### PR TITLE
o/devicestate: fix install tests on systems with /var/lib/snapd/snap

### DIFF
--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -85,6 +85,10 @@ func (s *deviceMgrInstallModeSuite) SetUpTest(c *C) {
 	classic := false
 	s.deviceMgrBaseSuite.setupBaseTest(c, classic)
 
+	s.AddCleanup(release.MockReleaseInfo(&release.OS{ID: "ubuntu"}))
+	// reload directory paths to match our mocked os-release
+	dirs.SetRootDir(dirs.GlobalRootDir)
+
 	s.ConfigureTargetSystemOptsPassed = nil
 	s.ConfigureTargetSystemErr = nil
 	restore := devicestate.MockSysconfigConfigureTargetSystem(func(mod *asserts.Model, opts *sysconfig.Options) error {

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -85,6 +85,8 @@ func (s *deviceMgrInstallModeSuite) SetUpTest(c *C) {
 	classic := false
 	s.deviceMgrBaseSuite.setupBaseTest(c, classic)
 
+	// restore dirs after os-release mock is cleaned up
+	s.AddCleanup(func() { dirs.SetRootDir(dirs.GlobalRootDir) })
 	s.AddCleanup(release.MockReleaseInfo(&release.OS{ID: "ubuntu"}))
 	// reload directory paths to match our mocked os-release
 	dirs.SetRootDir(dirs.GlobalRootDir)


### PR DESCRIPTION
Turns out we did not mock os-release for install mode tests, and some of the
recently added tests fail on systems which use /var/lib/snapd/snap like so:

```
FAIL: devicestate_install_mode_test.go:606: deviceMgrInstallModeSuite.TestMaybeApplyPreseededData

devicestate_install_mode_test.go:659:
    c.Check(osutil.FileExists(filepath.Join(writableDir, dirs.GlobalRootDir, "/snap/essential-snap/1")), Equals, true)
... obtained bool = false
... expected bool = true

devicestate_install_mode_test.go:661:
    c.Check(osutil.FileExists(filepath.Join(writableDir, dirs.GlobalRootDir, "/snap/mode-snap/3")), Equals, true)
... obtained bool = false
... expected bool = true

devicestate_install_mode_test.go:663:
    c.Check(osutil.FileExists(filepath.Join(writableDir, dirs.GlobalRootDir, "/snap/mode-snap-unasserted/x1")), Equals, true)
... obtained bool = false
... expected bool = true
``

Mock OS to be Ubuntu for the whole install suite.
