### PR TITLE
o/snapstate: print pids of running processes on BusySnapError

### DIFF
--- a/overlord/snapstate/autorefresh_test.go
+++ b/overlord/snapstate/autorefresh_test.go
@@ -916,9 +916,9 @@ func (s *autoRefreshTestSuite) TestInitialInhibitRefreshWithinInhibitWindow(c *C
 		Current:  si.Revision,
 	}
 	err := snapstate.InhibitRefresh(s.state, snapst, info, func(si *snap.Info) error {
-		return &snapstate.BusySnapError{SnapInfo: si}
+		return snapstate.NewBusySnapError(si, []int{123}, nil, nil)
 	})
-	c.Assert(err, ErrorMatches, `snap "pkg" has running apps or hooks`)
+	c.Assert(err, ErrorMatches, `snap "pkg" has running apps or hooks, pids: 123`)
 	c.Check(notificationCount, Equals, 1)
 }
 
@@ -948,9 +948,9 @@ func (s *autoRefreshTestSuite) TestSubsequentInhibitRefreshWithinInhibitWindow(c
 	}
 
 	err := snapstate.InhibitRefresh(s.state, snapst, info, func(si *snap.Info) error {
-		return &snapstate.BusySnapError{SnapInfo: si}
+		return snapstate.NewBusySnapError(si, []int{123}, nil, nil)
 	})
-	c.Assert(err, ErrorMatches, `snap "pkg" has running apps or hooks`)
+	c.Assert(err, ErrorMatches, `snap "pkg" has running apps or hooks, pids: 123`)
 	c.Check(notificationCount, Equals, 1)
 }
 

--- a/overlord/snapstate/handlers_link_test.go
+++ b/overlord/snapstate/handlers_link_test.go
@@ -1822,7 +1822,7 @@ func (s *linkSnapSuite) TestDoUnlinkSnapRefreshAwarenessHardCheckOn(c *C) {
 
 	chg := s.testDoUnlinkSnapRefreshAwareness(c)
 
-	c.Check(chg.Err(), ErrorMatches, `(?ms).*^- some-change-descr \(snap "some-snap" has running apps \(some-app\)\).*`)
+	c.Check(chg.Err(), ErrorMatches, `(?ms).*^- some-change-descr \(snap "some-snap" has running apps \(some-app\), pids: 1234\).*`)
 }
 
 func (s *linkSnapSuite) TestDoUnlinkSnapRefreshHardCheckOff(c *C) {

--- a/overlord/snapstate/refresh.go
+++ b/overlord/snapstate/refresh.go
@@ -156,18 +156,22 @@ func (err *BusySnapError) PendingSnapRefreshInfo() *userclient.PendingSnapRefres
 
 // Error formats an error string describing what is running.
 func (err *BusySnapError) Error() string {
+	pids := make([]string, 0, len(err.pids))
+	for _, p := range err.pids {
+		pids = append(pids, fmt.Sprintf("%d", p))
+	}
 	switch {
 	case len(err.busyAppNames) > 0 && len(err.busyHookNames) > 0:
-		return fmt.Sprintf("snap %q has running apps (%s) and hooks (%s)",
-			err.SnapInfo.InstanceName(), strings.Join(err.busyAppNames, ", "), strings.Join(err.busyHookNames, ", "))
+		return fmt.Sprintf("snap %q has running apps (%s) and hooks (%s), pids: %s",
+			err.SnapInfo.InstanceName(), strings.Join(err.busyAppNames, ", "), strings.Join(err.busyHookNames, ", "), strings.Join(pids, ", "))
 	case len(err.busyAppNames) > 0:
-		return fmt.Sprintf("snap %q has running apps (%s)",
-			err.SnapInfo.InstanceName(), strings.Join(err.busyAppNames, ", "))
+		return fmt.Sprintf("snap %q has running apps (%s), pids: %s",
+			err.SnapInfo.InstanceName(), strings.Join(err.busyAppNames, ", "), strings.Join(pids, ", "))
 	case len(err.busyHookNames) > 0:
-		return fmt.Sprintf("snap %q has running hooks (%s)",
-			err.SnapInfo.InstanceName(), strings.Join(err.busyHookNames, ", "))
+		return fmt.Sprintf("snap %q has running hooks (%s), pids: %s",
+			err.SnapInfo.InstanceName(), strings.Join(err.busyHookNames, ", "), strings.Join(pids, ", "))
 	default:
-		return fmt.Sprintf("snap %q has running apps or hooks", err.SnapInfo.InstanceName())
+		return fmt.Sprintf("snap %q has running apps or hooks, pids: %s", err.SnapInfo.InstanceName(), strings.Join(pids, ", "))
 	}
 }
 

--- a/overlord/snapstate/refresh.go
+++ b/overlord/snapstate/refresh.go
@@ -31,6 +31,7 @@ import (
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/sandbox/cgroup"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/strutil"
 	userclient "github.com/snapcore/snapd/usersession/client"
 )
 
@@ -156,22 +157,19 @@ func (err *BusySnapError) PendingSnapRefreshInfo() *userclient.PendingSnapRefres
 
 // Error formats an error string describing what is running.
 func (err *BusySnapError) Error() string {
-	pids := make([]string, 0, len(err.pids))
-	for _, p := range err.pids {
-		pids = append(pids, fmt.Sprintf("%d", p))
-	}
+	pids := strutil.IntsToCommaSeparated(err.pids)
 	switch {
 	case len(err.busyAppNames) > 0 && len(err.busyHookNames) > 0:
 		return fmt.Sprintf("snap %q has running apps (%s) and hooks (%s), pids: %s",
-			err.SnapInfo.InstanceName(), strings.Join(err.busyAppNames, ", "), strings.Join(err.busyHookNames, ", "), strings.Join(pids, ", "))
+			err.SnapInfo.InstanceName(), strings.Join(err.busyAppNames, ", "), strings.Join(err.busyHookNames, ", "), pids)
 	case len(err.busyAppNames) > 0:
 		return fmt.Sprintf("snap %q has running apps (%s), pids: %s",
-			err.SnapInfo.InstanceName(), strings.Join(err.busyAppNames, ", "), strings.Join(pids, ", "))
+			err.SnapInfo.InstanceName(), strings.Join(err.busyAppNames, ", "), pids)
 	case len(err.busyHookNames) > 0:
 		return fmt.Sprintf("snap %q has running hooks (%s), pids: %s",
-			err.SnapInfo.InstanceName(), strings.Join(err.busyHookNames, ", "), strings.Join(pids, ", "))
+			err.SnapInfo.InstanceName(), strings.Join(err.busyHookNames, ", "), pids)
 	default:
-		return fmt.Sprintf("snap %q has running apps or hooks, pids: %s", err.SnapInfo.InstanceName(), strings.Join(pids, ", "))
+		return fmt.Sprintf("snap %q has running apps or hooks, pids: %s", err.SnapInfo.InstanceName(), pids)
 	}
 }
 

--- a/overlord/snapstate/refresh_test.go
+++ b/overlord/snapstate/refresh_test.go
@@ -87,7 +87,7 @@ func (s *refreshSuite) TestSoftNothingRunningRefreshCheck(c *C) {
 	}
 	err = snapstate.SoftNothingRunningRefreshCheck(s.info)
 	c.Assert(err, NotNil)
-	c.Check(err.Error(), Equals, `snap "pkg" has running apps (app)`)
+	c.Check(err.Error(), Equals, `snap "pkg" has running apps (app), pids: 101`)
 	c.Check(err.(*snapstate.BusySnapError).Pids(), DeepEquals, []int{101})
 
 	// Hooks behave just like apps. IDEA: perhaps hooks should not be
@@ -97,7 +97,7 @@ func (s *refreshSuite) TestSoftNothingRunningRefreshCheck(c *C) {
 	}
 	err = snapstate.SoftNothingRunningRefreshCheck(s.info)
 	c.Assert(err, NotNil)
-	c.Check(err.Error(), Equals, `snap "pkg" has running hooks (configure)`)
+	c.Check(err.Error(), Equals, `snap "pkg" has running hooks (configure), pids: 105`)
 	c.Check(err.(*snapstate.BusySnapError).Pids(), DeepEquals, []int{105})
 
 	// Both apps and hooks can be running.
@@ -107,7 +107,7 @@ func (s *refreshSuite) TestSoftNothingRunningRefreshCheck(c *C) {
 	}
 	err = snapstate.SoftNothingRunningRefreshCheck(s.info)
 	c.Assert(err, NotNil)
-	c.Check(err.Error(), Equals, `snap "pkg" has running apps (app) and hooks (configure)`)
+	c.Check(err.Error(), Equals, `snap "pkg" has running apps (app) and hooks (configure), pids: 105, 106`)
 	c.Check(err.(*snapstate.BusySnapError).Pids(), DeepEquals, []int{105, 106})
 }
 
@@ -119,7 +119,7 @@ func (s *refreshSuite) TestHardNothingRunningRefreshCheck(c *C) {
 	}
 	err := snapstate.HardNothingRunningRefreshCheck(s.info)
 	c.Assert(err, NotNil)
-	c.Check(err.Error(), Equals, `snap "pkg" has running apps (daemon)`)
+	c.Check(err.Error(), Equals, `snap "pkg" has running apps (daemon), pids: 100`)
 	c.Check(err.(*snapstate.BusySnapError).Pids(), DeepEquals, []int{100})
 
 	// When the service is supposed to endure refreshes it will not be
@@ -135,7 +135,7 @@ func (s *refreshSuite) TestHardNothingRunningRefreshCheck(c *C) {
 	}
 	err = snapstate.HardNothingRunningRefreshCheck(s.info)
 	c.Assert(err, NotNil)
-	c.Check(err.Error(), Equals, `snap "pkg" has running apps (app)`)
+	c.Check(err.Error(), Equals, `snap "pkg" has running apps (app), pids: 101`)
 	c.Assert(err, FitsTypeOf, &snapstate.BusySnapError{})
 	c.Check(err.(*snapstate.BusySnapError).Pids(), DeepEquals, []int{101})
 
@@ -145,7 +145,7 @@ func (s *refreshSuite) TestHardNothingRunningRefreshCheck(c *C) {
 	}
 	err = snapstate.HardNothingRunningRefreshCheck(s.info)
 	c.Assert(err, NotNil)
-	c.Check(err.Error(), Equals, `snap "pkg" has running hooks (configure)`)
+	c.Check(err.Error(), Equals, `snap "pkg" has running hooks (configure), pids: 105`)
 	c.Check(err.(*snapstate.BusySnapError).Pids(), DeepEquals, []int{105})
 }
 
@@ -218,13 +218,13 @@ func (s *refreshSuite) TestDoSoftRefreshCheckDisallowed(c *C) {
 
 	// Pretend that snaps cannot refresh.
 	restore := snapstate.MockGenericRefreshCheck(func(info *snap.Info, canAppRunDuringRefresh func(app *snap.AppInfo) bool) error {
-		return &snapstate.BusySnapError{SnapInfo: info}
+		return snapstate.NewBusySnapError(info, []int{123}, nil, nil)
 	})
 	defer restore()
 
 	// Soft refresh should fail with a proper error.
 	err := snapstate.SoftCheckNothingRunningForRefresh(s.state, snapst, info)
-	c.Assert(err, ErrorMatches, `snap "pkg" has running apps or hooks`)
+	c.Assert(err, ErrorMatches, `snap "pkg" has running apps or hooks, pids: 123`)
 
 	// Validity check: the inhibition lock was not set.
 	hint, err := runinhibit.IsLocked(info.InstanceName())
@@ -269,13 +269,13 @@ func (s *refreshSuite) TestDoHardRefreshFlowRefreshDisallowed(c *C) {
 
 	// Pretend that snaps cannot refresh.
 	restore := snapstate.MockGenericRefreshCheck(func(info *snap.Info, canAppRunDuringRefresh func(app *snap.AppInfo) bool) error {
-		return &snapstate.BusySnapError{SnapInfo: info}
+		return snapstate.NewBusySnapError(info, []int{123}, nil, nil)
 	})
 	defer restore()
 
 	// Hard refresh should fail and not return a lock.
 	lock, err := snapstate.HardEnsureNothingRunningDuringRefresh(backend, s.state, snapst, info)
-	c.Assert(err, ErrorMatches, `snap "pkg" has running apps or hooks`)
+	c.Assert(err, ErrorMatches, `snap "pkg" has running apps or hooks, pids: 123`)
 	c.Assert(lock, IsNil)
 
 	// Validity check: the inhibition lock was not set.

--- a/overlord/snapstate/refresh_test.go
+++ b/overlord/snapstate/refresh_test.go
@@ -107,7 +107,7 @@ func (s *refreshSuite) TestSoftNothingRunningRefreshCheck(c *C) {
 	}
 	err = snapstate.SoftNothingRunningRefreshCheck(s.info)
 	c.Assert(err, NotNil)
-	c.Check(err.Error(), Equals, `snap "pkg" has running apps (app) and hooks (configure), pids: 105, 106`)
+	c.Check(err.Error(), Equals, `snap "pkg" has running apps (app) and hooks (configure), pids: 105,106`)
 	c.Check(err.(*snapstate.BusySnapError).Pids(), DeepEquals, []int{105, 106})
 }
 

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -420,7 +420,7 @@ func (s *snapmgrTestSuite) TestInstallFailsOnBusySnap(c *C) {
 
 	// And observe that we cannot refresh because the snap is busy.
 	_, err := snapstate.DoInstall(s.state, snapst, snapsup, 0, "", dummyInUseCheck)
-	c.Assert(err, ErrorMatches, `snap "some-snap" has running apps \(app\)`)
+	c.Assert(err, ErrorMatches, `snap "some-snap" has running apps \(app\), pids: 1234`)
 
 	// The state records the time of the failed refresh operation.
 	err = snapstate.Get(s.state, "some-snap", snapst)

--- a/tests/main/refresh-app-awareness/task.yaml
+++ b/tests/main/refresh-app-awareness/task.yaml
@@ -84,7 +84,7 @@ execute: |
             not snap install --dangerous test-snapd-refresh_2_all.snap >install.log 2>&1
             ;;
     esac
-    unwrap_msg < install.log | MATCH 'error: cannot install snap file: snap "test-snapd-refresh" has running apps +\(sh\)'
+    unwrap_msg < install.log | MATCH 'error: cannot install snap file: snap "test-snapd-refresh" has running apps +\(sh\), pids: [0-9]+'
     test-snapd-refresh.version | MATCH v1
 
     # Kill the app process running from v1.


### PR DESCRIPTION
Print pids of running processes when BusySnapError is encountered with refresh-app-awareness.