### PR TITLE
interfaces: allow map and execute permissions for files on removable media

### DIFF
--- a/interfaces/builtin/removable_media.go
+++ b/interfaces/builtin/removable_media.go
@@ -41,12 +41,12 @@ const removableMediaConnectedPlugAppArmor = `
 
 # Mount points could be in /run/media/<user>/* or /media/<user>/*
 /{,run/}media/*/ r,
-/{,run/}media/*/** rwkl,
+/{,run/}media/*/** mrwklix,
 
 # Allow read-only access to /mnt to enumerate items.
 /mnt/ r,
 # Allow write access to anything under /mnt
-/mnt/** rwkl,
+/mnt/** mrwklix,
 `
 
 func init() {

--- a/interfaces/builtin/removable_media_test.go
+++ b/interfaces/builtin/removable_media_test.go
@@ -80,7 +80,7 @@ func (s *RemovableMediaInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.client-snap.other"})
 	c.Check(apparmorSpec.SnippetForTag("snap.client-snap.other"), testutil.Contains, "/{,run/}media/*/ r")
-	c.Check(apparmorSpec.SnippetForTag("snap.client-snap.other"), testutil.Contains, "/mnt/** rwkl,")
+	c.Check(apparmorSpec.SnippetForTag("snap.client-snap.other"), testutil.Contains, "/mnt/** mrwklix,")
 }
 
 func (s *RemovableMediaInterfaceSuite) TestInterfaces(c *C) {


### PR DESCRIPTION
This PR is intended to help address https://github.com/canonical/steam-snap/issues/9 in the Steam snap. Steam allows the user to change the location where it stores games it downloads. While we are not trying to support arbitrary locations with the snap, one common case is to place the library on a volume mounted in `/media`. We almost support this by plugging the `removable-media` interface. Unfortunately, the AppArmor restrictions of that interface do not include execute permission.

This PR adds map and execute permissions for files under `/mnt/` and `/media/*/` to address this. As per @alexmurray's comment, it isn't worth making this configurable since a snap can already execute files found in these locations by first copying them to `$SNAP_USER_DATA`.