### PR TITLE
asserts: minimal changes to disable authority-delegation before full revert

### DIFF
--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -44,7 +44,7 @@ var MetaHeaders = [...]string{
 	"type",
 	"format",
 	"authority-id",
-	"signatory-id",
+	// XXX authority-delegation: "signatory-id",
 	"revision",
 	"body-length",
 	"sign-key-sha3-384",
@@ -161,7 +161,8 @@ func init() {
 	maxSupportedFormat[SystemUserType.Name] = 1
 
 	// done here to untangle initialization loop via Type()
-	typeRegistry[AuthorityDelegationType.Name] = AuthorityDelegationType
+	// XXX authority-delegation disabled
+	// typeRegistry[AuthorityDelegationType.Name] = AuthorityDelegationType
 }
 
 func MockMaxSupportedFormat(assertType *AssertionType, maxFormat int) (restore func()) {
@@ -503,10 +504,11 @@ func (ab *assertionBase) AuthorityID() string {
 // SignatoryID returns the account that signed this assertion, it will
 // differ from AuthorityID in the case of signing authority delegation.
 func (ab *assertionBase) SignatoryID() string {
-	signID := ab.HeaderString("signatory-id")
+	// XXX authority-delegation: disabled, remove this
+	/*signID := ab.HeaderString("signatory-id")
 	if signID != "" {
 		return signID
-	}
+	}*/
 	return ab.AuthorityID()
 }
 

--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -51,7 +51,7 @@ func (as *assertsSuite) TestTypeNames(c *C) {
 		"account",
 		"account-key",
 		"account-key-request",
-		"authority-delegation",
+		// XXX "authority-delegation",
 		"base-declaration",
 		"device-session-request",
 		"model",
@@ -995,7 +995,7 @@ func (as *assertsSuite) TestWithAuthority(c *C) {
 	withAuthority := []string{
 		"account",
 		"account-key",
-		"authority-delegation",
+		// XXX "authority-delegation",
 		"base-declaration",
 		"store",
 		"snap-declaration",

--- a/asserts/authority_delegation_test.go
+++ b/asserts/authority_delegation_test.go
@@ -39,6 +39,8 @@ type authorityDelegationSuite struct {
 var _ = Suite(&authorityDelegationSuite{})
 
 func (s *authorityDelegationSuite) SetUpSuite(c *C) {
+	c.Skip("authority-delegation disabled")
+
 	s.assertionsLines = `assertions:
   -
     type: snap-revision

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -740,7 +740,8 @@ func CheckSignature(assert Assertion, signingKey *AccountKey, _ []*AssertionCons
 	if signingKey != nil {
 		pubKey = signingKey.publicKey()
 		if assert.SignatoryID() != signingKey.AccountID() {
-			return nil, fmt.Errorf("assertion signatory %q does not match public key from %q", assert.SignatoryID(), signingKey.AccountID())
+			// XXX authority-delegation: s/signatory/authority/
+			return nil, fmt.Errorf("assertion authority %q does not match public key from %q", assert.SignatoryID(), signingKey.AccountID())
 		}
 		if assert.SignatoryID() != assert.AuthorityID() {
 			ad, err := roDB.Find(AuthorityDelegationType, map[string]string{
@@ -884,9 +885,10 @@ func CheckDelegation(assert Assertion, signingKey *AccountKey, delegationConstra
 var DefaultCheckers = []Checker{
 	CheckSigningKeyIsNotExpired,
 	CheckSignature,
-	CheckDelegationIsNotExpired,
+	// XXX authority-delegation disabled
+	// CheckDelegationIsNotExpired,
 	CheckTimestampVsSigningKeyValidity,
-	CheckTimestampVsDelegationValidity,
-	CheckDelegation,
+	// CheckTimestampVsDelegationValidity,
+	// CheckDelegation,
 	CheckCrossConsistency,
 }

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -335,7 +335,7 @@ func (chks *checkSuite) TestCheckMismatchedAccountIDandKey(c *C) {
 	c.Check(err, ErrorMatches, `error finding matching public key for signature: found public key ".*" from "canonical" but expected it from: random`)
 
 	_, err = asserts.CheckSignature(a, cfg.Trusted[0].(*asserts.AccountKey), nil, db, time.Time{}, time.Time{})
-	c.Check(err, ErrorMatches, `assertion signatory "random" does not match public key from "canonical"`)
+	c.Check(err, ErrorMatches, `assertion authority "random" does not match public key from "canonical"`)
 }
 
 func (chks *checkSuite) TestCheckAndSetEarliestTime(c *C) {
@@ -610,6 +610,8 @@ func (safs *signAddFindSuite) TestSignInadequateFormat(c *C) {
 }
 
 func (safs *signAddFindSuite) TestSignDelegation(c *C) {
+	c.Skip("authority-delegation disabled")
+
 	delegatedSigningDB, err := asserts.OpenDatabase(&asserts.DatabaseConfig{})
 	c.Assert(err, IsNil)
 	c.Assert(delegatedSigningDB.ImportKey(testPrivKey1), IsNil)
@@ -687,6 +689,8 @@ func (safs *signAddFindSuite) TestSignDelegation(c *C) {
 }
 
 func (safs *signAddFindSuite) TestSignDelegationMismatchedAccountIDandKey(c *C) {
+	c.Skip("authority-delegation disabled")
+
 	delegatedSigningDB, err := asserts.OpenDatabase(&asserts.DatabaseConfig{})
 	c.Assert(err, IsNil)
 	c.Assert(delegatedSigningDB.ImportKey(testPrivKey1), IsNil)
@@ -732,6 +736,8 @@ func (safs *signAddFindSuite) TestSignDelegationMismatchedAccountIDandKey(c *C) 
 }
 
 func (safs *signAddFindSuite) TestSignDelegationConstraintsMismatch(c *C) {
+	c.Skip("authority-delegation disabled")
+
 	delegatedSigningDB, err := asserts.OpenDatabase(&asserts.DatabaseConfig{})
 	c.Assert(err, IsNil)
 	c.Assert(delegatedSigningDB.ImportKey(testPrivKey1), IsNil)
@@ -814,6 +820,8 @@ func (safs *signAddFindSuite) TestSignDelegationConstraintsMismatch(c *C) {
 }
 
 func (safs *signAddFindSuite) TestSignDelegationExpired(c *C) {
+	c.Skip("authority-delegation disabled")
+
 	delegatedSigningDB, err := asserts.OpenDatabase(&asserts.DatabaseConfig{})
 	c.Assert(err, IsNil)
 	c.Assert(delegatedSigningDB.ImportKey(testPrivKey1), IsNil)

--- a/asserts/fetcher_test.go
+++ b/asserts/fetcher_test.go
@@ -129,6 +129,8 @@ func (s *fetcherSuite) TestFetch(c *C) {
 }
 
 func (s *fetcherSuite) TestFetchDelegation(c *C) {
+	c.Skip("authority-delegation disabled")
+
 	s.prereqSnapAssertions(c)
 
 	localDB := setup3rdPartySigning(c, "local", s.storeSigning, s.storeSigning.SigningDB.Database)

--- a/asserts/pool_test.go
+++ b/asserts/pool_test.go
@@ -300,6 +300,8 @@ func (s *poolSuite) TestFetch(c *C) {
 }
 
 func (s *poolSuite) TestFetchDelegation(c *C) {
+	c.Skip("authority-delegation disabled")
+
 	pool := asserts.NewPool(s.db, 64)
 
 	at5555 := &asserts.AtRevision{

--- a/asserts/snap_asserts_test.go
+++ b/asserts/snap_asserts_test.go
@@ -1007,6 +1007,8 @@ func (srs *snapRevSuite) TestSnapRevisionCheckMissingDeclaration(c *C) {
 }
 
 func (srs *snapRevSuite) TestSnapRevisionDelegation(c *C) {
+	c.Skip("authority-delegation disabled")
+
 	storeDB, db := makeStoreAndCheckDB(c)
 
 	prereqDevAccount(c, storeDB, db)
@@ -1047,6 +1049,8 @@ func (srs *snapRevSuite) TestSnapRevisionDelegation(c *C) {
 }
 
 func (srs *snapRevSuite) TestSnapRevisionDelegationInconsistentTimestamp(c *C) {
+	c.Skip("authority-delegation disabled")
+
 	storeDB, db := makeStoreAndCheckDB(c)
 
 	prereqDevAccount(c, storeDB, db)


### PR DESCRIPTION
authority-delegation might have been premature, disable until we might decide for a full revert