### PR TITLE
gadget/gadget_test.go: fix variable type

### DIFF
--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -3367,8 +3367,8 @@ func (s *gadgetYamlTestSuite) TestAllDiskVolumeDeviceTraitsMultipleGPTVolumes(c 
 	})
 	defer restore()
 
-	mod := &modelCharateristics{
-		systemSeed: true,
+	mod := &gadgettest.ModelCharacteristics{
+		SystemSeed: true,
 	}
 	vols, err := gadgettest.LayoutMultiVolumeFromYaml(
 		c.MkDir(),


### PR DESCRIPTION
This type got moved to gadgettest in one of the prior PRs, but the checks for
the PR where this specific test was introduced had it's checks run before that
PR was merged so it was green and thus mergable and didn't show this error.

Thanks to Maciej for finding this out so quickly.