### PR TITLE
interfaces/opengl: update allowed PCI accesses for RPi

### DIFF
--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -136,12 +136,14 @@ unix (bind,listen) type=seqpacket addr="@cuda-uvmfd-[0-9a-f]*",
 @{PROC}/driver/prl_vtg rw,
 
 # /sys/devices
-/sys/devices/{,*pcie-controller/,platform/soc/*.pcie/}pci[0-9a-f]*/**/config r,
-/sys/devices/{,*pcie-controller/,platform/soc/*.pcie/}pci[0-9a-f]*/**/revision r,
-/sys/devices/{,*pcie-controller/,platform/soc/*.pcie/}pci[0-9a-f]*/**/boot_vga r,
-/sys/devices/{,*pcie-controller/,platform/soc/*.pcie/}pci[0-9a-f]*/**/{,subsystem_}class r,
-/sys/devices/{,*pcie-controller/,platform/soc/*.pcie/}pci[0-9a-f]*/**/{,subsystem_}device r,
-/sys/devices/{,*pcie-controller/,platform/soc/*.pcie/}pci[0-9a-f]*/**/{,subsystem_}vendor r,
+/sys/devices/{,*pcie-controller/,platform/{soc,scb}/*.pcie/}pci[0-9a-f]*/**/config r,
+/sys/devices/{,*pcie-controller/,platform/{soc,scb}/*.pcie/}pci[0-9a-f]*/**/revision r,
+/sys/devices/{,*pcie-controller/,platform/{soc,scb}/*.pcie/}pci[0-9a-f]*/**/resource r,
+/sys/devices/{,*pcie-controller/,platform/{soc,scb}/*.pcie/}pci[0-9a-f]*/**/irq r,
+/sys/devices/{,*pcie-controller/,platform/{soc,scb}/*.pcie/}pci[0-9a-f]*/**/boot_vga r,
+/sys/devices/{,*pcie-controller/,platform/{soc,scb}/*.pcie/}pci[0-9a-f]*/**/{,subsystem_}class r,
+/sys/devices/{,*pcie-controller/,platform/{soc,scb}/*.pcie/}pci[0-9a-f]*/**/{,subsystem_}device r,
+/sys/devices/{,*pcie-controller/,platform/{soc,scb}/*.pcie/}pci[0-9a-f]*/**/{,subsystem_}vendor r,
 /sys/devices/**/drm{,_dp_aux_dev}/** r,
 
 # FIXME: this is an information leak and snapd should instead query udev for


### PR DESCRIPTION
When investigating why Firefox is particularly slow on Raspberry Pi the
denials reading PCI IO resources were logged. Further attempts with --devmode
showed this:

```
apparmor="ALLOWED" operation="open" profile="snap.firefox.firefox" name="/sys/devices/platform/scb/fd500000.pcie/pci0000:00/0000:00:00.0/resource" pid=8675 comm="firefox" requested_mask="r" denied_mask="r" fsuid=1000 ouid=0
apparmor="ALLOWED" operation="open" profile="snap.firefox.firefox" name="/sys/devices/platform/scb/fd500000.pcie/pci0000:00/0000:00:00.0/irq" pid=8675 comm="firefox" requested_mask="r" denied_mask="r" fsuid=1000 ouid=0
apparmor="ALLOWED" operation="open" profile="snap.firefox.firefox" name="/sys/devices/platform/scb/fd500000.pcie/pci0000:00/0000:00:00.0/vendor" pid=8675 comm="firefox" requested_mask="r" denied_mask="r" fsuid=1000 ouid=0
apparmor="ALLOWED" operation="open" profile="snap.firefox.firefox" name="/sys/devices/platform/scb/fd500000.pcie/pci0000:00/0000:00:00.0/device" pid=8675 comm="firefox" requested_mask="r" denied_mask="r" fsuid=1000 ouid=0
```

The patch updates the opengl interface to allow access to resource and irq
attributes, as well as uses alternative platform path.

