### PR TITLE
o/snapstate: implement transactional lanes for prereqs

### DIFF
--- a/overlord/snapstate/flags.go
+++ b/overlord/snapstate/flags.go
@@ -110,6 +110,5 @@ func (f Flags) ForSnapSetup() Flags {
 	f.NoReRefresh = false
 	f.RequireTypeBase = false
 	f.ApplySnapDevMode = false
-	f.Transactional = false
 	return f
 }

--- a/overlord/snapstate/handlers_prereq_test.go
+++ b/overlord/snapstate/handlers_prereq_test.go
@@ -192,7 +192,7 @@ func (s *prereqSuite) TestDoPrereqManyTransactional(c *C) {
 			linkedSnaps = append(linkedSnaps, snapsup.InstanceName())
 		}
 	}
-	c.Check(linkedSnaps, DeepEquals, expectedLinkedSnaps)
+	c.Check(linkedSnaps, testutil.DeepUnsortedMatches, expectedLinkedSnaps)
 }
 
 func (s *prereqSuite) TestDoPrereqTalksToStoreAndQueues(c *C) {

--- a/overlord/snapstate/handlers_prereq_test.go
+++ b/overlord/snapstate/handlers_prereq_test.go
@@ -136,7 +136,56 @@ func (s *prereqSuite) TestDoPrereqWithBaseNone(c *C) {
 	// check that the do-prereq task added all needed prereqs
 	expectedLinkedSnaps := []string{"prereq1", "snapd"}
 	linkedSnaps := make([]string, 0, len(expectedLinkedSnaps))
+	lane := 0
 	for _, t := range chg.Tasks() {
+		if t.Kind() == "link-snap" {
+			snapsup, err := snapstate.TaskSnapSetup(t)
+			c.Assert(err, IsNil)
+			linkedSnaps = append(linkedSnaps, snapsup.InstanceName())
+		} else if t.Kind() == "prerequisites" {
+			c.Assert(t.Lanes(), DeepEquals, []int{lane})
+			lane++
+		}
+	}
+	c.Check(linkedSnaps, DeepEquals, expectedLinkedSnaps)
+}
+
+func (s *prereqSuite) TestDoPrereqManyTransactional(c *C) {
+	s.state.Lock()
+
+	t := s.state.NewTask("prerequisites", "test")
+	t.Set("snap-setup", &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{
+			RealName: "foo",
+			Revision: snap.R(33),
+		},
+		Base: "none",
+		PrereqContentAttrs: map[string][]string{
+			"prereq1": {"some-content"}, "prereq2": {"other-content"}},
+		Flags: snapstate.Flags{Transactional: true},
+	})
+	// Ensure the manually created task matches the lane that will
+	// be shared across all tasks.
+	t.JoinLane(1)
+	chg := s.state.NewChange("dummy", "...")
+	chg.AddTask(t)
+	s.state.Unlock()
+
+	s.se.Ensure()
+	s.se.Wait()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Check(t.Status(), Equals, state.DoneStatus)
+
+	// check that the do-prereq task added all needed prereqs
+	expectedLinkedSnaps := []string{"prereq1", "prereq2", "snapd"}
+	linkedSnaps := make([]string, 0, len(expectedLinkedSnaps))
+	for _, t := range chg.Tasks() {
+		// Make sure that the Transacation flag has been applied,
+		// so we have only one lane.
+		c.Assert(t.Lanes(), DeepEquals, []int{1})
+
 		if t.Kind() == "link-snap" {
 			snapsup, err := snapstate.TaskSnapSetup(t)
 			c.Assert(err, IsNil)

--- a/overlord/snapstate/handlers_prereq_test.go
+++ b/overlord/snapstate/handlers_prereq_test.go
@@ -166,7 +166,7 @@ func (s *prereqSuite) TestDoPrereqManyTransactional(c *C) {
 		Flags: snapstate.Flags{Transactional: true},
 	})
 	// Set lane to make sure new tasks will match this one
-	lane := 3
+	lane := s.state.NewLane()
 	t.JoinLane(lane)
 	chg := s.state.NewChange("dummy", "...")
 	chg.AddTask(t)
@@ -211,8 +211,8 @@ func (s *prereqSuite) TestDoPrereqTransactionalFailTooManyLanes(c *C) {
 		Flags: snapstate.Flags{Transactional: true},
 	})
 	// There should be only one lane in a transactional change
-	t.JoinLane(1)
-	t.JoinLane(2)
+	t.JoinLane(s.state.NewLane())
+	t.JoinLane(s.state.NewLane())
 	chg := s.state.NewChange("dummy", "...")
 	chg.AddTask(t)
 	s.state.Unlock()


### PR DESCRIPTION
Make sure that the transactional flag is enforced when having
transactional updates with prerequirement snaps.