### PR TITLE
tests: skip validation of invalid strace on arm devices on snap-run test

### DIFF
--- a/tests/main/snap-run/task.yaml
+++ b/tests/main/snap-run/task.yaml
@@ -41,12 +41,16 @@ execute: |
         snap install strace-static --edge
     fi
 
-    echo "Test snap --strace invalid works"
-    if snap run --strace="invalid" test-snapd-sh.sh -c 'echo hello' 2>stderr ; then
-        echo "snap run with an invalid strace option should fail but it did not"
-        exit 1
+    # Skip validation of invalid strace on arm devices due to known error
+    # error: signal: segmentation fault
+    if not os.query is-arm; then
+        echo "Test snap --strace invalid works"
+        if snap run --strace="invalid" test-snapd-sh.sh -c 'echo hello' 2>stderr ; then
+            echo "snap run with an invalid strace option should fail but it did not"
+            exit 1
+        fi
+        MATCH "Can't stat 'invalid': No such file or directory" < stderr
     fi
-    MATCH "Can't stat 'invalid': No such file or directory" < stderr
 
     if os.query is-arch-linux || os.query is-opensuse-tumbleweed; then
         # Arch linux and Opensuse tumbleweed run the mainline kernel, strace


### PR DESCRIPTION
This test is failing since long time in arm devices with the same error.
A research was done on this issue but could not be fixed as the problem
is realted to strace.

Error:
Skip validation of invalid strace on arm devices due to known error
error: signal: segmentation fault
