### PR TITLE
interfaces/apparmor: Update base template for systemd-machined

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -163,6 +163,7 @@ var templateCommon = `
   /run/systemd/userdb/io.systemd.DynamicUser rw,        # systemd-exec users
   /run/systemd/userdb/io.systemd.Home rw,               # systemd-home dirs
   /run/systemd/userdb/io.systemd.NameServiceSwitch rw,  # UNIX/glibc NSS
+  /run/systemd/userdb/io.systemd.Machine rw,            # systemd-machined
 
   /etc/libnl-3/{classid,pktloc} r,      # apps that use libnl
 


### PR DESCRIPTION
The base apparmor template already includes the various VarLink sockets but
is missing the one from systemd-machined. Support was recently added
upstream in https://gitlab.com/apparmor/apparmor/-/merge_requests/861 so
this change ensures we keep the base template up to date in this regard
too.

Signed-off-by: Alex Murray <alex.murray@canonical.com>
