### PR TITLE
cmd/snap: replace existing code for 'snap model' to use shared code in clientutil (2/3)

### DIFF
--- a/cmd/snap/cmd_model.go
+++ b/cmd/snap/cmd_model.go
@@ -22,15 +22,12 @@ package main
 import (
 	"errors"
 	"fmt"
-	"strings"
-	"time"
 
 	"github.com/jessevdk/go-flags"
 
-	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/client"
+	"github.com/snapcore/snapd/client/clientutil"
 	"github.com/snapcore/snapd/i18n"
-	"github.com/snapcore/snapd/strutil"
 )
 
 var (
@@ -79,6 +76,27 @@ model assertion.
 	}
 )
 
+type cmdModelFormatter struct {
+	client *client.Client
+	esc    *escapes
+}
+
+func (mf cmdModelFormatter) GetEscapedDash() string {
+	return mf.esc.dash
+}
+
+func (mf cmdModelFormatter) LongPublisher(storeAccountID string) string {
+	// for the model command (not --serial) we want to show a publisher
+	// style display of "brand" instead of just "brand-id"
+	storeAccount, err := mf.client.StoreAccount(storeAccountID)
+	if err != nil {
+		return ""
+	}
+	// use the longPublisher helper to format the brand store account
+	// like we do in `snap info`
+	return longPublisher(mf.esc, storeAccount)
+}
+
 type cmdModel struct {
 	clientMixin
 	timeMixin
@@ -111,7 +129,6 @@ func (x *cmdModel) Execute(args []string) error {
 		return errNoVerboseAssertion
 	}
 
-	var mainAssertion asserts.Assertion
 	serialAssertion, serialErr := x.client.CurrentSerialAssertion()
 	modelAssertion, modelErr := x.client.CurrentModelAssertion()
 
@@ -131,21 +148,12 @@ func (x *cmdModel) Execute(args []string) error {
 		return serialErr
 	}
 
-	if x.Serial {
-		mainAssertion = serialAssertion
-	} else {
-		mainAssertion = modelAssertion
-	}
-
 	if x.Assertion {
 		// if we are using the serial assertion and we specifically didn't find the
 		// serial assertion, bail with specific error
 		if x.Serial && client.IsAssertionNotFoundError(serialErr) {
 			return errNoMainAssertion
 		}
-
-		_, err := Stdout.Write(asserts.Encode(mainAssertion))
-		return err
 	}
 
 	termWidth, _ := termSize()
@@ -155,9 +163,17 @@ func (x *cmdModel) Execute(args []string) error {
 		termWidth = 100
 	}
 
-	esc := x.getEscapes()
-
 	w := tabWriter()
+	modelFormatter := cmdModelFormatter{
+		esc:    x.getEscapes(),
+		client: x.client,
+	}
+	opts := clientutil.PrintModelAssertionOptions{
+		TermWidth: termWidth,
+		AbsTime:   x.AbsTime,
+		Verbose:   x.Verbose,
+		Assertion: x.Assertion,
+	}
 
 	if x.Serial && client.IsAssertionNotFoundError(serialErr) {
 		// for serial assertion, the primary keys are output (model and
@@ -170,241 +186,14 @@ func (x *cmdModel) Execute(args []string) error {
 		return errNoSerial
 	}
 
-	// the rest of this function is the main flow for outputting either the
-	// model or serial assertion in normal or verbose mode
-
-	// for the `snap model` case with no options, we don't want colons, we want
-	// to be like `snap version`
-	separator := ":"
-	if !x.Verbose && !x.Serial {
-		separator = ""
-	}
-
-	// ordering of the primary keys for model: brand, model, serial
-	// ordering of primary keys for serial is brand-id, model, serial
-
-	// output brand/brand-id
-	brandIDHeader := mainAssertion.HeaderString("brand-id")
-	modelHeader := mainAssertion.HeaderString("model")
-	// for the serial header, if there's no serial yet, it's not an error for
-	// model (and we already handled the serial error above) but need to add a
-	// parenthetical about the device not being registered yet
-	var serial string
-	if client.IsAssertionNotFoundError(serialErr) {
-		if x.Verbose || x.Serial {
-			// verbose and serial are yamlish, so we need to escape the dash
-			serial = esc.dash
-		} else {
-			serial = "-"
-		}
-		serial += " (device not registered yet)"
-	} else {
-		serial = serialAssertion.HeaderString("serial")
-	}
-
-	// handle brand/brand-id and model/model + display-name differently on just
-	// `snap model` w/o opts
-	if x.Serial || x.Verbose {
-		fmt.Fprintf(w, "brand-id:\t%s\n", brandIDHeader)
-		fmt.Fprintf(w, "model:\t%s\n", modelHeader)
-	} else {
-		// for the model command (not --serial) we want to show a publisher
-		// style display of "brand" instead of just "brand-id"
-		storeAccount, err := x.client.StoreAccount(brandIDHeader)
-		if err != nil {
+	if x.Serial {
+		if err := clientutil.PrintSerialAssertionYAML(w, *serialAssertion, modelFormatter, opts); err != nil {
 			return err
 		}
-		// use the longPublisher helper to format the brand store account
-		// like we do in `snap info`
-		fmt.Fprintf(w, "brand%s\t%s\n", separator, longPublisher(x.getEscapes(), storeAccount))
-
-		// for model, if there's a display-name, we show that first with the
-		// real model in parenthesis
-		if displayName := modelAssertion.HeaderString("display-name"); displayName != "" {
-			modelHeader = fmt.Sprintf("%s (%s)", displayName, modelHeader)
-		}
-		fmt.Fprintf(w, "model%s\t%s\n", separator, modelHeader)
-	}
-
-	// only output the grade if it is non-empty, either it is not in the model
-	// assertion for all non-uc20 model assertions, or it is non-empty and
-	// required for uc20 model assertions
-	grade := modelAssertion.HeaderString("grade")
-	if grade != "" {
-		fmt.Fprintf(w, "grade%s\t%s\n", separator, grade)
-	}
-
-	storageSafety := modelAssertion.HeaderString("storage-safety")
-	if storageSafety != "" {
-		fmt.Fprintf(w, "storage-safety%s\t%s\n", separator, storageSafety)
-	}
-
-	// serial is same for all variants
-	fmt.Fprintf(w, "serial%s\t%s\n", separator, serial)
-
-	// --verbose means output more information
-	if x.Verbose {
-		allHeadersMap := mainAssertion.Headers()
-
-		for _, headerName := range niceOrdering {
-			invalidTypeErr := fmt.Errorf(invalidTypeMessage, headerName)
-
-			headerValue, ok := allHeadersMap[headerName]
-			// make sure the header is in the map
-			if !ok {
-				continue
-			}
-
-			// switch on which header it is to handle some special cases
-			switch headerName {
-			// list of scalars
-			case "required-snaps", "system-user-authority":
-				headerIfaceList, ok := headerValue.([]interface{})
-				if !ok {
-					return invalidTypeErr
-				}
-				if len(headerIfaceList) == 0 {
-					continue
-				}
-				fmt.Fprintf(w, "%s:\t\n", headerName)
-				for _, elem := range headerIfaceList {
-					headerStringElem, ok := elem.(string)
-					if !ok {
-						return invalidTypeErr
-					}
-					// note we don't wrap these, since for now this is
-					// specifically just required-snaps and so all of these
-					// will be snap names which are required to be short
-					fmt.Fprintf(w, "  - %s\n", headerStringElem)
-				}
-
-			//timestamp needs to be formatted with fmtTime from the timeMixin
-			case "timestamp":
-				timestamp, ok := headerValue.(string)
-				if !ok {
-					return invalidTypeErr
-				}
-
-				// parse the time string as RFC3339, which is what the format is
-				// always in for assertions
-				t, err := time.Parse(time.RFC3339, timestamp)
-				if err != nil {
-					return err
-				}
-				fmt.Fprintf(w, "timestamp:\t%s\n", x.fmtTime(t))
-
-			// long string key we don't want to rewrap but can safely handle
-			// on "reasonable" width terminals
-			case "device-key-sha3-384":
-				// also flush the writer before continuing so the previous keys
-				// don't try to align with this key
-				w.Flush()
-				headerString, ok := headerValue.(string)
-				if !ok {
-					return invalidTypeErr
-				}
-
-				switch {
-				case termWidth > 86:
-					fmt.Fprintf(w, "device-key-sha3-384: %s\n", headerString)
-				case termWidth <= 86 && termWidth > 66:
-					fmt.Fprintln(w, "device-key-sha3-384: |")
-					strutil.WordWrapPadded(w, []rune(headerString), "  ", termWidth)
-				}
-			case "snaps":
-				// also flush the writer before continuing so the previous keys
-				// don't try to align with this key
-				w.Flush()
-				snapsHeader, ok := headerValue.([]interface{})
-				if !ok {
-					return invalidTypeErr
-				}
-				if len(snapsHeader) == 0 {
-					// unexpected why this is an empty list, but just ignore for
-					// now
-					continue
-				}
-				fmt.Fprintf(w, "snaps:\n")
-				for _, sn := range snapsHeader {
-					snMap, ok := sn.(map[string]interface{})
-					if !ok {
-						return invalidTypeErr
-					}
-					// iterate over all keys in the map in a stable, visually
-					// appealing ordering
-					// first do snap name, which will always be present since we
-					// parsed a valid assertion
-					name := snMap["name"].(string)
-					fmt.Fprintf(w, "  - name:\t%s\n", name)
-
-					// the rest of these may be absent, but they are all still
-					// simple strings
-					for _, snKey := range []string{"id", "type", "default-channel", "presence"} {
-						snValue, ok := snMap[snKey]
-						if !ok {
-							continue
-						}
-						snStrValue, ok := snValue.(string)
-						if !ok {
-							return invalidTypeErr
-						}
-						if snStrValue != "" {
-							fmt.Fprintf(w, "    %s:\t%s\n", snKey, snStrValue)
-						}
-					}
-
-					// finally handle "modes" which is a list
-					modes, ok := snMap["modes"]
-					if !ok {
-						continue
-					}
-					modesSlice, ok := modes.([]interface{})
-					if !ok {
-						return invalidTypeErr
-					}
-					if len(modesSlice) == 0 {
-						continue
-					}
-
-					modeStrSlice := make([]string, 0, len(modesSlice))
-					for _, mode := range modesSlice {
-						modeStr, ok := mode.(string)
-						if !ok {
-							return invalidTypeErr
-						}
-						modeStrSlice = append(modeStrSlice, modeStr)
-					}
-					modesSliceYamlStr := "[" + strings.Join(modeStrSlice, ", ") + "]"
-					fmt.Fprintf(w, "    modes:\t%s\n", modesSliceYamlStr)
-				}
-
-			// long base64 key we can rewrap safely
-			case "device-key":
-				headerString, ok := headerValue.(string)
-				if !ok {
-					return invalidTypeErr
-				}
-				// the string value here has newlines inserted as part of the
-				// raw assertion, but base64 doesn't care about whitespace, so
-				// it's safe to split by newlines and re-wrap to make it
-				// prettier
-				headerString = strings.Join(
-					strings.Split(headerString, "\n"),
-					"")
-				fmt.Fprintln(w, "device-key: |")
-				strutil.WordWrapPadded(w, []rune(headerString), "  ", termWidth)
-
-			// the default is all the rest of short scalar values, which all
-			// should be strings
-			default:
-				headerString, ok := headerValue.(string)
-				if !ok {
-					return invalidTypeErr
-				}
-				fmt.Fprintf(w, "%s:\t%s\n", headerName, headerString)
-			}
+	} else {
+		if err := clientutil.PrintModelAssertion(w, *modelAssertion, serialAssertion, modelFormatter, opts); err != nil {
+			return err
 		}
 	}
-
 	return w.Flush()
 }

--- a/cmd/snap/cmd_model.go
+++ b/cmd/snap/cmd_model.go
@@ -46,7 +46,6 @@ Similarly, the active serial assertion can be used for the output instead of the
 model assertion.
 `)
 
-	invalidTypeMessage    = i18n.G("invalid type for %q header")
 	errNoMainAssertion    = errors.New(i18n.G("device not ready yet (no assertions found)"))
 	errNoSerial           = errors.New(i18n.G("device not registered yet (no serial assertion found)"))
 	errNoVerboseAssertion = errors.New(i18n.G("cannot use --verbose with --assertion"))


### PR DESCRIPTION
This is the followup PR for https://github.com/snapcore/snapd/pull/11612. This replaces the existing printing logic in 'snap model' with the code added in 11612.