### PR TITLE
boot: mock amd64 arch for mabootable 20 suite

### DIFF
--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -165,6 +165,7 @@ func (s *makeBootable20Suite) SetUpTest(c *C) {
 
 	s.bootloader = bootloadertest.Mock("mock", c.MkDir()).RecoveryAware()
 	s.forceBootloader(s.bootloader)
+	s.AddCleanup(archtest.MockArchitecture("amd64"))
 }
 
 func (s *makeBootable20UbootSuite) SetUpTest(c *C) {


### PR DESCRIPTION
One last fix for tests failing on non amd64:

```
----------------------------------------------------------------------
FAIL: makebootable_test.go:791: makeBootable20Suite.TestMakeRunnableSystem20RunModeSealKeyErr

makebootable_test.go:893:
    c.Assert(err, IsNil)
... value *errors.errorString = &errors.errorString{s:"cannot copy trusted asset to cache: read /tmp/check-855608922/49/run/mnt/ubuntu-seed: is a directory"} ("cannot copy trusted asset to cache: read /tmp/check-855608922/49/run/mnt/ubuntu-seed: is a directory")
```

google:ubuntu-18.04-32:tests/unit/go is passing now