### PR TITLE
asserts: remove unused function, fix for linter

### DIFF
--- a/asserts/header_checks.go
+++ b/asserts/header_checks.go
@@ -180,10 +180,6 @@ func checkRFC3339DateWhat(m map[string]interface{}, name, what string) (time.Tim
 	return date, nil
 }
 
-func checkRFC3339DateWithDefault(headers map[string]interface{}, name string, defl time.Time) (time.Time, error) {
-	return checkRFC3339DateWithDefaultWhat(headers, name, "header", defl)
-}
-
 func checkRFC3339DateWithDefaultWhat(m map[string]interface{}, name, what string, defl time.Time) (time.Time, error) {
 	value, ok := m[name]
 	if !ok {


### PR DESCRIPTION
this was flagged by deadcode/unused.

there is no obvious future use case for this anymore so I'm removing it
but this will not always be clear cut with header_checks.go functions
which is a growing helper library
