### PR TITLE
vscode: added integrated support for MS VSCODE

### DIFF
--- a/osutil/cp_linux_test.go
+++ b/osutil/cp_linux_test.go
@@ -20,6 +20,7 @@
 package osutil_test
 
 import (
+	"io/ioutil"
 	"os"
 
 	. "gopkg.in/check.v1"
@@ -37,10 +38,18 @@ func (s *cpSuite) TestCpMulti(c *C) {
 }
 
 func (s *cpSuite) TestDoCpErr(c *C) {
-	f1, err := os.Open(s.f1)
+	c.Assert(ioutil.WriteFile(s.f2, nil, 0444), IsNil)
+
+	src, err := os.Open(s.f1)
 	c.Assert(err, IsNil)
-	st, err := f1.Stat()
+	defer src.Close()
+
+	roFd, err := os.Open(s.f2)
 	c.Assert(err, IsNil)
+	defer roFd.Close()
+
 	// force an error by asking it to write to a readonly stream
-	c.Check(osutil.DoCopyFile(f1, os.Stdin, st), NotNil)
+	st, err := src.Stat()
+	c.Assert(err, IsNil)
+	c.Check(osutil.DoCopyFile(src, roFd, st), NotNil)
 }

--- a/snapd.code-workspace
+++ b/snapd.code-workspace
@@ -21,12 +21,12 @@
 			"ms-vscode.cpptools-extension-pack", // C/C++ extensions
 
 			// Useful extra extensions, for reference:
-			//"766b.go-outliner", // Resolves "golang.go"'s poor outlining of packages that spread over several files
-			//"jerrygoyal.shortcut-menu-bar", // Toolbar that for some unknown reason is part of the UI
+			//"766b.go-outliner", // Outlines packages that spread over several files
+			//"jerrygoyal.shortcut-menu-bar", // Menu bar with shortcuts for navigation and editing
 			//"eamodio.gitlens", // Spectacular git-integration
-			//"aaron-bond.better-comments", // Brings more live into comments
-			//"vscodevim.vim", // For VIM users to get home experience
-			//"tuttieee.emacs-mcx", // For Emacs users to get home experience
+			//"aaron-bond.better-comments", // Decorates comments based on annotations
+			//"vscodevim.vim", // Vim emulation
+			//"tuttieee.emacs-mcx", // Emacs emulation
 		]
 	},
 

--- a/snapd.code-workspace
+++ b/snapd.code-workspace
@@ -5,24 +5,36 @@
 		}
 	],
 	"settings": {
+
+		// Attributes for the tests invoked directly from go-files in the UI
 		"go.testEnvVars": {"LANG": "C.UTF-8"},
-		"go.testFlags": ["-v","-check.v"]
+		"go.testFlags": [
+			"-v",
+			"-check.v"
+		],
 	},
 	"extensions": {
+
+		// Recommended extensions (type @recommended in Extensions tab to list)
 		"recommendations": [
-			"golang.go", 
-			"766b.go-outliner", 
-			"jerrygoyal.shortcut-menu-bar",
-			"eamodio.gitlens", 
-			"aaron-bond.better-comments",
-			"vscodevim.vim",
-			"tuttieee.emacs-mcx",
-			"ms-vscode.cpptools-extension-pack",
+			"golang.go", // Golang extensions 
+			"ms-vscode.cpptools-extension-pack", // C/C++ extensions
+
+			// Useful extra extensions, for reference:
+			//"766b.go-outliner", // Resolves "golang.go"'s poor outlining of packages that spread over several files
+			//"jerrygoyal.shortcut-menu-bar", // Toolbar that for some unknown reason is part of the UI
+			//"eamodio.gitlens", // Spectacular git-integration
+			//"aaron-bond.better-comments", // Brings more live into comments
+			//"vscodevim.vim", // For VIM users to get home experience
+			//"tuttieee.emacs-mcx", // For Emacs users to get home experience
 		]
 	},
+
 	"launch": {
 		"version": "0.2.0",
 		"configurations": [
+
+			// Default simple configuration to run tests of the package in the focus
 			{
 				"name": "Test (package)",
 				"type": "go",
@@ -34,6 +46,8 @@
 				"env": {"LANG": "C.UTF-8"},
 				"args": ["-test.timeout=30m0s"],
 			},
+
+			// Fully verbose configuration to run tests of the package in the focus
 			{
 				"name": "Test verbose (package)",
 				"type": "go",
@@ -48,5 +62,5 @@
 				}
 			},
 		]
-	}
+	},
 }

--- a/snapd.code-workspace
+++ b/snapd.code-workspace
@@ -1,0 +1,52 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"settings": {
+		"go.testEnvVars": {"LANG": "C.UTF-8"},
+		"go.testFlags": ["-v","-check.v"]
+	},
+	"extensions": {
+		"recommendations": [
+			"golang.go", 
+			"766b.go-outliner", 
+			"jerrygoyal.shortcut-menu-bar",
+			"eamodio.gitlens", 
+			"aaron-bond.better-comments",
+			"vscodevim.vim",
+			"tuttieee.emacs-mcx",
+			"ms-vscode.cpptools-extension-pack",
+		]
+	},
+	"launch": {
+		"version": "0.2.0",
+		"configurations": [
+			{
+				"name": "Test (package)",
+				"type": "go",
+				"request": "launch",
+				"mode": "test",
+				"cwd": "${fileDirname}",
+				"output": "/tmp/go-build${fileBasenameNoExtension}/${relativeFile}/snap.test",
+				"program": "${fileDirname}",
+				"env": {"LANG": "C.UTF-8"},
+				"args": ["-test.timeout=30m0s"],
+			},
+			{
+				"name": "Test verbose (package)",
+				"type": "go",
+				"request": "launch",
+				"mode": "test",
+				"cwd": "${fileDirname}",
+				"output": "/tmp/go-build${fileBasenameNoExtension}/${relativeFile}/snap.test",
+				"program": "${fileDirname}",
+				"env": {
+					"LANG": "C.UTF-8",
+					"args": ["-v", "-check.vv", "-test.timeout=30m0s"],
+				}
+			},
+		]
+	}
+}


### PR DESCRIPTION
Added support for MS VSCODE in a form of a workspace file
(snapd.code-workspace) configured to develop snapd using this IDE,
including recommendations for the set of useful extensions.
The IDE will suggest installing these extensions when the workspace
file is opened first time.

- The test `TestDoCpErr` has been adjusted to have a workaround
  for the issue of debugger (used by VSCode Go extension) that
  incorrectly allows writing to STDIN.

Signed-off-by: Arseniy Aharonov <arseniy.aharonov@canonical.com>

