### PR TITLE
overlord: small refactoring of group quota implementation in preparation of multiple quota values

### DIFF
--- a/client/quota.go
+++ b/client/quota.go
@@ -50,20 +50,18 @@ type QuotaValues struct {
 
 // EnsureQuota creates a quota group or updates an existing group.
 // The list of snaps can be empty.
-func (client *Client) EnsureQuota(groupName string, parent string, snaps []string, maxMemory quantity.Size) (changeID string, err error) {
+func (client *Client) EnsureQuota(groupName string, parent string, snaps []string, constraints *QuotaValues) (changeID string, err error) {
 	if groupName == "" {
 		return "", fmt.Errorf("cannot create or update quota group without a name")
 	}
 	// TODO: use naming.ValidateQuotaGroup()
 
 	data := &postQuotaData{
-		Action:    "ensure",
-		GroupName: groupName,
-		Parent:    parent,
-		Snaps:     snaps,
-		Constraints: &QuotaValues{
-			Memory: maxMemory,
-		},
+		Action:      "ensure",
+		GroupName:   groupName,
+		Parent:      parent,
+		Snaps:       snaps,
+		Constraints: constraints,
 	}
 
 	var body bytes.Buffer

--- a/client/quota_test.go
+++ b/client/quota_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 func (cs *clientSuite) TestCreateQuotaGroupInvalidName(c *check.C) {
-	_, err := cs.cli.EnsureQuota("", "", nil, 0)
+	_, err := cs.cli.EnsureQuota("", "", nil, nil)
 	c.Check(err, check.ErrorMatches, `cannot create or update quota group without a name`)
 }
 
@@ -44,7 +44,7 @@ func (cs *clientSuite) TestEnsureQuotaGroup(c *check.C) {
 		"change": "42"
 	}`
 
-	chgID, err := cs.cli.EnsureQuota("foo", "bar", []string{"snap-a", "snap-b"}, 1001)
+	chgID, err := cs.cli.EnsureQuota("foo", "bar", []string{"snap-a", "snap-b"}, &client.QuotaValues{Memory: quantity.Size(1001)})
 	c.Assert(err, check.IsNil)
 	c.Assert(chgID, check.Equals, "42")
 	c.Check(cs.req.Method, check.Equals, "POST")
@@ -68,7 +68,7 @@ func (cs *clientSuite) TestEnsureQuotaGroup(c *check.C) {
 func (cs *clientSuite) TestEnsureQuotaGroupError(c *check.C) {
 	cs.status = 500
 	cs.rsp = `{"type": "error"}`
-	_, err := cs.cli.EnsureQuota("foo", "bar", []string{"snap-a"}, 1)
+	_, err := cs.cli.EnsureQuota("foo", "bar", []string{"snap-a"}, &client.QuotaValues{Memory: quantity.Size(1)})
 	c.Check(err, check.ErrorMatches, `server error: "Internal Server Error"`)
 }
 

--- a/cmd/snap/cmd_quota.go
+++ b/cmd/snap/cmd_quota.go
@@ -107,10 +107,6 @@ type cmdSetQuota struct {
 	} `positional-args:"yes"`
 }
 
-func hasQuotaSet(maxMemory string) bool {
-	return maxMemory != ""
-}
-
 func parseQuotas(maxMemory string) (*client.QuotaValues, error) {
 	var mem int64
 
@@ -128,8 +124,11 @@ func parseQuotas(maxMemory string) (*client.QuotaValues, error) {
 }
 
 func (x *cmdSetQuota) Execute(args []string) (err error) {
+	hasQuotaSet := func() bool {
+		return x.MemoryMax != ""
+	}
 
-	quotaProvided := hasQuotaSet(x.MemoryMax)
+	quotaProvided := hasQuotaSet()
 
 	names := installedSnapNames(x.Positional.Snaps)
 

--- a/cmd/snap/cmd_quota.go
+++ b/cmd/snap/cmd_quota.go
@@ -124,11 +124,7 @@ func parseQuotas(maxMemory string) (*client.QuotaValues, error) {
 }
 
 func (x *cmdSetQuota) Execute(args []string) (err error) {
-	hasQuotaSet := func() bool {
-		return x.MemoryMax != ""
-	}
-
-	quotaProvided := hasQuotaSet()
+	quotaProvided := x.MemoryMax != ""
 
 	names := installedSnapNames(x.Positional.Snaps)
 

--- a/cmd/snap/cmd_quota.go
+++ b/cmd/snap/cmd_quota.go
@@ -107,12 +107,29 @@ type cmdSetQuota struct {
 	} `positional-args:"yes"`
 }
 
-func (x *cmdSetQuota) Execute(args []string) (err error) {
-	var maxMemory string
-	switch {
-	case x.MemoryMax != "":
-		maxMemory = x.MemoryMax
+func hasQuotaSet(maxMemory string) bool {
+	return maxMemory != ""
+}
+
+func parseQuotas(maxMemory string) (*client.QuotaValues, error) {
+	var mem int64
+
+	if maxMemory != "" {
+		value, err := strutil.ParseByteSize(maxMemory)
+		if err != nil {
+			return nil, err
+		}
+		mem = value
 	}
+
+	return &client.QuotaValues{
+		Memory: quantity.Size(mem),
+	}, nil
+}
+
+func (x *cmdSetQuota) Execute(args []string) (err error) {
+
+	quotaProvided := hasQuotaSet(x.MemoryMax)
 
 	names := installedSnapNames(x.Positional.Snaps)
 
@@ -125,7 +142,7 @@ func (x *cmdSetQuota) Execute(args []string) (err error) {
 	var chgID string
 
 	switch {
-	case maxMemory == "" && x.Parent == "" && len(x.Positional.Snaps) == 0:
+	case !quotaProvided && x.Parent == "" && len(x.Positional.Snaps) == 0:
 		// no snaps were specified, no memory limit was specified, and no parent
 		// was specified, so just the group name was provided - this is not
 		// supported since there is nothing to change/create
@@ -135,7 +152,7 @@ func (x *cmdSetQuota) Execute(args []string) (err error) {
 		}
 		return fmt.Errorf("cannot create quota group without memory limit")
 
-	case maxMemory == "" && x.Parent != "" && len(x.Positional.Snaps) == 0:
+	case !quotaProvided && x.Parent != "" && len(x.Positional.Snaps) == 0:
 		// this is either trying to create a new group with a parent and forgot
 		// to specify the memory limit for the new group, or the user is trying
 		// to re-parent a group, i.e. move it from the current parent to a
@@ -149,12 +166,11 @@ func (x *cmdSetQuota) Execute(args []string) (err error) {
 		}
 		return fmt.Errorf("cannot create quota group without memory limit")
 
-	case maxMemory != "":
+	case quotaProvided:
 		// we have a memory limit to set for this group, so specify that along
 		// with whatever snaps may have been provided and whatever parent may
 		// have been specified
-
-		mem, err := strutil.ParseByteSize(maxMemory)
+		quotaValues, err := parseQuotas(x.MemoryMax)
 		if err != nil {
 			return err
 		}
@@ -164,7 +180,7 @@ func (x *cmdSetQuota) Execute(args []string) (err error) {
 		// orphan a sub-group to no longer have a parent, but currently it just
 		// means leave the group with whatever parent it has, or if it doesn't
 		// currently exist, create the group without a parent group
-		chgID, err = x.client.EnsureQuota(x.Positional.GroupName, x.Parent, names, quantity.Size(mem))
+		chgID, err = x.client.EnsureQuota(x.Positional.GroupName, x.Parent, names, quotaValues)
 		if err != nil {
 			return err
 		}
@@ -178,7 +194,7 @@ func (x *cmdSetQuota) Execute(args []string) (err error) {
 		// currently support that, so currently all snaps specified here are
 		// just added to the group
 
-		chgID, err = x.client.EnsureQuota(x.Positional.GroupName, x.Parent, names, 0)
+		chgID, err = x.client.EnsureQuota(x.Positional.GroupName, x.Parent, names, nil)
 		if err != nil {
 			return err
 		}

--- a/cmd/snap/cmd_quota_test.go
+++ b/cmd/snap/cmd_quota_test.go
@@ -21,7 +21,6 @@ package main_test
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -102,12 +101,16 @@ type fakeQuotaGroupPostHandlerOpts struct {
 	maxMemory  int64
 }
 
+type quotasEnsureBodyConstraints struct {
+	Memory int64 `json:"memory,omitempty"`
+}
+
 type quotasEnsureBody struct {
-	Action      string                 `json:"action"`
-	GroupName   string                 `json:"group-name,omitempty"`
-	ParentName  string                 `json:"parent,omitempty"`
-	Snaps       []string               `json:"snaps,omitempty"`
-	Constraints map[string]interface{} `json:"constraints,omitempty"`
+	Action      string                      `json:"action"`
+	GroupName   string                      `json:"group-name,omitempty"`
+	ParentName  string                      `json:"parent,omitempty"`
+	Snaps       []string                    `json:"snaps,omitempty"`
+	Constraints quotasEnsureBodyConstraints `json:"constraints,omitempty"`
 }
 
 func makeFakeQuotaPostHandler(c *check.C, opts fakeQuotaGroupPostHandlerOpts) func(w http.ResponseWriter, r *http.Request) {
@@ -132,10 +135,10 @@ func makeFakeQuotaPostHandler(c *check.C, opts fakeQuotaGroupPostHandlerOpts) fu
 				GroupName:   opts.groupName,
 				ParentName:  opts.parentName,
 				Snaps:       opts.snaps,
-				Constraints: map[string]interface{}{},
+				Constraints: quotasEnsureBodyConstraints{},
 			}
 			if opts.maxMemory != 0 {
-				exp.Constraints["memory"] = json.Number(fmt.Sprintf("%d", opts.maxMemory))
+				exp.Constraints.Memory = opts.maxMemory
 			}
 
 			postJSON := quotasEnsureBody{}

--- a/daemon/api_quotas.go
+++ b/daemon/api_quotas.go
@@ -24,10 +24,10 @@ import (
 	"sort"
 
 	"github.com/snapcore/snapd/client"
-	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/jsonutil"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/servicestate"
+	"github.com/snapcore/snapd/overlord/servicestate/resources"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap/naming"
 	"github.com/snapcore/snapd/snap/quota"
@@ -63,8 +63,22 @@ var (
 	servicestateRemoveQuota = servicestate.RemoveQuota
 )
 
-var getQuotaMemUsage = func(grp *quota.Group) (quantity.Size, error) {
-	return grp.CurrentMemoryUsage()
+var getQuotaUsage = func(grp *quota.Group) (*client.QuotaValues, error) {
+	var currentUsage client.QuotaValues
+
+	mem, err := grp.CurrentMemoryUsage()
+	if err != nil {
+		return nil, err
+	}
+	currentUsage.Memory = mem
+
+	return &currentUsage, nil
+}
+
+func createQuotaValues(grp *quota.Group) *client.QuotaValues {
+	var constraints client.QuotaValues
+	constraints.Memory = grp.MemoryLimit
+	return &constraints
 }
 
 // getQuotaGroups returns all quota groups sorted by name.
@@ -90,22 +104,18 @@ func getQuotaGroups(c *Command, r *http.Request, _ *auth.UserState) Response {
 	for i, name := range names {
 		group := quotas[name]
 
-		memoryUsage, err := getQuotaMemUsage(group)
+		currentUsage, err := getQuotaUsage(group)
 		if err != nil {
 			return InternalError(err.Error())
 		}
 
 		results[i] = client.QuotaGroupResult{
-			GroupName: group.Name,
-			Parent:    group.ParentGroup,
-			Subgroups: group.SubGroups,
-			Snaps:     group.Snaps,
-			Constraints: &client.QuotaValues{
-				Memory: group.MemoryLimit,
-			},
-			Current: &client.QuotaValues{
-				Memory: memoryUsage,
-			},
+			GroupName:   group.Name,
+			Parent:      group.ParentGroup,
+			Subgroups:   group.SubGroups,
+			Snaps:       group.Snaps,
+			Constraints: createQuotaValues(group),
+			Current:     currentUsage,
 		}
 	}
 	return SyncResponse(results)
@@ -131,24 +141,30 @@ func getQuotaGroupInfo(c *Command, r *http.Request, _ *auth.UserState) Response 
 		return InternalError(err.Error())
 	}
 
-	memoryUsage, err := getQuotaMemUsage(group)
+	currentUsage, err := getQuotaUsage(group)
 	if err != nil {
 		return InternalError(err.Error())
 	}
 
 	res := client.QuotaGroupResult{
-		GroupName: group.Name,
-		Parent:    group.ParentGroup,
-		Snaps:     group.Snaps,
-		Subgroups: group.SubGroups,
-		Constraints: &client.QuotaValues{
-			Memory: group.MemoryLimit,
-		},
-		Current: &client.QuotaValues{
-			Memory: memoryUsage,
-		},
+		GroupName:   group.Name,
+		Parent:      group.ParentGroup,
+		Snaps:       group.Snaps,
+		Subgroups:   group.SubGroups,
+		Constraints: createQuotaValues(group),
+		Current:     currentUsage,
 	}
 	return SyncResponse(res)
+}
+
+func quotaValuesToResources(values client.QuotaValues) resources.QuotaResources {
+	var quotaResources resources.QuotaResources
+	if values.Memory != 0 {
+		quotaResources.Memory = &resources.QuotaResourceMemory{
+			MemoryLimit: values.Memory,
+		}
+	}
+	return quotaResources
 }
 
 // postQuotaGroup creates quota resource group or updates an existing group.
@@ -173,6 +189,9 @@ func postQuotaGroup(c *Command, r *http.Request, _ *auth.UserState) Response {
 
 	switch data.Action {
 	case "ensure":
+		// pack constraints into a resource limits struct
+		resourceLimits := quotaValuesToResources(data.Constraints)
+
 		// check if the quota group exists first, if it does then we need to
 		// update it instead of create it
 		_, err := servicestate.GetQuota(st, data.GroupName)
@@ -181,7 +200,7 @@ func postQuotaGroup(c *Command, r *http.Request, _ *auth.UserState) Response {
 		}
 		if err == servicestate.ErrQuotaNotFound {
 			// then we need to create the quota
-			ts, err = servicestateCreateQuota(st, data.GroupName, data.Parent, data.Snaps, data.Constraints.Memory)
+			ts, err = servicestateCreateQuota(st, data.GroupName, data.Parent, data.Snaps, resourceLimits)
 			if err != nil {
 				return errToResponse(err, nil, BadRequest, "cannot create quota group: %v")
 			}
@@ -189,8 +208,8 @@ func postQuotaGroup(c *Command, r *http.Request, _ *auth.UserState) Response {
 		} else if err == nil {
 			// the quota group already exists, update it
 			updateOpts := servicestate.QuotaGroupUpdate{
-				AddSnaps:       data.Snaps,
-				NewMemoryLimit: data.Constraints.Memory,
+				AddSnaps:          data.Snaps,
+				NewResourceLimits: resourceLimits,
 			}
 			ts, err = servicestateUpdateQuota(st, data.GroupName, updateOpts)
 			if err != nil {

--- a/daemon/api_quotas.go
+++ b/daemon/api_quotas.go
@@ -27,7 +27,6 @@ import (
 	"github.com/snapcore/snapd/jsonutil"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/servicestate"
-	"github.com/snapcore/snapd/overlord/servicestate/resources"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap/naming"
 	"github.com/snapcore/snapd/snap/quota"
@@ -157,10 +156,10 @@ func getQuotaGroupInfo(c *Command, r *http.Request, _ *auth.UserState) Response 
 	return SyncResponse(res)
 }
 
-func quotaValuesToResources(values client.QuotaValues) resources.QuotaResources {
-	var quotaResources resources.QuotaResources
+func quotaValuesToResources(values client.QuotaValues) quota.QuotaResources {
+	var quotaResources quota.QuotaResources
 	if values.Memory != 0 {
-		quotaResources.Memory = &resources.QuotaResourceMemory{
+		quotaResources.Memory = &quota.QuotaResourceMemory{
 			MemoryLimit: values.Memory,
 		}
 	}

--- a/daemon/api_quotas.go
+++ b/daemon/api_quotas.go
@@ -156,11 +156,11 @@ func getQuotaGroupInfo(c *Command, r *http.Request, _ *auth.UserState) Response 
 	return SyncResponse(res)
 }
 
-func quotaValuesToResources(values client.QuotaValues) quota.QuotaResources {
-	var quotaResources quota.QuotaResources
+func quotaValuesToResources(values client.QuotaValues) quota.Resources {
+	var quotaResources quota.Resources
 	if values.Memory != 0 {
-		quotaResources.Memory = &quota.QuotaResourceMemory{
-			MemoryLimit: values.Memory,
+		quotaResources.Memory = &quota.ResourceMemory{
+			Limit: values.Memory,
 		}
 	}
 	return quotaResources

--- a/daemon/api_quotas_test.go
+++ b/daemon/api_quotas_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/servicestate"
-	"github.com/snapcore/snapd/overlord/servicestate/resources"
 	"github.com/snapcore/snapd/overlord/servicestate/servicestatetest"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
@@ -74,11 +73,11 @@ func (s *apiQuotaSuite) SetUpTest(c *check.C) {
 }
 
 func mockQuotas(st *state.State, c *check.C) {
-	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, resources.CreateQuotaResources(11000))
+	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, quota.CreateQuotaResources(11000))
 	c.Assert(err, check.IsNil)
-	err = servicestatetest.MockQuotaInState(st, "bar", "foo", nil, resources.CreateQuotaResources(6000))
+	err = servicestatetest.MockQuotaInState(st, "bar", "foo", nil, quota.CreateQuotaResources(6000))
 	c.Assert(err, check.IsNil)
-	err = servicestatetest.MockQuotaInState(st, "baz", "foo", nil, resources.CreateQuotaResources(5000))
+	err = servicestatetest.MockQuotaInState(st, "baz", "foo", nil, quota.CreateQuotaResources(5000))
 	c.Assert(err, check.IsNil)
 }
 
@@ -105,11 +104,11 @@ func (s *apiQuotaSuite) TestPostQuotaInvalidGroupName(c *check.C) {
 }
 
 func (s *apiQuotaSuite) TestPostEnsureQuotaUnhappy(c *check.C) {
-	r := daemon.MockServicestateCreateQuota(func(st *state.State, name string, parentName string, snaps []string, resourceLimits resources.QuotaResources) (*state.TaskSet, error) {
+	r := daemon.MockServicestateCreateQuota(func(st *state.State, name string, parentName string, snaps []string, resourceLimits quota.QuotaResources) (*state.TaskSet, error) {
 		c.Check(name, check.Equals, "booze")
 		c.Check(parentName, check.Equals, "foo")
 		c.Check(snaps, check.DeepEquals, []string{"bar"})
-		c.Check(resourceLimits, check.DeepEquals, resources.CreateQuotaResources(quantity.Size(1000)))
+		c.Check(resourceLimits, check.DeepEquals, quota.CreateQuotaResources(quantity.Size(1000)))
 		return nil, fmt.Errorf("boom")
 	})
 	defer r()
@@ -133,12 +132,12 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaUnhappy(c *check.C) {
 
 func (s *apiQuotaSuite) TestPostEnsureQuotaCreateHappy(c *check.C) {
 	var createCalled int
-	r := daemon.MockServicestateCreateQuota(func(st *state.State, name string, parentName string, snaps []string, resourceLimits resources.QuotaResources) (*state.TaskSet, error) {
+	r := daemon.MockServicestateCreateQuota(func(st *state.State, name string, parentName string, snaps []string, resourceLimits quota.QuotaResources) (*state.TaskSet, error) {
 		createCalled++
 		c.Check(name, check.Equals, "booze")
 		c.Check(parentName, check.Equals, "foo")
 		c.Check(snaps, check.DeepEquals, []string{"some-snap"})
-		c.Check(resourceLimits, check.DeepEquals, resources.CreateQuotaResources(quantity.Size(1000)))
+		c.Check(resourceLimits, check.DeepEquals, quota.CreateQuotaResources(quantity.Size(1000)))
 		ts := state.NewTaskSet(st.NewTask("foo-quota", "..."))
 		return ts, nil
 	})
@@ -163,11 +162,11 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaCreateHappy(c *check.C) {
 
 func (s *apiQuotaSuite) TestPostEnsureQuotaCreateQuotaConflicts(c *check.C) {
 	var createCalled int
-	r := daemon.MockServicestateCreateQuota(func(st *state.State, name string, parentName string, snaps []string, resourceLimits resources.QuotaResources) (*state.TaskSet, error) {
+	r := daemon.MockServicestateCreateQuota(func(st *state.State, name string, parentName string, snaps []string, resourceLimits quota.QuotaResources) (*state.TaskSet, error) {
 		c.Check(name, check.Equals, "booze")
 		c.Check(parentName, check.Equals, "foo")
 		c.Check(snaps, check.DeepEquals, []string{"some-snap"})
-		c.Check(resourceLimits, check.DeepEquals, resources.CreateQuotaResources(quantity.Size(1000)))
+		c.Check(resourceLimits, check.DeepEquals, quota.CreateQuotaResources(quantity.Size(1000)))
 
 		createCalled++
 		switch createCalled {
@@ -222,11 +221,11 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaCreateQuotaConflicts(c *check.C) {
 func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateHappy(c *check.C) {
 	st := s.d.Overlord().State()
 	st.Lock()
-	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", nil, resources.CreateQuotaResources(5000))
+	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", nil, quota.CreateQuotaResources(5000))
 	st.Unlock()
 	c.Assert(err, check.IsNil)
 
-	r := daemon.MockServicestateCreateQuota(func(st *state.State, name string, parentName string, snaps []string, resourceLimits resources.QuotaResources) (*state.TaskSet, error) {
+	r := daemon.MockServicestateCreateQuota(func(st *state.State, name string, parentName string, snaps []string, resourceLimits quota.QuotaResources) (*state.TaskSet, error) {
 		c.Errorf("should not have called create quota")
 		return nil, fmt.Errorf("broken test")
 	})
@@ -238,7 +237,7 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateHappy(c *check.C) {
 		c.Assert(name, check.Equals, "ginger-ale")
 		c.Assert(opts, check.DeepEquals, servicestate.QuotaGroupUpdate{
 			AddSnaps:          []string{"some-snap"},
-			NewResourceLimits: resources.CreateQuotaResources(quantity.Size(9000)),
+			NewResourceLimits: quota.CreateQuotaResources(quantity.Size(9000)),
 		})
 		ts := state.NewTaskSet(st.NewTask("foo-quota", "..."))
 		return ts, nil
@@ -264,11 +263,11 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateHappy(c *check.C) {
 func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateConflicts(c *check.C) {
 	st := s.d.Overlord().State()
 	st.Lock()
-	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", nil, resources.CreateQuotaResources(5000))
+	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", nil, quota.CreateQuotaResources(5000))
 	st.Unlock()
 	c.Assert(err, check.IsNil)
 
-	r := daemon.MockServicestateCreateQuota(func(st *state.State, name string, parentName string, snaps []string, resourceLimits resources.QuotaResources) (*state.TaskSet, error) {
+	r := daemon.MockServicestateCreateQuota(func(st *state.State, name string, parentName string, snaps []string, resourceLimits quota.QuotaResources) (*state.TaskSet, error) {
 		c.Errorf("should not have called create quota")
 		return nil, fmt.Errorf("broken test")
 	})
@@ -280,7 +279,7 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateConflicts(c *check.C) {
 		c.Assert(name, check.Equals, "ginger-ale")
 		c.Assert(opts, check.DeepEquals, servicestate.QuotaGroupUpdate{
 			AddSnaps:          []string{"some-snap"},
-			NewResourceLimits: resources.CreateQuotaResources(quantity.Size(9000)),
+			NewResourceLimits: quota.CreateQuotaResources(quantity.Size(9000)),
 		})
 		switch updateCalled {
 		case 1:
@@ -360,7 +359,7 @@ func (s *apiQuotaSuite) TestPostRemoveQuotaHappy(c *check.C) {
 func (s *apiQuotaSuite) TestPostRemoveQuotaConflict(c *check.C) {
 	st := s.d.Overlord().State()
 	st.Lock()
-	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", []string{"some-snap"}, resources.CreateQuotaResources(5000))
+	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", []string{"some-snap"}, quota.CreateQuotaResources(5000))
 	st.Unlock()
 	c.Assert(err, check.IsNil)
 

--- a/daemon/api_quotas_test.go
+++ b/daemon/api_quotas_test.go
@@ -73,11 +73,11 @@ func (s *apiQuotaSuite) SetUpTest(c *check.C) {
 }
 
 func mockQuotas(st *state.State, c *check.C) {
-	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, quota.CreateResources(11000))
+	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, quota.NewResources(11000))
 	c.Assert(err, check.IsNil)
-	err = servicestatetest.MockQuotaInState(st, "bar", "foo", nil, quota.CreateResources(6000))
+	err = servicestatetest.MockQuotaInState(st, "bar", "foo", nil, quota.NewResources(6000))
 	c.Assert(err, check.IsNil)
-	err = servicestatetest.MockQuotaInState(st, "baz", "foo", nil, quota.CreateResources(5000))
+	err = servicestatetest.MockQuotaInState(st, "baz", "foo", nil, quota.NewResources(5000))
 	c.Assert(err, check.IsNil)
 }
 
@@ -108,7 +108,7 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaUnhappy(c *check.C) {
 		c.Check(name, check.Equals, "booze")
 		c.Check(parentName, check.Equals, "foo")
 		c.Check(snaps, check.DeepEquals, []string{"bar"})
-		c.Check(resourceLimits, check.DeepEquals, quota.CreateResources(quantity.Size(1000)))
+		c.Check(resourceLimits, check.DeepEquals, quota.NewResources(quantity.Size(1000)))
 		return nil, fmt.Errorf("boom")
 	})
 	defer r()
@@ -137,7 +137,7 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaCreateHappy(c *check.C) {
 		c.Check(name, check.Equals, "booze")
 		c.Check(parentName, check.Equals, "foo")
 		c.Check(snaps, check.DeepEquals, []string{"some-snap"})
-		c.Check(resourceLimits, check.DeepEquals, quota.CreateResources(quantity.Size(1000)))
+		c.Check(resourceLimits, check.DeepEquals, quota.NewResources(quantity.Size(1000)))
 		ts := state.NewTaskSet(st.NewTask("foo-quota", "..."))
 		return ts, nil
 	})
@@ -166,7 +166,7 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaCreateQuotaConflicts(c *check.C) {
 		c.Check(name, check.Equals, "booze")
 		c.Check(parentName, check.Equals, "foo")
 		c.Check(snaps, check.DeepEquals, []string{"some-snap"})
-		c.Check(resourceLimits, check.DeepEquals, quota.CreateResources(quantity.Size(1000)))
+		c.Check(resourceLimits, check.DeepEquals, quota.NewResources(quantity.Size(1000)))
 
 		createCalled++
 		switch createCalled {
@@ -221,7 +221,7 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaCreateQuotaConflicts(c *check.C) {
 func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateHappy(c *check.C) {
 	st := s.d.Overlord().State()
 	st.Lock()
-	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", nil, quota.CreateResources(5000))
+	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", nil, quota.NewResources(5000))
 	st.Unlock()
 	c.Assert(err, check.IsNil)
 
@@ -237,7 +237,7 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateHappy(c *check.C) {
 		c.Assert(name, check.Equals, "ginger-ale")
 		c.Assert(opts, check.DeepEquals, servicestate.QuotaGroupUpdate{
 			AddSnaps:          []string{"some-snap"},
-			NewResourceLimits: quota.CreateResources(quantity.Size(9000)),
+			NewResourceLimits: quota.NewResources(quantity.Size(9000)),
 		})
 		ts := state.NewTaskSet(st.NewTask("foo-quota", "..."))
 		return ts, nil
@@ -263,7 +263,7 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateHappy(c *check.C) {
 func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateConflicts(c *check.C) {
 	st := s.d.Overlord().State()
 	st.Lock()
-	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", nil, quota.CreateResources(5000))
+	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", nil, quota.NewResources(5000))
 	st.Unlock()
 	c.Assert(err, check.IsNil)
 
@@ -279,7 +279,7 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateConflicts(c *check.C) {
 		c.Assert(name, check.Equals, "ginger-ale")
 		c.Assert(opts, check.DeepEquals, servicestate.QuotaGroupUpdate{
 			AddSnaps:          []string{"some-snap"},
-			NewResourceLimits: quota.CreateResources(quantity.Size(9000)),
+			NewResourceLimits: quota.NewResources(quantity.Size(9000)),
 		})
 		switch updateCalled {
 		case 1:
@@ -359,7 +359,7 @@ func (s *apiQuotaSuite) TestPostRemoveQuotaHappy(c *check.C) {
 func (s *apiQuotaSuite) TestPostRemoveQuotaConflict(c *check.C) {
 	st := s.d.Overlord().State()
 	st.Lock()
-	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", []string{"some-snap"}, quota.CreateResources(5000))
+	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", []string{"some-snap"}, quota.NewResources(5000))
 	st.Unlock()
 	c.Assert(err, check.IsNil)
 

--- a/daemon/api_quotas_test.go
+++ b/daemon/api_quotas_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/servicestate"
+	"github.com/snapcore/snapd/overlord/servicestate/resources"
 	"github.com/snapcore/snapd/overlord/servicestate/servicestatetest"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
@@ -73,11 +74,11 @@ func (s *apiQuotaSuite) SetUpTest(c *check.C) {
 }
 
 func mockQuotas(st *state.State, c *check.C) {
-	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, 11000)
+	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, resources.CreateQuotaResources(11000))
 	c.Assert(err, check.IsNil)
-	err = servicestatetest.MockQuotaInState(st, "bar", "foo", nil, 6000)
+	err = servicestatetest.MockQuotaInState(st, "bar", "foo", nil, resources.CreateQuotaResources(6000))
 	c.Assert(err, check.IsNil)
-	err = servicestatetest.MockQuotaInState(st, "baz", "foo", nil, 5000)
+	err = servicestatetest.MockQuotaInState(st, "baz", "foo", nil, resources.CreateQuotaResources(5000))
 	c.Assert(err, check.IsNil)
 }
 
@@ -104,11 +105,11 @@ func (s *apiQuotaSuite) TestPostQuotaInvalidGroupName(c *check.C) {
 }
 
 func (s *apiQuotaSuite) TestPostEnsureQuotaUnhappy(c *check.C) {
-	r := daemon.MockServicestateCreateQuota(func(st *state.State, name string, parentName string, snaps []string, memoryLimit quantity.Size) (*state.TaskSet, error) {
+	r := daemon.MockServicestateCreateQuota(func(st *state.State, name string, parentName string, snaps []string, resourceLimits resources.QuotaResources) (*state.TaskSet, error) {
 		c.Check(name, check.Equals, "booze")
 		c.Check(parentName, check.Equals, "foo")
 		c.Check(snaps, check.DeepEquals, []string{"bar"})
-		c.Check(memoryLimit, check.DeepEquals, quantity.Size(1000))
+		c.Check(resourceLimits, check.DeepEquals, resources.CreateQuotaResources(quantity.Size(1000)))
 		return nil, fmt.Errorf("boom")
 	})
 	defer r()
@@ -132,12 +133,12 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaUnhappy(c *check.C) {
 
 func (s *apiQuotaSuite) TestPostEnsureQuotaCreateHappy(c *check.C) {
 	var createCalled int
-	r := daemon.MockServicestateCreateQuota(func(st *state.State, name string, parentName string, snaps []string, memoryLimit quantity.Size) (*state.TaskSet, error) {
+	r := daemon.MockServicestateCreateQuota(func(st *state.State, name string, parentName string, snaps []string, resourceLimits resources.QuotaResources) (*state.TaskSet, error) {
 		createCalled++
 		c.Check(name, check.Equals, "booze")
 		c.Check(parentName, check.Equals, "foo")
 		c.Check(snaps, check.DeepEquals, []string{"some-snap"})
-		c.Check(memoryLimit, check.DeepEquals, quantity.Size(1000))
+		c.Check(resourceLimits, check.DeepEquals, resources.CreateQuotaResources(quantity.Size(1000)))
 		ts := state.NewTaskSet(st.NewTask("foo-quota", "..."))
 		return ts, nil
 	})
@@ -162,11 +163,11 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaCreateHappy(c *check.C) {
 
 func (s *apiQuotaSuite) TestPostEnsureQuotaCreateQuotaConflicts(c *check.C) {
 	var createCalled int
-	r := daemon.MockServicestateCreateQuota(func(st *state.State, name string, parentName string, snaps []string, memoryLimit quantity.Size) (*state.TaskSet, error) {
+	r := daemon.MockServicestateCreateQuota(func(st *state.State, name string, parentName string, snaps []string, resourceLimits resources.QuotaResources) (*state.TaskSet, error) {
 		c.Check(name, check.Equals, "booze")
 		c.Check(parentName, check.Equals, "foo")
 		c.Check(snaps, check.DeepEquals, []string{"some-snap"})
-		c.Check(memoryLimit, check.DeepEquals, quantity.Size(1000))
+		c.Check(resourceLimits, check.DeepEquals, resources.CreateQuotaResources(quantity.Size(1000)))
 
 		createCalled++
 		switch createCalled {
@@ -221,11 +222,11 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaCreateQuotaConflicts(c *check.C) {
 func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateHappy(c *check.C) {
 	st := s.d.Overlord().State()
 	st.Lock()
-	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", nil, 5000)
+	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", nil, resources.CreateQuotaResources(5000))
 	st.Unlock()
 	c.Assert(err, check.IsNil)
 
-	r := daemon.MockServicestateCreateQuota(func(st *state.State, name string, parentName string, snaps []string, memoryLimit quantity.Size) (*state.TaskSet, error) {
+	r := daemon.MockServicestateCreateQuota(func(st *state.State, name string, parentName string, snaps []string, resourceLimits resources.QuotaResources) (*state.TaskSet, error) {
 		c.Errorf("should not have called create quota")
 		return nil, fmt.Errorf("broken test")
 	})
@@ -236,8 +237,8 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateHappy(c *check.C) {
 		updateCalled++
 		c.Assert(name, check.Equals, "ginger-ale")
 		c.Assert(opts, check.DeepEquals, servicestate.QuotaGroupUpdate{
-			AddSnaps:       []string{"some-snap"},
-			NewMemoryLimit: 9000,
+			AddSnaps:          []string{"some-snap"},
+			NewResourceLimits: resources.CreateQuotaResources(quantity.Size(9000)),
 		})
 		ts := state.NewTaskSet(st.NewTask("foo-quota", "..."))
 		return ts, nil
@@ -263,11 +264,11 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateHappy(c *check.C) {
 func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateConflicts(c *check.C) {
 	st := s.d.Overlord().State()
 	st.Lock()
-	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", nil, 5000)
+	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", nil, resources.CreateQuotaResources(5000))
 	st.Unlock()
 	c.Assert(err, check.IsNil)
 
-	r := daemon.MockServicestateCreateQuota(func(st *state.State, name string, parentName string, snaps []string, memoryLimit quantity.Size) (*state.TaskSet, error) {
+	r := daemon.MockServicestateCreateQuota(func(st *state.State, name string, parentName string, snaps []string, resourceLimits resources.QuotaResources) (*state.TaskSet, error) {
 		c.Errorf("should not have called create quota")
 		return nil, fmt.Errorf("broken test")
 	})
@@ -278,8 +279,8 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateConflicts(c *check.C) {
 		updateCalled++
 		c.Assert(name, check.Equals, "ginger-ale")
 		c.Assert(opts, check.DeepEquals, servicestate.QuotaGroupUpdate{
-			AddSnaps:       []string{"some-snap"},
-			NewMemoryLimit: 9000,
+			AddSnaps:          []string{"some-snap"},
+			NewResourceLimits: resources.CreateQuotaResources(quantity.Size(9000)),
 		})
 		switch updateCalled {
 		case 1:
@@ -359,7 +360,7 @@ func (s *apiQuotaSuite) TestPostRemoveQuotaHappy(c *check.C) {
 func (s *apiQuotaSuite) TestPostRemoveQuotaConflict(c *check.C) {
 	st := s.d.Overlord().State()
 	st.Lock()
-	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", []string{"some-snap"}, 5000)
+	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", []string{"some-snap"}, resources.CreateQuotaResources(5000))
 	st.Unlock()
 	c.Assert(err, check.IsNil)
 
@@ -464,18 +465,24 @@ func (s *apiQuotaSuite) TestListQuotas(c *check.C) {
 	st.Unlock()
 
 	calls := 0
-	r := daemon.MockGetQuotaMemUsage(func(grp *quota.Group) (quantity.Size, error) {
+	r := daemon.MockGetQuotaUsage(func(grp *quota.Group) (*client.QuotaValues, error) {
 		calls++
 		switch grp.Name {
 		case "bar":
-			return quantity.Size(500), nil
+			return &client.QuotaValues{
+				Memory: quantity.Size(500),
+			}, nil
 		case "baz":
-			return quantity.Size(1000), nil
+			return &client.QuotaValues{
+				Memory: quantity.Size(1000),
+			}, nil
 		case "foo":
-			return quantity.Size(5000), nil
+			return &client.QuotaValues{
+				Memory: quantity.Size(5000),
+			}, nil
 		default:
 			c.Errorf("unexpected call to get group memory usage for group %q", grp.Name)
-			return 0, fmt.Errorf("broken test")
+			return nil, fmt.Errorf("broken test")
 		}
 	})
 	defer r()
@@ -519,10 +526,12 @@ func (s *apiQuotaSuite) TestGetQuota(c *check.C) {
 	st.Unlock()
 
 	calls := 0
-	r := daemon.MockGetQuotaMemUsage(func(grp *quota.Group) (quantity.Size, error) {
+	r := daemon.MockGetQuotaUsage(func(grp *quota.Group) (*client.QuotaValues, error) {
 		calls++
 		c.Assert(grp.Name, check.Equals, "bar")
-		return quantity.Size(500), nil
+		return &client.QuotaValues{
+			Memory: quantity.Size(500),
+		}, nil
 	})
 	defer r()
 	defer func() {

--- a/daemon/api_quotas_test.go
+++ b/daemon/api_quotas_test.go
@@ -73,11 +73,11 @@ func (s *apiQuotaSuite) SetUpTest(c *check.C) {
 }
 
 func mockQuotas(st *state.State, c *check.C) {
-	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, quota.CreateQuotaResources(11000))
+	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, quota.CreateResources(11000))
 	c.Assert(err, check.IsNil)
-	err = servicestatetest.MockQuotaInState(st, "bar", "foo", nil, quota.CreateQuotaResources(6000))
+	err = servicestatetest.MockQuotaInState(st, "bar", "foo", nil, quota.CreateResources(6000))
 	c.Assert(err, check.IsNil)
-	err = servicestatetest.MockQuotaInState(st, "baz", "foo", nil, quota.CreateQuotaResources(5000))
+	err = servicestatetest.MockQuotaInState(st, "baz", "foo", nil, quota.CreateResources(5000))
 	c.Assert(err, check.IsNil)
 }
 
@@ -104,11 +104,11 @@ func (s *apiQuotaSuite) TestPostQuotaInvalidGroupName(c *check.C) {
 }
 
 func (s *apiQuotaSuite) TestPostEnsureQuotaUnhappy(c *check.C) {
-	r := daemon.MockServicestateCreateQuota(func(st *state.State, name string, parentName string, snaps []string, resourceLimits quota.QuotaResources) (*state.TaskSet, error) {
+	r := daemon.MockServicestateCreateQuota(func(st *state.State, name string, parentName string, snaps []string, resourceLimits quota.Resources) (*state.TaskSet, error) {
 		c.Check(name, check.Equals, "booze")
 		c.Check(parentName, check.Equals, "foo")
 		c.Check(snaps, check.DeepEquals, []string{"bar"})
-		c.Check(resourceLimits, check.DeepEquals, quota.CreateQuotaResources(quantity.Size(1000)))
+		c.Check(resourceLimits, check.DeepEquals, quota.CreateResources(quantity.Size(1000)))
 		return nil, fmt.Errorf("boom")
 	})
 	defer r()
@@ -132,12 +132,12 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaUnhappy(c *check.C) {
 
 func (s *apiQuotaSuite) TestPostEnsureQuotaCreateHappy(c *check.C) {
 	var createCalled int
-	r := daemon.MockServicestateCreateQuota(func(st *state.State, name string, parentName string, snaps []string, resourceLimits quota.QuotaResources) (*state.TaskSet, error) {
+	r := daemon.MockServicestateCreateQuota(func(st *state.State, name string, parentName string, snaps []string, resourceLimits quota.Resources) (*state.TaskSet, error) {
 		createCalled++
 		c.Check(name, check.Equals, "booze")
 		c.Check(parentName, check.Equals, "foo")
 		c.Check(snaps, check.DeepEquals, []string{"some-snap"})
-		c.Check(resourceLimits, check.DeepEquals, quota.CreateQuotaResources(quantity.Size(1000)))
+		c.Check(resourceLimits, check.DeepEquals, quota.CreateResources(quantity.Size(1000)))
 		ts := state.NewTaskSet(st.NewTask("foo-quota", "..."))
 		return ts, nil
 	})
@@ -162,11 +162,11 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaCreateHappy(c *check.C) {
 
 func (s *apiQuotaSuite) TestPostEnsureQuotaCreateQuotaConflicts(c *check.C) {
 	var createCalled int
-	r := daemon.MockServicestateCreateQuota(func(st *state.State, name string, parentName string, snaps []string, resourceLimits quota.QuotaResources) (*state.TaskSet, error) {
+	r := daemon.MockServicestateCreateQuota(func(st *state.State, name string, parentName string, snaps []string, resourceLimits quota.Resources) (*state.TaskSet, error) {
 		c.Check(name, check.Equals, "booze")
 		c.Check(parentName, check.Equals, "foo")
 		c.Check(snaps, check.DeepEquals, []string{"some-snap"})
-		c.Check(resourceLimits, check.DeepEquals, quota.CreateQuotaResources(quantity.Size(1000)))
+		c.Check(resourceLimits, check.DeepEquals, quota.CreateResources(quantity.Size(1000)))
 
 		createCalled++
 		switch createCalled {
@@ -221,11 +221,11 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaCreateQuotaConflicts(c *check.C) {
 func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateHappy(c *check.C) {
 	st := s.d.Overlord().State()
 	st.Lock()
-	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", nil, quota.CreateQuotaResources(5000))
+	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", nil, quota.CreateResources(5000))
 	st.Unlock()
 	c.Assert(err, check.IsNil)
 
-	r := daemon.MockServicestateCreateQuota(func(st *state.State, name string, parentName string, snaps []string, resourceLimits quota.QuotaResources) (*state.TaskSet, error) {
+	r := daemon.MockServicestateCreateQuota(func(st *state.State, name string, parentName string, snaps []string, resourceLimits quota.Resources) (*state.TaskSet, error) {
 		c.Errorf("should not have called create quota")
 		return nil, fmt.Errorf("broken test")
 	})
@@ -237,7 +237,7 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateHappy(c *check.C) {
 		c.Assert(name, check.Equals, "ginger-ale")
 		c.Assert(opts, check.DeepEquals, servicestate.QuotaGroupUpdate{
 			AddSnaps:          []string{"some-snap"},
-			NewResourceLimits: quota.CreateQuotaResources(quantity.Size(9000)),
+			NewResourceLimits: quota.CreateResources(quantity.Size(9000)),
 		})
 		ts := state.NewTaskSet(st.NewTask("foo-quota", "..."))
 		return ts, nil
@@ -263,11 +263,11 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateHappy(c *check.C) {
 func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateConflicts(c *check.C) {
 	st := s.d.Overlord().State()
 	st.Lock()
-	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", nil, quota.CreateQuotaResources(5000))
+	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", nil, quota.CreateResources(5000))
 	st.Unlock()
 	c.Assert(err, check.IsNil)
 
-	r := daemon.MockServicestateCreateQuota(func(st *state.State, name string, parentName string, snaps []string, resourceLimits quota.QuotaResources) (*state.TaskSet, error) {
+	r := daemon.MockServicestateCreateQuota(func(st *state.State, name string, parentName string, snaps []string, resourceLimits quota.Resources) (*state.TaskSet, error) {
 		c.Errorf("should not have called create quota")
 		return nil, fmt.Errorf("broken test")
 	})
@@ -279,7 +279,7 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateConflicts(c *check.C) {
 		c.Assert(name, check.Equals, "ginger-ale")
 		c.Assert(opts, check.DeepEquals, servicestate.QuotaGroupUpdate{
 			AddSnaps:          []string{"some-snap"},
-			NewResourceLimits: quota.CreateQuotaResources(quantity.Size(9000)),
+			NewResourceLimits: quota.CreateResources(quantity.Size(9000)),
 		})
 		switch updateCalled {
 		case 1:
@@ -359,7 +359,7 @@ func (s *apiQuotaSuite) TestPostRemoveQuotaHappy(c *check.C) {
 func (s *apiQuotaSuite) TestPostRemoveQuotaConflict(c *check.C) {
 	st := s.d.Overlord().State()
 	st.Lock()
-	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", []string{"some-snap"}, quota.CreateQuotaResources(5000))
+	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", []string{"some-snap"}, quota.CreateResources(5000))
 	st.Unlock()
 	c.Assert(err, check.IsNil)
 

--- a/daemon/export_api_quotas_test.go
+++ b/daemon/export_api_quotas_test.go
@@ -30,7 +30,7 @@ type (
 	PostQuotaGroupData = postQuotaGroupData
 )
 
-func MockServicestateCreateQuota(f func(st *state.State, name string, parentName string, snaps []string, resourceLimits quota.QuotaResources) (*state.TaskSet, error)) func() {
+func MockServicestateCreateQuota(f func(st *state.State, name string, parentName string, snaps []string, resourceLimits quota.Resources) (*state.TaskSet, error)) func() {
 	old := servicestateCreateQuota
 	servicestateCreateQuota = f
 	return func() {

--- a/daemon/export_api_quotas_test.go
+++ b/daemon/export_api_quotas_test.go
@@ -20,8 +20,9 @@
 package daemon
 
 import (
-	"github.com/snapcore/snapd/gadget/quantity"
+	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/overlord/servicestate"
+	"github.com/snapcore/snapd/overlord/servicestate/resources"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap/quota"
 )
@@ -30,7 +31,7 @@ type (
 	PostQuotaGroupData = postQuotaGroupData
 )
 
-func MockServicestateCreateQuota(f func(st *state.State, name string, parentName string, snaps []string, memoryLimit quantity.Size) (*state.TaskSet, error)) func() {
+func MockServicestateCreateQuota(f func(st *state.State, name string, parentName string, snaps []string, resourceLimits resources.QuotaResources) (*state.TaskSet, error)) func() {
 	old := servicestateCreateQuota
 	servicestateCreateQuota = f
 	return func() {
@@ -54,10 +55,10 @@ func MockServicestateRemoveQuota(f func(st *state.State, name string) (*state.Ta
 	}
 }
 
-func MockGetQuotaMemUsage(f func(grp *quota.Group) (quantity.Size, error)) (restore func()) {
-	old := getQuotaMemUsage
-	getQuotaMemUsage = f
+func MockGetQuotaUsage(f func(grp *quota.Group) (*client.QuotaValues, error)) (restore func()) {
+	old := getQuotaUsage
+	getQuotaUsage = f
 	return func() {
-		getQuotaMemUsage = old
+		getQuotaUsage = old
 	}
 }

--- a/daemon/export_api_quotas_test.go
+++ b/daemon/export_api_quotas_test.go
@@ -22,7 +22,6 @@ package daemon
 import (
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/overlord/servicestate"
-	"github.com/snapcore/snapd/overlord/servicestate/resources"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap/quota"
 )
@@ -31,7 +30,7 @@ type (
 	PostQuotaGroupData = postQuotaGroupData
 )
 
-func MockServicestateCreateQuota(f func(st *state.State, name string, parentName string, snaps []string, resourceLimits resources.QuotaResources) (*state.TaskSet, error)) func() {
+func MockServicestateCreateQuota(f func(st *state.State, name string, parentName string, snaps []string, resourceLimits quota.QuotaResources) (*state.TaskSet, error)) func() {
 	old := servicestateCreateQuota
 	servicestateCreateQuota = f
 	return func() {

--- a/overlord/configstate/configcore/vitality_test.go
+++ b/overlord/configstate/configcore/vitality_test.go
@@ -32,11 +32,11 @@ import (
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/configstate/configcore"
-	"github.com/snapcore/snapd/overlord/servicestate/resources"
 	"github.com/snapcore/snapd/overlord/servicestate/servicestatetest"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/quota"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/systemd"
 	"github.com/snapcore/snapd/systemd/systemdtest"
@@ -192,7 +192,7 @@ func (s *vitalitySuite) TestConfigureVitalityWithQuotaGroup(c *C) {
 	tr.Commit()
 
 	// make a new quota group with this snap in it
-	err := servicestatetest.MockQuotaInState(s.state, "foogroup", "", []string{"test-snap"}, resources.CreateQuotaResources(quantity.SizeMiB))
+	err := servicestatetest.MockQuotaInState(s.state, "foogroup", "", []string{"test-snap"}, quota.CreateQuotaResources(quantity.SizeMiB))
 	c.Assert(err, IsNil)
 
 	s.state.Unlock()

--- a/overlord/configstate/configcore/vitality_test.go
+++ b/overlord/configstate/configcore/vitality_test.go
@@ -192,7 +192,7 @@ func (s *vitalitySuite) TestConfigureVitalityWithQuotaGroup(c *C) {
 	tr.Commit()
 
 	// make a new quota group with this snap in it
-	err := servicestatetest.MockQuotaInState(s.state, "foogroup", "", []string{"test-snap"}, quota.CreateResources(quantity.SizeMiB))
+	err := servicestatetest.MockQuotaInState(s.state, "foogroup", "", []string{"test-snap"}, quota.NewResources(quantity.SizeMiB))
 	c.Assert(err, IsNil)
 
 	s.state.Unlock()

--- a/overlord/configstate/configcore/vitality_test.go
+++ b/overlord/configstate/configcore/vitality_test.go
@@ -192,7 +192,7 @@ func (s *vitalitySuite) TestConfigureVitalityWithQuotaGroup(c *C) {
 	tr.Commit()
 
 	// make a new quota group with this snap in it
-	err := servicestatetest.MockQuotaInState(s.state, "foogroup", "", []string{"test-snap"}, quota.CreateQuotaResources(quantity.SizeMiB))
+	err := servicestatetest.MockQuotaInState(s.state, "foogroup", "", []string{"test-snap"}, quota.CreateResources(quantity.SizeMiB))
 	c.Assert(err, IsNil)
 
 	s.state.Unlock()

--- a/overlord/configstate/configcore/vitality_test.go
+++ b/overlord/configstate/configcore/vitality_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/configstate/configcore"
+	"github.com/snapcore/snapd/overlord/servicestate/resources"
 	"github.com/snapcore/snapd/overlord/servicestate/servicestatetest"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
@@ -191,7 +192,7 @@ func (s *vitalitySuite) TestConfigureVitalityWithQuotaGroup(c *C) {
 	tr.Commit()
 
 	// make a new quota group with this snap in it
-	err := servicestatetest.MockQuotaInState(s.state, "foogroup", "", []string{"test-snap"}, quantity.SizeMiB)
+	err := servicestatetest.MockQuotaInState(s.state, "foogroup", "", []string{"test-snap"}, resources.CreateQuotaResources(quantity.SizeMiB))
 	c.Assert(err, IsNil)
 
 	s.state.Unlock()

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -732,7 +732,7 @@ apps:
 	tr.Commit()
 
 	// put the snap in a quota group
-	err := servicestatetest.MockQuotaInState(st, "quota-grp", "", []string{"foo"}, quota.CreateQuotaResources(quantity.SizeMiB))
+	err := servicestatetest.MockQuotaInState(st, "quota-grp", "", []string{"foo"}, quota.CreateResources(quantity.SizeMiB))
 	c.Assert(err, IsNil)
 
 	ts, err := snapstate.Remove(st, "foo", snap.R(0), &snapstate.RemoveFlags{Purge: true})

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -69,7 +69,6 @@ import (
 	"github.com/snapcore/snapd/overlord/ifacestate"
 	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/servicestate"
-	"github.com/snapcore/snapd/overlord/servicestate/resources"
 	"github.com/snapcore/snapd/overlord/servicestate/servicestatetest"
 	"github.com/snapcore/snapd/overlord/snapshotstate"
 	"github.com/snapcore/snapd/overlord/snapstate"
@@ -81,6 +80,7 @@ import (
 	"github.com/snapcore/snapd/seed/seedwriter"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/naming"
+	"github.com/snapcore/snapd/snap/quota"
 	"github.com/snapcore/snapd/snap/snapfile"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/store"
@@ -732,7 +732,7 @@ apps:
 	tr.Commit()
 
 	// put the snap in a quota group
-	err := servicestatetest.MockQuotaInState(st, "quota-grp", "", []string{"foo"}, resources.CreateQuotaResources(quantity.SizeMiB))
+	err := servicestatetest.MockQuotaInState(st, "quota-grp", "", []string{"foo"}, quota.CreateQuotaResources(quantity.SizeMiB))
 	c.Assert(err, IsNil)
 
 	ts, err := snapstate.Remove(st, "foo", snap.R(0), &snapstate.RemoveFlags{Purge: true})

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -732,7 +732,7 @@ apps:
 	tr.Commit()
 
 	// put the snap in a quota group
-	err := servicestatetest.MockQuotaInState(st, "quota-grp", "", []string{"foo"}, quota.CreateResources(quantity.SizeMiB))
+	err := servicestatetest.MockQuotaInState(st, "quota-grp", "", []string{"foo"}, quota.NewResources(quantity.SizeMiB))
 	c.Assert(err, IsNil)
 
 	ts, err := snapstate.Remove(st, "foo", snap.R(0), &snapstate.RemoveFlags{Purge: true})

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -69,6 +69,7 @@ import (
 	"github.com/snapcore/snapd/overlord/ifacestate"
 	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/servicestate"
+	"github.com/snapcore/snapd/overlord/servicestate/resources"
 	"github.com/snapcore/snapd/overlord/servicestate/servicestatetest"
 	"github.com/snapcore/snapd/overlord/snapshotstate"
 	"github.com/snapcore/snapd/overlord/snapstate"
@@ -731,7 +732,7 @@ apps:
 	tr.Commit()
 
 	// put the snap in a quota group
-	err := servicestatetest.MockQuotaInState(st, "quota-grp", "", []string{"foo"}, quantity.SizeMiB)
+	err := servicestatetest.MockQuotaInState(st, "quota-grp", "", []string{"foo"}, resources.CreateQuotaResources(quantity.SizeMiB))
 	c.Assert(err, IsNil)
 
 	ts, err := snapstate.Remove(st, "foo", snap.R(0), &snapstate.RemoveFlags{Purge: true})

--- a/overlord/servicestate/internal/quotas.go
+++ b/overlord/servicestate/internal/quotas.go
@@ -108,7 +108,7 @@ func PatchQuotas(st *state.State, grps ...*quota.Group) (map[string]*quota.Group
 
 // CreateQuotaInState creates a quota group with the given paremeters
 // in the state.  It takes the current map of all quota groups.
-func CreateQuotaInState(st *state.State, quotaName string, parentGrp *quota.Group, snaps []string, resourceLimits quota.QuotaResources, allGrps map[string]*quota.Group) (*quota.Group, map[string]*quota.Group, error) {
+func CreateQuotaInState(st *state.State, quotaName string, parentGrp *quota.Group, snaps []string, resourceLimits quota.Resources, allGrps map[string]*quota.Group) (*quota.Group, map[string]*quota.Group, error) {
 	// make sure that the parent group exists if we are creating a sub-group
 	var grp *quota.Group
 	var err error

--- a/overlord/servicestate/internal/quotas.go
+++ b/overlord/servicestate/internal/quotas.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/snapcore/snapd/gadget/quantity"
+	"github.com/snapcore/snapd/overlord/servicestate/resources"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap/quota"
 )
@@ -109,13 +109,13 @@ func PatchQuotas(st *state.State, grps ...*quota.Group) (map[string]*quota.Group
 
 // CreateQuotaInState creates a quota group with the given paremeters
 // in the state.  It takes the current map of all quota groups.
-func CreateQuotaInState(st *state.State, quotaName string, parentGrp *quota.Group, snaps []string, memoryLimit quantity.Size, allGrps map[string]*quota.Group) (*quota.Group, map[string]*quota.Group, error) {
+func CreateQuotaInState(st *state.State, quotaName string, parentGrp *quota.Group, snaps []string, resourceLimits resources.QuotaResources, allGrps map[string]*quota.Group) (*quota.Group, map[string]*quota.Group, error) {
 	// make sure that the parent group exists if we are creating a sub-group
 	var grp *quota.Group
 	var err error
 	updatedGrps := []*quota.Group{}
 	if parentGrp != nil {
-		grp, err = parentGrp.NewSubGroup(quotaName, memoryLimit)
+		grp, err = parentGrp.NewSubGroup(quotaName, resourceLimits)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -123,7 +123,7 @@ func CreateQuotaInState(st *state.State, quotaName string, parentGrp *quota.Grou
 		updatedGrps = append(updatedGrps, parentGrp)
 	} else {
 		// make a new group
-		grp, err = quota.NewGroup(quotaName, memoryLimit)
+		grp, err = quota.NewGroup(quotaName, resourceLimits)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/overlord/servicestate/internal/quotas.go
+++ b/overlord/servicestate/internal/quotas.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/snapcore/snapd/overlord/servicestate/resources"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap/quota"
 )
@@ -109,7 +108,7 @@ func PatchQuotas(st *state.State, grps ...*quota.Group) (map[string]*quota.Group
 
 // CreateQuotaInState creates a quota group with the given paremeters
 // in the state.  It takes the current map of all quota groups.
-func CreateQuotaInState(st *state.State, quotaName string, parentGrp *quota.Group, snaps []string, resourceLimits resources.QuotaResources, allGrps map[string]*quota.Group) (*quota.Group, map[string]*quota.Group, error) {
+func CreateQuotaInState(st *state.State, quotaName string, parentGrp *quota.Group, snaps []string, resourceLimits quota.QuotaResources, allGrps map[string]*quota.Group) (*quota.Group, map[string]*quota.Group, error) {
 	// make sure that the parent group exists if we are creating a sub-group
 	var grp *quota.Group
 	var err error

--- a/overlord/servicestate/internal/quotas_test.go
+++ b/overlord/servicestate/internal/quotas_test.go
@@ -135,7 +135,7 @@ func (s *servicestateQuotasSuite) TestCreateQuotaInState(c *C) {
 		Name:        "foogroup",
 		MemoryLimit: quantity.SizeGiB,
 	}
-	grp1, newGrps, err := internal.CreateQuotaInState(st, "foogroup", nil, nil, quota.CreateResources(quantity.SizeGiB), nil)
+	grp1, newGrps, err := internal.CreateQuotaInState(st, "foogroup", nil, nil, quota.NewResources(quantity.SizeGiB), nil)
 	c.Assert(err, IsNil)
 	c.Check(grp1, DeepEquals, grp)
 	c.Check(newGrps, DeepEquals, map[string]*quota.Group{
@@ -156,7 +156,7 @@ func (s *servicestateQuotasSuite) TestCreateQuotaInState(c *C) {
 		ParentGroup: "foogroup",
 		Snaps:       []string{"snap1", "snap2"},
 	}
-	grp3, newGrps, err := internal.CreateQuotaInState(st, "group-2", grp1, []string{"snap1", "snap2"}, quota.CreateResources(quantity.SizeGiB), nil)
+	grp3, newGrps, err := internal.CreateQuotaInState(st, "group-2", grp1, []string{"snap1", "snap2"}, quota.NewResources(quantity.SizeGiB), nil)
 	c.Assert(err, IsNil)
 	c.Check(grp3.Name, Equals, grp2.Name)
 	c.Check(grp3.MemoryLimit, Equals, grp2.MemoryLimit)

--- a/overlord/servicestate/internal/quotas_test.go
+++ b/overlord/servicestate/internal/quotas_test.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/overlord/servicestate/internal"
-	"github.com/snapcore/snapd/overlord/servicestate/resources"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap/quota"
 )
@@ -136,7 +135,7 @@ func (s *servicestateQuotasSuite) TestCreateQuotaInState(c *C) {
 		Name:        "foogroup",
 		MemoryLimit: quantity.SizeGiB,
 	}
-	grp1, newGrps, err := internal.CreateQuotaInState(st, "foogroup", nil, nil, resources.CreateQuotaResources(quantity.SizeGiB), nil)
+	grp1, newGrps, err := internal.CreateQuotaInState(st, "foogroup", nil, nil, quota.CreateQuotaResources(quantity.SizeGiB), nil)
 	c.Assert(err, IsNil)
 	c.Check(grp1, DeepEquals, grp)
 	c.Check(newGrps, DeepEquals, map[string]*quota.Group{
@@ -157,7 +156,7 @@ func (s *servicestateQuotasSuite) TestCreateQuotaInState(c *C) {
 		ParentGroup: "foogroup",
 		Snaps:       []string{"snap1", "snap2"},
 	}
-	grp3, newGrps, err := internal.CreateQuotaInState(st, "group-2", grp1, []string{"snap1", "snap2"}, resources.CreateQuotaResources(quantity.SizeGiB), nil)
+	grp3, newGrps, err := internal.CreateQuotaInState(st, "group-2", grp1, []string{"snap1", "snap2"}, quota.CreateQuotaResources(quantity.SizeGiB), nil)
 	c.Assert(err, IsNil)
 	c.Check(grp3.Name, Equals, grp2.Name)
 	c.Check(grp3.MemoryLimit, Equals, grp2.MemoryLimit)

--- a/overlord/servicestate/internal/quotas_test.go
+++ b/overlord/servicestate/internal/quotas_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/overlord/servicestate/internal"
+	"github.com/snapcore/snapd/overlord/servicestate/resources"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap/quota"
 )
@@ -122,7 +123,7 @@ func (s *servicestateQuotasSuite) TestQuotas(c *C) {
 
 	_, err = internal.PatchQuotas(st, otherGrp2, otherGrp)
 	// either group can get checked first
-	c.Assert(err, ErrorMatches, `cannot update quotas "other-group", "other-group2": group "other-group2?" is invalid: group memory limit must be non-zero`)
+	c.Assert(err, ErrorMatches, `cannot update quotas "other-group", "other-group2": group "other-group" is invalid: quota group must have a memory limit set`)
 }
 
 func (s *servicestateQuotasSuite) TestCreateQuotaInState(c *C) {
@@ -135,7 +136,7 @@ func (s *servicestateQuotasSuite) TestCreateQuotaInState(c *C) {
 		Name:        "foogroup",
 		MemoryLimit: quantity.SizeGiB,
 	}
-	grp1, newGrps, err := internal.CreateQuotaInState(st, "foogroup", nil, nil, quantity.SizeGiB, nil)
+	grp1, newGrps, err := internal.CreateQuotaInState(st, "foogroup", nil, nil, resources.CreateQuotaResources(quantity.SizeGiB), nil)
 	c.Assert(err, IsNil)
 	c.Check(grp1, DeepEquals, grp)
 	c.Check(newGrps, DeepEquals, map[string]*quota.Group{
@@ -156,7 +157,7 @@ func (s *servicestateQuotasSuite) TestCreateQuotaInState(c *C) {
 		ParentGroup: "foogroup",
 		Snaps:       []string{"snap1", "snap2"},
 	}
-	grp3, newGrps, err := internal.CreateQuotaInState(st, "group-2", grp1, []string{"snap1", "snap2"}, quantity.SizeGiB, nil)
+	grp3, newGrps, err := internal.CreateQuotaInState(st, "group-2", grp1, []string{"snap1", "snap2"}, resources.CreateQuotaResources(quantity.SizeGiB), nil)
 	c.Assert(err, IsNil)
 	c.Check(grp3.Name, Equals, grp2.Name)
 	c.Check(grp3.MemoryLimit, Equals, grp2.MemoryLimit)

--- a/overlord/servicestate/internal/quotas_test.go
+++ b/overlord/servicestate/internal/quotas_test.go
@@ -135,7 +135,7 @@ func (s *servicestateQuotasSuite) TestCreateQuotaInState(c *C) {
 		Name:        "foogroup",
 		MemoryLimit: quantity.SizeGiB,
 	}
-	grp1, newGrps, err := internal.CreateQuotaInState(st, "foogroup", nil, nil, quota.CreateQuotaResources(quantity.SizeGiB), nil)
+	grp1, newGrps, err := internal.CreateQuotaInState(st, "foogroup", nil, nil, quota.CreateResources(quantity.SizeGiB), nil)
 	c.Assert(err, IsNil)
 	c.Check(grp1, DeepEquals, grp)
 	c.Check(newGrps, DeepEquals, map[string]*quota.Group{
@@ -156,7 +156,7 @@ func (s *servicestateQuotasSuite) TestCreateQuotaInState(c *C) {
 		ParentGroup: "foogroup",
 		Snaps:       []string{"snap1", "snap2"},
 	}
-	grp3, newGrps, err := internal.CreateQuotaInState(st, "group-2", grp1, []string{"snap1", "snap2"}, quota.CreateQuotaResources(quantity.SizeGiB), nil)
+	grp3, newGrps, err := internal.CreateQuotaInState(st, "group-2", grp1, []string{"snap1", "snap2"}, quota.CreateResources(quantity.SizeGiB), nil)
 	c.Assert(err, IsNil)
 	c.Check(grp3.Name, Equals, grp2.Name)
 	c.Check(grp3.MemoryLimit, Equals, grp2.MemoryLimit)

--- a/overlord/servicestate/internal/quotas_test.go
+++ b/overlord/servicestate/internal/quotas_test.go
@@ -123,7 +123,7 @@ func (s *servicestateQuotasSuite) TestQuotas(c *C) {
 
 	_, err = internal.PatchQuotas(st, otherGrp2, otherGrp)
 	// either group can get checked first
-	c.Assert(err, ErrorMatches, `cannot update quotas "other-group", "other-group2": group "other-group" is invalid: quota group must have a memory limit set`)
+	c.Assert(err, ErrorMatches, `cannot update quotas "other-group", "other-group2": group "other-group2?" is invalid: quota group must have a memory limit set`)
 }
 
 func (s *servicestateQuotasSuite) TestCreateQuotaInState(c *C) {

--- a/overlord/servicestate/quota_control.go
+++ b/overlord/servicestate/quota_control.go
@@ -23,9 +23,9 @@ import (
 	"fmt"
 
 	"github.com/snapcore/snapd/features"
-	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/servicestate/internal"
+	"github.com/snapcore/snapd/overlord/servicestate/resources"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snapdenv"
@@ -65,7 +65,7 @@ func quotaGroupsAvailable(st *state.State) error {
 // CreateQuota attempts to create the specified quota group with the specified
 // snaps in it.
 // TODO: should this use something like QuotaGroupUpdate with fewer fields?
-func CreateQuota(st *state.State, name string, parentName string, snaps []string, memoryLimit quantity.Size) (*state.TaskSet, error) {
+func CreateQuota(st *state.State, name string, parentName string, snaps []string, resourceLimits resources.QuotaResources) (*state.TaskSet, error) {
 	if err := quotaGroupsAvailable(st); err != nil {
 		return nil, err
 	}
@@ -80,16 +80,9 @@ func CreateQuota(st *state.State, name string, parentName string, snaps []string
 		return nil, fmt.Errorf("group %q already exists", name)
 	}
 
-	if memoryLimit == 0 {
-		return nil, fmt.Errorf("cannot create quota group with no memory limit set")
-	}
-
-	// make sure the memory limit is at least 4K, that is the minimum size
-	// to allow nesting, otherwise groups with less than 4K will trigger the
-	// oom killer to be invoked when a new group is added as a sub-group to the
-	// larger group.
-	if memoryLimit <= 4*quantity.SizeKiB {
-		return nil, fmt.Errorf("memory limit for group %q is too small: size must be larger than 4KB", name)
+	// validate the resource limits for the group
+	if err := resourceLimits.Validate(); err != nil {
+		return nil, fmt.Errorf("cannot create quota group %q: %v", name, err)
 	}
 
 	// make sure the specified snaps exist and aren't currently in another group
@@ -106,11 +99,11 @@ func CreateQuota(st *state.State, name string, parentName string, snaps []string
 
 	// create the task with the action in it
 	qc := QuotaControlAction{
-		Action:      "create",
-		QuotaName:   name,
-		MemoryLimit: memoryLimit,
-		AddSnaps:    snaps,
-		ParentName:  parentName,
+		Action:         "create",
+		QuotaName:      name,
+		ResourceLimits: resourceLimits,
+		AddSnaps:       snaps,
+		ParentName:     parentName,
 	}
 
 	ts := state.NewTaskSet()
@@ -179,9 +172,9 @@ type QuotaGroupUpdate struct {
 	// the quota group
 	AddSnaps []string
 
-	// NewMemoryLimit is the new memory limit to be used for the quota group. If
-	// zero, then the quota group's memory limit is not changed.
-	NewMemoryLimit quantity.Size
+	// NewResourceLimits is the new resource limits to be used for the quota group. If
+	// the limits are zero, then the quota group's limits is not changed.
+	NewResourceLimits resources.QuotaResources
 }
 
 // UpdateQuota updates the quota as per the options.
@@ -203,15 +196,9 @@ func UpdateQuota(st *state.State, name string, updateOpts QuotaGroupUpdate) (*st
 		return nil, fmt.Errorf("group %q does not exist", name)
 	}
 
-	// check that the memory limit is not being decreased
-	if updateOpts.NewMemoryLimit != 0 {
-		// we disallow decreasing the memory limit because it is difficult to do
-		// so correctly with the current state of our code in
-		// EnsureSnapServices, see comment in ensureSnapServicesForGroup for
-		// full details
-		if updateOpts.NewMemoryLimit < grp.MemoryLimit {
-			return nil, fmt.Errorf("cannot decrease memory limit of existing quota-group, remove and re-create it to decrease the limit")
-		}
+	currentQuotas := grp.GetQuotaResources()
+	if err := currentQuotas.ValidateChange(updateOpts.NewResourceLimits); err != nil {
+		return nil, fmt.Errorf("cannot update group %q: %v", name, err)
 	}
 
 	// now ensure that all of the snaps mentioned in AddSnaps exist as snaps and
@@ -229,10 +216,10 @@ func UpdateQuota(st *state.State, name string, updateOpts QuotaGroupUpdate) (*st
 
 	// create the action and the correspoding task set
 	qc := QuotaControlAction{
-		Action:      "update",
-		QuotaName:   name,
-		MemoryLimit: updateOpts.NewMemoryLimit,
-		AddSnaps:    updateOpts.AddSnaps,
+		Action:         "update",
+		QuotaName:      name,
+		ResourceLimits: updateOpts.NewResourceLimits,
+		AddSnaps:       updateOpts.AddSnaps,
 	}
 
 	ts := state.NewTaskSet()

--- a/overlord/servicestate/quota_control.go
+++ b/overlord/servicestate/quota_control.go
@@ -25,9 +25,9 @@ import (
 	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/servicestate/internal"
-	"github.com/snapcore/snapd/overlord/servicestate/resources"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap/quota"
 	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/systemd"
 )
@@ -65,7 +65,7 @@ func quotaGroupsAvailable(st *state.State) error {
 // CreateQuota attempts to create the specified quota group with the specified
 // snaps in it.
 // TODO: should this use something like QuotaGroupUpdate with fewer fields?
-func CreateQuota(st *state.State, name string, parentName string, snaps []string, resourceLimits resources.QuotaResources) (*state.TaskSet, error) {
+func CreateQuota(st *state.State, name string, parentName string, snaps []string, resourceLimits quota.QuotaResources) (*state.TaskSet, error) {
 	if err := quotaGroupsAvailable(st); err != nil {
 		return nil, err
 	}
@@ -174,7 +174,7 @@ type QuotaGroupUpdate struct {
 
 	// NewResourceLimits is the new resource limits to be used for the quota group. If
 	// the limits are zero, then the quota group's limits is not changed.
-	NewResourceLimits resources.QuotaResources
+	NewResourceLimits quota.QuotaResources
 }
 
 // UpdateQuota updates the quota as per the options.

--- a/overlord/servicestate/quota_control.go
+++ b/overlord/servicestate/quota_control.go
@@ -65,7 +65,7 @@ func quotaGroupsAvailable(st *state.State) error {
 // CreateQuota attempts to create the specified quota group with the specified
 // snaps in it.
 // TODO: should this use something like QuotaGroupUpdate with fewer fields?
-func CreateQuota(st *state.State, name string, parentName string, snaps []string, resourceLimits quota.QuotaResources) (*state.TaskSet, error) {
+func CreateQuota(st *state.State, name string, parentName string, snaps []string, resourceLimits quota.Resources) (*state.TaskSet, error) {
 	if err := quotaGroupsAvailable(st); err != nil {
 		return nil, err
 	}
@@ -172,9 +172,9 @@ type QuotaGroupUpdate struct {
 	// the quota group
 	AddSnaps []string
 
-	// NewResourceLimits is the new resource limits to be used for the quota group. If
-	// the limits are zero, then the quota group's limits is not changed.
-	NewResourceLimits quota.QuotaResources
+	// NewResourceLimits is the new resource limits to be used for the quota group. A
+	// limit is only changed if the corresponding limit is != nil.
+	NewResourceLimits quota.Resources
 }
 
 // UpdateQuota updates the quota as per the options.

--- a/overlord/servicestate/quota_control_test.go
+++ b/overlord/servicestate/quota_control_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/servicestate"
+	"github.com/snapcore/snapd/overlord/servicestate/resources"
 	"github.com/snapcore/snapd/overlord/servicestate/servicestatetest"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
@@ -66,10 +67,10 @@ func (s *quotaControlSuite) SetUpTest(c *C) {
 }
 
 type quotaGroupState struct {
-	MemoryLimit quantity.Size
-	SubGroups   []string
-	ParentGroup string
-	Snaps       []string
+	ResourceLimits resources.QuotaResources
+	SubGroups      []string
+	ParentGroup    string
+	Snaps          []string
 }
 
 func checkQuotaState(c *C, st *state.State, exp map[string]quotaGroupState) {
@@ -79,7 +80,8 @@ func checkQuotaState(c *C, st *state.State, exp map[string]quotaGroupState) {
 	for name, grp := range m {
 		expGrp, ok := exp[name]
 		c.Assert(ok, Equals, true, Commentf("unexpected group %q in state", name))
-		c.Assert(grp.MemoryLimit, Equals, expGrp.MemoryLimit)
+		c.Assert(expGrp.ResourceLimits.Memory, NotNil)
+		c.Assert(grp.MemoryLimit, Equals, expGrp.ResourceLimits.Memory.MemoryLimit)
 		c.Assert(grp.ParentGroup, Equals, expGrp.ParentGroup)
 
 		c.Assert(grp.Snaps, HasLen, len(expGrp.Snaps))
@@ -208,7 +210,7 @@ func (s *quotaControlSuite) TestCreateQuotaNotEnabled(c *C) {
 	tr.Commit()
 
 	// try to create an empty quota group
-	_, err := servicestate.CreateQuota(s.state, "foo", "", nil, quantity.SizeGiB)
+	_, err := servicestate.CreateQuota(s.state, "foo", "", nil, resources.CreateQuotaResources(quantity.SizeGiB))
 	c.Assert(err, ErrorMatches, `experimental feature disabled - test it by setting 'experimental.quota-groups' to true`)
 }
 
@@ -221,7 +223,7 @@ func (s *quotaControlSuite) TestCreateQuotaSystemdTooOld(c *C) {
 
 	servicestate.CheckSystemdVersion()
 
-	_, err := servicestate.CreateQuota(s.state, "foo", "", nil, quantity.SizeGiB)
+	_, err := servicestate.CreateQuota(s.state, "foo", "", nil, resources.CreateQuotaResources(quantity.SizeGiB))
 	c.Assert(err, ErrorMatches, `cannot use quotas with incompatible systemd: systemd version 229 is too old \(expected at least 230\)`)
 }
 
@@ -230,7 +232,7 @@ func (s *quotaControlSuite) TestCreateQuotaPrecond(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, 2*quantity.SizeGiB)
+	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, resources.CreateQuotaResources(2*quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
 	tests := []struct {
@@ -240,13 +242,13 @@ func (s *quotaControlSuite) TestCreateQuotaPrecond(c *C) {
 		err   string
 	}{
 		{"foo", 16 * quantity.SizeKiB, nil, `group "foo" already exists`},
-		{"new", 0, nil, `cannot create quota group with no memory limit set`},
-		{"new", quantity.SizeKiB, nil, `memory limit for group "new" is too small: size must be larger than 4KB`},
+		{"new", 0, nil, `cannot create quota group "new": quota group must have a memory limit set`},
+		{"new", quantity.SizeKiB, nil, `cannot create quota group "new": memory limit 1024 is too small: size must be larger than 4KB`},
 		{"new", 16 * quantity.SizeKiB, []string{"baz"}, `cannot use snap "baz" in group "new": snap "baz" is not installed`},
 	}
 
 	for _, t := range tests {
-		_, err := servicestate.CreateQuota(st, t.name, "", t.snaps, t.mem)
+		_, err := servicestate.CreateQuota(st, t.name, "", t.snaps, resources.CreateQuotaResources(t.mem))
 		c.Check(err, ErrorMatches, t.err)
 	}
 }
@@ -263,17 +265,17 @@ func (s *quotaControlSuite) TestRemoveQuotaPreseeding(c *C) {
 	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
 
 	// create a quota group
-	ts, err := servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap"}, quantity.SizeGiB)
+	ts, err := servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap"}, resources.CreateQuotaResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
 	chg := st.NewChange("quota-control", "...")
 	chg.AddAll(ts)
 
 	exp := &servicestate.QuotaControlAction{
-		Action:      "create",
-		QuotaName:   "foo",
-		AddSnaps:    []string{"test-snap"},
-		MemoryLimit: quantity.SizeGiB,
+		Action:         "create",
+		QuotaName:      "foo",
+		AddSnaps:       []string{"test-snap"},
+		ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
 	}
 
 	checkQuotaControlTasks(c, chg.Tasks(), exp)
@@ -288,8 +290,8 @@ func (s *quotaControlSuite) TestRemoveQuotaPreseeding(c *C) {
 	// check that the quota groups were created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			MemoryLimit: quantity.SizeGiB,
-			Snaps:       []string{"test-snap"},
+			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			Snaps:          []string{"test-snap"},
 		},
 	})
 
@@ -324,17 +326,17 @@ func (s *quotaControlSuite) TestCreateUpdateRemoveQuotaHappy(c *C) {
 	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
 
 	// create the quota group
-	ts, err := servicestate.CreateQuota(st, "foo", "", []string{"test-snap"}, quantity.SizeGiB)
+	ts, err := servicestate.CreateQuota(st, "foo", "", []string{"test-snap"}, resources.CreateQuotaResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
 	chg := st.NewChange("quota-control", "...")
 	chg.AddAll(ts)
 
 	exp := &servicestate.QuotaControlAction{
-		Action:      "create",
-		QuotaName:   "foo",
-		AddSnaps:    []string{"test-snap"},
-		MemoryLimit: quantity.SizeGiB,
+		Action:         "create",
+		QuotaName:      "foo",
+		AddSnaps:       []string{"test-snap"},
+		ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
 	}
 
 	checkQuotaControlTasks(c, chg.Tasks(), exp)
@@ -349,22 +351,25 @@ func (s *quotaControlSuite) TestCreateUpdateRemoveQuotaHappy(c *C) {
 	// check that the quota groups were created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			MemoryLimit: quantity.SizeGiB,
-			Snaps:       []string{"test-snap"},
+			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			Snaps:          []string{"test-snap"},
 		},
 	})
 
 	// increase the memory limit
-	ts, err = servicestate.UpdateQuota(st, "foo", servicestate.QuotaGroupUpdate{NewMemoryLimit: 2 * quantity.SizeGiB})
+	ts, err = servicestate.UpdateQuota(st, "foo",
+		servicestate.QuotaGroupUpdate{
+			NewResourceLimits: resources.CreateQuotaResources(2 * quantity.SizeGiB),
+		})
 	c.Assert(err, IsNil)
 
 	chg = st.NewChange("quota-control", "...")
 	chg.AddAll(ts)
 
 	exp2 := &servicestate.QuotaControlAction{
-		Action:      "update",
-		QuotaName:   "foo",
-		MemoryLimit: 2 * quantity.SizeGiB,
+		Action:         "update",
+		QuotaName:      "foo",
+		ResourceLimits: resources.CreateQuotaResources(2 * quantity.SizeGiB),
 	}
 
 	checkQuotaControlTasks(c, chg.Tasks(), exp2)
@@ -378,8 +383,8 @@ func (s *quotaControlSuite) TestCreateUpdateRemoveQuotaHappy(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			MemoryLimit: 2 * quantity.SizeGiB,
-			Snaps:       []string{"test-snap"},
+			ResourceLimits: resources.CreateQuotaResources(2 * quantity.SizeGiB),
+			Snaps:          []string{"test-snap"},
 		},
 	})
 
@@ -445,17 +450,17 @@ func (s *quotaControlSuite) TestEnsureSnapAbsentFromQuotaGroup(c *C) {
 	snaptest.MockSnapCurrent(c, testYaml2, si2)
 
 	// create a quota group
-	ts, err := servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap", "test-snap2"}, quantity.SizeGiB)
+	ts, err := servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap", "test-snap2"}, resources.CreateQuotaResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
 	chg := st.NewChange("quota-control", "...")
 	chg.AddAll(ts)
 
 	exp := &servicestate.QuotaControlAction{
-		Action:      "create",
-		QuotaName:   "foo",
-		AddSnaps:    []string{"test-snap", "test-snap2"},
-		MemoryLimit: quantity.SizeGiB,
+		Action:         "create",
+		QuotaName:      "foo",
+		AddSnaps:       []string{"test-snap", "test-snap2"},
+		ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
 	}
 
 	checkQuotaControlTasks(c, chg.Tasks(), exp)
@@ -469,8 +474,8 @@ func (s *quotaControlSuite) TestEnsureSnapAbsentFromQuotaGroup(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			MemoryLimit: quantity.SizeGiB,
-			Snaps:       []string{"test-snap", "test-snap2"},
+			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			Snaps:          []string{"test-snap", "test-snap2"},
 		},
 	})
 
@@ -480,8 +485,8 @@ func (s *quotaControlSuite) TestEnsureSnapAbsentFromQuotaGroup(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			MemoryLimit: quantity.SizeGiB,
-			Snaps:       []string{"test-snap2"},
+			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			Snaps:          []string{"test-snap2"},
 		},
 	})
 
@@ -496,7 +501,7 @@ func (s *quotaControlSuite) TestEnsureSnapAbsentFromQuotaGroup(c *C) {
 	// and check that it got updated in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			MemoryLimit: quantity.SizeGiB,
+			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
 		},
 	})
 
@@ -523,7 +528,7 @@ func (s *quotaControlSuite) TestUpdateQuotaPrecond(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, 2*quantity.SizeGiB)
+	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, resources.CreateQuotaResources(2*quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
 	tests := []struct {
@@ -532,7 +537,7 @@ func (s *quotaControlSuite) TestUpdateQuotaPrecond(c *C) {
 		err  string
 	}{
 		{"what", servicestate.QuotaGroupUpdate{}, `group "what" does not exist`},
-		{"foo", servicestate.QuotaGroupUpdate{NewMemoryLimit: quantity.SizeGiB}, `cannot decrease memory limit of existing quota-group, remove and re-create it to decrease the limit`},
+		{"foo", servicestate.QuotaGroupUpdate{NewResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB)}, `cannot update group "foo": cannot decrease memory limit, remove and re-create it to decrease the limit`},
 		{"foo", servicestate.QuotaGroupUpdate{AddSnaps: []string{"baz"}}, `cannot use snap "baz" in group "foo": snap "baz" is not installed`},
 	}
 
@@ -547,9 +552,9 @@ func (s *quotaControlSuite) TestRemoveQuotaPrecond(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, 2*quantity.SizeGiB)
+	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, resources.CreateQuotaResources(2*quantity.SizeGiB))
 	c.Assert(err, IsNil)
-	err = servicestatetest.MockQuotaInState(st, "bar", "foo", nil, quantity.SizeGiB)
+	err = servicestatetest.MockQuotaInState(st, "bar", "foo", nil, resources.CreateQuotaResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
 	_, err = servicestate.RemoveQuota(st, "what")
@@ -559,8 +564,8 @@ func (s *quotaControlSuite) TestRemoveQuotaPrecond(c *C) {
 	c.Check(err, ErrorMatches, `cannot remove quota group "foo" with sub-groups, remove the sub-groups first`)
 }
 
-func (s *quotaControlSuite) createQuota(c *C, name string, limit quantity.Size, snaps ...string) {
-	ts, err := servicestate.CreateQuota(s.state, name, "", snaps, limit)
+func (s *quotaControlSuite) createQuota(c *C, name string, limits resources.QuotaResources, snaps ...string) {
+	ts, err := servicestate.CreateQuota(s.state, name, "", snaps, limits)
 	c.Assert(err, IsNil)
 
 	chg := s.state.NewChange("quota-control", "...")
@@ -600,7 +605,7 @@ func (s *quotaControlSuite) TestSnapOpUpdateQuotaConflict(c *C) {
 
 	// create a quota group
 	defer s.se.Stop()
-	s.createQuota(c, "foo", quantity.SizeGiB, "test-snap")
+	s.createQuota(c, "foo", resources.CreateQuotaResources(quantity.SizeGiB), "test-snap")
 
 	ts, err := snapstate.Disable(st, "test-snap2")
 	c.Assert(err, IsNil)
@@ -625,7 +630,7 @@ func (s *quotaControlSuite) TestSnapOpCreateQuotaConflict(c *C) {
 	chg1 := s.state.NewChange("disable", "...")
 	chg1.AddAll(ts)
 
-	_, err = servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap"}, quantity.SizeGiB)
+	_, err = servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap"}, resources.CreateQuotaResources(quantity.SizeGiB))
 	c.Assert(err, ErrorMatches, `snap "test-snap" has "disable" change in progress`)
 }
 
@@ -646,7 +651,7 @@ func (s *quotaControlSuite) TestSnapOpRemoveQuotaConflict(c *C) {
 
 	// create a quota group
 	defer s.se.Stop()
-	s.createQuota(c, "foo", quantity.SizeGiB, "test-snap")
+	s.createQuota(c, "foo", resources.CreateQuotaResources(quantity.SizeGiB), "test-snap")
 
 	ts, err := snapstate.Disable(st, "test-snap")
 	c.Assert(err, IsNil)
@@ -666,7 +671,7 @@ func (s *quotaControlSuite) TestCreateQuotaSnapOpConflict(c *C) {
 	snapstate.Set(s.state, "test-snap", s.testSnapState)
 	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
 
-	ts, err := servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap"}, quantity.SizeGiB)
+	ts, err := servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap"}, resources.CreateQuotaResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 	chg1 := s.state.NewChange("quota-control", "...")
 	chg1.AddAll(ts)
@@ -702,7 +707,7 @@ func (s *quotaControlSuite) TestUpdateQuotaSnapOpConflict(c *C) {
 
 	// create a quota group
 	defer s.se.Stop()
-	s.createQuota(c, "foo", quantity.SizeGiB, "test-snap")
+	s.createQuota(c, "foo", resources.CreateQuotaResources(quantity.SizeGiB), "test-snap")
 
 	ts, err := servicestate.UpdateQuota(st, "foo", servicestate.QuotaGroupUpdate{AddSnaps: []string{"test-snap2"}})
 	c.Assert(err, IsNil)
@@ -730,7 +735,7 @@ func (s *quotaControlSuite) TestRemoveQuotaSnapOpConflict(c *C) {
 
 	// create a quota group
 	defer s.se.Stop()
-	s.createQuota(c, "foo", quantity.SizeGiB, "test-snap")
+	s.createQuota(c, "foo", resources.CreateQuotaResources(quantity.SizeGiB), "test-snap")
 
 	ts, err := servicestate.RemoveQuota(st, "foo")
 	c.Assert(err, IsNil)
@@ -758,7 +763,7 @@ func (s *quotaControlSuite) TestRemoveQuotaLateSnapOpConflict(c *C) {
 
 	// create a quota group
 	defer s.se.Stop()
-	s.createQuota(c, "foo", quantity.SizeGiB, "test-snap")
+	s.createQuota(c, "foo", resources.CreateQuotaResources(quantity.SizeGiB), "test-snap")
 
 	ts, err := servicestate.RemoveQuota(st, "foo")
 	c.Assert(err, IsNil)
@@ -807,14 +812,17 @@ func (s *quotaControlSuite) TestUpdateQuotaUpdateQuotaConflict(c *C) {
 
 	// create a quota group
 	defer s.se.Stop()
-	s.createQuota(c, "foo", quantity.SizeGiB, "test-snap")
+	s.createQuota(c, "foo", resources.CreateQuotaResources(quantity.SizeGiB), "test-snap")
 
 	ts, err := servicestate.UpdateQuota(st, "foo", servicestate.QuotaGroupUpdate{AddSnaps: []string{"test-snap2"}})
 	c.Assert(err, IsNil)
 	chg1 := s.state.NewChange("quota-control", "...")
 	chg1.AddAll(ts)
 
-	_, err = servicestate.UpdateQuota(st, "foo", servicestate.QuotaGroupUpdate{NewMemoryLimit: 2 * quantity.SizeGiB})
+	_, err = servicestate.UpdateQuota(st, "foo",
+		servicestate.QuotaGroupUpdate{
+			NewResourceLimits: resources.CreateQuotaResources(2 * quantity.SizeGiB),
+		})
 	c.Assert(err, ErrorMatches, `quota group "foo" has "quota-control" change in progress`)
 }
 
@@ -845,7 +853,7 @@ func (s *quotaControlSuite) TestUpdateQuotaRemoveQuotaConflict(c *C) {
 
 	// create a quota group
 	defer s.se.Stop()
-	s.createQuota(c, "foo", quantity.SizeGiB, "test-snap")
+	s.createQuota(c, "foo", resources.CreateQuotaResources(quantity.SizeGiB), "test-snap")
 
 	ts, err := servicestate.UpdateQuota(st, "foo", servicestate.QuotaGroupUpdate{AddSnaps: []string{"test-snap2"}})
 	c.Assert(err, IsNil)
@@ -883,7 +891,7 @@ func (s *quotaControlSuite) TestRemoveQuotaUpdateQuotaConflict(c *C) {
 
 	// create a quota group
 	defer s.se.Stop()
-	s.createQuota(c, "foo", quantity.SizeGiB, "test-snap")
+	s.createQuota(c, "foo", resources.CreateQuotaResources(quantity.SizeGiB), "test-snap")
 
 	ts, err := servicestate.RemoveQuota(st, "foo")
 	c.Assert(err, IsNil)
@@ -913,11 +921,11 @@ func (s *quotaControlSuite) TestCreateQuotaCreateQuotaConflict(c *C) {
 	snapstate.Set(s.state, "test-snap2", snapst2)
 	snaptest.MockSnapCurrent(c, testYaml2, si2)
 
-	ts, err := servicestate.CreateQuota(st, "foo", "", []string{"test-snap"}, quantity.SizeGiB)
+	ts, err := servicestate.CreateQuota(st, "foo", "", []string{"test-snap"}, resources.CreateQuotaResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 	chg1 := s.state.NewChange("quota-control", "...")
 	chg1.AddAll(ts)
 
-	_, err = servicestate.CreateQuota(st, "foo", "", []string{"test-snap2"}, 2*quantity.SizeGiB)
+	_, err = servicestate.CreateQuota(st, "foo", "", []string{"test-snap2"}, resources.CreateQuotaResources(2*quantity.SizeGiB))
 	c.Assert(err, ErrorMatches, `quota group "foo" has "quota-control" change in progress`)
 }

--- a/overlord/servicestate/quota_control_test.go
+++ b/overlord/servicestate/quota_control_test.go
@@ -30,11 +30,11 @@ import (
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/servicestate"
-	"github.com/snapcore/snapd/overlord/servicestate/resources"
 	"github.com/snapcore/snapd/overlord/servicestate/servicestatetest"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/quota"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/systemd"
@@ -67,7 +67,7 @@ func (s *quotaControlSuite) SetUpTest(c *C) {
 }
 
 type quotaGroupState struct {
-	ResourceLimits resources.QuotaResources
+	ResourceLimits quota.QuotaResources
 	SubGroups      []string
 	ParentGroup    string
 	Snaps          []string
@@ -210,7 +210,7 @@ func (s *quotaControlSuite) TestCreateQuotaNotEnabled(c *C) {
 	tr.Commit()
 
 	// try to create an empty quota group
-	_, err := servicestate.CreateQuota(s.state, "foo", "", nil, resources.CreateQuotaResources(quantity.SizeGiB))
+	_, err := servicestate.CreateQuota(s.state, "foo", "", nil, quota.CreateQuotaResources(quantity.SizeGiB))
 	c.Assert(err, ErrorMatches, `experimental feature disabled - test it by setting 'experimental.quota-groups' to true`)
 }
 
@@ -223,7 +223,7 @@ func (s *quotaControlSuite) TestCreateQuotaSystemdTooOld(c *C) {
 
 	servicestate.CheckSystemdVersion()
 
-	_, err := servicestate.CreateQuota(s.state, "foo", "", nil, resources.CreateQuotaResources(quantity.SizeGiB))
+	_, err := servicestate.CreateQuota(s.state, "foo", "", nil, quota.CreateQuotaResources(quantity.SizeGiB))
 	c.Assert(err, ErrorMatches, `cannot use quotas with incompatible systemd: systemd version 229 is too old \(expected at least 230\)`)
 }
 
@@ -232,7 +232,7 @@ func (s *quotaControlSuite) TestCreateQuotaPrecond(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, resources.CreateQuotaResources(2*quantity.SizeGiB))
+	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, quota.CreateQuotaResources(2*quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
 	tests := []struct {
@@ -248,7 +248,7 @@ func (s *quotaControlSuite) TestCreateQuotaPrecond(c *C) {
 	}
 
 	for _, t := range tests {
-		_, err := servicestate.CreateQuota(st, t.name, "", t.snaps, resources.CreateQuotaResources(t.mem))
+		_, err := servicestate.CreateQuota(st, t.name, "", t.snaps, quota.CreateQuotaResources(t.mem))
 		c.Check(err, ErrorMatches, t.err)
 	}
 }
@@ -265,7 +265,7 @@ func (s *quotaControlSuite) TestRemoveQuotaPreseeding(c *C) {
 	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
 
 	// create a quota group
-	ts, err := servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap"}, resources.CreateQuotaResources(quantity.SizeGiB))
+	ts, err := servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap"}, quota.CreateQuotaResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
 	chg := st.NewChange("quota-control", "...")
@@ -275,7 +275,7 @@ func (s *quotaControlSuite) TestRemoveQuotaPreseeding(c *C) {
 		Action:         "create",
 		QuotaName:      "foo",
 		AddSnaps:       []string{"test-snap"},
-		ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+		ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
 	}
 
 	checkQuotaControlTasks(c, chg.Tasks(), exp)
@@ -290,7 +290,7 @@ func (s *quotaControlSuite) TestRemoveQuotaPreseeding(c *C) {
 	// check that the quota groups were created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -326,7 +326,7 @@ func (s *quotaControlSuite) TestCreateUpdateRemoveQuotaHappy(c *C) {
 	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
 
 	// create the quota group
-	ts, err := servicestate.CreateQuota(st, "foo", "", []string{"test-snap"}, resources.CreateQuotaResources(quantity.SizeGiB))
+	ts, err := servicestate.CreateQuota(st, "foo", "", []string{"test-snap"}, quota.CreateQuotaResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
 	chg := st.NewChange("quota-control", "...")
@@ -336,7 +336,7 @@ func (s *quotaControlSuite) TestCreateUpdateRemoveQuotaHappy(c *C) {
 		Action:         "create",
 		QuotaName:      "foo",
 		AddSnaps:       []string{"test-snap"},
-		ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+		ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
 	}
 
 	checkQuotaControlTasks(c, chg.Tasks(), exp)
@@ -351,7 +351,7 @@ func (s *quotaControlSuite) TestCreateUpdateRemoveQuotaHappy(c *C) {
 	// check that the quota groups were created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -359,7 +359,7 @@ func (s *quotaControlSuite) TestCreateUpdateRemoveQuotaHappy(c *C) {
 	// increase the memory limit
 	ts, err = servicestate.UpdateQuota(st, "foo",
 		servicestate.QuotaGroupUpdate{
-			NewResourceLimits: resources.CreateQuotaResources(2 * quantity.SizeGiB),
+			NewResourceLimits: quota.CreateQuotaResources(2 * quantity.SizeGiB),
 		})
 	c.Assert(err, IsNil)
 
@@ -369,7 +369,7 @@ func (s *quotaControlSuite) TestCreateUpdateRemoveQuotaHappy(c *C) {
 	exp2 := &servicestate.QuotaControlAction{
 		Action:         "update",
 		QuotaName:      "foo",
-		ResourceLimits: resources.CreateQuotaResources(2 * quantity.SizeGiB),
+		ResourceLimits: quota.CreateQuotaResources(2 * quantity.SizeGiB),
 	}
 
 	checkQuotaControlTasks(c, chg.Tasks(), exp2)
@@ -383,7 +383,7 @@ func (s *quotaControlSuite) TestCreateUpdateRemoveQuotaHappy(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: resources.CreateQuotaResources(2 * quantity.SizeGiB),
+			ResourceLimits: quota.CreateQuotaResources(2 * quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -450,7 +450,7 @@ func (s *quotaControlSuite) TestEnsureSnapAbsentFromQuotaGroup(c *C) {
 	snaptest.MockSnapCurrent(c, testYaml2, si2)
 
 	// create a quota group
-	ts, err := servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap", "test-snap2"}, resources.CreateQuotaResources(quantity.SizeGiB))
+	ts, err := servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap", "test-snap2"}, quota.CreateQuotaResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
 	chg := st.NewChange("quota-control", "...")
@@ -460,7 +460,7 @@ func (s *quotaControlSuite) TestEnsureSnapAbsentFromQuotaGroup(c *C) {
 		Action:         "create",
 		QuotaName:      "foo",
 		AddSnaps:       []string{"test-snap", "test-snap2"},
-		ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+		ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
 	}
 
 	checkQuotaControlTasks(c, chg.Tasks(), exp)
@@ -474,7 +474,7 @@ func (s *quotaControlSuite) TestEnsureSnapAbsentFromQuotaGroup(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap", "test-snap2"},
 		},
 	})
@@ -485,7 +485,7 @@ func (s *quotaControlSuite) TestEnsureSnapAbsentFromQuotaGroup(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap2"},
 		},
 	})
@@ -501,7 +501,7 @@ func (s *quotaControlSuite) TestEnsureSnapAbsentFromQuotaGroup(c *C) {
 	// and check that it got updated in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
 		},
 	})
 
@@ -528,7 +528,7 @@ func (s *quotaControlSuite) TestUpdateQuotaPrecond(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, resources.CreateQuotaResources(2*quantity.SizeGiB))
+	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, quota.CreateQuotaResources(2*quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
 	tests := []struct {
@@ -537,7 +537,7 @@ func (s *quotaControlSuite) TestUpdateQuotaPrecond(c *C) {
 		err  string
 	}{
 		{"what", servicestate.QuotaGroupUpdate{}, `group "what" does not exist`},
-		{"foo", servicestate.QuotaGroupUpdate{NewResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB)}, `cannot update group "foo": cannot decrease memory limit, remove and re-create it to decrease the limit`},
+		{"foo", servicestate.QuotaGroupUpdate{NewResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB)}, `cannot update group "foo": cannot decrease memory limit, remove and re-create it to decrease the limit`},
 		{"foo", servicestate.QuotaGroupUpdate{AddSnaps: []string{"baz"}}, `cannot use snap "baz" in group "foo": snap "baz" is not installed`},
 	}
 
@@ -552,9 +552,9 @@ func (s *quotaControlSuite) TestRemoveQuotaPrecond(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, resources.CreateQuotaResources(2*quantity.SizeGiB))
+	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, quota.CreateQuotaResources(2*quantity.SizeGiB))
 	c.Assert(err, IsNil)
-	err = servicestatetest.MockQuotaInState(st, "bar", "foo", nil, resources.CreateQuotaResources(quantity.SizeGiB))
+	err = servicestatetest.MockQuotaInState(st, "bar", "foo", nil, quota.CreateQuotaResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
 	_, err = servicestate.RemoveQuota(st, "what")
@@ -564,7 +564,7 @@ func (s *quotaControlSuite) TestRemoveQuotaPrecond(c *C) {
 	c.Check(err, ErrorMatches, `cannot remove quota group "foo" with sub-groups, remove the sub-groups first`)
 }
 
-func (s *quotaControlSuite) createQuota(c *C, name string, limits resources.QuotaResources, snaps ...string) {
+func (s *quotaControlSuite) createQuota(c *C, name string, limits quota.QuotaResources, snaps ...string) {
 	ts, err := servicestate.CreateQuota(s.state, name, "", snaps, limits)
 	c.Assert(err, IsNil)
 
@@ -605,7 +605,7 @@ func (s *quotaControlSuite) TestSnapOpUpdateQuotaConflict(c *C) {
 
 	// create a quota group
 	defer s.se.Stop()
-	s.createQuota(c, "foo", resources.CreateQuotaResources(quantity.SizeGiB), "test-snap")
+	s.createQuota(c, "foo", quota.CreateQuotaResources(quantity.SizeGiB), "test-snap")
 
 	ts, err := snapstate.Disable(st, "test-snap2")
 	c.Assert(err, IsNil)
@@ -630,7 +630,7 @@ func (s *quotaControlSuite) TestSnapOpCreateQuotaConflict(c *C) {
 	chg1 := s.state.NewChange("disable", "...")
 	chg1.AddAll(ts)
 
-	_, err = servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap"}, resources.CreateQuotaResources(quantity.SizeGiB))
+	_, err = servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap"}, quota.CreateQuotaResources(quantity.SizeGiB))
 	c.Assert(err, ErrorMatches, `snap "test-snap" has "disable" change in progress`)
 }
 
@@ -651,7 +651,7 @@ func (s *quotaControlSuite) TestSnapOpRemoveQuotaConflict(c *C) {
 
 	// create a quota group
 	defer s.se.Stop()
-	s.createQuota(c, "foo", resources.CreateQuotaResources(quantity.SizeGiB), "test-snap")
+	s.createQuota(c, "foo", quota.CreateQuotaResources(quantity.SizeGiB), "test-snap")
 
 	ts, err := snapstate.Disable(st, "test-snap")
 	c.Assert(err, IsNil)
@@ -671,7 +671,7 @@ func (s *quotaControlSuite) TestCreateQuotaSnapOpConflict(c *C) {
 	snapstate.Set(s.state, "test-snap", s.testSnapState)
 	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
 
-	ts, err := servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap"}, resources.CreateQuotaResources(quantity.SizeGiB))
+	ts, err := servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap"}, quota.CreateQuotaResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 	chg1 := s.state.NewChange("quota-control", "...")
 	chg1.AddAll(ts)
@@ -707,7 +707,7 @@ func (s *quotaControlSuite) TestUpdateQuotaSnapOpConflict(c *C) {
 
 	// create a quota group
 	defer s.se.Stop()
-	s.createQuota(c, "foo", resources.CreateQuotaResources(quantity.SizeGiB), "test-snap")
+	s.createQuota(c, "foo", quota.CreateQuotaResources(quantity.SizeGiB), "test-snap")
 
 	ts, err := servicestate.UpdateQuota(st, "foo", servicestate.QuotaGroupUpdate{AddSnaps: []string{"test-snap2"}})
 	c.Assert(err, IsNil)
@@ -735,7 +735,7 @@ func (s *quotaControlSuite) TestRemoveQuotaSnapOpConflict(c *C) {
 
 	// create a quota group
 	defer s.se.Stop()
-	s.createQuota(c, "foo", resources.CreateQuotaResources(quantity.SizeGiB), "test-snap")
+	s.createQuota(c, "foo", quota.CreateQuotaResources(quantity.SizeGiB), "test-snap")
 
 	ts, err := servicestate.RemoveQuota(st, "foo")
 	c.Assert(err, IsNil)
@@ -763,7 +763,7 @@ func (s *quotaControlSuite) TestRemoveQuotaLateSnapOpConflict(c *C) {
 
 	// create a quota group
 	defer s.se.Stop()
-	s.createQuota(c, "foo", resources.CreateQuotaResources(quantity.SizeGiB), "test-snap")
+	s.createQuota(c, "foo", quota.CreateQuotaResources(quantity.SizeGiB), "test-snap")
 
 	ts, err := servicestate.RemoveQuota(st, "foo")
 	c.Assert(err, IsNil)
@@ -812,7 +812,7 @@ func (s *quotaControlSuite) TestUpdateQuotaUpdateQuotaConflict(c *C) {
 
 	// create a quota group
 	defer s.se.Stop()
-	s.createQuota(c, "foo", resources.CreateQuotaResources(quantity.SizeGiB), "test-snap")
+	s.createQuota(c, "foo", quota.CreateQuotaResources(quantity.SizeGiB), "test-snap")
 
 	ts, err := servicestate.UpdateQuota(st, "foo", servicestate.QuotaGroupUpdate{AddSnaps: []string{"test-snap2"}})
 	c.Assert(err, IsNil)
@@ -821,7 +821,7 @@ func (s *quotaControlSuite) TestUpdateQuotaUpdateQuotaConflict(c *C) {
 
 	_, err = servicestate.UpdateQuota(st, "foo",
 		servicestate.QuotaGroupUpdate{
-			NewResourceLimits: resources.CreateQuotaResources(2 * quantity.SizeGiB),
+			NewResourceLimits: quota.CreateQuotaResources(2 * quantity.SizeGiB),
 		})
 	c.Assert(err, ErrorMatches, `quota group "foo" has "quota-control" change in progress`)
 }
@@ -853,7 +853,7 @@ func (s *quotaControlSuite) TestUpdateQuotaRemoveQuotaConflict(c *C) {
 
 	// create a quota group
 	defer s.se.Stop()
-	s.createQuota(c, "foo", resources.CreateQuotaResources(quantity.SizeGiB), "test-snap")
+	s.createQuota(c, "foo", quota.CreateQuotaResources(quantity.SizeGiB), "test-snap")
 
 	ts, err := servicestate.UpdateQuota(st, "foo", servicestate.QuotaGroupUpdate{AddSnaps: []string{"test-snap2"}})
 	c.Assert(err, IsNil)
@@ -891,7 +891,7 @@ func (s *quotaControlSuite) TestRemoveQuotaUpdateQuotaConflict(c *C) {
 
 	// create a quota group
 	defer s.se.Stop()
-	s.createQuota(c, "foo", resources.CreateQuotaResources(quantity.SizeGiB), "test-snap")
+	s.createQuota(c, "foo", quota.CreateQuotaResources(quantity.SizeGiB), "test-snap")
 
 	ts, err := servicestate.RemoveQuota(st, "foo")
 	c.Assert(err, IsNil)
@@ -921,11 +921,11 @@ func (s *quotaControlSuite) TestCreateQuotaCreateQuotaConflict(c *C) {
 	snapstate.Set(s.state, "test-snap2", snapst2)
 	snaptest.MockSnapCurrent(c, testYaml2, si2)
 
-	ts, err := servicestate.CreateQuota(st, "foo", "", []string{"test-snap"}, resources.CreateQuotaResources(quantity.SizeGiB))
+	ts, err := servicestate.CreateQuota(st, "foo", "", []string{"test-snap"}, quota.CreateQuotaResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 	chg1 := s.state.NewChange("quota-control", "...")
 	chg1.AddAll(ts)
 
-	_, err = servicestate.CreateQuota(st, "foo", "", []string{"test-snap2"}, resources.CreateQuotaResources(2*quantity.SizeGiB))
+	_, err = servicestate.CreateQuota(st, "foo", "", []string{"test-snap2"}, quota.CreateQuotaResources(2*quantity.SizeGiB))
 	c.Assert(err, ErrorMatches, `quota group "foo" has "quota-control" change in progress`)
 }

--- a/overlord/servicestate/quota_control_test.go
+++ b/overlord/servicestate/quota_control_test.go
@@ -210,7 +210,7 @@ func (s *quotaControlSuite) TestCreateQuotaNotEnabled(c *C) {
 	tr.Commit()
 
 	// try to create an empty quota group
-	_, err := servicestate.CreateQuota(s.state, "foo", "", nil, quota.CreateResources(quantity.SizeGiB))
+	_, err := servicestate.CreateQuota(s.state, "foo", "", nil, quota.NewResources(quantity.SizeGiB))
 	c.Assert(err, ErrorMatches, `experimental feature disabled - test it by setting 'experimental.quota-groups' to true`)
 }
 
@@ -223,7 +223,7 @@ func (s *quotaControlSuite) TestCreateQuotaSystemdTooOld(c *C) {
 
 	servicestate.CheckSystemdVersion()
 
-	_, err := servicestate.CreateQuota(s.state, "foo", "", nil, quota.CreateResources(quantity.SizeGiB))
+	_, err := servicestate.CreateQuota(s.state, "foo", "", nil, quota.NewResources(quantity.SizeGiB))
 	c.Assert(err, ErrorMatches, `cannot use quotas with incompatible systemd: systemd version 229 is too old \(expected at least 230\)`)
 }
 
@@ -232,7 +232,7 @@ func (s *quotaControlSuite) TestCreateQuotaPrecond(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, quota.CreateResources(2*quantity.SizeGiB))
+	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, quota.NewResources(2*quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
 	tests := []struct {
@@ -248,7 +248,7 @@ func (s *quotaControlSuite) TestCreateQuotaPrecond(c *C) {
 	}
 
 	for _, t := range tests {
-		_, err := servicestate.CreateQuota(st, t.name, "", t.snaps, quota.CreateResources(t.mem))
+		_, err := servicestate.CreateQuota(st, t.name, "", t.snaps, quota.NewResources(t.mem))
 		c.Check(err, ErrorMatches, t.err)
 	}
 }
@@ -265,7 +265,7 @@ func (s *quotaControlSuite) TestRemoveQuotaPreseeding(c *C) {
 	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
 
 	// create a quota group
-	ts, err := servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap"}, quota.CreateResources(quantity.SizeGiB))
+	ts, err := servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap"}, quota.NewResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
 	chg := st.NewChange("quota-control", "...")
@@ -275,7 +275,7 @@ func (s *quotaControlSuite) TestRemoveQuotaPreseeding(c *C) {
 		Action:         "create",
 		QuotaName:      "foo",
 		AddSnaps:       []string{"test-snap"},
-		ResourceLimits: quota.CreateResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResources(quantity.SizeGiB),
 	}
 
 	checkQuotaControlTasks(c, chg.Tasks(), exp)
@@ -290,7 +290,7 @@ func (s *quotaControlSuite) TestRemoveQuotaPreseeding(c *C) {
 	// check that the quota groups were created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -326,7 +326,7 @@ func (s *quotaControlSuite) TestCreateUpdateRemoveQuotaHappy(c *C) {
 	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
 
 	// create the quota group
-	ts, err := servicestate.CreateQuota(st, "foo", "", []string{"test-snap"}, quota.CreateResources(quantity.SizeGiB))
+	ts, err := servicestate.CreateQuota(st, "foo", "", []string{"test-snap"}, quota.NewResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
 	chg := st.NewChange("quota-control", "...")
@@ -336,7 +336,7 @@ func (s *quotaControlSuite) TestCreateUpdateRemoveQuotaHappy(c *C) {
 		Action:         "create",
 		QuotaName:      "foo",
 		AddSnaps:       []string{"test-snap"},
-		ResourceLimits: quota.CreateResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResources(quantity.SizeGiB),
 	}
 
 	checkQuotaControlTasks(c, chg.Tasks(), exp)
@@ -351,7 +351,7 @@ func (s *quotaControlSuite) TestCreateUpdateRemoveQuotaHappy(c *C) {
 	// check that the quota groups were created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -359,7 +359,7 @@ func (s *quotaControlSuite) TestCreateUpdateRemoveQuotaHappy(c *C) {
 	// increase the memory limit
 	ts, err = servicestate.UpdateQuota(st, "foo",
 		servicestate.QuotaGroupUpdate{
-			NewResourceLimits: quota.CreateResources(2 * quantity.SizeGiB),
+			NewResourceLimits: quota.NewResources(2 * quantity.SizeGiB),
 		})
 	c.Assert(err, IsNil)
 
@@ -369,7 +369,7 @@ func (s *quotaControlSuite) TestCreateUpdateRemoveQuotaHappy(c *C) {
 	exp2 := &servicestate.QuotaControlAction{
 		Action:         "update",
 		QuotaName:      "foo",
-		ResourceLimits: quota.CreateResources(2 * quantity.SizeGiB),
+		ResourceLimits: quota.NewResources(2 * quantity.SizeGiB),
 	}
 
 	checkQuotaControlTasks(c, chg.Tasks(), exp2)
@@ -383,7 +383,7 @@ func (s *quotaControlSuite) TestCreateUpdateRemoveQuotaHappy(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.CreateResources(2 * quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(2 * quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -450,7 +450,7 @@ func (s *quotaControlSuite) TestEnsureSnapAbsentFromQuotaGroup(c *C) {
 	snaptest.MockSnapCurrent(c, testYaml2, si2)
 
 	// create a quota group
-	ts, err := servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap", "test-snap2"}, quota.CreateResources(quantity.SizeGiB))
+	ts, err := servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap", "test-snap2"}, quota.NewResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
 	chg := st.NewChange("quota-control", "...")
@@ -460,7 +460,7 @@ func (s *quotaControlSuite) TestEnsureSnapAbsentFromQuotaGroup(c *C) {
 		Action:         "create",
 		QuotaName:      "foo",
 		AddSnaps:       []string{"test-snap", "test-snap2"},
-		ResourceLimits: quota.CreateResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResources(quantity.SizeGiB),
 	}
 
 	checkQuotaControlTasks(c, chg.Tasks(), exp)
@@ -474,7 +474,7 @@ func (s *quotaControlSuite) TestEnsureSnapAbsentFromQuotaGroup(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap", "test-snap2"},
 		},
 	})
@@ -485,7 +485,7 @@ func (s *quotaControlSuite) TestEnsureSnapAbsentFromQuotaGroup(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap2"},
 		},
 	})
@@ -501,7 +501,7 @@ func (s *quotaControlSuite) TestEnsureSnapAbsentFromQuotaGroup(c *C) {
 	// and check that it got updated in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB),
 		},
 	})
 
@@ -528,7 +528,7 @@ func (s *quotaControlSuite) TestUpdateQuotaPrecond(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, quota.CreateResources(2*quantity.SizeGiB))
+	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, quota.NewResources(2*quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
 	tests := []struct {
@@ -537,7 +537,7 @@ func (s *quotaControlSuite) TestUpdateQuotaPrecond(c *C) {
 		err  string
 	}{
 		{"what", servicestate.QuotaGroupUpdate{}, `group "what" does not exist`},
-		{"foo", servicestate.QuotaGroupUpdate{NewResourceLimits: quota.CreateResources(quantity.SizeGiB)}, `cannot update group "foo": cannot decrease memory limit, remove and re-create it to decrease the limit`},
+		{"foo", servicestate.QuotaGroupUpdate{NewResourceLimits: quota.NewResources(quantity.SizeGiB)}, `cannot update group "foo": cannot decrease memory limit, remove and re-create it to decrease the limit`},
 		{"foo", servicestate.QuotaGroupUpdate{AddSnaps: []string{"baz"}}, `cannot use snap "baz" in group "foo": snap "baz" is not installed`},
 	}
 
@@ -552,9 +552,9 @@ func (s *quotaControlSuite) TestRemoveQuotaPrecond(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, quota.CreateResources(2*quantity.SizeGiB))
+	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, quota.NewResources(2*quantity.SizeGiB))
 	c.Assert(err, IsNil)
-	err = servicestatetest.MockQuotaInState(st, "bar", "foo", nil, quota.CreateResources(quantity.SizeGiB))
+	err = servicestatetest.MockQuotaInState(st, "bar", "foo", nil, quota.NewResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
 	_, err = servicestate.RemoveQuota(st, "what")
@@ -605,7 +605,7 @@ func (s *quotaControlSuite) TestSnapOpUpdateQuotaConflict(c *C) {
 
 	// create a quota group
 	defer s.se.Stop()
-	s.createQuota(c, "foo", quota.CreateResources(quantity.SizeGiB), "test-snap")
+	s.createQuota(c, "foo", quota.NewResources(quantity.SizeGiB), "test-snap")
 
 	ts, err := snapstate.Disable(st, "test-snap2")
 	c.Assert(err, IsNil)
@@ -630,7 +630,7 @@ func (s *quotaControlSuite) TestSnapOpCreateQuotaConflict(c *C) {
 	chg1 := s.state.NewChange("disable", "...")
 	chg1.AddAll(ts)
 
-	_, err = servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap"}, quota.CreateResources(quantity.SizeGiB))
+	_, err = servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap"}, quota.NewResources(quantity.SizeGiB))
 	c.Assert(err, ErrorMatches, `snap "test-snap" has "disable" change in progress`)
 }
 
@@ -651,7 +651,7 @@ func (s *quotaControlSuite) TestSnapOpRemoveQuotaConflict(c *C) {
 
 	// create a quota group
 	defer s.se.Stop()
-	s.createQuota(c, "foo", quota.CreateResources(quantity.SizeGiB), "test-snap")
+	s.createQuota(c, "foo", quota.NewResources(quantity.SizeGiB), "test-snap")
 
 	ts, err := snapstate.Disable(st, "test-snap")
 	c.Assert(err, IsNil)
@@ -671,7 +671,7 @@ func (s *quotaControlSuite) TestCreateQuotaSnapOpConflict(c *C) {
 	snapstate.Set(s.state, "test-snap", s.testSnapState)
 	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
 
-	ts, err := servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap"}, quota.CreateResources(quantity.SizeGiB))
+	ts, err := servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap"}, quota.NewResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 	chg1 := s.state.NewChange("quota-control", "...")
 	chg1.AddAll(ts)
@@ -707,7 +707,7 @@ func (s *quotaControlSuite) TestUpdateQuotaSnapOpConflict(c *C) {
 
 	// create a quota group
 	defer s.se.Stop()
-	s.createQuota(c, "foo", quota.CreateResources(quantity.SizeGiB), "test-snap")
+	s.createQuota(c, "foo", quota.NewResources(quantity.SizeGiB), "test-snap")
 
 	ts, err := servicestate.UpdateQuota(st, "foo", servicestate.QuotaGroupUpdate{AddSnaps: []string{"test-snap2"}})
 	c.Assert(err, IsNil)
@@ -735,7 +735,7 @@ func (s *quotaControlSuite) TestRemoveQuotaSnapOpConflict(c *C) {
 
 	// create a quota group
 	defer s.se.Stop()
-	s.createQuota(c, "foo", quota.CreateResources(quantity.SizeGiB), "test-snap")
+	s.createQuota(c, "foo", quota.NewResources(quantity.SizeGiB), "test-snap")
 
 	ts, err := servicestate.RemoveQuota(st, "foo")
 	c.Assert(err, IsNil)
@@ -763,7 +763,7 @@ func (s *quotaControlSuite) TestRemoveQuotaLateSnapOpConflict(c *C) {
 
 	// create a quota group
 	defer s.se.Stop()
-	s.createQuota(c, "foo", quota.CreateResources(quantity.SizeGiB), "test-snap")
+	s.createQuota(c, "foo", quota.NewResources(quantity.SizeGiB), "test-snap")
 
 	ts, err := servicestate.RemoveQuota(st, "foo")
 	c.Assert(err, IsNil)
@@ -812,7 +812,7 @@ func (s *quotaControlSuite) TestUpdateQuotaUpdateQuotaConflict(c *C) {
 
 	// create a quota group
 	defer s.se.Stop()
-	s.createQuota(c, "foo", quota.CreateResources(quantity.SizeGiB), "test-snap")
+	s.createQuota(c, "foo", quota.NewResources(quantity.SizeGiB), "test-snap")
 
 	ts, err := servicestate.UpdateQuota(st, "foo", servicestate.QuotaGroupUpdate{AddSnaps: []string{"test-snap2"}})
 	c.Assert(err, IsNil)
@@ -821,7 +821,7 @@ func (s *quotaControlSuite) TestUpdateQuotaUpdateQuotaConflict(c *C) {
 
 	_, err = servicestate.UpdateQuota(st, "foo",
 		servicestate.QuotaGroupUpdate{
-			NewResourceLimits: quota.CreateResources(2 * quantity.SizeGiB),
+			NewResourceLimits: quota.NewResources(2 * quantity.SizeGiB),
 		})
 	c.Assert(err, ErrorMatches, `quota group "foo" has "quota-control" change in progress`)
 }
@@ -853,7 +853,7 @@ func (s *quotaControlSuite) TestUpdateQuotaRemoveQuotaConflict(c *C) {
 
 	// create a quota group
 	defer s.se.Stop()
-	s.createQuota(c, "foo", quota.CreateResources(quantity.SizeGiB), "test-snap")
+	s.createQuota(c, "foo", quota.NewResources(quantity.SizeGiB), "test-snap")
 
 	ts, err := servicestate.UpdateQuota(st, "foo", servicestate.QuotaGroupUpdate{AddSnaps: []string{"test-snap2"}})
 	c.Assert(err, IsNil)
@@ -891,7 +891,7 @@ func (s *quotaControlSuite) TestRemoveQuotaUpdateQuotaConflict(c *C) {
 
 	// create a quota group
 	defer s.se.Stop()
-	s.createQuota(c, "foo", quota.CreateResources(quantity.SizeGiB), "test-snap")
+	s.createQuota(c, "foo", quota.NewResources(quantity.SizeGiB), "test-snap")
 
 	ts, err := servicestate.RemoveQuota(st, "foo")
 	c.Assert(err, IsNil)
@@ -921,11 +921,11 @@ func (s *quotaControlSuite) TestCreateQuotaCreateQuotaConflict(c *C) {
 	snapstate.Set(s.state, "test-snap2", snapst2)
 	snaptest.MockSnapCurrent(c, testYaml2, si2)
 
-	ts, err := servicestate.CreateQuota(st, "foo", "", []string{"test-snap"}, quota.CreateResources(quantity.SizeGiB))
+	ts, err := servicestate.CreateQuota(st, "foo", "", []string{"test-snap"}, quota.NewResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 	chg1 := s.state.NewChange("quota-control", "...")
 	chg1.AddAll(ts)
 
-	_, err = servicestate.CreateQuota(st, "foo", "", []string{"test-snap2"}, quota.CreateResources(2*quantity.SizeGiB))
+	_, err = servicestate.CreateQuota(st, "foo", "", []string{"test-snap2"}, quota.NewResources(2*quantity.SizeGiB))
 	c.Assert(err, ErrorMatches, `quota group "foo" has "quota-control" change in progress`)
 }

--- a/overlord/servicestate/quota_handlers.go
+++ b/overlord/servicestate/quota_handlers.go
@@ -59,7 +59,7 @@ type QuotaControlAction struct {
 	// Either the initial limit the group is created with for the "create"
 	// action, or if non-zero for the "update" the memory limit, then the new
 	// value to be set.
-	ResourceLimits quota.QuotaResources `json:"resource-limits,omitempty"`
+	ResourceLimits quota.Resources `json:"resource-limits,omitempty"`
 
 	// ParentName is the name of the parent for the quota group if it is being
 	// created. Eventually this could be used with the "update" action to
@@ -333,7 +333,7 @@ func quotaRemove(st *state.State, action QuotaControlAction, allGrps map[string]
 	return grp, allGrps, nil
 }
 
-func quotaUpdateGroupLimits(grp *quota.Group, limits quota.QuotaResources) error {
+func quotaUpdateGroupLimits(grp *quota.Group, limits quota.Resources) error {
 	currentQuotas := grp.GetQuotaResources()
 	if err := currentQuotas.Change(limits); err != nil {
 		return fmt.Errorf("cannot update limits for group %q: %v", grp.Name, err)

--- a/overlord/servicestate/quota_handlers.go
+++ b/overlord/servicestate/quota_handlers.go
@@ -29,7 +29,6 @@ import (
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/servicestate/internal"
-	"github.com/snapcore/snapd/overlord/servicestate/resources"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/progress"
@@ -46,27 +45,27 @@ import (
 // modification that lives in a task.
 type QuotaControlAction struct {
 	// QuotaName is the name of the quota group being controlled.
-	QuotaName string `json:"quota-name"`
+	QuotaName string `json:"quota-name,omitempty"`
 
 	// Action is the action being taken on the quota group. It can be either
 	// "create", "update", or "remove".
-	Action string `json:"action"`
+	Action string `json:"action,omitempty"`
 
 	// AddSnaps is the set of snaps to add to the quota group, valid for either
 	// the "update" or the "create" actions.
-	AddSnaps []string `json:"snaps"`
+	AddSnaps []string `json:"snaps,omitempty"`
 
 	// ResourceLimits is the set of resource limits to set on the quota group.
 	// Either the initial limit the group is created with for the "create"
 	// action, or if non-zero for the "update" the memory limit, then the new
 	// value to be set.
-	ResourceLimits resources.QuotaResources `json:"resource-limits"`
+	ResourceLimits quota.QuotaResources `json:"resource-limits,omitempty"`
 
 	// ParentName is the name of the parent for the quota group if it is being
 	// created. Eventually this could be used with the "update" action to
 	// support moving quota groups from one parent to another, but that is
 	// currently not supported.
-	ParentName string
+	ParentName string `json:"parent-name,omitempty"`
 }
 
 func (m *ServiceManager) doQuotaControl(t *state.Task, _ *tomb.Tomb) error {
@@ -334,7 +333,7 @@ func quotaRemove(st *state.State, action QuotaControlAction, allGrps map[string]
 	return grp, allGrps, nil
 }
 
-func quotaUpdateGroupLimits(grp *quota.Group, limits resources.QuotaResources) error {
+func quotaUpdateGroupLimits(grp *quota.Group, limits quota.QuotaResources) error {
 	currentQuotas := grp.GetQuotaResources()
 	if err := currentQuotas.Change(limits); err != nil {
 		return fmt.Errorf("cannot update limits for group %q: %v", grp.Name, err)

--- a/overlord/servicestate/quota_handlers_test.go
+++ b/overlord/servicestate/quota_handlers_test.go
@@ -80,7 +80,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlCreate(c *C) {
 		{
 			Action:         "create",
 			QuotaName:      "foo-group",
-			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB),
 			AddSnaps:       []string{"test-snap"},
 		},
 	}
@@ -96,7 +96,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlCreate(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo-group": {
-			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -127,7 +127,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlCreateRestartOK(c *C) {
 		{
 			Action:         "create",
 			QuotaName:      "foo-group",
-			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB),
 			AddSnaps:       []string{"test-snap"},
 		},
 	}
@@ -136,7 +136,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlCreateRestartOK(c *C) {
 
 	expectedQuotaState := map[string]quotaGroupState{
 		"foo-group": {
-			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 		},
 	}
@@ -185,7 +185,7 @@ func (s *quotaHandlersSuite) TestQuotaStateAlreadyUpdatedBehavior(c *C) {
 		{
 			Action:         "create",
 			QuotaName:      "foo-group",
-			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB),
 			AddSnaps:       []string{"test-snap"},
 		},
 	}
@@ -258,7 +258,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlUpdate(c *C) {
 		{
 			Action:         "create",
 			QuotaName:      "foo-group",
-			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB),
 			AddSnaps:       []string{"test-snap"},
 		},
 	}
@@ -278,7 +278,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlUpdate(c *C) {
 		{
 			Action:         "update",
 			QuotaName:      "foo-group",
-			ResourceLimits: quota.CreateResources(2 * quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(2 * quantity.SizeGiB),
 		},
 	}
 
@@ -293,7 +293,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlUpdate(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo-group": {
-			ResourceLimits: quota.CreateResources(2 * quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(2 * quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -325,7 +325,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlUpdateRestartOK(c *C) {
 		{
 			Action:         "create",
 			QuotaName:      "foo-group",
-			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB),
 			AddSnaps:       []string{"test-snap"},
 		},
 	}
@@ -345,7 +345,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlUpdateRestartOK(c *C) {
 		{
 			Action:         "update",
 			QuotaName:      "foo-group",
-			ResourceLimits: quota.CreateResources(2 * quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(2 * quantity.SizeGiB),
 		},
 	}
 
@@ -353,7 +353,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlUpdateRestartOK(c *C) {
 
 	expectedQuotaState := map[string]quotaGroupState{
 		"foo-group": {
-			ResourceLimits: quota.CreateResources(2 * quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(2 * quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 		},
 	}
@@ -407,7 +407,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlRemove(c *C) {
 		{
 			Action:         "create",
 			QuotaName:      "foo-group",
-			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB),
 			AddSnaps:       []string{"test-snap"},
 		},
 	}
@@ -473,7 +473,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlRemoveRestartOK(c *C) {
 		{
 			Action:         "create",
 			QuotaName:      "foo-group",
-			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB),
 			AddSnaps:       []string{"test-snap"},
 		},
 	}
@@ -549,7 +549,7 @@ func (s *quotaHandlersSuite) TestQuotaCreatePreseeding(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.CreateResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResources(quantity.SizeGiB),
 		AddSnaps:       []string{"test-snap"},
 	}
 
@@ -559,7 +559,7 @@ func (s *quotaHandlersSuite) TestQuotaCreatePreseeding(c *C) {
 	// check that the quota groups were created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -586,7 +586,7 @@ func (s *quotaHandlersSuite) TestQuotaCreate(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.CreateResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResources(quantity.SizeGiB),
 		AddSnaps:       []string{"test-snap"},
 	}
 
@@ -600,7 +600,7 @@ func (s *quotaHandlersSuite) TestQuotaCreate(c *C) {
 	qc2 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.CreateResources(4 * quantity.SizeKiB),
+		ResourceLimits: quota.NewResources(4 * quantity.SizeKiB),
 		AddSnaps:       []string{"test-snap"},
 	}
 
@@ -613,7 +613,7 @@ func (s *quotaHandlersSuite) TestQuotaCreate(c *C) {
 	qc3 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.CreateResources(4*quantity.SizeKiB + 1),
+		ResourceLimits: quota.NewResources(4*quantity.SizeKiB + 1),
 		AddSnaps:       []string{"test-snap"},
 	}
 	err = s.callDoQuotaControl(&qc3)
@@ -622,7 +622,7 @@ func (s *quotaHandlersSuite) TestQuotaCreate(c *C) {
 	// check that the quota groups were created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.CreateResources(4*quantity.SizeKiB + 1),
+			ResourceLimits: quota.NewResources(4*quantity.SizeKiB + 1),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -655,7 +655,7 @@ func (s *quotaHandlersSuite) TestDoCreateSubGroupQuota(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo-group",
-		ResourceLimits: quota.CreateResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResources(quantity.SizeGiB),
 	}
 
 	err := s.callDoQuotaControl(&qc)
@@ -665,7 +665,7 @@ func (s *quotaHandlersSuite) TestDoCreateSubGroupQuota(c *C) {
 	qc2 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo2",
-		ResourceLimits: quota.CreateResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResources(quantity.SizeGiB),
 		ParentName:     "foo-non-real",
 		AddSnaps:       []string{"test-snap"},
 	}
@@ -678,7 +678,7 @@ func (s *quotaHandlersSuite) TestDoCreateSubGroupQuota(c *C) {
 	qc3 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo2",
-		ResourceLimits: quota.CreateResources(2 * quantity.SizeGiB),
+		ResourceLimits: quota.NewResources(2 * quantity.SizeGiB),
 		ParentName:     "foo-group",
 		AddSnaps:       []string{"test-snap"},
 	}
@@ -690,7 +690,7 @@ func (s *quotaHandlersSuite) TestDoCreateSubGroupQuota(c *C) {
 	qc4 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo2",
-		ResourceLimits: quota.CreateResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResources(quantity.SizeGiB),
 		ParentName:     "foo-group",
 		AddSnaps:       []string{"test-snap"},
 	}
@@ -701,11 +701,11 @@ func (s *quotaHandlersSuite) TestDoCreateSubGroupQuota(c *C) {
 	// check that the quota groups were created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo-group": {
-			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB),
 			SubGroups:      []string{"foo2"},
 		},
 		"foo2": {
-			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 			ParentGroup:    "foo-group",
 		},
@@ -761,7 +761,7 @@ func (s *quotaHandlersSuite) TestQuotaRemove(c *C) {
 	qc2 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.CreateResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResources(quantity.SizeGiB),
 		AddSnaps:       []string{"test-snap"},
 	}
 
@@ -772,7 +772,7 @@ func (s *quotaHandlersSuite) TestQuotaRemove(c *C) {
 	qc3 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo2",
-		ResourceLimits: quota.CreateResources(quantity.SizeGiB / 2),
+		ResourceLimits: quota.NewResources(quantity.SizeGiB / 2),
 		ParentName:     "foo",
 	}
 
@@ -782,7 +782,7 @@ func (s *quotaHandlersSuite) TestQuotaRemove(c *C) {
 	qc4 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo3",
-		ResourceLimits: quota.CreateResources(quantity.SizeGiB / 2),
+		ResourceLimits: quota.NewResources(quantity.SizeGiB / 2),
 		ParentName:     "foo",
 	}
 
@@ -792,16 +792,16 @@ func (s *quotaHandlersSuite) TestQuotaRemove(c *C) {
 	// check that the quota groups was created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 			SubGroups:      []string{"foo2", "foo3"},
 		},
 		"foo2": {
-			ResourceLimits: quota.CreateResources(quantity.SizeGiB / 2),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB / 2),
 			ParentGroup:    "foo",
 		},
 		"foo3": {
-			ResourceLimits: quota.CreateResources(quantity.SizeGiB / 2),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB / 2),
 			ParentGroup:    "foo",
 		},
 	})
@@ -827,12 +827,12 @@ func (s *quotaHandlersSuite) TestQuotaRemove(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 			SubGroups:      []string{"foo2"},
 		},
 		"foo2": {
-			ResourceLimits: quota.CreateResources(quantity.SizeGiB / 2),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB / 2),
 			ParentGroup:    "foo",
 		},
 	})
@@ -848,7 +848,7 @@ func (s *quotaHandlersSuite) TestQuotaRemove(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -920,7 +920,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateSubGroupTooBig(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.CreateResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResources(quantity.SizeGiB),
 		AddSnaps:       []string{"test-snap"},
 	}
 
@@ -929,7 +929,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateSubGroupTooBig(c *C) {
 
 	// ensure mem-limit is 1 GB
 	expFooGroupState := quotaGroupState{
-		ResourceLimits: quota.CreateResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResources(quantity.SizeGiB),
 		Snaps:          []string{"test-snap"},
 	}
 	checkQuotaState(c, st, map[string]quotaGroupState{
@@ -940,7 +940,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateSubGroupTooBig(c *C) {
 	qc2 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo2",
-		ResourceLimits: quota.CreateResources(quantity.SizeGiB / 2),
+		ResourceLimits: quota.NewResources(quantity.SizeGiB / 2),
 		AddSnaps:       []string{"test-snap2"},
 		ParentName:     "foo",
 	}
@@ -951,7 +951,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateSubGroupTooBig(c *C) {
 	expFooGroupState.SubGroups = []string{"foo2"}
 
 	expFoo2GroupState := quotaGroupState{
-		ResourceLimits: quota.CreateResources(quantity.SizeGiB / 2),
+		ResourceLimits: quota.NewResources(quantity.SizeGiB / 2),
 		Snaps:          []string{"test-snap2"},
 		ParentGroup:    "foo",
 	}
@@ -966,13 +966,13 @@ func (s *quotaHandlersSuite) TestQuotaUpdateSubGroupTooBig(c *C) {
 	qc3 := servicestate.QuotaControlAction{
 		Action:         "update",
 		QuotaName:      "foo2",
-		ResourceLimits: quota.CreateResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResources(quantity.SizeGiB),
 	}
 
 	err = s.callDoQuotaControl(&qc3)
 	c.Assert(err, IsNil)
 
-	expFoo2GroupState.ResourceLimits = quota.CreateResources(quantity.SizeGiB)
+	expFoo2GroupState.ResourceLimits = quota.NewResources(quantity.SizeGiB)
 	// and check that it got updated in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo":  expFooGroupState,
@@ -983,7 +983,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateSubGroupTooBig(c *C) {
 	qc4 := servicestate.QuotaControlAction{
 		Action:         "update",
 		QuotaName:      "foo2",
-		ResourceLimits: quota.CreateResources(2 * quantity.SizeGiB),
+		ResourceLimits: quota.NewResources(2 * quantity.SizeGiB),
 	}
 
 	err = s.callDoQuotaControl(&qc4)
@@ -1019,7 +1019,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateChangeMemLimit(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.CreateResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResources(quantity.SizeGiB),
 		AddSnaps:       []string{"test-snap"},
 	}
 
@@ -1029,7 +1029,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateChangeMemLimit(c *C) {
 	// ensure mem-limit is 1 GB
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -1038,7 +1038,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateChangeMemLimit(c *C) {
 	qc2 := servicestate.QuotaControlAction{
 		Action:         "update",
 		QuotaName:      "foo",
-		ResourceLimits: quota.CreateResources(2 * quantity.SizeGiB),
+		ResourceLimits: quota.NewResources(2 * quantity.SizeGiB),
 	}
 	err = s.callDoQuotaControl(&qc2)
 	c.Assert(err, IsNil)
@@ -1046,7 +1046,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateChangeMemLimit(c *C) {
 	// and check that it got updated in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.CreateResources(2 * quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(2 * quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -1055,7 +1055,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateChangeMemLimit(c *C) {
 	qc3 := servicestate.QuotaControlAction{
 		Action:         "update",
 		QuotaName:      "foo",
-		ResourceLimits: quota.CreateResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResources(quantity.SizeGiB),
 	}
 	err = s.callDoQuotaControl(&qc3)
 	c.Assert(err, ErrorMatches, "cannot update limits for group \"foo\": cannot decrease memory limit, remove and re-create it to decrease the limit")
@@ -1095,7 +1095,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnap(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.CreateResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResources(quantity.SizeGiB),
 		AddSnaps:       []string{"test-snap"},
 	}
 
@@ -1104,7 +1104,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnap(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -1121,7 +1121,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnap(c *C) {
 	// and check that it got updated in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap", "test-snap2"},
 		},
 	})
@@ -1161,7 +1161,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnapAlreadyInOtherGroup(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.CreateResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResources(quantity.SizeGiB),
 		AddSnaps:       []string{"test-snap"},
 	}
 
@@ -1170,7 +1170,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnapAlreadyInOtherGroup(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -1179,7 +1179,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnapAlreadyInOtherGroup(c *C) {
 	qc2 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo2",
-		ResourceLimits: quota.CreateResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResources(quantity.SizeGiB),
 		AddSnaps:       []string{"test-snap2"},
 	}
 
@@ -1189,11 +1189,11 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnapAlreadyInOtherGroup(c *C) {
 	// verify state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 		},
 		"foo2": {
-			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap2"},
 		},
 	})
@@ -1211,11 +1211,11 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnapAlreadyInOtherGroup(c *C) {
 	// nothing changed in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 		},
 		"foo2": {
-			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap2"},
 		},
 	})

--- a/overlord/servicestate/quota_handlers_test.go
+++ b/overlord/servicestate/quota_handlers_test.go
@@ -80,7 +80,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlCreate(c *C) {
 		{
 			Action:         "create",
 			QuotaName:      "foo-group",
-			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
 			AddSnaps:       []string{"test-snap"},
 		},
 	}
@@ -96,7 +96,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlCreate(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo-group": {
-			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -127,7 +127,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlCreateRestartOK(c *C) {
 		{
 			Action:         "create",
 			QuotaName:      "foo-group",
-			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
 			AddSnaps:       []string{"test-snap"},
 		},
 	}
@@ -136,7 +136,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlCreateRestartOK(c *C) {
 
 	expectedQuotaState := map[string]quotaGroupState{
 		"foo-group": {
-			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 		},
 	}
@@ -185,7 +185,7 @@ func (s *quotaHandlersSuite) TestQuotaStateAlreadyUpdatedBehavior(c *C) {
 		{
 			Action:         "create",
 			QuotaName:      "foo-group",
-			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
 			AddSnaps:       []string{"test-snap"},
 		},
 	}
@@ -258,7 +258,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlUpdate(c *C) {
 		{
 			Action:         "create",
 			QuotaName:      "foo-group",
-			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
 			AddSnaps:       []string{"test-snap"},
 		},
 	}
@@ -278,7 +278,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlUpdate(c *C) {
 		{
 			Action:         "update",
 			QuotaName:      "foo-group",
-			ResourceLimits: quota.CreateQuotaResources(2 * quantity.SizeGiB),
+			ResourceLimits: quota.CreateResources(2 * quantity.SizeGiB),
 		},
 	}
 
@@ -293,7 +293,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlUpdate(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo-group": {
-			ResourceLimits: quota.CreateQuotaResources(2 * quantity.SizeGiB),
+			ResourceLimits: quota.CreateResources(2 * quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -325,7 +325,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlUpdateRestartOK(c *C) {
 		{
 			Action:         "create",
 			QuotaName:      "foo-group",
-			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
 			AddSnaps:       []string{"test-snap"},
 		},
 	}
@@ -345,7 +345,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlUpdateRestartOK(c *C) {
 		{
 			Action:         "update",
 			QuotaName:      "foo-group",
-			ResourceLimits: quota.CreateQuotaResources(2 * quantity.SizeGiB),
+			ResourceLimits: quota.CreateResources(2 * quantity.SizeGiB),
 		},
 	}
 
@@ -353,7 +353,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlUpdateRestartOK(c *C) {
 
 	expectedQuotaState := map[string]quotaGroupState{
 		"foo-group": {
-			ResourceLimits: quota.CreateQuotaResources(2 * quantity.SizeGiB),
+			ResourceLimits: quota.CreateResources(2 * quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 		},
 	}
@@ -407,7 +407,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlRemove(c *C) {
 		{
 			Action:         "create",
 			QuotaName:      "foo-group",
-			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
 			AddSnaps:       []string{"test-snap"},
 		},
 	}
@@ -473,7 +473,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlRemoveRestartOK(c *C) {
 		{
 			Action:         "create",
 			QuotaName:      "foo-group",
-			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
 			AddSnaps:       []string{"test-snap"},
 		},
 	}
@@ -549,7 +549,7 @@ func (s *quotaHandlersSuite) TestQuotaCreatePreseeding(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
+		ResourceLimits: quota.CreateResources(quantity.SizeGiB),
 		AddSnaps:       []string{"test-snap"},
 	}
 
@@ -559,7 +559,7 @@ func (s *quotaHandlersSuite) TestQuotaCreatePreseeding(c *C) {
 	// check that the quota groups were created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -586,7 +586,7 @@ func (s *quotaHandlersSuite) TestQuotaCreate(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
+		ResourceLimits: quota.CreateResources(quantity.SizeGiB),
 		AddSnaps:       []string{"test-snap"},
 	}
 
@@ -600,7 +600,7 @@ func (s *quotaHandlersSuite) TestQuotaCreate(c *C) {
 	qc2 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.CreateQuotaResources(4 * quantity.SizeKiB),
+		ResourceLimits: quota.CreateResources(4 * quantity.SizeKiB),
 		AddSnaps:       []string{"test-snap"},
 	}
 
@@ -613,7 +613,7 @@ func (s *quotaHandlersSuite) TestQuotaCreate(c *C) {
 	qc3 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.CreateQuotaResources(4*quantity.SizeKiB + 1),
+		ResourceLimits: quota.CreateResources(4*quantity.SizeKiB + 1),
 		AddSnaps:       []string{"test-snap"},
 	}
 	err = s.callDoQuotaControl(&qc3)
@@ -622,7 +622,7 @@ func (s *quotaHandlersSuite) TestQuotaCreate(c *C) {
 	// check that the quota groups were created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.CreateQuotaResources(4*quantity.SizeKiB + 1),
+			ResourceLimits: quota.CreateResources(4*quantity.SizeKiB + 1),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -655,7 +655,7 @@ func (s *quotaHandlersSuite) TestDoCreateSubGroupQuota(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo-group",
-		ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
+		ResourceLimits: quota.CreateResources(quantity.SizeGiB),
 	}
 
 	err := s.callDoQuotaControl(&qc)
@@ -665,7 +665,7 @@ func (s *quotaHandlersSuite) TestDoCreateSubGroupQuota(c *C) {
 	qc2 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo2",
-		ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
+		ResourceLimits: quota.CreateResources(quantity.SizeGiB),
 		ParentName:     "foo-non-real",
 		AddSnaps:       []string{"test-snap"},
 	}
@@ -678,7 +678,7 @@ func (s *quotaHandlersSuite) TestDoCreateSubGroupQuota(c *C) {
 	qc3 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo2",
-		ResourceLimits: quota.CreateQuotaResources(2 * quantity.SizeGiB),
+		ResourceLimits: quota.CreateResources(2 * quantity.SizeGiB),
 		ParentName:     "foo-group",
 		AddSnaps:       []string{"test-snap"},
 	}
@@ -690,7 +690,7 @@ func (s *quotaHandlersSuite) TestDoCreateSubGroupQuota(c *C) {
 	qc4 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo2",
-		ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
+		ResourceLimits: quota.CreateResources(quantity.SizeGiB),
 		ParentName:     "foo-group",
 		AddSnaps:       []string{"test-snap"},
 	}
@@ -701,11 +701,11 @@ func (s *quotaHandlersSuite) TestDoCreateSubGroupQuota(c *C) {
 	// check that the quota groups were created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo-group": {
-			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
 			SubGroups:      []string{"foo2"},
 		},
 		"foo2": {
-			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 			ParentGroup:    "foo-group",
 		},
@@ -761,7 +761,7 @@ func (s *quotaHandlersSuite) TestQuotaRemove(c *C) {
 	qc2 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
+		ResourceLimits: quota.CreateResources(quantity.SizeGiB),
 		AddSnaps:       []string{"test-snap"},
 	}
 
@@ -772,7 +772,7 @@ func (s *quotaHandlersSuite) TestQuotaRemove(c *C) {
 	qc3 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo2",
-		ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB / 2),
+		ResourceLimits: quota.CreateResources(quantity.SizeGiB / 2),
 		ParentName:     "foo",
 	}
 
@@ -782,7 +782,7 @@ func (s *quotaHandlersSuite) TestQuotaRemove(c *C) {
 	qc4 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo3",
-		ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB / 2),
+		ResourceLimits: quota.CreateResources(quantity.SizeGiB / 2),
 		ParentName:     "foo",
 	}
 
@@ -792,16 +792,16 @@ func (s *quotaHandlersSuite) TestQuotaRemove(c *C) {
 	// check that the quota groups was created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 			SubGroups:      []string{"foo2", "foo3"},
 		},
 		"foo2": {
-			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB / 2),
+			ResourceLimits: quota.CreateResources(quantity.SizeGiB / 2),
 			ParentGroup:    "foo",
 		},
 		"foo3": {
-			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB / 2),
+			ResourceLimits: quota.CreateResources(quantity.SizeGiB / 2),
 			ParentGroup:    "foo",
 		},
 	})
@@ -827,12 +827,12 @@ func (s *quotaHandlersSuite) TestQuotaRemove(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 			SubGroups:      []string{"foo2"},
 		},
 		"foo2": {
-			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB / 2),
+			ResourceLimits: quota.CreateResources(quantity.SizeGiB / 2),
 			ParentGroup:    "foo",
 		},
 	})
@@ -848,7 +848,7 @@ func (s *quotaHandlersSuite) TestQuotaRemove(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -920,7 +920,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateSubGroupTooBig(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
+		ResourceLimits: quota.CreateResources(quantity.SizeGiB),
 		AddSnaps:       []string{"test-snap"},
 	}
 
@@ -929,7 +929,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateSubGroupTooBig(c *C) {
 
 	// ensure mem-limit is 1 GB
 	expFooGroupState := quotaGroupState{
-		ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
+		ResourceLimits: quota.CreateResources(quantity.SizeGiB),
 		Snaps:          []string{"test-snap"},
 	}
 	checkQuotaState(c, st, map[string]quotaGroupState{
@@ -940,7 +940,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateSubGroupTooBig(c *C) {
 	qc2 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo2",
-		ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB / 2),
+		ResourceLimits: quota.CreateResources(quantity.SizeGiB / 2),
 		AddSnaps:       []string{"test-snap2"},
 		ParentName:     "foo",
 	}
@@ -951,7 +951,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateSubGroupTooBig(c *C) {
 	expFooGroupState.SubGroups = []string{"foo2"}
 
 	expFoo2GroupState := quotaGroupState{
-		ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB / 2),
+		ResourceLimits: quota.CreateResources(quantity.SizeGiB / 2),
 		Snaps:          []string{"test-snap2"},
 		ParentGroup:    "foo",
 	}
@@ -966,13 +966,13 @@ func (s *quotaHandlersSuite) TestQuotaUpdateSubGroupTooBig(c *C) {
 	qc3 := servicestate.QuotaControlAction{
 		Action:         "update",
 		QuotaName:      "foo2",
-		ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
+		ResourceLimits: quota.CreateResources(quantity.SizeGiB),
 	}
 
 	err = s.callDoQuotaControl(&qc3)
 	c.Assert(err, IsNil)
 
-	expFoo2GroupState.ResourceLimits = quota.CreateQuotaResources(quantity.SizeGiB)
+	expFoo2GroupState.ResourceLimits = quota.CreateResources(quantity.SizeGiB)
 	// and check that it got updated in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo":  expFooGroupState,
@@ -983,7 +983,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateSubGroupTooBig(c *C) {
 	qc4 := servicestate.QuotaControlAction{
 		Action:         "update",
 		QuotaName:      "foo2",
-		ResourceLimits: quota.CreateQuotaResources(2 * quantity.SizeGiB),
+		ResourceLimits: quota.CreateResources(2 * quantity.SizeGiB),
 	}
 
 	err = s.callDoQuotaControl(&qc4)
@@ -1019,7 +1019,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateChangeMemLimit(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
+		ResourceLimits: quota.CreateResources(quantity.SizeGiB),
 		AddSnaps:       []string{"test-snap"},
 	}
 
@@ -1029,7 +1029,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateChangeMemLimit(c *C) {
 	// ensure mem-limit is 1 GB
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -1038,7 +1038,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateChangeMemLimit(c *C) {
 	qc2 := servicestate.QuotaControlAction{
 		Action:         "update",
 		QuotaName:      "foo",
-		ResourceLimits: quota.CreateQuotaResources(2 * quantity.SizeGiB),
+		ResourceLimits: quota.CreateResources(2 * quantity.SizeGiB),
 	}
 	err = s.callDoQuotaControl(&qc2)
 	c.Assert(err, IsNil)
@@ -1046,7 +1046,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateChangeMemLimit(c *C) {
 	// and check that it got updated in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.CreateQuotaResources(2 * quantity.SizeGiB),
+			ResourceLimits: quota.CreateResources(2 * quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -1055,7 +1055,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateChangeMemLimit(c *C) {
 	qc3 := servicestate.QuotaControlAction{
 		Action:         "update",
 		QuotaName:      "foo",
-		ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
+		ResourceLimits: quota.CreateResources(quantity.SizeGiB),
 	}
 	err = s.callDoQuotaControl(&qc3)
 	c.Assert(err, ErrorMatches, "cannot update limits for group \"foo\": cannot decrease memory limit, remove and re-create it to decrease the limit")
@@ -1095,7 +1095,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnap(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
+		ResourceLimits: quota.CreateResources(quantity.SizeGiB),
 		AddSnaps:       []string{"test-snap"},
 	}
 
@@ -1104,7 +1104,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnap(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -1121,7 +1121,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnap(c *C) {
 	// and check that it got updated in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap", "test-snap2"},
 		},
 	})
@@ -1161,7 +1161,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnapAlreadyInOtherGroup(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
+		ResourceLimits: quota.CreateResources(quantity.SizeGiB),
 		AddSnaps:       []string{"test-snap"},
 	}
 
@@ -1170,7 +1170,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnapAlreadyInOtherGroup(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -1179,7 +1179,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnapAlreadyInOtherGroup(c *C) {
 	qc2 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo2",
-		ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
+		ResourceLimits: quota.CreateResources(quantity.SizeGiB),
 		AddSnaps:       []string{"test-snap2"},
 	}
 
@@ -1189,11 +1189,11 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnapAlreadyInOtherGroup(c *C) {
 	// verify state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 		},
 		"foo2": {
-			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap2"},
 		},
 	})
@@ -1211,11 +1211,11 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnapAlreadyInOtherGroup(c *C) {
 	// nothing changed in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 		},
 		"foo2": {
-			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap2"},
 		},
 	})

--- a/overlord/servicestate/quota_handlers_test.go
+++ b/overlord/servicestate/quota_handlers_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/servicestate"
+	"github.com/snapcore/snapd/overlord/servicestate/resources"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
@@ -77,10 +78,10 @@ func (s *quotaHandlersSuite) TestDoQuotaControlCreate(c *C) {
 
 	qcs := []servicestate.QuotaControlAction{
 		{
-			Action:      "create",
-			QuotaName:   "foo-group",
-			MemoryLimit: quantity.SizeGiB,
-			AddSnaps:    []string{"test-snap"},
+			Action:         "create",
+			QuotaName:      "foo-group",
+			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			AddSnaps:       []string{"test-snap"},
 		},
 	}
 
@@ -95,8 +96,8 @@ func (s *quotaHandlersSuite) TestDoQuotaControlCreate(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo-group": {
-			MemoryLimit: quantity.SizeGiB,
-			Snaps:       []string{"test-snap"},
+			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			Snaps:          []string{"test-snap"},
 		},
 	})
 }
@@ -124,10 +125,10 @@ func (s *quotaHandlersSuite) TestDoQuotaControlCreateRestartOK(c *C) {
 
 	qcs := []servicestate.QuotaControlAction{
 		{
-			Action:      "create",
-			QuotaName:   "foo-group",
-			MemoryLimit: quantity.SizeGiB,
-			AddSnaps:    []string{"test-snap"},
+			Action:         "create",
+			QuotaName:      "foo-group",
+			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			AddSnaps:       []string{"test-snap"},
 		},
 	}
 
@@ -135,8 +136,8 @@ func (s *quotaHandlersSuite) TestDoQuotaControlCreateRestartOK(c *C) {
 
 	expectedQuotaState := map[string]quotaGroupState{
 		"foo-group": {
-			MemoryLimit: quantity.SizeGiB,
-			Snaps:       []string{"test-snap"},
+			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			Snaps:          []string{"test-snap"},
 		},
 	}
 
@@ -182,10 +183,10 @@ func (s *quotaHandlersSuite) TestQuotaStateAlreadyUpdatedBehavior(c *C) {
 
 	qcs := []servicestate.QuotaControlAction{
 		{
-			Action:      "create",
-			QuotaName:   "foo-group",
-			MemoryLimit: quantity.SizeGiB,
-			AddSnaps:    []string{"test-snap"},
+			Action:         "create",
+			QuotaName:      "foo-group",
+			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			AddSnaps:       []string{"test-snap"},
 		},
 	}
 
@@ -255,10 +256,10 @@ func (s *quotaHandlersSuite) TestDoQuotaControlUpdate(c *C) {
 
 	qcs := []servicestate.QuotaControlAction{
 		{
-			Action:      "create",
-			QuotaName:   "foo-group",
-			MemoryLimit: quantity.SizeGiB,
-			AddSnaps:    []string{"test-snap"},
+			Action:         "create",
+			QuotaName:      "foo-group",
+			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			AddSnaps:       []string{"test-snap"},
 		},
 	}
 
@@ -275,9 +276,9 @@ func (s *quotaHandlersSuite) TestDoQuotaControlUpdate(c *C) {
 	// update the memory limit to be double
 	qcs = []servicestate.QuotaControlAction{
 		{
-			Action:      "update",
-			QuotaName:   "foo-group",
-			MemoryLimit: 2 * quantity.SizeGiB,
+			Action:         "update",
+			QuotaName:      "foo-group",
+			ResourceLimits: resources.CreateQuotaResources(2 * quantity.SizeGiB),
 		},
 	}
 
@@ -292,8 +293,8 @@ func (s *quotaHandlersSuite) TestDoQuotaControlUpdate(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo-group": {
-			MemoryLimit: 2 * quantity.SizeGiB,
-			Snaps:       []string{"test-snap"},
+			ResourceLimits: resources.CreateQuotaResources(2 * quantity.SizeGiB),
+			Snaps:          []string{"test-snap"},
 		},
 	})
 }
@@ -322,10 +323,10 @@ func (s *quotaHandlersSuite) TestDoQuotaControlUpdateRestartOK(c *C) {
 
 	qcs := []servicestate.QuotaControlAction{
 		{
-			Action:      "create",
-			QuotaName:   "foo-group",
-			MemoryLimit: quantity.SizeGiB,
-			AddSnaps:    []string{"test-snap"},
+			Action:         "create",
+			QuotaName:      "foo-group",
+			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			AddSnaps:       []string{"test-snap"},
 		},
 	}
 
@@ -342,9 +343,9 @@ func (s *quotaHandlersSuite) TestDoQuotaControlUpdateRestartOK(c *C) {
 	// update the memory limit to be double
 	qcs = []servicestate.QuotaControlAction{
 		{
-			Action:      "update",
-			QuotaName:   "foo-group",
-			MemoryLimit: 2 * quantity.SizeGiB,
+			Action:         "update",
+			QuotaName:      "foo-group",
+			ResourceLimits: resources.CreateQuotaResources(2 * quantity.SizeGiB),
 		},
 	}
 
@@ -352,8 +353,8 @@ func (s *quotaHandlersSuite) TestDoQuotaControlUpdateRestartOK(c *C) {
 
 	expectedQuotaState := map[string]quotaGroupState{
 		"foo-group": {
-			MemoryLimit: 2 * quantity.SizeGiB,
-			Snaps:       []string{"test-snap"},
+			ResourceLimits: resources.CreateQuotaResources(2 * quantity.SizeGiB),
+			Snaps:          []string{"test-snap"},
 		},
 	}
 
@@ -404,10 +405,10 @@ func (s *quotaHandlersSuite) TestDoQuotaControlRemove(c *C) {
 
 	qcs := []servicestate.QuotaControlAction{
 		{
-			Action:      "create",
-			QuotaName:   "foo-group",
-			MemoryLimit: quantity.SizeGiB,
-			AddSnaps:    []string{"test-snap"},
+			Action:         "create",
+			QuotaName:      "foo-group",
+			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			AddSnaps:       []string{"test-snap"},
 		},
 	}
 
@@ -470,10 +471,10 @@ func (s *quotaHandlersSuite) TestDoQuotaControlRemoveRestartOK(c *C) {
 
 	qcs := []servicestate.QuotaControlAction{
 		{
-			Action:      "create",
-			QuotaName:   "foo-group",
-			MemoryLimit: quantity.SizeGiB,
-			AddSnaps:    []string{"test-snap"},
+			Action:         "create",
+			QuotaName:      "foo-group",
+			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			AddSnaps:       []string{"test-snap"},
 		},
 	}
 
@@ -546,10 +547,10 @@ func (s *quotaHandlersSuite) TestQuotaCreatePreseeding(c *C) {
 
 	// now we can create the quota group
 	qc := servicestate.QuotaControlAction{
-		Action:      "create",
-		QuotaName:   "foo",
-		MemoryLimit: quantity.SizeGiB,
-		AddSnaps:    []string{"test-snap"},
+		Action:         "create",
+		QuotaName:      "foo",
+		ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+		AddSnaps:       []string{"test-snap"},
 	}
 
 	err := s.callDoQuotaControl(&qc)
@@ -558,8 +559,8 @@ func (s *quotaHandlersSuite) TestQuotaCreatePreseeding(c *C) {
 	// check that the quota groups were created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			MemoryLimit: quantity.SizeGiB,
-			Snaps:       []string{"test-snap"},
+			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			Snaps:          []string{"test-snap"},
 		},
 	})
 }
@@ -583,10 +584,10 @@ func (s *quotaHandlersSuite) TestQuotaCreate(c *C) {
 
 	// trying to create a quota with a snap that doesn't exist fails
 	qc := servicestate.QuotaControlAction{
-		Action:      "create",
-		QuotaName:   "foo",
-		MemoryLimit: quantity.SizeGiB,
-		AddSnaps:    []string{"test-snap"},
+		Action:         "create",
+		QuotaName:      "foo",
+		ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+		AddSnaps:       []string{"test-snap"},
 	}
 
 	err := s.callDoQuotaControl(&qc)
@@ -597,23 +598,23 @@ func (s *quotaHandlersSuite) TestQuotaCreate(c *C) {
 	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
 
 	qc2 := servicestate.QuotaControlAction{
-		Action:      "create",
-		QuotaName:   "foo",
-		MemoryLimit: 4 * quantity.SizeKiB,
-		AddSnaps:    []string{"test-snap"},
+		Action:         "create",
+		QuotaName:      "foo",
+		ResourceLimits: resources.CreateQuotaResources(4 * quantity.SizeKiB),
+		AddSnaps:       []string{"test-snap"},
 	}
 
 	// trying to create a quota with too low of a memory limit fails
 	err = s.callDoQuotaControl(&qc2)
-	c.Assert(err, ErrorMatches, `memory limit for group "foo" is too small: size must be larger than 4KB`)
+	c.Assert(err, ErrorMatches, `cannot create quota group "foo": memory limit 4096 is too small: size must be larger than 4KB`)
 
 	// but with an adequately sized memory limit, and a snap that exists, we can
 	// create it
 	qc3 := servicestate.QuotaControlAction{
-		Action:      "create",
-		QuotaName:   "foo",
-		MemoryLimit: 4*quantity.SizeKiB + 1,
-		AddSnaps:    []string{"test-snap"},
+		Action:         "create",
+		QuotaName:      "foo",
+		ResourceLimits: resources.CreateQuotaResources(4*quantity.SizeKiB + 1),
+		AddSnaps:       []string{"test-snap"},
 	}
 	err = s.callDoQuotaControl(&qc3)
 	c.Assert(err, IsNil)
@@ -621,8 +622,8 @@ func (s *quotaHandlersSuite) TestQuotaCreate(c *C) {
 	// check that the quota groups were created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			MemoryLimit: 4*quantity.SizeKiB + 1,
-			Snaps:       []string{"test-snap"},
+			ResourceLimits: resources.CreateQuotaResources(4*quantity.SizeKiB + 1),
+			Snaps:          []string{"test-snap"},
 		},
 	})
 }
@@ -652,9 +653,9 @@ func (s *quotaHandlersSuite) TestDoCreateSubGroupQuota(c *C) {
 
 	// create a quota group with no snaps to be the parent
 	qc := servicestate.QuotaControlAction{
-		Action:      "create",
-		QuotaName:   "foo-group",
-		MemoryLimit: quantity.SizeGiB,
+		Action:         "create",
+		QuotaName:      "foo-group",
+		ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
 	}
 
 	err := s.callDoQuotaControl(&qc)
@@ -662,11 +663,11 @@ func (s *quotaHandlersSuite) TestDoCreateSubGroupQuota(c *C) {
 
 	// trying to create a quota group with a non-existent parent group fails
 	qc2 := servicestate.QuotaControlAction{
-		Action:      "create",
-		QuotaName:   "foo2",
-		MemoryLimit: quantity.SizeGiB,
-		ParentName:  "foo-non-real",
-		AddSnaps:    []string{"test-snap"},
+		Action:         "create",
+		QuotaName:      "foo2",
+		ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+		ParentName:     "foo-non-real",
+		AddSnaps:       []string{"test-snap"},
 	}
 
 	err = s.callDoQuotaControl(&qc2)
@@ -675,11 +676,11 @@ func (s *quotaHandlersSuite) TestDoCreateSubGroupQuota(c *C) {
 	// trying to create a quota group with too big of a limit to fit inside the
 	// parent fails
 	qc3 := servicestate.QuotaControlAction{
-		Action:      "create",
-		QuotaName:   "foo2",
-		MemoryLimit: 2 * quantity.SizeGiB,
-		ParentName:  "foo-group",
-		AddSnaps:    []string{"test-snap"},
+		Action:         "create",
+		QuotaName:      "foo2",
+		ResourceLimits: resources.CreateQuotaResources(2 * quantity.SizeGiB),
+		ParentName:     "foo-group",
+		AddSnaps:       []string{"test-snap"},
 	}
 
 	err = s.callDoQuotaControl(&qc3)
@@ -687,11 +688,11 @@ func (s *quotaHandlersSuite) TestDoCreateSubGroupQuota(c *C) {
 
 	// now we can create a sub-quota
 	qc4 := servicestate.QuotaControlAction{
-		Action:      "create",
-		QuotaName:   "foo2",
-		MemoryLimit: quantity.SizeGiB,
-		ParentName:  "foo-group",
-		AddSnaps:    []string{"test-snap"},
+		Action:         "create",
+		QuotaName:      "foo2",
+		ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+		ParentName:     "foo-group",
+		AddSnaps:       []string{"test-snap"},
 	}
 
 	err = s.callDoQuotaControl(&qc4)
@@ -700,13 +701,13 @@ func (s *quotaHandlersSuite) TestDoCreateSubGroupQuota(c *C) {
 	// check that the quota groups were created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo-group": {
-			MemoryLimit: quantity.SizeGiB,
-			SubGroups:   []string{"foo2"},
+			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			SubGroups:      []string{"foo2"},
 		},
 		"foo2": {
-			MemoryLimit: quantity.SizeGiB,
-			Snaps:       []string{"test-snap"},
-			ParentGroup: "foo-group",
+			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			Snaps:          []string{"test-snap"},
+			ParentGroup:    "foo-group",
 		},
 	})
 
@@ -758,10 +759,10 @@ func (s *quotaHandlersSuite) TestQuotaRemove(c *C) {
 	c.Assert(err, ErrorMatches, `cannot remove non-existent quota group "not-exists"`)
 
 	qc2 := servicestate.QuotaControlAction{
-		Action:      "create",
-		QuotaName:   "foo",
-		MemoryLimit: quantity.SizeGiB,
-		AddSnaps:    []string{"test-snap"},
+		Action:         "create",
+		QuotaName:      "foo",
+		ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+		AddSnaps:       []string{"test-snap"},
 	}
 
 	err = s.callDoQuotaControl(&qc2)
@@ -769,20 +770,20 @@ func (s *quotaHandlersSuite) TestQuotaRemove(c *C) {
 
 	// create 2 quota sub-groups too
 	qc3 := servicestate.QuotaControlAction{
-		Action:      "create",
-		QuotaName:   "foo2",
-		MemoryLimit: quantity.SizeGiB / 2,
-		ParentName:  "foo",
+		Action:         "create",
+		QuotaName:      "foo2",
+		ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB / 2),
+		ParentName:     "foo",
 	}
 
 	err = s.callDoQuotaControl(&qc3)
 	c.Assert(err, IsNil)
 
 	qc4 := servicestate.QuotaControlAction{
-		Action:      "create",
-		QuotaName:   "foo3",
-		MemoryLimit: quantity.SizeGiB / 2,
-		ParentName:  "foo",
+		Action:         "create",
+		QuotaName:      "foo3",
+		ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB / 2),
+		ParentName:     "foo",
 	}
 
 	err = s.callDoQuotaControl(&qc4)
@@ -791,17 +792,17 @@ func (s *quotaHandlersSuite) TestQuotaRemove(c *C) {
 	// check that the quota groups was created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			MemoryLimit: quantity.SizeGiB,
-			Snaps:       []string{"test-snap"},
-			SubGroups:   []string{"foo2", "foo3"},
+			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			Snaps:          []string{"test-snap"},
+			SubGroups:      []string{"foo2", "foo3"},
 		},
 		"foo2": {
-			MemoryLimit: quantity.SizeGiB / 2,
-			ParentGroup: "foo",
+			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB / 2),
+			ParentGroup:    "foo",
 		},
 		"foo3": {
-			MemoryLimit: quantity.SizeGiB / 2,
-			ParentGroup: "foo",
+			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB / 2),
+			ParentGroup:    "foo",
 		},
 	})
 
@@ -826,13 +827,13 @@ func (s *quotaHandlersSuite) TestQuotaRemove(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			MemoryLimit: quantity.SizeGiB,
-			Snaps:       []string{"test-snap"},
-			SubGroups:   []string{"foo2"},
+			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			Snaps:          []string{"test-snap"},
+			SubGroups:      []string{"foo2"},
 		},
 		"foo2": {
-			MemoryLimit: quantity.SizeGiB / 2,
-			ParentGroup: "foo",
+			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB / 2),
+			ParentGroup:    "foo",
 		},
 	})
 
@@ -847,8 +848,8 @@ func (s *quotaHandlersSuite) TestQuotaRemove(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			MemoryLimit: quantity.SizeGiB,
-			Snaps:       []string{"test-snap"},
+			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			Snaps:          []string{"test-snap"},
 		},
 	})
 
@@ -917,10 +918,10 @@ func (s *quotaHandlersSuite) TestQuotaUpdateSubGroupTooBig(c *C) {
 
 	// create a quota group
 	qc := servicestate.QuotaControlAction{
-		Action:      "create",
-		QuotaName:   "foo",
-		MemoryLimit: quantity.SizeGiB,
-		AddSnaps:    []string{"test-snap"},
+		Action:         "create",
+		QuotaName:      "foo",
+		ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+		AddSnaps:       []string{"test-snap"},
 	}
 
 	err := s.callDoQuotaControl(&qc)
@@ -928,8 +929,8 @@ func (s *quotaHandlersSuite) TestQuotaUpdateSubGroupTooBig(c *C) {
 
 	// ensure mem-limit is 1 GB
 	expFooGroupState := quotaGroupState{
-		MemoryLimit: quantity.SizeGiB,
-		Snaps:       []string{"test-snap"},
+		ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+		Snaps:          []string{"test-snap"},
 	}
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": expFooGroupState,
@@ -937,11 +938,11 @@ func (s *quotaHandlersSuite) TestQuotaUpdateSubGroupTooBig(c *C) {
 
 	// create a sub-group with 0.5 GiB
 	qc2 := servicestate.QuotaControlAction{
-		Action:      "create",
-		QuotaName:   "foo2",
-		MemoryLimit: quantity.SizeGiB / 2,
-		AddSnaps:    []string{"test-snap2"},
-		ParentName:  "foo",
+		Action:         "create",
+		QuotaName:      "foo2",
+		ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB / 2),
+		AddSnaps:       []string{"test-snap2"},
+		ParentName:     "foo",
 	}
 
 	err = s.callDoQuotaControl(&qc2)
@@ -950,9 +951,9 @@ func (s *quotaHandlersSuite) TestQuotaUpdateSubGroupTooBig(c *C) {
 	expFooGroupState.SubGroups = []string{"foo2"}
 
 	expFoo2GroupState := quotaGroupState{
-		MemoryLimit: quantity.SizeGiB / 2,
-		Snaps:       []string{"test-snap2"},
-		ParentGroup: "foo",
+		ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB / 2),
+		Snaps:          []string{"test-snap2"},
+		ParentGroup:    "foo",
 	}
 
 	// verify it was set in state
@@ -963,15 +964,15 @@ func (s *quotaHandlersSuite) TestQuotaUpdateSubGroupTooBig(c *C) {
 
 	// now try to increase it to the max size
 	qc3 := servicestate.QuotaControlAction{
-		Action:      "update",
-		QuotaName:   "foo2",
-		MemoryLimit: quantity.SizeGiB,
+		Action:         "update",
+		QuotaName:      "foo2",
+		ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
 	}
 
 	err = s.callDoQuotaControl(&qc3)
 	c.Assert(err, IsNil)
 
-	expFoo2GroupState.MemoryLimit = quantity.SizeGiB
+	expFoo2GroupState.ResourceLimits = resources.CreateQuotaResources(quantity.SizeGiB)
 	// and check that it got updated in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo":  expFooGroupState,
@@ -980,9 +981,9 @@ func (s *quotaHandlersSuite) TestQuotaUpdateSubGroupTooBig(c *C) {
 
 	// now try to increase it above the parent limit
 	qc4 := servicestate.QuotaControlAction{
-		Action:      "update",
-		QuotaName:   "foo2",
-		MemoryLimit: 2 * quantity.SizeGiB,
+		Action:         "update",
+		QuotaName:      "foo2",
+		ResourceLimits: resources.CreateQuotaResources(2 * quantity.SizeGiB),
 	}
 
 	err = s.callDoQuotaControl(&qc4)
@@ -1016,10 +1017,10 @@ func (s *quotaHandlersSuite) TestQuotaUpdateChangeMemLimit(c *C) {
 
 	// create a quota group
 	qc := servicestate.QuotaControlAction{
-		Action:      "create",
-		QuotaName:   "foo",
-		MemoryLimit: quantity.SizeGiB,
-		AddSnaps:    []string{"test-snap"},
+		Action:         "create",
+		QuotaName:      "foo",
+		ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+		AddSnaps:       []string{"test-snap"},
 	}
 
 	err := s.callDoQuotaControl(&qc)
@@ -1028,16 +1029,16 @@ func (s *quotaHandlersSuite) TestQuotaUpdateChangeMemLimit(c *C) {
 	// ensure mem-limit is 1 GB
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			MemoryLimit: quantity.SizeGiB,
-			Snaps:       []string{"test-snap"},
+			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			Snaps:          []string{"test-snap"},
 		},
 	})
 
 	// modify to 2 GB
 	qc2 := servicestate.QuotaControlAction{
-		Action:      "update",
-		QuotaName:   "foo",
-		MemoryLimit: 2 * quantity.SizeGiB,
+		Action:         "update",
+		QuotaName:      "foo",
+		ResourceLimits: resources.CreateQuotaResources(2 * quantity.SizeGiB),
 	}
 	err = s.callDoQuotaControl(&qc2)
 	c.Assert(err, IsNil)
@@ -1045,19 +1046,19 @@ func (s *quotaHandlersSuite) TestQuotaUpdateChangeMemLimit(c *C) {
 	// and check that it got updated in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			MemoryLimit: 2 * quantity.SizeGiB,
-			Snaps:       []string{"test-snap"},
+			ResourceLimits: resources.CreateQuotaResources(2 * quantity.SizeGiB),
+			Snaps:          []string{"test-snap"},
 		},
 	})
 
 	// trying to decrease the memory limit is not yet supported
 	qc3 := servicestate.QuotaControlAction{
-		Action:      "update",
-		QuotaName:   "foo",
-		MemoryLimit: quantity.SizeGiB,
+		Action:         "update",
+		QuotaName:      "foo",
+		ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
 	}
 	err = s.callDoQuotaControl(&qc3)
-	c.Assert(err, ErrorMatches, "cannot decrease memory limit of existing quota-group, remove and re-create it to decrease the limit")
+	c.Assert(err, ErrorMatches, "cannot update limits for group \"foo\": cannot decrease memory limit, remove and re-create it to decrease the limit")
 }
 
 func (s *quotaHandlersSuite) TestQuotaUpdateAddSnap(c *C) {
@@ -1092,10 +1093,10 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnap(c *C) {
 
 	// create a quota group
 	qc := servicestate.QuotaControlAction{
-		Action:      "create",
-		QuotaName:   "foo",
-		MemoryLimit: quantity.SizeGiB,
-		AddSnaps:    []string{"test-snap"},
+		Action:         "create",
+		QuotaName:      "foo",
+		ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+		AddSnaps:       []string{"test-snap"},
 	}
 
 	err := s.callDoQuotaControl(&qc)
@@ -1103,8 +1104,8 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnap(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			MemoryLimit: quantity.SizeGiB,
-			Snaps:       []string{"test-snap"},
+			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			Snaps:          []string{"test-snap"},
 		},
 	})
 
@@ -1120,8 +1121,8 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnap(c *C) {
 	// and check that it got updated in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			MemoryLimit: quantity.SizeGiB,
-			Snaps:       []string{"test-snap", "test-snap2"},
+			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			Snaps:          []string{"test-snap", "test-snap2"},
 		},
 	})
 }
@@ -1158,10 +1159,10 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnapAlreadyInOtherGroup(c *C) {
 
 	// create a quota group
 	qc := servicestate.QuotaControlAction{
-		Action:      "create",
-		QuotaName:   "foo",
-		MemoryLimit: quantity.SizeGiB,
-		AddSnaps:    []string{"test-snap"},
+		Action:         "create",
+		QuotaName:      "foo",
+		ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+		AddSnaps:       []string{"test-snap"},
 	}
 
 	err := s.callDoQuotaControl(&qc)
@@ -1169,17 +1170,17 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnapAlreadyInOtherGroup(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			MemoryLimit: quantity.SizeGiB,
-			Snaps:       []string{"test-snap"},
+			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			Snaps:          []string{"test-snap"},
 		},
 	})
 
 	// create another quota group with the second snap
 	qc2 := servicestate.QuotaControlAction{
-		Action:      "create",
-		QuotaName:   "foo2",
-		MemoryLimit: quantity.SizeGiB,
-		AddSnaps:    []string{"test-snap2"},
+		Action:         "create",
+		QuotaName:      "foo2",
+		ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+		AddSnaps:       []string{"test-snap2"},
 	}
 
 	err = s.callDoQuotaControl(&qc2)
@@ -1188,12 +1189,12 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnapAlreadyInOtherGroup(c *C) {
 	// verify state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			MemoryLimit: quantity.SizeGiB,
-			Snaps:       []string{"test-snap"},
+			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			Snaps:          []string{"test-snap"},
 		},
 		"foo2": {
-			MemoryLimit: quantity.SizeGiB,
-			Snaps:       []string{"test-snap2"},
+			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			Snaps:          []string{"test-snap2"},
 		},
 	})
 
@@ -1210,12 +1211,12 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnapAlreadyInOtherGroup(c *C) {
 	// nothing changed in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			MemoryLimit: quantity.SizeGiB,
-			Snaps:       []string{"test-snap"},
+			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			Snaps:          []string{"test-snap"},
 		},
 		"foo2": {
-			MemoryLimit: quantity.SizeGiB,
-			Snaps:       []string{"test-snap2"},
+			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			Snaps:          []string{"test-snap2"},
 		},
 	})
 }

--- a/overlord/servicestate/quota_handlers_test.go
+++ b/overlord/servicestate/quota_handlers_test.go
@@ -25,10 +25,10 @@ import (
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/servicestate"
-	"github.com/snapcore/snapd/overlord/servicestate/resources"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/quota"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/systemd"
@@ -80,7 +80,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlCreate(c *C) {
 		{
 			Action:         "create",
 			QuotaName:      "foo-group",
-			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
 			AddSnaps:       []string{"test-snap"},
 		},
 	}
@@ -96,7 +96,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlCreate(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo-group": {
-			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -127,7 +127,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlCreateRestartOK(c *C) {
 		{
 			Action:         "create",
 			QuotaName:      "foo-group",
-			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
 			AddSnaps:       []string{"test-snap"},
 		},
 	}
@@ -136,7 +136,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlCreateRestartOK(c *C) {
 
 	expectedQuotaState := map[string]quotaGroupState{
 		"foo-group": {
-			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 		},
 	}
@@ -185,7 +185,7 @@ func (s *quotaHandlersSuite) TestQuotaStateAlreadyUpdatedBehavior(c *C) {
 		{
 			Action:         "create",
 			QuotaName:      "foo-group",
-			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
 			AddSnaps:       []string{"test-snap"},
 		},
 	}
@@ -258,7 +258,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlUpdate(c *C) {
 		{
 			Action:         "create",
 			QuotaName:      "foo-group",
-			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
 			AddSnaps:       []string{"test-snap"},
 		},
 	}
@@ -278,7 +278,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlUpdate(c *C) {
 		{
 			Action:         "update",
 			QuotaName:      "foo-group",
-			ResourceLimits: resources.CreateQuotaResources(2 * quantity.SizeGiB),
+			ResourceLimits: quota.CreateQuotaResources(2 * quantity.SizeGiB),
 		},
 	}
 
@@ -293,7 +293,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlUpdate(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo-group": {
-			ResourceLimits: resources.CreateQuotaResources(2 * quantity.SizeGiB),
+			ResourceLimits: quota.CreateQuotaResources(2 * quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -325,7 +325,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlUpdateRestartOK(c *C) {
 		{
 			Action:         "create",
 			QuotaName:      "foo-group",
-			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
 			AddSnaps:       []string{"test-snap"},
 		},
 	}
@@ -345,7 +345,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlUpdateRestartOK(c *C) {
 		{
 			Action:         "update",
 			QuotaName:      "foo-group",
-			ResourceLimits: resources.CreateQuotaResources(2 * quantity.SizeGiB),
+			ResourceLimits: quota.CreateQuotaResources(2 * quantity.SizeGiB),
 		},
 	}
 
@@ -353,7 +353,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlUpdateRestartOK(c *C) {
 
 	expectedQuotaState := map[string]quotaGroupState{
 		"foo-group": {
-			ResourceLimits: resources.CreateQuotaResources(2 * quantity.SizeGiB),
+			ResourceLimits: quota.CreateQuotaResources(2 * quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 		},
 	}
@@ -407,7 +407,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlRemove(c *C) {
 		{
 			Action:         "create",
 			QuotaName:      "foo-group",
-			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
 			AddSnaps:       []string{"test-snap"},
 		},
 	}
@@ -473,7 +473,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlRemoveRestartOK(c *C) {
 		{
 			Action:         "create",
 			QuotaName:      "foo-group",
-			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
 			AddSnaps:       []string{"test-snap"},
 		},
 	}
@@ -549,7 +549,7 @@ func (s *quotaHandlersSuite) TestQuotaCreatePreseeding(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+		ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
 		AddSnaps:       []string{"test-snap"},
 	}
 
@@ -559,7 +559,7 @@ func (s *quotaHandlersSuite) TestQuotaCreatePreseeding(c *C) {
 	// check that the quota groups were created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -586,7 +586,7 @@ func (s *quotaHandlersSuite) TestQuotaCreate(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+		ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
 		AddSnaps:       []string{"test-snap"},
 	}
 
@@ -600,7 +600,7 @@ func (s *quotaHandlersSuite) TestQuotaCreate(c *C) {
 	qc2 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: resources.CreateQuotaResources(4 * quantity.SizeKiB),
+		ResourceLimits: quota.CreateQuotaResources(4 * quantity.SizeKiB),
 		AddSnaps:       []string{"test-snap"},
 	}
 
@@ -613,7 +613,7 @@ func (s *quotaHandlersSuite) TestQuotaCreate(c *C) {
 	qc3 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: resources.CreateQuotaResources(4*quantity.SizeKiB + 1),
+		ResourceLimits: quota.CreateQuotaResources(4*quantity.SizeKiB + 1),
 		AddSnaps:       []string{"test-snap"},
 	}
 	err = s.callDoQuotaControl(&qc3)
@@ -622,7 +622,7 @@ func (s *quotaHandlersSuite) TestQuotaCreate(c *C) {
 	// check that the quota groups were created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: resources.CreateQuotaResources(4*quantity.SizeKiB + 1),
+			ResourceLimits: quota.CreateQuotaResources(4*quantity.SizeKiB + 1),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -655,7 +655,7 @@ func (s *quotaHandlersSuite) TestDoCreateSubGroupQuota(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo-group",
-		ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+		ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
 	}
 
 	err := s.callDoQuotaControl(&qc)
@@ -665,7 +665,7 @@ func (s *quotaHandlersSuite) TestDoCreateSubGroupQuota(c *C) {
 	qc2 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo2",
-		ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+		ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
 		ParentName:     "foo-non-real",
 		AddSnaps:       []string{"test-snap"},
 	}
@@ -678,7 +678,7 @@ func (s *quotaHandlersSuite) TestDoCreateSubGroupQuota(c *C) {
 	qc3 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo2",
-		ResourceLimits: resources.CreateQuotaResources(2 * quantity.SizeGiB),
+		ResourceLimits: quota.CreateQuotaResources(2 * quantity.SizeGiB),
 		ParentName:     "foo-group",
 		AddSnaps:       []string{"test-snap"},
 	}
@@ -690,7 +690,7 @@ func (s *quotaHandlersSuite) TestDoCreateSubGroupQuota(c *C) {
 	qc4 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo2",
-		ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+		ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
 		ParentName:     "foo-group",
 		AddSnaps:       []string{"test-snap"},
 	}
@@ -701,11 +701,11 @@ func (s *quotaHandlersSuite) TestDoCreateSubGroupQuota(c *C) {
 	// check that the quota groups were created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo-group": {
-			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
 			SubGroups:      []string{"foo2"},
 		},
 		"foo2": {
-			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 			ParentGroup:    "foo-group",
 		},
@@ -761,7 +761,7 @@ func (s *quotaHandlersSuite) TestQuotaRemove(c *C) {
 	qc2 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+		ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
 		AddSnaps:       []string{"test-snap"},
 	}
 
@@ -772,7 +772,7 @@ func (s *quotaHandlersSuite) TestQuotaRemove(c *C) {
 	qc3 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo2",
-		ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB / 2),
+		ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB / 2),
 		ParentName:     "foo",
 	}
 
@@ -782,7 +782,7 @@ func (s *quotaHandlersSuite) TestQuotaRemove(c *C) {
 	qc4 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo3",
-		ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB / 2),
+		ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB / 2),
 		ParentName:     "foo",
 	}
 
@@ -792,16 +792,16 @@ func (s *quotaHandlersSuite) TestQuotaRemove(c *C) {
 	// check that the quota groups was created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 			SubGroups:      []string{"foo2", "foo3"},
 		},
 		"foo2": {
-			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB / 2),
+			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB / 2),
 			ParentGroup:    "foo",
 		},
 		"foo3": {
-			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB / 2),
+			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB / 2),
 			ParentGroup:    "foo",
 		},
 	})
@@ -827,12 +827,12 @@ func (s *quotaHandlersSuite) TestQuotaRemove(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 			SubGroups:      []string{"foo2"},
 		},
 		"foo2": {
-			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB / 2),
+			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB / 2),
 			ParentGroup:    "foo",
 		},
 	})
@@ -848,7 +848,7 @@ func (s *quotaHandlersSuite) TestQuotaRemove(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -920,7 +920,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateSubGroupTooBig(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+		ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
 		AddSnaps:       []string{"test-snap"},
 	}
 
@@ -929,7 +929,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateSubGroupTooBig(c *C) {
 
 	// ensure mem-limit is 1 GB
 	expFooGroupState := quotaGroupState{
-		ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+		ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
 		Snaps:          []string{"test-snap"},
 	}
 	checkQuotaState(c, st, map[string]quotaGroupState{
@@ -940,7 +940,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateSubGroupTooBig(c *C) {
 	qc2 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo2",
-		ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB / 2),
+		ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB / 2),
 		AddSnaps:       []string{"test-snap2"},
 		ParentName:     "foo",
 	}
@@ -951,7 +951,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateSubGroupTooBig(c *C) {
 	expFooGroupState.SubGroups = []string{"foo2"}
 
 	expFoo2GroupState := quotaGroupState{
-		ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB / 2),
+		ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB / 2),
 		Snaps:          []string{"test-snap2"},
 		ParentGroup:    "foo",
 	}
@@ -966,13 +966,13 @@ func (s *quotaHandlersSuite) TestQuotaUpdateSubGroupTooBig(c *C) {
 	qc3 := servicestate.QuotaControlAction{
 		Action:         "update",
 		QuotaName:      "foo2",
-		ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+		ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
 	}
 
 	err = s.callDoQuotaControl(&qc3)
 	c.Assert(err, IsNil)
 
-	expFoo2GroupState.ResourceLimits = resources.CreateQuotaResources(quantity.SizeGiB)
+	expFoo2GroupState.ResourceLimits = quota.CreateQuotaResources(quantity.SizeGiB)
 	// and check that it got updated in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo":  expFooGroupState,
@@ -983,7 +983,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateSubGroupTooBig(c *C) {
 	qc4 := servicestate.QuotaControlAction{
 		Action:         "update",
 		QuotaName:      "foo2",
-		ResourceLimits: resources.CreateQuotaResources(2 * quantity.SizeGiB),
+		ResourceLimits: quota.CreateQuotaResources(2 * quantity.SizeGiB),
 	}
 
 	err = s.callDoQuotaControl(&qc4)
@@ -1019,7 +1019,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateChangeMemLimit(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+		ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
 		AddSnaps:       []string{"test-snap"},
 	}
 
@@ -1029,7 +1029,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateChangeMemLimit(c *C) {
 	// ensure mem-limit is 1 GB
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -1038,7 +1038,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateChangeMemLimit(c *C) {
 	qc2 := servicestate.QuotaControlAction{
 		Action:         "update",
 		QuotaName:      "foo",
-		ResourceLimits: resources.CreateQuotaResources(2 * quantity.SizeGiB),
+		ResourceLimits: quota.CreateQuotaResources(2 * quantity.SizeGiB),
 	}
 	err = s.callDoQuotaControl(&qc2)
 	c.Assert(err, IsNil)
@@ -1046,7 +1046,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateChangeMemLimit(c *C) {
 	// and check that it got updated in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: resources.CreateQuotaResources(2 * quantity.SizeGiB),
+			ResourceLimits: quota.CreateQuotaResources(2 * quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -1055,7 +1055,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateChangeMemLimit(c *C) {
 	qc3 := servicestate.QuotaControlAction{
 		Action:         "update",
 		QuotaName:      "foo",
-		ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+		ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
 	}
 	err = s.callDoQuotaControl(&qc3)
 	c.Assert(err, ErrorMatches, "cannot update limits for group \"foo\": cannot decrease memory limit, remove and re-create it to decrease the limit")
@@ -1095,7 +1095,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnap(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+		ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
 		AddSnaps:       []string{"test-snap"},
 	}
 
@@ -1104,7 +1104,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnap(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -1121,7 +1121,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnap(c *C) {
 	// and check that it got updated in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap", "test-snap2"},
 		},
 	})
@@ -1161,7 +1161,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnapAlreadyInOtherGroup(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+		ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
 		AddSnaps:       []string{"test-snap"},
 	}
 
@@ -1170,7 +1170,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnapAlreadyInOtherGroup(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -1179,7 +1179,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnapAlreadyInOtherGroup(c *C) {
 	qc2 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo2",
-		ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+		ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
 		AddSnaps:       []string{"test-snap2"},
 	}
 
@@ -1189,11 +1189,11 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnapAlreadyInOtherGroup(c *C) {
 	// verify state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 		},
 		"foo2": {
-			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap2"},
 		},
 	})
@@ -1211,11 +1211,11 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnapAlreadyInOtherGroup(c *C) {
 	// nothing changed in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap"},
 		},
 		"foo2": {
-			ResourceLimits: resources.CreateQuotaResources(quantity.SizeGiB),
+			ResourceLimits: quota.CreateQuotaResources(quantity.SizeGiB),
 			Snaps:          []string{"test-snap2"},
 		},
 	})

--- a/overlord/servicestate/resources/quotas.go
+++ b/overlord/servicestate/resources/quotas.go
@@ -1,0 +1,105 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+* Copyright (C) 2021 Canonical Ltd
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License version 3 as
+* published by the Free Software Foundation.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+ */
+
+package resources
+
+import (
+	"fmt"
+
+	"github.com/snapcore/snapd/gadget/quantity"
+)
+
+// QuotaResourceMemory is the memory limit for the quota group being controlled,
+// either the initial limit the group is created with for the "create"
+// action, or if non-zero for the "update" the memory limit, then the new
+// value to be set.
+type QuotaResourceMemory struct {
+	MemoryLimit quantity.Size
+}
+
+type QuotaResources struct {
+	Memory *QuotaResourceMemory
+}
+
+func (qr *QuotaResources) validateMemoryQuota() error {
+	// make sure the memory limit is not zero
+	if qr.Memory.MemoryLimit == 0 {
+		return fmt.Errorf("cannot create quota group with no memory limit set")
+	}
+
+	// make sure the memory limit is at least 4K, that is the minimum size
+	// to allow nesting, otherwise groups with less than 4K will trigger the
+	// oom killer to be invoked when a new group is added as a sub-group to the
+	// larger group.
+	if qr.Memory.MemoryLimit <= 4*quantity.SizeKiB {
+		return fmt.Errorf("memory limit %d is too small: size must be larger than 4KB", qr.Memory.MemoryLimit)
+	}
+	return nil
+}
+
+func (qr *QuotaResources) Validate() error {
+	if qr.Memory == nil {
+		return fmt.Errorf("quota group must have a memory limit set")
+	}
+
+	if qr.Memory != nil {
+		if err := qr.validateMemoryQuota(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (qr *QuotaResources) ValidateChange(newLimits QuotaResources) error {
+
+	// check that the memory limit is not being decreased
+	if newLimits.Memory != nil && newLimits.Memory.MemoryLimit != 0 {
+		// we disallow decreasing the memory limit because it is difficult to do
+		// so correctly with the current state of our code in
+		// EnsureSnapServices, see comment in ensureSnapServicesForGroup for
+		// full details
+		if qr.Memory != nil && newLimits.Memory.MemoryLimit < qr.Memory.MemoryLimit {
+			return fmt.Errorf("cannot decrease memory limit, remove and re-create it to decrease the limit")
+		}
+	}
+
+	return nil
+}
+
+func (qr *QuotaResources) Change(newLimits QuotaResources) error {
+	if err := qr.ValidateChange(newLimits); err != nil {
+		return err
+	}
+
+	if newLimits.Memory != nil {
+		qr.Memory = newLimits.Memory
+	}
+	return nil
+}
+
+func CreateQuotaResources(memoryLimit quantity.Size) QuotaResources {
+	var quotaResources QuotaResources
+	if memoryLimit != 0 {
+		quotaResources.Memory = &QuotaResourceMemory{
+			MemoryLimit: memoryLimit,
+		}
+	}
+	return quotaResources
+}

--- a/overlord/servicestate/servicestate_test.go
+++ b/overlord/servicestate/servicestate_test.go
@@ -313,7 +313,7 @@ func (s *snapServiceOptionsSuite) TestSnapServiceOptionsQuotaGroups(c *C) {
 	defer st.Unlock()
 
 	// make a quota group
-	grp, err := quota.NewGroup("foogroup", quota.CreateQuotaResources(quantity.SizeGiB))
+	grp, err := quota.NewGroup("foogroup", quota.CreateResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
 	grp.Snaps = []string{"foosnap"}

--- a/overlord/servicestate/servicestate_test.go
+++ b/overlord/servicestate/servicestate_test.go
@@ -313,7 +313,7 @@ func (s *snapServiceOptionsSuite) TestSnapServiceOptionsQuotaGroups(c *C) {
 	defer st.Unlock()
 
 	// make a quota group
-	grp, err := quota.NewGroup("foogroup", quota.CreateResources(quantity.SizeGiB))
+	grp, err := quota.NewGroup("foogroup", quota.NewResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
 	grp.Snaps = []string{"foosnap"}

--- a/overlord/servicestate/servicestate_test.go
+++ b/overlord/servicestate/servicestate_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/servicestate"
-	"github.com/snapcore/snapd/overlord/servicestate/resources"
 	"github.com/snapcore/snapd/overlord/servicestate/servicestatetest"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
@@ -314,7 +313,7 @@ func (s *snapServiceOptionsSuite) TestSnapServiceOptionsQuotaGroups(c *C) {
 	defer st.Unlock()
 
 	// make a quota group
-	grp, err := quota.NewGroup("foogroup", resources.CreateQuotaResources(quantity.SizeGiB))
+	grp, err := quota.NewGroup("foogroup", quota.CreateQuotaResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
 	grp.Snaps = []string{"foosnap"}

--- a/overlord/servicestate/servicestate_test.go
+++ b/overlord/servicestate/servicestate_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/servicestate"
+	"github.com/snapcore/snapd/overlord/servicestate/resources"
 	"github.com/snapcore/snapd/overlord/servicestate/servicestatetest"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
@@ -313,7 +314,7 @@ func (s *snapServiceOptionsSuite) TestSnapServiceOptionsQuotaGroups(c *C) {
 	defer st.Unlock()
 
 	// make a quota group
-	grp, err := quota.NewGroup("foogroup", quantity.SizeGiB)
+	grp, err := quota.NewGroup("foogroup", resources.CreateQuotaResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
 	grp.Snaps = []string{"foosnap"}

--- a/overlord/servicestate/servicestatetest/quotas.go
+++ b/overlord/servicestate/servicestatetest/quotas.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 
 	"github.com/snapcore/snapd/overlord/servicestate/internal"
-	"github.com/snapcore/snapd/overlord/servicestate/resources"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap/quota"
 )
@@ -34,7 +33,7 @@ func PatchQuotas(st *state.State, grps ...*quota.Group) (map[string]*quota.Group
 	return internal.PatchQuotas(st, grps...)
 }
 
-func MockQuotaInState(st *state.State, quotaName string, parentName string, snaps []string, resourceLimits resources.QuotaResources) error {
+func MockQuotaInState(st *state.State, quotaName string, parentName string, snaps []string, resourceLimits quota.QuotaResources) error {
 	allGrps, err := internal.AllQuotas(st)
 	if err != nil {
 		return nil

--- a/overlord/servicestate/servicestatetest/quotas.go
+++ b/overlord/servicestate/servicestatetest/quotas.go
@@ -33,7 +33,7 @@ func PatchQuotas(st *state.State, grps ...*quota.Group) (map[string]*quota.Group
 	return internal.PatchQuotas(st, grps...)
 }
 
-func MockQuotaInState(st *state.State, quotaName string, parentName string, snaps []string, resourceLimits quota.QuotaResources) error {
+func MockQuotaInState(st *state.State, quotaName string, parentName string, snaps []string, resourceLimits quota.Resources) error {
 	allGrps, err := internal.AllQuotas(st)
 	if err != nil {
 		return nil

--- a/overlord/servicestate/servicestatetest/quotas.go
+++ b/overlord/servicestate/servicestatetest/quotas.go
@@ -22,8 +22,8 @@ package servicestatetest
 import (
 	"fmt"
 
-	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/overlord/servicestate/internal"
+	"github.com/snapcore/snapd/overlord/servicestate/resources"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap/quota"
 )
@@ -34,7 +34,7 @@ func PatchQuotas(st *state.State, grps ...*quota.Group) (map[string]*quota.Group
 	return internal.PatchQuotas(st, grps...)
 }
 
-func MockQuotaInState(st *state.State, quotaName string, parentName string, snaps []string, memoryLimit quantity.Size) error {
+func MockQuotaInState(st *state.State, quotaName string, parentName string, snaps []string, resourceLimits resources.QuotaResources) error {
 	allGrps, err := internal.AllQuotas(st)
 	if err != nil {
 		return nil
@@ -49,6 +49,6 @@ func MockQuotaInState(st *state.State, quotaName string, parentName string, snap
 		}
 	}
 
-	_, _, err = internal.CreateQuotaInState(st, quotaName, parentGrp, snaps, memoryLimit, allGrps)
+	_, _, err = internal.CreateQuotaInState(st, quotaName, parentGrp, snaps, resourceLimits, allGrps)
 	return err
 }

--- a/overlord/snapstate/backend/link_test.go
+++ b/overlord/snapstate/backend/link_test.go
@@ -789,7 +789,7 @@ apps:
 `
 	info := snaptest.MockSnap(c, yaml, &snap.SideInfo{Revision: snap.R(11)})
 
-	grp, err := quota.NewGroup("foogroup", quota.CreateQuotaResources(quantity.SizeMiB))
+	grp, err := quota.NewGroup("foogroup", quota.CreateResources(quantity.SizeMiB))
 	c.Assert(err, IsNil)
 
 	linkCtxWithGroup := backend.LinkContext{

--- a/overlord/snapstate/backend/link_test.go
+++ b/overlord/snapstate/backend/link_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/overlord/servicestate/resources"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/release"
@@ -789,7 +790,7 @@ apps:
 `
 	info := snaptest.MockSnap(c, yaml, &snap.SideInfo{Revision: snap.R(11)})
 
-	grp, err := quota.NewGroup("foogroup", quantity.SizeMiB)
+	grp, err := quota.NewGroup("foogroup", resources.CreateQuotaResources(quantity.SizeMiB))
 	c.Assert(err, IsNil)
 
 	linkCtxWithGroup := backend.LinkContext{

--- a/overlord/snapstate/backend/link_test.go
+++ b/overlord/snapstate/backend/link_test.go
@@ -38,7 +38,6 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/osutil"
-	"github.com/snapcore/snapd/overlord/servicestate/resources"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/release"
@@ -790,7 +789,7 @@ apps:
 `
 	info := snaptest.MockSnap(c, yaml, &snap.SideInfo{Revision: snap.R(11)})
 
-	grp, err := quota.NewGroup("foogroup", resources.CreateQuotaResources(quantity.SizeMiB))
+	grp, err := quota.NewGroup("foogroup", quota.CreateQuotaResources(quantity.SizeMiB))
 	c.Assert(err, IsNil)
 
 	linkCtxWithGroup := backend.LinkContext{

--- a/overlord/snapstate/backend/link_test.go
+++ b/overlord/snapstate/backend/link_test.go
@@ -789,7 +789,7 @@ apps:
 `
 	info := snaptest.MockSnap(c, yaml, &snap.SideInfo{Revision: snap.R(11)})
 
-	grp, err := quota.NewGroup("foogroup", quota.CreateResources(quantity.SizeMiB))
+	grp, err := quota.NewGroup("foogroup", quota.NewResources(quantity.SizeMiB))
 	c.Assert(err, IsNil)
 
 	linkCtxWithGroup := backend.LinkContext{

--- a/snap/quota/quota.go
+++ b/snap/quota/quota.go
@@ -28,7 +28,6 @@ import (
 
 	// TODO: move this to snap/quantity? or similar
 	"github.com/snapcore/snapd/gadget/quantity"
-	"github.com/snapcore/snapd/overlord/servicestate/resources"
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/snap/naming"
 	"github.com/snapcore/snapd/systemd"
@@ -74,7 +73,7 @@ type Group struct {
 }
 
 // NewGroup creates a new top quota group with the given name and memory limit.
-func NewGroup(name string, resourceLimits resources.QuotaResources) (*Group, error) {
+func NewGroup(name string, resourceLimits QuotaResources) (*Group, error) {
 	grp := &Group{
 		Name: name,
 	}
@@ -89,14 +88,14 @@ func NewGroup(name string, resourceLimits resources.QuotaResources) (*Group, err
 
 // UpdateQuotaLimits updates all the quota limits set for the group to the new limits
 // given. The limits must be validated prior to calling this function.
-func (grp *Group) UpdateQuotaLimits(resourceLimits resources.QuotaResources) {
+func (grp *Group) UpdateQuotaLimits(resourceLimits QuotaResources) {
 	if resourceLimits.Memory != nil {
 		grp.MemoryLimit = resourceLimits.Memory.MemoryLimit
 	}
 }
 
-func (grp *Group) GetQuotaResources() resources.QuotaResources {
-	return resources.CreateQuotaResources(grp.MemoryLimit)
+func (grp *Group) GetQuotaResources() QuotaResources {
+	return CreateQuotaResources(grp.MemoryLimit)
 }
 
 // CurrentMemoryUsage returns the current memory usage of the quota group. For
@@ -206,7 +205,7 @@ func (grp *Group) validate() error {
 }
 
 // NewSubGroup creates a new sub group under the current group.
-func (grp *Group) NewSubGroup(name string, resourceLimits resources.QuotaResources) (*Group, error) {
+func (grp *Group) NewSubGroup(name string, resourceLimits QuotaResources) (*Group, error) {
 	// TODO: implement a maximum sub-group depth
 
 	subGrp := &Group{

--- a/snap/quota/quota.go
+++ b/snap/quota/quota.go
@@ -28,6 +28,7 @@ import (
 
 	// TODO: move this to snap/quantity? or similar
 	"github.com/snapcore/snapd/gadget/quantity"
+	"github.com/snapcore/snapd/overlord/servicestate/resources"
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/snap/naming"
 	"github.com/snapcore/snapd/systemd"
@@ -73,17 +74,29 @@ type Group struct {
 }
 
 // NewGroup creates a new top quota group with the given name and memory limit.
-func NewGroup(name string, memLimit quantity.Size) (*Group, error) {
+func NewGroup(name string, resourceLimits resources.QuotaResources) (*Group, error) {
 	grp := &Group{
-		Name:        name,
-		MemoryLimit: memLimit,
+		Name: name,
 	}
+	grp.UpdateQuotaLimits(resourceLimits)
 
 	if err := grp.validate(); err != nil {
 		return nil, err
 	}
 
 	return grp, nil
+}
+
+// UpdateQuotaLimits updates all the quota limits set for the group to the new limits
+// given. The limits must be validated prior to calling this function.
+func (grp *Group) UpdateQuotaLimits(resourceLimits resources.QuotaResources) {
+	if resourceLimits.Memory != nil {
+		grp.MemoryLimit = resourceLimits.Memory.MemoryLimit
+	}
+}
+
+func (grp *Group) GetQuotaResources() resources.QuotaResources {
+	return resources.CreateQuotaResources(grp.MemoryLimit)
 }
 
 // CurrentMemoryUsage returns the current memory usage of the quota group. For
@@ -152,12 +165,11 @@ func (grp *Group) validate() error {
 		return fmt.Errorf("group name %q reserved", grp.Name)
 	}
 
-	if grp.MemoryLimit == 0 {
-		return fmt.Errorf("group memory limit must be non-zero")
+	// validate the resource limits for the group
+	limits := grp.GetQuotaResources()
+	if err := limits.Validate(); err != nil {
+		return err
 	}
-
-	// TODO: probably there is a minimum amount of bytes here that is
-	// technically usable/enforcable, should we check that too?
 
 	if grp.ParentGroup != "" && grp.Name == grp.ParentGroup {
 		return fmt.Errorf("group has circular parent reference to itself")
@@ -194,15 +206,15 @@ func (grp *Group) validate() error {
 }
 
 // NewSubGroup creates a new sub group under the current group.
-func (grp *Group) NewSubGroup(name string, memLimit quantity.Size) (*Group, error) {
+func (grp *Group) NewSubGroup(name string, resourceLimits resources.QuotaResources) (*Group, error) {
 	// TODO: implement a maximum sub-group depth
 
 	subGrp := &Group{
 		Name:        name,
-		MemoryLimit: memLimit,
 		ParentGroup: grp.Name,
 		parentGroup: grp,
 	}
+	subGrp.UpdateQuotaLimits(resourceLimits)
 
 	// check early that the sub group name is not the same as that of the
 	// parent, this is fine in systemd world, but in snapd we want unique quota

--- a/snap/quota/quota.go
+++ b/snap/quota/quota.go
@@ -73,7 +73,7 @@ type Group struct {
 }
 
 // NewGroup creates a new top quota group with the given name and memory limit.
-func NewGroup(name string, resourceLimits QuotaResources) (*Group, error) {
+func NewGroup(name string, resourceLimits Resources) (*Group, error) {
 	grp := &Group{
 		Name: name,
 	}
@@ -88,14 +88,14 @@ func NewGroup(name string, resourceLimits QuotaResources) (*Group, error) {
 
 // UpdateQuotaLimits updates all the quota limits set for the group to the new limits
 // given. The limits must be validated prior to calling this function.
-func (grp *Group) UpdateQuotaLimits(resourceLimits QuotaResources) {
+func (grp *Group) UpdateQuotaLimits(resourceLimits Resources) {
 	if resourceLimits.Memory != nil {
-		grp.MemoryLimit = resourceLimits.Memory.MemoryLimit
+		grp.MemoryLimit = resourceLimits.Memory.Limit
 	}
 }
 
-func (grp *Group) GetQuotaResources() QuotaResources {
-	return CreateQuotaResources(grp.MemoryLimit)
+func (grp *Group) GetQuotaResources() Resources {
+	return CreateResources(grp.MemoryLimit)
 }
 
 // CurrentMemoryUsage returns the current memory usage of the quota group. For
@@ -205,7 +205,7 @@ func (grp *Group) validate() error {
 }
 
 // NewSubGroup creates a new sub group under the current group.
-func (grp *Group) NewSubGroup(name string, resourceLimits QuotaResources) (*Group, error) {
+func (grp *Group) NewSubGroup(name string, resourceLimits Resources) (*Group, error) {
 	// TODO: implement a maximum sub-group depth
 
 	subGrp := &Group{

--- a/snap/quota/quota.go
+++ b/snap/quota/quota.go
@@ -95,7 +95,7 @@ func (grp *Group) UpdateQuotaLimits(resourceLimits Resources) {
 }
 
 func (grp *Group) GetQuotaResources() Resources {
-	return CreateResources(grp.MemoryLimit)
+	return NewResources(grp.MemoryLimit)
 }
 
 // CurrentMemoryUsage returns the current memory usage of the quota group. For

--- a/snap/quota/quota_test.go
+++ b/snap/quota/quota_test.go
@@ -27,7 +27,6 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/gadget/quantity"
-	"github.com/snapcore/snapd/overlord/servicestate/resources"
 	"github.com/snapcore/snapd/snap/quota"
 	"github.com/snapcore/snapd/systemd"
 )
@@ -44,88 +43,88 @@ func (ts *quotaTestSuite) TestNewGroup(c *C) {
 	tt := []struct {
 		name          string
 		sliceFileName string
-		limits        resources.QuotaResources
+		limits        quota.QuotaResources
 		err           string
 		comment       string
 	}{
 		{
 			name:    "group1",
-			limits:  resources.CreateQuotaResources(quantity.SizeMiB),
+			limits:  quota.CreateQuotaResources(quantity.SizeMiB),
 			comment: "basic happy",
 		},
 		{
 			name:    "biglimit",
-			limits:  resources.CreateQuotaResources(quantity.Size(math.MaxUint64)),
+			limits:  quota.CreateQuotaResources(quantity.Size(math.MaxUint64)),
 			comment: "huge limit happy",
 		},
 		{
 			name:    "zero",
-			limits:  resources.CreateQuotaResources(0),
+			limits:  quota.CreateQuotaResources(0),
 			err:     `quota group must have a memory limit set`,
 			comment: "group with zero memory limit",
 		},
 		{
 			name:    "group1-unsupported chars",
-			limits:  resources.CreateQuotaResources(quantity.SizeMiB),
+			limits:  quota.CreateQuotaResources(quantity.SizeMiB),
 			err:     `invalid quota group name: contains invalid characters.*`,
 			comment: "unsupported characters in group name",
 		},
 		{
 			name:    "group%%%",
-			limits:  resources.CreateQuotaResources(quantity.SizeMiB),
+			limits:  quota.CreateQuotaResources(quantity.SizeMiB),
 			err:     `invalid quota group name: contains invalid characters.*`,
 			comment: "more invalid characters in name",
 		},
 		{
 			name:    "CAPITALIZED",
-			limits:  resources.CreateQuotaResources(quantity.SizeMiB),
+			limits:  quota.CreateQuotaResources(quantity.SizeMiB),
 			err:     `invalid quota group name: contains invalid characters.*`,
 			comment: "capitalized letters",
 		},
 		{
 			name:    "g1",
-			limits:  resources.CreateQuotaResources(quantity.SizeMiB),
+			limits:  quota.CreateQuotaResources(quantity.SizeMiB),
 			comment: "small group name",
 		},
 		{
 			name:          "name-with-dashes",
 			sliceFileName: `name\x2dwith\x2ddashes`,
-			limits:        resources.CreateQuotaResources(quantity.SizeMiB),
+			limits:        quota.CreateQuotaResources(quantity.SizeMiB),
 			comment:       "name with dashes",
 		},
 		{
 			name:    "",
-			limits:  resources.CreateQuotaResources(quantity.SizeMiB),
+			limits:  quota.CreateQuotaResources(quantity.SizeMiB),
 			err:     `invalid quota group name: must not be empty`,
 			comment: "empty group name",
 		},
 		{
 			name:    "g",
-			limits:  resources.CreateQuotaResources(quantity.SizeMiB),
+			limits:  quota.CreateQuotaResources(quantity.SizeMiB),
 			err:     `invalid quota group name: must be between 2 and 40 characters long.*`,
 			comment: "too small group name",
 		},
 		{
 			name:    "root",
-			limits:  resources.CreateQuotaResources(quantity.SizeMiB),
+			limits:  quota.CreateQuotaResources(quantity.SizeMiB),
 			err:     `group name "root" reserved`,
 			comment: "reserved root name",
 		},
 		{
 			name:    "snapd",
-			limits:  resources.CreateQuotaResources(quantity.SizeMiB),
+			limits:  quota.CreateQuotaResources(quantity.SizeMiB),
 			err:     `group name "snapd" reserved`,
 			comment: "reserved snapd name",
 		},
 		{
 			name:    "system",
-			limits:  resources.CreateQuotaResources(quantity.SizeMiB),
+			limits:  quota.CreateQuotaResources(quantity.SizeMiB),
 			err:     `group name "system" reserved`,
 			comment: "reserved system name",
 		},
 		{
 			name:    "user",
-			limits:  resources.CreateQuotaResources(quantity.SizeMiB),
+			limits:  quota.CreateQuotaResources(quantity.SizeMiB),
 			err:     `group name "user" reserved`,
 			comment: "reserved user name",
 		},
@@ -151,72 +150,72 @@ func (ts *quotaTestSuite) TestNewGroup(c *C) {
 func (ts *quotaTestSuite) TestSimpleSubGroupVerification(c *C) {
 	tt := []struct {
 		rootname      string
-		rootlimits    resources.QuotaResources
+		rootlimits    quota.QuotaResources
 		subname       string
 		sliceFileName string
-		sublimits     resources.QuotaResources
+		sublimits     quota.QuotaResources
 		err           string
 		comment       string
 	}{
 		{
-			rootlimits: resources.CreateQuotaResources(quantity.SizeMiB),
+			rootlimits: quota.CreateQuotaResources(quantity.SizeMiB),
 			subname:    "sub",
-			sublimits:  resources.CreateQuotaResources(quantity.SizeMiB),
+			sublimits:  quota.CreateQuotaResources(quantity.SizeMiB),
 			comment:    "basic sub group with same quota as parent happy",
 		},
 		{
-			rootlimits: resources.CreateQuotaResources(quantity.SizeMiB),
+			rootlimits: quota.CreateQuotaResources(quantity.SizeMiB),
 			subname:    "sub",
-			sublimits:  resources.CreateQuotaResources(quantity.SizeMiB / 2),
+			sublimits:  quota.CreateQuotaResources(quantity.SizeMiB / 2),
 			comment:    "basic sub group with smaller quota than parent happy",
 		},
 		{
-			rootlimits:    resources.CreateQuotaResources(quantity.SizeMiB),
+			rootlimits:    quota.CreateQuotaResources(quantity.SizeMiB),
 			subname:       "sub-with-dashes",
 			sliceFileName: `myroot-sub\x2dwith\x2ddashes`,
-			sublimits:     resources.CreateQuotaResources(quantity.SizeMiB / 2),
+			sublimits:     quota.CreateQuotaResources(quantity.SizeMiB / 2),
 			comment:       "basic sub group with dashes in the name",
 		},
 		{
 			rootname:      "my-root",
-			rootlimits:    resources.CreateQuotaResources(quantity.SizeMiB),
+			rootlimits:    quota.CreateQuotaResources(quantity.SizeMiB),
 			subname:       "sub-with-dashes",
 			sliceFileName: `my\x2droot-sub\x2dwith\x2ddashes`,
-			sublimits:     resources.CreateQuotaResources(quantity.SizeMiB / 2),
+			sublimits:     quota.CreateQuotaResources(quantity.SizeMiB / 2),
 			comment:       "parent and sub group have dashes in name",
 		},
 		{
-			rootlimits: resources.CreateQuotaResources(quantity.SizeMiB),
+			rootlimits: quota.CreateQuotaResources(quantity.SizeMiB),
 			subname:    "sub",
-			sublimits:  resources.CreateQuotaResources(quantity.SizeMiB * 2),
+			sublimits:  quota.CreateQuotaResources(quantity.SizeMiB * 2),
 			err:        "sub-group memory limit of 2 MiB is too large to fit inside remaining quota space 1 MiB for parent group myroot",
 			comment:    "sub group with larger quota than parent unhappy",
 		},
 		{
-			rootlimits: resources.CreateQuotaResources(quantity.SizeMiB),
+			rootlimits: quota.CreateQuotaResources(quantity.SizeMiB),
 			subname:    "sub invalid chars",
-			sublimits:  resources.CreateQuotaResources(quantity.SizeMiB),
+			sublimits:  quota.CreateQuotaResources(quantity.SizeMiB),
 			err:        `invalid quota group name: contains invalid characters.*`,
 			comment:    "sub group with invalid name",
 		},
 		{
-			rootlimits: resources.CreateQuotaResources(quantity.SizeMiB),
+			rootlimits: quota.CreateQuotaResources(quantity.SizeMiB),
 			subname:    "myroot",
-			sublimits:  resources.CreateQuotaResources(quantity.SizeMiB),
+			sublimits:  quota.CreateQuotaResources(quantity.SizeMiB),
 			err:        `cannot use same name "myroot" for sub group as parent group`,
 			comment:    "sub group with same name as parent group",
 		},
 		{
-			rootlimits: resources.CreateQuotaResources(quantity.SizeMiB),
+			rootlimits: quota.CreateQuotaResources(quantity.SizeMiB),
 			subname:    "snapd",
-			sublimits:  resources.CreateQuotaResources(quantity.SizeMiB),
+			sublimits:  quota.CreateQuotaResources(quantity.SizeMiB),
 			err:        `group name "snapd" reserved`,
 			comment:    "sub group with reserved name",
 		},
 		{
-			rootlimits: resources.CreateQuotaResources(quantity.SizeMiB),
+			rootlimits: quota.CreateQuotaResources(quantity.SizeMiB),
 			subname:    "zero",
-			sublimits:  resources.CreateQuotaResources(0),
+			sublimits:  quota.CreateQuotaResources(0),
 			err:        `quota group must have a memory limit set`,
 			comment:    "sub group with zero memory limit",
 		},
@@ -249,30 +248,30 @@ func (ts *quotaTestSuite) TestSimpleSubGroupVerification(c *C) {
 }
 
 func (ts *quotaTestSuite) TestComplexSubGroups(c *C) {
-	rootGrp, err := quota.NewGroup("myroot", resources.CreateQuotaResources(quantity.SizeMiB))
+	rootGrp, err := quota.NewGroup("myroot", quota.CreateQuotaResources(quantity.SizeMiB))
 	c.Assert(err, IsNil)
 
 	// try adding 2 sub-groups with total quota split exactly equally
-	sub1, err := rootGrp.NewSubGroup("sub1", resources.CreateQuotaResources(quantity.SizeMiB/2))
+	sub1, err := rootGrp.NewSubGroup("sub1", quota.CreateQuotaResources(quantity.SizeMiB/2))
 	c.Assert(err, IsNil)
 	c.Assert(sub1.SliceFileName(), Equals, "snap.myroot-sub1.slice")
 
-	sub2, err := rootGrp.NewSubGroup("sub2", resources.CreateQuotaResources(quantity.SizeMiB/2))
+	sub2, err := rootGrp.NewSubGroup("sub2", quota.CreateQuotaResources(quantity.SizeMiB/2))
 	c.Assert(err, IsNil)
 	c.Assert(sub2.SliceFileName(), Equals, "snap.myroot-sub2.slice")
 
 	// adding another sub-group to this group fails
-	_, err = rootGrp.NewSubGroup("sub3", resources.CreateQuotaResources(5*quantity.SizeKiB))
+	_, err = rootGrp.NewSubGroup("sub3", quota.CreateQuotaResources(5*quantity.SizeKiB))
 	c.Assert(err, ErrorMatches, "sub-group memory limit of 5 KiB is too large to fit inside remaining quota space 0 B for parent group myroot")
 
 	// we can however add a sub-group to one of the sub-groups with the exact
 	// size of the parent sub-group
-	subsub1, err := sub1.NewSubGroup("subsub1", resources.CreateQuotaResources(quantity.SizeMiB/2))
+	subsub1, err := sub1.NewSubGroup("subsub1", quota.CreateQuotaResources(quantity.SizeMiB/2))
 	c.Assert(err, IsNil)
 	c.Assert(subsub1.SliceFileName(), Equals, "snap.myroot-sub1-subsub1.slice")
 
 	// and we can even add a smaller sub-sub-sub-group to the sub-group
-	subsubsub1, err := subsub1.NewSubGroup("subsubsub1", resources.CreateQuotaResources(quantity.SizeMiB/4))
+	subsubsub1, err := subsub1.NewSubGroup("subsubsub1", quota.CreateQuotaResources(quantity.SizeMiB/4))
 	c.Assert(err, IsNil)
 	c.Assert(subsubsub1.SliceFileName(), Equals, "snap.myroot-sub1-subsub1-subsubsub1.slice")
 }
@@ -491,10 +490,10 @@ func (ts *quotaTestSuite) TestResolveCrossReferences(c *C) {
 }
 
 func (ts *quotaTestSuite) TestAddAllNecessaryGroupsAvoidsInfiniteRecursion(c *C) {
-	grp, err := quota.NewGroup("infinite-group", resources.CreateQuotaResources(quantity.SizeGiB))
+	grp, err := quota.NewGroup("infinite-group", quota.CreateQuotaResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
-	grp2, err := grp.NewSubGroup("infinite-group2", resources.CreateQuotaResources(quantity.SizeGiB))
+	grp2, err := grp.NewSubGroup("infinite-group2", quota.CreateQuotaResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
 	// create a cycle artificially to the same group
@@ -514,7 +513,7 @@ func (ts *quotaTestSuite) TestAddAllNecessaryGroupsAvoidsInfiniteRecursion(c *C)
 	// make a real sub-group and try one more level of indirection going back
 	// to the parent
 	grp2.SetInternalSubGroups(nil)
-	grp3, err := grp2.NewSubGroup("infinite-group3", resources.CreateQuotaResources(quantity.SizeGiB))
+	grp3, err := grp2.NewSubGroup("infinite-group3", quota.CreateQuotaResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 	grp3.SetInternalSubGroups([]*quota.Group{grp})
 
@@ -528,7 +527,7 @@ func (ts *quotaTestSuite) TestAddAllNecessaryGroups(c *C) {
 	// it should initially be empty
 	c.Assert(qs.AllQuotaGroups(), HasLen, 0)
 
-	grp1, err := quota.NewGroup("myroot", resources.CreateQuotaResources(quantity.SizeGiB))
+	grp1, err := quota.NewGroup("myroot", quota.CreateQuotaResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
 	// add the group and make sure it is in the set
@@ -544,7 +543,7 @@ func (ts *quotaTestSuite) TestAddAllNecessaryGroups(c *C) {
 	c.Assert(qs.AllQuotaGroups(), DeepEquals, []*quota.Group{grp1})
 
 	// add a new group and make sure it is in the set now
-	grp2, err := quota.NewGroup("myroot2", resources.CreateQuotaResources(quantity.SizeGiB))
+	grp2, err := quota.NewGroup("myroot2", quota.CreateQuotaResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 	err = qs.AddAllNecessaryGroups(grp2)
 	c.Assert(err, IsNil)
@@ -555,7 +554,7 @@ func (ts *quotaTestSuite) TestAddAllNecessaryGroups(c *C) {
 
 	// make a sub-group and add the root group - it will automatically add
 	// the sub-group without us needing to explicitly add the sub-group
-	subgrp1, err := grp1.NewSubGroup("mysub1", resources.CreateQuotaResources(quantity.SizeGiB))
+	subgrp1, err := grp1.NewSubGroup("mysub1", quota.CreateQuotaResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 	// add grp2 as well
 	err = qs.AddAllNecessaryGroups(grp2)
@@ -572,13 +571,13 @@ func (ts *quotaTestSuite) TestAddAllNecessaryGroups(c *C) {
 
 	// create a new set of group and sub-groups to add the deepest child group
 	// and add that, and notice that the root groups are also added
-	grp3, err := quota.NewGroup("myroot3", resources.CreateQuotaResources(quantity.SizeGiB))
+	grp3, err := quota.NewGroup("myroot3", quota.CreateQuotaResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
-	subgrp3, err := grp3.NewSubGroup("mysub3", resources.CreateQuotaResources(quantity.SizeGiB))
+	subgrp3, err := grp3.NewSubGroup("mysub3", quota.CreateQuotaResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
-	subsubgrp3, err := subgrp3.NewSubGroup("mysubsub3", resources.CreateQuotaResources(quantity.SizeGiB))
+	subsubgrp3, err := subgrp3.NewSubGroup("mysubsub3", quota.CreateQuotaResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
 	err = qs.AddAllNecessaryGroups(subsubgrp3)
@@ -588,13 +587,13 @@ func (ts *quotaTestSuite) TestAddAllNecessaryGroups(c *C) {
 	// finally create a tree with multiple branches and ensure that adding just
 	// a single deepest child will add all the other deepest children from other
 	// branches
-	grp4, err := quota.NewGroup("myroot4", resources.CreateQuotaResources(quantity.SizeGiB))
+	grp4, err := quota.NewGroup("myroot4", quota.CreateQuotaResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
-	subgrp4, err := grp4.NewSubGroup("mysub4", resources.CreateQuotaResources(quantity.SizeGiB/2))
+	subgrp4, err := grp4.NewSubGroup("mysub4", quota.CreateQuotaResources(quantity.SizeGiB/2))
 	c.Assert(err, IsNil)
 
-	subgrp5, err := grp4.NewSubGroup("mysub5", resources.CreateQuotaResources(quantity.SizeGiB/2))
+	subgrp5, err := grp4.NewSubGroup("mysub5", quota.CreateQuotaResources(quantity.SizeGiB/2))
 	c.Assert(err, IsNil)
 
 	// adding just subgrp5 to a quota set will automatically add the other sub
@@ -606,13 +605,13 @@ func (ts *quotaTestSuite) TestAddAllNecessaryGroups(c *C) {
 }
 
 func (ts *quotaTestSuite) TestResolveCrossReferencesLimitCheckSkipsSelf(c *C) {
-	grp1, err := quota.NewGroup("myroot", resources.CreateQuotaResources(quantity.SizeGiB))
+	grp1, err := quota.NewGroup("myroot", quota.CreateQuotaResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
-	subgrp1, err := grp1.NewSubGroup("mysub1", resources.CreateQuotaResources(quantity.SizeGiB))
+	subgrp1, err := grp1.NewSubGroup("mysub1", quota.CreateQuotaResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
-	subgrp2, err := subgrp1.NewSubGroup("mysub2", resources.CreateQuotaResources(quantity.SizeGiB))
+	subgrp2, err := subgrp1.NewSubGroup("mysub2", quota.CreateQuotaResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
 	all := map[string]*quota.Group{
@@ -625,13 +624,13 @@ func (ts *quotaTestSuite) TestResolveCrossReferencesLimitCheckSkipsSelf(c *C) {
 }
 
 func (ts *quotaTestSuite) TestResolveCrossReferencesCircular(c *C) {
-	grp1, err := quota.NewGroup("myroot", resources.CreateQuotaResources(quantity.SizeGiB))
+	grp1, err := quota.NewGroup("myroot", quota.CreateQuotaResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
-	subgrp1, err := grp1.NewSubGroup("mysub1", resources.CreateQuotaResources(quantity.SizeGiB))
+	subgrp1, err := grp1.NewSubGroup("mysub1", quota.CreateQuotaResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
-	subgrp2, err := subgrp1.NewSubGroup("mysub2", resources.CreateQuotaResources(quantity.SizeGiB))
+	subgrp2, err := subgrp1.NewSubGroup("mysub2", quota.CreateQuotaResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
 	all := map[string]*quota.Group{
@@ -706,7 +705,7 @@ func (ts *quotaTestSuite) TestCurrentMemoryUsage(c *C) {
 	})
 	defer r()
 
-	grp1, err := quota.NewGroup("group", resources.CreateQuotaResources(quantity.SizeGiB))
+	grp1, err := quota.NewGroup("group", quota.CreateQuotaResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
 	// group initially is inactive, so it has no current memory usage

--- a/snap/quota/quota_test.go
+++ b/snap/quota/quota_test.go
@@ -49,82 +49,82 @@ func (ts *quotaTestSuite) TestNewGroup(c *C) {
 	}{
 		{
 			name:    "group1",
-			limits:  quota.CreateResources(quantity.SizeMiB),
+			limits:  quota.NewResources(quantity.SizeMiB),
 			comment: "basic happy",
 		},
 		{
 			name:    "biglimit",
-			limits:  quota.CreateResources(quantity.Size(math.MaxUint64)),
+			limits:  quota.NewResources(quantity.Size(math.MaxUint64)),
 			comment: "huge limit happy",
 		},
 		{
 			name:    "zero",
-			limits:  quota.CreateResources(0),
+			limits:  quota.NewResources(0),
 			err:     `quota group must have a memory limit set`,
 			comment: "group with zero memory limit",
 		},
 		{
 			name:    "group1-unsupported chars",
-			limits:  quota.CreateResources(quantity.SizeMiB),
+			limits:  quota.NewResources(quantity.SizeMiB),
 			err:     `invalid quota group name: contains invalid characters.*`,
 			comment: "unsupported characters in group name",
 		},
 		{
 			name:    "group%%%",
-			limits:  quota.CreateResources(quantity.SizeMiB),
+			limits:  quota.NewResources(quantity.SizeMiB),
 			err:     `invalid quota group name: contains invalid characters.*`,
 			comment: "more invalid characters in name",
 		},
 		{
 			name:    "CAPITALIZED",
-			limits:  quota.CreateResources(quantity.SizeMiB),
+			limits:  quota.NewResources(quantity.SizeMiB),
 			err:     `invalid quota group name: contains invalid characters.*`,
 			comment: "capitalized letters",
 		},
 		{
 			name:    "g1",
-			limits:  quota.CreateResources(quantity.SizeMiB),
+			limits:  quota.NewResources(quantity.SizeMiB),
 			comment: "small group name",
 		},
 		{
 			name:          "name-with-dashes",
 			sliceFileName: `name\x2dwith\x2ddashes`,
-			limits:        quota.CreateResources(quantity.SizeMiB),
+			limits:        quota.NewResources(quantity.SizeMiB),
 			comment:       "name with dashes",
 		},
 		{
 			name:    "",
-			limits:  quota.CreateResources(quantity.SizeMiB),
+			limits:  quota.NewResources(quantity.SizeMiB),
 			err:     `invalid quota group name: must not be empty`,
 			comment: "empty group name",
 		},
 		{
 			name:    "g",
-			limits:  quota.CreateResources(quantity.SizeMiB),
+			limits:  quota.NewResources(quantity.SizeMiB),
 			err:     `invalid quota group name: must be between 2 and 40 characters long.*`,
 			comment: "too small group name",
 		},
 		{
 			name:    "root",
-			limits:  quota.CreateResources(quantity.SizeMiB),
+			limits:  quota.NewResources(quantity.SizeMiB),
 			err:     `group name "root" reserved`,
 			comment: "reserved root name",
 		},
 		{
 			name:    "snapd",
-			limits:  quota.CreateResources(quantity.SizeMiB),
+			limits:  quota.NewResources(quantity.SizeMiB),
 			err:     `group name "snapd" reserved`,
 			comment: "reserved snapd name",
 		},
 		{
 			name:    "system",
-			limits:  quota.CreateResources(quantity.SizeMiB),
+			limits:  quota.NewResources(quantity.SizeMiB),
 			err:     `group name "system" reserved`,
 			comment: "reserved system name",
 		},
 		{
 			name:    "user",
-			limits:  quota.CreateResources(quantity.SizeMiB),
+			limits:  quota.NewResources(quantity.SizeMiB),
 			err:     `group name "user" reserved`,
 			comment: "reserved user name",
 		},
@@ -158,64 +158,64 @@ func (ts *quotaTestSuite) TestSimpleSubGroupVerification(c *C) {
 		comment       string
 	}{
 		{
-			rootlimits: quota.CreateResources(quantity.SizeMiB),
+			rootlimits: quota.NewResources(quantity.SizeMiB),
 			subname:    "sub",
-			sublimits:  quota.CreateResources(quantity.SizeMiB),
+			sublimits:  quota.NewResources(quantity.SizeMiB),
 			comment:    "basic sub group with same quota as parent happy",
 		},
 		{
-			rootlimits: quota.CreateResources(quantity.SizeMiB),
+			rootlimits: quota.NewResources(quantity.SizeMiB),
 			subname:    "sub",
-			sublimits:  quota.CreateResources(quantity.SizeMiB / 2),
+			sublimits:  quota.NewResources(quantity.SizeMiB / 2),
 			comment:    "basic sub group with smaller quota than parent happy",
 		},
 		{
-			rootlimits:    quota.CreateResources(quantity.SizeMiB),
+			rootlimits:    quota.NewResources(quantity.SizeMiB),
 			subname:       "sub-with-dashes",
 			sliceFileName: `myroot-sub\x2dwith\x2ddashes`,
-			sublimits:     quota.CreateResources(quantity.SizeMiB / 2),
+			sublimits:     quota.NewResources(quantity.SizeMiB / 2),
 			comment:       "basic sub group with dashes in the name",
 		},
 		{
 			rootname:      "my-root",
-			rootlimits:    quota.CreateResources(quantity.SizeMiB),
+			rootlimits:    quota.NewResources(quantity.SizeMiB),
 			subname:       "sub-with-dashes",
 			sliceFileName: `my\x2droot-sub\x2dwith\x2ddashes`,
-			sublimits:     quota.CreateResources(quantity.SizeMiB / 2),
+			sublimits:     quota.NewResources(quantity.SizeMiB / 2),
 			comment:       "parent and sub group have dashes in name",
 		},
 		{
-			rootlimits: quota.CreateResources(quantity.SizeMiB),
+			rootlimits: quota.NewResources(quantity.SizeMiB),
 			subname:    "sub",
-			sublimits:  quota.CreateResources(quantity.SizeMiB * 2),
+			sublimits:  quota.NewResources(quantity.SizeMiB * 2),
 			err:        "sub-group memory limit of 2 MiB is too large to fit inside remaining quota space 1 MiB for parent group myroot",
 			comment:    "sub group with larger quota than parent unhappy",
 		},
 		{
-			rootlimits: quota.CreateResources(quantity.SizeMiB),
+			rootlimits: quota.NewResources(quantity.SizeMiB),
 			subname:    "sub invalid chars",
-			sublimits:  quota.CreateResources(quantity.SizeMiB),
+			sublimits:  quota.NewResources(quantity.SizeMiB),
 			err:        `invalid quota group name: contains invalid characters.*`,
 			comment:    "sub group with invalid name",
 		},
 		{
-			rootlimits: quota.CreateResources(quantity.SizeMiB),
+			rootlimits: quota.NewResources(quantity.SizeMiB),
 			subname:    "myroot",
-			sublimits:  quota.CreateResources(quantity.SizeMiB),
+			sublimits:  quota.NewResources(quantity.SizeMiB),
 			err:        `cannot use same name "myroot" for sub group as parent group`,
 			comment:    "sub group with same name as parent group",
 		},
 		{
-			rootlimits: quota.CreateResources(quantity.SizeMiB),
+			rootlimits: quota.NewResources(quantity.SizeMiB),
 			subname:    "snapd",
-			sublimits:  quota.CreateResources(quantity.SizeMiB),
+			sublimits:  quota.NewResources(quantity.SizeMiB),
 			err:        `group name "snapd" reserved`,
 			comment:    "sub group with reserved name",
 		},
 		{
-			rootlimits: quota.CreateResources(quantity.SizeMiB),
+			rootlimits: quota.NewResources(quantity.SizeMiB),
 			subname:    "zero",
-			sublimits:  quota.CreateResources(0),
+			sublimits:  quota.NewResources(0),
 			err:        `quota group must have a memory limit set`,
 			comment:    "sub group with zero memory limit",
 		},
@@ -248,30 +248,30 @@ func (ts *quotaTestSuite) TestSimpleSubGroupVerification(c *C) {
 }
 
 func (ts *quotaTestSuite) TestComplexSubGroups(c *C) {
-	rootGrp, err := quota.NewGroup("myroot", quota.CreateResources(quantity.SizeMiB))
+	rootGrp, err := quota.NewGroup("myroot", quota.NewResources(quantity.SizeMiB))
 	c.Assert(err, IsNil)
 
 	// try adding 2 sub-groups with total quota split exactly equally
-	sub1, err := rootGrp.NewSubGroup("sub1", quota.CreateResources(quantity.SizeMiB/2))
+	sub1, err := rootGrp.NewSubGroup("sub1", quota.NewResources(quantity.SizeMiB/2))
 	c.Assert(err, IsNil)
 	c.Assert(sub1.SliceFileName(), Equals, "snap.myroot-sub1.slice")
 
-	sub2, err := rootGrp.NewSubGroup("sub2", quota.CreateResources(quantity.SizeMiB/2))
+	sub2, err := rootGrp.NewSubGroup("sub2", quota.NewResources(quantity.SizeMiB/2))
 	c.Assert(err, IsNil)
 	c.Assert(sub2.SliceFileName(), Equals, "snap.myroot-sub2.slice")
 
 	// adding another sub-group to this group fails
-	_, err = rootGrp.NewSubGroup("sub3", quota.CreateResources(5*quantity.SizeKiB))
+	_, err = rootGrp.NewSubGroup("sub3", quota.NewResources(5*quantity.SizeKiB))
 	c.Assert(err, ErrorMatches, "sub-group memory limit of 5 KiB is too large to fit inside remaining quota space 0 B for parent group myroot")
 
 	// we can however add a sub-group to one of the sub-groups with the exact
 	// size of the parent sub-group
-	subsub1, err := sub1.NewSubGroup("subsub1", quota.CreateResources(quantity.SizeMiB/2))
+	subsub1, err := sub1.NewSubGroup("subsub1", quota.NewResources(quantity.SizeMiB/2))
 	c.Assert(err, IsNil)
 	c.Assert(subsub1.SliceFileName(), Equals, "snap.myroot-sub1-subsub1.slice")
 
 	// and we can even add a smaller sub-sub-sub-group to the sub-group
-	subsubsub1, err := subsub1.NewSubGroup("subsubsub1", quota.CreateResources(quantity.SizeMiB/4))
+	subsubsub1, err := subsub1.NewSubGroup("subsubsub1", quota.NewResources(quantity.SizeMiB/4))
 	c.Assert(err, IsNil)
 	c.Assert(subsubsub1.SliceFileName(), Equals, "snap.myroot-sub1-subsub1-subsubsub1.slice")
 }
@@ -490,10 +490,10 @@ func (ts *quotaTestSuite) TestResolveCrossReferences(c *C) {
 }
 
 func (ts *quotaTestSuite) TestAddAllNecessaryGroupsAvoidsInfiniteRecursion(c *C) {
-	grp, err := quota.NewGroup("infinite-group", quota.CreateResources(quantity.SizeGiB))
+	grp, err := quota.NewGroup("infinite-group", quota.NewResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
-	grp2, err := grp.NewSubGroup("infinite-group2", quota.CreateResources(quantity.SizeGiB))
+	grp2, err := grp.NewSubGroup("infinite-group2", quota.NewResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
 	// create a cycle artificially to the same group
@@ -513,7 +513,7 @@ func (ts *quotaTestSuite) TestAddAllNecessaryGroupsAvoidsInfiniteRecursion(c *C)
 	// make a real sub-group and try one more level of indirection going back
 	// to the parent
 	grp2.SetInternalSubGroups(nil)
-	grp3, err := grp2.NewSubGroup("infinite-group3", quota.CreateResources(quantity.SizeGiB))
+	grp3, err := grp2.NewSubGroup("infinite-group3", quota.NewResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 	grp3.SetInternalSubGroups([]*quota.Group{grp})
 
@@ -527,7 +527,7 @@ func (ts *quotaTestSuite) TestAddAllNecessaryGroups(c *C) {
 	// it should initially be empty
 	c.Assert(qs.AllQuotaGroups(), HasLen, 0)
 
-	grp1, err := quota.NewGroup("myroot", quota.CreateResources(quantity.SizeGiB))
+	grp1, err := quota.NewGroup("myroot", quota.NewResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
 	// add the group and make sure it is in the set
@@ -543,7 +543,7 @@ func (ts *quotaTestSuite) TestAddAllNecessaryGroups(c *C) {
 	c.Assert(qs.AllQuotaGroups(), DeepEquals, []*quota.Group{grp1})
 
 	// add a new group and make sure it is in the set now
-	grp2, err := quota.NewGroup("myroot2", quota.CreateResources(quantity.SizeGiB))
+	grp2, err := quota.NewGroup("myroot2", quota.NewResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 	err = qs.AddAllNecessaryGroups(grp2)
 	c.Assert(err, IsNil)
@@ -554,7 +554,7 @@ func (ts *quotaTestSuite) TestAddAllNecessaryGroups(c *C) {
 
 	// make a sub-group and add the root group - it will automatically add
 	// the sub-group without us needing to explicitly add the sub-group
-	subgrp1, err := grp1.NewSubGroup("mysub1", quota.CreateResources(quantity.SizeGiB))
+	subgrp1, err := grp1.NewSubGroup("mysub1", quota.NewResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 	// add grp2 as well
 	err = qs.AddAllNecessaryGroups(grp2)
@@ -571,13 +571,13 @@ func (ts *quotaTestSuite) TestAddAllNecessaryGroups(c *C) {
 
 	// create a new set of group and sub-groups to add the deepest child group
 	// and add that, and notice that the root groups are also added
-	grp3, err := quota.NewGroup("myroot3", quota.CreateResources(quantity.SizeGiB))
+	grp3, err := quota.NewGroup("myroot3", quota.NewResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
-	subgrp3, err := grp3.NewSubGroup("mysub3", quota.CreateResources(quantity.SizeGiB))
+	subgrp3, err := grp3.NewSubGroup("mysub3", quota.NewResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
-	subsubgrp3, err := subgrp3.NewSubGroup("mysubsub3", quota.CreateResources(quantity.SizeGiB))
+	subsubgrp3, err := subgrp3.NewSubGroup("mysubsub3", quota.NewResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
 	err = qs.AddAllNecessaryGroups(subsubgrp3)
@@ -587,13 +587,13 @@ func (ts *quotaTestSuite) TestAddAllNecessaryGroups(c *C) {
 	// finally create a tree with multiple branches and ensure that adding just
 	// a single deepest child will add all the other deepest children from other
 	// branches
-	grp4, err := quota.NewGroup("myroot4", quota.CreateResources(quantity.SizeGiB))
+	grp4, err := quota.NewGroup("myroot4", quota.NewResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
-	subgrp4, err := grp4.NewSubGroup("mysub4", quota.CreateResources(quantity.SizeGiB/2))
+	subgrp4, err := grp4.NewSubGroup("mysub4", quota.NewResources(quantity.SizeGiB/2))
 	c.Assert(err, IsNil)
 
-	subgrp5, err := grp4.NewSubGroup("mysub5", quota.CreateResources(quantity.SizeGiB/2))
+	subgrp5, err := grp4.NewSubGroup("mysub5", quota.NewResources(quantity.SizeGiB/2))
 	c.Assert(err, IsNil)
 
 	// adding just subgrp5 to a quota set will automatically add the other sub
@@ -605,13 +605,13 @@ func (ts *quotaTestSuite) TestAddAllNecessaryGroups(c *C) {
 }
 
 func (ts *quotaTestSuite) TestResolveCrossReferencesLimitCheckSkipsSelf(c *C) {
-	grp1, err := quota.NewGroup("myroot", quota.CreateResources(quantity.SizeGiB))
+	grp1, err := quota.NewGroup("myroot", quota.NewResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
-	subgrp1, err := grp1.NewSubGroup("mysub1", quota.CreateResources(quantity.SizeGiB))
+	subgrp1, err := grp1.NewSubGroup("mysub1", quota.NewResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
-	subgrp2, err := subgrp1.NewSubGroup("mysub2", quota.CreateResources(quantity.SizeGiB))
+	subgrp2, err := subgrp1.NewSubGroup("mysub2", quota.NewResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
 	all := map[string]*quota.Group{
@@ -624,13 +624,13 @@ func (ts *quotaTestSuite) TestResolveCrossReferencesLimitCheckSkipsSelf(c *C) {
 }
 
 func (ts *quotaTestSuite) TestResolveCrossReferencesCircular(c *C) {
-	grp1, err := quota.NewGroup("myroot", quota.CreateResources(quantity.SizeGiB))
+	grp1, err := quota.NewGroup("myroot", quota.NewResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
-	subgrp1, err := grp1.NewSubGroup("mysub1", quota.CreateResources(quantity.SizeGiB))
+	subgrp1, err := grp1.NewSubGroup("mysub1", quota.NewResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
-	subgrp2, err := subgrp1.NewSubGroup("mysub2", quota.CreateResources(quantity.SizeGiB))
+	subgrp2, err := subgrp1.NewSubGroup("mysub2", quota.NewResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
 	all := map[string]*quota.Group{
@@ -705,7 +705,7 @@ func (ts *quotaTestSuite) TestCurrentMemoryUsage(c *C) {
 	})
 	defer r()
 
-	grp1, err := quota.NewGroup("group", quota.CreateResources(quantity.SizeGiB))
+	grp1, err := quota.NewGroup("group", quota.NewResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
 	// group initially is inactive, so it has no current memory usage

--- a/snap/quota/quota_test.go
+++ b/snap/quota/quota_test.go
@@ -43,88 +43,88 @@ func (ts *quotaTestSuite) TestNewGroup(c *C) {
 	tt := []struct {
 		name          string
 		sliceFileName string
-		limits        quota.QuotaResources
+		limits        quota.Resources
 		err           string
 		comment       string
 	}{
 		{
 			name:    "group1",
-			limits:  quota.CreateQuotaResources(quantity.SizeMiB),
+			limits:  quota.CreateResources(quantity.SizeMiB),
 			comment: "basic happy",
 		},
 		{
 			name:    "biglimit",
-			limits:  quota.CreateQuotaResources(quantity.Size(math.MaxUint64)),
+			limits:  quota.CreateResources(quantity.Size(math.MaxUint64)),
 			comment: "huge limit happy",
 		},
 		{
 			name:    "zero",
-			limits:  quota.CreateQuotaResources(0),
+			limits:  quota.CreateResources(0),
 			err:     `quota group must have a memory limit set`,
 			comment: "group with zero memory limit",
 		},
 		{
 			name:    "group1-unsupported chars",
-			limits:  quota.CreateQuotaResources(quantity.SizeMiB),
+			limits:  quota.CreateResources(quantity.SizeMiB),
 			err:     `invalid quota group name: contains invalid characters.*`,
 			comment: "unsupported characters in group name",
 		},
 		{
 			name:    "group%%%",
-			limits:  quota.CreateQuotaResources(quantity.SizeMiB),
+			limits:  quota.CreateResources(quantity.SizeMiB),
 			err:     `invalid quota group name: contains invalid characters.*`,
 			comment: "more invalid characters in name",
 		},
 		{
 			name:    "CAPITALIZED",
-			limits:  quota.CreateQuotaResources(quantity.SizeMiB),
+			limits:  quota.CreateResources(quantity.SizeMiB),
 			err:     `invalid quota group name: contains invalid characters.*`,
 			comment: "capitalized letters",
 		},
 		{
 			name:    "g1",
-			limits:  quota.CreateQuotaResources(quantity.SizeMiB),
+			limits:  quota.CreateResources(quantity.SizeMiB),
 			comment: "small group name",
 		},
 		{
 			name:          "name-with-dashes",
 			sliceFileName: `name\x2dwith\x2ddashes`,
-			limits:        quota.CreateQuotaResources(quantity.SizeMiB),
+			limits:        quota.CreateResources(quantity.SizeMiB),
 			comment:       "name with dashes",
 		},
 		{
 			name:    "",
-			limits:  quota.CreateQuotaResources(quantity.SizeMiB),
+			limits:  quota.CreateResources(quantity.SizeMiB),
 			err:     `invalid quota group name: must not be empty`,
 			comment: "empty group name",
 		},
 		{
 			name:    "g",
-			limits:  quota.CreateQuotaResources(quantity.SizeMiB),
+			limits:  quota.CreateResources(quantity.SizeMiB),
 			err:     `invalid quota group name: must be between 2 and 40 characters long.*`,
 			comment: "too small group name",
 		},
 		{
 			name:    "root",
-			limits:  quota.CreateQuotaResources(quantity.SizeMiB),
+			limits:  quota.CreateResources(quantity.SizeMiB),
 			err:     `group name "root" reserved`,
 			comment: "reserved root name",
 		},
 		{
 			name:    "snapd",
-			limits:  quota.CreateQuotaResources(quantity.SizeMiB),
+			limits:  quota.CreateResources(quantity.SizeMiB),
 			err:     `group name "snapd" reserved`,
 			comment: "reserved snapd name",
 		},
 		{
 			name:    "system",
-			limits:  quota.CreateQuotaResources(quantity.SizeMiB),
+			limits:  quota.CreateResources(quantity.SizeMiB),
 			err:     `group name "system" reserved`,
 			comment: "reserved system name",
 		},
 		{
 			name:    "user",
-			limits:  quota.CreateQuotaResources(quantity.SizeMiB),
+			limits:  quota.CreateResources(quantity.SizeMiB),
 			err:     `group name "user" reserved`,
 			comment: "reserved user name",
 		},
@@ -150,72 +150,72 @@ func (ts *quotaTestSuite) TestNewGroup(c *C) {
 func (ts *quotaTestSuite) TestSimpleSubGroupVerification(c *C) {
 	tt := []struct {
 		rootname      string
-		rootlimits    quota.QuotaResources
+		rootlimits    quota.Resources
 		subname       string
 		sliceFileName string
-		sublimits     quota.QuotaResources
+		sublimits     quota.Resources
 		err           string
 		comment       string
 	}{
 		{
-			rootlimits: quota.CreateQuotaResources(quantity.SizeMiB),
+			rootlimits: quota.CreateResources(quantity.SizeMiB),
 			subname:    "sub",
-			sublimits:  quota.CreateQuotaResources(quantity.SizeMiB),
+			sublimits:  quota.CreateResources(quantity.SizeMiB),
 			comment:    "basic sub group with same quota as parent happy",
 		},
 		{
-			rootlimits: quota.CreateQuotaResources(quantity.SizeMiB),
+			rootlimits: quota.CreateResources(quantity.SizeMiB),
 			subname:    "sub",
-			sublimits:  quota.CreateQuotaResources(quantity.SizeMiB / 2),
+			sublimits:  quota.CreateResources(quantity.SizeMiB / 2),
 			comment:    "basic sub group with smaller quota than parent happy",
 		},
 		{
-			rootlimits:    quota.CreateQuotaResources(quantity.SizeMiB),
+			rootlimits:    quota.CreateResources(quantity.SizeMiB),
 			subname:       "sub-with-dashes",
 			sliceFileName: `myroot-sub\x2dwith\x2ddashes`,
-			sublimits:     quota.CreateQuotaResources(quantity.SizeMiB / 2),
+			sublimits:     quota.CreateResources(quantity.SizeMiB / 2),
 			comment:       "basic sub group with dashes in the name",
 		},
 		{
 			rootname:      "my-root",
-			rootlimits:    quota.CreateQuotaResources(quantity.SizeMiB),
+			rootlimits:    quota.CreateResources(quantity.SizeMiB),
 			subname:       "sub-with-dashes",
 			sliceFileName: `my\x2droot-sub\x2dwith\x2ddashes`,
-			sublimits:     quota.CreateQuotaResources(quantity.SizeMiB / 2),
+			sublimits:     quota.CreateResources(quantity.SizeMiB / 2),
 			comment:       "parent and sub group have dashes in name",
 		},
 		{
-			rootlimits: quota.CreateQuotaResources(quantity.SizeMiB),
+			rootlimits: quota.CreateResources(quantity.SizeMiB),
 			subname:    "sub",
-			sublimits:  quota.CreateQuotaResources(quantity.SizeMiB * 2),
+			sublimits:  quota.CreateResources(quantity.SizeMiB * 2),
 			err:        "sub-group memory limit of 2 MiB is too large to fit inside remaining quota space 1 MiB for parent group myroot",
 			comment:    "sub group with larger quota than parent unhappy",
 		},
 		{
-			rootlimits: quota.CreateQuotaResources(quantity.SizeMiB),
+			rootlimits: quota.CreateResources(quantity.SizeMiB),
 			subname:    "sub invalid chars",
-			sublimits:  quota.CreateQuotaResources(quantity.SizeMiB),
+			sublimits:  quota.CreateResources(quantity.SizeMiB),
 			err:        `invalid quota group name: contains invalid characters.*`,
 			comment:    "sub group with invalid name",
 		},
 		{
-			rootlimits: quota.CreateQuotaResources(quantity.SizeMiB),
+			rootlimits: quota.CreateResources(quantity.SizeMiB),
 			subname:    "myroot",
-			sublimits:  quota.CreateQuotaResources(quantity.SizeMiB),
+			sublimits:  quota.CreateResources(quantity.SizeMiB),
 			err:        `cannot use same name "myroot" for sub group as parent group`,
 			comment:    "sub group with same name as parent group",
 		},
 		{
-			rootlimits: quota.CreateQuotaResources(quantity.SizeMiB),
+			rootlimits: quota.CreateResources(quantity.SizeMiB),
 			subname:    "snapd",
-			sublimits:  quota.CreateQuotaResources(quantity.SizeMiB),
+			sublimits:  quota.CreateResources(quantity.SizeMiB),
 			err:        `group name "snapd" reserved`,
 			comment:    "sub group with reserved name",
 		},
 		{
-			rootlimits: quota.CreateQuotaResources(quantity.SizeMiB),
+			rootlimits: quota.CreateResources(quantity.SizeMiB),
 			subname:    "zero",
-			sublimits:  quota.CreateQuotaResources(0),
+			sublimits:  quota.CreateResources(0),
 			err:        `quota group must have a memory limit set`,
 			comment:    "sub group with zero memory limit",
 		},
@@ -248,30 +248,30 @@ func (ts *quotaTestSuite) TestSimpleSubGroupVerification(c *C) {
 }
 
 func (ts *quotaTestSuite) TestComplexSubGroups(c *C) {
-	rootGrp, err := quota.NewGroup("myroot", quota.CreateQuotaResources(quantity.SizeMiB))
+	rootGrp, err := quota.NewGroup("myroot", quota.CreateResources(quantity.SizeMiB))
 	c.Assert(err, IsNil)
 
 	// try adding 2 sub-groups with total quota split exactly equally
-	sub1, err := rootGrp.NewSubGroup("sub1", quota.CreateQuotaResources(quantity.SizeMiB/2))
+	sub1, err := rootGrp.NewSubGroup("sub1", quota.CreateResources(quantity.SizeMiB/2))
 	c.Assert(err, IsNil)
 	c.Assert(sub1.SliceFileName(), Equals, "snap.myroot-sub1.slice")
 
-	sub2, err := rootGrp.NewSubGroup("sub2", quota.CreateQuotaResources(quantity.SizeMiB/2))
+	sub2, err := rootGrp.NewSubGroup("sub2", quota.CreateResources(quantity.SizeMiB/2))
 	c.Assert(err, IsNil)
 	c.Assert(sub2.SliceFileName(), Equals, "snap.myroot-sub2.slice")
 
 	// adding another sub-group to this group fails
-	_, err = rootGrp.NewSubGroup("sub3", quota.CreateQuotaResources(5*quantity.SizeKiB))
+	_, err = rootGrp.NewSubGroup("sub3", quota.CreateResources(5*quantity.SizeKiB))
 	c.Assert(err, ErrorMatches, "sub-group memory limit of 5 KiB is too large to fit inside remaining quota space 0 B for parent group myroot")
 
 	// we can however add a sub-group to one of the sub-groups with the exact
 	// size of the parent sub-group
-	subsub1, err := sub1.NewSubGroup("subsub1", quota.CreateQuotaResources(quantity.SizeMiB/2))
+	subsub1, err := sub1.NewSubGroup("subsub1", quota.CreateResources(quantity.SizeMiB/2))
 	c.Assert(err, IsNil)
 	c.Assert(subsub1.SliceFileName(), Equals, "snap.myroot-sub1-subsub1.slice")
 
 	// and we can even add a smaller sub-sub-sub-group to the sub-group
-	subsubsub1, err := subsub1.NewSubGroup("subsubsub1", quota.CreateQuotaResources(quantity.SizeMiB/4))
+	subsubsub1, err := subsub1.NewSubGroup("subsubsub1", quota.CreateResources(quantity.SizeMiB/4))
 	c.Assert(err, IsNil)
 	c.Assert(subsubsub1.SliceFileName(), Equals, "snap.myroot-sub1-subsub1-subsubsub1.slice")
 }
@@ -490,10 +490,10 @@ func (ts *quotaTestSuite) TestResolveCrossReferences(c *C) {
 }
 
 func (ts *quotaTestSuite) TestAddAllNecessaryGroupsAvoidsInfiniteRecursion(c *C) {
-	grp, err := quota.NewGroup("infinite-group", quota.CreateQuotaResources(quantity.SizeGiB))
+	grp, err := quota.NewGroup("infinite-group", quota.CreateResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
-	grp2, err := grp.NewSubGroup("infinite-group2", quota.CreateQuotaResources(quantity.SizeGiB))
+	grp2, err := grp.NewSubGroup("infinite-group2", quota.CreateResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
 	// create a cycle artificially to the same group
@@ -513,7 +513,7 @@ func (ts *quotaTestSuite) TestAddAllNecessaryGroupsAvoidsInfiniteRecursion(c *C)
 	// make a real sub-group and try one more level of indirection going back
 	// to the parent
 	grp2.SetInternalSubGroups(nil)
-	grp3, err := grp2.NewSubGroup("infinite-group3", quota.CreateQuotaResources(quantity.SizeGiB))
+	grp3, err := grp2.NewSubGroup("infinite-group3", quota.CreateResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 	grp3.SetInternalSubGroups([]*quota.Group{grp})
 
@@ -527,7 +527,7 @@ func (ts *quotaTestSuite) TestAddAllNecessaryGroups(c *C) {
 	// it should initially be empty
 	c.Assert(qs.AllQuotaGroups(), HasLen, 0)
 
-	grp1, err := quota.NewGroup("myroot", quota.CreateQuotaResources(quantity.SizeGiB))
+	grp1, err := quota.NewGroup("myroot", quota.CreateResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
 	// add the group and make sure it is in the set
@@ -543,7 +543,7 @@ func (ts *quotaTestSuite) TestAddAllNecessaryGroups(c *C) {
 	c.Assert(qs.AllQuotaGroups(), DeepEquals, []*quota.Group{grp1})
 
 	// add a new group and make sure it is in the set now
-	grp2, err := quota.NewGroup("myroot2", quota.CreateQuotaResources(quantity.SizeGiB))
+	grp2, err := quota.NewGroup("myroot2", quota.CreateResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 	err = qs.AddAllNecessaryGroups(grp2)
 	c.Assert(err, IsNil)
@@ -554,7 +554,7 @@ func (ts *quotaTestSuite) TestAddAllNecessaryGroups(c *C) {
 
 	// make a sub-group and add the root group - it will automatically add
 	// the sub-group without us needing to explicitly add the sub-group
-	subgrp1, err := grp1.NewSubGroup("mysub1", quota.CreateQuotaResources(quantity.SizeGiB))
+	subgrp1, err := grp1.NewSubGroup("mysub1", quota.CreateResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 	// add grp2 as well
 	err = qs.AddAllNecessaryGroups(grp2)
@@ -571,13 +571,13 @@ func (ts *quotaTestSuite) TestAddAllNecessaryGroups(c *C) {
 
 	// create a new set of group and sub-groups to add the deepest child group
 	// and add that, and notice that the root groups are also added
-	grp3, err := quota.NewGroup("myroot3", quota.CreateQuotaResources(quantity.SizeGiB))
+	grp3, err := quota.NewGroup("myroot3", quota.CreateResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
-	subgrp3, err := grp3.NewSubGroup("mysub3", quota.CreateQuotaResources(quantity.SizeGiB))
+	subgrp3, err := grp3.NewSubGroup("mysub3", quota.CreateResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
-	subsubgrp3, err := subgrp3.NewSubGroup("mysubsub3", quota.CreateQuotaResources(quantity.SizeGiB))
+	subsubgrp3, err := subgrp3.NewSubGroup("mysubsub3", quota.CreateResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
 	err = qs.AddAllNecessaryGroups(subsubgrp3)
@@ -587,13 +587,13 @@ func (ts *quotaTestSuite) TestAddAllNecessaryGroups(c *C) {
 	// finally create a tree with multiple branches and ensure that adding just
 	// a single deepest child will add all the other deepest children from other
 	// branches
-	grp4, err := quota.NewGroup("myroot4", quota.CreateQuotaResources(quantity.SizeGiB))
+	grp4, err := quota.NewGroup("myroot4", quota.CreateResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
-	subgrp4, err := grp4.NewSubGroup("mysub4", quota.CreateQuotaResources(quantity.SizeGiB/2))
+	subgrp4, err := grp4.NewSubGroup("mysub4", quota.CreateResources(quantity.SizeGiB/2))
 	c.Assert(err, IsNil)
 
-	subgrp5, err := grp4.NewSubGroup("mysub5", quota.CreateQuotaResources(quantity.SizeGiB/2))
+	subgrp5, err := grp4.NewSubGroup("mysub5", quota.CreateResources(quantity.SizeGiB/2))
 	c.Assert(err, IsNil)
 
 	// adding just subgrp5 to a quota set will automatically add the other sub
@@ -605,13 +605,13 @@ func (ts *quotaTestSuite) TestAddAllNecessaryGroups(c *C) {
 }
 
 func (ts *quotaTestSuite) TestResolveCrossReferencesLimitCheckSkipsSelf(c *C) {
-	grp1, err := quota.NewGroup("myroot", quota.CreateQuotaResources(quantity.SizeGiB))
+	grp1, err := quota.NewGroup("myroot", quota.CreateResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
-	subgrp1, err := grp1.NewSubGroup("mysub1", quota.CreateQuotaResources(quantity.SizeGiB))
+	subgrp1, err := grp1.NewSubGroup("mysub1", quota.CreateResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
-	subgrp2, err := subgrp1.NewSubGroup("mysub2", quota.CreateQuotaResources(quantity.SizeGiB))
+	subgrp2, err := subgrp1.NewSubGroup("mysub2", quota.CreateResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
 	all := map[string]*quota.Group{
@@ -624,13 +624,13 @@ func (ts *quotaTestSuite) TestResolveCrossReferencesLimitCheckSkipsSelf(c *C) {
 }
 
 func (ts *quotaTestSuite) TestResolveCrossReferencesCircular(c *C) {
-	grp1, err := quota.NewGroup("myroot", quota.CreateQuotaResources(quantity.SizeGiB))
+	grp1, err := quota.NewGroup("myroot", quota.CreateResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
-	subgrp1, err := grp1.NewSubGroup("mysub1", quota.CreateQuotaResources(quantity.SizeGiB))
+	subgrp1, err := grp1.NewSubGroup("mysub1", quota.CreateResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
-	subgrp2, err := subgrp1.NewSubGroup("mysub2", quota.CreateQuotaResources(quantity.SizeGiB))
+	subgrp2, err := subgrp1.NewSubGroup("mysub2", quota.CreateResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
 	all := map[string]*quota.Group{
@@ -705,7 +705,7 @@ func (ts *quotaTestSuite) TestCurrentMemoryUsage(c *C) {
 	})
 	defer r()
 
-	grp1, err := quota.NewGroup("group", quota.CreateQuotaResources(quantity.SizeGiB))
+	grp1, err := quota.NewGroup("group", quota.CreateResources(quantity.SizeGiB))
 	c.Assert(err, IsNil)
 
 	// group initially is inactive, so it has no current memory usage

--- a/snap/quota/resources.go
+++ b/snap/quota/resources.go
@@ -112,7 +112,7 @@ func (qr *Resources) Change(newLimits Resources) error {
 	return nil
 }
 
-func CreateResources(memoryLimit quantity.Size) Resources {
+func NewResources(memoryLimit quantity.Size) Resources {
 	var quotaResources Resources
 	if memoryLimit != 0 {
 		quotaResources.Memory = &ResourceMemory{

--- a/snap/quota/resources.go
+++ b/snap/quota/resources.go
@@ -59,8 +59,9 @@ func (qr *Resources) validateMemoryQuota() error {
 	return nil
 }
 
-// Validate performs validation of the provided quota resources for a group. Its intended
-// use is before creating a group.
+// Validate performs validation of the provided quota resources for a group.
+// The restrictions imposed are that atleast one limit should exist (memory for now),
+// and the memory limit must be above 4KB.
 func (qr *Resources) Validate() error {
 	if qr.Memory == nil {
 		return fmt.Errorf("quota group must have a memory limit set")

--- a/snap/quota/resources.go
+++ b/snap/quota/resources.go
@@ -40,7 +40,7 @@ type Resources struct {
 func (qr *Resources) validateMemoryQuota() error {
 	// make sure the memory limit is not zero
 	if qr.Memory.Limit == 0 {
-		return fmt.Errorf("cannot create quota group with no memory limit set")
+		return fmt.Errorf("memory quota must have a limit set")
 	}
 
 	// make sure the memory limit is at least 4K, that is the minimum size

--- a/snap/quota/resources.go
+++ b/snap/quota/resources.go
@@ -25,14 +25,8 @@ import (
 	"github.com/snapcore/snapd/gadget/quantity"
 )
 
-// ResourceMemory is the memory limit for the quota group being controlled,
-// either the initial limit the group is created with for the "create"
-// action, or if non-zero for the "update" the memory limit, then the new
-// value to be set.
+// ResourceMemory is the memory limit for a quota group.
 type ResourceMemory struct {
-	// Lets not set omitempty here, as we want to be able to see the 0 value in
-	// case the memory struct is provided. Remember that we have omitempty set on
-	// the memory value in QuotaResources.
 	Limit quantity.Size `json:"limit"`
 }
 

--- a/snap/quota/resources_test.go
+++ b/snap/quota/resources_test.go
@@ -1,0 +1,62 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package quota_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/gadget/quantity"
+	"github.com/snapcore/snapd/snap/quota"
+)
+
+type resourcesTestSuite struct{}
+
+var _ = Suite(&resourcesTestSuite{})
+
+func (s *resourcesTestSuite) TestQuotaValidation(c *C) {
+	tests := []struct {
+		limits quota.QuotaResources
+		err    string
+	}{
+		{quota.QuotaResources{}, `quota group must have a memory limit set`},
+		{quota.CreateQuotaResources(quantity.Size(0)), `quota group must have a memory limit set`},
+	}
+
+	for _, t := range tests {
+		err := t.limits.Validate()
+		c.Check(err, ErrorMatches, t.err)
+	}
+}
+
+func (s *resourcesTestSuite) TestQuotaChangeValidation(c *C) {
+	tests := []struct {
+		limits       quota.QuotaResources
+		updateLimits quota.QuotaResources
+		err          string
+	}{
+		{quota.CreateQuotaResources(quantity.SizeMiB), quota.QuotaResources{&quota.QuotaResourceMemory{0}}, `cannot remove memory limit from quota group`},
+		{quota.CreateQuotaResources(quantity.SizeMiB), quota.CreateQuotaResources(5 * quantity.SizeKiB), `cannot decrease memory limit, remove and re-create it to decrease the limit`},
+	}
+
+	for _, t := range tests {
+		err := t.limits.Change(t.updateLimits)
+		c.Check(err, ErrorMatches, t.err)
+	}
+}

--- a/snap/quota/resources_test.go
+++ b/snap/quota/resources_test.go
@@ -36,7 +36,7 @@ func (s *resourcesTestSuite) TestQuotaValidation(c *C) {
 		err    string
 	}{
 		{quota.Resources{}, `quota group must have a memory limit set`},
-		{quota.CreateResources(quantity.Size(0)), `quota group must have a memory limit set`},
+		{quota.NewResources(quantity.Size(0)), `quota group must have a memory limit set`},
 	}
 
 	for _, t := range tests {
@@ -51,8 +51,8 @@ func (s *resourcesTestSuite) TestQuotaChangeValidation(c *C) {
 		updateLimits quota.Resources
 		err          string
 	}{
-		{quota.CreateResources(quantity.SizeMiB), quota.Resources{&quota.ResourceMemory{0}}, `cannot remove memory limit from quota group`},
-		{quota.CreateResources(quantity.SizeMiB), quota.CreateResources(5 * quantity.SizeKiB), `cannot decrease memory limit, remove and re-create it to decrease the limit`},
+		{quota.NewResources(quantity.SizeMiB), quota.Resources{&quota.ResourceMemory{0}}, `cannot remove memory limit from quota group`},
+		{quota.NewResources(quantity.SizeMiB), quota.NewResources(5 * quantity.SizeKiB), `cannot decrease memory limit, remove and re-create it to decrease the limit`},
 	}
 
 	for _, t := range tests {

--- a/snap/quota/resources_test.go
+++ b/snap/quota/resources_test.go
@@ -32,11 +32,11 @@ var _ = Suite(&resourcesTestSuite{})
 
 func (s *resourcesTestSuite) TestQuotaValidation(c *C) {
 	tests := []struct {
-		limits quota.QuotaResources
+		limits quota.Resources
 		err    string
 	}{
-		{quota.QuotaResources{}, `quota group must have a memory limit set`},
-		{quota.CreateQuotaResources(quantity.Size(0)), `quota group must have a memory limit set`},
+		{quota.Resources{}, `quota group must have a memory limit set`},
+		{quota.CreateResources(quantity.Size(0)), `quota group must have a memory limit set`},
 	}
 
 	for _, t := range tests {
@@ -47,12 +47,12 @@ func (s *resourcesTestSuite) TestQuotaValidation(c *C) {
 
 func (s *resourcesTestSuite) TestQuotaChangeValidation(c *C) {
 	tests := []struct {
-		limits       quota.QuotaResources
-		updateLimits quota.QuotaResources
+		limits       quota.Resources
+		updateLimits quota.Resources
 		err          string
 	}{
-		{quota.CreateQuotaResources(quantity.SizeMiB), quota.QuotaResources{&quota.QuotaResourceMemory{0}}, `cannot remove memory limit from quota group`},
-		{quota.CreateQuotaResources(quantity.SizeMiB), quota.CreateQuotaResources(5 * quantity.SizeKiB), `cannot decrease memory limit, remove and re-create it to decrease the limit`},
+		{quota.CreateResources(quantity.SizeMiB), quota.Resources{&quota.ResourceMemory{0}}, `cannot remove memory limit from quota group`},
+		{quota.CreateResources(quantity.SizeMiB), quota.CreateResources(5 * quantity.SizeKiB), `cannot decrease memory limit, remove and re-create it to decrease the limit`},
 	}
 
 	for _, t := range tests {

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -219,7 +219,7 @@ func (s *servicesTestSuite) TestEnsureSnapServicesWithQuotas(c *C) {
 	svcFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-snap.svc1.service")
 
 	memLimit := quantity.SizeGiB
-	grp, err := quota.NewGroup("foogroup", quota.CreateQuotaResources(memLimit))
+	grp, err := quota.NewGroup("foogroup", quota.CreateResources(memLimit))
 	c.Assert(err, IsNil)
 
 	m := map[*snap.Info]*wrappers.SnapServiceOptions{
@@ -421,7 +421,7 @@ WantedBy=multi-user.target
 	c.Assert(err, IsNil)
 
 	// use new memory limit
-	grp, err := quota.NewGroup("foogroup", quota.CreateQuotaResources(memLimit2))
+	grp, err := quota.NewGroup("foogroup", quota.CreateResources(memLimit2))
 	c.Assert(err, IsNil)
 
 	m := map[*snap.Info]*wrappers.SnapServiceOptions{
@@ -515,7 +515,7 @@ WantedBy=multi-user.target
 	err = ioutil.WriteFile(svcFile, []byte(svcContent), 0644)
 	c.Assert(err, IsNil)
 
-	grp, err := quota.NewGroup("foogroup", quota.CreateQuotaResources(memLimit))
+	grp, err := quota.NewGroup("foogroup", quota.CreateResources(memLimit))
 	c.Assert(err, IsNil)
 
 	m := map[*snap.Info]*wrappers.SnapServiceOptions{
@@ -538,7 +538,7 @@ WantedBy=multi-user.target
 
 func (s *servicesTestSuite) TestRemoveQuotaGroup(c *C) {
 	// create the group
-	grp, err := quota.NewGroup("foogroup", quota.CreateQuotaResources(5*quantity.SizeKiB))
+	grp, err := quota.NewGroup("foogroup", quota.CreateResources(5*quantity.SizeKiB))
 	c.Assert(err, IsNil)
 
 	sliceFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.foogroup.slice")
@@ -608,12 +608,12 @@ apps:
 	var err error
 	memLimit := quantity.SizeGiB
 	// make a root quota group and add the first snap to it
-	grp, err := quota.NewGroup("foogroup", quota.CreateQuotaResources(memLimit))
+	grp, err := quota.NewGroup("foogroup", quota.CreateResources(memLimit))
 	c.Assert(err, IsNil)
 
 	// the second group is a sub-group with the same limit, but is for the
 	// second snap
-	subgrp, err := grp.NewSubGroup("subgroup", quota.CreateQuotaResources(memLimit))
+	subgrp, err := grp.NewSubGroup("subgroup", quota.CreateResources(memLimit))
 	c.Assert(err, IsNil)
 
 	sliceFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.foogroup.slice")
@@ -741,12 +741,12 @@ func (s *servicesTestSuite) TestEnsureSnapServicesWithSubGroupQuotaGroupsGenerat
 	var err error
 	memLimit := quantity.SizeGiB
 	// make a root quota group without any snaps in it
-	grp, err := quota.NewGroup("foogroup", quota.CreateQuotaResources(memLimit))
+	grp, err := quota.NewGroup("foogroup", quota.CreateResources(memLimit))
 	c.Assert(err, IsNil)
 
 	// the second group is a sub-group with the same limit, but it is the one
 	// with the snap in it
-	subgrp, err := grp.NewSubGroup("subgroup", quota.CreateQuotaResources(memLimit))
+	subgrp, err := grp.NewSubGroup("subgroup", quota.CreateResources(memLimit))
 	c.Assert(err, IsNil)
 
 	sliceFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.foogroup.slice")

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -219,7 +219,7 @@ func (s *servicesTestSuite) TestEnsureSnapServicesWithQuotas(c *C) {
 	svcFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-snap.svc1.service")
 
 	memLimit := quantity.SizeGiB
-	grp, err := quota.NewGroup("foogroup", quota.CreateResources(memLimit))
+	grp, err := quota.NewGroup("foogroup", quota.NewResources(memLimit))
 	c.Assert(err, IsNil)
 
 	m := map[*snap.Info]*wrappers.SnapServiceOptions{
@@ -421,7 +421,7 @@ WantedBy=multi-user.target
 	c.Assert(err, IsNil)
 
 	// use new memory limit
-	grp, err := quota.NewGroup("foogroup", quota.CreateResources(memLimit2))
+	grp, err := quota.NewGroup("foogroup", quota.NewResources(memLimit2))
 	c.Assert(err, IsNil)
 
 	m := map[*snap.Info]*wrappers.SnapServiceOptions{
@@ -515,7 +515,7 @@ WantedBy=multi-user.target
 	err = ioutil.WriteFile(svcFile, []byte(svcContent), 0644)
 	c.Assert(err, IsNil)
 
-	grp, err := quota.NewGroup("foogroup", quota.CreateResources(memLimit))
+	grp, err := quota.NewGroup("foogroup", quota.NewResources(memLimit))
 	c.Assert(err, IsNil)
 
 	m := map[*snap.Info]*wrappers.SnapServiceOptions{
@@ -538,7 +538,7 @@ WantedBy=multi-user.target
 
 func (s *servicesTestSuite) TestRemoveQuotaGroup(c *C) {
 	// create the group
-	grp, err := quota.NewGroup("foogroup", quota.CreateResources(5*quantity.SizeKiB))
+	grp, err := quota.NewGroup("foogroup", quota.NewResources(5*quantity.SizeKiB))
 	c.Assert(err, IsNil)
 
 	sliceFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.foogroup.slice")
@@ -608,12 +608,12 @@ apps:
 	var err error
 	memLimit := quantity.SizeGiB
 	// make a root quota group and add the first snap to it
-	grp, err := quota.NewGroup("foogroup", quota.CreateResources(memLimit))
+	grp, err := quota.NewGroup("foogroup", quota.NewResources(memLimit))
 	c.Assert(err, IsNil)
 
 	// the second group is a sub-group with the same limit, but is for the
 	// second snap
-	subgrp, err := grp.NewSubGroup("subgroup", quota.CreateResources(memLimit))
+	subgrp, err := grp.NewSubGroup("subgroup", quota.NewResources(memLimit))
 	c.Assert(err, IsNil)
 
 	sliceFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.foogroup.slice")
@@ -741,12 +741,12 @@ func (s *servicesTestSuite) TestEnsureSnapServicesWithSubGroupQuotaGroupsGenerat
 	var err error
 	memLimit := quantity.SizeGiB
 	// make a root quota group without any snaps in it
-	grp, err := quota.NewGroup("foogroup", quota.CreateResources(memLimit))
+	grp, err := quota.NewGroup("foogroup", quota.NewResources(memLimit))
 	c.Assert(err, IsNil)
 
 	// the second group is a sub-group with the same limit, but it is the one
 	// with the snap in it
-	subgrp, err := grp.NewSubGroup("subgroup", quota.CreateResources(memLimit))
+	subgrp, err := grp.NewSubGroup("subgroup", quota.NewResources(memLimit))
 	c.Assert(err, IsNil)
 
 	sliceFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.foogroup.slice")

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget/quantity"
+	"github.com/snapcore/snapd/overlord/servicestate/resources"
 
 	// imported to ensure actual interfaces are defined (in production this is guaranteed by ifacestate)
 	_ "github.com/snapcore/snapd/interfaces/builtin"
@@ -219,7 +220,7 @@ func (s *servicesTestSuite) TestEnsureSnapServicesWithQuotas(c *C) {
 	svcFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-snap.svc1.service")
 
 	memLimit := quantity.SizeGiB
-	grp, err := quota.NewGroup("foogroup", memLimit)
+	grp, err := quota.NewGroup("foogroup", resources.CreateQuotaResources(memLimit))
 	c.Assert(err, IsNil)
 
 	m := map[*snap.Info]*wrappers.SnapServiceOptions{
@@ -421,7 +422,7 @@ WantedBy=multi-user.target
 	c.Assert(err, IsNil)
 
 	// use new memory limit
-	grp, err := quota.NewGroup("foogroup", memLimit2)
+	grp, err := quota.NewGroup("foogroup", resources.CreateQuotaResources(memLimit2))
 	c.Assert(err, IsNil)
 
 	m := map[*snap.Info]*wrappers.SnapServiceOptions{
@@ -515,7 +516,7 @@ WantedBy=multi-user.target
 	err = ioutil.WriteFile(svcFile, []byte(svcContent), 0644)
 	c.Assert(err, IsNil)
 
-	grp, err := quota.NewGroup("foogroup", memLimit)
+	grp, err := quota.NewGroup("foogroup", resources.CreateQuotaResources(memLimit))
 	c.Assert(err, IsNil)
 
 	m := map[*snap.Info]*wrappers.SnapServiceOptions{
@@ -538,7 +539,7 @@ WantedBy=multi-user.target
 
 func (s *servicesTestSuite) TestRemoveQuotaGroup(c *C) {
 	// create the group
-	grp, err := quota.NewGroup("foogroup", quantity.SizeKiB)
+	grp, err := quota.NewGroup("foogroup", resources.CreateQuotaResources(5*quantity.SizeKiB))
 	c.Assert(err, IsNil)
 
 	sliceFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.foogroup.slice")
@@ -608,12 +609,12 @@ apps:
 	var err error
 	memLimit := quantity.SizeGiB
 	// make a root quota group and add the first snap to it
-	grp, err := quota.NewGroup("foogroup", memLimit)
+	grp, err := quota.NewGroup("foogroup", resources.CreateQuotaResources(memLimit))
 	c.Assert(err, IsNil)
 
 	// the second group is a sub-group with the same limit, but is for the
 	// second snap
-	subgrp, err := grp.NewSubGroup("subgroup", memLimit)
+	subgrp, err := grp.NewSubGroup("subgroup", resources.CreateQuotaResources(memLimit))
 	c.Assert(err, IsNil)
 
 	sliceFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.foogroup.slice")
@@ -741,12 +742,12 @@ func (s *servicesTestSuite) TestEnsureSnapServicesWithSubGroupQuotaGroupsGenerat
 	var err error
 	memLimit := quantity.SizeGiB
 	// make a root quota group without any snaps in it
-	grp, err := quota.NewGroup("foogroup", memLimit)
+	grp, err := quota.NewGroup("foogroup", resources.CreateQuotaResources(memLimit))
 	c.Assert(err, IsNil)
 
 	// the second group is a sub-group with the same limit, but it is the one
 	// with the snap in it
-	subgrp, err := grp.NewSubGroup("subgroup", memLimit)
+	subgrp, err := grp.NewSubGroup("subgroup", resources.CreateQuotaResources(memLimit))
 	c.Assert(err, IsNil)
 
 	sliceFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.foogroup.slice")

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -33,7 +33,6 @@ import (
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget/quantity"
-	"github.com/snapcore/snapd/overlord/servicestate/resources"
 
 	// imported to ensure actual interfaces are defined (in production this is guaranteed by ifacestate)
 	_ "github.com/snapcore/snapd/interfaces/builtin"
@@ -220,7 +219,7 @@ func (s *servicesTestSuite) TestEnsureSnapServicesWithQuotas(c *C) {
 	svcFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-snap.svc1.service")
 
 	memLimit := quantity.SizeGiB
-	grp, err := quota.NewGroup("foogroup", resources.CreateQuotaResources(memLimit))
+	grp, err := quota.NewGroup("foogroup", quota.CreateQuotaResources(memLimit))
 	c.Assert(err, IsNil)
 
 	m := map[*snap.Info]*wrappers.SnapServiceOptions{
@@ -422,7 +421,7 @@ WantedBy=multi-user.target
 	c.Assert(err, IsNil)
 
 	// use new memory limit
-	grp, err := quota.NewGroup("foogroup", resources.CreateQuotaResources(memLimit2))
+	grp, err := quota.NewGroup("foogroup", quota.CreateQuotaResources(memLimit2))
 	c.Assert(err, IsNil)
 
 	m := map[*snap.Info]*wrappers.SnapServiceOptions{
@@ -516,7 +515,7 @@ WantedBy=multi-user.target
 	err = ioutil.WriteFile(svcFile, []byte(svcContent), 0644)
 	c.Assert(err, IsNil)
 
-	grp, err := quota.NewGroup("foogroup", resources.CreateQuotaResources(memLimit))
+	grp, err := quota.NewGroup("foogroup", quota.CreateQuotaResources(memLimit))
 	c.Assert(err, IsNil)
 
 	m := map[*snap.Info]*wrappers.SnapServiceOptions{
@@ -539,7 +538,7 @@ WantedBy=multi-user.target
 
 func (s *servicesTestSuite) TestRemoveQuotaGroup(c *C) {
 	// create the group
-	grp, err := quota.NewGroup("foogroup", resources.CreateQuotaResources(5*quantity.SizeKiB))
+	grp, err := quota.NewGroup("foogroup", quota.CreateQuotaResources(5*quantity.SizeKiB))
 	c.Assert(err, IsNil)
 
 	sliceFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.foogroup.slice")
@@ -609,12 +608,12 @@ apps:
 	var err error
 	memLimit := quantity.SizeGiB
 	// make a root quota group and add the first snap to it
-	grp, err := quota.NewGroup("foogroup", resources.CreateQuotaResources(memLimit))
+	grp, err := quota.NewGroup("foogroup", quota.CreateQuotaResources(memLimit))
 	c.Assert(err, IsNil)
 
 	// the second group is a sub-group with the same limit, but is for the
 	// second snap
-	subgrp, err := grp.NewSubGroup("subgroup", resources.CreateQuotaResources(memLimit))
+	subgrp, err := grp.NewSubGroup("subgroup", quota.CreateQuotaResources(memLimit))
 	c.Assert(err, IsNil)
 
 	sliceFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.foogroup.slice")
@@ -742,12 +741,12 @@ func (s *servicesTestSuite) TestEnsureSnapServicesWithSubGroupQuotaGroupsGenerat
 	var err error
 	memLimit := quantity.SizeGiB
 	// make a root quota group without any snaps in it
-	grp, err := quota.NewGroup("foogroup", resources.CreateQuotaResources(memLimit))
+	grp, err := quota.NewGroup("foogroup", quota.CreateQuotaResources(memLimit))
 	c.Assert(err, IsNil)
 
 	// the second group is a sub-group with the same limit, but it is the one
 	// with the snap in it
-	subgrp, err := grp.NewSubGroup("subgroup", resources.CreateQuotaResources(memLimit))
+	subgrp, err := grp.NewSubGroup("subgroup", quota.CreateQuotaResources(memLimit))
 	c.Assert(err, IsNil)
 
 	sliceFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.foogroup.slice")


### PR DESCRIPTION
The is the first PR of two for the CPU Quota support for snaps. The PR is about refactoring a part of the current group quota implementation that currently supports the memory limit quota. This quota value is in most cases passed around as a parameter, the goal of this PR is to seperate this value out in a struct and then pass that around as well. This PR seperates the validation logic of quotas as well, and adds some helper functions to handle quotas.

Keep in mind that new quota values will be added in the next PR, and that many changes here will change again. 

overlord/servicestate has it's own type that keeps quota values in resources/quotas.go, I have been very unsure of the namings used in this case, and whether 'resources' was the correct name for that folder, if anyone has better namings please do feel free suggest.