### PR TITLE
cmd/snap: add help strings for set-quota options

### DIFF
--- a/cmd/snap/cmd_quota.go
+++ b/cmd/snap/cmd_quota.go
@@ -101,7 +101,15 @@ An existing sub group cannot be moved from one parent to another.
 
 func init() {
 	// TODO: unhide the commands when non-experimental
-	cmd := addCommand("set-quota", shortSetQuotaHelp, longSetQuotaHelp, func() flags.Commander { return &cmdSetQuota{} }, nil, nil)
+	cmd := addCommand("set-quota", shortSetQuotaHelp, longSetQuotaHelp,
+		func() flags.Commander { return &cmdSetQuota{} },
+		waitDescs.also(map[string]string{
+			"memory":  i18n.G("Memory quota"),
+			"cpu":     i18n.G("CPU quota"),
+			"cpu-set": i18n.G("CPU set quota"),
+			"threads": i18n.G("Threads quota"),
+			"parent":  i18n.G("Parent quota group"),
+		}), nil)
 	cmd.hidden = true
 
 	cmd = addCommand("quota", shortQuotaHelp, longQuotaHelp, func() flags.Commander { return &cmdQuota{} }, nil, nil)


### PR DESCRIPTION
Add help strings for `snap set-quota` options. Note, the whole quotas feature is
still considered experimental, hence the commands are hidden and go-flags only
prints out the top level description of the command, without the options in --help.

Related to: https://bugs.launchpad.net/snapd/+bug/1945362

Note this doesn't address the bug fully, we'd either have to make quota-groups an exported feature, or do not hide the commands (and thus consider quota-groups no longer experimental?).