### PR TITLE
cmd/snap,client: frontend for cpu/thread quotas 

### DIFF
--- a/client/quota.go
+++ b/client/quota.go
@@ -44,8 +44,16 @@ type QuotaGroupResult struct {
 	Current     *QuotaValues `json:"current,omitempty"`
 }
 
+type QuotaCPUValues struct {
+	Count       int   `json:"count,omitempty"`
+	Percentage  int   `json:"percentage,omitempty"`
+	AllowedCPUs []int `json:"allowed-cpus,omitempty"`
+}
+
 type QuotaValues struct {
-	Memory quantity.Size `json:"memory,omitempty"`
+	Memory  quantity.Size   `json:"memory,omitempty"`
+	CPU     *QuotaCPUValues `json:"cpu,omitempty"`
+	Threads int             `json:"threads,omitempty"`
 }
 
 // EnsureQuota creates a quota group or updates an existing group.

--- a/client/quota.go
+++ b/client/quota.go
@@ -45,15 +45,19 @@ type QuotaGroupResult struct {
 }
 
 type QuotaCPUValues struct {
-	Count       int   `json:"count,omitempty"`
-	Percentage  int   `json:"percentage,omitempty"`
-	AllowedCPUs []int `json:"allowed-cpus,omitempty"`
+	Count      int `json:"count,omitempty"`
+	Percentage int `json:"percentage,omitempty"`
+}
+
+type QuotaCPUSetValues struct {
+	CPUs []int `json:"cpus,omitempty"`
 }
 
 type QuotaValues struct {
-	Memory  quantity.Size   `json:"memory,omitempty"`
-	CPU     *QuotaCPUValues `json:"cpu,omitempty"`
-	Threads int             `json:"threads,omitempty"`
+	Memory  quantity.Size      `json:"memory,omitempty"`
+	CPU     *QuotaCPUValues    `json:"cpu,omitempty"`
+	CPUSet  *QuotaCPUSetValues `json:"cpu-set,omitempty"`
+	Threads int                `json:"threads,omitempty"`
 }
 
 // EnsureQuota creates a quota group or updates an existing group.

--- a/client/quota_test.go
+++ b/client/quota_test.go
@@ -44,7 +44,17 @@ func (cs *clientSuite) TestEnsureQuotaGroup(c *check.C) {
 		"change": "42"
 	}`
 
-	chgID, err := cs.cli.EnsureQuota("foo", "bar", []string{"snap-a", "snap-b"}, &client.QuotaValues{Memory: quantity.Size(1001)})
+	quotaValues := &client.QuotaValues{
+		Memory: quantity.Size(1001),
+		CPU: &client.QuotaCPUValues{
+			Count:       1,
+			Percentage:  50,
+			AllowedCPUs: []int{0},
+		},
+		Threads: 32,
+	}
+
+	chgID, err := cs.cli.EnsureQuota("foo", "bar", []string{"snap-a", "snap-b"}, quotaValues)
 	c.Assert(err, check.IsNil)
 	c.Assert(chgID, check.Equals, "42")
 	c.Check(cs.req.Method, check.Equals, "POST")
@@ -61,6 +71,12 @@ func (cs *clientSuite) TestEnsureQuotaGroup(c *check.C) {
 		"snaps":      []interface{}{"snap-a", "snap-b"},
 		"constraints": map[string]interface{}{
 			"memory": json.Number("1001"),
+			"cpu": map[string]interface{}{
+				"count":        json.Number("1"),
+				"percentage":   json.Number("50"),
+				"allowed-cpus": []interface{}{json.Number("0")},
+			},
+			"threads": json.Number("32"),
 		},
 	})
 }

--- a/client/quota_test.go
+++ b/client/quota_test.go
@@ -47,9 +47,11 @@ func (cs *clientSuite) TestEnsureQuotaGroup(c *check.C) {
 	quotaValues := &client.QuotaValues{
 		Memory: quantity.Size(1001),
 		CPU: &client.QuotaCPUValues{
-			Count:       1,
-			Percentage:  50,
-			AllowedCPUs: []int{0},
+			Count:      1,
+			Percentage: 50,
+		},
+		CPUSet: &client.QuotaCPUSetValues{
+			CPUs: []int{0},
 		},
 		Threads: 32,
 	}
@@ -72,9 +74,11 @@ func (cs *clientSuite) TestEnsureQuotaGroup(c *check.C) {
 		"constraints": map[string]interface{}{
 			"memory": json.Number("1001"),
 			"cpu": map[string]interface{}{
-				"count":        json.Number("1"),
-				"percentage":   json.Number("50"),
-				"allowed-cpus": []interface{}{json.Number("0")},
+				"count":      json.Number("1"),
+				"percentage": json.Number("50"),
+			},
+			"cpu-set": map[string]interface{}{
+				"cpus": []interface{}{json.Number("0")},
 			},
 			"threads": json.Number("32"),
 		},

--- a/cmd/snap/cmd_quota.go
+++ b/cmd/snap/cmd_quota.go
@@ -61,11 +61,10 @@ var longSetQuotaHelp = i18n.G(`
 The set-quota command updates or creates a quota group with the specified set of
 snaps.
 
-A quota group sets resource limits on the set of snaps it contains. Only maximum
-memory is currently supported. Snaps can be at most in one quota group but quota
-groups can be nested. Nested quota groups are subject to the restriction that 
-the total sum of maximum memory in sub-groups cannot exceed that of the parent
-group the nested groups are part of.
+A quota group sets resource limits on the set of snaps it contains. Snaps can 
+be at most in one quota group but quota groups can be nested. Nested quota 
+groups are subject to the restriction that the total sum of each existing quota
+in sub-groups cannot exceed that of the parent group the nested groups are part of.
 
 All provided snaps are appended to the group; to remove a snap from a
 quota group, the entire group must be removed with remove-quota and recreated 
@@ -77,6 +76,19 @@ decrease the memory limit for a quota group, the entire group must be removed
 with the remove-quota command and recreated with a lower limit. Increasing the
 memory limit for a quota group does not restart any services associated with 
 snaps in the quota group.
+
+The CPU limit for a quota group can be both increased and decreased after being
+set on a quota group.
+
+The CPU set limit for a quota group can be modified to include new cpus, or to remove
+existing cpus from the quota already set.
+
+The thread limit for a quota group can increased but not decreased. To
+decrease the thread limit for a quota group, the entire group must be removed
+with the remove-quota command and recreated with a lower limit.
+
+New quotas can be set on existing quota groups, but existing quotas cannot be removed
+from a quota group, without removing and recreating the entire group.
 
 Adding new snaps to a quota group will result in all non-disabled services in 
 that snap being restarted.

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -460,3 +460,11 @@ func MockAutostartSessionApps(f func(string) error) func() {
 		autostartSessionApps = old
 	}
 }
+
+func MockGetCGroupVersion(f func() (int, error)) (restore func()) {
+	old := getCGroupVersion
+	getCGroupVersion = f
+	return func() {
+		getCGroupVersion = old
+	}
+}

--- a/daemon/api_quotas.go
+++ b/daemon/api_quotas.go
@@ -91,9 +91,11 @@ func createQuotaValues(grp *quota.Group) *client.QuotaValues {
 
 	if grp.CPULimit != nil {
 		constraints.CPU = &client.QuotaCPUValues{
-			Count:       grp.CPULimit.Count,
-			Percentage:  grp.CPULimit.Percentage,
-			AllowedCPUs: grp.CPULimit.AllowedCPUs,
+			Count:      grp.CPULimit.Count,
+			Percentage: grp.CPULimit.Percentage,
+		}
+		constraints.CPUSet = &client.QuotaCPUSetValues{
+			CPUs: grp.CPULimit.AllowedCPUs,
 		}
 	}
 	return &constraints
@@ -187,9 +189,9 @@ func quotaValuesToResources(values client.QuotaValues) quota.Resources {
 		if values.CPU.Percentage != 0 {
 			resourcesBuilder.WithCPUPercentage(values.CPU.Percentage)
 		}
-		if len(values.CPU.AllowedCPUs) != 0 {
-			resourcesBuilder.WithAllowedCPUs(values.CPU.AllowedCPUs)
-		}
+	}
+	if values.CPUSet != nil && len(values.CPUSet.CPUs) != 0 {
+		resourcesBuilder.WithAllowedCPUs(values.CPUSet.CPUs)
 	}
 	if values.Threads != 0 {
 		resourcesBuilder.WithThreadLimit(values.Threads)

--- a/daemon/api_quotas.go
+++ b/daemon/api_quotas.go
@@ -65,11 +65,21 @@ var (
 var getQuotaUsage = func(grp *quota.Group) (*client.QuotaValues, error) {
 	var currentUsage client.QuotaValues
 
-	mem, err := grp.CurrentMemoryUsage()
-	if err != nil {
-		return nil, err
+	if grp.MemoryLimit != 0 {
+		mem, err := grp.CurrentMemoryUsage()
+		if err != nil {
+			return nil, err
+		}
+		currentUsage.Memory = mem
 	}
-	currentUsage.Memory = mem
+
+	if grp.TaskLimit != 0 {
+		threads, err := grp.CurrentTaskUsage()
+		if err != nil {
+			return nil, err
+		}
+		currentUsage.Threads = threads
+	}
 
 	return &currentUsage, nil
 }
@@ -77,6 +87,15 @@ var getQuotaUsage = func(grp *quota.Group) (*client.QuotaValues, error) {
 func createQuotaValues(grp *quota.Group) *client.QuotaValues {
 	var constraints client.QuotaValues
 	constraints.Memory = grp.MemoryLimit
+	constraints.Threads = grp.TaskLimit
+
+	if grp.CPULimit != nil {
+		constraints.CPU = &client.QuotaCPUValues{
+			Count:       grp.CPULimit.Count,
+			Percentage:  grp.CPULimit.Percentage,
+			AllowedCPUs: grp.CPULimit.AllowedCPUs,
+		}
+	}
 	return &constraints
 }
 
@@ -157,13 +176,25 @@ func getQuotaGroupInfo(c *Command, r *http.Request, _ *auth.UserState) Response 
 }
 
 func quotaValuesToResources(values client.QuotaValues) quota.Resources {
-	var quotaResources quota.Resources
+	resourcesBuilder := quota.NewResourcesBuilder()
 	if values.Memory != 0 {
-		quotaResources.Memory = &quota.ResourceMemory{
-			Limit: values.Memory,
+		resourcesBuilder.WithMemoryLimit(values.Memory)
+	}
+	if values.CPU != nil {
+		if values.CPU.Count != 0 {
+			resourcesBuilder.WithCPUCount(values.CPU.Count)
+		}
+		if values.CPU.Percentage != 0 {
+			resourcesBuilder.WithCPUPercentage(values.CPU.Percentage)
+		}
+		if len(values.CPU.AllowedCPUs) != 0 {
+			resourcesBuilder.WithAllowedCPUs(values.CPU.AllowedCPUs)
 		}
 	}
-	return quotaResources
+	if values.Threads != 0 {
+		resourcesBuilder.WithThreadLimit(values.Threads)
+	}
+	return resourcesBuilder.Build()
 }
 
 // postQuotaGroup creates quota resource group or updates an existing group.

--- a/daemon/api_quotas_test.go
+++ b/daemon/api_quotas_test.go
@@ -218,10 +218,16 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaCreateQuotaConflicts(c *check.C) {
 	c.Assert(createCalled, check.Equals, 2)
 }
 
-func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateHappy(c *check.C) {
+func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateCpuHappy(c *check.C) {
 	st := s.d.Overlord().State()
 	st.Lock()
-	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", nil, quota.NewResourcesBuilder().WithMemoryLimit(5000).Build())
+	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", nil,
+		quota.NewResourcesBuilder().
+			WithMemoryLimit(quantity.Size(5000)).
+			WithCPUCount(1).
+			WithCPUPercentage(100).
+			WithThreadLimit(256).
+			Build())
 	st.Unlock()
 	c.Assert(err, check.IsNil)
 
@@ -237,7 +243,7 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateHappy(c *check.C) {
 		c.Assert(name, check.Equals, "ginger-ale")
 		c.Assert(opts, check.DeepEquals, servicestate.QuotaGroupUpdate{
 			AddSnaps:          []string{"some-snap"},
-			NewResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.Size(9000)).Build(),
+			NewResourceLimits: quota.NewResourcesBuilder().WithCPUCount(2).WithCPUPercentage(100).WithThreadLimit(512).Build(),
 		})
 		ts := state.NewTaskSet(st.NewTask("foo-quota", "..."))
 		return ts, nil
@@ -245,10 +251,120 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateHappy(c *check.C) {
 	defer r()
 
 	data, err := json.Marshal(daemon.PostQuotaGroupData{
-		Action:      "ensure",
-		GroupName:   "ginger-ale",
-		Snaps:       []string{"some-snap"},
-		Constraints: client.QuotaValues{Memory: quantity.Size(9000)},
+		Action:    "ensure",
+		GroupName: "ginger-ale",
+		Snaps:     []string{"some-snap"},
+		Constraints: client.QuotaValues{
+			CPU: &client.QuotaCPUValues{
+				Count:      2,
+				Percentage: 100,
+			},
+			Threads: 512,
+		},
+	})
+	c.Assert(err, check.IsNil)
+
+	req, err := http.NewRequest("POST", "/v2/quotas", bytes.NewBuffer(data))
+	c.Assert(err, check.IsNil)
+	rsp := s.asyncReq(c, req, nil)
+	c.Assert(rsp.Status, check.Equals, 202)
+	c.Assert(updateCalled, check.Equals, 1)
+	c.Assert(s.ensureSoonCalled, check.Equals, 1)
+}
+
+func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateCpu2Happy(c *check.C) {
+	st := s.d.Overlord().State()
+	st.Lock()
+	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", nil,
+		quota.NewResourcesBuilder().
+			WithMemoryLimit(quantity.Size(5000)).
+			WithCPUCount(1).
+			WithCPUPercentage(100).
+			WithThreadLimit(256).
+			Build())
+	st.Unlock()
+	c.Assert(err, check.IsNil)
+
+	r := daemon.MockServicestateCreateQuota(func(st *state.State, name string, parentName string, snaps []string, resourceLimits quota.Resources) (*state.TaskSet, error) {
+		c.Errorf("should not have called create quota")
+		return nil, fmt.Errorf("broken test")
+	})
+	defer r()
+
+	updateCalled := 0
+	r = daemon.MockServicestateUpdateQuota(func(st *state.State, name string, opts servicestate.QuotaGroupUpdate) (*state.TaskSet, error) {
+		updateCalled++
+		c.Assert(name, check.Equals, "ginger-ale")
+		c.Assert(opts, check.DeepEquals, servicestate.QuotaGroupUpdate{
+			AddSnaps:          []string{"some-snap"},
+			NewResourceLimits: quota.NewResourcesBuilder().WithCPUCount(1).WithCPUPercentage(100).WithAllowedCPUs([]int{0, 1}).Build(),
+		})
+		ts := state.NewTaskSet(st.NewTask("foo-quota", "..."))
+		return ts, nil
+	})
+	defer r()
+
+	data, err := json.Marshal(daemon.PostQuotaGroupData{
+		Action:    "ensure",
+		GroupName: "ginger-ale",
+		Snaps:     []string{"some-snap"},
+		Constraints: client.QuotaValues{
+			CPU: &client.QuotaCPUValues{
+				Count:       1,
+				Percentage:  100,
+				AllowedCPUs: []int{0, 1},
+			},
+		},
+	})
+	c.Assert(err, check.IsNil)
+
+	req, err := http.NewRequest("POST", "/v2/quotas", bytes.NewBuffer(data))
+	c.Assert(err, check.IsNil)
+	rsp := s.asyncReq(c, req, nil)
+	c.Assert(rsp.Status, check.Equals, 202)
+	c.Assert(updateCalled, check.Equals, 1)
+	c.Assert(s.ensureSoonCalled, check.Equals, 1)
+}
+
+func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateMemoryHappy(c *check.C) {
+	st := s.d.Overlord().State()
+	st.Lock()
+	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", nil,
+		quota.NewResourcesBuilder().
+			WithMemoryLimit(quantity.Size(5000)).
+			WithCPUCount(1).
+			WithCPUPercentage(100).
+			WithThreadLimit(256).
+			Build())
+	st.Unlock()
+	c.Assert(err, check.IsNil)
+
+	r := daemon.MockServicestateCreateQuota(func(st *state.State, name string, parentName string, snaps []string, resourceLimits quota.Resources) (*state.TaskSet, error) {
+		c.Errorf("should not have called create quota")
+		return nil, fmt.Errorf("broken test")
+	})
+	defer r()
+
+	updateCalled := 0
+	r = daemon.MockServicestateUpdateQuota(func(st *state.State, name string, opts servicestate.QuotaGroupUpdate) (*state.TaskSet, error) {
+		updateCalled++
+		c.Assert(name, check.Equals, "ginger-ale")
+		c.Assert(opts, check.DeepEquals, servicestate.QuotaGroupUpdate{
+			AddSnaps:          []string{"some-snap"},
+			NewResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(9000).Build(),
+		})
+		ts := state.NewTaskSet(st.NewTask("foo-quota", "..."))
+		return ts, nil
+	})
+	defer r()
+
+	data, err := json.Marshal(daemon.PostQuotaGroupData{
+		Action:    "ensure",
+		GroupName: "ginger-ale",
+		Snaps:     []string{"some-snap"},
+		Constraints: client.QuotaValues{
+			Memory: quantity.Size(9000),
+		},
 	})
 	c.Assert(err, check.IsNil)
 

--- a/daemon/api_quotas_test.go
+++ b/daemon/api_quotas_test.go
@@ -310,9 +310,11 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateCpu2Happy(c *check.C) {
 		Snaps:     []string{"some-snap"},
 		Constraints: client.QuotaValues{
 			CPU: &client.QuotaCPUValues{
-				Count:       1,
-				Percentage:  100,
-				AllowedCPUs: []int{0, 1},
+				Count:      1,
+				Percentage: 100,
+			},
+			CPUSet: &client.QuotaCPUSetValues{
+				CPUs: []int{0, 1},
 			},
 		},
 	})


### PR DESCRIPTION
This the next PR in line, and also the one that actually enables users to use the new quotas. This PR adds the neccessary switches and missing frontend code to enable usage of the new quotas.