### PR TITLE
cmd/snap,strutil: move lineWrap to WordWrapPadded

### DIFF
--- a/cmd/snap/cmd_debug_state.go
+++ b/cmd/snap/cmd_debug_state.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/strutil"
 )
 
 type cmdDebugState struct {
@@ -259,7 +260,7 @@ func (c *cmdDebugState) showTask(st *state.State, taskID string) error {
 	if len(log) > 0 {
 		fmt.Fprintf(Stdout, "log: |\n")
 		for _, msg := range log {
-			if err := wrapLine(Stdout, []rune(msg), "  ", termWidth); err != nil {
+			if err := strutil.WordWrapPadded(Stdout, []rune(msg), "  ", termWidth); err != nil {
 				break
 			}
 		}

--- a/cmd/snap/cmd_info.go
+++ b/cmd/snap/cmd_info.go
@@ -138,38 +138,6 @@ func norm(path string) string {
 	return path
 }
 
-// runesTrimRightSpace returns text, with any trailing whitespace dropped.
-func runesTrimRightSpace(text []rune) []rune {
-	j := len(text)
-	for j > 0 && unicode.IsSpace(text[j-1]) {
-		j--
-	}
-	return text[:j]
-}
-
-// wrapLine wraps a line, assumed to be part of a block-style yaml
-// string, to fit into termWidth, preserving the line's indent, and
-// writes it out prepending padding to each line.
-func wrapLine(out io.Writer, text []rune, pad string, termWidth int) error {
-	// discard any trailing whitespace
-	text = runesTrimRightSpace(text)
-	// establish the indent of the whole block
-	idx := 0
-	for idx < len(text) && unicode.IsSpace(text[idx]) {
-		idx++
-	}
-	indent := pad + string(text[:idx])
-	text = text[idx:]
-	if len(indent) > termWidth/2 {
-		// If indent is too big there's not enough space for the actual
-		// text, in the pathological case the indent can even be bigger
-		// than the terminal which leads to lp:1828425.
-		// Rather than let that happen, give up.
-		indent = pad + "  "
-	}
-	return strutil.WordWrap(out, text, indent, indent, termWidth)
-}
-
 // wrapFlow wraps the text using yaml's flow style, allowing indent
 // characters for the first line.
 func wrapFlow(out io.Writer, text []rune, indent string, termWidth int) error {
@@ -201,7 +169,7 @@ func printDescr(w io.Writer, descr string, termWidth int) error {
 	var err error
 	descr = strings.TrimRightFunc(descr, unicode.IsSpace)
 	for _, line := range strings.Split(descr, "\n") {
-		err = wrapLine(w, []rune(line), "  ", termWidth)
+		err = strutil.WordWrapPadded(w, []rune(line), "  ", termWidth)
 		if err != nil {
 			break
 		}

--- a/cmd/snap/cmd_model.go
+++ b/cmd/snap/cmd_model.go
@@ -30,6 +30,7 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/strutil"
 )
 
 var (
@@ -308,7 +309,7 @@ func (x *cmdModel) Execute(args []string) error {
 					fmt.Fprintf(w, "device-key-sha3-384: %s\n", headerString)
 				case termWidth <= 86 && termWidth > 66:
 					fmt.Fprintln(w, "device-key-sha3-384: |")
-					wrapLine(w, []rune(headerString), "  ", termWidth)
+					strutil.WordWrapPadded(w, []rune(headerString), "  ", termWidth)
 				}
 			case "snaps":
 				// also flush the writer before continuing so the previous keys
@@ -391,7 +392,7 @@ func (x *cmdModel) Execute(args []string) error {
 					strings.Split(headerString, "\n"),
 					"")
 				fmt.Fprintln(w, "device-key: |")
-				wrapLine(w, []rune(headerString), "  ", termWidth)
+				strutil.WordWrapPadded(w, []rune(headerString), "  ", termWidth)
 
 			// the default is all the rest of short scalar values, which all
 			// should be strings

--- a/strutil/strutil.go
+++ b/strutil/strutil.go
@@ -300,13 +300,12 @@ func WordWrap(out io.Writer, text []rune, indent, indent2 string, termWidth int)
 	//       However, before this we'd count bytes instead of runes, so we'd be
 	//       even more broken. Think of it as successive approximations... at least
 	//       with this work we share tabwriter's opinion on the width of things!
-	if termWidth < 1 {
-		termWidth = 1
-	}
-
 	indentWidth := utf8.RuneCountInString(indent)
 	delta := indentWidth - utf8.RuneCountInString(indent2)
 	width := termWidth - indentWidth
+	if width < 1 {
+		width = 1
+	}
 
 	// establish the indent of the whole block
 	var err error
@@ -332,4 +331,36 @@ func WordWrap(out io.Writer, text []rune, indent, indent2 string, termWidth int)
 	}
 	_, err = fmt.Fprint(out, indent, string(text), "\n")
 	return err
+}
+
+// runesTrimRightSpace returns text, with any trailing whitespace dropped.
+func runesTrimRightSpace(text []rune) []rune {
+	j := len(text)
+	for j > 0 && unicode.IsSpace(text[j-1]) {
+		j--
+	}
+	return text[:j]
+}
+
+// WordWrapPadded wraps the given text, assumed to be part of a block-style yaml
+// string, to fit into termWidth, preserving the line's indent, and
+// writes it out prepending padding to each line.
+func WordWrapPadded(out io.Writer, text []rune, pad string, termWidth int) error {
+	// discard any trailing whitespace
+	text = runesTrimRightSpace(text)
+	// establish the indent of the whole block
+	idx := 0
+	for idx < len(text) && unicode.IsSpace(text[idx]) {
+		idx++
+	}
+	indent := pad + string(text[:idx])
+	text = text[idx:]
+	if len(indent) > termWidth/2 {
+		// If indent is too big there's not enough space for the actual
+		// text, in the pathological case the indent can even be bigger
+		// than the terminal which leads to lp:1828425.
+		// Rather than let that happen, give up.
+		indent = pad + "  "
+	}
+	return WordWrap(out, text, indent, indent, termWidth)
 }

--- a/strutil/strutil.go
+++ b/strutil/strutil.go
@@ -333,21 +333,12 @@ func WordWrap(out io.Writer, text []rune, indent, indent2 string, termWidth int)
 	return err
 }
 
-// runesTrimRightSpace returns text, with any trailing whitespace dropped.
-func runesTrimRightSpace(text []rune) []rune {
-	j := len(text)
-	for j > 0 && unicode.IsSpace(text[j-1]) {
-		j--
-	}
-	return text[:j]
-}
-
 // WordWrapPadded wraps the given text, assumed to be part of a block-style yaml
 // string, to fit into termWidth, preserving the line's indent, and
 // writes it out prepending padding to each line.
 func WordWrapPadded(out io.Writer, text []rune, pad string, termWidth int) error {
 	// discard any trailing whitespace
-	text = runesTrimRightSpace(text)
+	text = []rune(strings.TrimRightFunc(string(text), unicode.IsSpace))
 	// establish the indent of the whole block
 	idx := 0
 	for idx < len(text) && unicode.IsSpace(text[idx]) {

--- a/strutil/strutil_test.go
+++ b/strutil/strutil_test.go
@@ -318,3 +318,32 @@ func (strutilSuite) TestWordWrapCornerCase(c *check.C) {
   All hail EN SPACE.
 `[1:])
 }
+
+func (strutilSuite) TestWordWrapPadded(c *check.C) {
+	for _, t := range []struct {
+		input   string
+		width   int
+		padding string
+		output  string
+	}{
+		{input: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.", width: 20, padding: "  ", output: "  Lorem ipsum dolor\n  sit amet,\n  consectetur\n  adipiscing elit,\n  sed do eiusmod\n  tempor incididunt\n  ut labore et\n  dolore magna\n  aliqua.\n"},
+		{input: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.", width: 20, padding: "", output: "Lorem ipsum dolor\nsit amet,\nconsectetur\nadipiscing elit, sed\ndo eiusmod tempor\nincididunt ut labore\net dolore magna\naliqua.\n"},
+		{input: "Lorem ips", width: 20, padding: "  ", output: "  Lorem ips\n"},
+		{input: "", width: 5, padding: "", output: "\n"},
+		{input: "", width: 5, padding: "  ", output: "  \n"},
+
+		// no padding is added when len(padding) == width
+		{input: "Lorem ipsum", width: 0, padding: "", output: "L\no\nr\ne\nm\ni\np\ns\nu\nm\n"},
+
+		// padding gets added when len(padding) is > width, so expect a 4 space padding
+		{input: "Lorem ipsum", width: 0, padding: "  ", output: "    L\n    o\n    r\n    e\n    m\n    i\n    p\n    s\n    u\n    m\n"},
+
+		// padding should be added here as well as now the width is lower than len(padding)
+		{input: "Lorem ipsum", width: -10, padding: "", output: "  L\n  o\n  r\n  e\n  m\n  i\n  p\n  s\n  u\n  m\n"},
+	} {
+		buf := new(bytes.Buffer)
+		err := strutil.WordWrapPadded(buf, []rune(t.input), t.padding, t.width)
+		c.Assert(err, check.IsNil)
+		c.Check(buf.String(), check.Equals, t.output)
+	}
+}


### PR DESCRIPTION
Moved to strutil as its needed for snapctl model as well, also added unit tests for its none exists. I know there might be some overlap between the tests in WordWrapPadded and WordWrap, but because of the modifications happening to the text before it's handed to WordWrap, it makes sense to make sure we test the same width/padding patterns. It actually revealed a flaw with the width check in WordWrap, which is now done differently, as it did not catch all cases before.

Can this skip spread test?