### PR TITLE
tests: extend gadget-config-defaults test with refresh.retain

### DIFF
--- a/tests/core/gadget-config-defaults/gadget-rsyslog.yaml
+++ b/tests/core/gadget-config-defaults/gadget-rsyslog.yaml
@@ -3,6 +3,8 @@ defaults:
      a: A
      b: B
    system:
+     refresh:
+       retain: 5
      service:
        rsyslog:
          disable: true

--- a/tests/core/gadget-config-defaults/gadget-ssh-common.yaml
+++ b/tests/core/gadget-config-defaults/gadget-ssh-common.yaml
@@ -3,6 +3,8 @@ defaults:
      a: A
      b: B
    system:
+     refresh:
+       retain: 5
      service:
        ssh:
          disable: true

--- a/tests/core/gadget-config-defaults/gadget-ssh-oneline.yaml
+++ b/tests/core/gadget-config-defaults/gadget-ssh-oneline.yaml
@@ -3,4 +3,5 @@ defaults:
      a: A
      b: B
    system:
+     refresh.retain: 5
      service.ssh.disable: true

--- a/tests/core/gadget-config-defaults/task.yaml
+++ b/tests/core/gadget-config-defaults/task.yaml
@@ -167,6 +167,8 @@ execute: |
 
     echo "The configuration for core is applied"
     snap get core "service.$SERVICE.disable" | MATCH true
+    # request a document (-d) to ensure we get an integer
+    snap get -d system refresh.retain | MATCH "refresh.retain\": +5$"
 
     if [ "$SERVICE" = ssh ]; then
         echo "And the ssh service is disabled"


### PR DESCRIPTION
Extend gadget-config-defaults test with refresh.retain to ensure we handle integers correctly.
