### PR TITLE
client,cmd/snap: add journal quota frontend (5/n)

### DIFF
--- a/client/quota.go
+++ b/client/quota.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/snapcore/snapd/gadget/quantity"
 )
@@ -53,11 +54,18 @@ type QuotaCPUSetValues struct {
 	CPUs []int `json:"cpus,omitempty"`
 }
 
+type QuotaJournalValues struct {
+	Size       quantity.Size `json:"size,omitempty"`
+	RateCount  int           `json:"rate-count,omitempty"`
+	RatePeriod time.Duration `json:"rate-period,omitempty"`
+}
+
 type QuotaValues struct {
-	Memory  quantity.Size      `json:"memory,omitempty"`
-	CPU     *QuotaCPUValues    `json:"cpu,omitempty"`
-	CPUSet  *QuotaCPUSetValues `json:"cpu-set,omitempty"`
-	Threads int                `json:"threads,omitempty"`
+	Memory  quantity.Size       `json:"memory,omitempty"`
+	CPU     *QuotaCPUValues     `json:"cpu,omitempty"`
+	CPUSet  *QuotaCPUSetValues  `json:"cpu-set,omitempty"`
+	Threads int                 `json:"threads,omitempty"`
+	Journal *QuotaJournalValues `json:"journal,omitempty"`
 }
 
 // EnsureQuota creates a quota group or updates an existing group.

--- a/client/quota_test.go
+++ b/client/quota_test.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"io/ioutil"
+	"time"
 
 	"gopkg.in/check.v1"
 
@@ -54,6 +55,11 @@ func (cs *clientSuite) TestEnsureQuotaGroup(c *check.C) {
 			CPUs: []int{0},
 		},
 		Threads: 32,
+		Journal: &client.QuotaJournalValues{
+			Size:       quantity.SizeMiB,
+			RateCount:  150,
+			RatePeriod: time.Minute,
+		},
 	}
 
 	chgID, err := cs.cli.EnsureQuota("foo", "bar", []string{"snap-a", "snap-b"}, quotaValues)
@@ -81,6 +87,11 @@ func (cs *clientSuite) TestEnsureQuotaGroup(c *check.C) {
 				"cpus": []interface{}{json.Number("0")},
 			},
 			"threads": json.Number("32"),
+			"journal": map[string]interface{}{
+				"size":        json.Number("1048576"),
+				"rate-count":  json.Number("150"),
+				"rate-period": json.Number("60000000000"),
+			},
 		},
 	})
 }

--- a/cmd/snap/cmd_quota.go
+++ b/cmd/snap/cmd_quota.go
@@ -531,7 +531,7 @@ func (x *cmdQuotas) Execute(args []string) (err error) {
 				grpConstraints = append(grpConstraints, "journal-size="+strings.TrimSpace(fmtSize(int64(q.Constraints.Journal.Size))))
 			}
 			if q.Constraints.Journal.RateCount != 0 && q.Constraints.Journal.RatePeriod != 0 {
-				grpConstraints = append(grpConstraints, fmt.Sprintf("journal-rate=%dx/%s", q.Constraints.Journal.RateCount, q.Constraints.Journal.RatePeriod))
+				grpConstraints = append(grpConstraints, fmt.Sprintf("journal-rate=%d/%s", q.Constraints.Journal.RateCount, q.Constraints.Journal.RatePeriod))
 			}
 		}
 

--- a/cmd/snap/cmd_quota.go
+++ b/cmd/snap/cmd_quota.go
@@ -179,23 +179,17 @@ func parseJournalRateQuota(journalRateLimit string) (count int, period time.Dura
 	// messages and P is the period as a time string (e.g 5s)
 	parts := strings.Split(journalRateLimit, "/")
 	if len(parts) != 2 {
-		return 0, 0, fmt.Errorf("missing number of messages and period")
+		return 0, 0, fmt.Errorf("rate limit must be of the form <number of messages>/<period duration>")
 	}
 
 	count, err = strconv.Atoi(parts[0])
 	if err != nil {
 		return 0, 0, err
 	}
-	if count == 0 {
-		return 0, 0, fmt.Errorf("messages count must be larger than 0")
-	}
 
 	period, err = time.ParseDuration(parts[1])
 	if err != nil {
 		return 0, 0, fmt.Errorf("cannot parse pariod: %v", err)
-	}
-	if period == 0 {
-		return 0, 0, fmt.Errorf("period must be larger than 0")
 	}
 	return count, period, nil
 }

--- a/cmd/snap/cmd_quota.go
+++ b/cmd/snap/cmd_quota.go
@@ -184,12 +184,12 @@ func parseJournalRateQuota(journalRateLimit string) (count int, period time.Dura
 
 	count, err = strconv.Atoi(parts[0])
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, fmt.Errorf("cannot parse message count: %v", err)
 	}
 
 	period, err = time.ParseDuration(parts[1])
 	if err != nil {
-		return 0, 0, fmt.Errorf("cannot parse pariod: %v", err)
+		return 0, 0, fmt.Errorf("cannot parse period: %v", err)
 	}
 	return count, period, nil
 }

--- a/cmd/snap/cmd_quota.go
+++ b/cmd/snap/cmd_quota.go
@@ -114,7 +114,7 @@ func init() {
 			"cpu-set":            i18n.G("CPU set quota"),
 			"threads":            i18n.G("Threads quota"),
 			"journal-size":       i18n.G("Journal size quota"),
-			"journal-rate-limit": i18n.G("Journal rate limit quota"),
+			"journal-rate-limit": i18n.G("Journal rate limit as <message count>/<message period>"),
 			"parent":             i18n.G("Parent quota group"),
 		}), nil)
 	cmd.hidden = true

--- a/cmd/snap/cmd_quota_test.go
+++ b/cmd/snap/cmd_quota_test.go
@@ -238,7 +238,7 @@ func (s *quotaSuite) TestParseQuotas(c *check.C) {
 		{threadsMax: "-3", err: `cannot use threads value "-3"`},
 		{journalRateLimit: "0", err: `cannot parse journal rate limit "0": missing number of messages and period`},
 		{journalRateLimit: "x/5m", err: `cannot parse journal rate limit "x/5m": strconv.Atoi: parsing "x": invalid syntax`},
-		{journalRateLimit: "1/wow", err: `cannot parse journal rate limit "1/wow": cannot parse pariod: time: invalid duration "wow"`},
+		{journalRateLimit: "1/wow", err: `cannot parse journal rate limit "1/wow": cannot parse pariod: time: invalid duration ["]?wow["]?`},
 	} {
 		quotas, err := main.ParseQuotaValues(testData.maxMemory, testData.cpuMax,
 			testData.cpuSet, testData.threadsMax, testData.journalSizeMax, testData.journalRateLimit)

--- a/cmd/snap/cmd_quota_test.go
+++ b/cmd/snap/cmd_quota_test.go
@@ -236,7 +236,7 @@ func (s *quotaSuite) TestParseQuotas(c *check.C) {
 		{cpuSet: "0,-2", err: `cannot parse CPU set value "-2"`},
 		{threadsMax: "xxx", err: `cannot use threads value "xxx"`},
 		{threadsMax: "-3", err: `cannot use threads value "-3"`},
-		{journalRateLimit: "0", err: `cannot parse journal rate limit "0": missing number of messages and period`},
+		{journalRateLimit: "0", err: `cannot parse journal rate limit "0": rate limit must be of the form <number of messages>/<period duration>`},
 		{journalRateLimit: "x/5m", err: `cannot parse journal rate limit "x/5m": strconv.Atoi: parsing "x": invalid syntax`},
 		{journalRateLimit: "1/wow", err: `cannot parse journal rate limit "1/wow": cannot parse pariod: time: invalid duration ["]?wow["]?`},
 	} {

--- a/cmd/snap/cmd_quota_test.go
+++ b/cmd/snap/cmd_quota_test.go
@@ -236,9 +236,9 @@ func (s *quotaSuite) TestParseQuotas(c *check.C) {
 		{cpuSet: "0,-2", err: `cannot parse CPU set value "-2"`},
 		{threadsMax: "xxx", err: `cannot use threads value "xxx"`},
 		{threadsMax: "-3", err: `cannot use threads value "-3"`},
-		{journalRateLimit: "0", err: `cannot parse journal rate limit string "0"`},
-		{journalRateLimit: "x/5m", err: `cannot parse journal rate limit string "x\/5m"`},
-		{journalRateLimit: "1/wow", err: `cannot parse journal rate limit string "1\/wow"`},
+		{journalRateLimit: "0", err: `cannot parse journal rate limit "0": missing number of messages and period`},
+		{journalRateLimit: "x/5m", err: `cannot parse journal rate limit "x/5m": strconv.Atoi: parsing "x": invalid syntax`},
+		{journalRateLimit: "1/wow", err: `cannot parse journal rate limit "1/wow": cannot parse pariod: time: invalid duration "wow"`},
 	} {
 		quotas, err := main.ParseQuotaValues(testData.maxMemory, testData.cpuMax,
 			testData.cpuSet, testData.threadsMax, testData.journalSizeMax, testData.journalRateLimit)
@@ -437,6 +437,34 @@ current:
 	c.Check(s.quotaGetGroupHandlerCalls, check.Equals, 2)
 }
 
+func (s *quotaSuite) TestJournalQuotaGroupSimple(c *check.C) {
+	const jsonTemplate = `{
+		"type": "sync",
+		"status-code": 200,
+		"result": {
+			"group-name": "foo",
+			"constraints": {"journal":{"size":1048576,"rate-count":50,"rate-period":60000000000}}
+		}
+	}`
+
+	s.RedirectClientToTestServer(s.makeFakeGetQuotaGroupHandler(c, jsonTemplate))
+
+	outputTemplate := `
+name:  foo
+constraints:
+  journal-size:  1.05MB
+  journal-rate:  50/1m0s
+current:
+`[1:]
+
+	rest, err := main.Parser(main.Client()).ParseArgs([]string{"quota", "foo"})
+	c.Assert(err, check.IsNil)
+	c.Check(rest, check.HasLen, 0)
+	c.Check(s.Stderr(), check.Equals, "")
+	c.Check(s.Stdout(), check.Equals, outputTemplate)
+	c.Check(s.quotaGetGroupHandlerCalls, check.Equals, 1)
+}
+
 func (s *quotaSuite) TestSetQuotaGroupCreateNew(c *check.C) {
 	const postJSON = `{"type": "async", "status-code": 202,"change":"42", "result": []}`
 	fakeHandlerOpts := fakeQuotaGroupPostHandlerOpts{
@@ -632,10 +660,11 @@ func (s *quotaSuite) TestGetAllQuotaGroups(c *check.C) {
 			{"group-name":"fff","parent":"aaa","constraints":{"memory":1000},"current":{"memory":0}},
 			{"group-name":"xxx","constraints":{"memory":9900},"current":{"memory":10000}},
 			{"group-name":"cp0","constraints":{"memory":9900, "cpu":{"percentage":90}},"current":{"memory":10000}},
-			{"group-name":"cp1","subgroups":["cps0"],"constraints":{"cpu":{"count":2, "percentage":90}}},
+			{"group-name":"cp1","subgroups":["cps0","js0"],"constraints":{"cpu":{"count":2, "percentage":90}}},
 			{"group-name":"cps0","parent":"cp1","constraints":{"cpu":{"percentage":40}}},
 			{"group-name":"cp2","subgroups":["cps1"],"constraints":{"cpu":{"count":2,"percentage":100},"cpu-set":{"cpus":[0,1]}}},
-			{"group-name":"cps1","parent":"cp2","constraints":{"memory":9900,"cpu":{"percentage":50},"cpu-set":{"cpus":[1]}},"current":{"memory":10000}}
+			{"group-name":"cps1","parent":"cp2","constraints":{"memory":9900,"cpu":{"percentage":50},"cpu-set":{"cpus":[1]}},"current":{"memory":10000}},
+			{"group-name":"js0","parent":"cp1","constraints":{"journal":{"size":1048576,"rate-count":50,"rate-period":60000000000}}}
 			]}`))
 
 	rest, err := main.Parser(main.Client()).ParseArgs([]string{"quotas"})
@@ -643,22 +672,23 @@ func (s *quotaSuite) TestGetAllQuotaGroups(c *check.C) {
 	c.Check(rest, check.HasLen, 0)
 	c.Check(s.Stderr(), check.Equals, "")
 	c.Check(s.Stdout(), check.Equals, `
-Quota    Parent  Constraints                     Current
-cp0              memory=9.9kB,cpu=90%            memory=10.0kB
-cp1              cpu=2x,cpu=90%                  
-cps0     cp1     cpu=40%                         
-cp2              cpu=2x,cpu=100%,cpu-set=0,1     
-cps1     cp2     memory=9.9kB,cpu=50%,cpu-set=1  memory=10.0kB
-ggg              memory=1000B,threads=100        memory=3000B
-hhh              threads=100                     
-xxx              memory=9.9kB                    memory=10.0kB
-yyyyyyy          memory=1000B                    
-zzz              memory=5000B                    
-aaa      zzz     memory=1000B                    
-ccc      aaa     memory=400B                     
-ddd      aaa     memory=400B                     
-fff      aaa     memory=1000B                    
-bbb      zzz     memory=1000B                    memory=400B
+Quota    Parent  Constraints                                Current
+cp0              memory=9.9kB,cpu=90%                       memory=10.0kB
+cp1              cpu=2x,cpu=90%                             
+cps0     cp1     cpu=40%                                    
+js0      cp1     journal-size=1.05MB,journal-rate=50x/1m0s  
+cp2              cpu=2x,cpu=100%,cpu-set=0,1                
+cps1     cp2     memory=9.9kB,cpu=50%,cpu-set=1             memory=10.0kB
+ggg              memory=1000B,threads=100                   memory=3000B
+hhh              threads=100                                
+xxx              memory=9.9kB                               memory=10.0kB
+yyyyyyy          memory=1000B                               
+zzz              memory=5000B                               
+aaa      zzz     memory=1000B                               
+ccc      aaa     memory=400B                                
+ddd      aaa     memory=400B                                
+fff      aaa     memory=1000B                               
+bbb      zzz     memory=1000B                               memory=400B
 `[1:])
 	c.Check(s.quotaGetGroupsHandlerCalls, check.Equals, 1)
 }

--- a/cmd/snap/cmd_quota_test.go
+++ b/cmd/snap/cmd_quota_test.go
@@ -237,8 +237,8 @@ func (s *quotaSuite) TestParseQuotas(c *check.C) {
 		{threadsMax: "xxx", err: `cannot use threads value "xxx"`},
 		{threadsMax: "-3", err: `cannot use threads value "-3"`},
 		{journalRateLimit: "0", err: `cannot parse journal rate limit "0": rate limit must be of the form <number of messages>/<period duration>`},
-		{journalRateLimit: "x/5m", err: `cannot parse journal rate limit "x/5m": strconv.Atoi: parsing "x": invalid syntax`},
-		{journalRateLimit: "1/wow", err: `cannot parse journal rate limit "1/wow": cannot parse pariod: time: invalid duration ["]?wow["]?`},
+		{journalRateLimit: "x/5m", err: `cannot parse journal rate limit "x/5m": cannot parse message count: strconv.Atoi: parsing "x": invalid syntax`},
+		{journalRateLimit: "1/wow", err: `cannot parse journal rate limit "1/wow": cannot parse period: time: invalid duration ["]?wow["]?`},
 	} {
 		quotas, err := main.ParseQuotaValues(testData.maxMemory, testData.cpuMax,
 			testData.cpuSet, testData.threadsMax, testData.journalSizeMax, testData.journalRateLimit)

--- a/cmd/snap/cmd_quota_test.go
+++ b/cmd/snap/cmd_quota_test.go
@@ -672,23 +672,23 @@ func (s *quotaSuite) TestGetAllQuotaGroups(c *check.C) {
 	c.Check(rest, check.HasLen, 0)
 	c.Check(s.Stderr(), check.Equals, "")
 	c.Check(s.Stdout(), check.Equals, `
-Quota    Parent  Constraints                                Current
-cp0              memory=9.9kB,cpu=90%                       memory=10.0kB
-cp1              cpu=2x,cpu=90%                             
-cps0     cp1     cpu=40%                                    
-js0      cp1     journal-size=1.05MB,journal-rate=50x/1m0s  
-cp2              cpu=2x,cpu=100%,cpu-set=0,1                
-cps1     cp2     memory=9.9kB,cpu=50%,cpu-set=1             memory=10.0kB
-ggg              memory=1000B,threads=100                   memory=3000B
-hhh              threads=100                                
-xxx              memory=9.9kB                               memory=10.0kB
-yyyyyyy          memory=1000B                               
-zzz              memory=5000B                               
-aaa      zzz     memory=1000B                               
-ccc      aaa     memory=400B                                
-ddd      aaa     memory=400B                                
-fff      aaa     memory=1000B                               
-bbb      zzz     memory=1000B                               memory=400B
+Quota    Parent  Constraints                               Current
+cp0              memory=9.9kB,cpu=90%                      memory=10.0kB
+cp1              cpu=2x,cpu=90%                            
+cps0     cp1     cpu=40%                                   
+js0      cp1     journal-size=1.05MB,journal-rate=50/1m0s  
+cp2              cpu=2x,cpu=100%,cpu-set=0,1               
+cps1     cp2     memory=9.9kB,cpu=50%,cpu-set=1            memory=10.0kB
+ggg              memory=1000B,threads=100                  memory=3000B
+hhh              threads=100                               
+xxx              memory=9.9kB                              memory=10.0kB
+yyyyyyy          memory=1000B                              
+zzz              memory=5000B                              
+aaa      zzz     memory=1000B                              
+ccc      aaa     memory=400B                               
+ddd      aaa     memory=400B                               
+fff      aaa     memory=1000B                              
+bbb      zzz     memory=1000B                              memory=400B
 `[1:])
 	c.Check(s.quotaGetGroupsHandlerCalls, check.Equals, 1)
 }

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -458,13 +458,15 @@ func MockAutostartSessionApps(f func(string) error) func() {
 	}
 }
 
-func ParseQuotaValues(maxMemory, cpuMax, cpuSet, threadsMax string) (*client.QuotaValues, error) {
+func ParseQuotaValues(maxMemory, cpuMax, cpuSet, threadsMax, journalSizeMax, journalRateLimit string) (*client.QuotaValues, error) {
 	var quotas cmdSetQuota
 
 	quotas.MemoryMax = maxMemory
 	quotas.CPUMax = cpuMax
 	quotas.CPUSet = cpuSet
 	quotas.ThreadsMax = threadsMax
+	quotas.JournalSizeMax = journalSizeMax
+	quotas.JournalRateLimit = journalRateLimit
 
 	return quotas.parseQuotas()
 }

--- a/daemon/api_quotas.go
+++ b/daemon/api_quotas.go
@@ -196,6 +196,15 @@ func quotaValuesToResources(values client.QuotaValues) quota.Resources {
 	if values.Threads != 0 {
 		resourcesBuilder.WithThreadLimit(values.Threads)
 	}
+	if values.Journal != nil {
+		resourcesBuilder.WithJournalNamespace()
+		if values.Journal.Size != 0 {
+			resourcesBuilder.WithJournalSize(values.Journal.Size)
+		}
+		if values.Journal.RateCount != 0 && values.Journal.RatePeriod != 0 {
+			resourcesBuilder.WithJournalRate(values.Journal.RateCount, values.Journal.RatePeriod)
+		}
+	}
 	return resourcesBuilder.Build()
 }
 

--- a/daemon/api_quotas.go
+++ b/daemon/api_quotas.go
@@ -98,6 +98,13 @@ func createQuotaValues(grp *quota.Group) *client.QuotaValues {
 			CPUs: grp.CPULimit.AllowedCPUs,
 		}
 	}
+	if grp.JournalLimit != nil {
+		constraints.Journal = &client.QuotaJournalValues{
+			Size:       grp.JournalLimit.Size,
+			RateCount:  grp.JournalLimit.RateCount,
+			RatePeriod: grp.JournalLimit.RatePeriod,
+		}
+	}
 	return &constraints
 }
 

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -37,6 +37,8 @@ import (
 	"github.com/snapcore/snapd/testutil"
 )
 
+var CreateQuotaValues = createQuotaValues
+
 func APICommands() []*Command {
 	return api
 }

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -56,7 +56,7 @@ func journalQuotaLayout(quotaGroup *quota.Group) []snap.Layout {
 	// bind mount the journal namespace folder on top of the journal folder
 	// /run/systemd/journal.<ns> -> /run/systemd/journal
 	layouts := []snap.Layout{{
-		Bind: path.Join(dirs.SnapSystemdRunDir, fmt.Sprintf("journal.snap-%s", quotaGroup.Name)),
+		Bind: path.Join(dirs.SnapSystemdRunDir, fmt.Sprintf("journal.%s", quotaGroup.JournalNamespaceName())),
 		Path: path.Join(dirs.SnapSystemdRunDir, "journal"),
 		Mode: 0755,
 	}}

--- a/snap/quota/quota.go
+++ b/snap/quota/quota.go
@@ -257,11 +257,16 @@ func (grp *Group) SliceFileName() string {
 	return buf.String()
 }
 
+// JournalNamespaceName returns the snap formatted name of the log namespace
+func (grp *Group) JournalNamespaceName() string {
+	return fmt.Sprintf("snap-%s", grp.Name)
+}
+
 // JournalFileName returns the name of the journal configuration file that should
 // be used for this quota group. As an example, a group named "foo" will return a name
 // of journald@snap-foo.conf
 func (grp *Group) JournalFileName() string {
-	return fmt.Sprintf("journald@snap-%s.conf", grp.Name)
+	return fmt.Sprintf("journald@%s.conf", grp.JournalNamespaceName())
 }
 
 // groupQuotaAllocations contains information about current quotas of a group

--- a/snap/quota/quota_test.go
+++ b/snap/quota/quota_test.go
@@ -310,6 +310,18 @@ func (ts *quotaTestSuite) TestGroupUnmixableSnapsSubgroups(c *C) {
 	c.Assert(err, ErrorMatches, "cannot mix sub groups with snaps in the same group")
 }
 
+func (ts *quotaTestSuite) TestJournalNamespaceName(c *C) {
+	grp, err := quota.NewGroup("foo", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build())
+	c.Assert(err, IsNil)
+	c.Check(grp.JournalNamespaceName(), Equals, "snap-foo")
+}
+
+func (ts *quotaTestSuite) TestJournalFileName(c *C) {
+	grp, err := quota.NewGroup("foo", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build())
+	c.Assert(err, IsNil)
+	c.Check(grp.JournalFileName(), Equals, "journald@snap-foo.conf")
+}
+
 func (ts *quotaTestSuite) TestResolveCrossReferences(c *C) {
 	tt := []struct {
 		grps    map[string]*quota.Group

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -1320,7 +1320,7 @@ WantedBy={{.ServicesTarget}}
 	if opts.QuotaGroup != nil {
 		wrapperData.SliceUnit = opts.QuotaGroup.SliceFileName()
 		if opts.QuotaGroup.JournalLimit != nil {
-			wrapperData.LogNamespace = "snap-" + opts.QuotaGroup.Name
+			wrapperData.LogNamespace = opts.QuotaGroup.JournalNamespaceName()
 		}
 	}
 


### PR DESCRIPTION
This PR adds the frontend for journal quota options, and enables the usage of journal quotas. Spread tests will come in the last and final PR.