### PR TITLE
interfaces/browser-support: allow RealtimeKit's MakeThreadRealtimeWithPID

### DIFF
--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -279,7 +279,7 @@ dbus (send)
     bus=system
     path=/org/freedesktop/RealtimeKit1
     interface=org.freedesktop.RealtimeKit1
-    member=MakeThread{HighPriority,Realtime}
+    member=MakeThread{HighPriority,Realtime,RealtimeWithPID}
     peer=(name=org.freedesktop.RealtimeKit1, label=unconfined),
 `
 


### PR DESCRIPTION
This is needed for Firefox to set realtime priority on its AudioIPC child
processes (https://bugzilla.mozilla.org/show_bug.cgi?id=1755684).