### PR TITLE
o/snapstate: account for repeat migration in ~/Snap undo

### DIFF
--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -112,6 +112,6 @@ type managerBackend interface {
 	// ~/.snap/data migration related
 	HideSnapData(snapName string) error
 	UndoHideSnapData(snapName string) error
-	InitExposedSnapHome(snapName string, rev snap.Revision) error
-	RemoveExposedSnapHome(snapName string) error
+	InitExposedSnapHome(snapName string, rev snap.Revision) (*backend.UndoInfo, error)
+	UndoInitExposedSnapHome(snapName string, undoInfo *backend.UndoInfo) error
 }

--- a/overlord/snapstate/backend/copydata.go
+++ b/overlord/snapstate/backend/copydata.go
@@ -32,6 +32,7 @@ import (
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/strutil"
 )
 
 var (
@@ -255,38 +256,59 @@ var removeIfEmpty = func(dir string) error {
 	return os.Remove(dir)
 }
 
+// UndoInfo contains information about what an operation did so that it can be
+// undone.
+type UndoInfo struct {
+	// Created contains the directories created in the operation.
+	Created []string `json:"created,omitempty"`
+}
+
 // InitExposedSnapHome creates and initializes ~/Snap/<snapName> based on the
-// specified revision. Must be called after the snap has been migrated.
-func (b Backend) InitExposedSnapHome(snapName string, rev snap.Revision) (err error) {
+// specified revision. Must be called after the snap has been migrated. If no
+// error occurred, returns a non-nil undoInfo so that the operation can be undone.
+// If an error occurred, an attempt is made to undo so no undoInfo is returned.
+func (b Backend) InitExposedSnapHome(snapName string, rev snap.Revision) (undoInfo *UndoInfo, err error) {
 	opts := &dirs.SnapDirOptions{HiddenSnapDataDir: true}
 
 	users, err := allUsers(opts)
 	if err != nil {
-		return err
+		return nil, err
 	}
+
+	undoInfo = &UndoInfo{}
+	defer func() {
+		if err != nil {
+			if err := b.UndoInitExposedSnapHome(snapName, undoInfo); err != nil {
+				logger.Noticef("cannot undo ~/Snap init for %q after it failed: %v", snapName, err)
+			}
+
+			undoInfo = nil
+		}
+	}()
 
 	for _, usr := range users {
 		uid, gid, err := osutil.UidGid(usr)
 		if err != nil {
-			return err
+			return undoInfo, err
 		}
 
 		newUserHome := snap.UserExposedHomeDir(usr.HomeDir, snapName)
 		if exists, isDir, err := osutil.DirExists(newUserHome); err != nil {
-			return err
+			return undoInfo, err
 		} else if exists {
 			if !isDir {
-				return fmt.Errorf("cannot initialize new user HOME %q: already exists but is not a directory", newUserHome)
+				return undoInfo, fmt.Errorf("cannot initialize new user HOME %q: already exists but is not a directory", newUserHome)
 			}
 
 			// we reverted from a core22 base before, so the new HOME already exists
-			// TODO: return undo info about created dirs for doCopySnapData
 			continue
 		}
 
 		if err := mkdirAllChown(newUserHome, 0700, uid, gid); err != nil {
-			return fmt.Errorf("cannot create %q: %v", newUserHome, err)
+			return undoInfo, fmt.Errorf("cannot create %q: %v", newUserHome, err)
 		}
+
+		undoInfo.Created = append(undoInfo.Created, newUserHome)
 
 		userData := snap.UserDataDir(usr.HomeDir, snapName, rev, opts)
 		entries, err := ioutil.ReadDir(userData)
@@ -296,24 +318,27 @@ func (b Backend) InitExposedSnapHome(snapName string, rev snap.Revision) (err er
 				continue
 			}
 
-			return err
+			return undoInfo, err
 		}
 		for _, e := range entries {
 			src := filepath.Join(userData, e.Name())
 			dst := filepath.Join(newUserHome, e.Name())
 
 			if err := osutil.CopyFile(src, dst, osutil.CopyFlagPreserveAll|osutil.CopyFlagSync); err != nil {
-				return err
+				return undoInfo, err
 			}
 		}
 	}
 
-	return nil
+	return undoInfo, nil
 }
 
-// RemoveExposedSnapHome removes the ~/Snap dirs.
-func (b Backend) RemoveExposedSnapHome(snapName string) error {
+// UndoInitExposedSnapHome undoes the ~/Snap initialization according to the undoInfo.
+func (b Backend) UndoInitExposedSnapHome(snapName string, undoInfo *UndoInfo) error {
 	opts := &dirs.SnapDirOptions{HiddenSnapDataDir: true}
+	if undoInfo == nil {
+		undoInfo = &UndoInfo{}
+	}
 
 	var firstErr error
 	handle := func(err error) {
@@ -331,6 +356,10 @@ func (b Backend) RemoveExposedSnapHome(snapName string) error {
 
 	for _, usr := range users {
 		newUserHome := snap.UserExposedHomeDir(usr.HomeDir, snapName)
+		if !strutil.ListContains(undoInfo.Created, newUserHome) {
+			continue
+		}
+
 		if err := os.RemoveAll(newUserHome); err != nil {
 			handle(fmt.Errorf("cannot remove %q: %v", newUserHome, err))
 			continue

--- a/overlord/snapstate/backend/copydata_test.go
+++ b/overlord/snapstate/backend/copydata_test.go
@@ -930,9 +930,12 @@ func (s *copydataSuite) TestInitSnapUserHome(c *C) {
 	dirPath := filepath.Join(revDir, "dir")
 	c.Assert(os.Mkdir(dirPath, 0775), IsNil)
 
-	c.Assert(s.be.InitExposedSnapHome(snapName, rev), IsNil)
+	undoInfo, err := s.be.InitExposedSnapHome(snapName, rev)
+	c.Assert(err, IsNil)
+	exposedHome := filepath.Join(homeDir, dirs.ExposedSnapHomeDir, snapName)
+	c.Check(undoInfo.Created, DeepEquals, []string{exposedHome})
 
-	expectedFile := filepath.Join(homeDir, dirs.ExposedSnapHomeDir, snapName, "file")
+	expectedFile := filepath.Join(exposedHome, "file")
 	data, err := ioutil.ReadFile(expectedFile)
 	c.Assert(err, IsNil)
 	c.Check(string(data), Equals, "stuff")
@@ -942,7 +945,7 @@ func (s *copydataSuite) TestInitSnapUserHome(c *C) {
 	c.Check(exists, Equals, true)
 	c.Check(isReg, Equals, true)
 
-	expectedDir := filepath.Join(homeDir, dirs.ExposedSnapHomeDir, snapName, "dir")
+	expectedDir := filepath.Join(exposedHome, "dir")
 	exists, isDir, err := osutil.DirExists(expectedDir)
 	c.Assert(err, IsNil)
 	c.Check(exists, Equals, true)
@@ -977,7 +980,9 @@ func (s *copydataSuite) TestInitSnapFailOnFirstErr(c *C) {
 	rev, err := snap.ParseRevision("2")
 	c.Assert(err, IsNil)
 
-	c.Assert(s.be.InitExposedSnapHome(snapName, rev), ErrorMatches, ".*: boom")
+	undoInfo, err := s.be.InitExposedSnapHome(snapName, rev)
+	c.Assert(err, ErrorMatches, ".*: boom")
+	c.Check(undoInfo, IsNil)
 
 	exists, _, err := osutil.DirExists(filepath.Join(usr1.HomeDir, dirs.ExposedSnapHomeDir))
 	c.Assert(err, IsNil)
@@ -986,6 +991,57 @@ func (s *copydataSuite) TestInitSnapFailOnFirstErr(c *C) {
 	exists, _, err = osutil.DirExists(filepath.Join(usr2.HomeDir, dirs.ExposedSnapHomeDir))
 	c.Assert(err, IsNil)
 	c.Check(exists, Equals, false)
+}
+
+func (s *copydataSuite) TestInitSnapUndoOnErr(c *C) {
+	usr1, err := user.Current()
+	c.Assert(err, IsNil)
+	usr1.HomeDir = filepath.Join(s.tempdir, "user1")
+
+	usr2, err := user.Current()
+	c.Assert(err, IsNil)
+	usr2.HomeDir = filepath.Join(s.tempdir, "user2")
+
+	restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+		return []*user.User{usr1, usr2}, nil
+	})
+	defer restore()
+
+	first := true
+	restore = backend.MockMkdirAllChown(func(string, os.FileMode, sys.UserID, sys.GroupID) error {
+		if first {
+			first = false
+			return nil
+		}
+
+		return errors.New("boom")
+	})
+	defer restore()
+
+	var calledRemove bool
+	restore = backend.MockRemoveIfEmpty(func(dir string) error {
+		calledRemove = true
+		return backend.RemoveIfEmpty(dir)
+	})
+	defer restore()
+
+	snapName := "some-snap"
+	rev, err := snap.ParseRevision("2")
+	c.Assert(err, IsNil)
+
+	undoInfo, err := s.be.InitExposedSnapHome(snapName, rev)
+	c.Assert(err, ErrorMatches, ".*: boom")
+	c.Check(undoInfo, IsNil)
+
+	exists, _, err := osutil.DirExists(filepath.Join(usr1.HomeDir, dirs.ExposedSnapHomeDir))
+	c.Assert(err, IsNil)
+	c.Check(exists, Equals, false)
+
+	exists, _, err = osutil.DirExists(filepath.Join(usr2.HomeDir, dirs.ExposedSnapHomeDir))
+	c.Assert(err, IsNil)
+	c.Check(exists, Equals, false)
+
+	c.Check(calledRemove, Equals, true)
 }
 
 func (s *copydataSuite) TestInitSnapNothingToCopy(c *C) {
@@ -1002,7 +1058,9 @@ func (s *copydataSuite) TestInitSnapNothingToCopy(c *C) {
 	rev, err := snap.ParseRevision("2")
 	c.Assert(err, IsNil)
 
-	c.Assert(s.be.InitExposedSnapHome(snapName, rev), IsNil)
+	undoInfo, err := s.be.InitExposedSnapHome(snapName, rev)
+	c.Assert(err, IsNil)
+	c.Check(undoInfo.Created, DeepEquals, []string{snap.UserExposedHomeDir(usr.HomeDir, snapName)})
 
 	newHomeDir := filepath.Join(usr.HomeDir, dirs.ExposedSnapHomeDir, snapName)
 	exists, _, err := osutil.DirExists(newHomeDir)
@@ -1035,7 +1093,9 @@ func (s *copydataSuite) TestInitAlreadyExistsFile(c *C) {
 	rev, err := snap.ParseRevision("2")
 	c.Assert(err, IsNil)
 
-	c.Assert(s.be.InitExposedSnapHome(snapName, rev), ErrorMatches, fmt.Sprintf("cannot initialize new user HOME %q: already exists but is not a directory", newHome))
+	undoInfo, err := s.be.InitExposedSnapHome(snapName, rev)
+	c.Assert(err, ErrorMatches, fmt.Sprintf("cannot initialize new user HOME %q: already exists but is not a directory", newHome))
+	c.Check(undoInfo, IsNil)
 
 	exists, isReg, err := osutil.RegularFileExists(newHome)
 	c.Assert(err, IsNil)
@@ -1063,7 +1123,9 @@ func (s *copydataSuite) TestInitAlreadyExistsDir(c *C) {
 	rev, err := snap.ParseRevision("2")
 	c.Assert(err, IsNil)
 
-	c.Assert(s.be.InitExposedSnapHome(snapName, rev), IsNil)
+	undoInfo, err := s.be.InitExposedSnapHome(snapName, rev)
+	c.Assert(err, IsNil)
+	c.Check(undoInfo.Created, HasLen, 0)
 
 	exists, isDir, err := osutil.DirExists(newHome)
 	c.Assert(err, IsNil)
@@ -1090,8 +1152,10 @@ func (s *copydataSuite) TestRemoveExposedHome(c *C) {
 	exposedDir := filepath.Join(usr.HomeDir, dirs.ExposedSnapHomeDir, snapName)
 	c.Assert(os.MkdirAll(exposedDir, 0700), IsNil)
 	c.Assert(ioutil.WriteFile(filepath.Join(exposedDir, "file"), []byte("foo"), 0600), IsNil)
+	var undoInfo backend.UndoInfo
+	undoInfo.Created = append(undoInfo.Created, exposedDir)
 
-	c.Assert(s.be.RemoveExposedSnapHome(snapName), IsNil)
+	c.Assert(s.be.UndoInitExposedSnapHome(snapName, &undoInfo), IsNil)
 
 	exists, _, err := osutil.DirExists(exposedDir)
 	c.Assert(err, IsNil)
@@ -1119,6 +1183,7 @@ func (s *copydataSuite) TestRemoveExposedKeepGoingOnFail(c *C) {
 	defer restore()
 
 	snapName := "some-snap"
+	var undoInfo backend.UndoInfo
 	var usrs []*user.User
 	for _, usrName := range []string{"usr1", "usr2"} {
 		homedir := filepath.Join(s.tempdir, usrName)
@@ -1130,6 +1195,7 @@ func (s *copydataSuite) TestRemoveExposedKeepGoingOnFail(c *C) {
 		c.Assert(os.MkdirAll(exposedDir, 0700), IsNil)
 		c.Assert(ioutil.WriteFile(filepath.Join(exposedDir, "file"), []byte("foo"), 0700), IsNil)
 		usrs = append(usrs, usr)
+		undoInfo.Created = append(undoInfo.Created, exposedDir)
 	}
 
 	restUsers := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
@@ -1140,7 +1206,7 @@ func (s *copydataSuite) TestRemoveExposedKeepGoingOnFail(c *C) {
 	buf, restLogger := logger.MockLogger()
 	defer restLogger()
 
-	err := s.be.RemoveExposedSnapHome(snapName)
+	err := s.be.UndoInitExposedSnapHome(snapName, &undoInfo)
 	// the first error is returned
 	c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot remove %q: first error`, filepath.Join(s.tempdir, "usr1", "Snap")))
 	// second error is logged

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/progress"
+	"github.com/snapcore/snapd/randutil"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snapfile"
 	"github.com/snapcore/snapd/store"
@@ -81,7 +82,8 @@ type fakeOp struct {
 
 	requireSnapdTooling bool
 
-	dirOpts *dirs.SnapDirOptions
+	dirOpts  *dirs.SnapDirOptions
+	undoInfo *backend.UndoInfo
 }
 
 type fakeOps []fakeOp
@@ -1282,11 +1284,11 @@ func (f *fakeSnappyBackend) InitExposedSnapHome(snapName string, rev snap.Revisi
 		return nil, err
 	}
 
-	return &backend.UndoInfo{}, nil
+	return &backend.UndoInfo{Created: []string{randutil.RandomString(10)}}, nil
 }
 
 func (f *fakeSnappyBackend) UndoInitExposedSnapHome(snapName string, undoInfo *backend.UndoInfo) error {
-	f.appendOp(&fakeOp{op: "undo-init-exposed-snap-home", name: snapName})
+	f.appendOp(&fakeOp{op: "undo-init-exposed-snap-home", name: snapName, undoInfo: undoInfo})
 	return f.maybeErrForLastOp()
 }
 

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -1275,13 +1275,18 @@ func (f *fakeSnappyBackend) UndoHideSnapData(snapName string) error {
 	return f.maybeErrForLastOp()
 }
 
-func (f *fakeSnappyBackend) InitExposedSnapHome(snapName string, rev snap.Revision) error {
+func (f *fakeSnappyBackend) InitExposedSnapHome(snapName string, rev snap.Revision) (*backend.UndoInfo, error) {
 	f.appendOp(&fakeOp{op: "init-exposed-snap-home", name: snapName, revno: rev})
-	return f.maybeErrForLastOp()
+
+	if err := f.maybeErrForLastOp(); err != nil {
+		return nil, err
+	}
+
+	return &backend.UndoInfo{}, nil
 }
 
-func (f *fakeSnappyBackend) RemoveExposedSnapHome(snapName string) error {
-	f.appendOp(&fakeOp{op: "rm-exposed-snap-home", name: snapName})
+func (f *fakeSnappyBackend) UndoInitExposedSnapHome(snapName string, undoInfo *backend.UndoInfo) error {
+	f.appendOp(&fakeOp{op: "undo-init-exposed-snap-home", name: snapName})
 	return f.maybeErrForLastOp()
 }
 

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -52,6 +52,7 @@ import (
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
 	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
@@ -7606,25 +7607,63 @@ func (s *snapmgrTestSuite) TestUpdateDoHiddenDirMigrationOnCore22(c *C) {
 }
 
 func (s *snapmgrTestSuite) TestUndoMigrationIfUpdateToCore22FailsAfterWritingState(c *C) {
-	s.testUndoMigrationIfUpdateToCore22Fails(c, failAfterLinkSnap)
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	si := &snap.SideInfo{
+		Revision: snap.R(1),
+		SnapID:   "snap-for-core22-id",
+		RealName: "snap-core18-to-core22",
+	}
+	snapst := &snapstate.SnapState{
+		Sequence: []*snap.SideInfo{si},
+		Current:  si.Revision,
+		Active:   true,
+	}
+	snapstate.Set(s.state, "snap-core18-to-core22", snapst)
+	c.Assert(snapstate.WriteSeqFile("snap-core18-to-core22", snapst), IsNil)
+
+	// adding core22 so it's easier to find the other snap's tasks below
+	snapstate.Set(s.state, "core22", &snapstate.SnapState{
+		Sequence: []*snap.SideInfo{{
+			SnapID:   "core22",
+			Revision: snap.R("2"),
+			RealName: "core22",
+		}},
+		Current:  snap.R("2"),
+		SnapType: "base",
+	})
+
+	chg := s.state.NewChange("update", "update a snap")
+	ts, err := snapstate.Update(s.state, "snap-core18-to-core22", &snapstate.RevisionOptions{Channel: "channel-for-core22/stable"}, s.user.ID, snapstate.Flags{})
+	c.Assert(err, IsNil)
+	chg.AddAll(ts)
+
+	// fails change while after link-snap runs (after state is persisted)
+	expectedErr := failAfterLinkSnap(s.o, chg)
+
+	s.settle(c)
+	c.Assert(chg.Err(), Not(IsNil))
+	c.Assert(chg.Status(), Equals, state.ErrorStatus)
+	c.Assert(chg.Err(), ErrorMatches, fmt.Sprintf(`(.|\s)*%s\)?`, expectedErr.Error()))
+
+	expectedOps := []string{"hide-snap-data", "init-exposed-snap-home", "undo-init-exposed-snap-home", "undo-hide-snap-data"}
+	containsInOrder(c, s.fakeBackend.ops, expectedOps)
+
+	// check that the undoInfo returned by InitExposed and stored in the task is
+	// the same as the one passed into UndoInitExposed
+	t := findLastTask(chg, "copy-snap-data")
+	c.Assert(t, Not(IsNil))
+
+	var undoInfo backend.UndoInfo
+	c.Assert(t.Get("undo-exposed-home-init", &undoInfo), IsNil)
+	op := s.fakeBackend.ops.MustFindOp(c, "undo-init-exposed-snap-home")
+	c.Check(op.undoInfo, DeepEquals, &undoInfo)
+
+	assertMigrationState(c, s.state, "snap-core18-to-core22", nil)
 }
 
 func (s *snapmgrTestSuite) TestUndoMigrationIfUpdateToCore22Fails(c *C) {
-	// fails change while initializing ~/Snap (before state is persisted)
-	s.testUndoMigrationIfUpdateToCore22Fails(c, func(*overlord.Overlord, *state.Change) error {
-		err := errors.New("boom")
-		s.fakeBackend.maybeInjectErr = func(op *fakeOp) error {
-			if op.op == "init-exposed-snap-home" {
-				return err
-			}
-			return nil
-		}
-
-		return err
-	})
-}
-
-func (s *snapmgrTestSuite) testUndoMigrationIfUpdateToCore22Fails(c *C, prepFail prepFailFunc) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -7646,11 +7685,16 @@ func (s *snapmgrTestSuite) testUndoMigrationIfUpdateToCore22Fails(c *C, prepFail
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
-	// make change fail
-	expectedErr := prepFail(s.o, chg)
+	// fails change while initializing ~/Snap (before state is persisted)
+	expectedErr := errors.New("boom")
+	s.fakeBackend.maybeInjectErr = func(op *fakeOp) error {
+		if op.op == "init-exposed-snap-home" {
+			return expectedErr
+		}
+		return nil
+	}
 
 	s.settle(c)
-	c.Assert(chg.Err(), Not(IsNil))
 	c.Assert(chg.Status(), Equals, state.ErrorStatus)
 	c.Assert(chg.Err(), ErrorMatches, fmt.Sprintf(`(.|\s)*%s\)?`, expectedErr.Error()))
 

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -7445,7 +7445,7 @@ func (s *snapmgrTestSuite) TestUpdateAfterCore22Migration(c *C) {
 	c.Check(s.fakeBackend.ops.First("hide-snap-data"), IsNil)
 	c.Check(s.fakeBackend.ops.First("undo-hide-snap-data"), IsNil)
 	c.Check(s.fakeBackend.ops.First("init-exposed-snap-home"), IsNil)
-	c.Check(s.fakeBackend.ops.First("rm-exposed-snap-home"), IsNil)
+	c.Check(s.fakeBackend.ops.First("undo-init-exposed-snap-home"), IsNil)
 
 	expected := &dirs.SnapDirOptions{HiddenSnapDataDir: true, MigratedToExposedHome: true}
 	c.Check(s.fakeBackend.ops.MustFindOp(c, "copy-data").dirOpts, DeepEquals, expected)


### PR DESCRIPTION
This PR is based on the catch-all revert PR https://github.com/snapcore/snapd/pull/11497 so the only relevant commit is d97faecea80cdb5735db3bafd4563c2e3732c44b (and any that may be added later). This makes the initialization of ~/Snap return undo information so that if the operation has to be undone, we know what was created in the current change and what was done in a previous migration. This is relevant because a migration can happen after a previous migration was reverted and, if that fails, we don't want to remove things that were already there (since that would break revert's promise).