### PR TITLE
interfaces/builtin/account-control: allow to execute pam_tally2

### DIFF
--- a/interfaces/builtin/account_control.go
+++ b/interfaces/builtin/account_control.go
@@ -53,6 +53,7 @@ const accountControlConnectedPlugAppArmor = `
 /etc/default/useradd r,
 /etc/default/nss r,
 /etc/pam.d/{,*} r,
+/{,usr/}sbin/pam_tally2 ixr,
 
 # Needed by chpasswd
 /{,usr/}lib/@{multiarch}/security/* ixr,

--- a/tests/main/interfaces-account-control/account-control-consumer-core20/bin/chpasswd
+++ b/tests/main/interfaces-account-control/account-control-consumer-core20/bin/chpasswd
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /usr/sbin/chpasswd "$@"

--- a/tests/main/interfaces-account-control/account-control-consumer-core20/bin/deluser
+++ b/tests/main/interfaces-account-control/account-control-consumer-core20/bin/deluser
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /usr/sbin/deluser "$@"

--- a/tests/main/interfaces-account-control/account-control-consumer-core20/bin/useradd
+++ b/tests/main/interfaces-account-control/account-control-consumer-core20/bin/useradd
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /usr/sbin/useradd "$@"

--- a/tests/main/interfaces-account-control/account-control-consumer-core20/meta/snap.yaml
+++ b/tests/main/interfaces-account-control/account-control-consumer-core20/meta/snap.yaml
@@ -1,0 +1,16 @@
+name: account-control-consumer-core20
+version: 1.0
+summary: Basic account-control consumer snap
+description: A basic snap declaring a plug on a account-control slot
+base: core20
+
+apps:
+  useradd:
+    command: bin/useradd
+    plugs: [account-control]
+  deluser:
+    command: bin/deluser
+    plugs: [account-control]
+  chpasswd:
+    command: bin/chpasswd
+    plugs: [account-control]

--- a/tests/main/interfaces-account-control/task.yaml
+++ b/tests/main/interfaces-account-control/task.yaml
@@ -4,11 +4,12 @@ details: |
     This test makes sure that a snap using the account-control interface
     can handle the user accounts properly.
 
-systems: [ubuntu-core-16-64, ubuntu-core-18-64]
+systems: [ubuntu-core-16-64, ubuntu-core-18-64, ubuntu-core-20-64]
 
 environment:
     TSNAP/ac: account-control-consumer
     TSNAP/accore18: account-control-consumer-core18
+    TSNAP/accore20: account-control-consumer-core20
 
 prepare: |
     echo "Given a snap declaring a plug on account-control is installed"


### PR DESCRIPTION
Useradd can reach out to pam_tally2 to reset the login counter, in which case it
gets blocked by AppArmor with:

apparmor="DENIED" operation="exec" profile="snap.test.test"
name="/usr/sbin/pam_tally2" pid=5056 comm="useradd" requested_mask="x"
denied_mask="x" fsuid=0 ouid=0

Fixes: https://bugs.launchpad.net/snapd/+bug/1958640

See https://github.com/shadow-maint/shadow/blob/1882c66bda31e50367d41b36fea41cd04fa19c73/src/useradd.c#L2678 for reference