### PR TITLE
interfaces/opengl: add support for ARM Mali

### DIFF
--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -117,6 +117,10 @@ unix (bind,listen) type=seqpacket addr="@cuda-uvmfd-[0-9a-f]*",
 # Imagination PowerVR driver
 /dev/pvr_sync rw,
 
+# ARM Mali driver
+/dev/mali[0-9]* rw,
+/dev/dma_buf_te rw,
+
 # OpenCL ICD files
 /etc/OpenCL/vendors/ r,
 /etc/OpenCL/vendors/** r,
@@ -165,6 +169,8 @@ var openglConnectedPlugUDev = []string{
 	`KERNEL=="tegra_dc_ctrl"`,
 	`KERNEL=="tegra_dc_[0-9]*"`,
 	`KERNEL=="pvr_sync"`,
+	`KERNEL=="mali[0-9]*"`,
+	`KERNEL=="dma_buf_te"`,
 }
 
 func init() {

--- a/interfaces/builtin/opengl_test.go
+++ b/interfaces/builtin/opengl_test.go
@@ -82,6 +82,7 @@ func (s *OpenglInterfaceSuite) TestAppArmorSpec(c *C) {
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/dev/nvidia* rw,`)
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/dev/dri/renderD[0-9]* rw,`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/dev/mali[0-9]* rw,`)
 }
 
 func (s *OpenglInterfaceSuite) TestUDevSpec(c *C) {

--- a/interfaces/builtin/opengl_test.go
+++ b/interfaces/builtin/opengl_test.go
@@ -87,7 +87,7 @@ func (s *OpenglInterfaceSuite) TestAppArmorSpec(c *C) {
 func (s *OpenglInterfaceSuite) TestUDevSpec(c *C) {
 	spec := &udev.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 10)
+	c.Assert(spec.Snippets(), HasLen, 12)
 	c.Assert(spec.Snippets(), testutil.Contains, `# opengl
 SUBSYSTEM=="drm", KERNEL=="card[0-9]*", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `# opengl
@@ -102,6 +102,10 @@ KERNEL=="tegra_dc_ctrl", TAG+="snap_consumer_app"`)
 KERNEL=="tegra_dc_[0-9]*", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `# opengl
 KERNEL=="pvr_sync", TAG+="snap_consumer_app"`)
+	c.Assert(spec.Snippets(), testutil.Contains, `# opengl
+KERNEL=="mali[0-9]*", TAG+="snap_consumer_app"`)
+	c.Assert(spec.Snippets(), testutil.Contains, `# opengl
+KERNEL=="dma_buf_te", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
 }
 


### PR DESCRIPTION
$ udevadm info --query property /dev/mali0
DEVPATH=/devices/platform/soc/13040000.mali/misc/mali0
DEVNAME=/dev/mali0
DEVMODE=0666
MAJOR=10
MINOR=60
SUBSYSTEM=misc
USEC_INITIALIZED=5223664
TAGS=:snap_ubuntu-frame_ubuntu-frame:snap_mir-test-tools_qt-test:snap_mir-test-tools_sdl2-test:snap_mir-test-tools_smoke-test:snap_mir-test-tools_hook_configure:snap_ubuntu-frame_daemon:snap_mir-test-tools_gtk3-test:snap_mir-test-tools_performance-test:

dma_buf_test_exportor is a necessary kernel module since ARM Mali r32p0
It's the buffer allocator and can export a DMA buffer.
/dev/dma_buf_te is generated by dma_buf_test_exportor
$ udevadm info --query property /dev/dma_buf_te
DEVPATH=/devices/virtual/misc/dma_buf_te
DEVNAME=/dev/dma_buf_te
MAJOR=10
MINOR=58
SUBSYSTEM=misc
USEC_INITIALIZED=4964986
TAGS=:snap_ubuntu-frame_ubuntu-frame:snap_mir-test-tools_hook_configure:snap_ubuntu-frame_daemon:snap_mir-test-tools_performance-test:snap_mir-test-tools_qt-test:snap_mir-test-tools_gtk3-test:snap_mir-test-tools_smoke-test:snap_mir-test-tools_sdl2-test: