### PR TITLE
o/snapshotstate: check installed snaps before running 'save' tasks

### DIFF
--- a/overlord/snapshotstate/snapshotstate.go
+++ b/overlord/snapshotstate/snapshotstate.go
@@ -386,15 +386,13 @@ func Save(st *state.State, instanceNames []string, users []string) (setID uint64
 			return 0, nil, nil, err
 		}
 	} else {
-		var snapst snapstate.SnapState
+		installedSnaps, err := snapstate.All(st)
+		if err != nil {
+			return 0, nil, nil, err
+		}
 
 		for _, name := range instanceNames {
-			err := snapstate.Get(st, name, &snapst)
-			if err != nil && err != state.ErrNoState {
-				return 0, nil, nil, err
-			}
-
-			if !snapst.IsInstalled() {
+			if _, ok := installedSnaps[name]; !ok {
 				return 0, nil, nil, &snap.NotInstalledError{Snap: name}
 			}
 		}

--- a/overlord/snapshotstate/snapshotstate.go
+++ b/overlord/snapshotstate/snapshotstate.go
@@ -385,6 +385,19 @@ func Save(st *state.State, instanceNames []string, users []string) (setID uint64
 		if err != nil {
 			return 0, nil, nil, err
 		}
+	} else {
+		var snapst snapstate.SnapState
+
+		for _, name := range instanceNames {
+			err := snapstate.Get(st, name, &snapst)
+			if err != nil && err != state.ErrNoState {
+				return 0, nil, nil, err
+			}
+
+			if !snapst.IsInstalled() {
+				return 0, nil, nil, &snap.NotInstalledError{Snap: name}
+			}
+		}
 	}
 
 	// Make sure we do not snapshot if anything like install/remove/refresh is in progress

--- a/overlord/snapshotstate/snapshotstate_test.go
+++ b/overlord/snapshotstate/snapshotstate_test.go
@@ -499,6 +499,18 @@ func (snapshotSuite) TestSaveNoSnapsInState(c *check.C) {
 	c.Check(taskset.Tasks(), check.HasLen, 0)
 }
 
+func (snapshotSuite) TestSaveSnapNotInstalled(c *check.C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	setID, saved, taskset, err := snapshotstate.Save(st, []string{"foo"}, nil)
+	c.Assert(err, check.ErrorMatches, `snap "foo" is not installed`)
+	c.Check(setID, check.Equals, uint64(0))
+	c.Check(saved, check.HasLen, 0)
+	c.Check(taskset, check.IsNil)
+}
+
 func (snapshotSuite) TestSaveSomeSnaps(c *check.C) {
 	fakeSnapstateAll := func(*state.State) (map[string]*snapstate.SnapState, error) {
 		return map[string]*snapstate.SnapState{
@@ -526,17 +538,23 @@ func (snapshotSuite) TestSaveSomeSnaps(c *check.C) {
 	c.Check(tasks[1].Summary(), check.Equals, `Save data of snap "c-snap" in snapshot set #1`)
 }
 
-func (snapshotSuite) TestSaveOneSnap(c *check.C) {
-	fakeSnapstateAll := func(*state.State) (map[string]*snapstate.SnapState, error) {
+func (s snapshotSuite) TestSaveOneSnap(c *check.C) {
+	defer snapshotstate.MockSnapstateAll(func(*state.State) (map[string]*snapstate.SnapState, error) {
 		// snapstate.All isn't called when a snap name is passed in
 		return nil, errors.New("bzzt")
-	}
-
-	defer snapshotstate.MockSnapstateAll(fakeSnapstateAll)()
+	})()
 
 	st := state.New(nil)
 	st.Lock()
 	defer st.Unlock()
+
+	snapstate.Set(st, "a-snap", &snapstate.SnapState{
+		Active: true,
+		Sequence: []*snap.SideInfo{
+			{RealName: "a-snap", Revision: snap.R(1)},
+		},
+		Current: snap.R(1),
+	})
 
 	setID, saved, taskset, err := snapshotstate.Save(st, []string{"a-snap"}, []string{"a-user"})
 	c.Assert(err, check.IsNil)


### PR DESCRIPTION
Make 'snap save' check if the snaps are installed before running the
tasks, so the returned error has the expected 'kind' and message format.

Signed-off-by: Miguel Pires <miguel.pires@canonical.com>