### PR TITLE
many: support --ignore-running with refresh many

### DIFF
--- a/client/snap_op.go
+++ b/client/snap_op.go
@@ -102,6 +102,7 @@ type multiActionData struct {
 	Snaps         []string `json:"snaps,omitempty"`
 	Users         []string `json:"users,omitempty"`
 	Transactional bool     `json:"transactional,omitempty"`
+	IgnoreRunning bool     `json:"ignore-running,omitempty"`
 }
 
 // Install adds the snap with the given name from the given channel (or
@@ -207,6 +208,7 @@ func (client *Client) doMultiSnapActionFull(actionName string, snaps []string, o
 		// TODO: consider returning error when options.Dangerous is set
 		action.Users = options.Users
 		action.Transactional = options.Transactional
+		action.IgnoreRunning = options.IgnoreRunning
 	}
 
 	data, err := json.Marshal(&action)

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -842,9 +842,10 @@ func (x *cmdRefresh) Execute([]string) error {
 		x.setModes(opts)
 		return x.refreshOne(names[0], opts)
 	}
-	// transactional flag is the only one with meaning when
+	// transactional and ignore-running flags are the only ones with meaning when
 	// refreshing many snaps
 	opts := &client.SnapOptions{
+		IgnoreRunning: x.IgnoreRunning,
 		Transactional: x.Transactional,
 	}
 
@@ -854,9 +855,6 @@ func (x *cmdRefresh) Execute([]string) error {
 
 	if x.IgnoreValidation {
 		return errors.New(i18n.G("a single snap name must be specified when ignoring validation"))
-	}
-	if x.IgnoreRunning {
-		return errors.New(i18n.G("a single snap name must be specified when ignoring running apps and hooks"))
 	}
 
 	return x.refreshMany(names, opts)

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -1568,6 +1568,35 @@ func (s *SnapOpSuite) TestRefreshAllChannel(c *check.C) {
 	c.Assert(err, check.ErrorMatches, `a single snap name is needed to specify mode or channel flags`)
 }
 
+func (s *SnapOpSuite) TestRefreshOneIgnoreRunning(c *check.C) {
+	s.RedirectClientToTestServer(s.srv.handle)
+	s.srv.checker = func(r *http.Request) {
+		c.Check(r.Method, check.Equals, "POST")
+		c.Check(r.URL.Path, check.Equals, "/v2/snaps/one")
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+			"action":         "refresh",
+			"ignore-running": true,
+		})
+	}
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--ignore-running", "one"})
+	c.Assert(err, check.IsNil)
+}
+
+func (s *SnapOpSuite) TestRefreshManyIgnoreRunning(c *check.C) {
+	s.RedirectClientToTestServer(s.srv.handle)
+	s.srv.checker = func(r *http.Request) {
+		c.Check(r.Method, check.Equals, "POST")
+		c.Check(r.URL.Path, check.Equals, "/v2/snaps")
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+			"action":         "refresh",
+			"snaps":          []interface{}{"one", "two"},
+			"ignore-running": true,
+		})
+	}
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--ignore-running", "one", "two"})
+	c.Assert(err, check.IsNil)
+}
+
 func (s *SnapOpSuite) TestRefreshManyChannel(c *check.C) {
 	s.RedirectClientToTestServer(nil)
 	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--beta", "one", "two"})

--- a/daemon/api_snaps.go
+++ b/daemon/api_snaps.go
@@ -569,7 +569,10 @@ func snapInstallMany(inst *snapInstruction, st *state.State) (*snapInstructionRe
 			return nil, fmt.Errorf(i18n.G("cannot install snap with empty name"))
 		}
 	}
-	installed, tasksets, err := snapstateInstallMany(st, inst.Snaps, inst.userID, &snapstate.Flags{Transactional: inst.Transactional})
+	installed, tasksets, err := snapstateInstallMany(st, inst.Snaps, inst.userID, &snapstate.Flags{
+		Transactional: inst.Transactional,
+		IgnoreRunning: inst.IgnoreRunning,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -606,7 +609,10 @@ func snapUpdateMany(inst *snapInstruction, st *state.State) (*snapInstructionRes
 	}
 
 	// TODO: use a per-request context
-	updated, tasksets, err := snapstateUpdateMany(context.TODO(), st, inst.Snaps, inst.userID, &snapstate.Flags{Transactional: inst.Transactional})
+	updated, tasksets, err := snapstateUpdateMany(context.TODO(), st, inst.Snaps, inst.userID, &snapstate.Flags{
+		IgnoreRunning: inst.IgnoreRunning,
+		Transactional: inst.Transactional,
+	})
 	if err != nil {
 		if opts.IsRefreshOfAllSnaps {
 			if err := assertstateRestoreValidationSetsTracking(st); err != nil && !errors.Is(err, state.ErrNoState) {

--- a/daemon/api_snaps.go
+++ b/daemon/api_snaps.go
@@ -569,10 +569,7 @@ func snapInstallMany(inst *snapInstruction, st *state.State) (*snapInstructionRe
 			return nil, fmt.Errorf(i18n.G("cannot install snap with empty name"))
 		}
 	}
-	installed, tasksets, err := snapstateInstallMany(st, inst.Snaps, inst.userID, &snapstate.Flags{
-		Transactional: inst.Transactional,
-		IgnoreRunning: inst.IgnoreRunning,
-	})
+	installed, tasksets, err := snapstateInstallMany(st, inst.Snaps, inst.userID, &snapstate.Flags{Transactional: inst.Transactional})
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -749,7 +749,7 @@ func (s *snapsSuite) TestRefreshMany1(c *check.C) {
 }
 
 func (s *snapsSuite) TestInstallMany(c *check.C) {
-	defer daemon.MockSnapstateInstallMany(func(s *state.State, names []string, userID int, flags *snapstate.Flags) ([]string, []*state.TaskSet, error) {
+	defer daemon.MockSnapstateInstallMany(func(s *state.State, names []string, userID int, _ *snapstate.Flags) ([]string, []*state.TaskSet, error) {
 		c.Check(names, check.HasLen, 2)
 		t := s.NewTask("fake-install-2", "Install two")
 		return names, []*state.TaskSet{state.NewTaskSet(t)}, nil

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -766,29 +766,6 @@ func (s *snapsSuite) TestInstallMany(c *check.C) {
 	c.Check(res.Affected, check.DeepEquals, inst.Snaps)
 }
 
-func (s *snapsSuite) TestInstallManyIgnoreRunning(c *check.C) {
-	var calledFlags *snapstate.Flags
-
-	defer daemon.MockSnapstateInstallMany(func(s *state.State, names []string, userID int, flags *snapstate.Flags) ([]string, []*state.TaskSet, error) {
-		calledFlags = flags
-
-		c.Check(names, check.HasLen, 2)
-		t := s.NewTask("fake-install-2", "Install two")
-		return names, []*state.TaskSet{state.NewTaskSet(t)}, nil
-	})()
-
-	d := s.daemon(c)
-	inst := &daemon.SnapInstruction{Action: "install", Snaps: []string{"foo", "bar"}, IgnoreRunning: true}
-	st := d.Overlord().State()
-	st.Lock()
-	res, err := inst.DispatchForMany()(inst, st)
-	st.Unlock()
-	c.Assert(err, check.IsNil)
-	c.Check(res.Summary, check.Equals, `Install snaps "foo", "bar"`)
-	c.Check(res.Affected, check.DeepEquals, inst.Snaps)
-	c.Check(calledFlags.IgnoreRunning, check.Equals, true)
-}
-
 func (s *snapsSuite) TestInstallManyTransactionally(c *check.C) {
 	var calledFlags *snapstate.Flags
 

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1280,7 +1280,6 @@ func InstallMany(st *state.State, names []string, userID int, flags *Flags) ([]s
 		if err != nil {
 			return nil, nil, err
 		}
-		validatedFlags.IgnoreRunning = flags.IgnoreRunning
 
 		channel := "stable"
 		if sar.RedirectChannel != "" {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -166,6 +166,7 @@ func (ins installSnapInfo) SnapSetupForUpdate(st *state.State, params updatePara
 			Media:   update.Media,
 		},
 	}
+	snapsup.IgnoreRunning = globalFlags.IgnoreRunning
 	return &snapsup, snapst, nil
 }
 
@@ -1279,6 +1280,7 @@ func InstallMany(st *state.State, names []string, userID int, flags *Flags) ([]s
 		if err != nil {
 			return nil, nil, err
 		}
+		validatedFlags.IgnoreRunning = flags.IgnoreRunning
 
 		channel := "stable"
 		if sar.RedirectChannel != "" {


### PR DESCRIPTION
Support --ignore-running flag when refreshing multiple snaps.
