### PR TITLE
tests/lib/nested.sh: rm core18 snap after download

### DIFF
--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -628,6 +628,7 @@ nested_create_core_vm() {
                         snap download --channel="$CORE_CHANNEL" --basename=core18 core18
                         repack_core_snap_with_tweaks "core18.snap" "new-core18.snap"
                         EXTRA_FUNDAMENTAL="$EXTRA_FUNDAMENTAL --snap $PWD/new-core18.snap"
+                        rm core18.snap
                     fi
 
                     if [ "$NESTED_SIGN_SNAPS_FAKESTORE" = "true" ]; then


### PR DESCRIPTION
This is to avoid issues like we see sometimes from google-nested:ubuntu-18.04-64:tests/nested/manual/devmode-snaps-can-run-other-snaps:

```
+ snapcraftctl pull
[Errno 13] Permission denied: '/root/project/tests/nested/core/hotplug/core18.snap'
Traceback (most recent call last):
  File "/snap/snapcraft/6512/lib/python3.6/site-packages/snapcraft/file_utils.py", line 105, in link_or_copy
    link(source, destination, follow_symlinks=follow_symlinks)
  File "/snap/snapcraft/6512/lib/python3.6/site-packages/snapcraft/file_utils.py", line 139, in link
    os.link(source_path, destination, follow_symlinks=False)
OSError: [Errno 18] Invalid cross-device link: '/root/project/tests/nested/core/hotplug/core18.snap' -> '/root/parts/snapd-deb/src/tests/nested/core/hotplug/core18.snap'
```