### PR TITLE
interfaces/builtin: remove the name=org.freedesktop.DBus restriction in cups-control AppArmor rules

### DIFF
--- a/interfaces/builtin/cups_control.go
+++ b/interfaces/builtin/cups_control.go
@@ -81,7 +81,7 @@ dbus (send)
     bus=system
     path=/org/cups/cupsd/Notifier
     interface=org.cups.cupsd.Notifier
-    peer=(name=org.freedesktop.DBus,label=unconfined),
+    peer=(label=unconfined),
 
 # Allow daemon to send signals to its snap_daemon processes
 capability kill,
@@ -96,7 +96,7 @@ dbus (send)
     bus=system
     path=/org/cups/cupsd/Notifier
     interface=org.cups.cupsd.Notifier
-    peer=(name=org.freedesktop.DBus,label=###PLUG_SECURITY_TAGS###),
+    peer=(label=###PLUG_SECURITY_TAGS###),
 `
 
 const cupsControlConnectedPlugAppArmor = `
@@ -111,7 +111,7 @@ dbus (receive)
     bus=system
     path=/org/cups/cupsd/Notifier
     interface=org.cups.cupsd.Notifier
-    peer=(name=org.freedesktop.DBus,label=###SLOT_SECURITY_TAGS###),
+    peer=(label=###SLOT_SECURITY_TAGS###),
 `
 
 type cupsControlInterface struct {

--- a/interfaces/builtin/cups_control_test.go
+++ b/interfaces/builtin/cups_control_test.go
@@ -106,7 +106,7 @@ func (s *cupsControlSuite) TestAppArmorSpecCore(c *C) {
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "# Allow communicating with the cups server for printing and configuration.")
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "#include <abstractions/cups-client>")
-	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "peer=(name=org.freedesktop.DBus,label=\"snap.provider.app\"")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "peer=(label=\"snap.provider.app\"")
 	c.Assert(spec.SnippetForTag("snap.provider.app"), Not(testutil.Contains), "# Allow daemon access to create the CUPS socket")
 
 	// provider to consumer on core for PermanentSlot
@@ -120,7 +120,7 @@ func (s *cupsControlSuite) TestAppArmorSpecCore(c *C) {
 	spec = &apparmor.Specification{}
 	c.Assert(spec.AddConnectedSlot(s.iface, s.plug, s.providerSlot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.provider.app"})
-	c.Assert(spec.SnippetForTag("snap.provider.app"), testutil.Contains, "peer=(name=org.freedesktop.DBus,label=\"snap.consumer.app\"")
+	c.Assert(spec.SnippetForTag("snap.provider.app"), testutil.Contains, "peer=(label=\"snap.consumer.app\"")
 }
 
 func (s *cupsControlSuite) TestAppArmorSpecClassic(c *C) {
@@ -133,7 +133,7 @@ func (s *cupsControlSuite) TestAppArmorSpecClassic(c *C) {
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "# Allow communicating with the cups server for printing and configuration.")
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "#include <abstractions/cups-client>")
-	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "peer=(name=org.freedesktop.DBus,label=\"{unconfined,/usr/sbin/cupsd,cupsd}\"")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "peer=(label=\"{unconfined,/usr/sbin/cupsd,cupsd}\"")
 	c.Assert(spec.SnippetForTag("snap.provider.app"), Not(testutil.Contains), "# Allow daemon access to create the CUPS socket")
 
 	// core to consumer on classic is empty for PermanentSlot
@@ -152,7 +152,7 @@ func (s *cupsControlSuite) TestAppArmorSpecClassic(c *C) {
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "# Allow communicating with the cups server for printing and configuration.")
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "#include <abstractions/cups-client>")
-	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "peer=(name=org.freedesktop.DBus,label=\"snap.provider.app\"")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "peer=(label=\"snap.provider.app\"")
 	c.Assert(spec.SnippetForTag("snap.provider.app"), Not(testutil.Contains), "# Allow daemon access to create the CUPS socket")
 
 	// provider to consumer on classic for PermanentSlot
@@ -166,7 +166,7 @@ func (s *cupsControlSuite) TestAppArmorSpecClassic(c *C) {
 	spec = &apparmor.Specification{}
 	c.Assert(spec.AddConnectedSlot(s.iface, s.plug, s.providerSlot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.provider.app"})
-	c.Assert(spec.SnippetForTag("snap.provider.app"), testutil.Contains, "peer=(name=org.freedesktop.DBus,label=\"snap.consumer.app\"")
+	c.Assert(spec.SnippetForTag("snap.provider.app"), testutil.Contains, "peer=(label=\"snap.consumer.app\"")
 }
 
 func (s *cupsControlSuite) TestStaticInfo(c *C) {


### PR DESCRIPTION
While testing the CUPS snap, @tillkamppeter noticed that some D-Bus broadcast signals were being blocked by AppArmor.

On closer inspection, the rules related to the `org.cups.cupsd.Notifier` D-Bus interface all had a restriction like `peer=(name=org.freedesktop.DBus,label=...)`. This seemed weird to me, as that name is reserved for dbus-daemon, and these messages are not being sent to or received from the bus. Removing the `name=` restriction allowed the messages to be delivered.

I asked @alexmurray for his opinion, and he couldn't think of a reason the name conditional was included here either, so I've submitted this PR to remove it.

In this case, there isn't a different D-Bus name that could be used in the rule. The messages are sent by a short lived notifier plugin process:

https://github.com/OpenPrinting/cups/blob/master/notifier/dbus.c

It does not try to own a name, and the clients watching for the signal broadcasts don't match on a well known bus name either.