### PR TITLE
interfaces/cpu-control: fix apparmor rules of paths with CPU ID

### DIFF
--- a/interfaces/builtin/cpu_control.go
+++ b/interfaces/builtin/cpu_control.go
@@ -38,15 +38,15 @@ const cpuControlConnectedPlugAppArmor = `
 
 /sys/module/cpu_boost/parameters/input_boost_freq rw,
 /sys/module/cpu_boost/parameters/input_boost_ms rw,
-/sys/devices/system/cpu/cpu[0-9][0-9]*/cpufreq/scaling_min_freq rw,
-/sys/devices/system/cpu/cpu[0-9][0-9]*/cpufreq/scaling_max_freq rw,
-/sys/devices/system/cpu/cpu[0-9][0-9]*/core_ctl/min_cpus rw,
-/sys/devices/system/cpu/cpu[0-9][0-9]*/core_ctl/busy_up_thres rw,
-/sys/devices/system/cpu/cpu[0-9][0-9]*/core_ctl/busy_down_thres rw,
-/sys/devices/system/cpu/cpu[0-9][0-9]*/core_ctl/offline_delay_ms rw,
-/sys/devices/system/cpu/cpu[0-9][0-9]*/core_ctl/task_thres rw,
-/sys/devices/system/cpu/cpu[0-9][0-9]*/core_ctl/nr_prev_assist_thresh rw,
-/sys/devices/system/cpu/cpu[0-9][0-9]*/core_ctl/enable rw,
+/sys/devices/system/cpu/cpu[0-9]*/cpufreq/scaling_min_freq rw,
+/sys/devices/system/cpu/cpu[0-9]*/cpufreq/scaling_max_freq rw,
+/sys/devices/system/cpu/cpu[0-9]*/core_ctl/min_cpus rw,
+/sys/devices/system/cpu/cpu[0-9]*/core_ctl/busy_up_thres rw,
+/sys/devices/system/cpu/cpu[0-9]*/core_ctl/busy_down_thres rw,
+/sys/devices/system/cpu/cpu[0-9]*/core_ctl/offline_delay_ms rw,
+/sys/devices/system/cpu/cpu[0-9]*/core_ctl/task_thres rw,
+/sys/devices/system/cpu/cpu[0-9]*/core_ctl/nr_prev_assist_thresh rw,
+/sys/devices/system/cpu/cpu[0-9]*/core_ctl/enable rw,
 
 # https://www.kernel.org/doc/html/latest/admin-guide/pm/cpufreq.html#policy-interface-in-sysfs
 /sys/devices/system/cpu/cpufreq/{,**} r,
@@ -77,8 +77,8 @@ const cpuControlConnectedPlugAppArmor = `
 /proc/sys/kernel/sched_boost rw,
 
 # see https://www.osadl.org/monitoring/add-on-patches/4.16.7-rt1...4.16.15-rt7/sched-add-per-cpu-load-measurement.patch.html
-/proc/idleruntime/{all,cpu[0-9][0-9]*}/data r,
-/proc/idleruntime/{all,cpu[0-9][0-9]*}/reset w,
+/proc/idleruntime/{all,cpu[0-9]*}/data r,
+/proc/idleruntime/{all,cpu[0-9]*}/reset w,
 `
 
 func init() {


### PR DESCRIPTION
With the original rules, the paths in "/sys/devices/system/cpu/cpuX" are
not writable. AppArmor shows error messages, for instance:
```
audit: type=1400 audit(1649300989.268:103): apparmor="DENIED" operation="open" profile="snap.my-snap.init" name="/sys/devices/system/cpu/cpu4/core_ctl/min_cpus" pid=4702 comm="bash" requested_mask="wc" denied_mask="wc" fsuid=0 ouid=0
```

According to the AppArmor Core Policy Reference[1], the globbing syntax
is not correct.
> `*` - match zero or more characters at the directory level. When looking at the path as a string this will match every character except /

So, the following rule mean the CPU ID should be from cpu00* to cpu99*
```
/sys/devices/system/cpu/cpu[0-9][0-9]*/core_ctl/min_cpus rw
```

This patch change the path to be from cpu0* to cpu9*.

[1] https://gitlab.com/apparmor/apparmor/-/wikis/AppArmor_Core_Policy_Reference#apparmor-globbing-syntax
