### PR TITLE
secboot/keymgr: remove recovery key, authorize with existing key

### DIFF
--- a/secboot/keymgr/keymgr_luks2.go
+++ b/secboot/keymgr/keymgr_luks2.go
@@ -134,6 +134,12 @@ func RemoveRecoveryKeyFromLUKSDevice(dev string) error {
 	if err != nil {
 		return err
 	}
+	return RemoveRecoveryKeyFromLUKSDeviceUsingKey(currKey, dev)
+}
+
+// RemoveRecoveryKeyFromLUKSDeviceUsingKey removes an existing recovery key a
+// LUKS2 using the provided key to authorize the operation.
+func RemoveRecoveryKeyFromLUKSDeviceUsingKey(currKey keys.EncryptionKey, dev string) error {
 	// just remove the key we think is a recovery key (luks keyslot 1)
 	if err := luks2.KillSlot(dev, recoveryKeySlot, currKey); err != nil {
 		if !isKeyslotNotActive(err) {


### PR DESCRIPTION
Add another helper to remove a recovery key, but authorize the operation with an existing key. The use case is removal of a recovery key from ubuntu-save in a run mode system, where the ubuntu-save key isn't in the kernel keyring, but rather is readily available on disk.
