### PR TITLE
tests: get lxd snap from candidate channel

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -40,7 +40,7 @@ environment:
     SUDO_UID: ""
     TRUST_TEST_KEYS: '$(HOST: echo "${SPREAD_TRUST_TEST_KEYS:-true}")'
     # a global setting for LXD channel to use in the tests
-    LXD_SNAP_CHANNEL: "latest/edge"
+    LXD_SNAP_CHANNEL: "latest/candidate"
     UBUNTU_IMAGE_SNAP_CHANNEL: "latest/edge"
     CORE_CHANNEL: '$(HOST: echo "${SPREAD_CORE_CHANNEL:-edge}")'
     BASE_CHANNEL: '$(HOST: echo "${SPREAD_BASE_CHANNEL:-edge}")'


### PR DESCRIPTION
This is because all the tests that use lxd are failing with the
following/similar error

+ VERSION_ID=20.04
+ lxd.lxc launch --quiet ubuntu:20.04 my-ubuntu
Error: Failed to run: /snap/lxd/current/bin/lxd forkstart my-ubuntu
/var/snap/lxd/common/lxd/containers
/var/snap/lxd/common/lxd/logs/my-ubuntu/lxc.conf:
Try `lxc info --show-log local:my-ubuntu` for more info
-----

I'll create another change to revert this to edge.
