### PR TITLE
snap: Add missing zlib

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -103,6 +103,13 @@ parts:
       - liblzma5
     stage:
       - lib/*
+  # Needed by squashfs-tools and fc-cache
+  zlib:
+    plugin: nil
+    stage-packages:
+      - zlib1g
+    stage:
+      - lib/*
   # libc6 is part of core but we need it in the snapd snap for
   # CommandFromSystemSnap
   libc6:


### PR DESCRIPTION
Commands `mksquashfs`, `unsquashfs`, `fc-cache-v{6,7}` all load
`libz.so.1` from host. If it disappears or the ABI changes, they will
fail. So zlib needs to be packed in the snap.

To verify that a binary has all their dependencies, one can run in the root of the snap, for example:
```
LD_TRACE_LOADED_OBJECTS=1 ./lib64/ld-linux-x86-64.so.2 --library-path "${PWD}/lib/x86_64-linux-gnu:${PWD}/usr/lib/x86_64-linux-gnu" ./usr/bin/mksquashfs
```
