### PR TITLE
spread-shellcheck: add a caching layer

### DIFF
--- a/spread-shellcheck
+++ b/spread-shellcheck
@@ -173,7 +173,6 @@ class Cacher:
         h = hashlib.sha256()
         h.update(data)
         hdg = binascii.b2a_hex(h.digest()).decode()
-        prefix = hdg[:2]
         cachepath = Cacher._cache_path_for(hdg)
         logging.debug("cache stamp %s, exists? %s", cachepath.as_posix(), cachepath.exists())
         hit = cachepath.exists()
@@ -249,8 +248,7 @@ def checkfile(path, executor):
 
     if errors:
         raise errors
-    else:
-        Cacher().cache_success(digest, path)
+    Cacher().cache_success(digest, path)
 
 
 def is_file_in_dirs(file, dirs):

--- a/spread-shellcheck
+++ b/spread-shellcheck
@@ -19,9 +19,12 @@ import os
 import subprocess
 import argparse
 import itertools
+import hashlib
+import binascii
 from concurrent.futures import ThreadPoolExecutor
 from multiprocessing import cpu_count
 from typing import Dict
+from pathlib import Path
 
 import yaml
 
@@ -59,6 +62,7 @@ def parse_arguments():
                         help='run these many shellchecks in parallel (default: %(default)s)')
     parser.add_argument('-e', '--exclude', default=[], action="append",
                         help='path to exclude of the shell check')
+    parser.add_argument('--no-cache', help='disable caching', action='store_true')
     parser.add_argument('paths', nargs='+', help='paths to check')
     return parser.parse_args()
 
@@ -133,15 +137,59 @@ def checksection(data, env: Dict[str, str]):
                             stdout=subprocess.PIPE,
                             stdin=subprocess.PIPE,
                             shell=True)
-    stdout, _ = proc.communicate(input='\n'.join(script_data).encode('utf-8'), timeout=30)
+    stdout, _ = proc.communicate(input='\n'.join(script_data).encode('utf-8'), timeout=60)
     if proc.returncode != 0:
         raise ShellcheckRunError(stdout)
 
 
+class Cacher:
+    _instance = None
+    def __new__(cls):
+        if cls._instance is not None:
+            return cls._instance
+        instance = super().__new__(cls)
+        cls._instance = instance
+        instance.enabled = True
+        return instance
+
+    def disable(self):
+        logging.debug("caching is disabled")
+        self.enabled = False
+
+    @staticmethod
+    def _cache_path_for(digest):
+        prefix = digest[:2]
+        return Path.home().joinpath(".cache", "spread-shellcheck", prefix, digest)
+
+    def is_cached(self, data, path):
+        h = hashlib.sha256()
+        h.update(data)
+        hdg = binascii.b2a_hex(h.digest()).decode()
+        if not self.enabled:
+            return False, hdg
+        prefix = hdg[:2]
+        cachepath = Cacher._cache_path_for(hdg)
+        logging.debug("cache stamp %s, exists? %s", cachepath.as_posix(), cachepath.exists())
+        return cachepath.exists(), hdg
+
+    def cache_success(self, digest, path):
+        if not self.enabled:
+            return
+        cachepath = Cacher._cache_path_for(digest)
+        logging.debug("cache success, path %s", cachepath.as_posix())
+        cachepath.parent.mkdir(parents=True, exist_ok=True)
+        cachepath.touch()
+
+
 def checkfile(path, executor):
     logging.debug("checking file %s", path)
-    with open(path) as inf:
-        data = yaml.safe_load(inf)
+    with open(path, mode='rb') as inf:
+        rawdata = inf.read()
+        cached, digest = Cacher().is_cached(rawdata, path)
+        if cached:
+            logging.debug("entry %s already cached", digest)
+            return
+        data = yaml.safe_load(rawdata)
 
     errors = ShellcheckError(path)
     # TODO: handle stacking of environment from other places that influence it:
@@ -182,6 +230,9 @@ def checkfile(path, executor):
 
     if errors:
         raise errors
+    else:
+        Cacher().cache_success(digest, path)
+
 
 def is_file_in_dirs(file, dirs):
     for dir in dirs:
@@ -190,6 +241,7 @@ def is_file_in_dirs(file, dirs):
             return True
 
     return False
+
 
 def findfiles(locations, exclude):
     for loc in locations:
@@ -300,5 +352,8 @@ if __name__ == '__main__':
         # worker
         opts.max_procs += 1
         logging.warning('workers count bumped to 2 to workaround a deadlock')
+
+    if opts.no_cache:
+        Cacher().disable()
 
     main(opts)

--- a/spread-shellcheck
+++ b/spread-shellcheck
@@ -147,16 +147,22 @@ def checksection(data, env: Dict[str, str]):
 
 class Cacher:
     _instance = None
-    def __new__(cls):
-        if cls._instance is not None:
-            return cls._instance
-        instance = super().__new__(cls)
-        cls._instance = instance
-        instance._enabled = True
-        instance._lock = Lock()
-        instance._hit =0
-        instance._miss = 0
-        return instance
+
+    def __init__(self):
+        self._enabled = True
+        self._lock = Lock()
+        self._hit =0
+        self._miss = 0
+        self._shellcheck_version = None
+        self._probe_shellcheck_version()
+
+    @classmethod
+    def init(cls):
+        cls._instance = Cacher()
+
+    @classmethod
+    def get(cls):
+        return cls._instance
 
     def disable(self):
         logging.debug("caching is disabled")
@@ -170,11 +176,12 @@ class Cacher:
     def is_cached(self, data, path):
         if not self._enabled:
             return False, ""
-        # the digest only uses script content as input, but consider other
-        # possible inputs: path to the script (so moving the script around
-        # would cause a miss), or shellcheck version (cause a miss when
-        # shellcheck version is changed)
+        # the digest uses script content and shellcheck versions as inputs, but
+        # consider other possible inputs: path to the *.yaml file (so moving
+        # the script around would cause a miss) or even the contents of this
+        # script
         h = hashlib.sha256()
+        h.update(self._shellcheck_version)
         h.update(data)
         hdg = binascii.b2a_hex(h.digest()).decode()
         cachepath = Cacher._cache_path_for(hdg)
@@ -198,6 +205,11 @@ class Cacher:
             else:
                 self._miss += 1
 
+    def _probe_shellcheck_version(self):
+        logging.debug("probing shellcheck version")
+        out = subprocess.check_output("shellcheck --version", shell=True)
+        self._shellcheck_version = out
+
     @property
     def stats(self):
         return namedtuple('Stats', ['hit', 'miss'])(self._hit, self._miss)
@@ -207,7 +219,7 @@ def checkfile(path, executor):
     logging.debug("checking file %s", path)
     with open(path, mode='rb') as inf:
         rawdata = inf.read()
-        cached, digest = Cacher().is_cached(rawdata, path)
+        cached, digest = Cacher.get().is_cached(rawdata, path)
         if cached:
             logging.debug("entry %s already cached", digest)
             return
@@ -253,7 +265,7 @@ def checkfile(path, executor):
     if errors:
         raise errors
     # only stamp the cache when the script was found to be valid
-    Cacher().cache_success(digest, path)
+    Cacher.get().cache_success(digest, path)
 
 
 def is_file_in_dirs(file, dirs):
@@ -324,7 +336,7 @@ def main(opts):
             failures.merge(sf)
 
     if not opts.no_cache:
-        stats = Cacher().stats
+        stats = Cacher.get().stats
         logging.info("cache stats: hit %d miss %d", stats.hit, stats.miss)
 
     if failures:
@@ -379,7 +391,8 @@ if __name__ == '__main__':
         opts.max_procs += 1
         logging.warning('workers count bumped to 2 to workaround a deadlock')
 
+    Cacher.init()
     if opts.no_cache:
-        Cacher().disable()
+        Cacher.get().disable()
 
     main(opts)

--- a/spread-shellcheck
+++ b/spread-shellcheck
@@ -149,12 +149,12 @@ class Cacher:
             return cls._instance
         instance = super().__new__(cls)
         cls._instance = instance
-        instance.enabled = True
+        instance._enabled = True
         return instance
 
     def disable(self):
         logging.debug("caching is disabled")
-        self.enabled = False
+        self._enabled = False
 
     @staticmethod
     def _cache_path_for(digest):
@@ -162,18 +162,18 @@ class Cacher:
         return Path.home().joinpath(".cache", "spread-shellcheck", prefix, digest)
 
     def is_cached(self, data, path):
+        if not self._enabled:
+            return False, ""
         h = hashlib.sha256()
         h.update(data)
         hdg = binascii.b2a_hex(h.digest()).decode()
-        if not self.enabled:
-            return False, hdg
         prefix = hdg[:2]
         cachepath = Cacher._cache_path_for(hdg)
         logging.debug("cache stamp %s, exists? %s", cachepath.as_posix(), cachepath.exists())
         return cachepath.exists(), hdg
 
     def cache_success(self, digest, path):
-        if not self.enabled:
+        if not self._enabled:
             return
         cachepath = Cacher._cache_path_for(digest)
         logging.debug("cache success, path %s", cachepath.as_posix())

--- a/spread-shellcheck
+++ b/spread-shellcheck
@@ -22,9 +22,12 @@ import itertools
 import hashlib
 import binascii
 from concurrent.futures import ThreadPoolExecutor
+from threading import Lock
 from multiprocessing import cpu_count
 from typing import Dict
 from pathlib import Path
+from collections import namedtuple
+
 
 import yaml
 
@@ -150,6 +153,9 @@ class Cacher:
         instance = super().__new__(cls)
         cls._instance = instance
         instance._enabled = True
+        instance._lock = Lock()
+        instance._hit =0
+        instance._miss = 0
         return instance
 
     def disable(self):
@@ -170,7 +176,9 @@ class Cacher:
         prefix = hdg[:2]
         cachepath = Cacher._cache_path_for(hdg)
         logging.debug("cache stamp %s, exists? %s", cachepath.as_posix(), cachepath.exists())
-        return cachepath.exists(), hdg
+        hit = cachepath.exists()
+        self._record_cache_event(hit)
+        return hit, hdg
 
     def cache_success(self, digest, path):
         if not self._enabled:
@@ -179,6 +187,17 @@ class Cacher:
         logging.debug("cache success, path %s", cachepath.as_posix())
         cachepath.parent.mkdir(parents=True, exist_ok=True)
         cachepath.touch()
+
+    def _record_cache_event(self, hit):
+        with self._lock:
+            if hit:
+                self._hit += 1
+            else:
+                self._miss += 1
+
+    @property
+    def stats(self):
+        return namedtuple('Stats', ['hit', 'miss'])(self._hit, self._miss)
 
 
 def checkfile(path, executor):
@@ -300,6 +319,10 @@ def main(opts):
             checkpaths(paths, exclude, executor)
         except ShellcheckFailures as sf:
             failures.merge(sf)
+
+    if not opts.no_cache:
+        stats = Cacher().stats
+        logging.info("cache stats: hit %d miss %d", stats.hit, stats.miss)
 
     if failures:
         if opts.can_fail:

--- a/spread-shellcheck
+++ b/spread-shellcheck
@@ -170,6 +170,10 @@ class Cacher:
     def is_cached(self, data, path):
         if not self._enabled:
             return False, ""
+        # the digest only uses script content as input, but consider other
+        # possible inputs: path to the script (so moving the script around
+        # would cause a miss), or shellcheck version (cause a miss when
+        # shellcheck version is changed)
         h = hashlib.sha256()
         h.update(data)
         hdg = binascii.b2a_hex(h.digest()).decode()
@@ -248,6 +252,7 @@ def checkfile(path, executor):
 
     if errors:
         raise errors
+    # only stamp the cache when the script was found to be valid
     Cacher().cache_success(digest, path)
 
 


### PR DESCRIPTION
Add caching of check results. The cache uses stamps that are based on test
content, while the stamps tree is stored under ~/.cache/spread-shellcheck.

On my 8-core ryzen 1700 with NVMe, wall clock time went down from 1m09s to
0.37s (user time 469s -> 0.27s, 1730x speedup).

