### PR TITLE
tests: skip bind mount in snapd-snap test when the core snap in not repacked

### DIFF
--- a/tests/main/snapd-snap/task.yaml
+++ b/tests/main/snapd-snap/task.yaml
@@ -120,12 +120,15 @@ prepare: |
         # on top of the repacked one, then snapd will just serve the correct
         # file over HTTP to snapcraft when it asks for it
 
-        CORE_SNAP_REV=$(snap list core | grep -v Name | awk '{print $3}')
-        CORE_SNAP="/var/lib/snapd/snaps/core_${CORE_SNAP_REV}.snap"
-        ORIG_CORE_SNAP=${CORE_SNAP}.orig
-        
-        mount --bind "$ORIG_CORE_SNAP" "$CORE_SNAP"
-        tests.cleanup defer umount "$CORE_SNAP"
+        # when the SRU validation tests are executed, the core snap is not repacked
+        if [ "$MODIFY_CORE_SNAP_FOR_REEXEC" = 0 ]; then
+            CORE_SNAP_REV=$(snap list core | grep -v Name | awk '{print $3}')
+            CORE_SNAP="/var/lib/snapd/snaps/core_${CORE_SNAP_REV}.snap"
+            ORIG_CORE_SNAP=${CORE_SNAP}.orig
+
+            mount --bind "$ORIG_CORE_SNAP" "$CORE_SNAP"
+            tests.cleanup defer umount "$CORE_SNAP"
+        fi
     fi
 
 execute: |


### PR DESCRIPTION
This test is failing on sru validation with the following error:

mount --bind /var/lib/snapd/snaps/core_11993.snap.orig
/var/lib/snapd/snaps/core_11993.snap
mount: /var/lib/snapd/snaps/core_11993.snap: special device
/var/lib/snapd/snaps/core_11993.snap.orig does not exist.

To reproduce run:
 SPREAD_MODIFY_CORE_SNAP_FOR_REEXEC=0 SPREAD_TRUST_TEST_KEYS=false SPREAD_SNAP_REEXEC=0 SPREAD_CORE_CHANNEL=stable SPREAD_SRU_VALIDATION=1 spread -debug google-sru:ubuntu-20.04-64:tests/main/snapd-snap:lxd