### PR TITLE
i/b/kubernetes_support: add access to Java certificates

### DIFF
--- a/interfaces/builtin/kubernetes_support.go
+++ b/interfaces/builtin/kubernetes_support.go
@@ -68,6 +68,11 @@ capability dac_override,
 # https://github.com/projectcalico/cni-plugin/blob/master/pkg/types/types.go
 /{,var/}run/calico/ipam.lock rwk,
 
+# manually add java certs here
+# see also https://bugs.launchpad.net/apparmor/+bug/1816372
+/etc/ssl/certs/java/{,*} r,
+#include <abstractions/ssl_certs>
+
 /{,usr/}bin/systemd-run Cxr -> systemd_run,
 /run/systemd/private r,
 profile systemd_run (attach_disconnected,mediate_deleted) {


### PR DESCRIPTION
These are the same rules found in the greengrass-support interface.
