### PR TITLE
tests: remove ubuntu 21.04 from the spread tests executions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -276,7 +276,6 @@ jobs:
         - ubuntu-18.04-32
         - ubuntu-18.04-64
         - ubuntu-20.04-64
-        - ubuntu-21.04-64
         - ubuntu-21.10-64
         - ubuntu-22.04-64
         - ubuntu-core-16-64
@@ -364,7 +363,7 @@ jobs:
         - ubuntu-16.04-64
         - ubuntu-18.04-64
         - ubuntu-20.04-64
-        - ubuntu-21.04-64
+        - ubuntu-21.10-64
     steps:
     - name: Cleanup job workspace
       id: cleanup-job-workspace

--- a/spread.yaml
+++ b/spread.yaml
@@ -116,8 +116,6 @@ backends:
                   image: ubuntu-20.04-64
                   workers: 1
                   secure-boot: true
-            - ubuntu-21.04-64:
-                  workers: 8
             - ubuntu-21.10-64:
                   storage: 12G
                   workers: 8
@@ -175,8 +173,6 @@ backends:
                   workers: 6
             - ubuntu-20.04-64:
                   workers: 6
-            - ubuntu-21.04-64:
-                  workers: 6
             - ubuntu-21.10-64:
                   workers: 6
 
@@ -200,8 +196,8 @@ backends:
                   image: ubuntu-2004-64-virt-enabled
                   storage: 20G
                   workers: 7
-            - ubuntu-21.04-64:
-                  image: ubuntu-2104-64-virt-enabled
+            - ubuntu-21.10-64:
+                  image: ubuntu-2110-64-virt-enabled
                   storage: 20G
                   workers: 3
 
@@ -258,9 +254,6 @@ backends:
                   username: ubuntu
                   password: ubuntu
             - ubuntu-20.04-32:
-                  username: ubuntu
-                  password: ubuntu
-            - ubuntu-21.04-64:
                   username: ubuntu
                   password: ubuntu
             - ubuntu-21.10-64:

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -289,9 +289,6 @@ nested_get_google_image_url_for_vm() {
         ubuntu-20.04-64)
             echo "https://storage.googleapis.com/snapd-spread-tests/images/cloudimg/focal-server-cloudimg-amd64.img"
             ;;
-        ubuntu-21.04-64*)
-            echo "https://storage.googleapis.com/snapd-spread-tests/images/cloudimg/hirsute-server-cloudimg-amd64.img"
-            ;;
         ubuntu-21.10-64*)
             echo "https://storage.googleapis.com/snapd-spread-tests/images/cloudimg/impish-server-cloudimg-amd64.img"
             ;;
@@ -316,9 +313,6 @@ nested_get_ubuntu_image_url_for_vm() {
             ;;
         ubuntu-20.04-64*)
             echo "https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img"
-            ;;
-        ubuntu-21.04-64*)
-            echo "https://cloud-images.ubuntu.com/hirsute/current/hirsute-server-cloudimg-amd64.img"
             ;;
         ubuntu-21.10-64*)
             echo "https://cloud-images.ubuntu.com/impish/current/impish-server-cloudimg-amd64.img"

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -611,7 +611,7 @@ pkg_dependencies_ubuntu_classic(){
                 shellcheck
                 "
             ;;
-        ubuntu-21.04-64|ubuntu-21.10-64|ubuntu-22.04-64)
+        ubuntu-21.10-64|ubuntu-22.04-64)
             # bpftool is part of linux-tools package
             echo "
                 dbus-user-session

--- a/tests/main/cgroup-devices-v2/task.yaml
+++ b/tests/main/cgroup-devices-v2/task.yaml
@@ -8,7 +8,6 @@ systems:
   - -ubuntu-16.04-*
   - -ubuntu-18.04-*
   - -ubuntu-20.04-*
-  - -ubuntu-21.04-*
   # using ubuntu-21.10-* would also disable ubuntu-21.10-64-cgroupv2
   - -ubuntu-21.10-64
   - -ubuntu-core-*

--- a/tests/main/cgroup-tracking-failure/task.yaml
+++ b/tests/main/cgroup-tracking-failure/task.yaml
@@ -107,13 +107,6 @@ execute: |
             MATCH 'DEBUG: create transient scope job: /org/freedesktop/systemd1/job/[0-9]+' <debug.txt
             MATCH '1:name=systemd:/user.slice/user-0.slice/user@0.service/snap.test-snapd-sh.sh.[0-9a-f-]+.scope' <cgroup.txt
             ;;
-        ubuntu-21.04-*)
-            # Same as Ubuntu 20.04, but the cgroup path is slightly different
-            # with that version of systemd
-            MATCH 'DEBUG: using session bus' <debug.txt
-            MATCH 'DEBUG: create transient scope job: /org/freedesktop/systemd1/job/[0-9]+' <debug.txt
-            MATCH '1:name=systemd:/user.slice/user-0.slice/user@0.service/app.slice/snap.test-snapd-sh.sh.[0-9a-f-]+.scope' <cgroup.txt
-            ;;
         ubuntu-21.10-*)
             # Ubuntu 21.10 uses unified cgroup hierarchy, where we wait
             # for the systemd to complete the job that creates a transient scope
@@ -221,13 +214,6 @@ execute: |
             MATCH 'DEBUG: using session bus' <debug.txt
             MATCH 'DEBUG: create transient scope job: /org/freedesktop/systemd1/job/[0-9]+' <debug.txt
             MATCH '1:name=systemd:/user.slice/user-12345.slice/user@12345.service/snap.test-snapd-sh.sh.[0-9a-f-]+.scope' <cgroup.txt
-            ;;
-        ubuntu-21.04-*)
-            # Same as Ubuntu 20.04, but the cgroup path is slightly different
-            # with that version of systemd
-            MATCH 'DEBUG: using session bus' <debug.txt
-            MATCH 'DEBUG: create transient scope job: /org/freedesktop/systemd1/job/[0-9]+' <debug.txt
-            MATCH '1:name=systemd:/user.slice/user-12345.slice/user@12345.service/app.slice/snap.test-snapd-sh.sh.[0-9a-f-]+.scope' <cgroup.txt
             ;;
         ubuntu-21.10-*)
             # Same as Ubuntu 20.04, but the system uses a unified cgroup hierarchy

--- a/tests/main/lxd-mount-units/task.yaml
+++ b/tests/main/lxd-mount-units/task.yaml
@@ -5,7 +5,8 @@ details: |
     are correct for snapfuse.
 
 # only 20.04+, we want lxd images that come with snaps preinstalled.
-systems: [ubuntu-20*, ubuntu-21.04*, ubuntu-21.10*]
+# TODO: add ubuntu-22.04-* once the lxd image is published
+systems: [ubuntu-20*, ubuntu-21.10*]
 
 restore: |
     lxd.lxc stop ubuntu --force || true

--- a/tests/main/lxd-try/task.yaml
+++ b/tests/main/lxd-try/task.yaml
@@ -1,6 +1,7 @@
 summary: Check that try command works inside lxd container
 
-systems: [ubuntu-20.04-*, ubuntu-21.04-*, ubuntu-21.10-*]
+# TODO: add ubuntu-22.04-* once the lxd image is published
+systems: [ubuntu-20.04-*, ubuntu-21.10-*]
 
 prepare: |
   echo "Install lxd"

--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -9,7 +9,7 @@ backends: [-autopkgtest]
 # ubuntu-18.04-32: i386 is not supported by lxd
 # ubuntu-21.10-*: failing currently with
 # "Setup snap "core" (11993) security profiles (cannot run udev triggers: exit status 1"
-systems: [ubuntu-16*, ubuntu-18.04-64, ubuntu-20*, ubuntu-21.04-*, ubuntu-core-*]
+systems: [ubuntu-16*, ubuntu-18.04-64, ubuntu-20*, ubuntu-core-*]
 
 # Start before anything else as it can take a really long time.
 priority: 1000

--- a/tests/main/os.query/task.yaml
+++ b/tests/main/os.query/task.yaml
@@ -57,13 +57,6 @@ execute: |
             not os.query is-core
             os.query is-ubuntu
             ;;
-        ubuntu-21.04-*)
-            os.query is-classic
-            os.query is-hirsute
-            not os.query is-focal
-            not os.query is-core
-            os.query is-ubuntu
-            ;;
         ubuntu-21.10-*)
             os.query is-classic
             os.query is-impish


### PR DESCRIPTION
ubuntu 21.04 is not getting support anymore so it is removed from regular tests executions