### PR TITLE
many: fix failing golangci checks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -183,7 +183,8 @@ linters:
     # formatting is disabled until we move to Go 1.13
     # - gofmt
     - ineffassign
-    - gci
+    # disabling until https://github.com/daixiang0/gci/issues/54 is fixed
+    # - gci
     - testpackage
   # disable everything else
   disable-all: true

--- a/cmd/snap-preseed/preseed_classic_test.go
+++ b/cmd/snap-preseed/preseed_classic_test.go
@@ -20,11 +20,6 @@
 package main_test
 
 import (
-	"fmt"
-	"io/ioutil"
-	"os"
-	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/jessevdk/go-flags"
@@ -32,7 +27,6 @@ import (
 
 	"github.com/snapcore/snapd/cmd/snap-preseed"
 	"github.com/snapcore/snapd/dirs"
-	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/squashfs"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
@@ -62,26 +56,6 @@ func testParser(c *C) *flags.Parser {
 	_, err := parser.ParseArgs([]string{})
 	c.Assert(err, IsNil)
 	return parser
-}
-
-func mockVersionFiles(c *C, rootDir1, version1, rootDir2, version2 string) {
-	versions := []string{version1, version2}
-	for i, root := range []string{rootDir1, rootDir2} {
-		c.Assert(os.MkdirAll(filepath.Join(root, dirs.CoreLibExecDir), 0755), IsNil)
-		infoFile := filepath.Join(root, dirs.CoreLibExecDir, "info")
-		c.Assert(ioutil.WriteFile(infoFile, []byte(fmt.Sprintf("VERSION=%s", versions[i])), 0644), IsNil)
-	}
-}
-
-func mockChrootDirs(c *C, rootDir string, apparmorDir bool) func() {
-	if apparmorDir {
-		c.Assert(os.MkdirAll(filepath.Join(rootDir, "/sys/kernel/security/apparmor"), 0755), IsNil)
-	}
-	mockMountInfo := `912 920 0:57 / ${rootDir}/proc rw,nosuid,nodev,noexec,relatime - proc proc rw
-914 913 0:7 / ${rootDir}/sys/kernel/security rw,nosuid,nodev,noexec,relatime master:8 - securityfs securityfs rw
-915 920 0:58 / ${rootDir}/dev rw,relatime - tmpfs none rw,size=492k,mode=755,uid=100000,gid=100000
-`
-	return osutil.MockMountInfo(strings.Replace(mockMountInfo, "${rootDir}", rootDir, -1))
 }
 
 func (s *startPreseedSuite) TestRequiresRoot(c *C) {

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -27,7 +27,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -7787,27 +7786,6 @@ func (s *snapmgrTestSuite) TestUpdateMigrateTurnOffFlagAndRefreshToCore22ButFail
 
 	expected := &dirs.SnapDirOptions{HiddenSnapDataDir: true}
 	assertMigrationState(c, s.state, "snap-core18-to-core22", expected)
-}
-
-func mustMatch(c *C, haystack []string, needle string) {
-	c.Assert(someMatches(c, haystack, needle), Equals, true)
-}
-
-func mustNotMatch(c *C, haystack []string, needle string) {
-	c.Assert(someMatches(c, haystack, needle), Equals, false)
-}
-
-func someMatches(c *C, haystack []string, needle string) bool {
-	pattern, err := regexp.Compile(needle)
-	c.Assert(err, IsNil)
-
-	for _, s := range haystack {
-		if pattern.MatchString(s) {
-			return true
-		}
-	}
-
-	return false
 }
 
 // assertMigrationState checks the migration status in the state and sequence


### PR DESCRIPTION
Golangci is currently failing due to some unused code and a gci (https://github.com/daixiang0/gci/issues/54) issue.