### PR TITLE
cmd/snap-mgmt, packaging: trigger daemon reload after purging unit files

### DIFF
--- a/cmd/snap-mgmt/snap-mgmt.sh.in
+++ b/cmd/snap-mgmt/snap-mgmt.sh.in
@@ -132,6 +132,8 @@ purge() {
         rm -f "/etc/systemd/system/$unit"
         rm -f "/etc/systemd/system/multi-user.target.wants/$unit"
     done
+    # Units may have been removed do a reload
+    systemctl -q daemon-reload || true
 
     # snapd session-agent
     rm -f /etc/systemd/user/snapd.session-agent.socket

--- a/packaging/debian-sid/snapd.postrm
+++ b/packaging/debian-sid/snapd.postrm
@@ -97,6 +97,8 @@ if [ "$1" = "purge" ]; then
         rm -f "/etc/systemd/system/$unit"
         rm -f "/etc/systemd/system/multi-user.target.wants/$unit"
     done
+    # Units may have been removed do a reload
+    systemctl -q daemon-reload || true
 
     # snapd session-agent
     rm -f /etc/systemd/user/snapd.session-agent.socket

--- a/packaging/ubuntu-14.04/snapd.postrm
+++ b/packaging/ubuntu-14.04/snapd.postrm
@@ -97,6 +97,8 @@ if [ "$1" = "purge" ]; then
         rm -f "/etc/systemd/system/$unit"
         rm -f "/etc/systemd/system/multi-user.target.wants/$unit"
     done
+    # Units may have been removed do a reload
+    systemctl -q daemon-reload || true
 
     # snapd session-agent
     rm -f /etc/systemd/user/snapd.session-agent.socket

--- a/packaging/ubuntu-16.04/snapd.postrm
+++ b/packaging/ubuntu-16.04/snapd.postrm
@@ -103,6 +103,8 @@ if [ "$1" = "purge" ]; then
         rm -f "/etc/systemd/system/$unit"
         rm -f "/etc/systemd/system/multi-user.target.wants/$unit"
     done
+    # Units may have been removed do a reload
+    systemctl -q daemon-reload || true
 
     # snapd session-agent
     rm -f /etc/systemd/user/snapd.session-agent.socket


### PR DESCRIPTION
Since we have possibly removed systemd unit files, a daemon-reload is in order.

