### PR TITLE
interfaces: Allow locking in block-devices

### DIFF
--- a/interfaces/builtin/block_devices.go
+++ b/interfaces/builtin/block_devices.go
@@ -59,13 +59,13 @@ const blockDevicesConnectedPlugAppArmor = `
 /sys/devices/**/nvme/**/dev r,
 
 # Access to raw devices, not individual partitions
-/dev/hd[a-t] rw,                                          # IDE, MFM, RLL
-/dev/sd{,[a-h]}[a-z] rw,                                  # SCSI
-/dev/sdi[a-v] rw,                                         # SCSI continued
-/dev/i2o/hd{,[a-c]}[a-z] rw,                              # I2O hard disk
-/dev/i2o/hdd[a-x] rw,                                     # I2O hard disk continued
-/dev/mmcblk[0-9]{,[0-9],[0-9][0-9]} rw,                   # MMC (up to 1000 devices)
-/dev/vd[a-z] rw,                                          # virtio
+/dev/hd[a-t] rwk,                                          # IDE, MFM, RLL
+/dev/sd{,[a-h]}[a-z] rwk,                                  # SCSI
+/dev/sdi[a-v] rwk,                                         # SCSI continued
+/dev/i2o/hd{,[a-c]}[a-z] rwk,                              # I2O hard disk
+/dev/i2o/hdd[a-x] rwk,                                     # I2O hard disk continued
+/dev/mmcblk[0-9]{,[0-9],[0-9][0-9]} rwk,                   # MMC (up to 1000 devices)
+/dev/vd[a-z] rwk,                                          # virtio
 
 # Allow /dev/nvmeXnY namespace block devices. Please note this grants access to all
 # NVMe namespace block devices and that the numeric suffix on the character device
@@ -78,13 +78,13 @@ const blockDevicesConnectedPlugAppArmor = `
 #   controller's identifier. Do not assume any particular device relationship
 #   based on their names. If you do, you may irrevocably erase data on an
 #   unintended device.
-/dev/nvme{[0-9],[1-9][0-9]}n{[1-9],[1-5][0-9],6[0-3]} rw, # NVMe (up to 100 devices, with 1-63 namespaces)
+/dev/nvme{[0-9],[1-9][0-9]}n{[1-9],[1-5][0-9],6[0-3]} rwk, # NVMe (up to 100 devices, with 1-63 namespaces)
 
 # Allow /dev/nvmeX controller character devices. These character devices allow
 # manipulation of the block devices that we also allow above, so grouping this
 # access here makes sense, whereas access to individual partitions is delegated
 # to the raw-volume interface.
-/dev/nvme{[0-9],[1-9][0-9]} rw,                           # NVMe (up to 100 devices)
+/dev/nvme{[0-9],[1-9][0-9]} rwk,                           # NVMe (up to 100 devices)
 
 # SCSI device commands, et al
 capability sys_rawio,

--- a/interfaces/builtin/block_devices_test.go
+++ b/interfaces/builtin/block_devices_test.go
@@ -85,7 +85,7 @@ func (s *blockDevicesInterfaceSuite) TestAppArmorSpec(c *C) {
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `# Description: Allow write access to raw disk block devices.`)
-	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/dev/sd{,[a-h]}[a-z] rw,`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/dev/sd{,[a-h]}[a-z] rwk,`)
 }
 
 func (s *blockDevicesInterfaceSuite) TestUDevSpec(c *C) {


### PR DESCRIPTION
This is needed for microceph as ceph-osd requires locking the block
device it's using. As that's a pretty common pattern for software
writing to block devices, it's reasonable to just extend the existing
interface to allow it.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>