### PR TITLE
tests: add debugging to snap-confine-tmp-mount

### DIFF
--- a/tests/main/snap-confine-tmp-mount/task.yaml
+++ b/tests/main/snap-confine-tmp-mount/task.yaml
@@ -18,6 +18,12 @@ prepare: |
 restore: |
     tests.session -u test restore
 
+debug: |
+    # Print snap-confine stdout
+    cat /tmp/snap-confine-stdout.log || true
+    # Print snap-confine stderr
+    cat /tmp/snap-confine-stderr.log || true
+
 execute: |
     rm -rf /tmp/snap.test-snapd-sh
     # create /tmp/snap.test-snapd-sh as a regular user


### PR DESCRIPTION
This test has been seeing failing once when executing snap-confine
with stdout and stderr being redirected into separate files, but
understanding the reason of the failure is nearly impossible without
these files being printed into the logs.

