### PR TITLE
tests: install linux-tools-gcp on jammy to avoid bpftool dependency error

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -621,7 +621,7 @@ pkg_dependencies_ubuntu_classic(){
                 shellcheck
                 "
             ;;
-        ubuntu-21.10-64|ubuntu-22.04-64)
+        ubuntu-21.10-64)
             # bpftool is part of linux-tools package
             echo "
                 dbus-user-session
@@ -630,6 +630,21 @@ pkg_dependencies_ubuntu_classic(){
                 linux-tools-virtual
                 qemu-utils
                 "
+            ;;
+        ubuntu-22.04-64)
+            # bpftool is part of linux-tools package
+            echo "
+                dbus-user-session
+                fwupd
+                golang
+                linux-tools-virtual
+                qemu-utils
+                "
+            if [ "$SPREAD_BACKEND" = "google" ]; then
+                echo "
+                    linux-tools-gcp
+                    "
+            fi
             ;;
         ubuntu-*)
             echo "

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -621,17 +621,7 @@ pkg_dependencies_ubuntu_classic(){
                 shellcheck
                 "
             ;;
-        ubuntu-21.10-64)
-            # bpftool is part of linux-tools package
-            echo "
-                dbus-user-session
-                fwupd
-                golang
-                linux-tools-virtual
-                qemu-utils
-                "
-            ;;
-        ubuntu-22.04-64)
+        ubuntu-21.10-64|ubuntu-22.04-64)
             # bpftool is part of linux-tools package
             echo "
                 dbus-user-session

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -627,14 +627,9 @@ pkg_dependencies_ubuntu_classic(){
                 dbus-user-session
                 fwupd
                 golang
-                linux-tools-virtual
+                linux-tools-$(uname -r)
                 qemu-utils
                 "
-            if [ "$SPREAD_BACKEND" = "google" ]; then
-                echo "
-                    linux-tools-$(uname -r)
-                    "
-            fi
             ;;
         ubuntu-*)
             echo "

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -632,7 +632,7 @@ pkg_dependencies_ubuntu_classic(){
                 "
             if [ "$SPREAD_BACKEND" = "google" ]; then
                 echo "
-                    linux-tools-gcp
+                    linux-tools-$(uname -r)
                     "
             fi
             ;;


### PR DESCRIPTION
This dependency is needed to avoid this error.

Currently the error is not happening anymore because the dependency was
manually installed in jammy but it will break again on next image update

Error:

+ tests.device-cgroup test-strict-cgroup-helper.sh dump
WARNING: bpftool not found for kernel 5.15.0-1003

You may need to install the following packages for this specific
kernel:
    linux-tools-5.15.0-1003-gcp
    linux-cloud-tools-5.15.0-1003-gcp

You may also want to install one of the following packages to keep up
to date:
    linux-tools-gcp
    linux-cloud-tools-gcp
