### PR TITLE
seed,many: allow to limit LoadMeta to snaps of a precise mode

### DIFF
--- a/image/image_test.go
+++ b/image/image_test.go
@@ -596,7 +596,7 @@ func (s *imageSuite) loadSeed(c *C, seeddir string) (essSnaps []*seed.Snap, runS
 		label = filepath.Base(systems[0])
 	}
 
-	seed, err := seed.Open(seeddir, label)
+	sd, err := seed.Open(seeddir, label)
 	c.Assert(err, IsNil)
 
 	db, err := asserts.OpenDatabase(&asserts.DatabaseConfig{
@@ -609,14 +609,14 @@ func (s *imageSuite) loadSeed(c *C, seeddir string) (essSnaps []*seed.Snap, runS
 		return b.CommitTo(db, nil)
 	}
 
-	err = seed.LoadAssertions(db, commitTo)
+	err = sd.LoadAssertions(db, commitTo)
 	c.Assert(err, IsNil)
 
-	err = seed.LoadMeta(timings.New(nil))
+	err = sd.LoadMeta(seed.AllModes, timings.New(nil))
 	c.Assert(err, IsNil)
 
-	essSnaps = seed.EssentialSnaps()
-	runSnaps, err = seed.ModeSnaps("run")
+	essSnaps = sd.EssentialSnaps()
+	runSnaps, err = sd.ModeSnaps("run")
 	c.Assert(err, IsNil)
 
 	return essSnaps, runSnaps, db

--- a/image/preseed/preseed_linux.go
+++ b/image/preseed/preseed_linux.go
@@ -112,7 +112,7 @@ var systemSnapFromSeed = func(seedDir, sysLabel string) (systemSnap string, base
 	model := seed.Model()
 
 	tm := timings.New(nil)
-	if err := seed.LoadMeta(tm); err != nil {
+	if err := seed.LoadEssentialMeta(nil, tm); err != nil {
 		return "", "", err
 	}
 

--- a/image/preseed/preseed_test.go
+++ b/image/preseed/preseed_test.go
@@ -114,11 +114,11 @@ func (fs *Fake16Seed) Brand() (*asserts.Account, error) {
 }
 
 func (fs *Fake16Seed) LoadEssentialMeta(essentialTypes []snap.Type, tm timings.Measurer) error {
-	panic("unexpected")
+	return fs.LoadMetaErr
 }
 
-func (fs *Fake16Seed) LoadMeta(tm timings.Measurer) error {
-	return fs.LoadMetaErr
+func (fs *Fake16Seed) LoadMeta(mode string, tm timings.Measurer) error {
+	panic("unexpected")
 }
 
 func (fs *Fake16Seed) UsesSnapdSnap() bool {

--- a/overlord/devicestate/firstboot.go
+++ b/overlord/devicestate/firstboot.go
@@ -126,7 +126,7 @@ func populateStateFromSeedImpl(st *state.State, opts *populateStateFromSeedOptio
 	}
 
 	timings.Run(tm, "load-verified-snap-metadata", "load verified snap metadata from seed", func(nested timings.Measurer) {
-		err = deviceSeed.LoadMeta(nested)
+		err = deviceSeed.LoadMeta(mode, nested)
 	})
 	if release.OnClassic && err == seed.ErrNoMeta {
 		if preseed {

--- a/seed/seed.go
+++ b/seed/seed.go
@@ -127,7 +127,7 @@ type Seed interface {
 	ModeSnaps(mode string) ([]*Snap, error)
 
 	// NumSnaps returns the total number of snaps for which
-	// LoadeMeta loaded their metadata.
+	// LoadMeta loaded their metadata.
 	NumSnaps() int
 
 	// Iter provides a way to iterately perform a function on

--- a/seed/seed.go
+++ b/seed/seed.go
@@ -68,6 +68,10 @@ func (s *Snap) PlaceInfo() snap.PlaceInfo {
 	return &snap.Info{SideInfo: *s.SideInfo}
 }
 
+// AllModes can be passed to Seed.LoadMeta to load metadata for snaps
+// for all modes.
+const AllModes = ""
+
 // Seed supports loading assertions and seed snaps' metadata.
 type Seed interface {
 	// LoadAssertions loads all assertions from the seed with
@@ -102,7 +106,11 @@ type Seed interface {
 	// return ErrNoMeta if there is no metadata nor snaps in the
 	// seed, this is legitimate only on classic.
 	// It will panic if called before LoadAssertions.
-	LoadMeta(tm timings.Measurer) error
+	// If a precise mode is passed and not AllModes it will
+	// load the metadata only for the snaps of that mode.
+	// At which point ModeSnaps will only accept that mode
+	// and Iter and NumSnaps only consider the snaps for that mode.
+	LoadMeta(mode string, tm timings.Measurer) error
 
 	// UsesSnapdSnap returns whether the system as defined by the
 	// seed will use the snapd snap, after LoadMeta.
@@ -114,14 +122,16 @@ type Seed interface {
 
 	// ModeSnaps returns the snaps that should be available
 	// in the given mode as defined by the seed, after LoadMeta.
+	// If LoadMeta was passed a precise mode, passing a different
+	// mode here will result in error.
 	ModeSnaps(mode string) ([]*Snap, error)
 
-	// NumSnaps returns the total number of snaps in a seed.
+	// NumSnaps returns the total number of snaps for which
+	// LoadeMeta loaded their metadata.
 	NumSnaps() int
 
 	// Iter provides a way to iterately perform a function on
-	// each of the snaps in a seed. For UC20 all snaps will be
-	// considered independent of mode.
+	// each of the snaps for which LoadMeta loaded their metadata.
 	Iter(f func(sn *Snap) error) error
 }
 

--- a/seed/seed.go
+++ b/seed/seed.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2019-2021 Canonical Ltd
+ * Copyright (C) 2019-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/seed/seed16.go
+++ b/seed/seed16.go
@@ -349,7 +349,11 @@ func (s *seed16) LoadEssentialMeta(essentialTypes []snap.Type, tm timings.Measur
 	return s.loadEssentialMeta(essentialTypes, required, added, tm)
 }
 
-func (s *seed16) LoadMeta(tm timings.Measurer) error {
+func (s *seed16) LoadMeta(mode string, tm timings.Measurer) error {
+	if mode != AllModes && mode != "run" {
+		return fmt.Errorf("internal error: Core 16/18 have only run mode, got: %s", mode)
+	}
+
 	model := s.Model()
 
 	if err := s.loadYaml(); err != nil {

--- a/seed/seed16_test.go
+++ b/seed/seed16_test.go
@@ -207,7 +207,7 @@ func (s *seed16Suite) TestLoadMetaNoMeta(c *C) {
 	err = s.seed16.LoadAssertions(s.db, s.commitTo)
 	c.Assert(err, IsNil)
 
-	err = s.seed16.LoadMeta(s.perfTimings)
+	err = s.seed16.LoadMeta(seed.AllModes, s.perfTimings)
 	c.Check(err, Equals, seed.ErrNoMeta)
 }
 
@@ -237,7 +237,7 @@ func (s *seed16Suite) TestLoadMetaInvalidSeedYaml(c *C) {
 	err = ioutil.WriteFile(filepath.Join(s.SeedDir, "seed.yaml"), content, 0644)
 	c.Assert(err, IsNil)
 
-	err = s.seed16.LoadMeta(s.perfTimings)
+	err = s.seed16.LoadMeta(seed.AllModes, s.perfTimings)
 	c.Check(err, ErrorMatches, `cannot read seed yaml: invalid risk in channel name: track/not-a-risk`)
 }
 
@@ -424,7 +424,7 @@ func (s *seed16Suite) TestLoadMetaCore16Minimal(c *C) {
 	err := s.seed16.LoadAssertions(s.db, s.commitTo)
 	c.Assert(err, IsNil)
 
-	err = s.seed16.LoadMeta(s.perfTimings)
+	err = s.seed16.LoadMeta(seed.AllModes, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	c.Check(s.seed16.UsesSnapdSnap(), Equals, false)
@@ -470,7 +470,7 @@ func (s *seed16Suite) TestLoadMetaCore16(c *C) {
 	err := s.seed16.LoadAssertions(s.db, s.commitTo)
 	c.Assert(err, IsNil)
 
-	err = s.seed16.LoadMeta(s.perfTimings)
+	err = s.seed16.LoadMeta(seed.AllModes, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	essSnaps := s.seed16.EssentialSnaps()
@@ -508,7 +508,7 @@ func (s *seed16Suite) TestLoadMetaCore18Minimal(c *C) {
 	err := s.seed16.LoadAssertions(s.db, s.commitTo)
 	c.Assert(err, IsNil)
 
-	err = s.seed16.LoadMeta(s.perfTimings)
+	err = s.seed16.LoadMeta(seed.AllModes, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	c.Check(s.seed16.UsesSnapdSnap(), Equals, true)
@@ -564,7 +564,7 @@ func (s *seed16Suite) TestLoadMetaCore18(c *C) {
 	err := s.seed16.LoadAssertions(s.db, s.commitTo)
 	c.Assert(err, IsNil)
 
-	err = s.seed16.LoadMeta(s.perfTimings)
+	err = s.seed16.LoadMeta(seed.AllModes, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	essSnaps := s.seed16.EssentialSnaps()
@@ -635,7 +635,7 @@ func (s *seed16Suite) TestLoadMetaClassicNothing(c *C) {
 	err := s.seed16.LoadAssertions(s.db, s.commitTo)
 	c.Assert(err, IsNil)
 
-	err = s.seed16.LoadMeta(s.perfTimings)
+	err = s.seed16.LoadMeta(seed.AllModes, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	c.Check(s.seed16.UsesSnapdSnap(), Equals, false)
@@ -656,7 +656,7 @@ func (s *seed16Suite) TestLoadMetaClassicCore(c *C) {
 	err := s.seed16.LoadAssertions(s.db, s.commitTo)
 	c.Assert(err, IsNil)
 
-	err = s.seed16.LoadMeta(s.perfTimings)
+	err = s.seed16.LoadMeta(seed.AllModes, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	c.Check(s.seed16.UsesSnapdSnap(), Equals, false)
@@ -697,7 +697,7 @@ func (s *seed16Suite) TestLoadMetaClassicCoreWithGadget(c *C) {
 	err := s.seed16.LoadAssertions(s.db, s.commitTo)
 	c.Assert(err, IsNil)
 
-	err = s.seed16.LoadMeta(s.perfTimings)
+	err = s.seed16.LoadMeta(seed.AllModes, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	c.Check(s.seed16.UsesSnapdSnap(), Equals, false)
@@ -737,7 +737,7 @@ func (s *seed16Suite) TestLoadMetaClassicSnapd(c *C) {
 	err := s.seed16.LoadAssertions(s.db, s.commitTo)
 	c.Assert(err, IsNil)
 
-	err = s.seed16.LoadMeta(s.perfTimings)
+	err = s.seed16.LoadMeta(seed.AllModes, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	c.Check(s.seed16.UsesSnapdSnap(), Equals, true)
@@ -782,7 +782,7 @@ func (s *seed16Suite) TestLoadMetaClassicSnapdWithGadget(c *C) {
 	err := s.seed16.LoadAssertions(s.db, s.commitTo)
 	c.Assert(err, IsNil)
 
-	err = s.seed16.LoadMeta(s.perfTimings)
+	err = s.seed16.LoadMeta(seed.AllModes, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	c.Check(s.seed16.UsesSnapdSnap(), Equals, true)
@@ -832,7 +832,7 @@ func (s *seed16Suite) TestLoadMetaClassicSnapdWithGadget18(c *C) {
 	err := s.seed16.LoadAssertions(s.db, s.commitTo)
 	c.Assert(err, IsNil)
 
-	err = s.seed16.LoadMeta(s.perfTimings)
+	err = s.seed16.LoadMeta(seed.AllModes, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	c.Check(s.seed16.UsesSnapdSnap(), Equals, true)
@@ -901,7 +901,7 @@ func (s *seed16Suite) TestLoadMetaCore18Local(c *C) {
 	err := s.seed16.LoadAssertions(s.db, s.commitTo)
 	c.Assert(err, IsNil)
 
-	err = s.seed16.LoadMeta(s.perfTimings)
+	err = s.seed16.LoadMeta(seed.AllModes, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	essSnaps := s.seed16.EssentialSnaps()
@@ -963,7 +963,7 @@ func (s *seed16Suite) TestLoadMetaCore18StoreInfo(c *C) {
 	err := s.seed16.LoadAssertions(s.db, s.commitTo)
 	c.Assert(err, IsNil)
 
-	err = s.seed16.LoadMeta(s.perfTimings)
+	err = s.seed16.LoadMeta(seed.AllModes, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	essSnaps := s.seed16.EssentialSnaps()
@@ -1013,7 +1013,7 @@ func (s *seed16Suite) TestLoadMetaCore18EnforcePinnedTracks(c *C) {
 	err := s.seed16.LoadAssertions(s.db, s.commitTo)
 	c.Assert(err, IsNil)
 
-	err = s.seed16.LoadMeta(s.perfTimings)
+	err = s.seed16.LoadMeta(seed.AllModes, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	c.Check(s.seed16.UsesSnapdSnap(), Equals, true)
@@ -1134,7 +1134,7 @@ version: other-base
 		testSeedSnap16s = t.breakSeed(testSeedSnap16s)
 		s.writeSeed(c, testSeedSnap16s)
 
-		c.Check(seed16.LoadMeta(s.perfTimings), ErrorMatches, t.err)
+		c.Check(seed16.LoadMeta(seed.AllModes, s.perfTimings), ErrorMatches, t.err)
 	}
 }
 
@@ -1308,7 +1308,7 @@ func (s *seed16Suite) TestLoadEssentialAndMetaCore18(c *C) {
 	// caching in place
 	hideSnaps(c, []*seed.Snap{snapdSnap, core18Snap, pcKernelSnap}, nil)
 
-	err = seed16.LoadMeta(s.perfTimings)
+	err = seed16.LoadMeta(seed.AllModes, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	c.Check(seed16.UsesSnapdSnap(), Equals, true)

--- a/seed/seed20.go
+++ b/seed/seed20.go
@@ -67,6 +67,8 @@ type seed20 struct {
 
 	essCache map[string]*Snap
 
+	mode string
+
 	snaps []*Snap
 	// modes holds a matching applicable modes set for each snap in snaps
 	modes             [][]string
@@ -403,14 +405,19 @@ func (s *seed20) addModelSnap(modelSnap *asserts.ModelSnap, essential bool, filt
 	return seedSnap, nil
 }
 
-func (s *seed20) LoadMeta(tm timings.Measurer) error {
+func (s *seed20) LoadMeta(mode string, tm timings.Measurer) error {
 	if err := s.loadEssentialMeta(nil, tm); err != nil {
 		return err
 	}
+	s.mode = mode
 	if err := s.loadModelRestMeta(tm); err != nil {
 		return err
 	}
 
+	if s.mode != AllModes && s.mode != "run" {
+		// extra snaps are only fo run mode
+		return nil
+	}
 	// extra snaps
 	runMode := []string{"run"}
 	for {
@@ -468,6 +475,7 @@ func (s *seed20) resetSnaps() {
 	}
 
 	s.optSnapsIdx = 0
+	s.mode = AllModes
 	s.snaps = nil
 	s.modes = nil
 	s.essentialSnapsNum = 0
@@ -518,13 +526,34 @@ func (s *seed20) loadEssentialMeta(filterEssential func(*asserts.ModelSnap) bool
 	return nil
 }
 
+func modesInclude(modes []string, mode string) bool {
+	if strutil.ListContains(modes, mode) {
+		return true
+	}
+	if mode == "run" {
+		// not ephemeral
+		return false
+	}
+	return strutil.ListContains(modes, "ephemeral")
+}
+
 func (s *seed20) loadModelRestMeta(tm timings.Measurer) error {
 	model := s.Model()
 
+	var filterMode func(*asserts.ModelSnap) bool
+	if s.mode != AllModes {
+		filterMode = func(modelSnap *asserts.ModelSnap) bool {
+			return modesInclude(modelSnap.Modes, s.mode)
+		}
+	}
+
 	const notEssential = false
 	for _, modelSnap := range model.SnapsWithoutEssential() {
-		_, err := s.addModelSnap(modelSnap, notEssential, nil, nil, tm)
+		_, err := s.addModelSnap(modelSnap, notEssential, filterMode, nil, tm)
 		if err != nil {
+			if err == errFiltered {
+				continue
+			}
 			if _, ok := err.(*noSnapDeclarationError); ok && modelSnap.Presence == "optional" {
 				// skipped optional snap is ok
 				continue
@@ -541,6 +570,9 @@ func (s *seed20) EssentialSnaps() []*Snap {
 }
 
 func (s *seed20) ModeSnaps(mode string) ([]*Snap, error) {
+	if s.mode != AllModes && mode != s.mode {
+		return nil, fmt.Errorf("metadata was loaded only for snaps for mode %s not %s", s.mode, mode)
+	}
 	snaps := s.snaps[s.essentialSnapsNum:]
 	modes := s.modes[s.essentialSnapsNum:]
 	nGuess := len(snaps)

--- a/seed/seed20.go
+++ b/seed/seed20.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2020 Canonical Ltd
+ * Copyright (C) 2014-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/seed/seed20_test.go
+++ b/seed/seed20_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2019-2020 Canonical Ltd
+ * Copyright (C) 2019-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/seed/seed20_test.go
+++ b/seed/seed20_test.go
@@ -128,7 +128,7 @@ func (s *seed20Suite) TestLoadMetaCore20Minimal(c *C) {
 	err = seed20.LoadAssertions(s.db, s.commitTo)
 	c.Assert(err, IsNil)
 
-	err = seed20.LoadMeta(s.perfTimings)
+	err = seed20.LoadMeta(seed.AllModes, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	c.Check(seed20.UsesSnapdSnap(), Equals, true)
@@ -439,7 +439,7 @@ func (s *seed20Suite) TestLoadMetaMissingSnapDeclByName(c *C) {
 	err = seed20.LoadAssertions(s.db, s.commitTo)
 	c.Assert(err, IsNil)
 
-	err = seed20.LoadMeta(s.perfTimings)
+	err = seed20.LoadMeta(seed.AllModes, s.perfTimings)
 	c.Check(err, ErrorMatches, `cannot find snap-declaration for snap name: core20`)
 }
 
@@ -482,7 +482,7 @@ func (s *seed20Suite) TestLoadMetaMissingSnapDeclByID(c *C) {
 	err = seed20.LoadAssertions(s.db, s.commitTo)
 	c.Assert(err, IsNil)
 
-	err = seed20.LoadMeta(s.perfTimings)
+	err = seed20.LoadMeta(seed.AllModes, s.perfTimings)
 	c.Check(err, ErrorMatches, `cannot find snap-declaration for snap-id: pcididididididididididididididid`)
 }
 
@@ -499,7 +499,7 @@ func (s *seed20Suite) TestLoadMetaMissingSnap(c *C) {
 	err = seed20.LoadAssertions(s.db, s.commitTo)
 	c.Assert(err, IsNil)
 
-	err = seed20.LoadMeta(s.perfTimings)
+	err = seed20.LoadMeta(seed.AllModes, s.perfTimings)
 	c.Check(err, ErrorMatches, `cannot stat snap:.*pc_1\.snap.*`)
 }
 
@@ -516,7 +516,7 @@ func (s *seed20Suite) TestLoadMetaWrongSizeSnap(c *C) {
 	err = seed20.LoadAssertions(s.db, s.commitTo)
 	c.Assert(err, IsNil)
 
-	err = seed20.LoadMeta(s.perfTimings)
+	err = seed20.LoadMeta(seed.AllModes, s.perfTimings)
 	c.Check(err, ErrorMatches, `cannot validate ".*pc_1\.snap" for snap "pc" \(snap-id "pc.*"\), wrong size`)
 }
 
@@ -548,7 +548,7 @@ func (s *seed20Suite) TestLoadMetaWrongHashSnap(c *C) {
 	err = seed20.LoadAssertions(s.db, s.commitTo)
 	c.Assert(err, IsNil)
 
-	err = seed20.LoadMeta(s.perfTimings)
+	err = seed20.LoadMeta(seed.AllModes, s.perfTimings)
 	c.Check(err, ErrorMatches, `cannot validate ".*pc_1\.snap" for snap "pc" \(snap-id "pc.*"\), hash mismatch with snap-revision`)
 }
 
@@ -576,7 +576,7 @@ func (s *seed20Suite) TestLoadMetaWrongGadgetBase(c *C) {
 	err = seed20.LoadAssertions(s.db, s.commitTo)
 	c.Assert(err, IsNil)
 
-	err = seed20.LoadMeta(s.perfTimings)
+	err = seed20.LoadMeta(seed.AllModes, s.perfTimings)
 	c.Check(err, ErrorMatches, `cannot use gadget snap because its base "core18" is different from model base "core20"`)
 }
 
@@ -619,7 +619,7 @@ func (s *seed20Suite) TestLoadMetaCore20(c *C) {
 	err = seed20.LoadAssertions(s.db, s.commitTo)
 	c.Assert(err, IsNil)
 
-	err = seed20.LoadMeta(s.perfTimings)
+	err = seed20.LoadMeta(seed.AllModes, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	c.Check(seed20.UsesSnapdSnap(), Equals, true)
@@ -1059,7 +1059,7 @@ func (s *seed20Suite) TestLoadEssentialAndMetaCore20(c *C) {
 	// caching in place
 	hideSnaps(c, []*seed.Snap{snapdSnap, core20Snap, pcKernelSnap}, nil)
 
-	err = seed20.LoadMeta(s.perfTimings)
+	err = seed20.LoadMeta(seed.AllModes, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	c.Check(seed20.UsesSnapdSnap(), Equals, true)
@@ -1130,7 +1130,7 @@ func (s *seed20Suite) TestLoadMetaCore20LocalSnaps(c *C) {
 	err = seed20.LoadAssertions(s.db, s.commitTo)
 	c.Assert(err, IsNil)
 
-	err = seed20.LoadMeta(s.perfTimings)
+	err = seed20.LoadMeta(seed.AllModes, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	c.Check(seed20.UsesSnapdSnap(), Equals, true)
@@ -1225,7 +1225,7 @@ func (s *seed20Suite) TestLoadMetaCore20ChannelOverride(c *C) {
 	err = seed20.LoadAssertions(s.db, s.commitTo)
 	c.Assert(err, IsNil)
 
-	err = seed20.LoadMeta(s.perfTimings)
+	err = seed20.LoadMeta(seed.AllModes, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	c.Check(seed20.UsesSnapdSnap(), Equals, true)
@@ -1320,7 +1320,7 @@ func (s *seed20Suite) TestLoadMetaCore20ChannelOverrideSnapd(c *C) {
 	err = seed20.LoadAssertions(s.db, s.commitTo)
 	c.Assert(err, IsNil)
 
-	err = seed20.LoadMeta(s.perfTimings)
+	err = seed20.LoadMeta(seed.AllModes, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	c.Check(seed20.UsesSnapdSnap(), Equals, true)
@@ -1408,7 +1408,7 @@ func (s *seed20Suite) TestLoadMetaCore20LocalSnapd(c *C) {
 	err = seed20.LoadAssertions(s.db, s.commitTo)
 	c.Assert(err, IsNil)
 
-	err = seed20.LoadMeta(s.perfTimings)
+	err = seed20.LoadMeta(seed.AllModes, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	c.Check(seed20.UsesSnapdSnap(), Equals, true)
@@ -1490,7 +1490,7 @@ func (s *seed20Suite) TestLoadMetaCore20ModelOverrideSnapd(c *C) {
 	err = seed20.LoadAssertions(s.db, s.commitTo)
 	c.Assert(err, IsNil)
 
-	err = seed20.LoadMeta(s.perfTimings)
+	err = seed20.LoadMeta(seed.AllModes, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	c.Check(seed20.UsesSnapdSnap(), Equals, true)
@@ -1582,7 +1582,7 @@ func (s *seed20Suite) TestLoadMetaCore20OptionalSnaps(c *C) {
 	err = seed20.LoadAssertions(s.db, s.commitTo)
 	c.Assert(err, IsNil)
 
-	err = seed20.LoadMeta(s.perfTimings)
+	err = seed20.LoadMeta(seed.AllModes, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	c.Check(seed20.UsesSnapdSnap(), Equals, true)
@@ -1682,7 +1682,7 @@ func (s *seed20Suite) TestLoadMetaCore20OptionalSnapsLocal(c *C) {
 	err = seed20.LoadAssertions(s.db, s.commitTo)
 	c.Assert(err, IsNil)
 
-	err = seed20.LoadMeta(s.perfTimings)
+	err = seed20.LoadMeta(seed.AllModes, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	c.Check(seed20.UsesSnapdSnap(), Equals, true)
@@ -1775,7 +1775,7 @@ func (s *seed20Suite) TestLoadMetaCore20ExtraSnaps(c *C) {
 	err = seed20.LoadAssertions(s.db, s.commitTo)
 	c.Assert(err, IsNil)
 
-	err = seed20.LoadMeta(s.perfTimings)
+	err = seed20.LoadMeta(seed.AllModes, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	c.Check(seed20.UsesSnapdSnap(), Equals, true)
@@ -1898,7 +1898,7 @@ func (s *seed20Suite) TestLoadMetaCore20NotRunSnaps(c *C) {
 	err = seed20.LoadAssertions(s.db, s.commitTo)
 	c.Assert(err, IsNil)
 
-	err = seed20.LoadMeta(s.perfTimings)
+	err = seed20.LoadMeta(seed.AllModes, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	c.Check(seed20.UsesSnapdSnap(), Equals, true)
@@ -1937,6 +1937,8 @@ func (s *seed20Suite) TestLoadMetaCore20NotRunSnaps(c *C) {
 			Channel:       "20",
 		},
 	})
+
+	c.Check(seed20.NumSnaps(), Equals, 7)
 
 	runSnaps, err := seed20.ModeSnaps("run")
 	c.Assert(err, IsNil)
@@ -1993,6 +1995,174 @@ func (s *seed20Suite) TestLoadMetaCore20NotRunSnaps(c *C) {
 	})
 }
 
+func (s *seed20Suite) TestLoadMetaCore20PreciseNotRunSnaps(c *C) {
+	s.makeSnap(c, "snapd", "")
+	s.makeSnap(c, "core20", "")
+	s.makeSnap(c, "pc-kernel=20", "")
+	s.makeSnap(c, "pc=20", "")
+	s.makeSnap(c, "required20", "developerid")
+	s.makeSnap(c, "optional20-a", "developerid")
+	s.makeSnap(c, "optional20-b", "developerid")
+
+	sysLabel := "20191122"
+	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
+		"display-name": "my model",
+		"architecture": "amd64",
+		"base":         "core20",
+		"grade":        "signed",
+		"snaps": []interface{}{
+			map[string]interface{}{
+				"name":            "pc-kernel",
+				"id":              s.AssertedSnapID("pc-kernel"),
+				"type":            "kernel",
+				"default-channel": "20",
+			},
+			map[string]interface{}{
+				"name":            "pc",
+				"id":              s.AssertedSnapID("pc"),
+				"type":            "gadget",
+				"default-channel": "20",
+			},
+			map[string]interface{}{
+				"name":  "required20",
+				"id":    s.AssertedSnapID("required20"),
+				"modes": []interface{}{"run", "ephemeral"},
+			},
+			map[string]interface{}{
+				"name":     "optional20-a",
+				"id":       s.AssertedSnapID("optional20-a"),
+				"presence": "optional",
+				"modes":    []interface{}{"ephemeral"},
+			},
+			map[string]interface{}{
+				"name":     "optional20-b",
+				"id":       s.AssertedSnapID("optional20-b"),
+				"presence": "optional",
+				"modes":    []interface{}{"install"},
+			}},
+	}, []*seedwriter.OptionsSnap{
+		{Name: "optional20-a"},
+		{Name: "optional20-b"},
+	})
+
+	seed20, err := seed.Open(s.SeedDir, sysLabel)
+	c.Assert(err, IsNil)
+
+	err = seed20.LoadAssertions(s.db, s.commitTo)
+	c.Assert(err, IsNil)
+
+	err = seed20.LoadMeta("install", s.perfTimings)
+	c.Assert(err, IsNil)
+
+	c.Check(seed20.UsesSnapdSnap(), Equals, true)
+
+	essSnaps := seed20.EssentialSnaps()
+	c.Check(essSnaps, HasLen, 4)
+
+	c.Check(essSnaps, DeepEquals, []*seed.Snap{
+		{
+			Path:          s.expectedPath("snapd"),
+			SideInfo:      &s.AssertedSnapInfo("snapd").SideInfo,
+			EssentialType: snap.TypeSnapd,
+			Essential:     true,
+			Required:      true,
+			Channel:       "latest/stable",
+		}, {
+			Path:          s.expectedPath("pc-kernel"),
+			SideInfo:      &s.AssertedSnapInfo("pc-kernel").SideInfo,
+			EssentialType: snap.TypeKernel,
+			Essential:     true,
+			Required:      true,
+			Channel:       "20",
+		}, {
+			Path:          s.expectedPath("core20"),
+			SideInfo:      &s.AssertedSnapInfo("core20").SideInfo,
+			EssentialType: snap.TypeBase,
+			Essential:     true,
+			Required:      true,
+			Channel:       "latest/stable",
+		}, {
+			Path:          s.expectedPath("pc"),
+			SideInfo:      &s.AssertedSnapInfo("pc").SideInfo,
+			EssentialType: snap.TypeGadget,
+			Essential:     true,
+			Required:      true,
+			Channel:       "20",
+		},
+	})
+
+	c.Check(seed20.NumSnaps(), Equals, 7)
+
+	installSnaps, err := seed20.ModeSnaps("install")
+	c.Assert(err, IsNil)
+	c.Check(installSnaps, HasLen, 3)
+	c.Check(installSnaps, DeepEquals, []*seed.Snap{
+		{
+			Path:     s.expectedPath("required20"),
+			SideInfo: &s.AssertedSnapInfo("required20").SideInfo,
+			Required: true,
+			Channel:  "latest/stable",
+		},
+		{
+			Path:     s.expectedPath("optional20-a"),
+			SideInfo: &s.AssertedSnapInfo("optional20-a").SideInfo,
+			Required: false,
+			Channel:  "latest/stable",
+		},
+		{
+			Path:     s.expectedPath("optional20-b"),
+			SideInfo: &s.AssertedSnapInfo("optional20-b").SideInfo,
+			Required: false,
+			Channel:  "latest/stable",
+		},
+	})
+
+	_, err = seed20.ModeSnaps("recover")
+	c.Check(err, ErrorMatches, `metadata was loaded only for snaps for mode install not recover`)
+	_, err = seed20.ModeSnaps("run")
+	c.Check(err, ErrorMatches, `metadata was loaded only for snaps for mode install not run`)
+
+	err = seed20.LoadMeta("recover", s.perfTimings)
+	c.Assert(err, IsNil)
+	// only recover mode snaps
+	c.Check(seed20.NumSnaps(), Equals, 6)
+
+	recoverSnaps, err := seed20.ModeSnaps("recover")
+	c.Assert(err, IsNil)
+	c.Check(recoverSnaps, HasLen, 2)
+	c.Check(recoverSnaps, DeepEquals, []*seed.Snap{
+		{
+			Path:     s.expectedPath("required20"),
+			SideInfo: &s.AssertedSnapInfo("required20").SideInfo,
+			Required: true,
+			Channel:  "latest/stable",
+		},
+		{
+			Path:     s.expectedPath("optional20-a"),
+			SideInfo: &s.AssertedSnapInfo("optional20-a").SideInfo,
+			Required: false,
+			Channel:  "latest/stable",
+		},
+	})
+
+	err = seed20.LoadMeta("run", s.perfTimings)
+	c.Assert(err, IsNil)
+	// only recover mode snaps
+	c.Check(seed20.NumSnaps(), Equals, 5)
+
+	runSnaps, err := seed20.ModeSnaps("run")
+	c.Assert(err, IsNil)
+	c.Check(runSnaps, HasLen, 1)
+	c.Check(runSnaps, DeepEquals, []*seed.Snap{
+		{
+			Path:     s.expectedPath("required20"),
+			SideInfo: &s.AssertedSnapInfo("required20").SideInfo,
+			Required: true,
+			Channel:  "latest/stable",
+		},
+	})
+}
+
 func (s *seed20Suite) TestLoadMetaCore20LocalAssertedSnaps(c *C) {
 	s.makeSnap(c, "snapd", "")
 	s.makeSnap(c, "core20", "")
@@ -2030,7 +2200,7 @@ func (s *seed20Suite) TestLoadMetaCore20LocalAssertedSnaps(c *C) {
 	err = seed20.LoadAssertions(s.db, s.commitTo)
 	c.Assert(err, IsNil)
 
-	err = seed20.LoadMeta(s.perfTimings)
+	err = seed20.LoadMeta(seed.AllModes, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	c.Check(seed20.UsesSnapdSnap(), Equals, true)
@@ -2138,7 +2308,7 @@ func (s *seed20Suite) TestLoadMetaCore20Iter(c *C) {
 	err = seed20.LoadAssertions(s.db, s.commitTo)
 	c.Assert(err, IsNil)
 
-	err = seed20.LoadMeta(s.perfTimings)
+	err = seed20.LoadMeta(seed.AllModes, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	c.Check(seed20.NumSnaps(), Equals, 5)

--- a/seed/seed20_test.go
+++ b/seed/seed20_test.go
@@ -2147,7 +2147,7 @@ func (s *seed20Suite) TestLoadMetaCore20PreciseNotRunSnaps(c *C) {
 
 	err = seed20.LoadMeta("run", s.perfTimings)
 	c.Assert(err, IsNil)
-	// only recover mode snaps
+	// only run mode snaps
 	c.Check(seed20.NumSnaps(), Equals, 5)
 
 	runSnaps, err := seed20.ModeSnaps("run")

--- a/seed/seedtest/seedtest.go
+++ b/seed/seedtest/seedtest.go
@@ -363,7 +363,7 @@ func ValidateSeed(c *C, root, label string, usesSnapd bool, trusted []asserts.As
 	err = sd.LoadAssertions(db, commitTo)
 	c.Assert(err, IsNil)
 
-	err = sd.LoadMeta(tm)
+	err = sd.LoadMeta(seed.AllModes, tm)
 	c.Assert(err, IsNil)
 
 	// core18/core20 use the snapd snap, old core does not

--- a/seed/validate.go
+++ b/seed/validate.go
@@ -96,7 +96,7 @@ func ValidateFromYaml(seedYamlFile string) error {
 	}
 
 	tm := timings.New(nil)
-	if err := seed.LoadMeta(tm); err != nil {
+	if err := seed.LoadMeta(AllModes, tm); err != nil {
 		if missingErr, ok := err.(*essentialSnapMissingError); ok {
 			if seed.Model().Classic() && missingErr.SnapName == "core" {
 				err = fmt.Errorf("essential snap core or snapd must be part of the seed")

--- a/spread.yaml
+++ b/spread.yaml
@@ -44,7 +44,7 @@ environment:
     UBUNTU_IMAGE_SNAP_CHANNEL: "latest/candidate"
     # controls whether ubuntu-image is built using the current snapd tree as a
     # dependency or the one listed in its go.mod
-    UBUNTU_IMAGE_ALLOW_API_BREAK: '$(HOST: echo "${SPREAD_UBUNTU_IMAGE_ALLOW_API_BREAK:-true}")'
+    UBUNTU_IMAGE_ALLOW_API_BREAK: '$(HOST: echo "${SPREAD_UBUNTU_IMAGE_ALLOW_API_BREAK:-false}")'
     CORE_CHANNEL: '$(HOST: echo "${SPREAD_CORE_CHANNEL:-edge}")'
     BASE_CHANNEL: '$(HOST: echo "${SPREAD_BASE_CHANNEL:-edge}")'
     KERNEL_CHANNEL: '$(HOST: echo "${SPREAD_KERNEL_CHANNEL:-edge}")'

--- a/spread.yaml
+++ b/spread.yaml
@@ -44,7 +44,7 @@ environment:
     UBUNTU_IMAGE_SNAP_CHANNEL: "latest/candidate"
     # controls whether ubuntu-image is built using the current snapd tree as a
     # dependency or the one listed in its go.mod
-    UBUNTU_IMAGE_ALLOW_API_BREAK: '$(HOST: echo "${UBUNTU_IMAGE_ALLOW_API_BREAK:-true}")'
+    SPREAD_UBUNTU_IMAGE_ALLOW_API_BREAK: '$(HOST: echo "${SPREAD_UBUNTU_IMAGE_ALLOW_API_BREAK:-true}")'
     CORE_CHANNEL: '$(HOST: echo "${SPREAD_CORE_CHANNEL:-edge}")'
     BASE_CHANNEL: '$(HOST: echo "${SPREAD_BASE_CHANNEL:-edge}")'
     KERNEL_CHANNEL: '$(HOST: echo "${SPREAD_KERNEL_CHANNEL:-edge}")'
@@ -965,8 +965,8 @@ suites:
         prepare: |
             #shellcheck source=tests/lib/pkgdb.sh
             . "$TESTSLIB"/pkgdb.sh
-            #shellcheck source=tests/lib/nested.sh
-            . "$TESTSLIB"/nested.sh
+            #shellcheck source=tests/lib/image.sh
+            . "$TESTSLIB"/image.sh
             distro_update_package_db
             distro_install_package snapd qemu qemu-utils genisoimage sshpass qemu-kvm cloud-image-utils ovmf kpartx xz-utils mtools ca-certificates xdelta3
             if os.query is-xenial; then
@@ -974,7 +974,7 @@ suites:
                 # supported yet by the version of mkfs that shipped with Ubuntu 16.04
                 snap install ubuntu-image --channel="$UBUNTU_IMAGE_SNAP_CHANNEL" --classic
             else
-               nested_build_ubuntu_image
+               build_ubuntu_image
             fi
 
             # Install the snapd built
@@ -1007,8 +1007,8 @@ suites:
         prepare: |
             #shellcheck source=tests/lib/pkgdb.sh
             . "$TESTSLIB"/pkgdb.sh
-            #shellcheck source=tests/lib/nested.sh
-            . "$TESTSLIB"/nested.sh
+            #shellcheck source=tests/lib/image.sh
+            . "$TESTSLIB"/image.sh
             distro_update_package_db
             distro_install_package snapd qemu qemu-utils genisoimage sshpass qemu-kvm cloud-image-utils ovmf kpartx xz-utils mtools ca-certificates xdelta3
             if os.query is-xenial; then
@@ -1016,7 +1016,7 @@ suites:
                 # supported yet by the version of mkfs that shipped with Ubuntu 16.04
                 snap install ubuntu-image --channel="$UBUNTU_IMAGE_SNAP_CHANNEL" --classic
             else
-                nested_build_ubuntu_image
+                build_ubuntu_image
             fi
 
             # Install the snapd built
@@ -1054,8 +1054,8 @@ suites:
         prepare: |
             #shellcheck source=tests/lib/pkgdb.sh
             . "$TESTSLIB"/pkgdb.sh
-            #shellcheck source=tests/lib/nested.sh
-            . "$TESTSLIB"/nested.sh
+            #shellcheck source=tests/lib/image.sh
+            . "$TESTSLIB"/image.sh
             distro_update_package_db
             distro_install_package snapd qemu qemu-utils genisoimage sshpass qemu-kvm cloud-image-utils ovmf kpartx xz-utils mtools ca-certificates xdelta3
             if os.query is-xenial; then
@@ -1063,7 +1063,7 @@ suites:
                 # supported yet by the version of mkfs that shipped with Ubuntu 16.04
                 snap install ubuntu-image --channel="$UBUNTU_IMAGE_SNAP_CHANNEL" --classic
             else
-                nested_build_ubuntu_image
+                build_ubuntu_image
             fi
 
             # Install the snapd built

--- a/spread.yaml
+++ b/spread.yaml
@@ -42,6 +42,9 @@ environment:
     # a global setting for LXD channel to use in the tests
     LXD_SNAP_CHANNEL: "latest/candidate"
     UBUNTU_IMAGE_SNAP_CHANNEL: "latest/candidate"
+    # controls whether ubuntu-image is built using the current snapd tree as a
+    # dependency or the one listed in its go.mod
+    UBUNTU_IMAGE_ALLOW_API_BREAK: '$(HOST: echo "${UBUNTU_IMAGE_ALLOW_API_BREAK:-true}")'
     CORE_CHANNEL: '$(HOST: echo "${SPREAD_CORE_CHANNEL:-edge}")'
     BASE_CHANNEL: '$(HOST: echo "${SPREAD_BASE_CHANNEL:-edge}")'
     KERNEL_CHANNEL: '$(HOST: echo "${SPREAD_KERNEL_CHANNEL:-edge}")'
@@ -962,6 +965,8 @@ suites:
         prepare: |
             #shellcheck source=tests/lib/pkgdb.sh
             . "$TESTSLIB"/pkgdb.sh
+            #shellcheck source=tests/lib/nested.sh
+            . "$TESTSLIB"/nested.sh
             distro_update_package_db
             distro_install_package snapd qemu qemu-utils genisoimage sshpass qemu-kvm cloud-image-utils ovmf kpartx xz-utils mtools ca-certificates xdelta3
             if os.query is-xenial; then
@@ -969,13 +974,7 @@ suites:
                 # supported yet by the version of mkfs that shipped with Ubuntu 16.04
                 snap install ubuntu-image --channel="$UBUNTU_IMAGE_SNAP_CHANNEL" --classic
             else
-                # build a custom version ubuntu-image with test keys
-                (
-                    export GO111MODULE=off
-                    # use go get so that ubuntu-image is built with current snapd sources
-                    go get github.com/canonical/ubuntu-image/cmd/ubuntu-image
-                    go install -tags 'withtestkeys' github.com/canonical/ubuntu-image/cmd/ubuntu-image
-                )
+               nested_build_ubuntu_image
             fi
 
             # Install the snapd built
@@ -1008,6 +1007,8 @@ suites:
         prepare: |
             #shellcheck source=tests/lib/pkgdb.sh
             . "$TESTSLIB"/pkgdb.sh
+            #shellcheck source=tests/lib/nested.sh
+            . "$TESTSLIB"/nested.sh
             distro_update_package_db
             distro_install_package snapd qemu qemu-utils genisoimage sshpass qemu-kvm cloud-image-utils ovmf kpartx xz-utils mtools ca-certificates xdelta3
             if os.query is-xenial; then
@@ -1015,13 +1016,7 @@ suites:
                 # supported yet by the version of mkfs that shipped with Ubuntu 16.04
                 snap install ubuntu-image --channel="$UBUNTU_IMAGE_SNAP_CHANNEL" --classic
             else
-                # build a custom version ubuntu-image with test keys
-                (
-                    export GO111MODULE=off
-                    # use go get so that ubuntu-image is built with current snapd sources
-                    go get github.com/canonical/ubuntu-image/cmd/ubuntu-image
-                    go install -tags 'withtestkeys' github.com/canonical/ubuntu-image/cmd/ubuntu-image
-                )
+                nested_build_ubuntu_image
             fi
 
             # Install the snapd built
@@ -1059,6 +1054,8 @@ suites:
         prepare: |
             #shellcheck source=tests/lib/pkgdb.sh
             . "$TESTSLIB"/pkgdb.sh
+            #shellcheck source=tests/lib/nested.sh
+            . "$TESTSLIB"/nested.sh
             distro_update_package_db
             distro_install_package snapd qemu qemu-utils genisoimage sshpass qemu-kvm cloud-image-utils ovmf kpartx xz-utils mtools ca-certificates xdelta3
             if os.query is-xenial; then
@@ -1066,13 +1063,7 @@ suites:
                 # supported yet by the version of mkfs that shipped with Ubuntu 16.04
                 snap install ubuntu-image --channel="$UBUNTU_IMAGE_SNAP_CHANNEL" --classic
             else
-                # build a custom version ubuntu-image with test keys
-                (
-                    export GO111MODULE=off
-                    # use go get so that ubuntu-image is built with current snapd sources
-                    go get github.com/canonical/ubuntu-image/cmd/ubuntu-image
-                    go install -tags 'withtestkeys' github.com/canonical/ubuntu-image/cmd/ubuntu-image
-                )
+                nested_build_ubuntu_image
             fi
 
             # Install the snapd built

--- a/spread.yaml
+++ b/spread.yaml
@@ -44,7 +44,7 @@ environment:
     UBUNTU_IMAGE_SNAP_CHANNEL: "latest/candidate"
     # controls whether ubuntu-image is built using the current snapd tree as a
     # dependency or the one listed in its go.mod
-    SPREAD_UBUNTU_IMAGE_ALLOW_API_BREAK: '$(HOST: echo "${SPREAD_UBUNTU_IMAGE_ALLOW_API_BREAK:-true}")'
+    UBUNTU_IMAGE_ALLOW_API_BREAK: '$(HOST: echo "${SPREAD_UBUNTU_IMAGE_ALLOW_API_BREAK:-true}")'
     CORE_CHANNEL: '$(HOST: echo "${SPREAD_CORE_CHANNEL:-edge}")'
     BASE_CHANNEL: '$(HOST: echo "${SPREAD_BASE_CHANNEL:-edge}")'
     KERNEL_CHANNEL: '$(HOST: echo "${SPREAD_KERNEL_CHANNEL:-edge}")'

--- a/tests/lib/image.sh
+++ b/tests/lib/image.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 
 build_ubuntu_image() {
+    # the helper can be invoked multiple times, so do nothing if ubuntu-image
+    # was already built and is accessible
+    if command -v ubuntu-image; then
+        return
+    fi
+
     if [ "${UBUNTU_IMAGE_ALLOW_API_BREAK-true}" = "true" ]; then
         (
             # build a version which uses the current snapd tree as a dependency

--- a/tests/lib/image.sh
+++ b/tests/lib/image.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+build_ubuntu_image() {
+    if [ "${SPREAD_UBUNTU_IMAGE_ALLOW_API_BREAK-true}" = "true" ]; then
+        (
+            # build a version which uses the current snapd tree as a dependency
+            # shellcheck disable=SC2030,SC2031
+            export GO111MODULE=off
+            # use go get so that ubuntu-image is built with current snapd
+            # sources
+            go get github.com/canonical/ubuntu-image/cmd/ubuntu-image
+            go install -tags 'withtestkeys' github.com/canonical/ubuntu-image/cmd/ubuntu-image
+        )
+    else
+        (
+            # build a version which uses a particular revision of snapd listed
+            # in ubuntu-image go.mod file
+            # shellcheck disable=SC2030,SC2031
+            export GO111MODULE=on
+            # shellcheck disable=SC2030,SC2031
+            unset GOPATH
+            cd /tmp || exit 1
+            git clone https://github.com/canonical/ubuntu-image
+            cd ubuntu-image || exit 1
+            go build -tags 'withtestkeys' ./cmd/ubuntu-image
+        )
+        # make it available
+        cp -av /tmp/ubuntu-image/ubuntu-image "$GOHOME/bin"
+    fi
+}

--- a/tests/lib/image.sh
+++ b/tests/lib/image.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 build_ubuntu_image() {
-    if [ "${SPREAD_UBUNTU_IMAGE_ALLOW_API_BREAK-true}" = "true" ]; then
+    if [ "${UBUNTU_IMAGE_ALLOW_API_BREAK-true}" = "true" ]; then
         (
             # build a version which uses the current snapd tree as a dependency
             # shellcheck disable=SC2030,SC2031

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -1503,32 +1503,3 @@ nested_wait_for_device_initialized_change() {
         sleep "$wait"
     done
 }
-
-nested_build_ubuntu_image() {
-    if [ "${UBUNTU_IMAGE_ALLOW_API_BREAK-true}" = "true" ]; then
-        (
-            # build a version which uses the current snapd tree as a dependency
-            # shellcheck disable=SC2030,SC2031
-            export GO111MODULE=off
-            # use go get so that ubuntu-image is built with current snapd
-            # sources
-            go get github.com/canonical/ubuntu-image/cmd/ubuntu-image
-            go install -tags 'withtestkeys' github.com/canonical/ubuntu-image/cmd/ubuntu-image
-        )
-    else
-        (
-            # build a version which uses a particular revision of snapd listed
-            # in ubuntu-image go.mod file
-            # shellcheck disable=SC2030,SC2031
-            export GO111MODULE=on
-            # shellcheck disable=SC2030,SC2031
-            unset GOPATH
-            cd /tmp || exit 1
-            git clone https://github.com/canonical/ubuntu-image
-            cd ubuntu-image || exit 1
-            go build -tags 'withtestkeys' ./cmd/ubuntu-image
-        )
-        # make it available
-        cp -av /tmp/ubuntu-image/ubuntu-image "$GOHOME/bin"
-    fi
-}

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -1503,3 +1503,32 @@ nested_wait_for_device_initialized_change() {
         sleep "$wait"
     done
 }
+
+nested_build_ubuntu_image() {
+    if [ "${UBUNTU_IMAGE_ALLOW_API_BREAK-true}" = "true" ]; then
+        (
+            # build a version which uses the current snapd tree as a dependency
+            # shellcheck disable=SC2030,SC2031
+            export GO111MODULE=off
+            # use go get so that ubuntu-image is built with current snapd
+            # sources
+            go get github.com/canonical/ubuntu-image/cmd/ubuntu-image
+            go install -tags 'withtestkeys' github.com/canonical/ubuntu-image/cmd/ubuntu-image
+        )
+    else
+        (
+            # build a version which uses a particular revision of snapd listed
+            # in ubuntu-image go.mod file
+            # shellcheck disable=SC2030,SC2031
+            export GO111MODULE=on
+            # shellcheck disable=SC2030,SC2031
+            unset GOPATH
+            cd /tmp || exit 1
+            git clone https://github.com/canonical/ubuntu-image
+            cd ubuntu-image || exit 1
+            go build -tags 'withtestkeys' ./cmd/ubuntu-image
+        )
+        # make it available
+        cp -av /tmp/ubuntu-image/ubuntu-image "$GOHOME/bin"
+    fi
+}

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -857,14 +857,10 @@ setup_reflash_magic() {
         # supported yet by the version of mkfs that shipped with Ubuntu 16.04
         snap install ubuntu-image --channel="$UBUNTU_IMAGE_SNAP_CHANNEL" --classic
     else
-        # on all other systems, build a custom version ubuntu-image with test
-        # keys
         (
-            #shellcheck disable=SC2030
-            export GO111MODULE=off
-            # use go get so that ubuntu-image is built with current snapd sources
-            go get github.com/canonical/ubuntu-image/cmd/ubuntu-image
-            go install -tags 'withtestkeys' github.com/canonical/ubuntu-image/cmd/ubuntu-image
+            # shellcheck source=tests/lib/nested.sh
+            . "$TESTSLIB/nested.sh"
+            nested_build_ubuntu_image
         )
     fi
 

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -875,6 +875,7 @@ setup_reflash_magic() {
     # Note that we can not put it into /usr/bin as '/usr' is different
     # when the snap uses confinement.
     cp /usr/bin/snap "$IMAGE_HOME"
+    # shellcheck disable=SC2031
     export UBUNTU_IMAGE_SNAP_CMD="$IMAGE_HOME/snap"
 
     if os.query is-core18; then
@@ -891,15 +892,19 @@ setup_reflash_magic() {
         # FIXME: install would be better but we don't have dpkg on
         #        the image
         # unpack our freshly build snapd into the new snapd snap
+        # shellcheck disable=SC2031
         dpkg-deb -x "$SPREAD_PATH"/../snapd_*.deb "$UNPACK_DIR"
         # Debian packages don't carry permissions correctly and we use
         # post-inst hooks to fix that on classic systems. Here, as a special
         # case, fix the void directory we just unpacked.
+        # shellcheck disable=SC2031
         chmod 111 "$UNPACK_DIR/var/lib/snapd/void"
         # ensure any new timer units are available
+        # shellcheck disable=SC2031
         cp -a /etc/systemd/system/timers.target.wants/*.timer "$UNPACK_DIR/etc/systemd/system/timers.target.wants"
 
         # add gpio and iio slots
+        # shellcheck disable=SC2031
         cat >> "$UNPACK_DIR/meta/snap.yaml" <<-EOF
 slots:
     gpio-pin:
@@ -914,10 +919,13 @@ EOF
         # Make /var/lib/systemd writable so that we can get linger enabled.
         # This only applies to Ubuntu Core 16 where individual directories were
         # writable. In Core 18 and beyond all of /var/lib/systemd is writable.
+        # shellcheck disable=SC2031
         mkdir -p $UNPACK_DIR/var/lib/systemd/{catalog,coredump,deb-systemd-helper-enabled,rfkill,linger}
+        # shellcheck disable=SC2031
         touch "$UNPACK_DIR"/var/lib/systemd/random-seed
 
         # build new core snap for the image
+        # shellcheck disable=SC2031
         snap pack "$UNPACK_DIR" "$IMAGE_HOME"
 
         # FIXME: fetch directly once its in the assertion service

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -857,11 +857,9 @@ setup_reflash_magic() {
         # supported yet by the version of mkfs that shipped with Ubuntu 16.04
         snap install ubuntu-image --channel="$UBUNTU_IMAGE_SNAP_CHANNEL" --classic
     else
-        (
-            # shellcheck source=tests/lib/nested.sh
-            . "$TESTSLIB/nested.sh"
-            nested_build_ubuntu_image
-        )
+        # shellcheck source=tests/lib/image.sh
+        . "$TESTSLIB/image.sh"
+        build_ubuntu_image
     fi
 
     # needs to be under /home because ubuntu-device-flash
@@ -875,7 +873,6 @@ setup_reflash_magic() {
     # Note that we can not put it into /usr/bin as '/usr' is different
     # when the snap uses confinement.
     cp /usr/bin/snap "$IMAGE_HOME"
-    # shellcheck disable=SC2031
     export UBUNTU_IMAGE_SNAP_CMD="$IMAGE_HOME/snap"
 
     if os.query is-core18; then
@@ -892,19 +889,15 @@ setup_reflash_magic() {
         # FIXME: install would be better but we don't have dpkg on
         #        the image
         # unpack our freshly build snapd into the new snapd snap
-        # shellcheck disable=SC2031
         dpkg-deb -x "$SPREAD_PATH"/../snapd_*.deb "$UNPACK_DIR"
         # Debian packages don't carry permissions correctly and we use
         # post-inst hooks to fix that on classic systems. Here, as a special
         # case, fix the void directory we just unpacked.
-        # shellcheck disable=SC2031
         chmod 111 "$UNPACK_DIR/var/lib/snapd/void"
         # ensure any new timer units are available
-        # shellcheck disable=SC2031
         cp -a /etc/systemd/system/timers.target.wants/*.timer "$UNPACK_DIR/etc/systemd/system/timers.target.wants"
 
         # add gpio and iio slots
-        # shellcheck disable=SC2031
         cat >> "$UNPACK_DIR/meta/snap.yaml" <<-EOF
 slots:
     gpio-pin:
@@ -919,13 +912,10 @@ EOF
         # Make /var/lib/systemd writable so that we can get linger enabled.
         # This only applies to Ubuntu Core 16 where individual directories were
         # writable. In Core 18 and beyond all of /var/lib/systemd is writable.
-        # shellcheck disable=SC2031
         mkdir -p $UNPACK_DIR/var/lib/systemd/{catalog,coredump,deb-systemd-helper-enabled,rfkill,linger}
-        # shellcheck disable=SC2031
         touch "$UNPACK_DIR"/var/lib/systemd/random-seed
 
         # build new core snap for the image
-        # shellcheck disable=SC2031
         snap pack "$UNPACK_DIR" "$IMAGE_HOME"
 
         # FIXME: fetch directly once its in the assertion service


### PR DESCRIPTION
as "install" mode should usually not need much more than the
essential snaps this should require a bit less work when seeding it

