### PR TITLE
many: fix leftover empty snap dirs

### DIFF
--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -395,7 +395,7 @@ func createUserDataDirs(info *snap.Info, opts *dirs.SnapDirOptions) error {
 		return fmt.Errorf(i18n.G("cannot get the current user: %v"), err)
 	}
 
-	snapDir := filepath.Join(usr.HomeDir, dirs.UserHomeSnapDir)
+	snapDir := snap.SnapDir(usr.HomeDir, opts)
 	if err := os.MkdirAll(snapDir, 0700); err != nil {
 		return fmt.Errorf(i18n.G("cannot create snap home dir: %w"), err)
 	}

--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -504,6 +504,14 @@ func (s *RunSuite) testSnapRunCreateDataDirs(c *check.C, snapDir string, opts *d
 	c.Assert(err, check.IsNil)
 	c.Check(osutil.FileExists(filepath.Join(s.fakeHome, snapDir, "snapname/42")), check.Equals, true)
 	c.Check(osutil.FileExists(filepath.Join(s.fakeHome, snapDir, "snapname/common")), check.Equals, true)
+
+	// check we don't create the alternative dir
+	nonExistentDir := dirs.HiddenSnapDataHomeDir
+	if snapDir == dirs.HiddenSnapDataHomeDir {
+		nonExistentDir = dirs.UserHomeSnapDir
+	}
+
+	c.Check(osutil.FileExists(filepath.Join(s.fakeHome, nonExistentDir)), check.Equals, false)
 }
 
 func (s *RunSuite) TestParallelInstanceSnapRunCreateDataDirs(c *check.C) {

--- a/overlord/snapstate/backend/copydata_test.go
+++ b/overlord/snapstate/backend/copydata_test.go
@@ -744,7 +744,12 @@ func (s *copydataSuite) TestUndoHideSnapData(c *C) {
 	c.Assert(target, Equals, "10")
 
 	// ~/.snap/data was removed
-	_, err = os.Stat(snap.SnapDir(homedir, opts))
+	hiddenDir := snap.SnapDir(homedir, opts)
+	_, err = os.Stat(hiddenDir)
+	c.Assert(errors.Is(err, os.ErrNotExist), Equals, true)
+
+	// ~/.snap was removed
+	_, err = os.Stat(filepath.Base(hiddenDir))
 	c.Assert(errors.Is(err, os.ErrNotExist), Equals, true)
 }
 

--- a/tests/main/hidden-snap-dir/task.yaml
+++ b/tests/main/hidden-snap-dir/task.yaml
@@ -24,7 +24,7 @@ execute: |
     echo "$snapEnv" | MATCH "SNAP_USER_COMMON=/root/snap/$NAME/common"
 
     test -d "$HOME"/snap
-    not test -d "$HOME"/.snap
+    not test -d "$HOME"/.snap/data
 
     echo "Take a snapshot"
     "$NAME".cmd echo "prev_data" > "$HOME"/snap/"$NAME"/current/data
@@ -42,8 +42,7 @@ execute: |
     test -d "$HOME"/.snap/data/"$NAME"
     test -d "$HOME"/.snap/data/"$NAME"/common
     test -d "$HOME"/.snap/data/"$NAME"/x2
-    # check that ~/snap is removed if empty (core has no user data)
-    not test -d "$HOME"/snap
+    not test -d "$HOME"/snap/"$NAME"
 
     echo "Check the env vars point to ~/.snap/data"
     snapEnv=$("$NAME".env)
@@ -78,7 +77,7 @@ execute: |
     "$TESTSTOOLS"/snaps-state install-local "$NAME"
 
     test -d "$HOME"/.snap/data/"$NAME"
-    not test -d "$HOME"/snap
+    not test -d "$HOME"/snap/"$NAME"
     snapEnv=$("$NAME".env)
     echo "$snapEnv" | MATCH "SNAP_USER_DATA=$HOME/\.snap/data/$NAME/x1"
     echo "$snapEnv" | MATCH "SNAP_USER_COMMON=$HOME/\.snap/data/$NAME/common"

--- a/tests/main/hidden-snap-dir/task.yaml
+++ b/tests/main/hidden-snap-dir/task.yaml
@@ -42,7 +42,8 @@ execute: |
     test -d "$HOME"/.snap/data/"$NAME"
     test -d "$HOME"/.snap/data/"$NAME"/common
     test -d "$HOME"/.snap/data/"$NAME"/x2
-    not test -d "$HOME"/snap/"$NAME"
+    # check that ~/snap is removed if empty (core has no user data)
+    not test -d "$HOME"/snap
 
     echo "Check the env vars point to ~/.snap/data"
     snapEnv=$("$NAME".env)
@@ -77,7 +78,7 @@ execute: |
     "$TESTSTOOLS"/snaps-state install-local "$NAME"
 
     test -d "$HOME"/.snap/data/"$NAME"
-    not test -d "$HOME"/snap/"$NAME"
+    not test -d "$HOME"/snap
     snapEnv=$("$NAME".env)
     echo "$snapEnv" | MATCH "SNAP_USER_DATA=$HOME/\.snap/data/$NAME/x1"
     echo "$snapEnv" | MATCH "SNAP_USER_COMMON=$HOME/\.snap/data/$NAME/common"

--- a/tests/main/hidden-snap-dir/task.yaml
+++ b/tests/main/hidden-snap-dir/task.yaml
@@ -24,7 +24,7 @@ execute: |
     echo "$snapEnv" | MATCH "SNAP_USER_COMMON=/root/snap/$NAME/common"
 
     test -d "$HOME"/snap
-    not test -d "$HOME"/.snap/data
+    not test -d "$HOME"/.snap
 
     echo "Take a snapshot"
     "$NAME".cmd echo "prev_data" > "$HOME"/snap/"$NAME"/current/data
@@ -91,7 +91,7 @@ execute: |
     "$TESTSTOOLS"/snaps-state install-local "$NAME"
 
     echo "Check snap user data was moved back"
-    not test -d "$HOME"/.snap/data/"$NAME"
+    not test -d "$HOME"/.snap
     test -d "$HOME"/snap/"$NAME"
 
     MATCH "common" < "$HOME"/snap/"$NAME"/common/common

--- a/tests/main/hidden-snap-dir/task.yaml
+++ b/tests/main/hidden-snap-dir/task.yaml
@@ -90,7 +90,7 @@ execute: |
     "$TESTSTOOLS"/snaps-state install-local "$NAME"
 
     echo "Check snap user data was moved back"
-    not test -d "$HOME"/.snap
+    not test -d "$HOME"/.snap/data
     test -d "$HOME"/snap/"$NAME"
 
     MATCH "common" < "$HOME"/snap/"$NAME"/common/common


### PR DESCRIPTION
I noticed that some checks in the migration spread test could be a bit stricter. Making those changes actually made the test fail so this PR addresses the root causes and improves the tests (unit and spread). The first commit fixes an issue where even after migration, the `~/snap` dir was being created due to a hardcoded value. The second commit attempts to remove `~/.snap` (if empty) after removing `~/.snap/data`.