### PR TITLE
snapstate: do not auto-migrate to ~/Snap for core22 just yet (2.55)

### DIFF
--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1323,41 +1323,59 @@ const (
 )
 
 func triggeredMigration(oldBase, newBase string, opts *dirMigrationOptions) migration {
-	// we're refreshing to a core22 revision
-	if atLeastCore22(newBase) {
-		if opts.MigratedToHidden && !opts.MigratedToExposedHome {
-			// ~/.snap migration already happened so initialize ~/Snap only
-			return home
-		}
+	if !opts.MigratedToHidden && opts.UseHidden {
+		// flag is set and not migrated yet
+		return hidden
+	}
 
-		if !opts.MigratedToHidden {
-			//  nothing was migrated yet, so migrate to ~/.snap and ~/Snap
-			return full
-		}
-	} else {
-		// going back from core22
-		if atLeastCore22(oldBase) {
-			if opts.MigratedToExposedHome && opts.MigratedToHidden && !opts.UseHidden {
-				return revertFull
-			}
-
-			if opts.MigratedToExposedHome && opts.MigratedToHidden && opts.UseHidden {
-				return disableHome
-			}
-		} else {
-			if !opts.MigratedToHidden && opts.UseHidden {
-				// flag is set and not migrated yet
-				return hidden
-			}
-
-			if opts.MigratedToHidden && !opts.UseHidden {
-				// migration was done but flag was unset
-				return revertHidden
-			}
-		}
+	if opts.MigratedToHidden && !opts.UseHidden {
+		// migration was done but flag was unset
+		return revertHidden
 	}
 
 	return none
+
+	/* TODO:Snap-folder:
+	             after a discussion during the May 2022 sprint with Copenhagen
+		     it was decided to not do the migration to ~/Snap for all
+		     snaps with "base: core22" but instead add an opt-in mechanism
+
+				// we're refreshing to a core22 revision
+				if atLeastCore22(newBase) {
+					if opts.MigratedToHidden && !opts.MigratedToExposedHome {
+						// ~/.snap migration already happened so initialize ~/Snap only
+						return home
+					}
+
+					if !opts.MigratedToHidden {
+						//  nothing was migrated yet, so migrate to ~/.snap and ~/Snap
+						return full
+					}
+				} else {
+					// going back from core22
+					if atLeastCore22(oldBase) {
+						if opts.MigratedToExposedHome && opts.MigratedToHidden && !opts.UseHidden {
+							return revertFull
+						}
+
+						if opts.MigratedToExposedHome && opts.MigratedToHidden && opts.UseHidden {
+							return disableHome
+						}
+					} else {
+						if !opts.MigratedToHidden && opts.UseHidden {
+							// flag is set and not migrated yet
+							return hidden
+						}
+
+						if opts.MigratedToHidden && !opts.UseHidden {
+							// migration was done but flag was unset
+							return revertHidden
+						}
+					}
+				}
+
+				return none
+	*/
 }
 
 // atLeastCore22 returns true if 'base' is core22 or newer. Returns

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -5175,6 +5175,8 @@ type: base
 }
 
 func (s *snapmgrTestSuite) TestMigrateOnInstallWithCore24(c *C) {
+	c.Skip("TODO:Snap-folder: no automatic migration for core22 snaps to ~/Snap folder for now")
+
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -5218,6 +5220,8 @@ func (s *snapmgrTestSuite) TestUndoMigrateOnInstallWithCore22OnExposedMigration(
 }
 
 func (s *snapmgrTestSuite) testUndoMigrateOnInstallWithCore22(c *C, expectSeqFile bool, prepFail prepFailFunc) {
+	c.Skip("TODO:Snap-folder: no automatic migration for core22 snaps to ~/Snap folder for now")
+
 	s.state.Lock()
 	defer s.state.Unlock()
 

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -2360,6 +2360,8 @@ func (s *snapmgrTestSuite) TestUndoRevertDoHiddenMigration(c *C) {
 }
 
 func (s *snapmgrTestSuite) TestRevertFromCore22WithSetFlagKeepMigration(c *C) {
+	c.Skip("TODO:Snap-folder: no automatic migration for core22 snaps to ~/Snap folder for now")
+
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -2424,6 +2426,8 @@ func (s *snapmgrTestSuite) TestRevertFromCore22WithSetFlagKeepMigration(c *C) {
 }
 
 func (s *snapmgrTestSuite) TestRevertToCore22WithoutFlagSet(c *C) {
+	c.Skip("TODO:Snap-folder: no automatic migration for core22 snaps to ~/Snap folder for now")
+
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -2490,6 +2494,8 @@ func (s *snapmgrTestSuite) TestRevertToCore22AfterRevertedFullMigration(c *C) {
 }
 
 func (s *snapmgrTestSuite) testRevertToCore22AfterRevertedMigration(c *C, migrationState *dirs.SnapDirOptions) {
+	c.Skip("TODO:Snap-folder: no automatic migration for core22 snaps to ~/Snap folder for now")
+
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -8118,6 +8124,8 @@ func (s *snapmgrTestSuite) TestRemodelAddGadgetAssetTasks(c *C) {
 }
 
 func (s *snapmgrTestSuite) TestMigrationTriggers(c *C) {
+	c.Skip("TODO:Snap-folder: no automatic migration for core22 snaps to ~/Snap folder for now")
+
 	testCases := []struct {
 		oldBase  string
 		newBase  string

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -7629,6 +7629,8 @@ func (s *snapmgrTestSuite) TestRevertMigration(c *C) {
 }
 
 func (s *snapmgrTestSuite) TestUpdateDoHiddenDirMigrationOnCore22(c *C) {
+	c.Skip("TODO:Snap-folder: no automatic migration for core22 snaps to ~/Snap folder for now")
+
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -7666,6 +7668,8 @@ func (s *snapmgrTestSuite) TestUpdateDoHiddenDirMigrationOnCore22(c *C) {
 }
 
 func (s *snapmgrTestSuite) TestUndoMigrationIfUpdateToCore22FailsAfterWritingState(c *C) {
+	c.Skip("TODO:Snap-folder: no automatic migration for core22 snaps to ~/Snap folder for now")
+
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -7723,6 +7727,8 @@ func (s *snapmgrTestSuite) TestUndoMigrationIfUpdateToCore22FailsAfterWritingSta
 }
 
 func (s *snapmgrTestSuite) TestUndoMigrationIfUpdateToCore22Fails(c *C) {
+	c.Skip("TODO:Snap-folder: no automatic migration for core22 snaps to ~/Snap folder for now")
+
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -7764,6 +7770,8 @@ func (s *snapmgrTestSuite) TestUndoMigrationIfUpdateToCore22Fails(c *C) {
 }
 
 func (s *snapmgrTestSuite) TestUpdateMigrateTurnOffFlagAndRefreshToCore22(c *C) {
+	c.Skip("TODO:Snap-folder: no automatic migration for core22 snaps to ~/Snap folder for now")
+
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -7804,6 +7812,8 @@ func (s *snapmgrTestSuite) TestUpdateMigrateTurnOffFlagAndRefreshToCore22(c *C) 
 }
 
 func (s *snapmgrTestSuite) TestUpdateMigrateTurnOffFlagAndRefreshToCore22ButFail(c *C) {
+	c.Skip("TODO:Snap-folder: no automatic migration for core22 snaps to ~/Snap folder for now")
+
 	s.state.Lock()
 	defer s.state.Unlock()
 

--- a/tests/main/hidden-snap-dir/task.yaml
+++ b/tests/main/hidden-snap-dir/task.yaml
@@ -174,6 +174,12 @@ execute: |
     "$NAME".echo "$data" > "$HOME/snap/$NAME/x2/file"
     "$NAME".echo "$data" > "$HOME/snap/$NAME/common/file"
 
+    # TODO:Snap-folder: no automatic migration for core22 snaps to
+    # ~/Snap folder for now
+    #
+    echo "SKIP this part of the test"
+    exit 0
+    
     echo "Update snap to core22"
     snap install --edge core22
     cp -rf "$TESTSLIB/snaps/$NAME" "$PWD/$NAME"


### PR DESCRIPTION
This is https://github.com/snapcore/snapd/pull/11763 for 2.55 - sadly the test change did not apply cleanly from the cherry-pick