### PR TITLE
interfaces/builtin: update apparmor profile to allow creating mimic over /usr/share

### DIFF
--- a/interfaces/builtin/system_packages_doc.go
+++ b/interfaces/builtin/system_packages_doc.go
@@ -57,6 +57,9 @@ func (iface *systemPackagesDocInterface) AppArmorConnectedPlug(spec *apparmor.Sp
 	emit("  mount options=(bind) /var/lib/snapd/hostfs/usr/share/libreoffice/help/ -> /usr/share/libreoffice/help/,\n")
 	emit("  remount options=(bind, ro) /usr/share/libreoffice/help/,\n")
 	emit("  umount /usr/share/libreoffice/help/,\n")
+	// /usr/share/libreoffice may not exist, set up apparmor profile for
+	// creating a mimir, assuming that at least /usr/share exists
+	apparmor.GenWritableProfile(emit, "/usr/share/libreoffice/help", 3)
 	return nil
 }
 

--- a/interfaces/builtin/system_packages_doc.go
+++ b/interfaces/builtin/system_packages_doc.go
@@ -58,7 +58,7 @@ func (iface *systemPackagesDocInterface) AppArmorConnectedPlug(spec *apparmor.Sp
 	emit("  remount options=(bind, ro) /usr/share/libreoffice/help/,\n")
 	emit("  umount /usr/share/libreoffice/help/,\n")
 	// /usr/share/libreoffice may not exist, set up apparmor profile for
-	// creating a mimir, assuming that at least /usr/share exists
+	// creating a mimic, assuming that at least /usr/share exists
 	apparmor.GenWritableProfile(emit, "/usr/share/libreoffice/help", 3)
 	return nil
 }

--- a/interfaces/builtin/system_packages_doc_test.go
+++ b/interfaces/builtin/system_packages_doc_test.go
@@ -96,6 +96,13 @@ func (s *systemPackagesDocSuite) TestAppArmorSpec(c *C) {
 	c.Check(updateNS, testutil.Contains, "  mount options=(bind) /var/lib/snapd/hostfs/usr/share/libreoffice/help/ -> /usr/share/libreoffice/help/,\n")
 	c.Check(updateNS, testutil.Contains, "  remount options=(bind, ro) /usr/share/libreoffice/help/,\n")
 	c.Check(updateNS, testutil.Contains, "  umount /usr/share/libreoffice/help/,\n")
+
+	// check mimic bits
+	c.Check(updateNS, testutil.Contains, "  # Writable mimic /usr/share/libreoffice\n")
+	c.Check(updateNS, testutil.Contains, "  mount fstype=tmpfs options=(rw) tmpfs -> \"/usr/share/\",\n")
+	c.Check(updateNS, testutil.Contains, "  \"/usr/share/\" r,\n")
+	c.Check(updateNS, testutil.Contains, "  \"/tmp/.snap/usr/share/\" rw,\n")
+	c.Check(updateNS, testutil.Contains, "  mount options=(bind, rw) \"/tmp/.snap/usr/share/*\" -> \"/usr/share/*\",\n")
 }
 
 func (s *systemPackagesDocSuite) TestMountSpec(c *C) {

--- a/tests/main/interfaces-system-packages-doc/task.yaml
+++ b/tests/main/interfaces-system-packages-doc/task.yaml
@@ -7,6 +7,8 @@ prepare: |
     snap install --dangerous ./test-snapd-app_1_all.snap
     mkdir -p /usr/share/doc/system-packages-doc-iface
     echo text >/usr/share/doc/system-packages-doc-iface/content
+    mkdir -p /usr/share/libreoffice/help
+    echo text >/usr/share/libreoffice/help/content
 
 restore: |
     snap remove --purge test-snapd-app
@@ -20,7 +22,9 @@ execute: |
     # The interface works as expected
     snap connect test-snapd-app:system-packages-doc
     test-snapd-app.sh -c 'cat /usr/share/doc/system-packages-doc-iface/content' | MATCH text
+    test-snapd-app.sh -c 'cat /usr/share/libreoffice/help/content' | MATCH text
 
     # The interface can be disconnected
     snap disconnect test-snapd-app:system-packages-doc
     not test-snapd-app.sh -c 'test -e /usr/share/doc/system-packages-doc-iface/content'
+    not test-snapd-app.sh -c 'test -e /usr/share/libreoffice/help/content'


### PR DESCRIPTION
Extend the AppArmor profile snippets for this interface by adding entries that
allow creating a writable mimic over /usr/share and further down.