### PR TITLE
many: Do not use -enc suffix for encrypted parition labels

### DIFF
--- a/gadget/install/encrypt.go
+++ b/gadget/install/encrypt.go
@@ -65,7 +65,7 @@ func newEncryptedDeviceLUKS(part *gadget.OnDiskStructure, key secboot.Encryption
 		node: fmt.Sprintf("/dev/mapper/%s", name),
 	}
 
-	if err := secbootFormatEncryptedDevice(key, name+"-enc", part.Node); err != nil {
+	if err := secbootFormatEncryptedDevice(key, name, part.Node); err != nil {
 		return nil, fmt.Errorf("cannot format encrypted device: %v", err)
 	}
 

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -292,8 +292,8 @@ func EnsureLayoutCompatibility(gadgetLayout *LaidOutVolume, diskLayout *OnDiskVo
 				case EncryptionLUKS:
 					// then this partition is expected to have been encrypted, the
 					// filesystem label on disk will need "-enc" appended
-					if dv.Label != gv.Name+"-enc" {
-						return false, fmt.Sprintf("partition %[1]s is expected to be encrypted but is not named %[1]s-enc", gv.Name)
+					if dv.Label != gv.Name && dv.Label != gv.Name+"-enc" {
+						return false, fmt.Sprintf("partition %[1]s is expected to be encrypted but is not named %[1]s-enc or %[1]s", gv.Name)
 					}
 
 					// the filesystem should also be "crypto_LUKS"

--- a/secboot/secboot.go
+++ b/secboot/secboot.go
@@ -172,9 +172,3 @@ type UnlockResult struct {
 	// - UnlockedWithKey
 	UnlockMethod UnlockMethod
 }
-
-// EncryptedPartitionName returns the name/label used by an encrypted partition
-// corresponding to a given name.
-func EncryptedPartitionName(name string) string {
-	return name + "-enc"
-}


### PR DESCRIPTION
libblkid used by udev can detect if a partition is encrypted, so we do
not need to use an suffix to detect that.

snap-bootstrap in the initramfs needs to be updated for this to work.
