### PR TITLE
asserts,interfaces/policy: slot-snap-id allow-installation constraints

### DIFF
--- a/asserts/ifacedecls.go
+++ b/asserts/ifacedecls.go
@@ -621,6 +621,7 @@ func (r *PlugRule) setConstraints(field string, cstrs []constraintsHolder) {
 // PlugInstallationConstraints specifies a set of constraints on an interface plug relevant to the installation of snap.
 type PlugInstallationConstraints struct {
 	PlugSnapTypes []string
+	PlugSnapIDs   []string
 
 	PlugNames *NameConstraints
 
@@ -663,6 +664,8 @@ func (c *PlugInstallationConstraints) setIDConstraints(field string, cstrs []str
 	switch field {
 	case "plug-snap-type":
 		c.PlugSnapTypes = cstrs
+	case "plug-snap-id":
+		c.PlugSnapIDs = cstrs
 	default:
 		panic("unknown PlugInstallationConstraints field " + field)
 	}
@@ -678,7 +681,9 @@ func (c *PlugInstallationConstraints) setDeviceScopeConstraint(deviceScope *Devi
 
 func compilePlugInstallationConstraints(context *subruleContext, cDef constraintsDef) (constraintsHolder, error) {
 	plugInstCstrs := &PlugInstallationConstraints{}
-	err := baseCompileConstraints(context, cDef, plugInstCstrs, []string{"plug-names"}, []string{"plug-attributes"}, []string{"plug-snap-type"})
+	// plug-snap-id is supported here mainly for symmetry with the slot case
+	// see discussion there
+	err := baseCompileConstraints(context, cDef, plugInstCstrs, []string{"plug-names"}, []string{"plug-attributes"}, []string{"plug-snap-type", "plug-snap-id"})
 	if err != nil {
 		return nil, err
 	}
@@ -925,6 +930,7 @@ func (r *SlotRule) setConstraints(field string, cstrs []constraintsHolder) {
 // interface slot relevant to the installation of snap.
 type SlotInstallationConstraints struct {
 	SlotSnapTypes []string
+	SlotSnapIDs   []string
 
 	SlotNames *NameConstraints
 
@@ -967,6 +973,8 @@ func (c *SlotInstallationConstraints) setIDConstraints(field string, cstrs []str
 	switch field {
 	case "slot-snap-type":
 		c.SlotSnapTypes = cstrs
+	case "slot-snap-id":
+		c.SlotSnapIDs = cstrs
 	default:
 		panic("unknown SlotInstallationConstraints field " + field)
 	}
@@ -982,7 +990,17 @@ func (c *SlotInstallationConstraints) setDeviceScopeConstraint(deviceScope *Devi
 
 func compileSlotInstallationConstraints(context *subruleContext, cDef constraintsDef) (constraintsHolder, error) {
 	slotInstCstrs := &SlotInstallationConstraints{}
-	err := baseCompileConstraints(context, cDef, slotInstCstrs, []string{"slot-names"}, []string{"slot-attributes"}, []string{"slot-snap-type"})
+	// slot-snap-id here is mostly useful to restrict a relaxed
+	// base-declaration slot-snap-type constraint because the latter is used
+	// also for --dangerous installations. So in rare complex situations
+	// slot-snap-type might constraint to core and app
+	// but the intention is really that only system snaps should have the
+	// slot without a snap-declaration rule, slot-snap-id then can
+	// be used to limit to the known system snap snap-ids.
+	// This means we want app-slot to be super-privileged but we have
+	// slots for the interface on the system snaps as well.
+	// XXX mention real example
+	err := baseCompileConstraints(context, cDef, slotInstCstrs, []string{"slot-names"}, []string{"slot-attributes"}, []string{"slot-snap-type", "slot-snap-id"})
 	if err != nil {
 		return nil, err
 	}

--- a/asserts/ifacedecls_test.go
+++ b/asserts/ifacedecls_test.go
@@ -678,6 +678,7 @@ func (s *plugSlotRulesSuite) TestCompilePlugRuleInstalationConstraintsIDConstrai
 	rule, err := asserts.CompilePlugRule("iface", map[string]interface{}{
 		"allow-installation": map[string]interface{}{
 			"plug-snap-type": []interface{}{"core", "kernel", "gadget", "app"},
+			"plug-snap-id":   []interface{}{"snapidsnapidsnapidsnapidsnapid01", "snapidsnapidsnapidsnapidsnapid02"},
 		},
 	})
 	c.Assert(err, IsNil)
@@ -685,6 +686,7 @@ func (s *plugSlotRulesSuite) TestCompilePlugRuleInstalationConstraintsIDConstrai
 	c.Assert(rule.AllowInstallation, HasLen, 1)
 	cstrs := rule.AllowInstallation[0]
 	c.Check(cstrs.PlugSnapTypes, DeepEquals, []string{"core", "kernel", "gadget", "app"})
+	c.Check(cstrs.PlugSnapIDs, DeepEquals, []string{"snapidsnapidsnapidsnapidsnapid01", "snapidsnapidsnapidsnapidsnapid02"})
 }
 
 func (s *plugSlotRulesSuite) TestCompilePlugRuleInstallationConstraintsOnClassic(c *C) {
@@ -1522,6 +1524,7 @@ func (s *plugSlotRulesSuite) TestCompileSlotRuleInstallationConstraintsIDConstra
 	rule, err := asserts.CompileSlotRule("iface", map[string]interface{}{
 		"allow-installation": map[string]interface{}{
 			"slot-snap-type": []interface{}{"core", "kernel", "gadget", "app"},
+			"slot-snap-id":   []interface{}{"snapidsnapidsnapidsnapidsnapid01", "snapidsnapidsnapidsnapidsnapid02"},
 		},
 	})
 	c.Assert(err, IsNil)
@@ -1529,6 +1532,7 @@ func (s *plugSlotRulesSuite) TestCompileSlotRuleInstallationConstraintsIDConstra
 	c.Assert(rule.AllowInstallation, HasLen, 1)
 	cstrs := rule.AllowInstallation[0]
 	c.Check(cstrs.SlotSnapTypes, DeepEquals, []string{"core", "kernel", "gadget", "app"})
+	c.Check(cstrs.SlotSnapIDs, DeepEquals, []string{"snapidsnapidsnapidsnapidsnapid01", "snapidsnapidsnapidsnapidsnapid02"})
 }
 
 func (s *plugSlotRulesSuite) TestCompileSlotRuleInstallationConstraintsOnClassic(c *C) {

--- a/interfaces/policy/helpers.go
+++ b/interfaces/policy/helpers.go
@@ -245,6 +245,9 @@ func checkSlotInstallationConstraints1(ic *InstallCandidate, slot *snap.SlotInfo
 	if err := checkSnapType(slot.Snap, constraints.SlotSnapTypes); err != nil {
 		return err
 	}
+	if err := checkID("snap id", ic.snapID(), constraints.SlotSnapIDs, nil); err != nil {
+		return err
+	}
 	if err := checkOnClassic(constraints.OnClassic); err != nil {
 		return err
 	}
@@ -279,6 +282,9 @@ func checkPlugInstallationConstraints1(ic *InstallCandidate, plug *snap.PlugInfo
 		return err
 	}
 	if err := checkSnapType(plug.Snap, constraints.PlugSnapTypes); err != nil {
+		return err
+	}
+	if err := checkID("snap id", ic.snapID(), constraints.PlugSnapIDs, nil); err != nil {
 		return err
 	}
 	if err := checkOnClassic(constraints.OnClassic); err != nil {

--- a/interfaces/policy/policy.go
+++ b/interfaces/policy/policy.go
@@ -41,6 +41,13 @@ type InstallCandidate struct {
 	Store *asserts.Store
 }
 
+func (ic *InstallCandidate) snapID() string {
+	if ic.SnapDeclaration != nil {
+		return ic.SnapDeclaration.SnapID()
+	}
+	return "" // never a valid snap-id
+}
+
 func (ic *InstallCandidate) checkSlotRule(slot *snap.SlotInfo, rule *asserts.SlotRule, snapRule bool) error {
 	context := ""
 	if snapRule {


### PR DESCRIPTION
The use case for this is that we have now the unsupported situation of
an interface that is superprivileged but still wants to have special
system snap slots.

Because it needs to cover also the --dangerous case the
base-declaration slot side slot-snap-type constraint cannot express
this, it needs to allow both core and app. To restrict this as needed
we then allow to use slot-snap-id which can list the well-known system
snap ids.

Notice that this kind of constraint makes sense only in the
base-declaration.  In a snap-declaration the snap-id is fixed and
implied. We also do not want to put interface rules in the actual
snap-declarations of the system snaps.

Although there's no clear use case, as the system snaps don't have
plugs, we support also plug side allow-installation plug-snap-id for
symmetry.