### PR TITLE
i/b/network_{control,manager}.go: add more access to resolved

### DIFF
--- a/interfaces/builtin/network_control.go
+++ b/interfaces/builtin/network_control.go
@@ -46,7 +46,7 @@ const networkControlConnectedPlugAppArmor = `
 #
 # Allow access to the safe members of the systemd-resolved D-Bus API:
 #
-#   https://www.freedesktop.org/wiki/Software/systemd/resolved/
+#   https://www.freedesktop.org/software/systemd/man/org.freedesktop.resolve1.html
 #
 # This API may be used directly over the D-Bus system bus or it may be used
 # indirectly via the nss-resolve plugin:
@@ -59,13 +59,13 @@ dbus send
      path="/org/freedesktop/resolve1"
      interface="org.freedesktop.resolve1.Manager"
      member="Resolve{Address,Hostname,Record,Service}"
-     peer=(name="org.freedesktop.resolve1"),
+     peer=(name="org.freedesktop.resolve1", label=unconfined),
 
 dbus (send)
      bus=system
      path="/org/freedesktop/resolve1"
      interface="org.freedesktop.resolve1.Manager"
-     member="SetLink{DNS,MulticastDNS,Domains,LLMNR}"
+     member="SetLink{DefaultRoute,DNSOverTLS,DNS,DNSEx,DNSSEC,DNSSECNegativeTrustAnchors,MulticastDNS,Domains,LLMNR}"
      peer=(label=unconfined),
 
 #include <abstractions/ssl_certs>

--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -124,7 +124,7 @@ network packet,
 #
 # Allow access to the safe members of the systemd-resolved D-Bus API:
 #
-#   https://www.freedesktop.org/wiki/Software/systemd/resolved/
+#   https://www.freedesktop.org/software/systemd/man/org.freedesktop.resolve1.html
 #
 # This API may be used directly over the D-Bus system bus or it may be used
 # indirectly via the nss-resolve plugin:
@@ -136,13 +136,13 @@ dbus send
      path="/org/freedesktop/resolve1"
      interface="org.freedesktop.resolve1.Manager"
      member="Resolve{Address,Hostname,Record,Service}"
-     peer=(name="org.freedesktop.resolve1"),
+     peer=(name="org.freedesktop.resolve1", label=unconfined),
 
 dbus (send)
      bus=system
      path="/org/freedesktop/resolve1"
      interface="org.freedesktop.resolve1.Manager"
-     member="SetLink{DNS,MulticastDNS,Domains,LLMNR}"
+     member="SetLink{DefaultRoute,DNSOverTLS,DNS,DNSEx,DNSSEC,DNSSECNegativeTrustAnchors,MulticastDNS,Domains,LLMNR}"
      peer=(label=unconfined),
 
 dbus (send)

--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -298,7 +298,7 @@ dbus (receive, send)
     peer=(label=###SLOT_SECURITY_TAGS###),
 
 # nmcli uses this in newer versions
-dbus (receive, send)
+dbus (send)
    bus=system
    path=/org/freedesktop/DBus
    interface=org.freedesktop.DBus

--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -296,6 +296,14 @@ dbus (receive, send)
     path=/org/freedesktop
     interface=org.freedesktop.DBus.ObjectManager
     peer=(label=###SLOT_SECURITY_TAGS###),
+
+# nmcli uses this in newer versions
+dbus (receive, send)
+   bus=system
+   path=/org/freedesktop/DBus
+   interface=org.freedesktop.DBus
+   member=GetConnectionUnixUser
+   peer=(label=unconfined),
 `
 
 const networkManagerConnectedPlugIntrospectionSnippet = `


### PR DESCRIPTION
Allow more calls to systemd-resolved dBus interface from the
interfaces that can control network resources. These new calls are
being used now by NetworkManager in jammy. Also, point to more
up-to-date documentation for the interface.