### PR TITLE
o/snapstate: re-write state after undo migration

### DIFF
--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -108,6 +108,7 @@ var (
 	AffectedByRefresh = affectedByRefresh
 
 	GetDirMigrationOpts = getDirMigrationOpts
+	WriteSeqFile        = writeSeqFile
 )
 
 func PreviousSideInfo(snapst *SnapState) *snap.SideInfo {

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1244,9 +1244,9 @@ func (m *SnapManager) undoCopySnapData(t *state.Task, _ *tomb.Tomb) error {
 	return nil
 }
 
-// writeMigrationStatus is used to re-write the state and sequence file (if they
-// exist). This must be called after the migration undo procedure is done
-// since it only then we know the actual final state of the migration.
+// writeMigrationStatus writes the state and sequence file (if they exist).
+// This must be called after the migration undo procedure is done since only
+// then do we know the actual final state of the migration.
 func writeMigrationStatus(t *state.Task, snapst *SnapState, snapName string) error {
 	st := t.State()
 
@@ -1255,7 +1255,6 @@ func writeMigrationStatus(t *state.Task, snapst *SnapState, snapName string) err
 	st.Unlock()
 	if err != nil && err != state.ErrNoState {
 		return err
-
 	}
 
 	if err == nil {

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1157,10 +1157,10 @@ func (m *SnapManager) doCopySnapData(t *state.Task, _ *tomb.Tomb) error {
 			// undo the migration. In contrast to copy data for which the new revision
 			// directory can just be discarded, the snap data migration introduces
 			// a change that affects all revisions of the snap and thus needs to be reverted
-			if undoErr := m.backend.UndoHideSnapData(snapsup.InstanceName()); undoErr != nil {
+			if err := m.backend.UndoHideSnapData(snapsup.InstanceName()); err != nil {
 				st.Lock()
 				t.Logf("cannot undo snap dir migration (must manually restore %s's dirs from %s to %s): %v",
-					snapsup.InstanceName(), dirs.HiddenSnapDataHomeDir, dirs.UserHomeSnapDir, undoErr)
+					snapsup.InstanceName(), dirs.HiddenSnapDataHomeDir, dirs.UserHomeSnapDir, err)
 				st.Unlock()
 			}
 
@@ -1204,16 +1204,10 @@ func (m *SnapManager) undoCopySnapData(t *state.Task, _ *tomb.Tomb) error {
 			return err
 		}
 
-		snapsup.MigratedHidden = false
-		st.Lock()
-		err := SetTaskSnapSetup(t, snapsup)
-		st.Unlock()
-		if err != nil {
+		snapst.MigratedHidden = false
+		if err := writeMigrationStatus(t, snapst, snapsup.InstanceName()); err != nil {
 			return err
 		}
-
-		// persist the undone migration status before allowing the snap to be run
-		writeSeqFile(snapsup.InstanceName(), snapst)
 	}
 
 	st.Lock()
@@ -1247,6 +1241,38 @@ func (m *SnapManager) undoCopySnapData(t *state.Task, _ *tomb.Tomb) error {
 	if err := m.backend.RemoveSnapDataDir(newInfo, otherInstances); err != nil {
 		return err
 	}
+	return nil
+}
+
+// writeMigrationStatus is used to re-write the state and sequence file (if they
+// exist). This must be called after the migration undo procedure is done
+// since it only then we know the actual final state of the migration.
+func writeMigrationStatus(t *state.Task, snapst *SnapState, snapName string) error {
+	st := t.State()
+
+	st.Lock()
+	err := Get(st, snapName, &SnapState{})
+	st.Unlock()
+	if err != nil && err != state.ErrNoState {
+		return err
+
+	}
+
+	if err == nil {
+		// migration state might've been written in the change; update it after undo
+		st.Lock()
+		Set(st, snapName, snapst)
+		st.Unlock()
+	}
+
+	seqFile := filepath.Join(dirs.SnapSeqDir, snapName+".json")
+	if osutil.FileExists(seqFile) {
+		// might've written migration status to seq file in the change; update it
+		// after undo
+		return writeSeqFile(snapName, snapst)
+	}
+
+	// never got to write seq file; don't need to re-write migration status in it
 	return nil
 }
 
@@ -1460,10 +1486,9 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (err error) {
 	// keep instance key
 	snapst.InstanceKey = snapsup.InstanceKey
 
-	// this flag means that the migration happened in this change (later there
-	// will be another flag to signal that it's been undone). If it meant that
-	// the migration is "on" then we'd always have to set it for every change
-	// w/ a SnapSetup and link-snap (it'd be easy to forget and break state)
+	// don't keep the old state because, if we fail, we may or may not be able to
+	// revert the migration. We set the migration status after undoing any
+	// migration related ops
 	if snapsup.MigratedHidden {
 		snapst.MigratedHidden = true
 	}

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1257,6 +1257,7 @@ func writeMigrationStatus(t *state.Task, snapst *SnapState, snapName string) err
 		return err
 	}
 
+	// snap state was persisted, re-write it
 	if err == nil {
 		// migration state might've been written in the change; update it after undo
 		st.Lock()

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -103,8 +103,9 @@ type SnapSetup struct {
 	// each instance of given snap
 	InstanceKey string `json:"instance-key,omitempty"`
 
-	// MigratedHidden is set if the user's snap dir has been migrated
-	// to ~/.snap/data in the current change.
+	// MigratedHidden is set if the user's snap dir has been migrated to
+	// ~/.snap/data in the current change. So a 'false' value doesn't mean the
+	// dir isn't hidden. This prevents us from always having to set it.
 	MigratedHidden bool `json:"migrated-hidden,omitempty"`
 }
 

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -7086,11 +7086,13 @@ func (s *snapmgrTestSuite) TestUpdateDoHiddenDirMigration(c *C) {
 		SnapID:   "some-snap-id",
 		RealName: "some-snap",
 	}
-	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+	snapst := &snapstate.SnapState{
 		Sequence: []*snap.SideInfo{info},
 		Current:  info.Revision,
 		Active:   true,
-	})
+	}
+	snapstate.Set(s.state, "some-snap", snapst)
+	c.Assert(snapstate.WriteSeqFile("some-snap", snapst), IsNil)
 
 	chg := s.state.NewChange("update", "update a snap")
 	ts, err := snapstate.Update(s.state, "some-snap", nil, s.user.ID, snapstate.Flags{})
@@ -7108,6 +7110,56 @@ func (s *snapmgrTestSuite) TestUpdateDoHiddenDirMigration(c *C) {
 	assertMigrationState(c, s.state, "some-snap", true)
 }
 
+func (s *snapmgrTestSuite) TestUndoMigrationIfUpdateFailsAfterSettingState(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	tr := config.NewTransaction(s.state)
+	c.Assert(tr.Set("core", "experimental.hidden-snap-folder", true), IsNil)
+	tr.Commit()
+
+	info := &snap.SideInfo{
+		Revision: snap.R(1),
+		SnapID:   "some-snap-id",
+		RealName: "some-snap",
+	}
+	snapst := &snapstate.SnapState{
+		Sequence: []*snap.SideInfo{info},
+		Current:  info.Revision,
+		Active:   true,
+	}
+	snapstate.Set(s.state, "some-snap", snapst)
+	c.Assert(snapstate.WriteSeqFile("some-snap", snapst), IsNil)
+
+	chg := s.state.NewChange("update", "update a snap")
+	ts, err := snapstate.Update(s.state, "some-snap", nil, s.user.ID, snapstate.Flags{})
+	c.Assert(err, IsNil)
+	chg.AddAll(ts)
+
+	// fail the change after the link-snap task (after state is saved)
+	s.o.TaskRunner().AddHandler("fail", func(*state.Task, *tomb.Tomb) error {
+		return errors.New("expected")
+	}, nil)
+
+	failingTask := s.state.NewTask("fail", "expected failure")
+	chg.AddTask(failingTask)
+	linkTask := findLastTask(chg, "link-snap")
+	failingTask.WaitFor(linkTask)
+	for _, lane := range linkTask.Lanes() {
+		failingTask.JoinLane(lane)
+	}
+
+	s.settle(c)
+	c.Assert(chg.Err(), Not(IsNil))
+
+	// check migration is undone
+	s.fakeBackend.ops.MustFindOp(c, "hide-snap-data")
+	s.fakeBackend.ops.MustFindOp(c, "undo-hide-snap-data")
+
+	// check migration status was reverted in state and seq file
+	assertMigrationState(c, s.state, "some-snap", false)
+}
+
 func (s *snapmgrTestSuite) TestUndoMigrationIfUpdateFails(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -7121,11 +7173,13 @@ func (s *snapmgrTestSuite) TestUndoMigrationIfUpdateFails(c *C) {
 		SnapID:   "some-snap-id",
 		RealName: "some-snap",
 	}
-	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+	snapst := &snapstate.SnapState{
 		Sequence: []*snap.SideInfo{info},
 		Current:  info.Revision,
 		Active:   true,
-	})
+	}
+	snapstate.Set(s.state, "some-snap", snapst)
+	c.Assert(snapstate.WriteSeqFile("some-snap", snapst), IsNil)
 
 	// fail at the end
 	s.fakeBackend.linkSnapFailTrigger = filepath.Join(dirs.SnapMountDir, "/some-snap/11")
@@ -7159,12 +7213,14 @@ func (s *snapmgrTestSuite) TestUpdateAfterMigration(c *C) {
 		SnapID:   "some-snap-id",
 		RealName: "some-snap",
 	}
-	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+	snapst := &snapstate.SnapState{
 		Sequence:       []*snap.SideInfo{info},
 		Current:        info.Revision,
 		Active:         true,
 		MigratedHidden: true,
-	})
+	}
+	snapstate.Set(s.state, "some-snap", snapst)
+	c.Assert(snapstate.WriteSeqFile("some-snap", snapst), IsNil)
 
 	chg := s.state.NewChange("update", "update a snap")
 	ts, err := snapstate.Update(s.state, "some-snap", nil, s.user.ID, snapstate.Flags{})
@@ -7209,11 +7265,13 @@ func (s *snapmgrTestSuite) testUndoMigration(c *C, failUndo bool) {
 		SnapID:   "some-snap-id",
 		RealName: "some-snap",
 	}
-	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+	snapst := &snapstate.SnapState{
 		Sequence: []*snap.SideInfo{info},
 		Current:  info.Revision,
 		Active:   true,
-	})
+	}
+	snapstate.Set(s.state, "some-snap", snapst)
+	c.Assert(snapstate.WriteSeqFile("some-snap", snapst), IsNil)
 
 	s.fakeBackend.maybeInjectErr = func(op *fakeOp) error {
 		if op.op == "hide-snap-data" || (failUndo && op.op == "undo-hide-snap-data") {
@@ -7269,24 +7327,22 @@ func someMatches(c *C, haystack []string, needle string) bool {
 	return false
 }
 
+// assertMigrationState checks the migration status in the state and sequence
+// file. Fails if no state or sequence file exist.
 func assertMigrationState(c *C, st *state.State, snap string, migrated bool) {
 	// check snap state has expected migration value
 	var snapst snapstate.SnapState
 	c.Assert(snapstate.Get(st, snap, &snapst), IsNil)
 	c.Assert(snapst.MigratedHidden, Equals, migrated)
 
-	// read sequence file
+	assertMigrationInSeqFile(c, snap, migrated)
+}
+
+func assertMigrationInSeqFile(c *C, snap string, migrated bool) {
 	seqFilePath := filepath.Join(dirs.SnapSeqDir, snap+".json")
 	file, err := os.Open(seqFilePath)
-	if errors.Is(err, os.ErrNotExist) {
-		if migrated {
-			c.Fatalf("expected migration flag set in seq file but got: %v", err)
-		}
-
-		// not expecting migration, so it's ok for seq file to not exist
-		return
-	}
 	c.Assert(err, IsNil)
+	defer file.Close()
 
 	data, err := ioutil.ReadAll(file)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
Write state and sequence file after undoing the migration, if
these exist. This must be done after the undo procedure because
only then do we know what the migration's final state is. Also,
take care to re-write what was written during the change (e.g., if
the sequence file was written but not the state, re-write only the
sequence file with the undone migration status).
Add comments explaining why state is written where it is.
Add new tests and improve test robustness.