### PR TITLE
cmd/snap-update-ns: support AllowSocketFile in snap-update-ns

### DIFF
--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -158,7 +158,11 @@ func (c *Change) ensureTarget(as *Assumptions) ([]*Change, error) {
 			}
 		case "file":
 			if !fi.Mode().IsRegular() {
-				err = fmt.Errorf("cannot use %q as mount point: not a regular file", path)
+				// allow mounting a socket file if the entry specifically allows
+				// this
+				if !(fi.Mode()&os.ModeSocket == os.ModeSocket && c.Entry.AllowSocketFile()) {
+					err = fmt.Errorf("cannot use %q as mount point: not a regular file", path)
+				}
 			}
 		case "symlink":
 			if fi.Mode()&os.ModeSymlink == os.ModeSymlink {
@@ -202,7 +206,11 @@ func (c *Change) ensureSource(as *Assumptions) ([]*Change, error) {
 			}
 		case "file":
 			if !fi.Mode().IsRegular() {
-				err = fmt.Errorf("cannot use %q as bind-mount source: not a regular file", path)
+				// allow mounting a socket file if the entry specifically allows
+				// this
+				if !(fi.Mode()&os.ModeSocket == os.ModeSocket && c.Entry.AllowSocketFile()) {
+					err = fmt.Errorf("cannot use %q as bind-mount source: not a regular file", path)
+				}
 			}
 		}
 	} else if os.IsNotExist(err) {

--- a/osutil/mountentry.go
+++ b/osutil/mountentry.go
@@ -251,6 +251,10 @@ func (e *MountEntry) XSnapdKind() string {
 	return val
 }
 
+func (e *MountEntry) AllowSocketFile() bool {
+	return e.OptBool("x-snapd.allow-socket-bind-mount")
+}
+
 // XSnapdDetach returns true if a mount entry should be detached rather than unmounted.
 //
 // Whenever we create a recursive bind mount we don't want to just unmount it
@@ -338,4 +342,8 @@ func XSnapdSymlink(oldname string) string {
 // XSnapdIgnoreMissing returns the string "x-snapd.ignore-missing".
 func XSnapdIgnoreMissing() string {
 	return "x-snapd.ignore-missing"
+}
+
+func XSnapdAllowSocketFile() string {
+	return "x-snapd.allow-socket-bind-mount"
 }

--- a/testutil/lowlevel.go
+++ b/testutil/lowlevel.go
@@ -60,6 +60,7 @@ var (
 	FileInfoFile    = &fakeFileInfo{}
 	FileInfoDir     = &fakeFileInfo{mode: os.ModeDir}
 	FileInfoSymlink = &fakeFileInfo{mode: os.ModeSymlink}
+	FileInfoSocket  = &fakeFileInfo{mode: os.ModeSocket}
 )
 
 // Formatter for flags passed to open syscall.


### PR DESCRIPTION
When journal namespaces are enabled, systemd will create a mount namespace before launching a service. In the mount namespace, the journal is redirected by a bind mount (/run/systemd/journal.<namespace> is mounted to /run/systemd/journal). The issue is that this conflicts with how snap-confine is working, and we need to recreate this bind mount, in the final mount namespace for the snap.

This is a first of multiple PRs, to support socket bind mounts, which is a prerequisite to get journal namespaces working correctly.
This patch is made by Ian orignally for other purposes.
