### PR TITLE
o/snapstate: fix validation sets restoring and snap revert on failed refresh

### DIFF
--- a/daemon/api_snaps.go
+++ b/daemon/api_snaps.go
@@ -387,9 +387,9 @@ func snapRevert(inst *snapInstruction, st *state.State) (string, []*state.TaskSe
 	}
 
 	if inst.Revision.Unset() {
-		ts, err = snapstateRevert(st, inst.Snaps[0], flags)
+		ts, err = snapstateRevert(st, inst.Snaps[0], flags, "")
 	} else {
-		ts, err = snapstateRevertToRevision(st, inst.Snaps[0], inst.Revision, flags)
+		ts, err = snapstateRevertToRevision(st, inst.Snaps[0], inst.Revision, flags, "")
 	}
 	if err != nil {
 		return "", nil, err

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -2073,12 +2073,12 @@ func (s *snapsSuite) testRevertSnap(inst *daemon.SnapInstruction, c *check.C) {
 	instFlags, err := inst.ModeFlags()
 	c.Assert(err, check.IsNil)
 
-	defer daemon.MockSnapstateRevert(func(s *state.State, name string, flags snapstate.Flags) (*state.TaskSet, error) {
+	defer daemon.MockSnapstateRevert(func(s *state.State, name string, flags snapstate.Flags, fromChange string) (*state.TaskSet, error) {
 		c.Check(flags, check.Equals, instFlags)
 		queue = append(queue, name)
 		return nil, nil
 	})()
-	defer daemon.MockSnapstateRevertToRevision(func(s *state.State, name string, rev snap.Revision, flags snapstate.Flags) (*state.TaskSet, error) {
+	defer daemon.MockSnapstateRevertToRevision(func(s *state.State, name string, rev snap.Revision, flags snapstate.Flags, fromChange string) (*state.TaskSet, error) {
 		c.Check(flags, check.Equals, instFlags)
 		queue = append(queue, fmt.Sprintf("%s (%s)", name, rev))
 		return nil, nil

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -156,7 +156,7 @@ func MockSnapstateSwitch(mock func(*state.State, string, *snapstate.RevisionOpti
 	}
 }
 
-func MockSnapstateRevert(mock func(*state.State, string, snapstate.Flags) (*state.TaskSet, error)) (restore func()) {
+func MockSnapstateRevert(mock func(*state.State, string, snapstate.Flags, string) (*state.TaskSet, error)) (restore func()) {
 	oldSnapstateRevert := snapstateRevert
 	snapstateRevert = mock
 	return func() {
@@ -164,7 +164,7 @@ func MockSnapstateRevert(mock func(*state.State, string, snapstate.Flags) (*stat
 	}
 }
 
-func MockSnapstateRevertToRevision(mock func(*state.State, string, snap.Revision, snapstate.Flags) (*state.TaskSet, error)) (restore func()) {
+func MockSnapstateRevertToRevision(mock func(*state.State, string, snap.Revision, snapstate.Flags, string) (*state.TaskSet, error)) (restore func()) {
 	oldSnapstateRevertToRevision := snapstateRevertToRevision
 	snapstateRevertToRevision = mock
 	return func() {

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -3086,7 +3086,7 @@ apps:
 	c.Assert(err, ErrorMatches, ".*no such file.*")
 
 	// now do the revert
-	ts, err := snapstate.Revert(st, "foo", snapstate.Flags{})
+	ts, err := snapstate.Revert(st, "foo", snapstate.Flags{}, "")
 	c.Assert(err, IsNil)
 	chg := st.NewChange("revert-snap", "...")
 	chg.AddAll(ts)

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -411,6 +411,12 @@ func (f *fakeStore) lookupRefresh(cand refreshCand) (*snap.Info, error) {
 		name = "outdated-consumer"
 	case "outdated-producer-id":
 		name = "outdated-producer"
+	// for validation-sets testing
+	case "aaqKhntON3vR7kwEbVPsILm7bUViPDzx":
+		name = "some-snap"
+	// for validation-sets testing
+	case "bgtKhntON3vR7kwEbVPsILm7bUViPDzx":
+		name = "some-other-snap"
 	default:
 		panic(fmt.Sprintf("refresh: unknown snap-id: %s", cand.snapID))
 	}

--- a/overlord/snapstate/booted.go
+++ b/overlord/snapstate/booted.go
@@ -78,7 +78,7 @@ func UpdateBootRevisions(st *state.State) error {
 		if actual.SnapRevision() != info.SideInfo.Revision {
 			// FIXME: check that there is no task
 			//        for this already in progress
-			ts, err := RevertToRevision(st, actual.SnapName(), actual.SnapRevision(), Flags{})
+			ts, err := RevertToRevision(st, actual.SnapName(), actual.SnapRevision(), Flags{}, "")
 			if err != nil {
 				return err
 			}

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -414,7 +414,7 @@ func MockRestoreValidationSetsTracking(f func(*state.State) error) (restore func
 	}
 }
 
-func MockMaybeRestoreValidationSetsAndRevertSnaps(f func(st *state.State, refreshedSnaps []string) ([]*state.TaskSet, error)) (restore func()) {
+func MockMaybeRestoreValidationSetsAndRevertSnaps(f func(st *state.State, refreshedSnaps []string, fromChange string) ([]*state.TaskSet, error)) (restore func()) {
 	old := maybeRestoreValidationSetsAndRevertSnaps
 	maybeRestoreValidationSetsAndRevertSnaps = f
 	return func() {

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -3554,9 +3554,11 @@ func (m *SnapManager) doCheckReRefresh(t *state.Task, tomb *tomb.Tomb) error {
 		}
 	}
 
+	chg := t.Change()
+
 	// if any snap failed to refresh, reconsider validation set tracking
 	if failed {
-		tasksets, err := maybeRestoreValidationSetsAndRevertSnaps(st, snaps)
+		tasksets, err := maybeRestoreValidationSetsAndRevertSnaps(st, snaps, chg.ID())
 		if err != nil {
 			return err
 		}
@@ -3596,7 +3598,7 @@ func (m *SnapManager) doCheckReRefresh(t *state.Task, tomb *tomb.Tomb) error {
 	if err := t.Get("rerefresh-setup", &re); err != nil {
 		return err
 	}
-	chg := t.Change()
+
 	updated, tasksets, err := reRefreshUpdateMany(tomb.Context(nil), st, snaps, re.UserID, reRefreshFilter, re.Flags, chg.ID())
 	if err != nil {
 		return err
@@ -3663,11 +3665,12 @@ func (m *SnapManager) doConditionalAutoRefresh(t *state.Task, tomb *tomb.Tomb) e
 // validation sets and - if necessary - creates tasksets to revert some or all
 // of the refreshed snaps to their previous revisions to satisfy the restored
 // validation sets tracking.
-var maybeRestoreValidationSetsAndRevertSnaps = func(st *state.State, refreshedSnaps []string) ([]*state.TaskSet, error) {
+var maybeRestoreValidationSetsAndRevertSnaps = func(st *state.State, refreshedSnaps []string, fromChange string) ([]*state.TaskSet, error) {
 	enforcedSets, err := EnforcedValidationSets(st, nil)
 	if err != nil {
 		return nil, err
 	}
+
 	if enforcedSets == nil {
 		// no enforced validation sets, nothing to do
 		return nil, nil
@@ -3675,10 +3678,12 @@ var maybeRestoreValidationSetsAndRevertSnaps = func(st *state.State, refreshedSn
 
 	installedSnaps, ignoreValidation, err := InstalledSnaps(st)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("internal error: cannot get installed snaps: %v", err)
 	}
+
 	if err := enforcedSets.CheckInstalledSnaps(installedSnaps, ignoreValidation); err == nil {
 		// validation sets are still correct, nothing to do
+		logger.Debugf("validation sets are still correct after partial refresh")
 		return nil, nil
 	}
 
@@ -3690,47 +3695,59 @@ var maybeRestoreValidationSetsAndRevertSnaps = func(st *state.State, refreshedSn
 	// no snaps were refreshed, after restoring validation sets tracking
 	// there is nothing else to do
 	if len(refreshedSnaps) == 0 {
+		logger.Debugf("validation set tracking restored, no snaps were refreshed")
 		return nil, nil
+	}
+
+	// we need to fetch enforced sets again because of RestoreValidationSetsTracking.
+	enforcedSets, err = EnforcedValidationSets(st, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if enforcedSets == nil {
+		return nil, fmt.Errorf("internal error: no enforced validation sets after restoring from the stack")
 	}
 
 	// check installed snaps again against restored validation-sets.
 	// this may fail which is fine, but it tells us which snaps are
 	// at invalid revisions and need reverting.
-	// note: we need to fetch enforced sets again because of RestoreValidationSetsTracking.
-	enforcedSets, err = EnforcedValidationSets(st, nil)
-	if err != nil {
-		return nil, err
-	}
-	if enforcedSets == nil {
-		return nil, fmt.Errorf("internal error: no enforced validation sets after restoring from the stack")
-	}
 	err = enforcedSets.CheckInstalledSnaps(installedSnaps, ignoreValidation)
 	if err == nil {
 		// all fine after restoring validation sets: this can happen if previous
 		// validation sets only required a snap (regardless of its revision), then
 		// after update they require a specific snap revision, so after restoring
 		// we are back with the good state.
+		logger.Debugf("validation sets still valid after partial refresh, no snaps need reverting")
 		return nil, nil
 	}
 	verr, ok := err.(*snapasserts.ValidationSetsValidationError)
 	if !ok {
-		return nil, err
+		return nil, fmt.Errorf("internal error: %v", err)
 	}
+
 	if len(verr.WrongRevisionSnaps) == 0 {
 		// if we hit ValidationSetsValidationError but it's not about wrong revisions,
 		// then something is really broken (we shouldn't have invalid or missing required
 		// snaps at this point).
 		return nil, fmt.Errorf("internal error: unexpected validation error of installed snaps after unsuccesfull refresh: %v", verr)
 	}
+
+	wrongRevSnaps := make([]string, 0, len(verr.WrongRevisionSnaps))
+	for sn := range verr.WrongRevisionSnaps {
+		wrongRevSnaps = append(wrongRevSnaps, sn)
+	}
+	logger.Debugf("refreshed snaps: %s, snaps at wrong revisions: %s", strutil.Quoted(refreshedSnaps), wrongRevSnaps)
+
 	// revert some or all snaps
 	var tss []*state.TaskSet
 	for _, snapName := range refreshedSnaps {
 		if verr.WrongRevisionSnaps[snapName] != nil {
 			// XXX: should we be extra paranoid and use RevertToRevision with
 			// the specific revision from verr.WrongRevisionSnaps?
-			ts, err := Revert(st, snapName, Flags{RevertStatus: NotBlocked})
+			ts, err := Revert(st, snapName, Flags{RevertStatus: NotBlocked}, fromChange)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("cannot revert snap %q: %v", snapName, err)
 			}
 			tss = append(tss, ts)
 		}

--- a/overlord/snapstate/handlers_rerefresh_test.go
+++ b/overlord/snapstate/handlers_rerefresh_test.go
@@ -373,6 +373,8 @@ func (s *reRefreshSuite) TestFilterReturnsFalseIfEpochEqualZero(c *C) {
 	c.Check(snapstate.ReRefreshFilter(&snap.Info{Epoch: snap.Epoch{}}, snapst), Equals, false)
 }
 
+// validation-sets related tests
+
 func (s *refreshSuite) TestMaybeRestoreValidationSetsAndRevertSnaps(c *C) {
 	restore := snapstate.MockEnforcedValidationSets(func(st *state.State, extraVs *asserts.ValidationSet) (*snapasserts.ValidationSets, error) {
 		return nil, nil
@@ -385,7 +387,7 @@ func (s *refreshSuite) TestMaybeRestoreValidationSetsAndRevertSnaps(c *C) {
 
 	refreshedSnaps := []string{"foo", "bar"}
 	// nothing to do with no enforced validation sets
-	ts, err := snapstate.MaybeRestoreValidationSetsAndRevertSnaps(st, refreshedSnaps)
+	ts, err := snapstate.MaybeRestoreValidationSetsAndRevertSnaps(st, refreshedSnaps, "")
 	c.Assert(err, IsNil)
 	c.Check(ts, IsNil)
 }
@@ -484,9 +486,18 @@ func (s *validationSetsSuite) TestMaybeRestoreValidationSetsAndRevertSnapsOneRev
 	})
 	snaptest.MockSnap(c, `name: some-snap3`, si3)
 
+	chg := s.state.NewChange("install change", "...")
+	t1 := s.state.NewTask("link-snap", "...")
+	t1.Set("snap-setup", &snapstate.SnapSetup{SideInfo: &snap.SideInfo{RealName: "some-snap1", SnapID: "aaqKhntON3vR7kwEbVPsILm7bUViPDzx", Revision: snap.R(1)}})
+	t1.SetStatus(state.DoneStatus)
+	t2 := s.state.NewTask("check-rerefresh", "...")
+	chg.AddTask(t1)
+	chg.AddTask(t2)
+
 	// some-snap2 failed to refresh
 	refreshedSnaps := []string{"some-snap1", "some-snap3"}
-	ts, err := snapstate.MaybeRestoreValidationSetsAndRevertSnaps(st, refreshedSnaps)
+	// pass change id to make sure revert doesn't conflict
+	ts, err := snapstate.MaybeRestoreValidationSetsAndRevertSnaps(st, refreshedSnaps, chg.ID())
 	c.Assert(err, IsNil)
 
 	// we expect revert of snap1
@@ -516,6 +527,57 @@ func (s *validationSetsSuite) TestMaybeRestoreValidationSetsAndRevertSnapsOneRev
 
 	c.Check(restoreValidationSetsTrackingCalled, Equals, 1)
 	c.Check(enforcedValidationSetsCalled, Equals, 2)
+}
+
+func (s *validationSetsSuite) TestMaybeRestoreValidationSetsAndRevertNoSnapsRefreshed(c *C) {
+	var enforcedValidationSetsCalled int
+	restore := snapstate.MockEnforcedValidationSets(func(st *state.State, extraVs *asserts.ValidationSet) (*snapasserts.ValidationSets, error) {
+		enforcedValidationSetsCalled++
+
+		vs := snapasserts.NewValidationSets()
+		snap1 := map[string]interface{}{
+			"id":       "aaqKhntON3vR7kwEbVPsILm7bUViPDzx",
+			"name":     "some-snap1",
+			"presence": "required",
+			"revision": "3",
+		}
+
+		c.Assert(enforcedValidationSetsCalled, Equals, 1, Commentf("unexpected call to EnforcedValidatioSets"))
+		vsa1 := s.mockValidationSetAssert(c, "bar", "2", snap1)
+		vs.Add(vsa1.(*asserts.ValidationSet))
+		return vs, nil
+	})
+	defer restore()
+
+	var restoreValidationSetsTrackingCalled int
+	restoreRestoreValidationSetsTracking := snapstate.MockRestoreValidationSetsTracking(func(*state.State) error {
+		restoreValidationSetsTrackingCalled++
+		return nil
+	})
+	defer restoreRestoreValidationSetsTracking()
+
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	// snaps in the system
+	si1 := &snap.SideInfo{RealName: "some-snap1", SnapID: "aaqKhntON3vR7kwEbVPsILm7bUViPDzx", Revision: snap.R(1)}
+	snapstate.Set(s.state, "some-snap1", &snapstate.SnapState{
+		Active:   true,
+		Sequence: []*snap.SideInfo{si1},
+		Current:  snap.R(1),
+		SnapType: "app",
+	})
+	snaptest.MockSnap(c, `name: some-snap1`, si1)
+
+	// no snaps get refreshed
+	ts, err := snapstate.MaybeRestoreValidationSetsAndRevertSnaps(st, nil, "")
+	c.Assert(err, IsNil)
+
+	// we expect no snap reverts
+	c.Assert(ts, HasLen, 0)
+	c.Check(restoreValidationSetsTrackingCalled, Equals, 1)
+	c.Check(enforcedValidationSetsCalled, Equals, 1)
 }
 
 func (s *validationSetsSuite) TestMaybeRestoreValidationSetsAndRevertJustValidationSetsRestore(c *C) {
@@ -589,11 +651,80 @@ func (s *validationSetsSuite) TestMaybeRestoreValidationSetsAndRevertJustValidat
 	snaptest.MockSnap(c, `name: some-snap2`, si3)
 
 	refreshedSnaps := []string{"some-snap2"}
-	ts, err := snapstate.MaybeRestoreValidationSetsAndRevertSnaps(st, refreshedSnaps)
+	ts, err := snapstate.MaybeRestoreValidationSetsAndRevertSnaps(st, refreshedSnaps, "")
 	c.Assert(err, IsNil)
 
 	// we expect no snap reverts
 	c.Assert(ts, HasLen, 0)
 	c.Check(restoreValidationSetsTrackingCalled, Equals, 1)
 	c.Check(enforcedValidationSetsCalled, Equals, 2)
+}
+
+func (s *validationSetsSuite) TestMaybeRestoreValidationSetsAndRevertStillValid(c *C) {
+	var enforcedValidationSetsCalled int
+	restore := snapstate.MockEnforcedValidationSets(func(st *state.State, extraVs *asserts.ValidationSet) (*snapasserts.ValidationSets, error) {
+		enforcedValidationSetsCalled++
+
+		vs := snapasserts.NewValidationSets()
+		snap2 := map[string]interface{}{
+			"id":       "abcKhntON3vR7kwEbVPsILm7bUViPDzx",
+			"name":     "some-snap2",
+			"presence": "required",
+		}
+
+		c.Assert(enforcedValidationSetsCalled, Equals, 1, Commentf("unexpected call to EnforcedValidatioSets"))
+
+		// refreshed validation sets
+		// snap1 revision 3 is now required (but snap wasn't refreshed)
+		snap1 := map[string]interface{}{
+			"id":       "aaqKhntON3vR7kwEbVPsILm7bUViPDzx",
+			"name":     "some-snap1",
+			"presence": "required",
+		}
+		vsa1 := s.mockValidationSetAssert(c, "bar", "3", snap1, snap2)
+		vs.Add(vsa1.(*asserts.ValidationSet))
+		return vs, nil
+	})
+	defer restore()
+
+	var restoreValidationSetsTrackingCalled int
+	restoreRestoreValidationSetsTracking := snapstate.MockRestoreValidationSetsTracking(func(*state.State) error {
+		restoreValidationSetsTrackingCalled++
+		return nil
+	})
+	defer restoreRestoreValidationSetsTracking()
+
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	// snaps in the system after partial refresh
+	si1 := &snap.SideInfo{RealName: "some-snap1", SnapID: "aaqKhntON3vR7kwEbVPsILm7bUViPDzx", Revision: snap.R(3)}
+	snapstate.Set(s.state, "some-snap1", &snapstate.SnapState{
+		Active:   true,
+		Sequence: []*snap.SideInfo{si1},
+		Current:  snap.R(3),
+		SnapType: "app",
+	})
+	snaptest.MockSnap(c, `name: some-snap1`, si1)
+
+	si3 := &snap.SideInfo{RealName: "some-snap2", SnapID: "abcKhntON3vR7kwEbVPsILm7bUViPDzx", Revision: snap.R(1)}
+	snapstate.Set(s.state, "some-snap2", &snapstate.SnapState{
+		Active:   true,
+		Sequence: []*snap.SideInfo{si3},
+		Current:  snap.R(1),
+		SnapType: "app",
+	})
+	snaptest.MockSnap(c, `name: some-snap2`, si3)
+
+	// pretend that some-snap1 was refreshed (and some-snap2 failed), some-snap1 is now at revision 3; validation set
+	// with sequence 3 is still valid though so no snap reverts.
+	refreshedSnaps := []string{"some-snap1"}
+	ts, err := snapstate.MaybeRestoreValidationSetsAndRevertSnaps(st, refreshedSnaps, "")
+	c.Assert(err, IsNil)
+
+	// we expect no snap reverts
+	c.Assert(ts, HasLen, 0)
+	c.Check(restoreValidationSetsTrackingCalled, Equals, 0)
+	c.Check(enforcedValidationSetsCalled, Equals, 1)
 }

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -3082,7 +3082,7 @@ func validateSnapNames(names []string) error {
 
 // Revert returns a set of tasks for reverting to the previous version of the snap.
 // Note that the state must be locked by the caller.
-func Revert(st *state.State, name string, flags Flags) (*state.TaskSet, error) {
+func Revert(st *state.State, name string, flags Flags, fromChange string) (*state.TaskSet, error) {
 	var snapst SnapState
 	err := Get(st, name, &snapst)
 	if err != nil && !errors.Is(err, state.ErrNoState) {
@@ -3094,10 +3094,10 @@ func Revert(st *state.State, name string, flags Flags) (*state.TaskSet, error) {
 		return nil, fmt.Errorf("no revision to revert to")
 	}
 
-	return RevertToRevision(st, name, pi.Revision, flags)
+	return RevertToRevision(st, name, pi.Revision, flags, fromChange)
 }
 
-func RevertToRevision(st *state.State, name string, rev snap.Revision, flags Flags) (*state.TaskSet, error) {
+func RevertToRevision(st *state.State, name string, rev snap.Revision, flags Flags, fromChange string) (*state.TaskSet, error) {
 	var snapst SnapState
 	err := Get(st, name, &snapst)
 	if err != nil && !errors.Is(err, state.ErrNoState) {
@@ -3144,7 +3144,7 @@ func RevertToRevision(st *state.State, name string, rev snap.Revision, flags Fla
 		PlugsOnly:   len(info.Slots) == 0,
 		InstanceKey: snapst.InstanceKey,
 	}
-	return doInstall(st, &snapst, snapsup, 0, "", nil)
+	return doInstall(st, &snapst, snapsup, 0, fromChange, nil)
 }
 
 // TransitionCore transitions from an old core snap name to a new core

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -558,7 +558,7 @@ func (s *snapmgrTestSuite) testRevertTasksFullFlags(flags fullFlags, c *C) {
 		SnapType: "app",
 	})
 
-	ts, err := snapstate.Revert(s.state, "some-snap", flags.change)
+	ts, err := snapstate.Revert(s.state, "some-snap", flags.change, "")
 	c.Assert(err, IsNil)
 
 	tasks := ts.Tasks()
@@ -671,7 +671,7 @@ func (s *snapmgrTestSuite) TestRevertCreatesNoGCTasks(c *C) {
 		Current: snap.R(2),
 	})
 
-	ts, err := snapstate.RevertToRevision(s.state, "some-snap", snap.R(4), snapstate.Flags{})
+	ts, err := snapstate.RevertToRevision(s.state, "some-snap", snap.R(4), snapstate.Flags{}, "")
 	c.Assert(err, IsNil)
 
 	// ensure that we do not run any form of garbage-collection
@@ -1340,7 +1340,7 @@ func (s *snapmgrTestSuite) TestRevertRestoresConfigSnapshot(c *C) {
 	tr.Commit()
 
 	chg := s.state.NewChange("revert", "revert snap")
-	ts, err := snapstate.Revert(s.state, "some-snap", snapstate.Flags{})
+	ts, err := snapstate.Revert(s.state, "some-snap", snapstate.Flags{}, "")
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
@@ -1382,7 +1382,7 @@ func (s *snapmgrTestSuite) TestRevertNoRevertAgain(c *C) {
 		Current:  snap.R(7),
 	})
 
-	ts, err := snapstate.Revert(s.state, "some-snap", snapstate.Flags{})
+	ts, err := snapstate.Revert(s.state, "some-snap", snapstate.Flags{}, "")
 	c.Assert(err, ErrorMatches, "no revision to revert to")
 	c.Assert(ts, IsNil)
 }
@@ -1402,7 +1402,7 @@ func (s *snapmgrTestSuite) TestRevertNothingToRevertTo(c *C) {
 		Current:  si.Revision,
 	})
 
-	ts, err := snapstate.Revert(s.state, "some-snap", snapstate.Flags{})
+	ts, err := snapstate.Revert(s.state, "some-snap", snapstate.Flags{}, "")
 	c.Assert(err, ErrorMatches, "no revision to revert to")
 	c.Assert(ts, IsNil)
 }
@@ -1426,7 +1426,7 @@ func (s *snapmgrTestSuite) TestRevertToRevisionNoValidVersion(c *C) {
 		Current:  snap.R(77),
 	})
 
-	ts, err := snapstate.RevertToRevision(s.state, "some-snap", snap.R("99"), snapstate.Flags{})
+	ts, err := snapstate.RevertToRevision(s.state, "some-snap", snap.R("99"), snapstate.Flags{}, "")
 	c.Assert(err, ErrorMatches, `cannot find revision 99 for snap "some-snap"`)
 	c.Assert(ts, IsNil)
 }
@@ -1450,7 +1450,7 @@ func (s *snapmgrTestSuite) TestRevertToRevisionAlreadyCurrent(c *C) {
 		Current:  snap.R(77),
 	})
 
-	ts, err := snapstate.RevertToRevision(s.state, "some-snap", snap.R("77"), snapstate.Flags{})
+	ts, err := snapstate.RevertToRevision(s.state, "some-snap", snap.R("77"), snapstate.Flags{}, "")
 	c.Assert(err, ErrorMatches, `already on requested revision`)
 	c.Assert(ts, IsNil)
 }
@@ -1476,7 +1476,7 @@ func (s *snapmgrTestSuite) TestRevertRunThrough(c *C) {
 	})
 
 	chg := s.state.NewChange("revert", "revert a snap backwards")
-	ts, err := snapstate.Revert(s.state, "some-snap", snapstate.Flags{})
+	ts, err := snapstate.Revert(s.state, "some-snap", snapstate.Flags{}, "")
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
@@ -1571,7 +1571,7 @@ func (s *snapmgrTestSuite) TestRevertRevisionNotBlocked(c *C) {
 	})
 
 	chg := s.state.NewChange("revert", "revert a snap backwards")
-	ts, err := snapstate.Revert(s.state, "some-snap", snapstate.Flags{RevertStatus: snapstate.NotBlocked})
+	ts, err := snapstate.Revert(s.state, "some-snap", snapstate.Flags{RevertStatus: snapstate.NotBlocked}, "")
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
@@ -1630,7 +1630,7 @@ func (s *snapmgrTestSuite) TestRevertRevisionNotBlockedUndo(c *C) {
 	})
 
 	chg := s.state.NewChange("revert", "install a revert")
-	ts, err := snapstate.Revert(s.state, "some-snap", snapstate.Flags{RevertStatus: snapstate.NotBlocked})
+	ts, err := snapstate.Revert(s.state, "some-snap", snapstate.Flags{RevertStatus: snapstate.NotBlocked}, "")
 	c.Assert(err, IsNil)
 	tasks := ts.Tasks()
 	last := tasks[len(tasks)-1]
@@ -1696,7 +1696,7 @@ func (s *snapmgrTestSuite) TestRevertWithBaseRunThrough(c *C) {
 	})
 
 	chg := s.state.NewChange("revert", "revert a snap backwards")
-	ts, err := snapstate.Revert(s.state, "some-snap-with-base", snapstate.Flags{})
+	ts, err := snapstate.Revert(s.state, "some-snap-with-base", snapstate.Flags{}, "")
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
@@ -1785,7 +1785,7 @@ func (s *snapmgrTestSuite) TestParallelInstanceRevertRunThrough(c *C) {
 	})
 
 	chg := s.state.NewChange("revert", "revert a snap backwards")
-	ts, err := snapstate.Revert(s.state, "some-snap_instance", snapstate.Flags{})
+	ts, err := snapstate.Revert(s.state, "some-snap_instance", snapstate.Flags{}, "")
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
@@ -1885,7 +1885,7 @@ func (s *snapmgrTestSuite) TestRevertWithLocalRevisionRunThrough(c *C) {
 	})
 
 	chg := s.state.NewChange("revert", "revert a snap backwards")
-	ts, err := snapstate.Revert(s.state, "some-snap", snapstate.Flags{})
+	ts, err := snapstate.Revert(s.state, "some-snap", snapstate.Flags{}, "")
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
@@ -1927,7 +1927,7 @@ func (s *snapmgrTestSuite) TestRevertToRevisionNewVersion(c *C) {
 	})
 
 	chg := s.state.NewChange("revert", "revert a snap forward")
-	ts, err := snapstate.RevertToRevision(s.state, "some-snap", snap.R(7), snapstate.Flags{})
+	ts, err := snapstate.RevertToRevision(s.state, "some-snap", snap.R(7), snapstate.Flags{}, "")
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
@@ -2009,7 +2009,7 @@ func (s *snapmgrTestSuite) TestRevertTotalUndoRunThrough(c *C) {
 	})
 
 	chg := s.state.NewChange("revert", "revert a snap")
-	ts, err := snapstate.Revert(s.state, "some-snap", snapstate.Flags{})
+	ts, err := snapstate.Revert(s.state, "some-snap", snapstate.Flags{}, "")
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
@@ -2123,7 +2123,7 @@ func (s *snapmgrTestSuite) TestRevertUndoRunThrough(c *C) {
 	})
 
 	chg := s.state.NewChange("revert", "install a revert")
-	ts, err := snapstate.Revert(s.state, "some-snap", snapstate.Flags{})
+	ts, err := snapstate.Revert(s.state, "some-snap", snapstate.Flags{}, "")
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
@@ -2220,7 +2220,7 @@ func (s *snapmgrTestSuite) TestRevertUndoMigrationAfterUnsetFlag(c *C) {
 	c.Assert(snapstate.WriteSeqFile("some-snap", snapst), IsNil)
 
 	chg := s.state.NewChange("revert", "install a revert")
-	ts, err := snapstate.Revert(s.state, "some-snap", snapstate.Flags{})
+	ts, err := snapstate.Revert(s.state, "some-snap", snapstate.Flags{}, "")
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
@@ -2259,7 +2259,7 @@ func (s *snapmgrTestSuite) TestRevertKeepMigrationWithSetFlag(c *C) {
 	tr.Commit()
 
 	chg := s.state.NewChange("revert", "install a revert")
-	ts, err := snapstate.Revert(s.state, "some-snap", snapstate.Flags{})
+	ts, err := snapstate.Revert(s.state, "some-snap", snapstate.Flags{}, "")
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
@@ -2297,7 +2297,7 @@ func (s *snapmgrTestSuite) TestRevertDoHiddenMigration(c *C) {
 	tr.Commit()
 
 	chg := s.state.NewChange("revert", "install a revert")
-	ts, err := snapstate.RevertToRevision(s.state, "some-snap", si2.Revision, snapstate.Flags{})
+	ts, err := snapstate.RevertToRevision(s.state, "some-snap", si2.Revision, snapstate.Flags{}, "")
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
@@ -2340,7 +2340,7 @@ func (s *snapmgrTestSuite) TestUndoRevertDoHiddenMigration(c *C) {
 	tr.Commit()
 
 	chg := s.state.NewChange("revert", "install a revert")
-	ts, err := snapstate.RevertToRevision(s.state, "some-snap", si2.Revision, snapstate.Flags{})
+	ts, err := snapstate.RevertToRevision(s.state, "some-snap", si2.Revision, snapstate.Flags{}, "")
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
@@ -2414,7 +2414,7 @@ func (s *snapmgrTestSuite) TestRevertFromCore22WithSetFlagKeepMigration(c *C) {
 	})
 
 	chg := s.state.NewChange("revert", "install a revert")
-	ts, err := snapstate.Revert(s.state, "some-snap", snapstate.Flags{})
+	ts, err := snapstate.Revert(s.state, "some-snap", snapstate.Flags{}, "")
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
@@ -2468,7 +2468,7 @@ func (s *snapmgrTestSuite) TestRevertToCore22WithoutFlagSet(c *C) {
 	})
 
 	chg := s.state.NewChange("revert", "install a revert")
-	ts, err := snapstate.Revert(s.state, "some-snap", snapstate.Flags{})
+	ts, err := snapstate.Revert(s.state, "some-snap", snapstate.Flags{}, "")
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
@@ -2544,7 +2544,7 @@ func (s *snapmgrTestSuite) testRevertToCore22AfterRevertedMigration(c *C, migrat
 	})
 
 	chg := s.state.NewChange("revert", "install a revert")
-	ts, err := snapstate.RevertToRevision(s.state, "some-snap", si2.Revision, snapstate.Flags{})
+	ts, err := snapstate.RevertToRevision(s.state, "some-snap", si2.Revision, snapstate.Flags{}, "")
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
@@ -2625,7 +2625,7 @@ func (s *snapmgrTestSuite) testUndoRevertToCore22AfterRevertedMigration(c *C, mi
 	chg := s.state.NewChange("revert", "install a revert")
 	s.fakeBackend.linkSnapFailTrigger = filepath.Join(dirs.SnapMountDir, "/some-snap/2")
 
-	ts, err := snapstate.RevertToRevision(s.state, "some-snap", si2.Revision, snapstate.Flags{})
+	ts, err := snapstate.RevertToRevision(s.state, "some-snap", si2.Revision, snapstate.Flags{}, "")
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
@@ -2684,7 +2684,7 @@ func (s *snapmgrTestSuite) testRevertUndoHiddenMigrationFails(c *C, prepFail pre
 	c.Assert(snapstate.WriteSeqFile("some-snap", snapst), IsNil)
 
 	chg := s.state.NewChange("revert", "install a revert")
-	ts, err := snapstate.Revert(s.state, "some-snap", snapstate.Flags{})
+	ts, err := snapstate.Revert(s.state, "some-snap", snapstate.Flags{}, "")
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
@@ -2728,7 +2728,7 @@ func (s *snapmgrTestSuite) TestRevertUndoExposedMigrationFailsAfterWritingState(
 	tr.Commit()
 
 	chg := s.state.NewChange("revert", "install a revert")
-	ts, err := snapstate.Revert(s.state, "snap-core18-to-core22", snapstate.Flags{})
+	ts, err := snapstate.Revert(s.state, "snap-core18-to-core22", snapstate.Flags{}, "")
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
@@ -2788,7 +2788,7 @@ func (s *snapmgrTestSuite) testRevertUndoFullMigrationFails(c *C, prepFail prepF
 	c.Assert(snapstate.WriteSeqFile("snap-core18-to-core22", snapst), IsNil)
 
 	chg := s.state.NewChange("revert", "install a revert")
-	ts, err := snapstate.Revert(s.state, "snap-core18-to-core22", snapstate.Flags{})
+	ts, err := snapstate.Revert(s.state, "snap-core18-to-core22", snapstate.Flags{}, "")
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -7108,7 +7108,7 @@ func (s *validationSetsSuite) testUpdateManyValidationSetsPartialFailure(c *C) *
 			"name":     "some-other-snap",
 			"presence": "required",
 		}
-		sequence := "2"
+		var sequence string
 		if enforcedValidationSetsCalls == 0 {
 			snap1["revision"] = "11"
 			snap2["revision"] = "11"

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -447,7 +447,7 @@ func (s *snapmgrTestSuite) testOpSequence(c *C, opts *opSeqOpts) (*snapstate.Sna
 	var err error
 	if opts.revert {
 		chg = s.state.NewChange("revert", "revert a snap")
-		ts, err = snapstate.RevertToRevision(s.state, "some-snap", snap.R(opts.via), snapstate.Flags{})
+		ts, err = snapstate.RevertToRevision(s.state, "some-snap", snap.R(opts.via), snapstate.Flags{}, "")
 	} else {
 		chg = s.state.NewChange("refresh", "refresh a snap")
 		ts, err = snapstate.Update(s.state, "some-snap", &snapstate.RevisionOptions{Revision: snap.R(opts.via)}, s.user.ID, snapstate.Flags{})
@@ -7090,6 +7090,12 @@ func (s *validationSetsSuite) testUpdateManyValidationSetsPartialFailure(c *C) *
 	logbuf, rest := logger.MockLogger()
 	defer rest()
 
+	s.fakeStore.refreshRevnos = map[string]snap.Revision{
+		"aaqKhntON3vR7kwEbVPsILm7bUViPDz":  snap.R(11),
+		"bgtKhntON3vR7kwEbVPsILm7bUViPDzx": snap.R(11),
+	}
+
+	var enforcedValidationSetsCalls int
 	restore := snapstate.MockEnforcedValidationSets(func(st *state.State, extraVs *asserts.ValidationSet) (*snapasserts.ValidationSets, error) {
 		vs := snapasserts.NewValidationSets()
 		snap1 := map[string]interface{}{
@@ -7102,8 +7108,19 @@ func (s *validationSetsSuite) testUpdateManyValidationSetsPartialFailure(c *C) *
 			"name":     "some-other-snap",
 			"presence": "required",
 		}
-		vsa1 := s.mockValidationSetAssert(c, "bar", "2", snap1, snap2)
-		vs.Add(vsa1.(*asserts.ValidationSet))
+		sequence := "2"
+		if enforcedValidationSetsCalls == 0 {
+			snap1["revision"] = "11"
+			snap2["revision"] = "11"
+			sequence = "3"
+		} else {
+			snap1["revision"] = "1"
+			snap2["revision"] = "1"
+			sequence = "2"
+		}
+		vsa1 := s.mockValidationSetAssert(c, "bar", sequence, snap1, snap2)
+		c.Assert(vs.Add(vsa1.(*asserts.ValidationSet)), IsNil)
+		enforcedValidationSetsCalls++
 		return vs, nil
 	})
 	defer restore()
@@ -7119,7 +7136,7 @@ func (s *validationSetsSuite) testUpdateManyValidationSetsPartialFailure(c *C) *
 	}
 	assertstate.UpdateValidationSet(s.state, &tr)
 
-	si1 := &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)}
+	si1 := &snap.SideInfo{RealName: "some-snap", SnapID: "aaqKhntON3vR7kwEbVPsILm7bUViPDzx", Revision: snap.R(1)}
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
 		Sequence: []*snap.SideInfo{si1},
@@ -7128,7 +7145,7 @@ func (s *validationSetsSuite) testUpdateManyValidationSetsPartialFailure(c *C) *
 	})
 	snaptest.MockSnap(c, `name: some-snap`, si1)
 
-	si2 := &snap.SideInfo{RealName: "some-other-snap", SnapID: "some-other-snap-id", Revision: snap.R(1)}
+	si2 := &snap.SideInfo{RealName: "some-other-snap", SnapID: "bgtKhntON3vR7kwEbVPsILm7bUViPDzx", Revision: snap.R(1)}
 	snapstate.Set(s.state, "some-other-snap", &snapstate.SnapState{
 		Active:   true,
 		Sequence: []*snap.SideInfo{si2},
@@ -7155,7 +7172,7 @@ func (s *validationSetsSuite) testUpdateManyValidationSetsPartialFailure(c *C) *
 
 func (s *validationSetsSuite) TestUpdateManyValidationSetsPartialFailureNothingToRestore(c *C) {
 	var refreshed []string
-	restoreMaybeRestoreValidationSetsAndRevertSnaps := snapstate.MockMaybeRestoreValidationSetsAndRevertSnaps(func(st *state.State, refreshedSnaps []string) ([]*state.TaskSet, error) {
+	restoreMaybeRestoreValidationSetsAndRevertSnaps := snapstate.MockMaybeRestoreValidationSetsAndRevertSnaps(func(st *state.State, refreshedSnaps []string, fromChange string) ([]*state.TaskSet, error) {
 		refreshed = refreshedSnaps
 		// nothing to restore
 		return nil, nil
@@ -7182,43 +7199,62 @@ func (s *validationSetsSuite) TestUpdateManyValidationSetsPartialFailureNothingT
 }
 
 func (s *validationSetsSuite) TestUpdateManyValidationSetsPartialFailureRevertTasks(c *C) {
-	var refreshed []string
-	restoreMaybeRestoreValidationSetsAndRevertSnaps := snapstate.MockMaybeRestoreValidationSetsAndRevertSnaps(func(st *state.State, refreshedSnaps []string) ([]*state.TaskSet, error) {
-		refreshed = refreshedSnaps
-		ts := state.NewTaskSet(st.NewTask("fake-revert-task", ""))
-		return []*state.TaskSet{ts}, nil
-	})
-	defer restoreMaybeRestoreValidationSetsAndRevertSnaps()
-
-	var addCurrentTrackingToValidationSetsStackCalled int
-	restoreAddCurrentTrackingToValidationSetsStack := snapstate.MockAddCurrentTrackingToValidationSetsStack(func(st *state.State) error {
-		addCurrentTrackingToValidationSetsStackCalled++
+	restore := snapstate.MockRestoreValidationSetsTracking(func(st *state.State) error {
+		tr := assertstate.ValidationSetTracking{
+			AccountID: "foo",
+			Name:      "bar",
+			Mode:      assertstate.Enforce,
+			Current:   2,
+		}
+		assertstate.UpdateValidationSet(s.state, &tr)
 		return nil
 	})
-	defer restoreAddCurrentTrackingToValidationSetsStack()
+	defer restore()
 
 	chg := s.testUpdateManyValidationSetsPartialFailure(c)
-
-	// only some-snap was successfully refreshed, this also confirms that
-	// mockMaybeRestoreValidationSetsAndRevertSnaps was called.
-	c.Check(refreshed, DeepEquals, []string{"some-snap"})
 
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	// check that a fake revert task returned by maybeRestoreValidationSetsAndRevertSnaps
-	// got injected into the refresh change.
-	var seen bool
+	seenLinkSnap := make(map[string]int)
+	var checkReRefreshTask *state.Task
 	for _, t := range chg.Tasks() {
-		if t.Kind() == "fake-revert-task" {
-			seen = true
-			break
+		if t.Kind() == "check-rerefresh" {
+			checkReRefreshTask = t
+		}
+		if t.Kind() == "link-snap" {
+			sup, err := snapstate.TaskSnapSetup(t)
+			c.Assert(err, IsNil)
+			if sup.SnapName() == "some-snap" && t.Status() == state.DoneStatus {
+				c.Assert(t.Status(), Equals, state.DoneStatus)
+			}
+			// some-other-snap failed to refresh
+			if sup.SnapName() == "some-other-snap" {
+				c.Assert(t.Status(), Equals, state.ErrorStatus)
+			}
+			seenLinkSnap[fmt.Sprintf("%s:%s", sup.SnapName(), sup.Revision())]++
 		}
 	}
-	c.Check(seen, Equals, true)
 
-	// we haven't updated validation sets history
-	c.Check(addCurrentTrackingToValidationSetsStackCalled, Equals, 0)
+	// some-snap was seen twice, first time was successful refresh, second time was for
+	// the revert to previous revision
+	c.Check(seenLinkSnap, DeepEquals, map[string]int{
+		"some-snap:11": 1,
+		"some-snap:1":  1,
+		// some-other-snap failed
+		"some-other-snap:11": 1,
+	})
+
+	var snapSt snapstate.SnapState
+	// both snap are at the initial revisions
+	c.Assert(snapstate.Get(s.state, "some-snap", &snapSt), IsNil)
+	c.Check(snapSt.Current, Equals, snap.R("1"))
+	c.Assert(snapstate.Get(s.state, "some-other-snap", &snapSt), IsNil)
+	c.Check(snapSt.Current, Equals, snap.R("1"))
+
+	c.Check(chg.Status(), Equals, state.ErrorStatus)
+	c.Assert(checkReRefreshTask, NotNil)
+	c.Check(checkReRefreshTask.Status(), Equals, state.DoneStatus)
 }
 
 func (s *snapmgrTestSuite) TestUpdatePrerequisiteBackwardsCompat(c *C) {


### PR DESCRIPTION
The attempt to revert snaps in `maybeRestoreValidationSetsAndRevertSnaps` (in check-rerefresh, after partially successfull or failed refresh) would incorrectly conflict with own change, so revert wouldn't actually happen and check-rerefresh would report conflict error. This wasn't detected by the existing test due to insufficient mocking of the install change.

This PR passes own change around down to Revert, so conflict with own change gets ignored and improves the test of actual revert. New tests cases for MaybeRestoreValidationSetsAndRevertSnaps are added to cover all special cases inside this function.

The related bug is https://bugs.launchpad.net/snapd/+bug/1974188 but I'm still not sure why check-rerefresh didn't report any error there (yet the system ended up in "invalid" enforcing state; there is likely another problem in this area).


