### PR TITLE
tests: install snapd while restoring in snap-mgmt

### DIFF
--- a/tests/main/snap-mgmt/task.yaml
+++ b/tests/main/snap-mgmt/task.yaml
@@ -74,12 +74,24 @@ prepare: |
         test "$(find /etc/systemd/system -name 'snap.*.slice' | wc -l)" -gt 0
     fi
 
+restore: |
+    #shellcheck source=tests/lib/pkgdb.sh
+    . "$TESTSLIB/pkgdb.sh"
+    if [ -e pkg-removed ]; then
+        distro_install_build_snapd
+        rm pkg-removed
+    fi
+
+debug: |
+    systemctl --no-legend --full | grep -E 'snap\..*\.(service|timer|socket|slice)' || true
+
 execute: |
     echo "Stop snapd before purging"
     systemctl stop snapd.service snapd.socket
 
     echo "A purge will really purge things"
     snapd.tool exec snap-mgmt --purge
+    touch pkg-removed
 
     echo "Data directories are empty"
     SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"


### PR DESCRIPTION
This change is to make sure the environent is ok and snapd is
functional.

The change is to make this test work similar to what we do in
postrm-purge.

Whith out this change, when other tests like auto-refresh-gating are
executed after, snapd fails when it is restarted. See the error:

Apr 29 17:40:43 apr291718-620032 systemd[1]: snapd.service: Succeeded.
Apr 29 17:40:43 apr291718-620032 systemd[1]: Stopped Snap Daemon.
Apr 29 17:40:43 apr291718-620032 systemd[1]: Starting Snap Daemon...
Apr 29 17:40:43 apr291718-620032 systemd[1]: Dependency failed for Snap
Daemon.
Apr 29 17:40:43 apr291718-620032 systemd[1]: snapd.service: Job
snapd.service/start failed with result 'dependency'.
Apr 29 17:40:43 apr291718-620032 systemd[1]: snapd.service: Triggering
OnFailure= dependencies.

To reproduce the error run:
google:centos-8-64:tests/main/snap-mgmt
google:centos-8-64:tests/main/auto-refresh-gating
