### PR TITLE
i/b/kernel_module_load: expand $SNAP_COMMON in module options

### DIFF
--- a/interfaces/builtin/kernel_module_load.go
+++ b/interfaces/builtin/kernel_module_load.go
@@ -206,7 +206,7 @@ func (iface *kernelModuleLoadInterface) KModConnectedPlug(spec *kmod.Specificati
 				// just look for the "$SNAP_COMMON/" string and replace it; the
 				// extra "/" at the end ensures that the variable is
 				// terminated.
-				options := strings.ReplaceAll(moduleInfo.options, "$SNAP_COMMON/", commonDataDir + "/")
+				options := strings.ReplaceAll(moduleInfo.options, "$SNAP_COMMON/", commonDataDir+"/")
 				err = spec.SetModuleOptions(moduleInfo.name, options)
 			}
 		default:

--- a/interfaces/builtin/kernel_module_load.go
+++ b/interfaces/builtin/kernel_module_load.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/kmod"
@@ -179,6 +180,9 @@ func (iface *kernelModuleLoadInterface) BeforeConnectPlug(plug *interfaces.Conne
 }
 
 func (iface *kernelModuleLoadInterface) KModConnectedPlug(spec *kmod.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	snapInfo := plug.Snap()
+	commonDataDir := snapInfo.CommonDataDir()
+
 	err := enumerateModules(plug, func(moduleInfo *ModuleInfo) error {
 		var err error
 		switch moduleInfo.load {
@@ -192,7 +196,18 @@ func (iface *kernelModuleLoadInterface) KModConnectedPlug(spec *kmod.Specificati
 			fallthrough
 		case loadNone:
 			if len(moduleInfo.options) > 0 {
-				err = spec.SetModuleOptions(moduleInfo.name, moduleInfo.options)
+				// module options might include filesystem paths. Beside
+				// supporting hardcoded paths, it makes sense to support also
+				// paths to files provided by the snap; for this reason, we
+				// support expanding the $SNAP_COMMON variable here.
+				// We do not use os.Expand() because that supports both $ENV
+				// and ${ENV}, and we'd rather not alter the options which
+				// contain a "$" but are not meant to be expanded. Instead,
+				// just look for the "$SNAP_COMMON/" string and replace it; the
+				// extra "/" at the end ensures that the variable is
+				// terminated.
+				options := strings.ReplaceAll(moduleInfo.options, "$SNAP_COMMON/", commonDataDir + "/")
+				err = spec.SetModuleOptions(moduleInfo.name, options)
 			}
 		default:
 			// we can panic, this will be catched on validation

--- a/interfaces/builtin/kernel_module_load_test.go
+++ b/interfaces/builtin/kernel_module_load_test.go
@@ -58,6 +58,8 @@ plugs:
     options: p1=3 p2=true p3
   - name: mymodule2
     options: param_1=ok param_2=false
+  - name: expandvar
+    options: opt=$FOO path=$SNAP_COMMON/bar
 apps:
  app:
   plugs: [kmod]
@@ -172,6 +174,7 @@ func (s *KernelModuleLoadInterfaceSuite) TestKModSpec(c *C) {
 	c.Check(spec.ModuleOptions(), DeepEquals, map[string]string{
 		"mymodule1": "p1=3 p2=true p3",
 		"mymodule2": "param_1=ok param_2=false",
+		"expandvar": "opt=$FOO path=/var/snap/consumer/common/bar",
 	})
 	c.Check(spec.DisallowedModules(), DeepEquals, []string{"forbidden"})
 }


### PR DESCRIPTION
A kernel module might need to load a file from the filesystem, and we
might have cases where this file is shipped with the snap itself;
therefore, support using $SNAP_COMMON in the kernel module options.
