### PR TITLE
tests: Improve the unit testing workflow to run in parallel

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -72,7 +72,7 @@ jobs:
         mkdir -p $(dirname "$CACHE_RESULT_STAMP")
         touch "$CACHE_RESULT_STAMP"
 
-  unit-tests:
+  static-checks:
     runs-on: ubuntu-20.04
     env:
       GOPATH: ${{ github.workspace }}
@@ -99,20 +99,24 @@ jobs:
         # NOTE: checkout the code in a fixed location, even for forks, as this
         # is relevant for go's import system.
         path: ./src/github.com/snapcore/snapd
+
     # Fetch base ref, needed for golangci-lint
     - name: Fetching base ref ${{ github.base_ref }}
       run: |
         cd ${{ github.workspace }}/src/github.com/snapcore/snapd
         git fetch origin ${{ github.base_ref }}:${{ github.base_ref }}
+
     - name: Cache Debian dependencies
       id: cache-deb-downloads
       uses: actions/cache@v1
       with:
         path: /var/cache/apt
         key: var-cache-apt-{{ hashFiles('**/debian/control') }}
+
     - name: Run "apt update"
       run: |
           sudo apt update
+
     - name: Download Debian dependencies
       if: steps.cache-deb-downloads.outputs.cache-hit != 'true'
       run: |
@@ -127,10 +131,11 @@ jobs:
         # must include matrix or things get racy, i.e. when latest/edge
         # finishes after 1.9 it overrides the results from 1.9
         key: "${{ github.run_id }}-${{ github.job }}-${{ matrix.gochannel }}-results"
+
     - name: Check cached test results
       id: cached-results
       run: |
-          CACHE_RESULT_STAMP="${{ github.workspace }}/.test-results/${{ matrix.gochannel }}-success"
+          CACHE_RESULT_STAMP="${{ github.workspace }}/.test-results/success"
           echo "CACHE_RESULT_STAMP=$CACHE_RESULT_STAMP" >> $GITHUB_ENV
           if [ -e "$CACHE_RESULT_STAMP" ]; then
               echo "::set-output name=already-ran::true"
@@ -186,6 +191,98 @@ jobs:
           fi
           sudo apt-get install -y python3-yamlordereddictloader
           ./run-checks --static
+    - name: Cache successful run
+      run: |
+        mkdir -p $(dirname "$CACHE_RESULT_STAMP")
+        touch "$CACHE_RESULT_STAMP"
+
+  unit-tests:
+    needs: [static-checks]
+    runs-on: ubuntu-20.04
+    env:
+      GOPATH: ${{ github.workspace }}
+      # Set PATH to ignore the load of magic binaries from /usr/local/bin And
+      # to use the go snap automatically. Note that we install go from the
+      # snap in a step below. Without this we get the GitHub-controlled latest
+      # version of go.
+      PATH: /snap/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:${{ github.workspace }}/bin
+      GOROOT: ""
+      GITHUB_PULL_REQUEST: ${{ github.event.number }}
+    strategy:
+      # we cache successful runs so it's fine to keep going
+      fail-fast: false      
+      matrix:
+        gochannel:
+          - 1.13
+          - latest/stable
+        unit-scenario:
+          - normal
+          - snapd_debug
+          - withbootassetstesting
+          - nosecboot
+          - faultinject
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        # needed for git commit history
+        fetch-depth: 0
+        # NOTE: checkout the code in a fixed location, even for forks, as this
+        # is relevant for go's import system.
+        path: ./src/github.com/snapcore/snapd
+
+    # Fetch base ref, needed for golangci-lint
+    - name: Fetching base ref ${{ github.base_ref }}
+      run: |
+        cd ${{ github.workspace }}/src/github.com/snapcore/snapd
+        git fetch origin ${{ github.base_ref }}:${{ github.base_ref }}
+
+    - name: Cache Debian dependencies
+      id: cache-deb-downloads
+      uses: actions/cache@v1
+      with:
+        path: /var/cache/apt
+        key: var-cache-apt-{{ hashFiles('**/debian/control') }}
+
+    - name: Run "apt update"
+      run: |
+          sudo apt update
+
+    - name: Download Debian dependencies
+      if: steps.cache-deb-downloads.outputs.cache-hit != 'true'
+      run: |
+          sudo apt clean
+          sudo apt build-dep -d -y ${{ github.workspace }}/src/github.com/snapcore/snapd
+
+    - name: Cache snapd test results
+      id: cache-snapd-test-results
+      uses: actions/cache@v1
+      with:
+        path: "${{ github.workspace }}/.test-results"
+        # must include matrix or things get racy, i.e. when latest/edge
+        # finishes after 1.9 it overrides the results from 1.9
+        key: "${{ github.run_id }}-${{ github.job }}-${{ matrix.gochannel }}-${{ matrix.unit-scenario }}-results"
+
+    - name: Check cached test results
+      id: cached-results
+      run: |
+          CACHE_RESULT_STAMP="${{ github.workspace }}/.test-results/success"
+          echo "CACHE_RESULT_STAMP=$CACHE_RESULT_STAMP" >> $GITHUB_ENV
+          if [ -e "$CACHE_RESULT_STAMP" ]; then
+              echo "::set-output name=already-ran::true"
+          fi
+
+    - name: Install Debian dependencies
+      if: steps.cached-results.outputs.cached-results != 'true'
+      run: |
+          sudo apt build-dep -y ${{ github.workspace }}/src/github.com/snapcore/snapd
+
+    # golang latest ensures things work on the edge
+    - name: Install the go snap
+      if: steps.cached-results.outputs.already-ran != 'true'
+      run: |
+          sudo snap install --classic --channel=${{ matrix.gochannel }} go
+
     - name: Build C
       if: steps.cached-results.outputs.already-ran != 'true'
       run: |
@@ -204,23 +301,27 @@ jobs:
       if: steps.cached-results.outputs.already-ran != 'true'
       run: |
           rm -rf ${{ github.workspace }}/.coverage/
+
     - name: Test Go
-      if: steps.cached-results.outputs.already-ran != 'true'
+      if: matrix.unit-scenario == normal && steps.cached-results.outputs.already-ran != 'true'
       run: |
         cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
         ./run-checks --unit
+
     - name: Test Go (SNAPD_DEBUG=1)
-      if: steps.cached-results.outputs.already-ran != 'true'
+      if: matrix.unit-scenario == snapd_debug && steps.cached-results.outputs.already-ran != 'true'
       run: |
         cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
         SKIP_DIRTY_CHECK=1 SNAPD_DEBUG=1 ./run-checks --unit
+
     - name: Test Go (withbootassetstesting)
-      if: steps.cached-results.outputs.already-ran != 'true'
+      if: matrix.unit-scenario == withbootassetstesting && steps.cached-results.outputs.already-ran != 'true'
       run: |
         cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
         SKIP_DIRTY_CHECK=1 GO_BUILD_TAGS=withbootassetstesting ./run-checks --unit
+
     - name: Test Go (nosecboot)
-      if: steps.cached-results.outputs.already-ran != 'true'
+      if: matrix.unit-scenario == nosecboot && steps.cached-results.outputs.already-ran != 'true'
       run: |
         cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
         echo "Dropping github.com/snapcore/secboot"
@@ -229,17 +330,68 @@ jobs:
         # ${{ github.workspace }}/bin/govendor remove github.com/snapcore/secboot
         # ${{ github.workspace }}/bin/govendor remove +unused
         SKIP_DIRTY_CHECK=1 GO_BUILD_TAGS=nosecboot ./run-checks --unit
+
     - name: Test Go (faultinject)
-      if: steps.cached-results.outputs.already-ran != 'true'
+      if: matrix.unit-scenario == faultinject && steps.cached-results.outputs.already-ran != 'true'
       run: |
         cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
         SKIP_DIRTY_CHECK=1 GO_BUILD_TAGS=faultinject ./run-checks --unit
+
+    - name: Upload the coverage results
+      uses: actions/upload-artifact@v2
+      with:
+        path: ".coverage/coverage*.cov"
+
+    - name: Cache successful run
+      run: |
+        mkdir -p $(dirname "$CACHE_RESULT_STAMP")
+        touch "$CACHE_RESULT_STAMP"
+
+  code-coverage:
+    needs: [unit-tests]
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        # needed for git commit history
+        fetch-depth: 0
+        # NOTE: checkout the code in a fixed location, even for forks, as this
+        # is relevant for go's import system.
+        path: ./src/github.com/snapcore/snapd
+
+    - name: Cache snapd test results
+      id: cache-snapd-test-results
+      uses: actions/cache@v1
+      with:
+        path: "${{ github.workspace }}/.test-results"
+        # must include matrix or things get racy, i.e. when latest/edge
+        # finishes after 1.9 it overrides the results from 1.9
+        key: "${{ github.run_id }}-${{ github.job }}-results"
+
+    - name: Check cached test results
+      id: cached-results
+      run: |
+          CACHE_RESULT_STAMP="${{ github.workspace }}/.test-results/success"
+          echo "CACHE_RESULT_STAMP=$CACHE_RESULT_STAMP" >> $GITHUB_ENV
+          if [ -e "$CACHE_RESULT_STAMP" ]; then
+              echo "::set-output name=already-ran::true"
+          fi
+
+    - name: Download the coverage files
+      uses: actions/download-artifact@v3
+      with:
+        name: '*.cov'
+        path: .coverage/
+
     - name: Merge coverage results
       if: ${{ steps.cached-results.outputs.already-ran != 'true' && matrix.gochannel != 'latest/stable' }}
       run: |
         cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
         go install github.com/makholm/covertool
         covertool merge -o .coverage/all.cov .coverage/coverage*.cov
+
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v2
       # uploading to codecov occasionally fails, so continue running the test
@@ -252,307 +404,8 @@ jobs:
         name: codecov-umbrella
         files: .coverage/all.cov
         verbose: true
+
     - name: Cache successful run
       run: |
         mkdir -p $(dirname "$CACHE_RESULT_STAMP")
         touch "$CACHE_RESULT_STAMP"
-
-  spread:
-    needs: [unit-tests]
-    # have spread jobs run on master on PRs only, but on both PRs and pushes to
-    # release branches
-    if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/master' }}
-    runs-on: self-hosted
-    strategy:
-      # FIXME: enable fail-fast mode once spread can cancel an executing job.
-      # Disable fail-fast mode as it doesn't function with spread. It seems
-      # that cancelling tasks requires short, interruptible actions and
-      # interrupting spread, notably, does not work today. As such disable
-      # fail-fast while we tackle that problem upstream.
-      fail-fast: false
-      matrix:
-        system:
-        - amazon-linux-2-64
-        - arch-linux-64
-        - centos-7-64
-        - centos-8-64
-        - debian-10-64
-        - debian-11-64
-        - debian-sid-64
-        - fedora-34-64
-        - fedora-35-64
-        - opensuse-15.3-64
-        - opensuse-tumbleweed-64
-        - ubuntu-14.04-64
-        - ubuntu-16.04-64
-        - ubuntu-18.04-32
-        - ubuntu-18.04-64
-        - ubuntu-20.04-64
-        - ubuntu-21.10-64
-        - ubuntu-22.04-64
-        - ubuntu-core-16-64
-        - ubuntu-core-18-64
-        - ubuntu-core-20-64
-        - ubuntu-core-22-64
-        - ubuntu-secboot-20.04-64
-    steps:
-    - name: Cleanup job workspace
-      id: cleanup-job-workspace
-      run: |
-          rm -rf "${{ github.workspace }}"
-          mkdir "${{ github.workspace }}"
-
-    - name: Checkout code
-      uses: actions/checkout@v2
-      with:
-        # spread uses tags as delta reference
-        fetch-depth: 0
-
-    - name: Cache snapd test results
-      id: cache-snapd-test-results
-      uses: pat-s/always-upload-cache@v2.1.5
-      with:
-        path: "${{ github.workspace }}/.test-results"
-        key: "${{ github.run_id }}-${{ github.job }}-${{ matrix.system }}-results"
-
-    - name: Check cached test results
-      id: cached-results
-      run: |
-          TEST_RESULTS_DIR="${{ github.workspace }}/.test-results"
-          mkdir -p "$TEST_RESULTS_DIR"
-          echo "TEST_RESULTS_DIR=$TEST_RESULTS_DIR" >> $GITHUB_ENV
-
-          CACHE_RESULT_STAMP="$TEST_RESULTS_DIR/${{ matrix.system }}-success"
-          echo "CACHE_RESULT_STAMP=$CACHE_RESULT_STAMP" >> $GITHUB_ENV
-          if [ -e "$CACHE_RESULT_STAMP" ]; then
-              echo "::set-output name=already-ran::true"
-          fi
-
-          # Save the var with the failed tests file
-          echo "FAILED_TESTS_FILE=$TEST_RESULTS_DIR/${{ matrix.system }}-failed-tests" >> $GITHUB_ENV
-
-    - name: Check failed tests to run
-      if: "!contains(github.event.pull_request.labels.*.name, 'Run all') && steps.cached-results.outputs.already-ran != 'true'"
-      run: |
-          # Save previous failed test results in FAILED_TESTS env var
-          FAILED_TESTS=""
-          if [ -f "$FAILED_TESTS_FILE" ]; then
-              echo "Failed tests file found"
-              FAILED_TESTS="$(cat $FAILED_TESTS_FILE)"
-              if [ -n "$FAILED_TESTS" ]; then
-                  echo "Failed tests to run: $FAILED_TESTS"
-                  echo "FAILED_TESTS=$FAILED_TESTS" >> $GITHUB_ENV
-              fi
-          fi
-
-    - name: Run spread tests
-      if: "!contains(github.event.pull_request.labels.*.name, 'Skip spread') && steps.cached-results.outputs.already-ran != 'true'"
-      env:
-          SPREAD_GOOGLE_KEY: ${{ secrets.SPREAD_GOOGLE_KEY }}
-      run: |
-          # Register a problem matcher to highlight spread failures
-          echo "::add-matcher::.github/spread-problem-matcher.json"
-
-          # Save previous failed test results in FAILED_TESTS env var
-          RUN_TESTS="google:${{ matrix.system }}:tests/..."
-          if [ -n "$FAILED_TESTS" ]; then
-              RUN_TESTS="$FAILED_TESTS"
-          fi
-
-          # Run spread tests
-          # "pipefail" ensures that a non-zero status from the spread is
-          # propagated; and we use a subshell as this option could trigger
-          # undesired changes elsewhere
-          (set -o pipefail; spread -abend $RUN_TESTS | tee spread.log)
-
-    - name: Cache successful run
-      run: |
-        touch "$CACHE_RESULT_STAMP"
-
-    - name: Discard spread workers
-      if: always()
-      run: |
-        shopt -s nullglob;
-        for r in .spread-reuse.*.yaml; do
-          spread -discard -reuse-pid="$(echo "$r" | grep -o -E '[0-9]+')";
-        done
-
-    - name: report spread errors
-      if: always()
-      run: |
-        if [ -e spread.log ]; then
-            echo "Running spread log analyzer"
-            issues_metadata='{"source_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}'
-            ./tests/lib/external/snapd-testing-tools/utils/log-parser spread.log --print-detail error-debug --output spread-results.json --cut 100
-            while IFS= read -r line; do
-                if [ ! -z "$line" ]; then
-                    echo "Reporting spread error..."
-                    ./tests/lib/tools/report-mongodb --db-name snapd --db-collection spread_errors --metadata "$issues_metadata" "$line"
-                fi
-            done <<< $(jq -cr '.[] | select( .type == "info") | select( (.info_type == "Error") or (.info_type == "Debug"))' spread-results.json)
-        else
-            echo "No spread log found, skipping errors reporting"
-        fi
-
-    - name: save spread results
-      if: always()
-      run: |
-          if [ -f spread.log ]; then
-              echo "Running spread log analyzer"
-
-              # Aborted cannot be used to determine if we need to re-run all because it could be a aborted an entire suite
-              if grep -q "Aborted tasks: 0" spread.log; then
-                  ./tests/lib/external/snapd-testing-tools/utils/log-parser spread.log --output spread-results.json
-                  jq -r '.[] | select( .type == "result") | select( .result_type == "Failed") | select( .level == "task" or .level == "tasks" ) | .detail.lines[]' spread-results.json | grep "google:" | cut -d '-' -f2- | tr '\n' ' ' > "$FAILED_TESTS_FILE"
-
-                  echo "Failed tests saved for re-execution: $(cat $FAILED_TESTS_FILE)"
-              else
-                  echo "No failed tests saved, this means all the tests will be executed next run"
-                  touch "$FAILED_TESTS_FILE"
-              fi
-          else
-              echo "No spread log found, saving empty list of failed tests"
-              touch "$FAILED_TESTS_FILE"
-          fi
-
-  spread-nested:
-    needs: [unit-tests]
-    # have spread jobs run on master on PRs only, but on both PRs and pushes to
-    # release branches
-    if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/master' }}
-    runs-on: self-hosted
-    strategy:
-      # FIXME: enable fail-fast mode once spread can cancel an executing job.
-      # Disable fail-fast mode as it doesn't function with spread. It seems
-      # that cancelling tasks requires short, interruptible actions and
-      # interrupting spread, notably, does not work today. As such disable
-      # fail-fast while we tackle that problem upstream.
-      fail-fast: false
-      matrix:
-        system:
-        - ubuntu-16.04-64
-        - ubuntu-18.04-64
-        - ubuntu-20.04-64
-        - ubuntu-22.04-64
-    steps:
-    - name: Cleanup job workspace
-      id: cleanup-job-workspace
-      run: |
-          rm -rf "${{ github.workspace }}"
-          mkdir "${{ github.workspace }}"
-
-    - name: Checkout code
-      uses: actions/checkout@v2
-
-    - name: Cache snapd test results
-      id: cache-snapd-test-results
-      uses: pat-s/always-upload-cache@v2.1.5
-      with:
-        path: "${{ github.workspace }}/.test-results"
-        key: "${{ github.run_id }}-${{ github.job }}-${{ matrix.system }}-results"
-
-    - name: Check cached test results
-      id: cached-results
-      run: |
-          TEST_RESULTS_DIR="${{ github.workspace }}/.test-results"
-          mkdir -p "$TEST_RESULTS_DIR"
-          echo "TEST_RESULTS_DIR=$TEST_RESULTS_DIR" >> $GITHUB_ENV
-
-          CACHE_RESULT_STAMP="$TEST_RESULTS_DIR/${{ matrix.system }}-success"
-          echo "CACHE_RESULT_STAMP=$CACHE_RESULT_STAMP" >> $GITHUB_ENV
-          if [ -e "$CACHE_RESULT_STAMP" ]; then
-              echo "::set-output name=already-ran::true"
-          fi
-
-          # Save the var with the failed tests file
-          echo "FAILED_TESTS_FILE=$TEST_RESULTS_DIR/${{ matrix.system }}-failed-tests" >> $GITHUB_ENV
-
-    - name: Check failed tests to run
-      if: "!contains(github.event.pull_request.labels.*.name, 'Run all') && steps.cached-results.outputs.already-ran != 'true'"
-      run: |
-          # Save previous failed test results in FAILED_TESTS env var
-          FAILED_TESTS=""
-          if [ -f "$FAILED_TESTS_FILE" ]; then
-              echo "Failed tests file found"
-              FAILED_TESTS="$(cat $FAILED_TESTS_FILE)"
-              if [ -n "$FAILED_TESTS" ]; then
-                  echo "Failed tests to run: $FAILED_TESTS"
-                  echo "FAILED_TESTS=$FAILED_TESTS" >> $GITHUB_ENV
-              fi
-          fi
-
-
-    - name: Run spread tests
-      # run if the commit is pushed to the release/* branch or there is a 'Run
-      # nested' label set on the PR
-      if: "(contains(github.event.pull_request.labels.*.name, 'Run nested') || contains(github.ref, 'refs/heads/release/')) && steps.cached-results.outputs.already-ran != 'true'"
-      env:
-          SPREAD_GOOGLE_KEY: ${{ secrets.SPREAD_GOOGLE_KEY }}
-      run: |
-          # Register a problem matcher to highlight spread failures
-          echo "::add-matcher::.github/spread-problem-matcher.json"
-
-          export NESTED_BUILD_SNAPD_FROM_CURRENT=true
-          export NESTED_ENABLE_KVM=true
-
-          RUN_TESTS="google-nested:${{ matrix.system }}:tests/nested/..."
-          if [ -n "$FAILED_TESTS" ]; then
-              RUN_TESTS="$FAILED_TESTS"
-          fi
-
-          # Run spread tests
-          # "pipefail" ensures that a non-zero status from the spread is
-          # propagated; and we use a subshell as this option could trigger
-          # undesired changes elsewhere
-          (set -o pipefail; spread -abend $RUN_TESTS | tee spread.log)
-
-    - name: Cache successful run
-      run: |
-        touch "$CACHE_RESULT_STAMP"
-
-    - name: Discard spread workers
-      if: always()
-      run: |
-        shopt -s nullglob;
-        for r in .spread-reuse.*.yaml; do
-          spread -discard -reuse-pid="$(echo "$r" | grep -o -E '[0-9]+')";
-        done
-
-    - name: report spread errors
-      if: always()
-      run: |
-        if [ -e spread.log ]; then
-            echo "Running spread log analyzer"
-            issues_metadata='{"source_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}'
-            ./tests/lib/external/snapd-testing-tools/utils/log-parser spread.log --print-detail error --output spread-results.json --cut 100
-            while IFS= read -r line; do
-                if [ ! -z "$line" ]; then
-                    echo "Reporting spread error..."
-                    ./tests/lib/tools/report-mongodb --db-name snapd --db-collection spread_errors --metadata "$issues_metadata" "$line"
-                fi
-            done <<< $(jq -cr '.[] | select( .type == "info") | select( .info_type == "Error")' spread-results.json)
-        else
-            echo "No spread log found, skipping errors reporting"
-        fi
-
-    - name: save spread results
-      if: always()
-      run: |
-          if [ -f spread.log ]; then
-              echo "Running spread log analyzer"
-
-              # Aborted cannot be used to determine if we need to re-run all because it could be a aborted an entire suite
-              if grep -q "Aborted tasks: 0" spread.log; then
-                  ./tests/lib/external/snapd-testing-tools/utils/log-parser spread.log --output spread-results.json
-                  jq -r '.[] | select( .type == "result") | select( .result_type == "Failed") | select( .level == "task" or .level == "tasks" ) | .detail.lines[]' spread-results.json | grep "google-nested:" | cut -d '-' -f2- | tr '\n' ' ' > "$FAILED_TESTS_FILE"
-
-                  echo "Failed tests saved for re-execution: $(cat $FAILED_TESTS_FILE)"
-              else
-                  echo "No failed tests saved, this means all the tests will be executed next run"
-                  touch "$FAILED_TESTS_FILE"
-              fi
-          else
-              echo "No spread log found, saving empty list of failed tests"
-              touch "$FAILED_TESTS_FILE"
-          fi
-


### PR DESCRIPTION
This change includes:
 . Run first a workflow to make the static checks
 . Run in parallel all the unit tests
 . Run at the end the code coverage

This pr is created to validate the changes but it has deleted all the spread tests, so it can't be merged.