### PR TITLE
tests: fix the system-snap-refresh test

### DIFF
--- a/tests/core/system-snap-refresh/task.yaml
+++ b/tests/core/system-snap-refresh/task.yaml
@@ -46,22 +46,10 @@ execute: |
         fi
 
         # install new target snap
-
-        snap install --dangerous "/var/lib/snapd/snaps/${TARGET_SNAP_NAME}_${currRev}.snap" &> refresh.log
-        MATCH "snapd is about to reboot the system" < refresh.log
+        snap install --dangerous --no-wait "/var/lib/snapd/snaps/${TARGET_SNAP_NAME}_${currRev}.snap"
 
         # Detect in the logs when the reboot can been triggered
-        for _ in $(seq 50); do
-            if "$TESTSTOOLS"/journal-state match-log "Waiting for system reboot"; then
-                 break
-            fi
-            sleep 2
-        done
-
-        if ! "$TESTSTOOLS"/journal-state match-log "Waiting for system reboot"; then
-            echo "Taking too long to reach waiting for reboot"
-            exit 1
-        fi
+        "$TESTSTOOLS"/journal-state match-log -n 50 --wait 2 "Waiting for system reboot"
 
         REBOOT
     elif [ "$SPREAD_REBOOT" = 1 ]; then
@@ -77,17 +65,7 @@ execute: |
         MATCH "snapd is about to reboot the system" < revert.log
 
         # Detect in the logs when the reboot can been triggered
-        for _ in $(seq 50); do
-            if "$TESTSTOOLS"/journal-state match-log "Waiting for system reboot" -b; then
-                 break
-            fi
-            sleep 2
-        done
-
-        if ! "$TESTSTOOLS"/journal-state match-log "Waiting for system reboot" -b; then
-            echo "Taking too long to reach waiting for reboot"
-            exit 1
-        fi
+        "$TESTSTOOLS"/journal-state match-log -n 50 --wait 2 "Waiting for system reboot"
 
         REBOOT
     elif [  "$SPREAD_REBOOT" = 2 ]; then


### PR DESCRIPTION
The test is failing to install core20, this is sporadic and happens that the system instance suddenly loose connection. 
This is nan example of the error. 

The idea is to while the core snap is being installed, instead of iterating doing match-log, the test now uses the match-log  attributes -n and --wait as we do with retry tool. Also the snap install is done using the --no-wait to avoid the test finishes before the match-log finds the "Waiting for system reboot" message
