### PR TITLE
cmd/snap-confine: mount support cleanups

### DIFF
--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -38,10 +38,6 @@
 
 #define SC_NVIDIA_DRIVER_VERSION_FILE "/sys/module/nvidia/version"
 
-// note: if the parent dir changes to something other than
-// the current /var/lib/snapd/lib then sc_mkdir_and_mount_and_bind
-// and sc_mkdir_and_mount_and_glob_files might need updating, as they currently
-// assume that the parent directory of SC_LIB exists.
 #define SC_LIB "/var/lib/snapd/lib"
 #define SC_LIBGL_DIR   SC_LIB "/gl"
 #define SC_LIBGL32_DIR SC_LIB "/gl32"
@@ -591,8 +587,8 @@ void sc_mount_nvidia_driver(const char *rootfs_dir, const char *base_snap_name)
 	}
 
 	sc_identity old = sc_set_effective_identity(sc_root_group_identity());
-	int res = mkdir(SC_LIB, 0755);
-	if (res != 0 && errno != EEXIST) {
+	int res = sc_nonfatal_mkpath(SC_LIB, 0755);
+	if (res != 0) {
 		die("cannot create " SC_LIB);
 	}
 	if (res == 0 && (chown(SC_LIB, 0, 0) < 0)) {

--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -40,7 +40,8 @@
 
 // note: if the parent dir changes to something other than
 // the current /var/lib/snapd/lib then sc_mkdir_and_mount_and_bind
-// and sc_mkdir_and_mount_and_bind need updating.
+// and sc_mkdir_and_mount_and_glob_files might need updating, as they currently
+// assume that the parent directory of SC_LIB exists.
 #define SC_LIB "/var/lib/snapd/lib"
 #define SC_LIBGL_DIR   SC_LIB "/gl"
 #define SC_LIBGL32_DIR SC_LIB "/gl32"

--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -591,9 +591,9 @@ void sc_mount_nvidia_driver(const char *rootfs_dir, const char *base_snap_name)
 	if (res != 0) {
 		die("cannot create " SC_EXTRA_LIB_DIR);
 	}
-	if (res == 0 && (chown(SC_LIB, 0, 0) < 0)) {
+	if (res == 0 && (chown(SC_EXTRA_LIB_DIR, 0, 0) < 0)) {
 		// Adjust the ownership only if we created the directory.
-		die("cannot change ownership of " SC_LIB);
+		die("cannot change ownership of " SC_EXTRA_LIB_DIR);
 	}
 	(void)sc_set_effective_identity(old);
 

--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -35,14 +35,14 @@
 #include "../libsnap-confine-private/cleanup-funcs.h"
 #include "../libsnap-confine-private/string-utils.h"
 #include "../libsnap-confine-private/utils.h"
+#include "mount-support.h"
 
 #define SC_NVIDIA_DRIVER_VERSION_FILE "/sys/module/nvidia/version"
 
-#define SC_LIB "/var/lib/snapd/lib"
-#define SC_LIBGL_DIR   SC_LIB "/gl"
-#define SC_LIBGL32_DIR SC_LIB "/gl32"
-#define SC_VULKAN_DIR  SC_LIB "/vulkan"
-#define SC_GLVND_DIR  SC_LIB "/glvnd"
+#define SC_LIBGL_DIR   SC_EXTRA_LIB_DIR "/gl"
+#define SC_LIBGL32_DIR SC_EXTRA_LIB_DIR "/gl32"
+#define SC_VULKAN_DIR  SC_EXTRA_LIB_DIR "/vulkan"
+#define SC_GLVND_DIR  SC_EXTRA_LIB_DIR "/glvnd"
 
 #define SC_VULKAN_SOURCE_DIR "/usr/share/vulkan"
 #define SC_EGL_VENDOR_SOURCE_DIR "/usr/share/glvnd"
@@ -587,9 +587,9 @@ void sc_mount_nvidia_driver(const char *rootfs_dir, const char *base_snap_name)
 	}
 
 	sc_identity old = sc_set_effective_identity(sc_root_group_identity());
-	int res = sc_nonfatal_mkpath(SC_LIB, 0755);
+	int res = sc_nonfatal_mkpath(SC_EXTRA_LIB_DIR, 0755);
 	if (res != 0) {
-		die("cannot create " SC_LIB);
+		die("cannot create " SC_EXTRA_LIB_DIR);
 	}
 	if (res == 0 && (chown(SC_LIB, 0, 0) < 0)) {
 		// Adjust the ownership only if we created the directory.

--- a/cmd/snap-confine/mount-support.h
+++ b/cmd/snap-confine/mount-support.h
@@ -22,6 +22,16 @@
 #include "snap-confine-invocation.h"
 #include <sys/types.h>
 
+/* Base location where extra libraries might be made available to the snap.
+ * This is currently used for graphics drivers, but could pontentially be used
+ * for other goals as well.
+ *
+ * NOTE: do not bind-mount anything directly onto this directory! This is only
+ * a *base* directory: for exposing drivers and libraries, create a
+ * sub-directory in SC_EXTRA_LIB_DIR and use that one as the bind mount target.
+ */
+#define SC_EXTRA_LIB_DIR "/var/lib/snapd/lib"
+
 /**
  * Assuming a new mountspace, populate it accordingly.
  *


### PR DESCRIPTION
Here are a few cleanups, prompted by the new PR about a WSL2 mount-support module (https://github.com/snapcore/snapd/pull/11785).

There are just 4 small commits, but reviewing them as a whole can be a bit messy. I recommend have a look at each commit one by one to see the individual changes and the rationale.