### PR TITLE
asserts,interfaces/policy: move and prepare DeviceScopeConstraint for reuse

### DIFF
--- a/asserts/constraint.go
+++ b/asserts/constraint.go
@@ -354,3 +354,66 @@ func (matcher altAttrMatcher) match(apath string, v interface{}, ctx *attrMatchi
 	}
 	return fmt.Errorf("no alternative%s matches: %v", apathDescr, firstErr)
 }
+
+// DeviceScopeConstraint specifies a constraint based on which brand
+// store, brand or model the device belongs to.
+type DeviceScopeConstraint struct {
+	Store []string
+	Brand []string
+	// Model is a list of precise "<brand>/<model>" constraints
+	Model []string
+}
+
+var (
+	validStoreID         = regexp.MustCompile("^[-A-Z0-9a-z_]+$")
+	validBrandSlashModel = regexp.MustCompile("^(" +
+		strings.Trim(validAccountID.String(), "^$") +
+		")/(" +
+		strings.Trim(validModel.String(), "^$") +
+		")$")
+	deviceScopeConstraints = map[string]*regexp.Regexp{
+		"on-store": validStoreID,
+		"on-brand": validAccountID,
+		// on-model constraints are of the form list of
+		// <brand>/<model> strings where <brand> are account
+		// IDs as they appear in the respective model assertion
+		"on-model": validBrandSlashModel,
+	}
+)
+
+func detectDeviceScopeConstraint(cMap map[string]interface{}) bool {
+	// for consistency and simplicity we support all of on-store,
+	// on-brand, and on-model to appear together. The interpretation
+	// layer will AND them as usual
+	for field := range deviceScopeConstraints {
+		if cMap[field] != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// compileDeviceScopeConstraint compiles a DeviceScopeConstraint out of cMap,
+// it returns nil and no error if there are no on-store/on-brand/on-model
+// constraints in cMap
+func compileDeviceScopeConstraint(cMap map[string]interface{}, context string) (constr *DeviceScopeConstraint, err error) {
+	if !detectDeviceScopeConstraint(cMap) {
+		return nil, nil
+	}
+	// initial map size of 2: we expect usual cases to have just one of the
+	// constraints or rarely 2
+	deviceConstr := make(map[string][]string, 2)
+	for field, validRegexp := range deviceScopeConstraints {
+		vals, err := checkStringListInMap(cMap, field, fmt.Sprintf("%s in %s", field, context), validRegexp)
+		if err != nil {
+			return nil, err
+		}
+		deviceConstr[field] = vals
+	}
+
+	return &DeviceScopeConstraint{
+		Store: deviceConstr["on-store"],
+		Brand: deviceConstr["on-brand"],
+		Model: deviceConstr["on-model"],
+	}, nil
+}

--- a/asserts/constraint_test.go
+++ b/asserts/constraint_test.go
@@ -544,3 +544,121 @@ foo: [{p: "zzz"}, {p: "/foo/y"}]
 `), nil)
 	c.Check(err, ErrorMatches, `field "foo\.0\.p" value "zzz" does not match \^\(/foo/\.\*\)\$`)
 }
+
+type deviceScopeConstraintSuite struct {
+	testutil.BaseTest
+}
+
+var _ = Suite(&deviceScopeConstraintSuite{})
+
+func (s *deviceScopeConstraintSuite) TestCompile(c *C) {
+	tests := []struct {
+		m   map[string]interface{}
+		exp *asserts.DeviceScopeConstraint
+		err string
+	}{
+		{m: nil, exp: nil},
+		{m: map[string]interface{}{"on-store": []interface{}{"foo", "bar"}}, exp: &asserts.DeviceScopeConstraint{Store: []string{"foo", "bar"}}},
+		{m: map[string]interface{}{"on-brand": []interface{}{"foo", "bar"}}, exp: &asserts.DeviceScopeConstraint{Brand: []string{"foo", "bar"}}},
+		{m: map[string]interface{}{"on-model": []interface{}{"foo/model1", "bar/model-2"}}, exp: &asserts.DeviceScopeConstraint{Model: []string{"foo/model1", "bar/model-2"}}},
+		{
+			m: map[string]interface{}{
+				"on-brand": []interface{}{"foo", "bar"},
+				"on-model": []interface{}{"foo/model1", "bar/model-2"},
+				"on-store": []interface{}{"foo", "bar"},
+			},
+			exp: &asserts.DeviceScopeConstraint{
+				Store: []string{"foo", "bar"},
+				Brand: []string{"foo", "bar"},
+				Model: []string{"foo/model1", "bar/model-2"},
+			},
+		},
+		{m: map[string]interface{}{"on-store": ""}, err: `on-store in constraint must be a list of strings`},
+		{m: map[string]interface{}{"on-brand": "foo"}, err: `on-brand in constraint must be a list of strings`},
+		{m: map[string]interface{}{"on-model": map[string]interface{}{"brand": "x"}}, err: `on-model in constraint must be a list of strings`},
+	}
+
+	for _, t := range tests {
+		dsc, err := asserts.CompileDeviceScopeConstraint(t.m, "constraint")
+		if t.err == "" {
+			c.Check(err, IsNil)
+			c.Check(dsc, DeepEquals, t.exp)
+		} else {
+			c.Check(err, ErrorMatches, t.err)
+			c.Check(dsc, IsNil)
+		}
+	}
+}
+
+func (s *deviceScopeConstraintSuite) TestValidOnStoreBrandModel(c *C) {
+	tests := []struct {
+		constr string
+		value  string
+		valid  bool
+	}{
+		{"on-store", "", false},
+		{"on-store", "foo", true},
+		{"on-store", "F_o-O88", true},
+		{"on-store", "foo!", false},
+		{"on-store", "foo.", false},
+		{"on-store", "foo/", false},
+		{"on-brand", "", false},
+		// custom set brands (length 2-28)
+		{"on-brand", "dwell", true},
+		{"on-brand", "Dwell", false},
+		{"on-brand", "dwell-88", true},
+		{"on-brand", "dwell_88", false},
+		{"on-brand", "dwell.88", false},
+		{"on-brand", "dwell:88", false},
+		{"on-brand", "dwell!88", false},
+		{"on-brand", "a", false},
+		{"on-brand", "ab", true},
+		{"on-brand", "0123456789012345678901234567", true},
+		// snappy id brands (fixed length 32)
+		{"on-brand", "01234567890123456789012345678", false},
+		{"on-brand", "012345678901234567890123456789", false},
+		{"on-brand", "0123456789012345678901234567890", false},
+		{"on-brand", "01234567890123456789012345678901", true},
+		{"on-brand", "abcdefghijklmnopqrstuvwxyz678901", true},
+		{"on-brand", "ABCDEFGHIJKLMNOPQRSTUVWCYZ678901", true},
+		{"on-brand", "ABCDEFGHIJKLMNOPQRSTUVWCYZ678901X", false},
+		{"on-brand", "ABCDEFGHIJKLMNOPQ!STUVWCYZ678901", false},
+		{"on-brand", "ABCDEFGHIJKLMNOPQ_STUVWCYZ678901", false},
+		{"on-brand", "ABCDEFGHIJKLMNOPQ-STUVWCYZ678901", false},
+		{"on-model", "", false},
+		{"on-model", "/", false},
+		{"on-model", "dwell/dwell1", true},
+		{"on-model", "dwell", false},
+		{"on-model", "dwell/", false},
+		{"on-model", "dwell//dwell1", false},
+		{"on-model", "dwell/-dwell1", false},
+		{"on-model", "dwell/dwell1-", false},
+		{"on-model", "dwell/dwell1-23", true},
+		{"on-model", "dwell/dwell1!", false},
+		{"on-model", "dwell/dwe_ll1", false},
+		{"on-model", "dwell/dwe.ll1", false},
+	}
+
+	check := func(constr, value string, valid bool) {
+		cMap := map[string]interface{}{
+			constr: []interface{}{value},
+		}
+
+		_, err := asserts.CompileDeviceScopeConstraint(cMap, "constraint")
+		if valid {
+			c.Check(err, IsNil, Commentf("%v", cMap))
+		} else {
+			c.Check(err, ErrorMatches, fmt.Sprintf(`%s in constraint contains an invalid element: %q`, constr, value), Commentf("%v", cMap))
+		}
+	}
+
+	for _, t := range tests {
+		check(t.constr, t.value, t.valid)
+
+		if t.constr == "on-brand" {
+			// reuse and double check all brands also in the context of on-model!
+
+			check("on-model", t.value+"/foo", t.valid)
+		}
+	}
+}

--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -321,6 +321,10 @@ func CompileAttrMatcher(constraints interface{}, allowedOperations []string) (fu
 	return domatch, nil
 }
 
+var (
+	CompileDeviceScopeConstraint = compileDeviceScopeConstraint
+)
+
 // ifacedecls tests
 var (
 	CompileAttributeConstraints = compileAttributeConstraints

--- a/asserts/ifacedecls.go
+++ b/asserts/ifacedecls.go
@@ -397,14 +397,14 @@ func baseCompileConstraints(context *subruleContext, cDef constraintsDef, target
 		}
 		target.setOnClassicConstraint(c)
 	}
-	if !detectDeviceScopeConstraint(cMap) {
+	dsc, err := compileDeviceScopeConstraint(cMap, context.String())
+	if err != nil {
+		return err
+	}
+	if dsc == nil {
 		defaultUsed++
 	} else {
-		c, err := compileDeviceScopeConstraint(cMap, context.String())
-		if err != nil {
-			return err
-		}
-		target.setDeviceScopeConstraint(c)
+		target.setDeviceScopeConstraint(dsc)
 	}
 	// checks whether defaults have been used for everything, which is not
 	// well-formed

--- a/asserts/ifacedecls_test.go
+++ b/asserts/ifacedecls_test.go
@@ -2141,6 +2141,7 @@ func (s *plugSlotRulesSuite) TestSlotRuleFeatures(c *C) {
 }
 
 func (s *plugSlotRulesSuite) TestValidOnStoreBrandModel(c *C) {
+	// more extensive testing is now done in deviceScopeConstraintSuite
 	tests := []struct {
 		constr string
 		value  string
@@ -2150,43 +2151,20 @@ func (s *plugSlotRulesSuite) TestValidOnStoreBrandModel(c *C) {
 		{"on-store", "foo", true},
 		{"on-store", "F_o-O88", true},
 		{"on-store", "foo!", false},
-		{"on-store", "foo.", false},
-		{"on-store", "foo/", false},
 		{"on-brand", "", false},
 		// custom set brands (length 2-28)
 		{"on-brand", "dwell", true},
 		{"on-brand", "Dwell", false},
 		{"on-brand", "dwell-88", true},
 		{"on-brand", "dwell_88", false},
-		{"on-brand", "dwell.88", false},
-		{"on-brand", "dwell:88", false},
-		{"on-brand", "dwell!88", false},
-		{"on-brand", "a", false},
-		{"on-brand", "ab", true},
 		{"on-brand", "0123456789012345678901234567", true},
 		// snappy id brands (fixed length 32)
 		{"on-brand", "01234567890123456789012345678", false},
-		{"on-brand", "012345678901234567890123456789", false},
-		{"on-brand", "0123456789012345678901234567890", false},
 		{"on-brand", "01234567890123456789012345678901", true},
-		{"on-brand", "abcdefghijklmnopqrstuvwxyz678901", true},
-		{"on-brand", "ABCDEFGHIJKLMNOPQRSTUVWCYZ678901", true},
-		{"on-brand", "ABCDEFGHIJKLMNOPQRSTUVWCYZ678901X", false},
-		{"on-brand", "ABCDEFGHIJKLMNOPQ!STUVWCYZ678901", false},
-		{"on-brand", "ABCDEFGHIJKLMNOPQ_STUVWCYZ678901", false},
-		{"on-brand", "ABCDEFGHIJKLMNOPQ-STUVWCYZ678901", false},
 		{"on-model", "", false},
-		{"on-model", "/", false},
 		{"on-model", "dwell/dwell1", true},
 		{"on-model", "dwell", false},
 		{"on-model", "dwell/", false},
-		{"on-model", "dwell//dwell1", false},
-		{"on-model", "dwell/-dwell1", false},
-		{"on-model", "dwell/dwell1-", false},
-		{"on-model", "dwell/dwell1-23", true},
-		{"on-model", "dwell/dwell1!", false},
-		{"on-model", "dwell/dwe_ll1", false},
-		{"on-model", "dwell/dwe.ll1", false},
 	}
 
 	check := func(constr, value string, valid bool) {

--- a/interfaces/policy/helpers.go
+++ b/interfaces/policy/helpers.go
@@ -26,7 +26,6 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
-	"github.com/snapcore/snapd/strutil"
 )
 
 // check helpers
@@ -88,40 +87,10 @@ func checkDeviceScope(c *asserts.DeviceScopeConstraint, model *asserts.Model, st
 	if c == nil {
 		return nil
 	}
-	if model == nil {
-		return fmt.Errorf("cannot match on-store/on-brand/on-model without model")
+	opts := asserts.DeviceScopeConstraintCheckOptions{
+		UseFriendlyStores: true,
 	}
-	if store != nil && store.Store() != model.Store() {
-		return fmt.Errorf("store assertion and model store must match")
-	}
-	if len(c.Store) != 0 {
-		if !strutil.ListContains(c.Store, model.Store()) {
-			mismatch := true
-			if store != nil {
-				for _, sto := range c.Store {
-					if strutil.ListContains(store.FriendlyStores(), sto) {
-						mismatch = false
-						break
-					}
-				}
-			}
-			if mismatch {
-				return fmt.Errorf("on-store mismatch")
-			}
-		}
-	}
-	if len(c.Brand) != 0 {
-		if !strutil.ListContains(c.Brand, model.BrandID()) {
-			return fmt.Errorf("on-brand mismatch")
-		}
-	}
-	if len(c.Model) != 0 {
-		brandModel := fmt.Sprintf("%s/%s", model.BrandID(), model.Model())
-		if !strutil.ListContains(c.Model, brandModel) {
-			return fmt.Errorf("on-model mismatch")
-		}
-	}
-	return nil
+	return c.Check(model, store, &opts)
 }
 
 func checkNameConstraints(c *asserts.NameConstraints, iface, which, name string) error {


### PR DESCRIPTION
this moves DeviceScopeConstraint to constraint.go and adds a Check method in preparation for reuse of DeviceScopeConstraint for assertion constraints from authority-delegation.
