### PR TITLE
tests/main/snap-run-devmode-classic: use realpath on deb filename

### DIFF
--- a/tests/main/snap-run-devmode-classic/task.yaml
+++ b/tests/main/snap-run-devmode-classic/task.yaml
@@ -187,7 +187,7 @@ execute: |
         fi
 
         # undo the purging
-        apt install -y "$PROJECT_PATH/../snapd_1337.2.54.2_amd64.deb"
+        apt install -y "$(realpath $PROJECT_PATH/../snapd_1337.2.54.2_amd64.deb)"
 
     else
         echo "unknown variant $SNAP_TO_USE_FIRST"


### PR DESCRIPTION
Apparently this sometimes fails like so:

```
+ apt install -y /home/gopath/src/github.com/snapcore/snapd/../snapd_1337.2.54.2_amd64.deb

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Reading package lists...
E: Unsupported file /home/gopath/src/github.com/snapcore/snapd/../snapd_1337.2.54.2_amd64.deb given on commandline
-----
.
2022-02-17 19:17:44 Debug output for google:ubuntu-16.04-64:tests/main/snap-run-devmode-classic:snapd_first (feb171833-569329) :
```

But using realpath will at least get rid of the ".." which may be the source of
the problem (or it might be something else, still unclear why it failed).