### PR TITLE
tests: do not run mount-order-regression test on i386

### DIFF
--- a/tests/regression/mount-order-regression/task.yaml
+++ b/tests/regression/mount-order-regression/task.yaml
@@ -5,6 +5,10 @@ details: |
     We check that a typical GNOME snap using the content interface and layouts
     has its filesystem laid out as expected.
 
+systems:
+  # there is no gnome-3-38-2004 for i386
+  - -ubuntu-18.04-32
+
 environment:
     SNAP_NAME: test-content-layout-consumer
 


### PR DESCRIPTION
This test requires the `gnome-3-38-2004` snap but this snap is
not available for i386. So the test always fails right now.

This commit excludes it on i386.
