### PR TITLE
tests: add new "core22-migrate-dirs" test

### DIFF
--- a/tests/main/core22-migrate-dirs/task.yaml
+++ b/tests/main/core22-migrate-dirs/task.yaml
@@ -1,0 +1,38 @@
+summary: Check that migrating from core20->core22 works
+
+# this test is flaky on CentOS and openSUSE due to an issue w/ 'snap remove'
+# https://bugs.launchpad.net/snapd/+bug/1959036
+systems: [-centos-*, -opensuse-*]
+
+environment:
+    NAME: test-snapd-tools
+
+execute: |
+    # core22 snap isn't available for x86
+    if os.query is-pc-i386; then
+      exit 0
+    fi
+
+    echo "Install core20 snap"
+    snap_path_20=$("$TESTSTOOLS"/snaps-state pack-local "$NAME")
+    snap install --dangerous "$snap_path_20"
+    # trigger "snap run" so that we have a dir in /root/snap/test-snapd-tools
+    test-snapd-tools.echo foo
+
+    echo "Update snap to core22"
+    snap install --edge core22
+    cp -rf "$TESTSLIB/snaps/$NAME" "$PWD/$NAME"
+    echo -e "\nbase: core22" >> "$PWD/$NAME/meta/snap.yaml"
+    snap_path_22="${NAME}"_22.0_all.snap
+    snap pack --filename="$snap_path_22" "$PWD/$NAME"
+    snap install --dangerous "$snap_path_22"
+    test-snapd-tools.echo foo
+
+    echo "And remove it again"
+    snap remove --purge "$NAME"
+    echo "And install both again and see that it works"
+    snap install --dangerous "$snap_path_20"
+    test-snapd-tools.echo foo
+    snap install --dangerous "$snap_path_22"
+    test-snapd-tools.echo foo
+


### PR DESCRIPTION
This is a testcase for a bug that Alfonso found. If one installs
a snap and then refreshes that snap to core22 the hidden dirs
migration will happen. But when the snap is then purged and
the same steps are done again some dirs in the users home
already exit and that makes the current code fail:
```
And install both again
+ snap install --dangerous /home/gopath/src/github.com/snapcore/snapd/tests/lib/snaps/test-snapd-tools/test-snapd-tools_1.0_all.snap
test-snapd-tools 1.0 installed
+ test-snapd-tools.echo foo
foo
+ snap install --dangerous test-snapd-tools_22.0_all.snap
error: cannot perform the following tasks:
- Copy snap "test-snapd-tools" data (cannot move "/root/snap/test-snapd-tools" to "/root/.snap/data/test-snapd-tools": rename /root/snap/test-snapd-tools /root/.snap/data/test-snapd-tools: file exists)
```

This commit contains the a spread test for this.
