### PR TITLE
secboot: partial reprovision

### DIFF
--- a/secboot/export_sb_test.go
+++ b/secboot/export_sb_test.go
@@ -24,9 +24,12 @@ package secboot
 import (
 	"io"
 
+	"github.com/canonical/go-tpm2"
 	sb "github.com/snapcore/secboot"
 	sb_efi "github.com/snapcore/secboot/efi"
 	sb_tpm2 "github.com/snapcore/secboot/tpm2"
+
+	"github.com/snapcore/snapd/testutil"
 )
 
 var (
@@ -42,12 +45,18 @@ func MockSbConnectToDefaultTPM(f func() (*sb_tpm2.Connection, error)) (restore f
 	}
 }
 
-func MockProvisionTPM(f func(tpm *sb_tpm2.Connection, mode sb_tpm2.ProvisionMode, newLockoutAuth []byte) error) (restore func()) {
+func MockProvisionTPM(f func(tpm *sb_tpm2.Connection, mode sb_tpm2.ProvisionMode, newLockoutAuth, currentLockoutAuth []byte) error) (restore func()) {
 	old := provisionTPM
 	provisionTPM = f
 	return func() {
 		provisionTPM = old
 	}
+}
+
+func MockTPMReleaseResources(f func(tpm *sb_tpm2.Connection, handle tpm2.Handle) error) (restore func()) {
+	restore = testutil.Backup(&tpmReleaseResources)
+	tpmReleaseResources = f
+	return restore
 }
 
 func MockSbEfiAddSecureBootPolicyProfile(f func(profile *sb_tpm2.PCRProtectionProfile, params *sb_efi.SecureBootPolicyProfileParams) error) (restore func()) {

--- a/secboot/secboot.go
+++ b/secboot/secboot.go
@@ -100,6 +100,13 @@ type SealKeysParams struct {
 	TPMLockoutAuthFile string
 	// Whether we should provision the TPM
 	TPMProvision bool
+	// Only meaningful when used in conjunction with TPMProvision. Assumes a
+	// partial reprovisioniong of the TPM which was previously already
+	// provisioned by secboot. Existing lockout authorization data from
+	// TPMLockoutAuthFile will be used to authorize provisioning and will
+	// get overwritten in the process. The resource handles identified by
+	// PCRPolicyCounterHandle will be released before allocating them again
+	TPMPartialReprovision bool
 	// The handle at which to create a NV index for dynamic authorization policy revocation support
 	PCRPolicyCounterHandle uint32
 }

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -63,8 +63,9 @@ var (
 
 	randutilRandomKernelUUID = randutil.RandomKernelUUID
 
-	isTPMEnabled = isTPMEnabledImpl
-	provisionTPM = provisionTPMImpl
+	isTPMEnabled        = isTPMEnabledImpl
+	provisionTPM        = provisionTPMImpl
+	tpmReleaseResources = tpmReleaseResourcesImpl
 
 	// check whether the interfaces match
 	_ (sb.SnapModel) = ModelForSealing(nil)
@@ -284,6 +285,17 @@ func unlockEncryptedPartitionWithSealedKey(mapperName, sourceDevice, keyfile str
 	return UnlockedWithSealedKey, nil
 }
 
+func tpmReleaseResourcesImpl(tpm *sb_tpm2.Connection, handle tpm2.Handle) error {
+	rc, err := tpm.CreateResourceContextFromTPM(handle)
+	if err != nil {
+		return fmt.Errorf("cannot create resource context: %v", err)
+	}
+	if err := tpm.NVUndefineSpace(tpm.OwnerHandleContext(), rc, tpm.HmacSession()); err != nil {
+		return fmt.Errorf("cannot undefine space: %v", err)
+	}
+	return nil
+}
+
 // SealKeys provisions the TPM and seals the encryption keys according to the
 // specified parameters. If the TPM is already provisioned, or a sealed key already
 // exists, SealKeys will fail and return an error.
@@ -309,7 +321,14 @@ func SealKeys(keys []SealKeyRequest, params *SealKeysParams) error {
 
 	if params.TPMProvision {
 		// Provision the TPM as late as possible
-		if err := tpmProvision(tpm, params.TPMLockoutAuthFile); err != nil {
+		existingLockoutAuth := params.TPMPartialReprovision
+		if err := tpmProvision(tpm, params.TPMLockoutAuthFile, existingLockoutAuth); err != nil {
+			return err
+		}
+	}
+	if params.TPMPartialReprovision {
+		logger.Debugf("releasing TPM NV resource with handle %v", params.PCRPolicyCounterHandle)
+		if err := tpmReleaseResources(tpm, tpm2.Handle(params.PCRPolicyCounterHandle)); err != nil {
 			return err
 		}
 	}
@@ -472,7 +491,16 @@ func buildPCRProtectionProfile(modelParams []*SealKeyModelParams) (*sb_tpm2.PCRP
 	return pcrProfile, nil
 }
 
-func tpmProvision(tpm *sb_tpm2.Connection, lockoutAuthFile string) error {
+func tpmProvision(tpm *sb_tpm2.Connection, lockoutAuthFile string, existingLockoutAuth bool) error {
+	var currentLockoutAuth []byte
+	if existingLockoutAuth {
+		logger.Debugf("using existing lockout authorization")
+		d, err := ioutil.ReadFile(lockoutAuthFile)
+		if err != nil {
+			return fmt.Errorf("cannot read existing lockout auth: %v", err)
+		}
+		currentLockoutAuth = d
+	}
 	// Create and save the lockout authorization file
 	lockoutAuth := make([]byte, 16)
 	// crypto rand is protected against short reads
@@ -487,15 +515,20 @@ func tpmProvision(tpm *sb_tpm2.Connection, lockoutAuthFile string) error {
 	// TODO:UC20: ideally we should ask the firmware to clear the TPM and then reboot
 	//            if the device has previously been provisioned, see
 	//            https://godoc.org/github.com/snapcore/secboot#RequestTPMClearUsingPPI
-	if err := provisionTPM(tpm, sb_tpm2.ProvisionModeFull, lockoutAuth); err != nil {
+	if err := provisionTPM(tpm, sb_tpm2.ProvisionModeFull, lockoutAuth, currentLockoutAuth); err != nil {
 		logger.Noticef("TPM provisioning error: %v", err)
 		return fmt.Errorf("cannot provision TPM: %v", err)
 	}
 	return nil
 }
 
-func provisionTPMImpl(tpm *sb_tpm2.Connection, mode sb_tpm2.ProvisionMode, lockoutAuth []byte) error {
-	return tpm.EnsureProvisioned(mode, lockoutAuth)
+func provisionTPMImpl(tpm *sb_tpm2.Connection, mode sb_tpm2.ProvisionMode, newLockoutAuth []byte, currentLockoutAuth []byte) error {
+	if currentLockoutAuth != nil {
+		// use the current lockout authorization data to authorize
+		// provisioning
+		tpm.LockoutHandleContext().SetAuthValue(currentLockoutAuth)
+	}
+	return tpm.EnsureProvisioned(mode, newLockoutAuth)
 }
 
 // buildLoadSequences builds EFI load image event trees from this package LoadChains


### PR DESCRIPTION
Add support for partial reprovisioning which happens during factory reset. We
assume that the TPM has been previously provisioned and we have the lockout
authorization key. Thus we provision it again and authorize this operation using
the existing key. Then, when sealing the keys we will first release the
resources associated with PCR handles for each of the keys.

