### PR TITLE
o/snapstate: reduce maxInhibition for raa by 1s to avoid confusing notification

### DIFF
--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -48,8 +48,11 @@ const maxPostponement = 95 * 24 * time.Hour
 // buffer for maxPostponement when holding snaps with auto-refresh gating
 const maxPostponementBuffer = 5 * 24 * time.Hour
 
-// cannot inhibit refreshes for more than maxInhibition
-const maxInhibition = 14 * 24 * time.Hour
+// cannot inhibit refreshes for more than maxInhibition;
+// deduct 1s so it doesn't look confusing initially when two notifications
+// get displayed in short period of time and it immediately goes from "14 days"
+// to "13 days" left.
+const maxInhibition = 14*24*time.Hour - time.Second
 
 // hooks setup by devicestate
 var (

--- a/overlord/snapstate/autorefresh_test.go
+++ b/overlord/snapstate/autorefresh_test.go
@@ -905,7 +905,7 @@ func (s *autoRefreshTestSuite) TestInitialInhibitRefreshWithinInhibitWindow(c *C
 	restore := snapstate.MockAsyncPendingRefreshNotification(func(ctx context.Context, client *userclient.Client, refreshInfo *userclient.PendingSnapRefreshInfo) {
 		notificationCount++
 		c.Check(refreshInfo.InstanceName, Equals, "pkg")
-		c.Check(refreshInfo.TimeRemaining, Equals, time.Hour*14*24)
+		c.Check(refreshInfo.TimeRemaining, Equals, time.Hour*14*24-time.Second)
 	})
 	defer restore()
 


### PR DESCRIPTION
Reduce maxInhibition for refresh app awereness by 1 second as sharp 14 days leads to a slightly strange notification when refreshes are retried quickly and the app is still running: at first the notification says we have 14 days left, and a moment later it switches to 13 days.