### PR TITLE
interfaces/mount-observe: allow read on /proc/1/mount* files

### DIFF
--- a/interfaces/builtin/mount_observe.go
+++ b/interfaces/builtin/mount_observe.go
@@ -43,6 +43,9 @@ owner @{PROC}/@{pid}/mounts r,
 owner @{PROC}/@{pid}/mountinfo r,
 owner @{PROC}/@{pid}/mountstats r,
 /sys/devices/*/block/{,**} r,
+# Some applications look at pid 1's info when operating as non-root
+@{PROC}/1/mounts r,
+@{PROC}/1/mountinfo r,
 
 @{PROC}/swaps r,
 


### PR DESCRIPTION
Some applications (eg, telegraf) may run as non-root but still try to access /proc/1/mounts and /proc/1/mountinfo. While the kernel allows world-read, the AppArmor profile for mount-observe requires owner match. Rather than removing owner match, specifically allow these files for pid 1.