### PR TITLE
secboot/keymgr, cmd/snap-fde-keymgr: two step encryption key change

### DIFF
--- a/cmd/snap-fde-keymgr/export_test.go
+++ b/cmd/snap-fde-keymgr/export_test.go
@@ -51,9 +51,15 @@ func MockRemoveRecoveryKeyFromLUKSUsingKey(f func(key keys.EncryptionKey, dev st
 	return restore
 }
 
-func MockChangeLUKSEncryptionKey(f func(newKey keys.EncryptionKey, dev string) error) (restore func()) {
-	restore = testutil.Backup(&keymgrChangeLUKSDeviceEncryptionKey)
-	keymgrChangeLUKSDeviceEncryptionKey = f
+func MockStageLUKSEncryptionKeyChange(f func(newKey keys.EncryptionKey, dev string) error) (restore func()) {
+	restore = testutil.Backup(&keymgrStageLUKSDeviceEncryptionKeyChange)
+	keymgrStageLUKSDeviceEncryptionKeyChange = f
+	return restore
+}
+
+func MockTransitionLUKSEncryptionKeyChange(f func(newKey keys.EncryptionKey, dev string) error) (restore func()) {
+	restore = testutil.Backup(&keymgrTransitionLUKSDeviceEncryptionKeyChange)
+	keymgrTransitionLUKSDeviceEncryptionKeyChange = f
 	return restore
 }
 

--- a/secboot/keymgr/export_test.go
+++ b/secboot/keymgr/export_test.go
@@ -30,10 +30,4 @@ func MockGetDiskUnlockKeyFromKernel(f func(prefix, devicePath string, remove boo
 	return restore
 }
 
-func MockAddKeyToUserKeyring(f func(key []byte, devicePath, purpose, prefix string) error) (restore func()) {
-	restore = testutil.Backup(&keyringAddKeyToUserKeyring)
-	keyringAddKeyToUserKeyring = f
-	return restore
-}
-
 var RecoveryKDF = recoveryKDF

--- a/secboot/keymgr/keymgr_luks2.go
+++ b/secboot/keymgr/keymgr_luks2.go
@@ -204,7 +204,7 @@ func TransitionLUKSDeviceEncryptionKeyChange(newKey keys.EncryptionKey, dev stri
 	}
 
 	// the expected state is as follows:
-	// keys lot 0 - the old encryption key
+	// key slot 0 - the old encryption key
 	// key slot 2 - the new encryption key (added during --stage)
 	// the desired state is:
 	// key slot 0 - the new encryption key
@@ -212,10 +212,11 @@ func TransitionLUKSDeviceEncryptionKeyChange(newKey keys.EncryptionKey, dev stri
 	// it is possible that the system was rebooted right after key slot 0 was
 	// populated with the new key and key slot 2 was emptied
 
-	// there is no state information on disk which would if scenario 1
-	// occurred and to which stage it was executed, but we need to find out
-	// if key slot 2 is in use (as the caller believes that a key was staged
-	// earlier); do this indirectly by trying to add a key to key slot 2
+	// there is no state information on disk which would tell if the
+	// scenario 1 above occurred and to which stage it was executed, but we
+	// need to find out if key slot 2 is in use (as the caller believes that
+	// a key was staged earlier); do this indirectly by trying to add a key
+	// to key slot 2
 
 	// TODO rather than inspecting the errors, parse the LUKS2 headers
 

--- a/tests/main/uc20-create-partitions-encrypt/task.yaml
+++ b/tests/main/uc20-create-partitions-encrypt/task.yaml
@@ -71,6 +71,11 @@ restore: |
         losetup -d "$LOOP"
         losetup -l | NOMATCH "$LOOP"
     fi
+
+    # purge the key we added
+    systemd-run --pipe --wait --collect -p KeyringMode=inherit -- \
+        /usr/bin/keyctl purge -s user "ubuntu-fde:${LOOP}p4:unlock" || true
+
     apt autoremove -y cryptsetup
 
     rm -Rf /run/mnt
@@ -217,6 +222,44 @@ execute: |
     echo "Check the disk-mapping.json has expected contents"
     not cryptsetup open --key-file recovery-key "${LOOP}p5" test-data
     not cryptsetup open --key-file recovery-key "${LOOP}p4" test-save
+
+    echo "Verify encryption key change"
+    # first get the relevant ubuntu-save key to the user keyring
+    systemd-run --pipe --wait --collect -p KeyringMode=inherit -- \
+        /usr/bin/keyctl padd user "ubuntu-fde:${LOOP}p4:unlock" @u < save-key
+
+    # the new key is all ones
+    printf "11111111111111111111111111111111" > new-save-key
+    echo '{"key":"MTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTE="}' | \
+        systemd-run --pipe --wait --collect -p KeyringMode=inherit -- \
+            /usr/lib/snapd/snap-fde-keymgr change-encryption-key \
+                --device "${LOOP}p4" --stage
+    # now it's possible to open save with both the old and new keys
+    cryptsetup open --key-file save-key "${LOOP}p4" test-save
+    cryptsetup close /dev/mapper/test-save
+    cryptsetup open --key-file new-save-key "${LOOP}p4" test-save
+    cryptsetup close /dev/mapper/test-save
+
+    # now transition the key
+    echo '{"key":"MTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTE="}' | \
+        systemd-run --pipe --wait --collect -p KeyringMode=inherit -- \
+            /usr/lib/snapd/snap-fde-keymgr change-encryption-key \
+                --device "${LOOP}p4" --transition
+
+    # the old key no longer works
+    not cryptsetup open --key-file save-key "${LOOP}p4" test-save
+    # but the new key does
+    cryptsetup open --key-file new-save-key "${LOOP}p4" test-save
+    cryptsetup close /dev/mapper/test-save
+
+    # try to transition once more, such that we execute a reboot like scenario
+    echo '{"key":"MTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTE="}' | \
+        systemd-run --pipe --wait --collect -p KeyringMode=inherit -- \
+            /usr/lib/snapd/snap-fde-keymgr change-encryption-key \
+                --device "${LOOP}p4" --transition
+    # and opening should still work
+    cryptsetup open --key-file new-save-key "${LOOP}p4" test-save
+    cryptsetup close /dev/mapper/test-save
 
     LOOP_BASENAME="$(basename "$LOOP")"
 

--- a/tests/main/uc20-create-partitions-encrypt/task.yaml
+++ b/tests/main/uc20-create-partitions-encrypt/task.yaml
@@ -84,6 +84,11 @@ debug: |
     cat /proc/partitions
 
 execute: |
+    channel=20
+    if os.query is-jammy; then
+        channel=22
+    fi
+
     # this test simulates a reinstall, to clear the TPM this requires
     # a reboot so the losetup has to be redone
     if [ "$SPREAD_REBOOT" = 1 ]; then
@@ -131,8 +136,13 @@ execute: |
     sfdisk -d "$LOOP" | MATCH "^${LOOP}p1 .*size=\s*2048, type=21686148-6449-6E6F-744E-656564454649,.*BIOS Boot"
     sfdisk -d "$LOOP" | MATCH "^${LOOP}p2 .*size=\s*2457600, type=C12A7328-F81F-11D2-BA4B-00A0C93EC93B,.*ubuntu-seed"
     sfdisk -d "$LOOP" | MATCH "^${LOOP}p3 .*size=\s*1536000, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4,.*ubuntu-boot"
-    sfdisk -d "$LOOP" | MATCH "^${LOOP}p4 .*size=\s*32768, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4,.*ubuntu-save"
-    sfdisk -d "$LOOP" | MATCH "^${LOOP}p5 .*size=\s*15500753, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4,.*ubuntu-data"
+    if [ "$channel" = "20" ]; then
+        sfdisk -d "$LOOP" | MATCH "^${LOOP}p4 .*size=\s*32768, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4,.*ubuntu-save"
+        sfdisk -d "$LOOP" | MATCH "^${LOOP}p5 .*size=\s*15500753, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4,.*ubuntu-data"
+    else
+        sfdisk -d "$LOOP" | MATCH "^${LOOP}p4 .*size=\s*65536, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4,.*ubuntu-save"
+        sfdisk -d "$LOOP" | MATCH "^${LOOP}p5 .*size=\s*15467985, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4,.*ubuntu-data"
+    fi
 
     not cryptsetup isLuks "${LOOP}p1"
     not cryptsetup isLuks "${LOOP}p2"
@@ -315,8 +325,13 @@ execute: |
     jq -r '.pc.structure[3]."filesystem-label"' < "$DISK_MAPPING_JSON" | MATCH ubuntu-save-enc
     jq -r '.pc.structure[3]."partition-label"'  < "$DISK_MAPPING_JSON" | MATCH ubuntu-save
     jq -r '.pc.structure[3].id'                 < "$DISK_MAPPING_JSON" | MATCH ""
-    jq -r '.pc.structure[3].offset'             < "$DISK_MAPPING_JSON" | MATCH 2046820352
-    jq -r '.pc.structure[3].size'               < "$DISK_MAPPING_JSON" | MATCH 16777216
+    if [ "$channel" = "20" ]; then
+        jq -r '.pc.structure[3].offset'         < "$DISK_MAPPING_JSON" | MATCH 2046820352
+        jq -r '.pc.structure[3].size'           < "$DISK_MAPPING_JSON" | MATCH 16777216
+    else
+        jq -r '.pc.structure[3].offset'         < "$DISK_MAPPING_JSON" | MATCH 2046820352
+        jq -r '.pc.structure[3].size'           < "$DISK_MAPPING_JSON" | MATCH 33554432
+    fi
 
     # fifth structure - ubuntu-data-enc
     jq -r '.pc.structure[4]."device-path"'      < "$DISK_MAPPING_JSON" | MATCH "/sys/devices/virtual/block/$LOOP_BASENAME/${LOOP_BASENAME}p5"
@@ -324,5 +339,10 @@ execute: |
     jq -r '.pc.structure[4]."filesystem-label"' < "$DISK_MAPPING_JSON" | MATCH ubuntu-data-enc
     jq -r '.pc.structure[4]."partition-label"'  < "$DISK_MAPPING_JSON" | MATCH ubuntu-data
     jq -r '.pc.structure[4].id'                 < "$DISK_MAPPING_JSON" | MATCH ""
-    jq -r '.pc.structure[4].offset'             < "$DISK_MAPPING_JSON" | MATCH 2063597568
-    jq -r '.pc.structure[4].size'               < "$DISK_MAPPING_JSON" | MATCH 7936385536
+    if [ "$channel" = "20" ]; then
+        jq -r '.pc.structure[4].offset'         < "$DISK_MAPPING_JSON" | MATCH 2063597568
+        jq -r '.pc.structure[4].size'           < "$DISK_MAPPING_JSON" | MATCH 7936385536
+    else
+        jq -r '.pc.structure[4].offset'         < "$DISK_MAPPING_JSON" | MATCH 2080374784
+        jq -r '.pc.structure[4].size'           < "$DISK_MAPPING_JSON" | MATCH 7919608320
+    fi

--- a/tests/main/uc20-create-partitions/task.yaml
+++ b/tests/main/uc20-create-partitions/task.yaml
@@ -74,6 +74,11 @@ debug: |
     udevadm info --query property "${LOOP}p5" || true
 
 execute: |
+    channel=20
+    if os.query is-jammy; then
+        channel=22
+    fi
+
     LOOP="$(cat loop.txt)"
 
     echo "Run the snap-bootstrap tool"
@@ -164,8 +169,13 @@ execute: |
     sfdisk -l "$LOOP" | MATCH "${LOOP}p1 .* 1M\s* BIOS boot"
     sfdisk -l "$LOOP" | MATCH "${LOOP}p2 .* 1\.2G\s* EFI System"
     sfdisk -l "$LOOP" | MATCH "${LOOP}p3 .* 750M\s* Linux filesystem"
-    sfdisk -l "$LOOP" | MATCH "${LOOP}p4 .* 16M\s* Linux filesystem"
-    sfdisk -l "$LOOP" | MATCH "${LOOP}p5 .* 16\.7G\s* Linux filesystem"
+    if [ "$channel" = "20" ]; then
+        sfdisk -l "$LOOP" | MATCH "${LOOP}p4 .* 16M\s* Linux filesystem"
+        sfdisk -l "$LOOP" | MATCH "${LOOP}p5 .* 16\.7G\s* Linux filesystem"
+    else
+        sfdisk -l "$LOOP" | MATCH "${LOOP}p4 .* 32M\s* Linux filesystem"
+        sfdisk -l "$LOOP" | MATCH "${LOOP}p5 .* 16\.7G\s* Linux filesystem"
+    fi
 
     echo "check that the filesystems are created and mounted"
     mount | MATCH /run/mnt/ubuntu-boot
@@ -226,8 +236,13 @@ execute: |
     jq -r '.pc.structure[3]."filesystem-label"' < "$DISK_MAPPING_JSON" | MATCH ubuntu-save
     jq -r '.pc.structure[3]."partition-label"'  < "$DISK_MAPPING_JSON" | MATCH ubuntu-save
     jq -r '.pc.structure[3].id'                 < "$DISK_MAPPING_JSON" | MATCH ""
-    jq -r '.pc.structure[3].offset'             < "$DISK_MAPPING_JSON" | MATCH 2046820352
-    jq -r '.pc.structure[3].size'               < "$DISK_MAPPING_JSON" | MATCH 16777216
+    if [ "$channel" = "20" ]; then
+        jq -r '.pc.structure[3].offset'         < "$DISK_MAPPING_JSON" | MATCH 2046820352
+        jq -r '.pc.structure[3].size'           < "$DISK_MAPPING_JSON" | MATCH 16777216
+    else
+        jq -r '.pc.structure[3].offset'         < "$DISK_MAPPING_JSON" | MATCH 2046820352
+        jq -r '.pc.structure[3].size'           < "$DISK_MAPPING_JSON" | MATCH 33554432
+    fi
 
     # fifth structure - ubuntu-data
     jq -r '.pc.structure[4]."device-path"'      < "$DISK_MAPPING_JSON" | MATCH "/sys/devices/virtual/block/$LOOP_BASENAME/${LOOP_BASENAME}p5"
@@ -235,5 +250,10 @@ execute: |
     jq -r '.pc.structure[4]."filesystem-label"' < "$DISK_MAPPING_JSON" | MATCH ubuntu-data
     jq -r '.pc.structure[4]."partition-label"'  < "$DISK_MAPPING_JSON" | MATCH ubuntu-data
     jq -r '.pc.structure[4].id'                 < "$DISK_MAPPING_JSON" | MATCH ""
-    jq -r '.pc.structure[4].offset'             < "$DISK_MAPPING_JSON" | MATCH 2063597568
-    jq -r '.pc.structure[4].size'               < "$DISK_MAPPING_JSON" | MATCH 17936385536
+    if [ "$channel" = "20" ]; then
+        jq -r '.pc.structure[4].offset'         < "$DISK_MAPPING_JSON" | MATCH 2063597568
+        jq -r '.pc.structure[4].size'           < "$DISK_MAPPING_JSON" | MATCH 17936385536
+    else
+        jq -r '.pc.structure[4].offset'         < "$DISK_MAPPING_JSON" | MATCH 2080374784
+        jq -r '.pc.structure[4].size'           < "$DISK_MAPPING_JSON" | MATCH 17919608320
+    fi


### PR DESCRIPTION
Make encryption key change a 2 step process. First the new encryption key is staged (i.e. added in a temporary slot), after that, the encryption key is transitioned to become the main one. The first part of the process normally happens during factory reset, while the second in a post-reset run system.
