### PR TITLE
cmd/snap: rm unnecessary validation

### DIFF
--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -480,7 +480,7 @@ type cmdInstall struct {
 	IgnoreValidation bool   `long:"ignore-validation"`
 	IgnoreRunning    bool   `long:"ignore-running" hidden:"yes"`
 	Positional       struct {
-		Snaps []remoteSnapName `positional-arg-name:"<snap>"`
+		Snaps []remoteSnapName `positional-arg-name:"<snap>" required:"1"`
 	} `positional-args:"yes" required:"yes"`
 }
 
@@ -628,9 +628,6 @@ func (x *cmdInstall) Execute([]string) error {
 	x.setModes(opts)
 
 	names := remoteSnapNames(x.Positional.Snaps)
-	if len(names) == 0 {
-		return errors.New(i18n.G("cannot install zero snaps"))
-	}
 	for _, name := range names {
 		if len(name) == 0 {
 			return errors.New(i18n.G("cannot install snap with empty name"))

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -2014,7 +2014,8 @@ func (s *SnapOpSuite) TestInstallMany(c *check.C) {
 
 func (s *SnapOpSuite) TestInstallZeroEmpty(c *check.C) {
 	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"install"})
-	c.Assert(err, check.ErrorMatches, "cannot install zero snaps")
+	c.Assert(err, check.Not(check.IsNil))
+	c.Assert(err.Error(), check.Equals, "the required argument `<snap> (at least 1 argument)` was not provided")
 	_, err = snap.Parser(snap.Client()).ParseArgs([]string{"install", ""})
 	c.Assert(err, check.ErrorMatches, "cannot install snap with empty name")
 	_, err = snap.Parser(snap.Client()).ParseArgs([]string{"install", "", "bar"})


### PR DESCRIPTION
This PR removes a validation check for `snap install` since go-flags's validation already covers it. Apparently, if the positional struct contains a slice, the slice field must also have a required tag. I had a look at the other commands and did some testing to see if this happened anywhere else but didn't see other examples of this quirk.