### PR TITLE
tests/main/nfs-support: be robust against umount failures

### DIFF
--- a/tests/main/nfs-support/task.yaml
+++ b/tests/main/nfs-support/task.yaml
@@ -117,6 +117,23 @@ execute: |
         fi
     }
 
+    # This test calls umount right after executing a "su" command with the
+    # "test" user. But this can randomly fail, because entering the user
+    # session causes systemd to activate the dbus.service unit for the "test"
+    # user for the duration of the command, but its shutdown (which happens in
+    # the background) might take a little longer and leave the dbus-daemon
+    # "using" the /home/test directory, therefore preventing the umount.
+    umount_with_retry() {
+        # systemd-logind has a 10 seconds timeout for shutting down the user
+        # session, but we don't want to wait that long: let's kill all the
+        # processes belonging to the test user ourselves.
+        ps -U test -o pid= | while read PID
+        do
+            kill -9 "$PID" || true
+        done
+        retry -n 10 --wait 0.5 umount "$1"
+    }
+
     # Export /home over NFS.
     mkdir -p /etc/exports.d/
     echo '/home localhost(rw,no_subtree_check,no_root_squash)' > /etc/exports.d/test.exports
@@ -179,7 +196,7 @@ execute: |
     su -c 'snap run test-snapd-sh.with-home-plug -c "touch \$SNAP_USER_DATA/smoke-nfs3-tcp"' test
 
     # Unmount /home and restart snapd so that we can check another thing.
-    umount /home
+    umount_with_retry /home
     restart_snapd
 
     # Ensure that this removed the extra permissions.
@@ -205,7 +222,7 @@ execute: |
         su -c 'snap run test-snapd-sh.with-home-plug -c "touch \$SNAP_USER_DATA/smoke-nfs3-udp"' test
 
         # Unmount /home and restart snapd so that we can check another thing.
-        umount /home
+        umount_with_retry /home
         restart_snapd
 
         # Ensure that this removed the extra permissions.
@@ -227,7 +244,7 @@ execute: |
     su -c 'snap run test-snapd-sh.with-home-plug -c "touch \$SNAP_USER_DATA/smoke-nfs4"' test
 
     # Unmount /home and restart snapd so that we can check another thing.
-    umount /home
+    umount_with_retry /home
     restart_snapd
 
     # Ensure that this removed the extra permissions.

--- a/tests/main/nfs-support/task.yaml
+++ b/tests/main/nfs-support/task.yaml
@@ -127,7 +127,7 @@ execute: |
         # systemd-logind has a 10 seconds timeout for shutting down the user
         # session, but we don't want to wait that long: let's kill all the
         # processes belonging to the test user ourselves.
-        ps -U test -o pid= | while read PID
+        ps -U test -o pid= | while read -r PID
         do
             kill -9 "$PID" || true
         done


### PR DESCRIPTION
The umount command is often failing because the "test" user's
`dbus-daemon` process is still keeping the /home/test directory busy.

systemd-logind will automatically close the session after the test user
has logged out (which happens at the end of the `su` command), but it
allows for a 10 seconds grace period, which we cannot afford to waste.

Therefore, in addition to adding a retry loop to the umount operation,
we also explicitly kill all of the "test" user's processes.

