### PR TITLE
interfaces/cpu-control: add extra idleruntime data/reset files to cpu-control

### DIFF
--- a/interfaces/builtin/cpu_control.go
+++ b/interfaces/builtin/cpu_control.go
@@ -75,6 +75,10 @@ const cpuControlConnectedPlugAppArmor = `
 /proc/sys/kernel/sched_group_downmigrate rw,
 /proc/sys/kernel/sched_walt_rotate_big_tasks rw,
 /proc/sys/kernel/sched_boost rw,
+
+# see https://www.osadl.org/monitoring/add-on-patches/4.16.7-rt1...4.16.15-rt7/sched-add-per-cpu-load-measurement.patch.html
+/proc/idleruntime/{all,cpu[0-9][0-9]*}/data r,
+/proc/idleruntime/{all,cpu[0-9][0-9]*}/reset w,
 `
 
 func init() {


### PR DESCRIPTION
This is needed for some kernels with the mentioned patch where individual
monitoring of CPU's can be achieved by these files.

See also ticket 00329266 and LP bug 1962447