### PR TITLE
tests: prepare and restore nested tests

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -960,13 +960,12 @@ suites:
             # Install the snapd built
             dpkg -i "$SPREAD_PATH"/../snapd_*.deb
         prepare-each: |
-            tests.backup prepare
+            "$TESTSLIB"/prepare-restore.sh --prepare-suite-each
             tests.nested prepare
         restore-each: |
             tests.nested vm remove
             tests.nested restore
-            tests.cleanup restore
-            tests.backup restore
+            "$TESTSLIB"/prepare-restore.sh --restore-suite-each
         restore: |
             #shellcheck source=tests/lib/pkgdb.sh
             . "$TESTSLIB"/pkgdb.sh
@@ -1010,12 +1009,12 @@ suites:
             tests.nested prepare
             tests.nested build-image classic
         prepare-each: |
+            "$TESTSLIB"/prepare-restore.sh --prepare-suite-each
             tests.backup prepare
             tests.nested create-vm classic
         restore-each: |
             tests.nested vm remove
-            tests.cleanup restore
-            tests.backup restore
+            "$TESTSLIB"/prepare-restore.sh --restore-suite-each
         restore: |
             tests.nested restore
 
@@ -1061,12 +1060,12 @@ suites:
             tests.nested prepare
             tests.nested build-image core
         prepare-each: |
+            "$TESTSLIB"/prepare-restore.sh --prepare-suite-each
             tests.backup prepare
             tests.nested create-vm core
         restore-each: |
             tests.nested vm remove
-            tests.cleanup restore
-            tests.backup restore
+            "$TESTSLIB"/prepare-restore.sh --restore-suite-each
         restore: |
             tests.nested restore
 

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -587,6 +587,9 @@ nested_create_core_vm() {
 
     if [ -f "$NESTED_IMAGES_DIR/$IMAGE_NAME.pristine" ]; then
         cp -v "$NESTED_IMAGES_DIR/$IMAGE_NAME.pristine" "$NESTED_IMAGES_DIR/$IMAGE_NAME"
+        if [ ! "$NESTED_USE_CLOUD_INIT" = "true" ]; then
+            nested_create_assertions_disk
+        fi
         return
 
     elif [ ! -f "$NESTED_IMAGES_DIR/$IMAGE_NAME" ]; then

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -85,12 +85,13 @@ nested_check_unit_stays_active() {
 }
 
 nested_check_boot_errors() {
+    local cursor=$1
     # Check if the service started and it is running without errors
     if nested_is_core_20_system && ! nested_check_unit_stays_active "$NESTED_VM" 15 1; then
         # Error -> Code=qemu-system-x86_64: /build/qemu-rbeYHu/qemu-4.2/include/hw/core/cpu.h:633: cpu_asidx_from_attrs: Assertion `ret < cpu->num_ases && ret >= 0' failed
         # It is reproducible on an Intel machine without unrestricted mode support, the failure is most likely due to the guest entering an invalid state for Intel VT
         # The workaround is to restart the vm and check that qemu doesn't go into this bad state again
-        if nested_status_vm | MATCH "cpu_asidx_from_attrs: Assertion.*failed"; then
+        if "$TESTSTOOLS"/journal-state get-log-from-cursor "$cursor" -u "$NESTED_VM" | MATCH "cpu_asidx_from_attrs: Assertion.*failed"; then
             return 1
         fi
     fi
@@ -98,10 +99,14 @@ nested_check_boot_errors() {
 
 nested_retry_start_with_boot_errors() {
     local retry=3
+    local cursor
+    cursor="$("$TESTSTOOLS"/journal-state get-test-cursor)"
     while [ "$retry" -ge 0 ]; do
         retry=$(( retry - 1 ))
-        if ! nested_check_boot_errors; then
+        if ! nested_check_boot_errors "$cursor"; then
+            cursor="$("$TESTSTOOLS"/journal-state get-last-cursor)"
             nested_restart
+            sleep 3
         else
             return 0
         fi

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -626,6 +626,14 @@ prepare_suite_each() {
     fi
     "$TESTSTOOLS"/journal-state start-new-log
 
+    # Check if journalctl is ready to run the test
+    "$TESTSTOOLS"/journal-state check-log-started
+
+    # In case of nested tests the next checks and changes are not needed
+    if tests.nested is-nested; then
+        return 0
+    fi
+
     if [[ "$variant" = full ]]; then
         # shellcheck source=tests/lib/prepare.sh
         . "$TESTSLIB"/prepare.sh
@@ -634,8 +642,6 @@ prepare_suite_each() {
         fi
         prepare_memory_limit_override
     fi
-    # Check if journalctl is ready to run the test
-    "$TESTSTOOLS"/journal-state check-log-started
 
     case "$SPREAD_SYSTEM" in
         fedora-*|centos-*|amazon-*)
@@ -679,6 +685,11 @@ restore_suite_each() {
             # shellcheck disable=SC2086
             tests.pkgs install $packages
         fi
+    fi
+
+    # In case of nested tests the next checks and changes are not needed
+    if tests.nested is-nested; then
+        return 0
     fi
 
     # On Arch it seems that using sudo / su for working with the test user

--- a/tests/lib/tools/journal-state
+++ b/tests/lib/tools/journal-state
@@ -7,6 +7,7 @@ show_help() {
     echo "usage: journal-state start-new-log"
     echo "       journal-state check-log-started"
     echo "       journal-state get-last-cursor"
+    echo "       journal-state get-test-cursor"
     echo "       journal-state match-log <EXPRESSION> [--attempts|-n PARAM] [--wait PARAM] [--unit|-u PARAM] [-b]"
     echo "       journal-state get-log"
     echo "       journal-state get-log-from-cursor"
@@ -27,6 +28,15 @@ start_new_log(){
         echo "$SPREAD_JOB " >> "$JOURNALCTL_CURSOR_FILE"
         echo "$cursor" >> "$JOURNALCTL_CURSOR_FILE"
     fi
+}
+
+get_test_cursor(){
+    cursor="$(tail -n 1 "$JOURNALCTL_CURSOR_FILE")"
+    if [ -z "$cursor" ]; then
+        echo "Cursor for test not found"
+        exit 1
+    fi
+    echo "$cursor"
 }
 
 check_log_started(){


### PR DESCRIPTION
The idea of this change is to prepare and restore the nested tests as we do for the main suite.

Also by doing that we can access the journal logs instead of checking the systems service status.

This change also includes a fix for the assertion disk when the image is reused.
