### PR TITLE
cmd/snap: bugfix - default to 1 cpu count for the one part cpu quota specifier

### DIFF
--- a/cmd/snap/cmd_quota.go
+++ b/cmd/snap/cmd_quota.go
@@ -144,6 +144,9 @@ func parseCpuQuota(cpuMax string) (count int, percentage int, err error) {
 		if err != nil || count == 0 {
 			return 0, 0, parseError(cpuMax)
 		}
+	} else {
+		// Assume format was M%
+		count = 1
 	}
 
 	percentage, err = strconv.Atoi(match[2])

--- a/cmd/snap/cmd_quota_test.go
+++ b/cmd/snap/cmd_quota_test.go
@@ -215,7 +215,7 @@ func (s *quotaSuite) TestParseQuotas(c *check.C) {
 	}{
 		{maxMemory: "12KB", quotas: `{"memory":12000,"cpu":{},"cpu-set":{}}`},
 		{cpuMax: "12x40%", quotas: `{"cpu":{"count":12,"percentage":40},"cpu-set":{}}`},
-		{cpuMax: "40%", quotas: `{"cpu":{"percentage":40},"cpu-set":{}}`},
+		{cpuMax: "40%", quotas: `{"cpu":{"count":1,"percentage":40},"cpu-set":{}}`},
 		{cpuSet: "1,3", quotas: `{"cpu":{},"cpu-set":{"cpus":[1,3]}}`},
 		{threadsMax: "2", quotas: `{"cpu":{},"cpu-set":{},"threads":2}`},
 		// Error cases


### PR DESCRIPTION
Do this when using the single core specifier, since otherwise it would default to 0 cores and it would be prevented from updating the cpu quota when using --cpu X% on an existing cpu quota group. This issue was discovered as a part of the spread tests.
