### PR TITLE
tests: skip interfaces-cups-control from debian-sid

### DIFF
--- a/tests/main/interfaces-cups-control/task.yaml
+++ b/tests/main/interfaces-cups-control/task.yaml
@@ -15,7 +15,7 @@ details: |
 
 # Default cups/cups-pdf configuration on these distributions isn't
 # working yet without further tweaks.
-# TODO: enable on debian-sid once the cups deb package is fixed (cups is broken since last update)
+# TODO: enable on debian-sid once https://launchpad.net/bugs/1006853 is fixed
 systems: [-ubuntu-core-*, -opensuse-*, -fedora-*, -arch-*, -amazon-*, -centos-*, -debian-sid-*]
 
 environment:

--- a/tests/main/interfaces-cups-control/task.yaml
+++ b/tests/main/interfaces-cups-control/task.yaml
@@ -15,7 +15,8 @@ details: |
 
 # Default cups/cups-pdf configuration on these distributions isn't
 # working yet without further tweaks.
-systems: [-ubuntu-core-*, -opensuse-*, -fedora-*, -arch-*, -amazon-*, -centos-*]
+# TODO: enable on debian-sid once the cups deb package is fixed (cups is broken since last update)
+systems: [-ubuntu-core-*, -opensuse-*, -fedora-*, -arch-*, -amazon-*, -centos-*, -debian-sid-*]
 
 environment:
     TEST_FILE: /var/snap/test-snapd-cups-control-consumer/current/test_file.txt

--- a/tests/main/interfaces-cups-control/task.yaml
+++ b/tests/main/interfaces-cups-control/task.yaml
@@ -15,7 +15,7 @@ details: |
 
 # Default cups/cups-pdf configuration on these distributions isn't
 # working yet without further tweaks.
-# TODO: enable on debian-sid once https://launchpad.net/bugs/1006853 is fixed
+# TODO: enable on debian-sid once https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1006853 is fixed
 systems: [-ubuntu-core-*, -opensuse-*, -fedora-*, -arch-*, -amazon-*, -centos-*, -debian-sid-*]
 
 environment:


### PR DESCRIPTION
The last update for cups package produced failures for the cups related
tests. The research showed that the problem is with the cups deb
package.

To ensure snapd is not responsible of the error, I created a new debian
sid image with not snapd installed and run:

dmesg command is showing some denials as well:

[   13.532910] audit: type=1400 audit(1646305531.156:14):
apparmor="DENIED" operation="capable" profile="/usr/sbin/cupsd" pid=470
comm="cupsd" capability=12  capname="net_admin"

I tried the same in debian-11 and it works well

