### PR TITLE
packaging: use latest go to build spread

### DIFF
--- a/packaging/ubuntu-16.04/tests/integrationtests
+++ b/packaging/ubuntu-16.04/tests/integrationtests
@@ -46,11 +46,11 @@ systemctl daemon-reload
 systemctl restart snapd
 
 # Spread will only buid with recent go
-snap install --classic --channel 1.17/stable go
+snap install --classic go
 
 # and now run spread against localhost
 export GOPATH=/tmp/go
-/snap/bin/go get -u github.com/snapcore/spread/cmd/spread
+/snap/bin/go install github.com/snapcore/spread/cmd/spread@latest
 
 # the tests need this:
 groupadd --gid 12345 test


### PR DESCRIPTION
The most recent change in `go get` with go1.18 did not longer
install binaries. However we used this feature in our autopkgtest
script. As a workaround there was a commit to build spread with
go 1.17 to workaround this change.

This commit moves us back to latest go and instead of `go get`
we now use `go install`.

I tested this manually via
```
$ autopkgtest -U snapd_2.54.2.dsc -- qemu ubuntu-20.04-64.img
```
and it works as expected.
