### PR TITLE
tests: skip migration test on centOS

### DIFF
--- a/tests/main/hidden-snap-dir/task.yaml
+++ b/tests/main/hidden-snap-dir/task.yaml
@@ -1,5 +1,7 @@
 summary: Check that the experimental hidden dir feature migrates the dir
 
+# this test is flaky on CentOS 7 and 8. Disabling while the cause is
+# investigated
 systems: [-centos-*]
 
 environment:

--- a/tests/main/hidden-snap-dir/task.yaml
+++ b/tests/main/hidden-snap-dir/task.yaml
@@ -1,5 +1,7 @@
 summary: Check that the experimental hidden dir feature migrates the dir
 
+systems: [-centos-*]
+
 environment:
     NAME: test-snapd-tools
 


### PR DESCRIPTION
The hidden-snap-dir spread test is flaky on CentOS (sorry). I'll work on debugging it in the morning but for now this should prevent it from blocking anyone.