### PR TITLE
snapcraft.yaml: bump stable branch to release/2.56

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -30,7 +30,7 @@ parts:
     plugin: nil
     source-type: git
     source: https://git.launchpad.net/snapd
-    source-branch: release/2.55
+    source-branch: release/2.56
     build-snaps:
       - on riscv64: [go/1.16/stable]
       - else: [go/1.13/stable]


### PR DESCRIPTION
This will ensure that the "stable" build for riscv64 happens from the right branch.

Note that this is against "beta-riscv64" not **master**.

The build for riscv64 for beta/stable happens in https://launchpad.net/~snappy-dev/+snap/snapd-beta-riscv64