### PR TITLE
packaging,tests: fix running autopkgtest

### DIFF
--- a/packaging/ubuntu-16.04/tests/integrationtests
+++ b/packaging/ubuntu-16.04/tests/integrationtests
@@ -74,6 +74,9 @@ backends:
         - adt-local:
             username: ubuntu
             password: ubuntu
+prepare: |
+    # Copy external tools from the subtree to the "$TESTSLIB"/tools directory
+    cp -f "$TESTSLIB"/external/snapd-testing-tools/tools/* "$TESTSTOOLS"
 suites:
         tests/smoke/:
             summary: Essenial system level tests for snapd

--- a/tests/lib/tools/not
+++ b/tests/lib/tools/not
@@ -1,3 +1,5 @@
 # This is a placeholder for the tool which is copied from snapd-testing-tools project
 # The tool is copied from the tests/lib/external/snapd-testing-tools/tools directory
 # while the project is being prepared
+echo "placeholder called, source tree not properly setup"
+exit 1

--- a/tests/lib/tools/os.query
+++ b/tests/lib/tools/os.query
@@ -1,3 +1,5 @@
 # This is a placeholder for the tool which is copied from snapd-testing-tools project
 # The tool is copied from the tests/lib/external/snapd-testing-tools/tools directory
 # while the project is being prepared
+echo "placeholder called, source tree not properly setup"
+exit 1

--- a/tests/lib/tools/retry
+++ b/tests/lib/tools/retry
@@ -1,3 +1,5 @@
 # This is a placeholder for the tool which is copied from snapd-testing-tools project
 # The tool is copied from the tests/lib/external/snapd-testing-tools/tools directory
 # while the project is being prepared
+echo "placeholder called, source tree not properly setup"
+exit 1

--- a/tests/lib/tools/tests.backup
+++ b/tests/lib/tools/tests.backup
@@ -1,3 +1,5 @@
 # This is a placeholder for the tool which is copied from snapd-testing-tools project
 # The tool is copied from the tests/lib/external/snapd-testing-tools/tools directory
 # while the project is being prepared
+echo "placeholder called, source tree not properly setup"
+exit 1

--- a/tests/lib/tools/tests.cleanup
+++ b/tests/lib/tools/tests.cleanup
@@ -1,3 +1,5 @@
 # This is a placeholder for the tool which is copied from snapd-testing-tools project
 # The tool is copied from the tests/lib/external/snapd-testing-tools/tools directory
 # while the project is being prepared
+echo "placeholder called, source tree not properly setup"
+exit 1

--- a/tests/lib/tools/tests.pkgs
+++ b/tests/lib/tools/tests.pkgs
@@ -1,3 +1,5 @@
 # This is a placeholder for the tool which is copied from snapd-testing-tools project
 # The tool is copied from the tests/lib/external/snapd-testing-tools/tools directory
 # while the project is being prepared
+echo "placeholder called, source tree not properly setup"
+exit 1

--- a/tests/lib/tools/tests.pkgs.apt.sh
+++ b/tests/lib/tools/tests.pkgs.apt.sh
@@ -1,3 +1,5 @@
 # This is a placeholder for the tool which is copied from snapd-testing-tools project
 # The tool is copied from the tests/lib/external/snapd-testing-tools/tools directory
 # while the project is being prepared
+echo "placeholder called, source tree not properly setup"
+exit 1

--- a/tests/lib/tools/tests.pkgs.dnf-yum.sh
+++ b/tests/lib/tools/tests.pkgs.dnf-yum.sh
@@ -1,3 +1,6 @@
 # This is a placeholder for the tool which is copied from snapd-testing-tools project
 # The tool is copied from the tests/lib/external/snapd-testing-tools/tools directory
 # while the project is being prepared
+echo "placeholder called, source tree not properly setup"
+exit 1
+

--- a/tests/lib/tools/tests.pkgs.pacman.sh
+++ b/tests/lib/tools/tests.pkgs.pacman.sh
@@ -1,3 +1,5 @@
 # This is a placeholder for the tool which is copied from snapd-testing-tools project
 # The tool is copied from the tests/lib/external/snapd-testing-tools/tools directory
 # while the project is being prepared
+echo "placeholder called, source tree not properly setup"
+exit 1

--- a/tests/lib/tools/tests.pkgs.zypper.sh
+++ b/tests/lib/tools/tests.pkgs.zypper.sh
@@ -1,3 +1,5 @@
 # This is a placeholder for the tool which is copied from snapd-testing-tools project
 # The tool is copied from the tests/lib/external/snapd-testing-tools/tools directory
 # while the project is being prepared
+echo "placeholder called, source tree not properly setup"
+exit 1


### PR DESCRIPTION
The autopkgtest spread setup did not include the new external test
tools. This caused misleading errors during autopkgtest runs.

Also changes the placeholder tools to throw errors if they are
called to make clear what is happening.

This was tested with:
```
$ autopkgtest -s -U   -- qemu ~/VM/ubuntu-20.04-64.img
```
but I'm looking into how to also test it from spread to ensure
we do not run into this again. If feasible I will push a separate
PR on top of this one.