### PR TITLE
cmd/snap-preseed: address deadcode linter

### DIFF
--- a/cmd/snap-preseed/main.go
+++ b/cmd/snap-preseed/main.go
@@ -51,9 +51,10 @@ type options struct {
 }
 
 var (
-	osGetuid           = os.Getuid
-	Stdout   io.Writer = os.Stdout
-	Stderr   io.Writer = os.Stderr
+	osGetuid = os.Getuid
+	// unused currently, left in place for consistency for when it is needed
+	// Stdout   io.Writer = os.Stdout
+	Stderr io.Writer = os.Stderr
 
 	opts options
 )


### PR DESCRIPTION
See the failure in https://github.com/snapcore/snapd/actions/runs/2019403812.