### PR TITLE
bootloader/grub: Add support for shim with fallback

### DIFF
--- a/bootloader/grub.go
+++ b/bootloader/grub.go
@@ -451,19 +451,28 @@ func staticCommandLineForGrubAssetEdition(asset string, edition uint) string {
 
 // grubBootAssetPath contains the paths for assets in the boot chain.
 type grubBootAssetPath struct {
-	shimBinary string
-	grubBinary string
+	shimBinary         string
+	grubBinary         string
+	fallbackBinary     string
+	shimFallbackBinary string
+	grubFallbackBinary string
 }
 
 // grubBootAssetsForArch contains the paths for assets for different
 // architectures in a map
 var grubBootAssetsForArch = map[string]grubBootAssetPath{
 	"amd64": {
-		shimBinary: filepath.Join("EFI/boot/", "bootx64.efi"),
-		grubBinary: filepath.Join("EFI/boot/", "grubx64.efi")},
+		shimBinary:         filepath.Join("EFI/boot/", "bootx64.efi"),
+		grubBinary:         filepath.Join("EFI/boot/", "grubx64.efi"),
+		fallbackBinary:     filepath.Join("EFI/boot/", "fbx64.efi"),
+		shimFallbackBinary: filepath.Join("EFI/ubuntu/", "shimx64.efi"),
+		grubFallbackBinary: filepath.Join("EFI/ubuntu/", "grubx64.efi")},
 	"arm64": {
-		shimBinary: filepath.Join("EFI/boot/", "bootaa64.efi"),
-		grubBinary: filepath.Join("EFI/boot/", "grubaa64.efi")},
+		shimBinary:         filepath.Join("EFI/boot/", "bootaa64.efi"),
+		grubBinary:         filepath.Join("EFI/boot/", "grubaa64.efi"),
+		fallbackBinary:     filepath.Join("EFI/boot/", "fbaa64.efi"),
+		shimFallbackBinary: filepath.Join("EFI/ubuntu/", "shimaa64.efi"),
+		grubFallbackBinary: filepath.Join("EFI/ubuntu/", "grubaa64.efi")},
 }
 
 func (g *grub) getGrubBootAssetsForArch() (*grubBootAssetPath, error) {
@@ -480,6 +489,9 @@ func (g *grub) getGrubRecoveryModeTrustedAssets() ([]string, error) {
 	assets, err := g.getGrubBootAssetsForArch()
 	if err != nil {
 		return nil, err
+	}
+	if osutil.FileExists(filepath.Join(g.rootdir, assets.fallbackBinary)) {
+		return []string{assets.shimFallbackBinary, assets.grubFallbackBinary}, nil
 	}
 	return []string{assets.shimBinary, assets.grubBinary}, nil
 }

--- a/bootloader/grub_test.go
+++ b/bootloader/grub_test.go
@@ -251,6 +251,15 @@ func (s *grubTestSuite) makeFakeGrubEFINativeEnv(c *C, content []byte) {
 	c.Assert(err, IsNil)
 }
 
+func (s *grubTestSuite) makeFakeShimFallback(c *C) {
+	err := os.MkdirAll(filepath.Join(s.rootdir, "/EFI/boot"), 0755)
+	c.Assert(err, IsNil)
+	_, err = os.Create(filepath.Join(s.rootdir, "/EFI/boot/fbx64.efi"))
+	c.Assert(err, IsNil)
+	_, err = os.Create(filepath.Join(s.rootdir, "/EFI/boot/fbaa64.efi"))
+	c.Assert(err, IsNil)
+}
+
 func (s *grubTestSuite) TestNewGrubWithOptionRecovery(c *C) {
 	s.makeFakeGrubEFINativeEnv(c, nil)
 
@@ -1169,6 +1178,17 @@ func (s *grubTestSuite) TestTrustedAssetsNativePartitionLayout(c *C) {
 		"EFI/boot/grubx64.efi",
 	})
 
+	// recovery bootloader, with fallback implemented
+	s.makeFakeShimFallback(c)
+	tarb = bootloader.NewGrub(s.rootdir, recoveryOpts).(bootloader.TrustedAssetsBootloader)
+	c.Assert(tarb, NotNil)
+
+	ta, err = tarb.TrustedAssets()
+	c.Assert(err, IsNil)
+	c.Check(ta, DeepEquals, []string{
+		"EFI/ubuntu/shimx64.efi",
+		"EFI/ubuntu/grubx64.efi",
+	})
 }
 
 func (s *grubTestSuite) TestTrustedAssetsRoot(c *C) {
@@ -1217,6 +1237,22 @@ func (s *grubTestSuite) TestRecoveryBootChains(c *C) {
 	})
 }
 
+func (s *grubTestSuite) TestRecoveryBootChainsWithFallback(c *C) {
+	s.makeFakeShimFallback(c)
+	s.makeFakeGrubEFINativeEnv(c, nil)
+	g := bootloader.NewGrub(s.rootdir, &bootloader.Options{Role: bootloader.RoleRecovery})
+	tab, ok := g.(bootloader.TrustedAssetsBootloader)
+	c.Assert(ok, Equals, true)
+
+	chain, err := tab.RecoveryBootChain("kernel.snap")
+	c.Assert(err, IsNil)
+	c.Assert(chain, DeepEquals, []bootloader.BootFile{
+		{Path: "EFI/ubuntu/shimx64.efi", Role: bootloader.RoleRecovery},
+		{Path: "EFI/ubuntu/grubx64.efi", Role: bootloader.RoleRecovery},
+		{Snap: "kernel.snap", Path: "kernel.efi", Role: bootloader.RoleRecovery},
+	})
+}
+
 func (s *grubTestSuite) TestRecoveryBootChainsNotRecoveryBootloader(c *C) {
 	s.makeFakeGrubEnv(c)
 	g := bootloader.NewGrub(s.rootdir, nil)
@@ -1245,6 +1281,25 @@ func (s *grubTestSuite) TestBootChains(c *C) {
 	})
 }
 
+func (s *grubTestSuite) TestBootChainsWithFallback(c *C) {
+	s.makeFakeShimFallback(c)
+	s.makeFakeGrubEFINativeEnv(c, nil)
+	g := bootloader.NewGrub(s.rootdir, &bootloader.Options{Role: bootloader.RoleRecovery})
+	tab, ok := g.(bootloader.TrustedAssetsBootloader)
+	c.Assert(ok, Equals, true)
+
+	g2 := bootloader.NewGrub(s.rootdir, &bootloader.Options{Role: bootloader.RoleRunMode})
+
+	chain, err := tab.BootChain(g2, "kernel.snap")
+	c.Assert(err, IsNil)
+	c.Assert(chain, DeepEquals, []bootloader.BootFile{
+		{Path: "EFI/ubuntu/shimx64.efi", Role: bootloader.RoleRecovery},
+		{Path: "EFI/ubuntu/grubx64.efi", Role: bootloader.RoleRecovery},
+		{Path: "EFI/boot/grubx64.efi", Role: bootloader.RoleRunMode},
+		{Snap: "kernel.snap", Path: "kernel.efi", Role: bootloader.RoleRunMode},
+	})
+}
+
 func (s *grubTestSuite) TestBootChainsArm64(c *C) {
 	s.makeFakeGrubEFINativeEnv(c, nil)
 	r := archtest.MockArchitecture("arm64")
@@ -1260,6 +1315,27 @@ func (s *grubTestSuite) TestBootChainsArm64(c *C) {
 	c.Assert(chain, DeepEquals, []bootloader.BootFile{
 		{Path: "EFI/boot/bootaa64.efi", Role: bootloader.RoleRecovery},
 		{Path: "EFI/boot/grubaa64.efi", Role: bootloader.RoleRecovery},
+		{Path: "EFI/boot/grubaa64.efi", Role: bootloader.RoleRunMode},
+		{Snap: "kernel.snap", Path: "kernel.efi", Role: bootloader.RoleRunMode},
+	})
+}
+
+func (s *grubTestSuite) TestBootChainsArm64WithFallback(c *C) {
+	s.makeFakeGrubEFINativeEnv(c, nil)
+	s.makeFakeShimFallback(c)
+	r := archtest.MockArchitecture("arm64")
+	defer r()
+	g := bootloader.NewGrub(s.rootdir, &bootloader.Options{Role: bootloader.RoleRecovery})
+	tab, ok := g.(bootloader.TrustedAssetsBootloader)
+	c.Assert(ok, Equals, true)
+
+	g2 := bootloader.NewGrub(s.rootdir, &bootloader.Options{Role: bootloader.RoleRunMode})
+
+	chain, err := tab.BootChain(g2, "kernel.snap")
+	c.Assert(err, IsNil)
+	c.Assert(chain, DeepEquals, []bootloader.BootFile{
+		{Path: "EFI/ubuntu/shimaa64.efi", Role: bootloader.RoleRecovery},
+		{Path: "EFI/ubuntu/grubaa64.efi", Role: bootloader.RoleRecovery},
 		{Path: "EFI/boot/grubaa64.efi", Role: bootloader.RoleRunMode},
 		{Snap: "kernel.snap", Path: "kernel.efi", Role: bootloader.RoleRunMode},
 	})


### PR DESCRIPTION
When gadget uses shim fallback mode, the trusted assets chain is different. Add support to detect that.

When gadget uses shim with fallback, it will first boot to fbx64.efi which will create boot entry ubuntu using EFI/ubuntu/shimx64.efi asset. Then reset, and from then on boot via EFI/ubuntu/shimx64.efi, instead of EFI/boot/shimx64.efi.

This would allow correctly supporting fwupd on Ubuntu Core, and have the same expected bootchains as we do everywhere else.

Also this opens up opportunity in the future to implement a/b boot of shim too. I.e. one would be able to create ubuntuXXXX entry that would boot using shim from recovery-systemXXXX, and fallback to previous ubuntu entry if needed. At the moment we don't do shim a/b try-boot on the recovery partition.

[LP: #1962182](https://bugs.launchpad.net/snapd/+bug/1962182)