### PR TITLE
dirs: remove unused SnapMetaDir variable

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -53,7 +53,6 @@ var (
 	SnapKModModulesDir        string
 	SnapKModModprobeDir       string
 	LocaleDir                 string
-	SnapMetaDir               string
 	SnapdSocket               string
 	SnapSocket                string
 	SnapRunDir                string
@@ -361,7 +360,6 @@ func SetRootDir(rootdir string) {
 	SnapSeccompBase = filepath.Join(rootdir, snappyDir, "seccomp")
 	SnapSeccompDir = filepath.Join(SnapSeccompBase, "bpf")
 	SnapMountPolicyDir = filepath.Join(rootdir, snappyDir, "mount")
-	SnapMetaDir = filepath.Join(rootdir, snappyDir, "meta")
 	SnapdMaintenanceFile = filepath.Join(rootdir, snappyDir, "maintenance.json")
 	SnapBlobDir = SnapBlobDirUnder(rootdir)
 	SnapVoidDir = filepath.Join(rootdir, snappyDir, "void")


### PR DESCRIPTION
This is unused, and we do not have any "meta" dir under
"/var/lib/snapd/" since Snappy was removed in 2016 with commit
82c1b27bfe8b076bb9a2faaa430688e71705092a.
