### PR TITLE
spread-shellcheck: use safe_load rather than load with a loder

### DIFF
--- a/spread-shellcheck
+++ b/spread-shellcheck
@@ -141,7 +141,7 @@ def checksection(data, env: Dict[str, str]):
 def checkfile(path, executor):
     logging.debug("checking file %s", path)
     with open(path) as inf:
-        data = yaml.load(inf, Loader=yaml.CSafeLoader)
+        data = yaml.safe_load(inf)
 
     errors = ShellcheckError(path)
     # TODO: handle stacking of environment from other places that influence it:


### PR DESCRIPTION
Recent PyYAML made CSafeLoader a default, so for compatibility with older
version which still required CSafeLoader, use safe_load() explicitly which does
the right thing.

