### PR TITLE
tests/lib/nested: fix unbound variable

### DIFF
--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -808,7 +808,7 @@ EOF
             # shellcheck disable=SC2086
             "$UBUNTU_IMAGE" snap --image-size 10G "$NESTED_MODEL" \
                 $UBUNTU_IMAGE_CHANNEL_ARG \
-                "${UBUNTU_IMAGE_PRESEED_ARGS[@]}" \
+                "${UBUNTU_IMAGE_PRESEED_ARGS[@]:-}" \
                 --output-dir "$NESTED_IMAGES_DIR" \
                 $EXTRA_FUNDAMENTAL \
                 $EXTRA_SNAPS


### PR DESCRIPTION
From logs when preparing nested suite on 16.04:

```
+ '[' -n '' ']'
1855
/home/gopath/src/github.com/snapcore/snapd/tests/lib/nested.sh: line 809: UBUNTU_IMAGE_PRESEED_ARGS[@]: unbound variable
```
