### PR TITLE
o/snapstate: migration overwrites existing snap dir

### DIFF
--- a/overlord/snapstate/backend/copydata.go
+++ b/overlord/snapstate/backend/copydata.go
@@ -167,7 +167,7 @@ func (b Backend) HideSnapData(snapName string) error {
 			return err
 		} else if exists {
 			if err := os.RemoveAll(newSnapDir); err != nil {
-				return fmt.Errorf("cannot remove existing post-migration snap dir: %v", err)
+				return fmt.Errorf("cannot remove existing snap dir %q: %v", newSnapDir, err)
 			}
 		}
 

--- a/overlord/snapstate/backend/copydata.go
+++ b/overlord/snapstate/backend/copydata.go
@@ -162,8 +162,16 @@ func (b Backend) HideSnapData(snapName string) error {
 			return fmt.Errorf("cannot create snap dir %q: %w", hiddenSnapDir, err)
 		}
 
-		// move the snap's dir
 		newSnapDir := snap.UserSnapDir(usr.HomeDir, snapName, hiddenDirOpts)
+		if exists, _, err := osutil.DirExists(newSnapDir); err != nil {
+			return err
+		} else if exists {
+			if err := os.RemoveAll(newSnapDir); err != nil {
+				return fmt.Errorf("cannot remove existing post-migration snap dir: %v", err)
+			}
+		}
+
+		// move the snap's dir
 		if err := osutil.AtomicRename(oldSnapDir, newSnapDir); err != nil {
 			return fmt.Errorf("cannot move %q to %q: %w", oldSnapDir, newSnapDir, err)
 		}

--- a/tests/main/hidden-snap-dir/task.yaml
+++ b/tests/main/hidden-snap-dir/task.yaml
@@ -184,3 +184,27 @@ execute: |
     check_env "--with-exposed-home" "x3"
     check_dirs "--with-exposed-home" "x3"
     check_data "--with-exposed-home" "x3" "$data"
+
+    echo "Check migration after remove works"
+    # ensure dirs under ~/.snap/data are created
+    "$NAME".cmd 'true'
+    test -d "$HOME/.snap/data/$NAME"
+
+    echo "Remove snap"
+    snap remove --purge "$NAME"
+    # dir is leftover
+    test -d "$HOME/.snap/data/$NAME"
+
+    echo "Install snap with data under ~/snap"
+    snap pack "$TESTSLIB/snaps/$NAME"
+    snap unset system experimental.hidden-snap-folder
+    "$TESTSTOOLS"/snaps-state install-local "$NAME"
+    # create dirs under ~/snap to be migrated
+    "$NAME".cmd 'true'
+    test -d "$HOME/snap/$NAME"
+
+    echo "Migration to ~/.snap/data works"
+    snap set system experimental.hidden-snap-folder=true
+    "$TESTSTOOLS"/snaps-state install-local "$NAME"
+    test -d "$HOME/.snap/data/$NAME"
+    not test -e "$HOME/snap/$NAME"


### PR DESCRIPTION
'snap remove' wasn't removing the snap's user dir under ~/snap or 
~/.snap/data. This caused migrations to fail if a previous migration
occurred before since there was already data in its place. This PR 
fixes that issue and updates the spread test to cover it.
