### PR TITLE
quota: add test for `Resource.clone()`

### DIFF
--- a/snap/quota/export_test.go
+++ b/snap/quota/export_test.go
@@ -30,3 +30,7 @@ func (grp *Group) InspectInternalQuotaAllocations() map[string]*GroupQuotaAlloca
 	grp.getQuotaAllocations(allQuotas, nil)
 	return allQuotas
 }
+
+func ResourcesClone(r *Resources) Resources {
+	return r.clone()
+}


### PR DESCRIPTION
This test ensures that `Resource.clone()` is really a copy of the
existing resource with all fields copied.

It checks this by creating a `Resource` struct using `reflect` and
then initializes each field with the right type. Then clone() is
called and in the resulting struct it is checked that:

a) all fields are non-nil (i.e. that the clone() did not forgot
   to copy a field. This should protect us from adding fields in
   the future and forgetting to add them to "clone".

b) all pointers in the fields are different from the original
   `Resource`. This ensures we actually create a deep copy
   (at least on the first level) and not just assign the pointer
   to the same struct in the clone.

