### PR TITLE
snap/quota: fix bug in quota group tree validation code

### DIFF
--- a/snap/quota/export_test.go
+++ b/snap/quota/export_test.go
@@ -27,6 +27,6 @@ func (grp *Group) SetInternalSubGroups(grps []*Group) {
 
 func (grp *Group) InspectInternalQuotaAllocations() map[string]*GroupQuotaAllocations {
 	allQuotas := make(map[string]*GroupQuotaAllocations)
-	grp.getQuotaAllocations(allQuotas, nil)
+	grp.getQuotaAllocations(allQuotas)
 	return allQuotas
 }


### PR DESCRIPTION
This is another followup PR from https://github.com/snapcore/snapd/pull/11410 that handles additional cases in the quota tree validation code. There was unfortunately a bug in how groups were validated if we were changing parent quotas when sub-quotas were in effect.