### PR TITLE
cmd/snap-update-ns: convert some unexpected decimal file mode constants to octal.

### DIFF
--- a/cmd/snap-update-ns/system.go
+++ b/cmd/snap-update-ns/system.go
@@ -80,11 +80,11 @@ func (upCtx *SystemProfileUpdateContext) Assumptions() *Assumptions {
 	// As such, provide write access to all of /tmp.
 	as.AddUnrestrictedPaths("/var/lib/snapd/hostfs/tmp")
 	as.AddModeHint("/var/lib/snapd/hostfs/tmp/snap.*", 0700)
-	as.AddModeHint("/var/lib/snapd/hostfs/tmp/snap.*/tmp", 1777)
+	as.AddModeHint("/var/lib/snapd/hostfs/tmp/snap.*/tmp", 01777)
 	// This is to ensure that unprivileged users can create the socket. This
 	// permission only matters if the plug-side app constructs its mount
 	// namespace before the slot-side app is launched.
-	as.AddModeHint("/var/lib/snapd/hostfs/tmp/snap.*/tmp/.X11-unix", 1777)
+	as.AddModeHint("/var/lib/snapd/hostfs/tmp/snap.*/tmp/.X11-unix", 01777)
 	return as
 }
 

--- a/cmd/snap-update-ns/system_test.go
+++ b/cmd/snap-update-ns/system_test.go
@@ -79,9 +79,9 @@ func (s *systemSuite) TestAssumptions(c *C) {
 	c.Check(as.ModeForPath("/tmp"), Equals, os.FileMode(0755))
 	c.Check(as.ModeForPath("/var/lib/snapd/hostfs/tmp"), Equals, os.FileMode(0755))
 	c.Check(as.ModeForPath("/var/lib/snapd/hostfs/tmp/snap.x11-server"), Equals, os.FileMode(0700))
-	c.Check(as.ModeForPath("/var/lib/snapd/hostfs/tmp/snap.x11-server/tmp"), Equals, os.FileMode(1777))
+	c.Check(as.ModeForPath("/var/lib/snapd/hostfs/tmp/snap.x11-server/tmp"), Equals, os.FileMode(01777))
 	c.Check(as.ModeForPath("/var/lib/snapd/hostfs/tmp/snap.x11-server/foo"), Equals, os.FileMode(0755))
-	c.Check(as.ModeForPath("/var/lib/snapd/hostfs/tmp/snap.x11-server/tmp/.X11-unix"), Equals, os.FileMode(1777))
+	c.Check(as.ModeForPath("/var/lib/snapd/hostfs/tmp/snap.x11-server/tmp/.X11-unix"), Equals, os.FileMode(01777))
 
 	// Instances can, in addition, access /snap/$SNAP_INSTANCE_NAME
 	upCtx = update.NewSystemProfileUpdateContext("foo_instance", false)


### PR DESCRIPTION
Some of the file modes used in the `AddModeHint` calls were decimal integer constants, when they were clearly intended to be octal. The unit tests passed because they also used a decimal constant.

I couldn't see any spread test checking these permissions. As I remember it, the sequence of events for this to matter are:

1. Install a snap with an `x11` plug and another with an `x11` slot. Connect the plug to the slot.
2. Start a command from the plug-side snap before anything from the server has run.
3. The slot snap's private `/tmp` and `/tmp/X11-unix` directories should have been created with appropriate file permissions by the plug snap's run of snap-update-ns.

This is just the minimal change to fix this problem.  But if we're using Go >= 1.13 everywhere, it might be worth switching these octal constants to use the `0o` prefix that was added in that version:

https://go.dev/doc/go1.13#language

That would likely have made this kind of error more obvious.