### PR TITLE
packaging: update changelog for 2.54.3

### DIFF
--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -991,7 +991,18 @@ fi
 %changelog
 * Tue Feb 15 2022 Michael Vogt <michael.vogt@ubuntu.com>
 - New upstream release 2.54.3
- - bugfixes
+ - SECURITY UPDATE: Local privilege escalation
+  - snap-confine: Add validations of the location of the snap-confine
+    binary within snapd.
+  - snap-confine: Fix race condition in snap-confine when preparing a
+    private mount namespace for a snap.
+  - CVE-2021-44730
+  - CVE-2021-44731
+ - SECURITY UPDATE: Data injection from malicious snaps
+  - interfaces: Add validations of snap content interface and layout
+    paths in snapd.
+  - CVE-2021-4120
+  - LP: #1949368
 
 * Thu Jan 06 2022 Ian Johnson <ian.johnson@canonical.com>
 - New upstream release 2.54.2

--- a/packaging/ubuntu-14.04/changelog
+++ b/packaging/ubuntu-14.04/changelog
@@ -1,7 +1,17 @@
 snapd (2.54.3~14.04) trusty; urgency=medium
 
-  * New upstream release, LP: #1955137
-    - bugfixes
+  * SECURITY UPDATE: Local privilege escalation
+    - snap-confine: Add validations of the location of the snap-confine
+      binary within snapd.
+    - snap-confine: Fix race condition in snap-confine when preparing a
+      private mount namespace for a snap.
+    - CVE-2021-44730
+    - CVE-2021-44731
+  * SECURITY UPDATE: Data injection from malicious snaps
+    - interfaces: Add validations of snap content interface and layout
+      paths in snapd.
+    - CVE-2021-4120
+    - LP: #1949368
 
  -- Michael Vogt <michael.vogt@ubuntu.com>  Tue, 15 Feb 2022 12:55:24 +0100
 

--- a/packaging/ubuntu-16.04/changelog
+++ b/packaging/ubuntu-16.04/changelog
@@ -1,9 +1,19 @@
 snapd (2.54.3) xenial; urgency=medium
 
-  * New upstream release, LP: #1955137
-    - bugfixes
+  * SECURITY UPDATE: Local privilege escalation
+    - snap-confine: Add validations of the location of the snap-confine
+      binary within snapd.
+    - snap-confine: Fix race condition in snap-confine when preparing a
+      private mount namespace for a snap.
+    - CVE-2021-44730
+    - CVE-2021-44731
+  * SECURITY UPDATE: Data injection from malicious snaps
+    - interfaces: Add validations of snap content interface and layout
+      paths in snapd.
+    - CVE-2021-4120
+    - LP: #1949368
 
- -- Michael Vogt <michael.vogt@ubuntu.com>  Tue, 15 Feb 2022 12:55:24 +0100
+ -- Michael Vogt <michael.vogt@ubuntu.com>  Tue, 15 Feb 2022 17:45:13 +0100
 
 snapd (2.54.2) xenial; urgency=medium
 


### PR DESCRIPTION
The changelog for 2.54.3 can now fully updated after the CRD. This
commit is doing this.

Maybe someone familar with fedora/rpm can double check the format there.