### PR TITLE
cmd/snap: setup tracking cgroup when invoking a service directly as a user

### DIFF
--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -1175,6 +1175,21 @@ func (x *cmdRun) runSnapConfine(info *snap.Info, securityTag, snapApp, hook stri
 		// tracking cgroup, named after the systemd unit name, and those are
 		// sufficient to identify both the snap name and the app name.
 		needsTracking = false
+		// however it is still possible that the app (which is a
+		// service) was invoked by the user, so it may be running inside
+		// a user's scope cgroup, in which case separate tracking group
+		// needs to be established
+		if err := cgroupConfirmSystemdServiceTracking(securityTag); err != nil {
+			if err == cgroup.ErrCannotTrackProcess {
+				// we are not being tracked in a service cgroup
+				// after all, go ahead and create a transient
+				// scope
+				needsTracking = true
+				logger.Debugf("service app not tracked by systemd")
+			} else {
+				return err
+			}
+		}
 	}
 	// Allow using the session bus for all apps but not for hooks.
 	allowSessionBus := hook == ""
@@ -1183,8 +1198,6 @@ func (x *cmdRun) runSnapConfine(info *snap.Info, securityTag, snapApp, hook stri
 	if needsTracking {
 		opts := &cgroup.TrackingOptions{AllowSessionBus: allowSessionBus}
 		trackingErr = cgroupCreateTransientScopeForTracking(securityTag, opts)
-	} else {
-		trackingErr = cgroupConfirmSystemdServiceTracking(securityTag)
 	}
 	if trackingErr != nil {
 		if trackingErr != cgroup.ErrCannotTrackProcess {

--- a/tests/main/cgroup-tracking/task.yaml
+++ b/tests/main/cgroup-tracking/task.yaml
@@ -178,7 +178,7 @@ execute: |
         # that location writable
         chmod a+w /var/snap/test-snapd-tracking/common
     fi
-    echo "A service run directly as the root user will also get a tracking scope"
+    echo "A service run directly as the user will also get a tracking scope"
     rm -f /var/snap/test-snapd-tracking/common/nap.cgroup
     tests.session -p /tmp/4.pid -u "$USER" exec snap run test-snapd-tracking.nap &
     session4_pid=$!

--- a/tests/main/cgroup-tracking/task.yaml
+++ b/tests/main/cgroup-tracking/task.yaml
@@ -172,3 +172,19 @@ execute: |
 
     wait "$session3_pid" || true  # same as above
     retry -n 10 test ! -e "${base_cg_path}${pid3_tracking_cg_path}"
+
+    if [ "$USER" != "root" ]; then
+        # since the service we run here writes under /var/snap/ we need to make
+        # that location writable
+        chmod a+w /var/snap/test-snapd-tracking/common
+    fi
+    echo "A service run directly as the root user will also get a tracking scope"
+    rm -f /var/snap/test-snapd-tracking/common/nap.cgroup
+    tests.session -p /tmp/4.pid -u "$USER" exec snap run test-snapd-tracking.nap &
+    session4_pid=$!
+    retry -n 30 test -e /var/snap/test-snapd-tracking/common/nap.cgroup
+    pid4=$(cat /tmp/4.pid)
+    pid4_tracking_cg_path="$(grep -E "^$base_cg_id:" < "/proc/$pid4/cgroup" | cut -d : -f 3)"
+    echo "$pid4_tracking_cg_path" | MATCH '.*/snap\.test-snapd-tracking\.nap\.[0-9a-f-]+\.scope'
+    kill "$pid4"
+    wait "$session4_pid" || true


### PR DESCRIPTION
Normally apps declared to be services are started by systemd, and thus end up in
a service specific cgroup. However, it is possible for a user to invoke `snap
run foo.bar` (where foo.bar is a service) and thus run it themselves. In such
scenario, the service will be in the user's cgroup (typically the session
scope). On a cgroup v2 system, should the service then get access to devices,
and attempt to modify device filtering on the cgroup could break the session,
thus snap-confine stops and dies before modifying the cgroup. This was not a
problem with cgroup v1 as the device controller was separate and used a disjoint
hierarchy which could be modified freely.

Attempt to remedy this, by establishing a tracking cgroup also when an app being
a service is not in a systemd created group, in which case snap will attempt to
create a transient scope for it, like it does does all other apps.

Fixes: https://bugs.launchpad.net/snapd/+bug/1956917
See: https://forum.snapcraft.io/t/session-101-scope-is-not-a-snap-cgroup/28193