### PR TITLE
interfaces/modem-manager: Don't generate DBus plug policy

### DIFF
--- a/interfaces/builtin/modem_manager.go
+++ b/interfaces/builtin/modem_manager.go
@@ -249,16 +249,13 @@ socket AF_NETLINK - NETLINK_KOBJECT_UEVENT
 `
 
 const modemManagerPermanentSlotDBus = `
-<policy user="root">
-    <allow own="org.freedesktop.ModemManager1"/>
-    <allow send_destination="org.freedesktop.ModemManager1"/>
-</policy>
-`
-
-const modemManagerConnectedPlugDBus = `
 <policy context="default">
     <deny own="org.freedesktop.ModemManager1"/>
     <deny send_destination="org.freedesktop.ModemManager1"/>
+</policy>
+<policy user="root">
+    <allow own="org.freedesktop.ModemManager1"/>
+    <allow send_destination="org.freedesktop.ModemManager1"/>
 </policy>
 `
 
@@ -1353,16 +1350,6 @@ func (iface *modemManagerInterface) AppArmorConnectedPlug(spec *apparmor.Specifi
 	if release.OnClassic {
 		// Let confined apps access unconfined ofono on classic
 		spec.AddSnippet(modemManagerConnectedPlugAppArmorClassic)
-	}
-	return nil
-}
-
-func (iface *modemManagerInterface) DBusConnectedPlug(spec *dbus.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
-	// Don't create default policy on classic otherwise it will likely
-	// conflict with any existing policy for ModemManager from the
-	// distro itself
-	if !release.OnClassic {
-		spec.AddSnippet(modemManagerConnectedPlugDBus)
 	}
 	return nil
 }

--- a/interfaces/builtin/modem_manager.go
+++ b/interfaces/builtin/modem_manager.go
@@ -1358,7 +1358,12 @@ func (iface *modemManagerInterface) AppArmorConnectedPlug(spec *apparmor.Specifi
 }
 
 func (iface *modemManagerInterface) DBusConnectedPlug(spec *dbus.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
-	spec.AddSnippet(modemManagerConnectedPlugDBus)
+	// Don't create default policy on classic otherwise it will likely
+	// conflict with any existing policy for ModemManager from the
+	// distro itself
+	if !release.OnClassic {
+		spec.AddSnippet(modemManagerConnectedPlugDBus)
+	}
 	return nil
 }
 

--- a/interfaces/builtin/modem_manager_test.go
+++ b/interfaces/builtin/modem_manager_test.go
@@ -190,7 +190,6 @@ func (s *ModemManagerInterfaceSuite) TestConnectedPlugSnippetUsesUnconfinedLabel
 }
 
 func (s *ModemManagerInterfaceSuite) TestUsedSecuritySystems(c *C) {
-	release.OnClassic = true
 	plugSnap := snaptest.MockInfo(c, modemmgrMockPlugSnapInfoYaml, nil)
 	plug := interfaces.NewConnectedPlug(plugSnap.Plugs["modem-manager"], nil, nil)
 	apparmorSpec := &apparmor.Specification{}
@@ -201,7 +200,6 @@ func (s *ModemManagerInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	dbusSpec := &dbus.Specification{}
 	err = dbusSpec.AddConnectedPlug(s.iface, plug, s.slot)
 	c.Assert(err, IsNil)
-	// only added on non-classic systems
 	c.Assert(dbusSpec.SecurityTags(), HasLen, 0)
 
 	dbusSpec = &dbus.Specification{}
@@ -244,10 +242,7 @@ func (s *ModemManagerInterfaceSuite) TestConnectedPlugDBus(c *C) {
 	dbusSpec := &dbus.Specification{}
 	err := dbusSpec.AddConnectedPlug(s.iface, plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(dbusSpec.SecurityTags(), DeepEquals, []string{"snap.modem-manager.mmcli"})
-	snippet := dbusSpec.SnippetForTag("snap.modem-manager.mmcli")
-	c.Assert(snippet, testutil.Contains, "deny own=\"org.freedesktop.ModemManager1\"")
-	c.Assert(snippet, testutil.Contains, "deny send_destination=\"org.freedesktop.ModemManager1\"")
+	c.Assert(dbusSpec.SecurityTags(), DeepEquals, []string(nil))
 }
 
 func (s *ModemManagerInterfaceSuite) TestConnectedPlugDBusClassic(c *C) {

--- a/interfaces/builtin/modem_manager_test.go
+++ b/interfaces/builtin/modem_manager_test.go
@@ -190,6 +190,7 @@ func (s *ModemManagerInterfaceSuite) TestConnectedPlugSnippetUsesUnconfinedLabel
 }
 
 func (s *ModemManagerInterfaceSuite) TestUsedSecuritySystems(c *C) {
+	release.OnClassic = true
 	plugSnap := snaptest.MockInfo(c, modemmgrMockPlugSnapInfoYaml, nil)
 	plug := interfaces.NewConnectedPlug(plugSnap.Plugs["modem-manager"], nil, nil)
 	apparmorSpec := &apparmor.Specification{}
@@ -200,7 +201,8 @@ func (s *ModemManagerInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	dbusSpec := &dbus.Specification{}
 	err = dbusSpec.AddConnectedPlug(s.iface, plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(dbusSpec.SecurityTags(), HasLen, 1)
+	// only added on non-classic systems
+	c.Assert(dbusSpec.SecurityTags(), HasLen, 0)
 
 	dbusSpec = &dbus.Specification{}
 	err = dbusSpec.AddPermanentSlot(s.iface, s.slotInfo)
@@ -235,6 +237,7 @@ func (s *ModemManagerInterfaceSuite) TestPermanentSlotSecComp(c *C) {
 }
 
 func (s *ModemManagerInterfaceSuite) TestConnectedPlugDBus(c *C) {
+	release.OnClassic = false
 	plugSnap := snaptest.MockInfo(c, modemmgrMockPlugSnapInfoYaml, nil)
 	plug := interfaces.NewConnectedPlug(plugSnap.Plugs["modem-manager"], nil, nil)
 
@@ -245,6 +248,17 @@ func (s *ModemManagerInterfaceSuite) TestConnectedPlugDBus(c *C) {
 	snippet := dbusSpec.SnippetForTag("snap.modem-manager.mmcli")
 	c.Assert(snippet, testutil.Contains, "deny own=\"org.freedesktop.ModemManager1\"")
 	c.Assert(snippet, testutil.Contains, "deny send_destination=\"org.freedesktop.ModemManager1\"")
+}
+
+func (s *ModemManagerInterfaceSuite) TestConnectedPlugDBusClassic(c *C) {
+	plugSnap := snaptest.MockInfo(c, modemmgrMockPlugSnapInfoYaml, nil)
+	plug := interfaces.NewConnectedPlug(plugSnap.Plugs["modem-manager"], nil, nil)
+
+	release.OnClassic = true
+	dbusSpec := &dbus.Specification{}
+	err := dbusSpec.AddConnectedPlug(s.iface, plug, s.slot)
+	c.Assert(err, IsNil)
+	c.Assert(dbusSpec.SecurityTags(), DeepEquals, []string(nil))
 }
 
 func (s *ModemManagerInterfaceSuite) TestInterfaces(c *C) {


### PR DESCRIPTION
Classic systems provide their own ModemManager along with it's own DBus
policy - if we also generate DBus policy for ModemManager when a snap plugs
this interface, this will likely conflict with the DBus policy from the
classic system itself and cause unexpected results. As such, only generate
DBus policy for ModemManager when a snap plugs this interface on
non-classic systems (ie. Ubuntu Core etc).

See
https://forum.snapcraft.io/t/dbus-access-denied-while-using-modem-manager-plug-in-snap/29037/12
for background and discussion.

Signed-off-by: Alex Murray <alex.murray@canonical.com>

-------