### PR TITLE
tests/main/uc20-create-partitions: update the test for new Go versions

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -563,6 +563,9 @@ prepare_project() {
     # Build the tool for signing model assertions
     go install ./tests/lib/gendeveloper1model
 
+    # and the U20 create partitions wrapper
+    go install ./tests/lib/uc20-create-partitions
+
     # On core systems, the journal service is configured once the final core system
     # is created and booted what is done during the first test suite preparation
     if os.query is-classic; then

--- a/tests/main/uc20-create-partitions-encrypt/task.yaml
+++ b/tests/main/uc20-create-partitions-encrypt/task.yaml
@@ -70,7 +70,6 @@ restore: |
     apt autoremove -y cryptsetup
 
     rm -Rf /run/mnt
-    rm -f "$GOHOME"/bin/uc20-create-partitions
 
 debug: |
     cat /proc/partitions
@@ -103,7 +102,6 @@ execute: |
     kerneldir=""
 
     echo "Run the snap-bootstrap tool"
-    go get ../../lib/uc20-create-partitions
     uc20-create-partitions \
         --encrypt \
         ./gadget-dir "$kerneldir" "$LOOP"

--- a/tests/main/uc20-create-partitions-reinstall/task.yaml
+++ b/tests/main/uc20-create-partitions-reinstall/task.yaml
@@ -48,7 +48,6 @@ restore: |
         losetup -d "$LOOP"
         losetup -l | NOMATCH "$LOOP"
     fi
-    rm -f "$GOHOME"/bin/uc20-create-partitions
 
 debug: |
     cat /proc/partitions
@@ -67,7 +66,6 @@ execute: |
     udevadm info --query=property "${LOOP}p2" | grep ID_FS_TYPE ||:
 
     echo "Run the snap-bootstrap tool in auto-detect mode"
-    go get ../../lib/uc20-create-partitions
     # TODO:UC20: make kernel-dir non-empty once we have a gadget that has a
     #            "$kernel:" style ref in the meta/gadget.yaml
     kerneldir=""

--- a/tests/main/uc20-create-partitions/task.yaml
+++ b/tests/main/uc20-create-partitions/task.yaml
@@ -58,7 +58,6 @@ restore: |
         losetup -d "$LOOP"
         losetup -l | NOMATCH "$LOOP"
     fi
-    rm -f "$GOHOME"/bin/uc20-create-partitions
 
 debug: |
     cat /proc/partitions
@@ -74,7 +73,6 @@ execute: |
     LOOP="$(cat loop.txt)"
 
     echo "Run the snap-bootstrap tool"
-    go get ../../lib/uc20-create-partitions
     # TODO:UC20: make kernel-dir non-empty once we have a gadget that has a
     #            "$kernel:" style ref in the meta/gadget.yaml
     kerneldir=""


### PR DESCRIPTION
Which fails on 22.04:

```
Run the snap-bootstrap tool
+ go get ../../lib/uc20-create-partitions
+ uc20-create-partitions --encrypt ./gadget-dir '' /dev/loop1
/bin/bash: line 113: uc20-create-partitions: command not found
-----
```
