### PR TITLE
interfaces: network-manager: add AppArmor rule for configuring bridges

### DIFF
--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -81,6 +81,9 @@ network packet,
 /sys/devices/virtual/net/**/dev_id r,
 /sys/devices/**/net/**/ifindex r,
 
+# access to bridge sysfs interfaces for bridge settings
+/sys/devices/virtual/net/*/bridge/* rw,
+
 /dev/rfkill rw,
 
 /run/udev/data/* r,


### PR DESCRIPTION
The network-manager interface does not currently provide the AppArmor rules for configuring bridges, resulting in the following denial (among others):

```
= AppArmor =
Time: Apr 27 10:57:12
Log: apparmor="DENIED" operation="open" profile="snap.network-manager.networkmanager" name="/sys/devices/virtual/net/br0/bridge/vlan_filtering" pid=2863 comm="NetworkManager" requested_mask="w" denied_mask="w" fsuid=0 ouid=0
File: /sys/devices/virtual/net/br0/bridge/vlan_filtering (write)
Suggestions:
* adjust program to not access '/sys/devices/virtual/net/br0/bridge/vlan_filtering'
* adjust program to not access '/sys/devices/virtual/net/br[0-9]*/bridge/vlan_filtering'
```

This can be reproduced by creating a bridge interface using `nmcli` from the `network-manager` snap:

```
$ sudo nmcli con add type bridge ifname br0 bridge.vlan-filtering yes
Connection 'bridge-br0' (3981b337-92a9-45a7-b4a2-8478741aa876) successfully added.
$ sudo con up bridge-br0
Error: Connection activation failed: The device could not be readied for configuration
```

This PR adds the necessary AppArmor rule for configuring bridges through the sysfs interface. The AppArmor rule was copied from:

https://github.com/snapcore/snapd/blob/f960ee96f2d4bae99ef25e63764540ffbeacc44d/interfaces/builtin/network_control.go#L218.
