### PR TITLE
tests: skip the test interfaces-many-snap-provided in trusty

### DIFF
--- a/tests/main/interfaces-many-core-provided/task.yaml
+++ b/tests/main/interfaces-many-core-provided/task.yaml
@@ -27,6 +27,14 @@ environment:
     CONSUMER_SNAP: test-snapd-policy-app-consumer
 
 prepare: |
+    # We remove the shared-memory plug and interface in trusty because it fails with the
+    # following error since adding private /dev/shm support to shared-memory interface:
+    # shared-memory plug with "private: true" cannot be connected if "/dev/shm" is a symlink)
+    if os.query is-trusty; then
+        cp -r "$TESTSLIB/snaps/$CONSUMER_SNAP" .
+        sed -e '/shared-memory:/,+2d' -i $CONSUMER_SNAP/meta/snap.yaml
+    fi
+
     echo "Given a snap is installed"
     "$TESTSTOOLS"/snaps-state install-local "$CONSUMER_SNAP"
 

--- a/tests/main/interfaces-many-snap-provided/task.yaml
+++ b/tests/main/interfaces-many-snap-provided/task.yaml
@@ -42,7 +42,7 @@ debug: |
 
 prepare: |
     # We remove the shared-memory plug and interface in trusty because it fails with the
-    # following error since was added private /dev/shm support to shared-memory interface:
+    # following error since adding private /dev/shm support to shared-memory interface:
     # shared-memory plug with "private: true" cannot be connected if "/dev/shm" is a symlink)
     if os.query is-trusty; then
         cp -r "$TESTSLIB/snaps/$CONSUMER_SNAP" .

--- a/tests/main/interfaces-many-snap-provided/task.yaml
+++ b/tests/main/interfaces-many-snap-provided/task.yaml
@@ -27,11 +27,6 @@ environment:
     CONSUMER_SNAP: test-snapd-policy-app-consumer
 
 restore: |
-    if os.query is-trusty; then
-        echo "Ubuntu trusty is not supported, exiting..."
-        exit 0
-    fi
-
     # Remove the snaps to avoid timeout in next test
     PROVIDER_SNAP="test-snapd-policy-app-provider-classic"
     if os.query is-core; then
@@ -45,15 +40,16 @@ debug: |
     # shellcheck disable=SC2119
     "$TESTSTOOLS"/journal-state get-log
 
-execute: |
-    # We skip the test in trusty butcause it fails with the following error since
-    # was added private /dev/shm support to shared-memory interface
+prepare: |
+    # We remove the shared-memory plug and interface in trusty because it fails with the
+    # following error since was added private /dev/shm support to shared-memory interface:
     # shared-memory plug with "private: true" cannot be connected if "/dev/shm" is a symlink)
     if os.query is-trusty; then
-        echo "Ubuntu trusty is not supported, exiting..."
-        exit 0
+        cp -r "$TESTSLIB/snaps/$CONSUMER_SNAP" .
+        sed -e '/shared-memory:/,+2d' -i $CONSUMER_SNAP/meta/snap.yaml
     fi
 
+execute: |
     PROVIDER_SNAP="test-snapd-policy-app-provider-classic"    
     if os.query is-core; then
         PROVIDER_SNAP="test-snapd-policy-app-provider-core"

--- a/tests/main/interfaces-many-snap-provided/task.yaml
+++ b/tests/main/interfaces-many-snap-provided/task.yaml
@@ -26,6 +26,15 @@ priority: 100
 environment:
     CONSUMER_SNAP: test-snapd-policy-app-consumer
 
+prepare: |
+    # We remove the shared-memory plug and interface in trusty because it fails with the
+    # following error since adding private /dev/shm support to shared-memory interface:
+    # shared-memory plug with "private: true" cannot be connected if "/dev/shm" is a symlink)
+    if os.query is-trusty; then
+        cp -r "$TESTSLIB/snaps/$CONSUMER_SNAP" .
+        sed -e '/shared-memory:/,+2d' -i $CONSUMER_SNAP/meta/snap.yaml
+    fi
+
 restore: |
     # Remove the snaps to avoid timeout in next test
     PROVIDER_SNAP="test-snapd-policy-app-provider-classic"
@@ -39,15 +48,6 @@ debug: |
     # get the full journal to see any out-of-memory errors
     # shellcheck disable=SC2119
     "$TESTSTOOLS"/journal-state get-log
-
-prepare: |
-    # We remove the shared-memory plug and interface in trusty because it fails with the
-    # following error since adding private /dev/shm support to shared-memory interface:
-    # shared-memory plug with "private: true" cannot be connected if "/dev/shm" is a symlink)
-    if os.query is-trusty; then
-        cp -r "$TESTSLIB/snaps/$CONSUMER_SNAP" .
-        sed -e '/shared-memory:/,+2d' -i $CONSUMER_SNAP/meta/snap.yaml
-    fi
 
 execute: |
     PROVIDER_SNAP="test-snapd-policy-app-provider-classic"    

--- a/tests/main/interfaces-many-snap-provided/task.yaml
+++ b/tests/main/interfaces-many-snap-provided/task.yaml
@@ -27,6 +27,11 @@ environment:
     CONSUMER_SNAP: test-snapd-policy-app-consumer
 
 restore: |
+    if os.query is-trusty; then
+        echo "Ubuntu trusty is not supported, exiting..."
+        exit 0
+    fi
+
     # Remove the snaps to avoid timeout in next test
     PROVIDER_SNAP="test-snapd-policy-app-provider-classic"
     if os.query is-core; then
@@ -41,6 +46,14 @@ debug: |
     "$TESTSTOOLS"/journal-state get-log
 
 execute: |
+    # We skip the test in trusty butcause it fails with the following error since
+    # was added private /dev/shm support to shared-memory interface
+    # shared-memory plug with "private: true" cannot be connected if "/dev/shm" is a symlink)
+    if os.query is-trusty; then
+        echo "Ubuntu trusty is not supported, exiting..."
+        exit 0
+    fi
+
     PROVIDER_SNAP="test-snapd-policy-app-provider-classic"    
     if os.query is-core; then
         PROVIDER_SNAP="test-snapd-policy-app-provider-core"


### PR DESCRIPTION
We skip the test in trusty butcause it fails with the following error
since was added private /dev/shm support to shared-memory interface
shared-memory plug with "private: true" cannot be connected if
"/dev/shm" is a symlink)
