### PR TITLE
snap-exec: fix detection if `cups` interface is connected

### DIFF
--- a/cmd/snap-exec/export_test.go
+++ b/cmd/snap-exec/export_test.go
@@ -19,6 +19,12 @@
 
 package main
 
+import (
+	"syscall"
+
+	"github.com/snapcore/snapd/testutil"
+)
+
 var (
 	ExpandEnvCmdArgs = expandEnvCmdArgs
 	FindCommand      = findCommand
@@ -57,4 +63,10 @@ func MockOsReadlink(f func(string) (string, error)) func() {
 	return func() {
 		osReadlink = realOsReadlink
 	}
+}
+
+func MockSyscallStat(f func(string, *syscall.Stat_t) (err error)) func() {
+	r := testutil.Backup(&syscallStat)
+	syscallStat = f
+	return r
 }

--- a/cmd/snap-exec/main.go
+++ b/cmd/snap-exec/main.go
@@ -199,10 +199,13 @@ func execApp(snapApp, revision, command string, args []string) error {
 	// variables to plugging snap apps, but this is a lot simpler as a
 	// work-around
 	// we currently only handle the CUPS_SERVER environment variable, setting it
-	// to /var/cups/ if that directory exists - it should not exist anywhere
+	// to /var/cups/ if that dir is a bind-mount - it should not be one
 	// except in a strictly confined snap where we setup the bind mount from the
-	// source cups slot snap to the plugging snap
-	if exists, _, _ := osutil.DirExists(dirs.GlobalRootDir + "/var/cups"); exists {
+	// source cups slot snap to the plugging snap.
+	var stVar, stVarCups syscall.Stat_t
+	syscall.Stat(dirs.GlobalRootDir+"/var/", &stVar)
+	syscall.Stat(dirs.GlobalRootDir+"/var/cups/", &stVarCups)
+	if stVar.Dev != stVarCups.Dev {
 		env["CUPS_SERVER"] = "/var/cups/cups.sock"
 	}
 

--- a/cmd/snap-exec/main.go
+++ b/cmd/snap-exec/main.go
@@ -36,6 +36,7 @@ import (
 
 // for the tests
 var syscallExec = syscall.Exec
+var syscallStat = syscall.Stat
 var osReadlink = os.Readlink
 
 // commandline args
@@ -203,9 +204,9 @@ func execApp(snapApp, revision, command string, args []string) error {
 	// except in a strictly confined snap where we setup the bind mount from the
 	// source cups slot snap to the plugging snap.
 	var stVar, stVarCups syscall.Stat_t
-	syscall.Stat(dirs.GlobalRootDir+"/var/", &stVar)
-	syscall.Stat(dirs.GlobalRootDir+"/var/cups/", &stVarCups)
-	if stVar.Dev != stVarCups.Dev {
+	err1 := syscallStat(dirs.GlobalRootDir+"/var/", &stVar)
+	err2 := syscallStat(dirs.GlobalRootDir+"/var/cups/", &stVarCups)
+	if err1 == nil && err2 == nil && stVar.Dev != stVarCups.Dev {
 		env["CUPS_SERVER"] = "/var/cups/cups.sock"
 	}
 

--- a/tests/main/interfaces-cups-control/task.yaml
+++ b/tests/main/interfaces-cups-control/task.yaml
@@ -18,8 +18,6 @@ details: |
 # TODO: enable on debian-sid once https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1006853 is fixed
 systems: [-ubuntu-core-*, -opensuse-*, -fedora-*, -arch-*, -amazon-*, -centos-*, -debian-sid-*, -ubuntu-*-32]
 
-manual: true
-
 environment:
     TEST_FILE: /var/snap/test-snapd-cups-control-consumer/current/test_file.txt
 
@@ -74,4 +72,4 @@ execute: |
         echo "Expected error with plug disconnected"
         exit 1
     fi
-    MATCH "scheduler not responding" < print.error
+    MATCH "(scheduler not responding|No default destination)" < print.error


### PR DESCRIPTION
The cups interface needs a way to set the environment variable
`CUPS_SERVER` if the `cups` interface is connected. However we
have no mechanism for setting environment vars based on interface
connections currently. To workaround this, the cups work added
a workaround in `snap-exec` that tried to detect if `cups` is
connected and when it is set the environment. Unfortunately the
code in there was too simplistic because it just checked if
the directory `/var/cups` exists. However ths dir now always
exists because it's needed as the mount point.

This commit fixes the detection by checking if `/var/cups` is
a bind mount. This is checked by looking at the `stat()` data
and the `dev_t` field in there. If they differ it means the
bind mount exists and the only thing that creates this bind
mount is the `cups` `MountConnectedPlug()` code.

This is not great but it fixes the spread failure we see
in the `cups-control` test (which is a real bug) and should
be good enough until we have a proper interface backend that
can set environment variables.
