### PR TITLE
tests: fix auto-refresh-gating test forcing reset-failed before restart

### DIFF
--- a/tests/main/auto-refresh-gating/task.yaml
+++ b/tests/main/auto-refresh-gating/task.yaml
@@ -55,6 +55,7 @@ execute: |
 
     echo "Trigger auto-refresh of test-snapd-refresh-control-provider but hold it via test-snapd-refresh-control's hook"
     "$TESTSTOOLS"/snapd-state force-autorefresh
+    systemctl reset-failed snapd.{service,socket}
     systemctl start snapd.{service,socket}
     LAST_REFRESH_CHANGE_ID=$("$TESTSTOOLS"/snapd-state wait-for-snap-autorefresh "$CONTENT_SNAP_NAME" "$LAST_REFRESH_CHANGE_ID")
 
@@ -91,6 +92,7 @@ execute: |
   echo "--proceed" > "$CONTROL_FILE"
 
   "$TESTSTOOLS"/snapd-state force-autorefresh
+  systemctl reset-failed snapd.{service,socket}
   systemctl start snapd.{service,socket}
   LAST_REFRESH_CHANGE_ID=$("$TESTSTOOLS"/snapd-state wait-for-snap-autorefresh "$CONTENT_SNAP_NAME" "$LAST_REFRESH_CHANGE_ID")
 
@@ -116,6 +118,7 @@ execute: |
   "$TESTSTOOLS"/snapd-state change-snap-channel "$SNAP_NAME" beta
   "$TESTSTOOLS"/snapd-state force-autorefresh
 
+  systemctl reset-failed snapd.{service,socket}
   systemctl start snapd.{service,socket}
   LAST_REFRESH_CHANGE_ID=$("$TESTSTOOLS"/snapd-state wait-for-snap-autorefresh "$SNAP_NAME" "$LAST_REFRESH_CHANGE_ID")
 
@@ -138,6 +141,7 @@ execute: |
   echo "--proceed" > "$CONTROL_FILE"
   "$TESTSTOOLS"/snapd-state force-autorefresh
 
+  systemctl reset-failed snapd.{service,socket}
   systemctl start snapd.{service,socket}
   LAST_REFRESH_CHANGE_ID=$("$TESTSTOOLS"/snapd-state wait-for-snap-autorefresh "$SNAP_NAME" "$LAST_REFRESH_CHANGE_ID")
 
@@ -153,6 +157,7 @@ execute: |
   "$TESTSTOOLS"/snapd-state change-snap-channel "$CONTENT_SNAP_NAME" edge
   "$TESTSTOOLS"/snapd-state force-autorefresh
 
+  systemctl reset-failed snapd.{service,socket}
   systemctl start snapd.{service,socket}
   LAST_REFRESH_CHANGE_ID=$("$TESTSTOOLS"/snapd-state wait-for-snap-autorefresh "$CONTENT_SNAP_NAME" "$LAST_REFRESH_CHANGE_ID")
 
@@ -171,6 +176,7 @@ execute: |
   "$TESTSTOOLS"/snapd-state change-snap-channel "$CONTENT_SNAP_NAME" edge
   "$TESTSTOOLS"/snapd-state force-autorefresh
 
+  systemctl reset-failed snapd.{service,socket}
   systemctl start snapd.{service,socket}
   LAST_REFRESH_CHANGE_ID=$("$TESTSTOOLS"/snapd-state wait-for-snap-autorefresh "$CONTENT_SNAP_NAME" "$LAST_REFRESH_CHANGE_ID")
 


### PR DESCRIPTION
The test auto-refresh-gating is failing sporadically while snapd.socket is restarted with error 'start-limit-hit'.

The solution is to reset-failed before the snapd.socket is restarted.

To reproduce the issue run: 
-> spread-debug -debug -order -workers 1  google:centos-8-64:tests/main/snap-quota google:centos-8-64:tests/main/auto-refresh-gating

This is the issue:

● snapd.socket - Socket activation for snappy daemon
Loaded: loaded (/usr/lib/systemd/system/snapd.socket; enabled; vendor
preset: disabled)
Active: failed (Result: start-limit-hit) since Mon 2022-05-16
16:23:46 UTC; 11min ago
   Listen: /run/snapd.socket (Stream)
           /run/snapd-snap.socket (Stream)

May 16 16:23:46 may161603-595563 systemd[1]: Starting Socket activation
for snappy daemon.
May 16 16:23:46 may161603-595563 systemd[1]: Listening on Socket
activation for snappy daemon.
May 16 16:23:46 may161603-595563 systemd[1]: snapd.socket: Start request
repeated too quickly.
May 16 16:23:46 may161603-595563 systemd[1]: snapd.socket: Failed with
result 'start-limit-hit'.
May 16 16:23:46 may161603-595563 systemd[1]: Failed to listen on Socket
activation for snappy daemon.
