### PR TITLE
 many: add conversion for interface attribute values (2.54)

### DIFF
--- a/interfaces/connection.go
+++ b/interfaces/connection.go
@@ -86,7 +86,8 @@ func lookupAttr(staticAttrs map[string]interface{}, dynamicAttrs map[string]inte
 func getAttribute(snapName string, ifaceName string, staticAttrs map[string]interface{}, dynamicAttrs map[string]interface{}, path string, val interface{}) error {
 	v, ok := lookupAttr(staticAttrs, dynamicAttrs, path)
 	if !ok {
-		return fmt.Errorf("snap %q does not have attribute %q for interface %q", snapName, path, ifaceName)
+		err := fmt.Errorf("snap %q does not have attribute %q for interface %q", snapName, path, ifaceName)
+		return snap.AttributeNotFoundError{Err: err}
 	}
 
 	rt := reflect.TypeOf(val)

--- a/metautil/export_test.go
+++ b/metautil/export_test.go
@@ -1,0 +1,24 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package metautil
+
+var (
+	ConvertValue = convertValue
+)

--- a/metautil/type_conversions.go
+++ b/metautil/type_conversions.go
@@ -47,6 +47,24 @@ func convertValue(value reflect.Value, outputType reflect.Type) (reflect.Value, 
 		return outputValue, nil
 	case reflect.Interface:
 		return convertValue(value.Elem(), outputType)
+	case reflect.Map:
+		if outputType.Kind() != reflect.Map {
+			break
+		}
+		outputValue := reflect.MakeMapWithSize(outputType, value.Len())
+		iter := value.MapRange()
+		for iter.Next() {
+			convertedKey, err := convertValue(iter.Key(), outputType.Key())
+			if err != nil {
+				return nullValue, err
+			}
+			convertedValue, err := convertValue(iter.Value(), outputType.Elem())
+			if err != nil {
+				return nullValue, err
+			}
+			outputValue.SetMapIndex(convertedKey, convertedValue)
+		}
+		return outputValue, nil
 	}
 	return nullValue, fmt.Errorf(`cannot convert value "%v" into a %v`, value, outputType)
 }

--- a/metautil/type_conversions_test.go
+++ b/metautil/type_conversions_test.go
@@ -48,6 +48,9 @@ func (s *conversionssSuite) TestConvertHappy(c *C) {
 		// Complex types with conversion
 		{[]interface{}{"one", "two"}, []string{"one", "two"}},
 		{[]interface{}{24, 42}, []int{24, 42}},
+		{[]interface{}{[]string{"one"}, []string{"two"}}, [][]string{{"one"}, {"two"}}},
+		{[]interface{}{map[string]int{"one": 1}, map[string]int{"two": 2}}, []map[string]int{{"one": 1}, {"two": 2}}},
+		{map[interface{}]interface{}{"one": 1, "two": 2}, map[string]int{"one": 1, "two": 2}},
 	}
 
 	for _, testData := range data {
@@ -77,6 +80,9 @@ func (s *conversionssSuite) TestConvertUnhappy(c *C) {
 		{[]interface{}{1, "two", 3}, t([]int{}), `cannot convert value "two" into a int`},
 		{[]int{1, 2}, t([]string{}), `cannot convert value "1" into a string`},
 		{[]int{1, 2}, t(1), `cannot convert value "\[1 2\]" into a int`},
+		{map[interface{}]interface{}{"one": 1}, t(map[int]int{}), `cannot convert value "one" into a int`},
+		{map[interface{}]interface{}{1: 2}, t(map[int]string{}), `cannot convert value "2" into a string`},
+		{map[interface{}]interface{}{"one": 1}, t([]string{}), `cannot convert value "map\[one:1\]" into a \[\]string`},
 	}
 
 	for _, testData := range data {

--- a/metautil/type_conversions_test.go
+++ b/metautil/type_conversions_test.go
@@ -1,0 +1,91 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package metautil_test
+
+import (
+	"reflect"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/metautil"
+)
+
+type conversionssSuite struct{}
+
+var _ = Suite(&conversionssSuite{})
+
+func (s *conversionssSuite) TestConvertHappy(c *C) {
+	data := []struct {
+		inputValue    interface{}
+		expectedValue interface{}
+	}{
+		// Basic types
+		{"a string", "a string"},
+		{42, 42},
+		{true, true},
+
+		// Complex types with no conversion
+		{[]string{"one", "two"}, []string{"one", "two"}},
+		{[]int{24, 42}, []int{24, 42}},
+
+		// Complex types with conversion
+		{[]interface{}{"one", "two"}, []string{"one", "two"}},
+		{[]interface{}{24, 42}, []int{24, 42}},
+	}
+
+	for _, testData := range data {
+		inputValue := reflect.ValueOf(testData.inputValue)
+		outputType := reflect.TypeOf(testData.expectedValue)
+		expectedValue := testData.expectedValue
+		outputValue, err := metautil.ConvertValue(inputValue, outputType)
+		testTag := Commentf("%v -> %v", inputValue, expectedValue)
+		c.Check(err, IsNil, testTag)
+		c.Check(outputValue.Interface(), DeepEquals, expectedValue, testTag)
+	}
+}
+
+func (s *conversionssSuite) TestConvertUnhappy(c *C) {
+	t := reflect.TypeOf
+	data := []struct {
+		inputValue    interface{}
+		outputType    reflect.Type
+		expectedError string
+	}{
+		// Basic types
+		{"a string", t(42), `cannot convert value "a string" into a int`},
+		{true, t(""), `cannot convert value "true" into a string`},
+
+		// Complex types
+		{[]interface{}{"one", "two", 3}, t([]string{}), `cannot convert value "3" into a string`},
+		{[]interface{}{1, "two", 3}, t([]int{}), `cannot convert value "two" into a int`},
+		{[]int{1, 2}, t([]string{}), `cannot convert value "1" into a string`},
+		{[]int{1, 2}, t(1), `cannot convert value "\[1 2\]" into a int`},
+	}
+
+	for _, testData := range data {
+		inputValue := reflect.ValueOf(testData.inputValue)
+		outputType := testData.outputType
+		expectedError := testData.expectedError
+		outputValue, err := metautil.ConvertValue(inputValue, outputType)
+		testTag := Commentf("%v -> %T", inputValue, outputType)
+		c.Check(err, ErrorMatches, expectedError, testTag)
+		c.Check(outputValue.IsValid(), Equals, false, testTag)
+	}
+}

--- a/snap/info.go
+++ b/snap/info.go
@@ -565,9 +565,7 @@ func lookupAttr(attrs map[string]interface{}, path string) (interface{}, bool) {
 func getAttribute(snapName string, ifaceName string, attrs map[string]interface{}, key string, val interface{}) error {
 	v, ok := lookupAttr(attrs, key)
 	if !ok {
-		return AttributeNotFoundError{
-			fmt.Errorf("snap %q does not have attribute %q for interface %q", snapName, key, ifaceName),
-		}
+		return AttributeNotFoundError{fmt.Errorf("snap %q does not have attribute %q for interface %q", snapName, key, ifaceName)}
 	}
 
 	rt := reflect.TypeOf(val)

--- a/snap/info.go
+++ b/snap/info.go
@@ -518,6 +518,17 @@ type DeltaInfo struct {
 // sanity check that Info is a PlaceInfo
 var _ PlaceInfo = (*Info)(nil)
 
+type AttributeNotFoundError struct{ Err error }
+
+func (e AttributeNotFoundError) Error() string {
+	return e.Err.Error()
+}
+
+func (e AttributeNotFoundError) Is(target error) bool {
+	_, ok := target.(AttributeNotFoundError)
+	return ok
+}
+
 // PlugInfo provides information about a plug.
 type PlugInfo struct {
 	Snap *Info
@@ -554,7 +565,9 @@ func lookupAttr(attrs map[string]interface{}, path string) (interface{}, bool) {
 func getAttribute(snapName string, ifaceName string, attrs map[string]interface{}, key string, val interface{}) error {
 	v, ok := lookupAttr(attrs, key)
 	if !ok {
-		return fmt.Errorf("snap %q does not have attribute %q for interface %q", snapName, key, ifaceName)
+		return AttributeNotFoundError{
+			fmt.Errorf("snap %q does not have attribute %q for interface %q", snapName, key, ifaceName),
+		}
 	}
 
 	rt := reflect.TypeOf(val)

--- a/tests/main/degraded/task.yaml
+++ b/tests/main/degraded/task.yaml
@@ -1,5 +1,9 @@
 summary: Check that the system is not in "degraded" state
 
+# autopkgtest images sometimes have failing services (cosmic/s390x)
+# in their images so this test is not useful there.
+backends: [-autopkgtest]
+
 # run this early to ensure no test created failed units yet
 priority: 500
 


### PR DESCRIPTION
This is a minimal version of #11248 to support the 2.54 cherry-pick of the "custom-device" interface.