### PR TITLE
testutil: add ErrorIs test checker

### DIFF
--- a/testutil/errorischecker.go
+++ b/testutil/errorischecker.go
@@ -1,0 +1,54 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package testutil
+
+import (
+	"errors"
+	"fmt"
+
+	"gopkg.in/check.v1"
+)
+
+// ErrorIs calls errors.Is with the provided arguments.
+var ErrorIs = &errorIsChecker{
+	&check.CheckerInfo{Name: "ErrorIs", Params: []string{"error", "target"}},
+}
+
+type errorIsChecker struct {
+	*check.CheckerInfo
+}
+
+func (*errorIsChecker) Check(params []interface{}, names []string) (result bool, errMsg string) {
+	if params[0] == nil {
+		return params[1] == nil, ""
+	}
+
+	err, ok := params[0].(error)
+	if !ok {
+		return false, fmt.Sprintf("first argument must be an error")
+	}
+
+	target, ok := params[1].(error)
+	if !ok {
+		return false, fmt.Sprintf("second argument must be an error")
+	}
+
+	return errors.Is(err, target), ""
+}

--- a/testutil/errorischecker_test.go
+++ b/testutil/errorischecker_test.go
@@ -1,0 +1,73 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package testutil_test
+
+import (
+	"errors"
+
+	. "github.com/snapcore/snapd/testutil"
+
+	. "gopkg.in/check.v1"
+)
+
+type errorIsCheckerSuite struct{}
+
+var _ = Suite(&errorIsCheckerSuite{})
+
+type baseError struct{}
+
+func (baseError) Error() string { return "" }
+
+func (baseError) Is(err error) bool {
+	_, ok := err.(baseError)
+	return ok
+}
+
+type wrapperError struct {
+	err error
+}
+
+func (*wrapperError) Error() string { return "" }
+
+func (e *wrapperError) Unwrap() error { return e.err }
+
+func (*errorIsCheckerSuite) TestErrorIsCheckSucceeds(c *C) {
+	testInfo(c, ErrorIs, "ErrorIs", []string{"error", "target"})
+
+	c.Assert(baseError{}, ErrorIs, baseError{})
+	err := &wrapperError{err: baseError{}}
+	c.Assert(err, ErrorIs, baseError{})
+}
+
+func (*errorIsCheckerSuite) TestErrorIsCheckFails(c *C) {
+	c.Assert(nil, Not(ErrorIs), baseError{})
+	c.Assert(errors.New(""), Not(ErrorIs), baseError{})
+}
+
+func (*errorIsCheckerSuite) TestErrorIsWithInvalidArguments(c *C) {
+	res, errMsg := ErrorIs.Check([]interface{}{"", errors.New("")}, []string{"error", "target"})
+	c.Assert(res, Equals, false)
+	c.Assert(errMsg, Equals, "first argument must be an error")
+
+	res, errMsg = ErrorIs.Check([]interface{}{errors.New(""), ""}, []string{"error", "target"})
+	c.Assert(res, Equals, false)
+	c.Assert(errMsg, Equals, "second argument must be an error")
+
+}


### PR DESCRIPTION
This PR adds a new test checker that will be used to replaced error equality checks in tests for their `ErrorIs` equivalent. The idea is that some of the usages of `ErrNoState` don't have all the relevant information and some should even have entirely different error messages. Before we can replace `ErrNoState` where it's returned, we want to change the places that consume it to use `errors.Is` so that we can then change the return sites gradually. Ticket with context: https://warthogs.atlassian.net/browse/SNAPDENG-120
The next PR will replace the equals checker with this one, in the appropriate test checks, as well as occurrences of `!=` and `==` with the `errors.Is(...)` equivalent.