### PR TITLE
tests: set as manual the interfaces-cups-control test

### DIFF
--- a/tests/main/interfaces-cups-control/task.yaml
+++ b/tests/main/interfaces-cups-control/task.yaml
@@ -18,6 +18,8 @@ details: |
 # TODO: enable on debian-sid once https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1006853 is fixed
 systems: [-ubuntu-core-*, -opensuse-*, -fedora-*, -arch-*, -amazon-*, -centos-*, -debian-sid-*, -ubuntu-*-32]
 
+manual: true
+
 environment:
     TEST_FILE: /var/snap/test-snapd-cups-control-consumer/current/test_file.txt
 


### PR DESCRIPTION
The test is failing in a very similar way to the debian-sid error, but now in all the ubuntu versions. 
The idea is to set as manual until the error is researched a bit more.
The test-snapd-cups-control-consumer was already regenerated, but the
error is not gone.

Error:

+ test-snapd-cups-control-consumer.lpr
/var/snap/test-snapd-cups-control-consumer/current/test_file.txt
+ MATCH 'scheduler not responding'
grep error: pattern not found, got:
/snap/test-snapd-cups-control-consumer/17/usr/bin/lpr: Error - No
default destination.
