### PR TITLE
gadget/install: rm unused support for writing non-filesystem structures

### DIFF
--- a/gadget/install/content_test.go
+++ b/gadget/install/content_test.go
@@ -253,7 +253,7 @@ func (s *contentTestSuite) TestWriteFilesystemContent(c *C) {
 			observeErr:     tc.observeErr,
 			expectedStruct: &m.LaidOutStructure,
 		}
-		err := install.WriteContent(&m, s.gadgetRoot, obs)
+		err := install.WriteContent(&m, obs)
 		if tc.err == "" {
 			c.Assert(err, IsNil)
 		} else {
@@ -277,7 +277,7 @@ func (s *contentTestSuite) TestWriteFilesystemContent(c *C) {
 	}
 }
 
-func (s *contentTestSuite) TestWriteRawContent(c *C) {
+func (s *contentTestSuite) TestWriteRawContentNotSupported(c *C) {
 	mockNode := filepath.Join(s.dir, "mock-node")
 	err := ioutil.WriteFile(mockNode, nil, 0644)
 	c.Assert(err, IsNil)
@@ -295,13 +295,8 @@ func (s *contentTestSuite) TestWriteRawContent(c *C) {
 		},
 	}
 
-	err = install.WriteContent(&m, s.gadgetRoot, nil)
-	c.Assert(err, IsNil)
-
-	content, err := ioutil.ReadFile(m.Node)
-	c.Assert(err, IsNil)
-	// note the 2 zero byte start offset
-	c.Check(string(content), Equals, "\x00\x00pc-core.img content")
+	err = install.WriteContent(&m, nil)
+	c.Assert(err, ErrorMatches, `cannot write non-filesystem structures during install`)
 }
 
 func (s *contentTestSuite) TestMountFilesystem(c *C) {

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -204,7 +204,7 @@ func Run(model gadget.Model, gadgetRoot, kernelRoot, device string, options Opti
 		}
 
 		timings.Run(perfTimings, fmt.Sprintf("write-content[%s]", roleOrLabelOrName(part)), fmt.Sprintf("Write content for %s", roleOrLabelOrName(part)), func(timings.Measurer) {
-			err = writeContent(&part, gadgetRoot, observer)
+			err = writeContent(&part, observer)
 		})
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This was never used, since by design, we only create partitions with
filesystems in install mode (and specifically only ubuntu-save, ubuntu-data,
and ubuntu-boot).

Also remove the gadgetRoot parameter since it is not used.

Removing support for this isn't really necessary, but it's unused code that we
likely do not ever have a plan for using.