### PR TITLE
snap/quota,spread: raise lower memory quota limit to 640kb

### DIFF
--- a/overlord/servicestate/quota_control_test.go
+++ b/overlord/servicestate/quota_control_test.go
@@ -246,10 +246,10 @@ func (s *quotaControlSuite) TestCreateQuotaPrecond(c *C) {
 		snaps []string
 		err   string
 	}{
-		{"foo", 16 * quantity.SizeKiB, nil, `group "foo" already exists`},
+		{"foo", quantity.SizeMiB, nil, `group "foo" already exists`},
 		{"new", 0, nil, `cannot create quota group "new": memory quota must have a limit set`},
-		{"new", quantity.SizeKiB, nil, `cannot create quota group "new": memory limit 1024 is too small: size must be larger than 4KB`},
-		{"new", 16 * quantity.SizeKiB, []string{"baz"}, `cannot use snap "baz" in group "new": snap "baz" is not installed`},
+		{"new", quantity.SizeKiB, nil, `cannot create quota group "new": memory limit 1024 is too small: size must be larger than 640KB`},
+		{"new", quantity.SizeMiB, []string{"baz"}, `cannot use snap "baz" in group "new": snap "baz" is not installed`},
 	}
 
 	for _, t := range tests {

--- a/overlord/servicestate/quota_handlers_test.go
+++ b/overlord/servicestate/quota_handlers_test.go
@@ -641,14 +641,14 @@ func (s *quotaHandlersSuite) TestQuotaCreate(c *C) {
 
 	// trying to create a quota with too low of a memory limit fails
 	err = s.callDoQuotaControl(&qc2)
-	c.Assert(err, ErrorMatches, `cannot create quota group "foo": memory limit 4096 is too small: size must be larger than 4KB`)
+	c.Assert(err, ErrorMatches, `cannot create quota group "foo": memory limit 4096 is too small: size must be larger than 640KB`)
 
 	// but with an adequately sized memory limit, and a snap that exists, we can
 	// create it
 	qc3 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
-		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(4*quantity.SizeKiB + 1).Build(),
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(640*quantity.SizeKiB + 1).Build(),
 		AddSnaps:       []string{"test-snap"},
 	}
 	err = s.callDoQuotaControl(&qc3)
@@ -657,7 +657,7 @@ func (s *quotaHandlersSuite) TestQuotaCreate(c *C) {
 	// check that the quota groups were created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
-			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(4*quantity.SizeKiB + 1).Build(),
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(640*quantity.SizeKiB + 1).Build(),
 			Snaps:          []string{"test-snap"},
 		},
 	})

--- a/snap/quota/quota_test.go
+++ b/snap/quota/quota_test.go
@@ -164,24 +164,24 @@ func (ts *quotaTestSuite) TestSimpleSubGroupVerification(c *C) {
 			comment:    "basic sub group with same quota as parent happy",
 		},
 		{
-			rootlimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).WithCPUCount(1).WithCPUPercentage(100).WithAllowedCPUs([]int{0}).WithThreadLimit(32).Build(),
+			rootlimits: quota.NewResourcesBuilder().WithMemoryLimit(2 * quantity.SizeMiB).WithCPUCount(1).WithCPUPercentage(100).WithAllowedCPUs([]int{0}).WithThreadLimit(32).Build(),
 			subname:    "sub",
-			sublimits:  quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB / 2).WithCPUCount(1).WithCPUPercentage(50).WithAllowedCPUs([]int{0}).WithThreadLimit(16).Build(),
+			sublimits:  quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).WithCPUCount(1).WithCPUPercentage(50).WithAllowedCPUs([]int{0}).WithThreadLimit(16).Build(),
 			comment:    "basic sub group with smaller quota than parent happy",
 		},
 		{
-			rootlimits:    quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).WithCPUCount(1).WithCPUPercentage(100).WithAllowedCPUs([]int{0}).WithThreadLimit(32).Build(),
+			rootlimits:    quota.NewResourcesBuilder().WithMemoryLimit(2 * quantity.SizeMiB).WithCPUCount(1).WithCPUPercentage(100).WithAllowedCPUs([]int{0}).WithThreadLimit(32).Build(),
 			subname:       "sub-with-dashes",
 			sliceFileName: `myroot-sub\x2dwith\x2ddashes`,
-			sublimits:     quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB / 2).WithCPUCount(1).WithCPUPercentage(50).WithAllowedCPUs([]int{0}).WithThreadLimit(16).Build(),
+			sublimits:     quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).WithCPUCount(1).WithCPUPercentage(50).WithAllowedCPUs([]int{0}).WithThreadLimit(16).Build(),
 			comment:       "basic sub group with dashes in the name",
 		},
 		{
 			rootname:      "my-root",
-			rootlimits:    quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).WithCPUCount(1).WithCPUPercentage(100).WithAllowedCPUs([]int{0}).WithThreadLimit(32).Build(),
+			rootlimits:    quota.NewResourcesBuilder().WithMemoryLimit(2 * quantity.SizeMiB).WithCPUCount(1).WithCPUPercentage(100).WithAllowedCPUs([]int{0}).WithThreadLimit(32).Build(),
 			subname:       "sub-with-dashes",
 			sliceFileName: `my\x2droot-sub\x2dwith\x2ddashes`,
-			sublimits:     quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB / 2).WithCPUCount(1).WithCPUPercentage(50).WithAllowedCPUs([]int{0}).WithThreadLimit(16).Build(),
+			sublimits:     quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).WithCPUCount(1).WithCPUPercentage(50).WithAllowedCPUs([]int{0}).WithThreadLimit(16).Build(),
 			comment:       "parent and sub group have dashes in name",
 		},
 		{
@@ -269,30 +269,30 @@ func (ts *quotaTestSuite) TestSimpleSubGroupVerification(c *C) {
 }
 
 func (ts *quotaTestSuite) TestComplexSubGroups(c *C) {
-	rootGrp, err := quota.NewGroup("myroot", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build())
+	rootGrp, err := quota.NewGroup("myroot", quota.NewResourcesBuilder().WithMemoryLimit(2*quantity.SizeMiB).Build())
 	c.Assert(err, IsNil)
 
 	// try adding 2 sub-groups with total quota split exactly equally
-	sub1, err := rootGrp.NewSubGroup("sub1", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB/2).Build())
+	sub1, err := rootGrp.NewSubGroup("sub1", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build())
 	c.Assert(err, IsNil)
 	c.Assert(sub1.SliceFileName(), Equals, "snap.myroot-sub1.slice")
 
-	sub2, err := rootGrp.NewSubGroup("sub2", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB/2).Build())
+	sub2, err := rootGrp.NewSubGroup("sub2", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build())
 	c.Assert(err, IsNil)
 	c.Assert(sub2.SliceFileName(), Equals, "snap.myroot-sub2.slice")
 
 	// adding another sub-group to this group fails
-	_, err = rootGrp.NewSubGroup("sub3", quota.NewResourcesBuilder().WithMemoryLimit(5*quantity.SizeKiB).Build())
-	c.Assert(err, ErrorMatches, "sub-group memory limit of 5 KiB is too large to fit inside group \"myroot\" remaining quota space 0 B")
+	_, err = rootGrp.NewSubGroup("sub3", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build())
+	c.Assert(err, ErrorMatches, "sub-group memory limit of 1 MiB is too large to fit inside group \"myroot\" remaining quota space 0 B")
 
 	// we can however add a sub-group to one of the sub-groups with the exact
 	// size of the parent sub-group
-	subsub1, err := sub1.NewSubGroup("subsub1", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB/2).Build())
+	subsub1, err := sub1.NewSubGroup("subsub1", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build())
 	c.Assert(err, IsNil)
 	c.Assert(subsub1.SliceFileName(), Equals, "snap.myroot-sub1-subsub1.slice")
 
-	// and we can even add a smaller sub-sub-sub-group to the sub-group
-	subsubsub1, err := subsub1.NewSubGroup("subsubsub1", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB/4).Build())
+	// and we can even add a sub-sub-sub-group to the sub-group
+	subsubsub1, err := subsub1.NewSubGroup("subsubsub1", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build())
 	c.Assert(err, IsNil)
 	c.Assert(subsubsub1.SliceFileName(), Equals, "snap.myroot-sub1-subsub1-subsubsub1.slice")
 }
@@ -305,7 +305,7 @@ func (ts *quotaTestSuite) TestGroupUnmixableSnapsSubgroups(c *C) {
 	parent.Snaps = []string{"test-snap"}
 
 	// add a subgroup to the parent group, this should fail as the group now has snaps
-	_, err = parent.NewSubGroup("sub", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB/2).Build())
+	_, err = parent.NewSubGroup("sub", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build())
 	c.Assert(err, ErrorMatches, "cannot mix sub groups with snaps in the same group")
 }
 
@@ -418,17 +418,17 @@ func (ts *quotaTestSuite) TestResolveCrossReferences(c *C) {
 			grps: map[string]*quota.Group{
 				"foogroup": {
 					Name:        "foogroup",
-					MemoryLimit: quantity.SizeMiB,
+					MemoryLimit: 2 * quantity.SizeMiB,
 					SubGroups:   []string{"subgroup1", "subgroup2"},
 				},
 				"subgroup1": {
 					Name:        "subgroup1",
-					MemoryLimit: quantity.SizeMiB / 2,
+					MemoryLimit: quantity.SizeMiB,
 					ParentGroup: "foogroup",
 				},
 				"subgroup2": {
 					Name:        "subgroup2",
-					MemoryLimit: quantity.SizeMiB / 2,
+					MemoryLimit: quantity.SizeMiB,
 					ParentGroup: "foogroup",
 				},
 			},

--- a/snap/quota/resources.go
+++ b/snap/quota/resources.go
@@ -75,8 +75,8 @@ func (qr *Resources) validateMemoryQuota() error {
 	// to allow nesting, otherwise groups with less than 4K will trigger the
 	// oom killer to be invoked when a new group is added as a sub-group to the
 	// larger group.
-	if qr.Memory.Limit <= 4*quantity.SizeKiB {
-		return fmt.Errorf("memory limit %d is too small: size must be larger than 4KB", qr.Memory.Limit)
+	if qr.Memory.Limit <= 640*quantity.SizeKiB {
+		return fmt.Errorf("memory limit %d is too small: size must be larger than 640KB", qr.Memory.Limit)
 	}
 	return nil
 }
@@ -132,7 +132,7 @@ func (qr *Resources) CheckFeatureRequirements() error {
 
 // Validate performs validation of the provided quota resources for a group.
 // The restrictions imposed are that at least one limit should be set.
-// If memory limit is provided, it must be above 4KB.
+// If memory limit is provided, it must be above 640KB.
 // If cpu percentage is provided, it must be between 1 and 100.
 // If cpu set is provided, it must not be empty.
 // If thread count is provided, it must be above 0.

--- a/snap/quota/resources_test.go
+++ b/snap/quota/resources_test.go
@@ -44,7 +44,7 @@ func (s *resourcesTestSuite) TestQuotaValidationFails(c *C) {
 		{quota.Resources{CPUSet: &quota.ResourceCPUSet{}}, `cpu-set quota must not be empty`},
 		{quota.Resources{Threads: &quota.ResourceThreads{}}, `invalid thread quota with a thread count of 0`},
 		{quota.NewResourcesBuilder().Build(), `quota group must have at least one resource limit set`},
-		{quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeKiB).Build(), `memory limit 1024 is too small: size must be larger than 4KB`},
+		{quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeKiB).Build(), `memory limit 1024 is too small: size must be larger than 640KB`},
 		{quota.NewResourcesBuilder().WithCPUCount(1).Build(), `invalid cpu quota with count of >0 and percentage of 0`},
 	}
 
@@ -136,7 +136,7 @@ func (s *resourcesTestSuite) TestQuotaChangeValidationFails(c *C) {
 		{
 			quota.NewResourcesBuilder().WithCPUCount(1).Build(),
 			quota.NewResourcesBuilder().WithMemoryLimit(1).Build(),
-			`memory limit 1 is too small: size must be larger than 4KB`,
+			`memory limit 1 is too small: size must be larger than 640KB`,
 		},
 		{
 			quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build(),

--- a/tests/main/snap-quota-groups/task.yaml
+++ b/tests/main/snap-quota-groups/task.yaml
@@ -108,7 +108,7 @@ execute: |
   systemctl show --property=ActiveState "$sliceName" | MATCH "ActiveState=inactive"
 
   echo "Creating a quota with a very small memory limit results in the service being unable to start"
-  snap set-quota too-small --memory=4097B go-example-webserver
+  snap set-quota too-small --memory=1MB go-example-webserver
 
   # wait for systemd to finish trying to automatically restart it, we want 
   # systemd to hit the start limit for this service, otherwise systemd 

--- a/tests/main/snap-quota/task.yaml
+++ b/tests/main/snap-quota/task.yaml
@@ -27,12 +27,12 @@ execute: |
   snap set-quota group-two --parent=group-top1 --memory=2MB test-snapd-tools
 
   echo "Creating a nested empty quota groups which fails"
-  snap set-quota group-sub-one --parent=group-one --memory=10KB 2>&1 | tr '\n' ' ' | tr -s ' ' | MATCH 'cannot mix sub groups with snaps in the same group'
+  snap set-quota group-sub-one --parent=group-one --memory=1MB 2>&1 | tr '\n' ' ' | tr -s ' ' | MATCH 'cannot mix sub groups with snaps in the same group'
 
   echo "Creating some empty quota sub groups"
   snap set-quota group-three --parent=group-top1 --memory=15MB
-  snap set-quota group-sub-three --parent=group-three --memory=10KB
-  snap set-quota group-sub-sub-three --parent=group-sub-three --memory=5KB
+  snap set-quota group-sub-three --parent=group-three --memory=4MB
+  snap set-quota group-sub-sub-three --parent=group-sub-three --memory=1MB
 
   echo "Trying to add snap to more than one group fails"
   snap set-quota group-bad --memory=1MB hello-world 2>&1 | tr '\n' ' ' | tr -s ' ' | MATCH 'error: cannot create quota group: cannot add snap "hello-world" to group "group-bad": snap already in quota group "group-one"'
@@ -46,11 +46,11 @@ execute: |
   MATCH "     2\s+group-top1\s+memory=400MB\s+memory=[0-9.a-zA-Z]+$" < quotas.txt
   MATCH "     3\s+group-one\s+group-top1\s+memory=100MB\s+memory=[0-9.a-zA-Z]+$" < quotas.txt
   # this line could be either for memory=0 in the current column, in which case
-  # it is omitted entirely, or it could be memory=4096 on some systems where 
-  # empty cgroups have 4K memory usage even on empty cgroups
+  # it is omitted entirely, or it could be either 4096 or 12.3kB on some systems where 
+  # empty cgroups have memory usage even on empty cgroups
   MATCH "     4\s+group-three\s+group-top1\s+memory=15.0MB(\s*|\s*memory=[0-9.a-zA-Z]+)\s*$" < quotas.txt
-  MATCH "     5\s+group-sub-three\s+group-three\s+memory=10.0kB(\s*|\s*memory=4096B)\s*$" < quotas.txt
-  MATCH "     6\s+group-sub-sub-three\s+group-sub-three\s+memory=5000B\s*$" < quotas.txt
+  MATCH "     5\s+group-sub-three\s+group-three\s+memory=4.00MB(\s*|\s*memory=4096B|\s*memory=12.3kB)\s*$" < quotas.txt
+  MATCH "     6\s+group-sub-sub-three\s+group-sub-three\s+memory=1.00MB\s*$" < quotas.txt
   MATCH "     7\s+group-two\s+group-top1\s+memory=2.00MB\s*$" < quotas.txt
   MATCH "     8\s+group-top2\s+memory=500MB\s*$" < quotas.txt
 

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -567,7 +567,7 @@ WantedBy=multi-user.target
 
 func (s *servicesTestSuite) TestRemoveQuotaGroup(c *C) {
 	// create the group
-	resourceLimits := quota.NewResourcesBuilder().WithMemoryLimit(5 * quantity.SizeKiB).Build()
+	resourceLimits := quota.NewResourcesBuilder().WithMemoryLimit(650 * quantity.SizeKiB).Build()
 	grp, err := quota.NewGroup("foogroup", resourceLimits)
 	c.Assert(err, IsNil)
 


### PR DESCRIPTION
The 4KB was starting to make trouble for us due to higher memory requirements from newer systemd, so we raise the minimum memory limit for quota groups to handle this. The lowest amount that can be set now in systemd is 12kb, however I will set the minimum up to 640kb as it hardly makes sense to have a limit that low (AFAICT), if anyone has any strong feelings about a different lower limit please do tell.

The 640kb should be fine for everyone, this will not affect existing memory quota groups.
