### PR TITLE
interfaces/seccomp: Add rseq to base seccomp template

### DIFF
--- a/interfaces/seccomp/template.go
+++ b/interfaces/seccomp/template.go
@@ -343,6 +343,10 @@ renameat2
 restart_syscall
 
 rmdir
+
+# glibc 2.35 unconditionally calls rseq for all threads
+rseq
+
 rt_sigaction
 rt_sigpending
 rt_sigprocmask


### PR DESCRIPTION
glibc 2.35 calls rseq() for all threads so allow this by default

Signed-off-by: Alex Murray <alex.murray@canonical.com>
