### PR TITLE
configcore: allow disable `systemd-timesyncd`

### DIFF
--- a/overlord/configstate/configcore/services.go
+++ b/overlord/configstate/configcore/services.go
@@ -39,6 +39,7 @@ var services = []struct{ configName, systemdName string }{
 	{"rsyslog", "rsyslog.service"},
 	{"console-conf", "console-conf@*"},
 	{"systemd-resolved", "systemd-resolved.service"},
+	{"systemd-timesyncd", "systemd-timesyncd.service"},
 }
 
 func init() {

--- a/overlord/configstate/configcore/services_test.go
+++ b/overlord/configstate/configcore/services_test.go
@@ -114,6 +114,8 @@ func (s *servicesSuite) TestConfigureServiceDisabledIntegration(c *C) {
 		{"rsyslog", "rsyslog.service", false},
 		{"systemd-resolved", "systemd-resolved.service", true},
 		{"systemd-resolved", "systemd-resolved.service", false},
+		{"systemd-timesyncd", "systemd-timesyncd.service", true},
+		{"systemd-timesyncd", "systemd-timesyncd.service", false},
 	} {
 		s.systemctlArgs = nil
 		s.serviceInstalled = service.installed

--- a/tests/nested/core/coreconfig-services/task.yaml
+++ b/tests/nested/core/coreconfig-services/task.yaml
@@ -3,17 +3,21 @@ summary: Disable and enable back core services via snap set with reboot.
 systems: [ubuntu-18.04-64, ubuntu-20.04-64]
 
 execute: |
-  tests.nested exec "systemctl status systemd-resolved.service" | MATCH "Active: +active"
+  for srv in systemd-resolved systemd-timesyncd; do
+      tests.nested exec "systemctl status ${srv}.service" | MATCH "Active: +active"
 
-  echo "Disabling systemd-resolved service"
-  tests.nested exec "sudo snap set system service.systemd-resolved.disable=true"
-  tests.nested exec "systemctl status systemd-resolved.service" | MATCH "Active: +inactive"
+      echo "Disabling ${srv} service"
+      tests.nested exec "sudo snap set system service.${srv}.disable=true"
+      tests.nested exec "systemctl status ${srv}.service" | MATCH "Active: +inactive"
+  done
 
   current_boot_id=$(tests.nested boot-id)
   tests.nested exec "sudo reboot" || true
   tests.nested wait-for reboot "$current_boot_id"
 
-  echo "Enabling systemd-resolved service back"
-  tests.nested exec "systemctl status systemd-resolved.service" | MATCH "Active: +inactive"
-  tests.nested exec "sudo snap set system service.systemd-resolved.disable=false"
-  tests.nested exec "systemctl status systemd-resolved.service" | MATCH "Active: +active"
+  for srv in systemd-resolved systemd-timesyncd; do
+      echo "Enabling ${srv} service back"
+      tests.nested exec "systemctl status ${srv}.service" | MATCH "Active: +inactive"
+      tests.nested exec "sudo snap set system service.${srv}.disable=false"
+      tests.nested exec "systemctl status ${srv}.service" | MATCH "Active: +active"
+  done


### PR DESCRIPTION
This commit allows disabling the `systemd-timesyncd` service via
```
$ snap set system service.systemd-timesyncd.disable=true
```

This is useful if someone wants to run alternative timesync
daemons like chrony.
