### PR TITLE
osutil/disks: trigger udev on the partition device node

### DIFF
--- a/osutil/disks/disks_linux.go
+++ b/osutil/disks/disks_linux.go
@@ -635,8 +635,23 @@ func (d *disk) populatePartitions() error {
 				continue
 			}
 
-			// then the device is a partition, get the udev props for it
 			partDev := filepath.Base(path)
+
+			// then the device is a partition, trigger any udev events for it
+			// that might be sitting around and then get the udev props for it
+
+			// trigger
+			out, err := exec.Command("udevadm", "trigger", "--name-match="+partDev).CombinedOutput()
+			if err != nil {
+				return osutil.OutputErr(out, err)
+			}
+
+			// then settle
+			out, err = exec.Command("udevadm", "settle", "--timeout=180").CombinedOutput()
+			if err != nil {
+				return osutil.OutputErr(out, err)
+			}
+
 			udevProps, err := udevPropertiesForName(partDev)
 			if err != nil {
 				continue


### PR DESCRIPTION
Some particular devices seem to have a hard time around being able to do lots
of requests to the udev database, where getting udev properties for the gadget
asset update task will work and then getting udev properties for the specific
bootloader disk devices will fail because some properties are missing, but
waiting for them like we do here resolves this issue and ensures that all
properties are available when we query them here.