### PR TITLE
overlord/servicestate: disallow mixing snaps and subgroups.

### DIFF
--- a/overlord/servicestate/quota_control.go
+++ b/overlord/servicestate/quota_control.go
@@ -267,6 +267,12 @@ func UpdateQuota(st *state.State, name string, updateOpts QuotaGroupUpdate) (*st
 		return nil, fmt.Errorf("cannot update group %q: %v", name, err)
 	}
 
+	// ensure that the group we are modifying does not contain a mix of snaps and sub-groups
+	// as we no longer support this, and existing quota groups might have this
+	if err := ensureGroupIsNotMixed(name, allGrps); err != nil {
+		return nil, err
+	}
+
 	// now ensure that all of the snaps mentioned in AddSnaps exist as snaps and
 	// that they aren't already in an existing quota group
 	if err := validateSnapForAddingToGroup(st, updateOpts.AddSnaps, name, allGrps); err != nil {

--- a/overlord/servicestate/quota_control_test.go
+++ b/overlord/servicestate/quota_control_test.go
@@ -1169,3 +1169,55 @@ devices	10	135	1`)
 	c.Assert(err, NotNil)
 	c.Assert(err, ErrorMatches, errExpected)
 }
+
+// mockMixedQuotaGroup creates a new quota group mixed with the provided snaps and
+// a single sub-group with the same name appended with 'sub'. The group is created with
+// the memory limit of 1GB, and the subgroup has a limit of 512MB.
+func (s *quotaControlSuite) mockMixedQuotaGroup(name string, snaps []string) error {
+	st := s.state
+
+	// create the quota group
+	grp, err := quota.NewGroup(name, quota.NewResources(quantity.SizeGiB))
+	if err != nil {
+		return err
+	}
+
+	subGrpName := name + "-sub"
+	subGrp, err := grp.NewSubGroup(subGrpName, quota.NewResources(quantity.SizeGiB/2))
+	if err != nil {
+		return err
+	}
+
+	grp.Snaps = snaps
+
+	var quotas map[string]*quota.Group
+	if err := st.Get("quotas", &quotas); err != nil {
+		if err != state.ErrNoState {
+			return err
+		}
+		quotas = make(map[string]*quota.Group)
+	}
+	quotas[name] = grp
+	quotas[subGrpName] = subGrp
+	st.Set("quotas", quotas)
+	return nil
+}
+
+func (s *quotaControlSuite) TestUpdateQuotaModifyExistingMixable(c *C) {
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	// setup the snap so it exists
+	snapstate.Set(s.state, "test-snap", s.testSnapState)
+	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
+
+	err := s.mockMixedQuotaGroup("mixed-grp", []string{"test-snap"})
+	c.Assert(err, IsNil)
+
+	// try to update a quota value, this must fail
+	_, err = servicestate.UpdateQuota(st, "mixed-grp", servicestate.QuotaGroupUpdate{
+		NewResourceLimits: quota.NewResources(quantity.SizeGiB * 2),
+	})
+	c.Assert(err, ErrorMatches, `quota group \"mixed-grp\" has mixed snaps and sub-groups, which is not supported anymore. please remove it and create it again to make any modifications`)
+}

--- a/overlord/servicestate/quota_control_test.go
+++ b/overlord/servicestate/quota_control_test.go
@@ -1186,5 +1186,5 @@ func (s *quotaControlSuite) TestUpdateQuotaModifyExistingMixable(c *C) {
 	_, err = servicestate.UpdateQuota(st, "mixed-grp", servicestate.QuotaGroupUpdate{
 		NewResourceLimits: quota.NewResources(quantity.SizeGiB * 2),
 	})
-	c.Assert(err, ErrorMatches, `quota group \"mixed-grp\" has mixed snaps and sub-groups, which is not supported anymore. please remove it and create it again to make any modifications`)
+	c.Assert(err, ErrorMatches, `quota group "mixed-grp" has mixed snaps and sub-groups, which is no longer supported; removal and re-creation is necessary to modify it`)
 }

--- a/overlord/servicestate/quota_handlers.go
+++ b/overlord/servicestate/quota_handlers.go
@@ -605,7 +605,7 @@ func ensureGroupIsNotMixed(group string, allGrps map[string]*quota.Group) error 
 	grp, ok := allGrps[group]
 	if ok {
 		if len(grp.SubGroups) != 0 && len(grp.Snaps) != 0 {
-			return fmt.Errorf("quota group %q has mixed snaps and sub-groups, which is not supported anymore. please remove either snaps or sub-groups to modify this group", group)
+			return fmt.Errorf("quota group %q has mixed snaps and sub-groups, which is not supported anymore. please remove it and create it again to make any modifications", group)
 		}
 	}
 	return nil

--- a/overlord/servicestate/quota_handlers.go
+++ b/overlord/servicestate/quota_handlers.go
@@ -604,7 +604,7 @@ func ensureSnapServicesStateForGroup(st *state.State, grp *quota.Group, opts *en
 func ensureGroupIsNotMixed(group string, allGrps map[string]*quota.Group) error {
 	grp, ok := allGrps[group]
 	if ok && len(grp.SubGroups) != 0 && len(grp.Snaps) != 0 {
-		return fmt.Errorf("quota group %q has mixed snaps and sub-groups, which is not supported anymore. please remove it and create it again to make any modifications", group)
+		return fmt.Errorf("quota group %q has mixed snaps and sub-groups, which is no longer supported; removal and re-creation is necessary to modify it", group)
 	}
 	return nil
 }

--- a/overlord/servicestate/quota_handlers.go
+++ b/overlord/servicestate/quota_handlers.go
@@ -596,6 +596,16 @@ func ensureSnapServicesStateForGroup(st *state.State, grp *quota.Group, opts *en
 }
 
 func validateSnapForAddingToGroup(st *state.State, snaps []string, group string, allGrps map[string]*quota.Group) error {
+	grp, ok := allGrps[group]
+	if ok {
+		// With the new quotas we do not support groups that have a mixture of snaps and
+		// subgroups, as this will cause issues with nesting. Groups/subgroups may now
+		// only consist of either snaps or subgroups.
+		if len(grp.SubGroups) != 0 {
+			return fmt.Errorf("cannot mix snaps and sub groups in the group %q", group)
+		}
+	}
+
 	for _, name := range snaps {
 		// validate that the snap exists
 		_, err := snapstate.CurrentInfo(st, name)

--- a/overlord/servicestate/quota_handlers_test.go
+++ b/overlord/servicestate/quota_handlers_test.go
@@ -60,7 +60,8 @@ func (s *quotaHandlersSuite) SetUpTest(c *C) {
 
 // mockMixedQuotaGroup creates a new quota group mixed with the provided snaps and
 // a single sub-group with the same name appended with 'sub'. The group is created with
-// the memory limit of 1GB, and the subgroup has a limit of 512MB.
+// the memory limit of 1GB, and the subgroup has a limit of 512MB. We do this test as
+// this type of mixed groups were supported when the feature was experimental.
 func mockMixedQuotaGroup(st *state.State, name string, snaps []string) error {
 	// create the quota group
 	grp, err := quota.NewGroup(name, quota.NewResources(quantity.SizeGiB))
@@ -918,7 +919,7 @@ func (s *quotaHandlersSuite) TestQuotaSnapModifyExistingMixable(c *C) {
 		ResourceLimits: quota.NewResources(2 * quantity.SizeGiB),
 	}
 	err = s.callDoQuotaControl(&qc)
-	c.Assert(err, ErrorMatches, `quota group \"mixed-grp\" has mixed snaps and sub-groups, which is not supported anymore. please remove it and create it again to make any modifications`)
+	c.Assert(err, ErrorMatches, `quota group "mixed-grp" has mixed snaps and sub-groups, which is no longer supported; removal and re-creation is necessary to modify it`)
 }
 
 func (s *quotaHandlersSuite) TestQuotaSnapCanRemoveMixed(c *C) {

--- a/overlord/servicestate/quota_handlers_test.go
+++ b/overlord/servicestate/quota_handlers_test.go
@@ -920,7 +920,7 @@ func (s *quotaHandlersSuite) TestQuotaSnapModifyExistingMixable(c *C) {
 		ResourceLimits: quota.NewResources(2 * quantity.SizeGiB),
 	}
 	err = s.callDoQuotaControl(&qc)
-	c.Assert(err, ErrorMatches, `quota group \"mixed-grp\" has mixed snaps and sub-groups, which is not supported anymore. please remove either snaps or sub-groups to modify this group`)
+	c.Assert(err, ErrorMatches, `quota group \"mixed-grp\" has mixed snaps and sub-groups, which is not supported anymore. please remove it and create it again to make any modifications`)
 }
 
 func (s *quotaHandlersSuite) TestQuotaSnapSubgroupUnmixable(c *C) {

--- a/snap/quota/quota.go
+++ b/snap/quota/quota.go
@@ -222,7 +222,7 @@ func (grp *Group) NewSubGroup(name string, resourceLimits Resources) (*Group, er
 		return nil, fmt.Errorf("cannot use same name %q for sub group as parent group", name)
 	}
 
-	// With the new quotas we not support groups that have a mixture of snaps and
+	// With the new quotas we don't support groups that have a mixture of snaps and
 	// subgroups, as this will cause issues with nesting. Groups/subgroups may now
 	// only consist of either snaps or subgroups.
 	if len(grp.Snaps) != 0 {

--- a/snap/quota/quota.go
+++ b/snap/quota/quota.go
@@ -222,6 +222,13 @@ func (grp *Group) NewSubGroup(name string, resourceLimits Resources) (*Group, er
 		return nil, fmt.Errorf("cannot use same name %q for sub group as parent group", name)
 	}
 
+	// With the new quotas we not support groups that have a mixture of snaps and
+	// subgroups, as this will cause issues with nesting. Groups/subgroups may now
+	// only consist of either snaps or subgroups.
+	if len(grp.Snaps) != 0 {
+		return nil, fmt.Errorf("cannot mix sub groups with snaps in the same group")
+	}
+
 	if err := subGrp.validate(); err != nil {
 		return nil, err
 	}

--- a/snap/quota/quota_test.go
+++ b/snap/quota/quota_test.go
@@ -276,6 +276,18 @@ func (ts *quotaTestSuite) TestComplexSubGroups(c *C) {
 	c.Assert(subsubsub1.SliceFileName(), Equals, "snap.myroot-sub1-subsub1-subsubsub1.slice")
 }
 
+func (ts *quotaTestSuite) TestGroupUnmixableSnapsSubgroups(c *C) {
+	parent, err := quota.NewGroup("parent", quota.NewResources(quantity.SizeMiB))
+	c.Assert(err, IsNil)
+
+	// now we add a snap to the parent group
+	parent.Snaps = []string{"test-snap"}
+
+	// add a subgroup to the parent group, this should fail as the group now has snaps
+	_, err = parent.NewSubGroup("sub", quota.NewResources(quantity.SizeMiB/2))
+	c.Assert(err, ErrorMatches, "cannot mix sub groups with snaps in the same group")
+}
+
 func (ts *quotaTestSuite) TestResolveCrossReferences(c *C) {
 	tt := []struct {
 		grps    map[string]*quota.Group

--- a/tests/main/snap-quota/task.yaml
+++ b/tests/main/snap-quota/task.yaml
@@ -48,10 +48,11 @@ execute: |
   # this line could be either for memory=0 in the current column, in which case
   # it is omitted entirely, or it could be memory=4096 on some systems where 
   # empty cgroups have 4K memory usage even on empty cgroups
-  MATCH "     4\s+group-sub-three\s+group-three\s+memory=10.0kB(\s*|\s*memory=4096B)\s*$" < quotas.txt
-  MATCH "     5\s+group-sub-sub-three\s+group-sub-three\s+memory=5000B\s*$" < quotas.txt
-  MATCH "     6\s+group-two\s+group-top1\s+memory=2.00MB\s*$" < quotas.txt
-  MATCH "     7\s+group-top2\s+memory=500MB\s*$" < quotas.txt
+  MATCH "     4\s+group-three\s+group-top1\s+memory=15.0MB\s*$" < quotas.txt
+  MATCH "     5\s+group-sub-three\s+group-three\s+memory=10.0kB(\s*|\s*memory=4096B)\s*$" < quotas.txt
+  MATCH "     6\s+group-sub-sub-three\s+group-sub-three\s+memory=5000B\s*$" < quotas.txt
+  MATCH "     7\s+group-two\s+group-top1\s+memory=2.00MB\s*$" < quotas.txt
+  MATCH "     8\s+group-top2\s+memory=500MB\s*$" < quotas.txt
 
   echo "Checking quota group details"
   snap quota group-one | cat -n > details.txt
@@ -61,11 +62,9 @@ execute: |
   MATCH "     4\s+memory:\s+100MB$" < details.txt
   MATCH "     5\s+current:$" < details.txt
   MATCH "     6\s+memory:\s+[0-9.a-zA-Z]+B$" < details.txt
-  MATCH "     7\s+subgroups:$" < details.txt
-  MATCH "     8\s+- group-sub-one$" < details.txt
-  MATCH "     9\s+snaps:$" < details.txt
-  MATCH "    10\s+-\s+hello-world$" < details.txt
-  MATCH "    11\s+-\s+go-example-webserver$" < details.txt
+  MATCH "     7\s+snaps:$" < details.txt
+  MATCH "     8\s+-\s+hello-world$" < details.txt
+  MATCH "     9\s+-\s+go-example-webserver$" < details.txt
 
   echo "Checking that quota groups can be removed"
   snap remove-quota group-two

--- a/tests/main/snap-quota/task.yaml
+++ b/tests/main/snap-quota/task.yaml
@@ -48,7 +48,7 @@ execute: |
   # this line could be either for memory=0 in the current column, in which case
   # it is omitted entirely, or it could be memory=4096 on some systems where 
   # empty cgroups have 4K memory usage even on empty cgroups
-  MATCH "     4\s+group-three\s+group-top1\s+memory=15.0MB\s*$" < quotas.txt
+  MATCH "     4\s+group-three\s+group-top1\s+memory=[0-9.a-zA-Z]\s*$" < quotas.txt
   MATCH "     5\s+group-sub-three\s+group-three\s+memory=10.0kB(\s*|\s*memory=4096B)\s*$" < quotas.txt
   MATCH "     6\s+group-sub-sub-three\s+group-sub-three\s+memory=5000B\s*$" < quotas.txt
   MATCH "     7\s+group-two\s+group-top1\s+memory=2.00MB\s*$" < quotas.txt

--- a/tests/main/snap-quota/task.yaml
+++ b/tests/main/snap-quota/task.yaml
@@ -26,9 +26,13 @@ execute: |
   snap set-quota group-one --parent=group-top1 --memory=100MB hello-world
   snap set-quota group-two --parent=group-top1 --memory=2MB test-snapd-tools
 
-  echo "Creating some more nested empty quota groups"
-  snap set-quota group-sub-one --parent=group-one --memory=10KB
-  snap set-quota group-sub-sub-one --parent=group-sub-one --memory=5KB
+  echo "Creating a nested empty quota groups which fails"
+  snap set-quota group-sub-one --parent=group-one --memory=10KB 2>&1 | tr '\n' ' ' | tr -s ' ' | MATCH 'cannot mix sub groups with snaps in the same group'
+
+  echo "Creating some empty quota sub groups"
+  snap set-quota group-three --parent=group-top1 --memory=15MB
+  snap set-quota group-sub-three --parent=group-three --memory=10KB
+  snap set-quota group-sub-sub-three --parent=group-sub-three --memory=5KB
 
   echo "Trying to add snap to more than one group fails"
   snap set-quota group-bad --memory=1MB hello-world 2>&1 | tr '\n' ' ' | tr -s ' ' | MATCH 'error: cannot create quota group: cannot add snap "hello-world" to group "group-bad": snap already in quota group "group-one"'
@@ -44,8 +48,8 @@ execute: |
   # this line could be either for memory=0 in the current column, in which case
   # it is omitted entirely, or it could be memory=4096 on some systems where 
   # empty cgroups have 4K memory usage even on empty cgroups
-  MATCH "     4\s+group-sub-one\s+group-one\s+memory=10.0kB(\s*|\s*memory=4096B)\s*$" < quotas.txt
-  MATCH "     5\s+group-sub-sub-one\s+group-sub-one\s+memory=5000B\s*$" < quotas.txt
+  MATCH "     4\s+group-sub-three\s+group-one\s+memory=10.0kB(\s*|\s*memory=4096B)\s*$" < quotas.txt
+  MATCH "     5\s+group-sub-sub-three\s+group-sub-three\s+memory=5000B\s*$" < quotas.txt
   MATCH "     6\s+group-two\s+group-top1\s+memory=2.00MB\s*$" < quotas.txt
   MATCH "     7\s+group-top2\s+memory=500MB\s*$" < quotas.txt
 

--- a/tests/main/snap-quota/task.yaml
+++ b/tests/main/snap-quota/task.yaml
@@ -48,7 +48,7 @@ execute: |
   # this line could be either for memory=0 in the current column, in which case
   # it is omitted entirely, or it could be memory=4096 on some systems where 
   # empty cgroups have 4K memory usage even on empty cgroups
-  MATCH "     4\s+group-three\s+group-top1\s+memory=[0-9.a-zA-Z]\s*$" < quotas.txt
+  MATCH "     4\s+group-three\s+group-top1\s+memory=15.0MB(\s*|\s*memory=[0-9.a-zA-Z]+)\s*$" < quotas.txt
   MATCH "     5\s+group-sub-three\s+group-three\s+memory=10.0kB(\s*|\s*memory=4096B)\s*$" < quotas.txt
   MATCH "     6\s+group-sub-sub-three\s+group-sub-three\s+memory=5000B\s*$" < quotas.txt
   MATCH "     7\s+group-two\s+group-top1\s+memory=2.00MB\s*$" < quotas.txt

--- a/tests/main/snap-quota/task.yaml
+++ b/tests/main/snap-quota/task.yaml
@@ -48,7 +48,7 @@ execute: |
   # this line could be either for memory=0 in the current column, in which case
   # it is omitted entirely, or it could be memory=4096 on some systems where 
   # empty cgroups have 4K memory usage even on empty cgroups
-  MATCH "     4\s+group-sub-three\s+group-one\s+memory=10.0kB(\s*|\s*memory=4096B)\s*$" < quotas.txt
+  MATCH "     4\s+group-sub-three\s+group-three\s+memory=10.0kB(\s*|\s*memory=4096B)\s*$" < quotas.txt
   MATCH "     5\s+group-sub-sub-three\s+group-sub-three\s+memory=5000B\s*$" < quotas.txt
   MATCH "     6\s+group-two\s+group-top1\s+memory=2.00MB\s*$" < quotas.txt
   MATCH "     7\s+group-top2\s+memory=500MB\s*$" < quotas.txt


### PR DESCRIPTION
This PR disallows the mixing of snaps and quota subgroups in quota groups. The reason this is neccessary is because of the new quotas that we are implementing. Journal quotas and storage quotas do not support such nesting, and in this case it doesn't make sense for us to allow either. So it's better if we just allow groups to either contain subgroups only, or snaps only.