### PR TITLE
cmd/snap: adjust /cmd to migration changes 

### DIFF
--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -1,6 +1,6 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 /*
- * Copyright (C) 2014-2018 Canonical Ltd
+ * Copyright (C) 2014-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -20,6 +20,8 @@ package main
 
 import (
 	"bufio"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -1022,7 +1024,12 @@ func (x *cmdRun) runSnapConfine(info *snap.Info, securityTag, snapApp, hook stri
 		return fmt.Errorf(i18n.G("missing snap-confine: try updating your core/snapd package"))
 	}
 
-	opts := getSnapDirOptions()
+	snapName, _ := snap.SplitSnapApp(snapApp)
+	opts, err := getSnapDirOptions(snapName)
+	if err != nil {
+		return fmt.Errorf("cannot get snap dir options: %w", err)
+	}
+
 	if err := createUserDataDirs(info, opts); err != nil {
 		logger.Noticef("WARNING: cannot create user data directory: %s", err)
 	}
@@ -1229,11 +1236,25 @@ func (x *cmdRun) runSnapConfine(info *snap.Info, securityTag, snapApp, hook stri
 	}
 }
 
-// TODO: add migration status based on seq file info
-func getSnapDirOptions() *dirs.SnapDirOptions {
-	return &dirs.SnapDirOptions{
-		HiddenSnapDataDir: features.HiddenSnapDataHomeDir.IsEnabled(),
+func getSnapDirOptions(snap string) (*dirs.SnapDirOptions, error) {
+	var opts dirs.SnapDirOptions
+
+	data, err := ioutil.ReadFile(filepath.Join(dirs.SnapSeqDir, snap+".json"))
+	if errors.Is(err, os.ErrNotExist) {
+		return &opts, nil
+	} else if err != nil {
+		return nil, err
 	}
+
+	var seq struct {
+		MigratedToHiddenDir bool `json:"migrated-hidden"`
+	}
+	if err := json.Unmarshal(data, &seq); err != nil {
+		return nil, err
+	}
+
+	opts.HiddenSnapDataDir = seq.MigratedToHiddenDir
+	return &opts, nil
 }
 
 var cgroupCreateTransientScopeForTracking = cgroup.CreateTransientScopeForTracking

--- a/cmd/snap/cmd_userd.go
+++ b/cmd/snap/cmd_userd.go
@@ -3,7 +3,7 @@
 // +build !darwin
 
 /*
- * Copyright (C) 2017-2019 Canonical Ltd
+ * Copyright (C) 2017-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -25,17 +25,22 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	"github.com/jessevdk/go-flags"
 
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snapdtool"
 	"github.com/snapcore/snapd/usersession/agent"
 	"github.com/snapcore/snapd/usersession/autostart"
 	"github.com/snapcore/snapd/usersession/userd"
 )
+
+var autostartSessionApps = autostart.AutostartSessionApps
 
 type cmdUserd struct {
 	Autostart bool `long:"autostart"`
@@ -88,20 +93,21 @@ func (x *cmdUserd) Execute(args []string) error {
 	}
 
 	if x.Autostart {
-		// TODO: adapt this to look for snaps in both ~/.snap/data and ~/snap
-		// get the user's snap dir ($HOME/snap or $HOME/.snap/data)
-		usrSnapDir, err := getUserSnapDir()
+		// there may be two snap dirs (~/snap and ~/.snap/data)
+		usrSnapDirs, err := getUserSnapDirs()
 		if err != nil {
 			return err
 		}
 
-		// autostart is called when starting the graphical session, use that as
-		// an opportunity to fix ~/snap permission bits
-		if err := maybeFixupUsrSnapPermissions(usrSnapDir); err != nil {
-			fmt.Fprintf(Stderr, "failure fixing ~/snap permissions: %v\n", err)
+		for _, usrSnapDir := range usrSnapDirs {
+			// autostart is called when starting the graphical session, use that as
+			// an opportunity to fix snap dir permission bits
+			if err := maybeFixupUsrSnapPermissions(usrSnapDir); err != nil {
+				fmt.Fprintf(Stderr, "failure fixing %s permissions: %v\n", usrSnapDir, err)
+			}
 		}
 
-		return x.runAutostart(usrSnapDir)
+		return x.runAutostart(usrSnapDirs)
 	}
 
 	if x.Agent {
@@ -154,10 +160,20 @@ func (x *cmdUserd) runAgent() error {
 	return agent.Stop()
 }
 
-func (x *cmdUserd) runAutostart(usrSnapDir string) error {
-	if err := autostart.AutostartSessionApps(usrSnapDir); err != nil {
-		return fmt.Errorf("autostart failed for the following apps:\n%v", err)
+func (x *cmdUserd) runAutostart(usrSnapDirs []string) error {
+	var sb strings.Builder
+	for _, usrSnapDir := range usrSnapDirs {
+		if err := autostartSessionApps(usrSnapDir); err != nil {
+			// try to run autostart for others
+			sb.WriteString(err.Error())
+			sb.WriteRune('\n')
+		}
 	}
+
+	if sb.Len() > 0 {
+		return fmt.Errorf("autostart failed:\n%s", sb.String())
+	}
+
 	return nil
 }
 
@@ -168,12 +184,23 @@ func signalNotifyImpl(sig ...os.Signal) (ch chan os.Signal, stop func()) {
 	return ch, stop
 }
 
-func getUserSnapDir() (string, error) {
+func getUserSnapDirs() ([]string, error) {
 	usr, err := userCurrent()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	opts := getSnapDirOptions()
-	return snap.SnapDir(usr.HomeDir, opts), nil
+	var snapDirsInUse []string
+	exposedSnapDir := snap.SnapDir(usr.HomeDir, nil)
+	hiddenSnapDir := snap.SnapDir(usr.HomeDir, &dirs.SnapDirOptions{HiddenSnapDataDir: true})
+
+	for _, dir := range []string{exposedSnapDir, hiddenSnapDir} {
+		if exists, _, err := osutil.DirExists(dir); err != nil {
+			return nil, err
+		} else if exists {
+			snapDirsInUse = append(snapDirsInUse, dir)
+		}
+	}
+
+	return snapDirsInUse, nil
 }

--- a/cmd/snap/cmd_userd_test.go
+++ b/cmd/snap/cmd_userd_test.go
@@ -3,7 +3,7 @@
 // +build !darwin
 
 /*
- * Copyright (C) 2016-2019 Canonical Ltd
+ * Copyright (C) 2016-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -232,6 +232,8 @@ func (s *userdSuite) TestAutostartSessionAppsRestrictsPermissions(c *C) {
 
 func (s *userdSuite) TestAutostartSessionAppsLogsWhenItCannotRestrictPermissions(c *C) {
 	userDir := path.Join(c.MkDir(), "home")
+	c.Assert(os.MkdirAll(filepath.Join(userDir, "snap"), 0770), IsNil)
+
 	mockUserCurrent := func() (*user.User, error) {
 		return &user.User{HomeDir: userDir}, nil
 	}
@@ -278,4 +280,58 @@ func (s *userdSuite) TestAutostartSessionAppsRestrictsPermissionsNoCreateSnapDir
 
 	// make sure that the directory was not created
 	c.Assert(filepath.Join(userDir, "snap"), testutil.FileAbsent)
+}
+
+func (s *userdSuite) TestAutostartWithBothSnapDirs(c *C) {
+	userDir := path.Join(c.MkDir(), "home")
+	mockUserCurrent := func() (*user.User, error) {
+		return &user.User{HomeDir: userDir}, nil
+	}
+	r := snap.MockUserCurrent(mockUserCurrent)
+	defer r()
+
+	var autostartArgs []string
+	mockAutostart := func(arg string) error {
+		autostartArgs = append(autostartArgs, arg)
+		return nil
+	}
+	autostartRestore := snap.MockAutostartSessionApps(mockAutostart)
+	defer autostartRestore()
+
+	exposedDir := filepath.Join(userDir, "snap")
+	c.Assert(os.MkdirAll(exposedDir, 0770), IsNil)
+	hiddenDir := filepath.Join(userDir, ".snap", "data")
+	c.Assert(os.MkdirAll(hiddenDir, 0770), IsNil)
+
+	args, err := snap.Parser(snap.Client()).ParseArgs([]string{"userd", "--autostart"})
+	c.Assert(err, IsNil)
+	c.Assert(args, DeepEquals, []string{})
+
+	c.Assert(autostartArgs, testutil.DeepUnsortedMatches, []string{hiddenDir, exposedDir})
+}
+
+func (s *userdSuite) TestAutostartErrorsInBoth(c *C) {
+	userDir := path.Join(c.MkDir(), "home")
+	mockUserCurrent := func() (*user.User, error) {
+		return &user.User{HomeDir: userDir}, nil
+	}
+	r := snap.MockUserCurrent(mockUserCurrent)
+	defer r()
+
+	mockAutostart := func(arg string) error {
+		return fmt.Errorf("%s", arg)
+	}
+	autostartRestore := snap.MockAutostartSessionApps(mockAutostart)
+	defer autostartRestore()
+
+	exposedDir := filepath.Join(userDir, "snap")
+	c.Assert(os.MkdirAll(exposedDir, 0770), IsNil)
+	hiddenDir := filepath.Join(userDir, ".snap", "data")
+	c.Assert(os.MkdirAll(hiddenDir, 0770), IsNil)
+
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"userd", "--autostart"})
+	c.Assert(err, ErrorMatches, `autostart failed:
+.*/snap
+.*/\.snap/data
+`)
 }

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -443,3 +443,11 @@ func MockIsGraphicalSession(graphical bool) (restore func()) {
 		isGraphicalSession = old
 	}
 }
+
+func MockAutostartSessionApps(f func(string) error) func() {
+	old := autostartSessionApps
+	autostartSessionApps = f
+	return func() {
+		autostartSessionApps = old
+	}
+}

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -95,6 +95,8 @@ var (
 
 	GetKeypairManager = getKeypairManager
 	GenerateKey       = generateKey
+
+	GetSnapDirOptions = getSnapDirOptions
 )
 
 func HiddenCmd(descr string, completeHidden bool) *cmdInfo {


### PR DESCRIPTION
This PR adjusts the /cmd code to the migration changes. It's based on https://github.com/snapcore/snapd/pull/11169 so the only relevant commits are the last two. The first commit changes the autostart code to look for autostart files in ~/.snap/data as well as ~/snap and the second commit changes the get snap options to check the sequence file to see if the snap dir has been migrated. I'm marking this as blocked because #11169 needs to merge first but it'd be good to get a head start by getting some reviews on this as well.
