### PR TITLE
snap: add new cpu quotas 

### DIFF
--- a/daemon/api_quotas_test.go
+++ b/daemon/api_quotas_test.go
@@ -73,11 +73,11 @@ func (s *apiQuotaSuite) SetUpTest(c *check.C) {
 }
 
 func mockQuotas(st *state.State, c *check.C) {
-	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, quota.NewResources(11000))
+	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, quota.NewResourcesBuilder().WithMemoryLimit(11000).Build())
 	c.Assert(err, check.IsNil)
-	err = servicestatetest.MockQuotaInState(st, "bar", "foo", nil, quota.NewResources(6000))
+	err = servicestatetest.MockQuotaInState(st, "bar", "foo", nil, quota.NewResourcesBuilder().WithMemoryLimit(6000).Build())
 	c.Assert(err, check.IsNil)
-	err = servicestatetest.MockQuotaInState(st, "baz", "foo", nil, quota.NewResources(5000))
+	err = servicestatetest.MockQuotaInState(st, "baz", "foo", nil, quota.NewResourcesBuilder().WithMemoryLimit(5000).Build())
 	c.Assert(err, check.IsNil)
 }
 
@@ -108,7 +108,7 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaUnhappy(c *check.C) {
 		c.Check(name, check.Equals, "booze")
 		c.Check(parentName, check.Equals, "foo")
 		c.Check(snaps, check.DeepEquals, []string{"bar"})
-		c.Check(resourceLimits, check.DeepEquals, quota.NewResources(quantity.Size(1000)))
+		c.Check(resourceLimits, check.DeepEquals, quota.NewResourcesBuilder().WithMemoryLimit(quantity.Size(1000)).Build())
 		return nil, fmt.Errorf("boom")
 	})
 	defer r()
@@ -137,7 +137,7 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaCreateHappy(c *check.C) {
 		c.Check(name, check.Equals, "booze")
 		c.Check(parentName, check.Equals, "foo")
 		c.Check(snaps, check.DeepEquals, []string{"some-snap"})
-		c.Check(resourceLimits, check.DeepEquals, quota.NewResources(quantity.Size(1000)))
+		c.Check(resourceLimits, check.DeepEquals, quota.NewResourcesBuilder().WithMemoryLimit(quantity.Size(1000)).Build())
 		ts := state.NewTaskSet(st.NewTask("foo-quota", "..."))
 		return ts, nil
 	})
@@ -166,7 +166,7 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaCreateQuotaConflicts(c *check.C) {
 		c.Check(name, check.Equals, "booze")
 		c.Check(parentName, check.Equals, "foo")
 		c.Check(snaps, check.DeepEquals, []string{"some-snap"})
-		c.Check(resourceLimits, check.DeepEquals, quota.NewResources(quantity.Size(1000)))
+		c.Check(resourceLimits, check.DeepEquals, quota.NewResourcesBuilder().WithMemoryLimit(quantity.Size(1000)).Build())
 
 		createCalled++
 		switch createCalled {
@@ -221,7 +221,7 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaCreateQuotaConflicts(c *check.C) {
 func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateHappy(c *check.C) {
 	st := s.d.Overlord().State()
 	st.Lock()
-	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", nil, quota.NewResources(5000))
+	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", nil, quota.NewResourcesBuilder().WithMemoryLimit(5000).Build())
 	st.Unlock()
 	c.Assert(err, check.IsNil)
 
@@ -237,7 +237,7 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateHappy(c *check.C) {
 		c.Assert(name, check.Equals, "ginger-ale")
 		c.Assert(opts, check.DeepEquals, servicestate.QuotaGroupUpdate{
 			AddSnaps:          []string{"some-snap"},
-			NewResourceLimits: quota.NewResources(quantity.Size(9000)),
+			NewResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.Size(9000)).Build(),
 		})
 		ts := state.NewTaskSet(st.NewTask("foo-quota", "..."))
 		return ts, nil
@@ -263,7 +263,7 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateHappy(c *check.C) {
 func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateConflicts(c *check.C) {
 	st := s.d.Overlord().State()
 	st.Lock()
-	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", nil, quota.NewResources(5000))
+	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", nil, quota.NewResourcesBuilder().WithMemoryLimit(5000).Build())
 	st.Unlock()
 	c.Assert(err, check.IsNil)
 
@@ -279,7 +279,7 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateConflicts(c *check.C) {
 		c.Assert(name, check.Equals, "ginger-ale")
 		c.Assert(opts, check.DeepEquals, servicestate.QuotaGroupUpdate{
 			AddSnaps:          []string{"some-snap"},
-			NewResourceLimits: quota.NewResources(quantity.Size(9000)),
+			NewResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.Size(9000)).Build(),
 		})
 		switch updateCalled {
 		case 1:
@@ -359,7 +359,7 @@ func (s *apiQuotaSuite) TestPostRemoveQuotaHappy(c *check.C) {
 func (s *apiQuotaSuite) TestPostRemoveQuotaConflict(c *check.C) {
 	st := s.d.Overlord().State()
 	st.Lock()
-	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", []string{"some-snap"}, quota.NewResources(5000))
+	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", []string{"some-snap"}, quota.NewResourcesBuilder().WithMemoryLimit(5000).Build())
 	st.Unlock()
 	c.Assert(err, check.IsNil)
 

--- a/overlord/configstate/configcore/vitality_test.go
+++ b/overlord/configstate/configcore/vitality_test.go
@@ -196,7 +196,8 @@ func (s *vitalitySuite) TestConfigureVitalityWithQuotaGroup(c *C) {
 	tr.Commit()
 
 	// make a new quota group with this snap in it
-	err := servicestatetest.MockQuotaInState(s.state, "foogroup", "", []string{"test-snap"}, quota.NewResources(quantity.SizeMiB))
+	err := servicestatetest.MockQuotaInState(s.state, "foogroup", "", []string{"test-snap"},
+		quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build())
 	c.Assert(err, IsNil)
 
 	s.state.Unlock()

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -761,7 +761,8 @@ apps:
 	tr.Commit()
 
 	// put the snap in a quota group
-	err := servicestatetest.MockQuotaInState(st, "quota-grp", "", []string{"foo"}, quota.NewResources(quantity.SizeMiB))
+	err := servicestatetest.MockQuotaInState(st, "quota-grp", "", []string{"foo"},
+		quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build())
 	c.Assert(err, IsNil)
 
 	ts, err := snapstate.Remove(st, "foo", snap.R(0), &snapstate.RemoveFlags{Purge: true})
@@ -812,7 +813,8 @@ apps:
 	tr.Commit()
 
 	// add the snap to a quota group
-	ts, err := servicestate.CreateQuota(st, "grp", "", []string{"foo"}, quota.NewResources(quantity.SizeGiB))
+	ts, err := servicestate.CreateQuota(st, "grp", "", []string{"foo"},
+		quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
 	c.Assert(err, IsNil)
 	quotaUpdateChg := st.NewChange("update-quota", "...")
 	quotaUpdateChg.AddAll(ts)

--- a/overlord/servicestate/internal/quotas_test.go
+++ b/overlord/servicestate/internal/quotas_test.go
@@ -122,7 +122,7 @@ func (s *servicestateQuotasSuite) TestQuotas(c *C) {
 
 	_, err = internal.PatchQuotas(st, otherGrp2, otherGrp)
 	// either group can get checked first
-	c.Assert(err, ErrorMatches, `cannot update quotas "other-group", "other-group2": group "other-group2?" is invalid: quota group must have a memory limit set`)
+	c.Assert(err, ErrorMatches, `cannot update quotas "other-group", "other-group2": group "other-group2?" is invalid: quota group must have at least one resource limit set`)
 }
 
 func (s *servicestateQuotasSuite) TestCreateQuotaInState(c *C) {
@@ -135,7 +135,7 @@ func (s *servicestateQuotasSuite) TestCreateQuotaInState(c *C) {
 		Name:        "foogroup",
 		MemoryLimit: quantity.SizeGiB,
 	}
-	grp1, newGrps, err := internal.CreateQuotaInState(st, "foogroup", nil, nil, quota.NewResources(quantity.SizeGiB), nil)
+	grp1, newGrps, err := internal.CreateQuotaInState(st, "foogroup", nil, nil, quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(), nil)
 	c.Assert(err, IsNil)
 	c.Check(grp1, DeepEquals, grp)
 	c.Check(newGrps, DeepEquals, map[string]*quota.Group{
@@ -156,7 +156,7 @@ func (s *servicestateQuotasSuite) TestCreateQuotaInState(c *C) {
 		ParentGroup: "foogroup",
 		Snaps:       []string{"snap1", "snap2"},
 	}
-	grp3, newGrps, err := internal.CreateQuotaInState(st, "group-2", grp1, []string{"snap1", "snap2"}, quota.NewResources(quantity.SizeGiB), nil)
+	grp3, newGrps, err := internal.CreateQuotaInState(st, "group-2", grp1, []string{"snap1", "snap2"}, quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(), nil)
 	c.Assert(err, IsNil)
 	c.Check(grp3.Name, Equals, grp2.Name)
 	c.Check(grp3.MemoryLimit, Equals, grp2.MemoryLimit)

--- a/overlord/servicestate/quota_control_test.go
+++ b/overlord/servicestate/quota_control_test.go
@@ -210,7 +210,7 @@ func (s *quotaControlSuite) TestCreateQuotaNotEnabled(c *C) {
 	tr.Commit()
 
 	// try to create an empty quota group
-	_, err := servicestate.CreateQuota(s.state, "foo", "", nil, quota.NewResources(quantity.SizeGiB))
+	_, err := servicestate.CreateQuota(s.state, "foo", "", nil, quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
 	c.Assert(err, ErrorMatches, `experimental feature disabled - test it by setting 'experimental.quota-groups' to true`)
 }
 
@@ -223,7 +223,7 @@ func (s *quotaControlSuite) TestCreateQuotaSystemdTooOld(c *C) {
 
 	servicestate.CheckSystemdVersion()
 
-	_, err := servicestate.CreateQuota(s.state, "foo", "", nil, quota.NewResources(quantity.SizeGiB))
+	_, err := servicestate.CreateQuota(s.state, "foo", "", nil, quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
 	c.Assert(err, ErrorMatches, `cannot use quotas with incompatible systemd: systemd version 229 is too old \(expected at least 230\)`)
 }
 
@@ -232,7 +232,7 @@ func (s *quotaControlSuite) TestCreateQuotaPrecond(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, quota.NewResources(2*quantity.SizeGiB))
+	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB*2).Build())
 	c.Assert(err, IsNil)
 
 	tests := []struct {
@@ -242,13 +242,14 @@ func (s *quotaControlSuite) TestCreateQuotaPrecond(c *C) {
 		err   string
 	}{
 		{"foo", 16 * quantity.SizeKiB, nil, `group "foo" already exists`},
-		{"new", 0, nil, `cannot create quota group "new": quota group must have a memory limit set`},
+		{"new", 0, nil, `cannot create quota group "new": memory quota must have a limit set`},
 		{"new", quantity.SizeKiB, nil, `cannot create quota group "new": memory limit 1024 is too small: size must be larger than 4KB`},
 		{"new", 16 * quantity.SizeKiB, []string{"baz"}, `cannot use snap "baz" in group "new": snap "baz" is not installed`},
 	}
 
 	for _, t := range tests {
-		_, err := servicestate.CreateQuota(st, t.name, "", t.snaps, quota.NewResources(t.mem))
+		testConstraints := quota.NewResourcesBuilder().WithMemoryLimit(t.mem).Build()
+		_, err := servicestate.CreateQuota(st, t.name, "", t.snaps, testConstraints)
 		c.Check(err, ErrorMatches, t.err)
 	}
 }
@@ -265,7 +266,7 @@ func (s *quotaControlSuite) TestRemoveQuotaPreseeding(c *C) {
 	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
 
 	// create a quota group
-	ts, err := servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap"}, quota.NewResources(quantity.SizeGiB))
+	ts, err := servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap"}, quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
 	c.Assert(err, IsNil)
 
 	chg := st.NewChange("quota-control", "...")
@@ -275,7 +276,7 @@ func (s *quotaControlSuite) TestRemoveQuotaPreseeding(c *C) {
 		Action:         "create",
 		QuotaName:      "foo",
 		AddSnaps:       []string{"test-snap"},
-		ResourceLimits: quota.NewResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 	}
 
 	checkQuotaControlTasks(c, chg.Tasks(), exp)
@@ -290,7 +291,7 @@ func (s *quotaControlSuite) TestRemoveQuotaPreseeding(c *C) {
 	// check that the quota groups were created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -325,8 +326,11 @@ func (s *quotaControlSuite) TestCreateUpdateRemoveQuotaHappy(c *C) {
 	snapstate.Set(s.state, "test-snap", s.testSnapState)
 	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
 
+	// create the quota constraints to use for the test
+	quotaConstraits := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
+
 	// create the quota group
-	ts, err := servicestate.CreateQuota(st, "foo", "", []string{"test-snap"}, quota.NewResources(quantity.SizeGiB))
+	ts, err := servicestate.CreateQuota(st, "foo", "", []string{"test-snap"}, quotaConstraits)
 	c.Assert(err, IsNil)
 
 	chg := st.NewChange("quota-control", "...")
@@ -336,7 +340,7 @@ func (s *quotaControlSuite) TestCreateUpdateRemoveQuotaHappy(c *C) {
 		Action:         "create",
 		QuotaName:      "foo",
 		AddSnaps:       []string{"test-snap"},
-		ResourceLimits: quota.NewResources(quantity.SizeGiB),
+		ResourceLimits: quotaConstraits,
 	}
 
 	checkQuotaControlTasks(c, chg.Tasks(), exp)
@@ -351,16 +355,14 @@ func (s *quotaControlSuite) TestCreateUpdateRemoveQuotaHappy(c *C) {
 	// check that the quota groups were created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quotaConstraits,
 			Snaps:          []string{"test-snap"},
 		},
 	})
 
 	// increase the memory limit
-	ts, err = servicestate.UpdateQuota(st, "foo",
-		servicestate.QuotaGroupUpdate{
-			NewResourceLimits: quota.NewResources(2 * quantity.SizeGiB),
-		})
+	newConstraits := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB * 2).Build()
+	ts, err = servicestate.UpdateQuota(st, "foo", servicestate.QuotaGroupUpdate{NewResourceLimits: newConstraits})
 	c.Assert(err, IsNil)
 
 	chg = st.NewChange("quota-control", "...")
@@ -369,7 +371,7 @@ func (s *quotaControlSuite) TestCreateUpdateRemoveQuotaHappy(c *C) {
 	exp2 := &servicestate.QuotaControlAction{
 		Action:         "update",
 		QuotaName:      "foo",
-		ResourceLimits: quota.NewResources(2 * quantity.SizeGiB),
+		ResourceLimits: newConstraits,
 	}
 
 	checkQuotaControlTasks(c, chg.Tasks(), exp2)
@@ -383,7 +385,7 @@ func (s *quotaControlSuite) TestCreateUpdateRemoveQuotaHappy(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(2 * quantity.SizeGiB),
+			ResourceLimits: newConstraits,
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -450,7 +452,8 @@ func (s *quotaControlSuite) TestEnsureSnapAbsentFromQuotaGroup(c *C) {
 	snaptest.MockSnapCurrent(c, testYaml2, si2)
 
 	// create a quota group
-	ts, err := servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap", "test-snap2"}, quota.NewResources(quantity.SizeGiB))
+	quotaConstraits := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
+	ts, err := servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap", "test-snap2"}, quotaConstraits)
 	c.Assert(err, IsNil)
 
 	chg := st.NewChange("quota-control", "...")
@@ -460,7 +463,7 @@ func (s *quotaControlSuite) TestEnsureSnapAbsentFromQuotaGroup(c *C) {
 		Action:         "create",
 		QuotaName:      "foo",
 		AddSnaps:       []string{"test-snap", "test-snap2"},
-		ResourceLimits: quota.NewResources(quantity.SizeGiB),
+		ResourceLimits: quotaConstraits,
 	}
 
 	checkQuotaControlTasks(c, chg.Tasks(), exp)
@@ -474,7 +477,7 @@ func (s *quotaControlSuite) TestEnsureSnapAbsentFromQuotaGroup(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quotaConstraits,
 			Snaps:          []string{"test-snap", "test-snap2"},
 		},
 	})
@@ -485,7 +488,7 @@ func (s *quotaControlSuite) TestEnsureSnapAbsentFromQuotaGroup(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quotaConstraits,
 			Snaps:          []string{"test-snap2"},
 		},
 	})
@@ -501,7 +504,7 @@ func (s *quotaControlSuite) TestEnsureSnapAbsentFromQuotaGroup(c *C) {
 	// and check that it got updated in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quotaConstraits,
 		},
 	})
 
@@ -528,16 +531,18 @@ func (s *quotaControlSuite) TestUpdateQuotaPrecond(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, quota.NewResources(2*quantity.SizeGiB))
+	quotaConstraits := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB * 2).Build()
+	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, quotaConstraits)
 	c.Assert(err, IsNil)
 
+	newConstraits := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
 	tests := []struct {
 		name string
 		opts servicestate.QuotaGroupUpdate
 		err  string
 	}{
 		{"what", servicestate.QuotaGroupUpdate{}, `group "what" does not exist`},
-		{"foo", servicestate.QuotaGroupUpdate{NewResourceLimits: quota.NewResources(quantity.SizeGiB)}, `cannot update group "foo": cannot decrease memory limit, remove and re-create it to decrease the limit`},
+		{"foo", servicestate.QuotaGroupUpdate{NewResourceLimits: newConstraits}, `cannot update group "foo": cannot decrease memory limit, remove and re-create it to decrease the limit`},
 		{"foo", servicestate.QuotaGroupUpdate{AddSnaps: []string{"baz"}}, `cannot use snap "baz" in group "foo": snap "baz" is not installed`},
 	}
 
@@ -552,9 +557,12 @@ func (s *quotaControlSuite) TestRemoveQuotaPrecond(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, quota.NewResources(2*quantity.SizeGiB))
+	quotaConstraits2GB := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
+	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, quotaConstraits2GB)
 	c.Assert(err, IsNil)
-	err = servicestatetest.MockQuotaInState(st, "bar", "foo", nil, quota.NewResources(quantity.SizeGiB))
+
+	quotaConstraits1GB := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
+	err = servicestatetest.MockQuotaInState(st, "bar", "foo", nil, quotaConstraits1GB)
 	c.Assert(err, IsNil)
 
 	_, err = servicestate.RemoveQuota(st, "what")
@@ -605,7 +613,8 @@ func (s *quotaControlSuite) TestSnapOpUpdateQuotaConflict(c *C) {
 
 	// create a quota group
 	defer s.se.Stop()
-	s.createQuota(c, "foo", quota.NewResources(quantity.SizeGiB), "test-snap")
+	quotaConstraits := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
+	s.createQuota(c, "foo", quotaConstraits, "test-snap")
 
 	ts, err := snapstate.Disable(st, "test-snap2")
 	c.Assert(err, IsNil)
@@ -630,7 +639,8 @@ func (s *quotaControlSuite) TestSnapOpCreateQuotaConflict(c *C) {
 	chg1 := s.state.NewChange("disable", "...")
 	chg1.AddAll(ts)
 
-	_, err = servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap"}, quota.NewResources(quantity.SizeGiB))
+	quotaConstraits := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
+	_, err = servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap"}, quotaConstraits)
 	c.Assert(err, ErrorMatches, `snap "test-snap" has "disable" change in progress`)
 }
 
@@ -651,7 +661,8 @@ func (s *quotaControlSuite) TestSnapOpRemoveQuotaConflict(c *C) {
 
 	// create a quota group
 	defer s.se.Stop()
-	s.createQuota(c, "foo", quota.NewResources(quantity.SizeGiB), "test-snap")
+	quotaConstraits := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
+	s.createQuota(c, "foo", quotaConstraits, "test-snap")
 
 	ts, err := snapstate.Disable(st, "test-snap")
 	c.Assert(err, IsNil)
@@ -671,7 +682,8 @@ func (s *quotaControlSuite) TestCreateQuotaSnapOpConflict(c *C) {
 	snapstate.Set(s.state, "test-snap", s.testSnapState)
 	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
 
-	ts, err := servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap"}, quota.NewResources(quantity.SizeGiB))
+	quotaConstraits := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
+	ts, err := servicestate.CreateQuota(s.state, "foo", "", []string{"test-snap"}, quotaConstraits)
 	c.Assert(err, IsNil)
 	chg1 := s.state.NewChange("quota-control", "...")
 	chg1.AddAll(ts)
@@ -707,7 +719,8 @@ func (s *quotaControlSuite) TestUpdateQuotaSnapOpConflict(c *C) {
 
 	// create a quota group
 	defer s.se.Stop()
-	s.createQuota(c, "foo", quota.NewResources(quantity.SizeGiB), "test-snap")
+	quotaConstraits := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
+	s.createQuota(c, "foo", quotaConstraits, "test-snap")
 
 	ts, err := servicestate.UpdateQuota(st, "foo", servicestate.QuotaGroupUpdate{AddSnaps: []string{"test-snap2"}})
 	c.Assert(err, IsNil)
@@ -735,7 +748,8 @@ func (s *quotaControlSuite) TestRemoveQuotaSnapOpConflict(c *C) {
 
 	// create a quota group
 	defer s.se.Stop()
-	s.createQuota(c, "foo", quota.NewResources(quantity.SizeGiB), "test-snap")
+	quotaConstraits := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
+	s.createQuota(c, "foo", quotaConstraits, "test-snap")
 
 	ts, err := servicestate.RemoveQuota(st, "foo")
 	c.Assert(err, IsNil)
@@ -763,7 +777,8 @@ func (s *quotaControlSuite) TestRemoveQuotaLateSnapOpConflict(c *C) {
 
 	// create a quota group
 	defer s.se.Stop()
-	s.createQuota(c, "foo", quota.NewResources(quantity.SizeGiB), "test-snap")
+	quotaConstraits := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
+	s.createQuota(c, "foo", quotaConstraits, "test-snap")
 
 	ts, err := servicestate.RemoveQuota(st, "foo")
 	c.Assert(err, IsNil)
@@ -812,17 +827,16 @@ func (s *quotaControlSuite) TestUpdateQuotaUpdateQuotaConflict(c *C) {
 
 	// create a quota group
 	defer s.se.Stop()
-	s.createQuota(c, "foo", quota.NewResources(quantity.SizeGiB), "test-snap")
+	quotaConstraits := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
+	s.createQuota(c, "foo", quotaConstraits, "test-snap")
 
 	ts, err := servicestate.UpdateQuota(st, "foo", servicestate.QuotaGroupUpdate{AddSnaps: []string{"test-snap2"}})
 	c.Assert(err, IsNil)
 	chg1 := s.state.NewChange("quota-control", "...")
 	chg1.AddAll(ts)
 
-	_, err = servicestate.UpdateQuota(st, "foo",
-		servicestate.QuotaGroupUpdate{
-			NewResourceLimits: quota.NewResources(2 * quantity.SizeGiB),
-		})
+	newConstraits := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB * 2).Build()
+	_, err = servicestate.UpdateQuota(st, "foo", servicestate.QuotaGroupUpdate{NewResourceLimits: newConstraits})
 	c.Assert(err, ErrorMatches, `quota group "foo" has "quota-control" change in progress`)
 }
 
@@ -853,7 +867,8 @@ func (s *quotaControlSuite) TestUpdateQuotaRemoveQuotaConflict(c *C) {
 
 	// create a quota group
 	defer s.se.Stop()
-	s.createQuota(c, "foo", quota.NewResources(quantity.SizeGiB), "test-snap")
+	quotaConstraits := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
+	s.createQuota(c, "foo", quotaConstraits, "test-snap")
 
 	ts, err := servicestate.UpdateQuota(st, "foo", servicestate.QuotaGroupUpdate{AddSnaps: []string{"test-snap2"}})
 	c.Assert(err, IsNil)
@@ -891,7 +906,8 @@ func (s *quotaControlSuite) TestRemoveQuotaUpdateQuotaConflict(c *C) {
 
 	// create a quota group
 	defer s.se.Stop()
-	s.createQuota(c, "foo", quota.NewResources(quantity.SizeGiB), "test-snap")
+	quotaConstraits := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
+	s.createQuota(c, "foo", quotaConstraits, "test-snap")
 
 	ts, err := servicestate.RemoveQuota(st, "foo")
 	c.Assert(err, IsNil)
@@ -921,12 +937,14 @@ func (s *quotaControlSuite) TestCreateQuotaCreateQuotaConflict(c *C) {
 	snapstate.Set(s.state, "test-snap2", snapst2)
 	snaptest.MockSnapCurrent(c, testYaml2, si2)
 
-	ts, err := servicestate.CreateQuota(st, "foo", "", []string{"test-snap"}, quota.NewResources(quantity.SizeGiB))
+	quotaConstraits := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
+	ts, err := servicestate.CreateQuota(st, "foo", "", []string{"test-snap"}, quotaConstraits)
 	c.Assert(err, IsNil)
 	chg1 := s.state.NewChange("quota-control", "...")
 	chg1.AddAll(ts)
 
-	_, err = servicestate.CreateQuota(st, "foo", "", []string{"test-snap2"}, quota.NewResources(2*quantity.SizeGiB))
+	newConstraits := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB * 2).Build()
+	_, err = servicestate.CreateQuota(st, "foo", "", []string{"test-snap2"}, newConstraits)
 	c.Assert(err, ErrorMatches, `quota group "foo" has "quota-control" change in progress`)
 }
 
@@ -944,7 +962,7 @@ func (s *quotaControlSuite) TestUpdateQuotaModifyExistingMixable(c *C) {
 
 	// try to update a quota value, this must fail
 	_, err = servicestate.UpdateQuota(st, "mixed-grp", servicestate.QuotaGroupUpdate{
-		NewResourceLimits: quota.NewResources(quantity.SizeGiB * 2),
+		NewResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB * 2).Build(),
 	})
 	c.Assert(err, ErrorMatches, `quota group "mixed-grp" has mixed snaps and sub-groups, which is no longer supported; removal and re-creation is necessary to modify it`)
 }

--- a/overlord/servicestate/quota_handlers.go
+++ b/overlord/servicestate/quota_handlers.go
@@ -338,8 +338,7 @@ func quotaUpdateGroupLimits(grp *quota.Group, limits quota.Resources) error {
 	if err := currentQuotas.Change(limits); err != nil {
 		return fmt.Errorf("cannot update limits for group %q: %v", grp.Name, err)
 	}
-	grp.UpdateQuotaLimits(currentQuotas)
-	return nil
+	return grp.UpdateQuotaLimits(currentQuotas)
 }
 
 func quotaUpdate(st *state.State, action QuotaControlAction, allGrps map[string]*quota.Group) (*quota.Group, map[string]*quota.Group, error) {

--- a/overlord/servicestate/quota_handlers_test.go
+++ b/overlord/servicestate/quota_handlers_test.go
@@ -67,13 +67,13 @@ func (s *quotaHandlersSuite) SetUpTest(c *C) {
 // this type of mixed groups were supported when the feature was experimental.
 func mockMixedQuotaGroup(st *state.State, name string, snaps []string) error {
 	// create the quota group
-	grp, err := quota.NewGroup(name, quota.NewResources(quantity.SizeGiB))
+	grp, err := quota.NewGroup(name, quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
 	if err != nil {
 		return err
 	}
 
 	subGrpName := name + "-sub"
-	subGrp, err := grp.NewSubGroup(subGrpName, quota.NewResources(quantity.SizeGiB/2))
+	subGrp, err := grp.NewSubGroup(subGrpName, quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB/2).Build())
 	if err != nil {
 		return err
 	}
@@ -115,7 +115,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlCreate(c *C) {
 		{
 			Action:         "create",
 			QuotaName:      "foo-group",
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			AddSnaps:       []string{"test-snap"},
 		},
 	}
@@ -131,7 +131,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlCreate(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo-group": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -162,7 +162,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlCreateRestartOK(c *C) {
 		{
 			Action:         "create",
 			QuotaName:      "foo-group",
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			AddSnaps:       []string{"test-snap"},
 		},
 	}
@@ -171,7 +171,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlCreateRestartOK(c *C) {
 
 	expectedQuotaState := map[string]quotaGroupState{
 		"foo-group": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			Snaps:          []string{"test-snap"},
 		},
 	}
@@ -220,7 +220,7 @@ func (s *quotaHandlersSuite) TestQuotaStateAlreadyUpdatedBehavior(c *C) {
 		{
 			Action:         "create",
 			QuotaName:      "foo-group",
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			AddSnaps:       []string{"test-snap"},
 		},
 	}
@@ -293,7 +293,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlUpdate(c *C) {
 		{
 			Action:         "create",
 			QuotaName:      "foo-group",
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			AddSnaps:       []string{"test-snap"},
 		},
 	}
@@ -313,7 +313,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlUpdate(c *C) {
 		{
 			Action:         "update",
 			QuotaName:      "foo-group",
-			ResourceLimits: quota.NewResources(2 * quantity.SizeGiB),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB * 2).Build(),
 		},
 	}
 
@@ -328,7 +328,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlUpdate(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo-group": {
-			ResourceLimits: quota.NewResources(2 * quantity.SizeGiB),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB * 2).Build(),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -360,7 +360,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlUpdateRestartOK(c *C) {
 		{
 			Action:         "create",
 			QuotaName:      "foo-group",
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			AddSnaps:       []string{"test-snap"},
 		},
 	}
@@ -380,7 +380,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlUpdateRestartOK(c *C) {
 		{
 			Action:         "update",
 			QuotaName:      "foo-group",
-			ResourceLimits: quota.NewResources(2 * quantity.SizeGiB),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB * 2).Build(),
 		},
 	}
 
@@ -388,7 +388,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlUpdateRestartOK(c *C) {
 
 	expectedQuotaState := map[string]quotaGroupState{
 		"foo-group": {
-			ResourceLimits: quota.NewResources(2 * quantity.SizeGiB),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB * 2).Build(),
 			Snaps:          []string{"test-snap"},
 		},
 	}
@@ -442,7 +442,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlRemove(c *C) {
 		{
 			Action:         "create",
 			QuotaName:      "foo-group",
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			AddSnaps:       []string{"test-snap"},
 		},
 	}
@@ -508,7 +508,7 @@ func (s *quotaHandlersSuite) TestDoQuotaControlRemoveRestartOK(c *C) {
 		{
 			Action:         "create",
 			QuotaName:      "foo-group",
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			AddSnaps:       []string{"test-snap"},
 		},
 	}
@@ -584,7 +584,7 @@ func (s *quotaHandlersSuite) TestQuotaCreatePreseeding(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 		AddSnaps:       []string{"test-snap"},
 	}
 
@@ -594,7 +594,7 @@ func (s *quotaHandlersSuite) TestQuotaCreatePreseeding(c *C) {
 	// check that the quota groups were created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -621,7 +621,7 @@ func (s *quotaHandlersSuite) TestQuotaCreate(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 		AddSnaps:       []string{"test-snap"},
 	}
 
@@ -635,7 +635,7 @@ func (s *quotaHandlersSuite) TestQuotaCreate(c *C) {
 	qc2 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.NewResources(4 * quantity.SizeKiB),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(4 * quantity.SizeKiB).Build(),
 		AddSnaps:       []string{"test-snap"},
 	}
 
@@ -648,7 +648,7 @@ func (s *quotaHandlersSuite) TestQuotaCreate(c *C) {
 	qc3 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.NewResources(4*quantity.SizeKiB + 1),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(4*quantity.SizeKiB + 1).Build(),
 		AddSnaps:       []string{"test-snap"},
 	}
 	err = s.callDoQuotaControl(&qc3)
@@ -657,7 +657,7 @@ func (s *quotaHandlersSuite) TestQuotaCreate(c *C) {
 	// check that the quota groups were created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(4*quantity.SizeKiB + 1),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(4*quantity.SizeKiB + 1).Build(),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -690,7 +690,7 @@ func (s *quotaHandlersSuite) TestDoCreateSubGroupQuota(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo-group",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 	}
 
 	err := s.callDoQuotaControl(&qc)
@@ -700,7 +700,7 @@ func (s *quotaHandlersSuite) TestDoCreateSubGroupQuota(c *C) {
 	qc2 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo2",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 		ParentName:     "foo-non-real",
 		AddSnaps:       []string{"test-snap"},
 	}
@@ -713,7 +713,7 @@ func (s *quotaHandlersSuite) TestDoCreateSubGroupQuota(c *C) {
 	qc3 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo2",
-		ResourceLimits: quota.NewResources(2 * quantity.SizeGiB),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB * 2).Build(),
 		ParentName:     "foo-group",
 		AddSnaps:       []string{"test-snap"},
 	}
@@ -725,7 +725,7 @@ func (s *quotaHandlersSuite) TestDoCreateSubGroupQuota(c *C) {
 	qc4 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo2",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 		ParentName:     "foo-group",
 		AddSnaps:       []string{"test-snap"},
 	}
@@ -736,11 +736,11 @@ func (s *quotaHandlersSuite) TestDoCreateSubGroupQuota(c *C) {
 	// check that the quota groups were created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo-group": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			SubGroups:      []string{"foo2"},
 		},
 		"foo2": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			Snaps:          []string{"test-snap"},
 			ParentGroup:    "foo-group",
 		},
@@ -797,7 +797,7 @@ func (s *quotaHandlersSuite) TestQuotaRemove(c *C) {
 	qc2 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 	}
 
 	err = s.callDoQuotaControl(&qc2)
@@ -807,7 +807,7 @@ func (s *quotaHandlersSuite) TestQuotaRemove(c *C) {
 	qc3 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo2",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB / 2),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB / 2).Build(),
 		ParentName:     "foo",
 		AddSnaps:       []string{"test-snap"},
 	}
@@ -818,7 +818,7 @@ func (s *quotaHandlersSuite) TestQuotaRemove(c *C) {
 	qc4 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo3",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB / 2),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB / 2).Build(),
 		ParentName:     "foo",
 	}
 
@@ -828,16 +828,16 @@ func (s *quotaHandlersSuite) TestQuotaRemove(c *C) {
 	// check that the quota groups was created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			SubGroups:      []string{"foo2", "foo3"},
 		},
 		"foo2": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB / 2),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB / 2).Build(),
 			Snaps:          []string{"test-snap"},
 			ParentGroup:    "foo",
 		},
 		"foo3": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB / 2),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB / 2).Build(),
 			ParentGroup:    "foo",
 		},
 	})
@@ -863,11 +863,11 @@ func (s *quotaHandlersSuite) TestQuotaRemove(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			SubGroups:      []string{"foo2"},
 		},
 		"foo2": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB / 2),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB / 2).Build(),
 			Snaps:          []string{"test-snap"},
 			ParentGroup:    "foo",
 		},
@@ -884,7 +884,7 @@ func (s *quotaHandlersSuite) TestQuotaRemove(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 		},
 	})
 
@@ -919,7 +919,7 @@ func (s *quotaHandlersSuite) TestQuotaSnapModifyExistingMixable(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "update",
 		QuotaName:      "mixed-grp",
-		ResourceLimits: quota.NewResources(2 * quantity.SizeGiB),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB * 2).Build(),
 	}
 	err = s.callDoQuotaControl(&qc)
 	c.Assert(err, ErrorMatches, `quota group "mixed-grp" has mixed snaps and sub-groups, which is no longer supported; removal and re-creation is necessary to modify it`)
@@ -983,7 +983,7 @@ func (s *quotaHandlersSuite) TestQuotaSnapFailToMixSubgroupWithSnaps(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 		AddSnaps:       []string{"test-snap"},
 	}
 
@@ -994,7 +994,7 @@ func (s *quotaHandlersSuite) TestQuotaSnapFailToMixSubgroupWithSnaps(c *C) {
 	qc2 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo2",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB / 2),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB / 2).Build(),
 		ParentName:     "foo",
 	}
 
@@ -1004,7 +1004,7 @@ func (s *quotaHandlersSuite) TestQuotaSnapFailToMixSubgroupWithSnaps(c *C) {
 	// check that the quota groups was created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -1022,7 +1022,7 @@ func (s *quotaHandlersSuite) TestQuotaSnapFailToMixSnapsWithSubgroups(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 	}
 
 	err := s.callDoQuotaControl(&qc)
@@ -1032,7 +1032,7 @@ func (s *quotaHandlersSuite) TestQuotaSnapFailToMixSnapsWithSubgroups(c *C) {
 	qc2 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo2",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB / 2),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB / 2).Build(),
 		ParentName:     "foo",
 	}
 
@@ -1052,11 +1052,11 @@ func (s *quotaHandlersSuite) TestQuotaSnapFailToMixSnapsWithSubgroups(c *C) {
 	// check that the quota groups was created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			SubGroups:      []string{"foo2"},
 		},
 		"foo2": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB / 2),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB / 2).Build(),
 			ParentGroup:    "foo",
 		},
 	})
@@ -1119,7 +1119,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateSubGroupTooBig(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 	}
 
 	err := s.callDoQuotaControl(&qc)
@@ -1127,7 +1127,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateSubGroupTooBig(c *C) {
 
 	// ensure mem-limit is 1 GB
 	expFooGroupState := quotaGroupState{
-		ResourceLimits: quota.NewResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 	}
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": expFooGroupState,
@@ -1137,7 +1137,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateSubGroupTooBig(c *C) {
 	qc2 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo2",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB / 2),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB / 2).Build(),
 		AddSnaps:       []string{"test-snap", "test-snap2"},
 		ParentName:     "foo",
 	}
@@ -1148,7 +1148,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateSubGroupTooBig(c *C) {
 	expFooGroupState.SubGroups = []string{"foo2"}
 
 	expFoo2GroupState := quotaGroupState{
-		ResourceLimits: quota.NewResources(quantity.SizeGiB / 2),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB / 2).Build(),
 		Snaps:          []string{"test-snap", "test-snap2"},
 		ParentGroup:    "foo",
 	}
@@ -1163,13 +1163,13 @@ func (s *quotaHandlersSuite) TestQuotaUpdateSubGroupTooBig(c *C) {
 	qc3 := servicestate.QuotaControlAction{
 		Action:         "update",
 		QuotaName:      "foo2",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 	}
 
 	err = s.callDoQuotaControl(&qc3)
 	c.Assert(err, IsNil)
 
-	expFoo2GroupState.ResourceLimits = quota.NewResources(quantity.SizeGiB)
+	expFoo2GroupState.ResourceLimits = quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
 	// and check that it got updated in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo":  expFooGroupState,
@@ -1180,7 +1180,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateSubGroupTooBig(c *C) {
 	qc4 := servicestate.QuotaControlAction{
 		Action:         "update",
 		QuotaName:      "foo2",
-		ResourceLimits: quota.NewResources(2 * quantity.SizeGiB),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB * 2).Build(),
 	}
 
 	err = s.callDoQuotaControl(&qc4)
@@ -1216,7 +1216,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateChangeMemLimit(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 		AddSnaps:       []string{"test-snap"},
 	}
 
@@ -1226,7 +1226,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateChangeMemLimit(c *C) {
 	// ensure mem-limit is 1 GB
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -1235,7 +1235,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateChangeMemLimit(c *C) {
 	qc2 := servicestate.QuotaControlAction{
 		Action:         "update",
 		QuotaName:      "foo",
-		ResourceLimits: quota.NewResources(2 * quantity.SizeGiB),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB * 2).Build(),
 	}
 	err = s.callDoQuotaControl(&qc2)
 	c.Assert(err, IsNil)
@@ -1243,7 +1243,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateChangeMemLimit(c *C) {
 	// and check that it got updated in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(2 * quantity.SizeGiB),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB * 2).Build(),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -1252,7 +1252,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateChangeMemLimit(c *C) {
 	qc3 := servicestate.QuotaControlAction{
 		Action:         "update",
 		QuotaName:      "foo",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 	}
 	err = s.callDoQuotaControl(&qc3)
 	c.Assert(err, ErrorMatches, "cannot update limits for group \"foo\": cannot decrease memory limit, remove and re-create it to decrease the limit")
@@ -1292,7 +1292,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnap(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 		AddSnaps:       []string{"test-snap"},
 	}
 
@@ -1301,7 +1301,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnap(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -1318,7 +1318,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnap(c *C) {
 	// and check that it got updated in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			Snaps:          []string{"test-snap", "test-snap2"},
 		},
 	})
@@ -1358,7 +1358,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnapAlreadyInOtherGroup(c *C) {
 	qc := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 		AddSnaps:       []string{"test-snap"},
 	}
 
@@ -1367,7 +1367,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnapAlreadyInOtherGroup(c *C) {
 
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			Snaps:          []string{"test-snap"},
 		},
 	})
@@ -1376,7 +1376,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnapAlreadyInOtherGroup(c *C) {
 	qc2 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo2",
-		ResourceLimits: quota.NewResources(quantity.SizeGiB),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 		AddSnaps:       []string{"test-snap2"},
 	}
 
@@ -1386,11 +1386,11 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnapAlreadyInOtherGroup(c *C) {
 	// verify state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			Snaps:          []string{"test-snap"},
 		},
 		"foo2": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			Snaps:          []string{"test-snap2"},
 		},
 	})
@@ -1408,11 +1408,11 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnapAlreadyInOtherGroup(c *C) {
 	// nothing changed in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			Snaps:          []string{"test-snap"},
 		},
 		"foo2": {
-			ResourceLimits: quota.NewResources(quantity.SizeGiB),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			Snaps:          []string{"test-snap2"},
 		},
 	})

--- a/overlord/servicestate/quota_handlers_test.go
+++ b/overlord/servicestate/quota_handlers_test.go
@@ -719,7 +719,7 @@ func (s *quotaHandlersSuite) TestDoCreateSubGroupQuota(c *C) {
 	}
 
 	err = s.callDoQuotaControl(&qc3)
-	c.Assert(err, ErrorMatches, `sub-group memory limit of 2 GiB is too large to fit inside remaining quota space 1 GiB for parent group foo-group`)
+	c.Assert(err, ErrorMatches, `sub-group memory limit of 2 GiB is too large to fit inside group \"foo-group\" remaining quota space 1 GiB`)
 
 	// now we can create a sub-quota
 	qc4 := servicestate.QuotaControlAction{
@@ -1184,7 +1184,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateSubGroupTooBig(c *C) {
 	}
 
 	err = s.callDoQuotaControl(&qc4)
-	c.Assert(err, ErrorMatches, `cannot update quota "foo2": group "foo2" is invalid: sub-group memory limit of 2 GiB is too large to fit inside remaining quota space 1 GiB for parent group foo`)
+	c.Assert(err, ErrorMatches, `sub-group memory limit of 2 GiB is too large to fit inside group \"foo\" remaining quota space 1 GiB`)
 
 	// and make sure that the existing memory limit is still in place
 	checkQuotaState(c, st, map[string]quotaGroupState{

--- a/overlord/servicestate/servicestate_test.go
+++ b/overlord/servicestate/servicestate_test.go
@@ -313,7 +313,7 @@ func (s *snapServiceOptionsSuite) TestSnapServiceOptionsQuotaGroups(c *C) {
 	defer st.Unlock()
 
 	// make a quota group
-	grp, err := quota.NewGroup("foogroup", quota.NewResources(quantity.SizeGiB))
+	grp, err := quota.NewGroup("foogroup", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
 	c.Assert(err, IsNil)
 
 	grp.Snaps = []string{"foosnap"}

--- a/overlord/snapstate/backend/link_test.go
+++ b/overlord/snapstate/backend/link_test.go
@@ -789,7 +789,7 @@ apps:
 `
 	info := snaptest.MockSnap(c, yaml, &snap.SideInfo{Revision: snap.R(11)})
 
-	grp, err := quota.NewGroup("foogroup", quota.NewResources(quantity.SizeMiB))
+	grp, err := quota.NewGroup("foogroup", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build())
 	c.Assert(err, IsNil)
 
 	linkCtxWithGroup := backend.LinkContext{

--- a/snap/quota/export_test.go
+++ b/snap/quota/export_test.go
@@ -22,3 +22,9 @@ package quota
 func (grp *Group) SetInternalSubGroups(grps []*Group) {
 	grp.subGroups = grps
 }
+
+func (grp *Group) InspectInternalQuotaAllocations() map[string]*GroupQuotaAllocations {
+	allQuotas := make(map[string]*GroupQuotaAllocations)
+	grp.getgroupQuotaAllocations(allQuotas, nil)
+	return allQuotas
+}

--- a/snap/quota/export_test.go
+++ b/snap/quota/export_test.go
@@ -19,12 +19,14 @@
 
 package quota
 
+type GroupQuotaAllocations = groupQuotaAllocations
+
 func (grp *Group) SetInternalSubGroups(grps []*Group) {
 	grp.subGroups = grps
 }
 
 func (grp *Group) InspectInternalQuotaAllocations() map[string]*GroupQuotaAllocations {
 	allQuotas := make(map[string]*GroupQuotaAllocations)
-	grp.getgroupQuotaAllocations(allQuotas, nil)
+	grp.getQuotaAllocations(allQuotas, nil)
 	return allQuotas
 }

--- a/snap/quota/quota.go
+++ b/snap/quota/quota.go
@@ -296,6 +296,8 @@ func (grp *Group) getQuotaAllocations(allQuotas map[string]*groupQuotaAllocation
 			continue
 		}
 
+		// cyclic checks are made by visitTree so we make the assumption here
+		// that no cyclic dependencies exists.
 		subGroupLimits := subGroup.getQuotaAllocations(allQuotas, skipGrp)
 
 		// As we count up the usage of quotas across our sub-groups we must either use the actual

--- a/snap/quota/quota.go
+++ b/snap/quota/quota.go
@@ -36,7 +36,7 @@ import (
 type GroupQuotaCpu struct {
 	Count       int   `json:"count,omitempty"`
 	Percentage  int   `json:"percentage,omitempty"`
-	AllowedCpus []int `json:"allowed-cpus,omitempty"`
+	AllowedCPUs []int `json:"allowed-cpus,omitempty"`
 }
 
 // Group is a quota group of snaps, services or sub-groups that are all subject
@@ -112,7 +112,7 @@ func (grp *Group) UpdateQuotaLimits(resourceLimits Resources) {
 		grp.CpuLimit = &GroupQuotaCpu{
 			Count:       resourceLimits.CPU.Count,
 			Percentage:  resourceLimits.CPU.Percentage,
-			AllowedCpus: resourceLimits.CPU.AllowedCPUs,
+			AllowedCPUs: resourceLimits.CPU.AllowedCPUs,
 		}
 	}
 	if resourceLimits.Threads != nil {
@@ -132,8 +132,8 @@ func (grp *Group) GetQuotaResources() Resources {
 		if grp.CpuLimit.Percentage != 0 {
 			resourcesBuilder.WithCPUPercentage(grp.CpuLimit.Percentage)
 		}
-		if len(grp.CpuLimit.AllowedCpus) != 0 {
-			resourcesBuilder.WithAllowedCPUs(grp.CpuLimit.AllowedCpus)
+		if len(grp.CpuLimit.AllowedCPUs) != 0 {
+			resourcesBuilder.WithAllowedCPUs(grp.CpuLimit.AllowedCPUs)
 		}
 	}
 	if grp.TaskLimit != 0 {
@@ -298,10 +298,10 @@ func (grp *Group) validate() error {
 				return fmt.Errorf("group %q would exceed its parent group's CPU limit", grp.Name)
 			}
 
-			if len(grp.parentGroup.CpuLimit.AllowedCpus) > 0 {
+			if len(grp.parentGroup.CpuLimit.AllowedCPUs) > 0 {
 				// check if the group's allowed cpus are a subset of the parent group's allowed cpus
-				for _, cpu := range grp.CpuLimit.AllowedCpus {
-					if !arrayContains(grp.parentGroup.CpuLimit.AllowedCpus, cpu) {
+				for _, cpu := range grp.CpuLimit.AllowedCPUs {
+					if !arrayContains(grp.parentGroup.CpuLimit.AllowedCPUs, cpu) {
 						return fmt.Errorf("group %q has a CPU allowance that is not allowed by its parent group", grp.Name)
 					}
 				}
@@ -311,7 +311,7 @@ func (grp *Group) validate() error {
 		if grp.parentGroup.MemoryLimit != 0 {
 			// careful arithmetic here in case we somehow overflow the max size of
 			// quantity.Size
-			if grp.parentGroup.MemoryLimit-memoryUsed < grp.MemoryLimit {
+			if grp.MemoryLimit+memoryUsed > grp.parentGroup.MemoryLimit {
 				remaining := grp.parentGroup.MemoryLimit - memoryUsed
 				return fmt.Errorf("sub-group memory limit of %s is too large to fit inside remaining quota space %s for parent group %s", grp.MemoryLimit.IECString(), remaining.IECString(), grp.parentGroup.Name)
 			}

--- a/snap/quota/quota.go
+++ b/snap/quota/quota.go
@@ -409,8 +409,14 @@ func (grp *Group) validateQuotaLimits(resourceLimits Resources) error {
 }
 
 // UpdateQuotaLimits updates all the quota limits set for the group to the new limits
-// given. The limits must be validated prior to calling this function.
+// given. The limits will be validated against the group's parent group's limits, to verify
+// that they fit. For instance, if the parent group has a memory limit of 1GB, and the new limit
+// given here is 2GB, then the new limit will be rejected.
 func (grp *Group) UpdateQuotaLimits(resourceLimits Resources) error {
+	if err := resourceLimits.Validate(); err != nil {
+		return err
+	}
+
 	if err := grp.validateQuotaLimits(resourceLimits); err != nil {
 		return err
 	}

--- a/snap/quota/quota_test.go
+++ b/snap/quota/quota_test.go
@@ -772,11 +772,11 @@ func (ts *quotaTestSuite) TestGetGroupQuotaAllocations(c *C) {
 	// 	     <cpu-q0>      |       \                 (subgroup, 2x50% Cpu Quota)
 	// 		 /        <thread-q0>   \                (subgroup, 32 threads)
 	//      /	           |     <cpus-q0>           (subgroup, cpu-set quota with cpus 0,1)
-	// <mem-q1>        <mem-q2>       \              (2 subgroups, 256 Memory each)
+	// <mem-q1>        <mem-q2>       \              (2 subgroups, 256MB Memory each)
 	//    |                |       <cpus-q1>         (subgroup, cpu-set quota with cpus 0)
 	// <cpu-q1>        <thread-q1>                   (subgroups, cpu quota of 50%, thread quota of 16)
 	//                     |
-	//                 <mem-q3>
+	//                 <mem-q3>                      (subgroup, 128MB Memory)
 	grp1, err := quota.NewGroup("groot", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
 	c.Assert(err, IsNil)
 

--- a/snap/quota/quota_test.go
+++ b/snap/quota/quota_test.go
@@ -202,7 +202,7 @@ func (ts *quotaTestSuite) TestSimpleSubGroupVerification(c *C) {
 			rootlimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).WithCPUCount(1).WithCPUPercentage(100).WithAllowedCPUs([]int{0}).WithThreadLimit(32).Build(),
 			subname:    "sub",
 			sublimits:  quota.NewResourcesBuilder().WithAllowedCPUs([]int{1}).Build(),
-			err:        "sub-group request allowed cpu id of 1 which is not allowed by group \"myroot\"",
+			err:        "sub-group allowed cpu id of 1 is not allowed by group \"myroot\"",
 			comment:    "sub group with different cpu allowance quota than parent unhappy",
 		},
 		{

--- a/snap/quota/quota_test.go
+++ b/snap/quota/quota_test.go
@@ -282,8 +282,8 @@ func (ts *quotaTestSuite) TestComplexSubGroups(c *C) {
 	c.Assert(sub2.SliceFileName(), Equals, "snap.myroot-sub2.slice")
 
 	// adding another sub-group to this group fails
-	_, err = rootGrp.NewSubGroup("sub3", quota.NewResourcesBuilder().WithMemoryLimit(1).Build())
-	c.Assert(err, ErrorMatches, "memory limit 1 is too small: size must be larger than 4KB")
+	_, err = rootGrp.NewSubGroup("sub3", quota.NewResourcesBuilder().WithMemoryLimit(5*quantity.SizeKiB).Build())
+	c.Assert(err, ErrorMatches, "sub-group memory limit of 5 KiB is too large to fit inside group \"myroot\" remaining quota space 0 B")
 
 	// we can however add a sub-group to one of the sub-groups with the exact
 	// size of the parent sub-group

--- a/snap/quota/quota_test.go
+++ b/snap/quota/quota_test.go
@@ -805,19 +805,19 @@ func (ts *quotaTestSuite) TestCurrentTaskUsage(c *C) {
 	c.Assert(err, IsNil)
 
 	// group initially is inactive, so it has no current memory usage
-	currentMem, err := grp1.CurrentTaskUsage()
-	c.Assert(err, IsNil)
-	c.Assert(currentMem, Equals, 0)
+	currentTasks, err := grp1.CurrentTaskUsage()
+	c.Check(err, IsNil)
+	c.Check(currentTasks, Equals, 0)
 
 	// now with the slice mocked as active it has real usage
-	currentMem, err = grp1.CurrentTaskUsage()
-	c.Assert(err, IsNil)
-	c.Assert(currentMem, Equals, 32)
+	currentTasks, err = grp1.CurrentTaskUsage()
+	c.Check(err, IsNil)
+	c.Check(currentTasks, Equals, 32)
 
 	// but it can also have 0 usage
-	currentMem, err = grp1.CurrentTaskUsage()
-	c.Assert(err, IsNil)
-	c.Assert(currentMem, Equals, 0)
+	currentTasks, err = grp1.CurrentTaskUsage()
+	c.Check(err, IsNil)
+	c.Check(currentTasks, Equals, 0)
 }
 
 func (ts *quotaTestSuite) TestGetGroupQuotaAllocations(c *C) {
@@ -853,23 +853,23 @@ func (ts *quotaTestSuite) TestGetGroupQuotaAllocations(c *C) {
 	c.Assert(err, IsNil)
 
 	_, err = cpusq0.NewSubGroup("cpus-q1", quota.NewResourcesBuilder().WithAllowedCPUs([]int{0}).Build())
-	c.Assert(err, IsNil)
+	c.Check(err, IsNil)
 
 	_, err = memq1.NewSubGroup("cpu-q1", quota.NewResourcesBuilder().WithCPUCount(1).WithCPUPercentage(50).Build())
-	c.Assert(err, IsNil)
+	c.Check(err, IsNil)
 
 	thrq1, err := memq2.NewSubGroup("thread-q1", quota.NewResourcesBuilder().WithThreadLimit(16).Build())
 	c.Assert(err, IsNil)
 
 	_, err = thrq1.NewSubGroup("mem-q3", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB*128).Build())
-	c.Assert(err, IsNil)
+	c.Check(err, IsNil)
 
 	// Now we verify that the reservations made for the relevant groups are correct. The upper parent group will
 	// contained a combined overview of reserveations made.
 	allReservations := grp1.InspectInternalQuotaAllocations()
 
 	// Verify the root group
-	c.Assert(allReservations["groot"], DeepEquals, &quota.GroupQuotaAllocations{
+	c.Check(allReservations["groot"], DeepEquals, &quota.GroupQuotaAllocations{
 		MemoryLimit:      quantity.SizeGiB,
 		MemoryReserved:   quantity.SizeMiB * 512,
 		CpuReserved:      100,
@@ -878,7 +878,7 @@ func (ts *quotaTestSuite) TestGetGroupQuotaAllocations(c *C) {
 	})
 
 	// Verify the subgroup cpu-q0
-	c.Assert(allReservations["cpu-q0"], DeepEquals, &quota.GroupQuotaAllocations{
+	c.Check(allReservations["cpu-q0"], DeepEquals, &quota.GroupQuotaAllocations{
 		CpuLimit:         100,
 		CpuReserved:      50,
 		MemoryReserved:   quantity.SizeMiB * 256,
@@ -886,7 +886,7 @@ func (ts *quotaTestSuite) TestGetGroupQuotaAllocations(c *C) {
 	})
 
 	// Verify the subgroup thread-q0
-	c.Assert(allReservations["thread-q0"], DeepEquals, &quota.GroupQuotaAllocations{
+	c.Check(allReservations["thread-q0"], DeepEquals, &quota.GroupQuotaAllocations{
 		MemoryReserved:   quantity.SizeMiB * 256,
 		ThreadsLimit:     32,
 		ThreadsReserved:  16,
@@ -894,24 +894,24 @@ func (ts *quotaTestSuite) TestGetGroupQuotaAllocations(c *C) {
 	})
 
 	// Verify the subgroup cpus-q0
-	c.Assert(allReservations["cpus-q0"], DeepEquals, &quota.GroupQuotaAllocations{
+	c.Check(allReservations["cpus-q0"], DeepEquals, &quota.GroupQuotaAllocations{
 		AllowedCPUsLimit: []int{0, 1},
 	})
 
 	// Verify the subgroup cpus-q1
-	c.Assert(allReservations["cpus-q1"], DeepEquals, &quota.GroupQuotaAllocations{
+	c.Check(allReservations["cpus-q1"], DeepEquals, &quota.GroupQuotaAllocations{
 		AllowedCPUsLimit: []int{0},
 	})
 
 	// Verify the subgroup mem-q1
-	c.Assert(allReservations["mem-q1"], DeepEquals, &quota.GroupQuotaAllocations{
+	c.Check(allReservations["mem-q1"], DeepEquals, &quota.GroupQuotaAllocations{
 		MemoryLimit:      quantity.SizeMiB * 256,
 		CpuReserved:      50,
 		AllowedCPUsLimit: []int{},
 	})
 
 	// Verify the subgroup mem-q2
-	c.Assert(allReservations["mem-q2"], DeepEquals, &quota.GroupQuotaAllocations{
+	c.Check(allReservations["mem-q2"], DeepEquals, &quota.GroupQuotaAllocations{
 		MemoryLimit:      quantity.SizeMiB * 256,
 		MemoryReserved:   quantity.SizeMiB * 128,
 		ThreadsReserved:  16,
@@ -919,20 +919,20 @@ func (ts *quotaTestSuite) TestGetGroupQuotaAllocations(c *C) {
 	})
 
 	// Verify the subgroup cpu-q1
-	c.Assert(allReservations["cpu-q1"], DeepEquals, &quota.GroupQuotaAllocations{
+	c.Check(allReservations["cpu-q1"], DeepEquals, &quota.GroupQuotaAllocations{
 		CpuLimit:         50,
 		AllowedCPUsLimit: []int{},
 	})
 
 	// Verify the subgroup thread-q1
-	c.Assert(allReservations["thread-q1"], DeepEquals, &quota.GroupQuotaAllocations{
+	c.Check(allReservations["thread-q1"], DeepEquals, &quota.GroupQuotaAllocations{
 		MemoryReserved:   quantity.SizeMiB * 128,
 		ThreadsLimit:     16,
 		AllowedCPUsLimit: []int{},
 	})
 
 	// Verify the subgroup mem-q3
-	c.Assert(allReservations["mem-q3"], DeepEquals, &quota.GroupQuotaAllocations{
+	c.Check(allReservations["mem-q3"], DeepEquals, &quota.GroupQuotaAllocations{
 		MemoryLimit:      quantity.SizeMiB * 128,
 		AllowedCPUsLimit: []int{},
 	})
@@ -946,17 +946,17 @@ func (ts *quotaTestSuite) TestNestingOfLimitsWithExceedingParent(c *C) {
 	c.Assert(err, IsNil)
 
 	_, err = grp1.NewSubGroup("thread-sub", quota.NewResourcesBuilder().WithThreadLimit(32).Build())
-	c.Assert(err, IsNil)
+	c.Check(err, IsNil)
 
 	_, err = grp1.NewSubGroup("cpus-sub", quota.NewResourcesBuilder().WithAllowedCPUs([]int{0, 1}).Build())
-	c.Assert(err, IsNil)
+	c.Check(err, IsNil)
 
 	// Now we have the root with a memory limit, and three subgroups with
 	// each with one of the remaining limits. The point of this test is to make
 	// sure nested cases of limits that don't fit are caught and reported. So in a
 	// sub-sub group we create a limit higher than the upper parent
 	_, err = subgrp1.NewSubGroup("mem-sub", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB*2).Build())
-	c.Assert(err, ErrorMatches, `sub-group memory limit of 2 GiB is too large to fit inside group \"groot\" remaining quota space 1 GiB`)
+	c.Check(err, ErrorMatches, `sub-group memory limit of 2 GiB is too large to fit inside group \"groot\" remaining quota space 1 GiB`)
 }
 
 func (ts *quotaTestSuite) TestNestingOfLimitsWithExceedingSiblings(c *C) {
@@ -967,10 +967,10 @@ func (ts *quotaTestSuite) TestNestingOfLimitsWithExceedingSiblings(c *C) {
 	c.Assert(err, IsNil)
 
 	_, err = grp1.NewSubGroup("thread-sub", quota.NewResourcesBuilder().WithThreadLimit(32).Build())
-	c.Assert(err, IsNil)
+	c.Check(err, IsNil)
 
 	subgrp2, err := grp1.NewSubGroup("cpus-sub", quota.NewResourcesBuilder().WithAllowedCPUs([]int{0, 1}).Build())
-	c.Assert(err, IsNil)
+	c.Check(err, IsNil)
 
 	// The point here is to catch if we, in a nested, scenario, together with our siblings
 	// exceed one of the parent's limits.
@@ -978,11 +978,11 @@ func (ts *quotaTestSuite) TestNestingOfLimitsWithExceedingSiblings(c *C) {
 	c.Assert(err, IsNil)
 
 	_, err = subgrp3.NewSubGroup("mem-sub-sub", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
-	c.Assert(err, IsNil)
+	c.Check(err, IsNil)
 
 	// now we have consumed the entire memory quota set by the parent, so this should fail
 	_, err = subgrp2.NewSubGroup("mem-sub2", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
-	c.Assert(err, ErrorMatches, `sub-group memory limit of 1 GiB is too large to fit inside group \"groot\" remaining quota space 0 B`)
+	c.Check(err, ErrorMatches, `sub-group memory limit of 1 GiB is too large to fit inside group \"groot\" remaining quota space 0 B`)
 }
 
 func (ts *quotaTestSuite) TestChangingSubgroupLimits(c *C) {
@@ -999,11 +999,11 @@ func (ts *quotaTestSuite) TestChangingSubgroupLimits(c *C) {
 
 	// Now we change it to fill the entire quota of our upper parent
 	err = memgrp.UpdateQuotaLimits(quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
-	c.Assert(err, IsNil)
+	c.Check(err, IsNil)
 
 	// Now we try to change the limits of the subgroup to a value that is too large to fit inside the parent,
 	// the error message should also correctly report that the remaining space is 1GiB, as it should not consider
 	// the current memory quota of the subgroup.
 	err = memgrp.UpdateQuotaLimits(quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB * 2).Build())
-	c.Assert(err, ErrorMatches, `sub-group memory limit of 2 GiB is too large to fit inside group \"groot\" remaining quota space 1 GiB`)
+	c.Check(err, ErrorMatches, `sub-group memory limit of 2 GiB is too large to fit inside group \"groot\" remaining quota space 1 GiB`)
 }

--- a/snap/quota/quota_test.go
+++ b/snap/quota/quota_test.go
@@ -49,82 +49,82 @@ func (ts *quotaTestSuite) TestNewGroup(c *C) {
 	}{
 		{
 			name:    "group1",
-			limits:  quota.NewResources(quantity.SizeMiB),
+			limits:  quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).WithCPUCount(1).WithCPUPercentage(100).WithAllowedCPUs([]int{0}).WithThreadLimit(32).Build(),
 			comment: "basic happy",
 		},
 		{
 			name:    "biglimit",
-			limits:  quota.NewResources(quantity.Size(math.MaxUint64)),
+			limits:  quota.NewResourcesBuilder().WithMemoryLimit(quantity.Size(math.MaxUint64)).Build(),
 			comment: "huge limit happy",
 		},
 		{
 			name:    "zero",
-			limits:  quota.NewResources(0),
-			err:     `quota group must have a memory limit set`,
-			comment: "group with zero memory limit",
+			limits:  quota.NewResourcesBuilder().Build(),
+			err:     `quota group must have at least one resource limit set`,
+			comment: "group with no limits",
 		},
 		{
 			name:    "group1-unsupported chars",
-			limits:  quota.NewResources(quantity.SizeMiB),
+			limits:  quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build(),
 			err:     `invalid quota group name: contains invalid characters.*`,
 			comment: "unsupported characters in group name",
 		},
 		{
 			name:    "group%%%",
-			limits:  quota.NewResources(quantity.SizeMiB),
+			limits:  quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build(),
 			err:     `invalid quota group name: contains invalid characters.*`,
 			comment: "more invalid characters in name",
 		},
 		{
 			name:    "CAPITALIZED",
-			limits:  quota.NewResources(quantity.SizeMiB),
+			limits:  quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build(),
 			err:     `invalid quota group name: contains invalid characters.*`,
 			comment: "capitalized letters",
 		},
 		{
 			name:    "g1",
-			limits:  quota.NewResources(quantity.SizeMiB),
+			limits:  quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build(),
 			comment: "small group name",
 		},
 		{
 			name:          "name-with-dashes",
 			sliceFileName: `name\x2dwith\x2ddashes`,
-			limits:        quota.NewResources(quantity.SizeMiB),
+			limits:        quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build(),
 			comment:       "name with dashes",
 		},
 		{
 			name:    "",
-			limits:  quota.NewResources(quantity.SizeMiB),
+			limits:  quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build(),
 			err:     `invalid quota group name: must not be empty`,
 			comment: "empty group name",
 		},
 		{
 			name:    "g",
-			limits:  quota.NewResources(quantity.SizeMiB),
+			limits:  quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build(),
 			err:     `invalid quota group name: must be between 2 and 40 characters long.*`,
 			comment: "too small group name",
 		},
 		{
 			name:    "root",
-			limits:  quota.NewResources(quantity.SizeMiB),
+			limits:  quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build(),
 			err:     `group name "root" reserved`,
 			comment: "reserved root name",
 		},
 		{
 			name:    "snapd",
-			limits:  quota.NewResources(quantity.SizeMiB),
+			limits:  quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build(),
 			err:     `group name "snapd" reserved`,
 			comment: "reserved snapd name",
 		},
 		{
 			name:    "system",
-			limits:  quota.NewResources(quantity.SizeMiB),
+			limits:  quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build(),
 			err:     `group name "system" reserved`,
 			comment: "reserved system name",
 		},
 		{
 			name:    "user",
-			limits:  quota.NewResources(quantity.SizeMiB),
+			limits:  quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build(),
 			err:     `group name "user" reserved`,
 			comment: "reserved user name",
 		},
@@ -158,66 +158,87 @@ func (ts *quotaTestSuite) TestSimpleSubGroupVerification(c *C) {
 		comment       string
 	}{
 		{
-			rootlimits: quota.NewResources(quantity.SizeMiB),
+			rootlimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).WithCPUCount(1).WithCPUPercentage(100).WithAllowedCPUs([]int{0}).WithThreadLimit(32).Build(),
 			subname:    "sub",
-			sublimits:  quota.NewResources(quantity.SizeMiB),
+			sublimits:  quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).WithCPUCount(1).WithCPUPercentage(100).WithAllowedCPUs([]int{0}).WithThreadLimit(32).Build(),
 			comment:    "basic sub group with same quota as parent happy",
 		},
 		{
-			rootlimits: quota.NewResources(quantity.SizeMiB),
+			rootlimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).WithCPUCount(1).WithCPUPercentage(100).WithAllowedCPUs([]int{0}).WithThreadLimit(32).Build(),
 			subname:    "sub",
-			sublimits:  quota.NewResources(quantity.SizeMiB / 2),
+			sublimits:  quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB / 2).WithCPUCount(1).WithCPUPercentage(50).WithAllowedCPUs([]int{0}).WithThreadLimit(16).Build(),
 			comment:    "basic sub group with smaller quota than parent happy",
 		},
 		{
-			rootlimits:    quota.NewResources(quantity.SizeMiB),
+			rootlimits:    quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).WithCPUCount(1).WithCPUPercentage(100).WithAllowedCPUs([]int{0}).WithThreadLimit(32).Build(),
 			subname:       "sub-with-dashes",
 			sliceFileName: `myroot-sub\x2dwith\x2ddashes`,
-			sublimits:     quota.NewResources(quantity.SizeMiB / 2),
+			sublimits:     quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB / 2).WithCPUCount(1).WithCPUPercentage(50).WithAllowedCPUs([]int{0}).WithThreadLimit(16).Build(),
 			comment:       "basic sub group with dashes in the name",
 		},
 		{
 			rootname:      "my-root",
-			rootlimits:    quota.NewResources(quantity.SizeMiB),
+			rootlimits:    quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).WithCPUCount(1).WithCPUPercentage(100).WithAllowedCPUs([]int{0}).WithThreadLimit(32).Build(),
 			subname:       "sub-with-dashes",
 			sliceFileName: `my\x2droot-sub\x2dwith\x2ddashes`,
-			sublimits:     quota.NewResources(quantity.SizeMiB / 2),
+			sublimits:     quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB / 2).WithCPUCount(1).WithCPUPercentage(50).WithAllowedCPUs([]int{0}).WithThreadLimit(16).Build(),
 			comment:       "parent and sub group have dashes in name",
 		},
 		{
-			rootlimits: quota.NewResources(quantity.SizeMiB),
+			rootlimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).WithCPUCount(1).WithCPUPercentage(100).WithAllowedCPUs([]int{0}).WithThreadLimit(32).Build(),
 			subname:    "sub",
-			sublimits:  quota.NewResources(quantity.SizeMiB * 2),
+			sublimits:  quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB * 2).Build(),
 			err:        "sub-group memory limit of 2 MiB is too large to fit inside remaining quota space 1 MiB for parent group myroot",
-			comment:    "sub group with larger quota than parent unhappy",
+			comment:    "sub group with larger memory quota than parent unhappy",
 		},
 		{
-			rootlimits: quota.NewResources(quantity.SizeMiB),
+			rootlimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).WithCPUCount(1).WithCPUPercentage(100).WithAllowedCPUs([]int{0}).WithThreadLimit(32).Build(),
+			subname:    "sub",
+			sublimits:  quota.NewResourcesBuilder().WithCPUCount(2).WithCPUPercentage(100).Build(),
+			err:        "group \"sub\" would exceed its parent group's CPU limit",
+			comment:    "sub group with larger cpu count quota than parent unhappy",
+		},
+		{
+			rootlimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).WithCPUCount(1).WithCPUPercentage(100).WithAllowedCPUs([]int{0}).WithThreadLimit(32).Build(),
+			subname:    "sub",
+			sublimits:  quota.NewResourcesBuilder().WithAllowedCPUs([]int{1}).Build(),
+			err:        "group \"sub\" has a CPU allowance that is not allowed by its parent group",
+			comment:    "sub group with different cpu allowance quota than parent unhappy",
+		},
+		{
+			rootlimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).WithCPUCount(1).WithCPUPercentage(100).WithAllowedCPUs([]int{0}).WithThreadLimit(32).Build(),
+			subname:    "sub",
+			sublimits:  quota.NewResourcesBuilder().WithThreadLimit(64).Build(),
+			err:        "sub-group task limit of 64 is too large to fit inside remaining tasks 32 for parent group myroot",
+			comment:    "sub group with larger task allowance quota than parent unhappy",
+		},
+		{
+			rootlimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).WithCPUCount(1).WithCPUPercentage(100).WithAllowedCPUs([]int{0}).WithThreadLimit(32).Build(),
 			subname:    "sub invalid chars",
-			sublimits:  quota.NewResources(quantity.SizeMiB),
+			sublimits:  quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).WithCPUCount(1).WithCPUPercentage(100).WithAllowedCPUs([]int{0}).WithThreadLimit(32).Build(),
 			err:        `invalid quota group name: contains invalid characters.*`,
 			comment:    "sub group with invalid name",
 		},
 		{
-			rootlimits: quota.NewResources(quantity.SizeMiB),
+			rootlimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).WithCPUCount(1).WithCPUPercentage(100).WithAllowedCPUs([]int{0}).WithThreadLimit(32).Build(),
 			subname:    "myroot",
-			sublimits:  quota.NewResources(quantity.SizeMiB),
+			sublimits:  quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).WithCPUCount(1).WithCPUPercentage(100).WithAllowedCPUs([]int{0}).WithThreadLimit(32).Build(),
 			err:        `cannot use same name "myroot" for sub group as parent group`,
 			comment:    "sub group with same name as parent group",
 		},
 		{
-			rootlimits: quota.NewResources(quantity.SizeMiB),
+			rootlimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).WithCPUCount(1).WithCPUPercentage(100).WithAllowedCPUs([]int{0}).WithThreadLimit(32).Build(),
 			subname:    "snapd",
-			sublimits:  quota.NewResources(quantity.SizeMiB),
+			sublimits:  quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).WithCPUCount(1).WithCPUPercentage(100).WithAllowedCPUs([]int{0}).WithThreadLimit(32).Build(),
 			err:        `group name "snapd" reserved`,
 			comment:    "sub group with reserved name",
 		},
 		{
-			rootlimits: quota.NewResources(quantity.SizeMiB),
+			rootlimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).WithCPUCount(1).WithCPUPercentage(100).WithAllowedCPUs([]int{0}).WithThreadLimit(32).Build(),
 			subname:    "zero",
-			sublimits:  quota.NewResources(0),
-			err:        `quota group must have a memory limit set`,
-			comment:    "sub group with zero memory limit",
+			sublimits:  quota.NewResourcesBuilder().Build(),
+			err:        `quota group must have at least one resource limit set`,
+			comment:    "sub group with no limits",
 		},
 	}
 
@@ -248,43 +269,43 @@ func (ts *quotaTestSuite) TestSimpleSubGroupVerification(c *C) {
 }
 
 func (ts *quotaTestSuite) TestComplexSubGroups(c *C) {
-	rootGrp, err := quota.NewGroup("myroot", quota.NewResources(quantity.SizeMiB))
+	rootGrp, err := quota.NewGroup("myroot", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build())
 	c.Assert(err, IsNil)
 
 	// try adding 2 sub-groups with total quota split exactly equally
-	sub1, err := rootGrp.NewSubGroup("sub1", quota.NewResources(quantity.SizeMiB/2))
+	sub1, err := rootGrp.NewSubGroup("sub1", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB/2).Build())
 	c.Assert(err, IsNil)
 	c.Assert(sub1.SliceFileName(), Equals, "snap.myroot-sub1.slice")
 
-	sub2, err := rootGrp.NewSubGroup("sub2", quota.NewResources(quantity.SizeMiB/2))
+	sub2, err := rootGrp.NewSubGroup("sub2", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB/2).Build())
 	c.Assert(err, IsNil)
 	c.Assert(sub2.SliceFileName(), Equals, "snap.myroot-sub2.slice")
 
 	// adding another sub-group to this group fails
-	_, err = rootGrp.NewSubGroup("sub3", quota.NewResources(5*quantity.SizeKiB))
-	c.Assert(err, ErrorMatches, "sub-group memory limit of 5 KiB is too large to fit inside remaining quota space 0 B for parent group myroot")
+	_, err = rootGrp.NewSubGroup("sub3", quota.NewResourcesBuilder().WithMemoryLimit(1).Build())
+	c.Assert(err, ErrorMatches, "memory limit 1 is too small: size must be larger than 4KB")
 
 	// we can however add a sub-group to one of the sub-groups with the exact
 	// size of the parent sub-group
-	subsub1, err := sub1.NewSubGroup("subsub1", quota.NewResources(quantity.SizeMiB/2))
+	subsub1, err := sub1.NewSubGroup("subsub1", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB/2).Build())
 	c.Assert(err, IsNil)
 	c.Assert(subsub1.SliceFileName(), Equals, "snap.myroot-sub1-subsub1.slice")
 
 	// and we can even add a smaller sub-sub-sub-group to the sub-group
-	subsubsub1, err := subsub1.NewSubGroup("subsubsub1", quota.NewResources(quantity.SizeMiB/4))
+	subsubsub1, err := subsub1.NewSubGroup("subsubsub1", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB/4).Build())
 	c.Assert(err, IsNil)
 	c.Assert(subsubsub1.SliceFileName(), Equals, "snap.myroot-sub1-subsub1-subsubsub1.slice")
 }
 
 func (ts *quotaTestSuite) TestGroupUnmixableSnapsSubgroups(c *C) {
-	parent, err := quota.NewGroup("parent", quota.NewResources(quantity.SizeMiB))
+	parent, err := quota.NewGroup("parent", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build())
 	c.Assert(err, IsNil)
 
 	// now we add a snap to the parent group
 	parent.Snaps = []string{"test-snap"}
 
 	// add a subgroup to the parent group, this should fail as the group now has snaps
-	_, err = parent.NewSubGroup("sub", quota.NewResources(quantity.SizeMiB/2))
+	_, err = parent.NewSubGroup("sub", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB/2).Build())
 	c.Assert(err, ErrorMatches, "cannot mix sub groups with snaps in the same group")
 }
 
@@ -332,7 +353,7 @@ func (ts *quotaTestSuite) TestResolveCrossReferences(c *C) {
 					MemoryLimit: 0,
 				},
 			},
-			err:     `group "foogroup" is invalid: quota group must have a memory limit set`,
+			err:     `group "foogroup" is invalid: quota group must have at least one resource limit set`,
 			comment: "invalid group",
 		},
 		{
@@ -502,10 +523,10 @@ func (ts *quotaTestSuite) TestResolveCrossReferences(c *C) {
 }
 
 func (ts *quotaTestSuite) TestAddAllNecessaryGroupsAvoidsInfiniteRecursion(c *C) {
-	grp, err := quota.NewGroup("infinite-group", quota.NewResources(quantity.SizeGiB))
+	grp, err := quota.NewGroup("infinite-group", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
 	c.Assert(err, IsNil)
 
-	grp2, err := grp.NewSubGroup("infinite-group2", quota.NewResources(quantity.SizeGiB))
+	grp2, err := grp.NewSubGroup("infinite-group2", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
 	c.Assert(err, IsNil)
 
 	// create a cycle artificially to the same group
@@ -525,7 +546,7 @@ func (ts *quotaTestSuite) TestAddAllNecessaryGroupsAvoidsInfiniteRecursion(c *C)
 	// make a real sub-group and try one more level of indirection going back
 	// to the parent
 	grp2.SetInternalSubGroups(nil)
-	grp3, err := grp2.NewSubGroup("infinite-group3", quota.NewResources(quantity.SizeGiB))
+	grp3, err := grp2.NewSubGroup("infinite-group3", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
 	c.Assert(err, IsNil)
 	grp3.SetInternalSubGroups([]*quota.Group{grp})
 
@@ -539,7 +560,7 @@ func (ts *quotaTestSuite) TestAddAllNecessaryGroups(c *C) {
 	// it should initially be empty
 	c.Assert(qs.AllQuotaGroups(), HasLen, 0)
 
-	grp1, err := quota.NewGroup("myroot", quota.NewResources(quantity.SizeGiB))
+	grp1, err := quota.NewGroup("myroot", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
 	c.Assert(err, IsNil)
 
 	// add the group and make sure it is in the set
@@ -555,7 +576,7 @@ func (ts *quotaTestSuite) TestAddAllNecessaryGroups(c *C) {
 	c.Assert(qs.AllQuotaGroups(), DeepEquals, []*quota.Group{grp1})
 
 	// add a new group and make sure it is in the set now
-	grp2, err := quota.NewGroup("myroot2", quota.NewResources(quantity.SizeGiB))
+	grp2, err := quota.NewGroup("myroot2", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
 	c.Assert(err, IsNil)
 	err = qs.AddAllNecessaryGroups(grp2)
 	c.Assert(err, IsNil)
@@ -566,7 +587,7 @@ func (ts *quotaTestSuite) TestAddAllNecessaryGroups(c *C) {
 
 	// make a sub-group and add the root group - it will automatically add
 	// the sub-group without us needing to explicitly add the sub-group
-	subgrp1, err := grp1.NewSubGroup("mysub1", quota.NewResources(quantity.SizeGiB))
+	subgrp1, err := grp1.NewSubGroup("mysub1", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
 	c.Assert(err, IsNil)
 	// add grp2 as well
 	err = qs.AddAllNecessaryGroups(grp2)
@@ -583,13 +604,13 @@ func (ts *quotaTestSuite) TestAddAllNecessaryGroups(c *C) {
 
 	// create a new set of group and sub-groups to add the deepest child group
 	// and add that, and notice that the root groups are also added
-	grp3, err := quota.NewGroup("myroot3", quota.NewResources(quantity.SizeGiB))
+	grp3, err := quota.NewGroup("myroot3", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
 	c.Assert(err, IsNil)
 
-	subgrp3, err := grp3.NewSubGroup("mysub3", quota.NewResources(quantity.SizeGiB))
+	subgrp3, err := grp3.NewSubGroup("mysub3", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
 	c.Assert(err, IsNil)
 
-	subsubgrp3, err := subgrp3.NewSubGroup("mysubsub3", quota.NewResources(quantity.SizeGiB))
+	subsubgrp3, err := subgrp3.NewSubGroup("mysubsub3", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
 	c.Assert(err, IsNil)
 
 	err = qs.AddAllNecessaryGroups(subsubgrp3)
@@ -599,13 +620,13 @@ func (ts *quotaTestSuite) TestAddAllNecessaryGroups(c *C) {
 	// finally create a tree with multiple branches and ensure that adding just
 	// a single deepest child will add all the other deepest children from other
 	// branches
-	grp4, err := quota.NewGroup("myroot4", quota.NewResources(quantity.SizeGiB))
+	grp4, err := quota.NewGroup("myroot4", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
 	c.Assert(err, IsNil)
 
-	subgrp4, err := grp4.NewSubGroup("mysub4", quota.NewResources(quantity.SizeGiB/2))
+	subgrp4, err := grp4.NewSubGroup("mysub4", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB/2).Build())
 	c.Assert(err, IsNil)
 
-	subgrp5, err := grp4.NewSubGroup("mysub5", quota.NewResources(quantity.SizeGiB/2))
+	subgrp5, err := grp4.NewSubGroup("mysub5", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB/2).Build())
 	c.Assert(err, IsNil)
 
 	// adding just subgrp5 to a quota set will automatically add the other sub
@@ -617,13 +638,13 @@ func (ts *quotaTestSuite) TestAddAllNecessaryGroups(c *C) {
 }
 
 func (ts *quotaTestSuite) TestResolveCrossReferencesLimitCheckSkipsSelf(c *C) {
-	grp1, err := quota.NewGroup("myroot", quota.NewResources(quantity.SizeGiB))
+	grp1, err := quota.NewGroup("myroot", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
 	c.Assert(err, IsNil)
 
-	subgrp1, err := grp1.NewSubGroup("mysub1", quota.NewResources(quantity.SizeGiB))
+	subgrp1, err := grp1.NewSubGroup("mysub1", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
 	c.Assert(err, IsNil)
 
-	subgrp2, err := subgrp1.NewSubGroup("mysub2", quota.NewResources(quantity.SizeGiB))
+	subgrp2, err := subgrp1.NewSubGroup("mysub2", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
 	c.Assert(err, IsNil)
 
 	all := map[string]*quota.Group{
@@ -636,13 +657,13 @@ func (ts *quotaTestSuite) TestResolveCrossReferencesLimitCheckSkipsSelf(c *C) {
 }
 
 func (ts *quotaTestSuite) TestResolveCrossReferencesCircular(c *C) {
-	grp1, err := quota.NewGroup("myroot", quota.NewResources(quantity.SizeGiB))
+	grp1, err := quota.NewGroup("myroot", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
 	c.Assert(err, IsNil)
 
-	subgrp1, err := grp1.NewSubGroup("mysub1", quota.NewResources(quantity.SizeGiB))
+	subgrp1, err := grp1.NewSubGroup("mysub1", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
 	c.Assert(err, IsNil)
 
-	subgrp2, err := subgrp1.NewSubGroup("mysub2", quota.NewResources(quantity.SizeGiB))
+	subgrp2, err := subgrp1.NewSubGroup("mysub2", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
 	c.Assert(err, IsNil)
 
 	all := map[string]*quota.Group{
@@ -717,7 +738,7 @@ func (ts *quotaTestSuite) TestCurrentMemoryUsage(c *C) {
 	})
 	defer r()
 
-	grp1, err := quota.NewGroup("group", quota.NewResources(quantity.SizeGiB))
+	grp1, err := quota.NewGroup("group", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
 	c.Assert(err, IsNil)
 
 	// group initially is inactive, so it has no current memory usage

--- a/snap/quota/resources.go
+++ b/snap/quota/resources.go
@@ -70,7 +70,7 @@ func (qr *Resources) validateCpuQuota() error {
 		return fmt.Errorf("cannot validate quota limits with count of >0 and percentage of 0")
 	}
 
-	// atleast one cpu limit value must be set
+	// at least one cpu limit value must be set
 	if qr.CPU.Count == 0 && qr.CPU.Percentage == 0 && len(qr.CPU.AllowedCPUs) == 0 {
 		return fmt.Errorf("cannot validate quota limits with a cpu quota of 0 and no allowed cpus")
 	}
@@ -78,15 +78,15 @@ func (qr *Resources) validateCpuQuota() error {
 }
 
 func (qr *Resources) validateThreadQuota() error {
-	// make sure the thread count is not zero
-	if qr.Threads.Limit == 0 {
-		return fmt.Errorf("cannot create quota group with a thread count of 0")
+	// make sure the thread count is greater than 0
+	if qr.Threads.Limit <= 0 {
+		return fmt.Errorf("cannot create quota group with a thread count of %d", qr.Threads.Limit)
 	}
 	return nil
 }
 
 // Validate performs validation of the provided quota resources for a group.
-// The restrictions imposed are that atleast one limit should be set.
+// The restrictions imposed are that at least one limit should be set.
 // If memory limit is provided, it must be above 4KB.
 // If cpu percentage is provided, it must be between 1 and 100.
 // If thread count is provided, it must be above 0.

--- a/snap/quota/resources.go
+++ b/snap/quota/resources.go
@@ -72,7 +72,7 @@ func (qr *Resources) validateCpuQuota() error {
 
 	// atleast one cpu limit value must be set
 	if qr.CPU.Count == 0 && qr.CPU.Percentage == 0 && len(qr.CPU.AllowedCPUs) == 0 {
-		return fmt.Errorf("cannot validate quota limits with a cpu quota of 0 and allowed cpus of 0")
+		return fmt.Errorf("cannot validate quota limits with a cpu quota of 0 and no allowed cpus")
 	}
 	return nil
 }

--- a/snap/quota/resources.go
+++ b/snap/quota/resources.go
@@ -67,12 +67,12 @@ func (qr *Resources) validateMemoryQuota() error {
 func (qr *Resources) validateCpuQuota() error {
 	// if cpu count is non-zero, then percentage should be set
 	if qr.CPU.Count != 0 && qr.CPU.Percentage == 0 {
-		return fmt.Errorf("cannot validate quota limits with count of >0 and percentage of 0")
+		return fmt.Errorf("invalid cpu quota with count of >0 and percentage of 0")
 	}
 
 	// at least one cpu limit value must be set
 	if qr.CPU.Count == 0 && qr.CPU.Percentage == 0 && len(qr.CPU.AllowedCPUs) == 0 {
-		return fmt.Errorf("cannot validate quota limits with a cpu quota of 0 and no allowed cpus")
+		return fmt.Errorf("invalid cpu quota with a cpu quota of 0 and no allowed cpus")
 	}
 	return nil
 }
@@ -80,7 +80,7 @@ func (qr *Resources) validateCpuQuota() error {
 func (qr *Resources) validateThreadQuota() error {
 	// make sure the thread count is greater than 0
 	if qr.Threads.Limit <= 0 {
-		return fmt.Errorf("cannot create quota group with a thread count of %d", qr.Threads.Limit)
+		return fmt.Errorf("invalid thread quota with a thread count of %d", qr.Threads.Limit)
 	}
 	return nil
 }

--- a/snap/quota/resources_builder.go
+++ b/snap/quota/resources_builder.go
@@ -93,16 +93,5 @@ func (rb *ResourcesBuilder) Build() Resources {
 }
 
 func NewResourcesBuilder() *ResourcesBuilder {
-	return &ResourcesBuilder{
-		MemoryLimit:      0,
-		MemoryLimitSet:   false,
-		CPUCount:         0,
-		CPUCountSet:      false,
-		CPUPercentage:    0,
-		CPUPercentageSet: false,
-		AllowedCPUs:      nil,
-		AllowedCPUsSet:   false,
-		ThreadLimit:      0,
-		ThreadLimitSet:   false,
-	}
+	return &ResourcesBuilder{}
 }

--- a/snap/quota/resources_builder.go
+++ b/snap/quota/resources_builder.go
@@ -1,0 +1,108 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+* Copyright (C) 2021 Canonical Ltd
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License version 3 as
+* published by the Free Software Foundation.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+ */
+
+package quota
+
+import (
+	"github.com/snapcore/snapd/gadget/quantity"
+)
+
+type ResourcesBuilder struct {
+	MemoryLimit    quantity.Size
+	MemoryLimitSet bool
+
+	CPUCount    int
+	CPUCountSet bool
+
+	CPUPercentage    int
+	CPUPercentageSet bool
+
+	AllowedCPUs    []int
+	AllowedCPUsSet bool
+
+	ThreadLimit    int
+	ThreadLimitSet bool
+}
+
+func (rb *ResourcesBuilder) WithMemoryLimit(limit quantity.Size) *ResourcesBuilder {
+	rb.MemoryLimit = limit
+	rb.MemoryLimitSet = true
+	return rb
+}
+
+func (rb *ResourcesBuilder) WithCPUCount(count int) *ResourcesBuilder {
+	rb.CPUCount = count
+	rb.CPUCountSet = true
+	return rb
+}
+
+func (rb *ResourcesBuilder) WithCPUPercentage(percentage int) *ResourcesBuilder {
+	rb.CPUPercentage = percentage
+	rb.CPUPercentageSet = true
+	return rb
+}
+
+func (rb *ResourcesBuilder) WithAllowedCPUs(allowedCPUs []int) *ResourcesBuilder {
+	rb.AllowedCPUs = allowedCPUs
+	rb.AllowedCPUsSet = true
+	return rb
+}
+
+func (rb *ResourcesBuilder) WithThreadLimit(limit int) *ResourcesBuilder {
+	rb.ThreadLimit = limit
+	rb.ThreadLimitSet = true
+	return rb
+}
+
+func (rb *ResourcesBuilder) Build() Resources {
+	var quotaResources Resources
+	if rb.MemoryLimitSet {
+		quotaResources.Memory = &ResourceMemory{
+			Limit: rb.MemoryLimit,
+		}
+	}
+	if rb.CPUCountSet || rb.CPUPercentageSet || rb.AllowedCPUsSet {
+		quotaResources.CPU = &ResourceCPU{
+			Count:       rb.CPUCount,
+			Percentage:  rb.CPUPercentage,
+			AllowedCPUs: rb.AllowedCPUs,
+		}
+	}
+	if rb.ThreadLimitSet {
+		quotaResources.Threads = &ResourceThreads{
+			Limit: rb.ThreadLimit,
+		}
+	}
+	return quotaResources
+}
+
+func NewResourcesBuilder() *ResourcesBuilder {
+	return &ResourcesBuilder{
+		MemoryLimit:      0,
+		MemoryLimitSet:   false,
+		CPUCount:         0,
+		CPUCountSet:      false,
+		CPUPercentage:    0,
+		CPUPercentageSet: false,
+		AllowedCPUs:      nil,
+		AllowedCPUsSet:   false,
+		ThreadLimit:      0,
+		ThreadLimitSet:   false,
+	}
+}

--- a/snap/quota/resources_builder.go
+++ b/snap/quota/resources_builder.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
-* Copyright (C) 2021 Canonical Ltd
+* Copyright (C) 2022 Canonical Ltd
 *
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License version 3 as

--- a/snap/quota/resources_test.go
+++ b/snap/quota/resources_test.go
@@ -37,7 +37,7 @@ func (s *resourcesTestSuite) TestQuotaValidationFails(c *C) {
 	}{
 		{quota.Resources{}, `quota group must have at least one resource limit set`},
 		{quota.Resources{Memory: &quota.ResourceMemory{}}, `memory quota must have a limit set`},
-		{quota.Resources{CPU: &quota.ResourceCPU{}}, `cannot validate quota limits with a cpu quota of 0 and allowed cpus of 0`},
+		{quota.Resources{CPU: &quota.ResourceCPU{}}, `cannot validate quota limits with a cpu quota of 0 and no allowed cpus`},
 		{quota.Resources{Threads: &quota.ResourceThreads{}}, `cannot create quota group with a thread count of 0`},
 		{quota.NewResourcesBuilder().Build(), `quota group must have at least one resource limit set`},
 		{quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeKiB).Build(), `memory limit 1024 is too small: size must be larger than 4KB`},

--- a/snap/quota/resources_test.go
+++ b/snap/quota/resources_test.go
@@ -37,11 +37,11 @@ func (s *resourcesTestSuite) TestQuotaValidationFails(c *C) {
 	}{
 		{quota.Resources{}, `quota group must have at least one resource limit set`},
 		{quota.Resources{Memory: &quota.ResourceMemory{}}, `memory quota must have a limit set`},
-		{quota.Resources{CPU: &quota.ResourceCPU{}}, `cannot validate quota limits with a cpu quota of 0 and no allowed cpus`},
-		{quota.Resources{Threads: &quota.ResourceThreads{}}, `cannot create quota group with a thread count of 0`},
+		{quota.Resources{CPU: &quota.ResourceCPU{}}, `invalid cpu quota with a cpu quota of 0 and no allowed cpus`},
+		{quota.Resources{Threads: &quota.ResourceThreads{}}, `invalid thread quota with a thread count of 0`},
 		{quota.NewResourcesBuilder().Build(), `quota group must have at least one resource limit set`},
 		{quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeKiB).Build(), `memory limit 1024 is too small: size must be larger than 4KB`},
-		{quota.NewResourcesBuilder().WithCPUCount(1).Build(), `cannot validate quota limits with count of >0 and percentage of 0`},
+		{quota.NewResourcesBuilder().WithCPUCount(1).Build(), `invalid cpu quota with count of >0 and percentage of 0`},
 	}
 
 	for _, t := range tests {

--- a/snap/quota/resources_test.go
+++ b/snap/quota/resources_test.go
@@ -35,8 +35,13 @@ func (s *resourcesTestSuite) TestQuotaValidationFails(c *C) {
 		limits quota.Resources
 		err    string
 	}{
-		{quota.Resources{}, `quota group must have a memory limit set`},
-		{quota.NewResources(quantity.Size(0)), `quota group must have a memory limit set`},
+		{quota.Resources{}, `quota group must have at least one resource limit set`},
+		{quota.Resources{Memory: &quota.ResourceMemory{}}, `memory quota must have a limit set`},
+		{quota.Resources{CPU: &quota.ResourceCPU{}}, `cannot validate quota limits with a cpu quota of 0 and allowed cpus of 0`},
+		{quota.Resources{Threads: &quota.ResourceThreads{}}, `cannot create quota group with a thread count of 0`},
+		{quota.NewResourcesBuilder().Build(), `quota group must have at least one resource limit set`},
+		{quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeKiB).Build(), `memory limit 1024 is too small: size must be larger than 4KB`},
+		{quota.NewResourcesBuilder().WithCPUCount(1).Build(), `cannot validate quota limits with count of >0 and percentage of 0`},
 	}
 
 	for _, t := range tests {
@@ -49,8 +54,10 @@ func (s *resourcesTestSuite) TestQuotaValidationPasses(c *C) {
 	tests := []struct {
 		limits quota.Resources
 	}{
-		{quota.NewResources(quantity.SizeMiB)},
-		// expect more tests as the number of quotas grow
+		{quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build()},
+		{quota.NewResourcesBuilder().WithCPUCount(1).WithCPUPercentage(50).Build()},
+		{quota.NewResourcesBuilder().WithAllowedCPUs([]int{0, 1}).Build()},
+		{quota.NewResourcesBuilder().WithThreadLimit(16).Build()},
 	}
 
 	for _, t := range tests {
@@ -65,8 +72,16 @@ func (s *resourcesTestSuite) TestQuotaChangeValidationFails(c *C) {
 		updateLimits quota.Resources
 		err          string
 	}{
-		{quota.NewResources(quantity.SizeMiB), quota.Resources{&quota.ResourceMemory{0}}, `cannot remove memory limit from quota group`},
-		{quota.NewResources(quantity.SizeMiB), quota.NewResources(5 * quantity.SizeKiB), `cannot decrease memory limit, remove and re-create it to decrease the limit`},
+		{
+			quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build(),
+			quota.NewResourcesBuilder().WithMemoryLimit(0).Build(),
+			`cannot remove memory limit from quota group`,
+		},
+		{
+			quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build(),
+			quota.NewResourcesBuilder().WithMemoryLimit(5 * quantity.SizeKiB).Build(),
+			`cannot decrease memory limit, remove and re-create it to decrease the limit`,
+		},
 	}
 
 	for _, t := range tests {
@@ -85,8 +100,31 @@ func (s *resourcesTestSuite) TestQuotaChangeValidationPasses(c *C) {
 		// equal limits or newLimits as it can contain partial updates.
 		newLimits quota.Resources
 	}{
-		{quota.NewResources(quantity.SizeMiB), quota.NewResources(quantity.SizeGiB), quota.NewResources(quantity.SizeGiB)},
-		// expect more tests as the number of quotas grow
+		{
+			quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build(),
+			quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
+			quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
+		},
+		{
+			quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build(),
+			quota.NewResourcesBuilder().WithCPUCount(4).WithCPUPercentage(25).Build(),
+			quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).WithCPUCount(4).WithCPUPercentage(25).Build(),
+		},
+		{
+			quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).WithCPUCount(4).WithCPUPercentage(25).Build(),
+			quota.NewResourcesBuilder().WithAllowedCPUs([]int{0}).Build(),
+			quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).WithCPUCount(4).WithCPUPercentage(25).WithAllowedCPUs([]int{0}).Build(),
+		},
+		{
+			quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).WithCPUCount(4).WithCPUPercentage(25).WithAllowedCPUs([]int{0}).Build(),
+			quota.NewResourcesBuilder().WithThreadLimit(128).Build(),
+			quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).WithCPUCount(4).WithCPUPercentage(25).WithAllowedCPUs([]int{0}).WithThreadLimit(128).Build(),
+		},
+		{
+			quota.NewResourcesBuilder().WithCPUCount(1).WithCPUPercentage(100).Build(),
+			quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).WithThreadLimit(32).Build(),
+			quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).WithCPUCount(1).WithCPUPercentage(100).WithThreadLimit(32).Build(),
+		},
 	}
 
 	for _, t := range tests {

--- a/strutil/strutil.go
+++ b/strutil/strutil.go
@@ -39,7 +39,7 @@ func SizeToStr(size int64) string {
 	panic("SizeToStr got a size bigger than math.MaxInt64")
 }
 
-// IntsToCommaSeparated converts an int array to a comma-separated string
+// IntsToCommaSeparated converts an int array to a comma-separated string without whitespace
 func IntsToCommaSeparated(vals []int) string {
 	b := &strings.Builder{}
 	last := len(vals) - 1

--- a/strutil/strutil.go
+++ b/strutil/strutil.go
@@ -39,8 +39,8 @@ func SizeToStr(size int64) string {
 	panic("SizeToStr got a size bigger than math.MaxInt64")
 }
 
-// IntsToCommaSeparatedString converts an int array to a comma-separated string
-func IntsToCommaSeparatedString(vals []int) string {
+// IntsToCommaSeparated converts an int array to a comma-separated string
+func IntsToCommaSeparated(vals []int) string {
 	b := &strings.Builder{}
 	last := len(vals) - 1
 	for i, v := range vals {

--- a/strutil/strutil.go
+++ b/strutil/strutil.go
@@ -39,6 +39,19 @@ func SizeToStr(size int64) string {
 	panic("SizeToStr got a size bigger than math.MaxInt64")
 }
 
+// SliceToCommaSeparatedString converts an int array to a comma-separated string
+func SliceToCommaSeparatedString(vals []int) string {
+	b := &strings.Builder{}
+	last := len(vals) - 1
+	for i, v := range vals {
+		b.WriteString(strconv.Itoa(v))
+		if i != last {
+			b.WriteRune(',')
+		}
+	}
+	return b.String()
+}
+
 // Quoted formats a slice of strings to a quoted list of
 // comma-separated strings, e.g. `"snap1", "snap2"`
 func Quoted(names []string) string {

--- a/strutil/strutil.go
+++ b/strutil/strutil.go
@@ -39,8 +39,8 @@ func SizeToStr(size int64) string {
 	panic("SizeToStr got a size bigger than math.MaxInt64")
 }
 
-// SliceToCommaSeparatedString converts an int array to a comma-separated string
-func SliceToCommaSeparatedString(vals []int) string {
+// IntsToCommaSeparatedString converts an int array to a comma-separated string
+func IntsToCommaSeparatedString(vals []int) string {
 	b := &strings.Builder{}
 	last := len(vals) - 1
 	for i, v := range vals {

--- a/strutil/strutil_test.go
+++ b/strutil/strutil_test.go
@@ -71,7 +71,7 @@ func (ts *strutilSuite) TestSizeToStr(c *check.C) {
 	}
 }
 
-func (ts *strutilSuite) TestSliceToCommaSeparatedString(c *check.C) {
+func (ts *strutilSuite) TestIntsToCommaSeparatedString(c *check.C) {
 	for _, t := range []struct {
 		values []int
 		str    string
@@ -82,7 +82,7 @@ func (ts *strutilSuite) TestSliceToCommaSeparatedString(c *check.C) {
 		{[]int{0, -1}, "0,-1"},
 		{[]int{1, 2, 3}, "1,2,3"},
 	} {
-		c.Check(strutil.SliceToCommaSeparatedString(t.values), check.Equals, t.str)
+		c.Check(strutil.IntsToCommaSeparatedString(t.values), check.Equals, t.str)
 	}
 }
 

--- a/strutil/strutil_test.go
+++ b/strutil/strutil_test.go
@@ -71,6 +71,21 @@ func (ts *strutilSuite) TestSizeToStr(c *check.C) {
 	}
 }
 
+func (ts *strutilSuite) TestSliceToCommaSeparatedString(c *check.C) {
+	for _, t := range []struct {
+		values []int
+		str    string
+	}{
+		{[]int{}, ""},
+		{nil, ""},
+		{[]int{0}, "0"},
+		{[]int{0, -1}, "0,-1"},
+		{[]int{1, 2, 3}, "1,2,3"},
+	} {
+		c.Check(strutil.SliceToCommaSeparatedString(t.values), check.Equals, t.str)
+	}
+}
+
 func (ts *strutilSuite) TestListContains(c *check.C) {
 	for _, xs := range [][]string{
 		{},

--- a/strutil/strutil_test.go
+++ b/strutil/strutil_test.go
@@ -71,7 +71,7 @@ func (ts *strutilSuite) TestSizeToStr(c *check.C) {
 	}
 }
 
-func (ts *strutilSuite) TestIntsToCommaSeparatedString(c *check.C) {
+func (ts *strutilSuite) TestIntsToCommaSeparated(c *check.C) {
 	for _, t := range []struct {
 		values []int
 		str    string
@@ -82,7 +82,7 @@ func (ts *strutilSuite) TestIntsToCommaSeparatedString(c *check.C) {
 		{[]int{0, -1}, "0,-1"},
 		{[]int{1, 2, 3}, "1,2,3"},
 	} {
-		c.Check(strutil.IntsToCommaSeparatedString(t.values), check.Equals, t.str)
+		c.Check(strutil.IntsToCommaSeparated(t.values), check.Equals, t.str)
 	}
 }
 

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -117,22 +117,22 @@ func formatCpuGroupSlice(grp *quota.Group) string {
 			return ""
 		}
 
-		allowedCpusValue := strutil.SliceToCommaSeparatedString(grp.CPULimit.AllowedCPUs)
+		allowedCpusValue := strutil.IntsToCommaSeparatedString(grp.CPULimit.AllowedCPUs)
 		return fmt.Sprintf("AllowedCPUs=%s\n", allowedCpusValue)
 	}
 
-	template := `# Always enable cpu accounting, so the following cpu quota options have an effect
+	header := `# Always enable cpu accounting, so the following cpu quota options have an effect
 CPUAccounting=true
 `
-	return fmt.Sprint(template, calculateSystemdCPULimit(), getAllowedCpusValue(), "\n")
+	return fmt.Sprint(header, calculateSystemdCPULimit(), getAllowedCpusValue(), "\n")
 }
 
 func formatMemoryGroupSlice(grp *quota.Group) string {
 	buf := bytes.Buffer{}
-	template := `# Always enable memory accounting otherwise the MemoryMax setting does nothing.
+	header := `# Always enable memory accounting otherwise the MemoryMax setting does nothing.
 MemoryAccounting=true
 `
-	fmt.Fprint(&buf, template)
+	fmt.Fprint(&buf, header)
 
 	if grp.MemoryLimit != 0 {
 		valuesTemplate := `MemoryMax=%[1]d
@@ -148,11 +148,11 @@ MemoryLimit=%[1]d
 
 func formatTaskGroupSlice(grp *quota.Group) string {
 	buf := bytes.Buffer{}
-	template := `# Always enable task accounting in order to be able to count the processes/
+	header := `# Always enable task accounting in order to be able to count the processes/
 # threads, etc for a slice
 TasksAccounting=true
 `
-	fmt.Fprint(&buf, template)
+	fmt.Fprint(&buf, header)
 
 	if grp.TaskLimit != 0 {
 		taskValue := fmt.Sprintf("TasksMax=%d\n", grp.TaskLimit)

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -86,7 +86,7 @@ func max(a, b int) int {
 }
 
 func min(a, b int) int {
-	if a > b {
+	if b < a {
 		return b
 	}
 	return a
@@ -104,23 +104,21 @@ func formatCpuGroupSlice(grp *quota.Group) string {
 			return ""
 		}
 
-		cpuQuotaFormat := "CPUQuota=%d%%\n"
 		cpuQuotaSnap := max(grp.CpuLimit.Count, 1) * grp.CpuLimit.Percentage
 		cpuQuotaMax := runtime.NumCPU() * 100
-		return fmt.Sprintf(cpuQuotaFormat, min(cpuQuotaSnap, cpuQuotaMax))
+		return fmt.Sprintf("CPUQuota=%d%%\n", min(cpuQuotaSnap, cpuQuotaMax))
 	}
 
 	// getAllowedCpusValue converts allowed CPUs array to a comma-delimited
 	// string that systemd expects it to be in. If the array is empty then
 	// an empty string is returned
 	getAllowedCpusValue := func() string {
-		if len(grp.CpuLimit.AllowedCpus) == 0 {
+		if len(grp.CpuLimit.AllowedCPUs) == 0 {
 			return ""
 		}
 
-		allowedCpusFormat := "AllowedCPUs=%s\n"
-		allowedCpusValue := strings.Trim(strings.Join(strings.Fields(fmt.Sprint(grp.CpuLimit.AllowedCpus)), ","), "[]")
-		return fmt.Sprintf(allowedCpusFormat, allowedCpusValue)
+		allowedCpusValue := strings.Trim(strings.Join(strings.Fields(fmt.Sprint(grp.CpuLimit.AllowedCPUs)), ","), "[]")
+		return fmt.Sprintf("AllowedCPUs=%s\n", allowedCpusValue)
 	}
 
 	// AllowedCpus is only available for cgroupsv2

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -117,7 +117,7 @@ func formatCpuGroupSlice(grp *quota.Group) string {
 			return ""
 		}
 
-		allowedCpusValue := strutil.IntsToCommaSeparatedString(grp.CPULimit.AllowedCPUs)
+		allowedCpusValue := strutil.IntsToCommaSeparated(grp.CPULimit.AllowedCPUs)
 		return fmt.Sprintf("AllowedCPUs=%s\n", allowedCpusValue)
 	}
 

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -117,7 +117,7 @@ func formatCpuGroupSlice(grp *quota.Group) string {
 			return ""
 		}
 
-		allowedCpusValue := strings.Trim(strings.Join(strings.Fields(fmt.Sprint(grp.CPULimit.AllowedCPUs)), ","), "[]")
+		allowedCpusValue := strutil.SliceToCommaSeparatedString(grp.CPULimit.AllowedCPUs)
 		return fmt.Sprintf("AllowedCPUs=%s\n", allowedCpusValue)
 	}
 

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -284,7 +284,7 @@ TasksAccounting=true
 TasksMax=%[5]d
 `
 
-	allowedCpusValue := strutil.IntsToCommaSeparatedString(resourceLimits.CPU.AllowedCPUs)
+	allowedCpusValue := strutil.IntsToCommaSeparated(resourceLimits.CPU.AllowedCPUs)
 	sliceContent := fmt.Sprintf(sliceTempl, grp.Name,
 		resourceLimits.CPU.Count*resourceLimits.CPU.Percentage,
 		allowedCpusValue,
@@ -851,7 +851,7 @@ MemoryLimit=%[3]d
 TasksAccounting=true
 `
 
-	allowedCpusValue := strutil.IntsToCommaSeparatedString(resourceLimits.CPU.AllowedCPUs)
+	allowedCpusValue := strutil.IntsToCommaSeparated(resourceLimits.CPU.AllowedCPUs)
 	c.Assert(sliceFile, testutil.FileEquals, fmt.Sprintf(templ, "foogroup", allowedCpusValue, resourceLimits.Memory.Limit))
 	c.Assert(subSliceFile, testutil.FileEquals, fmt.Sprintf(templ, "subgroup", allowedCpusValue, resourceLimits.Memory.Limit))
 }

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -284,7 +284,7 @@ TasksAccounting=true
 TasksMax=%[5]d
 `
 
-	allowedCpusValue := strutil.SliceToCommaSeparatedString(resourceLimits.CPU.AllowedCPUs)
+	allowedCpusValue := strutil.IntsToCommaSeparatedString(resourceLimits.CPU.AllowedCPUs)
 	sliceContent := fmt.Sprintf(sliceTempl, grp.Name,
 		resourceLimits.CPU.Count*resourceLimits.CPU.Percentage,
 		allowedCpusValue,
@@ -851,7 +851,7 @@ MemoryLimit=%[3]d
 TasksAccounting=true
 `
 
-	allowedCpusValue := strutil.SliceToCommaSeparatedString(resourceLimits.CPU.AllowedCPUs)
+	allowedCpusValue := strutil.IntsToCommaSeparatedString(resourceLimits.CPU.AllowedCPUs)
 	c.Assert(sliceFile, testutil.FileEquals, fmt.Sprintf(templ, "foogroup", allowedCpusValue, resourceLimits.Memory.Limit))
 	c.Assert(subSliceFile, testutil.FileEquals, fmt.Sprintf(templ, "subgroup", allowedCpusValue, resourceLimits.Memory.Limit))
 }

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -218,8 +218,15 @@ func (s *servicesTestSuite) TestEnsureSnapServicesWithQuotas(c *C) {
 	info := snaptest.MockSnap(c, packageHello, &snap.SideInfo{Revision: snap.R(12)})
 	svcFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-snap.svc1.service")
 
-	memLimit := quantity.SizeGiB
-	grp, err := quota.NewGroup("foogroup", quota.NewResources(memLimit))
+	// set up arbitrary quotas for the group to test they get written correctly to the slice
+	resourceLimits := quota.NewResourcesBuilder().
+		WithMemoryLimit(quantity.SizeGiB).
+		WithCPUCount(2).
+		WithCPUPercentage(50).
+		WithAllowedCPUs([]int{0, 1}).
+		WithThreadLimit(32).
+		Build()
+	grp, err := quota.NewGroup("foogroup", resourceLimits)
 	c.Assert(err, IsNil)
 
 	m := map[*snap.Info]*wrappers.SnapServiceOptions{
@@ -260,18 +267,29 @@ Before=slices.target
 X-Snappy=yes
 
 [Slice]
+# Always enable cpu accounting, so the following cpu quota options have an effect
+CPUAccounting=true
+CPUQuota=%[2]d%%
+AllowedCPUs=%[3]s
+
 # Always enable memory accounting otherwise the MemoryMax setting does nothing.
 MemoryAccounting=true
-MemoryMax=%[2]s
+MemoryMax=%[4]d
 # for compatibility with older versions of systemd
-MemoryLimit=%[2]s
+MemoryLimit=%[4]d
 
 # Always enable task accounting in order to be able to count the processes/
 # threads, etc for a slice
 TasksAccounting=true
+TasksMax=%[5]d
 `
 
-	sliceContent := fmt.Sprintf(sliceTempl, grp.Name, memLimit.String())
+	allowedCpusValue := strings.Trim(strings.Join(strings.Fields(fmt.Sprint(resourceLimits.CPU.AllowedCPUs)), ","), "[]")
+	sliceContent := fmt.Sprintf(sliceTempl, grp.Name,
+		resourceLimits.CPU.Count*resourceLimits.CPU.Percentage,
+		allowedCpusValue,
+		resourceLimits.Memory.Limit,
+		resourceLimits.Threads.Limit)
 
 	exp := []changesObservation{
 		{
@@ -421,7 +439,8 @@ WantedBy=multi-user.target
 	c.Assert(err, IsNil)
 
 	// use new memory limit
-	grp, err := quota.NewGroup("foogroup", quota.NewResources(memLimit2))
+	resourceLimits := quota.NewResourcesBuilder().WithMemoryLimit(memLimit2).Build()
+	grp, err := quota.NewGroup("foogroup", resourceLimits)
 	c.Assert(err, IsNil)
 
 	m := map[*snap.Info]*wrappers.SnapServiceOptions{
@@ -458,6 +477,7 @@ func (s *servicesTestSuite) TestEnsureSnapServicesDoesNotRewriteQuotaSlicesOnNoo
 	svcFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-snap.svc1.service")
 
 	memLimit := quantity.SizeGiB
+	taskLimit := 32 // arbitrarily chosen
 
 	// write both the unit file and a slice before running the ensure
 	sliceTempl := `[Unit]
@@ -475,6 +495,7 @@ MemoryLimit=%[2]s
 # Always enable task accounting in order to be able to count the processes/
 # threads, etc for a slice
 TasksAccounting=true
+TasksMax=%[3]d
 `
 	sliceFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.foogroup.slice")
 
@@ -509,13 +530,14 @@ WantedBy=multi-user.target
 	err := os.MkdirAll(filepath.Dir(sliceFile), 0755)
 	c.Assert(err, IsNil)
 
-	err = ioutil.WriteFile(sliceFile, []byte(fmt.Sprintf(sliceTempl, "foogroup", memLimit.String())), 0644)
+	err = ioutil.WriteFile(sliceFile, []byte(fmt.Sprintf(sliceTempl, "foogroup", memLimit.String(), taskLimit)), 0644)
 	c.Assert(err, IsNil)
 
 	err = ioutil.WriteFile(svcFile, []byte(svcContent), 0644)
 	c.Assert(err, IsNil)
 
-	grp, err := quota.NewGroup("foogroup", quota.NewResources(memLimit))
+	resourceLimits := quota.NewResourcesBuilder().WithMemoryLimit(memLimit).WithThreadLimit(taskLimit).Build()
+	grp, err := quota.NewGroup("foogroup", resourceLimits)
 	c.Assert(err, IsNil)
 
 	m := map[*snap.Info]*wrappers.SnapServiceOptions{
@@ -533,12 +555,13 @@ WantedBy=multi-user.target
 
 	c.Assert(svcFile, testutil.FileEquals, svcContent)
 
-	c.Assert(sliceFile, testutil.FileEquals, fmt.Sprintf(sliceTempl, "foogroup", memLimit.String()))
+	c.Assert(sliceFile, testutil.FileEquals, fmt.Sprintf(sliceTempl, "foogroup", memLimit.String(), taskLimit))
 }
 
 func (s *servicesTestSuite) TestRemoveQuotaGroup(c *C) {
 	// create the group
-	grp, err := quota.NewGroup("foogroup", quota.NewResources(5*quantity.SizeKiB))
+	resourceLimits := quota.NewResourcesBuilder().WithMemoryLimit(5 * quantity.SizeKiB).Build()
+	grp, err := quota.NewGroup("foogroup", resourceLimits)
 	c.Assert(err, IsNil)
 
 	sliceFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.foogroup.slice")
@@ -606,14 +629,18 @@ apps:
 	svcFile2 := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-other-snap.svc1.service")
 
 	var err error
-	memLimit := quantity.SizeGiB
+	resourceLimits := quota.NewResourcesBuilder().
+		WithMemoryLimit(quantity.SizeGiB).
+		WithCPUCount(4).
+		WithCPUPercentage(25).
+		Build()
 	// make a root quota group and add the first snap to it
-	grp, err := quota.NewGroup("foogroup", quota.NewResources(memLimit))
+	grp, err := quota.NewGroup("foogroup", resourceLimits)
 	c.Assert(err, IsNil)
 
 	// the second group is a sub-group with the same limit, but is for the
 	// second snap
-	subgrp, err := grp.NewSubGroup("subgroup", quota.NewResources(memLimit))
+	subgrp, err := grp.NewSubGroup("subgroup", resourceLimits)
 	c.Assert(err, IsNil)
 
 	sliceFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.foogroup.slice")
@@ -630,19 +657,23 @@ Before=slices.target
 X-Snappy=yes
 
 [Slice]
+# Always enable cpu accounting, so the following cpu quota options have an effect
+CPUAccounting=true
+CPUQuota=%[2]d%%
+
 # Always enable memory accounting otherwise the MemoryMax setting does nothing.
 MemoryAccounting=true
-MemoryMax=%[2]s
+MemoryMax=%[3]d
 # for compatibility with older versions of systemd
-MemoryLimit=%[2]s
+MemoryLimit=%[3]d
 
 # Always enable task accounting in order to be able to count the processes/
 # threads, etc for a slice
 TasksAccounting=true
 `
 
-	sliceContent := fmt.Sprintf(sliceTempl, "foogroup", memLimit.String())
-	subSliceContent := fmt.Sprintf(sliceTempl, "subgroup", memLimit.String())
+	sliceContent := fmt.Sprintf(sliceTempl, "foogroup", resourceLimits.CPU.Count*resourceLimits.CPU.Percentage, resourceLimits.Memory.Limit)
+	subSliceContent := fmt.Sprintf(sliceTempl, "subgroup", resourceLimits.CPU.Count*resourceLimits.CPU.Percentage, resourceLimits.Memory.Limit)
 
 	svcTemplate := `[Unit]
 # Auto-generated, DO NOT EDIT
@@ -739,14 +770,17 @@ func (s *servicesTestSuite) TestEnsureSnapServicesWithSubGroupQuotaGroupsGenerat
 	svcFile1 := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-snap.svc1.service")
 
 	var err error
-	memLimit := quantity.SizeGiB
+	resourceLimits := quota.NewResourcesBuilder().
+		WithMemoryLimit(quantity.SizeGiB).
+		WithAllowedCPUs([]int{0}).
+		Build()
 	// make a root quota group without any snaps in it
-	grp, err := quota.NewGroup("foogroup", quota.NewResources(memLimit))
+	grp, err := quota.NewGroup("foogroup", resourceLimits)
 	c.Assert(err, IsNil)
 
 	// the second group is a sub-group with the same limit, but it is the one
 	// with the snap in it
-	subgrp, err := grp.NewSubGroup("subgroup", quota.NewResources(memLimit))
+	subgrp, err := grp.NewSubGroup("subgroup", resourceLimits)
 	c.Assert(err, IsNil)
 
 	sliceFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.foogroup.slice")
@@ -802,19 +836,24 @@ Before=slices.target
 X-Snappy=yes
 
 [Slice]
+# Always enable cpu accounting, so the following cpu quota options have an effect
+CPUAccounting=true
+AllowedCPUs=%[2]s
+
 # Always enable memory accounting otherwise the MemoryMax setting does nothing.
 MemoryAccounting=true
-MemoryMax=%[2]s
+MemoryMax=%[3]d
 # for compatibility with older versions of systemd
-MemoryLimit=%[2]s
+MemoryLimit=%[3]d
 
 # Always enable task accounting in order to be able to count the processes/
 # threads, etc for a slice
 TasksAccounting=true
 `
 
-	c.Assert(sliceFile, testutil.FileEquals, fmt.Sprintf(templ, "foogroup", memLimit.String()))
-	c.Assert(subSliceFile, testutil.FileEquals, fmt.Sprintf(templ, "subgroup", memLimit.String()))
+	allowedCpusValue := strings.Trim(strings.Join(strings.Fields(fmt.Sprint(resourceLimits.CPU.AllowedCPUs)), ","), "[]")
+	c.Assert(sliceFile, testutil.FileEquals, fmt.Sprintf(templ, "foogroup", allowedCpusValue, resourceLimits.Memory.Limit))
+	c.Assert(subSliceFile, testutil.FileEquals, fmt.Sprintf(templ, "subgroup", allowedCpusValue, resourceLimits.Memory.Limit))
 }
 
 func (s *servicesTestSuite) TestEnsureSnapServiceEnsureError(c *C) {

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -388,6 +388,9 @@ Before=slices.target
 X-Snappy=yes
 
 [Slice]
+# Always enable cpu accounting, so the following cpu quota options have an effect
+CPUAccounting=true
+
 # Always enable memory accounting otherwise the MemoryMax setting does nothing.
 MemoryAccounting=true
 MemoryMax=%[2]s
@@ -486,6 +489,9 @@ Before=slices.target
 X-Snappy=yes
 
 [Slice]
+# Always enable cpu accounting, so the following cpu quota options have an effect
+CPUAccounting=true
+
 # Always enable memory accounting otherwise the MemoryMax setting does nothing.
 MemoryAccounting=true
 MemoryMax=%[2]s
@@ -582,6 +588,9 @@ Before=slices.target
 X-Snappy=yes
 
 [Slice]
+# Always enable cpu accounting, so the following cpu quota options have an effect
+CPUAccounting=true
+
 # Always enable memory accounting otherwise the MemoryMax setting does nothing.
 MemoryAccounting=true
 MemoryMax=1024

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -284,7 +284,7 @@ TasksAccounting=true
 TasksMax=%[5]d
 `
 
-	allowedCpusValue := strings.Trim(strings.Join(strings.Fields(fmt.Sprint(resourceLimits.CPU.AllowedCPUs)), ","), "[]")
+	allowedCpusValue := strutil.SliceToCommaSeparatedString(resourceLimits.CPU.AllowedCPUs)
 	sliceContent := fmt.Sprintf(sliceTempl, grp.Name,
 		resourceLimits.CPU.Count*resourceLimits.CPU.Percentage,
 		allowedCpusValue,
@@ -851,7 +851,7 @@ MemoryLimit=%[3]d
 TasksAccounting=true
 `
 
-	allowedCpusValue := strings.Trim(strings.Join(strings.Fields(fmt.Sprint(resourceLimits.CPU.AllowedCPUs)), ","), "[]")
+	allowedCpusValue := strutil.SliceToCommaSeparatedString(resourceLimits.CPU.AllowedCPUs)
 	c.Assert(sliceFile, testutil.FileEquals, fmt.Sprintf(templ, "foogroup", allowedCpusValue, resourceLimits.Memory.Limit))
 	c.Assert(subSliceFile, testutil.FileEquals, fmt.Sprintf(templ, "subgroup", allowedCpusValue, resourceLimits.Memory.Limit))
 }


### PR DESCRIPTION
This is the third PR implementing cpu quotas, but it is the first of three incoming PRs. The purpose of this new PR series is to split up the primary PR which is too large #11252.

The PR has the following changes:
snap/quota: implement the new quotas
snap/quota: implement use of builder pattern for the quota.Resources
overlord:      correct tests after switching to builder pattern
daemon:      correct test after switching to builder pattern
wrappers:    implement the underlying functionality to write the new quotas to systemd slice file

