### PR TITLE
snapstate: make "remove vulnerable version" message more friendly

### DIFF
--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -690,7 +690,7 @@ func (m *SnapManager) ensureVulnerableSnapRemoved(name string) error {
 			return fmt.Errorf("cannot make task set for removing %s snap: %v", name, err)
 		}
 
-		msg := fmt.Sprintf(i18n.G("Remove inactive vulnerable %q snap rev %v"), name, rev)
+		msg := fmt.Sprintf(i18n.G("Remove inactive vulnerable %q snap (%v)"), name, rev)
 
 		chg := m.state.NewChange("remove-snap", msg)
 		chg.AddAll(tss)

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -690,7 +690,7 @@ func (m *SnapManager) ensureVulnerableSnapRemoved(name string) error {
 			return fmt.Errorf("cannot make task set for removing %s snap: %v", name, err)
 		}
 
-		msg := fmt.Sprintf(i18n.G("Remove vulnerable %q snap"), name)
+		msg := fmt.Sprintf(i18n.G("Remove inactive vulnerable %q snap rev %v"), name, rev)
 
 		chg := m.state.NewChange("remove-snap", msg)
 		chg.AddAll(tss)

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -2877,7 +2877,7 @@ SNAPD_APPARMOR_REEXEC=0
 	removeChg := allChgs[0]
 	c.Assert(removeChg.Status(), Equals, state.DoStatus)
 	c.Assert(removeChg.Kind(), Equals, "remove-snap")
-	c.Assert(removeChg.Summary(), Equals, fmt.Sprintf(`Remove vulnerable %q snap`, snapName))
+	c.Assert(removeChg.Summary(), Equals, fmt.Sprintf(`Remove inactive vulnerable %q snap rev 1`, snapName))
 
 	c.Assert(removeChg.Tasks(), HasLen, 2)
 	clearSnap := removeChg.Tasks()[0]

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -2877,7 +2877,7 @@ SNAPD_APPARMOR_REEXEC=0
 	removeChg := allChgs[0]
 	c.Assert(removeChg.Status(), Equals, state.DoStatus)
 	c.Assert(removeChg.Kind(), Equals, "remove-snap")
-	c.Assert(removeChg.Summary(), Equals, fmt.Sprintf(`Remove inactive vulnerable %q snap rev 1`, snapName))
+	c.Assert(removeChg.Summary(), Equals, fmt.Sprintf(`Remove inactive vulnerable %q snap (1)`, snapName))
 
 	c.Assert(removeChg.Tasks(), HasLen, 2)
 	clearSnap := removeChg.Tasks()[0]


### PR DESCRIPTION
This commit changes the the message:
```
Remove vulnerable "core" snap
```
to
```
Remove inactive vulnerable "core" snap rev 1
```
so that it's a bit clearer what exactly is happening and a bit
less scary.
