### PR TITLE
many: print valid/invalid status on snap validate --monitor ...

### DIFF
--- a/client/validate.go
+++ b/client/validate.go
@@ -77,7 +77,9 @@ func (client *Client) ForgetValidationSet(accountID, name string, sequence int) 
 	return nil
 }
 
-// ApplyValidationSet applies the given validation set identified by account and name.
+// ApplyValidationSet applies the given validation set identified by account and name and returns
+// the new validation set tracking info. For monitoring mode the returned res may indicate invalid
+// state.
 func (client *Client) ApplyValidationSet(accountID, name string, opts *ValidateApplyOptions) (res *ValidationSetResult, err error) {
 	if accountID == "" || name == "" {
 		return nil, xerrors.Errorf("cannot apply validation set without account ID and name")
@@ -95,12 +97,7 @@ func (client *Client) ApplyValidationSet(accountID, name string, opts *ValidateA
 	}
 	path := fmt.Sprintf("/v2/validation-sets/%s/%s", accountID, name)
 
-	if opts.Mode == "monitor" {
-		_, err = client.doSync("POST", path, nil, nil, &body, &res)
-	} else {
-		_, err = client.doSync("POST", path, nil, nil, &body, nil)
-	}
-	if err != nil {
+	if _, err := client.doSync("POST", path, nil, nil, &body, &res); err != nil {
 		fmt := "cannot apply validation set: %w"
 		return nil, xerrors.Errorf(fmt, err)
 	}

--- a/client/validate_test.go
+++ b/client/validate_test.go
@@ -111,12 +111,19 @@ func (cs *clientSuite) TestApplyValidationSetMonitor(c *check.C) {
 func (cs *clientSuite) TestApplyValidationSetEnforce(c *check.C) {
 	cs.rsp = `{
 		"type": "sync",
-		"status-code": 200
+		"status-code": 200,
+        "result": {"account-id": "foo", "name": "bar", "mode": "enforce", "sequence": 3, "valid": true}
 	}`
 	opts := &client.ValidateApplyOptions{Mode: "enforce", Sequence: 3}
 	vs, err := cs.cli.ApplyValidationSet("foo", "bar", opts)
 	c.Assert(err, check.IsNil)
-	c.Check(vs, check.IsNil)
+	c.Check(vs, check.DeepEquals, &client.ValidationSetResult{
+		AccountID: "foo",
+		Name:      "bar",
+		Mode:      "enforce",
+		Sequence:  3,
+		Valid:     true,
+	})
 	c.Check(cs.req.Method, check.Equals, "POST")
 	c.Check(cs.req.URL.Path, check.Equals, "/v2/validation-sets/foo/bar")
 	body, err := ioutil.ReadAll(cs.req.Body)

--- a/client/validate_test.go
+++ b/client/validate_test.go
@@ -78,13 +78,22 @@ func (cs *clientSuite) TestListValidationsSets(c *check.C) {
 	})
 }
 
-func (cs *clientSuite) TestApplyValidationSet(c *check.C) {
+func (cs *clientSuite) TestApplyValidationSetMonitor(c *check.C) {
 	cs.rsp = `{
 		"type": "sync",
-		"status-code": 200
+		"status-code": 200,
+		"result": {"account-id": "foo", "name": "bar", "mode": "monitor", "sequence": 3, "valid": true}
 	}`
 	opts := &client.ValidateApplyOptions{Mode: "monitor", Sequence: 3}
-	c.Assert(cs.cli.ApplyValidationSet("foo", "bar", opts), check.IsNil)
+	vs, err := cs.cli.ApplyValidationSet("foo", "bar", opts)
+	c.Assert(err, check.IsNil)
+	c.Check(vs, check.DeepEquals, &client.ValidationSetResult{
+		AccountID: "foo",
+		Name:      "bar",
+		Mode:      "monitor",
+		Sequence:  3,
+		Valid:     true,
+	})
 	c.Check(cs.req.Method, check.Equals, "POST")
 	c.Check(cs.req.URL.Path, check.Equals, "/v2/validation-sets/foo/bar")
 	body, err := ioutil.ReadAll(cs.req.Body)
@@ -99,11 +108,34 @@ func (cs *clientSuite) TestApplyValidationSet(c *check.C) {
 	})
 }
 
+func (cs *clientSuite) TestApplyValidationSetEnforce(c *check.C) {
+	cs.rsp = `{
+		"type": "sync",
+		"status-code": 200
+	}`
+	opts := &client.ValidateApplyOptions{Mode: "enforce", Sequence: 3}
+	vs, err := cs.cli.ApplyValidationSet("foo", "bar", opts)
+	c.Assert(err, check.IsNil)
+	c.Check(vs, check.IsNil)
+	c.Check(cs.req.Method, check.Equals, "POST")
+	c.Check(cs.req.URL.Path, check.Equals, "/v2/validation-sets/foo/bar")
+	body, err := ioutil.ReadAll(cs.req.Body)
+	c.Assert(err, check.IsNil)
+	var req map[string]interface{}
+	err = json.Unmarshal(body, &req)
+	c.Assert(err, check.IsNil)
+	c.Assert(req, check.DeepEquals, map[string]interface{}{
+		"action":   "apply",
+		"mode":     "enforce",
+		"sequence": float64(3),
+	})
+}
+
 func (cs *clientSuite) TestApplyValidationSetError(c *check.C) {
 	cs.status = 500
 	cs.rsp = errorResponseJSON
 	opts := &client.ValidateApplyOptions{Mode: "monitor"}
-	err := cs.cli.ApplyValidationSet("foo", "bar", opts)
+	_, err := cs.cli.ApplyValidationSet("foo", "bar", opts)
 	c.Assert(err, check.ErrorMatches, "cannot apply validation set: failed")
 	c.Check(cs.req.Method, check.Equals, "POST")
 	c.Check(cs.req.URL.Path, check.Equals, "/v2/validation-sets/foo/bar")
@@ -111,9 +143,9 @@ func (cs *clientSuite) TestApplyValidationSetError(c *check.C) {
 
 func (cs *clientSuite) TestApplyValidationSetInvalidArgs(c *check.C) {
 	opts := &client.ValidateApplyOptions{}
-	err := cs.cli.ApplyValidationSet("", "bar", opts)
+	_, err := cs.cli.ApplyValidationSet("", "bar", opts)
 	c.Assert(err, check.ErrorMatches, `cannot apply validation set without account ID and name`)
-	err = cs.cli.ApplyValidationSet("", "bar", opts)
+	_, err = cs.cli.ApplyValidationSet("", "bar", opts)
 	c.Assert(err, check.ErrorMatches, `cannot apply validation set without account ID and name`)
 }
 

--- a/cmd/snap/cmd_validate.go
+++ b/cmd/snap/cmd_validate.go
@@ -33,9 +33,8 @@ import (
 
 type cmdValidate struct {
 	clientMixin
-	Monitor bool `long:"monitor"`
-	// XXX: enforce mode is not supported yet
-	Enforce    bool `long:"enforce" hidden:"yes"`
+	Monitor    bool `long:"monitor"`
+	Enforce    bool `long:"enforce"`
 	Forget     bool `long:"forget"`
 	Positional struct {
 		ValidationSet string `positional-arg-name:"<validation-set>"`
@@ -152,7 +151,15 @@ func (cmd *cmdValidate) Execute(args []string) error {
 			Mode:     action,
 			Sequence: seq,
 		}
-		return cmd.client.ApplyValidationSet(accountID, name, opts)
+		res, err := cmd.client.ApplyValidationSet(accountID, name, opts)
+		if err != nil {
+			return err
+		}
+		if res != nil && action == "monitor" {
+			fmt.Fprintln(Stdout, fmtValid(res))
+			return nil
+		}
+		return nil
 	}
 
 	// no validation set argument, print list with extended info

--- a/cmd/snap/cmd_validate.go
+++ b/cmd/snap/cmd_validate.go
@@ -159,7 +159,6 @@ func (cmd *cmdValidate) Execute(args []string) error {
 		// and otherwise has no output.
 		if action == "monitor" {
 			fmt.Fprintln(Stdout, fmtValid(res))
-			return nil
 		}
 		return nil
 	}

--- a/cmd/snap/cmd_validate.go
+++ b/cmd/snap/cmd_validate.go
@@ -155,7 +155,9 @@ func (cmd *cmdValidate) Execute(args []string) error {
 		if err != nil {
 			return err
 		}
-		if res != nil && action == "monitor" {
+		// only print valid/invalid status for monitor mode; enforce fails with an error if invalid
+		// and otherwise has no output.
+		if action == "monitor" {
 			fmt.Fprintln(Stdout, fmtValid(res))
 			return nil
 		}

--- a/cmd/snap/cmd_validate_test.go
+++ b/cmd/snap/cmd_validate_test.go
@@ -137,7 +137,7 @@ func (s *validateSuite) TestValidateMonitorPinned(c *check.C) {
 }
 
 func (s *validateSuite) TestValidateEnforce(c *check.C) {
-	s.RedirectClientToTestServer(makeFakeValidationSetPostHandler(c, `{"type": "sync", "status-code": 200, "result": []}`, "enforce", 0))
+	s.RedirectClientToTestServer(makeFakeValidationSetPostHandler(c, `{"type": "sync", "status-code": 200, "result": {"account-id":"foo","name":"bar","mode":"enforce","sequence":3,"valid":true}}}`, "enforce", 0))
 
 	rest, err := main.Parser(main.Client()).ParseArgs([]string{"validate", "--enforce", "foo/bar"})
 	c.Assert(err, check.IsNil)
@@ -147,7 +147,7 @@ func (s *validateSuite) TestValidateEnforce(c *check.C) {
 }
 
 func (s *validateSuite) TestValidateEnforcePinned(c *check.C) {
-	s.RedirectClientToTestServer(makeFakeValidationSetPostHandler(c, `{"type": "sync", "status-code": 200, "result": []}`, "enforce", 5))
+	s.RedirectClientToTestServer(makeFakeValidationSetPostHandler(c, `{"type": "sync", "status-code": 200, "result": {"account-id":"foo","name":"bar","mode":"enforce","sequence":3,"valid":true}}}`, "enforce", 5))
 
 	rest, err := main.Parser(main.Client()).ParseArgs([]string{"validate", "--enforce", "foo/bar=5"})
 	c.Assert(err, check.IsNil)

--- a/cmd/snap/cmd_validate_test.go
+++ b/cmd/snap/cmd_validate_test.go
@@ -117,23 +117,23 @@ func (s *validateSuite) TestValidateInvalidArgs(c *check.C) {
 }
 
 func (s *validateSuite) TestValidateMonitor(c *check.C) {
-	s.RedirectClientToTestServer(makeFakeValidationSetPostHandler(c, `{"type": "sync", "status-code": 200, "result": []}`, "monitor", 0))
+	s.RedirectClientToTestServer(makeFakeValidationSetPostHandler(c, `{"type": "sync", "status-code": 200, "result": {"account-id":"foo","name":"bar","mode":"monitor","sequence":3,"valid":false}}`, "monitor", 0))
 
 	rest, err := main.Parser(main.Client()).ParseArgs([]string{"validate", "--monitor", "foo/bar"})
 	c.Assert(err, check.IsNil)
 	c.Check(rest, check.HasLen, 0)
 	c.Check(s.Stderr(), check.Equals, "")
-	c.Check(s.Stdout(), check.Equals, "")
+	c.Check(s.Stdout(), check.Equals, "invalid\n")
 }
 
 func (s *validateSuite) TestValidateMonitorPinned(c *check.C) {
-	s.RedirectClientToTestServer(makeFakeValidationSetPostHandler(c, `{"type": "sync", "status-code": 200, "result": []}`, "monitor", 3))
+	s.RedirectClientToTestServer(makeFakeValidationSetPostHandler(c, `{"type": "sync", "status-code": 200, "result": {"account-id":"foo","name":"bar","mode":"monitor","sequence":3,"valid":true}}}`, "monitor", 3))
 
 	rest, err := main.Parser(main.Client()).ParseArgs([]string{"validate", "--monitor", "foo/bar=3"})
 	c.Assert(err, check.IsNil)
 	c.Check(rest, check.HasLen, 0)
 	c.Check(s.Stderr(), check.Equals, "")
-	c.Check(s.Stdout(), check.Equals, "")
+	c.Check(s.Stdout(), check.Equals, "valid\n")
 }
 
 func (s *validateSuite) TestValidateEnforce(c *check.C) {

--- a/daemon/api_validate.go
+++ b/daemon/api_validate.go
@@ -303,7 +303,7 @@ func updateValidationSet(st *state.State, accountID, name string, reqMode string
 	if err != nil {
 		return InternalError(err.Error())
 	}
-	return SyncResponse(res)
+	return SyncResponse(*res)
 }
 
 // forgetValidationSet forgets the validation set.
@@ -411,11 +411,16 @@ func enforceValidationSet(st *state.State, accountID, name string, sequence, use
 	if err != nil {
 		return InternalError(err.Error())
 	}
-	if err := assertstateEnforceValidationSet(st, accountID, name, sequence, userID, snaps, ignoreValidation); err != nil {
+	tr, err := assertstateEnforceValidationSet(st, accountID, name, sequence, userID, snaps, ignoreValidation)
+	if err != nil {
 		// XXX: provide more specific error kinds? This would probably require
 		// assertstate.ValidationSetAssertionForEnforce tuning too.
 		return BadRequest("cannot enforce validation set: %v", err)
 	}
 
-	return SyncResponse(nil)
+	res, err := validationSetResultFromTracking(st, tr)
+	if err != nil {
+		return InternalError(err.Error())
+	}
+	return SyncResponse(*res)
 }

--- a/daemon/api_validate.go
+++ b/daemon/api_validate.go
@@ -144,6 +144,38 @@ var checkInstalledSnaps = func(vsets *snapasserts.ValidationSets, snaps []*snapa
 	return vsets.CheckInstalledSnaps(snaps, ignoreValidation)
 }
 
+func validationSetResultFromTracking(st *state.State, tr *assertstate.ValidationSetTracking) (*validationSetResult, error) {
+	var sequence int
+	if tr.PinnedAt > 0 {
+		sequence = tr.PinnedAt
+	} else {
+		sequence = tr.Current
+	}
+	modeStr, err := modeString(tr.Mode)
+	if err != nil {
+		return nil, err
+	}
+
+	sets, err := validationSetForAssert(st, tr.AccountID, tr.Name, sequence)
+	if err != nil {
+		return nil, err
+	}
+	snaps, _, err := snapstate.InstalledSnaps(st)
+	if err != nil {
+		return nil, err
+	}
+
+	validErr := checkInstalledSnaps(sets, snaps, nil)
+	return &validationSetResult{
+		AccountID: tr.AccountID,
+		Name:      tr.Name,
+		PinnedAt:  tr.PinnedAt,
+		Mode:      modeStr,
+		Sequence:  tr.Current,
+		Valid:     validErr == nil,
+	}, nil
+}
+
 func getValidationSet(c *Command, r *http.Request, user *auth.UserState) Response {
 	vars := muxVars(r)
 	accountID := vars["account"]
@@ -186,37 +218,12 @@ func getValidationSet(c *Command, r *http.Request, user *auth.UserState) Respons
 		return InternalError("accessing validation sets failed: %v", err)
 	}
 
-	modeStr, err := modeString(tr.Mode)
-	if err != nil {
-		return InternalError(err.Error())
-	}
-
 	// evaluate against installed snaps
-
-	if tr.PinnedAt > 0 {
-		sequence = tr.PinnedAt
-	} else {
-		sequence = tr.Current
-	}
-	sets, err := validationSetForAssert(st, tr.AccountID, tr.Name, sequence)
+	res, err := validationSetResultFromTracking(st, &tr)
 	if err != nil {
 		return InternalError(err.Error())
 	}
-	snaps, _, err := snapstate.InstalledSnaps(st)
-	if err != nil {
-		return InternalError(err.Error())
-	}
-
-	validErr := checkInstalledSnaps(sets, snaps, nil)
-	res := validationSetResult{
-		AccountID: tr.AccountID,
-		Name:      tr.Name,
-		PinnedAt:  tr.PinnedAt,
-		Mode:      modeStr,
-		Sequence:  tr.Current,
-		Valid:     validErr == nil,
-	}
-	return SyncResponse(res)
+	return SyncResponse(*res)
 }
 
 type validationSetApplyRequest struct {
@@ -287,11 +294,16 @@ func updateValidationSet(st *state.State, accountID, name string, reqMode string
 		return enforceValidationSet(st, accountID, name, sequence, userID)
 	}
 
-	err := assertstateMonitorValidationSet(st, accountID, name, sequence, userID)
+	tr, err := assertstateMonitorValidationSet(st, accountID, name, sequence, userID)
 	if err != nil {
 		return BadRequest("cannot get validation set assertion for %v: %v", assertstate.ValidationSetKey(accountID, name), err)
 	}
-	return SyncResponse(nil)
+
+	res, err := validationSetResultFromTracking(st, tr)
+	if err != nil {
+		return InternalError(err.Error())
+	}
+	return SyncResponse(res)
 }
 
 // forgetValidationSet forgets the validation set.

--- a/daemon/api_validate_test.go
+++ b/daemon/api_validate_test.go
@@ -630,6 +630,15 @@ func (s *apiValidationSetsSuite) TestApplyValidationSetMonitorModePinnedLocalOnl
 
 	rsp := s.syncReq(c, req, nil)
 	c.Assert(rsp.Status, check.Equals, 200)
+	res := rsp.Result.(daemon.ValidationSetResult)
+	c.Check(res, check.DeepEquals, daemon.ValidationSetResult{
+		AccountID: s.dev1acct.AccountID(),
+		Name:      "bar",
+		Mode:      "monitor",
+		PinnedAt:  99,
+		Sequence:  99999,
+		Valid:     true,
+	})
 	c.Check(called, check.Equals, 1)
 }
 
@@ -770,21 +779,27 @@ func (s *apiValidationSetsSuite) TestApplyValidationSetUnsupportedAction(c *chec
 }
 
 func (s *apiValidationSetsSuite) TestApplyValidationSetEnforceMode(c *check.C) {
+	st := s.d.Overlord().State()
+	st.Lock()
+	defer st.Unlock()
+
+	s.mockValidationSetsTracking(st)
+	assertstatetest.AddMany(st, s.dev1acct, s.acct1Key)
+	as := s.mockAssert(c, "bar", "99")
+	err := assertstate.Add(st, as)
+	c.Assert(err, check.IsNil)
+
 	var called int
-	restore := daemon.MockAssertstateEnforceValidationSet(func(st *state.State, accountID, name string, sequence int, userID int, snaps []*snapasserts.InstalledSnap, ignoreValidation map[string]bool) error {
+	restore := daemon.MockAssertstateEnforceValidationSet(func(st *state.State, accountID, name string, sequence int, userID int, snaps []*snapasserts.InstalledSnap, ignoreValidation map[string]bool) (*assertstate.ValidationSetTracking, error) {
 		c.Check(ignoreValidation, check.HasLen, 0)
 		c.Assert(accountID, check.Equals, s.dev1acct.AccountID())
 		c.Assert(name, check.Equals, "bar")
 		c.Assert(sequence, check.Equals, 0)
 		c.Check(userID, check.Equals, 0)
 		called++
-		return nil
+		return &assertstate.ValidationSetTracking{AccountID: accountID, Name: name, Mode: assertstate.Enforce, Current: 99}, nil
 	})
 	defer restore()
-
-	st := s.d.Overlord().State()
-	st.Lock()
-	defer st.Unlock()
 
 	snapstate.Set(st, "snap-b", &snapstate.SnapState{
 		Active:   true,
@@ -806,8 +821,18 @@ func (s *apiValidationSetsSuite) TestApplyValidationSetEnforceMode(c *check.C) {
 }
 
 func (s *apiValidationSetsSuite) TestApplyValidationSetEnforceModeIgnoreValidationOK(c *check.C) {
+	st := s.d.Overlord().State()
+	st.Lock()
+	defer st.Unlock()
+
+	s.mockValidationSetsTracking(st)
+	assertstatetest.AddMany(st, s.dev1acct, s.acct1Key)
+	as := s.mockAssert(c, "bar", "99")
+	err := assertstate.Add(st, as)
+	c.Assert(err, check.IsNil)
+
 	var called int
-	restore := daemon.MockAssertstateEnforceValidationSet(func(st *state.State, accountID, name string, sequence int, userID int, snaps []*snapasserts.InstalledSnap, ignoreValidation map[string]bool) error {
+	restore := daemon.MockAssertstateEnforceValidationSet(func(st *state.State, accountID, name string, sequence int, userID int, snaps []*snapasserts.InstalledSnap, ignoreValidation map[string]bool) (*assertstate.ValidationSetTracking, error) {
 		c.Check(ignoreValidation, check.DeepEquals, map[string]bool{"snap-b": true})
 		c.Check(snaps, testutil.DeepUnsortedMatches, []*snapasserts.InstalledSnap{
 			snapasserts.NewInstalledSnap("snap-b", "yOqKhntON3vR7kwEbVPsILm7bUViPDzz", snap.R("1"))})
@@ -816,13 +841,9 @@ func (s *apiValidationSetsSuite) TestApplyValidationSetEnforceModeIgnoreValidati
 		c.Assert(sequence, check.Equals, 0)
 		c.Check(userID, check.Equals, 0)
 		called++
-		return nil
+		return &assertstate.ValidationSetTracking{AccountID: accountID, Name: name, Mode: assertstate.Enforce, Current: 99}, nil
 	})
 	defer restore()
-
-	st := s.d.Overlord().State()
-	st.Lock()
-	defer st.Unlock()
 
 	snapstate.Set(st, "snap-b", &snapstate.SnapState{
 		Active:   true,
@@ -845,20 +866,26 @@ func (s *apiValidationSetsSuite) TestApplyValidationSetEnforceModeIgnoreValidati
 }
 
 func (s *apiValidationSetsSuite) TestApplyValidationSetEnforceModeSpecificSequence(c *check.C) {
+	st := s.d.Overlord().State()
+	st.Lock()
+	defer st.Unlock()
+
+	s.mockValidationSetsTracking(st)
+	assertstatetest.AddMany(st, s.dev1acct, s.acct1Key)
+	as := s.mockAssert(c, "bar", "5")
+	err := assertstate.Add(st, as)
+	c.Assert(err, check.IsNil)
+
 	var called int
-	restore := daemon.MockAssertstateEnforceValidationSet(func(st *state.State, accountID, name string, sequence int, userID int, snaps []*snapasserts.InstalledSnap, ignoreValidation map[string]bool) error {
+	restore := daemon.MockAssertstateEnforceValidationSet(func(st *state.State, accountID, name string, sequence int, userID int, snaps []*snapasserts.InstalledSnap, ignoreValidation map[string]bool) (*assertstate.ValidationSetTracking, error) {
 		c.Assert(accountID, check.Equals, s.dev1acct.AccountID())
 		c.Assert(name, check.Equals, "bar")
 		c.Assert(sequence, check.Equals, 5)
 		c.Check(userID, check.Equals, 0)
 		called++
-		return nil
+		return &assertstate.ValidationSetTracking{AccountID: accountID, Name: name, Mode: assertstate.Enforce, PinnedAt: 5, Current: 5}, nil
 	})
 	defer restore()
-
-	st := s.d.Overlord().State()
-	st.Lock()
-	defer st.Unlock()
 
 	snapstate.Set(st, "snap-b", &snapstate.SnapState{
 		Active:   true,
@@ -880,8 +907,8 @@ func (s *apiValidationSetsSuite) TestApplyValidationSetEnforceModeSpecificSequen
 }
 
 func (s *apiValidationSetsSuite) TestApplyValidationSetEnforceModeError(c *check.C) {
-	restore := daemon.MockAssertstateEnforceValidationSet(func(st *state.State, accountID, name string, sequence int, userID int, snaps []*snapasserts.InstalledSnap, ignoreValidation map[string]bool) error {
-		return fmt.Errorf("boom")
+	restore := daemon.MockAssertstateEnforceValidationSet(func(st *state.State, accountID, name string, sequence int, userID int, snaps []*snapasserts.InstalledSnap, ignoreValidation map[string]bool) (*assertstate.ValidationSetTracking, error) {
+		return nil, fmt.Errorf("boom")
 	})
 	defer restore()
 

--- a/daemon/api_validate_test.go
+++ b/daemon/api_validate_test.go
@@ -817,6 +817,14 @@ func (s *apiValidationSetsSuite) TestApplyValidationSetEnforceMode(c *check.C) {
 
 	rsp := s.syncReq(c, req, nil)
 	c.Assert(rsp.Status, check.Equals, 200)
+	res := rsp.Result.(daemon.ValidationSetResult)
+	c.Check(res, check.DeepEquals, daemon.ValidationSetResult{
+		AccountID: s.dev1acct.AccountID(),
+		Name:      "bar",
+		Mode:      "enforce",
+		Sequence:  99,
+		Valid:     true,
+	})
 	c.Check(called, check.Equals, 1)
 }
 
@@ -862,6 +870,14 @@ func (s *apiValidationSetsSuite) TestApplyValidationSetEnforceModeIgnoreValidati
 
 	rsp := s.syncReq(c, req, nil)
 	c.Assert(rsp.Status, check.Equals, 200)
+	res := rsp.Result.(daemon.ValidationSetResult)
+	c.Check(res, check.DeepEquals, daemon.ValidationSetResult{
+		AccountID: s.dev1acct.AccountID(),
+		Name:      "bar",
+		Mode:      "enforce",
+		Sequence:  99,
+		Valid:     true,
+	})
 	c.Check(called, check.Equals, 1)
 }
 
@@ -903,6 +919,15 @@ func (s *apiValidationSetsSuite) TestApplyValidationSetEnforceModeSpecificSequen
 
 	rsp := s.syncReq(c, req, nil)
 	c.Assert(rsp.Status, check.Equals, 200)
+	res := rsp.Result.(daemon.ValidationSetResult)
+	c.Check(res, check.DeepEquals, daemon.ValidationSetResult{
+		AccountID: s.dev1acct.AccountID(),
+		Name:      "bar",
+		Mode:      "enforce",
+		PinnedAt:  5,
+		Sequence:  5,
+		Valid:     true,
+	})
 	c.Check(called, check.Equals, 1)
 }
 

--- a/daemon/export_api_validate_test.go
+++ b/daemon/export_api_validate_test.go
@@ -21,6 +21,7 @@ package daemon
 
 import (
 	"github.com/snapcore/snapd/asserts/snapasserts"
+	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/state"
 )
 
@@ -36,7 +37,7 @@ func MockCheckInstalledSnaps(f func(vsets *snapasserts.ValidationSets, snaps []*
 	}
 }
 
-func MockAssertstateMonitorValidationSet(f func(st *state.State, accountID, name string, sequence int, userID int) error) func() {
+func MockAssertstateMonitorValidationSet(f func(st *state.State, accountID, name string, sequence int, userID int) (*assertstate.ValidationSetTracking, error)) func() {
 	old := assertstateMonitorValidationSet
 	assertstateMonitorValidationSet = f
 	return func() {

--- a/daemon/export_api_validate_test.go
+++ b/daemon/export_api_validate_test.go
@@ -45,7 +45,7 @@ func MockAssertstateMonitorValidationSet(f func(st *state.State, accountID, name
 	}
 }
 
-func MockAssertstateEnforceValidationSet(f func(st *state.State, accountID, name string, sequence int, userID int, snaps []*snapasserts.InstalledSnap, ignoreValidation map[string]bool) error) func() {
+func MockAssertstateEnforceValidationSet(f func(st *state.State, accountID, name string, sequence int, userID int, snaps []*snapasserts.InstalledSnap, ignoreValidation map[string]bool) (*assertstate.ValidationSetTracking, error)) func() {
 	old := assertstateEnforceValidationSet
 	assertstateEnforceValidationSet = f
 	return func() {

--- a/overlord/assertstate/assertstate.go
+++ b/overlord/assertstate/assertstate.go
@@ -772,15 +772,15 @@ func EnforceValidationSet(st *state.State, accountID, name string, sequence, use
 
 // MonitorValidationSet tries to fetch the given validation set and monitor it.
 // The current validation sets tracking state is saved in validation sets history.
-func MonitorValidationSet(st *state.State, accountID, name string, sequence int, userID int) error {
+func MonitorValidationSet(st *state.State, accountID, name string, sequence int, userID int) (*ValidationSetTracking, error) {
 	pinned := sequence > 0
 	opts := ResolveOptions{AllowLocalFallback: true}
 	as, local, err := validationSetAssertionForMonitor(st, accountID, name, sequence, pinned, userID, &opts)
 	if err != nil {
-		return fmt.Errorf("cannot get validation set assertion for %v: %v", ValidationSetKey(accountID, name), err)
+		return nil, fmt.Errorf("cannot get validation set assertion for %v: %v", ValidationSetKey(accountID, name), err)
 	}
 
-	tr := ValidationSetTracking{
+	tr := &ValidationSetTracking{
 		AccountID: accountID,
 		Name:      name,
 		Mode:      Monitor,
@@ -790,8 +790,8 @@ func MonitorValidationSet(st *state.State, accountID, name string, sequence int,
 		LocalOnly: local,
 	}
 
-	UpdateValidationSet(st, &tr)
-	return addCurrentTrackingToValidationSetsHistory(st)
+	UpdateValidationSet(st, tr)
+	return tr, addCurrentTrackingToValidationSetsHistory(st)
 }
 
 // TemporaryDB returns a temporary database stacked on top of the assertions

--- a/overlord/assertstate/assertstate.go
+++ b/overlord/assertstate/assertstate.go
@@ -751,10 +751,10 @@ func validationSetAssertionForEnforce(st *state.State, accountID, name string, s
 // EnforceValidationSet tries to fetch the given validation set and enforce it.
 // If all validation sets constrains are satisfied, the current validation sets
 // tracking state is saved in validation sets history.
-func EnforceValidationSet(st *state.State, accountID, name string, sequence, userID int, snaps []*snapasserts.InstalledSnap, ignoreValidation map[string]bool) error {
+func EnforceValidationSet(st *state.State, accountID, name string, sequence, userID int, snaps []*snapasserts.InstalledSnap, ignoreValidation map[string]bool) (*ValidationSetTracking, error) {
 	_, current, err := validationSetAssertionForEnforce(st, accountID, name, sequence, userID, snaps, ignoreValidation)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	tr := ValidationSetTracking{
@@ -767,7 +767,8 @@ func EnforceValidationSet(st *state.State, accountID, name string, sequence, use
 	}
 
 	UpdateValidationSet(st, &tr)
-	return addCurrentTrackingToValidationSetsHistory(st)
+	err = addCurrentTrackingToValidationSetsHistory(st)
+	return &tr, err
 }
 
 // MonitorValidationSet tries to fetch the given validation set and monitor it.

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -3357,7 +3357,7 @@ func (s *assertMgrSuite) TestEnforceValidationSetAssertion(c *C) {
 	}
 
 	sequence := 2
-	err := assertstate.EnforceValidationSet(st, s.dev1Acct.AccountID(), "bar", sequence, 0, snaps, nil)
+	tracking, err := assertstate.EnforceValidationSet(st, s.dev1Acct.AccountID(), "bar", sequence, 0, snaps, nil)
 	c.Assert(err, IsNil)
 
 	// and it has been committed
@@ -3372,6 +3372,7 @@ func (s *assertMgrSuite) TestEnforceValidationSetAssertion(c *C) {
 
 	var tr assertstate.ValidationSetTracking
 	c.Assert(assertstate.GetValidationSet(s.state, s.dev1Acct.AccountID(), "bar", &tr), IsNil)
+	c.Check(tr, DeepEquals, *tracking)
 
 	c.Check(tr, DeepEquals, assertstate.ValidationSetTracking{
 		AccountID: s.dev1Acct.AccountID(),
@@ -3417,7 +3418,7 @@ func (s *assertMgrSuite) TestEnforceValidationSetAssertionUpdate(c *C) {
 	}
 
 	sequence := 2
-	err := assertstate.EnforceValidationSet(st, s.dev1Acct.AccountID(), "bar", sequence, 0, snaps, nil)
+	tracking, err := assertstate.EnforceValidationSet(st, s.dev1Acct.AccountID(), "bar", sequence, 0, snaps, nil)
 	c.Assert(err, IsNil)
 
 	// and it has been committed
@@ -3439,6 +3440,7 @@ func (s *assertMgrSuite) TestEnforceValidationSetAssertionUpdate(c *C) {
 		PinnedAt:  2,
 		Current:   2,
 	})
+	c.Check(tr, DeepEquals, *tracking)
 
 	// and it was added to the history
 	vshist, err := assertstate.ValidationSetsHistory(st)
@@ -3455,7 +3457,7 @@ func (s *assertMgrSuite) TestEnforceValidationSetAssertionUpdate(c *C) {
 
 	// not pinned
 	sequence = 0
-	err = assertstate.EnforceValidationSet(st, s.dev1Acct.AccountID(), "bar", sequence, 0, snaps, nil)
+	tracking, err = assertstate.EnforceValidationSet(st, s.dev1Acct.AccountID(), "bar", sequence, 0, snaps, nil)
 	c.Assert(err, IsNil)
 
 	c.Assert(assertstate.GetValidationSet(s.state, s.dev1Acct.AccountID(), "bar", &tr), IsNil)
@@ -3466,6 +3468,7 @@ func (s *assertMgrSuite) TestEnforceValidationSetAssertionUpdate(c *C) {
 		PinnedAt:  0,
 		Current:   2,
 	})
+	c.Check(tr, DeepEquals, *tracking)
 }
 
 func (s *assertMgrSuite) TestEnforceValidationSetAssertionPinToOlderSequence(c *C) {
@@ -3492,7 +3495,7 @@ func (s *assertMgrSuite) TestEnforceValidationSetAssertionPinToOlderSequence(c *
 	}
 
 	sequence := 2
-	err := assertstate.EnforceValidationSet(st, s.dev1Acct.AccountID(), "bar", sequence, 0, snaps, nil)
+	tracking, err := assertstate.EnforceValidationSet(st, s.dev1Acct.AccountID(), "bar", sequence, 0, snaps, nil)
 	c.Assert(err, IsNil)
 
 	// and it has been committed
@@ -3514,10 +3517,11 @@ func (s *assertMgrSuite) TestEnforceValidationSetAssertionPinToOlderSequence(c *
 		PinnedAt:  2,
 		Current:   2,
 	})
+	c.Check(tr, DeepEquals, *tracking)
 
 	// pin to older
 	sequence = 1
-	err = assertstate.EnforceValidationSet(st, s.dev1Acct.AccountID(), "bar", sequence, 0, snaps, nil)
+	tracking, err = assertstate.EnforceValidationSet(st, s.dev1Acct.AccountID(), "bar", sequence, 0, snaps, nil)
 	c.Assert(err, IsNil)
 
 	c.Assert(assertstate.GetValidationSet(s.state, s.dev1Acct.AccountID(), "bar", &tr), IsNil)
@@ -3529,6 +3533,7 @@ func (s *assertMgrSuite) TestEnforceValidationSetAssertionPinToOlderSequence(c *
 		// and current points at the latest sequence available
 		Current: 2,
 	})
+	c.Check(tr, DeepEquals, *tracking)
 }
 
 func (s *assertMgrSuite) TestEnforceValidationSetAssertionAfterMonitor(c *C) {
@@ -3565,7 +3570,7 @@ func (s *assertMgrSuite) TestEnforceValidationSetAssertionAfterMonitor(c *C) {
 	c.Assert(s.storeSigning.Add(vsetAs), IsNil)
 
 	sequence := 2
-	err := assertstate.EnforceValidationSet(st, s.dev1Acct.AccountID(), "bar", sequence, 0, snaps, nil)
+	tracking, err := assertstate.EnforceValidationSet(st, s.dev1Acct.AccountID(), "bar", sequence, 0, snaps, nil)
 	c.Assert(err, IsNil)
 
 	// and it has been committed
@@ -3588,6 +3593,7 @@ func (s *assertMgrSuite) TestEnforceValidationSetAssertionAfterMonitor(c *C) {
 		PinnedAt:  2,
 		Current:   2,
 	})
+	c.Check(tr, DeepEquals, *tracking)
 }
 
 func (s *assertMgrSuite) TestEnforceValidationSetAssertionIgnoreValidation(c *C) {
@@ -3613,13 +3619,13 @@ func (s *assertMgrSuite) TestEnforceValidationSetAssertionIgnoreValidation(c *C)
 
 	sequence := 2
 	ignoreValidation := map[string]bool{}
-	err := assertstate.EnforceValidationSet(st, s.dev1Acct.AccountID(), "bar", sequence, 0, snaps, ignoreValidation)
+	_, err := assertstate.EnforceValidationSet(st, s.dev1Acct.AccountID(), "bar", sequence, 0, snaps, ignoreValidation)
 	wrongRevErr, ok := err.(*snapasserts.ValidationSetsValidationError)
 	c.Assert(ok, Equals, true)
 	c.Check(wrongRevErr.WrongRevisionSnaps["foo"], NotNil)
 
 	ignoreValidation["foo"] = true
-	err = assertstate.EnforceValidationSet(st, s.dev1Acct.AccountID(), "bar", sequence, 0, snaps, ignoreValidation)
+	tracking, err := assertstate.EnforceValidationSet(st, s.dev1Acct.AccountID(), "bar", sequence, 0, snaps, ignoreValidation)
 	c.Assert(err, IsNil)
 
 	// and it has been committed
@@ -3642,6 +3648,7 @@ func (s *assertMgrSuite) TestEnforceValidationSetAssertionIgnoreValidation(c *C)
 		PinnedAt:  2,
 		Current:   2,
 	})
+	c.Check(tr, DeepEquals, *tracking)
 }
 
 func (s *assertMgrSuite) TestMonitorValidationSet(c *C) {

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -3662,8 +3662,15 @@ func (s *assertMgrSuite) TestMonitorValidationSet(c *C) {
 	c.Assert(s.storeSigning.Add(vsetAs), IsNil)
 
 	sequence := 2
-	err := assertstate.MonitorValidationSet(st, s.dev1Acct.AccountID(), "bar", sequence, 0)
+	tr1, err := assertstate.MonitorValidationSet(st, s.dev1Acct.AccountID(), "bar", sequence, 0)
 	c.Assert(err, IsNil)
+	c.Check(tr1, DeepEquals, &assertstate.ValidationSetTracking{
+		AccountID: s.dev1Acct.AccountID(),
+		Name:      "bar",
+		Mode:      assertstate.Monitor,
+		PinnedAt:  2,
+		Current:   2,
+	})
 
 	// and it has been committed
 	_, err = assertstate.DB(s.state).Find(asserts.ValidationSetType, map[string]string{
@@ -3720,8 +3727,25 @@ func (s *assertMgrSuite) TestForgetValidationSet(c *C) {
 	vsetAs2 := s.validationSetAssert(c, "baz", "2", "2", "required", "1")
 	c.Assert(s.storeSigning.Add(vsetAs2), IsNil)
 
-	c.Assert(assertstate.MonitorValidationSet(st, s.dev1Acct.AccountID(), "bar", 2, 0), IsNil)
-	c.Assert(assertstate.MonitorValidationSet(st, s.dev1Acct.AccountID(), "baz", 2, 0), IsNil)
+	tr1, err := assertstate.MonitorValidationSet(st, s.dev1Acct.AccountID(), "bar", 2, 0)
+	c.Assert(err, IsNil)
+	c.Check(tr1, DeepEquals, &assertstate.ValidationSetTracking{
+		AccountID: s.dev1Acct.AccountID(),
+		Name:      "bar",
+		Mode:      assertstate.Monitor,
+		PinnedAt:  2,
+		Current:   2,
+	})
+
+	tr2, err := assertstate.MonitorValidationSet(st, s.dev1Acct.AccountID(), "baz", 2, 0)
+	c.Assert(err, IsNil)
+	c.Check(tr2, DeepEquals, &assertstate.ValidationSetTracking{
+		AccountID: s.dev1Acct.AccountID(),
+		Name:      "baz",
+		Mode:      assertstate.Monitor,
+		PinnedAt:  2,
+		Current:   2,
+	})
 
 	c.Assert(assertstate.ForgetValidationSet(st, s.dev1Acct.AccountID(), "bar"), IsNil)
 

--- a/tests/main/snap-validate-basic/task.yaml
+++ b/tests/main/snap-validate-basic/task.yaml
@@ -45,7 +45,7 @@ execute: |
   snap validate "$ACCOUNT_ID"/bar=1 2>&1 | MATCH "^invalid"
 
   echo "Checking that monitor mode is supported with a pinned sequence and local validation-set"
-  snap validate --monitor "$ACCOUNT_ID"/bar=1
+  snap validate --monitor "$ACCOUNT_ID"/bar=1 | MATCH "^invalid"
   snap validate | MATCH "$ACCOUNT_ID/bar=1 +monitor +1 +invalid"
 
   echo "Checking that validation-set is valid or invalid depending on presence of the snap"
@@ -72,7 +72,7 @@ execute: |
   snap validate 2>&1 | MATCH "No validations are available"
 
   echo "Checking that monitor mode is supported with a local validation-set (non-pinned)"
-  snap validate --monitor "$ACCOUNT_ID"/bar
+  snap validate --monitor "$ACCOUNT_ID"/bar | MATCH "^invalid"
   snap validate | MATCH "$ACCOUNT_ID/bar +monitor +1 +invalid"
   snap validate "$ACCOUNT_ID"/bar=1 | MATCH "^invalid"
   snap validate "$ACCOUNT_ID"/bar | MATCH "^invalid"
@@ -80,3 +80,7 @@ execute: |
   snap validate | MATCH "$ACCOUNT_ID/bar +monitor +1 +valid"
   snap validate "$ACCOUNT_ID"/bar=1 | MATCH "^valid"
   snap validate "$ACCOUNT_ID"/bar | MATCH "^valid"
+
+  echo "Check that --monitor mode report valid status when enabled"
+  snap validate --monitor "$ACCOUNT_ID"/bar | MATCH "^valid"
+  snap validate | MATCH "$ACCOUNT_ID/bar +monitor +1 +valid"


### PR DESCRIPTION
Report "valid" or "invalid" status for validation set right after enabling --monitor mode. REST API for the respective handler was changed to return the new v-s tracking state together with valid/invalid state (even though the returned info is not shown by the client I think it makes sense to return the complete struct for symmetry with other v-s handlers). 

Open question: should result be returned also for action=enforce for full symmetry, even if the client only prints errors atm?