### PR TITLE
tests: Install form candidate the bluez snap on i386

### DIFF
--- a/tests/main/interfaces-bluez/task.yaml
+++ b/tests/main/interfaces-bluez/task.yaml
@@ -9,7 +9,10 @@ details: |
 
 execute: |
     echo "Installing bluez snap from the store ..."
-    snap install --channel=latest/stable bluez
+    if os.query is-pc-i386; then
+        snap install --channel=latest/candidate bluez
+    else
+        snap install --channel=latest/stable bluez
 
     echo "Connecting bluez snap plugs/slots ..."
     snap connect bluez:client bluez:service


### PR DESCRIPTION
This is the error to fix:

2022-03-03 21:10:09 Error executing
external:ubuntu-core-18-32:tests/main/interfaces-bluez
(external:ubuntu-core-18-32) :

+ snap list --unicode=never bluez
+ echo 'Installing bluez snap from the store ...'
Installing bluez snap from the store ...
+ expected='(?s)bluez .* from Canonical\* installed\n'
+ grep -Pzq '(?s)bluez .* from Canonical\* installed\n'
+ snap install bluez
error: snap "bluez" is not available on stable but is available to
install on
       the following channels:

       candidate  snap install --candidate bluez
       beta       snap install --beta bluez
       edge       snap install --edge bluez

       Please be mindful pre-release channels may include features not
completely tested or implemented. Get more information with 'snap
info
       bluez'.
