### PR TITLE
github: cancel workflows when pushing to pull request branches

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,6 +7,10 @@ on:
     # branch, the master branch runs are just for unit tests + codecov.io
     branches: [ "master","release/**" ]
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   snap-builds:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
See
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
for details.

> If you build the group name with a property that is only defined for specific
> events, you can use a fallback value. For example, github.head_ref is only
> defined on pull_request events. If your workflow responds to other events in
> addition to pull_request events, you will need to provide a fallback to avoid
> a syntax error. The following concurrency group cancels in-progress jobs or
> runs on pull_request events only; if github.head_ref is undefined, the
> concurrency group will fallback to the run ID, which is guaranteed to be both
> unique and defined for the run.


