### PR TITLE
snap/quota,wrappers: fix nested quotas not being written correctly to slices

### DIFF
--- a/cmd/snap/cmd_quota.go
+++ b/cmd/snap/cmd_quota.go
@@ -77,7 +77,11 @@ memory limit for a quota group does not restart any services associated with
 snaps in the quota group.
 
 The CPU limit for a quota group can be both increased and decreased after being
-set on a quota group.
+set on a quota group. The CPU limit can be specified as a single percentage which
+means that the quota group is allowed an overall percentage of the CPU resources. Setting
+it to 50%% means that the quota group is allowed to use up to 50%% of all CPU cores.
+Setting the percentage to 2x100%% means that the quota group is allowed up to 100%%
+on two cpu cores.
 
 The CPU set limit for a quota group can be modified to include new cpus, or to remove
 existing cpus from the quota already set.

--- a/snap/quota/export_test.go
+++ b/snap/quota/export_test.go
@@ -21,6 +21,10 @@ package quota
 
 type GroupQuotaAllocations = groupQuotaAllocations
 
+func (grp *Group) GetCorrectedCPUCount() int {
+	return grp.getCorrectedCPUCount()
+}
+
 func (grp *Group) SetInternalSubGroups(grps []*Group) {
 	grp.subGroups = grps
 }

--- a/snap/quota/quota.go
+++ b/snap/quota/quota.go
@@ -265,13 +265,8 @@ func maxq(a, b quantity.Size) quantity.Size {
 	return b
 }
 
-func (grp *Group) getCPUSet() []int {
-	if grp.CPULimit == nil || len(grp.CPULimit.AllowedCPUs) == 0 {
-		return []int{}
-	}
-	return grp.CPULimit.AllowedCPUs
-}
-
+// GetCPUSetQuota returns the currently active CPU set quota for this group, which
+// could originate from a parent
 func (grp *Group) GetCPUSetQuota() []int {
 	if grp.CPULimit != nil && len(grp.CPULimit.AllowedCPUs) != 0 {
 		return grp.CPULimit.AllowedCPUs
@@ -303,6 +298,7 @@ func (grp *Group) getCorrectedCPUCount() int {
 	return cpuCount
 }
 
+// GetCPUQuota returns the currently active CPU quota
 func (grp *Group) GetCPUQuota() (int, int) {
 	if grp.CPULimit != nil && grp.CPULimit.Percentage != 0 {
 		return grp.getCorrectedCPUCount(), grp.CPULimit.Percentage
@@ -318,6 +314,7 @@ func (grp *Group) GetCPUQuota() (int, int) {
 	return 0, 0
 }
 
+// GetMemoryQuota returns the currently active memory quota
 func (grp *Group) GetMemoryQuota() quantity.Size {
 	if grp.MemoryLimit != 0 {
 		return grp.MemoryLimit
@@ -333,6 +330,7 @@ func (grp *Group) GetMemoryQuota() quantity.Size {
 	return 0
 }
 
+// GetThreadsQuota returns the currently active threads quota
 func (grp *Group) GetThreadsQuota() int {
 	if grp.TaskLimit != 0 {
 		return grp.TaskLimit
@@ -348,6 +346,16 @@ func (grp *Group) GetThreadsQuota() int {
 	return 0
 }
 
+// getCPUSet helper function to get either the CPU set for this group, or just
+// default to an empty slice
+func (grp *Group) getCPUSet() []int {
+	if grp.CPULimit == nil || len(grp.CPULimit.AllowedCPUs) == 0 {
+		return []int{}
+	}
+	return grp.CPULimit.AllowedCPUs
+}
+
+// getTotalCPUPercentage helper function to get a total percentage of CPU usage
 func (grp *Group) getTotalCPUPercentage() int {
 	if grp.CPULimit == nil || grp.CPULimit.Percentage == 0 {
 		return 0

--- a/snap/quota/quota_test.go
+++ b/snap/quota/quota_test.go
@@ -1219,3 +1219,20 @@ func (ts *quotaTestSuite) TestAddingNewMiddleParentThreadLimits(c *C) {
 	err = subgrp1.UpdateQuotaLimits(quota.NewResourcesBuilder().WithThreadLimit(1024).Build())
 	c.Check(err, IsNil)
 }
+
+func (ts *quotaTestSuite) TestCombinedCpuPercentageWithCpuSetLimits(c *C) {
+	grp1, err := quota.NewGroup("groot", quota.NewResourcesBuilder().WithAllowedCPUs([]int{0, 1}).Build())
+	c.Assert(err, IsNil)
+
+	subgrp1, err := grp1.NewSubGroup("cpu-sub1", quota.NewResourcesBuilder().WithCPUPercentage(50).Build())
+	c.Assert(err, IsNil)
+
+	// Verify that the number of cpus are now reported as 2
+	c.Check(subgrp1.GetCorrectedCPUCount(), Equals, 2)
+
+	subgrp2, err := grp1.NewSubGroup("cpu-sub2", quota.NewResourcesBuilder().WithCPUCount(8).WithCPUPercentage(50).Build())
+	c.Assert(err, IsNil)
+
+	// Verify that the number of cpus are now correctly reported and corrected to 2
+	c.Check(subgrp2.GetCorrectedCPUCount(), Equals, 2)
+}

--- a/snap/quota/resources.go
+++ b/snap/quota/resources.go
@@ -153,11 +153,11 @@ func (qr *Resources) ValidateChange(newLimits Resources) error {
 	}
 
 	// Check that the cpu limit is not being removed, we do not support setting these
-	// two settings individually. Count/Percentage must be updated in unison.
+	// two settings individually.
 	if newLimits.CPU != nil && qr.CPU != nil {
-		if newLimits.CPU.Count == 0 && qr.CPU.Count != 0 {
-			return fmt.Errorf("cannot remove cpu limit from quota group")
-		}
+		// Allow count to be changed to zero, but not percentage. This is because count
+		// is an optional setting and we want to allow the user to remove the count to indicate
+		// that we just want to use % of all cpus
 		if newLimits.CPU.Percentage == 0 && qr.CPU.Percentage != 0 {
 			return fmt.Errorf("cannot remove cpu limit from quota group")
 		}

--- a/snap/quota/resources_test.go
+++ b/snap/quota/resources_test.go
@@ -97,7 +97,7 @@ func (s *resourcesTestSuite) TestQuotaChangeValidationFails(c *C) {
 		},
 		{
 			quota.NewResourcesBuilder().WithCPUCount(2).WithCPUPercentage(75).Build(),
-			quota.NewResourcesBuilder().WithCPUCount(0).WithCPUPercentage(0).Build(),
+			quota.NewResourcesBuilder().WithCPUPercentage(0).Build(),
 			`cannot remove cpu limit from quota group`,
 		},
 		{
@@ -175,6 +175,11 @@ func (s *resourcesTestSuite) TestQuotaChangeValidationPasses(c *C) {
 			quota.NewResourcesBuilder().WithCPUCount(1).WithCPUPercentage(100).Build(),
 			quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).WithThreadLimit(32).Build(),
 			quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).WithCPUCount(1).WithCPUPercentage(100).WithThreadLimit(32).Build(),
+		},
+		{
+			quota.NewResourcesBuilder().WithCPUCount(4).WithCPUPercentage(25).Build(),
+			quota.NewResourcesBuilder().WithCPUPercentage(25).Build(),
+			quota.NewResourcesBuilder().WithCPUCount(0).WithCPUPercentage(25).Build(),
 		},
 		{
 			quota.NewResourcesBuilder().WithCPUCount(4).WithCPUPercentage(25).WithAllowedCPUs([]int{0}).Build(),

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -76,15 +76,6 @@ func generateSnapServiceFile(app *snap.AppInfo, opts *AddSnapServicesOptions) ([
 	return genServiceFile(app, opts)
 }
 
-// max returns the maximum of two integers. Why is this
-// not provided by golang?
-func max(a, b int) int {
-	if a < b {
-		return b
-	}
-	return a
-}
-
 func min(a, b int) int {
 	if b < a {
 		return b
@@ -101,7 +92,7 @@ CPUAccounting=true
 	if grp.CPULimit != nil && grp.CPULimit.Percentage != 0 {
 		// convert the number of cores and the allowed percentage
 		// to the systemd specific format.
-		cpuQuotaSnap := max(grp.CPULimit.Count, 1) * grp.CPULimit.Percentage
+		cpuQuotaSnap := grp.GetCorrectedCpuCount() * grp.CPULimit.Percentage
 		cpuQuotaMax := runtime.NumCPU() * 100
 
 		// The CPUQuota setting is only available since systemd 213

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"sort"
 	"strings"
 	"time"
@@ -291,6 +292,198 @@ TasksMax=%[5]d
 		allowedCpusValue,
 		resourceLimits.Memory.Limit,
 		resourceLimits.Threads.Limit)
+
+	exp := []changesObservation{
+		{
+			snapName: "hello-snap",
+			unitType: "service",
+			name:     "svc1",
+			old:      "",
+			new:      svcContent,
+		},
+		{
+			grp:      grp,
+			unitType: "slice",
+			new:      sliceContent,
+			old:      "",
+			name:     "foogroup",
+		},
+	}
+	r, observe := expChangeObserver(c, exp)
+	defer r()
+
+	err = wrappers.EnsureSnapServices(m, nil, observe, progress.Null)
+	c.Assert(err, IsNil)
+	c.Check(s.sysdLog, DeepEquals, [][]string{
+		{"daemon-reload"},
+	})
+
+	c.Assert(svcFile, testutil.FileEquals, svcContent)
+}
+
+func (s *servicesTestSuite) TestEnsureSnapServicesWithZeroCpuCountQuotas(c *C) {
+	// Kind of a special case, if the cpu count is zero it needs to automatically scale
+	// at the moment of writing the service file to the current number of cpu cores
+	info := snaptest.MockSnap(c, packageHello, &snap.SideInfo{Revision: snap.R(12)})
+	svcFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-snap.svc1.service")
+
+	// set up arbitrary quotas for the group to test they get written correctly to the slice
+	resourceLimits := quota.NewResourcesBuilder().
+		WithCPUPercentage(50).
+		Build()
+	grp, err := quota.NewGroup("foogroup", resourceLimits)
+	c.Assert(err, IsNil)
+
+	m := map[*snap.Info]*wrappers.SnapServiceOptions{
+		info: {QuotaGroup: grp},
+	}
+
+	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
+	svcContent := fmt.Sprintf(`[Unit]
+# Auto-generated, DO NOT EDIT
+Description=Service for snap application hello-snap.svc1
+Requires=%[1]s
+Wants=network.target
+After=%[1]s network.target snapd.apparmor.service
+X-Snappy=yes
+
+[Service]
+EnvironmentFile=-/etc/environment
+ExecStart=/usr/bin/snap run hello-snap.svc1
+SyslogIdentifier=hello-snap.svc1
+Restart=on-failure
+WorkingDirectory=%[2]s/var/snap/hello-snap/12
+ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
+ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
+TimeoutStopSec=30
+Type=forking
+Slice=snap.foogroup.slice
+
+[Install]
+WantedBy=multi-user.target
+`,
+		systemd.EscapeUnitNamePath(dir),
+		dirs.GlobalRootDir,
+	)
+
+	sliceTempl := `[Unit]
+Description=Slice for snap quota group %s
+Before=slices.target
+X-Snappy=yes
+
+[Slice]
+# Always enable cpu accounting, so the following cpu quota options have an effect
+CPUAccounting=true
+CPUQuota=%[2]d%%
+
+# Always enable memory accounting otherwise the MemoryMax setting does nothing.
+MemoryAccounting=true
+# Always enable task accounting in order to be able to count the processes/
+# threads, etc for a slice
+TasksAccounting=true
+`
+
+	sliceContent := fmt.Sprintf(sliceTempl, grp.Name,
+		runtime.NumCPU()*resourceLimits.CPU.Percentage)
+
+	exp := []changesObservation{
+		{
+			snapName: "hello-snap",
+			unitType: "service",
+			name:     "svc1",
+			old:      "",
+			new:      svcContent,
+		},
+		{
+			grp:      grp,
+			unitType: "slice",
+			new:      sliceContent,
+			old:      "",
+			name:     "foogroup",
+		},
+	}
+	r, observe := expChangeObserver(c, exp)
+	defer r()
+
+	err = wrappers.EnsureSnapServices(m, nil, observe, progress.Null)
+	c.Assert(err, IsNil)
+	c.Check(s.sysdLog, DeepEquals, [][]string{
+		{"daemon-reload"},
+	})
+
+	c.Assert(svcFile, testutil.FileEquals, svcContent)
+}
+
+func (s *servicesTestSuite) TestEnsureSnapServicesWithZeroCpuCountAndCpuSetQuotas(c *C) {
+	// Another special case, if the cpu count is zero it needs to automatically scale as the
+	// previous test, but only up the maximum allowed provided in the cpu-set. So in this test
+	// we provide only 1 allowed CPU, which means that the percentage that will be written is 50%
+	// and not 200% or how many cores that runs this test!
+	info := snaptest.MockSnap(c, packageHello, &snap.SideInfo{Revision: snap.R(12)})
+	svcFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-snap.svc1.service")
+
+	// set up arbitrary quotas for the group to test they get written correctly to the slice
+	resourceLimits := quota.NewResourcesBuilder().
+		WithCPUPercentage(50).
+		WithAllowedCPUs([]int{0}).
+		Build()
+	grp, err := quota.NewGroup("foogroup", resourceLimits)
+	c.Assert(err, IsNil)
+
+	m := map[*snap.Info]*wrappers.SnapServiceOptions{
+		info: {QuotaGroup: grp},
+	}
+
+	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
+	svcContent := fmt.Sprintf(`[Unit]
+# Auto-generated, DO NOT EDIT
+Description=Service for snap application hello-snap.svc1
+Requires=%[1]s
+Wants=network.target
+After=%[1]s network.target snapd.apparmor.service
+X-Snappy=yes
+
+[Service]
+EnvironmentFile=-/etc/environment
+ExecStart=/usr/bin/snap run hello-snap.svc1
+SyslogIdentifier=hello-snap.svc1
+Restart=on-failure
+WorkingDirectory=%[2]s/var/snap/hello-snap/12
+ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
+ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
+TimeoutStopSec=30
+Type=forking
+Slice=snap.foogroup.slice
+
+[Install]
+WantedBy=multi-user.target
+`,
+		systemd.EscapeUnitNamePath(dir),
+		dirs.GlobalRootDir,
+	)
+
+	sliceTempl := `[Unit]
+Description=Slice for snap quota group %s
+Before=slices.target
+X-Snappy=yes
+
+[Slice]
+# Always enable cpu accounting, so the following cpu quota options have an effect
+CPUAccounting=true
+CPUQuota=%[2]d%%
+AllowedCPUs=%[3]s
+
+# Always enable memory accounting otherwise the MemoryMax setting does nothing.
+MemoryAccounting=true
+# Always enable task accounting in order to be able to count the processes/
+# threads, etc for a slice
+TasksAccounting=true
+`
+
+	allowedCpusValue := strutil.IntsToCommaSeparated(resourceLimits.CPUSet.CPUs)
+	sliceContent := fmt.Sprintf(sliceTempl, grp.Name,
+		resourceLimits.CPU.Percentage,
+		allowedCpusValue)
 
 	exp := []changesObservation{
 		{


### PR DESCRIPTION
Unfortunately, after doing a thorough review of the nested quota support after being back from a vacation, my head was clear and I discovered that nested groups do not have their inherited limits written to slice files. So that means only the set limits on the actual group will be written.

This PR fixes this, and it relies on PR https://github.com/snapcore/snapd/pull/11605 landing first as a prerequisite, which also contains some fixes to how --cpu works.

So this PR is a bit smaller once the other one lands.