### PR TITLE
o/snapstate: add ~/Snap init related to backend

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -151,9 +151,9 @@ const (
 	// HiddenSnapDataHomeDir is an experimental hidden directory for snap data
 	HiddenSnapDataHomeDir = ".snap/data"
 
-	// ExposedSnapDir is the directory where snaps should place user-facing
+	// ExposedSnapHomeDir is the directory where snaps should place user-facing
 	// data after ~/snap has been migrated to ~/.snap
-	ExposedSnapDir = "Snap"
+	ExposedSnapHomeDir = "Snap"
 
 	// LocalInstallBlobTempPrefix is used by local install code:
 	// * in daemon to spool the snap file to <SnapBlobDir>/<LocalInstallBlobTempPrefix>*

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -174,7 +174,8 @@ type SnapDirOptions struct {
 	HiddenSnapDataDir bool
 
 	// MigratedToExposedHome determines if the snap's directory in ~/Snap has been
-	// initialized.
+	// initialized with the contents of the snap's previous home (i.e., the
+	// revisioned data directory).
 	MigratedToExposedHome bool
 }
 

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -145,11 +145,15 @@ const (
 	CoreLibExecDir   = "/usr/lib/snapd"
 	CoreSnapMountDir = "/snap"
 
-	// Directory with snap data inside user's home
+	// UserHomeSnapDir is the directory with snap data inside user's home
 	UserHomeSnapDir = "snap"
 
 	// HiddenSnapDataHomeDir is an experimental hidden directory for snap data
 	HiddenSnapDataHomeDir = ".snap/data"
+
+	// ExposedSnapDir is the directory where snaps should place user-facing
+	// data after ~/snap has been migrated to ~/.snap
+	ExposedSnapDir = "Snap"
 
 	// LocalInstallBlobTempPrefix is used by local install code:
 	// * in daemon to spool the snap file to <SnapBlobDir>/<LocalInstallBlobTempPrefix>*
@@ -165,8 +169,13 @@ var (
 )
 
 type SnapDirOptions struct {
-	// HiddenSnapDataDir determines if the snaps' data is in ~/.snap/data instead of ~/snap
+	// HiddenSnapDataDir determines if the snaps' data is in ~/.snap/data instead
+	// of ~/snap
 	HiddenSnapDataDir bool
+
+	// MigratedToExposedHome determines if the snap's directory in ~/Snap has been
+	// initialized.
+	MigratedToExposedHome bool
 }
 
 func init() {

--- a/osutil/cp.go
+++ b/osutil/cp.go
@@ -63,7 +63,7 @@ func doOpenFile(name string, flag int, perm os.FileMode) (fileish, error) {
 func CopyFile(src, dst string, flags CopyFlag) (err error) {
 	if flags&CopyFlagPreserveAll != 0 {
 		// Our native copy code does not preserve all attributes
-		// (yet). If the user needs this functionatlity we just
+		// (yet). If the user needs this functionality we just
 		// fallback to use the system's "cp" binary to do the copy.
 		if err := runCpPreserveAll(src, dst, "copy all"); err != nil {
 			return err

--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -112,4 +112,6 @@ type managerBackend interface {
 	// ~/.snap/data migration related
 	HideSnapData(snapName string) error
 	UndoHideSnapData(snapName string) error
+	InitExposedSnapHome(snapName string, rev snap.Revision) error
+	RemoveExposedSnapHome(snapName string) error
 }

--- a/overlord/snapstate/backend/copydata.go
+++ b/overlord/snapstate/backend/copydata.go
@@ -239,3 +239,91 @@ var removeIfEmpty = func(dir string) error {
 
 	return os.Remove(dir)
 }
+
+var maybeFailForTesting func() error
+
+// InitExposedSnapHome creates and initializes ~/Snap/<snapName> based on the
+// specified revision. Must be called after the snap has been migrated.
+func (b Backend) InitExposedSnapHome(snapName string, rev snap.Revision) (err error) {
+	opts := &dirs.SnapDirOptions{HiddenSnapDataDir: true}
+
+	users, err := allUsers(opts)
+	if err != nil {
+		return err
+	}
+
+	for _, usr := range users {
+		uid, gid, err := osutil.UidGid(usr)
+		if err != nil {
+			return err
+		}
+
+		if maybeFailForTesting != nil {
+			osutil.MustBeTestBinary("'maybeFailForTesting' should only be used in tests")
+			if err := maybeFailForTesting(); err != nil {
+				return err
+			}
+		}
+
+		newUserHome := snap.UserExposedHomeDir(usr.HomeDir, snapName)
+		if err := osutil.MkdirAllChown(newUserHome, 0700, uid, gid); err != nil {
+			return fmt.Errorf("cannot create %q: %v", newUserHome, err)
+		}
+
+		userData := snap.UserDataDir(usr.HomeDir, snapName, rev, opts)
+		entries, err := ioutil.ReadDir(userData)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				// there's nothing to copy into ~/Snap/<snap> (like on a fresh install)
+				continue
+			}
+
+			return err
+		}
+		for _, e := range entries {
+			src := filepath.Join(userData, e.Name())
+			dst := filepath.Join(newUserHome, e.Name())
+
+			if err := osutil.CopyFile(src, dst, osutil.CopyFlagPreserveAll|osutil.CopyFlagSync); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// RemoveExposedSnapHome removes the ~/Snap dirs.
+func (b Backend) RemoveExposedSnapHome(snapName string) error {
+	opts := &dirs.SnapDirOptions{HiddenSnapDataDir: true}
+
+	var firstErr error
+	handle := func(err error) {
+		if firstErr == nil {
+			firstErr = err
+		} else {
+			logger.Noticef(err.Error())
+		}
+	}
+
+	users, err := allUsers(opts)
+	if err != nil {
+		return err
+	}
+
+	for _, usr := range users {
+		newUserHome := snap.UserExposedHomeDir(usr.HomeDir, snapName)
+		if err := os.RemoveAll(newUserHome); err != nil {
+			handle(fmt.Errorf("cannot remove %q: %v", newUserHome, err))
+			continue
+		}
+
+		exposedSnapDir := filepath.Dir(newUserHome)
+		if err := removeIfEmpty(exposedSnapDir); err != nil {
+			handle(fmt.Errorf("cannot remove %q: %v", exposedSnapDir, err))
+			continue
+		}
+	}
+
+	return firstErr
+}

--- a/overlord/snapstate/backend/copydata_test.go
+++ b/overlord/snapstate/backend/copydata_test.go
@@ -904,3 +904,169 @@ func (s *copydataSuite) TestUndoHideKeepGoingPreserveFirstErr(c *C) {
 	// the undo keeps going and logs the next error
 	c.Assert(buf, Matches, `.*cannot remove dir ".*": other error\n`)
 }
+
+func (s *copydataSuite) TestInitSnapUserHome(c *C) {
+	homeDir := filepath.Join(s.tempdir, "user")
+	usr, err := user.Current()
+	c.Assert(err, IsNil)
+	usr.HomeDir = homeDir
+
+	restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+		return []*user.User{usr}, nil
+	})
+	defer restore()
+
+	snapName := "some-snap"
+	rev, err := snap.ParseRevision("2")
+	c.Assert(err, IsNil)
+
+	opts := &dirs.SnapDirOptions{HiddenSnapDataDir: true}
+	revDir := snap.UserDataDir(usr.HomeDir, snapName, rev, opts)
+	c.Assert(os.MkdirAll(revDir, 0700), IsNil)
+
+	filePath := filepath.Join(revDir, "file")
+	c.Assert(ioutil.WriteFile(filePath, []byte("stuff"), 0664), IsNil)
+
+	c.Assert(s.be.InitExposedSnapHome(snapName, rev), IsNil)
+
+	expectedFile := filepath.Join(homeDir, dirs.ExposedSnapDir, snapName, "file")
+	data, err := ioutil.ReadFile(expectedFile)
+	c.Assert(err, IsNil)
+	c.Check(string(data), Equals, "stuff")
+
+	exists, isReg, err := osutil.RegularFileExists(filePath)
+	c.Assert(err, IsNil)
+	c.Check(exists, Equals, true)
+	c.Check(isReg, Equals, true)
+}
+
+func (s *copydataSuite) TestInitSnapFailOnFirstErr(c *C) {
+	usr1, err := user.Current()
+	c.Assert(err, IsNil)
+	usr1.HomeDir = filepath.Join(s.tempdir, "user1")
+
+	usr2, err := user.Current()
+	c.Assert(err, IsNil)
+	usr2.HomeDir = filepath.Join(s.tempdir, "user2")
+
+	restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+		return []*user.User{usr1, usr2}, nil
+	})
+	defer restore()
+
+	restore = backend.MockInitSnapMaybeFailForTesting(func() error {
+		return errors.New("boom")
+	})
+	defer restore()
+
+	snapName := "some-snap"
+	rev, err := snap.ParseRevision("2")
+	c.Assert(err, IsNil)
+
+	c.Assert(s.be.InitExposedSnapHome(snapName, rev), ErrorMatches, "boom")
+
+	exists, _, err := osutil.DirExists(filepath.Join(usr1.HomeDir, dirs.ExposedSnapDir))
+	c.Assert(err, IsNil)
+	c.Check(exists, Equals, false)
+
+	exists, _, err = osutil.DirExists(filepath.Join(usr2.HomeDir, dirs.ExposedSnapDir))
+	c.Assert(err, IsNil)
+	c.Check(exists, Equals, false)
+}
+
+func (s *copydataSuite) TestInitSnapNothingToCopy(c *C) {
+	usr, err := user.Current()
+	c.Assert(err, IsNil)
+	usr.HomeDir = filepath.Join(s.tempdir, "user")
+
+	restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+		return []*user.User{usr}, nil
+	})
+	defer restore()
+
+	snapName := "some-snap"
+	rev, err := snap.ParseRevision("2")
+	c.Assert(err, IsNil)
+
+	c.Assert(s.be.InitExposedSnapHome(snapName, rev), IsNil)
+
+	newHomeDir := filepath.Join(usr.HomeDir, dirs.ExposedSnapDir, snapName)
+	exists, _, err := osutil.DirExists(newHomeDir)
+	c.Assert(err, IsNil)
+	c.Check(exists, Equals, true)
+
+	entries, err := ioutil.ReadDir(newHomeDir)
+	c.Assert(err, IsNil)
+	c.Check(entries, HasLen, 0)
+}
+
+func (s *copydataSuite) TestRemoveExposedHome(c *C) {
+	usr, err := user.Current()
+	c.Assert(err, IsNil)
+	usr.HomeDir = filepath.Join(s.tempdir, "user")
+
+	restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+		return []*user.User{usr}, nil
+	})
+	defer restore()
+
+	snapName := "some-snap"
+	exposedDir := filepath.Join(usr.HomeDir, dirs.ExposedSnapDir, snapName)
+	c.Assert(os.MkdirAll(exposedDir, 0700), IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(exposedDir, "file"), []byte("foo"), 0600), IsNil)
+
+	c.Assert(s.be.RemoveExposedSnapHome(snapName), IsNil)
+
+	exists, _, err := osutil.DirExists(exposedDir)
+	c.Assert(err, IsNil)
+	c.Assert(exists, Equals, false)
+
+	baseExposedDir := filepath.Base(exposedDir)
+	exists, _, err = osutil.DirExists(baseExposedDir)
+	c.Assert(err, IsNil)
+	c.Assert(exists, Equals, false)
+}
+
+func (s *copydataSuite) TestRemoveExposedKeepGoingOnFail(c *C) {
+	firstTime := true
+	restore := backend.MockRemoveIfEmpty(func(dir string) error {
+		var err error
+		if firstTime {
+			err = errors.New("first error")
+			firstTime = false
+		} else {
+			err = errors.New("other error")
+		}
+
+		return err
+	})
+	defer restore()
+
+	snapName := "some-snap"
+	var usrs []*user.User
+	for _, usrName := range []string{"usr1", "usr2"} {
+		homedir := filepath.Join(s.tempdir, usrName)
+		usr, err := user.Current()
+		c.Assert(err, IsNil)
+		usr.HomeDir = homedir
+
+		exposedDir := filepath.Join(homedir, dirs.ExposedSnapDir, snapName)
+		c.Assert(os.MkdirAll(exposedDir, 0700), IsNil)
+		c.Assert(ioutil.WriteFile(filepath.Join(exposedDir, "file"), []byte("foo"), 0700), IsNil)
+		usrs = append(usrs, usr)
+	}
+
+	restUsers := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+		return usrs, nil
+	})
+	defer restUsers()
+
+	buf, restLogger := logger.MockLogger()
+	defer restLogger()
+
+	err := s.be.RemoveExposedSnapHome(snapName)
+	// the first error is returned
+	c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot remove %q: first error`, filepath.Join(s.tempdir, "usr1", "Snap")))
+	// second error is logged
+	c.Assert(buf, Matches, fmt.Sprintf(`.*cannot remove %q: other error\n`, filepath.Join(s.tempdir, "usr2", "Snap")))
+}

--- a/overlord/snapstate/backend/copydata_test.go
+++ b/overlord/snapstate/backend/copydata_test.go
@@ -932,7 +932,7 @@ func (s *copydataSuite) TestInitSnapUserHome(c *C) {
 
 	c.Assert(s.be.InitExposedSnapHome(snapName, rev), IsNil)
 
-	expectedFile := filepath.Join(homeDir, dirs.ExposedSnapDir, snapName, "file")
+	expectedFile := filepath.Join(homeDir, dirs.ExposedSnapHomeDir, snapName, "file")
 	data, err := ioutil.ReadFile(expectedFile)
 	c.Assert(err, IsNil)
 	c.Check(string(data), Equals, "stuff")
@@ -942,7 +942,7 @@ func (s *copydataSuite) TestInitSnapUserHome(c *C) {
 	c.Check(exists, Equals, true)
 	c.Check(isReg, Equals, true)
 
-	expectedDir := filepath.Join(homeDir, dirs.ExposedSnapDir, snapName, "dir")
+	expectedDir := filepath.Join(homeDir, dirs.ExposedSnapHomeDir, snapName, "dir")
 	exists, isDir, err := osutil.DirExists(expectedDir)
 	c.Assert(err, IsNil)
 	c.Check(exists, Equals, true)
@@ -979,11 +979,11 @@ func (s *copydataSuite) TestInitSnapFailOnFirstErr(c *C) {
 
 	c.Assert(s.be.InitExposedSnapHome(snapName, rev), ErrorMatches, ".*: boom")
 
-	exists, _, err := osutil.DirExists(filepath.Join(usr1.HomeDir, dirs.ExposedSnapDir))
+	exists, _, err := osutil.DirExists(filepath.Join(usr1.HomeDir, dirs.ExposedSnapHomeDir))
 	c.Assert(err, IsNil)
 	c.Check(exists, Equals, false)
 
-	exists, _, err = osutil.DirExists(filepath.Join(usr2.HomeDir, dirs.ExposedSnapDir))
+	exists, _, err = osutil.DirExists(filepath.Join(usr2.HomeDir, dirs.ExposedSnapHomeDir))
 	c.Assert(err, IsNil)
 	c.Check(exists, Equals, false)
 }
@@ -1004,7 +1004,7 @@ func (s *copydataSuite) TestInitSnapNothingToCopy(c *C) {
 
 	c.Assert(s.be.InitExposedSnapHome(snapName, rev), IsNil)
 
-	newHomeDir := filepath.Join(usr.HomeDir, dirs.ExposedSnapDir, snapName)
+	newHomeDir := filepath.Join(usr.HomeDir, dirs.ExposedSnapHomeDir, snapName)
 	exists, _, err := osutil.DirExists(newHomeDir)
 	c.Assert(err, IsNil)
 	c.Check(exists, Equals, true)
@@ -1025,7 +1025,7 @@ func (s *copydataSuite) TestRemoveExposedHome(c *C) {
 	defer restore()
 
 	snapName := "some-snap"
-	exposedDir := filepath.Join(usr.HomeDir, dirs.ExposedSnapDir, snapName)
+	exposedDir := filepath.Join(usr.HomeDir, dirs.ExposedSnapHomeDir, snapName)
 	c.Assert(os.MkdirAll(exposedDir, 0700), IsNil)
 	c.Assert(ioutil.WriteFile(filepath.Join(exposedDir, "file"), []byte("foo"), 0600), IsNil)
 
@@ -1064,7 +1064,7 @@ func (s *copydataSuite) TestRemoveExposedKeepGoingOnFail(c *C) {
 		c.Assert(err, IsNil)
 		usr.HomeDir = homedir
 
-		exposedDir := filepath.Join(homedir, dirs.ExposedSnapDir, snapName)
+		exposedDir := filepath.Join(homedir, dirs.ExposedSnapHomeDir, snapName)
 		c.Assert(os.MkdirAll(exposedDir, 0700), IsNil)
 		c.Assert(ioutil.WriteFile(filepath.Join(exposedDir, "file"), []byte("foo"), 0700), IsNil)
 		usrs = append(usrs, usr)

--- a/overlord/snapstate/backend/copydata_test.go
+++ b/overlord/snapstate/backend/copydata_test.go
@@ -927,6 +927,8 @@ func (s *copydataSuite) TestInitSnapUserHome(c *C) {
 
 	filePath := filepath.Join(revDir, "file")
 	c.Assert(ioutil.WriteFile(filePath, []byte("stuff"), 0664), IsNil)
+	dirPath := filepath.Join(revDir, "dir")
+	c.Assert(os.Mkdir(dirPath, 0775), IsNil)
 
 	c.Assert(s.be.InitExposedSnapHome(snapName, rev), IsNil)
 
@@ -939,6 +941,17 @@ func (s *copydataSuite) TestInitSnapUserHome(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(exists, Equals, true)
 	c.Check(isReg, Equals, true)
+
+	expectedDir := filepath.Join(homeDir, dirs.ExposedSnapDir, snapName, "dir")
+	exists, isDir, err := osutil.DirExists(expectedDir)
+	c.Assert(err, IsNil)
+	c.Check(exists, Equals, true)
+	c.Check(isDir, Equals, true)
+
+	exists, isDir, err = osutil.DirExists(dirPath)
+	c.Assert(err, IsNil)
+	c.Check(exists, Equals, true)
+	c.Check(isDir, Equals, true)
 }
 
 func (s *copydataSuite) TestInitSnapFailOnFirstErr(c *C) {

--- a/overlord/snapstate/backend/copydata_test.go
+++ b/overlord/snapstate/backend/copydata_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/osutil/sys"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/snap"
@@ -954,7 +955,7 @@ func (s *copydataSuite) TestInitSnapFailOnFirstErr(c *C) {
 	})
 	defer restore()
 
-	restore = backend.MockInitSnapMaybeFailForTesting(func() error {
+	restore = backend.MockMkdirAllChown(func(string, os.FileMode, sys.UserID, sys.GroupID) error {
 		return errors.New("boom")
 	})
 	defer restore()
@@ -963,7 +964,7 @@ func (s *copydataSuite) TestInitSnapFailOnFirstErr(c *C) {
 	rev, err := snap.ParseRevision("2")
 	c.Assert(err, IsNil)
 
-	c.Assert(s.be.InitExposedSnapHome(snapName, rev), ErrorMatches, "boom")
+	c.Assert(s.be.InitExposedSnapHome(snapName, rev), ErrorMatches, ".*: boom")
 
 	exists, _, err := osutil.DirExists(filepath.Join(usr1.HomeDir, dirs.ExposedSnapDir))
 	c.Assert(err, IsNil)

--- a/overlord/snapstate/backend/export_test.go
+++ b/overlord/snapstate/backend/export_test.go
@@ -20,10 +20,12 @@
 package backend
 
 import (
+	"os"
 	"os/exec"
 	"os/user"
 
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil/sys"
 )
 
 var (
@@ -64,10 +66,10 @@ func MockRemoveIfEmpty(f func(dir string) error) func() {
 	}
 }
 
-func MockInitSnapMaybeFailForTesting(f func() error) func() {
-	old := maybeFailForTesting
-	maybeFailForTesting = f
+func MockMkdirAllChown(f func(string, os.FileMode, sys.UserID, sys.GroupID) error) func() {
+	old := mkdirAllChown
+	mkdirAllChown = f
 	return func() {
-		maybeFailForTesting = old
+		mkdirAllChown = old
 	}
 }

--- a/overlord/snapstate/backend/export_test.go
+++ b/overlord/snapstate/backend/export_test.go
@@ -54,7 +54,6 @@ func MockAllUsers(f func(options *dirs.SnapDirOptions) ([]*user.User, error)) fu
 	return func() {
 		allUsers = old
 	}
-
 }
 
 func MockRemoveIfEmpty(f func(dir string) error) func() {
@@ -62,5 +61,13 @@ func MockRemoveIfEmpty(f func(dir string) error) func() {
 	removeIfEmpty = f
 	return func() {
 		removeIfEmpty = old
+	}
+}
+
+func MockInitSnapMaybeFailForTesting(f func() error) func() {
+	old := maybeFailForTesting
+	maybeFailForTesting = f
+	return func() {
+		maybeFailForTesting = old
 	}
 }

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -1249,6 +1249,16 @@ func (f *fakeSnappyBackend) UndoHideSnapData(snapName string) error {
 	return f.maybeErrForLastOp()
 }
 
+func (f *fakeSnappyBackend) InitExposedSnapHome(snapName string, rev snap.Revision) error {
+	f.appendOp(&fakeOp{op: "init-exposed-snap-home", name: snapName})
+	return f.maybeErrForLastOp()
+}
+
+func (f *fakeSnappyBackend) RemoveExposedSnapHome(snapName string) error {
+	f.appendOp(&fakeOp{op: "rm-exposed-snap-home", name: snapName})
+	return f.maybeErrForLastOp()
+}
+
 func (f *fakeSnappyBackend) appendOp(op *fakeOp) {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/snap/info.go
+++ b/snap/info.go
@@ -229,8 +229,8 @@ func UserSnapDir(home string, name string, opts *dirs.SnapDirOptions) string {
 }
 
 // UserExposedHomeDir returns the snap's directory in the exposed home dir.
-func UserExposedHomeDir(home string, name string) string {
-	return filepath.Join(home, dirs.ExposedSnapDir, name)
+func UserExposedHomeDir(home string, snapName string) string {
+	return filepath.Join(home, dirs.ExposedSnapDir, snapName)
 }
 
 // UserXdgRuntimeDir returns the user-specific XDG_RUNTIME_DIR directory for

--- a/snap/info.go
+++ b/snap/info.go
@@ -228,6 +228,11 @@ func UserSnapDir(home string, name string, opts *dirs.SnapDirOptions) string {
 	return filepath.Join(home, snapDataDir(opts), name)
 }
 
+// UserExposedHomeDir returns the snap's directory in the exposed home dir.
+func UserExposedHomeDir(home string, name string) string {
+	return filepath.Join(home, dirs.ExposedSnapDir, name)
+}
+
 // UserXdgRuntimeDir returns the user-specific XDG_RUNTIME_DIR directory for
 // given snap name. The name can be either a snap name or snap instance name.
 func UserXdgRuntimeDir(euid sys.UserID, name string) string {
@@ -526,11 +531,17 @@ func (s *Info) UserCommonDataDir(home string, opts *dirs.SnapDirOptions) string 
 	return UserCommonDataDir(home, s.InstanceName(), opts)
 }
 
+// UserExposedHomeDir returns the new upper-case snap directory in the user home.
+func (s *Info) UserExposedHomeDir(home string) string {
+	return filepath.Join(home, dirs.ExposedSnapDir, s.InstanceName())
+}
+
 // CommonDataDir returns the data directory common across revisions of the snap.
 func (s *Info) CommonDataDir() string {
 	return CommonDataDir(s.InstanceName())
 }
 
+// DataHomeGlob returns the globbing expression for the snap directories in use
 func DataHomeGlob(opts *dirs.SnapDirOptions) string {
 	if opts == nil {
 		opts = &dirs.SnapDirOptions{}

--- a/snap/info.go
+++ b/snap/info.go
@@ -230,7 +230,7 @@ func UserSnapDir(home string, name string, opts *dirs.SnapDirOptions) string {
 
 // UserExposedHomeDir returns the snap's directory in the exposed home dir.
 func UserExposedHomeDir(home string, snapName string) string {
-	return filepath.Join(home, dirs.ExposedSnapDir, snapName)
+	return filepath.Join(home, dirs.ExposedSnapHomeDir, snapName)
 }
 
 // UserXdgRuntimeDir returns the user-specific XDG_RUNTIME_DIR directory for
@@ -533,7 +533,7 @@ func (s *Info) UserCommonDataDir(home string, opts *dirs.SnapDirOptions) string 
 
 // UserExposedHomeDir returns the new upper-case snap directory in the user home.
 func (s *Info) UserExposedHomeDir(home string) string {
-	return filepath.Join(home, dirs.ExposedSnapDir, s.InstanceName())
+	return filepath.Join(home, dirs.ExposedSnapHomeDir, s.InstanceName())
 }
 
 // CommonDataDir returns the data directory common across revisions of the snap.


### PR DESCRIPTION
Adds backend functions related to ~/Snap initialization and removal.