### PR TITLE
o/state: use more detailed NoStateError in state

### DIFF
--- a/daemon/api_connections_test.go
+++ b/daemon/api_connections_test.go
@@ -140,7 +140,7 @@ func (s *interfacesSuite) TestConnectionsNotFound(c *check.C) {
 	c.Check(err, check.IsNil)
 	c.Check(body, check.DeepEquals, map[string]interface{}{
 		"result": map[string]interface{}{
-			"message": "no state entry for key",
+			"message": `no state entry for key "snaps"`,
 			"kind":    "snap-not-found",
 			"value":   "not-found",
 		},

--- a/overlord/ifacestate/helpers_test.go
+++ b/overlord/ifacestate/helpers_test.go
@@ -193,11 +193,11 @@ func (s *helpersSuite) TestHotplugTaskHelpers(c *C) {
 
 	t := s.st.NewTask("foo", "")
 	_, _, err := ifacestate.GetHotplugAttrs(t)
-	c.Assert(err, ErrorMatches, `internal error: cannot get interface name from hotplug task: no state entry for key`)
+	c.Assert(err, ErrorMatches, `internal error: cannot get interface name from hotplug task: no state entry for key "interface"`)
 
 	t.Set("interface", "x")
 	_, _, err = ifacestate.GetHotplugAttrs(t)
-	c.Assert(err, ErrorMatches, `internal error: cannot get hotplug key from hotplug task: no state entry for key`)
+	c.Assert(err, ErrorMatches, `internal error: cannot get hotplug key from hotplug task: no state entry for key "hotplug-key"`)
 
 	ifacestate.SetHotplugAttrs(t, "iface", "key")
 

--- a/overlord/state/state.go
+++ b/overlord/state/state.go
@@ -46,7 +46,7 @@ type customData map[string]*json.RawMessage
 func (data customData) get(key string, value interface{}) error {
 	entryJSON := data[key]
 	if entryJSON == nil {
-		return ErrNoState
+		return &NoStateError{Key: key}
 	}
 	err := json.Unmarshal(*entryJSON, value)
 	if err != nil {
@@ -240,6 +240,26 @@ func (s *State) EnsureBefore(d time.Duration) {
 
 // ErrNoState represents the case of no state entry for a given key.
 var ErrNoState = errors.New("no state entry for key")
+
+// NoStateError represents the case where no state could be found for a given key.
+type NoStateError struct {
+	// Key is the key for which no state could be found.
+	Key string
+}
+
+func (e *NoStateError) Error() string {
+	var keyMsg string
+	if e.Key != "" {
+		keyMsg = fmt.Sprintf(" %q", e.Key)
+	}
+
+	return fmt.Sprintf("no state entry for key%s", keyMsg)
+}
+
+func (e *NoStateError) Is(err error) bool {
+	_, ok := err.(*NoStateError)
+	return ok || err == ErrNoState
+}
 
 // Get unmarshals the stored value associated with the provided key
 // into the value parameter.

--- a/overlord/state/state.go
+++ b/overlord/state/state.go
@@ -258,7 +258,7 @@ func (e *NoStateError) Error() string {
 
 func (e *NoStateError) Is(err error) bool {
 	_, ok := err.(*NoStateError)
-	return ok || err == ErrNoState
+	return ok || err == ErrNoState // nocheck=
 }
 
 // Get unmarshals the stored value associated with the provided key

--- a/run-checks
+++ b/run-checks
@@ -313,8 +313,9 @@ if [ "$STATIC" = 1 ]; then
         ./tests/lib/external/snapd-testing-tools/utils/check-test-format ./tests
     fi
 
+    # To ignore this check, add a '// nocheck=' to the end of the line
     echo "Checking for usages of !=, == or Equals with ErrNoState"
-    if got=$(grep -n -R -E "(\!=|==|Equals,) (state\.)?ErrNoState" --include=*.go) ; then
+    if got=$(grep -n -R -E "(\!=|==|Equals,) (state\.)?ErrNoState" --include=*.go | grep -v "//\s*nocheck=") ; then
       echo "Don't use equality checks with ErrNoState, use errors.Is() instead"
       echo "$got"
       exit 1


### PR DESCRIPTION
Replaces ErrNoState in `state/` with an error struct containing additional context. Also allow the '== ErrNoState' check in the run-checks script to ignore specific cases.

Signed-off-by: Miguel Pires <miguel.pires@canonical.com>