### PR TITLE
tests: move lxd-postrm-purge to manual until remove snapd works again

### DIFF
--- a/tests/main/lxd-postrm-purge/task.yaml
+++ b/tests/main/lxd-postrm-purge/task.yaml
@@ -6,13 +6,13 @@ summary: Check that package remove and purge works inside LXD containers
 # ubuntu-18.04-32: i386 is not supported by lxd
 systems: [ubuntu-18.04-64, ubuntu-20.04-*]
 
+manual: true
+
 # start early
 priority: 1000
 
 # lxd downloads can be quite slow
 kill-timeout: 25m
-
-manual: true
 
 prepare: |
     # using apt here is ok because this test only runs on ubuntu

--- a/tests/main/lxd-postrm-purge/task.yaml
+++ b/tests/main/lxd-postrm-purge/task.yaml
@@ -12,6 +12,8 @@ priority: 1000
 # lxd downloads can be quite slow
 kill-timeout: 25m
 
+manual: true
+
 prepare: |
     # using apt here is ok because this test only runs on ubuntu
     echo "Remove any installed debs (some images carry them) to ensure we test the snap"


### PR DESCRIPTION
This test is failing to remove snapd from the lxd container

These are the errors in the log:

apt autoremove --purge -y snapd ubuntu-core-launcher

rm: cannot remove '/var/snap/lxd/common/var/lib/lxcfs/proc/cpuinfo':
Function not implemented

rm: cannot remove
'/var/snap/lxd/common/var/lib/lxcfs/sys/devices/system/cpu/cpu0':
Operation not permitted

New PR to revert is change is created as well
