### PR TITLE
snap/quota: add values for journal quotas (journal quota 2/n)

### DIFF
--- a/snap/quota/quota.go
+++ b/snap/quota/quota.go
@@ -58,7 +58,7 @@ type GroupQuotaCPU struct {
 }
 
 // GroupQuotaJournal contains the supported limits for journald. Any limit set here
-// applies only the quota group itself. Journal limits will not be inherited by the
+// applies only to the quota group itself. Journal limits will not be inherited by the
 // sub-groups as this behaviour is not supported by systemd.
 type GroupQuotaJournal struct {
 	// Size is the maximum allowed size of the journal for the group.

--- a/snap/quota/quota.go
+++ b/snap/quota/quota.go
@@ -57,6 +57,24 @@ type GroupQuotaCPU struct {
 	AllowedCPUs []int `json:"allowed-cpus,omitempty"`
 }
 
+// GroupQuotaJournal contains the supported limits for journald. Any limit set here
+// applies only the quota group itself. Journal limits will not be inherited by the
+// sub-groups as this behaviour is not supported by systemd.
+type GroupQuotaJournal struct {
+	// Size is the maximum allowed size of the journal for the group.
+	// If the size is set below current usage, systemd will automatically treat
+	// the current usage of the journald namespace as the minimum limit and
+	// render whatever set here ineffective. The maximum allowed size for
+	// journald namespaces is 4GB. A value of 0 here means no limit is present.
+	Size quantity.Size `json:"size,omitempty"`
+
+	// RateCount/RatePeriod determines the maximum rate of journal writes for
+	// the group. The count is the number of journal messages that can be written
+	// in each period. 0 Values here means there is no limit currently set.
+	RateCount  int `json:"rate-count,omitempty"`
+	RatePeriod int `json:"rate-period,omitempty"`
+}
+
 // Group is a quota group of snaps, services or sub-groups that are all subject
 // to specific resource quotas. The only quota resource types currently
 // supported is memory, but this can be expanded in the future.
@@ -92,6 +110,11 @@ type Group struct {
 	// the group. Once the limit is reached, further forks() or clones() will be blocked
 	// for processes in the group.
 	TaskLimit int `json:"task-limit,omitempty"`
+
+	// JournalLimit is the limits that apply to the journal for this quota group. When
+	// this limit is present, then the quota group will be assigned a log namespace for
+	// journald.
+	JournalLimit *GroupQuotaJournal `json:"journal-limit,omitempty"`
 
 	// ParentGroup is the the parent group that this group is a child of. If it
 	// is empty, then this is a "root" quota group.
@@ -141,6 +164,15 @@ func (grp *Group) GetQuotaResources() Resources {
 	}
 	if grp.TaskLimit != 0 {
 		resourcesBuilder.WithThreadLimit(grp.TaskLimit)
+	}
+	if grp.JournalLimit != nil {
+		resourcesBuilder.WithJournalNamespace()
+		if grp.JournalLimit.Size != 0 {
+			resourcesBuilder.WithJournalSize(grp.JournalLimit.Size)
+		}
+		if grp.JournalLimit.RateCount != 0 && grp.JournalLimit.RatePeriod != 0 {
+			resourcesBuilder.WithJournalRate(grp.JournalLimit.RateCount, grp.JournalLimit.RatePeriod)
+		}
 	}
 	return resourcesBuilder.Build()
 }
@@ -224,8 +256,16 @@ func (grp *Group) SliceFileName() string {
 	return buf.String()
 }
 
+// JournalFileName returns the name of the journal configuration file that should
+// be used for this quota group. As an example, a group named "foo" will return a name
+// of journald@snap-foo.conf
+func (grp *Group) JournalFileName() string {
+	return fmt.Sprintf("journald@snap-%s.conf", grp.Name)
+}
+
 // groupQuotaAllocations contains information about current quotas of a group
-// and is used by getQuotaAllocations to contain this information.
+// and is used by getQuotaAllocations to contain this information. This only accounts
+// for quotas that support inheritance, which currently does not include journal quotas.
 // There are two types of values for each quota - the quota limit set by this group,
 // and the quota reserved by children of this group. Examples:
 // Group that has a non-memory quota, but has a child group that has a memory quota of 512mb:
@@ -671,6 +711,18 @@ func (grp *Group) UpdateQuotaLimits(resourceLimits Resources) error {
 	}
 	if resourceLimits.Threads != nil {
 		grp.TaskLimit = resourceLimits.Threads.Limit
+	}
+	if resourceLimits.Journal != nil {
+		if grp.JournalLimit == nil {
+			grp.JournalLimit = &GroupQuotaJournal{}
+		}
+		if resourceLimits.Journal.Size != nil {
+			grp.JournalLimit.Size = resourceLimits.Journal.Size.Limit
+		}
+		if resourceLimits.Journal.Rate != nil {
+			grp.JournalLimit.RateCount = resourceLimits.Journal.Rate.Count
+			grp.JournalLimit.RatePeriod = resourceLimits.Journal.Rate.Period
+		}
 	}
 	return nil
 }

--- a/snap/quota/quota.go
+++ b/snap/quota/quota.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"runtime"
 	"sort"
+	"time"
 
 	// TODO: move this to snap/quantity? or similar
 	"github.com/snapcore/snapd/gadget/quantity"
@@ -71,8 +72,8 @@ type GroupQuotaJournal struct {
 	// RateCount/RatePeriod determines the maximum rate of journal writes for
 	// the group. The count is the number of journal messages that can be written
 	// in each period. 0 Values here means there is no limit currently set.
-	RateCount  int `json:"rate-count,omitempty"`
-	RatePeriod int `json:"rate-period,omitempty"`
+	RateCount  int           `json:"rate-count,omitempty"`
+	RatePeriod time.Duration `json:"rate-period,omitempty"`
 }
 
 // Group is a quota group of snaps, services or sub-groups that are all subject

--- a/snap/quota/quota_test.go
+++ b/snap/quota/quota_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"math"
 	"testing"
+	"time"
 
 	. "gopkg.in/check.v1"
 
@@ -1295,11 +1296,11 @@ func (ts *quotaTestSuite) TestJournalQuotasSetCorrectly(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(grp1.JournalLimit, NotNil)
 
-	grp2, err := quota.NewGroup("groot2", quota.NewResourcesBuilder().WithJournalRate(15, 5).Build())
+	grp2, err := quota.NewGroup("groot2", quota.NewResourcesBuilder().WithJournalRate(15, time.Second).Build())
 	c.Assert(err, IsNil)
 	c.Assert(grp2.JournalLimit, NotNil)
 	c.Check(grp2.JournalLimit.RateCount, Equals, 15)
-	c.Check(grp2.JournalLimit.RatePeriod, Equals, 5)
+	c.Check(grp2.JournalLimit.RatePeriod, Equals, time.Second)
 
 	grp3, err := quota.NewGroup("groot3", quota.NewResourcesBuilder().WithJournalSize(quantity.SizeMiB).Build())
 	c.Assert(err, IsNil)
@@ -1316,11 +1317,11 @@ func (ts *quotaTestSuite) TestJournalQuotasUpdatesCorrectly(c *C) {
 	c.Assert(grp1.JournalLimit, NotNil)
 	c.Check(grp1.JournalLimit.Size, Equals, quantity.Size(0))
 	c.Check(grp1.JournalLimit.RateCount, Equals, 0)
-	c.Check(grp1.JournalLimit.RatePeriod, Equals, 0)
+	c.Check(grp1.JournalLimit.RatePeriod, Equals, time.Duration(0))
 
-	grp1.UpdateQuotaLimits(quota.NewResourcesBuilder().WithJournalRate(15, 5).WithJournalSize(quantity.SizeMiB).Build())
+	grp1.UpdateQuotaLimits(quota.NewResourcesBuilder().WithJournalRate(15, time.Microsecond*5).WithJournalSize(quantity.SizeMiB).Build())
 	c.Assert(grp1.JournalLimit, NotNil)
 	c.Check(grp1.JournalLimit.Size, Equals, quantity.SizeMiB)
 	c.Check(grp1.JournalLimit.RateCount, Equals, 15)
-	c.Check(grp1.JournalLimit.RatePeriod, Equals, 5)
+	c.Check(grp1.JournalLimit.RatePeriod, Equals, time.Microsecond*5)
 }


### PR DESCRIPTION
The second PR in the journal quota support series; add the neccessary support for journal quotas in snap/quota/quota.go