### PR TITLE
cmd/snap: exit w/ non-zero code on missing snap

### DIFF
--- a/cmd/snap/cmd_changes.go
+++ b/cmd/snap/cmd_changes.go
@@ -75,7 +75,7 @@ func queryChanges(cli *client.Client, opts *client.ChangesOptions) ([]*client.Ch
 	if err != nil {
 		return nil, err
 	}
-	if err := warnMaintenance(cli, "changes"); err != nil {
+	if err := warnMaintenance(cli); err != nil {
 		return nil, err
 	}
 	return chgs, nil
@@ -148,7 +148,7 @@ func queryChange(cli *client.Client, chid string) (*client.Change, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := warnMaintenance(cli, "change"); err != nil {
+	if err := warnMaintenance(cli); err != nil {
 		return nil, err
 	}
 	return chg, nil
@@ -198,9 +198,9 @@ func (c *cmdTasks) showChange(chid string) error {
 
 const line = "......................................................................"
 
-func warnMaintenance(cli *client.Client, opName string) error {
+func warnMaintenance(cli *client.Client) error {
 	if maintErr := cli.Maintenance(); maintErr != nil {
-		msg, err := errorToCmdMessage("", opName, maintErr, nil)
+		msg, err := errorToCmdMessage("", "", maintErr, nil)
 		if err != nil {
 			return err
 		}

--- a/cmd/snap/cmd_changes.go
+++ b/cmd/snap/cmd_changes.go
@@ -75,7 +75,7 @@ func queryChanges(cli *client.Client, opts *client.ChangesOptions) ([]*client.Ch
 	if err != nil {
 		return nil, err
 	}
-	if err := warnMaintenance(cli); err != nil {
+	if err := warnMaintenance(cli, "changes"); err != nil {
 		return nil, err
 	}
 	return chgs, nil
@@ -148,7 +148,7 @@ func queryChange(cli *client.Client, chid string) (*client.Change, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := warnMaintenance(cli); err != nil {
+	if err := warnMaintenance(cli, "change"); err != nil {
 		return nil, err
 	}
 	return chg, nil
@@ -198,9 +198,9 @@ func (c *cmdTasks) showChange(chid string) error {
 
 const line = "......................................................................"
 
-func warnMaintenance(cli *client.Client) error {
+func warnMaintenance(cli *client.Client, opName string) error {
 	if maintErr := cli.Maintenance(); maintErr != nil {
-		msg, err := errorToCmdMessage("", maintErr, nil)
+		msg, err := errorToCmdMessage("", opName, maintErr, nil)
 		if err != nil {
 			return err
 		}

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -159,7 +159,19 @@ func (x *cmdRemove) removeMany(opts *client.SnapOptions) error {
 	names := installedSnapNames(x.Positional.Snaps)
 	changeID, err := x.client.RemoveMany(names, opts)
 	if err != nil {
-		return err
+		var name string
+		if cerr, ok := err.(*client.Error); ok {
+			if snapName, ok := cerr.Value.(string); ok {
+				name = snapName
+			}
+		}
+
+		msg, err := errorToCmdMessage(name, "remove", err, opts)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(Stderr, msg)
+		return nil
 	}
 
 	chg, err := x.wait(changeID)

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -132,7 +132,7 @@ func (x *cmdRemove) removeOne(opts *client.SnapOptions) error {
 
 	changeID, err := x.client.Remove(name, opts)
 	if err != nil {
-		msg, err := errorToCmdMessage(name, err, opts)
+		msg, err := errorToCmdMessage(name, "remove", err, opts)
 		if err != nil {
 			return err
 		}
@@ -502,7 +502,7 @@ func (x *cmdInstall) installOne(nameOrPath, desiredName string, opts *client.Sna
 		changeID, err = x.client.Install(snapName, opts)
 	}
 	if err != nil {
-		msg, err := errorToCmdMessage(nameOrPath, err, opts)
+		msg, err := errorToCmdMessage(nameOrPath, "install", err, opts)
 		if err != nil {
 			return err
 		}
@@ -559,7 +559,7 @@ func (x *cmdInstall) installMany(names []string, opts *client.SnapOptions) error
 		if err, ok := err.(*client.Error); ok {
 			snapName, _ = err.Value.(string)
 		}
-		msg, err := errorToCmdMessage(snapName, err, opts)
+		msg, err := errorToCmdMessage(snapName, "install", err, opts)
 		if err != nil {
 			return err
 		}
@@ -704,7 +704,7 @@ func (x *cmdRefresh) refreshMany(snaps []string, opts *client.SnapOptions) error
 func (x *cmdRefresh) refreshOne(name string, opts *client.SnapOptions) error {
 	changeID, err := x.client.Refresh(name, opts)
 	if err != nil {
-		msg, err := errorToCmdMessage(name, err, opts)
+		msg, err := errorToCmdMessage(name, "refresh", err, opts)
 		if err != nil {
 			return err
 		}
@@ -912,7 +912,7 @@ func (x *cmdTry) Execute([]string) error {
 
 	changeID, err := x.client.Try(path, opts)
 	if err != nil {
-		msg, err := errorToCmdMessage(name, err, opts)
+		msg, err := errorToCmdMessage(name, "try", err, opts)
 		if err != nil {
 			return err
 		}

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -1841,25 +1841,29 @@ func (s *SnapOpSuite) TestNotInstalledError(c *check.C) {
 		err bool
 	}{
 		{cmd: "refresh foo", err: true},
+		{cmd: "refresh foo bar", err: true},
+		{cmd: "install foo", err: true},
+		{cmd: "install foo bar", err: true},
+		{cmd: "revert foo", err: true},
 		{cmd: "switch --channel stable foo", err: true},
+		{cmd: "switch --channel stable foo bar", err: true},
 		{cmd: "enable foo", err: true},
+		{cmd: "enable foo bar", err: true},
 		{cmd: "disable foo", err: true},
+		{cmd: "disable foo bar", err: true},
 		{cmd: "list foo", err: true},
+		{cmd: "list foo bar", err: true},
 		{cmd: "save foo", err: true},
+		{cmd: "save foo bar", err: true},
 		{cmd: "remove foo", err: false},
+		{cmd: "remove foo bar", err: false},
 	} {
-		var assert check.Checker
-		var msg string
-
-		if t.err {
-			assert = check.Not(check.IsNil)
-		} else {
-			assert = check.IsNil
-			msg = "not "
-		}
 		_, err := snap.Parser(snap.Client()).ParseArgs(strings.Fields(t.cmd))
-		comment := check.Commentf("command %q should %sreturn an error due to a non-existent snap but got %v", t.cmd, msg, err)
-		c.Check(err, assert, comment)
+		if t.err {
+			c.Check(err, check.ErrorMatches, "Snap was not installed")
+		} else {
+			c.Check(err, check.IsNil)
+		}
 	}
 }
 

--- a/cmd/snap/error.go
+++ b/cmd/snap/error.go
@@ -215,7 +215,6 @@ If you understand and want to proceed repeat the command including --classic.
 		msg = i18n.G("snap %q has no updates available")
 	case client.ErrorKindSnapNotInstalled:
 		isError = true
-
 		// if the snap isn't installed, then remove can ignore this error
 		if opName == "remove" {
 			isError = false

--- a/cmd/snap/error.go
+++ b/cmd/snap/error.go
@@ -87,7 +87,10 @@ func fill(para string, indent int) string {
 	return strings.TrimSpace(buf.String())
 }
 
-func errorToCmdMessage(snapName string, e error, opts *client.SnapOptions) (string, error) {
+// errorToCmdMessage returns the appropriate error message and value based on the
+// client error and some context information. The opName is the lowercase name
+// of the failed operation (e.g., "refresh").
+func errorToCmdMessage(snapName string, opName string, e error, opts *client.SnapOptions) (string, error) {
 	// do this here instead of in the caller for more DRY
 	err, ok := e.(*client.Error)
 	if !ok {
@@ -211,7 +214,13 @@ If you understand and want to proceed repeat the command including --classic.
 		isError = false
 		msg = i18n.G("snap %q has no updates available")
 	case client.ErrorKindSnapNotInstalled:
-		isError = false
+		isError = true
+
+		// if the snap isn't installed, then remove can ignore this error
+		if opName == "remove" {
+			isError = false
+		}
+
 		usesSnapName = false
 		msg = err.Message
 	case client.ErrorKindNetworkTimeout:

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -556,7 +556,7 @@ func run() error {
 			}
 		}
 
-		msg, err := errorToCmdMessage("", err, nil)
+		msg, err := errorToCmdMessage("", strings.ToLower(parser.Active.Name), err, nil)
 
 		if cmdline := strings.Join(os.Args, " "); strings.ContainsAny(cmdline, wrongDashes) {
 			// TRANSLATORS: the %+q is the commandline (+q means quoted, with any non-ascii character called out). Please keep the lines to at most 80 characters.


### PR DESCRIPTION
Snap always returned a 0 exit code when an operation failed due to the
snap not existing. This changes the default handling of that error to
return a non-zero exit code, except for 'snap remove' (since the result
is achieved).
LP bug: https://bugs.launchpad.net/snapd/+bug/1968609

Signed-off-by: Miguel Pires <miguel.pires@canonical.com>