### PR TITLE
packaging/ubuntu-16.04/control: recommend `fuse3 | fuse`

### DIFF
--- a/packaging/ubuntu-16.04/control
+++ b/packaging/ubuntu-16.04/control
@@ -65,7 +65,6 @@ Architecture: any
 Depends: adduser,
          apparmor (>= 2.10.95-0ubuntu2.2),
          ca-certificates,
-         fuse3 (>= 3.10.5-1) | fuse,
          openssh-client,
          squashfs-tools,
          systemd,
@@ -75,7 +74,8 @@ Depends: adduser,
          ${dbussession:Depends}
 Replaces: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9), snap-confine (<< 2.23), ubuntu-core-launcher (<< 2.22), snapd-xdg-open (<= 0.0.0)
 Breaks: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9), snap-confine (<< 2.23), ubuntu-core-launcher (<< 2.22), snapd-xdg-open (<= 0.0.0), ${snapd:Breaks}
-Recommends: gnupg
+Recommends: gnupg,
+            fuse3 (>= 3.10.5-1) | fuse
 Suggests: zenity | kdialog
 Conflicts: snap (<< 2013-11-29-1ubuntu1)
 Built-Using: ${Built-Using} ${misc:Built-Using}


### PR DESCRIPTION
This is a followup for https://github.com/snapcore/snapd/pull/11600.

Instead of a hard dependency on fuse3/fuse it's enough to have
a recommends because fuse is not strictly needed to run snapd.
It is just needed inside lxd.
