### PR TITLE
libsnap-confine-private: show proper error when aa_change_onexec() fails

### DIFF
--- a/cmd/libsnap-confine-private/apparmor-support.c
+++ b/cmd/libsnap-confine-private/apparmor-support.c
@@ -124,7 +124,10 @@ sc_maybe_aa_change_onexec(struct sc_apparmor *apparmor, const char *profile)
 	debug("requesting changing of apparmor profile on next exec to %s",
 	      profile);
 	if (aa_change_onexec(profile) < 0) {
+		/* Save errno because secure_getenv() can overwrite it */
+		int aa_change_onexec_errno = errno;
 		if (secure_getenv("SNAPPY_LAUNCHER_INSIDE_TESTS") == NULL) {
+			errno = aa_change_onexec_errno;
 			die("cannot change profile for the next exec call");
 		}
 	}


### PR DESCRIPTION
The call to secure_getenv() can overwrite the `errno` variable because
it internally invokes getauxval(), which could set `errno` to `ENOENT`.

This was discovered examining an error log containing these lines:

    run-hook: Error
    ERROR run hook "configure":
    -----
    cannot change profile for the next exec call: No such file or directory
    snap-update-ns failed with code 1
    -----
