### PR TITLE
.github: skip misspell and ineffassign on go 1.13

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -179,6 +179,10 @@ jobs:
               # and skip with other versions
               export SKIP_GOFMT=1
               echo "Formatting checks will be skipped due to the use of Go version ${{ matrix.gochannel }}"
+          else
+              # misspell and infessassign do not build with Go 1.13
+              export SKIP_MISSPELL=1
+              export SKIP_INEFFASSIGN=1
           fi
           sudo apt-get install -y python3-yamlordereddictloader
           ./run-checks --static

--- a/run-checks
+++ b/run-checks
@@ -221,24 +221,28 @@ if [ "$STATIC" = 1 ]; then
         ./tests/lib/external/snapd-testing-tools/utils/spread-shellcheck spread.yaml tests --exclude "$exclude_tools_path"
     fi
 
-    echo "Checking spelling errors"
-    if ! command -v misspell >/dev/null; then
-        goinstall github.com/client9/misspell/cmd/misspell
-    fi
-    # FIXME: auter is only misspelled in the changelog so we should fix there
-    # PROCES is used in the seccomp tests (PRIO_PROCES{,S,SS})
-    # exportfs is used in the nfs-support test
-    MISSPELL_IGNORE="auther,PROCES,PROCESSS,proces,processs,exportfs"
-    git ls-files -z -- . ':!:./po' ':!:./vendor' ':!:./c-vendor' ':!:./cmd/libsnap-confine-private/bpf/vendor' |
-        xargs -0 misspell -error -i "$MISSPELL_IGNORE"
-
-    if dpkg --compare-versions "$(go version | awk '$3 ~ /^go[0-9]/ {print substr($3, 3)}')" ge 1.12; then
-        echo "Checking for ineffective assignments"
-        if ! command -v ineffassign >/dev/null; then
-            goinstall github.com/gordonklaus/ineffassign
+    if [ -z "${SKIP_MISSPELL-}" ]; then
+        echo "Checking spelling errors"
+        if ! command -v misspell >/dev/null; then
+            goinstall github.com/client9/misspell/cmd/misspell
         fi
-        # ineffassign knows about ignoring vendor/ \o/
-        ineffassign ./...
+        # FIXME: auter is only misspelled in the changelog so we should fix there
+        # PROCES is used in the seccomp tests (PRIO_PROCES{,S,SS})
+        # exportfs is used in the nfs-support test
+        MISSPELL_IGNORE="auther,PROCES,PROCESSS,proces,processs,exportfs"
+        git ls-files -z -- . ':!:./po' ':!:./vendor' ':!:./c-vendor' ':!:./cmd/libsnap-confine-private/bpf/vendor' |
+            xargs -0 misspell -error -i "$MISSPELL_IGNORE"
+    fi
+
+    if [ -z "${SKIP_INEFFASSIGN-}" ]; then
+        if dpkg --compare-versions "$(go version | awk '$3 ~ /^go[0-9]/ {print substr($3, 3)}')" ge 1.12; then
+            echo "Checking for ineffective assignments"
+            if ! command -v ineffassign >/dev/null; then
+                goinstall github.com/gordonklaus/ineffassign
+            fi
+            # ineffassign knows about ignoring vendor/ \o/
+            ineffassign ./...
+        fi
     fi
 
     echo "Checking for naked returns"

--- a/tests/unit/go/task.yaml
+++ b/tests/unit/go/task.yaml
@@ -33,6 +33,10 @@ execute: |
         skip='SKIP_GOFMT=1'
     fi
 
+    if os.query is-xenial || os.query is-trusty || os.query is-bionic || os.query is-focal || ! os.query is-ubuntu; then
+        skip="${skip:-} SKIP_MISSPELL=1 SKIP_INEFFASSIGN=1"
+    fi
+
     if [[ -n "${SKIP_NAKEDRET:-}" ]]; then
         skip="${skip:-} SKIP_NAKEDRET=1"
     fi


### PR DESCRIPTION
A change in golang.org/x/sys broke build of misspell and ienffassign
on go 1.13.