### PR TITLE
interfaces/browser-support: allow editing of Jupyter notebooks in browsers

### DIFF
--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -72,6 +72,9 @@ owner /{dev,run}/shm/.io.nwjs.* mrw,
 /run/user/[0-9]*/snap.@{SNAP_INSTANCE_NAME}/{,.}com.google.Chrome.*/SS r,
 /run/user/[0-9]*/snap.@{SNAP_INSTANCE_NAME}/{,.}com.microsoft.Edge.*/SS r,
 
+# Allow access to Jupyter notebooks (LP: #1959417)
+owner @{HOME}/.local/share/jupyter/** rw,
+
 # Allow reading platform files
 /run/udev/data/+platform:* r,
 

--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -72,7 +72,8 @@ owner /{dev,run}/shm/.io.nwjs.* mrw,
 /run/user/[0-9]*/snap.@{SNAP_INSTANCE_NAME}/{,.}com.google.Chrome.*/SS r,
 /run/user/[0-9]*/snap.@{SNAP_INSTANCE_NAME}/{,.}com.microsoft.Edge.*/SS r,
 
-# Allow access to Jupyter notebooks (LP: #1959417)
+# Allow access to Jupyter notebooks. 
+# This is temporary and will be reverted once LP: #1959417 is fixed upstream.
 owner @{HOME}/.local/share/jupyter/** rw,
 
 # Allow reading platform files


### PR DESCRIPTION
Read-write access is needed to edit Jupyter notebooks. 

https://bugs.launchpad.net/ubuntu/+source/jupyter-notebook/+bug/1959417