### PR TITLE
tests: add back systemd-timesyncd to newer debian distros

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -648,6 +648,7 @@ pkg_dependencies_ubuntu_classic(){
             echo "
                  bpftool
                  strace
+                 systemd-timesyncd
                  "
             ;;
     esac


### PR DESCRIPTION
This package was initially added in #10949 to all debian distros in
order to fix the interfaces-timeserver-control test, but was recently
reverted in 958ee4bd7bfd46309e8ca79fdf8d72b66de9a0b2 as the package was
not present in debian-10.

So let's try to add it only to debian sid and debian 11.
