### PR TITLE
tests: fix interfaces-location-control tests leaking provider.py process

### DIFF
--- a/tests/main/interfaces-location-control/task.yaml
+++ b/tests/main/interfaces-location-control/task.yaml
@@ -29,6 +29,11 @@ prepare: |
 
 restore: |
     systemctl stop test-snapd-location-control-provider.service
+    # provider.py was started from a snap by the test-snapd-location-control-provider.service unit,
+    # normally it should be enough to kill the whole unit, however since that process
+    # was started from a snap, it got moved to a separate snap-specific transient
+    # scope, thus it is no longer part of the unit's cgroup
+    pkill -f provider.py || true
     tests.session -u test restore
 
 execute: |


### PR DESCRIPTION
The new invariant check https://github.com/snapcore/snapd/pull/11693 revealed one more test that has a problem similar to op-remove-retry test (already fixed that one).

This should unblock 11693.