### PR TITLE
interfaces,overlord: add support for adding extra mount layouts

### DIFF
--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -411,6 +411,9 @@ func (b *Backend) prepareProfiles(snapInfo *snap.Info, opts interfaces.Confineme
 	// Add snippets derived from the layout definition.
 	spec.(*Specification).AddLayout(snapInfo)
 
+	// Add additional mount layouts rules for the snap.
+	spec.(*Specification).AddExtraLayouts(snapInfo, opts.ExtraLayouts)
+
 	// core on classic is special
 	if snapName == "core" && release.OnClassic && apparmor_sandbox.ProbedLevel() != apparmor_sandbox.Unsupported {
 		if err := b.setupSnapConfineReexec(snapInfo); err != nil {

--- a/interfaces/apparmor/spec.go
+++ b/interfaces/apparmor/spec.go
@@ -289,24 +289,24 @@ func (spec *Specification) emitLayout(si *snap.Info, layout *snap.Layout) {
 //   the data)
 // Importantly, the above mount operations are happening within the per-snap
 // mount namespace.
-func (spec *Specification) AddLayout(si *snap.Info) {
-	if len(si.Layout) == 0 {
+func (spec *Specification) AddLayout(snapInfo *snap.Info) {
+	if len(snapInfo.Layout) == 0 {
 		return
 	}
 
 	// Walk the layout elements in deterministic order, by mount point name.
-	paths := make([]string, 0, len(si.Layout))
-	for path := range si.Layout {
+	paths := make([]string, 0, len(snapInfo.Layout))
+	for path := range snapInfo.Layout {
 		paths = append(paths, path)
 	}
 	sort.Strings(paths)
 
 	// Get tags describing all apps and hooks.
-	tags := make([]string, 0, len(si.Apps)+len(si.Hooks))
-	for _, app := range si.Apps {
+	tags := make([]string, 0, len(snapInfo.Apps)+len(snapInfo.Hooks))
+	for _, app := range snapInfo.Apps {
 		tags = append(tags, app.SecurityTag())
 	}
-	for _, hook := range si.Hooks {
+	for _, hook := range snapInfo.Hooks {
 		tags = append(tags, hook.SecurityTag())
 	}
 
@@ -317,7 +317,7 @@ func (spec *Specification) AddLayout(si *snap.Info) {
 	}
 	for _, tag := range tags {
 		for _, path := range paths {
-			snippet := snippetFromLayout(si.Layout[path])
+			snippet := snippetFromLayout(snapInfo.Layout[path])
 			spec.snippets[tag] = append(spec.snippets[tag], snippet)
 		}
 		sort.Strings(spec.snippets[tag])
@@ -325,8 +325,8 @@ func (spec *Specification) AddLayout(si *snap.Info) {
 
 	// Append update-ns snippets that allow constructing the layout.
 	for _, path := range paths {
-		layout := si.Layout[path]
-		spec.emitLayout(si, layout)
+		layout := snapInfo.Layout[path]
+		spec.emitLayout(snapInfo, layout)
 	}
 }
 

--- a/interfaces/apparmor/spec.go
+++ b/interfaces/apparmor/spec.go
@@ -331,8 +331,8 @@ func (spec *Specification) AddLayout(si *snap.Info) {
 }
 
 // AddExtraLayouts adds additional apparmor snippets based on the provided layouts.
-// The function is in part identical to AddLayout, except that it directly emits
-// the extra layouts.
+// The function is in part identical to AddLayout, except that it considers only the
+// layouts passed as parameters instead of those declared in the snap.Info structure.
 // XXX: Should we just combine this into AddLayout instead of this separate
 // function?
 func (spec *Specification) AddExtraLayouts(si *snap.Info, layouts []snap.Layout) {

--- a/interfaces/apparmor/spec.go
+++ b/interfaces/apparmor/spec.go
@@ -235,6 +235,43 @@ func (spec *Specification) UpdateNSIndexOf(snippet string) (idx int, ok bool) {
 	return spec.updateNS.IndexOf(snippet)
 }
 
+func (spec *Specification) emitLayout(si *snap.Info, layout *snap.Layout) {
+	emit := spec.AddUpdateNSf
+
+	emit("  # Layout %s\n", layout.String())
+	path := si.ExpandSnapVariables(layout.Path)
+	switch {
+	case layout.Bind != "":
+		bind := si.ExpandSnapVariables(layout.Bind)
+		// Allow bind mounting the layout element.
+		emit("  mount options=(rbind, rw) \"%s/\" -> \"%s/\",\n", bind, path)
+		emit("  mount options=(rprivate) -> \"%s/\",\n", path)
+		emit("  umount \"%s/\",\n", path)
+		// Allow constructing writable mimic in both bind-mount source and mount point.
+		GenWritableProfile(emit, path, 2) // At least / and /some-top-level-directory
+		GenWritableProfile(emit, bind, 4) // At least /, /snap/, /snap/$SNAP_NAME and /snap/$SNAP_NAME/$SNAP_REVISION
+	case layout.BindFile != "":
+		bindFile := si.ExpandSnapVariables(layout.BindFile)
+		// Allow bind mounting the layout element.
+		emit("  mount options=(bind, rw) \"%s\" -> \"%s\",\n", bindFile, path)
+		emit("  mount options=(rprivate) -> \"%s\",\n", path)
+		emit("  umount \"%s\",\n", path)
+		// Allow constructing writable mimic in both bind-mount source and mount point.
+		GenWritableFileProfile(emit, path, 2)     // At least / and /some-top-level-directory
+		GenWritableFileProfile(emit, bindFile, 4) // At least /, /snap/, /snap/$SNAP_NAME and /snap/$SNAP_NAME/$SNAP_REVISION
+	case layout.Type == "tmpfs":
+		emit("  mount fstype=tmpfs tmpfs -> \"%s/\",\n", path)
+		emit("  mount options=(rprivate) -> \"%s/\",\n", path)
+		emit("  umount \"%s/\",\n", path)
+		// Allow constructing writable mimic to mount point.
+		GenWritableProfile(emit, path, 2) // At least / and /some-top-level-directory
+	case layout.Symlink != "":
+		// Allow constructing writable mimic to symlink parent directory.
+		emit("  \"%s\" rw,\n", path)
+		GenWritableProfile(emit, path, 2) // At least / and /some-top-level-directory
+	}
+}
+
 // AddLayout adds apparmor snippets based on the layout of the snap.
 //
 // The per-snap snap-update-ns profiles are composed via a template and
@@ -286,43 +323,21 @@ func (spec *Specification) AddLayout(si *snap.Info) {
 		sort.Strings(spec.snippets[tag])
 	}
 
-	emit := spec.AddUpdateNSf
-
 	// Append update-ns snippets that allow constructing the layout.
 	for _, path := range paths {
-		l := si.Layout[path]
-		emit("  # Layout %s\n", l.String())
-		path := si.ExpandSnapVariables(l.Path)
-		switch {
-		case l.Bind != "":
-			bind := si.ExpandSnapVariables(l.Bind)
-			// Allow bind mounting the layout element.
-			emit("  mount options=(rbind, rw) \"%s/\" -> \"%s/\",\n", bind, path)
-			emit("  mount options=(rprivate) -> \"%s/\",\n", path)
-			emit("  umount \"%s/\",\n", path)
-			// Allow constructing writable mimic in both bind-mount source and mount point.
-			GenWritableProfile(emit, path, 2) // At least / and /some-top-level-directory
-			GenWritableProfile(emit, bind, 4) // At least /, /snap/, /snap/$SNAP_NAME and /snap/$SNAP_NAME/$SNAP_REVISION
-		case l.BindFile != "":
-			bindFile := si.ExpandSnapVariables(l.BindFile)
-			// Allow bind mounting the layout element.
-			emit("  mount options=(bind, rw) \"%s\" -> \"%s\",\n", bindFile, path)
-			emit("  mount options=(rprivate) -> \"%s\",\n", path)
-			emit("  umount \"%s\",\n", path)
-			// Allow constructing writable mimic in both bind-mount source and mount point.
-			GenWritableFileProfile(emit, path, 2)     // At least / and /some-top-level-directory
-			GenWritableFileProfile(emit, bindFile, 4) // At least /, /snap/, /snap/$SNAP_NAME and /snap/$SNAP_NAME/$SNAP_REVISION
-		case l.Type == "tmpfs":
-			emit("  mount fstype=tmpfs tmpfs -> \"%s/\",\n", path)
-			emit("  mount options=(rprivate) -> \"%s/\",\n", path)
-			emit("  umount \"%s/\",\n", path)
-			// Allow constructing writable mimic to mount point.
-			GenWritableProfile(emit, path, 2) // At least / and /some-top-level-directory
-		case l.Symlink != "":
-			// Allow constructing writable mimic to symlink parent directory.
-			emit("  \"%s\" rw,\n", path)
-			GenWritableProfile(emit, path, 2) // At least / and /some-top-level-directory
-		}
+		layout := si.Layout[path]
+		spec.emitLayout(si, layout)
+	}
+}
+
+// AddExtraLayouts adds additional apparmor snippets based on the provided layouts.
+// The function is in part identical to AddLayout, except that it directly emits
+// the extra layouts.
+// XXX: Should we just combine this into AddLayout instead of this separate
+// function?
+func (spec *Specification) AddExtraLayouts(si *snap.Info, layouts []snap.Layout) {
+	for _, layout := range layouts {
+		spec.emitLayout(si, &layout)
 	}
 }
 

--- a/interfaces/apparmor/spec_test.go
+++ b/interfaces/apparmor/spec_test.go
@@ -522,15 +522,19 @@ func (s *specSuite) TestApparmorExtraLayouts(c *C) {
 	}
 
 	s.spec.AddExtraLayouts(snapInfo, extraLayouts)
-	c.Assert(s.spec.Snippets(), HasLen, 0)
 
 	updateNS := s.spec.UpdateNS()
+
+	// verify that updateNS does indeed add all the additional layout
+	// lines. This just so happens to be 10 in this case because of reverse
+	// traversal for the path /usr/home/test
 	c.Assert(updateNS, HasLen, 10)
 
 	// make sure the extra layout is added
 	c.Assert(updateNS[0], Equals, "  # Layout /test: bind /usr/home/test\n")
 	c.Assert(updateNS[1], Equals, "  mount options=(rbind, rw) \"/usr/home/test/\" -> \"/test/\",\n")
 	c.Assert(updateNS[2], Equals, "  mount options=(rprivate) -> \"/test/\",\n")
+	// lines 3..9 is the traversal of the prefix for /usr/home/test
 }
 
 func (s *specSuite) TestUsesPtraceTrace(c *C) {

--- a/interfaces/apparmor/spec_test.go
+++ b/interfaces/apparmor/spec_test.go
@@ -506,6 +506,33 @@ func (s *specSuite) TestApparmorOvernameSnippets(c *C) {
 	c.Assert(updateNS[0], Equals, profile)
 }
 
+func (s *specSuite) TestApparmorExtraLayouts(c *C) {
+	snapInfo := snaptest.MockInfo(c, snapTrivial, &snap.SideInfo{Revision: snap.R(42)})
+	snapInfo.InstanceKey = "instance"
+
+	restore := apparmor.SetSpecScope(s.spec, []string{"snap.some-snap_instace.app"})
+	defer restore()
+
+	extraLayouts := []snap.Layout{
+		{
+			Path: "/test",
+			Bind: "/usr/home/test",
+			Mode: 0755,
+		},
+	}
+
+	s.spec.AddExtraLayouts(snapInfo, extraLayouts)
+	c.Assert(s.spec.Snippets(), HasLen, 0)
+
+	updateNS := s.spec.UpdateNS()
+	c.Assert(updateNS, HasLen, 10)
+
+	// make sure the extra layout is added
+	c.Assert(updateNS[0], Equals, "  # Layout /test: bind /usr/home/test\n")
+	c.Assert(updateNS[1], Equals, "  mount options=(rbind, rw) \"/usr/home/test/\" -> \"/test/\",\n")
+	c.Assert(updateNS[2], Equals, "  mount options=(rprivate) -> \"/test/\",\n")
+}
+
 func (s *specSuite) TestUsesPtraceTrace(c *C) {
 	c.Assert(s.spec.UsesPtraceTrace(), Equals, false)
 	s.spec.SetUsesPtraceTrace()

--- a/interfaces/backend.go
+++ b/interfaces/backend.go
@@ -63,6 +63,12 @@ type ConfinementOptions struct {
 	JailMode bool
 	// Classic flag switches the core snap "chroot" off.
 	Classic bool
+	// ExtraLayouts is a list of extra mount layouts to add to the
+	// snap. One example being if the snap is inside a quota group
+	// with a journal quota set. This will require an additional layout
+	// as systemd provides a mount namespace which will clash with the
+	// one snapd sets up.
+	ExtraLayouts []snap.Layout
 }
 
 // SecurityBackendOptions carries extra flags that affect initialization of the

--- a/interfaces/mount/backend.go
+++ b/interfaces/mount/backend.go
@@ -65,6 +65,7 @@ func (b *Backend) Setup(snapInfo *snap.Info, confinement interfaces.ConfinementO
 	}
 	spec.(*Specification).AddOvername(snapInfo)
 	spec.(*Specification).AddLayout(snapInfo)
+	spec.(*Specification).AddExtraLayouts(confinement.ExtraLayouts)
 	content := deriveContent(spec.(*Specification), snapInfo)
 	// synchronize the content with the filesystem
 	glob := fmt.Sprintf("snap.%s.*fstab", snapName)

--- a/interfaces/mount/spec.go
+++ b/interfaces/mount/spec.go
@@ -142,8 +142,8 @@ func (spec *Specification) AddLayout(si *snap.Info) {
 
 // AddExtraLayouts adds mount entries based on additional layouts that
 // are provided for the snap.
-func (spec *Specification) AddExtraLayouts(ExtraLayouts []snap.Layout) {
-	for _, layout := range ExtraLayouts {
+func (spec *Specification) AddExtraLayouts(layouts []snap.Layout) {
+	for _, layout := range layouts {
 		entry := mountEntryFromLayout(&layout)
 		spec.layout = append(spec.layout, entry)
 	}

--- a/interfaces/mount/spec.go
+++ b/interfaces/mount/spec.go
@@ -140,6 +140,15 @@ func (spec *Specification) AddLayout(si *snap.Info) {
 	}
 }
 
+// AddExtraLayouts adds mount entries based on additional layouts that
+// are provided for the snap.
+func (spec *Specification) AddExtraLayouts(ExtraLayouts []snap.Layout) {
+	for _, layout := range ExtraLayouts {
+		entry := mountEntryFromLayout(&layout)
+		spec.layout = append(spec.layout, entry)
+	}
+}
+
 // MountEntries returns a copy of the added mount entries.
 func (spec *Specification) MountEntries() []osutil.MountEntry {
 	result := make([]osutil.MountEntry, 0, len(spec.overname)+len(spec.layout)+len(spec.general))

--- a/interfaces/mount/spec_test.go
+++ b/interfaces/mount/spec_test.go
@@ -164,6 +164,21 @@ func (s *specSuite) TestMountEntryFromLayout(c *C) {
 	})
 }
 
+func (s *specSuite) TestMountEntryFromExtraLayouts(c *C) {
+	extraLayouts := []snap.Layout{
+		{
+			Path: "/test",
+			Bind: "/usr/home/test",
+			Mode: 0755,
+		},
+	}
+
+	s.spec.AddExtraLayouts(extraLayouts)
+	c.Assert(s.spec.MountEntries(), DeepEquals, []osutil.MountEntry{
+		{Dir: "/test", Name: "/usr/home/test", Options: []string{"rbind", "rw", "x-snapd.origin=layout"}},
+	})
+}
+
 func (s *specSuite) TestParallelInstanceMountEntryFromLayout(c *C) {
 	snapInfo := snaptest.MockInfo(c, snapWithLayout, &snap.SideInfo{Revision: snap.R(42)})
 	snapInfo.InstanceKey = "instance"

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -1700,8 +1700,8 @@ func (s *interfaceManagerSuite) testDisconnect(c *C, plugSnap, plugName, slotSna
 	c.Check(s.secBackend.SetupCalls[0].SnapInfo.InstanceName(), Equals, "consumer")
 	c.Check(s.secBackend.SetupCalls[1].SnapInfo.InstanceName(), Equals, "producer")
 
-	c.Check(s.secBackend.SetupCalls[0].Options, Equals, interfaces.ConfinementOptions{})
-	c.Check(s.secBackend.SetupCalls[1].Options, Equals, interfaces.ConfinementOptions{})
+	c.Check(s.secBackend.SetupCalls[0].Options, DeepEquals, interfaces.ConfinementOptions{})
+	c.Check(s.secBackend.SetupCalls[1].Options, DeepEquals, interfaces.ConfinementOptions{})
 }
 
 func (s *interfaceManagerSuite) TestDisconnectUndo(c *C) {
@@ -3434,8 +3434,8 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityReloadsConnectionsWhenInv
 	c.Check(s.secBackend.SetupCalls[0].SnapInfo.InstanceName(), Equals, "consumer")
 	c.Check(s.secBackend.SetupCalls[1].SnapInfo.InstanceName(), Equals, "producer")
 
-	c.Check(s.secBackend.SetupCalls[0].Options, Equals, interfaces.ConfinementOptions{})
-	c.Check(s.secBackend.SetupCalls[1].Options, Equals, interfaces.ConfinementOptions{})
+	c.Check(s.secBackend.SetupCalls[0].Options, DeepEquals, interfaces.ConfinementOptions{})
+	c.Check(s.secBackend.SetupCalls[1].Options, DeepEquals, interfaces.ConfinementOptions{})
 }
 
 func (s *interfaceManagerSuite) TestDoSetupSnapSecurityReloadsConnectionsWhenInvokedOnSlotSide(c *C) {
@@ -3452,8 +3452,8 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityReloadsConnectionsWhenInv
 	c.Check(s.secBackend.SetupCalls[0].SnapInfo.InstanceName(), Equals, "producer")
 	c.Check(s.secBackend.SetupCalls[1].SnapInfo.InstanceName(), Equals, "consumer")
 
-	c.Check(s.secBackend.SetupCalls[0].Options, Equals, interfaces.ConfinementOptions{})
-	c.Check(s.secBackend.SetupCalls[1].Options, Equals, interfaces.ConfinementOptions{})
+	c.Check(s.secBackend.SetupCalls[0].Options, DeepEquals, interfaces.ConfinementOptions{})
+	c.Check(s.secBackend.SetupCalls[1].Options, DeepEquals, interfaces.ConfinementOptions{})
 }
 
 func (s *interfaceManagerSuite) testDoSetupSnapSecurityReloadsConnectionsWhenInvokedOn(c *C, snapName string, revision snap.Revision) {
@@ -3523,7 +3523,7 @@ func (s *interfaceManagerSuite) TestSetupProfilesHonorsDevMode(c *C) {
 	c.Assert(s.secBackend.SetupCalls, HasLen, 1)
 	c.Assert(s.secBackend.RemoveCalls, HasLen, 0)
 	c.Check(s.secBackend.SetupCalls[0].SnapInfo.InstanceName(), Equals, "snap")
-	c.Check(s.secBackend.SetupCalls[0].Options, Equals, interfaces.ConfinementOptions{DevMode: true})
+	c.Check(s.secBackend.SetupCalls[0].Options, DeepEquals, interfaces.ConfinementOptions{DevMode: true})
 }
 
 func (s *interfaceManagerSuite) TestSetupProfilesSetupManyError(c *C) {
@@ -4072,8 +4072,8 @@ func (s *interfaceManagerSuite) TestConnectSetsUpSecurity(c *C) {
 	c.Check(s.secBackend.SetupCalls[0].SnapInfo.InstanceName(), Equals, "producer")
 	c.Check(s.secBackend.SetupCalls[1].SnapInfo.InstanceName(), Equals, "consumer")
 
-	c.Check(s.secBackend.SetupCalls[0].Options, Equals, interfaces.ConfinementOptions{})
-	c.Check(s.secBackend.SetupCalls[1].Options, Equals, interfaces.ConfinementOptions{})
+	c.Check(s.secBackend.SetupCalls[0].Options, DeepEquals, interfaces.ConfinementOptions{})
+	c.Check(s.secBackend.SetupCalls[1].Options, DeepEquals, interfaces.ConfinementOptions{})
 }
 
 func (s *interfaceManagerSuite) TestConnectSetsHotplugKeyFromTheSlot(c *C) {
@@ -4162,8 +4162,8 @@ func (s *interfaceManagerSuite) TestDisconnectSetsUpSecurity(c *C) {
 	c.Check(s.secBackend.SetupCalls[0].SnapInfo.InstanceName(), Equals, "consumer")
 	c.Check(s.secBackend.SetupCalls[1].SnapInfo.InstanceName(), Equals, "producer")
 
-	c.Check(s.secBackend.SetupCalls[0].Options, Equals, interfaces.ConfinementOptions{})
-	c.Check(s.secBackend.SetupCalls[1].Options, Equals, interfaces.ConfinementOptions{})
+	c.Check(s.secBackend.SetupCalls[0].Options, DeepEquals, interfaces.ConfinementOptions{})
+	c.Check(s.secBackend.SetupCalls[1].Options, DeepEquals, interfaces.ConfinementOptions{})
 }
 
 func (s *interfaceManagerSuite) TestDisconnectTracksConnectionsInState(c *C) {
@@ -4588,9 +4588,9 @@ func (s *interfaceManagerSuite) TestSetupProfilesDevModeMultiple(c *C) {
 	c.Assert(s.secBackend.SetupCalls, HasLen, 2)
 	c.Assert(s.secBackend.RemoveCalls, HasLen, 0)
 	c.Check(s.secBackend.SetupCalls[0].SnapInfo.InstanceName(), Equals, siC.InstanceName())
-	c.Check(s.secBackend.SetupCalls[0].Options, Equals, interfaces.ConfinementOptions{DevMode: true})
+	c.Check(s.secBackend.SetupCalls[0].Options, DeepEquals, interfaces.ConfinementOptions{DevMode: true})
 	c.Check(s.secBackend.SetupCalls[1].SnapInfo.InstanceName(), Equals, siP.InstanceName())
-	c.Check(s.secBackend.SetupCalls[1].Options, Equals, interfaces.ConfinementOptions{})
+	c.Check(s.secBackend.SetupCalls[1].Options, DeepEquals, interfaces.ConfinementOptions{})
 }
 
 func (s *interfaceManagerSuite) TestCheckInterfacesDeny(c *C) {
@@ -4974,7 +4974,7 @@ func (s *interfaceManagerSuite) TestUndoSetupProfilesOnRefresh(c *C) {
 	c.Assert(s.secBackend.RemoveCalls, HasLen, 0)
 	c.Check(s.secBackend.SetupCalls[0].SnapInfo.InstanceName(), Equals, snapInfo.InstanceName())
 	c.Check(s.secBackend.SetupCalls[0].SnapInfo.Revision, Equals, snapInfo.Revision)
-	c.Check(s.secBackend.SetupCalls[0].Options, Equals, interfaces.ConfinementOptions{})
+	c.Check(s.secBackend.SetupCalls[0].Options, DeepEquals, interfaces.ConfinementOptions{})
 }
 
 func (s *interfaceManagerSuite) TestManagerTransitionConnectionsCore(c *C) {
@@ -5290,14 +5290,14 @@ func (s *interfaceManagerSuite) TestUndoConnect(c *C) {
 	c.Assert(s.secBackend.SetupCalls, HasLen, 4)
 	c.Check(s.secBackend.SetupCalls[0].SnapInfo.InstanceName(), Equals, "producer")
 	c.Check(s.secBackend.SetupCalls[1].SnapInfo.InstanceName(), Equals, "consumer")
-	c.Check(s.secBackend.SetupCalls[0].Options, Equals, interfaces.ConfinementOptions{})
-	c.Check(s.secBackend.SetupCalls[1].Options, Equals, interfaces.ConfinementOptions{})
+	c.Check(s.secBackend.SetupCalls[0].Options, DeepEquals, interfaces.ConfinementOptions{})
+	c.Check(s.secBackend.SetupCalls[1].Options, DeepEquals, interfaces.ConfinementOptions{})
 
 	// by undo
 	c.Check(s.secBackend.SetupCalls[2].SnapInfo.InstanceName(), Equals, "producer")
 	c.Check(s.secBackend.SetupCalls[3].SnapInfo.InstanceName(), Equals, "consumer")
-	c.Check(s.secBackend.SetupCalls[2].Options, Equals, interfaces.ConfinementOptions{})
-	c.Check(s.secBackend.SetupCalls[3].Options, Equals, interfaces.ConfinementOptions{})
+	c.Check(s.secBackend.SetupCalls[2].Options, DeepEquals, interfaces.ConfinementOptions{})
+	c.Check(s.secBackend.SetupCalls[3].Options, DeepEquals, interfaces.ConfinementOptions{})
 }
 
 func (s *interfaceManagerSuite) TestUndoConnectUndesired(c *C) {


### PR DESCRIPTION
In preparation of adding support for journal namespace bind mount, we need to be able to add additional mount entries based on the current state of the snap (/whether the snap is in a quota group with a journal quota for instance), to mimic what systemd does during setup.

This is a followup PR based on my first attempt at adding this support, and with some guidance from Samuele, see https://github.com/snapcore/snapd/pull/11672.