### PR TITLE
tests: fix running tests.invariant on testflinger systems

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -707,6 +707,16 @@ prepare: |
     # The idea is to have a single directory with all the testing tools
     cp -f "$TESTSLIB"/external/snapd-testing-tools/tools/* "$TESTSTOOLS"
 
+    # ensure there are no broken snaps or the invariant test will fail later
+    if command -v snap; then
+        BROKEN="$(snap list --all | awk '/,?broken,?/ {print $1,$3}')"
+        if [ -n "$BROKEN" ]; then
+            echo "Test system has broken snaps:"
+            snap list --all
+            exit 1
+        fi
+    fi
+    
     # NOTE: At this stage the source tree is available and no more special
     # considerations apply.
     "$TESTSLIB"/prepare-restore.sh --prepare-project

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -1228,6 +1228,10 @@ prepare_ubuntu_core() {
 
     # Snapshot the fresh state (including boot/bootenv)
     if ! is_snapd_state_saved; then
+
+        # important to remove disabled snaps before calling save_snapd_state
+        # or restore will break
+        remove_disabled_snaps
         setup_experimental_features
         systemctl stop snapd.service snapd.socket
         save_snapd_state

--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -189,7 +189,7 @@ reset_all_snap() {
     fi
 
     # Exit in case there is a snap in broken state after restoring the snapd state
-    if snap list | grep -E "broken$"; then
+    if snap list --all | grep -E "broken$"; then
         echo "snap in broken state"
         exit 1
     fi

--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -214,11 +214,7 @@ reset_all_snap() {
 # 2021-04-23T20:11:20Z INFO Waiting for automatic snapd restart...
 # snapd 2.49.2 installed
 #
-
-snap list --all | grep disabled | while read -r name _ revision _ ; do
-    snap remove "$name" --revision="$revision"
-done
-
+remove_disabled_snaps
 
 # When the variable REUSE_SNAPD is set to 1, we don't remove and purge snapd.
 # In that case we just cleanup the environment by removing installed snaps as

--- a/tests/lib/state.sh
+++ b/tests/lib/state.sh
@@ -131,3 +131,9 @@ restore_snapd_lib() {
     fi
     rsync -av --delete "$SNAPD_STATE_PATH"/snapd-lib/cache /var/lib/snapd
 }
+
+remove_disabled_snaps() {
+    snap list --all | grep disabled | while read -r name _ revision _ ; do
+        snap remove "$name" --revision="$revision"
+    done
+}

--- a/tests/lib/tools/tests.invariant
+++ b/tests/lib/tools/tests.invariant
@@ -126,11 +126,12 @@ check_leftover_defer_sh() {
 check_broken_snaps() {
 	n="$1" # invariant name
 	(
-		# fist column is the snap name, revision is 3rd
+		SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
+		# first column is the snap name, revision is 3rd
 		snap list --all | awk '/,?broken,?/ {print $1,$3}' | while read -r name rev; do
 			echo "snap $name ($rev) is broken:"
-			systemctl status "snap-${name}-${rev}.mount" || true
-			ls -l "/snap/${name}/" || true
+			systemctl status "$(systemd-escape -p "$SNAP_MOUNT_DIR/${name}/${rev}).mount")" || true
+			ls -l "/${SNAP_MOUNT_DIR}/${name}/" || true
 			echo "---"
 		done
 	) > "$TESTSTMP/tests.invariant.$n"

--- a/tests/lib/tools/tests.invariant
+++ b/tests/lib/tools/tests.invariant
@@ -128,7 +128,10 @@ check_broken_snaps() {
 	(
 		# fist column is the snap name, revision is 3rd
 		snap list --all | awk '/,?broken,?/ {print $1,$3}' | while read -r name rev; do
-			echo "snap $name ($rev) is broken"
+			echo "snap $name ($rev) is broken:"
+			systemctl status "snap-${name}-${rev}.mount" || true
+			ls -l "/snap/${name}/" || true
+			echo "---"
 		done
 	) > "$TESTSTMP/tests.invariant.$n"
 	if [ -s "$TESTSTMP/tests.invariant.$n" ]; then


### PR DESCRIPTION
The reset_all_snaps code will get confused if the state contains
disabled snaps. The reason is that importing `reset.sh` will remove
all disabled snaps first. Then the `reset_all_snaps` will call
`restore_snapd_state` which will restore the state and the snaps
but the mount unit of the removed snaps are not re-started so
the snap appears to be broken.

This happens on e.g. the external testflinger devices when the
device starts with a stable core20, then refreshes to a core20
from beta. In that configuration the `tests.invariant` test will
detect a broken core20 revision because of the above behavior.

There are various ways to fix this, the easiest is to just start
with a snapd state that contains no disabled snaps on core systems.

The second commit also adds more debug code around the invariant
detection. I can remove this or move into a separate PR is wanted.
