### PR TITLE
testutil: add generic mocking helpers

### DIFF
--- a/osutil/export_test.go
+++ b/osutil/export_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/snapcore/snapd/osutil/sys"
 	"github.com/snapcore/snapd/strutil"
+	"github.com/snapcore/snapd/testutil"
 )
 
 var (
@@ -194,12 +195,9 @@ func MockEtcFstab(text string) (restore func()) {
 
 // MockUname mocks syscall.Uname as used by MachineName and KernelVersion
 func MockUname(f func(*syscall.Utsname) error) (restore func()) {
-	old := syscallUname
+	restore = testutil.BackupBeforeMocking(&syscallUname)
 	syscallUname = f
-
-	return func() {
-		syscallUname = old
-	}
+	return
 }
 
 var (

--- a/osutil/export_test.go
+++ b/osutil/export_test.go
@@ -195,9 +195,9 @@ func MockEtcFstab(text string) (restore func()) {
 
 // MockUname mocks syscall.Uname as used by MachineName and KernelVersion
 func MockUname(f func(*syscall.Utsname) error) (restore func()) {
-	restore = testutil.BackupBeforeMocking(&syscallUname)
+	r := testutil.Backup(&syscallUname)
 	syscallUname = f
-	return
+	return r
 }
 
 var (

--- a/overlord/export_test.go
+++ b/overlord/export_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/overlord/storecontext"
 	"github.com/snapcore/snapd/store"
+	"github.com/snapcore/snapd/testutil"
 )
 
 var (
@@ -43,17 +44,11 @@ func MockEnsureInterval(d time.Duration) (restore func()) {
 
 // MockPruneInterval sets the overlord prune interval for tests.
 func MockPruneInterval(prunei, prunew, abortw time.Duration) (restore func()) {
-	oldPruneInterval := pruneInterval
-	oldPruneWait := pruneWait
-	oldAbortWait := abortWait
+	r := testutil.BackupBeforeMocking(&pruneInterval, &pruneWait, &abortWait)
 	pruneInterval = prunei
 	pruneWait = prunew
 	abortWait = abortw
-	return func() {
-		pruneInterval = oldPruneInterval
-		pruneWait = oldPruneWait
-		abortWait = oldAbortWait
-	}
+	return r
 }
 
 // MockStateLockTimeout sets the overlord state lock timeout for the tests.

--- a/overlord/export_test.go
+++ b/overlord/export_test.go
@@ -44,7 +44,7 @@ func MockEnsureInterval(d time.Duration) (restore func()) {
 
 // MockPruneInterval sets the overlord prune interval for tests.
 func MockPruneInterval(prunei, prunew, abortw time.Duration) (restore func()) {
-	r := testutil.BackupBeforeMocking(&pruneInterval, &pruneWait, &abortWait)
+	r := testutil.Backup(&pruneInterval, &pruneWait, &abortWait)
 	pruneInterval = prunei
 	pruneWait = prunew
 	abortWait = abortw

--- a/testutil/base.go
+++ b/testutil/base.go
@@ -32,7 +32,7 @@ type BaseTest struct {
 	cleanupHandlers []func()
 }
 
-// SetUpTest prepares the cleanup
+// SetUpTest prepares the cleanup.
 func (s *BaseTest) SetUpTest(c *check.C) {
 	if len(s.cleanupHandlers) != 0 {
 		panic("BaseTest cleanup handlers were not consumed before a new test start, missing BaseTest.TearDownTest call?")
@@ -57,19 +57,19 @@ func (s *BaseTest) TearDownTest(c *check.C) {
 	s.cleanupHandlers = nil
 }
 
-// AddCleanup adds a new cleanup function to the test
+// AddCleanup adds a new cleanup function to the test.
 func (s *BaseTest) AddCleanup(f func()) {
 	s.cleanupHandlers = append(s.cleanupHandlers, f)
 }
 
-// BackupBeforeMocking backups the specified list of elements before further mocking
-func BackupBeforeMocking(mockablesByPtr ...interface{}) (restore func()) {
+// Backup the specified list of elements before further mocking.
+func Backup(mockablesByPtr ...interface{}) (restore func()) {
 	backup := backupMockables(mockablesByPtr)
 
 	return func() {
-		for idx, ptr := range mockablesByPtr {
+		for i, ptr := range mockablesByPtr {
 			mockedPtr := reflect.ValueOf(ptr)
-			mockedPtr.Elem().Set(backup[idx].Elem())
+			mockedPtr.Elem().Set(backup[i].Elem())
 		}
 	}
 }
@@ -77,16 +77,16 @@ func BackupBeforeMocking(mockablesByPtr ...interface{}) (restore func()) {
 func backupMockables(mockablesByPtr []interface{}) (backup []*reflect.Value) {
 	backup = make([]*reflect.Value, len(mockablesByPtr))
 
-	for idx, ptr := range mockablesByPtr {
+	for i, ptr := range mockablesByPtr {
 		mockedPtr := reflect.ValueOf(ptr)
 
 		if mockedPtr.Type().Kind() != reflect.Ptr {
-			panic("BackupBeforeMocking: each mockable must be passed by pointer!")
+			panic("Backup: each mockable must be passed by pointer!")
 		}
 
 		saved := reflect.New(mockedPtr.Elem().Type())
 		saved.Elem().Set(mockedPtr.Elem())
-		backup[idx] = &saved
+		backup[i] = &saved
 	}
 	return backup
 }

--- a/testutil/mocking_test.go
+++ b/testutil/mocking_test.go
@@ -1,0 +1,62 @@
+package testutil_test
+
+import (
+	"fmt"
+
+	"github.com/snapcore/snapd/testutil"
+)
+
+func ExampleBackupBeforeMocking_mockingSimple() {
+
+	mockable := func() {
+		fmt.Println("Original")
+	}
+
+	// Mock
+	restore := testutil.BackupBeforeMocking(&mockable)
+	mockable = func() {
+		fmt.Println("Mock")
+	}
+
+	// Restore
+	restore()
+
+	mockable()
+
+	// Output: Original
+
+}
+
+func ExampleBackupBeforeMocking_mockingMultiple() {
+	mockableFunc := func() {
+		fmt.Println("Original function")
+	}
+	mockableNumber := 17.53
+	mockableString := "Original string"
+	mockableStruct := struct {
+		first  string
+		second string
+	}{
+		first:  "Original",
+		second: "struct",
+	}
+
+	// Mock
+	restore := testutil.BackupBeforeMocking(&mockableFunc, &mockableNumber, &mockableString, &mockableStruct)
+	mockableFunc = func() {
+		fmt.Println("Mock")
+	}
+	mockableNumber = 37
+	mockableString = "Mock"
+	mockableStruct.first, mockableStruct.second = "mocked", "value"
+
+	// Restore
+	restore()
+
+	mockableFunc()
+	fmt.Println(mockableNumber, mockableString, mockableStruct)
+
+	// Output:
+	// Original function
+	// 17.53 Original string {Original struct}
+}

--- a/testutil/mocking_test.go
+++ b/testutil/mocking_test.go
@@ -6,14 +6,14 @@ import (
 	"github.com/snapcore/snapd/testutil"
 )
 
-func ExampleBackupBeforeMocking_mockingSimple() {
+func ExampleBackup_mockingSimple() {
 
 	mockable := func() {
 		fmt.Println("Original")
 	}
 
 	// Mock
-	restore := testutil.BackupBeforeMocking(&mockable)
+	restore := testutil.Backup(&mockable)
 	mockable = func() {
 		fmt.Println("Mock")
 	}
@@ -24,10 +24,9 @@ func ExampleBackupBeforeMocking_mockingSimple() {
 	mockable()
 
 	// Output: Original
-
 }
 
-func ExampleBackupBeforeMocking_mockingMultiple() {
+func ExampleBackup_mockingMultiple() {
 	mockableFunc := func() {
 		fmt.Println("Original function")
 	}
@@ -42,7 +41,7 @@ func ExampleBackupBeforeMocking_mockingMultiple() {
 	}
 
 	// Mock
-	restore := testutil.BackupBeforeMocking(&mockableFunc, &mockableNumber, &mockableString, &mockableStruct)
+	restore := testutil.Backup(&mockableFunc, &mockableNumber, &mockableString, &mockableStruct)
 	mockableFunc = func() {
 		fmt.Println("Mock")
 	}


### PR DESCRIPTION
testutil: add generic mocking helpers

Two generic mocking helpers have been added:
- `testutil.MockAny()` - allows mocking of any mutable object with a compliant substitute,
  it also return a restore function that shall be called to restore the original value

- `testutil.(*BaseTest).MockAny()` - allows mocking of any mutable object with a compliant substitute,
  unlike the API above, this one takes care of restoring the original value on its own

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
