### PR TITLE
store: set validation-sets on actions when refreshing

### DIFF
--- a/store/store_action.go
+++ b/store/store_action.go
@@ -77,10 +77,7 @@ type currentSnapV2JSON struct {
 	RefreshedDate    *time.Time `json:"refreshed-date,omitempty"`
 	IgnoreValidation bool       `json:"ignore-validation,omitempty"`
 	CohortKey        string     `json:"cohort-key,omitempty"`
-	// ValidationSets is an optional array of validation sets primary keys (it
-	// is not currently used; the store supports validation-sets in both
-	// current snaps context and in actions (actions takes precendence if both
-	// are set) and we use action's validation-sets also for refresh.
+	// ValidationSets is an optional array of validation sets primary keys.
 	ValidationSets [][]string `json:"validation-sets,omitempty"`
 }
 
@@ -330,8 +327,6 @@ func (s *Store) snapAction(ctx context.Context, currentSnaps []*CurrentSnap, act
 		if !curSnap.RefreshedDate.IsZero() {
 			refreshedDate = &curSnap.RefreshedDate
 		}
-		// note, ValidationSets are not currently set on currentSnapV2JSON (and shouldn't be set on currentSnaps,
-		// they need to be set on actions).
 		curSnapJSONs[i] = &currentSnapV2JSON{
 			SnapID:           curSnap.SnapID,
 			InstanceKey:      instanceKey,
@@ -341,6 +336,7 @@ func (s *Store) snapAction(ctx context.Context, currentSnaps []*CurrentSnap, act
 			RefreshedDate:    refreshedDate,
 			Epoch:            curSnap.Epoch,
 			CohortKey:        curSnap.CohortKey,
+			ValidationSets:   curSnap.ValidationSets,
 		}
 	}
 

--- a/store/store_action.go
+++ b/store/store_action.go
@@ -375,14 +375,11 @@ func (s *Store) snapAction(ctx context.Context, currentSnaps []*CurrentSnap, act
 			Channel:          a.Channel,
 			Revision:         a.Revision.N,
 			CohortKey:        a.CohortKey,
+			ValidationSets:   a.ValidationSets,
 			IgnoreValidation: ignoreValidation,
 		}
 		if !a.Revision.Unset() {
 			a.Channel = ""
-		}
-
-		if a.Action == "install" || a.Action == "refresh" {
-			aJSON.ValidationSets = a.ValidationSets
 		}
 
 		if a.Action == "install" {

--- a/store/store_action_test.go
+++ b/store/store_action_test.go
@@ -2529,6 +2529,7 @@ func (s *storeActionSuite) TestSnapActionRefreshWithValidationSets(c *C) {
 			"tracking-channel": "stable",
 			"refreshed-date":   helloRefreshedDateStr,
 			"epoch":            iZeroEpoch,
+			"validation-sets":  []interface{}{[]interface{}{"foo", "other"}},
 		})
 		c.Assert(req.Actions, HasLen, 1)
 		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
@@ -2577,6 +2578,8 @@ func (s *storeActionSuite) TestSnapActionRefreshWithValidationSets(c *C) {
 			TrackingChannel: "stable",
 			Revision:        snap.R(1),
 			RefreshedDate:   helloRefreshedDate,
+			// not actually set during refresh, but supported by snapAction
+			ValidationSets: [][]string{{"foo", "other"}},
 		},
 	}, []*store.SnapAction{
 		{

--- a/store/store_action_test.go
+++ b/store/store_action_test.go
@@ -2529,14 +2529,14 @@ func (s *storeActionSuite) TestSnapActionRefreshWithValidationSets(c *C) {
 			"tracking-channel": "stable",
 			"refreshed-date":   helloRefreshedDateStr,
 			"epoch":            iZeroEpoch,
-			"validation-sets":  []interface{}{[]interface{}{"foo", "bar"}, []interface{}{"foo", "baz"}},
 		})
 		c.Assert(req.Actions, HasLen, 1)
 		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
-			"action":       "refresh",
-			"instance-key": helloWorldSnapID,
-			"snap-id":      helloWorldSnapID,
-			"channel":      "stable",
+			"action":          "refresh",
+			"instance-key":    helloWorldSnapID,
+			"snap-id":         helloWorldSnapID,
+			"channel":         "stable",
+			"validation-sets": []interface{}{[]interface{}{"foo", "bar"}, []interface{}{"foo", "baz"}},
 		})
 
 		io.WriteString(w, `{
@@ -2577,14 +2577,14 @@ func (s *storeActionSuite) TestSnapActionRefreshWithValidationSets(c *C) {
 			TrackingChannel: "stable",
 			Revision:        snap.R(1),
 			RefreshedDate:   helloRefreshedDate,
-			ValidationSets:  [][]string{{"foo", "bar"}, {"foo", "baz"}},
 		},
 	}, []*store.SnapAction{
 		{
-			Action:       "refresh",
-			SnapID:       helloWorldSnapID,
-			Channel:      "stable",
-			InstanceName: "hello-world",
+			Action:         "refresh",
+			SnapID:         helloWorldSnapID,
+			Channel:        "stable",
+			InstanceName:   "hello-world",
+			ValidationSets: [][]string{{"foo", "bar"}, {"foo", "baz"}},
 		},
 	}, nil, nil, &store.RefreshOptions{PrivacyKey: "123"})
 	c.Assert(err, IsNil)


### PR DESCRIPTION
There was a bug where validation-sets were set on actions when
refreshing, but when actual snap actions were transformed into JSON
request the validation-sets field would only get carried over for
"install".

The test didn't catch that because it was "artificially" setting validation-sets key on context data (wouldn't happen in real code - `refreshCandidates` sets v-sets on action struct) and was expecting it on context data as well in the mockServer check.
