### PR TITLE
tests: ensure the ca-certificates package is installed

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -510,6 +510,7 @@ pkg_dependencies_ubuntu_generic(){
         automake
         autotools-dev
         build-essential
+        ca-certificates
         clang
         curl
         devscripts


### PR DESCRIPTION
On autopkgtest based ubuntu-20.04 the ca-certificates package is
not installed by default. This will lead to spread failures when
the prepare code tries to checkout code and cannot validate the
https certs. Therefore this commit ensures the package is
installed.

