### PR TITLE
tests: add lz4 dependency for jammy to avoid issues repacking kernel

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -628,6 +628,7 @@ pkg_dependencies_ubuntu_classic(){
                 fwupd
                 golang
                 linux-tools-$(uname -r)
+                lz4
                 qemu-utils
                 "
             ;;


### PR DESCRIPTION
The tests are failing to repack the kernel snap with the error
cpio: premature end of archive
This happens because the lz4 dependency is not installed in the system

Error:
+ cd repacked-kernel
+
unpackeddir=/home/gopath/src/github.com/snapcore/snapd/tests/main/abort/repacked-kernel
++ grep -Po 'config-\K.*'
++ ls config-5.15.0-27-generic
+ kver=5.15.0-27-generic
+ objcopy -j .initrd -O binary kernel.efi initrd
+ unmkinitramfs initrd unpacked-initrd
cpio: premature end of archive
