### PR TITLE
cmd/snapd-apparmor: fix bad variable initialization

### DIFF
--- a/cmd/snapd-apparmor/snapd-apparmor
+++ b/cmd/snapd-apparmor/snapd-apparmor
@@ -44,9 +44,9 @@ export AA_SFS="$SECURITYFS/apparmor"
 is_container_with_internal_policy() {
 	ns_stacked_path="${AA_SFS}/.ns_stacked"
 	ns_name_path="${AA_SFS}/.ns_name"
-	# shellcheck disable=SC3043
+	# shellcheck disable=SC3043,SC2039
 	local ns_stacked
-	# shellcheck disable=SC3043
+	# shellcheck disable=SC3043,SC2039
 	local ns_name
 
 	if ! [ -f "$ns_stacked_path" ] || ! [ -f "$ns_name_path" ]; then

--- a/cmd/snapd-apparmor/snapd-apparmor
+++ b/cmd/snapd-apparmor/snapd-apparmor
@@ -44,8 +44,8 @@ export AA_SFS="$SECURITYFS/apparmor"
 is_container_with_internal_policy() {
 	ns_stacked_path="${AA_SFS}/.ns_stacked"
 	ns_name_path="${AA_SFS}/.ns_name"
-	ns_stacked
-	ns_name
+	ns_stacked=""
+	ns_name=""
 
 	if ! [ -f "$ns_stacked_path" ] || ! [ -f "$ns_name_path" ]; then
 		return 1

--- a/cmd/snapd-apparmor/snapd-apparmor
+++ b/cmd/snapd-apparmor/snapd-apparmor
@@ -44,8 +44,10 @@ export AA_SFS="$SECURITYFS/apparmor"
 is_container_with_internal_policy() {
 	ns_stacked_path="${AA_SFS}/.ns_stacked"
 	ns_name_path="${AA_SFS}/.ns_name"
-	ns_stacked=""
-	ns_name=""
+	# shellcheck disable=SC3043
+	local ns_stacked
+	# shellcheck disable=SC3043
+	local ns_name
 
 	if ! [ -f "$ns_stacked_path" ] || ! [ -f "$ns_name_path" ]; then
 		return 1


### PR DESCRIPTION
This was supposed to be a variable initialization, but likely local got dropped
in the process of making this script POSIX shell compliant. and as a result it
ended up being a program invocation.
