### PR TITLE
many: use UC20+/pre-UC20 in user messages as needed

### DIFF
--- a/boot/boot.go
+++ b/boot/boot.go
@@ -439,7 +439,7 @@ func updateManagedBootConfigForBootloader(dev snap.Device, mode, gadgetSnapOrDir
 func UpdateCommandLineForGadgetComponent(dev snap.Device, gadgetSnapOrDir string) (needsReboot bool, err error) {
 	if !dev.HasModeenv() {
 		// only UC20 devices are supported
-		return false, fmt.Errorf("internal error: command line component cannot be updated on non UC20+ devices")
+		return false, fmt.Errorf("internal error: command line component cannot be updated on pre-UC20 devices")
 	}
 	opts := &bootloader.Options{
 		Role: bootloader.RoleRunMode,

--- a/boot/boot.go
+++ b/boot/boot.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2019-2020 Canonical Ltd
+ * Copyright (C) 2019-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -439,7 +439,7 @@ func updateManagedBootConfigForBootloader(dev snap.Device, mode, gadgetSnapOrDir
 func UpdateCommandLineForGadgetComponent(dev snap.Device, gadgetSnapOrDir string) (needsReboot bool, err error) {
 	if !dev.HasModeenv() {
 		// only UC20 devices are supported
-		return false, fmt.Errorf("internal error: command line component cannot be updated on non UC20 devices")
+		return false, fmt.Errorf("internal error: command line component cannot be updated on non UC20+ devices")
 	}
 	opts := &bootloader.Options{
 		Role: bootloader.RoleRunMode,

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2021 Canonical Ltd
+ * Copyright (C) 2014-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -3603,7 +3603,7 @@ func (s *bootKernelCommandLineSuite) TestCommandLineUpdateNonUC20(c *C) {
 	})
 
 	reboot, err := boot.UpdateCommandLineForGadgetComponent(nonUC20dev, sf)
-	c.Assert(err, ErrorMatches, "internal error: command line component cannot be updated on non UC20 devices")
+	c.Assert(err, ErrorMatches, `internal error: command line component cannot be updated on non UC20\+ devices`)
 	c.Assert(reboot, Equals, false)
 }
 

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -3603,7 +3603,7 @@ func (s *bootKernelCommandLineSuite) TestCommandLineUpdateNonUC20(c *C) {
 	})
 
 	reboot, err := boot.UpdateCommandLineForGadgetComponent(nonUC20dev, sf)
-	c.Assert(err, ErrorMatches, `internal error: command line component cannot be updated on non UC20\+ devices`)
+	c.Assert(err, ErrorMatches, `internal error: command line component cannot be updated on pre-UC20 devices`)
 	c.Assert(reboot, Equals, false)
 }
 

--- a/boot/bootstate20.go
+++ b/boot/bootstate20.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2019-2020 Canonical Ltd
+ * Copyright (C) 2019-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -560,7 +560,7 @@ func toBootStateUpdate20(update bootStateUpdate) (u20 *bootStateUpdate20, err er
 	if update != nil {
 		var ok bool
 		if u20, ok = update.(*bootStateUpdate20); !ok {
-			return nil, fmt.Errorf("internal error, cannot thread %T with update for UC20", update)
+			return nil, fmt.Errorf("internal error, cannot thread %T with update for UC20+", update)
 		}
 	}
 	if u20 == nil {

--- a/boot/flags.go
+++ b/boot/flags.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2021 Canonical Ltd
+ * Copyright (C) 2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -35,7 +35,7 @@ import (
 )
 
 var (
-	errNotUC20 = fmt.Errorf("cannot get boot flags on non-UC20 device")
+	errNotUC20 = fmt.Errorf("cannot get boot flags on non-UC20+ device")
 
 	understoodBootFlags = []string{
 		// the factory boot flag is set to indicate that this is a

--- a/boot/flags.go
+++ b/boot/flags.go
@@ -35,7 +35,7 @@ import (
 )
 
 var (
-	errNotUC20 = fmt.Errorf("cannot get boot flags on non-UC20+ device")
+	errNotUC20 = fmt.Errorf("cannot get boot flags on pre-UC20 device")
 
 	understoodBootFlags = []string{
 		// the factory boot flag is set to indicate that this is a

--- a/boot/flags_test.go
+++ b/boot/flags_test.go
@@ -49,13 +49,13 @@ func (s *bootFlagsSuite) TestBootFlagsFamilyClassic(c *C) {
 	defer bootloader.ForceError(nil)
 
 	_, err := boot.NextBootFlags(classicDev)
-	c.Assert(err, ErrorMatches, `cannot get boot flags on non-UC20\+ device`)
+	c.Assert(err, ErrorMatches, `cannot get boot flags on pre-UC20 device`)
 
 	err = boot.SetNextBootFlags(classicDev, "", []string{"foo"})
-	c.Assert(err, ErrorMatches, `cannot get boot flags on non-UC20\+ device`)
+	c.Assert(err, ErrorMatches, `cannot get boot flags on pre-UC20 device`)
 
 	_, err = boot.BootFlags(classicDev)
-	c.Assert(err, ErrorMatches, `cannot get boot flags on non-UC20\+ device`)
+	c.Assert(err, ErrorMatches, `cannot get boot flags on pre-UC20 device`)
 }
 
 func (s *bootFlagsSuite) TestBootFlagsFamilyUC16(c *C) {
@@ -66,13 +66,13 @@ func (s *bootFlagsSuite) TestBootFlagsFamilyUC16(c *C) {
 	defer bootloader.ForceError(nil)
 
 	_, err := boot.NextBootFlags(coreDev)
-	c.Assert(err, ErrorMatches, `cannot get boot flags on non-UC20\+ device`)
+	c.Assert(err, ErrorMatches, `cannot get boot flags on pre-UC20 device`)
 
 	err = boot.SetNextBootFlags(coreDev, "", []string{"foo"})
-	c.Assert(err, ErrorMatches, `cannot get boot flags on non-UC20\+ device`)
+	c.Assert(err, ErrorMatches, `cannot get boot flags on pre-UC20 device`)
 
 	_, err = boot.BootFlags(coreDev)
-	c.Assert(err, ErrorMatches, `cannot get boot flags on non-UC20\+ device`)
+	c.Assert(err, ErrorMatches, `cannot get boot flags on pre-UC20 device`)
 }
 
 func setupRealGrub(c *C, rootDir, baseDir string, opts *bootloader.Options) bootloader.Bootloader {

--- a/boot/flags_test.go
+++ b/boot/flags_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2021 Canonical Ltd
+ * Copyright (C) 2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -49,13 +49,13 @@ func (s *bootFlagsSuite) TestBootFlagsFamilyClassic(c *C) {
 	defer bootloader.ForceError(nil)
 
 	_, err := boot.NextBootFlags(classicDev)
-	c.Assert(err, ErrorMatches, "cannot get boot flags on non-UC20 device")
+	c.Assert(err, ErrorMatches, `cannot get boot flags on non-UC20\+ device`)
 
 	err = boot.SetNextBootFlags(classicDev, "", []string{"foo"})
-	c.Assert(err, ErrorMatches, "cannot get boot flags on non-UC20 device")
+	c.Assert(err, ErrorMatches, `cannot get boot flags on non-UC20\+ device`)
 
 	_, err = boot.BootFlags(classicDev)
-	c.Assert(err, ErrorMatches, "cannot get boot flags on non-UC20 device")
+	c.Assert(err, ErrorMatches, `cannot get boot flags on non-UC20\+ device`)
 }
 
 func (s *bootFlagsSuite) TestBootFlagsFamilyUC16(c *C) {
@@ -66,13 +66,13 @@ func (s *bootFlagsSuite) TestBootFlagsFamilyUC16(c *C) {
 	defer bootloader.ForceError(nil)
 
 	_, err := boot.NextBootFlags(coreDev)
-	c.Assert(err, ErrorMatches, "cannot get boot flags on non-UC20 device")
+	c.Assert(err, ErrorMatches, `cannot get boot flags on non-UC20\+ device`)
 
 	err = boot.SetNextBootFlags(coreDev, "", []string{"foo"})
-	c.Assert(err, ErrorMatches, "cannot get boot flags on non-UC20 device")
+	c.Assert(err, ErrorMatches, `cannot get boot flags on non-UC20\+ device`)
 
 	_, err = boot.BootFlags(coreDev)
-	c.Assert(err, ErrorMatches, "cannot get boot flags on non-UC20 device")
+	c.Assert(err, ErrorMatches, `cannot get boot flags on non-UC20\+ device`)
 }
 
 func setupRealGrub(c *C, rootDir, baseDir string, opts *bootloader.Options) bootloader.Bootloader {

--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2019 Canonical Ltd
+ * Copyright (C) 2014-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -301,7 +301,7 @@ func MakeRecoverySystemBootable(rootdir string, relativeRecoverySystemDir string
 // running in between.
 func MakeRunnableSystem(model *asserts.Model, bootWith *BootableSet, sealer *TrustedAssetsInstallObserver) error {
 	if model.Grade() == asserts.ModelGradeUnset {
-		return fmt.Errorf("internal error: cannot make non-uc20 system runnable")
+		return fmt.Errorf("internal error: cannot make non-UC20+ system runnable")
 	}
 	// TODO:UC20:
 	// - figure out what to do for uboot gadgets, currently we require them to

--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -301,7 +301,7 @@ func MakeRecoverySystemBootable(rootdir string, relativeRecoverySystemDir string
 // running in between.
 func MakeRunnableSystem(model *asserts.Model, bootWith *BootableSet, sealer *TrustedAssetsInstallObserver) error {
 	if model.Grade() == asserts.ModelGradeUnset {
-		return fmt.Errorf("internal error: cannot make non-UC20+ system runnable")
+		return fmt.Errorf("internal error: cannot make pre-UC20 system runnable")
 	}
 	// TODO:UC20:
 	// - figure out what to do for uboot gadgets, currently we require them to

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2021 Canonical Ltd
+ * Copyright (C) 2014-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -454,7 +454,7 @@ func (s *makeBootable20Suite) TestMakeSystemRunnable16Fails(c *C) {
 	model := boottest.MakeMockModel()
 
 	err := boot.MakeRunnableSystem(model, nil, nil)
-	c.Assert(err, ErrorMatches, "internal error: cannot make non-uc20 system runnable")
+	c.Assert(err, ErrorMatches, `internal error: cannot make non-UC20\+ system runnable`)
 }
 
 func (s *makeBootable20Suite) TestMakeSystemRunnable20(c *C) {
@@ -1345,7 +1345,7 @@ version: 5.0
 
 	// TODO:UC20: enable this use case
 	err = boot.MakeBootableImage(model, s.rootdir, bootWith, nil)
-	c.Assert(err, ErrorMatches, "non-empty uboot.env not supported on UC20 yet")
+	c.Assert(err, ErrorMatches, `non-empty uboot.env not supported on UC20\+ yet`)
 }
 
 func (s *makeBootable20UbootSuite) TestUbootMakeBootableImage20BootScr(c *C) {

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -454,7 +454,7 @@ func (s *makeBootable20Suite) TestMakeSystemRunnable16Fails(c *C) {
 	model := boottest.MakeMockModel()
 
 	err := boot.MakeRunnableSystem(model, nil, nil)
-	c.Assert(err, ErrorMatches, `internal error: cannot make non-UC20\+ system runnable`)
+	c.Assert(err, ErrorMatches, `internal error: cannot make pre-UC20 system runnable`)
 }
 
 func (s *makeBootable20Suite) TestMakeSystemRunnable20(c *C) {

--- a/boot/systems.go
+++ b/boot/systems.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2021 Canonical Ltd
+ * Copyright (C) 2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -44,7 +44,7 @@ func dropFromRecoverySystemsList(systemsList []string, systemLabel string) (newL
 // variables state is inconsistent.
 func ClearTryRecoverySystem(dev snap.Device, systemLabel string) error {
 	if !dev.HasModeenv() {
-		return fmt.Errorf("internal error: recovery systems can only be used on UC20")
+		return fmt.Errorf("internal error: recovery systems can only be used on UC20+")
 	}
 
 	m, err := loadModeenv()
@@ -105,7 +105,7 @@ func ClearTryRecoverySystem(dev snap.Device, systemLabel string) error {
 // caller should request switching to the given recovery system.
 func SetTryRecoverySystem(dev snap.Device, systemLabel string) (err error) {
 	if !dev.HasModeenv() {
-		return fmt.Errorf("internal error: recovery systems can only be used on UC20")
+		return fmt.Errorf("internal error: recovery systems can only be used on UC20+")
 	}
 
 	m, err := loadModeenv()
@@ -380,7 +380,7 @@ func InspectTryRecoverySystemOutcome(dev snap.Device) (outcome TryRecoverySystem
 // attempt to restore the previous state is made
 func PromoteTriedRecoverySystem(dev snap.Device, systemLabel string, triedSystems []string) (err error) {
 	if !dev.HasModeenv() {
-		return fmt.Errorf("internal error: recovery systems can only be used on UC20")
+		return fmt.Errorf("internal error: recovery systems can only be used on UC20+")
 	}
 
 	if !strutil.ListContains(triedSystems, systemLabel) {
@@ -422,7 +422,7 @@ func PromoteTriedRecoverySystem(dev snap.Device, systemLabel string, triedSystem
 // this call *DOES NOT* clear the boot environment variables.
 func DropRecoverySystem(dev snap.Device, systemLabel string) error {
 	if !dev.HasModeenv() {
-		return fmt.Errorf("internal error: recovery systems can only be used on UC20")
+		return fmt.Errorf("internal error: recovery systems can only be used on UC20+")
 	}
 
 	m, err := loadModeenv()

--- a/bootloader/lk.go
+++ b/bootloader/lk.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2019 Canonical Ltd
+ * Copyright (C) 2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -106,7 +106,7 @@ func (l *lk) dir() string {
 		return filepath.Join(l.rootdir, "/dev/disk/by-partlabel/")
 	case RoleRecovery, RoleRunMode:
 		// TODO: maybe panic'ing here is a bit harsh...
-		panic("internal error: shouldn't be using lk.dir() for uc20 runtime modes!")
+		panic("internal error: shouldn't be using lk.dir() for UC20+ runtime modes!")
 	default:
 		panic("unexpected bootloader role for lk dir")
 	}

--- a/bootloader/uboot.go
+++ b/bootloader/uboot.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2015 Canonical Ltd
+ * Copyright (C) 2014-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -131,7 +131,7 @@ func (u *uboot) InstallBootConfig(gadgetDir string, blOpts *Options) error {
 	if blOpts != nil && blOpts.Role == RoleRecovery {
 		// not supported yet, this is traditional uboot.env from gadget
 		// TODO:UC20: support this use-case
-		return fmt.Errorf("non-empty uboot.env not supported on UC20 yet")
+		return fmt.Errorf("non-empty uboot.env not supported on UC20+ yet")
 	}
 
 	systemFile := u.envFile()

--- a/cmd/snap/cmd_debug_bootvars.go
+++ b/cmd/snap/cmd_debug_bootvars.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2019 Canonical Ltd
+ * Copyright (C) 2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -49,7 +49,7 @@ func init() {
 		func() flags.Commander {
 			return &cmdBootvarsGet{}
 		}, map[string]string{
-			"uc20":     i18n.G("Whether to use uc20 boot vars or not"),
+			"uc20":     i18n.G("Whether to use UC20+ boot vars or not"),
 			"root-dir": i18n.G("Root directory to look for boot variables in"),
 		}, nil)
 
@@ -59,8 +59,8 @@ func init() {
 		func() flags.Commander {
 			return &cmdBootvarsSet{}
 		}, map[string]string{
-			"root-dir": i18n.G("Root directory to look for boot variables in (implies UC20)"),
-			"recovery": i18n.G("Manipulate the recovery bootloader (implies UC20)"),
+			"root-dir": i18n.G("Root directory to look for boot variables in (implies UC20+)"),
+			"recovery": i18n.G("Manipulate the recovery bootloader (implies UC20+)"),
 		}, nil)
 
 	if release.OnClassic {

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -102,7 +102,7 @@ func Run(model gadget.Model, gadgetRoot, kernelRoot, bootDevice string, options 
 	}
 
 	if model.Grade() == asserts.ModelGradeUnset {
-		return nil, fmt.Errorf("cannot run install mode on non-UC20+ system")
+		return nil, fmt.Errorf("cannot run install mode on pre-UC20 system")
 	}
 
 	laidOutBootVol, allLaidOutVols, err := gadget.LaidOutVolumesFromGadget(gadgetRoot, kernelRoot, model)
@@ -297,7 +297,7 @@ func FactoryReset(model gadget.Model, gadgetRoot, kernelRoot, bootDevice string,
 	}
 
 	if model.Grade() == asserts.ModelGradeUnset {
-		return nil, fmt.Errorf("cannot run factory-reset mode on non-UC20+ system")
+		return nil, fmt.Errorf("cannot run factory-reset mode on pre-UC20 system")
 	}
 
 	if options.EncryptionType != secboot.EncryptionTypeNone {

--- a/gadget/install/install_test.go
+++ b/gadget/install/install_test.go
@@ -3,7 +3,7 @@
 // +build !nosecboot
 
 /*
- * Copyright (C) 2019-2020 Canonical Ltd
+ * Copyright (C) 2019-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -69,7 +69,7 @@ func (s *installSuite) TestInstallRunError(c *C) {
 	c.Check(sys, IsNil)
 
 	sys, err = install.Run(&gadgettest.ModelCharacteristics{}, c.MkDir(), "", "", install.Options{}, nil, timings.New(nil))
-	c.Assert(err, ErrorMatches, `cannot run install mode on non-UC20\+ system`)
+	c.Assert(err, ErrorMatches, `cannot run install mode on pre-UC20 system`)
 	c.Check(sys, IsNil)
 }
 

--- a/image/image_linux.go
+++ b/image/image_linux.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2021 Canonical Ltd
+ * Copyright (C) 2014-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -73,7 +73,7 @@ func (custo *Customizations) validate(model *asserts.Model) error {
 	kind := "UC16/18"
 	switch {
 	case core20:
-		kind = "UC20"
+		kind = "UC20+"
 		// TODO:UC20: consider supporting these with grade dangerous?
 		unsupportedConsoleConfDisable()
 		if custo.CloudInitUserData != "" {

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2021 Canonical Ltd
+ * Copyright (C) 2014-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -1226,7 +1226,7 @@ func (s *imageSuite) TestPrepareUC20CustomizationsUnsupported(c *C) {
 			CloudInitUserData: "cloud-init-user-data",
 		},
 	})
-	c.Assert(err, ErrorMatches, `cannot support with UC20 model requested customizations: console-conf disable, cloud-init user-data`)
+	c.Assert(err, ErrorMatches, `cannot support with UC20\+ model requested customizations: console-conf disable, cloud-init user-data`)
 }
 
 func (s *imageSuite) TestPrepareClassicCustomizationsUnsupported(c *C) {

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2019 Canonical Ltd
+ * Copyright (C) 2016-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -879,7 +879,7 @@ func Remodel(st *state.State, new *asserts.Model) (*state.Change, error) {
 	if current.Grade() != new.Grade() {
 		if current.Grade() == asserts.ModelGradeUnset && new.Grade() != asserts.ModelGradeUnset {
 			// a case of pre-UC20 -> UC20 remodel
-			return nil, fmt.Errorf("cannot remodel to Ubuntu Core 20 models yet")
+			return nil, fmt.Errorf("cannot remodel from pre-UC20 to UC20+ models")
 		}
 		return nil, fmt.Errorf("cannot remodel from grade %v to grade %v", current.Grade(), new.Grade())
 	}

--- a/overlord/devicestate/devicestate_remodel_test.go
+++ b/overlord/devicestate/devicestate_remodel_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2021 Canonical Ltd
+ * Copyright (C) 2016-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -154,7 +154,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelUnhappy(c *C) {
 		{map[string]interface{}{"architecture": "pdp-7"}, "cannot remodel to different architectures yet"},
 		{map[string]interface{}{"base": "core18"}, "cannot remodel from core to bases yet"},
 		// pre-UC20 to UC20
-		{map[string]interface{}{"base": "core20", "kernel": nil, "gadget": nil, "snaps": mockCore20ModelSnaps}, "cannot remodel to Ubuntu Core 20 models yet"},
+		{map[string]interface{}{"base": "core20", "kernel": nil, "gadget": nil, "snaps": mockCore20ModelSnaps}, `cannot remodel from pre-UC20 to UC20\+ models`},
 	} {
 		mergeMockModelHeaders(cur, t.new)
 		new := s.brands.Model(t.new["brand"].(string), t.new["model"].(string), t.new)

--- a/overlord/devicestate/systems.go
+++ b/overlord/devicestate/systems.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2020 Canonical Ltd
+ * Copyright (C) 2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -210,7 +210,7 @@ type snapWriteObserveFunc func(systemDir, where string) error
 // systems on ubuntu-seed.
 func createSystemForModelFromValidatedSnaps(model *asserts.Model, label string, db asserts.RODatabase, getInfo getSnapInfoFunc, observeWrite snapWriteObserveFunc) (dir string, err error) {
 	if model.Grade() == asserts.ModelGradeUnset {
-		return "", fmt.Errorf("cannot create a system for non UC20 model")
+		return "", fmt.Errorf("cannot create a system for non-UC20+ model")
 	}
 
 	logger.Noticef("creating recovery system with label %q for %q", label, model.Model())

--- a/overlord/devicestate/systems.go
+++ b/overlord/devicestate/systems.go
@@ -210,7 +210,7 @@ type snapWriteObserveFunc func(systemDir, where string) error
 // systems on ubuntu-seed.
 func createSystemForModelFromValidatedSnaps(model *asserts.Model, label string, db asserts.RODatabase, getInfo getSnapInfoFunc, observeWrite snapWriteObserveFunc) (dir string, err error) {
 	if model.Grade() == asserts.ModelGradeUnset {
-		return "", fmt.Errorf("cannot create a system for non-UC20+ model")
+		return "", fmt.Errorf("cannot create a system for pre-UC20 model")
 	}
 
 	logger.Noticef("creating recovery system with label %q for %q", label, model.Model())

--- a/overlord/devicestate/systems_test.go
+++ b/overlord/devicestate/systems_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2021 Canonical Ltd
+ * Copyright (C) 2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -674,7 +674,7 @@ func (s *createSystemSuite) TestCreateSystemNonUC20(c *C) {
 	}
 	dir, err := devicestate.CreateSystemForModelFromValidatedSnaps(model, "1234", s.db,
 		infoGetter, snapWriteObserver)
-	c.Assert(err, ErrorMatches, `cannot create a system for non UC20 model`)
+	c.Assert(err, ErrorMatches, `cannot create a system for non-UC20\+ model`)
 	c.Check(dir, Equals, "")
 }
 

--- a/overlord/devicestate/systems_test.go
+++ b/overlord/devicestate/systems_test.go
@@ -674,7 +674,7 @@ func (s *createSystemSuite) TestCreateSystemNonUC20(c *C) {
 	}
 	dir, err := devicestate.CreateSystemForModelFromValidatedSnaps(model, "1234", s.db,
 		infoGetter, snapWriteObserver)
-	c.Assert(err, ErrorMatches, `cannot create a system for non-UC20\+ model`)
+	c.Assert(err, ErrorMatches, `cannot create a system for pre-UC20 model`)
 	c.Check(dir, Equals, "")
 }
 

--- a/seed/seedwriter/writer.go
+++ b/seed/seedwriter/writer.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2019-2021 Canonical Ltd
+ * Copyright (C) 2019-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -251,7 +251,7 @@ func New(model *asserts.Model, opts *Options) (*Writer, error) {
 	if model.Grade() != asserts.ModelGradeUnset {
 		// Core 20
 		if opts.Label == "" {
-			return nil, fmt.Errorf("internal error: cannot write Core 20 seed without Options.Label set")
+			return nil, fmt.Errorf("internal error: cannot write UC20+ seed without Options.Label set")
 		}
 		if err := asserts.IsValidSystemLabel(opts.Label); err != nil {
 			return nil, err


### PR DESCRIPTION
Use UC20+ instead of UC20.

Code comments and test-only strings are not touched here, for clarity they should be changed too, but it's a larger set and can wait.
