### PR TITLE
tests: reboot test running remodel

### DIFF
--- a/tests/core/remodel-base/task.yaml
+++ b/tests/core/remodel-base/task.yaml
@@ -14,7 +14,6 @@ prepare: |
     . "$TESTSLIB"/systemd.sh
 
     if [ "$SPREAD_REBOOT" = 0 ]; then
-        REBOOT_NEEDED=false
         if os.query is-core18 && snap list snapd | NOMATCH ' x1 '; then
             REBOOT_NEEDED=true
         fi
@@ -28,14 +27,7 @@ prepare: |
         # kick first boot again
         systemctl start snapd.service snapd.socket
 
-        if [ "$REBOOT_NEEDED" = true ]; then
-            echo "reboot when the system is ready"
-            for _ in $(seq 10); do
-                if "$TESTSTOOLS"/journal-state match-log "Waiting for system reboot"; then
-                     break
-                fi
-                sleep 1
-            done
+        if [ "$REBOOT_NEEDED" = true ] && "$TESTSTOOLS"/journal-state match-log -n 30 "Waiting for system reboot"; then
             REBOOT
         fi
     fi
@@ -52,7 +44,6 @@ restore: |
     . "$TESTSLIB"/systemd.sh
 
     if [ "$SPREAD_REBOOT" = 0 ]; then
-        REBOOT_NEEDED=false
         if os.query is-core18 && snap list snapd | NOMATCH ' x1 '; then
             REBOOT_NEEDED=true
         fi
@@ -67,14 +58,7 @@ restore: |
         # kick first boot again
         systemctl start snapd.service snapd.socket
 
-        if [ "$REBOOT_NEEDED" = true ]; then
-            echo "reboot when the system is ready"
-            for _ in $(seq 10); do
-                if "$TESTSTOOLS"/journal-state match-log "Waiting for system reboot"; then
-                     break
-                fi
-                sleep 1
-            done
+        if [ "$REBOOT_NEEDED" = true ] && "$TESTSTOOLS"/journal-state match-log -n 30 "Waiting for system reboot"; then
             REBOOT
         fi
     fi

--- a/tests/core/remodel-base/task.yaml
+++ b/tests/core/remodel-base/task.yaml
@@ -14,6 +14,7 @@ prepare: |
     . "$TESTSLIB"/systemd.sh
 
     if [ "$SPREAD_REBOOT" = 0 ]; then
+        REBOOT_NEEDED=false
         if os.query is-core18 && snap list snapd | NOMATCH ' x1 '; then
             REBOOT_NEEDED=true
         fi
@@ -44,6 +45,7 @@ restore: |
     . "$TESTSLIB"/systemd.sh
 
     if [ "$SPREAD_REBOOT" = 0 ]; then
+        REBOOT_NEEDED=false
         if os.query is-core18 && snap list snapd | NOMATCH ' x1 '; then
             REBOOT_NEEDED=true
         fi

--- a/tests/core/remodel-base/task.yaml
+++ b/tests/core/remodel-base/task.yaml
@@ -12,15 +12,33 @@ prepare: |
     . "$TESTSLIB"/core-config.sh
     #shellcheck source=tests/lib/systemd.sh
     . "$TESTSLIB"/systemd.sh
-    systemctl stop snapd.service snapd.socket
 
-    clean_snapd_lib
-    prepare_core_model
-    prepare_test_account valid-for-testing
-    prepare_test_model valid-for-testing-pc
+    if [ "$SPREAD_REBOOT" = 0 ]; then
+        REBOOT_NEEDED=false
+        if os.query is-core18 && snap list snapd | NOMATCH ' x1 '; then
+            REBOOT_NEEDED=true
+        fi
+        systemctl stop snapd.service snapd.socket
 
-    # kick first boot again
-    systemctl start snapd.service snapd.socket
+        clean_snapd_lib
+        prepare_core_model
+        prepare_test_account valid-for-testing
+        prepare_test_model valid-for-testing-pc
+
+        # kick first boot again
+        systemctl start snapd.service snapd.socket
+
+        if [ "$REBOOT_NEEDED" = true ]; then
+            echo "reboot when the system is ready"
+            for _ in $(seq 10); do
+                if "$TESTSTOOLS"/journal-state match-log "Waiting for system reboot"; then
+                     break
+                fi
+                sleep 1
+            done
+            REBOOT
+        fi
+    fi
 
     # wait for first boot to be done
     wait_for_first_boot_change
@@ -34,6 +52,11 @@ restore: |
     . "$TESTSLIB"/systemd.sh
 
     if [ "$SPREAD_REBOOT" = 0 ]; then
+        REBOOT_NEEDED=false
+        if os.query is-core18 && snap list snapd | NOMATCH ' x1 '; then
+            REBOOT_NEEDED=true
+        fi
+
         systemctl stop snapd.service snapd.socket
 
         clean_snapd_lib
@@ -44,14 +67,16 @@ restore: |
         # kick first boot again
         systemctl start snapd.service snapd.socket
 
-        echo "reboot when the system is ready"
-        for _ in $(seq 30); do
-            if "$TESTSTOOLS"/journal-state match-log "Waiting for system reboot"; then
-                 break
-            fi
-            sleep 1
-        done
-        REBOOT
+        if [ "$REBOOT_NEEDED" = true ]; then
+            echo "reboot when the system is ready"
+            for _ in $(seq 10); do
+                if "$TESTSTOOLS"/journal-state match-log "Waiting for system reboot"; then
+                     break
+                fi
+                sleep 1
+            done
+            REBOOT
+        fi
     fi
 
     # wait for first boot to be done

--- a/tests/core/remodel-gadget/task.yaml
+++ b/tests/core/remodel-gadget/task.yaml
@@ -14,6 +14,7 @@ prepare: |
     . "$TESTSLIB"/systemd.sh
 
     if [ "$SPREAD_REBOOT" = 0 ]; then
+        REBOOT_NEEDED=false
         if os.query is-core18 && snap list snapd | NOMATCH ' x1 '; then
             REBOOT_NEEDED=true
         fi
@@ -45,6 +46,7 @@ restore: |
     . "$TESTSLIB"/systemd.sh
 
     if [ "$SPREAD_REBOOT" = 0 ]; then
+        REBOOT_NEEDED=false
         if os.query is-core18 && snap list snapd | NOMATCH ' x1 '; then
             REBOOT_NEEDED=true
         fi

--- a/tests/core/remodel-gadget/task.yaml
+++ b/tests/core/remodel-gadget/task.yaml
@@ -14,7 +14,6 @@ prepare: |
     . "$TESTSLIB"/systemd.sh
 
     if [ "$SPREAD_REBOOT" = 0 ]; then
-        REBOOT_NEEDED=false
         if os.query is-core18 && snap list snapd | NOMATCH ' x1 '; then
             REBOOT_NEEDED=true
         fi
@@ -29,14 +28,7 @@ prepare: |
         # kick first boot again
         systemctl start snapd.service snapd.socket
 
-        if [ "$REBOOT_NEEDED" = true ]; then
-            echo "reboot when the system is ready"
-            for _ in $(seq 10); do
-                if "$TESTSTOOLS"/journal-state match-log "Waiting for system reboot"; then
-                     break
-                fi
-                sleep 1
-            done
+        if [ "$REBOOT_NEEDED" = true ] && "$TESTSTOOLS"/journal-state match-log -n 30 "Waiting for system reboot"; then
             REBOOT
         fi
     fi
@@ -53,7 +45,6 @@ restore: |
     . "$TESTSLIB"/systemd.sh
 
     if [ "$SPREAD_REBOOT" = 0 ]; then
-        REBOOT_NEEDED=false
         if os.query is-core18 && snap list snapd | NOMATCH ' x1 '; then
             REBOOT_NEEDED=true
         fi
@@ -68,14 +59,7 @@ restore: |
         # kick first boot again
         systemctl start snapd.service snapd.socket
 
-        if [ "$REBOOT_NEEDED" = true ]; then
-            echo "reboot when the system is ready"
-            for _ in $(seq 10); do
-                if "$TESTSTOOLS"/journal-state match-log "Waiting for system reboot"; then
-                     break
-                fi
-                sleep 1
-            done
+        if [ "$REBOOT_NEEDED" = true ] && "$TESTSTOOLS"/journal-state match-log -n 30 "Waiting for system reboot"; then
             REBOOT
         fi
     fi

--- a/tests/core/remodel-gadget/task.yaml
+++ b/tests/core/remodel-gadget/task.yaml
@@ -12,15 +12,34 @@ prepare: |
     . "$TESTSLIB"/core-config.sh
     #shellcheck source=tests/lib/systemd.sh
     . "$TESTSLIB"/systemd.sh
-    systemctl stop snapd.service snapd.socket
 
-    clean_snapd_lib
-    prepare_core_model
-    prepare_test_account valid-for-testing
-    prepare_test_model valid-for-testing-pc
+    if [ "$SPREAD_REBOOT" = 0 ]; then
+        REBOOT_NEEDED=false
+        if os.query is-core18 && snap list snapd | NOMATCH ' x1 '; then
+            REBOOT_NEEDED=true
+        fi
 
-    # kick first boot again
-    systemctl start snapd.service snapd.socket
+        systemctl stop snapd.service snapd.socket
+
+        clean_snapd_lib
+        prepare_core_model
+        prepare_test_account valid-for-testing
+        prepare_test_model valid-for-testing-pc
+
+        # kick first boot again
+        systemctl start snapd.service snapd.socket
+
+        if [ "$REBOOT_NEEDED" = true ]; then
+            echo "reboot when the system is ready"
+            for _ in $(seq 10); do
+                if "$TESTSTOOLS"/journal-state match-log "Waiting for system reboot"; then
+                     break
+                fi
+                sleep 1
+            done
+            REBOOT
+        fi
+    fi
 
     # wait for first boot to be done
     wait_for_first_boot_change
@@ -33,15 +52,33 @@ restore: |
     #shellcheck source=tests/lib/systemd.sh
     . "$TESTSLIB"/systemd.sh
 
-    systemctl stop snapd.service snapd.socket
+    if [ "$SPREAD_REBOOT" = 0 ]; then
+        REBOOT_NEEDED=false
+        if os.query is-core18 && snap list snapd | NOMATCH ' x1 '; then
+            REBOOT_NEEDED=true
+        fi
 
-    clean_snapd_lib
-    restore_test_account valid-for-testing
-    restore_test_model valid-for-testing-pc
-    restore_core_model
+        systemctl stop snapd.service snapd.socket
 
-    # kick first boot again
-    systemctl start snapd.service snapd.socket
+        clean_snapd_lib
+        restore_test_account valid-for-testing
+        restore_test_model valid-for-testing-pc
+        restore_core_model
+
+        # kick first boot again
+        systemctl start snapd.service snapd.socket
+
+        if [ "$REBOOT_NEEDED" = true ]; then
+            echo "reboot when the system is ready"
+            for _ in $(seq 10); do
+                if "$TESTSTOOLS"/journal-state match-log "Waiting for system reboot"; then
+                     break
+                fi
+                sleep 1
+            done
+            REBOOT
+        fi
+    fi
 
     # wait for first boot to be done
     snap wait system seed.loaded
@@ -62,6 +99,7 @@ restore: |
         find /var/snap
         exit 1
     fi
+
 execute: |
     #shellcheck source=tests/lib/core-config.sh
     . "$TESTSLIB"/core-config.sh

--- a/tests/core/remodel/task.yaml
+++ b/tests/core/remodel/task.yaml
@@ -2,7 +2,7 @@ summary: |
     Test remodel
 
 # TODO:UC20: enable for UC20
-systems: [ubuntu-core-1*-64]
+systems: [ubuntu-core-16-64, ubuntu-core-18-64]
 
 prepare: |
     #shellcheck source=tests/lib/core-config.sh
@@ -10,16 +10,34 @@ prepare: |
     #shellcheck source=tests/lib/systemd.sh
     . "$TESTSLIB"/systemd.sh
 
-    systemctl stop snapd.service snapd.socket
-    clean_snapd_lib
+    if [ "$SPREAD_REBOOT" = 0 ]; then
+        REBOOT_NEEDED=false
+        if os.query is-core18 && snap list snapd | NOMATCH ' x1 '; then
+            REBOOT_NEEDED=true
+        fi
 
-    # Generic setup for test account
-    prepare_core_model
-    prepare_test_account valid-for-testing
-    prepare_test_model valid-for-testing-pc
+        systemctl stop snapd.service snapd.socket
+        clean_snapd_lib
 
-    # kick first boot again
-    systemctl start snapd.service snapd.socket
+        # Generic setup for test account
+        prepare_core_model
+        prepare_test_account valid-for-testing
+        prepare_test_model valid-for-testing-pc
+
+        # kick first boot again
+        systemctl start snapd.service snapd.socket
+
+        if [ "$REBOOT_NEEDED" = true ]; then
+            echo "reboot when the system is ready"
+            for _ in $(seq 10); do
+                if "$TESTSTOOLS"/journal-state match-log "Waiting for system reboot"; then
+                     break
+                fi
+                sleep 1
+            done
+            REBOOT
+        fi
+    fi
 
     # wait for first boot to be done
     wait_for_first_boot_change
@@ -32,18 +50,37 @@ restore: |
     #shellcheck source=tests/lib/systemd.sh
     . "$TESTSLIB"/systemd.sh
 
-    systemctl stop snapd.service snapd.socket
-    clean_snapd_lib
+    if [ "$SPREAD_REBOOT" = 0 ]; then
+        REBOOT_NEEDED=true
+        REBOOT_NEEDED=false
+        if os.query is-core18 && snap list snapd | NOMATCH ' x1 '; then
+            REBOOT_NEEDED=true
+        fi
 
-    # Generic restore for test account
-    restore_test_account valid-for-testing
-    restore_test_model valid-for-testing-pc
-    restore_core_model
+        systemctl stop snapd.service snapd.socket
+        clean_snapd_lib
 
-    rm -f /var/lib/snapd/seed/assertions/test-snapd-with-configure_*.assert
+        # Generic restore for test account
+        restore_test_account valid-for-testing
+        restore_test_model valid-for-testing-pc
+        restore_core_model
 
-    # kick first boot again
-    systemctl start snapd.service snapd.socket
+        rm -f /var/lib/snapd/seed/assertions/test-snapd-with-configure_*.assert
+
+        # kick first boot again
+        systemctl start snapd.service snapd.socket
+        if [ "$REBOOT_NEEDED" = true ]; then
+            echo "reboot when the system is ready"
+            for _ in $(seq 10); do
+                if "$TESTSTOOLS"/journal-state match-log "Waiting for system reboot"; then
+                     break
+                fi
+                sleep 1
+            done
+            REBOOT
+        fi
+
+    fi
 
     # wait for first boot to be done
     wait_for_first_boot_change

--- a/tests/core/remodel/task.yaml
+++ b/tests/core/remodel/task.yaml
@@ -11,7 +11,6 @@ prepare: |
     . "$TESTSLIB"/systemd.sh
 
     if [ "$SPREAD_REBOOT" = 0 ]; then
-        REBOOT_NEEDED=false
         if os.query is-core18 && snap list snapd | NOMATCH ' x1 '; then
             REBOOT_NEEDED=true
         fi
@@ -27,14 +26,7 @@ prepare: |
         # kick first boot again
         systemctl start snapd.service snapd.socket
 
-        if [ "$REBOOT_NEEDED" = true ]; then
-            echo "reboot when the system is ready"
-            for _ in $(seq 10); do
-                if "$TESTSTOOLS"/journal-state match-log "Waiting for system reboot"; then
-                     break
-                fi
-                sleep 1
-            done
+        if [ "$REBOOT_NEEDED" = true ] && "$TESTSTOOLS"/journal-state match-log -n 30 "Waiting for system reboot"; then
             REBOOT
         fi
     fi
@@ -51,8 +43,6 @@ restore: |
     . "$TESTSLIB"/systemd.sh
 
     if [ "$SPREAD_REBOOT" = 0 ]; then
-        REBOOT_NEEDED=true
-        REBOOT_NEEDED=false
         if os.query is-core18 && snap list snapd | NOMATCH ' x1 '; then
             REBOOT_NEEDED=true
         fi
@@ -69,17 +59,10 @@ restore: |
 
         # kick first boot again
         systemctl start snapd.service snapd.socket
-        if [ "$REBOOT_NEEDED" = true ]; then
-            echo "reboot when the system is ready"
-            for _ in $(seq 10); do
-                if "$TESTSTOOLS"/journal-state match-log "Waiting for system reboot"; then
-                     break
-                fi
-                sleep 1
-            done
+
+        if [ "$REBOOT_NEEDED" = true ] && "$TESTSTOOLS"/journal-state match-log -n 30 "Waiting for system reboot"; then
             REBOOT
         fi
-
     fi
 
     # wait for first boot to be done

--- a/tests/core/remodel/task.yaml
+++ b/tests/core/remodel/task.yaml
@@ -11,6 +11,7 @@ prepare: |
     . "$TESTSLIB"/systemd.sh
 
     if [ "$SPREAD_REBOOT" = 0 ]; then
+        REBOOT_NEEDED=false
         if os.query is-core18 && snap list snapd | NOMATCH ' x1 '; then
             REBOOT_NEEDED=true
         fi
@@ -43,6 +44,7 @@ restore: |
     . "$TESTSLIB"/systemd.sh
 
     if [ "$SPREAD_REBOOT" = 0 ]; then
+        REBOOT_NEEDED=false
         if os.query is-core18 && snap list snapd | NOMATCH ' x1 '; then
             REBOOT_NEEDED=true
         fi


### PR DESCRIPTION
In case snapd is asserted, then we need to reboot after changing the model. 

These tests are failing when running beta validation because the tests don't detect that the sevice is going to reboot.
