### PR TITLE
data/selinux: allow the snap command to run systemctl

### DIFF
--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -805,6 +805,8 @@ can_exec(snappy_cli_t, snappy_exec_t)
 fs_getattr_tmpfs(snappy_cli_t)
 fs_getattr_cgroup(snappy_cli_t)
 
+# execute systemctl is-system-running when system-key mismatch is detected
+systemd_exec_systemctl(snappy_cli_t)
 
 ########################################
 #


### PR DESCRIPTION
Which can happen when there is a system key mismatch. Caught in the wild on
Fedora.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2057103

