### PR TITLE
tests/main/user-session-env: for for opensuse

### DIFF
--- a/tests/main/user-session-env/task.yaml
+++ b/tests/main/user-session-env/task.yaml
@@ -79,8 +79,8 @@ execute: |
                 NOMATCH 'XDG_DATA_DIRS=.*[:]?/var/lib/snapd/desktop[:]?.*' < "${user}-child-env"
                 MATCH "PATH=.*[:]?${SNAP_MOUNT_DIR}/bin[:]?.*" < "${user}-child-env"
                 ;;
-            test-fish:opensuse-tumbleweed-*)
-                # fish Tumbleweed somehow magically glues the ENV_* from su and
+            test-fish:opensuse-*)
+                # fish on openSUSE somehow magically glues the ENV_* from su and
                 # PATH, but fortunately it also displays ENV_ROOTPATH
                 NOMATCH "PATH=.*[:]?${SNAP_MOUNT_DIR}/bin[:]?.*" < "${user}-profile-env"
                 MATCH "ENV_ROOTPATH\s+.*[:]?${SNAP_MOUNT_DIR}/bin[:]?.*" < "${user}-profile-env"


### PR DESCRIPTION
The test is currently failing for opensuse-15.3:

    + for user in test "$TEST_ZSH_USER" "$TEST_FISH_USER"
    + echo 'checking test-fish'
    checking test-fish
    + '[' -e test-fish-session-env ']'
    + case "$user:$SPREAD_SYSTEM" in
    + MATCH 'XDG_DATA_DIRS=.[:]?/var/lib/snapd/desktop[:]?.'
    + MATCH 'PATH=.[:]?/snap/bin[:]?.'
    grep error: pattern not found, got:
    HOME=/home/test-fish
    LANG=en_US.UTF-8
    LOGNAME=test-fish
    PATH=/usr/local/bin:/bin:/usr/bin
    ENV_ROOTPATH	/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/snap/bin
    PWD=/home/test-fish
    SHELL=/usr/bin/fish
    SHLVL=1
    USER=test-fish
    XDG_DATA_DIRS=/usr/local/share:/usr/share:/var/lib/snapd/desktop

It seems openSUSE 15.3 is affected by the same issue as Tumbleweed, so
let's treat them in the same way. It's possible that the issue is not
caused by fish, but by some other system package (since the version of
fish in the two openSUSE distros we support is very different).

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
