### PR TITLE
o/devicestate: restore device key and serial when assertion is found

### DIFF
--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -32,6 +32,7 @@ import (
 	"gopkg.in/tomb.v2"
 
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/asserts/assertstest"
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/bootloader/bootloadertest"
@@ -1621,4 +1622,39 @@ func (s *deviceMgrInstallModeSuite) TestInstallModeWritesTimesyncdClockErr(c *C)
 	// install failed copying the timestamp
 	c.Check(installSystem.Err(), ErrorMatches, `(?s).*\(cannot seed timesyncd clock: cannot copy clock:.*Permission denied.*`)
 	c.Check(installSystem.Status(), Equals, state.ErrorStatus)
+}
+
+func makeDeviceSerialAssertionInDir(c *C, where string, storeStack *assertstest.StoreStack, brands *assertstest.SigningAccounts, model *asserts.Model, key asserts.PrivateKey, serialN string) *asserts.Serial {
+	encDevKey, err := asserts.EncodePublicKey(key.PublicKey())
+	c.Assert(err, IsNil)
+	serial, err := brands.Signing(model.BrandID()).Sign(asserts.SerialType, map[string]interface{}{
+		"brand-id":            model.BrandID(),
+		"model":               model.Model(),
+		"serial":              serialN,
+		"device-key":          string(encDevKey),
+		"device-key-sha3-384": key.PublicKey().ID(),
+		"timestamp":           time.Now().Format(time.RFC3339),
+	}, nil, "")
+	c.Assert(err, IsNil)
+	kp, err := asserts.OpenFSKeypairManager(where)
+	c.Assert(err, IsNil)
+	c.Assert(kp.Put(key), IsNil)
+	bs, err := asserts.OpenFSBackstore(where)
+	c.Assert(err, IsNil)
+	db, err := asserts.OpenDatabase(&asserts.DatabaseConfig{
+		Backstore:       bs,
+		Trusted:         storeStack.Trusted,
+		OtherPredefined: storeStack.Generic,
+	})
+	c.Assert(err, IsNil)
+
+	b := asserts.NewBatch(nil)
+	c.Logf("root key ID: %v", storeStack.RootSigning.KeyID)
+	c.Assert(b.Add(storeStack.StoreAccountKey("")), IsNil)
+	c.Assert(b.Add(brands.AccountKey(model.BrandID())), IsNil)
+	c.Assert(b.Add(brands.Account(model.BrandID())), IsNil)
+	c.Assert(b.Add(serial), IsNil)
+	c.Assert(b.Add(model), IsNil)
+	c.Assert(b.CommitTo(db, nil), IsNil)
+	return serial.(*asserts.Serial)
 }

--- a/overlord/devicestate/devicestate_serial_test.go
+++ b/overlord/devicestate/devicestate_serial_test.go
@@ -2207,3 +2207,110 @@ func (s *deviceMgrSerialSuite) TestFullDeviceRegistrationBlockedByNoRegister(c *
 	becomeOperational = s.findBecomeOperationalChange()
 	c.Assert(becomeOperational, IsNil)
 }
+
+func (s *deviceMgrSerialSuite) TestDeviceSerialRestoreHappy(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	// setup state as will be done by first-boot
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// in this case is just marked seeded without snaps
+	s.state.Set("seeded", true)
+
+	// save is available (where device keys are kept)
+	devicestate.SetSaveAvailable(s.mgr, true)
+
+	// this is the regular assertions DB
+	c.Assert(os.MkdirAll(dirs.SnapAssertsDBDir, 0755), IsNil)
+	// this is the ubuntu-save is bind mounted under /var/lib/snapd/save,
+	// there is a device directory under it
+	c.Assert(os.MkdirAll(dirs.SnapDeviceSaveDir, 0755), IsNil)
+
+	bs, err := asserts.OpenFSBackstore(dirs.SnapAssertsDBDir)
+	c.Assert(err, IsNil)
+
+	// the test suite uses a memory backstore DB, but we need to look at the
+	// filesystem
+	db, err := asserts.OpenDatabase(&asserts.DatabaseConfig{
+		Backstore:       bs,
+		Trusted:         s.storeSigning.Trusted,
+		OtherPredefined: s.storeSigning.Generic,
+	})
+	c.Assert(err, IsNil)
+	// cleanup is done by the suite
+	assertstate.ReplaceDB(s.state, db)
+	err = db.Add(s.storeSigning.StoreAccountKey(""))
+	c.Assert(err, IsNil)
+
+	model := s.makeModelAssertionInState(c, "my-brand", "pc-20", map[string]interface{}{
+		"architecture": "amd64",
+		// UC20
+		"base": "core20",
+		"snaps": []interface{}{
+			map[string]interface{}{
+				"name":            "pc-kernel",
+				"id":              snaptest.AssertedSnapID("pc-kernel"),
+				"type":            "kernel",
+				"default-channel": "20",
+			},
+			map[string]interface{}{
+				"name":            "pc",
+				"id":              snaptest.AssertedSnapID("pc"),
+				"type":            "gadget",
+				"default-channel": "20",
+			},
+		},
+	})
+
+	devicestatetest.MockGadget(c, s.state, "pc", snap.R(2), nil)
+
+	// the mock has written key under snap asserts dir, but when ubuntu-save
+	// exists, the key is written under ubuntu-save/device, thus
+	// factory-reset never restores is to the asserts dir
+	kp, err := asserts.OpenFSKeypairManager(dirs.SnapAssertsDBDir)
+	c.Assert(err, IsNil)
+
+	otherKey, _ := assertstest.GenerateKey(testKeyLength)
+	// an assertion for which there is no corresponding device key
+	makeDeviceSerialAssertionInDir(c, dirs.SnapAssertsDBDir, s.storeSigning, s.brands,
+		model, otherKey, "serial-other-key")
+	c.Assert(kp.Delete(otherKey.PublicKey().ID()), IsNil)
+	// an assertion which has a device key, which needs to be moved to the
+	// right location
+	makeDeviceSerialAssertionInDir(c, dirs.SnapAssertsDBDir, s.storeSigning, s.brands,
+		model, devKey, "serial-1234")
+	c.Assert(kp.Delete(devKey.PublicKey().ID()), IsNil)
+	// write the key under a location which corresponds to ubuntu-save/device
+	kp, err = asserts.OpenFSKeypairManager(dirs.SnapDeviceSaveDir)
+	c.Assert(err, IsNil)
+	c.Assert(kp.Put(devKey), IsNil)
+
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
+		Brand: "my-brand",
+		Model: "pc-20",
+	})
+
+	s.state.Unlock()
+	s.se.Ensure()
+	s.state.Lock()
+
+	// no need for the operational change
+	becomeOperational := s.findBecomeOperationalChange()
+	c.Check(becomeOperational, IsNil)
+
+	device, err := devicestatetest.Device(s.state)
+	c.Assert(err, IsNil)
+	c.Check(device.Brand, Equals, "my-brand")
+	c.Check(device.Model, Equals, "pc-20")
+	// serial was restored
+	c.Check(device.Serial, Equals, "serial-1234")
+	// key ID was restored
+	c.Check(device.KeyID, Equals, devKey.PublicKey().ID())
+	// key is present
+	_, err = devicestate.KeypairManager(s.mgr).Get(devKey.PublicKey().ID())
+	c.Check(err, IsNil)
+	// no session yet
+	c.Check(device.SessionMacaroon, Equals, "")
+}


### PR DESCRIPTION
It is possible that it went through factory reset, in which case the reset
process would have restored the device serial assertion and key if that were
present. Thus, when ensuring that the device is operational, check whether we
have something that can be restored.