### PR TITLE
many: replace ErrNoState equality checks w/ errors.Is()

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -22,6 +22,7 @@ package main
 import (
 	"crypto/subtle"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -286,7 +287,7 @@ func copyUbuntuDataAuth(src, dst string) error {
 	srcState := filepath.Join(src, "system-data/var/lib/snapd/state.json")
 	dstState := filepath.Join(dst, "system-data/var/lib/snapd/state.json")
 	err := state.CopyState(srcState, dstState, []string{"auth.users", "auth.macaroon-key", "auth.last-id"})
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return fmt.Errorf("cannot copy user state: %v", err)
 	}
 

--- a/cmd/snap/cmd_debug_state.go
+++ b/cmd/snap/cmd_debug_state.go
@@ -20,6 +20,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -284,7 +285,7 @@ func (c *cmdDebugState) showIsSeeded(st *state.State) error {
 
 	var isSeeded bool
 	err := st.Get("seeded", &isSeeded)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 	fmt.Fprintf(Stdout, "%v\n", isSeeded)

--- a/daemon/api_aliases.go
+++ b/daemon/api_aliases.go
@@ -21,6 +21,7 @@ package daemon
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -80,10 +81,10 @@ func changeAliases(c *Command, r *http.Request, user *auth.UserState) Response {
 			// or just an alias
 			var snapst snapstate.SnapState
 			err := snapstate.Get(st, a.Snap, &snapst)
-			if err != nil && err != state.ErrNoState {
+			if err != nil && !errors.Is(err, state.ErrNoState) {
 				return InternalError("%v", err)
 			}
-			if err == state.ErrNoState { // not a snap
+			if errors.Is(err, state.ErrNoState) { // not a snap
 				a.Snap = ""
 			}
 		}

--- a/daemon/api_connections.go
+++ b/daemon/api_connections.go
@@ -20,6 +20,7 @@
 package daemon
 
 import (
+	"errors"
 	"net/http"
 	"sort"
 
@@ -265,7 +266,7 @@ func getConnections(c *Command, r *http.Request, user *auth.UserState) Response 
 	snapName = ifacestate.RemapSnapFromRequest(snapName)
 	if snapName != "" {
 		if err := checkSnapInstalled(c.d.overlord.State(), snapName); err != nil {
-			if err == state.ErrNoState {
+			if errors.Is(err, state.ErrNoState) {
 				return SnapNotFound(snapName, err)
 			}
 			return InternalError("cannot access snap state: %v", err)

--- a/daemon/api_debug_seeding.go
+++ b/daemon/api_debug_seeding.go
@@ -20,6 +20,7 @@
 package daemon
 
 import (
+	"errors"
 	"time"
 
 	"github.com/snapcore/snapd/overlord/state"
@@ -66,18 +67,18 @@ type seedingInfo struct {
 func getSeedingInfo(st *state.State) Response {
 	var seeded, preseeded bool
 	err := st.Get("seeded", &seeded)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return InternalError(err.Error())
 	}
-	if err = st.Get("preseeded", &preseeded); err != nil && err != state.ErrNoState {
+	if err = st.Get("preseeded", &preseeded); err != nil && !errors.Is(err, state.ErrNoState) {
 		return InternalError(err.Error())
 	}
 
 	var preseedSysKey, seedRestartSysKey interface{}
-	if err := st.Get("preseed-system-key", &preseedSysKey); err != nil && err != state.ErrNoState {
+	if err := st.Get("preseed-system-key", &preseedSysKey); err != nil && !errors.Is(err, state.ErrNoState) {
 		return InternalError(err.Error())
 	}
-	if err := st.Get("seed-restart-system-key", &seedRestartSysKey); err != nil && err != state.ErrNoState {
+	if err := st.Get("seed-restart-system-key", &seedRestartSysKey); err != nil && !errors.Is(err, state.ErrNoState) {
 		return InternalError(err.Error())
 	}
 
@@ -116,7 +117,7 @@ func getSeedingInfo(st *state.State) Response {
 		{"seed-time", &data.SeedTime},
 	} {
 		var tm time.Time
-		if err := st.Get(t.name, &tm); err != nil && err != state.ErrNoState {
+		if err := st.Get(t.name, &tm); err != nil && !errors.Is(err, state.ErrNoState) {
 			return InternalError(err.Error())
 		}
 		if !tm.IsZero() {

--- a/daemon/api_download.go
+++ b/daemon/api_download.go
@@ -252,7 +252,7 @@ func downloadTokensSecret(d *Daemon) (secret []byte, err error) {
 	if err == nil {
 		return secret, nil
 	}
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return nil, err
 	}
 	secret, err = randutil.CryptoTokenBytes(32)

--- a/daemon/api_general.go
+++ b/daemon/api_general.go
@@ -22,6 +22,7 @@ package daemon
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"os/exec"
 	"sort"
@@ -113,7 +114,7 @@ func sysInfo(c *Command, r *http.Request, user *auth.UserState) Response {
 		return InternalError("cannot get refresh schedule: %s", err)
 	}
 	users, err := auth.Users(st)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return InternalError("cannot get user auth data: %s", err)
 	}
 

--- a/daemon/api_icons.go
+++ b/daemon/api_icons.go
@@ -20,6 +20,7 @@
 package daemon
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/snapcore/snapd/overlord/auth"
@@ -50,7 +51,7 @@ func iconGet(st *state.State, name string) Response {
 	var snapst snapstate.SnapState
 	err := snapstate.Get(st, name, &snapst)
 	if err != nil {
-		if err == state.ErrNoState {
+		if errors.Is(err, state.ErrNoState) {
 			return SnapNotFound(name, err)
 		}
 		return InternalError("cannot consult state: %v", err)

--- a/daemon/api_interfaces.go
+++ b/daemon/api_interfaces.go
@@ -21,6 +21,7 @@ package daemon
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"sort"
@@ -158,7 +159,7 @@ func changeInterfaces(c *Command, r *http.Request, user *auth.UserState) Respons
 		}
 		var snapst snapstate.SnapState
 		err := snapstate.Get(st, snapName, &snapst)
-		if (err == nil && !snapst.IsInstalled()) || err == state.ErrNoState {
+		if (err == nil && !snapst.IsInstalled()) || errors.Is(err, state.ErrNoState) {
 			return fmt.Errorf("snap %q is not installed", snapName)
 		}
 		if err == nil {

--- a/daemon/api_model.go
+++ b/daemon/api_model.go
@@ -21,6 +21,7 @@ package daemon
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 
 	"github.com/snapcore/snapd/asserts"
@@ -98,7 +99,7 @@ func getModel(c *Command, r *http.Request, _ *auth.UserState) Response {
 	devmgr := c.d.overlord.DeviceManager()
 
 	model, err := devmgr.Model()
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		return &apiError{
 			Status:  404,
 			Message: "no model assertion yet",
@@ -138,7 +139,7 @@ func getSerial(c *Command, r *http.Request, _ *auth.UserState) Response {
 	devmgr := c.d.overlord.DeviceManager()
 
 	serial, err := devmgr.Serial()
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		return &apiError{
 			Status:  404,
 			Message: "no serial assertion yet",

--- a/daemon/api_sideload_n_try_test.go
+++ b/daemon/api_sideload_n_try_test.go
@@ -222,7 +222,7 @@ func (s *sideloadSuite) sideloadCheck(c *check.C, content string, head map[strin
 
 	summary = chg.Summary()
 	err = chg.Get("system-restart-immediate", &systemRestartImmediate)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		c.Error(err)
 	}
 	return summary, systemRestartImmediate

--- a/daemon/api_snap_file.go
+++ b/daemon/api_snap_file.go
@@ -49,12 +49,10 @@ func getSnapFile(c *Command, r *http.Request, user *auth.UserState) Response {
 	if err == nil {
 		info, err = snapst.CurrentInfo()
 	}
-
 	if err != nil {
 		if errors.Is(err, state.ErrNoState) {
 			return SnapNotFound(name, err)
 		}
-
 		return InternalError("cannot download file for snap %q: %v", name, err)
 	}
 

--- a/daemon/api_snap_file.go
+++ b/daemon/api_snap_file.go
@@ -20,6 +20,7 @@
 package daemon
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/snapcore/snapd/overlord/auth"
@@ -48,14 +49,15 @@ func getSnapFile(c *Command, r *http.Request, user *auth.UserState) Response {
 	if err == nil {
 		info, err = snapst.CurrentInfo()
 	}
-	switch err {
-	case nil:
-		// ok
-	case state.ErrNoState:
-		return SnapNotFound(name, err)
-	default:
+
+	if err != nil {
+		if errors.Is(err, state.ErrNoState) {
+			return SnapNotFound(name, err)
+		}
+
 		return InternalError("cannot download file for snap %q: %v", name, err)
 	}
+
 	if !snapst.Active {
 		return BadRequest("cannot download file of inactive snap %q", name)
 	}

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -513,7 +513,7 @@ func (s *snapsSuite) testPostSnapsOp(c *check.C, extraJSON, contentType string) 
 	c.Check(chg.Get("api-data", &apiData), check.IsNil)
 	c.Check(apiData["snap-names"], check.DeepEquals, []interface{}{"fake1", "fake2"})
 	err = chg.Get("system-restart-immediate", &systemRestartImmediate)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		c.Error(err)
 	}
 	return systemRestartImmediate
@@ -1346,7 +1346,7 @@ func (s *snapsSuite) testPostSnap(c *check.C, extraJSON string, checkOpts func(o
 
 	summary = chg.Summary()
 	err = chg.Get("system-restart-immediate", &systemRestartImmediate)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		c.Error(err)
 	}
 	return summary, systemRestartImmediate

--- a/daemon/api_users.go
+++ b/daemon/api_users.go
@@ -21,6 +21,7 @@ package daemon
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os/user"
@@ -349,7 +350,7 @@ func createUser(c *Command, createData postUserCreateData) Response {
 		st.Lock()
 		serial, err = c.d.overlord.DeviceManager().Serial()
 		st.Unlock()
-		if err != nil && err != state.ErrNoState {
+		if err != nil && !errors.Is(err, state.ErrNoState) {
 			return InternalError("cannot create user: cannot get serial: %v", err)
 		}
 	}

--- a/daemon/api_validate.go
+++ b/daemon/api_validate.go
@@ -21,6 +21,7 @@ package daemon
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"sort"
@@ -177,7 +178,7 @@ func getValidationSet(c *Command, r *http.Request, user *auth.UserState) Respons
 
 	var tr assertstate.ValidationSetTracking
 	err := assertstate.GetValidationSet(st, accountID, name, &tr)
-	if err == state.ErrNoState || (err == nil && sequence != 0 && sequence != tr.PinnedAt) {
+	if errors.Is(err, state.ErrNoState) || (err == nil && sequence != 0 && sequence != tr.PinnedAt) {
 		// not available locally, try to find in the store.
 		return validateAgainstStore(st, accountID, name, sequence, user)
 	}
@@ -299,7 +300,7 @@ func forgetValidationSet(st *state.State, accountID, name string, sequence int) 
 	// check if it exists first
 	var tr assertstate.ValidationSetTracking
 	err := assertstate.GetValidationSet(st, accountID, name, &tr)
-	if err == state.ErrNoState || (err == nil && sequence != 0 && sequence != tr.PinnedAt) {
+	if errors.Is(err, state.ErrNoState) || (err == nil && sequence != 0 && sequence != tr.PinnedAt) {
 		return validationSetNotFound(accountID, name, sequence)
 	}
 	if err != nil {

--- a/daemon/api_validate_test.go
+++ b/daemon/api_validate_test.go
@@ -667,7 +667,7 @@ func (s *apiValidationSetsSuite) TestForgetValidationSet(c *check.C) {
 		st.Lock()
 		err = assertstate.GetValidationSet(st, s.dev1acct.AccountID(), "foo", &tr)
 		st.Unlock()
-		c.Assert(err, check.Equals, state.ErrNoState)
+		c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 
 		// and forget again fails
 		req, err = http.NewRequest("POST", fmt.Sprintf("/v2/validation-sets/%s/foo", s.dev1acct.AccountID()), strings.NewReader(body))

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -595,7 +595,7 @@ func (d *Daemon) rebootDelay(immediate bool) (time.Duration, error) {
 	// see whether a reboot had already been scheduled
 	var rebootAt time.Time
 	err := d.state.Get("daemon-system-restart-at", &rebootAt)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return 0, err
 	}
 	rebootDelay := 1 * time.Minute
@@ -673,7 +673,7 @@ var errExpectedReboot = errors.New("expected reboot did not happen")
 func (d *Daemon) RebootDidNotHappen(st *state.State) error {
 	var nTentative int
 	err := st.Get("daemon-system-restart-tentative", &nTentative)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 	nTentative++

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -1297,8 +1297,8 @@ func (s *daemonSuite) TestRestartExpectedRebootOK(c *check.C) {
 	defer st.Unlock()
 	var v interface{}
 	// these were cleared
-	c.Check(st.Get("daemon-system-restart-at", &v), check.Equals, state.ErrNoState)
-	c.Check(st.Get("system-restart-from-boot-id", &v), check.Equals, state.ErrNoState)
+	c.Check(st.Get("daemon-system-restart-at", &v), testutil.ErrorIs, state.ErrNoState)
+	c.Check(st.Get("system-restart-from-boot-id", &v), testutil.ErrorIs, state.ErrNoState)
 }
 
 func (s *daemonSuite) TestRestartExpectedRebootGiveUp(c *check.C) {
@@ -1321,9 +1321,9 @@ func (s *daemonSuite) TestRestartExpectedRebootGiveUp(c *check.C) {
 	defer st.Unlock()
 	var v interface{}
 	// these were cleared
-	c.Check(st.Get("daemon-system-restart-at", &v), check.Equals, state.ErrNoState)
-	c.Check(st.Get("system-restart-from-boot-id", &v), check.Equals, state.ErrNoState)
-	c.Check(st.Get("daemon-system-restart-tentative", &v), check.Equals, state.ErrNoState)
+	c.Check(st.Get("daemon-system-restart-at", &v), testutil.ErrorIs, state.ErrNoState)
+	c.Check(st.Get("system-restart-from-boot-id", &v), testutil.ErrorIs, state.ErrNoState)
+	c.Check(st.Get("daemon-system-restart-tentative", &v), testutil.ErrorIs, state.ErrNoState)
 }
 
 func (s *daemonSuite) TestRestartIntoSocketModeNoNewChanges(c *check.C) {

--- a/daemon/snap.go
+++ b/daemon/snap.go
@@ -50,7 +50,7 @@ func localSnapInfo(st *state.State, name string) (aboutSnap, error) {
 
 	var snapst snapstate.SnapState
 	err := snapstate.Get(st, name, &snapst)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return aboutSnap{}, fmt.Errorf("cannot consult state: %v", err)
 	}
 

--- a/overlord/assertstate/assertstate.go
+++ b/overlord/assertstate/assertstate.go
@@ -23,6 +23,7 @@
 package assertstate
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -688,11 +689,11 @@ func validationSetAssertionForEnforce(st *state.State, accountID, name string, s
 		// by RefreshValidationSetAssertions.
 		var tr ValidationSetTracking
 		trerr := GetValidationSet(st, accountID, name, &tr)
-		if trerr != nil && trerr != state.ErrNoState {
+		if trerr != nil && !errors.Is(trerr, state.ErrNoState) {
 			return nil, 0, trerr
 		}
 		// not tracked, update the assertion
-		if trerr == state.ErrNoState {
+		if errors.Is(trerr, state.ErrNoState) {
 			// update with pool
 			atSeq.Sequence = vs.Sequence()
 			atSeq.Revision = vs.Revision()

--- a/overlord/assertstate/validation_set_tracking.go
+++ b/overlord/assertstate/validation_set_tracking.go
@@ -21,6 +21,7 @@ package assertstate
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/snapcore/snapd/asserts"
@@ -76,7 +77,7 @@ func ValidationSetKey(accountID, name string) string {
 func UpdateValidationSet(st *state.State, tr *ValidationSetTracking) {
 	var vsmap map[string]*json.RawMessage
 	err := st.Get("validation-sets", &vsmap)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		panic("internal error: cannot unmarshal validation set tracking state: " + err.Error())
 	}
 	if vsmap == nil {
@@ -97,7 +98,7 @@ func UpdateValidationSet(st *state.State, tr *ValidationSetTracking) {
 func ForgetValidationSet(st *state.State, accountID, name string) error {
 	var vsmap map[string]*json.RawMessage
 	err := st.Get("validation-sets", &vsmap)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		panic("internal error: cannot unmarshal validation set tracking state: " + err.Error())
 	}
 	if len(vsmap) == 0 {
@@ -139,7 +140,7 @@ func GetValidationSet(st *state.State, accountID, name string, tr *ValidationSet
 // ValidationSets retrieves all ValidationSetTracking data.
 func ValidationSets(st *state.State) (map[string]*ValidationSetTracking, error) {
 	var vsmap map[string]*ValidationSetTracking
-	if err := st.Get("validation-sets", &vsmap); err != nil && err != state.ErrNoState {
+	if err := st.Get("validation-sets", &vsmap); err != nil && !errors.Is(err, state.ErrNoState) {
 		return nil, err
 	}
 	return vsmap, nil
@@ -252,7 +253,7 @@ func addToValidationSetsHistory(st *state.State, validationSets map[string]*Vali
 // the validations sets tracking history.
 func validationSetsHistoryTop(st *state.State) (map[string]*ValidationSetTracking, error) {
 	var vshist []*json.RawMessage
-	if err := st.Get("validation-sets-history", &vshist); err != nil && err != state.ErrNoState {
+	if err := st.Get("validation-sets-history", &vshist); err != nil && !errors.Is(err, state.ErrNoState) {
 		return nil, err
 	}
 	if len(vshist) == 0 {
@@ -270,7 +271,7 @@ func validationSetsHistoryTop(st *state.State) (map[string]*ValidationSetTrackin
 // ValidationSetsHistory returns the complete history of validation sets tracking.
 func ValidationSetsHistory(st *state.State) ([]map[string]*ValidationSetTracking, error) {
 	var vshist []map[string]*ValidationSetTracking
-	if err := st.Get("validation-sets-history", &vshist); err != nil && err != state.ErrNoState {
+	if err := st.Get("validation-sets-history", &vshist); err != nil && !errors.Is(err, state.ErrNoState) {
 		return nil, err
 	}
 	return vshist, nil

--- a/overlord/assertstate/validation_set_tracking_test.go
+++ b/overlord/assertstate/validation_set_tracking_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/assertstate/assertstatetest"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/testutil"
 )
 
 type validationSetTrackingSuite struct {
@@ -184,7 +185,7 @@ func (s *validationSetTrackingSuite) TestGet(c *C) {
 
 	// non-existing
 	err = assertstate.GetValidationSet(s.st, "foo", "baz", &res)
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 }
 
 func (s *validationSetTrackingSuite) mockAssert(c *C, name, sequence, presence string) asserts.Assertion {
@@ -414,7 +415,7 @@ func (s *validationSetTrackingSuite) TestRestoreValidationSetsTrackingNoHistory(
 	s.st.Lock()
 	defer s.st.Unlock()
 
-	c.Assert(assertstate.RestoreValidationSetsTracking(s.st), Equals, state.ErrNoState)
+	c.Assert(assertstate.RestoreValidationSetsTracking(s.st), testutil.ErrorIs, state.ErrNoState)
 }
 
 func (s *validationSetTrackingSuite) TestRestoreValidationSetsTracking(c *C) {

--- a/overlord/auth/auth.go
+++ b/overlord/auth/auth.go
@@ -139,7 +139,7 @@ func NewUser(st *state.State, username, email, macaroon string, discharges []str
 	var authStateData AuthState
 
 	err := st.Get("auth", &authStateData)
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		authStateData = AuthState{}
 	} else if err != nil {
 		return nil, err
@@ -193,7 +193,7 @@ func removeUser(st *state.State, p func(*UserState) bool) (*UserState, error) {
 	var authStateData AuthState
 
 	err := st.Get("auth", &authStateData)
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		return nil, ErrInvalidUser
 	}
 	if err != nil {
@@ -221,7 +221,7 @@ func Users(st *state.State) ([]*UserState, error) {
 	var authStateData AuthState
 
 	err := st.Get("auth", &authStateData)
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		return nil, nil
 	}
 	if err != nil {
@@ -250,7 +250,7 @@ func findUser(st *state.State, p func(*UserState) bool) (*UserState, error) {
 	var authStateData AuthState
 
 	err := st.Get("auth", &authStateData)
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		return nil, ErrInvalidUser
 	}
 	if err != nil {
@@ -271,7 +271,7 @@ func UpdateUser(st *state.State, user *UserState) error {
 	var authStateData AuthState
 
 	err := st.Get("auth", &authStateData)
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		return ErrInvalidUser
 	}
 	if err != nil {

--- a/overlord/cmdstate/cmdmgr.go
+++ b/overlord/cmdstate/cmdmgr.go
@@ -20,6 +20,7 @@
 package cmdstate
 
 import (
+	"errors"
 	"strings"
 	"time"
 
@@ -51,7 +52,7 @@ func doExec(t *state.Task, tomb *tomb.Tomb) error {
 	defer st.Unlock()
 
 	var ignore bool
-	if err := t.Get("ignore", &ignore); err != nil && err != state.ErrNoState {
+	if err := t.Get("ignore", &ignore); err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 	if ignore {
@@ -67,10 +68,10 @@ func doExec(t *state.Task, tomb *tomb.Tomb) error {
 
 	err := t.Get("timeout", &tout)
 	// timeout is optional and might not be set
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		tout = defaultExecTimeout
 	}
 

--- a/overlord/configstate/config/helpers.go
+++ b/overlord/configstate/config/helpers.go
@@ -22,6 +22,7 @@ package config
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"regexp"
 	"sort"
@@ -141,7 +142,7 @@ func PatchConfig(snapName string, subkeys []string, pos int, config interface{},
 func GetSnapConfig(st *state.State, snapName string) (*json.RawMessage, error) {
 	var config map[string]*json.RawMessage
 	err := st.Get("config", &config)
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		return nil, nil
 	}
 	if err != nil {
@@ -160,7 +161,7 @@ func SetSnapConfig(st *state.State, snapName string, snapcfg *json.RawMessage) e
 	err := st.Get("config", &config)
 	// empty nil snapcfg should be an empty message, but deal with "null" as well.
 	isNil := snapcfg == nil || len(*snapcfg) == 0 || bytes.Compare(*snapcfg, []byte("null")) == 0
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		if isNil {
 			// bail out early
 			return nil
@@ -187,7 +188,7 @@ func SaveRevisionConfig(st *state.State, snapName string, rev snap.Revision) err
 
 	// Get current configuration of the snap from state
 	err := st.Get("config", &config)
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		return nil
 	} else if err != nil {
 		return fmt.Errorf("internal error: cannot unmarshal configuration: %v", err)
@@ -198,7 +199,7 @@ func SaveRevisionConfig(st *state.State, snapName string, rev snap.Revision) err
 	}
 
 	err = st.Get("revision-config", &revisionConfig)
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		revisionConfig = make(map[string]map[string]*json.RawMessage)
 	} else if err != nil {
 		return err
@@ -221,14 +222,14 @@ func RestoreRevisionConfig(st *state.State, snapName string, rev snap.Revision) 
 	var revisionConfig map[string]map[string]*json.RawMessage // snap => revision => configuration
 
 	err := st.Get("revision-config", &revisionConfig)
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		return nil
 	} else if err != nil {
 		return fmt.Errorf("internal error: cannot unmarshal revision-config: %v", err)
 	}
 
 	err = st.Get("config", &config)
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		config = make(map[string]*json.RawMessage)
 	} else if err != nil {
 		return fmt.Errorf("internal error: cannot unmarshal configuration: %v", err)
@@ -250,7 +251,7 @@ func RestoreRevisionConfig(st *state.State, snapName string, rev snap.Revision) 
 func DiscardRevisionConfig(st *state.State, snapName string, rev snap.Revision) error {
 	var revisionConfig map[string]map[string]*json.RawMessage // snap => revision => configuration
 	err := st.Get("revision-config", &revisionConfig)
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		return nil
 	} else if err != nil {
 		return fmt.Errorf("internal error: cannot unmarshal revision-config: %v", err)
@@ -273,7 +274,7 @@ func DeleteSnapConfig(st *state.State, snapName string) error {
 	var config map[string]map[string]*json.RawMessage // snap => key => value
 
 	err := st.Get("config", &config)
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		return nil
 	} else if err != nil {
 		return fmt.Errorf("internal error: cannot unmarshal configuration: %v", err)

--- a/overlord/configstate/config/transaction.go
+++ b/overlord/configstate/config/transaction.go
@@ -22,6 +22,7 @@ package config
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"sort"
@@ -55,7 +56,7 @@ func NewTransaction(st *state.State) *Transaction {
 	// Record the current state of the map containing the config of every snap
 	// in the system. We'll use it for this transaction.
 	err := st.Get("config", &transaction.pristine)
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		transaction.pristine = make(map[string]map[string]*json.RawMessage)
 	} else if err != nil {
 		panic(fmt.Errorf("internal error: cannot unmarshal configuration: %v", err))
@@ -318,7 +319,7 @@ func (t *Transaction) Commit() {
 
 	// Update our copy of the config with the most recent one from the state.
 	err := t.state.Get("config", &t.pristine)
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		t.pristine = make(map[string]map[string]*json.RawMessage)
 	} else if err != nil {
 		panic(fmt.Errorf("internal error: cannot unmarshal configuration: %v", err))

--- a/overlord/configstate/configcore/cloud.go
+++ b/overlord/configstate/configcore/cloud.go
@@ -23,6 +23,7 @@ package configcore
 
 import (
 	"encoding/json"
+	"errors"
 	"io/ioutil"
 	"os"
 
@@ -39,7 +40,7 @@ func alreadySeeded(tr config.Conf) (bool, error) {
 	defer st.Unlock()
 	var seeded bool
 	err := tr.State().Get("seeded", &seeded)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return false, err
 	}
 	return seeded, nil

--- a/overlord/configstate/configcore/vitality.go
+++ b/overlord/configstate/configcore/vitality.go
@@ -22,6 +22,7 @@
 package configcore
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -86,7 +87,7 @@ func handleVitalityConfiguration(tr config.Conf, opts *fsOnlyContext) error {
 		err := snapstate.Get(st, instanceName, &snapst)
 		// not installed, vitality-score will be applied when the snap
 		// gets installed
-		if err == state.ErrNoState {
+		if errors.Is(err, state.ErrNoState) {
 			continue
 		}
 		if err != nil {

--- a/overlord/configstate/configstate.go
+++ b/overlord/configstate/configstate.go
@@ -22,6 +22,7 @@
 package configstate
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -61,7 +62,7 @@ func canConfigure(st *state.State, snapName string) error {
 
 	var snapst snapstate.SnapState
 	err := snapstate.Get(st, snapName, &snapst)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 
@@ -177,7 +178,7 @@ func EarlyConfig(st *state.State, preloadGadget func() (sysconfig.Device, *gadge
 	if preloadGadget != nil {
 		dev, gi, err := preloadGadget()
 		if err != nil {
-			if err == state.ErrNoState {
+			if errors.Is(err, state.ErrNoState) {
 				// nothing to do
 				return nil
 			}
@@ -194,7 +195,7 @@ func EarlyConfig(st *state.State, preloadGadget func() (sysconfig.Device, *gadge
 
 func systemAlreadyConfigured(st *state.State) (bool, error) {
 	var seeded bool
-	if err := st.Get("seeded", &seeded); err != nil && err != state.ErrNoState {
+	if err := st.Get("seeded", &seeded); err != nil && !errors.Is(err, state.ErrNoState) {
 		return false, err
 	}
 	if seeded {

--- a/overlord/configstate/configstate_test.go
+++ b/overlord/configstate/configstate_test.go
@@ -148,7 +148,7 @@ func (s *tasksetsSuite) TestConfigureInstalled(c *C) {
 			c.Check(err, IsNil)
 			c.Check(patch, DeepEquals, test.patch)
 		} else {
-			c.Check(err, Equals, state.ErrNoState)
+			c.Check(err, testutil.ErrorIs, state.ErrNoState)
 			c.Check(patch, IsNil)
 		}
 		c.Check(useDefaults, Equals, test.useDefaults)

--- a/overlord/configstate/hooks.go
+++ b/overlord/configstate/hooks.go
@@ -20,6 +20,7 @@
 package configstate
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/snapcore/snapd/overlord/configstate/config"
@@ -79,7 +80,7 @@ func (h *configureHandler) Before() error {
 
 	var patch map[string]interface{}
 	var useDefaults bool
-	if err := h.context.Get("use-defaults", &useDefaults); err != nil && err != state.ErrNoState {
+	if err := h.context.Get("use-defaults", &useDefaults); err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 
@@ -93,7 +94,7 @@ func (h *configureHandler) Before() error {
 		}
 
 		patch, err = snapstate.ConfigDefaults(st, deviceCtx, instanceName)
-		if err != nil && err != state.ErrNoState {
+		if err != nil && !errors.Is(err, state.ErrNoState) {
 			return err
 		}
 		// core is handled internally and does not need a configure
@@ -109,7 +110,7 @@ func (h *configureHandler) Before() error {
 			}
 		}
 	} else {
-		if err := h.context.Get("patch", &patch); err != nil && err != state.ErrNoState {
+		if err := h.context.Get("patch", &patch); err != nil && !errors.Is(err, state.ErrNoState) {
 			return err
 		}
 	}

--- a/overlord/devicestate/devicectx.go
+++ b/overlord/devicestate/devicectx.go
@@ -20,6 +20,8 @@
 package devicestate
 
 import (
+	"errors"
+
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
@@ -39,7 +41,7 @@ func DeviceCtx(st *state.State, task *state.Task, providedDeviceCtx snapstate.De
 	if err == nil {
 		return remodCtx, nil
 	}
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return nil, err
 	}
 	modelAs, err := findModel(st)

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -487,7 +487,7 @@ func (m *DeviceManager) ensureOperational() error {
 
 	var seeded bool
 	err = m.state.Get("seeded", &seeded)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 
@@ -514,7 +514,7 @@ func (m *DeviceManager) ensureOperational() error {
 
 	var storeID, gadget string
 	model, err := m.Model()
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 	if err == nil {
@@ -675,7 +675,7 @@ func init() {
 func (m *DeviceManager) setTimeOnce(name string, t time.Time) error {
 	var prev time.Time
 	err := m.state.Get(name, &prev)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 	if !prev.IsZero() {
@@ -804,7 +804,7 @@ func (m *DeviceManager) ensureSeeded() error {
 
 	var seeded bool
 	err := m.state.Get("seeded", &seeded)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 	if seeded {
@@ -880,7 +880,7 @@ func (m *DeviceManager) ensureBootOk() error {
 
 	if !m.bootOkRan {
 		deviceCtx, err := DeviceCtx(m.state, nil, nil)
-		if err != nil && err != state.ErrNoState {
+		if err != nil && !errors.Is(err, state.ErrNoState) {
 			return err
 		}
 		if err == nil {
@@ -911,7 +911,7 @@ func (m *DeviceManager) ensureCloudInitRestricted() error {
 
 	var seeded bool
 	err := m.state.Get("seeded", &seeded)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 
@@ -1088,7 +1088,7 @@ func (m *DeviceManager) ensureInstalled() error {
 
 	var seeded bool
 	err := m.state.Get("seeded", &seeded)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 	if !seeded {
@@ -1098,7 +1098,7 @@ func (m *DeviceManager) ensureInstalled() error {
 	perfTimings := timings.New(map[string]string{"ensure": "install-system"})
 
 	model, err := m.Model()
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 	if err != nil {
@@ -1176,7 +1176,7 @@ func (m *DeviceManager) ensureFactoryReset() error {
 
 	var seeded bool
 	err := m.state.Get("seeded", &seeded)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 	if !seeded {
@@ -1217,14 +1217,14 @@ func (m *DeviceManager) StartOfOperationTime() (time.Time, error) {
 	if err == nil {
 		return opTime, nil
 	}
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return opTime, err
 	}
 
 	// start-of-operation-time not set yet, use seed-time if available
 	var seedTime time.Time
 	err = m.state.Get("seed-time", &seedTime)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return opTime, err
 	}
 	if err == nil {
@@ -1258,7 +1258,7 @@ func (m *DeviceManager) ensureSeedInConfig() error {
 	if !m.ensureSeedInConfigRan {
 		// get global seeded option
 		var seeded bool
-		if err := m.state.Get("seeded", &seeded); err != nil && err != state.ErrNoState {
+		if err := m.state.Get("seeded", &seeded); err != nil && !errors.Is(err, state.ErrNoState) {
 			return err
 		}
 		if !seeded {
@@ -1285,7 +1285,7 @@ func (m *DeviceManager) appendTriedRecoverySystem(label string) error {
 	// state is locked by the caller
 
 	var triedSystems []string
-	if err := m.state.Get("tried-systems", &triedSystems); err != nil && err != state.ErrNoState {
+	if err := m.state.Get("tried-systems", &triedSystems); err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 	if strutil.ListContains(triedSystems, label) {
@@ -1313,7 +1313,7 @@ func (m *DeviceManager) ensureTriedRecoverySystem() error {
 	defer m.state.Unlock()
 
 	deviceCtx, err := DeviceCtx(m.state, nil, nil)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 	outcome, label, err := boot.InspectTryRecoverySystemOutcome(deviceCtx)
@@ -1430,7 +1430,7 @@ var errNoSaveSupport = errors.New("no save directory before UC20")
 func (m *DeviceManager) withSaveDir(f func() error) error {
 	// we use the model to check whether this is a UC20 device
 	model, err := m.Model()
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		return fmt.Errorf("internal error: cannot access save dir before a model is set")
 	}
 	if err != nil {
@@ -1474,7 +1474,7 @@ func (m *DeviceManager) withKeypairMgr(f func(asserts.KeypairManager) error) err
 	// to deal with that, this code typically will return the old location
 	// until a restart
 	model, err := m.Model()
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		return fmt.Errorf("internal error: cannot access device keypair manager before a model is set")
 	}
 	if err != nil {
@@ -1619,7 +1619,7 @@ type SystemModeInfo struct {
 // SystemModeInfo returns details about the current system mode the device is in.
 func (m *DeviceManager) SystemModeInfo() (*SystemModeInfo, error) {
 	deviceCtx, err := DeviceCtx(m.state, nil, nil)
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		return nil, fmt.Errorf("cannot report system mode information before device model is acknowledged")
 	}
 	if err != nil {
@@ -1628,7 +1628,7 @@ func (m *DeviceManager) SystemModeInfo() (*SystemModeInfo, error) {
 
 	var seeded bool
 	err = m.state.Get("seeded", &seeded)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return nil, err
 	}
 
@@ -1892,7 +1892,7 @@ func (scb storeContextBackend) SignDeviceSessionRequest(serial *asserts.Serial, 
 	}
 
 	privKey, err := scb.DeviceManager.keyPair()
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		return nil, fmt.Errorf("internal error: inconsistent state with serial but no device key")
 	}
 	if err != nil {

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -23,6 +23,7 @@ package devicestate
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"sort"
@@ -138,7 +139,7 @@ func canAutoRefresh(st *state.State) (bool, error) {
 	// Check model exists, for validity. We always have a model, either
 	// seeded or a generic one that ships with snapd.
 	_, err := findModel(st)
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		return false, nil
 	}
 	if err != nil {
@@ -146,7 +147,7 @@ func canAutoRefresh(st *state.State) (bool, error) {
 	}
 
 	_, err = findSerial(st, nil)
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		return false, nil
 	}
 	if err != nil {
@@ -522,7 +523,7 @@ func prereqsFromSnapTaskSet(ts *state.TaskSet) ([]string, error) {
 		// find the first task that carries snap setup
 		sup, err := snapstate.TaskSnapSetup(t)
 		if err != nil {
-			if err != state.ErrNoState {
+			if !errors.Is(err, state.ErrNoState) {
 				return nil, err
 			}
 			// try the next one
@@ -849,7 +850,7 @@ func remodelTasks(ctx context.Context, st *state.State, current, new *asserts.Mo
 func Remodel(st *state.State, new *asserts.Model) (*state.Change, error) {
 	var seeded bool
 	err := st.Get("seeded", &seeded)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return nil, err
 	}
 	if !seeded {
@@ -862,7 +863,7 @@ func Remodel(st *state.State, new *asserts.Model) (*state.Change, error) {
 	}
 
 	if _, err := findSerial(st, nil); err != nil {
-		if err == state.ErrNoState {
+		if errors.Is(err, state.ErrNoState) {
 			return nil, fmt.Errorf("cannot remodel without a serial")
 		}
 		return nil, err
@@ -1060,7 +1061,7 @@ func createRecoverySystemTasks(st *state.State, label string, snapSetupTasks []s
 func CreateRecoverySystem(st *state.State, label string) (*state.Change, error) {
 	var seeded bool
 	err := st.Get("seeded", &seeded)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return nil, err
 	}
 	if !seeded {

--- a/overlord/devicestate/devicestate_remodel_test.go
+++ b/overlord/devicestate/devicestate_remodel_test.go
@@ -1063,7 +1063,7 @@ func (s *deviceMgrRemodelSuite) TestDeviceCtxNoTask(c *C) {
 	// nothing in the state
 
 	_, err := devicestate.DeviceCtx(s.state, nil, nil)
-	c.Check(err, Equals, state.ErrNoState)
+	c.Check(err, testutil.ErrorIs, state.ErrNoState)
 
 	// have a model assertion
 	model := s.brands.Model("canonical", "pc", map[string]interface{}{

--- a/overlord/devicestate/devicestate_serial_test.go
+++ b/overlord/devicestate/devicestate_serial_test.go
@@ -1359,9 +1359,9 @@ func (s *deviceMgrSerialSuite) TestModelAndSerial(c *C) {
 	defer s.state.Unlock()
 	// nothing in the state
 	_, err := s.mgr.Model()
-	c.Check(err, Equals, state.ErrNoState)
+	c.Check(err, testutil.ErrorIs, state.ErrNoState)
 	_, err = s.mgr.Serial()
-	c.Check(err, Equals, state.ErrNoState)
+	c.Check(err, testutil.ErrorIs, state.ErrNoState)
 
 	// just brand and model
 	devicestatetest.SetDevice(s.state, &auth.DeviceState{
@@ -1369,9 +1369,9 @@ func (s *deviceMgrSerialSuite) TestModelAndSerial(c *C) {
 		Model: "pc",
 	})
 	_, err = s.mgr.Model()
-	c.Check(err, Equals, state.ErrNoState)
+	c.Check(err, testutil.ErrorIs, state.ErrNoState)
 	_, err = s.mgr.Serial()
-	c.Check(err, Equals, state.ErrNoState)
+	c.Check(err, testutil.ErrorIs, state.ErrNoState)
 
 	// have a model assertion
 	model := s.brands.Model("canonical", "pc", map[string]interface{}{
@@ -1386,7 +1386,7 @@ func (s *deviceMgrSerialSuite) TestModelAndSerial(c *C) {
 	c.Assert(mod.BrandID(), Equals, "canonical")
 
 	_, err = s.mgr.Serial()
-	c.Check(err, Equals, state.ErrNoState)
+	c.Check(err, testutil.ErrorIs, state.ErrNoState)
 
 	// have a serial as well
 	devicestatetest.SetDevice(s.state, &auth.DeviceState{
@@ -1397,7 +1397,7 @@ func (s *deviceMgrSerialSuite) TestModelAndSerial(c *C) {
 	_, err = s.mgr.Model()
 	c.Assert(err, IsNil)
 	_, err = s.mgr.Serial()
-	c.Check(err, Equals, state.ErrNoState)
+	c.Check(err, testutil.ErrorIs, state.ErrNoState)
 
 	// have a serial assertion
 	s.makeSerialAssertionInState(c, "canonical", "pc", "8989")
@@ -1434,9 +1434,9 @@ func (s *deviceMgrSerialSuite) TestStoreContextBackendModelAndSerial(c *C) {
 
 	// nothing in the state
 	_, err := scb.Model()
-	c.Check(err, Equals, state.ErrNoState)
+	c.Check(err, testutil.ErrorIs, state.ErrNoState)
 	_, err = scb.Serial()
-	c.Check(err, Equals, state.ErrNoState)
+	c.Check(err, testutil.ErrorIs, state.ErrNoState)
 
 	// just brand and model
 	devicestatetest.SetDevice(s.state, &auth.DeviceState{
@@ -1444,9 +1444,9 @@ func (s *deviceMgrSerialSuite) TestStoreContextBackendModelAndSerial(c *C) {
 		Model: "pc",
 	})
 	_, err = scb.Model()
-	c.Check(err, Equals, state.ErrNoState)
+	c.Check(err, testutil.ErrorIs, state.ErrNoState)
 	_, err = scb.Serial()
-	c.Check(err, Equals, state.ErrNoState)
+	c.Check(err, testutil.ErrorIs, state.ErrNoState)
 
 	// have a model assertion
 	model := s.brands.Model("canonical", "pc", map[string]interface{}{
@@ -1461,7 +1461,7 @@ func (s *deviceMgrSerialSuite) TestStoreContextBackendModelAndSerial(c *C) {
 	c.Assert(mod.BrandID(), Equals, "canonical")
 
 	_, err = scb.Serial()
-	c.Check(err, Equals, state.ErrNoState)
+	c.Check(err, testutil.ErrorIs, state.ErrNoState)
 
 	// have a serial as well
 	devicestatetest.SetDevice(s.state, &auth.DeviceState{
@@ -1472,7 +1472,7 @@ func (s *deviceMgrSerialSuite) TestStoreContextBackendModelAndSerial(c *C) {
 	_, err = scb.Model()
 	c.Assert(err, IsNil)
 	_, err = scb.Serial()
-	c.Check(err, Equals, state.ErrNoState)
+	c.Check(err, testutil.ErrorIs, state.ErrNoState)
 
 	// have a serial assertion
 	s.makeSerialAssertionInState(c, "canonical", "pc", "8989")
@@ -1560,7 +1560,7 @@ func (s *deviceMgrSerialSuite) TestStoreContextBackendProxyStore(c *C) {
 
 	// nothing in the state
 	_, err := scb.ProxyStore()
-	c.Check(err, Equals, state.ErrNoState)
+	c.Check(err, testutil.ErrorIs, state.ErrNoState)
 
 	// have a store referenced
 	tr := config.NewTransaction(s.state)
@@ -1569,7 +1569,7 @@ func (s *deviceMgrSerialSuite) TestStoreContextBackendProxyStore(c *C) {
 	c.Assert(err, IsNil)
 
 	_, err = scb.ProxyStore()
-	c.Check(err, Equals, state.ErrNoState)
+	c.Check(err, testutil.ErrorIs, state.ErrNoState)
 
 	operatorAcct := assertstest.NewAccount(s.storeSigning, "foo-operator", nil, "")
 

--- a/overlord/devicestate/devicestate_systems_test.go
+++ b/overlord/devicestate/devicestate_systems_test.go
@@ -1063,7 +1063,7 @@ func (s *deviceMgrSystemsSuite) TestDeviceManagerEnsureTriedSystemMissingInModee
 	var triedSystems []string
 	s.state.Lock()
 	err = s.state.Get("tried-systems", &triedSystems)
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 	// also logged
 	c.Check(s.logbuf.String(), testutil.Contains, `tried recovery system outcome error: recovery system "1234" was tried, but is not present in the modeenv CurrentRecoverySystems`)
 	s.state.Unlock()
@@ -1093,7 +1093,7 @@ func (s *deviceMgrSystemsSuite) TestDeviceManagerEnsureTriedSystemBad(c *C) {
 	var triedSystems []string
 	s.state.Lock()
 	err = s.state.Get("tried-systems", &triedSystems)
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 	c.Check(s.logbuf.String(), testutil.Contains, `tried recovery system "1234" failed`)
 	s.state.Unlock()
 
@@ -1113,7 +1113,7 @@ func (s *deviceMgrSystemsSuite) TestDeviceManagerEnsureTriedSystemBad(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 	err = s.state.Get("tried-systems", &triedSystems)
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 	// bootenv got cleared
 	m, err = s.bootloader.GetBootVars("try_recovery_system", "recovery_system_status")
 	c.Assert(err, IsNil)
@@ -1495,7 +1495,7 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemHappy
 
 	var triedSystemsAfterFinalize []string
 	err = s.state.Get("tried-systems", &triedSystemsAfterFinalize)
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 
 	modeenvAfterFinalize, err := boot.ReadModeenv("")
 	c.Assert(err, IsNil)
@@ -1873,7 +1873,7 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemUndo(
 
 	var triedSystemsAfter []string
 	err = s.state.Get("tried-systems", &triedSystemsAfter)
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 
 	modeenvAfterFinalize, err := boot.ReadModeenv("")
 	c.Assert(err, IsNil)

--- a/overlord/devicestate/firstboot.go
+++ b/overlord/devicestate/firstboot.go
@@ -108,7 +108,7 @@ func populateStateFromSeedImpl(st *state.State, opts *populateStateFromSeedOptio
 	// check that the state is empty
 	var seeded bool
 	err := st.Get("seeded", &seeded)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return nil, err
 	}
 	if seeded {

--- a/overlord/devicestate/firstboot_preseed_test.go
+++ b/overlord/devicestate/firstboot_preseed_test.go
@@ -337,7 +337,7 @@ snaps:
 	// but we're not considered seeded
 	var seeded bool
 	err = diskState.Get("seeded", &seeded)
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 }
 
 func (s *firstbootPreseedingClassic16Suite) TestPreseedClassicWithSnapdOnlyHappy(c *C) {
@@ -424,5 +424,5 @@ snaps:
 	// but we're not considered seeded
 	var seeded bool
 	err = diskState.Get("seeded", &seeded)
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 }

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -239,7 +239,7 @@ func (s *firstBoot16Suite) TestPopulateFromSeedOnClassicNoop(c *C) {
 	c.Assert(err, IsNil)
 
 	_, _, err = devicestate.PreloadGadget(s.overlord.DeviceManager())
-	c.Check(err, Equals, state.ErrNoState)
+	c.Check(err, testutil.ErrorIs, state.ErrNoState)
 
 	tsAll, err := devicestate.PopulateStateFromSeedImpl(st, nil, s.perfTimings)
 	c.Assert(err, IsNil)
@@ -281,7 +281,7 @@ func (s *firstBoot16Suite) TestPopulateFromSeedOnClassicNoSeedYaml(c *C) {
 	defer st.Unlock()
 
 	_, _, err = devicestate.PreloadGadget(ovld.DeviceManager())
-	c.Check(err, Equals, state.ErrNoState)
+	c.Check(err, testutil.ErrorIs, state.ErrNoState)
 
 	tsAll, err := devicestate.PopulateStateFromSeedImpl(st, nil, s.perfTimings)
 	c.Assert(err, IsNil)

--- a/overlord/devicestate/handlers.go
+++ b/overlord/devicestate/handlers.go
@@ -19,6 +19,7 @@
 package devicestate
 
 import (
+	"errors"
 	"fmt"
 	"os/exec"
 	"time"
@@ -54,7 +55,7 @@ func (m *DeviceManager) doMarkPreseeded(t *state.Task, _ *tomb.Tomb) error {
 		// EnsureBefore(0) done somewhere else.
 		// XXX: we should probably drop the flag from the task now that we have
 		// one on the state.
-		if err := t.Get("preseeded", &preseeded); err != nil && err != state.ErrNoState {
+		if err := t.Get("preseeded", &preseeded); err != nil && !errors.Is(err, state.ErrNoState) {
 			return err
 		}
 		if !preseeded {
@@ -121,7 +122,7 @@ func (s *seededSystem) sameAs(other *seededSystem) bool {
 
 func (m *DeviceManager) recordSeededSystem(st *state.State, whatSeeded *seededSystem) error {
 	var seeded []seededSystem
-	if err := st.Get("seeded-systems", &seeded); err != nil && err != state.ErrNoState {
+	if err := st.Get("seeded-systems", &seeded); err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 	for _, sys := range seeded {
@@ -170,7 +171,7 @@ func (m *DeviceManager) doMarkSeeded(t *state.Task, _ *tomb.Tomb) error {
 
 	now := time.Now()
 	var whatSeeded *seededSystem
-	if err := t.Get("seed-system", &whatSeeded); err != nil && err != state.ErrNoState {
+	if err := t.Get("seed-system", &whatSeeded); err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 	if whatSeeded != nil && deviceCtx.RunMode() {

--- a/overlord/devicestate/handlers_bootconfig.go
+++ b/overlord/devicestate/handlers_bootconfig.go
@@ -19,6 +19,7 @@
 package devicestate
 
 import (
+	"errors"
 	"fmt"
 
 	"gopkg.in/tomb.v2"
@@ -41,7 +42,7 @@ func (m *DeviceManager) doUpdateManagedBootConfig(t *state.Task, _ *tomb.Tomb) e
 
 	var seeded bool
 	err := st.Get("seeded", &seeded)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 	if !seeded {

--- a/overlord/devicestate/handlers_gadget.go
+++ b/overlord/devicestate/handlers_gadget.go
@@ -19,6 +19,7 @@
 package devicestate
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -48,7 +49,7 @@ func makeRollbackDir(name string) (string, error) {
 
 func currentGadgetInfo(st *state.State, curDeviceCtx snapstate.DeviceContext) (*gadget.GadgetData, error) {
 	currentInfo, err := snapstate.GadgetInfo(st, curDeviceCtx)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return nil, err
 	}
 	if currentInfo == nil {
@@ -258,7 +259,7 @@ func (m *DeviceManager) doUpdateGadgetCommandLine(t *state.Task, _ *tomb.Tomb) e
 
 	var seeded bool
 	err := st.Get("seeded", &seeded)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 	if !seeded {
@@ -299,7 +300,7 @@ func (m *DeviceManager) undoUpdateGadgetCommandLine(t *state.Task, _ *tomb.Tomb)
 
 	var seeded bool
 	err := st.Get("seeded", &seeded)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 	if !seeded {

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -24,6 +24,7 @@ import (
 	"compress/gzip"
 	"crypto"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -603,7 +604,7 @@ func (m *DeviceManager) doRestartSystemToRunMode(t *state.Task, _ *tomb.Tomb) er
 
 	var rebootOpts RebootOptions
 	err = t.Get("reboot", &rebootOpts)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 

--- a/overlord/devicestate/handlers_serial.go
+++ b/overlord/devicestate/handlers_serial.go
@@ -248,7 +248,7 @@ func (rc *initialRegistrationContext) FinishRegistration(serial *asserts.Serial)
 // registrationCtx returns a registrationContext appropriate for the task and its change.
 func (m *DeviceManager) registrationCtx(t *state.Task) (registrationContext, error) {
 	remodCtx, err := remodelCtxFromTask(t)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return nil, err
 	}
 	if regCtx, ok := remodCtx.(registrationContext); ok {
@@ -316,7 +316,7 @@ func prepareSerialRequest(t *state.Task, regCtx registrationContext, privKey ass
 	// slower full retries
 	var nTentatives int
 	err := t.Get("pre-poll-tentatives", &nTentatives)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return "", err
 	}
 	nTentatives++
@@ -484,7 +484,7 @@ var httputilNewHTTPClient = httputil.NewHTTPClient
 func getSerial(t *state.Task, regCtx registrationContext, privKey asserts.PrivateKey, device *auth.DeviceState, tm timings.Measurer) (serial *asserts.Serial, ancillaryBatch *asserts.Batch, err error) {
 	var serialSup serialSetup
 	err = t.Get("serial-setup", &serialSup)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return nil, nil, err
 	}
 
@@ -585,7 +585,7 @@ func getSerialRequestConfig(t *state.Task, regCtx registrationContext, client *h
 
 	st := t.State()
 	tr := config.NewTransaction(st)
-	if proxyStore, err := proxyStore(st, tr); err != nil && err != state.ErrNoState {
+	if proxyStore, err := proxyStore(st, tr); err != nil && !errors.Is(err, state.ErrNoState) {
 		return nil, err
 	} else if proxyStore != nil {
 		proxyURL = proxyStore.URL()
@@ -666,7 +666,7 @@ func (m *DeviceManager) doRequestSerial(t *state.Task, _ *tomb.Tomb) error {
 
 	// NB: the keyPair is fixed for now
 	privKey, err := m.keyPair()
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		return fmt.Errorf("internal error: cannot find device key pair")
 	}
 	if err != nil {

--- a/overlord/devicestate/handlers_systems.go
+++ b/overlord/devicestate/handlers_systems.go
@@ -21,6 +21,7 @@ package devicestate
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -50,7 +51,7 @@ func taskRecoverySystemSetup(t *state.Task) (*recoverySystemSetup, error) {
 	if err == nil {
 		return &setup, nil
 	}
-	if err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return nil, err
 	}
 	// find the task which holds the data

--- a/overlord/devicestate/handlers_systems.go
+++ b/overlord/devicestate/handlers_systems.go
@@ -51,7 +51,7 @@ func taskRecoverySystemSetup(t *state.Task) (*recoverySystemSetup, error) {
 	if err == nil {
 		return &setup, nil
 	}
-	if err != nil && !errors.Is(err, state.ErrNoState) {
+	if !errors.Is(err, state.ErrNoState) {
 		return nil, err
 	}
 	// find the task which holds the data

--- a/overlord/devicestate/handlers_test.go
+++ b/overlord/devicestate/handlers_test.go
@@ -535,7 +535,7 @@ func (s *preseedingClassicSuite) TestDoMarkPreseeded(c *C) {
 	c.Check(preseeded, Equals, true)
 
 	var systemKey map[string]interface{}
-	c.Assert(st.Get("seed-restart-system-key", &systemKey), Equals, state.ErrNoState)
+	c.Assert(st.Get("seed-restart-system-key", &systemKey), testutil.ErrorIs, state.ErrNoState)
 	c.Assert(st.Get("preseed-system-key", &systemKey), IsNil)
 	c.Check(systemKey["build-id"], Equals, "abcde")
 
@@ -626,7 +626,7 @@ func (s *preseedingClassicDoneSuite) TestDoMarkPreseededAfterFirstboot(c *C) {
 	// in real world preseed-system-key would be present at this point because
 	// mark-preseeded would be run twice (before & after preseeding); this is
 	// not the case in this test.
-	c.Assert(st.Get("preseed-system-key", &systemKey), Equals, state.ErrNoState)
+	c.Assert(st.Get("preseed-system-key", &systemKey), testutil.ErrorIs, state.ErrNoState)
 	c.Assert(st.Get("seed-restart-system-key", &systemKey), IsNil)
 	c.Check(systemKey["build-id"], Equals, "abcde")
 
@@ -740,7 +740,7 @@ func (s *preseedingUC20Suite) TestPreloadGadgetPicksSystemOnCore20(c *C) {
 
 	_, _, err = devicestate.PreloadGadget(mgr)
 	// error from mocked loadDeviceSeed results in ErrNoState from preloadGadget
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 	c.Check(readSysLabel, Equals, "20220108")
 }
 

--- a/overlord/devicestate/internal/state.go
+++ b/overlord/devicestate/internal/state.go
@@ -23,6 +23,8 @@
 package internal
 
 import (
+	"errors"
+
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/state"
 )
@@ -32,7 +34,7 @@ func Device(st *state.State) (*auth.DeviceState, error) {
 	var authStateData auth.AuthState
 
 	err := st.Get("auth", &authStateData)
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		return &auth.DeviceState{}, nil
 	} else if err != nil {
 		return nil, err
@@ -50,7 +52,7 @@ func SetDevice(st *state.State, device *auth.DeviceState) error {
 	var authStateData auth.AuthState
 
 	err := st.Get("auth", &authStateData)
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		authStateData = auth.AuthState{}
 	} else if err != nil {
 		return err

--- a/overlord/devicestate/remodel_test.go
+++ b/overlord/devicestate/remodel_test.go
@@ -720,19 +720,19 @@ func (s *remodelLogicSuite) TestRemodelContextForTaskNo(c *C) {
 
 	// task is nil
 	remodCtx1, err := devicestate.DeviceCtx(s.state, nil, nil)
-	c.Check(err, Equals, state.ErrNoState)
+	c.Check(err, testutil.ErrorIs, state.ErrNoState)
 	c.Check(remodCtx1, IsNil)
 
 	// no change
 	t := s.state.NewTask("random-task", "...")
 	_, err = devicestate.DeviceCtx(s.state, t, nil)
-	c.Check(err, Equals, state.ErrNoState)
+	c.Check(err, testutil.ErrorIs, state.ErrNoState)
 
 	// not a remodel change
 	chg := s.state.NewChange("not-remodel", "...")
 	chg.AddTask(t)
 	_, err = devicestate.DeviceCtx(s.state, t, nil)
-	c.Check(err, Equals, state.ErrNoState)
+	c.Check(err, testutil.ErrorIs, state.ErrNoState)
 }
 
 func (s *remodelLogicSuite) setupForRereg(c *C) (oldModel, newModel *asserts.Model) {
@@ -896,7 +896,7 @@ func (s *remodelLogicSuite) TestReregRemodelContextNewSerial(c *C) {
 
 	// no new serial yet
 	_, err = devBE.Serial()
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 
 	chg := s.state.NewChange("remodel", "...")
 
@@ -912,13 +912,13 @@ func (s *remodelLogicSuite) TestReregRemodelContextNewSerial(c *C) {
 
 	// still no new serial
 	_, err = devBE.Serial()
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 
 	newSerial := makeSerialAssertionInState(c, s.brands, s.state, "my-brand", "other-model", "serialserialserial2")
 
 	// same
 	_, err = devBE.Serial()
-	c.Check(err, Equals, state.ErrNoState)
+	c.Check(err, testutil.ErrorIs, state.ErrNoState)
 
 	// finish registration
 	regCtx := remodCtx.(devicestate.RegistrationContext)

--- a/overlord/devicestate/systems.go
+++ b/overlord/devicestate/systems.go
@@ -20,6 +20,7 @@
 package devicestate
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -42,7 +43,7 @@ func checkSystemRequestConflict(st *state.State, systemLabel string) error {
 	defer st.Unlock()
 
 	var seeded bool
-	if err := st.Get("seeded", &seeded); err != nil && err != state.ErrNoState {
+	if err := st.Get("seeded", &seeded); err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 	if seeded {

--- a/overlord/healthstate/healthstate.go
+++ b/overlord/healthstate/healthstate.go
@@ -21,6 +21,7 @@ package healthstate
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"regexp"
@@ -126,7 +127,7 @@ func (h *healthHandler) Done() error {
 	err := h.context.Get("health", &health)
 	h.context.Unlock()
 
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		// note it can't actually be state.ErrNoState because Before sets it
 		// (but if it were, health.Timestamp would still be zero)
 		return err
@@ -168,7 +169,7 @@ func appendHealth(ctx *hookstate.Context, health *HealthState) error {
 
 	var hs map[string]*HealthState
 	if err := st.Get("health", &hs); err != nil {
-		if err != state.ErrNoState {
+		if !errors.Is(err, state.ErrNoState) {
 			return err
 		}
 		hs = map[string]*HealthState{}
@@ -187,7 +188,7 @@ func SetFromHookContext(ctx *hookstate.Context) error {
 	err := ctx.Get("health", &health)
 
 	if err != nil {
-		if err == state.ErrNoState {
+		if errors.Is(err, state.ErrNoState) {
 			return nil
 		}
 		return err
@@ -197,7 +198,7 @@ func SetFromHookContext(ctx *hookstate.Context) error {
 
 func All(st *state.State) (map[string]*HealthState, error) {
 	var hs map[string]*HealthState
-	if err := st.Get("health", &hs); err != nil && err != state.ErrNoState {
+	if err := st.Get("health", &hs); err != nil && !errors.Is(err, state.ErrNoState) {
 		return nil, err
 	}
 	return hs, nil
@@ -206,7 +207,7 @@ func All(st *state.State) (map[string]*HealthState, error) {
 func Get(st *state.State, snap string) (*HealthState, error) {
 	var hs map[string]json.RawMessage
 	if err := st.Get("health", &hs); err != nil {
-		if err != state.ErrNoState {
+		if !errors.Is(err, state.ErrNoState) {
 			return nil, err
 		}
 		return nil, nil

--- a/overlord/healthstate/healthstate_test.go
+++ b/overlord/healthstate/healthstate_test.go
@@ -191,7 +191,7 @@ func (s *healthSuite) testHealth(c *check.C, cond healthHookTestCondition) {
 		c.Check(cmd.Calls(), check.DeepEquals, [][]string{{"snap", "run", "--hook", "check-health", "-r", "42", "test-snap"}})
 	} else {
 		// no script -> no health
-		c.Assert(err, check.Equals, state.ErrNoState)
+		c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 		c.Check(healths, check.IsNil)
 		c.Check(health, check.IsNil)
 		c.Check(cmd.Calls(), check.HasLen, 0)
@@ -222,7 +222,7 @@ func (s *healthSuite) TestSetFromHookContext(c *check.C) {
 	defer ctx.Unlock()
 
 	var hs map[string]*healthstate.HealthState
-	c.Check(s.state.Get("health", &hs), check.Equals, state.ErrNoState)
+	c.Check(s.state.Get("health", &hs), testutil.ErrorIs, state.ErrNoState)
 
 	ctx.Set("health", &healthstate.HealthState{Status: 42})
 
@@ -244,11 +244,11 @@ func (s *healthSuite) TestSetFromHookContextEmpty(c *check.C) {
 	defer ctx.Unlock()
 
 	var hs map[string]healthstate.HealthState
-	c.Check(s.state.Get("health", &hs), check.Equals, state.ErrNoState)
+	c.Check(s.state.Get("health", &hs), testutil.ErrorIs, state.ErrNoState)
 
 	err = healthstate.SetFromHookContext(ctx)
 	c.Assert(err, check.IsNil)
 
 	// no health in the context -> no health in state
-	c.Check(s.state.Get("health", &hs), check.Equals, state.ErrNoState)
+	c.Check(s.state.Get("health", &hs), testutil.ErrorIs, state.ErrNoState)
 }

--- a/overlord/hookstate/context.go
+++ b/overlord/hookstate/context.go
@@ -22,6 +22,7 @@ package hookstate
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -167,7 +168,7 @@ func (c *Context) Set(key string, value interface{}) {
 	if c.IsEphemeral() {
 		data, _ = c.cache["ephemeral-context"].(map[string]*json.RawMessage)
 	} else {
-		if err := c.task.Get("hook-context", &data); err != nil && err != state.ErrNoState {
+		if err := c.task.Get("hook-context", &data); err != nil && !errors.Is(err, state.ErrNoState) {
 			panic(fmt.Sprintf("internal error: cannot unmarshal context: %v", err))
 		}
 	}

--- a/overlord/hookstate/ctlcmd/health.go
+++ b/overlord/hookstate/ctlcmd/health.go
@@ -20,6 +20,7 @@
 package ctlcmd
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"time"
@@ -127,7 +128,7 @@ func (c *healthCommand) Execute([]string) error {
 	// if 'health' is there we've either already added an OnDone (and the
 	// following Set("health"), or we're in the set-health hook itself
 	// (which sets it to a fake entry for this purpose).
-	if err := ctx.Get("health", &v); err == state.ErrNoState {
+	if err := ctx.Get("health", &v); errors.Is(err, state.ErrNoState) {
 		ctx.OnDone(func() error {
 			return healthstate.SetFromHookContext(ctx)
 		})

--- a/overlord/hookstate/ctlcmd/refresh.go
+++ b/overlord/hookstate/ctlcmd/refresh.go
@@ -20,6 +20,7 @@
 package ctlcmd
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -189,7 +190,7 @@ func getUpdateDetails(context *hookstate.Context) (*updateDetails, error) {
 	}
 
 	var candidates map[string]*refreshCandidate
-	if err := st.Get("refresh-candidates", &candidates); err != nil && err != state.ErrNoState {
+	if err := st.Get("refresh-candidates", &candidates); err != nil && !errors.Is(err, state.ErrNoState) {
 		return nil, err
 	}
 

--- a/overlord/hookstate/hookmgr.go
+++ b/overlord/hookstate/hookmgr.go
@@ -21,6 +21,7 @@ package hookstate
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -226,7 +227,7 @@ func hookSetup(task *state.Task, key string) (*HookSetup, *snapstate.SnapState, 
 
 	var snapst snapstate.SnapState
 	err = snapstate.Get(task.State(), hooksup.Snap, &snapst)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return nil, nil, fmt.Errorf("cannot handle %q snap: %v", hooksup.Snap, err)
 	}
 
@@ -276,7 +277,7 @@ func (m *HookManager) undoRunHook(task *state.Task, tomb *tomb.Tomb) error {
 	hooksup, snapst, err := hookSetup(task, "undo-hook-setup")
 	task.State().Unlock()
 	if err != nil {
-		if err == state.ErrNoState {
+		if errors.Is(err, state.ErrNoState) {
 			// no undo hook setup
 			return nil
 		}

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -20,6 +20,7 @@
 package ifacestate
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"sort"
@@ -106,7 +107,7 @@ func (m *InterfaceManager) doSetupProfiles(task *state.Task, tomb *tomb.Tomb) er
 	// This code is just here to deal with old state that may still
 	// have the 2nd setup-profiles with this flag set.
 	var corePhase2 bool
-	if err := task.Get("core-phase-2", &corePhase2); err != nil && err != state.ErrNoState {
+	if err := task.Get("core-phase-2", &corePhase2); err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 	if corePhase2 {
@@ -265,7 +266,7 @@ func (m *InterfaceManager) undoSetupProfiles(task *state.Task, tomb *tomb.Tomb) 
 	defer perfTimings.Save(st)
 
 	var corePhase2 bool
-	if err := task.Get("core-phase-2", &corePhase2); err != nil && err != state.ErrNoState {
+	if err := task.Get("core-phase-2", &corePhase2); err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 	if corePhase2 {
@@ -283,7 +284,7 @@ func (m *InterfaceManager) undoSetupProfiles(task *state.Task, tomb *tomb.Tomb) 
 	// about the snap, if there is one.
 	var snapst snapstate.SnapState
 	err = snapstate.Get(st, snapName, &snapst)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 	sideInfo := snapst.CurrentSideInfo()
@@ -315,7 +316,7 @@ func (m *InterfaceManager) doDiscardConns(task *state.Task, _ *tomb.Tomb) error 
 
 	var snapst snapstate.SnapState
 	err = snapstate.Get(st, instanceName, &snapst)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 
@@ -349,7 +350,7 @@ func (m *InterfaceManager) undoDiscardConns(task *state.Task, _ *tomb.Tomb) erro
 
 	var removed map[string]*connState
 	err := task.Get("removed", &removed)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 
@@ -367,10 +368,10 @@ func (m *InterfaceManager) undoDiscardConns(task *state.Task, _ *tomb.Tomb) erro
 }
 
 func getDynamicHookAttributes(task *state.Task) (plugAttrs, slotAttrs map[string]interface{}, err error) {
-	if err = task.Get("plug-dynamic", &plugAttrs); err != nil && err != state.ErrNoState {
+	if err = task.Get("plug-dynamic", &plugAttrs); err != nil && !errors.Is(err, state.ErrNoState) {
 		return nil, nil, err
 	}
-	if err = task.Get("slot-dynamic", &slotAttrs); err != nil && err != state.ErrNoState {
+	if err = task.Get("slot-dynamic", &slotAttrs); err != nil && !errors.Is(err, state.ErrNoState) {
 		return nil, nil, err
 	}
 	if plugAttrs == nil {
@@ -402,15 +403,15 @@ func (m *InterfaceManager) doConnect(task *state.Task, _ *tomb.Tomb) (err error)
 	}
 
 	var autoConnect bool
-	if err := task.Get("auto", &autoConnect); err != nil && err != state.ErrNoState {
+	if err := task.Get("auto", &autoConnect); err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 	var byGadget bool
-	if err := task.Get("by-gadget", &byGadget); err != nil && err != state.ErrNoState {
+	if err := task.Get("by-gadget", &byGadget); err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 	var delayedSetupProfiles bool
-	if err := task.Get("delayed-setup-profiles", &delayedSetupProfiles); err != nil && err != state.ErrNoState {
+	if err := task.Get("delayed-setup-profiles", &delayedSetupProfiles); err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 
@@ -428,7 +429,7 @@ func (m *InterfaceManager) doConnect(task *state.Task, _ *tomb.Tomb) (err error)
 
 	var plugSnapst snapstate.SnapState
 	if err := snapstate.Get(st, plugRef.Snap, &plugSnapst); err != nil {
-		if autoConnect && err == state.ErrNoState {
+		if autoConnect && errors.Is(err, state.ErrNoState) {
 			// conflict logic should prevent this
 			return fmt.Errorf("internal error: snap %q is no longer available for auto-connecting", plugRef.Snap)
 		}
@@ -437,7 +438,7 @@ func (m *InterfaceManager) doConnect(task *state.Task, _ *tomb.Tomb) (err error)
 
 	var slotSnapst snapstate.SnapState
 	if err := snapstate.Get(st, slotRef.Snap, &slotSnapst); err != nil {
-		if autoConnect && err == state.ErrNoState {
+		if autoConnect && errors.Is(err, state.ErrNoState) {
 			// conflict logic should prevent this
 			return fmt.Errorf("internal error: snap %q is no longer available for auto-connecting", slotRef.Snap)
 		}
@@ -560,7 +561,7 @@ func (m *InterfaceManager) doDisconnect(task *state.Task, _ *tomb.Tomb) error {
 
 	// forget flag can be passed with snap disconnect --forget
 	var forget bool
-	if err := task.Get("forget", &forget); err != nil && err != state.ErrNoState {
+	if err := task.Get("forget", &forget); err != nil && !errors.Is(err, state.ErrNoState) {
 		return fmt.Errorf("internal error: cannot read 'forget' flag: %s", err)
 	}
 
@@ -568,7 +569,7 @@ func (m *InterfaceManager) doDisconnect(task *state.Task, _ *tomb.Tomb) error {
 	for _, instanceName := range []string{plugRef.Snap, slotRef.Snap} {
 		var snapst snapstate.SnapState
 		if err := snapstate.Get(st, instanceName, &snapst); err != nil {
-			if err == state.ErrNoState {
+			if errors.Is(err, state.ErrNoState) {
 				task.Logf("skipping disconnect operation for connection %s %s, snap %q doesn't exist", plugRef, slotRef, instanceName)
 				return nil
 			}
@@ -613,14 +614,14 @@ func (m *InterfaceManager) doDisconnect(task *state.Task, _ *tomb.Tomb) error {
 	// "auto-disconnect" flag indicates it's a disconnect triggered automatically as part of snap removal;
 	// such disconnects should not set undesired flag and instead just remove the connection.
 	var autoDisconnect bool
-	if err := task.Get("auto-disconnect", &autoDisconnect); err != nil && err != state.ErrNoState {
+	if err := task.Get("auto-disconnect", &autoDisconnect); err != nil && !errors.Is(err, state.ErrNoState) {
 		return fmt.Errorf("internal error: failed to read 'auto-disconnect' flag: %s", err)
 	}
 
 	// "by-hotplug" flag indicates it's a disconnect triggered by hotplug remove event;
 	// we want to keep information of the connection and just mark it as hotplug-gone.
 	var byHotplug bool
-	if err := task.Get("by-hotplug", &byHotplug); err != nil && err != state.ErrNoState {
+	if err := task.Get("by-hotplug", &byHotplug); err != nil && !errors.Is(err, state.ErrNoState) {
 		return fmt.Errorf("internal error: cannot read 'by-hotplug' flag: %s", err)
 	}
 
@@ -655,7 +656,7 @@ func (m *InterfaceManager) undoDisconnect(task *state.Task, _ *tomb.Tomb) error 
 
 	var oldconn connState
 	err := task.Get("old-conn", &oldconn)
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		return nil
 	}
 	if err != nil {
@@ -663,7 +664,7 @@ func (m *InterfaceManager) undoDisconnect(task *state.Task, _ *tomb.Tomb) error 
 	}
 
 	var forget bool
-	if err := task.Get("forget", &forget); err != nil && err != state.ErrNoState {
+	if err := task.Get("forget", &forget); err != nil && !errors.Is(err, state.ErrNoState) {
 		return fmt.Errorf("internal error: cannot read 'forget' flag: %s", err)
 	}
 
@@ -745,7 +746,7 @@ func (m *InterfaceManager) undoConnect(task *state.Task, _ *tomb.Tomb) error {
 
 	var old connState
 	err = task.Get("old-conn", &old)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 	if err == nil {
@@ -760,7 +761,7 @@ func (m *InterfaceManager) undoConnect(task *state.Task, _ *tomb.Tomb) error {
 	}
 
 	var delayedSetupProfiles bool
-	if err := task.Get("delayed-setup-profiles", &delayedSetupProfiles); err != nil && err != state.ErrNoState {
+	if err := task.Get("delayed-setup-profiles", &delayedSetupProfiles); err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 	if delayedSetupProfiles {
@@ -779,7 +780,7 @@ func (m *InterfaceManager) undoConnect(task *state.Task, _ *tomb.Tomb) error {
 
 	var plugSnapst snapstate.SnapState
 	err = snapstate.Get(st, plugRef.Snap, &plugSnapst)
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		return fmt.Errorf("internal error: snap %q is no longer available", plugRef.Snap)
 	}
 	if err != nil {
@@ -787,7 +788,7 @@ func (m *InterfaceManager) undoConnect(task *state.Task, _ *tomb.Tomb) error {
 	}
 	var slotSnapst snapstate.SnapState
 	err = snapstate.Get(st, slotRef.Snap, &slotSnapst)
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		return fmt.Errorf("internal error: snap %q is no longer available", slotRef.Snap)
 	}
 	if err != nil {
@@ -817,7 +818,7 @@ func obsoleteCorePhase2SetupProfiles(kind string, task *state.Task) (bool, error
 	}
 
 	var corePhase2 bool
-	if err := task.Get("core-phase-2", &corePhase2); err != nil && err != state.ErrNoState {
+	if err := task.Get("core-phase-2", &corePhase2); err != nil && !errors.Is(err, state.ErrNoState) {
 		return false, err
 	}
 	return corePhase2, nil

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -22,6 +22,7 @@ package ifacestate
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -71,7 +72,7 @@ func (m *InterfaceManager) addBackends(extra []interfaces.SecurityBackend) error
 	var snapdSnap snapstate.SnapState
 	var snapdSnapInfo *snap.Info
 	err := snapstate.Get(m.state, "snapd", &snapdSnap)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return fmt.Errorf("cannot access snapd snap state: %v", err)
 	}
 	if err == nil {
@@ -85,7 +86,7 @@ func (m *InterfaceManager) addBackends(extra []interfaces.SecurityBackend) error
 	var coreSnap snapstate.SnapState
 	var coreSnapInfo *snap.Info
 	err = snapstate.Get(m.state, "core", &coreSnap)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return fmt.Errorf("cannot access core snap state: %v", err)
 	}
 	if err == nil {
@@ -246,14 +247,14 @@ var removeStaleConnections = func(st *state.State) error {
 		}
 		var snapst snapstate.SnapState
 		if err := snapstate.Get(st, connRef.PlugRef.Snap, &snapst); err != nil {
-			if err != state.ErrNoState {
+			if !errors.Is(err, state.ErrNoState) {
 				return err
 			}
 			staleConns = append(staleConns, id)
 			continue
 		}
 		if err := snapstate.Get(st, connRef.SlotRef.Snap, &snapst); err != nil {
-			if err != state.ErrNoState {
+			if !errors.Is(err, state.ErrNoState) {
 				return err
 			}
 			staleConns = append(staleConns, id)
@@ -273,7 +274,7 @@ var removeStaleConnections = func(st *state.State) error {
 func isBroken(st *state.State, snapName string) (bool, error) {
 	var snapst snapstate.SnapState
 	err := snapstate.Get(st, snapName, &snapst)
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		return false, nil
 	}
 	if err != nil {
@@ -549,7 +550,7 @@ func newGadgetConnect(s *state.State, task *state.Task, repo *interfaces.Reposit
 func (gc *gadgetConnect) addGadgetConnections(newconns map[string]*interfaces.ConnRef, conns map[string]*connState, conflictError func(*state.Retry, error) error) error {
 	var seeded bool
 	err := gc.st.Get("seeded", &seeded)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 	// we apply gadget connections only during seeding or a remodeling
@@ -577,7 +578,7 @@ func (gc *gadgetConnect) addGadgetConnections(newconns map[string]*interfaces.Co
 
 	gconns, err := snapstate.GadgetConnections(gc.st, gc.deviceCtx)
 	if err != nil {
-		if err == state.ErrNoState {
+		if errors.Is(err, state.ErrNoState) {
 			// no gadget yet, nothing to do
 			return nil
 		}
@@ -933,7 +934,7 @@ func getPlugAndSlotRefs(task *state.Task) (interfaces.PlugRef, interfaces.SlotRe
 func getConns(st *state.State) (conns map[string]*connState, err error) {
 	var raw *json.RawMessage
 	err = st.Get("conns", &raw)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return nil, fmt.Errorf("cannot obtain raw data about existing connections: %s", err)
 	}
 	if raw != nil {
@@ -1227,7 +1228,7 @@ func getHotplugAttrs(task *state.Task) (ifaceName string, hotplugKey snap.Hotplu
 
 func allocHotplugSeq(st *state.State) (int, error) {
 	var seq int
-	if err := st.Get("hotplug-seq", &seq); err != nil && err != state.ErrNoState {
+	if err := st.Get("hotplug-seq", &seq); err != nil && !errors.Is(err, state.ErrNoState) {
 		return 0, fmt.Errorf("internal error: cannot allocate hotplug sequence number: %s", err)
 	}
 	seq++
@@ -1279,7 +1280,7 @@ func getHotplugSlots(st *state.State) (map[string]*HotplugSlotInfo, error) {
 	var slots map[string]*HotplugSlotInfo
 	err := st.Get("hotplug-slots", &slots)
 	if err != nil {
-		if err != state.ErrNoState {
+		if !errors.Is(err, state.ErrNoState) {
 			return nil, err
 		}
 		slots = make(map[string]*HotplugSlotInfo)

--- a/overlord/ifacestate/helpers_test.go
+++ b/overlord/ifacestate/helpers_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
 	"github.com/snapcore/snapd/timings"
 )
 
@@ -599,7 +600,7 @@ func (s *helpersSuite) TestAllocHotplugSeq(c *C) {
 	var stateSeq int
 
 	// precondition
-	c.Assert(s.st.Get("hotplug-seq", &stateSeq), Equals, state.ErrNoState)
+	c.Assert(s.st.Get("hotplug-seq", &stateSeq), testutil.ErrorIs, state.ErrNoState)
 
 	seq, err := ifacestate.AllocHotplugSeq(s.st)
 	c.Assert(err, IsNil)

--- a/overlord/ifacestate/hotplug.go
+++ b/overlord/ifacestate/hotplug.go
@@ -21,6 +21,7 @@ package ifacestate
 
 import (
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"strings"
 	"unicode"
@@ -133,7 +134,7 @@ func (m *InterfaceManager) hotplugDeviceAdded(devinfo *hotplug.HotplugDeviceInfo
 	}
 
 	gadget, err := snapstate.GadgetInfo(st, deviceCtx)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		logger.Noticef("internal error: cannot get gadget information: %v", err)
 	}
 

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -382,9 +382,9 @@ func (s *interfaceManagerSuite) TestConnectTask(c *C) {
 	task = ts.Tasks()[i]
 	c.Assert(task.Kind(), Equals, "connect")
 	var flag bool
-	c.Assert(task.Get("auto", &flag), Equals, state.ErrNoState)
-	c.Assert(task.Get("delayed-setup-profiles", &flag), Equals, state.ErrNoState)
-	c.Assert(task.Get("by-gadget", &flag), Equals, state.ErrNoState)
+	c.Assert(task.Get("auto", &flag), testutil.ErrorIs, state.ErrNoState)
+	c.Assert(task.Get("delayed-setup-profiles", &flag), testutil.ErrorIs, state.ErrNoState)
+	c.Assert(task.Get("by-gadget", &flag), testutil.ErrorIs, state.ErrNoState)
 	var plug interfaces.PlugRef
 	c.Assert(task.Get("plug", &plug), IsNil)
 	c.Assert(plug.Snap, Equals, "consumer")
@@ -400,7 +400,7 @@ func (s *interfaceManagerSuite) TestConnectTask(c *C) {
 
 	var autoconnect bool
 	err = task.Get("auto", &autoconnect)
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 	c.Assert(autoconnect, Equals, false)
 
 	// verify initial attributes are present in connect task
@@ -513,7 +513,7 @@ func (s *interfaceManagerSuite) TestBatchConnectTasks(c *C) {
 			c.Assert(err, IsNil)
 			c.Check(flag, Equals, true)
 		} else {
-			c.Assert(err, Equals, state.ErrNoState)
+			c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 		}
 
 	}
@@ -816,7 +816,7 @@ func (s *interfaceManagerSuite) TestParallelInstallConnectTask(c *C) {
 
 	var autoconnect bool
 	err = task.Get("auto", &autoconnect)
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 	c.Assert(autoconnect, Equals, false)
 
 	// verify initial attributes are present in connect task
@@ -1592,7 +1592,7 @@ func (s *interfaceManagerSuite) TestDisconnectTask(c *C) {
 	task = ts.Tasks()[2]
 	c.Assert(task.Kind(), Equals, "disconnect")
 	var autoDisconnect bool
-	c.Assert(task.Get("auto-disconnect", &autoDisconnect), Equals, state.ErrNoState)
+	c.Assert(task.Get("auto-disconnect", &autoDisconnect), testutil.ErrorIs, state.ErrNoState)
 	c.Assert(autoDisconnect, Equals, false)
 
 	var plug interfaces.PlugRef
@@ -2674,7 +2674,7 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityNoAutoConnectSlotsIfAlter
 	// Ensure that no connections were made
 	var conns map[string]interface{}
 	err := s.state.Get("conns", &conns)
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 	c.Check(conns, HasLen, 0)
 }
 
@@ -3931,7 +3931,7 @@ func (s *interfaceManagerSuite) testUndoDiscardConns(c *C, snapName string) {
 
 	var removed map[string]interface{}
 	err = change.Tasks()[0].Get("removed", &removed)
-	c.Check(err, Equals, state.ErrNoState)
+	c.Check(err, testutil.ErrorIs, state.ErrNoState)
 }
 
 func (s *interfaceManagerSuite) TestDoRemove(c *C) {
@@ -5399,7 +5399,7 @@ func (s *interfaceManagerSuite) TestConnectErrorMissingSlotSnapOnAutoConnect(c *
 	c.Assert(chg.Err(), ErrorMatches, `cannot perform the following tasks:\n.*snap "producer" is no longer available for auto-connecting.*`)
 
 	var conns map[string]interface{}
-	c.Assert(s.state.Get("conns", &conns), Equals, state.ErrNoState)
+	c.Assert(s.state.Get("conns", &conns), testutil.ErrorIs, state.ErrNoState)
 }
 
 func (s *interfaceManagerSuite) TestConnectErrorMissingPlugSnapOnAutoConnect(c *C) {
@@ -5425,7 +5425,7 @@ func (s *interfaceManagerSuite) TestConnectErrorMissingPlugSnapOnAutoConnect(c *
 	c.Assert(chg.Err(), ErrorMatches, `cannot perform the following tasks:\n.*snap "consumer" is no longer available for auto-connecting.*`)
 
 	var conns map[string]interface{}
-	c.Assert(s.state.Get("conns", &conns), Equals, state.ErrNoState)
+	c.Assert(s.state.Get("conns", &conns), testutil.ErrorIs, state.ErrNoState)
 }
 
 func (s *interfaceManagerSuite) TestConnectErrorMissingPlugOnAutoConnect(c *C) {
@@ -5460,7 +5460,7 @@ func (s *interfaceManagerSuite) TestConnectErrorMissingPlugOnAutoConnect(c *C) {
 
 	var conns map[string]interface{}
 	err = s.state.Get("conns", &conns)
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 }
 
 func (s *interfaceManagerSuite) TestConnectErrorMissingSlotOnAutoConnect(c *C) {
@@ -5495,7 +5495,7 @@ func (s *interfaceManagerSuite) TestConnectErrorMissingSlotOnAutoConnect(c *C) {
 
 	var conns map[string]interface{}
 	err = s.state.Get("conns", &conns)
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 }
 
 func (s *interfaceManagerSuite) TestConnectHandlesAutoconnect(c *C) {

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -4550,7 +4550,7 @@ hooks:
 
 	var snst snapstate.SnapState
 	err = snapstate.Get(st, "other-snap", &snst)
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 	_, err = repo.Connected("other-snap", "media-hub")
 	c.Assert(err, ErrorMatches, `snap "other-snap" has no plug or slot named "media-hub"`)
 }
@@ -4910,7 +4910,7 @@ func (s *mgrsSuite) TestRemodelRequiredSnapsAddedUndo(c *C) {
 	var snapst snapstate.SnapState
 	for _, snapName := range []string{"foo", "bar", "baz"} {
 		err = snapstate.Get(st, snapName, &snapst)
-		c.Assert(err, Equals, state.ErrNoState)
+		c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 	}
 
 	// old-required-snap-1 is still marked required
@@ -7078,7 +7078,7 @@ func (s *mgrsSuite) testRemodelUC20WithRecoverySystem(c *C, encrypted bool) {
 	// the new required-snap "foo" is not installed yet
 	var snapst snapstate.SnapState
 	err = snapstate.Get(st, "foo", &snapst)
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 
 	// simulate successful reboot to recovery and back
 	restart.MockPending(st, restart.RestartUnset)

--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -675,7 +675,7 @@ func (ovs *overlordSuite) TestOverlordStartUpSetsStartOfOperation(c *C) {
 
 	// validity check, not set
 	var opTime time.Time
-	c.Assert(st.Get("start-of-operation-time", &opTime), Equals, state.ErrNoState)
+	c.Assert(st.Get("start-of-operation-time", &opTime), testutil.ErrorIs, state.ErrNoState)
 	st.Unlock()
 
 	c.Assert(o.StartUp(), IsNil)
@@ -843,7 +843,7 @@ func (ovs *overlordSuite) TestEnsureLoopNoPruneWhenPreseed(c *C) {
 	defer st.Unlock()
 
 	var opTime time.Time
-	c.Assert(st.Get("start-of-operation-time", &opTime), Equals, state.ErrNoState)
+	c.Assert(st.Get("start-of-operation-time", &opTime), testutil.ErrorIs, state.ErrNoState)
 	c.Check(chg.Status(), Equals, state.DoingStatus)
 }
 

--- a/overlord/patch/patch1.go
+++ b/overlord/patch/patch1.go
@@ -20,6 +20,7 @@
 package patch
 
 import (
+	"errors"
 	"io/ioutil"
 	"path/filepath"
 
@@ -89,7 +90,7 @@ func patch1(s *state.State) error {
 	var stateMap map[string]*patch1SnapState
 
 	err := s.Get("snaps", &stateMap)
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		return nil
 	}
 	if err != nil {

--- a/overlord/patch/patch2.go
+++ b/overlord/patch/patch2.go
@@ -20,6 +20,8 @@
 package patch
 
 import (
+	"errors"
+
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 )
@@ -116,7 +118,7 @@ func patch2(s *state.State) error {
 
 	var oldStateMap map[string]*patch1SnapState
 	err := s.Get("snaps", &oldStateMap)
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		return nil
 	}
 	if err != nil {
@@ -135,10 +137,10 @@ func patch2(s *state.State) error {
 	for _, t := range s.Tasks() {
 		var newSS patch2SnapSetup
 		err := t.Get("snap-setup", &oldSS)
-		if err == state.ErrNoState {
+		if errors.Is(err, state.ErrNoState) {
 			continue
 		}
-		if err != nil && err != state.ErrNoState {
+		if err != nil && !errors.Is(err, state.ErrNoState) {
 			return err
 		}
 		// some things stay the same

--- a/overlord/patch/patch4_test.go
+++ b/overlord/patch/patch4_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord/patch"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/testutil"
 )
 
 type patch4Suite struct{}
@@ -260,7 +261,7 @@ func (s *patch4Suite) TestPatch4OnReverts(c *C) {
 		var idx int
 		c.Check(task.Get("had-candidate", &had), IsNil)
 		c.Check(had, Equals, true)
-		c.Check(task.Get("old-candidate-index", &idx), Equals, state.ErrNoState)
+		c.Check(task.Get("old-candidate-index", &idx), testutil.ErrorIs, state.ErrNoState)
 		c.Check(len(task.Change().Tasks()), Equals, 4)
 	}()
 
@@ -280,7 +281,7 @@ func (s *patch4Suite) TestPatch4OnReverts(c *C) {
 
 	var had bool
 	var idx int
-	c.Check(task.Get("had-candidate", &had), Equals, state.ErrNoState)
+	c.Check(task.Get("had-candidate", &had), testutil.ErrorIs, state.ErrNoState)
 	c.Check(task.Get("old-candidate-index", &idx), IsNil)
 	c.Check(idx, Equals, 1)
 	c.Check(len(task.Change().Tasks()), Equals, 4)
@@ -312,8 +313,8 @@ func (s *patch4Suite) TestPatch4OnRevertsNoCandidateYet(c *C) {
 
 		var had bool
 		var idx int
-		c.Check(task.Get("had-candidate", &had), Equals, state.ErrNoState)
-		c.Check(task.Get("old-candidate-index", &idx), Equals, state.ErrNoState)
+		c.Check(task.Get("had-candidate", &had), testutil.ErrorIs, state.ErrNoState)
+		c.Check(task.Get("old-candidate-index", &idx), testutil.ErrorIs, state.ErrNoState)
 		c.Check(len(task.Change().Tasks()), Equals, 4)
 	}()
 
@@ -333,7 +334,7 @@ func (s *patch4Suite) TestPatch4OnRevertsNoCandidateYet(c *C) {
 
 	var had bool
 	var idx int
-	c.Check(task.Get("had-candidate", &had), Equals, state.ErrNoState)
+	c.Check(task.Get("had-candidate", &had), testutil.ErrorIs, state.ErrNoState)
 	c.Check(task.Get("old-candidate-index", &idx), IsNil)
 	c.Check(idx, Equals, 1)
 	c.Check(len(task.Change().Tasks()), Equals, 4)
@@ -367,7 +368,7 @@ func (s *patch4Suite) TestPatch4OnRefreshes(c *C) {
 		var idx int
 		c.Check(task.Get("had-candidate", &had), IsNil)
 		c.Check(had, Equals, false)
-		c.Check(task.Get("old-candidate-index", &idx), Equals, state.ErrNoState)
+		c.Check(task.Get("old-candidate-index", &idx), testutil.ErrorIs, state.ErrNoState)
 		c.Check(len(task.Change().Tasks()), Equals, 7)
 	}()
 
@@ -387,7 +388,7 @@ func (s *patch4Suite) TestPatch4OnRefreshes(c *C) {
 
 	var had bool
 	var idx int
-	c.Check(task.Get("had-candidate", &had), Equals, state.ErrNoState)
+	c.Check(task.Get("had-candidate", &had), testutil.ErrorIs, state.ErrNoState)
 	c.Check(task.Get("old-candidate-index", &idx), IsNil)
 	c.Check(idx, Equals, 1)
 	// we added cleanup
@@ -422,8 +423,8 @@ func (s *patch4Suite) TestPatch4OnRefreshesNoHadCandidateYet(c *C) {
 
 		var had bool
 		var idx int
-		c.Check(task.Get("had-candidate", &had), Equals, state.ErrNoState)
-		c.Check(task.Get("old-candidate-index", &idx), Equals, state.ErrNoState)
+		c.Check(task.Get("had-candidate", &had), testutil.ErrorIs, state.ErrNoState)
+		c.Check(task.Get("old-candidate-index", &idx), testutil.ErrorIs, state.ErrNoState)
 		c.Check(len(task.Change().Tasks()), Equals, 7)
 	}()
 
@@ -443,7 +444,7 @@ func (s *patch4Suite) TestPatch4OnRefreshesNoHadCandidateYet(c *C) {
 
 	var had bool
 	var idx int
-	c.Check(task.Get("had-candidate", &had), Equals, state.ErrNoState)
+	c.Check(task.Get("had-candidate", &had), testutil.ErrorIs, state.ErrNoState)
 	c.Check(task.Get("old-candidate-index", &idx), IsNil)
 	c.Check(idx, Equals, 1)
 	// we added cleanup

--- a/overlord/patch/patch6.go
+++ b/overlord/patch/patch6.go
@@ -20,6 +20,8 @@
 package patch
 
 import (
+	"errors"
+
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 )
@@ -70,7 +72,7 @@ func patch6FlagsFromPatch4(old patch4Flags) patch6Flags {
 func patch6(st *state.State) error {
 	var oldStateMap map[string]*patch4SnapState
 	err := st.Get("snaps", &oldStateMap)
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		return nil
 	}
 	if err != nil {
@@ -92,10 +94,10 @@ func patch6(st *state.State) error {
 	for _, task := range st.Tasks() {
 		var old patch4SnapSetup
 		err := task.Get("snap-setup", &old)
-		if err == state.ErrNoState {
+		if errors.Is(err, state.ErrNoState) {
 			continue
 		}
-		if err != nil && err != state.ErrNoState {
+		if err != nil && !errors.Is(err, state.ErrNoState) {
 			return err
 		}
 

--- a/overlord/patch/patch6_1.go
+++ b/overlord/patch/patch6_1.go
@@ -20,6 +20,8 @@
 package patch
 
 import (
+	"errors"
+
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
@@ -108,7 +110,7 @@ func patch6_1(st *state.State) error {
 		var removed map[string]connStatePatch6_1
 		if task.Kind() == "discard-conns" {
 			err := task.Get("removed", &removed)
-			if err == state.ErrNoState {
+			if errors.Is(err, state.ErrNoState) {
 				continue
 			}
 			if err != nil {
@@ -129,7 +131,7 @@ func patch6_1(st *state.State) error {
 	// update conns
 	var conns map[string]connStatePatch6_1
 	err := st.Get("conns", &conns)
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		// no connections to process
 		return nil
 	}

--- a/overlord/patch/patch6_2.go
+++ b/overlord/patch/patch6_2.go
@@ -21,6 +21,7 @@ package patch
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -108,7 +109,7 @@ func hasSnapdSnapID(snapst patch62SnapState) bool {
 //  - ensure snapd snaps have TypeSnapd in pending install tasks.
 func patch6_2(st *state.State) error {
 	var snaps map[string]*json.RawMessage
-	if err := st.Get("snaps", &snaps); err != nil && err != state.ErrNoState {
+	if err := st.Get("snaps", &snaps); err != nil && !errors.Is(err, state.ErrNoState) {
 		return fmt.Errorf("internal error: cannot get snaps: %s", err)
 	}
 
@@ -158,7 +159,7 @@ func patch6_2(st *state.State) error {
 
 		var snapsup patch62SnapSetup
 		err := task.Get("snap-setup", &snapsup)
-		if err != nil && err != state.ErrNoState {
+		if err != nil && !errors.Is(err, state.ErrNoState) {
 			return fmt.Errorf("internal error: cannot get snap-setup of task %s: %s", task.ID(), err)
 		}
 

--- a/overlord/patch/patch6_3.go
+++ b/overlord/patch/patch6_3.go
@@ -21,6 +21,7 @@ package patch
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/snapcore/snapd/logger"
@@ -43,7 +44,7 @@ func normChan(in string) string {
 //  - ensure channel spec is valid
 func patch6_3(st *state.State) error {
 	var snaps map[string]*json.RawMessage
-	if err := st.Get("snaps", &snaps); err != nil && err != state.ErrNoState {
+	if err := st.Get("snaps", &snaps); err != nil && !errors.Is(err, state.ErrNoState) {
 		return fmt.Errorf("internal error: cannot get snaps: %s", err)
 	}
 
@@ -83,7 +84,7 @@ func patch6_3(st *state.State) error {
 		// check task snap-setup
 		var snapsup map[string]interface{}
 		err := task.Get("snap-setup", &snapsup)
-		if err != nil && err != state.ErrNoState {
+		if err != nil && !errors.Is(err, state.ErrNoState) {
 			return fmt.Errorf("internal error: cannot get snap-setup of task %s: %s", task.ID(), err)
 		}
 		if err == nil {

--- a/overlord/patch/patch6_test.go
+++ b/overlord/patch/patch6_test.go
@@ -20,6 +20,7 @@
 package patch_test
 
 import (
+	"errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -179,7 +180,7 @@ func (s *patch6Suite) TestPatch6(c *C) {
 
 	for _, task := range st.Tasks() {
 		snapsup, err := patch.Patch6SnapSetup(task)
-		if err == state.ErrNoState {
+		if errors.Is(err, state.ErrNoState) {
 			continue
 		}
 		c.Assert(err, IsNil)

--- a/overlord/patch/patch_test.go
+++ b/overlord/patch/patch_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snapdtool"
+	"github.com/snapcore/snapd/testutil"
 )
 
 func Test(t *testing.T) { TestingT(t) }
@@ -351,7 +352,7 @@ func (s *patchSuite) testMaybeResetPatchLevel6(c *C, snapdVersion, lastVersion s
 	c.Assert(st.Get("patch-level", &level), IsNil)
 	c.Assert(st.Get("patch-sublevel", &sublevel), IsNil)
 	c.Assert(st.Get("patch-sublevel-last-version", &ver), IsNil)
-	c.Assert(st.Get("patch-sublevel-reset", &lastRefresh), Equals, state.ErrNoState)
+	c.Assert(st.Get("patch-sublevel-reset", &lastRefresh), testutil.ErrorIs, state.ErrNoState)
 	c.Check(ver, Equals, "snapd-version-1")
 	c.Check(level, Equals, 6)
 	c.Check(sublevel, Equals, 2)

--- a/overlord/restart/restart.go
+++ b/overlord/restart/restart.go
@@ -21,6 +21,8 @@
 package restart
 
 import (
+	"errors"
+
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/overlord/state"
 )
@@ -67,7 +69,7 @@ func Init(st *state.State, curBootID string, h Handler) error {
 	}
 	var fromBootID string
 	err := st.Get("system-restart-from-boot-id", &fromBootID)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 	st.Cache(restartStateKey{}, rs)

--- a/overlord/restart/restart_test.go
+++ b/overlord/restart/restart_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/snapcore/snapd/bootloader/bootloadertest"
 	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/testutil"
 )
 
 func TestRestart(t *testing.T) { TestingT(t) }
@@ -143,7 +144,7 @@ func (s *restartSuite) TestRequestRestartSystemAndVerifyReboot(c *C) {
 	err = restart.Init(st, "boot-id-2", h2)
 	c.Assert(err, IsNil)
 	c.Check(h2.rebootAsExpected, Equals, true)
-	c.Check(st.Get("system-restart-from-boot-id", &fromBootID), Equals, state.ErrNoState)
+	c.Check(st.Get("system-restart-from-boot-id", &fromBootID), testutil.ErrorIs, state.ErrNoState)
 }
 
 func (s *restartSuite) TestRequestRestartSystemWithRebootInfo(c *C) {
@@ -189,5 +190,5 @@ func (s *restartSuite) TestRequestRestartSystemWithRebootInfo(c *C) {
 	err = restart.Init(st, "boot-id-2", h2)
 	c.Assert(err, IsNil)
 	c.Check(h2.rebootAsExpected, Equals, true)
-	c.Check(st.Get("system-restart-from-boot-id", &fromBootID), Equals, state.ErrNoState)
+	c.Check(st.Get("system-restart-from-boot-id", &fromBootID), testutil.ErrorIs, state.ErrNoState)
 }

--- a/overlord/servicestate/internal/quotas.go
+++ b/overlord/servicestate/internal/quotas.go
@@ -20,6 +20,7 @@
 package internal
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 
@@ -32,7 +33,7 @@ import (
 func AllQuotas(st *state.State) (map[string]*quota.Group, error) {
 	var quotas map[string]*quota.Group
 	if err := st.Get("quotas", &quotas); err != nil {
-		if err != state.ErrNoState {
+		if !errors.Is(err, state.ErrNoState) {
 			return nil, err
 		}
 		// otherwise there are no quotas so just return nil

--- a/overlord/servicestate/quota_handlers.go
+++ b/overlord/servicestate/quota_handlers.go
@@ -20,6 +20,7 @@
 package servicestate
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"time"
@@ -193,7 +194,7 @@ func rememberQuotaStateUpdated(t *state.Task, appsToRestartBySnap map[*snap.Info
 func quotaStateAlreadyUpdated(t *state.Task) (ok bool, appsToRestartBySnap map[*snap.Info][]*snap.AppInfo, err error) {
 	var updated quotaStateUpdated
 	if err := t.Get("state-updated", &updated); err != nil {
-		if err == state.ErrNoState {
+		if errors.Is(err, state.ErrNoState) {
 			return false, nil, nil
 		}
 		return false, nil, err
@@ -654,7 +655,7 @@ func quotaControlAffectedSnaps(t *state.Task) (snaps []string, err error) {
 
 	// if state-updated was already set we can use it
 	var updated quotaStateUpdated
-	if err := t.Get("state-updated", &updated); err != state.ErrNoState {
+	if err := t.Get("state-updated", &updated); !errors.Is(err, state.ErrNoState) {
 		if err != nil {
 			return nil, err
 		}

--- a/overlord/servicestate/quota_handlers_test.go
+++ b/overlord/servicestate/quota_handlers_test.go
@@ -20,6 +20,8 @@
 package servicestate_test
 
 import (
+	"errors"
+
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/gadget/quantity"
@@ -82,7 +84,7 @@ func mockMixedQuotaGroup(st *state.State, name string, snaps []string) error {
 
 	var quotas map[string]*quota.Group
 	if err := st.Get("quotas", &quotas); err != nil {
-		if err != state.ErrNoState {
+		if !errors.Is(err, state.ErrNoState) {
 			return err
 		}
 		quotas = make(map[string]*quota.Group)

--- a/overlord/servicestate/servicemgr.go
+++ b/overlord/servicestate/servicemgr.go
@@ -20,6 +20,7 @@
 package servicestate
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -85,7 +86,7 @@ func (m *ServiceManager) ensureSnapServicesUpdated() (err error) {
 	// only run after we are seeded
 	var seeded bool
 	err = m.state.Get("seeded", &seeded)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 	if !seeded {
@@ -97,7 +98,7 @@ func (m *ServiceManager) ensureSnapServicesUpdated() (err error) {
 
 	// ensure all snap services are updated
 	allStates, err := snapstate.All(m.state)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 
@@ -108,7 +109,7 @@ func (m *ServiceManager) ensureSnapServicesUpdated() (err error) {
 	}
 
 	allGrps, err := AllQuotas(m.state)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 

--- a/overlord/servicestate/servicestate.go
+++ b/overlord/servicestate/servicestate.go
@@ -20,6 +20,7 @@
 package servicestate
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"sort"
@@ -92,7 +93,7 @@ func serviceControlTs(st *state.State, appInfos []*snap.AppInfo, inst *Instructi
 	for _, snapName := range sortedNames {
 		var snapst snapstate.SnapState
 		if err := snapstate.Get(st, snapName, &snapst); err != nil {
-			if err == state.ErrNoState {
+			if errors.Is(err, state.ErrNoState) {
 				return nil, fmt.Errorf("snap not found: %s", snapName)
 			}
 			return nil, err
@@ -365,7 +366,7 @@ func SnapServiceOptions(st *state.State, instanceName string, quotaGroups map[st
 	// if quotaGroups was not provided to us, then go get that
 	if quotaGroups == nil {
 		allGrps, err := AllQuotas(st)
-		if err != nil && err != state.ErrNoState {
+		if err != nil && !errors.Is(err, state.ErrNoState) {
 			return nil, err
 		}
 		quotaGroups = allGrps

--- a/overlord/snapstate/aliasesv2.go
+++ b/overlord/snapstate/aliasesv2.go
@@ -21,6 +21,7 @@ package snapstate
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -316,7 +317,7 @@ func addAliasConflicts(st *state.State, skipSnap string, testAliases map[string]
 func checkAliasesConflicts(st *state.State, snapName string, candAutoDisabled bool, candAliases map[string]*AliasTarget, changing map[string]*SnapState) (conflicts map[string][]string, err error) {
 	var snapNames map[string]*json.RawMessage
 	err = st.Get("snaps", &snapNames)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return nil, err
 	}
 
@@ -450,7 +451,7 @@ func (m *SnapManager) ensureAliasesV2() error {
 
 	var aliasesV1 map[string]interface{}
 	err := m.state.Get("aliases", &aliasesV1)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 	if len(aliasesV1) == 0 {
@@ -473,7 +474,7 @@ func (m *SnapManager) ensureAliasesV2() error {
 		if t.Kind() == "alias" && !t.Status().Ready() {
 			var param interface{}
 			err := t.Get("aliases", &param)
-			if err == state.ErrNoState {
+			if errors.Is(err, state.ErrNoState) {
 				// not the old variant, leave alone
 				continue
 			}
@@ -536,7 +537,7 @@ func Alias(st *state.State, instanceName, app, alias string) (*state.TaskSet, er
 
 	var snapst SnapState
 	err := Get(st, instanceName, &snapst)
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		return nil, &snap.NotInstalledError{Snap: instanceName}
 	}
 	if err != nil {
@@ -593,7 +594,7 @@ func manualAlias(info *snap.Info, curAliases map[string]*AliasTarget, target, al
 func DisableAllAliases(st *state.State, instanceName string) (*state.TaskSet, error) {
 	var snapst SnapState
 	err := Get(st, instanceName, &snapst)
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		return nil, &snap.NotInstalledError{Snap: instanceName}
 	}
 	if err != nil {
@@ -680,7 +681,7 @@ func manualUnalias(curAliases map[string]*AliasTarget, alias string) (newAliases
 func Prefer(st *state.State, name string) (*state.TaskSet, error) {
 	var snapst SnapState
 	err := Get(st, name, &snapst)
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		return nil, &snap.NotInstalledError{Snap: name}
 	}
 	if err != nil {

--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -21,6 +21,7 @@ package snapstate
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -231,7 +232,7 @@ func canRefreshOnMeteredConnection(st *state.State) (bool, error) {
 	tr := config.NewTransaction(st)
 	var onMetered string
 	err := tr.GetMaybe("core", "refresh.metered", &onMetered)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return false, err
 	}
 
@@ -604,7 +605,7 @@ func refreshScheduleManaged(st *state.State) (managed, requested, legacy bool) {
 func getTime(st *state.State, timeKey string) (time.Time, error) {
 	var t1 time.Time
 	err := st.Get(timeKey, &t1)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return time.Time{}, err
 	}
 	return t1, nil

--- a/overlord/snapstate/autorefresh_gating.go
+++ b/overlord/snapstate/autorefresh_gating.go
@@ -21,6 +21,7 @@ package snapstate
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -89,10 +90,10 @@ func refreshGating(st *state.State) (map[string]map[string]*holdState, error) {
 	// held snaps -> holding snap(s) -> first-held/hold-until time
 	var gating map[string]map[string]*holdState
 	err := st.Get("snaps-hold", &gating)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return nil, fmt.Errorf("internal error: cannot get snaps-hold: %v", err)
 	}
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		return make(map[string]map[string]*holdState), nil
 	}
 	return gating, nil
@@ -405,7 +406,7 @@ func AffectedByRefreshCandidates(st *state.State) (map[string]*AffectedSnapInfo,
 	// we care only about the keys so this can use
 	// *json.RawMessage instead of refreshCandidates
 	var candidates map[string]*json.RawMessage
-	if err := st.Get("refresh-candidates", &candidates); err != nil && err != state.ErrNoState {
+	if err := st.Get("refresh-candidates", &candidates); err != nil && !errors.Is(err, state.ErrNoState) {
 		return nil, err
 	}
 

--- a/overlord/snapstate/catalogrefresh.go
+++ b/overlord/snapstate/catalogrefresh.go
@@ -69,7 +69,7 @@ func (r *catalogRefresh) Ensure() error {
 	// beside there is high change device has no internet
 	var seeded bool
 	err := r.state.Get("seeded", &seeded)
-	if err == state.ErrNoState || !seeded {
+	if errors.Is(err, state.ErrNoState) || !seeded {
 		logger.Debugf("CatalogRefresh:Ensure: skipping refresh, system is not seeded yet")
 		// not seeded yet
 		return nil

--- a/overlord/snapstate/check_snap.go
+++ b/overlord/snapstate/check_snap.go
@@ -20,6 +20,7 @@
 package snapstate
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -313,7 +314,7 @@ func checkCoreName(st *state.State, snapInfo, curInfo *snap.Info, _ snap.Contain
 		return nil
 	}
 	core, err := coreInfo(st)
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		return nil
 	}
 	if err != nil {
@@ -366,7 +367,7 @@ func checkGadgetOrKernel(st *state.State, snapInfo, curInfo *snap.Info, snapf sn
 	}
 
 	currentSnap, err := infoForDeviceSnap(st, deviceCtx, whichName)
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		// check if we are in the remodel case
 		if deviceCtx != nil && deviceCtx.ForRemodeling() {
 			if whichName(deviceCtx.Model()) == snapInfo.InstanceName() {

--- a/overlord/snapstate/conflict.go
+++ b/overlord/snapstate/conflict.go
@@ -20,6 +20,7 @@
 package snapstate
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 
@@ -225,7 +226,7 @@ func checkChangeConflictIgnoringOneChange(st *state.State, instanceName string, 
 		// install, while getting the snap info; for refresh, when
 		// getting what needs refreshing).
 		var cursnapst SnapState
-		if err := Get(st, instanceName, &cursnapst); err != nil && err != state.ErrNoState {
+		if err := Get(st, instanceName, &cursnapst); err != nil && !errors.Is(err, state.ErrNoState) {
 			return err
 		}
 

--- a/overlord/snapstate/cookies.go
+++ b/overlord/snapstate/cookies.go
@@ -21,6 +21,7 @@ package snapstate
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -34,7 +35,7 @@ import (
 func cookies(st *state.State) (map[string]string, error) {
 	var snapCookies map[string]string
 	if err := st.Get("snap-cookies", &snapCookies); err != nil {
-		if err != state.ErrNoState {
+		if !errors.Is(err, state.ErrNoState) {
 			return nil, fmt.Errorf("cannot get snap cookies: %v", err)
 		}
 		snapCookies = make(map[string]string)
@@ -48,7 +49,7 @@ func cookies(st *state.State) (map[string]string, error) {
 // It is the caller's responsibility to lock state before calling this function.
 func (m *SnapManager) SyncCookies(st *state.State) error {
 	var instanceNames map[string]*json.RawMessage
-	if err := st.Get("snaps", &instanceNames); err != nil && err != state.ErrNoState {
+	if err := st.Get("snaps", &instanceNames); err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 
@@ -131,7 +132,7 @@ func (m *SnapManager) removeSnapCookie(st *state.State, instanceName string) err
 	var snapCookies map[string]string
 	err := st.Get("snap-cookies", &snapCookies)
 	if err != nil {
-		if err != state.ErrNoState {
+		if !errors.Is(err, state.ErrNoState) {
 			return fmt.Errorf("cannot get snap cookies: %v", err)
 		}
 		// no cookies in the state

--- a/overlord/snapstate/devicectx.go
+++ b/overlord/snapstate/devicectx.go
@@ -20,6 +20,8 @@
 package snapstate
 
 import (
+	"errors"
+
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
@@ -77,7 +79,7 @@ func ModelFromTask(task *state.Task) (*asserts.Model, error) {
 func DevicePastSeeding(st *state.State, providedDeviceCtx DeviceContext) (DeviceContext, error) {
 	var seeded bool
 	err := st.Get("seeded", &seeded)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return nil, err
 	}
 	if chg := RemodelingChange(st); chg != nil {
@@ -94,7 +96,7 @@ func DevicePastSeeding(st *state.State, providedDeviceCtx DeviceContext) (Device
 		}
 	}
 	devCtx, err := DeviceCtx(st, nil, providedDeviceCtx)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return nil, err
 	}
 	// when seeded devCtx should not be nil except in the rare
@@ -117,7 +119,7 @@ func DevicePastSeeding(st *state.State, providedDeviceCtx DeviceContext) (Device
 func DeviceCtxFromState(st *state.State, providedDeviceCtx DeviceContext) (DeviceContext, error) {
 	deviceCtx, err := DeviceCtx(st, nil, providedDeviceCtx)
 	if err != nil {
-		if err == state.ErrNoState {
+		if errors.Is(err, state.ErrNoState) {
 			return nil, &ChangeConflictError{
 				Message:    "too early for operation, device model not yet acknowledged",
 				ChangeKind: "seed",

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -78,7 +78,7 @@ func TaskSnapSetup(t *state.Task) (*SnapSetup, error) {
 	var snapsup SnapSetup
 
 	err := t.Get("snap-setup", &snapsup)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return nil, err
 	}
 	if err == nil {
@@ -134,7 +134,7 @@ func snapSetupAndState(t *state.Task) (*SnapSetup, *SnapState, error) {
 	}
 	var snapst SnapState
 	err = Get(t.State(), snapsup.InstanceName(), &snapst)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return nil, nil, err
 	}
 	return snapsup, &snapst, nil
@@ -228,7 +228,7 @@ func findLinkSnapTaskForSnap(st *state.State, snapName string) (*state.Task, err
 func isInstalled(st *state.State, snapName string) (bool, error) {
 	var snapState SnapState
 	err := Get(st, snapName, &snapState)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return false, err
 	}
 	return snapState.IsInstalled(), nil
@@ -633,7 +633,7 @@ func (m *SnapManager) undoPrepareSnap(t *state.Task, _ *tomb.Tomb) error {
 
 	var ubuntuCoreTransitionCount int
 	err = st.Get("ubuntu-core-transition-retry", &ubuntuCoreTransitionCount)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 	extra := map[string]string{
@@ -778,7 +778,7 @@ var (
 func hasOtherInstances(st *state.State, instanceName string) (bool, error) {
 	snapName, _ := snap.SplitInstanceName(instanceName)
 	var all map[string]*json.RawMessage
-	if err := st.Get("snaps", &all); err != nil && err != state.ErrNoState {
+	if err := st.Get("snaps", &all); err != nil && !errors.Is(err, state.ErrNoState) {
 		return false, err
 	}
 	for otherName := range all {
@@ -797,7 +797,7 @@ var ErrKernelGadgetUpdateTaskMissing = errors.New("cannot refresh kernel with ch
 func checkKernelHasUpdateAssetsTask(t *state.Task) error {
 	for _, other := range t.Change().Tasks() {
 		snapsup, err := TaskSnapSetup(other)
-		if err == state.ErrNoState {
+		if errors.Is(err, state.ErrNoState) {
 			// XXX: hooks have no snapsup, is this detection okay?
 			continue
 		}
@@ -964,7 +964,7 @@ func (m *SnapManager) undoMountSnap(t *state.Task, _ *tomb.Tomb) error {
 	err = t.Get("snap-type", &typ)
 	st.Unlock()
 	// backward compatibility
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		typ = "app"
 	} else if err != nil {
 		return err
@@ -975,7 +975,7 @@ func (m *SnapManager) undoMountSnap(t *state.Task, _ *tomb.Tomb) error {
 	// install-record is optional (e.g. not present in tasks from older snapd)
 	err = t.Get("install-record", &installRecord)
 	st.Unlock()
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 
@@ -1447,7 +1447,7 @@ func writeMigrationStatus(t *state.Task, snapst *SnapState, snapsup *SnapSetup) 
 
 	snapName := snapsup.InstanceName()
 	err := Get(st, snapName, &SnapState{})
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 
@@ -1879,7 +1879,7 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (err error) {
 	if rebootInfo.RebootRequired {
 		var cannotReboot bool
 		// system reboot is required, but can this task request that?
-		if err := t.Get("cannot-reboot", &cannotReboot); err != nil && err != state.ErrNoState {
+		if err := t.Get("cannot-reboot", &cannotReboot); err != nil && !errors.Is(err, state.ErrNoState) {
 			return err
 		}
 		if !cannotReboot {
@@ -2061,7 +2061,7 @@ func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	}
 	var oldIgnoreValidation bool
 	err = t.Get("old-ignore-validation", &oldIgnoreValidation)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 	var oldTryMode bool
@@ -2094,19 +2094,19 @@ func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 	var oldRefreshInhibitedTime *time.Time
-	if err := t.Get("old-refresh-inhibited-time", &oldRefreshInhibitedTime); err != nil && err != state.ErrNoState {
+	if err := t.Get("old-refresh-inhibited-time", &oldRefreshInhibitedTime); err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 	var oldLastRefreshTime *time.Time
-	if err := t.Get("old-last-refresh-time", &oldLastRefreshTime); err != nil && err != state.ErrNoState {
+	if err := t.Get("old-last-refresh-time", &oldLastRefreshTime); err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 	var oldCohortKey string
-	if err := t.Get("old-cohort-key", &oldCohortKey); err != nil && err != state.ErrNoState {
+	if err := t.Get("old-cohort-key", &oldCohortKey); err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 	var oldRevsBeforeCand []snap.Revision
-	if err := t.Get("old-revs-before-cand", &oldRevsBeforeCand); err != nil && err != state.ErrNoState {
+	if err := t.Get("old-revs-before-cand", &oldRevsBeforeCand); err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 
@@ -2162,7 +2162,7 @@ func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	if isRevert {
 		var oldRevertStatus map[int]RevertStatus
 		err := t.Get("old-revert-status", &oldRevertStatus)
-		if err != nil && err != state.ErrNoState {
+		if err != nil && !errors.Is(err, state.ErrNoState) {
 			return err
 		}
 		// may be nil if not set (e.g. created by old snapd)
@@ -2463,7 +2463,7 @@ func (m *SnapManager) undoStartSnapServices(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	var oldLastActiveDisabledServices []string
-	if err := t.Get("old-last-active-disabled-services", &oldLastActiveDisabledServices); err != nil && err != state.ErrNoState {
+	if err := t.Get("old-last-active-disabled-services", &oldLastActiveDisabledServices); err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 	snapst.LastActiveDisabledServices = oldLastActiveDisabledServices
@@ -2511,7 +2511,7 @@ func (m *SnapManager) stopSnapServices(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	var stopReason snap.ServiceStopReason
-	if err := t.Get("stop-reason", &stopReason); err != nil && err != state.ErrNoState {
+	if err := t.Get("stop-reason", &stopReason); err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 
@@ -2592,14 +2592,14 @@ func (m *SnapManager) undoStopSnapServices(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	var lastActiveDisabled []string
-	if err := t.Get("old-last-active-disabled-services", &lastActiveDisabled); err != nil && err != state.ErrNoState {
+	if err := t.Get("old-last-active-disabled-services", &lastActiveDisabled); err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 	snapst.LastActiveDisabledServices = lastActiveDisabled
 	Set(st, snapsup.InstanceName(), snapst)
 
 	var disabledServices []string
-	if err := t.Get("disabled-services", &disabledServices); err != nil && err != state.ErrNoState {
+	if err := t.Get("disabled-services", &disabledServices); err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 
@@ -3045,7 +3045,7 @@ func (m *SnapManager) undoRefreshAliases(t *state.Task, _ *tomb.Tomb) error {
 	defer st.Unlock()
 	var oldAliases map[string]*AliasTarget
 	err := t.Get("old-aliases-v2", &oldAliases)
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		// nothing to do
 		return nil
 	}
@@ -3059,12 +3059,12 @@ func (m *SnapManager) undoRefreshAliases(t *state.Task, _ *tomb.Tomb) error {
 	snapName := snapsup.InstanceName()
 	curAutoDisabled := snapst.AutoAliasesDisabled
 	autoDisabled := curAutoDisabled
-	if err = t.Get("old-auto-aliases-disabled", &autoDisabled); err != nil && err != state.ErrNoState {
+	if err = t.Get("old-auto-aliases-disabled", &autoDisabled); err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 
 	var otherSnapDisabled map[string]*otherDisabledAliases
-	if err = t.Get("other-disabled-aliases", &otherSnapDisabled); err != nil && err != state.ErrNoState {
+	if err = t.Get("other-disabled-aliases", &otherSnapDisabled); err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 
@@ -3196,7 +3196,7 @@ func aliasesTrace(t *state.Task, added, removed []*backend.Alias) error {
 	chg := t.Change()
 	var data map[string]interface{}
 	err := chg.Get("api-data", &data)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 	if len(data) == 0 {

--- a/overlord/snapstate/handlers_discard_test.go
+++ b/overlord/snapstate/handlers_discard_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
 )
 
 type discardSnapSuite struct {
@@ -129,7 +130,7 @@ func (s *discardSnapSuite) TestDoDiscardSnapInQuotaGroup(c *C) {
 	defer s.state.Unlock()
 	var snapst snapstate.SnapState
 	err := snapstate.Get(s.state, "foo", &snapst)
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 
 	c.Check(t.Status(), Equals, state.DoneStatus)
 }
@@ -161,7 +162,7 @@ func (s *discardSnapSuite) TestDoDiscardSnapToEmpty(c *C) {
 	defer s.state.Unlock()
 	var snapst snapstate.SnapState
 	err := snapstate.Get(s.state, "foo", &snapst)
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 }
 
 func (s *discardSnapSuite) TestDoDiscardSnapErrorsForActive(c *C) {

--- a/overlord/snapstate/handlers_download_test.go
+++ b/overlord/snapstate/handlers_download_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/store"
+	"github.com/snapcore/snapd/testutil"
 )
 
 type downloadSnapSuite struct {
@@ -254,7 +255,7 @@ func (s *downloadSnapSuite) TestDoUndoDownloadSnap(c *C) {
 	// and nothing is in the state for "foo"
 	var snapst snapstate.SnapState
 	err := snapstate.Get(s.state, "foo", &snapst)
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 
 }
 

--- a/overlord/snapstate/handlers_link_test.go
+++ b/overlord/snapstate/handlers_link_test.go
@@ -349,7 +349,7 @@ func (s *linkSnapSuite) TestDoUndoLinkSnap(c *C) {
 				c.Check(snapst.Active, Equals, true)
 			case 2:
 				// Then link-snap is undone and the snap gets unlinked.
-				c.Check(err, Equals, state.ErrNoState)
+				c.Check(err, testutil.ErrorIs, state.ErrNoState)
 			}
 			return nil
 		},
@@ -388,7 +388,7 @@ func (s *linkSnapSuite) TestDoUndoLinkSnap(c *C) {
 	s.state.Lock()
 	var snapst snapstate.SnapState
 	err = snapstate.Get(s.state, "foo", &snapst)
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 	c.Check(t.Status(), Equals, state.UndoneStatus)
 
 	// and check that the sequence file got updated
@@ -712,7 +712,7 @@ func (s *linkSnapSuite) TestDoLinkSnapTryToCleanupOnError(c *C) {
 	// state as expected
 	var snapst snapstate.SnapState
 	err := snapstate.Get(s.state, "foo", &snapst)
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 
 	// tried to cleanup
 	expected := fakeOps{
@@ -1009,7 +1009,7 @@ func (s *linkSnapSuite) TestDoLinkSnapdSnapCleanupOnErrorFirstInstall(c *C) {
 	// state as expected
 	var snapst snapstate.SnapState
 	err := snapstate.Get(s.state, "foo", &snapst)
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 
 	// tried to cleanup
 	expected := fakeOps{
@@ -1076,7 +1076,7 @@ func (s *linkSnapSuite) TestDoLinkSnapdSnapCleanupOnErrorNthInstall(c *C) {
 	// state as expected
 	var snapst snapstate.SnapState
 	err := snapstate.Get(s.state, "foo", &snapst)
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 
 	// tried to cleanup
 	expected := fakeOps{
@@ -1356,7 +1356,7 @@ func (s *linkSnapSuite) TestDoUndoLinkSnapCoreClassic(c *C) {
 	s.state.Lock()
 	var snapst snapstate.SnapState
 	err := snapstate.Get(s.state, "core", &snapst)
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 	c.Check(t.Status(), Equals, state.UndoneStatus)
 
 	c.Check(s.restartRequested, DeepEquals, []restart.RestartType{restart.RestartDaemon, restart.RestartDaemon})
@@ -1726,7 +1726,7 @@ func (s *linkSnapSuite) TestUndoLinkSnapdFirstInstall(c *C) {
 
 	var snapst snapstate.SnapState
 	err := snapstate.Get(s.state, "snapd", &snapst)
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 	c.Check(t.Status(), Equals, state.UndoneStatus)
 
 	expected := fakeOps{

--- a/overlord/snapstate/refreshhints.go
+++ b/overlord/snapstate/refreshhints.go
@@ -20,6 +20,7 @@
 package snapstate
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -106,7 +107,7 @@ func (r *refreshHints) AtSeed() error {
 	if release.OnClassic {
 		var t1 time.Time
 		err := r.state.Get("last-refresh-hints", &t1)
-		if err != state.ErrNoState {
+		if !errors.Is(err, state.ErrNoState) {
 			// already set or other error
 			return err
 		}
@@ -219,7 +220,7 @@ func pruneRefreshCandidates(st *state.State, snaps ...string) error {
 
 	err = st.Get("refresh-candidates", &candidates)
 	if err != nil {
-		if err == state.ErrNoState {
+		if errors.Is(err, state.ErrNoState) {
 			return nil
 		}
 		return err

--- a/overlord/snapstate/refreshhints_test.go
+++ b/overlord/snapstate/refreshhints_test.go
@@ -173,7 +173,7 @@ func (s *refreshHintsTestSuite) TestAtSeedPolicy(c *C) {
 	c.Assert(err, IsNil)
 	var t1 time.Time
 	err = s.state.Get("last-refresh-hints", &t1)
-	c.Check(err, Equals, state.ErrNoState)
+	c.Check(err, testutil.ErrorIs, state.ErrNoState)
 
 	release.MockOnClassic(true)
 	// on classic it sets last-refresh-hints to now,
@@ -412,7 +412,7 @@ func (s *refreshHintsTestSuite) TestPruneRefreshCandidatesIncorrectFormat(c *C) 
 	c.Assert(snapstate.PruneRefreshCandidates(st, "snap-a"), IsNil)
 	var data interface{}
 	// and refresh-candidates has been removed from the state
-	c.Check(st.Get("refresh-candidates", data), Equals, state.ErrNoState)
+	c.Check(st.Get("refresh-candidates", data), testutil.ErrorIs, state.ErrNoState)
 }
 
 func (s *refreshHintsTestSuite) TestRefreshHintsNotApplicableWrongArch(c *C) {

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -562,7 +562,7 @@ func genRefreshRequestSalt(st *state.State) error {
 	st.Lock()
 	defer st.Unlock()
 
-	if err := st.Get("refresh-privacy-key", &refreshPrivacyKey); err != nil && err != state.ErrNoState {
+	if err := st.Get("refresh-privacy-key", &refreshPrivacyKey); err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 	if refreshPrivacyKey != "" {
@@ -654,7 +654,7 @@ func (m *SnapManager) ensureVulnerableSnapRemoved(name string) error {
 	// not exploitable in the current versions of snapd/core snaps.
 	var alreadyRemoved bool
 	key := fmt.Sprintf("%s-snap-cve-2021-44731-vuln-removed", name)
-	if err := m.state.Get(key, &alreadyRemoved); err != nil && err != state.ErrNoState {
+	if err := m.state.Get(key, &alreadyRemoved); err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 	if alreadyRemoved {
@@ -662,10 +662,10 @@ func (m *SnapManager) ensureVulnerableSnapRemoved(name string) error {
 	}
 	var snapSt SnapState
 	err := Get(m.state, name, &snapSt)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		// not installed, nothing to do
 		return nil
 	}
@@ -782,7 +782,7 @@ func (m *SnapManager) ensureForceDevmodeDropsDevmodeFromState() error {
 
 	// int because we might want to come back and do a second pass at cleanup
 	var fixed int
-	if err := m.state.Get("fix-forced-devmode", &fixed); err != nil && err != state.ErrNoState {
+	if err := m.state.Get("fix-forced-devmode", &fixed); err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 
@@ -792,7 +792,7 @@ func (m *SnapManager) ensureForceDevmodeDropsDevmodeFromState() error {
 
 	for _, name := range []string{"core", "ubuntu-core"} {
 		var snapst SnapState
-		if err := Get(m.state, name, &snapst); err == state.ErrNoState {
+		if err := Get(m.state, name, &snapst); errors.Is(err, state.ErrNoState) {
 			// nothing to see here
 			continue
 		} else if err != nil {
@@ -836,7 +836,7 @@ func (m *SnapManager) ensureSnapdSnapTransition() error {
 	// check if snapd snap is installed
 	var snapst SnapState
 	err := Get(m.state, "snapd", &snapst)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 	// nothing to do
@@ -869,7 +869,7 @@ func (m *SnapManager) ensureSnapdSnapTransition() error {
 	// Note that state.ErrNoState should never happen in practise. However
 	// if it *does* happen we still want to fix those systems by installing
 	// the snapd snap.
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 	coreChannel := snapst.TrackingChannel
@@ -886,7 +886,7 @@ func (m *SnapManager) ensureSnapdSnapTransition() error {
 	// ensure we limit the retries in case something goes wrong
 	var lastSnapdTransitionAttempt time.Time
 	err = m.state.Get("snapd-transition-last-retry-time", &lastSnapdTransitionAttempt)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 	now := time.Now()
@@ -897,7 +897,7 @@ func (m *SnapManager) ensureSnapdSnapTransition() error {
 
 	var retryCount int
 	err = m.state.Get("snapd-transition-retry", &retryCount)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 	m.state.Set("snapd-transition-retry", retryCount+1)
@@ -922,10 +922,10 @@ func (m *SnapManager) ensureUbuntuCoreTransition() error {
 
 	var snapst SnapState
 	err := Get(m.state, "ubuntu-core", &snapst)
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		return nil
 	}
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 
@@ -939,7 +939,7 @@ func (m *SnapManager) ensureUbuntuCoreTransition() error {
 	// ensure we limit the retries in case something goes wrong
 	var lastUbuntuCoreTransitionAttempt time.Time
 	err = m.state.Get("ubuntu-core-transition-last-retry-time", &lastUbuntuCoreTransitionAttempt)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 	now := time.Now()
@@ -957,7 +957,7 @@ func (m *SnapManager) ensureUbuntuCoreTransition() error {
 
 	var retryCount int
 	err = m.state.Get("ubuntu-core-transition-retry", &retryCount)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 	m.state.Set("ubuntu-core-transition-retry", retryCount+1)
@@ -981,7 +981,7 @@ func (m *SnapManager) atSeed() error {
 	defer m.state.Unlock()
 	var seeded bool
 	err := m.state.Get("seeded", &seeded)
-	if err != state.ErrNoState {
+	if !errors.Is(err, state.ErrNoState) {
 		// already seeded or other error
 		return err
 	}

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -981,7 +981,7 @@ func InstallPath(st *state.State, si *snap.SideInfo, path, instanceName, channel
 
 	var snapst SnapState
 	err = Get(st, instanceName, &snapst)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return nil, nil, err
 	}
 
@@ -1090,7 +1090,7 @@ func InstallWithDeviceContext(ctx context.Context, st *state.State, name string,
 
 	var snapst SnapState
 	err := Get(st, name, &snapst)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return nil, err
 	}
 	if snapst.IsInstalled() {
@@ -1184,7 +1184,7 @@ func InstallPathMany(ctx context.Context, st *state.State, sideInfos []*snap.Sid
 		}
 
 		var snapst SnapState
-		if err = Get(st, name, &snapst); err != nil && err != state.ErrNoState {
+		if err = Get(st, name, &snapst); err != nil && !errors.Is(err, state.ErrNoState) {
 			return nil, err
 		}
 
@@ -1239,7 +1239,7 @@ func InstallMany(st *state.State, names []string, userID int, flags *Flags) ([]s
 	for _, name := range names {
 		var snapst SnapState
 		err := Get(st, name, &snapst)
-		if err != nil && err != state.ErrNoState {
+		if err != nil && !errors.Is(err, state.ErrNoState) {
 			return nil, nil, err
 		}
 		if snapst.IsInstalled() {
@@ -1920,7 +1920,7 @@ func Switch(st *state.State, name string, opts *RevisionOptions) (*state.TaskSet
 	}
 	var snapst SnapState
 	err := Get(st, name, &snapst)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return nil, err
 	}
 	if !snapst.IsInstalled() {
@@ -1999,7 +1999,7 @@ func UpdateWithDeviceContext(st *state.State, name string, opts *RevisionOptions
 	}
 	var snapst SnapState
 	err := Get(st, name, &snapst)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return nil, err
 	}
 	if !snapst.IsInstalled() {
@@ -2436,7 +2436,7 @@ func checkDiskSpace(st *state.State, changeKind string, infos []minimalInstallIn
 func LinkNewBaseOrKernel(st *state.State, name string) (*state.TaskSet, error) {
 	var snapst SnapState
 	err := Get(st, name, &snapst)
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		return nil, &snap.NotInstalledError{Snap: name}
 	}
 	if err != nil {
@@ -2548,7 +2548,7 @@ func AddLinkNewBaseOrKernel(st *state.State, ts *state.TaskSet) (*state.TaskSet,
 func SwitchToNewGadget(st *state.State, name string) (*state.TaskSet, error) {
 	var snapst SnapState
 	err := Get(st, name, &snapst)
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		return nil, &snap.NotInstalledError{Snap: name}
 	}
 	if err != nil {
@@ -2628,7 +2628,7 @@ func AddGadgetAssetsTasks(st *state.State, ts *state.TaskSet) (*state.TaskSet, e
 func Enable(st *state.State, name string) (*state.TaskSet, error) {
 	var snapst SnapState
 	err := Get(st, name, &snapst)
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		return nil, &snap.NotInstalledError{Snap: name}
 	}
 	if err != nil {
@@ -2683,7 +2683,7 @@ func Enable(st *state.State, name string) (*state.TaskSet, error) {
 func Disable(st *state.State, name string) (*state.TaskSet, error) {
 	var snapst SnapState
 	err := Get(st, name, &snapst)
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		return nil, &snap.NotInstalledError{Snap: name}
 	}
 	if err != nil {
@@ -2826,7 +2826,7 @@ func Remove(st *state.State, name string, revision snap.Revision, flags *RemoveF
 func removeTasks(st *state.State, name string, revision snap.Revision, flags *RemoveFlags) (removeTs *state.TaskSet, snapshotSize uint64, err error) {
 	var snapst SnapState
 	err = Get(st, name, &snapst)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return nil, 0, err
 	}
 
@@ -3085,7 +3085,7 @@ func validateSnapNames(names []string) error {
 func Revert(st *state.State, name string, flags Flags) (*state.TaskSet, error) {
 	var snapst SnapState
 	err := Get(st, name, &snapst)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return nil, err
 	}
 
@@ -3100,7 +3100,7 @@ func Revert(st *state.State, name string, flags Flags) (*state.TaskSet, error) {
 func RevertToRevision(st *state.State, name string, rev snap.Revision, flags Flags) (*state.TaskSet, error) {
 	var snapst SnapState
 	err := Get(st, name, &snapst)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return nil, err
 	}
 
@@ -3159,7 +3159,7 @@ func RevertToRevision(st *state.State, name string, rev snap.Revision, flags Fla
 func TransitionCore(st *state.State, oldName, newName string) ([]*state.TaskSet, error) {
 	var oldSnapst, newSnapst SnapState
 	err := Get(st, oldName, &oldSnapst)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return nil, err
 	}
 	if !oldSnapst.IsInstalled() {
@@ -3169,7 +3169,7 @@ func TransitionCore(st *state.State, oldName, newName string) ([]*state.TaskSet,
 	var all []*state.TaskSet
 	// install new core (if not already installed)
 	err = Get(st, newName, &newSnapst)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return nil, err
 	}
 	if !newSnapst.IsInstalled() {
@@ -3239,7 +3239,7 @@ func Installing(st *state.State) bool {
 func Info(st *state.State, name string, revision snap.Revision) (*snap.Info, error) {
 	var snapst SnapState
 	err := Get(st, name, &snapst)
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		return nil, &snap.NotInstalledError{Snap: name}
 	}
 	if err != nil {
@@ -3259,7 +3259,7 @@ func Info(st *state.State, name string, revision snap.Revision) (*snap.Info, err
 func CurrentInfo(st *state.State, name string) (*snap.Info, error) {
 	var snapst SnapState
 	err := Get(st, name, &snapst)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return nil, err
 	}
 	info, err := snapst.CurrentInfo()
@@ -3306,7 +3306,7 @@ func All(st *state.State) (map[string]*SnapState, error) {
 	// XXX: result is a map because sideloaded snaps carry no name
 	// atm in their sideinfos
 	var stateMap map[string]*SnapState
-	if err := st.Get("snaps", &stateMap); err != nil && err != state.ErrNoState {
+	if err := st.Get("snaps", &stateMap); err != nil && !errors.Is(err, state.ErrNoState) {
 		return nil, err
 	}
 	curStates := make(map[string]*SnapState, len(stateMap))
@@ -3341,7 +3341,7 @@ func InstalledSnaps(st *state.State) (snaps []*snapasserts.InstalledSnap, ignore
 // NumSnaps returns the number of installed snaps.
 func NumSnaps(st *state.State) (int, error) {
 	var snaps map[string]*json.RawMessage
-	if err := st.Get("snaps", &snaps); err != nil && err != state.ErrNoState {
+	if err := st.Get("snaps", &snaps); err != nil && !errors.Is(err, state.ErrNoState) {
 		return -1, err
 	}
 	return len(snaps), nil
@@ -3353,7 +3353,7 @@ func NumSnaps(st *state.State) (int, error) {
 func Set(st *state.State, name string, snapst *SnapState) {
 	var snaps map[string]*json.RawMessage
 	err := st.Get("snaps", &snaps)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		panic("internal error: cannot unmarshal snaps state: " + err.Error())
 	}
 	if snaps == nil {
@@ -3376,7 +3376,7 @@ func Set(st *state.State, name string, snapst *SnapState) {
 func ActiveInfos(st *state.State) ([]*snap.Info, error) {
 	var stateMap map[string]*SnapState
 	var infos []*snap.Info
-	if err := st.Get("snaps", &stateMap); err != nil && err != state.ErrNoState {
+	if err := st.Get("snaps", &stateMap); err != nil && !errors.Is(err, state.ErrNoState) {
 		return nil, err
 	}
 	for instanceName, snapst := range stateMap {
@@ -3395,7 +3395,7 @@ func ActiveInfos(st *state.State) ([]*snap.Info, error) {
 
 func HasSnapOfType(st *state.State, snapType snap.Type) (bool, error) {
 	var stateMap map[string]*SnapState
-	if err := st.Get("snaps", &stateMap); err != nil && err != state.ErrNoState {
+	if err := st.Get("snaps", &stateMap); err != nil && !errors.Is(err, state.ErrNoState) {
 		return false, err
 	}
 
@@ -3414,7 +3414,7 @@ func HasSnapOfType(st *state.State, snapType snap.Type) (bool, error) {
 
 func infosForType(st *state.State, snapType snap.Type) ([]*snap.Info, error) {
 	var stateMap map[string]*SnapState
-	if err := st.Get("snaps", &stateMap); err != nil && err != state.ErrNoState {
+	if err := st.Get("snaps", &stateMap); err != nil && !errors.Is(err, state.ErrNoState) {
 		return nil, err
 	}
 
@@ -3518,8 +3518,7 @@ func coreInfo(st *state.State) (*snap.Info, error) {
 
 // ConfigDefaults returns the configuration defaults for the snap as
 // specified in the gadget for the given device context.
-// If gadget is absent or the snap has no snap-id it returns
-// ErrNoState.
+// If gadget is absent or the snap has no snap-id it returns ErrNoState.
 func ConfigDefaults(st *state.State, deviceCtx DeviceContext, snapName string) (map[string]interface{}, error) {
 	info, err := GadgetInfo(st, deviceCtx)
 	if err != nil {
@@ -3530,7 +3529,7 @@ func ConfigDefaults(st *state.State, deviceCtx DeviceContext, snapName string) (
 	// configuring "core"
 	isSystemDefaults := snapName == defaultCoreSnapName
 	var snapst SnapState
-	if err := Get(st, snapName, &snapst); err != nil && err != state.ErrNoState {
+	if err := Get(st, snapName, &snapst); err != nil && !errors.Is(err, state.ErrNoState) {
 		return nil, err
 	}
 

--- a/overlord/snapstate/snapstate_config_defaults_test.go
+++ b/overlord/snapstate/snapstate_config_defaults_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
 )
 
 func (s *snapmgrTestSuite) TestConfigDefaults(c *C) {
@@ -67,7 +68,7 @@ func (s *snapmgrTestSuite) TestConfigDefaults(c *C) {
 		SnapType: "app",
 	})
 	_, err = snapstate.ConfigDefaults(s.state, deviceCtx, "local-snap")
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 }
 
 func (s *snapmgrTestSuite) TestConfigDefaultsSmokeUC20(c *C) {
@@ -142,7 +143,7 @@ func (s *snapmgrTestSuite) TestConfigDefaultsNoGadget(c *C) {
 	makeInstalledMockCoreSnap(c)
 
 	_, err := snapstate.ConfigDefaults(s.state, deviceCtxNoGadget, "some-snap")
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 }
 
 func (s *snapmgrTestSuite) TestConfigDefaultsSystemWithCore(c *C) {

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -3288,7 +3288,7 @@ func (s *snapmgrTestSuite) TestInstallUndoRunThroughUndoContextOptional(c *C) {
 	mountTask := tasks[len(tasks)-11]
 	c.Assert(mountTask.Kind(), Equals, "mount-snap")
 	var installRecord backend.InstallRecord
-	c.Assert(mountTask.Get("install-record", &installRecord), Equals, state.ErrNoState)
+	c.Assert(mountTask.Get("install-record", &installRecord), testutil.ErrorIs, state.ErrNoState)
 }
 
 func (s *snapmgrTestSuite) TestInstallDefaultProviderCircular(c *C) {
@@ -3516,9 +3516,9 @@ func (s *snapmgrTestSuite) TestInstallManyTransactionallyFails(c *C) {
 
 	var snapSt snapstate.SnapState
 	// some-other-snap not installed due to download failure
-	c.Assert(snapstate.Get(s.state, "some-other-snap", &snapSt), Equals, state.ErrNoState)
+	c.Assert(snapstate.Get(s.state, "some-other-snap", &snapSt), testutil.ErrorIs, state.ErrNoState)
 	// some-snap not installed as this was a transactional install
-	c.Assert(snapstate.Get(s.state, "some-snap", &snapSt), Equals, state.ErrNoState)
+	c.Assert(snapstate.Get(s.state, "some-snap", &snapSt), testutil.ErrorIs, state.ErrNoState)
 }
 
 func (s *snapmgrTestSuite) TestInstallManyDiskSpaceError(c *C) {
@@ -3747,7 +3747,7 @@ func (s *snapmgrTestSuite) TestGadgetDefaultsInstalled(c *C) {
 
 	c.Assert(runHooks[0].Kind(), Equals, "run-hook")
 	err = runHooks[0].Get("hook-context", &m)
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 }
 
 func makeInstalledMockCoreSnap(c *C) {
@@ -3827,7 +3827,7 @@ version: 1.0
 	})
 	// use-defaults flag is part of hook-context which isn't set
 	err = runHooks[1].Get("hook-context", &m)
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 }
 
 func (s *snapmgrTestSuite) TestGadgetDefaultsAreNormalizedForConfigHook(c *C) {
@@ -3897,7 +3897,7 @@ func (s *snapmgrTestSuite) TestInstallContentProviderDownloadFailure(c *C) {
 
 	var snapSt snapstate.SnapState
 	// content provider not installed due to download failure
-	c.Assert(snapstate.Get(s.state, "snap-content-slot", &snapSt), Equals, state.ErrNoState)
+	c.Assert(snapstate.Get(s.state, "snap-content-slot", &snapSt), testutil.ErrorIs, state.ErrNoState)
 
 	// but content consumer gets installed
 	c.Assert(snapstate.Get(s.state, "snap-content-plug", &snapSt), IsNil)
@@ -4478,7 +4478,7 @@ func (s *snapmgrTestSuite) TestUndoMigrationIfInstallFails(c *C) {
 	assertMigrationInSeqFile(c, "some-snap", nil)
 
 	var snapst snapstate.SnapState
-	c.Assert(snapstate.Get(s.state, "some-snap", &snapst), Equals, state.ErrNoState)
+	c.Assert(snapstate.Get(s.state, "some-snap", &snapst), testutil.ErrorIs, state.ErrNoState)
 }
 
 func (s *snapmgrTestSuite) TestUndoMigrationIfInstallFailsAfterSettingState(c *C) {
@@ -4516,7 +4516,7 @@ func (s *snapmgrTestSuite) TestUndoMigrationIfInstallFailsAfterSettingState(c *C
 	assertMigrationInSeqFile(c, "some-snap", nil)
 
 	var snapst snapstate.SnapState
-	c.Assert(snapstate.Get(s.state, "some-snap", &snapst), Equals, state.ErrNoState)
+	c.Assert(snapstate.Get(s.state, "some-snap", &snapst), testutil.ErrorIs, state.ErrNoState)
 }
 
 func (s *snapmgrTestSuite) TestInstallDeduplicatesSnapNames(c *C) {
@@ -5242,7 +5242,7 @@ func (s *snapmgrTestSuite) testUndoMigrateOnInstallWithCore22(c *C, expectSeqFil
 
 	// nothing in state
 	var snapst snapstate.SnapState
-	c.Assert(snapstate.Get(s.state, snapName, &snapst), Equals, state.ErrNoState)
+	c.Assert(snapstate.Get(s.state, snapName, &snapst), testutil.ErrorIs, state.ErrNoState)
 
 	if expectSeqFile {
 		// seq file exists but is zeroed out

--- a/overlord/snapstate/snapstate_remove_test.go
+++ b/overlord/snapstate/snapstate_remove_test.go
@@ -364,7 +364,7 @@ func (s *snapmgrTestSuite) TestRemoveRunThrough(c *C) {
 	// verify snaps in the system state
 	var snapst snapstate.SnapState
 	err = snapstate.Get(s.state, "some-snap", &snapst)
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 	c.Check(snapstate.AuxStoreInfoFilename("some-snap-id"), testutil.FileAbsent)
 
 }
@@ -511,7 +511,7 @@ func (s *snapmgrTestSuite) TestParallelInstanceRemoveRunThrough(c *C) {
 	// verify snaps in the system state
 	var snapst snapstate.SnapState
 	err = snapstate.Get(s.state, "some-snap_instance", &snapst)
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 
 	// the non-instance snap is still there
 	err = snapstate.Get(s.state, "some-snap", &snapst)
@@ -615,7 +615,7 @@ func (s *snapmgrTestSuite) TestParallelInstanceRemoveRunThroughOtherInstances(c 
 	// verify snaps in the system state
 	var snapst snapstate.SnapState
 	err = snapstate.Get(s.state, "some-snap_instance", &snapst)
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 
 	// the other instance is still there
 	err = snapstate.Get(s.state, "some-snap_other", &snapst)
@@ -791,7 +791,7 @@ func (s *snapmgrTestSuite) TestRemoveWithManyRevisionsRunThrough(c *C) {
 	// verify snaps in the system state
 	var snapst snapstate.SnapState
 	err = snapstate.Get(s.state, "some-snap", &snapst)
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 }
 
 func (s *snapmgrTestSuite) TestRemoveOneRevisionRunThrough(c *C) {
@@ -1023,7 +1023,7 @@ func (s *snapmgrTestSuite) TestRemoveLastRevisionRunThrough(c *C) {
 	// verify snaps in the system state
 	var snapst snapstate.SnapState
 	err = snapstate.Get(s.state, "some-snap", &snapst)
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 }
 
 func (s *snapmgrTestSuite) TestRemoveCurrentActiveRevisionRefused(c *C) {
@@ -1179,7 +1179,7 @@ func (s *snapmgrTestSuite) TestRemoveDeletesConfigOnLastRevision(c *C) {
 	// verify snaps in the system state
 	var snapst snapstate.SnapState
 	err = snapstate.Get(s.state, "some-snap", &snapst)
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 
 	tr = config.NewTransaction(s.state)
 	err = tr.Get("some-snap", "foo", &res)
@@ -1699,7 +1699,7 @@ func (s *snapmgrTestSuite) TestRemovePrunesRefreshGatingDataOnLastRevision(c *C)
 	// verify snaps in the system state
 	var snapst snapstate.SnapState
 	err = snapstate.Get(st, "some-snap", &snapst)
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 
 	// held snaps were updated
 	held, err = snapstate.HeldSnaps(st)

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -4548,10 +4548,10 @@ func (s *snapmgrQuerySuite) TestGadgetInfo(c *C) {
 	deviceCtx := deviceWithGadgetContext("gadget")
 
 	_, err := snapstate.GadgetInfo(st, deviceCtxNoGadget)
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 
 	_, err = snapstate.GadgetInfo(st, deviceCtx)
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 
 	sideInfo := &snap.SideInfo{
 		RealName: "gadget",
@@ -4593,10 +4593,10 @@ func (s *snapmgrQuerySuite) TestKernelInfo(c *C) {
 	}
 
 	_, err := snapstate.KernelInfo(st, deviceCtxNoKernel)
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 
 	_, err = snapstate.KernelInfo(st, deviceCtx)
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 
 	sideInfo := &snap.SideInfo{
 		RealName: "pc-kernel",
@@ -4652,11 +4652,11 @@ version: v18
 	})
 
 	_, err := snapstate.BootBaseInfo(st, deviceCtxNoBootBase)
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 
 	// no boot-base in the state so ErrNoState
 	_, err = snapstate.BootBaseInfo(st, deviceCtx)
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 
 	sideInfo := &snap.SideInfo{RealName: "core20", Revision: snap.R(4)}
 	snaptest.MockSnap(c, `
@@ -5709,7 +5709,7 @@ func (s *snapmgrTestSuite) TestTransitionCoreTooEarly(c *C) {
 	// not counted as a try
 	var t time.Time
 	err := s.state.Get("ubuntu-core-transition-last-retry-time", &t)
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 }
 
 func (s *snapmgrTestSuite) TestTransitionCoreTimeLimitWorks(c *C) {
@@ -6145,7 +6145,7 @@ func (s *snapmgrTestSuite) TestEnsureAliasesV2(c *C) {
 
 	var gone interface{}
 	err = s.state.Get("aliases", &gone)
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 
 	var snapst snapstate.SnapState
 	err = snapstate.Get(s.state, "alias-snap", &snapst)
@@ -6213,7 +6213,7 @@ func (s *snapmgrTestSuite) TestEnsureAliasesV2SnapDisabled(c *C) {
 
 	var gone interface{}
 	err = s.state.Get("aliases", &gone)
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 
 	var snapst snapstate.SnapState
 	err = snapstate.Get(s.state, "alias-snap", &snapst)
@@ -6955,10 +6955,10 @@ func (s *snapmgrTestSuite) TestGadgetConnections(c *C) {
 	defer s.state.Unlock()
 
 	_, err := snapstate.GadgetConnections(s.state, deviceCtxNoGadget)
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 
 	_, err = snapstate.GadgetConnections(s.state, deviceCtx)
-	c.Assert(err, Equals, state.ErrNoState)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 
 	s.prepareGadget(c, `
 connections:

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -2371,7 +2371,7 @@ func (s *snapmgrTestSuite) TestUpdateMakesConfigSnapshot(c *C) {
 
 	var cfgs map[string]interface{}
 	// we don't have config snapshots yet
-	c.Assert(s.state.Get("revision-config", &cfgs), Equals, state.ErrNoState)
+	c.Assert(s.state.Get("revision-config", &cfgs), testutil.ErrorIs, state.ErrNoState)
 
 	chg := s.state.NewChange("update", "update a snap")
 	opts := &snapstate.RevisionOptions{Channel: "some-channel", Revision: snap.R(2)}
@@ -8102,7 +8102,7 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootHappy(c *C) {
 	c.Assert(linkSnapBase.Get("cannot-reboot", &cannotReboot), IsNil)
 	c.Assert(cannotReboot, Equals, true)
 	// but the link-snap of the kernel can issue a reboot
-	c.Assert(linkSnapKernel.Get("cannot-reboot", &cannotReboot), Equals, state.ErrNoState)
+	c.Assert(linkSnapKernel.Get("cannot-reboot", &cannotReboot), testutil.ErrorIs, state.ErrNoState)
 
 	// have fake backend indicate a need to reboot for both snaps
 	s.fakeBackend.linkSnapMaybeReboot = true
@@ -8390,7 +8390,7 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootUnsupportedWithGadget
 				}
 				var flag bool
 				// the flag isn't set for any of link-snap tasks
-				c.Assert(tsk.Get("cannot-reboot", &flag), Equals, state.ErrNoState)
+				c.Assert(tsk.Get("cannot-reboot", &flag), testutil.ErrorIs, state.ErrNoState)
 			}
 		}
 	}

--- a/overlord/snapstate/storehelpers.go
+++ b/overlord/snapstate/storehelpers.go
@@ -21,6 +21,7 @@ package snapstate
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -84,7 +85,7 @@ func refreshOptions(st *state.State, origOpts *store.RefreshOptions) (*store.Ref
 		opts = *origOpts
 	}
 
-	if err := st.Get("refresh-privacy-key", &opts.PrivacyKey); err != nil && err != state.ErrNoState {
+	if err := st.Get("refresh-privacy-key", &opts.PrivacyKey); err != nil && !errors.Is(err, state.ErrNoState) {
 		return nil, fmt.Errorf("cannot obtain store request salt: %v", err)
 	}
 	if opts.PrivacyKey == "" {

--- a/overlord/state/copy.go
+++ b/overlord/state/copy.go
@@ -22,6 +22,7 @@ package state
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -123,7 +124,7 @@ func CopyState(srcStatePath, dstStatePath string, dataEntries []string) error {
 	dstData := make(map[string]interface{})
 	for _, dataEntry := range dataEntries {
 		subkeys := strings.Split(dataEntry, ".")
-		if err := copyData(subkeys, 0, srcState.data, dstData); err != nil && err != ErrNoState {
+		if err := copyData(subkeys, 0, srcState.data, dstData); err != nil && !errors.Is(err, ErrNoState) {
 			return err
 		}
 	}

--- a/overlord/state/state.go
+++ b/overlord/state/state.go
@@ -431,8 +431,7 @@ func (s *State) Prune(startOfOperation time.Time, pruneWait, abortWait time.Dura
 
 // GetMaybeTimings implements timings.GetSaver
 func (s *State) GetMaybeTimings(timings interface{}) error {
-	err := s.Get("timings", timings)
-	if err != nil && err != ErrNoState {
+	if err := s.Get("timings", timings); err != nil && !errors.Is(err, ErrNoState) {
 		return err
 	}
 	return nil

--- a/overlord/state/state_test.go
+++ b/overlord/state/state_test.go
@@ -29,6 +29,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/testutil"
 )
 
 func TestState(t *testing.T) { TestingT(t) }
@@ -111,7 +112,7 @@ func (ss *stateSuite) TestGetNoState(c *C) {
 
 	var mSt1B mgrState1
 	err := st.Get("mgr9", &mSt1B)
-	c.Check(err, Equals, state.ErrNoState)
+	c.Check(err, testutil.ErrorIs, state.ErrNoState)
 }
 
 func (ss *stateSuite) TestSetToNilDeletes(c *C) {
@@ -129,7 +130,7 @@ func (ss *stateSuite) TestSetToNilDeletes(c *C) {
 
 	var v1 map[string]int
 	err = st.Get("a", &v1)
-	c.Check(err, Equals, state.ErrNoState)
+	c.Check(err, testutil.ErrorIs, state.ErrNoState)
 	c.Check(v1, HasLen, 0)
 }
 
@@ -143,7 +144,7 @@ func (ss *stateSuite) TestNullMeansNoState(c *C) {
 
 	var v1 map[string]int
 	err = st.Get("a", &v1)
-	c.Check(err, Equals, state.ErrNoState)
+	c.Check(err, testutil.ErrorIs, state.ErrNoState)
 	c.Check(v1, HasLen, 0)
 }
 

--- a/overlord/state/task_test.go
+++ b/overlord/state/task_test.go
@@ -127,7 +127,7 @@ func (ts *taskSuite) TestClear(c *C) {
 
 	t.Clear("a")
 
-	c.Check(t.Get("a", &v), Equals, state.ErrNoState)
+	c.Check(t.Get("a", &v), testutil.ErrorIs, state.ErrNoState)
 }
 
 func (ts *taskSuite) TestStatusAndSetStatus(c *C) {

--- a/overlord/storecontext/context.go
+++ b/overlord/storecontext/context.go
@@ -21,6 +21,7 @@
 package storecontext
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -179,7 +180,7 @@ func (sc *storeContext) StoreID(fallback string) (string, error) {
 	defer sc.state.Unlock()
 
 	mod, err := sc.deviceBackend.Model()
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return "", err
 	}
 
@@ -199,7 +200,7 @@ func (sc *storeContext) DeviceSessionRequestParams(nonce string) (*DeviceSession
 	defer sc.state.Unlock()
 
 	params, err := sc.deviceSessionRequestParams(nonce)
-	if err == state.ErrNoState {
+	if errors.Is(err, state.ErrNoState) {
 		return nil, store.ErrNoSerial
 	}
 
@@ -235,7 +236,7 @@ func (sc *storeContext) ProxyStoreParams(defaultURL *url.URL) (proxyStoreID stri
 	defer sc.state.Unlock()
 
 	sto, err := sc.proxyStoreer.ProxyStore()
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return "", nil, err
 	}
 

--- a/timings/timings_test.go
+++ b/timings/timings_test.go
@@ -165,7 +165,7 @@ func (s *timingsSuite) TestSaveNoTimings(c *C) {
 	timing.Save(s.st)
 
 	var stateTimings []interface{}
-	c.Assert(s.st.Get("timings", &stateTimings), Equals, state.ErrNoState)
+	c.Assert(s.st.Get("timings", &stateTimings), testutil.ErrorIs, state.ErrNoState)
 }
 
 func (s *timingsSuite) TestDuration(c *C) {
@@ -227,7 +227,7 @@ func (s *timingsSuite) testDurationThreshold(c *C, threshold time.Duration, expe
 
 	var stateTimings []interface{}
 	if expected == nil {
-		c.Assert(s.st.Get("timings", &stateTimings), Equals, state.ErrNoState)
+		c.Assert(s.st.Get("timings", &stateTimings), testutil.ErrorIs, state.ErrNoState)
 		c.Assert(stateTimings, IsNil)
 		return
 	}


### PR DESCRIPTION
Replaces equality checks of ErrNoState with errors.Is(). Once this error is only consumed through errors.Is(), we will be able to replace some of its usages with error structs containing extra information or more appropriate messages without breaking the consumer side.