### PR TITLE
interfaces/builtin: shared-memory drop plugs allow-installation: true

### DIFF
--- a/interfaces/builtin/shared_memory.go
+++ b/interfaces/builtin/shared_memory.go
@@ -48,7 +48,6 @@ const sharedMemorySummary = `allows two snaps to use predefined shared memory ob
 // unless a slot was also granted at some point.
 const sharedMemoryBaseDeclarationPlugs = `
   shared-memory:
-    allow-installation: true
     allow-connection:
       -
         plug-attributes:


### PR DESCRIPTION
this is the default and some tooling is confused by it being mentioned explicitly