### PR TITLE
cmd/snap: add --debug to snap run

### DIFF
--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -73,6 +73,7 @@ type cmdRun struct {
 	HookName string `long:"hook" hidden:"yes"`
 	Revision string `short:"r" default:"unset" hidden:"yes"`
 	Shell    bool   `long:"shell" `
+	Debug    bool   `long:"debug"`
 
 	// This options is both a selector (use or don't use strace) and it
 	// can also carry extra options for strace. This is why there is
@@ -119,6 +120,8 @@ and environment.
 			"timer": i18n.G("Run as a timer service with given schedule"),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"trace-exec": i18n.G("Display exec calls timing data"),
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"debug":      i18n.G("Enable debug logs during early snap startup phases"),
 			"parser-ran": "",
 		}, nil)
 }
@@ -477,6 +480,10 @@ func (x *cmdRun) straceOpts() (opts []string, raw bool, err error) {
 }
 
 func (x *cmdRun) snapRunApp(snapApp string, args []string) error {
+	if x.Debug {
+		os.Setenv("SNAPD_DEBUG", "1")
+		logger.Debugf("enabled debug logging of early snap startup")
+	}
 	snapName, appName := snap.SplitSnapApp(snapApp)
 	info, err := getSnapInfo(snapName, snap.R(0))
 	if err != nil {

--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -1971,3 +1971,48 @@ func (s *RunSuite) TestGetSnapDirOptions(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(opts, check.DeepEquals, &dirs.SnapDirOptions{HiddenSnapDataDir: true})
 }
+
+func (s *RunSuite) TestRunDebug(c *check.C) {
+	oldDebug, isSet := os.LookupEnv("SNAPD_DEBUG")
+	if isSet {
+		defer os.Setenv("SNAPD_DEBUG", oldDebug)
+	} else {
+		defer os.Unsetenv("SNAPD_DEBUG")
+	}
+
+	logBuf, r := logger.MockLogger()
+	defer r()
+
+	restore := mockSnapConfine(dirs.DistroLibExecDir)
+	defer restore()
+	execArg0 := ""
+	execArgs := []string{}
+	execEnv := []string{}
+	restore = snaprun.MockSyscallExec(func(arg0 string, args []string, envv []string) error {
+		execArg0 = arg0
+		execArgs = args
+		execEnv = envv
+		return nil
+	})
+	defer restore()
+
+	snaptest.MockSnapCurrent(c, string(mockYaml), &snap.SideInfo{
+		Revision: snap.R("12"),
+	})
+
+	// this will modify the current process environment
+	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--debug", "snapname.app"})
+	c.Assert(err, check.IsNil)
+	c.Check(execArg0, check.Equals, filepath.Join(dirs.DistroLibExecDir, "snap-confine"))
+	c.Check(execArgs, check.DeepEquals, []string{
+		filepath.Join(dirs.DistroLibExecDir, "snap-confine"),
+		"snap.snapname.app",
+		filepath.Join(dirs.CoreLibExecDir, "snap-exec"),
+		"snapname.app"})
+	c.Check(execEnv, testutil.Contains, "SNAP_REVISION=12")
+	c.Check(execEnv, testutil.Contains, "SNAPD_DEBUG=1")
+	// also set in env
+	c.Check(os.Getenv("SNAPD_DEBUG"), check.Equals, "1")
+	// and we've let the user know that logging was enabled
+	c.Check(logBuf.String(), testutil.Contains, "DEBUG: enabled debug logging of early snap startup")
+}


### PR DESCRIPTION
Add a --debug flag to snap run, which is equal to setting SNAPD_DEBUG=1 in the
environment, but will hopefully be more discoverable for users trying to poke at
things.

