### PR TITLE
interfaces/hardware_observe: add read access for various devices

### DIFF
--- a/interfaces/builtin/hardware_observe.go
+++ b/interfaces/builtin/hardware_observe.go
@@ -100,6 +100,12 @@ network netlink raw,
 /sys/kernel/debug/usb/devices r,
 @{PROC}/sys/abi/{,*} r,
 
+# hwinfo --short
+@{PROC}/ioports r,
+@{PROC}/dma r,
+@{PROC}/tty/driver/serial r,
+@{PROC}/sys/dev/cdrom/info r,
+
 # status of hugepages and transparent_hugepage, but not the pages themselves
 /sys/kernel/mm/{hugepages,transparent_hugepage}/{,**} r,
 


### PR DESCRIPTION
Add read access for various device info required by hwinfo utility not covered by existing policy

We are using the hwinfo utility on our Ubuntu Core devices, and to ensure functionality and reduce audit logs it would be great to get this extra policy added.

https://github.com/openSUSE/hwinfo