### PR TITLE
cmd/snap-preseed: support for core20 preseeding

### DIFF
--- a/cmd/snap-preseed/export_test.go
+++ b/cmd/snap-preseed/export_test.go
@@ -27,6 +27,7 @@ var (
 	Run                      = run
 	SystemSnapFromSeed       = systemSnapFromSeed
 	ChooseTargetSnapdVersion = chooseTargetSnapdVersion
+	CreatePreseedArtifact    = createPreseedArtifact
 )
 
 func MockOsGetuid(f func() int) (restore func()) {
@@ -47,10 +48,26 @@ func MockSnapdMountPath(path string) (restore func()) {
 	return func() { snapdMountPath = oldMountPath }
 }
 
-func MockSystemSnapFromSeed(f func(rootDir string) (string, error)) (restore func()) {
+func MockSystemSnapFromSeed(f func(rootDir, sysLabel string) (string, string, error)) (restore func()) {
 	oldSystemSnapFromSeed := systemSnapFromSeed
 	systemSnapFromSeed = f
 	return func() { systemSnapFromSeed = oldSystemSnapFromSeed }
+}
+
+func MockMakePreseedTempDir(f func() (string, error)) (restore func()) {
+	old := makePreseedTempDir
+	makePreseedTempDir = f
+	return func() {
+		makePreseedTempDir = old
+	}
+}
+
+func MockMakeWritableTempDir(f func() (string, error)) (restore func()) {
+	old := makeWritableTempDir
+	makeWritableTempDir = f
+	return func() {
+		makeWritableTempDir = old
+	}
 }
 
 func MockSeedOpen(f func(rootDir, label string) (seed.Seed, error)) (restore func()) {

--- a/cmd/snap-preseed/main.go
+++ b/cmd/snap-preseed/main.go
@@ -129,9 +129,9 @@ func run(parser *flags.Parser, args []string) (err error) {
 
 		// XXX: if prepareClassicChroot & runPreseedMode were refactored to
 		// use "chroot" inside runPreseedMode (and not syscall.Chroot at the
-		// beginning of prepareClassicChroot, then we could have a single
+		// beginning of prepareClassicChroot), then we could have a single
 		// runPreseedMode/runUC20PreseedMode function that handles both classic
-		// and core20).
+		// and core20.
 		targetSnapd, cleanup, err = prepareClassicChroot(chrootDir)
 		if err != nil {
 			return err

--- a/cmd/snap-preseed/main.go
+++ b/cmd/snap-preseed/main.go
@@ -29,6 +29,7 @@ import (
 
 	// for SanitizePlugsSlots
 	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -44,8 +45,7 @@ first-boot startup time`
 )
 
 type options struct {
-	Core20 bool `long:"core20"`
-	Reset  bool `long:"reset"`
+	Reset bool `long:"reset"`
 }
 
 var (
@@ -69,6 +69,12 @@ func Parser() *flags.Parser {
 	parser.ShortDescription = shortHelp
 	parser.LongDescription = longHelp
 	return parser
+}
+
+func probeCore20ImageDir(dir string) bool {
+	sysDir := filepath.Join(dir, "system-seed")
+	_, isDir, _ := osutil.DirExists(sysDir)
+	return isDir
 }
 
 func main() {
@@ -112,7 +118,7 @@ func run(parser *flags.Parser, args []string) (err error) {
 	}
 
 	var cleanup func()
-	if opts.Core20 {
+	if probeCore20ImageDir(chrootDir) {
 		var popts *PreseedOpts
 		popts, cleanup, err = prepareCore20Chroot(chrootDir)
 		if err != nil {

--- a/cmd/snap-preseed/main.go
+++ b/cmd/snap-preseed/main.go
@@ -57,10 +57,10 @@ var (
 )
 
 type PreseedOpts struct {
-	PrepareImageDir string
-	PreseedDir      string
-	SystemLabel     string
-	WritableDir     string
+	PrepareImageDir  string
+	PreseedChrootDir string
+	SystemLabel      string
+	WritableDir      string
 }
 
 func Parser() *flags.Parser {

--- a/cmd/snap-preseed/preseed_linux.go
+++ b/cmd/snap-preseed/preseed_linux.go
@@ -344,6 +344,9 @@ var makeWritableTempDir = func() (string, error) {
 func prepareCore20Chroot(prepareImageDir string) (preseed *PreseedOpts, cleanup func(), err error) {
 	sysDir := filepath.Join(prepareImageDir, "system-seed")
 	sysLabel, err := systemForPreseeding(sysDir)
+	if err != nil {
+		return nil, nil, err
+	}
 	snapdSnapPath, baseSnapPath, err := systemSnapFromSeed(sysDir, sysLabel)
 	if err != nil {
 		return nil, nil, err

--- a/cmd/snap-preseed/preseed_linux.go
+++ b/cmd/snap-preseed/preseed_linux.go
@@ -20,7 +20,9 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -97,27 +99,31 @@ func checkChroot(preseedChroot string) error {
 
 var seedOpen = seed.Open
 
-var systemSnapFromSeed = func(rootDir string) (string, error) {
-	seedDir := filepath.Join(dirs.SnapSeedDirUnder(rootDir))
-	seed, err := seedOpen(seedDir, "")
+var systemSnapFromSeed = func(seedDir, sysLabel string) (systemSnap string, baseSnap string, err error) {
+	seed, err := seedOpen(seedDir, sysLabel)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	// load assertions into temporary database
 	if err := seed.LoadAssertions(nil, nil); err != nil {
-		return "", err
+		return "", "", err
 	}
 	model := seed.Model()
 
 	tm := timings.New(nil)
 	if err := seed.LoadMeta(tm); err != nil {
-		return "", err
+		return "", "", err
 	}
 
-	// TODO: implement preseeding for core.
-	if !model.Classic() {
-		return "", fmt.Errorf("preseeding is only supported on classic systems")
+	if model.Classic() {
+		fmt.Fprintf(Stdout, "ubuntu classic preseeding")
+	} else {
+		if model.Base() == "core20" {
+			fmt.Fprintf(Stdout, "ubuntu core20 preseeding")
+		} else {
+			return "", "", fmt.Errorf("preseeding of ubuntu core with base %s", model.Base())
+		}
 	}
 
 	var required string
@@ -127,20 +133,21 @@ var systemSnapFromSeed = func(rootDir string) (string, error) {
 		required = "core"
 	}
 
-	var snapPath string
-	ess := seed.EssentialSnaps()
-	if len(ess) > 0 {
-		// core / snapd snap is the first essential snap.
-		if ess[0].SnapName() == required {
-			snapPath = ess[0].Path
+	var systemSnapPath, baseSnapPath string
+	for _, ess := range seed.EssentialSnaps() {
+		if ess.SnapName() == required {
+			systemSnapPath = ess.Path
+		}
+		if ess.EssentialType == "base" {
+			baseSnapPath = ess.Path
 		}
 	}
 
-	if snapPath == "" {
-		return "", fmt.Errorf("%s snap not found", required)
+	if systemSnapPath == "" {
+		return "", "", fmt.Errorf("%s snap not found", required)
 	}
 
-	return snapPath, nil
+	return systemSnapPath, baseSnapPath, nil
 }
 
 const snapdPreseedSupportVer = `2.43.3+`
@@ -200,7 +207,188 @@ func chooseTargetSnapdVersion() (*targetSnapdInfo, error) {
 	return &targetSnapdInfo{path: snapdPath, version: whichVer}, nil
 }
 
-func prepareChroot(preseedChroot string) (*targetSnapdInfo, func(), error) {
+func prepareCore20Mountpoints(prepareImageDir, tmpPreseedDir, snapdSnapBlob, baseSnapBlob, writable string) (cleanupMounts func(), err error) {
+	underPreseed := func(path string) string {
+		return filepath.Join(tmpPreseedDir, path)
+	}
+
+	if err := os.MkdirAll(filepath.Join(writable, "system-data", "etc"), 0755); err != nil {
+		return nil, err
+	}
+	where := filepath.Join(snapdMountPath)
+	if err := os.MkdirAll(where, 0755); err != nil {
+		return nil, err
+	}
+
+	var mounted []string
+
+	cleanupMounts = func() {
+		for i := len(mounted) - 1; i >= 0; i-- {
+			mnt := mounted[i]
+			cmd := exec.Command("umount", mnt)
+			if out, err := cmd.CombinedOutput(); err != nil {
+				fmt.Fprintf(Stdout, "cannot unmount: %v\n'umount %s' failed with: %s", err, mnt, out)
+			}
+		}
+
+		entries, err := osutil.LoadMountInfo()
+		if err != nil {
+			fmt.Fprintf(Stdout, "cannot parse mount info when cleaning up mount points: %v", err)
+			return
+		}
+		// cleanup after handle-writable-paths
+		for _, ent := range entries {
+			if strings.HasPrefix(ent.MountDir, tmpPreseedDir) {
+				cmd := exec.Command("umount", ent.MountDir)
+				if out, err := cmd.CombinedOutput(); err != nil {
+					fmt.Fprintf(Stdout, "cannot unmount: %v\n'umount %s' failed with: %s", err, ent.MountDir, out)
+				}
+			}
+		}
+	}
+
+	cleanupOnError := func() {
+		if err == nil {
+			return
+		}
+
+		if cleanupMounts != nil {
+			cleanupMounts()
+		}
+	}
+	defer cleanupOnError()
+
+	mounts := [][]string{
+		{"-o", "loop", baseSnapBlob, tmpPreseedDir},
+		{"-o", "loop", snapdSnapBlob, snapdMountPath},
+		{"-t", "tmpfs", "tmpfs", underPreseed("run")},
+		{"-t", "tmpfs", "tmpfs", underPreseed("var/tmp")},
+		{"--bind", underPreseed("var/tmp"), underPreseed("tmp")},
+		{"-t", "proc", "proc", underPreseed("proc")},
+		{"-t", "sysfs", "sysfs", underPreseed("sys")},
+		{"-t", "devtmpfs", "udev", underPreseed("dev")},
+		{"-t", "securityfs", "securityfs", underPreseed("sys/kernel/security")},
+		{"--bind", writable, underPreseed("writable")},
+	}
+
+	var out []byte
+	for _, mountArgs := range mounts {
+		cmd := exec.Command("mount", mountArgs...)
+		if out, err = cmd.CombinedOutput(); err != nil {
+			return nil, fmt.Errorf("cannot prepare mountpoint in preseed mode: %v\n'mount %s' failed with: %s", err, strings.Join(mountArgs, " "), out)
+		}
+		mounted = append(mounted, mountArgs[len(mountArgs)-1])
+	}
+
+	cmd := exec.Command(underPreseed("/usr/lib/core/handle-writable-paths"), tmpPreseedDir)
+	if out, err = cmd.CombinedOutput(); err != nil {
+		return nil, fmt.Errorf("handle-writable-paths failed with: %v\n%s", err, out)
+	}
+
+	for _, dir := range []string{
+		"etc/udev/rules.d", "etc/systemd/system", "etc/dbus-1/session.d",
+		"var/lib/snapd/seed", "var/cache/snapd", "var/cache/apparmor",
+		"var/snap", "snap"} {
+		if err = os.MkdirAll(filepath.Join(writable, dir), 0755); err != nil {
+			return nil, err
+		}
+	}
+
+	underWritable := func(path string) string {
+		return filepath.Join(writable, path)
+	}
+	mounts = [][]string{
+		{"--bind", underWritable("system-data/var/lib/snapd"), underPreseed("var/lib/snapd")},
+		{"--bind", underWritable("system-data/var/cache/snapd"), underPreseed("var/cache/snapd")},
+		{"--bind", underWritable("system-data/var/cache/apparmor"), underPreseed("var/cache/apparmor")},
+		{"--bind", underWritable("system-data/var/snap"), underPreseed("var/snap")},
+		{"--bind", underWritable("system-data/snap"), underPreseed("snap")},
+		{"--bind", underWritable("system-data/etc/systemd"), underPreseed("etc/systemd")},
+		{"--bind", underWritable("system-data/etc/dbus-1"), underPreseed("etc/dbus-1")},
+		{"--bind", underWritable("system-data/etc/udev/rules.d"), underPreseed("etc/udev/rules.d")},
+		{"--bind", filepath.Join(snapdMountPath, "/usr/lib/snapd"), underPreseed("/usr/lib/snapd")},
+		{"--bind", filepath.Join(prepareImageDir, "system-seed"), underPreseed("var/lib/snapd/seed")},
+	}
+
+	for _, mountArgs := range mounts {
+		cmd := exec.Command("mount", mountArgs...)
+		if out, err = cmd.CombinedOutput(); err != nil {
+			return nil, fmt.Errorf("cannot prepare mountpoint in preseed mode: %v\n'mount %s' failed with: %s", err, strings.Join(mountArgs, " "), out)
+		}
+		mounted = append(mounted, mountArgs[len(mountArgs)-1])
+	}
+
+	return cleanupMounts, nil
+}
+
+func systemForPreseeding(systemsDir string) (label string, err error) {
+	systemLabels, err := filepath.Glob(filepath.Join(systemsDir, "systems", "*"))
+	if err != nil && !os.IsNotExist(err) {
+		return "", fmt.Errorf("cannot list available systems: %v", err)
+	}
+	if len(systemLabels) != 1 {
+		return "", fmt.Errorf("expected a single system for preseeding, found %d", len(systemLabels))
+	}
+	return filepath.Base(systemLabels[0]), nil
+}
+
+var makePreseedTempDir = func() (string, error) {
+	return ioutil.TempDir("", "preseed-")
+}
+
+var makeWritableTempDir = func() (string, error) {
+	return ioutil.TempDir("", "writable-")
+}
+
+func prepareCore20Chroot(prepareImageDir string) (preseed *PreseedOpts, cleanup func(), err error) {
+	sysDir := filepath.Join(prepareImageDir, "system-seed")
+	sysLabel, err := systemForPreseeding(sysDir)
+	snapdSnapPath, baseSnapPath, err := systemSnapFromSeed(sysDir, sysLabel)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if snapdSnapPath == "" {
+		return nil, nil, fmt.Errorf("snapd snap not found")
+	}
+	if baseSnapPath == "" {
+		return nil, nil, fmt.Errorf("base snap not found")
+	}
+
+	tmpPreseedDir, err := makePreseedTempDir()
+	if err != nil {
+		return nil, nil, fmt.Errorf("cannot prepare uc20 chroot: %v", err)
+	}
+	writableTmpDir, err := makeWritableTempDir()
+	if err != nil {
+		return nil, nil, fmt.Errorf("cannot prepare uc20 chroot: %v", err)
+	}
+
+	cleanupMounts, err := prepareCore20Mountpoints(prepareImageDir, tmpPreseedDir, snapdSnapPath, baseSnapPath, writableTmpDir)
+	if err != nil {
+		return nil, nil, fmt.Errorf("cannot prepare uc20 mountpoints: %v", err)
+	}
+
+	cleanup = func() {
+		cleanupMounts()
+		if err := os.RemoveAll(tmpPreseedDir); err != nil {
+			fmt.Fprintf(Stdout, "%v", err)
+		}
+		if err := os.RemoveAll(writableTmpDir); err != nil {
+			fmt.Fprintf(Stdout, "%v", err)
+		}
+	}
+
+	opts := &PreseedOpts{
+		PrepareImageDir: prepareImageDir,
+		PreseedDir:      tmpPreseedDir,
+		SystemLabel:     sysLabel,
+		WritableDir:     writableTmpDir,
+	}
+	return opts, cleanup, nil
+}
+
+func prepareClassicChroot(preseedChroot string) (*targetSnapdInfo, func(), error) {
 	if err := syscallChroot(preseedChroot); err != nil {
 		return nil, nil, fmt.Errorf("cannot chroot into %s: %v", preseedChroot, err)
 	}
@@ -216,7 +404,7 @@ func prepareChroot(preseedChroot string) (*targetSnapdInfo, func(), error) {
 		rootDir = "/"
 	}
 
-	coreSnapPath, err := systemSnapFromSeed(rootDir)
+	coreSnapPath, _, err := systemSnapFromSeed(dirs.SnapSeedDirUnder(rootDir), "")
 	if err != nil {
 		return nil, nil, err
 	}
@@ -262,6 +450,54 @@ func prepareChroot(preseedChroot string) (*targetSnapdInfo, func(), error) {
 	}, nil
 }
 
+type preseedFilePatterns struct {
+	Exclude []string `json:"exclude"`
+	Include []string `json:"include"`
+}
+
+func createPreseedArtifact(opts *PreseedOpts) error {
+	artifactPath := filepath.Join(opts.PrepareImageDir, "system-seed", "systems", opts.SystemLabel, "preseed.tgz")
+	systemData := filepath.Join(opts.WritableDir, "system-data")
+
+	patternsFile := filepath.Join(systemData, "var/lib/snapd/preseed-export.json")
+	pf, err := os.Open(patternsFile)
+	if err != nil {
+		return err
+	}
+
+	var patterns preseedFilePatterns
+	dec := json.NewDecoder(pf)
+	if err := dec.Decode(&patterns); err != nil {
+		return err
+	}
+
+	args := []string{"-czf", artifactPath, "-p", "-C", systemData}
+	for _, excl := range patterns.Exclude {
+		args = append(args, "--exclude", excl)
+	}
+	for _, incl := range patterns.Include {
+		// tar doesn't support globs for files to include, since we are not using shell we need to
+		// handle globs explicitly.
+		matches, err := filepath.Glob(filepath.Join(systemData, incl))
+		if err != nil {
+			return err
+		}
+		for _, m := range matches {
+			relPath, err := filepath.Rel(systemData, m)
+			if err != nil {
+				return err
+			}
+			args = append(args, relPath)
+		}
+	}
+
+	cmd := exec.Command("tar", args...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("%v (%s)", err, out)
+	}
+	return nil
+}
+
 // runPreseedMode runs snapd in a preseed mode. It assumes running in a chroot.
 // The chroot is expected to be set-up and ready to use (critical system directories mounted).
 func runPreseedMode(preseedChroot string, targetSnapd *targetSnapdInfo) error {
@@ -277,6 +513,25 @@ func runPreseedMode(preseedChroot string, targetSnapd *targetSnapdInfo) error {
 
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("error running snapd in preseed mode: %v\n", err)
+	}
+
+	return nil
+}
+
+func runUC20PreseedMode(opts *PreseedOpts) error {
+	cmd := exec.Command("chroot", opts.PreseedDir, "/usr/lib/snapd/snapd")
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, "SNAPD_PRESEED=1")
+	cmd.Stderr = Stderr
+	cmd.Stdout = Stdout
+	fmt.Fprintf(Stdout, "starting to preseed uc20 system: %s", opts.PreseedDir)
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("error running snapd in preseed mode: %v\n", err)
+	}
+
+	if err := createPreseedArtifact(opts); err != nil {
+		return fmt.Errorf("cannot create preseed.tgz: %v", err)
 	}
 
 	return nil

--- a/cmd/snap-preseed/preseed_uc20_test.go
+++ b/cmd/snap-preseed/preseed_uc20_test.go
@@ -1,0 +1,192 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/cmd/snap-preseed"
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/testutil"
+)
+
+func (s *startPreseedSuite) TestRunPreseedUC20Happy(c *C) {
+	tmpDir := c.MkDir()
+	dirs.SetRootDir(tmpDir)
+	defer mockChrootDirs(c, tmpDir, true)()
+
+	restoreOsGuid := main.MockOsGetuid(func() int { return 0 })
+	defer restoreOsGuid()
+
+	mockChootCmd := testutil.MockCommand(c, "chroot", "")
+	defer mockChootCmd.Restore()
+
+	mockMountCmd := testutil.MockCommand(c, "mount", "")
+	defer mockMountCmd.Restore()
+
+	mockUmountCmd := testutil.MockCommand(c, "umount", "")
+	defer mockUmountCmd.Restore()
+
+	preseedTmpDir := filepath.Join(tmpDir, "preseed-tmp")
+	restoreMakePreseedTmpDir := main.MockMakePreseedTempDir(func() (string, error) {
+		return preseedTmpDir, nil
+	})
+	defer restoreMakePreseedTmpDir()
+
+	writableTmpDir := filepath.Join(tmpDir, "writable-tmp")
+	restoreMakeWritableTempDir := main.MockMakeWritableTempDir(func() (string, error) {
+		return writableTmpDir, nil
+	})
+	defer restoreMakeWritableTempDir()
+
+	c.Assert(os.MkdirAll(filepath.Join(writableTmpDir, "system-data/etc/bar"), 0755), IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(writableTmpDir, "system-data/etc/bar/a"), nil, 0644), IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(writableTmpDir, "system-data/etc/bar/b"), nil, 0644), IsNil)
+
+	mockTar := testutil.MockCommand(c, "tar", "")
+	defer mockTar.Restore()
+
+	const exportFileContents = `{
+"exclude": ["foo"],
+"include": ["/etc/bar/a", "/etc/bar/b"]
+}`
+
+	c.Assert(os.MkdirAll(filepath.Join(writableTmpDir, "system-data/var/lib/snapd"), 0755), IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(writableTmpDir, "system-data/var/lib/snapd/preseed-export.json"), []byte(exportFileContents), 0644), IsNil)
+
+	mockWritablePaths := testutil.MockCommand(c, filepath.Join(preseedTmpDir, "/usr/lib/core/handle-writable-paths"), "")
+	defer mockWritablePaths.Restore()
+
+	restore := osutil.MockMountInfo(fmt.Sprintf(`130 30 42:1 / %s/somepath rw,relatime shared:54 - ext4 /some/path rw
+`, preseedTmpDir))
+	defer restore()
+
+	targetSnapdRoot := filepath.Join(tmpDir, "target-core-mounted-here")
+	restoreMountPath := main.MockSnapdMountPath(targetSnapdRoot)
+	defer restoreMountPath()
+
+	restoreSystemSnapFromSeed := main.MockSystemSnapFromSeed(func(string, string) (string, string, error) { return "/a/snapd.snap", "/a/base.snap", nil })
+	defer restoreSystemSnapFromSeed()
+
+	parser := testParser(c)
+	c.Check(main.Run(parser, []string{"--core20", tmpDir}), IsNil)
+
+	c.Check(mockChootCmd.Calls()[0], DeepEquals, []string{"chroot", preseedTmpDir, "/usr/lib/snapd/snapd"})
+
+	c.Check(mockMountCmd.Calls(), DeepEquals, [][]string{
+		{"mount", "-o", "loop", "/a/base.snap", preseedTmpDir},
+		{"mount", "-o", "loop", "/a/snapd.snap", targetSnapdRoot},
+		{"mount", "-t", "tmpfs", "tmpfs", filepath.Join(preseedTmpDir, "run")},
+		{"mount", "-t", "tmpfs", "tmpfs", filepath.Join(preseedTmpDir, "var/tmp")},
+		{"mount", "--bind", filepath.Join(preseedTmpDir, "/var/tmp"), filepath.Join(preseedTmpDir, "tmp")},
+		{"mount", "-t", "proc", "proc", filepath.Join(preseedTmpDir, "proc")},
+		{"mount", "-t", "sysfs", "sysfs", filepath.Join(preseedTmpDir, "sys")},
+		{"mount", "-t", "devtmpfs", "udev", filepath.Join(preseedTmpDir, "dev")},
+		{"mount", "-t", "securityfs", "securityfs", filepath.Join(preseedTmpDir, "sys/kernel/security")},
+		{"mount", "--bind", writableTmpDir, filepath.Join(preseedTmpDir, "writable")},
+		{"mount", "--bind", filepath.Join(writableTmpDir, "system-data/var/lib/snapd"), filepath.Join(preseedTmpDir, "var/lib/snapd")},
+		{"mount", "--bind", filepath.Join(writableTmpDir, "system-data/var/cache/snapd"), filepath.Join(preseedTmpDir, "var/cache/snapd")},
+		{"mount", "--bind", filepath.Join(writableTmpDir, "system-data/var/cache/apparmor"), filepath.Join(preseedTmpDir, "var/cache/apparmor")},
+		{"mount", "--bind", filepath.Join(writableTmpDir, "system-data/var/snap"), filepath.Join(preseedTmpDir, "var/snap")},
+		{"mount", "--bind", filepath.Join(writableTmpDir, "system-data/snap"), filepath.Join(preseedTmpDir, "snap")},
+		{"mount", "--bind", filepath.Join(writableTmpDir, "system-data/etc/systemd"), filepath.Join(preseedTmpDir, "etc/systemd")},
+		{"mount", "--bind", filepath.Join(writableTmpDir, "system-data/etc/dbus-1"), filepath.Join(preseedTmpDir, "etc/dbus-1")},
+		{"mount", "--bind", filepath.Join(writableTmpDir, "system-data/etc/udev/rules.d"), filepath.Join(preseedTmpDir, "etc/udev/rules.d")},
+		{"mount", "--bind", filepath.Join(targetSnapdRoot, "/usr/lib/snapd"), filepath.Join(preseedTmpDir, "usr/lib/snapd")},
+		{"mount", "--bind", filepath.Join(tmpDir, "system-seed"), filepath.Join(preseedTmpDir, "var/lib/snapd/seed")},
+	})
+
+	c.Check(mockTar.Calls(), DeepEquals, [][]string{
+		{"tar", "-czf", filepath.Join(tmpDir, "system-seed/systems/preseed.tgz"), "-p", "-C",
+			filepath.Join(writableTmpDir, "system-data"), "--exclude", "foo", "etc/bar/a", "etc/bar/b"},
+	})
+
+	c.Check(mockUmountCmd.Calls(), DeepEquals, [][]string{
+		{"umount", filepath.Join(preseedTmpDir, "var/lib/snapd/seed")},
+		{"umount", filepath.Join(preseedTmpDir, "usr/lib/snapd")},
+		{"umount", filepath.Join(preseedTmpDir, "etc/udev/rules.d")},
+		{"umount", filepath.Join(preseedTmpDir, "etc/dbus-1")},
+		{"umount", filepath.Join(preseedTmpDir, "etc/systemd")},
+		{"umount", filepath.Join(preseedTmpDir, "snap")},
+		{"umount", filepath.Join(preseedTmpDir, "var/snap")},
+		{"umount", filepath.Join(preseedTmpDir, "var/cache/apparmor")},
+		{"umount", filepath.Join(preseedTmpDir, "var/cache/snapd")},
+		{"umount", filepath.Join(preseedTmpDir, "var/lib/snapd")},
+		{"umount", filepath.Join(preseedTmpDir, "writable")},
+		{"umount", filepath.Join(preseedTmpDir, "sys/kernel/security")},
+		{"umount", filepath.Join(preseedTmpDir, "dev")},
+		{"umount", filepath.Join(preseedTmpDir, "sys")},
+		{"umount", filepath.Join(preseedTmpDir, "proc")},
+		{"umount", filepath.Join(preseedTmpDir, "tmp")},
+		{"umount", filepath.Join(preseedTmpDir, "var/tmp")},
+		{"umount", filepath.Join(preseedTmpDir, "run")},
+		{"umount", filepath.Join(tmpDir, "target-core-mounted-here")},
+		{"umount", preseedTmpDir},
+		// from handle-writable-paths
+		{"umount", filepath.Join(preseedTmpDir, "somepath")},
+	})
+
+	// sanity check; -1 to account for handle-writable-paths mock which doesn’t trigger mount in the test
+	c.Check(len(mockMountCmd.Calls()), Equals, len(mockUmountCmd.Calls())-1)
+}
+
+func (s *startPreseedSuite) TestCreatePreseedArtifact(c *C) {
+	tmpDir := c.MkDir()
+	dirs.SetRootDir(tmpDir)
+
+	prepareDir := filepath.Join(tmpDir, "prepare-dir")
+	c.Assert(os.MkdirAll(filepath.Join(prepareDir, "system-seed/systems/20220203"), 0755), IsNil)
+
+	writableDir := filepath.Join(tmpDir, "writable")
+	c.Assert(os.MkdirAll(writableDir, 0755), IsNil)
+
+	mockTar := testutil.MockCommand(c, "tar", "")
+	defer mockTar.Restore()
+
+	c.Assert(os.MkdirAll(filepath.Join(writableDir, "system-data/etc/bar"), 0755), IsNil)
+	c.Assert(os.MkdirAll(filepath.Join(writableDir, "system-data/baz"), 0755), IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(writableDir, "system-data/etc/bar/a"), nil, 0644), IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(writableDir, "system-data/etc/bar/x"), nil, 0644), IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(writableDir, "system-data/baz/b"), nil, 0644), IsNil)
+
+	const exportFileContents = `{
+"exclude": ["/etc/bar/x*"],
+"include": ["/etc/bar/a", "/baz/*"]
+}`
+	c.Assert(os.MkdirAll(filepath.Join(writableDir, "system-data/var/lib/snapd"), 0755), IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(writableDir, "system-data/var/lib/snapd/preseed-export.json"), []byte(exportFileContents), 0644), IsNil)
+
+	opts := &main.PreseedOpts{
+		PrepareImageDir: prepareDir,
+		WritableDir:     writableDir,
+		SystemLabel:     "20220203",
+	}
+	c.Assert(main.CreatePreseedArtifact(opts), Equals, nil)
+	c.Check(mockTar.Calls(), DeepEquals, [][]string{
+		{"tar", "-czf", filepath.Join(tmpDir, "prepare-dir/system-seed/systems/20220203/preseed.tgz"), "-p", "-C",
+			filepath.Join(writableDir, "system-data"), "--exclude", "/etc/bar/x*", "etc/bar/a", "baz/b"},
+	})
+}

--- a/cmd/snap-preseed/preseed_uc20_test.go
+++ b/cmd/snap-preseed/preseed_uc20_test.go
@@ -91,8 +91,10 @@ func (s *startPreseedSuite) TestRunPreseedUC20Happy(c *C) {
 	restoreSystemSnapFromSeed := main.MockSystemSnapFromSeed(func(string, string) (string, string, error) { return "/a/snapd.snap", "/a/base.snap", nil })
 	defer restoreSystemSnapFromSeed()
 
+	c.Assert(os.MkdirAll(filepath.Join(tmpDir, "system-seed/systems/20220203"), 0755), IsNil)
+
 	parser := testParser(c)
-	c.Check(main.Run(parser, []string{"--core20", tmpDir}), IsNil)
+	c.Assert(main.Run(parser, []string{tmpDir}), IsNil)
 
 	c.Check(mockChootCmd.Calls()[0], DeepEquals, []string{"chroot", preseedTmpDir, "/usr/lib/snapd/snapd"})
 
@@ -120,7 +122,7 @@ func (s *startPreseedSuite) TestRunPreseedUC20Happy(c *C) {
 	})
 
 	c.Check(mockTar.Calls(), DeepEquals, [][]string{
-		{"tar", "-czf", filepath.Join(tmpDir, "system-seed/systems/preseed.tgz"), "-p", "-C",
+		{"tar", "-czf", filepath.Join(tmpDir, "system-seed/systems/20220203/preseed.tgz"), "-p", "-C",
 			filepath.Join(writableTmpDir, "system-data"), "--exclude", "foo", "etc/bar/a", "etc/bar/b"},
 	})
 


### PR DESCRIPTION
Support for `--core20` flag with snap-preseed command. Initialize required mountpoints and run snapd inside a chroot to initialize preseeding. Contrary to the classic case, here I use `chroot` command to run this in a subprocess, so that mountpoints can be cleaned up properly.

TODO: this will get moved to a different package to be callable from prepare-image code. I'll do this in a dedicated followup PR.