### PR TITLE
tests/mounts-persist-refresh-content-snap: regression test for firefox crash

### DIFF
--- a/tests/main/mounts-persist-refresh-content-snap/task.yaml
+++ b/tests/main/mounts-persist-refresh-content-snap/task.yaml
@@ -9,6 +9,8 @@ details: |
   the firefox snap). See launchpad bug https://bugs.launchpad.net/snapd/+bug/1945697 for
   full details.
 
+kill-timeout: 10m
+
 systems:
   - -ubuntu-14.04-* # no support for tests.session
   - -ubuntu-core-* # can't modify rootfs to add a fonts dir
@@ -32,26 +34,14 @@ prepare: |
   tests.session -u test prepare
   tests.cleanup defer tests.session -u test restore
 
-restore: |
-  # kill all the processes
-  if [ -f children.txt ]; then
-    children.txt | while IFS= read -r childpid; do
-      kill -9 "$childpid" || true
-    done
-  fi
-
 execute: |
+  touch /run/keep-running
   # read a file continuously in the background until it fails - note that the
   # while loop here has to be inside the snap run shell, since the process must
   # persist during the refresh, if it is on the outside the mount namespace will
   # be rebuilt and the crash will not be reproduced
-  tests.session -u test exec snap run --shell test-snapd-desktop-layout-with-content.cmd -c 'while test -d /usr/share/fonts/foo-font; do true; done' &
+  tests.session -u test exec snap run --shell test-snapd-desktop-layout-with-content.cmd -c 'while test -f /run/keep-running && test -d /usr/share/fonts/foo-font; do true; done' &
   pid=$!
-
-  # get the child process of the tests.session, since tests.session does some 
-  # tricky detachment stuff such that killing it is insufficient to exit
-  ps -o pid= --ppid "$pid" > children.txt
-  echo "$pid" >> children.txt
 
   # refresh the content slot snap
   # TODO: when refresh app awareness is enabled, this will need to ignore running processes to
@@ -63,3 +53,8 @@ execute: |
     echo "process died, test failed"
     exit 1
   fi
+
+  # signal to kill the loop
+  rm /run/keep-running
+
+  kill -9 "$pid" || true

--- a/tests/main/mounts-persist-refresh-content-snap/task.yaml
+++ b/tests/main/mounts-persist-refresh-content-snap/task.yaml
@@ -11,6 +11,7 @@ details: |
 
 systems:
   - -ubuntu-14.04-* # no support for tests.session
+  - -ubuntu-core-* # can't modify rootfs to add a fonts dir
 
 prepare: |
   # make a font directory and restart snapd so it will see it when it goes to

--- a/tests/main/mounts-persist-refresh-content-snap/task.yaml
+++ b/tests/main/mounts-persist-refresh-content-snap/task.yaml
@@ -1,0 +1,64 @@
+summary: Ensure that mounts persist during a refresh of a content snap
+
+details: |
+  A bug in snap-update-ns due to the experimental robust-mount-namespaces option
+  being enabled resulted in all files being shared by content interfaces disappearing
+  during a refresh, either of snapd or of the snap sharing files via a content. The
+  most visible example of this was the firefox snap, which would crash when the files
+  disappeared like this (other snaps would misbehave but would not crash as fatally as
+  the firefox snap). See launchpad bug https://bugs.launchpad.net/snapd/+bug/1945697 for
+  full details.
+
+systems:
+  - -ubuntu-14.04-* # no support for tests.session
+
+prepare: |
+  # make a font directory and restart snapd so it will see it when it goes to
+  # connect the desktop interface for the snap
+  mkdir /usr/share/fonts/foo-font
+  systemctl restart snapd
+
+  # install a snap which exposes some files via a content slot
+  "$TESTSTOOLS"/snaps-state install-local test-snapd-content-slot
+
+  # install a snap which consumes said files via content plug
+  "$TESTSTOOLS"/snaps-state install-local test-snapd-desktop-layout-with-content
+
+  # connect
+  snap connect test-snapd-desktop-layout-with-content:shared-content-plug test-snapd-content-slot:shared-content-slot
+
+  # prepare a user session
+  tests.session -u test prepare
+  tests.cleanup defer tests.session -u test restore
+
+restore: |
+  # kill all the processes
+  if [ -f children.txt ]; then
+    children.txt | while IFS= read -r childpid; do
+      kill -9 "$childpid" || true
+    done
+  fi
+
+execute: |
+  # read a file continuously in the background until it fails - note that the
+  # while loop here has to be inside the snap run shell, since the process must
+  # persist during the refresh, if it is on the outside the mount namespace will
+  # be rebuilt and the crash will not be reproduced
+  tests.session -u test exec snap run --shell test-snapd-desktop-layout-with-content.cmd -c 'while test -d /usr/share/fonts/foo-font; do true; done' &
+  pid=$!
+
+  # get the child process of the tests.session, since tests.session does some 
+  # tricky detachment stuff such that killing it is insufficient to exit
+  ps -o pid= --ppid "$pid" > children.txt
+  echo "$pid" >> children.txt
+
+  # refresh the content slot snap
+  # TODO: when refresh app awareness is enabled, this will need to ignore running processes to
+  # check the behavior
+  "$TESTSTOOLS"/snaps-state install-local test-snapd-content-slot
+
+  # ensure the process is still running
+  if not ps "$pid"; then
+    echo "process died, test failed"
+    exit 1
+  fi

--- a/tests/main/mounts-persist-refresh-content-snap/test-snapd-desktop-layout-with-content/bin.sh
+++ b/tests/main/mounts-persist-refresh-content-snap/test-snapd-desktop-layout-with-content/bin.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+/bin/bash "$@"

--- a/tests/main/mounts-persist-refresh-content-snap/test-snapd-desktop-layout-with-content/meta/snap.yaml
+++ b/tests/main/mounts-persist-refresh-content-snap/test-snapd-desktop-layout-with-content/meta/snap.yaml
@@ -1,0 +1,23 @@
+name: test-snapd-desktop-layout-with-content
+version: 0.1
+
+apps:
+  cmd:
+    cmd: bin.sh
+
+plugs:
+  desktop:
+    mount-host-font-cache: false
+  shared-content-plug:
+    interface: content
+    target: $SNAP/gnome-platform
+    content: mylib
+    default-provider: test-snapd-content-slot
+
+layout:
+  /usr/share/libdrm:
+    bind: $SNAP/gnome-platform/usr/share/libdrm
+  /usr/lib/x86_64-linux-gnu/webkit2gtk-4.0:
+    bind: $SNAP/gnome-platform/usr/lib/x86_64-linux-gnu/webkit2gtk-4.0
+  /usr/share/xml/iso-codes:
+    bind: $SNAP/gnome-platform/usr/share/xml/iso-codes


### PR DESCRIPTION
This ensures that files which are shared via mounts in the MountConnectedPlug
method in an interface like the desktop interface remain shared in the per-user
mount namespace when the content snap is refreshed (not the main snap itself
even). We don't expect this situation to happen much when refresh app awareness
is fully enabled by default, but it is still important to test that the
snap-update-ns isn't horribly breaking apps when refreshes happen to take place
when apps are still running (this could be the case for desktop systems which
have a running app for more than 14 days for example).

This is just to demonstrate that the same test fails on master but passes in https://github.com/snapcore/snapd/pull/10676. The failure mode is slightly odd though, it seems to just hang somewhere rather than failing in the `if` I expect it to, but meh failure is failure.