### PR TITLE
tests: use lxd from edge to avoid issues not fixed on candidate yet

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -40,7 +40,7 @@ environment:
     SUDO_UID: ""
     TRUST_TEST_KEYS: '$(HOST: echo "${SPREAD_TRUST_TEST_KEYS:-true}")'
     # a global setting for LXD channel to use in the tests
-    LXD_SNAP_CHANNEL: "latest/candidate"
+    LXD_SNAP_CHANNEL: "latest/edge"
     UBUNTU_IMAGE_SNAP_CHANNEL: "latest/edge"
     CORE_CHANNEL: '$(HOST: echo "${SPREAD_CORE_CHANNEL:-edge}")'
     BASE_CHANNEL: '$(HOST: echo "${SPREAD_BASE_CHANNEL:-edge}")'


### PR DESCRIPTION
This also fixes the error in test lxd-postrm-purge
