### PR TITLE
tests: fix snap-run test on centos-7 and ubuntu trusty

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -746,6 +746,7 @@ pkg_dependencies_amazon(){
         net-tools
         nfs-utils
         PackageKit
+        strace
         system-lsb-core
         rpm-build
         xdg-user-dirs

--- a/tests/main/snap-run/task.yaml
+++ b/tests/main/snap-run/task.yaml
@@ -1,8 +1,9 @@
 summary: Check that `snap run` runs
 
 # strace does not support _newselect on s390x
+# strace does not support _newselect on ubuntu-14.04-*
 # (https://github.com/strace/strace/issues/57)
-systems: [-*-s390x]
+systems: [-*-s390x, -ubuntu-14.04-*]
 
 prepare: |
     "$TESTSTOOLS"/snaps-state install-local basic-run


### PR DESCRIPTION
snap-run test fails on 2 systems:
 - ubuntu trusty: /usr/bin/strace: invalid system call '_newselect'
   The test is being skipped because the issue https://github.com/strace/strace/issues/57
 - centos-7: needs to have strace dependency installed
