### PR TITLE
osutil/disks: helper for obtaining the UUID of a partition which is a mount point source

### DIFF
--- a/osutil/disks/disks_darwin.go
+++ b/osutil/disks/disks_darwin.go
@@ -66,3 +66,7 @@ var mountPointsForPartitionRoot = func(p Partition, opts map[string]string) ([]s
 var diskFromPartitionDeviceNode = func(node string) (Disk, error) {
 	return nil, osutil.ErrDarwin
 }
+
+func PartitionUUIDFromMountPoint(mountpoint string, opts *Options) (string, error) {
+	return "", osutil.ErrDarwin
+}

--- a/osutil/disks/disks_linux.go
+++ b/osutil/disks/disks_linux.go
@@ -276,7 +276,7 @@ var diskFromPartitionDeviceNode = func(node string) (Disk, error) {
 		return nil, err
 	}
 
-	disk, err := diskFromPartUDevProps(props, nil)
+	disk, err := diskFromPartUDevProps(props)
 	if err != nil {
 		return nil, fmt.Errorf("cannot find disk from partition device node %s: %v", node, err)
 	}
@@ -431,79 +431,74 @@ func (d *disk) Schema() string {
 	return d.schema
 }
 
-func diskFromPartUDevProps(props map[string]string, opts *Options) (*disk, error) {
-	if opts != nil && opts.IsDecryptedDevice {
-		// verify that the mount point is indeed a mapper device, it should:
-		// 1. have DEVTYPE == disk from udev
-		// 2. have dm files in the sysfs entry for the maj:min of the device
-		if props["DEVTYPE"] != "disk" {
-			// not a decrypted device
-			return nil, fmt.Errorf("not a decrypted device: devtype is not disk (is %s)", props["DEVTYPE"])
-		}
+func parentPartitionPropsForOptions(props map[string]string) (map[string]string, error) {
+	// verify that the mount point is indeed a mapper device, it should:
+	// 1. have DEVTYPE == disk from udev
+	// 2. have dm files in the sysfs entry for the maj:min of the device
+	if props["DEVTYPE"] != "disk" {
+		// not a decrypted device
+		return nil, fmt.Errorf("not a decrypted device: devtype is not disk (is %s)", props["DEVTYPE"])
+	}
 
-		// TODO:UC20: currently, we effectively parse the DM_UUID env variable
-		//            that is set for the mapper device volume, but doing so is
-		//            actually wrong, since the value of DM_UUID is an
-		//            implementation detail that depends on the subsystem
-		//            "owner" of the device such that the prefix is considered
-		//            the owner and the suffix is private data owned by the
-		//            subsystem. In our case, in UC20 initramfs, we have the
-		//            device "owned" by systemd-cryptsetup, so we should ideally
-		//            parse that the first part of DM_UUID matches CRYPT- and
-		//            then use `cryptsetup status` (since CRYPT indicates it is
-		//            "owned" by cryptsetup) to get more information on the
-		//            device sufficient for our purposes to find the encrypted
-		//            device/partition underneath the mapper.
-		//            However we don't currently have cryptsetup in the initrd,
-		//            so we can't do that yet :-(
+	// TODO:UC20: currently, we effectively parse the DM_UUID env variable
+	//            that is set for the mapper device volume, but doing so is
+	//            actually wrong, since the value of DM_UUID is an
+	//            implementation detail that depends on the subsystem
+	//            "owner" of the device such that the prefix is considered
+	//            the owner and the suffix is private data owned by the
+	//            subsystem. In our case, in UC20 initramfs, we have the
+	//            device "owned" by systemd-cryptsetup, so we should ideally
+	//            parse that the first part of DM_UUID matches CRYPT- and
+	//            then use `cryptsetup status` (since CRYPT indicates it is
+	//            "owned" by cryptsetup) to get more information on the
+	//            device sufficient for our purposes to find the encrypted
+	//            device/partition underneath the mapper.
+	//            However we don't currently have cryptsetup in the initrd,
+	//            so we can't do that yet :-(
 
-		// TODO:UC20: these files are also likely readable through udev env
-		//            properties, but it's unclear if reading there is reliable
-		//            or not, given that these variables have been observed to
-		//            be missing from the initrd previously, and are not
-		//            available at all during userspace on UC20 for some reason
-		errFmt := "not a decrypted device: could not read device mapper metadata: %v"
+	// TODO:UC20: these files are also likely readable through udev env
+	//            properties, but it's unclear if reading there is reliable
+	//            or not, given that these variables have been observed to
+	//            be missing from the initrd previously, and are not
+	//            available at all during userspace on UC20 for some reason
+	errFmt := "not a decrypted device: could not read device mapper metadata: %v"
 
-		if props["MAJOR"] == "" {
-			return nil, fmt.Errorf("incomplete udev output missing required property \"MAJOR\"")
-		}
-		if props["MINOR"] == "" {
-			return nil, fmt.Errorf("incomplete udev output missing required property \"MAJOR\"")
-		}
+	if props["MAJOR"] == "" {
+		return nil, fmt.Errorf("incomplete udev output missing required property \"MAJOR\"")
+	}
+	if props["MINOR"] == "" {
+		return nil, fmt.Errorf("incomplete udev output missing required property \"MAJOR\"")
+	}
 
-		majmin := props["MAJOR"] + ":" + props["MINOR"]
+	majmin := props["MAJOR"] + ":" + props["MINOR"]
 
-		dmDir := filepath.Join(dirs.SysfsDir, "dev", "block", majmin, "dm")
-		dmUUID, err := ioutil.ReadFile(filepath.Join(dmDir, "uuid"))
-		if err != nil {
-			return nil, fmt.Errorf(errFmt, err)
-		}
-		dmUUID = bytes.TrimSpace(dmUUID)
+	dmDir := filepath.Join(dirs.SysfsDir, "dev", "block", majmin, "dm")
+	dmUUID, err := ioutil.ReadFile(filepath.Join(dmDir, "uuid"))
+	if err != nil {
+		return nil, fmt.Errorf(errFmt, err)
+	}
+	dmUUID = bytes.TrimSpace(dmUUID)
 
-		dmName, err := ioutil.ReadFile(filepath.Join(dmDir, "name"))
-		if err != nil {
-			return nil, fmt.Errorf(errFmt, err)
-		}
-		dmName = bytes.TrimSpace(dmName)
+	dmName, err := ioutil.ReadFile(filepath.Join(dmDir, "name"))
+	if err != nil {
+		return nil, fmt.Errorf(errFmt, err)
+	}
+	dmName = bytes.TrimSpace(dmName)
 
-		matchedHandler := false
-		for _, resolver := range deviceMapperBackResolvers {
-			if dev, ok := resolver(dmUUID, dmName); ok {
-				props, err = udevPropertiesForName(dev)
-				if err != nil {
-					return nil, fmt.Errorf("cannot get udev properties for encrypted partition %s: %v", dev, err)
-				}
-
-				matchedHandler = true
-				break
+	for _, resolver := range deviceMapperBackResolvers {
+		if dev, ok := resolver(dmUUID, dmName); ok {
+			props, err = udevPropertiesForName(dev)
+			if err != nil {
+				return nil, fmt.Errorf("cannot get udev properties for encrypted partition %s: %v", dev, err)
 			}
-		}
-
-		if !matchedHandler {
-			return nil, fmt.Errorf("internal error: no back resolver supports decrypted device mapper with UUID %q and name %q", dmUUID, dmName)
+			return props, nil
 		}
 	}
 
+	return nil, fmt.Errorf("internal error: no back resolver supports decrypted device mapper with UUID %q and name %q", dmUUID, dmName)
+}
+
+func diskFromPartUDevProps(props map[string]string) (*disk, error) {
 	// ID_PART_ENTRY_DISK will give us the major and minor of the disk that this
 	// partition originated from if this mount point is indeed for a partition
 	if props["ID_PART_ENTRY_DISK"] == "" {
@@ -577,42 +572,58 @@ func diskFromPartUDevProps(props map[string]string, opts *Options) (*disk, error
 	return d, nil
 }
 
-// diskFromMountPointImpl returns a Disk for the underlying mount source of the
-// specified mount point. For mount points which have sources that are not
-// partitions, and thus are a part of a disk, the returned Disk refers to the
-// volume/disk of the mount point itself.
-func diskFromMountPointImpl(mountpoint string, opts *Options) (*disk, error) {
+func partitionPropsFromMountPoint(mountpoint string) (source string, props map[string]string, err error) {
 	// first get the mount entry for the mountpoint
 	mounts, err := osutil.LoadMountInfo()
 	if err != nil {
-		return nil, err
+		return "", nil, err
 	}
-	var partMountPointSource string
 	// loop over the mount entries in reverse order to prevent shadowing of a
 	// particular mount on top of another one
 	for i := len(mounts) - 1; i >= 0; i-- {
 		if mounts[i].MountDir == mountpoint {
-			partMountPointSource = mounts[i].MountSource
+			source = mounts[i].MountSource
 			break
 		}
 	}
-	if partMountPointSource == "" {
-		return nil, fmt.Errorf("cannot find mountpoint %q", mountpoint)
+	if source == "" {
+		return "", nil, fmt.Errorf("cannot find mountpoint %q", mountpoint)
 	}
 
 	// now we have the partition for this mountpoint, we need to tie that back
 	// to a disk with a major minor, so query udev with the mount source path
 	// of the mountpoint for properties
-	props, err := udevPropertiesForName(partMountPointSource)
+	props, err = udevPropertiesForName(source)
 	if err != nil && props == nil {
 		// only fail here if props is nil, if it's available we validate it
 		// below
-		return nil, fmt.Errorf("cannot find disk for partition %s: %v", partMountPointSource, err)
+		return "", nil, fmt.Errorf("cannot process udev properties of %s: %v", source, err)
+	}
+	return source, props, nil
+}
+
+// diskFromMountPointImpl returns a Disk for the underlying mount source of the
+// specified mount point. For mount points which have sources that are not
+// partitions, and thus are a part of a disk, the returned Disk refers to the
+// volume/disk of the mount point itself.
+func diskFromMountPointImpl(mountpoint string, opts *Options) (*disk, error) {
+	source, props, err := partitionPropsFromMountPoint(mountpoint)
+	if err != nil {
+		return nil, err
 	}
 
-	disk, err := diskFromPartUDevProps(props, opts)
+	if opts != nil && opts.IsDecryptedDevice {
+		props, err = parentPartitionPropsForOptions(props)
+		if err != nil {
+			return nil, fmt.Errorf("cannot process properties of %v parent device: %v", source, err)
+		}
+	}
+
+	disk, err := diskFromPartUDevProps(props)
 	if err != nil {
-		return nil, fmt.Errorf("cannot find disk from mountpoint source %s of %s: %v", partMountPointSource, mountpoint, err)
+		// TODO: leave the inclusion of mpointpoint source in the error
+		// to the caller
+		return nil, fmt.Errorf("cannot find disk from mountpoint source %s of %s: %v", source, mountpoint, err)
 	}
 	return disk, nil
 }
@@ -928,4 +939,26 @@ func AllPhysicalDisks() ([]Disk, error) {
 		disks = append(disks, disk)
 	}
 	return disks, nil
+}
+
+// PartitionUUIDFromMountPoint returns the UUID of the partition which is a
+// source of a given mount point.
+func PartitionUUIDFromMountPoint(mountpoint string, opts *Options) (string, error) {
+	_, props, err := partitionPropsFromMountPoint(mountpoint)
+	if err != nil {
+		return "", err
+	}
+
+	if opts != nil && opts.IsDecryptedDevice {
+		props, err = parentPartitionPropsForOptions(props)
+		if err != nil {
+			return "", err
+		}
+	}
+	partUUID := props["ID_PART_ENTRY_UUID"]
+	if partUUID == "" {
+		partDev := filepath.Join("/dev", props["DEVNAME"])
+		return "", fmt.Errorf("cannot get required partition UUID udev property for device %s", partDev)
+	}
+	return partUUID, nil
 }

--- a/osutil/disks/disks_linux_test.go
+++ b/osutil/disks/disks_linux_test.go
@@ -503,7 +503,7 @@ func (s *diskSuite) TestDiskFromMountPointUnhappyIsDecryptedDeviceNotDiskDevice(
 
 	opts := &disks.Options{IsDecryptedDevice: true}
 	_, err := disks.DiskFromMountPoint("/run/mnt/point", opts)
-	c.Assert(err, ErrorMatches, `cannot find disk from mountpoint source /dev/vda4 of /run/mnt/point: not a decrypted device: devtype is not disk \(is partition\)`)
+	c.Assert(err, ErrorMatches, `cannot process properties of /dev/vda4 parent device: not a decrypted device: devtype is not disk \(is partition\)`)
 }
 
 func (s *diskSuite) TestDiskFromMountPointUnhappyIsDecryptedDeviceNoSysfs(c *C) {
@@ -531,7 +531,7 @@ func (s *diskSuite) TestDiskFromMountPointUnhappyIsDecryptedDeviceNoSysfs(c *C) 
 
 	opts := &disks.Options{IsDecryptedDevice: true}
 	_, err := disks.DiskFromMountPoint("/run/mnt/point", opts)
-	c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot find disk from mountpoint source /dev/mapper/something of /run/mnt/point: not a decrypted device: could not read device mapper metadata: open %s/dev/block/252:0/dm/uuid: no such file or directory`, dirs.SysfsDir))
+	c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot process properties of /dev/mapper/something parent device: not a decrypted device: could not read device mapper metadata: open %s/dev/block/252:0/dm/uuid: no such file or directory`, dirs.SysfsDir))
 }
 
 func (s *diskSuite) TestDiskFromMountPointHappySinglePartitionIgnoresNonPartitionsInSysfs(c *C) {
@@ -761,7 +761,7 @@ func (s *diskSuite) TestDiskFromMountPointIsDecryptedLUKSDeviceVolumeHappy(c *C)
 	}()
 
 	_, err = disks.DiskFromMountPoint("/run/mnt/point", opts)
-	c.Assert(err, ErrorMatches, `cannot find disk from mountpoint source /dev/mapper/something of /run/mnt/point: internal error: no back resolver supports decrypted device mapper with UUID "CRYPT-LUKS2-5a522809c87e4dfa81a88dc5667d1304-something" and name "something"`)
+	c.Assert(err, ErrorMatches, `cannot process properties of /dev/mapper/something parent device: internal error: no back resolver supports decrypted device mapper with UUID "CRYPT-LUKS2-5a522809c87e4dfa81a88dc5667d1304-something" and name "something"`)
 
 	// but when it is available it works
 	disks.RegisterDeviceMapperBackResolver("crypt-luks2", disks.CryptLuks2DeviceMapperBackResolver)
@@ -851,7 +851,7 @@ func (s *diskSuite) TestDiskFromMountPointIsDecryptedUnlockedDeviceVolumeHappy(c
 
 	// first try without the handler fails
 	_, err = disks.DiskFromMountPoint("/run/mnt/point", opts)
-	c.Assert(err, ErrorMatches, `cannot find disk from mountpoint source /dev/mapper/something-device-locked of /run/mnt/point: internal error: no back resolver supports decrypted device mapper with UUID "5a522809-c87e-4dfa-81a8-8dc5667d1304" and name "something-device-locked"`)
+	c.Assert(err, ErrorMatches, `cannot process properties of /dev/mapper/something-device-locked parent device: internal error: no back resolver supports decrypted device mapper with UUID "5a522809-c87e-4dfa-81a8-8dc5667d1304" and name "something-device-locked"`)
 
 	// next try with the FDE package handler works
 	disks.RegisterDeviceMapperBackResolver("device-unlock-kernel-fde", fde.DeviceUnlockKernelHookDeviceMapperBackResolver)
@@ -2021,4 +2021,92 @@ func (s *diskSuite) TestAllPhysicalDisks(c *C) {
 	c.Assert(d[1].KernelDeviceNode(), Equals, "/dev/nvme0n1")
 	c.Assert(d[2].KernelDeviceNode(), Equals, "/dev/sda")
 	c.Assert(d[3].KernelDeviceNode(), Equals, "/dev/sdb")
+}
+
+func (s *diskSuite) TestPartitionUUIDFromMopuntPointErrs(c *C) {
+	restore := osutil.MockMountInfo(``)
+	defer restore()
+
+	_, err := disks.PartitionUUIDFromMountPoint("/run/mnt/blah", nil)
+	c.Assert(err, ErrorMatches, "cannot find mountpoint \"/run/mnt/blah\"")
+
+	restore = osutil.MockMountInfo(`130 30 42:1 / /run/mnt/point rw,relatime shared:54 - ext4 /dev/vda4 rw
+`)
+	defer restore()
+
+	restore = disks.MockUdevPropertiesForDevice(func(typeOpt, dev string) (map[string]string, error) {
+		c.Assert(typeOpt, Equals, "--name")
+		c.Assert(dev, Equals, "/dev/vda4")
+		return map[string]string{
+			"DEVNAME": "vda4",
+			"prop":    "hello",
+		}, nil
+	})
+	defer restore()
+
+	_, err = disks.PartitionUUIDFromMountPoint("/run/mnt/point", nil)
+	c.Assert(err, ErrorMatches, "cannot get required partition UUID udev property for device /dev/vda4")
+}
+
+func (s *diskSuite) TestPartitionUUIDFromMountPointPlain(c *C) {
+	restore := osutil.MockMountInfo(`130 30 42:1 / /run/mnt/point rw,relatime shared:54 - ext4 /dev/vda4 rw
+`)
+	defer restore()
+	restore = disks.MockUdevPropertiesForDevice(func(typeOpt, dev string) (map[string]string, error) {
+		c.Assert(typeOpt, Equals, "--name")
+		c.Assert(dev, Equals, "/dev/vda4")
+		return map[string]string{
+			"DEVTYPE":            "disk",
+			"ID_PART_ENTRY_UUID": "foo-uuid",
+		}, nil
+	})
+	defer restore()
+
+	uuid, err := disks.PartitionUUIDFromMountPoint("/run/mnt/point", nil)
+	c.Assert(err, IsNil)
+	c.Assert(uuid, Equals, "foo-uuid")
+}
+
+func (s *diskSuite) TestPartitionUUIDFromMopuntPointDecrypted(c *C) {
+	restore := osutil.MockMountInfo(`130 30 42:1 / /run/mnt/point rw,relatime shared:54 - ext4 /dev/mapper/something rw
+`)
+	defer restore()
+	restore = disks.MockUdevPropertiesForDevice(func(typeOpt, dev string) (map[string]string, error) {
+		c.Assert(typeOpt, Equals, "--name")
+		switch dev {
+		case "/dev/mapper/something":
+			return map[string]string{
+				"DEVTYPE": "disk",
+				"MAJOR":   "242",
+				"MINOR":   "1",
+			}, nil
+		case "/dev/disk/by-uuid/5a522809-c87e-4dfa-81a8-8dc5667d1304":
+			return map[string]string{
+				"ID_PART_ENTRY_UUID": "foo-uuid",
+			}, nil
+		default:
+			c.Errorf("unexpected udev device properties requested: %s", dev)
+			return nil, fmt.Errorf("unexpected udev device: %s", dev)
+		}
+	})
+	defer restore()
+
+	// mock the sysfs dm uuid and name files
+	dmDir := filepath.Join(filepath.Join(dirs.SysfsDir, "dev", "block"), "242:1", "dm")
+	err := os.MkdirAll(dmDir, 0755)
+	c.Assert(err, IsNil)
+
+	b := []byte("something")
+	err = ioutil.WriteFile(filepath.Join(dmDir, "name"), b, 0644)
+	c.Assert(err, IsNil)
+
+	b = []byte("CRYPT-LUKS2-5a522809c87e4dfa81a88dc5667d1304-something")
+	err = ioutil.WriteFile(filepath.Join(dmDir, "uuid"), b, 0644)
+	c.Assert(err, IsNil)
+
+	uuid, err := disks.PartitionUUIDFromMountPoint("/run/mnt/point", &disks.Options{
+		IsDecryptedDevice: true,
+	})
+	c.Assert(err, IsNil)
+	c.Assert(uuid, Equals, "foo-uuid")
 }


### PR DESCRIPTION
Helper for getting the partition UUID of a mount point source, which then can be
used to build /dev/disk/by-partuuid/<dev> path.
