### PR TITLE
systemd: add systemd.Run() wrapper for systemd-run

### DIFF
--- a/kernel/fde/cmd_helper.go
+++ b/kernel/fde/cmd_helper.go
@@ -79,7 +79,8 @@ func runFDEinitramfsHelper(name string, stdin []byte) (output []byte, err error)
 		}
 	}
 
-	// TODO: put this into a new "systemd/run" package
+	// TODO: use the new systemd.Run() interface once it supports
+	//       running without dbus (i.e. supports running without --pipe)
 	cmd := exec.Command(
 		"systemd-run",
 		"--collect",

--- a/systemd/emulation.go
+++ b/systemd/emulation.go
@@ -222,3 +222,7 @@ func (s *emulation) Mount(what, where string, options ...string) error {
 func (s *emulation) Umount(whatOrWhere string) error {
 	return &notImplementedError{"Umount"}
 }
+
+func (s *emulation) Run(command []string, opts *RunOptions) ([]byte, error) {
+	return nil, &notImplementedError{"Run"}
+}


### PR DESCRIPTION
This commit adds a new `systemd.Run()` function that implements
a wrapper around `systemd-run`. This will be used to spawn
commands that use the `--keyring-mode=inherit` when interacting
with the kernel keyring.
