### PR TITLE
cmd/snap: join search terms passed in the command line

### DIFF
--- a/cmd/snap/cmd_find.go
+++ b/cmd/snap/cmd_find.go
@@ -155,7 +155,7 @@ type cmdFind struct {
 	Narrow     bool        `long:"narrow"`
 	Section    SectionName `long:"section" optional:"true" optional-value:"show-all-sections-please" default:"no-section-specified" default-mask:"-"`
 	Positional struct {
-		Query string
+		Query []string
 	} `positional-args:"yes"`
 	colorMixin
 }
@@ -183,8 +183,9 @@ func (x *cmdFind) Execute(args []string) error {
 	}
 
 	// LP: 1740605
-	if strings.TrimSpace(x.Positional.Query) == "" {
-		x.Positional.Query = ""
+	query := strings.Join(x.Positional.Query, " ")
+	if strings.TrimSpace(query) == "" {
+		query = ""
 	}
 
 	// section will be:
@@ -200,7 +201,7 @@ func (x *cmdFind) Execute(args []string) error {
 	}
 
 	// magic! `snap find` returns the featured snaps
-	showFeatured := (x.Positional.Query == "" && x.Section == "")
+	showFeatured := (query == "" && x.Section == "")
 	if showFeatured {
 		x.Section = "featured"
 	}
@@ -224,7 +225,7 @@ func (x *cmdFind) Execute(args []string) error {
 	}
 
 	opts := &client.FindOptions{
-		Query:   x.Positional.Query,
+		Query:   query,
 		Section: string(x.Section),
 		Private: x.Private,
 	}

--- a/cmd/snap/cmd_find_test.go
+++ b/cmd/snap/cmd_find_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"os"
 	"path"
 
@@ -125,14 +126,13 @@ func (s *SnapSuite) TestFindSnapName(c *check.C) {
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/find")
 			q := r.URL.Query()
-			if q.Get("q") == "" {
-				v, ok := q["section"]
-				c.Check(ok, check.Equals, true)
-				c.Check(v, check.DeepEquals, []string{""})
-			}
+			c.Check(q, check.DeepEquals, url.Values{
+				"q":     {"hello"},
+				"scope": {"wide"},
+			})
 			fmt.Fprint(w, findJSON)
 		default:
-			c.Fatalf("expected to get 2 requests, now on %d", n+1)
+			c.Fatalf("expected to get 1 request, now on %d", n+1)
 		}
 		n++
 	})
@@ -147,6 +147,112 @@ hello +2.10 +canonical\*\* +- +GNU Hello, the "hello world" snap
 hello-world +6.1 +canonical\*\* +- +Hello world example
 hello-huge +1.0 +noise +- +a really big snap
 `)
+	c.Check(s.Stderr(), check.Equals, "")
+
+	s.ResetStdStreams()
+}
+
+const findHelloWorldJSON = `
+{
+  "type": "sync",
+  "status-code": 200,
+  "status": "OK",
+  "result": [
+    {
+      "channel": "stable",
+      "confinement": "strict",
+      "description": "GNU hello prints a friendly greeting. This is part of the snapcraft tour at https://snapcraft.io/",
+      "developer": "canonical",
+      "publisher": {
+         "id": "canonical",
+         "username": "canonical",
+         "display-name": "Canonical",
+         "validation": "verified"
+      },
+      "download-size": 65536,
+      "icon": "",
+      "id": "mVyGrEwiqSi5PugCwyH7WgpoQLemtTd6",
+      "name": "hello",
+      "private": false,
+      "resource": "/v2/snaps/hello",
+      "revision": "1",
+      "status": "available",
+      "summary": "GNU Hello, the \"hello world\" snap",
+      "type": "app",
+      "version": "2.10"
+    },
+    {
+      "channel": "stable",
+      "confinement": "strict",
+      "description": "This is a simple hello world example.",
+      "developer": "canonical",
+      "publisher": {
+         "id": "canonical",
+         "username": "canonical",
+         "display-name": "Canonical",
+         "validation": "verified"
+      },
+      "download-size": 20480,
+      "icon": "",
+      "id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+      "name": "hello-world",
+      "private": false,
+      "resource": "/v2/snaps/hello-world",
+      "revision": "26",
+      "status": "available",
+      "summary": "Hello world example",
+      "type": "app",
+      "version": "6.1"
+    }
+  ],
+  "sources": [
+    "store"
+  ],
+  "suggested-currency": "GBP"
+}
+`
+
+func (s *SnapSuite) TestFindSnapNameAggregateTerms(c *check.C) {
+	n := 0
+
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		switch n {
+		case 0, 1:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/find")
+			q := r.URL.Query()
+			c.Check(q, check.DeepEquals, url.Values{
+				"q":     {"hello world"},
+				"scope": {"wide"},
+			})
+			fmt.Fprint(w, findHelloWorldJSON)
+		default:
+			c.Fatalf("expected to get 2 requests, now on %d", n+1)
+		}
+		n++
+	})
+
+	// search terms will become one string
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"find", "hello", "world"})
+
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.DeepEquals, []string{})
+
+	stdout := s.Stdout()
+	c.Check(s.Stdout(), check.Matches, `Name +Version +Publisher +Notes +Summary
+hello +2.10 +canonical\*\* +- +GNU Hello, the "hello world" snap
+hello-world +6.1 +canonical\*\* +- +Hello world example
+`)
+	c.Check(s.Stderr(), check.Equals, "")
+
+	s.ResetStdStreams()
+
+	// search terms are already joined in the command line
+	rest, err = snap.Parser(snap.Client()).ParseArgs([]string{"find", "hello world"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.DeepEquals, []string{})
+	// with same output
+	c.Check(s.Stdout(), check.Equals, stdout)
 	c.Check(s.Stderr(), check.Equals, "")
 
 	s.ResetStdStreams()

--- a/tests/main/searching/task.yaml
+++ b/tests/main/searching/task.yaml
@@ -43,8 +43,9 @@ execute: |
 
     echo "And a very specific query works too"
     # and returns a single result
-    expected='^Name +Version +Publisher +Notes +Summary\ntest-snapd-python-webserver +.*\n$'
-    snap find python based example webserver test-snapd | grep -Pzq "$expected"
+    snap find python based example webserver test-snapd | tail -n -1 > aggregate.out
+    test "$(wc -l < aggregate.out)" = "1"
+    MATCH '^test-snapd-python-webserver +.*$' < aggregate.out
 
     echo "List of snaps in a section works"
     # NOTE: this shows featured snaps which change all the time, do not

--- a/tests/main/searching/task.yaml
+++ b/tests/main/searching/task.yaml
@@ -41,6 +41,11 @@ execute: |
     expected='(?s)Name +Version +Publisher +Notes +Summary *\n(.*?\n)?test-snapd-tools +.*? *\n.*'
     snap find test-snapd- | grep -Pzq "$expected"
 
+    echo "And a very specific query works too"
+    # and returns a single result
+    expected='^Name +Version +Publisher +Notes +Summary\ntest-snapd-python-webserver +.*\n$'
+    snap find python based example webserver test-snapd | grep -Pzq "$expected"
+
     echo "List of snaps in a section works"
     # NOTE: this shows featured snaps which change all the time, do not
     # make any assumptions about the contents


### PR DESCRIPTION
Thus trying to mimic what apt search does. Thus, one does not have to run:

```
snap find "hello world"
```

to narrow down the results, but can run:

```
snap find hello world
```

Fixes: https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1972910