### PR TITLE
overlord: add missing grub.cfg assets mocks in manager_tests.go

### DIFF
--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -51,6 +51,7 @@ import (
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/boot/boottest"
 	"github.com/snapcore/snapd/bootloader"
+	"github.com/snapcore/snapd/bootloader/assets"
 	"github.com/snapcore/snapd/bootloader/bootloadertest"
 	"github.com/snapcore/snapd/bootloader/grubenv"
 	"github.com/snapcore/snapd/client"
@@ -174,6 +175,11 @@ func (s *baseMgrsSuite) SetUpTest(c *C) {
 	s.AddCleanup(osutil.MockMountInfo(""))
 
 	s.AddCleanup(archtest.MockArchitecture("amd64"))
+	snippets := []assets.ForEditions{
+		{FirstEdition: 1, Snippet: []byte("console=ttyS0 console=tty1 panic=-1")},
+	}
+	s.AddCleanup(assets.MockSnippetsForEdition("grub.cfg:static-cmdline", snippets))
+	s.AddCleanup(assets.MockSnippetsForEdition("grub-recovery.cfg:static-cmdline", snippets))
 
 	err := os.MkdirAll(filepath.Dir(dirs.SnapStateFile), 0755)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
The current code will mock the `amd64` architecutre when running
the manager tests but it does not mock the `grub.cfg:static-cmdline`
or the `grub-recovery.cfg:static-cmdline`. This is needed because
the `bootloader/asserts` package registers the cmdline via `init()`
so this happens before the architecture is mocked in the
`manager_test.go` code. Hence the manager tests will fail when
inspecting the commandline on non amd64/i386 machines.

This commit makes the mocking explicit. An alternative approach
would be to move the snippet registration out of `init()` and
run it on first boot but that has it's own problems so I went
with this approach.

To test this needs to be run either on an arm system or one
needs to edit `assets/grub.cfg` and remove the arches there.
