### PR TITLE
gadget/install: add unit tests for makeFilesystem, allow mocking mkfs.Make()

### DIFF
--- a/gadget/install/content_test.go
+++ b/gadget/install/content_test.go
@@ -21,6 +21,7 @@ package install_test
 
 import (
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -302,6 +303,58 @@ func (s *contentTestSuite) TestWriteRawContent(c *C) {
 	c.Assert(err, IsNil)
 	// note the 2 zero byte start offset
 	c.Check(string(content), Equals, "\x00\x00pc-core.img content")
+}
+
+func (s *contentTestSuite) TestMakeFilesystemStructureHasNoFilesystem(c *C) {
+	restore := install.MockMkfsMake(func(typ, img, label string, devSize, sectorSize quantity.Size) error {
+		c.Errorf("unexpected call to mkfs.Make()")
+		return fmt.Errorf("should not be called")
+	})
+	defer restore()
+
+	err := install.MakeFilesystem(&mockOnDiskStructureBiosBoot, quantity.Size(512))
+	c.Assert(err, ErrorMatches, `internal error: on disk structure for partition /dev/node1 has no filesystem`)
+}
+
+func (s *contentTestSuite) TestMakeFilesystem(c *C) {
+	mockUdevadm := testutil.MockCommand(c, "udevadm", "")
+	defer mockUdevadm.Restore()
+
+	restore := install.MockMkfsMake(func(typ, img, label string, devSize, sectorSize quantity.Size) error {
+		c.Assert(typ, Equals, "ext4")
+		c.Assert(img, Equals, "/dev/node3")
+		c.Assert(label, Equals, "ubuntu-data")
+		c.Assert(devSize, Equals, mockOnDiskStructureWritable.Size)
+		c.Assert(sectorSize, Equals, quantity.Size(512))
+		return nil
+	})
+	defer restore()
+
+	err := install.MakeFilesystem(&mockOnDiskStructureWritable, quantity.Size(512))
+	c.Assert(err, IsNil)
+
+	c.Assert(mockUdevadm.Calls(), DeepEquals, [][]string{
+		{"udevadm", "trigger", "--settle", "/dev/node3"},
+	})
+}
+
+func (s *contentTestSuite) TestMakeFilesystemRealMkfs(c *C) {
+	mockUdevadm := testutil.MockCommand(c, "udevadm", "")
+	defer mockUdevadm.Restore()
+
+	mockMkfsExt4 := testutil.MockCommand(c, "mkfs.ext4", "")
+	defer mockMkfsExt4.Restore()
+
+	err := install.MakeFilesystem(&mockOnDiskStructureWritable, quantity.Size(512))
+	c.Assert(err, IsNil)
+
+	c.Assert(mockUdevadm.Calls(), DeepEquals, [][]string{
+		{"udevadm", "trigger", "--settle", "/dev/node3"},
+	})
+
+	c.Assert(mockMkfsExt4.Calls(), DeepEquals, [][]string{
+		{"mkfs.ext4", "-L", "ubuntu-data", "/dev/node3"},
+	})
 }
 
 func (s *contentTestSuite) TestMountFilesystem(c *C) {

--- a/gadget/install/export_test.go
+++ b/gadget/install/export_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/snapcore/snapd/gadget"
+	"github.com/snapcore/snapd/gadget/quantity"
 )
 
 var (
@@ -67,5 +68,13 @@ func MockEnsureNodesExist(f func(dss []gadget.OnDiskStructure, timeout time.Dura
 	ensureNodesExist = f
 	return func() {
 		ensureNodesExist = old
+	}
+}
+
+func MockMkfsMake(f func(typ, img, label string, devSize, sectorSize quantity.Size) error) (restore func()) {
+	old := mkfsImpl
+	mkfsImpl = f
+	return func() {
+		mkfsImpl = old
 	}
 }


### PR DESCRIPTION
Also because we know we will never create partitions/structures other than 
those with filesystems in UC20 install mode, error if the provided 
OnDiskStructure does not have a filesystem.