### PR TITLE
kernel/fde: add PartitionName to various structs 

### DIFF
--- a/boot/seal.go
+++ b/boot/seal.go
@@ -54,8 +54,6 @@ var (
 // Hook functions setup by devicestate to support device-specific full
 // disk encryption implementations. The state must be locked when these
 // functions are called.
-//
-// XXX: move to "kernel/fde/fde.go" ?
 var (
 	HasFDESetupHook = func() (bool, error) {
 		return false, nil

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -54,6 +54,8 @@ var (
 // Hook functions setup by devicestate to support device-specific full
 // disk encryption implementations. The state must be locked when these
 // functions are called.
+//
+// XXX: move to "kernel/fde/fde.go" ?
 var (
 	HasFDESetupHook = func() (bool, error) {
 		return false, nil

--- a/kernel/fde/reveal_key.go
+++ b/kernel/fde/reveal_key.go
@@ -59,6 +59,7 @@ func runFDERevealKeyCommand(req *RevealKeyRequest) (output []byte, err error) {
 var runFDERevealKey = runFDERevealKeyCommand
 
 func MockRunFDERevealKey(mock func(*RevealKeyRequest) ([]byte, error)) (restore func()) {
+	osutil.MustBeTestBinary("fde-reveal-key can only be mocked in tests")
 	oldRunFDERevealKey := runFDERevealKey
 	runFDERevealKey = mock
 	return func() {


### PR DESCRIPTION
We need to specify the PartitionName for ICE decryption since it is currently
based on partition name as well as the mapper device provided in Device.

Also allow mocking the actual call to runFDEDeviceUnlockCommand from other 
packages without all the complexity of creating hook scripts and such, and add
some more debug logging.

All originally from @mvo5 in other branches.