### PR TITLE
tests: add invariant check for leftover cgroup scopes

### DIFF
--- a/tests/lib/tools/tests.invariant
+++ b/tests/lib/tools/tests.invariant
@@ -142,6 +142,16 @@ check_broken_snaps() {
 	fi
 }
 
+check_cgroup_scopes() {
+	n="$1" # invariant name
+	find /sys/fs/cgroup -name 'snap.*.scope' 2>&1 > "$TESTSTMP/tests.invariant.$n"
+	if [ -s "$TESTSTMP/tests.invariant.$n" ]; then
+		echo "tests.invariant: leftover cgroup scope files" >&2
+		cat "$TESTSTMP/tests.invariant.$n" >&2
+		return 1
+	fi
+}
+
 check_invariant() {
 	case "$1" in
 		root-files-in-home)
@@ -162,6 +172,9 @@ check_invariant() {
 		broken-snaps)
 			check_broken_snaps "$1"
 			;;
+		cgroup-scopes)
+			check_cgroup_scopes "$1"
+			;;
 		*)
 			echo "tests.invariant: unknown invariant $1" >&2
 			exit 1
@@ -170,7 +183,7 @@ check_invariant() {
 }
 
 main() {
-	ALL_INVARIANTS="root-files-in-home crashed-snap-confine lxcfs-mounted stray-dbus-daemon leftover-defer-sh broken-snaps"
+	ALL_INVARIANTS="root-files-in-home crashed-snap-confine lxcfs-mounted stray-dbus-daemon leftover-defer-sh broken-snaps cgroup-scopes"
 
 	case "$action" in
 		check)

--- a/tests/lib/tools/tests.invariant
+++ b/tests/lib/tools/tests.invariant
@@ -143,6 +143,12 @@ check_broken_snaps() {
 }
 
 check_cgroup_scopes() {
+	# xenial has leftover scope files possibly due to an old systemd bug
+	# https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1934147
+	if [ "$SPREAD_SYSTEM" == "ubuntu-core-16-64" ] || [ "$SPREAD_SYSTEM" == "ubuntu-16.04-64" ]; then
+		return 0
+	fi
+
 	n="$1" # invariant name
 	find /sys/fs/cgroup -name 'snap.*.scope' > "$TESTSTMP/tests.invariant.$n"
 	if [ -s "$TESTSTMP/tests.invariant.$n" ]; then

--- a/tests/lib/tools/tests.invariant
+++ b/tests/lib/tools/tests.invariant
@@ -144,7 +144,7 @@ check_broken_snaps() {
 
 check_cgroup_scopes() {
 	n="$1" # invariant name
-	find /sys/fs/cgroup -name 'snap.*.scope' 2>&1 > "$TESTSTMP/tests.invariant.$n"
+	find /sys/fs/cgroup -name 'snap.*.scope' > "$TESTSTMP/tests.invariant.$n"
 	if [ -s "$TESTSTMP/tests.invariant.$n" ]; then
 		echo "tests.invariant: leftover cgroup scope files" >&2
 		cat "$TESTSTMP/tests.invariant.$n" >&2

--- a/tests/lib/tools/tests.invariant
+++ b/tests/lib/tools/tests.invariant
@@ -145,7 +145,7 @@ check_broken_snaps() {
 check_cgroup_scopes() {
 	# xenial has leftover scope files possibly due to an old systemd bug
 	# https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1934147
-	if [ "$SPREAD_SYSTEM" == "ubuntu-core-16-64" ] || [ "$SPREAD_SYSTEM" == "ubuntu-16.04-64" ]; then
+	if [[ "$SPREAD_SYSTEM" == ubuntu-core-16-* ]] || [[ "$SPREAD_SYSTEM" == ubuntu-16.04-* ]]; then
 		return 0
 	fi
 


### PR DESCRIPTION
Add invariant check for leftover snap.*.scope in /sys/fs/cgroup (meaning a leftover snap process running after the test).

(suggested in the review of #11566)