### PR TITLE
strutil: move wrapGeneric function to strutil as WordWrap

### DIFF
--- a/cmd/snap/cmd_info.go
+++ b/cmd/snap/cmd_info.go
@@ -147,17 +147,6 @@ func runesTrimRightSpace(text []rune) []rune {
 	return text[:j]
 }
 
-// runesLastIndexSpace returns the index of the last whitespace rune
-// in the text. If the text has no whitespace, returns -1.
-func runesLastIndexSpace(text []rune) int {
-	for i := len(text) - 1; i >= 0; i-- {
-		if unicode.IsSpace(text[i]) {
-			return i
-		}
-	}
-	return -1
-}
-
 // wrapLine wraps a line, assumed to be part of a block-style yaml
 // string, to fit into termWidth, preserving the line's indent, and
 // writes it out prepending padding to each line.

--- a/cmd/snap/cmd_info_test.go
+++ b/cmd/snap/cmd_info_test.go
@@ -1040,20 +1040,6 @@ func (infoSuite) TestMaybePrintHealth(c *check.C) {
 	}
 }
 
-func (infoSuite) TestWrapCornerCase(c *check.C) {
-	// this particular corner case isn't currently reachable from
-	// printDescr nor printSummary, but best to have it covered
-	var buf bytes.Buffer
-	const s = "This is a paragraph indented with leading spaces that are encoded as multiple bytes. All hail EN SPACE."
-	snap.WrapFlow(&buf, []rune(s), "\u2002\u2002", 30)
-	c.Check(buf.String(), check.Equals, `
-  This is a paragraph indented
-  with leading spaces that are
-  encoded as multiple bytes.
-  All hail EN SPACE.
-`[1:])
-}
-
 func (infoSuite) TestBug1828425(c *check.C) {
 	const s = `This is a description
                                   that has

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -51,7 +51,6 @@ var (
 	Antialias           = antialias
 	FormatChannel       = fmtChannel
 	PrintDescr          = printDescr
-	WrapFlow            = wrapFlow
 	TrueishJSON         = trueishJSON
 	CompletionHandler   = completionHandler
 	MarkForNoCompletion = markForNoCompletion

--- a/strutil/strutil_test.go
+++ b/strutil/strutil_test.go
@@ -304,3 +304,17 @@ func (strutilSuite) TestWordWrap(c *check.C) {
 		c.Check(buf.String(), check.Equals, t.output)
 	}
 }
+
+func (strutilSuite) TestWordWrapCornerCase(c *check.C) {
+	// this particular corner case isn't currently reachable from
+	// printDescr nor printSummary, but best to have it covered
+	var buf bytes.Buffer
+	const s = "This is a paragraph indented with leading spaces that are encoded as multiple bytes. All hail EN SPACE."
+	strutil.WordWrap(&buf, []rune(s), "\u2002\u2002", "  ", 30)
+	c.Check(buf.String(), check.Equals, `
+  This is a paragraph indented
+  with leading spaces that are
+  encoded as multiple bytes.
+  All hail EN SPACE.
+`[1:])
+}

--- a/strutil/strutil_test.go
+++ b/strutil/strutil_test.go
@@ -20,6 +20,7 @@
 package strutil_test
 
 import (
+	"bytes"
 	"math"
 	"sort"
 	"testing"
@@ -277,5 +278,29 @@ func (strutilSuite) TestDeduplicate(c *check.C) {
 		{input: []string{}, output: []string{}},
 	} {
 		c.Assert(strutil.Deduplicate(t.input), check.DeepEquals, t.output)
+	}
+}
+
+func (strutilSuite) TestWordWrap(c *check.C) {
+	for _, t := range []struct {
+		input   string
+		width   int
+		indent  string
+		indent2 string
+		output  string
+	}{
+		{input: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.", width: 20, indent: "", indent2: "", output: "Lorem ipsum dolor\nsit amet,\nconsectetur\nadipiscing elit, sed\ndo eiusmod tempor\nincididunt ut labore\net dolore magna\naliqua.\n"},
+		{input: "Lorem ips", width: 20, indent: "", indent2: "", output: "Lorem ips\n"},
+		{input: "", width: 5, indent: "", indent2: "", output: "\n"},
+		{input: "", width: 5, indent: "  ", indent2: "  ", output: "  \n"},
+		{input: "Lorem ipsum", width: 0, indent: "", indent2: "", output: "L\no\nr\ne\nm\ni\np\ns\nu\nm\n"},
+		{input: "Lorem ipsum", width: -10, indent: "", indent2: "", output: "L\no\nr\ne\nm\ni\np\ns\nu\nm\n"},
+		{input: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.", width: 20, indent: "  ", indent2: "", output: "  Lorem ipsum dolor\nsit amet,\nconsectetur\nadipiscing elit, sed\ndo eiusmod tempor\nincididunt ut labore\net dolore magna\naliqua.\n"},
+		{input: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.", width: 20, indent: "", indent2: "  ", output: "Lorem ipsum dolor\n  sit amet,\n  consectetur\n  adipiscing elit,\n  sed do eiusmod\n  tempor incididunt\n  ut labore et\n  dolore magna\n  aliqua.\n"},
+	} {
+		buf := new(bytes.Buffer)
+		err := strutil.WordWrap(buf, []rune(t.input), t.indent, t.indent2, t.width)
+		c.Assert(err, check.IsNil)
+		c.Check(buf.String(), check.Equals, t.output)
 	}
 }


### PR DESCRIPTION
Will need this function other places for the model command in snapctl, and it being in cmd/snap was hard to reuse. I hope this looks fine!
