### PR TITLE
tests/main/uc20-create-partitions: add debugging information

### DIFF
--- a/tests/lib/uc20-create-partitions/main.go
+++ b/tests/lib/uc20-create-partitions/main.go
@@ -23,6 +23,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"runtime/pprof"
+	"time"
 
 	"github.com/jessevdk/go-flags"
 
@@ -77,6 +79,16 @@ func main() {
 	if args.Encrypt {
 		encryptionType = secboot.EncryptionTypeLUKS
 	}
+
+	go func() {
+		// wait for 3 minutes in case we get hung
+		time.Sleep(3 * time.Minute)
+
+		fmt.Println("program is stuck for 3 minutes, all go routines:")
+		pprof.Lookup("goroutine").WriteTo(os.Stdout, 1)
+
+		os.Exit(1)
+	}()
 
 	options := install.Options{
 		Mount:          args.Mount,

--- a/tests/main/uc20-create-partitions/task.yaml
+++ b/tests/main/uc20-create-partitions/task.yaml
@@ -153,6 +153,7 @@ execute: |
     cp gadget.yaml.backup gadget-dir/meta/gadget.yaml
 
     echo "Ensure we can deploy with mounting"
+    date --utc # for debugging hangs
     uc20-create-partitions --mount ./gadget-dir "$kerneldir" "$LOOP"
     sfdisk -l "$LOOP" | MATCH "${LOOP}p1 .* 1M\s* BIOS boot"
     sfdisk -l "$LOOP" | MATCH "${LOOP}p2 .* 1\.2G\s* EFI System"


### PR DESCRIPTION
It occurred to me that what might be happening when we see this test fail is
not that networking has disappeared and thus we lose the connection to the
spread machine, but rather than we are stuck/hung/deadlocked in
uc20-create-partitions.

So add some debug output there if we get stuck for 3 minutes. This should be
plenty long enough to actually run the test, but less than the time it takes
for the spread connection to time out.

For reference, the uc20-create-partitions-encrypt variant of the test, which 
should take the longest to execute, takes less than 2 minutes to execute:

```
2022-02-11 22:25:25 Preparing google:ubuntu-20.04-64:tests/main/uc20-create-partitions-encrypt (feb112148-627987)...
...
2022-02-11 22:25:33 Executing google:ubuntu-20.04-64:tests/main/uc20-create-partitions-encrypt (feb112148-627987) (274/566)...
...
2022-02-11 22:26:21 Restoring google:ubuntu-20.04-64:tests/main/uc20-create-partitions-encrypt (feb112148-627987)...
```