### PR TITLE
b/piboot.go: check EEPROM version for RPi4

### DIFF
--- a/bootloader/piboot.go
+++ b/bootloader/piboot.go
@@ -20,6 +20,7 @@
 package bootloader
 
 import (
+	"encoding/binary"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -51,9 +52,14 @@ const (
 // This is in a variable so it can be mocked in tests
 var ubuntuSeedDir = "/run/mnt/ubuntu-seed/"
 
+// More variables to facilitate mocking
+var rpi4RevisionCodesPath = "/sys/firmware/devicetree/base/system/linux,revision"
+var rpi4EepromTimeStampPath = "/proc/device-tree/chosen/bootloader/build-timestamp"
+
 type piboot struct {
-	rootdir string
-	basedir string
+	rootdir          string
+	basedir          string
+	prepareImageTime bool
 }
 
 func (p *piboot) setDefaults() {
@@ -65,6 +71,7 @@ func (p *piboot) processBlOpts(blOpts *Options) {
 		return
 	}
 
+	p.prepareImageTime = blOpts.PrepareImageTime
 	switch {
 	case blOpts.Role == RoleRecovery || blOpts.NoSlashBoot:
 		if !blOpts.PrepareImageTime {
@@ -375,7 +382,55 @@ func (p *piboot) layoutKernelAssetsToDir(snapf snap.Container, dstDir string) er
 	return nil
 }
 
+func (p *piboot) eepromVersionSupportsTryboot() bool {
+	// To find out the EEPROM version we do the same as the
+	// rpi-eeprom-update script (see
+	// https://github.com/raspberrypi/rpi-eeprom/blob/master/rpi-eeprom-update)
+	buf, err := ioutil.ReadFile(rpi4EepromTimeStampPath)
+	if err != nil {
+		return false
+	}
+
+	// The timestamp is seconds since the epoch, UTC time
+	eepromTs := binary.BigEndian.Uint32(buf)
+	// 2021-03-18 or more modern supports tryboot, see
+	// https://github.com/raspberrypi/rpi-eeprom/blob/master/firmware/release-notes.md#2021-04-19---promote-2021-03-18-from-latest-to-default---default
+	// The timestamp we compare with (jue 18 mar 2021 08:54:11 UTC) can be found with:
+	// $ strings pieeprom-2021-03-18.bin | grep BUILD_TIMESTAMP
+	if eepromTs < 1616057651 {
+		return false
+	}
+
+	return true
+}
+
+func (p *piboot) isRaspberryPi4() bool {
+	// For RPi4 detection we do the same as the rpi-eeprom-update script (see
+	// https://github.com/raspberrypi/rpi-eeprom/blob/master/rpi-eeprom-update)
+	buf, err := ioutil.ReadFile(rpi4RevisionCodesPath)
+	if err != nil {
+		return false
+	}
+
+	// If old style codes (older than RPi2) or processor != BCM2711 (RPi4's SoC),
+	// this is not an RPi4. For details, see
+	// https://www.raspberrypi.com/documentation/computers/raspberry-pi.html#raspberry-pi-revision-codes
+	boardInfo := binary.BigEndian.Uint32(buf)
+	if ((boardInfo>>23)&1) == 0 || ((boardInfo>>12)&0xF) != 3 {
+		return false
+	}
+
+	return true
+}
+
 func (p *piboot) ExtractKernelAssets(s snap.PlaceInfo, snapf snap.Container) error {
+	if !p.prepareImageTime {
+		// If this is a RPi4, check first if EEPROM supports tryboot
+		if p.isRaspberryPi4() && !p.eepromVersionSupportsTryboot() {
+			return fmt.Errorf("your EEPROM does not support tryboot, please upgrade to a newer one before installing Ubuntu Core")
+		}
+	}
+
 	// Rootdir will point to ubuntu-boot, but we need to put things in ubuntu-seed
 	dstDir := filepath.Join(ubuntuSeedDir, pibootPartFolder, s.Filename())
 

--- a/bootloader/piboot.go
+++ b/bootloader/piboot.go
@@ -356,15 +356,16 @@ func (p *piboot) layoutKernelAssetsToDir(snapf snap.Container, dstDir string) er
 	// armhf and arm64 pi-kernel store dtbs in different places
 	// (dtbs/ or dtbs/broadcom/ respectively)
 	var dtbDir string
-	if _, err := os.Stat(filepath.Join(dstDir, "dtbs/broadcom")); os.IsNotExist(err) {
-		dtbDir = "dtbs"
-	} else {
+	if _, isDir, _ := osutil.DirExists(filepath.Join(dstDir, "dtbs/broadcom")); isDir {
 		dtbDir = "dtbs/broadcom"
 		overlaysDir := filepath.Join(dstDir, "dtbs/overlays/")
 		if err := os.Rename(overlaysDir, newOvDir); err != nil {
 			return err
 		}
+	} else {
+		dtbDir = "dtbs"
 	}
+
 	dtbFiles := filepath.Join(dstDir, dtbDir, "*")
 	if output, err := exec.Command("sh", "-c",
 		"mv "+dtbFiles+" "+dstDir).CombinedOutput(); err != nil {

--- a/bootloader/piboot_test.go
+++ b/bootloader/piboot_test.go
@@ -610,3 +610,87 @@ func (s *pibootTestSuite) TestExtractKernelAssetsAndRemove(c *C) {
 	s.testExtractKernelAssetsAndRemove(c, "dtbs")
 	s.testExtractKernelAssetsAndRemove(c, "dtbs/broadcom")
 }
+
+func (s *pibootTestSuite) testExtractKernelAssetsOnRPi4CheckEeprom(c *C, rpiRevisionCode, eepromTimeStamp []byte, errExpected bool) {
+	opts := bootloader.Options{PrepareImageTime: false,
+		Role: bootloader.RoleRunMode, NoSlashBoot: true}
+	r := bootloader.MockPibootFiles(c, s.rootdir, &opts)
+	defer r()
+	r = bootloader.MockRPi4Files(c, s.rootdir, rpiRevisionCode, eepromTimeStamp)
+	defer r()
+	p := bootloader.NewPiboot(s.rootdir, &opts)
+	c.Assert(p, NotNil)
+
+	files := [][]string{
+		{"kernel.img", "I'm a kernel"},
+		{"initrd.img", "...and I'm an initrd"},
+		{"dtbs/broadcom/foo.dtb", "g'day, I'm foo.dtb"},
+		{"dtbs/overlays/bar.dtbo", "hello, I'm bar.dtbo"},
+		// must be last
+		{"meta/kernel.yaml", "version: 4.2"},
+	}
+	si := &snap.SideInfo{
+		RealName: "ubuntu-kernel",
+		Revision: snap.R(42),
+	}
+	fn := snaptest.MakeTestSnapWithFiles(c, packageKernel, files)
+	snapf, err := snapfile.Open(fn)
+	c.Assert(err, IsNil)
+
+	info, err := snap.ReadInfoFromSnapFile(snapf, si)
+	c.Assert(err, IsNil)
+
+	err = p.ExtractKernelAssets(info, snapf)
+	if errExpected {
+		c.Check(err.Error(), Equals,
+			"your EEPROM does not support tryboot, please upgrade to a newer one before installing Ubuntu Core")
+		return
+	}
+
+	c.Assert(err, IsNil)
+
+	// this is where the kernel/initrd is unpacked
+	kernelAssetsDir := filepath.Join(s.rootdir, "piboot", "ubuntu", "ubuntu-kernel_42.snap")
+
+	for _, def := range files {
+		if def[0] == "meta/kernel.yaml" {
+			break
+		}
+
+		destPath := def[0]
+		if strings.HasPrefix(destPath, "dtbs/broadcom/") {
+			destPath = strings.TrimPrefix(destPath, "dtbs/broadcom/")
+		} else if strings.HasPrefix(destPath, "dtbs/") {
+			destPath = strings.TrimPrefix(destPath, "dtbs/")
+		}
+		fullFn := filepath.Join(kernelAssetsDir, destPath)
+		c.Check(fullFn, testutil.FileEquals, def[1])
+	}
+
+	// remove
+	err = p.RemoveKernelAssets(info)
+	c.Assert(err, IsNil)
+
+	c.Check(osutil.FileExists(kernelAssetsDir), Equals, false)
+}
+
+func (s *pibootTestSuite) TestExtractKernelAssetsOnRPi4CheckEeprom(c *C) {
+	// Rev code is RPi4, eeprom supports tryboot
+	expectFailure := false
+	s.testExtractKernelAssetsOnRPi4CheckEeprom(c,
+		[]byte{0x00, 0xc0, 0x31, 0x11},
+		[]byte{0x61, 0xf0, 0x09, 0x91},
+		expectFailure)
+	// Rev code is RPi4, eeprom does not support tryboot
+	expectFailure = true
+	s.testExtractKernelAssetsOnRPi4CheckEeprom(c,
+		[]byte{0x00, 0xc0, 0x31, 0x11},
+		[]byte{0x60, 0x53, 0x15, 0x32},
+		expectFailure)
+	// Rev code is RPi3
+	expectFailure = false
+	s.testExtractKernelAssetsOnRPi4CheckEeprom(c,
+		[]byte{0x00, 0xa0, 0x20, 0x82},
+		[]byte{},
+		expectFailure)
+}

--- a/bootloader/piboot_test.go
+++ b/bootloader/piboot_test.go
@@ -643,7 +643,7 @@ func (s *pibootTestSuite) testExtractKernelAssetsOnRPi4CheckEeprom(c *C, rpiRevi
 	err = p.ExtractKernelAssets(info, snapf)
 	if errExpected {
 		c.Check(err.Error(), Equals,
-			"your EEPROM does not support tryboot, please upgrade to a newer one before installing Ubuntu Core")
+			"your EEPROM does not support tryboot, please upgrade to a newer one before installing Ubuntu Core - see http://forum.snapcraft.io/t/29455 for more details")
 		return
 	}
 


### PR DESCRIPTION
Check EEPROM version for RPi4 to make sure that tryboot is
supported. If the EEPROM need updating, return an error when
installing the kernel.