### PR TITLE
tests: disable netplan-cfg test

### DIFF
--- a/tests/nested/manual/core20-early-config/task.yaml
+++ b/tests/nested/manual/core20-early-config/task.yaml
@@ -2,6 +2,7 @@ summary: Test that gadget config defaults are applied early on core20.
 
 systems: [ubuntu-20.04-64]
 
+# TODO: revert this once the issue https://bugs.launchpad.net/ubuntu/+source/netplan.io/+bug/1967084 is fixed
 manual: true
 
 environment:

--- a/tests/nested/manual/core20-early-config/task.yaml
+++ b/tests/nested/manual/core20-early-config/task.yaml
@@ -2,6 +2,8 @@ summary: Test that gadget config defaults are applied early on core20.
 
 systems: [ubuntu-20.04-64]
 
+manual: true
+
 environment:
     NESTED_IMAGE_ID: core20-early-config
     NESTED_ENABLE_TPM: true


### PR DESCRIPTION
This test is failing in uc20 master branch

It fails when doing:
snap set system system.network.netplan.network.bridges.br54.dhcp4=true
with error:
Could not set hostname: Permission denied
