### PR TITLE
seed: support parallelism when loading/verifying snap metadata

### DIFF
--- a/image/preseed/preseed_test.go
+++ b/image/preseed/preseed_test.go
@@ -113,6 +113,8 @@ func (fs *Fake16Seed) Brand() (*asserts.Account, error) {
 	return assertstest.FakeAssertion(headers, nil).(*asserts.Account), nil
 }
 
+func (fs *Fake16Seed) SetParallelism(int) {}
+
 func (fs *Fake16Seed) LoadEssentialMeta(essentialTypes []snap.Type, tm timings.Measurer) error {
 	return fs.LoadMetaErr
 }

--- a/seed/seed.go
+++ b/seed/seed.go
@@ -92,6 +92,11 @@ type Seed interface {
 	// It will panic if called before LoadAssertions.
 	Brand() (*asserts.Account, error)
 
+	// SetParallelism suggests that n parallel jobs should be used
+	// to load and verify snap metadata by Load*Meta operations.
+	// The default is one single job.
+	SetParallelism(n int)
+
 	// LoadEssentialMeta loads the seed's snaps metadata for the
 	// essential snaps with types in the essentialTypes set while
 	// verifying them against assertions. It can return ErrNoMeta

--- a/seed/seed16.go
+++ b/seed/seed16.go
@@ -120,6 +120,10 @@ func (s *seed16) Brand() (*asserts.Account, error) {
 	return findBrand(s, s.db)
 }
 
+func (s *seed16) SetParallelism(int) {
+	// ignored
+}
+
 func (s *seed16) addSnap(sn *internal.Snap16, pinnedTrack string, cache map[string]*Snap, tm timings.Measurer) (*Snap, error) {
 	path := filepath.Join(s.seedDir, "snaps", sn.File)
 

--- a/seed/seed20.go
+++ b/seed/seed20.go
@@ -454,6 +454,7 @@ func (s *seed20) doLoadMeta(tm timings.Measurer) error {
 	for j := 1; j <= njobs; j++ {
 		jtm := tm.StartSpan(fmt.Sprintf("do-load-meta[%d]", j), fmt.Sprintf("snap metadata loading job #%d", j))
 		go func() {
+			defer jtm.Stop()
 		Consider:
 			for sntoc := range s.snapsToConsiderCh {
 				select {

--- a/seed/seed20.go
+++ b/seed/seed20.go
@@ -35,6 +35,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/snapasserts"
@@ -58,6 +59,8 @@ type seed20 struct {
 
 	snapRevsByID map[string]*asserts.SnapRevision
 
+	nLoadMetaJobs int
+
 	optSnaps    []*internal.Snap20
 	optSnapsIdx int
 
@@ -65,7 +68,10 @@ type seed20 struct {
 
 	metaFilesLoaded bool
 
-	essCache map[string]*Snap
+	snapsToConsiderCh chan snapToConsider
+
+	essCache   map[string]*Snap
+	essCacheMu sync.Mutex
 
 	mode string
 
@@ -311,13 +317,7 @@ func (s *seed20) lookupVerifiedRevision(snapRef naming.SnapRef, snapsDir string)
 	return snapPath, snapRev, snapDecl, nil
 }
 
-func (s *seed20) lookupSnap(snapRef naming.SnapRef, optSnap *internal.Snap20, channel string, snapsDir string, cache map[string]*Snap, tm timings.Measurer) (*Snap, error) {
-	snapKey := fmt.Sprintf("%s:%s", snapRef.ID(), snapRef.SnapName())
-	seedSnap := cache[snapKey]
-	if seedSnap != nil {
-		return seedSnap, nil
-	}
-
+func (s *seed20) lookupSnap(snapRef naming.SnapRef, optSnap *internal.Snap20, channel string, snapsDir string, tm timings.Measurer) (*Snap, error) {
 	if optSnap != nil && optSnap.Channel != "" {
 		channel = optSnap.Channel
 	}
@@ -356,53 +356,189 @@ func (s *seed20) lookupSnap(snapRef naming.SnapRef, optSnap *internal.Snap20, ch
 		sideInfo.EditedContact = auxInfo.Contact
 	}
 
-	seedSnap = &Snap{
+	return &Snap{
 		Path: path,
 
 		SideInfo: sideInfo,
 
 		Channel: channel,
-	}
-
-	if cache != nil {
-		cache[snapKey] = seedSnap
-	}
-
-	return seedSnap, nil
+	}, nil
 }
 
-func (s *seed20) addSnap(snapRef naming.SnapRef, optSnap *internal.Snap20, modes []string, channel string, snapsDir string, cache map[string]*Snap, tm timings.Measurer) (*Snap, error) {
-	seedSnap, err := s.lookupSnap(snapRef, optSnap, channel, snapsDir, cache, tm)
+type snapToConsider struct {
+	i         int
+	modelSnap *asserts.ModelSnap
+	optSnap   *internal.Snap20
+	essential bool
+}
+
+var errSkipped = errors.New("skipped optional snap")
+
+func (s *seed20) doLoadMetaOne(sntoc *snapToConsider, tm timings.Measurer) (*Snap, error) {
+	var snapRef naming.SnapRef
+	var channel string
+	var snapsDir string
+	var essential bool
+	var required bool
+	if sntoc.modelSnap != nil {
+		snapRef = sntoc.modelSnap
+		essential = sntoc.essential
+		required = essential || sntoc.modelSnap.Presence == "required"
+		channel = sntoc.modelSnap.DefaultChannel
+		snapsDir = "../../snaps"
+	} else {
+		snapRef = sntoc.optSnap
+		channel = "latest/stable"
+		snapsDir = "snaps"
+	}
+	seedSnap, err := s.lookupSnap(snapRef, sntoc.optSnap, channel, snapsDir, tm)
 	if err != nil {
+		if _, ok := err.(*noSnapDeclarationError); ok && !required {
+			// skipped optional snap is ok
+			return nil, errSkipped
+		}
 		return nil, err
 	}
+	seedSnap.Essential = essential
+	seedSnap.Required = required
+	if essential {
+		if sntoc.modelSnap.SnapType == "gadget" {
+			// validity
+			info, err := readInfo(seedSnap.Path, seedSnap.SideInfo)
+			if err != nil {
+				return nil, err
+			}
+			if info.Base != s.model.Base() {
+				return nil, fmt.Errorf("cannot use gadget snap because its base %q is different from model base %q", info.Base, s.model.Base())
+			}
+			// TODO: when we allow extend models for classic
+			// we need to add the gadget base here
+		}
 
-	s.snaps = append(s.snaps, seedSnap)
-	s.modes = append(s.modes, modes)
-
+		seedSnap.EssentialType = snapTypeFromModel(sntoc.modelSnap)
+	}
 	return seedSnap, nil
 }
 
-var errFiltered = errors.New("filtered out")
+func (s *seed20) doLoadMeta(tm timings.Measurer) error {
+	// setup essential snaps cache
+	if s.essCache == nil {
+		// 4 = snapd+base+kernel+gadget
+		s.essCache = make(map[string]*Snap, 4)
+	}
+	cacheEssential := func(snType string, essSnap *Snap) {
+		s.essCacheMu.Lock()
+		defer s.essCacheMu.Unlock()
+		s.essCache[snType] = essSnap
+	}
+	cachedEssential := func(snType string) *Snap {
+		s.essCacheMu.Lock()
+		defer s.essCacheMu.Unlock()
+		return s.essCache[snType]
+	}
+	runMode := []string{"run"}
 
-func (s *seed20) addModelSnap(modelSnap *asserts.ModelSnap, essential bool, filter func(*asserts.ModelSnap) bool, cache map[string]*Snap, tm timings.Measurer) (*Snap, error) {
+	n := len(s.snapsToConsiderCh)
+	close(s.snapsToConsiderCh)
+	if n > 0 {
+		s.snaps = make([]*Snap, n)
+		s.modes = make([][]string, n)
+	}
+
+	njobs := s.nLoadMetaJobs
+	if njobs < 1 {
+		njobs = 1
+	}
+	stopCh := make(chan struct{})
+	outcomesCh := make(chan error, njobs)
+	for j := 1; j <= njobs; j++ {
+		jtm := tm.StartSpan(fmt.Sprintf("do-load-meta[%d]", j), fmt.Sprintf("snap metadata loading job #%d", j))
+		go func() {
+		Consider:
+			for sntoc := range s.snapsToConsiderCh {
+				select {
+				case <-stopCh:
+					break Consider
+				default:
+				}
+				var seedSnap *Snap
+				modes := runMode
+				essential := false
+				if sntoc.modelSnap != nil {
+					modes = sntoc.modelSnap.Modes
+					essential = sntoc.essential
+				}
+				if essential {
+					seedSnap = cachedEssential(sntoc.modelSnap.SnapType)
+				}
+				if seedSnap == nil {
+					var err error
+					seedSnap, err = s.doLoadMetaOne(&sntoc, jtm)
+					if err != nil {
+						if err == errSkipped {
+							continue
+						}
+						outcomesCh <- err
+						return
+					}
+					if essential {
+						cacheEssential(sntoc.modelSnap.SnapType, seedSnap)
+					}
+				}
+				i := sntoc.i
+				s.snaps[i] = seedSnap
+				s.modes[i] = modes
+			}
+			outcomesCh <- nil
+		}()
+	}
+	var firstErr error
+	done := 0
+	for done != njobs {
+		err := <-outcomesCh
+		done++
+		if err != nil && firstErr == nil {
+			firstErr = err
+			close(stopCh)
+		}
+	}
+	s.snapsToConsiderCh = nil
+	if firstErr != nil {
+		return firstErr
+	}
+	osnaps := s.snaps
+	omodes := s.modes
+	s.snaps = s.snaps[:0]
+	s.modes = s.modes[:0]
+	for i, sn := range osnaps {
+		if sn != nil {
+			s.snaps = append(s.snaps, sn)
+			s.modes = append(s.modes, omodes[i])
+		}
+	}
+	return nil
+}
+
+func (s *seed20) SetParallelism(n int) {
+	s.nLoadMetaJobs = n
+}
+
+func (s *seed20) considerModelSnap(modelSnap *asserts.ModelSnap, essential bool, filter func(*asserts.ModelSnap) bool) {
 	optSnap, _ := s.nextOptSnap(modelSnap)
 	if filter != nil && !filter(modelSnap) {
-		return nil, errFiltered
-	}
-	seedSnap, err := s.addSnap(modelSnap, optSnap, modelSnap.Modes, modelSnap.DefaultChannel, "../../snaps", cache, tm)
-	if err != nil {
-		return nil, err
+		return
 	}
 
-	seedSnap.Essential = essential
-	seedSnap.Required = essential || modelSnap.Presence == "required"
+	s.snapsToConsiderCh <- snapToConsider{
+		i:         len(s.snapsToConsiderCh),
+		modelSnap: modelSnap,
+		optSnap:   optSnap,
+		essential: essential,
+	}
+
 	if essential {
-		seedSnap.EssentialType = snapTypeFromModel(modelSnap)
 		s.essentialSnapsNum++
 	}
-
-	return seedSnap, nil
 }
 
 func (s *seed20) LoadMeta(mode string, tm timings.Measurer) error {
@@ -414,25 +550,22 @@ func (s *seed20) LoadMeta(mode string, tm timings.Measurer) error {
 		return err
 	}
 
-	if s.mode != AllModes && s.mode != "run" {
+	if s.mode == AllModes || s.mode == "run" {
 		// extra snaps are only for run mode
-		return nil
-	}
-	// extra snaps
-	runMode := []string{"run"}
-	for {
-		optSnap, done := s.nextOptSnap(nil)
-		if done {
-			break
-		}
+		for {
+			optSnap, done := s.nextOptSnap(nil)
+			if done {
+				break
+			}
 
-		_, err := s.addSnap(optSnap, optSnap, runMode, "latest/stable", "snaps", nil, tm)
-		if err != nil {
-			return err
+			s.snapsToConsiderCh <- snapToConsider{
+				i:       len(s.snapsToConsiderCh),
+				optSnap: optSnap,
+			}
 		}
 	}
 
-	return nil
+	return s.doLoadMeta(tm)
 }
 
 func (s *seed20) LoadEssentialMeta(essentialTypes []snap.Type, tm timings.Measurer) error {
@@ -442,6 +575,11 @@ func (s *seed20) LoadEssentialMeta(essentialTypes []snap.Type, tm timings.Measur
 	}
 
 	if err := s.loadEssentialMeta(filterEssential, tm); err != nil {
+		return err
+	}
+
+	err := s.doLoadMeta(tm)
+	if err != nil {
 		return err
 	}
 
@@ -471,12 +609,6 @@ func (s *seed20) loadMetaFiles() error {
 }
 
 func (s *seed20) resetSnaps() {
-	// setup essential snaps cache
-	if s.essCache == nil {
-		// 4 = snapd+base+kernel+gadget
-		s.essCache = make(map[string]*Snap, 4)
-	}
-
 	s.optSnapsIdx = 0
 	s.mode = AllModes
 	s.snaps = nil
@@ -496,34 +628,26 @@ func (s *seed20) loadEssentialMeta(filterEssential func(*asserts.ModelSnap) bool
 	essSnaps := model.EssentialSnaps()
 	const essential = true
 
+	// create channels
+	if filterEssential != nil {
+		// LoadEssentialMeta
+		s.snapsToConsiderCh = make(chan snapToConsider, 4)
+	} else {
+		m := len(essSnaps) + len(model.SnapsWithoutEssential()) + len(s.optSnaps)
+		if essSnaps[0].SnapType != "snapd" {
+			m++
+		}
+		s.snapsToConsiderCh = make(chan snapToConsider, m)
+	}
+
 	// an explicit snapd is the first of all of snaps
 	if essSnaps[0].SnapType != "snapd" {
 		snapdSnap := internal.MakeSystemSnap("snapd", "latest/stable", []string{"run", "ephemeral"})
-		if _, err := s.addModelSnap(snapdSnap, essential, filterEssential, s.essCache, tm); err != nil && err != errFiltered {
-			return err
-		}
+		s.considerModelSnap(snapdSnap, essential, filterEssential)
 	}
 
 	for _, modelSnap := range essSnaps {
-		seedSnap, err := s.addModelSnap(modelSnap, essential, filterEssential, s.essCache, tm)
-		if err != nil {
-			if err == errFiltered {
-				continue
-			}
-			return err
-		}
-		if modelSnap.SnapType == "gadget" {
-			// validity
-			info, err := readInfo(seedSnap.Path, seedSnap.SideInfo)
-			if err != nil {
-				return err
-			}
-			if info.Base != model.Base() {
-				return fmt.Errorf("cannot use gadget snap because its base %q is different from model base %q", info.Base, model.Base())
-			}
-			// TODO: when we allow extend models for classic
-			// we need to add the gadget base here
-		}
+		s.considerModelSnap(modelSnap, essential, filterEssential)
 	}
 
 	return nil
@@ -557,17 +681,7 @@ func (s *seed20) loadModelRestMeta(tm timings.Measurer) error {
 
 	const notEssential = false
 	for _, modelSnap := range model.SnapsWithoutEssential() {
-		_, err := s.addModelSnap(modelSnap, notEssential, filterMode, nil, tm)
-		if err != nil {
-			if err == errFiltered {
-				continue
-			}
-			if _, ok := err.(*noSnapDeclarationError); ok && modelSnap.Presence == "optional" {
-				// skipped optional snap is ok
-				continue
-			}
-			return err
-		}
+		s.considerModelSnap(modelSnap, notEssential, filterMode)
 	}
 
 	return nil

--- a/seed/seed20.go
+++ b/seed/seed20.go
@@ -543,11 +543,11 @@ func (s *seed20) considerModelSnap(modelSnap *asserts.ModelSnap, essential bool,
 }
 
 func (s *seed20) LoadMeta(mode string, tm timings.Measurer) error {
-	if err := s.loadEssentialMeta(nil, tm); err != nil {
+	if err := s.queueEssentialMeta(nil, tm); err != nil {
 		return err
 	}
 	s.mode = mode
-	if err := s.loadModelRestMeta(tm); err != nil {
+	if err := s.queueModelRestMeta(tm); err != nil {
 		return err
 	}
 
@@ -575,7 +575,7 @@ func (s *seed20) LoadEssentialMeta(essentialTypes []snap.Type, tm timings.Measur
 		filterEssential = essentialSnapTypesToModelFilter(essentialTypes)
 	}
 
-	if err := s.loadEssentialMeta(filterEssential, tm); err != nil {
+	if err := s.queueEssentialMeta(filterEssential, tm); err != nil {
 		return err
 	}
 
@@ -617,7 +617,7 @@ func (s *seed20) resetSnaps() {
 	s.essentialSnapsNum = 0
 }
 
-func (s *seed20) loadEssentialMeta(filterEssential func(*asserts.ModelSnap) bool, tm timings.Measurer) error {
+func (s *seed20) queueEssentialMeta(filterEssential func(*asserts.ModelSnap) bool, tm timings.Measurer) error {
 	model := s.Model()
 
 	if err := s.loadMetaFiles(); err != nil {
@@ -670,7 +670,7 @@ func snapModesInclude(snapModes []string, mode string) bool {
 	return strutil.ListContains(snapModes, "ephemeral")
 }
 
-func (s *seed20) loadModelRestMeta(tm timings.Measurer) error {
+func (s *seed20) queueModelRestMeta(tm timings.Measurer) error {
 	model := s.Model()
 
 	var filterMode func(*asserts.ModelSnap) bool

--- a/seed/seed20_test.go
+++ b/seed/seed20_test.go
@@ -2002,6 +2002,10 @@ func (s *seed20Suite) TestLoadMetaCore20NotRunSnaps(c *C) {
 }
 
 func (s *seed20Suite) TestLoadMetaCore20PreciseNotRunSnaps(c *C) {
+	s.testLoadMetaCore20PreciseNotRunSnapsWithParallelism(c, 1)
+}
+
+func (s *seed20Suite) testLoadMetaCore20PreciseNotRunSnapsWithParallelism(c *C, parallelism int) {
 	s.makeSnap(c, "snapd", "")
 	s.makeSnap(c, "core20", "")
 	s.makeSnap(c, "pc-kernel=20", "")
@@ -2056,6 +2060,8 @@ func (s *seed20Suite) TestLoadMetaCore20PreciseNotRunSnaps(c *C) {
 
 	err = seed20.LoadAssertions(s.db, s.commitTo)
 	c.Assert(err, IsNil)
+
+	seed20.SetParallelism(parallelism)
 
 	err = seed20.LoadMeta("install", s.perfTimings)
 	c.Assert(err, IsNil)
@@ -2167,6 +2173,10 @@ func (s *seed20Suite) TestLoadMetaCore20PreciseNotRunSnaps(c *C) {
 			Channel:  "latest/stable",
 		},
 	})
+}
+
+func (s *seed20Suite) TestLoadMetaCore20PreciseNotRunSnapsParallelism2(c *C) {
+	s.testLoadMetaCore20PreciseNotRunSnapsWithParallelism(c, 2)
 }
 
 func (s *seed20Suite) TestLoadMetaCore20LocalAssertedSnaps(c *C) {
@@ -2342,4 +2352,38 @@ func (s *seed20Suite) TestLoadMetaCore20Iter(c *C) {
 		return nil
 	})
 	c.Assert(err, ErrorMatches, `mock error for snap "core20"`)
+}
+
+func (s *seed20Suite) TestLoadMetaWrongHashSnapParallelism2(c *C) {
+	sysLabel := "20191031"
+	sysDir := s.makeCore20MinimalSeed(c, sysLabel)
+
+	pcKernelRev := s.AssertedSnapRevision("pc-kernel")
+	wrongRev, err := s.StoreSigning.Sign(asserts.SnapRevisionType, map[string]interface{}{
+		"snap-sha3-384": strings.Repeat("B", 64),
+		"snap-size":     pcKernelRev.HeaderString("snap-size"),
+		"snap-id":       s.AssertedSnapID("pc-kernel"),
+		"developer-id":  "canonical",
+		"snap-revision": pcKernelRev.HeaderString("snap-revision"),
+		"timestamp":     time.Now().UTC().Format(time.RFC3339),
+	}, nil, "")
+	c.Assert(err, IsNil)
+
+	s.massageAssertions(c, filepath.Join(sysDir, "assertions", "snaps"), func(a asserts.Assertion) asserts.Assertion {
+		if a.Type() == asserts.SnapRevisionType && a.HeaderString("snap-id") == s.AssertedSnapID("pc-kernel") {
+			return wrongRev
+		}
+		return a
+	})
+
+	seed20, err := seed.Open(s.SeedDir, sysLabel)
+	c.Assert(err, IsNil)
+
+	err = seed20.LoadAssertions(s.db, s.commitTo)
+	c.Assert(err, IsNil)
+
+	seed20.SetParallelism(2)
+
+	err = seed20.LoadMeta(seed.AllModes, s.perfTimings)
+	c.Check(err, ErrorMatches, `cannot validate ".*pc-kernel_1\.snap" for snap "pc-kernel" \(snap-id "pckernel.*"\), hash mismatch with snap-revision`)
 }


### PR DESCRIPTION
This adds Seed.SetParallelism to control this.
Concretely ATM it is only implemented for UC 20+ seeds.