### PR TITLE
boot, secboot: separate the TPM provisioning and key sealing

### DIFF
--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/snapcore/snapd/secboot/keys"
 	"github.com/snapcore/snapd/seed"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
 	"github.com/snapcore/snapd/timings"
 )
 
@@ -101,6 +102,12 @@ func (o *TrustedAssetsInstallObserver) CurrentDataEncryptionKey() keys.Encryptio
 
 func (o *TrustedAssetsInstallObserver) CurrentSaveEncryptionKey() keys.EncryptionKey {
 	return o.saveEncryptionKey
+}
+
+func MockSecbootProvisionTPM(f func(lockoutAuthFile string) error) (restore func()) {
+	restore = testutil.Backup(&secbootProvisionTPM)
+	secbootProvisionTPM = f
+	return restore
 }
 
 func MockSecbootSealKeys(f func(keys []secboot.SealKeyRequest, params *secboot.SealKeysParams) error) (restore func()) {

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -101,11 +101,13 @@ func mockGadgetSeedSnap(c *C, files [][]string) *seed.Snap {
 
 func (s *sealSuite) TestSealKeyToModeenv(c *C) {
 	for _, tc := range []struct {
-		sealErr error
-		err     string
+		sealErr      error
+		provisionErr error
+		err          string
 	}{
 		{sealErr: nil, err: ""},
 		{sealErr: errors.New("seal error"), err: "cannot seal the encryption keys: seal error"},
+		{provisionErr: errors.New("provision error"), sealErr: errors.New("unexpected call"), err: "cannot seal the encryption keys: seal error"},
 	} {
 		rootdir := c.MkDir()
 		dirs.SetRootDir(rootdir)
@@ -164,22 +166,29 @@ func (s *sealSuite) TestSealKeyToModeenv(c *C) {
 		})
 		defer restore()
 
+		provisionCalls := 0
+		restore = boot.MockSecbootProvisionTPM(func(lockoutAuthFile string) error {
+			provisionCalls++
+			c.Check(lockoutAuthFile, Equals, filepath.Join(boot.InstallHostFDESaveDir, "tpm-lockout-auth"))
+			return tc.provisionErr
+		})
+		defer restore()
+
 		// set mock key sealing
 		sealKeysCalls := 0
 		restore = boot.MockSecbootSealKeys(func(keys []secboot.SealKeyRequest, params *secboot.SealKeysParams) error {
+			c.Assert(provisionCalls, Equals, 1, Commentf("TPM must have been provisioned before"))
 			sealKeysCalls++
 			switch sealKeysCalls {
 			case 1:
 				// the run object seals only the ubuntu-data key
 				c.Check(params.TPMPolicyAuthKeyFile, Equals, filepath.Join(boot.InstallHostFDESaveDir, "tpm-policy-auth-key"))
-				c.Check(params.TPMLockoutAuthFile, Equals, filepath.Join(boot.InstallHostFDESaveDir, "tpm-lockout-auth"))
 
 				dataKeyFile := filepath.Join(rootdir, "/run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key")
 				c.Check(keys, DeepEquals, []secboot.SealKeyRequest{{Key: myKey, KeyName: "ubuntu-data", KeyFile: dataKeyFile}})
 			case 2:
 				// the fallback object seals the ubuntu-data and the ubuntu-save keys
 				c.Check(params.TPMPolicyAuthKeyFile, Equals, "")
-				c.Check(params.TPMLockoutAuthFile, Equals, "")
 
 				dataKeyFile := filepath.Join(rootdir, "/run/mnt/ubuntu-seed/device/fde/ubuntu-data.recovery.sealed-key")
 				saveKeyFile := filepath.Join(rootdir, "/run/mnt/ubuntu-seed/device/fde/ubuntu-save.recovery.sealed-key")
@@ -235,10 +244,16 @@ func (s *sealSuite) TestSealKeyToModeenv(c *C) {
 		defer restore()
 
 		err = boot.SealKeyToModeenv(myKey, myKey2, model, modeenv)
-		if tc.sealErr != nil {
-			c.Assert(sealKeysCalls, Equals, 1)
+		c.Assert(provisionCalls, Equals, 1)
+		if tc.provisionErr != nil {
+			c.Assert(sealKeysCalls, Equals, 0)
+			continue
 		} else {
-			c.Assert(sealKeysCalls, Equals, 2)
+			if tc.sealErr != nil {
+				c.Assert(sealKeysCalls, Equals, 1)
+			} else {
+				c.Assert(sealKeysCalls, Equals, 2)
+			}
 		}
 		if tc.err == "" {
 			c.Assert(err, IsNil)

--- a/secboot/export_sb_test.go
+++ b/secboot/export_sb_test.go
@@ -42,11 +42,11 @@ func MockSbConnectToDefaultTPM(f func() (*sb_tpm2.Connection, error)) (restore f
 	}
 }
 
-func MockProvisionTPM(f func(tpm *sb_tpm2.Connection, mode sb_tpm2.ProvisionMode, newLockoutAuth []byte) error) (restore func()) {
-	old := provisionTPM
-	provisionTPM = f
+func MockSbTPMEnsureProvisioned(f func(tpm *sb_tpm2.Connection, mode sb_tpm2.ProvisionMode, newLockoutAuth []byte) error) (restore func()) {
+	old := sbTPMEnsureProvisioned
+	sbTPMEnsureProvisioned = f
 	return func() {
-		provisionTPM = old
+		sbTPMEnsureProvisioned = old
 	}
 }
 

--- a/secboot/secboot.go
+++ b/secboot/secboot.go
@@ -95,11 +95,6 @@ type SealKeysParams struct {
 	// The path to the authorization policy update key file (only relevant for TPM,
 	// if empty the key will not be saved)
 	TPMPolicyAuthKeyFile string
-	// The path to the lockout authorization file (only relevant for TPM and only
-	// used if TPMProvision is set to true)
-	TPMLockoutAuthFile string
-	// Whether we should provision the TPM
-	TPMProvision bool
 	// The handle at which to create a NV index for dynamic authorization policy revocation support
 	PCRPolicyCounterHandle uint32
 }

--- a/secboot/secboot_dummy.go
+++ b/secboot/secboot_dummy.go
@@ -44,3 +44,7 @@ func SealKeysWithFDESetupHook(runHook fde.RunSetupHookFunc, keys []SealKeyReques
 func ResealKeys(params *ResealKeysParams) error {
 	return errBuildWithoutSecboot
 }
+
+func ProvisionTPM(lockoutAuthFile string) error {
+	return errBuildWithoutSecboot
+}

--- a/secboot/secboot_sb_test.go
+++ b/secboot/secboot_sb_test.go
@@ -605,15 +605,61 @@ func (s *secbootSuite) TestEFIImageFromBootFile(c *C) {
 	}
 }
 
+func (s *secbootSuite) TestProvisionTPM(c *C) {
+	mockErr := errors.New("some error")
+
+	for idx, tc := range []struct {
+		tpmErr            error
+		tpmEnabled        bool
+		provisioningErr   error
+		provisioningCalls int
+		expectedErr       string
+	}{
+		{tpmErr: mockErr, expectedErr: "cannot connect to TPM: some error"},
+		{tpmEnabled: false, expectedErr: "TPM device is not enabled"},
+		{tpmEnabled: true, provisioningErr: mockErr, provisioningCalls: 1, expectedErr: "cannot provision TPM: some error"},
+		{tpmEnabled: true, provisioningCalls: 1, expectedErr: ""},
+	} {
+		c.Logf("tc: %v", idx)
+		d := c.MkDir()
+		tpm, restore := mockSbTPMConnection(c, tc.tpmErr)
+		defer restore()
+
+		// mock TPM enabled check
+		restore = secboot.MockIsTPMEnabled(func(t *sb_tpm2.Connection) bool {
+			return tc.tpmEnabled
+		})
+		defer restore()
+
+		// mock provisioning
+		provisioningCalls := 0
+		restore = secboot.MockSbTPMEnsureProvisioned(func(t *sb_tpm2.Connection, mode sb_tpm2.ProvisionMode, newLockoutAuth []byte) error {
+			provisioningCalls++
+			c.Assert(t, Equals, tpm)
+			c.Assert(mode, Equals, sb_tpm2.ProvisionModeFull)
+			return tc.provisioningErr
+		})
+		defer restore()
+
+		err := secboot.ProvisionTPM(filepath.Join(d, "lockout-auth"))
+		if tc.expectedErr != "" {
+			c.Assert(err, ErrorMatches, tc.expectedErr)
+		} else {
+			c.Assert(err, IsNil)
+		}
+		c.Check(provisioningCalls, Equals, tc.provisioningCalls)
+	}
+
+}
+
 func (s *secbootSuite) TestSealKey(c *C) {
 	mockErr := errors.New("some error")
 
-	for _, tc := range []struct {
+	for idx, tc := range []struct {
 		tpmErr               error
 		tpmEnabled           bool
 		missingFile          bool
 		badSnapFile          bool
-		skipProvision        bool
 		addEFISbPolicyErr    error
 		addEFIBootManagerErr error
 		addSystemdEFIStubErr error
@@ -632,11 +678,11 @@ func (s *secbootSuite) TestSealKey(c *C) {
 		{tpmEnabled: true, addEFIBootManagerErr: mockErr, expectedErr: "cannot add EFI boot manager profile: some error"},
 		{tpmEnabled: true, addSystemdEFIStubErr: mockErr, expectedErr: "cannot add systemd EFI stub profile: some error"},
 		{tpmEnabled: true, addSnapModelErr: mockErr, expectedErr: "cannot add snap model profile: some error"},
-		{tpmEnabled: true, provisioningErr: mockErr, provisioningCalls: 1, expectedErr: "cannot provision TPM: some error"},
 		{tpmEnabled: true, sealErr: mockErr, provisioningCalls: 1, sealCalls: 1, expectedErr: "some error"},
-		{tpmEnabled: true, skipProvision: true, provisioningCalls: 0, sealCalls: 1, expectedErr: ""},
-		{tpmEnabled: true, provisioningCalls: 1, sealCalls: 1, expectedErr: ""},
+		{tpmEnabled: true, sealCalls: 1, expectedErr: ""},
+		{tpmEnabled: true, sealCalls: 1, expectedErr: ""},
 	} {
+		c.Logf("tc: %v", idx)
 		tmpDir := c.MkDir()
 		var mockBF []bootloader.BootFile
 		for _, name := range []string{"a", "b", "c", "d"} {
@@ -694,8 +740,6 @@ func (s *secbootSuite) TestSealKey(c *C) {
 			},
 			TPMPolicyAuthKey:       myAuthKey,
 			TPMPolicyAuthKeyFile:   filepath.Join(tmpDir, "policy-auth-key-file"),
-			TPMLockoutAuthFile:     filepath.Join(tmpDir, "lockout-auth-file"),
-			TPMProvision:           !tc.skipProvision,
 			PCRPolicyCounterHandle: 42,
 		}
 
@@ -861,17 +905,6 @@ func (s *secbootSuite) TestSealKey(c *C) {
 		})
 		defer restore()
 
-		// mock provisioning
-		provisioningCalls := 0
-		restore = secboot.MockProvisionTPM(func(t *sb_tpm2.Connection, mode sb_tpm2.ProvisionMode, newLockoutAuth []byte) error {
-			provisioningCalls++
-			c.Assert(t, Equals, tpm)
-			c.Assert(mode, Equals, sb_tpm2.ProvisionModeFull)
-			c.Assert(myParams.TPMLockoutAuthFile, testutil.FilePresent)
-			return tc.provisioningErr
-		})
-		defer restore()
-
 		// mock sealing
 		sealCalls := 0
 		restore = secboot.MockSbSealKeyToTPMMultiple(func(t *sb_tpm2.Connection, kr []*sb_tpm2.SealKeyRequest, params *sb_tpm2.KeyCreationParams) (sb_tpm2.PolicyAuthKey, error) {
@@ -900,9 +933,7 @@ func (s *secbootSuite) TestSealKey(c *C) {
 		} else {
 			c.Assert(err, ErrorMatches, tc.expectedErr)
 		}
-		c.Assert(provisioningCalls, Equals, tc.provisioningCalls)
 		c.Assert(sealCalls, Equals, tc.sealCalls)
-
 	}
 }
 
@@ -1105,7 +1136,6 @@ func (s *secbootSuite) TestSealKeyNoModelParams(c *C) {
 	}
 	myParams := secboot.SealKeysParams{
 		TPMPolicyAuthKeyFile: "policy-auth-key-file",
-		TPMLockoutAuthFile:   "lockout-auth-file",
 	}
 
 	err := secboot.SealKeys(myKeys, &myParams)

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -63,16 +63,12 @@ var (
 
 	randutilRandomKernelUUID = randutil.RandomKernelUUID
 
-	isTPMEnabled = isTPMEnabledImpl
-	provisionTPM = provisionTPMImpl
+	isTPMEnabled           func(tpm *sb_tpm2.Connection) bool                                                  = (*sb_tpm2.Connection).IsEnabled
+	sbTPMEnsureProvisioned func(tpm *sb_tpm2.Connection, mode sb_tpm2.ProvisionMode, lockoutAuth []byte) error = (*sb_tpm2.Connection).EnsureProvisioned
 
 	// check whether the interfaces match
 	_ (sb.SnapModel) = ModelForSealing(nil)
 )
-
-func isTPMEnabledImpl(tpm *sb_tpm2.Connection) bool {
-	return tpm.IsEnabled()
-}
 
 func CheckTPMKeySealingSupported() error {
 	logger.Noticef("checking if secure boot is enabled...")
@@ -284,9 +280,27 @@ func unlockEncryptedPartitionWithSealedKey(mapperName, sourceDevice, keyfile str
 	return UnlockedWithSealedKey, nil
 }
 
-// SealKeys provisions the TPM and seals the encryption keys according to the
-// specified parameters. If the TPM is already provisioned, or a sealed key already
-// exists, SealKeys will fail and return an error.
+// ProvisionTPM provisions the default TPM and saves the lockout authorization
+// key to the specified file.
+func ProvisionTPM(lockoutAuthFile string) error {
+	tpm, err := sbConnectToDefaultTPM()
+	if err != nil {
+		return fmt.Errorf("cannot connect to TPM: %v", err)
+	}
+	defer tpm.Close()
+	if !isTPMEnabled(tpm) {
+		return fmt.Errorf("TPM device is not enabled")
+	}
+
+	if err := tpmProvision(tpm, lockoutAuthFile); err != nil {
+		return err
+	}
+	return nil
+}
+
+// SealKeys seals the encryption keys according to the specified parameters. The
+// TPM must have already been provisioned. If sealed key already exists at the
+// PCR handle, SealKeys will fail and return an error.
 func SealKeys(keys []SealKeyRequest, params *SealKeysParams) error {
 	numModels := len(params.ModelParams)
 	if numModels < 1 {
@@ -305,13 +319,6 @@ func SealKeys(keys []SealKeyRequest, params *SealKeysParams) error {
 	pcrProfile, err := buildPCRProtectionProfile(params.ModelParams)
 	if err != nil {
 		return err
-	}
-
-	if params.TPMProvision {
-		// Provision the TPM as late as possible
-		if err := tpmProvision(tpm, params.TPMLockoutAuthFile); err != nil {
-			return err
-		}
 	}
 
 	// Seal the provided keys to the TPM
@@ -487,15 +494,11 @@ func tpmProvision(tpm *sb_tpm2.Connection, lockoutAuthFile string) error {
 	// TODO:UC20: ideally we should ask the firmware to clear the TPM and then reboot
 	//            if the device has previously been provisioned, see
 	//            https://godoc.org/github.com/snapcore/secboot#RequestTPMClearUsingPPI
-	if err := provisionTPM(tpm, sb_tpm2.ProvisionModeFull, lockoutAuth); err != nil {
+	if err := sbTPMEnsureProvisioned(tpm, sb_tpm2.ProvisionModeFull, lockoutAuth); err != nil {
 		logger.Noticef("TPM provisioning error: %v", err)
 		return fmt.Errorf("cannot provision TPM: %v", err)
 	}
 	return nil
-}
-
-func provisionTPMImpl(tpm *sb_tpm2.Connection, mode sb_tpm2.ProvisionMode, lockoutAuth []byte) error {
-	return tpm.EnsureProvisioned(mode, lockoutAuth)
 }
 
 // buildLoadSequences builds EFI load image event trees from this package LoadChains


### PR DESCRIPTION
Provisioning of the TPM and sealing the keys are separate processes and thus it's time to split the secboot code which did this inside a single call.
