### PR TITLE
mkversion: check that snapd is a git source tree before guessing the version

### DIFF
--- a/mkversion.sh
+++ b/mkversion.sh
@@ -39,8 +39,11 @@ fi
 
 DIRTY=false
 
-# Let's try to derive the version from git..
-if command -v git >/dev/null; then
+# Let's try to derive the version from git only if the snapd source tree is
+# tracked by git. The script can be invoked when building distro packages in
+# which case, the source tree could be a tarball, but the distro packaging files
+# can be in git, so try not to confuse the two.
+if command -v git >/dev/null && [ -d "$(dirname "$0")/.git" ] ; then
     # don't include --dirty here as we independently track whether the tree is
     # dirty and append that last, including it here will make dirty trees 
     # directly on top of tags show up with version_from_git as 2.46-dirty which


### PR DESCRIPTION
It is possible that when the mkversion is called, the snapd source tree isn't a
git repository, but rather an extracted source tarball.

To make matters worse, the distro packaging files can be kept in a git source
tree. Then during the build from source tarballs within that source tree
mkversion will incorrectly interpret the output of `git describe` which actually
describes the state of the distro packaging repository.