### PR TITLE
o/devicestate: preseeding test cleanup

### DIFF
--- a/overlord/devicestate/devicestate_bootconfig_test.go
+++ b/overlord/devicestate/devicestate_bootconfig_test.go
@@ -49,7 +49,8 @@ type deviceMgrBootconfigSuite struct {
 var _ = Suite(&deviceMgrBootconfigSuite{})
 
 func (s *deviceMgrBootconfigSuite) SetUpTest(c *C) {
-	s.deviceMgrBaseSuite.SetUpTest(c)
+	classic := false
+	s.deviceMgrBaseSuite.setupBaseTest(c, classic)
 
 	s.managedbl = bootloadertest.Mock("mock", c.MkDir()).WithTrustedAssets()
 	bootloader.Force(s.managedbl)

--- a/overlord/devicestate/devicestate_cloudinit_test.go
+++ b/overlord/devicestate/devicestate_cloudinit_test.go
@@ -33,7 +33,8 @@ type cloudInitSuite struct {
 var _ = Suite(&cloudInitSuite{})
 
 func (s *cloudInitBaseSuite) SetUpTest(c *C) {
-	s.deviceMgrBaseSuite.SetUpTest(c)
+	classic := false
+	s.deviceMgrBaseSuite.setupBaseTest(c, classic)
 
 	// undo the cloud-init mocking from deviceMgrBaseSuite, since here we
 	// actually want the default function used to be the real one
@@ -571,7 +572,7 @@ func (s *cloudInitSuite) TestCloudInitRunningEnsuresUntilNotRunning(c *C) {
 	cloudInitScriptStateFile := filepath.Join(c.MkDir(), "cloud-init-state")
 
 	cmd := testutil.MockCommand(c, "cloud-init", fmt.Sprintf(`
-# the first time the script is called the file shouldn't exist, so return 
+# the first time the script is called the file shouldn't exist, so return
 # running
 # next time when the file exists, return done
 if [ -f %[1]s ]; then

--- a/overlord/devicestate/devicestate_gadget_test.go
+++ b/overlord/devicestate/devicestate_gadget_test.go
@@ -141,7 +141,8 @@ volumes:
 `
 
 func (s *deviceMgrGadgetSuite) SetUpTest(c *C) {
-	s.deviceMgrBaseSuite.SetUpTest(c)
+	classic := false
+	s.deviceMgrBaseSuite.setupBaseTest(c, classic)
 
 	s.managedbl = bootloadertest.Mock("mock", c.MkDir()).WithTrustedAssets()
 	s.managedbl.StaticCommandLine = "console=ttyS0 console=tty1 panic=-1"

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -76,7 +76,8 @@ func (s *deviceMgrInstallModeSuite) findInstallSystem() *state.Change {
 }
 
 func (s *deviceMgrInstallModeSuite) SetUpTest(c *C) {
-	s.deviceMgrBaseSuite.SetUpTest(c)
+	classic := false
+	s.deviceMgrBaseSuite.setupBaseTest(c, classic)
 
 	s.ConfigureTargetSystemOptsPassed = nil
 	s.ConfigureTargetSystemErr = nil

--- a/overlord/devicestate/devicestate_remodel_test.go
+++ b/overlord/devicestate/devicestate_remodel_test.go
@@ -64,6 +64,11 @@ type deviceMgrRemodelSuite struct {
 
 var _ = Suite(&deviceMgrRemodelSuite{})
 
+func (s *deviceMgrRemodelSuite) SetUpTest(c *C) {
+	classic := false
+	s.setupBaseTest(c, classic)
+}
+
 func (s *deviceMgrRemodelSuite) TestRemodelUnhappyNotSeeded(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()

--- a/overlord/devicestate/devicestate_serial_test.go
+++ b/overlord/devicestate/devicestate_serial_test.go
@@ -66,6 +66,11 @@ type deviceMgrSerialSuite struct {
 
 var _ = Suite(&deviceMgrSerialSuite{})
 
+func (s *deviceMgrSerialSuite) SetUpTest(c *C) {
+	classic := false
+	s.setupBaseTest(c, classic)
+}
+
 func (s *deviceMgrSerialSuite) signSerial(c *C, bhv *devicestatetest.DeviceServiceBehavior, headers map[string]interface{}, body []byte) (serial asserts.Assertion, ancillary []asserts.Assertion, err error) {
 	brandID := headers["brand-id"].(string)
 	model := headers["model"].(string)

--- a/overlord/devicestate/devicestate_systems_test.go
+++ b/overlord/devicestate/devicestate_systems_test.go
@@ -74,7 +74,8 @@ var _ = Suite(&deviceMgrSystemsSuite{})
 var _ = Suite(&deviceMgrSystemsCreateSuite{})
 
 func (s *deviceMgrSystemsBaseSuite) SetUpTest(c *C) {
-	s.deviceMgrBaseSuite.SetUpTest(c)
+	classic := false
+	s.deviceMgrBaseSuite.setupBaseTest(c, classic)
 
 	s.brands.Register("other-brand", brandPrivKey3, map[string]interface{}{
 		"display-name": "other publisher",

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -136,7 +136,7 @@ var (
 	brandPrivKey3, _ = assertstest.GenerateKey(752)
 )
 
-func (s *deviceMgrBaseSuite) SetUpTest(c *C) {
+func (s *deviceMgrBaseSuite) setupBaseTest(c *C, classic bool) {
 	s.BaseTest.SetUpTest(c)
 
 	dirs.SetRootDir(c.MkDir())
@@ -157,7 +157,7 @@ func (s *deviceMgrBaseSuite) SetUpTest(c *C) {
 	bootloader.Force(s.bootloader)
 	s.AddCleanup(func() { bootloader.Force(nil) })
 
-	s.AddCleanup(release.MockOnClassic(false))
+	s.AddCleanup(release.MockOnClassic(classic))
 
 	s.storeSigning = assertstest.NewStoreStack("canonical", nil)
 	s.restartObserve = nil
@@ -349,6 +349,11 @@ func makeSerialAssertionInState(c *C, brands *assertstest.SigningAccounts, st *s
 
 func (s *deviceMgrBaseSuite) makeSerialAssertionInState(c *C, brandID, model, serialN string) *asserts.Serial {
 	return makeSerialAssertionInState(c, s.brands, s.state, brandID, model, serialN)
+}
+
+func (s *deviceMgrSuite) SetUpTest(c *C) {
+	classic := false
+	s.setupBaseTest(c, classic)
 }
 
 func (s *deviceMgrSuite) TestDeviceManagerSetTimeOnce(c *C) {

--- a/overlord/devicestate/firstboot_preseed_test.go
+++ b/overlord/devicestate/firstboot_preseed_test.go
@@ -260,6 +260,12 @@ func (s *firstbootPreseedingClassic16Suite) SetUpTest(c *C) {
 
 	restoreRelease := release.MockOnClassic(true)
 	s.AddCleanup(restoreRelease)
+
+	mockMountCmd := testutil.MockCommand(c, "mount", "")
+	s.AddCleanup(mockMountCmd.Restore)
+
+	mockUmountCmd := testutil.MockCommand(c, "umount", "")
+	s.AddCleanup(mockUmountCmd.Restore)
 }
 
 func (s *firstbootPreseedingClassic16Suite) TestPreseedOnClassicHappy(c *C) {
@@ -268,12 +274,6 @@ func (s *firstbootPreseedingClassic16Suite) TestPreseedOnClassicHappy(c *C) {
 
 	// sanity
 	c.Assert(release.OnClassic, Equals, true)
-
-	mockMountCmd := testutil.MockCommand(c, "mount", "")
-	defer mockMountCmd.Restore()
-
-	mockUmountCmd := testutil.MockCommand(c, "umount", "")
-	defer mockUmountCmd.Restore()
 
 	coreFname, _, _ := s.makeCoreSnaps(c, "")
 
@@ -363,11 +363,8 @@ func (s *firstbootPreseedingClassic16Suite) TestPreseedClassicWithSnapdOnlyHappy
 	restorePreseedMode := snapdenv.MockPreseeding(true)
 	defer restorePreseedMode()
 
-	mockMountCmd := testutil.MockCommand(c, "mount", "")
-	defer mockMountCmd.Restore()
-
-	mockUmountCmd := testutil.MockCommand(c, "umount", "")
-	defer mockUmountCmd.Restore()
+	// sanity
+	c.Assert(release.OnClassic, Equals, true)
 
 	core18Fname, snapdFname, _, _ := s.makeCore18Snaps(c, &core18SnapsOpts{
 		classic: true,

--- a/overlord/devicestate/firstboot_preseed_test.go
+++ b/overlord/devicestate/firstboot_preseed_test.go
@@ -27,9 +27,6 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"github.com/snapcore/snapd/boot/boottest"
-	"github.com/snapcore/snapd/bootloader"
-	"github.com/snapcore/snapd/bootloader/bootloadertest"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/overlord/devicestate"
@@ -260,37 +257,6 @@ func (s *firstbootPreseed16Suite) SetUpTest(c *C) {
 
 	s.AddCleanup(interfaces.MockSystemKey(`{"core": "123"}`))
 	c.Assert(interfaces.WriteSystemKey(), IsNil)
-}
-
-func (s *firstbootPreseed16Suite) TestPreseedHappy(c *C) {
-	restore := snapdenv.MockPreseeding(true)
-	defer restore()
-
-	mockMountCmd := testutil.MockCommand(c, "mount", "")
-	defer mockMountCmd.Restore()
-
-	mockUmountCmd := testutil.MockCommand(c, "umount", "")
-	defer mockUmountCmd.Restore()
-
-	bloader := boottest.MockUC16Bootenv(bootloadertest.Mock("mock", c.MkDir()))
-	bootloader.Force(bloader)
-	defer bootloader.Force(nil)
-	bloader.SetBootKernel("pc-kernel_1.snap")
-	bloader.SetBootBase("core_1.snap")
-
-	s.startOverlord(c)
-	st := s.overlord.State()
-	opts := &devicestate.PopulateStateFromSeedOptions{Preseed: true}
-	chg, _ := s.makeSeedChange(c, st, opts, checkPreseedTasks, checkPreseedOrder)
-	err := s.overlord.Settle(settleTimeout)
-
-	st.Lock()
-	defer st.Unlock()
-
-	c.Assert(err, IsNil)
-	c.Assert(chg.Err(), IsNil)
-
-	checkPreseedTaskStates(c, st)
 }
 
 func (s *firstbootPreseed16Suite) TestPreseedOnClassicHappy(c *C) {

--- a/overlord/devicestate/firstboot_preseed_test.go
+++ b/overlord/devicestate/firstboot_preseed_test.go
@@ -40,12 +40,12 @@ import (
 	"github.com/snapcore/snapd/testutil"
 )
 
-type firstbootPreseed16Suite struct {
+type firstbootPreseedingClassic16Suite struct {
 	firstBootBaseTest
 	firstBoot16BaseTest
 }
 
-var _ = Suite(&firstbootPreseed16Suite{})
+var _ = Suite(&firstbootPreseedingClassic16Suite{})
 
 func checkPreseedTasks(c *C, tsAll []*state.TaskSet) {
 	// the tasks of the last taskset must be mark-preseeded, mark-seeded, in that order
@@ -246,7 +246,7 @@ func checkPreseedOrder(c *C, tsAll []*state.TaskSet, snaps ...string) {
 	c.Check(matched, Equals, len(snaps))
 }
 
-func (s *firstbootPreseed16Suite) SetUpTest(c *C) {
+func (s *firstbootPreseedingClassic16Suite) SetUpTest(c *C) {
 	s.TestingSeed16 = &seedtest.TestingSeed16{}
 	s.setup16BaseTest(c, &s.firstBootBaseTest)
 
@@ -257,14 +257,17 @@ func (s *firstbootPreseed16Suite) SetUpTest(c *C) {
 
 	s.AddCleanup(interfaces.MockSystemKey(`{"core": "123"}`))
 	c.Assert(interfaces.WriteSystemKey(), IsNil)
+
+	restoreRelease := release.MockOnClassic(true)
+	s.AddCleanup(restoreRelease)
 }
 
-func (s *firstbootPreseed16Suite) TestPreseedOnClassicHappy(c *C) {
+func (s *firstbootPreseedingClassic16Suite) TestPreseedOnClassicHappy(c *C) {
 	restore := snapdenv.MockPreseeding(true)
 	defer restore()
 
-	restoreRelease := release.MockOnClassic(true)
-	defer restoreRelease()
+	// sanity
+	c.Assert(release.OnClassic, Equals, true)
 
 	mockMountCmd := testutil.MockCommand(c, "mount", "")
 	defer mockMountCmd.Restore()
@@ -356,12 +359,9 @@ snaps:
 	c.Assert(err, Equals, state.ErrNoState)
 }
 
-func (s *firstbootPreseed16Suite) TestPreseedClassicWithSnapdOnlyHappy(c *C) {
+func (s *firstbootPreseedingClassic16Suite) TestPreseedClassicWithSnapdOnlyHappy(c *C) {
 	restorePreseedMode := snapdenv.MockPreseeding(true)
 	defer restorePreseedMode()
-
-	restore := release.MockOnClassic(true)
-	defer restore()
 
 	mockMountCmd := testutil.MockCommand(c, "mount", "")
 	defer mockMountCmd.Restore()

--- a/overlord/devicestate/handlers_test.go
+++ b/overlord/devicestate/handlers_test.go
@@ -439,6 +439,7 @@ func (s *deviceMgrSuite) TestDoPrepareRemodeling(c *C) {
 	c.Check(ok, Equals, false)
 }
 
+// TODO: move to preseeding_test.go
 type preseedingBaseSuite struct {
 	deviceMgrBaseSuite
 

--- a/overlord/devicestate/handlers_test.go
+++ b/overlord/devicestate/handlers_test.go
@@ -499,10 +499,6 @@ func (s *preseedingClassicSuite) SetUpTest(c *C) {
 	s.preseedingBaseSuite.SetUpTest(c, preseed, classic)
 }
 
-func (s *preseedingClassicSuite) TearDownTest(c *C) {
-	s.preseedingBaseSuite.TearDownTest(c)
-}
-
 func (s *preseedingClassicSuite) TestDoMarkPreseeded(c *C) {
 	now := time.Now()
 	restore := devicestate.MockTimeNow(func() time.Time {
@@ -600,10 +596,6 @@ func (s *preseedingClassicDoneSuite) SetUpTest(c *C) {
 	classic := true
 	preseed := false
 	s.preseedingBaseSuite.SetUpTest(c, preseed, classic)
-}
-
-func (s *preseedingClassicDoneSuite) TearDownTest(c *C) {
-	s.preseedingBaseSuite.TearDownTest(c)
 }
 
 func (s *preseedingClassicDoneSuite) TestDoMarkPreseededAfterFirstboot(c *C) {

--- a/overlord/devicestate/handlers_test.go
+++ b/overlord/devicestate/handlers_test.go
@@ -446,12 +446,12 @@ type preseedBaseSuite struct {
 	cmdSystemctl *testutil.MockCmd
 }
 
-func (s *preseedBaseSuite) SetUpTest(c *C, preseed bool) {
+func (s *preseedBaseSuite) SetUpTest(c *C, preseed, classic bool) {
 	r := snapdenv.MockPreseeding(preseed)
 
 	// preseed mode helper needs to be mocked before setting up
 	// deviceMgrBaseSuite due to device Manager init.
-	s.deviceMgrBaseSuite.SetUpTest(c)
+	s.deviceMgrBaseSuite.setupBaseTest(c, classic)
 
 	// can use cleanup only after having called base SetUpTest
 	s.AddCleanup(r)
@@ -497,7 +497,9 @@ type preseedModeSuite struct {
 var _ = Suite(&preseedModeSuite{})
 
 func (s *preseedModeSuite) SetUpTest(c *C) {
-	s.preseedBaseSuite.SetUpTest(c, true)
+	classic := true
+	preseed := true
+	s.preseedBaseSuite.SetUpTest(c, preseed, classic)
 }
 
 func (s *preseedModeSuite) TearDownTest(c *C) {
@@ -598,7 +600,9 @@ type preseedDoneSuite struct {
 var _ = Suite(&preseedDoneSuite{})
 
 func (s *preseedDoneSuite) SetUpTest(c *C) {
-	s.preseedBaseSuite.SetUpTest(c, false)
+	classic := true
+	preseed := false
+	s.preseedBaseSuite.SetUpTest(c, preseed, classic)
 }
 
 func (s *preseedDoneSuite) TearDownTest(c *C) {

--- a/overlord/devicestate/handlers_test.go
+++ b/overlord/devicestate/handlers_test.go
@@ -439,18 +439,17 @@ func (s *deviceMgrSuite) TestDoPrepareRemodeling(c *C) {
 	c.Check(ok, Equals, false)
 }
 
-type preseedBaseSuite struct {
+type preseedingBaseSuite struct {
 	deviceMgrBaseSuite
 
 	cmdUmount    *testutil.MockCmd
 	cmdSystemctl *testutil.MockCmd
 }
 
-func (s *preseedBaseSuite) SetUpTest(c *C, preseed, classic bool) {
-	r := snapdenv.MockPreseeding(preseed)
-
+func (s *preseedingBaseSuite) SetUpTest(c *C, preseed, classic bool) {
 	// preseed mode helper needs to be mocked before setting up
 	// deviceMgrBaseSuite due to device Manager init.
+	r := snapdenv.MockPreseeding(preseed)
 	s.deviceMgrBaseSuite.setupBaseTest(c, classic)
 
 	// can use cleanup only after having called base SetUpTest
@@ -487,26 +486,23 @@ apps:
 	})
 }
 
-// TODO: rename preesed mode to just preseeding as much as possible,
-// preseed mode souns like a UC20 system mode but is just a snapd mode
-// but preseed snapd mode is a mouthful
-type preseedModeSuite struct {
-	preseedBaseSuite
+type preseedingClassicSuite struct {
+	preseedingBaseSuite
 }
 
-var _ = Suite(&preseedModeSuite{})
+var _ = Suite(&preseedingClassicSuite{})
 
-func (s *preseedModeSuite) SetUpTest(c *C) {
+func (s *preseedingClassicSuite) SetUpTest(c *C) {
 	classic := true
 	preseed := true
-	s.preseedBaseSuite.SetUpTest(c, preseed, classic)
+	s.preseedingBaseSuite.SetUpTest(c, preseed, classic)
 }
 
-func (s *preseedModeSuite) TearDownTest(c *C) {
-	s.preseedBaseSuite.TearDownTest(c)
+func (s *preseedingClassicSuite) TearDownTest(c *C) {
+	s.preseedingBaseSuite.TearDownTest(c)
 }
 
-func (s *preseedModeSuite) TestDoMarkPreseeded(c *C) {
+func (s *preseedingClassicSuite) TestDoMarkPreseeded(c *C) {
 	now := time.Now()
 	restore := devicestate.MockTimeNow(func() time.Time {
 		return now
@@ -566,7 +562,7 @@ func (s *preseedModeSuite) TestDoMarkPreseeded(c *C) {
 	c.Check(t.Status(), Equals, state.DoingStatus)
 }
 
-func (s *preseedModeSuite) TestEnsureSeededPreseedFlag(c *C) {
+func (s *preseedingClassicSuite) TestEnsureSeededPreseedFlag(c *C) {
 	now := time.Now()
 	restoreTimeNow := devicestate.MockTimeNow(func() time.Time {
 		return now
@@ -593,23 +589,23 @@ func (s *preseedModeSuite) TestEnsureSeededPreseedFlag(c *C) {
 	c.Check(preseedStartTime.Equal(now), Equals, true)
 }
 
-type preseedDoneSuite struct {
-	preseedBaseSuite
+type preseedingClassicDoneSuite struct {
+	preseedingBaseSuite
 }
 
-var _ = Suite(&preseedDoneSuite{})
+var _ = Suite(&preseedingClassicDoneSuite{})
 
-func (s *preseedDoneSuite) SetUpTest(c *C) {
+func (s *preseedingClassicDoneSuite) SetUpTest(c *C) {
 	classic := true
 	preseed := false
-	s.preseedBaseSuite.SetUpTest(c, preseed, classic)
+	s.preseedingBaseSuite.SetUpTest(c, preseed, classic)
 }
 
-func (s *preseedDoneSuite) TearDownTest(c *C) {
-	s.preseedBaseSuite.TearDownTest(c)
+func (s *preseedingClassicDoneSuite) TearDownTest(c *C) {
+	s.preseedingBaseSuite.TearDownTest(c)
 }
 
-func (s *preseedDoneSuite) TestDoMarkPreseededAfterFirstboot(c *C) {
+func (s *preseedingClassicDoneSuite) TestDoMarkPreseededAfterFirstboot(c *C) {
 	st := s.state
 	st.Lock()
 	defer st.Unlock()

--- a/overlord/devicestate/systems_test.go
+++ b/overlord/devicestate/systems_test.go
@@ -75,7 +75,8 @@ var (
 )
 
 func (s *createSystemSuite) SetUpTest(c *C) {
-	s.deviceMgrBaseSuite.SetUpTest(c)
+	classic := false
+	s.deviceMgrBaseSuite.setupBaseTest(c, classic)
 
 	s.ss = &seedtest.SeedSnaps{
 		StoreSigning: s.storeSigning,


### PR DESCRIPTION
- pass "classic" flag to deviceMgrBaseSuite to allow creating device manager with mocked classic/core upfront. This doesn't prevent tests from overriding MockOnClassic later in the test but is important in case DeviceManager needs to know if it's on classic early in its init (important for core20/preseeding tests).
- drop TestPreseedHappy which was pointless/misleading as it was actually run against core; TestPreseedOnClassicHappy covers real case.
- renamed test suites from preseed* to preseeding*
- some minor cleanups and sanity checks for classic.