### PR TITLE
tests: skip mount-order-regression test on ubuntu-core for i386

### DIFF
--- a/tests/regression/mount-order-regression/task.yaml
+++ b/tests/regression/mount-order-regression/task.yaml
@@ -8,6 +8,8 @@ details: |
 systems:
   # there is no gnome-3-38-2004 for i386
   - -ubuntu-18.04-32
+  - -ubuntu-core-16-32
+  - -ubuntu-core-18-32
 
 environment:
     SNAP_NAME: test-content-layout-consumer


### PR DESCRIPTION
This is needed because gnome-3-38-2004 snap is not available for i386
and in beta validation it is also used the systems ubuntu-core-16-32 and
ubuntu-core-18-32
