### PR TITLE
o/state: fix undo with independent tasks in same change and lane

### DIFF
--- a/overlord/state/task.go
+++ b/overlord/state/task.go
@@ -200,6 +200,12 @@ func (t *Task) Status() Status {
 func (t *Task) SetStatus(new Status) {
 	t.state.writing()
 	old := t.status
+	if new == DoneStatus && old == AbortStatus {
+		// if the task is in AbortStatus (because some other task ran in parallel and had an error so the change is
+		// aborted) and DoneStatus was requested (which can happen if the task handler sets its status explicitly)
+		// then keep it at aborted so it can transition to Undo.
+		return
+	}
 	t.status = new
 	if !old.Ready() && new.Ready() {
 		t.readyTime = timeNow()

--- a/overlord/state/task_test.go
+++ b/overlord/state/task_test.go
@@ -144,6 +144,18 @@ func (ts *taskSuite) TestStatusAndSetStatus(c *C) {
 	c.Check(t.Status(), Equals, state.DoneStatus)
 }
 
+func (ts *taskSuite) TestSetDoneAfterAbortNoop(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	t := st.NewTask("download", "1...")
+	t.SetStatus(state.AbortStatus)
+	c.Check(t.Status(), Equals, state.AbortStatus)
+	t.SetStatus(state.DoneStatus)
+	c.Check(t.Status(), Equals, state.AbortStatus)
+}
+
 func (ts *taskSuite) TestIsCleanAndSetClean(c *C) {
 	st := state.New(nil)
 	st.Lock()

--- a/overlord/state/taskrunner_test.go
+++ b/overlord/state/taskrunner_test.go
@@ -643,14 +643,12 @@ func (ts *taskRunnerSuite) TestUndoSingleLane(c *C) {
 
 	st.Unlock()
 
-	for {
+        var done bool
+	for !done {
 		c.Assert(r.Ensure(), Equals, nil)
 		st.Lock()
-		done := chg.IsReady() && chg.IsClean()
+		done = chg.IsReady() && chg.IsClean()
 		st.Unlock()
-		if done {
-			break
-		}
 	}
 
 	st.Lock()

--- a/overlord/state/taskrunner_test.go
+++ b/overlord/state/taskrunner_test.go
@@ -643,7 +643,7 @@ func (ts *taskRunnerSuite) TestUndoSingleLane(c *C) {
 
 	st.Unlock()
 
-        var done bool
+	var done bool
 	for !done {
 		c.Assert(r.Ensure(), Equals, nil)
 		st.Lock()

--- a/overlord/state/taskrunner_test.go
+++ b/overlord/state/taskrunner_test.go
@@ -578,6 +578,103 @@ func (ts *taskRunnerSuite) TestExternalAbort(c *C) {
 	ensureChange(c, r, sb, chg)
 }
 
+func (ts *taskRunnerSuite) TestUndoSingleLane(c *C) {
+	sb := &stateBackend{}
+	st := state.New(sb)
+	r := state.NewTaskRunner(st)
+	defer r.Stop()
+
+	r.AddHandler("noop", func(t *state.Task, tb *tomb.Tomb) error {
+		return nil
+	}, func(t *state.Task, tb *tomb.Tomb) error {
+		return nil
+	})
+
+	r.AddHandler("noop-slow", func(t *state.Task, tb *tomb.Tomb) error {
+		time.Sleep(10 * time.Millisecond)
+		t.State().Lock()
+		defer t.State().Unlock()
+		// critical
+		t.SetStatus(state.DoneStatus)
+		return nil
+	}, func(t *state.Task, tb *tomb.Tomb) error {
+		return nil
+	})
+
+	r.AddHandler("fail", func(t *state.Task, tb *tomb.Tomb) error {
+		return fmt.Errorf("fail")
+	}, nil)
+
+	st.Lock()
+
+	lane := st.NewLane()
+	chg := st.NewChange("install", "...")
+
+	// first taskset
+	var prev *state.Task
+	for i := 0; i < 10; i++ {
+		t := st.NewTask("noop-slow", "...")
+		if prev != nil {
+			t.WaitFor(prev)
+		}
+		chg.AddTask(t)
+		t.JoinLane(lane)
+
+		prev = t
+	}
+
+	// second taskset with a failing task that triggers undo of the change
+	prev = nil
+	for i := 0; i < 10; i++ {
+		t := st.NewTask("noop", "...")
+		if prev != nil {
+			t.WaitFor(prev)
+		}
+		chg.AddTask(t)
+		t.JoinLane(lane)
+		prev = t
+	}
+
+	// error trigger
+	t := st.NewTask("fail", "...")
+	t.WaitFor(prev)
+	chg.AddTask(t)
+	t.JoinLane(lane)
+
+	st.Unlock()
+
+	for {
+		c.Assert(r.Ensure(), Equals, nil)
+		st.Lock()
+		done := chg.IsReady() && chg.IsClean()
+		st.Unlock()
+		if done {
+			break
+		}
+	}
+
+	st.Lock()
+	defer st.Unlock()
+
+	// make sure all tasks are either undone or on hold (except for "fail" task which
+	// is in error).
+	for _, t := range st.Tasks() {
+		switch t.Kind() {
+		case "fail":
+			c.Assert(t.Status(), Equals, state.ErrorStatus)
+		case "noop", "noop-slow":
+			if t.Status() != state.UndoneStatus && t.Status() != state.HoldStatus {
+				for _, tsk := range st.Tasks() {
+					fmt.Printf("%s -> %s\n", tsk.Kind(), tsk.Status())
+				}
+				c.Fatalf("unexpected status: %s", t.Status())
+			}
+		default:
+			c.Fatalf("unexpected kind: %s", t.Kind())
+		}
+	}
+}
+
 func (ts *taskRunnerSuite) TestStopHandlerJustFinishing(c *C) {
 	sb := &stateBackend{}
 	st := state.New(sb)


### PR DESCRIPTION
Make the transition from AbortStatus to DoneStatus a noop in task's SetStatus. This is to avoid the race where if the tasks are in same change and lane but run concurrently (i.e. they are not chained) and one of them fails, taskrunner would abort the other that's currently in Doing, and if the aborted task explicitly sets own status to DoneStatus, it wouldn't get undone.

The sequence of events is as follows:
- handler of task A gets started in a go routine, its state is "Doing". State is not locked by taskrunner when it enters the "do" handler of the task.
- at the same time another independent task B in same change fails with an error. With that, taskrunner aborts all tasks in the lane - this includes task A.
- taskrunner sets task A status to "Abort" (this would lead to transition to "Undo" status on next iteration of taskrunner).
- however, the go routine of task A is already started, it locks the state and sets task A status to "Done".
- in next iteration of taskrunner only the tasks with "Undo" status and "Abort" status will be considered for undoing (Undo -> Undoing -> Undone). Since task A overwrote the "Abort" status, it escapes these transitions.

This only affects newly introduced transactional updates, because in all other cases we keep tasks chained within changes, so they run sequentially.

The new testrunner test mirrors the scenario with transactional install which sometimes fails in our spread tests because of this issue.