### PR TITLE
tests: fix repair test failure when run in a loop

### DIFF
--- a/cmd/snap-repair/cmd_show_test.go
+++ b/cmd/snap-repair/cmd_show_test.go
@@ -33,7 +33,10 @@ import (
 func (r *repairSuite) TestShowRepairSingle(c *C) {
 	makeMockRepairState(c)
 
-	err := repair.ParseArgs([]string{"show", "canonical-1"})
+	// repair.ParseArgs() always appends to its internal slice:
+	// cmdShow.Positional.Repair. To workaround this we create a
+	// new cmdShow here
+	err := repair.NewCmdShow("canonical-1").Execute(nil)
 	c.Check(err, IsNil)
 	c.Check(r.Stdout(), Equals, `repair: canonical-1
 revision: 3


### PR DESCRIPTION
Use repair.NewCmdShow in the test to avoid appending to internal slice; this follows existing tests in the suite and fixes failures when running the test with -count N.
