### PR TITLE
overlord/ifacestate: add journal bind-mount snap layout when snap is in a journal quota group (4/n)

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -99,6 +99,7 @@ var (
 	SnapRuntimeServicesDir string
 	SnapUserServicesDir    string
 	SnapSystemdConfDir     string
+	SnapSystemdDir         string
 	SnapDesktopFilesDir    string
 	SnapDesktopIconsDir    string
 	SnapPolkitPolicyDir    string

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -99,7 +99,6 @@ var (
 	SnapRuntimeServicesDir string
 	SnapUserServicesDir    string
 	SnapSystemdConfDir     string
-	SnapSystemdDir         string
 	SnapDesktopFilesDir    string
 	SnapDesktopIconsDir    string
 	SnapPolkitPolicyDir    string

--- a/overlord/ifacestate/export_test.go
+++ b/overlord/ifacestate/export_test.go
@@ -61,6 +61,7 @@ var (
 
 	BatchConnectTasks                = batchConnectTasks
 	FirstTaskAfterBootWhenPreseeding = firstTaskAfterBootWhenPreseeding
+	BuildConfinementOptions          = buildConfinementOptions
 )
 
 type ConnectOpts = connectOpts

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -47,15 +47,13 @@ import (
 var snapstateFinishRestart = snapstate.FinishRestart
 
 // addJournalQuotaLayout handles the addition of a journal quota bind mount
-// in case the snap has a journal quota. This mimicks what systemd does for
-// services with log namespaces.
+// to mimicks what systemd does for services with log namespaces.
 func addJournalQuotaLayout(quotaGroup *quota.Group, layouts *[]snap.Layout) error {
 	if quotaGroup.JournalLimit == nil {
 		return nil
 	}
 
-	// We need to bind mount the journal namespace folder ontop of
-	// the journal folder
+	// bind mount the journal namespace folder ontop of the journal folder
 	// /etc/systemd/journal.<ns> -> /etc/systemd/journal
 	journalLayout := snap.Layout{
 		Bind: path.Join(dirs.SnapSystemdDir, fmt.Sprintf("journal.snap-%s", quotaGroup.Name)),

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -46,11 +46,11 @@ import (
 
 var snapstateFinishRestart = snapstate.FinishRestart
 
-// getJournalQuotaLayout returns the necessary journal quota mount layouts
+// journalQuotaLayout returns the necessary journal quota mount layouts
 // to mimick what systemd does for services with log namespaces.
-func getJournalQuotaLayout(quotaGroup *quota.Group) []snap.Layout {
+func journalQuotaLayout(quotaGroup *quota.Group) []snap.Layout {
 	if quotaGroup.JournalLimit == nil {
-		return []snap.Layout{}
+		return nil
 	}
 
 	// bind mount the journal namespace folder on top of the journal folder
@@ -74,7 +74,7 @@ func getExtraLayouts(st *state.State, snapInstanceName string) ([]snap.Layout, e
 
 	var extraLayouts []snap.Layout
 	if snapOpts.QuotaGroup != nil {
-		extraLayouts = append(extraLayouts, getJournalQuotaLayout(snapOpts.QuotaGroup)...)
+		extraLayouts = append(extraLayouts, journalQuotaLayout(snapOpts.QuotaGroup)...)
 	}
 
 	return extraLayouts, nil

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -22,7 +22,6 @@ package ifacestate
 import (
 	"errors"
 	"fmt"
-	"log"
 	"path"
 	"reflect"
 	"sort"
@@ -51,12 +50,10 @@ var snapstateFinishRestart = snapstate.FinishRestart
 // in case the snap has a journal quota. This mimicks what systemd does for
 // services with log namespaces.
 func addJournalQuotaLayout(quotaGroup *quota.Group, layouts *[]snap.Layout) error {
-	log.Println("3.1")
 	if quotaGroup.JournalLimit == nil {
 		return nil
 	}
 
-	log.Println("3.2")
 	// We need to bind mount the journal namespace folder ontop of
 	// the journal folder
 	// /etc/systemd/journal.<ns> -> /etc/systemd/journal
@@ -102,7 +99,6 @@ func buildConfinementOptions(st *state.State, snapInstanceName string, flags sna
 	extraLayouts, err := getExtraLayouts(st, snapInstanceName)
 	if err != nil {
 		logger.Noticef("cannot get extra mount layouts of snap %q: %s", snapInstanceName, err)
-		log.Printf("cannot get extra mount layouts of snap %q: %s", snapInstanceName, err)
 	}
 	return confinementOptions(flags, extraLayouts)
 }

--- a/overlord/ifacestate/handlers_test.go
+++ b/overlord/ifacestate/handlers_test.go
@@ -126,14 +126,14 @@ func mockInstalledSnap(c *C, st *state.State, snapYaml string) *snap.Info {
 }
 
 func (s *handlersSuite) TestBuildConfinementOptions(c *C) {
-	// Mock installed snap
 	s.st.Lock()
 	defer s.st.Unlock()
 
 	snapInfo := mockInstalledSnap(c, s.st, snapAyaml)
 	flags := snapstate.Flags{}
-	opts := ifacestate.BuildConfinementOptions(s.st, snapInfo.InstanceName(), snapstate.Flags{})
+	opts, err := ifacestate.BuildConfinementOptions(s.st, snapInfo.InstanceName(), snapstate.Flags{})
 
+	c.Check(err, IsNil)
 	c.Check(len(opts.ExtraLayouts), Equals, 0)
 	c.Check(opts.Classic, Equals, flags.Classic)
 	c.Check(opts.DevMode, Equals, flags.DevMode)
@@ -141,7 +141,6 @@ func (s *handlersSuite) TestBuildConfinementOptions(c *C) {
 }
 
 func (s *handlersSuite) TestBuildConfinementOptionsWithLogNamespace(c *C) {
-	// Mock installed snap
 	s.st.Lock()
 	defer s.st.Unlock()
 
@@ -156,8 +155,9 @@ func (s *handlersSuite) TestBuildConfinementOptionsWithLogNamespace(c *C) {
 	c.Assert(err, IsNil)
 
 	flags := snapstate.Flags{}
-	opts := ifacestate.BuildConfinementOptions(s.st, snapInfo.InstanceName(), snapstate.Flags{})
+	opts, err := ifacestate.BuildConfinementOptions(s.st, snapInfo.InstanceName(), snapstate.Flags{})
 
+	c.Check(err, IsNil)
 	c.Assert(len(opts.ExtraLayouts), Equals, 1)
 	c.Check(opts.ExtraLayouts[0].Bind, Equals, path.Join(dirs.SnapSystemdDir, "journal.snap-foo"))
 	c.Check(opts.ExtraLayouts[0].Path, Equals, path.Join(dirs.SnapSystemdDir, "journal"))

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -177,7 +177,7 @@ func (m *InterfaceManager) regenerateAllSecurityProfiles(tm timings.Measurer) er
 		if err := snapstate.Get(m.state, snapName, &snapst); err != nil {
 			logger.Noticef("cannot get state of snap %q: %s", snapName, err)
 		}
-		return buildConfinementOptions(m.state, snapName, snapst.Flags)
+		return buildConfinementOptions(m.state, snapst.InstanceName(), snapst.Flags)
 	}
 
 	// For each backend:

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -177,7 +177,7 @@ func (m *InterfaceManager) regenerateAllSecurityProfiles(tm timings.Measurer) er
 		if err := snapstate.Get(m.state, snapName, &snapst); err != nil {
 			logger.Noticef("cannot get state of snap %q: %s", snapName, err)
 		}
-		return confinementOptions(snapst.Flags)
+		return buildConfinementOptions(m.state, snapName, snapst.Flags)
 	}
 
 	// For each backend:

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -177,7 +177,11 @@ func (m *InterfaceManager) regenerateAllSecurityProfiles(tm timings.Measurer) er
 		if err := snapstate.Get(m.state, snapName, &snapst); err != nil {
 			logger.Noticef("cannot get state of snap %q: %s", snapName, err)
 		}
-		return buildConfinementOptions(m.state, snapst.InstanceName(), snapst.Flags)
+		opts, err := buildConfinementOptions(m.state, snapst.InstanceName(), snapst.Flags)
+		if err != nil {
+			logger.Noticef("cannot get confinement options for snap %q: %s", snapName, err)
+		}
+		return opts
 	}
 
 	// For each backend:


### PR DESCRIPTION
When a snap is in a quota group with a journal quota set, we need to add a bind mount from /etc/systemd/journal.<ns> to /etc/systemd/journal to simulate whatever systemd does to support journal namespaces. This code adds this redirect.