### PR TITLE
snap/quota: add positive tests for the quota.Resources logic

### DIFF
--- a/snap/quota/resources_test.go
+++ b/snap/quota/resources_test.go
@@ -30,7 +30,7 @@ type resourcesTestSuite struct{}
 
 var _ = Suite(&resourcesTestSuite{})
 
-func (s *resourcesTestSuite) TestQuotaValidation(c *C) {
+func (s *resourcesTestSuite) TestQuotaValidationFails(c *C) {
 	tests := []struct {
 		limits quota.Resources
 		err    string
@@ -45,7 +45,20 @@ func (s *resourcesTestSuite) TestQuotaValidation(c *C) {
 	}
 }
 
-func (s *resourcesTestSuite) TestQuotaChangeValidation(c *C) {
+func (s *resourcesTestSuite) TestQuotaValidationPasses(c *C) {
+	tests := []struct {
+		limits quota.Resources
+	}{
+		{quota.NewResources(quantity.SizeMiB)},
+	}
+
+	for _, t := range tests {
+		err := t.limits.Validate()
+		c.Check(err, IsNil)
+	}
+}
+
+func (s *resourcesTestSuite) TestQuotaChangeValidationFails(c *C) {
 	tests := []struct {
 		limits       quota.Resources
 		updateLimits quota.Resources
@@ -58,5 +71,19 @@ func (s *resourcesTestSuite) TestQuotaChangeValidation(c *C) {
 	for _, t := range tests {
 		err := t.limits.Change(t.updateLimits)
 		c.Check(err, ErrorMatches, t.err)
+	}
+}
+
+func (s *resourcesTestSuite) TestQuotaChangeValidationPasses(c *C) {
+	tests := []struct {
+		limits       quota.Resources
+		updateLimits quota.Resources
+	}{
+		{quota.NewResources(quantity.SizeMiB), quota.NewResources(quantity.SizeGiB)},
+	}
+
+	for _, t := range tests {
+		err := t.limits.Change(t.updateLimits)
+		c.Check(err, IsNil)
 	}
 }

--- a/snap/quota/resources_test.go
+++ b/snap/quota/resources_test.go
@@ -50,6 +50,7 @@ func (s *resourcesTestSuite) TestQuotaValidationPasses(c *C) {
 		limits quota.Resources
 	}{
 		{quota.NewResources(quantity.SizeMiB)},
+		// expect more tests as the number of quotas grow
 	}
 
 	for _, t := range tests {
@@ -78,12 +79,19 @@ func (s *resourcesTestSuite) TestQuotaChangeValidationPasses(c *C) {
 	tests := []struct {
 		limits       quota.Resources
 		updateLimits quota.Resources
+
+		// this is not strictly neccessary as we only have one limit right now
+		// but as we add additional limits, the updateLimits will not
+		// equal limits or newLimits as it can contain partial updates.
+		newLimits quota.Resources
 	}{
-		{quota.NewResources(quantity.SizeMiB), quota.NewResources(quantity.SizeGiB)},
+		{quota.NewResources(quantity.SizeMiB), quota.NewResources(quantity.SizeGiB), quota.NewResources(quantity.SizeGiB)},
+		// expect more tests as the number of quotas grow
 	}
 
 	for _, t := range tests {
 		err := t.limits.Change(t.updateLimits)
 		c.Check(err, IsNil)
+		c.Check(t.limits, DeepEquals, t.newLimits)
 	}
 }

--- a/snap/quota/resources_test.go
+++ b/snap/quota/resources_test.go
@@ -80,7 +80,7 @@ func (s *resourcesTestSuite) TestQuotaChangeValidationPasses(c *C) {
 		limits       quota.Resources
 		updateLimits quota.Resources
 
-		// this is not strictly neccessary as we only have one limit right now
+		// this is not strictly necessary as we only have one limit right now
 		// but as we add additional limits, the updateLimits will not
 		// equal limits or newLimits as it can contain partial updates.
 		newLimits quota.Resources


### PR DESCRIPTION
There were some missing test cases for the Resources.Validate logic. This adds test cases that verify that Validate and ValidateChange can actually give some positive feedback as well as negative.