### PR TITLE
interfaces/shared-memory: Update AppArmor permissions for mmap+link

### DIFF
--- a/interfaces/builtin/shared_memory.go
+++ b/interfaces/builtin/shared_memory.go
@@ -220,7 +220,7 @@ func writeSharedMemoryPaths(w io.Writer, slot *interfaces.ConnectedSlot,
 	snippetType sharedMemorySnippetType) {
 	emitWritableRule := func(path string) {
 		// Ubuntu 14.04 uses /run/shm instead of the most common /dev/shm
-		fmt.Fprintf(w, "\"/{dev,run}/shm/%s\" rwk,\n", path)
+		fmt.Fprintf(w, "\"/{dev,run}/shm/%s\" mrwlk,\n", path)
 	}
 
 	// All checks were already done in BeforePrepare{Plug,Slot}

--- a/interfaces/builtin/shared_memory_test.go
+++ b/interfaces/builtin/shared_memory_test.go
@@ -393,12 +393,12 @@ func (s *SharedMemoryInterfaceSuite) TestAppArmorSpec(c *C) {
 
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app", "snap.provider.app"})
 
-	c.Check(plugSnippet, testutil.Contains, `"/{dev,run}/shm/bar" rwk,`)
+	c.Check(plugSnippet, testutil.Contains, `"/{dev,run}/shm/bar" mrwlk,`)
 	c.Check(plugSnippet, testutil.Contains, `"/{dev,run}/shm/bar-ro" r,`)
 
 	// Slot has read-write permissions to all paths
-	c.Check(slotSnippet, testutil.Contains, `"/{dev,run}/shm/bar" rwk,`)
-	c.Check(slotSnippet, testutil.Contains, `"/{dev,run}/shm/bar-ro" rwk,`)
+	c.Check(slotSnippet, testutil.Contains, `"/{dev,run}/shm/bar" mrwlk,`)
+	c.Check(slotSnippet, testutil.Contains, `"/{dev,run}/shm/bar-ro" mrwlk,`)
 
 	wildcardSpec := &apparmor.Specification{}
 	c.Assert(wildcardSpec.AddConnectedPlug(s.iface, s.wildcardPlug, s.wildcardSlot), IsNil)
@@ -409,12 +409,12 @@ func (s *SharedMemoryInterfaceSuite) TestAppArmorSpec(c *C) {
 
 	c.Assert(wildcardSpec.SecurityTags(), DeepEquals, []string{"snap.consumer.app", "snap.provider.app"})
 
-	c.Check(wildcardPlugSnippet, testutil.Contains, `"/{dev,run}/shm/bar*" rwk,`)
+	c.Check(wildcardPlugSnippet, testutil.Contains, `"/{dev,run}/shm/bar*" mrwlk,`)
 	c.Check(wildcardPlugSnippet, testutil.Contains, `"/{dev,run}/shm/bar-ro*" r,`)
 
 	// Slot has read-write permissions to all paths
-	c.Check(wildcardSlotSnippet, testutil.Contains, `"/{dev,run}/shm/bar*" rwk,`)
-	c.Check(wildcardSlotSnippet, testutil.Contains, `"/{dev,run}/shm/bar-ro*" rwk,`)
+	c.Check(wildcardSlotSnippet, testutil.Contains, `"/{dev,run}/shm/bar*" mrwlk,`)
+	c.Check(wildcardSlotSnippet, testutil.Contains, `"/{dev,run}/shm/bar-ro*" mrwlk,`)
 
 	spec = &apparmor.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.privatePlug, s.privateSlot), IsNil)


### PR DESCRIPTION
Allow snaps to mmap and link files under their own shared-memory
paths. Fixes LP: #1974464.

Signed-off-by: Alex Murray <alex.murray@canonical.com>

-------