### PR TITLE
secboot/keymgr: extend unit tests, add helper for identify keyslot used error

### DIFF
--- a/secboot/keymgr/keymgr_luks2.go
+++ b/secboot/keymgr/keymgr_luks2.go
@@ -59,6 +59,17 @@ func getEncryptionKeyFromUserKeyring(dev string) ([]byte, error) {
 	return currKey, err
 }
 
+var keyslotFull = regexp.MustCompile(`^.* cryptsetup failed with: Key slot [0-9]+ is full, please select another one\.$`)
+
+// IsKeyslotAlreadyUsed returns true if the error indicates that the keyslot
+// attempted for a given key is already used
+func IsKeyslotAlreadyUsed(err error) bool {
+	if err == nil {
+		return false
+	}
+	return keyslotFull.MatchString(err.Error())
+}
+
 func isKeyslotNotActive(err error) bool {
 	match, _ := regexp.MatchString(`.*: Keyslot [0-9]+ is not active`, err.Error())
 	return match

--- a/secboot/keymgr/keymgr_luks2_test.go
+++ b/secboot/keymgr/keymgr_luks2_test.go
@@ -178,6 +178,8 @@ exit 1
 	defer cmd.Restore()
 	err := keymgr.AddRecoveryKeyToLUKSDevice(mockRecoveryKey, "/dev/foobar")
 	c.Assert(err, ErrorMatches, "cannot add key: cryptsetup failed with: Other error, cryptsetup boom")
+	// should match the keyslot full error too
+	c.Assert(keymgr.IsKeyslotAlreadyUsed(err), Equals, false)
 }
 
 func (s *keymgrSuite) TestAddRecoveryKeyToDeviceOccupiedSlot(c *C) {
@@ -215,6 +217,8 @@ exit 1
 	c.Assert(calls, HasLen, 1)
 	c.Assert(calls[0], HasLen, 16)
 	c.Assert(calls[0][:2], DeepEquals, []string{"cryptsetup", "luksAddKey"})
+	// should match the keyslot full error too
+	c.Assert(keymgr.IsKeyslotAlreadyUsed(err), Equals, true)
 }
 
 func (s *keymgrSuite) TestAddRecoveryKeyToDeviceUsingExistingKey(c *C) {


### PR DESCRIPTION
Extend secboot/keymgr tests to cover a scenario in which cryptsetup fails with some arbitrary error. Add a helper to identify keyslot full errors. Unfortunately there's no smarter way to introspect the errors coming out from snapcore/secboot cryptsetup
wrappers our code is based on. Unfortunately there's no reasonable way to identify particular error coming from cryptsetup either, even though the manpage lists different error exit statuses, trying to use an occupied error falls under 'parameters' and has the status 1 which is shared with other errors. 

