### PR TITLE
interfaces: fix opengl interface on RISC-V

### DIFF
--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -132,12 +132,12 @@ unix (bind,listen) type=seqpacket addr="@cuda-uvmfd-[0-9a-f]*",
 @{PROC}/driver/prl_vtg rw,
 
 # /sys/devices
-/sys/devices/{,*pcie-controller/}pci[0-9a-f]*/**/config r,
-/sys/devices/{,*pcie-controller/}pci[0-9a-f]*/**/revision r,
-/sys/devices/{,*pcie-controller/}pci[0-9a-f]*/**/boot_vga r,
-/sys/devices/{,*pcie-controller/}pci[0-9a-f]*/**/{,subsystem_}class r,
-/sys/devices/{,*pcie-controller/}pci[0-9a-f]*/**/{,subsystem_}device r,
-/sys/devices/{,*pcie-controller/}pci[0-9a-f]*/**/{,subsystem_}vendor r,
+/sys/devices/{,*pcie-controller/,platform/soc/*.pcie/}pci[0-9a-f]*/**/config r,
+/sys/devices/{,*pcie-controller/,platform/soc/*.pcie/}pci[0-9a-f]*/**/revision r,
+/sys/devices/{,*pcie-controller/,platform/soc/*.pcie/}pci[0-9a-f]*/**/boot_vga r,
+/sys/devices/{,*pcie-controller/,platform/soc/*.pcie/}pci[0-9a-f]*/**/{,subsystem_}class r,
+/sys/devices/{,*pcie-controller/,platform/soc/*.pcie/}pci[0-9a-f]*/**/{,subsystem_}device r,
+/sys/devices/{,*pcie-controller/,platform/soc/*.pcie/}pci[0-9a-f]*/**/{,subsystem_}vendor r,
 /sys/devices/**/drm{,_dp_aux_dev}/** r,
 
 # FIXME: this is an information leak and snapd should instead query udev for


### PR DESCRIPTION
On RISC-V (or at least the SiFive Unmatched) the PCI devices show up under the platform subtree:

```plain
/sys/devices/platform/soc/e00000000.pcie/pci0000:00/0000:00:00.0/
├── 0000:00:00.0:pcie001
├── 0000:00:00.0:pcie002
├── 0000:00:00.0:pcie010
├── 0000:01:00.0
├── aer_dev_correctable
├── aer_dev_fatal
├── aer_dev_nonfatal
├── aer_rootport_total_err_cor
├── aer_rootport_total_err_fatal
├── aer_rootport_total_err_nonfatal
├── ari_enabled
├── broken_parity_status
├── class
├── config
├── consistent_dma_mask_bits
├── current_link_speed
├── current_link_width
├── device
├── devspec
├── dma_mask_bits
├── driver -> ../../../../../../bus/pci/drivers/pcieport
├── driver_override
├── enable
├── irq
├── link
├── local_cpulist
├── local_cpus
├── max_link_speed
├── max_link_width
├── modalias
├── msi_bus
├── msi_irqs
├── numa_node
├── pci_bus
├── power_state
├── remove
├── rescan
├── resource
├── resource0
├── revision
├── rom
├── secondary_bus_number
├── subordinate_bus_number
├── subsystem -> ../../../../../../bus/pci
├── subsystem_device
├── subsystem_vendor
├── uevent
└── vendor

9 directories, 39 files
```

This fixes AMD graphics on Ubuntu Frame on SiFive Unmatched.