### PR TITLE
interfaces/builtin: add more permissions for steam-support

### DIFF
--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -55,6 +55,7 @@ const openglConnectedPlugAppArmor = `
 /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libcudnn{,_adv_infer,_adv_train,_cnn_infer,_cnn_train,_ops_infer,_ops_train}*.so{,.*} rm,
 /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnvrtc{,-builtins}*.so{,.*} rm,
 /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnvToolsExt.so{,.*} rm,
+/var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}nvidia/wine/*.dll rm,
 
 # Support reading the Vulkan ICD files
 /var/lib/snapd/lib/vulkan/ r,

--- a/interfaces/builtin/steam_support.go
+++ b/interfaces/builtin/steam_support.go
@@ -168,7 +168,7 @@ mount options=(rw, rbind) /oldroot/run/systemd/resolve/io.systemd.Resolve -> /ne
 mount options=(rw, rbind) /bindfile* -> /newroot/run/host/container-manager,
 
 # Allow mounting Nvidia drivers into the sandbox
-mount options=(rw, rbind) /oldroot/var/lib/snapd/hostfs/usr/lib/@{multiarch}/* -> /newroot/var/lib/snapd/hostfs/usr/lib/@{multiarch}/*,
+mount options=(rw, rbind) /oldroot/var/lib/snapd/hostfs/usr/lib/@{multiarch}/** -> /newroot/var/lib/snapd/hostfs/usr/lib/@{multiarch}/**,
 
 # Allow masking of certain directories in the sandbox
 mount fstype=tmpfs options=(rw, nosuid, nodev) tmpfs -> /newroot/home/*/snap/steam/common/.local/share/vulkan/implicit_layer.d/,

--- a/interfaces/builtin/steam_support.go
+++ b/interfaces/builtin/steam_support.go
@@ -184,6 +184,7 @@ pivot_root oldroot=/newroot/ /newroot/,
 umount /,
 
 # Permissions needed within sandbox root
+deny /usr/bin/{chfn,chsh,gpasswd,mount,newgrp,passwd,su,sudo,umount} x,
 /usr/bin/** ixr,
 /usr/sbin/** ixr,
 /usr/lib/pressure-vessel/** ixr,

--- a/interfaces/builtin/steam_support.go
+++ b/interfaces/builtin/steam_support.go
@@ -167,6 +167,9 @@ mount options=(rw, rbind) /oldroot/run/dbus/system_bus_socket -> /newroot/run/db
 mount options=(rw, rbind) /oldroot/run/systemd/resolve/io.systemd.Resolve -> /newroot/run/systemd/resolve/io.systemd.Resolve,
 mount options=(rw, rbind) /bindfile* -> /newroot/run/host/container-manager,
 
+# Allow mounting Nvidia drivers into the sandbox
+mount options=(rw, rbind) /oldroot/var/lib/snapd/hostfs/usr/lib/@{multiarch}/* -> /newroot/var/lib/snapd/hostfs/usr/lib/@{multiarch}/*,
+
 # Allow masking of certain directories in the sandbox
 mount fstype=tmpfs options=(rw, nosuid, nodev) tmpfs -> /newroot/home/*/snap/steam/common/.local/share/vulkan/implicit_layer.d/,
 mount fstype=tmpfs options=(rw, nosuid, nodev) tmpfs -> /newroot/run/pressure-vessel/ldso/,
@@ -179,6 +182,8 @@ pivot_root oldroot=/newroot/ /newroot/,
 umount /,
 
 # Permissions needed within sandbox root
+/usr/bin/** ixr,
+/usr/sbin/** ixr,
 /usr/lib/pressure-vessel/** ixr,
 /run/host/** mr,
 /run/pressure-vessel/** mrw,

--- a/interfaces/builtin/steam_support.go
+++ b/interfaces/builtin/steam_support.go
@@ -132,6 +132,8 @@ mount options=(rw, rbind) /oldroot/home/**/usr/ -> /newroot/usr/,
 mount options=(rw, rbind) /oldroot/home/**/usr/etc/** -> /newroot/etc/**,
 mount options=(rw, rbind) /oldroot/home/**/usr/etc/ld.so.cache -> /newroot/run/pressure-vessel/ldso/runtime-ld.so.cache,
 mount options=(rw, rbind) /oldroot/home/**/usr/etc/ld.so.conf -> /newroot/run/pressure-vessel/ldso/runtime-ld.so.conf,
+mount options=(rw, rbind) /oldroot/mnt/{,**} -> /newroot/mnt/{,**},
+mount options=(rw, rbind) /oldroot/media/{,**} -> /newroot/media/{,**},
 
 mount options=(rw, rbind) /oldroot/etc/machine-id -> /newroot/etc/machine-id,
 mount options=(rw, rbind) /oldroot/etc/group -> /newroot/etc/group,


### PR DESCRIPTION
This adds a few additional permissions to the steam-support interface. In particular:

* grant execute access to everything in `/usr/bin` and `/usr/sbin`. Inside the pressure-vessel container, `/usr` is provided by the Steam Runtime, and any of the binaries found there could be used by the sandboxed game. We are not yet trying to transition to a sub-profile for the PV sandbox yet (not really sure how achievable that'd even be), so this also grants exec access to those paths in the base snap before entering the sandbox.
* PV tries to bind mount the individual Nvidia driver files into the sandbox, so we let it do that too. It's possible more is needed after this though.