### PR TITLE
gadget/install, kernel: more ICE helpers/support

### DIFF
--- a/gadget/install/encrypt.go
+++ b/gadget/install/encrypt.go
@@ -26,8 +26,11 @@ import (
 	"fmt"
 	"os/exec"
 
+	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/gadget"
+	"github.com/snapcore/snapd/kernel/fde"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/osutil/disks"
 	"github.com/snapcore/snapd/secboot"
 )
 
@@ -102,4 +105,74 @@ func cryptsetupClose(name string) error {
 		return osutil.OutputErr(output, err)
 	}
 	return nil
+}
+
+// encryptedDeviceWithSetupHook represents a block device that is setup using
+// the "device-setup" hook.
+type encryptedDeviceWithSetupHook struct {
+	parent *gadget.OnDiskStructure
+	name   string
+	node   string
+}
+
+// sanity
+var _ = encryptedDevice(&encryptedDeviceWithSetupHook{})
+
+// newEncryptedDeviceWithSetupHook creates an encrypted device in the
+// existing partition using the specified key using the fde-setup hook
+func newEncryptedDeviceWithSetupHook(part *gadget.OnDiskStructure, key secboot.EncryptionKey, name string) (encryptedDevice, error) {
+	// for roles requiring encryption, the filesystem label is always set to
+	// either the implicit value or a value that has been validated
+	if part.Name != name || part.Label != name {
+		return nil, fmt.Errorf("cannot use partition name %q for an encrypted structure with %v role and filesystem with label %q",
+			name, part.Role, part.Label)
+	}
+
+	// 1. create linear mapper device with 1Mb of reserved space
+	uuid := ""
+	offset := fde.DeviceSetupHookPartitionOffset
+	sizeMinusOffset := uint64(part.Size) - offset
+	mapperDevice, err := disks.CreateLinearMapperDevice(part.Node, name, uuid, offset, sizeMinusOffset)
+	if err != nil {
+		return nil, err
+	}
+
+	// 2. run fde-setup "device-setup" on it
+	// TODO: We may need a different way to run the fde-setup hook
+	//       here. The hook right now runs with a locked state. But
+	//       when this runs the state will be unlocked but our hook
+	//       mechanism needs a locked state. This means we either need
+	//       something like "boot.RunFDE*Device*SetupHook" or we run
+	//       the entire install with the state locked (which may not
+	//       be as terrible as it sounds as this is a rare situation).
+	runHook := boot.RunFDESetupHook
+	params := &fde.DeviceSetupParams{
+		Key:           key,
+		Device:        mapperDevice,
+		PartitionName: name,
+	}
+	if err := fde.DeviceSetup(runHook, params); err != nil {
+		return nil, err
+	}
+
+	return &encryptedDeviceWithSetupHook{
+		parent: part,
+		name:   name,
+		node:   mapperDevice,
+	}, nil
+}
+
+func (dev *encryptedDeviceWithSetupHook) Close() error {
+	if output, err := exec.Command("dmsetup", "remove", dev.name).CombinedOutput(); err != nil {
+		return osutil.OutputErr(output, err)
+	}
+	return nil
+}
+
+func (dev *encryptedDeviceWithSetupHook) Node() string {
+	return dev.node
+}
+
+func (dev *encryptedDeviceWithSetupHook) AddRecoveryKey(key secboot.EncryptionKey, rkey secboot.RecoveryKey) error {
+	return fmt.Errorf("recovery keys are not supported on devices that use the device-setup hook")
 }

--- a/gadget/install/encrypt.go
+++ b/gadget/install/encrypt.go
@@ -118,9 +118,9 @@ type encryptedDeviceWithSetupHook struct {
 // sanity
 var _ = encryptedDevice(&encryptedDeviceWithSetupHook{})
 
-// newEncryptedDeviceWithSetupHook creates an encrypted device in the
+// createEncryptedDeviceWithSetupHook creates an encrypted device in the
 // existing partition using the specified key using the fde-setup hook
-func newEncryptedDeviceWithSetupHook(part *gadget.OnDiskStructure, key secboot.EncryptionKey, name string) (encryptedDevice, error) {
+func createEncryptedDeviceWithSetupHook(part *gadget.OnDiskStructure, key secboot.EncryptionKey, name string) (encryptedDevice, error) {
 	// for roles requiring encryption, the filesystem label is always set to
 	// either the implicit value or a value that has been validated
 	if part.Name != name || part.Label != name {

--- a/gadget/install/encrypt_test.go
+++ b/gadget/install/encrypt_test.go
@@ -196,7 +196,7 @@ var mockDeviceStructureForDeviceSetupHook = gadget.OnDiskStructure{
 	Node: "/dev/node1",
 }
 
-func (s *encryptSuite) TestNewEncryptedDeviceWithSetupHook(c *C) {
+func (s *encryptSuite) TestCreateEncryptedDeviceWithSetupHook(c *C) {
 
 	for _, tc := range []struct {
 		mockedOpenErr            string
@@ -234,7 +234,7 @@ func (s *encryptSuite) TestNewEncryptedDeviceWithSetupHook(c *C) {
 		mockDmsetup := testutil.MockCommand(c, "dmsetup", script)
 		s.AddCleanup(mockDmsetup.Restore)
 
-		dev, err := install.NewEncryptedDeviceWithSetupHook(&mockDeviceStructureForDeviceSetupHook,
+		dev, err := install.CreateEncryptedDeviceWithSetupHook(&mockDeviceStructureForDeviceSetupHook,
 			s.mockedEncryptionKey, "ubuntu-data")
 		if tc.expectedErr == "" {
 			c.Assert(err, IsNil)
@@ -258,7 +258,7 @@ func (s *encryptSuite) TestNewEncryptedDeviceWithSetupHook(c *C) {
 	}
 }
 
-func (s *encryptSuite) TestNewEncryptedDeviceWithSetupHookPartitionNameCheck(c *C) {
+func (s *encryptSuite) TestCreateEncryptedDeviceWithSetupHookPartitionNameCheck(c *C) {
 	mockDeviceStructureBadName := gadget.OnDiskStructure{
 		LaidOutStructure: gadget.LaidOutStructure{
 			VolumeStructure: &gadget.VolumeStructure{
@@ -282,7 +282,7 @@ func (s *encryptSuite) TestNewEncryptedDeviceWithSetupHookPartitionNameCheck(c *
 	s.AddCleanup(mockDmsetup.Restore)
 
 	// pass a name that does not match partition name
-	dev, err := install.NewEncryptedDeviceWithSetupHook(&mockDeviceStructureBadName,
+	dev, err := install.CreateEncryptedDeviceWithSetupHook(&mockDeviceStructureBadName,
 		s.mockedEncryptionKey, "some-name")
 	c.Assert(err, ErrorMatches, `cannot use partition name "some-name" for an encrypted structure with system-data role and filesystem with label "ubuntu-data"`)
 	c.Check(dev, IsNil)
@@ -291,7 +291,7 @@ func (s *encryptSuite) TestNewEncryptedDeviceWithSetupHookPartitionNameCheck(c *
 	// the implicit value or has already been validated and matches what is
 	// expected for the particular role
 	mockDeviceStructureBadName.Name = "bad-name"
-	dev, err = install.NewEncryptedDeviceWithSetupHook(&mockDeviceStructureBadName,
+	dev, err = install.CreateEncryptedDeviceWithSetupHook(&mockDeviceStructureBadName,
 		s.mockedEncryptionKey, "bad-name")
 	c.Assert(err, ErrorMatches, `cannot use partition name "bad-name" for an encrypted structure with system-data role and filesystem with label "ubuntu-data"`)
 	c.Check(dev, IsNil)
@@ -309,7 +309,7 @@ func (s *encryptSuite) TestAddRecoveryKeyDeviceWithSetupHook(c *C) {
 	mockDmsetup := testutil.MockCommand(c, "dmsetup", "")
 	s.AddCleanup(mockDmsetup.Restore)
 
-	dev, err := install.NewEncryptedDeviceWithSetupHook(&mockDeviceStructureForDeviceSetupHook,
+	dev, err := install.CreateEncryptedDeviceWithSetupHook(&mockDeviceStructureForDeviceSetupHook,
 		s.mockedEncryptionKey, "ubuntu-data")
 	c.Assert(err, IsNil)
 	c.Check(setupReq.Device, Equals, "/dev/mapper/ubuntu-data")

--- a/gadget/install/encrypt_test.go
+++ b/gadget/install/encrypt_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/gadget/install"
+	"github.com/snapcore/snapd/gadget/quantity"
+	"github.com/snapcore/snapd/kernel/fde"
 	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -49,12 +51,14 @@ var _ = Suite(&encryptSuite{})
 var mockDeviceStructure = gadget.OnDiskStructure{
 	LaidOutStructure: gadget.LaidOutStructure{
 		VolumeStructure: &gadget.VolumeStructure{
-			Name: "Test structure",
-			Size: 0x100000,
+			Role:  gadget.SystemData,
+			Name:  "Test structure",
+			Label: "some-label",
 		},
 		StartOffset: 0,
 		YamlIndex:   1,
 	},
+	Size: 3 * quantity.SizeMiB,
 	Node: "/dev/node1",
 }
 
@@ -176,4 +180,141 @@ func (s *encryptSuite) TestAddRecoveryKey(c *C) {
 			{"cryptsetup", "close", "some-label"},
 		})
 	}
+}
+
+var mockDeviceStructureForDeviceSetupHook = gadget.OnDiskStructure{
+	LaidOutStructure: gadget.LaidOutStructure{
+		VolumeStructure: &gadget.VolumeStructure{
+			Role:  gadget.SystemData,
+			Name:  "ubuntu-data",
+			Label: "ubuntu-data",
+		},
+		StartOffset: 0,
+		YamlIndex:   1,
+	},
+	Size: 3 * quantity.SizeMiB,
+	Node: "/dev/node1",
+}
+
+func (s *encryptSuite) TestNewEncryptedDeviceWithSetupHook(c *C) {
+
+	for _, tc := range []struct {
+		mockedOpenErr            string
+		mockedRunFDESetupHookErr error
+		expectedErr              string
+	}{
+		{
+			mockedOpenErr:            "",
+			mockedRunFDESetupHookErr: nil,
+			expectedErr:              "",
+		},
+		{
+			mockedRunFDESetupHookErr: errors.New("fde-setup hook error"),
+			mockedOpenErr:            "",
+			expectedErr:              "device setup failed with: fde-setup hook error",
+		},
+
+		{
+			mockedOpenErr:            "open error",
+			mockedRunFDESetupHookErr: nil,
+			expectedErr:              `cannot create mapper "ubuntu-data" on /dev/node1: open error`,
+		},
+	} {
+		script := ""
+		if tc.mockedOpenErr != "" {
+			script = fmt.Sprintf("echo '%s'>&2; exit 1", tc.mockedOpenErr)
+
+		}
+
+		restore := install.MockBootRunFDESetupHook(func(req *fde.SetupRequest) ([]byte, error) {
+			return nil, tc.mockedRunFDESetupHookErr
+		})
+		defer restore()
+
+		mockDmsetup := testutil.MockCommand(c, "dmsetup", script)
+		s.AddCleanup(mockDmsetup.Restore)
+
+		dev, err := install.NewEncryptedDeviceWithSetupHook(&mockDeviceStructureForDeviceSetupHook,
+			s.mockedEncryptionKey, "ubuntu-data")
+		if tc.expectedErr == "" {
+			c.Assert(err, IsNil)
+		} else {
+			c.Assert(err, ErrorMatches, tc.expectedErr)
+			continue
+		}
+		c.Check(dev.Node(), Equals, "/dev/mapper/ubuntu-data")
+
+		err = dev.Close()
+		c.Assert(err, IsNil)
+
+		c.Check(mockDmsetup.Calls(), DeepEquals, [][]string{
+			// Caculation is in 512 byte blocks. The total
+			// size of the mock device is 3Mb: 2Mb
+			// (4096*512) length if left and the offset is
+			// 1Mb (2048*512) at the start
+			{"dmsetup", "create", "ubuntu-data", "--table", "0 4096 linear /dev/node1 2048"},
+			{"dmsetup", "remove", "ubuntu-data"},
+		})
+	}
+}
+
+func (s *encryptSuite) TestNewEncryptedDeviceWithSetupHookPartitionNameCheck(c *C) {
+	mockDeviceStructureBadName := gadget.OnDiskStructure{
+		LaidOutStructure: gadget.LaidOutStructure{
+			VolumeStructure: &gadget.VolumeStructure{
+				Role:  gadget.SystemData,
+				Name:  "ubuntu-data",
+				Label: "ubuntu-data",
+			},
+			StartOffset: 0,
+			YamlIndex:   1,
+		},
+		Size: 3 * quantity.SizeMiB,
+		Node: "/dev/node1",
+	}
+	restore := install.MockBootRunFDESetupHook(func(req *fde.SetupRequest) ([]byte, error) {
+		c.Error("unexpected call")
+		return nil, fmt.Errorf("unexpected call")
+	})
+	defer restore()
+
+	mockDmsetup := testutil.MockCommand(c, "dmsetup", `echo "unexpected call" >&2; exit 1`)
+	s.AddCleanup(mockDmsetup.Restore)
+
+	// pass a name that does not match partition name
+	dev, err := install.NewEncryptedDeviceWithSetupHook(&mockDeviceStructureBadName,
+		s.mockedEncryptionKey, "some-name")
+	c.Assert(err, ErrorMatches, `cannot use partition name "some-name" for an encrypted structure with system-data role and filesystem with label "ubuntu-data"`)
+	c.Check(dev, IsNil)
+	c.Check(mockDmsetup.Calls(), HasLen, 0)
+	// make structure name different than the label, which is set to either
+	// the implicit value or has already been validated and matches what is
+	// expected for the particular role
+	mockDeviceStructureBadName.Name = "bad-name"
+	dev, err = install.NewEncryptedDeviceWithSetupHook(&mockDeviceStructureBadName,
+		s.mockedEncryptionKey, "bad-name")
+	c.Assert(err, ErrorMatches, `cannot use partition name "bad-name" for an encrypted structure with system-data role and filesystem with label "ubuntu-data"`)
+	c.Check(dev, IsNil)
+	c.Check(mockDmsetup.Calls(), HasLen, 0)
+}
+
+func (s *encryptSuite) TestAddRecoveryKeyDeviceWithSetupHook(c *C) {
+	var setupReq *fde.SetupRequest
+	restore := install.MockBootRunFDESetupHook(func(req *fde.SetupRequest) ([]byte, error) {
+		setupReq = req
+		return nil, nil
+	})
+	defer restore()
+
+	mockDmsetup := testutil.MockCommand(c, "dmsetup", "")
+	s.AddCleanup(mockDmsetup.Restore)
+
+	dev, err := install.NewEncryptedDeviceWithSetupHook(&mockDeviceStructureForDeviceSetupHook,
+		s.mockedEncryptionKey, "ubuntu-data")
+	c.Assert(err, IsNil)
+	c.Check(setupReq.Device, Equals, "/dev/mapper/ubuntu-data")
+	c.Check(setupReq.PartitionName, Equals, "ubuntu-data")
+
+	err = dev.AddRecoveryKey(s.mockedEncryptionKey, s.mockedRecoveryKey)
+	c.Check(err, ErrorMatches, "recovery keys are not supported on devices that use the device-setup hook")
 }

--- a/gadget/install/export_secboot_test.go
+++ b/gadget/install/export_secboot_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/kernel/fde"
 	"github.com/snapcore/snapd/secboot"
+	"github.com/snapcore/snapd/testutil"
 )
 
 var (
@@ -34,25 +35,20 @@ var (
 )
 
 func MockSecbootFormatEncryptedDevice(f func(key secboot.EncryptionKey, label, node string) error) (restore func()) {
-	old := secbootFormatEncryptedDevice
+	r := testutil.Backup(&secbootFormatEncryptedDevice)
 	secbootFormatEncryptedDevice = f
-	return func() {
-		secbootFormatEncryptedDevice = old
-	}
+	return r
+
 }
 
 func MockSecbootAddRecoveryKey(f func(key secboot.EncryptionKey, rkey secboot.RecoveryKey, node string) error) (restore func()) {
-	old := secbootAddRecoveryKey
+	r := testutil.Backup(&secbootAddRecoveryKey)
 	secbootAddRecoveryKey = f
-	return func() {
-		secbootAddRecoveryKey = old
-	}
+	return r
 }
 
 func MockBootRunFDESetupHook(f func(req *fde.SetupRequest) ([]byte, error)) (restore func()) {
-	old := boot.RunFDESetupHook
+	r := testutil.Backup(&boot.RunFDESetupHook)
 	boot.RunFDESetupHook = f
-	return func() {
-		boot.RunFDESetupHook = old
-	}
+	return r
 }

--- a/gadget/install/export_secboot_test.go
+++ b/gadget/install/export_secboot_test.go
@@ -22,12 +22,15 @@
 package install
 
 import (
+	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/kernel/fde"
 	"github.com/snapcore/snapd/secboot"
 )
 
 var (
-	DiskWithSystemSeed     = diskWithSystemSeed
-	NewEncryptedDeviceLUKS = newEncryptedDeviceLUKS
+	DiskWithSystemSeed              = diskWithSystemSeed
+	NewEncryptedDeviceLUKS          = newEncryptedDeviceLUKS
+	NewEncryptedDeviceWithSetupHook = newEncryptedDeviceWithSetupHook
 )
 
 func MockSecbootFormatEncryptedDevice(f func(key secboot.EncryptionKey, label, node string) error) (restore func()) {
@@ -43,5 +46,13 @@ func MockSecbootAddRecoveryKey(f func(key secboot.EncryptionKey, rkey secboot.Re
 	secbootAddRecoveryKey = f
 	return func() {
 		secbootAddRecoveryKey = old
+	}
+}
+
+func MockBootRunFDESetupHook(f func(req *fde.SetupRequest) ([]byte, error)) (restore func()) {
+	old := boot.RunFDESetupHook
+	boot.RunFDESetupHook = f
+	return func() {
+		boot.RunFDESetupHook = old
 	}
 }

--- a/gadget/install/export_secboot_test.go
+++ b/gadget/install/export_secboot_test.go
@@ -28,9 +28,9 @@ import (
 )
 
 var (
-	DiskWithSystemSeed              = diskWithSystemSeed
-	NewEncryptedDeviceLUKS          = newEncryptedDeviceLUKS
-	NewEncryptedDeviceWithSetupHook = newEncryptedDeviceWithSetupHook
+	DiskWithSystemSeed                 = diskWithSystemSeed
+	NewEncryptedDeviceLUKS             = newEncryptedDeviceLUKS
+	CreateEncryptedDeviceWithSetupHook = createEncryptedDeviceWithSetupHook
 )
 
 func MockSecbootFormatEncryptedDevice(f func(key secboot.EncryptionKey, label, node string) error) (restore func()) {

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -183,18 +183,38 @@ func Run(model gadget.Model, gadgetRoot, kernelRoot, bootDevice string, options 
 			}
 			logger.Noticef("encrypting partition device %v", part.Node)
 			var dataPart encryptedDevice
-			timings.Run(perfTimings, fmt.Sprintf("new-encrypted-device[%s]", roleOrLabelOrName(part)), fmt.Sprintf("Create encryption device for %s", roleOrLabelOrName(part)), func(timings.Measurer) {
-				dataPart, err = newEncryptedDeviceLUKS(&part, keys.Key, part.Label)
-			})
-			if err != nil {
-				return nil, err
-			}
+			switch options.EncryptionType {
+			case secboot.EncryptionTypeLUKS:
+				timings.Run(perfTimings, fmt.Sprintf("new-encrypted-device[%s]", roleOrLabelOrName(part)), fmt.Sprintf("Create encryption device for %s", roleOrLabelOrName(part)), func(timings.Measurer) {
+					dataPart, err = newEncryptedDeviceLUKS(&part, keys.Key, part.Label)
+				})
+				if err != nil {
+					return nil, err
+				}
 
-			timings.Run(perfTimings, fmt.Sprintf("add-recovery-key[%s]", roleOrLabelOrName(part)), fmt.Sprintf("Adding recovery key for %s", roleOrLabelOrName(part)), func(timings.Measurer) {
-				err = dataPart.AddRecoveryKey(keys.Key, keys.RecoveryKey)
-			})
-			if err != nil {
-				return nil, err
+				timings.Run(perfTimings, fmt.Sprintf("add-recovery-key[%s]", roleOrLabelOrName(part)), fmt.Sprintf("Adding recovery key for %s", roleOrLabelOrName(part)), func(timings.Measurer) {
+					err = dataPart.AddRecoveryKey(keys.Key, keys.RecoveryKey)
+				})
+				if err != nil {
+					return nil, err
+				}
+
+				partsEncrypted[part.Name] = gadget.StructureEncryptionParameters{
+					Method: gadget.EncryptionLUKS,
+				}
+			case secboot.EncryptionTypeDeviceSetupHook:
+				timings.Run(perfTimings, fmt.Sprintf("new-encrypted-device-setup-hook[%s]", roleOrLabelOrName(part)), fmt.Sprintf("Create encryption device for %s using device-setup-hook", roleOrLabelOrName(part)), func(timings.Measurer) {
+					dataPart, err = newEncryptedDeviceWithSetupHook(&part, keys.Key, part.Name)
+				})
+				if err != nil {
+					return nil, err
+				}
+				// Note that inline-crypt-hw does not
+				// support recovery keys currently
+
+				partsEncrypted[part.Name] = gadget.StructureEncryptionParameters{
+					Method: gadget.EncryptionICE,
+				}
 			}
 
 			// update the encrypted device node
@@ -204,12 +224,6 @@ func Run(model gadget.Model, gadgetRoot, kernelRoot, bootDevice string, options 
 			}
 			keysForRoles[part.Role] = keys
 			logger.Noticef("encrypted device %v", part.Node)
-
-			// TODO: how to determine if this will be a LUKS or an ICE encrypted
-			// partition?
-			partsEncrypted[part.Name] = gadget.StructureEncryptionParameters{
-				Method: gadget.EncryptionLUKS,
-			}
 		}
 
 		// use the diskLayout.SectorSize here instead of lv.SectorSize, we check

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -204,7 +204,7 @@ func Run(model gadget.Model, gadgetRoot, kernelRoot, bootDevice string, options 
 				}
 			case secboot.EncryptionTypeDeviceSetupHook:
 				timings.Run(perfTimings, fmt.Sprintf("new-encrypted-device-setup-hook[%s]", roleOrLabelOrName(part)), fmt.Sprintf("Create encryption device for %s using device-setup-hook", roleOrLabelOrName(part)), func(timings.Measurer) {
-					dataPart, err = newEncryptedDeviceWithSetupHook(&part, keys.Key, part.Name)
+					dataPart, err = createEncryptedDeviceWithSetupHook(&part, keys.Key, part.Name)
 				})
 				if err != nil {
 					return nil, err

--- a/kernel/fde/fde.go
+++ b/kernel/fde/fde.go
@@ -34,6 +34,11 @@ import (
 	"github.com/snapcore/snapd/osutil"
 )
 
+// DeviceSetupHookPartitionOffset defines the free space that is reserved
+// at the start of a device-setup based partition for future use (like
+// to simulate LUKS keyslot like setup).
+const DeviceSetupHookPartitionOffset = uint64(1 * 1024 * 1024)
+
 // HasRevealKey return true if the current system has a "fde-reveal-key"
 // binary (usually used in the initrd).
 //
@@ -193,4 +198,10 @@ func DeviceSetup(runSetupHook RunSetupHookFunc, params *DeviceSetupParams) error
 	}
 
 	return nil
+}
+
+// EncryptedDeviceMapperName returns the name to use in device mapper for a
+// device that is encrypted using FDE hooks
+func EncryptedDeviceMapperName(name string) string {
+	return name + "-device-locked"
 }

--- a/kernel/fde/fde_test.go
+++ b/kernel/fde/fde_test.go
@@ -683,3 +683,14 @@ func (s *fdeSuite) TestIsEncryptedDeviceMapperName(c *C) {
 		c.Assert(fde.IsHardwareEncryptedDeviceMapperName(t), Equals, false)
 	}
 }
+
+func (s *fdeSuite) TestEncryptedDeviceMapperName(c *C) {
+	for _, str := range []string{
+		"ubuntu-data",
+		"ubuntu-save",
+		"foo",
+		"other",
+	} {
+		c.Assert(fde.EncryptedDeviceMapperName(str), Equals, str+"-device-locked")
+	}
+}


### PR DESCRIPTION
* Allow running the device-setup hook from install mode in gadget/install package when ICE is used (it never will be in this branch, that is a followup)
* Add some helpers and constants to the kernel/fde package

Originally all from @mvo5 