### PR TITLE
asserts,cmd/snap-repair: support delegation when validating signatures

### DIFF
--- a/asserts/account_key.go
+++ b/asserts/account_key.go
@@ -31,9 +31,33 @@ var validAccountKeyName = regexp.MustCompile(`^(?:[a-z0-9]+-?)*[a-z](?:-?[a-z0-9
 // belonging to the account.
 type AccountKey struct {
 	assertionBase
-	since  time.Time
-	until  time.Time
+	sinceUntil
 	pubKey PublicKey
+}
+
+type sinceUntil struct {
+	since time.Time
+	until time.Time
+}
+
+func checkSinceUntilWhat(m map[string]interface{}, what string) (*sinceUntil, error) {
+	since, err := checkRFC3339DateWhat(m, "since", what)
+	if err != nil {
+		return nil, err
+	}
+
+	until, err := checkRFC3339DateWithDefaultWhat(m, "until", what, time.Time{})
+	if err != nil {
+		return nil, err
+	}
+	if !until.IsZero() && until.Before(since) {
+		return nil, fmt.Errorf("'until' time cannot be before 'since' time")
+	}
+
+	return &sinceUntil{
+		since: since,
+		until: until,
+	}, nil
 }
 
 // AccountID returns the account-id of this account-key.
@@ -65,33 +89,33 @@ func (ak *AccountKey) PublicKeyID() string {
 	return ak.pubKey.ID()
 }
 
-// isKeyValidAt returns whether the account key is valid at 'when' time.
-func (ak *AccountKey) isKeyValidAt(when time.Time) bool {
-	valid := when.After(ak.since) || when.Equal(ak.since)
-	if valid && !ak.until.IsZero() {
-		valid = when.Before(ak.until)
+// isValidAt returns whether the since-until constraint is valid at 'when' time.
+func (su *sinceUntil) isValidAt(when time.Time) bool {
+	valid := when.After(su.since) || when.Equal(su.since)
+	if valid && !su.until.IsZero() {
+		valid = when.Before(su.until)
 	}
 	return valid
 }
 
-// isKeyValidAssumingCurTimeWithin returns whether the account key is
+// isValidAssumingCurTimeWithin returns whether the since-until constraint  is
 // possibly valid if the current time is known to be within [earliest,
 // latest]. That means the intersection of possible current times and
 // validity is not empty.
 // If latest is zero, then current time is assumed to be >=earliest.
 // If earliest == latest this is equivalent to isKeyValidAt().
-func (ak *AccountKey) isKeyValidAssumingCurTimeWithin(earliest, latest time.Time) bool {
+func (su *sinceUntil) isValidAssumingCurTimeWithin(earliest, latest time.Time) bool {
 	if !latest.IsZero() {
 		// impossible input => false
 		if latest.Before(earliest) {
 			return false
 		}
-		if latest.Before(ak.since) {
+		if latest.Before(su.since) {
 			return false
 		}
 	}
-	if !ak.until.IsZero() {
-		if earliest.After(ak.until) || earliest.Equal(ak.until) {
+	if !su.until.IsZero() {
+		if earliest.After(su.until) || earliest.Equal(su.until) {
 			return false
 		}
 	}
@@ -181,17 +205,9 @@ func assembleAccountKey(assert assertionBase) (Assertion, error) {
 		}
 	}
 
-	since, err := checkRFC3339Date(assert.headers, "since")
+	sinceUntil, err := checkSinceUntilWhat(assert.headers, "header")
 	if err != nil {
 		return nil, err
-	}
-
-	until, err := checkRFC3339DateWithDefault(assert.headers, "until", time.Time{})
-	if err != nil {
-		return nil, err
-	}
-	if !until.IsZero() && until.Before(since) {
-		return nil, fmt.Errorf("'until' time cannot be before 'since' time")
 	}
 
 	pubk, err := checkPublicKey(&assert, "public-key-sha3-384")
@@ -202,8 +218,7 @@ func assembleAccountKey(assert assertionBase) (Assertion, error) {
 	// ignore extra headers for future compatibility
 	return &AccountKey{
 		assertionBase: assert,
-		since:         since,
-		until:         until,
+		sinceUntil:    *sinceUntil,
 		pubKey:        pubk,
 	}, nil
 }
@@ -211,8 +226,7 @@ func assembleAccountKey(assert assertionBase) (Assertion, error) {
 // AccountKeyRequest holds an account-key-request assertion, which is a self-signed request to prove that the requester holds the private key and wishes to create an account-key assertion for it.
 type AccountKeyRequest struct {
 	assertionBase
-	since  time.Time
-	until  time.Time
+	sinceUntil
 	pubKey PublicKey
 }
 
@@ -284,17 +298,9 @@ func assembleAccountKeyRequest(assert assertionBase) (Assertion, error) {
 		return nil, err
 	}
 
-	since, err := checkRFC3339Date(assert.headers, "since")
+	sinceUntil, err := checkSinceUntilWhat(assert.headers, "header")
 	if err != nil {
 		return nil, err
-	}
-
-	until, err := checkRFC3339DateWithDefault(assert.headers, "until", time.Time{})
-	if err != nil {
-		return nil, err
-	}
-	if !until.IsZero() && until.Before(since) {
-		return nil, fmt.Errorf("'until' time cannot be before 'since' time")
 	}
 
 	pubk, err := checkPublicKey(&assert, "public-key-sha3-384")
@@ -305,8 +311,7 @@ func assembleAccountKeyRequest(assert assertionBase) (Assertion, error) {
 	// ignore extra headers for future compatibility
 	return &AccountKeyRequest{
 		assertionBase: assert,
-		since:         since,
-		until:         until,
+		sinceUntil:    *sinceUntil,
 		pubKey:        pubk,
 	}, nil
 }

--- a/asserts/account_key_test.go
+++ b/asserts/account_key_test.go
@@ -622,7 +622,7 @@ func (aks *accountKeySuite) TestPublicKeyIsValidAssumingCurTimeWithinWithUntilPu
 	}
 
 	for _, t := range tests {
-		c.Check(asserts.AccountKeyIsKeyValidAssumingCurTimeWithin(accKey, t.timePt, t.timePt), Equals, t.valid)
+		c.Check(asserts.IsValidAssumingCurTimeWithin(accKey, t.timePt, t.timePt), Equals, t.valid)
 	}
 }
 
@@ -657,7 +657,7 @@ func (aks *accountKeySuite) TestPublicKeyIsValidAssumingCurTimeWithinNoUntilPunc
 	}
 
 	for _, t := range tests {
-		c.Check(asserts.AccountKeyIsKeyValidAssumingCurTimeWithin(accKey, t.timePt, t.timePt), Equals, t.valid)
+		c.Check(asserts.IsValidAssumingCurTimeWithin(accKey, t.timePt, t.timePt), Equals, t.valid)
 	}
 }
 
@@ -711,7 +711,7 @@ func (aks *accountKeySuite) TestPublicKeyIsValidAssumingCurTimeWithinWithUntilIn
 	}
 
 	for _, t := range tests {
-		c.Check(asserts.AccountKeyIsKeyValidAssumingCurTimeWithin(accKey, t.earliest, t.latest), Equals, t.valid)
+		c.Check(asserts.IsValidAssumingCurTimeWithin(accKey, t.earliest, t.latest), Equals, t.valid)
 	}
 
 }
@@ -766,7 +766,7 @@ func (aks *accountKeySuite) TestPublicKeyIsValidAssumingCurTimeWithinNoUntilInte
 	}
 
 	for _, t := range tests {
-		c.Check(asserts.AccountKeyIsKeyValidAssumingCurTimeWithin(accKey, t.earliest, t.latest), Equals, t.valid)
+		c.Check(asserts.IsValidAssumingCurTimeWithin(accKey, t.earliest, t.latest), Equals, t.valid)
 	}
 
 }

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -398,8 +398,12 @@ type Assertion interface {
 	SupportedFormat() bool
 	// Revision returns the revision of this assertion
 	Revision() int
-	// AuthorityID returns the authority that signed this assertion
+	// AuthorityID returns the authority ultimately responsible
+	// for this assertion
 	AuthorityID() string
+	// SignatoryID returns the account that signed this assertion, it will
+	// differ from AuthorityID in the case of signing authority delegation
+	SignatoryID() string
 
 	// Header retrieves the header with name
 	Header(name string) interface{}
@@ -488,9 +492,19 @@ func (ab *assertionBase) Revision() int {
 	return ab.revision
 }
 
-// AuthorityID returns the authority-id a.k.a the signer id of the assertion.
+// AuthorityID returns the authority-id a.k.a the authority ultimately responsible for the assertion.
 func (ab *assertionBase) AuthorityID() string {
 	return ab.HeaderString("authority-id")
+}
+
+// SignatoryID returns the account that signed this assertion, it will
+// differ from AuthorityID in the case of signing authority delegation.
+func (ab *assertionBase) SignatoryID() string {
+	signID := ab.HeaderString("signatory-id")
+	if signID != "" {
+		return signID
+	}
+	return ab.AuthorityID()
 }
 
 // Header returns the value of an header by name.

--- a/asserts/authority_delegation.go
+++ b/asserts/authority_delegation.go
@@ -135,9 +135,14 @@ func assembleAuthorityDelegation(assert assertionBase) (Assertion, error) {
 		if err != nil {
 			return nil, fmt.Errorf("cannot compile headers constraint: %v", err)
 		}
+		sinceUntil, err := checkSinceUntilWhat(m, "constraint")
+		if err != nil {
+			return nil, err
+		}
 		acs = append(acs, &AssertionConstraints{
 			assertType: t,
 			matcher:    matcher,
+			sinceUntil: *sinceUntil,
 		})
 	}
 
@@ -153,7 +158,7 @@ func assembleAuthorityDelegation(assert assertionBase) (Assertion, error) {
 type AssertionConstraints struct {
 	assertType *AssertionType
 	matcher    attrMatcher
-	// XXX since/until
+	sinceUntil
 	// XXX device scoping
 }
 

--- a/asserts/authority_delegation.go
+++ b/asserts/authority_delegation.go
@@ -139,6 +139,12 @@ func assembleAuthorityDelegation(assert assertionBase) (Assertion, error) {
 		if err != nil {
 			return nil, err
 		}
+		_, onStore := m["on-store"]
+		_, onBrand := m["on-brand"]
+		_, onModel := m["on-model"]
+		if onStore || onBrand || onModel {
+			return nil, fmt.Errorf("device scope constraints not yet implemented")
+		}
 		acs = append(acs, &AssertionConstraints{
 			assertType: t,
 			matcher:    matcher,
@@ -165,6 +171,9 @@ type AssertionConstraints struct {
 // Check checks whether the assertion matches the constraints.
 // It returns an error otherwise.
 func (ac *AssertionConstraints) Check(a Assertion) error {
+	if a.Type() != ac.assertType {
+		return fmt.Errorf("assertion %q does not match constraint for assertion type %q", a.Type().Name, ac.assertType.Name)
+	}
 	return ac.matcher.match("", a.Headers(), &attrMatchingContext{
 		attrWord: "header",
 	})

--- a/asserts/authority_delegation_test.go
+++ b/asserts/authority_delegation_test.go
@@ -278,6 +278,8 @@ func (s *authorityDelegationSuite) TestDecodeDeviceScope(c *C) {
 	sinceFrag := "    since: 2022-01-12T00:00:00.0Z\n"
 	for _, deviceScoping := range []string{
 		"on-store: store1",
+		"on-brand: brand-id-1",
+		"on-model: brand-id-1/model1",
 	} {
 		withDeviceScope := strings.Replace(encoded, sinceFrag, fmt.Sprintf("    %s\n", deviceScoping)+sinceFrag, 1)
 		_, err := asserts.Decode([]byte(withDeviceScope))

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -703,7 +703,7 @@ func CheckSigningKeyIsNotExpired(assert Assertion, signingKey *AccountKey, roDB 
 		// (e.g. account-key-request)
 		return nil
 	}
-	if !signingKey.isKeyValidAssumingCurTimeWithin(checkTimeEarliest, checkTimeLatest) {
+	if !signingKey.isValidAssumingCurTimeWithin(checkTimeEarliest, checkTimeLatest) {
 		return fmt.Errorf("assertion is signed with expired public key %q from %q", assert.SignKeyID(), assert.AuthorityID())
 	}
 	return nil
@@ -752,7 +752,7 @@ func CheckTimestampVsSigningKeyValidity(assert Assertion, signingKey *AccountKey
 	}
 	if tstamped, ok := assert.(timestamped); ok {
 		checkTime := tstamped.Timestamp()
-		if !signingKey.isKeyValidAt(checkTime) {
+		if !signingKey.isValidAt(checkTime) {
 			until := ""
 			if !signingKey.Until().IsZero() {
 				until = fmt.Sprintf(" until %q", signingKey.Until())

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -719,7 +719,7 @@ func CheckSignature(assert Assertion, signingKey *AccountKey, _ []*AssertionCons
 	if signingKey != nil {
 		pubKey = signingKey.publicKey()
 		if assert.SignatoryID() != signingKey.AccountID() {
-			return nil, fmt.Errorf("assertion signatory %q does not match public key from %q", assert.AuthorityID(), signingKey.AccountID())
+			return nil, fmt.Errorf("assertion signatory %q does not match public key from %q", assert.SignatoryID(), signingKey.AccountID())
 		}
 		if assert.SignatoryID() != assert.AuthorityID() {
 			ad, err := roDB.Find(AuthorityDelegationType, map[string]string{

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -215,7 +215,9 @@ type RODatabase interface {
 // A Checker defines a check on an assertion considering aspects such as
 // the signing key, and consistency with other
 // assertions in the database.
-type Checker func(assert Assertion, signingKey *AccountKey, roDB RODatabase, checkTimeEarliest, checkTimeLatest time.Time) error
+// It can also participate in validating and filtering delegation assertion
+// constraint in the case of delegation.
+type Checker func(assert Assertion, signingKey *AccountKey, delegationConstraints []*AssertionConstraints, roDB RODatabase, checkTimeEarliest, checkTimeLatest time.Time) ([]*AssertionConstraints, error)
 
 // Database holds assertions and can be used to sign or check
 // further assertions.
@@ -431,11 +433,13 @@ func (db *Database) Check(assert Assertion) error {
 		}
 	}
 
+	var delegationConstraints []*AssertionConstraints
 	for _, checker := range db.checkers {
-		err := checker(assert, accKey, db, earliestTime, latestTime)
+		acs, err := checker(assert, accKey, delegationConstraints, db, earliestTime, latestTime)
 		if err != nil {
 			return err
 		}
+		delegationConstraints = acs
 	}
 
 	return nil
@@ -695,27 +699,27 @@ func (db *Database) FindSequence(assertType *AssertionType, sequenceHeaders map[
 // assertion checkers
 
 // CheckSigningKeyIsNotExpired checks that the signing key is not expired.
-func CheckSigningKeyIsNotExpired(assert Assertion, signingKey *AccountKey, roDB RODatabase, checkTimeEarliest, checkTimeLatest time.Time) error {
+func CheckSigningKeyIsNotExpired(assert Assertion, signingKey *AccountKey, delegationConstraints []*AssertionConstraints, roDB RODatabase, checkTimeEarliest, checkTimeLatest time.Time) ([]*AssertionConstraints, error) {
 	if signingKey == nil {
 		// assert isn't signed with an account-key key, CheckSignature
 		// will fail anyway unless we teach it more stuff,
 		// Also this check isn't so relevant for self-signed asserts
 		// (e.g. account-key-request)
-		return nil
+		return nil, nil
 	}
 	if !signingKey.isValidAssumingCurTimeWithin(checkTimeEarliest, checkTimeLatest) {
-		return fmt.Errorf("assertion is signed with expired public key %q from %q", assert.SignKeyID(), assert.SignatoryID())
+		return nil, fmt.Errorf("assertion is signed with expired public key %q from %q", assert.SignKeyID(), assert.SignatoryID())
 	}
-	return nil
+	return delegationConstraints, nil
 }
 
 // CheckSignature checks that the signature is valid.
-func CheckSignature(assert Assertion, signingKey *AccountKey, roDB RODatabase, checkTimeEarliest, checkTimeLatest time.Time) error {
+func CheckSignature(assert Assertion, signingKey *AccountKey, _ []*AssertionConstraints, roDB RODatabase, checkTimeEarliest, checkTimeLatest time.Time) (delegationConstraints []*AssertionConstraints, err error) {
 	var pubKey PublicKey
 	if signingKey != nil {
 		pubKey = signingKey.publicKey()
 		if assert.SignatoryID() != signingKey.AccountID() {
-			return fmt.Errorf("assertion signatory %q does not match public key from %q", assert.AuthorityID(), signingKey.AccountID())
+			return nil, fmt.Errorf("assertion signatory %q does not match public key from %q", assert.AuthorityID(), signingKey.AccountID())
 		}
 		if assert.SignatoryID() != assert.AuthorityID() {
 			ad, err := roDB.Find(AuthorityDelegationType, map[string]string{
@@ -724,34 +728,34 @@ func CheckSignature(assert Assertion, signingKey *AccountKey, roDB RODatabase, c
 			})
 			if err != nil {
 				if IsNotFound(err) {
-					return fmt.Errorf("no matching authority-delegation for signing delegation from %q to %q", assert.AuthorityID(), assert.SignatoryID())
+					return nil, fmt.Errorf("no matching authority-delegation for signing delegation from %q to %q", assert.AuthorityID(), assert.SignatoryID())
 
 				}
-				return err
+				return nil, err
 			}
 			acs := ad.(*AuthorityDelegation).MatchingConstraints(assert)
 			if len(acs) == 0 {
-				return fmt.Errorf("no valid constraints supporting delegated %q from %q to %q", assert.Type().Name, assert.AuthorityID(), assert.SignatoryID())
+				return nil, fmt.Errorf("no matching constraints supporting delegated %s assertion from %q to %q", assert.Type().Name, assert.AuthorityID(), assert.SignatoryID())
 			}
-			return fmt.Errorf("signing authority delegation not implemented")
+			delegationConstraints = acs
 		}
 	} else {
 		custom, ok := assert.(customSigner)
 		if !ok {
-			return fmt.Errorf("cannot check no-authority assertion type %q", assert.Type().Name)
+			return nil, fmt.Errorf("cannot check no-authority assertion type %q", assert.Type().Name)
 		}
 		pubKey = custom.signKey()
 	}
 	content, encSig := assert.Signature()
 	signature, err := decodeSignature(encSig)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	err = pubKey.verify(content, signature)
 	if err != nil {
-		return fmt.Errorf("failed signature verification: %v", err)
+		return nil, fmt.Errorf("failed signature verification: %v", err)
 	}
-	return nil
+	return delegationConstraints, nil
 }
 
 type timestamped interface {
@@ -760,13 +764,13 @@ type timestamped interface {
 
 // CheckTimestampVsSigningKeyValidity verifies that the timestamp of
 // the assertion is within the signing key validity.
-func CheckTimestampVsSigningKeyValidity(assert Assertion, signingKey *AccountKey, roDB RODatabase, checkTimeEarliest, checkTimeLatest time.Time) error {
+func CheckTimestampVsSigningKeyValidity(assert Assertion, signingKey *AccountKey, delegationConstraints []*AssertionConstraints, roDB RODatabase, checkTimeEarliest, checkTimeLatest time.Time) ([]*AssertionConstraints, error) {
 	if signingKey == nil {
 		// assert isn't signed with an account-key key, CheckSignature
 		// will fail anyway unless we teach it more stuff.
 		// Also this check isn't so relevant for self-signed asserts
 		// (e.g. account-key-request)
-		return nil
+		return nil, nil
 	}
 	if tstamped, ok := assert.(timestamped); ok {
 		checkTime := tstamped.Timestamp()
@@ -775,14 +779,12 @@ func CheckTimestampVsSigningKeyValidity(assert Assertion, signingKey *AccountKey
 			if !signingKey.Until().IsZero() {
 				until = fmt.Sprintf(" until %q", signingKey.Until())
 			}
-			return fmt.Errorf("%s assertion timestamp %q outside of signing key validity (key valid since %q%s)",
+			return nil, fmt.Errorf("%s assertion timestamp %q outside of signing key validity (key valid since %q%s)",
 				assert.Type().Name, checkTime, signingKey.Since(), until)
 		}
 	}
-	return nil
+	return delegationConstraints, nil
 }
-
-// XXX: keeping these in this form until we know better
 
 // A consistencyChecker performs further checks based on the full
 // assertion database knowledge and its own signing key.
@@ -791,12 +793,68 @@ type consistencyChecker interface {
 }
 
 // CheckCrossConsistency verifies that the assertion is consistent with the other statements in the database.
-func CheckCrossConsistency(assert Assertion, signingKey *AccountKey, roDB RODatabase, checkTimeEarliest, checkTimeLatest time.Time) error {
+func CheckCrossConsistency(assert Assertion, signingKey *AccountKey, delegationConstraints []*AssertionConstraints, roDB RODatabase, checkTimeEarliest, checkTimeLatest time.Time) ([]*AssertionConstraints, error) {
 	// see if the assertion requires further checks
 	if checker, ok := assert.(consistencyChecker); ok {
-		return checker.checkConsistency(roDB, signingKey)
+		return delegationConstraints, checker.checkConsistency(roDB, signingKey)
 	}
-	return nil
+	return delegationConstraints, nil
+}
+
+// CheckDelegationIsNotExpired checks that there is at least one not expired delegation constraint.
+func CheckDelegationIsNotExpired(assert Assertion, signingKey *AccountKey, delegationConstraints []*AssertionConstraints, roDB RODatabase, checkTimeEarliest, checkTimeLatest time.Time) ([]*AssertionConstraints, error) {
+	if len(delegationConstraints) == 0 {
+		// nothing to do
+		return nil, nil
+	}
+	notExpired := make([]*AssertionConstraints, 0, len(delegationConstraints))
+	for _, ac := range delegationConstraints {
+		if ac.isValidAssumingCurTimeWithin(checkTimeEarliest, checkTimeLatest) {
+			notExpired = append(notExpired, ac)
+		}
+	}
+	if len(notExpired) == 0 {
+		return nil, fmt.Errorf("all constraints supporting delegated %s assertion from %q to %q are expired", assert.Type().Name, assert.AuthorityID(), assert.SignatoryID())
+	}
+	return notExpired, nil
+}
+
+// CheckTimestampVsDelegationValidity verifies that the timestamp of
+// the assertion is within at least one of the delegation constraints validity.
+func CheckTimestampVsDelegationValidity(assert Assertion, signingKey *AccountKey, delegationConstraints []*AssertionConstraints, roDB RODatabase, checkTimeEarliest, checkTimeLatest time.Time) ([]*AssertionConstraints, error) {
+	if len(delegationConstraints) == 0 {
+		// nothing to do
+		return nil, nil
+	}
+	if tstamped, ok := assert.(timestamped); ok {
+		checkTime := tstamped.Timestamp()
+		valid := make([]*AssertionConstraints, 0, len(delegationConstraints))
+		for _, ac := range delegationConstraints {
+			if ac.isValidAt(checkTime) {
+				valid = append(valid, ac)
+			}
+		}
+		if len(valid) == 0 {
+			return nil, fmt.Errorf("delegated %s assertion from %q to %q timestamp %q is outside all supporting delegation constraints validity", assert.Type().Name, assert.AuthorityID(), assert.SignatoryID(), checkTime)
+		}
+		return valid, nil
+	}
+	return delegationConstraints, nil
+}
+
+// CheckDelegation performs the final verification of delegation based
+// on filtered delegation assertion constraints.
+func CheckDelegation(assert Assertion, signingKey *AccountKey, delegationConstraints []*AssertionConstraints, roDB RODatabase, checkTimeEarliest, checkTimeLatest time.Time) ([]*AssertionConstraints, error) {
+	if signingKey == nil || assert.SignatoryID() == assert.AuthorityID() {
+		// not a delegation scenario
+		return nil, nil
+	}
+	for _, ac := range delegationConstraints {
+		if ac.Check(assert) == nil {
+			return nil, nil
+		}
+	}
+	return nil, fmt.Errorf("no valid constraints supporting delegated %s assertion from %q to %q", assert.Type().Name, assert.AuthorityID(), assert.SignatoryID())
 }
 
 // DefaultCheckers lists the default and recommended assertion
@@ -805,6 +863,9 @@ func CheckCrossConsistency(assert Assertion, signingKey *AccountKey, roDB ROData
 var DefaultCheckers = []Checker{
 	CheckSigningKeyIsNotExpired,
 	CheckSignature,
+	CheckDelegationIsNotExpired,
 	CheckTimestampVsSigningKeyValidity,
+	CheckTimestampVsDelegationValidity,
+	CheckDelegation,
 	CheckCrossConsistency,
 }

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -835,7 +835,7 @@ func CheckTimestampVsDelegationValidity(assert Assertion, signingKey *AccountKey
 			}
 		}
 		if len(valid) == 0 {
-			return nil, fmt.Errorf("delegated %s assertion from %q to %q timestamp %q is outside all supporting delegation constraints validity", assert.Type().Name, assert.AuthorityID(), assert.SignatoryID(), checkTime)
+			return nil, fmt.Errorf("delegated %s assertion from %q to %q timestamp %q is outside of all supporting delegation constraints validity", assert.Type().Name, assert.AuthorityID(), assert.SignatoryID(), checkTime)
 		}
 		return valid, nil
 	}

--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -78,8 +78,10 @@ func MakeAccountKeyForTest(authorityID string, openPGPPubKey PublicKey, since ti
 				"public-key-sha3-384": openPGPPubKey.ID(),
 			},
 		},
-		since:  since.UTC(),
-		until:  since.UTC().AddDate(validYears, 0, 0),
+		sinceUntil: sinceUntil{
+			since: since.UTC(),
+			until: since.UTC().AddDate(validYears, 0, 0),
+		},
 		pubKey: openPGPPubKey,
 	}
 }
@@ -255,12 +257,16 @@ func init() {
 
 // AccountKeyIsKeyValidAt exposes isKeyValidAt on AccountKey for tests
 func AccountKeyIsKeyValidAt(ak *AccountKey, when time.Time) bool {
-	return ak.isKeyValidAt(when)
+	return ak.isValidAt(when)
 }
 
-// AccountKeyIsKeyValidAssumingCurTimeWithin exposes isKeyValidAssumingCurTimeWithin on AccountKey for tests
-func AccountKeyIsKeyValidAssumingCurTimeWithin(ak *AccountKey, earliest, latest time.Time) bool {
-	return ak.isKeyValidAssumingCurTimeWithin(earliest, latest)
+type sinceUntilLike interface {
+	isValidAssumingCurTimeWithin(earliest, latest time.Time) bool
+}
+
+// IsValidAssumingCurTimeWithin exposes sinceUntil.isValidAssumingCurTimeWithin
+func IsValidAssumingCurTimeWithin(su sinceUntilLike, earliest, latest time.Time) bool {
+	return su.isValidAssumingCurTimeWithin(earliest, latest)
 }
 
 type GPGRunner func(input []byte, args ...string) ([]byte, error)

--- a/asserts/snap_asserts_test.go
+++ b/asserts/snap_asserts_test.go
@@ -1047,7 +1047,7 @@ func (srs *snapRevSuite) TestSnapRevisionDelegation(c *C) {
 	c.Check(err, IsNil)
 }
 
-func (srs *snapRevSuite) TestSnapRevisionDelegationIncosistentTimestamp(c *C) {
+func (srs *snapRevSuite) TestSnapRevisionDelegationInconsistentTimestamp(c *C) {
 	storeDB, db := makeStoreAndCheckDB(c)
 
 	prereqDevAccount(c, storeDB, db)
@@ -1087,7 +1087,7 @@ func (srs *snapRevSuite) TestSnapRevisionDelegationIncosistentTimestamp(c *C) {
 	c.Check(db.Add(ad), IsNil)
 
 	err = db.Check(snapRev)
-	c.Check(err, ErrorMatches, `delegated snap-revision assertion from "canonical" to "other" timestamp ".*" is outside all supporting delegation constraints validity`)
+	c.Check(err, ErrorMatches, `delegated snap-revision assertion from "canonical" to "other" timestamp ".*" is outside of all supporting delegation constraints validity`)
 }
 
 func (srs *snapRevSuite) TestPrimaryKey(c *C) {

--- a/asserts/snap_asserts_test.go
+++ b/asserts/snap_asserts_test.go
@@ -1006,6 +1006,90 @@ func (srs *snapRevSuite) TestSnapRevisionCheckMissingDeclaration(c *C) {
 	c.Assert(err, ErrorMatches, `snap-revision assertion for snap id "snap-id-1" does not have a matching snap-declaration assertion`)
 }
 
+func (srs *snapRevSuite) TestSnapRevisionDelegation(c *C) {
+	storeDB, db := makeStoreAndCheckDB(c)
+
+	prereqDevAccount(c, storeDB, db)
+	prereqSnapDecl(c, storeDB, db)
+
+	otherDB := setup3rdPartySigning(c, "other", storeDB, db)
+
+	since := time.Now()
+	headers := srs.makeHeaders(map[string]interface{}{
+		"authority-id": "canonical",
+		"signatory-id": "other",
+		"timestamp":    since.Format(time.RFC3339),
+	})
+	snapRev, err := otherDB.Sign(asserts.SnapRevisionType, headers, nil, "")
+	c.Assert(err, IsNil)
+
+	// now add authority-delegation
+	headers = map[string]interface{}{
+		"type":         "account-key",
+		"authority-id": "canonical",
+		"account-id":   "canonical",
+		"delegate-id":  "other",
+		"assertions": []interface{}{
+			map[string]interface{}{
+				"type": "snap-revision",
+				"headers": map[string]interface{}{
+					"snap-id": "snap-id-1",
+				},
+				"since": since.AddDate(0, -1, 0).Format(time.RFC3339),
+			},
+		},
+	}
+	ad, err := storeDB.Sign(asserts.AuthorityDelegationType, headers, nil, "")
+	c.Assert(err, IsNil)
+	c.Check(db.Add(ad), IsNil)
+
+	err = db.Check(snapRev)
+	c.Check(err, IsNil)
+}
+
+func (srs *snapRevSuite) TestSnapRevisionDelegationIncosistentTimestamp(c *C) {
+	storeDB, db := makeStoreAndCheckDB(c)
+
+	prereqDevAccount(c, storeDB, db)
+	prereqSnapDecl(c, storeDB, db)
+
+	otherDB := setup3rdPartySigning(c, "other", storeDB, db)
+
+	headers := srs.makeHeaders(map[string]interface{}{
+		"authority-id": "canonical",
+		"signatory-id": "other",
+		"timestamp":    time.Now().Format(time.RFC3339),
+	})
+	snapRev, err := otherDB.Sign(asserts.SnapRevisionType, headers, nil, "")
+	c.Assert(err, IsNil)
+
+	// move forward in time
+	time.Sleep(100 * time.Millisecond)
+
+	// now add authority-delegation
+	headers = map[string]interface{}{
+		"type":         "account-key",
+		"authority-id": "canonical",
+		"account-id":   "canonical",
+		"delegate-id":  "other",
+		"assertions": []interface{}{
+			map[string]interface{}{
+				"type": "snap-revision",
+				"headers": map[string]interface{}{
+					"snap-id": "snap-id-1",
+				},
+				"since": time.Now().Format(time.RFC3339Nano),
+			},
+		},
+	}
+	ad, err := storeDB.Sign(asserts.AuthorityDelegationType, headers, nil, "")
+	c.Assert(err, IsNil)
+	c.Check(db.Add(ad), IsNil)
+
+	err = db.Check(snapRev)
+	c.Check(err, ErrorMatches, `delegated snap-revision assertion from "canonical" to "other" timestamp ".*" is outside all supporting delegation constraints validity`)
+}
+
 func (srs *snapRevSuite) TestPrimaryKey(c *C) {
 	storeDB, db := makeStoreAndCheckDB(c)
 

--- a/cmd/snap-repair/runner.go
+++ b/cmd/snap-repair/runner.go
@@ -660,7 +660,10 @@ func verifySignatures(a asserts.Assertion, workBS asserts.Backstore, trusted ass
 				return err
 			}
 		}
-		if err := asserts.CheckSignature(a, key.(*asserts.AccountKey), nil, time.Time{}, time.Time{}); err != nil {
+		if a.SignatoryID() != a.AuthorityID() {
+			return fmt.Errorf("signing authority delegation is not supported for repairs")
+		}
+		if _, err := asserts.CheckSignature(a, key.(*asserts.AccountKey), nil, nil, time.Time{}, time.Time{}); err != nil {
 			return err
 		}
 		a = key


### PR DESCRIPTION
this adds support for since-until in assertion constraints and needed checks during assertion/signature validation.

Currently prohibit delegation for repairs.

TODO in later PRs:
* first-class formatting/encoding support for signatory-id
* retrieve authority-delegation as needed when fetching account-keys for assertions
* support device scope constraint in assertion constraint, take them into account on assertion retrieval as well
* implement $WITHIN(n1,n2) constraint
