### PR TITLE
cmd/snap: cleanup and make the code a bit easier to read/maintain for quota options

### DIFF
--- a/cmd/snap/cmd_quota.go
+++ b/cmd/snap/cmd_quota.go
@@ -165,23 +165,19 @@ func parseCpuQuota(cpuMax string) (count int, percentage int, err error) {
 	return count, percentage, nil
 }
 
-func parseQuotas(maxMemory string, cpuMax string, cpuSet string, threadsMax string) (*client.QuotaValues, error) {
-	var mem int64
-	var cpuCount int
-	var cpuPercentage int
-	var cpus []int
-	var threads int
+func (x *cmdSetQuota) parseQuotas() (*client.QuotaValues, error) {
+	var quotaValues client.QuotaValues
 
-	if maxMemory != "" {
-		value, err := strutil.ParseByteSize(maxMemory)
+	if x.MemoryMax != "" {
+		value, err := strutil.ParseByteSize(x.MemoryMax)
 		if err != nil {
 			return nil, err
 		}
-		mem = value
+		quotaValues.Memory = quantity.Size(value)
 	}
 
-	if cpuMax != "" {
-		countValue, percentageValue, err := parseCpuQuota(cpuMax)
+	if x.CPUMax != "" {
+		countValue, percentageValue, err := parseCpuQuota(x.CPUMax)
 		if err != nil {
 			return nil, err
 		}
@@ -189,12 +185,15 @@ func parseQuotas(maxMemory string, cpuMax string, cpuSet string, threadsMax stri
 			return nil, fmt.Errorf("cannot use value %v: cpu quota percentage must be between 1 and 100", percentageValue)
 		}
 
-		cpuCount = countValue
-		cpuPercentage = percentageValue
+		quotaValues.CPU = &client.QuotaCPUValues{
+			Count:      countValue,
+			Percentage: percentageValue,
+		}
 	}
 
-	if cpuSet != "" {
-		cpuTokens := strutil.CommaSeparatedList(cpuSet)
+	if x.CPUSet != "" {
+		var cpus []int
+		cpuTokens := strutil.CommaSeparatedList(x.CPUSet)
 		for _, cpuToken := range cpuTokens {
 			cpu, err := strconv.ParseUint(cpuToken, 10, 32)
 			if err != nil {
@@ -202,31 +201,29 @@ func parseQuotas(maxMemory string, cpuMax string, cpuSet string, threadsMax stri
 			}
 			cpus = append(cpus, int(cpu))
 		}
-	}
 
-	if threadsMax != "" {
-		value, err := strconv.ParseUint(threadsMax, 10, 32)
-		if err != nil {
-			return nil, fmt.Errorf("cannot use threads value %q", threadsMax)
-		}
-		threads = int(value)
-	}
-
-	return &client.QuotaValues{
-		Memory: quantity.Size(mem),
-		CPU: &client.QuotaCPUValues{
-			Count:      cpuCount,
-			Percentage: cpuPercentage,
-		},
-		CPUSet: &client.QuotaCPUSetValues{
+		quotaValues.CPUSet = &client.QuotaCPUSetValues{
 			CPUs: cpus,
-		},
-		Threads: threads,
-	}, nil
+		}
+	}
+
+	if x.ThreadsMax != "" {
+		value, err := strconv.ParseUint(x.ThreadsMax, 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("cannot use threads value %q", x.ThreadsMax)
+		}
+		quotaValues.Threads = int(value)
+	}
+
+	return &quotaValues, nil
+}
+
+func (x *cmdSetQuota) hasQuotaSet() bool {
+	return x.MemoryMax != "" || x.CPUMax != "" || x.CPUSet != "" || x.ThreadsMax != ""
 }
 
 func (x *cmdSetQuota) Execute(args []string) (err error) {
-	quotaProvided := x.MemoryMax != "" || x.CPUMax != "" || x.CPUSet != "" || x.ThreadsMax != ""
+	quotaProvided := x.hasQuotaSet()
 
 	names := installedSnapNames(x.Positional.Snaps)
 
@@ -267,7 +264,7 @@ func (x *cmdSetQuota) Execute(args []string) (err error) {
 		// we have a limits to set for this group, so specify that along
 		// with whatever snaps may have been provided and whatever parent may
 		// have been specified
-		quotaValues, err := parseQuotas(x.MemoryMax, x.CPUMax, x.CPUSet, x.ThreadsMax)
+		quotaValues, err := x.parseQuotas()
 		if err != nil {
 			return err
 		}

--- a/cmd/snap/cmd_quota_test.go
+++ b/cmd/snap/cmd_quota_test.go
@@ -212,11 +212,11 @@ func (s *quotaSuite) TestParseQuotas(c *check.C) {
 		quotas string
 		err    string
 	}{
-		{maxMemory: "12KB", quotas: `{"memory":12000,"cpu":{},"cpu-set":{}}`},
-		{cpuMax: "12x40%", quotas: `{"cpu":{"count":12,"percentage":40},"cpu-set":{}}`},
-		{cpuMax: "40%", quotas: `{"cpu":{"percentage":40},"cpu-set":{}}`},
-		{cpuSet: "1,3", quotas: `{"cpu":{},"cpu-set":{"cpus":[1,3]}}`},
-		{threadsMax: "2", quotas: `{"cpu":{},"cpu-set":{},"threads":2}`},
+		{maxMemory: "12KB", quotas: `{"memory":12000}`},
+		{cpuMax: "12x40%", quotas: `{"cpu":{"count":12,"percentage":40}}`},
+		{cpuMax: "40%", quotas: `{"cpu":{"percentage":40}}`},
+		{cpuSet: "1,3", quotas: `{"cpu-set":{"cpus":[1,3]}}`},
+		{threadsMax: "2", quotas: `{"threads":2}`},
 		// Error cases
 		{cpuMax: "ASD", err: `cannot parse cpu quota string "ASD"`},
 		{cpuMax: "0x100%", err: `cannot parse cpu quota string "0x100%"`},
@@ -230,7 +230,7 @@ func (s *quotaSuite) TestParseQuotas(c *check.C) {
 		{threadsMax: "xxx", err: `cannot use threads value "xxx"`},
 		{threadsMax: "-3", err: `cannot use threads value "-3"`},
 	} {
-		quotas, err := main.ParseQuotas(testData.maxMemory, testData.cpuMax, testData.cpuSet, testData.threadsMax)
+		quotas, err := main.ParseQuotaValues(testData.maxMemory, testData.cpuMax, testData.cpuSet, testData.threadsMax)
 		testLabel := check.Commentf("%v", testData)
 		if testData.err == "" {
 			c.Check(err, check.IsNil, testLabel)

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -95,8 +95,6 @@ var (
 	IsStopping = isStopping
 
 	GetSnapDirOptions = getSnapDirOptions
-
-	ParseQuotas = parseQuotas
 )
 
 func HiddenCmd(descr string, completeHidden bool) *cmdInfo {
@@ -458,4 +456,15 @@ func MockAutostartSessionApps(f func(string) error) func() {
 	return func() {
 		autostartSessionApps = old
 	}
+}
+
+func ParseQuotaValues(maxMemory, cpuMax, cpuSet, threadsMax string) (*client.QuotaValues, error) {
+	var quotas cmdSetQuota
+
+	quotas.MemoryMax = maxMemory
+	quotas.CPUMax = cpuMax
+	quotas.CPUSet = cpuSet
+	quotas.ThreadsMax = threadsMax
+
+	return quotas.parseQuotas()
 }


### PR DESCRIPTION
This is some more cleanup before adding journal quota options as it started to get crowded with parameters.