### PR TITLE
tests/lib/tools: add piboot to boot_path()

### DIFF
--- a/tests/lib/tools/boot-state
+++ b/tests/lib/tools/boot-state
@@ -147,6 +147,8 @@ boot_path() {
         echo "/boot/grub/"
     elif [ -f /boot/grub2/grubenv ]; then
         echo "/boot/grub2/"
+    elif [ -f /boot/piboot/piboot.conf ]; then
+        echo "/boot/piboot/"
     else
         echo "boot-state: cannot determine boot path" >&2
         ls -alR /boot


### PR DESCRIPTION
This fixes smoke-tests on raspberry pi's 3+4 when using piboot.

I don't know if this is the right file to check against, but it seems to be the only one present other than the snap itself