### PR TITLE
cmd/snap: add check switch for snap debug state

### DIFF
--- a/cmd/snap/cmd_debug_state.go
+++ b/cmd/snap/cmd_debug_state.go
@@ -170,12 +170,8 @@ func (c *cmdDebugState) showTasks(st *state.State, changeID string) error {
 		if c.NoHoldState && t.Status() == state.HoldStatus {
 			continue
 		}
-		var lanes []string
-		for _, lane := range t.Lanes() {
-			lanes = append(lanes, fmt.Sprintf("%d", lane))
-		}
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			strings.Join(lanes, ","),
+			strutil.IntsToCommaSeparated(t.Lanes()),
 			t.ID(),
 			t.Status().String(),
 			c.fmtTime(t.SpawnTime()),
@@ -239,12 +235,8 @@ func (c *cmdDebugState) checkTasks(st *state.State, changeID string) error {
 			fmt.Fprintf(w, "Lanes\tID\tStatus\tSpawn\tReady\tKind\tSummary\tAfter\tBefore\n")
 			for _, tid := range tdcErr.IDs {
 				t := st.Task(tid)
-				var lanes []string
-				for _, lane := range t.Lanes() {
-					lanes = append(lanes, fmt.Sprintf("%d", lane))
-				}
 				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%v\t%v\n",
-					strings.Join(lanes, ","),
+					strutil.IntsToCommaSeparated(t.Lanes()),
 					t.ID(),
 					t.Status().String(),
 					c.fmtTime(t.SpawnTime()),

--- a/cmd/snap/cmd_debug_state.go
+++ b/cmd/snap/cmd_debug_state.go
@@ -40,6 +40,7 @@ type cmdDebugState struct {
 	Changes  bool   `long:"changes"`
 	TaskID   string `long:"task"`
 	ChangeID string `long:"change"`
+	Check    bool   `long:"check"`
 
 	IsSeeded bool `long:"is-seeded"`
 
@@ -86,6 +87,7 @@ func init() {
 		"no-hold":   i18n.G("Omit tasks in 'Hold' state in the change output"),
 		"changes":   i18n.G("List all changes"),
 		"is-seeded": i18n.G("Output seeding status (true or false)"),
+		"check":     i18n.G("Check change consistency"),
 	}), nil)
 }
 
@@ -195,6 +197,69 @@ func (c *cmdDebugState) showTasks(st *state.State, changeID string) error {
 		}
 	}
 
+	return nil
+}
+
+func (c *cmdDebugState) checkTasks(st *state.State, changeID string) error {
+	st.Lock()
+	defer st.Unlock()
+
+	showAtMostTasks := 3
+	formatAtMostTaskIDs := func(tasks []*state.Task) string {
+		var b strings.Builder
+		b.WriteRune('[')
+		atMostTasks := tasks
+		trimmed := false
+		if len(atMostTasks) > showAtMostTasks {
+			atMostTasks = tasks[:showAtMostTasks]
+			trimmed = true
+		}
+		for i, t := range atMostTasks {
+			b.WriteString(t.ID())
+			if i < len(atMostTasks)-1 {
+				b.WriteRune(',')
+			}
+		}
+		if trimmed {
+			b.WriteString(",...")
+		}
+		b.WriteRune(']')
+		return b.String()
+	}
+
+	chg := st.Change(changeID)
+	if chg == nil {
+		return fmt.Errorf("no such change: %s", changeID)
+	}
+	err := chg.CheckTaskDependencies()
+	if err != nil {
+		if tdcErr, ok := err.(*state.TaskDependencyCycleError); ok {
+			fmt.Fprintf(Stdout, "Detected task dependency cycle involving tasks:\n")
+			w := tabwriter.NewWriter(Stdout, 5, 3, 2, ' ', 0)
+			fmt.Fprintf(w, "Lanes\tID\tStatus\tSpawn\tReady\tKind\tSummary\tAfter\tBefore\n")
+			for _, tid := range tdcErr.IDs {
+				t := st.Task(tid)
+				var lanes []string
+				for _, lane := range t.Lanes() {
+					lanes = append(lanes, fmt.Sprintf("%d", lane))
+				}
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%v\t%v\n",
+					strings.Join(lanes, ","),
+					t.ID(),
+					t.Status().String(),
+					c.fmtTime(t.SpawnTime()),
+					c.fmtTime(t.ReadyTime()),
+					t.Kind(),
+					t.Summary(),
+					formatAtMostTaskIDs(t.WaitTasks()),
+					formatAtMostTaskIDs(t.HaltTasks()),
+				)
+			}
+			w.Flush()
+		} else {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -326,6 +391,9 @@ func (c *cmdDebugState) Execute(args []string) error {
 		}
 		if c.DotOutput {
 			return c.writeDotOutput(st, c.ChangeID)
+		}
+		if c.Check {
+			return c.checkTasks(st, c.ChangeID)
 		}
 		return c.showTasks(st, c.ChangeID)
 	}

--- a/cmd/snap/cmd_debug_state.go
+++ b/cmd/snap/cmd_debug_state.go
@@ -379,6 +379,9 @@ func (c *cmdDebugState) Execute(args []string) error {
 	if c.NoHoldState && c.ChangeID == "" {
 		return fmt.Errorf("--no-hold can only be used with --change=")
 	}
+	if c.Check && c.ChangeID == "" {
+		return fmt.Errorf("--check can only be used with --change")
+	}
 
 	if c.Changes {
 		return c.showChanges(st)

--- a/cmd/snap/cmd_debug_state_test.go
+++ b/cmd/snap/cmd_debug_state_test.go
@@ -259,10 +259,29 @@ func (s *SnapSuite) TestDebugTasksWithCycles(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	c.Check(s.Stdout(), Matches,
-		"Lanes  ID   Status  Spawn                 Ready                 Kind  Summary\n"+
+		""+
+			"Lanes  ID   Status  Spawn                 Ready                 Kind  Summary\n"+
 			"0      13   Do      0001-01-01T00:00:00Z  0001-01-01T00:00:00Z  bar   Bar task\n"+
 			"0      12   Do      0001-01-01T00:00:00Z  0001-01-01T00:00:00Z  bar   Bar task\n"+
 			"0      11   Done    0001-01-01T00:00:00Z  0001-01-01T00:00:00Z  foo   Foo task\n")
+	c.Check(s.Stderr(), Equals, "")
+}
+
+func (s *SnapSuite) TestDebugCheckForCycles(c *C) {
+	dir := c.MkDir()
+	stateFile := filepath.Join(dir, "test-state.json")
+	c.Assert(ioutil.WriteFile(stateFile, stateCyclesJSON, 0644), IsNil)
+
+	rest, err := main.Parser(main.Client()).ParseArgs([]string{"debug", "state", "--check", "--change=1", stateFile})
+	c.Assert(err, IsNil)
+	c.Assert(rest, DeepEquals, []string{})
+	c.Check(s.Stdout(), Equals, ``+
+		`Detected task dependency cycle involving tasks:
+Lanes  ID   Status  Spawn       Ready       Kind  Summary   After  Before
+0      11   Done    0001-01-01  0001-01-01  foo   Foo task  []     [13]
+0      12   Do      0001-01-01  0001-01-01  bar   Bar task  []     [13]
+0      13   Do      0001-01-01  0001-01-01  bar   Bar task  []     [11,12]
+`)
 	c.Check(s.Stderr(), Equals, "")
 }
 

--- a/cmd/snap/cmd_debug_state_test.go
+++ b/cmd/snap/cmd_debug_state_test.go
@@ -126,21 +126,24 @@ var stateCyclesJSON = []byte(`
 			"kind": "foo",
 			"summary": "Foo task",
 			"status": 4,
-			"halt-tasks": ["13"]
+			"halt-tasks": ["13"],
+			"lanes": [1,2]
 		},
 		"12": {
 			"id": "12",
 			"change": "1",
 			"kind": "bar",
 			"summary": "Bar task",
-			"halt-tasks": ["13"]
+			"halt-tasks": ["13"],
+			"lanes": [1]
 		},
 		"13": {
 			"id": "13",
 			"change": "1",
 			"kind": "bar",
 			"summary": "Bar task",
-			"halt-tasks": ["11","12"]
+			"halt-tasks": ["11","12"],
+			"lanes": [2]
 		}
 	}
 }
@@ -261,9 +264,9 @@ func (s *SnapSuite) TestDebugTasksWithCycles(c *C) {
 	c.Check(s.Stdout(), Matches,
 		""+
 			"Lanes  ID   Status  Spawn                 Ready                 Kind  Summary\n"+
-			"0      13   Do      0001-01-01T00:00:00Z  0001-01-01T00:00:00Z  bar   Bar task\n"+
-			"0      12   Do      0001-01-01T00:00:00Z  0001-01-01T00:00:00Z  bar   Bar task\n"+
-			"0      11   Done    0001-01-01T00:00:00Z  0001-01-01T00:00:00Z  foo   Foo task\n")
+			"1      12   Do      0001-01-01T00:00:00Z  0001-01-01T00:00:00Z  bar   Bar task\n"+
+			"1,2    11   Done    0001-01-01T00:00:00Z  0001-01-01T00:00:00Z  foo   Foo task\n"+
+			"2      13   Do      0001-01-01T00:00:00Z  0001-01-01T00:00:00Z  bar   Bar task\n")
 	c.Check(s.Stderr(), Equals, "")
 }
 
@@ -278,9 +281,9 @@ func (s *SnapSuite) TestDebugCheckForCycles(c *C) {
 	c.Check(s.Stdout(), Equals, ``+
 		`Detected task dependency cycle involving tasks:
 Lanes  ID   Status  Spawn       Ready       Kind  Summary   After  Before
-0      11   Done    0001-01-01  0001-01-01  foo   Foo task  []     [13]
-0      12   Do      0001-01-01  0001-01-01  bar   Bar task  []     [13]
-0      13   Do      0001-01-01  0001-01-01  bar   Bar task  []     [11,12]
+1,2    11   Done    0001-01-01  0001-01-01  foo   Foo task  []     [13]
+1      12   Do      0001-01-01  0001-01-01  bar   Bar task  []     [13]
+2      13   Do      0001-01-01  0001-01-01  bar   Bar task  []     [11,12]
 `)
 	c.Check(s.Stderr(), Equals, "")
 }


### PR DESCRIPTION
Add a new flag to snap debug state that helps investigate if a given state
contains task dependency cycles.

On a particularly problematic dump it looks like this:

```
Detected task dependency cycle involving tasks:
Lanes  ID   Status  Spawn                      Ready       Kind                   Summary                                                                      After              Before
2      341  Do      27 days ago, at 09:22 CET  0001-01-01  prerequisites          Ensure prerequisites for "pc-kernel" are available                           [322,323,324,...]  [342,359,360]
2      342  Do      27 days ago, at 09:22 CET  0001-01-01  download-snap          Download snap "pc-kernel" (932) from channel "20/stable"                     [341,322,323,...]  [343,359,360]
2      343  Do      27 days ago, at 09:22 CET  0001-01-01  validate-snap          Fetch and check assertions for snap "pc-kernel" (932)                        [342,322,323,...]  [344,359,360]
2      344  Do      27 days ago, at 09:22 CET  0001-01-01  mount-snap             Mount snap "pc-kernel" (932)                                                 [343,322,323,...]  [345,359,360]
2      345  Do      27 days ago, at 09:22 CET  0001-01-01  run-hook               Run pre-refresh hook of "pc-kernel" snap if present                          [344,322,323,...]  [346,359,360]
2      346  Do      27 days ago, at 09:22 CET  0001-01-01  stop-snap-services     Stop snap "pc-kernel" services                                               [345,322,323,...]  [347,359,360]
2      347  Do      27 days ago, at 09:22 CET  0001-01-01  remove-aliases         Remove aliases for snap "pc-kernel"                                          [346,322,323,...]  [348,359,360]
...
2      360  Do      27 days ago, at 09:22 CET  0001-01-01  run-hook               Run health check of "pc-kernel" snap                                         [341,342,343,...]  []
3,2    371  Do      27 days ago, at 09:22 CET  0001-01-01  link-snap              Make snap "core20" (1376) available to the system                            [370,351]          [372,378,379,...]
3,2    372  Do      27 days ago, at 09:22 CET  0001-01-01  auto-connect           Automatically connect eligible plugs and slots of snap "core20"              [371,352]          [373,378,379,...]
3      373  Do      27 days ago, at 09:22 CET  0001-01-01  set-auto-aliases       Set automatic aliases for snap "core20"                                      [372,353]          [374,378,379,...]
3      374  Do      27 days ago, at 09:22 CET  0001-01-01  setup-aliases          Setup snap "core20" aliases                                                  [373]              [375,378,379,...]
3      375  Do      27 days ago, at 09:22 CET  0001-01-01  run-hook               Run post-refresh hook of "core20" snap if present                            [374]              [376,378,379,...]
3      376  Do      27 days ago, at 09:22 CET  0001-01-01  start-snap-services    Start snap "core20" (1376) services                                          [375]              [377,378,379,...]
3      377  Do      27 days ago, at 09:22 CET  0001-01-01  cleanup                Clean up "core20" (1376) install                                             [376]              [378,379,380,...]
3      378  Do      27 days ago, at 09:22 CET  0001-01-01  run-hook               Run health check of "core20" snap                                            [361,362,363,...]  [379,380,381,...]
...
```
