### PR TITLE
tests/main/user-session-env: special case bash profile on Tumbleweed

### DIFF
--- a/tests/main/user-session-env/task.yaml
+++ b/tests/main/user-session-env/task.yaml
@@ -53,6 +53,7 @@ execute: |
 
     SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
     for user in test "$TEST_ZSH_USER" "$TEST_FISH_USER" ; do
+        echo "checking $user"
         if [ -e "${user}-session-env" ]; then
             # Even though there's user session support, systemd may be too old and
             # not support user-environment-generators (specifically systemd versions
@@ -95,7 +96,13 @@ execute: |
                 MATCH "PATH=.*[:]?${SNAP_MOUNT_DIR}/bin[:]?.*" < "${user}-child-env"
                 # make sure that XDG_DATA_DIRS contains the default locations as well
                 MATCH 'XDG_DATA_DIRS=.*[:]?/usr/share[:]?.*' < "${user}-profile-env"
-                MATCH 'XDG_DATA_DIRS=.*[:]?/usr/local/share[:]?.*' < "${user}-profile-env"
+                if ! os.query is-opensuse-tumbleweed; then
+                    # it was observed that on Tumbleweed XDG_DATA_DIRS seems to
+                    # have a default value which does not include
+                    # /usr/local/share, so apply the check only on remaining
+                    # systems
+                    MATCH 'XDG_DATA_DIRS=.*[:]?/usr/local/share[:]?.*' < "${user}-profile-env"
+                fi
                 ;;
         esac
     done


### PR DESCRIPTION
It was observed that the bash profiles on Tumbleweed do not contain
/usr/local/share in XDG_DATA_DIRS. The system seems to provide a non empty
default value, hence the defaults our profile provides are not applied.


