### PR TITLE
i/b/accounts_service: fix path of introspectable objects

### DIFF
--- a/interfaces/builtin/accounts_service.go
+++ b/interfaces/builtin/accounts_service.go
@@ -65,7 +65,7 @@ dbus (receive, send)
 dbus (send)
     bus=session
     interface=org.freedesktop.DBus.Introspectable
-    path=/com/ubuntu/OnlineAccounts{,/**}
+    path=/org/gnome/OnlineAccounts{,/**}
     member=Introspect,
 `
 


### PR DESCRIPTION
Looking at the history of this interface, it doesn't seem that the idea
was that of supporting Ubuntu OnlineAccounts as well; it seems more
likely that the `/com/ubuntu/...` is a copy&paste error, since it's the
only line referring to UOA in the whole interface.

Since GLib D-Bus client library by default introspects the objects when
a proxy is created, let's correct these lines (instead of just removing
them).

The most conservative step would be that of adding this rule with the
`deny` prefix, since having the rule with the wrong path was essentially
leading to the same result (aside from the suppressed warning), but that
would not buy us anything in terms of security or privacy: the
`Introspect` method only describes the D-Bus API of the object, and even
if a client was trying to abuse it to find out which object paths exist
and which don't, we already have the rules for the `Properties`
interface that grant access to the same paths, so adding this rule does
not make things worse.
