### PR TITLE
sandbox,quota: ensure cgroup is available when creating mem quotas

### DIFF
--- a/sandbox/cgroup/export_test.go
+++ b/sandbox/cgroup/export_test.go
@@ -22,6 +22,8 @@ import (
 	"time"
 
 	"github.com/godbus/dbus"
+
+	"github.com/snapcore/snapd/testutil"
 )
 
 var (
@@ -102,4 +104,10 @@ func MockCreateScopeJobTimeout(d time.Duration) (restore func()) {
 	return func() {
 		createScopeJobTimeout = oldCreateScopeJobTimeout
 	}
+}
+
+func MockCgroupsFilePath(path string) (restore func()) {
+	r := testutil.Backup(&cgroupsFilePath)
+	cgroupsFilePath = path
+	return r
 }

--- a/sandbox/cgroup/memory.go
+++ b/sandbox/cgroup/memory.go
@@ -1,0 +1,70 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package cgroup
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+var cgroupsFilePath = "/proc/cgroups"
+
+// CheckMemoryCgroup checks if the memory cgroup is enabled. It will return
+// an error if not.
+//
+// Since the control groups can be enabled/disabled without the kernel config the only
+// way to identify the status of memory control groups is via /proc/cgroups
+// "cat /proc/cgroups | grep memory" returns the active status of memory control group
+// and the 3rd parameter is the status
+// 0 => false => disabled
+// 1 => true => enabled
+func CheckMemoryCgroup() error {
+	cgroupsFile, err := os.Open(cgroupsFilePath)
+	if err != nil {
+		return fmt.Errorf("cannot open cgroups file: %v", err)
+	}
+	defer cgroupsFile.Close()
+
+	scanner := bufio.NewScanner(cgroupsFile)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "memory\t") {
+			memoryCgroupValues := strings.Fields(line)
+			if len(memoryCgroupValues) < 4 {
+				// change in size, should investigate the new structure
+				return fmt.Errorf("cannot parse cgroups file: invalid line %q", line)
+			}
+			isMemoryEnabled := memoryCgroupValues[3] == "1"
+			if !isMemoryEnabled {
+				return fmt.Errorf("memory cgroup is disabled on this system")
+			}
+			return nil
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("cannot read %v contents: %v", cgroupsFilePath, err)
+	}
+
+	// no errors so far but the only path here is the cgroups file without the memory line
+	return fmt.Errorf("cannot find memory cgroup in %v", cgroupsFilePath)
+}

--- a/sandbox/cgroup/memory.go
+++ b/sandbox/cgroup/memory.go
@@ -62,9 +62,9 @@ func CheckMemoryCgroup() error {
 	}
 
 	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("cannot read %v contents: %v", cgroupsFilePath, err)
+		return fmt.Errorf("cannot read %s contents: %v", cgroupsFilePath, err)
 	}
 
 	// no errors so far but the only path here is the cgroups file without the memory line
-	return fmt.Errorf("cannot find memory cgroup in %v", cgroupsFilePath)
+	return fmt.Errorf("cannot find memory cgroup in %s", cgroupsFilePath)
 }

--- a/sandbox/cgroup/memory_test.go
+++ b/sandbox/cgroup/memory_test.go
@@ -1,0 +1,97 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package cgroup_test
+
+import (
+	"io/ioutil"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/sandbox/cgroup"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type memorySuite struct {
+	testutil.BaseTest
+
+	mockCgroupsFile string
+}
+
+var _ = Suite(&memorySuite{})
+
+var (
+	cgroupContentCommon = `#subsys_name	hierarchy	num_cgroups	enabled
+cpuset	6	3	1
+cpu	3	133	1
+devices	10	135	1`
+)
+
+func (s *memorySuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+
+	s.mockCgroupsFile = filepath.Join(c.MkDir(), "cgroups")
+	s.AddCleanup(cgroup.MockCgroupsFilePath(s.mockCgroupsFile))
+}
+
+func (s *memorySuite) TestCheckMemoryCgroupHappy(c *C) {
+	extra := "memory	2	223	1"
+	content := cgroupContentCommon + "\n" + extra
+
+	err := ioutil.WriteFile(s.mockCgroupsFile, []byte(content), 0644)
+	c.Assert(err, IsNil)
+	err = cgroup.CheckMemoryCgroup()
+	c.Assert(err, IsNil)
+}
+
+func (s *memorySuite) TestCheckMemoryCgroupMissing(c *C) {
+	// note there is no file created for s.mockCgroupsFile
+
+	err := cgroup.CheckMemoryCgroup()
+	c.Assert(err, ErrorMatches, "cannot open cgroups file: open .*/cgroups: no such file or directory")
+}
+
+func (s *memorySuite) TestCheckMemoryCgroupNoMemoryEntry(c *C) {
+	content := cgroupContentCommon
+
+	err := ioutil.WriteFile(s.mockCgroupsFile, []byte(content), 0644)
+	c.Assert(err, IsNil)
+	err = cgroup.CheckMemoryCgroup()
+	c.Assert(err, ErrorMatches, "cannot find memory cgroup in .*/cgroups")
+}
+
+func (s *memorySuite) TestCheckMemoryCgroupInvalidMemoryEntry(c *C) {
+	extra := "memory	invalid line"
+	content := cgroupContentCommon + "\n" + extra
+
+	err := ioutil.WriteFile(s.mockCgroupsFile, []byte(content), 0644)
+	c.Assert(err, IsNil)
+	err = cgroup.CheckMemoryCgroup()
+	c.Assert(err, ErrorMatches, `cannot parse cgroups file: invalid line "memory\\tinvalid line"`)
+}
+
+func (s *memorySuite) TestCheckMemoryCgroupDisabled(c *C) {
+	extra := "memory	2	223	0"
+	content := cgroupContentCommon + "\n" + extra
+
+	err := ioutil.WriteFile(s.mockCgroupsFile, []byte(content), 0644)
+	c.Assert(err, IsNil)
+	err = cgroup.CheckMemoryCgroup()
+	c.Assert(err, ErrorMatches, "memory cgroup is disabled on this system")
+}

--- a/snap/quota/resources.go
+++ b/snap/quota/resources.go
@@ -123,10 +123,8 @@ func (qr *Resources) CheckFeatureRequirements() error {
 			return fmt.Errorf("cannot use CPU set with cgroup version %d", cgroupVer)
 		}
 	}
-	if qr.Memory != nil {
-		if cgroupCheckMemoryCgroupErr != nil {
-			return fmt.Errorf("cannot use memory quota: %v", cgroupCheckMemoryCgroupErr)
-		}
+	if qr.Memory != nil && cgroupCheckMemoryCgroupErr != nil {
+		return fmt.Errorf("cannot use memory quota: %v", cgroupCheckMemoryCgroupErr)
 	}
 
 	return nil

--- a/snap/quota/resources.go
+++ b/snap/quota/resources.go
@@ -29,10 +29,13 @@ import (
 var (
 	cgroupVer    int
 	cgroupVerErr error
+
+	cgroupCheckMemoryCgroupErr error
 )
 
 func init() {
 	cgroupVer, cgroupVerErr = cgroup.Version()
+	cgroupCheckMemoryCgroupErr = cgroup.CheckMemoryCgroup()
 }
 
 type ResourceMemory struct {
@@ -118,6 +121,11 @@ func (qr *Resources) CheckFeatureRequirements() error {
 		}
 		if cgroupVer < 2 {
 			return fmt.Errorf("cannot use CPU set with cgroup version %d", cgroupVer)
+		}
+	}
+	if qr.Memory != nil {
+		if cgroupCheckMemoryCgroupErr != nil {
+			return fmt.Errorf("cannot use memory quota: %v", cgroupCheckMemoryCgroupErr)
 		}
 	}
 

--- a/tests/core/mem-cgroup-disabled/task.yaml
+++ b/tests/core/mem-cgroup-disabled/task.yaml
@@ -83,6 +83,9 @@ execute: |
       # and we get the expected error message
       snap quota grp 2>&1 | MATCH "error: memory usage unavailable"
 
+      # updating quota groups does not work and gives a useful error message
+      snap set-quota --memory=200MB grp 2>&1 | tr -s "\n " " " | MATCH 'error: cannot update quota group: cannot update group "grp": cannot use memory quota: memory cgroup is disabled on this system'
+
       # make sure our snap still has the Slice setting
       MATCH Slice=snap.grp.slice < "$SVC_UNIT"
 


### PR DESCRIPTION
This commit ensures that quotas can only be created/updated if
the memory cgroup is available. Without having the memory cgroup
the snapd memory quota system will not work.
