### PR TITLE
tests: do not run mem-cgroup-disabled on external backends

### DIFF
--- a/tests/core/mem-cgroup-disabled/task.yaml
+++ b/tests/core/mem-cgroup-disabled/task.yaml
@@ -11,6 +11,13 @@ prepare: |
     echo "Skipping non-grub device test"
     exit 0
   fi
+  # external backends would fail because a signed gadget cannot be replaced
+  # with an unsigned one
+  # TODO: remove once https://github.com/snapcore/snapd/pull/11589 landed
+  if ! snap list pc | grep -q " x[0-9]+ "; then  
+    echo "This test needs a sideloaded gadget snap"
+    exit
+  fi
 
   echo "Create copy of gadget snap with cgroup_disable=memory set in cmdline.extra"
   PC_REV=$(snap list pc | tail -n +2 | awk '{print $3}')
@@ -37,7 +44,13 @@ execute: |
     echo "Skipping non-grub device test"
     exit 0
   fi
-
+  # external backends would fail because a signed gadget cannot be replaced
+  # with an unsigned one
+  # TODO: remove once https://github.com/snapcore/snapd/pull/11589 landed
+  if ! snap list pc | grep -q " x[0-9]+ "; then
+    echo "This test needs a sideloaded gadget snap"
+    exit
+  fi
   case "$SPREAD_REBOOT" in 
     0)
       # ensure memory cgroups is enabled to start


### PR DESCRIPTION
External backends fail with:
```
2022-04-11 15:42:24 Error executing external:ubuntu-core-22-64:tests/core/mem-cgroup-disabled (external:ubuntu-core-22-64) :
-----
+ not os.query is-pc-amd64
+ case "$SPREAD_REBOOT" in
++ awk '{print $4}'
++ grep memory
+ '[' 1 '!=' 1 ']'
+ /home/gopath/src/github.com/snapcore/snapd/tests/lib/tools/snaps-state install-local test-snapd-simple-service
test-snapd-simple-service 1.0 installed
+ snap set system experimental.quota-groups=true
+ snap set-quota grp --memory=100MB test-snapd-simple-service
+ MATCH Slice=snap.grp.slice
+ snap install --dangerous pc-cgroup-disabled.snap
error: cannot perform the following tasks:
- Mount snap "pc" (unset) (cannot replace signed gadget snap with an unasserted one)
-----
.
2022-04-11 15:42:24 Debug output for external:ubuntu-core-22-64:tests/core/mem-cgroup-disabled (external:ubuntu-core-22-64) :
```

because they don't have a sideloaded gadget. So until https://github.com/snapcore/snapd/pull/11589 is merged this test needs to be skipped on devices that do not already sideload the gadget.
