### PR TITLE
many: backport attrer interface changes to 2.54

### DIFF
--- a/interfaces/builtin/kernel_module_load.go
+++ b/interfaces/builtin/kernel_module_load.go
@@ -70,21 +70,13 @@ var kernelModuleNameRegexp = regexp.MustCompile(`^[-a-zA-Z0-9_]+$`)
 var kernelModuleOptionsRegexp = regexp.MustCompile(`^([a-zA-Z][a-zA-Z0-9_]*(=[[:graph:]]+)? *)+$`)
 
 func enumerateModules(plug interfaces.Attrer, handleModule func(moduleInfo *ModuleInfo) error) error {
-	modulesAttr, ok := plug.Lookup("modules")
-	if !ok {
-		return nil
-	}
-	modules, ok := modulesAttr.([]interface{})
-	if !ok {
+	var modules []map[string]interface{}
+	err := plug.Attr("modules", &modules)
+	if err != nil && !errors.Is(err, snap.AttributeNotFoundError{}) {
 		return modulesAttrTypeError
 	}
 
-	for _, m := range modules {
-		module, ok := m.(map[string]interface{})
-		if !ok {
-			return modulesAttrTypeError
-		}
-
+	for _, module := range modules {
 		name, ok := module["name"].(string)
 		if !ok {
 			return errors.New(`kernel-module-load "name" must be a string`)

--- a/interfaces/builtin/mount_control.go
+++ b/interfaces/builtin/mount_control.go
@@ -211,21 +211,13 @@ func parseStringList(mountEntry map[string]interface{}, fieldName string) ([]str
 }
 
 func enumerateMounts(plug interfaces.Attrer, fn func(mountInfo *MountInfo) error) error {
-	mountAttr, ok := plug.Lookup("mount")
-	if !ok {
-		return nil
-	}
-	mounts, ok := mountAttr.([]interface{})
-	if !ok {
+	var mounts []map[string]interface{}
+	err := plug.Attr("mount", &mounts)
+	if err != nil && !errors.Is(err, snap.AttributeNotFoundError{}) {
 		return mountAttrTypeError
 	}
 
-	for _, m := range mounts {
-		mount, ok := m.(map[string]interface{})
-		if !ok {
-			return mountAttrTypeError
-		}
-
+	for _, mount := range mounts {
 		what, ok := mount["what"].(string)
 		if !ok {
 			return fmt.Errorf(`mount-control "what" must be a string`)

--- a/interfaces/builtin/shared_memory.go
+++ b/interfaces/builtin/shared_memory.go
@@ -98,27 +98,13 @@ func validateSharedMemoryPath(path string) error {
 }
 
 func stringListAttribute(attrer interfaces.Attrer, key string) ([]string, error) {
-	parseError := func(key string, value interface{}) error {
-		return fmt.Errorf(`shared-memory %q attribute must be a list of strings, not "%v"`, key, value)
-	}
-	attr, ok := attrer.Lookup(key)
-	if !ok {
-		return nil, nil
-	}
-
-	attrList, ok := attr.([]interface{})
-	if !ok || len(attrList) == 0 {
-		return nil, parseError(key, attr)
+	var stringList []string
+	err := attrer.Attr(key, &stringList)
+	if err != nil && !errors.Is(err, snap.AttributeNotFoundError{}) {
+		value, _ := attrer.Lookup(key)
+		return nil, fmt.Errorf(`shared-memory %q attribute must be a list of strings, not "%v"`, key, value)
 	}
 
-	stringList := make([]string, 0, len(attrList))
-	for _, value := range attrList {
-		s, ok := value.(string)
-		if !ok {
-			return nil, parseError(key, attrList)
-		}
-		stringList = append(stringList, s)
-	}
 	return stringList, nil
 }
 

--- a/interfaces/connection.go
+++ b/interfaces/connection.go
@@ -86,7 +86,8 @@ func lookupAttr(staticAttrs map[string]interface{}, dynamicAttrs map[string]inte
 func getAttribute(snapName string, ifaceName string, staticAttrs map[string]interface{}, dynamicAttrs map[string]interface{}, path string, val interface{}) error {
 	v, ok := lookupAttr(staticAttrs, dynamicAttrs, path)
 	if !ok {
-		return fmt.Errorf("snap %q does not have attribute %q for interface %q", snapName, path, ifaceName)
+		err := fmt.Errorf("snap %q does not have attribute %q for interface %q", snapName, path, ifaceName)
+		return snap.AttributeNotFoundError{Err: err}
 	}
 
 	rt := reflect.TypeOf(val)

--- a/interfaces/connection.go
+++ b/interfaces/connection.go
@@ -21,10 +21,10 @@ package interfaces
 
 import (
 	"fmt"
-	"reflect"
 	"strings"
 
 	"github.com/snapcore/snapd/interfaces/utils"
+	"github.com/snapcore/snapd/metautil"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -90,17 +90,7 @@ func getAttribute(snapName string, ifaceName string, staticAttrs map[string]inte
 		return snap.AttributeNotFoundError{Err: err}
 	}
 
-	rt := reflect.TypeOf(val)
-	if rt.Kind() != reflect.Ptr || val == nil {
-		return fmt.Errorf("internal error: cannot get %q attribute of interface %q with non-pointer value", path, ifaceName)
-	}
-
-	if reflect.TypeOf(v) != rt.Elem() {
-		return fmt.Errorf("snap %q has interface %q with invalid value type %T for %q attribute: %T", snapName, ifaceName, v, path, val)
-	}
-	rv := reflect.ValueOf(val)
-	rv.Elem().Set(reflect.ValueOf(v))
-	return nil
+	return metautil.SetValueFromAttribute(snapName, ifaceName, path, v, val)
 }
 
 // NewConnectedSlot creates an object representing a connected slot.

--- a/interfaces/export_test.go
+++ b/interfaces/export_test.go
@@ -72,4 +72,7 @@ func MockReadBuildID(mock func(p string) (string, error)) (restore func()) {
 
 type SystemKey = systemKey
 
-var SystemKeyVersion = systemKeyVersion
+var (
+	GetAttribute     = getAttribute
+	SystemKeyVersion = systemKeyVersion
+)

--- a/metautil/export_test.go
+++ b/metautil/export_test.go
@@ -1,0 +1,24 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package metautil
+
+var (
+	ConvertValue = convertValue
+)

--- a/metautil/type_conversions.go
+++ b/metautil/type_conversions.go
@@ -47,6 +47,24 @@ func convertValue(value reflect.Value, outputType reflect.Type) (reflect.Value, 
 		return outputValue, nil
 	case reflect.Interface:
 		return convertValue(value.Elem(), outputType)
+	case reflect.Map:
+		if outputType.Kind() != reflect.Map {
+			break
+		}
+		outputValue := reflect.MakeMapWithSize(outputType, value.Len())
+		iter := value.MapRange()
+		for iter.Next() {
+			convertedKey, err := convertValue(iter.Key(), outputType.Key())
+			if err != nil {
+				return nullValue, err
+			}
+			convertedValue, err := convertValue(iter.Value(), outputType.Elem())
+			if err != nil {
+				return nullValue, err
+			}
+			outputValue.SetMapIndex(convertedKey, convertedValue)
+		}
+		return outputValue, nil
 	}
 	return nullValue, fmt.Errorf(`cannot convert value "%v" into a %v`, value, outputType)
 }

--- a/metautil/type_conversions.go
+++ b/metautil/type_conversions.go
@@ -51,6 +51,13 @@ func convertValue(value reflect.Value, outputType reflect.Type) (reflect.Value, 
 	return nullValue, fmt.Errorf(`cannot convert value "%v" into a %v`, value, outputType)
 }
 
+// SetValueFromAttribute attempts to convert the attribute value read from the
+// given snap/interface into the desired type.
+//
+// The snapName, ifaceName and attrName are only used to produce contextual
+// error messages, but are not otherwise significant. This function only
+// operates converting the attrVal parameter into a value which can fit into
+// the val parameter, which therefore must be a pointer.
 func SetValueFromAttribute(snapName string, ifaceName string, attrName string, attrVal interface{}, val interface{}) error {
 	rt := reflect.TypeOf(val)
 	if rt.Kind() != reflect.Ptr || val == nil {

--- a/metautil/type_conversions_test.go
+++ b/metautil/type_conversions_test.go
@@ -48,6 +48,9 @@ func (s *conversionssSuite) TestConvertHappy(c *C) {
 		// Complex types with conversion
 		{[]interface{}{"one", "two"}, []string{"one", "two"}},
 		{[]interface{}{24, 42}, []int{24, 42}},
+		{[]interface{}{[]string{"one"}, []string{"two"}}, [][]string{{"one"}, {"two"}}},
+		{[]interface{}{map[string]int{"one": 1}, map[string]int{"two": 2}}, []map[string]int{{"one": 1}, {"two": 2}}},
+		{map[interface{}]interface{}{"one": 1, "two": 2}, map[string]int{"one": 1, "two": 2}},
 	}
 
 	for _, testData := range data {
@@ -77,6 +80,9 @@ func (s *conversionssSuite) TestConvertUnhappy(c *C) {
 		{[]interface{}{1, "two", 3}, t([]int{}), `cannot convert value "two" into a int`},
 		{[]int{1, 2}, t([]string{}), `cannot convert value "1" into a string`},
 		{[]int{1, 2}, t(1), `cannot convert value "\[1 2\]" into a int`},
+		{map[interface{}]interface{}{"one": 1}, t(map[int]int{}), `cannot convert value "one" into a int`},
+		{map[interface{}]interface{}{1: 2}, t(map[int]string{}), `cannot convert value "2" into a string`},
+		{map[interface{}]interface{}{"one": 1}, t([]string{}), `cannot convert value "map\[one:1\]" into a \[\]string`},
 	}
 
 	for _, testData := range data {

--- a/metautil/type_conversions_test.go
+++ b/metautil/type_conversions_test.go
@@ -1,0 +1,91 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package metautil_test
+
+import (
+	"reflect"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/metautil"
+)
+
+type conversionssSuite struct{}
+
+var _ = Suite(&conversionssSuite{})
+
+func (s *conversionssSuite) TestConvertHappy(c *C) {
+	data := []struct {
+		inputValue    interface{}
+		expectedValue interface{}
+	}{
+		// Basic types
+		{"a string", "a string"},
+		{42, 42},
+		{true, true},
+
+		// Complex types with no conversion
+		{[]string{"one", "two"}, []string{"one", "two"}},
+		{[]int{24, 42}, []int{24, 42}},
+
+		// Complex types with conversion
+		{[]interface{}{"one", "two"}, []string{"one", "two"}},
+		{[]interface{}{24, 42}, []int{24, 42}},
+	}
+
+	for _, testData := range data {
+		inputValue := reflect.ValueOf(testData.inputValue)
+		outputType := reflect.TypeOf(testData.expectedValue)
+		expectedValue := testData.expectedValue
+		outputValue, err := metautil.ConvertValue(inputValue, outputType)
+		testTag := Commentf("%v -> %v", inputValue, expectedValue)
+		c.Check(err, IsNil, testTag)
+		c.Check(outputValue.Interface(), DeepEquals, expectedValue, testTag)
+	}
+}
+
+func (s *conversionssSuite) TestConvertUnhappy(c *C) {
+	t := reflect.TypeOf
+	data := []struct {
+		inputValue    interface{}
+		outputType    reflect.Type
+		expectedError string
+	}{
+		// Basic types
+		{"a string", t(42), `cannot convert value "a string" into a int`},
+		{true, t(""), `cannot convert value "true" into a string`},
+
+		// Complex types
+		{[]interface{}{"one", "two", 3}, t([]string{}), `cannot convert value "3" into a string`},
+		{[]interface{}{1, "two", 3}, t([]int{}), `cannot convert value "two" into a int`},
+		{[]int{1, 2}, t([]string{}), `cannot convert value "1" into a string`},
+		{[]int{1, 2}, t(1), `cannot convert value "\[1 2\]" into a int`},
+	}
+
+	for _, testData := range data {
+		inputValue := reflect.ValueOf(testData.inputValue)
+		outputType := testData.outputType
+		expectedError := testData.expectedError
+		outputValue, err := metautil.ConvertValue(inputValue, outputType)
+		testTag := Commentf("%v -> %T", inputValue, outputType)
+		c.Check(err, ErrorMatches, expectedError, testTag)
+		c.Check(outputValue.IsValid(), Equals, false, testTag)
+	}
+}

--- a/snap/export_test.go
+++ b/snap/export_test.go
@@ -24,6 +24,7 @@ var (
 	ValidateDescription          = validateDescription
 	ValidateTitle                = validateTitle
 	InfoFromSnapYamlWithSideInfo = infoFromSnapYamlWithSideInfo
+	GetAttribute                 = getAttribute
 )
 
 func (info *Info) ForceRenamePlug(oldName, newName string) {

--- a/snap/info.go
+++ b/snap/info.go
@@ -707,6 +707,17 @@ type DeltaInfo struct {
 // sanity check that Info is a PlaceInfo
 var _ PlaceInfo = (*Info)(nil)
 
+type AttributeNotFoundError struct{ Err error }
+
+func (e AttributeNotFoundError) Error() string {
+	return e.Err.Error()
+}
+
+func (e AttributeNotFoundError) Is(target error) bool {
+	_, ok := target.(AttributeNotFoundError)
+	return ok
+}
+
 // PlugInfo provides information about a plug.
 type PlugInfo struct {
 	Snap *Info
@@ -743,7 +754,9 @@ func lookupAttr(attrs map[string]interface{}, path string) (interface{}, bool) {
 func getAttribute(snapName string, ifaceName string, attrs map[string]interface{}, key string, val interface{}) error {
 	v, ok := lookupAttr(attrs, key)
 	if !ok {
-		return fmt.Errorf("snap %q does not have attribute %q for interface %q", snapName, key, ifaceName)
+		return AttributeNotFoundError{
+			fmt.Errorf("snap %q does not have attribute %q for interface %q", snapName, key, ifaceName),
+		}
 	}
 
 	rt := reflect.TypeOf(val)

--- a/snap/info.go
+++ b/snap/info.go
@@ -754,9 +754,7 @@ func lookupAttr(attrs map[string]interface{}, path string) (interface{}, bool) {
 func getAttribute(snapName string, ifaceName string, attrs map[string]interface{}, key string, val interface{}) error {
 	v, ok := lookupAttr(attrs, key)
 	if !ok {
-		return AttributeNotFoundError{
-			fmt.Errorf("snap %q does not have attribute %q for interface %q", snapName, key, ifaceName),
-		}
+		return AttributeNotFoundError{fmt.Errorf("snap %q does not have attribute %q for interface %q", snapName, key, ifaceName)}
 	}
 
 	return metautil.SetValueFromAttribute(snapName, ifaceName, key, v, val)

--- a/snap/info.go
+++ b/snap/info.go
@@ -26,12 +26,12 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"reflect"
 	"sort"
 	"strings"
 	"time"
 
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/metautil"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/sys"
 	"github.com/snapcore/snapd/snap/naming"
@@ -759,18 +759,7 @@ func getAttribute(snapName string, ifaceName string, attrs map[string]interface{
 		}
 	}
 
-	rt := reflect.TypeOf(val)
-	if rt.Kind() != reflect.Ptr || val == nil {
-		return fmt.Errorf("internal error: cannot get %q attribute of interface %q with non-pointer value", key, ifaceName)
-	}
-
-	if reflect.TypeOf(v) != rt.Elem() {
-		return fmt.Errorf("snap %q has interface %q with invalid value type for %q attribute", snapName, ifaceName, key)
-	}
-	rv := reflect.ValueOf(val)
-	rv.Elem().Set(reflect.ValueOf(v))
-
-	return nil
+	return metautil.SetValueFromAttribute(snapName, ifaceName, key, v, val)
 }
 
 func (plug *PlugInfo) Attr(key string, val interface{}) error {

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -1412,7 +1412,7 @@ func (s *infoSuite) TestPlugInfoAttr(c *C) {
 	c.Assert(plug.Attr("number", &intVal), IsNil)
 	c.Check(intVal, Equals, 123)
 
-	c.Check(plug.Attr("key", &intVal), ErrorMatches, `snap "snap" has interface "interface" with invalid value type for "key" attribute`)
+	c.Check(plug.Attr("key", &intVal), ErrorMatches, `snap "snap" has interface "interface" with invalid value type string for "key" attribute: \*int`)
 	c.Check(plug.Attr("unknown", &val), ErrorMatches, `snap "snap" does not have attribute "unknown" for interface "interface"`)
 	c.Check(plug.Attr("key", intVal), ErrorMatches, `internal error: cannot get "key" attribute of interface "interface" with non-pointer value`)
 }
@@ -1429,7 +1429,7 @@ func (s *infoSuite) TestSlotInfoAttr(c *C) {
 	c.Assert(slot.Attr("number", &intVal), IsNil)
 	c.Check(intVal, Equals, 123)
 
-	c.Check(slot.Attr("key", &intVal), ErrorMatches, `snap "snap" has interface "interface" with invalid value type for "key" attribute`)
+	c.Check(slot.Attr("key", &intVal), ErrorMatches, `snap "snap" has interface "interface" with invalid value type string for "key" attribute: \*int`)
 	c.Check(slot.Attr("unknown", &val), ErrorMatches, `snap "snap" does not have attribute "unknown" for interface "interface"`)
 	c.Check(slot.Attr("key", intVal), ErrorMatches, `internal error: cannot get "key" attribute of interface "interface" with non-pointer value`)
 }

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -20,6 +20,7 @@
 package snap_test
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -1862,4 +1863,24 @@ func (s *infoSuite) TestHelpersWithHiddenSnapFolder(c *C) {
 	c.Check(snap.UserDataDir("/home/bob", "name_instance", snap.R(1), opts), Equals, "/home/bob/.snap/data/name_instance/1")
 	c.Check(snap.UserCommonDataDir("/home/bob", "name_instance", opts), Equals, "/home/bob/.snap/data/name_instance/common")
 	c.Check(snap.UserSnapDir("/home/bob", "name_instance", opts), Equals, "/home/bob/.snap/data/name_instance")
+}
+
+func (s *infoSuite) TestGetAttributeUnhappy(c *C) {
+	attrs := map[string]interface{}{}
+	var stringVal string
+	err := snap.GetAttribute("snap0", "iface0", attrs, "non-existent", &stringVal)
+	c.Check(stringVal, Equals, "")
+	c.Check(err, ErrorMatches, `snap "snap0" does not have attribute "non-existent" for interface "iface0"`)
+	c.Check(errors.Is(err, snap.AttributeNotFoundError{}), Equals, true)
+}
+
+func (s *infoSuite) TestGetAttributeHappy(c *C) {
+	attrs := map[string]interface{}{
+		"attr0": "a string",
+		"attr1": 12,
+	}
+	var intVal int
+	err := snap.GetAttribute("snap0", "iface0", attrs, "attr1", &intVal)
+	c.Check(err, IsNil)
+	c.Check(intVal, Equals, 12)
 }


### PR DESCRIPTION
Same commits as in https://github.com/snapcore/snapd/pull/11248 (the only conflict was on the polkit interface test, which is absent in the release branch).