### PR TITLE
t/m/interfaces-network-manager: use different channel depending on system

### DIFF
--- a/tests/main/interfaces-network-manager/task.yaml
+++ b/tests/main/interfaces-network-manager/task.yaml
@@ -21,9 +21,9 @@ systems:
 
 prepare: |
     echo "Given a network-manager snap is installed"
-    if [ "$SPREAD_SYSTEM" = ubuntu-core-16-32 ] || [ "$SPREAD_SYSTEM" = ubuntu-core-16-64 ]; then
+    if os.query is-core16; then
         snap install --channel=latest network-manager
-    elif [ "$SPREAD_SYSTEM" = ubuntu-core-18-32 ] || [ "$SPREAD_SYSTEM" = ubuntu-core-18-64 ]; then
+    elif os.query is-core18; then
         snap install --channel=1.10 network-manager
     else
         snap install --channel=20 network-manager

--- a/tests/main/interfaces-network-manager/task.yaml
+++ b/tests/main/interfaces-network-manager/task.yaml
@@ -20,7 +20,15 @@ systems:
     - ubuntu-core-20-64
 
 prepare: |
-    echo "Give a network-manager snap is installed"
+    echo "Given a network-manager snap is installed"
+    if [ "$SPREAD_SYSTEM" = ubuntu-core-16-32 ] || [ "$SPREAD_SYSTEM" = ubuntu-core-16-64 ]; then
+        snap install --channel=latest network-manager
+    elif [ "$SPREAD_SYSTEM" = ubuntu-core-18-32 ] || [ "$SPREAD_SYSTEM" = ubuntu-core-18-64 ]; then
+        snap install --channel=1.10 network-manager
+    else
+        snap install --channel=20 network-manager
+    fi
+
     snap install network-manager
 
 execute: |
@@ -34,7 +42,7 @@ execute: |
     done
 
     echo "The interface is connected by default"
-    snap interfaces -i network-manager | MATCH "network-manager:service .*network-manager:nmcli"
+    snap connections network-manager | MATCH "network-manager:nmcli *network-manager:service"
 
     echo "And allows to add a new connection"
     conn_name=nmtest


### PR DESCRIPTION
Install network-manager from different channels depending on system
under test. Due to tight integration with UC, each UC version requires
a different NM snap.