### PR TITLE
tests: Handle PPAs being served from ppa.launchpadcontent.net

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -401,7 +401,7 @@ distro_install_build_snapd(){
         apt update
 
         # Double check that it really comes from the PPA
-        apt show snapd | grep "APT-Sources: http.*ppa.launchpad.net"
+        apt show snapd | grep -E "APT-Sources: http.*ppa\.launchpad(content)?\.net"
     else
         packages=
         case "$SPREAD_SYSTEM" in


### PR DESCRIPTION
We now have a new HTTPS-capable domain for public PPAs, namely
ppa.launchpadcontent.net.  Adjust a test to accept that.
