### PR TITLE
tests: fix snap-run-gdbserver test by retrying the check

### DIFF
--- a/tests/main/snap-run-gdbserver/task.yaml
+++ b/tests/main/snap-run-gdbserver/task.yaml
@@ -33,5 +33,5 @@ execute: |
     echo c | eval $gdb_cmd
 
     # ensure the program ran and was running as a user
-    MATCH hello-hello-hello < stdout
+    retry --wait 1 -n 5 sh -c 'MATCH hello-hello-hello < stdout'
     MATCH "uid:$(id -u test)" < stdout


### PR DESCRIPTION
The test fails doing 'MATCH hello-hello-hello < stdout'

But during the debug I see the output is in stdout file, the problem
seems to be a race between the tool and the check.

The solution found is to retry the check.

