### PR TITLE
tests: increase nested disk size on classic images

### DIFF
--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -1244,6 +1244,8 @@ nested_start_classic_vm() {
     if [ ! -f "$NESTED_IMAGES_DIR/$IMAGE_NAME" ] ; then
         cp -v "$NESTED_IMAGES_DIR/$IMAGE_NAME.pristine" "$IMAGE_NAME"
     fi
+    # Give extra disk space for the image
+    qemu-img resize "$NESTED_IMAGES_DIR/$IMAGE_NAME" +2G
 
     # Now qemu parameters are defined
     local PARAM_SMP PARAM_MEM


### PR DESCRIPTION
This error only affects the classic images. This is the error I see in
logs

-y "linux-modules-extra-$(uname -r)"'
Warning: Permanently added '[localhost]:8022' (ECDSA) to the list of
known hosts.

WARNING: apt does not have a stable CLI interface. Use with caution in
scripts.

Reading package lists...
Building dependency tree...
Reading state information...
linux-modules-extra-5.13.0-27-generic is already the newest version
(5.13.0-27.29).
0 upgraded, 0 newly installed, 0 to remove and 7 not upgraded.
1 not fully installed or removed.
After this operation, 0 B of additional disk space will be used.
Setting up linux-image-5.13.0-27-generic (5.13.0-27.29) ...
Processing triggers for linux-image-5.13.0-27-generic (5.13.0-27.29) ...
/etc/kernel/postinst.d/initramfs-tools:
update-initramfs: Generating /boot/initrd.img-5.13.0-27-generic
cpio: write error: No space left on device
E: mkinitramfs failure cpio 2
update-initramfs: failed for /boot/initrd.img-5.13.0-27-generic with 1.
run-parts: /etc/kernel/postinst.d/initramfs-tools exited with return
code 1
dpkg: error processing package linux-image-5.13.0-27-generic
(--configure):
installed linux-image-5.13.0-27-generic package post-installation
script subprocess returned error exit status 1
Errors were encountered while processing:
 linux-image-5.13.0-27-generic
needrestart is being skipped since dpkg has failed

