### PR TITLE
.github: use reviewdog action from woke tool

### DIFF
--- a/.github/workflows/naming.yml
+++ b/.github/workflows/naming.yml
@@ -13,7 +13,7 @@ jobs:
         id: files
 
       - name: woke
-        uses:  get-woke/woke-action@v0
+        uses:  get-woke/woke-action-reviewdog@v0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-check

--- a/.github/workflows/naming.yml
+++ b/.github/workflows/naming.yml
@@ -9,13 +9,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - uses: jitterbit/get-changed-files@v1
+      - uses: tj-actions/changed-files@v18.7
         id: files
 
       - name: woke
-        uses:  get-woke/woke-action-reviewdog@v0
+        uses: get-woke/woke-action-reviewdog@v0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-check
           fail-on-error: true
-          woke-args: ${{ steps.files.outputs.added_modified }}
+          woke-args: ${{ steps.files.outputs.all_changed_files }}


### PR DESCRIPTION
The `woke-action` does not have the `reporter` option and running it
generates a warning:

    Unexpected input(s) 'reporter', valid inputs are ['github-token', 'woke-args', 'fail-on-error', 'workdir', 'woke-version']

