### PR TITLE
many: move boot.Device to snap.Device

### DIFF
--- a/boot/boot.go
+++ b/boot/boot.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/snap"
 )
@@ -79,21 +78,6 @@ var _ BootParticipant = trivial{}
 // ensure trivial is a Kernel
 var _ BootKernel = trivial{}
 
-// Device carries information about the device model and mode that is
-// relevant to boot. Note snapstate.DeviceContext implements this, and that's
-// the expected use case.
-type Device interface {
-	RunMode() bool
-	Classic() bool
-
-	Kernel() string
-	Base() string
-
-	HasModeenv() bool
-
-	Model() *asserts.Model
-}
-
 // Participant figures out what the BootParticipant is for the given
 // arguments, and returns it. If the snap does _not_ participate in
 // the boot process, the returned object will be a NOP, so it's safe
@@ -101,7 +85,7 @@ type Device interface {
 //
 // Currently, on classic, nothing is a boot participant (returned will
 // always be NOP).
-func Participant(s snap.PlaceInfo, t snap.Type, dev Device) BootParticipant {
+func Participant(s snap.PlaceInfo, t snap.Type, dev snap.Device) BootParticipant {
 	if applicable(s, t, dev) {
 		bs, err := bootStateFor(t, dev)
 		if err != nil {
@@ -115,7 +99,7 @@ func Participant(s snap.PlaceInfo, t snap.Type, dev Device) BootParticipant {
 
 // bootloaderOptionsForDeviceKernel returns a set of bootloader options that
 // enable correct kernel extraction and removal for given device
-func bootloaderOptionsForDeviceKernel(dev Device) *bootloader.Options {
+func bootloaderOptionsForDeviceKernel(dev snap.Device) *bootloader.Options {
 	if !dev.HasModeenv() {
 		return nil
 	}
@@ -128,14 +112,14 @@ func bootloaderOptionsForDeviceKernel(dev Device) *bootloader.Options {
 // Kernel checks that the given arguments refer to a kernel snap
 // that participates in the boot process, and returns the associated
 // BootKernel, or a trivial implementation otherwise.
-func Kernel(s snap.PlaceInfo, t snap.Type, dev Device) BootKernel {
+func Kernel(s snap.PlaceInfo, t snap.Type, dev snap.Device) BootKernel {
 	if t == snap.TypeKernel && applicable(s, t, dev) {
 		return &coreKernel{s: s, bopts: bootloaderOptionsForDeviceKernel(dev)}
 	}
 	return trivial{}
 }
 
-func applicable(s snap.PlaceInfo, t snap.Type, dev Device) bool {
+func applicable(s snap.PlaceInfo, t snap.Type, dev snap.Device) bool {
 	if dev.Classic() {
 		return false
 	}
@@ -203,7 +187,7 @@ type successfulBootState interface {
 
 // bootStateFor finds the right bootState implementation of the given
 // snap type and Device, if applicable.
-func bootStateFor(typ snap.Type, dev Device) (s bootState, err error) {
+func bootStateFor(typ snap.Type, dev snap.Device) (s bootState, err error) {
 	if !dev.RunMode() {
 		return nil, fmt.Errorf("internal error: no boot state handling for ephemeral modes")
 	}
@@ -232,7 +216,7 @@ func fixedInUse(inUse bool) InUseFunc {
 
 // InUse returns a checker for whether a given name/revision is used in the
 // boot environment for snaps of the relevant snap type.
-func InUse(typ snap.Type, dev Device) (InUseFunc, error) {
+func InUse(typ snap.Type, dev snap.Device) (InUseFunc, error) {
 	if dev.Classic() {
 		// no boot state on classic
 		return fixedInUse(false), nil
@@ -280,7 +264,7 @@ var (
 // GetCurrentBoot returns the currently set name and revision for boot for the given
 // type of snap, which can be snap.TypeBase (or snap.TypeOS), or snap.TypeKernel.
 // Returns ErrBootNameAndRevisionNotReady if the values are temporarily not established.
-func GetCurrentBoot(t snap.Type, dev Device) (snap.PlaceInfo, error) {
+func GetCurrentBoot(t snap.Type, dev snap.Device) (snap.PlaceInfo, error) {
 	s, err := bootStateFor(t, dev)
 	if err != nil {
 		return nil, err
@@ -324,7 +308,7 @@ type bootStateUpdate interface {
 //   means snapd did not start successfully. In this case the bootloader
 //   will set snap_mode="" and the system will boot with the known good
 //   values from snap_{core,kernel}
-func MarkBootSuccessful(dev Device) error {
+func MarkBootSuccessful(dev snap.Device) error {
 	const errPrefix = "cannot mark boot successful: %s"
 
 	var u bootStateUpdate
@@ -368,7 +352,7 @@ var ErrUnsupportedSystemMode = errors.New("system mode is unsupported")
 // the given recovery system in a particular mode. Returns
 // ErrUnsupportedSystemMode when booting into a recovery system is not supported
 // by the device.
-func SetRecoveryBootSystemAndMode(dev Device, systemLabel, mode string) error {
+func SetRecoveryBootSystemAndMode(dev snap.Device, systemLabel, mode string) error {
 	if !dev.HasModeenv() {
 		// only UC20 devices are supported
 		return ErrUnsupportedSystemMode
@@ -401,7 +385,7 @@ func SetRecoveryBootSystemAndMode(dev Device, systemLabel, mode string) error {
 // UpdateManagedBootConfigs updates managed boot config assets if those are
 // present for the ubuntu-boot bootloader. Returns true when an update was
 // carried out.
-func UpdateManagedBootConfigs(dev Device, gadgetSnapOrDir string) (updated bool, err error) {
+func UpdateManagedBootConfigs(dev snap.Device, gadgetSnapOrDir string) (updated bool, err error) {
 	if !dev.HasModeenv() {
 		// only UC20 devices use managed boot config
 		return false, nil
@@ -412,7 +396,7 @@ func UpdateManagedBootConfigs(dev Device, gadgetSnapOrDir string) (updated bool,
 	return updateManagedBootConfigForBootloader(dev, ModeRun, gadgetSnapOrDir)
 }
 
-func updateManagedBootConfigForBootloader(dev Device, mode, gadgetSnapOrDir string) (updated bool, err error) {
+func updateManagedBootConfigForBootloader(dev snap.Device, mode, gadgetSnapOrDir string) (updated bool, err error) {
 	if mode != ModeRun {
 		return false, fmt.Errorf("internal error: updating boot config of recovery bootloader is not supported yet")
 	}
@@ -441,7 +425,7 @@ func updateManagedBootConfigForBootloader(dev Device, mode, gadgetSnapOrDir stri
 // contributes to the kernel command line of the run system. Returns true when a
 // change in command line has been observed and a reboot is needed. The reboot,
 // if needed, should be requested at the the earliest possible occasion.
-func UpdateCommandLineForGadgetComponent(dev Device, gadgetSnapOrDir string) (needsReboot bool, err error) {
+func UpdateCommandLineForGadgetComponent(dev snap.Device, gadgetSnapOrDir string) (needsReboot bool, err error) {
 	if !dev.HasModeenv() {
 		// only UC20 devices are supported
 		return false, fmt.Errorf("internal error: command line component cannot be updated on non UC20 devices")

--- a/boot/boot_robustness_test.go
+++ b/boot/boot_robustness_test.go
@@ -120,8 +120,8 @@ func pureenvBootloaderLogic(c *C, modeVar string, bl bootloader.Bootloader) (sna
 // SetBootVars
 func (s *bootenv20Suite) checkBootStateAfterUnexpectedRebootAndCleanup(
 	c *C,
-	dev boot.Device,
-	bootFunc func(boot.Device) error,
+	dev snap.Device,
+	bootFunc func(snap.Device) error,
 	panicFunc string,
 	expectedBootedKernel snap.PlaceInfo,
 	expectedModeenvCurrentKernels []snap.PlaceInfo,
@@ -302,7 +302,7 @@ func (s *bootenv20Suite) TestHappySetNextBoot20KernelUpgradeUnexpectedReboots(c 
 		// make sure it's not a trivial boot participant
 		c.Assert(bootKern.IsTrivial(), Equals, false)
 
-		setNextFunc := func(boot.Device) error {
+		setNextFunc := func(snap.Device) error {
 			// we don't care about the reboot required logic here
 			_, err := bootKern.SetNextBoot()
 			return err

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -3059,7 +3059,7 @@ type recoveryBootenv20Suite struct {
 
 	bootloader *bootloadertest.MockBootloader
 
-	dev boot.Device
+	dev snap.Device
 }
 
 var _ = Suite(&recoveryBootenv20Suite{})
@@ -3486,7 +3486,7 @@ type bootKernelCommandLineSuite struct {
 
 	bootloader            *bootloadertest.MockTrustedAssetsBootloader
 	gadgetSnap            string
-	uc20dev               boot.Device
+	uc20dev               snap.Device
 	recoveryKernelBf      bootloader.BootFile
 	runKernelBf           bootloader.BootFile
 	modeenvWithEncryption *boot.Modeenv

--- a/boot/bootstate16.go
+++ b/boot/bootstate16.go
@@ -31,7 +31,7 @@ type bootState16 struct {
 	errName   string
 }
 
-func newBootState16(typ snap.Type, dev Device) bootState {
+func newBootState16(typ snap.Type, dev snap.Device) bootState {
 	var varSuffix, errName string
 	switch typ {
 	case snap.TypeKernel:

--- a/boot/bootstate20.go
+++ b/boot/bootstate20.go
@@ -31,7 +31,7 @@ import (
 	"github.com/snapcore/snapd/strutil"
 )
 
-func newBootState20(typ snap.Type, dev Device) bootState {
+func newBootState20(typ snap.Type, dev snap.Device) bootState {
 	switch typ {
 	case snap.TypeBase:
 		return &bootState20Base{}
@@ -192,7 +192,7 @@ type bootState20Kernel struct {
 	blOpts *bootloader.Options
 	blDir  string
 
-	dev Device
+	dev snap.Device
 }
 
 func (ks20 *bootState20Kernel) loadBootenv() error {
@@ -657,7 +657,7 @@ func genericInitramfsSelectSnap(bs bootState20, modeenv *Modeenv, expectedTrySta
 // bootState20BootAssets implements the successfulBootState interface for trusted
 // boot assets UC20.
 type bootState20BootAssets struct {
-	dev Device
+	dev snap.Device
 }
 
 func (ba20 *bootState20BootAssets) markSuccessful(update bootStateUpdate) (bootStateUpdate, error) {
@@ -698,7 +698,7 @@ func (ba20 *bootState20BootAssets) markSuccessful(update bootStateUpdate) (bootS
 	return u20, nil
 }
 
-func trustedAssetsBootState(dev Device) *bootState20BootAssets {
+func trustedAssetsBootState(dev snap.Device) *bootState20BootAssets {
 	return &bootState20BootAssets{
 		dev: dev,
 	}
@@ -707,7 +707,7 @@ func trustedAssetsBootState(dev Device) *bootState20BootAssets {
 // bootState20CommandLine implements the successfulBootState interface for
 // kernel command line
 type bootState20CommandLine struct {
-	dev Device
+	dev snap.Device
 }
 
 func (bcl20 *bootState20CommandLine) markSuccessful(update bootStateUpdate) (bootStateUpdate, error) {
@@ -723,7 +723,7 @@ func (bcl20 *bootState20CommandLine) markSuccessful(update bootStateUpdate) (boo
 	return u20, nil
 }
 
-func trustedCommandLineBootState(dev Device) *bootState20CommandLine {
+func trustedCommandLineBootState(dev snap.Device) *bootState20CommandLine {
 	return &bootState20CommandLine{
 		dev: dev,
 	}
@@ -732,7 +732,7 @@ func trustedCommandLineBootState(dev Device) *bootState20CommandLine {
 // bootState20RecoverySystem implements the successfulBootState interface for
 // tried recovery systems
 type bootState20RecoverySystem struct {
-	dev Device
+	dev snap.Device
 }
 
 func (brs20 *bootState20RecoverySystem) markSuccessful(update bootStateUpdate) (bootStateUpdate, error) {
@@ -749,14 +749,14 @@ func (brs20 *bootState20RecoverySystem) markSuccessful(update bootStateUpdate) (
 	return u20, nil
 }
 
-func recoverySystemsBootState(dev Device) *bootState20RecoverySystem {
+func recoverySystemsBootState(dev snap.Device) *bootState20RecoverySystem {
 	return &bootState20RecoverySystem{dev: dev}
 }
 
 // bootState20Model implements the successfulBootState interface for device
 // model related bookkeeping
 type bootState20Model struct {
-	dev Device
+	dev snap.Device
 }
 
 func (brs20 *bootState20Model) markSuccessful(update bootStateUpdate) (bootStateUpdate, error) {
@@ -776,6 +776,6 @@ func (brs20 *bootState20Model) markSuccessful(update bootStateUpdate) (bootState
 	return u20, nil
 }
 
-func modelBootState(dev Device) *bootState20Model {
+func modelBootState(dev snap.Device) *bootState20Model {
 	return &bootState20Model{dev: dev}
 }

--- a/boot/boottest/device.go
+++ b/boot/boottest/device.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 
 	"github.com/snapcore/snapd/asserts"
-	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/snap"
 )
 
 type mockDevice struct {
@@ -40,7 +40,7 @@ type mockDevice struct {
 // returns true for UC20 and an empty boot snap name panics.
 // It returns <boot-snap-name> for both Base and Kernel, for more
 // control mock a DeviceContext.
-func MockDevice(s string) boot.Device {
+func MockDevice(s string) snap.Device {
 	bootsnap, mode, uc20 := snapAndMode(s)
 	if uc20 && bootsnap == "" {
 		panic("MockDevice with no snap name and @mode is unsupported")
@@ -55,7 +55,7 @@ func MockDevice(s string) boot.Device {
 // MockUC20Device implements boot.Device and returns true for HasModeenv.
 // Arguments are mode (empty means "run"), and model.
 // If model is nil a default model is used (same as MakeMockUC20Model).
-func MockUC20Device(mode string, model *asserts.Model) boot.Device {
+func MockUC20Device(mode string, model *asserts.Model) snap.Device {
 	if mode == "" {
 		mode = "run"
 	}

--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/snapcore/snapd/timings"
 )
 
-func NewCoreBootParticipant(s snap.PlaceInfo, t snap.Type, dev Device) *coreBootParticipant {
+func NewCoreBootParticipant(s snap.PlaceInfo, t snap.Type, dev snap.Device) *coreBootParticipant {
 	bs, err := bootStateFor(t, dev)
 	if err != nil {
 		panic(err)
@@ -39,7 +39,7 @@ func NewCoreBootParticipant(s snap.PlaceInfo, t snap.Type, dev Device) *coreBoot
 	return &coreBootParticipant{s: s, bs: bs}
 }
 
-func NewCoreKernel(s snap.PlaceInfo, d Device) *coreKernel {
+func NewCoreKernel(s snap.PlaceInfo, d snap.Device) *coreKernel {
 	return &coreKernel{s, bootloaderOptionsForDeviceKernel(d)}
 }
 

--- a/boot/flags.go
+++ b/boot/flags.go
@@ -30,6 +30,7 @@ import (
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/strutil"
 )
 
@@ -201,7 +202,7 @@ func InitramfsExposeBootFlagsForSystem(flags []string) error {
 // error will have IsUnknownFlagErroror() return true. This is to allow gracefully
 // ignoring unknown boot flags while still processing supported flags.
 // Only to be used on UC20+ systems with recovery systems.
-func BootFlags(dev Device) ([]string, error) {
+func BootFlags(dev snap.Device) ([]string, error) {
 	if !dev.HasModeenv() {
 		return nil, errNotUC20
 	}
@@ -235,7 +236,7 @@ func BootFlags(dev Device) ([]string, error) {
 // Only to be used on UC20+ systems with recovery systems.
 // TODO: should this accept a modeenv that was previously read from i.e.
 // devicestate manager?
-func nextBootFlags(dev Device) ([]string, error) {
+func nextBootFlags(dev snap.Device) ([]string, error) {
 	if !dev.HasModeenv() {
 		return nil, errNotUC20
 	}
@@ -251,7 +252,7 @@ func nextBootFlags(dev Device) ([]string, error) {
 // setNextBootFlags sets the boot flags for the next boot to take effect after
 // rebooting. This information always gets saved to the modeenv.
 // Only to be used on UC20+ systems with recovery systems.
-func setNextBootFlags(dev Device, rootDir string, flags []string) error {
+func setNextBootFlags(dev snap.Device, rootDir string, flags []string) error {
 	if !dev.HasModeenv() {
 		return errNotUC20
 	}

--- a/boot/model.go
+++ b/boot/model.go
@@ -26,6 +26,7 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/snap"
 )
 
 // DeviceChange handles a change of the underlying device. Specifically it can
@@ -33,7 +34,7 @@ import (
 // encryption keys will be resealed for both models. The device model file which
 // is measured during boot will be updated. The recovery systems that belong to
 // the old model will no longer be usable.
-func DeviceChange(from Device, to Device) error {
+func DeviceChange(from snap.Device, to snap.Device) error {
 	if !to.HasModeenv() {
 		// nothing useful happens on a non-UC20 system here
 		return nil

--- a/boot/model_test.go
+++ b/boot/model_test.go
@@ -43,8 +43,8 @@ import (
 type modelSuite struct {
 	baseBootenvSuite
 
-	oldUc20dev boot.Device
-	newUc20dev boot.Device
+	oldUc20dev snap.Device
+	newUc20dev snap.Device
 
 	runKernelBf      bootloader.BootFile
 	recoveryKernelBf bootloader.BootFile

--- a/boot/systems.go
+++ b/boot/systems.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/strutil"
 )
 
@@ -41,7 +42,7 @@ func dropFromRecoverySystemsList(systemsList []string, systemLabel string) (newL
 // the try model in the modeenv state file, then reseals and clears related
 // bootloader variables. An empty system label can be passed when the boot
 // variables state is inconsistent.
-func ClearTryRecoverySystem(dev Device, systemLabel string) error {
+func ClearTryRecoverySystem(dev snap.Device, systemLabel string) error {
 	if !dev.HasModeenv() {
 		return fmt.Errorf("internal error: recovery systems can only be used on UC20")
 	}
@@ -102,7 +103,7 @@ func ClearTryRecoverySystem(dev Device, systemLabel string) error {
 // optionally sets a try model, if the device model is different from the
 // current one, which typically can happen during a remodel. Once done, the
 // caller should request switching to the given recovery system.
-func SetTryRecoverySystem(dev Device, systemLabel string) (err error) {
+func SetTryRecoverySystem(dev snap.Device, systemLabel string) (err error) {
 	if !dev.HasModeenv() {
 		return fmt.Errorf("internal error: recovery systems can only be used on UC20")
 	}
@@ -312,7 +313,7 @@ func observeSuccessfulSystems(m *Modeenv) (*Modeenv, error) {
 // no recovery system has been tried, the outcome will be
 // TryRecoverySystemOutcomeNoneTried. The caller is responsible for clearing the
 // bootenv once the status bas been properly acted on.
-func InspectTryRecoverySystemOutcome(dev Device) (outcome TryRecoverySystemOutcome, label string, err error) {
+func InspectTryRecoverySystemOutcome(dev snap.Device) (outcome TryRecoverySystemOutcome, label string, err error) {
 	opts := &bootloader.Options{
 		// setup the recovery bootloader
 		Role: bootloader.RoleRecovery,
@@ -377,7 +378,7 @@ func InspectTryRecoverySystemOutcome(dev Device) (outcome TryRecoverySystemOutco
 // provided list of tried systems should contain the system in question. If the
 // system uses encryption, the keys will updated state. If resealing fails, an
 // attempt to restore the previous state is made
-func PromoteTriedRecoverySystem(dev Device, systemLabel string, triedSystems []string) (err error) {
+func PromoteTriedRecoverySystem(dev snap.Device, systemLabel string, triedSystems []string) (err error) {
 	if !dev.HasModeenv() {
 		return fmt.Errorf("internal error: recovery systems can only be used on UC20")
 	}
@@ -419,7 +420,7 @@ func PromoteTriedRecoverySystem(dev Device, systemLabel string, triedSystems []s
 // DropRecoverySystem drops a provided system from the list of good and current
 // recovery systems, updates the modeenv and reseals the keys a needed. Note,
 // this call *DOES NOT* clear the boot environment variables.
-func DropRecoverySystem(dev Device, systemLabel string) error {
+func DropRecoverySystem(dev snap.Device, systemLabel string) error {
 	if !dev.HasModeenv() {
 		return fmt.Errorf("internal error: recovery systems can only be used on UC20")
 	}

--- a/boot/systems_test.go
+++ b/boot/systems_test.go
@@ -51,7 +51,7 @@ func (s *baseSystemsSuite) SetUpTest(c *C) {
 type systemsSuite struct {
 	baseSystemsSuite
 
-	uc20dev boot.Device
+	uc20dev snap.Device
 
 	runKernelBf      bootloader.BootFile
 	recoveryKernelBf bootloader.BootFile

--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -24,7 +24,6 @@ import (
 	"io"
 
 	"github.com/snapcore/snapd/asserts"
-	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/cmd/snaplock/runinhibit"
 	"github.com/snapcore/snapd/dirs"
@@ -71,23 +70,23 @@ type StoreService interface {
 
 type managerBackend interface {
 	// install related
-	SetupSnap(snapFilePath, instanceName string, si *snap.SideInfo, dev boot.Device, opts *backend.SetupSnapOptions, meter progress.Meter) (snap.Type, *backend.InstallRecord, error)
+	SetupSnap(snapFilePath, instanceName string, si *snap.SideInfo, dev snap.Device, opts *backend.SetupSnapOptions, meter progress.Meter) (snap.Type, *backend.InstallRecord, error)
 	CopySnapData(newSnap, oldSnap *snap.Info, meter progress.Meter, opts *dirs.SnapDirOptions) error
-	LinkSnap(info *snap.Info, dev boot.Device, linkCtx backend.LinkContext, tm timings.Measurer) (rebootRequired bool, err error)
+	LinkSnap(info *snap.Info, dev snap.Device, linkCtx backend.LinkContext, tm timings.Measurer) (rebootRequired bool, err error)
 	StartServices(svcs []*snap.AppInfo, disabledSvcs []string, meter progress.Meter, tm timings.Measurer) error
 	StopServices(svcs []*snap.AppInfo, reason snap.ServiceStopReason, meter progress.Meter, tm timings.Measurer) error
 	ServicesEnableState(info *snap.Info, meter progress.Meter) (map[string]bool, error)
 	QueryDisabledServices(info *snap.Info, pb progress.Meter) ([]string, error)
 
 	// the undoers for install
-	UndoSetupSnap(s snap.PlaceInfo, typ snap.Type, installRecord *backend.InstallRecord, dev boot.Device, meter progress.Meter) error
+	UndoSetupSnap(s snap.PlaceInfo, typ snap.Type, installRecord *backend.InstallRecord, dev snap.Device, meter progress.Meter) error
 	UndoCopySnapData(newSnap, oldSnap *snap.Info, meter progress.Meter, opts *dirs.SnapDirOptions) error
 	// cleanup
 	ClearTrashedData(oldSnap *snap.Info)
 
 	// remove related
 	UnlinkSnap(info *snap.Info, linkCtx backend.LinkContext, meter progress.Meter) error
-	RemoveSnapFiles(s snap.PlaceInfo, typ snap.Type, installRecord *backend.InstallRecord, dev boot.Device, meter progress.Meter) error
+	RemoveSnapFiles(s snap.PlaceInfo, typ snap.Type, installRecord *backend.InstallRecord, dev snap.Device, meter progress.Meter) error
 	RemoveSnapDir(s snap.PlaceInfo, hasOtherInstances bool) error
 	RemoveSnapData(info *snap.Info, opts *dirs.SnapDirOptions) error
 	RemoveSnapCommonData(info *snap.Info, opts *dirs.SnapDirOptions) error

--- a/overlord/snapstate/backend/link.go
+++ b/overlord/snapstate/backend/link.go
@@ -99,7 +99,7 @@ func hasFontConfigCache(info *snap.Info) bool {
 }
 
 // LinkSnap makes the snap available by generating wrappers and setting the current symlinks.
-func (b Backend) LinkSnap(info *snap.Info, dev boot.Device, linkCtx LinkContext, tm timings.Measurer) (rebootRequired bool, e error) {
+func (b Backend) LinkSnap(info *snap.Info, dev snap.Device, linkCtx LinkContext, tm timings.Measurer) (rebootRequired bool, e error) {
 	if info.Revision.Unset() {
 		return false, fmt.Errorf("cannot link snap %q with unset revision", info.InstanceName())
 	}

--- a/overlord/snapstate/backend/link_test.go
+++ b/overlord/snapstate/backend/link_test.go
@@ -30,7 +30,6 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/boot/boottest"
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/bootloader/bootloadertest"
@@ -511,7 +510,7 @@ func (s *linkCleanupSuite) TestLinkCleansUpDataDirAndSymlinksOnSymlinkFail(c *C)
 func (s *linkCleanupSuite) TestLinkRunsUpdateFontconfigCachesClassic(c *C) {
 	current := filepath.Join(s.info.MountDir(), "..", "current")
 
-	for _, dev := range []boot.Device{mockDev, mockClassicDev} {
+	for _, dev := range []snap.Device{mockDev, mockClassicDev} {
 		var updateFontconfigCaches int
 		restore := backend.MockUpdateFontconfigCaches(func() error {
 			c.Assert(osutil.FileExists(current), Equals, false)

--- a/overlord/snapstate/backend/setup.go
+++ b/overlord/snapstate/backend/setup.go
@@ -44,7 +44,7 @@ type SetupSnapOptions struct {
 }
 
 // SetupSnap does prepare and mount the snap for further processing.
-func (b Backend) SetupSnap(snapFilePath, instanceName string, sideInfo *snap.SideInfo, dev boot.Device, setupOpts *SetupSnapOptions, meter progress.Meter) (snapType snap.Type, installRecord *InstallRecord, err error) {
+func (b Backend) SetupSnap(snapFilePath, instanceName string, sideInfo *snap.SideInfo, dev snap.Device, setupOpts *SetupSnapOptions, meter progress.Meter) (snapType snap.Type, installRecord *InstallRecord, err error) {
 	if setupOpts == nil {
 		setupOpts = &SetupSnapOptions{}
 	}
@@ -111,7 +111,7 @@ func (b Backend) SetupSnap(snapFilePath, instanceName string, sideInfo *snap.Sid
 }
 
 // RemoveSnapFiles removes the snap files from the disk after unmounting the snap.
-func (b Backend) RemoveSnapFiles(s snap.PlaceInfo, typ snap.Type, installRecord *InstallRecord, dev boot.Device, meter progress.Meter) error {
+func (b Backend) RemoveSnapFiles(s snap.PlaceInfo, typ snap.Type, installRecord *InstallRecord, dev snap.Device, meter progress.Meter) error {
 	mountDir := s.MountDir()
 
 	// this also ensures that the mount unit stops
@@ -163,7 +163,7 @@ func (b Backend) RemoveSnapDir(s snap.PlaceInfo, hasOtherInstances bool) error {
 }
 
 // UndoSetupSnap undoes the work of SetupSnap using RemoveSnapFiles.
-func (b Backend) UndoSetupSnap(s snap.PlaceInfo, typ snap.Type, installRecord *InstallRecord, dev boot.Device, meter progress.Meter) error {
+func (b Backend) UndoSetupSnap(s snap.PlaceInfo, typ snap.Type, installRecord *InstallRecord, dev snap.Device, meter progress.Meter) error {
 	return b.RemoveSnapFiles(s, typ, installRecord, dev, meter)
 }
 

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -32,7 +32,6 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/cmd/snaplock/runinhibit"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
@@ -808,7 +807,7 @@ apps:
     before: [svc2]
 `
 
-func (f *fakeSnappyBackend) SetupSnap(snapFilePath, instanceName string, si *snap.SideInfo, dev boot.Device, opts *backend.SetupSnapOptions, p progress.Meter) (snap.Type, *backend.InstallRecord, error) {
+func (f *fakeSnappyBackend) SetupSnap(snapFilePath, instanceName string, si *snap.SideInfo, dev snap.Device, opts *backend.SetupSnapOptions, p progress.Meter) (snap.Type, *backend.InstallRecord, error) {
 	p.Notify("setup-snap")
 	revno := snap.R(0)
 	if si != nil {
@@ -945,7 +944,7 @@ func (f *fakeSnappyBackend) CopySnapData(newInfo, oldInfo *snap.Info, p progress
 	return f.maybeErrForLastOp()
 }
 
-func (f *fakeSnappyBackend) LinkSnap(info *snap.Info, dev boot.Device, linkCtx backend.LinkContext, tm timings.Measurer) (rebootRequired bool, err error) {
+func (f *fakeSnappyBackend) LinkSnap(info *snap.Info, dev snap.Device, linkCtx backend.LinkContext, tm timings.Measurer) (rebootRequired bool, err error) {
 	if info.MountDir() == f.linkSnapWaitTrigger {
 		f.linkSnapWaitCh <- 1
 		<-f.linkSnapWaitCh
@@ -1050,7 +1049,7 @@ func (f *fakeSnappyBackend) QueryDisabledServices(info *snap.Info, meter progres
 	return l, nil
 }
 
-func (f *fakeSnappyBackend) UndoSetupSnap(s snap.PlaceInfo, typ snap.Type, installRecord *backend.InstallRecord, dev boot.Device, p progress.Meter) error {
+func (f *fakeSnappyBackend) UndoSetupSnap(s snap.PlaceInfo, typ snap.Type, installRecord *backend.InstallRecord, dev snap.Device, p progress.Meter) error {
 	p.Notify("setup-snap")
 	f.appendOp(&fakeOp{
 		op:    "undo-setup-snap",
@@ -1089,7 +1088,7 @@ func (f *fakeSnappyBackend) UnlinkSnap(info *snap.Info, linkCtx backend.LinkCont
 	return f.maybeErrForLastOp()
 }
 
-func (f *fakeSnappyBackend) RemoveSnapFiles(s snap.PlaceInfo, typ snap.Type, installRecord *backend.InstallRecord, dev boot.Device, meter progress.Meter) error {
+func (f *fakeSnappyBackend) RemoveSnapFiles(s snap.PlaceInfo, typ snap.Type, installRecord *backend.InstallRecord, dev snap.Device, meter progress.Meter) error {
 	meter.Notify("remove-snap-files")
 	f.appendOp(&fakeOp{
 		op:    "remove-snap-files",

--- a/overlord/snapstate/devicectx.go
+++ b/overlord/snapstate/devicectx.go
@@ -21,8 +21,8 @@ package snapstate
 
 import (
 	"github.com/snapcore/snapd/asserts"
-	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
 )
 
 // A DeviceContext provides for operating as a given device and with
@@ -43,8 +43,8 @@ type DeviceContext interface {
 	// SystemMode returns the system  mode (run,install,recover,...).
 	SystemMode() string
 
-	// DeviceContext should be usable as boot.Device
-	boot.Device
+	// DeviceContext should be usable as snap.Device
+	snap.Device
 }
 
 // Hook setup by devicestate to pick a device context from state,

--- a/overlord/snapstate/policy.go
+++ b/overlord/snapstate/policy.go
@@ -14,7 +14,7 @@ import (
 type Policy interface {
 	// CanRemove verifies that a snap can be removed.
 	// If rev is not unset, check for removing only that revision.
-	CanRemove(st *state.State, snapst *SnapState, rev snap.Revision, dev boot.Device) error
+	CanRemove(st *state.State, snapst *SnapState, rev snap.Revision, dev snap.Device) error
 }
 
 var PolicyFor func(snap.Type, *asserts.Model) Policy = policyForUnset

--- a/overlord/snapstate/policy/base.go
+++ b/overlord/snapstate/policy/base.go
@@ -22,7 +22,6 @@ package policy
 import (
 	"sort"
 
-	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
@@ -32,7 +31,7 @@ type basePolicy struct {
 	modelBase string
 }
 
-func (p *basePolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev snap.Revision, dev boot.Device) error {
+func (p *basePolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev snap.Revision, dev snap.Device) error {
 	name := snapst.InstanceName()
 	if name == "" {
 		// not installed, or something. What are you even trying to do.

--- a/overlord/snapstate/policy/gadget.go
+++ b/overlord/snapstate/policy/gadget.go
@@ -20,7 +20,6 @@
 package policy
 
 import (
-	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
@@ -30,7 +29,7 @@ type gadgetPolicy struct {
 	modelGadget string
 }
 
-func (p *gadgetPolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev snap.Revision, dev boot.Device) error {
+func (p *gadgetPolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev snap.Revision, dev snap.Device) error {
 	name := snapst.InstanceName()
 	if name == "" {
 		// not installed, or something. What are you even trying to do.

--- a/overlord/snapstate/policy/kernel.go
+++ b/overlord/snapstate/policy/kernel.go
@@ -20,7 +20,6 @@
 package policy
 
 import (
-	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
@@ -30,7 +29,7 @@ type kernelPolicy struct {
 	modelKernel string
 }
 
-func (p *kernelPolicy) CanRemove(_ *state.State, snapst *snapstate.SnapState, rev snap.Revision, dev boot.Device) error {
+func (p *kernelPolicy) CanRemove(_ *state.State, snapst *snapstate.SnapState, rev snap.Revision, dev snap.Device) error {
 	name := snapst.InstanceName()
 	if name == "" {
 		// not installed, or something. What are you even trying to do.

--- a/overlord/snapstate/policy/os.go
+++ b/overlord/snapstate/policy/os.go
@@ -20,7 +20,6 @@
 package policy
 
 import (
-	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
@@ -30,7 +29,7 @@ type osPolicy struct {
 	modelBase string
 }
 
-func (p *osPolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev snap.Revision, dev boot.Device) error {
+func (p *osPolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev snap.Revision, dev snap.Device) error {
 	name := snapst.InstanceName()
 	if name == "" {
 		// not installed, or something. What are you even trying to do.

--- a/overlord/snapstate/policy/policy.go
+++ b/overlord/snapstate/policy/policy.go
@@ -49,11 +49,11 @@ func For(typ snap.Type, model *asserts.Model) snapstate.Policy {
 	}
 }
 
-func ephemeral(dev boot.Device) bool {
+func ephemeral(dev snap.Device) bool {
 	return !dev.RunMode()
 }
 
-func inUse(name string, rev snap.Revision, typ snap.Type, dev boot.Device) error {
+func inUse(name string, rev snap.Revision, typ snap.Type, dev snap.Device) error {
 	check, err := boot.InUse(typ, dev)
 	if err != nil {
 		return err
@@ -66,7 +66,7 @@ func inUse(name string, rev snap.Revision, typ snap.Type, dev boot.Device) error
 
 type appPolicy struct{}
 
-func (appPolicy) CanRemove(_ *state.State, snapst *snapstate.SnapState, rev snap.Revision, dev boot.Device) error {
+func (appPolicy) CanRemove(_ *state.State, snapst *snapstate.SnapState, rev snap.Revision, dev snap.Device) error {
 	if ephemeral(dev) {
 		return errEphemeralSnapsNotRemovalable
 	}

--- a/overlord/snapstate/policy/snapd.go
+++ b/overlord/snapstate/policy/snapd.go
@@ -20,7 +20,6 @@
 package policy
 
 import (
-	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
@@ -30,7 +29,7 @@ type snapdPolicy struct {
 	onClassic bool
 }
 
-func (p *snapdPolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev snap.Revision, dev boot.Device) error {
+func (p *snapdPolicy) CanRemove(st *state.State, snapst *snapstate.SnapState, rev snap.Revision, dev snap.Device) error {
 	name := snapst.InstanceName()
 	if name == "" {
 		// not installed, or something. What are you even trying to do.

--- a/snap/device.go
+++ b/snap/device.go
@@ -1,0 +1,37 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snap
+
+import "github.com/snapcore/snapd/asserts"
+
+// Device carries information about the device model and mode that is
+// relevant to boot and other packages. Note snapstate.DeviceContext implements
+// this, and that's the expected use case.
+type Device interface {
+	RunMode() bool
+	Classic() bool
+
+	Kernel() string
+	Base() string
+
+	HasModeenv() bool
+
+	Model() *asserts.Model
+}


### PR DESCRIPTION
This is a purely mechanical change because it touches so many files, the real
interesting parts we need that prompted this will be followups.