### PR TITLE
data/env: more workarounds for even older fish shells, provide reasonable defaults (2.54)

### DIFF
--- a/data/env/snapd.fish.in
+++ b/data/env/snapd.fish.in
@@ -8,7 +8,16 @@ end
 # looked for in XDG_DATA_DIRS; make sure it includes the relevant directory for
 # snappy applications' desktop files.
 set -ul snap_xdg_path /var/lib/snapd/desktop
-set --path --export XDG_DATA_DIRS $XDG_DATA_DIRS
-if not contains $snap_xdg_path $XDG_DATA_DIRS
-    set XDG_DATA_DIRS $XDG_DATA_DIRS $snap_xdg_path
+# note, snapd supports distros going back as far as Ubuntu 16.04, what means we
+# must make sure that this is compatible with old fish shells which do not have
+# fish_add_path or set --path
+
+if not set -q XDG_DATA_DIRS
+    set --global --export XDG_DATA_DIRS $XDG_DATA_DIRS
+    # XDG_DATA_DIRS is not defined, set it to some reasonable defaults
+    set XDG_DATA_DIRS (string join : /usr/local/share /usr/share)
+end
+
+if not contains $snap_xdg_path (string split : "$XDG_DATA_DIRS")
+    set XDG_DATA_DIRS (string join : -- $XDG_DATA_DIRS $snap_xdg_path)
 end

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -531,6 +531,7 @@ pkg_dependencies_ubuntu_classic(){
         avahi-daemon
         cups
         dbus-user-session
+        fish
         fontconfig
         gnome-keyring
         jq
@@ -669,6 +670,7 @@ pkg_dependencies_fedora_centos_common(){
         dbus-x11
         evolution-data-server
         expect
+        fish
         fontconfig
         fwupd
         git
@@ -706,6 +708,7 @@ pkg_dependencies_amazon(){
         curl
         dbus-x11
         expect
+        fish
         fontconfig
         fwupd
         git
@@ -741,6 +744,7 @@ pkg_dependencies_opensuse(){
         dbus-1-python3
         evolution-data-server
         expect
+        fish
         fontconfig
         fwupd
         git
@@ -776,6 +780,7 @@ pkg_dependencies_arch(){
     curl
     evolution-data-server
     expect
+    fish
     fontconfig
     fwupd
     git

--- a/tests/main/user-session-env/task.yaml
+++ b/tests/main/user-session-env/task.yaml
@@ -7,32 +7,52 @@ details: |
     inside the user session, no matter the shell they use.
 
 systems:
-   - -ubuntu-core-*  # cannot install zsh
+   - -ubuntu-core-*  # cannot install zsh or fish
    - -ubuntu-14.04-* # cannot use systemd
+   - -amazon-linux-2-* # no fish package for AMZN2
+
 
 environment:
     TEST_ZSH_USER: test-zsh
+    TEST_FISH_USER: test-fish
 
 prepare: |
+
     echo "Create a user with a different shell"
-    useradd --create-home --user-group -s /bin/zsh "$TEST_ZSH_USER"
-    tests.session prepare -u test,test-zsh
+    useradd --create-home --user-group -s /usr/bin/zsh "$TEST_ZSH_USER"
+    useradd --create-home --user-group -s /usr/bin/fish "$TEST_FISH_USER"
+    # tests.session assumes that the shell is sh compatible, which isn't true
+    # for fish
+    for user in test "$TEST_ZSH_USER" ; do
+        tests.session prepare -u "$user"
+    done
 
 restore: |
-    tests.session restore -u test,test-zsh
+    for user in test "$TEST_ZSH_USER"  ; do
+        tests.session restore -u "$user"
+    done
     userdel -f -r "$TEST_ZSH_USER"
+    userdel -f -r "$TEST_FISH_USER"
 
 execute: |
-    for user in test "$TEST_ZSH_USER"; do
+    for user in test "$TEST_ZSH_USER" ; do
         # Dump the environment set up by the user session manager
         if tests.session has-session-systemd-and-dbus; then
             tests.session -u "$user" exec systemctl --user show-environment > "${user}-session-env"
         fi
         tests.session -u "$user" exec env > "${user}-profile-env"
+        # dump the variables exported to a subprocess
+        tests.session -u "$user" exec sh -c 'exec env' > "${user}-child-env"
     done
+    # tests.session as the helper assumes a sh compatible shell, so we cannot
+    # use it with fish
+    su -c 'env' -l "$TEST_FISH_USER"  > "${TEST_FISH_USER}-profile-env"
+    # fish allows environment variables to be selectively exported to
+    # subprocesses, dump them now and verify that the right ones are there later
+    su -c 'sh -c "exec env"' -l "$TEST_FISH_USER" > "${TEST_FISH_USER}-child-env"
 
     SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
-    for user in test "$TEST_ZSH_USER"; do
+    for user in test "$TEST_ZSH_USER" "$TEST_FISH_USER" ; do
         if [ -e "${user}-session-env" ]; then
             # Even though there's user session support, systemd may be too old and
             # not support user-environment-generators (specifically systemd versions
@@ -49,9 +69,33 @@ execute: |
                 NOMATCH 'XDG_DATA_DIRS=.*[:]?/var/lib/snapd/desktop[:]?.*' < "${user}-profile-env"
                 NOMATCH "PATH=.*[:]?${SNAP_MOUNT_DIR}/bin[:]?.*" < "${user}-profile-env"
                 ;;
+            test-fish:ubuntu-16.04*)
+                # fish on 16.04 is just too old to support vendor_conf.d so
+                # XDG_DATA_DIRS is not appended to, but also does not clobber
+                # PATH
+                NOMATCH 'XDG_DATA_DIRS=.*[:]?/var/lib/snapd/desktop[:]?.*' < "${user}-profile-env"
+                MATCH "PATH=.*[:]?${SNAP_MOUNT_DIR}/bin[:]?.*" < "${user}-profile-env"
+                NOMATCH 'XDG_DATA_DIRS=.*[:]?/var/lib/snapd/desktop[:]?.*' < "${user}-child-env"
+                MATCH "PATH=.*[:]?${SNAP_MOUNT_DIR}/bin[:]?.*" < "${user}-child-env"
+                ;;
+            test-fish:opensuse-tumbleweed-*)
+                # fish Tumbleweed somehow magically glues the ENV_* from su and
+                # PATH, but fortunately it also displays ENV_ROOTPATH
+                NOMATCH "PATH=.*[:]?${SNAP_MOUNT_DIR}/bin[:]?.*" < "${user}-profile-env"
+                MATCH "ENV_ROOTPATH\s+.*[:]?${SNAP_MOUNT_DIR}/bin[:]?.*" < "${user}-profile-env"
+                MATCH 'XDG_DATA_DIRS=.*[:]?/var/lib/snapd/desktop[:]?.*' < "${user}-child-env"
+                NOMATCH "PATH=.*[:]?${SNAP_MOUNT_DIR}/bin[:]?.*" < "${user}-child-env"
+                MATCH "ENV_ROOTPATH\s+.*[:]?${SNAP_MOUNT_DIR}/bin[:]?.*" < "${user}-child-env"
+                ;;
             *)
                 MATCH 'XDG_DATA_DIRS=.*[:]?/var/lib/snapd/desktop[:]?.*' < "${user}-profile-env"
                 MATCH "PATH=.*[:]?${SNAP_MOUNT_DIR}/bin[:]?.*" < "${user}-profile-env"
+                # similarly the right paths are set for subprocesses
+                MATCH 'XDG_DATA_DIRS=.*[:]?/var/lib/snapd/desktop[:]?.*' < "${user}-child-env"
+                MATCH "PATH=.*[:]?${SNAP_MOUNT_DIR}/bin[:]?.*" < "${user}-child-env"
+                # make sure that XDG_DATA_DIRS contains the default locations as well
+                MATCH 'XDG_DATA_DIRS=.*[:]?/usr/share[:]?.*' < "${user}-profile-env"
+                MATCH 'XDG_DATA_DIRS=.*[:]?/usr/local/share[:]?.*' < "${user}-profile-env"
                 ;;
         esac
     done


### PR DESCRIPTION
with merge fixes

Tweak snapd.fish to be compatible with even older releases of fish, going back to 2.7, which was shipped with Ubuntu 18.04.

* data/env: make fish setup compatible with fish 2.7

Make the environment setup script compatible with fish 2.7 which was shipped
with Ubuntu 18.04.

Thanks to @faho for the review.

Signed-off-by: Maciej Borzecki <maciej.zenon.borzecki@canonical.com>

* tests/main/user-session-env: verify env in fish shell

Signed-off-by: Maciej Borzecki <maciej.zenon.borzecki@canonical.com>

* tests/main/user-session-env: tweak comments

Signed-off-by: Maciej Borzecki <maciej.zenon.borzecki@canonical.com>

* data/env: provide reasonable default if XDG_DATA_DIRS is unset in fish shell

Fixes: https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1960702

Signed-off-by: Maciej Borzecki <maciej.zenon.borzecki@canonical.com>

* tests/main/user-session-env: verify that XDG_DATA_DIRS contains reasonable defaults

Signed-off-by: Maciej Borzecki <maciej.zenon.borzecki@canonical.com>

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
