### PR TITLE
o/snapstate: allow installing the snapd-desktop-integration snap even if the user-daemons feature is otherwise disabled

### DIFF
--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -221,6 +221,7 @@ func (f *fakeStore) snap(spec snapSpec) (*snap.Info, error) {
 
 	typ := snap.TypeApp
 	epoch := snap.E("1*")
+	snapID := spec.Name + "-id"
 	switch spec.Name {
 	case "core", "core16", "ubuntu-core", "some-core":
 		typ = snap.TypeOS
@@ -238,6 +239,8 @@ func (f *fakeStore) snap(spec snapSpec) (*snap.Info, error) {
 		confinement = "classic"
 	case "some-epoch-snap":
 		epoch = snap.E("42")
+	case "snapd-desktop-integration":
+		snapID = "IrwRHakqtzhFRHJOOPxKVPU0Kk7Erhcu"
 	}
 
 	if spec.Name == "snap-unknown" {
@@ -249,7 +252,7 @@ func (f *fakeStore) snap(spec snapSpec) (*snap.Info, error) {
 		SideInfo: snap.SideInfo{
 			RealName: spec.Name,
 			Channel:  spec.Channel,
-			SnapID:   spec.Name + "-id",
+			SnapID:   snapID,
 			Revision: spec.Revision,
 		},
 		Version: spec.Name,

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -889,17 +889,15 @@ func validateFeatureFlags(st *state.State, info *snap.Info) error {
 	}
 
 	if hasUserService {
+		flag, err := features.Flag(tr, features.UserDaemons)
+		if err != nil {
+			return err
+		}
 		// The snapd-desktop-integration snap is allowed to
 		// use user daemons, irrespective of the feature flag
 		// state.
-		if info.SnapID != snapdDesktopIntegrationSnapID {
-			flag, err := features.Flag(tr, features.UserDaemons)
-			if err != nil {
-				return err
-			}
-			if !flag {
-				return fmt.Errorf("experimental feature disabled - test it by setting 'experimental.user-daemons' to true")
-			}
+		if !flag && info.SnapID != snapdDesktopIntegrationSnapID {
+			return fmt.Errorf("experimental feature disabled - test it by setting 'experimental.user-daemons' to true")
 		}
 		if !release.SystemctlSupportsUserUnits() {
 			return fmt.Errorf("user session daemons are not supported on this release")

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -896,6 +896,9 @@ func validateFeatureFlags(st *state.State, info *snap.Info) error {
 		// The snapd-desktop-integration snap is allowed to
 		// use user daemons, irrespective of the feature flag
 		// state.
+		//
+		// TODO: remove the special case once
+		// experimental.user-daemons is the default
 		if !flag && info.SnapID != snapdDesktopIntegrationSnapID {
 			return fmt.Errorf("experimental feature disabled - test it by setting 'experimental.user-daemons' to true")
 		}

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -77,6 +77,8 @@ const (
 	LastBeforeLocalModificationsEdge = state.TaskSetEdge("last-before-local-modifications")
 )
 
+const snapdDesktopIntegrationSnapID = "IrwRHakqtzhFRHJOOPxKVPU0Kk7Erhcu"
+
 var ErrNothingToDo = errors.New("nothing to do")
 
 var osutilCheckFreeSpace = osutil.CheckFreeSpace
@@ -887,12 +889,17 @@ func validateFeatureFlags(st *state.State, info *snap.Info) error {
 	}
 
 	if hasUserService {
-		flag, err := features.Flag(tr, features.UserDaemons)
-		if err != nil {
-			return err
-		}
-		if !flag {
-			return fmt.Errorf("experimental feature disabled - test it by setting 'experimental.user-daemons' to true")
+		// The snapd-desktop-integration snap is allowed to
+		// use user daemons, irrespective of the feature flag
+		// state.
+		if info.SnapID != snapdDesktopIntegrationSnapID {
+			flag, err := features.Flag(tr, features.UserDaemons)
+			if err != nil {
+				return err
+			}
+			if !flag {
+				return fmt.Errorf("experimental feature disabled - test it by setting 'experimental.user-daemons' to true")
+			}
 		}
 		if !release.SystemctlSupportsUserUnits() {
 			return fmt.Errorf("user session daemons are not supported on this release")

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -3137,6 +3137,30 @@ func (s *snapmgrTestSuite) TestInstallUserDaemonsUsupportedOnTrusty(c *C) {
 	c.Assert(err, ErrorMatches, "user session daemons are not supported on this release")
 }
 
+func (s *snapmgrTestSuite) TestInstallUserDaemonsSnapdDesktopIntegration(c *C) {
+	restore := release.MockReleaseInfo(&release.OS{ID: "ubuntu", VersionID: "22.04"})
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	tr := config.NewTransaction(s.state)
+	tr.Set("core", "experimental.user-daemons", false)
+	tr.Commit()
+
+	// Installing snapd-desktop-integration is possible even when
+	// user-daemons is disabled.
+	opts := &snapstate.RevisionOptions{Channel: "channel-for-user-daemon"}
+	_, err := snapstate.Install(context.Background(), s.state, "snapd-desktop-integration", opts, s.user.ID, snapstate.Flags{})
+	c.Check(err, IsNil)
+
+	// However, it will still fail on systems that do not support
+	// the user-daemons feature at all.
+	restore = release.MockReleaseInfo(&release.OS{ID: "ubuntu", VersionID: "14.04"})
+	defer restore()
+	_, err = snapstate.Install(context.Background(), s.state, "snapd-desktop-integration", opts, s.user.ID, snapstate.Flags{})
+	c.Check(err, ErrorMatches, "user session daemons are not supported on this release")
+}
+
 func (s *snapmgrTestSuite) TestInstallDbusActivationChecksFeatureFlag(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()


### PR DESCRIPTION
At present, the user-daemons feature flag in snapd is disabled by default. However, we'd like to be able to make the snapd-desktop-integration snap (which relies on the feature) installable anyway. This PR disables the feature flag check if the snap ID matches the that of snapd-desktop-integration (as shown by running `snap info snapd-desktop-integration`).

I had originally considered also including a check for the snap name to help test unpublished versions of the snap (where there will be no snap ID), but determined that would be unnecessary: we can just enable the feature flag for that testing.