### PR TITLE
osutil/mkfs: Expose option for --lib flag in fakeroot call

### DIFF
--- a/osutil/mkfs/mkfs.go
+++ b/osutil/mkfs/mkfs.go
@@ -117,7 +117,6 @@ func mkfsExt4(img, label, contentsRootDir string, deviceSize, sectorSize quantit
 		// no need to fake it if we're already root
 		cmd = exec.Command(mkfsArgs[0], mkfsArgs[1:]...)
 	}
-	cmd.Env = os.Environ()
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return osutil.OutputErr(out, err)

--- a/osutil/mkfs/mkfs.go
+++ b/osutil/mkfs/mkfs.go
@@ -106,6 +106,12 @@ func mkfsExt4(img, label, contentsRootDir string, deviceSize, sectorSize quantit
 	var cmd *exec.Cmd
 	if os.Geteuid() != 0 {
 		// run through fakeroot so that files are owned by root
+		fakerootLib := os.Getenv("FAKEROOT_LIB")
+		if fakerootLib != "" {
+			// When executing fakeroot from a classic confinement snap the location of
+			// libfakeroot must be specified, or else it will be loaded from the host system
+			mkfsArgs = append([]string{"--lib", fakerootLib}, mkfsArgs...)
+		}
 		cmd = exec.Command("fakeroot", mkfsArgs...)
 	} else {
 		// no need to fake it if we're already root

--- a/osutil/mkfs/mkfs.go
+++ b/osutil/mkfs/mkfs.go
@@ -111,6 +111,7 @@ func mkfsExt4(img, label, contentsRootDir string, deviceSize, sectorSize quantit
 		// no need to fake it if we're already root
 		cmd = exec.Command(mkfsArgs[0], mkfsArgs[1:]...)
 	}
+	cmd.Env = os.Environ()
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return osutil.OutputErr(out, err)

--- a/osutil/mkfs/mkfs.go
+++ b/osutil/mkfs/mkfs.go
@@ -110,7 +110,7 @@ func mkfsExt4(img, label, contentsRootDir string, deviceSize, sectorSize quantit
 		if fakerootLib != "" {
 			// When executing fakeroot from a classic confinement snap the location of
 			// libfakeroot must be specified, or else it will be loaded from the host system
-			mkfsArgs = append([]string{"--lib", fakerootLib}, mkfsArgs...)
+			mkfsArgs = append([]string{"--lib", fakerootLib, "--"}, mkfsArgs...)
 		}
 		cmd = exec.Command("fakeroot", mkfsArgs...)
 	} else {


### PR DESCRIPTION
ubuntu-image is a classic confined snap, and therefore has access to system files such as /usr/lib/. This has been causing problems with the existing fakeroot call, as the fakeroot binary was being called from within the snap, but loading libfakeroot from the host system.

While this is caused by fakeroot hard coding path values, fakeroot does provide a --lib flag to allow the user to specify another location to look for libfakeroot. The change in this PR uses an environment variable to look for the location of libfakeroot. That environment variable will be set in ubuntu-image, and then the correct libfakeroot can be loaded when ubuntu-image calls osutil/mkfs

I used the approach of an environment variable as it seemed like the minimal code change that would get the job done. If the snapd team would prefer I bubble up options that could be passed to mkfs.Ext4 instead, I would be happy to change strategies.