### PR TITLE
tests: fix "undo purging" step in snap-run-devmode-classic

### DIFF
--- a/tests/main/snap-run-devmode-classic/task.yaml
+++ b/tests/main/snap-run-devmode-classic/task.yaml
@@ -187,7 +187,7 @@ execute: |
         fi
 
         # undo the purging
-        apt install -y "$PROJECT_PATH/../snapd_1337.2.54.2_amd64.deb"
+        apt install -y "$PROJECT_PATH/../"snapd_1337.*_amd64.deb
 
     else
         echo "unknown variant $SNAP_TO_USE_FIRST"


### PR DESCRIPTION
The current "snap-run-devmode-classic" test is hardcoding a
version number in the restore step of the test. This breaks
the test after 2.54.3 was released.
