### PR TITLE
tests/core/gadget-update-pc: add mbr/dos variant

### DIFF
--- a/tests/core/gadget-update-pc/task.yaml
+++ b/tests/core/gadget-update-pc/task.yaml
@@ -5,6 +5,8 @@ environment:
     # snap-id of 'pc' gadget snap
     PC_SNAP_ID: UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH
     START_REVISION: 1000
+    CORE_GADGET_SCHEMA/gpt: "gpt"
+    CORE_GADGET_SCHEMA/mbr: "mbr"
 
 prepare: |
     # external backends do not enable test keys
@@ -177,7 +179,14 @@ execute: |
         # using foo.img from x2
         szfoo=$(stat -c '%s' foo-x2.img)
         # a raw content was written
-        dd if='/dev/disk/by-partlabel/BIOS\x20Boot' skip="$szimg" bs=1 count="$szfoo" of=foo-written.img
+        if [ "$CORE_GADGET_SCHEMA" = "gpt" ]; then
+            # on GPT can use by-partlabel
+            dd if='/dev/disk/by-partlabel/BIOS\x20Boot' skip="$szimg" bs=1 count="$szfoo" of=foo-written.img
+        else
+            # on MBR no partition labels and BIOS Boot does not have a 
+            # filesystem so we just assume that it's the first partition
+            dd if='/dev/sda1' skip="$szimg" bs=1 count="$szfoo" of=foo-written.img
+        fi
         test "$(cat foo-written.img)" = 'this is foo-x2'
 
         if os.query is-core20; then
@@ -221,7 +230,15 @@ execute: |
         # using foo.img from x3
         szfoo=$(stat -c '%s' foo-x3.img)
         # a raw content was written
-        dd if='/dev/disk/by-partlabel/BIOS\x20Boot' skip="$szimg" bs=1 count="$szfoo" of=foo-updated-written.img
+        if [ "$CORE_GADGET_SCHEMA" = "gpt" ]; then
+            # on GPT can use by-partlabel
+            dd if='/dev/disk/by-partlabel/BIOS\x20Boot' skip="$szimg" bs=1 count="$szfoo" of=foo-updated-written.img
+        else
+            # on MBR no partition labels and BIOS Boot does not have a 
+            # filesystem so we just assume that it's the first partition
+            dd if='/dev/sda1' skip="$szimg" bs=1 count="$szfoo" of=foo-updated-written.img
+        fi
+        
         test "$(cat foo-updated-written.img)" = 'this is updated foo-x3'
 
         if os.query is-core20; then

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -955,6 +955,19 @@ EOF
         snap download --basename=pc --channel="20/$GADGET_CHANNEL" pc
         test -e pc.snap
         unsquashfs -d pc-gadget pc.snap
+
+        # change the schema to DOS if that env var is set
+        if [ "${CORE_GADGET_SCHEMA:-}" != "" ]; then
+            if os.query is-core20 || os.query is-core22; then
+                # to use DOS on UC20+, we cannot have ubuntu-save otherwise we 
+                # have too many partitions for DOS, so remove ubuntu-save from
+                # the gadget.yaml since we can't use encryption on GCE anyways
+                # and the tests using DOS are mainly about gadget asset updates
+                # anyways
+                sed -i "/name: ubuntu-save/,+4 d" pc-gadget/meta/gadget.yaml
+            fi
+            sed -i -e "s@bootloader: grub@schema: $CORE_GADGET_SCHEMA\n    bootloader: grub@g" pc-gadget/meta/gadget.yaml
+        fi
         
         # TODO: it would be desirable when we need to do in-depth debugging of
         # UC20 runs in google to have snapd.debug=1 always on the kernel command


### PR DESCRIPTION
Test that we can update gadget assets when using DOS schema as well. This
requires some tweaking in prepare.sh, namely to add the schema, but also on
UC20 to drop the ubuntu-save partition since on DOS we can only have 4
partitions.