### PR TITLE
tests/nested/manual/remodel-cross-store,remodel-simple: wait for serial

### DIFF
--- a/tests/nested/manual/remodel-cross-store/task.yaml
+++ b/tests/nested/manual/remodel-cross-store/task.yaml
@@ -79,6 +79,9 @@ execute: |
 
     boot_id="$(tests.nested boot-id)"
 
+    # wait until device is initialized and has a serial
+    nested_wait_for_device_initialized_change
+
     tests.nested exec "snap model --assertion" | MATCH "brand-id: $SNAPD_TEST_BRAND\$"
     tests.nested exec "snap model --assertion" | MATCH "store: $SNAPD_STORE_WHITEBOX\$"
     tests.nested exec "snap model --assertion" | MATCH '^model: test-snapd-remodel-pc$'

--- a/tests/nested/manual/remodel-simple/task.yaml
+++ b/tests/nested/manual/remodel-simple/task.yaml
@@ -74,6 +74,9 @@ execute: |
 
     boot_id="$(tests.nested boot-id)"
 
+    # wait until device is initialized and has a serial
+    nested_wait_for_device_initialized_change
+
     tests.nested exec "snap model --assertion" | MATCH "brand-id: $SNAPD_TEST_BRAND\$"
     tests.nested exec "snap model --assertion" | MATCH "store: $SNAPD_STORE_WHITEBOX\$"
     tests.nested exec "snap model --assertion" | MATCH '^model: test-snapd-remodel-pc$'


### PR DESCRIPTION
Wait for serial before querying for it and proceeding with remodel.


