### PR TITLE
i/seccomp/template.go: add close_range to the allowed syscalls

### DIFF
--- a/interfaces/seccomp/template.go
+++ b/interfaces/seccomp/template.go
@@ -105,6 +105,7 @@ clock_nanosleep_time64
 clone
 clone3
 close
+close_range
 
 # needed by ls -l
 connect


### PR DESCRIPTION
close_range was added to kernel 5.9. For snap-seccomp to actually use
this information, libseccomp 2.5.2 or later is needed.