### PR TITLE
o/snapstate: write state when undoing migration

### DIFF
--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -103,8 +103,9 @@ type SnapSetup struct {
 	// each instance of given snap
 	InstanceKey string `json:"instance-key,omitempty"`
 
-	// MigratedHidden is set if the user's snap dir has been migrated
-	// to ~/.snap/data in the current change.
+	// MigratedHidden is set if the user's snap dir has been migrated to
+	// ~/.snap/data in the current change. So a 'false' value doesn't mean the
+	// dir isn't hidden. This prevents us from always having to set it.
 	MigratedHidden bool `json:"migrated-hidden,omitempty"`
 }
 


### PR DESCRIPTION
Re-write the state after undoing the migration because it might've
been written in 'link-snap' before being undone. Also, add some
comments explaining why the state is written where it is (i.e., only
after the undo do we know the actual final state). 