### PR TITLE
interfaces: add max_map_count to system-observe

### DIFF
--- a/interfaces/builtin/system_observe.go
+++ b/interfaces/builtin/system_observe.go
@@ -60,6 +60,7 @@ ptrace (read),
 @{PROC}/partitions r,
 @{PROC}/sys/kernel/panic r,
 @{PROC}/sys/kernel/panic_on_oops r,
+@{PROC}/sys/vm/max_map_count r,
 @{PROC}/sys/vm/panic_on_oom r,
 
 # These are not process-specific (/proc/*/... and /proc/*/task/*/...)


### PR DESCRIPTION
OpenSearch Snap needs to access /proc/sys/vm/max_map_count and this
has a good fit with the system-observe interface.

For better context, please look at this [link](https://forum.snapcraft.io/t/manual-review-for-opensearch-auto-connect-request-for-mount-observe-and-system-files/29475)
