### PR TITLE
o/servicestate: revert #11003 checking for memory cgroup being disabled

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -134,8 +134,6 @@ var (
 	SysfsDir        string
 
 	FeaturesDir string
-
-	CGroupsStatusFile string
 )
 
 const (
@@ -430,8 +428,6 @@ func SetRootDir(rootdir string) {
 
 	LocaleDir = filepath.Join(rootdir, "/usr/share/locale")
 	ClassicDir = filepath.Join(rootdir, "/writable/classic")
-
-	CGroupsStatusFile = filepath.Join(rootdir, "/proc/cgroups")
 
 	opensuseTWWithLibexec := func() bool {
 		// XXX: this is pretty naive if openSUSE ever starts going back

--- a/overlord/servicestate/export_test.go
+++ b/overlord/servicestate/export_test.go
@@ -30,8 +30,6 @@ var (
 	CheckSystemdVersion      = checkSystemdVersion
 	QuotaStateAlreadyUpdated = quotaStateAlreadyUpdated
 	ServiceControlTs         = serviceControlTs
-	CGroupsFilePath          = cgroupsFilePath
-	SetCGroupsFilePath       = setCGroupsFilePath
 )
 
 type QuotaStateUpdated = quotaStateUpdated

--- a/overlord/servicestate/quota_control_test.go
+++ b/overlord/servicestate/quota_control_test.go
@@ -21,7 +21,6 @@ package servicestate_test
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"time"
 
@@ -53,10 +52,10 @@ func (s *quotaControlSuite) SetUpTest(c *C) {
 
 	// we don't need the EnsureSnapServices ensure loop to run by default
 	servicestate.MockEnsuredSnapServices(s.mgr, true)
+
 	// we enable quota-groups by default
 	s.state.Lock()
 	defer s.state.Unlock()
-
 	tr := config.NewTransaction(s.state)
 	tr.Set("core", "experimental.quota-groups", true)
 	tr.Commit()
@@ -65,23 +64,6 @@ func (s *quotaControlSuite) SetUpTest(c *C) {
 	r := systemd.MockSystemdVersion(248, nil)
 	s.AddCleanup(r)
 	servicestate.CheckSystemdVersion()
-
-	cgroupsPath := dirs.GlobalRootDir + "/proc/cgroups"
-	if _, err := os.Stat(filepath.Dir(cgroupsPath)); os.IsNotExist(err) {
-		err := os.Mkdir(filepath.Dir(cgroupsPath), 0777)
-		c.Assert(err, IsNil)
-	}
-	cgroupsFile, err := os.Create(cgroupsPath)
-	c.Assert(err, IsNil)
-	defer cgroupsFile.Close()
-	// memory is enabled & file size is reduced as we only check for memory at this point
-	_, err = cgroupsFile.WriteString(`#subsys_name	hierarchy	num_cgroups	enabled
-cpuset	6	3	1
-cpu	3	133	1
-memory	2	223	1
-devices	10	135	1`)
-	c.Assert(err, IsNil)
-	cgroupsFile.Sync()
 }
 
 type quotaGroupState struct {
@@ -675,6 +657,7 @@ func (s *quotaControlSuite) TestSnapOpRemoveQuotaConflict(c *C) {
 	c.Assert(err, IsNil)
 	chg1 := s.state.NewChange("disable", "...")
 	chg1.AddAll(ts)
+
 	_, err = servicestate.RemoveQuota(st, "foo")
 	c.Assert(err, ErrorMatches, `snap "test-snap" has "disable" change in progress`)
 }
@@ -945,229 +928,6 @@ func (s *quotaControlSuite) TestCreateQuotaCreateQuotaConflict(c *C) {
 
 	_, err = servicestate.CreateQuota(st, "foo", "", []string{"test-snap2"}, quota.NewResources(2*quantity.SizeGiB))
 	c.Assert(err, ErrorMatches, `quota group "foo" has "quota-control" change in progress`)
-}
-
-func (s *quotaControlSuite) TestMemoryCGroupDisabled(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	memoryCGroupFile := servicestate.CGroupsFilePath
-	defer func() {
-		servicestate.SetCGroupsFilePath(memoryCGroupFile)
-	}()
-
-	cgroupsPath := dirs.GlobalRootDir + "/proc/cgroups"
-	cgroupsFile, err := os.Create(cgroupsPath)
-	c.Assert(err, IsNil)
-	defer cgroupsFile.Close()
-	// memory is enabled & file size is reduced as we only check for memory at this point
-	_, err = cgroupsFile.WriteString(`#subsys_name	hierarchy	num_cgroups	enabled
-cpuset	6	3	1
-cpu	3	133	1
-memory	2	223	0
-devices	10	135	1`)
-	c.Assert(err, IsNil)
-	cgroupsFile.Sync()
-	// reset memory cgroup status with the enabled file
-	servicestate.SetCGroupsFilePath(cgroupsPath)
-
-	// check if all operations fail with the expected error message
-	errExpected := `cannot retrieve quota information, memory cgroup is disabled on this system`
-	_, err = servicestate.AllQuotas(s.state)
-	c.Assert(err, NotNil)
-	c.Assert(err, ErrorMatches, errExpected)
-
-	_, err = servicestate.GetQuota(s.state, "foo")
-	c.Assert(err, NotNil)
-	c.Assert(err, ErrorMatches, errExpected)
-
-	_, err = servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap"}, quota.NewResources(2*quantity.SizeGiB))
-	c.Assert(err, NotNil)
-	c.Assert(err, ErrorMatches, errExpected)
-
-	_, err = servicestate.RemoveQuota(s.state, "foo")
-	c.Assert(err, NotNil)
-	c.Assert(err, ErrorMatches, errExpected)
-
-	_, err = servicestate.UpdateQuota(s.state, "foo", servicestate.QuotaGroupUpdate{NewResourceLimits: quota.NewResources(2 * quantity.SizeGiB)})
-	c.Assert(err, NotNil)
-	c.Assert(err, ErrorMatches, errExpected)
-}
-
-func (s *quotaControlSuite) TestMemoryCGroupEnabled(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	memoryCGroupFile := servicestate.CGroupsFilePath
-	defer func() {
-		servicestate.SetCGroupsFilePath(memoryCGroupFile)
-	}()
-
-	cgroupsPath := dirs.GlobalRootDir + "/proc/cgroups"
-	cgroupsFile, err := os.Create(cgroupsPath)
-	c.Assert(err, IsNil)
-	defer cgroupsFile.Close()
-	// memory is enabled & file size is reduced as we only check for memory at this point
-	_, err = cgroupsFile.WriteString(`#subsys_name	hierarchy	num_cgroups	enabled
-cpuset	6	3	1
-cpu	3	133	1
-memory	2	223	1
-devices	10	135	1`)
-	c.Assert(err, IsNil)
-	cgroupsFile.Sync()
-
-	// reset memory cgroup status with the enabled file
-	servicestate.SetCGroupsFilePath(cgroupsPath)
-
-	// check if all operations fail with the expected error message
-	_, err = servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap"}, quota.NewResources(2*quantity.SizeGiB))
-	c.Assert(err, NotNil)
-	c.Assert(err, ErrorMatches, `cannot use snap \"test-snap\" in group \"foo\": snap \"test-snap\" is not installed`)
-
-	_, err = servicestate.RemoveQuota(s.state, "foo")
-	c.Assert(err, NotNil)
-	c.Assert(err, ErrorMatches, `cannot remove non-existent quota group \"foo\"`)
-
-	_, err = servicestate.UpdateQuota(s.state, "foo", servicestate.QuotaGroupUpdate{NewResourceLimits: quota.NewResources(2 * quantity.SizeGiB)})
-	c.Assert(err, NotNil)
-	c.Assert(err, ErrorMatches, `group \"foo\" does not exist`)
-
-	_, err = servicestate.AllQuotas(s.state)
-	c.Assert(err, IsNil)
-
-	_, err = servicestate.GetQuota(s.state, "foo")
-	c.Assert(err, NotNil)
-	c.Assert(err, ErrorMatches, `quota not found`)
-}
-
-func (s *quotaControlSuite) TestMemoryCGroupMissingFile(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	memoryCGroupFile := servicestate.CGroupsFilePath
-	defer func() {
-		servicestate.SetCGroupsFilePath(memoryCGroupFile)
-	}()
-
-	// reset memory cgroup status with the non-existing file
-	cgroupsPath := dirs.GlobalRootDir + "/missing_file"
-	servicestate.SetCGroupsFilePath(cgroupsPath)
-
-	// check if all operations fail with the expected error message
-	errExpected := fmt.Sprintf(`cannot open cgroups file: open %v: no such file or directory`, cgroupsPath)
-	_, err := servicestate.AllQuotas(s.state)
-	c.Assert(err, NotNil)
-	c.Assert(err, ErrorMatches, errExpected)
-
-	_, err = servicestate.GetQuota(s.state, "foo")
-	c.Assert(err, NotNil)
-	c.Assert(err, ErrorMatches, errExpected)
-
-	_, err = servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap"}, quota.NewResources(2*quantity.SizeGiB))
-	c.Assert(err, NotNil)
-	c.Assert(err, ErrorMatches, errExpected)
-
-	_, err = servicestate.RemoveQuota(s.state, "foo")
-	c.Assert(err, NotNil)
-	c.Assert(err, ErrorMatches, errExpected)
-
-	_, err = servicestate.UpdateQuota(s.state, "foo", servicestate.QuotaGroupUpdate{NewResourceLimits: quota.NewResources(2 * quantity.SizeGiB)})
-	c.Assert(err, NotNil)
-	c.Assert(err, ErrorMatches, errExpected)
-}
-
-func (s *quotaControlSuite) TestMemoryCGroupMalformed(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	memoryCGroupFile := servicestate.CGroupsFilePath
-	defer func() {
-		servicestate.SetCGroupsFilePath(memoryCGroupFile)
-	}()
-
-	cgroupsPath := dirs.GlobalRootDir + "/proc/cgroups"
-	cgroupsFile, err := os.Create(cgroupsPath)
-	c.Assert(err, IsNil)
-	defer cgroupsFile.Close()
-	// each configuration has 3 fields instead of 4
-	_, err = cgroupsFile.WriteString(`#subsys_name	hierarchy	num_cgroups	enabled	extra_field
-cpuset	6	3
-cpu	3	133
-memory	2	223
-devices	10	135`)
-	c.Assert(err, IsNil)
-	cgroupsFile.Sync()
-
-	// reset memory cgroup status with the disabled file
-	servicestate.SetCGroupsFilePath(cgroupsPath)
-
-	// check if all operations fail with the expected error message
-	errExpected := `cannot parse memory control group configuration`
-	_, err = servicestate.AllQuotas(s.state)
-	c.Assert(err, NotNil)
-	c.Assert(err, ErrorMatches, errExpected)
-
-	_, err = servicestate.GetQuota(s.state, "foo")
-	c.Assert(err, NotNil)
-	c.Assert(err, ErrorMatches, errExpected)
-
-	_, err = servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap"}, quota.NewResources(2*quantity.SizeGiB))
-	c.Assert(err, NotNil)
-	c.Assert(err, ErrorMatches, errExpected)
-
-	_, err = servicestate.RemoveQuota(s.state, "foo")
-	c.Assert(err, NotNil)
-	c.Assert(err, ErrorMatches, errExpected)
-
-	_, err = servicestate.UpdateQuota(s.state, "foo", servicestate.QuotaGroupUpdate{NewResourceLimits: quota.NewResources(2 * quantity.SizeGiB)})
-	c.Assert(err, NotNil)
-	c.Assert(err, ErrorMatches, errExpected)
-}
-
-func (s *quotaControlSuite) TestMemoryCGroupMissingMemory(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	memoryCGroupFile := servicestate.CGroupsFilePath
-	defer func() {
-		servicestate.SetCGroupsFilePath(memoryCGroupFile)
-	}()
-
-	cgroupsPath := dirs.GlobalRootDir + "/proc/cgroups"
-	cgroupsFile, err := os.Create(cgroupsPath)
-	c.Assert(err, IsNil)
-	defer cgroupsFile.Close()
-	// memory is enabled & file size is reduced as we only check for memory at this point
-	_, err = cgroupsFile.WriteString(`#subsys_name	hierarchy	num_cgroups	enabled
-cpuset	6	3	1
-cpu	3	133	1
-devices	10	135	1`)
-	c.Assert(err, IsNil)
-	cgroupsFile.Sync()
-	// reset memory cgroup status with the enabled file
-	servicestate.SetCGroupsFilePath(cgroupsPath)
-
-	// check if all operations fail with the expected error message
-	errExpected := `cannot retrieve memory cgroup configuration, it is not available in the kernel config`
-	_, err = servicestate.AllQuotas(s.state)
-	c.Assert(err, NotNil)
-	c.Assert(err, ErrorMatches, errExpected)
-
-	_, err = servicestate.GetQuota(s.state, "foo")
-	c.Assert(err, NotNil)
-	c.Assert(err, ErrorMatches, errExpected)
-
-	_, err = servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap"}, quota.NewResources(2*quantity.SizeGiB))
-	c.Assert(err, NotNil)
-	c.Assert(err, ErrorMatches, errExpected)
-
-	_, err = servicestate.RemoveQuota(s.state, "foo")
-	c.Assert(err, NotNil)
-	c.Assert(err, ErrorMatches, errExpected)
-
-	_, err = servicestate.UpdateQuota(s.state, "foo", servicestate.QuotaGroupUpdate{NewResourceLimits: quota.NewResources(2 * quantity.SizeGiB)})
-	c.Assert(err, NotNil)
-	c.Assert(err, ErrorMatches, errExpected)
 }
 
 func (s *quotaControlSuite) TestUpdateQuotaModifyExistingMixable(c *C) {

--- a/overlord/servicestate/quotas.go
+++ b/overlord/servicestate/quotas.go
@@ -32,18 +32,11 @@ var ErrQuotaNotFound = errors.New("quota not found")
 // AllQuotas returns all currently tracked quota groups in the state. They are
 // validated for consistency using ResolveCrossReferences before being returned.
 func AllQuotas(st *state.State) (map[string]*quota.Group, error) {
-	if memoryCGroupError != nil {
-		return nil, memoryCGroupError
-	}
 	return internal.AllQuotas(st)
 }
 
 // GetQuota returns an individual quota group by name.
 func GetQuota(st *state.State, name string) (*quota.Group, error) {
-	if memoryCGroupError != nil {
-		return nil, memoryCGroupError
-	}
-
 	allGrps, err := internal.AllQuotas(st)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This reverts commit d5eb40d189275403b12f2f4464192196fe691463.

PR #11003 unfortunately introduced a regression on systems where the memory
cgroup was disabled because now servicestate.AllQuotas would return an error,
but we need to be able to access at least the quota group information in the
state in order to compute what options to generate services with in a few
places:

* in the ensure loop of the servicestate manager (runs all the time)
* in link-snap tasks (for snap installs/refreshes)
* in config tasks (for specifically the vitality-rank config setting)
* in discard-snap tasks (for snap removes)

So when the memory cgroup is disabled, all of the above things fail, including
catastrophically not being able to update the snapd snap (since snap refreshes
are now also broken), meaning that a user's device could not be fixed unless
they first re-enable the memory cgroup.

This will be un-reverted when we have added sufficient tests to demonstrate
that this memory cgroup check can be done in such a way without breaking this
functionality.