### PR TITLE
tests: adapt nested tests to use tests.nested tool

### DIFF
--- a/tests/nested/core/core20-fault-inject/task.yaml
+++ b/tests/nested/core/core20-fault-inject/task.yaml
@@ -7,9 +7,6 @@ details: |
 systems: [ubuntu-20.04-64]
 
 execute: |
-    #shellcheck source=tests/lib/nested.sh
-    . "$TESTSLIB/nested.sh"
-
     # automatically cleaned up in restore
     echo "Inject a reboot on link-snap"
     cat <<EOF > fault-inject.conf
@@ -27,7 +24,7 @@ execute: |
     tests.nested exec "sudo systemctl daemon-reload"
     tests.nested exec "sudo systemctl restart snapd.service"
 
-    boot_id="$( nested_get_boot_id )"
+    boot_id="$(tests.nested boot-id)"
     echo "We should observe a reboot being triggered when linking the snap"
     change_id="$(tests.nested exec 'sudo snap install --no-wait test-snapd-sh')"
 

--- a/tests/nested/manual/core20-remodel/task.yaml
+++ b/tests/nested/manual/core20-remodel/task.yaml
@@ -16,7 +16,7 @@ prepare: |
 execute: |
     # shellcheck source=tests/lib/nested.sh
     . "$TESTSLIB/nested.sh"
-    boot_id="$( nested_get_boot_id )"
+    boot_id="$(tests.nested boot-id)"
     tests.nested exec snap model |MATCH 'model +my-model$'
     # XXX: recovery system label is based on a date; we may end up with a
     # different label if the remodel runs around midnight; the label will
@@ -24,12 +24,12 @@ execute: |
     label_base=$(tests.nested exec "date '+%Y%m%d'")
 
     # wait until device is initialized and has a serial
-    nested_wait_for_device_initialized_change
+    tests.nested wait-for device-initialized
 
     echo "Refresh model assertion to revision 2"
-    nested_copy "$TESTSLIB/assertions/valid-for-testing-pc-revno-2-20.model"
+    tests.nested copy "$TESTSLIB/assertions/valid-for-testing-pc-revno-2-20.model"
     REMOTE_CHG_ID="$(tests.nested exec sudo snap remodel --no-wait valid-for-testing-pc-revno-2-20.model)"
-    nested_wait_for_reboot "${boot_id}"
+    tests.nested wait-for reboot "${boot_id}"
     tests.nested exec sudo snap watch "${REMOTE_CHG_ID}"
 
     echo "Verify the system is back in run mode"
@@ -59,12 +59,12 @@ execute: |
     # snaps directory
     tests.nested exec find /run/mnt/ubuntu-seed/snaps -name 'test-snapd-tools-core20_*.snap' | MATCH 'test-snapd-tools-core20'
 
-    boot_id="$( nested_get_boot_id )"
+    boot_id="$(tests.nested boot-id)"
 
     echo "Refresh model assertion to revision 3"
-    nested_copy "$TESTSLIB/assertions/valid-for-testing-pc-revno-3-20.model"
+    tests.nested copy "$TESTSLIB/assertions/valid-for-testing-pc-revno-3-20.model"
     REMOTE_CHG_ID="$(tests.nested exec sudo snap remodel --no-wait valid-for-testing-pc-revno-3-20.model)"
-    nested_wait_for_reboot "${boot_id}"
+    tests.nested wait-for reboot "${boot_id}"
     tests.nested exec sudo snap watch "${REMOTE_CHG_ID}"
 
     echo "Verify the model"
@@ -86,20 +86,21 @@ execute: |
     # because the system is considered 'seeded' we are able to switch to the
     # recover mode
     echo "Switch to recover mode of new seed system"
-    boot_id="$( nested_get_boot_id )"
+    boot_id="$(tests.nested boot-id)"
     tests.nested exec sudo snap reboot --recover "${revno3_label}" | MATCH 'Reboot into ".*" "recover" mode'
-    nested_wait_for_reboot "${boot_id}"
+    tests.nested wait-for reboot "${boot_id}"
     # Verify we are in recover mode with the expected system label
     tests.nested exec 'sudo cat /proc/cmdline' | MATCH "snapd_recovery_mode=recover snapd_recovery_system=${revno3_label} "
+
     # we are in recover mode, so tools need to be set up again
     nested_prepare_tools
 
-    boot_id="$( nested_get_boot_id )"
+    boot_id="$(tests.nested boot-id)"
     echo "And back to run mode"
-    nested_wait_for_snap_command
+    tests.nested wait-for snap-command
     tests.nested exec "sudo snap wait system seed.loaded"
     tests.nested exec sudo snap reboot --run | MATCH 'Reboot into "run" mode.'
-    nested_wait_for_reboot "${boot_id}"
+    tests.nested wait-for reboot "${boot_id}"
     tests.nested exec 'sudo cat /proc/cmdline' | MATCH "snapd_recovery_mode=run "
 
     echo "Verify all recovery systems are listed"

--- a/tests/nested/manual/core20-to-core22/task.yaml
+++ b/tests/nested/manual/core20-to-core22/task.yaml
@@ -13,20 +13,23 @@ environment:
   # after remodel completes
   NESTED_ENABLE_TPM: false
   NESTED_ENABLE_SECURE_BOOT: false
-  NESTED_BUILD_SNAPD_FROM_CURRENT: false
+  # we need pc/pc-kernel/core20 from the store, such that they get properly
+  # refreshed when doing a UC20 to UC22 remodel
+  NESTED_REPACK_KERNEL_SNAP: false
+  NESTED_REPACK_GADGET_SNAP: false
+  NESTED_REPACK_BASE_SNAP: false
 
 prepare: |
-    # we need pc/pc-kernel/core20 from the store, such that they get properly
-    # refreshed when doing a UC20 to UC22 remodel
-    "$TESTSTOOLS"/snaps-state repack_snapd_deb_into_snap snapd "$PWD/extra-snaps"
     tests.nested build-image core
     tests.nested create-vm core
 
 execute: |
     # shellcheck source=tests/lib/nested.sh
     . "$TESTSLIB/nested.sh"
-    boot_id="$( nested_get_boot_id )"
+
+    boot_id="$(tests.nested boot-id)"
     tests.nested exec snap model |MATCH 'model +my-model$'
+
     # XXX: recovery system label is based on a date; we may end up with a
     # different label if the remodel runs around midnight; the label will
     # conflict with an existing system label
@@ -34,10 +37,10 @@ execute: |
     label="${label_base}-1"
 
     # wait until device is initialized and has a serial
-    nested_wait_for_device_initialized_change
+    tests.nested wait-for device-initialized
 
     echo "Remodel to UC22"
-    nested_copy "$TESTSLIB/assertions/valid-for-testing-pc-22-from-20.model"
+    tests.nested copy "$TESTSLIB/assertions/valid-for-testing-pc-22-from-20.model"
     REMOTE_CHG_ID="$(tests.nested exec sudo snap remodel --no-wait valid-for-testing-pc-22-from-20.model)"
     test -n "$REMOTE_CHG_ID"
     # very long retry wait for the change to be in stable state, once it's
@@ -48,7 +51,7 @@ execute: |
 
     # we should have rebooted a couple of times (at least twice for the recovery
     # system and the base), so boot-id should be different
-    current_boot_id="$( nested_get_boot_id )"
+    current_boot_id="$(tests.nested boot-id)"
     test "$boot_id" != "$current_boot_id"
 
     tests.nested exec sudo snap list pc | MATCH " 22/edge "
@@ -61,21 +64,22 @@ execute: |
     NOMATCH core20 < model-from-seed.model
 
     echo "Verify that UC22 recover system is usable"
-    boot_id="$( nested_get_boot_id )"
+    boot_id="$(tests.nested boot-id)"
     tests.nested exec sudo snap reboot --recover "${label}" | MATCH 'Reboot into ".*" "recover" mode'
-    nested_wait_for_reboot "${boot_id}"
+    tests.nested wait-for reboot "${boot_id}"
     # Verify we are in recover mode with the expected system label
     tests.nested exec 'sudo cat /proc/cmdline' | MATCH "snapd_recovery_mode=recover snapd_recovery_system=${label} "
+
     # we are in recover mode, so tools need to be set up again
     nested_prepare_tools
 
-    nested_wait_for_snap_command
+    tests.nested wait-for snap-command
     # there should be no core20 since the seed is UC22
     tests.nested exec sudo snap list | NOMATCH core20
 
-    boot_id="$( nested_get_boot_id )"
+    boot_id="$(tests.nested boot-id)"
     echo "And back to run mode"
     tests.nested exec "sudo snap wait system seed.loaded"
     tests.nested exec sudo snap reboot --run | MATCH 'Reboot into "run" mode.'
-    nested_wait_for_reboot "${boot_id}"
+    tests.nested wait-for reboot "${boot_id}"
     tests.nested exec 'sudo cat /proc/cmdline' | MATCH "snapd_recovery_mode=run "


### PR DESCRIPTION
Update some tests to use the new tool and also the new variables to skip kernel/gadget/base repack
