### PR TITLE
data/env: more workarounds for even older fish shells, provide reasonable defaults

### DIFF
--- a/data/env/snapd.fish.in
+++ b/data/env/snapd.fish.in
@@ -8,7 +8,10 @@ end
 # looked for in XDG_DATA_DIRS; make sure it includes the relevant directory for
 # snappy applications' desktop files.
 set -ul snap_xdg_path /var/lib/snapd/desktop
-set --path --export XDG_DATA_DIRS $XDG_DATA_DIRS
-if not contains $snap_xdg_path $XDG_DATA_DIRS
-    set XDG_DATA_DIRS $XDG_DATA_DIRS $snap_xdg_path
+# note, snapd supports distros going back as far as Ubuntu 16.04, what means we
+# must make sure that this is compatible with old fish shells which do not have
+# fish_add_path or set --path
+set --global --export XDG_DATA_DIRS $XDG_DATA_DIRS
+if not contains $snap_xdg_path (string split : "$XDG_DATA_DIRS")
+    set XDG_DATA_DIRS (string join : -- $XDG_DATA_DIRS $snap_xdg_path)
 end

--- a/data/env/snapd.fish.in
+++ b/data/env/snapd.fish.in
@@ -11,7 +11,13 @@ set -ul snap_xdg_path /var/lib/snapd/desktop
 # note, snapd supports distros going back as far as Ubuntu 16.04, what means we
 # must make sure that this is compatible with old fish shells which do not have
 # fish_add_path or set --path
-set --global --export XDG_DATA_DIRS $XDG_DATA_DIRS
+
+if not set -q XDG_DATA_DIRS
+    set --global --export XDG_DATA_DIRS $XDG_DATA_DIRS
+    # XDG_DATA_DIRS is not defined, set it to some reasonable defaults
+    set XDG_DATA_DIRS (string join : /usr/local/share /usr/share)
+end
+
 if not contains $snap_xdg_path (string split : "$XDG_DATA_DIRS")
     set XDG_DATA_DIRS (string join : -- $XDG_DATA_DIRS $snap_xdg_path)
 end

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -541,6 +541,7 @@ pkg_dependencies_ubuntu_classic(){
     echo "
         avahi-daemon
         cups
+        fish
         fontconfig
         gnome-keyring
         jq
@@ -684,6 +685,7 @@ pkg_dependencies_fedora_centos_common(){
         dbus-x11
         evolution-data-server
         expect
+        fish
         fontconfig
         fwupd
         git
@@ -722,6 +724,7 @@ pkg_dependencies_amazon(){
         curl
         dbus-x11
         expect
+        fish
         fontconfig
         fwupd
         git
@@ -757,6 +760,7 @@ pkg_dependencies_opensuse(){
         dbus-1-python3
         evolution-data-server
         expect
+        fish
         fontconfig
         fwupd
         git
@@ -792,6 +796,7 @@ pkg_dependencies_arch(){
     curl
     evolution-data-server
     expect
+    fish
     fontconfig
     fwupd
     git

--- a/tests/main/user-session-env/task.yaml
+++ b/tests/main/user-session-env/task.yaml
@@ -41,15 +41,14 @@ execute: |
             tests.session -u "$user" exec systemctl --user show-environment > "${user}-session-env"
         fi
         tests.session -u "$user" exec env > "${user}-profile-env"
-        # fish allows environment variables to not be exported to subprocesses, make
-        # sure the right variables are exported though
+        # dump the variables exported to a subprocess
         tests.session -u "$user" exec sh -c 'exec env' > "${user}-child-env"
     done
     # tests.session as the helper assumes a sh compatible shell, so we cannot
     # use it with fish
     su -c 'env' -l "$TEST_FISH_USER"  > "${TEST_FISH_USER}-profile-env"
-    # fish allows environment variables to not be exported to subprocesses, make
-    # sure the right variables are exported though
+    # fish allows environment variables to be selectively exported to
+    # subprocesses, dump them now and verify that the right ones are there later
     su -c 'sh -c "exec env"' -l "$TEST_FISH_USER" > "${TEST_FISH_USER}-child-env"
 
     SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
@@ -66,7 +65,7 @@ execute: |
         # Profile should also be correctly set up
         case "$user:$SPREAD_SYSTEM" in
             test-zsh:ubuntu-*|test-zsh:debian-*)
-                # zsh due to https://bugs.launchpad.net/ubuntu/+source/zsh/+bug/1640514
+                # Due to https://bugs.launchpad.net/ubuntu/+source/zsh/+bug/1640514
                 NOMATCH 'XDG_DATA_DIRS=.*[:]?/var/lib/snapd/desktop[:]?.*' < "${user}-profile-env"
                 NOMATCH "PATH=.*[:]?${SNAP_MOUNT_DIR}/bin[:]?.*" < "${user}-profile-env"
                 ;;

--- a/tests/main/user-session-env/task.yaml
+++ b/tests/main/user-session-env/task.yaml
@@ -93,6 +93,9 @@ execute: |
                 # similarly the right paths are set for subprocesses
                 MATCH 'XDG_DATA_DIRS=.*[:]?/var/lib/snapd/desktop[:]?.*' < "${user}-child-env"
                 MATCH "PATH=.*[:]?${SNAP_MOUNT_DIR}/bin[:]?.*" < "${user}-child-env"
+                # make sure that XDG_DATA_DIRS contains the default locations as well
+                MATCH 'XDG_DATA_DIRS=.*[:]?/usr/share[:]?.*' < "${user}-profile-env"
+                MATCH 'XDG_DATA_DIRS=.*[:]?/usr/local/share[:]?.*' < "${user}-profile-env"
                 ;;
         esac
     done

--- a/tests/main/user-session-env/task.yaml
+++ b/tests/main/user-session-env/task.yaml
@@ -7,32 +7,53 @@ details: |
     inside the user session, no matter the shell they use.
 
 systems:
-   - -ubuntu-core-*  # cannot install zsh
+   - -ubuntu-core-*  # cannot install zsh or fish
    - -ubuntu-14.04-* # cannot use systemd
+   - -amazon-linux-2-* # no fish package for AMZN2
+
 
 environment:
     TEST_ZSH_USER: test-zsh
+    TEST_FISH_USER: test-fish
 
 prepare: |
+
     echo "Create a user with a different shell"
-    useradd --create-home --user-group -s /bin/zsh "$TEST_ZSH_USER"
-    tests.session prepare -u test,test-zsh
+    useradd --create-home --user-group -s /usr/bin/zsh "$TEST_ZSH_USER"
+    useradd --create-home --user-group -s /usr/bin/fish "$TEST_FISH_USER"
+    # tests.session assumes that the shell is sh compatible, which isn't true
+    # for fish
+    for user in test "$TEST_ZSH_USER" ; do
+        tests.session prepare -u "$user"
+    done
 
 restore: |
-    tests.session restore -u test,test-zsh
+    for user in test "$TEST_ZSH_USER"  ; do
+        tests.session restore -u "$user"
+    done
     userdel -f -r "$TEST_ZSH_USER"
+    userdel -f -r "$TEST_FISH_USER"
 
 execute: |
-    for user in test "$TEST_ZSH_USER"; do
+    for user in test "$TEST_ZSH_USER" ; do
         # Dump the environment set up by the user session manager
         if tests.session has-session-systemd-and-dbus; then
             tests.session -u "$user" exec systemctl --user show-environment > "${user}-session-env"
         fi
         tests.session -u "$user" exec env > "${user}-profile-env"
+        # fish allows environment variables to not be exported to subprocesses, make
+        # sure the right variables are exported though
+        tests.session -u "$user" exec sh -c 'exec env' > "${user}-child-env"
     done
+    # tests.session as the helper assumes a sh compatible shell, so we cannot
+    # use it with fish
+    su -c 'env' -l "$TEST_FISH_USER"  > "${TEST_FISH_USER}-profile-env"
+    # fish allows environment variables to not be exported to subprocesses, make
+    # sure the right variables are exported though
+    su -c 'sh -c "exec env"' -l "$TEST_FISH_USER" > "${TEST_FISH_USER}-child-env"
 
     SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
-    for user in test "$TEST_ZSH_USER"; do
+    for user in test "$TEST_ZSH_USER" "$TEST_FISH_USER" ; do
         if [ -e "${user}-session-env" ]; then
             # Even though there's user session support, systemd may be too old and
             # not support user-environment-generators (specifically systemd versions
@@ -45,13 +66,34 @@ execute: |
         # Profile should also be correctly set up
         case "$user:$SPREAD_SYSTEM" in
             test-zsh:ubuntu-*|test-zsh:debian-*)
-                # Due to https://bugs.launchpad.net/ubuntu/+source/zsh/+bug/1640514
+                # zsh due to https://bugs.launchpad.net/ubuntu/+source/zsh/+bug/1640514
                 NOMATCH 'XDG_DATA_DIRS=.*[:]?/var/lib/snapd/desktop[:]?.*' < "${user}-profile-env"
                 NOMATCH "PATH=.*[:]?${SNAP_MOUNT_DIR}/bin[:]?.*" < "${user}-profile-env"
+                ;;
+            test-fish:ubuntu-16.04*)
+                # fish on 16.04 is just too old to support vendor_conf.d so
+                # XDG_DATA_DIRS is not appended to, but also does not clobber
+                # PATH
+                NOMATCH 'XDG_DATA_DIRS=.*[:]?/var/lib/snapd/desktop[:]?.*' < "${user}-profile-env"
+                MATCH "PATH=.*[:]?${SNAP_MOUNT_DIR}/bin[:]?.*" < "${user}-profile-env"
+                NOMATCH 'XDG_DATA_DIRS=.*[:]?/var/lib/snapd/desktop[:]?.*' < "${user}-child-env"
+                MATCH "PATH=.*[:]?${SNAP_MOUNT_DIR}/bin[:]?.*" < "${user}-child-env"
+                ;;
+            test-fish:opensuse-tumbleweed-*)
+                # fish Tumbleweed somehow magically glues the ENV_* from su and
+                # PATH, but fortunately it also displays ENV_ROOTPATH
+                NOMATCH "PATH=.*[:]?${SNAP_MOUNT_DIR}/bin[:]?.*" < "${user}-profile-env"
+                MATCH "ENV_ROOTPATH\s+.*[:]?${SNAP_MOUNT_DIR}/bin[:]?.*" < "${user}-profile-env"
+                MATCH 'XDG_DATA_DIRS=.*[:]?/var/lib/snapd/desktop[:]?.*' < "${user}-child-env"
+                NOMATCH "PATH=.*[:]?${SNAP_MOUNT_DIR}/bin[:]?.*" < "${user}-child-env"
+                MATCH "ENV_ROOTPATH\s+.*[:]?${SNAP_MOUNT_DIR}/bin[:]?.*" < "${user}-child-env"
                 ;;
             *)
                 MATCH 'XDG_DATA_DIRS=.*[:]?/var/lib/snapd/desktop[:]?.*' < "${user}-profile-env"
                 MATCH "PATH=.*[:]?${SNAP_MOUNT_DIR}/bin[:]?.*" < "${user}-profile-env"
+                # similarly the right paths are set for subprocesses
+                MATCH 'XDG_DATA_DIRS=.*[:]?/var/lib/snapd/desktop[:]?.*' < "${user}-child-env"
+                MATCH "PATH=.*[:]?${SNAP_MOUNT_DIR}/bin[:]?.*" < "${user}-child-env"
                 ;;
         esac
     done


### PR DESCRIPTION
Tweak snapd.fish to be compatible with even older releases of fish, going back to 2.7, which was shipped with Ubuntu 18.04.
