### PR TITLE
many: fix issues flagged by golangci and configure it to fail build

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -158,8 +158,7 @@ jobs:
         working-directory: ./src/github.com/snapcore/snapd
         # show only new issues
         # use empty path prefix to make annotations work
-        # TODO: start failing once the config is tuned properly
-        args: --new-from-rev=${{ github.base_ref }} --path-prefix= --issues-exit-code=0
+        args: --new-from-rev=${{ github.base_ref }} --path-prefix=
         # skip all additional steps
         skip-go-installation: true
         skip-pkg-cache: true

--- a/asserts/fetcher.go
+++ b/asserts/fetcher.go
@@ -26,6 +26,7 @@ import (
 type fetchProgress int
 
 const (
+	//nolint:deadcode
 	fetchNotSeen fetchProgress = iota
 	fetchRetrieved
 	fetchSaved

--- a/cmd/snap-update-ns/utils.go
+++ b/cmd/snap-update-ns/utils.go
@@ -41,6 +41,7 @@ const (
 	// SquashfsMagic is the equivalent of SQUASHFS_MAGIC
 	SquashfsMagic = 0x73717368
 	// Ext4Magic is the equivalent of EXT4_SUPER_MAGIC
+	//nolint:deadcode
 	Ext4Magic = 0xef53
 	// TmpfsMagic is the equivalent of TMPFS_MAGIC
 	TmpfsMagic = 0x01021994

--- a/cmd/snap/cmd_auto_import.go
+++ b/cmd/snap/cmd_auto_import.go
@@ -45,8 +45,6 @@ import (
 
 const autoImportsName = "auto-import.assert"
 
-var mountInfoPath = "/proc/self/mountinfo"
-
 func autoImportCandidates() ([]string, error) {
 	var cands []string
 

--- a/dbusutil/netplantest/netplantest.go
+++ b/dbusutil/netplantest/netplantest.go
@@ -37,8 +37,6 @@ const (
 	netplanInterface  = "io.netplan.Netplan"
 
 	netplanConfigInterface = "io.netplan.Netplan.Config"
-
-	introspectInterface = "org.freedesktop.DBus.Introspectable"
 )
 
 type NetplanServer struct {

--- a/desktop/notification/fdo_test.go
+++ b/desktop/notification/fdo_test.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/godbus/dbus"
-
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/desktop/notification"

--- a/desktop/notification/gtk_test.go
+++ b/desktop/notification/gtk_test.go
@@ -20,9 +20,8 @@
 package notification_test
 
 import (
-	. "gopkg.in/check.v1"
-
 	"github.com/godbus/dbus"
+	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/desktop/notification"
 	"github.com/snapcore/snapd/desktop/notification/notificationtest"

--- a/desktop/notification/manager_test.go
+++ b/desktop/notification/manager_test.go
@@ -22,9 +22,9 @@ package notification_test
 import (
 	"fmt"
 
+	"github.com/godbus/dbus"
 	. "gopkg.in/check.v1"
 
-	"github.com/godbus/dbus"
 	"github.com/snapcore/snapd/desktop/notification"
 	"github.com/snapcore/snapd/testutil"
 )

--- a/osutil/faultinject_dummy_test.go
+++ b/osutil/faultinject_dummy_test.go
@@ -32,8 +32,6 @@ import (
 
 type testhelperDummyFaultInjectionSuite struct {
 	testutil.BaseTest
-
-	sysroot string
 }
 
 var _ = Suite(&testhelperDummyFaultInjectionSuite{})

--- a/overlord/configstate/configcore/netplan.go
+++ b/overlord/configstate/configcore/netplan.go
@@ -38,9 +38,8 @@ import (
 	"strings"
 	"time"
 
-	"gopkg.in/yaml.v3"
-
 	"github.com/godbus/dbus"
+	"gopkg.in/yaml.v3"
 
 	"github.com/snapcore/snapd/dbusutil"
 	"github.com/snapcore/snapd/logger"

--- a/overlord/configstate/configcore/netplan_test.go
+++ b/overlord/configstate/configcore/netplan_test.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/godbus/dbus"
-
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/dbusutil"

--- a/spdx/licenses.go
+++ b/spdx/licenses.go
@@ -24,6 +24,7 @@ package spdx
 // Version: 3.11 2020-11-25
 //
 // jq < json/licenses.json '.licenses | .[] | select(.isOsiApproved == true) | .licenseId' | sort | sed -e 's/$/,/'
+//nolint:deadcode,unused
 var osi = []string{
 	"0BSD",
 	"AAL",

--- a/store/store.go
+++ b/store/store.go
@@ -702,6 +702,7 @@ var (
 type deviceAuthNeed int
 
 const (
+	//nolint:deadcode
 	deviceAuthPreferred deviceAuthNeed = iota
 	deviceAuthCustomStoreOnly
 )

--- a/strutil/shlex/shlex.go
+++ b/strutil/shlex/shlex.go
@@ -85,6 +85,7 @@ const (
 
 // Classes of rune token
 const (
+	//nolint:deadcode
 	unknownRuneClass runeTokenClass = iota
 	spaceRuneClass
 	escapingQuoteRuneClass


### PR DESCRIPTION
Fixes some issues flagged by golangci-lint:
* Groups 3rd party imports
* Removes some unused vars
* Moves var only used in tests into test pkg
* Add 'nolint' to ignore warning on unused iotas (wasn't sure if those were left intentionally, for instance for readability purposes)

Also allow golangci to fail the build so we can catch these nits before they're merged.