### PR TITLE
interfaces/network-control: add D-Bus rules for resolved too

### DIFF
--- a/interfaces/builtin/network_control.go
+++ b/interfaces/builtin/network_control.go
@@ -61,6 +61,13 @@ dbus send
      member="Resolve{Address,Hostname,Record,Service}"
      peer=(name="org.freedesktop.resolve1"),
 
+dbus (send)
+     bus=system
+     path="/org/freedesktop/resolve1"
+     interface="org.freedesktop.resolve1.Manager"
+     member="SetLink{DNS,MulticastDNS,Domains,LLMNR}"
+     peer=(label=unconfined),
+
 #include <abstractions/ssl_certs>
 
 capability net_admin,


### PR DESCRIPTION
Currently the only place these rules are exposed is in the network-manager
slot, which is only intended to be slotted by network-manager itself, but there
are valid use cases to be able to call these D-Bus endpoints for a snap
managing the network that is not network-manager too, so add them here.

Fixes: https://bugs.launchpad.net/snapd/+bug/1962501
