### PR TITLE
tests: fix restore of the BUILD_DIR in failover test on uc18

### DIFF
--- a/tests/core/failover/task.yaml
+++ b/tests/core/failover/task.yaml
@@ -42,7 +42,6 @@ prepare: |
         exit 0
     fi
 
-    mkdir -p "$BUILD_DIR"
     if [ "$TRUST_TEST_KEYS" = "false" ]; then
         echo "This test needs test keys to be trusted"
         exit
@@ -55,8 +54,9 @@ prepare: |
     snap ack "$TESTSLIB/assertions/developer1.account-key"
     #shellcheck source=tests/lib/store.sh
     . "$TESTSLIB"/store.sh
-
     setup_fake_store "$BLOB_DIR"
+
+    mkdir -p "$BUILD_DIR"
 
 restore: |
     if [ "$TARGET_SNAP" = "kernel" ] && os.query is-arm; then
@@ -71,6 +71,7 @@ restore: |
     #shellcheck source=tests/lib/store.sh
     . "$TESTSLIB"/store.sh
     teardown_fake_store "$BLOB_DIR"
+
     rm -rf "$BUILD_DIR"
 
 debug: |


### PR DESCRIPTION
The idea is to remove the $BUILD_DIR always when it is created.
With kernel snap and TRUST_TEST_KEYS = False it was being created but
not deleted making fail the restore invariant checks.

This produces that the whole test suite fails.
