### PR TITLE
o/snapstate: fix TestSnapdRefreshTasks test after two r-a-a PRs

### DIFF
--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -7719,11 +7719,6 @@ func (s *snapmgrTestSuite) TestSnapdRefreshTasks(c *C) {
 			name: "snapd",
 		},
 		{
-			op:          "run-inhibit-snap-for-unlink",
-			name:        "snapd",
-			inhibitHint: "refresh",
-		},
-		{
 			op:   "copy-data",
 			path: filepath.Join(dirs.SnapMountDir, "snapd/11"),
 			old:  filepath.Join(dirs.SnapMountDir, "snapd/1"),


### PR DESCRIPTION
Two PRs for refresh-app-awareness landed at the same time, one of them enabled r-a-a by default adding expected run-inhibit-snap-for-unlink backend op to `TestSnapdRefreshTasks` test , the other PR however excluded snapd from r-a-a runinhibit logic but since the PRs were independent, this exploded only in master.