### PR TITLE
snap: implement "star" developers

### DIFF
--- a/asserts/account.go
+++ b/asserts/account.go
@@ -58,7 +58,7 @@ func (acc *Account) DisplayName() string {
 }
 
 // Validation returns the level of confidence of the authority in the
-// account's identity, expected to be "unproven" or "verified", and
+// account's identity, expected to be "unproven", "verified" or "starred", and
 // for forward compatibility any value != "unproven" can be considered
 // at least "verified".
 func (acc *Account) Validation() string {

--- a/asserts/account.go
+++ b/asserts/account.go
@@ -58,9 +58,7 @@ func (acc *Account) DisplayName() string {
 }
 
 // Validation returns the level of confidence of the authority in the
-// account's identity, expected to be "unproven", "verified" or "starred", and
-// for forward compatibility any value != "unproven" can be considered
-// at least "verified".
+// account's identity, expected to be "unproven", "starred" or "verified".
 func (acc *Account) Validation() string {
 	return acc.validation
 }

--- a/cmd/snap/cmd_find_test.go
+++ b/cmd/snap/cmd_find_test.go
@@ -143,8 +143,8 @@ func (s *SnapSuite) TestFindSnapName(c *check.C) {
 	c.Assert(rest, check.DeepEquals, []string{})
 
 	c.Check(s.Stdout(), check.Matches, `Name +Version +Publisher +Notes +Summary
-hello +2.10 +canonical\* +- +GNU Hello, the "hello world" snap
-hello-world +6.1 +canonical\* +- +Hello world example
+hello +2.10 +canonical\*\* +- +GNU Hello, the "hello world" snap
+hello-world +6.1 +canonical\*\* +- +Hello world example
 hello-huge +1.0 +noise +- +a really big snap
 `)
 	c.Check(s.Stderr(), check.Equals, "")
@@ -234,7 +234,7 @@ func (s *SnapSuite) TestFindHello(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Matches, `Name +Version +Publisher +Notes +Summary
-hello +2.10 +canonical\* +- +GNU Hello, the "hello world" snap
+hello +2.10 +canonical\*\* +- +GNU Hello, the "hello world" snap
 hello-huge +1.0 +noise +- +a really big snap
 `)
 	c.Check(s.Stderr(), check.Equals, "")
@@ -261,7 +261,7 @@ func (s *SnapSuite) TestFindHelloNarrow(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Matches, `Name +Version +Publisher +Notes +Summary
-hello +2.10 +canonical\* +- +GNU Hello, the "hello world" snap
+hello +2.10 +canonical\*\* +- +GNU Hello, the "hello world" snap
 hello-huge +1.0 +noise +- +a really big snap
 `)
 	c.Check(s.Stderr(), check.Equals, "")
@@ -324,7 +324,7 @@ func (s *SnapSuite) TestFindPriced(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Matches, `Name +Version +Publisher +Notes +Summary
-hello +2.10 +canonical\* +1.99GBP +GNU Hello, the "hello world" snap
+hello +2.10 +canonical\*\* +1.99GBP +GNU Hello, the "hello world" snap
 `)
 	c.Check(s.Stderr(), check.Equals, "")
 }
@@ -385,7 +385,7 @@ func (s *SnapSuite) TestFindPricedAndBought(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Matches, `Name +Version +Publisher +Notes +Summary
-hello +2.10 +canonical\* +bought +GNU Hello, the "hello world" snap
+hello +2.10 +canonical\*\* +bought +GNU Hello, the "hello world" snap
 `)
 	c.Check(s.Stderr(), check.Equals, "")
 }

--- a/cmd/snap/cmd_info_test.go
+++ b/cmd/snap/cmd_info_test.go
@@ -436,7 +436,7 @@ func (s *infoSuite) TestInfoPricedNarrowTerminal(c *check.C) {
 name:    hello
 summary: GNU Hello, the "hello world"
   snap
-publisher: Canonical*
+publisher: Canonical**
 license:   Proprietary
 price:     1.99GBP
 description: |
@@ -471,7 +471,7 @@ func (s *infoSuite) TestInfoPriced(c *check.C) {
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Equals, `name:      hello
 summary:   GNU Hello, the "hello world" snap
-publisher: Canonical*
+publisher: Canonical**
 license:   Proprietary
 price:     1.99GBP
 description: |
@@ -593,7 +593,7 @@ func (s *infoSuite) TestInfoUnquoted(c *check.C) {
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Equals, `name:      hello
 summary:   The GNU Hello snap
-publisher: Canonical*
+publisher: Canonical**
 license:   MIT
 description: |
   GNU hello prints a friendly greeting. This is part of the snapcraft tour at
@@ -699,7 +699,7 @@ health:
   message:  please configure the grawflit
   checked:  2019-05-13T16:27:01+01:00
   revision: 1
-publisher: Canonical*
+publisher: Canonical**
 license:   BSD-3
 description: |
   GNU hello prints a friendly greeting. This is part of the snapcraft tour at
@@ -757,7 +757,7 @@ func (s *infoSuite) TestInfoWithLocalNoLicense(c *check.C) {
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Equals, `name:      hello
 summary:   The GNU Hello snap
-publisher: Canonical*
+publisher: Canonical**
 license:   unset
 description: |
   GNU hello prints a friendly greeting. This is part of the snapcraft tour at
@@ -793,7 +793,7 @@ func (s *infoSuite) TestInfoWithChannelsAndLocal(c *check.C) {
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Equals, `name:      hello
 summary:   The GNU Hello snap
-publisher: Canonical*
+publisher: Canonical**
 store-url: https://snapcraft.io/hello
 license:   unset
 description: |
@@ -820,7 +820,7 @@ installed:     2.10                      (100)  1kB disabled
 	refreshDate := isoDateTimeToLocalDate(c, "2006-01-02T22:04:07.123456789Z")
 	c.Check(s.Stdout(), check.Equals, fmt.Sprintf(`name:      hello
 summary:   The GNU Hello snap
-publisher: Canonical*
+publisher: Canonical**
 store-url: https://snapcraft.io/hello
 license:   unset
 description: |
@@ -893,7 +893,7 @@ func (s *infoSuite) TestInfoHumanTimes(c *check.C) {
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Equals, `name:      hello
 summary:   The GNU Hello snap
-publisher: Canonical*
+publisher: Canonical**
 license:   unset
 description: |
   GNU hello prints a friendly greeting. This is part of the snapcraft tour at
@@ -1118,7 +1118,7 @@ func (s *infoSuite) TestInfoParllelInstance(c *check.C) {
 	// make sure local and remote info is combined in the output
 	c.Check(s.Stdout(), check.Equals, fmt.Sprintf(`name:      hello_foo
 summary:   The GNU Hello snap
-publisher: Canonical*
+publisher: Canonical**
 store-url: https://snapcraft.io/hello
 license:   unset
 description: |
@@ -1198,7 +1198,7 @@ func (s *infoSuite) TestInfoStoreURL(c *check.C) {
 	// make sure local and remote info is combined in the output
 	c.Check(s.Stdout(), check.Equals, fmt.Sprintf(`name:      hello
 summary:   The GNU Hello snap
-publisher: Canonical*
+publisher: Canonical**
 store-url: https://snapcraft.io/hello
 license:   unset
 description: |

--- a/cmd/snap/cmd_model_test.go
+++ b/cmd/snap/cmd_model_test.go
@@ -352,7 +352,7 @@ func (s *SnapSuite) TestModel(c *check.C) {
 			modelF:  simpleHappyResponder(happyModelAssertionResponse),
 			serialF: simpleHappyResponder(happySerialAssertionResponse),
 			outText: `
-brand   MeMeMe (meuser*)
+brand   MeMeMe (meuser**)
 model   test-model
 serial  serialserial
 `[1:],
@@ -362,7 +362,7 @@ serial  serialserial
 			modelF:  simpleHappyResponder(happyUC20ModelAssertionResponse),
 			serialF: simpleHappyResponder(happySerialUC20AssertionResponse),
 			outText: `
-brand           MeMeMe (meuser*)
+brand           MeMeMe (meuser**)
 model           test-snapd-core-20-amd64
 grade           dangerous
 storage-safety  prefer-encrypted
@@ -374,7 +374,7 @@ serial          7777
 			modelF:  simpleHappyResponder(happyModelWithDisplayNameAssertionResponse),
 			serialF: simpleHappyResponder(happySerialAssertionResponse),
 			outText: `
-brand   MeMeMe (meuser*)
+brand   MeMeMe (meuser**)
 model   Model Name (test-model)
 serial  serialserial
 `[1:],
@@ -384,7 +384,7 @@ serial  serialserial
 			modelF:  simpleHappyResponder(happyModelAssertionResponse),
 			serialF: simpleUnhappyResponder(noSerialAssertionYetResponse),
 			outText: `
-brand   MeMeMe (meuser*)
+brand   MeMeMe (meuser**)
 model   test-model
 serial  - (device not registered yet)
 `[1:],

--- a/cmd/snap/color.go
+++ b/cmd/snap/color.go
@@ -207,7 +207,7 @@ func longPublisher(esc *escapes, storeAccount *snap.StoreAccount) string {
 //   right).
 func shortPublisher(esc *escapes, storeAccount *snap.StoreAccount) string {
 	if storeAccount == nil {
-		return "-" + 	esc.green + esc.end
+		return "-" + esc.green + esc.end
 	}
 	var badge, color string
 	switch storeAccount.Validation {

--- a/cmd/snap/color.go
+++ b/cmd/snap/color.go
@@ -128,24 +128,30 @@ var unicodeDescs = mixinDescs{
 }
 
 type escapes struct {
-	green string
-	bold  string
-	end   string
+	green        string
+	brightYellow string
+	bold         string
+	dim          string
+	end          string
 
 	tick, dash, uparrow, star string
 }
 
 var (
 	color = escapes{
-		green: "\033[32m",
-		bold:  "\033[1m",
-		end:   "\033[0m",
+		green:        "\033[32m",
+		brightYellow: "\033[93m",
+		bold:         "\033[1m",
+		dim:          "\033[2m",
+		end:          "\033[0m",
 	}
 
 	mono = escapes{
-		green: "\033[1m",
-		bold:  "\033[1m",
-		end:   "\033[0m",
+		green:        "\033[1m",
+		brightYellow: "\033[2m",
+		bold:         "\033[1m",
+		dim:          "\033[2m",
+		end:          "\033[0m",
 	}
 
 	noesc = escapes{}
@@ -163,26 +169,31 @@ func fillerPublisher(esc *escapes) string {
 // * if the publisher's username and display name match, it's just the display
 //   name; otherwise, it'll include the username in parentheses
 //
-// * if the publisher is verified, it'll include a green check mark; otherwise,
+// * if the publisher is "starred" it'll include a yellow star; if the
+//   publisher is "verified", it'll include a green check mark; otherwise,
 //   it'll include a no-op escape sequence of the same length as the escape
-//   sequence used to make it green (this so that tabwriter gets things right).
+//   sequence used to make it colorful (this so that tabwriter gets things
+//   right).
 func longPublisher(esc *escapes, storeAccount *snap.StoreAccount) string {
+	color := esc.green
 	if storeAccount == nil {
-		return esc.dash + esc.green + esc.end
+		return esc.dash + color + esc.end
 	}
 	badge := ""
 	switch storeAccount.Validation {
 	case "verified":
 		badge = esc.tick
+		color = esc.green
 	case "starred":
 		badge = esc.star
+		color = esc.brightYellow
 	}
 	// NOTE this makes e.g. 'Potato' == 'potato', and 'Potato Team' == 'potato-team',
 	// but 'Potato Team' != 'potatoteam', 'Potato Inc.' != 'potato' (in fact 'Potato Inc.' != 'potato-inc')
 	if strings.EqualFold(strings.Replace(storeAccount.Username, "-", " ", -1), storeAccount.DisplayName) {
-		return storeAccount.DisplayName + esc.green + badge + esc.end
+		return storeAccount.DisplayName + color + badge + esc.end
 	}
-	return fmt.Sprintf("%s (%s%s%s%s)", storeAccount.DisplayName, storeAccount.Username, esc.green, badge, esc.end)
+	return fmt.Sprintf("%s (%s%s%s%s)", storeAccount.DisplayName, storeAccount.Username, color, badge, esc.end)
 }
 
 // shortPublisher returns a string that'll present the publisher of a snap to the
@@ -190,20 +201,25 @@ func longPublisher(esc *escapes, storeAccount *snap.StoreAccount) string {
 //
 // * it'll always be just the username
 //
-// * if the publisher is verified, it'll include a green check mark; otherwise,
+// * if the publisher is "starred" it'll include a yellow star; if the
+//   publisher is "verified", it'll include a green check mark; otherwise,
 //   it'll include a no-op escape sequence of the same length as the escape
-//   sequence used to make it green (this so that tabwriter gets things right).
+//   sequence used to make it colorful (this so that tabwriter gets things
+//   right).
 func shortPublisher(esc *escapes, storeAccount *snap.StoreAccount) string {
+	color := esc.green
 	if storeAccount == nil {
-		return "-" + esc.green + esc.end
+		return "-" + color + esc.end
 	}
 	badge := ""
 	switch storeAccount.Validation {
 	case "verified":
 		badge = esc.tick
+		color = esc.green
 	case "starred":
 		badge = esc.star
+		color = esc.brightYellow
 	}
-	return storeAccount.Username + esc.green + badge + esc.end
+	return storeAccount.Username + color + badge + esc.end
 
 }

--- a/cmd/snap/color.go
+++ b/cmd/snap/color.go
@@ -131,7 +131,6 @@ type escapes struct {
 	green        string
 	brightYellow string
 	bold         string
-	dim          string
 	end          string
 
 	tick, dash, uparrow, star string
@@ -142,15 +141,13 @@ var (
 		green:        "\033[32m",
 		brightYellow: "\033[93m",
 		bold:         "\033[1m",
-		dim:          "\033[2m",
 		end:          "\033[0m",
 	}
 
 	mono = escapes{
-		green:        "\033[1m",
-		brightYellow: "\033[2m",
+		green:        "\033[1m", // bold
+		brightYellow: "\033[2m", // dim
 		bold:         "\033[1m",
-		dim:          "\033[2m",
 		end:          "\033[0m",
 	}
 
@@ -175,11 +172,10 @@ func fillerPublisher(esc *escapes) string {
 //   sequence used to make it colorful (this so that tabwriter gets things
 //   right).
 func longPublisher(esc *escapes, storeAccount *snap.StoreAccount) string {
-	color := esc.green
 	if storeAccount == nil {
-		return esc.dash + color + esc.end
+		return esc.dash + esc.green + esc.end
 	}
-	badge := ""
+	var badge, color string
 	switch storeAccount.Validation {
 	case "verified":
 		badge = esc.tick
@@ -187,6 +183,9 @@ func longPublisher(esc *escapes, storeAccount *snap.StoreAccount) string {
 	case "starred":
 		badge = esc.star
 		color = esc.brightYellow
+	default:
+		// no-op escape sequence so that things line-up
+		color = esc.green
 	}
 	// NOTE this makes e.g. 'Potato' == 'potato', and 'Potato Team' == 'potato-team',
 	// but 'Potato Team' != 'potatoteam', 'Potato Inc.' != 'potato' (in fact 'Potato Inc.' != 'potato-inc')
@@ -207,11 +206,10 @@ func longPublisher(esc *escapes, storeAccount *snap.StoreAccount) string {
 //   sequence used to make it colorful (this so that tabwriter gets things
 //   right).
 func shortPublisher(esc *escapes, storeAccount *snap.StoreAccount) string {
-	color := esc.green
 	if storeAccount == nil {
-		return "-" + color + esc.end
+		return "-" + 	esc.green + esc.end
 	}
-	badge := ""
+	var badge, color string
 	switch storeAccount.Validation {
 	case "verified":
 		badge = esc.tick
@@ -219,6 +217,9 @@ func shortPublisher(esc *escapes, storeAccount *snap.StoreAccount) string {
 	case "starred":
 		badge = esc.star
 		color = esc.brightYellow
+	default:
+		// no-op escape sequence so that things line-up
+		color = esc.green
 	}
 	return storeAccount.Username + color + badge + esc.end
 

--- a/cmd/snap/color.go
+++ b/cmd/snap/color.go
@@ -39,10 +39,12 @@ func (ux unicodeMixin) addUnicodeChars(esc *escapes) {
 		esc.dash = "–" // that's an en dash (so yaml is happy)
 		esc.uparrow = "↑"
 		esc.tick = "✓"
+		esc.star = "✪"
 	} else {
 		esc.dash = "--" // two dashes keeps yaml happy also
 		esc.uparrow = "^"
-		esc.tick = "*"
+		esc.tick = "**"
+		esc.star = "*"
 	}
 }
 
@@ -130,7 +132,7 @@ type escapes struct {
 	bold  string
 	end   string
 
-	tick, dash, uparrow string
+	tick, dash, uparrow, star string
 }
 
 var (
@@ -169,8 +171,11 @@ func longPublisher(esc *escapes, storeAccount *snap.StoreAccount) string {
 		return esc.dash + esc.green + esc.end
 	}
 	badge := ""
-	if storeAccount.Validation == "verified" {
+	switch storeAccount.Validation {
+	case "verified":
 		badge = esc.tick
+	case "starred":
+		badge = esc.star
 	}
 	// NOTE this makes e.g. 'Potato' == 'potato', and 'Potato Team' == 'potato-team',
 	// but 'Potato Team' != 'potatoteam', 'Potato Inc.' != 'potato' (in fact 'Potato Inc.' != 'potato-inc')
@@ -193,8 +198,11 @@ func shortPublisher(esc *escapes, storeAccount *snap.StoreAccount) string {
 		return "-" + esc.green + esc.end
 	}
 	badge := ""
-	if storeAccount.Validation == "verified" {
+	switch storeAccount.Validation {
+	case "verified":
 		badge = esc.tick
+	case "starred":
+		badge = esc.star
 	}
 	return storeAccount.Username + esc.green + badge + esc.end
 

--- a/cmd/snap/color_test.go
+++ b/cmd/snap/color_test.go
@@ -126,6 +126,7 @@ func (s *SnapSuite) TestPublisherEscapes(c *check.C) {
 		color, unicode    bool
 		username, display string
 		verified          bool
+		starred           bool
 		short, long, fill string
 	}
 	for _, t := range []T{
@@ -140,13 +141,22 @@ func (s *SnapSuite) TestPublisherEscapes(c *check.C) {
 			short: "potato\x1b[32m\x1b[0m", long: "Potato\x1b[32m\x1b[0m", fill: "\x1b[32m\x1b[0m"},
 		// verified equal under fold:
 		{color: false, unicode: false, username: "potato", display: "Potato", verified: true,
-			short: "potato*", long: "Potato*", fill: ""},
+			short: "potato**", long: "Potato**", fill: ""},
 		{color: false, unicode: true, username: "potato", display: "Potato", verified: true,
 			short: "potato✓", long: "Potato✓", fill: ""},
 		{color: true, unicode: false, username: "potato", display: "Potato", verified: true,
-			short: "potato\x1b[32m*\x1b[0m", long: "Potato\x1b[32m*\x1b[0m", fill: "\x1b[32m\x1b[0m"},
+			short: "potato\x1b[32m**\x1b[0m", long: "Potato\x1b[32m**\x1b[0m", fill: "\x1b[32m\x1b[0m"},
 		{color: true, unicode: true, username: "potato", display: "Potato", verified: true,
 			short: "potato\x1b[32m✓\x1b[0m", long: "Potato\x1b[32m✓\x1b[0m", fill: "\x1b[32m\x1b[0m"},
+		// starred equal under fold:
+		{color: false, unicode: false, username: "potato", display: "Potato", starred: true,
+			short: "potato*", long: "Potato*", fill: ""},
+		{color: false, unicode: true, username: "potato", display: "Potato", starred: true,
+			short: "potato✪", long: "Potato✪", fill: ""},
+		{color: true, unicode: false, username: "potato", display: "Potato", starred: true,
+			short: "potato\x1b[32m*\x1b[0m", long: "Potato\x1b[32m*\x1b[0m", fill: "\x1b[32m\x1b[0m"},
+		{color: true, unicode: true, username: "potato", display: "Potato", starred: true,
+			short: "potato\x1b[32m✪\x1b[0m", long: "Potato\x1b[32m✪\x1b[0m", fill: "\x1b[32m\x1b[0m"},
 		// non-verified, different
 		{color: false, unicode: false, username: "potato", display: "Carrot",
 			short: "potato", long: "Carrot (potato)", fill: ""},
@@ -158,13 +168,22 @@ func (s *SnapSuite) TestPublisherEscapes(c *check.C) {
 			short: "potato\x1b[32m\x1b[0m", long: "Carrot (potato\x1b[32m\x1b[0m)", fill: "\x1b[32m\x1b[0m"},
 		// verified, different
 		{color: false, unicode: false, username: "potato", display: "Carrot", verified: true,
-			short: "potato*", long: "Carrot (potato*)", fill: ""},
+			short: "potato**", long: "Carrot (potato**)", fill: ""},
 		{color: false, unicode: true, username: "potato", display: "Carrot", verified: true,
 			short: "potato✓", long: "Carrot (potato✓)", fill: ""},
 		{color: true, unicode: false, username: "potato", display: "Carrot", verified: true,
-			short: "potato\x1b[32m*\x1b[0m", long: "Carrot (potato\x1b[32m*\x1b[0m)", fill: "\x1b[32m\x1b[0m"},
+			short: "potato\x1b[32m**\x1b[0m", long: "Carrot (potato\x1b[32m**\x1b[0m)", fill: "\x1b[32m\x1b[0m"},
 		{color: true, unicode: true, username: "potato", display: "Carrot", verified: true,
 			short: "potato\x1b[32m✓\x1b[0m", long: "Carrot (potato\x1b[32m✓\x1b[0m)", fill: "\x1b[32m\x1b[0m"},
+		// starred, different
+		{color: false, unicode: false, username: "potato", display: "Carrot", starred: true,
+			short: "potato*", long: "Carrot (potato*)", fill: ""},
+		{color: false, unicode: true, username: "potato", display: "Carrot", starred: true,
+			short: "potato✪", long: "Carrot (potato✪)", fill: ""},
+		{color: true, unicode: false, username: "potato", display: "Carrot", starred: true,
+			short: "potato\x1b[32m*\x1b[0m", long: "Carrot (potato\x1b[32m*\x1b[0m)", fill: "\x1b[32m\x1b[0m"},
+		{color: true, unicode: true, username: "potato", display: "Carrot", starred: true,
+			short: "potato\x1b[32m✪\x1b[0m", long: "Carrot (potato\x1b[32m✪\x1b[0m)", fill: "\x1b[32m\x1b[0m"},
 		// some interesting equal-under-folds:
 		{color: false, unicode: false, username: "potato", display: "PoTaTo",
 			short: "potato", long: "PoTaTo", fill: ""},
@@ -172,8 +191,13 @@ func (s *SnapSuite) TestPublisherEscapes(c *check.C) {
 			short: "potato-team", long: "Potato Team", fill: ""},
 	} {
 		pub := &snap.StoreAccount{Username: t.username, DisplayName: t.display}
-		if t.verified {
+		switch {
+		case t.verified && t.starred:
+			panic("invalid test setup: cannot be starred and valided at the same time")
+		case t.verified:
 			pub.Validation = "verified"
+		case t.starred:
+			pub.Validation = "starred"
 		}
 		color := "never"
 		if t.color {

--- a/cmd/snap/color_test.go
+++ b/cmd/snap/color_test.go
@@ -193,7 +193,7 @@ func (s *SnapSuite) TestPublisherEscapes(c *check.C) {
 		pub := &snap.StoreAccount{Username: t.username, DisplayName: t.display}
 		switch {
 		case t.verified && t.starred:
-			panic("invalid test setup: cannot be starred and valided at the same time")
+			panic("invalid test setup: cannot be starred and validated at the same time")
 		case t.verified:
 			pub.Validation = "verified"
 		case t.starred:

--- a/cmd/snap/color_test.go
+++ b/cmd/snap/color_test.go
@@ -154,9 +154,9 @@ func (s *SnapSuite) TestPublisherEscapes(c *check.C) {
 		{color: false, unicode: true, username: "potato", display: "Potato", starred: true,
 			short: "potato✪", long: "Potato✪", fill: ""},
 		{color: true, unicode: false, username: "potato", display: "Potato", starred: true,
-			short: "potato\x1b[32m*\x1b[0m", long: "Potato\x1b[32m*\x1b[0m", fill: "\x1b[32m\x1b[0m"},
+			short: "potato\x1b[93m*\x1b[0m", long: "Potato\x1b[93m*\x1b[0m", fill: "\x1b[32m\x1b[0m"},
 		{color: true, unicode: true, username: "potato", display: "Potato", starred: true,
-			short: "potato\x1b[32m✪\x1b[0m", long: "Potato\x1b[32m✪\x1b[0m", fill: "\x1b[32m\x1b[0m"},
+			short: "potato\x1b[93m✪\x1b[0m", long: "Potato\x1b[93m✪\x1b[0m", fill: "\x1b[32m\x1b[0m"},
 		// non-verified, different
 		{color: false, unicode: false, username: "potato", display: "Carrot",
 			short: "potato", long: "Carrot (potato)", fill: ""},
@@ -181,9 +181,9 @@ func (s *SnapSuite) TestPublisherEscapes(c *check.C) {
 		{color: false, unicode: true, username: "potato", display: "Carrot", starred: true,
 			short: "potato✪", long: "Carrot (potato✪)", fill: ""},
 		{color: true, unicode: false, username: "potato", display: "Carrot", starred: true,
-			short: "potato\x1b[32m*\x1b[0m", long: "Carrot (potato\x1b[32m*\x1b[0m)", fill: "\x1b[32m\x1b[0m"},
+			short: "potato\x1b[93m*\x1b[0m", long: "Carrot (potato\x1b[93m*\x1b[0m)", fill: "\x1b[32m\x1b[0m"},
 		{color: true, unicode: true, username: "potato", display: "Carrot", starred: true,
-			short: "potato\x1b[32m✪\x1b[0m", long: "Carrot (potato\x1b[32m✪\x1b[0m)", fill: "\x1b[32m\x1b[0m"},
+			short: "potato\x1b[93m✪\x1b[0m", long: "Carrot (potato\x1b[93m✪\x1b[0m)", fill: "\x1b[32m\x1b[0m"},
 		// some interesting equal-under-folds:
 		{color: false, unicode: false, username: "potato", display: "PoTaTo",
 			short: "potato", long: "PoTaTo", fill: ""},

--- a/tests/core/basic20/task.yaml
+++ b/tests/core/basic20/task.yaml
@@ -101,7 +101,7 @@ execute: |
     MODEL="$(snap model --verbose | grep '^model' | awk '{ print $2 }')"
     BRAND_ID="$(snap model --verbose | grep '^brand-id:' | awk '{print $2}')"
     if [ "$(snap known account "username=$BRAND_ID" | grep '^validation:' | awk '{print $2}')" != "unproven" ]; then
-        BRAND_ID="$BRAND_ID\*"
+        BRAND_ID="$BRAND_ID\*\*"
     fi
     snap recovery --unicode=never | MATCH "[0-9]+ +$BRAND_ID +$MODEL +current"
 

--- a/tests/main/listing/task.yaml
+++ b/tests/main/listing/task.yaml
@@ -27,7 +27,7 @@ execute: |
     NAME=core
     VERSION=$CORE_GIT_VERSION
     REV=$NUMBER_REV
-    PUBLISHER="canonical\\*"
+    PUBLISHER="canonical\\*\\*"
     TRACKING=-
     NOTES=core
 


### PR DESCRIPTION
This commit adds support for the new account `starred` validation
value. It displays a unicode star "✪" when possible, otherwise
a ascii "*". Note that this also means that validated developers
get a "**" appended now. While this is an incompatible change
it is what was agreeded in the star developers spec because it
is the most natural way to present these values in ascii.

An example for the output is:
```
$ snap info josm
name:      josm
summary:   Editor for OpenStreetMap
publisher: Michael Vogt (mvo✪)
...
```

