### PR TITLE
check-commit-email: do not fail when current dir is not under git

### DIFF
--- a/check-commit-email.py
+++ b/check-commit-email.py
@@ -10,6 +10,7 @@
 # like a developer would do locally in which case this ends up checking all
 # commits locally - some day that may grow to be unwieldy but for now seems ok.
 
+import os
 import subprocess
 from email.utils import parseaddr
 
@@ -39,6 +40,8 @@ def get_commit_range():
 
 
 if __name__ == "__main__":
+    if not os.path.exists('.git'):
+        exit(0)
     commitrange = get_commit_range()
     args = ["git", "log", "--format=format:%h,%ce%n%h,%ae"]
     if commitrange != "":


### PR DESCRIPTION
The check fails with a source tarball, like the one used during spread tests.

```
Error: 2022-01-21 07:44:44 Error executing google:ubuntu-20.04-64:tests/unit/go (jan210735-282406) :
-----
...
Obtaining c-dependencies
HEAD is now at 74f4fe8 Merge pull request #63 from vasi/vasi-win-ci
Checking docs
fatal: not a git repository (or any of the parent directories): .git
Traceback (most recent call last):
  File "./check-commit-email.py", line 42, in <module>
    commitrange = get_commit_range()
  File "./check-commit-email.py", line 22, in get_commit_range
    lines = subprocess.check_output(
  File "/usr/lib/python3.8/subprocess.py", line 415, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib/python3.8/subprocess.py", line 516, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['git', 'cat-file', '-p', '@']' returned non-zero exit status 128.

Crushing failure and despair.
```

