### PR TITLE
many: replace use of "sanity" for interface implementation checks

### DIFF
--- a/asserts/account.go
+++ b/asserts/account.go
@@ -78,7 +78,7 @@ func (acc *Account) checkConsistency(db RODatabase, acck *AccountKey) error {
 	return nil
 }
 
-// sanity
+// expected interface is implemented
 var _ consistencyChecker = (*Account)(nil)
 
 func assembleAccount(assert assertionBase) (Assertion, error) {

--- a/asserts/account_key.go
+++ b/asserts/account_key.go
@@ -180,7 +180,7 @@ func (ak *AccountKey) checkConsistency(db RODatabase, acck *AccountKey) error {
 	return nil
 }
 
-// sanity
+// expected interface is implemented
 var _ consistencyChecker = (*AccountKey)(nil)
 
 // Prerequisites returns references to this account-key's prerequisite assertions.
@@ -274,7 +274,7 @@ func (akr *AccountKeyRequest) checkConsistency(db RODatabase, acck *AccountKey) 
 	return nil
 }
 
-// sanity
+// expected interfaces are implemented
 var (
 	_ consistencyChecker = (*AccountKeyRequest)(nil)
 	_ customSigner       = (*AccountKeyRequest)(nil)

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -562,7 +562,7 @@ func (ab *assertionBase) At() *AtRevision {
 	return &AtRevision{Ref: *ab.Ref(), Revision: ab.Revision()}
 }
 
-// sanity check
+// expected interface is implemented
 var _ Assertion = (*assertionBase)(nil)
 
 // Decode parses a serialized assertion.

--- a/asserts/model.go
+++ b/asserts/model.go
@@ -563,7 +563,7 @@ func (mod *Model) checkConsistency(db RODatabase, acck *AccountKey) error {
 	return nil
 }
 
-// sanity
+// expected interface is implemented
 var _ consistencyChecker = (*Model)(nil)
 
 // limit model to only lowercase for now

--- a/asserts/repair.go
+++ b/asserts/repair.go
@@ -119,7 +119,7 @@ func (r *Repair) checkConsistency(db RODatabase, acck *AccountKey) error {
 	return nil
 }
 
-// sanity
+// expected interface is implemented
 var _ consistencyChecker = (*Repair)(nil)
 
 func assembleRepair(assert assertionBase) (Assertion, error) {

--- a/asserts/snap_asserts.go
+++ b/asserts/snap_asserts.go
@@ -115,7 +115,7 @@ func (snapdcl *SnapDeclaration) checkConsistency(db RODatabase, acck *AccountKey
 	return nil
 }
 
-// sanity
+// expected interface is implemented
 var _ consistencyChecker = (*SnapDeclaration)(nil)
 
 // Prerequisites returns references to this snap-declaration's prerequisite assertions.
@@ -476,7 +476,7 @@ func (snaprev *SnapRevision) checkConsistency(db RODatabase, acck *AccountKey) e
 	return nil
 }
 
-// sanity
+// expected interface is implemented
 var _ consistencyChecker = (*SnapRevision)(nil)
 
 // Prerequisites returns references to this snap-revision's prerequisite assertions.
@@ -610,7 +610,7 @@ func (validation *Validation) checkConsistency(db RODatabase, acck *AccountKey) 
 	return nil
 }
 
-// sanity
+// expected interface is implemented
 var _ consistencyChecker = (*Validation)(nil)
 
 // Prerequisites returns references to this validation's prerequisite assertions.
@@ -684,7 +684,7 @@ func (basedcl *BaseDeclaration) checkConsistency(db RODatabase, acck *AccountKey
 	return nil
 }
 
-// sanity
+// expected interface is implemented
 var _ consistencyChecker = (*BaseDeclaration)(nil)
 
 func assembleBaseDeclaration(assert assertionBase) (Assertion, error) {
@@ -860,7 +860,7 @@ func (snapdev *SnapDeveloper) checkConsistency(db RODatabase, acck *AccountKey) 
 	return nil
 }
 
-// sanity
+// expected interface is implemented
 var _ consistencyChecker = (*SnapDeveloper)(nil)
 
 // Prerequisites returns references to this snap-developer's prerequisite assertions.

--- a/asserts/system_user.go
+++ b/asserts/system_user.go
@@ -123,7 +123,7 @@ func (su *SystemUser) checkConsistency(db RODatabase, acck *AccountKey) error {
 	return nil
 }
 
-// sanity
+// expected interface is implemented
 var _ consistencyChecker = (*SystemUser)(nil)
 
 type shadow struct {

--- a/bootloader/grub.go
+++ b/bootloader/grub.go
@@ -32,7 +32,7 @@ import (
 	"github.com/snapcore/snapd/snap"
 )
 
-// sanity - grub implements the required interfaces
+// grub implements the required interfaces
 var (
 	_ Bootloader                        = (*grub)(nil)
 	_ RecoveryAwareBootloader           = (*grub)(nil)

--- a/bootloader/uboot.go
+++ b/bootloader/uboot.go
@@ -29,7 +29,7 @@ import (
 	"github.com/snapcore/snapd/snap"
 )
 
-// sanity - uboot implements the required interfaces
+// uboot implements the required interfaces
 var (
 	_ Bootloader                             = (*uboot)(nil)
 	_ ExtractedRecoveryKernelImageBootloader = (*uboot)(nil)

--- a/daemon/api_base_test.go
+++ b/daemon/api_base_test.go
@@ -372,7 +372,7 @@ func (m *fakeSnapManager) Ensure() error {
 	return nil
 }
 
-// sanity
+// expected interface is implemented
 var _ overlord.StateManager = (*fakeSnapManager)(nil)
 
 func (s *apiBaseSuite) daemonWithFakeSnapManager(c *check.C) *daemon.Daemon {

--- a/gadget/install/encrypt.go
+++ b/gadget/install/encrypt.go
@@ -50,7 +50,7 @@ type encryptedDeviceLUKS struct {
 	node   string
 }
 
-// sanity
+// expected interface is implemented
 var _ = encryptedDevice(&encryptedDeviceLUKS{})
 
 // newEncryptedDeviceLUKS creates an encrypted device in the existing

--- a/overlord/devicestate/devicectx.go
+++ b/overlord/devicestate/devicectx.go
@@ -98,7 +98,7 @@ func (dc groundDeviceContext) HasModeenv() bool {
 	return dc.model.Grade() != asserts.ModelGradeUnset
 }
 
-// sanity
+// expected interface is implemented
 var _ snapstate.DeviceContext = &groundDeviceContext{}
 
 type modelDeviceContext struct {
@@ -116,7 +116,7 @@ func (dc *modelDeviceContext) Store() snapstate.StoreService {
 	return nil
 }
 
-// sanity
+// expected interface is implemented
 var _ snapstate.DeviceContext = &modelDeviceContext{}
 
 // SystemModeInfoFromState returns details about the system mode the device is in.

--- a/snap/info.go
+++ b/snap/info.go
@@ -715,7 +715,7 @@ type DeltaInfo struct {
 	Sha3_384        string `json:"sha3-384,omitempty"`
 }
 
-// sanity check that Info is a PlaceInfo
+// check that Info is a PlaceInfo
 var _ PlaceInfo = (*Info)(nil)
 
 type AttributeNotFoundError struct{ Err error }


### PR DESCRIPTION
This commit replaces the use of "sanity" with more inclusive
naming. When `// sanity` is used to check if an interface is
implemented the comment `expected interface is implemented`
is used.
