### PR TITLE
o/snapstate: support migrating snap home as change

### DIFF
--- a/features/features.go
+++ b/features/features.go
@@ -53,7 +53,7 @@ const (
 	DbusActivation
 	// HiddenSnapDataHomeDir controls if the snaps' data dir is ~/.snap/data instead of ~/snap
 	HiddenSnapDataHomeDir
-	// MoveSnapHomeDir controls whether snap user data under ~/snap (or ~/.snap/data) are moved to ~/Snap.
+	// MoveSnapHomeDir controls whether snap user data under ~/snap (or ~/.snap/data) can be moved to ~/Snap.
 	MoveSnapHomeDir
 	// CheckDiskSpaceRemove controls free disk space check on remove whenever automatic snapshot needs to be created.
 	CheckDiskSpaceRemove

--- a/features/features.go
+++ b/features/features.go
@@ -53,6 +53,8 @@ const (
 	DbusActivation
 	// HiddenSnapDataHomeDir controls if the snaps' data dir is ~/.snap/data instead of ~/snap
 	HiddenSnapDataHomeDir
+	// MoveSnapHomeDir controls whether snap user data under ~/snap (or ~/.snap/data) are moved to ~/Snap.
+	MoveSnapHomeDir
 	// CheckDiskSpaceRemove controls free disk space check on remove whenever automatic snapshot needs to be created.
 	CheckDiskSpaceRemove
 	// CheckDiskSpaceInstall controls free disk space check on snap install.
@@ -95,6 +97,7 @@ var featureNames = map[SnapdFeature]string{
 	DbusActivation: "dbus-activation",
 
 	HiddenSnapDataHomeDir: "hidden-snap-folder",
+	MoveSnapHomeDir:       "move-snap-home-dir",
 
 	CheckDiskSpaceInstall: "check-disk-space-install",
 	CheckDiskSpaceRefresh: "check-disk-space-refresh",
@@ -123,6 +126,7 @@ var featuresExported = map[SnapdFeature]bool{
 	ClassicPreservesXdgRuntimeDir: true,
 	RobustMountNamespaceUpdates:   true,
 	HiddenSnapDataHomeDir:         true,
+	MoveSnapHomeDir:               true,
 }
 
 // String returns the name of a snapd feature.

--- a/features/features_test.go
+++ b/features/features_test.go
@@ -50,6 +50,7 @@ func (*featureSuite) TestName(c *C) {
 	c.Check(features.UserDaemons.String(), Equals, "user-daemons")
 	c.Check(features.DbusActivation.String(), Equals, "dbus-activation")
 	c.Check(features.HiddenSnapDataHomeDir.String(), Equals, "hidden-snap-folder")
+	c.Check(features.MoveSnapHomeDir.String(), Equals, "move-snap-home-dir")
 	c.Check(features.CheckDiskSpaceInstall.String(), Equals, "check-disk-space-install")
 	c.Check(features.CheckDiskSpaceRefresh.String(), Equals, "check-disk-space-refresh")
 	c.Check(features.CheckDiskSpaceRemove.String(), Equals, "check-disk-space-remove")
@@ -79,6 +80,7 @@ func (*featureSuite) TestIsExported(c *C) {
 	c.Check(features.UserDaemons.IsExported(), Equals, false)
 	c.Check(features.DbusActivation.IsExported(), Equals, false)
 	c.Check(features.HiddenSnapDataHomeDir.IsExported(), Equals, true)
+	c.Check(features.MoveSnapHomeDir.IsExported(), Equals, true)
 	c.Check(features.CheckDiskSpaceInstall.IsExported(), Equals, false)
 	c.Check(features.CheckDiskSpaceRefresh.IsExported(), Equals, false)
 	c.Check(features.CheckDiskSpaceRemove.IsExported(), Equals, false)
@@ -116,6 +118,7 @@ func (*featureSuite) TestIsEnabledWhenUnset(c *C) {
 	c.Check(features.UserDaemons.IsEnabledWhenUnset(), Equals, false)
 	c.Check(features.DbusActivation.IsEnabledWhenUnset(), Equals, true)
 	c.Check(features.HiddenSnapDataHomeDir.IsEnabledWhenUnset(), Equals, false)
+	c.Check(features.MoveSnapHomeDir.IsEnabledWhenUnset(), Equals, false)
 	c.Check(features.CheckDiskSpaceInstall.IsEnabledWhenUnset(), Equals, false)
 	c.Check(features.CheckDiskSpaceRefresh.IsEnabledWhenUnset(), Equals, false)
 	c.Check(features.CheckDiskSpaceRemove.IsEnabledWhenUnset(), Equals, false)
@@ -128,6 +131,7 @@ func (*featureSuite) TestControlFile(c *C) {
 	c.Check(features.ParallelInstances.ControlFile(), Equals, "/var/lib/snapd/features/parallel-instances")
 	c.Check(features.RobustMountNamespaceUpdates.ControlFile(), Equals, "/var/lib/snapd/features/robust-mount-namespace-updates")
 	c.Check(features.HiddenSnapDataHomeDir.ControlFile(), Equals, "/var/lib/snapd/features/hidden-snap-folder")
+	c.Check(features.MoveSnapHomeDir.ControlFile(), Equals, "/var/lib/snapd/features/move-snap-home-dir")
 	// Features that are not exported don't have a control file.
 	c.Check(features.Layouts.ControlFile, PanicMatches, `cannot compute the control file of feature "layouts" because that feature is not exported`)
 }

--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -112,7 +112,7 @@ type managerBackend interface {
 	// ~/.snap/data migration related
 	HideSnapData(snapName string) error
 	UndoHideSnapData(snapName string) error
-	InitExposedSnapHome(snapName string, rev snap.Revision) (*backend.UndoInfo, error)
+	InitExposedSnapHome(snapName string, rev snap.Revision, opts *dirs.SnapDirOptions) (*backend.UndoInfo, error)
 	UndoInitExposedSnapHome(snapName string, undoInfo *backend.UndoInfo) error
 	InitXDGDirs(info *snap.Info) error
 }

--- a/overlord/snapstate/backend/copydata.go
+++ b/overlord/snapstate/backend/copydata.go
@@ -272,12 +272,10 @@ type UndoInfo struct {
 }
 
 // InitExposedSnapHome creates and initializes ~/Snap/<snapName> based on the
-// specified revision. Must be called after the snap has been migrated. If no
-// error occurred, returns a non-nil undoInfo so that the operation can be undone.
-// If an error occurred, an attempt is made to undo so no undoInfo is returned.
-func (b Backend) InitExposedSnapHome(snapName string, rev snap.Revision) (undoInfo *UndoInfo, err error) {
-	opts := &dirs.SnapDirOptions{HiddenSnapDataDir: true}
-
+// specified revision. If no error occurred, returns a non-nil undoInfo so that
+// the operation can be undone. If an error occurred, an attempt is made to undo
+// so no undoInfo is returned.
+func (b Backend) InitExposedSnapHome(snapName string, rev snap.Revision, opts *dirs.SnapDirOptions) (undoInfo *UndoInfo, err error) {
 	users, err := allUsers(opts)
 	if err != nil {
 		return nil, err

--- a/overlord/snapstate/backend/copydata_test.go
+++ b/overlord/snapstate/backend/copydata_test.go
@@ -973,7 +973,7 @@ func (s *copydataSuite) TestInitSnapUserHome(c *C) {
 	dirPath := filepath.Join(revDir, "dir")
 	c.Assert(os.Mkdir(dirPath, 0775), IsNil)
 
-	undoInfo, err := s.be.InitExposedSnapHome(snapName, rev)
+	undoInfo, err := s.be.InitExposedSnapHome(snapName, rev, opts)
 	c.Assert(err, IsNil)
 	exposedHome := filepath.Join(homeDir, dirs.ExposedSnapHomeDir, snapName)
 	c.Check(undoInfo.Created, DeepEquals, []string{exposedHome})
@@ -1025,7 +1025,7 @@ func (s *copydataSuite) TestInitExposedHomeIgnoreXDGDirs(c *C) {
 	localPath := filepath.Join(revDir, ".local", "share")
 	c.Assert(os.MkdirAll(localPath, 0700), IsNil)
 
-	undoInfo, err := s.be.InitExposedSnapHome(snapName, rev)
+	undoInfo, err := s.be.InitExposedSnapHome(snapName, rev, opts)
 	c.Assert(err, IsNil)
 	exposedHome := snap.UserExposedHomeDir(homeDir, snapName)
 	c.Check(undoInfo.Created, DeepEquals, []string{exposedHome})
@@ -1074,7 +1074,7 @@ func (s *copydataSuite) TestInitSnapFailOnFirstErr(c *C) {
 	rev, err := snap.ParseRevision("2")
 	c.Assert(err, IsNil)
 
-	undoInfo, err := s.be.InitExposedSnapHome(snapName, rev)
+	undoInfo, err := s.be.InitExposedSnapHome(snapName, rev, nil)
 	c.Assert(err, ErrorMatches, ".*: boom")
 	c.Check(undoInfo, IsNil)
 
@@ -1123,7 +1123,7 @@ func (s *copydataSuite) TestInitSnapUndoOnErr(c *C) {
 	rev, err := snap.ParseRevision("2")
 	c.Assert(err, IsNil)
 
-	undoInfo, err := s.be.InitExposedSnapHome(snapName, rev)
+	undoInfo, err := s.be.InitExposedSnapHome(snapName, rev, nil)
 	c.Assert(err, ErrorMatches, ".*: boom")
 	c.Check(undoInfo, IsNil)
 
@@ -1152,7 +1152,7 @@ func (s *copydataSuite) TestInitSnapNothingToCopy(c *C) {
 	rev, err := snap.ParseRevision("2")
 	c.Assert(err, IsNil)
 
-	undoInfo, err := s.be.InitExposedSnapHome(snapName, rev)
+	undoInfo, err := s.be.InitExposedSnapHome(snapName, rev, nil)
 	c.Assert(err, IsNil)
 	c.Check(undoInfo.Created, DeepEquals, []string{snap.UserExposedHomeDir(usr.HomeDir, snapName)})
 
@@ -1187,7 +1187,7 @@ func (s *copydataSuite) TestInitAlreadyExistsFile(c *C) {
 	rev, err := snap.ParseRevision("2")
 	c.Assert(err, IsNil)
 
-	undoInfo, err := s.be.InitExposedSnapHome(snapName, rev)
+	undoInfo, err := s.be.InitExposedSnapHome(snapName, rev, nil)
 	c.Assert(err, ErrorMatches, fmt.Sprintf("cannot initialize new user HOME %q: already exists but is not a directory", newHome))
 	c.Check(undoInfo, IsNil)
 
@@ -1217,7 +1217,7 @@ func (s *copydataSuite) TestInitAlreadyExistsDir(c *C) {
 	rev, err := snap.ParseRevision("2")
 	c.Assert(err, IsNil)
 
-	undoInfo, err := s.be.InitExposedSnapHome(snapName, rev)
+	undoInfo, err := s.be.InitExposedSnapHome(snapName, rev, nil)
 	c.Assert(err, IsNil)
 	c.Check(undoInfo.Created, HasLen, 0)
 

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -1308,7 +1308,7 @@ func (f *fakeSnappyBackend) UndoHideSnapData(snapName string) error {
 	return f.maybeErrForLastOp()
 }
 
-func (f *fakeSnappyBackend) InitExposedSnapHome(snapName string, rev snap.Revision) (*backend.UndoInfo, error) {
+func (f *fakeSnappyBackend) InitExposedSnapHome(snapName string, rev snap.Revision, opts *dirs.SnapDirOptions) (*backend.UndoInfo, error) {
 	f.appendOp(&fakeOp{op: "init-exposed-snap-home", name: snapName, revno: rev})
 
 	if err := f.maybeErrForLastOp(); err != nil {

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1282,7 +1282,7 @@ func (m *SnapManager) doCopySnapData(t *state.Task, _ *tomb.Tomb) (err error) {
 		snapsup.MigratedHidden = true
 		fallthrough
 	case home:
-		undo, err := m.backend.InitExposedSnapHome(snapName, newInfo.Revision)
+		undo, err := m.backend.InitExposedSnapHome(snapName, newInfo.Revision, opts.getSnapDirOpts())
 		if err != nil {
 			return err
 		}
@@ -3658,6 +3658,68 @@ func (m *SnapManager) doConditionalAutoRefresh(t *state.Task, tomb *tomb.Tomb) e
 
 	st.EnsureBefore(0)
 	return nil
+}
+
+func (m *SnapManager) doMigrateSnapHome(t *state.Task, tomb *tomb.Tomb) error {
+	st := t.State()
+	st.Lock()
+	snapsup, snapst, err := snapSetupAndState(t)
+	st.Unlock()
+	if err != nil {
+		return err
+	}
+
+	st.Lock()
+	opts, err := getDirMigrationOpts(st, snapst, snapsup)
+	st.Unlock()
+	if err != nil {
+		return err
+	}
+
+	dirOpts := opts.getSnapDirOpts()
+	undo, err := m.backend.InitExposedSnapHome(snapsup.InstanceName(), snapsup.Revision(), dirOpts)
+	if err != nil {
+		return err
+	}
+
+	st.Lock()
+	t.Set("undo-exposed-home-init", undo)
+	st.Unlock()
+	snapsup.MigratedToExposedHome = true
+
+	st.Lock()
+	defer st.Unlock()
+	return SetTaskSnapSetup(t, snapsup)
+}
+
+func (m *SnapManager) undoMigrateSnapHome(t *state.Task, tomb *tomb.Tomb) error {
+	st := t.State()
+	st.Lock()
+	snapsup, snapst, err := snapSetupAndState(t)
+	st.Unlock()
+	if err != nil {
+		return err
+	}
+
+	var undo backend.UndoInfo
+
+	st.Lock()
+	err = t.Get("undo-exposed-home-init", &undo)
+	st.Unlock()
+	if err != nil {
+		return err
+	}
+
+	if err := m.backend.UndoInitExposedSnapHome(snapsup.InstanceName(), &undo); err != nil {
+		return err
+	}
+
+	snapsup.MigratedToExposedHome = false
+	snapst.MigratedToExposedHome = false
+
+	st.Lock()
+	defer st.Unlock()
+	return writeMigrationStatus(t, snapst, snapsup)
 }
 
 // maybeRestoreValidationSetsAndRevertSnaps restores validation-sets to their

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -3683,12 +3683,10 @@ func (m *SnapManager) doMigrateSnapHome(t *state.Task, tomb *tomb.Tomb) error {
 	}
 
 	st.Lock()
+	defer st.Unlock()
 	t.Set("undo-exposed-home-init", undo)
-	st.Unlock()
 	snapsup.MigratedToExposedHome = true
 
-	st.Lock()
-	defer st.Unlock()
 	return SetTaskSnapSetup(t, snapsup)
 }
 

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -528,6 +528,7 @@ func Manager(st *state.State, runner *state.TaskRunner) (*SnapManager, error) {
 
 	// misc
 	runner.AddHandler("switch-snap", m.doSwitchSnap, nil)
+	runner.AddHandler("migrate-snap-home", m.doMigrateSnapHome, m.undoMigrateSnapHome)
 
 	// control serialisation
 	runner.AddBlocked(m.blockedTask)

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -2484,12 +2484,12 @@ func MigrateHome(st *state.State, snaps []string) ([]*state.TaskSet, error) {
 			tasks = append(tasks, t)
 		}
 
-		stop := st.NewTask("stop-snap-services", fmt.Sprintf(i18n.G("Stop snap %q services"), snapsup.InstanceName()))
+		stop := st.NewTask("stop-snap-services", fmt.Sprintf(i18n.G("Stop snap %q services"), name))
 		stop.Set("stop-reason", "home-migration")
 		addTask(stop)
 		prev = stop
 
-		unlink := st.NewTask("unlink-current-snap", fmt.Sprintf(i18n.G("Make current revision for snap %q unavailable"), snapsup.InstanceName()))
+		unlink := st.NewTask("unlink-current-snap", fmt.Sprintf(i18n.G("Make current revision for snap %q unavailable"), name))
 		addTask(unlink)
 		prev = unlink
 
@@ -2498,12 +2498,12 @@ func MigrateHome(st *state.State, snaps []string) ([]*state.TaskSet, error) {
 		prev = migrate
 
 		// finalize (wrappers+current symlink)
-		linkSnap := st.NewTask("link-snap", fmt.Sprintf(i18n.G("Make snap %q (%s) available to the system"), snapsup.InstanceName(), si.Revision))
+		linkSnap := st.NewTask("link-snap", fmt.Sprintf(i18n.G("Make snap %q (%s) available to the system"), name, si.Revision))
 		addTask(linkSnap)
 		prev = linkSnap
 
 		// run new services
-		startSnapServices := st.NewTask("start-snap-services", fmt.Sprintf(i18n.G("Start snap %q (%s) services"), snapsup.InstanceName(), si.Revision))
+		startSnapServices := st.NewTask("start-snap-services", fmt.Sprintf(i18n.G("Start snap %q (%s) services"), name, si.Revision))
 		addTask(startSnapServices)
 		prev = startSnapServices
 

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2021 Canonical Ltd
+ * Copyright (C) 2016-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -1152,6 +1152,13 @@ func InstallWithDeviceContext(ctx context.Context, st *state.State, name string,
 	return doInstall(st, &snapst, snapsup, 0, fromChange, nil)
 }
 
+// InstallPathMany returns a set of tasks for installing snaps from a file paths
+// and snap.Infos.
+//
+// The state must be locked by the caller.
+// The provided SideInfos can contain just a name which results in a
+// local revision and sideloading, or full metadata in which case
+// the snaps will appear as installed from the store.
 func InstallPathMany(ctx context.Context, st *state.State, sideInfos []*snap.SideInfo, paths []string, userID int, flags *Flags) ([]*state.TaskSet, error) {
 	if flags == nil {
 		flags = &Flags{}
@@ -2429,6 +2436,87 @@ func checkDiskSpace(st *state.State, changeKind string, infos []minimalInstallIn
 	}
 
 	return nil
+}
+
+// MigrateHome migrates a set of snaps to use a ~/Snap sub-directory as HOME.
+// The state must be locked by the caller.
+func MigrateHome(st *state.State, snaps []string) ([]*state.TaskSet, error) {
+	tr := config.NewTransaction(st)
+	moveDir, err := features.Flag(tr, features.MoveSnapHomeDir)
+	if err != nil {
+		return nil, err
+	}
+
+	if !moveDir {
+		_, confName := features.MoveSnapHomeDir.ConfigOption()
+		return nil, fmt.Errorf("cannot migrate to ~/Snap: flag %q is not set", confName)
+	}
+
+	allSnaps, err := All(st)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, name := range snaps {
+		if snapst, ok := allSnaps[name]; !ok {
+			return nil, snap.NotInstalledError{Snap: name}
+		} else if snapst.MigratedToExposedHome {
+			return nil, fmt.Errorf("cannot migrate %q to ~/Snap: already migrated", name)
+		}
+	}
+
+	var tss []*state.TaskSet
+	for _, name := range snaps {
+		si := allSnaps[name].CurrentSideInfo()
+		snapsup := &SnapSetup{
+			SideInfo: si,
+		}
+
+		var tasks []*state.Task
+		prepare := st.NewTask("prepare-snap", fmt.Sprintf(i18n.G("Prepare snap %q (%s)"), name, si.Revision))
+		prepare.Set("snap-setup", snapsup)
+		tasks = append(tasks, prepare)
+
+		prev := prepare
+		addTask := func(t *state.Task) {
+			t.Set("snap-setup-task", prepare.ID())
+			t.WaitFor(prev)
+			tasks = append(tasks, t)
+		}
+
+		stop := st.NewTask("stop-snap-services", fmt.Sprintf(i18n.G("Stop snap %q services"), snapsup.InstanceName()))
+		stop.Set("stop-reason", "home-migration")
+		addTask(stop)
+		prev = stop
+
+		unlink := st.NewTask("unlink-current-snap", fmt.Sprintf(i18n.G("Make current revision for snap %q unavailable"), snapsup.InstanceName()))
+		addTask(unlink)
+		prev = unlink
+
+		migrate := st.NewTask("migrate-snap-home", fmt.Sprintf(i18n.G("Migrate %q to ~/Snap"), name))
+		addTask(migrate)
+		prev = migrate
+
+		// finalize (wrappers+current symlink)
+		linkSnap := st.NewTask("link-snap", fmt.Sprintf(i18n.G("Make snap %q (%s) available to the system"), snapsup.InstanceName(), si.Revision))
+		addTask(linkSnap)
+		prev = linkSnap
+
+		// run new services
+		startSnapServices := st.NewTask("start-snap-services", fmt.Sprintf(i18n.G("Start snap %q (%s) services"), snapsup.InstanceName(), si.Revision))
+		addTask(startSnapServices)
+		prev = startSnapServices
+
+		var ts state.TaskSet
+		for _, t := range tasks {
+			ts.AddTask(t)
+		}
+
+		ts.JoinLane(st.NewLane())
+		tss = append(tss, &ts)
+	}
+
+	return tss, nil
 }
 
 // LinkNewBaseOrKernel creates a new task set with prepare/link-snap, and

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -8155,6 +8155,177 @@ func (s *snapmgrTestSuite) TestRemodelAddGadgetAssetTasks(c *C) {
 	c.Assert(tsNew, IsNil)
 }
 
+func (s *snapmgrTestSuite) TestMigrateHome(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	tr := config.NewTransaction(s.state)
+	c.Assert(tr.Set("core", "experimental.move-snap-home-dir", true), IsNil)
+	tr.Commit()
+
+	si := &snap.SideInfo{RealName: "some-snap", Revision: snap.R(3)}
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active:   true,
+		Sequence: []*snap.SideInfo{si},
+		Current:  si.Revision,
+		SnapType: "app",
+	})
+
+	chg := s.state.NewChange("migrate-home", "...")
+	tss, err := snapstate.MigrateHome(s.state, []string{"some-snap"})
+	c.Assert(err, IsNil)
+	for _, ts := range tss {
+		chg.AddAll(ts)
+	}
+
+	defer s.se.Stop()
+	s.settle(c)
+
+	c.Assert(tss, HasLen, 1)
+	c.Assert(taskNames(tss[0].Tasks()), DeepEquals, []string{
+		`prepare-snap`,
+		`stop-snap-services`,
+		`unlink-current-snap`,
+		`migrate-snap-home`,
+		`link-snap`,
+		`start-snap-services`,
+	})
+
+	c.Assert(chg.Err(), IsNil)
+	c.Assert(chg.IsReady(), Equals, true)
+
+	var undo backend.UndoInfo
+	migrateTask := findLastTask(chg, "migrate-snap-home")
+	c.Assert(migrateTask.Get("undo-exposed-home-init", &undo), IsNil)
+	c.Assert(undo.Created, HasLen, 1)
+
+	s.fakeBackend.ops.MustFindOp(c, "init-exposed-snap-home")
+
+	// check migration is off in state and seq file
+	assertMigrationState(c, s.state, "some-snap", &dirs.SnapDirOptions{MigratedToExposedHome: true})
+}
+
+func (s *snapmgrTestSuite) TestMigrateHomeUndo(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	tr := config.NewTransaction(s.state)
+	c.Assert(tr.Set("core", "experimental.move-snap-home-dir", true), IsNil)
+	tr.Commit()
+
+	si := &snap.SideInfo{RealName: "some-snap", Revision: snap.R(3)}
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active:   true,
+		Sequence: []*snap.SideInfo{si},
+		Current:  si.Revision,
+	})
+
+	chg := s.state.NewChange("migrate-home", "...")
+	tss, err := snapstate.MigrateHome(s.state, []string{"some-snap"})
+	c.Assert(err, IsNil)
+
+	c.Assert(tss, HasLen, 1)
+	c.Assert(taskNames(tss[0].Tasks()), DeepEquals, []string{
+		`prepare-snap`,
+		`stop-snap-services`,
+		`unlink-current-snap`,
+		`migrate-snap-home`,
+		`link-snap`,
+		`start-snap-services`,
+	})
+
+	for _, ts := range tss {
+		chg.AddAll(ts)
+	}
+
+	// fail the change after the link-snap task (after state is saved)
+	s.o.TaskRunner().AddHandler("fail", func(*state.Task, *tomb.Tomb) error {
+		return errors.New("boom")
+	}, nil)
+
+	failingTask := s.state.NewTask("fail", "expected failure")
+	chg.AddTask(failingTask)
+	linkTask := findLastTask(chg, "link-snap")
+	failingTask.WaitFor(linkTask)
+	for _, lane := range linkTask.Lanes() {
+		failingTask.JoinLane(lane)
+	}
+
+	defer s.se.Stop()
+	s.settle(c)
+
+	c.Assert(chg.Err(), ErrorMatches, `(.|\s)* expected failure \(boom\)`)
+	c.Assert(chg.IsReady(), Equals, true)
+
+	s.fakeBackend.ops.MustFindOp(c, "init-exposed-snap-home")
+	s.fakeBackend.ops.MustFindOp(c, "undo-init-exposed-snap-home")
+
+	// check migration is off in state and seq file
+	assertMigrationState(c, s.state, "some-snap", nil)
+}
+
+func (s *snapmgrTestSuite) TestMigrateHomeFailIfUnsetFeature(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	tss, err := snapstate.MigrateHome(s.state, []string{"some-snap"})
+	c.Check(tss, IsNil)
+	c.Assert(err, ErrorMatches, `cannot migrate to ~/Snap: flag "experimental.move-snap-home-dir" is not set`)
+}
+
+func (s *snapmgrTestSuite) TestMigrateHomeFailIfSnapNotInstalled(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	tr := config.NewTransaction(s.state)
+	c.Assert(tr.Set("core", "experimental.move-snap-home-dir", true), IsNil)
+	tr.Commit()
+
+	si := &snap.SideInfo{RealName: "some-snap", Revision: snap.R(3)}
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active:   true,
+		Sequence: []*snap.SideInfo{si},
+		Current:  si.Revision,
+		SnapType: "app",
+	})
+
+	tss, err := snapstate.MigrateHome(s.state, []string{"some-snap", "other-snap"})
+	c.Check(tss, IsNil)
+	c.Assert(err, ErrorMatches, `snap "other-snap" is not installed`)
+}
+
+func (s *snapmgrTestSuite) TestMigrateHomeFailIfAlreadyMigrated(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	tr := config.NewTransaction(s.state)
+	c.Assert(tr.Set("core", "experimental.move-snap-home-dir", true), IsNil)
+	tr.Commit()
+
+	si := &snap.SideInfo{RealName: "some-snap", Revision: snap.R(3)}
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active:                true,
+		Sequence:              []*snap.SideInfo{si},
+		Current:               si.Revision,
+		SnapType:              "app",
+		MigratedToExposedHome: true,
+	})
+
+	tss, err := snapstate.MigrateHome(s.state, []string{"some-snap"})
+	c.Check(tss, IsNil)
+	c.Assert(err, ErrorMatches, `cannot migrate "some-snap" to ~/Snap: already migrated`)
+}
+
+func taskNames(tasks []*state.Task) []string {
+	var names []string
+
+	for _, t := range tasks {
+		names = append(names, t.Kind())
+	}
+
+	return names
+}
+
 func (s *snapmgrTestSuite) TestMigrationTriggers(c *C) {
 	c.Skip("TODO:Snap-folder: no automatic migration for core22 snaps to ~/Snap folder for now")
 


### PR DESCRIPTION
This adds an experimental feature and snapstate support for migrating a snap's home to ~/Snap. This will be used for a debug command to experimentally migrate snaps' homes.
