### PR TITLE
cmd/snap/auto-import: use osutil.LoadMountInfo impl instead

### DIFF
--- a/cmd/snap/cmd_auto_import.go
+++ b/cmd/snap/cmd_auto_import.go
@@ -20,7 +20,6 @@
 package main
 
 import (
-	"bufio"
 	"crypto"
 	"encoding/base64"
 	"fmt"
@@ -51,49 +50,23 @@ var mountInfoPath = "/proc/self/mountinfo"
 func autoImportCandidates() ([]string, error) {
 	var cands []string
 
-	// see https://www.kernel.org/doc/Documentation/filesystems/proc.txt,
-	// sec. 3.5
-	f, err := os.Open(mountInfoPath)
-	if err != nil {
-		return nil, err
-	}
-	defer f.Close()
-
 	isTesting := snapdenv.Testing()
 
-	// TODO: re-write this to use osutil.LoadMountInfo instead of doing the
-	//       parsing ourselves
-
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		l := strings.Fields(scanner.Text())
-
-		// Per proc.txt:3.5, /proc/<pid>/mountinfo looks like
-		//
-		//  36 35 98:0 /mnt1 /mnt2 rw,noatime master:1 - ext3 /dev/root rw,errors=continue
-		//  (1)(2)(3)   (4)   (5)      (6)      (7)   (8) (9)   (10)         (11)
-		//
-		// and (7) has zero or more elements, find the "-" separator.
-		i := 6
-		for i < len(l) && l[i] != "-" {
-			i++
-		}
-		if i+2 >= len(l) {
-			continue
-		}
-
-		mountSrc := l[i+2]
-
+	mnts, err := osutil.LoadMountInfo()
+	if err != nil {
+		return nil, fmt.Errorf("couldn't parse mountinfo: %v", err)
+	}
+	for _, mnt := range mnts {
 		// skip everything that is not a device (cgroups, debugfs etc)
-		if !strings.HasPrefix(mountSrc, "/dev/") {
+		if !strings.HasPrefix(mnt.MountSource, "/dev/") {
 			continue
 		}
 		// skip all loop devices (snaps)
-		if strings.HasPrefix(mountSrc, "/dev/loop") {
+		if strings.HasPrefix(mnt.MountSource, "/dev/loop") {
 			continue
 		}
 		// skip all ram disks (unless in tests)
-		if !isTesting && strings.HasPrefix(mountSrc, "/dev/ram") {
+		if !isTesting && strings.HasPrefix(mnt.MountSource, "/dev/ram") {
 			continue
 		}
 
@@ -102,7 +75,7 @@ func autoImportCandidates() ([]string, error) {
 		//       and determine what partitions to skip using the disks package?
 
 		// skip all initramfs mounted disks on uc20
-		mountPoint := l[4]
+		mountPoint := mnt.MountDir
 		if strings.HasPrefix(mountPoint, boot.InitramfsRunMntDir) {
 			continue
 		}
@@ -111,7 +84,14 @@ func autoImportCandidates() ([]string, error) {
 		// initramfs dirs on uc20, this can show up as
 		// /writable/system-data/var/lib/snapd/seed as well as
 		// /var/lib/snapd/seed
-		if strings.HasSuffix(mountPoint, dirs.SnapSeedDir) {
+		if strings.HasPrefix(mountPoint, dirs.SnapSeedDir) {
+			continue
+		}
+
+		// TODO: we should probably make this a formal dir in dirs.go, but it is
+		// not directly used since we just use SnapSeedDir instead
+		writableSystemDataDir := filepath.Join(dirs.GlobalRootDir, "writable", "system-data")
+		if strings.HasPrefix(mountPoint, dirs.SnapSeedDirUnder(writableSystemDataDir)) {
 			continue
 		}
 
@@ -121,7 +101,7 @@ func autoImportCandidates() ([]string, error) {
 		}
 	}
 
-	return cands, scanner.Err()
+	return cands, nil
 }
 
 func queueFile(src string) error {

--- a/cmd/snap/cmd_auto_import_test.go
+++ b/cmd/snap/cmd_auto_import_test.go
@@ -37,13 +37,6 @@ import (
 	"github.com/snapcore/snapd/testutil"
 )
 
-func makeMockMountInfo(c *C, content string) string {
-	fn := filepath.Join(c.MkDir(), "mountinfo")
-	err := ioutil.WriteFile(fn, []byte(content), 0644)
-	c.Assert(err, IsNil)
-	return fn
-}
-
 func (s *SnapSuite) TestAutoImportAssertsHappy(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
@@ -77,14 +70,14 @@ func (s *SnapSuite) TestAutoImportAssertsHappy(c *C) {
 
 	})
 
-	fakeAssertsFn := filepath.Join(c.MkDir(), "auto-import.assert")
+	testDir := c.MkDir()
+	fakeAssertsFn := filepath.Join(testDir, "auto-import.assert")
 	err := ioutil.WriteFile(fakeAssertsFn, fakeAssertData, 0644)
 	c.Assert(err, IsNil)
 
-	mockMountInfoFmt := `
-24 0 8:18 / %s rw,relatime shared:1 - ext4 /dev/sdb2 rw,errors=remount-ro,data=ordered`
-	content := fmt.Sprintf(mockMountInfoFmt, filepath.Dir(fakeAssertsFn))
-	restore = snap.MockMountInfoPath(makeMockMountInfo(c, content))
+	mockMountInfoFmt := fmt.Sprintf(`24 0 8:18 / %s rw,relatime shared:1 - ext4 /dev/sdb2 rw,errors=remount-ro,data=ordered
+`, testDir)
+	restore = osutil.MockMountInfo(mockMountInfoFmt)
 	defer restore()
 
 	logbuf, restore := logger.MockLogger()
@@ -112,14 +105,14 @@ func (s *SnapSuite) TestAutoImportAssertsNotImportedFromLoop(c *C) {
 		panic("not reached")
 	})
 
-	fakeAssertsFn := filepath.Join(c.MkDir(), "auto-import.assert")
+	testDir := c.MkDir()
+	fakeAssertsFn := filepath.Join(testDir, "auto-import.assert")
 	err := ioutil.WriteFile(fakeAssertsFn, fakeAssertData, 0644)
 	c.Assert(err, IsNil)
 
-	mockMountInfoFmtWithLoop := `
-24 0 8:18 / %s rw,relatime shared:1 - squashfs /dev/loop1 rw,errors=remount-ro,data=ordered`
+	mockMountInfoFmtWithLoop := `24 0 8:18 / %s rw,relatime shared:1 - squashfs /dev/loop1 rw,errors=remount-ro,data=ordered`
 	content := fmt.Sprintf(mockMountInfoFmtWithLoop, filepath.Dir(fakeAssertsFn))
-	restore = snap.MockMountInfoPath(makeMockMountInfo(c, content))
+	restore = osutil.MockMountInfo(content)
 	defer restore()
 
 	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"auto-import"})
@@ -127,35 +120,6 @@ func (s *SnapSuite) TestAutoImportAssertsNotImportedFromLoop(c *C) {
 	c.Assert(rest, DeepEquals, []string{})
 	c.Check(s.Stdout(), Equals, "")
 	c.Check(s.Stderr(), Equals, "")
-}
-
-func (s *SnapSuite) TestAutoImportCandidatesHappy(c *C) {
-	dirs := make([]string, 4)
-	args := make([]interface{}, len(dirs))
-	files := make([]string, len(dirs))
-	for i := range dirs {
-		dirs[i] = c.MkDir()
-		args[i] = dirs[i]
-		files[i] = filepath.Join(dirs[i], "auto-import.assert")
-		err := ioutil.WriteFile(files[i], nil, 0644)
-		c.Assert(err, IsNil)
-	}
-
-	mockMountInfoFmtWithLoop := `
-too short
-24 0 8:18 / %[1]s rw,relatime foo ext3 /dev/meep2 no,separator
-24 0 8:18 / %[2]s rw,relatime - ext3 /dev/meep2 rw,errors=remount-ro,data=ordered
-24 0 8:18 / %[3]s rw,relatime opt:1 - ext4 /dev/meep3 rw,errors=remount-ro,data=ordered
-24 0 8:18 / %[4]s rw,relatime opt:1 opt:2 - ext2 /dev/meep1 rw,errors=remount-ro,data=ordered
-`
-
-	content := fmt.Sprintf(mockMountInfoFmtWithLoop, args...)
-	restore := snap.MockMountInfoPath(makeMockMountInfo(c, content))
-	defer restore()
-
-	l, err := snap.AutoImportCandidates()
-	c.Check(err, IsNil)
-	c.Check(l, DeepEquals, files[1:])
 }
 
 func (s *SnapSuite) TestAutoImportAssertsHappyNotOnClassic(c *C) {
@@ -173,8 +137,7 @@ func (s *SnapSuite) TestAutoImportAssertsHappyNotOnClassic(c *C) {
 
 	mockMountInfoFmt := `
 24 0 8:18 / %s rw,relatime shared:1 - ext4 /dev/sdb2 rw,errors=remount-ro,data=ordered`
-	content := fmt.Sprintf(mockMountInfoFmt, filepath.Dir(fakeAssertsFn))
-	restore = snap.MockMountInfoPath(makeMockMountInfo(c, content))
+	restore = osutil.MockMountInfo(mockMountInfoFmt)
 	defer restore()
 
 	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"auto-import"})
@@ -200,10 +163,8 @@ func (s *SnapSuite) TestAutoImportIntoSpool(c *C) {
 	err := ioutil.WriteFile(fakeAssertsFn, fakeAssertData, 0644)
 	c.Assert(err, IsNil)
 
-	mockMountInfoFmt := `
-24 0 8:18 / %s rw,relatime shared:1 - squashfs /dev/sc1 rw,errors=remount-ro,data=ordered`
-	content := fmt.Sprintf(mockMountInfoFmt, filepath.Dir(fakeAssertsFn))
-	restore = snap.MockMountInfoPath(makeMockMountInfo(c, content))
+	mockMountInfoFmt := fmt.Sprintf(`24 0 8:18 / %s rw,relatime shared:1 - squashfs /dev/sc1 rw,errors=remount-ro,data=ordered`, filepath.Dir(fakeAssertsFn))
+	restore = osutil.MockMountInfo(mockMountInfoFmt)
 	defer restore()
 
 	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"auto-import"})
@@ -223,6 +184,9 @@ func (s *SnapSuite) TestAutoImportIntoSpool(c *C) {
 
 func (s *SnapSuite) TestAutoImportFromSpoolHappy(c *C) {
 	restore := release.MockOnClassic(false)
+	defer restore()
+
+	restore = osutil.MockMountInfo(``)
 	defer restore()
 
 	fakeAssertData := []byte("my-assertion")
@@ -293,10 +257,8 @@ func (s *SnapSuite) TestAutoImportIntoSpoolUnhappyTooBig(c *C) {
 	err := ioutil.WriteFile(fakeAssertsFn, fakeAssertData, 0644)
 	c.Assert(err, IsNil)
 
-	mockMountInfoFmt := `
-24 0 8:18 / %s rw,relatime shared:1 - squashfs /dev/sc1 rw,errors=remount-ro,data=ordered`
-	content := fmt.Sprintf(mockMountInfoFmt, filepath.Dir(fakeAssertsFn))
-	restore = snap.MockMountInfoPath(makeMockMountInfo(c, content))
+	mockMountInfoFmt := fmt.Sprintf(`24 0 8:18 / %s rw,relatime shared:1 - squashfs /dev/sc1 rw,errors=remount-ro,data=ordered`, filepath.Dir(fakeAssertsFn))
+	restore = osutil.MockMountInfo(mockMountInfoFmt)
 	defer restore()
 
 	_, err = snap.Parser(snap.Client()).ParseArgs([]string{"auto-import"})
@@ -327,6 +289,9 @@ var mountStatic = []string{"mount", "-t", "ext4,vfat", "-o", "ro", "--make-priva
 
 func (s *SnapSuite) TestAutoImportFromRemovable(c *C) {
 	restore := release.MockOnClassic(false)
+	defer restore()
+
+	restore = osutil.MockMountInfo(``)
 	defer restore()
 
 	_, restoreLogger := logger.MockLogger()
@@ -400,6 +365,9 @@ func (s *SnapSuite) TestAutoImportNoRemovable(c *C) {
 	})
 	defer restore()
 
+	restore = osutil.MockMountInfo(``)
+	defer restore()
+
 	mountCmd := testutil.MockCommand(c, "mount", "exit 1")
 	defer mountCmd.Restore()
 
@@ -421,6 +389,9 @@ func (s *SnapSuite) TestAutoImportNoRemovable(c *C) {
 
 func (s *SnapSuite) TestAutoImportFromMount(c *C) {
 	restore := release.MockOnClassic(false)
+	defer restore()
+
+	restore = osutil.MockMountInfo(``)
 	defer restore()
 
 	_, restoreLogger := logger.MockLogger()
@@ -488,17 +459,15 @@ func (s *SnapSuite) TestAutoImportUC20CandidatesIgnoresSystemPartitions(c *C) {
 		c.Assert(ioutil.WriteFile(file, nil, 0644), IsNil)
 	}
 
-	mockMountInfoFmtWithLoop := `
-24 0 8:18 / %[1]s%[2]s rw,relatime foo ext3 /dev/meep2 no,separator
+	mockMountInfoFmtWithLoop := `24 0 8:18 / %[1]s%[2]s rw,relatime foo - ext3 /dev/meep2 rw,errors=remount-ro,data=ordered
 24 0 8:18 / %[1]s%[3]s rw,relatime - ext3 /dev/meep2 rw,errors=remount-ro,data=ordered
 24 0 8:18 / %[1]s%[4]s rw,relatime opt:1 - ext4 /dev/meep3 rw,errors=remount-ro,data=ordered
 24 0 8:18 / %[1]s%[5]s rw,relatime opt:1 opt:2 - ext2 /dev/meep4 rw,errors=remount-ro,data=ordered
 24 0 8:18 / %[1]s%[6]s rw,relatime opt:1 opt:2 - ext2 /dev/meep5 rw,errors=remount-ro,data=ordered
-24 0 8:18 / %[1]s%[7]s rw,relatime opt:1 opt:2 - ext2 /dev/meep78 rw,errors=remount-ro,data=ordered
-`
+24 0 8:18 / %[1]s%[7]s rw,relatime opt:1 opt:2 - ext2 /dev/meep78 rw,errors=remount-ro,data=ordered`
 
 	content := fmt.Sprintf(mockMountInfoFmtWithLoop, args...)
-	restore := snap.MockMountInfoPath(makeMockMountInfo(c, content))
+	restore := osutil.MockMountInfo(content)
 	defer restore()
 
 	l, err := snap.AutoImportCandidates()
@@ -541,17 +510,15 @@ func (s *SnapSuite) TestAutoImportAssertsManagedEmptyReply(c *C) {
 		default:
 			c.Fatalf("unexpected request: %v (expected %d got %d)", r, total, n)
 		}
-
 	})
 
 	fakeAssertsFn := filepath.Join(c.MkDir(), "auto-import.assert")
 	err := ioutil.WriteFile(fakeAssertsFn, fakeAssertData, 0644)
 	c.Assert(err, IsNil)
 
-	mockMountInfoFmt := `
-24 0 8:18 / %s rw,relatime shared:1 - ext4 /dev/sdb2 rw,errors=remount-ro,data=ordered`
+	mockMountInfoFmt := `24 0 8:18 / %s rw,relatime shared:1 - ext4 /dev/sdb2 rw,errors=remount-ro,data=ordered`
 	content := fmt.Sprintf(mockMountInfoFmt, filepath.Dir(fakeAssertsFn))
-	restore = snap.MockMountInfoPath(makeMockMountInfo(c, content))
+	restore = osutil.MockMountInfo(content)
 	defer restore()
 
 	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"auto-import"})

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -194,14 +194,6 @@ func MockGetEnv(f func(name string) string) (restore func()) {
 	}
 }
 
-func MockMountInfoPath(newMountInfoPath string) (restore func()) {
-	mountInfoPathOrig := mountInfoPath
-	mountInfoPath = newMountInfoPath
-	return func() {
-		mountInfoPath = mountInfoPathOrig
-	}
-}
-
 func MockOsReadlink(f func(string) (string, error)) (restore func()) {
 	osReadlinkOrig := osReadlink
 	osReadlink = f

--- a/osutil/mountinfo.go
+++ b/osutil/mountinfo.go
@@ -19,11 +19,20 @@
 
 package osutil
 
-func MockMountInfo(content string) (restore func()) {
-	panic("MockMountInfo not implemented on darwin")
-}
-
-// LoadMountInfo is not implemented on darwin
-func LoadMountInfo() ([]*MountInfoEntry, error) {
-	return nil, ErrDarwin
+// MountInfoEntry contains data from /proc/$PID/mountinfo
+//
+// For details please refer to mountinfo documentation at
+// https://www.kernel.org/doc/Documentation/filesystems/proc.txt
+type MountInfoEntry struct {
+	MountID        int
+	ParentID       int
+	DevMajor       int
+	DevMinor       int
+	Root           string
+	MountDir       string
+	MountOptions   map[string]string
+	OptionalFields []string
+	FsType         string
+	MountSource    string
+	SuperOptions   map[string]string
 }

--- a/osutil/mountinfo_linux.go
+++ b/osutil/mountinfo_linux.go
@@ -31,24 +31,6 @@ import (
 	"strings"
 )
 
-// MountInfoEntry contains data from /proc/$PID/mountinfo
-//
-// For details please refer to mountinfo documentation at
-// https://www.kernel.org/doc/Documentation/filesystems/proc.txt
-type MountInfoEntry struct {
-	MountID        int
-	ParentID       int
-	DevMajor       int
-	DevMinor       int
-	Root           string
-	MountDir       string
-	MountOptions   map[string]string
-	OptionalFields []string
-	FsType         string
-	MountSource    string
-	SuperOptions   map[string]string
-}
-
 func flattenMap(m map[string]string) string {
 	keys := make([]string, 0, len(m))
 	for key := range m {


### PR DESCRIPTION
Eliminate the custom mount table parsing here in lieu of the existing and
arguably better tested parsing in LoadMountInfo.

Also fix a test-only bug where we were not properly skipping the UC20+ specific
mount dir of /writable/system-data/var/lib/snapd/seed. The code as written only
worked when dirs.GlobalRootDir was the empty string, if that was any other dir
like in tests, then it wouldn't match and we would consider it. However the
unit test for this specific case, TestAutoImportUC20CandidatesIgnoresSystemPartitions
had inadvertently copied the erroneous mount line which did not have a "-" to
delineate between the optional flags for the mount entry and the rest of the
mount fields which was used in another test, so it was silently skipped with
the custom implementation that was here before. Fixing this line demonstrated
the test-only issue mentioned above and so it had to be fixed to properly test
this case.