### PR TITLE
interfaces: allow access to the file locking for cryptosetup in the dm-crypt interface

### DIFF
--- a/interfaces/builtin/dm_crypt.go
+++ b/interfaces/builtin/dm_crypt.go
@@ -60,7 +60,11 @@ mount options=(rw,nosuid,nodev) /dev/dm-[0-9]* -> /{,run/}media/**,
 /{,usr/}bin/umount ixr,
 
 # mount/umount (via libmount) track some mount info in these files
-/run/mount/utab* wrlk,
+/{,var/}run/mount/utab* wrlk,
+
+# Allow access to the file locking mechanism
+/{,var/}run/cryptsetup/ r,
+/{,var/}run/cryptsetup/* rwk,
 `
 
 const dmCryptConnectedPlugSecComp = `

--- a/interfaces/builtin/dm_crypt_test.go
+++ b/interfaces/builtin/dm_crypt_test.go
@@ -85,13 +85,15 @@ func (s *DmCryptInterfaceSuite) TestAppArmorSpec(c *C) {
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/dev/mapper/control")
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/dev/dm-[0-9]*")
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/run/systemd/seats/*")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/{,var/}run/cryptsetup/ r,")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/{,var/}run/cryptsetup/* rwk,")
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/{,run/}media/{,**}")
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "mount options=(ro,nosuid,nodev) /dev/dm-[0-9]*")
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "mount options=(rw,nosuid,nodev) /dev/dm-[0-9]*")
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/{,usr/}sbin/cryptsetup ixr,")
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/{,usr/}bin/mount ixr,")
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/{,usr/}bin/umount ixr,")
-	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/run/mount/utab* wrlk,")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/{,var/}run/mount/utab* wrlk,")
 }
 
 func (s *DmCryptInterfaceSuite) TestUDevSpec(c *C) {


### PR DESCRIPTION
I created a snap that tries to use `cryptsetup` utility and installed it in `dev-mode`. According to the logs; it requires access to the  `/run/cryptosetup/` directory and also creates file(s) inside.

```
= AppArmor =
Time: May 11 11:55:03
Log: apparmor="ALLOWED" operation="open" profile="snap.test-content-slot.slot-exec" name="/run/cryptsetup/" pid=720119 comm="cryptsetup" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
File: /run/cryptsetup/ (read)
Suggestions:
* adjust program to use $SNAP_DATA
* adjust program to use /run/shm/snap.$SNAP_NAME.*
* adjust program to use /run/snap.$SNAP_NAME.*
* adjust snap to use snap layouts (https://forum.snapcraft.io/t/snap-layouts/7207)

= AppArmor =
Time: May 11 11:55:03
Log: apparmor="ALLOWED" operation="mknod" profile="snap.test-content-slot.slot-exec" name="/run/cryptsetup/L_8:17" pid=720119 comm="cryptsetup" requested_mask="c" denied_mask="c" fsuid=0 ouid=0
File: /run/cryptsetup/L_8:17 (write)
Suggestions:
* adjust program to use $SNAP_DATA
* adjust program to use /run/shm/snap.$SNAP_NAME.*
* adjust program to use /run/snap.$SNAP_NAME.*
* adjust snap to use snap layouts (https://forum.snapcraft.io/t/snap-layouts/7207)

= AppArmor =
Time: May 11 11:55:03
Log: apparmor="ALLOWED" operation="open" profile="snap.test-content-slot.slot-exec" name="/run/cryptsetup/L_8:17" pid=720119 comm="cryptsetup" requested_mask="wrc" denied_mask="wrc" fsuid=0 ouid=0
File: /run/cryptsetup/L_8:17 (write)
Suggestions:
* adjust program to use $SNAP_DATA
* adjust program to use /run/shm/snap.$SNAP_NAME.*
* adjust program to use /run/snap.$SNAP_NAME.*
* adjust snap to use snap layouts (https://forum.snapcraft.io/t/snap-layouts/7207)

= AppArmor =
Time: May 11 11:55:03
Log: apparmor="ALLOWED" operation="file_lock" profile="snap.test-content-slot.slot-exec" name="/run/cryptsetup/L_8:17" pid=720119 comm="cryptsetup" requested_mask="wk" denied_mask="wk" fsuid=0 ouid=0
File: /run/cryptsetup/L_8:17 (write)
Suggestions:
* adjust program to use $SNAP_DATA
* adjust program to use /run/shm/snap.$SNAP_NAME.*
* adjust program to use /run/snap.$SNAP_NAME.*
* adjust snap to use snap layouts (https://forum.snapcraft.io/t/snap-layouts/7207)

= AppArmor =
Time: May 11 11:55:03
Log: apparmor="ALLOWED" operation="unlink" profile="snap.test-content-slot.slot-exec" name="/run/cryptsetup/L_8:17" pid=720119 comm="cryptsetup" requested_mask="d" denied_mask="d" fsuid=0 ouid=0
File: /run/cryptsetup/L_8:17 (write)
Suggestions:
* adjust program to use $SNAP_DATA
* adjust program to use /run/shm/snap.$SNAP_NAME.*
* adjust program to use /run/snap.$SNAP_NAME.*
* adjust snap to use snap layouts (https://forum.snapcraft.io/t/snap-layouts/7207)

= AppArmor =
Time: May 11 11:55:03
Log: apparmor="ALLOWED" operation="open" profile="snap.test-content-slot.slot-exec" name="/run/cryptsetup/" pid=720119 comm="cryptsetup" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
File: /run/cryptsetup/ (read)
Suggestions:
* adjust program to use $SNAP_DATA
* adjust program to use /run/shm/snap.$SNAP_NAME.*
* adjust program to use /run/snap.$SNAP_NAME.*
* adjust snap to use snap layouts (https://forum.snapcraft.io/t/snap-layouts/7207)

= AppArmor =
Time: May 11 11:55:03
Log: apparmor="ALLOWED" operation="mknod" profile="snap.test-content-slot.slot-exec" name="/run/cryptsetup/L_8:17" pid=720119 comm="cryptsetup" requested_mask="c" denied_mask="c" fsuid=0 ouid=0
File: /run/cryptsetup/L_8:17 (write)
Suggestions:
* adjust program to use $SNAP_DATA
* adjust program to use /run/shm/snap.$SNAP_NAME.*
* adjust program to use /run/snap.$SNAP_NAME.*
* adjust snap to use snap layouts (https://forum.snapcraft.io/t/snap-layouts/7207)

= AppArmor =
Time: May 11 11:55:03
Log: apparmor="ALLOWED" operation="open" profile="snap.test-content-slot.slot-exec" name="/run/cryptsetup/L_8:17" pid=720119 comm="cryptsetup" requested_mask="wrc" denied_mask="wrc" fsuid=0 ouid=0
File: /run/cryptsetup/L_8:17 (write)
Suggestions:
* adjust program to use $SNAP_DATA
* adjust program to use /run/shm/snap.$SNAP_NAME.*
* adjust program to use /run/snap.$SNAP_NAME.*
* adjust snap to use snap layouts (https://forum.snapcraft.io/t/snap-layouts/7207)

= AppArmor =
Time: May 11 11:55:03
Log: apparmor="ALLOWED" operation="file_lock" profile="snap.test-content-slot.slot-exec" name="/run/cryptsetup/L_8:17" pid=720119 comm="cryptsetup" requested_mask="wk" denied_mask="wk" fsuid=0 ouid=0
File: /run/cryptsetup/L_8:17 (write)
Suggestions:
* adjust program to use $SNAP_DATA
* adjust program to use /run/shm/snap.$SNAP_NAME.*
* adjust program to use /run/snap.$SNAP_NAME.*
* adjust snap to use snap layouts (https://forum.snapcraft.io/t/snap-layouts/7207)

= AppArmor =
Time: May 11 11:55:03
Log: apparmor="ALLOWED" operation="unlink" profile="snap.test-content-slot.slot-exec" name="/run/cryptsetup/L_8:17" pid=720119 comm="cryptsetup" requested_mask="d" denied_mask="d" fsuid=0 ouid=0
File: /run/cryptsetup/L_8:17 (write)
Suggestions:
* adjust program to use $SNAP_DATA
* adjust program to use /run/shm/snap.$SNAP_NAME.*
* adjust program to use /run/snap.$SNAP_NAME.*
* adjust snap to use snap layouts (https://forum.snapcraft.io/t/snap-layouts/7207)

= AppArmor =
Time: May 11 11:55:10
Log: apparmor="ALLOWED" operation="open" profile="snap.test-content-slot.slot-exec" name="/run/cryptsetup/" pid=720119 comm="cryptsetup" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
File: /run/cryptsetup/ (read)
Suggestions:
* adjust program to use $SNAP_DATA
* adjust program to use /run/shm/snap.$SNAP_NAME.*
* adjust program to use /run/snap.$SNAP_NAME.*
* adjust snap to use snap layouts (https://forum.snapcraft.io/t/snap-layouts/7207)

= AppArmor =
Time: May 11 11:55:10
Log: apparmor="ALLOWED" operation="mknod" profile="snap.test-content-slot.slot-exec" name="/run/cryptsetup/L_8:17" pid=720119 comm="cryptsetup" requested_mask="c" denied_mask="c" fsuid=0 ouid=0
File: /run/cryptsetup/L_8:17 (write)
Suggestions:
* adjust program to use $SNAP_DATA
* adjust program to use /run/shm/snap.$SNAP_NAME.*
* adjust program to use /run/snap.$SNAP_NAME.*
* adjust snap to use snap layouts (https://forum.snapcraft.io/t/snap-layouts/7207)

= AppArmor =
Time: May 11 11:55:10
Log: apparmor="ALLOWED" operation="open" profile="snap.test-content-slot.slot-exec" name="/run/cryptsetup/L_8:17" pid=720119 comm="cryptsetup" requested_mask="wrc" denied_mask="wrc" fsuid=0 ouid=0
File: /run/cryptsetup/L_8:17 (write)
Suggestions:
* adjust program to use $SNAP_DATA
* adjust program to use /run/shm/snap.$SNAP_NAME.*
* adjust program to use /run/snap.$SNAP_NAME.*
* adjust snap to use snap layouts (https://forum.snapcraft.io/t/snap-layouts/7207)

= AppArmor =
Time: May 11 11:55:10
Log: apparmor="ALLOWED" operation="file_lock" profile="snap.test-content-slot.slot-exec" name="/run/cryptsetup/L_8:17" pid=720119 comm="cryptsetup" requested_mask="wk" denied_mask="wk" fsuid=0 ouid=0
File: /run/cryptsetup/L_8:17 (write)
Suggestions:
* adjust program to use $SNAP_DATA
* adjust program to use /run/shm/snap.$SNAP_NAME.*
* adjust program to use /run/snap.$SNAP_NAME.*
* adjust snap to use snap layouts (https://forum.snapcraft.io/t/snap-layouts/7207)


= AppArmor =
Time: May 11 11:55:10
Log: apparmor="ALLOWED" operation="open" profile="snap.test-content-slot.slot-exec" name="/run/cryptsetup/" pid=720119 comm="cryptsetup" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
File: /run/cryptsetup/ (read)
Suggestions:
* adjust program to use $SNAP_DATA
* adjust program to use /run/shm/snap.$SNAP_NAME.*
* adjust program to use /run/snap.$SNAP_NAME.*
* adjust snap to use snap layouts (https://forum.snapcraft.io/t/snap-layouts/7207)

= AppArmor =
Time: May 11 11:55:10
Log: apparmor="ALLOWED" operation="mknod" profile="snap.test-content-slot.slot-exec" name="/run/cryptsetup/L_8:17" pid=720119 comm="cryptsetup" requested_mask="c" denied_mask="c" fsuid=0 ouid=0
File: /run/cryptsetup/L_8:17 (write)
Suggestions:
* adjust program to use $SNAP_DATA
* adjust program to use /run/shm/snap.$SNAP_NAME.*
* adjust program to use /run/snap.$SNAP_NAME.*
* adjust snap to use snap layouts (https://forum.snapcraft.io/t/snap-layouts/7207)

= AppArmor =
Time: May 11 11:55:10
Log: apparmor="ALLOWED" operation="open" profile="snap.test-content-slot.slot-exec" name="/run/cryptsetup/L_8:17" pid=720119 comm="cryptsetup" requested_mask="wrc" denied_mask="wrc" fsuid=0 ouid=0
File: /run/cryptsetup/L_8:17 (write)
Suggestions:
* adjust program to use $SNAP_DATA
* adjust program to use /run/shm/snap.$SNAP_NAME.*
* adjust program to use /run/snap.$SNAP_NAME.*
* adjust snap to use snap layouts (https://forum.snapcraft.io/t/snap-layouts/7207)

= AppArmor =
Time: May 11 11:55:10
Log: apparmor="ALLOWED" operation="file_lock" profile="snap.test-content-slot.slot-exec" name="/run/cryptsetup/L_8:17" pid=720119 comm="cryptsetup" requested_mask="wk" denied_mask="wk" fsuid=0 ouid=0
File: /run/cryptsetup/L_8:17 (write)
Suggestions:
* adjust program to use $SNAP_DATA
* adjust program to use /run/shm/snap.$SNAP_NAME.*
* adjust program to use /run/snap.$SNAP_NAME.*
* adjust snap to use snap layouts (https://forum.snapcraft.io/t/snap-layouts/7207)

```
