### PR TITLE
tests: increase the times in snapd-sigterm for arm devices

### DIFF
--- a/tests/main/snapd-sigterm/task.yaml
+++ b/tests/main/snapd-sigterm/task.yaml
@@ -10,6 +10,12 @@ restore: |
     systemctl start snapd.service
 
 execute: |
+    # The time used for arm devices is higher because those are slow devices
+    MAX_TIME=5
+    if [ "$SPREAD_BACKEND" = "external" ] && os.query is-arm; then
+        MAX_TIME=12
+    fi
+
     echo "Make a request, keep the connection open"
     python3 - << EOF > stamp &
     import socket, time
@@ -38,7 +44,7 @@ execute: |
 
     TEST_TIME1="$(date +'%s')"
 
-    if ((TEST_TIME1 > TEST_TIME0 + 5)); then
-        echo "Stopping snapd took more than 5 seconds!"
+    if ((TEST_TIME1 > TEST_TIME0 + MAX_TIME)); then
+        echo "Stopping snapd took more than $MAX_TIME seconds!"
         exit 1
     fi


### PR DESCRIPTION
The maximun time allowed to stop snapd on arm devices needs to be higher
than 5 seconds because those devices are slower than the google vms

Those are some time examples that I got from a dragonboard. Other
devices are showing similar times.

    ubuntu@localhost:~$ date +"%T.%3N" && sudo systemctl stop snapd.service
    && ./retry -n 100 --wait 0.1 --quiet sh -c 'systemctl is-active
    snapd.service | grep -Eq "inactive"' && date +"%T.%3N"
    12:30:08.833
    Warning: Stopping snapd.service, but it can still be activated by:
      snapd.socket
    12:30:17.368
    ubuntu@localhost:~$ date +"%T.%3N" && sudo systemctl start snapd.service
    && ./retry -n 100 --wait 0.1 --quiet sh -c 'systemctl is-active
    snapd.service | grep -Eq "^active"' && date +"%T.%3N"
    12:40:44.515
    12:40:45.614
    ubuntu@localhost:~$ date +"%T.%3N" && sudo systemctl stop snapd.service
    && ./retry -n 100 --wait 0.1 --quiet sh -c 'systemctl is-active
    snapd.service | grep -Eq "inactive"' && date +"%T.%3N"
    12:40:48.100
    Warning: Stopping snapd.service, but it can still be activated by:
      snapd.socket
    12:40:57.387
    ubuntu@localhost:~$ date +"%T.%3N" && sudo systemctl start snapd.service
    && ./retry -n 100 --wait 0.1 --quiet sh -c 'systemctl is-active
    snapd.service | grep -Eq "^active"' && date +"%T.%3N"
    12:41:56.590
    12:41:57.684
    ubuntu@localhost:~$ date +"%T.%3N" && sudo systemctl stop snapd.service
    && ./retry -n 100 --wait 0.1 --quiet sh -c 'systemctl is-active
    snapd.service | grep -Eq "inactive"' && date +"%T.%3N"
    12:42:01.561
    Warning: Stopping snapd.service, but it can still be activated by:
      snapd.socket
    12:42:09.446
    ubuntu@localhost:~$ date +"%T.%3N" && sudo systemctl start snapd.service
    && ./retry -n 100 --wait 0.1 --quiet sh -c 'systemctl is-active
    snapd.service | grep -Eq "^active"' && date +"%T.%3N"
    12:42:12.820
    12:42:13.959
    ubuntu@localhost:~$ date +"%T.%3N" && sudo systemctl stop snapd.service
    && ./retry -n 100 --wait 0.1 --quiet sh -c 'systemctl is-active
    snapd.service | grep -Eq "inactive"' && date +"%T.%3N"
    12:42:17.192
    Warning: Stopping snapd.service, but it can still be activated by:
      snapd.socket
    12:42:25.524
