### PR TITLE
many: have relevant Database.Find* methods take policy into account, RODatabaseView.Find* uses the implicit one

### DIFF
--- a/asserts/account.go
+++ b/asserts/account.go
@@ -71,7 +71,7 @@ func (acc *Account) Timestamp() time.Time {
 }
 
 // Implement further consistency checks.
-func (acc *Account) checkConsistency(db RODatabase, acck *AccountKey) error {
+func (acc *Account) checkConsistency(db RODatabaseView, acck *AccountKey) error {
 	if !db.IsTrustedAccount(acc.AuthorityID()) {
 		return fmt.Errorf("account assertion for %q is not signed by a directly trusted authority: %s", acc.AccountID(), acc.AuthorityID())
 	}

--- a/asserts/account_key.go
+++ b/asserts/account_key.go
@@ -143,7 +143,7 @@ func checkPublicKey(ab *assertionBase, keyIDName string) (PublicKey, error) {
 }
 
 // Implement further consistency checks.
-func (ak *AccountKey) checkConsistency(db RODatabase, acck *AccountKey) error {
+func (ak *AccountKey) checkConsistency(db RODatabaseView, acck *AccountKey) error {
 	if !db.IsTrustedAccount(ak.AuthorityID()) {
 		return fmt.Errorf("account-key assertion for %q is not signed by a directly trusted authority: %s", ak.AccountID(), ak.AuthorityID())
 	}
@@ -261,7 +261,7 @@ func (akr *AccountKeyRequest) signKey() PublicKey {
 }
 
 // Implement further consistency checks.
-func (akr *AccountKeyRequest) checkConsistency(db RODatabase, acck *AccountKey) error {
+func (akr *AccountKeyRequest) checkConsistency(db RODatabaseView, acck *AccountKey) error {
 	_, err := db.Find(AccountType, map[string]string{
 		"account-id": akr.AccountID(),
 	})

--- a/asserts/account_key_test.go
+++ b/asserts/account_key_test.go
@@ -295,7 +295,7 @@ func (aks *accountKeySuite) TestAccountKeyCheck(c *C) {
 
 	aks.prereqAccount(c, db)
 
-	err = db.Check(accKey)
+	err = db.Check(accKey, nil)
 	c.Assert(err, IsNil)
 }
 
@@ -315,7 +315,7 @@ func (aks *accountKeySuite) TestAccountKeyCheckNoAccount(c *C) {
 
 	db := aks.openDB(c)
 
-	err = db.Check(accKey)
+	err = db.Check(accKey, nil)
 	c.Assert(err, ErrorMatches, `account-key assertion for "acc-id1" does not have a matching account assertion`)
 }
 
@@ -336,7 +336,7 @@ func (aks *accountKeySuite) TestAccountKeyCheckUntrustedAuthority(c *C) {
 	accKey, err := otherDB.Sign(asserts.AccountKeyType, headers, []byte(aks.pubKeyBody), "")
 	c.Assert(err, IsNil)
 
-	err = db.Check(accKey)
+	err = db.Check(accKey, nil)
 	c.Assert(err, ErrorMatches, `account-key assertion for "acc-id1" is not signed by a directly trusted authority:.*`)
 }
 
@@ -364,7 +364,7 @@ func (aks *accountKeySuite) TestAccountKeyCheckSameNameAndNewRevision(c *C) {
 	newAccKey, err := asserts.AssembleAndSignInTest(asserts.AccountKeyType, headers, []byte(aks.pubKeyBody), trustedKey)
 	c.Assert(err, IsNil)
 
-	err = db.Check(newAccKey)
+	err = db.Check(newAccKey, nil)
 	c.Assert(err, IsNil)
 }
 
@@ -401,7 +401,7 @@ func (aks *accountKeySuite) TestAccountKeyCheckSameAccountAndDifferentName(c *C)
 	newAccKey, err := asserts.AssembleAndSignInTest(asserts.AccountKeyType, headers, newPubKeyEncoded, trustedKey)
 	c.Assert(err, IsNil)
 
-	err = db.Check(newAccKey)
+	err = db.Check(newAccKey, nil)
 	c.Assert(err, IsNil)
 }
 
@@ -447,7 +447,7 @@ func (aks *accountKeySuite) TestAccountKeyCheckSameNameAndDifferentAccount(c *C)
 	newAccKey, err := asserts.AssembleAndSignInTest(asserts.AccountKeyType, headers, newPubKeyEncoded, trustedKey)
 	c.Assert(err, IsNil)
 
-	err = db.Check(newAccKey)
+	err = db.Check(newAccKey, nil)
 	c.Assert(err, IsNil)
 }
 
@@ -484,7 +484,7 @@ func (aks *accountKeySuite) TestAccountKeyCheckNameClash(c *C) {
 	newAccKey, err := asserts.AssembleAndSignInTest(asserts.AccountKeyType, headers, newPubKeyEncoded, trustedKey)
 	c.Assert(err, IsNil)
 
-	err = db.Check(newAccKey)
+	err = db.Check(newAccKey, nil)
 	c.Assert(err, ErrorMatches, fmt.Sprintf(`account-key assertion for "acc-id1" with ID %q has the same name "default" as existing ID %q`, newPubKey.ID(), aks.keyID))
 }
 
@@ -814,7 +814,7 @@ func (aks *accountKeySuite) TestAccountKeyRequestHappy(c *C) {
 	db := aks.openDB(c)
 	aks.prereqAccount(c, db)
 
-	err = db.Check(akr2)
+	err = db.Check(akr2, nil)
 	c.Check(err, IsNil)
 
 	c.Check(akr2.AccountID(), Equals, "acc-id1")
@@ -853,7 +853,7 @@ func (aks *accountKeySuite) TestAccountKeyRequestUntil(c *C) {
 		c.Assert(err, IsNil)
 		akr2 := a.(*asserts.AccountKeyRequest)
 		c.Check(akr2.Until(), Equals, test.until)
-		err = db.Check(akr2)
+		err = db.Check(akr2, nil)
 		c.Check(err, IsNil)
 	}
 }
@@ -985,6 +985,6 @@ func (aks *accountKeySuite) TestAccountKeyRequestNoAccount(c *C) {
 
 	db := aks.openDB(c)
 
-	err = db.Check(akr)
+	err = db.Check(akr, nil)
 	c.Assert(err, ErrorMatches, `account-key-request assertion for "acc-id1" does not have a matching account assertion`)
 }

--- a/asserts/account_key_test.go
+++ b/asserts/account_key_test.go
@@ -274,7 +274,7 @@ func (aks *accountKeySuite) prereqAccount(c *C, db *asserts.Database) {
 	c.Assert(err, IsNil)
 
 	// prereq
-	db.Add(acct1)
+	db.Add(acct1, nil)
 }
 
 func (aks *accountKeySuite) TestAccountKeyCheck(c *C) {
@@ -357,7 +357,7 @@ func (aks *accountKeySuite) TestAccountKeyCheckSameNameAndNewRevision(c *C) {
 	db := aks.openDB(c)
 	aks.prereqAccount(c, db)
 
-	err = db.Add(accKey)
+	err = db.Add(accKey, nil)
 	c.Assert(err, IsNil)
 
 	headers["revision"] = "1"
@@ -385,7 +385,7 @@ func (aks *accountKeySuite) TestAccountKeyCheckSameAccountAndDifferentName(c *C)
 	db := aks.openDB(c)
 	aks.prereqAccount(c, db)
 
-	err = db.Add(accKey)
+	err = db.Add(accKey, nil)
 	c.Assert(err, IsNil)
 
 	newPrivKey, _ := assertstest.GenerateKey(752)
@@ -424,7 +424,7 @@ func (aks *accountKeySuite) TestAccountKeyCheckSameNameAndDifferentAccount(c *C)
 	c.Assert(err, IsNil)
 	aks.prereqAccount(c, db)
 
-	err = db.Add(accKey)
+	err = db.Add(accKey, nil)
 	c.Assert(err, IsNil)
 
 	newPrivKey, _ := assertstest.GenerateKey(752)
@@ -439,7 +439,7 @@ func (aks *accountKeySuite) TestAccountKeyCheckSameNameAndDifferentAccount(c *C)
 		"authority-id": "canonical",
 		"account-id":   "acc-id2",
 	}, trustedKey.PublicKey().ID())
-	db.Add(acct2)
+	db.Add(acct2, nil)
 
 	headers["account-id"] = "acc-id2"
 	headers["public-key-sha3-384"] = newPubKey.ID()
@@ -468,7 +468,7 @@ func (aks *accountKeySuite) TestAccountKeyCheckNameClash(c *C) {
 	db := aks.openDB(c)
 	aks.prereqAccount(c, db)
 
-	err = db.Add(accKey)
+	err = db.Add(accKey, nil)
 	c.Assert(err, IsNil)
 
 	newPrivKey, _ := assertstest.GenerateKey(752)
@@ -506,7 +506,7 @@ func (aks *accountKeySuite) TestAccountKeyAddAndFind(c *C) {
 
 	aks.prereqAccount(c, db)
 
-	err = db.Add(accKey)
+	err = db.Add(accKey, nil)
 	c.Assert(err, IsNil)
 
 	found, err := db.Find(asserts.AccountKeyType, map[string]string{
@@ -871,7 +871,7 @@ func (aks *accountKeySuite) TestAccountKeyRequestAddAndFind(c *C) {
 	db := aks.openDB(c)
 	aks.prereqAccount(c, db)
 
-	err = db.Add(akr)
+	err = db.Add(akr, nil)
 	c.Assert(err, IsNil)
 
 	found, err := db.Find(asserts.AccountKeyRequestType, map[string]string{

--- a/asserts/account_test.go
+++ b/asserts/account_test.go
@@ -152,7 +152,7 @@ func (s *accountSuite) TestCheckInconsistentTimestamp(c *C) {
 	account, err := storeDB.Sign(asserts.AccountType, headers, nil, "")
 	c.Assert(err, IsNil)
 
-	err = db.Check(account)
+	err = db.Check(account, nil)
 	c.Assert(err, ErrorMatches, `account assertion timestamp "2011-01-01 14:00:00 \+0000 UTC" outside of signing key validity \(key valid since.*\)`)
 }
 
@@ -170,7 +170,7 @@ func (s *accountSuite) TestCheckUntrustedAuthority(c *C) {
 	account, err := otherDB.Sign(asserts.AccountType, headers, nil, "")
 	c.Assert(err, IsNil)
 
-	err = db.Check(account)
+	err = db.Check(account, nil)
 	c.Assert(err, ErrorMatches, `account assertion for "abc-123" is not signed by a directly trusted authority:.*`)
 }
 

--- a/asserts/assertstest/assertstest.go
+++ b/asserts/assertstest/assertstest.go
@@ -239,7 +239,7 @@ func NewSigningDB(authorityID string, privKey asserts.PrivateKey) *SigningDB {
 }
 
 func (db *SigningDB) Add(assert asserts.Assertion) error {
-	return db.Database.Add(assert, nil)
+	return db.Database.Add(assert, asserts.TransparentAssertionPolicy)
 }
 
 func (db *SigningDB) Sign(assertType *asserts.AssertionType, headers map[string]interface{}, body []byte, keyID string) (asserts.Assertion, error) {
@@ -497,7 +497,7 @@ func AddMany(db interface{}, assertions ...asserts.Assertion) {
 	switch dbAdder := db.(type) {
 	case *asserts.Database:
 		add = func(a asserts.Assertion) error {
-			return dbAdder.Add(a, nil)
+			return dbAdder.Add(a, asserts.TransparentAssertionPolicy)
 		}
 	case accuDB:
 		add = dbAdder.Add

--- a/asserts/assertstest/assertstest_test.go
+++ b/asserts/assertstest/assertstest_test.go
@@ -155,7 +155,7 @@ func (s *helperSuite) TestStoreStack(c *C) {
 	c.Check(store.GenericClassicModel.BrandID(), Equals, "generic")
 	c.Check(store.GenericClassicModel.Model(), Equals, "generic-classic")
 	c.Check(store.GenericClassicModel.Classic(), Equals, true)
-	err = db.Check(store.GenericClassicModel)
+	err = db.Check(store.GenericClassicModel, nil)
 	c.Assert(err, IsNil)
 
 	err = db.Add(store.GenericKey)

--- a/asserts/assertstest/assertstest_test.go
+++ b/asserts/assertstest/assertstest_test.go
@@ -130,17 +130,17 @@ func (s *helperSuite) TestStoreStack(c *C) {
 	c.Check(acct.AccountID(), HasLen, 32)
 	c.Check(acct.Validation(), Equals, "unproven")
 
-	err = db.Add(storeAccKey)
+	err = db.Add(storeAccKey, nil)
 	c.Assert(err, IsNil)
 
-	err = db.Add(acct)
+	err = db.Add(acct, nil)
 	c.Assert(err, IsNil)
 
 	devKey, _ := assertstest.GenerateKey(752)
 
 	acctKey := assertstest.NewAccountKey(store, acct, nil, devKey.PublicKey(), "")
 
-	err = db.Add(acctKey)
+	err = db.Add(acctKey, nil)
 	c.Assert(err, IsNil)
 
 	c.Check(acctKey.Name(), Equals, "default")
@@ -158,7 +158,7 @@ func (s *helperSuite) TestStoreStack(c *C) {
 	err = db.Check(store.GenericClassicModel, nil)
 	c.Assert(err, IsNil)
 
-	err = db.Add(store.GenericKey)
+	err = db.Add(store.GenericKey, nil)
 	c.Assert(err, IsNil)
 }
 
@@ -210,7 +210,7 @@ func (s *helperSuite) TestSigningAccountsAccountsAndKeysPlusAddMany(c *C) {
 		Trusted:   store.Trusted,
 	})
 	c.Assert(err, IsNil)
-	err = db.Add(store.StoreAccountKey(""))
+	err = db.Add(store.StoreAccountKey(""), nil)
 	c.Assert(err, IsNil)
 
 	assertstest.AddMany(db, sa.AccountsAndKeys("my-brand")...)

--- a/asserts/authority_delegation.go
+++ b/asserts/authority_delegation.go
@@ -56,7 +56,7 @@ func (ad *AuthorityDelegation) MatchingConstraints(a Assertion) []*AssertionCons
 }
 
 // Implement further consistency checks.
-func (ad *AuthorityDelegation) checkConsistency(db RODatabase, acck *AccountKey) error {
+func (ad *AuthorityDelegation) checkConsistency(db RODatabaseView, acck *AccountKey) error {
 	if !db.IsTrustedAccount(ad.AuthorityID()) {
 		// XXX if this is relaxed then authority-id must otherwise
 		// match account-id

--- a/asserts/authority_delegation_test.go
+++ b/asserts/authority_delegation_test.go
@@ -105,7 +105,7 @@ func (s *authorityDelegationSuite) TestAuthorityDelegationCheckUntrustedAuthorit
 	ad, err := otherDB.Sign(asserts.AuthorityDelegationType, headers, nil, "")
 	c.Assert(err, IsNil)
 
-	err = db.Check(ad)
+	err = db.Check(ad, nil)
 	c.Assert(err, ErrorMatches, `authority-delegation assertion for "canonical" is not signed by a directly trusted authority: other`)
 }
 
@@ -125,7 +125,7 @@ func (s *authorityDelegationSuite) TestAuthorityDelegationCheckAccountReferences
 	ad, err := storeDB.Sign(asserts.AuthorityDelegationType, headers, nil, "")
 	c.Assert(err, IsNil)
 
-	err = db.Check(ad)
+	err = db.Check(ad, nil)
 	c.Assert(err, ErrorMatches, `authority-delegation assertion for \"other\" does not have a matching account assertion`)
 
 	otherAcct := assertstest.NewAccount(storeDB, "other", map[string]interface{}{
@@ -133,7 +133,7 @@ func (s *authorityDelegationSuite) TestAuthorityDelegationCheckAccountReferences
 	}, "")
 	c.Assert(db.Add(otherAcct), IsNil)
 
-	err = db.Check(ad)
+	err = db.Check(ad, nil)
 	c.Assert(err, ErrorMatches, `authority-delegation assertion for \"other\" does not have a matching account assertion for delegated \"other2\"`)
 }
 
@@ -162,7 +162,7 @@ func (s *authorityDelegationSuite) TestAuthorityDelegationCheckHappy(c *C) {
 	}, "")
 	c.Assert(db.Add(other2Acct), IsNil)
 
-	err = db.Check(ad)
+	err = db.Check(ad, nil)
 	c.Check(err, IsNil)
 }
 

--- a/asserts/authority_delegation_test.go
+++ b/asserts/authority_delegation_test.go
@@ -131,7 +131,7 @@ func (s *authorityDelegationSuite) TestAuthorityDelegationCheckAccountReferences
 	otherAcct := assertstest.NewAccount(storeDB, "other", map[string]interface{}{
 		"account-id": "other",
 	}, "")
-	c.Assert(db.Add(otherAcct), IsNil)
+	c.Assert(db.Add(otherAcct, nil), IsNil)
 
 	err = db.Check(ad, nil)
 	c.Assert(err, ErrorMatches, `authority-delegation assertion for \"other\" does not have a matching account assertion for delegated \"other2\"`)
@@ -156,11 +156,11 @@ func (s *authorityDelegationSuite) TestAuthorityDelegationCheckHappy(c *C) {
 	otherAcct := assertstest.NewAccount(storeDB, "other", map[string]interface{}{
 		"account-id": "other",
 	}, "")
-	c.Assert(db.Add(otherAcct), IsNil)
+	c.Assert(db.Add(otherAcct, nil), IsNil)
 	other2Acct := assertstest.NewAccount(storeDB, "other2", map[string]interface{}{
 		"account-id": "other2",
 	}, "")
-	c.Assert(db.Add(other2Acct), IsNil)
+	c.Assert(db.Add(other2Acct, nil), IsNil)
 
 	err = db.Check(ad, nil)
 	c.Check(err, IsNil)

--- a/asserts/batch.go
+++ b/asserts/batch.go
@@ -110,7 +110,7 @@ func (b *Batch) AddStream(r io.Reader) ([]*Ref, error) {
 
 // Fetch adds to the batch by invoking fetching to drive an internal
 // Fetcher that was built with trustedDB and retrieve.
-func (b *Batch) Fetch(trustedDB RODatabase, retrieve func(*Ref) (Assertion, error), fetching func(Fetcher) error) error {
+func (b *Batch) Fetch(trustedDB RODatabaseView, retrieve func(*Ref) (Assertion, error), fetching func(Fetcher) error) error {
 	f := NewFetcher(trustedDB, retrieve, b.Add)
 	return fetching(f)
 }

--- a/asserts/batch.go
+++ b/asserts/batch.go
@@ -174,7 +174,8 @@ func (b *Batch) commitTo(db *Database, observe func(Assertion)) error {
 
 	var errs []error
 	for _, a := range b.added {
-		err := db.Add(a)
+		// XXX policy
+		err := db.Add(a, nil)
 		if IsUnaccceptedUpdate(err) {
 			// unsupported format case is handled before
 			// be idempotent

--- a/asserts/batch_test.go
+++ b/asserts/batch_test.go
@@ -495,7 +495,7 @@ func (s *batchSuite) TestFetch(c *C) {
 		return f.Fetch(ref)
 	}
 
-	err = batch.Fetch(s.db, retrieve, fetching)
+	err = batch.Fetch(s.db.ROUnderPolicy(nil), retrieve, fetching)
 	c.Assert(err, IsNil)
 
 	// nothing was added yet

--- a/asserts/batch_test.go
+++ b/asserts/batch_test.go
@@ -155,7 +155,7 @@ func (s *batchSuite) TestAddEmptyStream(c *C) {
 
 func (s *batchSuite) TestConsiderPreexisting(c *C) {
 	// prereq store key
-	err := s.db.Add(s.storeSigning.StoreAccountKey(""))
+	err := s.db.Add(s.storeSigning.StoreAccountKey(""), nil)
 	c.Assert(err, IsNil)
 
 	batch := asserts.NewBatch(nil)
@@ -314,7 +314,7 @@ func (s *batchSuite) TestCommitPartial(c *C) {
 	// Commit does add any successful assertion until the first error
 
 	// store key already present
-	err := s.db.Add(s.storeSigning.StoreAccountKey(""))
+	err := s.db.Add(s.storeSigning.StoreAccountKey(""), nil)
 	c.Assert(err, IsNil)
 
 	batch := asserts.NewBatch(nil)
@@ -355,7 +355,7 @@ func (s *batchSuite) TestCommitPartial(c *C) {
 
 func (s *batchSuite) TestCommitMissing(c *C) {
 	// store key already present
-	err := s.db.Add(s.storeSigning.StoreAccountKey(""))
+	err := s.db.Add(s.storeSigning.StoreAccountKey(""), nil)
 	c.Assert(err, IsNil)
 
 	batch := asserts.NewBatch(nil)
@@ -371,7 +371,7 @@ func (s *batchSuite) TestCommitMissing(c *C) {
 
 func (s *batchSuite) TestPrecheckPartial(c *C) {
 	// store key already present
-	err := s.db.Add(s.storeSigning.StoreAccountKey(""))
+	err := s.db.Add(s.storeSigning.StoreAccountKey(""), nil)
 	c.Assert(err, IsNil)
 
 	batch := asserts.NewBatch(nil)
@@ -412,7 +412,7 @@ func (s *batchSuite) TestPrecheckPartial(c *C) {
 
 func (s *batchSuite) TestPrecheckHappy(c *C) {
 	// store key already present
-	err := s.db.Add(s.storeSigning.StoreAccountKey(""))
+	err := s.db.Add(s.storeSigning.StoreAccountKey(""), nil)
 	c.Assert(err, IsNil)
 
 	batch := asserts.NewBatch(nil)
@@ -462,7 +462,7 @@ func (s *batchSuite) TestPrecheckHappy(c *C) {
 }
 
 func (s *batchSuite) TestFetch(c *C) {
-	err := s.db.Add(s.storeSigning.StoreAccountKey(""))
+	err := s.db.Add(s.storeSigning.StoreAccountKey(""), nil)
 	c.Assert(err, IsNil)
 
 	s.snapDecl(c, "foo", nil)

--- a/asserts/batch_test.go
+++ b/asserts/batch_test.go
@@ -495,7 +495,7 @@ func (s *batchSuite) TestFetch(c *C) {
 		return f.Fetch(ref)
 	}
 
-	err = batch.Fetch(s.db.ROUnderPolicy(nil), retrieve, fetching)
+	err = batch.Fetch(s.db, retrieve, fetching)
 	c.Assert(err, IsNil)
 
 	// nothing was added yet

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -660,7 +660,7 @@ func (db *Database) FindTrusted(assertionType *AssertionType, headers map[string
 	return find([]Backstore{db.trusted}, assertionType, headers, -1)
 }
 
-func (db *Database) findMany(backstores []Backstore, assertionType *AssertionType, headers map[string]string) ([]Assertion, error) {
+func findMany(backstores []Backstore, assertionType *AssertionType, headers map[string]string) ([]Assertion, error) {
 	err := checkAssertType(assertionType)
 	if err != nil {
 		return nil, err
@@ -689,14 +689,14 @@ func (db *Database) findMany(backstores []Backstore, assertionType *AssertionTyp
 // FindMany finds assertions based on arbitrary headers.
 // It returns a NotFoundError if no assertion can be found.
 func (db *Database) FindMany(assertionType *AssertionType, headers map[string]string) ([]Assertion, error) {
-	return db.findMany(db.backstores, assertionType, headers)
+	return findMany(db.backstores, assertionType, headers)
 }
 
 // FindManyPrefined finds assertions in the predefined sets (trusted
 // or not) based on arbitrary headers.  It returns a NotFoundError if
 // no assertion can be found.
 func (db *Database) FindManyPredefined(assertionType *AssertionType, headers map[string]string) ([]Assertion, error) {
-	return db.findMany([]Backstore{db.trusted, db.predefined}, assertionType, headers)
+	return findMany([]Backstore{db.trusted, db.predefined}, assertionType, headers)
 }
 
 // FindSequence finds an assertion for the given headers and after for

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -446,12 +446,13 @@ func (db *Database) policy(pol AssertionPolicy) (AssertionPolicy, bool) {
 // Check tests whether the assertion is properly signed and consistent with all the stored knowledge.
 func (db *Database) Check(assert Assertion, pol AssertionPolicy) error {
 	earliestTime, latestTime := db.earliestLatestTime()
+	pol, polOk := db.policy(pol)
 	roView := db.ROWithPolicy(pol)
 	signingKey, delegationConstraints, err := db.check(assert, roView, earliestTime, latestTime)
 	if err != nil {
 		return err
 	}
-	if pol, ok := db.policy(pol); ok {
+	if polOk {
 		return pol.Check(assert, signingKey, delegationConstraints, roView, earliestTime, latestTime)
 	}
 	return nil

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -227,6 +227,12 @@ type RODatabaseView interface {
 	// constraints that cover the timestamp will be considered
 	// matching.
 	DelegationConstraints(assert Assertion) ([]*AssertionConstraints, error)
+
+	// WithPolicy returns a RODatabaseView on the same
+	// database that respects the given policy.
+	// pol can be nil in which case the same RODatabaseView can be
+	// returned.
+	WithPolicy(pol AssertionPolicy) RODatabaseView
 }
 
 // AssertionPolicy can express local/site-specific assertion validation
@@ -494,6 +500,13 @@ func (db *Database) SetEarliestTime(earliest time.Time) {
 type roDBView struct {
 	*Database
 	pol AssertionPolicy
+}
+
+func (v *roDBView) WithPolicy(pol AssertionPolicy) RODatabaseView {
+	if pol == nil {
+		return v
+	}
+	return &roDBView{Database: v.Database, pol: pol}
 }
 
 func (v *roDBView) Check(assert Assertion) error {

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -228,6 +228,21 @@ type AssertionPolicy interface {
 	Accept(assert Assertion, signingKey *AccountKey, delegationConstraints []*AssertionConstraints, roDB RODatabaseView, checkTimeEarliest, checkTimeLatest time.Time) error
 }
 
+type transparentAssertionPolicy struct{}
+
+func (pol transparentAssertionPolicy) Check(Assertion, *AccountKey, []*AssertionConstraints, RODatabaseView, time.Time, time.Time) error {
+	return nil
+}
+
+func (pol transparentAssertionPolicy) Accept(Assertion, *AccountKey, []*AssertionConstraints, RODatabaseView, time.Time, time.Time) error {
+	return nil
+}
+
+// TransparentAssertionPolicy does not perform any additional checks,
+// in particual in the case of delegation. It is meant mainly for
+// intermediary sites that are not the actual consumers of assertions.
+var TransparentAssertionPolicy AssertionPolicy = transparentAssertionPolicy{}
+
 // A Checker defines a check on an assertion considering aspects such as
 // the signing key, and consistency with other
 // assertions in the database.

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -492,7 +492,8 @@ func (db *Database) check(assert Assertion, roView RODatabaseView, earliestTime,
 
 // Add persists the assertion after ensuring it is properly signed and consistent with all the stored knowledge.
 // It will return an error when trying to add an older revision of the assertion than the one currently stored.
-func (db *Database) Add(assert Assertion) error {
+// XXX document pol use
+func (db *Database) Add(assert Assertion, pol AssertionPolicy) error {
 	ref := assert.Ref()
 
 	if len(ref.PrimaryKey) == 0 {

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015-2021 Canonical Ltd
+ * Copyright (C) 2015-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -169,8 +169,8 @@ func IsUnaccceptedUpdate(err error) bool {
 	return false
 }
 
-// A RODatabase exposes read-only access to an assertion database.
-type RODatabase interface {
+// A RODatabaseView exposes read-only access to an assertion database.
+type RODatabaseView interface {
 	// IsTrustedAccount returns whether the account is part of the trusted set.
 	IsTrustedAccount(accountID string) bool
 	// Find an assertion based on arbitrary headers.
@@ -217,7 +217,7 @@ type RODatabase interface {
 // assertions in the database.
 // It can also participate in validating and filtering delegation assertion
 // constraint in the case of delegation.
-type Checker func(assert Assertion, signingKey *AccountKey, delegationConstraints []*AssertionConstraints, roDB RODatabase, checkTimeEarliest, checkTimeLatest time.Time) ([]*AssertionConstraints, error)
+type Checker func(assert Assertion, signingKey *AccountKey, delegationConstraints []*AssertionConstraints, roDB RODatabaseView, checkTimeEarliest, checkTimeLatest time.Time) ([]*AssertionConstraints, error)
 
 // Database holds assertions and can be used to sign or check
 // further assertions.
@@ -699,7 +699,7 @@ func (db *Database) FindSequence(assertType *AssertionType, sequenceHeaders map[
 // assertion checkers
 
 // CheckSigningKeyIsNotExpired checks that the signing key is not expired.
-func CheckSigningKeyIsNotExpired(assert Assertion, signingKey *AccountKey, delegationConstraints []*AssertionConstraints, roDB RODatabase, checkTimeEarliest, checkTimeLatest time.Time) ([]*AssertionConstraints, error) {
+func CheckSigningKeyIsNotExpired(assert Assertion, signingKey *AccountKey, delegationConstraints []*AssertionConstraints, roDB RODatabaseView, checkTimeEarliest, checkTimeLatest time.Time) ([]*AssertionConstraints, error) {
 	if signingKey == nil {
 		// assert isn't signed with an account-key key, CheckSignature
 		// will fail anyway unless we teach it more stuff,
@@ -714,7 +714,7 @@ func CheckSigningKeyIsNotExpired(assert Assertion, signingKey *AccountKey, deleg
 }
 
 // CheckSignature checks that the signature is valid.
-func CheckSignature(assert Assertion, signingKey *AccountKey, _ []*AssertionConstraints, roDB RODatabase, checkTimeEarliest, checkTimeLatest time.Time) (delegationConstraints []*AssertionConstraints, err error) {
+func CheckSignature(assert Assertion, signingKey *AccountKey, _ []*AssertionConstraints, roDB RODatabaseView, checkTimeEarliest, checkTimeLatest time.Time) (delegationConstraints []*AssertionConstraints, err error) {
 	var pubKey PublicKey
 	if signingKey != nil {
 		pubKey = signingKey.publicKey()
@@ -764,7 +764,7 @@ type timestamped interface {
 
 // CheckTimestampVsSigningKeyValidity verifies that the timestamp of
 // the assertion is within the signing key validity.
-func CheckTimestampVsSigningKeyValidity(assert Assertion, signingKey *AccountKey, delegationConstraints []*AssertionConstraints, roDB RODatabase, checkTimeEarliest, checkTimeLatest time.Time) ([]*AssertionConstraints, error) {
+func CheckTimestampVsSigningKeyValidity(assert Assertion, signingKey *AccountKey, delegationConstraints []*AssertionConstraints, roDB RODatabaseView, checkTimeEarliest, checkTimeLatest time.Time) ([]*AssertionConstraints, error) {
 	if signingKey == nil {
 		// assert isn't signed with an account-key key, CheckSignature
 		// will fail anyway unless we teach it more stuff.
@@ -789,11 +789,11 @@ func CheckTimestampVsSigningKeyValidity(assert Assertion, signingKey *AccountKey
 // A consistencyChecker performs further checks based on the full
 // assertion database knowledge and its own signing key.
 type consistencyChecker interface {
-	checkConsistency(roDB RODatabase, signingKey *AccountKey) error
+	checkConsistency(roDB RODatabaseView, signingKey *AccountKey) error
 }
 
 // CheckCrossConsistency verifies that the assertion is consistent with the other statements in the database.
-func CheckCrossConsistency(assert Assertion, signingKey *AccountKey, delegationConstraints []*AssertionConstraints, roDB RODatabase, checkTimeEarliest, checkTimeLatest time.Time) ([]*AssertionConstraints, error) {
+func CheckCrossConsistency(assert Assertion, signingKey *AccountKey, delegationConstraints []*AssertionConstraints, roDB RODatabaseView, checkTimeEarliest, checkTimeLatest time.Time) ([]*AssertionConstraints, error) {
 	// see if the assertion requires further checks
 	if checker, ok := assert.(consistencyChecker); ok {
 		return delegationConstraints, checker.checkConsistency(roDB, signingKey)
@@ -802,7 +802,7 @@ func CheckCrossConsistency(assert Assertion, signingKey *AccountKey, delegationC
 }
 
 // CheckDelegationIsNotExpired checks that there is at least one not expired delegation constraint.
-func CheckDelegationIsNotExpired(assert Assertion, signingKey *AccountKey, delegationConstraints []*AssertionConstraints, roDB RODatabase, checkTimeEarliest, checkTimeLatest time.Time) ([]*AssertionConstraints, error) {
+func CheckDelegationIsNotExpired(assert Assertion, signingKey *AccountKey, delegationConstraints []*AssertionConstraints, roDB RODatabaseView, checkTimeEarliest, checkTimeLatest time.Time) ([]*AssertionConstraints, error) {
 	if len(delegationConstraints) == 0 {
 		// nothing to do
 		return nil, nil
@@ -821,7 +821,7 @@ func CheckDelegationIsNotExpired(assert Assertion, signingKey *AccountKey, deleg
 
 // CheckTimestampVsDelegationValidity verifies that the timestamp of
 // the assertion is within at least one of the delegation constraints validity.
-func CheckTimestampVsDelegationValidity(assert Assertion, signingKey *AccountKey, delegationConstraints []*AssertionConstraints, roDB RODatabase, checkTimeEarliest, checkTimeLatest time.Time) ([]*AssertionConstraints, error) {
+func CheckTimestampVsDelegationValidity(assert Assertion, signingKey *AccountKey, delegationConstraints []*AssertionConstraints, roDB RODatabaseView, checkTimeEarliest, checkTimeLatest time.Time) ([]*AssertionConstraints, error) {
 	if len(delegationConstraints) == 0 {
 		// nothing to do
 		return nil, nil
@@ -844,7 +844,7 @@ func CheckTimestampVsDelegationValidity(assert Assertion, signingKey *AccountKey
 
 // CheckDelegation performs the final verification of delegation based
 // on filtered delegation assertion constraints.
-func CheckDelegation(assert Assertion, signingKey *AccountKey, delegationConstraints []*AssertionConstraints, roDB RODatabase, checkTimeEarliest, checkTimeLatest time.Time) ([]*AssertionConstraints, error) {
+func CheckDelegation(assert Assertion, signingKey *AccountKey, delegationConstraints []*AssertionConstraints, roDB RODatabaseView, checkTimeEarliest, checkTimeLatest time.Time) ([]*AssertionConstraints, error) {
 	if signingKey == nil || assert.SignatoryID() == assert.AuthorityID() {
 		// not a delegation scenario
 		return nil, nil

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -666,6 +666,9 @@ func (safs *signAddFindSuite) TestSignDelegation(c *C) {
 	err = safs.db.Check(a1, nil)
 	c.Check(err, ErrorMatches, `no matching authority-delegation for signing delegation from "canonical" to "delegated-acct"`)
 
+	_, err = safs.db.DelegationConstraints(a1)
+	c.Check(err, ErrorMatches, `no matching authority-delegation for signing delegation from "canonical" to "delegated-acct"`)
+
 	ak, err := safs.db.FindSigningKey(a1)
 	c.Assert(err, IsNil)
 	c.Check(ak, DeepEquals, delegatedAcctKey)
@@ -1015,6 +1018,9 @@ func (safs *signAddFindSuite) TestSignDelegationConstraintsMismatch(c *C) {
 	c.Assert(safs.db.Add(ad, nil), IsNil)
 
 	err = safs.db.Check(a1, nil)
+	c.Check(err, ErrorMatches, `no matching constraints supporting delegated test-only assertion from "canonical" to "delegated-acct"`)
+
+	_, err = safs.db.DelegationConstraints(a1)
 	c.Check(err, ErrorMatches, `no matching constraints supporting delegated test-only assertion from "canonical" to "delegated-acct"`)
 
 	// test CheckDelegation directly as well, first retrieve the constraints

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -334,7 +334,7 @@ func (chks *checkSuite) TestCheckMismatchedAccountIDandKey(c *C) {
 	err = db.Check(a, nil)
 	c.Check(err, ErrorMatches, `error finding matching public key for signature: found public key ".*" from "canonical" but expected it from: random`)
 
-	_, err = asserts.CheckSignature(a, cfg.Trusted[0].(*asserts.AccountKey), nil, db.ROUnderPolicy(nil), time.Time{}, time.Time{})
+	_, err = asserts.CheckSignature(a, cfg.Trusted[0].(*asserts.AccountKey), nil, db.ROWithPolicy(nil), time.Time{}, time.Time{})
 	c.Check(err, ErrorMatches, `assertion signatory "random" does not match public key from "canonical"`)
 }
 
@@ -680,7 +680,7 @@ func (safs *signAddFindSuite) TestSignDelegation(c *C) {
 	// test CheckDelegation directly as well, first retrieve the constraints
 	acs := ad.(*asserts.AuthorityDelegation).MatchingConstraints(a1)
 
-	acs, err = asserts.CheckDelegation(a1, delegatedAcctKey.(*asserts.AccountKey), acs, safs.db.ROUnderPolicy(nil), time.Time{}, time.Time{})
+	acs, err = asserts.CheckDelegation(a1, delegatedAcctKey.(*asserts.AccountKey), acs, safs.db.ROWithPolicy(nil), time.Time{}, time.Time{})
 	c.Check(err, IsNil)
 	// the constraints are consumed and not passed further along
 	c.Check(acs, HasLen, 0)
@@ -727,7 +727,7 @@ func (safs *signAddFindSuite) TestSignDelegationMismatchedAccountIDandKey(c *C) 
 	a1, err := delegatedSigningDB.Sign(asserts.TestOnlyType, headers, nil, delegatedKeyID)
 	c.Assert(err, IsNil)
 
-	_, err = asserts.CheckSignature(a1, delegatedAcctKey.(*asserts.AccountKey), nil, safs.db.ROUnderPolicy(nil), time.Time{}, time.Time{})
+	_, err = asserts.CheckSignature(a1, delegatedAcctKey.(*asserts.AccountKey), nil, safs.db.ROWithPolicy(nil), time.Time{}, time.Time{})
 	c.Check(err, ErrorMatches, `assertion signatory "random" does not match public key from "delegated-acct"`)
 }
 
@@ -806,10 +806,10 @@ func (safs *signAddFindSuite) TestSignDelegationConstraintsMismatch(c *C) {
 	}))
 	c.Assert(acs, HasLen, 1)
 
-	_, err = asserts.CheckDelegation(a1, delegatedAcctKey.(*asserts.AccountKey), nil, safs.db.ROUnderPolicy(nil), time.Time{}, time.Time{})
+	_, err = asserts.CheckDelegation(a1, delegatedAcctKey.(*asserts.AccountKey), nil, safs.db.ROWithPolicy(nil), time.Time{}, time.Time{})
 	c.Check(err, ErrorMatches, `no valid constraints supporting delegated test-only assertion from "canonical" to "delegated-acct"`)
 
-	_, err = asserts.CheckDelegation(a1, delegatedAcctKey.(*asserts.AccountKey), acs, safs.db.ROUnderPolicy(nil), time.Time{}, time.Time{})
+	_, err = asserts.CheckDelegation(a1, delegatedAcctKey.(*asserts.AccountKey), acs, safs.db.ROWithPolicy(nil), time.Time{}, time.Time{})
 	c.Check(err, ErrorMatches, `no valid constraints supporting delegated test-only assertion from "canonical" to "delegated-acct"`)
 }
 

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -638,8 +638,8 @@ func (safs *signAddFindSuite) TestSignDelegation(c *C) {
 	delegatedAcctKey, err := safs.signingDB.Sign(asserts.AccountKeyType, headers, pubKeyEncoded, safs.signingKeyID)
 	c.Assert(err, IsNil)
 
-	c.Assert(safs.db.Add(delegatedAcct), IsNil)
-	c.Assert(safs.db.Add(delegatedAcctKey), IsNil)
+	c.Assert(safs.db.Add(delegatedAcct, nil), IsNil)
+	c.Assert(safs.db.Add(delegatedAcctKey, nil), IsNil)
 
 	headers = map[string]interface{}{
 		"authority-id": "canonical",
@@ -672,7 +672,7 @@ func (safs *signAddFindSuite) TestSignDelegation(c *C) {
 	ad, err := safs.signingDB.Sign(asserts.AuthorityDelegationType, headers, nil, safs.signingKeyID)
 	c.Assert(err, IsNil)
 
-	c.Assert(safs.db.Add(ad), IsNil)
+	c.Assert(safs.db.Add(ad, nil), IsNil)
 
 	err = safs.db.Check(a1, nil)
 	c.Check(err, IsNil)
@@ -731,8 +731,8 @@ func (safs *signAddFindSuite) TestSignDelegationWithPolicy(c *C) {
 	delegatedAcctKey, err := safs.signingDB.Sign(asserts.AccountKeyType, headers, pubKeyEncoded, safs.signingKeyID)
 	c.Assert(err, IsNil)
 
-	c.Assert(safs.db.Add(delegatedAcct), IsNil)
-	c.Assert(safs.db.Add(delegatedAcctKey), IsNil)
+	c.Assert(safs.db.Add(delegatedAcct, nil), IsNil)
+	c.Assert(safs.db.Add(delegatedAcctKey, nil), IsNil)
 
 	headers = map[string]interface{}{
 		"authority-id": "canonical",
@@ -762,7 +762,7 @@ func (safs *signAddFindSuite) TestSignDelegationWithPolicy(c *C) {
 	ad, err := safs.signingDB.Sign(asserts.AuthorityDelegationType, headers, nil, safs.signingKeyID)
 	c.Assert(err, IsNil)
 
-	c.Assert(safs.db.Add(ad), IsNil)
+	c.Assert(safs.db.Add(ad, nil), IsNil)
 
 	pol := &testPolicy{}
 	err = safs.db.Check(a1, pol)
@@ -824,8 +824,8 @@ func (safs *signAddFindSuite) TestSignDelegationMismatchedAccountIDandKey(c *C) 
 	delegatedAcctKey, err := safs.signingDB.Sign(asserts.AccountKeyType, headers, pubKeyEncoded, safs.signingKeyID)
 	c.Assert(err, IsNil)
 
-	c.Assert(safs.db.Add(delegatedAcct), IsNil)
-	c.Assert(safs.db.Add(delegatedAcctKey), IsNil)
+	c.Assert(safs.db.Add(delegatedAcct, nil), IsNil)
+	c.Assert(safs.db.Add(delegatedAcctKey, nil), IsNil)
 
 	headers = map[string]interface{}{
 		"authority-id": "canonical",
@@ -869,8 +869,8 @@ func (safs *signAddFindSuite) TestSignDelegationConstraintsMismatch(c *C) {
 	delegatedAcctKey, err := safs.signingDB.Sign(asserts.AccountKeyType, headers, pubKeyEncoded, safs.signingKeyID)
 	c.Assert(err, IsNil)
 
-	c.Assert(safs.db.Add(delegatedAcct), IsNil)
-	c.Assert(safs.db.Add(delegatedAcctKey), IsNil)
+	c.Assert(safs.db.Add(delegatedAcct, nil), IsNil)
+	c.Assert(safs.db.Add(delegatedAcctKey, nil), IsNil)
 
 	headers = map[string]interface{}{
 		"authority-id": "canonical",
@@ -900,7 +900,7 @@ func (safs *signAddFindSuite) TestSignDelegationConstraintsMismatch(c *C) {
 	ad, err := safs.signingDB.Sign(asserts.AuthorityDelegationType, headers, nil, safs.signingKeyID)
 	c.Assert(err, IsNil)
 
-	c.Assert(safs.db.Add(ad), IsNil)
+	c.Assert(safs.db.Add(ad, nil), IsNil)
 
 	err = safs.db.Check(a1, nil)
 	c.Check(err, ErrorMatches, `no matching constraints supporting delegated test-only assertion from "canonical" to "delegated-acct"`)
@@ -951,8 +951,8 @@ func (safs *signAddFindSuite) TestSignDelegationExpired(c *C) {
 	delegatedAcctKey, err := safs.signingDB.Sign(asserts.AccountKeyType, headers, pubKeyEncoded, safs.signingKeyID)
 	c.Assert(err, IsNil)
 
-	c.Assert(safs.db.Add(delegatedAcct), IsNil)
-	c.Assert(safs.db.Add(delegatedAcctKey), IsNil)
+	c.Assert(safs.db.Add(delegatedAcct, nil), IsNil)
+	c.Assert(safs.db.Add(delegatedAcctKey, nil), IsNil)
 
 	headers = map[string]interface{}{
 		"authority-id": "canonical",
@@ -983,7 +983,7 @@ func (safs *signAddFindSuite) TestSignDelegationExpired(c *C) {
 	ad, err := safs.signingDB.Sign(asserts.AuthorityDelegationType, headers, nil, safs.signingKeyID)
 	c.Assert(err, IsNil)
 
-	c.Assert(safs.db.Add(ad), IsNil)
+	c.Assert(safs.db.Add(ad, nil), IsNil)
 
 	err = safs.db.Check(a1, nil)
 	c.Check(err, ErrorMatches, `all constraints supporting delegated test-only assertion from "canonical" to "delegated-acct" are expired`)
@@ -1007,7 +1007,7 @@ func (safs *signAddFindSuite) TestAddRefusesSelfSignedKey(c *C) {
 	c.Assert(err, IsNil)
 
 	// this must fail
-	err = safs.db.Add(acctKey)
+	err = safs.db.Add(acctKey, nil)
 	c.Check(err, ErrorMatches, `no matching public key.*`)
 }
 
@@ -1019,7 +1019,7 @@ func (safs *signAddFindSuite) TestAddSuperseding(c *C) {
 	a1, err := safs.signingDB.Sign(asserts.TestOnlyType, headers, nil, safs.signingKeyID)
 	c.Assert(err, IsNil)
 
-	err = safs.db.Add(a1)
+	err = safs.db.Add(a1, nil)
 	c.Assert(err, IsNil)
 
 	retrieved1, err := safs.db.Find(asserts.TestOnlyType, map[string]string{
@@ -1033,7 +1033,7 @@ func (safs *signAddFindSuite) TestAddSuperseding(c *C) {
 	a2, err := safs.signingDB.Sign(asserts.TestOnlyType, headers, nil, safs.signingKeyID)
 	c.Assert(err, IsNil)
 
-	err = safs.db.Add(a2)
+	err = safs.db.Add(a2, nil)
 	c.Assert(err, IsNil)
 
 	retrieved2, err := safs.db.Find(asserts.TestOnlyType, map[string]string{
@@ -1043,7 +1043,7 @@ func (safs *signAddFindSuite) TestAddSuperseding(c *C) {
 	c.Check(retrieved2, NotNil)
 	c.Check(retrieved2.Revision(), Equals, 1)
 
-	err = safs.db.Add(a1)
+	err = safs.db.Add(a1, nil)
 	c.Check(err, ErrorMatches, "revision 0 is older than current revision 1")
 	c.Check(asserts.IsUnaccceptedUpdate(err), Equals, true)
 }
@@ -1055,7 +1055,7 @@ func (safs *signAddFindSuite) TestAddNoAuthorityNoPrimaryKey(c *C) {
 	a, err := asserts.SignWithoutAuthority(asserts.TestOnlyNoAuthorityType, headers, nil, testPrivKey0)
 	c.Assert(err, IsNil)
 
-	err = safs.db.Add(a)
+	err = safs.db.Add(a, nil)
 	c.Assert(err, ErrorMatches, `internal error: assertion type "test-only-no-authority" has no primary key`)
 }
 
@@ -1066,7 +1066,7 @@ func (safs *signAddFindSuite) TestAddNoAuthorityButPrimaryKey(c *C) {
 	a, err := asserts.SignWithoutAuthority(asserts.TestOnlyNoAuthorityPKType, headers, nil, testPrivKey0)
 	c.Assert(err, IsNil)
 
-	err = safs.db.Add(a)
+	err = safs.db.Add(a, nil)
 	c.Assert(err, ErrorMatches, `cannot check no-authority assertion type "test-only-no-authority-pk"`)
 }
 
@@ -1083,7 +1083,7 @@ func (safs *signAddFindSuite) TestAddUnsupportedFormat(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(aUnsupp.SupportedFormat(), Equals, false)
 
-	err = safs.db.Add(aUnsupp)
+	err = safs.db.Add(aUnsupp, nil)
 	c.Assert(err, FitsTypeOf, &asserts.UnsupportedFormatError{})
 	c.Check(err.(*asserts.UnsupportedFormatError).Update, Equals, false)
 	c.Check(err, ErrorMatches, `proposed "test-only" assertion has format 77 but 1 is latest supported`)
@@ -1098,10 +1098,10 @@ func (safs *signAddFindSuite) TestAddUnsupportedFormat(c *C) {
 	aSupp, err := asserts.AssembleAndSignInTest(asserts.TestOnlyType, headers, nil, testPrivKey0)
 	c.Assert(err, IsNil)
 
-	err = safs.db.Add(aSupp)
+	err = safs.db.Add(aSupp, nil)
 	c.Assert(err, IsNil)
 
-	err = safs.db.Add(aUnsupp)
+	err = safs.db.Add(aUnsupp, nil)
 	c.Assert(err, FitsTypeOf, &asserts.UnsupportedFormatError{})
 	c.Check(err.(*asserts.UnsupportedFormatError).Update, Equals, true)
 	c.Check(err, ErrorMatches, `proposed "test-only" assertion has format 77 but 1 is latest supported \(current not updated\)`)
@@ -1134,7 +1134,7 @@ func (safs *signAddFindSuite) TestFindNotFound(c *C) {
 	a1, err := safs.signingDB.Sign(asserts.TestOnlyType, headers, nil, safs.signingKeyID)
 	c.Assert(err, IsNil)
 
-	err = safs.db.Add(a1)
+	err = safs.db.Add(a1, nil)
 	c.Assert(err, IsNil)
 
 	hdrs := map[string]string{
@@ -1174,7 +1174,7 @@ func (safs *signAddFindSuite) TestFindMany(c *C) {
 	}
 	aa, err := safs.signingDB.Sign(asserts.TestOnlyType, headers, nil, safs.signingKeyID)
 	c.Assert(err, IsNil)
-	err = safs.db.Add(aa)
+	err = safs.db.Add(aa, nil)
 	c.Assert(err, IsNil)
 
 	headers = map[string]interface{}{
@@ -1184,7 +1184,7 @@ func (safs *signAddFindSuite) TestFindMany(c *C) {
 	}
 	ab, err := safs.signingDB.Sign(asserts.TestOnlyType, headers, nil, safs.signingKeyID)
 	c.Assert(err, IsNil)
-	err = safs.db.Add(ab)
+	err = safs.db.Add(ab, nil)
 	c.Assert(err, IsNil)
 
 	headers = map[string]interface{}{
@@ -1194,7 +1194,7 @@ func (safs *signAddFindSuite) TestFindMany(c *C) {
 	}
 	ac, err := safs.signingDB.Sign(asserts.TestOnlyType, headers, nil, safs.signingKeyID)
 	c.Assert(err, IsNil)
-	err = safs.db.Add(ac)
+	err = safs.db.Add(ac, nil)
 	c.Assert(err, IsNil)
 
 	res, err := safs.db.FindMany(asserts.TestOnlyType, map[string]string{
@@ -1247,9 +1247,9 @@ func (safs *signAddFindSuite) TestFindFindsPredefined(c *C) {
 		"authority-id": "canonical",
 	}, pk1.PublicKey(), safs.signingKeyID)
 
-	err := safs.db.Add(acct1)
+	err := safs.db.Add(acct1, nil)
 	c.Assert(err, IsNil)
-	err = safs.db.Add(acct1Key)
+	err = safs.db.Add(acct1Key, nil)
 	c.Assert(err, IsNil)
 
 	// find the trusted key as well
@@ -1290,9 +1290,9 @@ func (safs *signAddFindSuite) TestFindTrusted(c *C) {
 		"authority-id": "canonical",
 	}, pk1.PublicKey(), safs.signingKeyID)
 
-	err := safs.db.Add(acct1)
+	err := safs.db.Add(acct1, nil)
 	c.Assert(err, IsNil)
-	err = safs.db.Add(acct1Key)
+	err = safs.db.Add(acct1Key, nil)
 	c.Assert(err, IsNil)
 
 	// find the trusted account
@@ -1348,9 +1348,9 @@ func (safs *signAddFindSuite) TestFindPredefined(c *C) {
 		"authority-id": "canonical",
 	}, pk1.PublicKey(), safs.signingKeyID)
 
-	err := safs.db.Add(acct1)
+	err := safs.db.Add(acct1, nil)
 	c.Assert(err, IsNil)
-	err = safs.db.Add(acct1Key)
+	err = safs.db.Add(acct1Key, nil)
 	c.Assert(err, IsNil)
 
 	// find the trusted account
@@ -1436,9 +1436,9 @@ func (safs *signAddFindSuite) TestFindManyPredefined(c *C) {
 		"authority-id": "canonical",
 	}, pk1.PublicKey(), safs.signingKeyID)
 
-	err = db.Add(acct1)
+	err = db.Add(acct1, nil)
 	c.Assert(err, IsNil)
-	err = db.Add(acct1Key)
+	err = db.Add(acct1Key, nil)
 	c.Assert(err, IsNil)
 
 	// find the trusted account
@@ -1509,7 +1509,7 @@ func (safs *signAddFindSuite) TestDontLetAddConfusinglyAssertionClashingWithTrus
 	tKey, err := safs.signingDB.Sign(asserts.AccountKeyType, headers, []byte(pubKey0Encoded), safs.signingKeyID)
 	c.Assert(err, IsNil)
 
-	err = safs.db.Add(tKey)
+	err = safs.db.Add(tKey, nil)
 	c.Check(err, ErrorMatches, `cannot add "account-key" assertion with primary key clashing with a trusted assertion: .*`)
 }
 
@@ -1525,7 +1525,7 @@ func (safs *signAddFindSuite) TestDontLetAddConfusinglyAssertionClashingWithPred
 	predefAcct, err := safs.signingDB.Sign(asserts.AccountType, headers, nil, safs.signingKeyID)
 	c.Assert(err, IsNil)
 
-	err = safs.db.Add(predefAcct)
+	err = safs.db.Add(predefAcct, nil)
 	c.Check(err, ErrorMatches, `cannot add "account" assertion with primary key clashing with a predefined assertion: .*`)
 }
 
@@ -1538,7 +1538,7 @@ func (safs *signAddFindSuite) TestFindAndRefResolve(c *C) {
 	a1, err := safs.signingDB.Sign(asserts.TestOnly2Type, headers, nil, safs.signingKeyID)
 	c.Assert(err, IsNil)
 
-	err = safs.db.Add(a1)
+	err = safs.db.Add(a1, nil)
 	c.Assert(err, IsNil)
 
 	ref := &asserts.Ref{
@@ -1578,7 +1578,7 @@ func (safs *signAddFindSuite) TestFindMaxFormat(c *C) {
 	af0, err := safs.signingDB.Sign(asserts.TestOnlyType, headers, nil, safs.signingKeyID)
 	c.Assert(err, IsNil)
 
-	err = safs.db.Add(af0)
+	err = safs.db.Add(af0, nil)
 	c.Assert(err, IsNil)
 
 	headers = map[string]interface{}{
@@ -1590,7 +1590,7 @@ func (safs *signAddFindSuite) TestFindMaxFormat(c *C) {
 	af1, err := safs.signingDB.Sign(asserts.TestOnlyType, headers, nil, safs.signingKeyID)
 	c.Assert(err, IsNil)
 
-	err = safs.db.Add(af1)
+	err = safs.db.Add(af1, nil)
 	c.Assert(err, IsNil)
 
 	a, err := safs.db.FindMaxFormat(asserts.TestOnlyType, map[string]string{
@@ -1619,7 +1619,7 @@ func (safs *signAddFindSuite) TestWithStackedBackstore(c *C) {
 	a1, err := safs.signingDB.Sign(asserts.TestOnlyType, headers, nil, safs.signingKeyID)
 	c.Assert(err, IsNil)
 
-	err = safs.db.Add(a1)
+	err = safs.db.Add(a1, nil)
 	c.Assert(err, IsNil)
 
 	headers = map[string]interface{}{
@@ -1632,7 +1632,7 @@ func (safs *signAddFindSuite) TestWithStackedBackstore(c *C) {
 	bs := asserts.NewMemoryBackstore()
 	stacked := safs.db.WithStackedBackstore(bs)
 
-	err = stacked.Add(a2)
+	err = stacked.Add(a2, nil)
 	c.Assert(err, IsNil)
 
 	_, err = stacked.Find(asserts.TestOnlyType, map[string]string{
@@ -1681,7 +1681,7 @@ func (safs *signAddFindSuite) TestWithStackedBackstoreSafety(c *C) {
 	tKey, err := safs.signingDB.Sign(asserts.AccountKeyType, headers, []byte(pubKey0Encoded), safs.signingKeyID)
 	c.Assert(err, IsNil)
 
-	err = stacked.Add(tKey)
+	err = stacked.Add(tKey, nil)
 	c.Check(err, ErrorMatches, `cannot add "account-key" assertion with primary key clashing with a trusted assertion: .*`)
 
 	// cannot go back to old revisions
@@ -1700,10 +1700,10 @@ func (safs *signAddFindSuite) TestWithStackedBackstoreSafety(c *C) {
 	a1, err := safs.signingDB.Sign(asserts.TestOnlyType, headers, nil, safs.signingKeyID)
 	c.Assert(err, IsNil)
 
-	err = safs.db.Add(a1)
+	err = safs.db.Add(a1, nil)
 	c.Assert(err, IsNil)
 
-	err = stacked.Add(a0)
+	err = stacked.Add(a0, nil)
 	c.Assert(err, DeepEquals, &asserts.RevisionError{
 		Used:    0,
 		Current: 1,
@@ -1758,7 +1758,7 @@ func (safs *signAddFindSuite) TestFindSequence(c *C) {
 
 	for _, a := range []asserts.Assertion{sq1f0, sq2f0, sq2f1, sq3f1} {
 
-		err = safs.db.Add(a)
+		err = safs.db.Add(a, nil)
 		c.Assert(err, IsNil)
 	}
 
@@ -1766,7 +1766,7 @@ func (safs *signAddFindSuite) TestFindSequence(c *C) {
 	// scenario atm
 	bs := asserts.NewMemoryBackstore()
 	db := safs.db.WithStackedBackstore(bs)
-	err = db.Add(sq3f2)
+	err = db.Add(sq3f2, nil)
 	c.Assert(err, IsNil)
 
 	seqHeaders := map[string]string{

--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -341,8 +341,8 @@ func RuleFeature(rule featureExposer, flabel string) bool {
 	return rule.feature(flabel)
 }
 
-func (b *Batch) DoPrecheck(db *Database) error {
-	return b.precheck(db)
+func (b *Batch) DoPrecheck(db *Database, pol AssertionPolicy) error {
+	return b.precheck(db, pol)
 }
 
 // pool tests

--- a/asserts/extkeypairmgr_test.go
+++ b/asserts/extkeypairmgr_test.go
@@ -242,7 +242,7 @@ func (s *extKeypairMgrSuite) TestSignFlow(c *C) {
 	c.Assert(err, IsNil)
 
 	// valid
-	err = checkDB.Check(a)
+	err = checkDB.Check(a, nil)
 	c.Assert(err, IsNil)
 
 	c.Check(s.pgm.Calls(), DeepEquals, [][]string{

--- a/asserts/extkeypairmgr_test.go
+++ b/asserts/extkeypairmgr_test.go
@@ -219,12 +219,12 @@ func (s *extKeypairMgrSuite) TestSignFlow(c *C) {
 	})
 	c.Assert(err, IsNil)
 	// add store key
-	err = checkDB.Add(store.StoreAccountKey(""))
+	err = checkDB.Add(store.StoreAccountKey(""), nil)
 	c.Assert(err, IsNil)
 	// enable brand key
-	err = checkDB.Add(brandAcct)
+	err = checkDB.Add(brandAcct, nil)
 	c.Assert(err, IsNil)
-	err = checkDB.Add(brandAccKey)
+	err = checkDB.Add(brandAccKey, nil)
 	c.Assert(err, IsNil)
 
 	modelHdsrs := map[string]interface{}{

--- a/asserts/fetcher.go
+++ b/asserts/fetcher.go
@@ -43,7 +43,7 @@ type Fetcher interface {
 }
 
 type fetcher struct {
-	db       RODatabaseView
+	db       PredefinedView
 	retrieve func(*Ref) (Assertion, error)
 	save     func(Assertion) error
 
@@ -51,7 +51,7 @@ type fetcher struct {
 }
 
 // NewFetcher creates a Fetcher which will use trustedDB to determine trusted assertions, will fetch assertions following prerequisites using retrieve, and then will pass them to save, saving prerequisites before dependent assertions.
-func NewFetcher(trustedDB RODatabaseView, retrieve func(*Ref) (Assertion, error), save func(Assertion) error) Fetcher {
+func NewFetcher(trustedDB PredefinedView, retrieve func(*Ref) (Assertion, error), save func(Assertion) error) Fetcher {
 	return &fetcher{
 		db:       trustedDB,
 		retrieve: retrieve,

--- a/asserts/fetcher.go
+++ b/asserts/fetcher.go
@@ -43,7 +43,7 @@ type Fetcher interface {
 }
 
 type fetcher struct {
-	db       RODatabase
+	db       RODatabaseView
 	retrieve func(*Ref) (Assertion, error)
 	save     func(Assertion) error
 
@@ -51,7 +51,7 @@ type fetcher struct {
 }
 
 // NewFetcher creates a Fetcher which will use trustedDB to determine trusted assertions, will fetch assertions following prerequisites using retrieve, and then will pass them to save, saving prerequisites before dependent assertions.
-func NewFetcher(trustedDB RODatabase, retrieve func(*Ref) (Assertion, error), save func(Assertion) error) Fetcher {
+func NewFetcher(trustedDB RODatabaseView, retrieve func(*Ref) (Assertion, error), save func(Assertion) error) Fetcher {
 	return &fetcher{
 		db:       trustedDB,
 		retrieve: retrieve,

--- a/asserts/fetcher_test.go
+++ b/asserts/fetcher_test.go
@@ -111,7 +111,7 @@ func (s *fetcherSuite) TestFetch(c *C) {
 		return ref.Resolve(s.storeSigning.Find)
 	}
 
-	f := asserts.NewFetcher(db, retrieve, db.Add)
+	f := asserts.NewFetcher(db.ROUnderPolicy(nil), retrieve, db.Add)
 
 	err = f.Fetch(ref)
 	c.Assert(err, IsNil)
@@ -183,7 +183,7 @@ func (s *fetcherSuite) TestFetchDelegation(c *C) {
 		return ref.Resolve(s.storeSigning.Find)
 	}
 
-	f := asserts.NewFetcher(db, retrieve, db.Add)
+	f := asserts.NewFetcher(db.ROUnderPolicy(nil), retrieve, db.Add)
 
 	err = f.Fetch(ref)
 	c.Assert(err, IsNil)
@@ -219,7 +219,7 @@ func (s *fetcherSuite) TestSave(c *C) {
 		return ref.Resolve(s.storeSigning.Find)
 	}
 
-	f := asserts.NewFetcher(db, retrieve, db.Add)
+	f := asserts.NewFetcher(db.ROUnderPolicy(nil), retrieve, db.Add)
 
 	ref := &asserts.Ref{
 		Type:       asserts.SnapRevisionType,

--- a/asserts/fetcher_test.go
+++ b/asserts/fetcher_test.go
@@ -186,7 +186,7 @@ func (s *fetcherSuite) TestFetchDelegation(c *C) {
 		return ref.Resolve(s.storeSigning.Find)
 	}
 	save := func(a asserts.Assertion) error {
-		return db.Add(a, nil)
+		return db.Add(a, asserts.TransparentAssertionPolicy)
 	}
 
 	f := asserts.NewFetcher(db, retrieve, save)

--- a/asserts/fetcher_test.go
+++ b/asserts/fetcher_test.go
@@ -111,7 +111,7 @@ func (s *fetcherSuite) TestFetch(c *C) {
 		return ref.Resolve(s.storeSigning.Find)
 	}
 
-	f := asserts.NewFetcher(db.ROUnderPolicy(nil), retrieve, db.Add)
+	f := asserts.NewFetcher(db, retrieve, db.Add)
 
 	err = f.Fetch(ref)
 	c.Assert(err, IsNil)
@@ -183,7 +183,7 @@ func (s *fetcherSuite) TestFetchDelegation(c *C) {
 		return ref.Resolve(s.storeSigning.Find)
 	}
 
-	f := asserts.NewFetcher(db.ROUnderPolicy(nil), retrieve, db.Add)
+	f := asserts.NewFetcher(db, retrieve, db.Add)
 
 	err = f.Fetch(ref)
 	c.Assert(err, IsNil)
@@ -219,7 +219,7 @@ func (s *fetcherSuite) TestSave(c *C) {
 		return ref.Resolve(s.storeSigning.Find)
 	}
 
-	f := asserts.NewFetcher(db.ROUnderPolicy(nil), retrieve, db.Add)
+	f := asserts.NewFetcher(db, retrieve, db.Add)
 
 	ref := &asserts.Ref{
 		Type:       asserts.SnapRevisionType,

--- a/asserts/fetcher_test.go
+++ b/asserts/fetcher_test.go
@@ -110,8 +110,11 @@ func (s *fetcherSuite) TestFetch(c *C) {
 	retrieve := func(ref *asserts.Ref) (asserts.Assertion, error) {
 		return ref.Resolve(s.storeSigning.Find)
 	}
+	save := func(a asserts.Assertion) error {
+		return db.Add(a, nil)
+	}
 
-	f := asserts.NewFetcher(db, retrieve, db.Add)
+	f := asserts.NewFetcher(db, retrieve, save)
 
 	err = f.Fetch(ref)
 	c.Assert(err, IsNil)
@@ -182,8 +185,11 @@ func (s *fetcherSuite) TestFetchDelegation(c *C) {
 	retrieve := func(ref *asserts.Ref) (asserts.Assertion, error) {
 		return ref.Resolve(s.storeSigning.Find)
 	}
+	save := func(a asserts.Assertion) error {
+		return db.Add(a, nil)
+	}
 
-	f := asserts.NewFetcher(db, retrieve, db.Add)
+	f := asserts.NewFetcher(db, retrieve, save)
 
 	err = f.Fetch(ref)
 	c.Assert(err, IsNil)
@@ -218,8 +224,11 @@ func (s *fetcherSuite) TestSave(c *C) {
 	retrieve := func(ref *asserts.Ref) (asserts.Assertion, error) {
 		return ref.Resolve(s.storeSigning.Find)
 	}
+	save := func(a asserts.Assertion) error {
+		return db.Add(a, nil)
+	}
 
-	f := asserts.NewFetcher(db, retrieve, db.Add)
+	f := asserts.NewFetcher(db, retrieve, save)
 
 	ref := &asserts.Ref{
 		Type:       asserts.SnapRevisionType,

--- a/asserts/gpgkeypairmgr_test.go
+++ b/asserts/gpgkeypairmgr_test.go
@@ -119,7 +119,7 @@ func (gkms *gpgKeypairMgrSuite) TestUseInSigning(c *C) {
 	snapBuild, err := signDB.Sign(asserts.SnapBuildType, headers, nil, assertstest.DevKeyID)
 	c.Assert(err, IsNil)
 
-	err = checkDB.Check(snapBuild)
+	err = checkDB.Check(snapBuild, nil)
 	c.Check(err, IsNil)
 }
 

--- a/asserts/gpgkeypairmgr_test.go
+++ b/asserts/gpgkeypairmgr_test.go
@@ -100,12 +100,12 @@ func (gkms *gpgKeypairMgrSuite) TestUseInSigning(c *C) {
 	})
 	c.Assert(err, IsNil)
 	// add store key
-	err = checkDB.Add(store.StoreAccountKey(""))
+	err = checkDB.Add(store.StoreAccountKey(""), nil)
 	c.Assert(err, IsNil)
 	// enable devel key
-	err = checkDB.Add(devAcct)
+	err = checkDB.Add(devAcct, nil)
 	c.Assert(err, IsNil)
-	err = checkDB.Add(devAccKey)
+	err = checkDB.Add(devAccKey, nil)
 	c.Assert(err, IsNil)
 
 	headers := map[string]interface{}{

--- a/asserts/model.go
+++ b/asserts/model.go
@@ -558,7 +558,7 @@ func (mod *Model) Timestamp() time.Time {
 }
 
 // Implement further consistency checks.
-func (mod *Model) checkConsistency(db RODatabase, acck *AccountKey) error {
+func (mod *Model) checkConsistency(db RODatabaseView, acck *AccountKey) error {
 	// TODO: double check trust level of authority depending on class and possibly allowed-modes
 	return nil
 }

--- a/asserts/model_test.go
+++ b/asserts/model_test.go
@@ -503,7 +503,7 @@ func (mods *modelSuite) TestModelCheck(c *C) {
 	model, err := brandDB.Sign(asserts.ModelType, headers, nil, "")
 	c.Assert(err, IsNil)
 
-	err = db.Check(model)
+	err = db.Check(model, nil)
 	c.Assert(err, IsNil)
 }
 
@@ -520,7 +520,7 @@ func (mods *modelSuite) TestModelCheckInconsistentTimestamp(c *C) {
 	model, err := brandDB.Sign(asserts.ModelType, headers, nil, "")
 	c.Assert(err, IsNil)
 
-	err = db.Check(model)
+	err = db.Check(model, nil)
 	c.Assert(err, ErrorMatches, `model assertion timestamp "2011-01-01 14:00:00 \+0000 UTC" outside of signing key validity \(key valid since.*\)`)
 }
 

--- a/asserts/pool.go
+++ b/asserts/pool.go
@@ -963,6 +963,7 @@ func (p *Pool) AddSequenceToUpdate(toUpdate *AtSequence, group string) error {
 // per group. An error is returned directly only if CommitTo is called
 // with possible pending unresolved assertions.
 func (p *Pool) CommitTo(db *Database) error {
+	// XXX policy
 	if p.curPhase == poolPhaseAddUnresolved {
 		return fmt.Errorf("internal error: cannot commit Pool during add unresolved phase")
 	}
@@ -989,6 +990,7 @@ func (p *Pool) CommitTo(db *Database) error {
 		}
 		return err
 	}
+	roView := db.ROUnderPolicy(nil)
 
 NextGroup:
 	for _, gRec := range p.groups {
@@ -997,7 +999,7 @@ NextGroup:
 			continue
 		}
 		// TODO: try to reuse fetcher
-		f := NewFetcher(db, retrieve, save)
+		f := NewFetcher(roView, retrieve, save)
 		for i := range gRec.resolved {
 			if err := f.Fetch(&gRec.resolved[i]); err != nil {
 				gRec.setErr(err)

--- a/asserts/pool.go
+++ b/asserts/pool.go
@@ -96,6 +96,7 @@ func NewPool(groundDB RODatabaseView, n int) *Pool {
 		panic(fmt.Sprintf("NewPool: %v", err))
 	}
 	return &Pool{
+		// XXX policy: need transparent policy once Find is affected
 		groundDB:            groundDB,
 		numbering:           make(map[string]uint16),
 		groupings:           groupings,

--- a/asserts/pool.go
+++ b/asserts/pool.go
@@ -69,7 +69,7 @@ type Grouping string
 // All the resolved assertions in a Pool from groups not in error can
 // be committed to a destination database with CommitTo.
 type Pool struct {
-	groundDB RODatabase
+	groundDB RODatabaseView
 
 	numbering map[string]uint16
 	groupings *internal.Groupings
@@ -90,7 +90,7 @@ type Pool struct {
 // predefined assertions and to provide the current revision for
 // assertions to update and their prerequisites. Up to n groups can be
 // used to organize the assertions.
-func NewPool(groundDB RODatabase, n int) *Pool {
+func NewPool(groundDB RODatabaseView, n int) *Pool {
 	groupings, err := internal.NewGroupings(n)
 	if err != nil {
 		panic(fmt.Sprintf("NewPool: %v", err))

--- a/asserts/pool.go
+++ b/asserts/pool.go
@@ -963,7 +963,6 @@ func (p *Pool) AddSequenceToUpdate(toUpdate *AtSequence, group string) error {
 // per group. An error is returned directly only if CommitTo is called
 // with possible pending unresolved assertions.
 func (p *Pool) CommitTo(db *Database) error {
-	// XXX policy
 	if p.curPhase == poolPhaseAddUnresolved {
 		return fmt.Errorf("internal error: cannot commit Pool during add unresolved phase")
 	}
@@ -990,7 +989,6 @@ func (p *Pool) CommitTo(db *Database) error {
 		}
 		return err
 	}
-	roView := db.ROUnderPolicy(nil)
 
 NextGroup:
 	for _, gRec := range p.groups {
@@ -999,7 +997,7 @@ NextGroup:
 			continue
 		}
 		// TODO: try to reuse fetcher
-		f := NewFetcher(roView, retrieve, save)
+		f := NewFetcher(db, retrieve, save)
 		for i := range gRec.resolved {
 			if err := f.Fetch(&gRec.resolved[i]); err != nil {
 				gRec.setErr(err)

--- a/asserts/pool.go
+++ b/asserts/pool.go
@@ -980,7 +980,8 @@ func (p *Pool) CommitTo(db *Database) error {
 		return a, nil
 	}
 	save := func(a Assertion) error {
-		err := db.Add(a)
+		// XXX policy
+		err := db.Add(a, nil)
 		if IsUnaccceptedUpdate(err) {
 			// unsupported format case is handled before.
 			// be idempotent, db has already the same or

--- a/asserts/pool.go
+++ b/asserts/pool.go
@@ -95,8 +95,11 @@ func NewPool(groundDB RODatabaseView, n int) *Pool {
 	if err != nil {
 		panic(fmt.Sprintf("NewPool: %v", err))
 	}
+	// we want to transparently find any currently present
+	// assertions, any policy validation will happen when CommitTo
+	// adds to the database
+	groundDB = groundDB.WithPolicy(TransparentAssertionPolicy)
 	return &Pool{
-		// XXX policy: need transparent policy once Find is affected
 		groundDB:            groundDB,
 		numbering:           make(map[string]uint16),
 		groupings:           groupings,

--- a/asserts/pool_test.go
+++ b/asserts/pool_test.go
@@ -177,7 +177,7 @@ func (s *poolSuite) SetUpTest(c *C) {
 }
 
 func (s *poolSuite) TestAddUnresolved(c *C) {
-	pool := asserts.NewPool(s.db, 64)
+	pool := asserts.NewPool(s.db.ROUnderPolicy(nil), 64)
 
 	at1 := &asserts.AtRevision{
 		Ref:      asserts.Ref{Type: asserts.TestOnlyRevType, PrimaryKey: []string{"1111"}},
@@ -195,7 +195,7 @@ func (s *poolSuite) TestAddUnresolved(c *C) {
 }
 
 func (s *poolSuite) TestAddUnresolvedPredefined(c *C) {
-	pool := asserts.NewPool(s.db, 64)
+	pool := asserts.NewPool(s.db.ROUnderPolicy(nil), 64)
 
 	at := s.hub.TrustedAccount.At()
 	at.Revision = asserts.RevisionNotKnown
@@ -210,7 +210,7 @@ func (s *poolSuite) TestAddUnresolvedPredefined(c *C) {
 }
 
 func (s *poolSuite) TestAddUnresolvedGrouping(c *C) {
-	pool := asserts.NewPool(s.db, 64)
+	pool := asserts.NewPool(s.db.ROUnderPolicy(nil), 64)
 
 	storeKeyAt := s.hub.StoreAccountKey("").At()
 
@@ -226,7 +226,7 @@ func (s *poolSuite) TestAddUnresolvedGrouping(c *C) {
 }
 
 func (s *poolSuite) TestAddUnresolvedDup(c *C) {
-	pool := asserts.NewPool(s.db, 64)
+	pool := asserts.NewPool(s.db.ROUnderPolicy(nil), 64)
 
 	storeKeyAt := s.hub.StoreAccountKey("").At()
 
@@ -262,7 +262,7 @@ func sortToResolve(toResolve map[asserts.Grouping][]*asserts.AtRevision) {
 }
 
 func (s *poolSuite) TestFetch(c *C) {
-	pool := asserts.NewPool(s.db, 64)
+	pool := asserts.NewPool(s.db.ROUnderPolicy(nil), 64)
 
 	at1111 := &asserts.AtRevision{
 		Ref:      asserts.Ref{Type: asserts.TestOnlyRevType, PrimaryKey: []string{"1111"}},
@@ -300,7 +300,7 @@ func (s *poolSuite) TestFetch(c *C) {
 }
 
 func (s *poolSuite) TestFetchDelegation(c *C) {
-	pool := asserts.NewPool(s.db, 64)
+	pool := asserts.NewPool(s.db.ROUnderPolicy(nil), 64)
 
 	at5555 := &asserts.AtRevision{
 		Ref:      asserts.Ref{Type: asserts.TestOnlyRevType, PrimaryKey: []string{"5555"}},
@@ -344,7 +344,7 @@ func (s *poolSuite) TestFetchDelegation(c *C) {
 }
 
 func (s *poolSuite) TestFetchSequenceForming(c *C) {
-	pool := asserts.NewPool(s.db, 64)
+	pool := asserts.NewPool(s.db.ROUnderPolicy(nil), 64)
 
 	// revision and sequence not set
 	atseq := &asserts.AtSequence{
@@ -389,7 +389,7 @@ func (s *poolSuite) TestFetchSequenceForming(c *C) {
 }
 
 func (s *poolSuite) TestCompleteFetch(c *C) {
-	pool := asserts.NewPool(s.db, 64)
+	pool := asserts.NewPool(s.db.ROUnderPolicy(nil), 64)
 
 	at1111 := &asserts.AtRevision{
 		Ref:      asserts.Ref{Type: asserts.TestOnlyRevType, PrimaryKey: []string{"1111"}},
@@ -455,7 +455,7 @@ func (s *poolSuite) TestCompleteFetch(c *C) {
 func (s *poolSuite) TestPushSuggestionForPrerequisite(c *C) {
 	assertstest.AddMany(s.db, s.hub.StoreAccountKey(""))
 
-	pool := asserts.NewPool(s.db, 64)
+	pool := asserts.NewPool(s.db.ROUnderPolicy(nil), 64)
 
 	at1111 := &asserts.AtRevision{
 		Ref:      asserts.Ref{Type: asserts.TestOnlyRevType, PrimaryKey: []string{"1111"}},
@@ -516,7 +516,7 @@ func (s *poolSuite) TestPushSuggestionForPrerequisite(c *C) {
 func (s *poolSuite) TestPushSuggestionForNew(c *C) {
 	assertstest.AddMany(s.db, s.hub.StoreAccountKey(""))
 
-	pool := asserts.NewPool(s.db, 64)
+	pool := asserts.NewPool(s.db.ROUnderPolicy(nil), 64)
 
 	atOne := &asserts.AtRevision{
 		Ref:      asserts.Ref{Type: asserts.TestOnlyDeclType, PrimaryKey: []string{"one"}},
@@ -577,7 +577,7 @@ func (s *poolSuite) TestPushSuggestionForNew(c *C) {
 func (s *poolSuite) TestPushSuggestionForNewSeqForming(c *C) {
 	assertstest.AddMany(s.db, s.hub.StoreAccountKey(""))
 
-	pool := asserts.NewPool(s.db, 64)
+	pool := asserts.NewPool(s.db.ROUnderPolicy(nil), 64)
 
 	atOne := &asserts.AtSequence{
 		Type:        asserts.TestOnlySeqType,
@@ -627,7 +627,7 @@ func (s *poolSuite) TestPushSuggestionForNewSeqForming(c *C) {
 func (s *poolSuite) TestPushSuggestionForNewViaBatch(c *C) {
 	assertstest.AddMany(s.db, s.hub.StoreAccountKey(""))
 
-	pool := asserts.NewPool(s.db, 64)
+	pool := asserts.NewPool(s.db.ROUnderPolicy(nil), 64)
 
 	atOne := &asserts.AtRevision{
 		Ref:      asserts.Ref{Type: asserts.TestOnlyDeclType, PrimaryKey: []string{"one"}},
@@ -695,7 +695,7 @@ func (s *poolSuite) TestPushSuggestionForNewViaBatch(c *C) {
 }
 
 func (s *poolSuite) TestAddUnresolvedUnresolved(c *C) {
-	pool := asserts.NewPool(s.db, 64)
+	pool := asserts.NewPool(s.db.ROUnderPolicy(nil), 64)
 
 	at1 := &asserts.AtRevision{
 		Ref:      asserts.Ref{Type: asserts.TestOnlyRevType, PrimaryKey: []string{"1111"}},
@@ -720,7 +720,7 @@ func (s *poolSuite) TestAddUnresolvedUnresolved(c *C) {
 }
 
 func (s *poolSuite) TestAddFormatTooNew(c *C) {
-	pool := asserts.NewPool(s.db, 64)
+	pool := asserts.NewPool(s.db.ROUnderPolicy(nil), 64)
 
 	_, _, err := pool.ToResolve()
 	c.Assert(err, IsNil)
@@ -748,7 +748,7 @@ func (s *poolSuite) TestAddFormatTooNew(c *C) {
 }
 
 func (s *poolSuite) TestAddOlderIgnored(c *C) {
-	pool := asserts.NewPool(s.db, 64)
+	pool := asserts.NewPool(s.db.ROUnderPolicy(nil), 64)
 
 	_, _, err := pool.ToResolve()
 	c.Assert(err, IsNil)
@@ -779,7 +779,7 @@ func (s *poolSuite) TestAddOlderIgnored(c *C) {
 }
 
 func (s *poolSuite) TestUnknownGroup(c *C) {
-	pool := asserts.NewPool(s.db, 64)
+	pool := asserts.NewPool(s.db.ROUnderPolicy(nil), 64)
 
 	_, err := pool.Singleton("suggestion")
 	c.Assert(err, IsNil)
@@ -792,7 +792,7 @@ func (s *poolSuite) TestUnknownGroup(c *C) {
 func (s *poolSuite) TestAddCurrentRevision(c *C) {
 	assertstest.AddMany(s.db, s.hub.StoreAccountKey(""), s.dev1Acct, s.decl1)
 
-	pool := asserts.NewPool(s.db, 64)
+	pool := asserts.NewPool(s.db.ROUnderPolicy(nil), 64)
 
 	atDev1Acct := s.dev1Acct.At()
 	atDev1Acct.Revision = asserts.RevisionNotKnown
@@ -840,7 +840,7 @@ func (s *poolSuite) TestAddCurrentRevision(c *C) {
 func (s *poolSuite) TestAddCurrentRevisionSeqForming(c *C) {
 	assertstest.AddMany(s.db, s.hub.StoreAccountKey(""), s.dev1Acct, s.decl1)
 
-	pool := asserts.NewPool(s.db, 64)
+	pool := asserts.NewPool(s.db.ROUnderPolicy(nil), 64)
 
 	atSeq := &asserts.AtSequence{
 		Type:        asserts.TestOnlySeqType,
@@ -888,7 +888,7 @@ func (s *poolSuite) TestUpdate(c *C) {
 	assertstest.AddMany(s.db, s.dev1Acct, s.decl1, s.rev1_1111)
 	assertstest.AddMany(s.db, s.dev2Acct, s.decl2, s.rev2_2222)
 
-	pool := asserts.NewPool(s.db, 64)
+	pool := asserts.NewPool(s.db.ROUnderPolicy(nil), 64)
 
 	err := pool.AddToUpdate(s.decl1.Ref(), "for_one") // group num: 0
 	c.Assert(err, IsNil)
@@ -940,7 +940,7 @@ func (s *poolSuite) TestUpdate(c *C) {
 func (s *poolSuite) TestUpdateSeqFormingUnpinnedNewerSequence(c *C) {
 	assertstest.AddMany(s.db, s.hub.StoreAccountKey(""), s.seq1_1111r5)
 
-	pool := asserts.NewPool(s.db, 64)
+	pool := asserts.NewPool(s.db.ROUnderPolicy(nil), 64)
 
 	atseq := &asserts.AtSequence{
 		Type:        s.seq1_1111r5.Type(),
@@ -996,7 +996,7 @@ func (s *poolSuite) TestUpdateSeqFormingUnpinnedNewerSequence(c *C) {
 func (s *poolSuite) TestUpdateSeqFormingUnpinnedSameSequenceNewerRev(c *C) {
 	assertstest.AddMany(s.db, s.hub.StoreAccountKey(""), s.seq1_1111r5)
 
-	pool := asserts.NewPool(s.db, 64)
+	pool := asserts.NewPool(s.db.ROUnderPolicy(nil), 64)
 
 	atseq := &asserts.AtSequence{
 		Type:        s.seq1_1111r5.Type(),
@@ -1052,7 +1052,7 @@ func (s *poolSuite) TestUpdateSeqFormingUnpinnedSameSequenceNewerRev(c *C) {
 func (s *poolSuite) TestUpdateSeqFormingUnpinnedSameSequenceSameRevNoop(c *C) {
 	assertstest.AddMany(s.db, s.hub.StoreAccountKey(""), s.seq1_1111r5)
 
-	pool := asserts.NewPool(s.db, 64)
+	pool := asserts.NewPool(s.db.ROUnderPolicy(nil), 64)
 
 	atseq := &asserts.AtSequence{
 		Type:        s.seq1_1111r5.Type(),
@@ -1103,7 +1103,7 @@ func (s *poolSuite) TestUpdateSeqFormingUnpinnedSameSequenceSameRevNoop(c *C) {
 func (s *poolSuite) TestUpdateSeqFormingPinnedNewerSequenceSameRevisionNoop(c *C) {
 	assertstest.AddMany(s.db, s.hub.StoreAccountKey(""), s.seq1_1111r5)
 
-	pool := asserts.NewPool(s.db, 64)
+	pool := asserts.NewPool(s.db.ROUnderPolicy(nil), 64)
 
 	atseq := &asserts.AtSequence{
 		Type:        s.seq1_1111r5.Type(),
@@ -1160,7 +1160,7 @@ func (s *poolSuite) TestUpdateSeqFormingPinnedNewerSequenceSameRevisionNoop(c *C
 func (s *poolSuite) TestUpdateSeqFormingPinnedNewerSequenceNewerRevisionNoop(c *C) {
 	assertstest.AddMany(s.db, s.hub.StoreAccountKey(""), s.seq1_1111r5)
 
-	pool := asserts.NewPool(s.db, 64)
+	pool := asserts.NewPool(s.db.ROUnderPolicy(nil), 64)
 
 	atseq := &asserts.AtSequence{
 		Type:        s.seq1_1111r5.Type(),
@@ -1210,7 +1210,7 @@ func (s *poolSuite) TestUpdateSeqFormingPinnedNewerSequenceNewerRevisionNoop(c *
 
 func (s *poolSuite) TestUpdateSeqFormingPinnedSameSequenceNewerRevision(c *C) {
 	assertstest.AddMany(s.db, s.hub.StoreAccountKey(""), s.seq1_1111r5)
-	pool := asserts.NewPool(s.db, 64)
+	pool := asserts.NewPool(s.db.ROUnderPolicy(nil), 64)
 
 	atseq := &asserts.AtSequence{
 		Type:        s.seq1_1111r5.Type(),
@@ -1257,7 +1257,7 @@ func (s *poolSuite) TestUpdateSeqFormingPinnedSameSequenceNewerRevision(c *C) {
 func (s *poolSuite) TestUpdateSeqFormingUseAssertRevision(c *C) {
 	assertstest.AddMany(s.db, s.hub.StoreAccountKey(""), s.seq1_1111r5)
 
-	pool := asserts.NewPool(s.db, 64)
+	pool := asserts.NewPool(s.db.ROUnderPolicy(nil), 64)
 
 	atseq := &asserts.AtSequence{
 		Type:        s.seq1_1111r5.Type(),
@@ -1287,7 +1287,7 @@ func (s *poolSuite) TestUpdateSeqFormingUseAssertRevision(c *C) {
 }
 
 func (s *poolSuite) TestAddSequenceToUpdateMissingSequenceError(c *C) {
-	pool := asserts.NewPool(s.db, 64)
+	pool := asserts.NewPool(s.db.ROUnderPolicy(nil), 64)
 	atseq := &asserts.AtSequence{
 		Type:        s.seq1_1111r5.Type(),
 		SequenceKey: []string{"1111"},
@@ -1298,7 +1298,7 @@ func (s *poolSuite) TestAddSequenceToUpdateMissingSequenceError(c *C) {
 }
 
 func (s *poolSuite) TestAddUnresolvedSeqUnresolved(c *C) {
-	pool := asserts.NewPool(s.db, 64)
+	pool := asserts.NewPool(s.db.ROUnderPolicy(nil), 64)
 
 	atseq := &asserts.AtSequence{
 		Type:        s.seq1_1111r5.Type(),
@@ -1331,7 +1331,7 @@ func (s *poolSuite) TestAddUnresolvedSeqUnresolved(c *C) {
 }
 
 func (s *poolSuite) TestAddUnresolvedSeqOnce(c *C) {
-	pool := asserts.NewPool(s.db, 64)
+	pool := asserts.NewPool(s.db.ROUnderPolicy(nil), 64)
 
 	atseq := &asserts.AtSequence{
 		Type:        s.seq1_1111r5.Type(),
@@ -1350,7 +1350,7 @@ func (s *poolSuite) TestAddUnresolvedSeqOnce(c *C) {
 
 func (s *poolSuite) TestAddSeqToUpdateOnce(c *C) {
 	assertstest.AddMany(s.db, s.hub.StoreAccountKey(""), s.seq1_1111r5)
-	pool := asserts.NewPool(s.db, 64)
+	pool := asserts.NewPool(s.db.ROUnderPolicy(nil), 64)
 
 	atseq := &asserts.AtSequence{
 		Type:        s.seq1_1111r5.Type(),
@@ -1368,7 +1368,7 @@ func (s *poolSuite) TestAddSeqToUpdateOnce(c *C) {
 }
 
 func (s *poolSuite) TestAddSeqToUpdateNotFound(c *C) {
-	pool := asserts.NewPool(s.db, 64)
+	pool := asserts.NewPool(s.db.ROUnderPolicy(nil), 64)
 
 	atseq := &asserts.AtSequence{
 		Type:        s.seq1_1111r5.Type(),
@@ -1385,7 +1385,7 @@ var errBoom = errors.New("boom")
 func (s *poolSuite) TestAddErrorEarly(c *C) {
 	assertstest.AddMany(s.db, s.hub.StoreAccountKey(""))
 
-	pool := asserts.NewPool(s.db, 64)
+	pool := asserts.NewPool(s.db.ROUnderPolicy(nil), 64)
 
 	storeKey := s.hub.StoreAccountKey("")
 	err := pool.AddToUpdate(storeKey.Ref(), "store_key")
@@ -1439,7 +1439,7 @@ func (s *poolSuite) TestAddErrorEarly(c *C) {
 func (s *poolSuite) TestAddErrorLater(c *C) {
 	assertstest.AddMany(s.db, s.hub.StoreAccountKey(""))
 
-	pool := asserts.NewPool(s.db, 64)
+	pool := asserts.NewPool(s.db.ROUnderPolicy(nil), 64)
 
 	storeKey := s.hub.StoreAccountKey("")
 	err := pool.AddToUpdate(storeKey.Ref(), "store_key")
@@ -1483,7 +1483,7 @@ func (s *poolSuite) TestNopUpdatePlusFetchOfPushed(c *C) {
 	assertstest.AddMany(s.db, s.decl1)
 	assertstest.AddMany(s.db, s.rev1_1111)
 
-	pool := asserts.NewPool(s.db, 64)
+	pool := asserts.NewPool(s.db.ROUnderPolicy(nil), 64)
 
 	atOne := s.decl1.At()
 	err := pool.AddToUpdate(&atOne.Ref, "for_one")
@@ -1542,7 +1542,7 @@ func (s *poolSuite) TestNopUpdatePlusFetchOfPushed(c *C) {
 func (s *poolSuite) TestAddToUpdateThenUnresolved(c *C) {
 	assertstest.AddMany(s.db, s.hub.StoreAccountKey(""))
 
-	pool := asserts.NewPool(s.db, 64)
+	pool := asserts.NewPool(s.db.ROUnderPolicy(nil), 64)
 
 	storeKey := s.hub.StoreAccountKey("")
 	storeKeyAt := storeKey.At()
@@ -1564,7 +1564,7 @@ func (s *poolSuite) TestAddToUpdateThenUnresolved(c *C) {
 func (s *poolSuite) TestAddUnresolvedThenToUpdate(c *C) {
 	assertstest.AddMany(s.db, s.hub.StoreAccountKey(""))
 
-	pool := asserts.NewPool(s.db, 64)
+	pool := asserts.NewPool(s.db.ROUnderPolicy(nil), 64)
 
 	storeKey := s.hub.StoreAccountKey("")
 	storeKeyAt := storeKey.At()
@@ -1586,7 +1586,7 @@ func (s *poolSuite) TestAddUnresolvedThenToUpdate(c *C) {
 func (s *poolSuite) TestNopUpdatePlusFetch(c *C) {
 	assertstest.AddMany(s.db, s.hub.StoreAccountKey(""))
 
-	pool := asserts.NewPool(s.db, 64)
+	pool := asserts.NewPool(s.db.ROUnderPolicy(nil), 64)
 
 	storeKey := s.hub.StoreAccountKey("")
 	err := pool.AddToUpdate(storeKey.Ref(), "store_key")
@@ -1628,7 +1628,7 @@ func (s *poolSuite) TestNopUpdatePlusFetch(c *C) {
 }
 
 func (s *poolSuite) TestParallelPartialResolutionFailure(c *C) {
-	pool := asserts.NewPool(s.db, 64)
+	pool := asserts.NewPool(s.db.ROUnderPolicy(nil), 64)
 
 	atOne := &asserts.AtRevision{
 		Ref:      asserts.Ref{Type: asserts.TestOnlyDeclType, PrimaryKey: []string{"one"}},
@@ -1686,7 +1686,7 @@ func (s *poolSuite) TestParallelPartialResolutionFailure(c *C) {
 func (s *poolSuite) TestAddErrors(c *C) {
 	assertstest.AddMany(s.db, s.hub.StoreAccountKey(""))
 
-	pool := asserts.NewPool(s.db, 64)
+	pool := asserts.NewPool(s.db.ROUnderPolicy(nil), 64)
 
 	storeKey := s.hub.StoreAccountKey("")
 	err := pool.AddToUpdate(storeKey.Ref(), "store_key")
@@ -1732,7 +1732,7 @@ func (s *poolSuite) TestPoolReuseWithClearGroupsAndUnchanged(c *C) {
 	assertstest.AddMany(s.db, s.dev1Acct, s.decl1)
 	assertstest.AddMany(s.db, s.dev2Acct, s.decl2)
 
-	pool := asserts.NewPool(s.db, 64)
+	pool := asserts.NewPool(s.db.ROUnderPolicy(nil), 64)
 
 	err := pool.AddToUpdate(s.decl1.Ref(), "for_one") // group num: 0
 	c.Assert(err, IsNil)
@@ -1777,7 +1777,7 @@ func (s *poolSuite) TestPoolReuseWithClearGroupsAndUnchanged(c *C) {
 
 func (s *poolSuite) TestBackstore(c *C) {
 	assertstest.AddMany(s.db, s.hub.StoreAccountKey(""), s.dev1Acct)
-	pool := asserts.NewPool(s.db, 64)
+	pool := asserts.NewPool(s.db.ROUnderPolicy(nil), 64)
 
 	at1111 := &asserts.AtRevision{
 		Ref:      asserts.Ref{Type: asserts.TestOnlyRevType, PrimaryKey: []string{"1111"}},

--- a/asserts/repair.go
+++ b/asserts/repair.go
@@ -112,7 +112,7 @@ func (r *Repair) Timestamp() time.Time {
 }
 
 // Implement further consistency checks.
-func (r *Repair) checkConsistency(db RODatabase, acck *AccountKey) error {
+func (r *Repair) checkConsistency(db RODatabaseView, acck *AccountKey) error {
 	// Do the cross-checks when this assertion is actually used,
 	// i.e. in the future repair code
 

--- a/asserts/serial_asserts.go
+++ b/asserts/serial_asserts.go
@@ -61,7 +61,7 @@ func (ser *Serial) Timestamp() time.Time {
 	return ser.timestamp
 }
 
-func (ser *Serial) checkConsistency(db RODatabase, acck *AccountKey) error {
+func (ser *Serial) checkConsistency(db RODatabaseView, acck *AccountKey) error {
 	if ser.AuthorityID() != ser.BrandID() {
 		// serial authority and brand do not match, check the model
 		a, err := db.Find(ModelType, map[string]string{

--- a/asserts/serial_asserts_test.go
+++ b/asserts/serial_asserts_test.go
@@ -179,7 +179,7 @@ func (ss *serialSuite) TestSerialCheck(c *C) {
 			}
 			model, err := brandDB.Sign(asserts.ModelType, modHeaders, nil, "")
 			c.Assert(err, IsNil)
-			err = checkDB.Add(model)
+			err = checkDB.Add(model, nil)
 			c.Assert(err, IsNil)
 		}
 

--- a/asserts/serial_asserts_test.go
+++ b/asserts/serial_asserts_test.go
@@ -197,7 +197,7 @@ func (ss *serialSuite) TestSerialCheck(c *C) {
 			continue
 		}
 
-		err = checkDB.Check(serial)
+		err = checkDB.Check(serial, nil)
 		if test.expectedErr == "" {
 			c.Check(err, IsNil)
 		} else {

--- a/asserts/snap_asserts.go
+++ b/asserts/snap_asserts.go
@@ -98,7 +98,7 @@ func (snapdcl *SnapDeclaration) Aliases() map[string]string {
 }
 
 // Implement further consistency checks.
-func (snapdcl *SnapDeclaration) checkConsistency(db RODatabase, acck *AccountKey) error {
+func (snapdcl *SnapDeclaration) checkConsistency(db RODatabaseView, acck *AccountKey) error {
 	if !db.IsTrustedAccount(snapdcl.AuthorityID()) {
 		return fmt.Errorf("snap-declaration assertion for %q (id %q) is not signed by a directly trusted authority: %s", snapdcl.SnapName(), snapdcl.SnapID(), snapdcl.AuthorityID())
 	}
@@ -448,7 +448,7 @@ func (snaprev *SnapRevision) Timestamp() time.Time {
 }
 
 // Implement further consistency checks.
-func (snaprev *SnapRevision) checkConsistency(db RODatabase, acck *AccountKey) error {
+func (snaprev *SnapRevision) checkConsistency(db RODatabaseView, acck *AccountKey) error {
 	// TODO: expand this to consider other stores signing on their own
 	if !db.IsTrustedAccount(snaprev.AuthorityID()) {
 		return fmt.Errorf("snap-revision assertion for snap id %q is not signed by a store: %s", snaprev.SnapID(), snaprev.AuthorityID())
@@ -580,7 +580,7 @@ func (validation *Validation) Timestamp() time.Time {
 }
 
 // Implement further consistency checks.
-func (validation *Validation) checkConsistency(db RODatabase, acck *AccountKey) error {
+func (validation *Validation) checkConsistency(db RODatabaseView, acck *AccountKey) error {
 	_, err := db.Find(SnapDeclarationType, map[string]string{
 		"series":  validation.Series(),
 		"snap-id": validation.ApprovedSnapID(),
@@ -676,7 +676,7 @@ func (basedcl *BaseDeclaration) SlotRule(interfaceName string) *SlotRule {
 }
 
 // Implement further consistency checks.
-func (basedcl *BaseDeclaration) checkConsistency(db RODatabase, acck *AccountKey) error {
+func (basedcl *BaseDeclaration) checkConsistency(db RODatabaseView, acck *AccountKey) error {
 	// XXX: not signed or stored yet in a db, but being ready for that
 	if !db.IsTrustedAccount(basedcl.AuthorityID()) {
 		return fmt.Errorf("base-declaration assertion for series %s is not signed by a directly trusted authority: %s", basedcl.Series(), basedcl.AuthorityID())
@@ -811,7 +811,7 @@ func (snapdev *SnapDeveloper) PublisherID() string {
 	return snapdev.HeaderString("publisher-id")
 }
 
-func (snapdev *SnapDeveloper) checkConsistency(db RODatabase, acck *AccountKey) error {
+func (snapdev *SnapDeveloper) checkConsistency(db RODatabaseView, acck *AccountKey) error {
 	// Check authority is the publisher or trusted.
 	authorityID := snapdev.AuthorityID()
 	publisherID := snapdev.PublisherID()

--- a/asserts/snap_asserts_test.go
+++ b/asserts/snap_asserts_test.go
@@ -589,7 +589,7 @@ func (sds *snapDeclSuite) TestSnapDeclarationCheck(c *C) {
 	snapDecl, err := storeDB.Sign(asserts.SnapDeclarationType, headers, nil, "")
 	c.Assert(err, IsNil)
 
-	err = db.Check(snapDecl)
+	err = db.Check(snapDecl, nil)
 	c.Assert(err, IsNil)
 }
 
@@ -608,7 +608,7 @@ func (sds *snapDeclSuite) TestSnapDeclarationCheckUntrustedAuthority(c *C) {
 	snapDecl, err := otherDB.Sign(asserts.SnapDeclarationType, headers, nil, "")
 	c.Assert(err, IsNil)
 
-	err = db.Check(snapDecl)
+	err = db.Check(snapDecl, nil)
 	c.Assert(err, ErrorMatches, `snap-declaration assertion for "foo" \(id "snap-id-1"\) is not signed by a directly trusted authority:.*`)
 }
 
@@ -625,7 +625,7 @@ func (sds *snapDeclSuite) TestSnapDeclarationCheckMissingPublisherAccount(c *C) 
 	snapDecl, err := storeDB.Sign(asserts.SnapDeclarationType, headers, nil, "")
 	c.Assert(err, IsNil)
 
-	err = db.Check(snapDecl)
+	err = db.Check(snapDecl, nil)
 	c.Assert(err, ErrorMatches, `snap-declaration assertion for "foo" \(id "snap-id-1"\) does not have a matching account assertion for the publisher "dev-id1"`)
 }
 
@@ -804,7 +804,7 @@ func (sbs *snapBuildSuite) TestSnapBuildCheck(c *C) {
 	snapBuild, err := devDB.Sign(asserts.SnapBuildType, headers, nil, "")
 	c.Assert(err, IsNil)
 
-	err = db.Check(snapBuild)
+	err = db.Check(snapBuild, nil)
 	c.Assert(err, IsNil)
 }
 
@@ -822,7 +822,7 @@ func (sbs *snapBuildSuite) TestSnapBuildCheckInconsistentTimestamp(c *C) {
 	snapBuild, err := devDB.Sign(asserts.SnapBuildType, headers, nil, "")
 	c.Assert(err, IsNil)
 
-	err = db.Check(snapBuild)
+	err = db.Check(snapBuild, nil)
 	c.Assert(err, ErrorMatches, `snap-build assertion timestamp "2013-01-01 14:00:00 \+0000 UTC" outside of signing key validity \(key valid since.*\)`)
 }
 
@@ -950,7 +950,7 @@ func (srs *snapRevSuite) TestSnapRevisionCheck(c *C) {
 	snapRev, err := storeDB.Sign(asserts.SnapRevisionType, headers, nil, "")
 	c.Assert(err, IsNil)
 
-	err = db.Check(snapRev)
+	err = db.Check(snapRev, nil)
 	c.Assert(err, IsNil)
 }
 
@@ -963,7 +963,7 @@ func (srs *snapRevSuite) TestSnapRevisionCheckInconsistentTimestamp(c *C) {
 	snapRev, err := storeDB.Sign(asserts.SnapRevisionType, headers, nil, "")
 	c.Assert(err, IsNil)
 
-	err = db.Check(snapRev)
+	err = db.Check(snapRev, nil)
 	c.Assert(err, ErrorMatches, `snap-revision assertion timestamp "2013-01-01 14:00:00 \+0000 UTC" outside of signing key validity \(key valid since.*\)`)
 }
 
@@ -978,7 +978,7 @@ func (srs *snapRevSuite) TestSnapRevisionCheckUntrustedAuthority(c *C) {
 	snapRev, err := otherDB.Sign(asserts.SnapRevisionType, headers, nil, "")
 	c.Assert(err, IsNil)
 
-	err = db.Check(snapRev)
+	err = db.Check(snapRev, nil)
 	c.Assert(err, ErrorMatches, `snap-revision assertion for snap id "snap-id-1" is not signed by a store:.*`)
 }
 
@@ -989,7 +989,7 @@ func (srs *snapRevSuite) TestSnapRevisionCheckMissingDeveloperAccount(c *C) {
 	snapRev, err := storeDB.Sign(asserts.SnapRevisionType, headers, nil, "")
 	c.Assert(err, IsNil)
 
-	err = db.Check(snapRev)
+	err = db.Check(snapRev, nil)
 	c.Assert(err, ErrorMatches, `snap-revision assertion for snap id "snap-id-1" does not have a matching account assertion for the developer "dev-id1"`)
 }
 
@@ -1002,7 +1002,7 @@ func (srs *snapRevSuite) TestSnapRevisionCheckMissingDeclaration(c *C) {
 	snapRev, err := storeDB.Sign(asserts.SnapRevisionType, headers, nil, "")
 	c.Assert(err, IsNil)
 
-	err = db.Check(snapRev)
+	err = db.Check(snapRev, nil)
 	c.Assert(err, ErrorMatches, `snap-revision assertion for snap id "snap-id-1" does not have a matching snap-declaration assertion`)
 }
 
@@ -1042,7 +1042,7 @@ func (srs *snapRevSuite) TestSnapRevisionDelegation(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(db.Add(ad), IsNil)
 
-	err = db.Check(snapRev)
+	err = db.Check(snapRev, nil)
 	c.Check(err, IsNil)
 }
 
@@ -1084,7 +1084,7 @@ func (srs *snapRevSuite) TestSnapRevisionDelegationInconsistentTimestamp(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(db.Add(ad), IsNil)
 
-	err = db.Check(snapRev)
+	err = db.Check(snapRev, nil)
 	c.Check(err, ErrorMatches, `delegated snap-revision assertion from "canonical" to "other" timestamp ".*" is outside of all supporting delegation constraints validity`)
 }
 
@@ -1233,7 +1233,7 @@ func (vs *validationSuite) TestValidationCheck(c *C) {
 	validation, err := devDB.Sign(asserts.ValidationType, headers, nil, "")
 	c.Assert(err, IsNil)
 
-	err = db.Check(validation)
+	err = db.Check(validation, nil)
 	c.Assert(err, IsNil)
 }
 
@@ -1250,7 +1250,7 @@ func (vs *validationSuite) TestValidationCheckWrongAuthority(c *C) {
 	validation, err := storeDB.Sign(asserts.ValidationType, headers, nil, "")
 	c.Assert(err, IsNil)
 
-	err = db.Check(validation)
+	err = db.Check(validation, nil)
 	c.Assert(err, ErrorMatches, `validation assertion by snap "foo" \(id "snap-id-1"\) not signed by its publisher`)
 }
 
@@ -1317,7 +1317,7 @@ func (vs *validationSuite) TestMissingGatedSnapDeclaration(c *C) {
 	a, err := devDB.Sign(asserts.ValidationType, headers, nil, "")
 	c.Assert(err, IsNil)
 
-	err = db.Check(a)
+	err = db.Check(a, nil)
 	c.Assert(err, ErrorMatches, `validation assertion by snap-id "snap-id-1" does not have a matching snap-declaration assertion for approved-snap-id "snap-id-2"`)
 }
 
@@ -1331,7 +1331,7 @@ func (vs *validationSuite) TestMissingGatingSnapDeclaration(c *C) {
 	a, err := devDB.Sign(asserts.ValidationType, headers, nil, "")
 	c.Assert(err, IsNil)
 
-	err = db.Check(a)
+	err = db.Check(a, nil)
 	c.Assert(err, ErrorMatches, `validation assertion by snap-id "snap-id-1" does not have a matching snap-declaration assertion`)
 }
 
@@ -1507,7 +1507,7 @@ func (s *baseDeclSuite) TestBaseDeclarationCheckUntrustedAuthority(c *C) {
 	baseDecl, err := otherDB.Sign(asserts.BaseDeclarationType, headers, nil, "")
 	c.Assert(err, IsNil)
 
-	err = db.Check(baseDecl)
+	err = db.Check(baseDecl, nil)
 	c.Assert(err, ErrorMatches, `base-declaration assertion for series 16 is not signed by a directly trusted authority: other`)
 }
 
@@ -1766,7 +1766,7 @@ func (sds *snapDevSuite) TestAuthorityIsPublisher(c *C) {
 	c.Assert(snapDev.HeaderString("authority-id"), Equals, "dev-id1")
 	c.Assert(snapDev.HeaderString("publisher-id"), Equals, "dev-id1")
 
-	err = db.Check(snapDev)
+	err = db.Check(snapDev, nil)
 	c.Assert(err, IsNil)
 }
 
@@ -1795,7 +1795,7 @@ func (sds *snapDevSuite) TestAuthorityIsNotPublisher(c *C) {
 	c.Assert(snapDev.HeaderString("authority-id"), Equals, "dev-id1")
 	c.Assert(snapDev.HeaderString("publisher-id"), Equals, "dev-id2")
 
-	err = db.Check(snapDev)
+	err = db.Check(snapDev, nil)
 	c.Assert(err, ErrorMatches, `snap-developer must be signed by the publisher or a trusted authority but got authority "dev-id1" and publisher "dev-id2"`)
 }
 
@@ -1832,7 +1832,7 @@ func (sds *snapDevSuite) TestAuthorityIsNotPublisherButIsTrusted(c *C) {
 	c.Assert(snapDev.HeaderString("authority-id"), Equals, "canonical")
 	c.Assert(snapDev.HeaderString("publisher-id"), Equals, "dev-id1")
 
-	err = db.Check(snapDev)
+	err = db.Check(snapDev, nil)
 	c.Assert(err, IsNil)
 }
 
@@ -1870,7 +1870,7 @@ func (sds *snapDevSuite) TestCheckNewPublisherAccountExists(c *C) {
 	c.Assert(snapDev.HeaderString("publisher-id"), Equals, "dev-id2")
 
 	// There's no account for dev-id2 yet so it should fail.
-	err = db.Check(snapDev)
+	err = db.Check(snapDev, nil)
 	c.Assert(err, ErrorMatches, `snap-developer assertion for snap-id "snap-id-1" does not have a matching account assertion for the publisher "dev-id2"`)
 
 	// But once the dev-id2 account is added the snap-developer is ok.
@@ -1884,7 +1884,7 @@ func (sds *snapDevSuite) TestCheckNewPublisherAccountExists(c *C) {
 	err = db.Add(account)
 	c.Assert(err, IsNil)
 
-	err = db.Check(snapDev)
+	err = db.Check(snapDev, nil)
 	c.Assert(err, IsNil)
 }
 
@@ -1914,7 +1914,7 @@ func (sds *snapDevSuite) TestCheckDeveloperAccountExists(c *C) {
 		},
 	}, nil, "")
 	c.Assert(err, IsNil)
-	err = db.Check(snapDev)
+	err = db.Check(snapDev, nil)
 	c.Assert(err, ErrorMatches, `snap-developer assertion for snap-id "snap-id-1" does not have a matching account assertion for the developer "dev-id2"`)
 }
 
@@ -1930,7 +1930,7 @@ func (sds *snapDevSuite) TestCheckMissingDeclaration(c *C) {
 	snapDev, err := devDB.Sign(asserts.SnapDeveloperType, headers, nil, "")
 	c.Assert(err, IsNil)
 
-	err = db.Check(snapDev)
+	err = db.Check(snapDev, nil)
 	c.Assert(err, ErrorMatches, `snap-developer assertion for snap id "snap-id-1" does not have a matching snap-declaration assertion`)
 }
 

--- a/asserts/snap_asserts_test.go
+++ b/asserts/snap_asserts_test.go
@@ -1086,6 +1086,10 @@ func (srs *snapRevSuite) TestSnapRevisionDelegationInconsistentTimestamp(c *C) {
 
 	err = db.Check(snapRev, nil)
 	c.Check(err, ErrorMatches, `delegated snap-revision assertion from "canonical" to "other" timestamp ".*" is outside of all supporting delegation constraints validity`)
+
+	_, err = db.DelegationConstraints(snapRev)
+	c.Check(err, ErrorMatches, `delegated snap-revision assertion from "canonical" to "other" timestamp ".*" is outside of all supporting delegation constraints validity`)
+
 }
 
 func (srs *snapRevSuite) TestPrimaryKey(c *C) {

--- a/asserts/snap_asserts_test.go
+++ b/asserts/snap_asserts_test.go
@@ -570,7 +570,7 @@ func prereqDevAccount(c *C, storeDB assertstest.SignerDB, db *asserts.Database) 
 	dev1Acct := assertstest.NewAccount(storeDB, "developer1", map[string]interface{}{
 		"account-id": "dev-id1",
 	}, "")
-	err := db.Add(dev1Acct)
+	err := db.Add(dev1Acct, nil)
 	c.Assert(err, IsNil)
 }
 
@@ -764,10 +764,10 @@ func makeStoreAndCheckDB(c *C) (store *assertstest.StoreStack, checkDB *asserts.
 	c.Assert(err, IsNil)
 
 	// add store key
-	err = checkDB.Add(store.StoreAccountKey(""))
+	err = checkDB.Add(store.StoreAccountKey(""), nil)
 	c.Assert(err, IsNil)
 	// add generic key
-	err = checkDB.Add(store.GenericKey)
+	err = checkDB.Add(store.GenericKey, nil)
 	c.Assert(err, IsNil)
 
 	return store, checkDB
@@ -781,9 +781,9 @@ func setup3rdPartySigning(c *C, username string, storeDB assertstest.SignerDB, c
 	}, "")
 	accKey := assertstest.NewAccountKey(storeDB, acct, nil, privKey.PublicKey(), "")
 
-	err := checkDB.Add(acct)
+	err := checkDB.Add(acct, nil)
 	c.Assert(err, IsNil)
-	err = checkDB.Add(accKey)
+	err = checkDB.Add(accKey, nil)
 	c.Assert(err, IsNil)
 
 	return assertstest.NewSigningDB(acct.AccountID(), privKey)
@@ -936,7 +936,7 @@ func prereqSnapDecl(c *C, storeDB assertstest.SignerDB, db *asserts.Database) {
 		"timestamp":    time.Now().Format(time.RFC3339),
 	}, nil, "")
 	c.Assert(err, IsNil)
-	err = db.Add(snapDecl)
+	err = db.Add(snapDecl, nil)
 	c.Assert(err, IsNil)
 }
 
@@ -1040,7 +1040,7 @@ func (srs *snapRevSuite) TestSnapRevisionDelegation(c *C) {
 	}
 	ad, err := storeDB.Sign(asserts.AuthorityDelegationType, headers, nil, "")
 	c.Assert(err, IsNil)
-	c.Check(db.Add(ad), IsNil)
+	c.Check(db.Add(ad, nil), IsNil)
 
 	err = db.Check(snapRev, nil)
 	c.Check(err, IsNil)
@@ -1082,7 +1082,7 @@ func (srs *snapRevSuite) TestSnapRevisionDelegationInconsistentTimestamp(c *C) {
 	}
 	ad, err := storeDB.Sign(asserts.AuthorityDelegationType, headers, nil, "")
 	c.Assert(err, IsNil)
-	c.Check(db.Add(ad), IsNil)
+	c.Check(db.Add(ad, nil), IsNil)
 
 	err = db.Check(snapRev, nil)
 	c.Check(err, ErrorMatches, `delegated snap-revision assertion from "canonical" to "other" timestamp ".*" is outside of all supporting delegation constraints validity`)
@@ -1097,7 +1097,7 @@ func (srs *snapRevSuite) TestPrimaryKey(c *C) {
 	headers := srs.makeHeaders(nil)
 	snapRev, err := storeDB.Sign(asserts.SnapRevisionType, headers, nil, "")
 	c.Assert(err, IsNil)
-	err = db.Add(snapRev)
+	err = db.Add(snapRev, nil)
 	c.Assert(err, IsNil)
 
 	_, err = db.Find(asserts.SnapRevisionType, map[string]string{
@@ -1218,7 +1218,7 @@ func prereqSnapDecl2(c *C, storeDB assertstest.SignerDB, db *asserts.Database) {
 		"timestamp":    time.Now().Format(time.RFC3339),
 	}, nil, "")
 	c.Assert(err, IsNil)
-	err = db.Add(snapDecl)
+	err = db.Add(snapDecl, nil)
 	c.Assert(err, IsNil)
 }
 
@@ -1754,7 +1754,7 @@ func (sds *snapDevSuite) TestAuthorityIsPublisher(c *C) {
 		"timestamp":    time.Now().UTC().Format(time.RFC3339),
 	}, nil, "")
 	c.Assert(err, IsNil)
-	err = db.Add(snapDecl)
+	err = db.Add(snapDecl, nil)
 	c.Assert(err, IsNil)
 
 	snapDev, err := devDB.Sign(asserts.SnapDeveloperType, map[string]interface{}{
@@ -1782,7 +1782,7 @@ func (sds *snapDevSuite) TestAuthorityIsNotPublisher(c *C) {
 		"timestamp":    time.Now().UTC().Format(time.RFC3339),
 	}, nil, "")
 	c.Assert(err, IsNil)
-	err = db.Add(snapDecl)
+	err = db.Add(snapDecl, nil)
 	c.Assert(err, IsNil)
 
 	snapDev, err := devDB.Sign(asserts.SnapDeveloperType, map[string]interface{}{
@@ -1809,7 +1809,7 @@ func (sds *snapDevSuite) TestAuthorityIsNotPublisherButIsTrusted(c *C) {
 		"timestamp":    time.Now().UTC().Format(time.RFC3339),
 	}, nil, "")
 	c.Assert(err, IsNil)
-	err = db.Add(account)
+	err = db.Add(account, nil)
 	c.Assert(err, IsNil)
 
 	snapDecl, err := storeDB.Sign(asserts.SnapDeclarationType, map[string]interface{}{
@@ -1820,7 +1820,7 @@ func (sds *snapDevSuite) TestAuthorityIsNotPublisherButIsTrusted(c *C) {
 		"timestamp":    time.Now().UTC().Format(time.RFC3339),
 	}, nil, "")
 	c.Assert(err, IsNil)
-	err = db.Add(snapDecl)
+	err = db.Add(snapDecl, nil)
 	c.Assert(err, IsNil)
 
 	snapDev, err := storeDB.Sign(asserts.SnapDeveloperType, map[string]interface{}{
@@ -1846,7 +1846,7 @@ func (sds *snapDevSuite) TestCheckNewPublisherAccountExists(c *C) {
 		"timestamp":    time.Now().UTC().Format(time.RFC3339),
 	}, nil, "")
 	c.Assert(err, IsNil)
-	err = db.Add(account)
+	err = db.Add(account, nil)
 	c.Assert(err, IsNil)
 
 	snapDecl, err := storeDB.Sign(asserts.SnapDeclarationType, map[string]interface{}{
@@ -1857,7 +1857,7 @@ func (sds *snapDevSuite) TestCheckNewPublisherAccountExists(c *C) {
 		"timestamp":    time.Now().UTC().Format(time.RFC3339),
 	}, nil, "")
 	c.Assert(err, IsNil)
-	err = db.Add(snapDecl)
+	err = db.Add(snapDecl, nil)
 	c.Assert(err, IsNil)
 
 	snapDev, err := storeDB.Sign(asserts.SnapDeveloperType, map[string]interface{}{
@@ -1881,7 +1881,7 @@ func (sds *snapDevSuite) TestCheckNewPublisherAccountExists(c *C) {
 		"timestamp":    time.Now().UTC().Format(time.RFC3339),
 	}, nil, "")
 	c.Assert(err, IsNil)
-	err = db.Add(account)
+	err = db.Add(account, nil)
 	c.Assert(err, IsNil)
 
 	err = db.Check(snapDev, nil)
@@ -1900,7 +1900,7 @@ func (sds *snapDevSuite) TestCheckDeveloperAccountExists(c *C) {
 		"timestamp":    time.Now().UTC().Format(time.RFC3339),
 	}, nil, "")
 	c.Assert(err, IsNil)
-	err = db.Add(snapDecl)
+	err = db.Add(snapDecl, nil)
 	c.Assert(err, IsNil)
 
 	snapDev, err := devDB.Sign(asserts.SnapDeveloperType, map[string]interface{}{

--- a/asserts/snapasserts/snapasserts_test.go
+++ b/asserts/snapasserts/snapasserts_test.go
@@ -61,9 +61,9 @@ func (s *snapassertsSuite) SetUpTest(c *C) {
 	s.localDB = localDB
 
 	// add in prereqs assertions
-	err = s.localDB.Add(s.storeSigning.StoreAccountKey(""))
+	err = s.localDB.Add(s.storeSigning.StoreAccountKey(""), nil)
 	c.Assert(err, IsNil)
-	err = s.localDB.Add(s.dev1Acct)
+	err = s.localDB.Add(s.dev1Acct, nil)
 	c.Assert(err, IsNil)
 
 	headers := map[string]interface{}{
@@ -75,7 +75,7 @@ func (s *snapassertsSuite) SetUpTest(c *C) {
 	}
 	snapDecl, err := s.storeSigning.Sign(asserts.SnapDeclarationType, headers, nil, "")
 	c.Assert(err, IsNil)
-	err = s.localDB.Add(snapDecl)
+	err = s.localDB.Add(snapDecl, nil)
 	c.Assert(err, IsNil)
 }
 
@@ -110,7 +110,7 @@ func (s *snapassertsSuite) TestCrossCheckHappy(c *C) {
 	}
 	snapRev, err := s.storeSigning.Sign(asserts.SnapRevisionType, headers, nil, "")
 	c.Assert(err, IsNil)
-	err = s.localDB.Add(snapRev)
+	err = s.localDB.Add(snapRev, nil)
 	c.Assert(err, IsNil)
 
 	si := &snap.SideInfo{
@@ -139,7 +139,7 @@ func (s *snapassertsSuite) TestCrossCheckErrors(c *C) {
 	}
 	snapRev, err := s.storeSigning.Sign(asserts.SnapRevisionType, headers, nil, "")
 	c.Assert(err, IsNil)
-	err = s.localDB.Add(snapRev)
+	err = s.localDB.Add(snapRev, nil)
 	c.Assert(err, IsNil)
 
 	si := &snap.SideInfo{
@@ -197,7 +197,7 @@ func (s *snapassertsSuite) TestCrossCheckRevokedSnapDecl(c *C) {
 	}
 	snapDecl, err := s.storeSigning.Sign(asserts.SnapDeclarationType, headers, nil, "")
 	c.Assert(err, IsNil)
-	err = s.localDB.Add(snapDecl)
+	err = s.localDB.Add(snapDecl, nil)
 	c.Assert(err, IsNil)
 
 	digest := makeDigest(12)
@@ -212,7 +212,7 @@ func (s *snapassertsSuite) TestCrossCheckRevokedSnapDecl(c *C) {
 	}
 	snapRev, err := s.storeSigning.Sign(asserts.SnapRevisionType, headers, nil, "")
 	c.Assert(err, IsNil)
-	err = s.localDB.Add(snapRev)
+	err = s.localDB.Add(snapRev, nil)
 	c.Assert(err, IsNil)
 
 	si := &snap.SideInfo{
@@ -239,7 +239,7 @@ func (s *snapassertsSuite) TestDeriveSideInfoHappy(c *C) {
 	}
 	snapRev, err := s.storeSigning.Sign(asserts.SnapRevisionType, headers, nil, "")
 	c.Assert(err, IsNil)
-	err = s.localDB.Add(snapRev)
+	err = s.localDB.Add(snapRev, nil)
 	c.Assert(err, IsNil)
 
 	tempdir := c.MkDir()
@@ -281,7 +281,7 @@ func (s *snapassertsSuite) TestDeriveSideInfoSizeMismatch(c *C) {
 	}
 	snapRev, err := s.storeSigning.Sign(asserts.SnapRevisionType, headers, nil, "")
 	c.Assert(err, IsNil)
-	err = s.localDB.Add(snapRev)
+	err = s.localDB.Add(snapRev, nil)
 	c.Assert(err, IsNil)
 
 	tempdir := c.MkDir()
@@ -305,7 +305,7 @@ func (s *snapassertsSuite) TestDeriveSideInfoRevokedSnapDecl(c *C) {
 	}
 	snapDecl, err := s.storeSigning.Sign(asserts.SnapDeclarationType, headers, nil, "")
 	c.Assert(err, IsNil)
-	err = s.localDB.Add(snapDecl)
+	err = s.localDB.Add(snapDecl, nil)
 	c.Assert(err, IsNil)
 
 	digest := makeDigest(42)
@@ -320,7 +320,7 @@ func (s *snapassertsSuite) TestDeriveSideInfoRevokedSnapDecl(c *C) {
 	}
 	snapRev, err := s.storeSigning.Sign(asserts.SnapRevisionType, headers, nil, "")
 	c.Assert(err, IsNil)
-	err = s.localDB.Add(snapRev)
+	err = s.localDB.Add(snapRev, nil)
 	c.Assert(err, IsNil)
 
 	tempdir := c.MkDir()

--- a/asserts/store_asserts.go
+++ b/asserts/store_asserts.go
@@ -65,7 +65,7 @@ func (store *Store) Timestamp() time.Time {
 	return store.timestamp
 }
 
-func (store *Store) checkConsistency(db RODatabase, acck *AccountKey) error {
+func (store *Store) checkConsistency(db RODatabaseView, acck *AccountKey) error {
 	// Will be applied to a system's snapd or influence snapd
 	// policy decisions (via friendly-stores) so must be signed by a trusted
 	// authority!

--- a/asserts/store_asserts_test.go
+++ b/asserts/store_asserts_test.go
@@ -166,7 +166,7 @@ func (s *storeSuite) TestCheckAuthority(c *C) {
 
 	// Add account for operator.
 	operator := assertstest.NewAccount(storeDB, "op-id1", nil, "")
-	err := db.Add(operator)
+	err := db.Add(operator, nil)
 	c.Assert(err, IsNil)
 
 	otherDB := setup3rdPartySigning(c, "other", storeDB, db)
@@ -219,7 +219,7 @@ func (s *storeSuite) TestCheckOperatorAccount(c *C) {
 
 	// Add the op-id1 account.
 	operator := assertstest.NewAccount(storeDB, "op-id1", map[string]interface{}{"account-id": "op-id1"}, "")
-	err = db.Add(operator)
+	err = db.Add(operator, nil)
 	c.Assert(err, IsNil)
 
 	// Now the operator exists so Check succeeds.

--- a/asserts/store_asserts_test.go
+++ b/asserts/store_asserts_test.go
@@ -180,13 +180,13 @@ func (s *storeSuite) TestCheckAuthority(c *C) {
 	// store signed by some other account fails.
 	store, err := otherDB.Sign(asserts.StoreType, storeHeaders, nil, "")
 	c.Assert(err, IsNil)
-	err = db.Check(store)
+	err = db.Check(store, nil)
 	c.Assert(err, ErrorMatches, `store assertion "store1" is not signed by a directly trusted authority: other`)
 
 	// but succeeds when signed by a trusted authority.
 	store, err = storeDB.Sign(asserts.StoreType, storeHeaders, nil, "")
 	c.Assert(err, IsNil)
-	err = db.Check(store)
+	err = db.Check(store, nil)
 	c.Assert(err, IsNil)
 }
 
@@ -214,7 +214,7 @@ func (s *storeSuite) TestCheckOperatorAccount(c *C) {
 	c.Assert(err, IsNil)
 
 	// No account for operator op-id1 yet, so Check fails.
-	err = db.Check(store)
+	err = db.Check(store, nil)
 	c.Assert(err, ErrorMatches, `store assertion "store1" does not have a matching account assertion for the operator "op-id1"`)
 
 	// Add the op-id1 account.
@@ -223,7 +223,7 @@ func (s *storeSuite) TestCheckOperatorAccount(c *C) {
 	c.Assert(err, IsNil)
 
 	// Now the operator exists so Check succeeds.
-	err = db.Check(store)
+	err = db.Check(store, nil)
 	c.Assert(err, IsNil)
 }
 

--- a/asserts/sysdb/sysdb_test.go
+++ b/asserts/sysdb/sysdb_test.go
@@ -153,7 +153,7 @@ func (sdbs *sysDBSuite) TestOpenSysDatabase(c *C) {
 
 	c.Check(trustedAcc.(*asserts.Account).Validation(), Equals, "verified")
 
-	err = db.Check(trustedAcc)
+	err = db.Check(trustedAcc, nil)
 	c.Check(err, IsNil)
 
 	// check generic
@@ -169,14 +169,14 @@ func (sdbs *sysDBSuite) TestOpenSysDatabase(c *C) {
 
 	c.Check(genericAcc.(*asserts.Account).Validation(), Equals, "verified")
 
-	err = db.Check(genericAcc)
+	err = db.Check(genericAcc, nil)
 	c.Check(err, IsNil)
 
-	err = db.Check(sysdb.GenericClassicModel())
+	err = db.Check(sysdb.GenericClassicModel(), nil)
 	c.Check(err, IsNil)
 
 	// extraneous
-	err = db.Check(sdbs.probeAssert)
+	err = db.Check(sdbs.probeAssert, nil)
 	c.Check(err, ErrorMatches, "no matching public key.*")
 }
 
@@ -188,7 +188,7 @@ func (sdbs *sysDBSuite) TestOpenSysDatabaseExtras(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(db, NotNil)
 
-	err = db.Check(sdbs.probeAssert)
+	err = db.Check(sdbs.probeAssert, nil)
 	c.Check(err, IsNil)
 }
 

--- a/asserts/system_user.go
+++ b/asserts/system_user.go
@@ -116,7 +116,7 @@ func (su *SystemUser) ValidAt(when time.Time) bool {
 }
 
 // Implement further consistency checks.
-func (su *SystemUser) checkConsistency(db RODatabase, acck *AccountKey) error {
+func (su *SystemUser) checkConsistency(db RODatabaseView, acck *AccountKey) error {
 	// Do the cross-checks when this assertion is actually used,
 	// i.e. in the create-user code. See also Model.checkConsitency
 

--- a/cmd/snap-preseed/main_test.go
+++ b/cmd/snap-preseed/main_test.go
@@ -335,7 +335,7 @@ func mockClassicModel() *asserts.Model {
 	return assertstest.FakeAssertion(headers, nil).(*asserts.Model)
 }
 
-func (fs *Fake16Seed) LoadAssertions(db asserts.RODatabase, commitTo func(*asserts.Batch) error) error {
+func (fs *Fake16Seed) LoadAssertions(db asserts.RODatabaseView, commitTo func(*asserts.Batch) error) error {
 	return fs.LoadAssertionsErr
 }
 

--- a/cmd/snap-preseed/main_test.go
+++ b/cmd/snap-preseed/main_test.go
@@ -336,7 +336,7 @@ func mockClassicModel() *asserts.Model {
 	return assertstest.FakeAssertion(headers, nil).(*asserts.Model)
 }
 
-func (fs *Fake16Seed) LoadAssertions(db snapasserts.Finder, commitTo func(*asserts.Batch) error) error {
+func (fs *Fake16Seed) LoadAssertions(db snapasserts.Finder, commitTo func(*asserts.Batch, asserts.AssertionPolicy) error) error {
 	return fs.LoadAssertionsErr
 }
 

--- a/cmd/snap-preseed/main_test.go
+++ b/cmd/snap-preseed/main_test.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/assertstest"
+	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/cmd/snap-preseed"
 	"github.com/snapcore/snapd/cmd/snaplock/runinhibit"
 	"github.com/snapcore/snapd/dirs"
@@ -335,7 +336,7 @@ func mockClassicModel() *asserts.Model {
 	return assertstest.FakeAssertion(headers, nil).(*asserts.Model)
 }
 
-func (fs *Fake16Seed) LoadAssertions(db asserts.RODatabaseView, commitTo func(*asserts.Batch) error) error {
+func (fs *Fake16Seed) LoadAssertions(db snapasserts.Finder, commitTo func(*asserts.Batch) error) error {
 	return fs.LoadAssertionsErr
 }
 

--- a/cmd/snap/cmd_download.go
+++ b/cmd/snap/cmd_download.go
@@ -91,10 +91,9 @@ func fetchSnapAssertionsDirect(tsto *image.ToolingStore, snapPath string, snapIn
 	save := func(a asserts.Assertion) error {
 		return encoder.Encode(a)
 	}
-	// XXX policy
 	f := tsto.AssertionFetcher(db, save)
 
-	_, err = image.FetchAndCheckSnapAssertions(snapPath, snapInfo, f, db.ROUnderPolicy(nil))
+	_, err = image.FetchAndCheckSnapAssertions(snapPath, snapInfo, f, db)
 	return assertPath, err
 }
 

--- a/cmd/snap/cmd_download.go
+++ b/cmd/snap/cmd_download.go
@@ -91,7 +91,7 @@ func fetchSnapAssertionsDirect(tsto *image.ToolingStore, snapPath string, snapIn
 	save := func(a asserts.Assertion) error {
 		return encoder.Encode(a)
 	}
-	f := tsto.AssertionFetcher(db, save)
+	f := tsto.AssertionFetcher(db, save, asserts.TransparentAssertionPolicy)
 
 	_, err = image.FetchAndCheckSnapAssertions(snapPath, snapInfo, f, db)
 	return assertPath, err

--- a/cmd/snap/cmd_download.go
+++ b/cmd/snap/cmd_download.go
@@ -91,9 +91,10 @@ func fetchSnapAssertionsDirect(tsto *image.ToolingStore, snapPath string, snapIn
 	save := func(a asserts.Assertion) error {
 		return encoder.Encode(a)
 	}
+	// XXX policy
 	f := tsto.AssertionFetcher(db, save)
 
-	_, err = image.FetchAndCheckSnapAssertions(snapPath, snapInfo, f, db)
+	_, err = image.FetchAndCheckSnapAssertions(snapPath, snapInfo, f, db.ROUnderPolicy(nil))
 	return assertPath, err
 }
 

--- a/daemon/api_asserts.go
+++ b/daemon/api_asserts.go
@@ -110,7 +110,7 @@ func doAssert(c *Command, r *http.Request, user *auth.UserState) Response {
 	state.Lock()
 	defer state.Unlock()
 
-	if err := assertstate.AddBatch(state, batch, &asserts.CommitOptions{
+	if err := assertstate.AddBatch(state, batch, nil, &asserts.CommitOptions{
 		Precheck: true,
 	}); err != nil {
 		return BadRequest("assert failed: %v", err)

--- a/image/helpers.go
+++ b/image/helpers.go
@@ -449,6 +449,7 @@ func (tsto *ToolingStore) DownloadMany(toDownload []SnapToDownload, curSnaps []*
 
 // AssertionFetcher creates an asserts.Fetcher for assertions against the given store using dlOpts for authorization, the fetcher will add assertions in the given database and after that also call save for each of them.
 func (tsto *ToolingStore) AssertionFetcher(db *asserts.Database, save func(asserts.Assertion) error) asserts.Fetcher {
+	// XXX policy
 	retrieve := func(ref *asserts.Ref) (asserts.Assertion, error) {
 		return tsto.sto.Assertion(ref.Type, ref.PrimaryKey, tsto.user)
 	}
@@ -463,7 +464,7 @@ func (tsto *ToolingStore) AssertionFetcher(db *asserts.Database, save func(asser
 		}
 		return save(a)
 	}
-	return asserts.NewFetcher(db, retrieve, save2)
+	return asserts.NewFetcher(db.ROUnderPolicy(nil), retrieve, save2)
 }
 
 // FetchAndCheckSnapAssertions fetches and cross checks the snap assertions matching the given snap file using the provided asserts.Fetcher and assertion database.

--- a/image/helpers.go
+++ b/image/helpers.go
@@ -454,7 +454,8 @@ func (tsto *ToolingStore) AssertionFetcher(db *asserts.Database, save func(asser
 	}
 	save2 := func(a asserts.Assertion) error {
 		// for checking
-		err := db.Add(a)
+		// XXX policy
+		err := db.Add(a, nil)
 		if err != nil {
 			if _, ok := err.(*asserts.RevisionError); ok {
 				return nil

--- a/image/helpers.go
+++ b/image/helpers.go
@@ -467,7 +467,7 @@ func (tsto *ToolingStore) AssertionFetcher(db *asserts.Database, save func(asser
 }
 
 // FetchAndCheckSnapAssertions fetches and cross checks the snap assertions matching the given snap file using the provided asserts.Fetcher and assertion database.
-func FetchAndCheckSnapAssertions(snapPath string, info *snap.Info, f asserts.Fetcher, db asserts.RODatabase) (*asserts.SnapDeclaration, error) {
+func FetchAndCheckSnapAssertions(snapPath string, info *snap.Info, f asserts.Fetcher, db asserts.RODatabaseView) (*asserts.SnapDeclaration, error) {
 	sha3_384, size, err := asserts.SnapFileSHA3_384(snapPath)
 	if err != nil {
 		return nil, err

--- a/image/helpers.go
+++ b/image/helpers.go
@@ -449,7 +449,6 @@ func (tsto *ToolingStore) DownloadMany(toDownload []SnapToDownload, curSnaps []*
 
 // AssertionFetcher creates an asserts.Fetcher for assertions against the given store using dlOpts for authorization, the fetcher will add assertions in the given database and after that also call save for each of them.
 func (tsto *ToolingStore) AssertionFetcher(db *asserts.Database, save func(asserts.Assertion) error) asserts.Fetcher {
-	// XXX policy
 	retrieve := func(ref *asserts.Ref) (asserts.Assertion, error) {
 		return tsto.sto.Assertion(ref.Type, ref.PrimaryKey, tsto.user)
 	}
@@ -464,11 +463,11 @@ func (tsto *ToolingStore) AssertionFetcher(db *asserts.Database, save func(asser
 		}
 		return save(a)
 	}
-	return asserts.NewFetcher(db.ROUnderPolicy(nil), retrieve, save2)
+	return asserts.NewFetcher(db, retrieve, save2)
 }
 
 // FetchAndCheckSnapAssertions fetches and cross checks the snap assertions matching the given snap file using the provided asserts.Fetcher and assertion database.
-func FetchAndCheckSnapAssertions(snapPath string, info *snap.Info, f asserts.Fetcher, db asserts.RODatabaseView) (*asserts.SnapDeclaration, error) {
+func FetchAndCheckSnapAssertions(snapPath string, info *snap.Info, f asserts.Fetcher, db snapasserts.Finder) (*asserts.SnapDeclaration, error) {
 	sha3_384, size, err := asserts.SnapFileSHA3_384(snapPath)
 	if err != nil {
 		return nil, err

--- a/image/image_linux.go
+++ b/image/image_linux.go
@@ -326,7 +326,8 @@ func setupSeed(tsto *ToolingStore, model *asserts.Model, opts *Options) error {
 	}
 
 	newFetcher := func(save func(asserts.Assertion) error) asserts.Fetcher {
-		return tsto.AssertionFetcher(db, save)
+		// XXX policy: pass a device policy
+		return tsto.AssertionFetcher(db, save, asserts.TransparentAssertionPolicy)
 	}
 	f, err := w.Start(db, newFetcher)
 	if err != nil {

--- a/image/image_linux.go
+++ b/image/image_linux.go
@@ -282,8 +282,6 @@ func setupSeed(tsto *ToolingStore, model *asserts.Model, opts *Options) error {
 	if err != nil {
 		return err
 	}
-	// XXX policy
-	roView := db.ROUnderPolicy(nil)
 
 	wOpts := &seedwriter.Options{
 		SeedDir:        seedDir,
@@ -330,7 +328,7 @@ func setupSeed(tsto *ToolingStore, model *asserts.Model, opts *Options) error {
 	newFetcher := func(save func(asserts.Assertion) error) asserts.Fetcher {
 		return tsto.AssertionFetcher(db, save)
 	}
-	f, err := w.Start(roView, newFetcher)
+	f, err := w.Start(db, newFetcher)
 	if err != nil {
 		return err
 	}
@@ -349,7 +347,7 @@ func setupSeed(tsto *ToolingStore, model *asserts.Model, opts *Options) error {
 
 	var curSnaps []*CurrentSnap
 	for _, sn := range localSnaps {
-		si, aRefs, err := seedwriter.DeriveSideInfo(sn.Path, f, roView)
+		si, aRefs, err := seedwriter.DeriveSideInfo(sn.Path, f, db)
 		if err != nil && !asserts.IsNotFound(err) {
 			return err
 		}
@@ -424,7 +422,7 @@ func setupSeed(tsto *ToolingStore, model *asserts.Model, opts *Options) error {
 
 			// fetch snap assertions
 			prev := len(f.Refs())
-			if _, err = FetchAndCheckSnapAssertions(dlsn.Path, dlsn.Info, f, roView); err != nil {
+			if _, err = FetchAndCheckSnapAssertions(dlsn.Path, dlsn.Info, f, db); err != nil {
 				return err
 			}
 			aRefs := f.Refs()[prev:]

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -608,7 +608,8 @@ func (s *imageSuite) loadSeed(c *C, seeddir string) (essSnaps []*seed.Snap, runS
 		return b.CommitTo(db, nil)
 	}
 
-	err = seed.LoadAssertions(db, commitTo)
+	roDB = db.ROUnderPolicy(nil)
+	err = seed.LoadAssertions(roDB, commitTo)
 	c.Assert(err, IsNil)
 
 	err = seed.LoadMeta(timings.New(nil))
@@ -618,7 +619,7 @@ func (s *imageSuite) loadSeed(c *C, seeddir string) (essSnaps []*seed.Snap, runS
 	runSnaps, err = seed.ModeSnaps("run")
 	c.Assert(err, IsNil)
 
-	return essSnaps, runSnaps, db
+	return essSnaps, runSnaps, roDB
 }
 
 func (s *imageSuite) TestSetupSeed(c *C) {

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -585,7 +585,7 @@ func (s *imageSuite) setupSnaps(c *C, publishers map[string]string, defaultsYaml
 	s.MakeAssertedSnap(c, snapBaseNone, nil, snap.R(1), "other")
 }
 
-func (s *imageSuite) loadSeed(c *C, seeddir string) (essSnaps []*seed.Snap, runSnaps []*seed.Snap, roDB asserts.RODatabase) {
+func (s *imageSuite) loadSeed(c *C, seeddir string) (essSnaps []*seed.Snap, runSnaps []*seed.Snap, roDB asserts.RODatabaseView) {
 	label := ""
 	systems, err := filepath.Glob(filepath.Join(seeddir, "systems", "*"))
 	c.Assert(err, IsNil)

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -604,8 +604,8 @@ func (s *imageSuite) loadSeed(c *C, seeddir string) (essSnaps []*seed.Snap, runS
 	})
 	c.Assert(err, IsNil)
 
-	commitTo := func(b *asserts.Batch) error {
-		return b.CommitTo(db, nil)
+	commitTo := func(b *asserts.Batch, pol asserts.AssertionPolicy) error {
+		return b.CommitTo(db, pol, nil)
 	}
 
 	err = seed.LoadAssertions(db, commitTo)

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -608,8 +608,7 @@ func (s *imageSuite) loadSeed(c *C, seeddir string) (essSnaps []*seed.Snap, runS
 		return b.CommitTo(db, nil)
 	}
 
-	roDB = db.ROUnderPolicy(nil)
-	err = seed.LoadAssertions(roDB, commitTo)
+	err = seed.LoadAssertions(db, commitTo)
 	c.Assert(err, IsNil)
 
 	err = seed.LoadMeta(timings.New(nil))
@@ -619,7 +618,7 @@ func (s *imageSuite) loadSeed(c *C, seeddir string) (essSnaps []*seed.Snap, runS
 	runSnaps, err = seed.ModeSnaps("run")
 	c.Assert(err, IsNil)
 
-	return essSnaps, runSnaps, roDB
+	return essSnaps, runSnaps, db.ROWithPolicy(nil)
 }
 
 func (s *imageSuite) TestSetupSeed(c *C) {

--- a/overlord/assertstate/assertmgr.go
+++ b/overlord/assertstate/assertmgr.go
@@ -76,7 +76,7 @@ func cachedDB(s *state.State) *asserts.Database {
 }
 
 // DB returns a read-only view of system assertion database.
-func DB(s *state.State) asserts.RODatabase {
+func DB(s *state.State) asserts.RODatabaseView {
 	return cachedDB(s)
 }
 

--- a/overlord/assertstate/assertmgr.go
+++ b/overlord/assertstate/assertmgr.go
@@ -78,7 +78,7 @@ func cachedDB(s *state.State) *asserts.Database {
 // DB returns a read-only view of system assertion database.
 func DB(s *state.State) asserts.RODatabaseView {
 	// XXX policy
-	return cachedDB(s).ROUnderPolicy(nil)
+	return cachedDB(s).ROWithPolicy(nil)
 }
 
 // doValidateSnap fetches the relevant assertions for the snap being installed and cross checks them with the snap.

--- a/overlord/assertstate/assertmgr.go
+++ b/overlord/assertstate/assertmgr.go
@@ -77,7 +77,8 @@ func cachedDB(s *state.State) *asserts.Database {
 
 // DB returns a read-only view of system assertion database.
 func DB(s *state.State) asserts.RODatabaseView {
-	return cachedDB(s)
+	// XXX policy
+	return cachedDB(s).ROUnderPolicy(nil)
 }
 
 // doValidateSnap fetches the relevant assertions for the snap being installed and cross checks them with the snap.

--- a/overlord/assertstate/assertstate.go
+++ b/overlord/assertstate/assertstate.go
@@ -39,11 +39,13 @@ import (
 // Add the given assertion to the system assertion database.
 func Add(s *state.State, a asserts.Assertion) error {
 	// TODO: deal together with asserts itself with (cascading) side effects of possible assertion updates
+	// XXX policy
 	return cachedDB(s).Add(a)
 }
 
 // AddBatch adds the given assertion batch to the system assertion database.
 func AddBatch(s *state.State, batch *asserts.Batch, opts *asserts.CommitOptions) error {
+	// XXX policy
 	return batch.CommitTo(cachedDB(s), opts)
 }
 
@@ -526,6 +528,7 @@ func validationSetAssertionForMonitor(st *state.State, accountID, name string, s
 	}
 
 	db := cachedDB(st)
+	// XXX policy
 
 	// try to get existing one from db
 	if sequence > 0 {
@@ -544,7 +547,7 @@ func validationSetAssertionForMonitor(st *state.State, accountID, name string, s
 
 	// try to resolve or update with pool
 	// XXX policy
-	pool := asserts.NewPool(db.ROUnderPolicy(nil), maxGroups)
+	pool := asserts.NewPool(db.ROWithPolicy(nil), maxGroups)
 	atSeq := &asserts.AtSequence{
 		Type:        asserts.ValidationSetType,
 		SequenceKey: []string{release.Series, accountID, name},
@@ -649,7 +652,7 @@ func validationSetAssertionForEnforce(st *state.State, accountID, name string, s
 	}
 
 	// XXX policy
-	pool := asserts.NewPool(db.ROUnderPolicy(nil), maxGroups)
+	pool := asserts.NewPool(db.ROWithPolicy(nil), maxGroups)
 	atSeq := &asserts.AtSequence{
 		Type:        asserts.ValidationSetType,
 		SequenceKey: []string{release.Series, accountID, name},

--- a/overlord/assertstate/assertstate.go
+++ b/overlord/assertstate/assertstate.go
@@ -44,9 +44,12 @@ func Add(s *state.State, a asserts.Assertion) error {
 }
 
 // AddBatch adds the given assertion batch to the system assertion database.
-func AddBatch(s *state.State, batch *asserts.Batch, opts *asserts.CommitOptions) error {
-	// XXX policy
-	return batch.CommitTo(cachedDB(s), opts)
+func AddBatch(s *state.State, batch *asserts.Batch, pol asserts.AssertionPolicy, opts *asserts.CommitOptions) error {
+	// XXX policy: this should not be needed once we have a default policy concept
+	if pol == nil {
+		pol = asserts.TransparentAssertionPolicy
+	}
+	return batch.CommitTo(cachedDB(s), pol, opts)
 }
 
 func findError(format string, ref *asserts.Ref, err error) error {

--- a/overlord/assertstate/assertstate.go
+++ b/overlord/assertstate/assertstate.go
@@ -40,7 +40,7 @@ import (
 func Add(s *state.State, a asserts.Assertion) error {
 	// TODO: deal together with asserts itself with (cascading) side effects of possible assertion updates
 	// XXX policy
-	return cachedDB(s).Add(a)
+	return cachedDB(s).Add(a, nil)
 }
 
 // AddBatch adds the given assertion batch to the system assertion database.

--- a/overlord/assertstate/assertstate.go
+++ b/overlord/assertstate/assertstate.go
@@ -543,7 +543,8 @@ func validationSetAssertionForMonitor(st *state.State, accountID, name string, s
 	}
 
 	// try to resolve or update with pool
-	pool := asserts.NewPool(db, maxGroups)
+	// XXX policy
+	pool := asserts.NewPool(db.ROUnderPolicy(nil), maxGroups)
 	atSeq := &asserts.AtSequence{
 		Type:        asserts.ValidationSetType,
 		SequenceKey: []string{release.Series, accountID, name},
@@ -647,7 +648,8 @@ func validationSetAssertionForEnforce(st *state.State, accountID, name string, s
 		headers["sequence"] = fmt.Sprintf("%d", sequence)
 	}
 
-	pool := asserts.NewPool(db, maxGroups)
+	// XXX policy
+	pool := asserts.NewPool(db.ROUnderPolicy(nil), maxGroups)
 	atSeq := &asserts.AtSequence{
 		Type:        asserts.ValidationSetType,
 		SequenceKey: []string{release.Series, accountID, name},

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -79,7 +79,7 @@ var _ = Suite(&assertMgrSuite{})
 type fakeStore struct {
 	storetest.Store
 	state                           *state.State
-	db                              asserts.RODatabase
+	db                              asserts.RODatabaseView
 	maxDeclSupportedFormat          int
 	maxValidationSetSupportedFormat int
 

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -269,7 +269,7 @@ func (s *assertMgrSuite) SetUpTest(c *C) {
 
 	s.fakeStore = &fakeStore{
 		state: s.state,
-		db:    s.storeSigning,
+		db:    s.storeSigning.ROUnderPolicy(nil),
 		// leave this comment to keep old gofmt happy
 		maxDeclSupportedFormat:          asserts.SnapDeclarationType.MaxSupportedFormat(),
 		maxValidationSetSupportedFormat: asserts.ValidationSetType.MaxSupportedFormat(),
@@ -284,7 +284,8 @@ func (s *assertMgrSuite) TestDB(c *C) {
 	defer s.state.Unlock()
 
 	db := assertstate.DB(s.state)
-	c.Check(db, FitsTypeOf, (*asserts.Database)(nil))
+	c.Assert(db, NotNil)
+	c.Check(db.IsTrustedAccount("can0nical"), Equals, true)
 }
 
 func (s *assertMgrSuite) TestAdd(c *C) {

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -269,7 +269,7 @@ func (s *assertMgrSuite) SetUpTest(c *C) {
 
 	s.fakeStore = &fakeStore{
 		state: s.state,
-		db:    s.storeSigning.ROUnderPolicy(nil),
+		db:    s.storeSigning.ROWithPolicy(nil),
 		// leave this comment to keep old gofmt happy
 		maxDeclSupportedFormat:          asserts.SnapDeclarationType.MaxSupportedFormat(),
 		maxValidationSetSupportedFormat: asserts.ValidationSetType.MaxSupportedFormat(),

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -3306,7 +3306,7 @@ func (s *assertMgrSuite) TestTemporaryDB(c *C) {
 	tempDB := assertstate.TemporaryDB(st)
 	c.Assert(tempDB, NotNil)
 	// and add the model to it
-	err = tempDB.Add(model)
+	err = tempDB.Add(model, nil)
 	c.Assert(err, IsNil)
 	fromTemp, err := tempDB.Find(asserts.ModelType, hdrs)
 	c.Assert(err, IsNil)
@@ -3322,7 +3322,7 @@ func (s *assertMgrSuite) TestTemporaryDB(c *C) {
 	// such that we can lookup the revision 2 in a temporary DB
 	tempDB = assertstate.TemporaryDB(st)
 	c.Assert(tempDB, NotNil)
-	err = tempDB.Add(modelRev2)
+	err = tempDB.Add(modelRev2, nil)
 	c.Assert(err, IsNil)
 	fromTemp, err = tempDB.Find(asserts.ModelType, hdrs)
 	c.Assert(err, IsNil)

--- a/overlord/assertstate/bulk.go
+++ b/overlord/assertstate/bulk.go
@@ -45,10 +45,7 @@ const storeGroup = "store assertion"
 var maxGroups = 256
 
 func bulkRefreshSnapDeclarations(s *state.State, snapStates map[string]*snapstate.SnapState, userID int, deviceCtx snapstate.DeviceContext, opts *RefreshAssertionsOptions) error {
-	db := cachedDB(s)
-
-	// XXX policy
-	pool := asserts.NewPool(db.ROWithPolicy(nil), maxGroups)
+	pool := asserts.NewPool(cachedDB(s).ROWithPolicy(nil), maxGroups)
 
 	var mergedRPErr *resolvePoolError
 	tryResolvePool := func() error {
@@ -142,9 +139,7 @@ func bulkRefreshSnapDeclarations(s *state.State, snapStates map[string]*snapstat
 }
 
 func bulkRefreshValidationSetAsserts(s *state.State, vsets map[string]*ValidationSetTracking, beforeCommitChecker func(*asserts.Database, asserts.Backstore) error, userID int, deviceCtx snapstate.DeviceContext, opts *RefreshAssertionsOptions) error {
-	db := cachedDB(s)
-	// XXX policy
-	pool := asserts.NewPool(db.ROWithPolicy(nil), maxGroups)
+	pool := asserts.NewPool(cachedDB(s).ROWithPolicy(nil), maxGroups)
 
 	ignoreNotFound := make(map[string]bool)
 
@@ -254,7 +249,6 @@ func resolvePool(s *state.State, pool *asserts.Pool, checkBeforeCommit func(*ass
 	}
 	sto := snapstate.Store(s, deviceCtx)
 	db := cachedDB(s)
-	// XXX policy
 	unsupported := handleUnsupported(db)
 
 	for {
@@ -309,6 +303,7 @@ func resolvePool(s *state.State, pool *asserts.Pool, checkBeforeCommit func(*ass
 			return err
 		}
 	}
+	// XXX policy
 	pool.CommitTo(db)
 
 	errors := pool.Errors()

--- a/overlord/assertstate/bulk.go
+++ b/overlord/assertstate/bulk.go
@@ -48,7 +48,7 @@ func bulkRefreshSnapDeclarations(s *state.State, snapStates map[string]*snapstat
 	db := cachedDB(s)
 
 	// XXX policy
-	pool := asserts.NewPool(db.ROUnderPolicy(nil), maxGroups)
+	pool := asserts.NewPool(db.ROWithPolicy(nil), maxGroups)
 
 	var mergedRPErr *resolvePoolError
 	tryResolvePool := func() error {
@@ -144,7 +144,7 @@ func bulkRefreshSnapDeclarations(s *state.State, snapStates map[string]*snapstat
 func bulkRefreshValidationSetAsserts(s *state.State, vsets map[string]*ValidationSetTracking, beforeCommitChecker func(*asserts.Database, asserts.Backstore) error, userID int, deviceCtx snapstate.DeviceContext, opts *RefreshAssertionsOptions) error {
 	db := cachedDB(s)
 	// XXX policy
-	pool := asserts.NewPool(db.ROUnderPolicy(nil), maxGroups)
+	pool := asserts.NewPool(db.ROWithPolicy(nil), maxGroups)
 
 	ignoreNotFound := make(map[string]bool)
 
@@ -255,7 +255,7 @@ func resolvePool(s *state.State, pool *asserts.Pool, checkBeforeCommit func(*ass
 	sto := snapstate.Store(s, deviceCtx)
 	db := cachedDB(s)
 	// XXX policy
-	unsupported := handleUnsupported(db.ROUnderPolicy(nil))
+	unsupported := handleUnsupported(db)
 
 	for {
 		storeOpts := &store.RefreshOptions{IsAutoRefresh: opts.IsAutoRefresh}

--- a/overlord/assertstate/bulk.go
+++ b/overlord/assertstate/bulk.go
@@ -47,7 +47,8 @@ var maxGroups = 256
 func bulkRefreshSnapDeclarations(s *state.State, snapStates map[string]*snapstate.SnapState, userID int, deviceCtx snapstate.DeviceContext, opts *RefreshAssertionsOptions) error {
 	db := cachedDB(s)
 
-	pool := asserts.NewPool(db, maxGroups)
+	// XXX policy
+	pool := asserts.NewPool(db.ROUnderPolicy(nil), maxGroups)
 
 	var mergedRPErr *resolvePoolError
 	tryResolvePool := func() error {
@@ -142,7 +143,8 @@ func bulkRefreshSnapDeclarations(s *state.State, snapStates map[string]*snapstat
 
 func bulkRefreshValidationSetAsserts(s *state.State, vsets map[string]*ValidationSetTracking, beforeCommitChecker func(*asserts.Database, asserts.Backstore) error, userID int, deviceCtx snapstate.DeviceContext, opts *RefreshAssertionsOptions) error {
 	db := cachedDB(s)
-	pool := asserts.NewPool(db, maxGroups)
+	// XXX policy
+	pool := asserts.NewPool(db.ROUnderPolicy(nil), maxGroups)
 
 	ignoreNotFound := make(map[string]bool)
 
@@ -252,7 +254,8 @@ func resolvePool(s *state.State, pool *asserts.Pool, checkBeforeCommit func(*ass
 	}
 	sto := snapstate.Store(s, deviceCtx)
 	db := cachedDB(s)
-	unsupported := handleUnsupported(db)
+	// XXX policy
+	unsupported := handleUnsupported(db.ROUnderPolicy(nil))
 
 	for {
 		storeOpts := &store.RefreshOptions{IsAutoRefresh: opts.IsAutoRefresh}

--- a/overlord/assertstate/helpers.go
+++ b/overlord/assertstate/helpers.go
@@ -53,8 +53,10 @@ func doFetch(s *state.State, userID int, deviceCtx snapstate.DeviceContext, fetc
 	// TODO: once we have a bulk assertion retrieval endpoint this approach will change
 
 	db := cachedDB(s)
+	// XXX policy
+	roView := db.ROUnderPolicy(nil)
 
-	b := asserts.NewBatch(handleUnsupported(db))
+	b := asserts.NewBatch(handleUnsupported(roView))
 
 	user, err := userFromUserID(s, userID)
 	if err != nil {
@@ -69,7 +71,7 @@ func doFetch(s *state.State, userID int, deviceCtx snapstate.DeviceContext, fetc
 	}
 
 	s.Unlock()
-	err = b.Fetch(db, retrieve, fetching)
+	err = b.Fetch(roView, retrieve, fetching)
 	s.Lock()
 	if err != nil {
 		return err

--- a/overlord/assertstate/helpers.go
+++ b/overlord/assertstate/helpers.go
@@ -37,7 +37,7 @@ func userFromUserID(st *state.State, userID int) (*auth.UserState, error) {
 
 // handleUnsupported behaves as a fallback in case of bugs, we do ask
 // the store to filter unsupported formats!
-func handleUnsupported(db asserts.RODatabase) func(ref *asserts.Ref, unsupportedErr error) error {
+func handleUnsupported(db asserts.RODatabaseView) func(ref *asserts.Ref, unsupportedErr error) error {
 	return func(ref *asserts.Ref, unsupportedErr error) error {
 		if _, err := ref.Resolve(db.Find); err != nil {
 			// nothing there yet or any other error

--- a/overlord/assertstate/helpers.go
+++ b/overlord/assertstate/helpers.go
@@ -80,5 +80,6 @@ func doFetch(s *state.State, userID int, deviceCtx snapstate.DeviceContext, fetc
 	// TODO: trigger w. caller a global sanity check if a is revoked
 	// (but try to save as much possible still),
 	// or err is a check error
-	return b.CommitTo(db, nil)
+	// XXX policy: use a device policy
+	return b.CommitTo(db, asserts.TransparentAssertionPolicy, nil)
 }

--- a/overlord/assertstate/validation_set_tracking_test.go
+++ b/overlord/assertstate/validation_set_tracking_test.go
@@ -48,7 +48,7 @@ func (s *validationSetTrackingSuite) SetUpTest(c *C) {
 		Trusted:   storeSigning.Trusted,
 	})
 	c.Assert(err, IsNil)
-	c.Assert(db.Add(storeSigning.StoreAccountKey("")), IsNil)
+	assertstest.AddMany(db, storeSigning.StoreAccountKey(""))
 	assertstate.ReplaceDB(s.st, db)
 
 	s.dev1acct = assertstest.NewAccount(storeSigning, "developer1", nil, "")

--- a/overlord/configstate/configcore/proxy_test.go
+++ b/overlord/configstate/configcore/proxy_test.go
@@ -67,8 +67,7 @@ func (s *proxySuite) SetUpTest(c *C) {
 	assertstate.ReplaceDB(s.state, db)
 	s.state.Unlock()
 
-	err = db.Add(s.storeSigning.StoreAccountKey(""))
-	c.Assert(err, IsNil)
+	assertstest.AddMany(db, s.storeSigning.StoreAccountKey(""))
 }
 
 func (s *proxySuite) makeMockEtcEnvironment(c *C) {

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -114,7 +114,7 @@ type fakeStore struct {
 	storetest.Store
 
 	state *state.State
-	db    asserts.RODatabase
+	db    asserts.RODatabaseView
 }
 
 func (sto *fakeStore) pokeStateLock() {

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -199,8 +199,7 @@ func (s *deviceMgrBaseSuite) SetUpTest(c *C) {
 		s.state.Unlock()
 	})
 
-	err = db.Add(s.storeSigning.StoreAccountKey(""))
-	c.Assert(err, IsNil)
+	assertstest.AddMany(db, s.storeSigning.StoreAccountKey(""))
 
 	hookMgr, err := hookstate.Manager(s.state, s.o.TaskRunner())
 	c.Assert(err, IsNil)

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -84,7 +84,7 @@ type deviceMgrBaseSuite struct {
 	se      *overlord.StateEngine
 	hookMgr *hookstate.HookManager
 	mgr     *devicestate.DeviceManager
-	db      *asserts.Database
+	db      asserts.RODatabaseView
 
 	bootloader *bootloadertest.MockBootloader
 
@@ -212,7 +212,7 @@ func (s *deviceMgrBaseSuite) SetUpTest(c *C) {
 	mgr, err := devicestate.Manager(s.state, hookMgr, s.o.TaskRunner(), s.newStore)
 	c.Assert(err, IsNil)
 
-	s.db = db
+	s.db = db.ROUnderPolicy(nil)
 	s.hookMgr = hookMgr
 	s.o.AddManager(s.hookMgr)
 	s.mgr = mgr
@@ -230,7 +230,7 @@ func (s *deviceMgrBaseSuite) SetUpTest(c *C) {
 	s.state.Lock()
 	snapstate.ReplaceStore(s.state, &fakeStore{
 		state: s.state,
-		db:    s.storeSigning,
+		db:    s.storeSigning.ROUnderPolicy(nil),
 	})
 	s.state.Unlock()
 

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/assertstest"
+	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/asserts/sysdb"
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/bootloader"
@@ -114,7 +115,7 @@ type fakeStore struct {
 	storetest.Store
 
 	state *state.State
-	db    asserts.RODatabaseView
+	db    snapasserts.Finder
 }
 
 func (sto *fakeStore) pokeStateLock() {
@@ -212,7 +213,7 @@ func (s *deviceMgrBaseSuite) SetUpTest(c *C) {
 	mgr, err := devicestate.Manager(s.state, hookMgr, s.o.TaskRunner(), s.newStore)
 	c.Assert(err, IsNil)
 
-	s.db = db.ROUnderPolicy(nil)
+	s.db = db.ROWithPolicy(nil)
 	s.hookMgr = hookMgr
 	s.o.AddManager(s.hookMgr)
 	s.mgr = mgr
@@ -230,7 +231,7 @@ func (s *deviceMgrBaseSuite) SetUpTest(c *C) {
 	s.state.Lock()
 	snapstate.ReplaceStore(s.state, &fakeStore{
 		state: s.state,
-		db:    s.storeSigning.ROUnderPolicy(nil),
+		db:    s.storeSigning,
 	})
 	s.state.Unlock()
 

--- a/overlord/devicestate/firstboot.go
+++ b/overlord/devicestate/firstboot.go
@@ -397,8 +397,8 @@ func loadDeviceSeed(st *state.State, sysLabel string) (deviceSeed seed.Seed, err
 
 	// collect and
 	// set device,model from the model assertion
-	commitTo := func(batch *asserts.Batch) error {
-		return assertstate.AddBatch(st, batch, nil)
+	commitTo := func(batch *asserts.Batch, pol asserts.AssertionPolicy) error {
+		return assertstate.AddBatch(st, batch, pol, nil)
 	}
 
 	if err := deviceSeed.LoadAssertions(assertstate.DB(st), commitTo); err != nil {

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -658,10 +658,12 @@ func (s *firstBoot16Suite) TestPopulateFromSeedHappy(c *C) {
 
 func (s *firstBoot16Suite) TestPopulateFromSeedMissingBootloader(c *C) {
 	s.startOverlord(c)
-	st0 := s.overlord.State()
-	st0.Lock()
-	db := assertstate.DB(st0)
-	st0.Unlock()
+	db, err := asserts.OpenDatabase(&asserts.DatabaseConfig{
+		Backstore:       asserts.NewMemoryBackstore(),
+		Trusted:         s.StoreSigning.Trusted,
+		OtherPredefined: s.StoreSigning.Generic,
+	})
+	c.Assert(err, IsNil)
 
 	// we run only with the relevant managers to produce the error
 	// situation
@@ -682,7 +684,7 @@ func (s *firstBoot16Suite) TestPopulateFromSeedMissingBootloader(c *C) {
 	c.Assert(err, IsNil)
 
 	st.Lock()
-	assertstate.ReplaceDB(st, db.(*asserts.Database))
+	assertstate.ReplaceDB(st, db)
 	st.Unlock()
 
 	o.AddManager(o.TaskRunner())

--- a/overlord/devicestate/handlers_serial.go
+++ b/overlord/devicestate/handlers_serial.go
@@ -705,7 +705,8 @@ func (m *DeviceManager) doRequestSerial(t *state.Task, _ *tomb.Tomb) error {
 			if err != nil {
 				return err
 			}
-			return b.CommitTo(savedb, nil)
+			// XXX policy: use a device policy
+			return b.CommitTo(savedb, asserts.TransparentAssertionPolicy, nil)
 		})
 		if err != nil && err != errNoSaveSupport {
 			return fmt.Errorf("cannot save serial to device save assertion database: %v", err)
@@ -802,7 +803,8 @@ func acceptSerialPlusBatch(t *state.Task, serial *asserts.Serial, batch *asserts
 	if err != nil {
 		return err
 	}
-	return assertstate.AddBatch(st, batch, &asserts.CommitOptions{Precheck: true})
+	// XXX policy: use a device policy
+	return assertstate.AddBatch(st, batch, asserts.TransparentAssertionPolicy, &asserts.CommitOptions{Precheck: true})
 }
 
 var repeatRequestSerial string // for tests

--- a/overlord/devicestate/handlers_serial.go
+++ b/overlord/devicestate/handlers_serial.go
@@ -693,7 +693,8 @@ func (m *DeviceManager) doRequestSerial(t *state.Task, _ *tomb.Tomb) error {
 				return ref.Resolve(db.Find)
 			}
 			b := asserts.NewBatch(nil)
-			err := b.Fetch(savedb, retrieve, func(f asserts.Fetcher) error {
+			// XXX policy
+			err := b.Fetch(savedb.ROUnderPolicy(nil), retrieve, func(f asserts.Fetcher) error {
 				// save the associated model as well
 				// as it might be required for cross-checks
 				// of the serial

--- a/overlord/devicestate/handlers_serial.go
+++ b/overlord/devicestate/handlers_serial.go
@@ -693,8 +693,7 @@ func (m *DeviceManager) doRequestSerial(t *state.Task, _ *tomb.Tomb) error {
 				return ref.Resolve(db.Find)
 			}
 			b := asserts.NewBatch(nil)
-			// XXX policy
-			err := b.Fetch(savedb.ROUnderPolicy(nil), retrieve, func(f asserts.Fetcher) error {
+			err := b.Fetch(savedb, retrieve, func(f asserts.Fetcher) error {
 				// save the associated model as well
 				// as it might be required for cross-checks
 				// of the serial

--- a/overlord/devicestate/handlers_systems.go
+++ b/overlord/devicestate/handlers_systems.go
@@ -207,7 +207,7 @@ func (m *DeviceManager) doCreateRecoverySystem(t *state.Task, _ *tomb.Tomb) (err
 		return logNewSystemSnapFile(filepath.Join(recoverySystemDir, "snapd-new-file-log"), where)
 	}
 
-	var db asserts.RODatabase
+	var db asserts.RODatabaseView
 	if isRemodel {
 		// during remodel, the model assertion is not yet present in the
 		// assertstate database, hence we need to use a temporary one to

--- a/overlord/devicestate/handlers_systems.go
+++ b/overlord/devicestate/handlers_systems.go
@@ -219,7 +219,7 @@ func (m *DeviceManager) doCreateRecoverySystem(t *state.Task, _ *tomb.Tomb) (err
 			return fmt.Errorf("cannot create a temporary database with model: %v", err)
 		}
 		// XXX policy
-		db = tempDB.ROUnderPolicy(nil)
+		db = tempDB.ROWithPolicy(nil)
 	} else {
 		db = assertstate.DB(st)
 	}

--- a/overlord/devicestate/handlers_systems.go
+++ b/overlord/devicestate/handlers_systems.go
@@ -215,10 +215,10 @@ func (m *DeviceManager) doCreateRecoverySystem(t *state.Task, _ *tomb.Tomb) (err
 		// createSystemForModelFromValidatedSnaps expects all relevant
 		// assertions to be present in the passed db
 		tempDB := assertstate.TemporaryDB(st)
-		if err := tempDB.Add(model); err != nil {
+		// XXX policy
+		if err := tempDB.Add(model, nil); err != nil {
 			return fmt.Errorf("cannot create a temporary database with model: %v", err)
 		}
-		// XXX policy
 		db = tempDB.ROWithPolicy(nil)
 	} else {
 		db = assertstate.DB(st)

--- a/overlord/devicestate/handlers_systems.go
+++ b/overlord/devicestate/handlers_systems.go
@@ -218,7 +218,8 @@ func (m *DeviceManager) doCreateRecoverySystem(t *state.Task, _ *tomb.Tomb) (err
 		if err := tempDB.Add(model); err != nil {
 			return fmt.Errorf("cannot create a temporary database with model: %v", err)
 		}
-		db = tempDB
+		// XXX policy
+		db = tempDB.ROUnderPolicy(nil)
 	} else {
 		db = assertstate.DB(st)
 	}

--- a/overlord/devicestate/systems.go
+++ b/overlord/devicestate/systems.go
@@ -208,7 +208,7 @@ type snapWriteObserveFunc func(systemDir, where string) error
 // recovery system - some snaps may be in the recovery system directory while
 // others may be in the common snaps directory shared between multiple recovery
 // systems on ubuntu-seed.
-func createSystemForModelFromValidatedSnaps(model *asserts.Model, label string, db asserts.RODatabase, getInfo getSnapInfoFunc, observeWrite snapWriteObserveFunc) (dir string, err error) {
+func createSystemForModelFromValidatedSnaps(model *asserts.Model, label string, db asserts.RODatabaseView, getInfo getSnapInfoFunc, observeWrite snapWriteObserveFunc) (dir string, err error) {
 	if model.Grade() == asserts.ModelGradeUnset {
 		return "", fmt.Errorf("cannot create a system for non UC20 model")
 	}

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -84,8 +84,7 @@ func (am *AssertsMock) SetupAsserts(c *C, st *state.State, cleaner cleaner) {
 	})
 	c.Assert(err, IsNil)
 	am.Db = db
-	err = db.Add(am.storeSigning.StoreAccountKey(""))
-	c.Assert(err, IsNil)
+	assertstest.AddMany(db, am.storeSigning.StoreAccountKey(""))
 
 	st.Lock()
 	assertstate.ReplaceDB(st, am.Db)
@@ -125,7 +124,7 @@ func (am *AssertsMock) MockSnapDecl(c *C, name, publisher string, extraHeaders m
 		acct := assertstest.NewAccount(am.storeSigning, publisher, map[string]interface{}{
 			"account-id": publisher,
 		}, "")
-		err = am.Db.Add(acct)
+		err = am.Db.Add(acct, nil)
 	}
 	c.Assert(err, IsNil)
 
@@ -143,7 +142,7 @@ func (am *AssertsMock) MockSnapDecl(c *C, name, publisher string, extraHeaders m
 	snapDecl, err := am.storeSigning.Sign(asserts.SnapDeclarationType, headers, nil, "")
 	c.Assert(err, IsNil)
 
-	err = am.Db.Add(snapDecl)
+	err = am.Db.Add(snapDecl, nil)
 	c.Assert(err, IsNil)
 }
 

--- a/seed/helpers.go
+++ b/seed/helpers.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/asserts/sysdb"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snapfile"
@@ -141,7 +142,7 @@ func essentialSnapTypesToModelFilter(essentialTypes []snap.Type) func(modSnap *a
 	}
 }
 
-func findBrand(seed Seed, db asserts.RODatabaseView) (*asserts.Account, error) {
+func findBrand(seed Seed, db snapasserts.Finder) (*asserts.Account, error) {
 	a, err := db.Find(asserts.AccountType, map[string]string{
 		"account-id": seed.Model().BrandID(),
 	})

--- a/seed/helpers.go
+++ b/seed/helpers.go
@@ -42,7 +42,7 @@ func MockTrusted(mockTrusted []asserts.Assertion) (restore func()) {
 	}
 }
 
-func newMemAssertionsDB(commitObserve func(verified asserts.Assertion)) (db *asserts.Database, commitTo func(*asserts.Batch) error, err error) {
+func newMemAssertionsDB(commitObserve func(verified asserts.Assertion)) (db *asserts.Database, commitTo func(*asserts.Batch, asserts.AssertionPolicy) error, err error) {
 	memDB, err := asserts.OpenDatabase(&asserts.DatabaseConfig{
 		Backstore: asserts.NewMemoryBackstore(),
 		Trusted:   trusted,
@@ -51,8 +51,8 @@ func newMemAssertionsDB(commitObserve func(verified asserts.Assertion)) (db *ass
 		return nil, nil, err
 	}
 
-	commitTo = func(b *asserts.Batch) error {
-		return b.CommitToAndObserve(memDB, commitObserve, nil)
+	commitTo = func(b *asserts.Batch, pol asserts.AssertionPolicy) error {
+		return b.CommitToAndObserve(memDB, pol, commitObserve, nil)
 	}
 
 	return memDB, commitTo, nil

--- a/seed/helpers.go
+++ b/seed/helpers.go
@@ -141,7 +141,7 @@ func essentialSnapTypesToModelFilter(essentialTypes []snap.Type) func(modSnap *a
 	}
 }
 
-func findBrand(seed Seed, db asserts.RODatabase) (*asserts.Account, error) {
+func findBrand(seed Seed, db asserts.RODatabaseView) (*asserts.Account, error) {
 	a, err := db.Find(asserts.AccountType, map[string]string{
 		"account-id": seed.Model().BrandID(),
 	})

--- a/seed/helpers_test.go
+++ b/seed/helpers_test.go
@@ -104,7 +104,7 @@ func (s *helpersSuite) TestLoadAssertions(c *C) {
 	})
 	c.Assert(err, IsNil)
 
-	err = b.CommitTo(db, nil)
+	err = b.CommitTo(db, asserts.TransparentAssertionPolicy, nil)
 	c.Assert(err, IsNil)
 
 	_, err = db.Find(asserts.SnapRevisionType, map[string]string{

--- a/seed/seed.go
+++ b/seed/seed.go
@@ -79,7 +79,7 @@ type Seed interface {
 	// be setup instead. ErrNoAssertions will be returned if there
 	// is no assertions directory in the seed, this is legitimate
 	// only on classic.
-	LoadAssertions(db asserts.RODatabase, commitTo func(*asserts.Batch) error) error
+	LoadAssertions(db asserts.RODatabaseView, commitTo func(*asserts.Batch) error) error
 
 	// Model returns the seed provided model assertion.
 	// It will panic if called before LoadAssertions.

--- a/seed/seed.go
+++ b/seed/seed.go
@@ -80,7 +80,7 @@ type Seed interface {
 	// be setup instead. ErrNoAssertions will be returned if there
 	// is no assertions directory in the seed, this is legitimate
 	// only on classic.
-	LoadAssertions(db snapasserts.Finder, commitTo func(*asserts.Batch) error) error
+	LoadAssertions(db snapasserts.Finder, commitTo func(*asserts.Batch, asserts.AssertionPolicy) error) error
 
 	// Model returns the seed provided model assertion.
 	// It will panic if called before LoadAssertions.
@@ -209,7 +209,6 @@ func ReadSystemEssentialAndBetterEarliestTime(seedDir, label string, essentialTy
 	db.SetEarliestTime(earliestTime)
 
 	// load assertions into the temporary database
-	// XXX policy
 	if err := seed20.LoadAssertions(db, commitTo); err != nil {
 		return nil, nil, time.Time{}, err
 	}

--- a/seed/seed.go
+++ b/seed/seed.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/seed/internal"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/timings"
@@ -79,7 +80,7 @@ type Seed interface {
 	// be setup instead. ErrNoAssertions will be returned if there
 	// is no assertions directory in the seed, this is legitimate
 	// only on classic.
-	LoadAssertions(db asserts.RODatabaseView, commitTo func(*asserts.Batch) error) error
+	LoadAssertions(db snapasserts.Finder, commitTo func(*asserts.Batch) error) error
 
 	// Model returns the seed provided model assertion.
 	// It will panic if called before LoadAssertions.
@@ -209,7 +210,7 @@ func ReadSystemEssentialAndBetterEarliestTime(seedDir, label string, essentialTy
 
 	// load assertions into the temporary database
 	// XXX policy
-	if err := seed20.LoadAssertions(db.ROUnderPolicy(nil), commitTo); err != nil {
+	if err := seed20.LoadAssertions(db, commitTo); err != nil {
 		return nil, nil, time.Time{}, err
 	}
 

--- a/seed/seed.go
+++ b/seed/seed.go
@@ -208,7 +208,8 @@ func ReadSystemEssentialAndBetterEarliestTime(seedDir, label string, essentialTy
 	db.SetEarliestTime(earliestTime)
 
 	// load assertions into the temporary database
-	if err := seed20.LoadAssertions(db, commitTo); err != nil {
+	// XXX policy
+	if err := seed20.LoadAssertions(db.ROUnderPolicy(nil), commitTo); err != nil {
 		return nil, nil, time.Time{}, err
 	}
 

--- a/seed/seed16.go
+++ b/seed/seed16.go
@@ -46,7 +46,7 @@ import (
 type seed16 struct {
 	seedDir string
 
-	db asserts.RODatabase
+	db asserts.RODatabaseView
 
 	model *asserts.Model
 
@@ -60,7 +60,7 @@ type seed16 struct {
 	usesSnapdSnap bool
 }
 
-func (s *seed16) LoadAssertions(db asserts.RODatabase, commitTo func(*asserts.Batch) error) error {
+func (s *seed16) LoadAssertions(db asserts.RODatabaseView, commitTo func(*asserts.Batch) error) error {
 	if db == nil {
 		// a db was not provided, create an internal temporary one
 		var err error

--- a/seed/seed16.go
+++ b/seed/seed16.go
@@ -64,10 +64,12 @@ func (s *seed16) LoadAssertions(db asserts.RODatabaseView, commitTo func(*assert
 	if db == nil {
 		// a db was not provided, create an internal temporary one
 		var err error
-		db, commitTo, err = newMemAssertionsDB(nil)
+		var rwDB *asserts.Database
+		rwDB, commitTo, err = newMemAssertionsDB(nil)
 		if err != nil {
 			return err
 		}
+		db = rwDB.ROUnderPolicy(nil)
 	}
 
 	assertSeedDir := filepath.Join(s.seedDir, "assertions")

--- a/seed/seed16.go
+++ b/seed/seed16.go
@@ -46,7 +46,7 @@ import (
 type seed16 struct {
 	seedDir string
 
-	db asserts.RODatabaseView
+	db snapasserts.Finder
 
 	model *asserts.Model
 
@@ -60,16 +60,14 @@ type seed16 struct {
 	usesSnapdSnap bool
 }
 
-func (s *seed16) LoadAssertions(db asserts.RODatabaseView, commitTo func(*asserts.Batch) error) error {
+func (s *seed16) LoadAssertions(db snapasserts.Finder, commitTo func(*asserts.Batch) error) error {
 	if db == nil {
 		// a db was not provided, create an internal temporary one
 		var err error
-		var rwDB *asserts.Database
-		rwDB, commitTo, err = newMemAssertionsDB(nil)
+		db, commitTo, err = newMemAssertionsDB(nil)
 		if err != nil {
 			return err
 		}
-		db = rwDB.ROUnderPolicy(nil)
 	}
 
 	assertSeedDir := filepath.Join(s.seedDir, "assertions")

--- a/seed/seed16.go
+++ b/seed/seed16.go
@@ -60,7 +60,7 @@ type seed16 struct {
 	usesSnapdSnap bool
 }
 
-func (s *seed16) LoadAssertions(db snapasserts.Finder, commitTo func(*asserts.Batch) error) error {
+func (s *seed16) LoadAssertions(db snapasserts.Finder, commitTo func(*asserts.Batch, asserts.AssertionPolicy) error) error {
 	if db == nil {
 		// a db was not provided, create an internal temporary one
 		var err error
@@ -93,7 +93,8 @@ func (s *seed16) LoadAssertions(db snapasserts.Finder, commitTo func(*asserts.Ba
 		return fmt.Errorf("seed must have a model assertion")
 	}
 
-	if err := commitTo(batch); err != nil {
+	// XXX policy: use a device policy
+	if err := commitTo(batch, asserts.TransparentAssertionPolicy); err != nil {
 		return err
 	}
 

--- a/seed/seed16_test.go
+++ b/seed/seed16_test.go
@@ -49,8 +49,7 @@ type seed16Suite struct {
 
 	seed16 seed.Seed
 
-	db   asserts.RODatabaseView
-	rwDB *asserts.Database
+	db *asserts.Database
 
 	perfTimings timings.Measurer
 }
@@ -87,14 +86,13 @@ func (s *seed16Suite) SetUpTest(c *C) {
 		Trusted:   s.StoreSigning.Trusted,
 	})
 	c.Assert(err, IsNil)
-	s.db = db.ROUnderPolicy(nil)
-	s.rwDB = db
+	s.db = db
 
 	s.perfTimings = timings.New(nil)
 }
 
 func (s *seed16Suite) commitTo(b *asserts.Batch) error {
-	return b.CommitTo(s.rwDB, nil)
+	return b.CommitTo(s.db, nil)
 }
 
 func (s *seed16Suite) TestLoadAssertionsNoAssertions(c *C) {

--- a/seed/seed16_test.go
+++ b/seed/seed16_test.go
@@ -91,8 +91,8 @@ func (s *seed16Suite) SetUpTest(c *C) {
 	s.perfTimings = timings.New(nil)
 }
 
-func (s *seed16Suite) commitTo(b *asserts.Batch) error {
-	return b.CommitTo(s.db, nil)
+func (s *seed16Suite) commitTo(b *asserts.Batch, pol asserts.AssertionPolicy) error {
+	return b.CommitTo(s.db, pol, nil)
 }
 
 func (s *seed16Suite) TestLoadAssertionsNoAssertions(c *C) {

--- a/seed/seed16_test.go
+++ b/seed/seed16_test.go
@@ -49,7 +49,8 @@ type seed16Suite struct {
 
 	seed16 seed.Seed
 
-	db *asserts.Database
+	db   asserts.RODatabaseView
+	rwDB *asserts.Database
 
 	perfTimings timings.Measurer
 }
@@ -86,13 +87,14 @@ func (s *seed16Suite) SetUpTest(c *C) {
 		Trusted:   s.StoreSigning.Trusted,
 	})
 	c.Assert(err, IsNil)
-	s.db = db
+	s.db = db.ROUnderPolicy(nil)
+	s.rwDB = db
 
 	s.perfTimings = timings.New(nil)
 }
 
 func (s *seed16Suite) commitTo(b *asserts.Batch) error {
-	return b.CommitTo(s.db, nil)
+	return b.CommitTo(s.rwDB, nil)
 }
 
 func (s *seed16Suite) TestLoadAssertionsNoAssertions(c *C) {

--- a/seed/seed20.go
+++ b/seed/seed20.go
@@ -73,7 +73,7 @@ type seed20 struct {
 	essentialSnapsNum int
 }
 
-func (s *seed20) LoadAssertions(db snapasserts.Finder, commitTo func(*asserts.Batch) error) error {
+func (s *seed20) LoadAssertions(db snapasserts.Finder, commitTo func(*asserts.Batch, asserts.AssertionPolicy) error) error {
 	if db == nil {
 		// a db was not provided, create an internal temporary one
 		var err error
@@ -118,7 +118,8 @@ func (s *seed20) LoadAssertions(db snapasserts.Finder, commitTo func(*asserts.Ba
 	}
 
 	// this also verifies the consistency of all of them
-	if err := commitTo(batch); err != nil {
+	// XXX policy: use a device policy
+	if err := commitTo(batch, asserts.TransparentAssertionPolicy); err != nil {
 		return err
 	}
 

--- a/seed/seed20.go
+++ b/seed/seed20.go
@@ -49,7 +49,7 @@ import (
 type seed20 struct {
 	systemDir string
 
-	db asserts.RODatabaseView
+	db snapasserts.Finder
 
 	model *asserts.Model
 
@@ -73,16 +73,14 @@ type seed20 struct {
 	essentialSnapsNum int
 }
 
-func (s *seed20) LoadAssertions(db asserts.RODatabaseView, commitTo func(*asserts.Batch) error) error {
+func (s *seed20) LoadAssertions(db snapasserts.Finder, commitTo func(*asserts.Batch) error) error {
 	if db == nil {
 		// a db was not provided, create an internal temporary one
 		var err error
-		var rwDB *asserts.Database
-		rwDB, commitTo, err = newMemAssertionsDB(nil)
+		db, commitTo, err = newMemAssertionsDB(nil)
 		if err != nil {
 			return err
 		}
-		db = rwDB.ROUnderPolicy(nil)
 	}
 
 	assertsDir := filepath.Join(s.systemDir, "assertions")

--- a/seed/seed20.go
+++ b/seed/seed20.go
@@ -49,7 +49,7 @@ import (
 type seed20 struct {
 	systemDir string
 
-	db asserts.RODatabase
+	db asserts.RODatabaseView
 
 	model *asserts.Model
 
@@ -73,7 +73,7 @@ type seed20 struct {
 	essentialSnapsNum int
 }
 
-func (s *seed20) LoadAssertions(db asserts.RODatabase, commitTo func(*asserts.Batch) error) error {
+func (s *seed20) LoadAssertions(db asserts.RODatabaseView, commitTo func(*asserts.Batch) error) error {
 	if db == nil {
 		// a db was not provided, create an internal temporary one
 		var err error

--- a/seed/seed20.go
+++ b/seed/seed20.go
@@ -77,10 +77,12 @@ func (s *seed20) LoadAssertions(db asserts.RODatabaseView, commitTo func(*assert
 	if db == nil {
 		// a db was not provided, create an internal temporary one
 		var err error
-		db, commitTo, err = newMemAssertionsDB(nil)
+		var rwDB *asserts.Database
+		rwDB, commitTo, err = newMemAssertionsDB(nil)
 		if err != nil {
 			return err
 		}
+		db = rwDB.ROUnderPolicy(nil)
 	}
 
 	assertsDir := filepath.Join(s.systemDir, "assertions")

--- a/seed/seed20_test.go
+++ b/seed/seed20_test.go
@@ -46,8 +46,7 @@ type seed20Suite struct {
 	*seedtest.TestingSeed20
 	devAcct *asserts.Account
 
-	db   asserts.RODatabaseView
-	rwDB *asserts.Database
+	db *asserts.Database
 
 	perfTimings timings.Measurer
 }
@@ -77,14 +76,13 @@ func (s *seed20Suite) SetUpTest(c *C) {
 		Trusted:   s.StoreSigning.Trusted,
 	})
 	c.Assert(err, IsNil)
-	s.db = db.ROUnderPolicy(nil)
-	s.rwDB = db
+	s.db = db
 
 	s.perfTimings = timings.New(nil)
 }
 
 func (s *seed20Suite) commitTo(b *asserts.Batch) error {
-	return b.CommitTo(s.rwDB, nil)
+	return b.CommitTo(s.db, nil)
 }
 
 func (s *seed20Suite) makeSnap(c *C, yamlKey, publisher string) {

--- a/seed/seed20_test.go
+++ b/seed/seed20_test.go
@@ -46,7 +46,8 @@ type seed20Suite struct {
 	*seedtest.TestingSeed20
 	devAcct *asserts.Account
 
-	db *asserts.Database
+	db   asserts.RODatabaseView
+	rwDB *asserts.Database
 
 	perfTimings timings.Measurer
 }
@@ -76,13 +77,14 @@ func (s *seed20Suite) SetUpTest(c *C) {
 		Trusted:   s.StoreSigning.Trusted,
 	})
 	c.Assert(err, IsNil)
-	s.db = db
+	s.db = db.ROUnderPolicy(nil)
+	s.rwDB = db
 
 	s.perfTimings = timings.New(nil)
 }
 
 func (s *seed20Suite) commitTo(b *asserts.Batch) error {
-	return b.CommitTo(s.db, nil)
+	return b.CommitTo(s.rwDB, nil)
 }
 
 func (s *seed20Suite) makeSnap(c *C, yamlKey, publisher string) {

--- a/seed/seedtest/seedtest.go
+++ b/seed/seedtest/seedtest.go
@@ -251,7 +251,6 @@ func (s *TestingSeed20) MakeSeedWithModel(c *C, label string, model *asserts.Mod
 		Trusted:   s.StoreSigning.Trusted,
 	})
 	c.Assert(err, IsNil)
-	roView := db.ROUnderPolicy(nil)
 
 	retrieve := func(ref *asserts.Ref) (asserts.Assertion, error) {
 		return ref.Resolve(s.StoreSigning.Find)
@@ -268,7 +267,7 @@ func (s *TestingSeed20) MakeSeedWithModel(c *C, label string, model *asserts.Mod
 			}
 			return save(a)
 		}
-		return asserts.NewFetcher(roView, retrieve, save2)
+		return asserts.NewFetcher(db, retrieve, save2)
 	}
 
 	opts := seedwriter.Options{
@@ -281,14 +280,14 @@ func (s *TestingSeed20) MakeSeedWithModel(c *C, label string, model *asserts.Mod
 	err = w.SetOptionsSnaps(optSnaps)
 	c.Assert(err, IsNil)
 
-	rf, err := w.Start(roView, newFetcher)
+	rf, err := w.Start(db, newFetcher)
 	c.Assert(err, IsNil)
 
 	localSnaps, err := w.LocalSnaps()
 	c.Assert(err, IsNil)
 
 	for _, sn := range localSnaps {
-		si, aRefs, err := seedwriter.DeriveSideInfo(sn.Path, rf, roView)
+		si, aRefs, err := seedwriter.DeriveSideInfo(sn.Path, rf, db)
 		if !asserts.IsNotFound(err) {
 			c.Assert(err, IsNil)
 		}
@@ -361,7 +360,7 @@ func ValidateSeed(c *C, root, label string, usesSnapd bool, trusted []asserts.As
 	sd, err := seed.Open(root, label)
 	c.Assert(err, IsNil)
 
-	err = sd.LoadAssertions(db.ROUnderPolicy(nil), commitTo)
+	err = sd.LoadAssertions(db, commitTo)
 	c.Assert(err, IsNil)
 
 	err = sd.LoadMeta(tm)

--- a/seed/seedtest/seedtest.go
+++ b/seed/seedtest/seedtest.go
@@ -251,6 +251,7 @@ func (s *TestingSeed20) MakeSeedWithModel(c *C, label string, model *asserts.Mod
 		Trusted:   s.StoreSigning.Trusted,
 	})
 	c.Assert(err, IsNil)
+	roView := db.ROUnderPolicy(nil)
 
 	retrieve := func(ref *asserts.Ref) (asserts.Assertion, error) {
 		return ref.Resolve(s.StoreSigning.Find)
@@ -267,7 +268,7 @@ func (s *TestingSeed20) MakeSeedWithModel(c *C, label string, model *asserts.Mod
 			}
 			return save(a)
 		}
-		return asserts.NewFetcher(db, retrieve, save2)
+		return asserts.NewFetcher(roView, retrieve, save2)
 	}
 
 	opts := seedwriter.Options{
@@ -280,14 +281,14 @@ func (s *TestingSeed20) MakeSeedWithModel(c *C, label string, model *asserts.Mod
 	err = w.SetOptionsSnaps(optSnaps)
 	c.Assert(err, IsNil)
 
-	rf, err := w.Start(db, newFetcher)
+	rf, err := w.Start(roView, newFetcher)
 	c.Assert(err, IsNil)
 
 	localSnaps, err := w.LocalSnaps()
 	c.Assert(err, IsNil)
 
 	for _, sn := range localSnaps {
-		si, aRefs, err := seedwriter.DeriveSideInfo(sn.Path, rf, db)
+		si, aRefs, err := seedwriter.DeriveSideInfo(sn.Path, rf, roView)
 		if !asserts.IsNotFound(err) {
 			c.Assert(err, IsNil)
 		}
@@ -360,7 +361,7 @@ func ValidateSeed(c *C, root, label string, usesSnapd bool, trusted []asserts.As
 	sd, err := seed.Open(root, label)
 	c.Assert(err, IsNil)
 
-	err = sd.LoadAssertions(db, commitTo)
+	err = sd.LoadAssertions(db.ROUnderPolicy(nil), commitTo)
 	c.Assert(err, IsNil)
 
 	err = sd.LoadMeta(tm)

--- a/seed/seedtest/seedtest.go
+++ b/seed/seedtest/seedtest.go
@@ -366,8 +366,8 @@ func ValidateSeed(c *C, root, label string, usesSnapd bool, trusted []asserts.As
 		Trusted:   trusted,
 	})
 	c.Assert(err, IsNil)
-	commitTo := func(b *asserts.Batch) error {
-		return b.CommitTo(db, nil)
+	commitTo := func(b *asserts.Batch, pol asserts.AssertionPolicy) error {
+		return b.CommitTo(db, pol, nil)
 	}
 
 	sd, err := seed.Open(root, label)

--- a/seed/seedtest/seedtest.go
+++ b/seed/seedtest/seedtest.go
@@ -114,9 +114,9 @@ func (ss *SeedSnaps) MakeAssertedSnap(c *C, snapYaml string, files [][]string, r
 	}
 
 	for _, db := range dbs {
-		err := db.Add(declA)
+		err := db.Add(declA, nil)
 		c.Assert(err, IsNil)
-		err = db.Add(revA)
+		err = db.Add(revA, nil)
 		c.Assert(err, IsNil)
 	}
 
@@ -258,7 +258,7 @@ func (s *TestingSeed20) MakeSeedWithModel(c *C, label string, model *asserts.Mod
 	newFetcher := func(save func(asserts.Assertion) error) asserts.Fetcher {
 		save2 := func(a asserts.Assertion) error {
 			// for checking
-			err := db.Add(a)
+			err := db.Add(a, nil)
 			if err != nil {
 				if _, ok := err.(*asserts.RevisionError); ok {
 					return nil

--- a/seed/seedwriter/helpers.go
+++ b/seed/seedwriter/helpers.go
@@ -139,7 +139,7 @@ func (s seedSnapsByType) Less(i, j int) bool {
 // finderFromFetcher exposes an assertion Finder interface out of a Fetcher.
 type finderFromFetcher struct {
 	f  asserts.Fetcher
-	db asserts.RODatabaseView
+	db snapasserts.Finder
 }
 
 func (fnd *finderFromFetcher) Find(assertionType *asserts.AssertionType, headers map[string]string) (asserts.Assertion, error) {
@@ -160,7 +160,7 @@ func (fnd *finderFromFetcher) Find(assertionType *asserts.AssertionType, headers
 // DeriveSideInfo tries to construct a SideInfo for the given snap
 // using its digest to fetch the relevant snap assertions. It will
 // fail with an asserts.NotFoundError if it cannot find them.
-func DeriveSideInfo(snapPath string, rf RefAssertsFetcher, db asserts.RODatabaseView) (*snap.SideInfo, []*asserts.Ref, error) {
+func DeriveSideInfo(snapPath string, rf RefAssertsFetcher, db snapasserts.Finder) (*snap.SideInfo, []*asserts.Ref, error) {
 	fnd := &finderFromFetcher{f: rf, db: db}
 	prev := len(rf.Refs())
 	si, err := snapasserts.DeriveSideInfo(snapPath, fnd)

--- a/seed/seedwriter/helpers.go
+++ b/seed/seedwriter/helpers.go
@@ -139,7 +139,7 @@ func (s seedSnapsByType) Less(i, j int) bool {
 // finderFromFetcher exposes an assertion Finder interface out of a Fetcher.
 type finderFromFetcher struct {
 	f  asserts.Fetcher
-	db asserts.RODatabase
+	db asserts.RODatabaseView
 }
 
 func (fnd *finderFromFetcher) Find(assertionType *asserts.AssertionType, headers map[string]string) (asserts.Assertion, error) {
@@ -160,7 +160,7 @@ func (fnd *finderFromFetcher) Find(assertionType *asserts.AssertionType, headers
 // DeriveSideInfo tries to construct a SideInfo for the given snap
 // using its digest to fetch the relevant snap assertions. It will
 // fail with an asserts.NotFoundError if it cannot find them.
-func DeriveSideInfo(snapPath string, rf RefAssertsFetcher, db asserts.RODatabase) (*snap.SideInfo, []*asserts.Ref, error) {
+func DeriveSideInfo(snapPath string, rf RefAssertsFetcher, db asserts.RODatabaseView) (*snap.SideInfo, []*asserts.Ref, error) {
 	fnd := &finderFromFetcher{f: rf, db: db}
 	prev := len(rf.Refs())
 	si, err := snapasserts.DeriveSideInfo(snapPath, fnd)

--- a/seed/seedwriter/seed16.go
+++ b/seed/seedwriter/seed16.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/seed/internal"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/channel"
@@ -175,7 +176,7 @@ func (tr *tree16) localSnapPath(sn *SeedSnap) (string, error) {
 	return filepath.Join(tr.snapsDirPath, sn.Info.Filename()), nil
 }
 
-func (tr *tree16) writeAssertions(db asserts.RODatabaseView, modelRefs []*asserts.Ref, snapsFromModel []*SeedSnap, extraSnaps []*SeedSnap) error {
+func (tr *tree16) writeAssertions(db snapasserts.Finder, modelRefs []*asserts.Ref, snapsFromModel []*SeedSnap, extraSnaps []*SeedSnap) error {
 	seedAssertsDir := filepath.Join(tr.opts.SeedDir, "assertions")
 	if err := os.MkdirAll(seedAssertsDir, 0755); err != nil {
 		return err

--- a/seed/seedwriter/seed16.go
+++ b/seed/seedwriter/seed16.go
@@ -175,7 +175,7 @@ func (tr *tree16) localSnapPath(sn *SeedSnap) (string, error) {
 	return filepath.Join(tr.snapsDirPath, sn.Info.Filename()), nil
 }
 
-func (tr *tree16) writeAssertions(db asserts.RODatabase, modelRefs []*asserts.Ref, snapsFromModel []*SeedSnap, extraSnaps []*SeedSnap) error {
+func (tr *tree16) writeAssertions(db asserts.RODatabaseView, modelRefs []*asserts.Ref, snapsFromModel []*SeedSnap, extraSnaps []*SeedSnap) error {
 	seedAssertsDir := filepath.Join(tr.opts.SeedDir, "assertions")
 	if err := os.MkdirAll(seedAssertsDir, 0755); err != nil {
 		return err

--- a/seed/seedwriter/seed20.go
+++ b/seed/seedwriter/seed20.go
@@ -208,7 +208,7 @@ func (tr *tree20) localSnapPath(sn *SeedSnap) (string, error) {
 	return filepath.Join(sysSnapsDir, fmt.Sprintf("%s_%s.snap", sn.SnapName(), sn.Info.Version)), nil
 }
 
-func (tr *tree20) writeAssertions(db asserts.RODatabase, modelRefs []*asserts.Ref, snapsFromModel []*SeedSnap, extraSnaps []*SeedSnap) error {
+func (tr *tree20) writeAssertions(db asserts.RODatabaseView, modelRefs []*asserts.Ref, snapsFromModel []*SeedSnap, extraSnaps []*SeedSnap) error {
 	assertsDir := filepath.Join(tr.systemDir, "assertions")
 	if err := os.MkdirAll(assertsDir, 0755); err != nil {
 		return err

--- a/seed/seedwriter/seed20.go
+++ b/seed/seedwriter/seed20.go
@@ -27,6 +27,7 @@ import (
 	"path/filepath"
 
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/seed/internal"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/channel"
@@ -208,7 +209,7 @@ func (tr *tree20) localSnapPath(sn *SeedSnap) (string, error) {
 	return filepath.Join(sysSnapsDir, fmt.Sprintf("%s_%s.snap", sn.SnapName(), sn.Info.Version)), nil
 }
 
-func (tr *tree20) writeAssertions(db asserts.RODatabaseView, modelRefs []*asserts.Ref, snapsFromModel []*SeedSnap, extraSnaps []*SeedSnap) error {
+func (tr *tree20) writeAssertions(db snapasserts.Finder, modelRefs []*asserts.Ref, snapsFromModel []*SeedSnap, extraSnaps []*SeedSnap) error {
 	assertsDir := filepath.Join(tr.systemDir, "assertions")
 	if err := os.MkdirAll(assertsDir, 0755); err != nil {
 		return err

--- a/seed/seedwriter/writer.go
+++ b/seed/seedwriter/writer.go
@@ -168,7 +168,7 @@ type Writer struct {
 	// Downloaded signaled complete
 	warnings []string
 
-	db asserts.RODatabase
+	db asserts.RODatabaseView
 
 	expectedStep writerStep
 
@@ -226,7 +226,7 @@ type tree interface {
 
 	localSnapPath(*SeedSnap) (string, error)
 
-	writeAssertions(db asserts.RODatabase, modelRefs []*asserts.Ref, snapsFromModel []*SeedSnap, extraSnaps []*SeedSnap) error
+	writeAssertions(db asserts.RODatabaseView, modelRefs []*asserts.Ref, snapsFromModel []*SeedSnap, extraSnaps []*SeedSnap) error
 
 	writeMeta(snapsFromModel []*SeedSnap, extraSnaps []*SeedSnap) error
 }
@@ -443,12 +443,12 @@ func IsSytemDirectoryExistsError(err error) bool {
 // that the snap assertions will end up in the given db (writing assertion
 // database). When the system seed directory is already present,
 // SystemAlreadyExistsError is returned.
-func (w *Writer) Start(db asserts.RODatabase, newFetcher NewFetcherFunc) (RefAssertsFetcher, error) {
+func (w *Writer) Start(db asserts.RODatabaseView, newFetcher NewFetcherFunc) (RefAssertsFetcher, error) {
 	if err := w.checkStep(startStep); err != nil {
 		return nil, err
 	}
 	if db == nil {
-		return nil, fmt.Errorf("internal error: Writer *asserts.RODatabase is nil")
+		return nil, fmt.Errorf("internal error: Writer *asserts.RODatabaseView is nil")
 	}
 	if newFetcher == nil {
 		return nil, fmt.Errorf("internal error: Writer newFetcherFunc is nil")

--- a/seed/seedwriter/writer.go
+++ b/seed/seedwriter/writer.go
@@ -168,7 +168,7 @@ type Writer struct {
 	// Downloaded signaled complete
 	warnings []string
 
-	db asserts.RODatabaseView
+	db snapasserts.Finder
 
 	expectedStep writerStep
 
@@ -226,7 +226,7 @@ type tree interface {
 
 	localSnapPath(*SeedSnap) (string, error)
 
-	writeAssertions(db asserts.RODatabaseView, modelRefs []*asserts.Ref, snapsFromModel []*SeedSnap, extraSnaps []*SeedSnap) error
+	writeAssertions(db snapasserts.Finder, modelRefs []*asserts.Ref, snapsFromModel []*SeedSnap, extraSnaps []*SeedSnap) error
 
 	writeMeta(snapsFromModel []*SeedSnap, extraSnaps []*SeedSnap) error
 }
@@ -443,7 +443,7 @@ func IsSytemDirectoryExistsError(err error) bool {
 // that the snap assertions will end up in the given db (writing assertion
 // database). When the system seed directory is already present,
 // SystemAlreadyExistsError is returned.
-func (w *Writer) Start(db asserts.RODatabaseView, newFetcher NewFetcherFunc) (RefAssertsFetcher, error) {
+func (w *Writer) Start(db snapasserts.Finder, newFetcher NewFetcherFunc) (RefAssertsFetcher, error) {
 	if err := w.checkStep(startStep); err != nil {
 		return nil, err
 	}

--- a/seed/seedwriter/writer_test.go
+++ b/seed/seedwriter/writer_test.go
@@ -53,7 +53,7 @@ type writerSuite struct {
 
 	opts *seedwriter.Options
 
-	db         asserts.RODatabaseView
+	db         *asserts.Database
 	newFetcher seedwriter.NewFetcherFunc
 	rf         seedwriter.RefAssertsFetcher
 
@@ -98,7 +98,7 @@ func (s *writerSuite) SetUpTest(c *C) {
 		Trusted:   s.StoreSigning.Trusted,
 	})
 	c.Assert(err, IsNil)
-	s.db = db.ROUnderPolicy(nil)
+	s.db = db
 
 	retrieve := func(ref *asserts.Ref) (asserts.Assertion, error) {
 		return ref.Resolve(s.StoreSigning.Find)
@@ -115,7 +115,7 @@ func (s *writerSuite) SetUpTest(c *C) {
 			}
 			return save(a)
 		}
-		return asserts.NewFetcher(s.db, retrieve, save2)
+		return asserts.NewFetcher(db, retrieve, save2)
 	}
 	s.rf = seedwriter.MakeRefAssertsFetcher(s.newFetcher)
 

--- a/seed/seedwriter/writer_test.go
+++ b/seed/seedwriter/writer_test.go
@@ -53,7 +53,7 @@ type writerSuite struct {
 
 	opts *seedwriter.Options
 
-	db         *asserts.Database
+	db         asserts.RODatabaseView
 	newFetcher seedwriter.NewFetcherFunc
 	rf         seedwriter.RefAssertsFetcher
 
@@ -98,7 +98,7 @@ func (s *writerSuite) SetUpTest(c *C) {
 		Trusted:   s.StoreSigning.Trusted,
 	})
 	c.Assert(err, IsNil)
-	s.db = db
+	s.db = db.ROUnderPolicy(nil)
 
 	retrieve := func(ref *asserts.Ref) (asserts.Assertion, error) {
 		return ref.Resolve(s.StoreSigning.Find)
@@ -115,7 +115,7 @@ func (s *writerSuite) SetUpTest(c *C) {
 			}
 			return save(a)
 		}
-		return asserts.NewFetcher(db, retrieve, save2)
+		return asserts.NewFetcher(s.db, retrieve, save2)
 	}
 	s.rf = seedwriter.MakeRefAssertsFetcher(s.newFetcher)
 

--- a/seed/seedwriter/writer_test.go
+++ b/seed/seedwriter/writer_test.go
@@ -106,7 +106,7 @@ func (s *writerSuite) SetUpTest(c *C) {
 	s.newFetcher = func(save func(asserts.Assertion) error) asserts.Fetcher {
 		save2 := func(a asserts.Assertion) error {
 			// for checking
-			err := db.Add(a)
+			err := db.Add(a, nil)
 			if err != nil {
 				if _, ok := err.(*asserts.RevisionError); ok {
 					return nil

--- a/store/store_asserts_test.go
+++ b/store/store_asserts_test.go
@@ -269,7 +269,7 @@ func (s *storeAssertsSuite) TestDownloadAssertionsSimple(c *C) {
 	err = sto.DownloadAssertions(urls, b, nil)
 	c.Assert(err, IsNil)
 
-	c.Assert(b.CommitTo(s.db, nil), IsNil)
+	c.Assert(b.CommitTo(s.db, asserts.TransparentAssertionPolicy, nil), IsNil)
 
 	// added
 	_, err = s.decl1.Ref().Resolve(s.db.Find)
@@ -320,7 +320,7 @@ func (s *storeAssertsSuite) TestDownloadAssertionsWithStreams(c *C) {
 	err = sto.DownloadAssertions(urls, b, nil)
 	c.Assert(err, IsNil)
 
-	c.Assert(b.CommitTo(s.db, nil), IsNil)
+	c.Assert(b.CommitTo(s.db, asserts.TransparentAssertionPolicy, nil), IsNil)
 
 	// added
 	_, err = s.decl1.Ref().Resolve(s.db.Find)

--- a/tests/lib/fakestore/refresh/refresh.go
+++ b/tests/lib/fakestore/refresh/refresh.go
@@ -82,7 +82,7 @@ func MakeFakeRefreshForSnaps(snap string, blobDir string, snapBlob string) error
 	}
 
 	save := func(a asserts.Assertion) error {
-		err := db.Add(a)
+		err := db.Add(a, nil)
 		if err != nil {
 			if _, ok := err.(*asserts.RevisionError); !ok {
 				return err

--- a/tests/lib/fakestore/refresh/refresh.go
+++ b/tests/lib/fakestore/refresh/refresh.go
@@ -92,7 +92,7 @@ func MakeFakeRefreshForSnaps(snap string, blobDir string, snapBlob string) error
 		return err
 	}
 
-	f := asserts.NewFetcher(db.ROUnderPolicy(nil), retrieve, save)
+	f := asserts.NewFetcher(db, retrieve, save)
 
 	if err := makeFakeRefreshForSnap(snap, blobDir, snapBlob, db, f); err != nil {
 		return err

--- a/tests/lib/fakestore/refresh/refresh.go
+++ b/tests/lib/fakestore/refresh/refresh.go
@@ -92,7 +92,7 @@ func MakeFakeRefreshForSnaps(snap string, blobDir string, snapBlob string) error
 		return err
 	}
 
-	f := asserts.NewFetcher(db, retrieve, save)
+	f := asserts.NewFetcher(db.ROUnderPolicy(nil), retrieve, save)
 
 	if err := makeFakeRefreshForSnap(snap, blobDir, snapBlob, db, f); err != nil {
 		return err


### PR DESCRIPTION
As explained in #11392 Find* methods need to take policy into account because the constraint parameter values might have changed between the time an assertion is stored vs retrieved.

The trusted FindTrusted/Predefined* methods shouldn't need to take the policy into account as the data they deal with is part of the site configuration.

Expose some helpers on RODatabaseView for use in policy implementations (DelegationConstraints, FindSigningKey).