### PR TITLE
spread: non-functional cleanup of go1.6 legacy

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -10,9 +10,7 @@ environment:
     GOPROXY: https://proxy.golang.org,direct
     REUSE_PROJECT: '$(HOST: echo "$REUSE_PROJECT")'
     PROJECT_PATH: $GOHOME/src/github.com/snapcore/snapd
-    # /usr/lib/go-1.6/bin for trusty (needs to be last as we use
-    # a different go in gccgo tests)
-    PATH: $GOHOME/bin:/snap/bin:$PATH:/usr/lib/go-1.6/bin:/var/lib/snapd/snap/bin:$PROJECT_PATH/tests/bin
+    PATH: $GOHOME/bin:/snap/bin:$PATH:/var/lib/snapd/snap/bin:$PROJECT_PATH/tests/bin
     TESTSLIB: $PROJECT_PATH/tests/lib
     TESTSTOOLS: $PROJECT_PATH/tests/lib/tools
     TESTSTMP: /var/tmp/snapd-tools


### PR DESCRIPTION
In the YML spread file there are leftovers from go1.6,
which have no functional meaning, as snapd is already running go1.13

This change should not be having impact as is purely cosmetic.

Signed-off-by: Arseniy Aharonov <arseniy.aharonov@canonical.com>

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
