### PR TITLE
tests: switch to "test-snapd-swtpm"

### DIFF
--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -944,8 +944,8 @@ nested_force_stop_vm() {
 nested_force_start_vm() {
     # if the nested-vm is using a swtpm, we need to wait until the file exists
     # because the file disappears temporarily after qemu exits
-    if systemctl show nested-vm -p ExecStart | grep -q swtpm-mvo; then
-        retry -n 10 --wait 1 test -S /var/snap/swtpm-mvo/current/swtpm-sock
+    if systemctl show nested-vm -p ExecStart | grep -q test-snapd-swtpm; then
+        retry -n 10 --wait 1 test -S /var/snap/test-snapd-swtpm/current/swtpm-sock
     fi
     systemctl start nested-vm
 }
@@ -1063,16 +1063,16 @@ nested_start_core_vm_unit() {
         fi
 
         if nested_is_tpm_enabled; then
-            if snap list swtpm-mvo >/dev/null; then
+            if snap list test-snapd-swtpm >/dev/null; then
                 # reset the tpm state
-                rm /var/snap/swtpm-mvo/current/tpm2-00.permall
-                snap restart swtpm-mvo > /dev/null
+                rm /var/snap/test-snapd-swtpm/current/tpm2-00.permall
+                snap restart test-snapd-swtpm > /dev/null
             else
-                snap install swtpm-mvo --beta
+                snap install test-snapd-swtpm --beta
             fi
             # wait for the tpm sock file to exist
-            retry -n 10 --wait 1 test -S /var/snap/swtpm-mvo/current/swtpm-sock
-            PARAM_TPM="-chardev socket,id=chrtpm,path=/var/snap/swtpm-mvo/current/swtpm-sock -tpmdev emulator,id=tpm0,chardev=chrtpm -device tpm-tis,tpmdev=tpm0"
+            retry -n 10 --wait 1 test -S /var/snap/test-snapd-swtpm/current/swtpm-sock
+            PARAM_TPM="-chardev socket,id=chrtpm,path=/var/snap/test-snapd-swtpm/current/swtpm-sock -tpmdev emulator,id=tpm0,chardev=chrtpm -device tpm-tis,tpmdev=tpm0"
         fi
         PARAM_IMAGE="-drive file=$CURRENT_IMAGE,cache=none,format=raw,id=disk1,if=none -device virtio-blk-pci,drive=disk1,bootindex=1"
     else


### PR DESCRIPTION
We currently use `swtpm-mvo` for testing. However this snap is
owned by an individual (me) and it's not clear from the name
that the main purpose of the snap is to test snapd.

So this commit moves to the new `test-snapd-swtpm` snap that
is team maintained in `github.com/snapcore/test-snapd-swtpm`
and has a more suitable name.

Thanks to Ian for the rename of the snap and for modernizing it.
