### PR TITLE
many: add transactional flag to snapd API

### DIFF
--- a/client/snap_op.go
+++ b/client/snap_op.go
@@ -61,8 +61,8 @@ type field struct {
 	value bool
 }
 
-func writeFields(mw *multipart.Writer, fields *[]field) error {
-	for _, fd := range *fields {
+func writeFields(mw *multipart.Writer, fields []field) error {
+	for _, fd := range fields {
 		if err := writeFieldBool(mw, fd.field, fd.value); err != nil {
 			return err
 		}
@@ -72,7 +72,7 @@ func writeFields(mw *multipart.Writer, fields *[]field) error {
 }
 
 func (opts *SnapOptions) writeModeFields(mw *multipart.Writer) error {
-	fields := &[]field{
+	fields := []field{
 		{"devmode", opts.DevMode},
 		{"classic", opts.Classic},
 		{"jailmode", opts.JailMode},
@@ -82,7 +82,7 @@ func (opts *SnapOptions) writeModeFields(mw *multipart.Writer) error {
 }
 
 func (opts *SnapOptions) writeOptionFields(mw *multipart.Writer) error {
-	fields := &[]field{
+	fields := []field{
 		{"ignore-running", opts.IgnoreRunning},
 		{"unaliased", opts.Unaliased},
 		{"transactional", opts.Transactional},
@@ -204,9 +204,7 @@ func (client *Client) doMultiSnapActionFull(actionName string, snaps []string, o
 		Snaps:  snaps,
 	}
 	if options != nil {
-		if options.Dangerous {
-			return nil, "", ErrDangerousNotApplicable
-		}
+		// TODO consider returning error when options.Dangerous is set
 		action.Users = options.Users
 		action.Transactional = options.Transactional
 	}

--- a/client/snap_op.go
+++ b/client/snap_op.go
@@ -204,7 +204,7 @@ func (client *Client) doMultiSnapActionFull(actionName string, snaps []string, o
 		Snaps:  snaps,
 	}
 	if options != nil {
-		// TODO consider returning error when options.Dangerous is set
+		// TODO: consider returning error when options.Dangerous is set
 		action.Users = options.Users
 		action.Transactional = options.Transactional
 	}

--- a/client/snap_op_test.go
+++ b/client/snap_op_test.go
@@ -469,9 +469,9 @@ func (cs *clientSuite) TestClientOpInstallDangerous(c *check.C) {
 	_, err = cs.cli.Install("foo", &opts)
 	c.Assert(err, check.Equals, client.ErrDangerousNotApplicable)
 
-	// nor does InstallMany
+	// InstallMany just ignores it without error for the moment
 	_, err = cs.cli.InstallMany([]string{"foo"}, &opts)
-	c.Assert(err, check.NotNil)
+	c.Assert(err, check.IsNil)
 }
 
 func (cs *clientSuite) TestClientOpInstallUnaliased(c *check.C) {

--- a/client/snap_op_test.go
+++ b/client/snap_op_test.go
@@ -186,6 +186,37 @@ func (cs *clientSuite) TestClientMultiOpSnap(c *check.C) {
 	}
 }
 
+func (cs *clientSuite) TestClientMultiOpSnapTransactional(c *check.C) {
+	cs.status = 202
+	cs.rsp = `{
+		"change": "d728",
+		"status-code": 202,
+		"type": "async"
+	}`
+	for _, s := range multiOps {
+		// Note body is essentially the same as TestClientMultiSnapshot; keep in sync
+		id, err := s.op(cs.cli, []string{pkgName},
+			&client.SnapOptions{Transactional: true})
+		c.Assert(err, check.IsNil)
+
+		c.Assert(cs.req.Header.Get("Content-Type"), check.Equals, "application/json", check.Commentf(s.action))
+
+		body, err := ioutil.ReadAll(cs.req.Body)
+		c.Assert(err, check.IsNil, check.Commentf(s.action))
+		jsonBody := make(map[string]interface{})
+		err = json.Unmarshal(body, &jsonBody)
+		c.Assert(err, check.IsNil, check.Commentf(s.action))
+		c.Check(jsonBody["action"], check.Equals, s.action, check.Commentf(s.action))
+		c.Check(jsonBody["snaps"], check.DeepEquals, []interface{}{pkgName}, check.Commentf(s.action))
+		c.Check(jsonBody["transactional"], check.Equals, true,
+			check.Commentf(s.action))
+		c.Check(jsonBody, check.HasLen, 3, check.Commentf(s.action))
+
+		c.Check(cs.req.URL.Path, check.Equals, "/v2/snaps", check.Commentf(s.action))
+		c.Check(id, check.Equals, "d728", check.Commentf(s.action))
+	}
+}
+
 func (cs *clientSuite) TestClientMultiSnapshot(c *check.C) {
 	// Note body is essentially the same as TestClientMultiOpSnap; keep in sync
 	cs.status = 202
@@ -339,6 +370,44 @@ func (cs *clientSuite) TestClientOpInstallPathMany(c *check.C) {
 	c.Check(id, check.Equals, "66b3")
 }
 
+func (cs *clientSuite) TestClientOpInstallPathManyTransactionally(c *check.C) {
+	cs.status = 202
+	cs.rsp = `{
+		"change": "66b3",
+		"status-code": 202,
+		"type": "async"
+	}`
+
+	var paths []string
+	names := []string{"foo.snap", "bar.snap"}
+	for _, name := range names {
+		path := filepath.Join(c.MkDir(), name)
+		paths = append(paths, path)
+		c.Assert(ioutil.WriteFile(path, []byte("snap-data"), 0644), check.IsNil)
+	}
+
+	id, err := cs.cli.InstallPathMany(paths, &client.SnapOptions{Transactional: true})
+	c.Assert(err, check.IsNil)
+
+	body, err := ioutil.ReadAll(cs.req.Body)
+	c.Assert(err, check.IsNil)
+
+	for _, name := range names {
+		c.Assert(string(body), check.Matches, fmt.Sprintf(`(?s).*Content-Disposition: form-data; name="snap"; filename="%s"\r\nContent-Type: application/octet-stream\r\n\r\nsnap-data\r\n.*`, name))
+
+	}
+	c.Assert(string(body), check.Matches, `(?s).*Content-Disposition: form-data; name="action"\r\n\r\ninstall\r\n.*`)
+	c.Assert(string(body), check.Matches, `(?s).*Content-Disposition: form-data; name="transactional"\r\n\r\ntrue\r\n.*`)
+
+	c.Check(cs.req.Method, check.Equals, "POST")
+	c.Check(cs.req.URL.Path, check.Equals, "/v2/snaps")
+	c.Assert(cs.req.Header.Get("Content-Type"), check.Matches, "multipart/form-data; boundary=.*")
+
+	_, ok := cs.req.Context().Deadline()
+	c.Assert(ok, check.Equals, false)
+	c.Check(id, check.Equals, "66b3")
+}
+
 func (cs *clientSuite) TestClientOpInstallPathManyWithOptions(c *check.C) {
 	cs.status = 202
 	cs.rsp = `{
@@ -400,9 +469,7 @@ func (cs *clientSuite) TestClientOpInstallDangerous(c *check.C) {
 	_, err = cs.cli.Install("foo", &opts)
 	c.Assert(err, check.Equals, client.ErrDangerousNotApplicable)
 
-	// nor does InstallMany (whether it fails because any option
-	// at all was provided, or because dangerous was provided, is
-	// unimportant)
+	// nor does InstallMany
 	_, err = cs.cli.InstallMany([]string{"foo"}, &opts)
 	c.Assert(err, check.NotNil)
 }
@@ -441,6 +508,44 @@ func (cs *clientSuite) TestClientOpInstallUnaliased(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	c.Assert(string(body), check.Matches, "(?s).*Content-Disposition: form-data; name=\"unaliased\"\r\n\r\ntrue\r\n.*")
+}
+
+func (cs *clientSuite) TestClientOpInstallTransactional(c *check.C) {
+	cs.status = 202
+	cs.rsp = `{
+		"change": "66b3",
+		"status-code": 202,
+		"type": "async"
+	}`
+	bodyData := []byte("snap-data")
+
+	snap := filepath.Join(c.MkDir(), "foo.snap")
+	err := ioutil.WriteFile(snap, bodyData, 0644)
+	c.Assert(err, check.IsNil)
+
+	opts := client.SnapOptions{
+		Transactional: true,
+	}
+
+	_, err = cs.cli.InstallMany([]string{"foo", "bar"}, &opts)
+	c.Assert(err, check.IsNil)
+
+	body, err := ioutil.ReadAll(cs.req.Body)
+	c.Assert(err, check.IsNil)
+	jsonBody := make(map[string]interface{})
+	err = json.Unmarshal(body, &jsonBody)
+	c.Assert(err, check.IsNil, check.Commentf("body: %v", string(body)))
+	c.Check(jsonBody["transactional"], check.Equals, true,
+		check.Commentf("body: %v", string(body)))
+
+	_, err = cs.cli.InstallPath(snap, "", &opts)
+	c.Assert(err, check.IsNil)
+
+	body, err = ioutil.ReadAll(cs.req.Body)
+	c.Assert(err, check.IsNil)
+
+	c.Assert(string(body), check.Matches,
+		"(?s).*Content-Disposition: form-data; name=\"transactional\"\r\n\r\ntrue\r\n.*")
 }
 
 func formToMap(c *check.C, mr *multipart.Reader) map[string]string {

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -828,19 +828,24 @@ func (x *cmdRefresh) Execute([]string) error {
 	}
 
 	names := installedSnapNames(x.Positional.Snaps)
-	opts := &client.SnapOptions{
-		Amend:            x.Amend,
-		Channel:          x.Channel,
-		IgnoreValidation: x.IgnoreValidation,
-		IgnoreRunning:    x.IgnoreRunning,
-		Revision:         x.Revision,
-		CohortKey:        x.Cohort,
-		LeaveCohort:      x.LeaveCohort,
-		Transactional:    x.Transactional,
-	}
-	x.setModes(opts)
 	if len(names) == 1 {
+		opts := &client.SnapOptions{
+			Amend:            x.Amend,
+			Channel:          x.Channel,
+			IgnoreValidation: x.IgnoreValidation,
+			IgnoreRunning:    x.IgnoreRunning,
+			Revision:         x.Revision,
+			CohortKey:        x.Cohort,
+			LeaveCohort:      x.LeaveCohort,
+			Transactional:    x.Transactional,
+		}
+		x.setModes(opts)
 		return x.refreshOne(names[0], opts)
+	}
+	// transactional flag is the only one with meaning when
+	// refreshing many snaps
+	opts := &client.SnapOptions{
+		Transactional: x.Transactional,
 	}
 
 	if x.asksForMode() || x.asksForChannel() {

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -479,6 +479,7 @@ type cmdInstall struct {
 	Cohort           string `long:"cohort"`
 	IgnoreValidation bool   `long:"ignore-validation"`
 	IgnoreRunning    bool   `long:"ignore-running" hidden:"yes"`
+	Transactional    bool   `long:"transactional"`
 	Positional       struct {
 		Snaps []remoteSnapName `positional-arg-name:"<snap>" required:"1"`
 	} `positional-args:"yes" required:"yes"`
@@ -550,8 +551,7 @@ func (x *cmdInstall) installMany(names []string, opts *client.SnapOptions) error
 			return errors.New(i18n.G("cannot specify mode for multiple store snaps (only for one store snap or several local ones)"))
 		}
 
-		// install many doesn't support opts
-		changeID, err = x.client.InstallMany(names, nil)
+		changeID, err = x.client.InstallMany(names, opts)
 	}
 
 	if err != nil {
@@ -624,6 +624,7 @@ func (x *cmdInstall) Execute([]string) error {
 		CohortKey:        x.Cohort,
 		IgnoreValidation: x.IgnoreValidation,
 		IgnoreRunning:    x.IgnoreRunning,
+		Transactional:    x.Transactional,
 	}
 	x.setModes(opts)
 
@@ -666,6 +667,7 @@ type cmdRefresh struct {
 	Time             bool   `long:"time"`
 	IgnoreValidation bool   `long:"ignore-validation"`
 	IgnoreRunning    bool   `long:"ignore-running" hidden:"yes"`
+	Transactional    bool   `long:"transactional"`
 	Positional       struct {
 		Snaps []installedSnapName `positional-arg-name:"<snap>"`
 	} `positional-args:"yes"`
@@ -826,17 +828,18 @@ func (x *cmdRefresh) Execute([]string) error {
 	}
 
 	names := installedSnapNames(x.Positional.Snaps)
+	opts := &client.SnapOptions{
+		Amend:            x.Amend,
+		Channel:          x.Channel,
+		IgnoreValidation: x.IgnoreValidation,
+		IgnoreRunning:    x.IgnoreRunning,
+		Revision:         x.Revision,
+		CohortKey:        x.Cohort,
+		LeaveCohort:      x.LeaveCohort,
+		Transactional:    x.Transactional,
+	}
+	x.setModes(opts)
 	if len(names) == 1 {
-		opts := &client.SnapOptions{
-			Amend:            x.Amend,
-			Channel:          x.Channel,
-			IgnoreValidation: x.IgnoreValidation,
-			IgnoreRunning:    x.IgnoreRunning,
-			Revision:         x.Revision,
-			CohortKey:        x.Cohort,
-			LeaveCohort:      x.LeaveCohort,
-		}
-		x.setModes(opts)
 		return x.refreshOne(names[0], opts)
 	}
 
@@ -851,7 +854,7 @@ func (x *cmdRefresh) Execute([]string) error {
 		return errors.New(i18n.G("a single snap name must be specified when ignoring running apps and hooks"))
 	}
 
-	return x.refreshMany(names, nil)
+	return x.refreshMany(names, opts)
 }
 
 type cmdTry struct {
@@ -1137,6 +1140,8 @@ func init() {
 			"ignore-validation": i18n.G("Ignore validation by other snaps blocking the installation"),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"ignore-running": i18n.G("Ignore running hooks or applications blocking the installation"),
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"transactional": i18n.G("Install a set of snaps transactionally."),
 		}), nil)
 	addCommand("refresh", shortRefreshHelp, longRefreshHelp, func() flags.Commander { return &cmdRefresh{} },
 		colorDescs.also(waitDescs).also(channelDescs).also(modeDescs).also(timeDescs).also(map[string]string{
@@ -1156,6 +1161,8 @@ func init() {
 			"cohort": i18n.G("Refresh the snap into the given cohort"),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"leave-cohort": i18n.G("Refresh the snap out of its cohort"),
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"transactional": i18n.G("Refresh a set of snaps transactionally."),
 		}), nil)
 	addCommand("try", shortTryHelp, longTryHelp, func() flags.Commander { return &cmdTry{} }, waitDescs.also(modeDescs), nil)
 	addCommand("enable", shortEnableHelp, longEnableHelp, func() flags.Commander { return &cmdEnable{} }, waitDescs, nil)

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -920,6 +920,68 @@ func (s *SnapOpSuite) TestInstallPathDangerous(c *check.C) {
 	c.Check(s.srv.n, check.Equals, s.srv.total)
 }
 
+func (s *SnapOpSuite) TestInstallPathManyTransactional(c *check.C) {
+	snaps := []string{"foo.snap", "bar.snap"}
+	total := 4
+	n := 0
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		switch n {
+		case 0:
+			c.Check(r.URL.Path, check.Equals, "/v2/snaps")
+			c.Check(r.Method, check.Equals, "POST")
+
+			form := testForm(r, c)
+			defer form.RemoveAll()
+			c.Check(form.Value["action"], check.DeepEquals, []string{"install"})
+			c.Check(form.Value["transactional"], check.DeepEquals, []string{"true"})
+			c.Check(form.Value, check.HasLen, 2)
+			names, filenames, bodies := formFiles(form, c)
+			for i, name := range names {
+				c.Check(name, check.Equals, "snap")
+				c.Check(filenames[i], check.Equals, snaps[i])
+				c.Assert(string(bodies[i]), check.Equals, "snap-data")
+			}
+			w.WriteHeader(202)
+			fmt.Fprintln(w, `{"type":"async", "change": "42", "status-code": 202}`)
+		case 1:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/changes/42")
+			fmt.Fprintln(w, `{"type": "sync", "result": {"status": "Doing"}}`)
+		case 2:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/changes/42")
+			fmt.Fprintln(w, `{"type": "sync", "result": {"ready": true, "status": "Done", "data": {"snap-names": ["one","two"]}}}`)
+		case 3:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/snaps")
+			fmt.Fprintf(w, `{"type": "sync", "result": [{"name": "one", "version": "1.0", "developer": "bar", "publisher": {"id": "bar-id", "username": "bar", "display-name": "Bar"}},{"name": "two", "version": "2.0", "developer": "baz", "publisher": {"id": "baz-id", "username": "baz", "display-name": "Baz"}}]}\n`)
+
+		default:
+			c.Fatalf("expected to get %d requests, now on %d", total, n+1)
+		}
+
+		n++
+	})
+
+	args := []string{"install", "--transactional"}
+	for _, snap := range snaps {
+		path := filepath.Join(c.MkDir(), snap)
+		args = append(args, path)
+		err := ioutil.WriteFile(path, []byte("snap-data"), 0644)
+		c.Assert(err, check.IsNil)
+	}
+
+	rest, err := snap.Parser(snap.Client()).ParseArgs(args)
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.DeepEquals, []string{})
+
+	c.Check(s.Stdout(), check.Matches, `(?sm).*one 1.0 from Bar installed`)
+	c.Check(s.Stdout(), check.Matches, `(?sm).*two 2.0 from Baz installed`)
+	c.Check(s.Stderr(), check.Equals, "")
+
+	c.Check(n, check.Equals, total)
+}
+
 func (s *SnapOpSuite) TestInstallPathInstance(c *check.C) {
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps")

--- a/daemon/api_sideload_n_try.go
+++ b/daemon/api_sideload_n_try.go
@@ -157,6 +157,7 @@ func sideloadOrTrySnap(c *Command, body io.ReadCloser, boundary string, user *au
 	flags.RemoveSnapPath = true
 	flags.Unaliased = isTrue(form, "unaliased")
 	flags.IgnoreRunning = isTrue(form, "ignore-running")
+	flags.Transactional = isTrue(form, "transactional")
 
 	sideloadFlags := sideloadFlags{
 		Flags:       flags,

--- a/daemon/api_sideload_n_try_test.go
+++ b/daemon/api_sideload_n_try_test.go
@@ -650,7 +650,7 @@ func (s *sideloadSuite) TestSideloadCleanUpUnusedTempSnapFiles(c *check.C) {
 
 func (s *sideloadSuite) TestSideloadManySnaps(c *check.C) {
 	d := s.daemonWithFakeSnapManager(c)
-	expectedFlags := &snapstate.Flags{RemoveSnapPath: true, DevMode: true}
+	expectedFlags := &snapstate.Flags{RemoveSnapPath: true, DevMode: true, Transactional: true}
 
 	restore := daemon.MockSnapstateInstallPathMany(func(_ context.Context, s *state.State, infos []*snap.SideInfo, paths []string, userID int, flags *snapstate.Flags) ([]*state.TaskSet, error) {
 		c.Check(flags, check.DeepEquals, expectedFlags)
@@ -680,6 +680,10 @@ func (s *sideloadSuite) TestSideloadManySnaps(c *check.C) {
 
 	body := "----hello--\r\n" +
 		"Content-Disposition: form-data; name=\"devmode\"\r\n" +
+		"\r\n" +
+		"true\r\n" +
+		"----hello--\r\n"
+	body += "Content-Disposition: form-data; name=\"transactional\"\r\n" +
 		"\r\n" +
 		"true\r\n" +
 		"----hello--\r\n"

--- a/daemon/api_snaps.go
+++ b/daemon/api_snaps.go
@@ -198,6 +198,7 @@ type snapInstruction struct {
 	Unaliased              bool     `json:"unaliased"`
 	Purge                  bool     `json:"purge,omitempty"`
 	SystemRestartImmediate bool     `json:"system-restart-immediate"`
+	Transactional          bool     `json:"transactional"`
 	Snaps                  []string `json:"snaps"`
 	Users                  []string `json:"users"`
 
@@ -568,7 +569,7 @@ func snapInstallMany(inst *snapInstruction, st *state.State) (*snapInstructionRe
 			return nil, fmt.Errorf(i18n.G("cannot install snap with empty name"))
 		}
 	}
-	installed, tasksets, err := snapstateInstallMany(st, inst.Snaps, inst.userID, &snapstate.Flags{})
+	installed, tasksets, err := snapstateInstallMany(st, inst.Snaps, inst.userID, &snapstate.Flags{Transactional: inst.Transactional})
 	if err != nil {
 		return nil, err
 	}
@@ -605,7 +606,7 @@ func snapUpdateMany(inst *snapInstruction, st *state.State) (*snapInstructionRes
 	}
 
 	// TODO: use a per-request context
-	updated, tasksets, err := snapstateUpdateMany(context.TODO(), st, inst.Snaps, inst.userID, nil)
+	updated, tasksets, err := snapstateUpdateMany(context.TODO(), st, inst.Snaps, inst.userID, &snapstate.Flags{Transactional: inst.Transactional})
 	if err != nil {
 		if opts.IsRefreshOfAllSnaps {
 			if err := assertstateRestoreValidationSetsTracking(st); err != nil && !errors.Is(err, state.ErrNoState) {

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -626,6 +626,45 @@ func (s *snapsSuite) TestRefreshAllRestoresValidationSets(c *check.C) {
 }
 
 func (s *snapsSuite) TestRefreshMany(c *check.C) {
+	var calledFlags *snapstate.Flags
+
+	refreshSnapAssertions := false
+	var refreshAssertionsOpts *assertstate.RefreshAssertionsOptions
+	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int, opts *assertstate.RefreshAssertionsOptions) error {
+		refreshSnapAssertions = true
+		refreshAssertionsOpts = opts
+		return nil
+	})()
+
+	defer daemon.MockSnapstateUpdateMany(func(_ context.Context, s *state.State, names []string, userID int, flags *snapstate.Flags) ([]string, []*state.TaskSet, error) {
+		calledFlags = flags
+
+		c.Check(names, check.HasLen, 2)
+		t := s.NewTask("fake-refresh-2", "Refreshing two")
+		return names, []*state.TaskSet{state.NewTaskSet(t)}, nil
+	})()
+
+	d := s.daemon(c)
+	inst := &daemon.SnapInstruction{
+		Action:        "refresh",
+		Transactional: true,
+		Snaps:         []string{"foo", "bar"},
+	}
+	st := d.Overlord().State()
+	st.Lock()
+	res, err := inst.DispatchForMany()(inst, st)
+	st.Unlock()
+	c.Assert(err, check.IsNil)
+	c.Check(res.Summary, check.Equals, `Refresh snaps "foo", "bar"`)
+	c.Check(res.Affected, check.DeepEquals, inst.Snaps)
+	c.Check(refreshSnapAssertions, check.Equals, true)
+	c.Assert(refreshAssertionsOpts, check.NotNil)
+	c.Check(refreshAssertionsOpts.IsRefreshOfAllSnaps, check.Equals, false)
+
+	c.Check(calledFlags.Transactional, check.Equals, true)
+}
+
+func (s *snapsSuite) TestRefreshManyTransactionally(c *check.C) {
 	refreshSnapAssertions := false
 	var refreshAssertionsOpts *assertstate.RefreshAssertionsOptions
 	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int, opts *assertstate.RefreshAssertionsOptions) error {
@@ -695,6 +734,35 @@ func (s *snapsSuite) TestInstallMany(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Check(res.Summary, check.Equals, `Install snaps "foo", "bar"`)
 	c.Check(res.Affected, check.DeepEquals, inst.Snaps)
+}
+
+func (s *snapsSuite) TestInstallManyTransactionally(c *check.C) {
+	var calledFlags *snapstate.Flags
+
+	defer daemon.MockSnapstateInstallMany(func(s *state.State, names []string, userID int, flags *snapstate.Flags) ([]string, []*state.TaskSet, error) {
+		calledFlags = flags
+
+		c.Check(names, check.HasLen, 2)
+		t := s.NewTask("fake-install-2", "Install two")
+		return names, []*state.TaskSet{state.NewTaskSet(t)}, nil
+	})()
+
+	d := s.daemon(c)
+	inst := &daemon.SnapInstruction{
+		Action:        "install",
+		Transactional: true,
+		Snaps:         []string{"foo", "bar"},
+	}
+
+	st := d.Overlord().State()
+	st.Lock()
+	res, err := inst.DispatchForMany()(inst, st)
+	st.Unlock()
+	c.Assert(err, check.IsNil)
+	c.Check(res.Summary, check.Equals, `Install snaps "foo", "bar"`)
+	c.Check(res.Affected, check.DeepEquals, inst.Snaps)
+
+	c.Check(calledFlags.Transactional, check.Equals, true)
 }
 
 func (s *snapsSuite) TestInstallManyEmptyName(c *check.C) {

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -625,7 +625,7 @@ func (s *snapsSuite) TestRefreshAllRestoresValidationSets(c *check.C) {
 	c.Check(refreshAssertionsOpts.IsRefreshOfAllSnaps, check.Equals, true)
 }
 
-func (s *snapsSuite) TestRefreshMany(c *check.C) {
+func (s *snapsSuite) TestRefreshManyTransactionally(c *check.C) {
 	var calledFlags *snapstate.Flags
 
 	refreshSnapAssertions := false
@@ -664,7 +664,7 @@ func (s *snapsSuite) TestRefreshMany(c *check.C) {
 	c.Check(calledFlags.Transactional, check.Equals, true)
 }
 
-func (s *snapsSuite) TestRefreshManyTransactionally(c *check.C) {
+func (s *snapsSuite) TestRefreshMany(c *check.C) {
 	refreshSnapAssertions := false
 	var refreshAssertionsOpts *assertstate.RefreshAssertionsOptions
 	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int, opts *assertstate.RefreshAssertionsOptions) error {


### PR DESCRIPTION
Add transactional flag to snapd API. This is a continuation of https://github.com/snapcore/snapd/pull/11271, and it is the second of a series of three (see https://github.com/snapcore/snapd/pull/11255 for the original PR).