### PR TITLE
tests: allow run spread tests using a private ppa

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -58,8 +58,12 @@ environment:
     NO_PROXY: "127.0.0.1"
     NEW_CORE_CHANNEL: '$(HOST: echo "$SPREAD_NEW_CORE_CHANNEL")'
     SRU_VALIDATION: '$(HOST: echo "${SPREAD_SRU_VALIDATION:-0}")'
-    # use the ppa_validation_name to install snapd from that ppa
+    # use the ppa_validation_name to install snapd from a public ppa
     PPA_VALIDATION_NAME: '$(HOST: echo "${SPREAD_PPA_VALIDATION_NAME:-}")'
+    # use the ppa_source_line and ppa_gpg_key to install snapd from a private ppa
+    PPA_SOURCE_LINE: '$(HOST: echo "${SPREAD_PPA_SOURCE_LINE:-}")'
+    PPA_GPG_KEY: '$(HOST: echo "${SPREAD_PPA_GPG_KEY:-}")'
+    # List the snaps which are cached
     PRE_CACHE_SNAPS: test-snapd-tools test-snapd-sh jq
     # always skip removing the rsync snap
     SKIP_REMOVE_SNAPS: '$(HOST: echo "${SPREAD_SKIP_REMOVE_SNAPS:-}") test-snapd-rsync test-snapd-rsync-core18 test-snapd-rsync-core20'

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -392,6 +392,13 @@ distro_install_build_snapd(){
         if os.query is-trusty && [ "$SPREAD_REBOOT" = 0 ]; then
             REBOOT
         fi
+    elif [ -n "$PPA_GPG_KEY" ] && [ -n "$PPA_SOURCE_LINE" ]; then
+        echo "$PPA_GPG_KEY" | apt-key add -
+        echo "$PPA_SOURCE_LINE" | sed s/YOUR_UBUNTU_VERSION_HERE/"$(lsb_release -c -s)"/g >> /etc/apt/sources.list
+        apt update
+        apt install -y snapd
+
+        apt show snapd | MATCH "APT-Sources: http.*private-ppa\.launchpad(content)?\.net"
     elif [ -n "$PPA_VALIDATION_NAME" ]; then
         apt install -y snapd
         add-apt-repository -y "$PPA_VALIDATION_NAME"
@@ -401,7 +408,7 @@ distro_install_build_snapd(){
         apt update
 
         # Double check that it really comes from the PPA
-        apt show snapd | grep -E "APT-Sources: http.*ppa\.launchpad(content)?\.net"
+        apt show snapd | MATCH "APT-Sources: http.*ppa\.launchpad(content)?\.net"
     else
         packages=
         case "$SPREAD_SYSTEM" in


### PR DESCRIPTION
This change includes new env vars to add the private ppa source line and the gpg key used to varify the source.
To validate it run:

SPREAD_PPA_SOURCE_LINE="<PPA SOURCE LINE>" SPREAD_PPA_GPG_KEY="$(cat <PATH TO THE KEY>)" SPREAD_MODIFY_CORE_SNAP_FOR_REEXEC=0 SPREAD_TRUST_TEST_KEYS=false SPREAD_SNAP_REEXEC=0 SPREAD_CORE_CHANNEL=stable spread google-sru:
