### PR TITLE
spread: switch to CentOS 8 Stream image

### DIFF
--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -157,6 +157,7 @@ selinux_get_enforce_mode(snappy_t)
 optional_policy(`
 	dbus_read_config(snappy_t)
 	allow snappy_t dbusd_etc_t:file { write create rename unlink };
+	allow snappy_t dbusd_etc_t:dir { add_name remove_name };
 	allow snappy_t dbusd_etc_t:lnk_file { read };
 ')
 

--- a/spread.yaml
+++ b/spread.yaml
@@ -631,10 +631,18 @@ prepare: |
         apt-get update && apt-get install -y eatmydata
     fi
 
-    if [[ "$SPREAD_SYSTEM" == centos-* ]]; then
-        # make sure EPEL is enabled
-        yum install -y epel-release
-    fi
+    case "$SPREAD_SYSTEM" in
+        centos-7-*)
+            # make sure EPEL is enabled
+            yum install -y epel-release
+            ;;
+        centos-8-*)
+            # enable powertools repository
+            dnf config-manager --set-enabled powertools
+            # CentOS Stream requires EPEL Next too, see https://docs.fedoraproject.org/en-US/epel/
+            dnf install -y epel-release epel-next-release
+            ;;
+    esac
 
     case "$SPREAD_SYSTEM" in
         ubuntu-*|debian-*)

--- a/spread.yaml
+++ b/spread.yaml
@@ -148,6 +148,10 @@ backends:
                   workers: 6
                   storage: preserve-size
                   image: centos-7-64
+            - centos-8-64:
+                  workers: 6
+                  storage: preserve-size
+                  image: centos-stream-8
             # unstable systems below
             - opensuse-15.2-64:
                   workers: 6
@@ -157,10 +161,6 @@ backends:
             - opensuse-tumbleweed-64:
                   workers: 6
                   manual: true
-            - centos-8-64:
-                  workers: 6
-                  storage: preserve-size
-                  image: centos-8-64
 
     google-sru:
         type: google

--- a/spread.yaml
+++ b/spread.yaml
@@ -582,6 +582,13 @@ prepare: |
         restorecon -v /etc/gai.conf
     fi
 
+    if [[ "$SPREAD_SYSTEM" == centos-8-* ]]; then
+        # the default image of CentOS 8 Stream is set up in enforcing mode,
+        # which may break some tests. Note that there are tests targeting
+        # SELinux which explicitly enable enforcing mode.
+        setenforce 0
+    fi
+
     # Note that os.query or any other tool cannot be used here before the current.delta file is unpacked
     if [[ "$SPREAD_SYSTEM" == fedora-* ]]; then
         # The Fedora archive mirror seems to be unreliable.

--- a/tests/main/degraded/task.yaml
+++ b/tests/main/degraded/task.yaml
@@ -32,6 +32,10 @@ execute: |
             # Some mount units failing which are installed in the prebuilt image 
             systemctl reset-failed --type mount
             ;;
+        centos-8-*)
+            # tries to load ipmi_si module which fails with ENODEV
+            systemctl reset-failed systemd-modules-load.service
+            ;;
     esac
 
     if systemctl status | grep "State: [d]egraded"; then

--- a/tests/main/interfaces-packagekit-control/task.yaml
+++ b/tests/main/interfaces-packagekit-control/task.yaml
@@ -5,8 +5,6 @@ systems:
     - -ubuntu-core-*
     # Ubuntu 14.04 PackageKit seems to be too old
     - -ubuntu-14.04-*
-    # PackageKit is buggy https://bugzilla.redhat.com/show_bug.cgi?id=1807864
-    - -centos-8-*
 
 restore: |
     snap remove --purge test-snapd-packagekit


### PR DESCRIPTION
CentOS 8 has hit EOL and is now delivered as CentOS 8 Stream offering.

See: https://www.centos.org/centos-stream/


