### PR TITLE
woke.yaml: add config for "woke" checker

### DIFF
--- a/.woke.yaml
+++ b/.woke.yaml
@@ -1,0 +1,5 @@
+ignore_files:
+  - packaging/ubuntu-14.04/changelog
+  - packaging/ubuntu-16.04/changelog
+  - packaging/debian-sid/changelog
+  - packaging/fedora/snapd.spec


### PR DESCRIPTION
This commits add a config for the "woke" checker [1] that we
use to check for inclusive language. It exlcudes the various
packaging changelogs right now because we should not change
a changelog retroactively.

[1] https://github.com/get-woke/woke
