### PR TITLE
snap, wrappers: support restart-limits.{count,period} for StartLimit* settings

### DIFF
--- a/snap/info.go
+++ b/snap/info.go
@@ -931,6 +931,7 @@ type AppInfo struct {
 	RefreshMode     string
 	StopMode        StopModeType
 	InstallMode     string
+	RestartLimits   RestartLimits
 
 	// TODO: this should go away once we have more plumbing and can change
 	// things vs refactor

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -67,6 +67,11 @@ func (td *typoDetector) UnmarshalYAML(func(interface{}) error) error {
 	return fmt.Errorf("typo detected: %s", td.Hint)
 }
 
+type RestartLimits struct {
+	Count  int             `yaml:"count,omitempty"`
+	Period timeout.Timeout `yaml:"period,omitempty"`
+}
+
 type appYaml struct {
 	Aliases []string `yaml:"aliases,omitempty"`
 
@@ -86,6 +91,7 @@ type appYaml struct {
 	RefreshMode     string          `yaml:"refresh-mode,omitempty"`
 	StopMode        StopModeType    `yaml:"stop-mode,omitempty"`
 	InstallMode     string          `yaml:"install-mode,omitempty"`
+	RestartLimits   RestartLimits   `yaml:"restart-limits,omitempty"`
 
 	RestartCond  RestartCondition `yaml:"restart-condition,omitempty"`
 	RestartDelay timeout.Timeout  `yaml:"restart-delay,omitempty"`
@@ -364,6 +370,7 @@ func setAppsFromSnapYaml(y snapYaml, snap *Info, strk *scopedTracker) error {
 			ReloadCommand:   yApp.ReloadCommand,
 			PostStopCommand: yApp.PostStopCommand,
 			RestartCond:     yApp.RestartCond,
+			RestartLimits:   yApp.RestartLimits,
 			RestartDelay:    yApp.RestartDelay,
 			BusName:         yApp.BusName,
 			CommonID:        yApp.CommonID,

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -987,6 +987,12 @@ TimeoutStopSec={{.StopTimeout.Seconds}}
 {{- if .StartTimeout}}
 TimeoutStartSec={{.StartTimeout.Seconds}}
 {{- end}}
+{{- if .RestartLimitCount}}
+StartLimitBurst={{.RestartLimitCount}}
+{{- end}}
+{{- if .RestartLimitInterval}}
+StartLimitInterval={{.RestartLimitInterval.Seconds}}
+{{- end}}
 Type={{.App.Daemon}}
 {{- if .Remain}}
 RemainAfterExit={{.Remain}}
@@ -1068,10 +1074,13 @@ WantedBy={{.ServicesTarget}}
 	wrapperData := struct {
 		App *snap.AppInfo
 
-		Restart                  string
-		WorkingDir               string
-		StopTimeout              time.Duration
-		StartTimeout             time.Duration
+		Restart              string
+		WorkingDir           string
+		StopTimeout          time.Duration
+		StartTimeout         time.Duration
+		RestartLimitCount    int
+		RestartLimitInterval time.Duration
+
 		ServicesTarget           string
 		PrerequisiteTarget       string
 		MountUnit                string
@@ -1094,14 +1103,16 @@ WantedBy={{.ServicesTarget}}
 
 		InterfaceServiceSnippets: ifaceSpecifiedServiceSnippet,
 
-		Restart:        restartCond,
-		StopTimeout:    serviceStopTimeout(appInfo),
-		StartTimeout:   time.Duration(appInfo.StartTimeout),
-		Remain:         remain,
-		KillMode:       killMode,
-		KillSignal:     appInfo.StopMode.KillSignal(),
-		OOMAdjustScore: oomAdjustScore,
-		BusName:        busName,
+		Restart:              restartCond,
+		RestartLimitCount:    appInfo.RestartLimits.Count,
+		RestartLimitInterval: time.Duration(appInfo.RestartLimits.Period),
+		StopTimeout:          serviceStopTimeout(appInfo),
+		StartTimeout:         time.Duration(appInfo.StartTimeout),
+		Remain:               remain,
+		KillMode:             killMode,
+		KillSignal:           appInfo.StopMode.KillSignal(),
+		OOMAdjustScore:       oomAdjustScore,
+		BusName:              busName,
 
 		Before: genServiceNames(appInfo.Snap, appInfo.Before),
 		After:  genServiceNames(appInfo.Snap, appInfo.After),

--- a/wrappers/services_gen_test.go
+++ b/wrappers/services_gen_test.go
@@ -262,6 +262,71 @@ apps:
 	c.Check(string(generatedWrapper), testutil.Contains, "\nTimeoutStartSec=600\n")
 }
 
+func (s *servicesWrapperGenSuite) TestGenerateSnapServiceFileWithRestartLimitsBurst(c *C) {
+	yamlText := `
+name: snap
+version: 1.0
+apps:
+    app:
+        command: bin/start
+        daemon: simple
+        restart-limits:
+            count: 50
+`
+	info, err := snap.InfoFromSnapYaml([]byte(yamlText))
+	c.Assert(err, IsNil)
+	info.Revision = snap.R(44)
+	app := info.Apps["app"]
+
+	generatedWrapper, err := wrappers.GenerateSnapServiceFile(app, nil)
+	c.Assert(err, IsNil)
+	c.Check(string(generatedWrapper), testutil.Contains, "\nStartLimitBurst=50\n")
+}
+
+func (s *servicesWrapperGenSuite) TestGenerateSnapServiceFileWithRestartLimitsInterval(c *C) {
+	yamlText := `
+name: snap
+version: 1.0
+apps:
+    app:
+        command: bin/start
+        daemon: simple
+        restart-limits:
+            period: 1m
+`
+	info, err := snap.InfoFromSnapYaml([]byte(yamlText))
+	c.Assert(err, IsNil)
+	info.Revision = snap.R(44)
+	app := info.Apps["app"]
+
+	generatedWrapper, err := wrappers.GenerateSnapServiceFile(app, nil)
+	c.Assert(err, IsNil)
+	c.Check(string(generatedWrapper), testutil.Contains, "\nStartLimitInterval=60\n")
+}
+
+func (s *servicesWrapperGenSuite) TestGenerateSnapServiceFileWithRestartLimitsBurstAndInterval(c *C) {
+	yamlText := `
+name: snap
+version: 1.0
+apps:
+    app:
+        command: bin/start
+        daemon: simple
+        restart-limits:
+            period: 1m
+            count: 100
+`
+	info, err := snap.InfoFromSnapYaml([]byte(yamlText))
+	c.Assert(err, IsNil)
+	info.Revision = snap.R(44)
+	app := info.Apps["app"]
+
+	generatedWrapper, err := wrappers.GenerateSnapServiceFile(app, nil)
+	c.Assert(err, IsNil)
+	c.Check(string(generatedWrapper), testutil.Contains, "\nStartLimitInterval=60\n")
+	c.Check(string(generatedWrapper), testutil.Contains, "\nStartLimitBurst=100\n")
+}
+
 func (s *servicesWrapperGenSuite) TestGenerateSnapServiceFileRestart(c *C) {
 	yamlTextTemplate := `
 name: snap


### PR DESCRIPTION
This allows a snap daemon to configure at what point systemd considers the
service totally failed and will give up trying to restart it via settings like:
```yaml
apps:
  foo:
    cmd: foo.sh
    plugs:
      - shutdown
    daemon: simple
    restart-limits:
      count: 50
      period: 1s
```
Where if systemd finds that the service has failed to start successfully 50
times in 1 second systemd will mark the service fully failed and it needs to be
unmarked with reset-failed or a reboot.

See also customer ticket 00327964

See also spec https://docs.google.com/document/d/15YEfZGq77TUfnO357n_Rc2HkX3dsW0ikKWpP2Q411m0/edit