### PR TITLE
tests: enable snap-userd-reexec on ubuntu and debian

### DIFF
--- a/tests/main/snap-userd-reexec/task.yaml
+++ b/tests/main/snap-userd-reexec/task.yaml
@@ -1,7 +1,7 @@
 summary: Check that core refresh will create the userd dbus serivce file
 
 # only run on systems that re-exec
-systems: [ubuntu-18*]
+systems: [ubuntu-1*, ubuntu-2*, debian-*]
 
 environment:
     # uploading the core snap triggers OOM


### PR DESCRIPTION
The idea of this change is to run this test in all the systems that support reexec.
