### PR TITLE
cmd/snap/quota: fix typo in the help message

### DIFF
--- a/cmd/snap/cmd_quota.go
+++ b/cmd/snap/cmd_quota.go
@@ -66,7 +66,7 @@ group the nested groups are part of.
 
 All provided snaps are appended to the group; to remove a snap from a
 quota group, the entire group must be removed with remove-quota and recreated 
-without the quota group. To remove a sub-group from the quota group, the 
+without the snap. To remove a sub-group from the quota group, the 
 sub-group must be removed directly with the remove-quota command.
 
 The memory limit for a quota group can be increased but not decreased. To


### PR DESCRIPTION
As requested by Alberto a long time ago: https://github.com/snapcore/snapd/pull/10333#discussion_r644519259