### PR TITLE
cmd/snap: rename the verbose logging flag in snap run

### DIFF
--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -73,7 +73,7 @@ type cmdRun struct {
 	HookName string `long:"hook" hidden:"yes"`
 	Revision string `short:"r" default:"unset" hidden:"yes"`
 	Shell    bool   `long:"shell" `
-	Debug    bool   `long:"debug"`
+	Verbose  bool   `long:"verbose"`
 
 	// This options is both a selector (use or don't use strace) and it
 	// can also carry extra options for strace. This is why there is
@@ -121,7 +121,7 @@ and environment.
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"trace-exec": i18n.G("Display exec calls timing data"),
 			// TRANSLATORS: This should not start with a lowercase letter.
-			"debug":      i18n.G("Enable debug logs during early snap startup phases"),
+			"verbose":    i18n.G("Enable verbose logging during early snap startup phases"),
 			"parser-ran": "",
 		}, nil)
 }
@@ -480,9 +480,9 @@ func (x *cmdRun) straceOpts() (opts []string, raw bool, err error) {
 }
 
 func (x *cmdRun) snapRunApp(snapApp string, args []string) error {
-	if x.Debug {
+	if x.Verbose {
 		os.Setenv("SNAPD_DEBUG", "1")
-		logger.Debugf("enabled debug logging of early snap startup")
+		logger.Debugf("enabled verbose logging of early snap startup")
 	}
 	snapName, appName := snap.SplitSnapApp(snapApp)
 	info, err := getSnapInfo(snapName, snap.R(0))

--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -1972,7 +1972,7 @@ func (s *RunSuite) TestGetSnapDirOptions(c *check.C) {
 	c.Assert(opts, check.DeepEquals, &dirs.SnapDirOptions{HiddenSnapDataDir: true})
 }
 
-func (s *RunSuite) TestRunDebug(c *check.C) {
+func (s *RunSuite) TestRunVerbose(c *check.C) {
 	oldDebug, isSet := os.LookupEnv("SNAPD_DEBUG")
 	if isSet {
 		defer os.Setenv("SNAPD_DEBUG", oldDebug)
@@ -2001,7 +2001,7 @@ func (s *RunSuite) TestRunDebug(c *check.C) {
 	})
 
 	// this will modify the current process environment
-	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--debug", "snapname.app"})
+	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--verbose", "snapname.app"})
 	c.Assert(err, check.IsNil)
 	c.Check(execArg0, check.Equals, filepath.Join(dirs.DistroLibExecDir, "snap-confine"))
 	c.Check(execArgs, check.DeepEquals, []string{
@@ -2014,5 +2014,5 @@ func (s *RunSuite) TestRunDebug(c *check.C) {
 	// also set in env
 	c.Check(os.Getenv("SNAPD_DEBUG"), check.Equals, "1")
 	// and we've let the user know that logging was enabled
-	c.Check(logBuf.String(), testutil.Contains, "DEBUG: enabled debug logging of early snap startup")
+	c.Check(logBuf.String(), testutil.Contains, "DEBUG: enabled verbose logging of early snap startup")
 }


### PR DESCRIPTION
Based on discussion from the last SU. The --debug flag is confusing, let's try a different name, proposals are welcome.


