### PR TITLE
snap: cpu quota support through --cpu, --cpu-set and --thread

### DIFF
--- a/client/quota.go
+++ b/client/quota.go
@@ -44,8 +44,16 @@ type QuotaGroupResult struct {
 	Current     *QuotaValues `json:"current,omitempty"`
 }
 
+type QuotaCpuValues struct {
+	Count       int   `json:"count,omitempty"`
+	Percentage  int   `json:"percentage,omitempty"`
+	AllowedCpus []int `json:"allowed-cpus,omitempty"`
+}
+
 type QuotaValues struct {
-	Memory quantity.Size `json:"memory,omitempty"`
+	Memory  quantity.Size   `json:"memory,omitempty"`
+	Cpu     *QuotaCpuValues `json:"cpu,omitempty"`
+	Threads int             `json:"threads,omitempty"`
 }
 
 // EnsureQuota creates a quota group or updates an existing group.

--- a/client/quota_test.go
+++ b/client/quota_test.go
@@ -44,7 +44,17 @@ func (cs *clientSuite) TestEnsureQuotaGroup(c *check.C) {
 		"change": "42"
 	}`
 
-	chgID, err := cs.cli.EnsureQuota("foo", "bar", []string{"snap-a", "snap-b"}, &client.QuotaValues{Memory: quantity.Size(1001)})
+	quotaValues := &client.QuotaValues{
+		Memory: quantity.Size(1001),
+		Cpu: &client.QuotaCpuValues{
+			Count:       1,
+			Percentage:  50,
+			AllowedCpus: []int{0},
+		},
+		Threads: 32,
+	}
+
+	chgID, err := cs.cli.EnsureQuota("foo", "bar", []string{"snap-a", "snap-b"}, quotaValues)
 	c.Assert(err, check.IsNil)
 	c.Assert(chgID, check.Equals, "42")
 	c.Check(cs.req.Method, check.Equals, "POST")

--- a/client/quota_test.go
+++ b/client/quota_test.go
@@ -71,6 +71,12 @@ func (cs *clientSuite) TestEnsureQuotaGroup(c *check.C) {
 		"snaps":      []interface{}{"snap-a", "snap-b"},
 		"constraints": map[string]interface{}{
 			"memory": json.Number("1001"),
+			"cpu": map[string]interface{}{
+				"count":        json.Number("1"),
+				"percentage":   json.Number("50"),
+				"allowed-cpus": []interface{}{json.Number("0")},
+			},
+			"threads": json.Number("32"),
 		},
 	})
 }

--- a/cmd/snap/cmd_quota.go
+++ b/cmd/snap/cmd_quota.go
@@ -339,8 +339,10 @@ func (x *cmdQuota) Execute(args []string) (err error) {
 
 	fmt.Fprintf(w, "constraints:\n")
 
-	val := strings.TrimSpace(fmtSize(int64(group.Constraints.Memory)))
-	fmt.Fprintf(w, "  memory:\t%s\n", val)
+	if group.Constraints.Memory != 0 {
+		val := strings.TrimSpace(fmtSize(int64(group.Constraints.Memory)))
+		fmt.Fprintf(w, "  memory:\t%s\n", val)
+	}
 	if group.Constraints.Cpu != nil {
 		fmt.Fprintf(w, "  cpu-count:\t%d\n", group.Constraints.Cpu.Count)
 		fmt.Fprintf(w, "  cpu-percentage:\t%d\n", group.Constraints.Cpu.Percentage)
@@ -350,7 +352,9 @@ func (x *cmdQuota) Execute(args []string) (err error) {
 			fmt.Fprintf(w, "  allowed-cpus:\t%s\n", allowedCpus)
 		}
 	}
-	fmt.Fprintf(w, "  threads:\t%d\n", group.Constraints.Threads)
+	if group.Constraints.Threads != 0 {
+		fmt.Fprintf(w, "  threads:\t%d\n", group.Constraints.Threads)
+	}
 
 	var memoryUsage string = "0B"
 	var currentThreads int = 0
@@ -360,8 +364,12 @@ func (x *cmdQuota) Execute(args []string) (err error) {
 	}
 
 	fmt.Fprintf(w, "current:\n")
-	fmt.Fprintf(w, "  memory:\t%s\n", memoryUsage)
-	fmt.Fprintf(w, "  threads:\t%d\n", currentThreads)
+	if group.Constraints.Memory != 0 {
+		fmt.Fprintf(w, "  memory:\t%s\n", memoryUsage)
+	}
+	if group.Constraints.Threads != 0 {
+		fmt.Fprintf(w, "  threads:\t%d\n", currentThreads)
+	}
 
 	if len(group.Subgroups) > 0 {
 		fmt.Fprint(w, "subgroups:\n")
@@ -459,7 +467,7 @@ func (x *cmdQuotas) Execute(args []string) (err error) {
 			if q.Current.Memory != 0 {
 				grpCurrent = append(grpCurrent, "memory="+strings.TrimSpace(fmtSize(int64(q.Current.Memory))))
 			}
-			if q.Current.Threads != 0 {
+			if q.Constraints.Threads != 0 && q.Current.Threads != 0 {
 				grpCurrent = append(grpCurrent, "thread="+fmt.Sprintf("%d", q.Current.Threads))
 			}
 		}

--- a/cmd/snap/cmd_quota.go
+++ b/cmd/snap/cmd_quota.go
@@ -350,6 +350,7 @@ func (x *cmdQuota) Execute(args []string) (err error) {
 			fmt.Fprintf(w, "  allowed-cpus:\t%s\n", allowedCpus)
 		}
 	}
+	fmt.Fprintf(w, "  threads:\t%d\n", group.Constraints.Threads)
 
 	var memoryUsage string = "0B"
 	var currentThreads int = 0

--- a/cmd/snap/cmd_quota.go
+++ b/cmd/snap/cmd_quota.go
@@ -131,8 +131,8 @@ func parseCpuQuota(cpuMax string) (int, int, error) {
 	}
 
 	// Detect whether format was NxM% or M%
-	if len(match) == 2 {
-		percentage, err := strconv.Atoi(match[1])
+	if len(match[1]) == 0 {
+		percentage, err := strconv.Atoi(match[2])
 		if err != nil || percentage == 0 {
 			return 0, 0, fmt.Errorf("invalid cpu quota value specified for --cpu")
 		}

--- a/cmd/snap/cmd_quota.go
+++ b/cmd/snap/cmd_quota.go
@@ -22,7 +22,6 @@ package main
 import (
 	"fmt"
 	"regexp"
-	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -182,7 +181,7 @@ func parseQuotas(maxMemory string, cpuMax string, cpuSet string, threadMax strin
 	if cpuSet != "" {
 		cgv, err := getCGroupVersion()
 		if err != nil {
-			return nil, fmt.Errorf("cgroup v2 is required for --cpu-set: %v", err)
+			return nil, err
 		}
 		if cgv < 2 {
 			return nil, fmt.Errorf("cannot use --cpu-set with cgroup version %d", cgv)
@@ -194,8 +193,8 @@ func parseQuotas(maxMemory string, cpuMax string, cpuSet string, threadMax strin
 			if err != nil {
 				return nil, fmt.Errorf("cannot parse value for --cpu-set at position %d", i)
 			}
-			if cpu < 0 || cpu >= runtime.NumCPU() {
-				return nil, fmt.Errorf("invalid cpu number %d in --cpu-set", cpu)
+			if cpu < 0 {
+				return nil, fmt.Errorf("cannot use a negative CPU number in --cpu-set")
 			}
 			allowedCpus = append(allowedCpus, cpu)
 		}

--- a/cmd/snap/cmd_quota.go
+++ b/cmd/snap/cmd_quota.go
@@ -426,7 +426,7 @@ func (x *cmdQuotas) Execute(args []string) (err error) {
 
 		var grpConstraintsBuffer bytes.Buffer
 		var addComma bool
-		writeConstraint := func(buffer bytes.Buffer, message string) {
+		writeConstraint := func(buffer *bytes.Buffer, message string) {
 			if addComma {
 				buffer.WriteString(",")
 			}
@@ -436,13 +436,13 @@ func (x *cmdQuotas) Execute(args []string) (err error) {
 
 		// format memory constraint as memory=N
 		if q.Constraints.Memory != 0 {
-			writeConstraint(grpConstraintsBuffer, "memory="+strings.TrimSpace(fmtSize(int64(q.Constraints.Memory))))
+			writeConstraint(&grpConstraintsBuffer, "memory="+strings.TrimSpace(fmtSize(int64(q.Constraints.Memory))))
 		}
 
 		// format cpu constraint as cpu=NxM%,allowed-cpus=x,y,z
 		if q.Constraints.Cpu != nil {
 			if q.Constraints.Cpu.Count != 0 || q.Constraints.Cpu.Percentage != 0 {
-				writeConstraint(grpConstraintsBuffer, "cpu=")
+				writeConstraint(&grpConstraintsBuffer, "cpu=")
 				if q.Constraints.Cpu.Count != 0 {
 					grpConstraintsBuffer.WriteString(fmt.Sprintf("%dx", q.Constraints.Cpu.Count))
 				}
@@ -453,13 +453,13 @@ func (x *cmdQuotas) Execute(args []string) (err error) {
 
 			if len(q.Constraints.Cpu.AllowedCpus) > 0 {
 				allowedCpus := strings.Trim(strings.Join(strings.Fields(fmt.Sprint(q.Constraints.Cpu.AllowedCpus)), ","), "[]")
-				writeConstraint(grpConstraintsBuffer, "allowed-cpus="+allowedCpus)
+				writeConstraint(&grpConstraintsBuffer, "allowed-cpus="+allowedCpus)
 			}
 		}
 
 		// format threads constraint as thread=N
 		if q.Constraints.Threads != 0 {
-			writeConstraint(grpConstraintsBuffer, "thread="+strconv.Itoa(q.Constraints.Threads))
+			writeConstraint(&grpConstraintsBuffer, "thread="+strconv.Itoa(q.Constraints.Threads))
 		}
 
 		// format current resource values as memory=N,thread=N
@@ -468,10 +468,10 @@ func (x *cmdQuotas) Execute(args []string) (err error) {
 		var grpCurrentBuffer bytes.Buffer
 		if q.Current != nil {
 			if q.Current.Memory != 0 {
-				writeConstraint(grpCurrentBuffer, "memory="+strings.TrimSpace(fmtSize(int64(q.Current.Memory))))
+				writeConstraint(&grpCurrentBuffer, "memory="+strings.TrimSpace(fmtSize(int64(q.Current.Memory))))
 			}
 			if q.Current.Threads != 0 {
-				writeConstraint(grpCurrentBuffer, "thread="+fmt.Sprintf("%d", q.Current.Threads))
+				writeConstraint(&grpCurrentBuffer, "thread="+fmt.Sprintf("%d", q.Current.Threads))
 			}
 		}
 

--- a/cmd/snap/cmd_quota_test.go
+++ b/cmd/snap/cmd_quota_test.go
@@ -248,7 +248,8 @@ func (s *quotaSuite) TestGetQuotaGroup(c *check.C) {
 name:    foo
 parent:  bar
 constraints:
-  memory:  1000B
+  memory:   1000B
+  threads:  0
 current:
   memory:   900B
   threads:  0
@@ -279,7 +280,8 @@ func (s *quotaSuite) TestGetMemoryQuotaGroupSimple(c *check.C) {
 	outputTemplate := `
 name:  foo
 constraints:
-  memory:  1000B
+  memory:   1000B
+  threads:  0
 current:
   memory:   %dB
   threads:  0
@@ -326,6 +328,7 @@ constraints:
   cpu-count:       1
   cpu-percentage:  50
   allowed-cpus:    0,1
+  threads:         32
 current:
   memory:   0B
   threads:  %d

--- a/cmd/snap/cmd_quota_test.go
+++ b/cmd/snap/cmd_quota_test.go
@@ -245,19 +245,19 @@ func (s *quotaSuite) TestGetQuotaGroup(c *check.C) {
 	c.Check(rest, check.HasLen, 0)
 	c.Check(s.Stderr(), check.Equals, "")
 	c.Check(s.Stdout(), check.Equals, `
- name:    foo
- parent:  bar
- constraints:
-   memory:  1000B
- current:
-   memory:   900B
-   threads:  0
- subgroups:
-   - subgrp1
- snaps:
-   - snap-a
-   - snap-b
- `[1:])
+name:    foo
+parent:  bar
+constraints:
+  memory:  1000B
+current:
+  memory:   900B
+  threads:  0
+subgroups:
+  - subgrp1
+snaps:
+  - snap-a
+  - snap-b
+`[1:])
 }
 
 func (s *quotaSuite) TestGetQuotaGroupSimple(c *check.C) {
@@ -277,13 +277,13 @@ func (s *quotaSuite) TestGetQuotaGroupSimple(c *check.C) {
 	s.RedirectClientToTestServer(makeFakeGetQuotaGroupHandler(c, fmt.Sprintf(jsonTemplate, 0)))
 
 	outputTemplate := `
- name:  foo
- constraints:
-   memory:  1000B
- current:
-   memory:   %dB
-   threads:  0
- `[1:]
+name:  foo
+constraints:
+  memory:  1000B
+current:
+  memory:   %dB
+  threads:  0
+`[1:]
 
 	rest, err := main.Parser(main.Client()).ParseArgs([]string{"quota", "foo"})
 	c.Assert(err, check.IsNil)
@@ -341,7 +341,7 @@ func (s *quotaSuite) TestSetQuotaGroupUpdateExistingUnhappy(c *check.C) {
 
 func (s *quotaSuite) TestSetQuotaGroupCreateNewUnhappy(c *check.C) {
 	const exists = false
-	s.testSetQuotaGroupUpdateExistingUnhappy(c, "cannot create quota group without any quotas", exists)
+	s.testSetQuotaGroupUpdateExistingUnhappy(c, "cannot create quota group without any limit", exists)
 }
 
 func (s *quotaSuite) TestSetQuotaGroupCreateNewUnhappyWithParent(c *check.C) {
@@ -494,16 +494,16 @@ func (s *quotaSuite) TestGetAllQuotaGroups(c *check.C) {
 	c.Check(rest, check.HasLen, 0)
 	c.Check(s.Stderr(), check.Equals, "")
 	c.Check(s.Stdout(), check.Equals, `
- Quota    Parent  Constraints   Current
- xxx              memory=9.9kB  memory=10.0kB
- yyyyyyy          memory=1000B  
- zzz              memory=5000B  
- aaa      zzz     memory=1000B  
- ccc      aaa     memory=400B   
- ddd      aaa     memory=400B   
- fff      aaa     memory=1000B  
- bbb      zzz     memory=1000B  memory=400B
- `[1:])
+Quota    Parent  Constraints   Current
+xxx              memory=9.9kB  memory=10.0kB
+yyyyyyy          memory=1000B  
+zzz              memory=5000B  
+aaa      zzz     memory=1000B  
+ccc      aaa     memory=400B   
+ddd      aaa     memory=400B   
+fff      aaa     memory=1000B  
+bbb      zzz     memory=1000B  memory=400B
+`[1:])
 }
 
 func (s *quotaSuite) TestGetAllQuotaGroupsInconsistencyError(c *check.C) {

--- a/cmd/snap/cmd_quota_test.go
+++ b/cmd/snap/cmd_quota_test.go
@@ -248,11 +248,9 @@ func (s *quotaSuite) TestGetQuotaGroup(c *check.C) {
 name:    foo
 parent:  bar
 constraints:
-  memory:   1000B
-  threads:  0
+  memory:  1000B
 current:
-  memory:   900B
-  threads:  0
+  memory:  900B
 subgroups:
   - subgrp1
 snaps:
@@ -280,11 +278,9 @@ func (s *quotaSuite) TestGetMemoryQuotaGroupSimple(c *check.C) {
 	outputTemplate := `
 name:  foo
 constraints:
-  memory:   1000B
-  threads:  0
+  memory:  1000B
 current:
-  memory:   %dB
-  threads:  0
+  memory:  %dB
 `[1:]
 
 	rest, err := main.Parser(main.Client()).ParseArgs([]string{"quota", "foo"})
@@ -324,13 +320,11 @@ func (s *quotaSuite) TestGetCpuQuotaGroupSimple(c *check.C) {
 	outputTemplate := `
 name:  foo
 constraints:
-  memory:          0B
   cpu-count:       1
   cpu-percentage:  50
   allowed-cpus:    0,1
   threads:         32
 current:
-  memory:   0B
   threads:  %d
 `[1:]
 

--- a/cmd/snap/cmd_quota_test.go
+++ b/cmd/snap/cmd_quota_test.go
@@ -43,13 +43,13 @@ func makeFakeGetQuotaGroupNotFoundHandler(c *check.C, group string) func(w http.
 		c.Check(r.Method, check.Equals, "GET")
 		w.WriteHeader(404)
 		fmt.Fprintln(w, `{
-			 "result": {
-				 "message": "not found"
-			 },
-			 "status": "Not Found",
-			 "status-code": 404,
-			 "type": "error"
-		 }`)
+			"result": {
+				"message": "not found"
+			},
+			"status": "Not Found",
+			"status-code": 404,
+			"type": "error"
+		}`)
 	}
 
 }
@@ -226,17 +226,17 @@ func (s *quotaSuite) TestGetQuotaGroup(c *check.C) {
 	defer restore()
 
 	const json = `{
-		 "type": "sync",
-		 "status-code": 200,
-		 "result": {
-			 "group-name":"foo",
-			 "parent":"bar",
-			 "subgroups":["subgrp1"],
-			 "snaps":["snap-a","snap-b"],
-			 "constraints": { "memory": 1000 },
-			 "current": { "memory": 900 }
-		 }
-	 }`
+		"type": "sync",
+		"status-code": 200,
+		"result": {
+			"group-name":"foo",
+			"parent":"bar",
+			"subgroups":["subgrp1"],
+			"snaps":["snap-a","snap-b"],
+			"constraints": { "memory": 1000 },
+			"current": { "memory": 900 }
+		}
+	}`
 
 	s.RedirectClientToTestServer(makeFakeGetQuotaGroupHandler(c, json))
 
@@ -265,14 +265,14 @@ func (s *quotaSuite) TestGetQuotaGroupSimple(c *check.C) {
 	defer restore()
 
 	const jsonTemplate = `{
-		 "type": "sync",
-		 "status-code": 200,
-		 "result": {
-			 "group-name": "foo",
-			 "constraints": {"memory": 1000},
-			 "current": {"memory": %d}
-		 }
-	 }`
+		"type": "sync",
+		"status-code": 200,
+		"result": {
+			"group-name": "foo",
+			"constraints": {"memory": 1000},
+			"current": {"memory": %d}
+		}
+	}`
 
 	s.RedirectClientToTestServer(makeFakeGetQuotaGroupHandler(c, fmt.Sprintf(jsonTemplate, 0)))
 
@@ -358,18 +358,18 @@ func (s *quotaSuite) testSetQuotaGroupUpdateExistingUnhappy(c *check.C, errPatte
 	if exists {
 		// existing group has 1000 memory limit
 		const getJson = `{
-			 "type": "sync",
-			 "status-code": 200,
-			 "result": {
-				 "group-name":"foo",
-				 "current": {
-					 "memory": 500
-				 },
-				 "constraints": {
-					 "memory": 1000
-				 }
-			 }
-		 }`
+			"type": "sync",
+			"status-code": 200,
+			"result": {
+				"group-name":"foo",
+				"current": {
+					"memory": 500
+				},
+				"constraints": {
+					"memory": 1000
+				}
+			}
+		}`
 
 		s.RedirectClientToTestServer(makeFakeGetQuotaGroupHandler(c, getJson))
 	} else {
@@ -392,14 +392,14 @@ func (s *quotaSuite) TestSetQuotaGroupUpdateExisting(c *check.C) {
 	}
 
 	const getJsonTemplate = `{
-		 "type": "sync",
-		 "status-code": 200,
-		 "result": {
-			 "group-name":"foo",
-			 "constraints": { "memory": %d },
-			 "current": { "memory": 500 }
-		 }
-	 }`
+		"type": "sync",
+		"status-code": 200,
+		"result": {
+			"group-name":"foo",
+			"constraints": { "memory": %d },
+			"current": { "memory": 500 }
+		}
+	}`
 
 	routes := map[string]http.HandlerFunc{
 		"/v2/quotas": makeFakeQuotaPostHandler(
@@ -479,15 +479,15 @@ func (s *quotaSuite) TestGetAllQuotaGroups(c *check.C) {
 
 	s.RedirectClientToTestServer(makeFakeGetQuotaGroupsHandler(c,
 		`{"type": "sync", "status-code": 200, "result": [
-			 {"group-name":"aaa","subgroups":["ccc","ddd","fff"],"parent":"zzz","constraints":{"memory":1000}},
-			 {"group-name":"ddd","parent":"aaa","constraints":{"memory":400}},
-			 {"group-name":"bbb","parent":"zzz","constraints":{"memory":1000},"current":{"memory":400}},
-			 {"group-name":"yyyyyyy","constraints":{"memory":1000}},
-			 {"group-name":"zzz","subgroups":["bbb","aaa"],"constraints":{"memory":5000}},
-			 {"group-name":"ccc","parent":"aaa","constraints":{"memory":400}},
-			 {"group-name":"fff","parent":"aaa","constraints":{"memory":1000},"current":{"memory":0}},
-			 {"group-name":"xxx","constraints":{"memory":9900},"current":{"memory":10000}}
-			 ]}`))
+			{"group-name":"aaa","subgroups":["ccc","ddd","fff"],"parent":"zzz","constraints":{"memory":1000}},
+			{"group-name":"ddd","parent":"aaa","constraints":{"memory":400}},
+			{"group-name":"bbb","parent":"zzz","constraints":{"memory":1000},"current":{"memory":400}},
+			{"group-name":"yyyyyyy","constraints":{"memory":1000}},
+			{"group-name":"zzz","subgroups":["bbb","aaa"],"constraints":{"memory":5000}},
+			{"group-name":"ccc","parent":"aaa","constraints":{"memory":400}},
+			{"group-name":"fff","parent":"aaa","constraints":{"memory":1000},"current":{"memory":0}},
+			{"group-name":"xxx","constraints":{"memory":9900},"current":{"memory":10000}}
+			]}`))
 
 	rest, err := main.Parser(main.Client()).ParseArgs([]string{"quotas"})
 	c.Assert(err, check.IsNil)
@@ -512,7 +512,7 @@ func (s *quotaSuite) TestGetAllQuotaGroupsInconsistencyError(c *check.C) {
 
 	s.RedirectClientToTestServer(makeFakeGetQuotaGroupsHandler(c,
 		`{"type": "sync", "status-code": 200, "result": [
-			 {"group-name":"aaa","subgroups":["ccc"],"max-memory":1000}]}`))
+			{"group-name":"aaa","subgroups":["ccc"],"max-memory":1000}]}`))
 
 	_, err := main.Parser(main.Client()).ParseArgs([]string{"quotas"})
 	c.Assert(err, check.ErrorMatches, `internal error: inconsistent groups received, unknown subgroup "ccc"`)

--- a/cmd/snap/export_cmd_quota_test.go
+++ b/cmd/snap/export_cmd_quota_test.go
@@ -1,0 +1,28 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+func MockGetCGroupVersion(f func() (int, error)) (restore func()) {
+	old := getCGroupVersion
+	getCGroupVersion = f
+	return func() {
+		getCGroupVersion = old
+	}
+}

--- a/daemon/api_quotas.go
+++ b/daemon/api_quotas.go
@@ -172,27 +172,10 @@ func getQuotaGroupInfo(c *Command, r *http.Request, _ *auth.UserState) Response 
 }
 
 func quotaValuesToResources(values client.QuotaValues) quota.Resources {
-	var quotaResources quota.Resources
-	if values.Memory != 0 {
-		quotaResources.Memory = &quota.ResourceMemory{
-			Limit: values.Memory,
-		}
-	}
-
 	if values.Cpu != nil {
-		quotaResources.Cpu = &quota.ResourceCpu{
-			Count:       values.Cpu.Count,
-			Percentage:  values.Cpu.Percentage,
-			AllowedCpus: values.Cpu.AllowedCpus,
-		}
+		return quota.NewResources(values.Memory, values.Cpu.Count, values.Cpu.Percentage, values.Cpu.AllowedCpus, values.Threads)
 	}
-
-	if values.Threads != 0 {
-		quotaResources.Thread = &quota.ResourceThreads{
-			Limit: values.Threads,
-		}
-	}
-	return quotaResources
+	return quota.NewResources(values.Memory, 0, 0, nil, values.Threads)
 }
 
 // postQuotaGroup creates quota resource group or updates an existing group.

--- a/daemon/api_quotas.go
+++ b/daemon/api_quotas.go
@@ -180,7 +180,7 @@ func quotaValuesToResources(values client.QuotaValues) quota.Resources {
 	}
 
 	if values.Cpu != nil {
-		quotaResources.Cpu = &resources.QuotaResourceCpu{
+		quotaResources.Cpu = &quota.ResourceCpu{
 			Count:       values.Cpu.Count,
 			Percentage:  values.Cpu.Percentage,
 			AllowedCpus: values.Cpu.AllowedCpus,
@@ -188,8 +188,8 @@ func quotaValuesToResources(values client.QuotaValues) quota.Resources {
 	}
 
 	if values.Threads != 0 {
-		quotaResources.Thread = &resources.QuotaResourceThreads{
-			ThreadLimit: values.Threads,
+		quotaResources.Thread = &quota.ResourceThreads{
+			Limit: values.Threads,
 		}
 	}
 	return quotaResources

--- a/daemon/api_quotas.go
+++ b/daemon/api_quotas.go
@@ -65,17 +65,21 @@ var (
 var getQuotaUsage = func(grp *quota.Group) (*client.QuotaValues, error) {
 	var currentUsage client.QuotaValues
 
-	mem, err := grp.CurrentMemoryUsage()
-	if err != nil {
-		return nil, err
+	if grp.MemoryLimit != 0 {
+		mem, err := grp.CurrentMemoryUsage()
+		if err != nil {
+			return nil, err
+		}
+		currentUsage.Memory = mem
 	}
-	currentUsage.Memory = mem
 
-	threads, err := grp.CurrentTaskUsage()
-	if err != nil {
-		return nil, err
+	if grp.TaskLimit != 0 {
+		threads, err := grp.CurrentTaskUsage()
+		if err != nil {
+			return nil, err
+		}
+		currentUsage.Threads = threads
 	}
-	currentUsage.Threads = threads
 
 	return &currentUsage, nil
 }

--- a/daemon/api_quotas.go
+++ b/daemon/api_quotas.go
@@ -182,9 +182,15 @@ func quotaValuesToResources(values client.QuotaValues) quota.Resources {
 		resourcesBuilder.WithMemoryLimit(values.Memory)
 	}
 	if values.Cpu != nil {
-		resourcesBuilder.WithCPUCount(values.Cpu.Count)
-		resourcesBuilder.WithCPUPercentage(values.Cpu.Percentage)
-		resourcesBuilder.WithAllowedCPUs(values.Cpu.AllowedCpus)
+		if values.Cpu.Count != 0 {
+			resourcesBuilder.WithCPUCount(values.Cpu.Count)
+		}
+		if values.Cpu.Percentage != 0 {
+			resourcesBuilder.WithCPUPercentage(values.Cpu.Percentage)
+		}
+		if len(values.Cpu.AllowedCpus) != 0 {
+			resourcesBuilder.WithAllowedCPUs(values.Cpu.AllowedCpus)
+		}
 	}
 	if values.Threads != 0 {
 		resourcesBuilder.WithThreadLimit(values.Threads)

--- a/daemon/api_quotas.go
+++ b/daemon/api_quotas.go
@@ -176,10 +176,20 @@ func getQuotaGroupInfo(c *Command, r *http.Request, _ *auth.UserState) Response 
 }
 
 func quotaValuesToResources(values client.QuotaValues) quota.Resources {
-	if values.Cpu != nil {
-		return quota.NewResources(values.Memory, values.Cpu.Count, values.Cpu.Percentage, values.Cpu.AllowedCpus, values.Threads)
+	resourcesBuilder := quota.NewResourcesBuilder()
+
+	if values.Memory != 0 {
+		resourcesBuilder.WithMemoryLimit(values.Memory)
 	}
-	return quota.NewResources(values.Memory, 0, 0, nil, values.Threads)
+	if values.Cpu != nil {
+		resourcesBuilder.WithCPUCount(values.Cpu.Count)
+		resourcesBuilder.WithCPUPercentage(values.Cpu.Percentage)
+		resourcesBuilder.WithAllowedCPUs(values.Cpu.AllowedCpus)
+	}
+	if values.Threads != 0 {
+		resourcesBuilder.WithThreadLimit(values.Threads)
+	}
+	return resourcesBuilder.Build()
 }
 
 // postQuotaGroup creates quota resource group or updates an existing group.

--- a/daemon/api_quotas_test.go
+++ b/daemon/api_quotas_test.go
@@ -242,11 +242,11 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaCreateQuotaConflicts(c *check.C) {
 func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateCpuHappy(c *check.C) {
 	st := s.d.Overlord().State()
 	st.Lock()
-	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", nil, resources.CreateQuotaResources(5000, 1, 100, nil, 256))
+	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", nil, quota.NewResources(5000, 1, 100, nil, 256))
 	st.Unlock()
 	c.Assert(err, check.IsNil)
 
-	r := daemon.MockServicestateCreateQuota(func(st *state.State, name string, parentName string, snaps []string, resourceLimits resources.QuotaResources) (*state.TaskSet, error) {
+	r := daemon.MockServicestateCreateQuota(func(st *state.State, name string, parentName string, snaps []string, resourceLimits quota.Resources) (*state.TaskSet, error) {
 		c.Errorf("should not have called create quota")
 		return nil, fmt.Errorf("broken test")
 	})
@@ -258,7 +258,7 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateCpuHappy(c *check.C) {
 		c.Assert(name, check.Equals, "ginger-ale")
 		c.Assert(opts, check.DeepEquals, servicestate.QuotaGroupUpdate{
 			AddSnaps:          []string{"some-snap"},
-			NewResourceLimits: resources.CreateQuotaResources(0, 2, 100, nil, 512),
+			NewResourceLimits: quota.NewResources(0, 2, 100, nil, 512),
 		})
 		ts := state.NewTaskSet(st.NewTask("foo-quota", "..."))
 		return ts, nil
@@ -338,11 +338,11 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateCpu2Happy(c *check.C) {
 func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateMemoryHappy(c *check.C) {
 	st := s.d.Overlord().State()
 	st.Lock()
-	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", nil, resources.CreateQuotaResources(5000, 1, 100, nil, 256))
+	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", nil, quota.NewResources(5000, 1, 100, nil, 256))
 	st.Unlock()
 	c.Assert(err, check.IsNil)
 
-	r := daemon.MockServicestateCreateQuota(func(st *state.State, name string, parentName string, snaps []string, resourceLimits resources.QuotaResources) (*state.TaskSet, error) {
+	r := daemon.MockServicestateCreateQuota(func(st *state.State, name string, parentName string, snaps []string, resourceLimits quota.Resources) (*state.TaskSet, error) {
 		c.Errorf("should not have called create quota")
 		return nil, fmt.Errorf("broken test")
 	})
@@ -354,7 +354,7 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateMemoryHappy(c *check.C) {
 		c.Assert(name, check.Equals, "ginger-ale")
 		c.Assert(opts, check.DeepEquals, servicestate.QuotaGroupUpdate{
 			AddSnaps:          []string{"some-snap"},
-			NewResourceLimits: resources.CreateQuotaResources(9000, 0, 0, nil, 0),
+			NewResourceLimits: quota.NewResources(9000, 0, 0, nil, 0),
 		})
 		ts := state.NewTaskSet(st.NewTask("foo-quota", "..."))
 		return ts, nil

--- a/overlord/configstate/configcore/vitality_test.go
+++ b/overlord/configstate/configcore/vitality_test.go
@@ -196,7 +196,7 @@ func (s *vitalitySuite) TestConfigureVitalityWithQuotaGroup(c *C) {
 	tr.Commit()
 
 	// make a new quota group with this snap in it
-	err := servicestatetest.MockQuotaInState(s.state, "foogroup", "", []string{"test-snap"}, quota.NewResources(quantity.SizeMiB, 0, 0, nil, 0))
+	err := servicestatetest.MockQuotaInState(s.state, "foogroup", "", []string{"test-snap"}, quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build())
 	c.Assert(err, IsNil)
 
 	s.state.Unlock()

--- a/overlord/configstate/configcore/vitality_test.go
+++ b/overlord/configstate/configcore/vitality_test.go
@@ -196,7 +196,7 @@ func (s *vitalitySuite) TestConfigureVitalityWithQuotaGroup(c *C) {
 	tr.Commit()
 
 	// make a new quota group with this snap in it
-	err := servicestatetest.MockQuotaInState(s.state, "foogroup", "", []string{"test-snap"}, quota.NewResources(quantity.SizeMiB))
+	err := servicestatetest.MockQuotaInState(s.state, "foogroup", "", []string{"test-snap"}, quota.NewResources(quantity.SizeMiB, 0, 0, nil, 0))
 	c.Assert(err, IsNil)
 
 	s.state.Unlock()

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -744,7 +744,7 @@ apps:
 	tr.Commit()
 
 	// put the snap in a quota group
-	err := servicestatetest.MockQuotaInState(st, "quota-grp", "", []string{"foo"}, quota.NewResources(quantity.SizeMiB, 0, 0, nil, 0))
+	err := servicestatetest.MockQuotaInState(st, "quota-grp", "", []string{"foo"}, quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build())
 	c.Assert(err, IsNil)
 
 	ts, err := snapstate.Remove(st, "foo", snap.R(0), &snapstate.RemoveFlags{Purge: true})
@@ -795,7 +795,7 @@ apps:
 	tr.Commit()
 
 	// add the snap to a quota group
-	ts, err := servicestate.CreateQuota(st, "grp", "", []string{"foo"}, quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0))
+	ts, err := servicestate.CreateQuota(st, "grp", "", []string{"foo"}, quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
 	c.Assert(err, IsNil)
 	quotaUpdateChg := st.NewChange("update-quota", "...")
 	quotaUpdateChg.AddAll(ts)

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -744,7 +744,7 @@ apps:
 	tr.Commit()
 
 	// put the snap in a quota group
-	err := servicestatetest.MockQuotaInState(st, "quota-grp", "", []string{"foo"}, quota.NewResources(quantity.SizeMiB))
+	err := servicestatetest.MockQuotaInState(st, "quota-grp", "", []string{"foo"}, quota.NewResources(quantity.SizeMiB, 0, 0, nil, 0))
 	c.Assert(err, IsNil)
 
 	ts, err := snapstate.Remove(st, "foo", snap.R(0), &snapstate.RemoveFlags{Purge: true})

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -795,7 +795,7 @@ apps:
 	tr.Commit()
 
 	// add the snap to a quota group
-	ts, err := servicestate.CreateQuota(st, "grp", "", []string{"foo"}, quota.NewResources(quantity.SizeGiB))
+	ts, err := servicestate.CreateQuota(st, "grp", "", []string{"foo"}, quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0))
 	c.Assert(err, IsNil)
 	quotaUpdateChg := st.NewChange("update-quota", "...")
 	quotaUpdateChg.AddAll(ts)

--- a/overlord/servicestate/internal/quotas_test.go
+++ b/overlord/servicestate/internal/quotas_test.go
@@ -135,7 +135,7 @@ func (s *servicestateQuotasSuite) TestCreateQuotaInState(c *C) {
 		Name:        "foogroup",
 		MemoryLimit: quantity.SizeGiB,
 	}
-	grp1, newGrps, err := internal.CreateQuotaInState(st, "foogroup", nil, nil, quota.NewResources(quantity.SizeGiB), nil)
+	grp1, newGrps, err := internal.CreateQuotaInState(st, "foogroup", nil, nil, quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0), nil)
 	c.Assert(err, IsNil)
 	c.Check(grp1, DeepEquals, grp)
 	c.Check(newGrps, DeepEquals, map[string]*quota.Group{
@@ -156,7 +156,7 @@ func (s *servicestateQuotasSuite) TestCreateQuotaInState(c *C) {
 		ParentGroup: "foogroup",
 		Snaps:       []string{"snap1", "snap2"},
 	}
-	grp3, newGrps, err := internal.CreateQuotaInState(st, "group-2", grp1, []string{"snap1", "snap2"}, quota.NewResources(quantity.SizeGiB), nil)
+	grp3, newGrps, err := internal.CreateQuotaInState(st, "group-2", grp1, []string{"snap1", "snap2"}, quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0), nil)
 	c.Assert(err, IsNil)
 	c.Check(grp3.Name, Equals, grp2.Name)
 	c.Check(grp3.MemoryLimit, Equals, grp2.MemoryLimit)

--- a/overlord/servicestate/internal/quotas_test.go
+++ b/overlord/servicestate/internal/quotas_test.go
@@ -135,7 +135,7 @@ func (s *servicestateQuotasSuite) TestCreateQuotaInState(c *C) {
 		Name:        "foogroup",
 		MemoryLimit: quantity.SizeGiB,
 	}
-	grp1, newGrps, err := internal.CreateQuotaInState(st, "foogroup", nil, nil, quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0), nil)
+	grp1, newGrps, err := internal.CreateQuotaInState(st, "foogroup", nil, nil, quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(), nil)
 	c.Assert(err, IsNil)
 	c.Check(grp1, DeepEquals, grp)
 	c.Check(newGrps, DeepEquals, map[string]*quota.Group{
@@ -156,7 +156,7 @@ func (s *servicestateQuotasSuite) TestCreateQuotaInState(c *C) {
 		ParentGroup: "foogroup",
 		Snaps:       []string{"snap1", "snap2"},
 	}
-	grp3, newGrps, err := internal.CreateQuotaInState(st, "group-2", grp1, []string{"snap1", "snap2"}, quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0), nil)
+	grp3, newGrps, err := internal.CreateQuotaInState(st, "group-2", grp1, []string{"snap1", "snap2"}, quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(), nil)
 	c.Assert(err, IsNil)
 	c.Check(grp3.Name, Equals, grp2.Name)
 	c.Check(grp3.MemoryLimit, Equals, grp2.MemoryLimit)

--- a/overlord/servicestate/internal/quotas_test.go
+++ b/overlord/servicestate/internal/quotas_test.go
@@ -122,7 +122,7 @@ func (s *servicestateQuotasSuite) TestQuotas(c *C) {
 
 	_, err = internal.PatchQuotas(st, otherGrp2, otherGrp)
 	// either group can get checked first
-	c.Assert(err, ErrorMatches, `cannot update quotas "other-group", "other-group2": group "other-group2?" is invalid: quota group must have a memory limit set`)
+	c.Assert(err, ErrorMatches, `cannot update quotas "other-group", "other-group2": group "other-group2?" is invalid: quota group must have at least one resource limit set`)
 }
 
 func (s *servicestateQuotasSuite) TestCreateQuotaInState(c *C) {

--- a/overlord/servicestate/quota_control_test.go
+++ b/overlord/servicestate/quota_control_test.go
@@ -962,7 +962,7 @@ func (s *quotaControlSuite) TestUpdateQuotaModifyExistingMixable(c *C) {
 
 	// try to update a quota value, this must fail
 	_, err = servicestate.UpdateQuota(st, "mixed-grp", servicestate.QuotaGroupUpdate{
-		NewResourceLimits: quota.NewResources(quantity.SizeGiB * 2),
+		NewResourceLimits: quota.NewResources(quantity.SizeGiB*2, 0, 0, nil, 0),
 	})
 	c.Assert(err, ErrorMatches, `quota group "mixed-grp" has mixed snaps and sub-groups, which is no longer supported; removal and re-creation is necessary to modify it`)
 }

--- a/overlord/servicestate/quota_control_test.go
+++ b/overlord/servicestate/quota_control_test.go
@@ -210,7 +210,7 @@ func (s *quotaControlSuite) TestCreateQuotaNotEnabled(c *C) {
 	tr.Commit()
 
 	// try to create an empty quota group
-	_, err := servicestate.CreateQuota(s.state, "foo", "", nil, quota.NewResources(quantity.SizeGiB))
+	_, err := servicestate.CreateQuota(s.state, "foo", "", nil, quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0))
 	c.Assert(err, ErrorMatches, `experimental feature disabled - test it by setting 'experimental.quota-groups' to true`)
 }
 
@@ -223,7 +223,7 @@ func (s *quotaControlSuite) TestCreateQuotaSystemdTooOld(c *C) {
 
 	servicestate.CheckSystemdVersion()
 
-	_, err := servicestate.CreateQuota(s.state, "foo", "", nil, quota.NewResources(quantity.SizeGiB))
+	_, err := servicestate.CreateQuota(s.state, "foo", "", nil, quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0))
 	c.Assert(err, ErrorMatches, `cannot use quotas with incompatible systemd: systemd version 229 is too old \(expected at least 230\)`)
 }
 
@@ -232,7 +232,7 @@ func (s *quotaControlSuite) TestCreateQuotaPrecond(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, quota.NewResources(2*quantity.SizeGiB))
+	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, quota.NewResources(2*quantity.SizeGiB, 0, 0, nil, 0))
 	c.Assert(err, IsNil)
 
 	tests := []struct {
@@ -242,13 +242,14 @@ func (s *quotaControlSuite) TestCreateQuotaPrecond(c *C) {
 		err   string
 	}{
 		{"foo", 16 * quantity.SizeKiB, nil, `group "foo" already exists`},
-		{"new", 0, nil, `cannot create quota group "new": quota group must have a memory limit set`},
-		{"new", quantity.SizeKiB, nil, `cannot create quota group "new": memory limit 1024 is too small: size must be larger than 4KB`},
+		{"new", 0, nil, `limits for group "new" could not be validated: quota group must have at least one resource quota set`},
+		{"new", quantity.SizeKiB, nil, `limits for group "new" could not be validated: memory limit 1024 is too small: size must be larger than 4KB`},
 		{"new", 16 * quantity.SizeKiB, []string{"baz"}, `cannot use snap "baz" in group "new": snap "baz" is not installed`},
 	}
 
 	for _, t := range tests {
-		_, err := servicestate.CreateQuota(st, t.name, "", t.snaps, quota.NewResources(t.mem))
+		testConstraints := quota.NewResources(t.mem, 0, 0, nil, 0)
+		_, err := servicestate.CreateQuota(st, t.name, "", t.snaps, testConstraints)
 		c.Check(err, ErrorMatches, t.err)
 	}
 }
@@ -265,7 +266,7 @@ func (s *quotaControlSuite) TestRemoveQuotaPreseeding(c *C) {
 	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
 
 	// create a quota group
-	ts, err := servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap"}, quota.NewResources(quantity.SizeGiB))
+	ts, err := servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap"}, quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0))
 	c.Assert(err, IsNil)
 
 	chg := st.NewChange("quota-control", "...")
@@ -275,7 +276,7 @@ func (s *quotaControlSuite) TestRemoveQuotaPreseeding(c *C) {
 		Action:         "create",
 		QuotaName:      "foo",
 		AddSnaps:       []string{"test-snap"},
-		ResourceLimits: quota.NewResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
 	}
 
 	checkQuotaControlTasks(c, chg.Tasks(), exp)
@@ -290,7 +291,7 @@ func (s *quotaControlSuite) TestRemoveQuotaPreseeding(c *C) {
 	// check that the quota groups were created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -325,8 +326,11 @@ func (s *quotaControlSuite) TestCreateUpdateRemoveQuotaHappy(c *C) {
 	snapstate.Set(s.state, "test-snap", s.testSnapState)
 	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
 
+	// create the quota constraints to use for the test
+	quotaConstraits := quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0)
+
 	// create the quota group
-	ts, err := servicestate.CreateQuota(st, "foo", "", []string{"test-snap"}, quota.NewResources(quantity.SizeGiB))
+	ts, err := servicestate.CreateQuota(st, "foo", "", []string{"test-snap"}, quotaConstraits)
 	c.Assert(err, IsNil)
 
 	chg := st.NewChange("quota-control", "...")
@@ -336,7 +340,7 @@ func (s *quotaControlSuite) TestCreateUpdateRemoveQuotaHappy(c *C) {
 		Action:         "create",
 		QuotaName:      "foo",
 		AddSnaps:       []string{"test-snap"},
-		ResourceLimits: quota.NewResources(quantity.SizeGiB),
+		ResourceLimits: quotaConstraits,
 	}
 
 	checkQuotaControlTasks(c, chg.Tasks(), exp)
@@ -351,16 +355,14 @@ func (s *quotaControlSuite) TestCreateUpdateRemoveQuotaHappy(c *C) {
 	// check that the quota groups were created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quotaConstraits,
 			Snaps:          []string{"test-snap"},
 		},
 	})
 
 	// increase the memory limit
-	ts, err = servicestate.UpdateQuota(st, "foo",
-		servicestate.QuotaGroupUpdate{
-			NewResourceLimits: quota.NewResources(2 * quantity.SizeGiB),
-		})
+	newConstraits := quota.NewResources(2*quantity.SizeGiB, 0, 0, nil, 0)
+	ts, err = servicestate.UpdateQuota(st, "foo", servicestate.QuotaGroupUpdate{NewResourceLimits: newConstraits})
 	c.Assert(err, IsNil)
 
 	chg = st.NewChange("quota-control", "...")
@@ -369,7 +371,7 @@ func (s *quotaControlSuite) TestCreateUpdateRemoveQuotaHappy(c *C) {
 	exp2 := &servicestate.QuotaControlAction{
 		Action:         "update",
 		QuotaName:      "foo",
-		ResourceLimits: quota.NewResources(2 * quantity.SizeGiB),
+		ResourceLimits: newConstraits,
 	}
 
 	checkQuotaControlTasks(c, chg.Tasks(), exp2)
@@ -383,7 +385,7 @@ func (s *quotaControlSuite) TestCreateUpdateRemoveQuotaHappy(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(2 * quantity.SizeGiB),
+			ResourceLimits: newConstraits,
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -450,7 +452,8 @@ func (s *quotaControlSuite) TestEnsureSnapAbsentFromQuotaGroup(c *C) {
 	snaptest.MockSnapCurrent(c, testYaml2, si2)
 
 	// create a quota group
-	ts, err := servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap", "test-snap2"}, quota.NewResources(quantity.SizeGiB))
+	quotaConstraits := quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0)
+	ts, err := servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap", "test-snap2"}, quotaConstraits)
 	c.Assert(err, IsNil)
 
 	chg := st.NewChange("quota-control", "...")
@@ -460,7 +463,7 @@ func (s *quotaControlSuite) TestEnsureSnapAbsentFromQuotaGroup(c *C) {
 		Action:         "create",
 		QuotaName:      "foo",
 		AddSnaps:       []string{"test-snap", "test-snap2"},
-		ResourceLimits: quota.NewResources(quantity.SizeGiB),
+		ResourceLimits: quotaConstraits,
 	}
 
 	checkQuotaControlTasks(c, chg.Tasks(), exp)
@@ -474,7 +477,7 @@ func (s *quotaControlSuite) TestEnsureSnapAbsentFromQuotaGroup(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quotaConstraits,
 			Snaps:          []string{"test-snap", "test-snap2"},
 		},
 	})
@@ -485,7 +488,7 @@ func (s *quotaControlSuite) TestEnsureSnapAbsentFromQuotaGroup(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quotaConstraits,
 			Snaps:          []string{"test-snap2"},
 		},
 	})
@@ -501,7 +504,7 @@ func (s *quotaControlSuite) TestEnsureSnapAbsentFromQuotaGroup(c *C) {
 	// and check that it got updated in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quotaConstraits,
 		},
 	})
 
@@ -528,16 +531,18 @@ func (s *quotaControlSuite) TestUpdateQuotaPrecond(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, quota.NewResources(2*quantity.SizeGiB))
+	quotaConstraits := quota.NewResources(2*quantity.SizeGiB, 0, 0, nil, 0)
+	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, quotaConstraits)
 	c.Assert(err, IsNil)
 
+	newConstraits := quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0)
 	tests := []struct {
 		name string
 		opts servicestate.QuotaGroupUpdate
 		err  string
 	}{
 		{"what", servicestate.QuotaGroupUpdate{}, `group "what" does not exist`},
-		{"foo", servicestate.QuotaGroupUpdate{NewResourceLimits: quota.NewResources(quantity.SizeGiB)}, `cannot update group "foo": cannot decrease memory limit, remove and re-create it to decrease the limit`},
+		{"foo", servicestate.QuotaGroupUpdate{NewResourceLimits: newConstraits}, `cannot update group "foo": cannot decrease memory limit of existing quota-group, remove and re-create it to decrease the limit`},
 		{"foo", servicestate.QuotaGroupUpdate{AddSnaps: []string{"baz"}}, `cannot use snap "baz" in group "foo": snap "baz" is not installed`},
 	}
 
@@ -552,9 +557,12 @@ func (s *quotaControlSuite) TestRemoveQuotaPrecond(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, quota.NewResources(2*quantity.SizeGiB))
+	quotaConstraits2GB := quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0)
+	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, quotaConstraits2GB)
 	c.Assert(err, IsNil)
-	err = servicestatetest.MockQuotaInState(st, "bar", "foo", nil, quota.NewResources(quantity.SizeGiB))
+
+	quotaConstraits1GB := quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0)
+	err = servicestatetest.MockQuotaInState(st, "bar", "foo", nil, quotaConstraits1GB)
 	c.Assert(err, IsNil)
 
 	_, err = servicestate.RemoveQuota(st, "what")
@@ -605,7 +613,8 @@ func (s *quotaControlSuite) TestSnapOpUpdateQuotaConflict(c *C) {
 
 	// create a quota group
 	defer s.se.Stop()
-	s.createQuota(c, "foo", quota.NewResources(quantity.SizeGiB), "test-snap")
+	quotaConstraits := quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0)
+	s.createQuota(c, "foo", quotaConstraits, "test-snap")
 
 	ts, err := snapstate.Disable(st, "test-snap2")
 	c.Assert(err, IsNil)
@@ -630,7 +639,8 @@ func (s *quotaControlSuite) TestSnapOpCreateQuotaConflict(c *C) {
 	chg1 := s.state.NewChange("disable", "...")
 	chg1.AddAll(ts)
 
-	_, err = servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap"}, quota.NewResources(quantity.SizeGiB))
+	quotaConstraits := quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0)
+	_, err = servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap"}, quotaConstraits)
 	c.Assert(err, ErrorMatches, `snap "test-snap" has "disable" change in progress`)
 }
 
@@ -651,7 +661,8 @@ func (s *quotaControlSuite) TestSnapOpRemoveQuotaConflict(c *C) {
 
 	// create a quota group
 	defer s.se.Stop()
-	s.createQuota(c, "foo", quota.NewResources(quantity.SizeGiB), "test-snap")
+	quotaConstraits := quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0)
+	s.createQuota(c, "foo", quotaConstraits, "test-snap")
 
 	ts, err := snapstate.Disable(st, "test-snap")
 	c.Assert(err, IsNil)
@@ -671,7 +682,8 @@ func (s *quotaControlSuite) TestCreateQuotaSnapOpConflict(c *C) {
 	snapstate.Set(s.state, "test-snap", s.testSnapState)
 	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
 
-	ts, err := servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap"}, quota.NewResources(quantity.SizeGiB))
+	quotaConstraits := quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0)
+	ts, err := servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap"}, quotaConstraits)
 	c.Assert(err, IsNil)
 	chg1 := s.state.NewChange("quota-control", "...")
 	chg1.AddAll(ts)
@@ -707,7 +719,8 @@ func (s *quotaControlSuite) TestUpdateQuotaSnapOpConflict(c *C) {
 
 	// create a quota group
 	defer s.se.Stop()
-	s.createQuota(c, "foo", quota.NewResources(quantity.SizeGiB), "test-snap")
+	quotaConstraits := quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0)
+	s.createQuota(c, "foo", quotaConstraits, "test-snap")
 
 	ts, err := servicestate.UpdateQuota(st, "foo", servicestate.QuotaGroupUpdate{AddSnaps: []string{"test-snap2"}})
 	c.Assert(err, IsNil)
@@ -735,7 +748,8 @@ func (s *quotaControlSuite) TestRemoveQuotaSnapOpConflict(c *C) {
 
 	// create a quota group
 	defer s.se.Stop()
-	s.createQuota(c, "foo", quota.NewResources(quantity.SizeGiB), "test-snap")
+	quotaConstraits := quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0)
+	s.createQuota(c, "foo", quotaConstraits, "test-snap")
 
 	ts, err := servicestate.RemoveQuota(st, "foo")
 	c.Assert(err, IsNil)
@@ -763,7 +777,8 @@ func (s *quotaControlSuite) TestRemoveQuotaLateSnapOpConflict(c *C) {
 
 	// create a quota group
 	defer s.se.Stop()
-	s.createQuota(c, "foo", quota.NewResources(quantity.SizeGiB), "test-snap")
+	quotaConstraits := quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0)
+	s.createQuota(c, "foo", quotaConstraits, "test-snap")
 
 	ts, err := servicestate.RemoveQuota(st, "foo")
 	c.Assert(err, IsNil)
@@ -812,17 +827,16 @@ func (s *quotaControlSuite) TestUpdateQuotaUpdateQuotaConflict(c *C) {
 
 	// create a quota group
 	defer s.se.Stop()
-	s.createQuota(c, "foo", quota.NewResources(quantity.SizeGiB), "test-snap")
+	quotaConstraits := quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0)
+	s.createQuota(c, "foo", quotaConstraits, "test-snap")
 
 	ts, err := servicestate.UpdateQuota(st, "foo", servicestate.QuotaGroupUpdate{AddSnaps: []string{"test-snap2"}})
 	c.Assert(err, IsNil)
 	chg1 := s.state.NewChange("quota-control", "...")
 	chg1.AddAll(ts)
 
-	_, err = servicestate.UpdateQuota(st, "foo",
-		servicestate.QuotaGroupUpdate{
-			NewResourceLimits: quota.NewResources(2 * quantity.SizeGiB),
-		})
+	newConstraits := quota.NewResources(2*quantity.SizeGiB, 0, 0, nil, 0)
+	_, err = servicestate.UpdateQuota(st, "foo", servicestate.QuotaGroupUpdate{NewResourceLimits: newConstraits})
 	c.Assert(err, ErrorMatches, `quota group "foo" has "quota-control" change in progress`)
 }
 
@@ -853,7 +867,8 @@ func (s *quotaControlSuite) TestUpdateQuotaRemoveQuotaConflict(c *C) {
 
 	// create a quota group
 	defer s.se.Stop()
-	s.createQuota(c, "foo", quota.NewResources(quantity.SizeGiB), "test-snap")
+	quotaConstraits := quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0)
+	s.createQuota(c, "foo", quotaConstraits, "test-snap")
 
 	ts, err := servicestate.UpdateQuota(st, "foo", servicestate.QuotaGroupUpdate{AddSnaps: []string{"test-snap2"}})
 	c.Assert(err, IsNil)
@@ -891,7 +906,8 @@ func (s *quotaControlSuite) TestRemoveQuotaUpdateQuotaConflict(c *C) {
 
 	// create a quota group
 	defer s.se.Stop()
-	s.createQuota(c, "foo", quota.NewResources(quantity.SizeGiB), "test-snap")
+	quotaConstraits := quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0)
+	s.createQuota(c, "foo", quotaConstraits, "test-snap")
 
 	ts, err := servicestate.RemoveQuota(st, "foo")
 	c.Assert(err, IsNil)
@@ -921,12 +937,14 @@ func (s *quotaControlSuite) TestCreateQuotaCreateQuotaConflict(c *C) {
 	snapstate.Set(s.state, "test-snap2", snapst2)
 	snaptest.MockSnapCurrent(c, testYaml2, si2)
 
-	ts, err := servicestate.CreateQuota(st, "foo", "", []string{"test-snap"}, quota.NewResources(quantity.SizeGiB))
+	quotaConstraits := quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0)
+	ts, err := servicestate.CreateQuota(st, "foo", "", []string{"test-snap"}, quotaConstraits)
 	c.Assert(err, IsNil)
 	chg1 := s.state.NewChange("quota-control", "...")
 	chg1.AddAll(ts)
 
-	_, err = servicestate.CreateQuota(st, "foo", "", []string{"test-snap2"}, quota.NewResources(2*quantity.SizeGiB))
+	newConstraits := quota.NewResources(2*quantity.SizeGiB, 0, 0, nil, 0)
+	_, err = servicestate.CreateQuota(st, "foo", "", []string{"test-snap2"}, newConstraits)
 	c.Assert(err, ErrorMatches, `quota group "foo" has "quota-control" change in progress`)
 }
 

--- a/overlord/servicestate/quota_control_test.go
+++ b/overlord/servicestate/quota_control_test.go
@@ -242,8 +242,8 @@ func (s *quotaControlSuite) TestCreateQuotaPrecond(c *C) {
 		err   string
 	}{
 		{"foo", 16 * quantity.SizeKiB, nil, `group "foo" already exists`},
-		{"new", 0, nil, `limits for group "new" could not be validated: quota group must have at least one resource quota set`},
-		{"new", quantity.SizeKiB, nil, `limits for group "new" could not be validated: memory limit 1024 is too small: size must be larger than 4KB`},
+		{"new", 0, nil, `cannot create quota group "new": quota group must have at least one resource limit set`},
+		{"new", quantity.SizeKiB, nil, `cannot create quota group "new": memory limit 1024 is too small: size must be larger than 4KB`},
 		{"new", 16 * quantity.SizeKiB, []string{"baz"}, `cannot use snap "baz" in group "new": snap "baz" is not installed`},
 	}
 
@@ -542,7 +542,7 @@ func (s *quotaControlSuite) TestUpdateQuotaPrecond(c *C) {
 		err  string
 	}{
 		{"what", servicestate.QuotaGroupUpdate{}, `group "what" does not exist`},
-		{"foo", servicestate.QuotaGroupUpdate{NewResourceLimits: newConstraits}, `cannot update group "foo": cannot decrease memory limit of existing quota-group, remove and re-create it to decrease the limit`},
+		{"foo", servicestate.QuotaGroupUpdate{NewResourceLimits: newConstraits}, `cannot update group "foo": cannot decrease memory limit, remove and re-create it to decrease the limit`},
 		{"foo", servicestate.QuotaGroupUpdate{AddSnaps: []string{"baz"}}, `cannot use snap "baz" in group "foo": snap "baz" is not installed`},
 	}
 

--- a/overlord/servicestate/quota_handlers_test.go
+++ b/overlord/servicestate/quota_handlers_test.go
@@ -115,7 +115,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlCreate(c *C) {
 		{
 			Action:         "create",
 			QuotaName:      "foo-group",
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
 			AddSnaps:       []string{"test-snap"},
 		},
 	}
@@ -131,7 +131,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlCreate(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo-group": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -162,7 +162,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlCreateRestartOK(c *C) {
 		{
 			Action:         "create",
 			QuotaName:      "foo-group",
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
 			AddSnaps:       []string{"test-snap"},
 		},
 	}
@@ -171,7 +171,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlCreateRestartOK(c *C) {
 
 	expectedQuotaState := map[string]quotaGroupState{
 		"foo-group": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
 			Snaps:          []string{"test-snap"},
 		},
 	}
@@ -220,7 +220,7 @@ func (s *quotaHandlersSuite) TestQuotaStateAlreadyUpdatedBehavior(c *C) {
 		{
 			Action:         "create",
 			QuotaName:      "foo-group",
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
 			AddSnaps:       []string{"test-snap"},
 		},
 	}
@@ -293,7 +293,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlUpdate(c *C) {
 		{
 			Action:         "create",
 			QuotaName:      "foo-group",
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
 			AddSnaps:       []string{"test-snap"},
 		},
 	}
@@ -313,7 +313,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlUpdate(c *C) {
 		{
 			Action:         "update",
 			QuotaName:      "foo-group",
-			ResourceLimits: quota.NewResources(2 * quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(2*quantity.SizeGiB, 0, 0, nil, 0),
 		},
 	}
 
@@ -328,7 +328,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlUpdate(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo-group": {
-			ResourceLimits: quota.NewResources(2 * quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(2*quantity.SizeGiB, 0, 0, nil, 0),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -360,7 +360,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlUpdateRestartOK(c *C) {
 		{
 			Action:         "create",
 			QuotaName:      "foo-group",
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
 			AddSnaps:       []string{"test-snap"},
 		},
 	}
@@ -380,7 +380,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlUpdateRestartOK(c *C) {
 		{
 			Action:         "update",
 			QuotaName:      "foo-group",
-			ResourceLimits: quota.NewResources(2 * quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(2*quantity.SizeGiB, 0, 0, nil, 0),
 		},
 	}
 
@@ -388,7 +388,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlUpdateRestartOK(c *C) {
 
 	expectedQuotaState := map[string]quotaGroupState{
 		"foo-group": {
-			ResourceLimits: quota.NewResources(2 * quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(2*quantity.SizeGiB, 0, 0, nil, 0),
 			Snaps:          []string{"test-snap"},
 		},
 	}
@@ -442,7 +442,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlRemove(c *C) {
 		{
 			Action:         "create",
 			QuotaName:      "foo-group",
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
 			AddSnaps:       []string{"test-snap"},
 		},
 	}
@@ -508,7 +508,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlRemoveRestartOK(c *C) {
 		{
 			Action:         "create",
 			QuotaName:      "foo-group",
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
 			AddSnaps:       []string{"test-snap"},
 		},
 	}
@@ -584,7 +584,7 @@ func (s *quotaHandlersSuite) TestQuotaCreatePreseeding(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
 		AddSnaps:       []string{"test-snap"},
 	}
 
@@ -594,7 +594,7 @@ func (s *quotaHandlersSuite) TestQuotaCreatePreseeding(c *C) {
 	// check that the quota groups were created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -621,7 +621,7 @@ func (s *quotaHandlersSuite) TestQuotaCreate(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
 		AddSnaps:       []string{"test-snap"},
 	}
 
@@ -635,20 +635,20 @@ func (s *quotaHandlersSuite) TestQuotaCreate(c *C) {
 	qc2 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.NewResources(4 * quantity.SizeKiB),
+		ResourceLimits: quota.NewResources(4*quantity.SizeKiB, 0, 0, nil, 0),
 		AddSnaps:       []string{"test-snap"},
 	}
 
 	// trying to create a quota with too low of a memory limit fails
 	err = s.callDoQuotaControl(&qc2)
-	c.Assert(err, ErrorMatches, `cannot create quota group "foo": memory limit 4096 is too small: size must be larger than 4KB`)
+	c.Assert(err, ErrorMatches, `limits for group "foo" could not be validated: memory limit 4096 is too small: size must be larger than 4KB`)
 
 	// but with an adequately sized memory limit, and a snap that exists, we can
 	// create it
 	qc3 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.NewResources(4*quantity.SizeKiB + 1),
+		ResourceLimits: quota.NewResources(4*quantity.SizeKiB+1, 0, 0, nil, 0),
 		AddSnaps:       []string{"test-snap"},
 	}
 	err = s.callDoQuotaControl(&qc3)
@@ -657,7 +657,7 @@ func (s *quotaHandlersSuite) TestQuotaCreate(c *C) {
 	// check that the quota groups were created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(4*quantity.SizeKiB + 1),
+			ResourceLimits: quota.NewResources(4*quantity.SizeKiB+1, 0, 0, nil, 0),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -690,7 +690,7 @@ func (s *quotaHandlersSuite) TestDoCreateSubGroupQuota(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo-group",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
 	}
 
 	err := s.callDoQuotaControl(&qc)
@@ -700,7 +700,7 @@ func (s *quotaHandlersSuite) TestDoCreateSubGroupQuota(c *C) {
 	qc2 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo2",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
 		ParentName:     "foo-non-real",
 		AddSnaps:       []string{"test-snap"},
 	}
@@ -713,7 +713,7 @@ func (s *quotaHandlersSuite) TestDoCreateSubGroupQuota(c *C) {
 	qc3 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo2",
-		ResourceLimits: quota.NewResources(2 * quantity.SizeGiB),
+		ResourceLimits: quota.NewResources(2*quantity.SizeGiB, 0, 0, nil, 0),
 		ParentName:     "foo-group",
 		AddSnaps:       []string{"test-snap"},
 	}
@@ -725,7 +725,7 @@ func (s *quotaHandlersSuite) TestDoCreateSubGroupQuota(c *C) {
 	qc4 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo2",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
 		ParentName:     "foo-group",
 		AddSnaps:       []string{"test-snap"},
 	}
@@ -736,11 +736,11 @@ func (s *quotaHandlersSuite) TestDoCreateSubGroupQuota(c *C) {
 	// check that the quota groups were created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo-group": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
 			SubGroups:      []string{"foo2"},
 		},
 		"foo2": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
 			Snaps:          []string{"test-snap"},
 			ParentGroup:    "foo-group",
 		},
@@ -797,7 +797,7 @@ func (s *quotaHandlersSuite) TestQuotaRemove(c *C) {
 	qc2 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
 	}
 
 	err = s.callDoQuotaControl(&qc2)
@@ -807,7 +807,7 @@ func (s *quotaHandlersSuite) TestQuotaRemove(c *C) {
 	qc3 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo2",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB / 2),
+		ResourceLimits: quota.NewResources(quantity.SizeGiB/2, 0, 0, nil, 0),
 		ParentName:     "foo",
 		AddSnaps:       []string{"test-snap"},
 	}
@@ -818,7 +818,7 @@ func (s *quotaHandlersSuite) TestQuotaRemove(c *C) {
 	qc4 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo3",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB / 2),
+		ResourceLimits: quota.NewResources(quantity.SizeGiB/2, 0, 0, nil, 0),
 		ParentName:     "foo",
 	}
 
@@ -828,16 +828,16 @@ func (s *quotaHandlersSuite) TestQuotaRemove(c *C) {
 	// check that the quota groups was created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
 			SubGroups:      []string{"foo2", "foo3"},
 		},
 		"foo2": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB / 2),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB/2, 0, 0, nil, 0),
 			Snaps:          []string{"test-snap"},
 			ParentGroup:    "foo",
 		},
 		"foo3": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB / 2),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB/2, 0, 0, nil, 0),
 			ParentGroup:    "foo",
 		},
 	})
@@ -863,11 +863,11 @@ func (s *quotaHandlersSuite) TestQuotaRemove(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
 			SubGroups:      []string{"foo2"},
 		},
 		"foo2": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB / 2),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB/2, 0, 0, nil, 0),
 			Snaps:          []string{"test-snap"},
 			ParentGroup:    "foo",
 		},
@@ -884,7 +884,7 @@ func (s *quotaHandlersSuite) TestQuotaRemove(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
 		},
 	})
 
@@ -983,8 +983,8 @@ func (s *quotaHandlersSuite) TestQuotaSnapFailToMixSubgroupWithSnaps(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB),
-		AddSnaps:       []string{"test-snap"},
+		ResourceLimits: quota.NewResources(quantity.SizeGiB), 0, 0, nil, 0,
+		AddSnaps: []string{"test-snap"},
 	}
 
 	err := s.callDoQuotaControl(&qc)
@@ -994,7 +994,7 @@ func (s *quotaHandlersSuite) TestQuotaSnapFailToMixSubgroupWithSnaps(c *C) {
 	qc2 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo2",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB / 2),
+		ResourceLimits: quota.NewResources(quantity.SizeGiB/2, 0, 0, nil, 0),
 		ParentName:     "foo",
 	}
 
@@ -1004,7 +1004,7 @@ func (s *quotaHandlersSuite) TestQuotaSnapFailToMixSubgroupWithSnaps(c *C) {
 	// check that the quota groups was created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -1022,7 +1022,7 @@ func (s *quotaHandlersSuite) TestQuotaSnapFailToMixSnapsWithSubgroups(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
 	}
 
 	err := s.callDoQuotaControl(&qc)
@@ -1032,7 +1032,7 @@ func (s *quotaHandlersSuite) TestQuotaSnapFailToMixSnapsWithSubgroups(c *C) {
 	qc2 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo2",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB / 2),
+		ResourceLimits: quota.NewResources(quantity.SizeGiB/2, 0, 0, nil, 0),
 		ParentName:     "foo",
 	}
 
@@ -1052,11 +1052,11 @@ func (s *quotaHandlersSuite) TestQuotaSnapFailToMixSnapsWithSubgroups(c *C) {
 	// check that the quota groups was created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
 			SubGroups:      []string{"foo2"},
 		},
 		"foo2": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB / 2),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB/2, 0, 0, nil, 0),
 			ParentGroup:    "foo",
 		},
 	})
@@ -1119,7 +1119,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateSubGroupTooBig(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
 	}
 
 	err := s.callDoQuotaControl(&qc)
@@ -1127,7 +1127,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateSubGroupTooBig(c *C) {
 
 	// ensure mem-limit is 1 GB
 	expFooGroupState := quotaGroupState{
-		ResourceLimits: quota.NewResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
 	}
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": expFooGroupState,
@@ -1137,7 +1137,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateSubGroupTooBig(c *C) {
 	qc2 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo2",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB / 2),
+		ResourceLimits: quota.NewResources(quantity.SizeGiB/2, 0, 0, nil, 0),
 		AddSnaps:       []string{"test-snap", "test-snap2"},
 		ParentName:     "foo",
 	}
@@ -1148,7 +1148,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateSubGroupTooBig(c *C) {
 	expFooGroupState.SubGroups = []string{"foo2"}
 
 	expFoo2GroupState := quotaGroupState{
-		ResourceLimits: quota.NewResources(quantity.SizeGiB / 2),
+		ResourceLimits: quota.NewResources(quantity.SizeGiB/2, 0, 0, nil, 0),
 		Snaps:          []string{"test-snap", "test-snap2"},
 		ParentGroup:    "foo",
 	}
@@ -1163,13 +1163,13 @@ func (s *quotaHandlersSuite) TestQuotaUpdateSubGroupTooBig(c *C) {
 	qc3 := servicestate.QuotaControlAction{
 		Action:         "update",
 		QuotaName:      "foo2",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
 	}
 
 	err = s.callDoQuotaControl(&qc3)
 	c.Assert(err, IsNil)
 
-	expFoo2GroupState.ResourceLimits = quota.NewResources(quantity.SizeGiB)
+	expFoo2GroupState.ResourceLimits = quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0)
 	// and check that it got updated in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo":  expFooGroupState,
@@ -1180,7 +1180,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateSubGroupTooBig(c *C) {
 	qc4 := servicestate.QuotaControlAction{
 		Action:         "update",
 		QuotaName:      "foo2",
-		ResourceLimits: quota.NewResources(2 * quantity.SizeGiB),
+		ResourceLimits: quota.NewResources(2*quantity.SizeGiB, 0, 0, nil, 0),
 	}
 
 	err = s.callDoQuotaControl(&qc4)
@@ -1216,7 +1216,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateChangeMemLimit(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
 		AddSnaps:       []string{"test-snap"},
 	}
 
@@ -1226,7 +1226,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateChangeMemLimit(c *C) {
 	// ensure mem-limit is 1 GB
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -1235,7 +1235,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateChangeMemLimit(c *C) {
 	qc2 := servicestate.QuotaControlAction{
 		Action:         "update",
 		QuotaName:      "foo",
-		ResourceLimits: quota.NewResources(2 * quantity.SizeGiB),
+		ResourceLimits: quota.NewResources(2*quantity.SizeGiB, 0, 0, nil, 0),
 	}
 	err = s.callDoQuotaControl(&qc2)
 	c.Assert(err, IsNil)
@@ -1243,7 +1243,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateChangeMemLimit(c *C) {
 	// and check that it got updated in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(2 * quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(2*quantity.SizeGiB, 0, 0, nil, 0),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -1252,10 +1252,10 @@ func (s *quotaHandlersSuite) TestQuotaUpdateChangeMemLimit(c *C) {
 	qc3 := servicestate.QuotaControlAction{
 		Action:         "update",
 		QuotaName:      "foo",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
 	}
 	err = s.callDoQuotaControl(&qc3)
-	c.Assert(err, ErrorMatches, "cannot update limits for group \"foo\": cannot decrease memory limit, remove and re-create it to decrease the limit")
+	c.Assert(err, ErrorMatches, "cannot update limits for group \"foo\": cannot decrease memory limit of existing quota-group, remove and re-create it to decrease the limit")
 }
 
 func (s *quotaHandlersSuite) TestQuotaUpdateAddSnap(c *C) {
@@ -1292,7 +1292,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnap(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
 		AddSnaps:       []string{"test-snap"},
 	}
 
@@ -1301,7 +1301,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnap(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -1318,7 +1318,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnap(c *C) {
 	// and check that it got updated in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
 			Snaps:          []string{"test-snap", "test-snap2"},
 		},
 	})
@@ -1358,7 +1358,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnapAlreadyInOtherGroup(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
 		AddSnaps:       []string{"test-snap"},
 	}
 
@@ -1367,7 +1367,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnapAlreadyInOtherGroup(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -1376,7 +1376,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnapAlreadyInOtherGroup(c *C) {
 	qc2 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo2",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
 		AddSnaps:       []string{"test-snap2"},
 	}
 
@@ -1386,11 +1386,11 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnapAlreadyInOtherGroup(c *C) {
 	// verify state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
 			Snaps:          []string{"test-snap"},
 		},
 		"foo2": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
 			Snaps:          []string{"test-snap2"},
 		},
 	})
@@ -1408,11 +1408,11 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnapAlreadyInOtherGroup(c *C) {
 	// nothing changed in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
 			Snaps:          []string{"test-snap"},
 		},
 		"foo2": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
 			Snaps:          []string{"test-snap2"},
 		},
 	})

--- a/overlord/servicestate/quota_handlers_test.go
+++ b/overlord/servicestate/quota_handlers_test.go
@@ -67,13 +67,13 @@ func (s *quotaHandlersSuite) SetUpTest(c *C) {
 // this type of mixed groups were supported when the feature was experimental.
 func mockMixedQuotaGroup(st *state.State, name string, snaps []string) error {
 	// create the quota group
-	grp, err := quota.NewGroup(name, quota.NewResources(quantity.SizeGiB))
+	grp, err := quota.NewGroup(name, quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0))
 	if err != nil {
 		return err
 	}
 
 	subGrpName := name + "-sub"
-	subGrp, err := grp.NewSubGroup(subGrpName, quota.NewResources(quantity.SizeGiB/2))
+	subGrp, err := grp.NewSubGroup(subGrpName, quota.NewResources(quantity.SizeGiB/2, 0, 0, nil, 0))
 	if err != nil {
 		return err
 	}
@@ -919,7 +919,7 @@ func (s *quotaHandlersSuite) TestQuotaSnapModifyExistingMixable(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "update",
 		QuotaName:      "mixed-grp",
-		ResourceLimits: quota.NewResources(2 * quantity.SizeGiB),
+		ResourceLimits: quota.NewResources(2*quantity.SizeGiB, 0, 0, nil, 0),
 	}
 	err = s.callDoQuotaControl(&qc)
 	c.Assert(err, ErrorMatches, `quota group "mixed-grp" has mixed snaps and sub-groups, which is no longer supported; removal and re-creation is necessary to modify it`)
@@ -983,8 +983,8 @@ func (s *quotaHandlersSuite) TestQuotaSnapFailToMixSubgroupWithSnaps(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB), 0, 0, nil, 0,
-		AddSnaps: []string{"test-snap"},
+		ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
+		AddSnaps:       []string{"test-snap"},
 	}
 
 	err := s.callDoQuotaControl(&qc)

--- a/overlord/servicestate/quota_handlers_test.go
+++ b/overlord/servicestate/quota_handlers_test.go
@@ -67,13 +67,13 @@ func (s *quotaHandlersSuite) SetUpTest(c *C) {
 // this type of mixed groups were supported when the feature was experimental.
 func mockMixedQuotaGroup(st *state.State, name string, snaps []string) error {
 	// create the quota group
-	grp, err := quota.NewGroup(name, quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0))
+	grp, err := quota.NewGroup(name, quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
 	if err != nil {
 		return err
 	}
 
 	subGrpName := name + "-sub"
-	subGrp, err := grp.NewSubGroup(subGrpName, quota.NewResources(quantity.SizeGiB/2, 0, 0, nil, 0))
+	subGrp, err := grp.NewSubGroup(subGrpName, quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB/2).Build())
 	if err != nil {
 		return err
 	}
@@ -115,7 +115,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlCreate(c *C) {
 		{
 			Action:         "create",
 			QuotaName:      "foo-group",
-			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			AddSnaps:       []string{"test-snap"},
 		},
 	}
@@ -131,7 +131,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlCreate(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo-group": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -162,7 +162,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlCreateRestartOK(c *C) {
 		{
 			Action:         "create",
 			QuotaName:      "foo-group",
-			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			AddSnaps:       []string{"test-snap"},
 		},
 	}
@@ -171,7 +171,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlCreateRestartOK(c *C) {
 
 	expectedQuotaState := map[string]quotaGroupState{
 		"foo-group": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			Snaps:          []string{"test-snap"},
 		},
 	}
@@ -220,7 +220,7 @@ func (s *quotaHandlersSuite) TestQuotaStateAlreadyUpdatedBehavior(c *C) {
 		{
 			Action:         "create",
 			QuotaName:      "foo-group",
-			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			AddSnaps:       []string{"test-snap"},
 		},
 	}
@@ -293,7 +293,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlUpdate(c *C) {
 		{
 			Action:         "create",
 			QuotaName:      "foo-group",
-			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			AddSnaps:       []string{"test-snap"},
 		},
 	}
@@ -313,7 +313,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlUpdate(c *C) {
 		{
 			Action:         "update",
 			QuotaName:      "foo-group",
-			ResourceLimits: quota.NewResources(2*quantity.SizeGiB, 0, 0, nil, 0),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB * 2).Build(),
 		},
 	}
 
@@ -328,7 +328,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlUpdate(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo-group": {
-			ResourceLimits: quota.NewResources(2*quantity.SizeGiB, 0, 0, nil, 0),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB * 2).Build(),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -360,7 +360,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlUpdateRestartOK(c *C) {
 		{
 			Action:         "create",
 			QuotaName:      "foo-group",
-			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			AddSnaps:       []string{"test-snap"},
 		},
 	}
@@ -380,7 +380,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlUpdateRestartOK(c *C) {
 		{
 			Action:         "update",
 			QuotaName:      "foo-group",
-			ResourceLimits: quota.NewResources(2*quantity.SizeGiB, 0, 0, nil, 0),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB * 2).Build(),
 		},
 	}
 
@@ -388,7 +388,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlUpdateRestartOK(c *C) {
 
 	expectedQuotaState := map[string]quotaGroupState{
 		"foo-group": {
-			ResourceLimits: quota.NewResources(2*quantity.SizeGiB, 0, 0, nil, 0),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB * 2).Build(),
 			Snaps:          []string{"test-snap"},
 		},
 	}
@@ -442,7 +442,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlRemove(c *C) {
 		{
 			Action:         "create",
 			QuotaName:      "foo-group",
-			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			AddSnaps:       []string{"test-snap"},
 		},
 	}
@@ -508,7 +508,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlRemoveRestartOK(c *C) {
 		{
 			Action:         "create",
 			QuotaName:      "foo-group",
-			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			AddSnaps:       []string{"test-snap"},
 		},
 	}
@@ -584,7 +584,7 @@ func (s *quotaHandlersSuite) TestQuotaCreatePreseeding(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 		AddSnaps:       []string{"test-snap"},
 	}
 
@@ -594,7 +594,7 @@ func (s *quotaHandlersSuite) TestQuotaCreatePreseeding(c *C) {
 	// check that the quota groups were created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -621,7 +621,7 @@ func (s *quotaHandlersSuite) TestQuotaCreate(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 		AddSnaps:       []string{"test-snap"},
 	}
 
@@ -635,7 +635,7 @@ func (s *quotaHandlersSuite) TestQuotaCreate(c *C) {
 	qc2 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.NewResources(4*quantity.SizeKiB, 0, 0, nil, 0),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(4 * quantity.SizeKiB).Build(),
 		AddSnaps:       []string{"test-snap"},
 	}
 
@@ -648,7 +648,7 @@ func (s *quotaHandlersSuite) TestQuotaCreate(c *C) {
 	qc3 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.NewResources(4*quantity.SizeKiB+1, 0, 0, nil, 0),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(4*quantity.SizeKiB + 1).Build(),
 		AddSnaps:       []string{"test-snap"},
 	}
 	err = s.callDoQuotaControl(&qc3)
@@ -657,7 +657,7 @@ func (s *quotaHandlersSuite) TestQuotaCreate(c *C) {
 	// check that the quota groups were created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(4*quantity.SizeKiB+1, 0, 0, nil, 0),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(4*quantity.SizeKiB + 1).Build(),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -690,7 +690,7 @@ func (s *quotaHandlersSuite) TestDoCreateSubGroupQuota(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo-group",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 	}
 
 	err := s.callDoQuotaControl(&qc)
@@ -700,7 +700,7 @@ func (s *quotaHandlersSuite) TestDoCreateSubGroupQuota(c *C) {
 	qc2 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo2",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 		ParentName:     "foo-non-real",
 		AddSnaps:       []string{"test-snap"},
 	}
@@ -713,7 +713,7 @@ func (s *quotaHandlersSuite) TestDoCreateSubGroupQuota(c *C) {
 	qc3 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo2",
-		ResourceLimits: quota.NewResources(2*quantity.SizeGiB, 0, 0, nil, 0),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB * 2).Build(),
 		ParentName:     "foo-group",
 		AddSnaps:       []string{"test-snap"},
 	}
@@ -725,7 +725,7 @@ func (s *quotaHandlersSuite) TestDoCreateSubGroupQuota(c *C) {
 	qc4 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo2",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 		ParentName:     "foo-group",
 		AddSnaps:       []string{"test-snap"},
 	}
@@ -736,11 +736,11 @@ func (s *quotaHandlersSuite) TestDoCreateSubGroupQuota(c *C) {
 	// check that the quota groups were created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo-group": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			SubGroups:      []string{"foo2"},
 		},
 		"foo2": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			Snaps:          []string{"test-snap"},
 			ParentGroup:    "foo-group",
 		},
@@ -797,7 +797,7 @@ func (s *quotaHandlersSuite) TestQuotaRemove(c *C) {
 	qc2 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 	}
 
 	err = s.callDoQuotaControl(&qc2)
@@ -807,7 +807,7 @@ func (s *quotaHandlersSuite) TestQuotaRemove(c *C) {
 	qc3 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo2",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB/2, 0, 0, nil, 0),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB / 2).Build(),
 		ParentName:     "foo",
 		AddSnaps:       []string{"test-snap"},
 	}
@@ -818,7 +818,7 @@ func (s *quotaHandlersSuite) TestQuotaRemove(c *C) {
 	qc4 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo3",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB/2, 0, 0, nil, 0),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB / 2).Build(),
 		ParentName:     "foo",
 	}
 
@@ -828,16 +828,16 @@ func (s *quotaHandlersSuite) TestQuotaRemove(c *C) {
 	// check that the quota groups was created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			SubGroups:      []string{"foo2", "foo3"},
 		},
 		"foo2": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB/2, 0, 0, nil, 0),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB / 2).Build(),
 			Snaps:          []string{"test-snap"},
 			ParentGroup:    "foo",
 		},
 		"foo3": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB/2, 0, 0, nil, 0),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB / 2).Build(),
 			ParentGroup:    "foo",
 		},
 	})
@@ -863,11 +863,11 @@ func (s *quotaHandlersSuite) TestQuotaRemove(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			SubGroups:      []string{"foo2"},
 		},
 		"foo2": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB/2, 0, 0, nil, 0),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB / 2).Build(),
 			Snaps:          []string{"test-snap"},
 			ParentGroup:    "foo",
 		},
@@ -884,7 +884,7 @@ func (s *quotaHandlersSuite) TestQuotaRemove(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 		},
 	})
 
@@ -919,7 +919,7 @@ func (s *quotaHandlersSuite) TestQuotaSnapModifyExistingMixable(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "update",
 		QuotaName:      "mixed-grp",
-		ResourceLimits: quota.NewResources(2*quantity.SizeGiB, 0, 0, nil, 0),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB * 2).Build(),
 	}
 	err = s.callDoQuotaControl(&qc)
 	c.Assert(err, ErrorMatches, `quota group "mixed-grp" has mixed snaps and sub-groups, which is no longer supported; removal and re-creation is necessary to modify it`)
@@ -983,7 +983,7 @@ func (s *quotaHandlersSuite) TestQuotaSnapFailToMixSubgroupWithSnaps(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 		AddSnaps:       []string{"test-snap"},
 	}
 
@@ -994,7 +994,7 @@ func (s *quotaHandlersSuite) TestQuotaSnapFailToMixSubgroupWithSnaps(c *C) {
 	qc2 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo2",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB/2, 0, 0, nil, 0),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB / 2).Build(),
 		ParentName:     "foo",
 	}
 
@@ -1004,7 +1004,7 @@ func (s *quotaHandlersSuite) TestQuotaSnapFailToMixSubgroupWithSnaps(c *C) {
 	// check that the quota groups was created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -1022,7 +1022,7 @@ func (s *quotaHandlersSuite) TestQuotaSnapFailToMixSnapsWithSubgroups(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 	}
 
 	err := s.callDoQuotaControl(&qc)
@@ -1032,7 +1032,7 @@ func (s *quotaHandlersSuite) TestQuotaSnapFailToMixSnapsWithSubgroups(c *C) {
 	qc2 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo2",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB/2, 0, 0, nil, 0),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB / 2).Build(),
 		ParentName:     "foo",
 	}
 
@@ -1052,11 +1052,11 @@ func (s *quotaHandlersSuite) TestQuotaSnapFailToMixSnapsWithSubgroups(c *C) {
 	// check that the quota groups was created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			SubGroups:      []string{"foo2"},
 		},
 		"foo2": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB/2, 0, 0, nil, 0),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB / 2).Build(),
 			ParentGroup:    "foo",
 		},
 	})
@@ -1119,7 +1119,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateSubGroupTooBig(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 	}
 
 	err := s.callDoQuotaControl(&qc)
@@ -1127,7 +1127,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateSubGroupTooBig(c *C) {
 
 	// ensure mem-limit is 1 GB
 	expFooGroupState := quotaGroupState{
-		ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 	}
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": expFooGroupState,
@@ -1137,7 +1137,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateSubGroupTooBig(c *C) {
 	qc2 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo2",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB/2, 0, 0, nil, 0),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB / 2).Build(),
 		AddSnaps:       []string{"test-snap", "test-snap2"},
 		ParentName:     "foo",
 	}
@@ -1148,7 +1148,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateSubGroupTooBig(c *C) {
 	expFooGroupState.SubGroups = []string{"foo2"}
 
 	expFoo2GroupState := quotaGroupState{
-		ResourceLimits: quota.NewResources(quantity.SizeGiB/2, 0, 0, nil, 0),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB / 2).Build(),
 		Snaps:          []string{"test-snap", "test-snap2"},
 		ParentGroup:    "foo",
 	}
@@ -1163,13 +1163,13 @@ func (s *quotaHandlersSuite) TestQuotaUpdateSubGroupTooBig(c *C) {
 	qc3 := servicestate.QuotaControlAction{
 		Action:         "update",
 		QuotaName:      "foo2",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 	}
 
 	err = s.callDoQuotaControl(&qc3)
 	c.Assert(err, IsNil)
 
-	expFoo2GroupState.ResourceLimits = quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0)
+	expFoo2GroupState.ResourceLimits = quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
 	// and check that it got updated in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo":  expFooGroupState,
@@ -1180,7 +1180,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateSubGroupTooBig(c *C) {
 	qc4 := servicestate.QuotaControlAction{
 		Action:         "update",
 		QuotaName:      "foo2",
-		ResourceLimits: quota.NewResources(2*quantity.SizeGiB, 0, 0, nil, 0),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB * 2).Build(),
 	}
 
 	err = s.callDoQuotaControl(&qc4)
@@ -1216,7 +1216,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateChangeMemLimit(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 		AddSnaps:       []string{"test-snap"},
 	}
 
@@ -1226,7 +1226,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateChangeMemLimit(c *C) {
 	// ensure mem-limit is 1 GB
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -1235,7 +1235,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateChangeMemLimit(c *C) {
 	qc2 := servicestate.QuotaControlAction{
 		Action:         "update",
 		QuotaName:      "foo",
-		ResourceLimits: quota.NewResources(2*quantity.SizeGiB, 0, 0, nil, 0),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB * 2).Build(),
 	}
 	err = s.callDoQuotaControl(&qc2)
 	c.Assert(err, IsNil)
@@ -1243,7 +1243,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateChangeMemLimit(c *C) {
 	// and check that it got updated in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(2*quantity.SizeGiB, 0, 0, nil, 0),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB * 2).Build(),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -1252,7 +1252,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateChangeMemLimit(c *C) {
 	qc3 := servicestate.QuotaControlAction{
 		Action:         "update",
 		QuotaName:      "foo",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 	}
 	err = s.callDoQuotaControl(&qc3)
 	c.Assert(err, ErrorMatches, "cannot update limits for group \"foo\": cannot decrease memory limit, remove and re-create it to decrease the limit")
@@ -1292,7 +1292,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnap(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 		AddSnaps:       []string{"test-snap"},
 	}
 
@@ -1301,7 +1301,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnap(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -1318,7 +1318,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnap(c *C) {
 	// and check that it got updated in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			Snaps:          []string{"test-snap", "test-snap2"},
 		},
 	})
@@ -1358,7 +1358,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnapAlreadyInOtherGroup(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 		AddSnaps:       []string{"test-snap"},
 	}
 
@@ -1367,7 +1367,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnapAlreadyInOtherGroup(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -1376,7 +1376,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnapAlreadyInOtherGroup(c *C) {
 	qc2 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo2",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 		AddSnaps:       []string{"test-snap2"},
 	}
 
@@ -1386,11 +1386,11 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnapAlreadyInOtherGroup(c *C) {
 	// verify state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			Snaps:          []string{"test-snap"},
 		},
 		"foo2": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			Snaps:          []string{"test-snap2"},
 		},
 	})
@@ -1408,11 +1408,11 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnapAlreadyInOtherGroup(c *C) {
 	// nothing changed in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			Snaps:          []string{"test-snap"},
 		},
 		"foo2": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			Snaps:          []string{"test-snap2"},
 		},
 	})

--- a/overlord/servicestate/quota_handlers_test.go
+++ b/overlord/servicestate/quota_handlers_test.go
@@ -641,7 +641,7 @@ func (s *quotaHandlersSuite) TestQuotaCreate(c *C) {
 
 	// trying to create a quota with too low of a memory limit fails
 	err = s.callDoQuotaControl(&qc2)
-	c.Assert(err, ErrorMatches, `limits for group "foo" could not be validated: memory limit 4096 is too small: size must be larger than 4KB`)
+	c.Assert(err, ErrorMatches, `cannot create quota group "foo": memory limit 4096 is too small: size must be larger than 4KB`)
 
 	// but with an adequately sized memory limit, and a snap that exists, we can
 	// create it
@@ -1255,7 +1255,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateChangeMemLimit(c *C) {
 		ResourceLimits: quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0),
 	}
 	err = s.callDoQuotaControl(&qc3)
-	c.Assert(err, ErrorMatches, "cannot update limits for group \"foo\": cannot decrease memory limit of existing quota-group, remove and re-create it to decrease the limit")
+	c.Assert(err, ErrorMatches, "cannot update limits for group \"foo\": cannot decrease memory limit, remove and re-create it to decrease the limit")
 }
 
 func (s *quotaHandlersSuite) TestQuotaUpdateAddSnap(c *C) {

--- a/overlord/servicestate/quotas.go
+++ b/overlord/servicestate/quotas.go
@@ -29,33 +29,6 @@ import (
 
 var ErrQuotaNotFound = errors.New("quota not found")
 
-func verifyRequiredCGroupsEnabledSingle(group *quota.Group) error {
-	if group.MemoryLimit != 0 && memoryCGroupError != nil {
-		return memoryCGroupError
-	}
-	if group.CpuLimit != nil {
-		if len(group.CpuLimit.AllowedCpus) > 0 && cpuSetCGroupError != nil {
-			return cpuSetCGroupError
-		}
-		if (group.CpuLimit.Count != 0 || group.CpuLimit.Percentage != 0) && cpuCGroupError != nil {
-			return cpuCGroupError
-		}
-	}
-	if group.TaskLimit != 0 && cpuCGroupError != nil {
-		return cpuCGroupError
-	}
-	return nil
-}
-
-func verifyRequiredCGroupsEnabled(groups map[string]*quota.Group) error {
-	for _, group := range groups {
-		if err := verifyRequiredCGroupsEnabledSingle(group); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 // AllQuotas returns all currently tracked quota groups in the state. They are
 // validated for consistency using ResolveCrossReferences before being returned.
 func AllQuotas(st *state.State) (map[string]*quota.Group, error) {
@@ -72,10 +45,6 @@ func GetQuota(st *state.State, name string) (*quota.Group, error) {
 	group, ok := allGrps[name]
 	if !ok {
 		return nil, ErrQuotaNotFound
-	}
-
-	if err := verifyRequiredCGroupsEnabledSingle(group); err != nil {
-		return nil, err
 	}
 	return group, nil
 }

--- a/overlord/servicestate/servicestate_test.go
+++ b/overlord/servicestate/servicestate_test.go
@@ -313,7 +313,7 @@ func (s *snapServiceOptionsSuite) TestSnapServiceOptionsQuotaGroups(c *C) {
 	defer st.Unlock()
 
 	// make a quota group
-	grp, err := quota.NewGroup("foogroup", quota.NewResources(quantity.SizeGiB, 0, 100, []int{0}, 64))
+	grp, err := quota.NewGroup("foogroup", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
 	c.Assert(err, IsNil)
 
 	grp.Snaps = []string{"foosnap"}

--- a/overlord/servicestate/servicestate_test.go
+++ b/overlord/servicestate/servicestate_test.go
@@ -313,7 +313,7 @@ func (s *snapServiceOptionsSuite) TestSnapServiceOptionsQuotaGroups(c *C) {
 	defer st.Unlock()
 
 	// make a quota group
-	grp, err := quota.NewGroup("foogroup", quota.NewResources(quantity.SizeGiB))
+	grp, err := quota.NewGroup("foogroup", quota.NewResources(quantity.SizeGiB, 0, 100, []int{0}, 64))
 	c.Assert(err, IsNil)
 
 	grp.Snaps = []string{"foosnap"}

--- a/overlord/snapstate/backend/link_test.go
+++ b/overlord/snapstate/backend/link_test.go
@@ -789,7 +789,7 @@ apps:
 `
 	info := snaptest.MockSnap(c, yaml, &snap.SideInfo{Revision: snap.R(11)})
 
-	grp, err := quota.NewGroup("foogroup", quota.NewResources(quantity.SizeMiB))
+	grp, err := quota.NewGroup("foogroup", quota.NewResources(quantity.SizeMiB, 0, 0, nil, 0))
 	c.Assert(err, IsNil)
 
 	linkCtxWithGroup := backend.LinkContext{

--- a/overlord/snapstate/backend/link_test.go
+++ b/overlord/snapstate/backend/link_test.go
@@ -789,7 +789,7 @@ apps:
 `
 	info := snaptest.MockSnap(c, yaml, &snap.SideInfo{Revision: snap.R(11)})
 
-	grp, err := quota.NewGroup("foogroup", quota.NewResources(quantity.SizeMiB, 0, 0, nil, 0))
+	grp, err := quota.NewGroup("foogroup", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build())
 	c.Assert(err, IsNil)
 
 	linkCtxWithGroup := backend.LinkContext{

--- a/snap/quota/quota.go
+++ b/snap/quota/quota.go
@@ -108,15 +108,15 @@ func (grp *Group) UpdateQuotaLimits(resourceLimits Resources) {
 	if resourceLimits.Memory != nil {
 		grp.MemoryLimit = resourceLimits.Memory.Limit
 	}
-	if resourceLimits.Cpu != nil {
+	if resourceLimits.CPU != nil {
 		grp.CpuLimit = &GroupQuotaCpu{
-			Count:       resourceLimits.Cpu.Count,
-			Percentage:  resourceLimits.Cpu.Percentage,
-			AllowedCpus: resourceLimits.Cpu.AllowedCpus,
+			Count:       resourceLimits.CPU.Count,
+			Percentage:  resourceLimits.CPU.Percentage,
+			AllowedCpus: resourceLimits.CPU.AllowedCPUs,
 		}
 	}
-	if resourceLimits.Thread != nil {
-		grp.TaskLimit = resourceLimits.Thread.Limit
+	if resourceLimits.Threads != nil {
+		grp.TaskLimit = resourceLimits.Threads.Limit
 	}
 }
 

--- a/snap/quota/quota.go
+++ b/snap/quota/quota.go
@@ -116,11 +116,11 @@ func (grp *Group) UpdateQuotaLimits(resourceLimits Resources) {
 		}
 	}
 	if resourceLimits.Thread != nil {
-		grp.TaskLimit = resourceLimits.Thread.ThreadLimit
+		grp.TaskLimit = resourceLimits.Thread.Limit
 	}
 }
 
-func (grp *Group) GetQuotaResources() QuotaResources {
+func (grp *Group) GetQuotaResources() Resources {
 	if grp.CpuLimit != nil {
 		return NewResources(
 			grp.MemoryLimit, grp.CpuLimit.Count, grp.CpuLimit.Percentage,

--- a/snap/quota/quota.go
+++ b/snap/quota/quota.go
@@ -126,9 +126,15 @@ func (grp *Group) GetQuotaResources() Resources {
 		resourcesBuilder.WithMemoryLimit(grp.MemoryLimit)
 	}
 	if grp.CpuLimit != nil {
-		resourcesBuilder.WithCPUCount(grp.CpuLimit.Count)
-		resourcesBuilder.WithCPUPercentage(grp.CpuLimit.Percentage)
-		resourcesBuilder.WithAllowedCPUs(grp.CpuLimit.AllowedCpus)
+		if grp.CpuLimit.Count != 0 {
+			resourcesBuilder.WithCPUCount(grp.CpuLimit.Count)
+		}
+		if grp.CpuLimit.Percentage != 0 {
+			resourcesBuilder.WithCPUPercentage(grp.CpuLimit.Percentage)
+		}
+		if len(grp.CpuLimit.AllowedCpus) != 0 {
+			resourcesBuilder.WithAllowedCPUs(grp.CpuLimit.AllowedCpus)
+		}
 	}
 	if grp.TaskLimit != 0 {
 		resourcesBuilder.WithThreadLimit(grp.TaskLimit)

--- a/snap/quota/quota.go
+++ b/snap/quota/quota.go
@@ -121,12 +121,19 @@ func (grp *Group) UpdateQuotaLimits(resourceLimits Resources) {
 }
 
 func (grp *Group) GetQuotaResources() Resources {
-	if grp.CpuLimit != nil {
-		return NewResources(
-			grp.MemoryLimit, grp.CpuLimit.Count, grp.CpuLimit.Percentage,
-			grp.CpuLimit.AllowedCpus, grp.TaskLimit)
+	resourcesBuilder := NewResourcesBuilder()
+	if grp.MemoryLimit != 0 {
+		resourcesBuilder.WithMemoryLimit(grp.MemoryLimit)
 	}
-	return NewResources(grp.MemoryLimit, 0, 0, nil, grp.TaskLimit)
+	if grp.CpuLimit != nil {
+		resourcesBuilder.WithCPUCount(grp.CpuLimit.Count)
+		resourcesBuilder.WithCPUPercentage(grp.CpuLimit.Percentage)
+		resourcesBuilder.WithAllowedCPUs(grp.CpuLimit.AllowedCpus)
+	}
+	if grp.TaskLimit != 0 {
+		resourcesBuilder.WithThreadLimit(grp.TaskLimit)
+	}
+	return resourcesBuilder.Build()
 }
 
 // CurrentMemoryUsage returns the current memory usage of the quota group. For

--- a/snap/quota/quota.go
+++ b/snap/quota/quota.go
@@ -33,6 +33,12 @@ import (
 	"github.com/snapcore/snapd/systemd"
 )
 
+type GroupQuotaCpu struct {
+	Count       int   `json:"count,omitempty"`
+	Percentage  int   `json:"percentage,omitempty"`
+	AllowedCpus []int `json:"allowed-cpus,omitempty"`
+}
+
 // Group is a quota group of snaps, services or sub-groups that are all subject
 // to specific resource quotas. The only quota resource types currently
 // supported is memory, but this can be expanded in the future.
@@ -58,6 +64,16 @@ type Group struct {
 	// specific behavior of which processes are killed is subject to the
 	// ExhaustionBehavior. MemoryLimit is expressed in bytes.
 	MemoryLimit quantity.Size `json:"memory-limit,omitempty"`
+
+	// CpuLimit is the quotas for the cpu and consists of a couple of nubs.
+	// It is possible to control the percentage of the cpu available for the group
+	// and which cores (requires cgroupsv2) are allowed to be used.
+	CpuLimit *GroupQuotaCpu `json:"cpu-limit,omitempty"`
+
+	// TaskLimit is the limit of threads/processes that can be active at once in
+	// the group. Once the limit is reached, further forks() or clones() will be blocked
+	// for processes in the group.
+	TaskLimit int `json:"task-limit,omitempty"`
 
 	// ParentGroup is the the parent group that this group is a child of. If it
 	// is empty, then this is a "root" quota group.
@@ -92,10 +108,25 @@ func (grp *Group) UpdateQuotaLimits(resourceLimits Resources) {
 	if resourceLimits.Memory != nil {
 		grp.MemoryLimit = resourceLimits.Memory.Limit
 	}
+	if resourceLimits.Cpu != nil {
+		grp.CpuLimit = &GroupQuotaCpu{
+			Count:       resourceLimits.Cpu.Count,
+			Percentage:  resourceLimits.Cpu.Percentage,
+			AllowedCpus: resourceLimits.Cpu.AllowedCpus,
+		}
+	}
+	if resourceLimits.Thread != nil {
+		grp.TaskLimit = resourceLimits.Thread.ThreadLimit
+	}
 }
 
-func (grp *Group) GetQuotaResources() Resources {
-	return NewResources(grp.MemoryLimit)
+func (grp *Group) GetQuotaResources() QuotaResources {
+	if grp.CpuLimit != nil {
+		return NewResources(
+			grp.MemoryLimit, grp.CpuLimit.Count, grp.CpuLimit.Percentage,
+			grp.CpuLimit.AllowedCpus, grp.TaskLimit)
+	}
+	return NewResources(grp.MemoryLimit, 0, 0, nil, grp.TaskLimit)
 }
 
 // CurrentMemoryUsage returns the current memory usage of the quota group. For
@@ -121,6 +152,31 @@ func (grp *Group) CurrentMemoryUsage() (quantity.Size, error) {
 	}
 
 	return mem, nil
+}
+
+// CurrentTaskUsage returns the current task (processes, threads) usage of the quota group.
+// For quota groups which do not yet have a backing systemd slice on the system (
+// i.e. quota groups without any snaps in them), the task usage is reported
+// as 0
+func (grp *Group) CurrentTaskUsage() (int, error) {
+	sysd := systemd.New(systemd.SystemMode, progress.Null)
+
+	// check if this group is actually active, it could not physically exist yet
+	// since it has no snaps in it
+	isActive, err := sysd.IsActive(grp.SliceFileName())
+	if err != nil {
+		return 0, err
+	}
+	if !isActive {
+		return 0, nil
+	}
+
+	count, err := sysd.CurrentTasksCount(grp.SliceFileName())
+	if err != nil {
+		return 0, err
+	}
+
+	return int(count), nil
 }
 
 // SliceFileName returns the name of the slice file that should be used for this
@@ -182,22 +238,76 @@ func (grp *Group) validate() error {
 		}
 	}
 
-	// check that if this is a sub-group, then the parent group has enough space
+	// Check that if this is a sub-group, then the parent group has enough space
 	// to accommodate this new group (we assume that other existing sub-groups
-	// in the parent group have already been validated)
+	// in the parent group have already been validated).
 	if grp.parentGroup != nil {
-		alreadyUsed := quantity.Size(0)
+		memoryUsed := quantity.Size(0)
+		tasksUsed := 0
+		cpuQuotaUsed := 0
+
+		max := func(a, b int) int {
+			if a > b {
+				return a
+			}
+			return b
+		}
+
+		calculateCpuQuota := func(grp *Group) int {
+			if grp.CpuLimit == nil {
+				return 0
+			}
+			return max(grp.CpuLimit.Count, 1) * grp.CpuLimit.Percentage
+		}
+
 		for _, child := range grp.parentGroup.subGroups {
 			if child.Name == grp.Name {
 				continue
 			}
-			alreadyUsed += child.MemoryLimit
+
+			memoryUsed += child.MemoryLimit
+			tasksUsed += child.TaskLimit
+			cpuQuotaUsed += calculateCpuQuota(child)
 		}
-		// careful arithmetic here in case we somehow overflow the max size of
-		// quantity.Size
-		if grp.parentGroup.MemoryLimit-alreadyUsed < grp.MemoryLimit {
-			remaining := grp.parentGroup.MemoryLimit - alreadyUsed
-			return fmt.Errorf("sub-group memory limit of %s is too large to fit inside remaining quota space %s for parent group %s", grp.MemoryLimit.IECString(), remaining.IECString(), grp.parentGroup.Name)
+
+		if grp.parentGroup.CpuLimit != nil && grp.CpuLimit != nil {
+			arrayContains := func(arr []int, val int) bool {
+				for _, v := range arr {
+					if v == val {
+						return true
+					}
+				}
+				return false
+			}
+
+			upperLimit := calculateCpuQuota(grp.parentGroup)
+			if cpuQuotaUsed+calculateCpuQuota(grp) > upperLimit {
+				return fmt.Errorf("group %q would exceed its parent group's CPU limit", grp.Name)
+			}
+
+			if len(grp.parentGroup.CpuLimit.AllowedCpus) > 0 {
+				// check if the group's allowed cpus are a subset of the parent group's allowed cpus
+				for _, cpu := range grp.CpuLimit.AllowedCpus {
+					if !arrayContains(grp.parentGroup.CpuLimit.AllowedCpus, cpu) {
+						return fmt.Errorf("group %q has a CPU allowance that is not allowed by its parent group", grp.Name)
+					}
+				}
+			}
+		}
+
+		if grp.parentGroup.MemoryLimit != 0 {
+			// careful arithmetic here in case we somehow overflow the max size of
+			// quantity.Size
+			if grp.parentGroup.MemoryLimit-memoryUsed < grp.MemoryLimit {
+				remaining := grp.parentGroup.MemoryLimit - memoryUsed
+				return fmt.Errorf("sub-group memory limit of %s is too large to fit inside remaining quota space %s for parent group %s", grp.MemoryLimit.IECString(), remaining.IECString(), grp.parentGroup.Name)
+			}
+		}
+
+		if grp.parentGroup.TaskLimit != 0 {
+			if tasksUsed+grp.TaskLimit > grp.parentGroup.TaskLimit {
+				return fmt.Errorf("sub-group task limit of %d is too large to fit inside remaining tasks %d for parent group %s", grp.TaskLimit, grp.parentGroup.TaskLimit-tasksUsed, grp.parentGroup.Name)
+			}
 		}
 	}
 

--- a/snap/quota/quota_test.go
+++ b/snap/quota/quota_test.go
@@ -49,82 +49,82 @@ func (ts *quotaTestSuite) TestNewGroup(c *C) {
 	}{
 		{
 			name:    "group1",
-			limits:  quota.NewResources(quantity.SizeMiB),
+			limits:  quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
 			comment: "basic happy",
 		},
 		{
 			name:    "biglimit",
-			limits:  quota.NewResources(quantity.Size(math.MaxUint64)),
+			limits:  quota.NewResources(quantity.Size(math.MaxUint64), 1, 100, []int{0}, 32),
 			comment: "huge limit happy",
 		},
 		{
 			name:    "zero",
-			limits:  quota.NewResources(0),
-			err:     `quota group must have a memory limit set`,
-			comment: "group with zero memory limit",
+			limits:  quota.NewResources(0, 0, 0, nil, 0),
+			err:     `quota group must have at least one resource quota set`,
+			comment: "group with no limits",
 		},
 		{
 			name:    "group1-unsupported chars",
-			limits:  quota.NewResources(quantity.SizeMiB),
+			limits:  quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
 			err:     `invalid quota group name: contains invalid characters.*`,
 			comment: "unsupported characters in group name",
 		},
 		{
 			name:    "group%%%",
-			limits:  quota.NewResources(quantity.SizeMiB),
+			limits:  quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
 			err:     `invalid quota group name: contains invalid characters.*`,
 			comment: "more invalid characters in name",
 		},
 		{
 			name:    "CAPITALIZED",
-			limits:  quota.NewResources(quantity.SizeMiB),
+			limits:  quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
 			err:     `invalid quota group name: contains invalid characters.*`,
 			comment: "capitalized letters",
 		},
 		{
 			name:    "g1",
-			limits:  quota.NewResources(quantity.SizeMiB),
+			limits:  quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
 			comment: "small group name",
 		},
 		{
 			name:          "name-with-dashes",
 			sliceFileName: `name\x2dwith\x2ddashes`,
-			limits:        quota.NewResources(quantity.SizeMiB),
+			limits:        quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
 			comment:       "name with dashes",
 		},
 		{
 			name:    "",
-			limits:  quota.NewResources(quantity.SizeMiB),
+			limits:  quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
 			err:     `invalid quota group name: must not be empty`,
 			comment: "empty group name",
 		},
 		{
 			name:    "g",
-			limits:  quota.NewResources(quantity.SizeMiB),
+			limits:  quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
 			err:     `invalid quota group name: must be between 2 and 40 characters long.*`,
 			comment: "too small group name",
 		},
 		{
 			name:    "root",
-			limits:  quota.NewResources(quantity.SizeMiB),
+			limits:  quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
 			err:     `group name "root" reserved`,
 			comment: "reserved root name",
 		},
 		{
 			name:    "snapd",
-			limits:  quota.NewResources(quantity.SizeMiB),
+			limits:  quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
 			err:     `group name "snapd" reserved`,
 			comment: "reserved snapd name",
 		},
 		{
 			name:    "system",
-			limits:  quota.NewResources(quantity.SizeMiB),
+			limits:  quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
 			err:     `group name "system" reserved`,
 			comment: "reserved system name",
 		},
 		{
 			name:    "user",
-			limits:  quota.NewResources(quantity.SizeMiB),
+			limits:  quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
 			err:     `group name "user" reserved`,
 			comment: "reserved user name",
 		},
@@ -158,66 +158,87 @@ func (ts *quotaTestSuite) TestSimpleSubGroupVerification(c *C) {
 		comment       string
 	}{
 		{
-			rootlimits: quota.NewResources(quantity.SizeMiB),
+			rootlimits: quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
 			subname:    "sub",
-			sublimits:  quota.NewResources(quantity.SizeMiB),
+			sublimits:  quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
 			comment:    "basic sub group with same quota as parent happy",
 		},
 		{
-			rootlimits: quota.NewResources(quantity.SizeMiB),
+			rootlimits: quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
 			subname:    "sub",
-			sublimits:  quota.NewResources(quantity.SizeMiB / 2),
+			sublimits:  quota.NewResources(quantity.SizeMiB/2, 1, 50, []int{0}, 16),
 			comment:    "basic sub group with smaller quota than parent happy",
 		},
 		{
-			rootlimits:    quota.NewResources(quantity.SizeMiB),
+			rootlimits:    quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
 			subname:       "sub-with-dashes",
 			sliceFileName: `myroot-sub\x2dwith\x2ddashes`,
-			sublimits:     quota.NewResources(quantity.SizeMiB / 2),
+			sublimits:     quota.NewResources(quantity.SizeMiB/2, 1, 50, []int{0}, 16),
 			comment:       "basic sub group with dashes in the name",
 		},
 		{
 			rootname:      "my-root",
-			rootlimits:    quota.NewResources(quantity.SizeMiB),
+			rootlimits:    quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
 			subname:       "sub-with-dashes",
 			sliceFileName: `my\x2droot-sub\x2dwith\x2ddashes`,
-			sublimits:     quota.NewResources(quantity.SizeMiB / 2),
+			sublimits:     quota.NewResources(quantity.SizeMiB/2, 1, 50, []int{0}, 16),
 			comment:       "parent and sub group have dashes in name",
 		},
 		{
-			rootlimits: quota.NewResources(quantity.SizeMiB),
+			rootlimits: quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
 			subname:    "sub",
-			sublimits:  quota.NewResources(quantity.SizeMiB * 2),
+			sublimits:  quota.NewResources(quantity.SizeMiB*2, 0, 0, nil, 0),
 			err:        "sub-group memory limit of 2 MiB is too large to fit inside remaining quota space 1 MiB for parent group myroot",
-			comment:    "sub group with larger quota than parent unhappy",
+			comment:    "sub group with larger memory quota than parent unhappy",
 		},
 		{
-			rootlimits: quota.NewResources(quantity.SizeMiB),
+			rootlimits: quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
+			subname:    "sub",
+			sublimits:  quota.NewResources(quantity.SizeMiB/2, 2, 100, nil, 0),
+			err:        "group \"sub\" would exceed its parent group's CPU limit",
+			comment:    "sub group with larger cpu count quota than parent unhappy",
+		},
+		{
+			rootlimits: quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
+			subname:    "sub",
+			sublimits:  quota.NewResources(quantity.SizeMiB/2, 1, 50, []int{1}, 0),
+			err:        "group \"sub\" has a CPU allowance that is not allowed by its parent group",
+			comment:    "sub group with different cpu allowance quota than parent unhappy",
+		},
+		{
+			rootlimits: quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
+			subname:    "sub",
+			sublimits:  quota.NewResources(quantity.SizeMiB/2, 1, 100, []int{0}, 64),
+			err:        "sub-group task limit of 64 is too large to fit inside remaining task space 32 for parent group myroot",
+			comment:    "sub group with larger task allowance quota than parent unhappy",
+		},
+		{
+			rootlimits: quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
 			subname:    "sub invalid chars",
-			sublimits:  quota.NewResources(quantity.SizeMiB),
+			sublimits:  quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
 			err:        `invalid quota group name: contains invalid characters.*`,
 			comment:    "sub group with invalid name",
 		},
 		{
-			rootlimits: quota.NewResources(quantity.SizeMiB),
+			rootlimits: quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
 			subname:    "myroot",
-			sublimits:  quota.NewResources(quantity.SizeMiB),
+			sublimits:  quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
 			err:        `cannot use same name "myroot" for sub group as parent group`,
 			comment:    "sub group with same name as parent group",
 		},
 		{
-			rootlimits: quota.NewResources(quantity.SizeMiB),
+			rootlimits: quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
 			subname:    "snapd",
-			sublimits:  quota.NewResources(quantity.SizeMiB),
+			sublimits:  quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
 			err:        `group name "snapd" reserved`,
 			comment:    "sub group with reserved name",
 		},
 		{
-			rootlimits: quota.NewResources(quantity.SizeMiB),
+			rootlimits: quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
 			subname:    "zero",
-			sublimits:  quota.NewResources(0),
-			err:        `quota group must have a memory limit set`,
-			comment:    "sub group with zero memory limit",
+			sublimits:  quota.NewResources(0, 0, 0, nil, 0),
+			err:        `quota group must have at least one resource quota set`,
+			comment:    "sub group with no limits",
 		},
 	}
 
@@ -248,30 +269,30 @@ func (ts *quotaTestSuite) TestSimpleSubGroupVerification(c *C) {
 }
 
 func (ts *quotaTestSuite) TestComplexSubGroups(c *C) {
-	rootGrp, err := quota.NewGroup("myroot", quota.NewResources(quantity.SizeMiB))
+	rootGrp, err := quota.NewGroup("myroot", quota.NewResources(quantity.SizeMiB, 0, 0, nil, 0))
 	c.Assert(err, IsNil)
 
 	// try adding 2 sub-groups with total quota split exactly equally
-	sub1, err := rootGrp.NewSubGroup("sub1", quota.NewResources(quantity.SizeMiB/2))
+	sub1, err := rootGrp.NewSubGroup("sub1", quota.NewResources(quantity.SizeMiB/2, 0, 0, nil, 0))
 	c.Assert(err, IsNil)
 	c.Assert(sub1.SliceFileName(), Equals, "snap.myroot-sub1.slice")
 
-	sub2, err := rootGrp.NewSubGroup("sub2", quota.NewResources(quantity.SizeMiB/2))
+	sub2, err := rootGrp.NewSubGroup("sub2", quota.NewResources(quantity.SizeMiB/2, 0, 0, nil, 0))
 	c.Assert(err, IsNil)
 	c.Assert(sub2.SliceFileName(), Equals, "snap.myroot-sub2.slice")
 
 	// adding another sub-group to this group fails
-	_, err = rootGrp.NewSubGroup("sub3", quota.NewResources(5*quantity.SizeKiB))
-	c.Assert(err, ErrorMatches, "sub-group memory limit of 5 KiB is too large to fit inside remaining quota space 0 B for parent group myroot")
+	_, err = rootGrp.NewSubGroup("sub3", quota.NewResources(1, 0, 0, nil, 0))
+	c.Assert(err, ErrorMatches, "memory limit 1 is too small: size must be larger than 4KB")
 
 	// we can however add a sub-group to one of the sub-groups with the exact
 	// size of the parent sub-group
-	subsub1, err := sub1.NewSubGroup("subsub1", quota.NewResources(quantity.SizeMiB/2))
+	subsub1, err := sub1.NewSubGroup("subsub1", quota.NewResources(quantity.SizeMiB/2, 0, 0, nil, 0))
 	c.Assert(err, IsNil)
 	c.Assert(subsub1.SliceFileName(), Equals, "snap.myroot-sub1-subsub1.slice")
 
 	// and we can even add a smaller sub-sub-sub-group to the sub-group
-	subsubsub1, err := subsub1.NewSubGroup("subsubsub1", quota.NewResources(quantity.SizeMiB/4))
+	subsubsub1, err := subsub1.NewSubGroup("subsubsub1", quota.NewResources(quantity.SizeMiB/4, 0, 0, nil, 0))
 	c.Assert(err, IsNil)
 	c.Assert(subsubsub1.SliceFileName(), Equals, "snap.myroot-sub1-subsub1-subsubsub1.slice")
 }
@@ -332,7 +353,7 @@ func (ts *quotaTestSuite) TestResolveCrossReferences(c *C) {
 					MemoryLimit: 0,
 				},
 			},
-			err:     `group "foogroup" is invalid: quota group must have a memory limit set`,
+			err:     `group "foogroup" is invalid: quota group must have at least one resource quota set`,
 			comment: "invalid group",
 		},
 		{
@@ -502,10 +523,10 @@ func (ts *quotaTestSuite) TestResolveCrossReferences(c *C) {
 }
 
 func (ts *quotaTestSuite) TestAddAllNecessaryGroupsAvoidsInfiniteRecursion(c *C) {
-	grp, err := quota.NewGroup("infinite-group", quota.NewResources(quantity.SizeGiB))
+	grp, err := quota.NewGroup("infinite-group", quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0))
 	c.Assert(err, IsNil)
 
-	grp2, err := grp.NewSubGroup("infinite-group2", quota.NewResources(quantity.SizeGiB))
+	grp2, err := grp.NewSubGroup("infinite-group2", quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0))
 	c.Assert(err, IsNil)
 
 	// create a cycle artificially to the same group
@@ -525,7 +546,7 @@ func (ts *quotaTestSuite) TestAddAllNecessaryGroupsAvoidsInfiniteRecursion(c *C)
 	// make a real sub-group and try one more level of indirection going back
 	// to the parent
 	grp2.SetInternalSubGroups(nil)
-	grp3, err := grp2.NewSubGroup("infinite-group3", quota.NewResources(quantity.SizeGiB))
+	grp3, err := grp2.NewSubGroup("infinite-group3", quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0))
 	c.Assert(err, IsNil)
 	grp3.SetInternalSubGroups([]*quota.Group{grp})
 
@@ -539,7 +560,7 @@ func (ts *quotaTestSuite) TestAddAllNecessaryGroups(c *C) {
 	// it should initially be empty
 	c.Assert(qs.AllQuotaGroups(), HasLen, 0)
 
-	grp1, err := quota.NewGroup("myroot", quota.NewResources(quantity.SizeGiB))
+	grp1, err := quota.NewGroup("myroot", quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0))
 	c.Assert(err, IsNil)
 
 	// add the group and make sure it is in the set
@@ -555,7 +576,7 @@ func (ts *quotaTestSuite) TestAddAllNecessaryGroups(c *C) {
 	c.Assert(qs.AllQuotaGroups(), DeepEquals, []*quota.Group{grp1})
 
 	// add a new group and make sure it is in the set now
-	grp2, err := quota.NewGroup("myroot2", quota.NewResources(quantity.SizeGiB))
+	grp2, err := quota.NewGroup("myroot2", quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0))
 	c.Assert(err, IsNil)
 	err = qs.AddAllNecessaryGroups(grp2)
 	c.Assert(err, IsNil)
@@ -566,7 +587,7 @@ func (ts *quotaTestSuite) TestAddAllNecessaryGroups(c *C) {
 
 	// make a sub-group and add the root group - it will automatically add
 	// the sub-group without us needing to explicitly add the sub-group
-	subgrp1, err := grp1.NewSubGroup("mysub1", quota.NewResources(quantity.SizeGiB))
+	subgrp1, err := grp1.NewSubGroup("mysub1", quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0))
 	c.Assert(err, IsNil)
 	// add grp2 as well
 	err = qs.AddAllNecessaryGroups(grp2)
@@ -583,13 +604,13 @@ func (ts *quotaTestSuite) TestAddAllNecessaryGroups(c *C) {
 
 	// create a new set of group and sub-groups to add the deepest child group
 	// and add that, and notice that the root groups are also added
-	grp3, err := quota.NewGroup("myroot3", quota.NewResources(quantity.SizeGiB))
+	grp3, err := quota.NewGroup("myroot3", quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0))
 	c.Assert(err, IsNil)
 
-	subgrp3, err := grp3.NewSubGroup("mysub3", quota.NewResources(quantity.SizeGiB))
+	subgrp3, err := grp3.NewSubGroup("mysub3", quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0))
 	c.Assert(err, IsNil)
 
-	subsubgrp3, err := subgrp3.NewSubGroup("mysubsub3", quota.NewResources(quantity.SizeGiB))
+	subsubgrp3, err := subgrp3.NewSubGroup("mysubsub3", quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0))
 	c.Assert(err, IsNil)
 
 	err = qs.AddAllNecessaryGroups(subsubgrp3)
@@ -599,13 +620,13 @@ func (ts *quotaTestSuite) TestAddAllNecessaryGroups(c *C) {
 	// finally create a tree with multiple branches and ensure that adding just
 	// a single deepest child will add all the other deepest children from other
 	// branches
-	grp4, err := quota.NewGroup("myroot4", quota.NewResources(quantity.SizeGiB))
+	grp4, err := quota.NewGroup("myroot4", quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0))
 	c.Assert(err, IsNil)
 
-	subgrp4, err := grp4.NewSubGroup("mysub4", quota.NewResources(quantity.SizeGiB/2))
+	subgrp4, err := grp4.NewSubGroup("mysub4", quota.NewResources(quantity.SizeGiB/2, 0, 0, nil, 0))
 	c.Assert(err, IsNil)
 
-	subgrp5, err := grp4.NewSubGroup("mysub5", quota.NewResources(quantity.SizeGiB/2))
+	subgrp5, err := grp4.NewSubGroup("mysub5", quota.NewResources(quantity.SizeGiB/2, 0, 0, nil, 0))
 	c.Assert(err, IsNil)
 
 	// adding just subgrp5 to a quota set will automatically add the other sub
@@ -617,13 +638,13 @@ func (ts *quotaTestSuite) TestAddAllNecessaryGroups(c *C) {
 }
 
 func (ts *quotaTestSuite) TestResolveCrossReferencesLimitCheckSkipsSelf(c *C) {
-	grp1, err := quota.NewGroup("myroot", quota.NewResources(quantity.SizeGiB))
+	grp1, err := quota.NewGroup("myroot", quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0))
 	c.Assert(err, IsNil)
 
-	subgrp1, err := grp1.NewSubGroup("mysub1", quota.NewResources(quantity.SizeGiB))
+	subgrp1, err := grp1.NewSubGroup("mysub1", quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0))
 	c.Assert(err, IsNil)
 
-	subgrp2, err := subgrp1.NewSubGroup("mysub2", quota.NewResources(quantity.SizeGiB))
+	subgrp2, err := subgrp1.NewSubGroup("mysub2", quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0))
 	c.Assert(err, IsNil)
 
 	all := map[string]*quota.Group{
@@ -636,13 +657,13 @@ func (ts *quotaTestSuite) TestResolveCrossReferencesLimitCheckSkipsSelf(c *C) {
 }
 
 func (ts *quotaTestSuite) TestResolveCrossReferencesCircular(c *C) {
-	grp1, err := quota.NewGroup("myroot", quota.NewResources(quantity.SizeGiB))
+	grp1, err := quota.NewGroup("myroot", quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0))
 	c.Assert(err, IsNil)
 
-	subgrp1, err := grp1.NewSubGroup("mysub1", quota.NewResources(quantity.SizeGiB))
+	subgrp1, err := grp1.NewSubGroup("mysub1", quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0))
 	c.Assert(err, IsNil)
 
-	subgrp2, err := subgrp1.NewSubGroup("mysub2", quota.NewResources(quantity.SizeGiB))
+	subgrp2, err := subgrp1.NewSubGroup("mysub2", quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0))
 	c.Assert(err, IsNil)
 
 	all := map[string]*quota.Group{
@@ -717,7 +738,7 @@ func (ts *quotaTestSuite) TestCurrentMemoryUsage(c *C) {
 	})
 	defer r()
 
-	grp1, err := quota.NewGroup("group", quota.NewResources(quantity.SizeGiB))
+	grp1, err := quota.NewGroup("group", quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0))
 	c.Assert(err, IsNil)
 
 	// group initially is inactive, so it has no current memory usage

--- a/snap/quota/quota_test.go
+++ b/snap/quota/quota_test.go
@@ -209,7 +209,7 @@ func (ts *quotaTestSuite) TestSimpleSubGroupVerification(c *C) {
 			rootlimits: quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
 			subname:    "sub",
 			sublimits:  quota.NewResources(quantity.SizeMiB/2, 1, 100, []int{0}, 64),
-			err:        "sub-group task limit of 64 is too large to fit inside remaining task space 32 for parent group myroot",
+			err:        "sub-group task limit of 64 is too large to fit inside remaining tasks 32 for parent group myroot",
 			comment:    "sub group with larger task allowance quota than parent unhappy",
 		},
 		{
@@ -353,7 +353,7 @@ func (ts *quotaTestSuite) TestResolveCrossReferences(c *C) {
 					MemoryLimit: 0,
 				},
 			},
-			err:     `group "foogroup" is invalid: quota group must have at least one resource quota set`,
+			err:     `group "foogroup" is invalid: quota group must have at least one resource limit set`,
 			comment: "invalid group",
 		},
 		{

--- a/snap/quota/quota_test.go
+++ b/snap/quota/quota_test.go
@@ -49,82 +49,82 @@ func (ts *quotaTestSuite) TestNewGroup(c *C) {
 	}{
 		{
 			name:    "group1",
-			limits:  quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
+			limits:  quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).WithCPUCount(1).WithCPUPercentage(100).WithAllowedCPUs([]int{0}).WithThreadLimit(32).Build(),
 			comment: "basic happy",
 		},
 		{
 			name:    "biglimit",
-			limits:  quota.NewResources(quantity.Size(math.MaxUint64), 1, 100, []int{0}, 32),
+			limits:  quota.NewResourcesBuilder().WithMemoryLimit(quantity.Size(math.MaxUint64)).Build(),
 			comment: "huge limit happy",
 		},
 		{
 			name:    "zero",
-			limits:  quota.NewResources(0, 0, 0, nil, 0),
+			limits:  quota.NewResourcesBuilder().Build(),
 			err:     `quota group must have at least one resource limit set`,
 			comment: "group with no limits",
 		},
 		{
 			name:    "group1-unsupported chars",
-			limits:  quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
+			limits:  quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build(),
 			err:     `invalid quota group name: contains invalid characters.*`,
 			comment: "unsupported characters in group name",
 		},
 		{
 			name:    "group%%%",
-			limits:  quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
+			limits:  quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build(),
 			err:     `invalid quota group name: contains invalid characters.*`,
 			comment: "more invalid characters in name",
 		},
 		{
 			name:    "CAPITALIZED",
-			limits:  quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
+			limits:  quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build(),
 			err:     `invalid quota group name: contains invalid characters.*`,
 			comment: "capitalized letters",
 		},
 		{
 			name:    "g1",
-			limits:  quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
+			limits:  quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build(),
 			comment: "small group name",
 		},
 		{
 			name:          "name-with-dashes",
 			sliceFileName: `name\x2dwith\x2ddashes`,
-			limits:        quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
+			limits:        quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build(),
 			comment:       "name with dashes",
 		},
 		{
 			name:    "",
-			limits:  quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
+			limits:  quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build(),
 			err:     `invalid quota group name: must not be empty`,
 			comment: "empty group name",
 		},
 		{
 			name:    "g",
-			limits:  quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
+			limits:  quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build(),
 			err:     `invalid quota group name: must be between 2 and 40 characters long.*`,
 			comment: "too small group name",
 		},
 		{
 			name:    "root",
-			limits:  quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
+			limits:  quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build(),
 			err:     `group name "root" reserved`,
 			comment: "reserved root name",
 		},
 		{
 			name:    "snapd",
-			limits:  quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
+			limits:  quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build(),
 			err:     `group name "snapd" reserved`,
 			comment: "reserved snapd name",
 		},
 		{
 			name:    "system",
-			limits:  quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
+			limits:  quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build(),
 			err:     `group name "system" reserved`,
 			comment: "reserved system name",
 		},
 		{
 			name:    "user",
-			limits:  quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
+			limits:  quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build(),
 			err:     `group name "user" reserved`,
 			comment: "reserved user name",
 		},
@@ -158,85 +158,85 @@ func (ts *quotaTestSuite) TestSimpleSubGroupVerification(c *C) {
 		comment       string
 	}{
 		{
-			rootlimits: quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
+			rootlimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).WithCPUCount(1).WithCPUPercentage(100).WithAllowedCPUs([]int{0}).WithThreadLimit(32).Build(),
 			subname:    "sub",
-			sublimits:  quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
+			sublimits:  quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).WithCPUCount(1).WithCPUPercentage(100).WithAllowedCPUs([]int{0}).WithThreadLimit(32).Build(),
 			comment:    "basic sub group with same quota as parent happy",
 		},
 		{
-			rootlimits: quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
+			rootlimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).WithCPUCount(1).WithCPUPercentage(100).WithAllowedCPUs([]int{0}).WithThreadLimit(32).Build(),
 			subname:    "sub",
-			sublimits:  quota.NewResources(quantity.SizeMiB/2, 1, 50, []int{0}, 16),
+			sublimits:  quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB / 2).WithCPUCount(1).WithCPUPercentage(50).WithAllowedCPUs([]int{0}).WithThreadLimit(16).Build(),
 			comment:    "basic sub group with smaller quota than parent happy",
 		},
 		{
-			rootlimits:    quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
+			rootlimits:    quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).WithCPUCount(1).WithCPUPercentage(100).WithAllowedCPUs([]int{0}).WithThreadLimit(32).Build(),
 			subname:       "sub-with-dashes",
 			sliceFileName: `myroot-sub\x2dwith\x2ddashes`,
-			sublimits:     quota.NewResources(quantity.SizeMiB/2, 1, 50, []int{0}, 16),
+			sublimits:     quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB / 2).WithCPUCount(1).WithCPUPercentage(50).WithAllowedCPUs([]int{0}).WithThreadLimit(16).Build(),
 			comment:       "basic sub group with dashes in the name",
 		},
 		{
 			rootname:      "my-root",
-			rootlimits:    quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
+			rootlimits:    quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).WithCPUCount(1).WithCPUPercentage(100).WithAllowedCPUs([]int{0}).WithThreadLimit(32).Build(),
 			subname:       "sub-with-dashes",
 			sliceFileName: `my\x2droot-sub\x2dwith\x2ddashes`,
-			sublimits:     quota.NewResources(quantity.SizeMiB/2, 1, 50, []int{0}, 16),
+			sublimits:     quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB / 2).WithCPUCount(1).WithCPUPercentage(50).WithAllowedCPUs([]int{0}).WithThreadLimit(16).Build(),
 			comment:       "parent and sub group have dashes in name",
 		},
 		{
-			rootlimits: quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
+			rootlimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).WithCPUCount(1).WithCPUPercentage(100).WithAllowedCPUs([]int{0}).WithThreadLimit(32).Build(),
 			subname:    "sub",
-			sublimits:  quota.NewResources(quantity.SizeMiB*2, 0, 0, nil, 0),
+			sublimits:  quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB * 2).Build(),
 			err:        "sub-group memory limit of 2 MiB is too large to fit inside remaining quota space 1 MiB for parent group myroot",
 			comment:    "sub group with larger memory quota than parent unhappy",
 		},
 		{
-			rootlimits: quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
+			rootlimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).WithCPUCount(1).WithCPUPercentage(100).WithAllowedCPUs([]int{0}).WithThreadLimit(32).Build(),
 			subname:    "sub",
-			sublimits:  quota.NewResources(quantity.SizeMiB/2, 2, 100, nil, 0),
+			sublimits:  quota.NewResourcesBuilder().WithCPUCount(2).WithCPUPercentage(100).Build(),
 			err:        "group \"sub\" would exceed its parent group's CPU limit",
 			comment:    "sub group with larger cpu count quota than parent unhappy",
 		},
 		{
-			rootlimits: quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
+			rootlimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).WithCPUCount(1).WithCPUPercentage(100).WithAllowedCPUs([]int{0}).WithThreadLimit(32).Build(),
 			subname:    "sub",
-			sublimits:  quota.NewResources(quantity.SizeMiB/2, 1, 50, []int{1}, 0),
+			sublimits:  quota.NewResourcesBuilder().WithAllowedCPUs([]int{1}).Build(),
 			err:        "group \"sub\" has a CPU allowance that is not allowed by its parent group",
 			comment:    "sub group with different cpu allowance quota than parent unhappy",
 		},
 		{
-			rootlimits: quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
+			rootlimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).WithCPUCount(1).WithCPUPercentage(100).WithAllowedCPUs([]int{0}).WithThreadLimit(32).Build(),
 			subname:    "sub",
-			sublimits:  quota.NewResources(quantity.SizeMiB/2, 1, 100, []int{0}, 64),
+			sublimits:  quota.NewResourcesBuilder().WithThreadLimit(64).Build(),
 			err:        "sub-group task limit of 64 is too large to fit inside remaining tasks 32 for parent group myroot",
 			comment:    "sub group with larger task allowance quota than parent unhappy",
 		},
 		{
-			rootlimits: quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
+			rootlimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).WithCPUCount(1).WithCPUPercentage(100).WithAllowedCPUs([]int{0}).WithThreadLimit(32).Build(),
 			subname:    "sub invalid chars",
-			sublimits:  quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
+			sublimits:  quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).WithCPUCount(1).WithCPUPercentage(100).WithAllowedCPUs([]int{0}).WithThreadLimit(32).Build(),
 			err:        `invalid quota group name: contains invalid characters.*`,
 			comment:    "sub group with invalid name",
 		},
 		{
-			rootlimits: quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
+			rootlimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).WithCPUCount(1).WithCPUPercentage(100).WithAllowedCPUs([]int{0}).WithThreadLimit(32).Build(),
 			subname:    "myroot",
-			sublimits:  quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
+			sublimits:  quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).WithCPUCount(1).WithCPUPercentage(100).WithAllowedCPUs([]int{0}).WithThreadLimit(32).Build(),
 			err:        `cannot use same name "myroot" for sub group as parent group`,
 			comment:    "sub group with same name as parent group",
 		},
 		{
-			rootlimits: quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
+			rootlimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).WithCPUCount(1).WithCPUPercentage(100).WithAllowedCPUs([]int{0}).WithThreadLimit(32).Build(),
 			subname:    "snapd",
-			sublimits:  quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
+			sublimits:  quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).WithCPUCount(1).WithCPUPercentage(100).WithAllowedCPUs([]int{0}).WithThreadLimit(32).Build(),
 			err:        `group name "snapd" reserved`,
 			comment:    "sub group with reserved name",
 		},
 		{
-			rootlimits: quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
+			rootlimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).WithCPUCount(1).WithCPUPercentage(100).WithAllowedCPUs([]int{0}).WithThreadLimit(32).Build(),
 			subname:    "zero",
-			sublimits:  quota.NewResources(0, 0, 0, nil, 0),
+			sublimits:  quota.NewResourcesBuilder().Build(),
 			err:        `quota group must have at least one resource limit set`,
 			comment:    "sub group with no limits",
 		},
@@ -269,43 +269,43 @@ func (ts *quotaTestSuite) TestSimpleSubGroupVerification(c *C) {
 }
 
 func (ts *quotaTestSuite) TestComplexSubGroups(c *C) {
-	rootGrp, err := quota.NewGroup("myroot", quota.NewResources(quantity.SizeMiB, 0, 0, nil, 0))
+	rootGrp, err := quota.NewGroup("myroot", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build())
 	c.Assert(err, IsNil)
 
 	// try adding 2 sub-groups with total quota split exactly equally
-	sub1, err := rootGrp.NewSubGroup("sub1", quota.NewResources(quantity.SizeMiB/2, 0, 0, nil, 0))
+	sub1, err := rootGrp.NewSubGroup("sub1", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB/2).Build())
 	c.Assert(err, IsNil)
 	c.Assert(sub1.SliceFileName(), Equals, "snap.myroot-sub1.slice")
 
-	sub2, err := rootGrp.NewSubGroup("sub2", quota.NewResources(quantity.SizeMiB/2, 0, 0, nil, 0))
+	sub2, err := rootGrp.NewSubGroup("sub2", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB/2).Build())
 	c.Assert(err, IsNil)
 	c.Assert(sub2.SliceFileName(), Equals, "snap.myroot-sub2.slice")
 
 	// adding another sub-group to this group fails
-	_, err = rootGrp.NewSubGroup("sub3", quota.NewResources(1, 0, 0, nil, 0))
+	_, err = rootGrp.NewSubGroup("sub3", quota.NewResourcesBuilder().WithMemoryLimit(1).Build())
 	c.Assert(err, ErrorMatches, "memory limit 1 is too small: size must be larger than 4KB")
 
 	// we can however add a sub-group to one of the sub-groups with the exact
 	// size of the parent sub-group
-	subsub1, err := sub1.NewSubGroup("subsub1", quota.NewResources(quantity.SizeMiB/2, 0, 0, nil, 0))
+	subsub1, err := sub1.NewSubGroup("subsub1", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB/2).Build())
 	c.Assert(err, IsNil)
 	c.Assert(subsub1.SliceFileName(), Equals, "snap.myroot-sub1-subsub1.slice")
 
 	// and we can even add a smaller sub-sub-sub-group to the sub-group
-	subsubsub1, err := subsub1.NewSubGroup("subsubsub1", quota.NewResources(quantity.SizeMiB/4, 0, 0, nil, 0))
+	subsubsub1, err := subsub1.NewSubGroup("subsubsub1", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB/4).Build())
 	c.Assert(err, IsNil)
 	c.Assert(subsubsub1.SliceFileName(), Equals, "snap.myroot-sub1-subsub1-subsubsub1.slice")
 }
 
 func (ts *quotaTestSuite) TestGroupUnmixableSnapsSubgroups(c *C) {
-	parent, err := quota.NewGroup("parent", quota.NewResources(quantity.SizeMiB, 0, 0, nil, 0))
+	parent, err := quota.NewGroup("parent", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build())
 	c.Assert(err, IsNil)
 
 	// now we add a snap to the parent group
 	parent.Snaps = []string{"test-snap"}
 
 	// add a subgroup to the parent group, this should fail as the group now has snaps
-	_, err = parent.NewSubGroup("sub", quota.NewResources(quantity.SizeMiB/2, 0, 0, nil, 0))
+	_, err = parent.NewSubGroup("sub", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB/2).Build())
 	c.Assert(err, ErrorMatches, "cannot mix sub groups with snaps in the same group")
 }
 
@@ -523,10 +523,10 @@ func (ts *quotaTestSuite) TestResolveCrossReferences(c *C) {
 }
 
 func (ts *quotaTestSuite) TestAddAllNecessaryGroupsAvoidsInfiniteRecursion(c *C) {
-	grp, err := quota.NewGroup("infinite-group", quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0))
+	grp, err := quota.NewGroup("infinite-group", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
 	c.Assert(err, IsNil)
 
-	grp2, err := grp.NewSubGroup("infinite-group2", quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0))
+	grp2, err := grp.NewSubGroup("infinite-group2", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
 	c.Assert(err, IsNil)
 
 	// create a cycle artificially to the same group
@@ -546,7 +546,7 @@ func (ts *quotaTestSuite) TestAddAllNecessaryGroupsAvoidsInfiniteRecursion(c *C)
 	// make a real sub-group and try one more level of indirection going back
 	// to the parent
 	grp2.SetInternalSubGroups(nil)
-	grp3, err := grp2.NewSubGroup("infinite-group3", quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0))
+	grp3, err := grp2.NewSubGroup("infinite-group3", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
 	c.Assert(err, IsNil)
 	grp3.SetInternalSubGroups([]*quota.Group{grp})
 
@@ -560,7 +560,7 @@ func (ts *quotaTestSuite) TestAddAllNecessaryGroups(c *C) {
 	// it should initially be empty
 	c.Assert(qs.AllQuotaGroups(), HasLen, 0)
 
-	grp1, err := quota.NewGroup("myroot", quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0))
+	grp1, err := quota.NewGroup("myroot", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
 	c.Assert(err, IsNil)
 
 	// add the group and make sure it is in the set
@@ -576,7 +576,7 @@ func (ts *quotaTestSuite) TestAddAllNecessaryGroups(c *C) {
 	c.Assert(qs.AllQuotaGroups(), DeepEquals, []*quota.Group{grp1})
 
 	// add a new group and make sure it is in the set now
-	grp2, err := quota.NewGroup("myroot2", quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0))
+	grp2, err := quota.NewGroup("myroot2", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
 	c.Assert(err, IsNil)
 	err = qs.AddAllNecessaryGroups(grp2)
 	c.Assert(err, IsNil)
@@ -587,7 +587,7 @@ func (ts *quotaTestSuite) TestAddAllNecessaryGroups(c *C) {
 
 	// make a sub-group and add the root group - it will automatically add
 	// the sub-group without us needing to explicitly add the sub-group
-	subgrp1, err := grp1.NewSubGroup("mysub1", quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0))
+	subgrp1, err := grp1.NewSubGroup("mysub1", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
 	c.Assert(err, IsNil)
 	// add grp2 as well
 	err = qs.AddAllNecessaryGroups(grp2)
@@ -604,13 +604,13 @@ func (ts *quotaTestSuite) TestAddAllNecessaryGroups(c *C) {
 
 	// create a new set of group and sub-groups to add the deepest child group
 	// and add that, and notice that the root groups are also added
-	grp3, err := quota.NewGroup("myroot3", quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0))
+	grp3, err := quota.NewGroup("myroot3", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
 	c.Assert(err, IsNil)
 
-	subgrp3, err := grp3.NewSubGroup("mysub3", quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0))
+	subgrp3, err := grp3.NewSubGroup("mysub3", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
 	c.Assert(err, IsNil)
 
-	subsubgrp3, err := subgrp3.NewSubGroup("mysubsub3", quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0))
+	subsubgrp3, err := subgrp3.NewSubGroup("mysubsub3", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
 	c.Assert(err, IsNil)
 
 	err = qs.AddAllNecessaryGroups(subsubgrp3)
@@ -620,13 +620,13 @@ func (ts *quotaTestSuite) TestAddAllNecessaryGroups(c *C) {
 	// finally create a tree with multiple branches and ensure that adding just
 	// a single deepest child will add all the other deepest children from other
 	// branches
-	grp4, err := quota.NewGroup("myroot4", quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0))
+	grp4, err := quota.NewGroup("myroot4", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
 	c.Assert(err, IsNil)
 
-	subgrp4, err := grp4.NewSubGroup("mysub4", quota.NewResources(quantity.SizeGiB/2, 0, 0, nil, 0))
+	subgrp4, err := grp4.NewSubGroup("mysub4", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB/2).Build())
 	c.Assert(err, IsNil)
 
-	subgrp5, err := grp4.NewSubGroup("mysub5", quota.NewResources(quantity.SizeGiB/2, 0, 0, nil, 0))
+	subgrp5, err := grp4.NewSubGroup("mysub5", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB/2).Build())
 	c.Assert(err, IsNil)
 
 	// adding just subgrp5 to a quota set will automatically add the other sub
@@ -638,13 +638,13 @@ func (ts *quotaTestSuite) TestAddAllNecessaryGroups(c *C) {
 }
 
 func (ts *quotaTestSuite) TestResolveCrossReferencesLimitCheckSkipsSelf(c *C) {
-	grp1, err := quota.NewGroup("myroot", quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0))
+	grp1, err := quota.NewGroup("myroot", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
 	c.Assert(err, IsNil)
 
-	subgrp1, err := grp1.NewSubGroup("mysub1", quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0))
+	subgrp1, err := grp1.NewSubGroup("mysub1", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
 	c.Assert(err, IsNil)
 
-	subgrp2, err := subgrp1.NewSubGroup("mysub2", quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0))
+	subgrp2, err := subgrp1.NewSubGroup("mysub2", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
 	c.Assert(err, IsNil)
 
 	all := map[string]*quota.Group{
@@ -657,13 +657,13 @@ func (ts *quotaTestSuite) TestResolveCrossReferencesLimitCheckSkipsSelf(c *C) {
 }
 
 func (ts *quotaTestSuite) TestResolveCrossReferencesCircular(c *C) {
-	grp1, err := quota.NewGroup("myroot", quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0))
+	grp1, err := quota.NewGroup("myroot", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
 	c.Assert(err, IsNil)
 
-	subgrp1, err := grp1.NewSubGroup("mysub1", quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0))
+	subgrp1, err := grp1.NewSubGroup("mysub1", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
 	c.Assert(err, IsNil)
 
-	subgrp2, err := subgrp1.NewSubGroup("mysub2", quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0))
+	subgrp2, err := subgrp1.NewSubGroup("mysub2", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
 	c.Assert(err, IsNil)
 
 	all := map[string]*quota.Group{
@@ -738,7 +738,7 @@ func (ts *quotaTestSuite) TestCurrentMemoryUsage(c *C) {
 	})
 	defer r()
 
-	grp1, err := quota.NewGroup("group", quota.NewResources(quantity.SizeGiB, 0, 0, nil, 0))
+	grp1, err := quota.NewGroup("group", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
 	c.Assert(err, IsNil)
 
 	// group initially is inactive, so it has no current memory usage

--- a/snap/quota/quota_test.go
+++ b/snap/quota/quota_test.go
@@ -60,7 +60,7 @@ func (ts *quotaTestSuite) TestNewGroup(c *C) {
 		{
 			name:    "zero",
 			limits:  quota.NewResources(0, 0, 0, nil, 0),
-			err:     `quota group must have at least one resource quota set`,
+			err:     `quota group must have at least one resource limit set`,
 			comment: "group with no limits",
 		},
 		{
@@ -237,7 +237,7 @@ func (ts *quotaTestSuite) TestSimpleSubGroupVerification(c *C) {
 			rootlimits: quota.NewResources(quantity.SizeMiB, 1, 100, []int{0}, 32),
 			subname:    "zero",
 			sublimits:  quota.NewResources(0, 0, 0, nil, 0),
-			err:        `quota group must have at least one resource quota set`,
+			err:        `quota group must have at least one resource limit set`,
 			comment:    "sub group with no limits",
 		},
 	}

--- a/snap/quota/quota_test.go
+++ b/snap/quota/quota_test.go
@@ -298,14 +298,14 @@ func (ts *quotaTestSuite) TestComplexSubGroups(c *C) {
 }
 
 func (ts *quotaTestSuite) TestGroupUnmixableSnapsSubgroups(c *C) {
-	parent, err := quota.NewGroup("parent", quota.NewResources(quantity.SizeMiB))
+	parent, err := quota.NewGroup("parent", quota.NewResources(quantity.SizeMiB, 0, 0, nil, 0))
 	c.Assert(err, IsNil)
 
 	// now we add a snap to the parent group
 	parent.Snaps = []string{"test-snap"}
 
 	// add a subgroup to the parent group, this should fail as the group now has snaps
-	_, err = parent.NewSubGroup("sub", quota.NewResources(quantity.SizeMiB/2))
+	_, err = parent.NewSubGroup("sub", quota.NewResources(quantity.SizeMiB/2, 0, 0, nil, 0))
 	c.Assert(err, ErrorMatches, "cannot mix sub groups with snaps in the same group")
 }
 

--- a/snap/quota/resources.go
+++ b/snap/quota/resources.go
@@ -39,7 +39,7 @@ type ResourceThreads struct {
 	Limit int `json:"limit"`
 }
 
-// Resources is built up of multiple quota limits. Each quota limit is a pointer
+// Resources are built up of multiple quota limits. Each quota limit is a pointer
 // value to indicate that their presence may be optional, and because we want to detect
 // whenever someone changes a limit to '0' explicitly.
 type Resources struct {
@@ -169,26 +169,4 @@ func (qr *Resources) Change(newLimits Resources) error {
 		qr.Threads = newLimits.Threads
 	}
 	return nil
-}
-
-func NewResources(memoryLimit quantity.Size, cpuCount int, cpuPercentage int, allowedCpus []int, threadLimit int) Resources {
-	var quotaResources Resources
-	if memoryLimit != 0 {
-		quotaResources.Memory = &ResourceMemory{
-			Limit: memoryLimit,
-		}
-	}
-	if cpuCount != 0 || cpuPercentage != 0 || len(allowedCpus) != 0 {
-		quotaResources.CPU = &ResourceCPU{
-			Count:       cpuCount,
-			Percentage:  cpuPercentage,
-			AllowedCPUs: allowedCpus,
-		}
-	}
-	if threadLimit != 0 {
-		quotaResources.Threads = &ResourceThreads{
-			Limit: threadLimit,
-		}
-	}
-	return quotaResources
 }

--- a/snap/quota/resources.go
+++ b/snap/quota/resources.go
@@ -65,9 +65,14 @@ func (qr *Resources) validateMemoryQuota() error {
 }
 
 func (qr *Resources) validateCpuQuota() error {
-	// make sure the cpu count is not zero
+	// if cpu count is non-zero, then percentage should be set
+	if qr.Cpu.Count != 0 && qr.Cpu.Percentage == 0 {
+		return fmt.Errorf("cannot validate quota limits with count of >0 and percentage of 0")
+	}
+
+	// atleast one cpu limit value must be set
 	if qr.Cpu.Count == 0 && qr.Cpu.Percentage == 0 && len(qr.Cpu.AllowedCpus) == 0 {
-		return fmt.Errorf("cannot create quota group with a cpu quota of 0 and allowed cpus of 0")
+		return fmt.Errorf("cannot validate quota limits with a cpu quota of 0 and allowed cpus of 0")
 	}
 	return nil
 }

--- a/snap/quota/resources.go
+++ b/snap/quota/resources.go
@@ -29,10 +29,10 @@ type ResourceMemory struct {
 	Limit quantity.Size `json:"limit"`
 }
 
-type ResourceCpu struct {
+type ResourceCPU struct {
 	Count       int   `json:"count"`
 	Percentage  int   `json:"percentage"`
-	AllowedCpus []int `json:"allowed-cpus"`
+	AllowedCPUs []int `json:"allowed-cpus"`
 }
 
 type ResourceThreads struct {
@@ -43,9 +43,9 @@ type ResourceThreads struct {
 // value to indicate that their presence may be optional, and because we want to detect
 // whenever someone changes a limit to '0' explicitly.
 type Resources struct {
-	Memory *ResourceMemory  `json:"memory,omitempty"`
-	Cpu    *ResourceCpu     `json:"cpu,omitempty"`
-	Thread *ResourceThreads `json:"thread,omitempty"`
+	Memory  *ResourceMemory  `json:"memory,omitempty"`
+	CPU     *ResourceCPU     `json:"cpu,omitempty"`
+	Threads *ResourceThreads `json:"thread,omitempty"`
 }
 
 func (qr *Resources) validateMemoryQuota() error {
@@ -66,12 +66,12 @@ func (qr *Resources) validateMemoryQuota() error {
 
 func (qr *Resources) validateCpuQuota() error {
 	// if cpu count is non-zero, then percentage should be set
-	if qr.Cpu.Count != 0 && qr.Cpu.Percentage == 0 {
+	if qr.CPU.Count != 0 && qr.CPU.Percentage == 0 {
 		return fmt.Errorf("cannot validate quota limits with count of >0 and percentage of 0")
 	}
 
 	// atleast one cpu limit value must be set
-	if qr.Cpu.Count == 0 && qr.Cpu.Percentage == 0 && len(qr.Cpu.AllowedCpus) == 0 {
+	if qr.CPU.Count == 0 && qr.CPU.Percentage == 0 && len(qr.CPU.AllowedCPUs) == 0 {
 		return fmt.Errorf("cannot validate quota limits with a cpu quota of 0 and allowed cpus of 0")
 	}
 	return nil
@@ -79,7 +79,7 @@ func (qr *Resources) validateCpuQuota() error {
 
 func (qr *Resources) validateThreadQuota() error {
 	// make sure the thread count is not zero
-	if qr.Thread.Limit == 0 {
+	if qr.Threads.Limit == 0 {
 		return fmt.Errorf("cannot create quota group with a thread count of 0")
 	}
 	return nil
@@ -91,7 +91,7 @@ func (qr *Resources) validateThreadQuota() error {
 // If cpu percentage is provided, it must be between 1 and 100.
 // If thread count is provided, it must be above 0.
 func (qr *Resources) Validate() error {
-	if qr.Memory == nil && qr.Cpu == nil && qr.Thread == nil {
+	if qr.Memory == nil && qr.CPU == nil && qr.Threads == nil {
 		return fmt.Errorf("quota group must have at least one resource limit set")
 	}
 
@@ -101,13 +101,13 @@ func (qr *Resources) Validate() error {
 		}
 	}
 
-	if qr.Cpu != nil {
+	if qr.CPU != nil {
 		if err := qr.validateCpuQuota(); err != nil {
 			return err
 		}
 	}
 
-	if qr.Thread != nil {
+	if qr.Threads != nil {
 		if err := qr.validateThreadQuota(); err != nil {
 			return err
 		}
@@ -149,24 +149,24 @@ func (qr *Resources) Change(newLimits Resources) error {
 	if newLimits.Memory != nil {
 		qr.Memory = newLimits.Memory
 	}
-	if newLimits.Cpu != nil {
-		if qr.Cpu == nil {
-			qr.Cpu = newLimits.Cpu
+	if newLimits.CPU != nil {
+		if qr.CPU == nil {
+			qr.CPU = newLimits.CPU
 		} else {
 			// update count/percentage as one unit
-			if newLimits.Cpu.Count != 0 || newLimits.Cpu.Percentage != 0 {
-				qr.Cpu.Count = newLimits.Cpu.Count
-				qr.Cpu.Percentage = newLimits.Cpu.Percentage
+			if newLimits.CPU.Count != 0 || newLimits.CPU.Percentage != 0 {
+				qr.CPU.Count = newLimits.CPU.Count
+				qr.CPU.Percentage = newLimits.CPU.Percentage
 			}
 
 			// update allowed cpus as one unit
-			if len(newLimits.Cpu.AllowedCpus) != 0 {
-				qr.Cpu.AllowedCpus = newLimits.Cpu.AllowedCpus
+			if len(newLimits.CPU.AllowedCPUs) != 0 {
+				qr.CPU.AllowedCPUs = newLimits.CPU.AllowedCPUs
 			}
 		}
 	}
-	if newLimits.Thread != nil {
-		qr.Thread = newLimits.Thread
+	if newLimits.Threads != nil {
+		qr.Threads = newLimits.Threads
 	}
 	return nil
 }
@@ -179,14 +179,14 @@ func NewResources(memoryLimit quantity.Size, cpuCount int, cpuPercentage int, al
 		}
 	}
 	if cpuCount != 0 || cpuPercentage != 0 || len(allowedCpus) != 0 {
-		quotaResources.Cpu = &ResourceCpu{
+		quotaResources.CPU = &ResourceCPU{
 			Count:       cpuCount,
 			Percentage:  cpuPercentage,
-			AllowedCpus: allowedCpus,
+			AllowedCPUs: allowedCpus,
 		}
 	}
 	if threadLimit != 0 {
-		quotaResources.Thread = &ResourceThreads{
+		quotaResources.Threads = &ResourceThreads{
 			Limit: threadLimit,
 		}
 	}

--- a/snap/quota/resources.go
+++ b/snap/quota/resources.go
@@ -25,16 +25,27 @@ import (
 	"github.com/snapcore/snapd/gadget/quantity"
 )
 
-// ResourceMemory is the memory limit for a quota group.
 type ResourceMemory struct {
 	Limit quantity.Size `json:"limit"`
+}
+
+type ResourceCpu struct {
+	Count       int   `json:"count"`
+	Percentage  int   `json:"percentage"`
+	AllowedCpus []int `json:"allowed-cpus"`
+}
+
+type ResourceThreads struct {
+	Limit int `json:"limit"`
 }
 
 // Resources is built up of multiple quota limits. Each quota limit is a pointer
 // value to indicate that their presence may be optional, and because we want to detect
 // whenever someone changes a limit to '0' explicitly.
 type Resources struct {
-	Memory *ResourceMemory `json:"memory,omitempty"`
+	Memory *ResourceMemory  `json:"memory,omitempty"`
+	Cpu    *ResourceCpu     `json:"cpu,omitempty"`
+	Thread *ResourceThreads `json:"thread,omitempty"`
 }
 
 func (qr *Resources) validateMemoryQuota() error {
@@ -53,12 +64,30 @@ func (qr *Resources) validateMemoryQuota() error {
 	return nil
 }
 
+func (qr *Resources) validateCpuQuota() error {
+	// make sure the cpu count is not zero
+	if qr.Cpu.Count == 0 && qr.Cpu.Percentage == 0 && len(qr.Cpu.AllowedCpus) == 0 {
+		return fmt.Errorf("cannot create quota group with a cpu quota of 0 and allowed cpus of 0")
+	}
+	return nil
+}
+
+func (qr *Resources) validateThreadQuota() error {
+	// make sure the thread count is not zero
+	if qr.Thread.Limit == 0 {
+		return fmt.Errorf("cannot create quota group with a thread count of 0")
+	}
+	return nil
+}
+
 // Validate performs validation of the provided quota resources for a group.
-// The restrictions imposed are that atleast one limit should exist (memory for now),
-// and the memory limit must be above 4KB.
+// The restrictions imposed are that atleast one limit should be set.
+// If memory limit is provided, it must be above 4KB.
+// If cpu percentage is provided, it must be between 1 and 100.
+// If thread count is provided, it must be above 0.
 func (qr *Resources) Validate() error {
-	if qr.Memory == nil {
-		return fmt.Errorf("quota group must have a memory limit set")
+	if qr.Memory == nil && qr.Cpu == nil && qr.Thread == nil {
+		return fmt.Errorf("quota group must have at least one resource limit set")
 	}
 
 	if qr.Memory != nil {
@@ -67,6 +96,17 @@ func (qr *Resources) Validate() error {
 		}
 	}
 
+	if qr.Cpu != nil {
+		if err := qr.validateCpuQuota(); err != nil {
+			return err
+		}
+	}
+
+	if qr.Thread != nil {
+		if err := qr.validateThreadQuota(); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -104,14 +144,45 @@ func (qr *Resources) Change(newLimits Resources) error {
 	if newLimits.Memory != nil {
 		qr.Memory = newLimits.Memory
 	}
+	if newLimits.Cpu != nil {
+		if qr.Cpu == nil {
+			qr.Cpu = newLimits.Cpu
+		} else {
+			// update count/percentage as one unit
+			if newLimits.Cpu.Count != 0 || newLimits.Cpu.Percentage != 0 {
+				qr.Cpu.Count = newLimits.Cpu.Count
+				qr.Cpu.Percentage = newLimits.Cpu.Percentage
+			}
+
+			// update allowed cpus as one unit
+			if len(newLimits.Cpu.AllowedCpus) != 0 {
+				qr.Cpu.AllowedCpus = newLimits.Cpu.AllowedCpus
+			}
+		}
+	}
+	if newLimits.Thread != nil {
+		qr.Thread = newLimits.Thread
+	}
 	return nil
 }
 
-func NewResources(memoryLimit quantity.Size) Resources {
+func NewResources(memoryLimit quantity.Size, cpuCount int, cpuPercentage int, allowedCpus []int, threadLimit int) Resources {
 	var quotaResources Resources
 	if memoryLimit != 0 {
 		quotaResources.Memory = &ResourceMemory{
 			Limit: memoryLimit,
+		}
+	}
+	if cpuCount != 0 || cpuPercentage != 0 || len(allowedCpus) != 0 {
+		quotaResources.Cpu = &ResourceCpu{
+			Count:       cpuCount,
+			Percentage:  cpuPercentage,
+			AllowedCpus: allowedCpus,
+		}
+	}
+	if threadLimit != 0 {
+		quotaResources.Thread = &ResourceThreads{
+			Limit: threadLimit,
 		}
 	}
 	return quotaResources

--- a/snap/quota/resources_builder.go
+++ b/snap/quota/resources_builder.go
@@ -1,0 +1,108 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+* Copyright (C) 2021 Canonical Ltd
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License version 3 as
+* published by the Free Software Foundation.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+ */
+
+package quota
+
+import (
+	"github.com/snapcore/snapd/gadget/quantity"
+)
+
+type ResourcesBuilder struct {
+	MemoryLimit    quantity.Size
+	MemoryLimitSet bool
+
+	CPUCount    int
+	CPUCountSet bool
+
+	CPUPercentage    int
+	CPUPercentageSet bool
+
+	AllowedCPUs    []int
+	AllowedCPUsSet bool
+
+	ThreadLimit    int
+	ThreadLimitSet bool
+}
+
+func (rb *ResourcesBuilder) WithMemoryLimit(limit quantity.Size) *ResourcesBuilder {
+	rb.MemoryLimit = limit
+	rb.MemoryLimitSet = true
+	return rb
+}
+
+func (rb *ResourcesBuilder) WithCPUCount(count int) *ResourcesBuilder {
+	rb.CPUCount = count
+	rb.CPUCountSet = true
+	return rb
+}
+
+func (rb *ResourcesBuilder) WithCPUPercentage(percentage int) *ResourcesBuilder {
+	rb.CPUPercentage = percentage
+	rb.CPUPercentageSet = true
+	return rb
+}
+
+func (rb *ResourcesBuilder) WithAllowedCPUs(allowedCPUs []int) *ResourcesBuilder {
+	rb.AllowedCPUs = allowedCPUs
+	rb.AllowedCPUsSet = true
+	return rb
+}
+
+func (rb *ResourcesBuilder) WithThreadLimit(limit int) *ResourcesBuilder {
+	rb.ThreadLimit = limit
+	rb.ThreadLimitSet = true
+	return rb
+}
+
+func (rb *ResourcesBuilder) Build() Resources {
+	var quotaResources Resources
+	if rb.MemoryLimitSet {
+		quotaResources.Memory = &ResourceMemory{
+			Limit: rb.MemoryLimit,
+		}
+	}
+	if rb.CPUCountSet || rb.CPUPercentageSet || rb.AllowedCPUsSet {
+		quotaResources.CPU = &ResourceCPU{
+			Count:       rb.CPUCount,
+			Percentage:  rb.CPUPercentage,
+			AllowedCPUs: rb.AllowedCPUs,
+		}
+	}
+	if rb.ThreadLimitSet {
+		quotaResources.Threads = &ResourceThreads{
+			Limit: rb.ThreadLimit,
+		}
+	}
+	return quotaResources
+}
+
+func NewResourcesBuilder() *ResourcesBuilder {
+	return &ResourcesBuilder{
+		MemoryLimit:      0,
+		MemoryLimitSet:   false,
+		CPUCount:         0,
+		CPUCountSet:      false,
+		CPUPercentage:    0,
+		CPUPercentageSet: false,
+		AllowedCPUs:      nil,
+		AllowedCPUsSet:   false,
+		ThreadLimit:      0,
+		ThreadLimitSet:   false,
+	}
+}

--- a/snap/quota/resources_test.go
+++ b/snap/quota/resources_test.go
@@ -37,8 +37,8 @@ func (s *resourcesTestSuite) TestQuotaValidationFails(c *C) {
 	}{
 		{quota.Resources{}, `quota group must have at least one resource limit set`},
 		{quota.Resources{Memory: &quota.ResourceMemory{}}, `memory quota must have a limit set`},
-		{quota.Resources{Cpu: &quota.ResourceCpu{}}, `cannot validate quota limits with a cpu quota of 0 and allowed cpus of 0`},
-		{quota.Resources{Thread: &quota.ResourceThreads{}}, `cannot create quota group with a thread count of 0`},
+		{quota.Resources{CPU: &quota.ResourceCPU{}}, `cannot validate quota limits with a cpu quota of 0 and allowed cpus of 0`},
+		{quota.Resources{Threads: &quota.ResourceThreads{}}, `cannot create quota group with a thread count of 0`},
 		{quota.NewResources(quantity.Size(0), 0, 0, nil, 0), `quota group must have at least one resource limit set`},
 		{quota.NewResources(quantity.SizeKiB, 0, 0, nil, 0), `memory limit 1024 is too small: size must be larger than 4KB`},
 		{quota.NewResources(0, 1, 0, nil, 0), `cannot validate quota limits with count of >0 and percentage of 0`},

--- a/snap/quota/resources_test.go
+++ b/snap/quota/resources_test.go
@@ -35,8 +35,8 @@ func (s *resourcesTestSuite) TestQuotaValidationFails(c *C) {
 		limits quota.Resources
 		err    string
 	}{
-		{quota.Resources{}, `quota group must have a memory limit set`},
-		{quota.NewResources(quantity.Size(0)), `quota group must have a memory limit set`},
+		{quota.Resources{}, `quota group must have at least one resource limit set`},
+		{quota.NewResources(quantity.Size(0), 0, 0, nil, 0), `quota group must have at least one resource limit set`},
 	}
 
 	for _, t := range tests {
@@ -65,8 +65,8 @@ func (s *resourcesTestSuite) TestQuotaChangeValidationFails(c *C) {
 		updateLimits quota.Resources
 		err          string
 	}{
-		{quota.NewResources(quantity.SizeMiB), quota.Resources{&quota.ResourceMemory{0}}, `cannot remove memory limit from quota group`},
-		{quota.NewResources(quantity.SizeMiB), quota.NewResources(5 * quantity.SizeKiB), `cannot decrease memory limit, remove and re-create it to decrease the limit`},
+		{quota.NewResources(quantity.SizeMiB, 0, 0, nil, 0), quota.Resources{&quota.ResourceMemory{0}, nil, nil}, `cannot remove memory limit from quota group`},
+		{quota.NewResources(quantity.SizeMiB, 0, 0, nil, 0), quota.NewResources(5*quantity.SizeKiB, 0, 0, nil, 0), `cannot decrease memory limit, remove and re-create it to decrease the limit`},
 	}
 
 	for _, t := range tests {

--- a/tests/main/snap-quota-cpu/task.yaml
+++ b/tests/main/snap-quota-cpu/task.yaml
@@ -30,7 +30,7 @@ execute: |
   echo "Verifying cpu usage, expecting atleast above 90%"
   # Bash cannot handle floating point numbers, so we multiple by 100 and use
   # integer numbers instead
-  initialUsage=`top -b -n 2 -d 0.2 | head | grep "stress" | awk '{print $9*100}'`
+  initialUsage=$(top -b -n 2 -d 0.2 | head | grep "stress" | awk '{print $9*100}')
   if [ "$initialUsage" -lt 9000 ]; then
     echo "Expected cpu usage to be atleast above 90%, got $initialUsage"
     exit 1

--- a/tests/main/snap-quota-cpu/task.yaml
+++ b/tests/main/snap-quota-cpu/task.yaml
@@ -31,7 +31,7 @@ execute: |
   # Bash cannot handle floating point numbers, so we multiple by 100 and use
   # integer numbers instead
   initialUsage=`top -b -n 2 -d 0.2 | head | grep "stress" | awk '{print $9*100}'`
-  if [ $initialUsage -lt 9000 ]; then
+  if [ "$initialUsage" -lt 9000 ]; then
     echo "Expected cpu usage to be atleast above 90%, got $initialUsage"
     exit 1
   fi
@@ -80,11 +80,11 @@ execute: |
     n=0
     until [ "$n" -ge 5 ]
     do
-      usage=`top -b -n 2 -d 0.2 | head | grep "$1" | awk '{print $9*100}'`
-      if [ $usage -lt $2 ]; then
+      usage=$(top -b -n 2 -d 0.2 | head | grep "$1" | awk '{print $9*100}')
+      if [ "$usage" -lt "$2" ]; then
         return 0
       fi
-      n=$((n+1)) 
+      n=$((n+1))
       sleep 1
     done
 
@@ -93,14 +93,14 @@ execute: |
   }
 
   echo "Verifying quota cpu usage, expecting around 50% usage"
-  # allow for up to 10% difference, this is neccessary due to how we measure
+  # allow for up to 10% difference, this is necessary due to how we measure
   ensure_cpu_usage_lower_than "stress" 6000
 
   echo "Update the quota to a lower percentage while running"
   snap set-quota group-one --cpu=20%
 
   echo "Verifying quota cpu usage, expecting around 20% usage"
-  # allow for up to 10% difference, this is neccessary due to how we measure
+  # allow for up to 10% difference, this is necessary due to how we measure
   ensure_cpu_usage_lower_than "stress" 3000
 
   echo "Removing the quota will stop the slice and the service will be restarted"
@@ -115,8 +115,8 @@ execute: |
   systemctl show --property=ActiveState "$sliceName" | MATCH "ActiveState=inactive"
 
   echo "Verifying cpu usage, expecting atleast above 90% again"
-  currentUsage=`top -b -n 2 -d 5.0 | head | grep "stress" | awk '{print $9*100}'`
-  if [ $currentUsage -lt 9000 ]; then
+  currentUsage=$(top -b -n 2 -d 5.0 | head | grep "stress" | awk '{print $9*100}')
+  if [ "$currentUsage" -lt 9000 ]; then
     echo "Expected cpu usage to be atleast above 90%, got $currentUsage"
     exit 1
   fi

--- a/tests/main/snap-quota-cpu/task.yaml
+++ b/tests/main/snap-quota-cpu/task.yaml
@@ -24,17 +24,25 @@ execute: |
   echo "Starting service and verifying cpu usage"
   snap start test-snapd-stressd.stress-sc
 
-  echo "Wait for a second to cpu usage to stabilize"
-  sleep 1
+  # helper function that has retry logic to allow for cpu usage to stabilize
+  function ensure_cpu_usage_higher_than {
+    n=0
+    until [ "$n" -ge 5 ]
+    do
+      usage=$(top -b -n 2 -d 0.2 | head | grep "$1" | awk '{print $9*100}')
+      if [ "$usage" -gt "$2" ]; then
+        return 0
+      fi
+      n=$((n+1))
+      sleep 1
+    done
 
-  echo "Verifying cpu usage, expecting atleast above 90%"
-  # Bash cannot handle floating point numbers, so we multiple by 100 and use
-  # integer numbers instead
-  initialUsage=$(top -b -n 2 -d 0.2 | head | grep "stress" | awk '{print $9*100}')
-  if [ "$initialUsage" -lt 9000 ]; then
-    echo "Expected cpu usage to be atleast above 90%, got $initialUsage"
+    echo "Expected cpu usage to be minimum $2%, got $usage"
     exit 1
-  fi
+  }
+  
+  echo "Verifying cpu usage, expecting atleast above 90%"
+  ensure_cpu_usage_higher_than "stress" 9000
 
   echo "Create a group with a snap in it"
   snap set-quota group-one --cpu=2x25% test-snapd-stressd
@@ -115,11 +123,7 @@ execute: |
   systemctl show --property=ActiveState "$sliceName" | MATCH "ActiveState=inactive"
 
   echo "Verifying cpu usage, expecting atleast above 90% again"
-  currentUsage=$(top -b -n 2 -d 5.0 | head | grep "stress" | awk '{print $9*100}')
-  if [ "$currentUsage" -lt 9000 ]; then
-    echo "Expected cpu usage to be atleast above 90%, got $currentUsage"
-    exit 1
-  fi
+  ensure_cpu_usage_higher_than "stress" 9000
 
   echo "Stopping the service"
   snap stop test-snapd-stressd.stress-sc

--- a/tests/main/snap-quota-cpu/task.yaml
+++ b/tests/main/snap-quota-cpu/task.yaml
@@ -1,0 +1,125 @@
+summary: Functional test for cpu quota-related snap commands.
+
+details: |
+  Functional test for snap cpu quota group commands ensuring that they are 
+  effective in practice.
+
+# these systems do not support quota groups due to their old systemd versions,
+# we do have a check to do for these systems, but that is just to ensure that
+# we don't allow using quota groups, and that check is done in the snap-quota
+# spread instead
+systems:
+  - -ubuntu-14.04-*
+  - -centos-7-*
+  - -amazon-linux-2-*
+  - -ubuntu-16.04-*
+  - -ubuntu-core-16-*
+
+prepare: |
+  snap install test-snapd-stressd --edge --devmode
+  snap set system experimental.quota-groups=true
+  tests.cleanup defer snap unset system experimental.quota-groups
+
+execute: |
+  echo "Starting service and verifying cpu usage"
+  snap start test-snapd-stressd.stress-sc
+
+  echo "Wait for a second to cpu usage to stabilize"
+  sleep 1
+
+  echo "Verifying cpu usage, expecting atleast above 90%"
+  # Bash cannot handle floating point numbers, so we multiple by 100 and use
+  # integer numbers instead
+  initialUsage=`top -b -n 2 -d 0.2 | head | grep "stress" | awk '{print $9*100}'`
+  if [ $initialUsage -lt 9000 ]; then
+    echo "Expected cpu usage to be atleast above 90%, got $initialUsage"
+    exit 1
+  fi
+
+  echo "Create a group with a snap in it"
+  snap set-quota group-one --cpu=2x25% test-snapd-stressd
+
+  echo "The systemd slice should be active now"
+  sliceName="snap.$(systemd-escape --path group-one).slice"
+  systemctl show --property=ActiveState "$sliceName" | MATCH "ActiveState=active"
+
+  echo "The service should also still be active"
+  snap services test-snapd-stressd.stress-sc | MATCH "test-snapd-stressd.stress-sc\s+disabled\s+active"
+
+  # systemd/kernel have three different locations for the cgroup pids depending
+  # on version
+  echo "The systemd slice should have two processes (all from stress snap) in it now"
+  cgroupsV1OldSystemdProcsFile="/sys/fs/cgroup/cpuacct/$sliceName/snap.test-snapd-stressd.stress-sc.service/cgroup.procs"
+  cgroupsV1ProcsFile="/sys/fs/cgroup/cpuacct/$sliceName/cgroup.procs"
+  cgroupsV2ProcsFile="/sys/fs/cgroup/$sliceName/snap.test-snapd-stressd.stress-sc.service/cgroup.procs"
+  if [ -e "$cgroupsV2ProcsFile" ]; then
+      cgroupProcsFile="$cgroupsV2ProcsFile"
+  elif [ -e "$cgroupsV1OldSystemdProcsFile" ]; then
+      cgroupProcsFile="$cgroupsV1OldSystemdProcsFile"
+  elif [ -e "$cgroupsV1ProcsFile" ]; then
+      cgroupProcsFile="$cgroupsV1ProcsFile"
+  else
+      echo "cannot detect cgroup procs file"
+      exit 1
+  fi
+
+  #shellcheck disable=SC2016
+  retry --wait 1 -n 100 --env cgroupProcsFile="$cgroupProcsFile" sh -x -c 'test "$(wc -l < $cgroupProcsFile)" = 2'
+  SERVER_PID=$(cat "$cgroupProcsFile")
+
+  echo "And that process is the main PID for the stress daemon"
+  systemctl show --property=MainPID snap.test-snapd-stressd.stress-sc.service | MATCH "MainPID=$SERVER_PID"
+
+  echo "And the service is in the Control Group for the slice"
+  # using a regexp for the ControlGroup match here as on older systemd (16.04)
+  # the group is double escaped
+  systemctl show --property=ControlGroup snap.test-snapd-stressd.stress-sc.service | MATCH 'ControlGroup=/snap.group(.*)one.slice/snap.test-snapd-stressd.stress-sc.service'
+
+  # helper function that has retry logic to allow for cpu usage to stabilize
+  function ensure_cpu_usage_lower_than {
+    n=0
+    until [ "$n" -ge 5 ]
+    do
+      usage=`top -b -n 2 -d 0.2 | head | grep "$1" | awk '{print $9*100}'`
+      if [ $usage -lt $2 ]; then
+        return 0
+      fi
+      n=$((n+1)) 
+      sleep 1
+    done
+
+    echo "Expected cpu usage to be maximum $2%, got $usage"
+    exit 1
+  }
+
+  echo "Verifying quota cpu usage, expecting around 50% usage"
+  # allow for up to 10% difference, this is neccessary due to how we measure
+  ensure_cpu_usage_lower_than "stress" 6000
+
+  echo "Update the quota to a lower percentage while running"
+  snap set-quota group-one --cpu=20%
+
+  echo "Verifying quota cpu usage, expecting around 20% usage"
+  # allow for up to 10% difference, this is neccessary due to how we measure
+  ensure_cpu_usage_lower_than "stress" 3000
+
+  echo "Removing the quota will stop the slice and the service will be restarted"
+  snap remove-quota group-one
+  systemctl show --property=MainPID snap.test-snapd-stressd.stress-sc.service | NOMATCH "MainPID=$SERVER_PID"
+  snap services test-snapd-stressd.stress-sc | MATCH "test-snapd-stressd.stress-sc\s+disabled\s+active"
+
+  echo "And the service is not in a slice anymore"
+  systemctl show --property=ControlGroup snap.test-snapd-stressd.stress-sc.service | NOMATCH "/$sliceName/snap.test-snapd-stressd.stress-sc.service"
+
+  echo "And the slice is not active anymore"
+  systemctl show --property=ActiveState "$sliceName" | MATCH "ActiveState=inactive"
+
+  echo "Verifying cpu usage, expecting atleast above 90% again"
+  currentUsage=`top -b -n 2 -d 5.0 | head | grep "stress" | awk '{print $9*100}'`
+  if [ $currentUsage -lt 9000 ]; then
+    echo "Expected cpu usage to be atleast above 90%, got $currentUsage"
+    exit 1
+  fi
+
+  echo "Stopping the service"
+  snap stop test-snapd-stressd.stress-sc

--- a/tests/main/snap-quota-cpu/task.yaml
+++ b/tests/main/snap-quota-cpu/task.yaml
@@ -41,8 +41,8 @@ execute: |
     exit 1
   }
   
-  echo "Verifying cpu usage, expecting atleast above 90%"
-  ensure_cpu_usage_higher_than "stress" 9000
+  echo "Verifying cpu usage, expecting atleast above 60% as we test against 50%"
+  ensure_cpu_usage_higher_than "stress" 6000
 
   echo "Create a group with a snap in it"
   snap set-quota group-one --cpu=2x25% test-snapd-stressd
@@ -122,8 +122,8 @@ execute: |
   echo "And the slice is not active anymore"
   systemctl show --property=ActiveState "$sliceName" | MATCH "ActiveState=inactive"
 
-  echo "Verifying cpu usage, expecting atleast above 90% again"
-  ensure_cpu_usage_higher_than "stress" 9000
+  echo "Verifying cpu usage, expecting atleast above 60% again"
+  ensure_cpu_usage_higher_than "stress" 6000
 
   echo "Stopping the service"
   snap stop test-snapd-stressd.stress-sc

--- a/tests/main/snap-quota-memory/task.yaml
+++ b/tests/main/snap-quota-memory/task.yaml
@@ -1,7 +1,7 @@
-summary: Functional test for quota-related snap commands.
+summary: Functional test for memory quota-related snap commands.
 
 details: |
-  Functional test for snap quota group commands ensuring that they are 
+  Functional test for snap memory quota group commands ensuring that they are 
   effective in practice.
 
 # these systems do not support quota groups due to their old systemd versions,

--- a/tests/main/snap-quota-thread/task.yaml
+++ b/tests/main/snap-quota-thread/task.yaml
@@ -108,7 +108,7 @@ execute: |
 
   echo "Verify the service is now running at full capacity"
   SPAWNER_PID=$(systemctl show snap.test-snapd-stressd.spawner.service --property=ExecMainPID | cut -d = -f 2)
-  threadCount=$(ps huH p $SPAWNER_PID | wc -l)
+  threadCount=$(ps huH p "$SPAWNER_PID" | wc -l)
   if ! [ "$threadCount" -eq "$SPAWNER_MAX_THREADS" ]; then
     echo "Expected $SPAWNER_MAX_THREADS threads, got $threadCount"
     exit 1

--- a/tests/main/snap-quota-thread/task.yaml
+++ b/tests/main/snap-quota-thread/task.yaml
@@ -79,7 +79,7 @@ execute: |
   echo "Verify the number of threads is correct (=16)"
   
   threadUsage="$(sudo snap run test-snapd-curl.curl --unix-socket /run/snapd.socket http://localhost/v2/quotas/group-one | jq -r '.result.current.threads')"
-  if ! [ $threadUsage -eq 16 ]; then
+  if ! [ "$threadUsage" -eq 16 ]; then
     echo "thread usage reported does not equal the expected quota usage $threadUsage"
     exit 1
   fi
@@ -90,7 +90,7 @@ execute: |
   echo "Verify the number of threads is correct (=24)"
   sleep 3 # sleep the delay time (2s) and one more to allow for threads to start
   threadUsage="$(sudo snap run test-snapd-curl.curl --unix-socket /run/snapd.socket http://localhost/v2/quotas/group-one | jq -r '.result.current.threads')"
-  if ! [ $threadUsage -eq 24 ]; then
+  if ! [ "$threadUsage" -eq 24 ]; then
     echo "thread usage reported does not equal the expected quota usage $threadUsage"
     exit 1
   fi
@@ -107,9 +107,9 @@ execute: |
   systemctl show --property=ActiveState "$sliceName" | MATCH "ActiveState=inactive"
 
   echo "Verify the service is now running at full capacity"
-  SPAWNER_PID=`systemctl show snap.test-snapd-stressd.spawner.service --property=ExecMainPID | cut -d = -f 2`
-  threadCount=`ps huH p $SPAWNER_PID | wc -l`
-  if ! [ $threadCount -eq $SPAWNER_MAX_THREADS ]; then
+  SPAWNER_PID=$(systemctl show snap.test-snapd-stressd.spawner.service --property=ExecMainPID | cut -d = -f 2)
+  threadCount=$(ps huH p $SPAWNER_PID | wc -l)
+  if ! [ "$threadCount" -eq "$SPAWNER_MAX_THREADS" ]; then
     echo "Expected $SPAWNER_MAX_THREADS threads, got $threadCount"
     exit 1
   fi

--- a/tests/main/snap-quota-thread/task.yaml
+++ b/tests/main/snap-quota-thread/task.yaml
@@ -1,0 +1,118 @@
+summary: Functional test for thread/task quota-related snap commands.
+
+details: |
+  Functional test for snap thread/task quota group commands ensuring that they are 
+  effective in practice.
+
+# these systems do not support quota groups due to their old systemd versions,
+# we do have a check to do for these systems, but that is just to ensure that
+# we don't allow using quota groups, and that check is done in the snap-quota
+# spread instead
+systems:
+  - -ubuntu-14.04-*
+  - -centos-7-*
+  - -amazon-linux-2-*
+  - -ubuntu-16.04-*
+  - -ubuntu-core-16-*
+
+prepare: |
+  snap install jq
+  snap install test-snapd-stressd --edge --devmode
+  snap install test-snapd-curl --edge --devmode
+  snap set system experimental.quota-groups=true
+  tests.cleanup defer snap unset system experimental.quota-groups
+
+execute: |
+  # Spawner spawns 32 workers per default in the snap, but the total
+  # count of threads expected is 33 including the main thread.
+  SPAWNER_MAX_THREADS=33
+
+  echo "Create a group with the spawner snap in it"
+  snap set-quota group-one --thread=16 test-snapd-stressd
+
+  echo "Starting service"
+  # the reason we start the service afterwards is because the task limit
+  # wont kill any tasks that exceeds the limit, so we test instead that we
+  # can increment the limit. 
+  snap start test-snapd-stressd.spawner
+  sleep 1
+
+  echo "The systemd slice should be active now"
+  sliceName="snap.$(systemd-escape --path group-one).slice"
+  systemctl show --property=ActiveState "$sliceName" | MATCH "ActiveState=active"
+
+  echo "The service should be active"
+  snap services test-snapd-stressd.spawner | MATCH "test-snapd-stressd.spawner\s+disabled\s+active"
+
+  # systemd/kernel have three different locations for the cgroup pids depending
+  # on version
+  echo "The systemd slice should have one process in it now"
+  cgroupsV1OldSystemdProcsFile="/sys/fs/cgroup/pids/$sliceName/snap.test-snapd-stressd.spawner.service/cgroup.procs"
+  cgroupsV1ProcsFile="/sys/fs/cgroup/pids/$sliceName/cgroup.procs"
+  cgroupsV2ProcsFile="/sys/fs/cgroup/$sliceName/snap.test-snapd-stressd.spawner.service/cgroup.procs"
+  if [ -e "$cgroupsV2ProcsFile" ]; then
+      cgroupProcsFile="$cgroupsV2ProcsFile"
+  elif [ -e "$cgroupsV1OldSystemdProcsFile" ]; then
+      cgroupProcsFile="$cgroupsV1OldSystemdProcsFile"
+  elif [ -e "$cgroupsV1ProcsFile" ]; then
+      cgroupProcsFile="$cgroupsV1ProcsFile"
+  else
+      echo "cannot detect cgroup procs file"
+      exit 1
+  fi
+
+  #shellcheck disable=SC2016
+  retry --wait 1 -n 100 --env cgroupProcsFile="$cgroupProcsFile" sh -x -c 'test "$(wc -l < $cgroupProcsFile)" = 1'
+  SERVER_PID=$(cat "$cgroupProcsFile")
+
+  echo "And that process is the main PID for spawner"
+  systemctl show --property=MainPID snap.test-snapd-stressd.spawner.service | MATCH "MainPID=$SERVER_PID"
+
+  echo "And the service is in the Control Group for the slice"
+  # using a regexp for the ControlGroup match here as on older systemd (16.04)
+  # the group is double escaped
+  systemctl show --property=ControlGroup snap.test-snapd-stressd.spawner.service | MATCH 'ControlGroup=/snap.group(.*)one.slice/snap.test-snapd-stressd.spawner.service'
+
+  # snap quota group-one formats the quota usage as a nice human readable 
+  # string, which complicates the comparison here, so instead just grab the 
+  # task usage from the REST API instead
+  echo "Verify the number of threads is correct (=16)"
+  
+  threadUsage="$(sudo snap run test-snapd-curl.curl --unix-socket /run/snapd.socket http://localhost/v2/quotas/group-one | jq -r '.result.current.threads')"
+  if ! [ $threadUsage -eq 16 ]; then
+    echo "thread usage reported does not equal the expected quota usage $threadUsage"
+    exit 1
+  fi
+
+  echo "Increase the thread quota to 24"
+  snap set-quota group-one --thread=24
+
+  echo "Verify the number of threads is correct (=24)"
+  sleep 3 # sleep the delay time (2s) and one more to allow for threads to start
+  threadUsage="$(sudo snap run test-snapd-curl.curl --unix-socket /run/snapd.socket http://localhost/v2/quotas/group-one | jq -r '.result.current.threads')"
+  if ! [ $threadUsage -eq 24 ]; then
+    echo "thread usage reported does not equal the expected quota usage $threadUsage"
+    exit 1
+  fi
+
+  echo "Removing the quota will stop the slice and the service will be restarted"
+  snap remove-quota group-one
+  systemctl show --property=MainPID snap.test-snapd-stressd.spawner.service | NOMATCH "MainPID=$SERVER_PID"
+  snap services test-snapd-stressd.spawner | MATCH "test-snapd-stressd.spawner\s+disabled\s+active"
+
+  echo "And the service is not in a slice anymore"
+  systemctl show --property=ControlGroup snap.test-snapd-stressd.spawner.service | NOMATCH "/$sliceName/snap.test-snapd-stressd.spawner.service"
+
+  echo "And the slice is not active anymore"
+  systemctl show --property=ActiveState "$sliceName" | MATCH "ActiveState=inactive"
+
+  echo "Verify the service is now running at full capacity"
+  SPAWNER_PID=`systemctl show snap.test-snapd-stressd.spawner.service --property=ExecMainPID | cut -d = -f 2`
+  threadCount=`ps huH p $SPAWNER_PID | wc -l`
+  if ! [ $threadCount -eq $SPAWNER_MAX_THREADS ]; then
+    echo "Expected $SPAWNER_MAX_THREADS threads, got $threadCount"
+    exit 1
+  fi
+
+  echo "Stop the service"
+  snap stop test-snapd-stressd.spawner

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -125,8 +125,8 @@ func formatCpuGroupSlice(grp *quota.Group) string {
 
 	// AllowedCpus is only available for cgroupsv2
 	template := `# Always enable cpu accounting, so the following cpu quota options have an effect
- CPUAccounting=true
- `
+CPUAccounting=true
+`
 	return fmt.Sprint(template, calculateSystemdCPULimit(), getAllowedCpusValue(), "\n")
 }
 
@@ -136,28 +136,28 @@ func formatMemoryGroupSlice(grp *quota.Group) string {
 	}
 
 	template := `# Always enable memory accounting otherwise the MemoryMax setting does nothing.
- MemoryAccounting=true
- MemoryMax=%[1]d
- # for compatibility with older versions of systemd
- MemoryLimit=%[1]d
- 
- `
+MemoryAccounting=true
+MemoryMax=%[1]d
+# for compatibility with older versions of systemd
+MemoryLimit=%[1]d
+
+`
 	return fmt.Sprintf(template, grp.MemoryLimit)
 }
 
 func formatTaskGroupSlice(grp *quota.Group) string {
 	if grp.TaskLimit == 0 {
 		return `# Always enable task accounting in order to be able to count the processes/
- # threads, etc for a slice
- TasksAccounting=true
- `
+# threads, etc for a slice
+TasksAccounting=true
+`
 	}
 
 	template := `# Always enable task accounting in order to be able to count the processes/
- # threads, etc for a slice
- TasksAccounting=true
- TasksMax=%d
- `
+# threads, etc for a slice
+TasksAccounting=true
+TasksMax=%d
+`
 	return fmt.Sprintf(template, grp.TaskLimit)
 }
 
@@ -170,12 +170,12 @@ func generateGroupSliceFile(grp *quota.Group) []byte {
 	memoryOptions := formatMemoryGroupSlice(grp)
 	taskOptions := formatTaskGroupSlice(grp)
 	template := `[Unit]
- Description=Slice for snap quota group %[1]s
- Before=slices.target
- X-Snappy=yes
- 
- [Slice]
- `
+Description=Slice for snap quota group %[1]s
+Before=slices.target
+X-Snappy=yes
+
+[Slice]
+`
 
 	fmt.Fprintf(&buf, template, grp.Name)
 	fmt.Fprint(&buf, cpuOptions, memoryOptions, taskOptions)
@@ -1023,81 +1023,81 @@ func genServiceFile(appInfo *snap.AppInfo, opts *AddSnapServicesOptions) ([]byte
 	ifaceSpecifiedServiceSnippet := strings.Join(ifaceServiceSnippets.Items(), "\n")
 
 	serviceTemplate := `[Unit]
- # Auto-generated, DO NOT EDIT
- Description=Service for snap application {{.App.Snap.InstanceName}}.{{.App.Name}}
- {{- if .MountUnit }}
- Requires={{.MountUnit}}
- {{- end }}
- {{- if .PrerequisiteTarget}}
- Wants={{.PrerequisiteTarget}}
- {{- end}}
- {{- if .After}}
- After={{ stringsJoin .After " " }}
- {{- end}}
- {{- if .Before}}
- Before={{ stringsJoin .Before " "}}
- {{- end}}
- {{- if .CoreMountedSnapdSnapDep}}
- Wants={{ stringsJoin .CoreMountedSnapdSnapDep " "}}
- After={{ stringsJoin .CoreMountedSnapdSnapDep " "}}
- {{- end}}
- X-Snappy=yes
- 
- [Service]
- EnvironmentFile=-/etc/environment
- ExecStart={{.App.LauncherCommand}}
- SyslogIdentifier={{.App.Snap.InstanceName}}.{{.App.Name}}
- Restart={{.Restart}}
- {{- if .App.RestartDelay}}
- RestartSec={{.App.RestartDelay.Seconds}}
- {{- end}}
- WorkingDirectory={{.WorkingDir}}
- {{- if .App.StopCommand}}
- ExecStop={{.App.LauncherStopCommand}}
- {{- end}}
- {{- if .App.ReloadCommand}}
- ExecReload={{.App.LauncherReloadCommand}}
- {{- end}}
- {{- if .App.PostStopCommand}}
- ExecStopPost={{.App.LauncherPostStopCommand}}
- {{- end}}
- {{- if .StopTimeout}}
- TimeoutStopSec={{.StopTimeout.Seconds}}
- {{- end}}
- {{- if .StartTimeout}}
- TimeoutStartSec={{.StartTimeout.Seconds}}
- {{- end}}
- Type={{.App.Daemon}}
- {{- if .Remain}}
- RemainAfterExit={{.Remain}}
- {{- end}}
- {{- if .BusName}}
- BusName={{.BusName}}
- {{- end}}
- {{- if .App.WatchdogTimeout}}
- WatchdogSec={{.App.WatchdogTimeout.Seconds}}
- {{- end}}
- {{- if .KillMode}}
- KillMode={{.KillMode}}
- {{- end}}
- {{- if .KillSignal}}
- KillSignal={{.KillSignal}}
- {{- end}}
- {{- if .OOMAdjustScore }}
- OOMScoreAdjust={{.OOMAdjustScore}}
- {{- end}}
- {{- if .InterfaceServiceSnippets}}
- {{.InterfaceServiceSnippets}}
- {{- end}}
- {{- if .SliceUnit}}
- Slice={{.SliceUnit}}
- {{- end}}
- {{- if not (or .App.Sockets .App.Timer .App.ActivatesOn) }}
- 
- [Install]
- WantedBy={{.ServicesTarget}}
- {{- end}}
- `
+# Auto-generated, DO NOT EDIT
+Description=Service for snap application {{.App.Snap.InstanceName}}.{{.App.Name}}
+{{- if .MountUnit }}
+Requires={{.MountUnit}}
+{{- end }}
+{{- if .PrerequisiteTarget}}
+Wants={{.PrerequisiteTarget}}
+{{- end}}
+{{- if .After}}
+After={{ stringsJoin .After " " }}
+{{- end}}
+{{- if .Before}}
+Before={{ stringsJoin .Before " "}}
+{{- end}}
+{{- if .CoreMountedSnapdSnapDep}}
+Wants={{ stringsJoin .CoreMountedSnapdSnapDep " "}}
+After={{ stringsJoin .CoreMountedSnapdSnapDep " "}}
+{{- end}}
+X-Snappy=yes
+
+[Service]
+EnvironmentFile=-/etc/environment
+ExecStart={{.App.LauncherCommand}}
+SyslogIdentifier={{.App.Snap.InstanceName}}.{{.App.Name}}
+Restart={{.Restart}}
+{{- if .App.RestartDelay}}
+RestartSec={{.App.RestartDelay.Seconds}}
+{{- end}}
+WorkingDirectory={{.WorkingDir}}
+{{- if .App.StopCommand}}
+ExecStop={{.App.LauncherStopCommand}}
+{{- end}}
+{{- if .App.ReloadCommand}}
+ExecReload={{.App.LauncherReloadCommand}}
+{{- end}}
+{{- if .App.PostStopCommand}}
+ExecStopPost={{.App.LauncherPostStopCommand}}
+{{- end}}
+{{- if .StopTimeout}}
+TimeoutStopSec={{.StopTimeout.Seconds}}
+{{- end}}
+{{- if .StartTimeout}}
+TimeoutStartSec={{.StartTimeout.Seconds}}
+{{- end}}
+Type={{.App.Daemon}}
+{{- if .Remain}}
+RemainAfterExit={{.Remain}}
+{{- end}}
+{{- if .BusName}}
+BusName={{.BusName}}
+{{- end}}
+{{- if .App.WatchdogTimeout}}
+WatchdogSec={{.App.WatchdogTimeout.Seconds}}
+{{- end}}
+{{- if .KillMode}}
+KillMode={{.KillMode}}
+{{- end}}
+{{- if .KillSignal}}
+KillSignal={{.KillSignal}}
+{{- end}}
+{{- if .OOMAdjustScore }}
+OOMScoreAdjust={{.OOMAdjustScore}}
+{{- end}}
+{{- if .InterfaceServiceSnippets}}
+{{.InterfaceServiceSnippets}}
+{{- end}}
+{{- if .SliceUnit}}
+Slice={{.SliceUnit}}
+{{- end}}
+{{- if not (or .App.Sockets .App.Timer .App.ActivatesOn) }}
+
+[Install]
+WantedBy={{.ServicesTarget}}
+{{- end}}
+`
 	var templateOut bytes.Buffer
 	tmpl := template.New("service-wrapper")
 	tmpl.Funcs(template.FuncMap{
@@ -1236,25 +1236,25 @@ func genServiceFile(appInfo *snap.AppInfo, opts *AddSnapServicesOptions) ([]byte
 
 func genServiceSocketFile(appInfo *snap.AppInfo, socketName string) []byte {
 	socketTemplate := `[Unit]
- # Auto-generated, DO NOT EDIT
- Description=Socket {{.SocketName}} for snap application {{.App.Snap.InstanceName}}.{{.App.Name}}
- {{- if .MountUnit}}
- Requires={{.MountUnit}}
- After={{.MountUnit}}
- {{- end}}
- X-Snappy=yes
- 
- [Socket]
- Service={{.ServiceFileName}}
- FileDescriptorName={{.SocketInfo.Name}}
- ListenStream={{.ListenStream}}
- {{- if .SocketInfo.SocketMode}}
- SocketMode={{.SocketInfo.SocketMode | printf "%04o"}}
- {{- end}}
- 
- [Install]
- WantedBy={{.SocketsTarget}}
- `
+# Auto-generated, DO NOT EDIT
+Description=Socket {{.SocketName}} for snap application {{.App.Snap.InstanceName}}.{{.App.Name}}
+{{- if .MountUnit}}
+Requires={{.MountUnit}}
+After={{.MountUnit}}
+{{- end}}
+X-Snappy=yes
+
+[Socket]
+Service={{.ServiceFileName}}
+FileDescriptorName={{.SocketInfo.Name}}
+ListenStream={{.ListenStream}}
+{{- if .SocketInfo.SocketMode}}
+SocketMode={{.SocketInfo.SocketMode | printf "%04o"}}
+{{- end}}
+
+[Install]
+WantedBy={{.SocketsTarget}}
+`
 	var templateOut bytes.Buffer
 	t := template.Must(template.New("socket-wrapper").Parse(socketTemplate))
 
@@ -1332,21 +1332,21 @@ func renderListenStream(socket *snap.SocketInfo) string {
 
 func generateSnapTimerFile(app *snap.AppInfo) ([]byte, error) {
 	timerTemplate := `[Unit]
- # Auto-generated, DO NOT EDIT
- Description=Timer {{.TimerName}} for snap application {{.App.Snap.InstanceName}}.{{.App.Name}}
- {{- if .MountUnit}}
- Requires={{.MountUnit}}
- After={{.MountUnit}}
- {{- end}}
- X-Snappy=yes
- 
- [Timer]
- Unit={{.ServiceFileName}}
- {{ range .Schedules }}OnCalendar={{ . }}
- {{ end }}
- [Install]
- WantedBy={{.TimersTarget}}
- `
+# Auto-generated, DO NOT EDIT
+Description=Timer {{.TimerName}} for snap application {{.App.Snap.InstanceName}}.{{.App.Name}}
+{{- if .MountUnit}}
+Requires={{.MountUnit}}
+After={{.MountUnit}}
+{{- end}}
+X-Snappy=yes
+
+[Timer]
+Unit={{.ServiceFileName}}
+{{ range .Schedules }}OnCalendar={{ . }}
+{{ end }}
+[Install]
+WantedBy={{.TimersTarget}}
+`
 	var templateOut bytes.Buffer
 	t := template.Must(template.New("timer-wrapper").Parse(timerTemplate))
 

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -282,8 +282,8 @@ TasksMax=%[5]d
 	sliceContent := fmt.Sprintf(sliceTempl, grp.Name,
 		resourceLimits.Cpu.Count*resourceLimits.Cpu.Percentage,
 		allowedCpusValue,
-		resourceLimits.Memory.MemoryLimit,
-		resourceLimits.Thread.ThreadLimit)
+		resourceLimits.Memory.Limit,
+		resourceLimits.Thread.Limit)
 
 	exp := []changesObservation{
 		{
@@ -662,8 +662,8 @@ MemoryLimit=%[3]d
 TasksAccounting=true
 `
 
-	sliceContent := fmt.Sprintf(sliceTempl, "foogroup", resourceLimits.Cpu.Count*resourceLimits.Cpu.Percentage, resourceLimits.Memory.MemoryLimit)
-	subSliceContent := fmt.Sprintf(sliceTempl, "subgroup", resourceLimits.Cpu.Count*resourceLimits.Cpu.Percentage, resourceLimits.Memory.MemoryLimit)
+	sliceContent := fmt.Sprintf(sliceTempl, "foogroup", resourceLimits.Cpu.Count*resourceLimits.Cpu.Percentage, resourceLimits.Memory.Limit)
+	subSliceContent := fmt.Sprintf(sliceTempl, "subgroup", resourceLimits.Cpu.Count*resourceLimits.Cpu.Percentage, resourceLimits.Memory.Limit)
 
 	svcTemplate := `[Unit]
 # Auto-generated, DO NOT EDIT
@@ -760,7 +760,7 @@ func (s *servicesTestSuite) TestEnsureSnapServicesWithSubGroupQuotaGroupsGenerat
 	svcFile1 := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-snap.svc1.service")
 
 	var err error
-	resourceLimits := resources.CreateQuotaResources(quantity.SizeGiB, 0, 0, []int{0}, 0)
+	resourceLimits := quota.NewResources(quantity.SizeGiB, 0, 0, []int{0}, 0)
 	// make a root quota group without any snaps in it
 	grp, err := quota.NewGroup("foogroup", resourceLimits)
 	c.Assert(err, IsNil)
@@ -839,8 +839,8 @@ TasksAccounting=true
 `
 
 	allowedCpusValue := strings.Trim(strings.Join(strings.Fields(fmt.Sprint(resourceLimits.Cpu.AllowedCpus)), ","), "[]")
-	c.Assert(sliceFile, testutil.FileEquals, fmt.Sprintf(templ, "foogroup", allowedCpusValue, resourceLimits.Memory.MemoryLimit))
-	c.Assert(subSliceFile, testutil.FileEquals, fmt.Sprintf(templ, "subgroup", allowedCpusValue, resourceLimits.Memory.MemoryLimit))
+	c.Assert(sliceFile, testutil.FileEquals, fmt.Sprintf(templ, "foogroup", allowedCpusValue, resourceLimits.Memory.Limit))
+	c.Assert(subSliceFile, testutil.FileEquals, fmt.Sprintf(templ, "subgroup", allowedCpusValue, resourceLimits.Memory.Limit))
 }
 
 func (s *servicesTestSuite) TestEnsureSnapServiceEnsureError(c *C) {

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -278,12 +278,12 @@ TasksAccounting=true
 TasksMax=%[5]d
 `
 
-	allowedCpusValue := strings.Trim(strings.Join(strings.Fields(fmt.Sprint(resourceLimits.Cpu.AllowedCpus)), ","), "[]")
+	allowedCpusValue := strings.Trim(strings.Join(strings.Fields(fmt.Sprint(resourceLimits.CPU.AllowedCPUs)), ","), "[]")
 	sliceContent := fmt.Sprintf(sliceTempl, grp.Name,
-		resourceLimits.Cpu.Count*resourceLimits.Cpu.Percentage,
+		resourceLimits.CPU.Count*resourceLimits.CPU.Percentage,
 		allowedCpusValue,
 		resourceLimits.Memory.Limit,
-		resourceLimits.Thread.Limit)
+		resourceLimits.Threads.Limit)
 
 	exp := []changesObservation{
 		{
@@ -662,8 +662,8 @@ MemoryLimit=%[3]d
 TasksAccounting=true
 `
 
-	sliceContent := fmt.Sprintf(sliceTempl, "foogroup", resourceLimits.Cpu.Count*resourceLimits.Cpu.Percentage, resourceLimits.Memory.Limit)
-	subSliceContent := fmt.Sprintf(sliceTempl, "subgroup", resourceLimits.Cpu.Count*resourceLimits.Cpu.Percentage, resourceLimits.Memory.Limit)
+	sliceContent := fmt.Sprintf(sliceTempl, "foogroup", resourceLimits.CPU.Count*resourceLimits.CPU.Percentage, resourceLimits.Memory.Limit)
+	subSliceContent := fmt.Sprintf(sliceTempl, "subgroup", resourceLimits.CPU.Count*resourceLimits.CPU.Percentage, resourceLimits.Memory.Limit)
 
 	svcTemplate := `[Unit]
 # Auto-generated, DO NOT EDIT
@@ -838,7 +838,7 @@ MemoryLimit=%[3]d
 TasksAccounting=true
 `
 
-	allowedCpusValue := strings.Trim(strings.Join(strings.Fields(fmt.Sprint(resourceLimits.Cpu.AllowedCpus)), ","), "[]")
+	allowedCpusValue := strings.Trim(strings.Join(strings.Fields(fmt.Sprint(resourceLimits.CPU.AllowedCPUs)), ","), "[]")
 	c.Assert(sliceFile, testutil.FileEquals, fmt.Sprintf(templ, "foogroup", allowedCpusValue, resourceLimits.Memory.Limit))
 	c.Assert(subSliceFile, testutil.FileEquals, fmt.Sprintf(templ, "subgroup", allowedCpusValue, resourceLimits.Memory.Limit))
 }

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -120,27 +120,27 @@ func (s *servicesTestSuite) TestAddSnapServicesAndRemove(c *C) {
 
 	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
 	c.Assert(svcFile, testutil.FileEquals, fmt.Sprintf(`[Unit]
-# Auto-generated, DO NOT EDIT
-Description=Service for snap application hello-snap.svc1
-Requires=%[1]s
-Wants=network.target
-After=%[1]s network.target snapd.apparmor.service
-X-Snappy=yes
-
-[Service]
-EnvironmentFile=-/etc/environment
-ExecStart=/usr/bin/snap run hello-snap.svc1
-SyslogIdentifier=hello-snap.svc1
-Restart=on-failure
-WorkingDirectory=%[2]s/var/snap/hello-snap/12
-ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
-ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
-TimeoutStopSec=30
-Type=forking
-
-[Install]
-WantedBy=multi-user.target
-`,
+ # Auto-generated, DO NOT EDIT
+ Description=Service for snap application hello-snap.svc1
+ Requires=%[1]s
+ Wants=network.target
+ After=%[1]s network.target snapd.apparmor.service
+ X-Snappy=yes
+ 
+ [Service]
+ EnvironmentFile=-/etc/environment
+ ExecStart=/usr/bin/snap run hello-snap.svc1
+ SyslogIdentifier=hello-snap.svc1
+ Restart=on-failure
+ WorkingDirectory=%[2]s/var/snap/hello-snap/12
+ ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
+ ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
+ TimeoutStopSec=30
+ Type=forking
+ 
+ [Install]
+ WantedBy=multi-user.target
+ `,
 		systemd.EscapeUnitNamePath(dir),
 		dirs.GlobalRootDir,
 	))
@@ -188,27 +188,27 @@ func (s *servicesTestSuite) TestEnsureSnapServicesAdds(c *C) {
 
 	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
 	c.Assert(svcFile, testutil.FileEquals, fmt.Sprintf(`[Unit]
-# Auto-generated, DO NOT EDIT
-Description=Service for snap application hello-snap.svc1
-Requires=%[1]s
-Wants=network.target
-After=%[1]s network.target snapd.apparmor.service
-X-Snappy=yes
-
-[Service]
-EnvironmentFile=-/etc/environment
-ExecStart=/usr/bin/snap run hello-snap.svc1
-SyslogIdentifier=hello-snap.svc1
-Restart=on-failure
-WorkingDirectory=%[2]s/var/snap/hello-snap/12
-ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
-ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
-TimeoutStopSec=30
-Type=forking
-
-[Install]
-WantedBy=multi-user.target
-`,
+ # Auto-generated, DO NOT EDIT
+ Description=Service for snap application hello-snap.svc1
+ Requires=%[1]s
+ Wants=network.target
+ After=%[1]s network.target snapd.apparmor.service
+ X-Snappy=yes
+ 
+ [Service]
+ EnvironmentFile=-/etc/environment
+ ExecStart=/usr/bin/snap run hello-snap.svc1
+ SyslogIdentifier=hello-snap.svc1
+ Restart=on-failure
+ WorkingDirectory=%[2]s/var/snap/hello-snap/12
+ ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
+ ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
+ TimeoutStopSec=30
+ Type=forking
+ 
+ [Install]
+ WantedBy=multi-user.target
+ `,
 		systemd.EscapeUnitNamePath(dir),
 		dirs.GlobalRootDir,
 	))
@@ -218,8 +218,9 @@ func (s *servicesTestSuite) TestEnsureSnapServicesWithQuotas(c *C) {
 	info := snaptest.MockSnap(c, packageHello, &snap.SideInfo{Revision: snap.R(12)})
 	svcFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-snap.svc1.service")
 
-	memLimit := quantity.SizeGiB
-	grp, err := quota.NewGroup("foogroup", quota.NewResources(memLimit))
+	// set up arbitrary quotas for the group to test they get written correctly to the slice
+	resourceLimits := quota.NewResources(quantity.SizeGiB, 2, 50, []int{0, 1}, 32)
+	grp, err := quota.NewGroup("foogroup", resourceLimits)
 	c.Assert(err, IsNil)
 
 	m := map[*snap.Info]*wrappers.SnapServiceOptions{
@@ -228,50 +229,61 @@ func (s *servicesTestSuite) TestEnsureSnapServicesWithQuotas(c *C) {
 
 	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
 	svcContent := fmt.Sprintf(`[Unit]
-# Auto-generated, DO NOT EDIT
-Description=Service for snap application hello-snap.svc1
-Requires=%[1]s
-Wants=network.target
-After=%[1]s network.target snapd.apparmor.service
-X-Snappy=yes
-
-[Service]
-EnvironmentFile=-/etc/environment
-ExecStart=/usr/bin/snap run hello-snap.svc1
-SyslogIdentifier=hello-snap.svc1
-Restart=on-failure
-WorkingDirectory=%[2]s/var/snap/hello-snap/12
-ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
-ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
-TimeoutStopSec=30
-Type=forking
-Slice=snap.foogroup.slice
-
-[Install]
-WantedBy=multi-user.target
-`,
+ # Auto-generated, DO NOT EDIT
+ Description=Service for snap application hello-snap.svc1
+ Requires=%[1]s
+ Wants=network.target
+ After=%[1]s network.target snapd.apparmor.service
+ X-Snappy=yes
+ 
+ [Service]
+ EnvironmentFile=-/etc/environment
+ ExecStart=/usr/bin/snap run hello-snap.svc1
+ SyslogIdentifier=hello-snap.svc1
+ Restart=on-failure
+ WorkingDirectory=%[2]s/var/snap/hello-snap/12
+ ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
+ ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
+ TimeoutStopSec=30
+ Type=forking
+ Slice=snap.foogroup.slice
+ 
+ [Install]
+ WantedBy=multi-user.target
+ `,
 		systemd.EscapeUnitNamePath(dir),
 		dirs.GlobalRootDir,
 	)
 
 	sliceTempl := `[Unit]
-Description=Slice for snap quota group %s
-Before=slices.target
-X-Snappy=yes
+ Description=Slice for snap quota group %s
+ Before=slices.target
+ X-Snappy=yes
+ 
+ [Slice]
+ # Always enable cpu accounting, so the following cpu quota options have an effect
+ CPUAccounting=true
+ CPUQuota=%[2]d
+ AllowedCPUs=%[3]s
+ 
+ # Always enable memory accounting otherwise the MemoryMax setting does nothing.
+ MemoryAccounting=true
+ MemoryMax=%[4]d
+ # for compatibility with older versions of systemd
+ MemoryLimit=%[4]d
+ 
+ # Always enable task accounting in order to be able to count the processes/
+ # threads, etc for a slice
+ TasksAccounting=true
+ TasksMax=%[5]d
+ `
 
-[Slice]
-# Always enable memory accounting otherwise the MemoryMax setting does nothing.
-MemoryAccounting=true
-MemoryMax=%[2]s
-# for compatibility with older versions of systemd
-MemoryLimit=%[2]s
-
-# Always enable task accounting in order to be able to count the processes/
-# threads, etc for a slice
-TasksAccounting=true
-`
-
-	sliceContent := fmt.Sprintf(sliceTempl, grp.Name, memLimit.String())
+	allowedCpusValue := strings.Trim(strings.Join(strings.Fields(fmt.Sprint(resourceLimits.Cpu.AllowedCpus)), ","), "[]")
+	sliceContent := fmt.Sprintf(sliceTempl, grp.Name,
+		resourceLimits.Cpu.Count*resourceLimits.Cpu.Percentage,
+		allowedCpusValue,
+		resourceLimits.Memory.MemoryLimit,
+		resourceLimits.Thread.ThreadLimit)
 
 	exp := []changesObservation{
 		{
@@ -365,47 +377,47 @@ func (s *servicesTestSuite) TestEnsureSnapServicesRewritesQuotaSlices(c *C) {
 	// write both the unit file and a slice with a different memory limit
 	// setting than will be provided below
 	sliceTempl := `[Unit]
-Description=Slice for snap quota group %s
-Before=slices.target
-X-Snappy=yes
-
-[Slice]
-# Always enable memory accounting otherwise the MemoryMax setting does nothing.
-MemoryAccounting=true
-MemoryMax=%[2]s
-# for compatibility with older versions of systemd
-MemoryLimit=%[2]s
-
-# Always enable task accounting in order to be able to count the processes/
-# threads, etc for a slice
-TasksAccounting=true
-`
+ Description=Slice for snap quota group %s
+ Before=slices.target
+ X-Snappy=yes
+ 
+ [Slice]
+ # Always enable memory accounting otherwise the MemoryMax setting does nothing.
+ MemoryAccounting=true
+ MemoryMax=%[2]s
+ # for compatibility with older versions of systemd
+ MemoryLimit=%[2]s
+ 
+ # Always enable task accounting in order to be able to count the processes/
+ # threads, etc for a slice
+ TasksAccounting=true
+ `
 	sliceFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.foogroup.slice")
 
 	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
 	svcContent := fmt.Sprintf(`[Unit]
-# Auto-generated, DO NOT EDIT
-Description=Service for snap application hello-snap.svc1
-Requires=%[1]s
-Wants=network.target
-After=%[1]s network.target snapd.apparmor.service
-X-Snappy=yes
-
-[Service]
-EnvironmentFile=-/etc/environment
-ExecStart=/usr/bin/snap run hello-snap.svc1
-SyslogIdentifier=hello-snap.svc1
-Restart=on-failure
-WorkingDirectory=%[2]s/var/snap/hello-snap/12
-ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
-ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
-TimeoutStopSec=30
-Type=forking
-Slice=snap.foogroup.slice
-
-[Install]
-WantedBy=multi-user.target
-`,
+ # Auto-generated, DO NOT EDIT
+ Description=Service for snap application hello-snap.svc1
+ Requires=%[1]s
+ Wants=network.target
+ After=%[1]s network.target snapd.apparmor.service
+ X-Snappy=yes
+ 
+ [Service]
+ EnvironmentFile=-/etc/environment
+ ExecStart=/usr/bin/snap run hello-snap.svc1
+ SyslogIdentifier=hello-snap.svc1
+ Restart=on-failure
+ WorkingDirectory=%[2]s/var/snap/hello-snap/12
+ ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
+ ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
+ TimeoutStopSec=30
+ Type=forking
+ Slice=snap.foogroup.slice
+ 
+ [Install]
+ WantedBy=multi-user.target
+ `,
 		systemd.EscapeUnitNamePath(dir),
 		dirs.GlobalRootDir,
 	)
@@ -421,7 +433,8 @@ WantedBy=multi-user.target
 	c.Assert(err, IsNil)
 
 	// use new memory limit
-	grp, err := quota.NewGroup("foogroup", quota.NewResources(memLimit2))
+	resourceLimits := quota.NewResources(memLimit2, 0, 0, nil, 0)
+	grp, err := quota.NewGroup("foogroup", resourceLimits)
 	c.Assert(err, IsNil)
 
 	m := map[*snap.Info]*wrappers.SnapServiceOptions{
@@ -458,50 +471,52 @@ func (s *servicesTestSuite) TestEnsureSnapServicesDoesNotRewriteQuotaSlicesOnNoo
 	svcFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-snap.svc1.service")
 
 	memLimit := quantity.SizeGiB
+	taskLimit := 32 // arbitrarily chosen
 
 	// write both the unit file and a slice before running the ensure
 	sliceTempl := `[Unit]
-Description=Slice for snap quota group %s
-Before=slices.target
-X-Snappy=yes
-
-[Slice]
-# Always enable memory accounting otherwise the MemoryMax setting does nothing.
-MemoryAccounting=true
-MemoryMax=%[2]s
-# for compatibility with older versions of systemd
-MemoryLimit=%[2]s
-
-# Always enable task accounting in order to be able to count the processes/
-# threads, etc for a slice
-TasksAccounting=true
-`
+ Description=Slice for snap quota group %s
+ Before=slices.target
+ X-Snappy=yes
+ 
+ [Slice]
+ # Always enable memory accounting otherwise the MemoryMax setting does nothing.
+ MemoryAccounting=true
+ MemoryMax=%[2]s
+ # for compatibility with older versions of systemd
+ MemoryLimit=%[2]s
+ 
+ # Always enable task accounting in order to be able to count the processes/
+ # threads, etc for a slice
+ TasksAccounting=true
+ TasksMax=%[3]d
+ `
 	sliceFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.foogroup.slice")
 
 	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
 	svcContent := fmt.Sprintf(`[Unit]
-# Auto-generated, DO NOT EDIT
-Description=Service for snap application hello-snap.svc1
-Requires=%[1]s
-Wants=network.target
-After=%[1]s network.target snapd.apparmor.service
-X-Snappy=yes
-
-[Service]
-EnvironmentFile=-/etc/environment
-ExecStart=/usr/bin/snap run hello-snap.svc1
-SyslogIdentifier=hello-snap.svc1
-Restart=on-failure
-WorkingDirectory=%[2]s/var/snap/hello-snap/12
-ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
-ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
-TimeoutStopSec=30
-Type=forking
-Slice=snap.foogroup.slice
-
-[Install]
-WantedBy=multi-user.target
-`,
+ # Auto-generated, DO NOT EDIT
+ Description=Service for snap application hello-snap.svc1
+ Requires=%[1]s
+ Wants=network.target
+ After=%[1]s network.target snapd.apparmor.service
+ X-Snappy=yes
+ 
+ [Service]
+ EnvironmentFile=-/etc/environment
+ ExecStart=/usr/bin/snap run hello-snap.svc1
+ SyslogIdentifier=hello-snap.svc1
+ Restart=on-failure
+ WorkingDirectory=%[2]s/var/snap/hello-snap/12
+ ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
+ ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
+ TimeoutStopSec=30
+ Type=forking
+ Slice=snap.foogroup.slice
+ 
+ [Install]
+ WantedBy=multi-user.target
+ `,
 		systemd.EscapeUnitNamePath(dir),
 		dirs.GlobalRootDir,
 	)
@@ -509,13 +524,14 @@ WantedBy=multi-user.target
 	err := os.MkdirAll(filepath.Dir(sliceFile), 0755)
 	c.Assert(err, IsNil)
 
-	err = ioutil.WriteFile(sliceFile, []byte(fmt.Sprintf(sliceTempl, "foogroup", memLimit.String())), 0644)
+	err = ioutil.WriteFile(sliceFile, []byte(fmt.Sprintf(sliceTempl, "foogroup", memLimit.String(), taskLimit)), 0644)
 	c.Assert(err, IsNil)
 
 	err = ioutil.WriteFile(svcFile, []byte(svcContent), 0644)
 	c.Assert(err, IsNil)
 
-	grp, err := quota.NewGroup("foogroup", quota.NewResources(memLimit))
+	resourceLimits := quota.NewResources(memLimit, 0, 0, nil, taskLimit)
+	grp, err := quota.NewGroup("foogroup", resourceLimits)
 	c.Assert(err, IsNil)
 
 	m := map[*snap.Info]*wrappers.SnapServiceOptions{
@@ -533,12 +549,13 @@ WantedBy=multi-user.target
 
 	c.Assert(svcFile, testutil.FileEquals, svcContent)
 
-	c.Assert(sliceFile, testutil.FileEquals, fmt.Sprintf(sliceTempl, "foogroup", memLimit.String()))
+	c.Assert(sliceFile, testutil.FileEquals, fmt.Sprintf(sliceTempl, "foogroup", memLimit.String(), taskLimit))
 }
 
 func (s *servicesTestSuite) TestRemoveQuotaGroup(c *C) {
 	// create the group
-	grp, err := quota.NewGroup("foogroup", quota.NewResources(5*quantity.SizeKiB))
+	resourceLimits := quota.NewResources(5*quantity.SizeKiB, 0, 0, nil, 0)
+	grp, err := quota.NewGroup("foogroup", resourceLimits)
 	c.Assert(err, IsNil)
 
 	sliceFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.foogroup.slice")
@@ -554,17 +571,17 @@ func (s *servicesTestSuite) TestRemoveQuotaGroup(c *C) {
 
 	// now write slice file and ensure it is deleted
 	sliceTempl := `[Unit]
-Description=Slice for snap quota group %s
-Before=slices.target
-X-Snappy=yes
-
-[Slice]
-# Always enable memory accounting otherwise the MemoryMax setting does nothing.
-MemoryAccounting=true
-MemoryMax=1024
-# for compatibility with older versions of systemd
-MemoryLimit=1024
-`
+ Description=Slice for snap quota group %s
+ Before=slices.target
+ X-Snappy=yes
+ 
+ [Slice]
+ # Always enable memory accounting otherwise the MemoryMax setting does nothing.
+ MemoryAccounting=true
+ MemoryMax=1024
+ # for compatibility with older versions of systemd
+ MemoryLimit=1024
+ `
 
 	err = os.MkdirAll(filepath.Dir(sliceFile), 0755)
 	c.Assert(err, IsNil)
@@ -586,34 +603,34 @@ MemoryLimit=1024
 func (s *servicesTestSuite) TestEnsureSnapServicesWithSubGroupQuotaGroupsForSnaps(c *C) {
 	info1 := snaptest.MockSnap(c, packageHello, &snap.SideInfo{Revision: snap.R(12)})
 	info2 := snaptest.MockSnap(c, `
-name: hello-other-snap
-version: 1.10
-summary: hello
-description: Hello...
-apps:
- hello:
+ name: hello-other-snap
+ version: 1.10
+ summary: hello
+ description: Hello...
+ apps:
+  hello:
+	command: bin/hello
+  world:
+	command: bin/world
+	completer: world-completer.sh
+  svc1:
    command: bin/hello
- world:
-   command: bin/world
-   completer: world-completer.sh
- svc1:
-  command: bin/hello
-  stop-command: bin/goodbye
-  post-stop-command: bin/missya
-  daemon: forking
-`, &snap.SideInfo{Revision: snap.R(12)})
+   stop-command: bin/goodbye
+   post-stop-command: bin/missya
+   daemon: forking
+ `, &snap.SideInfo{Revision: snap.R(12)})
 	svcFile1 := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-snap.svc1.service")
 	svcFile2 := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-other-snap.svc1.service")
 
 	var err error
-	memLimit := quantity.SizeGiB
+	resourceLimits := quota.NewResources(quantity.SizeGiB, 4, 25, nil, 0)
 	// make a root quota group and add the first snap to it
-	grp, err := quota.NewGroup("foogroup", quota.NewResources(memLimit))
+	grp, err := quota.NewGroup("foogroup", resourceLimits)
 	c.Assert(err, IsNil)
 
 	// the second group is a sub-group with the same limit, but is for the
 	// second snap
-	subgrp, err := grp.NewSubGroup("subgroup", quota.NewResources(memLimit))
+	subgrp, err := grp.NewSubGroup("subgroup", resourceLimits)
 	c.Assert(err, IsNil)
 
 	sliceFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.foogroup.slice")
@@ -625,48 +642,52 @@ apps:
 	}
 
 	sliceTempl := `[Unit]
-Description=Slice for snap quota group %s
-Before=slices.target
-X-Snappy=yes
+ Description=Slice for snap quota group %s
+ Before=slices.target
+ X-Snappy=yes
+ 
+ [Slice]
+ # Always enable cpu accounting, so the following cpu quota options have an effect
+ CPUAccounting=true
+ CPUQuota=%[2]d
+ 
+ # Always enable memory accounting otherwise the MemoryMax setting does nothing.
+ MemoryAccounting=true
+ MemoryMax=%[3]d
+ # for compatibility with older versions of systemd
+ MemoryLimit=%[3]d
+ 
+ # Always enable task accounting in order to be able to count the processes/
+ # threads, etc for a slice
+ TasksAccounting=true
+ `
 
-[Slice]
-# Always enable memory accounting otherwise the MemoryMax setting does nothing.
-MemoryAccounting=true
-MemoryMax=%[2]s
-# for compatibility with older versions of systemd
-MemoryLimit=%[2]s
-
-# Always enable task accounting in order to be able to count the processes/
-# threads, etc for a slice
-TasksAccounting=true
-`
-
-	sliceContent := fmt.Sprintf(sliceTempl, "foogroup", memLimit.String())
-	subSliceContent := fmt.Sprintf(sliceTempl, "subgroup", memLimit.String())
+	sliceContent := fmt.Sprintf(sliceTempl, "foogroup", resourceLimits.Cpu.Count*resourceLimits.Cpu.Percentage, resourceLimits.Memory.MemoryLimit)
+	subSliceContent := fmt.Sprintf(sliceTempl, "subgroup", resourceLimits.Cpu.Count*resourceLimits.Cpu.Percentage, resourceLimits.Memory.MemoryLimit)
 
 	svcTemplate := `[Unit]
-# Auto-generated, DO NOT EDIT
-Description=Service for snap application %[1]s.svc1
-Requires=%[2]s
-Wants=network.target
-After=%[2]s network.target snapd.apparmor.service
-X-Snappy=yes
-
-[Service]
-EnvironmentFile=-/etc/environment
-ExecStart=/usr/bin/snap run %[1]s.svc1
-SyslogIdentifier=%[1]s.svc1
-Restart=on-failure
-WorkingDirectory=%[3]s/var/snap/%[1]s/12
-ExecStop=/usr/bin/snap run --command=stop %[1]s.svc1
-ExecStopPost=/usr/bin/snap run --command=post-stop %[1]s.svc1
-TimeoutStopSec=30
-Type=forking
-Slice=%[4]s
-
-[Install]
-WantedBy=multi-user.target
-`
+ # Auto-generated, DO NOT EDIT
+ Description=Service for snap application %[1]s.svc1
+ Requires=%[2]s
+ Wants=network.target
+ After=%[2]s network.target snapd.apparmor.service
+ X-Snappy=yes
+ 
+ [Service]
+ EnvironmentFile=-/etc/environment
+ ExecStart=/usr/bin/snap run %[1]s.svc1
+ SyslogIdentifier=%[1]s.svc1
+ Restart=on-failure
+ WorkingDirectory=%[3]s/var/snap/%[1]s/12
+ ExecStop=/usr/bin/snap run --command=stop %[1]s.svc1
+ ExecStopPost=/usr/bin/snap run --command=post-stop %[1]s.svc1
+ TimeoutStopSec=30
+ Type=forking
+ Slice=%[4]s
+ 
+ [Install]
+ WantedBy=multi-user.target
+ `
 
 	dir1 := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
 	dir2 := filepath.Join(dirs.SnapMountDir, "hello-other-snap", "12.mount")
@@ -739,14 +760,14 @@ func (s *servicesTestSuite) TestEnsureSnapServicesWithSubGroupQuotaGroupsGenerat
 	svcFile1 := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-snap.svc1.service")
 
 	var err error
-	memLimit := quantity.SizeGiB
+	resourceLimits := resources.CreateQuotaResources(quantity.SizeGiB, 0, 0, []int{0}, 0)
 	// make a root quota group without any snaps in it
-	grp, err := quota.NewGroup("foogroup", quota.NewResources(memLimit))
+	grp, err := quota.NewGroup("foogroup", resourceLimits)
 	c.Assert(err, IsNil)
 
 	// the second group is a sub-group with the same limit, but it is the one
 	// with the snap in it
-	subgrp, err := grp.NewSubGroup("subgroup", quota.NewResources(memLimit))
+	subgrp, err := grp.NewSubGroup("subgroup", resourceLimits)
 	c.Assert(err, IsNil)
 
 	sliceFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.foogroup.slice")
@@ -763,28 +784,28 @@ func (s *servicesTestSuite) TestEnsureSnapServicesWithSubGroupQuotaGroupsGenerat
 	})
 
 	svcTemplate := `[Unit]
-# Auto-generated, DO NOT EDIT
-Description=Service for snap application %[1]s.svc1
-Requires=%[2]s
-Wants=network.target
-After=%[2]s network.target snapd.apparmor.service
-X-Snappy=yes
-
-[Service]
-EnvironmentFile=-/etc/environment
-ExecStart=/usr/bin/snap run %[1]s.svc1
-SyslogIdentifier=%[1]s.svc1
-Restart=on-failure
-WorkingDirectory=%[3]s/var/snap/%[1]s/12
-ExecStop=/usr/bin/snap run --command=stop %[1]s.svc1
-ExecStopPost=/usr/bin/snap run --command=post-stop %[1]s.svc1
-TimeoutStopSec=30
-Type=forking
-Slice=%[4]s
-
-[Install]
-WantedBy=multi-user.target
-`
+ # Auto-generated, DO NOT EDIT
+ Description=Service for snap application %[1]s.svc1
+ Requires=%[2]s
+ Wants=network.target
+ After=%[2]s network.target snapd.apparmor.service
+ X-Snappy=yes
+ 
+ [Service]
+ EnvironmentFile=-/etc/environment
+ ExecStart=/usr/bin/snap run %[1]s.svc1
+ SyslogIdentifier=%[1]s.svc1
+ Restart=on-failure
+ WorkingDirectory=%[3]s/var/snap/%[1]s/12
+ ExecStop=/usr/bin/snap run --command=stop %[1]s.svc1
+ ExecStopPost=/usr/bin/snap run --command=post-stop %[1]s.svc1
+ TimeoutStopSec=30
+ Type=forking
+ Slice=%[4]s
+ 
+ [Install]
+ WantedBy=multi-user.target
+ `
 
 	dir1 := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
 
@@ -797,24 +818,29 @@ WantedBy=multi-user.target
 
 	// check that both the parent and sub-group slice units were generated
 	templ := `[Unit]
-Description=Slice for snap quota group %s
-Before=slices.target
-X-Snappy=yes
+ Description=Slice for snap quota group %s
+ Before=slices.target
+ X-Snappy=yes
+ 
+ [Slice]
+ # Always enable cpu accounting, so the following cpu quota options have an effect
+ CPUAccounting=true
+ AllowedCPUs=%[2]s
+ 
+ # Always enable memory accounting otherwise the MemoryMax setting does nothing.
+ MemoryAccounting=true
+ MemoryMax=%[3]d
+ # for compatibility with older versions of systemd
+ MemoryLimit=%[3]d
+ 
+ # Always enable task accounting in order to be able to count the processes/
+ # threads, etc for a slice
+ TasksAccounting=true
+ `
 
-[Slice]
-# Always enable memory accounting otherwise the MemoryMax setting does nothing.
-MemoryAccounting=true
-MemoryMax=%[2]s
-# for compatibility with older versions of systemd
-MemoryLimit=%[2]s
-
-# Always enable task accounting in order to be able to count the processes/
-# threads, etc for a slice
-TasksAccounting=true
-`
-
-	c.Assert(sliceFile, testutil.FileEquals, fmt.Sprintf(templ, "foogroup", memLimit.String()))
-	c.Assert(subSliceFile, testutil.FileEquals, fmt.Sprintf(templ, "subgroup", memLimit.String()))
+	allowedCpusValue := strings.Trim(strings.Join(strings.Fields(fmt.Sprint(resourceLimits.Cpu.AllowedCpus)), ","), "[]")
+	c.Assert(sliceFile, testutil.FileEquals, fmt.Sprintf(templ, "foogroup", allowedCpusValue, resourceLimits.Memory.MemoryLimit))
+	c.Assert(subSliceFile, testutil.FileEquals, fmt.Sprintf(templ, "subgroup", allowedCpusValue, resourceLimits.Memory.MemoryLimit))
 }
 
 func (s *servicesTestSuite) TestEnsureSnapServiceEnsureError(c *C) {
@@ -872,27 +898,27 @@ func (s *servicesTestSuite) TestEnsureSnapServicesPreseedingHappy(c *C) {
 
 	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
 	c.Assert(svcFile, testutil.FileEquals, fmt.Sprintf(`[Unit]
-# Auto-generated, DO NOT EDIT
-Description=Service for snap application hello-snap.svc1
-Requires=%[1]s
-Wants=network.target
-After=%[1]s network.target snapd.apparmor.service
-X-Snappy=yes
-
-[Service]
-EnvironmentFile=-/etc/environment
-ExecStart=/usr/bin/snap run hello-snap.svc1
-SyslogIdentifier=hello-snap.svc1
-Restart=on-failure
-WorkingDirectory=%[2]s/var/snap/hello-snap/12
-ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
-ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
-TimeoutStopSec=30
-Type=forking
-
-[Install]
-WantedBy=multi-user.target
-`,
+ # Auto-generated, DO NOT EDIT
+ Description=Service for snap application hello-snap.svc1
+ Requires=%[1]s
+ Wants=network.target
+ After=%[1]s network.target snapd.apparmor.service
+ X-Snappy=yes
+ 
+ [Service]
+ EnvironmentFile=-/etc/environment
+ ExecStart=/usr/bin/snap run hello-snap.svc1
+ SyslogIdentifier=hello-snap.svc1
+ Restart=on-failure
+ WorkingDirectory=%[2]s/var/snap/hello-snap/12
+ ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
+ ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
+ TimeoutStopSec=30
+ Type=forking
+ 
+ [Install]
+ WantedBy=multi-user.target
+ `,
 		systemd.EscapeUnitNamePath(dir),
 		dirs.GlobalRootDir,
 	))
@@ -909,22 +935,22 @@ func (s *servicesTestSuite) TestEnsureSnapServicesRequireMountedSnapdSnapOptions
 	// that the global options apply to all snaps
 	info1 := snaptest.MockSnap(c, packageHello, &snap.SideInfo{Revision: snap.R(12)})
 	info2 := snaptest.MockSnap(c, `
-name: hello-other-snap
-version: 1.10
-summary: hello
-description: Hello...
-apps:
- hello:
+ name: hello-other-snap
+ version: 1.10
+ summary: hello
+ description: Hello...
+ apps:
+  hello:
+	command: bin/hello
+  world:
+	command: bin/world
+	completer: world-completer.sh
+  svc1:
    command: bin/hello
- world:
-   command: bin/world
-   completer: world-completer.sh
- svc1:
-  command: bin/hello
-  stop-command: bin/goodbye
-  post-stop-command: bin/missya
-  daemon: forking
-`, &snap.SideInfo{Revision: snap.R(12)})
+   stop-command: bin/goodbye
+   post-stop-command: bin/missya
+   daemon: forking
+ `, &snap.SideInfo{Revision: snap.R(12)})
 	svcFile1 := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-snap.svc1.service")
 	svcFile2 := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-other-snap.svc1.service")
 
@@ -950,29 +976,29 @@ apps:
 	})
 
 	template := `[Unit]
-# Auto-generated, DO NOT EDIT
-Description=Service for snap application %[1]s.svc1
-Requires=%[2]s
-Wants=network.target
-After=%[2]s network.target snapd.apparmor.service
-Wants=usr-lib-snapd.mount
-After=usr-lib-snapd.mount
-X-Snappy=yes
-
-[Service]
-EnvironmentFile=-/etc/environment
-ExecStart=/usr/bin/snap run %[1]s.svc1
-SyslogIdentifier=%[1]s.svc1
-Restart=on-failure
-WorkingDirectory=%[3]s/var/snap/%[1]s/12
-ExecStop=/usr/bin/snap run --command=stop %[1]s.svc1
-ExecStopPost=/usr/bin/snap run --command=post-stop %[1]s.svc1
-TimeoutStopSec=30
-Type=forking
-%[4]s
-[Install]
-WantedBy=multi-user.target
-`
+ # Auto-generated, DO NOT EDIT
+ Description=Service for snap application %[1]s.svc1
+ Requires=%[2]s
+ Wants=network.target
+ After=%[2]s network.target snapd.apparmor.service
+ Wants=usr-lib-snapd.mount
+ After=usr-lib-snapd.mount
+ X-Snappy=yes
+ 
+ [Service]
+ EnvironmentFile=-/etc/environment
+ ExecStart=/usr/bin/snap run %[1]s.svc1
+ SyslogIdentifier=%[1]s.svc1
+ Restart=on-failure
+ WorkingDirectory=%[3]s/var/snap/%[1]s/12
+ ExecStop=/usr/bin/snap run --command=stop %[1]s.svc1
+ ExecStopPost=/usr/bin/snap run --command=post-stop %[1]s.svc1
+ TimeoutStopSec=30
+ Type=forking
+ %[4]s
+ [Install]
+ WantedBy=multi-user.target
+ `
 
 	dir1 := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
 	dir2 := filepath.Join(dirs.SnapMountDir, "hello-other-snap", "12.mount")
@@ -995,37 +1021,37 @@ WantedBy=multi-user.target
 func (s *servicesTestSuite) TestEnsureSnapServicesCallback(c *C) {
 	// hava a 2nd new service definition
 	info := snaptest.MockSnap(c, packageHello+` svc2:
-  command: bin/hello
-  stop-command: bin/goodbye
-  post-stop-command: bin/missya
-  daemon: forking
-`, &snap.SideInfo{Revision: snap.R(12)})
+   command: bin/hello
+   stop-command: bin/goodbye
+   post-stop-command: bin/missya
+   daemon: forking
+ `, &snap.SideInfo{Revision: snap.R(12)})
 	svc1File := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-snap.svc1.service")
 	svc2File := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-snap.svc2.service")
 
 	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
 	template := `[Unit]
-# Auto-generated, DO NOT EDIT
-Description=Service for snap application hello-snap.%[1]s
-Requires=%[2]s
-Wants=network.target
-After=%[2]s network.target snapd.apparmor.service
-X-Snappy=yes
-
-[Service]
-EnvironmentFile=-/etc/environment
-ExecStart=/usr/bin/snap run hello-snap.%[1]s
-SyslogIdentifier=hello-snap.%[1]s
-Restart=on-failure
-WorkingDirectory=%[3]s/var/snap/hello-snap/12
-ExecStop=/usr/bin/snap run --command=stop hello-snap.%[1]s
-ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.%[1]s
-TimeoutStopSec=30
-Type=forking
-%[4]s
-[Install]
-WantedBy=multi-user.target
-`
+ # Auto-generated, DO NOT EDIT
+ Description=Service for snap application hello-snap.%[1]s
+ Requires=%[2]s
+ Wants=network.target
+ After=%[2]s network.target snapd.apparmor.service
+ X-Snappy=yes
+ 
+ [Service]
+ EnvironmentFile=-/etc/environment
+ ExecStart=/usr/bin/snap run hello-snap.%[1]s
+ SyslogIdentifier=hello-snap.%[1]s
+ Restart=on-failure
+ WorkingDirectory=%[3]s/var/snap/hello-snap/12
+ ExecStop=/usr/bin/snap run --command=stop hello-snap.%[1]s
+ ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.%[1]s
+ TimeoutStopSec=30
+ Type=forking
+ %[4]s
+ [Install]
+ WantedBy=multi-user.target
+ `
 	svc1Content := fmt.Sprintf(template,
 		"svc1",
 		systemd.EscapeUnitNamePath(dir),
@@ -1088,37 +1114,37 @@ func (s *servicesTestSuite) TestEnsureSnapServicesAddsNewSvc(c *C) {
 	// test that with an existing service unit definition, it is not changed
 	// but we do add the new one
 	info := snaptest.MockSnap(c, packageHello+` svc2:
-  command: bin/hello
-  stop-command: bin/goodbye
-  post-stop-command: bin/missya
-  daemon: forking
-`, &snap.SideInfo{Revision: snap.R(12)})
+   command: bin/hello
+   stop-command: bin/goodbye
+   post-stop-command: bin/missya
+   daemon: forking
+ `, &snap.SideInfo{Revision: snap.R(12)})
 	svc1File := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-snap.svc1.service")
 	svc2File := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-snap.svc2.service")
 
 	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
 	template := `[Unit]
-# Auto-generated, DO NOT EDIT
-Description=Service for snap application hello-snap.%[1]s
-Requires=%[2]s
-Wants=network.target
-After=%[2]s network.target snapd.apparmor.service
-X-Snappy=yes
-
-[Service]
-EnvironmentFile=-/etc/environment
-ExecStart=/usr/bin/snap run hello-snap.%[1]s
-SyslogIdentifier=hello-snap.%[1]s
-Restart=on-failure
-WorkingDirectory=%[3]s/var/snap/hello-snap/12
-ExecStop=/usr/bin/snap run --command=stop hello-snap.%[1]s
-ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.%[1]s
-TimeoutStopSec=30
-Type=forking
-%[4]s
-[Install]
-WantedBy=multi-user.target
-`
+ # Auto-generated, DO NOT EDIT
+ Description=Service for snap application hello-snap.%[1]s
+ Requires=%[2]s
+ Wants=network.target
+ After=%[2]s network.target snapd.apparmor.service
+ X-Snappy=yes
+ 
+ [Service]
+ EnvironmentFile=-/etc/environment
+ ExecStart=/usr/bin/snap run hello-snap.%[1]s
+ SyslogIdentifier=hello-snap.%[1]s
+ Restart=on-failure
+ WorkingDirectory=%[3]s/var/snap/hello-snap/12
+ ExecStop=/usr/bin/snap run --command=stop hello-snap.%[1]s
+ ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.%[1]s
+ TimeoutStopSec=30
+ Type=forking
+ %[4]s
+ [Install]
+ WantedBy=multi-user.target
+ `
 	svc1Content := fmt.Sprintf(template,
 		"svc1",
 		systemd.EscapeUnitNamePath(dir),
@@ -1170,27 +1196,27 @@ func (s *servicesTestSuite) TestEnsureSnapServicesNoChangeNoop(c *C) {
 
 	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
 	template := `[Unit]
-# Auto-generated, DO NOT EDIT
-Description=Service for snap application hello-snap.svc1
-Requires=%[1]s
-Wants=network.target
-After=%[1]s network.target snapd.apparmor.service
-X-Snappy=yes
-
-[Service]
-EnvironmentFile=-/etc/environment
-ExecStart=/usr/bin/snap run hello-snap.svc1
-SyslogIdentifier=hello-snap.svc1
-Restart=on-failure
-WorkingDirectory=%[2]s/var/snap/hello-snap/12
-ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
-ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
-TimeoutStopSec=30
-Type=forking
-%s
-[Install]
-WantedBy=multi-user.target
-`
+ # Auto-generated, DO NOT EDIT
+ Description=Service for snap application hello-snap.svc1
+ Requires=%[1]s
+ Wants=network.target
+ After=%[1]s network.target snapd.apparmor.service
+ X-Snappy=yes
+ 
+ [Service]
+ EnvironmentFile=-/etc/environment
+ ExecStart=/usr/bin/snap run hello-snap.svc1
+ SyslogIdentifier=hello-snap.svc1
+ Restart=on-failure
+ WorkingDirectory=%[2]s/var/snap/hello-snap/12
+ ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
+ ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
+ TimeoutStopSec=30
+ Type=forking
+ %s
+ [Install]
+ WantedBy=multi-user.target
+ `
 	origContent := fmt.Sprintf(template,
 		systemd.EscapeUnitNamePath(dir),
 		dirs.GlobalRootDir,
@@ -1238,27 +1264,27 @@ func (s *servicesTestSuite) TestEnsureSnapServicesChanges(c *C) {
 
 	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
 	template := `[Unit]
-# Auto-generated, DO NOT EDIT
-Description=Service for snap application hello-snap.svc1
-Requires=%[1]s
-Wants=network.target
-After=%[1]s network.target snapd.apparmor.service
-X-Snappy=yes
-
-[Service]
-EnvironmentFile=-/etc/environment
-ExecStart=/usr/bin/snap run hello-snap.svc1
-SyslogIdentifier=hello-snap.svc1
-Restart=on-failure
-WorkingDirectory=%[2]s/var/snap/hello-snap/12
-ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
-ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
-TimeoutStopSec=30
-Type=forking
-%s
-[Install]
-WantedBy=multi-user.target
-`
+ # Auto-generated, DO NOT EDIT
+ Description=Service for snap application hello-snap.svc1
+ Requires=%[1]s
+ Wants=network.target
+ After=%[1]s network.target snapd.apparmor.service
+ X-Snappy=yes
+ 
+ [Service]
+ EnvironmentFile=-/etc/environment
+ ExecStart=/usr/bin/snap run hello-snap.svc1
+ SyslogIdentifier=hello-snap.svc1
+ Restart=on-failure
+ WorkingDirectory=%[2]s/var/snap/hello-snap/12
+ ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
+ ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
+ TimeoutStopSec=30
+ Type=forking
+ %s
+ [Install]
+ WantedBy=multi-user.target
+ `
 	origContent := fmt.Sprintf(template,
 		systemd.EscapeUnitNamePath(dir),
 		dirs.GlobalRootDir,
@@ -1302,27 +1328,27 @@ func (s *servicesTestSuite) TestEnsureSnapServicesRollsback(c *C) {
 	// pretend we already have a unit file with no VitalityRank options set
 	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
 	template := `[Unit]
-# Auto-generated, DO NOT EDIT
-Description=Service for snap application hello-snap.svc1
-Requires=%[1]s
-Wants=network.target
-After=%[1]s network.target snapd.apparmor.service
-X-Snappy=yes
-
-[Service]
-EnvironmentFile=-/etc/environment
-ExecStart=/usr/bin/snap run hello-snap.svc1
-SyslogIdentifier=hello-snap.svc1
-Restart=on-failure
-WorkingDirectory=%[2]s/var/snap/hello-snap/12
-ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
-ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
-TimeoutStopSec=30
-Type=forking
-%s
-[Install]
-WantedBy=multi-user.target
-`
+ # Auto-generated, DO NOT EDIT
+ Description=Service for snap application hello-snap.svc1
+ Requires=%[1]s
+ Wants=network.target
+ After=%[1]s network.target snapd.apparmor.service
+ X-Snappy=yes
+ 
+ [Service]
+ EnvironmentFile=-/etc/environment
+ ExecStart=/usr/bin/snap run hello-snap.svc1
+ SyslogIdentifier=hello-snap.svc1
+ Restart=on-failure
+ WorkingDirectory=%[2]s/var/snap/hello-snap/12
+ ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
+ ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
+ TimeoutStopSec=30
+ Type=forking
+ %s
+ [Install]
+ WantedBy=multi-user.target
+ `
 	origContent := fmt.Sprintf(template,
 		systemd.EscapeUnitNamePath(dir),
 		dirs.GlobalRootDir,
@@ -1386,27 +1412,27 @@ func (s *servicesTestSuite) TestEnsureSnapServicesRemovesNewAddOnRollback(c *C) 
 	// pretend we already have a unit file with no VitalityRank options set
 	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
 	template := `[Unit]
-# Auto-generated, DO NOT EDIT
-Description=Service for snap application hello-snap.svc1
-Requires=%[1]s
-Wants=network.target
-After=%[1]s network.target snapd.apparmor.service
-X-Snappy=yes
-
-[Service]
-EnvironmentFile=-/etc/environment
-ExecStart=/usr/bin/snap run hello-snap.svc1
-SyslogIdentifier=hello-snap.svc1
-Restart=on-failure
-WorkingDirectory=%[2]s/var/snap/hello-snap/12
-ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
-ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
-TimeoutStopSec=30
-Type=forking
-%s
-[Install]
-WantedBy=multi-user.target
-`
+ # Auto-generated, DO NOT EDIT
+ Description=Service for snap application hello-snap.svc1
+ Requires=%[1]s
+ Wants=network.target
+ After=%[1]s network.target snapd.apparmor.service
+ X-Snappy=yes
+ 
+ [Service]
+ EnvironmentFile=-/etc/environment
+ ExecStart=/usr/bin/snap run hello-snap.svc1
+ SyslogIdentifier=hello-snap.svc1
+ Restart=on-failure
+ WorkingDirectory=%[2]s/var/snap/hello-snap/12
+ ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
+ ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
+ TimeoutStopSec=30
+ Type=forking
+ %s
+ [Install]
+ WantedBy=multi-user.target
+ `
 	// make systemctl fail the first time when we try to do a daemon-reload,
 	// then the next time don't return an error
 	systemctlCalls := 0
@@ -1450,11 +1476,11 @@ WantedBy=multi-user.target
 
 func (s *servicesTestSuite) TestEnsureSnapServicesOnlyRemovesNewAddOnRollback(c *C) {
 	info := snaptest.MockSnap(c, packageHello+` svc2:
-  command: bin/hello
-  stop-command: bin/goodbye
-  post-stop-command: bin/missya
-  daemon: forking
-`, &snap.SideInfo{Revision: snap.R(12)})
+   command: bin/hello
+   stop-command: bin/goodbye
+   post-stop-command: bin/missya
+   daemon: forking
+ `, &snap.SideInfo{Revision: snap.R(12)})
 
 	// we won't delete existing files, but we will delete new files, so mock an
 	// existing file to check that it doesn't get deleted
@@ -1464,27 +1490,27 @@ func (s *servicesTestSuite) TestEnsureSnapServicesOnlyRemovesNewAddOnRollback(c 
 	// pretend we already have a unit file with no VitalityRank options set
 	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
 	template := `[Unit]
-# Auto-generated, DO NOT EDIT
-Description=Service for snap application hello-snap.%[1]s
-Requires=%[2]s
-Wants=network.target
-After=%[2]s network.target snapd.apparmor.service
-X-Snappy=yes
-
-[Service]
-EnvironmentFile=-/etc/environment
-ExecStart=/usr/bin/snap run hello-snap.%[1]s
-SyslogIdentifier=hello-snap.%[1]s
-Restart=on-failure
-WorkingDirectory=%[3]s/var/snap/hello-snap/12
-ExecStop=/usr/bin/snap run --command=stop hello-snap.%[1]s
-ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.%[1]s
-TimeoutStopSec=30
-Type=forking
-%[4]s
-[Install]
-WantedBy=multi-user.target
-`
+ # Auto-generated, DO NOT EDIT
+ Description=Service for snap application hello-snap.%[1]s
+ Requires=%[2]s
+ Wants=network.target
+ After=%[2]s network.target snapd.apparmor.service
+ X-Snappy=yes
+ 
+ [Service]
+ EnvironmentFile=-/etc/environment
+ ExecStart=/usr/bin/snap run hello-snap.%[1]s
+ SyslogIdentifier=hello-snap.%[1]s
+ Restart=on-failure
+ WorkingDirectory=%[3]s/var/snap/hello-snap/12
+ ExecStop=/usr/bin/snap run --command=stop hello-snap.%[1]s
+ ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.%[1]s
+ TimeoutStopSec=30
+ Type=forking
+ %[4]s
+ [Install]
+ WantedBy=multi-user.target
+ `
 
 	svc1Content := fmt.Sprintf(template,
 		"svc1",
@@ -1554,8 +1580,8 @@ func (s *servicesTestSuite) TestEnsureSnapServicesSubunits(c *C) {
 	}
 
 	info := snaptest.MockSnap(c, packageHello+`
-  timer: 10:00-12:00
-`, &snap.SideInfo{Revision: snap.R(11)})
+   timer: 10:00-12:00
+ `, &snap.SideInfo{Revision: snap.R(11)})
 
 	m := map[*snap.Info]*wrappers.SnapServiceOptions{
 		info: nil,
@@ -1572,12 +1598,12 @@ func (s *servicesTestSuite) TestEnsureSnapServicesSubunits(c *C) {
 
 	// change vitality, timer, add socket
 	info = snaptest.MockSnap(c, packageHello+`
-  plugs: [network-bind]
-  timer: 10:00-12:00,20:00-22:00
-  sockets:
-    sock1:
-      listen-stream: $SNAP_DATA/sock1.socket
-`, &snap.SideInfo{Revision: snap.R(12)})
+   plugs: [network-bind]
+   timer: 10:00-12:00,20:00-22:00
+   sockets:
+	 sock1:
+	   listen-stream: $SNAP_DATA/sock1.socket
+ `, &snap.SideInfo{Revision: snap.R(12)})
 
 	m = map[*snap.Info]*wrappers.SnapServiceOptions{
 		info: {VitalityRank: 1},
@@ -1601,28 +1627,28 @@ func (s *servicesTestSuite) TestAddSnapServicesWithInterfaceSnippets(c *C) {
 		{
 			"docker-support",
 			`
-  plugs:
-   - docker-support`,
+   plugs:
+	- docker-support`,
 		},
 		{
 			"k8s-support",
 			`
-  plugs:
-   - kubernetes-support`,
+   plugs:
+	- kubernetes-support`,
 		},
 		{
 			"lxd-support",
 			`
-  plugs:
-   - lxd-support
-`,
+   plugs:
+	- lxd-support
+ `,
 		},
 		{
 			"greengrass-support",
 			`
-  plugs:
-   - greengrass-support
-`,
+   plugs:
+	- greengrass-support
+ `,
 		},
 
 		// multiple interfaces that require Delegate=true, but only one is
@@ -1631,9 +1657,9 @@ func (s *servicesTestSuite) TestAddSnapServicesWithInterfaceSnippets(c *C) {
 		{
 			"multiple interfaces that require Delegate=true",
 			`
-  plugs:
-   - docker-support
-   - kubernetes-support`,
+   plugs:
+	- docker-support
+	- kubernetes-support`,
 		},
 
 		// interfaces with flavor attributes
@@ -1641,44 +1667,44 @@ func (s *servicesTestSuite) TestAddSnapServicesWithInterfaceSnippets(c *C) {
 		{
 			"k8s-support with kubelet",
 			`
-  plugs:
-   - kubelet
-plugs:
- kubelet:
-  interface: kubernetes-support
-  flavor: kubelet
-`,
+   plugs:
+	- kubelet
+ plugs:
+  kubelet:
+   interface: kubernetes-support
+   flavor: kubelet
+ `,
 		},
 		{
 			"k8s-support with kubeproxy",
 			`
-  plugs:
-   - kubeproxy
-plugs:
- kubeproxy:
-  interface: kubernetes-support
-  flavor: kubeproxy
-`,
+   plugs:
+	- kubeproxy
+ plugs:
+  kubeproxy:
+   interface: kubernetes-support
+   flavor: kubeproxy
+ `,
 		},
 		{
 			"greengrass-support with legacy-container flavor",
 			`
-  plugs:
-   - greengrass
-plugs:
- greengrass:
-  interface: greengrass-support
-  flavor: legacy-container
-`,
+   plugs:
+	- greengrass
+ plugs:
+  greengrass:
+   interface: greengrass-support
+   flavor: legacy-container
+ `,
 		},
 	}
 
 	for _, t := range tt {
 		comment := Commentf(t.comment)
 		info := snaptest.MockSnap(c, packageHelloNoSrv+`
- svc1:
-  daemon: simple
-`+t.plugSnippet,
+  svc1:
+   daemon: simple
+ `+t.plugSnippet,
 			&snap.SideInfo{Revision: snap.R(12)})
 		svcFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-snap.svc1.service")
 
@@ -1690,26 +1716,26 @@ plugs:
 
 		dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
 		c.Assert(svcFile, testutil.FileEquals, fmt.Sprintf(`[Unit]
-# Auto-generated, DO NOT EDIT
-Description=Service for snap application hello-snap.svc1
-Requires=%[1]s
-Wants=network.target
-After=%[1]s network.target snapd.apparmor.service
-X-Snappy=yes
-
-[Service]
-EnvironmentFile=-/etc/environment
-ExecStart=/usr/bin/snap run hello-snap.svc1
-SyslogIdentifier=hello-snap.svc1
-Restart=on-failure
-WorkingDirectory=%[2]s/var/snap/hello-snap/12
-TimeoutStopSec=30
-Type=simple
-Delegate=true
-
-[Install]
-WantedBy=multi-user.target
-`,
+ # Auto-generated, DO NOT EDIT
+ Description=Service for snap application hello-snap.svc1
+ Requires=%[1]s
+ Wants=network.target
+ After=%[1]s network.target snapd.apparmor.service
+ X-Snappy=yes
+ 
+ [Service]
+ EnvironmentFile=-/etc/environment
+ ExecStart=/usr/bin/snap run hello-snap.svc1
+ SyslogIdentifier=hello-snap.svc1
+ Restart=on-failure
+ WorkingDirectory=%[2]s/var/snap/hello-snap/12
+ TimeoutStopSec=30
+ Type=simple
+ Delegate=true
+ 
+ [Install]
+ WantedBy=multi-user.target
+ `,
 			systemd.EscapeUnitNamePath(dir),
 			dirs.GlobalRootDir,
 		), comment)
@@ -1739,10 +1765,10 @@ WantedBy=multi-user.target
 
 func (s *servicesTestSuite) TestAddSnapServicesAndRemoveUserDaemons(c *C) {
 	info := snaptest.MockSnap(c, packageHelloNoSrv+`
- svc1:
-  daemon: simple
-  daemon-scope: user
-`, &snap.SideInfo{Revision: snap.R(12)})
+  svc1:
+   daemon: simple
+   daemon-scope: user
+ `, &snap.SideInfo{Revision: snap.R(12)})
 	svcFile := filepath.Join(s.tempdir, "/etc/systemd/user/snap.hello-snap.svc1.service")
 
 	err := wrappers.AddSnapServices(info, nil, progress.Null)
@@ -1775,22 +1801,22 @@ func (s *servicesTestSuite) TestAddSnapServicesAndRemoveUserDaemons(c *C) {
 }
 
 var snapdYaml = `name: snapd
-version: 1.0
-type: snapd
-`
+ version: 1.0
+ type: snapd
+ `
 
 func (s *servicesTestSuite) TestRemoveSnapWithSocketsRemovesSocketsService(c *C) {
 	info := snaptest.MockSnap(c, packageHelloNoSrv+`
- svc1:
-  daemon: simple
-  plugs: [network-bind]
-  sockets:
-    sock1:
-      listen-stream: $SNAP_DATA/sock1.socket
-      socket-mode: 0666
-    sock2:
-      listen-stream: $SNAP_COMMON/sock2.socket
-`, &snap.SideInfo{Revision: snap.R(12)})
+  svc1:
+   daemon: simple
+   plugs: [network-bind]
+   sockets:
+	 sock1:
+	   listen-stream: $SNAP_DATA/sock1.socket
+	   socket-mode: 0666
+	 sock2:
+	   listen-stream: $SNAP_COMMON/sock2.socket
+ `, &snap.SideInfo{Revision: snap.R(12)})
 
 	err := wrappers.AddSnapServices(info, nil, progress.Null)
 	c.Assert(err, IsNil)
@@ -1824,13 +1850,13 @@ func (s *servicesTestSuite) TestRemoveSnapPackageFallbackToKill(c *C) {
 	defer r()
 
 	info := snaptest.MockSnap(c, `name: wat
-version: 42
-apps:
- wat:
-   command: wat
-   stop-timeout: 20ms
-   daemon: forking
-`, &snap.SideInfo{Revision: snap.R(11)})
+ version: 42
+ apps:
+  wat:
+	command: wat
+	stop-timeout: 20ms
+	daemon: forking
+ `, &snap.SideInfo{Revision: snap.R(11)})
 
 	err := wrappers.AddSnapServices(info, nil, progress.Null)
 	c.Assert(err, IsNil)
@@ -1866,14 +1892,14 @@ func (s *servicesTestSuite) TestRemoveSnapPackageUserDaemonStopFailure(c *C) {
 	defer r()
 
 	info := snaptest.MockSnap(c, `name: wat
-version: 42
-apps:
- wat:
-   command: wat
-   stop-timeout: 20ms
-   daemon: forking
-   daemon-scope: user
-`, &snap.SideInfo{Revision: snap.R(11)})
+ version: 42
+ apps:
+  wat:
+	command: wat
+	stop-timeout: 20ms
+	daemon: forking
+	daemon-scope: user
+ `, &snap.SideInfo{Revision: snap.R(11)})
 
 	err := wrappers.AddSnapServices(info, nil, progress.Null)
 	c.Assert(err, IsNil)
@@ -1891,48 +1917,48 @@ apps:
 
 func (s *servicesTestSuite) TestServicesEnableState(c *C) {
 	info := snaptest.MockSnap(c, packageHello+`
- svc2:
-  command: bin/hello
-  daemon: forking
- svc3:
-  command: bin/hello
-  daemon: simple
-  daemon-scope: user
-`, &snap.SideInfo{Revision: snap.R(12)})
+  svc2:
+   command: bin/hello
+   daemon: forking
+  svc3:
+   command: bin/hello
+   daemon: simple
+   daemon-scope: user
+ `, &snap.SideInfo{Revision: snap.R(12)})
 	svc1File := "snap.hello-snap.svc1.service"
 	svc2File := "snap.hello-snap.svc2.service"
 
 	s.systemctlRestorer()
 	r := testutil.MockCommand(c, "systemctl", `#!/bin/sh
-	if [ "$1" = "--root" ]; then
-		# shifting by 2 also drops the temp dir arg to --root
-	    shift 2
-	fi
-
-	case "$1" in
-		is-enabled)
-			case "$2" in 
-			"snap.hello-snap.svc1.service")
-				echo "disabled"
-				exit 1
-				;;
-			"snap.hello-snap.svc2.service")
-				echo "enabled"
-				exit 0
-				;;
-			*)
-				echo "unexpected is-enabled of service $2"
-				exit 2
-				;;
-			esac
-	        ;;
-	    *)
-	        echo "unexpected op $*"
-	        exit 2
-	esac
-
-	exit 1
-	`)
+	 if [ "$1" = "--root" ]; then
+		 # shifting by 2 also drops the temp dir arg to --root
+		 shift 2
+	 fi
+ 
+	 case "$1" in
+		 is-enabled)
+			 case "$2" in 
+			 "snap.hello-snap.svc1.service")
+				 echo "disabled"
+				 exit 1
+				 ;;
+			 "snap.hello-snap.svc2.service")
+				 echo "enabled"
+				 exit 0
+				 ;;
+			 *)
+				 echo "unexpected is-enabled of service $2"
+				 exit 2
+				 ;;
+			 esac
+			 ;;
+		 *)
+			 echo "unexpected op $*"
+			 exit 2
+	 esac
+ 
+	 exit 1
+	 `)
 	defer r.Restore()
 
 	states, err := wrappers.ServicesEnableState(info, progress.Null)
@@ -1963,31 +1989,31 @@ func (s *servicesTestSuite) TestServicesEnableStateFail(c *C) {
 
 	s.systemctlRestorer()
 	r := testutil.MockCommand(c, "systemctl", `#!/bin/sh
-	if [ "$1" = "--root" ]; then
-		# shifting by 2 also drops the temp dir arg to --root
-	    shift 2
-	fi
-
-	case "$1" in
-		is-enabled)
-			case "$2" in
-			"snap.hello-snap.svc1.service")
-				echo "whoops"
-				exit 1
-				;;
-			*)
-				echo "unexpected is-enabled of service $2"
-				exit 2
-				;;
-			esac
-	        ;;
-	    *)
-	        echo "unexpected op $*"
-	        exit 2
-	esac
-
-	exit 1
-	`)
+	 if [ "$1" = "--root" ]; then
+		 # shifting by 2 also drops the temp dir arg to --root
+		 shift 2
+	 fi
+ 
+	 case "$1" in
+		 is-enabled)
+			 case "$2" in
+			 "snap.hello-snap.svc1.service")
+				 echo "whoops"
+				 exit 1
+				 ;;
+			 *)
+				 echo "unexpected is-enabled of service $2"
+				 exit 2
+				 ;;
+			 esac
+			 ;;
+		 *)
+			 echo "unexpected op $*"
+			 exit 2
+	 esac
+ 
+	 exit 1
+	 `)
 	defer r.Restore()
 
 	_, err := wrappers.ServicesEnableState(info, progress.Null)
@@ -2000,53 +2026,53 @@ func (s *servicesTestSuite) TestServicesEnableStateFail(c *C) {
 
 func (s *servicesTestSuite) TestAddSnapServicesWithDisabledServices(c *C) {
 	info := snaptest.MockSnap(c, packageHello+`
- svc2:
-  command: bin/hello
-  daemon: forking
-`, &snap.SideInfo{Revision: snap.R(12)})
+  svc2:
+   command: bin/hello
+   daemon: forking
+ `, &snap.SideInfo{Revision: snap.R(12)})
 
 	s.systemctlRestorer()
 	r := testutil.MockCommand(c, "systemctl", `#!/bin/sh
-	if [ "$1" = "--root" ]; then
-	    shift 2
-	fi
-
-	case "$1" in
-		enable)
-			case "$2" in 
-				"snap.hello-snap.svc1.service")
-					echo "unexpected enable of disabled service $2"
-					exit 1
-					;;
-				"snap.hello-snap.svc2.service")
-					exit 0
-					;;
-				*)
-					echo "unexpected enable of service $2"
-					exit 1
-					;;
-			esac
-			;;
-		start)
-			case "$2" in
-				"snap.hello-snap.svc2.service")
-					exit 0
-					;;
-			*)
-					echo "unexpected start of service $2"
-					exit 1
-					;;
-			esac
-			;;
-		daemon-reload)
-			exit 0
-			;;
-	    *)
-	        echo "unexpected op $*"
-	        exit 2
-	esac
-	exit 2
-	`)
+	 if [ "$1" = "--root" ]; then
+		 shift 2
+	 fi
+ 
+	 case "$1" in
+		 enable)
+			 case "$2" in 
+				 "snap.hello-snap.svc1.service")
+					 echo "unexpected enable of disabled service $2"
+					 exit 1
+					 ;;
+				 "snap.hello-snap.svc2.service")
+					 exit 0
+					 ;;
+				 *)
+					 echo "unexpected enable of service $2"
+					 exit 1
+					 ;;
+			 esac
+			 ;;
+		 start)
+			 case "$2" in
+				 "snap.hello-snap.svc2.service")
+					 exit 0
+					 ;;
+			 *)
+					 echo "unexpected start of service $2"
+					 exit 1
+					 ;;
+			 esac
+			 ;;
+		 daemon-reload)
+			 exit 0
+			 ;;
+		 *)
+			 echo "unexpected op $*"
+			 exit 2
+	 esac
+	 exit 2
+	 `)
 	defer r.Restore()
 
 	// svc1 will be disabled
@@ -2105,26 +2131,26 @@ func (s *servicesTestSuite) TestStopServicesWithSockets(c *C) {
 	defer r()
 
 	info := snaptest.MockSnap(c, packageHelloNoSrv+`
- svc1:
-  daemon: simple
-  plugs: [network-bind]
-  sockets:
-    sock1:
-      listen-stream: $SNAP_COMMON/sock1.socket
-      socket-mode: 0666
-    sock2:
-      listen-stream: $SNAP_DATA/sock2.socket
- svc2:
-  daemon: simple
-  daemon-scope: user
-  plugs: [network-bind]
-  sockets:
-    sock1:
-      listen-stream: $SNAP_USER_COMMON/sock1.socket
-      socket-mode: 0666
-    sock2:
-      listen-stream: $SNAP_USER_DATA/sock2.socket
-`, &snap.SideInfo{Revision: snap.R(12)})
+  svc1:
+   daemon: simple
+   plugs: [network-bind]
+   sockets:
+	 sock1:
+	   listen-stream: $SNAP_COMMON/sock1.socket
+	   socket-mode: 0666
+	 sock2:
+	   listen-stream: $SNAP_DATA/sock2.socket
+  svc2:
+   daemon: simple
+   daemon-scope: user
+   plugs: [network-bind]
+   sockets:
+	 sock1:
+	   listen-stream: $SNAP_USER_COMMON/sock1.socket
+	   socket-mode: 0666
+	 sock2:
+	   listen-stream: $SNAP_USER_DATA/sock2.socket
+ `, &snap.SideInfo{Revision: snap.R(12)})
 
 	err := wrappers.AddSnapServices(info, nil, progress.Null)
 	c.Assert(err, IsNil)
@@ -2163,10 +2189,10 @@ func (s *servicesTestSuite) TestStartServices(c *C) {
 
 func (s *servicesTestSuite) TestStartServicesUserDaemons(c *C) {
 	info := snaptest.MockSnap(c, packageHelloNoSrv+`
- svc1:
-  daemon: simple
-  daemon-scope: user
-`, &snap.SideInfo{Revision: snap.R(12)})
+  svc1:
+   daemon: simple
+   daemon-scope: user
+ `, &snap.SideInfo{Revision: snap.R(12)})
 	svcFile := filepath.Join(s.tempdir, "/etc/systemd/user/snap.hello-snap.svc1.service")
 
 	flags := &wrappers.StartServicesFlags{Enable: true}
@@ -2192,37 +2218,37 @@ func (s *servicesTestSuite) TestNoStartDisabledServices(c *C) {
 	svc2Name := "snap.hello-snap.svc2.service"
 
 	info := snaptest.MockSnap(c, packageHello+`
- svc2:
-  command: bin/hello
-  daemon: simple
-`, &snap.SideInfo{Revision: snap.R(12)})
+  svc2:
+   command: bin/hello
+   daemon: simple
+ `, &snap.SideInfo{Revision: snap.R(12)})
 
 	s.systemctlRestorer()
 	r := testutil.MockCommand(c, "systemctl", `#!/bin/sh
-	if [ "$1" = "--root" ]; then
-	    shift 2
-	fi
-
-	case "$1" in
-		start)
-			if [ "$2" = "snap.hello-snap.svc2.service" ]; then
-				exit 0
-			fi
-			echo "unexpected start of service $2"
-			exit 1
-			;;
-		enable)
-			if [ "$2" = "snap.hello-snap.svc2.service" ]; then
-				exit 0
-			fi
-			echo "unexpected enable of service $2"
-			exit 1
-			;;
-	    *)
-	        echo "unexpected call $*"
-	        exit 2
-	esac
-	`)
+	 if [ "$1" = "--root" ]; then
+		 shift 2
+	 fi
+ 
+	 case "$1" in
+		 start)
+			 if [ "$2" = "snap.hello-snap.svc2.service" ]; then
+				 exit 0
+			 fi
+			 echo "unexpected start of service $2"
+			 exit 1
+			 ;;
+		 enable)
+			 if [ "$2" = "snap.hello-snap.svc2.service" ]; then
+				 exit 0
+			 fi
+			 echo "unexpected enable of service $2"
+			 exit 1
+			 ;;
+		 *)
+			 echo "unexpected call $*"
+			 exit 2
+	 esac
+	 `)
 	defer r.Restore()
 
 	flags := &wrappers.StartServicesFlags{Enable: true}
@@ -2240,9 +2266,9 @@ func (s *servicesTestSuite) TestAddSnapMultiServicesFailCreateCleanup(c *C) {
 	c.Check(svcFiles, HasLen, 0)
 
 	info := snaptest.MockSnap(c, packageHello+`
- svc2:
-  daemon: potato
-`, &snap.SideInfo{Revision: snap.R(12)})
+  svc2:
+   daemon: potato
+ `, &snap.SideInfo{Revision: snap.R(12)})
 
 	err := wrappers.AddSnapServices(info, nil, progress.Null)
 	c.Assert(err, ErrorMatches, ".*potato.*")
@@ -2296,10 +2322,10 @@ func (s *servicesTestSuite) TestMultiServicesFailEnableCleanup(c *C) {
 	defer r()
 
 	info := snaptest.MockSnap(c, packageHello+`
- svc2:
-  command: bin/hello
-  daemon: simple
-`, &snap.SideInfo{Revision: snap.R(12)})
+  svc2:
+   command: bin/hello
+   daemon: simple
+ `, &snap.SideInfo{Revision: snap.R(12)})
 
 	err := wrappers.AddSnapServices(info, nil, progress.Null)
 	c.Assert(err, IsNil)
@@ -2338,10 +2364,10 @@ func (s *servicesTestSuite) TestAddSnapMultiServicesStartFailOnSystemdReloadClea
 	defer r()
 
 	info := snaptest.MockSnap(c, packageHello+`
- svc2:
-  command: bin/hello
-  daemon: simple
-`, &snap.SideInfo{Revision: snap.R(12)})
+  svc2:
+   command: bin/hello
+   daemon: simple
+ `, &snap.SideInfo{Revision: snap.R(12)})
 
 	err := wrappers.AddSnapServices(info, nil, progress.Null)
 	c.Assert(err, ErrorMatches, "failed")
@@ -2384,15 +2410,15 @@ func (s *servicesTestSuite) TestAddSnapMultiUserServicesFailEnableCleanup(c *C) 
 	defer r()
 
 	info := snaptest.MockSnap(c, packageHelloNoSrv+`
- svc1:
-  command: bin/hello
-  daemon: simple
-  daemon-scope: user
- svc2:
-  command: bin/hello
-  daemon: simple
-  daemon-scope: user
-`, &snap.SideInfo{Revision: snap.R(12)})
+  svc1:
+   command: bin/hello
+   daemon: simple
+   daemon-scope: user
+  svc2:
+   command: bin/hello
+   daemon: simple
+   daemon-scope: user
+ `, &snap.SideInfo{Revision: snap.R(12)})
 
 	err := wrappers.AddSnapServices(info, nil, progress.Null)
 	c.Assert(err, ErrorMatches, "cannot reload daemon: failed")
@@ -2435,15 +2461,15 @@ func (s *servicesTestSuite) TestAddSnapMultiUserServicesStartFailOnSystemdReload
 	defer r()
 
 	info := snaptest.MockSnap(c, packageHelloNoSrv+`
- svc1:
-  command: bin/hello
-  daemon: simple
-  daemon-scope: user
- svc2:
-  command: bin/hello
-  daemon: simple
-  daemon-scope: user
-`, &snap.SideInfo{Revision: snap.R(12)})
+  svc1:
+   command: bin/hello
+   daemon: simple
+   daemon-scope: user
+  svc2:
+   command: bin/hello
+   daemon: simple
+   daemon-scope: user
+ `, &snap.SideInfo{Revision: snap.R(12)})
 
 	err := wrappers.AddSnapServices(info, nil, progress.Null)
 	c.Assert(err, ErrorMatches, "cannot reload daemon: failed")
@@ -2459,19 +2485,19 @@ func (s *servicesTestSuite) TestAddSnapMultiUserServicesStartFailOnSystemdReload
 
 func (s *servicesTestSuite) TestAddSnapSocketFiles(c *C) {
 	info := snaptest.MockSnap(c, packageHelloNoSrv+`
- svc1:
-  daemon: simple
-  plugs: [network-bind]
-  sockets:
-    sock1:
-      listen-stream: $SNAP_COMMON/sock1.socket
-      socket-mode: 0666
-    sock2:
-      listen-stream: $SNAP_DATA/sock2.socket
-    sock3:
-      listen-stream: $XDG_RUNTIME_DIR/sock3.socket
-
-`, &snap.SideInfo{Revision: snap.R(12)})
+  svc1:
+   daemon: simple
+   plugs: [network-bind]
+   sockets:
+	 sock1:
+	   listen-stream: $SNAP_COMMON/sock1.socket
+	   socket-mode: 0666
+	 sock2:
+	   listen-stream: $SNAP_DATA/sock2.socket
+	 sock3:
+	   listen-stream: $XDG_RUNTIME_DIR/sock3.socket
+ 
+ `, &snap.SideInfo{Revision: snap.R(12)})
 
 	sock1File := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-snap.svc1.sock1.socket")
 	sock2File := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-snap.svc1.sock2.socket")
@@ -2482,48 +2508,48 @@ func (s *servicesTestSuite) TestAddSnapSocketFiles(c *C) {
 
 	expected := fmt.Sprintf(
 		`[Socket]
-Service=snap.hello-snap.svc1.service
-FileDescriptorName=sock1
-ListenStream=%s
-SocketMode=0666
-
-`, filepath.Join(s.tempdir, "/var/snap/hello-snap/common/sock1.socket"))
+ Service=snap.hello-snap.svc1.service
+ FileDescriptorName=sock1
+ ListenStream=%s
+ SocketMode=0666
+ 
+ `, filepath.Join(s.tempdir, "/var/snap/hello-snap/common/sock1.socket"))
 	c.Check(sock1File, testutil.FileContains, expected)
 
 	expected = fmt.Sprintf(
 		`[Socket]
-Service=snap.hello-snap.svc1.service
-FileDescriptorName=sock2
-ListenStream=%s
-
-`, filepath.Join(s.tempdir, "/var/snap/hello-snap/12/sock2.socket"))
+ Service=snap.hello-snap.svc1.service
+ FileDescriptorName=sock2
+ ListenStream=%s
+ 
+ `, filepath.Join(s.tempdir, "/var/snap/hello-snap/12/sock2.socket"))
 	c.Check(sock2File, testutil.FileContains, expected)
 
 	expected = fmt.Sprintf(
 		`[Socket]
-Service=snap.hello-snap.svc1.service
-FileDescriptorName=sock3
-ListenStream=%s
-
-`, filepath.Join(s.tempdir, "/run/user/0/snap.hello-snap/sock3.socket"))
+ Service=snap.hello-snap.svc1.service
+ FileDescriptorName=sock3
+ ListenStream=%s
+ 
+ `, filepath.Join(s.tempdir, "/run/user/0/snap.hello-snap/sock3.socket"))
 	c.Check(sock3File, testutil.FileContains, expected)
 }
 
 func (s *servicesTestSuite) TestAddSnapUserSocketFiles(c *C) {
 	info := snaptest.MockSnap(c, packageHelloNoSrv+`
- svc1:
-  daemon: simple
-  daemon-scope: user
-  plugs: [network-bind]
-  sockets:
-    sock1:
-      listen-stream: $SNAP_USER_COMMON/sock1.socket
-      socket-mode: 0666
-    sock2:
-      listen-stream: $SNAP_USER_DATA/sock2.socket
-    sock3:
-      listen-stream: $XDG_RUNTIME_DIR/sock3.socket
-`, &snap.SideInfo{Revision: snap.R(12)})
+  svc1:
+   daemon: simple
+   daemon-scope: user
+   plugs: [network-bind]
+   sockets:
+	 sock1:
+	   listen-stream: $SNAP_USER_COMMON/sock1.socket
+	   socket-mode: 0666
+	 sock2:
+	   listen-stream: $SNAP_USER_DATA/sock2.socket
+	 sock3:
+	   listen-stream: $XDG_RUNTIME_DIR/sock3.socket
+ `, &snap.SideInfo{Revision: snap.R(12)})
 
 	sock1File := filepath.Join(s.tempdir, "/etc/systemd/user/snap.hello-snap.svc1.sock1.socket")
 	sock2File := filepath.Join(s.tempdir, "/etc/systemd/user/snap.hello-snap.svc1.sock2.socket")
@@ -2533,28 +2559,28 @@ func (s *servicesTestSuite) TestAddSnapUserSocketFiles(c *C) {
 	c.Assert(err, IsNil)
 
 	expected := `[Socket]
-Service=snap.hello-snap.svc1.service
-FileDescriptorName=sock1
-ListenStream=%h/snap/hello-snap/common/sock1.socket
-SocketMode=0666
-
-`
+ Service=snap.hello-snap.svc1.service
+ FileDescriptorName=sock1
+ ListenStream=%h/snap/hello-snap/common/sock1.socket
+ SocketMode=0666
+ 
+ `
 	c.Check(sock1File, testutil.FileContains, expected)
 
 	expected = `[Socket]
-Service=snap.hello-snap.svc1.service
-FileDescriptorName=sock2
-ListenStream=%h/snap/hello-snap/12/sock2.socket
-
-`
+ Service=snap.hello-snap.svc1.service
+ FileDescriptorName=sock2
+ ListenStream=%h/snap/hello-snap/12/sock2.socket
+ 
+ `
 	c.Check(sock2File, testutil.FileContains, expected)
 
 	expected = `[Socket]
-Service=snap.hello-snap.svc1.service
-FileDescriptorName=sock3
-ListenStream=%t/snap.hello-snap/sock3.socket
-
-`
+ Service=snap.hello-snap.svc1.service
+ FileDescriptorName=sock3
+ ListenStream=%t/snap.hello-snap/sock3.socket
+ 
+ `
 	c.Check(sock3File, testutil.FileContains, expected)
 }
 
@@ -2576,10 +2602,10 @@ func (s *servicesTestSuite) TestStartSnapMultiServicesFailStartCleanup(c *C) {
 	defer r()
 
 	info := snaptest.MockSnap(c, packageHello+`
- svc2:
-  command: bin/hello
-  daemon: simple
-`, &snap.SideInfo{Revision: snap.R(12)})
+  svc2:
+   command: bin/hello
+   daemon: simple
+ `, &snap.SideInfo{Revision: snap.R(12)})
 
 	svcs := info.Services()
 	c.Assert(svcs, HasLen, 2)
@@ -2623,21 +2649,21 @@ func (s *servicesTestSuite) TestStartSnapMultiServicesFailStartCleanupWithSocket
 	defer r()
 
 	info := snaptest.MockSnap(c, packageHello+`
- svc2:
-  command: bin/hello
-  daemon: simple
-  sockets:
-    sock1:
-      listen-stream: $SNAP_COMMON/sock1.socket
-      socket-mode: 0666
- svc3:
-  command: bin/hello
-  daemon: simple
-  sockets:
-    sock1:
-      listen-stream: $SNAP_COMMON/sock1.socket
-      socket-mode: 0666
-`, &snap.SideInfo{Revision: snap.R(12)})
+  svc2:
+   command: bin/hello
+   daemon: simple
+   sockets:
+	 sock1:
+	   listen-stream: $SNAP_COMMON/sock1.socket
+	   socket-mode: 0666
+  svc3:
+   command: bin/hello
+   daemon: simple
+   sockets:
+	 sock1:
+	   listen-stream: $SNAP_COMMON/sock1.socket
+	   socket-mode: 0666
+ `, &snap.SideInfo{Revision: snap.R(12)})
 
 	// ensure desired order
 	apps := []*snap.AppInfo{info.Apps["svc1"], info.Apps["svc2"], info.Apps["svc3"]}
@@ -2751,15 +2777,15 @@ func (s *servicesTestSuite) TestStartSnapMultiUserServicesFailStartCleanup(c *C)
 	defer r()
 
 	info := snaptest.MockSnap(c, packageHelloNoSrv+`
- svc1:
-  command: bin/hello
-  daemon: simple
-  daemon-scope: user
- svc2:
-  command: bin/hello
-  daemon: simple
-  daemon-scope: user
-`, &snap.SideInfo{Revision: snap.R(12)})
+  svc1:
+   command: bin/hello
+   daemon: simple
+   daemon-scope: user
+  svc2:
+   command: bin/hello
+   daemon: simple
+   daemon-scope: user
+ `, &snap.SideInfo{Revision: snap.R(12)})
 
 	svcs := info.Services()
 	c.Assert(svcs, HasLen, 2)
@@ -2799,17 +2825,17 @@ func (s *servicesTestSuite) TestStartSnapServicesKeepsOrder(c *C) {
 	defer r()
 
 	info := snaptest.MockSnap(c, `name: services-snap
-apps:
-  svc1:
-    daemon: simple
-    before: [svc3]
-  svc2:
-    daemon: simple
-    after: [svc1]
-  svc3:
-    daemon: simple
-    before: [svc2]
-`, &snap.SideInfo{Revision: snap.R(12)})
+ apps:
+   svc1:
+	 daemon: simple
+	 before: [svc3]
+   svc2:
+	 daemon: simple
+	 after: [svc1]
+   svc3:
+	 daemon: simple
+	 before: [svc2]
+ `, &snap.SideInfo{Revision: snap.R(12)})
 
 	svcs := info.Services()
 	c.Assert(svcs, HasLen, 3)
@@ -2845,20 +2871,20 @@ apps:
 
 func (s *servicesTestSuite) TestServiceAfterBefore(c *C) {
 	snapYaml := packageHello + `
- svc2:
-   daemon: forking
-   after: [svc1]
- svc3:
-   daemon: forking
-   before: [svc4]
-   after:  [svc2]
- svc4:
-   daemon: forking
-   after:
-     - svc1
-     - svc2
-     - svc3
-`
+  svc2:
+	daemon: forking
+	after: [svc1]
+  svc3:
+	daemon: forking
+	before: [svc4]
+	after:  [svc2]
+  svc4:
+	daemon: forking
+	after:
+	  - svc1
+	  - svc2
+	  - svc3
+ `
 	info := snaptest.MockSnap(c, snapYaml, &snap.SideInfo{Revision: snap.R(12)})
 
 	checks := []struct {
@@ -2912,15 +2938,15 @@ func (s *servicesTestSuite) TestServiceAfterBefore(c *C) {
 
 func (s *servicesTestSuite) TestServiceWatchdog(c *C) {
 	snapYaml := packageHello + `
- svc2:
-   daemon: forking
-   watchdog-timeout: 12s
- svc3:
-   daemon: forking
-   watchdog-timeout: 0s
- svc4:
-   daemon: forking
-`
+  svc2:
+	daemon: forking
+	watchdog-timeout: 12s
+  svc3:
+	daemon: forking
+	watchdog-timeout: 0s
+  svc4:
+	daemon: forking
+ `
 	info := snaptest.MockSnap(c, snapYaml, &snap.SideInfo{Revision: snap.R(12)})
 
 	err := wrappers.AddSnapServices(info, nil, progress.Null)
@@ -2943,13 +2969,13 @@ func (s *servicesTestSuite) TestServiceWatchdog(c *C) {
 
 func (s *servicesTestSuite) TestStopServiceEndure(c *C) {
 	const surviveYaml = `name: survive-snap
-version: 1.0
-apps:
- survivor:
-  command: bin/survivor
-  refresh-mode: endure
-  daemon: simple
-`
+ version: 1.0
+ apps:
+  survivor:
+   command: bin/survivor
+   refresh-mode: endure
+   daemon: simple
+ `
 	info := snaptest.MockSnap(c, surviveYaml, &snap.SideInfo{Revision: snap.R(1)})
 	survivorFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.survive-snap.survivor.service")
 
@@ -3005,13 +3031,13 @@ func (s *servicesTestSuite) TestStopServiceSigs(c *C) {
 		{mode: "sigusr2-all", expectedSig: "USR2", expectedWho: "all"},
 	} {
 		surviveYaml := fmt.Sprintf(`name: survive-snap
-version: 1.0
-apps:
- srv:
-  command: bin/survivor
-  stop-mode: %s
-  daemon: simple
-`, t.mode)
+ version: 1.0
+ apps:
+  srv:
+   command: bin/survivor
+   stop-mode: %s
+   daemon: simple
+ `, t.mode)
 		info := snaptest.MockSnap(c, surviveYaml, &snap.SideInfo{Revision: snap.R(1)})
 
 		s.sysdLog = nil
@@ -3073,20 +3099,20 @@ func (s *servicesTestSuite) TestStartSnapSocketEnableStart(c *C) {
 	svc3Sock := "snap.hello-snap.svc3.sock.socket"
 
 	info := snaptest.MockSnap(c, packageHello+`
- svc2:
-  command: bin/hello
-  daemon: simple
-  sockets:
-    sock:
-      listen-stream: $SNAP_COMMON/sock1.socket
- svc3:
-  command: bin/hello
-  daemon: simple
-  daemon-scope: user
-  sockets:
-    sock:
-      listen-stream: $SNAP_USER_COMMON/sock1.socket
-`, &snap.SideInfo{Revision: snap.R(12)})
+  svc2:
+   command: bin/hello
+   daemon: simple
+   sockets:
+	 sock:
+	   listen-stream: $SNAP_COMMON/sock1.socket
+  svc3:
+   command: bin/hello
+   daemon: simple
+   daemon-scope: user
+   sockets:
+	 sock:
+	   listen-stream: $SNAP_USER_COMMON/sock1.socket
+ `, &snap.SideInfo{Revision: snap.R(12)})
 
 	// fix the apps order to make the test stable
 	apps := []*snap.AppInfo{info.Apps["svc1"], info.Apps["svc2"], info.Apps["svc3"]}
@@ -3110,16 +3136,16 @@ func (s *servicesTestSuite) TestStartSnapTimerEnableStart(c *C) {
 	svc3Timer := "snap.hello-snap.svc3.timer"
 
 	info := snaptest.MockSnap(c, packageHello+`
- svc2:
-  command: bin/hello
-  daemon: simple
-  timer: 10:00-12:00
- svc3:
-  command: bin/hello
-  daemon: simple
-  daemon-scope: user
-  timer: 10:00-12:00
-`, &snap.SideInfo{Revision: snap.R(12)})
+  svc2:
+   command: bin/hello
+   daemon: simple
+   timer: 10:00-12:00
+  svc3:
+   command: bin/hello
+   daemon: simple
+   daemon-scope: user
+   timer: 10:00-12:00
+ `, &snap.SideInfo{Revision: snap.R(12)})
 
 	// fix the apps order to make the test stable
 	apps := []*snap.AppInfo{info.Apps["svc1"], info.Apps["svc2"], info.Apps["svc3"]}
@@ -3152,11 +3178,11 @@ func (s *servicesTestSuite) TestStartSnapTimerCleanup(c *C) {
 	defer r()
 
 	info := snaptest.MockSnap(c, packageHello+`
- svc2:
-  command: bin/hello
-  daemon: simple
-  timer: 10:00-12:00
-`, &snap.SideInfo{Revision: snap.R(12)})
+  svc2:
+   command: bin/hello
+   daemon: simple
+   timer: 10:00-12:00
+ `, &snap.SideInfo{Revision: snap.R(12)})
 
 	// fix the apps order to make the test stable
 	apps := []*snap.AppInfo{info.Apps["svc1"], info.Apps["svc2"]}
@@ -3179,11 +3205,11 @@ func (s *servicesTestSuite) TestStartSnapTimerCleanup(c *C) {
 
 func (s *servicesTestSuite) TestAddRemoveSnapWithTimersAddsRemovesTimerFiles(c *C) {
 	info := snaptest.MockSnap(c, packageHello+`
- svc2:
-  command: bin/hello
-  daemon: simple
-  timer: 10:00-12:00
-`, &snap.SideInfo{Revision: snap.R(12)})
+  svc2:
+   command: bin/hello
+   daemon: simple
+   timer: 10:00-12:00
+ `, &snap.SideInfo{Revision: snap.R(12)})
 
 	err := wrappers.AddSnapServices(info, nil, progress.Null)
 	c.Assert(err, IsNil)
@@ -3206,19 +3232,19 @@ func (s *servicesTestSuite) TestAddRemoveSnapWithTimersAddsRemovesTimerFiles(c *
 
 func (s *servicesTestSuite) TestFailedAddSnapCleansUp(c *C) {
 	info := snaptest.MockSnap(c, packageHello+`
- svc2:
-  command: bin/hello
-  daemon: simple
-  timer: 10:00-12:00
- svc3:
-  command: bin/hello
-  daemon: simple
-  plugs: [network-bind]
-  sockets:
-    sock1:
-      listen-stream: $SNAP_COMMON/sock1.socket
-      socket-mode: 0666
-`, &snap.SideInfo{Revision: snap.R(12)})
+  svc2:
+   command: bin/hello
+   daemon: simple
+   timer: 10:00-12:00
+  svc3:
+   command: bin/hello
+   daemon: simple
+   plugs: [network-bind]
+   sockets:
+	 sock1:
+	   listen-stream: $SNAP_COMMON/sock1.socket
+	   socket-mode: 0666
+ `, &snap.SideInfo{Revision: snap.R(12)})
 
 	calls := 0
 	r := systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
@@ -3243,34 +3269,34 @@ func (s *servicesTestSuite) TestFailedAddSnapCleansUp(c *C) {
 
 func (s *servicesTestSuite) TestAddServicesDidReload(c *C) {
 	const base = `name: hello-snap
-version: 1.10
-summary: hello
-description: Hello...
-apps:
-`
+ version: 1.10
+ summary: hello
+ description: Hello...
+ apps:
+ `
 	onlyServices := snaptest.MockSnap(c, base+`
- svc1:
-  command: bin/hello
-  daemon: simple
-`, &snap.SideInfo{Revision: snap.R(12)})
+  svc1:
+   command: bin/hello
+   daemon: simple
+ `, &snap.SideInfo{Revision: snap.R(12)})
 
 	onlySockets := snaptest.MockSnap(c, base+`
- svc1:
-  command: bin/hello
-  daemon: simple
-  plugs: [network-bind]
-  sockets:
-    sock1:
-      listen-stream: $SNAP_COMMON/sock1.socket
-      socket-mode: 0666
-`, &snap.SideInfo{Revision: snap.R(12)})
+  svc1:
+   command: bin/hello
+   daemon: simple
+   plugs: [network-bind]
+   sockets:
+	 sock1:
+	   listen-stream: $SNAP_COMMON/sock1.socket
+	   socket-mode: 0666
+ `, &snap.SideInfo{Revision: snap.R(12)})
 
 	onlyTimers := snaptest.MockSnap(c, base+`
- svc1:
-  command: bin/hello
-  daemon: oneshot
-  timer: 10:00-12:00
-`, &snap.SideInfo{Revision: snap.R(12)})
+  svc1:
+   command: bin/hello
+   daemon: oneshot
+   timer: 10:00-12:00
+ `, &snap.SideInfo{Revision: snap.R(12)})
 
 	for i, info := range []*snap.Info{onlyServices, onlySockets, onlyTimers} {
 		s.sysdLog = nil
@@ -3289,26 +3315,26 @@ apps:
 
 func (s *servicesTestSuite) TestSnapServicesActivation(c *C) {
 	const snapYaml = `name: hello-snap
-version: 1.10
-summary: hello
-description: Hello...
-apps:
- svc1:
-  command: bin/hello
-  daemon: simple
-  plugs: [network-bind]
-  sockets:
-    sock1:
-      listen-stream: $SNAP_COMMON/sock1.socket
-      socket-mode: 0666
- svc2:
-  command: bin/hello
-  daemon: oneshot
-  timer: 10:00-12:00
- svc3:
-  command: bin/hello
-  daemon: simple
-`
+ version: 1.10
+ summary: hello
+ description: Hello...
+ apps:
+  svc1:
+   command: bin/hello
+   daemon: simple
+   plugs: [network-bind]
+   sockets:
+	 sock1:
+	   listen-stream: $SNAP_COMMON/sock1.socket
+	   socket-mode: 0666
+  svc2:
+   command: bin/hello
+   daemon: oneshot
+   timer: 10:00-12:00
+  svc3:
+   command: bin/hello
+   daemon: simple
+ `
 	svc1Socket := "snap.hello-snap.svc1.sock1.socket"
 	svc2Timer := "snap.hello-snap.svc2.timer"
 	svc3Name := "snap.hello-snap.svc3.service"
@@ -3339,12 +3365,12 @@ apps:
 
 func (s *servicesTestSuite) TestServiceRestartDelay(c *C) {
 	snapYaml := packageHello + `
- svc2:
-   daemon: forking
-   restart-delay: 12s
- svc3:
-   daemon: forking
-`
+  svc2:
+	daemon: forking
+	restart-delay: 12s
+  svc3:
+	daemon: forking
+ `
 	info := snaptest.MockSnap(c, snapYaml, &snap.SideInfo{Revision: snap.R(12)})
 
 	err := wrappers.AddSnapServices(info, nil, progress.Null)
@@ -3371,12 +3397,12 @@ func (s *servicesTestSuite) TestAddRemoveSnapServiceWithSnapd(c *C) {
 
 func (s *servicesTestSuite) TestReloadOrRestart(c *C) {
 	const surviveYaml = `name: test-snap
-version: 1.0
-apps:
-  foo:
-    command: bin/foo
-    daemon: simple
-`
+ version: 1.0
+ apps:
+   foo:
+	 command: bin/foo
+	 daemon: simple
+ `
 	info := snaptest.MockSnap(c, surviveYaml, &snap.SideInfo{Revision: snap.R(1)})
 	srvFile := "snap.test-snap.foo.service"
 
@@ -3423,21 +3449,21 @@ apps:
 
 func (s *servicesTestSuite) TestRestartInDifferentStates(c *C) {
 	const manyServicesYaml = `name: test-snap
-version: 1.0
-apps:
-  svc1:
-    command: bin/foo
-    daemon: simple
-  svc2:
-    command: bin/foo
-    daemon: simple
-  svc3:
-    command: bin/foo
-    daemon: simple
-  svc4:
-    command: bin/foo
-    daemon: simple
-`
+ version: 1.0
+ apps:
+   svc1:
+	 command: bin/foo
+	 daemon: simple
+   svc2:
+	 command: bin/foo
+	 daemon: simple
+   svc3:
+	 command: bin/foo
+	 daemon: simple
+   svc4:
+	 command: bin/foo
+	 daemon: simple
+ `
 	srvFile1 := "snap.test-snap.svc1.service"
 	srvFile2 := "snap.test-snap.svc2.service"
 	srvFile3 := "snap.test-snap.svc3.service"
@@ -3499,9 +3525,9 @@ apps:
 
 func (s *servicesTestSuite) TestStopAndDisableServices(c *C) {
 	info := snaptest.MockSnap(c, packageHelloNoSrv+`
- svc1:
-  daemon: simple
-`, &snap.SideInfo{Revision: snap.R(12)})
+  svc1:
+   daemon: simple
+ `, &snap.SideInfo{Revision: snap.R(12)})
 	svcFile := "snap.hello-snap.svc1.service"
 
 	err := wrappers.AddSnapServices(info, nil, progress.Null)

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -120,27 +120,27 @@ func (s *servicesTestSuite) TestAddSnapServicesAndRemove(c *C) {
 
 	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
 	c.Assert(svcFile, testutil.FileEquals, fmt.Sprintf(`[Unit]
- # Auto-generated, DO NOT EDIT
- Description=Service for snap application hello-snap.svc1
- Requires=%[1]s
- Wants=network.target
- After=%[1]s network.target snapd.apparmor.service
- X-Snappy=yes
- 
- [Service]
- EnvironmentFile=-/etc/environment
- ExecStart=/usr/bin/snap run hello-snap.svc1
- SyslogIdentifier=hello-snap.svc1
- Restart=on-failure
- WorkingDirectory=%[2]s/var/snap/hello-snap/12
- ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
- ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
- TimeoutStopSec=30
- Type=forking
- 
- [Install]
- WantedBy=multi-user.target
- `,
+# Auto-generated, DO NOT EDIT
+Description=Service for snap application hello-snap.svc1
+Requires=%[1]s
+Wants=network.target
+After=%[1]s network.target snapd.apparmor.service
+X-Snappy=yes
+
+[Service]
+EnvironmentFile=-/etc/environment
+ExecStart=/usr/bin/snap run hello-snap.svc1
+SyslogIdentifier=hello-snap.svc1
+Restart=on-failure
+WorkingDirectory=%[2]s/var/snap/hello-snap/12
+ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
+ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
+TimeoutStopSec=30
+Type=forking
+
+[Install]
+WantedBy=multi-user.target
+`,
 		systemd.EscapeUnitNamePath(dir),
 		dirs.GlobalRootDir,
 	))
@@ -188,27 +188,27 @@ func (s *servicesTestSuite) TestEnsureSnapServicesAdds(c *C) {
 
 	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
 	c.Assert(svcFile, testutil.FileEquals, fmt.Sprintf(`[Unit]
- # Auto-generated, DO NOT EDIT
- Description=Service for snap application hello-snap.svc1
- Requires=%[1]s
- Wants=network.target
- After=%[1]s network.target snapd.apparmor.service
- X-Snappy=yes
- 
- [Service]
- EnvironmentFile=-/etc/environment
- ExecStart=/usr/bin/snap run hello-snap.svc1
- SyslogIdentifier=hello-snap.svc1
- Restart=on-failure
- WorkingDirectory=%[2]s/var/snap/hello-snap/12
- ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
- ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
- TimeoutStopSec=30
- Type=forking
- 
- [Install]
- WantedBy=multi-user.target
- `,
+# Auto-generated, DO NOT EDIT
+Description=Service for snap application hello-snap.svc1
+Requires=%[1]s
+Wants=network.target
+After=%[1]s network.target snapd.apparmor.service
+X-Snappy=yes
+
+[Service]
+EnvironmentFile=-/etc/environment
+ExecStart=/usr/bin/snap run hello-snap.svc1
+SyslogIdentifier=hello-snap.svc1
+Restart=on-failure
+WorkingDirectory=%[2]s/var/snap/hello-snap/12
+ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
+ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
+TimeoutStopSec=30
+Type=forking
+
+[Install]
+WantedBy=multi-user.target
+`,
 		systemd.EscapeUnitNamePath(dir),
 		dirs.GlobalRootDir,
 	))
@@ -229,54 +229,54 @@ func (s *servicesTestSuite) TestEnsureSnapServicesWithQuotas(c *C) {
 
 	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
 	svcContent := fmt.Sprintf(`[Unit]
- # Auto-generated, DO NOT EDIT
- Description=Service for snap application hello-snap.svc1
- Requires=%[1]s
- Wants=network.target
- After=%[1]s network.target snapd.apparmor.service
- X-Snappy=yes
- 
- [Service]
- EnvironmentFile=-/etc/environment
- ExecStart=/usr/bin/snap run hello-snap.svc1
- SyslogIdentifier=hello-snap.svc1
- Restart=on-failure
- WorkingDirectory=%[2]s/var/snap/hello-snap/12
- ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
- ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
- TimeoutStopSec=30
- Type=forking
- Slice=snap.foogroup.slice
- 
- [Install]
- WantedBy=multi-user.target
- `,
+# Auto-generated, DO NOT EDIT
+Description=Service for snap application hello-snap.svc1
+Requires=%[1]s
+Wants=network.target
+After=%[1]s network.target snapd.apparmor.service
+X-Snappy=yes
+
+[Service]
+EnvironmentFile=-/etc/environment
+ExecStart=/usr/bin/snap run hello-snap.svc1
+SyslogIdentifier=hello-snap.svc1
+Restart=on-failure
+WorkingDirectory=%[2]s/var/snap/hello-snap/12
+ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
+ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
+TimeoutStopSec=30
+Type=forking
+Slice=snap.foogroup.slice
+
+[Install]
+WantedBy=multi-user.target
+`,
 		systemd.EscapeUnitNamePath(dir),
 		dirs.GlobalRootDir,
 	)
 
 	sliceTempl := `[Unit]
- Description=Slice for snap quota group %s
- Before=slices.target
- X-Snappy=yes
- 
- [Slice]
- # Always enable cpu accounting, so the following cpu quota options have an effect
- CPUAccounting=true
- CPUQuota=%[2]d
- AllowedCPUs=%[3]s
- 
- # Always enable memory accounting otherwise the MemoryMax setting does nothing.
- MemoryAccounting=true
- MemoryMax=%[4]d
- # for compatibility with older versions of systemd
- MemoryLimit=%[4]d
- 
- # Always enable task accounting in order to be able to count the processes/
- # threads, etc for a slice
- TasksAccounting=true
- TasksMax=%[5]d
- `
+Description=Slice for snap quota group %s
+Before=slices.target
+X-Snappy=yes
+
+[Slice]
+# Always enable cpu accounting, so the following cpu quota options have an effect
+CPUAccounting=true
+CPUQuota=%[2]d%%
+AllowedCPUs=%[3]s
+
+# Always enable memory accounting otherwise the MemoryMax setting does nothing.
+MemoryAccounting=true
+MemoryMax=%[4]d
+# for compatibility with older versions of systemd
+MemoryLimit=%[4]d
+
+# Always enable task accounting in order to be able to count the processes/
+# threads, etc for a slice
+TasksAccounting=true
+TasksMax=%[5]d
+`
 
 	allowedCpusValue := strings.Trim(strings.Join(strings.Fields(fmt.Sprint(resourceLimits.Cpu.AllowedCpus)), ","), "[]")
 	sliceContent := fmt.Sprintf(sliceTempl, grp.Name,
@@ -377,47 +377,47 @@ func (s *servicesTestSuite) TestEnsureSnapServicesRewritesQuotaSlices(c *C) {
 	// write both the unit file and a slice with a different memory limit
 	// setting than will be provided below
 	sliceTempl := `[Unit]
- Description=Slice for snap quota group %s
- Before=slices.target
- X-Snappy=yes
- 
- [Slice]
- # Always enable memory accounting otherwise the MemoryMax setting does nothing.
- MemoryAccounting=true
- MemoryMax=%[2]s
- # for compatibility with older versions of systemd
- MemoryLimit=%[2]s
- 
- # Always enable task accounting in order to be able to count the processes/
- # threads, etc for a slice
- TasksAccounting=true
- `
+Description=Slice for snap quota group %s
+Before=slices.target
+X-Snappy=yes
+
+[Slice]
+# Always enable memory accounting otherwise the MemoryMax setting does nothing.
+MemoryAccounting=true
+MemoryMax=%[2]s
+# for compatibility with older versions of systemd
+MemoryLimit=%[2]s
+
+# Always enable task accounting in order to be able to count the processes/
+# threads, etc for a slice
+TasksAccounting=true
+`
 	sliceFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.foogroup.slice")
 
 	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
 	svcContent := fmt.Sprintf(`[Unit]
- # Auto-generated, DO NOT EDIT
- Description=Service for snap application hello-snap.svc1
- Requires=%[1]s
- Wants=network.target
- After=%[1]s network.target snapd.apparmor.service
- X-Snappy=yes
- 
- [Service]
- EnvironmentFile=-/etc/environment
- ExecStart=/usr/bin/snap run hello-snap.svc1
- SyslogIdentifier=hello-snap.svc1
- Restart=on-failure
- WorkingDirectory=%[2]s/var/snap/hello-snap/12
- ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
- ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
- TimeoutStopSec=30
- Type=forking
- Slice=snap.foogroup.slice
- 
- [Install]
- WantedBy=multi-user.target
- `,
+# Auto-generated, DO NOT EDIT
+Description=Service for snap application hello-snap.svc1
+Requires=%[1]s
+Wants=network.target
+After=%[1]s network.target snapd.apparmor.service
+X-Snappy=yes
+
+[Service]
+EnvironmentFile=-/etc/environment
+ExecStart=/usr/bin/snap run hello-snap.svc1
+SyslogIdentifier=hello-snap.svc1
+Restart=on-failure
+WorkingDirectory=%[2]s/var/snap/hello-snap/12
+ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
+ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
+TimeoutStopSec=30
+Type=forking
+Slice=snap.foogroup.slice
+
+[Install]
+WantedBy=multi-user.target
+`,
 		systemd.EscapeUnitNamePath(dir),
 		dirs.GlobalRootDir,
 	)
@@ -475,48 +475,48 @@ func (s *servicesTestSuite) TestEnsureSnapServicesDoesNotRewriteQuotaSlicesOnNoo
 
 	// write both the unit file and a slice before running the ensure
 	sliceTempl := `[Unit]
- Description=Slice for snap quota group %s
- Before=slices.target
- X-Snappy=yes
- 
- [Slice]
- # Always enable memory accounting otherwise the MemoryMax setting does nothing.
- MemoryAccounting=true
- MemoryMax=%[2]s
- # for compatibility with older versions of systemd
- MemoryLimit=%[2]s
- 
- # Always enable task accounting in order to be able to count the processes/
- # threads, etc for a slice
- TasksAccounting=true
- TasksMax=%[3]d
- `
+Description=Slice for snap quota group %s
+Before=slices.target
+X-Snappy=yes
+
+[Slice]
+# Always enable memory accounting otherwise the MemoryMax setting does nothing.
+MemoryAccounting=true
+MemoryMax=%[2]s
+# for compatibility with older versions of systemd
+MemoryLimit=%[2]s
+
+# Always enable task accounting in order to be able to count the processes/
+# threads, etc for a slice
+TasksAccounting=true
+TasksMax=%[3]d
+`
 	sliceFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.foogroup.slice")
 
 	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
 	svcContent := fmt.Sprintf(`[Unit]
- # Auto-generated, DO NOT EDIT
- Description=Service for snap application hello-snap.svc1
- Requires=%[1]s
- Wants=network.target
- After=%[1]s network.target snapd.apparmor.service
- X-Snappy=yes
- 
- [Service]
- EnvironmentFile=-/etc/environment
- ExecStart=/usr/bin/snap run hello-snap.svc1
- SyslogIdentifier=hello-snap.svc1
- Restart=on-failure
- WorkingDirectory=%[2]s/var/snap/hello-snap/12
- ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
- ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
- TimeoutStopSec=30
- Type=forking
- Slice=snap.foogroup.slice
- 
- [Install]
- WantedBy=multi-user.target
- `,
+# Auto-generated, DO NOT EDIT
+Description=Service for snap application hello-snap.svc1
+Requires=%[1]s
+Wants=network.target
+After=%[1]s network.target snapd.apparmor.service
+X-Snappy=yes
+
+[Service]
+EnvironmentFile=-/etc/environment
+ExecStart=/usr/bin/snap run hello-snap.svc1
+SyslogIdentifier=hello-snap.svc1
+Restart=on-failure
+WorkingDirectory=%[2]s/var/snap/hello-snap/12
+ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
+ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
+TimeoutStopSec=30
+Type=forking
+Slice=snap.foogroup.slice
+
+[Install]
+WantedBy=multi-user.target
+`,
 		systemd.EscapeUnitNamePath(dir),
 		dirs.GlobalRootDir,
 	)
@@ -571,17 +571,17 @@ func (s *servicesTestSuite) TestRemoveQuotaGroup(c *C) {
 
 	// now write slice file and ensure it is deleted
 	sliceTempl := `[Unit]
- Description=Slice for snap quota group %s
- Before=slices.target
- X-Snappy=yes
- 
- [Slice]
- # Always enable memory accounting otherwise the MemoryMax setting does nothing.
- MemoryAccounting=true
- MemoryMax=1024
- # for compatibility with older versions of systemd
- MemoryLimit=1024
- `
+Description=Slice for snap quota group %s
+Before=slices.target
+X-Snappy=yes
+
+[Slice]
+# Always enable memory accounting otherwise the MemoryMax setting does nothing.
+MemoryAccounting=true
+MemoryMax=1024
+# for compatibility with older versions of systemd
+MemoryLimit=1024
+`
 
 	err = os.MkdirAll(filepath.Dir(sliceFile), 0755)
 	c.Assert(err, IsNil)
@@ -603,22 +603,22 @@ func (s *servicesTestSuite) TestRemoveQuotaGroup(c *C) {
 func (s *servicesTestSuite) TestEnsureSnapServicesWithSubGroupQuotaGroupsForSnaps(c *C) {
 	info1 := snaptest.MockSnap(c, packageHello, &snap.SideInfo{Revision: snap.R(12)})
 	info2 := snaptest.MockSnap(c, `
- name: hello-other-snap
- version: 1.10
- summary: hello
- description: Hello...
- apps:
-  hello:
-	command: bin/hello
-  world:
-	command: bin/world
-	completer: world-completer.sh
-  svc1:
+name: hello-other-snap
+version: 1.10
+summary: hello
+description: Hello...
+apps:
+ hello:
    command: bin/hello
-   stop-command: bin/goodbye
-   post-stop-command: bin/missya
-   daemon: forking
- `, &snap.SideInfo{Revision: snap.R(12)})
+ world:
+   command: bin/world
+   completer: world-completer.sh
+ svc1:
+  command: bin/hello
+  stop-command: bin/goodbye
+  post-stop-command: bin/missya
+  daemon: forking
+`, &snap.SideInfo{Revision: snap.R(12)})
 	svcFile1 := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-snap.svc1.service")
 	svcFile2 := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-other-snap.svc1.service")
 
@@ -642,52 +642,52 @@ func (s *servicesTestSuite) TestEnsureSnapServicesWithSubGroupQuotaGroupsForSnap
 	}
 
 	sliceTempl := `[Unit]
- Description=Slice for snap quota group %s
- Before=slices.target
- X-Snappy=yes
- 
- [Slice]
- # Always enable cpu accounting, so the following cpu quota options have an effect
- CPUAccounting=true
- CPUQuota=%[2]d
- 
- # Always enable memory accounting otherwise the MemoryMax setting does nothing.
- MemoryAccounting=true
- MemoryMax=%[3]d
- # for compatibility with older versions of systemd
- MemoryLimit=%[3]d
- 
- # Always enable task accounting in order to be able to count the processes/
- # threads, etc for a slice
- TasksAccounting=true
- `
+Description=Slice for snap quota group %s
+Before=slices.target
+X-Snappy=yes
+
+[Slice]
+# Always enable cpu accounting, so the following cpu quota options have an effect
+CPUAccounting=true
+CPUQuota=%[2]d%%
+
+# Always enable memory accounting otherwise the MemoryMax setting does nothing.
+MemoryAccounting=true
+MemoryMax=%[3]d
+# for compatibility with older versions of systemd
+MemoryLimit=%[3]d
+
+# Always enable task accounting in order to be able to count the processes/
+# threads, etc for a slice
+TasksAccounting=true
+`
 
 	sliceContent := fmt.Sprintf(sliceTempl, "foogroup", resourceLimits.Cpu.Count*resourceLimits.Cpu.Percentage, resourceLimits.Memory.MemoryLimit)
 	subSliceContent := fmt.Sprintf(sliceTempl, "subgroup", resourceLimits.Cpu.Count*resourceLimits.Cpu.Percentage, resourceLimits.Memory.MemoryLimit)
 
 	svcTemplate := `[Unit]
- # Auto-generated, DO NOT EDIT
- Description=Service for snap application %[1]s.svc1
- Requires=%[2]s
- Wants=network.target
- After=%[2]s network.target snapd.apparmor.service
- X-Snappy=yes
- 
- [Service]
- EnvironmentFile=-/etc/environment
- ExecStart=/usr/bin/snap run %[1]s.svc1
- SyslogIdentifier=%[1]s.svc1
- Restart=on-failure
- WorkingDirectory=%[3]s/var/snap/%[1]s/12
- ExecStop=/usr/bin/snap run --command=stop %[1]s.svc1
- ExecStopPost=/usr/bin/snap run --command=post-stop %[1]s.svc1
- TimeoutStopSec=30
- Type=forking
- Slice=%[4]s
- 
- [Install]
- WantedBy=multi-user.target
- `
+# Auto-generated, DO NOT EDIT
+Description=Service for snap application %[1]s.svc1
+Requires=%[2]s
+Wants=network.target
+After=%[2]s network.target snapd.apparmor.service
+X-Snappy=yes
+
+[Service]
+EnvironmentFile=-/etc/environment
+ExecStart=/usr/bin/snap run %[1]s.svc1
+SyslogIdentifier=%[1]s.svc1
+Restart=on-failure
+WorkingDirectory=%[3]s/var/snap/%[1]s/12
+ExecStop=/usr/bin/snap run --command=stop %[1]s.svc1
+ExecStopPost=/usr/bin/snap run --command=post-stop %[1]s.svc1
+TimeoutStopSec=30
+Type=forking
+Slice=%[4]s
+
+[Install]
+WantedBy=multi-user.target
+`
 
 	dir1 := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
 	dir2 := filepath.Join(dirs.SnapMountDir, "hello-other-snap", "12.mount")
@@ -784,28 +784,28 @@ func (s *servicesTestSuite) TestEnsureSnapServicesWithSubGroupQuotaGroupsGenerat
 	})
 
 	svcTemplate := `[Unit]
- # Auto-generated, DO NOT EDIT
- Description=Service for snap application %[1]s.svc1
- Requires=%[2]s
- Wants=network.target
- After=%[2]s network.target snapd.apparmor.service
- X-Snappy=yes
- 
- [Service]
- EnvironmentFile=-/etc/environment
- ExecStart=/usr/bin/snap run %[1]s.svc1
- SyslogIdentifier=%[1]s.svc1
- Restart=on-failure
- WorkingDirectory=%[3]s/var/snap/%[1]s/12
- ExecStop=/usr/bin/snap run --command=stop %[1]s.svc1
- ExecStopPost=/usr/bin/snap run --command=post-stop %[1]s.svc1
- TimeoutStopSec=30
- Type=forking
- Slice=%[4]s
- 
- [Install]
- WantedBy=multi-user.target
- `
+# Auto-generated, DO NOT EDIT
+Description=Service for snap application %[1]s.svc1
+Requires=%[2]s
+Wants=network.target
+After=%[2]s network.target snapd.apparmor.service
+X-Snappy=yes
+
+[Service]
+EnvironmentFile=-/etc/environment
+ExecStart=/usr/bin/snap run %[1]s.svc1
+SyslogIdentifier=%[1]s.svc1
+Restart=on-failure
+WorkingDirectory=%[3]s/var/snap/%[1]s/12
+ExecStop=/usr/bin/snap run --command=stop %[1]s.svc1
+ExecStopPost=/usr/bin/snap run --command=post-stop %[1]s.svc1
+TimeoutStopSec=30
+Type=forking
+Slice=%[4]s
+
+[Install]
+WantedBy=multi-user.target
+`
 
 	dir1 := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
 
@@ -818,25 +818,25 @@ func (s *servicesTestSuite) TestEnsureSnapServicesWithSubGroupQuotaGroupsGenerat
 
 	// check that both the parent and sub-group slice units were generated
 	templ := `[Unit]
- Description=Slice for snap quota group %s
- Before=slices.target
- X-Snappy=yes
- 
- [Slice]
- # Always enable cpu accounting, so the following cpu quota options have an effect
- CPUAccounting=true
- AllowedCPUs=%[2]s
- 
- # Always enable memory accounting otherwise the MemoryMax setting does nothing.
- MemoryAccounting=true
- MemoryMax=%[3]d
- # for compatibility with older versions of systemd
- MemoryLimit=%[3]d
- 
- # Always enable task accounting in order to be able to count the processes/
- # threads, etc for a slice
- TasksAccounting=true
- `
+Description=Slice for snap quota group %s
+Before=slices.target
+X-Snappy=yes
+
+[Slice]
+# Always enable cpu accounting, so the following cpu quota options have an effect
+CPUAccounting=true
+AllowedCPUs=%[2]s
+
+# Always enable memory accounting otherwise the MemoryMax setting does nothing.
+MemoryAccounting=true
+MemoryMax=%[3]d
+# for compatibility with older versions of systemd
+MemoryLimit=%[3]d
+
+# Always enable task accounting in order to be able to count the processes/
+# threads, etc for a slice
+TasksAccounting=true
+`
 
 	allowedCpusValue := strings.Trim(strings.Join(strings.Fields(fmt.Sprint(resourceLimits.Cpu.AllowedCpus)), ","), "[]")
 	c.Assert(sliceFile, testutil.FileEquals, fmt.Sprintf(templ, "foogroup", allowedCpusValue, resourceLimits.Memory.MemoryLimit))
@@ -898,27 +898,27 @@ func (s *servicesTestSuite) TestEnsureSnapServicesPreseedingHappy(c *C) {
 
 	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
 	c.Assert(svcFile, testutil.FileEquals, fmt.Sprintf(`[Unit]
- # Auto-generated, DO NOT EDIT
- Description=Service for snap application hello-snap.svc1
- Requires=%[1]s
- Wants=network.target
- After=%[1]s network.target snapd.apparmor.service
- X-Snappy=yes
- 
- [Service]
- EnvironmentFile=-/etc/environment
- ExecStart=/usr/bin/snap run hello-snap.svc1
- SyslogIdentifier=hello-snap.svc1
- Restart=on-failure
- WorkingDirectory=%[2]s/var/snap/hello-snap/12
- ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
- ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
- TimeoutStopSec=30
- Type=forking
- 
- [Install]
- WantedBy=multi-user.target
- `,
+# Auto-generated, DO NOT EDIT
+Description=Service for snap application hello-snap.svc1
+Requires=%[1]s
+Wants=network.target
+After=%[1]s network.target snapd.apparmor.service
+X-Snappy=yes
+
+[Service]
+EnvironmentFile=-/etc/environment
+ExecStart=/usr/bin/snap run hello-snap.svc1
+SyslogIdentifier=hello-snap.svc1
+Restart=on-failure
+WorkingDirectory=%[2]s/var/snap/hello-snap/12
+ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
+ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
+TimeoutStopSec=30
+Type=forking
+
+[Install]
+WantedBy=multi-user.target
+`,
 		systemd.EscapeUnitNamePath(dir),
 		dirs.GlobalRootDir,
 	))
@@ -935,22 +935,22 @@ func (s *servicesTestSuite) TestEnsureSnapServicesRequireMountedSnapdSnapOptions
 	// that the global options apply to all snaps
 	info1 := snaptest.MockSnap(c, packageHello, &snap.SideInfo{Revision: snap.R(12)})
 	info2 := snaptest.MockSnap(c, `
- name: hello-other-snap
- version: 1.10
- summary: hello
- description: Hello...
- apps:
-  hello:
-	command: bin/hello
-  world:
-	command: bin/world
-	completer: world-completer.sh
-  svc1:
+name: hello-other-snap
+version: 1.10
+summary: hello
+description: Hello...
+apps:
+ hello:
    command: bin/hello
-   stop-command: bin/goodbye
-   post-stop-command: bin/missya
-   daemon: forking
- `, &snap.SideInfo{Revision: snap.R(12)})
+ world:
+   command: bin/world
+   completer: world-completer.sh
+ svc1:
+  command: bin/hello
+  stop-command: bin/goodbye
+  post-stop-command: bin/missya
+  daemon: forking
+`, &snap.SideInfo{Revision: snap.R(12)})
 	svcFile1 := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-snap.svc1.service")
 	svcFile2 := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-other-snap.svc1.service")
 
@@ -976,29 +976,29 @@ func (s *servicesTestSuite) TestEnsureSnapServicesRequireMountedSnapdSnapOptions
 	})
 
 	template := `[Unit]
- # Auto-generated, DO NOT EDIT
- Description=Service for snap application %[1]s.svc1
- Requires=%[2]s
- Wants=network.target
- After=%[2]s network.target snapd.apparmor.service
- Wants=usr-lib-snapd.mount
- After=usr-lib-snapd.mount
- X-Snappy=yes
- 
- [Service]
- EnvironmentFile=-/etc/environment
- ExecStart=/usr/bin/snap run %[1]s.svc1
- SyslogIdentifier=%[1]s.svc1
- Restart=on-failure
- WorkingDirectory=%[3]s/var/snap/%[1]s/12
- ExecStop=/usr/bin/snap run --command=stop %[1]s.svc1
- ExecStopPost=/usr/bin/snap run --command=post-stop %[1]s.svc1
- TimeoutStopSec=30
- Type=forking
- %[4]s
- [Install]
- WantedBy=multi-user.target
- `
+# Auto-generated, DO NOT EDIT
+Description=Service for snap application %[1]s.svc1
+Requires=%[2]s
+Wants=network.target
+After=%[2]s network.target snapd.apparmor.service
+Wants=usr-lib-snapd.mount
+After=usr-lib-snapd.mount
+X-Snappy=yes
+
+[Service]
+EnvironmentFile=-/etc/environment
+ExecStart=/usr/bin/snap run %[1]s.svc1
+SyslogIdentifier=%[1]s.svc1
+Restart=on-failure
+WorkingDirectory=%[3]s/var/snap/%[1]s/12
+ExecStop=/usr/bin/snap run --command=stop %[1]s.svc1
+ExecStopPost=/usr/bin/snap run --command=post-stop %[1]s.svc1
+TimeoutStopSec=30
+Type=forking
+%[4]s
+[Install]
+WantedBy=multi-user.target
+`
 
 	dir1 := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
 	dir2 := filepath.Join(dirs.SnapMountDir, "hello-other-snap", "12.mount")
@@ -1021,37 +1021,37 @@ func (s *servicesTestSuite) TestEnsureSnapServicesRequireMountedSnapdSnapOptions
 func (s *servicesTestSuite) TestEnsureSnapServicesCallback(c *C) {
 	// hava a 2nd new service definition
 	info := snaptest.MockSnap(c, packageHello+` svc2:
-   command: bin/hello
-   stop-command: bin/goodbye
-   post-stop-command: bin/missya
-   daemon: forking
- `, &snap.SideInfo{Revision: snap.R(12)})
+  command: bin/hello
+  stop-command: bin/goodbye
+  post-stop-command: bin/missya
+  daemon: forking
+`, &snap.SideInfo{Revision: snap.R(12)})
 	svc1File := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-snap.svc1.service")
 	svc2File := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-snap.svc2.service")
 
 	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
 	template := `[Unit]
- # Auto-generated, DO NOT EDIT
- Description=Service for snap application hello-snap.%[1]s
- Requires=%[2]s
- Wants=network.target
- After=%[2]s network.target snapd.apparmor.service
- X-Snappy=yes
- 
- [Service]
- EnvironmentFile=-/etc/environment
- ExecStart=/usr/bin/snap run hello-snap.%[1]s
- SyslogIdentifier=hello-snap.%[1]s
- Restart=on-failure
- WorkingDirectory=%[3]s/var/snap/hello-snap/12
- ExecStop=/usr/bin/snap run --command=stop hello-snap.%[1]s
- ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.%[1]s
- TimeoutStopSec=30
- Type=forking
- %[4]s
- [Install]
- WantedBy=multi-user.target
- `
+# Auto-generated, DO NOT EDIT
+Description=Service for snap application hello-snap.%[1]s
+Requires=%[2]s
+Wants=network.target
+After=%[2]s network.target snapd.apparmor.service
+X-Snappy=yes
+
+[Service]
+EnvironmentFile=-/etc/environment
+ExecStart=/usr/bin/snap run hello-snap.%[1]s
+SyslogIdentifier=hello-snap.%[1]s
+Restart=on-failure
+WorkingDirectory=%[3]s/var/snap/hello-snap/12
+ExecStop=/usr/bin/snap run --command=stop hello-snap.%[1]s
+ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.%[1]s
+TimeoutStopSec=30
+Type=forking
+%[4]s
+[Install]
+WantedBy=multi-user.target
+`
 	svc1Content := fmt.Sprintf(template,
 		"svc1",
 		systemd.EscapeUnitNamePath(dir),
@@ -1114,37 +1114,37 @@ func (s *servicesTestSuite) TestEnsureSnapServicesAddsNewSvc(c *C) {
 	// test that with an existing service unit definition, it is not changed
 	// but we do add the new one
 	info := snaptest.MockSnap(c, packageHello+` svc2:
-   command: bin/hello
-   stop-command: bin/goodbye
-   post-stop-command: bin/missya
-   daemon: forking
- `, &snap.SideInfo{Revision: snap.R(12)})
+  command: bin/hello
+  stop-command: bin/goodbye
+  post-stop-command: bin/missya
+  daemon: forking
+`, &snap.SideInfo{Revision: snap.R(12)})
 	svc1File := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-snap.svc1.service")
 	svc2File := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-snap.svc2.service")
 
 	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
 	template := `[Unit]
- # Auto-generated, DO NOT EDIT
- Description=Service for snap application hello-snap.%[1]s
- Requires=%[2]s
- Wants=network.target
- After=%[2]s network.target snapd.apparmor.service
- X-Snappy=yes
- 
- [Service]
- EnvironmentFile=-/etc/environment
- ExecStart=/usr/bin/snap run hello-snap.%[1]s
- SyslogIdentifier=hello-snap.%[1]s
- Restart=on-failure
- WorkingDirectory=%[3]s/var/snap/hello-snap/12
- ExecStop=/usr/bin/snap run --command=stop hello-snap.%[1]s
- ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.%[1]s
- TimeoutStopSec=30
- Type=forking
- %[4]s
- [Install]
- WantedBy=multi-user.target
- `
+# Auto-generated, DO NOT EDIT
+Description=Service for snap application hello-snap.%[1]s
+Requires=%[2]s
+Wants=network.target
+After=%[2]s network.target snapd.apparmor.service
+X-Snappy=yes
+
+[Service]
+EnvironmentFile=-/etc/environment
+ExecStart=/usr/bin/snap run hello-snap.%[1]s
+SyslogIdentifier=hello-snap.%[1]s
+Restart=on-failure
+WorkingDirectory=%[3]s/var/snap/hello-snap/12
+ExecStop=/usr/bin/snap run --command=stop hello-snap.%[1]s
+ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.%[1]s
+TimeoutStopSec=30
+Type=forking
+%[4]s
+[Install]
+WantedBy=multi-user.target
+`
 	svc1Content := fmt.Sprintf(template,
 		"svc1",
 		systemd.EscapeUnitNamePath(dir),
@@ -1196,27 +1196,27 @@ func (s *servicesTestSuite) TestEnsureSnapServicesNoChangeNoop(c *C) {
 
 	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
 	template := `[Unit]
- # Auto-generated, DO NOT EDIT
- Description=Service for snap application hello-snap.svc1
- Requires=%[1]s
- Wants=network.target
- After=%[1]s network.target snapd.apparmor.service
- X-Snappy=yes
- 
- [Service]
- EnvironmentFile=-/etc/environment
- ExecStart=/usr/bin/snap run hello-snap.svc1
- SyslogIdentifier=hello-snap.svc1
- Restart=on-failure
- WorkingDirectory=%[2]s/var/snap/hello-snap/12
- ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
- ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
- TimeoutStopSec=30
- Type=forking
- %s
- [Install]
- WantedBy=multi-user.target
- `
+# Auto-generated, DO NOT EDIT
+Description=Service for snap application hello-snap.svc1
+Requires=%[1]s
+Wants=network.target
+After=%[1]s network.target snapd.apparmor.service
+X-Snappy=yes
+
+[Service]
+EnvironmentFile=-/etc/environment
+ExecStart=/usr/bin/snap run hello-snap.svc1
+SyslogIdentifier=hello-snap.svc1
+Restart=on-failure
+WorkingDirectory=%[2]s/var/snap/hello-snap/12
+ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
+ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
+TimeoutStopSec=30
+Type=forking
+%s
+[Install]
+WantedBy=multi-user.target
+`
 	origContent := fmt.Sprintf(template,
 		systemd.EscapeUnitNamePath(dir),
 		dirs.GlobalRootDir,
@@ -1264,27 +1264,27 @@ func (s *servicesTestSuite) TestEnsureSnapServicesChanges(c *C) {
 
 	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
 	template := `[Unit]
- # Auto-generated, DO NOT EDIT
- Description=Service for snap application hello-snap.svc1
- Requires=%[1]s
- Wants=network.target
- After=%[1]s network.target snapd.apparmor.service
- X-Snappy=yes
- 
- [Service]
- EnvironmentFile=-/etc/environment
- ExecStart=/usr/bin/snap run hello-snap.svc1
- SyslogIdentifier=hello-snap.svc1
- Restart=on-failure
- WorkingDirectory=%[2]s/var/snap/hello-snap/12
- ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
- ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
- TimeoutStopSec=30
- Type=forking
- %s
- [Install]
- WantedBy=multi-user.target
- `
+# Auto-generated, DO NOT EDIT
+Description=Service for snap application hello-snap.svc1
+Requires=%[1]s
+Wants=network.target
+After=%[1]s network.target snapd.apparmor.service
+X-Snappy=yes
+
+[Service]
+EnvironmentFile=-/etc/environment
+ExecStart=/usr/bin/snap run hello-snap.svc1
+SyslogIdentifier=hello-snap.svc1
+Restart=on-failure
+WorkingDirectory=%[2]s/var/snap/hello-snap/12
+ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
+ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
+TimeoutStopSec=30
+Type=forking
+%s
+[Install]
+WantedBy=multi-user.target
+`
 	origContent := fmt.Sprintf(template,
 		systemd.EscapeUnitNamePath(dir),
 		dirs.GlobalRootDir,
@@ -1328,27 +1328,27 @@ func (s *servicesTestSuite) TestEnsureSnapServicesRollsback(c *C) {
 	// pretend we already have a unit file with no VitalityRank options set
 	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
 	template := `[Unit]
- # Auto-generated, DO NOT EDIT
- Description=Service for snap application hello-snap.svc1
- Requires=%[1]s
- Wants=network.target
- After=%[1]s network.target snapd.apparmor.service
- X-Snappy=yes
- 
- [Service]
- EnvironmentFile=-/etc/environment
- ExecStart=/usr/bin/snap run hello-snap.svc1
- SyslogIdentifier=hello-snap.svc1
- Restart=on-failure
- WorkingDirectory=%[2]s/var/snap/hello-snap/12
- ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
- ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
- TimeoutStopSec=30
- Type=forking
- %s
- [Install]
- WantedBy=multi-user.target
- `
+# Auto-generated, DO NOT EDIT
+Description=Service for snap application hello-snap.svc1
+Requires=%[1]s
+Wants=network.target
+After=%[1]s network.target snapd.apparmor.service
+X-Snappy=yes
+
+[Service]
+EnvironmentFile=-/etc/environment
+ExecStart=/usr/bin/snap run hello-snap.svc1
+SyslogIdentifier=hello-snap.svc1
+Restart=on-failure
+WorkingDirectory=%[2]s/var/snap/hello-snap/12
+ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
+ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
+TimeoutStopSec=30
+Type=forking
+%s
+[Install]
+WantedBy=multi-user.target
+`
 	origContent := fmt.Sprintf(template,
 		systemd.EscapeUnitNamePath(dir),
 		dirs.GlobalRootDir,
@@ -1412,27 +1412,27 @@ func (s *servicesTestSuite) TestEnsureSnapServicesRemovesNewAddOnRollback(c *C) 
 	// pretend we already have a unit file with no VitalityRank options set
 	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
 	template := `[Unit]
- # Auto-generated, DO NOT EDIT
- Description=Service for snap application hello-snap.svc1
- Requires=%[1]s
- Wants=network.target
- After=%[1]s network.target snapd.apparmor.service
- X-Snappy=yes
- 
- [Service]
- EnvironmentFile=-/etc/environment
- ExecStart=/usr/bin/snap run hello-snap.svc1
- SyslogIdentifier=hello-snap.svc1
- Restart=on-failure
- WorkingDirectory=%[2]s/var/snap/hello-snap/12
- ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
- ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
- TimeoutStopSec=30
- Type=forking
- %s
- [Install]
- WantedBy=multi-user.target
- `
+# Auto-generated, DO NOT EDIT
+Description=Service for snap application hello-snap.svc1
+Requires=%[1]s
+Wants=network.target
+After=%[1]s network.target snapd.apparmor.service
+X-Snappy=yes
+
+[Service]
+EnvironmentFile=-/etc/environment
+ExecStart=/usr/bin/snap run hello-snap.svc1
+SyslogIdentifier=hello-snap.svc1
+Restart=on-failure
+WorkingDirectory=%[2]s/var/snap/hello-snap/12
+ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
+ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
+TimeoutStopSec=30
+Type=forking
+%s
+[Install]
+WantedBy=multi-user.target
+`
 	// make systemctl fail the first time when we try to do a daemon-reload,
 	// then the next time don't return an error
 	systemctlCalls := 0
@@ -1476,11 +1476,11 @@ func (s *servicesTestSuite) TestEnsureSnapServicesRemovesNewAddOnRollback(c *C) 
 
 func (s *servicesTestSuite) TestEnsureSnapServicesOnlyRemovesNewAddOnRollback(c *C) {
 	info := snaptest.MockSnap(c, packageHello+` svc2:
-   command: bin/hello
-   stop-command: bin/goodbye
-   post-stop-command: bin/missya
-   daemon: forking
- `, &snap.SideInfo{Revision: snap.R(12)})
+  command: bin/hello
+  stop-command: bin/goodbye
+  post-stop-command: bin/missya
+  daemon: forking
+`, &snap.SideInfo{Revision: snap.R(12)})
 
 	// we won't delete existing files, but we will delete new files, so mock an
 	// existing file to check that it doesn't get deleted
@@ -1490,27 +1490,27 @@ func (s *servicesTestSuite) TestEnsureSnapServicesOnlyRemovesNewAddOnRollback(c 
 	// pretend we already have a unit file with no VitalityRank options set
 	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
 	template := `[Unit]
- # Auto-generated, DO NOT EDIT
- Description=Service for snap application hello-snap.%[1]s
- Requires=%[2]s
- Wants=network.target
- After=%[2]s network.target snapd.apparmor.service
- X-Snappy=yes
- 
- [Service]
- EnvironmentFile=-/etc/environment
- ExecStart=/usr/bin/snap run hello-snap.%[1]s
- SyslogIdentifier=hello-snap.%[1]s
- Restart=on-failure
- WorkingDirectory=%[3]s/var/snap/hello-snap/12
- ExecStop=/usr/bin/snap run --command=stop hello-snap.%[1]s
- ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.%[1]s
- TimeoutStopSec=30
- Type=forking
- %[4]s
- [Install]
- WantedBy=multi-user.target
- `
+# Auto-generated, DO NOT EDIT
+Description=Service for snap application hello-snap.%[1]s
+Requires=%[2]s
+Wants=network.target
+After=%[2]s network.target snapd.apparmor.service
+X-Snappy=yes
+
+[Service]
+EnvironmentFile=-/etc/environment
+ExecStart=/usr/bin/snap run hello-snap.%[1]s
+SyslogIdentifier=hello-snap.%[1]s
+Restart=on-failure
+WorkingDirectory=%[3]s/var/snap/hello-snap/12
+ExecStop=/usr/bin/snap run --command=stop hello-snap.%[1]s
+ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.%[1]s
+TimeoutStopSec=30
+Type=forking
+%[4]s
+[Install]
+WantedBy=multi-user.target
+`
 
 	svc1Content := fmt.Sprintf(template,
 		"svc1",
@@ -1580,8 +1580,8 @@ func (s *servicesTestSuite) TestEnsureSnapServicesSubunits(c *C) {
 	}
 
 	info := snaptest.MockSnap(c, packageHello+`
-   timer: 10:00-12:00
- `, &snap.SideInfo{Revision: snap.R(11)})
+  timer: 10:00-12:00
+`, &snap.SideInfo{Revision: snap.R(11)})
 
 	m := map[*snap.Info]*wrappers.SnapServiceOptions{
 		info: nil,
@@ -1598,12 +1598,12 @@ func (s *servicesTestSuite) TestEnsureSnapServicesSubunits(c *C) {
 
 	// change vitality, timer, add socket
 	info = snaptest.MockSnap(c, packageHello+`
-   plugs: [network-bind]
-   timer: 10:00-12:00,20:00-22:00
-   sockets:
-	 sock1:
-	   listen-stream: $SNAP_DATA/sock1.socket
- `, &snap.SideInfo{Revision: snap.R(12)})
+  plugs: [network-bind]
+  timer: 10:00-12:00,20:00-22:00
+  sockets:
+    sock1:
+      listen-stream: $SNAP_DATA/sock1.socket
+`, &snap.SideInfo{Revision: snap.R(12)})
 
 	m = map[*snap.Info]*wrappers.SnapServiceOptions{
 		info: {VitalityRank: 1},
@@ -1627,28 +1627,28 @@ func (s *servicesTestSuite) TestAddSnapServicesWithInterfaceSnippets(c *C) {
 		{
 			"docker-support",
 			`
-   plugs:
-	- docker-support`,
+  plugs:
+   - docker-support`,
 		},
 		{
 			"k8s-support",
 			`
-   plugs:
-	- kubernetes-support`,
+  plugs:
+   - kubernetes-support`,
 		},
 		{
 			"lxd-support",
 			`
-   plugs:
-	- lxd-support
- `,
+  plugs:
+   - lxd-support
+`,
 		},
 		{
 			"greengrass-support",
 			`
-   plugs:
-	- greengrass-support
- `,
+  plugs:
+   - greengrass-support
+`,
 		},
 
 		// multiple interfaces that require Delegate=true, but only one is
@@ -1657,9 +1657,9 @@ func (s *servicesTestSuite) TestAddSnapServicesWithInterfaceSnippets(c *C) {
 		{
 			"multiple interfaces that require Delegate=true",
 			`
-   plugs:
-	- docker-support
-	- kubernetes-support`,
+  plugs:
+   - docker-support
+   - kubernetes-support`,
 		},
 
 		// interfaces with flavor attributes
@@ -1667,44 +1667,44 @@ func (s *servicesTestSuite) TestAddSnapServicesWithInterfaceSnippets(c *C) {
 		{
 			"k8s-support with kubelet",
 			`
-   plugs:
-	- kubelet
- plugs:
-  kubelet:
-   interface: kubernetes-support
-   flavor: kubelet
- `,
+  plugs:
+   - kubelet
+plugs:
+ kubelet:
+  interface: kubernetes-support
+  flavor: kubelet
+`,
 		},
 		{
 			"k8s-support with kubeproxy",
 			`
-   plugs:
-	- kubeproxy
- plugs:
-  kubeproxy:
-   interface: kubernetes-support
-   flavor: kubeproxy
- `,
+  plugs:
+   - kubeproxy
+plugs:
+ kubeproxy:
+  interface: kubernetes-support
+  flavor: kubeproxy
+`,
 		},
 		{
 			"greengrass-support with legacy-container flavor",
 			`
-   plugs:
-	- greengrass
- plugs:
-  greengrass:
-   interface: greengrass-support
-   flavor: legacy-container
- `,
+  plugs:
+   - greengrass
+plugs:
+ greengrass:
+  interface: greengrass-support
+  flavor: legacy-container
+`,
 		},
 	}
 
 	for _, t := range tt {
 		comment := Commentf(t.comment)
 		info := snaptest.MockSnap(c, packageHelloNoSrv+`
-  svc1:
-   daemon: simple
- `+t.plugSnippet,
+ svc1:
+  daemon: simple
+`+t.plugSnippet,
 			&snap.SideInfo{Revision: snap.R(12)})
 		svcFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-snap.svc1.service")
 
@@ -1716,26 +1716,26 @@ func (s *servicesTestSuite) TestAddSnapServicesWithInterfaceSnippets(c *C) {
 
 		dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
 		c.Assert(svcFile, testutil.FileEquals, fmt.Sprintf(`[Unit]
- # Auto-generated, DO NOT EDIT
- Description=Service for snap application hello-snap.svc1
- Requires=%[1]s
- Wants=network.target
- After=%[1]s network.target snapd.apparmor.service
- X-Snappy=yes
- 
- [Service]
- EnvironmentFile=-/etc/environment
- ExecStart=/usr/bin/snap run hello-snap.svc1
- SyslogIdentifier=hello-snap.svc1
- Restart=on-failure
- WorkingDirectory=%[2]s/var/snap/hello-snap/12
- TimeoutStopSec=30
- Type=simple
- Delegate=true
- 
- [Install]
- WantedBy=multi-user.target
- `,
+# Auto-generated, DO NOT EDIT
+Description=Service for snap application hello-snap.svc1
+Requires=%[1]s
+Wants=network.target
+After=%[1]s network.target snapd.apparmor.service
+X-Snappy=yes
+
+[Service]
+EnvironmentFile=-/etc/environment
+ExecStart=/usr/bin/snap run hello-snap.svc1
+SyslogIdentifier=hello-snap.svc1
+Restart=on-failure
+WorkingDirectory=%[2]s/var/snap/hello-snap/12
+TimeoutStopSec=30
+Type=simple
+Delegate=true
+
+[Install]
+WantedBy=multi-user.target
+`,
 			systemd.EscapeUnitNamePath(dir),
 			dirs.GlobalRootDir,
 		), comment)
@@ -1765,10 +1765,10 @@ func (s *servicesTestSuite) TestAddSnapServicesWithInterfaceSnippets(c *C) {
 
 func (s *servicesTestSuite) TestAddSnapServicesAndRemoveUserDaemons(c *C) {
 	info := snaptest.MockSnap(c, packageHelloNoSrv+`
-  svc1:
-   daemon: simple
-   daemon-scope: user
- `, &snap.SideInfo{Revision: snap.R(12)})
+ svc1:
+  daemon: simple
+  daemon-scope: user
+`, &snap.SideInfo{Revision: snap.R(12)})
 	svcFile := filepath.Join(s.tempdir, "/etc/systemd/user/snap.hello-snap.svc1.service")
 
 	err := wrappers.AddSnapServices(info, nil, progress.Null)
@@ -1801,22 +1801,22 @@ func (s *servicesTestSuite) TestAddSnapServicesAndRemoveUserDaemons(c *C) {
 }
 
 var snapdYaml = `name: snapd
- version: 1.0
- type: snapd
- `
+version: 1.0
+type: snapd
+`
 
 func (s *servicesTestSuite) TestRemoveSnapWithSocketsRemovesSocketsService(c *C) {
 	info := snaptest.MockSnap(c, packageHelloNoSrv+`
-  svc1:
-   daemon: simple
-   plugs: [network-bind]
-   sockets:
-	 sock1:
-	   listen-stream: $SNAP_DATA/sock1.socket
-	   socket-mode: 0666
-	 sock2:
-	   listen-stream: $SNAP_COMMON/sock2.socket
- `, &snap.SideInfo{Revision: snap.R(12)})
+ svc1:
+  daemon: simple
+  plugs: [network-bind]
+  sockets:
+    sock1:
+      listen-stream: $SNAP_DATA/sock1.socket
+      socket-mode: 0666
+    sock2:
+      listen-stream: $SNAP_COMMON/sock2.socket
+`, &snap.SideInfo{Revision: snap.R(12)})
 
 	err := wrappers.AddSnapServices(info, nil, progress.Null)
 	c.Assert(err, IsNil)
@@ -1850,13 +1850,13 @@ func (s *servicesTestSuite) TestRemoveSnapPackageFallbackToKill(c *C) {
 	defer r()
 
 	info := snaptest.MockSnap(c, `name: wat
- version: 42
- apps:
-  wat:
-	command: wat
-	stop-timeout: 20ms
-	daemon: forking
- `, &snap.SideInfo{Revision: snap.R(11)})
+version: 42
+apps:
+ wat:
+   command: wat
+   stop-timeout: 20ms
+   daemon: forking
+`, &snap.SideInfo{Revision: snap.R(11)})
 
 	err := wrappers.AddSnapServices(info, nil, progress.Null)
 	c.Assert(err, IsNil)
@@ -1892,14 +1892,14 @@ func (s *servicesTestSuite) TestRemoveSnapPackageUserDaemonStopFailure(c *C) {
 	defer r()
 
 	info := snaptest.MockSnap(c, `name: wat
- version: 42
- apps:
-  wat:
-	command: wat
-	stop-timeout: 20ms
-	daemon: forking
-	daemon-scope: user
- `, &snap.SideInfo{Revision: snap.R(11)})
+version: 42
+apps:
+ wat:
+   command: wat
+   stop-timeout: 20ms
+   daemon: forking
+   daemon-scope: user
+`, &snap.SideInfo{Revision: snap.R(11)})
 
 	err := wrappers.AddSnapServices(info, nil, progress.Null)
 	c.Assert(err, IsNil)
@@ -1917,48 +1917,48 @@ func (s *servicesTestSuite) TestRemoveSnapPackageUserDaemonStopFailure(c *C) {
 
 func (s *servicesTestSuite) TestServicesEnableState(c *C) {
 	info := snaptest.MockSnap(c, packageHello+`
-  svc2:
-   command: bin/hello
-   daemon: forking
-  svc3:
-   command: bin/hello
-   daemon: simple
-   daemon-scope: user
- `, &snap.SideInfo{Revision: snap.R(12)})
+ svc2:
+  command: bin/hello
+  daemon: forking
+ svc3:
+  command: bin/hello
+  daemon: simple
+  daemon-scope: user
+`, &snap.SideInfo{Revision: snap.R(12)})
 	svc1File := "snap.hello-snap.svc1.service"
 	svc2File := "snap.hello-snap.svc2.service"
 
 	s.systemctlRestorer()
 	r := testutil.MockCommand(c, "systemctl", `#!/bin/sh
-	 if [ "$1" = "--root" ]; then
-		 # shifting by 2 also drops the temp dir arg to --root
-		 shift 2
-	 fi
- 
-	 case "$1" in
-		 is-enabled)
-			 case "$2" in 
-			 "snap.hello-snap.svc1.service")
-				 echo "disabled"
-				 exit 1
-				 ;;
-			 "snap.hello-snap.svc2.service")
-				 echo "enabled"
-				 exit 0
-				 ;;
-			 *)
-				 echo "unexpected is-enabled of service $2"
-				 exit 2
-				 ;;
-			 esac
-			 ;;
-		 *)
-			 echo "unexpected op $*"
-			 exit 2
-	 esac
- 
-	 exit 1
-	 `)
+	if [ "$1" = "--root" ]; then
+		# shifting by 2 also drops the temp dir arg to --root
+	    shift 2
+	fi
+
+	case "$1" in
+		is-enabled)
+			case "$2" in 
+			"snap.hello-snap.svc1.service")
+				echo "disabled"
+				exit 1
+				;;
+			"snap.hello-snap.svc2.service")
+				echo "enabled"
+				exit 0
+				;;
+			*)
+				echo "unexpected is-enabled of service $2"
+				exit 2
+				;;
+			esac
+	        ;;
+	    *)
+	        echo "unexpected op $*"
+	        exit 2
+	esac
+
+	exit 1
+	`)
 	defer r.Restore()
 
 	states, err := wrappers.ServicesEnableState(info, progress.Null)
@@ -1989,31 +1989,31 @@ func (s *servicesTestSuite) TestServicesEnableStateFail(c *C) {
 
 	s.systemctlRestorer()
 	r := testutil.MockCommand(c, "systemctl", `#!/bin/sh
-	 if [ "$1" = "--root" ]; then
-		 # shifting by 2 also drops the temp dir arg to --root
-		 shift 2
-	 fi
- 
-	 case "$1" in
-		 is-enabled)
-			 case "$2" in
-			 "snap.hello-snap.svc1.service")
-				 echo "whoops"
-				 exit 1
-				 ;;
-			 *)
-				 echo "unexpected is-enabled of service $2"
-				 exit 2
-				 ;;
-			 esac
-			 ;;
-		 *)
-			 echo "unexpected op $*"
-			 exit 2
-	 esac
- 
-	 exit 1
-	 `)
+	if [ "$1" = "--root" ]; then
+		# shifting by 2 also drops the temp dir arg to --root
+	    shift 2
+	fi
+
+	case "$1" in
+		is-enabled)
+			case "$2" in
+			"snap.hello-snap.svc1.service")
+				echo "whoops"
+				exit 1
+				;;
+			*)
+				echo "unexpected is-enabled of service $2"
+				exit 2
+				;;
+			esac
+	        ;;
+	    *)
+	        echo "unexpected op $*"
+	        exit 2
+	esac
+
+	exit 1
+	`)
 	defer r.Restore()
 
 	_, err := wrappers.ServicesEnableState(info, progress.Null)
@@ -2026,53 +2026,53 @@ func (s *servicesTestSuite) TestServicesEnableStateFail(c *C) {
 
 func (s *servicesTestSuite) TestAddSnapServicesWithDisabledServices(c *C) {
 	info := snaptest.MockSnap(c, packageHello+`
-  svc2:
-   command: bin/hello
-   daemon: forking
- `, &snap.SideInfo{Revision: snap.R(12)})
+ svc2:
+  command: bin/hello
+  daemon: forking
+`, &snap.SideInfo{Revision: snap.R(12)})
 
 	s.systemctlRestorer()
 	r := testutil.MockCommand(c, "systemctl", `#!/bin/sh
-	 if [ "$1" = "--root" ]; then
-		 shift 2
-	 fi
- 
-	 case "$1" in
-		 enable)
-			 case "$2" in 
-				 "snap.hello-snap.svc1.service")
-					 echo "unexpected enable of disabled service $2"
-					 exit 1
-					 ;;
-				 "snap.hello-snap.svc2.service")
-					 exit 0
-					 ;;
-				 *)
-					 echo "unexpected enable of service $2"
-					 exit 1
-					 ;;
-			 esac
-			 ;;
-		 start)
-			 case "$2" in
-				 "snap.hello-snap.svc2.service")
-					 exit 0
-					 ;;
-			 *)
-					 echo "unexpected start of service $2"
-					 exit 1
-					 ;;
-			 esac
-			 ;;
-		 daemon-reload)
-			 exit 0
-			 ;;
-		 *)
-			 echo "unexpected op $*"
-			 exit 2
-	 esac
-	 exit 2
-	 `)
+	if [ "$1" = "--root" ]; then
+	    shift 2
+	fi
+
+	case "$1" in
+		enable)
+			case "$2" in 
+				"snap.hello-snap.svc1.service")
+					echo "unexpected enable of disabled service $2"
+					exit 1
+					;;
+				"snap.hello-snap.svc2.service")
+					exit 0
+					;;
+				*)
+					echo "unexpected enable of service $2"
+					exit 1
+					;;
+			esac
+			;;
+		start)
+			case "$2" in
+				"snap.hello-snap.svc2.service")
+					exit 0
+					;;
+			*)
+					echo "unexpected start of service $2"
+					exit 1
+					;;
+			esac
+			;;
+		daemon-reload)
+			exit 0
+			;;
+	    *)
+	        echo "unexpected op $*"
+	        exit 2
+	esac
+	exit 2
+	`)
 	defer r.Restore()
 
 	// svc1 will be disabled
@@ -2131,26 +2131,26 @@ func (s *servicesTestSuite) TestStopServicesWithSockets(c *C) {
 	defer r()
 
 	info := snaptest.MockSnap(c, packageHelloNoSrv+`
-  svc1:
-   daemon: simple
-   plugs: [network-bind]
-   sockets:
-	 sock1:
-	   listen-stream: $SNAP_COMMON/sock1.socket
-	   socket-mode: 0666
-	 sock2:
-	   listen-stream: $SNAP_DATA/sock2.socket
-  svc2:
-   daemon: simple
-   daemon-scope: user
-   plugs: [network-bind]
-   sockets:
-	 sock1:
-	   listen-stream: $SNAP_USER_COMMON/sock1.socket
-	   socket-mode: 0666
-	 sock2:
-	   listen-stream: $SNAP_USER_DATA/sock2.socket
- `, &snap.SideInfo{Revision: snap.R(12)})
+ svc1:
+  daemon: simple
+  plugs: [network-bind]
+  sockets:
+    sock1:
+      listen-stream: $SNAP_COMMON/sock1.socket
+      socket-mode: 0666
+    sock2:
+      listen-stream: $SNAP_DATA/sock2.socket
+ svc2:
+  daemon: simple
+  daemon-scope: user
+  plugs: [network-bind]
+  sockets:
+    sock1:
+      listen-stream: $SNAP_USER_COMMON/sock1.socket
+      socket-mode: 0666
+    sock2:
+      listen-stream: $SNAP_USER_DATA/sock2.socket
+`, &snap.SideInfo{Revision: snap.R(12)})
 
 	err := wrappers.AddSnapServices(info, nil, progress.Null)
 	c.Assert(err, IsNil)
@@ -2189,10 +2189,10 @@ func (s *servicesTestSuite) TestStartServices(c *C) {
 
 func (s *servicesTestSuite) TestStartServicesUserDaemons(c *C) {
 	info := snaptest.MockSnap(c, packageHelloNoSrv+`
-  svc1:
-   daemon: simple
-   daemon-scope: user
- `, &snap.SideInfo{Revision: snap.R(12)})
+ svc1:
+  daemon: simple
+  daemon-scope: user
+`, &snap.SideInfo{Revision: snap.R(12)})
 	svcFile := filepath.Join(s.tempdir, "/etc/systemd/user/snap.hello-snap.svc1.service")
 
 	flags := &wrappers.StartServicesFlags{Enable: true}
@@ -2218,37 +2218,37 @@ func (s *servicesTestSuite) TestNoStartDisabledServices(c *C) {
 	svc2Name := "snap.hello-snap.svc2.service"
 
 	info := snaptest.MockSnap(c, packageHello+`
-  svc2:
-   command: bin/hello
-   daemon: simple
- `, &snap.SideInfo{Revision: snap.R(12)})
+ svc2:
+  command: bin/hello
+  daemon: simple
+`, &snap.SideInfo{Revision: snap.R(12)})
 
 	s.systemctlRestorer()
 	r := testutil.MockCommand(c, "systemctl", `#!/bin/sh
-	 if [ "$1" = "--root" ]; then
-		 shift 2
-	 fi
- 
-	 case "$1" in
-		 start)
-			 if [ "$2" = "snap.hello-snap.svc2.service" ]; then
-				 exit 0
-			 fi
-			 echo "unexpected start of service $2"
-			 exit 1
-			 ;;
-		 enable)
-			 if [ "$2" = "snap.hello-snap.svc2.service" ]; then
-				 exit 0
-			 fi
-			 echo "unexpected enable of service $2"
-			 exit 1
-			 ;;
-		 *)
-			 echo "unexpected call $*"
-			 exit 2
-	 esac
-	 `)
+	if [ "$1" = "--root" ]; then
+	    shift 2
+	fi
+
+	case "$1" in
+		start)
+			if [ "$2" = "snap.hello-snap.svc2.service" ]; then
+				exit 0
+			fi
+			echo "unexpected start of service $2"
+			exit 1
+			;;
+		enable)
+			if [ "$2" = "snap.hello-snap.svc2.service" ]; then
+				exit 0
+			fi
+			echo "unexpected enable of service $2"
+			exit 1
+			;;
+	    *)
+	        echo "unexpected call $*"
+	        exit 2
+	esac
+	`)
 	defer r.Restore()
 
 	flags := &wrappers.StartServicesFlags{Enable: true}
@@ -2266,9 +2266,9 @@ func (s *servicesTestSuite) TestAddSnapMultiServicesFailCreateCleanup(c *C) {
 	c.Check(svcFiles, HasLen, 0)
 
 	info := snaptest.MockSnap(c, packageHello+`
-  svc2:
-   daemon: potato
- `, &snap.SideInfo{Revision: snap.R(12)})
+ svc2:
+  daemon: potato
+`, &snap.SideInfo{Revision: snap.R(12)})
 
 	err := wrappers.AddSnapServices(info, nil, progress.Null)
 	c.Assert(err, ErrorMatches, ".*potato.*")
@@ -2322,10 +2322,10 @@ func (s *servicesTestSuite) TestMultiServicesFailEnableCleanup(c *C) {
 	defer r()
 
 	info := snaptest.MockSnap(c, packageHello+`
-  svc2:
-   command: bin/hello
-   daemon: simple
- `, &snap.SideInfo{Revision: snap.R(12)})
+ svc2:
+  command: bin/hello
+  daemon: simple
+`, &snap.SideInfo{Revision: snap.R(12)})
 
 	err := wrappers.AddSnapServices(info, nil, progress.Null)
 	c.Assert(err, IsNil)
@@ -2364,10 +2364,10 @@ func (s *servicesTestSuite) TestAddSnapMultiServicesStartFailOnSystemdReloadClea
 	defer r()
 
 	info := snaptest.MockSnap(c, packageHello+`
-  svc2:
-   command: bin/hello
-   daemon: simple
- `, &snap.SideInfo{Revision: snap.R(12)})
+ svc2:
+  command: bin/hello
+  daemon: simple
+`, &snap.SideInfo{Revision: snap.R(12)})
 
 	err := wrappers.AddSnapServices(info, nil, progress.Null)
 	c.Assert(err, ErrorMatches, "failed")
@@ -2410,15 +2410,15 @@ func (s *servicesTestSuite) TestAddSnapMultiUserServicesFailEnableCleanup(c *C) 
 	defer r()
 
 	info := snaptest.MockSnap(c, packageHelloNoSrv+`
-  svc1:
-   command: bin/hello
-   daemon: simple
-   daemon-scope: user
-  svc2:
-   command: bin/hello
-   daemon: simple
-   daemon-scope: user
- `, &snap.SideInfo{Revision: snap.R(12)})
+ svc1:
+  command: bin/hello
+  daemon: simple
+  daemon-scope: user
+ svc2:
+  command: bin/hello
+  daemon: simple
+  daemon-scope: user
+`, &snap.SideInfo{Revision: snap.R(12)})
 
 	err := wrappers.AddSnapServices(info, nil, progress.Null)
 	c.Assert(err, ErrorMatches, "cannot reload daemon: failed")
@@ -2461,15 +2461,15 @@ func (s *servicesTestSuite) TestAddSnapMultiUserServicesStartFailOnSystemdReload
 	defer r()
 
 	info := snaptest.MockSnap(c, packageHelloNoSrv+`
-  svc1:
-   command: bin/hello
-   daemon: simple
-   daemon-scope: user
-  svc2:
-   command: bin/hello
-   daemon: simple
-   daemon-scope: user
- `, &snap.SideInfo{Revision: snap.R(12)})
+ svc1:
+  command: bin/hello
+  daemon: simple
+  daemon-scope: user
+ svc2:
+  command: bin/hello
+  daemon: simple
+  daemon-scope: user
+`, &snap.SideInfo{Revision: snap.R(12)})
 
 	err := wrappers.AddSnapServices(info, nil, progress.Null)
 	c.Assert(err, ErrorMatches, "cannot reload daemon: failed")
@@ -2485,19 +2485,19 @@ func (s *servicesTestSuite) TestAddSnapMultiUserServicesStartFailOnSystemdReload
 
 func (s *servicesTestSuite) TestAddSnapSocketFiles(c *C) {
 	info := snaptest.MockSnap(c, packageHelloNoSrv+`
-  svc1:
-   daemon: simple
-   plugs: [network-bind]
-   sockets:
-	 sock1:
-	   listen-stream: $SNAP_COMMON/sock1.socket
-	   socket-mode: 0666
-	 sock2:
-	   listen-stream: $SNAP_DATA/sock2.socket
-	 sock3:
-	   listen-stream: $XDG_RUNTIME_DIR/sock3.socket
- 
- `, &snap.SideInfo{Revision: snap.R(12)})
+ svc1:
+  daemon: simple
+  plugs: [network-bind]
+  sockets:
+    sock1:
+      listen-stream: $SNAP_COMMON/sock1.socket
+      socket-mode: 0666
+    sock2:
+      listen-stream: $SNAP_DATA/sock2.socket
+    sock3:
+      listen-stream: $XDG_RUNTIME_DIR/sock3.socket
+
+`, &snap.SideInfo{Revision: snap.R(12)})
 
 	sock1File := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-snap.svc1.sock1.socket")
 	sock2File := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-snap.svc1.sock2.socket")
@@ -2508,48 +2508,48 @@ func (s *servicesTestSuite) TestAddSnapSocketFiles(c *C) {
 
 	expected := fmt.Sprintf(
 		`[Socket]
- Service=snap.hello-snap.svc1.service
- FileDescriptorName=sock1
- ListenStream=%s
- SocketMode=0666
- 
- `, filepath.Join(s.tempdir, "/var/snap/hello-snap/common/sock1.socket"))
+Service=snap.hello-snap.svc1.service
+FileDescriptorName=sock1
+ListenStream=%s
+SocketMode=0666
+
+`, filepath.Join(s.tempdir, "/var/snap/hello-snap/common/sock1.socket"))
 	c.Check(sock1File, testutil.FileContains, expected)
 
 	expected = fmt.Sprintf(
 		`[Socket]
- Service=snap.hello-snap.svc1.service
- FileDescriptorName=sock2
- ListenStream=%s
- 
- `, filepath.Join(s.tempdir, "/var/snap/hello-snap/12/sock2.socket"))
+Service=snap.hello-snap.svc1.service
+FileDescriptorName=sock2
+ListenStream=%s
+
+`, filepath.Join(s.tempdir, "/var/snap/hello-snap/12/sock2.socket"))
 	c.Check(sock2File, testutil.FileContains, expected)
 
 	expected = fmt.Sprintf(
 		`[Socket]
- Service=snap.hello-snap.svc1.service
- FileDescriptorName=sock3
- ListenStream=%s
- 
- `, filepath.Join(s.tempdir, "/run/user/0/snap.hello-snap/sock3.socket"))
+Service=snap.hello-snap.svc1.service
+FileDescriptorName=sock3
+ListenStream=%s
+
+`, filepath.Join(s.tempdir, "/run/user/0/snap.hello-snap/sock3.socket"))
 	c.Check(sock3File, testutil.FileContains, expected)
 }
 
 func (s *servicesTestSuite) TestAddSnapUserSocketFiles(c *C) {
 	info := snaptest.MockSnap(c, packageHelloNoSrv+`
-  svc1:
-   daemon: simple
-   daemon-scope: user
-   plugs: [network-bind]
-   sockets:
-	 sock1:
-	   listen-stream: $SNAP_USER_COMMON/sock1.socket
-	   socket-mode: 0666
-	 sock2:
-	   listen-stream: $SNAP_USER_DATA/sock2.socket
-	 sock3:
-	   listen-stream: $XDG_RUNTIME_DIR/sock3.socket
- `, &snap.SideInfo{Revision: snap.R(12)})
+ svc1:
+  daemon: simple
+  daemon-scope: user
+  plugs: [network-bind]
+  sockets:
+    sock1:
+      listen-stream: $SNAP_USER_COMMON/sock1.socket
+      socket-mode: 0666
+    sock2:
+      listen-stream: $SNAP_USER_DATA/sock2.socket
+    sock3:
+      listen-stream: $XDG_RUNTIME_DIR/sock3.socket
+`, &snap.SideInfo{Revision: snap.R(12)})
 
 	sock1File := filepath.Join(s.tempdir, "/etc/systemd/user/snap.hello-snap.svc1.sock1.socket")
 	sock2File := filepath.Join(s.tempdir, "/etc/systemd/user/snap.hello-snap.svc1.sock2.socket")
@@ -2559,28 +2559,28 @@ func (s *servicesTestSuite) TestAddSnapUserSocketFiles(c *C) {
 	c.Assert(err, IsNil)
 
 	expected := `[Socket]
- Service=snap.hello-snap.svc1.service
- FileDescriptorName=sock1
- ListenStream=%h/snap/hello-snap/common/sock1.socket
- SocketMode=0666
- 
- `
+Service=snap.hello-snap.svc1.service
+FileDescriptorName=sock1
+ListenStream=%h/snap/hello-snap/common/sock1.socket
+SocketMode=0666
+
+`
 	c.Check(sock1File, testutil.FileContains, expected)
 
 	expected = `[Socket]
- Service=snap.hello-snap.svc1.service
- FileDescriptorName=sock2
- ListenStream=%h/snap/hello-snap/12/sock2.socket
- 
- `
+Service=snap.hello-snap.svc1.service
+FileDescriptorName=sock2
+ListenStream=%h/snap/hello-snap/12/sock2.socket
+
+`
 	c.Check(sock2File, testutil.FileContains, expected)
 
 	expected = `[Socket]
- Service=snap.hello-snap.svc1.service
- FileDescriptorName=sock3
- ListenStream=%t/snap.hello-snap/sock3.socket
- 
- `
+Service=snap.hello-snap.svc1.service
+FileDescriptorName=sock3
+ListenStream=%t/snap.hello-snap/sock3.socket
+
+`
 	c.Check(sock3File, testutil.FileContains, expected)
 }
 
@@ -2602,10 +2602,10 @@ func (s *servicesTestSuite) TestStartSnapMultiServicesFailStartCleanup(c *C) {
 	defer r()
 
 	info := snaptest.MockSnap(c, packageHello+`
-  svc2:
-   command: bin/hello
-   daemon: simple
- `, &snap.SideInfo{Revision: snap.R(12)})
+ svc2:
+  command: bin/hello
+  daemon: simple
+`, &snap.SideInfo{Revision: snap.R(12)})
 
 	svcs := info.Services()
 	c.Assert(svcs, HasLen, 2)
@@ -2649,21 +2649,21 @@ func (s *servicesTestSuite) TestStartSnapMultiServicesFailStartCleanupWithSocket
 	defer r()
 
 	info := snaptest.MockSnap(c, packageHello+`
-  svc2:
-   command: bin/hello
-   daemon: simple
-   sockets:
-	 sock1:
-	   listen-stream: $SNAP_COMMON/sock1.socket
-	   socket-mode: 0666
-  svc3:
-   command: bin/hello
-   daemon: simple
-   sockets:
-	 sock1:
-	   listen-stream: $SNAP_COMMON/sock1.socket
-	   socket-mode: 0666
- `, &snap.SideInfo{Revision: snap.R(12)})
+ svc2:
+  command: bin/hello
+  daemon: simple
+  sockets:
+    sock1:
+      listen-stream: $SNAP_COMMON/sock1.socket
+      socket-mode: 0666
+ svc3:
+  command: bin/hello
+  daemon: simple
+  sockets:
+    sock1:
+      listen-stream: $SNAP_COMMON/sock1.socket
+      socket-mode: 0666
+`, &snap.SideInfo{Revision: snap.R(12)})
 
 	// ensure desired order
 	apps := []*snap.AppInfo{info.Apps["svc1"], info.Apps["svc2"], info.Apps["svc3"]}
@@ -2777,15 +2777,15 @@ func (s *servicesTestSuite) TestStartSnapMultiUserServicesFailStartCleanup(c *C)
 	defer r()
 
 	info := snaptest.MockSnap(c, packageHelloNoSrv+`
-  svc1:
-   command: bin/hello
-   daemon: simple
-   daemon-scope: user
-  svc2:
-   command: bin/hello
-   daemon: simple
-   daemon-scope: user
- `, &snap.SideInfo{Revision: snap.R(12)})
+ svc1:
+  command: bin/hello
+  daemon: simple
+  daemon-scope: user
+ svc2:
+  command: bin/hello
+  daemon: simple
+  daemon-scope: user
+`, &snap.SideInfo{Revision: snap.R(12)})
 
 	svcs := info.Services()
 	c.Assert(svcs, HasLen, 2)
@@ -2825,17 +2825,17 @@ func (s *servicesTestSuite) TestStartSnapServicesKeepsOrder(c *C) {
 	defer r()
 
 	info := snaptest.MockSnap(c, `name: services-snap
- apps:
-   svc1:
-	 daemon: simple
-	 before: [svc3]
-   svc2:
-	 daemon: simple
-	 after: [svc1]
-   svc3:
-	 daemon: simple
-	 before: [svc2]
- `, &snap.SideInfo{Revision: snap.R(12)})
+apps:
+  svc1:
+    daemon: simple
+    before: [svc3]
+  svc2:
+    daemon: simple
+    after: [svc1]
+  svc3:
+    daemon: simple
+    before: [svc2]
+`, &snap.SideInfo{Revision: snap.R(12)})
 
 	svcs := info.Services()
 	c.Assert(svcs, HasLen, 3)
@@ -2871,20 +2871,20 @@ func (s *servicesTestSuite) TestStartSnapServicesKeepsOrder(c *C) {
 
 func (s *servicesTestSuite) TestServiceAfterBefore(c *C) {
 	snapYaml := packageHello + `
-  svc2:
-	daemon: forking
-	after: [svc1]
-  svc3:
-	daemon: forking
-	before: [svc4]
-	after:  [svc2]
-  svc4:
-	daemon: forking
-	after:
-	  - svc1
-	  - svc2
-	  - svc3
- `
+ svc2:
+   daemon: forking
+   after: [svc1]
+ svc3:
+   daemon: forking
+   before: [svc4]
+   after:  [svc2]
+ svc4:
+   daemon: forking
+   after:
+     - svc1
+     - svc2
+     - svc3
+`
 	info := snaptest.MockSnap(c, snapYaml, &snap.SideInfo{Revision: snap.R(12)})
 
 	checks := []struct {
@@ -2938,15 +2938,15 @@ func (s *servicesTestSuite) TestServiceAfterBefore(c *C) {
 
 func (s *servicesTestSuite) TestServiceWatchdog(c *C) {
 	snapYaml := packageHello + `
-  svc2:
-	daemon: forking
-	watchdog-timeout: 12s
-  svc3:
-	daemon: forking
-	watchdog-timeout: 0s
-  svc4:
-	daemon: forking
- `
+ svc2:
+   daemon: forking
+   watchdog-timeout: 12s
+ svc3:
+   daemon: forking
+   watchdog-timeout: 0s
+ svc4:
+   daemon: forking
+`
 	info := snaptest.MockSnap(c, snapYaml, &snap.SideInfo{Revision: snap.R(12)})
 
 	err := wrappers.AddSnapServices(info, nil, progress.Null)
@@ -2969,13 +2969,13 @@ func (s *servicesTestSuite) TestServiceWatchdog(c *C) {
 
 func (s *servicesTestSuite) TestStopServiceEndure(c *C) {
 	const surviveYaml = `name: survive-snap
- version: 1.0
- apps:
-  survivor:
-   command: bin/survivor
-   refresh-mode: endure
-   daemon: simple
- `
+version: 1.0
+apps:
+ survivor:
+  command: bin/survivor
+  refresh-mode: endure
+  daemon: simple
+`
 	info := snaptest.MockSnap(c, surviveYaml, &snap.SideInfo{Revision: snap.R(1)})
 	survivorFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.survive-snap.survivor.service")
 
@@ -3031,13 +3031,13 @@ func (s *servicesTestSuite) TestStopServiceSigs(c *C) {
 		{mode: "sigusr2-all", expectedSig: "USR2", expectedWho: "all"},
 	} {
 		surviveYaml := fmt.Sprintf(`name: survive-snap
- version: 1.0
- apps:
-  srv:
-   command: bin/survivor
-   stop-mode: %s
-   daemon: simple
- `, t.mode)
+version: 1.0
+apps:
+ srv:
+  command: bin/survivor
+  stop-mode: %s
+  daemon: simple
+`, t.mode)
 		info := snaptest.MockSnap(c, surviveYaml, &snap.SideInfo{Revision: snap.R(1)})
 
 		s.sysdLog = nil
@@ -3099,20 +3099,20 @@ func (s *servicesTestSuite) TestStartSnapSocketEnableStart(c *C) {
 	svc3Sock := "snap.hello-snap.svc3.sock.socket"
 
 	info := snaptest.MockSnap(c, packageHello+`
-  svc2:
-   command: bin/hello
-   daemon: simple
-   sockets:
-	 sock:
-	   listen-stream: $SNAP_COMMON/sock1.socket
-  svc3:
-   command: bin/hello
-   daemon: simple
-   daemon-scope: user
-   sockets:
-	 sock:
-	   listen-stream: $SNAP_USER_COMMON/sock1.socket
- `, &snap.SideInfo{Revision: snap.R(12)})
+ svc2:
+  command: bin/hello
+  daemon: simple
+  sockets:
+    sock:
+      listen-stream: $SNAP_COMMON/sock1.socket
+ svc3:
+  command: bin/hello
+  daemon: simple
+  daemon-scope: user
+  sockets:
+    sock:
+      listen-stream: $SNAP_USER_COMMON/sock1.socket
+`, &snap.SideInfo{Revision: snap.R(12)})
 
 	// fix the apps order to make the test stable
 	apps := []*snap.AppInfo{info.Apps["svc1"], info.Apps["svc2"], info.Apps["svc3"]}
@@ -3136,16 +3136,16 @@ func (s *servicesTestSuite) TestStartSnapTimerEnableStart(c *C) {
 	svc3Timer := "snap.hello-snap.svc3.timer"
 
 	info := snaptest.MockSnap(c, packageHello+`
-  svc2:
-   command: bin/hello
-   daemon: simple
-   timer: 10:00-12:00
-  svc3:
-   command: bin/hello
-   daemon: simple
-   daemon-scope: user
-   timer: 10:00-12:00
- `, &snap.SideInfo{Revision: snap.R(12)})
+ svc2:
+  command: bin/hello
+  daemon: simple
+  timer: 10:00-12:00
+ svc3:
+  command: bin/hello
+  daemon: simple
+  daemon-scope: user
+  timer: 10:00-12:00
+`, &snap.SideInfo{Revision: snap.R(12)})
 
 	// fix the apps order to make the test stable
 	apps := []*snap.AppInfo{info.Apps["svc1"], info.Apps["svc2"], info.Apps["svc3"]}
@@ -3178,11 +3178,11 @@ func (s *servicesTestSuite) TestStartSnapTimerCleanup(c *C) {
 	defer r()
 
 	info := snaptest.MockSnap(c, packageHello+`
-  svc2:
-   command: bin/hello
-   daemon: simple
-   timer: 10:00-12:00
- `, &snap.SideInfo{Revision: snap.R(12)})
+ svc2:
+  command: bin/hello
+  daemon: simple
+  timer: 10:00-12:00
+`, &snap.SideInfo{Revision: snap.R(12)})
 
 	// fix the apps order to make the test stable
 	apps := []*snap.AppInfo{info.Apps["svc1"], info.Apps["svc2"]}
@@ -3205,11 +3205,11 @@ func (s *servicesTestSuite) TestStartSnapTimerCleanup(c *C) {
 
 func (s *servicesTestSuite) TestAddRemoveSnapWithTimersAddsRemovesTimerFiles(c *C) {
 	info := snaptest.MockSnap(c, packageHello+`
-  svc2:
-   command: bin/hello
-   daemon: simple
-   timer: 10:00-12:00
- `, &snap.SideInfo{Revision: snap.R(12)})
+ svc2:
+  command: bin/hello
+  daemon: simple
+  timer: 10:00-12:00
+`, &snap.SideInfo{Revision: snap.R(12)})
 
 	err := wrappers.AddSnapServices(info, nil, progress.Null)
 	c.Assert(err, IsNil)
@@ -3232,19 +3232,19 @@ func (s *servicesTestSuite) TestAddRemoveSnapWithTimersAddsRemovesTimerFiles(c *
 
 func (s *servicesTestSuite) TestFailedAddSnapCleansUp(c *C) {
 	info := snaptest.MockSnap(c, packageHello+`
-  svc2:
-   command: bin/hello
-   daemon: simple
-   timer: 10:00-12:00
-  svc3:
-   command: bin/hello
-   daemon: simple
-   plugs: [network-bind]
-   sockets:
-	 sock1:
-	   listen-stream: $SNAP_COMMON/sock1.socket
-	   socket-mode: 0666
- `, &snap.SideInfo{Revision: snap.R(12)})
+ svc2:
+  command: bin/hello
+  daemon: simple
+  timer: 10:00-12:00
+ svc3:
+  command: bin/hello
+  daemon: simple
+  plugs: [network-bind]
+  sockets:
+    sock1:
+      listen-stream: $SNAP_COMMON/sock1.socket
+      socket-mode: 0666
+`, &snap.SideInfo{Revision: snap.R(12)})
 
 	calls := 0
 	r := systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
@@ -3269,34 +3269,34 @@ func (s *servicesTestSuite) TestFailedAddSnapCleansUp(c *C) {
 
 func (s *servicesTestSuite) TestAddServicesDidReload(c *C) {
 	const base = `name: hello-snap
- version: 1.10
- summary: hello
- description: Hello...
- apps:
- `
+version: 1.10
+summary: hello
+description: Hello...
+apps:
+`
 	onlyServices := snaptest.MockSnap(c, base+`
-  svc1:
-   command: bin/hello
-   daemon: simple
- `, &snap.SideInfo{Revision: snap.R(12)})
+ svc1:
+  command: bin/hello
+  daemon: simple
+`, &snap.SideInfo{Revision: snap.R(12)})
 
 	onlySockets := snaptest.MockSnap(c, base+`
-  svc1:
-   command: bin/hello
-   daemon: simple
-   plugs: [network-bind]
-   sockets:
-	 sock1:
-	   listen-stream: $SNAP_COMMON/sock1.socket
-	   socket-mode: 0666
- `, &snap.SideInfo{Revision: snap.R(12)})
+ svc1:
+  command: bin/hello
+  daemon: simple
+  plugs: [network-bind]
+  sockets:
+    sock1:
+      listen-stream: $SNAP_COMMON/sock1.socket
+      socket-mode: 0666
+`, &snap.SideInfo{Revision: snap.R(12)})
 
 	onlyTimers := snaptest.MockSnap(c, base+`
-  svc1:
-   command: bin/hello
-   daemon: oneshot
-   timer: 10:00-12:00
- `, &snap.SideInfo{Revision: snap.R(12)})
+ svc1:
+  command: bin/hello
+  daemon: oneshot
+  timer: 10:00-12:00
+`, &snap.SideInfo{Revision: snap.R(12)})
 
 	for i, info := range []*snap.Info{onlyServices, onlySockets, onlyTimers} {
 		s.sysdLog = nil
@@ -3315,26 +3315,26 @@ func (s *servicesTestSuite) TestAddServicesDidReload(c *C) {
 
 func (s *servicesTestSuite) TestSnapServicesActivation(c *C) {
 	const snapYaml = `name: hello-snap
- version: 1.10
- summary: hello
- description: Hello...
- apps:
-  svc1:
-   command: bin/hello
-   daemon: simple
-   plugs: [network-bind]
-   sockets:
-	 sock1:
-	   listen-stream: $SNAP_COMMON/sock1.socket
-	   socket-mode: 0666
-  svc2:
-   command: bin/hello
-   daemon: oneshot
-   timer: 10:00-12:00
-  svc3:
-   command: bin/hello
-   daemon: simple
- `
+version: 1.10
+summary: hello
+description: Hello...
+apps:
+ svc1:
+  command: bin/hello
+  daemon: simple
+  plugs: [network-bind]
+  sockets:
+    sock1:
+      listen-stream: $SNAP_COMMON/sock1.socket
+      socket-mode: 0666
+ svc2:
+  command: bin/hello
+  daemon: oneshot
+  timer: 10:00-12:00
+ svc3:
+  command: bin/hello
+  daemon: simple
+`
 	svc1Socket := "snap.hello-snap.svc1.sock1.socket"
 	svc2Timer := "snap.hello-snap.svc2.timer"
 	svc3Name := "snap.hello-snap.svc3.service"
@@ -3365,12 +3365,12 @@ func (s *servicesTestSuite) TestSnapServicesActivation(c *C) {
 
 func (s *servicesTestSuite) TestServiceRestartDelay(c *C) {
 	snapYaml := packageHello + `
-  svc2:
-	daemon: forking
-	restart-delay: 12s
-  svc3:
-	daemon: forking
- `
+ svc2:
+   daemon: forking
+   restart-delay: 12s
+ svc3:
+   daemon: forking
+`
 	info := snaptest.MockSnap(c, snapYaml, &snap.SideInfo{Revision: snap.R(12)})
 
 	err := wrappers.AddSnapServices(info, nil, progress.Null)
@@ -3397,12 +3397,12 @@ func (s *servicesTestSuite) TestAddRemoveSnapServiceWithSnapd(c *C) {
 
 func (s *servicesTestSuite) TestReloadOrRestart(c *C) {
 	const surviveYaml = `name: test-snap
- version: 1.0
- apps:
-   foo:
-	 command: bin/foo
-	 daemon: simple
- `
+version: 1.0
+apps:
+  foo:
+    command: bin/foo
+    daemon: simple
+`
 	info := snaptest.MockSnap(c, surviveYaml, &snap.SideInfo{Revision: snap.R(1)})
 	srvFile := "snap.test-snap.foo.service"
 
@@ -3449,21 +3449,21 @@ func (s *servicesTestSuite) TestReloadOrRestart(c *C) {
 
 func (s *servicesTestSuite) TestRestartInDifferentStates(c *C) {
 	const manyServicesYaml = `name: test-snap
- version: 1.0
- apps:
-   svc1:
-	 command: bin/foo
-	 daemon: simple
-   svc2:
-	 command: bin/foo
-	 daemon: simple
-   svc3:
-	 command: bin/foo
-	 daemon: simple
-   svc4:
-	 command: bin/foo
-	 daemon: simple
- `
+version: 1.0
+apps:
+  svc1:
+    command: bin/foo
+    daemon: simple
+  svc2:
+    command: bin/foo
+    daemon: simple
+  svc3:
+    command: bin/foo
+    daemon: simple
+  svc4:
+    command: bin/foo
+    daemon: simple
+`
 	srvFile1 := "snap.test-snap.svc1.service"
 	srvFile2 := "snap.test-snap.svc2.service"
 	srvFile3 := "snap.test-snap.svc3.service"
@@ -3525,9 +3525,9 @@ func (s *servicesTestSuite) TestRestartInDifferentStates(c *C) {
 
 func (s *servicesTestSuite) TestStopAndDisableServices(c *C) {
 	info := snaptest.MockSnap(c, packageHelloNoSrv+`
-  svc1:
-   daemon: simple
- `, &snap.SideInfo{Revision: snap.R(12)})
+ svc1:
+  daemon: simple
+`, &snap.SideInfo{Revision: snap.R(12)})
 	svcFile := "snap.hello-snap.svc1.service"
 
 	err := wrappers.AddSnapServices(info, nil, progress.Null)

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -219,7 +219,13 @@ func (s *servicesTestSuite) TestEnsureSnapServicesWithQuotas(c *C) {
 	svcFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-snap.svc1.service")
 
 	// set up arbitrary quotas for the group to test they get written correctly to the slice
-	resourceLimits := quota.NewResources(quantity.SizeGiB, 2, 50, []int{0, 1}, 32)
+	resourceLimits := quota.NewResourcesBuilder().
+		WithMemoryLimit(quantity.SizeGiB).
+		WithCPUCount(2).
+		WithCPUPercentage(50).
+		WithAllowedCPUs([]int{0, 1}).
+		WithThreadLimit(32).
+		Build()
 	grp, err := quota.NewGroup("foogroup", resourceLimits)
 	c.Assert(err, IsNil)
 
@@ -433,7 +439,7 @@ WantedBy=multi-user.target
 	c.Assert(err, IsNil)
 
 	// use new memory limit
-	resourceLimits := quota.NewResources(memLimit2, 0, 0, nil, 0)
+	resourceLimits := quota.NewResourcesBuilder().WithMemoryLimit(memLimit2).Build()
 	grp, err := quota.NewGroup("foogroup", resourceLimits)
 	c.Assert(err, IsNil)
 
@@ -530,7 +536,7 @@ WantedBy=multi-user.target
 	err = ioutil.WriteFile(svcFile, []byte(svcContent), 0644)
 	c.Assert(err, IsNil)
 
-	resourceLimits := quota.NewResources(memLimit, 0, 0, nil, taskLimit)
+	resourceLimits := quota.NewResourcesBuilder().WithMemoryLimit(memLimit).WithThreadLimit(taskLimit).Build()
 	grp, err := quota.NewGroup("foogroup", resourceLimits)
 	c.Assert(err, IsNil)
 
@@ -554,7 +560,7 @@ WantedBy=multi-user.target
 
 func (s *servicesTestSuite) TestRemoveQuotaGroup(c *C) {
 	// create the group
-	resourceLimits := quota.NewResources(5*quantity.SizeKiB, 0, 0, nil, 0)
+	resourceLimits := quota.NewResourcesBuilder().WithMemoryLimit(5 * quantity.SizeKiB).Build()
 	grp, err := quota.NewGroup("foogroup", resourceLimits)
 	c.Assert(err, IsNil)
 
@@ -623,7 +629,11 @@ apps:
 	svcFile2 := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-other-snap.svc1.service")
 
 	var err error
-	resourceLimits := quota.NewResources(quantity.SizeGiB, 4, 25, nil, 0)
+	resourceLimits := quota.NewResourcesBuilder().
+		WithMemoryLimit(quantity.SizeGiB).
+		WithCPUCount(4).
+		WithCPUPercentage(25).
+		Build()
 	// make a root quota group and add the first snap to it
 	grp, err := quota.NewGroup("foogroup", resourceLimits)
 	c.Assert(err, IsNil)
@@ -760,7 +770,10 @@ func (s *servicesTestSuite) TestEnsureSnapServicesWithSubGroupQuotaGroupsGenerat
 	svcFile1 := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-snap.svc1.service")
 
 	var err error
-	resourceLimits := quota.NewResources(quantity.SizeGiB, 0, 0, []int{0}, 0)
+	resourceLimits := quota.NewResourcesBuilder().
+		WithMemoryLimit(quantity.SizeGiB).
+		WithAllowedCPUs([]int{0}).
+		Build()
 	// make a root quota group without any snaps in it
 	grp, err := quota.NewGroup("foogroup", resourceLimits)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
This is the third PR for cpu-quota support in snaps, see the first two PRs which handles the initial refactoring #11247 and removal of nesting #11303. Quota groups now also support the following values:

- cpu quota: You can control the allowed cpu time through --cpu (i.e. --cpu=50% or --cpu=2x100%)
- allowed cpus quota: You can control which cpu cores the snap is allowed on through --cpu-set, this requires cgroupv2 support
- max threads quota: You can control the number of threads/processes a snap is allowed to run through --thread

The spec for the feature is located [here - Google Docs](https://docs.google.com/document/u/1/d/1tQKyThDOr0ajM6JR1J-dbxuRKRVLYF7PmLb5V7iWK64)

Example of running the Quota: https://pastebin.com/XCWm9uHv