### PR TITLE
secboot/keys: introduce a package for secboot key types, use the package throughout the code base

### DIFF
--- a/boot/assets.go
+++ b/boot/assets.go
@@ -36,7 +36,7 @@ import (
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
-	"github.com/snapcore/snapd/secboot"
+	"github.com/snapcore/snapd/secboot/keys"
 	"github.com/snapcore/snapd/strutil"
 )
 
@@ -263,8 +263,8 @@ type TrustedAssetsInstallObserver struct {
 	trustedRecoveryAssets []string
 	trackedRecoveryAssets bootAssetsMap
 
-	dataEncryptionKey secboot.EncryptionKey
-	saveEncryptionKey secboot.EncryptionKey
+	dataEncryptionKey keys.EncryptionKey
+	saveEncryptionKey keys.EncryptionKey
 }
 
 // Observe observes the operation related to the content of a given gadget
@@ -339,7 +339,7 @@ func (o *TrustedAssetsInstallObserver) currentTrustedRecoveryBootAssetsMap() boo
 	return o.trackedRecoveryAssets
 }
 
-func (o *TrustedAssetsInstallObserver) ChosenEncryptionKeys(key, saveKey secboot.EncryptionKey) {
+func (o *TrustedAssetsInstallObserver) ChosenEncryptionKeys(key, saveKey keys.EncryptionKey) {
 	o.dataEncryptionKey = key
 	o.saveEncryptionKey = saveKey
 }

--- a/boot/assets_test.go
+++ b/boot/assets_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/secboot"
+	"github.com/snapcore/snapd/secboot/keys"
 	"github.com/snapcore/snapd/seed"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
@@ -479,9 +480,9 @@ func (s *assetsSuite) TestInstallObserverNonTrustedBootloader(c *C) {
 	obs, err := boot.TrustedAssetsInstallObserverForModel(uc20Model, d, useEncryption)
 	c.Assert(err, IsNil)
 	c.Assert(obs, NotNil)
-	obs.ChosenEncryptionKeys(secboot.EncryptionKey{1, 2, 3, 4}, secboot.EncryptionKey{5, 6, 7, 8})
-	c.Check(obs.CurrentDataEncryptionKey(), DeepEquals, secboot.EncryptionKey{1, 2, 3, 4})
-	c.Check(obs.CurrentSaveEncryptionKey(), DeepEquals, secboot.EncryptionKey{5, 6, 7, 8})
+	obs.ChosenEncryptionKeys(keys.EncryptionKey{1, 2, 3, 4}, keys.EncryptionKey{5, 6, 7, 8})
+	c.Check(obs.CurrentDataEncryptionKey(), DeepEquals, keys.EncryptionKey{1, 2, 3, 4})
+	c.Check(obs.CurrentSaveEncryptionKey(), DeepEquals, keys.EncryptionKey{5, 6, 7, 8})
 }
 
 func (s *assetsSuite) TestInstallObserverTrustedButNoAssets(c *C) {
@@ -500,9 +501,9 @@ func (s *assetsSuite) TestInstallObserverTrustedButNoAssets(c *C) {
 	obs, err := boot.TrustedAssetsInstallObserverForModel(uc20Model, d, useEncryption)
 	c.Assert(err, IsNil)
 	c.Assert(obs, NotNil)
-	obs.ChosenEncryptionKeys(secboot.EncryptionKey{1, 2, 3, 4}, secboot.EncryptionKey{5, 6, 7, 8})
-	c.Check(obs.CurrentDataEncryptionKey(), DeepEquals, secboot.EncryptionKey{1, 2, 3, 4})
-	c.Check(obs.CurrentSaveEncryptionKey(), DeepEquals, secboot.EncryptionKey{5, 6, 7, 8})
+	obs.ChosenEncryptionKeys(keys.EncryptionKey{1, 2, 3, 4}, keys.EncryptionKey{5, 6, 7, 8})
+	c.Check(obs.CurrentDataEncryptionKey(), DeepEquals, keys.EncryptionKey{1, 2, 3, 4})
+	c.Check(obs.CurrentSaveEncryptionKey(), DeepEquals, keys.EncryptionKey{5, 6, 7, 8})
 }
 
 func (s *assetsSuite) TestInstallObserverTrustedReuseNameErr(c *C) {

--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/kernel/fde"
 	"github.com/snapcore/snapd/secboot"
+	"github.com/snapcore/snapd/secboot/keys"
 	"github.com/snapcore/snapd/seed"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/timings"
@@ -94,11 +95,11 @@ func (o *TrustedAssetsInstallObserver) CurrentTrustedRecoveryBootAssetsMap() Boo
 	return o.currentTrustedRecoveryBootAssetsMap()
 }
 
-func (o *TrustedAssetsInstallObserver) CurrentDataEncryptionKey() secboot.EncryptionKey {
+func (o *TrustedAssetsInstallObserver) CurrentDataEncryptionKey() keys.EncryptionKey {
 	return o.dataEncryptionKey
 }
 
-func (o *TrustedAssetsInstallObserver) CurrentSaveEncryptionKey() secboot.EncryptionKey {
+func (o *TrustedAssetsInstallObserver) CurrentSaveEncryptionKey() keys.EncryptionKey {
 	return o.saveEncryptionKey
 }
 

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/secboot"
+	"github.com/snapcore/snapd/secboot/keys"
 	"github.com/snapcore/snapd/seed"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snapfile"
@@ -563,8 +564,8 @@ version: 5.0
 	c.Assert(err, IsNil)
 
 	// set encryption key
-	myKey := secboot.EncryptionKey{}
-	myKey2 := secboot.EncryptionKey{}
+	myKey := keys.EncryptionKey{}
+	myKey2 := keys.EncryptionKey{}
 	for i := range myKey {
 		myKey[i] = byte(i)
 		myKey2[i] = byte(128 + i)
@@ -906,8 +907,8 @@ version: 5.0
 	c.Assert(err, IsNil)
 
 	// set encryption key
-	myKey := secboot.EncryptionKey{}
-	myKey2 := secboot.EncryptionKey{}
+	myKey := keys.EncryptionKey{}
+	myKey2 := keys.EncryptionKey{}
 	for i := range myKey {
 		myKey[i] = byte(i)
 		myKey2[i] = byte(128 + i)

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -37,6 +37,7 @@ import (
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/secboot"
+	"github.com/snapcore/snapd/secboot/keys"
 	"github.com/snapcore/snapd/seed"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/strutil"
@@ -103,7 +104,7 @@ func recoveryBootChainsFileUnder(rootdir string) string {
 // sealKeyToModeenv seals the supplied keys to the parameters specified
 // in modeenv.
 // It assumes to be invoked in install mode.
-func sealKeyToModeenv(key, saveKey secboot.EncryptionKey, model *asserts.Model, modeenv *Modeenv) error {
+func sealKeyToModeenv(key, saveKey keys.EncryptionKey, model *asserts.Model, modeenv *Modeenv) error {
 	// make sure relevant locations exist
 	for _, p := range []string{
 		InitramfsSeedEncryptionKeyDir,
@@ -128,7 +129,7 @@ func sealKeyToModeenv(key, saveKey secboot.EncryptionKey, model *asserts.Model, 
 	return sealKeyToModeenvUsingSecboot(key, saveKey, modeenv)
 }
 
-func runKeySealRequests(key secboot.EncryptionKey) []secboot.SealKeyRequest {
+func runKeySealRequests(key keys.EncryptionKey) []secboot.SealKeyRequest {
 	return []secboot.SealKeyRequest{
 		{
 			Key:     key,
@@ -138,7 +139,7 @@ func runKeySealRequests(key secboot.EncryptionKey) []secboot.SealKeyRequest {
 	}
 }
 
-func fallbackKeySealRequests(key, saveKey secboot.EncryptionKey) []secboot.SealKeyRequest {
+func fallbackKeySealRequests(key, saveKey keys.EncryptionKey) []secboot.SealKeyRequest {
 	return []secboot.SealKeyRequest{
 		{
 			Key:     key,
@@ -153,14 +154,14 @@ func fallbackKeySealRequests(key, saveKey secboot.EncryptionKey) []secboot.SealK
 	}
 }
 
-func sealKeyToModeenvUsingFDESetupHook(key, saveKey secboot.EncryptionKey, modeenv *Modeenv) error {
+func sealKeyToModeenvUsingFDESetupHook(key, saveKey keys.EncryptionKey, modeenv *Modeenv) error {
 	// XXX: Move the auxKey creation to a more generic place, see
 	// PR#10123 for a possible way of doing this. However given
 	// that the equivalent key for the TPM case is also created in
 	// sealKeyToModeenvUsingTPM more symetric to create the auxKey
 	// here and when we also move TPM to use the auxKey to move
 	// the creation of it.
-	auxKey, err := secboot.NewAuxKey()
+	auxKey, err := keys.NewAuxKey()
 	if err != nil {
 		return fmt.Errorf("cannot create aux key: %v", err)
 	}
@@ -181,7 +182,7 @@ func sealKeyToModeenvUsingFDESetupHook(key, saveKey secboot.EncryptionKey, modee
 	return nil
 }
 
-func sealKeyToModeenvUsingSecboot(key, saveKey secboot.EncryptionKey, modeenv *Modeenv) error {
+func sealKeyToModeenvUsingSecboot(key, saveKey keys.EncryptionKey, modeenv *Modeenv) error {
 	// build the recovery mode boot chain
 	rbl, err := bootloader.Find(InitramfsUbuntuSeedDir, &bootloader.Options{
 		Role: bootloader.RoleRecovery,
@@ -264,7 +265,7 @@ func sealKeyToModeenvUsingSecboot(key, saveKey secboot.EncryptionKey, modeenv *M
 	return nil
 }
 
-func sealRunObjectKeys(key secboot.EncryptionKey, pbc predictableBootChains, authKey *ecdsa.PrivateKey, roleToBlName map[bootloader.Role]string) error {
+func sealRunObjectKeys(key keys.EncryptionKey, pbc predictableBootChains, authKey *ecdsa.PrivateKey, roleToBlName map[bootloader.Role]string) error {
 	modelParams, err := sealKeyModelParams(pbc, roleToBlName)
 	if err != nil {
 		return fmt.Errorf("cannot prepare for key sealing: %v", err)
@@ -290,7 +291,7 @@ func sealRunObjectKeys(key secboot.EncryptionKey, pbc predictableBootChains, aut
 	return nil
 }
 
-func sealFallbackObjectKeys(key, saveKey secboot.EncryptionKey, pbc predictableBootChains, authKey *ecdsa.PrivateKey, roleToBlName map[bootloader.Role]string) error {
+func sealFallbackObjectKeys(key, saveKey keys.EncryptionKey, pbc predictableBootChains, authKey *ecdsa.PrivateKey, roleToBlName map[bootloader.Role]string) error {
 	// also seal the keys to the recovery bootchains as a fallback
 	modelParams, err := sealKeyModelParams(pbc, roleToBlName)
 	if err != nil {

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/snapcore/snapd/kernel/fde"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/secboot"
+	"github.com/snapcore/snapd/secboot/keys"
 	"github.com/snapcore/snapd/seed"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
@@ -148,8 +149,8 @@ func (s *sealSuite) TestSealKeyToModeenv(c *C) {
 		})
 
 		// set encryption key
-		myKey := secboot.EncryptionKey{}
-		myKey2 := secboot.EncryptionKey{}
+		myKey := keys.EncryptionKey{}
+		myKey2 := keys.EncryptionKey{}
 		for i := range myKey {
 			myKey[i] = byte(i)
 			myKey2[i] = byte(128 + i)
@@ -1584,8 +1585,8 @@ func (s *sealSuite) TestSealToModeenvWithFdeHookHappy(c *C) {
 		Grade:          string(model.Grade()),
 		ModelSignKeyID: model.SignKeyID(),
 	}
-	key := secboot.EncryptionKey{1, 2, 3, 4}
-	saveKey := secboot.EncryptionKey{5, 6, 7, 8}
+	key := keys.EncryptionKey{1, 2, 3, 4}
+	saveKey := keys.EncryptionKey{5, 6, 7, 8}
 
 	err := boot.SealKeyToModeenv(key, saveKey, model, modeenv)
 	c.Assert(err, IsNil)
@@ -1628,8 +1629,8 @@ func (s *sealSuite) TestSealToModeenvWithFdeHookSad(c *C) {
 	modeenv := &boot.Modeenv{
 		RecoverySystem: "20200825",
 	}
-	key := secboot.EncryptionKey{1, 2, 3, 4}
-	saveKey := secboot.EncryptionKey{5, 6, 7, 8}
+	key := keys.EncryptionKey{1, 2, 3, 4}
+	saveKey := keys.EncryptionKey{5, 6, 7, 8}
 
 	model := boottest.MakeMockUC20Model()
 	err := boot.SealKeyToModeenv(key, saveKey, model, modeenv)

--- a/daemon/api_system_recovery_keys.go
+++ b/daemon/api_system_recovery_keys.go
@@ -26,7 +26,7 @@ import (
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord/auth"
-	"github.com/snapcore/snapd/secboot"
+	"github.com/snapcore/snapd/secboot/keys"
 )
 
 var systemRecoveryKeysCmd = &Command{
@@ -38,13 +38,13 @@ var systemRecoveryKeysCmd = &Command{
 func getSystemRecoveryKeys(c *Command, r *http.Request, user *auth.UserState) Response {
 	var rsp client.SystemRecoveryKeysResponse
 
-	rkey, err := secboot.RecoveryKeyFromFile(filepath.Join(dirs.SnapFDEDir, "recovery.key"))
+	rkey, err := keys.RecoveryKeyFromFile(filepath.Join(dirs.SnapFDEDir, "recovery.key"))
 	if err != nil {
 		return InternalError(err.Error())
 	}
 	rsp.RecoveryKey = rkey.String()
 
-	reinstallKey, err := secboot.RecoveryKeyFromFile(filepath.Join(dirs.SnapFDEDir, "reinstall.key"))
+	reinstallKey, err := keys.RecoveryKeyFromFile(filepath.Join(dirs.SnapFDEDir, "reinstall.key"))
 	if err != nil {
 		return InternalError(err.Error())
 	}

--- a/daemon/api_system_recovery_keys_test.go
+++ b/daemon/api_system_recovery_keys_test.go
@@ -31,7 +31,7 @@ import (
 
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/dirs"
-	"github.com/snapcore/snapd/secboot"
+	"github.com/snapcore/snapd/secboot/keys"
 )
 
 var _ = Suite(&recoveryKeysSuite{})
@@ -64,7 +64,7 @@ func mockSystemRecoveryKeys(c *C) {
 }
 
 func (s *recoveryKeysSuite) TestSystemGetRecoveryKeysAsRootHappy(c *C) {
-	if (secboot.RecoveryKey{}).String() == "not-implemented" {
+	if (keys.RecoveryKey{}).String() == "not-implemented" {
 		c.Skip("needs working secboot recovery key")
 	}
 

--- a/gadget/install/encrypt.go
+++ b/gadget/install/encrypt.go
@@ -32,6 +32,7 @@ import (
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/disks"
 	"github.com/snapcore/snapd/secboot"
+	"github.com/snapcore/snapd/secboot/keys"
 )
 
 var (
@@ -42,7 +43,7 @@ var (
 // encryptedDeviceCryptsetup represents a encrypted block device.
 type encryptedDevice interface {
 	Node() string
-	AddRecoveryKey(key secboot.EncryptionKey, rkey secboot.RecoveryKey) error
+	AddRecoveryKey(key keys.EncryptionKey, rkey keys.RecoveryKey) error
 	Close() error
 }
 
@@ -58,7 +59,7 @@ var _ = encryptedDevice(&encryptedDeviceLUKS{})
 
 // newEncryptedDeviceLUKS creates an encrypted device in the existing
 // partition using the specified key with the LUKS backend.
-func newEncryptedDeviceLUKS(part *gadget.OnDiskStructure, key secboot.EncryptionKey, name string) (encryptedDevice, error) {
+func newEncryptedDeviceLUKS(part *gadget.OnDiskStructure, key keys.EncryptionKey, name string) (encryptedDevice, error) {
 	dev := &encryptedDeviceLUKS{
 		parent: part,
 		name:   name,
@@ -79,7 +80,7 @@ func newEncryptedDeviceLUKS(part *gadget.OnDiskStructure, key secboot.Encryption
 	return dev, nil
 }
 
-func (dev *encryptedDeviceLUKS) AddRecoveryKey(key secboot.EncryptionKey, rkey secboot.RecoveryKey) error {
+func (dev *encryptedDeviceLUKS) AddRecoveryKey(key keys.EncryptionKey, rkey keys.RecoveryKey) error {
 	return secbootAddRecoveryKey(key, rkey, dev.parent.Node)
 }
 
@@ -91,7 +92,7 @@ func (dev *encryptedDeviceLUKS) Close() error {
 	return cryptsetupClose(dev.name)
 }
 
-func cryptsetupOpen(key secboot.EncryptionKey, node, name string) error {
+func cryptsetupOpen(key keys.EncryptionKey, node, name string) error {
 	cmd := exec.Command("cryptsetup", "open", "--key-file", "-", node, name)
 	cmd.Stdin = bytes.NewReader(key[:])
 	if output, err := cmd.CombinedOutput(); err != nil {
@@ -120,7 +121,7 @@ var _ = encryptedDevice(&encryptedDeviceWithSetupHook{})
 
 // createEncryptedDeviceWithSetupHook creates an encrypted device in the
 // existing partition using the specified key using the fde-setup hook
-func createEncryptedDeviceWithSetupHook(part *gadget.OnDiskStructure, key secboot.EncryptionKey, name string) (encryptedDevice, error) {
+func createEncryptedDeviceWithSetupHook(part *gadget.OnDiskStructure, key keys.EncryptionKey, name string) (encryptedDevice, error) {
 	// for roles requiring encryption, the filesystem label is always set to
 	// either the implicit value or a value that has been validated
 	if part.Name != name || part.Label != name {
@@ -173,6 +174,6 @@ func (dev *encryptedDeviceWithSetupHook) Node() string {
 	return dev.node
 }
 
-func (dev *encryptedDeviceWithSetupHook) AddRecoveryKey(key secboot.EncryptionKey, rkey secboot.RecoveryKey) error {
+func (dev *encryptedDeviceWithSetupHook) AddRecoveryKey(key keys.EncryptionKey, rkey keys.RecoveryKey) error {
 	return fmt.Errorf("recovery keys are not supported on devices that use the device-setup hook")
 }

--- a/gadget/install/encrypt_test.go
+++ b/gadget/install/encrypt_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/snapcore/snapd/gadget/install"
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/kernel/fde"
-	"github.com/snapcore/snapd/secboot"
+	"github.com/snapcore/snapd/secboot/keys"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -42,8 +42,8 @@ type encryptSuite struct {
 
 	mockCryptsetup *testutil.MockCmd
 
-	mockedEncryptionKey secboot.EncryptionKey
-	mockedRecoveryKey   secboot.RecoveryKey
+	mockedEncryptionKey keys.EncryptionKey
+	mockedRecoveryKey   keys.RecoveryKey
 }
 
 var _ = Suite(&encryptSuite{})
@@ -67,11 +67,11 @@ func (s *encryptSuite) SetUpTest(c *C) {
 	c.Assert(os.MkdirAll(dirs.SnapRunDir, 0755), IsNil)
 
 	// create empty key to prevent blocking on lack of system entropy
-	s.mockedEncryptionKey = secboot.EncryptionKey{}
+	s.mockedEncryptionKey = keys.EncryptionKey{}
 	for i := range s.mockedEncryptionKey {
 		s.mockedEncryptionKey[i] = byte(i)
 	}
-	s.mockedRecoveryKey = secboot.RecoveryKey{15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
+	s.mockedRecoveryKey = keys.RecoveryKey{15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
 }
 
 func (s *encryptSuite) TestNewEncryptedDeviceLUKS(c *C) {
@@ -105,7 +105,7 @@ func (s *encryptSuite) TestNewEncryptedDeviceLUKS(c *C) {
 		s.AddCleanup(s.mockCryptsetup.Restore)
 
 		calls := 0
-		restore := install.MockSecbootFormatEncryptedDevice(func(key secboot.EncryptionKey, label, node string) error {
+		restore := install.MockSecbootFormatEncryptedDevice(func(key keys.EncryptionKey, label, node string) error {
 			calls++
 			c.Assert(key, DeepEquals, s.mockedEncryptionKey)
 			c.Assert(label, Equals, "some-label-enc")
@@ -145,13 +145,13 @@ func (s *encryptSuite) TestAddRecoveryKey(c *C) {
 		s.mockCryptsetup = testutil.MockCommand(c, "cryptsetup", "")
 		s.AddCleanup(s.mockCryptsetup.Restore)
 
-		restore := install.MockSecbootFormatEncryptedDevice(func(key secboot.EncryptionKey, label, node string) error {
+		restore := install.MockSecbootFormatEncryptedDevice(func(key keys.EncryptionKey, label, node string) error {
 			return nil
 		})
 		defer restore()
 
 		calls := 0
-		restore = install.MockSecbootAddRecoveryKey(func(key secboot.EncryptionKey, rkey secboot.RecoveryKey, node string) error {
+		restore = install.MockSecbootAddRecoveryKey(func(key keys.EncryptionKey, rkey keys.RecoveryKey, node string) error {
 			calls++
 			c.Assert(key, DeepEquals, s.mockedEncryptionKey)
 			c.Assert(rkey, DeepEquals, s.mockedRecoveryKey)

--- a/gadget/install/export_secboot_test.go
+++ b/gadget/install/export_secboot_test.go
@@ -24,7 +24,7 @@ package install
 import (
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/kernel/fde"
-	"github.com/snapcore/snapd/secboot"
+	"github.com/snapcore/snapd/secboot/keys"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -34,14 +34,14 @@ var (
 	CreateEncryptedDeviceWithSetupHook = createEncryptedDeviceWithSetupHook
 )
 
-func MockSecbootFormatEncryptedDevice(f func(key secboot.EncryptionKey, label, node string) error) (restore func()) {
+func MockSecbootFormatEncryptedDevice(f func(key keys.EncryptionKey, label, node string) error) (restore func()) {
 	r := testutil.Backup(&secbootFormatEncryptedDevice)
 	secbootFormatEncryptedDevice = f
 	return r
 
 }
 
-func MockSecbootAddRecoveryKey(f func(key secboot.EncryptionKey, rkey secboot.RecoveryKey, node string) error) (restore func()) {
+func MockSecbootAddRecoveryKey(f func(key keys.EncryptionKey, rkey keys.RecoveryKey, node string) error) (restore func()) {
 	r := testutil.Backup(&secbootAddRecoveryKey)
 	secbootAddRecoveryKey = f
 	return r

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -33,6 +33,7 @@ import (
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil/disks"
 	"github.com/snapcore/snapd/secboot"
+	"github.com/snapcore/snapd/secboot/keys"
 	"github.com/snapcore/snapd/timings"
 )
 
@@ -153,12 +154,12 @@ func Run(model gadget.Model, gadgetRoot, kernelRoot, bootDevice string, options 
 	}
 
 	makeKeySet := func() (*EncryptionKeySet, error) {
-		key, err := secboot.NewEncryptionKey()
+		key, err := keys.NewEncryptionKey()
 		if err != nil {
 			return nil, fmt.Errorf("cannot create encryption key: %v", err)
 		}
 
-		rkey, err := secboot.NewRecoveryKey()
+		rkey, err := keys.NewRecoveryKey()
 		if err != nil {
 			return nil, fmt.Errorf("cannot create recovery key: %v", err)
 		}

--- a/gadget/install/install_test.go
+++ b/gadget/install/install_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/osutil/disks"
 	"github.com/snapcore/snapd/secboot"
+	"github.com/snapcore/snapd/secboot/keys"
 	"github.com/snapcore/snapd/testutil"
 	"github.com/snapcore/snapd/timings"
 )
@@ -346,10 +347,10 @@ func (s *installSuite) testInstall(c *C, opts installOpts) {
 	gadgetRoot, err := gadgettest.WriteGadgetYaml(c.MkDir(), gadgettest.RaspiSimplifiedYaml)
 	c.Assert(err, IsNil)
 
-	var savePrimaryKey, dataPrimaryKey secboot.EncryptionKey
+	var savePrimaryKey, dataPrimaryKey keys.EncryptionKey
 
 	secbootFormatEncryptedDeviceCall := 0
-	restore = install.MockSecbootFormatEncryptedDevice(func(key secboot.EncryptionKey, label, node string) error {
+	restore = install.MockSecbootFormatEncryptedDevice(func(key keys.EncryptionKey, label, node string) error {
 		if !opts.encryption {
 			c.Error("unexpected call to secboot.FormatEncryptedDevice when encryption is off")
 			return fmt.Errorf("no encryption functions should be called")
@@ -375,10 +376,10 @@ func (s *installSuite) testInstall(c *C, opts installOpts) {
 	})
 	defer restore()
 
-	var saveRecoveryKey, dataRecoveryKey secboot.RecoveryKey
+	var saveRecoveryKey, dataRecoveryKey keys.RecoveryKey
 
 	secbootAddRecoveryKeyCall := 0
-	restore = install.MockSecbootAddRecoveryKey(func(key secboot.EncryptionKey, rkey secboot.RecoveryKey, node string) error {
+	restore = install.MockSecbootAddRecoveryKey(func(key keys.EncryptionKey, rkey keys.RecoveryKey, node string) error {
 		if !opts.encryption {
 			c.Error("unexpected call to secboot.AddRecoveryKey when encryption is off")
 			return fmt.Errorf("no encryption functions should be called")
@@ -843,7 +844,7 @@ func (s *installSuite) testFactoryReset(c *C, opts factoryResetOpts) {
 	gadgetRoot, err := gadgettest.WriteGadgetYaml(c.MkDir(), opts.gadgetYaml)
 	c.Assert(err, IsNil)
 
-	restore = install.MockSecbootFormatEncryptedDevice(func(key secboot.EncryptionKey, label, node string) error {
+	restore = install.MockSecbootFormatEncryptedDevice(func(key keys.EncryptionKey, label, node string) error {
 		c.Error("unexpected call to secboot.FormatEncryptedDevice")
 		return fmt.Errorf("unexpected call")
 	})

--- a/gadget/install/params.go
+++ b/gadget/install/params.go
@@ -21,6 +21,7 @@ package install
 
 import (
 	"github.com/snapcore/snapd/secboot"
+	"github.com/snapcore/snapd/secboot/keys"
 )
 
 type Options struct {
@@ -32,8 +33,8 @@ type Options struct {
 
 // EncryptionKeySet is a set of encryption keys.
 type EncryptionKeySet struct {
-	Key         secboot.EncryptionKey
-	RecoveryKey secboot.RecoveryKey
+	Key         keys.EncryptionKey
+	RecoveryKey keys.RecoveryKey
 }
 
 // InstalledSystemSideData carries side data of an installed system, eg. secrets

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -53,6 +53,7 @@ import (
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/secboot"
+	"github.com/snapcore/snapd/secboot/keys"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/sysconfig"
@@ -198,11 +199,11 @@ type encTestCase struct {
 }
 
 var (
-	dataEncryptionKey = secboot.EncryptionKey{'d', 'a', 't', 'a', 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
-	dataRecoveryKey   = secboot.RecoveryKey{'r', 'e', 'c', 'o', 'v', 'e', 'r', 'y', 10, 11, 12, 13, 14, 15, 16, 17}
+	dataEncryptionKey = keys.EncryptionKey{'d', 'a', 't', 'a', 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	dataRecoveryKey   = keys.RecoveryKey{'r', 'e', 'c', 'o', 'v', 'e', 'r', 'y', 10, 11, 12, 13, 14, 15, 16, 17}
 
-	saveKey      = secboot.EncryptionKey{'s', 'a', 'v', 'e', 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
-	reinstallKey = secboot.RecoveryKey{'r', 'e', 'i', 'n', 's', 't', 'a', 'l', 'l', 11, 12, 13, 14, 15, 16, 17}
+	saveKey      = keys.EncryptionKey{'s', 'a', 'v', 'e', 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	reinstallKey = keys.RecoveryKey{'r', 'e', 'i', 'n', 's', 't', 'a', 'l', 'l', 11, 12, 13, 14, 15, 16, 17}
 )
 
 func (s *deviceMgrInstallModeSuite) doRunChangeTestWithEncryption(c *C, grade string, tc encTestCase) error {

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -59,7 +59,7 @@ import (
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/overlord/storecontext"
 	"github.com/snapcore/snapd/release"
-	"github.com/snapcore/snapd/secboot"
+	"github.com/snapcore/snapd/secboot/keys"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/snapdenv"
@@ -1573,7 +1573,7 @@ func (s *deviceMgrSuite) TestRunFDESetupHookHappy(c *C) {
 	})
 	st.Unlock()
 
-	mockKey := secboot.EncryptionKey{1, 2, 3, 4}
+	mockKey := keys.EncryptionKey{1, 2, 3, 4}
 
 	var hookCalled []string
 	hookInvoke := func(ctx *hookstate.Context, tomb *tomb.Tomb) ([]byte, error) {

--- a/overlord/hookstate/ctlcmd/fde_setup_test.go
+++ b/overlord/hookstate/ctlcmd/fde_setup_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
 	"github.com/snapcore/snapd/overlord/hookstate/hooktest"
 	"github.com/snapcore/snapd/overlord/state"
-	"github.com/snapcore/snapd/secboot"
+	"github.com/snapcore/snapd/secboot/keys"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -127,7 +127,7 @@ func (s *fdeSetupSuite) TestFdeSetupRequestOpFeatures(c *C) {
 }
 
 func (s *fdeSetupSuite) TestFdeSetupRequestOpInitialSetup(c *C) {
-	mockKey := secboot.EncryptionKey{1, 2, 3, 4}
+	mockKey := keys.EncryptionKey{1, 2, 3, 4}
 	fdeSetup := &fde.SetupRequest{
 		Op:      "initial-setup",
 		Key:     mockKey[:],
@@ -168,7 +168,7 @@ func (s *fdeSetupSuite) TestFdeSetupResult(c *C) {
 }
 
 func (s *fdeSetupSuite) TestFdeSetupRequestOpDeviceSetup(c *C) {
-	mockKey := secboot.EncryptionKey{1, 2, 3, 4}
+	mockKey := keys.EncryptionKey{1, 2, 3, 4}
 	fdeSetup := &fde.SetupRequest{
 		Op:     "device-setup",
 		Key:    mockKey[:],

--- a/packaging/debian-sid/rules
+++ b/packaging/debian-sid/rules
@@ -141,7 +141,7 @@ override_dh_auto_build:
 	find _build/src/$(DH_GOPKG)/cmd/snap-bootstrap -name "*.go" | xargs rm -f
 	find _build/src/$(DH_GOPKG)/gadget/install -name "*.go" | grep -vE '(params\.go|install_dummy\.go)'| xargs rm -f
 	# XXX: once dh-golang understands go build tags this would not be needed
-	find _build/src/$(DH_GOPKG)/secboot/ -name "*.go" | grep -Ev '(encrypt\.go|secboot_dummy\.go|secboot\.go|encrypt_dummy\.go)' | xargs rm -f
+	find _build/src/$(DH_GOPKG)/secboot/ -name "*.go" | grep -E '(.*_sb(_test)?\.go|.*_tpm(_test)?\.go|secboot_hooks.go)' | xargs rm -f
 	# and build, we cannot use modules as packaging on Debian requires us to use
 	# dependencies from the distro, and this would require further updates to the
 	# go.mod file

--- a/secboot/encrypt.go
+++ b/secboot/encrypt.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2021 Canonical Ltd
+ * Copyright (C) 2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -18,104 +18,6 @@
  */
 
 package secboot
-
-import (
-	"crypto/rand"
-	"fmt"
-	"io"
-	"os"
-	"path/filepath"
-
-	"github.com/snapcore/snapd/osutil"
-)
-
-const (
-	// The encryption key size is set so it has the same entropy as the derived
-	// key.
-	encryptionKeySize = 32
-
-	// XXX: needs to be in sync with
-	//      github.com/snapcore/secboot/crypto.go:"type RecoveryKey"
-	// Size of the recovery key.
-	recoveryKeySize = 16
-
-	// The auxiliary key is used to bind keys to models
-	auxKeySize = 32
-)
-
-// used in tests
-var randRead = rand.Read
-
-// EncryptionKey is the key used to encrypt the data partition.
-type EncryptionKey []byte
-
-func NewEncryptionKey() (EncryptionKey, error) {
-	key := make(EncryptionKey, encryptionKeySize)
-	// rand.Read() is protected against short reads
-	_, err := randRead(key[:])
-	// On return, n == len(b) if and only if err == nil
-	return key, err
-}
-
-// Save writes the key in the location specified by filename.
-func (key EncryptionKey) Save(filename string) error {
-	if err := os.MkdirAll(filepath.Dir(filename), 0755); err != nil {
-		return err
-	}
-	return osutil.AtomicWriteFile(filename, key[:], 0600, 0)
-}
-
-// RecoveryKey is a key used to unlock the encrypted partition when
-// the encryption key can't be used, for example when unseal fails.
-type RecoveryKey [recoveryKeySize]byte
-
-func NewRecoveryKey() (RecoveryKey, error) {
-	var key RecoveryKey
-	// rand.Read() is protected against short reads
-	_, err := randRead(key[:])
-	// On return, n == len(b) if and only if err == nil
-	return key, err
-}
-
-// Save writes the recovery key in the location specified by filename.
-func (key RecoveryKey) Save(filename string) error {
-	if err := os.MkdirAll(filepath.Dir(filename), 0755); err != nil {
-		return err
-	}
-	return osutil.AtomicWriteFile(filename, key[:], 0600, 0)
-}
-
-func RecoveryKeyFromFile(recoveryKeyFile string) (*RecoveryKey, error) {
-	f, err := os.Open(recoveryKeyFile)
-	if err != nil {
-		return nil, fmt.Errorf("cannot open recovery key: %v", err)
-	}
-	defer f.Close()
-	st, err := f.Stat()
-	if err != nil {
-		return nil, fmt.Errorf("cannot stat recovery key: %v", err)
-	}
-	if st.Size() != int64(len(RecoveryKey{})) {
-		return nil, fmt.Errorf("cannot read recovery key: unexpected size %v for the recovery key file %s", st.Size(), recoveryKeyFile)
-	}
-
-	var rkey RecoveryKey
-	if _, err := io.ReadFull(f, rkey[:]); err != nil {
-		return nil, fmt.Errorf("cannot read recovery key: %v", err)
-	}
-	return &rkey, nil
-}
-
-// AuxKey is the key to bind models to keys.
-type AuxKey [auxKeySize]byte
-
-func NewAuxKey() (AuxKey, error) {
-	var key AuxKey
-	// rand.Read() is protected against short reads
-	_, err := randRead(key[:])
-	// On return, n == len(b) if and only if err == nil
-	return key, err
-}
 
 // EncryptionType specifies what encryption backend should be used (if any)
 type EncryptionType string

--- a/secboot/encrypt_sb.go
+++ b/secboot/encrypt_sb.go
@@ -27,6 +27,7 @@ import (
 	sb "github.com/snapcore/secboot"
 
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/secboot/keys"
 )
 
 var (
@@ -40,7 +41,7 @@ const metadataKiBSize = 2048     // 2MB
 // FormatEncryptedDevice initializes an encrypted volume on the block device
 // given by node, setting the specified label. The key used to unlock the volume
 // is provided using the key argument.
-func FormatEncryptedDevice(key EncryptionKey, label, node string) error {
+func FormatEncryptedDevice(key keys.EncryptionKey, label, node string) error {
 	opts := &sb.InitializeLUKS2ContainerOptions{
 		// use a lower, but still reasonable size that should give us
 		// enough room
@@ -63,7 +64,7 @@ func FormatEncryptedDevice(key EncryptionKey, label, node string) error {
 // The existing key to the encrypted volume is provided in the key argument.
 //
 // A heuristic memory cost is used.
-func AddRecoveryKey(key EncryptionKey, rkey RecoveryKey, node string) error {
+func AddRecoveryKey(key keys.EncryptionKey, rkey keys.RecoveryKey, node string) error {
 	usableMem, err := osutil.TotalUsableMemory()
 	if err != nil {
 		return fmt.Errorf("cannot get usable memory for KDF parameters when adding the recovery key: %v", err)
@@ -89,8 +90,4 @@ func AddRecoveryKey(key EncryptionKey, rkey RecoveryKey, node string) error {
 	}
 
 	return sbAddRecoveryKeyToLUKS2Container(node, key[:], sb.RecoveryKey(rkey), opts)
-}
-
-func (k RecoveryKey) String() string {
-	return sb.RecoveryKey(k).String()
 }

--- a/secboot/encrypt_sb_test.go
+++ b/secboot/encrypt_sb_test.go
@@ -3,7 +3,7 @@
 // +build !nosecboot
 
 /*
- * Copyright (C) 2021 Canonical Ltd
+ * Copyright (C) 2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -31,6 +31,7 @@ import (
 
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/secboot"
+	"github.com/snapcore/snapd/secboot/keys"
 )
 
 func (s *encryptSuite) TestFormatEncryptedDevice(c *C) {
@@ -42,7 +43,7 @@ func (s *encryptSuite) TestFormatEncryptedDevice(c *C) {
 		{initErr: errors.New("some error"), err: "some error"},
 	} {
 		// create empty key to prevent blocking on lack of system entropy
-		myKey := secboot.EncryptionKey{}
+		myKey := keys.EncryptionKey{}
 		for i := range myKey {
 			myKey[i] = byte(i)
 		}
@@ -95,12 +96,12 @@ func (s *encryptSuite) TestAddRecoveryKey(c *C) {
 		{addErr: errors.New("some error"), err: "some error"},
 	} {
 		// create empty key to prevent blocking on lack of system entropy
-		myKey := secboot.EncryptionKey{}
+		myKey := keys.EncryptionKey{}
 		for i := range myKey {
 			myKey[i] = byte(i)
 		}
 
-		myRecoveryKey := secboot.RecoveryKey{15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
+		myRecoveryKey := keys.RecoveryKey{15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
 
 		calls := 0
 		restore := secboot.MockSbAddRecoveryKeyToLUKS2Container(func(devicePath string, key []byte, recoveryKey sb.RecoveryKey, opts *sb.KDFOptions) error {

--- a/secboot/keys/export_test.go
+++ b/secboot/keys/export_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2021 Canonical Ltd
+ * Copyright (C) 2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -17,7 +17,7 @@
  *
  */
 
-package secboot
+package keys
 
 func MockRandRead(f func(p []byte) (int, error)) (restore func()) {
 	oldRandRead := randRead

--- a/secboot/keys/keys.go
+++ b/secboot/keys/keys.go
@@ -1,0 +1,118 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package keys
+
+import (
+	"crypto/rand"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/snapcore/snapd/osutil"
+)
+
+const (
+	// The encryption key size is set so it has the same entropy as the derived
+	// key.
+	EncryptionKeySize = 32
+
+	// XXX: needs to be in sync with
+	//      github.com/snapcore/secboot/crypto.go:"type RecoveryKey"
+	// Size of the recovery key.
+	RecoveryKeySize = 16
+
+	// The auxiliary key is used to bind keys to models
+	AuxKeySize = 32
+)
+
+// used in tests
+var randRead = rand.Read
+
+// EncryptionKey is the key used to encrypt the data partition.
+type EncryptionKey []byte
+
+func NewEncryptionKey() (EncryptionKey, error) {
+	key := make(EncryptionKey, EncryptionKeySize)
+	// rand.Read() is protected against short reads
+	_, err := randRead(key[:])
+	// On return, n == len(b) if and only if err == nil
+	return key, err
+}
+
+// Save writes the key in the location specified by filename.
+func (key EncryptionKey) Save(filename string) error {
+	if err := os.MkdirAll(filepath.Dir(filename), 0755); err != nil {
+		return err
+	}
+	return osutil.AtomicWriteFile(filename, key[:], 0600, 0)
+}
+
+// RecoveryKey is a key used to unlock the encrypted partition when
+// the encryption key can't be used, for example when unseal fails.
+type RecoveryKey [RecoveryKeySize]byte
+
+func NewRecoveryKey() (RecoveryKey, error) {
+	var key RecoveryKey
+	// rand.Read() is protected against short reads
+	_, err := randRead(key[:])
+	// On return, n == len(b) if and only if err == nil
+	return key, err
+}
+
+// Save writes the recovery key in the location specified by filename.
+func (key RecoveryKey) Save(filename string) error {
+	if err := os.MkdirAll(filepath.Dir(filename), 0755); err != nil {
+		return err
+	}
+	return osutil.AtomicWriteFile(filename, key[:], 0600, 0)
+}
+
+func RecoveryKeyFromFile(recoveryKeyFile string) (*RecoveryKey, error) {
+	f, err := os.Open(recoveryKeyFile)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open recovery key: %v", err)
+	}
+	defer f.Close()
+	st, err := f.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("cannot stat recovery key: %v", err)
+	}
+	if st.Size() != int64(len(RecoveryKey{})) {
+		return nil, fmt.Errorf("cannot read recovery key: unexpected size %v for the recovery key file %s", st.Size(), recoveryKeyFile)
+	}
+
+	var rkey RecoveryKey
+	if _, err := io.ReadFull(f, rkey[:]); err != nil {
+		return nil, fmt.Errorf("cannot read recovery key: %v", err)
+	}
+	return &rkey, nil
+}
+
+// AuxKey is the key to bind models to keys.
+type AuxKey [AuxKeySize]byte
+
+func NewAuxKey() (AuxKey, error) {
+	var key AuxKey
+	// rand.Read() is protected against short reads
+	_, err := randRead(key[:])
+	// On return, n == len(b) if and only if err == nil
+	return key, err
+}

--- a/secboot/keys/keys_dummy.go
+++ b/secboot/keys/keys_dummy.go
@@ -1,7 +1,9 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build nosecboot
+// +build nosecboot
 
 /*
- * Copyright (C) 2019-2022 Canonical Ltd
+ * Copyright (C) 2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -17,22 +19,8 @@
  *
  */
 
-package secboot_test
+package keys
 
-import (
-	"testing"
-
-	. "gopkg.in/check.v1"
-)
-
-func TestSecboot(t *testing.T) { TestingT(t) }
-
-type encryptSuite struct {
-	dir string
-}
-
-var _ = Suite(&encryptSuite{})
-
-func (s *encryptSuite) SetUpTest(c *C) {
-	s.dir = c.MkDir()
+func (k RecoveryKey) String() string {
+	return "not-implemented"
 }

--- a/secboot/keys/keys_sb.go
+++ b/secboot/keys/keys_sb.go
@@ -1,9 +1,9 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
-//go:build nosecboot
-// +build nosecboot
+//go:build !nosecboot
+// +build !nosecboot
 
 /*
- * Copyright (C) 2020 Canonical Ltd
+ * Copyright (C) 2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -19,8 +19,12 @@
  *
  */
 
-package secboot
+package keys
+
+import (
+	sb "github.com/snapcore/secboot"
+)
 
 func (k RecoveryKey) String() string {
-	return "not-implemented"
+	return sb.RecoveryKey(k).String()
 }

--- a/secboot/keys/keys_test.go
+++ b/secboot/keys/keys_test.go
@@ -1,0 +1,116 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019-2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package keys_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/secboot/keys"
+	"github.com/snapcore/snapd/testutil"
+)
+
+func TestSecboot(t *testing.T) { TestingT(t) }
+
+type keysSuite struct {
+	dir string
+}
+
+var _ = Suite(&keysSuite{})
+
+func (s *keysSuite) SetUpTest(c *C) {
+	s.dir = c.MkDir()
+}
+
+func (s *keysSuite) TestRecoveryKeySave(c *C) {
+	kf := filepath.Join(s.dir, "test-key")
+	kfNested := filepath.Join(s.dir, "deeply/nested/test-key")
+
+	rkey := keys.RecoveryKey{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 255}
+	err := rkey.Save(kf)
+	c.Assert(err, IsNil)
+	c.Assert(kf, testutil.FileEquals, rkey[:])
+
+	fileInfo, err := os.Stat(kf)
+	c.Assert(err, IsNil)
+	c.Assert(fileInfo.Mode(), Equals, os.FileMode(0600))
+
+	err = rkey.Save(kfNested)
+	c.Assert(err, IsNil)
+	c.Assert(kfNested, testutil.FileEquals, rkey[:])
+	di, err := os.Stat(filepath.Dir(kfNested))
+	c.Assert(err, IsNil)
+	c.Assert(di.Mode().Perm(), Equals, os.FileMode(0755))
+}
+
+func (s *keysSuite) TestEncryptionKeySave(c *C) {
+	kf := filepath.Join(s.dir, "test-key")
+	kfNested := filepath.Join(s.dir, "deeply/nested/test-key")
+
+	ekey := keys.EncryptionKey{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 255}
+	err := ekey.Save(kf)
+	c.Assert(err, IsNil)
+	c.Assert(kf, testutil.FileEquals, []byte(ekey))
+
+	fileInfo, err := os.Stat(kf)
+	c.Assert(err, IsNil)
+	c.Assert(fileInfo.Mode(), Equals, os.FileMode(0600))
+
+	err = ekey.Save(kfNested)
+	c.Assert(err, IsNil)
+	c.Assert(kfNested, testutil.FileEquals, []byte(ekey))
+	di, err := os.Stat(filepath.Dir(kfNested))
+	c.Assert(err, IsNil)
+	c.Assert(di.Mode().Perm(), Equals, os.FileMode(0755))
+}
+
+func (s *keysSuite) TestNewAuxKeyHappy(c *C) {
+	restore := keys.MockRandRead(func(p []byte) (int, error) {
+		for i := range p {
+			p[i] = byte(i % 10)
+		}
+		return len(p), nil
+	})
+	defer restore()
+
+	auxKey, err := keys.NewAuxKey()
+	c.Assert(err, IsNil)
+	c.Assert(auxKey, HasLen, 32)
+	c.Check(auxKey[:], DeepEquals, []byte{
+		0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9,
+		0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9,
+		0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9,
+		0x0, 0x1,
+	})
+}
+
+func (s *keysSuite) TestNewAuxKeySad(c *C) {
+	restore := keys.MockRandRead(func(p []byte) (int, error) {
+		return 0, fmt.Errorf("fail")
+	})
+	defer restore()
+
+	_, err := keys.NewAuxKey()
+	c.Check(err, ErrorMatches, "fail")
+}

--- a/secboot/secboot.go
+++ b/secboot/secboot.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/bootloader"
+	"github.com/snapcore/snapd/secboot/keys"
 )
 
 const (
@@ -58,7 +59,7 @@ func NewLoadChain(bf bootloader.BootFile, next ...*LoadChain) *LoadChain {
 
 type SealKeyRequest struct {
 	// The key to seal
-	Key EncryptionKey
+	Key keys.EncryptionKey
 	// The key name; identical keys should have identical names
 	KeyName string
 	// The path to store the sealed key file. The same Key/KeyName
@@ -107,7 +108,7 @@ type SealKeysWithFDESetupHookParams struct {
 	// Initial model to bind sealed keys to.
 	Model ModelForSealing
 	// AuxKey is the auxiliary key used to bind models.
-	AuxKey AuxKey
+	AuxKey keys.AuxKey
 	// The path to the aux key file (if empty the key will not be
 	// saved)
 	AuxKeyFile string

--- a/secboot/secboot_sb_test.go
+++ b/secboot/secboot_sb_test.go
@@ -49,6 +49,7 @@ import (
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/disks"
 	"github.com/snapcore/snapd/secboot"
+	"github.com/snapcore/snapd/secboot/keys"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snapfile"
 	"github.com/snapcore/snapd/snap/squashfs"
@@ -698,8 +699,8 @@ func (s *secbootSuite) TestSealKey(c *C) {
 			PCRPolicyCounterHandle: 42,
 		}
 
-		myKey := secboot.EncryptionKey{}
-		myKey2 := secboot.EncryptionKey{}
+		myKey := keys.EncryptionKey{}
+		myKey2 := keys.EncryptionKey{}
 		for i := range myKey {
 			myKey[i] = byte(i)
 			myKey2[i] = byte(128 + i)
@@ -1098,7 +1099,7 @@ func (s *secbootSuite) TestResealKey(c *C) {
 func (s *secbootSuite) TestSealKeyNoModelParams(c *C) {
 	myKeys := []secboot.SealKeyRequest{
 		{
-			Key:     secboot.EncryptionKey{},
+			Key:     keys.EncryptionKey{},
 			KeyFile: "keyfile",
 		},
 	}
@@ -1349,9 +1350,9 @@ func (s *secbootSuite) TestSealKeysWithFDESetupHookHappy(c *C) {
 		return json.Marshal(res)
 	}
 
-	key1 := secboot.EncryptionKey{1, 2, 3, 4}
-	key2 := secboot.EncryptionKey{5, 6, 7, 8}
-	auxKey := secboot.AuxKey{9, 10, 11, 12}
+	key1 := keys.EncryptionKey{1, 2, 3, 4}
+	key2 := keys.EncryptionKey{5, 6, 7, 8}
+	auxKey := keys.AuxKey{9, 10, 11, 12}
 	key1Fn := filepath.Join(tmpdir, "key1.key")
 	key2Fn := filepath.Join(tmpdir, "key2.key")
 	auxKeyFn := filepath.Join(tmpdir, "aux-key")
@@ -1392,8 +1393,8 @@ func (s *secbootSuite) TestSealKeysWithFDESetupHookSad(c *C) {
 		return nil, fmt.Errorf("hook failed")
 	}
 
-	key := secboot.EncryptionKey{1, 2, 3, 4}
-	auxKey := secboot.AuxKey{5, 6, 7, 8}
+	key := keys.EncryptionKey{1, 2, 3, 4}
+	auxKey := keys.AuxKey{5, 6, 7, 8}
 	keyFn := filepath.Join(tmpdir, "key.key")
 	auxKeyFn := filepath.Join(tmpdir, "aux-key")
 	params := secboot.SealKeysWithFDESetupHookParams{
@@ -1410,12 +1411,12 @@ func (s *secbootSuite) TestSealKeysWithFDESetupHookSad(c *C) {
 	c.Check(auxKeyFn, testutil.FileAbsent)
 }
 
-func makeMockDiskKey() secboot.EncryptionKey {
-	return secboot.EncryptionKey{0, 1, 2, 3, 4, 5}
+func makeMockDiskKey() keys.EncryptionKey {
+	return keys.EncryptionKey{0, 1, 2, 3, 4, 5}
 }
 
-func makeMockAuxKey() secboot.AuxKey {
-	return secboot.AuxKey{6, 7, 8, 9}
+func makeMockAuxKey() keys.AuxKey {
+	return keys.AuxKey{6, 7, 8, 9}
 }
 
 func makeMockUnencryptedPayload() []byte {

--- a/tests/lib/uc20-create-partitions/main.go
+++ b/tests/lib/uc20-create-partitions/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/secboot"
+	"github.com/snapcore/snapd/secboot/keys"
 	"github.com/snapcore/snapd/timings"
 )
 
@@ -54,7 +55,7 @@ func (o *simpleObserver) Observe(op gadget.ContentOperation, affectedStruct *gad
 	return gadget.ChangeApply, nil
 }
 
-func (o *simpleObserver) ChosenEncryptionKey(key secboot.EncryptionKey) {}
+func (o *simpleObserver) ChosenEncryptionKey(key keys.EncryptionKey) {}
 
 type uc20Constraints struct{}
 


### PR DESCRIPTION
As part of the factory-reset work and introducing keymgr in https://github.com/snapcore/snapd/pull/11715 we're moving key types to a separate package secboot/keys.