### PR TITLE
cmd/snap-confine: remove mention of "legacy mode" from comment

### DIFF
--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -147,8 +147,8 @@ static void setup_private_pts(void)
 
 	struct stat st;
 
-	// Make sure /dev/pts/ptmx exists, otherwise we are in legacy mode
-	// which doesn't provide the isolation we require.
+	// Make sure /dev/pts/ptmx exists, otherwise the system doesn't provide the
+	// isolation we require.
 	if (stat("/dev/pts/ptmx", &st) != 0) {
 		die("cannot stat /dev/pts/ptmx");
 	}


### PR DESCRIPTION
One more :-)

The mention of "legacy mode" is confusing here, because this code is
indeed also executed on snap-confine's legacy mode path; so, this is
obviously referring to a kernel's legacy mode.

To reduce confusion, reformulate the comment.
