### PR TITLE
o/snapstate: exclude services from refresh app awareness hard running check

### DIFF
--- a/overlord/snapstate/refresh.go
+++ b/overlord/snapstate/refresh.go
@@ -119,8 +119,7 @@ func SoftNothingRunningRefreshCheck(info *snap.Info) error {
 // refreshed and the refresh process is aborted.
 func HardNothingRunningRefreshCheck(info *snap.Info) error {
 	return genericRefreshCheck(info, func(app *snap.AppInfo) bool {
-		// TODO: use a constant instead of "endure"
-		return app.IsService() && app.RefreshMode == "endure"
+		return app.IsService()
 	})
 }
 

--- a/overlord/snapstate/refresh_test.go
+++ b/overlord/snapstate/refresh_test.go
@@ -112,15 +112,12 @@ func (s *refreshSuite) TestSoftNothingRunningRefreshCheck(c *C) {
 }
 
 func (s *refreshSuite) TestHardNothingRunningRefreshCheck(c *C) {
-	// Regular services are blocking hard refresh check.
-	// We were expecting them to be gone by now.
+	// Services are ignored by hard refresh check.
 	s.pids = map[string][]int{
 		"snap.pkg.daemon": {100},
 	}
 	err := snapstate.HardNothingRunningRefreshCheck(s.info)
-	c.Assert(err, NotNil)
-	c.Check(err.Error(), Equals, `snap "pkg" has running apps (daemon), pids: 100`)
-	c.Check(err.(*snapstate.BusySnapError).Pids(), DeepEquals, []int{100})
+	c.Assert(err, IsNil)
 
 	// When the service is supposed to endure refreshes it will not be
 	// stopped. As such such services cannot block refresh.

--- a/tests/main/services-refresh-mode/task.yaml
+++ b/tests/main/services-refresh-mode/task.yaml
@@ -18,9 +18,7 @@ execute: |
     systemctl show -p MainPID snap.test-snapd-service.test-snapd-endure-service > old-main.pid
 
     echo "When it is re-installed"
-    # Due to refresh-app-awareness we need --ignore-running to ignore the service that
-    # keeps running due to "endure" mode.
-    "$TESTSTOOLS"/snaps-state install-local test-snapd-service --ignore-running
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-service
 
     echo "We can still see it running with the same PID"
     systemctl show -p MainPID snap.test-snapd-service.test-snapd-endure-service > new-main.pid

--- a/tests/main/services-snapctl/task.yaml
+++ b/tests/main/services-snapctl/task.yaml
@@ -76,8 +76,7 @@ execute: |
 
     echo "Reinstalling the snap with configure hook calling snapctl restart works"
     snap set test-snapd-service command=restart
-    # Due to refresh-app-awareness we need --ignore-running as test-snapd-sigterm-service keeps running after sigterm.
-    "$TESTSTOOLS"/snaps-state install-local test-snapd-service --ignore-running
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-service
     # shellcheck disable=SC2119
     if "$TESTSTOOLS"/journal-state get-log | MATCH "error running snapctl"; then
         echo "snapctl should not report errors"

--- a/tests/main/services-stop-mode-sigkill/task.yaml
+++ b/tests/main/services-stop-mode-sigkill/task.yaml
@@ -34,9 +34,7 @@ execute: |
     [ "$n" = "2" ]
 
     echo "When it is re-installed one process uses sigterm, the other sigterm-all"
-    # due to refresh-app-awareness we need to ignore running processes since the
-    # sigterm service keeps a sleep process running.
-    "$TESTSTOOLS"/snaps-state install-local test-snapd-service --ignore-running
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-service
     retry -n 20 --wait 1 sh -c 'test -f /var/snap/test-snapd-service/common/ready'
 
     echo "After reinstall the sigterm-all service and all children got killed"

--- a/tests/main/services-stop-mode/task.yaml
+++ b/tests/main/services-stop-mode/task.yaml
@@ -37,9 +37,7 @@ execute: |
     done
 
     echo "When it is re-installed"
-    # Due to refresh-app-awareness we need to --ignore-running to ignore the running test-snapd-sigterm-service (it
-    # keeps running after sigterm).
-    "$TESTSTOOLS"/snaps-state install-local test-snapd-service --ignore-running
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-service
     retry -n 20 --wait 1 sh -c 'test -f /var/snap/test-snapd-service/common/ready'
 
     # note that sigterm{,-all} is tested separately


### PR DESCRIPTION
Exclude services from refresh-app-awareness check. So far we would ignore services with "endure" mode only, but there was an issue also with services which use stop-mode:sigterm and leave running child processes during refresh (microk8s). The agreed solution is to exclude services altogether - the assumption is that services generally know what they are doing and since snapd stops them during refresh (except for endure), they do the right thing.

Fixes: https://bugs.launchpad.net/snapd/+bug/1975714