### PR TITLE
cmd/snap-preseed, image: move preseeding code to image/preseed

### DIFF
--- a/cmd/snap-preseed/preseed_classic_test.go
+++ b/cmd/snap-preseed/preseed_classic_test.go
@@ -30,18 +30,15 @@ import (
 	"github.com/jessevdk/go-flags"
 	. "gopkg.in/check.v1"
 
-	"github.com/snapcore/snapd/asserts"
-	"github.com/snapcore/snapd/asserts/assertstest"
 	"github.com/snapcore/snapd/cmd/snap-preseed"
 	"github.com/snapcore/snapd/cmd/snaplock/runinhibit"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/image/preseed"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/squashfs"
 	apparmor_sandbox "github.com/snapcore/snapd/sandbox/apparmor"
-	"github.com/snapcore/snapd/seed"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
-	"github.com/snapcore/snapd/timings"
 )
 
 func Test(t *testing.T) { TestingT(t) }
@@ -137,7 +134,7 @@ func (s *startPreseedSuite) TestRunPreseedMountUnhappy(c *C) {
 	restoreOsGuid := main.MockOsGetuid(func() int { return 0 })
 	defer restoreOsGuid()
 
-	restoreSyscallChroot := main.MockSyscallChroot(func(path string) error { return nil })
+	restoreSyscallChroot := preseed.MockSyscallChroot(func(path string) error { return nil })
 	defer restoreSyscallChroot()
 
 	mockMountCmd := testutil.MockCommand(c, "mount", `echo "something went wrong"
@@ -146,10 +143,10 @@ exit 32
 	defer mockMountCmd.Restore()
 
 	targetSnapdRoot := filepath.Join(tmpDir, "target-core-mounted-here")
-	restoreMountPath := main.MockSnapdMountPath(targetSnapdRoot)
+	restoreMountPath := preseed.MockSnapdMountPath(targetSnapdRoot)
 	defer restoreMountPath()
 
-	restoreSystemSnapFromSeed := main.MockSystemSnapFromSeed(func(string, string) (string, string, error) { return "/a/core.snap", "", nil })
+	restoreSystemSnapFromSeed := preseed.MockSystemSnapFromSeed(func(string, string) (string, string, error) { return "/a/core.snap", "", nil })
 	defer restoreSystemSnapFromSeed()
 
 	parser := testParser(c)
@@ -184,7 +181,7 @@ func (s *startPreseedSuite) TestChrootFailure(c *C) {
 	restoreOsGuid := main.MockOsGetuid(func() int { return 0 })
 	defer restoreOsGuid()
 
-	restoreSyscallChroot := main.MockSyscallChroot(func(path string) error {
+	restoreSyscallChroot := preseed.MockSyscallChroot(func(path string) error {
 		return fmt.Errorf("FAIL: %s", path)
 	})
 	defer restoreSyscallChroot()
@@ -204,7 +201,7 @@ func (s *startPreseedSuite) TestRunPreseedHappy(c *C) {
 	restoreOsGuid := main.MockOsGetuid(func() int { return 0 })
 	defer restoreOsGuid()
 
-	restoreSyscallChroot := main.MockSyscallChroot(func(path string) error { return nil })
+	restoreSyscallChroot := preseed.MockSyscallChroot(func(path string) error { return nil })
 	defer restoreSyscallChroot()
 
 	mockMountCmd := testutil.MockCommand(c, "mount", "")
@@ -214,10 +211,10 @@ func (s *startPreseedSuite) TestRunPreseedHappy(c *C) {
 	defer mockUmountCmd.Restore()
 
 	targetSnapdRoot := filepath.Join(tmpDir, "target-core-mounted-here")
-	restoreMountPath := main.MockSnapdMountPath(targetSnapdRoot)
+	restoreMountPath := preseed.MockSnapdMountPath(targetSnapdRoot)
 	defer restoreMountPath()
 
-	restoreSystemSnapFromSeed := main.MockSystemSnapFromSeed(func(string, string) (string, string, error) { return "/a/core.snap", "", nil })
+	restoreSystemSnapFromSeed := preseed.MockSystemSnapFromSeed(func(string, string) (string, string, error) { return "/a/core.snap", "", nil })
 	defer restoreSystemSnapFromSeed()
 
 	mockTargetSnapd := testutil.MockCommand(c, filepath.Join(targetSnapdRoot, "usr/lib/snapd/snapd"), `#!/bin/sh
@@ -267,7 +264,7 @@ func (s *startPreseedSuite) TestRunPreseedHappyDebVersionIsNewer(c *C) {
 	restoreOsGuid := main.MockOsGetuid(func() int { return 0 })
 	defer restoreOsGuid()
 
-	restoreSyscallChroot := main.MockSyscallChroot(func(path string) error { return nil })
+	restoreSyscallChroot := preseed.MockSyscallChroot(func(path string) error { return nil })
 	defer restoreSyscallChroot()
 
 	mockMountCmd := testutil.MockCommand(c, "mount", "")
@@ -277,10 +274,10 @@ func (s *startPreseedSuite) TestRunPreseedHappyDebVersionIsNewer(c *C) {
 	defer mockUmountCmd.Restore()
 
 	targetSnapdRoot := filepath.Join(tmpDir, "target-core-mounted-here")
-	restoreMountPath := main.MockSnapdMountPath(targetSnapdRoot)
+	restoreMountPath := preseed.MockSnapdMountPath(targetSnapdRoot)
 	defer restoreMountPath()
 
-	restoreSystemSnapFromSeed := main.MockSystemSnapFromSeed(func(string, string) (string, string, error) { return "/a/core.snap", "", nil })
+	restoreSystemSnapFromSeed := preseed.MockSystemSnapFromSeed(func(string, string) (string, string, error) { return "/a/core.snap", "", nil })
 	defer restoreSystemSnapFromSeed()
 
 	c.Assert(os.MkdirAll(filepath.Join(targetSnapdRoot, "usr/lib/snapd/"), 0755), IsNil)
@@ -312,146 +309,6 @@ func (s *startPreseedSuite) TestRunPreseedHappyDebVersionIsNewer(c *C) {
 	c.Assert(mockSnapdFromSnap.Calls(), HasLen, 0)
 }
 
-type Fake16Seed struct {
-	AssertsModel      *asserts.Model
-	Essential         []*seed.Snap
-	LoadMetaErr       error
-	LoadAssertionsErr error
-	UsesSnapd         bool
-}
-
-// Fake implementation of seed.Seed interface
-
-func mockClassicModel() *asserts.Model {
-	headers := map[string]interface{}{
-		"type":         "model",
-		"authority-id": "brand",
-		"series":       "16",
-		"brand-id":     "brand",
-		"model":        "classicbaz-3000",
-		"classic":      "true",
-		"timestamp":    "2018-01-01T08:00:00+00:00",
-	}
-	return assertstest.FakeAssertion(headers, nil).(*asserts.Model)
-}
-
-func (fs *Fake16Seed) LoadAssertions(db asserts.RODatabase, commitTo func(*asserts.Batch) error) error {
-	return fs.LoadAssertionsErr
-}
-
-func (fs *Fake16Seed) Model() *asserts.Model {
-	return fs.AssertsModel
-}
-
-func (fs *Fake16Seed) Brand() (*asserts.Account, error) {
-	headers := map[string]interface{}{
-		"type":         "account",
-		"account-id":   "brand",
-		"display-name": "fake brand",
-		"username":     "brand",
-		"timestamp":    "2018-01-01T08:00:00+00:00",
-	}
-	return assertstest.FakeAssertion(headers, nil).(*asserts.Account), nil
-}
-
-func (fs *Fake16Seed) LoadEssentialMeta(essentialTypes []snap.Type, tm timings.Measurer) error {
-	panic("unexpected")
-}
-
-func (fs *Fake16Seed) LoadMeta(tm timings.Measurer) error {
-	return fs.LoadMetaErr
-}
-
-func (fs *Fake16Seed) UsesSnapdSnap() bool {
-	return fs.UsesSnapd
-}
-
-func (fs *Fake16Seed) EssentialSnaps() []*seed.Snap {
-	return fs.Essential
-}
-
-func (fs *Fake16Seed) ModeSnaps(mode string) ([]*seed.Snap, error) {
-	return nil, nil
-}
-
-func (fs *Fake16Seed) NumSnaps() int {
-	return 0
-}
-
-func (fs *Fake16Seed) Iter(f func(sn *seed.Snap) error) error {
-	return nil
-}
-
-func (s *startPreseedSuite) TestSystemSnapFromSeed(c *C) {
-	tmpDir := c.MkDir()
-
-	restore := main.MockSeedOpen(func(rootDir, label string) (seed.Seed, error) {
-		return &Fake16Seed{
-			AssertsModel: mockClassicModel(),
-			Essential:    []*seed.Snap{{Path: "/some/path/core", SideInfo: &snap.SideInfo{RealName: "core"}}},
-		}, nil
-	})
-	defer restore()
-
-	path, _, err := main.SystemSnapFromSeed(tmpDir, "")
-	c.Assert(err, IsNil)
-	c.Check(path, Equals, "/some/path/core")
-}
-
-func (s *startPreseedSuite) TestSystemSnapFromSnapdSeed(c *C) {
-	tmpDir := c.MkDir()
-
-	restore := main.MockSeedOpen(func(rootDir, label string) (seed.Seed, error) {
-		return &Fake16Seed{
-			AssertsModel: mockClassicModel(),
-			Essential:    []*seed.Snap{{Path: "/some/path/snapd.snap", SideInfo: &snap.SideInfo{RealName: "snapd"}}},
-			UsesSnapd:    true,
-		}, nil
-	})
-	defer restore()
-
-	path, _, err := main.SystemSnapFromSeed(tmpDir, "")
-	c.Assert(err, IsNil)
-	c.Check(path, Equals, "/some/path/snapd.snap")
-}
-
-func (s *startPreseedSuite) TestSystemSnapFromSeedOpenError(c *C) {
-	tmpDir := c.MkDir()
-
-	restore := main.MockSeedOpen(func(rootDir, label string) (seed.Seed, error) { return nil, fmt.Errorf("fail") })
-	defer restore()
-
-	_, _, err := main.SystemSnapFromSeed(tmpDir, "")
-	c.Assert(err, ErrorMatches, "fail")
-}
-
-func (s *startPreseedSuite) TestSystemSnapFromSeedErrors(c *C) {
-	tmpDir := c.MkDir()
-
-	fakeSeed := &Fake16Seed{}
-	fakeSeed.AssertsModel = mockClassicModel()
-
-	restore := main.MockSeedOpen(func(rootDir, label string) (seed.Seed, error) { return fakeSeed, nil })
-	defer restore()
-
-	fakeSeed.Essential = []*seed.Snap{{Path: "", SideInfo: &snap.SideInfo{RealName: "core"}}}
-	_, _, err := main.SystemSnapFromSeed(tmpDir, "")
-	c.Assert(err, ErrorMatches, "core snap not found")
-
-	fakeSeed.Essential = []*seed.Snap{{Path: "/some/path", SideInfo: &snap.SideInfo{RealName: "foosnap"}}}
-	_, _, err = main.SystemSnapFromSeed(tmpDir, "")
-	c.Assert(err, ErrorMatches, "core snap not found")
-
-	fakeSeed.LoadMetaErr = fmt.Errorf("load meta failed")
-	_, _, err = main.SystemSnapFromSeed(tmpDir, "")
-	c.Assert(err, ErrorMatches, "load meta failed")
-
-	fakeSeed.LoadMetaErr = nil
-	fakeSeed.LoadAssertionsErr = fmt.Errorf("load assertions failed")
-	_, _, err = main.SystemSnapFromSeed(tmpDir, "")
-	c.Assert(err, ErrorMatches, "load assertions failed")
-}
-
 func (s *startPreseedSuite) TestRunPreseedUnsupportedVersion(c *C) {
 	tmpDir := c.MkDir()
 	dirs.SetRootDir(tmpDir)
@@ -461,17 +318,17 @@ func (s *startPreseedSuite) TestRunPreseedUnsupportedVersion(c *C) {
 	restoreOsGuid := main.MockOsGetuid(func() int { return 0 })
 	defer restoreOsGuid()
 
-	restoreSyscallChroot := main.MockSyscallChroot(func(path string) error { return nil })
+	restoreSyscallChroot := preseed.MockSyscallChroot(func(path string) error { return nil })
 	defer restoreSyscallChroot()
 
 	mockMountCmd := testutil.MockCommand(c, "mount", "")
 	defer mockMountCmd.Restore()
 
 	targetSnapdRoot := filepath.Join(tmpDir, "target-core-mounted-here")
-	restoreMountPath := main.MockSnapdMountPath(targetSnapdRoot)
+	restoreMountPath := preseed.MockSnapdMountPath(targetSnapdRoot)
 	defer restoreMountPath()
 
-	restoreSystemSnapFromSeed := main.MockSystemSnapFromSeed(func(string, string) (string, string, error) { return "/a/core.snap", "", nil })
+	restoreSystemSnapFromSeed := preseed.MockSystemSnapFromSeed(func(string, string) (string, string, error) { return "/a/core.snap", "", nil })
 	defer restoreSystemSnapFromSeed()
 
 	c.Assert(os.MkdirAll(filepath.Join(targetSnapdRoot, "usr/lib/snapd/"), 0755), IsNil)
@@ -488,86 +345,6 @@ func (s *startPreseedSuite) TestRunPreseedUnsupportedVersion(c *C) {
 	parser := testParser(c)
 	c.Check(main.Run(parser, []string{tmpDir}), ErrorMatches,
 		`snapd 2.43.0 from the target system does not support preseeding, the minimum required version is 2.43.3\+`)
-}
-
-func (s *startPreseedSuite) TestChooseTargetSnapdVersion(c *C) {
-	tmpDir := c.MkDir()
-	dirs.SetRootDir(tmpDir)
-	c.Assert(os.MkdirAll(filepath.Join(tmpDir, "usr/lib/snapd/"), 0755), IsNil)
-
-	targetSnapdRoot := filepath.Join(tmpDir, "target-core-mounted-here")
-	c.Assert(os.MkdirAll(filepath.Join(targetSnapdRoot, "usr/lib/snapd/"), 0755), IsNil)
-	restoreMountPath := main.MockSnapdMountPath(targetSnapdRoot)
-	defer restoreMountPath()
-
-	var versions = []struct {
-		fromSnap        string
-		fromDeb         string
-		expectedPath    string
-		expectedVersion string
-		expectedErr     string
-	}{
-		{
-			fromDeb:  "2.44.0",
-			fromSnap: "2.45.3+git123",
-			// snap version wins
-			expectedVersion: "2.45.3+git123",
-			expectedPath:    filepath.Join(tmpDir, "target-core-mounted-here/usr/lib/snapd/snapd"),
-		},
-		{
-			fromDeb:  "2.44.0",
-			fromSnap: "2.44.0",
-			// snap version wins
-			expectedVersion: "2.44.0",
-			expectedPath:    filepath.Join(tmpDir, "target-core-mounted-here/usr/lib/snapd/snapd"),
-		},
-		{
-			fromDeb:  "2.45.1+20.04",
-			fromSnap: "2.45.1",
-			// deb version wins
-			expectedVersion: "2.45.1+20.04",
-			expectedPath:    filepath.Join(tmpDir, "usr/lib/snapd/snapd"),
-		},
-		{
-			fromDeb:  "2.45.2",
-			fromSnap: "2.45.1",
-			// deb version wins
-			expectedVersion: "2.45.2",
-			expectedPath:    filepath.Join(tmpDir, "usr/lib/snapd/snapd"),
-		},
-		{
-			fromSnap:    "2.45.1",
-			expectedErr: fmt.Sprintf("cannot open snapd info file %q.*", filepath.Join(tmpDir, "usr/lib/snapd/info")),
-		},
-		{
-			fromDeb:     "2.45.1",
-			expectedErr: fmt.Sprintf("cannot open snapd info file %q.*", filepath.Join(tmpDir, "target-core-mounted-here/usr/lib/snapd/info")),
-		},
-	}
-
-	for _, test := range versions {
-		infoFile := filepath.Join(tmpDir, "usr/lib/snapd/info")
-		os.Remove(infoFile)
-		if test.fromDeb != "" {
-			c.Assert(ioutil.WriteFile(infoFile, []byte(fmt.Sprintf("VERSION=%s", test.fromDeb)), 0644), IsNil)
-		}
-		infoFile = filepath.Join(targetSnapdRoot, "usr/lib/snapd/info")
-		os.Remove(infoFile)
-		if test.fromSnap != "" {
-			c.Assert(ioutil.WriteFile(infoFile, []byte(fmt.Sprintf("VERSION=%s", test.fromSnap)), 0644), IsNil)
-		}
-
-		targetSnapd, err := main.ChooseTargetSnapdVersion()
-		if test.expectedErr != "" {
-			c.Assert(err, ErrorMatches, test.expectedErr)
-		} else {
-			c.Assert(err, IsNil)
-			c.Assert(targetSnapd, NotNil)
-			path, version := main.SnapdPathAndVersion(targetSnapd)
-			c.Check(path, Equals, test.expectedPath)
-			c.Check(version, Equals, test.expectedVersion)
-		}
-	}
 }
 
 func (s *startPreseedSuite) TestRunPreseedAgainstFilesystemRoot(c *C) {

--- a/image/preseed/export_test.go
+++ b/image/preseed/export_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2019 Canonical Ltd
+ * Copyright (C) 2019-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -17,14 +17,26 @@
  *
  */
 
-package main
+package preseed
 
-var (
-	Run = run
+import (
+	"github.com/snapcore/snapd/seed"
 )
 
-func MockOsGetuid(f func() int) (restore func()) {
-	oldOsGetuid := osGetuid
-	osGetuid = f
-	return func() { osGetuid = oldOsGetuid }
+var (
+	SystemSnapFromSeed       = systemSnapFromSeed
+	ChooseTargetSnapdVersion = chooseTargetSnapdVersion
+	CreatePreseedArtifact    = createPreseedArtifact
+)
+
+func MockSeedOpen(f func(rootDir, label string) (seed.Seed, error)) (restore func()) {
+	oldSeedOpen := seedOpen
+	seedOpen = f
+	return func() {
+		seedOpen = oldSeedOpen
+	}
+}
+
+func SnapdPathAndVersion(targetSnapd *TargetSnapdInfo) (string, string) {
+	return targetSnapd.path, targetSnapd.version
 }

--- a/image/preseed/preseed.go
+++ b/image/preseed/preseed.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2019 Canonical Ltd
+ * Copyright (C) 2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -17,14 +17,26 @@
  *
  */
 
-package main
+package preseed
 
-var (
-	Run = run
+import (
+	"io"
+	"os"
 )
 
-func MockOsGetuid(f func() int) (restore func()) {
-	oldOsGetuid := osGetuid
-	osGetuid = f
-	return func() { osGetuid = oldOsGetuid }
+var (
+	Stdout io.Writer = os.Stdout
+	Stderr io.Writer = os.Stderr
+)
+
+type PreseedOpts struct {
+	PrepareImageDir  string
+	PreseedChrootDir string
+	SystemLabel      string
+	WritableDir      string
+}
+
+type TargetSnapdInfo struct {
+	path    string
+	version string
 }

--- a/image/preseed/preseed_other.go
+++ b/image/preseed/preseed_other.go
@@ -3,7 +3,7 @@
 // +build !linux
 
 /*
- * Copyright (C) 2019 Canonical Ltd
+ * Copyright (C) 2019-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -19,7 +19,7 @@
  *
  */
 
-package main
+package preseed
 
 import (
 	"errors"
@@ -27,16 +27,22 @@ import (
 
 var preseedNotAvailableError = errors.New("preseed mode not available for systems other than linux")
 
-func checkChroot(preseedChroot string) error {
+func CheckChroot(preseedChroot string) error {
 	return preseedNotAvailableError
 }
 
-func prepareChroot(preseedChroot string) (*targetSnapdInfo, func(), error) {
-	return nil, preseedNotAvailableError
+func PrepareClassicChroot(preseedChroot string) (*TargetSnapdInfo, func(), error) {
+	return nil, nil, preseedNotAvailableError
 }
 
-func runPreseedMode(rootDir string) error {
+func PrepareCore20Chroot(prepareImageDir string) (preseed *PreseedOpts, cleanup func(), err error) {
+	return nil, nil, preseedNotAvailableError
+}
+
+func RunPreseedMode(preseedChroot string, targetSnapd *TargetSnapdInfo) error {
 	return preseedNotAvailableError
 }
 
-func cleanup() {}
+func RunUC20PreseedMode(opts *PreseedOpts) error {
+	return preseedNotAvailableError
+}

--- a/image/preseed/preseed_test.go
+++ b/image/preseed/preseed_test.go
@@ -1,0 +1,317 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package preseed_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/asserts/assertstest"
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/image/preseed"
+	"github.com/snapcore/snapd/osutil/squashfs"
+	"github.com/snapcore/snapd/seed"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+	"github.com/snapcore/snapd/timings"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+var _ = Suite(&preseedSuite{})
+
+type preseedSuite struct {
+	testutil.BaseTest
+}
+
+func (s *preseedSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	restore := squashfs.MockNeedsFuse(false)
+	s.BaseTest.AddCleanup(restore)
+}
+
+func (s *preseedSuite) TearDownTest(c *C) {
+	s.BaseTest.TearDownTest(c)
+	dirs.SetRootDir("")
+}
+
+type Fake16Seed struct {
+	AssertsModel      *asserts.Model
+	Essential         []*seed.Snap
+	LoadMetaErr       error
+	LoadAssertionsErr error
+	UsesSnapd         bool
+}
+
+// Fake implementation of seed.Seed interface
+
+func mockClassicModel() *asserts.Model {
+	headers := map[string]interface{}{
+		"type":         "model",
+		"authority-id": "brand",
+		"series":       "16",
+		"brand-id":     "brand",
+		"model":        "classicbaz-3000",
+		"classic":      "true",
+		"timestamp":    "2018-01-01T08:00:00+00:00",
+	}
+	return assertstest.FakeAssertion(headers, nil).(*asserts.Model)
+}
+
+func (fs *Fake16Seed) LoadAssertions(db asserts.RODatabase, commitTo func(*asserts.Batch) error) error {
+	return fs.LoadAssertionsErr
+}
+
+func (fs *Fake16Seed) Model() *asserts.Model {
+	return fs.AssertsModel
+}
+
+func (fs *Fake16Seed) Brand() (*asserts.Account, error) {
+	headers := map[string]interface{}{
+		"type":         "account",
+		"account-id":   "brand",
+		"display-name": "fake brand",
+		"username":     "brand",
+		"timestamp":    "2018-01-01T08:00:00+00:00",
+	}
+	return assertstest.FakeAssertion(headers, nil).(*asserts.Account), nil
+}
+
+func (fs *Fake16Seed) LoadEssentialMeta(essentialTypes []snap.Type, tm timings.Measurer) error {
+	panic("unexpected")
+}
+
+func (fs *Fake16Seed) LoadMeta(tm timings.Measurer) error {
+	return fs.LoadMetaErr
+}
+
+func (fs *Fake16Seed) UsesSnapdSnap() bool {
+	return fs.UsesSnapd
+}
+
+func (fs *Fake16Seed) EssentialSnaps() []*seed.Snap {
+	return fs.Essential
+}
+
+func (fs *Fake16Seed) ModeSnaps(mode string) ([]*seed.Snap, error) {
+	return nil, nil
+}
+
+func (fs *Fake16Seed) NumSnaps() int {
+	return 0
+}
+
+func (fs *Fake16Seed) Iter(f func(sn *seed.Snap) error) error {
+	return nil
+}
+
+func (s *preseedSuite) TestSystemSnapFromSeed(c *C) {
+	tmpDir := c.MkDir()
+
+	restore := preseed.MockSeedOpen(func(rootDir, label string) (seed.Seed, error) {
+		return &Fake16Seed{
+			AssertsModel: mockClassicModel(),
+			Essential:    []*seed.Snap{{Path: "/some/path/core", SideInfo: &snap.SideInfo{RealName: "core"}}},
+		}, nil
+	})
+	defer restore()
+
+	path, _, err := preseed.SystemSnapFromSeed(tmpDir, "")
+	c.Assert(err, IsNil)
+	c.Check(path, Equals, "/some/path/core")
+}
+
+func (s *preseedSuite) TestSystemSnapFromSnapdSeed(c *C) {
+	tmpDir := c.MkDir()
+
+	restore := preseed.MockSeedOpen(func(rootDir, label string) (seed.Seed, error) {
+		return &Fake16Seed{
+			AssertsModel: mockClassicModel(),
+			Essential:    []*seed.Snap{{Path: "/some/path/snapd.snap", SideInfo: &snap.SideInfo{RealName: "snapd"}}},
+			UsesSnapd:    true,
+		}, nil
+	})
+	defer restore()
+
+	path, _, err := preseed.SystemSnapFromSeed(tmpDir, "")
+	c.Assert(err, IsNil)
+	c.Check(path, Equals, "/some/path/snapd.snap")
+}
+
+func (s *preseedSuite) TestSystemSnapFromSeedOpenError(c *C) {
+	tmpDir := c.MkDir()
+
+	restore := preseed.MockSeedOpen(func(rootDir, label string) (seed.Seed, error) { return nil, fmt.Errorf("fail") })
+	defer restore()
+
+	_, _, err := preseed.SystemSnapFromSeed(tmpDir, "")
+	c.Assert(err, ErrorMatches, "fail")
+}
+
+func (s *preseedSuite) TestSystemSnapFromSeedErrors(c *C) {
+	tmpDir := c.MkDir()
+
+	fakeSeed := &Fake16Seed{}
+	fakeSeed.AssertsModel = mockClassicModel()
+
+	restore := preseed.MockSeedOpen(func(rootDir, label string) (seed.Seed, error) { return fakeSeed, nil })
+	defer restore()
+
+	fakeSeed.Essential = []*seed.Snap{{Path: "", SideInfo: &snap.SideInfo{RealName: "core"}}}
+	_, _, err := preseed.SystemSnapFromSeed(tmpDir, "")
+	c.Assert(err, ErrorMatches, "core snap not found")
+
+	fakeSeed.Essential = []*seed.Snap{{Path: "/some/path", SideInfo: &snap.SideInfo{RealName: "foosnap"}}}
+	_, _, err = preseed.SystemSnapFromSeed(tmpDir, "")
+	c.Assert(err, ErrorMatches, "core snap not found")
+
+	fakeSeed.LoadMetaErr = fmt.Errorf("load meta failed")
+	_, _, err = preseed.SystemSnapFromSeed(tmpDir, "")
+	c.Assert(err, ErrorMatches, "load meta failed")
+
+	fakeSeed.LoadMetaErr = nil
+	fakeSeed.LoadAssertionsErr = fmt.Errorf("load assertions failed")
+	_, _, err = preseed.SystemSnapFromSeed(tmpDir, "")
+	c.Assert(err, ErrorMatches, "load assertions failed")
+}
+
+func (s *preseedSuite) TestChooseTargetSnapdVersion(c *C) {
+	tmpDir := c.MkDir()
+	dirs.SetRootDir(tmpDir)
+	c.Assert(os.MkdirAll(filepath.Join(tmpDir, "usr/lib/snapd/"), 0755), IsNil)
+
+	targetSnapdRoot := filepath.Join(tmpDir, "target-core-mounted-here")
+	c.Assert(os.MkdirAll(filepath.Join(targetSnapdRoot, "usr/lib/snapd/"), 0755), IsNil)
+	restoreMountPath := preseed.MockSnapdMountPath(targetSnapdRoot)
+	defer restoreMountPath()
+
+	var versions = []struct {
+		fromSnap        string
+		fromDeb         string
+		expectedPath    string
+		expectedVersion string
+		expectedErr     string
+	}{
+		{
+			fromDeb:  "2.44.0",
+			fromSnap: "2.45.3+git123",
+			// snap version wins
+			expectedVersion: "2.45.3+git123",
+			expectedPath:    filepath.Join(tmpDir, "target-core-mounted-here/usr/lib/snapd/snapd"),
+		},
+		{
+			fromDeb:  "2.44.0",
+			fromSnap: "2.44.0",
+			// snap version wins
+			expectedVersion: "2.44.0",
+			expectedPath:    filepath.Join(tmpDir, "target-core-mounted-here/usr/lib/snapd/snapd"),
+		},
+		{
+			fromDeb:  "2.45.1+20.04",
+			fromSnap: "2.45.1",
+			// deb version wins
+			expectedVersion: "2.45.1+20.04",
+			expectedPath:    filepath.Join(tmpDir, "usr/lib/snapd/snapd"),
+		},
+		{
+			fromDeb:  "2.45.2",
+			fromSnap: "2.45.1",
+			// deb version wins
+			expectedVersion: "2.45.2",
+			expectedPath:    filepath.Join(tmpDir, "usr/lib/snapd/snapd"),
+		},
+		{
+			fromSnap:    "2.45.1",
+			expectedErr: fmt.Sprintf("cannot open snapd info file %q.*", filepath.Join(tmpDir, "usr/lib/snapd/info")),
+		},
+		{
+			fromDeb:     "2.45.1",
+			expectedErr: fmt.Sprintf("cannot open snapd info file %q.*", filepath.Join(tmpDir, "target-core-mounted-here/usr/lib/snapd/info")),
+		},
+	}
+
+	for _, test := range versions {
+		infoFile := filepath.Join(tmpDir, "usr/lib/snapd/info")
+		os.Remove(infoFile)
+		if test.fromDeb != "" {
+			c.Assert(ioutil.WriteFile(infoFile, []byte(fmt.Sprintf("VERSION=%s", test.fromDeb)), 0644), IsNil)
+		}
+		infoFile = filepath.Join(targetSnapdRoot, "usr/lib/snapd/info")
+		os.Remove(infoFile)
+		if test.fromSnap != "" {
+			c.Assert(ioutil.WriteFile(infoFile, []byte(fmt.Sprintf("VERSION=%s", test.fromSnap)), 0644), IsNil)
+		}
+
+		targetSnapd, err := preseed.ChooseTargetSnapdVersion()
+		if test.expectedErr != "" {
+			c.Assert(err, ErrorMatches, test.expectedErr)
+		} else {
+			c.Assert(err, IsNil)
+			c.Assert(targetSnapd, NotNil)
+			path, version := preseed.SnapdPathAndVersion(targetSnapd)
+			c.Check(path, Equals, test.expectedPath)
+			c.Check(version, Equals, test.expectedVersion)
+		}
+	}
+}
+
+func (s *preseedSuite) TestCreatePreseedArtifact(c *C) {
+	tmpDir := c.MkDir()
+	dirs.SetRootDir(tmpDir)
+
+	prepareDir := filepath.Join(tmpDir, "prepare-dir")
+	c.Assert(os.MkdirAll(filepath.Join(prepareDir, "system-seed/systems/20220203"), 0755), IsNil)
+
+	writableDir := filepath.Join(tmpDir, "writable")
+	c.Assert(os.MkdirAll(writableDir, 0755), IsNil)
+
+	mockTar := testutil.MockCommand(c, "tar", "")
+	defer mockTar.Restore()
+
+	c.Assert(os.MkdirAll(filepath.Join(writableDir, "system-data/etc/bar"), 0755), IsNil)
+	c.Assert(os.MkdirAll(filepath.Join(writableDir, "system-data/baz"), 0755), IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(writableDir, "system-data/etc/bar/a"), nil, 0644), IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(writableDir, "system-data/etc/bar/x"), nil, 0644), IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(writableDir, "system-data/baz/b"), nil, 0644), IsNil)
+
+	const exportFileContents = `{
+"exclude": ["/etc/bar/x*"],
+"include": ["/etc/bar/a", "/baz/*"]
+}`
+	c.Assert(os.MkdirAll(filepath.Join(writableDir, "system-data/var/lib/snapd"), 0755), IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(writableDir, "system-data/var/lib/snapd/preseed-export.json"), []byte(exportFileContents), 0644), IsNil)
+
+	opts := &preseed.PreseedOpts{
+		PrepareImageDir: prepareDir,
+		WritableDir:     writableDir,
+		SystemLabel:     "20220203",
+	}
+	c.Assert(preseed.CreatePreseedArtifact(opts), Equals, nil)
+	c.Check(mockTar.Calls(), DeepEquals, [][]string{
+		{"tar", "-czf", filepath.Join(tmpDir, "prepare-dir/system-seed/systems/20220203/preseed.tgz"), "-p", "-C",
+			filepath.Join(writableDir, "system-data"), "--exclude", "/etc/bar/x*", "etc/bar/a", "baz/b"},
+	})
+}

--- a/image/preseed/reset.go
+++ b/image/preseed/reset.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2020 Canonical Ltd
+ * Copyright (C) 2020-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -17,7 +17,7 @@
  *
  */
 
-package main
+package preseed
 
 import (
 	"fmt"
@@ -31,7 +31,7 @@ import (
 	apparmor_sandbox "github.com/snapcore/snapd/sandbox/apparmor"
 )
 
-func resetPreseededChroot(preseedChroot string) error {
+func ResetPreseededChroot(preseedChroot string) error {
 	exists, isDir, err := osutil.DirExists(preseedChroot)
 	if err != nil {
 		return fmt.Errorf("cannot reset %q: %v", preseedChroot, err)


### PR DESCRIPTION
Move preseeding code to image/preseed to allow for intergration with prepare-image (and ubuntu-image).

There are no changes to logic, changes revolve around exporting some methods/structs and splitting the tests between cmd/snap-preseed and new image/preseed. Ideally most of the tests from snap-preseed would be refactored and moved to image/preseed but I wanted to keep this change reasonable for the time being (potential TODO material); as such, actual preseeding is tested from snap-preseed command tests and require a few mock helpers to be exported via image/preseed.

Also added a few missing stubs to preseed_other.go to make it happy on macOS.