### PR TITLE
systemd: remove the systemctl stop timeout handling

### DIFF
--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -1104,11 +1104,6 @@ func (s *systemd) Stop(serviceNames []string) error {
 		return errProgress
 	}
 
-	// No error, but not all units have stopped
-	if len(serviceNames) != 0 {
-		return &Timeout{action: "stop", services: serviceNames}
-	}
-
 	// Stopped and no error
 	return nil
 }
@@ -1173,23 +1168,6 @@ func (e *Error) Error() string {
 		return fmt.Sprintf("systemctl command %v failed with: %v%s", e.cmd, e.runErr, msg)
 	}
 	return fmt.Sprintf("systemctl command %v failed with exit status %d%s", e.cmd, e.exitCode, msg)
-}
-
-// Timeout is returned if the systemd action failed to reach the
-// expected state in a reasonable amount of time
-type Timeout struct {
-	action   string
-	services []string
-}
-
-func (e *Timeout) Error() string {
-	return fmt.Sprintf("%v failed to %v: timeout", strutil.Quoted(e.services), e.action)
-}
-
-// IsTimeout checks whether the given error is a Timeout
-func IsTimeout(err error) bool {
-	_, isTimeout := err.(*Timeout)
-	return isTimeout
 }
 
 func (l Log) parseLogRawMessageString(key string, sliceHandler func([]string) (string, error)) (string, error) {

--- a/usersession/agent/export_test.go
+++ b/usersession/agent/export_test.go
@@ -21,7 +21,6 @@ package agent
 
 import (
 	"syscall"
-	"time"
 )
 
 var (
@@ -30,14 +29,6 @@ var (
 	PendingRefreshNotificationCmd = pendingRefreshNotificationCmd
 	FinishRefreshNotificationCmd  = finishRefreshNotificationCmd
 )
-
-func MockStopTimeouts(kill time.Duration) (restore func()) {
-	oldKillWait := killWait
-	killWait = kill
-	return func() {
-		killWait = oldKillWait
-	}
-}
 
 func MockUcred(ucred *syscall.Ucred, err error) (restore func()) {
 	old := sysGetsockoptUcred

--- a/usersession/agent/rest_api.go
+++ b/usersession/agent/rest_api.go
@@ -84,10 +84,6 @@ type serviceInstruction struct {
 	Services []string `json:"services"`
 }
 
-var (
-	killWait = 5 * time.Second
-)
-
 func serviceStart(inst *serviceInstruction, sysd systemd.Systemd) Response {
 	// Refuse to start non-snap services
 	for _, service := range inst.Services {

--- a/usersession/agent/rest_api_test.go
+++ b/usersession/agent/rest_api_test.go
@@ -22,6 +22,7 @@ package agent_test
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http/httptest"
@@ -321,7 +322,7 @@ func (s *restSuite) TestServicesStopNonSnap(c *C) {
 	c.Check(s.sysdLog, HasLen, 0)
 }
 
-func (s *restSuite) TestServicesStopReportsTimeout(c *C) {
+func (s *restSuite) TestServicesStopReportsError(c *C) {
 	var sysdLog [][]string
 	restore := systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
 		// Ignore "show" spam
@@ -329,7 +330,7 @@ func (s *restSuite) TestServicesStopReportsTimeout(c *C) {
 			sysdLog = append(sysdLog, cmd)
 		}
 		if cmd[len(cmd)-1] == "snap.bar.service" {
-			return []byte("ActiveState=active\n"), nil
+			return []byte("ActiveState=active\n"), errors.New("mock systemctl error")
 		}
 		return []byte("ActiveState=inactive\n"), nil
 	})
@@ -350,7 +351,7 @@ func (s *restSuite) TestServicesStopReportsTimeout(c *C) {
 		"kind":    "service-control",
 		"value": map[string]interface{}{
 			"stop-errors": map[string]interface{}{
-				"snap.bar.service": `"snap.bar.service" failed to stop: timeout`,
+				"snap.bar.service": "mock systemctl error",
 			},
 		},
 	})

--- a/usersession/agent/rest_api_test.go
+++ b/usersession/agent/rest_api_test.go
@@ -66,8 +66,6 @@ func (s *restSuite) SetUpTest(c *C) {
 	s.AddCleanup(restore)
 	restore = systemd.MockStopDelays(2*time.Millisecond, 4*time.Millisecond)
 	s.AddCleanup(restore)
-	restore = agent.MockStopTimeouts(time.Millisecond)
-	s.AddCleanup(restore)
 
 	var err error
 	s.notify, err = notificationtest.NewFdoServer()

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -20,6 +20,7 @@
 package wrappers_test
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -2060,8 +2061,9 @@ func (s *servicesTestSuite) TestRemoveSnapPackageFallbackToKill(c *C) {
 		// StopServices generates
 		if cmd[0] != "show" {
 			sysdLog = append(sysdLog, cmd)
+			return nil, nil
 		}
-		return []byte("ActiveState=active\n"), nil
+		return []byte("ActiveState=active\n"), errors.New("mock systemctl error")
 	})
 	defer r()
 
@@ -2082,13 +2084,10 @@ apps:
 	svcFName := "snap.wat.wat.service"
 
 	err = wrappers.StopServices(info.Services(), nil, "", progress.Null, s.perfTimings)
-	c.Assert(err, IsNil)
+	c.Assert(err, ErrorMatches, "mock systemctl error")
 
 	c.Check(sysdLog, DeepEquals, [][]string{
 		{"stop", svcFName},
-		// check kill invocations
-		{"kill", svcFName, "-s", "TERM", "--kill-who=all"},
-		{"kill", svcFName, "-s", "KILL", "--kill-who=all"},
 	})
 }
 
@@ -2919,19 +2918,17 @@ func (s *servicesTestSuite) TestStartSnapMultiServicesFailStartCleanupWithSocket
 	err := wrappers.StartServices(apps, nil, flags, &progress.Null, s.perfTimings)
 	c.Assert(err, ErrorMatches, "failed")
 	c.Logf("sysdlog: %v", sysdLog)
-	c.Assert(sysdLog, HasLen, 16, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
+	c.Assert(sysdLog, HasLen, 14, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
 	c.Check(sysdLog, DeepEquals, [][]string{
 		{"--no-reload", "enable", svc2SocketName, svc3SocketName, svc1Name},
 		{"daemon-reload"},
 		{"start", svc2SocketName},
 		{"start", svc3SocketName}, // start failed, what follows is the cleanup
-		{"stop", svc3SocketName},
+		{"stop", svc3SocketName, svc3Name},
 		{"show", "--property=ActiveState", svc3SocketName},
-		{"stop", svc3Name},
 		{"show", "--property=ActiveState", svc3Name},
-		{"stop", svc2SocketName},
+		{"stop", svc2SocketName, svc2Name},
 		{"show", "--property=ActiveState", svc2SocketName},
-		{"stop", svc2Name},
 		{"show", "--property=ActiveState", svc2Name},
 		{"stop", svc1Name},
 		{"show", "--property=ActiveState", svc1Name},
@@ -2988,20 +2985,18 @@ func (s *servicesTestSuite) TestStartSnapMultiServicesFailStartNoEnableNoDisable
 	err := wrappers.StartServices(apps, nil, flags, &progress.Null, s.perfTimings)
 	c.Assert(err, ErrorMatches, "failed")
 	c.Logf("sysdlog: %v", sysdLog)
-	c.Assert(sysdLog, HasLen, 17, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
+	c.Assert(sysdLog, HasLen, 15, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
 	c.Check(sysdLog, DeepEquals, [][]string{
 		{"--no-reload", "enable", svc2SocketName, svc3SocketName},
 		{"daemon-reload"},
 		{"start", svc2SocketName},
 		{"start", svc3SocketName},
 		{"start", svc1Name}, // start failed, what follows is the cleanup
-		{"stop", svc3SocketName},
+		{"stop", svc3SocketName, svc3Name},
 		{"show", "--property=ActiveState", svc3SocketName},
-		{"stop", svc3Name},
 		{"show", "--property=ActiveState", svc3Name},
-		{"stop", svc2SocketName},
+		{"stop", svc2SocketName, svc2Name},
 		{"show", "--property=ActiveState", svc2SocketName},
-		{"stop", svc2Name},
 		{"show", "--property=ActiveState", svc2Name},
 		{"stop", svc1Name},
 		{"show", "--property=ActiveState", svc1Name},
@@ -3339,8 +3334,6 @@ apps:
 			c.Check(s.sysdLog, DeepEquals, [][]string{
 				{"stop", filepath.Base(survivorFile)},
 				{"show", "--property=ActiveState", "snap.survive-snap.srv.service"},
-				{"kill", filepath.Base(survivorFile), "-s", "TERM", "--kill-who=all"},
-				{"kill", filepath.Base(survivorFile), "-s", "KILL", "--kill-who=all"},
 			})
 		default:
 			panic("not reached")
@@ -3448,14 +3441,13 @@ func (s *servicesTestSuite) TestStartSnapTimerCleanup(c *C) {
 	flags := &wrappers.StartServicesFlags{Enable: true}
 	err := wrappers.StartServices(apps, nil, flags, &progress.Null, s.perfTimings)
 	c.Assert(err, ErrorMatches, "failed")
-	c.Assert(sysdLog, HasLen, 11, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
+	c.Assert(sysdLog, HasLen, 10, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
 	c.Check(sysdLog, DeepEquals, [][]string{
 		{"--no-reload", "enable", svc2Timer, svc1Name},
 		{"daemon-reload"},
 		{"start", svc2Timer}, // this call fails
-		{"stop", svc2Timer},
+		{"stop", svc2Timer, svc2Name},
 		{"show", "--property=ActiveState", svc2Timer},
-		{"stop", svc2Name},
 		{"show", "--property=ActiveState", svc2Name},
 		{"stop", svc1Name},
 		{"show", "--property=ActiveState", svc1Name},


### PR DESCRIPTION
This patch relates to:
https://github.com/snapcore/snapd/pull/11340

In the process of improving the systemd stop code to better track
the progress of stopping units, we also removed the snapd concept
of a timeout period in order to exclusively rely on
'systemctl stop' to return an error after its internal stop
escalation process failed.

We therefore no longer can produce a 'Timeout' error.

This patch removes code in the code base that used to deal
with this 'Timeout' condition.

The idea behind this patch is that we trust 'systemctl stop'
to tell us if it failed to stop a unit within its configured
timeout, and if it fails, there is nothing more we can do but
to return an error.

Signed-off-by: Fred Lotter <fred.lotter@canonical.com>

