### PR TITLE
asserts: first-class support for formatting/encoding signatory-id

### DIFF
--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -909,7 +909,7 @@ func assemble(headers map[string]interface{}, body, content, signature []byte) (
 	}
 
 	if !utf8.Valid(body) {
-		return nil, fmt.Errorf("body is not utf8")
+		return nil, fmt.Errorf("assertion body is not utf8")
 	}
 
 	if _, err := checkDigest(headers, "sign-key-sha3-384", crypto.SHA3_384); err != nil {

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -873,11 +873,11 @@ func Assemble(headers map[string]interface{}, body, content, signature []byte) (
 	return assemble(headers, body, content, signature)
 }
 
-func checkAuthority(assertType *AssertionType, headers map[string]interface{}) (hasSignatoryID bool, err error) {
-	_, hasSignatoryID = headers["signatory-id"]
+func checkAuthority(_ *AssertionType, headers map[string]interface{}) (hasSignatoryID bool, err error) {
 	if _, err := checkNotEmptyString(headers, "authority-id"); err != nil {
 		return false, err
 	}
+	_, hasSignatoryID = headers["signatory-id"]
 	if hasSignatoryID {
 		if _, err := checkNotEmptyString(headers, "signatory-id"); err != nil {
 			return false, err
@@ -887,12 +887,10 @@ func checkAuthority(assertType *AssertionType, headers map[string]interface{}) (
 }
 
 func checkNoAuthority(assertType *AssertionType, headers map[string]interface{}) error {
-	_, ok := headers["authority-id"]
-	if ok {
+	if _, ok := headers["authority-id"]; ok {
 		return fmt.Errorf("%q assertion cannot have authority-id set", assertType.Name)
 	}
-	_, ok = headers["signatory-id"]
-	if ok {
+	if _, ok := headers["signatory-id"]; ok {
 		return fmt.Errorf("%q assertion cannot have signatory-id set", assertType.Name)
 	}
 	return nil

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -44,6 +44,7 @@ var MetaHeaders = [...]string{
 	"type",
 	"format",
 	"authority-id",
+	"signatory-id",
 	"revision",
 	"body-length",
 	"sign-key-sha3-384",
@@ -872,6 +873,31 @@ func Assemble(headers map[string]interface{}, body, content, signature []byte) (
 	return assemble(headers, body, content, signature)
 }
 
+func checkAuthority(assertType *AssertionType, headers map[string]interface{}) (hasSignatoryID bool, err error) {
+	_, hasSignatoryID = headers["signatory-id"]
+	if _, err := checkNotEmptyString(headers, "authority-id"); err != nil {
+		return false, err
+	}
+	if hasSignatoryID {
+		if _, err := checkNotEmptyString(headers, "signatory-id"); err != nil {
+			return false, err
+		}
+	}
+	return hasSignatoryID, nil
+}
+
+func checkNoAuthority(assertType *AssertionType, headers map[string]interface{}) error {
+	_, ok := headers["authority-id"]
+	if ok {
+		return fmt.Errorf("%q assertion cannot have authority-id set", assertType.Name)
+	}
+	_, ok = headers["signatory-id"]
+	if ok {
+		return fmt.Errorf("%q assertion cannot have signatory-id set", assertType.Name)
+	}
+	return nil
+}
+
 // assemble is the internal variant of Assemble, assumes headers are already checked for supported types
 func assemble(headers map[string]interface{}, body, content, signature []byte) (Assertion, error) {
 	length, err := checkIntWithDefault(headers, "body-length", 0)
@@ -900,13 +926,12 @@ func assemble(headers map[string]interface{}, body, content, signature []byte) (
 	}
 
 	if assertType.flags&noAuthority == 0 {
-		if _, err := checkNotEmptyString(headers, "authority-id"); err != nil {
+		if _, err := checkAuthority(assertType, headers); err != nil {
 			return nil, fmt.Errorf("assertion: %v", err)
 		}
 	} else {
-		_, ok := headers["authority-id"]
-		if ok {
-			return nil, fmt.Errorf("%q assertion cannot have authority-id set", assertType.Name)
+		if err := checkNoAuthority(assertType, headers); err != nil {
+			return nil, err
 		}
 	}
 
@@ -975,14 +1000,15 @@ func assembleAndSign(assertType *AssertionType, headers map[string]interface{}, 
 	finalHeaders["body-length"] = strconv.Itoa(bodyLength)
 	finalHeaders["sign-key-sha3-384"] = privKey.PublicKey().ID()
 
+	var hasSignatoryID bool
 	if withAuthority {
-		if _, err := checkNotEmptyString(finalHeaders, "authority-id"); err != nil {
+		hasSignatoryID, err = checkAuthority(assertType, finalHeaders)
+		if err != nil {
 			return nil, err
 		}
 	} else {
-		_, ok := finalHeaders["authority-id"]
-		if ok {
-			return nil, fmt.Errorf("%q assertion cannot have authority-id set", assertType.Name)
+		if err := checkNoAuthority(assertType, finalHeaders); err != nil {
+			return nil, err
 		}
 	}
 
@@ -1020,6 +1046,9 @@ func assembleAndSign(assertType *AssertionType, headers map[string]interface{}, 
 
 	if withAuthority {
 		writeHeader(buf, finalHeaders, "authority-id")
+		if hasSignatoryID && finalHeaders["authority-id"] != finalHeaders["signatory-id"] {
+			writeHeader(buf, finalHeaders, "signatory-id")
+		}
 	}
 
 	if revision > 0 {
@@ -1031,6 +1060,7 @@ func assembleAndSign(assertType *AssertionType, headers map[string]interface{}, 
 		"type":              true,
 		"format":            true,
 		"authority-id":      true,
+		"signatory-id":      true,
 		"revision":          true,
 		"body-length":       true,
 		"sign-key-sha3-384": true,

--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -366,6 +366,7 @@ func (as *assertsSuite) TestDecodeInvalid(c *C) {
 		{"body-length: 5", "body-length: 3", "assertion body length and declared body-length don't match: 5 != 3"},
 		{"authority-id: auth-id\n", "", `assertion: "authority-id" header is mandatory`},
 		{"authority-id: auth-id\n", "authority-id: \n", `assertion: "authority-id" header should not be empty`},
+		{"authority-id: auth-id\n", "authority-id: auth-id\nsignatory-id: \n", `assertion: "signatory-id" header should not be empty`},
 		{keyIDHdr, "", `assertion: "sign-key-sha3-384" header is mandatory`},
 		{keyIDHdr, "sign-key-sha3-384: \n", `assertion: "sign-key-sha3-384" header should not be empty`},
 		{keyIDHdr, "sign-key-sha3-384: $\n", `assertion: "sign-key-sha3-384" header cannot be decoded: .*`},
@@ -403,6 +404,16 @@ func (as *assertsSuite) TestDecodeNoAuthorityInvalid(c *C) {
 
 	_, err := asserts.Decode([]byte(invalid))
 	c.Check(err, ErrorMatches, `"test-only-no-authority" assertion cannot have authority-id set`)
+
+	invalid = "type: test-only-no-authority\n" +
+		"signatory-id: auth-id1\n" +
+		"hdr: FOO\n" +
+		"sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij" +
+		"\n\n" +
+		"openpgp c2ln"
+
+	_, err = asserts.Decode([]byte(invalid))
+	c.Check(err, ErrorMatches, `"test-only-no-authority" assertion cannot have signatory-id set`)
 }
 
 func checkContent(c *C, a asserts.Assertion, encoded string) {
@@ -688,6 +699,41 @@ func (as *assertsSuite) TestSignFormatSanityEmptyBody(c *C) {
 	c.Check(err, IsNil)
 }
 
+func (as *assertsSuite) TestSignFormatSanitySignatoryId(c *C) {
+	headers := map[string]interface{}{
+		"authority-id": "auth-id1",
+		"primary-key":  "0",
+		"signatory-id": "delegated-auth-id",
+	}
+	a, err := asserts.AssembleAndSignInTest(asserts.TestOnlyType, headers, nil, testPrivKey1)
+	c.Assert(err, IsNil)
+
+	b := asserts.Encode(a)
+	c.Check(bytes.HasPrefix(b, []byte(`type: test-only
+authority-id: auth-id1
+signatory-id: delegated-auth-id
+`)), Equals, true)
+
+	_, err = asserts.Decode(b)
+	c.Check(err, IsNil)
+}
+
+func (as *assertsSuite) TestSignFormatSanitySignatoryIdCoalesce(c *C) {
+	headers := map[string]interface{}{
+		"authority-id": "auth-id1",
+		"primary-key":  "0",
+		"signatory-id": "auth-id1",
+	}
+	a, err := asserts.AssembleAndSignInTest(asserts.TestOnlyType, headers, nil, testPrivKey1)
+	c.Assert(err, IsNil)
+
+	b := asserts.Encode(a)
+	c.Check(bytes.Contains(b, []byte("signatory-id:")), Equals, false)
+
+	_, err = asserts.Decode(b)
+	c.Check(err, IsNil)
+}
+
 func (as *assertsSuite) TestSignFormatSanityNonEmptyBody(c *C) {
 	headers := map[string]interface{}{
 		"authority-id": "auth-id1",
@@ -924,6 +970,13 @@ func (as *assertsSuite) TestSignWithoutAuthorityMisuse(c *C) {
 			"hdr":          "FOO",
 		}, nil, testPrivKey1)
 	c.Check(err, ErrorMatches, `"test-only-no-authority" assertion cannot have authority-id set`)
+
+	_, err = asserts.SignWithoutAuthority(asserts.TestOnlyNoAuthorityType,
+		map[string]interface{}{
+			"signatory-id": "auth-id1",
+			"hdr":          "FOO",
+		}, nil, testPrivKey1)
+	c.Check(err, ErrorMatches, `"test-only-no-authority" assertion cannot have signatory-id set`)
 }
 
 func (ss *serialSuite) TestSignatureCheckError(c *C) {

--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -384,7 +384,7 @@ func (as *assertsSuite) TestDecodeInvalid(c *C) {
 		{"primary-key: abc\n", "", `assertion test-only: "primary-key" header is mandatory`},
 		{"primary-key: abc\n", "primary-key:\n  - abc\n", `assertion test-only: "primary-key" header must be a string`},
 		{"primary-key: abc\n", "primary-key: a/c\n", `assertion test-only: "primary-key" primary key header cannot contain '/'`},
-		{"abcde", "ab\xffde", "body is not utf8"},
+		{"abcde", "ab\xffde", "assertion body is not utf8"},
 	}
 
 	for _, test := range invalidAssertTests {

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -474,6 +474,17 @@ func (safs *signAddFindSuite) TestSignMissingAuthorityId(c *C) {
 	c.Check(a1, IsNil)
 }
 
+func (safs *signAddFindSuite) TestSignInvalidSignatoryID(c *C) {
+	headers := map[string]interface{}{
+		"authority-id": "auth-id1",
+		"signatory-id": []interface{}{"foo"},
+		"primary-key":  "a",
+	}
+	a1, err := safs.signingDB.Sign(asserts.TestOnlyType, headers, nil, safs.signingKeyID)
+	c.Assert(err, ErrorMatches, `"signatory-id" header must be a string`)
+	c.Check(a1, IsNil)
+}
+
 func (safs *signAddFindSuite) TestSignMissingPrimaryKey(c *C) {
 	headers := map[string]interface{}{
 		"authority-id": "canonical",


### PR DESCRIPTION
together with checks for it