### PR TITLE
i/b/custom_device: fix generation of udev rules

### DIFF
--- a/interfaces/builtin/custom_device.go
+++ b/interfaces/builtin/custom_device.go
@@ -405,7 +405,7 @@ func (iface *customDeviceInterface) UDevConnectedPlug(spec *udev.Specification, 
 
 	// Now write all the rules
 	for _, rule := range deviceRules {
-		spec.AddSnippet(rule)
+		spec.TagDevice(rule)
 	}
 
 	return nil

--- a/interfaces/builtin/custom_device_test.go
+++ b/interfaces/builtin/custom_device_test.go
@@ -467,28 +467,47 @@ apps:
 	}
 
 	for _, testData := range data {
+		testLabel := Commentf("yaml: %s", testData.slotYaml)
 		spec := &udev.Specification{}
 		snapYaml := fmt.Sprintf(slotYamlTemplate, testData.slotYaml)
 		slot, _ := MockConnectedSlot(c, snapYaml, nil, "hwdev")
 		c.Assert(spec.AddConnectedPlug(s.iface, s.plug, slot), IsNil)
 		snippets := spec.Snippets()
 
+		// The first lines are for the tagging, the last one is for the
+		// snap-device-helper
+		rulesCount := len(testData.expectedRules)
+		c.Assert(snippets, HasLen, rulesCount+1)
+
 		// The following rule is not fixed since the order of the elements depend
 		// on the map iteration order, which in golang is not deterministic.
 		// Therefore, we decompose each rule into a map:
 		var decomposedSnippets []map[string]string
-		for _, snippet := range snippets {
-			ruleTags := strings.Split(snippet, ", ")
+		for _, snippet := range snippets[:rulesCount] {
+			lines := strings.Split(snippet, "\n")
+			c.Assert(lines, HasLen, 2, testLabel)
+
+			// The first line is just a comment
+			c.Check(lines[0], Matches, "^#.*", testLabel)
+
+			// The second line contains the actual rule
+			ruleTags := strings.Split(lines[1], ", ")
+			// Verify that the last part is the tag assignment
+			lastElement := len(ruleTags) - 1
+			c.Check(ruleTags[lastElement], Equals, `TAG+="snap_consumer_app"`)
 			decomposedTags := make(map[string]string)
-			for _, ruleTag := range ruleTags {
+			for _, ruleTag := range ruleTags[:lastElement] {
 				tagMembers := strings.SplitN(ruleTag, "==", 2)
 				c.Assert(tagMembers, HasLen, 2)
 				decomposedTags[tagMembers[0]] = tagMembers[1]
 			}
 			decomposedSnippets = append(decomposedSnippets, decomposedTags)
 		}
-		c.Assert(decomposedSnippets, testutil.DeepUnsortedMatches, testData.expectedRules,
-			Commentf("yaml: %s", testData.slotYaml))
+		c.Assert(decomposedSnippets, testutil.DeepUnsortedMatches, testData.expectedRules, testLabel)
+
+		// The last line of the snippet is about snap-device-helper
+		actionLine := snippets[rulesCount]
+		c.Assert(actionLine, Matches, `^TAG=="snap_consumer_app", RUN\+="/usr/lib/snapd/snap-device-helper .*`, testLabel)
 	}
 }
 


### PR DESCRIPTION
The udev rules being generated did not include an actual action. We must
use spec.TagDevice in order to actually tag the device.
