### PR TITLE
tests: new Jammy image for testing

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -124,7 +124,6 @@ backends:
             - ubuntu-22.04-64:
                   storage: 12G
                   workers: 8
-                  image: ubuntu-os-cloud-devel/ubuntu-2204-lts
 
             - debian-10-64:
                   workers: 6


### PR DESCRIPTION
The new image is a copy from ubuntu-os-cloud-devel/ubuntu-2204-lts but with little changes.

This was included just to avoid the pagination issue of spread
