### PR TITLE
tests: fix snaps-state test for sru validation

### DIFF
--- a/tests/main/snaps-state/task.yaml
+++ b/tests/main/snaps-state/task.yaml
@@ -122,6 +122,12 @@ execute: |
         echo "$sum" | awk '{print $1}'
     }
 
+    # Skip test repack when the sru validation is being executed, in this
+    # scenario the deb package used comes from the sru and repack is not done
+    if [ "$SRU_VALIDATION" = 1 ]; then
+        exit 0
+    fi
+
     # Check the repack of the snapd deb into core and snapd snaps. This check is executed
     # on ubuntu/debian systems where the snapd_*.deb is generated while the system is prepared
     if ls "$SPREAD_PATH"/../snapd_*.deb; then


### PR DESCRIPTION
Skip validation of repacking when the sru validation is being executed, in this scenario the deb package used comes from the sru and repack is not done

To reproduce the issue, run: 
SPREAD_MODIFY_CORE_SNAP_FOR_REEXEC=0 SPREAD_TRUST_TEST_KEYS=false SPREAD_SNAP_REEXEC=0 SPREAD_CORE_CHANNEL=stable SPREAD_SRU_VALIDATION=1 spread -debug google-sru:ubuntu-20.04-64:tests/main/snaps-state