### PR TITLE
snap-confine: allow numbers in hook security tag

### DIFF
--- a/cmd/libsnap-confine-private/snap-test.c
+++ b/cmd/libsnap-confine-private/snap-test.c
@@ -125,6 +125,12 @@ static void test_sc_is_hook_security_tag(void)
 	g_assert_false(sc_is_hook_security_tag("snap.name.app!hook.foo"));
 	g_assert_false(sc_is_hook_security_tag("snap.name.app.hook!foo"));
 	g_assert_false(sc_is_hook_security_tag("snap.name.app.hook.-foo"));
+	g_assert_false(sc_is_hook_security_tag("snap.foo_bar.hook.0abcd"));
+	g_assert_false(sc_is_hook_security_tag("snap.foo.hook.abc--"));
+	g_assert_false(sc_is_hook_security_tag("snap.foo_bar.hook.!foo"));
+	g_assert_false(sc_is_hook_security_tag("snap.foo_bar.hook.-foo"));
+	g_assert_false(sc_is_hook_security_tag("snap.foo_bar.hook!foo"));
+	g_assert_false(sc_is_hook_security_tag("snap.foo_bar.!foo"));
 }
 
 static void test_sc_snap_or_instance_name_validate(gconstpointer data)

--- a/cmd/libsnap-confine-private/snap-test.c
+++ b/cmd/libsnap-confine-private/snap-test.c
@@ -119,6 +119,7 @@ static void test_sc_is_hook_security_tag(void)
 		      ("snap.foo_instance.hook.bar-baz"));
 	g_assert_true(sc_is_hook_security_tag("snap.foo_bar.hook.bar-baz"));
 	g_assert_true(sc_is_hook_security_tag("snap.foo_bar.hook.f00"));
+	g_assert_true(sc_is_hook_security_tag("snap.foo_bar.hook.f-0-0"));
 
 	// Now, test the names we know are not valid hook security tags
 	g_assert_false(sc_is_hook_security_tag("snap.foo_instance.bar-baz"));

--- a/cmd/libsnap-confine-private/snap-test.c
+++ b/cmd/libsnap-confine-private/snap-test.c
@@ -118,13 +118,13 @@ static void test_sc_is_hook_security_tag(void)
 	g_assert_true(sc_is_hook_security_tag
 		      ("snap.foo_instance.hook.bar-baz"));
 	g_assert_true(sc_is_hook_security_tag("snap.foo_bar.hook.bar-baz"));
+	g_assert_true(sc_is_hook_security_tag("snap.name.app.hook.f00"));
 
 	// Now, test the names we know are not valid hook security tags
 	g_assert_false(sc_is_hook_security_tag("snap.foo_instance.bar-baz"));
 	g_assert_false(sc_is_hook_security_tag("snap.name.app!hook.foo"));
 	g_assert_false(sc_is_hook_security_tag("snap.name.app.hook!foo"));
 	g_assert_false(sc_is_hook_security_tag("snap.name.app.hook.-foo"));
-	g_assert_false(sc_is_hook_security_tag("snap.name.app.hook.f00"));
 }
 
 static void test_sc_snap_or_instance_name_validate(gconstpointer data)

--- a/cmd/libsnap-confine-private/snap-test.c
+++ b/cmd/libsnap-confine-private/snap-test.c
@@ -118,7 +118,7 @@ static void test_sc_is_hook_security_tag(void)
 	g_assert_true(sc_is_hook_security_tag
 		      ("snap.foo_instance.hook.bar-baz"));
 	g_assert_true(sc_is_hook_security_tag("snap.foo_bar.hook.bar-baz"));
-	g_assert_true(sc_is_hook_security_tag("snap.name.app.hook.f00"));
+	g_assert_true(sc_is_hook_security_tag("snap.foo_bar.hook.f00"));
 
 	// Now, test the names we know are not valid hook security tags
 	g_assert_false(sc_is_hook_security_tag("snap.foo_instance.bar-baz"));

--- a/cmd/libsnap-confine-private/snap.c
+++ b/cmd/libsnap-confine-private/snap.c
@@ -61,7 +61,7 @@ bool sc_security_tag_validate(const char *security_tag, const char *snap_name)
 bool sc_is_hook_security_tag(const char *security_tag)
 {
 	const char *whitelist_re =
-	    "^snap\\.[a-z](-?[a-z0-9])*(_[a-z0-9]{1,10})?\\.(hook\\.[a-z](-?[a-z])*)$";
+	    "^snap\\.[a-z](-?[a-z0-9])*(_[a-z0-9]{1,10})?\\.(hook\\.[a-z](-?[a-z0-9])*)$";
 
 	regex_t re;
 	if (regcomp(&re, whitelist_re, REG_EXTENDED | REG_NOSUB) != 0)

--- a/tests/main/interfaces-hooks-plug-with-number/task.yaml
+++ b/tests/main/interfaces-hooks-plug-with-number/task.yaml
@@ -1,0 +1,11 @@
+summary: Check that `snap connect` runs interface hooks when plug name ends with
+    a number.
+
+prepare: |
+    echo "Install test hooks snaps"
+    "$TESTSTOOLS"/snaps-state install-local test-snap
+
+execute: |
+    echo "Test that snap connect with plug ending with a number succeeds"
+    snap connect test-snap:consumer0
+    MATCH "value" < "/var/snap/test-snap/common/connect-plug-consumer0-done"

--- a/tests/main/interfaces-hooks-plug-with-number/test-snap/meta/hooks/connect-plug-consumer0
+++ b/tests/main/interfaces-hooks-plug-with-number/test-snap/meta/hooks/connect-plug-consumer0
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+snapctl get :consumer0 some-attribute > "$SNAP_COMMON/connect-plug-consumer0-done" 2>&1

--- a/tests/main/interfaces-hooks-plug-with-number/test-snap/meta/hooks/prepare-plug-consumer0
+++ b/tests/main/interfaces-hooks-plug-with-number/test-snap/meta/hooks/prepare-plug-consumer0
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+snapctl set :consumer0 some-attribute=value

--- a/tests/main/interfaces-hooks-plug-with-number/test-snap/meta/snap.yaml
+++ b/tests/main/interfaces-hooks-plug-with-number/test-snap/meta/snap.yaml
@@ -1,0 +1,6 @@
+name: test-snap
+version: 1.0
+plugs:
+    consumer0:
+        interface: system-observe
+


### PR DESCRIPTION
Allow numbers in hook names (except for the first character) when checking hook security tag in snap-confine to allow interface hooks for such plugs/slots; this matches the `validHook` regex (see `snap/naming/validate.go`) used by snapd.
Hooks for plugs/slots names that end with numbers otherwise cause an error if snapctl is used:
    
```connect-plug-station0": error: error running snapctl: interface attributes can only be read during the execution of interface hooks```
    
The error arises because snap-confine doesn't consider passed security context as hook's, and overrides SNAP_COOKIE env var with the one for the snap, replacing the cookie value passed by snap run for the hook execution. As a consequence snapctl considers to be running with an ephemeral context (not from the hook), so cannot figure hook name etc and errors out.
