### PR TITLE
interfaces/builtin/system-packages: use a broad AppArmor snippet for mounting /usr/share/*-docs

### DIFF
--- a/interfaces/builtin/system_packages_doc.go
+++ b/interfaces/builtin/system_packages_doc.go
@@ -40,9 +40,8 @@ const systemPackagesDocConnectedPlugAppArmor = `
 # Description: can access documentation of system packages.
 
 /usr/share/doc/{,**} r,
-/usr/share/gtk-doc/{,**} r,
+/usr/share/*-doc{,s}/{,**} r,
 /usr/share/libreoffice/help/{,**} r,
-/usr/share/xubuntu-docs/{,**} r,
 `
 
 type systemPackagesDocInterface struct {
@@ -62,11 +61,14 @@ func (iface *systemPackagesDocInterface) AppArmorConnectedPlug(spec *apparmor.Sp
 	emit("  mount options=(bind) /var/lib/snapd/hostfs/usr/share/libreoffice/help/ -> /usr/share/libreoffice/help/,\n")
 	emit("  remount options=(bind, ro) /usr/share/libreoffice/help/,\n")
 	emit("  umount /usr/share/libreoffice/help/,\n")
-	emit("  mount options=(bind) /var/lib/snapd/hostfs/usr/share/xubuntu-docs/ -> /usr/share/xubuntu-docs/,\n")
-	emit("  remount options=(bind, ro) /usr/share/xubuntu-docs/,\n")
-	emit("  umount /usr/share/xubuntu-docs/,\n")
-	// the mount targets under /usr/share/ do not necessarily exist in the
-	// base image, in which case, we need to create a writable mimic
+	// generic docs from the host
+	emit("  # Mount generic *-docs locations from /usr/share\n")
+	emit("  mount options=(bind) /var/lib/snapd/hostfs/usr/share/*-doc{,s}/ -> /usr/share/*-doc{,s}/,\n")
+	emit("  remount options=(bind, ro) /usr/share/*-doc{,s}/,\n")
+	emit("  umount /usr/share/*-doc{,s}/,\n")
+	// The docs locations may not exist under /usr/share in the base snap,
+	// what will trigger a mimic to be created and the profile needs to
+	// allow it.
 	apparmor.GenWritableProfile(emit, "/usr/share/", 3)
 	return nil
 }

--- a/interfaces/builtin/system_packages_doc_test.go
+++ b/interfaces/builtin/system_packages_doc_test.go
@@ -87,7 +87,7 @@ func (s *systemPackagesDocSuite) TestAppArmorSpec(c *C) {
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "# Description: can access documentation of system packages.")
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/usr/share/doc/{,**} r,")
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/usr/share/libreoffice/help/{,**} r,")
-	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/usr/share/xubuntu-docs/{,**} r,")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/usr/share/*-doc{,s}/{,**} r,")
 
 	updateNS := spec.UpdateNS()
 	c.Check(updateNS, testutil.Contains, "  # Mount documentation of system packages\n")
@@ -103,16 +103,16 @@ func (s *systemPackagesDocSuite) TestAppArmorSpec(c *C) {
 	c.Check(updateNS, testutil.Contains, "  remount options=(bind, ro) /usr/share/libreoffice/help/,\n")
 	c.Check(updateNS, testutil.Contains, "  umount /usr/share/libreoffice/help/,\n")
 
-	c.Check(updateNS, testutil.Contains, "  mount options=(bind) /var/lib/snapd/hostfs/usr/share/xubuntu-docs/ -> /usr/share/xubuntu-docs/,\n")
-	c.Check(updateNS, testutil.Contains, "  remount options=(bind, ro) /usr/share/xubuntu-docs/,\n")
-	c.Check(updateNS, testutil.Contains, "  umount /usr/share/xubuntu-docs/,\n")
-	// check mimic bits
 	c.Check(updateNS, testutil.Contains, "  # Writable mimic /usr/share\n")
 	c.Check(updateNS, testutil.Contains, "  mount fstype=tmpfs options=(rw) tmpfs -> \"/usr/share/\",\n")
 	c.Check(updateNS, testutil.Contains, "  \"/usr/share/\" r,\n")
 	c.Check(updateNS, testutil.Contains, "  \"/tmp/.snap/usr/share/\" rw,\n")
 	c.Check(updateNS, testutil.Contains, "  mount options=(bind, rw) \"/tmp/.snap/usr/share/*\" -> \"/usr/share/*\",\n")
 
+	c.Check(updateNS, testutil.Contains, "  # Mount generic *-docs locations from /usr/share\n")
+	c.Check(updateNS, testutil.Contains, "  mount options=(bind) /var/lib/snapd/hostfs/usr/share/*-doc{,s}/ -> /usr/share/*-doc{,s}/,\n")
+	c.Check(updateNS, testutil.Contains, "  remount options=(bind, ro) /usr/share/*-doc{,s}/,\n")
+	c.Check(updateNS, testutil.Contains, "  umount /usr/share/*-doc{,s}/,\n")
 }
 
 func (s *systemPackagesDocSuite) TestMountSpec(c *C) {


### PR DESCRIPTION
As suggested in #11615

We still need to add a mount snippet for each doc, but at least we don't have to update the apparmor rules. The tests/main/interfaces-system-packages-doc spread test verifies accesses to xubuntu-docs and gtk-doc already.