### PR TITLE
tests: fix test to avoid editing the test-snapd-tools snap.yaml file

### DIFF
--- a/tests/main/hidden-snap-dir/task.yaml
+++ b/tests/main/hidden-snap-dir/task.yaml
@@ -176,8 +176,9 @@ execute: |
 
     echo "Update snap to core22"
     snap install --edge core22
-    echo -e "\nbase: core22" >> "$TESTSLIB/snaps/$NAME/meta/snap.yaml"
-    snap pack "$TESTSLIB/snaps/$NAME"
+    cp -rf "$TESTSLIB/snaps/$NAME" "$PWD/$NAME"
+    echo -e "\nbase: core22" >> "$PWD/$NAME/meta/snap.yaml"
+    snap pack "$PWD/$NAME"
     snap install --dangerous "$NAME"_1.0_all.snap
 
     check_env "--with-exposed-home" "x3"


### PR DESCRIPTION
This fix is to prevent that thes snap.yaml file of the test-snapd-tools
is modified to make it "base: core22" because in the following tests
where we do "snap try test-snapd-tools", it fails with the error:

- Ensure prerequisites for "test-snapd-tools" are available (cannot
install snap base "core22": no snap revision available as specified)
