### PR TITLE
many: allow errors in `current` quota group API result

### DIFF
--- a/client/quota.go
+++ b/client/quota.go
@@ -54,10 +54,16 @@ type QuotaCPUSetValues struct {
 }
 
 type QuotaValues struct {
-	Memory  quantity.Size      `json:"memory,omitempty"`
-	CPU     *QuotaCPUValues    `json:"cpu,omitempty"`
-	CPUSet  *QuotaCPUSetValues `json:"cpu-set,omitempty"`
-	Threads int                `json:"threads,omitempty"`
+	Memory quantity.Size `json:"memory,omitempty"`
+	// MemoryErr is set if the current memory quota cannot be retrieved
+	MemoryErr string `json:"memory-err,omitempty"`
+
+	CPU    *QuotaCPUValues    `json:"cpu,omitempty"`
+	CPUSet *QuotaCPUSetValues `json:"cpu-set,omitempty"`
+
+	Threads int `json:"threads,omitempty"`
+	// MemoryErr is set if the current threads quota cannot be retrieved
+	ThreadsErr string `json:"threads-err,omitempty"`
 }
 
 // EnsureQuota creates a quota group or updates an existing group.

--- a/cmd/snap/cmd_quota.go
+++ b/cmd/snap/cmd_quota.go
@@ -349,10 +349,18 @@ func (x *cmdQuota) Execute(args []string) (err error) {
 	}
 
 	memoryUsage := "0B"
-	currentThreads := 0
+	currentThreads := "0"
 	if group.Current != nil {
-		memoryUsage = strings.TrimSpace(fmtSize(int64(group.Current.Memory)))
-		currentThreads = group.Current.Threads
+		if group.Current.MemoryErr != "" {
+			memoryUsage = "error: " + group.Current.MemoryErr
+		} else {
+			memoryUsage = strings.TrimSpace(fmtSize(int64(group.Current.Memory)))
+		}
+		if group.Current.ThreadsErr != "" {
+			currentThreads = "error: " + group.Current.ThreadsErr
+		} else {
+			currentThreads = strconv.Itoa(group.Current.Threads)
+		}
 	}
 
 	fmt.Fprintf(w, "current:\n")
@@ -360,7 +368,7 @@ func (x *cmdQuota) Execute(args []string) (err error) {
 		fmt.Fprintf(w, "  memory:\t%s\n", memoryUsage)
 	}
 	if group.Constraints.Threads != 0 {
-		fmt.Fprintf(w, "  threads:\t%d\n", currentThreads)
+		fmt.Fprintf(w, "  threads:\t%s\n", currentThreads)
 	}
 
 	if len(group.Subgroups) > 0 {

--- a/daemon/api_quotas.go
+++ b/daemon/api_quotas.go
@@ -68,7 +68,7 @@ var getQuotaUsage = func(grp *quota.Group) (*client.QuotaValues, error) {
 	if grp.MemoryLimit != 0 {
 		mem, err := grp.CurrentMemoryUsage()
 		if err != nil {
-			return nil, err
+			currentUsage.MemoryErr = err.Error()
 		}
 		currentUsage.Memory = mem
 	}
@@ -76,7 +76,7 @@ var getQuotaUsage = func(grp *quota.Group) (*client.QuotaValues, error) {
 	if grp.TaskLimit != 0 {
 		threads, err := grp.CurrentTaskUsage()
 		if err != nil {
-			return nil, err
+			currentUsage.ThreadsErr = err.Error()
 		}
 		currentUsage.Threads = threads
 	}


### PR DESCRIPTION
As discussed in
https://github.com/snapcore/snapd/pull/11370#pullrequestreview-880977661
we should not fail if the current memory or thread usage cannot
be determined. This commit provides a possible way to do this by
extending the `QuotaValues` to have an optional `{Memory,Threads}Err`
member. Not super elegant so ideas welcome.

Setting to draft for now as this is just one possible approach and I'm open for ideas.