### PR TITLE
tests: add regression tests for disabled memory cgroup operation

### DIFF
--- a/overlord/configstate/configcore/vitality_test.go
+++ b/overlord/configstate/configcore/vitality_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/configstate/configcore"
+	"github.com/snapcore/snapd/overlord/servicestate"
 	"github.com/snapcore/snapd/overlord/servicestate/servicestatetest"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
@@ -162,6 +163,9 @@ func (s *vitalitySuite) testConfigureVitalityWithValidSnap(c *C, uc18 bool) {
 
 func (s *vitalitySuite) TestConfigureVitalityWithQuotaGroup(c *C) {
 	r := systemd.MockSystemdVersion(248, nil)
+	defer r()
+
+	r = servicestate.EnsureQuotaUsability()
 	defer r()
 
 	si := &snap.SideInfo{RealName: "test-snap", Revision: snap.R(1)}

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -724,6 +724,9 @@ func (s *mgrsSuite) TestHappyRemoveWithQuotas(c *C) {
 	r := systemd.MockSystemdVersion(248, nil)
 	defer r()
 
+	r = servicestate.EnsureQuotaUsability()
+	defer r()
+
 	st := s.o.State()
 	st.Lock()
 	defer st.Unlock()
@@ -770,6 +773,9 @@ func (s *mgrsSuite) TestHappyRefreshWithQuotasInServiceUnitMaintained(c *C) {
 	// had in https://github.com/snapcore/snapd/pull/11339
 
 	r := systemd.MockSystemdVersion(248, nil)
+	defer r()
+
+	r = servicestate.EnsureQuotaUsability()
 	defer r()
 
 	st := s.o.State()

--- a/overlord/servicestate/quota_control.go
+++ b/overlord/servicestate/quota_control.go
@@ -41,7 +41,21 @@ func checkSystemdVersion() {
 }
 
 func init() {
+	EnsureQuotaUsability()
+}
+
+// EnsureQuotaUsability is exported for unit tests from other packages to re-run
+// the init() time checks for quota usability which set the errors which
+// quotaGroupsAvailable() checks for.
+// It saves the previous state of the usability errors to be restored via the
+// provided restore function.
+func EnsureQuotaUsability() (restore func()) {
+	oldSystemdErr := systemdVersionError
 	checkSystemdVersion()
+
+	return func() {
+		systemdVersionError = oldSystemdErr
+	}
 }
 
 func quotaGroupsAvailable(st *state.State) error {

--- a/overlord/servicestate/quota_handlers_test.go
+++ b/overlord/servicestate/quota_handlers_test.go
@@ -54,8 +54,11 @@ func (s *quotaHandlersSuite) SetUpTest(c *C) {
 	tr.Commit()
 
 	// mock that we have a new enough version of systemd by default
-	r := systemd.MockSystemdVersion(248, nil)
-	s.AddCleanup(r)
+	systemdRestore := systemd.MockSystemdVersion(248, nil)
+	s.AddCleanup(systemdRestore)
+
+	usabilityErrRestore := servicestate.EnsureQuotaUsability()
+	s.AddCleanup(usabilityErrRestore)
 }
 
 // mockMixedQuotaGroup creates a new quota group mixed with the provided snaps and

--- a/tests/core/mem-cgroup-disabled/task.yaml
+++ b/tests/core/mem-cgroup-disabled/task.yaml
@@ -1,0 +1,119 @@
+summary: Check basic functionality when memory cgroup is disabled
+
+environment:
+  SVC_UNIT: /etc/systemd/system/snap.test-snapd-simple-service.test-snapd-simple-service.service
+
+# only run on UC20+ to use the convenient cmdline.extra file
+systems: [ubuntu-core-2*]
+
+prepare: |
+  if ! os.query is-pc-amd64; then
+    echo "Skipping non-grub device test"
+    exit 0
+  fi
+
+  echo "Create copy of gadget snap with cgroup_disable=memory set in cmdline.extra"
+  PC_REV=$(snap list pc | tail -n +2 | awk '{print $3}')
+  sudo cp "/var/lib/snapd/snaps/pc_$PC_REV.snap" pc-gadget.snap
+
+  unsquashfs -d pc-gadget-no-cgroup pc-gadget.snap
+
+  # check if there is already a cmdline.extra or cmdline.full and append to it
+  # if it's there
+  if [ -f pc-gadget-no-cgroup/cmdline.full ]; then
+    # use the cmdline.full file
+    echo "" >> pc-gadget-no-cgroup/cmdline.full
+    echo "cgroup_disable=memory" >> pc-gadget-no-cgroup/cmdline.full
+  else
+    # either no file at all or cmdline.extra
+    echo "" >> pc-gadget-no-cgroup/cmdline.extra
+    echo "cgroup_disable=memory" >> pc-gadget-no-cgroup/cmdline.extra
+  fi
+
+  snap pack pc-gadget-no-cgroup --filename=pc-cgroup-disabled.snap
+
+execute: |
+  if ! os.query is-pc-amd64; then
+    echo "Skipping non-grub device test"
+    exit 0
+  fi
+
+  case "$SPREAD_REBOOT" in 
+    0)
+
+      # ensure memory cgroups is enabled to start
+      if [ "$(grep memory < /proc/cgroups | awk '{print $4}')" != "1" ]; then
+        echo "expected memory cgroup to be enabled to start"
+        exit 1
+      fi
+
+      # install a snap with a service
+      "$TESTSTOOLS"/snaps-state install-local test-snapd-simple-service
+
+      # enable quota groups
+      snap set system experimental.quota-groups=true
+
+      # put it in a quota group
+      snap set-quota grp --memory=100MB test-snapd-simple-service
+
+      # check it is in the slice
+      MATCH Slice=snap.grp.slice < "$SVC_UNIT"
+
+      # now disable the memory cgroup by adding cgroup_disable=memory to the 
+      # kernel command line
+      snap install --dangerous pc-cgroup-disabled.snap
+      REBOOT
+
+      ;;
+    1)
+      # wait for change to complete
+      snap watch --last=install\?
+
+      # ensure memory cgroups is now disabled
+      if [ "$(grep memory < /proc/cgroups | awk '{print $4}')" != "0" ]; then
+        echo "expected memory cgroup to be disabled"
+        exit 1
+      fi
+      
+      # we cannot check quota group usage
+      if snap quota grp; then
+        echo "expected quota command to fail"
+        exit 1
+      fi
+
+      # and we get the expected error message
+      snap quota grp 2>&1 | MATCH "error: memory usage unavailable"
+
+      # make sure our snap still has the Slice setting
+      MATCH Slice=snap.grp.slice < "$SVC_UNIT"
+
+      # we can refresh the snap still even though memory cgroup is disabled
+      "$TESTSTOOLS"/snaps-state install-local test-snapd-simple-service
+
+      # and still has the slice setting
+      MATCH Slice=snap.grp.slice < "$SVC_UNIT"
+
+      # TODO: should we also check the vitality-rank config too?
+
+      # finally we can still remove the snap without issue
+      snap remove test-snapd-simple-service
+      
+      # revert back to normal pc gadget without the command line
+      snap revert pc
+      REBOOT
+
+      ;;
+    2)
+      # wait for change to complete
+      snap watch --last=revert\?
+
+      # ensure memory cgroups is enabled again
+      if [ "$(grep memory < /proc/cgroups | awk '{print $4}')" != "1" ]; then
+        echo "expected memory cgroup to be enabled after revert"
+        exit 1
+      fi
+
+      # ensure quota commands don't error
+      snap quota grp | NOMATCH "error: memory usage unavailable"
+      ;;
+  esac

--- a/tests/core/mem-cgroup-disabled/task.yaml
+++ b/tests/core/mem-cgroup-disabled/task.yaml
@@ -1,10 +1,10 @@
 summary: Check basic functionality when memory cgroup is disabled
 
-environment:
-  SVC_UNIT: /etc/systemd/system/snap.test-snapd-simple-service.test-snapd-simple-service.service
-
 # only run on UC20+ to use the convenient cmdline.extra file
 systems: [ubuntu-core-2*]
+
+environment:
+  SVC_UNIT: /etc/systemd/system/snap.test-snapd-simple-service.test-snapd-simple-service.service
 
 prepare: |
   if ! os.query is-pc-amd64; then


### PR DESCRIPTION
Add a managers level unit test which should be duplicated when we add back the memory cgroup enable check to also run when the memory cgroup is disabled.
Also add a spread test which runs with the memory cgroup disabled so we have a full end-to-end test of the situation.