### PR TITLE
snapstate: do not auto-migrate to ~/Snap for core22 just yet

### DIFF
--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1323,41 +1323,59 @@ const (
 )
 
 func triggeredMigration(oldBase, newBase string, opts *dirMigrationOptions) migration {
-	// we're refreshing to a core22 revision
-	if atLeastCore22(newBase) {
-		if opts.MigratedToHidden && !opts.MigratedToExposedHome {
-			// ~/.snap migration already happened so initialize ~/Snap only
-			return home
-		}
+	if !opts.MigratedToHidden && opts.UseHidden {
+		// flag is set and not migrated yet
+		return hidden
+	}
 
-		if !opts.MigratedToHidden {
-			//  nothing was migrated yet, so migrate to ~/.snap and ~/Snap
-			return full
-		}
-	} else {
-		// going back from core22
-		if atLeastCore22(oldBase) {
-			if opts.MigratedToExposedHome && opts.MigratedToHidden && !opts.UseHidden {
-				return revertFull
-			}
-
-			if opts.MigratedToExposedHome && opts.MigratedToHidden && opts.UseHidden {
-				return disableHome
-			}
-		} else {
-			if !opts.MigratedToHidden && opts.UseHidden {
-				// flag is set and not migrated yet
-				return hidden
-			}
-
-			if opts.MigratedToHidden && !opts.UseHidden {
-				// migration was done but flag was unset
-				return revertHidden
-			}
-		}
+	if opts.MigratedToHidden && !opts.UseHidden {
+		// migration was done but flag was unset
+		return revertHidden
 	}
 
 	return none
+
+	/* TODO:Snap-folder:
+	             after a discussion during the May 2022 sprint with Copenhagen
+		     it was decided to not do the migration to ~/Snap for all
+		     snaps with "base: core22" but instead add an opt-in mechanism
+
+				// we're refreshing to a core22 revision
+				if atLeastCore22(newBase) {
+					if opts.MigratedToHidden && !opts.MigratedToExposedHome {
+						// ~/.snap migration already happened so initialize ~/Snap only
+						return home
+					}
+
+					if !opts.MigratedToHidden {
+						//  nothing was migrated yet, so migrate to ~/.snap and ~/Snap
+						return full
+					}
+				} else {
+					// going back from core22
+					if atLeastCore22(oldBase) {
+						if opts.MigratedToExposedHome && opts.MigratedToHidden && !opts.UseHidden {
+							return revertFull
+						}
+
+						if opts.MigratedToExposedHome && opts.MigratedToHidden && opts.UseHidden {
+							return disableHome
+						}
+					} else {
+						if !opts.MigratedToHidden && opts.UseHidden {
+							// flag is set and not migrated yet
+							return hidden
+						}
+
+						if opts.MigratedToHidden && !opts.UseHidden {
+							// migration was done but flag was unset
+							return revertHidden
+						}
+					}
+				}
+
+				return none
+	*/
 }
 
 // atLeastCore22 returns true if 'base' is core22 or newer. Returns

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -5175,6 +5175,8 @@ type: base
 }
 
 func (s *snapmgrTestSuite) TestMigrateOnInstallWithCore24(c *C) {
+	c.Skip("TODO:Snap-folder: no automatic migration for core22 snaps to ~/Snap folder for now")
+
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -5218,6 +5220,8 @@ func (s *snapmgrTestSuite) TestUndoMigrateOnInstallWithCore22OnExposedMigration(
 }
 
 func (s *snapmgrTestSuite) testUndoMigrateOnInstallWithCore22(c *C, expectSeqFile bool, prepFail prepFailFunc) {
+	c.Skip("TODO:Snap-folder: no automatic migration for core22 snaps to ~/Snap folder for now")
+
 	s.state.Lock()
 	defer s.state.Unlock()
 

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -2361,6 +2361,8 @@ func (s *snapmgrTestSuite) TestUndoRevertDoHiddenMigration(c *C) {
 }
 
 func (s *snapmgrTestSuite) TestRevertFromCore22WithSetFlagKeepMigration(c *C) {
+	c.Skip("TODO:Snap-folder: no automatic migration for core22 snaps to ~/Snap folder for now")
+
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -2425,6 +2427,8 @@ func (s *snapmgrTestSuite) TestRevertFromCore22WithSetFlagKeepMigration(c *C) {
 }
 
 func (s *snapmgrTestSuite) TestRevertToCore22WithoutFlagSet(c *C) {
+	c.Skip("TODO:Snap-folder: no automatic migration for core22 snaps to ~/Snap folder for now")
+
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -2491,6 +2495,8 @@ func (s *snapmgrTestSuite) TestRevertToCore22AfterRevertedFullMigration(c *C) {
 }
 
 func (s *snapmgrTestSuite) testRevertToCore22AfterRevertedMigration(c *C, migrationState *dirs.SnapDirOptions) {
+	c.Skip("TODO:Snap-folder: no automatic migration for core22 snaps to ~/Snap folder for now")
+
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -8150,6 +8156,8 @@ func (s *snapmgrTestSuite) TestRemodelAddGadgetAssetTasks(c *C) {
 }
 
 func (s *snapmgrTestSuite) TestMigrationTriggers(c *C) {
+	c.Skip("TODO:Snap-folder: no automatic migration for core22 snaps to ~/Snap folder for now")
+
 	testCases := []struct {
 		oldBase  string
 		newBase  string

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -7628,6 +7628,8 @@ func (s *snapmgrTestSuite) TestRevertMigration(c *C) {
 }
 
 func (s *snapmgrTestSuite) TestUpdateDoHiddenDirMigrationOnCore22(c *C) {
+	c.Skip("TODO:Snap-folder: no automatic migration for core22 snaps to ~/Snap folder for now")
+
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -7665,6 +7667,8 @@ func (s *snapmgrTestSuite) TestUpdateDoHiddenDirMigrationOnCore22(c *C) {
 }
 
 func (s *snapmgrTestSuite) TestUndoMigrationIfUpdateToCore22FailsAfterWritingState(c *C) {
+	c.Skip("TODO:Snap-folder: no automatic migration for core22 snaps to ~/Snap folder for now")
+
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -7722,6 +7726,8 @@ func (s *snapmgrTestSuite) TestUndoMigrationIfUpdateToCore22FailsAfterWritingSta
 }
 
 func (s *snapmgrTestSuite) TestUndoMigrationIfUpdateToCore22Fails(c *C) {
+	c.Skip("TODO:Snap-folder: no automatic migration for core22 snaps to ~/Snap folder for now")
+
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -7763,6 +7769,8 @@ func (s *snapmgrTestSuite) TestUndoMigrationIfUpdateToCore22Fails(c *C) {
 }
 
 func (s *snapmgrTestSuite) TestUpdateMigrateTurnOffFlagAndRefreshToCore22(c *C) {
+	c.Skip("TODO:Snap-folder: no automatic migration for core22 snaps to ~/Snap folder for now")
+
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -7803,6 +7811,8 @@ func (s *snapmgrTestSuite) TestUpdateMigrateTurnOffFlagAndRefreshToCore22(c *C) 
 }
 
 func (s *snapmgrTestSuite) TestUpdateMigrateTurnOffFlagAndRefreshToCore22ButFail(c *C) {
+	c.Skip("TODO:Snap-folder: no automatic migration for core22 snaps to ~/Snap folder for now")
+
 	s.state.Lock()
 	defer s.state.Unlock()
 

--- a/tests/main/hidden-snap-dir/task.yaml
+++ b/tests/main/hidden-snap-dir/task.yaml
@@ -174,6 +174,13 @@ execute: |
       exit 0
     fi
 
+
+    # TODO:Snap-folder: no automatic migration for core22 snaps to
+    # ~/Snap folder for now
+    #
+    echo "SKIP this part of the test"
+    exit 0
+    
     echo "Update snap to core22"
     # write a file in a default XDG dir so we can check it's migrated
     mkdir "$HOME/snap/$NAME/x2/.config"


### PR DESCRIPTION
During the roadmap sprint in Copenhagen we had a discussion about
the behavior of the ~/Snap folder migration. Unfortunately there
seems to have been some misunderstandings in the previous plan
and during the discussion it became apparent that is considered
to risky to migrate all the snaps with `base: core22`.

Instead we will most likely create an experimental option to
opt-in into the ~/Snap folder for selected snaps to get feedback
and gather data what snaps behave well and which are problematic.

Based on these results we will then decide if:
a) we do the migration at a future point automatically for all snaps
b) if allow snaps to opt-in into the migration via a flag in snap.yaml
c) migrate with core24

This is an initial commit to remove the current automatic migration
for core22 based snaps. We need to act quickly here to ensure
as few snaps as possible have migrated already (but there really
should be none because snapcraft does not allow building
`base: core22` snaps yet in their stable channel).


Draft for now as the spread tests will need tweaking but it's hard
for me to run them locally while traveling.