### PR TITLE
tests: set interfaces-cups-control test to manual

### DIFF
--- a/tests/main/interfaces-cups-control/task.yaml
+++ b/tests/main/interfaces-cups-control/task.yaml
@@ -18,6 +18,9 @@ details: |
 # TODO: enable on debian-sid once https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1006853 is fixed
 systems: [-ubuntu-core-*, -opensuse-*, -fedora-*, -arch-*, -amazon-*, -centos-*, -debian-sid-*]
 
+# TODO: enable once https://bugs.launchpad.net/snapd/+bug/1964262 is fixed
+manual: true
+
 environment:
     TEST_FILE: /var/snap/test-snapd-cups-control-consumer/current/test_file.txt
 


### PR DESCRIPTION
This test is affected by this issue https://bugs.launchpad.net/snapd/+bug/1964262
