### PR TITLE
interfaces, o/ifacestate: don't allow devmode snaps calling other snaps on UC22

### DIFF
--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -785,10 +785,9 @@ func (b *Backend) addContent(securityTag string, snapInfo *snap.Info, cmdName st
 				usrLibSnapdConfineTransitionTarget = snapdProfileTarget()
 			case b.snapdSnap != nil && b.coreSnap != nil:
 				// both are installed - need to check which one to use
-				// TODO: is snapInfo.Base sometimes unset for snaps w/o bases
-				// these days? maybe this needs to be this instead ?
-				// if release.OnClassic && (snapInfo.Base == "core" || snapInfo.Base == "")
-				if release.OnClassic && snapInfo.Base == "core" {
+				// note that a base of "core" is represented by base == "" for
+				// historical reasons
+				if release.OnClassic && snapInfo.Base == "" {
 					// use the core snap as the target only if we are on
 					// classic and the base is core
 					usrLibSnapdConfineTransitionTarget = coreProfileTarget()

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -48,6 +48,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/logger"
@@ -77,6 +78,8 @@ type Backend struct {
 
 	coreSnap  *snap.Info
 	snapdSnap *snap.Info
+
+	model *asserts.Model
 }
 
 // Name returns the name of the backend.
@@ -93,6 +96,7 @@ func (b *Backend) Initialize(opts *interfaces.SecurityBackendOptions) error {
 	if opts != nil {
 		b.coreSnap = opts.CoreSnapInfo
 		b.snapdSnap = opts.SnapdSnapInfo
+		b.model = opts.Model
 	}
 	// NOTE: It would be nice if we could also generate the profile for
 	// snap-confine executing from the core snap, right here, and not have to
@@ -724,6 +728,11 @@ func (b *Backend) addContent(securityTag string, snapInfo *snap.Info, cmdName st
 		case "###DEVMODE_SNAP_CONFINE###":
 			if !opts.DevMode {
 				// nothing to add if we are not in devmode
+				return ""
+			}
+
+			if b.model != nil && b.model.Base() == "core22" {
+				// nothing to add if we are on UC22
 				return ""
 			}
 

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -191,6 +191,174 @@ func (s *backendSuite) TestName(c *C) {
 	c.Check(s.Backend.Name(), Equals, interfaces.SecurityAppArmor)
 }
 
+type expSnapConfineTransitionRules struct {
+	usrBinSnapRules   bool
+	usrLibSnapdTarget string
+	coreSnapTarget    string
+	snapdSnapTarget   string
+}
+
+func checkProfileExtraRules(c *C, profile string, exp expSnapConfineTransitionRules) {
+	if exp.usrBinSnapRules {
+		c.Assert(profile, testutil.FileContains, "  /usr/bin/snap ixr,")
+		c.Assert(profile, testutil.FileContains, " /snap/{snapd,core}/*/usr/bin/snap ixr,")
+	} else {
+		c.Assert(profile, Not(testutil.FileContains), "  /usr/bin/snap ixr,")
+		c.Assert(profile, Not(testutil.FileContains), " /snap/{snapd,core}/*/usr/bin/snap ixr,")
+	}
+
+	if exp.usrLibSnapdTarget != "" {
+		rule := fmt.Sprintf("/usr/lib/snapd/snap-confine Pxr -> %s,", exp.usrLibSnapdTarget)
+		c.Assert(profile, testutil.FileContains, rule)
+	} else {
+		c.Assert(profile, Not(testutil.FileMatches), "/usr/lib/snapd/snap-confine Pxr ->.*,")
+	}
+
+	if exp.coreSnapTarget != "" {
+		rule := fmt.Sprintf("/snap/core/*/usr/lib/snapd/snap-confine Pxr -> %s,", exp.coreSnapTarget)
+		c.Assert(profile, testutil.FileContains, rule)
+	} else {
+		c.Assert(profile, Not(testutil.FileMatches), "/snap/core/*/usr/lib/snapd/snap-confine Pxr ->.*,")
+	}
+
+	if exp.snapdSnapTarget != "" {
+		rule := fmt.Sprintf("/snap/snapd/*/usr/lib/snapd/snap-confine Pxr -> %s,", exp.snapdSnapTarget)
+		c.Assert(profile, testutil.FileContains, rule)
+	} else {
+		c.Assert(profile, Not(testutil.FileMatches), "/snap/snapd/*/usr/lib/snapd/snap-confine Pxr ->.*,")
+	}
+}
+
+func (s *backendSuite) TestInstallingDevmodeSnapCoreSnapOnlyExtraRules(c *C) {
+	// re-initialize with new options
+	backendOpts := &interfaces.SecurityBackendOptions{
+		CoreSnapInfo: ifacetest.DefaultInitializeOpts.CoreSnapInfo,
+	}
+	err := s.Backend.Initialize(backendOpts)
+	c.Assert(err, IsNil)
+
+	devMode := interfaces.ConfinementOptions{DevMode: true}
+	s.InstallSnap(c, devMode, "", ifacetest.SambaYamlV1, 1)
+
+	profile := filepath.Join(dirs.SnapAppArmorDir, "snap.samba.smbd")
+
+	checkProfileExtraRules(c, profile, expSnapConfineTransitionRules{
+		usrBinSnapRules:   true,
+		usrLibSnapdTarget: "/usr/lib/snapd/snap-confine",
+		coreSnapTarget:    "/snap/core/123/usr/lib/snapd/snap-confine",
+	})
+}
+
+func (s *backendSuite) TestInstallingDevmodeSnapSnapdSnapOnlyExtraRules(c *C) {
+	// re-initialize with new options
+	backendOpts := &interfaces.SecurityBackendOptions{
+		SnapdSnapInfo: ifacetest.DefaultInitializeOpts.SnapdSnapInfo,
+	}
+	err := s.Backend.Initialize(backendOpts)
+	c.Assert(err, IsNil)
+
+	devMode := interfaces.ConfinementOptions{DevMode: true}
+	s.InstallSnap(c, devMode, "", ifacetest.SambaYamlV1, 1)
+
+	profile := filepath.Join(dirs.SnapAppArmorDir, "snap.samba.smbd")
+
+	checkProfileExtraRules(c, profile, expSnapConfineTransitionRules{
+		usrBinSnapRules:   true,
+		usrLibSnapdTarget: "/snap/snapd/321/usr/lib/snapd/snap-confine",
+		snapdSnapTarget:   "/snap/snapd/321/usr/lib/snapd/snap-confine",
+	})
+}
+
+func (s *backendSuite) TestInstallingDevmodeSnapBothSnapdAndCoreSnapOnlyExtraRulesCore(c *C) {
+	r := release.MockOnClassic(false)
+	defer r()
+
+	// re-initialize with new options
+	backendOpts := &interfaces.SecurityBackendOptions{
+		SnapdSnapInfo: ifacetest.DefaultInitializeOpts.SnapdSnapInfo,
+		CoreSnapInfo:  ifacetest.DefaultInitializeOpts.CoreSnapInfo,
+	}
+	err := s.Backend.Initialize(backendOpts)
+	c.Assert(err, IsNil)
+
+	devMode := interfaces.ConfinementOptions{DevMode: true}
+	// snap base is core, but we are not on classic
+	s.InstallSnap(c, devMode, "", ifacetest.SambaYamlV1, 1)
+
+	profile := filepath.Join(dirs.SnapAppArmorDir, "snap.samba.smbd")
+	checkProfileExtraRules(c, profile, expSnapConfineTransitionRules{
+		usrBinSnapRules:   true,
+		usrLibSnapdTarget: "/snap/snapd/321/usr/lib/snapd/snap-confine",
+		snapdSnapTarget:   "/snap/snapd/321/usr/lib/snapd/snap-confine",
+		coreSnapTarget:    "/snap/core/123/usr/lib/snapd/snap-confine",
+	})
+}
+
+func (s *backendSuite) TestInstallingDevmodeSnapBothSnapdAndCoreSnapOnlyExtraRulesClassic(c *C) {
+	r := release.MockOnClassic(true)
+	defer r()
+
+	// re-initialize with new options
+	backendOpts := &interfaces.SecurityBackendOptions{
+		SnapdSnapInfo: ifacetest.DefaultInitializeOpts.SnapdSnapInfo,
+		CoreSnapInfo:  ifacetest.DefaultInitializeOpts.CoreSnapInfo,
+	}
+	err := s.Backend.Initialize(backendOpts)
+	c.Assert(err, IsNil)
+
+	devMode := interfaces.ConfinementOptions{DevMode: true}
+	// base core snap
+	s.InstallSnap(c, devMode, "", ifacetest.SambaYamlV1, 1)
+
+	profile := filepath.Join(dirs.SnapAppArmorDir, "snap.samba.smbd")
+	checkProfileExtraRules(c, profile, expSnapConfineTransitionRules{
+		usrBinSnapRules:   true,
+		usrLibSnapdTarget: "/snap/core/123/usr/lib/snapd/snap-confine",
+		snapdSnapTarget:   "/snap/snapd/321/usr/lib/snapd/snap-confine",
+		coreSnapTarget:    "/snap/core/123/usr/lib/snapd/snap-confine",
+	})
+}
+
+func (s *backendSuite) TestInstallingDevmodeSnapNonCoreBaseBothSnapdAndCoreSnapOnlyExtraRulesClassic(c *C) {
+	r := release.MockOnClassic(true)
+	defer r()
+
+	// re-initialize with new options
+	backendOpts := &interfaces.SecurityBackendOptions{
+		SnapdSnapInfo: ifacetest.DefaultInitializeOpts.SnapdSnapInfo,
+		CoreSnapInfo:  ifacetest.DefaultInitializeOpts.CoreSnapInfo,
+	}
+	err := s.Backend.Initialize(backendOpts)
+	c.Assert(err, IsNil)
+
+	devMode := interfaces.ConfinementOptions{DevMode: true}
+	// non-base core
+	s.InstallSnap(c, devMode, "", ifacetest.SambaYamlV1Core20Base, 1)
+
+	profile := filepath.Join(dirs.SnapAppArmorDir, "snap.samba.smbd")
+	checkProfileExtraRules(c, profile, expSnapConfineTransitionRules{
+		usrBinSnapRules:   true,
+		usrLibSnapdTarget: "/snap/snapd/321/usr/lib/snapd/snap-confine",
+		snapdSnapTarget:   "/snap/snapd/321/usr/lib/snapd/snap-confine",
+		coreSnapTarget:    "/snap/core/123/usr/lib/snapd/snap-confine",
+	})
+}
+
+func (s *backendSuite) TestInstallingDevmodeSnapNeitherSnapdNorCoreSnapInstalledPanicsLikeUC16InitialSeedWithDevmodeSnapInSeed(c *C) {
+	r := release.MockOnClassic(true)
+	defer r()
+
+	// neither snap is installed
+	backendOpts := &interfaces.SecurityBackendOptions{}
+	err := s.Backend.Initialize(backendOpts)
+	c.Assert(err, IsNil)
+
+	devMode := interfaces.ConfinementOptions{DevMode: true}
+	c.Assert(func() {
+		s.InstallSnap(c, devMode, "", ifacetest.SambaYamlV1, 1)
+	}, PanicMatches, "neither snapd nor core snap available while preparing apparmor profile for devmode snap samba, panicing to restart snapd to continue seeding")
+}
+
 func (s *backendSuite) TestInstallingSnapWritesAndLoadsProfiles(c *C) {
 	s.InstallSnap(c, interfaces.ConfinementOptions{}, "", ifacetest.SambaYamlV1, 1)
 	updateNSProfile := filepath.Join(dirs.SnapAppArmorDir, "snap-update-ns.samba")

--- a/interfaces/backend.go
+++ b/interfaces/backend.go
@@ -20,6 +20,7 @@
 package interfaces
 
 import (
+	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/timings"
 )
@@ -76,6 +77,8 @@ type SecurityBackendOptions struct {
 	// SnapdSnapInfo is the current revision of the snapd snap (if it is
 	// installed)
 	SnapdSnapInfo *snap.Info
+	// Model is the model assertion of the device.
+	Model *asserts.Model
 }
 
 // SecurityBackend abstracts interactions between the interface system and the

--- a/interfaces/ifacetest/backendtest.go
+++ b/interfaces/ifacetest/backendtest.go
@@ -51,6 +51,11 @@ func (s *BackendSuite) SetUpTest(c *C) {
 	c.Assert(ok, Equals, true)
 	DefaultInitializeOpts.CoreSnapInfo = snInfo
 
+	snapdSnapPlaceInfo := snap.MinimalPlaceInfo("snapd", snap.Revision{N: 321})
+	snInfo, ok = snapdSnapPlaceInfo.(*snap.Info)
+	c.Assert(ok, Equals, true)
+	DefaultInitializeOpts.SnapdSnapInfo = snInfo
+
 	// Isolate this test to a temporary directory
 	s.RootDir = c.MkDir()
 	dirs.SetRootDir(s.RootDir)
@@ -78,6 +83,17 @@ func (s *BackendSuite) TearDownTest(c *C) {
 // Tests for Setup() and Remove()
 const SambaYamlV1 = `
 name: samba
+version: 1
+developer: acme
+apps:
+    smbd:
+slots:
+    slot:
+        interface: iface
+`
+const SambaYamlV1Core20Base = `
+name: samba
+base: core20
 version: 1
 developer: acme
 apps:

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -37,6 +37,7 @@ import (
 	"github.com/snapcore/snapd/jsonutil"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/assertstate"
+	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
@@ -95,10 +96,22 @@ func (m *InterfaceManager) addBackends(extra []interfaces.SecurityBackend) error
 		}
 	}
 
+	// get the model
+	deviceCtx, err := devicestate.DeviceCtx(m.state, nil, nil)
+	if err != nil && err != state.ErrNoState {
+		return err
+	}
+
+	var model *asserts.Model
+	if deviceCtx != nil {
+		model = deviceCtx.Model()
+	}
+
 	opts := interfaces.SecurityBackendOptions{
 		Preseed:       m.preseed,
 		CoreSnapInfo:  coreSnapInfo,
 		SnapdSnapInfo: snapdSnapInfo,
+		Model:         model,
 	}
 	for _, backend := range backends.All {
 		if err := backend.Initialize(&opts); err != nil {


### PR DESCRIPTION
Eventually we will also disable this behavior of being able to call snap-confine from a devmode snap
for all other systems, but for now we can only get away with disabling UC22.

Also add missing unit tests from the branch we didn't have time to write/prepare.