### PR TITLE
snap-bootstrap: Cleanup dependencies in systemd mounts

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -1213,10 +1213,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsInstallModeHappyRealSystemdMou
 
 	// check that all of the override files are present
 	for _, initrdUnit := range []string{
-		"initrd.target",
 		"initrd-fs.target",
-		"initrd-switch-root.target",
-		"local-fs.target",
 	} {
 		for _, mountUnit := range []string{
 			systemd.EscapeUnitNamePath(boot.InitramfsUbuntuSeedDir),
@@ -1228,8 +1225,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsInstallModeHappyRealSystemdMou
 			fname := fmt.Sprintf("snap_bootstrap_%s.conf", mountUnit)
 			unitFile := filepath.Join(dirs.GlobalRootDir, "/run/systemd/system", initrdUnit+".d", fname)
 			c.Assert(unitFile, testutil.FileEquals, fmt.Sprintf(`[Unit]
-Requires=%[1]s
-After=%[1]s
+Wants=%[1]s
 `, mountUnit+".mount"))
 		}
 	}
@@ -1245,6 +1241,8 @@ After=%[1]s
 			"--no-pager",
 			"--no-ask-password",
 			"--fsck=yes",
+			"--property=DefaultDependencies=no",
+			"--property=Before=initrd-fs.target",
 		}, {
 			"systemd-mount",
 			filepath.Join(s.seedDir, "snaps", s.snapd.Filename()),
@@ -1253,6 +1251,8 @@ After=%[1]s
 			"--no-ask-password",
 			"--fsck=no",
 			"--options=ro",
+			"--property=DefaultDependencies=no",
+			"--property=Before=initrd-fs.target",
 		}, {
 			"systemd-mount",
 			filepath.Join(s.seedDir, "snaps", s.kernel.Filename()),
@@ -1261,6 +1261,8 @@ After=%[1]s
 			"--no-ask-password",
 			"--fsck=no",
 			"--options=ro",
+			"--property=DefaultDependencies=no",
+			"--property=Before=initrd-fs.target",
 		}, {
 			"systemd-mount",
 			filepath.Join(s.seedDir, "snaps", s.core20.Filename()),
@@ -1269,6 +1271,8 @@ After=%[1]s
 			"--no-ask-password",
 			"--fsck=no",
 			"--options=ro",
+			"--property=DefaultDependencies=no",
+			"--property=Before=initrd-fs.target",
 		}, {
 			"systemd-mount",
 			"tmpfs",
@@ -1278,6 +1282,8 @@ After=%[1]s
 			"--type=tmpfs",
 			"--fsck=no",
 			"--options=nosuid",
+			"--property=DefaultDependencies=no",
+			"--property=Before=initrd-fs.target",
 		},
 	})
 }
@@ -1383,10 +1389,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeNoSaveHappyRealSyst
 
 	// check that all of the override files are present
 	for _, initrdUnit := range []string{
-		"initrd.target",
 		"initrd-fs.target",
-		"initrd-switch-root.target",
-		"local-fs.target",
 	} {
 		for _, mountUnit := range []string{
 			systemd.EscapeUnitNamePath(boot.InitramfsUbuntuSeedDir),
@@ -1399,8 +1402,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeNoSaveHappyRealSyst
 			fname := fmt.Sprintf("snap_bootstrap_%s.conf", mountUnit)
 			unitFile := filepath.Join(dirs.GlobalRootDir, "/run/systemd/system", initrdUnit+".d", fname)
 			c.Assert(unitFile, testutil.FileEquals, fmt.Sprintf(`[Unit]
-Requires=%[1]s
-After=%[1]s
+Wants=%[1]s
 `, mountUnit+".mount"))
 		}
 	}
@@ -1416,6 +1418,8 @@ After=%[1]s
 			"--no-pager",
 			"--no-ask-password",
 			"--fsck=yes",
+			"--property=DefaultDependencies=no",
+			"--property=Before=initrd-fs.target",
 		}, {
 			"systemd-mount",
 			filepath.Join(s.seedDir, "snaps", s.snapd.Filename()),
@@ -1424,6 +1428,8 @@ After=%[1]s
 			"--no-ask-password",
 			"--fsck=no",
 			"--options=ro",
+			"--property=DefaultDependencies=no",
+			"--property=Before=initrd-fs.target",
 		}, {
 			"systemd-mount",
 			filepath.Join(s.seedDir, "snaps", s.kernel.Filename()),
@@ -1432,6 +1438,8 @@ After=%[1]s
 			"--no-ask-password",
 			"--fsck=no",
 			"--options=ro",
+			"--property=DefaultDependencies=no",
+			"--property=Before=initrd-fs.target",
 		}, {
 			"systemd-mount",
 			filepath.Join(s.seedDir, "snaps", s.core20.Filename()),
@@ -1440,6 +1448,8 @@ After=%[1]s
 			"--no-ask-password",
 			"--fsck=no",
 			"--options=ro",
+			"--property=DefaultDependencies=no",
+			"--property=Before=initrd-fs.target",
 		}, {
 			"systemd-mount",
 			"tmpfs",
@@ -1449,6 +1459,8 @@ After=%[1]s
 			"--type=tmpfs",
 			"--fsck=no",
 			"--options=nosuid",
+			"--property=DefaultDependencies=no",
+			"--property=Before=initrd-fs.target",
 		}, {
 			"systemd-mount",
 			"/dev/disk/by-partuuid/ubuntu-boot-partuuid",
@@ -1456,6 +1468,8 @@ After=%[1]s
 			"--no-pager",
 			"--no-ask-password",
 			"--fsck=yes",
+			"--property=DefaultDependencies=no",
+			"--property=Before=initrd-fs.target",
 		}, {
 			"systemd-mount",
 			"/dev/disk/by-partuuid/ubuntu-data-partuuid",
@@ -1464,6 +1478,8 @@ After=%[1]s
 			"--no-ask-password",
 			"--fsck=no",
 			"--options=nosuid",
+			"--property=DefaultDependencies=no",
+			"--property=Before=initrd-fs.target",
 		},
 	})
 
@@ -1532,18 +1548,14 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRecoverModeWithSaveHappyRealSy
 
 	// check that all of the override files are present
 	for _, initrdUnit := range []string{
-		"initrd.target",
 		"initrd-fs.target",
-		"initrd-switch-root.target",
-		"local-fs.target",
 	} {
 
 		mountUnit := systemd.EscapeUnitNamePath(boot.InitramfsUbuntuSaveDir)
 		fname := fmt.Sprintf("snap_bootstrap_%s.conf", mountUnit)
 		unitFile := filepath.Join(dirs.GlobalRootDir, "/run/systemd/system", initrdUnit+".d", fname)
 		c.Assert(unitFile, testutil.FileEquals, fmt.Sprintf(`[Unit]
-Requires=%[1]s
-After=%[1]s
+Wants=%[1]s
 `, mountUnit+".mount"))
 	}
 
@@ -1565,6 +1577,8 @@ After=%[1]s
 			"--no-pager",
 			"--no-ask-password",
 			"--fsck=yes",
+			"--property=DefaultDependencies=no",
+			"--property=Before=initrd-fs.target",
 		}, {
 			"systemd-mount",
 			filepath.Join(s.seedDir, "snaps", s.snapd.Filename()),
@@ -1573,6 +1587,8 @@ After=%[1]s
 			"--no-ask-password",
 			"--fsck=no",
 			"--options=ro",
+			"--property=DefaultDependencies=no",
+			"--property=Before=initrd-fs.target",
 		}, {
 			"systemd-mount",
 			filepath.Join(s.seedDir, "snaps", s.kernel.Filename()),
@@ -1581,6 +1597,8 @@ After=%[1]s
 			"--no-ask-password",
 			"--fsck=no",
 			"--options=ro",
+			"--property=DefaultDependencies=no",
+			"--property=Before=initrd-fs.target",
 		}, {
 			"systemd-mount",
 			filepath.Join(s.seedDir, "snaps", s.core20.Filename()),
@@ -1589,6 +1607,8 @@ After=%[1]s
 			"--no-ask-password",
 			"--fsck=no",
 			"--options=ro",
+			"--property=DefaultDependencies=no",
+			"--property=Before=initrd-fs.target",
 		}, {
 			"systemd-mount",
 			"tmpfs",
@@ -1598,6 +1618,8 @@ After=%[1]s
 			"--type=tmpfs",
 			"--fsck=no",
 			"--options=nosuid",
+			"--property=DefaultDependencies=no",
+			"--property=Before=initrd-fs.target",
 		}, {
 			"systemd-mount",
 			"/dev/disk/by-partuuid/ubuntu-boot-partuuid",
@@ -1605,6 +1627,8 @@ After=%[1]s
 			"--no-pager",
 			"--no-ask-password",
 			"--fsck=yes",
+			"--property=DefaultDependencies=no",
+			"--property=Before=initrd-fs.target",
 		}, {
 			"systemd-mount",
 			"/dev/disk/by-partuuid/ubuntu-data-partuuid",
@@ -1613,6 +1637,8 @@ After=%[1]s
 			"--no-ask-password",
 			"--fsck=no",
 			"--options=nosuid",
+			"--property=DefaultDependencies=no",
+			"--property=Before=initrd-fs.target",
 		}, {
 			"systemd-mount",
 			"/dev/disk/by-partuuid/ubuntu-save-partuuid",
@@ -1620,6 +1646,8 @@ After=%[1]s
 			"--no-pager",
 			"--no-ask-password",
 			"--fsck=no",
+			"--property=DefaultDependencies=no",
+			"--property=Before=initrd-fs.target",
 		},
 	})
 
@@ -1706,10 +1734,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeHappyNoSaveRealSystemdM
 
 	// check that all of the override files are present
 	for _, initrdUnit := range []string{
-		"initrd.target",
 		"initrd-fs.target",
-		"initrd-switch-root.target",
-		"local-fs.target",
 	} {
 		for _, mountUnit := range []string{
 			systemd.EscapeUnitNamePath(boot.InitramfsUbuntuBootDir),
@@ -1721,8 +1746,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeHappyNoSaveRealSystemdM
 			fname := fmt.Sprintf("snap_bootstrap_%s.conf", mountUnit)
 			unitFile := filepath.Join(dirs.GlobalRootDir, "/run/systemd/system", initrdUnit+".d", fname)
 			c.Assert(unitFile, testutil.FileEquals, fmt.Sprintf(`[Unit]
-Requires=%[1]s
-After=%[1]s
+Wants=%[1]s
 `, mountUnit+".mount"))
 		}
 	}
@@ -1738,6 +1762,8 @@ After=%[1]s
 			"--no-pager",
 			"--no-ask-password",
 			"--fsck=yes",
+			"--property=DefaultDependencies=no",
+			"--property=Before=initrd-fs.target",
 		}, {
 			"systemd-mount",
 			"/dev/disk/by-partuuid/ubuntu-seed-partuuid",
@@ -1745,6 +1771,8 @@ After=%[1]s
 			"--no-pager",
 			"--no-ask-password",
 			"--fsck=yes",
+			"--property=DefaultDependencies=no",
+			"--property=Before=initrd-fs.target",
 		}, {
 			"systemd-mount",
 			"/dev/disk/by-partuuid/ubuntu-data-partuuid",
@@ -1753,6 +1781,8 @@ After=%[1]s
 			"--no-ask-password",
 			"--fsck=yes",
 			"--options=nosuid",
+			"--property=DefaultDependencies=no",
+			"--property=Before=initrd-fs.target",
 		}, {
 			"systemd-mount",
 			filepath.Join(dirs.SnapBlobDirUnder(boot.InitramfsWritableDir), s.core20.Filename()),
@@ -1761,6 +1791,8 @@ After=%[1]s
 			"--no-ask-password",
 			"--fsck=no",
 			"--options=ro",
+			"--property=DefaultDependencies=no",
+			"--property=Before=initrd-fs.target",
 		}, {
 			"systemd-mount",
 			filepath.Join(dirs.SnapBlobDirUnder(boot.InitramfsWritableDir), s.kernel.Filename()),
@@ -1769,6 +1801,8 @@ After=%[1]s
 			"--no-ask-password",
 			"--fsck=no",
 			"--options=ro",
+			"--property=DefaultDependencies=no",
+			"--property=Before=initrd-fs.target",
 		},
 	})
 }
@@ -1826,18 +1860,14 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeWithSaveHappyRealSystem
 
 	// check that all of the override files are present
 	for _, initrdUnit := range []string{
-		"initrd.target",
 		"initrd-fs.target",
-		"initrd-switch-root.target",
-		"local-fs.target",
 	} {
 
 		mountUnit := systemd.EscapeUnitNamePath(boot.InitramfsUbuntuSaveDir)
 		fname := fmt.Sprintf("snap_bootstrap_%s.conf", mountUnit)
 		unitFile := filepath.Join(dirs.GlobalRootDir, "/run/systemd/system", initrdUnit+".d", fname)
 		c.Assert(unitFile, testutil.FileEquals, fmt.Sprintf(`[Unit]
-Requires=%[1]s
-After=%[1]s
+Wants=%[1]s
 `, mountUnit+".mount"))
 	}
 
@@ -1857,6 +1887,8 @@ After=%[1]s
 			"--no-pager",
 			"--no-ask-password",
 			"--fsck=yes",
+			"--property=DefaultDependencies=no",
+			"--property=Before=initrd-fs.target",
 		}, {
 			"systemd-mount",
 			"/dev/disk/by-partuuid/ubuntu-seed-partuuid",
@@ -1864,6 +1896,8 @@ After=%[1]s
 			"--no-pager",
 			"--no-ask-password",
 			"--fsck=yes",
+			"--property=DefaultDependencies=no",
+			"--property=Before=initrd-fs.target",
 		}, {
 			"systemd-mount",
 			"/dev/disk/by-partuuid/ubuntu-data-partuuid",
@@ -1872,6 +1906,8 @@ After=%[1]s
 			"--no-ask-password",
 			"--fsck=yes",
 			"--options=nosuid",
+			"--property=DefaultDependencies=no",
+			"--property=Before=initrd-fs.target",
 		}, {
 			"systemd-mount",
 			"/dev/disk/by-partuuid/ubuntu-save-partuuid",
@@ -1879,6 +1915,8 @@ After=%[1]s
 			"--no-pager",
 			"--no-ask-password",
 			"--fsck=yes",
+			"--property=DefaultDependencies=no",
+			"--property=Before=initrd-fs.target",
 		}, {
 			"systemd-mount",
 			filepath.Join(dirs.SnapBlobDirUnder(boot.InitramfsWritableDir), s.core20.Filename()),
@@ -1887,6 +1925,8 @@ After=%[1]s
 			"--no-ask-password",
 			"--fsck=no",
 			"--options=ro",
+			"--property=DefaultDependencies=no",
+			"--property=Before=initrd-fs.target",
 		}, {
 			"systemd-mount",
 			filepath.Join(dirs.SnapBlobDirUnder(boot.InitramfsWritableDir), s.kernel.Filename()),
@@ -1895,6 +1935,8 @@ After=%[1]s
 			"--no-ask-password",
 			"--fsck=no",
 			"--options=ro",
+			"--property=DefaultDependencies=no",
+			"--property=Before=initrd-fs.target",
 		},
 	})
 }

--- a/cmd/snap-bootstrap/initramfs_systemd_mount.go
+++ b/cmd/snap-bootstrap/initramfs_systemd_mount.go
@@ -41,8 +41,7 @@ var (
 	defaultMountUnitWaitTimeout = time.Minute + 30*time.Second
 
 	unitFileDependOverride = `[Unit]
-Requires=%[1]s
-After=%[1]s
+Wants=%[1]s
 `
 
 	doSystemdMount = doSystemdMountImpl
@@ -144,6 +143,41 @@ func doSystemdMountImpl(what, where string, opts *systemdMountOptions) error {
 		args = append(args, "--options="+strings.Join(options, ","))
 	}
 
+	// if it should survive pivot_root() then we need to add overrides for this
+	// unit to /run/systemd units
+	if !opts.Ephemeral {
+		// Default dependencies are not necessary for initrd
+		// units. For instance this would add
+		// `Before=local-fs.target`. But `local-fs.target` is not
+		// the right target. We need `Before=initrd-fs.target` instead.
+		args = append(args, "--property=DefaultDependencies=no")
+
+		// to survive the pivot_root, mounts need to be "wanted" by
+		// initrd-switch-root.target directly or indirectly. The
+		// proper target to place them in is initrd-fs.target
+		// note we could do this statically in the initramfs main filesystem
+		// layout, but that means that changes to snap-bootstrap would block on
+		// waiting for those files to be added before things works here, this is
+		// a more flexible strategy that puts snap-bootstrap in control
+		overrideContent := []byte(fmt.Sprintf(unitFileDependOverride, unitName))
+		initrdUnit := "initrd-fs.target"
+		targetDir := filepath.Join(dirs.GlobalRootDir, "/run/systemd/system", initrdUnit+".d")
+		err := os.MkdirAll(targetDir, 0755)
+		if err != nil {
+			return err
+		}
+
+		// add an override file for the initrd unit to depend on this mount
+		// unit so that when we isolate to the initrd unit, it does not get
+		// unmounted
+		fname := fmt.Sprintf("snap_bootstrap_%s.conf", whereEscaped)
+		err = ioutil.WriteFile(filepath.Join(targetDir, fname), overrideContent, 0644)
+		if err != nil {
+			return err
+		}
+		args = append(args, "--property=Before="+initrdUnit)
+	}
+
 	// note that we do not currently parse any output from systemd-mount, but if
 	// we ever do, take special care surrounding the debug output that systemd
 	// outputs with the "debug" kernel command line present (or equivalently the
@@ -152,40 +186,6 @@ func doSystemdMountImpl(what, where string, opts *systemdMountOptions) error {
 	out, err := exec.Command("systemd-mount", args...).CombinedOutput()
 	if err != nil {
 		return osutil.OutputErr(out, err)
-	}
-
-	// if it should survive pivot_root() then we need to add overrides for this
-	// unit to /run/systemd units
-	if !opts.Ephemeral {
-		// to survive the pivot_root, we need to make the mount units depend on
-		// all of the various initrd special targets by adding runtime conf
-		// files there
-		// note we could do this statically in the initramfs main filesystem
-		// layout, but that means that changes to snap-bootstrap would block on
-		// waiting for those files to be added before things works here, this is
-		// a more flexible strategy that puts snap-bootstrap in control
-		overrideContent := []byte(fmt.Sprintf(unitFileDependOverride, unitName))
-		for _, initrdUnit := range []string{
-			"initrd.target",
-			"initrd-fs.target",
-			"initrd-switch-root.target",
-			"local-fs.target",
-		} {
-			targetDir := filepath.Join(dirs.GlobalRootDir, "/run/systemd/system", initrdUnit+".d")
-			err := os.MkdirAll(targetDir, 0755)
-			if err != nil {
-				return err
-			}
-
-			// add an override file for the initrd unit to depend on this mount
-			// unit so that when we isolate to the initrd unit, it does not get
-			// unmounted
-			fname := fmt.Sprintf("snap_bootstrap_%s.conf", whereEscaped)
-			err = ioutil.WriteFile(filepath.Join(targetDir, fname), overrideContent, 0644)
-			if err != nil {
-				return err
-			}
-		}
 	}
 
 	if !opts.NoWait {

--- a/cmd/snap-bootstrap/initramfs_systemd_mount_test.go
+++ b/cmd/snap-bootstrap/initramfs_systemd_mount_test.go
@@ -237,38 +237,57 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			args := []string{
 				"systemd-mount", t.what, t.where, "--no-pager", "--no-ask-password",
 			}
-			if opts.Tmpfs {
-				args = append(args, "--type=tmpfs")
-			}
-			if opts.NeedsFsck {
-				args = append(args, "--fsck=yes")
-			} else {
-				args = append(args, "--fsck=no")
-			}
-			if opts.NoWait {
-				args = append(args, "--no-block")
-			}
 			c.Assert(call[:len(args)], DeepEquals, args)
+
+			foundTypeTmpfs := false
+			foundFsckYes := false
+			foundFsckNo := false
+			foundNoBlock := false
+			foundDefaultDependenciesNo := false
+			foundBeforeInitrdfsTarget := false
 			foundNoSuid := false
 			foundBind := false
 			foundReadOnly := false
-			if len(call) != len(args) {
-				c.Assert(len(call), Equals, len(args)+1)
-				c.Assert(strings.HasPrefix(call[len(args)], "--options="), Equals, true)
-				for _, opt := range strings.Split(strings.TrimPrefix(call[len(args)], "--options="), ",") {
-					switch opt {
-					case "nosuid":
-						foundNoSuid = true
-					case "bind":
-						foundBind = true
-					case "ro":
-						foundReadOnly = true
-					default:
-						c.Logf("Option '%s' unexpected", opt)
-						c.Fail()
+
+			for _, arg := range call[len(args):] {
+				switch {
+				case arg == "--type=tmpfs":
+					foundTypeTmpfs = true
+				case arg == "--fsck=yes":
+					foundFsckYes = true
+				case arg == "--fsck=no":
+					foundFsckNo = true
+				case arg == "--no-block":
+					foundNoBlock = true
+				case arg == "--property=DefaultDependencies=no":
+					foundDefaultDependenciesNo = true
+				case arg == "--property=Before=initrd-fs.target":
+					foundBeforeInitrdfsTarget = true
+				case strings.HasPrefix(arg, "--options="):
+					for _, opt := range strings.Split(strings.TrimPrefix(arg, "--options="), ",") {
+						switch opt {
+						case "nosuid":
+							foundNoSuid = true
+						case "bind":
+							foundBind = true
+						case "ro":
+							foundReadOnly = true
+						default:
+							c.Logf("Option '%s' unexpected", opt)
+							c.Fail()
+						}
 					}
+				default:
+					c.Logf("Argument '%s' unexpected", arg)
+					c.Fail()
 				}
 			}
+			c.Assert(foundTypeTmpfs, Equals, opts.Tmpfs)
+			c.Assert(foundFsckYes, Equals, opts.NeedsFsck)
+			c.Assert(foundFsckNo, Equals, !opts.NeedsFsck)
+			c.Assert(foundNoBlock, Equals, opts.NoWait)
+			c.Assert(foundDefaultDependenciesNo, Equals, !opts.Ephemeral)
+			c.Assert(foundBeforeInitrdfsTarget, Equals, !opts.Ephemeral)
 			c.Assert(foundNoSuid, Equals, opts.NoSuid)
 			c.Assert(foundBind, Equals, opts.Bind)
 			c.Assert(foundReadOnly, Equals, opts.ReadOnly)
@@ -276,10 +295,7 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			// check that the overrides are present if opts.Ephemeral is false,
 			// or check the overrides are not present if opts.Ephemeral is true
 			for _, initrdUnit := range []string{
-				"initrd.target",
 				"initrd-fs.target",
-				"initrd-switch-root.target",
-				"local-fs.target",
 			} {
 				mountUnit := systemd.EscapeUnitNamePath(t.where)
 				fname := fmt.Sprintf("snap_bootstrap_%s.conf", mountUnit)
@@ -288,8 +304,7 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 					c.Assert(unitFile, testutil.FileAbsent)
 				} else {
 					c.Assert(unitFile, testutil.FileEquals, fmt.Sprintf(`[Unit]
-Requires=%[1]s
-After=%[1]s
+Wants=%[1]s
 `, mountUnit+".mount"))
 				}
 			}


### PR DESCRIPTION
To be able to survive switch root, mounts need to be "wanted" directly
or indirectly by `initrd-switch-root.target`. `initrd-fs.target` is
the proper target and enough. Specifying other targets is superfluous.

The mounts do not need to be "required". "Requires" has a stricter
semantic and potentially makes systems less robust. It is recommended
by documentation that we use "Wants" where "Requires" is not needed.

`initrd.target` and `local-fs.target` are not part
`initrd-switch-root.target` and are normally taken down during the
switch of root.

Default dependencies are not useful in non ephemeral mounts.
Specifically `Before=local-fs.target`. The dependency we need is
`Before=initrd-fs.target`.
