### PR TITLE
interfaces/serial-port: add ttyGS to serial port allow list

### DIFF
--- a/interfaces/builtin/serial_port.go
+++ b/interfaces/builtin/serial_port.go
@@ -75,7 +75,8 @@ func (iface *serialPortInterface) String() string {
 //  - ttySCX (NXP SC16IS7xx serial devices)
 //  - ttyMSMX (Qualcomm msm7x serial devices)
 //  - ttyHSX (Qualcomm GENI based QTI serial cores)
-var serialDeviceNodePattern = regexp.MustCompile("^/dev/tty(mxc|USB|ACM|AMA|XRUSB|S|O|SC|MSM|HS)[0-9]+$")
+//  - ttyGSX (USB gadget serial devices)
+var serialDeviceNodePattern = regexp.MustCompile("^/dev/tty(mxc|USB|ACM|AMA|XRUSB|S|O|SC|MSM|HS|GS)[0-9]+$")
 
 // Pattern that is considered valid for the udev symlink to the serial device,
 // path attributes will be compared to this for validity when usb vid and pid

--- a/interfaces/builtin/serial_port_test.go
+++ b/interfaces/builtin/serial_port_test.go
@@ -90,8 +90,8 @@ type SerialPortInterfaceSuite struct {
 	badPathSlot11Info    *snap.SlotInfo
 	badPathSlot12        *interfaces.ConnectedSlot
 	badPathSlot12Info    *snap.SlotInfo
-	badPathSlot13        *interfaces.ConnectedSlot
-	badPathSlot13Info    *snap.SlotInfo
+	badPathSlot100        *interfaces.ConnectedSlot
+	badPathSlot100Info    *snap.SlotInfo
 	badInterfaceSlot     *interfaces.ConnectedSlot
 	badInterfaceSlotInfo *snap.SlotInfo
 
@@ -204,7 +204,7 @@ slots:
     bad-path-12:
         interface: serial-port
         path: /dev/ttyHS
-    bad-path-13:
+    bad-path-100:
         interface: serial-port
         path: /dev/ttyillegal0
     bad-interface: other-interface
@@ -259,8 +259,8 @@ slots:
 	s.badPathSlot11 = interfaces.NewConnectedSlot(s.badPathSlot11Info, nil, nil)
 	s.badPathSlot12Info = osSnapInfo.Slots["bad-path-12"]
 	s.badPathSlot12 = interfaces.NewConnectedSlot(s.badPathSlot12Info, nil, nil)
-	s.badPathSlot13Info = osSnapInfo.Slots["bad-path-13"]
-	s.badPathSlot13 = interfaces.NewConnectedSlot(s.badPathSlot13Info, nil, nil)
+	s.badPathSlot100Info = osSnapInfo.Slots["bad-path-100"]
+	s.badPathSlot100 = interfaces.NewConnectedSlot(s.badPathSlot100Info, nil, nil)
 	s.badInterfaceSlotInfo = osSnapInfo.Slots["bad-interface"]
 	s.badInterfaceSlot = interfaces.NewConnectedSlot(s.badInterfaceSlotInfo, nil, nil)
 
@@ -365,7 +365,19 @@ func (s *SerialPortInterfaceSuite) TestName(c *C) {
 }
 
 func (s *SerialPortInterfaceSuite) TestSanitizeCoreSnapSlots(c *C) {
-	for _, slot := range []*snap.SlotInfo{s.testSlot1Info, s.testSlot2Info, s.testSlot3Info, s.testSlot4Info, s.testSlot5Info, s.testSlot6Info, s.testSlot7Info, s.testSlot8Info, s.testSlot9Info, s.testSlot10Info, s.testSlot11Info} {
+	for _, slot := range []*snap.SlotInfo{
+		s.testSlot1Info,
+		s.testSlot2Info,
+		s.testSlot3Info,
+		s.testSlot4Info,
+		s.testSlot5Info,
+		s.testSlot6Info,
+		s.testSlot7Info,
+		s.testSlot8Info,
+		s.testSlot9Info,
+		s.testSlot10Info,
+		s.testSlot11Info,
+	} {
 		c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), IsNil)
 	}
 }
@@ -375,7 +387,21 @@ func (s *SerialPortInterfaceSuite) TestSanitizeBadCoreSnapSlots(c *C) {
 	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.missingPathSlotInfo), ErrorMatches, `serial-port slot must have a path attribute`)
 
 	// Slots with incorrect value of the "path" attribute are rejected.
-	for _, slot := range []*snap.SlotInfo{s.badPathSlot1Info, s.badPathSlot2Info, s.badPathSlot3Info, s.badPathSlot4Info, s.badPathSlot5Info, s.badPathSlot6Info, s.badPathSlot7Info, s.badPathSlot8Info, s.badPathSlot9Info, s.badPathSlot10Info, s.badPathSlot11Info, s.badPathSlot12Info, s.badPathSlot13Info} {
+	for _, slot := range []*snap.SlotInfo{
+		s.badPathSlot1Info,
+		s.badPathSlot2Info,
+		s.badPathSlot3Info,
+		s.badPathSlot4Info,
+		s.badPathSlot5Info,
+		s.badPathSlot6Info,
+		s.badPathSlot7Info,
+		s.badPathSlot8Info,
+		s.badPathSlot9Info,
+		s.badPathSlot10Info,
+		s.badPathSlot11Info,
+		s.badPathSlot12Info,
+		s.badPathSlot100Info,
+	} {
 		c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), ErrorMatches, "serial-port path attribute must be a valid device node")
 	}
 }
@@ -534,14 +560,14 @@ func (s *SerialPortInterfaceSuite) TestConnectedPlugAppArmorSnippets(c *C) {
 	expectedSnippet11 := `/dev/ttyHS0 rwk,`
 	checkConnectedPlugSnippet(s.testPlugPort1, s.testSlot11, expectedSnippet11)
 
-	expectedSnippet12 := `/dev/tty[A-Z]*[0-9] rwk,`
-	checkConnectedPlugSnippet(s.testPlugPort1, s.testUDev1, expectedSnippet12)
+	expectedSnippet100 := `/dev/tty[A-Z]*[0-9] rwk,`
+	checkConnectedPlugSnippet(s.testPlugPort1, s.testUDev1, expectedSnippet100)
 
-	expectedSnippet13 := `/dev/tty[A-Z]*[0-9] rwk,`
-	checkConnectedPlugSnippet(s.testPlugPort2, s.testUDev2, expectedSnippet13)
+	expectedSnippet101 := `/dev/tty[A-Z]*[0-9] rwk,`
+	checkConnectedPlugSnippet(s.testPlugPort2, s.testUDev2, expectedSnippet101)
 
-	expectedSnippet14 := `/dev/tty[A-Z]*[0-9] rwk,`
-	checkConnectedPlugSnippet(s.testPlugPort2, s.testUDev3, expectedSnippet14)
+	expectedSnippet102 := `/dev/tty[A-Z]*[0-9] rwk,`
+	checkConnectedPlugSnippet(s.testPlugPort2, s.testUDev3, expectedSnippet102)
 }
 
 func (s *SerialPortInterfaceSuite) TestConnectedPlugUDevSnippetsForPath(c *C) {
@@ -614,17 +640,17 @@ SUBSYSTEM=="tty", KERNEL=="ttyHS0", TAG+="snap_client-snap_app-accessing-3rd-por
 	checkConnectedPlugSnippet(s.testPlugPort3, s.testSlot11, expectedSnippet11, expectedExtraSnippet11)
 
 	// these have product and vendor ids
-	expectedSnippet12 := `# serial-port
+	expectedSnippet100 := `# serial-port
 IMPORT{builtin}="usb_id"
 SUBSYSTEM=="tty", SUBSYSTEMS=="usb", ATTRS{idVendor}=="0001", ATTRS{idProduct}=="0001", TAG+="snap_client-snap_app-accessing-3rd-port"`
-	expectedExtraSnippet12 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-3rd-port", RUN+="%v/snap-device-helper $env{ACTION} snap_client-snap_app-accessing-3rd-port $devpath $major:$minor"`, dirs.DistroLibExecDir)
-	checkConnectedPlugSnippet(s.testPlugPort3, s.testUDev1, expectedSnippet12, expectedExtraSnippet12)
+	expectedExtraSnippet100 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-3rd-port", RUN+="%v/snap-device-helper $env{ACTION} snap_client-snap_app-accessing-3rd-port $devpath $major:$minor"`, dirs.DistroLibExecDir)
+	checkConnectedPlugSnippet(s.testPlugPort3, s.testUDev1, expectedSnippet100, expectedExtraSnippet100)
 
-	expectedSnippet13 := `# serial-port
+	expectedSnippet101 := `# serial-port
 IMPORT{builtin}="usb_id"
 SUBSYSTEM=="tty", SUBSYSTEMS=="usb", ATTRS{idVendor}=="ffff", ATTRS{idProduct}=="ffff", TAG+="snap_client-snap_app-accessing-3rd-port"`
-	expectedExtraSnippet13 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-3rd-port", RUN+="%v/snap-device-helper $env{ACTION} snap_client-snap_app-accessing-3rd-port $devpath $major:$minor"`, dirs.DistroLibExecDir)
-	checkConnectedPlugSnippet(s.testPlugPort3, s.testUDev2, expectedSnippet13, expectedExtraSnippet13)
+	expectedExtraSnippet101 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-3rd-port", RUN+="%v/snap-device-helper $env{ACTION} snap_client-snap_app-accessing-3rd-port $devpath $major:$minor"`, dirs.DistroLibExecDir)
+	checkConnectedPlugSnippet(s.testPlugPort3, s.testUDev2, expectedSnippet101, expectedExtraSnippet101)
 }
 
 func (s *SerialPortInterfaceSuite) TestHotplugDeviceDetected(c *C) {

--- a/interfaces/builtin/serial_port_test.go
+++ b/interfaces/builtin/serial_port_test.go
@@ -62,6 +62,8 @@ type SerialPortInterfaceSuite struct {
 	testSlot10Info       *snap.SlotInfo
 	testSlot11           *interfaces.ConnectedSlot
 	testSlot11Info       *snap.SlotInfo
+	testSlot12           *interfaces.ConnectedSlot
+	testSlot12Info       *snap.SlotInfo
 	testSlotCleaned      *interfaces.ConnectedSlot
 	testSlotCleanedInfo  *snap.SlotInfo
 	missingPathSlot      *interfaces.ConnectedSlot
@@ -90,6 +92,8 @@ type SerialPortInterfaceSuite struct {
 	badPathSlot11Info    *snap.SlotInfo
 	badPathSlot12        *interfaces.ConnectedSlot
 	badPathSlot12Info    *snap.SlotInfo
+	badPathSlot13        *interfaces.ConnectedSlot
+	badPathSlot13Info    *snap.SlotInfo
 	badPathSlot100        *interfaces.ConnectedSlot
 	badPathSlot100Info    *snap.SlotInfo
 	badInterfaceSlot     *interfaces.ConnectedSlot
@@ -164,6 +168,9 @@ slots:
     test-port-11:
         interface: serial-port
         path: /dev/ttyHS0
+    test-port-12:
+        interface: serial-port
+        path: /dev/ttyGS0
     test-port-unclean:
         interface: serial-port
         path: /dev/./././ttyS1////
@@ -204,6 +211,9 @@ slots:
     bad-path-12:
         interface: serial-port
         path: /dev/ttyHS
+    bad-path-13:
+        interface: serial-port
+        path: /dev/ttyGS
     bad-path-100:
         interface: serial-port
         path: /dev/ttyillegal0
@@ -231,6 +241,8 @@ slots:
 	s.testSlot10 = interfaces.NewConnectedSlot(s.testSlot10Info, nil, nil)
 	s.testSlot11Info = osSnapInfo.Slots["test-port-11"]
 	s.testSlot11 = interfaces.NewConnectedSlot(s.testSlot11Info, nil, nil)
+	s.testSlot12Info = osSnapInfo.Slots["test-port-12"]
+	s.testSlot12 = interfaces.NewConnectedSlot(s.testSlot12Info, nil, nil)
 	s.testSlotCleanedInfo = osSnapInfo.Slots["test-port-unclean"]
 	s.testSlotCleaned = interfaces.NewConnectedSlot(s.testSlotCleanedInfo, nil, nil)
 	s.missingPathSlotInfo = osSnapInfo.Slots["missing-path"]
@@ -259,6 +271,8 @@ slots:
 	s.badPathSlot11 = interfaces.NewConnectedSlot(s.badPathSlot11Info, nil, nil)
 	s.badPathSlot12Info = osSnapInfo.Slots["bad-path-12"]
 	s.badPathSlot12 = interfaces.NewConnectedSlot(s.badPathSlot12Info, nil, nil)
+	s.badPathSlot13Info = osSnapInfo.Slots["bad-path-13"]
+	s.badPathSlot13 = interfaces.NewConnectedSlot(s.badPathSlot13Info, nil, nil)
 	s.badPathSlot100Info = osSnapInfo.Slots["bad-path-100"]
 	s.badPathSlot100 = interfaces.NewConnectedSlot(s.badPathSlot100Info, nil, nil)
 	s.badInterfaceSlotInfo = osSnapInfo.Slots["bad-interface"]
@@ -377,6 +391,7 @@ func (s *SerialPortInterfaceSuite) TestSanitizeCoreSnapSlots(c *C) {
 		s.testSlot9Info,
 		s.testSlot10Info,
 		s.testSlot11Info,
+		s.testSlot12Info,
 	} {
 		c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), IsNil)
 	}
@@ -400,6 +415,7 @@ func (s *SerialPortInterfaceSuite) TestSanitizeBadCoreSnapSlots(c *C) {
 		s.badPathSlot10Info,
 		s.badPathSlot11Info,
 		s.badPathSlot12Info,
+		s.badPathSlot13Info,
 		s.badPathSlot100Info,
 	} {
 		c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), ErrorMatches, "serial-port path attribute must be a valid device node")
@@ -560,6 +576,9 @@ func (s *SerialPortInterfaceSuite) TestConnectedPlugAppArmorSnippets(c *C) {
 	expectedSnippet11 := `/dev/ttyHS0 rwk,`
 	checkConnectedPlugSnippet(s.testPlugPort1, s.testSlot11, expectedSnippet11)
 
+	expectedSnippet12 := `/dev/ttyGS0 rwk,`
+	checkConnectedPlugSnippet(s.testPlugPort1, s.testSlot12, expectedSnippet12)
+
 	expectedSnippet100 := `/dev/tty[A-Z]*[0-9] rwk,`
 	checkConnectedPlugSnippet(s.testPlugPort1, s.testUDev1, expectedSnippet100)
 
@@ -638,6 +657,11 @@ SUBSYSTEM=="tty", KERNEL=="ttyMSM0", TAG+="snap_client-snap_app-accessing-3rd-po
 SUBSYSTEM=="tty", KERNEL=="ttyHS0", TAG+="snap_client-snap_app-accessing-3rd-port"`
 	expectedExtraSnippet11 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-3rd-port", RUN+="%v/snap-device-helper $env{ACTION} snap_client-snap_app-accessing-3rd-port $devpath $major:$minor"`, dirs.DistroLibExecDir)
 	checkConnectedPlugSnippet(s.testPlugPort3, s.testSlot11, expectedSnippet11, expectedExtraSnippet11)
+
+	expectedSnippet12 := `# serial-port
+SUBSYSTEM=="tty", KERNEL=="ttyGS0", TAG+="snap_client-snap_app-accessing-3rd-port"`
+	expectedExtraSnippet12 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-3rd-port", RUN+="%v/snap-device-helper $env{ACTION} snap_client-snap_app-accessing-3rd-port $devpath $major:$minor"`, dirs.DistroLibExecDir)
+	checkConnectedPlugSnippet(s.testPlugPort3, s.testSlot12, expectedSnippet12, expectedExtraSnippet12)
 
 	// these have product and vendor ids
 	expectedSnippet100 := `# serial-port

--- a/interfaces/builtin/serial_port_test.go
+++ b/interfaces/builtin/serial_port_test.go
@@ -94,8 +94,8 @@ type SerialPortInterfaceSuite struct {
 	badPathSlot12Info    *snap.SlotInfo
 	badPathSlot13        *interfaces.ConnectedSlot
 	badPathSlot13Info    *snap.SlotInfo
-	badPathSlot100        *interfaces.ConnectedSlot
-	badPathSlot100Info    *snap.SlotInfo
+	badPathSlot100       *interfaces.ConnectedSlot
+	badPathSlot100Info   *snap.SlotInfo
 	badInterfaceSlot     *interfaces.ConnectedSlot
 	badInterfaceSlotInfo *snap.SlotInfo
 


### PR DESCRIPTION
Add support for USB gadget serial devices.
    
ttyGSX: drivers/usb/gadget/legacy/g_serial.c
Document: https://www.kernel.org/doc/Documentation/usb/gadget_serial.txt

I also changed the variable IDs, so it would be easier to add new serial devices.