### PR TITLE
tests: smoke test support for core22

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -412,6 +412,18 @@ backends:
             - ubuntu-core-20-arm-32:
                   username: external
                   password: ubuntu
+            - ubuntu-core-22-64:
+                  username: external
+                  password: ubuntu
+            - ubuntu-core-22-32:
+                  username: external
+                  password: ubuntu
+            - ubuntu-core-22-arm-64:
+                  username: external
+                  password: ubuntu
+            - ubuntu-core-22-arm-32:
+                  username: external
+                  password: ubuntu
 
 path: /home/gopath/src/github.com/snapcore/snapd
 

--- a/tests/core/remove/task.yaml
+++ b/tests/core/remove/task.yaml
@@ -14,6 +14,8 @@ execute: |
         base=core18
     elif os.query is-core20; then
         base=core20
+    elif os.query is-core22; then
+        base=core22
     fi
     echo "Ensure $base cannot be removed"
     if snap remove --purge "$base"; then

--- a/tests/lib/core-config.sh
+++ b/tests/lib/core-config.sh
@@ -82,6 +82,8 @@ get_test_model(){
         echo "${MODEL_NAME}-18.model"
     elif os.query is-core20; then
         echo "${MODEL_NAME}-20.model"
+    elif os.query is-core22; then
+        echo "${MODEL_NAME}-22.model"
     else
         echo "${MODEL_NAME}.model"
     fi
@@ -92,6 +94,8 @@ get_test_snap_suffix(){
         echo "-core18"
     elif os.query is-core20; then
         echo "-core20"
+    elif os.query is-core22; then
+        echo "-core22"
     fi
 }
 

--- a/tests/lib/external/snapd-testing-tools/tests/os.query/task.yaml
+++ b/tests/lib/external/snapd-testing-tools/tests/os.query/task.yaml
@@ -35,11 +35,6 @@ execute: |
             os.query is-pc-amd64
             ! os.query is-arm
             ;;
-        ubuntu-21.04-64)
-            os.query is-hirsute
-            os.query is-classic
-            ! os.query is-core
-            ;;
         ubuntu-21.10-64)
             os.query is-impish
             os.query is-classic

--- a/tests/lib/external/snapd-testing-tools/tools/os.query
+++ b/tests/lib/external/snapd-testing-tools/tools/os.query
@@ -2,8 +2,8 @@
 
 show_help() {
     echo "usage: os.query is-core, is-classic"
-    echo "       os.query is-core16, is-core18, is-core20"
-    echo "       os.query is-trusty, is-xenial, is-bionic, is-focal, is-hirsute, is-impish"
+    echo "       os.query is-core16, is-core18, is-core20, is-core22"
+    echo "       os.query is-trusty, is-xenial, is-bionic, is-focal, is-impish"
     echo "       os.query is-ubuntu, is-debian, is-fedora, is-amazon-linux, is-arch-linux, is-centos, is-centos-7, is-centos-8, is-opensuse"
     echo "       os.query is-opensuse-tumbleweed, is-debian-sid, is-debian-11, is-debian-10"
     echo "       os.query is-pc-amd64, is-pc-i386, is-arm, is-armhf, is-arm64"
@@ -27,6 +27,10 @@ is_core20() {
     [[ "$SPREAD_SYSTEM" == ubuntu-core-20-* ]]
 }
 
+is_core22() {
+    [[ "$SPREAD_SYSTEM" == ubuntu-core-22-* ]]
+}
+
 is_classic() {
     ! is_core
 }
@@ -45,10 +49,6 @@ is_bionic() {
 
 is_focal() {
     grep -qFx 'UBUNTU_CODENAME=focal' /etc/os-release
-}
-
-is_hirsute() {
-    grep -qFx 'UBUNTU_CODENAME=hirsute' /etc/os-release
 }
 
 is_impish() {

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -55,6 +55,10 @@ ensure_jq() {
     elif os.query is-core20; then
         snap install --devmode --edge jq-core20
         snap alias jq-core20.jq jq
+    elif os.query is-core22; then
+        # TODO core22 snap of jq needs to be made
+        snap install --devmode --edge jq-core20
+        snap alias jq-core20.jq jq
     else
         snap install --devmode jq
     fi
@@ -830,6 +834,8 @@ setup_reflash_magic() {
         core_name="core18"
     elif os.query is-core20; then
         core_name="core20"
+    elif os.query is-core22; then
+        core_name="core22"
     fi
     # XXX: we get "error: too early for operation, device not yet
     # seeded or device model not acknowledged" here sometimes. To
@@ -879,6 +885,9 @@ setup_reflash_magic() {
     elif os.query is-core20; then
         repack_snapd_snap_with_deb_content_and_run_mode_firstboot_tweaks "$IMAGE_HOME"
         cp "$TESTSLIB/assertions/ubuntu-core-20-amd64.model" "$IMAGE_HOME/pc.model"
+    elif os.query is-core22; then
+        repack_snapd_snap_with_deb_content_and_run_mode_firstboot_tweaks "$IMAGE_HOME"
+        cp "$TESTSLIB/assertions/ubuntu-core-22-amd64.model" "$IMAGE_HOME/pc.model"
     else
         # FIXME: install would be better but we don't have dpkg on
         #        the image
@@ -991,7 +1000,7 @@ EOF
 
     # on core18 we need to use the modified snapd snap and on core16
     # it is the modified core that contains our freshly build snapd
-    if os.query is-core18 || os.query is-core20; then
+    if os.query is-core18 || os.query is-core20 || os.query is-core22; then
         extra_snap=("$IMAGE_HOME"/snapd_*.snap)
     else
         extra_snap=("$IMAGE_HOME"/core_*.snap)
@@ -1047,7 +1056,7 @@ EOF
                     --output-dir "$IMAGE_HOME"
     rm -f ./pc-kernel_*.{snap,assert} ./pc-kernel.{snap,assert} ./pc_*.{snap,assert} ./snapd_*.{snap,assert} ./core20.{snap,assert}
 
-    if os.query is-core20; then
+    if os.query is-core20 || os.query is-core22; then
         # (ab)use ubuntu-seed
         LOOP_PARTITION=2
     else
@@ -1057,7 +1066,7 @@ EOF
     # expand the uc16 and uc18 images a little bit (400M) as it currently will
     # run out of space easily from local spread runs if there are extra files in
     # the project not included in the git ignore and spread ignore, etc.
-    if ! os.query is-core20; then
+    if ! (os.query is-core20 && os.query is-core22); then
         # grow the image by 400M
         truncate --size=+400M "$IMAGE_HOME/$IMAGE"
         # fix the GPT table because old versions of parted complain about this 
@@ -1081,7 +1090,7 @@ EOF
     dev=$(basename "$devloop")
 
     # resize the 2nd partition from that loop device to fix the size
-    if ! os.query is-core20; then
+    if ! (os.query is-core20 && os.query is-core22); then
         resize2fs -p "/dev/mapper/${dev}p${LOOP_PARTITION}"
     fi
 
@@ -1108,7 +1117,7 @@ EOF
           --exclude /gopath/pkg/ \
           --include core/ \
           /home/gopath /mnt/user-data/
-    elif os.query is-core20; then
+    elif os.query is-core20 || os.query is-core22; then
         # prepare passwd for run-mode-overlay-data
 
         # use /etc/{group,passwd,shadow,gshadow} from the core20 snap, merged
@@ -1191,7 +1200,7 @@ EOF
     chmod +x "$IMAGE_HOME/prep-reflash.sh"
 
     DEVPREFIX=""
-    if os.query is-core20; then
+    if os.query is-core20 || os.query is-core22; then
         DEVPREFIX="/boot"
     fi
     # extract ROOT from /proc/cmdline
@@ -1248,7 +1257,7 @@ prepare_ubuntu_core() {
     done
 
     echo "Ensure the snapd snap is available"
-    if os.query is-core18 || os.query is-core20; then
+    if os.query is-core18 || os.query is-core20 || os.query is-core22; then
         if ! snap list snapd; then
             echo "snapd snap on core18 is missing"
             snap list
@@ -1263,6 +1272,8 @@ prepare_ubuntu_core() {
             rsync_snap="test-snapd-rsync-core18"
         elif os.query is-core20; then
             rsync_snap="test-snapd-rsync-core20"
+        elif os.query is-core22; then
+            rsync_snap="test-snapd-rsync-core22"
         fi
         snap install --devmode --edge "$rsync_snap"
         snap alias "$rsync_snap".rsync rsync
@@ -1274,7 +1285,7 @@ prepare_ubuntu_core() {
 
     echo "Ensure the core snap is cached"
     # Cache snaps
-    if os.query is-core18 || os.query is-core20; then
+    if os.query is-core18 || os.query is-core20 || os.query is-core22; then
         if snap list core >& /dev/null; then
             echo "core snap on core18 should not be installed yet"
             snap list
@@ -1285,6 +1296,10 @@ prepare_ubuntu_core() {
             cache_snaps test-snapd-sh-core18
         fi
         if os.query is-core20; then
+            cache_snaps test-snapd-sh-core20
+        fi
+        if os.query is-core22; then
+            # TODO core22 version of sh
             cache_snaps test-snapd-sh-core20
         fi
     fi

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -1299,11 +1299,7 @@ prepare_ubuntu_core() {
             cache_snaps test-snapd-sh-core20
         fi
         if os.query is-core22; then
-            # TODO core22 version of sh
-            # there exists a core22 of this snap in --edge
-            # but have to change logic of cache_snaps to use
-            # edge instead, so we are waiting a bit
-            cache_snaps test-snapd-sh-core20
+            cache_snaps test-snapd-sh-core22
         fi
     fi
 
@@ -1333,6 +1329,12 @@ cache_snaps(){
     # Download each of the snaps we want to pre-cache. Note that `snap download`
     # a quick no-op if the file is complete.
     for snap_name in "$@"; do
+        # TODO remove this once test-snapd-sh-core22 leaves edge
+        if os.query is-core22; then
+            snap download --edge "$snap_name"
+        else
+            snap download "$snap_name"
+        fi
         snap download "$snap_name"
 
         # Copy all of the snaps back to the spool directory. From there we

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -56,9 +56,8 @@ ensure_jq() {
         snap install --devmode --edge jq-core20
         snap alias jq-core20.jq jq
     elif os.query is-core22; then
-        # TODO core22 snap of jq needs to be made
-        snap install --devmode --edge jq-core20
-        snap alias jq-core20.jq jq
+        snap install --devmode --edge jq-core22
+        snap alias jq-core22.jq jq
     else
         snap install --devmode jq
     fi
@@ -81,6 +80,7 @@ disable_refreshes() {
     snap remove --purge jq
     snap remove --purge jq-core18
     snap remove --purge jq-core20
+    snap remove --purge jq-core22
 }
 
 setup_systemd_snapd_overrides() {
@@ -1300,6 +1300,9 @@ prepare_ubuntu_core() {
         fi
         if os.query is-core22; then
             # TODO core22 version of sh
+            # there exists a core22 of this snap in --edge
+            # but have to change logic of cache_snaps to use
+            # edge instead, so we are waiting a bit
             cache_snaps test-snapd-sh-core20
         fi
     fi

--- a/tests/lib/state.sh
+++ b/tests/lib/state.sh
@@ -122,7 +122,7 @@ restore_snapd_lib() {
     # Synchronize snaps, seed and cache directories. The this is done separately in order to avoid copying
     # the snap files due to it is a heavy task and take most of the time of the restore phase.
     rsync -av --delete "$SNAPD_STATE_PATH"/snapd-lib/snaps /var/lib/snapd
-    if os.query is-core20 ; then
+    if os.query is-core20 || os.query is-core22; then
         # TODO:UC20: /var/lib/snapd/seed is a read only bind mount, use the rw
         # mount or later mount seed as needed
         rsync -av --delete "$SNAPD_STATE_PATH"/snapd-lib/seed/ /run/mnt/ubuntu-seed/

--- a/tests/lib/systems.sh
+++ b/tests/lib/systems.sh
@@ -10,6 +10,9 @@ get_snap_for_system(){
         ubuntu-core-20-*)
             echo "${snap}-core20"
             ;;
+        ubuntu-core-22-*)
+            echo "${snap}-core22"
+            ;;
         *)
             echo "$snap"
             ;;
@@ -23,6 +26,9 @@ get_core_for_system(){
             ;;
         ubuntu-core-20-*)
             echo "core20"
+            ;;
+        ubuntu-core-22-*)
+            echo "core22"
             ;;
         *)
             echo "core"

--- a/tests/repack-kernel/task.yaml
+++ b/tests/repack-kernel/task.yaml
@@ -1,0 +1,53 @@
+summary: tests for the repack-kernel tool
+
+# ubuntu-core-initramfs seems to be only available on ubuntu-20.04
+systems: [ubuntu-20.04-64]
+
+prepare: |
+    # install dependencies
+    apt update -yqq
+    apt install snapd
+
+execute: |
+    repack-kernel | MATCH 'usage: repack-kernel <command> <opts>'
+    repack-kernel -h | MATCH 'usage: repack-kernel <command> <opts>'
+    repack-kernel --help | MATCH 'usage: repack-kernel <command> <opts>'
+
+    # verify error when calling without an invalid commnnd
+    test "$(repack-kernel invalid-command 2>&1 | grep -c "no such command: invalid-command")" -eq 1
+
+    # verify that an error is thrown when calling commands without arguments
+    test "$(repack-kernel extract 2>&1 | grep -c "invalid arguments for extract")" -eq 1
+    test "$(repack-kernel extract "upstream-pc-kernel.snap" 2>&1 | grep -c "invalid arguments for extract")" -eq 1
+    test "$(repack-kernel prepare 2>&1 | grep -c "missing target for prepare")" -eq 1
+    test "$(repack-kernel cull-modules 2>&1 | grep -c "missing target for cull-modules")" -eq 1
+    test "$(repack-kernel cull-firmware 2>&1 | grep -c "missing target for cull-firmware")" -eq 1
+
+    # download the kernel snap
+    snap download pc-kernel --channel=20/stable --basename=upstream-pc-kernel
+
+    # setup dependencies
+    repack-kernel setup
+
+    # extract the kernel snap, including extracting the initrd from the kernel.efi
+    kerneldir=/tmp/kernel-workdir
+    repack-kernel extract "upstream-pc-kernel.snap" "$kerneldir"
+
+    # cull modules and firmware
+    repack-kernel cull-modules "$kerneldir"
+    repack-kernel cull-firmware "$kerneldir"
+
+    # repack the initrd into the kernel.efi
+    repack-kernel prepare "$kerneldir"
+
+    # repack the kernel snap itself
+    repack-kernel pack "$kerneldir" --filename=pc-kernel.snap
+    rm -rf "$kerneldir"
+
+    if ![ -f "pc-kernel.snap" ]; then
+        echo "Repack failed, pc-kernel.snap was not created"
+        exit 1
+    fi
+
+restore: |
+    apt remove snapd -yqq

--- a/tests/smoke/install/task.yaml
+++ b/tests/smoke/install/task.yaml
@@ -44,9 +44,9 @@ execute: |
     snap changes | MATCH 'Install "test-snapd-sh" snap'
 
     echo "Ensure different bases work"
-    for base in core18 core20; do
-        # no core20 snap for i386
-        if [ "$base" = "core20" ] && [ "$(uname -m)" = i686 ]; then
+    for base in core18 core20 core22; do
+        # no core20 or core22 snap for i386
+        if ([ "$base" = "core20" ] || [ "$base" = "core22" ]) && [ "$(uname -m)" = i686 ]; then
             continue
         fi
 

--- a/tools/repack-kernel
+++ b/tools/repack-kernel
@@ -1,0 +1,231 @@
+#!/bin/bash
+set -e
+
+if [ -n "$D" ]; then
+    set -x
+fi
+
+show_help() {
+    echo "usage: repack-kernel <command> <opts>"
+    echo ""
+    echo "handle extraction of the kernel snap to a workspace directory, and later"
+    echo "repacking it back to a snap."
+    echo ""
+    echo "   repack-kernel setup                        - setup system dependencies"
+    echo "   repack-kernel extract <snap-file> <target> - extract under <target> workspace tree"
+    echo "   repack-kernel prepare <target>             - prepare initramfs & kernel for repacking"
+    echo "   repack-kernel pack <target>                - pack the kernel"
+    echo "   repack-kernel cull-firmware <target>       - remove unnecessary firmware"
+    echo "   repack-kernel cull-modules <target>        - remove unnecessary modules"
+    echo ""
+}
+
+setup() {
+    if [ "$UID" != "0" ]; then
+        echo "run as root (only this command)"
+        exit 1
+    fi
+
+    # carries ubuntu-core-initframfs
+    add-apt-repository ppa:snappy-dev/image -y
+    apt update -y
+    
+    if ! dpkg -s ubuntu-core-initramfs >/dev/null 2>&1; then
+        if ! apt install ubuntu-core-initramfs -y; then
+            echo "ubuntu-core-initramfs was not available in deb repository!"
+            exit 1
+        fi
+    fi
+}
+
+get_kver() {
+    local kerneldir="$1"
+    (
+        cd "$kerneldir"
+        #shellcheck disable=SC2010
+        ls "config"-* | grep -Po 'config-\K.*'
+    )
+}
+
+extract() {
+    local snap_file="$1"
+    local target="$2"
+
+    if [ -z "$target" ] || [ -z "$snap_file" ]; then
+        echo "repack-kernel: invalid arguments for extract"
+        exit 1
+    fi
+
+    target=$(realpath "$target")
+
+    mkdir -p "$target" "$target/work" "$target/backup"
+
+    # kernel snap is huge, unpacking to current dir
+    unsquashfs -d "$target/kernel" "$snap_file"
+
+    kver="$(get_kver "$target/kernel")"
+
+    # repack initrd magic, beware
+    # assumptions: initrd is compressed with LZ4, cpio block size 512, microcode
+    # at the beginning of initrd image
+
+    # XXX: ideally we should unpack the initrd, replace snap-boostrap and
+    # repack it using ubuntu-core-initramfs --skeleton=<unpacked> this does not
+    # work and the rebuilt kernel.efi panics unable to start init, but we
+    # still need the unpacked initrd to get the right kernel modules
+    objcopy -j .initrd -O binary "$target"/kernel/kernel.efi "$target/work/initrd"
+
+    # copy out the kernel image for create-efi command
+    objcopy -j .linux -O binary "$target"/kernel/kernel.efi "$target/work/vmlinuz-$kver"
+
+    cp -a "$target"/kernel/kernel.efi "$target/backup/"
+
+    # this works on 20.04 but not on 18.04
+    unmkinitramfs "$target"/work/initrd "$target"/work/unpacked-initrd
+    
+    # copy the unpacked initrd to use as the target skeleton
+    cp -ar "$target/work/unpacked-initrd" "$target/skeleton"
+
+    echo "prepared workspace at $target"
+    echo "  kernel:              $target/kernel ($kver)"
+    echo "  kernel.efi backup:   $target/backup/kernel.efi"
+    echo "  temporary artifacts: $target/work"
+    echo "  initramfs skeleton:  $target/skeleton"
+
+}
+
+prepare() {
+    local target="$1"
+
+    if [ -z "$target" ]; then
+        echo "repack-kernel: missing target for prepare"
+        exit 1
+    fi
+
+    target=$(realpath "$target")
+    local kver="$(get_kver "$target/kernel")"
+
+    (
+        # all the skeleton edits go to a local copy of distro directory
+        local skeletondir="$target/skeleton"
+
+        cd "$target/work"
+        # XXX: need to be careful to build an initrd using the right kernel
+        # modules from the unpacked initrd, rather than the host which may be
+        # running a different kernel
+        (
+            # accommodate assumptions about tree layout, use the unpacked initrd
+            # to pick up the right modules
+            cd unpacked-initrd/main
+            ubuntu-core-initramfs create-initrd \
+                                  --kernelver "$kver" \
+                                  --skeleton "$skeletondir" \
+                                  --feature main \
+                                  --kerneldir "lib/modules/$kver" \
+                                  --output "$target/work/repacked-initrd"
+        )
+
+        # assumes all files are named <name>-$kver
+        ubuntu-core-initramfs create-efi \
+                              --kernelver "$kver" \
+                              --initrd repacked-initrd \
+                              --kernel vmlinuz \
+                              --output repacked-kernel.efi
+
+        cp "repacked-kernel.efi-$kver" "$target/kernel/kernel.efi"
+
+        # XXX: needed?
+        chmod +x "$target/kernel/kernel.efi"
+    )
+}
+
+cull_firmware() {
+    local target="$1"
+
+    if [ -z "$target" ]; then
+        echo "repack-kernel: missing target for cull-firmware"
+        exit 1
+    fi
+    (
+        # XXX: drop ~450MB+ of firmware which should not be needed in under qemu
+        # or the cloud system
+        rm -rf "$target"/kernel/firmware/*
+    )
+}
+
+cull_modules() {
+    local target="$1"
+
+    if [ -z "$target" ]; then
+        echo "repack-kernel: missing target for cull-modules"
+        exit 1
+    fi
+
+    target="$(realpath $target)"
+    local kver="$(get_kver "$target/kernel")"
+
+    (
+        cd "$target/kernel"
+        # drop unnecessary modules
+        awk '{print $1}' <  /proc/modules  | sort > "$target/work/current-modules"
+        #shellcheck disable=SC2044
+        for m in $(find modules/ -name '*.ko'); do
+            noko=$(basename "$m"); noko="${noko%.ko}"
+            if echo "$noko" | grep -f "$target/work/current-modules" -q ; then
+                echo "keeping $m - $noko"
+            else
+                rm -f "$m"
+            fi
+        done
+
+        # depmod assumes that /lib/modules/$kver is under basepath
+        mkdir -p fake/lib
+        ln -s "$PWD/modules" fake/lib/modules
+        depmod -b "$PWD/fake" -A -v "$kver"
+        rm -rf fake
+    )
+}
+
+pack() {
+    local target="$1"
+
+    if [ -z "$target" ]; then
+        echo "repack-kernel: missing target for pack"
+        exit 1
+    fi
+    snap pack "${@:2}" "$target/kernel" 
+}
+
+main() {
+    if [ $# -eq 0 ]; then
+        show_help
+        exit 0
+    fi
+
+    local subcommand="$1"
+    local action=
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            -h|--help)
+                show_help
+                exit 0
+                ;;
+            *)
+                action=$(echo "$subcommand" | tr '-' '_')
+                shift
+                break
+                ;;
+        esac
+    done
+
+    if [ -z "$(declare -f "$action")" ]; then
+        echo "repack-kernel: no such command: $subcommand" >&2
+        show_help
+        exit 1
+    fi
+
+    "$action" "$@"
+}
+
+main "$@"
+


### PR DESCRIPTION
This is a PR to get smoke tests up and running for core22. 

There are some TODOs in this as some core22 snaps are not out of edge. And I had to update the snapd-testing-tools subtree to get the new commits for is-core22 etc.