### PR TITLE
interfaces/{cpu,power}-control: add more accesses for commercial device tuning

### DIFF
--- a/interfaces/builtin/cpu_control.go
+++ b/interfaces/builtin/cpu_control.go
@@ -36,6 +36,18 @@ const cpuControlConnectedPlugAppArmor = `
 /sys/devices/system/cpu/smt/*       r,
 /sys/devices/system/cpu/smt/control w,
 
+/sys/module/cpu_boost/parameters/input_boost_freq rw,
+/sys/module/cpu_boost/parameters/input_boost_ms rw,
+/sys/devices/system/cpu/cpu[0-9][0-9]*/cpufreq/scaling_min_freq rw,
+/sys/devices/system/cpu/cpu[0-9][0-9]*/cpufreq/scaling_max_freq rw,
+/sys/devices/system/cpu/cpu[0-9][0-9]*/core_ctl/min_cpus rw,
+/sys/devices/system/cpu/cpu[0-9][0-9]*/core_ctl/busy_up_thres rw,
+/sys/devices/system/cpu/cpu[0-9][0-9]*/core_ctl/busy_down_thres rw,
+/sys/devices/system/cpu/cpu[0-9][0-9]*/core_ctl/offline_delay_ms rw,
+/sys/devices/system/cpu/cpu[0-9][0-9]*/core_ctl/task_thres rw,
+/sys/devices/system/cpu/cpu[0-9][0-9]*/core_ctl/nr_prev_assist_thresh rw,
+/sys/devices/system/cpu/cpu[0-9][0-9]*/core_ctl/enable rw,
+
 # https://www.kernel.org/doc/html/latest/admin-guide/pm/cpufreq.html#policy-interface-in-sysfs
 /sys/devices/system/cpu/cpufreq/{,**} r,
 /sys/devices/system/cpu/cpufreq/policy*/energy_performance_preference w,
@@ -43,6 +55,10 @@ const cpuControlConnectedPlugAppArmor = `
 /sys/devices/system/cpu/cpufreq/policy*/scaling_max_freq w,
 /sys/devices/system/cpu/cpufreq/policy*/scaling_min_freq w,
 /sys/devices/system/cpu/cpufreq/policy*/scaling_setspeed w,
+/sys/devices/system/cpu/cpufreq/policy*/schedutil/up_rate_limit_us rw,
+/sys/devices/system/cpu/cpufreq/policy*/schedutil/down_rate_limit_us rw,
+/sys/devices/system/cpu/cpufreq/policy*/schedutil/hispeed_freq rw,
+/sys/devices/system/cpu/cpufreq/policy*/schedutil/pl rw,
 /sys/devices/system/cpu/cpufreq/boost w,
 
 # https://www.kernel.org/doc/html/latest/admin-guide/pm/intel_pstate.html#user-space-interface-in-sysfs
@@ -52,6 +68,13 @@ const cpuControlConnectedPlugAppArmor = `
 /sys/devices/system/cpu/intel_pstate/min_perf_pct w,
 /sys/devices/system/cpu/intel_pstate/no_turbo w,
 /sys/devices/system/cpu/intel_pstate/status w,
+
+/proc/sys/kernel/sched_upmigrate rw,
+/proc/sys/kernel/sched_downmigrate rw,
+/proc/sys/kernel/sched_group_upmigrate rw,
+/proc/sys/kernel/sched_group_downmigrate rw,
+/proc/sys/kernel/sched_walt_rotate_big_tasks rw,
+/proc/sys/kernel/sched_boost rw,
 `
 
 func init() {

--- a/interfaces/builtin/power_control.go
+++ b/interfaces/builtin/power_control.go
@@ -46,6 +46,9 @@ const powerControlConnectedPlugAppArmor = `
 #/sys/devices/**/power/async w,
 #/sys/devices/**/power/autosuspend_delay_ms w,
 #/sys/devices/**/power/pm_qos* w,
+
+# for android kernels, see https://android.googlesource.com/kernel/msm/+/android-msm-bullhead-3.10-marshmallow-dr/Documentation/devicetree/bindings/arm/msm/lpm-levels.txt
+/sys/module/lpm_levels/parameters/sleep_disabled rw,
 `
 
 func init() {


### PR DESCRIPTION
See the init_post_boot.sh[1] script for a summary of these accesses. There are
other accesses we are still evaluating where to provide them, they likely
belong in either custom-devices or in system-files for specific devices
however.

See also salesforce ticket 00320679.

[1] https://source.codeaurora.org/quic/le/snap/yaml/tree/sa8155p-gadget/postboot/init_post_boot.sh?h=UC.UM.1.0.r1-00600-sa8155.0