### PR TITLE
release: sync 2.55 back with master

### DIFF
--- a/cmd/snap-update-ns/change_test.go
+++ b/cmd/snap-update-ns/change_test.go
@@ -22,6 +22,7 @@ package main_test
 import (
 	"errors"
 	"os"
+	"path/filepath"
 	"syscall"
 
 	. "gopkg.in/check.v1"
@@ -430,57 +431,67 @@ func (s *changeSuite) TestNeededChangesParallelInstancesInsideMount(c *C) {
 }
 
 func (s *changeSuite) TestRuntimeUsingSymlinks(c *C) {
+	dirs.SetRootDir(c.MkDir())
+	defer func() {
+		dirs.SetRootDir("")
+	}()
+
+	optDir := filepath.Join(dirs.GlobalRootDir, "/opt")
+	optFooRuntimeDir := filepath.Join(dirs.GlobalRootDir, "/opt/foo-runtime")
+	snapAppX1FooRuntimeDir := filepath.Join(dirs.GlobalRootDir, "/snap/app/x1/foo-runtime")
+	snapAppX2FooRuntimeDir := filepath.Join(dirs.GlobalRootDir, "/snap/app/x2/foo-runtime")
+	snapFooRuntimeX1OptFooRuntime := filepath.Join(dirs.GlobalRootDir, "/snap/foo-runtime/x1/opt/foo-runtime")
 
 	// We start with a runtime shared from one snap to another and then exposed
 	// to /opt with a symbolic link. This is the initial state of the
 	// application in version v1.
 	initial := &osutil.MountProfile{}
 	desiredV1 := &osutil.MountProfile{Entries: []osutil.MountEntry{
-		{Name: "none", Dir: "/opt/runtime", Type: "none", Options: []string{"x-snapd.kind=symlink", "x-snapd.symlink=/snap/app/x1/runtime", "x-snapd.origin=layout"}},
-		{Name: "/snap/runtime/x1/opt/runtime", Dir: "/snap/app/x1/runtime", Type: "none", Options: []string{"bind", "ro"}},
+		{Name: "none", Dir: optFooRuntimeDir, Type: "none", Options: []string{"x-snapd.kind=symlink", "x-snapd.symlink=" + snapAppX1FooRuntimeDir, "x-snapd.origin=layout"}},
+		{Name: snapFooRuntimeX1OptFooRuntime, Dir: snapAppX1FooRuntimeDir, Type: "none", Options: []string{"bind", "ro"}},
 	}}
 	// The changes we compute are trivial, simply perform each operation in order.
 	changes := update.NeededChanges(initial, desiredV1)
 	c.Assert(changes, DeepEquals, []*update.Change{
-		{Entry: osutil.MountEntry{Name: "none", Dir: "/opt/runtime", Type: "none", Options: []string{"x-snapd.kind=symlink", "x-snapd.symlink=/snap/app/x1/runtime", "x-snapd.origin=layout"}}, Action: update.Mount},
-		{Entry: osutil.MountEntry{Name: "/snap/runtime/x1/opt/runtime", Dir: "/snap/app/x1/runtime", Type: "none", Options: []string{"bind", "ro"}}, Action: update.Mount},
+		{Entry: osutil.MountEntry{Name: "none", Dir: optFooRuntimeDir, Type: "none", Options: []string{"x-snapd.kind=symlink", "x-snapd.symlink=" + snapAppX1FooRuntimeDir, "x-snapd.origin=layout"}}, Action: update.Mount},
+		{Entry: osutil.MountEntry{Name: snapFooRuntimeX1OptFooRuntime, Dir: snapAppX1FooRuntimeDir, Type: "none", Options: []string{"bind", "ro"}}, Action: update.Mount},
 	})
 	// After performing both changes we have a new synthesized entry. We get an
 	// extra writable mimic over /opt so that we can add our symlink. The
 	// content sharing into $SNAP is applied as expected since the snap ships
 	// the required mount point.
 	currentV1 := &osutil.MountProfile{Entries: []osutil.MountEntry{
-		{Name: "/snap/runtime/x1/opt/runtime", Dir: "/snap/app/x1/runtime", Type: "none", Options: []string{"bind", "ro"}},
-		{Name: "none", Dir: "/opt/runtime", Type: "none", Options: []string{"x-snapd.kind=symlink", "x-snapd.symlink=/snap/app/x1/runtime", "x-snapd.origin=layout"}},
-		{Name: "tmpfs", Dir: "/opt", Type: "tmpfs", Options: []string{"x-snapd.synthetic", "x-snapd.needed-by=/opt/runtime", "mode=0755", "uid=0", "gid=0"}},
+		{Name: snapFooRuntimeX1OptFooRuntime, Dir: snapAppX1FooRuntimeDir, Type: "none", Options: []string{"bind", "ro"}},
+		{Name: "none", Dir: optFooRuntimeDir, Type: "none", Options: []string{"x-snapd.kind=symlink", "x-snapd.symlink=" + snapAppX1FooRuntimeDir, "x-snapd.origin=layout"}},
+		{Name: "tmpfs", Dir: optDir, Type: "tmpfs", Options: []string{"x-snapd.synthetic", "x-snapd.needed-by=" + optFooRuntimeDir, "mode=0755", "uid=0", "gid=0"}},
 	}}
 	// We now proceed to replace app v1 with v2 which uses a bind mount instead
 	// of a symlink. First, let's start with the updated desired profile:
 	desiredV2 := &osutil.MountProfile{Entries: []osutil.MountEntry{
-		{Name: "/snap/app/x2/runtime", Dir: "/opt/runtime", Type: "none", Options: []string{"rbind", "rw", "x-snapd.origin=layout"}},
-		{Name: "/snap/runtime/x1/opt/runtime", Dir: "/snap/app/x2/runtime", Type: "none", Options: []string{"bind", "ro"}},
+		{Name: snapAppX2FooRuntimeDir, Dir: optFooRuntimeDir, Type: "none", Options: []string{"rbind", "rw", "x-snapd.origin=layout"}},
+		{Name: snapFooRuntimeX1OptFooRuntime, Dir: snapAppX2FooRuntimeDir, Type: "none", Options: []string{"bind", "ro"}},
 	}}
 
 	// Let's see what the update algorithm thinks.
 	changes = update.NeededChanges(currentV1, desiredV2)
 	c.Assert(changes, DeepEquals, []*update.Change{
 		// We are dropping the content interface bind mount because app changed revision
-		{Entry: osutil.MountEntry{Name: "/snap/runtime/x1/opt/runtime", Dir: "/snap/app/x1/runtime", Type: "none", Options: []string{"bind", "ro", "x-snapd.detach"}}, Action: update.Unmount},
+		{Entry: osutil.MountEntry{Name: snapFooRuntimeX1OptFooRuntime, Dir: snapAppX1FooRuntimeDir, Type: "none", Options: []string{"bind", "ro", "x-snapd.detach"}}, Action: update.Unmount},
 		// We are not keeping /opt, it's safer this way.
-		{Entry: osutil.MountEntry{Name: "none", Dir: "/opt/runtime", Type: "none", Options: []string{"x-snapd.kind=symlink", "x-snapd.symlink=/snap/app/x1/runtime", "x-snapd.origin=layout"}}, Action: update.Unmount},
+		{Entry: osutil.MountEntry{Name: "none", Dir: optFooRuntimeDir, Type: "none", Options: []string{"x-snapd.kind=symlink", "x-snapd.symlink=" + snapAppX1FooRuntimeDir, "x-snapd.origin=layout"}}, Action: update.Unmount},
 		// We are re-creating /opt from scratch.
-		{Entry: osutil.MountEntry{Name: "tmpfs", Dir: "/opt", Type: "tmpfs", Options: []string{"x-snapd.synthetic", "x-snapd.needed-by=/opt/runtime", "mode=0755", "uid=0", "gid=0"}}, Action: update.Keep},
-		// We are adding a new bind mount for /opt/runtime
-		{Entry: osutil.MountEntry{Name: "/snap/app/x2/runtime", Dir: "/opt/runtime", Type: "none", Options: []string{"rbind", "rw", "x-snapd.origin=layout"}}, Action: update.Mount},
+		{Entry: osutil.MountEntry{Name: "tmpfs", Dir: optDir, Type: "tmpfs", Options: []string{"x-snapd.synthetic", "x-snapd.needed-by=" + optFooRuntimeDir, "mode=0755", "uid=0", "gid=0"}}, Action: update.Keep},
+		// We are adding a new bind mount for /opt/foo-runtime
+		{Entry: osutil.MountEntry{Name: snapAppX2FooRuntimeDir, Dir: optFooRuntimeDir, Type: "none", Options: []string{"rbind", "rw", "x-snapd.origin=layout"}}, Action: update.Mount},
 		// We also adding the updated path of the content interface (for revision x2)
-		{Entry: osutil.MountEntry{Name: "/snap/runtime/x1/opt/runtime", Dir: "/snap/app/x2/runtime", Type: "none", Options: []string{"bind", "ro"}}, Action: update.Mount},
+		{Entry: osutil.MountEntry{Name: snapFooRuntimeX1OptFooRuntime, Dir: snapAppX2FooRuntimeDir, Type: "none", Options: []string{"bind", "ro"}}, Action: update.Mount},
 	})
 
 	// After performing all those changes this is the profile we observe.
 	currentV2 := &osutil.MountProfile{Entries: []osutil.MountEntry{
-		{Name: "tmpfs", Dir: "/opt", Type: "tmpfs", Options: []string{"x-snapd.synthetic", "x-snapd.needed-by=/opt/runtime", "mode=0755", "uid=0", "gid=0", "x-snapd.detach"}},
-		{Name: "/snap/app/x2/runtime", Dir: "/opt/runtime", Type: "none", Options: []string{"rbind", "rw", "x-snapd.origin=layout"}},
-		{Name: "/snap/runtime/x1/opt/runtime", Dir: "/snap/app/x2/runtime", Type: "none", Options: []string{"bind", "ro"}},
+		{Name: "tmpfs", Dir: optDir, Type: "tmpfs", Options: []string{"x-snapd.synthetic", "x-snapd.needed-by=" + optFooRuntimeDir, "mode=0755", "uid=0", "gid=0", "x-snapd.detach"}},
+		{Name: snapAppX2FooRuntimeDir, Dir: optFooRuntimeDir, Type: "none", Options: []string{"rbind", "rw", "x-snapd.origin=layout"}},
+		{Name: snapFooRuntimeX1OptFooRuntime, Dir: snapAppX2FooRuntimeDir, Type: "none", Options: []string{"bind", "ro"}},
 	}}
 
 	// So far so good. To trigger the issue we now revert or refresh to v1
@@ -489,15 +500,15 @@ func (s *changeSuite) TestRuntimeUsingSymlinks(c *C) {
 	changes = update.NeededChanges(currentV2, desiredV1)
 	c.Assert(changes, DeepEquals, []*update.Change{
 		// We are, again, dropping the content interface bind mount because app changed revision
-		{Entry: osutil.MountEntry{Name: "/snap/runtime/x1/opt/runtime", Dir: "/snap/app/x2/runtime", Type: "none", Options: []string{"bind", "ro", "x-snapd.detach"}}, Action: update.Unmount},
+		{Entry: osutil.MountEntry{Name: snapFooRuntimeX1OptFooRuntime, Dir: snapAppX2FooRuntimeDir, Type: "none", Options: []string{"bind", "ro", "x-snapd.detach"}}, Action: update.Unmount},
 		// We are also dropping the bind mount from /opt/runtime since we want a symlink instead
-		{Entry: osutil.MountEntry{Name: "/snap/app/x2/runtime", Dir: "/opt/runtime", Type: "none", Options: []string{"rbind", "rw", "x-snapd.origin=layout", "x-snapd.detach"}}, Action: update.Unmount},
+		{Entry: osutil.MountEntry{Name: snapAppX2FooRuntimeDir, Dir: optFooRuntimeDir, Type: "none", Options: []string{"rbind", "rw", "x-snapd.origin=layout", "x-snapd.detach"}}, Action: update.Unmount},
 		// Again, recreate the tmpfs.
-		{Entry: osutil.MountEntry{Name: "tmpfs", Dir: "/opt", Type: "tmpfs", Options: []string{"x-snapd.synthetic", "x-snapd.needed-by=/opt/runtime", "mode=0755", "uid=0", "gid=0", "x-snapd.detach"}}, Action: update.Keep},
-		// We are providing a symlink /opt/runtime -> to $SNAP/runtime.
-		{Entry: osutil.MountEntry{Name: "none", Dir: "/opt/runtime", Type: "none", Options: []string{"x-snapd.kind=symlink", "x-snapd.symlink=/snap/app/x1/runtime", "x-snapd.origin=layout"}}, Action: update.Mount},
-		// We are bind mounting the runtime from another snap into $SNAP/runtime
-		{Entry: osutil.MountEntry{Name: "/snap/runtime/x1/opt/runtime", Dir: "/snap/app/x1/runtime", Type: "none", Options: []string{"bind", "ro"}}, Action: update.Mount},
+		{Entry: osutil.MountEntry{Name: "tmpfs", Dir: optDir, Type: "tmpfs", Options: []string{"x-snapd.synthetic", "x-snapd.needed-by=" + optFooRuntimeDir, "mode=0755", "uid=0", "gid=0", "x-snapd.detach"}}, Action: update.Keep},
+		// We are providing a symlink /opt/foo-runtime -> to $SNAP/foo-runtime.
+		{Entry: osutil.MountEntry{Name: "none", Dir: optFooRuntimeDir, Type: "none", Options: []string{"x-snapd.kind=symlink", "x-snapd.symlink=" + snapAppX1FooRuntimeDir, "x-snapd.origin=layout"}}, Action: update.Mount},
+		// We are bind mounting the runtime from another snap into $SNAP/foo-runtime
+		{Entry: osutil.MountEntry{Name: snapFooRuntimeX1OptFooRuntime, Dir: snapAppX1FooRuntimeDir, Type: "none", Options: []string{"bind", "ro"}}, Action: update.Mount},
 	})
 
 	// The problem is that the tmpfs contains leftovers from the things we

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -11,7 +11,7 @@ pkgdesc="Service and tools for management of snap packages."
 depends=('squashfs-tools' 'libseccomp' 'libsystemd' 'apparmor')
 optdepends=('bash-completion: bash completion support'
             'xdg-desktop-portal: desktop integration')
-pkgver=2.55
+pkgver=2.55.2
 pkgrel=1
 arch=('x86_64' 'i686' 'armv7h' 'aarch64')
 url="https://github.com/snapcore/snapd"

--- a/packaging/debian-sid/changelog
+++ b/packaging/debian-sid/changelog
@@ -1,3 +1,18 @@
+snapd (2.55.2-1) unstable; urgency=medium
+
+  * New upstream release, LP: #1965808
+    - cmd/snap-update-ns: actually use entirely non-existent dirs
+
+ -- Ian Johnson <ian.johnson@canonical.com>  Mon, 21 Mar 2022 22:16:54 -0500
+
+snapd (2.55.1-1) unstable; urgency=medium
+
+  * New upstream release, LP: #1965808
+    - cmd/snap-update-ns/change_test.go: use non-exist name foo-runtime
+      instead
+
+ -- Ian Johnson <ian.johnson@canonical.com>  Mon, 21 Mar 2022 20:45:56 -0500
+
 snapd (2.55-1) unstable; urgency=medium
 
   * New upstream release, LP: #1965808

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -102,7 +102,7 @@
 %endif
 
 Name:           snapd
-Version:        2.55
+Version:        2.55.2
 Release:        0%{?dist}
 Summary:        A transactional software package manager
 License:        GPLv3
@@ -980,6 +980,15 @@ fi
 
 
 %changelog
+* Mon Mar 21 2022 Ian Johnson <ian.johnson@canonical.com>
+- New upstream release 2.55.2
+ - cmd/snap-update-ns: actually use entirely non-existent dirs
+
+* Mon Mar 21 2022 Ian Johnson <ian.johnson@canonical.com>
+- New upstream release 2.55.1
+ - cmd/snap-update-ns/change_test.go: use non-exist name foo-runtime
+   instead
+
 * Mon Mar 21 2022 Ian Johnson <ian.johnson@canonical.com>
 - New upstream release 2.55
  - kernel/fde: add PartitionName to various structs

--- a/packaging/opensuse/snapd.changes
+++ b/packaging/opensuse/snapd.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Tue Mar 22 03:16:54 UTC 2022 - ian.johnson@canonical.com
+
+- Update to upstream release 2.55.2
+
+-------------------------------------------------------------------
+Tue Mar 22 01:45:56 UTC 2022 - ian.johnson@canonical.com
+
+- Update to upstream release 2.55.1
+
+-------------------------------------------------------------------
 Mon Mar 21 20:55:16 UTC 2022 - ian.johnson@canonical.com
 
 - Update to upstream release 2.55

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -81,7 +81,7 @@
 
 
 Name:           snapd
-Version:        2.55
+Version:        2.55.2
 Release:        0
 Summary:        Tools enabling systems to work with .snap files
 License:        GPL-3.0

--- a/packaging/ubuntu-14.04/changelog
+++ b/packaging/ubuntu-14.04/changelog
@@ -1,3 +1,18 @@
+snapd (2.55.2~14.04) trusty; urgency=medium
+
+  * New upstream release, LP: #1965808
+    - cmd/snap-update-ns: actually use entirely non-existent dirs
+
+ -- Ian Johnson <ian.johnson@canonical.com>  Mon, 21 Mar 2022 22:16:54 -0500
+
+snapd (2.55.1~14.04) trusty; urgency=medium
+
+  * New upstream release, LP: #1965808
+    - cmd/snap-update-ns/change_test.go: use non-exist name foo-runtime
+      instead
+
+ -- Ian Johnson <ian.johnson@canonical.com>  Mon, 21 Mar 2022 20:45:56 -0500
+
 snapd (2.55~14.04) trusty; urgency=medium
 
   * New upstream release, LP: #1965808

--- a/packaging/ubuntu-16.04/changelog
+++ b/packaging/ubuntu-16.04/changelog
@@ -1,3 +1,18 @@
+snapd (2.55.2) xenial; urgency=medium
+
+  * New upstream release, LP: #1965808
+    - cmd/snap-update-ns: actually use entirely non-existent dirs
+
+ -- Ian Johnson <ian.johnson@canonical.com>  Mon, 21 Mar 2022 22:16:54 -0500
+
+snapd (2.55.1) xenial; urgency=medium
+
+  * New upstream release, LP: #1965808
+    - cmd/snap-update-ns/change_test.go: use non-exist name foo-runtime
+      instead
+
+ -- Ian Johnson <ian.johnson@canonical.com>  Mon, 21 Mar 2022 20:45:56 -0500
+
 snapd (2.55) xenial; urgency=medium
 
   * New upstream release, LP: #1965808


### PR DESCRIPTION
Unfortunately this PR has a few extra things in it beyond just the packaging changes, but luckily it's just these 2 PR's:
- [x] https://github.com/snapcore/snapd/pull/11552 (failed attempt 1 to fix LP builders)
- [x] https://github.com/snapcore/snapd/pull/11553 (successful attempt 2 to fix LP builders)

As well as the changelog stuff for 2.55.2 and 2.55.1. 

Before reviewing this, please also go back and review the changelog in https://github.com/snapcore/snapd/pull/11550 which is the very large changelog between 2.54.4 and 2.55.