### PR TITLE
interfaces/apparmor: allow executing /usr/bin/numfmt in the base template

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -578,6 +578,7 @@ var defaultCoreRuntimeTemplateRules = `
   /{,usr/}bin/mv ixr,
   /{,usr/}bin/nice ixr,
   /{,usr/}bin/nohup ixr,
+  /{,usr/}bin/numfmt ixr,
   /{,usr/}bin/od ixr,
   /{,usr/}bin/openssl ixr, # may cause harmless capability block_suspend denial
   /{,usr/}bin/paste ixr,


### PR DESCRIPTION
Numfmt is a tool for formatting numbers. It should be allowed by the base
template.

Fixes: https://bugs.launchpad.net/bugs/1971074
