### PR TITLE
snap/quota: change the journal quota period to be a time.Duration

### DIFF
--- a/snap/quota/resources.go
+++ b/snap/quota/resources.go
@@ -60,8 +60,10 @@ type ResourceJournalSize struct {
 }
 
 type ResourceJournalRate struct {
-	Count  int `json:"count"`
-	Period int `json:"period"`
+	// Count is the maximum number of journald messages per Period.
+	Count int `json:"count"`
+	// Period is the time period in microseconds.
+	PeriodUsec uint64 `json:"period-usec"`
 }
 
 // ResourceJournal represents the available journal quotas. It's structured
@@ -174,7 +176,7 @@ func (qr *Resources) validateJournalQuota() error {
 	}
 
 	if qr.Journal.Rate != nil {
-		if qr.Journal.Rate.Count <= 0 || qr.Journal.Rate.Period <= 0 {
+		if qr.Journal.Rate.Count <= 0 || qr.Journal.Rate.PeriodUsec == 0 {
 			return fmt.Errorf("journal quota must have a rate count and period larger than zero")
 		}
 	}
@@ -335,7 +337,7 @@ func (qr *Resources) ValidateChange(newLimits Resources) error {
 
 		if qr.Journal.Rate != nil && newLimits.Journal.Rate != nil {
 			count := newLimits.Journal.Rate.Count
-			period := newLimits.Journal.Rate.Period
+			period := newLimits.Journal.Rate.PeriodUsec
 			if count == 0 && period == 0 {
 				return fmt.Errorf("cannot remove journal rate limit from quota group")
 			}
@@ -366,7 +368,7 @@ func (qr *Resources) clone() Resources {
 			resourcesCopy.Journal.Size = &ResourceJournalSize{Limit: qr.Journal.Size.Limit}
 		}
 		if qr.Journal.Rate != nil {
-			resourcesCopy.Journal.Rate = &ResourceJournalRate{Count: qr.Journal.Rate.Count, Period: qr.Journal.Rate.Period}
+			resourcesCopy.Journal.Rate = &ResourceJournalRate{Count: qr.Journal.Rate.Count, PeriodUsec: qr.Journal.Rate.PeriodUsec}
 		}
 	}
 	return resourcesCopy

--- a/snap/quota/resources.go
+++ b/snap/quota/resources.go
@@ -176,8 +176,8 @@ func (qr *Resources) validateJournalQuota() error {
 	}
 
 	if qr.Journal.Rate != nil {
-		if qr.Journal.Rate.Count <= 0 || qr.Journal.Rate.Period.Microseconds() == 0 {
-			return fmt.Errorf("journal quota must have a rate count larger than zero and period larger than zero microseconds")
+		if qr.Journal.Rate.Count <= 0 || qr.Journal.Rate.Period < time.Microsecond {
+			return fmt.Errorf("journal quota must have a rate count larger than zero and period at least 1 microsecond (minimum resolution)")
 		}
 	}
 	return nil
@@ -338,7 +338,10 @@ func (qr *Resources) ValidateChange(newLimits Resources) error {
 		if qr.Journal.Rate != nil && newLimits.Journal.Rate != nil {
 			count := newLimits.Journal.Rate.Count
 			period := newLimits.Journal.Rate.Period
-			if count == 0 && period.Microseconds() == 0 {
+
+			// Validate() will make sure the period is atleast one microsecond, here
+			// we simply check against != 0 to make sure the user is not removing limit
+			if count == 0 && period == 0 {
 				return fmt.Errorf("cannot remove journal rate limit from quota group")
 			}
 		}

--- a/snap/quota/resources_builder.go
+++ b/snap/quota/resources_builder.go
@@ -45,7 +45,7 @@ type ResourcesBuilder struct {
 	JournalSizeLimitSet bool
 
 	JournalRateCountLimit  int
-	JournalRatePeriodLimit int
+	JournalRatePeriodLimit uint64
 	JournalRateSet         bool
 }
 
@@ -90,9 +90,9 @@ func (rb *ResourcesBuilder) WithJournalSize(limit quantity.Size) *ResourcesBuild
 	return rb
 }
 
-func (rb *ResourcesBuilder) WithJournalRate(count, period int) *ResourcesBuilder {
+func (rb *ResourcesBuilder) WithJournalRate(count int, periodUsec uint64) *ResourcesBuilder {
 	rb.JournalRateCountLimit = count
-	rb.JournalRatePeriodLimit = period
+	rb.JournalRatePeriodLimit = periodUsec
 	rb.JournalRateSet = true
 	return rb
 }
@@ -129,8 +129,8 @@ func (rb *ResourcesBuilder) Build() Resources {
 		}
 		if rb.JournalRateSet {
 			quotaResources.Journal.Rate = &ResourceJournalRate{
-				Count:  rb.JournalRateCountLimit,
-				Period: rb.JournalRatePeriodLimit,
+				Count:      rb.JournalRateCountLimit,
+				PeriodUsec: rb.JournalRatePeriodLimit,
 			}
 		}
 	}

--- a/snap/quota/resources_builder.go
+++ b/snap/quota/resources_builder.go
@@ -20,6 +20,8 @@
 package quota
 
 import (
+	"time"
+
 	"github.com/snapcore/snapd/gadget/quantity"
 )
 
@@ -45,7 +47,7 @@ type ResourcesBuilder struct {
 	JournalSizeLimitSet bool
 
 	JournalRateCountLimit  int
-	JournalRatePeriodLimit uint64
+	JournalRatePeriodLimit time.Duration
 	JournalRateSet         bool
 }
 
@@ -90,9 +92,9 @@ func (rb *ResourcesBuilder) WithJournalSize(limit quantity.Size) *ResourcesBuild
 	return rb
 }
 
-func (rb *ResourcesBuilder) WithJournalRate(count int, periodUsec uint64) *ResourcesBuilder {
+func (rb *ResourcesBuilder) WithJournalRate(count int, period time.Duration) *ResourcesBuilder {
 	rb.JournalRateCountLimit = count
-	rb.JournalRatePeriodLimit = periodUsec
+	rb.JournalRatePeriodLimit = period
 	rb.JournalRateSet = true
 	return rb
 }
@@ -129,8 +131,8 @@ func (rb *ResourcesBuilder) Build() Resources {
 		}
 		if rb.JournalRateSet {
 			quotaResources.Journal.Rate = &ResourceJournalRate{
-				Count:      rb.JournalRateCountLimit,
-				PeriodUsec: rb.JournalRatePeriodLimit,
+				Count:  rb.JournalRateCountLimit,
+				Period: rb.JournalRatePeriodLimit,
 			}
 		}
 	}

--- a/snap/quota/resources_test.go
+++ b/snap/quota/resources_test.go
@@ -22,6 +22,7 @@ package quota_test
 import (
 	"fmt"
 	"reflect"
+	"time"
 
 	. "gopkg.in/check.v1"
 
@@ -46,8 +47,8 @@ func (s *resourcesTestSuite) TestQuotaValidationFails(c *C) {
 		{quota.NewResourcesBuilder().Build(), `quota group must have at least one resource limit set`},
 		{quota.NewResourcesBuilder().WithCPUCount(1).Build(), `invalid cpu quota with count of >0 and percentage of 0`},
 		{quota.NewResourcesBuilder().WithCPUCount(2).WithCPUPercentage(100).WithAllowedCPUs([]int{0}).Build(), `cpu usage 200% is larger than the maximum allowed for provided set \[0\] of 100%`},
-		{quota.NewResourcesBuilder().WithJournalRate(0, 1).Build(), `journal quota must have a rate count and period larger than zero`},
-		{quota.NewResourcesBuilder().WithJournalRate(1, 0).Build(), `journal quota must have a rate count and period larger than zero`},
+		{quota.NewResourcesBuilder().WithJournalRate(0, 1).Build(), `journal quota must have a rate count larger than zero and period larger than zero microseconds`},
+		{quota.NewResourcesBuilder().WithJournalRate(1, 0).Build(), `journal quota must have a rate count larger than zero and period larger than zero microseconds`},
 		{quota.NewResourcesBuilder().WithJournalSize(0).Build(), `journal size quota must have a limit set`},
 	}
 
@@ -92,7 +93,7 @@ func (s *resourcesTestSuite) TestQuotaValidationPasses(c *C) {
 		{quota.NewResourcesBuilder().WithAllowedCPUs([]int{0, 1}).Build()},
 		{quota.NewResourcesBuilder().WithThreadLimit(16).Build()},
 		{quota.NewResourcesBuilder().WithJournalSize(quantity.SizeMiB).Build()},
-		{quota.NewResourcesBuilder().WithJournalRate(1, 1).Build()},
+		{quota.NewResourcesBuilder().WithJournalRate(1, time.Microsecond).Build()},
 		{quota.NewResourcesBuilder().WithJournalNamespace().Build()},
 	}
 
@@ -192,7 +193,7 @@ func (s *resourcesTestSuite) TestQuotaChangeValidationFails(c *C) {
 		{
 			quota.NewResourcesBuilder().WithJournalRate(1, 1).Build(),
 			quota.NewResourcesBuilder().WithJournalRate(-2, 0).Build(),
-			`journal quota must have a rate count and period larger than zero`,
+			`journal quota must have a rate count larger than zero and period larger than zero microseconds`,
 		},
 		{
 			quota.NewResourcesBuilder().WithJournalSize(quantity.SizeGiB).Build(),
@@ -273,9 +274,9 @@ func (s *resourcesTestSuite) TestQuotaChangeValidationPasses(c *C) {
 			quota.NewResourcesBuilder().WithCPUCount(1).WithCPUPercentage(50).WithAllowedCPUs([]int{0, 1, 2}).Build(),
 		},
 		{
-			quota.NewResourcesBuilder().WithJournalRate(15, 5).Build(),
-			quota.NewResourcesBuilder().WithJournalRate(5, 5).Build(),
-			quota.NewResourcesBuilder().WithJournalRate(5, 5).Build(),
+			quota.NewResourcesBuilder().WithJournalRate(15, 5*time.Second).Build(),
+			quota.NewResourcesBuilder().WithJournalRate(5, 5*time.Second).Build(),
+			quota.NewResourcesBuilder().WithJournalRate(5, 5*time.Second).Build(),
 		},
 		{
 			quota.NewResourcesBuilder().WithJournalSize(quantity.SizeGiB).Build(),
@@ -283,9 +284,9 @@ func (s *resourcesTestSuite) TestQuotaChangeValidationPasses(c *C) {
 			quota.NewResourcesBuilder().WithJournalSize(quantity.SizeMiB).Build(),
 		},
 		{
-			quota.NewResourcesBuilder().WithJournalRate(15, 5).Build(),
+			quota.NewResourcesBuilder().WithJournalRate(15, 5*time.Second).Build(),
 			quota.NewResourcesBuilder().WithJournalSize(quantity.SizeGiB).Build(),
-			quota.NewResourcesBuilder().WithJournalSize(quantity.SizeGiB).WithJournalRate(15, 5).Build(),
+			quota.NewResourcesBuilder().WithJournalSize(quantity.SizeGiB).WithJournalRate(15, 5*time.Second).Build(),
 		},
 		{
 			quota.NewResourcesBuilder().WithCPUCount(4).WithCPUPercentage(25).Build(),
@@ -294,8 +295,8 @@ func (s *resourcesTestSuite) TestQuotaChangeValidationPasses(c *C) {
 		},
 		{
 			quota.NewResourcesBuilder().WithCPUCount(4).WithCPUPercentage(25).Build(),
-			quota.NewResourcesBuilder().WithJournalRate(15, 5).Build(),
-			quota.NewResourcesBuilder().WithCPUCount(4).WithCPUPercentage(25).WithJournalRate(15, 5).Build(),
+			quota.NewResourcesBuilder().WithJournalRate(15, time.Second).Build(),
+			quota.NewResourcesBuilder().WithCPUCount(4).WithCPUPercentage(25).WithJournalRate(15, time.Second).Build(),
 		},
 		{
 			quota.NewResourcesBuilder().WithCPUCount(4).WithCPUPercentage(25).Build(),

--- a/snap/quota/resources_test.go
+++ b/snap/quota/resources_test.go
@@ -49,6 +49,7 @@ func (s *resourcesTestSuite) TestQuotaValidationFails(c *C) {
 		{quota.NewResourcesBuilder().WithCPUCount(2).WithCPUPercentage(100).WithAllowedCPUs([]int{0}).Build(), `cpu usage 200% is larger than the maximum allowed for provided set \[0\] of 100%`},
 		{quota.NewResourcesBuilder().WithJournalRate(0, 1).Build(), `journal quota must have a rate count larger than zero and period at least 1 microsecond \(minimum resolution\)`},
 		{quota.NewResourcesBuilder().WithJournalRate(1, 0).Build(), `journal quota must have a rate count larger than zero and period at least 1 microsecond \(minimum resolution\)`},
+		{quota.NewResourcesBuilder().WithJournalRate(1, time.Nanosecond).Build(), `journal quota must have a rate count larger than zero and period at least 1 microsecond \(minimum resolution\)`},
 		{quota.NewResourcesBuilder().WithJournalSize(0).Build(), `journal size quota must have a limit set`},
 	}
 

--- a/snap/quota/resources_test.go
+++ b/snap/quota/resources_test.go
@@ -47,8 +47,8 @@ func (s *resourcesTestSuite) TestQuotaValidationFails(c *C) {
 		{quota.NewResourcesBuilder().Build(), `quota group must have at least one resource limit set`},
 		{quota.NewResourcesBuilder().WithCPUCount(1).Build(), `invalid cpu quota with count of >0 and percentage of 0`},
 		{quota.NewResourcesBuilder().WithCPUCount(2).WithCPUPercentage(100).WithAllowedCPUs([]int{0}).Build(), `cpu usage 200% is larger than the maximum allowed for provided set \[0\] of 100%`},
-		{quota.NewResourcesBuilder().WithJournalRate(0, 1).Build(), `journal quota must have a rate count larger than zero and period larger than zero microseconds`},
-		{quota.NewResourcesBuilder().WithJournalRate(1, 0).Build(), `journal quota must have a rate count larger than zero and period larger than zero microseconds`},
+		{quota.NewResourcesBuilder().WithJournalRate(0, 1).Build(), `journal quota must have a rate count larger than zero and period at least 1 microsecond \(minimum resolution\)`},
+		{quota.NewResourcesBuilder().WithJournalRate(1, 0).Build(), `journal quota must have a rate count larger than zero and period at least 1 microsecond \(minimum resolution\)`},
 		{quota.NewResourcesBuilder().WithJournalSize(0).Build(), `journal size quota must have a limit set`},
 	}
 
@@ -193,7 +193,7 @@ func (s *resourcesTestSuite) TestQuotaChangeValidationFails(c *C) {
 		{
 			quota.NewResourcesBuilder().WithJournalRate(1, 1).Build(),
 			quota.NewResourcesBuilder().WithJournalRate(-2, 0).Build(),
-			`journal quota must have a rate count larger than zero and period larger than zero microseconds`,
+			`journal quota must have a rate count larger than zero and period at least 1 microsecond \(minimum resolution\)`,
 		},
 		{
 			quota.NewResourcesBuilder().WithJournalSize(quantity.SizeGiB).Build(),

--- a/snap/quota/resources_test.go
+++ b/snap/quota/resources_test.go
@@ -191,7 +191,7 @@ func (s *resourcesTestSuite) TestQuotaChangeValidationFails(c *C) {
 		},
 		{
 			quota.NewResourcesBuilder().WithJournalRate(1, 1).Build(),
-			quota.NewResourcesBuilder().WithJournalRate(-2, -2).Build(),
+			quota.NewResourcesBuilder().WithJournalRate(-2, 0).Build(),
 			`journal quota must have a rate count and period larger than zero`,
 		},
 		{


### PR DESCRIPTION
To clarify intentions and also better support the maximum resolution for the 'Period' member. This was a small oversight. 

Systemd (and us) support a resolution down to microseconds, and thus I have decided to store the Period as microseconds. My original intent was to have this member be a time.Duration, however this type does not support json marshalling, and I really wanted to avoid writing my own custom type with custom marshalling code for that.

Thanks to @mardy for catching this!

**UPDATE:**

Changed to a time.Duration as it seems it works just fine when marshalling a time.Duration through json, that was my mistake - I had misunderstood reports about this, and should have tested how it worked before jumping to conclusions.