### PR TITLE
wrappers: write journald config files for quota groups with journal quotas (3/n)

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -102,6 +102,7 @@ var (
 	SnapDesktopFilesDir    string
 	SnapDesktopIconsDir    string
 	SnapPolkitPolicyDir    string
+	SnapSystemdDir         string
 
 	SnapDBusSessionPolicyDir   string
 	SnapDBusSystemPolicyDir    string
@@ -420,6 +421,7 @@ func SetRootDir(rootdir string) {
 	SnapRuntimeServicesDir = filepath.Join(rootdir, "/run/systemd/system")
 	SnapUserServicesDir = filepath.Join(rootdir, "/etc/systemd/user")
 	SnapSystemdConfDir = SnapSystemdConfDirUnder(rootdir)
+	SnapSystemdDir = filepath.Join(rootdir, "/etc/systemd")
 
 	SnapDBusSystemPolicyDir = filepath.Join(rootdir, "/etc/dbus-1/system.d")
 	SnapDBusSessionPolicyDir = filepath.Join(rootdir, "/etc/dbus-1/session.d")

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -573,8 +573,8 @@ func (es *ensureSnapServicesContext) restore() {
 			}
 		}
 		if es.journalCtlReloadNeeded {
-			if e := es.sysd.Restart([]string{"systemd-journald.service"}); e != nil {
-				es.inter.Notify(fmt.Sprintf("while trying to restart systemd-journald due to previous failure: %v", e))
+			if err := es.sysd.Restart([]string{"systemd-journald.service"}); err != nil {
+				es.inter.Notify(fmt.Sprintf("while trying to restart systemd-journald due to previous failure: %v", err))
 			}
 		}
 	}
@@ -597,10 +597,10 @@ func (es *ensureSnapServicesContext) reloadModified() error {
 		if err := userDaemonReload(); err != nil {
 			return err
 		}
-		if es.journalCtlReloadNeeded {
-			if err := es.sysd.Restart([]string{"systemd-journald.service"}); err != nil {
-				return err
-			}
+	}
+	if es.journalCtlReloadNeeded {
+		if err := es.sysd.Restart([]string{"systemd-journald.service"}); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -750,10 +750,10 @@ func (es *ensureSnapServicesContext) ensureSnapSlices(quotaGroups *quota.QuotaGr
 	// now make sure that all of the slice units exist
 	for _, grp := range quotaGroups.AllQuotaGroups() {
 		content := generateGroupSliceFile(grp)
-		sliceFileName := grp.SliceFileName()
 
-		slicePath := filepath.Join(dirs.SnapServicesDir, sliceFileName)
-		if err := handleSliceModification(grp, slicePath, content); err != nil {
+		sliceFileName := grp.SliceFileName()
+		path := filepath.Join(dirs.SnapServicesDir, sliceFileName)
+		if err := handleSliceModification(grp, path, content); err != nil {
 			return err
 		}
 	}
@@ -794,8 +794,8 @@ func (es *ensureSnapServicesContext) ensureSnapJournaldUnits(quotaGroups *quota.
 		contents := generateJournaldConfFile(grp)
 		fileName := grp.JournalFileName()
 
-		journalConfPath := filepath.Join(dirs.SnapSystemdDir, fileName)
-		if err := handleJournalModification(grp, journalConfPath, contents); err != nil {
+		path := filepath.Join(dirs.SnapSystemdDir, fileName)
+		if err := handleJournalModification(grp, path, contents); err != nil {
 			return err
 		}
 	}

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -197,7 +197,6 @@ func generateJournaldConfFile(grp *quota.Group) []byte {
 	template := `# Journald configuration for snap quota group %[1]s
 [Journal]
 `
-
 	fmt.Fprintf(&buf, template, grp.Name)
 	fmt.Fprint(&buf, sizeOptions, rateOptions)
 	return buf.Bytes()

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -180,9 +180,9 @@ func formatJournalRateConf(grp *quota.Group) string {
 	if grp.JournalLimit.RateCount == 0 || grp.JournalLimit.RatePeriod == 0 {
 		return ""
 	}
-	return fmt.Sprintf(`RateLimitIntervalSec=%ds
+	return fmt.Sprintf(`RateLimitIntervalSec=%dus
 RateLimitBurst=%d
-`, grp.JournalLimit.RatePeriod, grp.JournalLimit.RateCount)
+`, grp.JournalLimit.RatePeriod.Microseconds(), grp.JournalLimit.RateCount)
 }
 
 func generateJournaldConfFile(grp *quota.Group) []byte {

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -626,7 +626,7 @@ func (s *servicesTestSuite) TestEnsureSnapServicesWithJournalQuotas(c *C) {
 	// set up arbitrary quotas for the group to test they get written correctly to the slice
 	resourceLimits := quota.NewResourcesBuilder().
 		WithJournalSize(10*quantity.SizeMiB).
-		WithJournalRate(15, 5).
+		WithJournalRate(15, 5*time.Second).
 		Build()
 	grp, err := quota.NewGroup("foogroup", resourceLimits)
 	c.Assert(err, IsNil)
@@ -666,7 +666,7 @@ WantedBy=multi-user.target
 [Journal]
 SystemMaxUse=10485760
 RuntimeMaxUse=10485760
-RateLimitIntervalSec=5s
+RateLimitIntervalSec=5000000us
 RateLimitBurst=15
 `
 

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -610,9 +610,6 @@ LogNamespace=snap-foogroup
 	c.Assert(err, IsNil)
 	c.Check(s.sysdLog, DeepEquals, [][]string{
 		{"daemon-reload"},
-		{"stop", "systemd-journald.service"},
-		{"show", "--property=ActiveState", "systemd-journald.service"},
-		{"start", "systemd-journald.service"},
 	})
 
 	c.Assert(svcFile, testutil.FileEquals, svcContent)
@@ -720,9 +717,6 @@ LogNamespace=snap-foogroup
 	c.Assert(err, IsNil)
 	c.Check(s.sysdLog, DeepEquals, [][]string{
 		{"daemon-reload"},
-		{"stop", "systemd-journald.service"},
-		{"show", "--property=ActiveState", "systemd-journald.service"},
-		{"start", "systemd-journald.service"},
 	})
 
 	c.Assert(svcFile, testutil.FileEquals, svcContent)


### PR DESCRIPTION
This adds the neccesary code to write journald config files for quota groups with journal quotas.