### PR TITLE
wrappers: do not reload the deamon or restart snapd services when preseeding on core

### DIFF
--- a/overlord/snapstate/backend/link.go
+++ b/overlord/snapstate/backend/link.go
@@ -275,7 +275,7 @@ func removeGeneratedWrappers(s *snap.Info, firstInstallUndo bool, meter progress
 
 func GenerateSnapdWrappers(s *snap.Info) error {
 	// snapd services are handled separately via an explicit helper
-	return wrappers.AddSnapdSnapServices(s, progress.Null)
+	return wrappers.AddSnapdSnapServices(s, nil, progress.Null)
 }
 
 func removeGeneratedSnapdWrappers(s *snap.Info, firstInstall bool, meter progress.Meter) error {

--- a/systemd/emulation.go
+++ b/systemd/emulation.go
@@ -51,7 +51,7 @@ func (s *emulation) Backend() Backend {
 }
 
 func (s *emulation) DaemonReload() error {
-	return &notImplementedError{"DaemonReload"}
+	return nil
 }
 
 func (s *emulation) DaemonReexec() error {
@@ -69,15 +69,15 @@ func (s *emulation) Disable(services []string) error {
 }
 
 func (s *emulation) Start(services []string) error {
-	return &notImplementedError{"Start"}
+	return nil
 }
 
 func (s *emulation) StartNoBlock(services []string) error {
-	return &notImplementedError{"StartNoBlock"}
+	return nil
 }
 
 func (s *emulation) Stop(services []string, timeout time.Duration) error {
-	return &notImplementedError{"Stop"}
+	return nil
 }
 
 func (s *emulation) Kill(service, signal, who string) error {
@@ -85,7 +85,7 @@ func (s *emulation) Kill(service, signal, who string) error {
 }
 
 func (s *emulation) Restart(services []string, timeout time.Duration) error {
-	return &notImplementedError{"Restart"}
+	return nil
 }
 
 func (s *emulation) ReloadOrRestart(service string) error {

--- a/wrappers/core18_test.go
+++ b/wrappers/core18_test.go
@@ -229,11 +229,6 @@ func (s *servicesTestSuite) TestAddSnapServicesForSnapdOnCorePreseeding(c *C) {
 	// reset root dir
 	dirs.SetRootDir(s.tempdir)
 
-	systemctlRestorer := systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
-		return nil, fmt.Errorf("not expected")
-	})
-	defer systemctlRestorer()
-
 	info := makeMockSnapdSnap(c)
 	// add the snapd service
 	err := wrappers.AddSnapdSnapServices(info, &wrappers.AddSnapdSnapServicesOptions{Preseeding: true}, progress.Null)
@@ -308,7 +303,6 @@ WantedBy=snapd.service
 		{"--root", s.tempdir, "enable", "snapd.autoimport.service"},
 		{"--root", s.tempdir, "enable", "snapd.service"},
 		{"--root", s.tempdir, "enable", "snapd.snap-repair.timer"},
-		// test pretends snapd.socket is disabled and needs enabling
 		{"--root", s.tempdir, "enable", "snapd.socket"},
 		{"--root", s.tempdir, "enable", "snapd.system-shutdown.service"},
 		{"--user", "--global", "disable", "snapd.session-agent.service"},

--- a/wrappers/core18_test.go
+++ b/wrappers/core18_test.go
@@ -230,19 +230,7 @@ func (s *servicesTestSuite) TestAddSnapServicesForSnapdOnCorePreseeding(c *C) {
 	dirs.SetRootDir(s.tempdir)
 
 	systemctlRestorer := systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
-		s.sysdLog = append(s.sysdLog, cmd)
-		if cmd[0] == "show" && cmd[1] == "--property=Id,ActiveState,UnitFileState,Type" {
-			s := fmt.Sprintf("Type=oneshot\nId=%s\nActiveState=inactive\nUnitFileState=enabled\n", cmd[2])
-			return []byte(s), nil
-		}
-		if len(cmd) == 2 && cmd[0] == "is-enabled" {
-			// pretend snapd.socket is disabled
-			if cmd[1] == "snapd.socket" {
-				return []byte("disabled"), &mockSystemctlError{msg: "disabled", exitCode: 1}
-			}
-			return []byte("enabled"), nil
-		}
-		return []byte("ActiveState=inactive\n"), nil
+		return nil, fmt.Errorf("not expected")
 	})
 	defer systemctlRestorer()
 


### PR DESCRIPTION
Do not call reload-daemon or restart services on core when preseeding, use EumulationMode. The unit test is based on the existing test for non-preseeding case.

There is a TODO about user services which will currently call `systemctl enable --global --user` .. without `--root`; this needs changes to EmulationMode which I'd like to address separately. I didn't see any issues when testing the prototype without it, but it probably needs to be handled via emulation mode for completeness and consistence with the rest.