### PR TITLE
cmd/snap-confine: build const data structures at compile-time

### DIFF
--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -360,7 +360,7 @@ static void sc_mkdir_and_mount_and_glob_files(const char *rootfs_dir,
 static void sc_mount_nvidia_driver_biarch(const char *rootfs_dir, const char **globs, size_t globs_len)
 {
 
-	const char *native_sources[] = {
+	static const char *native_sources[] = {
 		NATIVE_LIBDIR,
 		NATIVE_LIBDIR "/nvidia*",
 	};
@@ -369,7 +369,7 @@ static void sc_mount_nvidia_driver_biarch(const char *rootfs_dir, const char **g
 
 #if UINTPTR_MAX == 0xffffffffffffffff
 	// Alternative 32-bit support
-	const char *lib32_sources[] = {
+	static const char *lib32_sources[] = {
 		LIB32_DIR,
 		LIB32_DIR "/nvidia*",
 	};

--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -321,7 +321,7 @@ static void sc_bootstrap_mount_namespace(const struct sc_mount_config *config)
 		// Fixes the following bugs:
 		//  - https://bugs.launchpad.net/snap-confine/+bug/1580018
 		//  - https://bugzilla.opensuse.org/show_bug.cgi?id=1028568
-		const char *dirs_from_core[] = {
+		static const char *dirs_from_core[] = {
 			"/etc/alternatives", "/etc/nsswitch.conf",
 			// Some specific and privileged interfaces (e.g docker-support) give
 			// access to apparmor_parser from the base snap which at a minimum
@@ -659,7 +659,7 @@ void sc_populate_mount_ns(struct sc_apparmor *apparmor, int snap_update_ns_fd,
 	// Check which mode we should run in, normal or legacy.
 	if (inv->is_normal_mode) {
 		// In normal mode we use the base snap as / and set up several bind mounts.
-		const struct sc_mount mounts[] = {
+		static const struct sc_mount mounts[] = {
 			{"/dev"},	// because it contains devices on host OS
 			{"/etc"},	// because that's where /etc/resolv.conf lives, perhaps a bad idea
 			{"/home"},	// to support /home/*/snap and home interface
@@ -699,7 +699,7 @@ void sc_populate_mount_ns(struct sc_apparmor *apparmor, int snap_update_ns_fd,
 	} else {
 		// In legacy mode we don't pivot and instead just arrange bi-
 		// directional mount propagation for two directories.
-		const struct sc_mount mounts[] = {
+		static const struct sc_mount mounts[] = {
 			{"/media", true},
 			{"/run/netns", true},
 			{},


### PR DESCRIPTION
Adding the `static` keyword before initializations of const variables
ensures that such initialization will happen at compile-time. As it can
be seen from this assembly snippet (extracted from the
sc_populate_mount_ns() function), before this change the array of
`sc_mount` structures was computed at run-time:

```as
.LC62:
    .string "/home"
.LC63:
    .string "/root"
.LC64:
    .string "/proc"

[...]

    leaq    .LC62(%rip), %rax
    movq    %rax, 128(%rsp)
    leaq    .LC63(%rip), %rax
    movq    %rax, 160(%rsp)
    leaq    .LC64(%rip), %rax
    movq    %rax, 192(%rsp)
```

whereas, declaring these variables as `static` causes them to be dumped
into the read-only data section, and loaded with a single operation:

```as
.LC115:
    .string "/home"
.LC116:
    .string "/root"
.LC117:
    .string "/proc"

[...]

mounts.3:
    .quad   .LC113
    .zero   24
    .quad   .LC114
    .zero   24
    .quad   .LC115
    .zero   24

[...]

    leaq    mounts.3(%rip), %rax
    movq    %rax, 8(%rsp)
```
