### PR TITLE
tests/nested/manual/minimal-smoke: bump mem to 512 for unencrypted case too

### DIFF
--- a/tests/nested/manual/minimal-smoke/task.yaml
+++ b/tests/nested/manual/minimal-smoke/task.yaml
@@ -23,7 +23,8 @@ execute: |
         if tests.nested is-enabled secboot; then
             MINIMAL_MEM=512
         else
-            MINIMAL_MEM=384
+            # TODO: this used to be 384, investigate why this has increased
+            MINIMAL_MEM=512
         fi
         NESTED_SPREAD_SYSTEM=ubuntu-core-20-64
     elif tests.nested is-nested uc18; then


### PR DESCRIPTION
This needs more investigation, but for now to get test coverage again, bump it
to 512M.

See also https://bugs.launchpad.net/snapd/+bug/1954545