### PR TITLE
overlord, boot: fix unit tests on arches other than amd64

### DIFF
--- a/boot/assets_test.go
+++ b/boot/assets_test.go
@@ -28,6 +28,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/arch/archtest"
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/boot/boottest"
@@ -56,6 +57,8 @@ func (s *assetsSuite) SetUpTest(c *C) {
 
 	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error { return nil })
 	s.AddCleanup(restore)
+
+	s.AddCleanup(archtest.MockArchitecture("amd64"))
 }
 
 func checkContentGlob(c *C, glob string, expected []string) {

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -27,6 +27,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/arch/archtest"
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/boot/boottest"
@@ -60,6 +61,8 @@ func (s *makeBootableSuite) SetUpTest(c *C) {
 
 	s.bootloader = bootloadertest.Mock("mock", c.MkDir())
 	s.forceBootloader(s.bootloader)
+
+	s.AddCleanup(archtest.MockArchitecture("amd64"))
 }
 
 func makeSnap(c *C, name, yaml string, revno snap.Revision) (fn string, info *snap.Info) {

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -29,6 +29,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/arch/archtest"
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/boot/boottest"
@@ -57,6 +58,7 @@ func (s *sealSuite) SetUpTest(c *C) {
 	rootdir := c.MkDir()
 	dirs.SetRootDir(rootdir)
 	s.AddCleanup(func() { dirs.SetRootDir("/") })
+	s.AddCleanup(archtest.MockArchitecture("amd64"))
 }
 
 func mockKernelSeedSnap(rev snap.Revision) *seed.Snap {

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -43,6 +43,7 @@ import (
 	"gopkg.in/tomb.v2"
 	"gopkg.in/yaml.v2"
 
+	"github.com/snapcore/snapd/arch/archtest"
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/assertstest"
 	"github.com/snapcore/snapd/asserts/sysdb"
@@ -168,6 +169,8 @@ func (s *baseMgrsSuite) SetUpTest(c *C) {
 
 	// needed for system key generation
 	s.AddCleanup(osutil.MockMountInfo(""))
+
+	s.AddCleanup(archtest.MockArchitecture("amd64"))
 
 	err := os.MkdirAll(filepath.Dir(dirs.SnapStateFile), 0755)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
Couple of fixes for running unit tests on arches other than amd64.

See the failures of snapd builds on LP for amhf, arm64, s390s, ppc64el,  eg: https://launchpadlibrarian.net/588462410/buildlog_ubuntu-jammy-arm64.snapd_2.54.3-0~202203011107~ubuntu22.04.1_BUILDING.txt.gz