### PR TITLE
tests: moving lxd to edge channel

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -40,7 +40,7 @@ environment:
     SUDO_UID: ""
     TRUST_TEST_KEYS: '$(HOST: echo "${SPREAD_TRUST_TEST_KEYS:-true}")'
     # a global setting for LXD channel to use in the tests
-    LXD_SNAP_CHANNEL: "latest/candidate"
+    LXD_SNAP_CHANNEL: "latest/edge"
     UBUNTU_IMAGE_SNAP_CHANNEL: "latest/candidate"
     # controls whether ubuntu-image is built using the current snapd tree as a
     # dependency or the one listed in its go.mod


### PR DESCRIPTION
This is because an issue that was raised few days ago and it is already
fixed on edge channel.

The issue is the following: https://github.com/lxc/lxd/issues/10449

It produces an error when creating bionic and focal instances

A following pr will be created to revert this change