### PR TITLE
spread: switch back to building ubuntu-image from source

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -44,7 +44,7 @@ environment:
     UBUNTU_IMAGE_SNAP_CHANNEL: "latest/candidate"
     # controls whether ubuntu-image is built using the current snapd tree as a
     # dependency or the one listed in its go.mod
-    UBUNTU_IMAGE_ALLOW_API_BREAK: '$(HOST: echo "${SPREAD_UBUNTU_IMAGE_ALLOW_API_BREAK:-false}")'
+    UBUNTU_IMAGE_ALLOW_API_BREAK: '$(HOST: echo "${SPREAD_UBUNTU_IMAGE_ALLOW_API_BREAK:-true}")'
     CORE_CHANNEL: '$(HOST: echo "${SPREAD_CORE_CHANNEL:-edge}")'
     BASE_CHANNEL: '$(HOST: echo "${SPREAD_BASE_CHANNEL:-edge}")'
     KERNEL_CHANNEL: '$(HOST: echo "${SPREAD_KERNEL_CHANNEL:-edge}")'

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -808,7 +808,7 @@ EOF
             # shellcheck disable=SC2086
             "$UBUNTU_IMAGE" snap --image-size 10G "$NESTED_MODEL" \
                 $UBUNTU_IMAGE_CHANNEL_ARG \
-                "${UBUNTU_IMAGE_PRESEED_ARGS[@]}" \
+                "${UBUNTU_IMAGE_PRESEED_ARGS[@]:-}" \
                 --output-dir "$NESTED_IMAGES_DIR" \
                 $EXTRA_FUNDAMENTAL \
                 $EXTRA_SNAPS


### PR DESCRIPTION
The relevant fixes for ubuntu-image are in their tree
https://github.com/canonical/ubuntu-image/commit/a5da68af0c46fad0575505ac44e4c2f14a707313
we can build it from master again.

Based on top of #11820 so that the nested tests on core 16 run.