### PR TITLE
tests: validate tests tools just on google and qemu backends

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -758,7 +758,7 @@ restore-each: |
 suites:
     tests/lib/tools/suite/:
         summary: Tests for tests/lib/tools tools
-        backends: [google]
+        backends: [google, qemu]
         prepare-each: |
             "$TESTSLIB"/prepare-restore.sh --prepare-suite-each-minimal-no-snaps
         restore-each: |

--- a/spread.yaml
+++ b/spread.yaml
@@ -758,6 +758,7 @@ restore-each: |
 suites:
     tests/lib/tools/suite/:
         summary: Tests for tests/lib/tools tools
+        backends: [google]
         prepare-each: |
             "$TESTSLIB"/prepare-restore.sh --prepare-suite-each-minimal-no-snaps
         restore-each: |

--- a/tests/main/boot-state/task.yaml
+++ b/tests/main/boot-state/task.yaml
@@ -1,5 +1,7 @@
 summary: smoke test for the boot-state tool
 
+backends: [google]
+
 execute: |
     # Check help
     "$TESTSTOOLS"/boot-state | MATCH "usage: boot-state bootenv"

--- a/tests/main/boot-state/task.yaml
+++ b/tests/main/boot-state/task.yaml
@@ -1,6 +1,6 @@
 summary: smoke test for the boot-state tool
 
-backends: [google]
+backends: [google, qemu]
 
 execute: |
     # Check help

--- a/tests/main/os.paths/task.yaml
+++ b/tests/main/os.paths/task.yaml
@@ -1,6 +1,6 @@
 summary: smoke test for the os.paths tool
 
-backends: [google]
+backends: [google, qemu]
 
 execute: |
     # Check help

--- a/tests/main/os.paths/task.yaml
+++ b/tests/main/os.paths/task.yaml
@@ -1,5 +1,7 @@
 summary: smoke test for the os.paths tool
 
+backends: [google]
+
 execute: |
     # Check help
     os.paths | MATCH "usage: snap-mount-dir, media-dir, libexec-dir"

--- a/tests/main/os.query/task.yaml
+++ b/tests/main/os.query/task.yaml
@@ -1,6 +1,6 @@
 summary: smoke test for the system-state tool
 
-backends: [google]
+backends: [google, qemu]
 
 execute: |
     # Check help

--- a/tests/main/os.query/task.yaml
+++ b/tests/main/os.query/task.yaml
@@ -1,5 +1,7 @@
 summary: smoke test for the system-state tool
 
+backends: [google]
+
 execute: |
     # Check help
     os.query | MATCH "usage: os.query is-core, is-classic"

--- a/tests/main/snapd-state/task.yaml
+++ b/tests/main/snapd-state/task.yaml
@@ -1,6 +1,6 @@
 summary: smoke test for the snapd-state test tool
 
-backends: [google]
+backends: [google, qemu]
 
 prepare: |
     snap install test-snapd-tools

--- a/tests/main/snapd-state/task.yaml
+++ b/tests/main/snapd-state/task.yaml
@@ -1,5 +1,7 @@
 summary: smoke test for the snapd-state test tool
 
+backends: [google]
+
 prepare: |
     snap install test-snapd-tools
     snap install --devmode jq

--- a/tests/main/snaps-state/task.yaml
+++ b/tests/main/snaps-state/task.yaml
@@ -1,5 +1,7 @@
 summary: smoke test for the snaps-state tool
 
+backends: [google]
+
 prepare: |
     snap set system experimental.parallel-instances=true
 

--- a/tests/main/snaps-state/task.yaml
+++ b/tests/main/snaps-state/task.yaml
@@ -1,6 +1,6 @@
 summary: smoke test for the snaps-state tool
 
-backends: [google]
+backends: [google, qemu]
 
 prepare: |
     snap set system experimental.parallel-instances=true


### PR DESCRIPTION
The idea is to avoid spending time validating testing tools on other
backends such as external.

Those tests are making longer the edge/beta validations for example.
