### PR TITLE
sandbox: improve error message from `ProbeCgroupVersion()`

### DIFF
--- a/sandbox/cgroup/cgroup.go
+++ b/sandbox/cgroup/cgroup.go
@@ -101,7 +101,7 @@ func probeCgroupVersion() (version int, err error) {
 	cgroupMount := filepath.Join(rootPath, cgroupMountPoint)
 	typ, err := fsTypeForPath(cgroupMount)
 	if err != nil {
-		return Unknown, fmt.Errorf("cannot determine filesystem type: %v", err)
+		return Unknown, fmt.Errorf("cannot determine cgroup version: %v", err)
 	}
 	if typ == cgroup2SuperMagic {
 		return V2, nil

--- a/sandbox/cgroup/cgroup_test.go
+++ b/sandbox/cgroup/cgroup_test.go
@@ -93,7 +93,7 @@ func (s *cgroupSuite) TestProbeVersionUnhappy(c *C) {
 	})
 	defer restore()
 	v, err := cgroup.ProbeCgroupVersion()
-	c.Assert(err, ErrorMatches, "cannot determine filesystem type: statfs fail")
+	c.Assert(err, ErrorMatches, "cannot determine cgroup version: statfs fail")
 	c.Assert(v, Equals, cgroup.Unknown)
 }
 


### PR DESCRIPTION
During the review of #11534 it was noticed that the exiting error
message if the cgroup version cannot be detected is not very helpful:
```
cannot determine filesystem type: no such file or directory
```
instead the error should give useful context that it tried to
detect the cgroup version.

This commit fixes this and moves to:
```
cannot determine cgroup version: no such file or directory
```
