### PR TITLE
snap,wrappers: add `sigint{,-all}` to supported stop-modes

### DIFF
--- a/snap/info.go
+++ b/snap/info.go
@@ -911,7 +911,7 @@ func (st StopModeType) KillSignal() string {
 // Validate ensures that the StopModeType has an valid value.
 func (st StopModeType) Validate() error {
 	switch st {
-	case "", "sigterm", "sigterm-all", "sighup", "sighup-all", "sigusr1", "sigusr1-all", "sigusr2", "sigusr2-all":
+	case "", "sigterm", "sigterm-all", "sighup", "sighup-all", "sigusr1", "sigusr1-all", "sigusr2", "sigusr2-all", "sigint", "sigint-all":
 		// valid
 		return nil
 	}

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -1547,6 +1547,8 @@ func (s *infoSuite) TestStopModeTypeKillMode(c *C) {
 		{"sigusr1-all", true},
 		{"sigusr2", false},
 		{"sigusr2-all", true},
+		{"sigint", false},
+		{"sigint-all", true},
 	} {
 		c.Check(snap.StopModeType(t.stopMode).KillAll(), Equals, t.killall, Commentf("wrong KillAll for %v", t.stopMode))
 	}

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -518,6 +518,8 @@ func (s *ValidateSuite) TestAppStopMode(c *C) {
 		{"sigusr1-all", true},
 		{"sigusr2", true},
 		{"sigusr2-all", true},
+		{"sigint", true},
+		{"sigint-all", true},
 		// bad
 		{"invalid-thing", false},
 	} {

--- a/tests/lib/snaps/test-snapd-service/bin/start-stop-mode
+++ b/tests/lib/snaps/test-snapd-service/bin/start-stop-mode
@@ -43,7 +43,7 @@ def main() -> None:
         nonlocal loop
         loop = False
 
-    for signum in signal.SIGUSR1, signal.SIGUSR2, signal.SIGHUP:
+    for signum in signal.SIGUSR1, signal.SIGUSR2, signal.SIGHUP, signal.SIGINT:
         signal.signal(signum, on_signal)
 
     # Tell systemd that we are considered ready now or touch a file in

--- a/tests/lib/snaps/test-snapd-service/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-service/meta/snap.yaml
@@ -47,6 +47,16 @@ apps:
         command: bin/start-stop-mode-sigterm
         daemon: simple
         stop-mode: sigterm-all
+    test-snapd-sigint-service:
+        command: bin/start-stop-mode sigint
+        stop-command: bin/stop-stop-mode sigint
+        daemon: simple
+        stop-mode: sigint
+    test-snapd-sigint-all-service:
+        command: bin/start-stop-mode sigint-all
+        stop-command: bin/stop-stop-mode sigint-all
+        daemon: simple
+        stop-mode: sigint-all
     test-snapd-endure-service:
         command: bin/start-stop-mode endure
         stop-command: bin/stop-stop-mode endure

--- a/tests/main/services-stop-mode/task.yaml
+++ b/tests/main/services-stop-mode/task.yaml
@@ -13,7 +13,7 @@ restore: |
     snap remove --purge test-snapd-service || true
 
 debug: |
-    stop_modes="sighup sighup-all sigusr1 sigusr1-all sigusr2 sigusr2-all"
+    stop_modes="sighup sighup-all sigusr1 sigusr1-all sigusr2 sigusr2-all sigint sigint-all"
     for s in $stop_modes; do
         systemctl status "snap.test-snapd-service.test-snapd-${s}-service" || true
     done
@@ -31,7 +31,7 @@ execute: |
     systemctl status snap.test-snapd-service.test-snapd-service|MATCH "running"
     systemctl show -p MainPID snap.test-snapd-service.test-snapd-service > old-main.pid
 
-    stop_modes="sighup sighup-all sigusr1 sigusr1-all sigusr2 sigusr2-all"
+    stop_modes="sighup sighup-all sigusr1 sigusr1-all sigusr2 sigusr2-all sigint sigint-all"
     for s in $stop_modes; do
         systemctl show -p ActiveState "snap.test-snapd-service.test-snapd-${s}-service" | MATCH "ActiveState=active"
     done

--- a/wrappers/services_gen_test.go
+++ b/wrappers/services_gen_test.go
@@ -896,7 +896,7 @@ func (s *servicesWrapperGenSuite) TestTimerGenerateSchedules(c *C) {
 }
 
 func (s *servicesWrapperGenSuite) TestKillModeSig(c *C) {
-	for _, rm := range []string{"sigterm", "sighup", "sigusr1", "sigusr2"} {
+	for _, rm := range []string{"sigterm", "sighup", "sigusr1", "sigusr2", "sigint"} {
 		service := &snap.AppInfo{
 			Snap: &snap.Info{
 				SuggestedName: "snap",

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -3090,6 +3090,8 @@ func (s *servicesTestSuite) TestStopServiceSigs(c *C) {
 		{mode: "sigusr1-all", expectedSig: "USR1", expectedWho: "all"},
 		{mode: "sigusr2", expectedSig: "USR2", expectedWho: "main"},
 		{mode: "sigusr2-all", expectedSig: "USR2", expectedWho: "all"},
+		{mode: "sigint", expectedSig: "INT", expectedWho: "main"},
+		{mode: "sigint-all", expectedSig: "INT", expectedWho: "all"},
 	} {
 		surviveYaml := fmt.Sprintf(`name: survive-snap
 version: 1.0


### PR DESCRIPTION
The robotics team needs SIGINT as a stop mode for their ROS snap.
This commit enables `stop-mode: sigint` and `stop-mode: sigint-all`.
