### PR TITLE
daemon,systemd: support for journal namespaces when retrieving snap logs (6/n)

### DIFF
--- a/daemon/api_apps.go
+++ b/daemon/api_apps.go
@@ -210,9 +210,6 @@ func getLogs(c *Command, r *http.Request, user *auth.UserState) Response {
 		return AppNotFound("no matching services")
 	}
 
-	// group service names by their namespace
-	namespaces := make(map[string][]string)
-
 	c.d.overlord.State().Lock()
 	allQuotas, err := servicestate.AllQuotas(c.d.overlord.State())
 	if err != nil {
@@ -220,6 +217,9 @@ func getLogs(c *Command, r *http.Request, user *auth.UserState) Response {
 		return InternalError("cannot get service quotas: %v", err)
 	}
 
+	// group service names by their namespace so we can make only one
+	// journctl call per namespace.
+	namespaces := make(map[string][]string)
 	for _, appInfo := range appInfos {
 		opts, err := servicestate.SnapServiceOptions(c.d.overlord.State(), appInfo.Snap.InstanceName(), allQuotas)
 		if err != nil {

--- a/daemon/api_apps_test.go
+++ b/daemon/api_apps_test.go
@@ -850,8 +850,17 @@ func (s *appsSuite) TestLogsFromMultipleNamespaces(c *check.C) {
 	rec := httptest.NewRecorder()
 	s.req(c, req, nil).ServeHTTP(rec, req)
 
+	// The order of namespaces can change, so we sort the service names
+	// and namespaces before checking results to get a stable output.
+	sort.Slice(s.jctlSvcses, func(i, j int) bool {
+		sort.Strings(s.jctlSvcses[i])
+		sort.Strings(s.jctlSvcses[j])
+		return s.jctlSvcses[i][0] < s.jctlSvcses[j][0]
+	})
+	sort.Strings(s.jctlNmspcs)
+
 	c.Check(s.jctlSvcses, check.DeepEquals, [][]string{{"snap.snap-a.svc2.service"}, {"snap.snap-b.svc3.service"}})
-	c.Check(s.jctlNmspcs, check.DeepEquals, []string{"snap-foo", ""})
+	c.Check(s.jctlNmspcs, check.DeepEquals, []string{"", "snap-foo"})
 	c.Check(s.jctlNs, check.DeepEquals, []int{42, 42})
 	c.Check(s.jctlFollows, check.DeepEquals, []bool{false, false})
 

--- a/daemon/response.go
+++ b/daemon/response.go
@@ -286,6 +286,10 @@ type journalLineReaderSeqResponse struct {
 	follow  bool
 }
 
+// readAllLogsSorted combines the output of multiple io.ReadCloser's into a single
+// list of systemd.Log objects. The final list of systemd.Log objects will be sorted by
+// their timestamps, and this function will also close all the readers after reading
+// their logs.
 func (rr *journalLineReaderSeqResponse) readAllLogsSorted() ([]systemd.Log, error) {
 	var logs []systemd.Log
 	for _, r := range rr.readers {

--- a/snap/quota/quota.go
+++ b/snap/quota/quota.go
@@ -257,6 +257,8 @@ func (grp *Group) SliceFileName() string {
 	return buf.String()
 }
 
+// JournalNamespaceName formats the current group's name into an appropriate
+// name to use as the journal log namespace name.
 func (grp *Group) JournalNamespaceName() string {
 	if grp.JournalLimit == nil {
 		return ""

--- a/snap/quota/quota.go
+++ b/snap/quota/quota.go
@@ -257,11 +257,18 @@ func (grp *Group) SliceFileName() string {
 	return buf.String()
 }
 
+func (grp *Group) JournalNamespaceName() string {
+	if grp.JournalLimit == nil {
+		return ""
+	}
+	return "snap-" + grp.Name
+}
+
 // JournalFileName returns the name of the journal configuration file that should
 // be used for this quota group. As an example, a group named "foo" will return a name
 // of journald@snap-foo.conf
 func (grp *Group) JournalFileName() string {
-	return fmt.Sprintf("journald@snap-%s.conf", grp.Name)
+	return fmt.Sprintf("journald@%s.conf", grp.JournalNamespaceName())
 }
 
 // groupQuotaAllocations contains information about current quotas of a group

--- a/systemd/emulation.go
+++ b/systemd/emulation.go
@@ -120,7 +120,7 @@ func (s *emulation) IsActive(service string) (bool, error) {
 	return false, &notImplementedError{"IsActive"}
 }
 
-func (s *emulation) LogReader(services []string, n int, follow bool) (io.ReadCloser, error) {
+func (s *emulation) LogReader(services []string, namespace string, n int, follow bool) (io.ReadCloser, error) {
 	return nil, fmt.Errorf("LogReader")
 }
 

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -270,10 +270,10 @@ func EnsureAtLeast(requiredVersion int) error {
 var osutilStreamCommand = osutil.StreamCommand
 
 // jctl calls journalctl to get the JSON logs of the given services.
-var jctl = func(svcs []string, n int, follow bool) (io.ReadCloser, error) {
+var jctl = func(svcs []string, namespace string, n int, follow bool) (io.ReadCloser, error) {
 	// args will need two entries per service, plus a fixed number (give or take
 	// one) for the initial options.
-	args := make([]string, 0, 2*len(svcs)+6)        // the fixed number is 6
+	args := make([]string, 0, 2*len(svcs)+7)        // the fixed number is 7
 	args = append(args, "-o", "json", "--no-pager") //   3...
 	if n < 0 {
 		args = append(args, "--no-tail") // < 2
@@ -283,6 +283,9 @@ var jctl = func(svcs []string, n int, follow bool) (io.ReadCloser, error) {
 	if follow {
 		args = append(args, "-f") // ... + 1 == 6
 	}
+	if len(namespace) > 0 {
+		args = append(args, fmt.Sprintf("--namespace=%s", namespace)) // ... + 1 == 7
+	}
 
 	for i := range svcs {
 		args = append(args, "-u", svcs[i]) // this is why 2×
@@ -291,7 +294,7 @@ var jctl = func(svcs []string, n int, follow bool) (io.ReadCloser, error) {
 	return osutilStreamCommand("journalctl", args...)
 }
 
-func MockJournalctl(f func(svcs []string, n int, follow bool) (io.ReadCloser, error)) func() {
+func MockJournalctl(f func(svcs []string, namespace string, n int, follow bool) (io.ReadCloser, error)) func() {
 	oldJctl := jctl
 	jctl = f
 	return func() {
@@ -371,7 +374,7 @@ type Systemd interface {
 	// IsActive checks whether the given service is Active
 	IsActive(service string) (bool, error)
 	// LogReader returns a reader for the given services' log.
-	LogReader(services []string, n int, follow bool) (io.ReadCloser, error)
+	LogReader(services []string, namespace string, n int, follow bool) (io.ReadCloser, error)
 	// AddMountUnitFile adds/enables/starts a mount unit.
 	AddMountUnitFile(name, revision, what, where, fstype string) (string, error)
 	// AddMountUnitFileWithOptions adds/enables/starts a mount unit with options.
@@ -628,8 +631,8 @@ func (s *systemd) StartNoBlock(serviceNames []string) error {
 	return err
 }
 
-func (*systemd) LogReader(serviceNames []string, n int, follow bool) (io.ReadCloser, error) {
-	return jctl(serviceNames, n, follow)
+func (*systemd) LogReader(serviceNames []string, namespace string, n int, follow bool) (io.ReadCloser, error) {
+	return jctl(serviceNames, namespace, n, follow)
 }
 
 var statusregex = regexp.MustCompile(`(?m)^(?:(.+?)=(.*)|(.*))?$`)

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -283,7 +283,7 @@ var jctl = func(svcs []string, namespace string, n int, follow bool) (io.ReadClo
 	if follow {
 		args = append(args, "-f") // ... + 1 == 6
 	}
-	if len(namespace) > 0 {
+	if namespace != "" {
 		args = append(args, fmt.Sprintf("--namespace=%s", namespace)) // ... + 1 == 7
 	}
 

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -142,7 +142,7 @@ func formatLogNamespaceSlice(grp *quota.Group) string {
 	if grp.JournalLimit == nil {
 		return ""
 	}
-	return fmt.Sprintf("LogNamespace=snap-%s\n", grp.Name)
+	return fmt.Sprintf("LogNamespace=%s\n", grp.JournalNamespaceName())
 }
 
 // generateGroupSliceFile generates a systemd slice unit definition for the


### PR DESCRIPTION
This is the soon to be last PR in the journal quota series. The last one contains the spread tests. 

This PR contains functionality for the 'snap logs' command to support services which are placed in a journal namespace. If services get passed which are in journal namespace we cannot get all the logs in a single journalctl call anymore, it is now needed to call once per namespace. The logs code now groups services into namespaces and call once per namespace, then combine and sort their output.