### PR TITLE
gadget/install, o/devicestate: do not create recovery and reinstall keys during installation

### DIFF
--- a/gadget/install/encrypt.go
+++ b/gadget/install/encrypt.go
@@ -37,13 +37,11 @@ import (
 
 var (
 	secbootFormatEncryptedDevice = secboot.FormatEncryptedDevice
-	secbootAddRecoveryKey        = secboot.AddRecoveryKey
 )
 
 // encryptedDeviceCryptsetup represents a encrypted block device.
 type encryptedDevice interface {
 	Node() string
-	AddRecoveryKey(key keys.EncryptionKey, rkey keys.RecoveryKey) error
 	Close() error
 }
 
@@ -78,10 +76,6 @@ func newEncryptedDeviceLUKS(part *gadget.OnDiskStructure, key keys.EncryptionKey
 	}
 
 	return dev, nil
-}
-
-func (dev *encryptedDeviceLUKS) AddRecoveryKey(key keys.EncryptionKey, rkey keys.RecoveryKey) error {
-	return secbootAddRecoveryKey(key, rkey, dev.parent.Node)
 }
 
 func (dev *encryptedDeviceLUKS) Node() string {
@@ -172,8 +166,4 @@ func (dev *encryptedDeviceWithSetupHook) Close() error {
 
 func (dev *encryptedDeviceWithSetupHook) Node() string {
 	return dev.node
-}
-
-func (dev *encryptedDeviceWithSetupHook) AddRecoveryKey(key keys.EncryptionKey, rkey keys.RecoveryKey) error {
-	return fmt.Errorf("recovery keys are not supported on devices that use the device-setup hook")
 }

--- a/gadget/install/export_secboot_test.go
+++ b/gadget/install/export_secboot_test.go
@@ -41,12 +41,6 @@ func MockSecbootFormatEncryptedDevice(f func(key keys.EncryptionKey, label, node
 
 }
 
-func MockSecbootAddRecoveryKey(f func(key keys.EncryptionKey, rkey keys.RecoveryKey, node string) error) (restore func()) {
-	r := testutil.Backup(&secbootAddRecoveryKey)
-	secbootAddRecoveryKey = f
-	return r
-}
-
 func MockBootRunFDESetupHook(f func(req *fde.SetupRequest) ([]byte, error)) (restore func()) {
 	r := testutil.Backup(&boot.RunFDESetupHook)
 	boot.RunFDESetupHook = f

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -153,25 +153,10 @@ func Run(model gadget.Model, gadgetRoot, kernelRoot, bootDevice string, options 
 		return nil, fmt.Errorf("cannot create the partitions: %v", err)
 	}
 
-	makeKeySet := func() (*EncryptionKeySet, error) {
-		key, err := keys.NewEncryptionKey()
-		if err != nil {
-			return nil, fmt.Errorf("cannot create encryption key: %v", err)
-		}
-
-		rkey, err := keys.NewRecoveryKey()
-		if err != nil {
-			return nil, fmt.Errorf("cannot create recovery key: %v", err)
-		}
-		return &EncryptionKeySet{
-			Key:         key,
-			RecoveryKey: rkey,
-		}, nil
-	}
 	roleNeedsEncryption := func(role string) bool {
 		return role == gadget.SystemData || role == gadget.SystemSave
 	}
-	var keysForRoles map[string]*EncryptionKeySet
+	var keyForRole map[string]keys.EncryptionKey
 
 	partsEncrypted := map[string]gadget.StructureEncryptionParameters{}
 
@@ -191,9 +176,13 @@ func Run(model gadget.Model, gadgetRoot, kernelRoot, bootDevice string, options 
 		}
 
 		if encrypt && roleNeedsEncryption(part.Role) {
-			var keys *EncryptionKeySet
+			var encryptionKey keys.EncryptionKey
+			var err error
 			timings.Run(perfTimings, fmt.Sprintf("make-key-set[%s]", roleOrLabelOrName(part)), fmt.Sprintf("Create encryption key set for %s", roleOrLabelOrName(part)), func(timings.Measurer) {
-				keys, err = makeKeySet()
+				encryptionKey, err = keys.NewEncryptionKey()
+				if err != nil {
+					err = fmt.Errorf("cannot create encryption key: %v", err)
+				}
 			})
 			if err != nil {
 				return nil, err
@@ -203,14 +192,7 @@ func Run(model gadget.Model, gadgetRoot, kernelRoot, bootDevice string, options 
 			switch options.EncryptionType {
 			case secboot.EncryptionTypeLUKS:
 				timings.Run(perfTimings, fmt.Sprintf("new-encrypted-device[%s]", roleOrLabelOrName(part)), fmt.Sprintf("Create encryption device for %s", roleOrLabelOrName(part)), func(timings.Measurer) {
-					dataPart, err = newEncryptedDeviceLUKS(&part, keys.Key, part.Label)
-				})
-				if err != nil {
-					return nil, err
-				}
-
-				timings.Run(perfTimings, fmt.Sprintf("add-recovery-key[%s]", roleOrLabelOrName(part)), fmt.Sprintf("Adding recovery key for %s", roleOrLabelOrName(part)), func(timings.Measurer) {
-					err = dataPart.AddRecoveryKey(keys.Key, keys.RecoveryKey)
+					dataPart, err = newEncryptedDeviceLUKS(&part, encryptionKey, part.Label)
 				})
 				if err != nil {
 					return nil, err
@@ -221,7 +203,7 @@ func Run(model gadget.Model, gadgetRoot, kernelRoot, bootDevice string, options 
 				}
 			case secboot.EncryptionTypeDeviceSetupHook:
 				timings.Run(perfTimings, fmt.Sprintf("new-encrypted-device-setup-hook[%s]", roleOrLabelOrName(part)), fmt.Sprintf("Create encryption device for %s using device-setup-hook", roleOrLabelOrName(part)), func(timings.Measurer) {
-					dataPart, err = createEncryptedDeviceWithSetupHook(&part, keys.Key, part.Name)
+					dataPart, err = createEncryptedDeviceWithSetupHook(&part, encryptionKey, part.Name)
 				})
 				if err != nil {
 					return nil, err
@@ -236,10 +218,10 @@ func Run(model gadget.Model, gadgetRoot, kernelRoot, bootDevice string, options 
 
 			// update the encrypted device node
 			part.Node = dataPart.Node()
-			if keysForRoles == nil {
-				keysForRoles = map[string]*EncryptionKeySet{}
+			if keyForRole == nil {
+				keyForRole = map[string]keys.EncryptionKey{}
 			}
-			keysForRoles[part.Role] = keys
+			keyForRole[part.Role] = encryptionKey
 			logger.Noticef("encrypted device %v", part.Node)
 		}
 
@@ -284,7 +266,7 @@ func Run(model gadget.Model, gadgetRoot, kernelRoot, bootDevice string, options 
 	}
 
 	return &InstalledSystemSideData{
-		KeysForRoles: keysForRoles,
+		KeyForRole: keyForRole,
 	}, nil
 }
 

--- a/gadget/install/params.go
+++ b/gadget/install/params.go
@@ -31,15 +31,9 @@ type Options struct {
 	EncryptionType secboot.EncryptionType
 }
 
-// EncryptionKeySet is a set of encryption keys.
-type EncryptionKeySet struct {
-	Key         keys.EncryptionKey
-	RecoveryKey keys.RecoveryKey
-}
-
 // InstalledSystemSideData carries side data of an installed system, eg. secrets
 // to access its partitions.
 type InstalledSystemSideData struct {
 	// KeysForRoles contains key sets for the relevant structure roles.
-	KeysForRoles map[string]*EncryptionKeySet
+	KeyForRole map[string]keys.EncryptionKey
 }

--- a/tests/lib/uc20-create-partitions/main.go
+++ b/tests/lib/uc20-create-partitions/main.go
@@ -89,22 +89,20 @@ func main() {
 	}
 
 	if args.Encrypt {
-		if installSideData == nil || installSideData.KeysForRoles == nil {
+		if installSideData == nil || len(installSideData.KeyForRole) == 0 {
 			panic("expected encryption keys")
 		}
-		dataKey := installSideData.KeysForRoles[gadget.SystemData]
+		dataKey := installSideData.KeyForRole[gadget.SystemData]
 		if dataKey == nil {
 			panic("ubuntu-data encryption key is unset")
 		}
-		saveKey := installSideData.KeysForRoles[gadget.SystemSave]
+		saveKey := installSideData.KeyForRole[gadget.SystemSave]
 		if saveKey == nil {
 			panic("ubuntu-save encryption key is unset")
 		}
 		toWrite := map[string][]byte{
-			"unsealed-key":  dataKey.Key[:],
-			"recovery-key":  dataKey.RecoveryKey[:],
-			"save-key":      saveKey.Key[:],
-			"reinstall-key": saveKey.RecoveryKey[:],
+			"unsealed-key": dataKey[:],
+			"save-key":     saveKey[:],
 		}
 		for keyFileName, keyData := range toWrite {
 			if err := ioutil.WriteFile(keyFileName, keyData, 0644); err != nil {

--- a/tests/main/uc20-create-partitions-encrypt/task.yaml
+++ b/tests/main/uc20-create-partitions-encrypt/task.yaml
@@ -151,12 +151,13 @@ execute: |
     umount ./mnt
     cryptsetup close /dev/mapper/test
 
+    # TODO: convert the test to use snap-fde-keymgr add-recovery-key/remove-recovery-key
     # Test the recovery key
-    echo "Ensure that we can open the encrypted ubuntu-data device using the recovery key"
-    cryptsetup open --key-file recovery-key "${LOOP}p5" test-recovery
-    mount /dev/mapper/test-recovery ./mnt
-    umount ./mnt
-    cryptsetup close /dev/mapper/test-recovery
+    # echo "Ensure that we can open the encrypted ubuntu-data device using the recovery key"
+    # cryptsetup open --key-file recovery-key "${LOOP}p5" test-recovery
+    # mount /dev/mapper/test-recovery ./mnt
+    # umount ./mnt
+    # cryptsetup close /dev/mapper/test-recovery
 
     # Test the save key
     echo "Ensure that we can open the encrypted ubuntu-save device using the run mode key"
@@ -165,12 +166,13 @@ execute: |
     umount ./mnt
     cryptsetup close /dev/mapper/test-save
 
+    # TODO: convert the test to use snap-fde-keymgr add-recovery-key/remove-recovery-key
     # Test the reinstall key
-    echo "Ensure that we can open the encrypted ubuntu-save device using the reinstall key"
-    cryptsetup open --key-file reinstall-key "${LOOP}p4" test-reinstall
-    mount /dev/mapper/test-reinstall ./mnt
-    umount ./mnt
-    cryptsetup close /dev/mapper/test-reinstall
+    # echo "Ensure that we can open the encrypted ubuntu-save device using the reinstall key"
+    # cryptsetup open --key-file reinstall-key "${LOOP}p4" test-reinstall
+    # mount /dev/mapper/test-reinstall ./mnt
+    # umount ./mnt
+    # cryptsetup close /dev/mapper/test-reinstall
 
     echo "Check the disk-mapping.json has expected contents"
 

--- a/tests/nested/core/core20-tpm/task.yaml
+++ b/tests/nested/core/core20-tpm/task.yaml
@@ -17,12 +17,14 @@ execute: |
     echo "and secure boot is enabled on the nested vm"
     tests.nested exec "xxd /sys/firmware/efi/efivars/SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c" | MATCH "00000000: 0600 0000 01\s+....."
 
-    echo "and the recovery key is available"
-    tests.nested exec "test -e /var/lib/snapd/device/fde/recovery.key"
-    echo "and has the expected size"
-    tests.nested exec "stat --printf=%s /var/lib/snapd/device/fde/recovery.key" | MATCH '^16$'
-    echo "and has the expected owner and permissions"
-    tests.nested exec "stat --printf='%u:%g %a' /var/lib/snapd/device/fde/recovery.key" | MATCH '^0:0 600$'
+    # TODO test adding/removing of recovery keys
+    echo "and the recovery key is unavailable"
+    tests.nested exec "test ! -e /var/lib/snapd/device/fde/recovery.key"
+    # TODO execute these checks when adding recovery keys
+    # echo "and has the expected size"
+    # tests.nested exec "stat --printf=%s /var/lib/snapd/device/fde/recovery.key" | MATCH '^16$'
+    # echo "and has the expected owner and permissions"
+    # tests.nested exec "stat --printf='%u:%g %a' /var/lib/snapd/device/fde/recovery.key" | MATCH '^0:0 600$'
 
     echo "and the tpm-{policy-auth-key,lockout-auth} files are in ubuntu-save"
     tests.nested exec "test -e /var/lib/snapd/save/device/fde/tpm-policy-auth-key"

--- a/tests/nested/manual/uc20-fde-hooks-v1/task.yaml
+++ b/tests/nested/manual/uc20-fde-hooks-v1/task.yaml
@@ -27,7 +27,7 @@ prepare: |
 execute: |
   echo "Check that we have an encrypted system"
   tests.nested exec "find /dev/mapper" | MATCH ubuntu-data-[0-9a-f-]+
-  tests.nested exec "test -e /var/lib/snapd/device/fde/recovery.key"
+  tests.nested exec "test ! -e /var/lib/snapd/device/fde/recovery.key"
   tests.nested exec "test -e /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key"
   tests.nested exec "test -e /run/mnt/ubuntu-seed/device/fde/ubuntu-data.recovery.sealed-key"
   tests.nested exec "test -e /run/mnt/ubuntu-seed/device/fde/ubuntu-save.recovery.sealed-key"

--- a/tests/nested/manual/uc20-fde-hooks/task.yaml
+++ b/tests/nested/manual/uc20-fde-hooks/task.yaml
@@ -30,7 +30,7 @@ prepare: |
 execute: |
   echo "Check that we have an encrypted system"
   tests.nested exec "find /dev/mapper" | MATCH ubuntu-data-[0-9a-f-]+
-  tests.nested exec "test -e /var/lib/snapd/device/fde/recovery.key"
+  tests.nested exec "test ! -e /var/lib/snapd/device/fde/recovery.key"
   tests.nested exec "test -e /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key"
   tests.nested exec "test -e /run/mnt/ubuntu-seed/device/fde/ubuntu-data.recovery.sealed-key"
   tests.nested exec "test -e /run/mnt/ubuntu-seed/device/fde/ubuntu-save.recovery.sealed-key"


### PR DESCRIPTION
As part of making the recovery keys optional, stop creating them during install.
