### PR TITLE
wrappers: refactor EnsureSnapServices

### DIFF
--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -510,24 +510,27 @@ func (es ensureSnapServicesContext) restore() {
 		if state == nil {
 			// we don't have anything to rollback to, so just remove the
 			// file
-			if e := os.Remove(file); e != nil {
-				es.inter.Notify(fmt.Sprintf("while trying to remove %s due to previous failure: %v", file, e))
+			if err := os.Remove(file); err != nil {
+				es.inter.Notify(fmt.Sprintf("while trying to remove %s due to previous failure: %v", file, err))
 			}
 		} else {
 			// rollback the file to the previous state
-			if e := osutil.EnsureFileState(file, state); e != nil {
-				es.inter.Notify(fmt.Sprintf("while trying to rollback %s due to previous failure: %v", file, e))
+			if err := osutil.EnsureFileState(file, state); err != nil {
+				es.inter.Notify(fmt.Sprintf("while trying to rollback %s due to previous failure: %v", file, err))
 			}
 		}
 	}
-	if es.modifiedSystem && !es.opts.Preseeding {
-		if e := es.sysd.DaemonReload(); e != nil {
-			es.inter.Notify(fmt.Sprintf("while trying to perform systemd daemon-reload due to previous failure: %v", e))
+
+	if !es.opts.Preseeding {
+		if es.modifiedSystem {
+			if err := es.sysd.DaemonReload(); err != nil {
+				es.inter.Notify(fmt.Sprintf("while trying to perform systemd daemon-reload due to previous failure: %v", err))
+			}
 		}
-	}
-	if es.modifiedUser && !es.opts.Preseeding {
-		if e := userDaemonReload(); e != nil {
-			es.inter.Notify(fmt.Sprintf("while trying to perform user systemd daemon-reload due to previous failure: %v", e))
+		if es.modifiedUser {
+			if err := userDaemonReload(); err != nil {
+				es.inter.Notify(fmt.Sprintf("while trying to perform user systemd daemon-reload due to previous failure: %v", err))
+			}
 		}
 	}
 }

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -474,12 +474,10 @@ type EnsureSnapServicesOptions struct {
 // ensureSnapServicesContext is the context for EnsureSnapServices.
 // EnsureSnapServices supports transactional update/write of systemd service
 // files and slice files. A part of this is to support rollback of files and
-// also keep track of whether a restart of systemd daemon is required. To encapsulate
-// some of this functionality, the following structure has been defined which keeps
-// state and arguments required to easier allow a splitup of the code.
+// also keep track of whether a restart of systemd daemon is required.
 type ensureSnapServicesContext struct {
 	// snaps, observeChange, opts and inter are the arguments
-	// taken in in EnsureSnapServices. They are here to allow sub-functions
+	// taken by EnsureSnapServices. They are here to allow sub-functions
 	// to easier access these, and keep parameter lists shorter.
 	snaps         map[*snap.Info]*SnapServiceOptions
 	observeChange ObserveChangeCallback

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -489,7 +489,7 @@ type ensureSnapServicesContext struct {
 	// note: is not used when preseeding is set in opts.Preseeding
 	sysd systemd.Systemd
 	// modifiedSystem/modifiedUser keeps track of whether a systemd
-	// daemon reload is neccessary, either for the system level and/or user level.
+	// daemon reload is necessary, either for the system level and/or user level.
 	modifiedSystem bool
 	modifiedUser   bool
 	// modifiedFiles is the set of units that were modified and the previous

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -471,6 +471,240 @@ type EnsureSnapServicesOptions struct {
 	RequireMountedSnapdSnap bool
 }
 
+// ensureSnapServicesContext is the context for the EnsureSnapServices.
+// EnsureSnapServices supports transactional update/write of systemd service
+// files and slice files. A part of this is to support rollback of files and
+// also keep track of whether a restart of systemd daemon is required. To encapsulate
+// some of this functionality, the following structure has been defined which keeps
+// state and arguments required to easier allow a splitup of the code.
+type ensureSnapServicesContext struct {
+	// snaps, observeChange, opts and inter are the arguments
+	// taken in in EnsureSnapServices. They are here to allow sub-functions
+	// to easier access these, and keep parameter lists shorter.
+	snaps         map[*snap.Info]*SnapServiceOptions
+	observeChange ObserveChangeCallback
+	opts          *EnsureSnapServicesOptions
+	inter         Interacter
+
+	// note: is not used when preseeding is set in opts.Preseeding
+	sysd systemd.Systemd
+	// modifiedSystem/modifiedUser keeps track of whether a systemd
+	// daemon reload is neccessary, either for the system level and/or user level.
+	modifiedSystem bool
+	modifiedUser   bool
+	// modifiedFiles is the set of units that were modified and the previous
+	// state of the unit before modification that we can roll back to if there
+	// are any issues.
+	// note that the rollback is best effort, if we are rebooted in the middle,
+	// there is no guarantee about the state of files, some may have been
+	// updated and some may have been rolled back, higher level tasks/changes
+	// should have do/undo handlers to properly handle the case where this
+	// function is interrupted midway
+	modifiedFiles map[string]*osutil.MemoryFileState
+}
+
+// restore is a helper function which should be called in case any errors happen
+// during the write/update of systemd files
+func (es ensureSnapServicesContext) restore() {
+	for file, state := range es.modifiedFiles {
+		if state == nil {
+			// we don't have anything to rollback to, so just remove the
+			// file
+			if e := os.Remove(file); e != nil {
+				es.inter.Notify(fmt.Sprintf("while trying to remove %s due to previous failure: %v", file, e))
+			}
+		} else {
+			// rollback the file to the previous state
+			if e := osutil.EnsureFileState(file, state); e != nil {
+				es.inter.Notify(fmt.Sprintf("while trying to rollback %s due to previous failure: %v", file, e))
+			}
+		}
+	}
+	if es.modifiedSystem && !es.opts.Preseeding {
+		if e := es.sysd.DaemonReload(); e != nil {
+			es.inter.Notify(fmt.Sprintf("while trying to perform systemd daemon-reload due to previous failure: %v", e))
+		}
+	}
+	if es.modifiedUser && !es.opts.Preseeding {
+		if e := userDaemonReload(); e != nil {
+			es.inter.Notify(fmt.Sprintf("while trying to perform user systemd daemon-reload due to previous failure: %v", e))
+		}
+	}
+}
+
+// reloadModified uses the modifiedSystem/modifiedUser to determine whether a reload
+// is required from systemd to take the new systemd files into effect. This is a NOP
+// if preseeding is set in opts.Preseeding
+func (es ensureSnapServicesContext) reloadModified() error {
+	if !es.opts.Preseeding {
+		if es.modifiedSystem {
+			if err := es.sysd.DaemonReload(); err != nil {
+				return err
+			}
+		}
+		if es.modifiedUser {
+			if err := userDaemonReload(); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// ensureSnapAppsSystemdServices takes care of writing .service files for all services
+// registered in snap.Info apps.
+func ensureSnapAppsSystemdServices(context *ensureSnapServicesContext, snapInfo *snap.Info, opts *AddSnapServicesOptions) error {
+	handleFileModification := func(app *snap.AppInfo, unitType string, name, path string, content []byte) error {
+		old, modifiedFile, err := tryFileUpdate(path, content)
+		if err != nil {
+			return err
+		}
+
+		if modifiedFile {
+			if context.observeChange != nil {
+				var oldContent []byte
+				if old != nil {
+					oldContent = old.Content
+				}
+				context.observeChange(app, nil, unitType, name, string(oldContent), string(content))
+			}
+			context.modifiedFiles[path] = old
+
+			// also mark that we need to reload either the system or
+			// user instance of systemd
+			switch app.DaemonScope {
+			case snap.SystemDaemon:
+				context.modifiedSystem = true
+			case snap.UserDaemon:
+				context.modifiedUser = true
+			}
+		}
+
+		return nil
+	}
+
+	// note that the Preseeding option is not used here at all
+	for _, app := range snapInfo.Apps {
+		if !app.IsService() {
+			continue
+		}
+
+		// create services first; this doesn't trigger systemd
+
+		// Generate new service file state
+		path := app.ServiceFile()
+		content, err := generateSnapServiceFile(app, opts)
+		if err != nil {
+			return err
+		}
+
+		if err := handleFileModification(app, "service", app.Name, path, content); err != nil {
+			return err
+		}
+
+		// Generate systemd .socket files if needed
+		socketFiles, err := generateSnapSocketFiles(app)
+		if err != nil {
+			return err
+		}
+		for name, content := range socketFiles {
+			path := app.Sockets[name].File()
+			if err := handleFileModification(app, "socket", name, path, content); err != nil {
+				return err
+			}
+		}
+
+		if app.Timer != nil {
+			content, err := generateSnapTimerFile(app)
+			if err != nil {
+				return err
+			}
+			path := app.Timer.File()
+			if err := handleFileModification(app, "timer", "", path, content); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// ensureSnapsSystemdServices takes care of writing .service files for all apps in the provided snaps
+// list, and also returns a quota group set that represents all quota groups for the set of snaps
+// provided if they are a part of any.
+func ensureSnapsSystemdServices(context *ensureSnapServicesContext) (*quota.QuotaGroupSet, error) {
+	neededQuotaGrps := &quota.QuotaGroupSet{}
+
+	for s, snapSvcOpts := range context.snaps {
+		if s.Type() == snap.TypeSnapd {
+			return nil, fmt.Errorf("internal error: adding explicit services for snapd snap is unexpected")
+		}
+
+		// always use RequireMountedSnapdSnap options from the global options
+		genServiceOpts := &AddSnapServicesOptions{
+			RequireMountedSnapdSnap: context.opts.RequireMountedSnapdSnap,
+		}
+		if snapSvcOpts != nil {
+			// and if there are per-snap options specified, use that for
+			// VitalityRank
+			genServiceOpts.VitalityRank = snapSvcOpts.VitalityRank
+			genServiceOpts.QuotaGroup = snapSvcOpts.QuotaGroup
+
+			if snapSvcOpts.QuotaGroup != nil {
+				if err := neededQuotaGrps.AddAllNecessaryGroups(snapSvcOpts.QuotaGroup); err != nil {
+					// this error can basically only be a circular reference
+					// in the quota group tree
+					return nil, err
+				}
+			}
+		}
+
+		if err := ensureSnapAppsSystemdServices(context, s, genServiceOpts); err != nil {
+			return nil, err
+		}
+	}
+	return neededQuotaGrps, nil
+}
+
+func ensureSnapSlices(context *ensureSnapServicesContext, quotaGroups *quota.QuotaGroupSet) error {
+	handleSliceModification := func(grp *quota.Group, path string, content []byte) error {
+		old, modifiedFile, err := tryFileUpdate(path, content)
+		if err != nil {
+			return err
+		}
+
+		if modifiedFile {
+			if context.observeChange != nil {
+				var oldContent []byte
+				if old != nil {
+					oldContent = old.Content
+				}
+				context.observeChange(nil, grp, "slice", grp.Name, string(oldContent), string(content))
+			}
+
+			context.modifiedFiles[path] = old
+
+			// also mark that we need to reload the system instance of systemd
+			// TODO: also handle reloading the user instance of systemd when
+			// needed
+			context.modifiedSystem = true
+		}
+
+		return nil
+	}
+
+	// now make sure that all of the slice units exist
+	for _, grp := range quotaGroups.AllQuotaGroups() {
+		content := generateGroupSliceFile(grp)
+
+		sliceFileName := grp.SliceFileName()
+		path := filepath.Join(dirs.SnapServicesDir, sliceFileName)
+		if err := handleSliceModification(grp, path, content); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // EnsureSnapServices will ensure that the specified snap services' file states
 // are up to date with the specified options and infos. It will add new services
 // if those units don't already exist, but it does not delete existing service
@@ -489,209 +723,37 @@ type EnsureSnapServicesOptions struct {
 // if the function did not return an error.
 // This function is idempotent.
 func EnsureSnapServices(snaps map[*snap.Info]*SnapServiceOptions, opts *EnsureSnapServicesOptions, observeChange ObserveChangeCallback, inter Interacter) (err error) {
-	// note, sysd is not used when preseeding
-	sysd := systemd.New(systemd.SystemMode, inter)
-
 	if opts == nil {
 		opts = &EnsureSnapServicesOptions{}
 	}
 
-	// we only consider the global EnsureSnapServicesOptions to decide if we
-	// are preseeding or not to reduce confusion about which set of options
-	// determines whether we are preseeding or not during the ensure operation
-	preseeding := opts.Preseeding
-
-	// modifiedUnitsPreviousState is the set of units that were modified and the previous
-	// state of the unit before modification that we can roll back to if there
-	// are any issues.
-	// note that the rollback is best effort, if we are rebooted in the middle,
-	// there is no guarantee about the state of files, some may have been
-	// updated and some may have been rolled back, higher level tasks/changes
-	// should have do/undo handlers to properly handle the case where this
-	// function is interrupted midway
-	modifiedUnitsPreviousState := make(map[string]*osutil.MemoryFileState)
-	var modifiedSystem, modifiedUser bool
+	context := &ensureSnapServicesContext{
+		snaps:         snaps,
+		observeChange: observeChange,
+		opts:          opts,
+		inter:         inter,
+		sysd:          systemd.New(systemd.SystemMode, inter),
+		modifiedFiles: make(map[string]*osutil.MemoryFileState),
+	}
 
 	defer func() {
 		if err == nil {
 			return
 		}
-		for file, state := range modifiedUnitsPreviousState {
-			if state == nil {
-				// we don't have anything to rollback to, so just remove the
-				// file
-				if e := os.Remove(file); e != nil {
-					inter.Notify(fmt.Sprintf("while trying to remove %s due to previous failure: %v", file, e))
-				}
-			} else {
-				// rollback the file to the previous state
-				if e := osutil.EnsureFileState(file, state); e != nil {
-					inter.Notify(fmt.Sprintf("while trying to rollback %s due to previous failure: %v", file, e))
-				}
-			}
-		}
-		if modifiedSystem && !preseeding {
-			if e := sysd.DaemonReload(); e != nil {
-				inter.Notify(fmt.Sprintf("while trying to perform systemd daemon-reload due to previous failure: %v", e))
-			}
-		}
-		if modifiedUser && !preseeding {
-			if e := userDaemonReload(); e != nil {
-				inter.Notify(fmt.Sprintf("while trying to perform user systemd daemon-reload due to previous failure: %v", e))
-			}
-		}
+		context.restore()
 	}()
 
-	handleFileModification := func(app *snap.AppInfo, unitType string, name, path string, content []byte) error {
-		old, modifiedFile, err := tryFileUpdate(path, content)
-		if err != nil {
-			return err
-		}
-
-		if modifiedFile {
-			if observeChange != nil {
-				var oldContent []byte
-				if old != nil {
-					oldContent = old.Content
-				}
-				observeChange(app, nil, unitType, name, string(oldContent), string(content))
-			}
-			modifiedUnitsPreviousState[path] = old
-
-			// also mark that we need to reload either the system or
-			// user instance of systemd
-			switch app.DaemonScope {
-			case snap.SystemDaemon:
-				modifiedSystem = true
-			case snap.UserDaemon:
-				modifiedUser = true
-			}
-		}
-
-		return nil
+	quotaGroups, err := ensureSnapsSystemdServices(context)
+	if err != nil {
+		return err
 	}
 
-	neededQuotaGrps := &quota.QuotaGroupSet{}
-
-	for s, snapSvcOpts := range snaps {
-		if s.Type() == snap.TypeSnapd {
-			return fmt.Errorf("internal error: adding explicit services for snapd snap is unexpected")
-		}
-
-		// always use RequireMountedSnapdSnap options from the global options
-		genServiceOpts := &AddSnapServicesOptions{
-			RequireMountedSnapdSnap: opts.RequireMountedSnapdSnap,
-		}
-		if snapSvcOpts != nil {
-			// and if there are per-snap options specified, use that for
-			// VitalityRank
-			genServiceOpts.VitalityRank = snapSvcOpts.VitalityRank
-			genServiceOpts.QuotaGroup = snapSvcOpts.QuotaGroup
-
-			if snapSvcOpts.QuotaGroup != nil {
-				if err := neededQuotaGrps.AddAllNecessaryGroups(snapSvcOpts.QuotaGroup); err != nil {
-					// this error can basically only be a circular reference
-					// in the quota group tree
-					return err
-				}
-			}
-		}
-		// note that the Preseeding option is not used here at all
-
-		for _, app := range s.Apps {
-			if !app.IsService() {
-				continue
-			}
-
-			// create services first; this doesn't trigger systemd
-
-			// Generate new service file state
-			path := app.ServiceFile()
-			content, err := generateSnapServiceFile(app, genServiceOpts)
-			if err != nil {
-				return err
-			}
-
-			if err := handleFileModification(app, "service", app.Name, path, content); err != nil {
-				return err
-			}
-
-			// Generate systemd .socket files if needed
-			socketFiles, err := generateSnapSocketFiles(app)
-			if err != nil {
-				return err
-			}
-			for name, content := range socketFiles {
-				path := app.Sockets[name].File()
-				if err := handleFileModification(app, "socket", name, path, content); err != nil {
-					return err
-				}
-			}
-
-			if app.Timer != nil {
-				content, err := generateSnapTimerFile(app)
-				if err != nil {
-					return err
-				}
-				path := app.Timer.File()
-				if err := handleFileModification(app, "timer", "", path, content); err != nil {
-					return err
-				}
-			}
-		}
+	err = ensureSnapSlices(context, quotaGroups)
+	if err != nil {
+		return err
 	}
 
-	handleSliceModification := func(grp *quota.Group, path string, content []byte) error {
-		old, modifiedFile, err := tryFileUpdate(path, content)
-		if err != nil {
-			return err
-		}
-
-		if modifiedFile {
-			if observeChange != nil {
-				var oldContent []byte
-				if old != nil {
-					oldContent = old.Content
-				}
-				observeChange(nil, grp, "slice", grp.Name, string(oldContent), string(content))
-			}
-
-			modifiedUnitsPreviousState[path] = old
-
-			// also mark that we need to reload the system instance of systemd
-			// TODO: also handle reloading the user instance of systemd when
-			// needed
-			modifiedSystem = true
-		}
-
-		return nil
-	}
-
-	// now make sure that all of the slice units exist
-	for _, grp := range neededQuotaGrps.AllQuotaGroups() {
-		content := generateGroupSliceFile(grp)
-
-		sliceFileName := grp.SliceFileName()
-		path := filepath.Join(dirs.SnapServicesDir, sliceFileName)
-		if err := handleSliceModification(grp, path, content); err != nil {
-			return err
-		}
-	}
-
-	if !preseeding {
-		if modifiedSystem {
-			if err = sysd.DaemonReload(); err != nil {
-				return err
-			}
-		}
-		if modifiedUser {
-			if err = userDaemonReload(); err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
+	return context.reloadModified()
 }
 
 // AddSnapServicesOptions is a struct for controlling the generated service

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -471,7 +471,7 @@ type EnsureSnapServicesOptions struct {
 	RequireMountedSnapdSnap bool
 }
 
-// ensureSnapServicesContext is the context for the EnsureSnapServices.
+// ensureSnapServicesContext is the context for EnsureSnapServices.
 // EnsureSnapServices supports transactional update/write of systemd service
 // files and slice files. A part of this is to support rollback of files and
 // also keep track of whether a restart of systemd daemon is required. To encapsulate


### PR DESCRIPTION
The function was quite long and complex, and I need to add the journal config files that need to written as well, so I wanted to split out the different things it did to make it easier to read/maintain

