### PR TITLE
asserts: start generalizing attrMatcher

### DIFF
--- a/asserts/constraint_test.go
+++ b/asserts/constraint_test.go
@@ -79,14 +79,14 @@ func (s *attrMatcherSuite) TestSimple(c *C) {
 		"baz": "BAZ",
 	}
 	err = domatch(values, nil)
-	c.Check(err, ErrorMatches, `attribute "bar" value "BAZ" does not match \^\(BAR\)\$`)
+	c.Check(err, ErrorMatches, `field "bar" value "BAZ" does not match \^\(BAR\)\$`)
 
 	values = map[string]interface{}{
 		"foo": "FOO",
 		"baz": "BAZ",
 	}
 	err = domatch(values, nil)
-	c.Check(err, ErrorMatches, `attribute "bar" has constraints but is unset`)
+	c.Check(err, ErrorMatches, `field "bar" has constraints but is unset`)
 }
 
 func (s *attrMatcherSuite) TestSimpleAnchorsVsRegexpAlt(c *C) {
@@ -107,25 +107,25 @@ func (s *attrMatcherSuite) TestSimpleAnchorsVsRegexpAlt(c *C) {
 		"bar": "BARR",
 	}
 	err = domatch(values, nil)
-	c.Check(err, ErrorMatches, `attribute "bar" value "BARR" does not match \^\(BAR|BAZ\)\$`)
+	c.Check(err, ErrorMatches, `field "bar" value "BARR" does not match \^\(BAR|BAZ\)\$`)
 
 	values = map[string]interface{}{
 		"bar": "BBAZ",
 	}
 	err = domatch(values, nil)
-	c.Check(err, ErrorMatches, `attribute "bar" value "BAZZ" does not match \^\(BAR|BAZ\)\$`)
+	c.Check(err, ErrorMatches, `field "bar" value "BAZZ" does not match \^\(BAR|BAZ\)\$`)
 
 	values = map[string]interface{}{
 		"bar": "BABAZ",
 	}
 	err = domatch(values, nil)
-	c.Check(err, ErrorMatches, `attribute "bar" value "BABAZ" does not match \^\(BAR|BAZ\)\$`)
+	c.Check(err, ErrorMatches, `field "bar" value "BABAZ" does not match \^\(BAR|BAZ\)\$`)
 
 	values = map[string]interface{}{
 		"bar": "BARAZ",
 	}
 	err = domatch(values, nil)
-	c.Check(err, ErrorMatches, `attribute "bar" value "BARAZ" does not match \^\(BAR|BAZ\)\$`)
+	c.Check(err, ErrorMatches, `field "bar" value "BARAZ" does not match \^\(BAR|BAZ\)\$`)
 }
 
 func (s *attrMatcherSuite) TestNested(c *C) {
@@ -154,7 +154,7 @@ foo: FOO
 bar: BAZ
 baz: BAZ
 `), nil)
-	c.Check(err, ErrorMatches, `attribute "bar" must be a map`)
+	c.Check(err, ErrorMatches, `field "bar" must be a map`)
 
 	err = domatch(vals(`
 foo: FOO
@@ -164,7 +164,7 @@ bar:
   bar3: BAR3
 baz: BAZ
 `), nil)
-	c.Check(err, ErrorMatches, `attribute "bar\.bar2" value "BAR22" does not match \^\(BAR2\)\$`)
+	c.Check(err, ErrorMatches, `field "bar\.bar2" value "BAR22" does not match \^\(BAR2\)\$`)
 
 	err = domatch(vals(`
 foo: FOO
@@ -175,7 +175,7 @@ bar:
   bar3: BAR3
 baz: BAZ
 `), nil)
-	c.Check(err, ErrorMatches, `attribute "bar\.bar2" must be a scalar or list`)
+	c.Check(err, ErrorMatches, `field "bar\.bar2" must be a scalar or list`)
 }
 
 func (s *attrMatcherSuite) TestAlternative(c *C) {
@@ -213,7 +213,7 @@ func (s *attrMatcherSuite) TestAlternative(c *C) {
 		"baz": "BAR",
 	}
 	err = domatch(values, nil)
-	c.Check(err, ErrorMatches, `no alternative matches: attribute "bar" value "BARR" does not match \^\(BAR\)\$`)
+	c.Check(err, ErrorMatches, `no alternative matches: field "bar" value "BARR" does not match \^\(BAR\)\$`)
 }
 
 func (s *attrMatcherSuite) TestNestedAlternative(c *C) {
@@ -251,7 +251,7 @@ bar:
   bar1: BAR1
   bar2: BAR3
 `), nil)
-	c.Check(err, ErrorMatches, `no alternative for attribute "bar\.bar2" matches: attribute "bar\.bar2" value "BAR3" does not match \^\(BAR2\)\$`)
+	c.Check(err, ErrorMatches, `no alternative for field "bar\.bar2" matches: field "bar\.bar2" value "BAR3" does not match \^\(BAR2\)\$`)
 }
 
 func (s *attrMatcherSuite) TestAlternativeMatchingStringList(c *C) {
@@ -344,7 +344,7 @@ mnt: [{what: "/dev/x*", where: "/foo/*", options: ["rw", "nodev"]}, {what: "/bar
 	c.Assert(err, IsNil)
 
 	err = domatchExtensiveNoMatch(toMatch, nil)
-	c.Check(err, ErrorMatches, `no alternative for attribute "mnt\.0" matches: no alternative for attribute "mnt\.0.options\.1" matches:.*`)
+	c.Check(err, ErrorMatches, `no alternative for field "mnt\.0" matches: no alternative for field "mnt\.0.options\.1" matches:.*`)
 }
 
 func (s *attrMatcherSuite) TestOtherScalars(c *C) {
@@ -443,7 +443,7 @@ foo: ["/foo/x", "/foo/y"]
 	err = domatch(vals(`
 foo: ["/foo/x", "/foo"]
 `), nil)
-	c.Check(err, ErrorMatches, `attribute "foo\.1" value "/foo" does not match \^\(/foo/\.\*\)\$`)
+	c.Check(err, ErrorMatches, `field "foo\.1" value "/foo" does not match \^\(/foo/\.\*\)\$`)
 }
 
 func (s *attrMatcherSuite) TestMissingCheck(c *C) {
@@ -462,7 +462,7 @@ bar: baz
 	err = domatch(vals(`
 foo: ["x"]
 `), nil)
-	c.Check(err, ErrorMatches, `attribute "foo" is constrained to be missing but is set`)
+	c.Check(err, ErrorMatches, `field "foo" is constrained to be missing but is set`)
 }
 
 func (s *attrMatcherSuite) TestEvalCheck(c *C) {
@@ -479,7 +479,7 @@ func (s *attrMatcherSuite) TestEvalCheck(c *C) {
 foo: foo
 bar: bar
 `), nil)
-	c.Check(err, ErrorMatches, `attribute "(foo|bar)" cannot be matched without context`)
+	c.Check(err, ErrorMatches, `field "(foo|bar)" cannot be matched without context`)
 
 	calls := make(map[[2]string]bool)
 	comp1 := func(op string, arg string) (interface{}, error) {
@@ -509,7 +509,7 @@ bar: bar.baz
 foo: foo
 bar: bar.baz
 `), testEvalAttr{comp2})
-	c.Check(err, ErrorMatches, `attribute "bar" constraint \$PLUG\(bar\.baz\) cannot be evaluated: boom`)
+	c.Check(err, ErrorMatches, `field "bar" constraint \$PLUG\(bar\.baz\) cannot be evaluated: boom`)
 
 	comp3 := func(op string, arg string) (interface{}, error) {
 		if op == "slot" {
@@ -522,7 +522,7 @@ bar: bar.baz
 foo: foo
 bar: bar.baz
 `), testEvalAttr{comp3})
-	c.Check(err, ErrorMatches, `attribute "foo" does not match \$SLOT\(foo\): foo != other-value`)
+	c.Check(err, ErrorMatches, `field "foo" does not match \$SLOT\(foo\): foo != other-value`)
 }
 
 func (s *attrMatcherSuite) TestMatchingListsMap(c *C) {
@@ -542,5 +542,5 @@ foo: [{p: "/foo/x"}, {p: "/foo/y"}]
 	err = domatch(vals(`
 foo: [{p: "zzz"}, {p: "/foo/y"}]
 `), nil)
-	c.Check(err, ErrorMatches, `attribute "foo\.0\.p" value "zzz" does not match \^\(/foo/\.\*\)\$`)
+	c.Check(err, ErrorMatches, `field "foo\.0\.p" value "zzz" does not match \^\(/foo/\.\*\)\$`)
 }

--- a/asserts/constraint_test.go
+++ b/asserts/constraint_test.go
@@ -62,7 +62,7 @@ func (s *attrMatcherSuite) TestSimple(c *C) {
   bar: BAR`))
 	c.Assert(err, IsNil)
 
-	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}))
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
 	c.Assert(err, IsNil)
 
 	values := map[string]interface{}{
@@ -94,7 +94,7 @@ func (s *attrMatcherSuite) TestSimpleAnchorsVsRegexpAlt(c *C) {
   bar: BAR|BAZ`))
 	c.Assert(err, IsNil)
 
-	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}))
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
 	c.Assert(err, IsNil)
 
 	values := map[string]interface{}{
@@ -136,7 +136,7 @@ func (s *attrMatcherSuite) TestNested(c *C) {
     bar2: BAR2`))
 	c.Assert(err, IsNil)
 
-	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}))
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
 	c.Assert(err, IsNil)
 
 	err = domatch(vals(`
@@ -188,7 +188,7 @@ func (s *attrMatcherSuite) TestAlternative(c *C) {
     bar: BAZ`))
 	c.Assert(err, IsNil)
 
-	domatch, err := asserts.CompileAttrMatcher(m["attrs"])
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"], nil)
 	c.Assert(err, IsNil)
 
 	values := map[string]interface{}{
@@ -226,7 +226,7 @@ func (s *attrMatcherSuite) TestNestedAlternative(c *C) {
       - BAR22`))
 	c.Assert(err, IsNil)
 
-	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}))
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
 	c.Assert(err, IsNil)
 
 	err = domatch(vals(`
@@ -264,7 +264,7 @@ write:
   write: /var/(tmp|lib/snapd/snapshots)`))
 	c.Assert(err, IsNil)
 
-	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}))
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
 	c.Assert(err, IsNil)
 
 	err = domatch(toMatch, nil)
@@ -276,7 +276,7 @@ write:
     - /var/lib/snapd/snapshots`))
 	c.Assert(err, IsNil)
 
-	domatchLst, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}))
+	domatchLst, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
 	c.Assert(err, IsNil)
 
 	err = domatchLst(toMatch, nil)
@@ -296,7 +296,7 @@ mnt: [{what: "/dev/x*", where: "/foo/*", options: ["rw", "nodev"]}, {what: "/bar
       options: rw|bind|nodev`))
 	c.Assert(err, IsNil)
 
-	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}))
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
 	c.Assert(err, IsNil)
 
 	err = domatch(toMatch, nil)
@@ -318,7 +318,7 @@ mnt: [{what: "/dev/x*", where: "/foo/*", options: ["rw", "nodev"]}, {what: "/bar
         - bind`))
 	c.Assert(err, IsNil)
 
-	domatchExtensive, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}))
+	domatchExtensive, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
 	c.Assert(err, IsNil)
 
 	err = domatchExtensive(toMatch, nil)
@@ -340,7 +340,7 @@ mnt: [{what: "/dev/x*", where: "/foo/*", options: ["rw", "nodev"]}, {what: "/bar
         - bind`))
 	c.Assert(err, IsNil)
 
-	domatchExtensiveNoMatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}))
+	domatchExtensiveNoMatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
 	c.Assert(err, IsNil)
 
 	err = domatchExtensiveNoMatch(toMatch, nil)
@@ -353,7 +353,7 @@ func (s *attrMatcherSuite) TestOtherScalars(c *C) {
   bar: true`))
 	c.Assert(err, IsNil)
 
-	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}))
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
 	c.Assert(err, IsNil)
 
 	err = domatch(vals(`
@@ -371,47 +371,58 @@ bar: true
 }
 
 func (s *attrMatcherSuite) TestCompileErrors(c *C) {
-	_, err := asserts.CompileAttrMatcher(1)
+	_, err := asserts.CompileAttrMatcher(1, nil)
 	c.Check(err, ErrorMatches, `top constraint must be a key-value map, regexp or a list of alternative constraints: 1`)
 
 	_, err = asserts.CompileAttrMatcher(map[string]interface{}{
 		"foo": 1,
-	})
+	}, nil)
 	c.Check(err, ErrorMatches, `constraint "foo" must be a key-value map, regexp or a list of alternative constraints: 1`)
 
 	_, err = asserts.CompileAttrMatcher(map[string]interface{}{
 		"foo": "[",
-	})
+	}, nil)
 	c.Check(err, ErrorMatches, `cannot compile "foo" constraint "\[": error parsing regexp:.*`)
 
 	_, err = asserts.CompileAttrMatcher(map[string]interface{}{
 		"foo": []interface{}{"foo", "["},
-	})
+	}, nil)
 	c.Check(err, ErrorMatches, `cannot compile "foo/alt#2/" constraint "\[": error parsing regexp:.*`)
 
 	_, err = asserts.CompileAttrMatcher(map[string]interface{}{
 		"foo": []interface{}{"foo", []interface{}{"bar", "baz"}},
-	})
+	}, nil)
 	c.Check(err, ErrorMatches, `cannot nest alternative constraints directly at "foo/alt#2/"`)
 
-	_, err = asserts.CompileAttrMatcher("FOO")
+	_, err = asserts.CompileAttrMatcher("FOO", nil)
 	c.Check(err, ErrorMatches, `first level of non alternative constraints must be a set of key-value contraints`)
 
-	_, err = asserts.CompileAttrMatcher([]interface{}{"FOO"})
+	_, err = asserts.CompileAttrMatcher([]interface{}{"FOO"}, nil)
 	c.Check(err, ErrorMatches, `first level of non alternative constraints must be a set of key-value contraints`)
+
+	_, err = asserts.CompileAttrMatcher(map[string]interface{}{
+		"foo": "$FOO()",
+	}, nil)
+	c.Check(err, ErrorMatches, `cannot compile "foo" constraint "\$FOO\(\)": no \$OP\(\) constraints supported`)
 
 	wrongDollarConstraints := []string{
 		"$",
 		"$FOO(a)",
 		"$SLOT",
 		"$SLOT()",
+		"$SLOT(x,y)",
+		"$SLOT(x,y,z)",
 	}
 
 	for _, wrong := range wrongDollarConstraints {
 		_, err := asserts.CompileAttrMatcher(map[string]interface{}{
 			"foo": wrong,
-		})
-		c.Check(err, ErrorMatches, fmt.Sprintf(`cannot compile "foo" constraint "%s": not a valid \$SLOT\(\)/\$PLUG\(\) constraint`, regexp.QuoteMeta(wrong)))
+		}, []string{"SLOT", "OP"})
+		if wrong != "$SLOT(x,y)" {
+			c.Check(err, ErrorMatches, fmt.Sprintf(`cannot compile "foo" constraint "%s": not a valid \$SLOT\(\)/\$OP\(\) constraint`, regexp.QuoteMeta(wrong)))
+		} else {
+			c.Check(err, ErrorMatches, fmt.Sprintf(`cannot compile "foo" constraint "%s": \$SLOT\(\) constraint expects 1 argument`, regexp.QuoteMeta(wrong)))
+		}
 
 	}
 }
@@ -421,7 +432,7 @@ func (s *attrMatcherSuite) TestMatchingListsSimple(c *C) {
   foo: /foo/.*`))
 	c.Assert(err, IsNil)
 
-	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}))
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
 	c.Assert(err, IsNil)
 
 	err = domatch(vals(`
@@ -440,7 +451,7 @@ func (s *attrMatcherSuite) TestMissingCheck(c *C) {
   foo: $MISSING`))
 	c.Assert(err, IsNil)
 
-	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}))
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
 	c.Assert(err, IsNil)
 
 	err = domatch(vals(`
@@ -461,7 +472,7 @@ func (s *attrMatcherSuite) TestEvalCheck(c *C) {
   bar: $PLUG(bar.baz)`))
 	c.Assert(err, IsNil)
 
-	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}))
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), []string{"SLOT", "PLUG"})
 	c.Assert(err, IsNil)
 
 	err = domatch(vals(`
@@ -520,7 +531,7 @@ func (s *attrMatcherSuite) TestMatchingListsMap(c *C) {
     p: /foo/.*`))
 	c.Assert(err, IsNil)
 
-	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}))
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
 	c.Assert(err, IsNil)
 
 	err = domatch(vals(`

--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -291,13 +291,19 @@ func (gkm *GPGKeypairManager) ParametersForGenerate(passphrase string, name stri
 
 // constraint tests
 
-func CompileAttrMatcher(constraints interface{}) (func(attrs map[string]interface{}, ctx AttrMatchContext) error, error) {
-	matcher, err := compileAttrMatcher(compileContext{}, constraints)
+func CompileAttrMatcher(constraints interface{}, allowedOperations []string) (func(attrs map[string]interface{}, helper AttrMatchContext) error, error) {
+	// XXX adjust
+	cc := compileContext{
+		opts: &compileAttrMatcherOptions{
+			allowedOperations: allowedOperations,
+		},
+	}
+	matcher, err := compileAttrMatcher(cc, constraints)
 	if err != nil {
 		return nil, err
 	}
-	domatch := func(attrs map[string]interface{}, ctx AttrMatchContext) error {
-		return matcher.match("", attrs, ctx)
+	domatch := func(attrs map[string]interface{}, helper AttrMatchContext) error {
+		return matcher.match("", attrs, &attrMatchingContext{helper: helper})
 	}
 	return domatch, nil
 }

--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -303,7 +303,10 @@ func CompileAttrMatcher(constraints interface{}, allowedOperations []string) (fu
 		return nil, err
 	}
 	domatch := func(attrs map[string]interface{}, helper AttrMatchContext) error {
-		return matcher.match("", attrs, &attrMatchingContext{helper: helper})
+		return matcher.match("", attrs, &attrMatchingContext{
+			attrWord: "field",
+			helper:   helper,
+		})
 	}
 	return domatch, nil
 }

--- a/asserts/ifacedecls.go
+++ b/asserts/ifacedecls.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015-2017 Canonical Ltd
+ * Copyright (C) 2015-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -54,7 +54,12 @@ func (ac *AttributeConstraints) feature(flabel string) bool {
 // compileAttributeConstraints checks and compiles a mapping or list
 // from the assertion format into AttributeConstraints.
 func compileAttributeConstraints(constraints interface{}) (*AttributeConstraints, error) {
-	matcher, err := compileAttrMatcher(compileContext{}, constraints)
+	cc := compileContext{
+		opts: &compileAttrMatcherOptions{
+			allowedOperations: []string{"SLOT", "PLUG"},
+		},
+	}
+	matcher, err := compileAttrMatcher(cc, constraints)
 	if err != nil {
 		return nil, err
 	}
@@ -69,7 +74,7 @@ func (matcher fixedAttrMatcher) feature(flabel string) bool {
 	return false
 }
 
-func (matcher fixedAttrMatcher) match(apath string, v interface{}, ctx AttrMatchContext) error {
+func (matcher fixedAttrMatcher) match(apath string, v interface{}, ctx *attrMatchingContext) error {
 	return matcher.result
 }
 
@@ -84,8 +89,8 @@ type Attrer interface {
 }
 
 // Check checks whether attrs don't match the constraints.
-func (c *AttributeConstraints) Check(attrer Attrer, ctx AttrMatchContext) error {
-	return c.matcher.match("", attrer, ctx)
+func (c *AttributeConstraints) Check(attrer Attrer, helper AttrMatchContext) error {
+	return c.matcher.match("", attrer, &attrMatchingContext{helper: helper})
 }
 
 // SideArityConstraint specifies a constraint for the overall arity of

--- a/asserts/ifacedecls.go
+++ b/asserts/ifacedecls.go
@@ -90,7 +90,10 @@ type Attrer interface {
 
 // Check checks whether attrs don't match the constraints.
 func (c *AttributeConstraints) Check(attrer Attrer, helper AttrMatchContext) error {
-	return c.matcher.match("", attrer, &attrMatchingContext{helper: helper})
+	return c.matcher.match("", attrer, &attrMatchingContext{
+		attrWord: "attribute",
+		helper:   helper,
+	})
 }
 
 // SideArityConstraint specifies a constraint for the overall arity of


### PR DESCRIPTION
Generalization is along:

* start preparing for different usages to have different sets of $OP() operators allowed
* have usage context specif word instead of "attribute" mainly in errors


