### PR TITLE
cmd/snap: make 1.18 vet happy

### DIFF
--- a/cmd/snap/cmd_find_test.go
+++ b/cmd/snap/cmd_find_test.go
@@ -130,7 +130,7 @@ func (s *SnapSuite) TestFindSnapName(c *check.C) {
 				c.Check(ok, check.Equals, true)
 				c.Check(v, check.DeepEquals, []string{""})
 			}
-			fmt.Fprintln(w, findJSON)
+			fmt.Fprint(w, findJSON)
 		default:
 			c.Fatalf("expected to get 2 requests, now on %d", n+1)
 		}
@@ -223,7 +223,7 @@ func (s *SnapSuite) TestFindHello(c *check.C) {
 			c.Check(q, check.HasLen, 2)
 			c.Check(q.Get("q"), check.Equals, "hello")
 			c.Check(q.Get("scope"), check.Equals, "wide")
-			fmt.Fprintln(w, findHelloJSON)
+			fmt.Fprint(w, findHelloJSON)
 		default:
 			c.Fatalf("expected to get 1 requests, now on %d", n+1)
 		}
@@ -250,7 +250,7 @@ func (s *SnapSuite) TestFindHelloNarrow(c *check.C) {
 			q := r.URL.Query()
 			c.Check(q, check.HasLen, 1)
 			c.Check(q.Get("q"), check.Equals, "hello")
-			fmt.Fprintln(w, findHelloJSON)
+			fmt.Fprint(w, findHelloJSON)
 		default:
 			c.Fatalf("expected to get 1 requests, now on %d", n+1)
 		}
@@ -313,7 +313,7 @@ func (s *SnapSuite) TestFindPriced(c *check.C) {
 		case 0:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/find")
-			fmt.Fprintln(w, findPricedJSON)
+			fmt.Fprint(w, findPricedJSON)
 		default:
 			c.Fatalf("expected to get 1 requests, now on %d", n+1)
 		}
@@ -374,7 +374,7 @@ func (s *SnapSuite) TestFindPricedAndBought(c *check.C) {
 		case 0:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/find")
-			fmt.Fprintln(w, findPricedAndBoughtJSON)
+			fmt.Fprint(w, findPricedAndBoughtJSON)
 		default:
 			c.Fatalf("expected to get 1 requests, now on %d", n+1)
 		}
@@ -398,7 +398,7 @@ func (s *SnapSuite) TestFindNothingMeansFeaturedSection(c *check.C) {
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/find")
 			c.Check(r.URL.Query().Get("section"), check.Equals, "featured")
-			fmt.Fprintln(w, findJSON)
+			fmt.Fprint(w, findJSON)
 		default:
 			c.Fatalf("expected to get 1 request, now on %d", n+1)
 		}
@@ -447,7 +447,8 @@ const findNetworkTimeoutErrorJSON = `
     "kind": "network-timeout"
   },
   "status-code": 400
-}`
+}
+`
 
 func (s *SnapSuite) TestFindNetworkTimeoutError(c *check.C) {
 	n := 0
@@ -456,7 +457,7 @@ func (s *SnapSuite) TestFindNetworkTimeoutError(c *check.C) {
 		case 0:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/find")
-			fmt.Fprintln(w, findNetworkTimeoutErrorJSON)
+			fmt.Fprint(w, findNetworkTimeoutErrorJSON)
 		default:
 			c.Fatalf("expected to get 1 requests, now on %d", n+1)
 		}

--- a/cmd/snap/cmd_info_test.go
+++ b/cmd/snap/cmd_info_test.go
@@ -418,7 +418,7 @@ func (s *infoSuite) TestInfoPricedNarrowTerminal(c *check.C) {
 		case 0:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/find")
-			fmt.Fprintln(w, findPricedJSON)
+			fmt.Fprint(w, findPricedJSON)
 		case 1:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/snaps/hello")
@@ -455,7 +455,7 @@ func (s *infoSuite) TestInfoPriced(c *check.C) {
 		case 0:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/find")
-			fmt.Fprintln(w, findPricedJSON)
+			fmt.Fprint(w, findPricedJSON)
 		case 1:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/snaps/hello")
@@ -577,11 +577,11 @@ func (s *infoSuite) TestInfoUnquoted(c *check.C) {
 		case 0:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/find")
-			fmt.Fprintln(w, mockInfoJSON)
+			fmt.Fprint(w, mockInfoJSON)
 		case 1:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/snaps/hello")
-			fmt.Fprintln(w, "{}")
+			fmt.Fprint(w, "{}")
 		default:
 			c.Fatalf("expected to get 2 requests, now on %d (%v)", n+1, r)
 		}
@@ -677,11 +677,11 @@ func (s *infoSuite) TestInfoWithLocalDifferentLicense(c *check.C) {
 		case 0:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/find")
-			fmt.Fprintln(w, mockInfoJSON)
+			fmt.Fprint(w, mockInfoJSON)
 		case 1:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/snaps/hello")
-			fmt.Fprintln(w, mockInfoJSONOtherLicense)
+			fmt.Fprint(w, mockInfoJSONOtherLicense)
 		default:
 			c.Fatalf("expected to get 2 requests, now on %d (%v)", n+1, r)
 		}
@@ -741,11 +741,11 @@ func (s *infoSuite) TestInfoWithLocalNoLicense(c *check.C) {
 		case 0:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/find")
-			fmt.Fprintln(w, mockInfoJSON)
+			fmt.Fprint(w, mockInfoJSON)
 		case 1:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/snaps/hello")
-			fmt.Fprintln(w, mockInfoJSONNoLicense)
+			fmt.Fprint(w, mockInfoJSONNoLicense)
 		default:
 			c.Fatalf("expected to get 2 requests, now on %d (%v)", n+1, r)
 		}
@@ -777,11 +777,11 @@ func (s *infoSuite) TestInfoWithChannelsAndLocal(c *check.C) {
 		case 0, 2, 4:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/find")
-			fmt.Fprintln(w, mockInfoJSONWithChannels)
+			fmt.Fprint(w, mockInfoJSONWithChannels)
 		case 1, 3, 5:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/snaps/hello")
-			fmt.Fprintln(w, mockInfoJSONNoLicense)
+			fmt.Fprint(w, mockInfoJSONNoLicense)
 		default:
 			c.Fatalf("expected to get 6 requests, now on %d (%v)", n+1, r)
 		}
@@ -881,7 +881,7 @@ func (s *infoSuite) TestInfoHumanTimes(c *check.C) {
 		case 1:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/snaps/hello")
-			fmt.Fprintln(w, mockInfoJSONNoLicense)
+			fmt.Fprint(w, mockInfoJSONNoLicense)
 		default:
 			c.Fatalf("expected to get 2 requests, now on %d (%v)", n+1, r)
 		}
@@ -1114,11 +1114,11 @@ func (s *infoSuite) TestInfoParllelInstance(c *check.C) {
 			q := r.URL.Query()
 			// asks for the instance snap
 			c.Check(q.Get("name"), check.Equals, "hello")
-			fmt.Fprintln(w, mockInfoJSONWithChannels)
+			fmt.Fprint(w, mockInfoJSONWithChannels)
 		case 1:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/snaps/hello_foo")
-			fmt.Fprintln(w, mockInfoJSONParallelInstance)
+			fmt.Fprint(w, mockInfoJSONParallelInstance)
 		default:
 			c.Fatalf("expected to get 2 requests, now on %d (%v)", n+1, r)
 		}
@@ -1194,11 +1194,11 @@ func (s *infoSuite) TestInfoStoreURL(c *check.C) {
 			q := r.URL.Query()
 			// asks for the instance snap
 			c.Check(q.Get("name"), check.Equals, "hello")
-			fmt.Fprintln(w, mockInfoJSONWithChannels)
+			fmt.Fprint(w, mockInfoJSONWithChannels)
 		case 1:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/snaps/hello")
-			fmt.Fprintln(w, mockInfoJSONWithStoreURL)
+			fmt.Fprint(w, mockInfoJSONWithStoreURL)
 		default:
 			c.Fatalf("expected to get 2 requests, now on %d (%v)", n+1, r)
 		}

--- a/cmd/snap/cmd_known_test.go
+++ b/cmd/snap/cmd_known_test.go
@@ -63,7 +63,7 @@ func (s *SnapSuite) TestKnownViaSnapd(c *check.C) {
 			c.Check(r.URL.Path, check.Equals, "/v2/assertions/model")
 			c.Check(r.URL.Query(), check.DeepEquals, expectedQuery)
 			w.Header().Set("X-Ubuntu-Assertions-Count", "1")
-			fmt.Fprintln(w, mockModelAssertion)
+			fmt.Fprint(w, mockModelAssertion)
 		default:
 			c.Fatalf("expected to get 1 requests, now on %d", n+1)
 		}
@@ -103,7 +103,7 @@ func (s *SnapSuite) TestKnownRemoteViaSnapd(c *check.C) {
 				"remote":   []string{"true"},
 			})
 			w.Header().Set("X-Ubuntu-Assertions-Count", "1")
-			fmt.Fprintln(w, mockModelAssertion)
+			fmt.Fprint(w, mockModelAssertion)
 		default:
 			c.Fatalf("expected to get 1 requests, now on %d", n+1)
 		}
@@ -138,7 +138,7 @@ func (s *SnapSuite) TestKnownRemoteDirect(c *check.C) {
 		case 0:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/assertions/model/16/canonical/pi99")
-			fmt.Fprintln(w, mockModelAssertion)
+			fmt.Fprint(w, mockModelAssertion)
 		default:
 			c.Fatalf("expected to get 1 requests, now on %d", n+1)
 		}
@@ -185,7 +185,7 @@ func (s *SnapSuite) TestKnownRemoteAutoFallback(c *check.C) {
 		case 0:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/assertions/model/16/canonical/pi99")
-			fmt.Fprintln(w, mockModelAssertion)
+			fmt.Fprint(w, mockModelAssertion)
 		default:
 			c.Fatalf("expected to get 1 requests, now on %d", n+1)
 		}

--- a/cmd/snap/cmd_routine_portal_info_test.go
+++ b/cmd/snap/cmd_routine_portal_info_test.go
@@ -98,7 +98,7 @@ func (s *SnapSuite) TestPortalInfo(c *C) {
 		case 0:
 			c.Check(r.Method, Equals, "GET")
 			c.Check(r.URL.Path, Equals, "/v2/snaps/hello")
-			fmt.Fprintln(w, mockInfoJSONWithApps)
+			fmt.Fprint(w, mockInfoJSONWithApps)
 		case 1:
 			c.Check(r.Method, Equals, "GET")
 			c.Check(r.URL.Path, Equals, "/v2/connections")
@@ -158,7 +158,7 @@ func (s *SnapSuite) TestPortalInfoNoAppInfo(c *C) {
 		case 0:
 			c.Check(r.Method, Equals, "GET")
 			c.Check(r.URL.Path, Equals, "/v2/snaps/hello")
-			fmt.Fprintln(w, mockInfoJSONWithApps)
+			fmt.Fprint(w, mockInfoJSONWithApps)
 		case 1:
 			c.Check(r.Method, Equals, "GET")
 			c.Check(r.URL.Path, Equals, "/v2/connections")

--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -1752,7 +1752,7 @@ func (s *RunSuite) TestSnapRunHookKernelImplicitBase(c *check.C) {
 			case 0:
 				c.Check(r.Method, check.Equals, "GET")
 				c.Check(r.URL.RawQuery, check.Equals, "")
-				fmt.Fprintln(w, happyUC20ModelAssertionResponse)
+				fmt.Fprint(w, happyUC20ModelAssertionResponse)
 			default:
 				c.Fatalf("expected to get 1 request for /v2/model, now on %d", nModel+1)
 			}


### PR DESCRIPTION
Go vet in 1.18 is more picky about fmt.*rintln and additional newlines at the
end of output, thus producing errors like:

```
./cmd_info_test.go:1197:4: fmt.Fprintln arg list ends with redundant newline
./cmd_info_test.go:1201:4: fmt.Fprintln arg list ends with redundant newline
./cmd_routine_portal_info_test.go:101:4: fmt.Fprintln arg list ends with redundant newline
./cmd_routine_portal_info_test.go:161:4: fmt.Fprintln arg list ends with redundant newline
./cmd_run_test.go:1755:5: fmt.Fprintln arg list ends with redundant newline
```

See https://github.com/golang/go/issues/49350 and https://go.dev/doc/go1.18#vet
Although I believe we should not be hitting this case, still it does not make
sense to output so many newlines, so it's worth fixing.
