### PR TITLE
tests: run failed tests by default

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -332,7 +332,7 @@ jobs:
           echo "FAILED_TESTS_FILE=$TEST_RESULTS_DIR/${{ matrix.system }}-failed-tests" >> $GITHUB_ENV
 
     - name: Check failed tests to run
-      if: "contains(github.event.pull_request.labels.*.name, 'Run failed') && steps.cached-results.outputs.already-ran != 'true'"
+      if: "!contains(github.event.pull_request.labels.*.name, 'Run all') && steps.cached-results.outputs.already-ran != 'true'"
       run: |
           # Save previous failed test results in FAILED_TESTS env var
           FAILED_TESTS=""
@@ -468,7 +468,7 @@ jobs:
           echo "FAILED_TESTS_FILE=$TEST_RESULTS_DIR/${{ matrix.system }}-failed-tests" >> $GITHUB_ENV
 
     - name: Check failed tests to run
-      if: "contains(github.event.pull_request.labels.*.name, 'Run failed') && steps.cached-results.outputs.already-ran != 'true'"
+      if: "!contains(github.event.pull_request.labels.*.name, 'Run all') && steps.cached-results.outputs.already-ran != 'true'"
       run: |
           # Save previous failed test results in FAILED_TESTS env var
           FAILED_TESTS=""


### PR DESCRIPTION
By default when a github actions job is re-executed, just the failed tests are executed. 

If the pr has a label called "Run all", then all the tests are going to be executed in case the job failed previously.

Once this pr is merged, the "Run failed" label will be removed