### PR TITLE
tests: ensure /snap/bin is in PATH in "tests.session exec"

### DIFF
--- a/tests/lib/tools/tests.session
+++ b/tests/lib/tools/tests.session
@@ -342,7 +342,7 @@ BEGIN {
 			Environment as 1 TERM=xterm-256color \
 			$selinux_context_arg \
 			ExecStart "a(sasb)" 1 \
-				"$(command -v runuser)" 6 "$(command -v runuser)" -l "$user" - -c "SNAPD_DEBUG=$SNAPD_DEBUG SNAP_CONFINE_DEBUG=$SNAP_CONFINE_DEBUG exec $tmp_dir/exec <$tmp_dir/stdin.pipe >$tmp_dir/stdout.pipe 2>$tmp_dir/stderr.pipe" false \
+				"$(command -v runuser)" 6 "$(command -v runuser)" -l "$user" - -c "SNAPD_DEBUG=$SNAPD_DEBUG SNAP_CONFINE_DEBUG=$SNAP_CONFINE_DEBUG PATH=$PATH:/snap/bin exec $tmp_dir/exec <$tmp_dir/stdin.pipe >$tmp_dir/stdout.pipe 2>$tmp_dir/stderr.pipe" false \
 		0
 	# This is done so that we can configure file redirects. Once Ubuntu 16.04 is no
 	# longer supported we can use Standard{Input,Output,Error}=file:path property

--- a/tests/main/parallel-install-basic/task.yaml
+++ b/tests/main/parallel-install-basic/task.yaml
@@ -17,6 +17,12 @@ restore: |
 
     tests.session -u test restore
 
+debug: |
+    ls /snap/bin/
+    cat /etc/environment
+    tests.session -u test exec sh -c 'echo $PATH'
+    tests.session -u test exec sh -c 'env'
+
 execute: |
     "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
     "$TESTSTOOLS"/snaps-state install-local-as test-snapd-sh test-snapd-sh_foo


### PR DESCRIPTION
We saw the tests/main/parallel-install-basic test failing on
various external UC16 devices. It turns out that on these
device with UC16 the tests.session dbus call to StartTransientUnit
does not include /snap/bin in PATH. So some tests (like
parallel-install-basic) fail.

This commit force /snap/bin in the PATH in tests.session exec.
