### PR TITLE
i/b/mount_control: add an optional "/" to the mount target rule

### DIFF
--- a/interfaces/builtin/mount_control.go
+++ b/interfaces/builtin/mount_control.go
@@ -460,7 +460,7 @@ func (iface *mountControlInterface) AppArmorConnectedPlug(spec *apparmor.Specifi
 
 		options := strings.Join(mountInfo.options, ",")
 
-		emit("  mount %s options=(%s) \"%s\" -> \"%s\",\n", typeRule, options, source, target)
+		emit("  mount %s options=(%s) \"%s\" -> \"%s{,/}\",\n", typeRule, options, source, target)
 		emit("  umount \"%s\",\n", target)
 		return nil
 	})

--- a/interfaces/builtin/mount_control_test.go
+++ b/interfaces/builtin/mount_control_test.go
@@ -284,22 +284,22 @@ func (s *MountControlInterfaceSuite) TestAppArmorSpec(c *C) {
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `capability sys_admin,`)
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/{,usr/}bin/mount ixr,`)
 
-	expectedMountLine1 := `mount fstype=(ext2,ext3,ext4) options=(rw,sync) "/dev/sd*" -> "/media/**",`
+	expectedMountLine1 := `mount fstype=(ext2,ext3,ext4) options=(rw,sync) "/dev/sd*" -> "/media/**{,/}",`
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, expectedMountLine1)
 
-	expectedMountLine2 := `mount  options=(bind) "/usr/**" -> "/var/snap/consumer/common/**",`
+	expectedMountLine2 := `mount  options=(bind) "/usr/**" -> "/var/snap/consumer/common/**{,/}",`
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, expectedMountLine2)
 
 	expectedMountLine3 := `mount fstype=(` +
 		`aufs,autofs,btrfs,ext2,ext3,ext4,hfs,iso9660,jfs,msdos,ntfs,ramfs,` +
 		`reiserfs,squashfs,tmpfs,ubifs,udf,ufs,vfat,zfs,xfs` +
-		`) options=(ro) "/dev/sda{0,1}" -> "/var/snap/consumer/common/**",`
+		`) options=(ro) "/dev/sda{0,1}" -> "/var/snap/consumer/common/**{,/}",`
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, expectedMountLine3)
 
 	expectedMountLine4 := `mount fstype=(` +
 		`aufs,autofs,btrfs,ext2,ext3,ext4,hfs,iso9660,jfs,msdos,ntfs,ramfs,` +
 		`reiserfs,squashfs,tmpfs,ubifs,udf,ufs,vfat,zfs,xfs` +
-		`) options=(sync) "/dev/sda[0-1]" -> "/var/snap/consumer/common/{foo,other,**}",`
+		`) options=(sync) "/dev/sda[0-1]" -> "/var/snap/consumer/common/{foo,other,**}{,/}",`
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, expectedMountLine4)
 }
 

--- a/tests/lib/snaps/test-snapd-mount-control/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-mount-control/meta/snap.yaml
@@ -11,7 +11,7 @@ plugs:
               where: $SNAP_COMMON/**
               options: [rw, bind]
             - what: /var/tmp/**
-              where: $SNAP_COMMON/**
+              where: $SNAP_COMMON/target
               options: [rw, bind]
               persistent: true
             - what: /dev/sd*


### PR DESCRIPTION
AppArmor is very strict when it comes to specifying the target of a
mount rule: when the mount refers to a directory, the target *must* end
with a "/", or AppArmor will block the operation. We did not catch this
in our tests because we have always been ending our "where" attributes
with a "**", that also matches slashes.

So, we update the rule to allow for an optional "/" at the end of the
mount target specification; note that our regular expression for the
validation of the mount target attribute is written in such a way that
an ending slash is not allowed. For the time being this seems proper,
because we don't want to expose this subtlety to the developer.
