### PR TITLE
gadget/update.go: add buildNewVolumeToDeviceMapping for existing devices

### DIFF
--- a/gadget/export_test.go
+++ b/gadget/export_test.go
@@ -58,6 +58,9 @@ var (
 
 	GadgetVolumeConsumesOneKernelUpdateAsset = gadgetVolumeConsumesOneKernelUpdateAsset
 
+	BuildNewVolumeToDeviceMapping = buildNewVolumeToDeviceMapping
+	ErrSkipUpdateProceedRefresh   = errSkipUpdateProceedRefresh
+
 	OnDiskStructureIsLikelyImplicitSystemDataRole = onDiskStructureIsLikelyImplicitSystemDataRole
 )
 

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -670,7 +670,7 @@ func DiskTraitsFromDeviceAndValidate(expLayout *LaidOutVolume, dev string, opts 
 
 // unable to proceed with the gadget asset update, but not fatal to the refresh
 // operation itself
-var errSkipUpdateProceedRefresh = errors.New("could not identify disk for gadget asset update")
+var errSkipUpdateProceedRefresh = errors.New("cannot identify disk for gadget asset update")
 
 // buildNewVolumeToDeviceMapping builds a DiskVolumeDeviceTraits for only the
 // volume containing the system-boot role, when we cannot load an existing
@@ -696,7 +696,7 @@ volumeLoop:
 	if systemBootVolume == "" {
 		// didn't find system-boot anywhere somehow
 		if preUC20 {
-			logger.Noticef("WARNING: could not identify disk for gadget asset update of volume %s: unable to find any volume with system-boot role on it", systemBootVolume)
+			logger.Noticef("WARNING: cannot identify disk for gadget asset update of volume %s: unable to find any volume with system-boot role on it", systemBootVolume)
 			return nil, errSkipUpdateProceedRefresh
 		}
 		// shouldn't be possible on UC20
@@ -741,11 +741,11 @@ volumeLoop:
 		// couldn't find a disk at all, pre-UC20 we just warn about this
 		// but let the update continue
 		if preUC20 {
-			logger.Noticef("WARNING: could not identify disk for gadget asset update of volume %s", systemBootVolume)
+			logger.Noticef("WARNING: cannot identify disk for gadget asset update of volume %s", systemBootVolume)
 			return nil, errSkipUpdateProceedRefresh
 		}
 		// fatal error on UC20+
-		return nil, fmt.Errorf("could not identify disk for gadget asset update of volume %s", systemBootVolume)
+		return nil, fmt.Errorf("cannot identify disk for gadget asset update of volume %s", systemBootVolume)
 	}
 
 	// we found the device, construct the traits with validation options

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -29,6 +29,7 @@ import (
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/kernel"
 	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/disks"
 )
 
@@ -759,17 +760,13 @@ volumeLoop:
 		// TODO: this needs to check if the specified partitions are ICE when
 		// we support ICE too
 
-		// TODO: is this a good enough check to know if encryption was turned
-		// on? note that we can't import the boot pkg here
-		keysPattern := filepath.Join(dirs.SnapFDEDir, "*.key")
-		files, err := filepath.Glob(keysPattern)
-		if err != nil {
-			return nil, fmt.Errorf("internal glob pattern error: %v", err)
-		}
-
-		if len(files) != 0 {
-			// then we have keys for encryption stored from install mode, so we
-			// at least should have ubuntu-data encrypted
+		// check if there is a marker file written, that will indicate if
+		// encryption was turned on
+		encryptionMarkerFile := filepath.Join(dirs.SnapFDEDir, "marker")
+		if osutil.FileExists(encryptionMarkerFile) {
+			// then we have the crypto marker file for encryption
+			// cross-validation between ubuntu-data and ubuntu-save stored from
+			// install mode, so we at least should have ubuntu-data encrypted
 			validateOpts.ExpectedStructureEncryption = map[string]StructureEncryptionParameters{
 				"ubuntu-data": {Method: EncryptionLUKS},
 			}

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -673,9 +673,9 @@ func DiskTraitsFromDeviceAndValidate(expLayout *LaidOutVolume, dev string, opts 
 var errSkipUpdateProceedRefresh = errors.New("could not identify disk for gadget asset update")
 
 // buildNewVolumeToDeviceMapping builds a DiskVolumeDeviceTraits for only the
-// system-boot role containing volume when we cannot load an existing traits
-// object from disk-mapping.json. It is meant to be used only with all UC16 /
-// UC18 installs as well as UC20 installs from before we started writing
+// volume containing the system-boot role, when we cannot load an existing
+// traits object from disk-mapping.json. It is meant to be used only with all
+// UC16/UC18 installs as well as UC20 installs from before we started writing
 // disk-mapping.json during install mode.
 func buildNewVolumeToDeviceMapping(old GadgetData, laidOutVols map[string]*LaidOutVolume, preUC20 bool) (map[string]DiskVolumeDeviceTraits, error) {
 	var systemBootVolume string
@@ -700,7 +700,7 @@ volumeLoop:
 			return nil, errSkipUpdateProceedRefresh
 		}
 		// shouldn't be possible on UC20
-		return nil, fmt.Errorf("unable to find any volume with system-boot, gadget is broken")
+		return nil, fmt.Errorf("cannot find any volume with system-boot, gadget is broken")
 	}
 
 	laidOutVol := laidOutVols[systemBootVolume]

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -766,24 +766,11 @@ volumeLoop:
 		if osutil.FileExists(encryptionMarkerFile) {
 			// then we have the crypto marker file for encryption
 			// cross-validation between ubuntu-data and ubuntu-save stored from
-			// install mode, so we at least should have ubuntu-data encrypted
+			// install mode, so mark ubuntu-save and data as expected to be
+			// encrypted
 			validateOpts.ExpectedStructureEncryption = map[string]StructureEncryptionParameters{
 				"ubuntu-data": {Method: EncryptionLUKS},
-			}
-
-			// check if ubuntu-save exists to know whether to also assume
-			// encryption for ubuntu-save too - this should always happen since
-			// we require ubuntu-save for encryption, but there was a time
-			// during UC20 development where you could have encryption without
-			// ubuntu-save, so there is a small chance such devices could have
-			// persisted
-			for _, s := range laidOutVol.Structure {
-				if s.Role == SystemSave {
-					validateOpts.ExpectedStructureEncryption["ubuntu-save"] = StructureEncryptionParameters{
-						Method: EncryptionLUKS,
-					}
-					break
-				}
+				"ubuntu-save": {Method: EncryptionLUKS},
 			}
 		}
 	}

--- a/gadget/update_test.go
+++ b/gadget/update_test.go
@@ -2345,13 +2345,12 @@ func (u *updateTestSuite) TestBuildNewVolumeToDeviceMappingUC20Encryption(c *C) 
 	})
 	defer restore()
 
-	// mock key files such that the function realizes this device was installed
-	// with encryption
-	recoveryKey := filepath.Join(dirs.SnapFDEDir, "recovery.key")
-	err = os.MkdirAll(filepath.Dir(recoveryKey), 0755)
+	// write an encryption marker
+	markerFile := filepath.Join(dirs.SnapFDEDir, "marker")
+	err = os.MkdirAll(filepath.Dir(markerFile), 0755)
 	c.Assert(err, IsNil)
 
-	err = ioutil.WriteFile(recoveryKey, nil, 0644)
+	err = ioutil.WriteFile(markerFile, nil, 0644)
 	c.Assert(err, IsNil)
 
 	postUC20 := false

--- a/gadget/update_test.go
+++ b/gadget/update_test.go
@@ -2230,6 +2230,141 @@ func (u *updateTestSuite) TestBuildNewVolumeToDeviceMappingImplicitSystemDataUC1
 	})
 }
 
+func (u *updateTestSuite) TestBuildNewVolumeToDeviceMappingImplicitSystemBootSingleVolume(c *C) {
+	dirs.SetRootDir(c.MkDir())
+	defer func() { dirs.SetRootDir("") }()
+
+	// not there is no role or filesystem-label or name referencing system-boot
+	// here so there are no implicit roles set for this yaml, but it is valid as
+	// we used to allow installation of such gadget.yaml and as such need to
+	// continue to support updates for this
+	const implicitSystemBootVolumeYAML = `volumes:
+  pc:
+    bootloader: grub
+    structure:
+      - name: mbr
+        type: mbr
+        size: 440
+      - name: BIOS Boot
+        type: DA,21686148-6449-6E6F-744E-656564454649
+        size: 1M
+        offset: 1M
+        offset-write: mbr+92
+      - name: EFI System
+        type: EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+        filesystem: vfat
+        size: 50M
+`
+
+	laidOutVolume, err := gadgettest.LayoutFromYaml(c.MkDir(), implicitSystemBootVolumeYAML, &gadgettest.ModelCharacteristics{})
+	c.Assert(err, IsNil)
+
+	old := gadget.GadgetData{
+		Info: &gadget.Info{
+			Volumes: map[string]*gadget.Volume{
+				"pc": laidOutVolume.Volume,
+			},
+		},
+	}
+
+	// setup symlink for the system-boot partition
+	err = os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "/dev/disk/by-partlabel"), 0755)
+	c.Assert(err, IsNil)
+	fakedevicepart := filepath.Join(dirs.GlobalRootDir, "/dev/sda1")
+	err = os.Symlink(fakedevicepart, filepath.Join(dirs.GlobalRootDir, "/dev/disk/by-partlabel", disks.BlkIDEncodeLabel("EFI System")))
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(fakedevicepart, nil, 0644)
+	c.Assert(err, IsNil)
+
+	// mock the partition device node to mock disk
+	restore := disks.MockPartitionDeviceNodeToDiskMapping(map[string]*disks.MockDiskMapping{
+		filepath.Join(dirs.GlobalRootDir, "/dev/sda1"): gadgettest.UC16ImplicitSystemDataMockDiskMapping,
+	})
+	defer restore()
+
+	// and the device name to the disk itself
+	restore = disks.MockDeviceNameToDiskMapping(map[string]*disks.MockDiskMapping{
+		"/dev/sda": gadgettest.UC16ImplicitSystemDataMockDiskMapping,
+	})
+	defer restore()
+
+	allLaidOutVolumes := map[string]*gadget.LaidOutVolume{
+		"pc": laidOutVolume,
+	}
+
+	preUC20 := true
+	m, err := gadget.BuildNewVolumeToDeviceMapping(old, allLaidOutVolumes, preUC20)
+	c.Assert(err, IsNil)
+
+	c.Assert(m, DeepEquals, map[string]gadget.DiskVolumeDeviceTraits{
+		"pc": gadgettest.UC16ImplicitSystemDataDeviceTraits,
+	})
+}
+
+func (u *updateTestSuite) TestBuildNewVolumeToDeviceMappingImplicitSystemBootMultiVolumeNotSupported(c *C) {
+	dirs.SetRootDir(c.MkDir())
+	defer func() { dirs.SetRootDir("") }()
+
+	// not there is no role or filesystem-label or name referencing system-boot
+	// here so there are no implicit roles set for this yaml, but it is valid as
+	// we used to allow installation of such gadget.yaml, but since it has
+	// multiple volumes, we need to make sure we fail with a specific error that
+	// allows the overall gadget refresh to proceed but skips the asset update
+	const implicitSystemBootVolumeYAML = `volumes:
+  pc:
+    bootloader: grub
+    structure:
+      - name: mbr
+        type: mbr
+        size: 440
+      - name: BIOS Boot
+        type: DA,21686148-6449-6E6F-744E-656564454649
+        size: 1M
+        offset: 1M
+        offset-write: mbr+92
+      - name: EFI System
+        type: EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+        filesystem: vfat
+        size: 50M
+  foo:
+    structure:
+      - name: some-thing
+        type: EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+        filesystem: vfat
+        size: 50M
+`
+
+	// need to manually lay out this YAML, the helpers don't work for
+	// multi-volume non-UC20 setups like this
+	gadgetRoot, err := gadgettest.WriteGadgetYaml(c.MkDir(), implicitSystemBootVolumeYAML)
+	c.Assert(err, IsNil)
+
+	constraints := gadget.LayoutConstraints{
+		NonMBRStartOffset: 1 * quantity.OffsetMiB,
+	}
+
+	info, err := gadget.ReadInfo(gadgetRoot, &gadgettest.ModelCharacteristics{})
+	c.Assert(err, IsNil)
+
+	allLaidOutVolumes := map[string]*gadget.LaidOutVolume{}
+
+	for volName, vol := range info.Volumes {
+		lvol, err := gadget.LayoutVolume(gadgetRoot, "", vol, constraints)
+		c.Assert(err, IsNil)
+		allLaidOutVolumes[volName] = lvol
+	}
+
+	old := gadget.GadgetData{Info: info}
+
+	// don't need to mock anything, we don't get far enough
+
+	// we fail with the error that skips the asset update but proceeds with the
+	// rest of the refresh
+	preUC20 := true
+	_, err = gadget.BuildNewVolumeToDeviceMapping(old, allLaidOutVolumes, preUC20)
+	c.Assert(err, Equals, gadget.ErrSkipUpdateProceedRefresh)
+}
+
 func (u *updateTestSuite) TestBuildNewVolumeToDeviceMappingPreUC20NonFatalError(c *C) {
 	dirs.SetRootDir(c.MkDir())
 	defer func() { dirs.SetRootDir("") }()


### PR DESCRIPTION
For devices that don't have a disk-mapping.json, we need this method to
construct the traits for the system-boot containing volume only to allow
gadget asset updates to be performed on specifically that volume only.

The naive check to see if the device has encryption or not may be too 
naive, not sure...