### PR TITLE
interface/opengl: allow read on /proc/sys/dev/i915/perf_stream_paranoid

### DIFF
--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -96,6 +96,9 @@ unix (send, receive) type=dgram peer=(addr="@nvidia[0-9a-f]*"),
 # va-api
 /dev/dri/renderD[0-9]* rw,
 
+# intel
+@{PROC}/sys/dev/i915/perf_stream_paranoid r,
+
 # cuda
 @{PROC}/sys/vm/mmap_min_addr r,
 @{PROC}/devices r,


### PR DESCRIPTION
/proc/sys/dev/i915/perf_stream_paranoid is used to allow toggling Intel
Graphics metrics collection to non-root users. The firefox snap (at
least) reads this during startup (but doesn't try to write to it) which
causes log noise but otherwise seems to work ok. Since the contents are
a simple integer value, there is nothing sensitive in the file, so allow
snaps that plug opengl to read the file.

References:
- https://github.com/intel/pti-gpu#prerequisites
