### PR TITLE
many: replace use of "sanity" with more inclusive naming (part 2)

### DIFF
--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -688,7 +688,7 @@ func (as *assertsSuite) TestEncoderSingleDecodeOK(c *C) {
 	c.Check(cont1, DeepEquals, cont0)
 }
 
-func (as *assertsSuite) TestSignFormatSanityEmptyBody(c *C) {
+func (as *assertsSuite) TestSignFormatValidityEmptyBody(c *C) {
 	headers := map[string]interface{}{
 		"authority-id": "auth-id1",
 		"primary-key":  "0",
@@ -700,7 +700,7 @@ func (as *assertsSuite) TestSignFormatSanityEmptyBody(c *C) {
 	c.Check(err, IsNil)
 }
 
-func (as *assertsSuite) TestSignFormatSanitySignatoryId(c *C) {
+func (as *assertsSuite) TestSignFormatValiditySignatoryId(c *C) {
 	headers := map[string]interface{}{
 		"authority-id": "auth-id1",
 		"primary-key":  "0",
@@ -719,7 +719,7 @@ signatory-id: delegated-auth-id
 	c.Check(err, IsNil)
 }
 
-func (as *assertsSuite) TestSignFormatSanitySignatoryIdCoalesce(c *C) {
+func (as *assertsSuite) TestSignFormatValiditySignatoryIdCoalesce(c *C) {
 	headers := map[string]interface{}{
 		"authority-id": "auth-id1",
 		"primary-key":  "0",
@@ -735,7 +735,7 @@ func (as *assertsSuite) TestSignFormatSanitySignatoryIdCoalesce(c *C) {
 	c.Check(err, IsNil)
 }
 
-func (as *assertsSuite) TestSignFormatSanityNonEmptyBody(c *C) {
+func (as *assertsSuite) TestSignFormatValidityNonEmptyBody(c *C) {
 	headers := map[string]interface{}{
 		"authority-id": "auth-id1",
 		"primary-key":  "0",
@@ -750,7 +750,7 @@ func (as *assertsSuite) TestSignFormatSanityNonEmptyBody(c *C) {
 	c.Check(decoded.Body(), DeepEquals, body)
 }
 
-func (as *assertsSuite) TestSignFormatSanitySupportMultilineHeaderValues(c *C) {
+func (as *assertsSuite) TestSignFormatValiditySupportMultilineHeaderValues(c *C) {
 	headers := map[string]interface{}{
 		"authority-id": "auth-id1",
 		"primary-key":  "0",

--- a/boot/modeenv_test.go
+++ b/boot/modeenv_test.go
@@ -92,7 +92,7 @@ func (s *modeenvSuite) makeMockModeenvFile(c *C, content string) {
 	c.Assert(err, IsNil)
 }
 
-func (s *modeenvSuite) TestWasReadSanity(c *C) {
+func (s *modeenvSuite) TestWasReadValidity(c *C) {
 	modeenv := &boot.Modeenv{}
 	c.Check(modeenv.WasRead(), Equals, false)
 }

--- a/cmd/autogen.sh
+++ b/cmd/autogen.sh
@@ -14,7 +14,7 @@ if [ ! -e VERSION ]; then
 	( cd .. && ./mkversion.sh )
 fi
 
-# Sanity check, are we in the right directory?
+# Validity check, are we in the right directory?
 test -f configure.ac
 
 # Regenerate the build system

--- a/cmd/autogen.sh
+++ b/cmd/autogen.sh
@@ -14,7 +14,7 @@ if [ ! -e VERSION ]; then
 	( cd .. && ./mkversion.sh )
 fi
 
-# Validity check, are we in the right directory?
+# Precondition check, are we in the right directory?
 test -f configure.ac
 
 # Regenerate the build system

--- a/cmd/snap-update-ns/utils_test.go
+++ b/cmd/snap-update-ns/utils_test.go
@@ -1026,7 +1026,7 @@ func (s *realSystemSuite) TestSecureMksymlinkAllForReal(c *C) {
 }
 
 func (s *utilsSuite) TestCleanTrailingSlash(c *C) {
-	// This is a sanity test for the use of filepath.Clean in secureMk{dir,file}All
+	// This is a validity test for the use of filepath.Clean in secureMk{dir,file}All
 	c.Assert(filepath.Clean("/path/"), Equals, "/path")
 	c.Assert(filepath.Clean("path/"), Equals, "path")
 	c.Assert(filepath.Clean("path/."), Equals, "path")

--- a/cmd/snap/cmd_debug_bootvars_test.go
+++ b/cmd/snap/cmd_debug_bootvars_test.go
@@ -151,7 +151,7 @@ snapd_full_cmdline_args=
 		"foo": "recovery",
 	})
 
-	// but basic sanity checks are still done
+	// but basic validity checks are still done
 	_, err = snap.Parser(snap.Client()).ParseArgs([]string{"debug", "set-boot-vars", "--recovery", "--root-dir", boot.InitramfsUbuntuBootDir, "foo=recovery"})
 	c.Assert(err, check.ErrorMatches, "cannot use run bootloader root-dir with a recovery flag")
 }

--- a/daemon/api_apps_test.go
+++ b/daemon/api_apps_test.go
@@ -99,7 +99,7 @@ func (s *appsSuite) fakeServiceControl(st *state.State, appInfos []*snap.AppInfo
 		serviceCommand.options = "reload"
 	}
 	// only one flag should ever be set (depending on Action), but appending
-	// them below acts as an extra sanity check.
+	// them below acts as an extra validity check.
 	if inst.StartOptions.Enable {
 		serviceCommand.options += "enable"
 	}

--- a/daemon/api_debug_seeding.go
+++ b/daemon/api_debug_seeding.go
@@ -124,7 +124,7 @@ func getSeedingInfo(st *state.State) Response {
 		}
 	}
 
-	// XXX: consistency & sanity checks, e.g. if preseeded, then need to have
+	// XXX: consistency & validity checks, e.g. if preseeded, then need to have
 	// preseed-start-time, preseeded-time, preseed-system-key etc?
 
 	return SyncResponse(data)

--- a/daemon/api_validate_test.go
+++ b/daemon/api_validate_test.go
@@ -360,7 +360,7 @@ func (s *apiValidationSetsSuite) TestGetValidationSetLatestFromRemote(c *check.C
 		c.Assert(sequence, check.Equals, 0)
 		as, err := asserts.Decode(validationSetAssertion)
 		c.Assert(err, check.IsNil)
-		// sanity
+		// validity
 		c.Assert(as.Type().Name, check.Equals, "validation-set")
 		return as, nil
 	}
@@ -651,7 +651,7 @@ func (s *apiValidationSetsSuite) TestForgetValidationSet(c *check.C) {
 		var tr assertstate.ValidationSetTracking
 
 		st.Lock()
-		// sanity, it exists before removing
+		// validity, it exists before removing
 		err := assertstate.GetValidationSet(st, s.dev1acct.AccountID(), "foo", &tr)
 		st.Unlock()
 		c.Assert(err, check.IsNil)

--- a/desktop/notification/gtk.go
+++ b/desktop/notification/gtk.go
@@ -44,7 +44,7 @@ var newGtkBackend = func(conn *dbus.Conn, desktopID string) (NotificationManager
 	// If the D-Bus service is not already running, assume it is
 	// not available.
 	// Use owner to verify that the return values of the method call have the
-	// types we expect, which is generally a good sanity check.
+	// types we expect, which is generally a good validity check.
 	var owner string
 	if err := conn.BusObject().Call("org.freedesktop.DBus.GetNameOwner", 0, gtkBusName).Store(&owner); err != nil {
 		return nil, err

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -2801,7 +2801,7 @@ func (s *gadgetYamlTestSuite) TestLayoutCompatibility(c *C) {
 	smallDeviceLayout := mockDeviceLayout
 	smallDeviceLayout.UsableSectorsEnd = uint64(100 * quantity.SizeMiB / 512)
 
-	// sanity check
+	// validity check
 	c.Check(gadgetLayoutWithExtras.Size > quantity.Size(smallDeviceLayout.UsableSectorsEnd*uint64(smallDeviceLayout.SectorSize)), Equals, true)
 	err = gadget.EnsureLayoutCompatibility(gadgetLayoutWithExtras, &smallDeviceLayout, nil)
 	c.Assert(err, ErrorMatches, `device /dev/node \(last usable byte at 100 MiB\) is too small to fit the requested layout \(1\.17 GiB\)`)

--- a/gadget/layout_test.go
+++ b/gadget/layout_test.go
@@ -1081,7 +1081,7 @@ volumes:
 }
 
 func mockKernel(c *C, kernelYaml string, filesWithContent map[string]string) string {
-	// sanity
+	// validity
 	_, err := kernel.InfoFromKernelYaml([]byte(kernelYaml))
 	c.Assert(err, IsNil)
 

--- a/gadget/layout_test.go
+++ b/gadget/layout_test.go
@@ -1081,7 +1081,7 @@ volumes:
 }
 
 func mockKernel(c *C, kernelYaml string, filesWithContent map[string]string) string {
-	// validity
+	// precondition
 	_, err := kernel.InfoFromKernelYaml([]byte(kernelYaml))
 	c.Assert(err, IsNil)
 

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -678,7 +678,7 @@ func (s *imageSuite) TestSetupSeed(c *C) {
 
 			Channel: stableChannel,
 		})
-		// sanity
+		// validity
 		if name == "core" {
 			c.Check(essSnaps[i].SideInfo.SnapID, Equals, s.AssertedSnapID("core"))
 		}
@@ -3201,7 +3201,7 @@ func (s *imageSuite) TestSetupSeedCore20UBoot(c *C) {
 	err := image.SetupSeed(s.tsto, model, opts)
 	c.Assert(err, IsNil)
 
-	// sanity checks
+	// validity checks
 	seeddir := filepath.Join(prepareDir, "system-seed")
 	seedsnapsdir := filepath.Join(seeddir, "snaps")
 	essSnaps, runSnaps, _ := s.loadSeed(c, seeddir)

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -678,7 +678,7 @@ func (s *imageSuite) TestSetupSeed(c *C) {
 
 			Channel: stableChannel,
 		})
-		// validity
+		// precondition
 		if name == "core" {
 			c.Check(essSnaps[i].SideInfo.SnapID, Equals, s.AssertedSnapID("core"))
 		}

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -1422,7 +1422,7 @@ func (s *backendSuite) TestSnapConfineProfileDiscardedLateSnapd(c *C) {
 	s.writeVanillaSnapConfineProfile(c, snapdInfo)
 	err := s.Backend.Setup(snapdInfo, interfaces.ConfinementOptions{}, s.Repo, s.perf)
 	c.Assert(err, IsNil)
-	// sanity
+	// validity
 	c.Assert(filepath.Join(dirs.SnapAppArmorDir, "snap-confine.snapd.222"), testutil.FilePresent)
 	// place a canary
 	c.Assert(ioutil.WriteFile(filepath.Join(dirs.SnapAppArmorDir, "snap-confine.snapd.111"), nil, 0644), IsNil)

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -1422,7 +1422,7 @@ func (s *backendSuite) TestSnapConfineProfileDiscardedLateSnapd(c *C) {
 	s.writeVanillaSnapConfineProfile(c, snapdInfo)
 	err := s.Backend.Setup(snapdInfo, interfaces.ConfinementOptions{}, s.Repo, s.perf)
 	c.Assert(err, IsNil)
-	// validity
+	// precondition
 	c.Assert(filepath.Join(dirs.SnapAppArmorDir, "snap-confine.snapd.222"), testutil.FilePresent)
 	// place a canary
 	c.Assert(ioutil.WriteFile(filepath.Join(dirs.SnapAppArmorDir, "snap-confine.snapd.111"), nil, 0644), IsNil)

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -967,7 +967,7 @@ slots:
 	}
 }
 
-func (s *baseDeclSuite) TestSanity(c *C) {
+func (s *baseDeclSuite) TestValidity(c *C) {
 	all := builtin.Interfaces()
 
 	// these interfaces have rules both for the slots and plugs side

--- a/interfaces/repo.go
+++ b/interfaces/repo.go
@@ -645,7 +645,7 @@ func (r *Repository) Disconnect(plugSnapName, plugName, slotSnapName, slotName s
 	r.m.Lock()
 	defer r.m.Unlock()
 
-	// Sanity check
+	// Validity check
 	if plugSnapName == "" {
 		return fmt.Errorf("cannot disconnect, plug snap name is empty")
 	}

--- a/interfaces/system_key.go
+++ b/interfaces/system_key.go
@@ -299,7 +299,7 @@ func CurrentSystemKey() (interface{}, error) {
 
 // SystemKeysMatch returns whether the given system keys match.
 func SystemKeysMatch(systemKey1, systemKey2 interface{}) (bool, error) {
-	// sanity check
+	// validity check
 	_, ok1 := systemKey1.(*systemKey)
 	_, ok2 := systemKey2.(*systemKey)
 	if !(ok1 && ok2) {

--- a/interfaces/system_key.go
+++ b/interfaces/system_key.go
@@ -299,7 +299,7 @@ func CurrentSystemKey() (interface{}, error) {
 
 // SystemKeysMatch returns whether the given system keys match.
 func SystemKeysMatch(systemKey1, systemKey2 interface{}) (bool, error) {
-	// validity check
+	// precondition check
 	_, ok1 := systemKey1.(*systemKey)
 	_, ok2 := systemKey2.(*systemKey)
 	if !(ok1 && ok2) {

--- a/interfaces/udev/spec_test.go
+++ b/interfaces/udev/spec_test.go
@@ -146,7 +146,7 @@ func (s *specSuite) TestTagDeviceAltLibexecdir(c *C) {
 	restore := release.MockReleaseInfo(&release.OS{ID: "fedora"})
 	defer restore()
 	dirs.SetRootDir("")
-	// sanity
+	// validity
 	c.Check(dirs.DistroLibExecDir, Equals, "/usr/libexec/snapd")
 	s.testTagDevice(c, "/usr/libexec/snapd")
 }

--- a/overlord/assertstate/assertmgr.go
+++ b/overlord/assertstate/assertmgr.go
@@ -136,7 +136,7 @@ func doValidateSnap(t *state.Task, _ *tomb.Tomb) error {
 	db := DB(st)
 	err = snapasserts.CrossCheck(snapsup.InstanceName(), sha3_384, snapSize, snapsup.SideInfo, db)
 	if err != nil {
-		// TODO: trigger a global sanity check
+		// TODO: trigger a global validity check
 		// that will generate the changes to deal with this
 		// for things like snap-decl revocation and renames?
 		return err

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -2380,7 +2380,7 @@ func (s *assertMgrSuite) TestRefreshValidationSetAssertions(c *C) {
 	err = s.storeSigning.Add(vsetAs3)
 	c.Assert(err, IsNil)
 
-	// validity check - sequence 4 not available locally yet
+	// precondition check - sequence 4 not available locally yet
 	_, err = assertstate.DB(s.state).Find(asserts.ValidationSetType, map[string]string{
 		"series":     "16",
 		"account-id": s.dev1Acct.AccountID(),
@@ -2536,7 +2536,7 @@ func (s *assertMgrSuite) TestRefreshValidationSetAssertionsLocalOnlyFailed(c *C)
 	err = assertstate.RefreshValidationSetAssertions(s.state, 0, nil)
 	c.Assert(err, IsNil)
 
-	// validity - local assertion vsetAs1 is the latest
+	// precondition - local assertion vsetAs1 is the latest
 	a, err := assertstate.DB(s.state).FindSequence(asserts.ValidationSetType, map[string]string{
 		"series":     "16",
 		"account-id": s.dev1Acct.AccountID(),

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -2380,7 +2380,7 @@ func (s *assertMgrSuite) TestRefreshValidationSetAssertions(c *C) {
 	err = s.storeSigning.Add(vsetAs3)
 	c.Assert(err, IsNil)
 
-	// sanity check - sequence 4 not available locally yet
+	// validity check - sequence 4 not available locally yet
 	_, err = assertstate.DB(s.state).Find(asserts.ValidationSetType, map[string]string{
 		"series":     "16",
 		"account-id": s.dev1Acct.AccountID(),
@@ -2536,7 +2536,7 @@ func (s *assertMgrSuite) TestRefreshValidationSetAssertionsLocalOnlyFailed(c *C)
 	err = assertstate.RefreshValidationSetAssertions(s.state, 0, nil)
 	c.Assert(err, IsNil)
 
-	// sanity - local assertion vsetAs1 is the latest
+	// validity - local assertion vsetAs1 is the latest
 	a, err := assertstate.DB(s.state).FindSequence(asserts.ValidationSetType, map[string]string{
 		"series":     "16",
 		"account-id": s.dev1Acct.AccountID(),

--- a/overlord/assertstate/helpers.go
+++ b/overlord/assertstate/helpers.go
@@ -75,7 +75,7 @@ func doFetch(s *state.State, userID int, deviceCtx snapstate.DeviceContext, fetc
 		return err
 	}
 
-	// TODO: trigger w. caller a global sanity check if a is revoked
+	// TODO: trigger w. caller a global validity check if a is revoked
 	// (but try to save as much possible still),
 	// or err is a check error
 	return b.CommitTo(db, nil)

--- a/overlord/configstate/config/helpers_test.go
+++ b/overlord/configstate/config/helpers_test.go
@@ -149,7 +149,7 @@ func (s *configHelpersSuite) TestSnapConfig(c *C) {
 	buf, err := json.Marshal(nil)
 	c.Assert(err, IsNil)
 	empty2 := (*json.RawMessage)(&buf)
-	// sanity check
+	// validity check
 	c.Check(bytes.Compare(*empty2, []byte(`null`)), Equals, 0)
 
 	for _, emptyCfg := range []*json.RawMessage{nil, &empty1, empty2, {}} {

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -230,7 +230,7 @@ func checkGadgetValid(st *state.State, snapInfo, _ *snap.Info, snapf snap.Contai
 		return nil
 	}
 
-	// do basic validity checks on the gadget against its model constraints
+	// do basic precondition checks on the gadget against its model constraints
 	_, err := gadget.ReadInfoFromSnapFile(snapf, deviceCtx.Model())
 	return err
 }
@@ -1031,7 +1031,7 @@ func pickRecoverySystemLabel(labelBase string) (string, error) {
 }
 
 func createRecoverySystemTasks(st *state.State, label string, snapSetupTasks []string) (*state.TaskSet, error) {
-	// validity check, the directory should not exist yet
+	// precondition check, the directory should not exist yet
 	systemDirectory := filepath.Join(boot.InitramfsUbuntuSeedDir, "systems", label)
 	exists, _, err := osutil.DirExists(systemDirectory)
 	if err != nil {

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -135,7 +135,7 @@ func canAutoRefresh(st *state.State) (bool, error) {
 		return true, nil
 	}
 
-	// Check model exists, for sanity. We always have a model, either
+	// Check model exists, for validity. We always have a model, either
 	// seeded or a generic one that ships with snapd.
 	_, err := findModel(st)
 	if err == state.ErrNoState {
@@ -1031,7 +1031,7 @@ func pickRecoverySystemLabel(labelBase string) (string, error) {
 }
 
 func createRecoverySystemTasks(st *state.State, label string, snapSetupTasks []string) (*state.TaskSet, error) {
-	// sanity check, the directory should not exist yet
+	// validity check, the directory should not exist yet
 	systemDirectory := filepath.Join(boot.InitramfsUbuntuSeedDir, "systems", label)
 	exists, _, err := osutil.DirExists(systemDirectory)
 	if err != nil {

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -847,7 +847,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallBootloaderVarSetFails(c *C) {
 	c.Check(s.restartRequests, HasLen, 0)
 }
 
-func (s *deviceMgrInstallModeSuite) testInstallEncryptionSanityChecks(c *C, errMatch string) {
+func (s *deviceMgrInstallModeSuite) testInstallEncryptionValidityChecks(c *C, errMatch string) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 
@@ -875,18 +875,18 @@ func (s *deviceMgrInstallModeSuite) testInstallEncryptionSanityChecks(c *C, errM
 	c.Check(s.restartRequests, HasLen, 0)
 }
 
-func (s *deviceMgrInstallModeSuite) TestInstallEncryptionSanityChecksNoKeys(c *C) {
+func (s *deviceMgrInstallModeSuite) TestInstallEncryptionValidityChecksNoKeys(c *C) {
 	restore := devicestate.MockInstallRun(func(mod gadget.Model, gadgetRoot, kernelRoot, device string, options install.Options, _ gadget.ContentObserver, _ timings.Measurer) (*install.InstalledSystemSideData, error) {
 		c.Check(options.EncryptionType, Equals, secboot.EncryptionTypeLUKS)
 		// no keys set
 		return &install.InstalledSystemSideData{}, nil
 	})
 	defer restore()
-	s.testInstallEncryptionSanityChecks(c, `(?ms)cannot perform the following tasks:
+	s.testInstallEncryptionValidityChecks(c, `(?ms)cannot perform the following tasks:
 - Setup system for run mode \(internal error: system encryption keys are unset\)`)
 }
 
-func (s *deviceMgrInstallModeSuite) TestInstallEncryptionSanityChecksNoSystemDataKey(c *C) {
+func (s *deviceMgrInstallModeSuite) TestInstallEncryptionValidityChecksNoSystemDataKey(c *C) {
 	restore := devicestate.MockInstallRun(func(mod gadget.Model, gadgetRoot, kernelRoot, device string, options install.Options, _ gadget.ContentObserver, _ timings.Measurer) (*install.InstalledSystemSideData, error) {
 		c.Check(options.EncryptionType, Equals, secboot.EncryptionTypeLUKS)
 		// no keys set
@@ -896,7 +896,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallEncryptionSanityChecksNoSystemDat
 		}, nil
 	})
 	defer restore()
-	s.testInstallEncryptionSanityChecks(c, `(?ms)cannot perform the following tasks:
+	s.testInstallEncryptionValidityChecks(c, `(?ms)cannot perform the following tasks:
 - Setup system for run mode \(internal error: system encryption keys are unset\)`)
 }
 

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -905,7 +905,7 @@ func (s *deviceMgrSuite) TestCanAutoRefreshNoSerialFallback(c *C) {
 	// third attempt ongoing, or done
 	// fallback, try auto-refresh
 	devicestate.IncEnsureOperationalAttempts(s.state)
-	// sanity
+	// validity
 	c.Check(devicestate.EnsureOperationalAttempts(s.state), Equals, 3)
 	c.Check(canAutoRefresh(), Equals, true)
 }

--- a/overlord/devicestate/firstboot20_test.go
+++ b/overlord/devicestate/firstboot20_test.go
@@ -230,7 +230,7 @@ func (s *firstBoot20Suite) earlySetup(c *C, m *boot.Modeenv, modelGrade asserts.
 
 	sysLabel := m.RecoverySystem
 	model = s.setupCore20Seed(c, sysLabel, modelGrade, extraGadgetYaml, extraSnaps...)
-	// sanity check that our returned model has the expected grade
+	// validity check that our returned model has the expected grade
 	c.Assert(model.Grade(), Equals, modelGrade)
 
 	bloader = bootloadertest.Mock("mock", c.MkDir()).WithExtractedRunKernelImage()

--- a/overlord/devicestate/firstboot_preseed_test.go
+++ b/overlord/devicestate/firstboot_preseed_test.go
@@ -253,7 +253,7 @@ func (s *firstbootPreseedingClassic16Suite) TestPreseedOnClassicHappy(c *C) {
 	restore := snapdenv.MockPreseeding(true)
 	defer restore()
 
-	// validity
+	// precondition
 	c.Assert(release.OnClassic, Equals, true)
 
 	coreFname, _, _ := s.makeCoreSnaps(c, "")
@@ -344,7 +344,7 @@ func (s *firstbootPreseedingClassic16Suite) TestPreseedClassicWithSnapdOnlyHappy
 	restorePreseedMode := snapdenv.MockPreseeding(true)
 	defer restorePreseedMode()
 
-	// validity
+	// precondition
 	c.Assert(release.OnClassic, Equals, true)
 
 	core18Fname, snapdFname, _, _ := s.makeCore18Snaps(c, &core18SnapsOpts{

--- a/overlord/devicestate/firstboot_preseed_test.go
+++ b/overlord/devicestate/firstboot_preseed_test.go
@@ -85,7 +85,7 @@ func checkPreseedTaskStates(c *C, st *state.State) {
 		}
 	}
 
-	// sanity: check that doneTasks is not declaring more tasks than
+	// validity: check that doneTasks is not declaring more tasks than
 	// actually expected.
 	c.Check(doneTasks, DeepEquals, seenDone)
 }
@@ -253,7 +253,7 @@ func (s *firstbootPreseedingClassic16Suite) TestPreseedOnClassicHappy(c *C) {
 	restore := snapdenv.MockPreseeding(true)
 	defer restore()
 
-	// sanity
+	// validity
 	c.Assert(release.OnClassic, Equals, true)
 
 	coreFname, _, _ := s.makeCoreSnaps(c, "")
@@ -344,7 +344,7 @@ func (s *firstbootPreseedingClassic16Suite) TestPreseedClassicWithSnapdOnlyHappy
 	restorePreseedMode := snapdenv.MockPreseeding(true)
 	defer restorePreseedMode()
 
-	// sanity
+	// validity
 	c.Assert(release.OnClassic, Equals, true)
 
 	core18Fname, snapdFname, _, _ := s.makeCore18Snaps(c, &core18SnapsOpts{

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -311,7 +311,7 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	if trustedInstallObserver != nil {
-		// sanity check
+		// validity check
 		if installedSystem.KeysForRoles == nil || installedSystem.KeysForRoles[gadget.SystemData] == nil || installedSystem.KeysForRoles[gadget.SystemSave] == nil {
 			return fmt.Errorf("internal error: system encryption keys are unset")
 		}

--- a/overlord/hookstate/ctlcmd/is_connected_test.go
+++ b/overlord/hookstate/ctlcmd/is_connected_test.go
@@ -251,7 +251,7 @@ func (s *isConnectedSuite) TestIsConnectedFromApp(c *C) {
 	mockContext, err := hookstate.NewContext(nil, s.st, setup, s.mockHandler, "")
 	c.Check(err, IsNil)
 
-	// sanity
+	// validity
 	c.Assert(mockContext.IsEphemeral(), Equals, true)
 
 	s.testIsConnected(c, mockContext)

--- a/overlord/hookstate/ctlcmd/refresh_test.go
+++ b/overlord/hookstate/ctlcmd/refresh_test.go
@@ -227,7 +227,7 @@ version: 1
 	c.Check(err, IsNil)
 	s.st.Unlock()
 
-	// sanity check
+	// validity check
 	var gating map[string]map[string]interface{}
 	s.st.Lock()
 	snapsHold := s.st.Get("snaps-hold", &gating)

--- a/overlord/hookstate/ctlcmd/unset_test.go
+++ b/overlord/hookstate/ctlcmd/unset_test.go
@@ -67,7 +67,7 @@ func (s *unsetSuite) TestUnsetOne(c *C) {
 	tr.Commit()
 	s.mockContext.State().Unlock()
 
-	// Sanity check
+	// Validity check
 	var value interface{}
 	s.mockContext.State().Lock()
 	tr = config.NewTransaction(s.mockContext.State())

--- a/overlord/ifacestate/helpers_test.go
+++ b/overlord/ifacestate/helpers_test.go
@@ -598,7 +598,7 @@ func (s *helpersSuite) TestAllocHotplugSeq(c *C) {
 
 	var stateSeq int
 
-	// sanity
+	// validity
 	c.Assert(s.st.Get("hotplug-seq", &stateSeq), Equals, state.ErrNoState)
 
 	seq, err := ifacestate.AllocHotplugSeq(s.st)

--- a/overlord/ifacestate/helpers_test.go
+++ b/overlord/ifacestate/helpers_test.go
@@ -598,7 +598,7 @@ func (s *helpersSuite) TestAllocHotplugSeq(c *C) {
 
 	var stateSeq int
 
-	// validity
+	// precondition
 	c.Assert(s.st.Get("hotplug-seq", &stateSeq), Equals, state.ErrNoState)
 
 	seq, err := ifacestate.AllocHotplugSeq(s.st)

--- a/overlord/ifacestate/hotplug_test.go
+++ b/overlord/ifacestate/hotplug_test.go
@@ -634,7 +634,7 @@ func (s *hotplugSuite) TestHotplugEnumerationDone(c *C) {
 			"interface":   "test-a",
 			"hotplug-key": "yet-another-device"}})
 
-	// sanity
+	// validity
 	slot, _ := repo.SlotForHotplugKey("test-a", "key-other-device")
 	c.Assert(slot, NotNil)
 
@@ -807,7 +807,7 @@ func (s *hotplugSuite) TestDefaultDeviceKey(c *C) {
 	key, err := ifacestate.DefaultDeviceKey(di, 0)
 	c.Assert(err, IsNil)
 
-	// sanity check
+	// validity check
 	c.Check(key, HasLen, 65)
 	c.Check(key, Equals, snap.HotplugKey("08bcbdcda3fee3534c0288506d9b75d4e26fe3692a36a11e75d05eac9ebf5ca7d"))
 	c.Assert(key, Equals, keyHelper("ID_V4L_PRODUCT\x00v4lproduct\x00ID_VENDOR_ID\x00vendor\x00ID_MODEL_ID\x00model\x00ID_SERIAL\x00serial\x00"))

--- a/overlord/ifacestate/hotplug_test.go
+++ b/overlord/ifacestate/hotplug_test.go
@@ -634,7 +634,7 @@ func (s *hotplugSuite) TestHotplugEnumerationDone(c *C) {
 			"interface":   "test-a",
 			"hotplug-key": "yet-another-device"}})
 
-	// validity
+	// precondition
 	slot, _ := repo.SlotForHotplugKey("test-a", "key-other-device")
 	c.Assert(slot, NotNil)
 

--- a/overlord/patch/patch_test.go
+++ b/overlord/patch/patch_test.go
@@ -370,7 +370,7 @@ func (s *patchSuite) TestDifferentSnapdVersionPatchLevel6(c *C) {
 	s.testMaybeResetPatchLevel6(c, "snapd-version-1", "snapd-version-2", []int{61, 62})
 }
 
-func (s *patchSuite) TestSanity(c *C) {
+func (s *patchSuite) TestValidity(c *C) {
 	patches := patch.PatchesForTest()
 	levels := make([]int, 0, len(patches))
 	for l := range patches {

--- a/overlord/servicestate/service_control_test.go
+++ b/overlord/servicestate/service_control_test.go
@@ -129,7 +129,7 @@ func (s *serviceControlSuite) mockTestSnap(c *C) *snap.Info {
 
 func verifyControlTasks(c *C, tasks []*state.Task, expectedAction, actionModifier string,
 	expectedServices []string, expectedExplicitServices []string) {
-	// sanity, ensures test checks below are hit
+	// validity, ensures test checks below are hit
 	c.Assert(len(tasks) > 0, Equals, true)
 
 	splitServiceName := func(name string) (snapName, serviceName string) {

--- a/overlord/servicestate/service_control_test.go
+++ b/overlord/servicestate/service_control_test.go
@@ -129,7 +129,7 @@ func (s *serviceControlSuite) mockTestSnap(c *C) *snap.Info {
 
 func verifyControlTasks(c *C, tasks []*state.Task, expectedAction, actionModifier string,
 	expectedServices []string, expectedExplicitServices []string) {
-	// validity, ensures test checks below are hit
+	// precondition, ensures test checks below are hit
 	c.Assert(len(tasks) > 0, Equals, true)
 
 	splitServiceName := func(name string) (snapName, serviceName string) {

--- a/overlord/snapshotstate/backend/backend_test.go
+++ b/overlord/snapshotstate/backend/backend_test.go
@@ -689,7 +689,7 @@ func (s *snapshotSuite) testHappyRoundtrip(c *check.C, marker string) {
 
 	for i := 0; i < 3; i++ {
 		comm := check.Commentf("%d", i)
-		// sanity check
+		// validity check
 		c.Check(diff().Run(), check.NotNil, comm)
 
 		// restore leaves things like they were (again and again)
@@ -767,7 +767,7 @@ func (s *snapshotSuite) TestRestoreRoundtripDifferentRevision(c *check.C) {
 		return cmd
 	}
 
-	// sanity check
+	// validity check
 	c.Check(diff().Run(), check.NotNil)
 
 	// restore leaves things like they were, but in the new dir

--- a/overlord/snapshotstate/snapshotmgr_test.go
+++ b/overlord/snapshotstate/snapshotmgr_test.go
@@ -215,7 +215,7 @@ func (snapshotSuite) testEnsureForgetSnapshotsConflict(c *check.C, snapshotOp st
 	c.Check(removeCalled, check.Equals, 0)
 
 	if tsk != nil {
-		// sanity check of the test setup: snapshot gets removed once conflict goes away
+		// validity check of the test setup: snapshot gets removed once conflict goes away
 		tsk.SetStatus(state.DoneStatus)
 	} else {
 		c.Check(snapshotstate.UnsetSnapshotOpInProgress(st, 1), check.Equals, snapshotOp)

--- a/overlord/snapshotstate/snapshotstate_test.go
+++ b/overlord/snapshotstate/snapshotstate_test.go
@@ -651,7 +651,7 @@ func (snapshotSuite) TestSaveIntegrationFails(c *check.C) {
 		c.Skip("this test cannot run as root (runuser will fail)")
 	}
 	c.Assert(os.MkdirAll(dirs.SnapshotsDir, 0755), check.IsNil)
-	// validity check: no files in snapshot dir
+	// precondition check: no files in snapshot dir
 	out, err := exec.Command("find", dirs.SnapshotsDir, "-type", "f").CombinedOutput()
 	c.Assert(err, check.IsNil)
 	c.Check(string(out), check.Equals, "")
@@ -761,7 +761,7 @@ func (snapshotSuite) testSaveIntegrationTarFails(c *check.C, tarLogLines int, ex
 		c.Skip("this test cannot run as root (runuser will fail)")
 	}
 	c.Assert(os.MkdirAll(dirs.SnapshotsDir, 0755), check.IsNil)
-	// validity check: no files in snapshot dir
+	// precondition check: no files in snapshot dir
 	out, err := exec.Command("find", dirs.SnapshotsDir, "-type", "f").CombinedOutput()
 	c.Assert(err, check.IsNil)
 	c.Check(string(out), check.Equals, "")

--- a/overlord/snapshotstate/snapshotstate_test.go
+++ b/overlord/snapshotstate/snapshotstate_test.go
@@ -651,7 +651,7 @@ func (snapshotSuite) TestSaveIntegrationFails(c *check.C) {
 		c.Skip("this test cannot run as root (runuser will fail)")
 	}
 	c.Assert(os.MkdirAll(dirs.SnapshotsDir, 0755), check.IsNil)
-	// sanity check: no files in snapshot dir
+	// validity check: no files in snapshot dir
 	out, err := exec.Command("find", dirs.SnapshotsDir, "-type", "f").CombinedOutput()
 	c.Assert(err, check.IsNil)
 	c.Check(string(out), check.Equals, "")
@@ -734,18 +734,18 @@ exec /bin/tar "$@"
 	c.Assert(tasks, check.HasLen, 3)
 
 	// task 0 (for "one-snap") will have been undone
-	c.Check(tasks[0].Summary(), testutil.Contains, `"one-snap"`) // sanity check: task 0 is one-snap's
+	c.Check(tasks[0].Summary(), testutil.Contains, `"one-snap"`) // validity check: task 0 is one-snap's
 	c.Check(tasks[0].Status(), check.Equals, state.UndoneStatus)
 
 	// task 1 (for "too-snap") will have errored
-	c.Check(tasks[1].Summary(), testutil.Contains, `"too-snap"`) // sanity check: task 1 is too-snap's
+	c.Check(tasks[1].Summary(), testutil.Contains, `"too-snap"`) // validity check: task 1 is too-snap's
 	c.Check(tasks[1].Status(), check.Equals, state.ErrorStatus)
 	c.Check(strings.Join(tasks[1].Log(), "\n"), check.Matches, `(?ms)\S+ ERROR cannot create archive:
 /bin/tar: common/common-too-snap: .* Permission denied
 /bin/tar: Exiting with failure status due to previous errors`)
 
 	// task 2 (for "tri-snap") will have errored as well, hopefully, but it's a race (see the "tar" comment above)
-	c.Check(tasks[2].Summary(), testutil.Contains, `"tri-snap"`) // sanity check: task 2 is tri-snap's
+	c.Check(tasks[2].Summary(), testutil.Contains, `"tri-snap"`) // validity check: task 2 is tri-snap's
 	c.Check(tasks[2].Status(), check.Equals, state.ErrorStatus, check.Commentf("if this ever fails, duplicate the fake tar sleeps please"))
 	// sometimes you'll get one, sometimes you'll get the other (depending on ordering of events)
 	c.Check(strings.Join(tasks[2].Log(), "\n"), check.Matches, `\S+ ERROR( tar failed:)? context canceled`)
@@ -761,7 +761,7 @@ func (snapshotSuite) testSaveIntegrationTarFails(c *check.C, tarLogLines int, ex
 		c.Skip("this test cannot run as root (runuser will fail)")
 	}
 	c.Assert(os.MkdirAll(dirs.SnapshotsDir, 0755), check.IsNil)
-	// sanity check: no files in snapshot dir
+	// validity check: no files in snapshot dir
 	out, err := exec.Command("find", dirs.SnapshotsDir, "-type", "f").CombinedOutput()
 	c.Assert(err, check.IsNil)
 	c.Check(string(out), check.Equals, "")
@@ -834,7 +834,7 @@ exec /bin/tar "$@"
 	c.Assert(tasks, check.HasLen, 1)
 
 	// task 1 (for "too-snap") will have errored
-	c.Check(tasks[0].Summary(), testutil.Contains, `"tar-fail-snap"`) // sanity check: task 1 is too-snap's
+	c.Check(tasks[0].Summary(), testutil.Contains, `"tar-fail-snap"`) // validity check: task 1 is too-snap's
 	c.Check(tasks[0].Status(), check.Equals, state.ErrorStatus)
 	c.Check(strings.Join(tasks[0].Log(), "\n"), check.Matches, expectedErr)
 

--- a/overlord/snapstate/aux_store_info_test.go
+++ b/overlord/snapstate/aux_store_info_test.go
@@ -39,7 +39,7 @@ func (s *auxInfoSuite) SetUpTest(c *check.C) {
 }
 
 func (s *auxInfoSuite) TestAuxStoreInfoFilename(c *check.C) {
-	// sanity check
+	// validity check
 	filename := snapstate.AuxStoreInfoFilename("some-snap-id")
 	c.Check(filename, check.Equals, filepath.Join(dirs.SnapAuxStoreInfoDir, "some-snap-id.json"))
 }

--- a/overlord/snapstate/aux_store_info_test.go
+++ b/overlord/snapstate/aux_store_info_test.go
@@ -39,7 +39,7 @@ func (s *auxInfoSuite) SetUpTest(c *check.C) {
 }
 
 func (s *auxInfoSuite) TestAuxStoreInfoFilename(c *check.C) {
-	// validity check
+	// precondition check
 	filename := snapstate.AuxStoreInfoFilename("some-snap-id")
 	c.Check(filename, check.Equals, filepath.Join(dirs.SnapAuxStoreInfoDir, "some-snap-id.json"))
 }

--- a/overlord/snapstate/backend/copydata_test.go
+++ b/overlord/snapstate/backend/copydata_test.go
@@ -492,7 +492,7 @@ func (s *copydataSuite) TestCopyDataPartialFailure(c *C) {
 	// pretend we install a new version
 	v2 := snaptest.MockSnap(c, helloYaml2, &snap.SideInfo{Revision: snap.R(20)})
 
-	// validity check: the 20 dirs don't exist yet (but 10 do)
+	// precondition check: the 20 dirs don't exist yet (but 10 do)
 	for _, dir := range []string{dirs.SnapDataDir, homedir1, homedir2} {
 		c.Assert(osutil.FileExists(filepath.Join(dir, "hello", "20")), Equals, false, Commentf(dir))
 		c.Assert(osutil.FileExists(filepath.Join(dir, "hello", "10")), Equals, true, Commentf(dir))

--- a/overlord/snapstate/backend/copydata_test.go
+++ b/overlord/snapstate/backend/copydata_test.go
@@ -169,7 +169,7 @@ func (s *copydataSuite) TestCopyDataNoUserHomes(c *C) {
 	_, err = os.Stat(filepath.Join(v2.CommonDataDir(), "canary.common"))
 	c.Assert(err, IsNil)
 
-	// sanity atm
+	// validity atm
 	c.Check(v1.DataDir(), Not(Equals), v2.DataDir())
 	c.Check(v1.CommonDataDir(), Equals, v2.CommonDataDir())
 }
@@ -492,7 +492,7 @@ func (s *copydataSuite) TestCopyDataPartialFailure(c *C) {
 	// pretend we install a new version
 	v2 := snaptest.MockSnap(c, helloYaml2, &snap.SideInfo{Revision: snap.R(20)})
 
-	// sanity check: the 20 dirs don't exist yet (but 10 do)
+	// validity check: the 20 dirs don't exist yet (but 10 do)
 	for _, dir := range []string{dirs.SnapDataDir, homedir1, homedir2} {
 		c.Assert(osutil.FileExists(filepath.Join(dir, "hello", "20")), Equals, false, Commentf(dir))
 		c.Assert(osutil.FileExists(filepath.Join(dir, "hello", "10")), Equals, true, Commentf(dir))

--- a/overlord/snapstate/catalogrefresh_test.go
+++ b/overlord/snapstate/catalogrefresh_test.go
@@ -282,7 +282,7 @@ func (s *catalogRefreshTestSuite) TestCatalogRefreshSkipWhenTesting(c *C) {
 
 	// and reset the next refresh time
 	snapstate.MockCatalogRefreshNextRefresh(cr7, time.Time{})
-	// sanity
+	// validity
 	c.Check(snapstate.NextCatalogRefresh(cr7).IsZero(), Equals, true)
 
 	err = cr7.Ensure()

--- a/overlord/snapstate/handlers_link_test.go
+++ b/overlord/snapstate/handlers_link_test.go
@@ -1389,7 +1389,7 @@ func (s *linkSnapSuite) TestLinkSnapInjectsAutoConnectIfMissing(c *C) {
 	c.Assert(chg.Err(), IsNil)
 	c.Assert(chg.Tasks(), HasLen, 6)
 
-	// sanity checks
+	// validity checks
 	t := chg.Tasks()[1]
 	c.Assert(t.Kind(), Equals, "link-snap")
 	t = chg.Tasks()[3]

--- a/overlord/snapstate/handlers_prereq_test.go
+++ b/overlord/snapstate/handlers_prereq_test.go
@@ -384,13 +384,13 @@ func (s *prereqSuite) TestDoPrereqRetryWhenBaseInFlight(c *C) {
 		}
 	}
 
-	// sanity check, exactly two calls to link-snap due to retry error on 1st call
+	// validity check, exactly two calls to link-snap due to retry error on 1st call
 	c.Check(calls, Equals, 2)
 
 	c.Check(tCore.Status(), Equals, state.DoneStatus)
 	c.Check(prereqTask.Status(), Equals, state.DoneStatus)
 
-	// sanity
+	// validity
 	c.Check(chg.Status(), Equals, state.DoneStatus)
 }
 

--- a/overlord/snapstate/refresh_test.go
+++ b/overlord/snapstate/refresh_test.go
@@ -226,7 +226,7 @@ func (s *refreshSuite) TestDoSoftRefreshCheckDisallowed(c *C) {
 	err := snapstate.SoftCheckNothingRunningForRefresh(s.state, snapst, info)
 	c.Assert(err, ErrorMatches, `snap "pkg" has running apps or hooks`)
 
-	// Sanity check: the inhibition lock was not set.
+	// Validity check: the inhibition lock was not set.
 	hint, err := runinhibit.IsLocked(info.InstanceName())
 	c.Assert(err, IsNil)
 	c.Check(hint, Equals, runinhibit.HintNotInhibited)
@@ -278,7 +278,7 @@ func (s *refreshSuite) TestDoHardRefreshFlowRefreshDisallowed(c *C) {
 	c.Assert(err, ErrorMatches, `snap "pkg" has running apps or hooks`)
 	c.Assert(lock, IsNil)
 
-	// Sanity check: the inhibition lock was not set.
+	// Validity check: the inhibition lock was not set.
 	op := backend.ops.MustFindOp(c, "run-inhibit-snap-for-unlink")
 	c.Check(op.inhibitHint, Equals, runinhibit.Hint("refresh"))
 }

--- a/overlord/snapstate/storehelpers_test.go
+++ b/overlord/snapstate/storehelpers_test.go
@@ -334,7 +334,7 @@ func (s *snapmgrTestSuite) TestInstallSizeWithOtherChangeAffectingSameSnaps(c *C
 	// snap3 and its base installed by another change, not counted here
 	c.Check(sz, Equals, uint64(snap1Size+someBaseSize))
 
-	// sanity
+	// validity
 	c.Check(currentSnapsCalled, Equals, 2)
 }
 

--- a/overlord/state/warning_test.go
+++ b/overlord/state/warning_test.go
@@ -99,7 +99,7 @@ func (stateSuite) TestUnmarshalErrors(c *check.C) {
 	}
 
 	for _, t := range []T1{
-		// sanity check
+		// validity check
 		{`{"message": "x", "first-added": "2006-01-02T15:04:05Z", "expire-after": "1h", "repeat-after": "1h"}`, nil},
 		// remove one field at a time:
 		{`{                "first-added": "2006-01-02T15:04:05Z", "expire-after": "1h", "repeat-after": "1h"}`, state.ErrNoWarningMessage},


### PR DESCRIPTION
This commit replaces the use of "sanity" with more inclusive
naming. When "sanity" is used in a more general sense either
"validity" or "quick" is used.

