### PR TITLE
data/env: fix fish env for all versions of fish, unexport local vars, export XDG_DATA_DIRS

### DIFF
--- a/data/env/snapd.fish.in
+++ b/data/env/snapd.fish.in
@@ -1,12 +1,14 @@
 # Expand $PATH to include the directory where snappy applications go.
-set -u snap_bin_path "@SNAP_MOUNT_DIR@/bin"
-fish_add_path -aP $snap_bin_path
+set -ul snap_bin_path "@SNAP_MOUNT_DIR@/bin"
+if not contains $snap_bin_path $PATH
+    set PATH $PATH $snap_bin_path
+end
 
 # Desktop files (used by desktop environments within both X11 and Wayland) are
 # looked for in XDG_DATA_DIRS; make sure it includes the relevant directory for
 # snappy applications' desktop files.
-set -u snap_xdg_path /var/lib/snapd/desktop
-set --path XDG_DATA_DIRS $XDG_DATA_DIRS
-if ! contains $snap_xdg_path $XDG_DATA_DIRS
+set -ul snap_xdg_path /var/lib/snapd/desktop
+set --path --export XDG_DATA_DIRS $XDG_DATA_DIRS
+if not contains $snap_xdg_path $XDG_DATA_DIRS
     set XDG_DATA_DIRS $XDG_DATA_DIRS $snap_xdg_path
 end


### PR DESCRIPTION
Make the fish env setup script compatible with old versions of fish 3.0.x which
was released back in 2019, but is still shipped by recent releases of distros
eg. Ubuntu 21.10.

While doing so, make sure that helper variables used in the script stay local.

Since only newer versions of fish (3.1+) are aware of XDG_DATA_DIRS make sure
that it's exported.

Fixes:
https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1958022
https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1957948
https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1960492
