### PR TITLE
tests: workaround lxd issue lp:10079 (function not implemented) on prep-snapd-in-lxd

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -40,7 +40,7 @@ environment:
     SUDO_UID: ""
     TRUST_TEST_KEYS: '$(HOST: echo "${SPREAD_TRUST_TEST_KEYS:-true}")'
     # a global setting for LXD channel to use in the tests
-    LXD_SNAP_CHANNEL: "latest/edge"
+    LXD_SNAP_CHANNEL: "latest/candidate"
     UBUNTU_IMAGE_SNAP_CHANNEL: "latest/edge"
     CORE_CHANNEL: '$(HOST: echo "${SPREAD_CORE_CHANNEL:-edge}")'
     BASE_CHANNEL: '$(HOST: echo "${SPREAD_BASE_CHANNEL:-edge}")'

--- a/spread.yaml
+++ b/spread.yaml
@@ -40,7 +40,7 @@ environment:
     SUDO_UID: ""
     TRUST_TEST_KEYS: '$(HOST: echo "${SPREAD_TRUST_TEST_KEYS:-true}")'
     # a global setting for LXD channel to use in the tests
-    LXD_SNAP_CHANNEL: "latest/candidate"
+    LXD_SNAP_CHANNEL: "latest/edge"
     UBUNTU_IMAGE_SNAP_CHANNEL: "latest/edge"
     CORE_CHANNEL: '$(HOST: echo "${SPREAD_CORE_CHANNEL:-edge}")'
     BASE_CHANNEL: '$(HOST: echo "${SPREAD_BASE_CHANNEL:-edge}")'

--- a/tests/main/lxd-postrm-purge/prep-snapd-in-lxd.sh
+++ b/tests/main/lxd-postrm-purge/prep-snapd-in-lxd.sh
@@ -5,7 +5,7 @@ set -ex
 # TODO: Remove the refresh once the issue https://github.com/lxc/lxd/issues/10079 is release to 4.0/candidate
 # Make sure the lxd snap is updated before removing it
 for i in $(seq 30); do
-    if command -v snap; then
+    if snap changes | grep -qE "Done.*Initialize device"; then
         break
     fi
     sleep 1

--- a/tests/main/lxd-postrm-purge/prep-snapd-in-lxd.sh
+++ b/tests/main/lxd-postrm-purge/prep-snapd-in-lxd.sh
@@ -4,6 +4,12 @@ set -ex
 
 # TODO: Remove the refresh once the issue https://github.com/lxc/lxd/issues/10079 is release to 4.0/candidate
 # Make sure the lxd snap is updated before removing it
+for i in $(seq 30); do
+    if command -v snap; then
+        break
+    fi
+    sleep 1
+done
 snap refresh lxd --channel=latest/stable
 snap remove lxd
 

--- a/tests/main/lxd-postrm-purge/prep-snapd-in-lxd.sh
+++ b/tests/main/lxd-postrm-purge/prep-snapd-in-lxd.sh
@@ -4,7 +4,7 @@ set -ex
 
 # TODO: Remove the refresh once the issue https://github.com/lxc/lxd/issues/10079 is release to 4.0/candidate
 # Make sure the lxd snap is updated before removing it
-snap refresh lxd --channel=latest
+snap refresh lxd --channel=latest/stable
 snap remove lxd
 
 # XXX: remove once the "umount /snap" change in postrm has propagated all

--- a/tests/main/lxd-postrm-purge/prep-snapd-in-lxd.sh
+++ b/tests/main/lxd-postrm-purge/prep-snapd-in-lxd.sh
@@ -10,6 +10,7 @@ for i in $(seq 30); do
     fi
     sleep 1
 done
+snap wait system seed.loaded
 snap refresh lxd --channel=latest/stable
 snap remove lxd
 

--- a/tests/main/lxd-postrm-purge/prep-snapd-in-lxd.sh
+++ b/tests/main/lxd-postrm-purge/prep-snapd-in-lxd.sh
@@ -2,6 +2,11 @@
 
 set -ex
 
+# TODO: Remove the refresh once the issue https://github.com/lxc/lxd/issues/10079 is release to 4.0/candidate
+# Make sure the lxd snap is updated before removing it
+snap refresh lxd --channel=latest
+snap remove lxd
+
 # XXX: remove once the "umount /snap" change in postrm has propagated all
 #      the way to the image
 if [ -e /var/lib/dpkg/info/snapd.postrm ]; then

--- a/tests/main/lxd/prep-snapd-in-lxd.sh
+++ b/tests/main/lxd/prep-snapd-in-lxd.sh
@@ -5,7 +5,7 @@ set -ex
 # TODO: Remove the refresh once the issue https://github.com/lxc/lxd/issues/10079 is release to 4.0/candidate
 # Make sure the lxd snap is updated before removing it
 for i in $(seq 30); do
-    if command -v snap; then
+    if snap changes | grep -qE "Done.*Initialize device"; then
         break
     fi
     sleep 1

--- a/tests/main/lxd/prep-snapd-in-lxd.sh
+++ b/tests/main/lxd/prep-snapd-in-lxd.sh
@@ -4,6 +4,12 @@ set -ex
 
 # TODO: Remove the refresh once the issue https://github.com/lxc/lxd/issues/10079 is release to 4.0/candidate
 # Make sure the lxd snap is updated before removing it
+for i in $(seq 30); do
+    if command -v snap; then
+        break
+    fi
+    sleep 1
+done
 snap refresh lxd --channel=latest/stable
 snap remove lxd
 

--- a/tests/main/lxd/prep-snapd-in-lxd.sh
+++ b/tests/main/lxd/prep-snapd-in-lxd.sh
@@ -4,7 +4,7 @@ set -ex
 
 # TODO: Remove the refresh once the issue https://github.com/lxc/lxd/issues/10079 is release to 4.0/candidate
 # Make sure the lxd snap is updated before removing it
-snap refresh lxd --channel=latest
+snap refresh lxd --channel=latest/stable
 snap remove lxd
 
 # XXX: remove once the "umount /snap" change in postrm has propagated all

--- a/tests/main/lxd/prep-snapd-in-lxd.sh
+++ b/tests/main/lxd/prep-snapd-in-lxd.sh
@@ -10,6 +10,7 @@ for i in $(seq 30); do
     fi
     sleep 1
 done
+snap wait system seed.loaded
 snap refresh lxd --channel=latest/stable
 snap remove lxd
 

--- a/tests/main/lxd/prep-snapd-in-lxd.sh
+++ b/tests/main/lxd/prep-snapd-in-lxd.sh
@@ -2,6 +2,11 @@
 
 set -ex
 
+# TODO: Remove the refresh once the issue https://github.com/lxc/lxd/issues/10079 is release to 4.0/candidate
+# Make sure the lxd snap is updated before removing it
+snap refresh lxd --channel=latest
+snap remove lxd
+
 # XXX: remove once the "umount /snap" change in postrm has propagated all
 #      the way to the image
 if [ -e /var/lib/dpkg/info/snapd.postrm ]; then


### PR DESCRIPTION
This workaround is to avoid error (function not implemented) in lxd when
it is being removed.
