### PR TITLE
asserts: start implementing authority-delegation

### DIFF
--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -105,21 +105,20 @@ var (
 )
 
 var typeRegistry = map[string]*AssertionType{
-	AccountType.Name:             AccountType,
-	AccountKeyType.Name:          AccountKeyType,
-	ModelType.Name:               ModelType,
-	SerialType.Name:              SerialType,
-	BaseDeclarationType.Name:     BaseDeclarationType,
-	SnapDeclarationType.Name:     SnapDeclarationType,
-	SnapBuildType.Name:           SnapBuildType,
-	SnapRevisionType.Name:        SnapRevisionType,
-	SnapDeveloperType.Name:       SnapDeveloperType,
-	SystemUserType.Name:          SystemUserType,
-	ValidationType.Name:          ValidationType,
-	ValidationSetType.Name:       ValidationSetType,
-	RepairType.Name:              RepairType,
-	StoreType.Name:               StoreType,
-	AuthorityDelegationType.Name: AuthorityDelegationType,
+	AccountType.Name:         AccountType,
+	AccountKeyType.Name:      AccountKeyType,
+	ModelType.Name:           ModelType,
+	SerialType.Name:          SerialType,
+	BaseDeclarationType.Name: BaseDeclarationType,
+	SnapDeclarationType.Name: SnapDeclarationType,
+	SnapBuildType.Name:       SnapBuildType,
+	SnapRevisionType.Name:    SnapRevisionType,
+	SnapDeveloperType.Name:   SnapDeveloperType,
+	SystemUserType.Name:      SystemUserType,
+	ValidationType.Name:      ValidationType,
+	ValidationSetType.Name:   ValidationSetType,
+	RepairType.Name:          RepairType,
+	StoreType.Name:           StoreType,
 	// no authority
 	DeviceSessionRequestType.Name: DeviceSessionRequestType,
 	SerialRequestType.Name:        SerialRequestType,
@@ -157,6 +156,9 @@ func init() {
 
 	// 1: support to limit to device serials
 	maxSupportedFormat[SystemUserType.Name] = 1
+
+	// done here to untangle initialization loop via Type()
+	typeRegistry[AuthorityDelegationType.Name] = AuthorityDelegationType
 }
 
 func MockMaxSupportedFormat(assertType *AssertionType, maxFormat int) (restore func()) {

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015-2020 Canonical Ltd
+ * Copyright (C) 2015-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -78,20 +78,21 @@ func (at *AssertionType) SequenceForming() bool {
 
 // Understood assertion types.
 var (
-	AccountType         = &AssertionType{"account", []string{"account-id"}, assembleAccount, 0}
-	AccountKeyType      = &AssertionType{"account-key", []string{"public-key-sha3-384"}, assembleAccountKey, 0}
-	RepairType          = &AssertionType{"repair", []string{"brand-id", "repair-id"}, assembleRepair, sequenceForming}
-	ModelType           = &AssertionType{"model", []string{"series", "brand-id", "model"}, assembleModel, 0}
-	SerialType          = &AssertionType{"serial", []string{"brand-id", "model", "serial"}, assembleSerial, 0}
-	BaseDeclarationType = &AssertionType{"base-declaration", []string{"series"}, assembleBaseDeclaration, 0}
-	SnapDeclarationType = &AssertionType{"snap-declaration", []string{"series", "snap-id"}, assembleSnapDeclaration, 0}
-	SnapBuildType       = &AssertionType{"snap-build", []string{"snap-sha3-384"}, assembleSnapBuild, 0}
-	SnapRevisionType    = &AssertionType{"snap-revision", []string{"snap-sha3-384"}, assembleSnapRevision, 0}
-	SnapDeveloperType   = &AssertionType{"snap-developer", []string{"snap-id", "publisher-id"}, assembleSnapDeveloper, 0}
-	SystemUserType      = &AssertionType{"system-user", []string{"brand-id", "email"}, assembleSystemUser, 0}
-	ValidationType      = &AssertionType{"validation", []string{"series", "snap-id", "approved-snap-id", "approved-snap-revision"}, assembleValidation, 0}
-	ValidationSetType   = &AssertionType{"validation-set", []string{"series", "account-id", "name", "sequence"}, assembleValidationSet, sequenceForming}
-	StoreType           = &AssertionType{"store", []string{"store"}, assembleStore, 0}
+	AccountType             = &AssertionType{"account", []string{"account-id"}, assembleAccount, 0}
+	AccountKeyType          = &AssertionType{"account-key", []string{"public-key-sha3-384"}, assembleAccountKey, 0}
+	RepairType              = &AssertionType{"repair", []string{"brand-id", "repair-id"}, assembleRepair, sequenceForming}
+	ModelType               = &AssertionType{"model", []string{"series", "brand-id", "model"}, assembleModel, 0}
+	SerialType              = &AssertionType{"serial", []string{"brand-id", "model", "serial"}, assembleSerial, 0}
+	BaseDeclarationType     = &AssertionType{"base-declaration", []string{"series"}, assembleBaseDeclaration, 0}
+	SnapDeclarationType     = &AssertionType{"snap-declaration", []string{"series", "snap-id"}, assembleSnapDeclaration, 0}
+	SnapBuildType           = &AssertionType{"snap-build", []string{"snap-sha3-384"}, assembleSnapBuild, 0}
+	SnapRevisionType        = &AssertionType{"snap-revision", []string{"snap-sha3-384"}, assembleSnapRevision, 0}
+	SnapDeveloperType       = &AssertionType{"snap-developer", []string{"snap-id", "publisher-id"}, assembleSnapDeveloper, 0}
+	SystemUserType          = &AssertionType{"system-user", []string{"brand-id", "email"}, assembleSystemUser, 0}
+	ValidationType          = &AssertionType{"validation", []string{"series", "snap-id", "approved-snap-id", "approved-snap-revision"}, assembleValidation, 0}
+	ValidationSetType       = &AssertionType{"validation-set", []string{"series", "account-id", "name", "sequence"}, assembleValidationSet, sequenceForming}
+	StoreType               = &AssertionType{"store", []string{"store"}, assembleStore, 0}
+	AuthorityDelegationType = &AssertionType{"authority-delegation", []string{"account-id", "delegate-id"}, assembleAuthorityDelegation, 0}
 
 // ...
 )
@@ -104,20 +105,21 @@ var (
 )
 
 var typeRegistry = map[string]*AssertionType{
-	AccountType.Name:         AccountType,
-	AccountKeyType.Name:      AccountKeyType,
-	ModelType.Name:           ModelType,
-	SerialType.Name:          SerialType,
-	BaseDeclarationType.Name: BaseDeclarationType,
-	SnapDeclarationType.Name: SnapDeclarationType,
-	SnapBuildType.Name:       SnapBuildType,
-	SnapRevisionType.Name:    SnapRevisionType,
-	SnapDeveloperType.Name:   SnapDeveloperType,
-	SystemUserType.Name:      SystemUserType,
-	ValidationType.Name:      ValidationType,
-	ValidationSetType.Name:   ValidationSetType,
-	RepairType.Name:          RepairType,
-	StoreType.Name:           StoreType,
+	AccountType.Name:             AccountType,
+	AccountKeyType.Name:          AccountKeyType,
+	ModelType.Name:               ModelType,
+	SerialType.Name:              SerialType,
+	BaseDeclarationType.Name:     BaseDeclarationType,
+	SnapDeclarationType.Name:     SnapDeclarationType,
+	SnapBuildType.Name:           SnapBuildType,
+	SnapRevisionType.Name:        SnapRevisionType,
+	SnapDeveloperType.Name:       SnapDeveloperType,
+	SystemUserType.Name:          SystemUserType,
+	ValidationType.Name:          ValidationType,
+	ValidationSetType.Name:       ValidationSetType,
+	RepairType.Name:              RepairType,
+	StoreType.Name:               StoreType,
+	AuthorityDelegationType.Name: AuthorityDelegationType,
 	// no authority
 	DeviceSessionRequestType.Name: DeviceSessionRequestType,
 	SerialRequestType.Name:        SerialRequestType,

--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015-2020 Canonical Ltd
+ * Copyright (C) 2015-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -51,6 +51,7 @@ func (as *assertsSuite) TestTypeNames(c *C) {
 		"account",
 		"account-key",
 		"account-key-request",
+		"authority-delegation",
 		"base-declaration",
 		"device-session-request",
 		"model",
@@ -940,6 +941,7 @@ func (as *assertsSuite) TestWithAuthority(c *C) {
 	withAuthority := []string{
 		"account",
 		"account-key",
+		"authority-delegation",
 		"base-declaration",
 		"store",
 		"snap-declaration",

--- a/asserts/authority_delegation.go
+++ b/asserts/authority_delegation.go
@@ -1,0 +1,103 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package asserts
+
+import (
+	"fmt"
+)
+
+// AuthorityDelegation holds an authority-delegation assertion, asserting
+// that a specified delegated authority can sign a constrained set
+// of assertion for a given account.
+type AuthorityDelegation struct {
+	assertionBase
+	// assertionConstraints
+}
+
+// AccountID returns the account-id of this this authority-delegation.
+func (ad *AuthorityDelegation) AccountID() string {
+	return ad.HeaderString("account-id")
+}
+
+// DelegateID returns the delegated account-id for this authority-delegation.
+func (ad *AuthorityDelegation) DelegateID() string {
+	return ad.HeaderString("delegate-id")
+}
+
+// Implement further consistency checks.
+func (ad *AuthorityDelegation) checkConsistency(db RODatabase, acck *AccountKey) error {
+	// XXX test this
+	if !db.IsTrustedAccount(ad.AuthorityID()) {
+		// XXX if this is relaxed then authority-id must otherwise
+		// match account-id
+		return fmt.Errorf("authority-delegation assertion for %q is not signed by a directly trusted authority: %s", ad.AccountID(), ad.AuthorityID())
+	}
+	_, err := db.Find(AccountType, map[string]string{
+		"account-id": ad.AccountID(),
+	})
+	if IsNotFound(err) {
+		return fmt.Errorf("authority-delegation assertion for %q does not have a matching account assertion", ad.AccountID())
+	}
+	if err != nil {
+		return err
+	}
+	_, err = db.Find(AccountType, map[string]string{
+		"account-id": ad.DelegateID(),
+	})
+	if IsNotFound(err) {
+		return fmt.Errorf("authority-delegation assertion for %q does not have a matching account assertion for delegated %q", ad.AccountID(), ad.DelegateID())
+	}
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// sound
+var _ consistencyChecker = (*AuthorityDelegation)(nil)
+
+// Prerequisites returns references to this authority-delegation's prerequisite assertions.
+func (ad *AuthorityDelegation) Prerequisites() []*Ref {
+	// XXX test this
+	return []*Ref{
+		{Type: AccountType, PrimaryKey: []string{ad.AccountID()}},
+		{Type: AccountType, PrimaryKey: []string{ad.DelegateID()}},
+	}
+}
+
+func assembleAuthorityDelegation(assert assertionBase) (Assertion, error) {
+	// XXX test errors
+	_, err := checkNotEmptyString(assert.headers, "account-id")
+	if err != nil {
+		return nil, err
+	}
+	_, err = checkNotEmptyString(assert.headers, "delegate-id")
+	if err != nil {
+		return nil, err
+	}
+
+	// XXX parse assertion constraints
+
+	// ignore extra headers for future compatibility
+	return &AuthorityDelegation{
+		assertionBase: assert,
+	}, nil
+
+}

--- a/asserts/authority_delegation.go
+++ b/asserts/authority_delegation.go
@@ -31,7 +31,7 @@ type AuthorityDelegation struct {
 	assertionConstraints []*AssertionConstraints
 }
 
-// AccountID returns the account-id of this this authority-delegation.
+// AccountID returns the account-id of this authority-delegation.
 func (ad *AuthorityDelegation) AccountID() string {
 	return ad.HeaderString("account-id")
 }
@@ -133,7 +133,7 @@ func assembleAuthorityDelegation(assert assertionBase) (Assertion, error) {
 		}
 		matcher, err := compileAttrMatcher(cc, hm)
 		if err != nil {
-			return nil, fmt.Errorf("cannot compile \"headers\" constraint: %v", err)
+			return nil, fmt.Errorf("cannot compile headers constraint: %v", err)
 		}
 		acs = append(acs, &AssertionConstraints{
 			assertType: t,

--- a/asserts/authority_delegation.go
+++ b/asserts/authority_delegation.go
@@ -25,7 +25,7 @@ import (
 
 // AuthorityDelegation holds an authority-delegation assertion, asserting
 // that a specified delegated authority can sign a constrained set
-// of assertion for a given account.
+// of assertions for a given account.
 type AuthorityDelegation struct {
 	assertionBase
 	assertionConstraints []*AssertionConstraints

--- a/asserts/authority_delegation_test.go
+++ b/asserts/authority_delegation_test.go
@@ -20,9 +20,12 @@
 package asserts_test
 
 import (
+	"strings"
+
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/asserts/assertstest"
 )
 
 type authorityDelegationSuite struct {
@@ -38,8 +41,8 @@ func (s *authorityDelegationSuite) SetUpSuite(c *C) {
     type: snap-revision
     headers:
       snap-id:
-        - snap-id1
-        - snap-id2
+        - snap-id-1
+        - snap-id-2
       provenance: prov-key1
     since: 2022-01-12T00:00:00.0Z
     until: 2032-01-01T00:00:00.0Z
@@ -63,4 +66,177 @@ func (s *authorityDelegationSuite) TestDecodeOK(c *C) {
 	c.Check(ad.DelegateID(), Equals, "acc-id1")
 }
 
+func (s *authorityDelegationSuite) TestPrerequisites(c *C) {
+	encoded := s.validEncoded
+	a, err := asserts.Decode([]byte(encoded))
+	c.Assert(err, IsNil)
+
+	prereqs := a.Prerequisites()
+	c.Check(prereqs, DeepEquals, []*asserts.Ref{
+		{Type: asserts.AccountType, PrimaryKey: []string{"canonical"}},
+		{Type: asserts.AccountType, PrimaryKey: []string{"acc-id1"}},
+	})
+}
+
+func (s *authorityDelegationSuite) TestAuthorityDelegationCheckUntrustedAuthority(c *C) {
+	storeDB, db := makeStoreAndCheckDB(c)
+
+	otherDB := setup3rdPartySigning(c, "other", storeDB, db)
+
+	headers := map[string]interface{}{
+		"account-id":  "canonical",
+		"delegate-id": "other",
+		"assertions": []interface{}{
+			map[string]interface{}{
+				"type": "snap-declaration",
+			},
+		},
+	}
+	ad, err := otherDB.Sign(asserts.AuthorityDelegationType, headers, nil, "")
+	c.Assert(err, IsNil)
+
+	err = db.Check(ad)
+	c.Assert(err, ErrorMatches, `authority-delegation assertion for "canonical" is not signed by a directly trusted authority: other`)
+}
+
+func (s *authorityDelegationSuite) TestAuthorityDelegationCheckAccounttReferences(c *C) {
+	storeDB, db := makeStoreAndCheckDB(c)
+
+	headers := map[string]interface{}{
+		"account-id":  "other",
+		"delegate-id": "other2",
+		"assertions": []interface{}{
+			map[string]interface{}{
+				"type": "model",
+			},
+		},
+	}
+	ad, err := storeDB.Sign(asserts.AuthorityDelegationType, headers, nil, "")
+	c.Assert(err, IsNil)
+
+	err = db.Check(ad)
+	c.Assert(err, ErrorMatches, `authority-delegation assertion for \"other\" does not have a matching account assertion`)
+
+	otherAcct := assertstest.NewAccount(storeDB, "other", map[string]interface{}{
+		"account-id": "other",
+	}, "")
+	c.Assert(db.Add(otherAcct), IsNil)
+
+	err = db.Check(ad)
+	c.Assert(err, ErrorMatches, `authority-delegation assertion for \"other\" does not have a matching account assertion for delegated \"other2\"`)
+}
+
+func (s *authorityDelegationSuite) TestAuthorityDelegationCheckHappy(c *C) {
+	storeDB, db := makeStoreAndCheckDB(c)
+
+	headers := map[string]interface{}{
+		"account-id":  "other",
+		"delegate-id": "other2",
+		"assertions": []interface{}{
+			map[string]interface{}{
+				"type": "model",
+			},
+		},
+	}
+	ad, err := storeDB.Sign(asserts.AuthorityDelegationType, headers, nil, "")
+	c.Assert(err, IsNil)
+
+	otherAcct := assertstest.NewAccount(storeDB, "other", map[string]interface{}{
+		"account-id": "other",
+	}, "")
+	c.Assert(db.Add(otherAcct), IsNil)
+	other2Acct := assertstest.NewAccount(storeDB, "other2", map[string]interface{}{
+		"account-id": "other2",
+	}, "")
+	c.Assert(db.Add(other2Acct), IsNil)
+
+	err = db.Check(ad)
+	c.Check(err, IsNil)
+}
+
+func (s *authorityDelegationSuite) TestMatchingConstraints(c *C) {
+	// XXX test a bit more once AssertionConstraints has some accessors
+	encoded := s.validEncoded
+	a, err := asserts.Decode([]byte(encoded))
+	c.Assert(err, IsNil)
+	ad := a.(*asserts.AuthorityDelegation)
+	storeDB, _ := makeStoreAndCheckDB(c)
+
+	headers := makeSnapRevisionHeaders(map[string]interface{}{
+		"snap-id":    "snap-id-1",
+		"provenance": "prov-key1",
+	})
+	snapRevWProvenance, err := storeDB.Sign(asserts.SnapRevisionType, headers, nil, "")
+	c.Assert(err, IsNil)
+
+	acs := ad.MatchingConstraints(snapRevWProvenance)
+	c.Check(acs, HasLen, 1)
+
+	// no provenance => no match
+	headers = makeSnapRevisionHeaders(map[string]interface{}{
+		"snap-id": "snap-id-1",
+	})
+	snapRevWoProvenance, err := storeDB.Sign(asserts.SnapRevisionType, headers, nil, "")
+	c.Assert(err, IsNil)
+
+	acs = ad.MatchingConstraints(snapRevWoProvenance)
+	c.Check(acs, HasLen, 0)
+
+	twoAssertConstraints := strings.Replace(encoded, s.assertionsLines, s.assertionsLines+`  -
+    type: snap-revision
+    headers:
+      snap-id:
+        - snap-id-1
+    since: 2022-01-26T00:00:00.0Z
+    until: 2032-01-26T00:00:00.0Z
+`, 1)
+	a, err = asserts.Decode([]byte(twoAssertConstraints))
+	c.Assert(err, IsNil)
+	ad2 := a.(*asserts.AuthorityDelegation)
+
+	acs = ad2.MatchingConstraints(snapRevWProvenance)
+	c.Check(acs, HasLen, 2)
+	acs = ad2.MatchingConstraints(snapRevWoProvenance)
+	c.Check(acs, HasLen, 1)
+}
+
 // TODO: on-store... constraints
+
+const authDelegErrPrefix = "assertion authority-delegation: "
+
+func (s *authorityDelegationSuite) TestDecodeInvalid(c *C) {
+	encoded := s.validEncoded
+	const hdrs = `headers:
+      snap-id:
+        - snap-id-1
+        - snap-id-2
+      provenance: prov-key1
+`
+
+	invalidTests := []struct{ original, invalid, expectedErr string }{
+		{"account-id: canonical\n", "", `"account-id" header is mandatory`},
+		{"account-id: canonical\n", "account-id: \n", `"account-id" header should not be empty`},
+		{"delegate-id: acc-id1\n", "", `"delegate-id" header is mandatory`},
+		{"delegate-id: acc-id1\n", "delegate-id: \n", `"delegate-id" header should not be empty`},
+		{s.assertionsLines, "", `assertions constraints are mandatory`},
+		{s.assertionsLines, "assertions: \n", "assertions constraints must be a list of maps"},
+		{s.assertionsLines, "assertions: foo\n", "assertions constraints must be a list of maps"},
+		{s.assertionsLines, "assertions:\n  foo: bar\n", "assertions constraints must be a list of maps"},
+		{s.assertionsLines, "assertions:\n  - foo\n", "assertions constraints must be a list of maps"},
+		{"    type: snap-revision\n", "", `"type" constraint is mandatory`},
+		{"type: snap-revision", "type: ", `"type" constraint should not be empty`},
+		{"type: snap-revision", "type: foo", `"foo" is not a valid assertion type`},
+		{"type: snap-revision", "type: 1", `"1" is not a valid assertion type`},
+		{hdrs, "headers: \n", `"headers" constraint must be a map`},
+		{hdrs, "headers: foo\n", `"headers" constraint must be a map`},
+		{hdrs, `headers:
+      provenance: $FOO
+`, `cannot compile "headers" constraint:.*`},
+	}
+
+	for _, test := range invalidTests {
+		invalid := strings.Replace(encoded, test.original, test.invalid, 1)
+		_, err := asserts.Decode([]byte(invalid))
+		c.Check(err, ErrorMatches, authDelegErrPrefix+test.expectedErr)
+	}
+}

--- a/asserts/authority_delegation_test.go
+++ b/asserts/authority_delegation_test.go
@@ -99,7 +99,7 @@ func (s *authorityDelegationSuite) TestAuthorityDelegationCheckUntrustedAuthorit
 	c.Assert(err, ErrorMatches, `authority-delegation assertion for "canonical" is not signed by a directly trusted authority: other`)
 }
 
-func (s *authorityDelegationSuite) TestAuthorityDelegationCheckAccounttReferences(c *C) {
+func (s *authorityDelegationSuite) TestAuthorityDelegationCheckAccountReferences(c *C) {
 	storeDB, db := makeStoreAndCheckDB(c)
 
 	headers := map[string]interface{}{
@@ -231,7 +231,7 @@ func (s *authorityDelegationSuite) TestDecodeInvalid(c *C) {
 		{hdrs, "headers: foo\n", `"headers" constraint must be a map`},
 		{hdrs, `headers:
       provenance: $FOO
-`, `cannot compile "headers" constraint:.*`},
+`, `cannot compile headers constraint:.*`},
 	}
 
 	for _, test := range invalidTests {

--- a/asserts/authority_delegation_test.go
+++ b/asserts/authority_delegation_test.go
@@ -1,0 +1,66 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package asserts_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/asserts"
+)
+
+type authorityDelegationSuite struct {
+	assertionsLines string
+	validEncoded    string
+}
+
+var _ = Suite(&authorityDelegationSuite{})
+
+func (s *authorityDelegationSuite) SetUpSuite(c *C) {
+	s.assertionsLines = `assertions:
+  -
+    type: snap-revision
+    headers:
+      snap-id:
+        - snap-id1
+        - snap-id2
+      provenance: prov-key1
+    since: 2022-01-12T00:00:00.0Z
+    until: 2032-01-01T00:00:00.0Z
+`
+	s.validEncoded = `type: authority-delegation
+authority-id: canonical
+account-id: canonical
+delegate-id: acc-id1
+` + s.assertionsLines + "sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij" +
+		"\n\n" +
+		"AXNpZw=="
+}
+
+func (s *authorityDelegationSuite) TestDecodeOK(c *C) {
+	encoded := s.validEncoded
+	a, err := asserts.Decode([]byte(encoded))
+	c.Assert(err, IsNil)
+	c.Check(a.Type(), Equals, asserts.AuthorityDelegationType)
+	ad := a.(*asserts.AuthorityDelegation)
+	c.Check(ad.AccountID(), Equals, "canonical")
+	c.Check(ad.DelegateID(), Equals, "acc-id1")
+}
+
+// TODO: on-store... constraints

--- a/asserts/constraint.go
+++ b/asserts/constraint.go
@@ -37,7 +37,8 @@ const (
 )
 
 type attrMatchingContext struct {
-	// attrWord is the usage context word for "attribute"
+	// attrWord is the usage context word for "attribute", mainly
+	// useful in errors
 	attrWord string
 	helper   AttrMatchContext
 }

--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -28,7 +28,11 @@ import (
 
 // expose test-only things here
 
-var NumAssertionType = len(typeRegistry)
+var NumAssertionType int
+
+func init() {
+	NumAssertionType = len(typeRegistry)
+}
 
 // v1FixedTimestamp exposed for tests
 var V1FixedTimestamp = v1FixedTimestamp

--- a/asserts/header_checks.go
+++ b/asserts/header_checks.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015-2020 Canonical Ltd
+ * Copyright (C) 2015-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -300,13 +300,17 @@ func checkOptionalBool(headers map[string]interface{}, name string) (bool, error
 }
 
 func checkMap(headers map[string]interface{}, name string) (map[string]interface{}, error) {
-	value, ok := headers[name]
+	return checkMapWhat(headers, name, "header")
+}
+
+func checkMapWhat(m map[string]interface{}, name, what string) (map[string]interface{}, error) {
+	value, ok := m[name]
 	if !ok {
 		return nil, nil
 	}
-	m, ok := value.(map[string]interface{})
+	mv, ok := value.(map[string]interface{})
 	if !ok {
-		return nil, fmt.Errorf("%q header must be a map", name)
+		return nil, fmt.Errorf("%q %s must be a map", name, what)
 	}
-	return m, nil
+	return mv, nil
 }

--- a/asserts/snap_asserts_test.go
+++ b/asserts/snap_asserts_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015-2017 Canonical Ltd
+ * Copyright (C) 2015-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -852,7 +852,7 @@ func (srs *snapRevSuite) makeValidEncoded() string {
 		"AXNpZw=="
 }
 
-func (srs *snapRevSuite) makeHeaders(overrides map[string]interface{}) map[string]interface{} {
+func makeSnapRevisionHeaders(overrides map[string]interface{}) map[string]interface{} {
 	headers := map[string]interface{}{
 		"authority-id":  "canonical",
 		"snap-sha3-384": blobSHA3_384,
@@ -867,6 +867,10 @@ func (srs *snapRevSuite) makeHeaders(overrides map[string]interface{}) map[strin
 		headers[k] = v
 	}
 	return headers
+}
+
+func (srs *snapRevSuite) makeHeaders(overrides map[string]interface{}) map[string]interface{} {
+	return makeSnapRevisionHeaders(overrides)
 }
 
 func (srs *snapRevSuite) TestDecodeOK(c *C) {


### PR DESCRIPTION
authority-delegation allows and constraints delegating signing authority from one account to another.

TODO in later PRs:
* support "since" and optional "until" in assertion constraints
* support authority-delegation during signature checking and assertion validation
* implement $WITHIN(n1,n2) constraint
* support device scope constraint in assertion constraint, take them into account on assertion retrieval as well 

based on #11309 and #11308
