### PR TITLE
cmd/snap-bootstrap: Listen to keyboard added after start and handle switch root

### DIFF
--- a/cmd/snap-bootstrap/export_test.go
+++ b/cmd/snap-bootstrap/export_test.go
@@ -82,7 +82,7 @@ func MockSystemdMount(f func(_, _ string, opts *SystemdMountOptions) error) (res
 	}
 }
 
-func MockTriggerwatchWait(f func(_ time.Duration) error) (restore func()) {
+func MockTriggerwatchWait(f func(_ time.Duration, _ time.Duration) error) (restore func()) {
 	oldTriggerwatchWait := triggerwatchWait
 	triggerwatchWait = f
 	return func() {
@@ -91,6 +91,7 @@ func MockTriggerwatchWait(f func(_ time.Duration) error) (restore func()) {
 }
 
 var DefaultTimeout = defaultTimeout
+var DefaultDeviceTimeout = defaultDeviceTimeout
 
 func MockDefaultMarkerFile(p string) (restore func()) {
 	old := defaultMarkerFile

--- a/data/systemd/snapd.recovery-chooser-trigger.service.in
+++ b/data/systemd/snapd.recovery-chooser-trigger.service.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=Wait for the Ubuntu Core chooser trigger
-Before=snapd.service
+Wants=getty-pre.target
+Before=getty-pre.target
 # don't run on classic or uc16/uc18
 ConditionKernelCommandLine=snapd_recovery_mode
 # only run when there are input devices


### PR DESCRIPTION
Keyboard drivers and the drivers for the bus they are plugged into are
not necessarily initialized by the time udev has settled cold plug
events. That means we have to read events for new input devices and
read those keyboards.

Also because the daemon is started in initramfs and needs to write
into the file system, it needs to chroot when switch root happens.

There are 2 things to decide in this PR:
 - What should be the proper way to notify the switch root. This PR uses SIGUSR1. But we could use an RPC for example using dbus. That way we could pass the path too the new root for example.
 - Now we always wait 10s before starting snapd. Before, it would not wait if no keyboard was found. Should we have a second timeout, like if after 3s no keyboard was found, we cancel.
 - `osutil/udev` has another interface to look for device through `/sys`. Should we replace use of `evdev.ListInputDevices` to use that?

I will open a PR on core-initrd later for necessary changes and link to it.
