### PR TITLE
store: fix flaky test

### DIFF
--- a/store/store_action_test.go
+++ b/store/store_action_test.go
@@ -3224,5 +3224,5 @@ func (s *storeActionSuite) TestSnapActionTimeout(c *C) {
 	close(quit)
 	// go 1.17 started quoting the failing URL, also context deadline
 	// exceeded may appear in place of request being canceled
-	c.Assert(err, ErrorMatches, `.*/v2/snaps/refresh"?: (net/http: request canceled|context deadline exceeded) \(Client.Timeout exceeded while awaiting headers\).*`)
+	c.Assert(err, ErrorMatches, `.*/v2/snaps/refresh"?: (net/http: request canceled|context deadline exceeded)( \(Client.Timeout exceeded while awaiting headers\))?.*`)
 }


### PR DESCRIPTION
```
FAIL: store_action_test.go:3191: storeActionSuite.TestSnapActionTimeout
store_action_test.go:3227:
    c.Assert(err, ErrorMatches, `.*/v2/snaps/refresh"?: (net/http: request canceled|context deadline exceeded) \(Client.Timeout exceeded while awaiting headers\).*`)
... error string = "Post \"http://127.0.0.1:38011/v2/snaps/refresh\": context deadline exceeded"
... regex string = ".*/v2/snaps/refresh\"?: (net/http: request canceled|context deadline exceeded) \\(Client.Timeout exceeded while awaiting headers\\).*"
```
https://github.com/snapcore/snapd/runs/4838818272?check_suite_focus=true
