### PR TITLE
seed: let SnapHandler provided a different final path for snaps

### DIFF
--- a/seed/helpers.go
+++ b/seed/helpers.go
@@ -154,10 +154,14 @@ func findBrand(seed Seed, db asserts.RODatabase) (*asserts.Account, error) {
 
 type defaultSnapHandler struct{}
 
-func (h defaultSnapHandler) HandleUnassertedSnap(name, path string, _ timings.Measurer) error {
-	return nil
+func (h defaultSnapHandler) HandleUnassertedSnap(name, path string, _ timings.Measurer) (string, error) {
+	return path, nil
 }
 
-func (h defaultSnapHandler) HandleAndDigestAssertedSnap(name, path string, essType snap.Type, _ *asserts.SnapRevision, _ func(string, uint64) (snap.Revision, error), _ timings.Measurer) (string, uint64, error) {
-	return asserts.SnapFileSHA3_384(path)
+func (h defaultSnapHandler) HandleAndDigestAssertedSnap(name, path string, essType snap.Type, _ *asserts.SnapRevision, _ func(string, uint64) (snap.Revision, error), _ timings.Measurer) (string, string, uint64, error) {
+	sha3_384, size, err := asserts.SnapFileSHA3_384(path)
+	if err != nil {
+		return "", "", 0, err
+	}
+	return path, sha3_384, size, err
 }

--- a/seed/seed.go
+++ b/seed/seed.go
@@ -168,11 +168,15 @@ type SnapHandler interface {
 	// snapRev is provided by UC20+ seeds.
 	// deriveRev is provided by UC16/18 seeds, it can be used
 	// to get early access to the snap revision based on the digest.
-	HandleAndDigestAssertedSnap(name, path string, essentialType snap.Type, snapRev *asserts.SnapRevision, deriveRev func(snapSHA3_384 string, snapSize uint64) (snap.Revision, error), tm timings.Measurer) (snapSHA3_384 string, snapSize uint64, err error)
+	// A different path can be returned if the snap has been copied
+	// elsewhere.
+	HandleAndDigestAssertedSnap(name, path string, essentialType snap.Type, snapRev *asserts.SnapRevision, deriveRev func(snapSHA3_384 string, snapSize uint64) (snap.Revision, error), tm timings.Measurer) (newPath, snapSHA3_384 string, snapSize uint64, err error)
 
 	// HandleUnassertedSnap should perfrom any dedicated handling
 	// for the given unasserted snap.
-	HandleUnassertedSnap(name, path string, tm timings.Measurer) error
+	// A different path can be returned if the snap has been copied
+	// elsewhere.
+	HandleUnassertedSnap(name, path string, tm timings.Measurer) (newPath string, err error)
 }
 
 // Open returns a Seed implementation for the seed at seedDir.

--- a/seed/seed16.go
+++ b/seed/seed16.go
@@ -193,6 +193,7 @@ func (s *seed16) addSnap(sn *internal.Snap16, essType snap.Type, pinnedTrack str
 			// TODO: consider whether to use this if we have links?
 			sideInfo.EditedContact = sn.Contact
 		}
+		origPath := path
 		if newPath != "" {
 			path = newPath
 		}
@@ -200,7 +201,7 @@ func (s *seed16) addSnap(sn *internal.Snap16, essType snap.Type, pinnedTrack str
 
 		seedSnap.SideInfo = &sideInfo
 		if cache != nil {
-			cache[path] = seedSnap
+			cache[origPath] = seedSnap
 		}
 	}
 

--- a/seed/seed16.go
+++ b/seed/seed16.go
@@ -144,15 +144,17 @@ func (s *seed16) addSnap(sn *internal.Snap16, essType snap.Type, pinnedTrack str
 			}
 		}
 		seedSnap = &Snap{
-			Path:    path,
 			Channel: snapChannel,
 			Classic: sn.Classic,
 			DevMode: sn.DevMode,
 		}
 
 		var sideInfo snap.SideInfo
+		var newPath string
 		if sn.Unasserted {
-			if err := handler.HandleUnassertedSnap(sn.Name, path, tm); err != nil {
+			var err error
+			newPath, err = handler.HandleUnassertedSnap(sn.Name, path, tm)
+			if err != nil {
 				return nil, err
 			}
 			sideInfo.RealName = sn.Name
@@ -173,7 +175,7 @@ func (s *seed16) addSnap(sn *internal.Snap16, essType snap.Type, pinnedTrack str
 			timings.Run(tm, "derive-side-info", fmt.Sprintf("hash and derive side info for snap %q", sn.Name), func(nested timings.Measurer) {
 				var snapSHA3_384 string
 				var snapSize uint64
-				snapSHA3_384, snapSize, err = handler.HandleAndDigestAssertedSnap(sn.Name, path, essType, nil, deriveRev, tm)
+				newPath, snapSHA3_384, snapSize, err = handler.HandleAndDigestAssertedSnap(sn.Name, path, essType, nil, deriveRev, tm)
 				if err != nil {
 					return
 				}
@@ -191,6 +193,10 @@ func (s *seed16) addSnap(sn *internal.Snap16, essType snap.Type, pinnedTrack str
 			// TODO: consider whether to use this if we have links?
 			sideInfo.EditedContact = sn.Contact
 		}
+		if newPath != "" {
+			path = newPath
+		}
+		seedSnap.Path = path
 
 		seedSnap.SideInfo = &sideInfo
 		if cache != nil {

--- a/seed/seed20_test.go
+++ b/seed/seed20_test.go
@@ -44,6 +44,7 @@ import (
 type testSnapHandler struct {
 	seedDir    string
 	mu         sync.Mutex
+	pathPrefix string
 	asserted   map[string]string
 	unasserted map[string]string
 }
@@ -64,17 +65,17 @@ func (h *testSnapHandler) rel(path string) string {
 	return p
 }
 
-func (h *testSnapHandler) HandleUnassertedSnap(name, path string, _ timings.Measurer) error {
+func (h *testSnapHandler) HandleUnassertedSnap(name, path string, _ timings.Measurer) (string, error) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.unasserted[name] = h.rel(path)
-	return nil
+	return h.pathPrefix + path, nil
 }
 
-func (h *testSnapHandler) HandleAndDigestAssertedSnap(name, path string, essType snap.Type, snapRev *asserts.SnapRevision, deriveRev func(string, uint64) (snap.Revision, error), _ timings.Measurer) (string, uint64, error) {
+func (h *testSnapHandler) HandleAndDigestAssertedSnap(name, path string, essType snap.Type, snapRev *asserts.SnapRevision, deriveRev func(string, uint64) (snap.Revision, error), _ timings.Measurer) (string, string, uint64, error) {
 	snapSHA3_384, sz, err := asserts.SnapFileSHA3_384(path)
 	if err != nil {
-		return "", 0, err
+		return "", "", 0, err
 	}
 	func() {
 		h.mu.Lock()
@@ -89,7 +90,11 @@ func (h *testSnapHandler) HandleAndDigestAssertedSnap(name, path string, essType
 		}
 		h.asserted[name] = fmt.Sprintf("%s:%s:%s", h.rel(path), essType, revno)
 	}()
-	return snapSHA3_384, sz, err
+	if essType != "gadget" {
+		// XXX seed logic actually reads the gadget, leave it alone
+		path = h.pathPrefix + path
+	}
+	return path, snapSHA3_384, sz, err
 }
 
 type seed20Suite struct {
@@ -1429,6 +1434,112 @@ func (s *seed20Suite) TestLoadMetaCore20SnapHandler(c *C) {
 	c.Check(runSnaps, DeepEquals, []*seed.Snap{
 		{
 			Path:     filepath.Join(s.SeedDir, "systems", sysLabel, "snaps", "required20_1.0.snap"),
+			SideInfo: &snap.SideInfo{RealName: "required20"},
+			Required: true,
+		},
+	})
+
+	c.Check(h.asserted, DeepEquals, map[string]string{
+		"snapd":     "snaps/snapd_1.snap:snapd:1",
+		"pc-kernel": "snaps/pc-kernel_1.snap:kernel:1",
+		"core20":    "snaps/core20_1.snap:base:1",
+		"pc":        "snaps/pc_1.snap:gadget:1",
+	})
+	c.Check(h.unasserted, DeepEquals, map[string]string{
+		"required20": filepath.Join("systems", sysLabel, "snaps", "required20_1.0.snap"),
+	})
+}
+
+func (s *seed20Suite) TestLoadMetaCore20SnapHandlerChangePath(c *C) {
+	s.makeSnap(c, "snapd", "")
+	s.makeSnap(c, "core20", "")
+	s.makeSnap(c, "pc-kernel=20", "")
+	s.makeSnap(c, "pc=20", "")
+	requiredFn := s.makeLocalSnap(c, "required20")
+
+	sysLabel := "20191030"
+	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
+		"display-name": "my model",
+		"architecture": "amd64",
+		"base":         "core20",
+		"grade":        "dangerous",
+		"snaps": []interface{}{
+			map[string]interface{}{
+				"name":            "pc-kernel",
+				"id":              s.AssertedSnapID("pc-kernel"),
+				"type":            "kernel",
+				"default-channel": "20",
+			},
+			map[string]interface{}{
+				"name":            "pc",
+				"id":              s.AssertedSnapID("pc"),
+				"type":            "gadget",
+				"default-channel": "20",
+			},
+			map[string]interface{}{
+				"name": "required20",
+				"id":   s.AssertedSnapID("required20"),
+			}},
+	}, []*seedwriter.OptionsSnap{
+		{Path: requiredFn},
+	})
+
+	seed20, err := seed.Open(s.SeedDir, sysLabel)
+	c.Assert(err, IsNil)
+
+	err = seed20.LoadAssertions(s.db, s.commitTo)
+	c.Assert(err, IsNil)
+
+	h := newTestSnapHandler(s.SeedDir)
+	h.pathPrefix = "saved"
+
+	err = seed20.LoadMeta(seed.AllModes, h, s.perfTimings)
+	c.Assert(err, IsNil)
+
+	c.Check(seed20.UsesSnapdSnap(), Equals, true)
+
+	essSnaps := seed20.EssentialSnaps()
+	c.Check(essSnaps, HasLen, 4)
+
+	c.Check(essSnaps, DeepEquals, []*seed.Snap{
+		{
+			Path:          "saved" + s.expectedPath("snapd"),
+			SideInfo:      &s.AssertedSnapInfo("snapd").SideInfo,
+			EssentialType: snap.TypeSnapd,
+			Essential:     true,
+			Required:      true,
+			Channel:       "latest/stable",
+		}, {
+			Path:          "saved" + s.expectedPath("pc-kernel"),
+			SideInfo:      &s.AssertedSnapInfo("pc-kernel").SideInfo,
+			EssentialType: snap.TypeKernel,
+			Essential:     true,
+			Required:      true,
+			Channel:       "20",
+		}, {
+			Path:          "saved" + s.expectedPath("core20"),
+			SideInfo:      &s.AssertedSnapInfo("core20").SideInfo,
+			EssentialType: snap.TypeBase,
+			Essential:     true,
+			Required:      true,
+			Channel:       "latest/stable",
+		}, {
+			Path:          s.expectedPath("pc"),
+			SideInfo:      &s.AssertedSnapInfo("pc").SideInfo,
+			EssentialType: snap.TypeGadget,
+			Essential:     true,
+			Required:      true,
+			Channel:       "20",
+		},
+	})
+
+	runSnaps, err := seed20.ModeSnaps("run")
+	c.Assert(err, IsNil)
+	c.Check(runSnaps, HasLen, 1)
+
+	c.Check(runSnaps, DeepEquals, []*seed.Snap{
+		{
+			Path:     filepath.Join("saved", s.SeedDir, "systems", sysLabel, "snaps", "required20_1.0.snap"),
 			SideInfo: &snap.SideInfo{RealName: "required20"},
 			Required: true,
 		},


### PR DESCRIPTION
this should allow to reduce Container.Install work if SnapHandler already copied the snap.

