### PR TITLE
interfaces: update network-control interface with permissions required by resolvectl

### DIFF
--- a/interfaces/builtin/network_control.go
+++ b/interfaces/builtin/network_control.go
@@ -68,6 +68,22 @@ dbus (send)
      member="SetLink{DefaultRoute,DNSOverTLS,DNS,DNSEx,DNSSEC,DNSSECNegativeTrustAnchors,MulticastDNS,Domains,LLMNR}"
      peer=(label=unconfined),
 
+# required by resolvectl command
+dbus (send,receive)
+     bus=system
+     path="/org/freedesktop/resolve1"
+     interface=org.freedesktop.DBus.Properties
+     member={GetAll,PropertiesChanged,Get}
+     peer=(label=unconfined),
+
+# required by resolvectl command
+dbus (send,receive)
+     bus=system
+     path="/org/freedesktop/resolve1/link/*"
+     interface="org.freedesktop.DBus.Properties"
+     member={GetAll,PropertiesChanged,Get}
+     peer=(label=unconfined),
+
 #include <abstractions/ssl_certs>
 
 capability net_admin,
@@ -131,6 +147,7 @@ network sna,
 /{,usr/}{,s}bin/pppdump ixr,
 /{,usr/}{,s}bin/pppoe-discovery ixr,
 #/{,usr/}{,s}bin/pppstats ixr,            # needs sys_module
+/{,usr/}{,s}bin/resolvectl ixr,
 /{,usr/}{,s}bin/route ixr,
 /{,usr/}{,s}bin/routef ixr,
 /{,usr/}{,s}bin/routel ixr,

--- a/interfaces/builtin/network_control.go
+++ b/interfaces/builtin/network_control.go
@@ -69,19 +69,35 @@ dbus (send)
      peer=(label=unconfined),
 
 # required by resolvectl command
-dbus (send,receive)
+dbus (send)
      bus=system
      path="/org/freedesktop/resolve1"
      interface=org.freedesktop.DBus.Properties
-     member={GetAll,PropertiesChanged,Get}
+     member=Get{,All}
      peer=(label=unconfined),
 
 # required by resolvectl command
-dbus (send,receive)
+dbus (receive)
+     bus=system
+     path="/org/freedesktop/resolve1"
+     interface=org.freedesktop.DBus.Properties
+     member=PropertiesChanged
+     peer=(label=unconfined),
+
+# required by resolvectl command
+dbus (send)
      bus=system
      path="/org/freedesktop/resolve1/link/*"
      interface="org.freedesktop.DBus.Properties"
-     member={GetAll,PropertiesChanged,Get}
+     member=Get{,All}
+     peer=(label=unconfined),
+
+# required by resolvectl command
+dbus (receive)
+     bus=system
+     path="/org/freedesktop/resolve1/link/*"
+     interface="org.freedesktop.DBus.Properties"
+     member=PropertiesChanged
      peer=(label=unconfined),
 
 #include <abstractions/ssl_certs>

--- a/tests/main/interfaces-network-control/network-control-consumer/meta/snap.yaml
+++ b/tests/main/interfaces-network-control/network-control-consumer/meta/snap.yaml
@@ -2,6 +2,7 @@ name: network-control-consumer
 version: 1.0
 summary: Basic network-control consumer snap
 description: A basic snap declaring a plug on network-control
+base: core20
 
 apps:
   cmd:

--- a/tests/main/interfaces-network-control/task.yaml
+++ b/tests/main/interfaces-network-control/task.yaml
@@ -55,7 +55,14 @@ execute: |
     network-control-consumer.cmd ss -lnt | MATCH "LISTEN.*:$PORT"
 
     echo "And DNS information"
-    network-control-consumer.cmd resolvectl | MATCH "DNS Server"
+    case "$SPREAD_SYSTEM" in
+    centos-*|debian-*|arch-linux-*|amazon-linux-*)
+        # echo no systemd-resolved in those images
+        ;;
+    *)
+        network-control-consumer.cmd resolvectl | MATCH "DNS Server"
+        ;;
+    esac
 
     if [ "$(snap debug confinement)" = strict ] ; then
         echo "When the plug is disconnected"

--- a/tests/main/interfaces-network-control/task.yaml
+++ b/tests/main/interfaces-network-control/task.yaml
@@ -54,6 +54,9 @@ execute: |
     echo "Then the snap command can query network status information"
     network-control-consumer.cmd ss -lnt | MATCH "LISTEN.*:$PORT"
 
+    echo "And DNS information"
+    network-control-consumer.cmd resolvectl | MATCH "DNS Server"
+
     if [ "$(snap debug confinement)" = strict ] ; then
         echo "When the plug is disconnected"
         snap disconnect network-control-consumer:network-control


### PR DESCRIPTION
Update network-control interface with permissions required by resolvectl: read/query permissions for dbus objects required by resolvectl and permission to execute resolvectl command itself. This was requested by one of the customers.

Fixes https://bugs.launchpad.net/snappy/+bug/1976305