### PR TITLE
i/b/desktop,unity7: remove name= specification on D-Bus signals

### DIFF
--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -97,7 +97,7 @@ dbus (send)
      bus=session
      interface=org.gtk.Actions
      member=Changed
-     peer=(name=org.freedesktop.DBus, label=unconfined),
+     peer=(label=unconfined),
 
 # notifications
 dbus (send)

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -317,7 +317,7 @@ dbus (send)
     bus=session
     interface=org.gtk.Actions
     member=Changed
-    peer=(name=org.freedesktop.DBus, label=unconfined),
+    peer=(label=unconfined),
 
 dbus (receive)
     bus=session
@@ -335,7 +335,7 @@ dbus (send)
     bus=session
     interface=org.gtk.Menus
     member=Changed
-    peer=(name=org.freedesktop.DBus, label=unconfined),
+    peer=(label=unconfined),
 
 # Ubuntu menus
 dbus (send)
@@ -362,7 +362,7 @@ dbus (send)
     path=/{MenuBar{,/[0-9A-F]*},com/canonical/{menu/[0-9A-F]*,dbusmenu}}
     interface=com.canonical.dbusmenu
     member="{LayoutUpdated,ItemsPropertiesUpdated}"
-    peer=(name=org.freedesktop.DBus, label=unconfined),
+    peer=(label=unconfined),
 
 dbus (receive)
     bus=session
@@ -430,7 +430,7 @@ dbus (send)
     path=/{StatusNotifierItem,org/ayatana/NotificationItem/*}
     interface=org.kde.StatusNotifierItem
     member="New{AttentionIcon,Icon,IconThemePath,OverlayIcon,Status,Title,ToolTip}"
-    peer=(name=org.freedesktop.DBus, label=unconfined),
+    peer=(label=unconfined),
 
 dbus (receive)
     bus=session
@@ -444,7 +444,7 @@ dbus (send)
     path=/{StatusNotifierItem/menu,org/ayatana/NotificationItem/*/Menu}
     interface=com.canonical.dbusmenu
     member="{LayoutUpdated,ItemsPropertiesUpdated}"
-    peer=(name=org.freedesktop.DBus, label=unconfined),
+    peer=(label=unconfined),
 
 dbus (receive)
     bus=session
@@ -489,7 +489,7 @@ dbus (send)
     path=/org/ayatana/NotificationItem/*
     interface=org.kde.StatusNotifierItem
     member=XAyatanaNew*
-    peer=(name=org.freedesktop.DBus, label=unconfined),
+    peer=(label=unconfined),
 
 # unity launcher
 dbus (send)
@@ -497,14 +497,14 @@ dbus (send)
     path=/com/canonical/unity/launcherentry/[0-9]*
     interface=com.canonical.Unity.LauncherEntry
     member=Update
-    peer=(name=org.freedesktop.DBus, label=unconfined),
+    peer=(label=unconfined),
 
 dbus (send)
     bus=session
     path=/com/canonical/unity/launcherentry/[0-9]*
     interface=com.canonical.dbusmenu
     member="{LayoutUpdated,ItemsPropertiesUpdated}"
-    peer=(name=org.freedesktop.DBus, label=unconfined),
+    peer=(label=unconfined),
 
 dbus (receive)
     bus=session


### PR DESCRIPTION
All the rules touched in this commit are about D-Bus signals. We want
the D-Bus daemon to forward them to any listening processes, so it's not
correct to limit them to the D-Bus daemon only.

Opening as a draft as I'm not sure this is correct. The fact that all D-Bus signals have this specification makes me thing that maybe this is intentional and that the rule might be like this because of some internal logic to the D-Bus AppArmor module of how signals are being treated.

Incidentally, I wonder if having the `label=unconfined` label is correct -- don't we want these signals to potentially reach any listening process, including confined snap applications?

@alexmurray, @jhenstridge: waiting for your feedback, on whether this is needed/correct at all.