### PR TITLE
snap/quota: additional validation in resources.go

### DIFF
--- a/snap/quota/quota.go
+++ b/snap/quota/quota.go
@@ -434,8 +434,10 @@ func (grp *Group) validateQuotasFit(resourceLimits Resources) error {
 				return err
 			}
 		}
-		if len(resourceLimits.CPU.AllowedCPUs) != 0 {
-			if err := grp.validateCPUsAllowedResourceFit(allQuotas, resourceLimits.CPU.AllowedCPUs); err != nil {
+	}
+	if resourceLimits.CPUSet != nil {
+		if len(resourceLimits.CPUSet.CPUs) != 0 {
+			if err := grp.validateCPUsAllowedResourceFit(allQuotas, resourceLimits.CPUSet.CPUs); err != nil {
 				return err
 			}
 		}
@@ -466,10 +468,15 @@ func (grp *Group) UpdateQuotaLimits(resourceLimits Resources) error {
 	}
 	if resourceLimits.CPU != nil {
 		grp.CPULimit = &GroupQuotaCPU{
-			Count:       resourceLimits.CPU.Count,
-			Percentage:  resourceLimits.CPU.Percentage,
-			AllowedCPUs: resourceLimits.CPU.AllowedCPUs,
+			Count:      resourceLimits.CPU.Count,
+			Percentage: resourceLimits.CPU.Percentage,
 		}
+	}
+	if resourceLimits.CPUSet != nil {
+		if grp.CPULimit == nil {
+			grp.CPULimit = &GroupQuotaCPU{}
+		}
+		grp.CPULimit.AllowedCPUs = resourceLimits.CPUSet.CPUs
 	}
 	if resourceLimits.Threads != nil {
 		grp.TaskLimit = resourceLimits.Threads.Limit

--- a/snap/quota/resources.go
+++ b/snap/quota/resources.go
@@ -30,9 +30,12 @@ type ResourceMemory struct {
 }
 
 type ResourceCPU struct {
-	Count       int   `json:"count"`
-	Percentage  int   `json:"percentage"`
-	AllowedCPUs []int `json:"allowed-cpus"`
+	Count      int `json:"count"`
+	Percentage int `json:"percentage"`
+}
+
+type ResourceCPUSet struct {
+	CPUs []int `json:"cpus"`
 }
 
 type ResourceThreads struct {
@@ -45,6 +48,7 @@ type ResourceThreads struct {
 type Resources struct {
 	Memory  *ResourceMemory  `json:"memory,omitempty"`
 	CPU     *ResourceCPU     `json:"cpu,omitempty"`
+	CPUSet  *ResourceCPUSet  `json:"cpu-set,omitempty"`
 	Threads *ResourceThreads `json:"thread,omitempty"`
 }
 
@@ -64,15 +68,22 @@ func (qr *Resources) validateMemoryQuota() error {
 	return nil
 }
 
-func (qr *Resources) validateCpuQuota() error {
+func (qr *Resources) validateCPUQuota() error {
 	// if cpu count is non-zero, then percentage should be set
 	if qr.CPU.Count != 0 && qr.CPU.Percentage == 0 {
 		return fmt.Errorf("invalid cpu quota with count of >0 and percentage of 0")
 	}
 
 	// at least one cpu limit value must be set
-	if qr.CPU.Count == 0 && qr.CPU.Percentage == 0 && len(qr.CPU.AllowedCPUs) == 0 {
-		return fmt.Errorf("invalid cpu quota with a cpu quota of 0 and no allowed cpus")
+	if qr.CPU.Count == 0 && qr.CPU.Percentage == 0 {
+		return fmt.Errorf("invalid cpu quota with a cpu quota of 0")
+	}
+	return nil
+}
+
+func (qr *Resources) validateCPUSetQuota() error {
+	if len(qr.CPUSet.CPUs) == 0 {
+		return fmt.Errorf("cpu-set quota must not be empty")
 	}
 	return nil
 }
@@ -89,9 +100,10 @@ func (qr *Resources) validateThreadQuota() error {
 // The restrictions imposed are that at least one limit should be set.
 // If memory limit is provided, it must be above 4KB.
 // If cpu percentage is provided, it must be between 1 and 100.
+// If cpu set is provided, it must not be empty.
 // If thread count is provided, it must be above 0.
 func (qr *Resources) Validate() error {
-	if qr.Memory == nil && qr.CPU == nil && qr.Threads == nil {
+	if qr.Memory == nil && qr.CPU == nil && qr.CPUSet == nil && qr.Threads == nil {
 		return fmt.Errorf("quota group must have at least one resource limit set")
 	}
 
@@ -102,7 +114,13 @@ func (qr *Resources) Validate() error {
 	}
 
 	if qr.CPU != nil {
-		if err := qr.validateCpuQuota(); err != nil {
+		if err := qr.validateCPUQuota(); err != nil {
+			return err
+		}
+	}
+
+	if qr.CPUSet != nil {
+		if err := qr.validateCPUSetQuota(); err != nil {
 			return err
 		}
 	}
@@ -119,8 +137,7 @@ func (qr *Resources) Validate() error {
 // This is to catch issues where we want to guard against lowering limits where not supported
 // or to make sure that certain/all limits are not removed.
 func (qr *Resources) ValidateChange(newLimits Resources) error {
-
-	// Check that the memory limit is not being decreased, but we allow it to be removed
+	// Check that the memory limit is not being decreased
 	if newLimits.Memory != nil {
 		if newLimits.Memory.Limit == 0 {
 			return fmt.Errorf("cannot remove memory limit from quota group")
@@ -135,6 +152,37 @@ func (qr *Resources) ValidateChange(newLimits Resources) error {
 		}
 	}
 
+	// Check that the cpu limit is not being removed, we do not support setting these
+	// two settings individually. Count/Percentage must be updated in unison.
+	if newLimits.CPU != nil && qr.CPU != nil {
+		if newLimits.CPU.Count == 0 && qr.CPU.Count != 0 {
+			return fmt.Errorf("cannot remove cpu limit from quota group")
+		}
+		if newLimits.CPU.Percentage == 0 && qr.CPU.Percentage != 0 {
+			return fmt.Errorf("cannot remove cpu limit from quota group")
+		}
+	}
+
+	// Check that we are not removing the entire cpu set
+	if newLimits.CPUSet != nil && qr.CPUSet != nil {
+		if len(newLimits.CPUSet.CPUs) == 0 {
+			return fmt.Errorf("cannot remove all allowed cpus from quota group")
+		}
+	}
+
+	// Check that the thread limit is not being decreased
+	if newLimits.Threads != nil {
+		if newLimits.Threads.Limit == 0 {
+			return fmt.Errorf("cannot remove thread limit from quota group")
+		}
+
+		// we disallow decreasing the thread limit initially until we understand
+		// the full consequences of doing so.
+		if qr.Threads != nil && newLimits.Threads.Limit < qr.Threads.Limit {
+			return fmt.Errorf("cannot decrease thread limit, remove and re-create it to decrease the limit")
+		}
+	}
+
 	return nil
 }
 
@@ -146,27 +194,27 @@ func (qr *Resources) Change(newLimits Resources) error {
 		return err
 	}
 
+	// perform the changes initially on a dry-run so we can validate
+	// the resulting quotas combined.
+	resultingLimits := *qr
 	if newLimits.Memory != nil {
-		qr.Memory = newLimits.Memory
+		resultingLimits.Memory = newLimits.Memory
 	}
 	if newLimits.CPU != nil {
-		if qr.CPU == nil {
-			qr.CPU = newLimits.CPU
-		} else {
-			// update count/percentage as one unit
-			if newLimits.CPU.Count != 0 || newLimits.CPU.Percentage != 0 {
-				qr.CPU.Count = newLimits.CPU.Count
-				qr.CPU.Percentage = newLimits.CPU.Percentage
-			}
-
-			// update allowed cpus as one unit
-			if len(newLimits.CPU.AllowedCPUs) != 0 {
-				qr.CPU.AllowedCPUs = newLimits.CPU.AllowedCPUs
-			}
-		}
+		resultingLimits.CPU = newLimits.CPU
+	}
+	if newLimits.CPUSet != nil {
+		resultingLimits.CPUSet = newLimits.CPUSet
 	}
 	if newLimits.Threads != nil {
-		qr.Threads = newLimits.Threads
+		resultingLimits.Threads = newLimits.Threads
 	}
+
+	// now perform validation on the dry run
+	if err := resultingLimits.Validate(); err != nil {
+		return err
+	}
+
+	*qr = resultingLimits
 	return nil
 }

--- a/snap/quota/resources_builder.go
+++ b/snap/quota/resources_builder.go
@@ -77,11 +77,15 @@ func (rb *ResourcesBuilder) Build() Resources {
 			Limit: rb.MemoryLimit,
 		}
 	}
-	if rb.CPUCountSet || rb.CPUPercentageSet || rb.AllowedCPUsSet {
+	if rb.CPUCountSet || rb.CPUPercentageSet {
 		quotaResources.CPU = &ResourceCPU{
-			Count:       rb.CPUCount,
-			Percentage:  rb.CPUPercentage,
-			AllowedCPUs: rb.AllowedCPUs,
+			Count:      rb.CPUCount,
+			Percentage: rb.CPUPercentage,
+		}
+	}
+	if rb.AllowedCPUsSet {
+		quotaResources.CPUSet = &ResourceCPUSet{
+			CPUs: rb.AllowedCPUs,
 		}
 	}
 	if rb.ThreadLimitSet {

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -284,7 +284,7 @@ TasksAccounting=true
 TasksMax=%[5]d
 `
 
-	allowedCpusValue := strutil.IntsToCommaSeparated(resourceLimits.CPU.AllowedCPUs)
+	allowedCpusValue := strutil.IntsToCommaSeparated(resourceLimits.CPUSet.CPUs)
 	sliceContent := fmt.Sprintf(sliceTempl, grp.Name,
 		resourceLimits.CPU.Count*resourceLimits.CPU.Percentage,
 		allowedCpusValue,
@@ -860,7 +860,7 @@ MemoryLimit=%[3]d
 TasksAccounting=true
 `
 
-	allowedCpusValue := strutil.IntsToCommaSeparated(resourceLimits.CPU.AllowedCPUs)
+	allowedCpusValue := strutil.IntsToCommaSeparated(resourceLimits.CPUSet.CPUs)
 	c.Assert(sliceFile, testutil.FileEquals, fmt.Sprintf(templ, "foogroup", allowedCpusValue, resourceLimits.Memory.Limit))
 	c.Assert(subSliceFile, testutil.FileEquals, fmt.Sprintf(templ, "subgroup", allowedCpusValue, resourceLimits.Memory.Limit))
 }


### PR DESCRIPTION
This is a followup PR from https://github.com/snapcore/snapd/pull/11410, to address some issues/incompleteness Ian found during his review of resources{_test}.go.

This adds missing validation of the new CPU/Thread quotas, and the resulting quota.Resources was not being validated properly.

This also performs few renames of AllowedCPUs => CPUSet, I will create a seperate PR that renames the rest.