### PR TITLE
gadget/install/partition.go: include DiskIndex in synthesized OnDiskStructure

### DIFF
--- a/gadget/install/partition.go
+++ b/gadget/install/partition.go
@@ -125,7 +125,8 @@ func buildPartitionList(dl *gadget.OnDiskVolume, pv *gadget.LaidOutVolume) (sfdi
 		}
 	}
 
-	// The partition index
+	// The partition / disk index - note that it will start at 1, we increment
+	// it before we use it in the loop below
 	pIndex := 0
 
 	// Write new partition data in named-fields format
@@ -159,19 +160,20 @@ func buildPartitionList(dl *gadget.OnDiskVolume, pv *gadget.LaidOutVolume) (sfdi
 
 		ptype := partitionType(dl.Schema, p.Type)
 
-		// Can we use the index here? Get the largest existing partition number and
-		// build from there could be safer if the disk partitions are not consecutive
-		// (can this actually happen in our images?)
+		// synthesize the node name and on disk structure
 		node := deviceName(dl.Device, pIndex)
-		fmt.Fprintf(buf, "%s : start=%12d, size=%12d, type=%s, name=%q\n", node,
-			startInSectors, newSizeInSectors, ptype, s.Name)
-
-		toBeCreated = append(toBeCreated, gadget.OnDiskStructure{
+		ps := gadget.OnDiskStructure{
 			LaidOutStructure: p,
 			Node:             node,
 			DiskIndex:        pIndex,
 			Size:             quantity.Size(newSizeInSectors * sectorSize),
-		})
+		}
+
+		// format sfdisk output for creating this partition
+		fmt.Fprintf(buf, "%s : start=%12d, size=%12d, type=%s, name=%q\n", node,
+			startInSectors, newSizeInSectors, ptype, s.Name)
+
+		toBeCreated = append(toBeCreated, ps)
 	}
 
 	return buf, toBeCreated, nil

--- a/gadget/install/partition.go
+++ b/gadget/install/partition.go
@@ -169,6 +169,7 @@ func buildPartitionList(dl *gadget.OnDiskVolume, pv *gadget.LaidOutVolume) (sfdi
 		toBeCreated = append(toBeCreated, gadget.OnDiskStructure{
 			LaidOutStructure: p,
 			Node:             node,
+			DiskIndex:        pIndex,
 			Size:             quantity.Size(newSizeInSectors * sectorSize),
 		})
 	}

--- a/gadget/install/partition_test.go
+++ b/gadget/install/partition_test.go
@@ -152,6 +152,10 @@ var mockOnDiskStructureWritable = gadget.OnDiskStructure{
 		StartOffset: 1260388352,
 		YamlIndex:   3,
 	},
+	// Note the DiskIndex appears to be the same as the YamlIndex, but this is
+	// because YamlIndex starts at 0 and DiskIndex starts at 1, and there is a
+	// yaml structure (the MBR) that does not appear on disk
+	DiskIndex: 3,
 	// expanded to fill the disk
 	Size: 2*quantity.SizeGiB + 845*quantity.SizeMiB + 1031680,
 }
@@ -171,7 +175,11 @@ var mockOnDiskStructureSave = gadget.OnDiskStructure{
 		StartOffset: 1260388352,
 		YamlIndex:   3,
 	},
-	Size: 128 * quantity.SizeMiB,
+	// Note the DiskIndex appears to be the same as the YamlIndex, but this is
+	// because YamlIndex starts at 0 and DiskIndex starts at 1, and there is a
+	// yaml structure (the MBR) that does not appear on disk
+	DiskIndex: 3,
+	Size:      128 * quantity.SizeMiB,
 }
 
 var mockOnDiskStructureWritableAfterSave = gadget.OnDiskStructure{
@@ -189,6 +197,10 @@ var mockOnDiskStructureWritableAfterSave = gadget.OnDiskStructure{
 		StartOffset: 1394606080,
 		YamlIndex:   4,
 	},
+	// Note the DiskIndex appears to be the same as the YamlIndex, but this is
+	// because YamlIndex starts at 0 and DiskIndex starts at 1, and there is a
+	// yaml structure (the MBR) that does not appear on disk
+	DiskIndex: 4,
 	// expanded to fill the disk
 	Size: 2*quantity.SizeGiB + 717*quantity.SizeMiB + 1031680,
 }


### PR DESCRIPTION
This is not strictly necessary, but resolves an issue wherein we previously
were mounting all partitions during install mode at the same location of
<contentMountpoint>/0 in writeFilesystemContent(). This is because we were 
using ds.Index as the directory to use for each partition, but now that we
switched to using YamlIndex and DiskIndex, the mount code in 
writeFilesystemContent() was adapted to use DiskIndex which made sense at the 
time because the structure it is operating on is an OnDiskStructure. This 
didn't cause any obvious issues since we unmount things before mounting again
so even though we would be mounting on the same directory different partitions, 
nothing was broken.

The alternative to this change is to revert to effectively using the YamlIndex
instead as the final mount point directory name, but again it makes more sense
to use the DiskIndex in writeFilesystemContent() because it is accepting an
OnDiskStructure instead of a LaidOutStructure.

The other reason we didn't notice this is because we do not have any end to end
tests of install.Run() where we would have noticed that 
createMissingPartitions() was providing incorrectly synthesized 
OnDiskStructures to be used with writeFilesystemContent(). That should be 
remedied soon (and indeed I only noticed this while writing unit tests for 
install.Run()).

This bug was introduced in snapcore/snapd#11234.