### PR TITLE
o/snapshotstate: refactor snapshot read/write logic

### DIFF
--- a/overlord/snapshotstate/backend/backend.go
+++ b/overlord/snapshotstate/backend/backend.go
@@ -456,10 +456,10 @@ func addToZip(ctx context.Context, snapshot *client.Snapshot, w *zip.Writer, use
 		tarArgs = append(tarArgs, fmt.Sprintf("--exclude=%s", path))
 	}
 
-	// use --directory so that the file is added without its parent dirs
+	// use --directory so that the directory is added without its parent dirs
 	for _, path := range paths {
-		parent, file := filepath.Split(path)
-		tarArgs = append(tarArgs, "--directory", parent, file)
+		parent, dir := filepath.Split(path)
+		tarArgs = append(tarArgs, "--directory", parent, dir)
 	}
 
 	var sz osutil.Sizer

--- a/overlord/snapshotstate/backend/backend.go
+++ b/overlord/snapshotstate/backend/backend.go
@@ -336,8 +336,8 @@ func Save(ctx context.Context, id uint64, si *snap.Info, cfg map[string]interfac
 	w := zip.NewWriter(aw)
 	defer w.Close() // note this does not close the file descriptor (that's done by hand on the atomic writer, above)
 	savingUserData := false
-	baseDir := snap.BaseDataDir(si.InstanceName())
-	if err := addSnapDirToZip(ctx, snapshot, w, "root", archiveName, baseDir, savingUserData, snapshotOptions.ExcludePaths); err != nil {
+	baseDataDir := snap.BaseDataDir(si.InstanceName())
+	if err := addSnapDirToZip(ctx, snapshot, w, "root", archiveName, baseDataDir, savingUserData, snapshotOptions.ExcludePaths); err != nil {
 		return nil, err
 	}
 

--- a/overlord/snapshotstate/backend/backend.go
+++ b/overlord/snapshotstate/backend/backend.go
@@ -336,7 +336,8 @@ func Save(ctx context.Context, id uint64, si *snap.Info, cfg map[string]interfac
 	w := zip.NewWriter(aw)
 	defer w.Close() // note this does not close the file descriptor (that's done by hand on the atomic writer, above)
 	savingUserData := false
-	if err := addSnapDirToZip(ctx, snapshot, w, "root", archiveName, si.DataDir(), savingUserData, snapshotOptions.ExcludePaths); err != nil {
+	baseDataDir := snap.BaseDataDir(si.InstanceName())
+	if err := addSnapDirToZip(ctx, snapshot, w, "root", archiveName, baseDataDir, savingUserData, snapshotOptions.ExcludePaths); err != nil {
 		return nil, err
 	}
 

--- a/overlord/snapshotstate/backend/backend.go
+++ b/overlord/snapshotstate/backend/backend.go
@@ -336,8 +336,7 @@ func Save(ctx context.Context, id uint64, si *snap.Info, cfg map[string]interfac
 	w := zip.NewWriter(aw)
 	defer w.Close() // note this does not close the file descriptor (that's done by hand on the atomic writer, above)
 	savingUserData := false
-	baseDataDir := snap.BaseDataDir(si.InstanceName())
-	if err := addSnapDirToZip(ctx, snapshot, w, "root", archiveName, baseDataDir, savingUserData, snapshotOptions.ExcludePaths); err != nil {
+	if err := addSnapDirToZip(ctx, snapshot, w, "root", archiveName, si.DataDir(), savingUserData, snapshotOptions.ExcludePaths); err != nil {
 		return nil, err
 	}
 

--- a/overlord/snapshotstate/backend/backend.go
+++ b/overlord/snapshotstate/backend/backend.go
@@ -336,7 +336,8 @@ func Save(ctx context.Context, id uint64, si *snap.Info, cfg map[string]interfac
 	w := zip.NewWriter(aw)
 	defer w.Close() // note this does not close the file descriptor (that's done by hand on the atomic writer, above)
 	savingUserData := false
-	if err := addDirToZip(ctx, snapshot, w, "root", archiveName, si.DataDir(), savingUserData, snapshotOptions.ExcludePaths); err != nil {
+	baseDir := snap.BaseDataDir(si.InstanceName())
+	if err := addSnapDirToZip(ctx, snapshot, w, "root", archiveName, baseDir, savingUserData, snapshotOptions.ExcludePaths); err != nil {
 		return nil, err
 	}
 
@@ -347,7 +348,8 @@ func Save(ctx context.Context, id uint64, si *snap.Info, cfg map[string]interfac
 
 	savingUserData = true
 	for _, usr := range users {
-		if err := addDirToZip(ctx, snapshot, w, usr.Username, userArchiveName(usr), si.UserDataDir(usr.HomeDir, opts), savingUserData, snapshotOptions.ExcludePaths); err != nil {
+		snapDataDir := filepath.Dir(si.UserDataDir(usr.HomeDir, opts))
+		if err := addSnapDirToZip(ctx, snapshot, w, usr.Username, userArchiveName(usr), snapDataDir, savingUserData, snapshotOptions.ExcludePaths); err != nil {
 			return nil, err
 		}
 	}
@@ -385,27 +387,17 @@ func Save(ctx context.Context, id uint64, si *snap.Info, cfg map[string]interfac
 
 var isTesting = snapdenv.Testing()
 
-func addDirToZip(ctx context.Context, snapshot *client.Snapshot, w *zip.Writer, username string, entry, dir string, savingUserData bool, excludePaths []string) error {
-	parent, revdir := filepath.Split(dir)
-	exists, isDir, err := osutil.DirExists(parent)
+// addSnapDirToZip adds the 'common' and the 'rev' revisioned dir under 'snapDir'
+// to the snapshot. If one doesn't exist, it's ignored. If none exists, the
+// operation is skipped.
+func addSnapDirToZip(ctx context.Context, snapshot *client.Snapshot, w *zip.Writer, username, entry, snapDir string, savingUserData bool, excludePaths []string) error {
+	paths, err := pathsForSnapshot(snapDir, snapshot)
 	if err != nil {
 		return err
 	}
-	if exists && !isDir {
-		logger.Noticef("Not saving directories under %q in snapshot #%d of %q as it is not a directory.", parent, snapshot.SetID, snapshot.Snap)
+
+	if len(paths) == 0 {
 		return nil
-	}
-	if !exists {
-		logger.Debugf("Not saving directories under %q in snapshot #%d of %q as it is does not exist.", parent, snapshot.SetID, snapshot.Snap)
-		return nil
-	}
-	tarArgs := []string{
-		"--create",
-		"--sparse", "--gzip",
-		"--format", "gnu",
-		"--directory", parent,
-		"--anchored",
-		"--no-wildcards-match-slash",
 	}
 
 	expandSnapDataDirs := func(varName string) string {
@@ -420,7 +412,7 @@ func addDirToZip(ctx context.Context, snapshot *client.Snapshot, w *zip.Writer, 
 		case varName == "SNAP_DATA" && !savingUserData:
 			fallthrough
 		case varName == "SNAP_USER_DATA" && savingUserData:
-			return revdir
+			return snapshot.Revision.String()
 		}
 		// The variable specified does not match the current operating mode
 		// (for example, the variable is SNAP_COMMON but we are saving user
@@ -429,6 +421,8 @@ func addDirToZip(ctx context.Context, snapshot *client.Snapshot, w *zip.Writer, 
 		// order to do this, we return a "-" as a sentinel.
 		return "-"
 	}
+
+	var expExcludePaths []string
 	for _, excludePath := range excludePaths {
 		expandedPath := os.Expand(excludePath, expandSnapDataDirs)
 		// "-" is the sentinel returned by expandSnapDataDirs() if the
@@ -436,47 +430,36 @@ func addDirToZip(ctx context.Context, snapshot *client.Snapshot, w *zip.Writer, 
 		if expandedPath[0] == '-' {
 			continue
 		}
-		tarArgs = append(tarArgs, fmt.Sprintf("--exclude=%s", expandedPath))
+		expExcludePaths = append(expExcludePaths, expandedPath)
 	}
 
-	noRev, noCommon := true, true
+	return addToZip(ctx, snapshot, w, username, entry, paths, expExcludePaths)
+}
 
-	exists, isDir, err = osutil.DirExists(dir)
-	if err != nil {
-		return err
-	}
-	switch {
-	case exists && isDir:
-		tarArgs = append(tarArgs, revdir)
-		noRev = false
-	case exists && !isDir:
-		logger.Noticef("Not saving %q in snapshot #%d of %q as it is not a directory.", dir, snapshot.SetID, snapshot.Snap)
-	case !exists:
-		logger.Debugf("Not saving %q in snapshot #%d of %q as it is does not exist.", dir, snapshot.SetID, snapshot.Snap)
-	}
-
-	common := filepath.Join(parent, "common")
-	exists, isDir, err = osutil.DirExists(common)
-	if err != nil {
-		return err
-	}
-	switch {
-	case exists && isDir:
-		tarArgs = append(tarArgs, "common")
-		noCommon = false
-	case exists && !isDir:
-		logger.Noticef("Not saving %q in snapshot #%d of %q as it is not a directory.", common, snapshot.SetID, snapshot.Snap)
-	case !exists:
-		logger.Debugf("Not saving %q in snapshot #%d of %q as it is does not exist.", common, snapshot.SetID, snapshot.Snap)
-	}
-
-	if noCommon && noRev {
-		return nil
-	}
-
+// addToZip adds 'paths' to the snapshot. tar will change into the paths' parent
+// directory before creating the archive so that parent dirs are not added.
+func addToZip(ctx context.Context, snapshot *client.Snapshot, w *zip.Writer, username, entry string, paths []string, excludePaths []string) error {
 	archiveWriter, err := w.CreateHeader(&zip.FileHeader{Name: entry})
 	if err != nil {
 		return err
+	}
+
+	tarArgs := []string{
+		"--create",
+		"--sparse", "--gzip",
+		"--format", "gnu",
+		"--anchored",
+		"--no-wildcards-match-slash",
+	}
+
+	for _, path := range excludePaths {
+		tarArgs = append(tarArgs, fmt.Sprintf("--exclude=%s", path))
+	}
+
+	// use --directory so that the file is added without its parent dirs
+	for _, path := range paths {
+		parent, file := filepath.Split(path)
+		tarArgs = append(tarArgs, "--directory", parent, file)
 	}
 
 	var sz osutil.Sizer
@@ -484,18 +467,20 @@ func addDirToZip(ctx context.Context, snapshot *client.Snapshot, w *zip.Writer, 
 
 	cmd := tarAsUser(username, tarArgs...)
 	cmd.Stdout = io.MultiWriter(archiveWriter, hasher, &sz)
+
+	// keep (at most) the last 5 non-empty lines of what 'tar' writes to stderr
+	// (those are the most likely contain the reason for fatal errors)
 	matchCounter := &strutil.MatchCounter{
-		// keep at most 5 matches
-		N: 5,
-		// keep the last lines only, those likely contain the reason for
-		// fatal errors
+		N:     5,
 		LastN: true,
 	}
 	cmd.Stderr = matchCounter
+
 	if isTesting {
 		matchCounter.N = -1
 		cmd.Stderr = io.MultiWriter(os.Stderr, matchCounter)
 	}
+
 	if err := osutil.RunWithContext(ctx, cmd); err != nil {
 		matches, count := matchCounter.Matches()
 		if count > 0 {
@@ -514,6 +499,41 @@ func addDirToZip(ctx context.Context, snapshot *client.Snapshot, w *zip.Writer, 
 	snapshot.Size += sz.Size()
 
 	return nil
+}
+
+// pathsForSnapshot returns a list of absolute paths under 'snapDir' that should
+// be included in the snapshot (based on what directories exist).
+func pathsForSnapshot(snapDir string, snapshot *client.Snapshot) ([]string, error) {
+	dirExists := func(path string) (bool, error) {
+		exists, isDir, err := osutil.DirExists(path)
+		if err != nil {
+			return false, err
+		}
+
+		if exists && isDir {
+			return true, nil
+		}
+
+		if !exists {
+			logger.Debugf("Not saving %q in snapshot #%d of %q as it is does not exist.", path, snapshot.SetID, snapshot.Snap)
+		} else if !isDir {
+			logger.Noticef("Not saving %q in snapshot #%d of %q as it is not a directory.", path, snapshot.SetID, snapshot.Snap)
+		}
+
+		return false, nil
+	}
+
+	var snapshotPaths []string
+	for _, subDir := range []string{snapshot.Revision.String(), "common"} {
+		subPath := filepath.Join(snapDir, subDir)
+		if ok, err := dirExists(subPath); err != nil {
+			return nil, err
+		} else if ok {
+			snapshotPaths = append(snapshotPaths, subPath)
+		}
+	}
+
+	return snapshotPaths, nil
 }
 
 var ErrCannotCancel = errors.New("cannot cancel: import already finished")

--- a/overlord/snapshotstate/backend/export_test.go
+++ b/overlord/snapshotstate/backend/export_test.go
@@ -40,7 +40,7 @@ var (
 
 	NewMultiError = newMultiError
 
-	AddDirToZip = addDirToZip
+	AddSnapDirToZip = addSnapDirToZip
 )
 
 func MockIsTesting(newIsTesting bool) func() {

--- a/overlord/snapshotstate/backend/helpers.go
+++ b/overlord/snapshotstate/backend/helpers.go
@@ -36,6 +36,7 @@ import (
 	"github.com/snapcore/snapd/snap"
 )
 
+// zipMember returns an io.ReadCloser for the 'member' file in the 'f' zip file.
 func zipMember(f *os.File, member string) (r io.ReadCloser, sz int64, err error) {
 	// rewind the file
 	// (shouldn't be needed, but doesn't hurt too much)

--- a/snap/info.go
+++ b/snap/info.go
@@ -94,6 +94,9 @@ type PlaceInfo interface {
 	// XdgRuntimeDirs returns a glob that matches all XDG_RUNTIME_DIR
 	// directories for all users of the snap.
 	XdgRuntimeDirs() string
+
+	// UserExposedHomeDir returns the snap's new home directory under ~/Snap.
+	UserExposedHomeDir(home string) string
 }
 
 // MinimalPlaceInfo returns a PlaceInfo with just the location information for a


### PR DESCRIPTION
The addToZip function was highly coupled with the snap directory structure which
made it hard to add things to the snapshot. This refactor separates pre-condition
checks, logic coupled to the snap directory structure and the actual writing
logic. This should make it easier to add ~/Snap while also being simpler overall.
Also refactors the reading logic a bit.