### PR TITLE
tests: skip ~/.snap migration test on openSUSE

### DIFF
--- a/tests/main/hidden-snap-dir/task.yaml
+++ b/tests/main/hidden-snap-dir/task.yaml
@@ -1,8 +1,8 @@
 summary: Check that the experimental hidden dir feature migrates the dir
 
-# this test is flaky on CentOS 7 and 8. Disabling while the cause is
-# investigated
-systems: [-centos-*]
+# this test is flaky on CentOS and openSUSE due to an issue w/ 'snap remove'
+# https://bugs.launchpad.net/snapd/+bug/1959036
+systems: [-centos-*, -opensuse-*]
 
 environment:
     NAME: test-snapd-tools


### PR DESCRIPTION
Skip the hidden snap dir test on openSUSE, since the 'snap remove'
issue was observed there as well. Also, update the comment about
the flakiness and link to LP report.
