### PR TITLE
many: unit test fix when SNAPD_DEBUG=1 is set

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -202,6 +202,11 @@ jobs:
       run: |
         cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
         ./run-checks --unit
+    - name: Test Go (SNAPD_DEBUG=1)
+      if: steps.cached-results.outputs.already-ran != 'true'
+      run: |
+        cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
+        SKIP_DIRTY_CHECK=1 SNAPD_DEBUG=1 ./run-checks --unit
     - name: Test Go (withbootassetstesting)
       if: steps.cached-results.outputs.already-ran != 'true'
       run: |

--- a/bootloader/lkenv/lkenv_test.go
+++ b/bootloader/lkenv/lkenv_test.go
@@ -44,6 +44,8 @@ import (
 func Test(t *testing.T) { TestingT(t) }
 
 type lkenvTestSuite struct {
+	testutil.BaseTest
+
 	envPath    string
 	envPathbak string
 }
@@ -59,6 +61,7 @@ var (
 )
 
 func (l *lkenvTestSuite) SetUpTest(c *C) {
+	l.BaseTest.SetUpTest(c)
 	l.envPath = filepath.Join(c.MkDir(), "snapbootsel.bin")
 	l.envPathbak = l.envPath + "bak"
 }

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -41,11 +41,13 @@ func Test(t *testing.T) { TestingT(t) }
 var _ = Suite(&LogSuite{})
 
 type LogSuite struct {
+	testutil.BaseTest
 	logbuf        *bytes.Buffer
 	restoreLogger func()
 }
 
 func (s *LogSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
 	s.logbuf, s.restoreLogger = logger.MockLogger()
 }
 

--- a/osutil/buildid_test.go
+++ b/osutil/buildid_test.go
@@ -30,15 +30,22 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/testutil"
 )
 
-type buildIDSuite struct{}
+type buildIDSuite struct {
+	testutil.BaseTest
+}
 
 var _ = Suite(&buildIDSuite{})
 
 var truePath = osutil.LookPathDefault("true", "/bin/true")
 var falsePath = osutil.LookPathDefault("false", "/bin/false")
 var gccPath = osutil.LookPathDefault("gcc", "/usr/bin/gcc")
+
+func (s *buildIDSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+}
 
 func buildID(c *C, fname string) string {
 	// XXX host's 'file' command may be too old to know about Go BuildID or

--- a/overlord/snapshotstate/backend/backend_test.go
+++ b/overlord/snapshotstate/backend/backend_test.go
@@ -54,6 +54,7 @@ import (
 )
 
 type snapshotSuite struct {
+	testutil.BaseTest
 	root      string
 	restore   []func()
 	tarPath   string
@@ -99,6 +100,7 @@ func table(si snap.PlaceInfo, homeDir string) []tableT {
 }
 
 func (s *snapshotSuite) SetUpTest(c *check.C) {
+	s.BaseTest.SetUpTest(c)
 	s.root = c.MkDir()
 
 	dirs.SetRootDir(s.root)

--- a/overlord/state/taskrunner_test.go
+++ b/overlord/state/taskrunner_test.go
@@ -36,7 +36,9 @@ import (
 	"github.com/snapcore/snapd/testutil"
 )
 
-type taskRunnerSuite struct{}
+type taskRunnerSuite struct {
+	testutil.BaseTest
+}
 
 var _ = Suite(&taskRunnerSuite{})
 
@@ -140,6 +142,10 @@ var sequenceTests = []struct{ setup, result string }{{
 	setup:  "t11:was-done:1 t12:was-done:2 t21:was-done:2 t31:was-done:2 t32:do-error:2",
 	result: "t31:undo t32:do t32:do-error t21:undo",
 }}
+
+func (ts *taskRunnerSuite) SetUpTest(c *C) {
+	ts.BaseTest.SetUpTest(c)
+}
 
 func (ts *taskRunnerSuite) TestSequenceTests(c *C) {
 	sb := &stateBackend{}

--- a/testutil/base.go
+++ b/testutil/base.go
@@ -20,6 +20,8 @@
 package testutil
 
 import (
+	"os"
+
 	"gopkg.in/check.v1"
 )
 
@@ -34,6 +36,11 @@ func (s *BaseTest) SetUpTest(c *check.C) {
 	if len(s.cleanupHandlers) != 0 {
 		panic("BaseTest cleanup handlers were not consumed before a new test start, missing BaseTest.TearDownTest call?")
 	}
+
+	// When unit tests are called with SNAPD_DEBUG=1, we tend to get some failures due to the
+	// mismatch in the expected output and actual output. Instead of doing an unset SNAPD_DEBUG
+	// in all those cases, adding it in here - a common test helper function to be called by inidividual unit tests.
+	os.Unsetenv("SNAPD_DEBUG")
 }
 
 // TearDownTest cleans up the channel.ini files in case they were changed by


### PR DESCRIPTION
Minor changes ensuring unset SNAPD_DEBG to avoid test failures when run with SNAPD_DEBUG=1
