### PR TITLE
quota: detect/error if cpu-set is used with cgroup v1

### DIFF
--- a/overlord/servicestate/export_test.go
+++ b/overlord/servicestate/export_test.go
@@ -23,6 +23,8 @@ import (
 	tomb "gopkg.in/tomb.v2"
 
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap/quota"
+	"github.com/snapcore/snapd/testutil"
 )
 
 var (
@@ -46,4 +48,10 @@ func MockOsutilBootID(mockID string) (restore func()) {
 	return func() {
 		osutilBootID = old
 	}
+}
+
+func MockResourcesCheckFeatureRequirements(f func(*quota.Resources) error) (restore func()) {
+	r := testutil.Backup(&resourcesCheckFeatureRequirements)
+	resourcesCheckFeatureRequirements = f
+	return r
 }

--- a/snap/quota/export_test.go
+++ b/snap/quota/export_test.go
@@ -19,6 +19,10 @@
 
 package quota
 
+import (
+	"github.com/snapcore/snapd/testutil"
+)
+
 type GroupQuotaAllocations = groupQuotaAllocations
 
 func (grp *Group) SetInternalSubGroups(grps []*Group) {
@@ -29,4 +33,16 @@ func (grp *Group) InspectInternalQuotaAllocations() map[string]*GroupQuotaAlloca
 	allQuotas := make(map[string]*GroupQuotaAllocations)
 	grp.getQuotaAllocations(allQuotas)
 	return allQuotas
+}
+
+func MockCgroupVer(mockVer int) (restore func()) {
+	r := testutil.Backup(&cgroupVer)
+	cgroupVer = mockVer
+	return r
+}
+
+func MockCgroupVerErr(mockErr error) (restore func()) {
+	r := testutil.Backup(&cgroupVerErr)
+	cgroupVerErr = mockErr
+	return r
 }

--- a/snap/quota/quota_test.go
+++ b/snap/quota/quota_test.go
@@ -29,14 +29,24 @@ import (
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/snap/quota"
 	"github.com/snapcore/snapd/systemd"
+	"github.com/snapcore/snapd/testutil"
 )
 
 // Hook up check.v1 into the "go test" runner
 func Test(t *testing.T) { TestingT(t) }
 
-type quotaTestSuite struct{}
+type quotaTestSuite struct {
+	testutil.BaseTest
+}
 
 var _ = Suite(&quotaTestSuite{})
+
+func (ts *quotaTestSuite) SetUpTest(c *C) {
+	ts.BaseTest.SetUpTest(c)
+
+	ts.AddCleanup(quota.MockCgroupVer(2))
+	ts.AddCleanup(quota.MockCgroupVerErr(nil))
+}
 
 func (ts *quotaTestSuite) TestNewGroup(c *C) {
 

--- a/snap/quota/quota_test.go
+++ b/snap/quota/quota_test.go
@@ -29,24 +29,14 @@ import (
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/snap/quota"
 	"github.com/snapcore/snapd/systemd"
-	"github.com/snapcore/snapd/testutil"
 )
 
 // Hook up check.v1 into the "go test" runner
 func Test(t *testing.T) { TestingT(t) }
 
-type quotaTestSuite struct {
-	testutil.BaseTest
-}
+type quotaTestSuite struct{}
 
 var _ = Suite(&quotaTestSuite{})
-
-func (ts *quotaTestSuite) SetUpTest(c *C) {
-	ts.BaseTest.SetUpTest(c)
-
-	ts.AddCleanup(quota.MockCgroupVer(2))
-	ts.AddCleanup(quota.MockCgroupVerErr(nil))
-}
 
 func (ts *quotaTestSuite) TestNewGroup(c *C) {
 

--- a/snap/quota/resources.go
+++ b/snap/quota/resources.go
@@ -95,12 +95,6 @@ func (qr *Resources) validateCPUSetQuota() error {
 	if len(qr.CPUSet.CPUs) == 0 {
 		return fmt.Errorf("cpu-set quota must not be empty")
 	}
-	if cgroupVerErr != nil {
-		return cgroupVerErr
-	}
-	if cgroupVer < 2 {
-		return fmt.Errorf("cannot use CPU set with cgroup version %d", cgroupVer)
-	}
 
 	return nil
 }
@@ -110,6 +104,23 @@ func (qr *Resources) validateThreadQuota() error {
 	if qr.Threads.Limit <= 0 {
 		return fmt.Errorf("invalid thread quota with a thread count of %d", qr.Threads.Limit)
 	}
+	return nil
+}
+
+// CheckFeatureRequirements checks if the current system meets the
+// requirements for the given resource request.
+//
+// E.g. a CPUSet only only be set set on systems with cgroup v2.
+func (qr *Resources) CheckFeatureRequirements() error {
+	if qr.CPUSet != nil {
+		if cgroupVerErr != nil {
+			return cgroupVerErr
+		}
+		if cgroupVer < 2 {
+			return fmt.Errorf("cannot use CPU set with cgroup version %d", cgroupVer)
+		}
+	}
+
 	return nil
 }
 

--- a/snap/quota/resources.go
+++ b/snap/quota/resources.go
@@ -23,7 +23,17 @@ import (
 	"fmt"
 
 	"github.com/snapcore/snapd/gadget/quantity"
+	"github.com/snapcore/snapd/sandbox/cgroup"
 )
+
+var (
+	cgroupVer    int
+	cgroupVerErr error
+)
+
+func init() {
+	cgroupVer, cgroupVerErr = cgroup.Version()
+}
 
 type ResourceMemory struct {
 	Limit quantity.Size `json:"limit"`
@@ -85,6 +95,13 @@ func (qr *Resources) validateCPUSetQuota() error {
 	if len(qr.CPUSet.CPUs) == 0 {
 		return fmt.Errorf("cpu-set quota must not be empty")
 	}
+	if cgroupVerErr != nil {
+		return cgroupVerErr
+	}
+	if cgroupVer < 2 {
+		return fmt.Errorf("cannot use CPU set with cgroup version %d", cgroupVer)
+	}
+
 	return nil
 }
 

--- a/snap/quota/resources.go
+++ b/snap/quota/resources.go
@@ -130,6 +130,9 @@ func (qr *Resources) CheckFeatureRequirements() error {
 // If cpu percentage is provided, it must be between 1 and 100.
 // If cpu set is provided, it must not be empty.
 // If thread count is provided, it must be above 0.
+//
+// Note that before applying the quota to the system
+// CheckFeatureRequirements() should be called.
 func (qr *Resources) Validate() error {
 	if qr.Memory == nil && qr.CPU == nil && qr.CPUSet == nil && qr.Threads == nil {
 		return fmt.Errorf("quota group must have at least one resource limit set")

--- a/snap/quota/resources_test.go
+++ b/snap/quota/resources_test.go
@@ -27,21 +27,11 @@ import (
 
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/snap/quota"
-	"github.com/snapcore/snapd/testutil"
 )
 
-type resourcesTestSuite struct {
-	testutil.BaseTest
-}
+type resourcesTestSuite struct{}
 
 var _ = Suite(&resourcesTestSuite{})
-
-func (s *resourcesTestSuite) SetUpTest(c *C) {
-	s.BaseTest.SetUpTest(c)
-
-	s.AddCleanup(quota.MockCgroupVer(2))
-	s.AddCleanup(quota.MockCgroupVerErr(nil))
-}
 
 func (s *resourcesTestSuite) TestQuotaValidationFails(c *C) {
 	tests := []struct {
@@ -64,7 +54,7 @@ func (s *resourcesTestSuite) TestQuotaValidationFails(c *C) {
 	}
 }
 
-func (s *resourcesTestSuite) TestQuotaValidationCgroupV1(c *C) {
+func (s *resourcesTestSuite) TestResourceCheckFeatureRequirementsCgroupv1(c *C) {
 	r := quota.MockCgroupVer(1)
 	defer r()
 
@@ -74,10 +64,10 @@ func (s *resourcesTestSuite) TestQuotaValidationCgroupV1(c *C) {
 
 	// cpu set with cgroup v1 is not supported
 	bad := quota.NewResourcesBuilder().WithAllowedCPUs([]int{0, 1}).Build()
-	c.Check(bad.Validate(), ErrorMatches, "cannot use CPU set with cgroup version 1")
+	c.Check(bad.CheckFeatureRequirements(), ErrorMatches, "cannot use CPU set with cgroup version 1")
 }
 
-func (s *resourcesTestSuite) TestQuotaValidationCgroupV1Err(c *C) {
+func (s *resourcesTestSuite) TestResourceCheckFeatureRequirementsCgroupv1Err(c *C) {
 	r := quota.MockCgroupVerErr(fmt.Errorf("some cgroup detection error"))
 	defer r()
 
@@ -87,7 +77,7 @@ func (s *resourcesTestSuite) TestQuotaValidationCgroupV1Err(c *C) {
 
 	// cpu set without cgroup detection is not supported
 	bad := quota.NewResourcesBuilder().WithAllowedCPUs([]int{0, 1}).Build()
-	c.Check(bad.Validate(), ErrorMatches, "some cgroup detection error")
+	c.Check(bad.CheckFeatureRequirements(), ErrorMatches, "some cgroup detection error")
 }
 
 func (s *resourcesTestSuite) TestQuotaValidationPasses(c *C) {


### PR DESCRIPTION
This commit adds a check that cpu-set resources can only be set
on systems with cgroup v2.

This is a followup for https://github.com/snapcore/snapd/pull/11534#discussion_r834116997 - the cgroup v2 check was only done client side but must be done on the backend. 

Setting to draft as I'm not 100% sure this is the right place, the `servicestate/quota_control.go` would also be an option but it does not have a natural place to validate a detail like this (AFAICT). Plus we already have systemd handling there so cgroup detection seems not too out of place.