### PR TITLE
tests: allow ubuntu-image to be built with a compatible snapd tree

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -44,7 +44,7 @@ environment:
     UBUNTU_IMAGE_SNAP_CHANNEL: "latest/candidate"
     # controls whether ubuntu-image is built using the current snapd tree as a
     # dependency or the one listed in its go.mod
-    UBUNTU_IMAGE_ALLOW_API_BREAK: '$(HOST: echo "${UBUNTU_IMAGE_ALLOW_API_BREAK:-true}")'
+    SPREAD_UBUNTU_IMAGE_ALLOW_API_BREAK: '$(HOST: echo "${SPREAD_UBUNTU_IMAGE_ALLOW_API_BREAK:-true}")'
     CORE_CHANNEL: '$(HOST: echo "${SPREAD_CORE_CHANNEL:-edge}")'
     BASE_CHANNEL: '$(HOST: echo "${SPREAD_BASE_CHANNEL:-edge}")'
     KERNEL_CHANNEL: '$(HOST: echo "${SPREAD_KERNEL_CHANNEL:-edge}")'
@@ -965,8 +965,8 @@ suites:
         prepare: |
             #shellcheck source=tests/lib/pkgdb.sh
             . "$TESTSLIB"/pkgdb.sh
-            #shellcheck source=tests/lib/nested.sh
-            . "$TESTSLIB"/nested.sh
+            #shellcheck source=tests/lib/image.sh
+            . "$TESTSLIB"/image.sh
             distro_update_package_db
             distro_install_package snapd qemu qemu-utils genisoimage sshpass qemu-kvm cloud-image-utils ovmf kpartx xz-utils mtools ca-certificates xdelta3
             if os.query is-xenial; then
@@ -974,7 +974,7 @@ suites:
                 # supported yet by the version of mkfs that shipped with Ubuntu 16.04
                 snap install ubuntu-image --channel="$UBUNTU_IMAGE_SNAP_CHANNEL" --classic
             else
-               nested_build_ubuntu_image
+               build_ubuntu_image
             fi
 
             # Install the snapd built
@@ -1007,8 +1007,8 @@ suites:
         prepare: |
             #shellcheck source=tests/lib/pkgdb.sh
             . "$TESTSLIB"/pkgdb.sh
-            #shellcheck source=tests/lib/nested.sh
-            . "$TESTSLIB"/nested.sh
+            #shellcheck source=tests/lib/image.sh
+            . "$TESTSLIB"/image.sh
             distro_update_package_db
             distro_install_package snapd qemu qemu-utils genisoimage sshpass qemu-kvm cloud-image-utils ovmf kpartx xz-utils mtools ca-certificates xdelta3
             if os.query is-xenial; then
@@ -1016,7 +1016,7 @@ suites:
                 # supported yet by the version of mkfs that shipped with Ubuntu 16.04
                 snap install ubuntu-image --channel="$UBUNTU_IMAGE_SNAP_CHANNEL" --classic
             else
-                nested_build_ubuntu_image
+                build_ubuntu_image
             fi
 
             # Install the snapd built
@@ -1054,8 +1054,8 @@ suites:
         prepare: |
             #shellcheck source=tests/lib/pkgdb.sh
             . "$TESTSLIB"/pkgdb.sh
-            #shellcheck source=tests/lib/nested.sh
-            . "$TESTSLIB"/nested.sh
+            #shellcheck source=tests/lib/image.sh
+            . "$TESTSLIB"/image.sh
             distro_update_package_db
             distro_install_package snapd qemu qemu-utils genisoimage sshpass qemu-kvm cloud-image-utils ovmf kpartx xz-utils mtools ca-certificates xdelta3
             if os.query is-xenial; then
@@ -1063,7 +1063,7 @@ suites:
                 # supported yet by the version of mkfs that shipped with Ubuntu 16.04
                 snap install ubuntu-image --channel="$UBUNTU_IMAGE_SNAP_CHANNEL" --classic
             else
-                nested_build_ubuntu_image
+                build_ubuntu_image
             fi
 
             # Install the snapd built

--- a/spread.yaml
+++ b/spread.yaml
@@ -42,6 +42,9 @@ environment:
     # a global setting for LXD channel to use in the tests
     LXD_SNAP_CHANNEL: "latest/candidate"
     UBUNTU_IMAGE_SNAP_CHANNEL: "latest/candidate"
+    # controls whether ubuntu-image is built using the current snapd tree as a
+    # dependency or the one listed in its go.mod
+    UBUNTU_IMAGE_ALLOW_API_BREAK: '$(HOST: echo "${UBUNTU_IMAGE_ALLOW_API_BREAK:-true}")'
     CORE_CHANNEL: '$(HOST: echo "${SPREAD_CORE_CHANNEL:-edge}")'
     BASE_CHANNEL: '$(HOST: echo "${SPREAD_BASE_CHANNEL:-edge}")'
     KERNEL_CHANNEL: '$(HOST: echo "${SPREAD_KERNEL_CHANNEL:-edge}")'
@@ -962,6 +965,8 @@ suites:
         prepare: |
             #shellcheck source=tests/lib/pkgdb.sh
             . "$TESTSLIB"/pkgdb.sh
+            #shellcheck source=tests/lib/nested.sh
+            . "$TESTSLIB"/nested.sh
             distro_update_package_db
             distro_install_package snapd qemu qemu-utils genisoimage sshpass qemu-kvm cloud-image-utils ovmf kpartx xz-utils mtools ca-certificates xdelta3
             if os.query is-xenial; then
@@ -969,13 +974,7 @@ suites:
                 # supported yet by the version of mkfs that shipped with Ubuntu 16.04
                 snap install ubuntu-image --channel="$UBUNTU_IMAGE_SNAP_CHANNEL" --classic
             else
-                # build a custom version ubuntu-image with test keys
-                (
-                    export GO111MODULE=off
-                    # use go get so that ubuntu-image is built with current snapd sources
-                    go get github.com/canonical/ubuntu-image/cmd/ubuntu-image
-                    go install -tags 'withtestkeys' github.com/canonical/ubuntu-image/cmd/ubuntu-image
-                )
+               nested_build_ubuntu_image
             fi
 
             # Install the snapd built
@@ -1008,6 +1007,8 @@ suites:
         prepare: |
             #shellcheck source=tests/lib/pkgdb.sh
             . "$TESTSLIB"/pkgdb.sh
+            #shellcheck source=tests/lib/nested.sh
+            . "$TESTSLIB"/nested.sh
             distro_update_package_db
             distro_install_package snapd qemu qemu-utils genisoimage sshpass qemu-kvm cloud-image-utils ovmf kpartx xz-utils mtools ca-certificates xdelta3
             if os.query is-xenial; then
@@ -1015,13 +1016,7 @@ suites:
                 # supported yet by the version of mkfs that shipped with Ubuntu 16.04
                 snap install ubuntu-image --channel="$UBUNTU_IMAGE_SNAP_CHANNEL" --classic
             else
-                # build a custom version ubuntu-image with test keys
-                (
-                    export GO111MODULE=off
-                    # use go get so that ubuntu-image is built with current snapd sources
-                    go get github.com/canonical/ubuntu-image/cmd/ubuntu-image
-                    go install -tags 'withtestkeys' github.com/canonical/ubuntu-image/cmd/ubuntu-image
-                )
+                nested_build_ubuntu_image
             fi
 
             # Install the snapd built
@@ -1059,6 +1054,8 @@ suites:
         prepare: |
             #shellcheck source=tests/lib/pkgdb.sh
             . "$TESTSLIB"/pkgdb.sh
+            #shellcheck source=tests/lib/nested.sh
+            . "$TESTSLIB"/nested.sh
             distro_update_package_db
             distro_install_package snapd qemu qemu-utils genisoimage sshpass qemu-kvm cloud-image-utils ovmf kpartx xz-utils mtools ca-certificates xdelta3
             if os.query is-xenial; then
@@ -1066,13 +1063,7 @@ suites:
                 # supported yet by the version of mkfs that shipped with Ubuntu 16.04
                 snap install ubuntu-image --channel="$UBUNTU_IMAGE_SNAP_CHANNEL" --classic
             else
-                # build a custom version ubuntu-image with test keys
-                (
-                    export GO111MODULE=off
-                    # use go get so that ubuntu-image is built with current snapd sources
-                    go get github.com/canonical/ubuntu-image/cmd/ubuntu-image
-                    go install -tags 'withtestkeys' github.com/canonical/ubuntu-image/cmd/ubuntu-image
-                )
+                nested_build_ubuntu_image
             fi
 
             # Install the snapd built

--- a/spread.yaml
+++ b/spread.yaml
@@ -44,7 +44,7 @@ environment:
     UBUNTU_IMAGE_SNAP_CHANNEL: "latest/candidate"
     # controls whether ubuntu-image is built using the current snapd tree as a
     # dependency or the one listed in its go.mod
-    SPREAD_UBUNTU_IMAGE_ALLOW_API_BREAK: '$(HOST: echo "${SPREAD_UBUNTU_IMAGE_ALLOW_API_BREAK:-true}")'
+    UBUNTU_IMAGE_ALLOW_API_BREAK: '$(HOST: echo "${SPREAD_UBUNTU_IMAGE_ALLOW_API_BREAK:-true}")'
     CORE_CHANNEL: '$(HOST: echo "${SPREAD_CORE_CHANNEL:-edge}")'
     BASE_CHANNEL: '$(HOST: echo "${SPREAD_BASE_CHANNEL:-edge}")'
     KERNEL_CHANNEL: '$(HOST: echo "${SPREAD_KERNEL_CHANNEL:-edge}")'

--- a/tests/lib/image.sh
+++ b/tests/lib/image.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 
 build_ubuntu_image() {
+    # the helper can be invoked multiple times, so do nothing if ubuntu-image
+    # was already built and is accessible
+    if command -v ubuntu-image; then
+        return
+    fi
+
     if [ "${UBUNTU_IMAGE_ALLOW_API_BREAK-true}" = "true" ]; then
         (
             # build a version which uses the current snapd tree as a dependency

--- a/tests/lib/image.sh
+++ b/tests/lib/image.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+build_ubuntu_image() {
+    if [ "${SPREAD_UBUNTU_IMAGE_ALLOW_API_BREAK-true}" = "true" ]; then
+        (
+            # build a version which uses the current snapd tree as a dependency
+            # shellcheck disable=SC2030,SC2031
+            export GO111MODULE=off
+            # use go get so that ubuntu-image is built with current snapd
+            # sources
+            go get github.com/canonical/ubuntu-image/cmd/ubuntu-image
+            go install -tags 'withtestkeys' github.com/canonical/ubuntu-image/cmd/ubuntu-image
+        )
+    else
+        (
+            # build a version which uses a particular revision of snapd listed
+            # in ubuntu-image go.mod file
+            # shellcheck disable=SC2030,SC2031
+            export GO111MODULE=on
+            # shellcheck disable=SC2030,SC2031
+            unset GOPATH
+            cd /tmp || exit 1
+            git clone https://github.com/canonical/ubuntu-image
+            cd ubuntu-image || exit 1
+            go build -tags 'withtestkeys' ./cmd/ubuntu-image
+        )
+        # make it available
+        cp -av /tmp/ubuntu-image/ubuntu-image "$GOHOME/bin"
+    fi
+}

--- a/tests/lib/image.sh
+++ b/tests/lib/image.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 build_ubuntu_image() {
-    if [ "${SPREAD_UBUNTU_IMAGE_ALLOW_API_BREAK-true}" = "true" ]; then
+    if [ "${UBUNTU_IMAGE_ALLOW_API_BREAK-true}" = "true" ]; then
         (
             # build a version which uses the current snapd tree as a dependency
             # shellcheck disable=SC2030,SC2031

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -1503,32 +1503,3 @@ nested_wait_for_device_initialized_change() {
         sleep "$wait"
     done
 }
-
-nested_build_ubuntu_image() {
-    if [ "${UBUNTU_IMAGE_ALLOW_API_BREAK-true}" = "true" ]; then
-        (
-            # build a version which uses the current snapd tree as a dependency
-            # shellcheck disable=SC2030,SC2031
-            export GO111MODULE=off
-            # use go get so that ubuntu-image is built with current snapd
-            # sources
-            go get github.com/canonical/ubuntu-image/cmd/ubuntu-image
-            go install -tags 'withtestkeys' github.com/canonical/ubuntu-image/cmd/ubuntu-image
-        )
-    else
-        (
-            # build a version which uses a particular revision of snapd listed
-            # in ubuntu-image go.mod file
-            # shellcheck disable=SC2030,SC2031
-            export GO111MODULE=on
-            # shellcheck disable=SC2030,SC2031
-            unset GOPATH
-            cd /tmp || exit 1
-            git clone https://github.com/canonical/ubuntu-image
-            cd ubuntu-image || exit 1
-            go build -tags 'withtestkeys' ./cmd/ubuntu-image
-        )
-        # make it available
-        cp -av /tmp/ubuntu-image/ubuntu-image "$GOHOME/bin"
-    fi
-}

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -1503,3 +1503,32 @@ nested_wait_for_device_initialized_change() {
         sleep "$wait"
     done
 }
+
+nested_build_ubuntu_image() {
+    if [ "${UBUNTU_IMAGE_ALLOW_API_BREAK-true}" = "true" ]; then
+        (
+            # build a version which uses the current snapd tree as a dependency
+            # shellcheck disable=SC2030,SC2031
+            export GO111MODULE=off
+            # use go get so that ubuntu-image is built with current snapd
+            # sources
+            go get github.com/canonical/ubuntu-image/cmd/ubuntu-image
+            go install -tags 'withtestkeys' github.com/canonical/ubuntu-image/cmd/ubuntu-image
+        )
+    else
+        (
+            # build a version which uses a particular revision of snapd listed
+            # in ubuntu-image go.mod file
+            # shellcheck disable=SC2030,SC2031
+            export GO111MODULE=on
+            # shellcheck disable=SC2030,SC2031
+            unset GOPATH
+            cd /tmp || exit 1
+            git clone https://github.com/canonical/ubuntu-image
+            cd ubuntu-image || exit 1
+            go build -tags 'withtestkeys' ./cmd/ubuntu-image
+        )
+        # make it available
+        cp -av /tmp/ubuntu-image/ubuntu-image "$GOHOME/bin"
+    fi
+}

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -857,14 +857,10 @@ setup_reflash_magic() {
         # supported yet by the version of mkfs that shipped with Ubuntu 16.04
         snap install ubuntu-image --channel="$UBUNTU_IMAGE_SNAP_CHANNEL" --classic
     else
-        # on all other systems, build a custom version ubuntu-image with test
-        # keys
         (
-            #shellcheck disable=SC2030
-            export GO111MODULE=off
-            # use go get so that ubuntu-image is built with current snapd sources
-            go get github.com/canonical/ubuntu-image/cmd/ubuntu-image
-            go install -tags 'withtestkeys' github.com/canonical/ubuntu-image/cmd/ubuntu-image
+            # shellcheck source=tests/lib/nested.sh
+            . "$TESTSLIB/nested.sh"
+            nested_build_ubuntu_image
         )
     fi
 

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -875,6 +875,7 @@ setup_reflash_magic() {
     # Note that we can not put it into /usr/bin as '/usr' is different
     # when the snap uses confinement.
     cp /usr/bin/snap "$IMAGE_HOME"
+    # shellcheck disable=SC2031
     export UBUNTU_IMAGE_SNAP_CMD="$IMAGE_HOME/snap"
 
     if os.query is-core18; then
@@ -891,15 +892,19 @@ setup_reflash_magic() {
         # FIXME: install would be better but we don't have dpkg on
         #        the image
         # unpack our freshly build snapd into the new snapd snap
+        # shellcheck disable=SC2031
         dpkg-deb -x "$SPREAD_PATH"/../snapd_*.deb "$UNPACK_DIR"
         # Debian packages don't carry permissions correctly and we use
         # post-inst hooks to fix that on classic systems. Here, as a special
         # case, fix the void directory we just unpacked.
+        # shellcheck disable=SC2031
         chmod 111 "$UNPACK_DIR/var/lib/snapd/void"
         # ensure any new timer units are available
+        # shellcheck disable=SC2031
         cp -a /etc/systemd/system/timers.target.wants/*.timer "$UNPACK_DIR/etc/systemd/system/timers.target.wants"
 
         # add gpio and iio slots
+        # shellcheck disable=SC2031
         cat >> "$UNPACK_DIR/meta/snap.yaml" <<-EOF
 slots:
     gpio-pin:
@@ -914,10 +919,13 @@ EOF
         # Make /var/lib/systemd writable so that we can get linger enabled.
         # This only applies to Ubuntu Core 16 where individual directories were
         # writable. In Core 18 and beyond all of /var/lib/systemd is writable.
+        # shellcheck disable=SC2031
         mkdir -p $UNPACK_DIR/var/lib/systemd/{catalog,coredump,deb-systemd-helper-enabled,rfkill,linger}
+        # shellcheck disable=SC2031
         touch "$UNPACK_DIR"/var/lib/systemd/random-seed
 
         # build new core snap for the image
+        # shellcheck disable=SC2031
         snap pack "$UNPACK_DIR" "$IMAGE_HOME"
 
         # FIXME: fetch directly once its in the assertion service

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -857,11 +857,9 @@ setup_reflash_magic() {
         # supported yet by the version of mkfs that shipped with Ubuntu 16.04
         snap install ubuntu-image --channel="$UBUNTU_IMAGE_SNAP_CHANNEL" --classic
     else
-        (
-            # shellcheck source=tests/lib/nested.sh
-            . "$TESTSLIB/nested.sh"
-            nested_build_ubuntu_image
-        )
+        # shellcheck source=tests/lib/image.sh
+        . "$TESTSLIB/image.sh"
+        build_ubuntu_image
     fi
 
     # needs to be under /home because ubuntu-device-flash
@@ -875,7 +873,6 @@ setup_reflash_magic() {
     # Note that we can not put it into /usr/bin as '/usr' is different
     # when the snap uses confinement.
     cp /usr/bin/snap "$IMAGE_HOME"
-    # shellcheck disable=SC2031
     export UBUNTU_IMAGE_SNAP_CMD="$IMAGE_HOME/snap"
 
     if os.query is-core18; then
@@ -892,19 +889,15 @@ setup_reflash_magic() {
         # FIXME: install would be better but we don't have dpkg on
         #        the image
         # unpack our freshly build snapd into the new snapd snap
-        # shellcheck disable=SC2031
         dpkg-deb -x "$SPREAD_PATH"/../snapd_*.deb "$UNPACK_DIR"
         # Debian packages don't carry permissions correctly and we use
         # post-inst hooks to fix that on classic systems. Here, as a special
         # case, fix the void directory we just unpacked.
-        # shellcheck disable=SC2031
         chmod 111 "$UNPACK_DIR/var/lib/snapd/void"
         # ensure any new timer units are available
-        # shellcheck disable=SC2031
         cp -a /etc/systemd/system/timers.target.wants/*.timer "$UNPACK_DIR/etc/systemd/system/timers.target.wants"
 
         # add gpio and iio slots
-        # shellcheck disable=SC2031
         cat >> "$UNPACK_DIR/meta/snap.yaml" <<-EOF
 slots:
     gpio-pin:
@@ -919,13 +912,10 @@ EOF
         # Make /var/lib/systemd writable so that we can get linger enabled.
         # This only applies to Ubuntu Core 16 where individual directories were
         # writable. In Core 18 and beyond all of /var/lib/systemd is writable.
-        # shellcheck disable=SC2031
         mkdir -p $UNPACK_DIR/var/lib/systemd/{catalog,coredump,deb-systemd-helper-enabled,rfkill,linger}
-        # shellcheck disable=SC2031
         touch "$UNPACK_DIR"/var/lib/systemd/random-seed
 
         # build new core snap for the image
-        # shellcheck disable=SC2031
         snap pack "$UNPACK_DIR" "$IMAGE_HOME"
 
         # FIXME: fetch directly once its in the assertion service


### PR DESCRIPTION
While building PRs to snapd, we would normally build u-i using the current snapd
checkout, but that may be unfavorable, as the PR under test may introduce
incompatible changes, thus breaking ubuntu-image. Add an option to build u-i
using the snapd tree it specifies in its go.mod file.

