### PR TITLE
run-checks: fail on equality checks w/ ErrNoState

### DIFF
--- a/overlord/healthstate/healthstate.go
+++ b/overlord/healthstate/healthstate.go
@@ -133,7 +133,7 @@ func (h *healthHandler) Done() error {
 		return err
 	}
 	if health.Timestamp.IsZero() {
-		// health was actually the marker (or err == state.ErrNoState)
+		// health was actually the marker (or errors.Is(err, state.ErrNoState))
 		health = HealthState{
 			Revision:  h.context.SnapRevision(),
 			Timestamp: time.Now(),

--- a/run-checks
+++ b/run-checks
@@ -311,6 +311,13 @@ if [ "$STATIC" = 1 ]; then
         echo "Checking tests formatting"
         ./tests/lib/external/snapd-testing-tools/utils/check-test-format ./tests
     fi
+
+		echo "Checking for usages of !=, == or Equals with ErrNoState"
+		if got=$(grep -n -R -E "(\!=|==|Equals,) (state\.)?ErrNoState" --include=*.go) ; then
+			echo "Don't use equality checks with ErrNoState, use errors.Is() instead"
+			echo "$got"
+			exit 1
+		fi
 fi
 
 if [ "$UNIT" = 1 ]; then


### PR DESCRIPTION
Adds a check to run-checks to prevent equality checks from being used with ErrNoState.

Signed-off-by: Miguel Pires <miguel.pires@canonical.com>