### PR TITLE
interfaces/system-packages-doc: allow read-only access to /usr/share/libreoffice/help (LP: #1951210)

### DIFF
--- a/interfaces/builtin/system_packages_doc.go
+++ b/interfaces/builtin/system_packages_doc.go
@@ -40,6 +40,7 @@ const systemPackagesDocConnectedPlugAppArmor = `
 # Description: can access documentation of system packages.
 
 /usr/share/doc/{,**} r,
+/usr/share/libreoffice/help/{,**} r,
 `
 
 type systemPackagesDocInterface struct {
@@ -53,15 +54,24 @@ func (iface *systemPackagesDocInterface) AppArmorConnectedPlug(spec *apparmor.Sp
 	emit("  mount options=(bind) /var/lib/snapd/hostfs/usr/share/doc/ -> /usr/share/doc/,\n")
 	emit("  remount options=(bind, ro) /usr/share/doc/,\n")
 	emit("  umount /usr/share/doc/,\n")
+	emit("  mount options=(bind) /var/lib/snapd/hostfs/usr/share/libreoffice/help/ -> /usr/share/libreoffice/help/,\n")
+	emit("  remount options=(bind, ro) /usr/share/libreoffice/help/,\n")
+	emit("  umount /usr/share/libreoffice/help/,\n")
 	return nil
 }
 
 func (iface *systemPackagesDocInterface) MountConnectedPlug(spec *mount.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
-	return spec.AddMountEntry(osutil.MountEntry{
+	spec.AddMountEntry(osutil.MountEntry{
 		Name:    "/var/lib/snapd/hostfs/usr/share/doc",
 		Dir:     "/usr/share/doc",
 		Options: []string{"bind", "ro"},
 	})
+	spec.AddMountEntry(osutil.MountEntry{
+		Name:    "/var/lib/snapd/hostfs/usr/share/libreoffice/help",
+		Dir:     "/usr/share/libreoffice/help",
+		Options: []string{"bind", "ro"},
+	})
+	return nil
 }
 
 func init() {

--- a/interfaces/builtin/system_packages_doc_test.go
+++ b/interfaces/builtin/system_packages_doc_test.go
@@ -86,12 +86,16 @@ func (s *systemPackagesDocSuite) TestAppArmorSpec(c *C) {
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "# Description: can access documentation of system packages.")
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/usr/share/doc/{,**} r,")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/usr/share/libreoffice/help/{,**} r,")
 
 	updateNS := spec.UpdateNS()
 	c.Check(updateNS, testutil.Contains, "  # Mount documentation of system packages\n")
 	c.Check(updateNS, testutil.Contains, "  mount options=(bind) /var/lib/snapd/hostfs/usr/share/doc/ -> /usr/share/doc/,\n")
 	c.Check(updateNS, testutil.Contains, "  remount options=(bind, ro) /usr/share/doc/,\n")
 	c.Check(updateNS, testutil.Contains, "  umount /usr/share/doc/,\n")
+	c.Check(updateNS, testutil.Contains, "  mount options=(bind) /var/lib/snapd/hostfs/usr/share/libreoffice/help/ -> /usr/share/libreoffice/help/,\n")
+	c.Check(updateNS, testutil.Contains, "  remount options=(bind, ro) /usr/share/libreoffice/help/,\n")
+	c.Check(updateNS, testutil.Contains, "  umount /usr/share/libreoffice/help/,\n")
 }
 
 func (s *systemPackagesDocSuite) TestMountSpec(c *C) {
@@ -102,10 +106,13 @@ func (s *systemPackagesDocSuite) TestMountSpec(c *C) {
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.coreSlot), IsNil)
 
 	entries := spec.MountEntries()
-	c.Assert(entries, HasLen, 1)
+	c.Assert(entries, HasLen, 2)
 	c.Check(entries[0].Name, Equals, "/var/lib/snapd/hostfs/usr/share/doc")
 	c.Check(entries[0].Dir, Equals, "/usr/share/doc")
 	c.Check(entries[0].Options, DeepEquals, []string{"bind", "ro"})
+	c.Check(entries[1].Name, Equals, "/var/lib/snapd/hostfs/usr/share/libreoffice/help")
+	c.Check(entries[1].Dir, Equals, "/usr/share/libreoffice/help")
+	c.Check(entries[1].Options, DeepEquals, []string{"bind", "ro"})
 
 	entries = spec.UserMountEntries()
 	c.Assert(entries, HasLen, 0)


### PR DESCRIPTION
See the last few comments on https://bugs.launchpad.net/ubuntu/+source/libreoffice/+bug/1951210 for why this is needed.

Note that this problem affects the libreoffice deb packages, which ship HTML help files under `/usr/share/libreoffice/help/` and rely on an external browser to view them, but not the libreoffice snap, which embeds a built-in help viewer application.

In Ubuntu 22.04, the default web browser is the firefox snap, and as a consequence the libreoffice help can't be viewed.