### PR TITLE
tests: disable snap-quota-* tests for arch-linux

### DIFF
--- a/tests/main/snap-quota-groups/task.yaml
+++ b/tests/main/snap-quota-groups/task.yaml
@@ -8,12 +8,14 @@ details: |
 # we do have a check to do for these systems, but that is just to ensure that
 # we don't allow using quota groups, and that check is done in the snap-quota
 # spread instead
+# TODO: arch-linux is disable until snapd pr #11608 is landed
 systems:
   - -ubuntu-14.04-*
   - -centos-7-*
   - -amazon-linux-2-*
   - -ubuntu-16.04-*
   - -ubuntu-core-16-*
+  - -arch-linux-*
 
 prepare: |
   snap install go-example-webserver jq remarshal hello-world

--- a/tests/main/snap-quota/task.yaml
+++ b/tests/main/snap-quota/task.yaml
@@ -3,6 +3,9 @@ summary: Basic test for quota-related snap commands.
 details: |
   Basic test for snap quota, remove-quota and quotas commands.
 
+# TODO: arch-linux is disable until snapd pr #11608 is landed
+systems: [-arch-linux-*]
+
 prepare: |
   snap install hello-world go-example-webserver test-snapd-tools
   snap set system experimental.quota-groups=true


### PR DESCRIPTION
The tests are failing with some errors which are under investigation.
There is a PR #11608 which should enable the tests.

Last error found is

+ sudo snap run test-snapd-curl.curl --unix-socket /run/snapd.socket
http://localhost/v2/quotas/group-four
 . . .
+ snapdSaysMemUsage=12288
+ '[' 12288 '!=' null ']'
+ '[' 12288 '!=' 0 ']'
+ '[' 12288 '!=' 4096 ']'
+ echo 'unexpected memory usage for empty quota group group-four, snapd
says: 12288'
unexpected memory usage for empty quota group group-four, snapd says:
12288
+ exit 1
