### PR TITLE
o/ifacestate: add convenience Active() method to ConnectionState struct

### DIFF
--- a/daemon/access.go
+++ b/daemon/access.go
@@ -191,7 +191,7 @@ func requireThemeApiAccessImpl(d *Daemon, ucred *ucrednet) *apiError {
 		return Forbidden("internal error: cannot get connections: %s", err)
 	}
 	for refStr, connState := range conns {
-		if connState.Undesired || connState.HotplugGone || connState.Interface != "snap-themes-control" {
+		if !connState.Active() || connState.Interface != "snap-themes-control" {
 			continue
 		}
 		connRef, err := interfaces.ParseConnRef(refStr)

--- a/overlord/hookstate/ctlcmd/is_connected.go
+++ b/overlord/hookstate/ctlcmd/is_connected.go
@@ -152,7 +152,7 @@ func (c *isConnectedCommand) Execute(args []string) error {
 	// hooks). plug and slot names are unique within a snap, so there is no
 	// ambiguity when matching.
 	for refStr, connState := range conns {
-		if connState.Undesired || connState.HotplugGone {
+		if !connState.Active() {
 			continue
 		}
 		connRef, err := interfaces.ParseConnRef(refStr)

--- a/overlord/hookstate/ctlcmd/mount.go
+++ b/overlord/hookstate/ctlcmd/mount.go
@@ -153,7 +153,7 @@ func (m *mountCommand) checkConnections(context *hookstate.Context) error {
 			continue
 		}
 
-		if connState.Undesired || connState.HotplugGone {
+		if !connState.Active() {
 			continue
 		}
 

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -266,6 +266,12 @@ type ConnectionState struct {
 	HotplugGone      bool
 }
 
+// Active returns true if connection is not undesired and not removed by
+// hotplug.
+func (c ConnectionState) Active() bool {
+	return !(c.Undesired || c.HotplugGone)
+}
+
 // ConnectionStates return the state of connections stored in the state.
 // Note that this includes inactive connections (i.e. referring to non-
 // existing plug/slots), so this map must be cross-referenced with current

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -9024,3 +9024,19 @@ func (s *interfaceManagerSuite) TestConnectSetsUpSecurityFails(c *C) {
 	ifaces := repo.Interfaces()
 	c.Check(ifaces.Connections, HasLen, 0)
 }
+
+func (s *interfaceManagerSuite) TestConnectionStateActive(c *C) {
+	for i, cs := range []struct {
+		undesired      bool
+		hotplugGone    bool
+		expectedActive bool
+	}{
+		{false, false, true},
+		{true, false, false},
+		{false, true, false},
+		{true, true, false},
+	} {
+		connState := ifacestate.ConnectionState{Undesired: cs.undesired, HotplugGone: cs.hotplugGone}
+		c.Assert(connState.Active(), Equals, cs.expectedActive, Commentf("#%d: %v", i, cs))
+	}
+}


### PR DESCRIPTION
There are a couple of places where a ConnectionState is checked for hotplug gone and undesired flag (upcoming #10864 is another one), so I though of reducing it by a tiny bit by adding `Active()` convenience method.

My initial idea was to have a helper for iterating over conns with a lambda for the actual logic (because this is the pattern for those places), but there is no good way of doing this without making it more complex, so it's not a win.

I'll update this PR after #10864 lands.
