### PR TITLE
interfaces/udev: refactor handling of udevadm triggers for input

### DIFF
--- a/interfaces/udev/udev_test.go
+++ b/interfaces/udev/udev_test.go
@@ -189,7 +189,6 @@ func (s *uDevSuite) TestReloadUDevRulesRunsUDevAdmWithTwoSubsystems(c *C) {
 		{"udevadm", "control", "--reload-rules"},
 		{"udevadm", "trigger", "--subsystem-nomatch=input"},
 		{"udevadm", "trigger", "--subsystem-match=input"},
-		{"udevadm", "trigger", "--subsystem-match=tty"},
 		{"udevadm", "settle", "--timeout=10"},
 	})
 }


### PR DESCRIPTION
The old code would run unnecessary `udevadm trigger` commands in a
couple of situations:

1. If a subsystem other than "input" was specified, the trigger for it
   would be run twice: once because of the unconditional call to
   `udevadm --subsystem-nomatch=input`, and once because of the call to
   `udevadm --subsystem-match=<subsystem>`.
2. If both "input" and "input/keys" are part of the subsystem list,
   there's no need to run a trigger specific to the keys: running the
   trigger for the whole "input" subsystem is enough.

Note that I do not understand the "FIXME" comment. I see that the history of this code is in https://github.com/snapcore/snapd/pull/5250, but it's not clear to me why we cannot update the subsystem list on interface removal. If you know the reason, please let me know -- maybe that part can be fixed as well.
