### PR TITLE
gadget: add searchForVolumeWithTraits + tests

### DIFF
--- a/gadget/export_test.go
+++ b/gadget/export_test.go
@@ -59,6 +59,8 @@ var (
 	GadgetVolumeConsumesOneKernelUpdateAsset = gadgetVolumeConsumesOneKernelUpdateAsset
 
 	OnDiskStructureIsLikelyImplicitSystemDataRole = onDiskStructureIsLikelyImplicitSystemDataRole
+
+	SearchForVolumeWithTraits = searchForVolumeWithTraits
 )
 
 func MockEvalSymlinks(mock func(path string) (string, error)) (restore func()) {

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -428,6 +428,9 @@ func AllDiskVolumeDeviceTraits(allLaidOutVols map[string]*LaidOutVolume, optsPer
 		// traits for it, this will also validate concretely that the
 		// device we picked and the volume are compatible
 		opts := optsPerVolume[name]
+		if opts == nil {
+			opts = &DiskVolumeValidationOptions{}
+		}
 		traits, err := DiskTraitsFromDeviceAndValidate(vol, dev, opts)
 		if err != nil {
 			return nil, fmt.Errorf("cannot gather disk traits for device %s to use with volume %s: %v", dev, name, err)

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -133,7 +133,7 @@ func searchForVolumeWithTraits(laidOutVol *LaidOutVolume, traits DiskVolumeDevic
 	// iterate over the different traits, validating whether the resulting disk
 	// actually exists and matches the volume we have in the gadget.yaml
 
-	checkCandidateDisk := func(candidate disks.Disk, method string, providedErr error) bool {
+	isCandidateCompatible := func(candidate disks.Disk, method string, providedErr error) bool {
 		if providedErr != nil {
 			if candidate != nil {
 				logger.Debugf("candidate disk %s not appropriate for volume %s because err: %v", candidate.KernelDeviceNode(), vol.Name, providedErr)
@@ -171,7 +171,7 @@ func searchForVolumeWithTraits(laidOutVol *LaidOutVolume, traits DiskVolumeDevic
 	// first try the kernel device path if it is set
 	if traits.OriginalDevicePath != "" {
 		disk, err := disks.DiskFromDevicePath(traits.OriginalDevicePath)
-		if ok := checkCandidateDisk(disk, "device path", err); ok {
+		if isCandidateCompatible(disk, "device path", err) {
 			return disk, nil
 		}
 	}
@@ -179,7 +179,7 @@ func searchForVolumeWithTraits(laidOutVol *LaidOutVolume, traits DiskVolumeDevic
 	// next try the kernel device node name
 	if traits.OriginalKernelPath != "" {
 		disk, err := disks.DiskFromDeviceName(traits.OriginalKernelPath)
-		if ok := checkCandidateDisk(disk, "device name", err); ok {
+		if isCandidateCompatible(disk, "device name", err) {
 			return disk, nil
 		}
 	}
@@ -195,7 +195,7 @@ func searchForVolumeWithTraits(laidOutVol *LaidOutVolume, traits DiskVolumeDevic
 				if blockDevDisk.DiskID() == traits.DiskID {
 					// found the block device for this Disk ID, get the
 					// disks.Disk for it
-					if ok := checkCandidateDisk(blockDevDisk, "disk ID", err); ok {
+					if isCandidateCompatible(blockDevDisk, "disk ID", err) {
 						return blockDevDisk, nil
 					}
 
@@ -217,7 +217,7 @@ func searchForVolumeWithTraits(laidOutVol *LaidOutVolume, traits DiskVolumeDevic
 	// structures to match a structure we measured previously to find a on disk
 	// device and then find a disk from that device and see if it matches
 
-	return nil, fmt.Errorf("could not find physical disk laid out to map with volume %s", vol.Name)
+	return nil, fmt.Errorf("cannot find physical disk laid out to map with volume %s", vol.Name)
 }
 
 // IsCreatableAtInstall returns whether the gadget structure would be created at

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -124,6 +124,102 @@ type ContentUpdateObserver interface {
 	Canceled() error
 }
 
+func searchForVolumeWithTraits(laidOutVol *LaidOutVolume, traits DiskVolumeDeviceTraits, validateOpts *DiskVolumeValidationOptions) (disks.Disk, error) {
+	if validateOpts == nil {
+		validateOpts = &DiskVolumeValidationOptions{}
+	}
+
+	vol := laidOutVol.Volume
+	// iterate over the different traits, validating whether the resulting disk
+	// actually exists and matches the volume we have in the gadget.yaml
+
+	checkCandidateDisk := func(candidate disks.Disk, method string, providedErr error) bool {
+		if providedErr != nil {
+			if candidate != nil {
+				logger.Debugf("candidate disk %s not appropriate for volume %s because err: %v", candidate.KernelDeviceNode(), vol.Name, providedErr)
+				return false
+			}
+			logger.Debugf("cannot locate disk for volume %s with method %s because err: %v", vol.Name, method, providedErr)
+
+			return false
+		}
+		diskLayout, onDiskErr := OnDiskVolumeFromDevice(candidate.KernelDeviceNode())
+		if onDiskErr != nil {
+			// unexpected in reality, we already called one of
+			// DiskFromDeviceName or DiskFromDevicePath to get this reference,
+			// so it's unclear how those methods could return a disk that
+			// OnDiskVolumeFromDevice is unhappy about
+			logger.Debugf("cannot find on disk volume from candidate disk %s: %v", candidate.KernelDeviceNode(), onDiskErr)
+			return false
+		}
+		// then try to validate it by laying out the volume
+		opts := &EnsureLayoutCompatibilityOptions{
+			AssumeCreatablePartitionsCreated: true,
+			AllowImplicitSystemData:          validateOpts.AllowImplicitSystemData,
+			ExpectedStructureEncryption:      validateOpts.ExpectedStructureEncryption,
+		}
+		ensureErr := EnsureLayoutCompatibility(laidOutVol, diskLayout, opts)
+		if ensureErr != nil {
+			logger.Debugf("candidate disk %s not appropriate for volume %s due to incompatibility: %v", candidate.KernelDeviceNode(), vol.Name, ensureErr)
+			return false
+		}
+
+		// success, we found it
+		return true
+	}
+
+	// first try the kernel device path if it is set
+	if traits.OriginalDevicePath != "" {
+		disk, err := disks.DiskFromDevicePath(traits.OriginalDevicePath)
+		if ok := checkCandidateDisk(disk, "device path", err); ok {
+			return disk, nil
+		}
+	}
+
+	// next try the kernel device node name
+	if traits.OriginalKernelPath != "" {
+		disk, err := disks.DiskFromDeviceName(traits.OriginalKernelPath)
+		if ok := checkCandidateDisk(disk, "device name", err); ok {
+			return disk, nil
+		}
+	}
+
+	// next try the disk ID from the partition table
+	if traits.DiskID != "" {
+		// there isn't a way to find a disk using the disk ID directly, so we
+		// instead have to get all the disks and then check them all to see if
+		// the disk ID's match
+		blockdevDisks, err := disks.AllPhysicalDisks()
+		if err == nil {
+			for _, blockDevDisk := range blockdevDisks {
+				if blockDevDisk.DiskID() == traits.DiskID {
+					// found the block device for this Disk ID, get the
+					// disks.Disk for it
+					if ok := checkCandidateDisk(blockDevDisk, "disk ID", err); ok {
+						return blockDevDisk, nil
+					}
+
+					// otherwise if it didn't match we keep iterating over
+					// the block devices, since we could have a situation
+					// where an attacker has cloned the disk and put their own
+					// content on it to attack the device and so there are two
+					// block devices with the same ID but non-matching
+					// structures
+				}
+			}
+		} else {
+			logger.Noticef("error getting all physical disks: %v", err)
+		}
+	}
+
+	// TODO: implement this final last ditch effort
+	// finally, try doing an inverse search using the individual
+	// structures to match a structure we measured previously to find a on disk
+	// device and then find a disk from that device and see if it matches
+
+	return nil, fmt.Errorf("could not find physical disk laid out to map with volume %s", vol.Name)
+}
+
 // IsCreatableAtInstall returns whether the gadget structure would be created at
 // install - currently that is only ubuntu-save, ubuntu-data, and ubuntu-boot
 func IsCreatableAtInstall(gv *VolumeStructure) bool {

--- a/gadget/update_test.go
+++ b/gadget/update_test.go
@@ -2116,7 +2116,7 @@ func (u *updateTestSuite) TestDiskTraitsFromDeviceAndValidateDOSSingleVolume(c *
 	c.Assert(traits, DeepEquals, gadgettest.ExpectedRaspiDiskVolumeDeviceTraits)
 }
 
-func (s *gadgetYamlTestSuite) TestDiskTraitsFromDeviceAndValidateImplicitSystemDataHappy(c *C) {
+func (s *updateTestSuite) TestDiskTraitsFromDeviceAndValidateImplicitSystemDataHappy(c *C) {
 	// mock the device name
 	restore := disks.MockDeviceNameToDiskMapping(map[string]*disks.MockDiskMapping{
 		"/dev/sda": gadgettest.UC16ImplicitSystemDataMockDiskMapping,
@@ -2139,4 +2139,135 @@ func (s *gadgetYamlTestSuite) TestDiskTraitsFromDeviceAndValidateImplicitSystemD
 	c.Assert(err, IsNil)
 
 	c.Assert(traits, DeepEquals, gadgettest.UC16ImplicitSystemDataDeviceTraits)
+}
+
+func (s *updateTestSuite) TestSearchForVolumeWithTraitsImplicitSystemData(c *C) {
+	allowImplicitDataOpts := &gadget.DiskVolumeValidationOptions{
+		AllowImplicitSystemData: true,
+	}
+	testSearchForVolumeWithTraits(c,
+		gadgettest.UC16YAMLImplicitSystemData,
+		"pc",
+		&gadgettest.ModelCharacteristics{},
+		gadgettest.UC16ImplicitSystemDataMockDiskMapping,
+		gadgettest.UC16ImplicitSystemDataDeviceTraits,
+		allowImplicitDataOpts,
+	)
+}
+
+func (s *updateTestSuite) TestSearchForVolumeWithTraitsNonSystemBoot(c *C) {
+	testSearchForVolumeWithTraits(c,
+		gadgettest.MultiVolumeUC20GadgetYaml,
+		"foo",
+		&gadgettest.ModelCharacteristics{SystemSeed: true},
+		gadgettest.VMExtraVolumeDiskMapping,
+		gadgettest.VMExtraVolumeDeviceTraits,
+		nil,
+	)
+}
+
+func (s *updateTestSuite) TestSearchForVolumeWithTraitsUC20Encryption(c *C) {
+	encryptOpts := &gadget.DiskVolumeValidationOptions{
+		ExpectedStructureEncryption: map[string]gadget.StructureEncryptionParameters{
+			"ubuntu-data": {Method: gadget.EncryptionLUKS},
+			"ubuntu-save": {Method: gadget.EncryptionLUKS},
+		},
+	}
+
+	testSearchForVolumeWithTraits(c,
+		gadgettest.RaspiSimplifiedYaml,
+		"pi",
+		&gadgettest.ModelCharacteristics{SystemSeed: true},
+		gadgettest.ExpectedLUKSEncryptedRaspiMockDiskMapping,
+		gadgettest.ExpectedLUKSEncryptedRaspiDiskVolumeDeviceTraits,
+		encryptOpts,
+	)
+}
+
+func testSearchForVolumeWithTraits(c *C,
+	gadgetYaml string,
+	volName string,
+	model *gadgettest.ModelCharacteristics,
+	realMapping *disks.MockDiskMapping,
+	traits gadget.DiskVolumeDeviceTraits,
+	validateOpts *gadget.DiskVolumeValidationOptions,
+) {
+	dirs.SetRootDir(c.MkDir())
+	defer func() { dirs.SetRootDir("") }()
+	otherDisk := &disks.MockDiskMapping{
+		DevNum:  "1:1",
+		DevPath: traits.OriginalDevicePath,
+		DevNode: "/dev/fooo",
+	}
+
+	r := disks.MockDeviceNameToDiskMapping(map[string]*disks.MockDiskMapping{
+		traits.OriginalKernelPath: realMapping,
+		"/dev/fooo":               otherDisk,
+	})
+	defer r()
+
+	allVolumes, err := gadgettest.LayoutMultiVolumeFromYaml(c.MkDir(), gadgetYaml, model)
+	c.Assert(err, IsNil)
+
+	laidOutVol := allVolumes[volName]
+
+	// first go around we use the device path which matches
+	r = disks.MockDevicePathToDiskMapping(map[string]*disks.MockDiskMapping{
+		traits.OriginalDevicePath: realMapping,
+	})
+	defer r()
+
+	d, err := gadget.SearchForVolumeWithTraits(laidOutVol, traits, validateOpts)
+	c.Assert(err, IsNil)
+	c.Assert(d.Dev(), Equals, realMapping.DevNum)
+
+	// now make the device path change to something else
+	r = disks.MockDevicePathToDiskMapping(map[string]*disks.MockDiskMapping{
+		"/sys/devices/new":        realMapping,
+		traits.OriginalDevicePath: otherDisk,
+	})
+	defer r()
+
+	// we still find it because we fall back on the device name from the traits
+	// (/dev/sda)
+	d2, err := gadget.SearchForVolumeWithTraits(laidOutVol, traits, validateOpts)
+	c.Assert(err, IsNil)
+	c.Assert(d2.Dev(), Equals, realMapping.DevNum)
+
+	// now try the last fallback which is the disk ID
+
+	// because we can't make the first check of DiskFromDeviceName that comes
+	// from checking traits.OriginalKernelPath fail, but then the subsequent one
+	// to validate the disk successful, we have to instead just set the
+	// OriginalKernelPath to empty so it skips the check entirely
+	traits.OriginalKernelPath = ""
+
+	devicePathMapping := map[string]*disks.MockDiskMapping{
+		traits.OriginalDevicePath: otherDisk,
+	}
+
+	// mock two disks in /sys/block
+	blockDir := filepath.Join(dirs.SysfsDir, "block")
+	err = os.MkdirAll(blockDir, 0755)
+	c.Assert(err, IsNil)
+	for _, f := range []string{"real", "other"} {
+		blockDevSym := filepath.Join(blockDir, f)
+		err := os.Symlink("something", blockDevSym)
+		c.Assert(err, IsNil)
+
+		switch f {
+		case "real":
+			devicePathMapping[blockDevSym] = realMapping
+		case "other":
+			devicePathMapping[blockDevSym] = otherDisk
+		}
+	}
+
+	r = disks.MockDevicePathToDiskMapping(devicePathMapping)
+	defer r()
+
+	d3, err := gadget.SearchForVolumeWithTraits(laidOutVol, traits, validateOpts)
+	c.Assert(err, IsNil)
+	c.Assert(d3.Dev(), Equals, realMapping.DevNum)
+
 }


### PR DESCRIPTION
This is used during a multi-volume asset update routine where we have the 
traits for a volume which is to be updated and the LaidOutVolume for it, and we
want to find a real disks.Disk{} for it.

Also make the debug endpoint slightly smarter so it works on UC16/UC18 devices too.