### PR TITLE
packaging: install Go snap from 1.17 channel in the integration tests

### DIFF
--- a/packaging/ubuntu-16.04/tests/integrationtests
+++ b/packaging/ubuntu-16.04/tests/integrationtests
@@ -46,7 +46,7 @@ systemctl daemon-reload
 systemctl restart snapd
 
 # Spread will only buid with recent go
-snap install --classic go
+snap install --classic --channel 1.17/stable go
 
 # and now run spread against localhost
 export GOPATH=/tmp/go


### PR DESCRIPTION
The behaviour of "go get" changes in 1.18 meaning spread does not get
installed to the expected location (or indeed, at all).
