### PR TITLE
tests: fix `tests/core/create-user` on testflinger pi3

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -34,7 +34,6 @@ environment:
     SUDO_USER: ""
     SUDO_UID: ""
     TRUST_TEST_KEYS: '$(HOST: echo "${SPREAD_TRUST_TEST_KEYS:-true}")'
-    MANAGED_DEVICE: "false"
     # a global setting for LXD channel to use in the tests
     LXD_SNAP_CHANNEL: "latest/edge"
     # TODO: as of 2021-11-18 ubuntu-image in candidate and up has a bug which is
@@ -373,7 +372,6 @@ backends:
         type: adhoc
         environment:
             SPREAD_EXTERNAL_ADDRESS: '$(HOST: echo "${SPREAD_EXTERNAL_ADDRESS:-localhost:8022}")'
-            MANAGED_DEVICE: "true"
             TRUST_TEST_KEYS: "false"
         allocate: |
             ADDRESS $SPREAD_EXTERNAL_ADDRESS

--- a/tests/core/create-user/task.yaml
+++ b/tests/core/create-user/task.yaml
@@ -21,7 +21,7 @@ debug: |
     fi
 
 execute: |
-    if [ "$MANAGED_DEVICE" = "true" ]; then
+    if [ "$(snap managed)" = "true" ]; then
         # Leave a file indicating the device was initially managed
         touch managed.device
 


### PR DESCRIPTION
The `create-user` test was failing on the testflinger external
pi3 devices. The reason is that the test only looked at
`$MANAGED_DEVICE` which is set in spread.yaml just based on
if the device is external or not. However not all external
devices are already managed (the testflinger pi3 is not).

So this commit fixes this by simply checking directly for
`snap managed` instead.

In addition the MANAGED_DEVICE (which is now no longer used)
is removed.