### PR TITLE
o/devicestate/handlers_install.go: use --all to get binary data too for logs

### DIFF
--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -111,7 +111,7 @@ func writeLogs(rootdir string) error {
 	gz := gzip.NewWriter(f)
 	defer gz.Close()
 
-	cmd := exec.Command("journalctl", "-b", "0")
+	cmd := exec.Command("journalctl", "-b", "0", "--all")
 	cmd.Stdout = gz
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("cannot collect journal output: %v", err)


### PR DESCRIPTION
Otherwise journalctl will end up serializing the data as `[100 KB binary data]` in the logs etc. 
These log files also will include application snap output sometimes from i.e. the install-device
hook, so we should try to be more accommodating.