### PR TITLE
cmd: set core22 migration related env vars and update spread test

### DIFF
--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -403,6 +403,14 @@ func createUserDataDirs(info *snap.Info, opts *dirs.SnapDirOptions) error {
 	instanceUserData := info.UserDataDir(usr.HomeDir, opts)
 	instanceCommonUserData := info.UserCommonDataDir(usr.HomeDir, opts)
 	createDirs := []string{instanceUserData, instanceCommonUserData}
+
+	if opts.MigratedToExposedHome {
+		createDirs = append(createDirs,
+			filepath.Join(info.UserDataDir(usr.HomeDir, opts), "data"),
+			filepath.Join(info.UserDataDir(usr.HomeDir, opts), "config"),
+			filepath.Join(info.UserDataDir(usr.HomeDir, opts), "cache"))
+	}
+
 	if info.InstanceKey != "" {
 		// parallel instance snaps get additional mapping in their mount
 		// namespace, namely /home/joe/snap/foo_bar ->
@@ -1256,13 +1264,16 @@ func getSnapDirOptions(snap string) (*dirs.SnapDirOptions, error) {
 	}
 
 	var seq struct {
-		MigratedToHiddenDir bool `json:"migrated-hidden"`
+		MigratedToHiddenDir   bool `json:"migrated-hidden"`
+		MigratedToExposedHome bool `json:"migrated-exposed-home"`
 	}
 	if err := json.Unmarshal(data, &seq); err != nil {
 		return nil, err
 	}
 
 	opts.HiddenSnapDataDir = seq.MigratedToHiddenDir
+	opts.MigratedToExposedHome = seq.MigratedToExposedHome
+
 	return &opts, nil
 }
 

--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -2002,9 +2002,11 @@ func (s *RunSuite) TestGetSnapDirOptions(c *check.C) {
 	// write sequence file
 	seqFile := filepath.Join(dirs.SnapSeqDir, "somesnap.json")
 	str := struct {
-		Migrated bool `json:"migrated-hidden"`
+		MigratedHidden        bool `json:"migrated-hidden"`
+		MigratedToExposedHome bool `json:"migrated-exposed-home"`
 	}{
-		Migrated: true,
+		MigratedHidden:        true,
+		MigratedToExposedHome: true,
 	}
 	data, err := json.Marshal(&str)
 	c.Assert(err, check.IsNil)
@@ -2015,7 +2017,7 @@ func (s *RunSuite) TestGetSnapDirOptions(c *check.C) {
 
 	opts, err := snaprun.GetSnapDirOptions("somesnap")
 	c.Assert(err, check.IsNil)
-	c.Assert(opts, check.DeepEquals, &dirs.SnapDirOptions{HiddenSnapDataDir: true})
+	c.Assert(opts, check.DeepEquals, &dirs.SnapDirOptions{HiddenSnapDataDir: true, MigratedToExposedHome: true})
 }
 
 func (s *RunSuite) TestRunDebugLog(c *check.C) {

--- a/snap/snapenv/snapenv.go
+++ b/snap/snapenv/snapenv.go
@@ -102,6 +102,10 @@ func basicEnv(info *snap.Info) osutil.Environment {
 // used by so many other modules, we run into circular dependencies if it's
 // somewhere more reasonable like the snappy module.
 func userEnv(info *snap.Info, home string, opts *dirs.SnapDirOptions) osutil.Environment {
+	if opts == nil {
+		opts = &dirs.SnapDirOptions{}
+	}
+
 	// To keep things simple the user variables always point to the
 	// instance-specific directories.
 	env := osutil.Environment{
@@ -122,5 +126,14 @@ func userEnv(info *snap.Info, home string, opts *dirs.SnapDirOptions) osutil.Env
 	}
 	// Provide the location of the real home directory.
 	env["SNAP_REAL_HOME"] = home
+
+	if opts.MigratedToExposedHome {
+		env["XDG_DATA_HOME"] = filepath.Join(info.UserDataDir(home, opts), "data")
+		env["XDG_CONFIG_HOME"] = filepath.Join(info.UserDataDir(home, opts), "config")
+		env["XDG_CACHE_HOME"] = filepath.Join(info.UserDataDir(home, opts), "cache")
+
+		env["SNAP_USER_HOME"] = info.UserExposedHomeDir(home)
+		env["HOME"] = info.UserExposedHomeDir(home)
+	}
 	return env
 }

--- a/snap/snapenv/snapenv_test.go
+++ b/snap/snapenv/snapenv_test.go
@@ -305,13 +305,30 @@ func (s *HTestSuite) TestHiddenDirEnv(c *C) {
 		opts *dirs.SnapDirOptions
 	}{
 		{dir: dirs.UserHomeSnapDir, opts: nil},
-		{dir: dirs.HiddenSnapDataHomeDir, opts: &dirs.SnapDirOptions{HiddenSnapDataDir: true}}} {
+		{dir: dirs.HiddenSnapDataHomeDir, opts: &dirs.SnapDirOptions{HiddenSnapDataDir: true}},
+		{dir: dirs.HiddenSnapDataHomeDir, opts: &dirs.SnapDirOptions{HiddenSnapDataDir: true, MigratedToExposedHome: true}}} {
 		env := osutil.Environment{}
 		ExtendEnvForRun(env, mockSnapInfo, t.opts)
 
 		c.Check(env["SNAP_USER_COMMON"], Equals, filepath.Join(testDir, t.dir, mockSnapInfo.SuggestedName, "common"))
 		c.Check(env["SNAP_USER_DATA"], DeepEquals, filepath.Join(testDir, t.dir, mockSnapInfo.SuggestedName, mockSnapInfo.Revision.String()))
-		c.Check(env["HOME"], DeepEquals, filepath.Join(testDir, t.dir, mockSnapInfo.SuggestedName, mockSnapInfo.Revision.String()))
+
+		if t.opts != nil && t.opts.MigratedToExposedHome {
+			exposedSnapDir := filepath.Join(testDir, dirs.ExposedSnapHomeDir, mockSnapInfo.SuggestedName)
+			c.Check(env["HOME"], DeepEquals, exposedSnapDir)
+			c.Check(env["SNAP_USER_HOME"], DeepEquals, exposedSnapDir)
+
+			c.Check(env["XDG_DATA_HOME"], Equals, filepath.Join(testDir, t.dir, mockSnapInfo.SuggestedName, mockSnapInfo.Revision.String(), "data"))
+			c.Check(env["XDG_CONFIG_HOME"], Equals, filepath.Join(testDir, t.dir, mockSnapInfo.SuggestedName, mockSnapInfo.Revision.String(), "config"))
+			c.Check(env["XDG_CACHE_HOME"], Equals, filepath.Join(testDir, t.dir, mockSnapInfo.SuggestedName, mockSnapInfo.Revision.String(), "cache"))
+		} else {
+			c.Check(env["HOME"], DeepEquals, filepath.Join(testDir, t.dir, mockSnapInfo.SuggestedName, mockSnapInfo.Revision.String()))
+			c.Check(env["SNAP_USER_HOME"], Equals, "")
+
+			c.Check(env["XDG_DATA_HOME"], Equals, "")
+			c.Check(env["XDG_CONFIG_HOME"], Equals, "")
+			c.Check(env["XDG_CACHE_HOME"], Equals, "")
+		}
 	}
 }
 

--- a/tests/main/hidden-snap-dir/task.yaml
+++ b/tests/main/hidden-snap-dir/task.yaml
@@ -22,13 +22,13 @@ execute: |
 
     # Checks that the env vars are as expected after the migration.
     check_env() {
+      echo "Check the env vars were migrated"
+
       local CHECK_EXPOSED_HOME="no"
       if [ "$1" = "--with-exposed-home" ]; then
         CHECK_EXPOSED_HOME="yes"
         shift
       fi
-
-      echo "Check the env vars were migrated"
       local REV="$1"
 
       snapEnv=$("$NAME".env)
@@ -49,13 +49,13 @@ execute: |
 
     # Checks that the snap dirs are as expected after the migration.
     check_dirs() {
+      echo "Check directories were migrated"
+
       local CHECK_EXPOSED_HOME="no"
       if [ "$1" = "--with-exposed-home" ]; then
         CHECK_EXPOSED_HOME="yes"
         shift
       fi
-
-      echo "Check directories were migrated"
       local REV="$1"
 
       test -d "$HOME/.snap/data/$NAME"
@@ -68,7 +68,7 @@ execute: |
 
       not test -d "$HOME/snap/$NAME"
 
-      if [ "$2" = "yes" ]; then
+      if [ "$CHECK_EXPOSED_HOME" = "yes" ]; then
         echo "Checking core22 migration related dirs"
         test -d "$HOME/Snap/$NAME"
         test -d "$HOME/.snap/data/$NAME/$REV/data"
@@ -80,13 +80,13 @@ execute: |
     # Checks that there is a file named 'file' in the new dirs containing the
     # expected data
     check_data() {
+      echo "Check that the written data was migrated"
+
       local CHECK_EXPOSED_HOME="no"
       if [ "$1" = "--with-exposed-home" ]; then
         CHECK_EXPOSED_HOME="yes"
         shift
       fi
-
-      echo "Check that the written data was migrated"
       local REV="$1"
       local EXPECTED_DATA="$2"
 

--- a/tests/main/hidden-snap-dir/task.yaml
+++ b/tests/main/hidden-snap-dir/task.yaml
@@ -8,13 +8,79 @@ environment:
     NAME: test-snapd-tools
 
 prepare: |
-    snap pack "$TESTSLIB"/snaps/"$NAME"
+    snap pack "$TESTSLIB/snaps/$NAME"
     "$TESTSTOOLS"/snaps-state install-local "$NAME"
 
 restore: |
     snap unset system experimental.hidden-snap-folder
 
 execute: |
+    # core22 snap isn't available for x86
+    if os.query is-pc-i386; then
+      exit 0
+    fi
+
+    # Checks that the env vars are as expected after the migration. 1st parameter
+    # is the current revision; 2nd parameter toggles ~/Snap related checks
+    # ("true" does the checks, anything else doesn't)
+    check_env() {
+      echo "Check the env vars were migrated"
+
+      snapEnv=$("$NAME".env)
+      echo "$snapEnv" | MATCH "SNAP_USER_DATA=$HOME/\.snap/data/$NAME/$1"
+      echo "$snapEnv" | MATCH "SNAP_USER_COMMON=$HOME/\.snap/data/$NAME/common"
+
+      if [ "$2" = "true" ]; then
+        echo "Checking core22 migration related env vars"
+        echo "$snapEnv" | MATCH "HOME=$HOME/Snap"
+        echo "$snapEnv" | MATCH "SNAP_USER_HOME=$HOME/Snap"
+        echo "$snapEnv" | MATCH "XDG_DATA_HOME=$HOME/\.snap/data/$NAME/$1/data"
+        echo "$snapEnv" | MATCH "XDG_CACHE_HOME=$HOME/\.snap/data/$NAME/$1/cache"
+        echo "$snapEnv" | MATCH "XDG_CONFIG_HOME=$HOME/\.snap/data/$NAME/$1/config"
+      else
+        echo "$snapEnv" | MATCH "HOME=$HOME/\.snap/data/$NAME/$1"
+      fi
+    }
+
+    # Checks that the snap dirs are as expected after the migration. 1st parameter
+    # is the current revision. 2nd parameter toggles ~/Snap related checks
+    # ("true" does the checks, anything else doesn't)
+    check_dirs() {
+      echo "Check directories were migrated"
+
+      test -d "$HOME/.snap/data/$NAME"
+      test -d "$HOME/.snap/data/$NAME/common"
+      test -d "$HOME/.snap/data/$NAME/$1"
+      if [ "$(readlink "$HOME/.snap/data/$NAME/current")" != "$1" ]; then
+        echo "expected 'current' to point to new revision after refresh"
+        exit 1
+      fi
+
+      not test -d "$HOME/snap/$NAME"
+
+      if [ "$2" = "true" ]; then
+        echo "Checking core22 migration related dirs"
+        test -d "$HOME/Snap/$NAME"
+        test -d "$HOME/.snap/data/$NAME/$1/data"
+        test -d "$HOME/.snap/data/$NAME/$1/config"
+        test -d "$HOME/.snap/data/$NAME/$1/cache"
+      fi
+    }
+
+    # Checks that there is a file named 'file' in the new dirs containing the
+    # expected data. 1st parameter is the current revision; 2nd parameter is
+    # the expected file contents; 3rd parameter toggles ~/Snap related checks
+    check_data() {
+      echo "Check that the written data was migrated"
+
+      MATCH "$2" < "$HOME/.snap/data/$NAME/common/file"
+      MATCH "$2" < "$HOME/.snap/data/$NAME/$1/file"
+
+      if [ "$3" = "true" ]; then
+        MATCH "$2" < "$HOME/Snap/$NAME/file"
+      fi
+    }
+
     echo "Set experimental hidden snap folder feature"
     snap set system experimental.hidden-snap-folder=true
 
@@ -27,63 +93,48 @@ execute: |
     not test -d "$HOME"/.snap/data
 
     echo "Take a snapshot"
-    "$NAME".cmd echo "prev_data" > "$HOME"/snap/"$NAME"/current/data
+    "$NAME".cmd echo "prev_data" > "$HOME/snap/$NAME/current/file"
     # get the snapshot number from the 2nd line (the 1st line is the header)
     snapshot=$(snap save "$NAME" | awk 'FNR == 2 {print $1}')
 
     echo "Write data to user data dirs"
-    "$NAME".echo "data" > "$HOME"/snap/"$NAME"/current/data
-    "$NAME".echo "common" > "$HOME"/snap/"$NAME"/common/common
+    data="old_data"
+    "$NAME".echo "$data" > "$HOME/snap/$NAME/current/file"
+    "$NAME".echo "$data" > "$HOME/snap/$NAME/common/file"
 
     echo "Refresh the snap"
     "$TESTSTOOLS"/snaps-state install-local "$NAME"
 
-    echo "Check snap directory was migrated"
-    test -d "$HOME"/.snap/data/"$NAME"
-    test -d "$HOME"/.snap/data/"$NAME"/common
-    test -d "$HOME"/.snap/data/"$NAME"/x2
-    not test -d "$HOME"/snap/"$NAME"
-
-    echo "Check the env vars point to ~/.snap/data"
-    snapEnv=$("$NAME".env)
-    echo "$snapEnv" | MATCH "SNAP_USER_DATA=$HOME/\.snap/data/$NAME/x2"
-    echo "$snapEnv" | MATCH "SNAP_USER_COMMON=$HOME/\.snap/data/$NAME/common"
-
-    # 'current' symlink is created just before the snap runs, so this check
-    # must come after a snap run
-    if [ "$(readlink "$HOME"/.snap/data/"$NAME"/current)" != "x2" ]; then
-      echo "expected 'current' to point to new revision after refresh"
-      exit 1
-    fi
-
-    echo "Check that the written data is in the new dir"
-    MATCH "common" < "$HOME"/.snap/data/"$NAME"/common/common
-    MATCH "data" < "$HOME"/.snap/data/"$NAME"/x2/data
+    # Check env vars, dirs and data after the migration
+    check_env "x2" ""
+    # Note: some dirs are created just before the snap runs for the 1st time,
+    # so this check must come after a snap run
+    check_dirs "x2" ""
+    check_data "x2" "$data" ""
 
     echo "Check the snap can write to the new dirs"
     #shellcheck disable=SC2016
-    "$NAME".cmd sh -c 'echo "new_data" > "$SNAP_USER_DATA"/new_data'
+    "$NAME".cmd sh -c 'echo "new_data" > "$SNAP_USER_DATA"/file'
     #shellcheck disable=SC2016
-    "$NAME".cmd sh -c 'echo "new_common" > "$SNAP_USER_COMMON"/new_common'
-    MATCH "new_common" < "$HOME"/.snap/data/"$NAME"/common/new_common
-    MATCH "new_data" < "$HOME"/.snap/data/"$NAME"/x2/new_data
+    "$NAME".cmd sh -c 'echo "new_data" > "$SNAP_USER_COMMON"/file'
+
+    check_data "x2" "new_data" ""
 
     echo "Restore snapshot and check data was restored"
     snap restore "$snapshot"
-    MATCH "prev_data" < "$HOME"/.snap/data/"$NAME"/x2/data
+    MATCH "prev_data" < "$HOME/.snap/data/$NAME/x2/file"
 
     echo "Check that snap starts off hidden after a fresh install"
     snap remove --purge "$NAME"
     "$TESTSTOOLS"/snaps-state install-local "$NAME"
 
-    test -d "$HOME"/.snap/data/"$NAME"
-    not test -d "$HOME"/snap/"$NAME"
-    snapEnv=$("$NAME".env)
-    echo "$snapEnv" | MATCH "SNAP_USER_DATA=$HOME/\.snap/data/$NAME/x1"
-    echo "$snapEnv" | MATCH "SNAP_USER_COMMON=$HOME/\.snap/data/$NAME/common"
+    check_env "x1" ""
+    check_dirs "x1" ""
 
-    "$NAME".echo "data" > "$HOME"/.snap/data/"$NAME"/x1/data
-    "$NAME".echo "common" > "$HOME"/.snap/data/"$NAME"/common/common
+    data="new_data"
+    "$NAME".echo "$data" > "$HOME/.snap/data/$NAME/x1/file"
+    "$NAME".echo "$data" > "$HOME/.snap/data/$NAME/common/file"
+    check_data "x1" "$data" ""
 
     echo "Revert migration (unset flag and refresh)"
     snap unset system experimental.hidden-snap-folder
@@ -91,12 +142,27 @@ execute: |
 
     echo "Check snap user data was moved back"
     not test -d "$HOME"/.snap/data
-    test -d "$HOME"/snap/"$NAME"
+    test -d "$HOME/snap/$NAME"
 
-    MATCH "common" < "$HOME"/snap/"$NAME"/common/common
-    MATCH "data" < "$HOME"/snap/"$NAME"/x2/data
+    MATCH "$data" < "$HOME/snap/$NAME/common/file"
+    MATCH "$data" < "$HOME/snap/$NAME/x2/file"
 
     echo "Check environment variables were restored"
     snapEnv=$("$NAME".env)
     echo "$snapEnv" | MATCH "SNAP_USER_DATA=$HOME/snap/$NAME/x2"
     echo "$snapEnv" | MATCH "SNAP_USER_COMMON=$HOME/snap/$NAME/common"
+    echo "$snapEnv" | MATCH "HOME=$HOME/snap/$NAME/x2"
+
+    data="old_data"
+    "$NAME".echo "$data" > "$HOME/snap/$NAME/x2/file"
+    "$NAME".echo "$data" > "$HOME/snap/$NAME/common/file"
+
+    echo "Update snap to core22"
+    snap install --edge core22
+    echo -e "\nbase: core22" >> "$TESTSLIB/snaps/$NAME/meta/snap.yaml"
+    snap pack "$TESTSLIB/snaps/$NAME"
+    snap install --dangerous "$NAME"_1.0_all.snap
+
+    check_env "x3" "true"
+    check_dirs "x3" "true"
+    check_data "x3" "$data" "true"

--- a/tests/main/hidden-snap-dir/task.yaml
+++ b/tests/main/hidden-snap-dir/task.yaml
@@ -20,17 +20,22 @@ execute: |
       exit 0
     fi
 
-    # Checks that the env vars are as expected after the migration. 1st parameter
-    # is the current revision; 2nd parameter toggles ~/Snap related checks
-    # ("true" does the checks, anything else doesn't)
+    # Checks that the env vars are as expected after the migration.
     check_env() {
+      local CHECK_EXPOSED_HOME="no"
+      if [ "$1" = "--with-exposed-home" ]; then
+        CHECK_EXPOSED_HOME="yes"
+        shift
+      fi
+
       echo "Check the env vars were migrated"
+      local REV="$1"
 
       snapEnv=$("$NAME".env)
-      echo "$snapEnv" | MATCH "SNAP_USER_DATA=$HOME/\.snap/data/$NAME/$1"
+      echo "$snapEnv" | MATCH "SNAP_USER_DATA=$HOME/\.snap/data/$NAME/$REV"
       echo "$snapEnv" | MATCH "SNAP_USER_COMMON=$HOME/\.snap/data/$NAME/common"
 
-      if [ "$2" = "true" ]; then
+      if [ "$CHECK_EXPOSED_HOME" = "yes" ]; then
         echo "Checking core22 migration related env vars"
         echo "$snapEnv" | MATCH "HOME=$HOME/Snap"
         echo "$snapEnv" | MATCH "SNAP_USER_HOME=$HOME/Snap"
@@ -42,42 +47,54 @@ execute: |
       fi
     }
 
-    # Checks that the snap dirs are as expected after the migration. 1st parameter
-    # is the current revision. 2nd parameter toggles ~/Snap related checks
-    # ("true" does the checks, anything else doesn't)
+    # Checks that the snap dirs are as expected after the migration.
     check_dirs() {
+      local CHECK_EXPOSED_HOME="no"
+      if [ "$1" = "--with-exposed-home" ]; then
+        CHECK_EXPOSED_HOME="yes"
+        shift
+      fi
+
       echo "Check directories were migrated"
+      local REV="$1"
 
       test -d "$HOME/.snap/data/$NAME"
       test -d "$HOME/.snap/data/$NAME/common"
-      test -d "$HOME/.snap/data/$NAME/$1"
-      if [ "$(readlink "$HOME/.snap/data/$NAME/current")" != "$1" ]; then
+      test -d "$HOME/.snap/data/$NAME/$REV"
+      if [ "$(readlink "$HOME/.snap/data/$NAME/current")" != "$REV" ]; then
         echo "expected 'current' to point to new revision after refresh"
         exit 1
       fi
 
       not test -d "$HOME/snap/$NAME"
 
-      if [ "$2" = "true" ]; then
+      if [ "$2" = "yes" ]; then
         echo "Checking core22 migration related dirs"
         test -d "$HOME/Snap/$NAME"
-        test -d "$HOME/.snap/data/$NAME/$1/data"
-        test -d "$HOME/.snap/data/$NAME/$1/config"
-        test -d "$HOME/.snap/data/$NAME/$1/cache"
+        test -d "$HOME/.snap/data/$NAME/$REV/data"
+        test -d "$HOME/.snap/data/$NAME/$REV/config"
+        test -d "$HOME/.snap/data/$NAME/$REV/cache"
       fi
     }
 
     # Checks that there is a file named 'file' in the new dirs containing the
-    # expected data. 1st parameter is the current revision; 2nd parameter is
-    # the expected file contents; 3rd parameter toggles ~/Snap related checks
+    # expected data
     check_data() {
+      local CHECK_EXPOSED_HOME="no"
+      if [ "$1" = "--with-exposed-home" ]; then
+        CHECK_EXPOSED_HOME="yes"
+        shift
+      fi
+
       echo "Check that the written data was migrated"
+      local REV="$1"
+      local EXPECTED_DATA="$2"
 
-      MATCH "$2" < "$HOME/.snap/data/$NAME/common/file"
-      MATCH "$2" < "$HOME/.snap/data/$NAME/$1/file"
+      MATCH "$EXPECTED_DATA" < "$HOME/.snap/data/$NAME/common/file"
+      MATCH "$EXPECTED_DATA" < "$HOME/.snap/data/$NAME/$REV/file"
 
-      if [ "$3" = "true" ]; then
-        MATCH "$2" < "$HOME/Snap/$NAME/file"
+      if [ "$CHECK_EXPOSED_HOME" = "yes" ]; then
+        MATCH "$EXPECTED_DATA" < "$HOME/Snap/$NAME/file"
       fi
     }
 
@@ -106,11 +123,11 @@ execute: |
     "$TESTSTOOLS"/snaps-state install-local "$NAME"
 
     # Check env vars, dirs and data after the migration
-    check_env "x2" ""
+    check_env "x2"
     # Note: some dirs are created just before the snap runs for the 1st time,
     # so this check must come after a snap run
     check_dirs "x2" ""
-    check_data "x2" "$data" ""
+    check_data "x2" "$data"
 
     echo "Check the snap can write to the new dirs"
     #shellcheck disable=SC2016
@@ -118,7 +135,7 @@ execute: |
     #shellcheck disable=SC2016
     "$NAME".cmd sh -c 'echo "new_data" > "$SNAP_USER_COMMON"/file'
 
-    check_data "x2" "new_data" ""
+    check_data "x2" "new_data"
 
     echo "Restore snapshot and check data was restored"
     snap restore "$snapshot"
@@ -128,13 +145,13 @@ execute: |
     snap remove --purge "$NAME"
     "$TESTSTOOLS"/snaps-state install-local "$NAME"
 
-    check_env "x1" ""
-    check_dirs "x1" ""
+    check_env "x1"
+    check_dirs "x1"
 
     data="new_data"
     "$NAME".echo "$data" > "$HOME/.snap/data/$NAME/x1/file"
     "$NAME".echo "$data" > "$HOME/.snap/data/$NAME/common/file"
-    check_data "x1" "$data" ""
+    check_data "x1" "$data"
 
     echo "Revert migration (unset flag and refresh)"
     snap unset system experimental.hidden-snap-folder
@@ -163,6 +180,6 @@ execute: |
     snap pack "$TESTSLIB/snaps/$NAME"
     snap install --dangerous "$NAME"_1.0_all.snap
 
-    check_env "x3" "true"
-    check_dirs "x3" "true"
-    check_data "x3" "$data" "true"
+    check_env "--with-exposed-home" "x3"
+    check_dirs "--with-exposed-home" "x3"
+    check_data "--with-exposed-home" "x3" "$data"

--- a/tests/main/hidden-snap-dir/task.yaml
+++ b/tests/main/hidden-snap-dir/task.yaml
@@ -39,11 +39,11 @@ execute: |
         echo "Checking core22 migration related env vars"
         echo "$snapEnv" | MATCH "HOME=$HOME/Snap"
         echo "$snapEnv" | MATCH "SNAP_USER_HOME=$HOME/Snap"
-        echo "$snapEnv" | MATCH "XDG_DATA_HOME=$HOME/\.snap/data/$NAME/$1/data"
-        echo "$snapEnv" | MATCH "XDG_CACHE_HOME=$HOME/\.snap/data/$NAME/$1/cache"
-        echo "$snapEnv" | MATCH "XDG_CONFIG_HOME=$HOME/\.snap/data/$NAME/$1/config"
+        echo "$snapEnv" | MATCH "XDG_DATA_HOME=$HOME/\.snap/data/$NAME/$REV/data"
+        echo "$snapEnv" | MATCH "XDG_CACHE_HOME=$HOME/\.snap/data/$NAME/$REV/cache"
+        echo "$snapEnv" | MATCH "XDG_CONFIG_HOME=$HOME/\.snap/data/$NAME/$REV/config"
       else
-        echo "$snapEnv" | MATCH "HOME=$HOME/\.snap/data/$NAME/$1"
+        echo "$snapEnv" | MATCH "HOME=$HOME/\.snap/data/$NAME/$REV"
       fi
     }
 


### PR DESCRIPTION
~This is based on https://github.com/snapcore/snapd/pull/11431 so only commits from fd486e65a8 (including) matter.~ fd486e65a8 sets environment variables related to the core22 migration. b95356d27e refactors and updates the spread tests