### PR TITLE
seed,image: changes necessary for ubuntu-image to support preseeding extra snaps in classic images

### DIFF
--- a/cmd/snap-preseed/main_test.go
+++ b/cmd/snap-preseed/main_test.go
@@ -317,6 +317,7 @@ type Fake16Seed struct {
 	Essential         []*seed.Snap
 	LoadMetaErr       error
 	LoadAssertionsErr error
+	IterErr           error
 	UsesSnapd         bool
 }
 
@@ -372,6 +373,14 @@ func (fs *Fake16Seed) EssentialSnaps() []*seed.Snap {
 
 func (fs *Fake16Seed) ModeSnaps(mode string) ([]*seed.Snap, error) {
 	return nil, nil
+}
+
+func (fs *Fake16Seed) NumSnaps() int {
+	return 0
+}
+
+func (fs *Fake16Seed) Iter(f func(sn *seed.Snap) error) error {
+	return fs.IterErr
 }
 
 func (s *startPreseedSuite) TestSystemSnapFromSeed(c *C) {

--- a/cmd/snap-preseed/main_test.go
+++ b/cmd/snap-preseed/main_test.go
@@ -317,7 +317,6 @@ type Fake16Seed struct {
 	Essential         []*seed.Snap
 	LoadMetaErr       error
 	LoadAssertionsErr error
-	IterErr           error
 	UsesSnapd         bool
 }
 
@@ -380,7 +379,7 @@ func (fs *Fake16Seed) NumSnaps() int {
 }
 
 func (fs *Fake16Seed) Iter(f func(sn *seed.Snap) error) error {
-	return fs.IterErr
+	return nil
 }
 
 func (s *startPreseedSuite) TestSystemSnapFromSeed(c *C) {

--- a/image/export_test.go
+++ b/image/export_test.go
@@ -20,6 +20,7 @@
 package image
 
 import (
+	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/store"
@@ -60,5 +61,13 @@ func MockWriteResolvedContent(f func(prepareImageDir string, info *gadget.Info, 
 	writeResolvedContent = f
 	return func() {
 		writeResolvedContent = oldWriteResolvedContent
+	}
+}
+
+func MockNewToolingStoreFromModel(f func(model *asserts.Model, fallbackArchitecture string) (*ToolingStore, error)) (restore func()) {
+	old := newToolingStoreFromModel
+	newToolingStoreFromModel = f
+	return func() {
+		newToolingStoreFromModel = old
 	}
 }

--- a/image/image_linux.go
+++ b/image/image_linux.go
@@ -98,6 +98,9 @@ func Prepare(opts *Options) error {
 	var model *asserts.Model
 	var err error
 	if opts.Classic && opts.ModelFile == "" {
+		// This is needed to support using ubuntu-image to preseed snaps in a rootfs
+		// that has already been built. Since there is no model assertion file
+		// we can use the GenericClassicModel to preseed snaps in the rootfs
 		model = sysdb.GenericClassicModel()
 	} else {
 		model, err = decodeModelAssertion(opts)

--- a/image/image_linux.go
+++ b/image/image_linux.go
@@ -94,6 +94,8 @@ func classicHasSnaps(model *asserts.Model, opts *Options) bool {
 	return model.Gadget() != "" || len(model.RequiredNoEssentialSnaps()) != 0 || len(opts.Snaps) != 0
 }
 
+var newToolingStoreFromModel = NewToolingStoreFromModel
+
 func Prepare(opts *Options) error {
 	var model *asserts.Model
 	var err error
@@ -126,7 +128,7 @@ func Prepare(opts *Options) error {
 		}
 	}
 
-	tsto, err := NewToolingStoreFromModel(model, opts.Architecture)
+	tsto, err := newToolingStoreFromModel(model, opts.Architecture)
 	if err != nil {
 		return err
 	}

--- a/image/image_linux.go
+++ b/image/image_linux.go
@@ -95,9 +95,15 @@ func classicHasSnaps(model *asserts.Model, opts *Options) bool {
 }
 
 func Prepare(opts *Options) error {
-	model, err := decodeModelAssertion(opts)
-	if err != nil {
-		return err
+	var model *asserts.Model
+	var err error
+	if opts.Classic && opts.ModelFile == "" {
+		model = sysdb.GenericClassicModel()
+	} else {
+		model, err = decodeModelAssertion(opts)
+		if err != nil {
+			return err
+		}
 	}
 
 	if model.Architecture() != "" && opts.Architecture != "" && model.Architecture() != opts.Architecture {

--- a/image/image_linux.go
+++ b/image/image_linux.go
@@ -100,9 +100,11 @@ func Prepare(opts *Options) error {
 	var model *asserts.Model
 	var err error
 	if opts.Classic && opts.ModelFile == "" {
-		// This is needed to support using ubuntu-image to preseed snaps in a rootfs
-		// that has already been built. Since there is no model assertion file
-		// we can use the GenericClassicModel to preseed snaps in the rootfs
+		// ubuntu-image has a use case for preseeding snaps in an arbitrary rootfs
+		// using its --filesystem flag. This rootfs may or may not already have
+		// snaps preseeded in it. In the case where the provided rootfs has no
+		// snaps seeded image.Prepare will be called with no model assertion,
+		// and we then use the GenericClassicModel.
 		model = sysdb.GenericClassicModel()
 	} else {
 		model, err = decodeModelAssertion(opts)

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -2033,7 +2033,7 @@ func (s *imageSuite) TestPrepareClassicModelNoModelAssertion(c *C) {
 		Architecture: "amd64",
 		PrepareDir:   preparedir,
 		Classic:      true,
-		Snaps:        []string{
+		Snaps: []string{
 			s.AssertedSnap("pc"),
 			s.AssertedSnap("pc-kernel"),
 			s.AssertedSnap("core"),
@@ -2046,7 +2046,7 @@ func (s *imageSuite) TestPrepareClassicModelNoModelAssertion(c *C) {
 	seedsnapsdir := filepath.Join(seeddir, "snaps")
 
 	for _, name := range []string{"core", "pc-kernel", "pc"} {
-		p := filepath.Join(seedsnapsdir, name + "_x1.snap")
+		p := filepath.Join(seedsnapsdir, name+"_x1.snap")
 		c.Check(p, testutil.FilePresent)
 	}
 }

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -2033,7 +2033,7 @@ func (s *imageSuite) TestPrepareClassicModelNoModelAssertion(c *C) {
 	})
 	defer restore()
 
-	// prepare an image with no model assetion but classic set to true
+	// prepare an image with no model assertion but classic set to true
 	// to ensure the GenericClassicModel is used without error
 	err := image.Prepare(&image.Options{
 		Architecture: "amd64",

--- a/osutil/mkfs/mkfs.go
+++ b/osutil/mkfs/mkfs.go
@@ -25,10 +25,10 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/strutil/shlex"
 )
 
 // MakeFunc defines a function signature that is used by all of the mkfs.<filesystem>
@@ -111,8 +111,14 @@ func mkfsExt4(img, label, contentsRootDir string, deviceSize, sectorSize quantit
 		if fakerootFlags != "" {
 			// When executing fakeroot from a classic confinement snap the location of
 			// libfakeroot must be specified, or else it will be loaded from the host system
-			fakerootArgs := append(strings.Split(fakerootFlags, " "), "--")
-			mkfsArgs = append(fakerootArgs, mkfsArgs...)
+			flags, err := shlex.Split(fakerootFlags)
+			if err != nil {
+				return fmt.Errorf("cannot split fakeroot command: %v", err)
+			}
+			if len(fakerootFlags) > 0 {
+				fakerootArgs := append(flags, "--")
+				mkfsArgs = append(fakerootArgs, mkfsArgs...)
+			}
 		}
 		cmd = exec.Command("fakeroot", mkfsArgs...)
 	} else {

--- a/seed/seed.go
+++ b/seed/seed.go
@@ -117,11 +117,12 @@ type Seed interface {
 	// in the given mode as defined by the seed, after LoadMeta.
 	ModeSnaps(mode string) ([]*Snap, error)
 
-	// NumSnaps returns the total number of snaps in a seed
+	// NumSnaps returns the total number of snaps in a seed.
 	NumSnaps() int
 
 	// Iter provides a way to iterately perform a function on
-	// each of the snaps in a seed
+	// each of the snaps in a seed. For UC20 all snaps will be
+	// considered independent of mode.
 	Iter(f func(sn *Snap) error) error
 }
 

--- a/seed/seed.go
+++ b/seed/seed.go
@@ -116,6 +116,13 @@ type Seed interface {
 	// ModeSnaps returns the snaps that should be available
 	// in the given mode as defined by the seed, after LoadMeta.
 	ModeSnaps(mode string) ([]*Snap, error)
+
+	// NumSnaps returns the total number of snaps in a seed
+	NumSnaps() int
+
+	// Iter provides a way to iterately perform a function on
+	// each of the snaps in a seed
+	Iter(f func(sn *Snap) error) error
 }
 
 // Open returns a Seed implementation for the seed at seedDir.

--- a/seed/seed20.go
+++ b/seed/seed20.go
@@ -559,3 +559,16 @@ func (s *seed20) ModeSnaps(mode string) ([]*Snap, error) {
 	}
 	return res, nil
 }
+
+func (s *seed20) NumSnaps() int {
+	return len(s.snaps)
+}
+
+func (s *seed20) Iter(f func(sn *Snap) error) error {
+	for _, sn := range s.snaps {
+		if err := f(sn); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/seed/validate.go
+++ b/seed/validate.go
@@ -105,13 +105,10 @@ func ValidateFromYaml(seedYamlFile string) error {
 		return newValidationError("", err)
 	}
 
-	// TODO:UC20: make the NumSnaps/Iter part of Seed
-	seed16 := seed.(*seed16)
-
 	ve := &ValidationError{}
 	// read the snap infos
-	snapInfos := make([]*snap.Info, 0, seed16.NumSnaps())
-	seed16.Iter(func(sn *Snap) error {
+	snapInfos := make([]*snap.Info, 0, seed.NumSnaps())
+	seed.Iter(func(sn *Snap) error {
 		snapf, err := snapfile.Open(sn.Path)
 		if err != nil {
 			ve.addErr("", err)


### PR DESCRIPTION
There are two changes here that are needed for ubuntu-image to support the --snap flag for classic image builds.

seed/seed.go: This change adds the NumSnaps and Iter functions to the seed interface. This is needed because there is a specific use case that requires ubuntu-image to parse seed.yaml and iterate through the snaps to create a list of the snaps and their channels. There is already a TODO for this task.

image/image_linux.go: This change is necessary to use image.Prepare on a prebuilt rootfs for which there is no model assertion. In this case the GenericClassicModel from sysdb is used