### PR TITLE
interfaces/mount-observe: Allow read access to /run/mount/utab

### DIFF
--- a/interfaces/builtin/mount_observe.go
+++ b/interfaces/builtin/mount_observe.go
@@ -49,6 +49,9 @@ owner @{PROC}/@{pid}/mountstats r,
 # This is often out of date but some apps insist on using it
 /etc/mtab r,
 /etc/fstab r,
+
+# some apps also insist on consulting utab
+/run/mount/utab r,
 `
 
 const mountObserveConnectedPlugSecComp = `


### PR DESCRIPTION
This is required by some applications as seen in
https://forum.snapcraft.io/t/permissions-and-alias-request-for-softmaker-office-21/29907/14

Signed-off-by: Alex Murray <alex.murray@canonical.com>