### PR TITLE
spread: drop openSUSE Leap 15.2

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -302,9 +302,6 @@ backends:
             - amazon-linux-2-64:
                   username: ec2-user
                   password: ec2-user
-            - opensuse-15.2-64:
-                  username: opensuse
-                  password: opensuse
             - opensuse-tumbleweed-64:
                   username: opensuse
                   password: opensuse


### PR DESCRIPTION
Leap 15.2 is EOL since Jan 4th 2022. See
https://lists.opensuse.org/archives/list/security-announce@lists.opensuse.org/thread/DKIXTCVYQEKZ2ANWGLWL5Q77ZMIOTQJ2/
for details.


