### PR TITLE
cmd/snap: refactor 'snap model' to use same code as 'snapctl model'

### DIFF
--- a/client/clientutil/export_test.go
+++ b/client/clientutil/export_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2018-2020 Canonical Ltd
+ * Copyright (C) 2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/client/clientutil/export_test.go
+++ b/client/clientutil/export_test.go
@@ -1,0 +1,24 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018-2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package clientutil
+
+type ModelWriter = modelWriter
+
+var NewModelWriter = newModelWriter

--- a/client/clientutil/modelinfo.go
+++ b/client/clientutil/modelinfo.go
@@ -1,0 +1,576 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018-2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package clientutil
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+	"time"
+	"unicode"
+
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/strutil"
+	"github.com/snapcore/snapd/timeutil"
+)
+
+var (
+	invalidTypeMessage = i18n.G("invalid type for %q header")
+	errNoMainAssertion = errors.New(i18n.G("device not ready yet (no assertions found)"))
+	errNoSerial        = errors.New(i18n.G("device not registered yet (no serial assertion found)"))
+
+	// this list is a "nice" "human" "readable" "ordering" of headers to print
+	// off, sorted in lexical order with meta headers and primary key headers
+	// removed, and big nasty keys such as device-key-sha3-384 and
+	// device-key at the bottom
+	// it also contains both serial and model assertion headers, but we
+	// follow the same code path for both assertion types and some of the
+	// headers are shared between the two, so it still works out correctly
+	niceOrdering = [...]string{
+		"architecture",
+		"base",
+		"classic",
+		"display-name",
+		"gadget",
+		"kernel",
+		"revision",
+		"store",
+		"system-user-authority",
+		"timestamp",
+		"required-snaps", // for uc16 and uc18 models
+		"snaps",          // for uc20 models
+		"device-key-sha3-384",
+		"device-key",
+	}
+)
+
+type OutputFormat int
+
+type ModelFormatter interface {
+	GetPublisher() string
+	GetEscapedDash() string
+}
+
+const (
+	MODELWRITER_RAW_FORMAT OutputFormat = iota
+	MODELWRITER_YAML_FORMAT
+	MODELWRITER_JSON_FORMAT
+)
+
+type modelAssertJSON struct {
+	Headers map[string]interface{} `json:"headers,omitempty"`
+	Body    string                 `json:"body,omitempty"`
+}
+
+type modelWriterState struct {
+	indent       int
+	firstElement bool
+	inArray      bool
+	inlineArray  bool
+	arrayMembers []string
+}
+
+type modelWriter struct {
+	w            *tabwriter.Writer
+	format       OutputFormat
+	currentState modelWriterState
+	states       []modelWriterState
+}
+
+// runesTrimRightSpace returns text, with any trailing whitespace dropped.
+func runesTrimRightSpace(text []rune) []rune {
+	j := len(text)
+	for j > 0 && unicode.IsSpace(text[j-1]) {
+		j--
+	}
+	return text[:j]
+}
+
+// wrapLine wraps a line, assumed to be part of a block-style yaml
+// string, to fit into termWidth, preserving the line's indent, and
+// writes it out prepending padding to each line.
+func wrapLine(out io.Writer, text []rune, pad string, termWidth int) error {
+	// discard any trailing whitespace
+	text = runesTrimRightSpace(text)
+	// establish the indent of the whole block
+	idx := 0
+	for idx < len(text) && unicode.IsSpace(text[idx]) {
+		idx++
+	}
+	indent := pad + string(text[:idx])
+	text = text[idx:]
+	if len(indent) > termWidth/2 {
+		// If indent is too big there's not enough space for the actual
+		// text, in the pathological case the indent can even be bigger
+		// than the terminal which leads to lp:1828425.
+		// Rather than let that happen, give up.
+		indent = pad + "  "
+	}
+	return strutil.WordWrap(out, text, indent, indent, termWidth)
+}
+
+func (w *modelWriter) pushState() {
+	w.states = append(w.states, w.currentState)
+	w.currentState = modelWriterState{
+		indent:       w.currentState.indent,
+		firstElement: true,
+		inArray:      false,
+		inlineArray:  false,
+		arrayMembers: nil,
+	}
+}
+
+func (w *modelWriter) popState() {
+	w.currentState = w.states[len(w.states)-1]
+	w.states = w.states[:len(w.states)-1]
+}
+
+func (w *modelWriter) increaseIndent() {
+	w.currentState.indent += 2
+}
+
+func (w *modelWriter) indent() string {
+	return strings.Repeat(" ", w.currentState.indent)
+}
+
+func (w *modelWriter) writeSeperator() {
+	if w.currentState.firstElement {
+		w.currentState.firstElement = false
+		return
+	}
+
+	if w.format == MODELWRITER_JSON_FORMAT {
+		fmt.Fprint(w.w, ",\n")
+	} else {
+		fmt.Fprint(w.w, "\n")
+	}
+}
+
+func (w *modelWriter) startObject(name string) {
+	if w.format == MODELWRITER_JSON_FORMAT {
+		fmt.Fprintf(w.w, "%s%s", w.indent(), "{\n")
+	} else if w.format == MODELWRITER_YAML_FORMAT {
+		if w.currentState.inArray {
+			fmt.Fprintf(w.w, "%s- name:\t%s\n", w.indent(), name)
+		} else if len(name) > 0 {
+			fmt.Fprintf(w.w, "%s%s:\n", w.indent(), name)
+		}
+	}
+
+	w.pushState()
+	// the only time we do not increase indentation for yaml
+	// is for the root object, which is called like this
+	// startObject("")
+	if w.format != MODELWRITER_YAML_FORMAT || len(name) != 0 {
+		w.increaseIndent()
+	}
+}
+
+func (w *modelWriter) endObject() {
+	w.popState()
+	if w.format == MODELWRITER_JSON_FORMAT {
+		fmt.Fprintf(w.w, "\n%s%s", w.indent(), "}")
+	}
+
+	// root element? add a newline
+	if len(w.states) == 0 {
+		fmt.Fprint(w.w, "\n")
+	}
+}
+
+// startArray marks that any following members will be part of an array
+// instead of the outer object. The array can be inlined, which means that
+// it will fit it into one single line. This is useful for yaml to format arrays
+// as [1,2,3] instead of
+// - 1
+// - 2
+// - 3
+func (w *modelWriter) startArray(name string, inline bool) {
+	if w.format == MODELWRITER_JSON_FORMAT {
+		fmt.Fprintf(w.w, "%s%q: [\n", w.indent(), name)
+	} else {
+		if inline {
+			fmt.Fprintf(w.w, "%s%s:\t[", w.indent(), name)
+		} else {
+			fmt.Fprintf(w.w, "%s%s:\t\n", w.indent(), name)
+		}
+	}
+
+	w.pushState()
+	w.increaseIndent()
+	w.currentState.inArray = true
+	w.currentState.inlineArray = inline
+}
+
+func (w *modelWriter) endArray() {
+	if w.format == MODELWRITER_JSON_FORMAT {
+		sep := fmt.Sprintf("%s,\n", w.indent())
+		strings.Join(w.currentState.arrayMembers, sep)
+		fmt.Fprint(w.w, strings.Repeat(" ", w.currentState.indent-2)+"],\n")
+	} else if w.format == MODELWRITER_YAML_FORMAT {
+		if w.currentState.inlineArray {
+			fmt.Fprintf(w.w, "%s]", strings.Join(w.currentState.arrayMembers, ", "))
+		} else {
+			for _, member := range w.currentState.arrayMembers {
+				fmt.Fprintf(w.w, "%s- %s\n", w.indent(), member)
+			}
+		}
+	}
+	w.popState()
+}
+
+func (w *modelWriter) writeStringPair(name, value string) {
+	w.writeSeperator()
+	if w.format == MODELWRITER_JSON_FORMAT {
+		fmt.Fprintf(w.w, "%s%q: %q", w.indent(), name, value)
+	} else if w.format == MODELWRITER_YAML_FORMAT {
+		fmt.Fprintf(w.w, "%s%s:\t%s", w.indent(), name, value)
+	} else {
+		fmt.Fprintf(w.w, "%s%s\t%s", w.indent(), name, value)
+	}
+}
+
+func (w *modelWriter) writeWrappedStringPair(name, value string, lineWidth int) error {
+	w.writeSeperator()
+	if w.format == MODELWRITER_JSON_FORMAT {
+		fmt.Fprintf(w.w, "%s%q: %s", w.indent(), name, value)
+	} else if w.format == MODELWRITER_YAML_FORMAT {
+		fmt.Fprintf(w.w, "%s%s: |\n", w.indent(), name)
+		if err := wrapLine(w.w, []rune(value), "  "+w.indent(), lineWidth); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *modelWriter) writeStringValue(value string) {
+	// this is only ever called for array members currently, if it was to be used
+	// for other cases, they need to be implemented here.
+	if w.currentState.inArray {
+		w.currentState.arrayMembers = append(w.currentState.arrayMembers, value)
+	}
+}
+
+func newModelWriter(w *tabwriter.Writer, format OutputFormat) *modelWriter {
+	return &modelWriter{
+		w:      w,
+		format: format,
+		currentState: modelWriterState{
+			firstElement: true,
+		},
+	}
+}
+
+func fmtTime(t time.Time, abs bool) string {
+	if abs {
+		return t.Format(time.RFC3339)
+	}
+	return timeutil.Human(t)
+}
+
+func PrintModelAssertation(w *tabwriter.Writer, format OutputFormat, modelFormatter ModelFormatter, termWidth int, useSerial, absTime, verbose, assertation bool, modelAssertion *asserts.Model, serialAssertion *asserts.Serial) error {
+	var mainAssertion asserts.Assertion
+
+	// if we got an invalid model assertion bail early
+	if modelAssertion == nil {
+		return errNoMainAssertion
+	}
+
+	if useSerial {
+		mainAssertion = serialAssertion
+	} else {
+		mainAssertion = modelAssertion
+	}
+
+	if assertation {
+		// if we are using the serial assertion and we specifically didn't find the
+		// serial assertion, bail with specific error
+		if useSerial && serialAssertion == nil {
+			return errNoMainAssertion
+		}
+
+		var data []byte
+		if format == MODELWRITER_JSON_FORMAT {
+			modelJSON := modelAssertJSON{}
+			modelJSON.Headers = mainAssertion.Headers()
+			modelJSON.Body = string(mainAssertion.Body())
+			marshalled, err := json.MarshalIndent(modelJSON, "", "  ")
+			if err != nil {
+				return err
+			}
+			data = marshalled
+		} else {
+			data = asserts.Encode(mainAssertion)
+		}
+		_, err := w.Write(data)
+		return err
+	}
+
+	mw := newModelWriter(w, format)
+
+	if useSerial && serialAssertion == nil {
+		// for serial assertion, the primary keys are output (model and
+		// brand-id), but if we didn't find the serial assertion then we still
+		// output the brand-id and model from the model assertion, but also
+		// return a devNotReady error
+		mw.startObject("")
+		mw.writeStringPair("brand-id", modelAssertion.HeaderString("brand-id"))
+		mw.writeStringPair("model", modelAssertion.HeaderString("model"))
+		mw.endObject()
+		w.Flush()
+		return errNoSerial
+	}
+
+	// the rest of this function is the main flow for outputting either the
+	// model or serial assertion in normal or verbose mode
+	mw.startObject("")
+
+	// ordering of the primary keys for model: brand, model, serial
+	// ordering of primary keys for serial is brand-id, model, serial
+
+	// output brand/brand-id
+	brandIDHeader := mainAssertion.HeaderString("brand-id")
+	modelHeader := mainAssertion.HeaderString("model")
+	// for the serial header, if there's no serial yet, it's not an error for
+	// model (and we already handled the serial error above) but need to add a
+	// parenthetical about the device not being registered yet
+	var serial string
+	if serialAssertion == nil {
+		if verbose || useSerial {
+			// verbose and serial are yamlish, so we need to escape the dash
+			serial = modelFormatter.GetEscapedDash()
+		} else {
+			serial = "-"
+		}
+		serial += " (device not registered yet)"
+	} else {
+		serial = serialAssertion.HeaderString("serial")
+	}
+
+	// handle brand/brand-id and model/model + display-name differently on just
+	// `snap model` w/o opts
+	if verbose || useSerial {
+		mw.writeStringPair("brand-id", brandIDHeader)
+		mw.writeStringPair("model", modelHeader)
+	} else {
+		publisher := modelFormatter.GetPublisher()
+		mw.writeStringPair("brand", publisher)
+
+		// for model, if there's a display-name, we show that first with the
+		// real model in parenthesis
+		if displayName := modelAssertion.HeaderString("display-name"); displayName != "" {
+			modelHeader = fmt.Sprintf("%s (%s)", displayName, modelHeader)
+		}
+		mw.writeStringPair("model", modelHeader)
+	}
+
+	// only output the grade if it is non-empty, either it is not in the model
+	// assertion for all non-uc20 model assertions, or it is non-empty and
+	// required for uc20 model assertions
+	grade := modelAssertion.HeaderString("grade")
+	if grade != "" {
+		mw.writeStringPair("grade", grade)
+	}
+
+	storageSafety := modelAssertion.HeaderString("storage-safety")
+	if storageSafety != "" {
+		mw.writeStringPair("storage-safety", storageSafety)
+	}
+
+	// serial is same for all variants
+	mw.writeStringPair("serial", serial)
+
+	// verbose means output more information
+	if verbose {
+		allHeadersMap := mainAssertion.Headers()
+
+		for _, headerName := range niceOrdering {
+			invalidTypeErr := fmt.Errorf(invalidTypeMessage, headerName)
+
+			headerValue, ok := allHeadersMap[headerName]
+			// make sure the header is in the map
+			if !ok {
+				continue
+			}
+
+			// switch on which header it is to handle some special cases
+			switch headerName {
+			// list of scalars
+			case "required-snaps", "system-user-authority":
+				headerIfaceList, ok := headerValue.([]interface{})
+				if !ok {
+					return invalidTypeErr
+				}
+				if len(headerIfaceList) == 0 {
+					continue
+				}
+
+				mw.startArray(headerName, false)
+				for _, elem := range headerIfaceList {
+					headerStringElem, ok := elem.(string)
+					if !ok {
+						return invalidTypeErr
+					}
+					// note we don't wrap these, since for now this is
+					// specifically just required-snaps and so all of these
+					// will be snap names which are required to be short
+					mw.writeStringValue(headerStringElem)
+				}
+				mw.endArray()
+
+			//timestamp needs to be formatted with fmtTime from the timeMixin
+			case "timestamp":
+				timestamp, ok := headerValue.(string)
+				if !ok {
+					return invalidTypeErr
+				}
+
+				// parse the time string as RFC3339, which is what the format is
+				// always in for assertions
+				t, err := time.Parse(time.RFC3339, timestamp)
+				if err != nil {
+					return err
+				}
+				mw.writeStringPair("timestamp", fmtTime(t, absTime))
+
+			// long string key we don't want to rewrap but can safely handle
+			// on "reasonable" width terminals
+			case "device-key-sha3-384":
+				// also flush the writer before continuing so the previous keys
+				// don't try to align with this key
+				w.Flush()
+				headerString, ok := headerValue.(string)
+				if !ok {
+					return invalidTypeErr
+				}
+
+				switch {
+				case termWidth > 86:
+					mw.writeStringPair("device-key-sha3-384", headerString)
+				case termWidth <= 86 && termWidth > 66:
+					if err := mw.writeWrappedStringPair("device-key-sha3-384", headerString, termWidth); err != nil {
+						return err
+					}
+				}
+			case "snaps":
+				// also flush the writer before continuing so the previous keys
+				// don't try to align with this key
+				w.Flush()
+				snapsHeader, ok := headerValue.([]interface{})
+				if !ok {
+					return invalidTypeErr
+				}
+				if len(snapsHeader) == 0 {
+					// unexpected why this is an empty list, but just ignore for
+					// now
+					continue
+				}
+				mw.startArray("snaps", false)
+				for _, sn := range snapsHeader {
+					snMap, ok := sn.(map[string]interface{})
+					if !ok {
+						return invalidTypeErr
+					}
+					// iterate over all keys in the map in a stable, visually
+					// appealing ordering
+					// first do snap name, which will always be present since we
+					// parsed a valid assertion
+					name := snMap["name"].(string)
+					mw.startObject(name)
+
+					// the rest of these may be absent, but they are all still
+					// simple strings
+					for _, snKey := range []string{"id", "type", "default-channel", "presence"} {
+						snValue, ok := snMap[snKey]
+						if !ok {
+							continue
+						}
+						snStrValue, ok := snValue.(string)
+						if !ok {
+							return invalidTypeErr
+						}
+						if snStrValue != "" {
+							mw.writeStringPair(snKey, snStrValue)
+						}
+					}
+
+					// finally handle "modes" which is a list
+					modes, ok := snMap["modes"]
+					if !ok {
+						mw.endObject()
+						continue
+					}
+					modesSlice, ok := modes.([]interface{})
+					if !ok {
+						return invalidTypeErr
+					}
+					if len(modesSlice) == 0 {
+						mw.endObject()
+						continue
+					}
+
+					mw.startArray("modes", true)
+					for _, mode := range modesSlice {
+						modeStr, ok := mode.(string)
+						if !ok {
+							return invalidTypeErr
+						}
+						mw.writeStringValue(modeStr)
+					}
+					mw.endArray()
+					mw.endObject()
+				}
+				mw.endArray()
+
+			// long base64 key we can rewrap safely
+			case "device-key":
+				headerString, ok := headerValue.(string)
+				if !ok {
+					return invalidTypeErr
+				}
+				// the string value here has newlines inserted as part of the
+				// raw assertion, but base64 doesn't care about whitespace, so
+				// it's safe to split by newlines and re-wrap to make it
+				// prettier
+				headerString = strings.Join(
+					strings.Split(headerString, "\n"),
+					"")
+				if err := mw.writeWrappedStringPair("device-key", headerString, termWidth); err != nil {
+					return err
+				}
+
+			// the default is all the rest of short scalar values, which all
+			// should be strings
+			default:
+				headerString, ok := headerValue.(string)
+				if !ok {
+					return invalidTypeErr
+				}
+				mw.writeStringPair(headerName, headerString)
+			}
+		}
+	}
+	mw.endObject()
+	return w.Flush()
+}

--- a/client/clientutil/modelinfo_test.go
+++ b/client/clientutil/modelinfo_test.go
@@ -1,0 +1,444 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018-2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package clientutil_test
+
+import (
+	"bytes"
+	"text/tabwriter"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/client/clientutil"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type modelInfoSuite struct {
+	testutil.BaseTest
+}
+
+func (s *modelInfoSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+}
+
+var _ = Suite(&modelInfoSuite{})
+
+func (*modelInfoSuite) TestBasicObjectAnonymousRootYaml(c *C) {
+	var buffer bytes.Buffer
+	var tbw tabwriter.Writer
+	tbw.Init(&buffer, 4, 4, 0, '\t', 0)
+
+	writer := clientutil.NewModelWriter(&tbw, clientutil.MODELWRITER_YAML_FORMAT)
+
+	// test basic object functionality with yaml, with empty name to mark
+	// the root object as root.
+	writer.StartObject("")
+	writer.WriteStringPair("foo", "bar")
+	writer.WriteStringPair("baz", "qux")
+	writer.EndObject()
+
+	tbw.Flush()
+	c.Check(buffer.String(), Equals, "foo:bar\nbaz:qux\n")
+}
+
+func (*modelInfoSuite) TestBasicObjectYaml(c *C) {
+	var buffer bytes.Buffer
+	var tbw tabwriter.Writer
+	tbw.Init(&buffer, 4, 4, 0, '\t', 0)
+
+	writer := clientutil.NewModelWriter(&tbw, clientutil.MODELWRITER_YAML_FORMAT)
+
+	// test basic object functionality with yaml, with empty name to mark
+	// the root object as root.
+	writer.StartObject("project")
+	writer.WriteStringPair("foo", "bar")
+	writer.WriteStringPair("baz", "qux")
+	writer.EndObject()
+
+	tbw.Flush()
+	c.Check(buffer.String(), Equals, "project:\n  foo:\tbar\n  baz:\tqux\n")
+}
+
+func (*modelInfoSuite) TestNestedObjectYaml(c *C) {
+	var buffer bytes.Buffer
+	var tbw tabwriter.Writer
+	tbw.Init(&buffer, 4, 4, 0, '\t', 0)
+
+	writer := clientutil.NewModelWriter(&tbw, clientutil.MODELWRITER_YAML_FORMAT)
+
+	// test basic object functionality with yaml, with empty name to mark
+	// the root object as root.
+	writer.StartObject("project")
+	writer.WriteStringPair("foo", "bar")
+	writer.WriteStringPair("baz", "qux")
+	writer.StartObject("sub")
+	writer.WriteStringPair("foo", "bar")
+	writer.WriteStringPair("baz", "qux")
+	writer.EndObject()
+	writer.EndObject()
+
+	tbw.Flush()
+	c.Check(buffer.String(), Equals, `project:
+  foo:	bar
+  baz:	qux
+  sub:
+    foo:bar
+    baz:qux
+`)
+}
+
+func (*modelInfoSuite) TestNestedObjectWithArrayYaml(c *C) {
+	var buffer bytes.Buffer
+	var tbw tabwriter.Writer
+	tbw.Init(&buffer, 4, 4, 0, '\t', 0)
+
+	writer := clientutil.NewModelWriter(&tbw, clientutil.MODELWRITER_YAML_FORMAT)
+
+	// test basic object functionality with yaml, with empty name to mark
+	// the root object as root.
+	writer.StartObject("project")
+	writer.WriteStringPair("foo", "bar")
+	writer.WriteStringPair("baz", "qux")
+	writer.StartObject("sub")
+	writer.WriteStringPair("foo", "bar")
+	writer.WriteStringPair("baz", "qux")
+	writer.StartArray("items", false)
+	writer.WriteStringValue("item1")
+	writer.WriteStringValue("item2")
+	writer.EndArray()
+	writer.WriteStringPair("xxx", "yyy")
+	writer.EndObject()
+	writer.EndObject()
+
+	tbw.Flush()
+	c.Check(buffer.String(), Equals, `project:
+  foo:	bar
+  baz:	qux
+  sub:
+    foo:	bar
+    baz:	qux
+    items:	
+      - item1
+      - item2
+    xxx:yyy
+`)
+}
+
+func (*modelInfoSuite) TestArrayOfObjectsYaml(c *C) {
+	var buffer bytes.Buffer
+	var tbw tabwriter.Writer
+	tbw.Init(&buffer, 4, 4, 0, '\t', 0)
+
+	writer := clientutil.NewModelWriter(&tbw, clientutil.MODELWRITER_YAML_FORMAT)
+
+	// test basic object functionality with yaml, with empty name to mark
+	// the root object as root.
+	writer.StartObject("project")
+	writer.WriteStringPair("foo", "bar")
+	writer.WriteStringPair("baz", "qux")
+	writer.StartArray("objects", false)
+	writer.StartObject("object1")
+	writer.WriteStringPair("foo", "bar")
+	writer.WriteStringPair("baz", "qux")
+	writer.EndObject()
+	writer.StartObject("object2")
+	writer.WriteStringPair("foo", "bar")
+	writer.WriteStringPair("baz", "qux")
+	writer.EndObject()
+	writer.EndArray()
+	writer.EndObject()
+
+	tbw.Flush()
+	c.Check(buffer.String(), Equals, `project:
+  foo:		bar
+  baz:		qux
+  objects:	
+    - name:	object1
+      foo:	bar
+      baz:	qux
+    - name:	object2
+      foo:	bar
+      baz:	qux
+`)
+}
+
+func (*modelInfoSuite) TestObjectWithArrayYaml(c *C) {
+	var buffer bytes.Buffer
+	var tbw tabwriter.Writer
+	tbw.Init(&buffer, 4, 4, 0, '\t', 0)
+
+	writer := clientutil.NewModelWriter(&tbw, clientutil.MODELWRITER_YAML_FORMAT)
+
+	// test basic object functionality with yaml, with empty name to mark
+	// the root object as root.
+	writer.StartObject("project")
+	writer.StartArray("foo", false)
+	writer.WriteStringValue("bar")
+	writer.WriteStringValue("baz")
+
+	// this should have no effect as it's not allowed to write pairs
+	// in arrays, instead we should use StartObject
+	writer.WriteStringPair("qux", "quux")
+
+	writer.EndArray()
+	writer.EndObject()
+
+	tbw.Flush()
+	c.Check(buffer.String(), Equals, `project:
+  foo:	
+    - bar
+    - baz
+`)
+}
+
+func (*modelInfoSuite) TestObjectWithInlineArrayYaml(c *C) {
+	var buffer bytes.Buffer
+	var tbw tabwriter.Writer
+	tbw.Init(&buffer, 4, 4, 0, '\t', 0)
+
+	writer := clientutil.NewModelWriter(&tbw, clientutil.MODELWRITER_YAML_FORMAT)
+
+	// test basic object functionality with yaml, with empty name to mark
+	// the root object as root.
+	writer.StartObject("project")
+	writer.StartArray("foo", true)
+	writer.WriteStringValue("bar")
+	writer.WriteStringValue("baz")
+
+	// this should have no effect as it's not allowed to write pairs
+	// in arrays, instead we should use StartObject
+	writer.WriteStringPair("qux", "quux")
+
+	writer.EndArray()
+	writer.EndObject()
+
+	tbw.Flush()
+	c.Check(buffer.String(), Equals, `project:
+  foo:	[bar, baz]
+`)
+}
+
+func (*modelInfoSuite) TestBasicObjectAnonymousRootJson(c *C) {
+	var buffer bytes.Buffer
+	var tbw tabwriter.Writer
+	tbw.Init(&buffer, 4, 4, 0, '\t', 0)
+
+	writer := clientutil.NewModelWriter(&tbw, clientutil.MODELWRITER_JSON_FORMAT)
+
+	writer.StartObject("")
+	writer.WriteStringPair("foo", "bar")
+	writer.WriteStringPair("baz", "qux")
+	writer.EndObject()
+
+	tbw.Flush()
+	c.Check(buffer.String(), Equals, "{\n  \"foo\": \"bar\",\n  \"baz\": \"qux\"\n}\n")
+}
+
+func (*modelInfoSuite) TestBasicObjectJson(c *C) {
+	var buffer bytes.Buffer
+	var tbw tabwriter.Writer
+	tbw.Init(&buffer, 4, 4, 0, '\t', 0)
+
+	writer := clientutil.NewModelWriter(&tbw, clientutil.MODELWRITER_JSON_FORMAT)
+
+	// the root object of json is ignored always, as json always has a anonymous root
+	writer.StartObject("")
+	writer.WriteStringPair("foo", "bar")
+	writer.WriteStringPair("baz", "qux")
+	writer.EndObject()
+
+	tbw.Flush()
+	c.Check(buffer.String(), Equals, "{\n  \"foo\": \"bar\",\n  \"baz\": \"qux\"\n}\n")
+}
+
+func (*modelInfoSuite) TestNestedObjectJson(c *C) {
+	var buffer bytes.Buffer
+	var tbw tabwriter.Writer
+	tbw.Init(&buffer, 4, 4, 0, '\t', 0)
+
+	writer := clientutil.NewModelWriter(&tbw, clientutil.MODELWRITER_JSON_FORMAT)
+
+	// test basic object functionality with yaml, with empty name to mark
+	// the root object as root.
+	writer.StartObject("")
+	writer.WriteStringPair("foo", "bar")
+	writer.WriteStringPair("baz", "qux")
+	writer.StartObject("sub")
+	writer.WriteStringPair("foo", "bar")
+	writer.WriteStringPair("baz", "qux")
+	writer.EndObject()
+	writer.EndObject()
+
+	tbw.Flush()
+	c.Check(buffer.String(), Equals, `{
+  "foo": "bar",
+  "baz": "qux",
+  "sub": {
+    "foo": "bar",
+    "baz": "qux"
+  }
+}
+`)
+}
+
+func (*modelInfoSuite) TestNestedObjectWithArrayJson(c *C) {
+	var buffer bytes.Buffer
+	var tbw tabwriter.Writer
+	tbw.Init(&buffer, 4, 4, 0, '\t', 0)
+
+	writer := clientutil.NewModelWriter(&tbw, clientutil.MODELWRITER_JSON_FORMAT)
+
+	// test basic object functionality with yaml, with empty name to mark
+	// the root object as root.
+	writer.StartObject("")
+	writer.WriteStringPair("foo", "bar")
+	writer.WriteStringPair("baz", "qux")
+	writer.StartObject("sub")
+	writer.WriteStringPair("foo", "bar")
+	writer.WriteStringPair("baz", "qux")
+	writer.StartArray("items", false)
+	writer.WriteStringValue("item1")
+	writer.WriteStringValue("item2")
+	writer.EndArray()
+	writer.WriteStringPair("xxx", "yyy")
+	writer.EndObject()
+	writer.EndObject()
+
+	tbw.Flush()
+	c.Check(buffer.String(), Equals, `{
+  "foo": "bar",
+  "baz": "qux",
+  "sub": {
+    "foo": "bar",
+    "baz": "qux",
+    "items": [
+      "item1",
+      "item2"
+    ],
+    "xxx": "yyy"
+  }
+}
+`)
+}
+
+func (*modelInfoSuite) TestArrayOfObjectsJson(c *C) {
+	var buffer bytes.Buffer
+	var tbw tabwriter.Writer
+	tbw.Init(&buffer, 4, 4, 0, '\t', 0)
+
+	writer := clientutil.NewModelWriter(&tbw, clientutil.MODELWRITER_JSON_FORMAT)
+
+	// test basic object functionality with yaml, with empty name to mark
+	// the root object as root.
+	writer.StartObject("")
+	writer.WriteStringPair("foo", "bar")
+	writer.WriteStringPair("baz", "qux")
+	writer.StartArray("objects", false)
+	writer.StartObject("object1")
+	writer.WriteStringPair("foo", "bar")
+	writer.WriteStringPair("baz", "qux")
+	writer.EndObject()
+	writer.StartObject("object2")
+	writer.WriteStringPair("foo", "bar")
+	writer.WriteStringPair("baz", "qux")
+	writer.EndObject()
+	writer.EndArray()
+	writer.EndObject()
+
+	tbw.Flush()
+	c.Check(buffer.String(), Equals, `{
+  "foo": "bar",
+  "baz": "qux",
+  "objects": [
+    {
+      "name": "object1",
+      "foo": "bar",
+      "baz": "qux"
+    },
+    {
+      "name": "object2",
+      "foo": "bar",
+      "baz": "qux"
+    }
+  ]
+}
+`)
+}
+
+func (*modelInfoSuite) TestObjectWithArrayJson(c *C) {
+	var buffer bytes.Buffer
+	var tbw tabwriter.Writer
+	tbw.Init(&buffer, 4, 4, 0, '\t', 0)
+
+	writer := clientutil.NewModelWriter(&tbw, clientutil.MODELWRITER_JSON_FORMAT)
+
+	// test basic object functionality with yaml, with empty name to mark
+	// the root object as root.
+	writer.StartObject("")
+	writer.StartArray("foo", false)
+	writer.WriteStringValue("bar")
+	writer.WriteStringValue("baz")
+
+	// this should have no effect as it's not allowed to write pairs
+	// in arrays, instead we should use StartObject
+	writer.WriteStringPair("qux", "quux")
+
+	writer.EndArray()
+	writer.EndObject()
+
+	tbw.Flush()
+	c.Check(buffer.String(), Equals, `{
+  "foo": [
+    "bar",
+    "baz"
+  ]
+}
+`)
+}
+
+func (*modelInfoSuite) TestObjectWithInlineArrayJson(c *C) {
+	var buffer bytes.Buffer
+	var tbw tabwriter.Writer
+	tbw.Init(&buffer, 4, 4, 0, '\t', 0)
+
+	writer := clientutil.NewModelWriter(&tbw, clientutil.MODELWRITER_JSON_FORMAT)
+
+	// test basic object functionality with yaml, with empty name to mark
+	// the root object as root.
+	writer.StartObject("")
+	writer.StartArray("foo", true)
+	writer.WriteStringValue("bar")
+	writer.WriteStringValue("baz")
+
+	// this should have no effect as it's not allowed to write pairs
+	// in arrays, instead we should use StartObject
+	writer.WriteStringPair("qux", "quux")
+
+	writer.EndArray()
+	writer.EndObject()
+
+	tbw.Flush()
+	c.Check(buffer.String(), Equals, `{
+  "foo": [
+    "bar",
+    "baz"
+  ]
+}
+`)
+}

--- a/cmd/snap/cmd_model.go
+++ b/cmd/snap/cmd_model.go
@@ -170,7 +170,7 @@ func (x *cmdModel) Execute(args []string) error {
 		format = clientutil.MODELWRITER_RAW_FORMAT
 	}
 
-	err := clientutil.PrintModelAssertation(
+	err := clientutil.PrintModelAssertion(
 		w, format, modelFormatter,
 		termWidth, x.Serial, x.AbsTime, x.Verbose, x.Assertion,
 		modelAssertion, serialAssertion)

--- a/cmd/snap/cmd_model.go
+++ b/cmd/snap/cmd_model.go
@@ -21,15 +21,13 @@ package main
 
 import (
 	"errors"
-	"fmt"
-	"strings"
-	"time"
 
 	"github.com/jessevdk/go-flags"
 
-	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/client"
+	"github.com/snapcore/snapd/client/clientutil"
 	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/snap"
 )
 
 var (
@@ -48,10 +46,9 @@ Similarly, the active serial assertion can be used for the output instead of the
 model assertion.
 `)
 
-	invalidTypeMessage    = i18n.G("invalid type for %q header")
 	errNoMainAssertion    = errors.New(i18n.G("device not ready yet (no assertions found)"))
-	errNoSerial           = errors.New(i18n.G("device not registered yet (no serial assertion found)"))
 	errNoVerboseAssertion = errors.New(i18n.G("cannot use --verbose with --assertion"))
+	errNoSerial           = errors.New(i18n.G("device not registered yet (no serial assertion found)"))
 
 	// this list is a "nice" "human" "readable" "ordering" of headers to print
 	// off, sorted in lexical order with meta headers and primary key headers
@@ -88,6 +85,19 @@ type cmdModel struct {
 	Assertion bool `long:"assertion"`
 }
 
+type cmdModelFormatter struct {
+	storeAccount *snap.StoreAccount
+	esc          *escapes
+}
+
+func (mf cmdModelFormatter) GetEscapedDash() string {
+	return mf.esc.dash
+}
+
+func (mf cmdModelFormatter) GetPublisher() string {
+	return longPublisher(mf.esc, mf.storeAccount)
+}
+
 func init() {
 	addCommand("model",
 		shortModelHelp,
@@ -110,7 +120,6 @@ func (x *cmdModel) Execute(args []string) error {
 		return errNoVerboseAssertion
 	}
 
-	var mainAssertion asserts.Assertion
 	serialAssertion, serialErr := x.client.CurrentSerialAssertion()
 	modelAssertion, modelErr := x.client.CurrentModelAssertion()
 
@@ -126,25 +135,11 @@ func (x *cmdModel) Execute(args []string) error {
 	// if the serial assertion error is anything other than not found, also
 	// bail early
 	// the serial assertion not being found may not be fatal
-	if serialErr != nil && !client.IsAssertionNotFoundError(serialErr) {
-		return serialErr
-	}
-
-	if x.Serial {
-		mainAssertion = serialAssertion
-	} else {
-		mainAssertion = modelAssertion
-	}
-
-	if x.Assertion {
-		// if we are using the serial assertion and we specifically didn't find the
-		// serial assertion, bail with specific error
-		if x.Serial && client.IsAssertionNotFoundError(serialErr) {
-			return errNoMainAssertion
+	if serialErr != nil {
+		if !client.IsAssertionNotFoundError(serialErr) {
+			return serialErr
 		}
-
-		_, err := Stdout.Write(asserts.Encode(mainAssertion))
-		return err
+		serialAssertion = nil
 	}
 
 	termWidth, _ := termSize()
@@ -154,256 +149,33 @@ func (x *cmdModel) Execute(args []string) error {
 		termWidth = 100
 	}
 
-	esc := x.getEscapes()
-
 	w := tabWriter()
-
-	if x.Serial && client.IsAssertionNotFoundError(serialErr) {
-		// for serial assertion, the primary keys are output (model and
-		// brand-id), but if we didn't find the serial assertion then we still
-		// output the brand-id and model from the model assertion, but also
-		// return a devNotReady error
-		fmt.Fprintf(w, "brand-id:\t%s\n", modelAssertion.HeaderString("brand-id"))
-		fmt.Fprintf(w, "model:\t%s\n", modelAssertion.HeaderString("model"))
-		w.Flush()
-		return errNoSerial
+	format := clientutil.MODELWRITER_YAML_FORMAT
+	modelFormatter := cmdModelFormatter{
+		esc: x.getEscapes(),
 	}
 
-	// the rest of this function is the main flow for outputting either the
-	// model or serial assertion in normal or verbose mode
-
-	// for the `snap model` case with no options, we don't want colons, we want
-	// to be like `snap version`
-	separator := ":"
-	if !x.Verbose && !x.Serial {
-		separator = ""
-	}
-
-	// ordering of the primary keys for model: brand, model, serial
-	// ordering of primary keys for serial is brand-id, model, serial
-
-	// output brand/brand-id
-	brandIDHeader := mainAssertion.HeaderString("brand-id")
-	modelHeader := mainAssertion.HeaderString("model")
-	// for the serial header, if there's no serial yet, it's not an error for
-	// model (and we already handled the serial error above) but need to add a
-	// parenthetical about the device not being registered yet
-	var serial string
-	if client.IsAssertionNotFoundError(serialErr) {
-		if x.Verbose || x.Serial {
-			// verbose and serial are yamlish, so we need to escape the dash
-			serial = esc.dash
-		} else {
-			serial = "-"
-		}
-		serial += " (device not registered yet)"
-	} else {
-		serial = serialAssertion.HeaderString("serial")
-	}
-
-	// handle brand/brand-id and model/model + display-name differently on just
-	// `snap model` w/o opts
-	if x.Serial || x.Verbose {
-		fmt.Fprintf(w, "brand-id:\t%s\n", brandIDHeader)
-		fmt.Fprintf(w, "model:\t%s\n", modelHeader)
-	} else {
-		// for the model command (not --serial) we want to show a publisher
-		// style display of "brand" instead of just "brand-id"
+	// for the model command (not --serial) we want to show a publisher
+	// style display of "brand" instead of just "brand-id"
+	if !x.Serial && !x.Verbose {
+		brandIDHeader := modelAssertion.HeaderString("brand-id")
 		storeAccount, err := x.client.StoreAccount(brandIDHeader)
 		if err != nil {
 			return err
 		}
-		// use the longPublisher helper to format the brand store account
-		// like we do in `snap info`
-		fmt.Fprintf(w, "brand%s\t%s\n", separator, longPublisher(x.getEscapes(), storeAccount))
-
-		// for model, if there's a display-name, we show that first with the
-		// real model in parenthesis
-		if displayName := modelAssertion.HeaderString("display-name"); displayName != "" {
-			modelHeader = fmt.Sprintf("%s (%s)", displayName, modelHeader)
-		}
-		fmt.Fprintf(w, "model%s\t%s\n", separator, modelHeader)
+		modelFormatter.storeAccount = storeAccount
 	}
 
-	// only output the grade if it is non-empty, either it is not in the model
-	// assertion for all non-uc20 model assertions, or it is non-empty and
-	// required for uc20 model assertions
-	grade := modelAssertion.HeaderString("grade")
-	if grade != "" {
-		fmt.Fprintf(w, "grade%s\t%s\n", separator, grade)
+	if !x.Serial && !x.Verbose {
+		format = clientutil.MODELWRITER_RAW_FORMAT
 	}
 
-	storageSafety := modelAssertion.HeaderString("storage-safety")
-	if storageSafety != "" {
-		fmt.Fprintf(w, "storage-safety%s\t%s\n", separator, storageSafety)
+	err := clientutil.PrintModelAssertation(
+		w, format, modelFormatter,
+		termWidth, x.Serial, x.AbsTime, x.Verbose, x.Assertion,
+		modelAssertion, serialAssertion)
+	if err != nil {
+		return err
 	}
-
-	// serial is same for all variants
-	fmt.Fprintf(w, "serial%s\t%s\n", separator, serial)
-
-	// --verbose means output more information
-	if x.Verbose {
-		allHeadersMap := mainAssertion.Headers()
-
-		for _, headerName := range niceOrdering {
-			invalidTypeErr := fmt.Errorf(invalidTypeMessage, headerName)
-
-			headerValue, ok := allHeadersMap[headerName]
-			// make sure the header is in the map
-			if !ok {
-				continue
-			}
-
-			// switch on which header it is to handle some special cases
-			switch headerName {
-			// list of scalars
-			case "required-snaps", "system-user-authority":
-				headerIfaceList, ok := headerValue.([]interface{})
-				if !ok {
-					return invalidTypeErr
-				}
-				if len(headerIfaceList) == 0 {
-					continue
-				}
-				fmt.Fprintf(w, "%s:\t\n", headerName)
-				for _, elem := range headerIfaceList {
-					headerStringElem, ok := elem.(string)
-					if !ok {
-						return invalidTypeErr
-					}
-					// note we don't wrap these, since for now this is
-					// specifically just required-snaps and so all of these
-					// will be snap names which are required to be short
-					fmt.Fprintf(w, "  - %s\n", headerStringElem)
-				}
-
-			//timestamp needs to be formatted with fmtTime from the timeMixin
-			case "timestamp":
-				timestamp, ok := headerValue.(string)
-				if !ok {
-					return invalidTypeErr
-				}
-
-				// parse the time string as RFC3339, which is what the format is
-				// always in for assertions
-				t, err := time.Parse(time.RFC3339, timestamp)
-				if err != nil {
-					return err
-				}
-				fmt.Fprintf(w, "timestamp:\t%s\n", x.fmtTime(t))
-
-			// long string key we don't want to rewrap but can safely handle
-			// on "reasonable" width terminals
-			case "device-key-sha3-384":
-				// also flush the writer before continuing so the previous keys
-				// don't try to align with this key
-				w.Flush()
-				headerString, ok := headerValue.(string)
-				if !ok {
-					return invalidTypeErr
-				}
-
-				switch {
-				case termWidth > 86:
-					fmt.Fprintf(w, "device-key-sha3-384: %s\n", headerString)
-				case termWidth <= 86 && termWidth > 66:
-					fmt.Fprintln(w, "device-key-sha3-384: |")
-					wrapLine(w, []rune(headerString), "  ", termWidth)
-				}
-			case "snaps":
-				// also flush the writer before continuing so the previous keys
-				// don't try to align with this key
-				w.Flush()
-				snapsHeader, ok := headerValue.([]interface{})
-				if !ok {
-					return invalidTypeErr
-				}
-				if len(snapsHeader) == 0 {
-					// unexpected why this is an empty list, but just ignore for
-					// now
-					continue
-				}
-				fmt.Fprintf(w, "snaps:\n")
-				for _, sn := range snapsHeader {
-					snMap, ok := sn.(map[string]interface{})
-					if !ok {
-						return invalidTypeErr
-					}
-					// iterate over all keys in the map in a stable, visually
-					// appealing ordering
-					// first do snap name, which will always be present since we
-					// parsed a valid assertion
-					name := snMap["name"].(string)
-					fmt.Fprintf(w, "  - name:\t%s\n", name)
-
-					// the rest of these may be absent, but they are all still
-					// simple strings
-					for _, snKey := range []string{"id", "type", "default-channel", "presence"} {
-						snValue, ok := snMap[snKey]
-						if !ok {
-							continue
-						}
-						snStrValue, ok := snValue.(string)
-						if !ok {
-							return invalidTypeErr
-						}
-						if snStrValue != "" {
-							fmt.Fprintf(w, "    %s:\t%s\n", snKey, snStrValue)
-						}
-					}
-
-					// finally handle "modes" which is a list
-					modes, ok := snMap["modes"]
-					if !ok {
-						continue
-					}
-					modesSlice, ok := modes.([]interface{})
-					if !ok {
-						return invalidTypeErr
-					}
-					if len(modesSlice) == 0 {
-						continue
-					}
-
-					modeStrSlice := make([]string, 0, len(modesSlice))
-					for _, mode := range modesSlice {
-						modeStr, ok := mode.(string)
-						if !ok {
-							return invalidTypeErr
-						}
-						modeStrSlice = append(modeStrSlice, modeStr)
-					}
-					modesSliceYamlStr := "[" + strings.Join(modeStrSlice, ", ") + "]"
-					fmt.Fprintf(w, "    modes:\t%s\n", modesSliceYamlStr)
-				}
-
-			// long base64 key we can rewrap safely
-			case "device-key":
-				headerString, ok := headerValue.(string)
-				if !ok {
-					return invalidTypeErr
-				}
-				// the string value here has newlines inserted as part of the
-				// raw assertion, but base64 doesn't care about whitespace, so
-				// it's safe to split by newlines and re-wrap to make it
-				// prettier
-				headerString = strings.Join(
-					strings.Split(headerString, "\n"),
-					"")
-				fmt.Fprintln(w, "device-key: |")
-				wrapLine(w, []rune(headerString), "  ", termWidth)
-
-			// the default is all the rest of short scalar values, which all
-			// should be strings
-			default:
-				headerString, ok := headerValue.(string)
-				if !ok {
-					return invalidTypeErr
-				}
-				fmt.Fprintf(w, "%s:\t%s\n", headerName, headerString)
-			}
-		}
-	}
-
 	return w.Flush()
 }

--- a/cmd/snap/cmd_model_test.go
+++ b/cmd/snap/cmd_model_test.go
@@ -457,7 +457,7 @@ serial:          serialserial
 architecture:    amd64
 base:            core20
 timestamp:       2018-09-11T22:00:00Z
-snaps:
+snaps:                
   - name:             pc
     id:               UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH
     type:             gadget

--- a/overlord/hookstate/ctlcmd/model.go
+++ b/overlord/hookstate/ctlcmd/model.go
@@ -1,0 +1,157 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package ctlcmd
+
+import (
+	"fmt"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/snapcore/snapd/client/clientutil"
+	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/overlord/devicestate"
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+)
+
+var (
+	shortModelHelp = i18n.G("Get the active model for this device")
+	longModelHelp  = i18n.G(`
+The model command returns the active model assertion information for this
+device.
+
+By default, the model identification information is presented in a structured,
+yaml-like format, but this can be changed to json by using the --json flag.
+
+Similarly, the active serial assertion can be used for the output instead of the
+model assertion.
+`)
+)
+
+func init() {
+	addCommand("model", shortModelHelp, longModelHelp, func() command { return &modelCommand{} })
+}
+
+type modelCommand struct {
+	baseCommand
+	Assertion bool `long:"assertion"`
+	Json      bool `long:"json"`
+	TermWidth int  `long:"term-width"`
+}
+
+type modelCommandFormatter struct {
+	storeAccount *snap.StoreAccount
+}
+
+func (mf modelCommandFormatter) GetEscapedDash() string {
+	return "--"
+}
+
+func (mf modelCommandFormatter) GetEscapedTick() string {
+	return "*"
+}
+
+func (mf modelCommandFormatter) GetPublisher() string {
+	if mf.storeAccount == nil {
+		return mf.GetEscapedDash() + "\033[0m"
+	}
+
+	badge := ""
+	if mf.storeAccount.Validation == "verified" {
+		badge = mf.GetEscapedTick()
+	}
+
+	// NOTE this makes e.g. 'Potato' == 'potato', and 'Potato Team' == 'potato-team',
+	// but 'Potato Team' != 'potatoteam', 'Potato Inc.' != 'potato' (in fact 'Potato Inc.' != 'potato-inc')
+	if strings.EqualFold(strings.Replace(mf.storeAccount.Username, "-", " ", -1), mf.storeAccount.DisplayName) {
+		return mf.storeAccount.DisplayName + badge + "\033[0m"
+	}
+	return fmt.Sprintf("%s (%s%s%s)", mf.storeAccount.DisplayName, mf.storeAccount.Username, badge, "\033[0m")
+}
+
+func (c *modelCommand) reportError(format string, a ...interface{}) {
+	w := tabwriter.NewWriter(c.stderr, 2, 2, 2, ' ', 0)
+	fmt.Fprintf(w, format, a...)
+}
+
+func (c *modelCommand) checkGadgetOrModel(st *state.State, snapName string) error {
+	st.Lock()
+	defer st.Unlock()
+
+	var snapst snapstate.SnapState
+	if err := snapstate.Get(st, snapName, &snapst); err != nil {
+		return fmt.Errorf("failed to get snapstate for snap %s: %v", snapName, err)
+	}
+
+	// get the brand of the current snap
+	snapInfo, err := snapst.CurrentInfo()
+	if err != nil {
+		return err
+	}
+
+	deviceCtx, err := devicestate.DeviceCtx(st, nil, nil)
+	if err != nil {
+		return err
+	}
+
+	// the request snap must be a gadget or come from the same
+	// brand as the device model assertion
+	if snapType := snapInfo.Type(); snapType != snap.TypeGadget {
+		if snapInfo.Publisher.ID != deviceCtx.Model().BrandID() {
+			c.reportError("cannot get model assertion for snap %q: not a gadget or from the same brand as the device model assertion\n", snapName)
+			return fmt.Errorf("insufficient permissions to get model assertion for snap %q", snapName)
+		}
+	}
+	return nil
+}
+
+func (c *modelCommand) Execute([]string) error {
+	context, err := c.ensureContext()
+	if err != nil {
+		return err
+	}
+
+	st := context.State()
+	if err := c.checkGadgetOrModel(st, context.InstanceName()); err != nil {
+		return err
+	}
+
+	st.Lock()
+	deviceCtx, err := snapstate.DeviceCtx(st, nil, nil)
+	if err != nil {
+		return err
+	}
+	st.Unlock()
+
+	format := clientutil.MODELWRITER_YAML_FORMAT
+	if c.Json {
+		format = clientutil.MODELWRITER_JSON_FORMAT
+	}
+
+	var modelFormatter modelCommandFormatter
+	modelAssertation := deviceCtx.Model()
+	w := tabwriter.NewWriter(c.stdout, 2, 2, 2, ' ', 0)
+	if err = clientutil.PrintModelAssertation(w, format, modelFormatter, c.TermWidth, false, false, true, c.Assertion, modelAssertation, nil); err != nil {
+		return err
+	}
+	w.Flush()
+	return nil
+}

--- a/overlord/hookstate/ctlcmd/model.go
+++ b/overlord/hookstate/ctlcmd/model.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2018 Canonical Ltd
+ * Copyright (C) 2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/overlord/hookstate/ctlcmd/model_test.go
+++ b/overlord/hookstate/ctlcmd/model_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2021 Canonical Ltd
+ * Copyright (C) 2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/overlord/hookstate/ctlcmd/model_test.go
+++ b/overlord/hookstate/ctlcmd/model_test.go
@@ -1,0 +1,422 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package ctlcmd_test
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/asserts/assertstest"
+	"github.com/snapcore/snapd/asserts/sysdb"
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/gadget"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/overlord"
+	"github.com/snapcore/snapd/overlord/assertstate"
+	"github.com/snapcore/snapd/overlord/assertstate/assertstatetest"
+	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/overlord/devicestate"
+	"github.com/snapcore/snapd/overlord/devicestate/devicestatetest"
+	"github.com/snapcore/snapd/overlord/hookstate"
+	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
+	"github.com/snapcore/snapd/overlord/hookstate/hooktest"
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/overlord/storecontext"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/store/storetest"
+	"github.com/snapcore/snapd/sysconfig"
+	"github.com/snapcore/snapd/testutil"
+	"github.com/snapcore/snapd/timeutil"
+)
+
+type modelSuite struct {
+	testutil.BaseTest
+
+	o           *overlord.Overlord
+	state       *state.State
+	hookMgr     *hookstate.HookManager
+	mgr         *devicestate.DeviceManager
+	db          *asserts.Database
+	mockHandler *hooktest.MockHandler
+
+	storeSigning *assertstest.StoreStack
+	brands       *assertstest.SigningAccounts
+
+	newFakeStore func(storecontext.DeviceBackend) snapstate.StoreService
+}
+
+type fakeSnapStore struct {
+	storetest.Store
+
+	state *state.State
+	db    asserts.RODatabase
+}
+
+var _ = Suite(&modelSuite{})
+
+var (
+	brandPrivKey, _  = assertstest.GenerateKey(752)
+	brandPrivKey2, _ = assertstest.GenerateKey(752)
+)
+
+func (s *modelSuite) newStore(devBE storecontext.DeviceBackend) snapstate.StoreService {
+	return s.newFakeStore(devBE)
+}
+
+func (s *modelSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+
+	dirs.SetRootDir(c.MkDir())
+	s.AddCleanup(func() { dirs.SetRootDir("") })
+
+	err := os.MkdirAll(dirs.SnapRunDir, 0755)
+	c.Assert(err, IsNil)
+	err = os.MkdirAll(dirs.SnapdStateDir(dirs.GlobalRootDir), 0755)
+	c.Assert(err, IsNil)
+
+	s.AddCleanup(osutil.MockMountInfo(``))
+
+	s.o = overlord.Mock()
+	s.state = s.o.State()
+	s.mockHandler = hooktest.NewMockHandler()
+	s.storeSigning = assertstest.NewStoreStack("canonical", nil)
+
+	s.AddCleanup(sysdb.MockGenericClassicModel(s.storeSigning.GenericClassicModel))
+
+	s.brands = assertstest.NewSigningAccounts(s.storeSigning)
+	s.brands.Register("my-brand", brandPrivKey, map[string]interface{}{
+		"display-name": "fancy model publisher",
+		"validation":   "certified",
+	})
+	s.brands.Register("rereg-brand", brandPrivKey2, nil)
+
+	db, err := asserts.OpenDatabase(&asserts.DatabaseConfig{
+		Backstore:       asserts.NewMemoryBackstore(),
+		Trusted:         s.storeSigning.Trusted,
+		OtherPredefined: s.storeSigning.Generic,
+	})
+	c.Assert(err, IsNil)
+
+	s.state.Lock()
+	assertstate.ReplaceDB(s.state, db)
+	s.state.Unlock()
+	s.AddCleanup(func() {
+		s.state.Lock()
+		assertstate.ReplaceDB(s.state, nil)
+		s.state.Unlock()
+	})
+
+	err = db.Add(s.storeSigning.StoreAccountKey(""))
+	c.Assert(err, IsNil)
+
+	hookMgr, err := hookstate.Manager(s.state, s.o.TaskRunner())
+	c.Assert(err, IsNil)
+
+	devicestate.EarlyConfig = func(*state.State, func() (sysconfig.Device, *gadget.Info, error)) error {
+		return nil
+	}
+	s.AddCleanup(func() { devicestate.EarlyConfig = nil })
+
+	mgr, err := devicestate.Manager(s.state, hookMgr, s.o.TaskRunner(), s.newStore)
+	c.Assert(err, IsNil)
+
+	s.db = db
+	s.hookMgr = hookMgr
+	s.o.AddManager(s.hookMgr)
+	s.mgr = mgr
+	s.o.AddManager(s.mgr)
+	s.o.AddManager(s.o.TaskRunner())
+
+	s.state.Lock()
+	snapstate.ReplaceStore(s.state, &fakeSnapStore{
+		state: s.state,
+		db:    s.storeSigning,
+	})
+	s.state.Unlock()
+
+	s.AddCleanup(func() { s.newFakeStore = nil })
+}
+
+func (s *modelSuite) setupBrands() {
+	assertstatetest.AddMany(s.state, s.brands.AccountsAndKeys("my-brand")...)
+	otherAcct := assertstest.NewAccount(s.storeSigning, "other-brand", map[string]interface{}{
+		"account-id": "other-brand",
+	}, "")
+	assertstatetest.AddMany(s.state, otherAcct)
+}
+
+const snapGadgetYaml = `name: gadget1
+type: gadget
+version: 1
+`
+
+const snapBaseYaml = `name: snap1-base
+type: base
+version: 1
+`
+
+const snapYaml = `name: snap1
+base: snap1-base
+version: 1
+`
+
+func (s *modelSuite) TestUnhappyModelCommandNotGadgetOrSamePublisher(c *C) {
+	// Make sure that we can not get the model assertation if we are not a gadget
+	// type snap, or if we are not the publisher of the model assertion.
+	s.state.Lock()
+	s.setupBrands()
+
+	// set a model assertion
+	current := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+		"architecture": "amd64",
+		"kernel":       "pc-kernel",
+		"gadget":       "pc",
+		"base":         "core18",
+	})
+	err := assertstate.Add(s.state, current)
+	c.Assert(err, IsNil)
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
+		Brand: "canonical",
+		Model: "pc-model",
+	})
+
+	c.Assert(err, IsNil)
+	task := s.state.NewTask("test-task", "my test task")
+	setup := &hookstate.HookSetup{Snap: "snap1", Revision: snap.R(1), Hook: "test-hook"}
+	mockContext, err := hookstate.NewContext(task, s.state, setup, s.mockHandler, "")
+	c.Assert(err, IsNil)
+	mockInstalledSnap(c, s.state, snapBaseYaml, "")
+	mockInstalledSnap(c, s.state, snapYaml, "")
+	s.state.Unlock()
+
+	stdout, stderr, err := ctlcmd.Run(mockContext, []string{"model"}, 0)
+	c.Check(err, ErrorMatches, "insufficient permissions to get model assertion for snap \"snap1\"")
+	c.Check(string(stdout), Equals, "")
+	c.Check(string(stderr), Equals, "cannot get model assertion for snap \"snap1\": not a gadget or from the same brand as the device model assertion\n")
+}
+
+func (s *modelSuite) TestHappyModelCommandPublisherYaml(c *C) {
+	// Make sure that we can get the model assertion even if the snap is
+	// is not a gadget, but comes from the same publisher as the model
+	s.state.Lock()
+	s.setupBrands()
+
+	// set a model assertion
+	current := s.brands.Model("my-brand", "pc-model", map[string]interface{}{
+		"architecture": "amd64",
+		"kernel":       "pc-kernel",
+		"gadget":       "pc",
+		"base":         "core18",
+	})
+	err := assertstate.Add(s.state, current)
+	c.Assert(err, IsNil)
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
+		Brand: "my-brand",
+		Model: "pc-model",
+	})
+
+	c.Assert(err, IsNil)
+	task := s.state.NewTask("test-task", "my test task")
+	setup := &hookstate.HookSetup{Snap: "gadget1", Revision: snap.R(1), Hook: "test-hook"}
+	mockContext, err := hookstate.NewContext(task, s.state, setup, s.mockHandler, "")
+	c.Assert(err, IsNil)
+	mockInstalledSnap(c, s.state, snapGadgetYaml, "")
+	s.state.Unlock()
+
+	stdout, stderr, err := ctlcmd.Run(mockContext, []string{"model"}, 0)
+	c.Check(err, IsNil)
+	c.Check(string(stdout), Equals, fmt.Sprintf(`brand-id:      my-brand
+model:         pc-model
+serial:        -- (device not registered yet)
+architecture:  amd64
+base:          core18
+gadget:        pc
+kernel:        pc-kernel
+timestamp:     %s
+`, timeutil.Human(time.Now())))
+	c.Check(string(stderr), Equals, "")
+}
+
+func (s *modelSuite) TestHappyModelCommandGadgetYaml(c *C) {
+	// This tests verifies that a snap that is a gadget can be used to
+	// get the model assertion, even if from a different publisher
+	s.state.Lock()
+	s.setupBrands()
+
+	// set a model assertion
+	current := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+		"architecture": "amd64",
+		"kernel":       "pc-kernel",
+		"gadget":       "pc",
+		"base":         "core18",
+	})
+	err := assertstate.Add(s.state, current)
+	c.Assert(err, IsNil)
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
+		Brand: "canonical",
+		Model: "pc-model",
+	})
+
+	c.Assert(err, IsNil)
+	task := s.state.NewTask("test-task", "my test task")
+	setup := &hookstate.HookSetup{Snap: "gadget1", Revision: snap.R(1), Hook: "test-hook"}
+	mockContext, err := hookstate.NewContext(task, s.state, setup, s.mockHandler, "")
+	c.Assert(err, IsNil)
+	mockInstalledSnap(c, s.state, snapGadgetYaml, "")
+	s.state.Unlock()
+
+	stdout, stderr, err := ctlcmd.Run(mockContext, []string{"model"}, 0)
+	c.Check(err, IsNil)
+	c.Check(string(stdout), Equals, fmt.Sprintf(`brand-id:      canonical
+model:         pc-model
+serial:        -- (device not registered yet)
+architecture:  amd64
+base:          core18
+gadget:        pc
+kernel:        pc-kernel
+timestamp:     %s
+`, timeutil.Human(time.Now())))
+	c.Check(string(stderr), Equals, "")
+}
+
+func (s *modelSuite) TestHappyModelCommandGadgetJson(c *C) {
+	s.state.Lock()
+	s.setupBrands()
+
+	// set a model assertion
+	current := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+		"architecture": "amd64",
+		"kernel":       "pc-kernel",
+		"gadget":       "pc",
+		"base":         "core18",
+	})
+	err := assertstate.Add(s.state, current)
+	c.Assert(err, IsNil)
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
+		Brand: "canonical",
+		Model: "pc-model",
+	})
+
+	c.Assert(err, IsNil)
+	task := s.state.NewTask("test-task", "my test task")
+	setup := &hookstate.HookSetup{Snap: "gadget1", Revision: snap.R(1), Hook: "test-hook"}
+	mockContext, err := hookstate.NewContext(task, s.state, setup, s.mockHandler, "")
+	c.Assert(err, IsNil)
+	mockInstalledSnap(c, s.state, snapGadgetYaml, "")
+	s.state.Unlock()
+
+	stdout, stderr, err := ctlcmd.Run(mockContext, []string{"model", "--json"}, 0)
+	c.Check(err, IsNil)
+	c.Check(string(stdout), Equals, fmt.Sprintf(`{
+  "brand-id": "canonical",
+  "model": "pc-model",
+  "serial": "-- (device not registered yet)",
+  "architecture": "amd64",
+  "base": "core18",
+  "gadget": "pc",
+  "kernel": "pc-kernel",
+  "timestamp": "%s"
+}
+`, timeutil.Human(time.Now())))
+	c.Check(string(stderr), Equals, "")
+}
+
+func (s *modelSuite) TestHappyModelCommandAssertionGadgetYaml(c *C) {
+	s.state.Lock()
+	s.setupBrands()
+
+	// set a model assertion
+	current := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+		"architecture": "amd64",
+		"kernel":       "pc-kernel",
+		"gadget":       "pc",
+		"base":         "core18",
+	})
+	err := assertstate.Add(s.state, current)
+	c.Assert(err, IsNil)
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
+		Brand: "canonical",
+		Model: "pc-model",
+	})
+
+	c.Assert(err, IsNil)
+	task := s.state.NewTask("test-task", "my test task")
+	setup := &hookstate.HookSetup{Snap: "gadget1", Revision: snap.R(1), Hook: "test-hook"}
+	mockContext, err := hookstate.NewContext(task, s.state, setup, s.mockHandler, "")
+	c.Assert(err, IsNil)
+	mockInstalledSnap(c, s.state, snapGadgetYaml, "")
+	s.state.Unlock()
+
+	stdout, stderr, err := ctlcmd.Run(mockContext, []string{"model", "--assertion"}, 0)
+	c.Check(err, IsNil)
+	c.Check(string(stdout), Equals, string(asserts.Encode(current)))
+	c.Check(string(stderr), Equals, "")
+}
+
+func (s *modelSuite) TestHappyModelCommandAssertionGadgetJson(c *C) {
+	s.state.Lock()
+	s.setupBrands()
+
+	// set a model assertion
+	current := s.brands.Model("canonical", "pc-model", map[string]interface{}{
+		"architecture": "amd64",
+		"kernel":       "pc-kernel",
+		"gadget":       "pc",
+		"base":         "core18",
+	})
+	err := assertstate.Add(s.state, current)
+	c.Assert(err, IsNil)
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
+		Brand: "canonical",
+		Model: "pc-model",
+	})
+
+	c.Assert(err, IsNil)
+	task := s.state.NewTask("test-task", "my test task")
+	setup := &hookstate.HookSetup{Snap: "gadget1", Revision: snap.R(1), Hook: "test-hook"}
+	mockContext, err := hookstate.NewContext(task, s.state, setup, s.mockHandler, "")
+	c.Assert(err, IsNil)
+	mockInstalledSnap(c, s.state, snapGadgetYaml, "")
+	s.state.Unlock()
+
+	stdout, stderr, err := ctlcmd.Run(mockContext, []string{"model", "--assertion", "--json"}, 0)
+	c.Check(err, IsNil)
+	c.Check(string(stdout), Equals, fmt.Sprintf(`{
+  "headers": {
+    "architecture": "amd64",
+    "authority-id": "canonical",
+    "base": "core18",
+    "brand-id": "canonical",
+    "gadget": "pc",
+    "kernel": "pc-kernel",
+    "model": "pc-model",
+    "series": "16",
+    "sign-key-sha3-384": "%s",
+    "timestamp": "%s",
+    "type": "model"
+  }
+}`, current.SignKeyID(), time.Now().Format("2006-01-02T15:04:05-07:00")))
+	c.Check(string(stderr), Equals, "")
+}

--- a/overlord/hookstate/ctlcmd/model_test.go
+++ b/overlord/hookstate/ctlcmd/model_test.go
@@ -183,7 +183,7 @@ version: 1
 `
 
 func (s *modelSuite) TestUnhappyModelCommandNotGadgetOrSamePublisher(c *C) {
-	// Make sure that we can not get the model assertation if we are not a gadget
+	// Make sure that we can not get the model assertion if we are not a gadget
 	// type snap, or if we are not the publisher of the model assertion.
 	s.state.Lock()
 	s.setupBrands()

--- a/strutil/strutil_test.go
+++ b/strutil/strutil_test.go
@@ -20,6 +20,7 @@
 package strutil_test
 
 import (
+	"bytes"
 	"math"
 	"sort"
 	"testing"
@@ -277,5 +278,29 @@ func (strutilSuite) TestDeduplicate(c *check.C) {
 		{input: []string{}, output: []string{}},
 	} {
 		c.Assert(strutil.Deduplicate(t.input), check.DeepEquals, t.output)
+	}
+}
+
+func (strutilSuite) TestWordWrap(c *check.C) {
+	for _, t := range []struct {
+		input   string
+		width   int
+		indent  string
+		indent2 string
+		output  string
+	}{
+		{input: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.", width: 20, indent: "", indent2: "", output: "Lorem ipsum dolor\nsit amet,\nconsectetur\nadipiscing elit, sed\ndo eiusmod tempor\nincididunt ut labore\net dolore magna\naliqua.\n"},
+		{input: "Lorem ips", width: 20, indent: "", indent2: "", output: "Lorem ips\n"},
+		{input: "", width: 5, indent: "", indent2: "", output: "\n"},
+		{input: "", width: 5, indent: "  ", indent2: "  ", output: "  \n"},
+		{input: "Lorem ipsum", width: 0, indent: "", indent2: "", output: "L\no\nr\ne\nm\ni\np\ns\nu\nm\n"},
+		{input: "Lorem ipsum", width: -10, indent: "", indent2: "", output: "L\no\nr\ne\nm\ni\np\ns\nu\nm\n"},
+		{input: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.", width: 20, indent: "  ", indent2: "", output: "  Lorem ipsum dolor\nsit amet,\nconsectetur\nadipiscing elit, sed\ndo eiusmod tempor\nincididunt ut labore\net dolore magna\naliqua.\n"},
+		{input: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.", width: 20, indent: "", indent2: "  ", output: "Lorem ipsum dolor\n  sit amet,\n  consectetur\n  adipiscing elit,\n  sed do eiusmod\n  tempor incididunt\n  ut labore et\n  dolore magna\n  aliqua.\n"},
+	} {
+		buf := new(bytes.Buffer)
+		err := strutil.WordWrap(buf, []rune(t.input), t.indent, t.indent2, t.width)
+		c.Assert(err, check.IsNil)
+		c.Check(buf.String(), check.Equals, t.output)
 	}
 }


### PR DESCRIPTION
This is the third PR in the patch series of 'snapctl model' command. This relies on the two previous PRs having landed (https://github.com/snapcore/snapd/pull/11579 and https://github.com/snapcore/snapd/pull/11594), and refactors the snap model command to use the same backend code for snapctl model.

I will keep this in draft untill prerequisites are ready