### PR TITLE
.github: Trigger daily riscv64 snapd edge builds

### DIFF
--- a/.github/workflows/riscv64-builds.yml
+++ b/.github/workflows/riscv64-builds.yml
@@ -1,0 +1,19 @@
+name: lp-snap-request-build-riscv64
+
+on:
+  schedule:
+  - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  lp-snap-request-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: trigger-lp-snap-request-build
+        env:
+          SNAPD_RISCV64_BOT_BASE64: ${{ secrets.SNAPD_RISCV64_BOT_BASE64 }}
+        if: env.SNAPD_RISCV64_BOT_BASE64 != null
+        run: |
+          sudo apt install -y lptools
+          echo $SNAPD_RISCV64_BOT_BASE64 | base64 --decode > SNAPD_RISCV64_BOT.cred
+          lp-shell --credentials-file=SNAPD_RISCV64_BOT.cred -c 'snap=lp.load("~snappy-dev-riscv64/+snap/snapd-master-riscv64"); snap.requestBuilds(archive=snap.auto_build_archive_link, channels=snap.auto_build_channels, pocket=snap.auto_build_pocket)'


### PR DESCRIPTION
Use github actions workflow to trigger daily riscv64 snapd edge
builds.