### PR TITLE
tests: skip version check on lp-1871652 for sru validation

### DIFF
--- a/tests/regression/lp-1871652/task.yaml
+++ b/tests/regression/lp-1871652/task.yaml
@@ -25,12 +25,16 @@ prepare: |
     lxc exec bionic -- snap install lxd --channel="$LXD_SNAP_CHANNEL"
     lxc exec bionic -- lxc info >/dev/null
 
+
     # Overwrite the snap binary inside the container with the one from this
     # system. Given that snapd on the system has just been built from source it
     # will have the custom 1337 version string.
-    # NOTE: This step is only necessary while snapd in the store is older than the fix.
+    # NOTE: For SRU validation snapd is not built from source, so version does not match 1337
+    # NOTE: This step is only necessary while snapd in the store is older than the fix
     lxc file push /usr/bin/snap bionic/usr/bin/snap
-    lxc exec bionic -- snap version | MATCH 1337
+    if [ ! "$SRU_VALIDATION" = 1 ]; then
+        lxc exec bionic -- snap version | MATCH 1337
+    fi
 
     # Hide real snap binary, ensuring we run the patched one we copied above.
     # I considered unmounting the core snap instead but this upsets parts of

--- a/tests/regression/lp-1871652/task.yaml
+++ b/tests/regression/lp-1871652/task.yaml
@@ -25,7 +25,6 @@ prepare: |
     lxc exec bionic -- snap install lxd --channel="$LXD_SNAP_CHANNEL"
     lxc exec bionic -- lxc info >/dev/null
 
-
     # Overwrite the snap binary inside the container with the one from this
     # system. Given that snapd on the system has just been built from source it
     # will have the custom 1337 version string.


### PR DESCRIPTION
The test assumes that snapd is built from source but it doesn't happen for sru validation and the test fails because of that.

To check the test, run:
SPREAD_MODIFY_CORE_SNAP_FOR_REEXEC=0 SPREAD_TRUST_TEST_KEYS=false SPREAD_SNAP_REEXEC=0 SPREAD_CORE_CHANNEL=stable SPREAD_SRU_VALIDATION=1 spread -debug google-sru:ubuntu-18.04-64:tests/regression/lp-1871652
