### PR TITLE
devicestate: wait for NTP sync before trying to get a serial assertion

### DIFF
--- a/overlord/devicestate/handlers_serial.go
+++ b/overlord/devicestate/handlers_serial.go
@@ -664,6 +664,12 @@ func (m *DeviceManager) doRequestSerial(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
+	// wait for ntp sync before trying to register the serial
+	maxWait := 10 * time.Minute
+	if !m.ntpSyncedOrWaitedLongerThan(maxWait) {
+		return &state.Retry{}
+	}
+
 	// NB: the keyPair is fixed for now
 	privKey, err := m.keyPair()
 	if err == state.ErrNoState {


### PR DESCRIPTION
One of the recent bugreport we got was that on systems with no
battery powered clocks the device registration can be slow. The
first step here is to ensure that any logic we run that involves
backoff/timers waits for NTP synchronization. This commit adds
some simple code to ensure this.
