### PR TITLE
tests: skip snap-userd-reexec test when reexec is not enabled

### DIFF
--- a/tests/main/snap-userd-reexec/task.yaml
+++ b/tests/main/snap-userd-reexec/task.yaml
@@ -16,6 +16,11 @@ restore: |
     fi
 
 execute: |
+    if [ "$MODIFY_CORE_SNAP_FOR_REEXEC" = 0 ]; then
+        echo "Reexec is not enabled, exiting..."
+        exit 0
+    fi
+
     snap list | awk "/^core / {print(\$3)}" > prevBoot
 
     echo "Ensure service file is created if missing (e.g. on re-exec)"


### PR DESCRIPTION
When sru validation is executed the reexec is not enabled

To validate the test, run:
SPREAD_MODIFY_CORE_SNAP_FOR_REEXEC=0 SPREAD_TRUST_TEST_KEYS=false SPREAD_SNAP_REEXEC=0 SPREAD_CORE_CHANNEL=stable SPREAD_SRU_VALIDATION=1 spread -shell google-sru:ubuntu-18.04-64:tests/main/snap-userd-reexec