### PR TITLE
o/snapstate: deal with potentially invalid type of refresh.retain value due to lax validation

### DIFF
--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -340,6 +340,7 @@ var (
 	PruneSnapsHold             = pruneSnapsHold
 	CreateGateAutoRefreshHooks = createGateAutoRefreshHooks
 	AutoRefreshPhase1          = autoRefreshPhase1
+	RefreshRetain              = refreshRetain
 )
 
 func MockTimeNow(f func() time.Time) (restore func()) {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -278,13 +278,13 @@ func refreshRetain(st *state.State) int {
 		case string:
 			retain, err = strconv.Atoi(v)
 		default:
-			logger.Noticef("refresh.retain system option has unexpected type: %v (type: %T):", val, val)
+			logger.Noticef("internal error: refresh.retain system option has unexpected type: %T", v)
 		}
 	}
 
 	// this covers error from Get() and strconv above.
 	if err != nil && !config.IsNoOption(err) {
-		logger.Noticef("refresh.retain system option is not valid: %v:", err)
+		logger.Noticef("internal error: refresh.retain system option is not valid: %v:", err)
 	}
 
 	// not set, use default value

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -284,7 +284,7 @@ func refreshRetain(st *state.State) int {
 
 	// this covers error from Get() and strconv above.
 	if err != nil && !config.IsNoOption(err) {
-		logger.Noticef("internal error: refresh.retain system option is not valid: %v:", err)
+		logger.Noticef("internal error: refresh.retain system option is not valid: %v", err)
 	}
 
 	// not set, use default value

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -254,6 +255,48 @@ func optedIntoSnapdSnap(st *state.State) (bool, error) {
 		return false, err
 	}
 	return experimentalAllowSnapd, nil
+}
+
+// refreshRetain returns refresh.retain value if set, or the default value (different for core and classic).
+// It deals with potentially wrong type due to lax validation.
+func refreshRetain(st *state.State) int {
+	var val interface{}
+	// due to lax validation of refresh.retain on set we might end up having a string representing a number here; handle it gracefully
+	// for backwards compatibility.
+	err := config.NewTransaction(st).Get("core", "refresh.retain", &val)
+	var retain int
+	if err == nil {
+		switch v := val.(type) {
+		// this is the expected value; confusingly, since we pass interface{} to Get(), we get json.Number type; if int reference was passed,
+		// we would get an int instead of json.Number.
+		case json.Number:
+			retain, err = strconv.Atoi(string(v))
+		// not really expected when requesting interface{}.
+		case int:
+			retain = v
+		// we can get string here due to lax validation of refresh.retain on Set in older releases.
+		case string:
+			retain, err = strconv.Atoi(v)
+		default:
+			logger.Noticef("refresh.retain system option has unexpected type: %v (type: %T):", val, val)
+		}
+	}
+
+	// this covers error from Get() and strconv above.
+	if err != nil && !config.IsNoOption(err) {
+		logger.Noticef("refresh.retain system option is not valid: %v:", err)
+	}
+
+	// not set, use default value
+	if retain == 0 {
+		// on classic we only keep 2 copies by default
+		if release.OnClassic {
+			retain = 2
+		} else {
+			retain = 3
+		}
+	}
+	return retain
 }
 
 func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int, fromChange string, inUseCheck func(snap.Type) (boot.InUseFunc, error)) (*state.TaskSet, error) {
@@ -486,15 +529,7 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 
 	// Do not do that if we are reverting to a local revision
 	if snapst.IsInstalled() && !snapsup.Flags.Revert {
-		var retain int
-		if err := config.NewTransaction(st).Get("core", "refresh.retain", &retain); err != nil {
-			// on classic we only keep 2 copies by default
-			if release.OnClassic {
-				retain = 2
-			} else {
-				retain = 3
-			}
-		}
+		retain := refreshRetain(st)
 
 		// if we're not using an already present revision, account for the one being added
 		if snapst.LastIndex(targetRevision) == -1 {

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -4532,11 +4532,36 @@ func (s *snapmgrTestSuite) TestRefreshRetain(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	for i, val := range []interface{}{1, json.Number("2"), "3"} {
+	restore := release.MockOnClassic(true)
+	defer restore()
+
+	// default value for classic
+	c.Assert(snapstate.RefreshRetain(st), Equals, 2)
+
+	release.MockOnClassic(false)
+	// default value for core
+	c.Assert(snapstate.RefreshRetain(st), Equals, 3)
+
+	buf, restoreLogger := logger.MockLogger()
+	defer restoreLogger()
+
+	for i, val := range []struct {
+		input    interface{}
+		expected int
+		msg      string
+	}{
+		{1, 1, "^$"},
+		{json.Number("2"), 2, "^$"},
+		{"6", 6, "^$"},
+		// invalid => default value for core
+		{map[string]interface{}{"foo": "bar"}, 3, `.*internal error: refresh.retain system option has unexpected type: map\[string\]interface {}\n`},
+	} {
 		tr := config.NewTransaction(s.state)
-		tr.Set("core", "refresh.retain", val)
+		tr.Set("core", "refresh.retain", val.input)
 		tr.Commit()
-		c.Assert(snapstate.RefreshRetain(st), Equals, i+1, Commentf("#%d", i))
+		c.Assert(snapstate.RefreshRetain(st), Equals, val.expected, Commentf("#%d", i))
+		c.Assert(buf.String(), Matches, val.msg, Commentf("#%d", i))
+		buf.Reset()
 	}
 }
 

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -4527,6 +4527,19 @@ func (s *snapmgrTestSuite) TestSeqRetainConf(c *C) {
 	}
 }
 
+func (s *snapmgrTestSuite) TestRefreshRetain(c *C) {
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	for i, val := range []interface{}{1, json.Number("2"), "3"} {
+		tr := config.NewTransaction(s.state)
+		tr.Set("core", "refresh.retain", val)
+		tr.Commit()
+		c.Assert(snapstate.RefreshRetain(st), Equals, i+1, Commentf("#%d", i))
+	}
+}
+
 func (s *snapmgrTestSuite) TestSnapStateNoLocalRevision(c *C) {
 	si7 := snap.SideInfo{
 		RealName: "some-snap",


### PR DESCRIPTION
The validation of refresh.retain value is too lax and allows a string to be passed, e.g.

```
$ sudo snap set system refresh.retain=\"2\"

$ sudo snap get system refresh.retain
2

$ sudo snap get -d system refresh.retain
{
	"refresh.retain": "2"
}
```
Same thing is of course possible when using our REST API.

(using -d flag reveals it's stored as string; note that `snap set system refresh.retain=\"aaa\"' will fail, so we are good on that front).

This causes an issue in snapstate where refresh.retain value is read; unexpected type is silently ignored and we revert to the default retain value (2 or 3 depending on classic/core).

The PR fixes this by expecting either a json.Number or string. 
This fixes LP: #1947724