### PR TITLE
osutil: allow setting desired mtime on the AtomicFile, preserve mtime on copy

### DIFF
--- a/osutil/cp.go
+++ b/osutil/cp.go
@@ -142,6 +142,7 @@ func AtomicWriteFileCopy(dst, src string, flags AtomicWriteFlags) (err error) {
 	if err != nil {
 		return fmt.Errorf("cannot create atomic file: %v", err)
 	}
+	fout.SetModTime(fi.ModTime())
 	defer func() {
 		if cerr := fout.Cancel(); cerr != ErrCannotCancel && err == nil {
 			err = fmt.Errorf("cannot cancel temporary file copy %s: %v", fout.Name(), cerr)

--- a/osutil/cp_test.go
+++ b/osutil/cp_test.go
@@ -305,6 +305,23 @@ func (s *cpSuite) TestAtomicWriteFileCopySimple(c *C) {
 
 }
 
+func (s *cpSuite) TestAtomicWriteFileCopyPreservesModTime(c *C) {
+	t := time.Date(2010, time.January, 1, 13, 0, 0, 0, time.UTC)
+	c.Assert(os.Chtimes(s.f1, t, t), IsNil)
+
+	err := osutil.AtomicWriteFileCopy(s.f2, s.f1, 0)
+	c.Assert(err, IsNil)
+	c.Assert(s.f2, testutil.FileEquals, s.data)
+
+	finfo, err := os.Stat(s.f1)
+	c.Assert(err, IsNil)
+	m1 := finfo.ModTime()
+	finfo, err = os.Stat(s.f2)
+	c.Assert(err, IsNil)
+	m2 := finfo.ModTime()
+	c.Assert(m1.Equal(m2), Equals, true)
+}
+
 func (s *cpSuite) TestAtomicWriteFileCopyOverwrites(c *C) {
 	err := ioutil.WriteFile(s.f2, []byte("this is f2 content"), 0644)
 	c.Assert(err, IsNil)

--- a/osutil/io.go
+++ b/osutil/io.go
@@ -147,6 +147,7 @@ var chown = sys.Chown
 
 const NoChown = sys.FlagID
 
+// SetModTime sets the given modification time on the created file.
 func (aw *AtomicFile) SetModTime(t time.Time) {
 	aw.mtime = t
 }
@@ -178,7 +179,7 @@ func (aw *AtomicFile) commit() error {
 	}
 
 	if !aw.mtime.IsZero() {
-		if err := os.Chtimes(aw.tmpname, aw.mtime, aw.mtime); err != nil {
+		if err := os.Chtimes(aw.tmpname, time.Now(), aw.mtime); err != nil {
 			return err
 		}
 	}

--- a/osutil/io.go
+++ b/osutil/io.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"path/filepath"
 	"syscall"
+	"time"
 
 	"github.com/snapcore/snapd/osutil/sys"
 	"github.com/snapcore/snapd/randutil"
@@ -57,6 +58,7 @@ type AtomicFile struct {
 	tmpname string
 	uid     sys.UserID
 	gid     sys.GroupID
+	mtime   time.Time
 	closed  bool
 	renamed bool
 }
@@ -145,6 +147,10 @@ var chown = sys.Chown
 
 const NoChown = sys.FlagID
 
+func (aw *AtomicFile) SetModTime(t time.Time) {
+	aw.mtime = t
+}
+
 func (aw *AtomicFile) commit() error {
 	if aw.uid != NoChown || aw.gid != NoChown {
 		if err := chown(aw.File, aw.uid, aw.gid); err != nil {
@@ -169,6 +175,12 @@ func (aw *AtomicFile) commit() error {
 
 	if err := aw.Close(); err != nil {
 		return err
+	}
+
+	if !aw.mtime.IsZero() {
+		if err := os.Chtimes(aw.tmpname, aw.mtime, aw.mtime); err != nil {
+			return err
+		}
 	}
 
 	if err := os.Rename(aw.tmpname, aw.target); err != nil {

--- a/osutil/io_test.go
+++ b/osutil/io_test.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	. "gopkg.in/check.v1"
 
@@ -234,6 +235,21 @@ func (ts *AtomicWriteTestSuite) TestAtomicFileCancel(c *C) {
 	c.Check(osutil.FileExists(fn), Equals, true)
 	c.Check(aw.Cancel(), IsNil)
 	c.Check(osutil.FileExists(fn), Equals, false)
+}
+
+func (ts *AtomicWriteTestSuite) TestAtomicFileModTime(c *C) {
+	d := c.MkDir()
+	p := filepath.Join(d, "foo")
+
+	aw, err := osutil.NewAtomicFile(p, 0644, 0, osutil.NoChown, osutil.NoChown)
+	c.Assert(err, IsNil)
+	t := time.Date(2010, time.January, 1, 13, 0, 0, 0, time.UTC)
+	aw.SetModTime(t)
+	c.Assert(aw.Commit(), IsNil)
+
+	finfo, err := os.Stat(p)
+	c.Assert(err, IsNil)
+	c.Assert(finfo.ModTime().Equal(t), Equals, true)
 }
 
 func (ts *AtomicWriteTestSuite) TestAtomicFileCommitAs(c *C) {


### PR DESCRIPTION
Allow setting desired modification time on AtomicFile and preserve mtime in AtomicWriteFileCopy.