### PR TITLE
boot,bootloader: add missing grub.cfg assets mocks in some tests

### DIFF
--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -63,6 +63,11 @@ func (s *makeBootableSuite) SetUpTest(c *C) {
 	s.forceBootloader(s.bootloader)
 
 	s.AddCleanup(archtest.MockArchitecture("amd64"))
+	snippets := []assets.ForEditions{
+		{FirstEdition: 1, Snippet: []byte("console=ttyS0 console=tty1 panic=-1")},
+	}
+	s.AddCleanup(assets.MockSnippetsForEdition("grub.cfg:static-cmdline", snippets))
+	s.AddCleanup(assets.MockSnippetsForEdition("grub-recovery.cfg:static-cmdline", snippets))
 }
 
 func makeSnap(c *C, name, yaml string, revno snap.Revision) (fn string, info *snap.Info) {
@@ -166,6 +171,11 @@ func (s *makeBootable20Suite) SetUpTest(c *C) {
 	s.bootloader = bootloadertest.Mock("mock", c.MkDir()).RecoveryAware()
 	s.forceBootloader(s.bootloader)
 	s.AddCleanup(archtest.MockArchitecture("amd64"))
+	snippets := []assets.ForEditions{
+		{FirstEdition: 1, Snippet: []byte("console=ttyS0 console=tty1 panic=-1")},
+	}
+	s.AddCleanup(assets.MockSnippetsForEdition("grub.cfg:static-cmdline", snippets))
+	s.AddCleanup(assets.MockSnippetsForEdition("grub-recovery.cfg:static-cmdline", snippets))
 }
 
 func (s *makeBootable20UbootSuite) SetUpTest(c *C) {

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/boot/boottest"
 	"github.com/snapcore/snapd/bootloader"
+	"github.com/snapcore/snapd/bootloader/assets"
 	"github.com/snapcore/snapd/bootloader/bootloadertest"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/kernel/fde"
@@ -59,6 +60,11 @@ func (s *sealSuite) SetUpTest(c *C) {
 	dirs.SetRootDir(rootdir)
 	s.AddCleanup(func() { dirs.SetRootDir("/") })
 	s.AddCleanup(archtest.MockArchitecture("amd64"))
+	snippets := []assets.ForEditions{
+		{FirstEdition: 1, Snippet: []byte("console=ttyS0 console=tty1 panic=-1")},
+	}
+	s.AddCleanup(assets.MockSnippetsForEdition("grub.cfg:static-cmdline", snippets))
+	s.AddCleanup(assets.MockSnippetsForEdition("grub-recovery.cfg:static-cmdline", snippets))
 }
 
 func mockKernelSeedSnap(rev snap.Revision) *seed.Snap {

--- a/bootloader/assets/grub_test.go
+++ b/bootloader/assets/grub_test.go
@@ -47,6 +47,11 @@ func (s *grubAssetsTestSuite) SetUpTest(c *C) {
 	// By default assume amd64 in the tests: there are specialized
 	// tests for other arches
 	s.AddCleanup(archtest.MockArchitecture("amd64"))
+	snippets := []assets.ForEditions{
+		{FirstEdition: 1, Snippet: []byte("console=ttyS0 console=tty1 panic=-1")},
+	}
+	s.AddCleanup(assets.MockSnippetsForEdition("grub.cfg:static-cmdline", snippets))
+	s.AddCleanup(assets.MockSnippetsForEdition("grub-recovery.cfg:static-cmdline", snippets))
 }
 
 func (s *grubAssetsTestSuite) testGrubConfigContains(c *C, name string, keys ...string) {

--- a/bootloader/grub_test.go
+++ b/bootloader/grub_test.go
@@ -57,6 +57,11 @@ func (s *grubTestSuite) SetUpTest(c *C) {
 	// By default assume amd64 in the tests: there are specialized
 	// tests for other arches
 	s.AddCleanup(archtest.MockArchitecture("amd64"))
+	snippets := []assets.ForEditions{
+		{FirstEdition: 1, Snippet: []byte("console=ttyS0 console=tty1 panic=-1")},
+	}
+	s.AddCleanup(assets.MockSnippetsForEdition("grub.cfg:static-cmdline", snippets))
+	s.AddCleanup(assets.MockSnippetsForEdition("grub-recovery.cfg:static-cmdline", snippets))
 }
 
 // grubEditenvCmd finds the right grub{,2}-editenv command


### PR DESCRIPTION
This is the same fix as commit 17fbdc7c, but in other tests.

The current code will mock the `amd64` architecture when running some
tests but it does not mock the `grub.cfg:static-cmdline` or the
`grub-recovery.cfg:static-cmdline`. This is needed because the
`bootloader/asserts` package registers the cmdline via `init()` so
this happens before the architecture is mocked in the testing
code. Hence the tests will fail when inspecting the command line on
non amd64/i386 machines.

This commit makes the mocking explicit. An alternative approach would
be to move the snippet registration out of `init()` and run it on
first boot but that has it's own problems so this other approach was
followed.
