### PR TITLE
tests/main/snap-system-key: reset-failed snapd and snapd.socket

### DIFF
--- a/tests/main/snap-system-key/task.yaml
+++ b/tests/main/snap-system-key/task.yaml
@@ -29,6 +29,8 @@ execute: |
     }
     restart_snapd() {
         stop_snapd
+        # to avoid hitting "start-limit-hit"
+        systemctl reset-failed snapd.service snapd.socket
         start_snapd
     }
 
@@ -40,7 +42,7 @@ execute: |
     restart_snapd
     buf2="$(stat /var/lib/snapd/system-key)"
     if [ "$buf" != "$buf2" ]; then
-        echo "system-key got rewriten: $buf != buf2, test broken"
+        echo "system-key got rewritten: $buf != buf2, test broken"
         exit 1
     fi
 
@@ -48,7 +50,7 @@ execute: |
     printf '{"version":1}' > /var/lib/snapd/system-key
     restart_snapd
     if grep '{"version":1}' /var/lib/snapd/system-key; then
-        echo "system-key *not* rewriten test broken"
+        echo "system-key *not* rewritten test broken"
         exit 1
     fi
 
@@ -67,12 +69,12 @@ execute: |
     echo "Change system-key, with running snapd"
     printf '{"version":1}' > /var/lib/snapd/system-key
     test-snapd-sh.sh -c 'echo good'
-    
+
     echo "Things work again after a restart of snapd"
     restart_snapd
     test-snapd-sh.sh -c 'echo good-again'
     if grep '{"version":1}' /var/lib/snapd/system-key; then
-        echo "system-key *not* rewriten test broken"
+        echo "system-key *not* rewritten test broken"
         exit 1
     fi
 


### PR DESCRIPTION
We start and stop snapd a lot during this test, so if it runs fast enough, it
can hit the start limit which looks in the logs like this:
```
Feb 03 18:01:47 feb031721-896841 systemd[1]: Starting Socket activation for snappy daemon.
Feb 03 18:01:47 feb031721-896841 systemd[1]: Listening on Socket activation for snappy daemon.
Feb 03 18:01:47 feb031721-896841 systemd[1]: Starting Snap Daemon...
Feb 03 18:01:47 feb031721-896841 systemd[1]: snapd.socket: Start request repeated too quickly.
Feb 03 18:01:47 feb031721-896841 systemd[1]: snapd.socket: Failed with result 'start-limit-hit'.
Feb 03 18:01:47 feb031721-896841 systemd[1]: Failed to listen on Socket activation for snappy daemon.
Feb 03 18:01:47 feb031721-896841 systemd[1]: Dependency failed for Snap Daemon.
Feb 03 18:01:47 feb031721-896841 systemd[1]: snapd.service: Job snapd.service/start failed with result 'dependency'.
Feb 03 18:01:47 feb031721-896841 systemd[1]: snapd.service: Triggering OnFailure= dependencies.
```
which makes the test fail because at the end we can't properly restart snapd.

Also fix typos in the error messages.