### PR TITLE
i/b/hardware-observe.go: add access to the thermal sysfs

### DIFF
--- a/interfaces/builtin/hardware_observe.go
+++ b/interfaces/builtin/hardware_observe.go
@@ -147,6 +147,10 @@ network netlink raw,
 # some devices use this information to set serial, etc. for Ubuntu Core devices
 /sys/devices/virtual/dmi/id/product_name r,
 /sys/devices/virtual/dmi/id/sys_vendor r,
+
+# allow read access to thermal sysfs
+/sys/devices/virtual/thermal/cooling_device[0-9]*/** r,
+/sys/devices/virtual/thermal/thermal_zone[0-9]*/** r,
 `
 
 const hardwareObserveConnectedPlugSecComp = `


### PR DESCRIPTION
Allow read access to the thermal sysfs from the hardware-observe
interface. See Documentation/driver-api/thermal/sysfs-api.rst in the
kernel for reference.