### PR TITLE
quota: add some more unit tests around Resource.Change()

### DIFF
--- a/snap/quota/resources_test.go
+++ b/snap/quota/resources_test.go
@@ -103,6 +103,34 @@ func (s *resourcesTestSuite) TestQuotaChangeValidationFails(c *C) {
 			quota.NewResourcesBuilder().WithAllowedCPUs([]int{}).Build(),
 			`cannot remove all allowed cpus from quota group`,
 		},
+		// ensure that changes will call "Validate" too
+		{
+			quota.NewResourcesBuilder().WithCPUCount(1).Build(),
+			quota.NewResourcesBuilder().WithMemoryLimit(1).Build(),
+			`memory limit 1 is too small: size must be larger than 4KB`,
+		},
+		{
+			quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build(),
+			quota.NewResourcesBuilder().WithCPUCount(0).Build(),
+			`invalid cpu quota with a cpu quota of 0`,
+		},
+		{
+			quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build(),
+			quota.NewResourcesBuilder().WithCPUCount(2).WithCPUPercentage(0).Build(),
+			`invalid cpu quota with count of >0 and percentage of 0`,
+		},
+		{
+			quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build(),
+
+			quota.NewResourcesBuilder().WithAllowedCPUs([]int{}).Build(),
+			`cpu-set quota must not be empty`,
+		},
+		{
+			quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build(),
+
+			quota.NewResourcesBuilder().WithThreadLimit(-1).Build(),
+			`invalid thread quota with a thread count of -1`,
+		},
 	}
 
 	for _, t := range tests {


### PR DESCRIPTION
We did not really check that when `Resource.Change()` got called
we also call `Validate()` on the new resulting `Resource`.

This commit adds these missing tests for the various resource types.
