### PR TITLE
deps: bump libseccomp to include build fixes, run unit tests using CC=clang

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/mvo5/goconfigparser v0.0.0-20200803085309-72e476556adb
 	// if below two libseccomp-golang lines are updated, one must also update packaging/ubuntu-14.04/rules
 	github.com/mvo5/libseccomp-golang v0.9.1-0.20180308152521-f4de83b52afb // old trusty builds only
-	github.com/seccomp/libseccomp-golang v0.9.2-0.20210917151616-9da99da69b1b
+	github.com/seccomp/libseccomp-golang v0.9.2-0.20220502024300-f57e1d55ea18
 	github.com/snapcore/bolt v1.3.2-0.20210908134111-63c8bfcf7af8
 	github.com/snapcore/go-gettext v0.0.0-20191107141714-82bbea49e785
 	github.com/snapcore/secboot v0.0.0-20211018143212-802bb19ca263

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ github.com/rogpeppe/clock v0.0.0-20190514195947-2896927a307a h1:3QH7VyOaaiUHNrA9
 github.com/rogpeppe/clock v0.0.0-20190514195947-2896927a307a/go.mod h1:4r5QyqhjIWCcK8DO4KMclc5Iknq5qVBAlbYYzAbUScQ=
 github.com/seccomp/libseccomp-golang v0.9.2-0.20210917151616-9da99da69b1b h1:x1CNwq9AHu5YhO+igGGZ4ov+eKU0U3kaiZCymcVUdSk=
 github.com/seccomp/libseccomp-golang v0.9.2-0.20210917151616-9da99da69b1b/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
+github.com/seccomp/libseccomp-golang v0.9.2-0.20220502024300-f57e1d55ea18 h1:A15Ffi2aT/BtygokOpAI0Diwrw8PTHuDwaAN5C48s74=
+github.com/seccomp/libseccomp-golang v0.9.2-0.20220502024300-f57e1d55ea18/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
 github.com/snapcore/bolt v1.3.2-0.20210908134111-63c8bfcf7af8 h1:WmyDfH38e3MaMWrMCO5YpW96BANq5Ti2iwbliM/xTW0=
 github.com/snapcore/bolt v1.3.2-0.20210908134111-63c8bfcf7af8/go.mod h1:Z6z3sf12AMDjT/4tbT/PmzzdACAxkWGhkuKWiVpTWLM=
 github.com/snapcore/go-gettext v0.0.0-20191107141714-82bbea49e785 h1:PaunR+BhraKSLxt2awQ42zofkP+NKh/VjQ0PjIMk/y4=

--- a/tests/unit/go/task.yaml
+++ b/tests/unit/go/task.yaml
@@ -63,10 +63,13 @@ execute: |
                 ./run-checks --unit"
         fi
     else
+        # on 14.04 we need to use a fork of libseccomp-golang
+        sed -i 's|\"github.com/seccomp/libseccomp-golang\"|\"github.com/mvo5/libseccomp-golang\"|' \
+            /tmp/static-unit-tests/src/github.com/snapcore/snapd/cmd/snap-seccomp/*.go
+
         if [ "$VARIANT" = "static" ] ; then
             # 14.04 only
             su -l -c "cd /tmp/static-unit-tests/src/github.com/snapcore/snapd && \
-                sed -i 's|\"github.com/seccomp/libseccomp-golang\"|\"github.com/mvo5/libseccomp-golang\"|' cmd/snap-seccomp/*.go && \
                 PATH=$PATH \
                 GOPATH=/tmp/static-unit-tests \
                 ${skip:-} \

--- a/tests/unit/go/task.yaml
+++ b/tests/unit/go/task.yaml
@@ -7,6 +7,11 @@ priority: 1000
 # want to run the tests there at the same time, we should not run into problems
 # with delayed session cleanup on this system
 
+environment:
+    VARIANT/clang: clang
+    VARIANT/gcc: gcc
+    VARIANT/static: static
+
 prepare: |
     if not os.query is-trusty; then
         tests.session -u test prepare
@@ -42,31 +47,37 @@ execute: |
     fi
 
     if not os.query is-trusty; then
-        tests.session -u test exec sh -c "cd /tmp/static-unit-tests/src/github.com/snapcore/snapd && \
-            PATH=$PATH \
-            GOPATH=/tmp/static-unit-tests \
-            ${skip:-} \
-            SKIP_TESTS_FORMAT_CHECK=1 \
-            ./run-checks --static"
-
-        tests.session -u test exec sh -c "cd /tmp/static-unit-tests/src/github.com/snapcore/snapd && \
-            PATH=$PATH \
-            GOPATH=/tmp/static-unit-tests \
-            SKIP_COVERAGE=1 \
-            ./run-checks --unit"
+        if [ "$VARIANT" = "static" ] ; then
+            tests.session -u test exec sh -c "cd /tmp/static-unit-tests/src/github.com/snapcore/snapd && \
+                PATH=$PATH \
+                GOPATH=/tmp/static-unit-tests \
+                ${skip:-} \
+                SKIP_TESTS_FORMAT_CHECK=1 \
+                ./run-checks --static"
+        else
+            tests.session -u test exec sh -c "cd /tmp/static-unit-tests/src/github.com/snapcore/snapd && \
+                PATH=$PATH \
+                GOPATH=/tmp/static-unit-tests \
+                SKIP_COVERAGE=1 \
+                CC=$VARIANT \
+                ./run-checks --unit"
+        fi
     else
-        # 14.04 only
-        su -l -c "cd /tmp/static-unit-tests/src/github.com/snapcore/snapd && \
-            sed -i 's|\"github.com/seccomp/libseccomp-golang\"|\"github.com/mvo5/libseccomp-golang\"|' cmd/snap-seccomp/*.go && \
-            PATH=$PATH \
-            GOPATH=/tmp/static-unit-tests \
-            ${skip:-} \
-            SKIP_TESTS_FORMAT_CHECK=1 \
-            ./run-checks --static" test
-
-        su -l -c "cd /tmp/static-unit-tests/src/github.com/snapcore/snapd && \
-            PATH=$PATH \
-            GOPATH=/tmp/static-unit-tests \
-            SKIP_COVERAGE=1 \
-            ./run-checks --unit" test
+        if [ "$VARIANT" = "static" ] ; then
+            # 14.04 only
+            su -l -c "cd /tmp/static-unit-tests/src/github.com/snapcore/snapd && \
+                sed -i 's|\"github.com/seccomp/libseccomp-golang\"|\"github.com/mvo5/libseccomp-golang\"|' cmd/snap-seccomp/*.go && \
+                PATH=$PATH \
+                GOPATH=/tmp/static-unit-tests \
+                ${skip:-} \
+                SKIP_TESTS_FORMAT_CHECK=1 \
+                ./run-checks --static" test
+        else
+            su -l -c "cd /tmp/static-unit-tests/src/github.com/snapcore/snapd && \
+                PATH=$PATH \
+                GOPATH=/tmp/static-unit-tests \
+                SKIP_COVERAGE=1 \
+                CC=$VARIANT \
+                ./run-checks --unit" test
+        fi
     fi

--- a/tests/unit/go/task.yaml
+++ b/tests/unit/go/task.yaml
@@ -67,6 +67,18 @@ execute: |
         sed -i 's|\"github.com/seccomp/libseccomp-golang\"|\"github.com/mvo5/libseccomp-golang\"|' \
             /tmp/static-unit-tests/src/github.com/snapcore/snapd/cmd/snap-seccomp/*.go
 
+        if [ "$VARIANT" = "clang" ]; then
+            # clang is more picky about duplicate values in switch statements,
+            # and the fork has some unresolved issues which fail the build with like so:
+            #
+            # ../../../../pkg/mod/github.com/mvo5/libseccomp-golang@v0.9.1-0.20180308152521-f4de83b52afb/seccomp_internal.go:404:2: duplicate case _Ciconst_C_ARCH_MIPS (value 4294967295) in switch
+            # 	previous case at $WORK/b338/_cgo_gotypes.go:75:7
+            # ../../../../pkg/mod/github.com/mvo5/libseccomp-golang@v0.9.1-0.20180308152521-f4de83b52afb/seccomp_internal.go:406:2: duplicate case _Ciconst_C_ARCH_MIPS64 (value 4294967295) in switch
+            # 	previous case at $WORK/b338/_cgo_gotypes.go:75:7
+            echo "skipping"
+            exit 0
+        fi
+
         if [ "$VARIANT" = "static" ] ; then
             # 14.04 only
             su -l -c "cd /tmp/static-unit-tests/src/github.com/snapcore/snapd && \


### PR DESCRIPTION
See https://github.com/seccomp/libseccomp-golang/pull/85 for details. Also fixes
https://github.com/seccomp/libseccomp-golang/issues/89.

Fixes: https://bugs.launchpad.net/bugs/1972119

This is a list of changes in libseccomp-golang: https://github.com/seccomp/libseccomp-golang/compare/9da99da69b1b425f6e8ebb86fa61a656b84c6dcd...f57e1d55ea18cbace22a9eefbd5e83417a2c1ace