### PR TITLE
tests: moving ubuntu-image to candidate to fix uc16 tests

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -41,7 +41,7 @@ environment:
     TRUST_TEST_KEYS: '$(HOST: echo "${SPREAD_TRUST_TEST_KEYS:-true}")'
     # a global setting for LXD channel to use in the tests
     LXD_SNAP_CHANNEL: "latest/candidate"
-    UBUNTU_IMAGE_SNAP_CHANNEL: "latest/edge"
+    UBUNTU_IMAGE_SNAP_CHANNEL: "latest/candidate"
     CORE_CHANNEL: '$(HOST: echo "${SPREAD_CORE_CHANNEL:-edge}")'
     BASE_CHANNEL: '$(HOST: echo "${SPREAD_BASE_CHANNEL:-edge}")'
     KERNEL_CHANNEL: '$(HOST: echo "${SPREAD_KERNEL_CHANNEL:-edge}")'


### PR DESCRIPTION
Snapd tests are failing to create a new core image using ubuntu-image
snap from edge channel (rev 275)

This is the error that we see in the logs. The same code works well when
we use ubuntu-image from candidate channel (rev 253)

Bug created: https://bugs.launchpad.net/ubuntu-image/+bug/1966475