### PR TITLE
tests: enable nested tpm test for core22

### DIFF
--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -24,6 +24,8 @@ NESTED_FAKESTORE_SNAP_DECL_PC_GADGET="${NESTED_FAKESTORE_SNAP_DECL_PC_GADGET:-}"
 NESTED_UBUNTU_IMAGE_SNAPPY_FORCE_SAS_URL="${NESTED_UBUNTU_IMAGE_SNAPPY_FORCE_SAS_URL:-}"
 NESTED_UBUNTU_IMAGE_PRESEED_KEY="${NESTED_UBUNTU_IMAGE_PRESEED_KEY:-}"
 
+NESTED_PHYSICAL_4K_SECTOR_SIZE="${NESTED_PHYSICAL_4K_SECTOR_SIZE:-}"
+
 nested_wait_for_ssh() {
     # TODO:UC20: the retry count should be lowered to something more reasonable.
     local retry=800
@@ -1133,6 +1135,9 @@ nested_start_core_vm_unit() {
         PARAM_IMAGE="-drive file=$CURRENT_IMAGE,cache=none,format=raw,id=disk1,if=none -device virtio-blk-pci,drive=disk1,bootindex=1"
     else
         PARAM_IMAGE="-drive file=$CURRENT_IMAGE,cache=none,format=raw"
+    fi
+    if [ "$PHYSICAL_4K_SECTOR_SIZE" = "true" ]; then
+       PARAM_IMAGE="$PARAM_IMAGE,physical_block_size=4096,logical_block_size=512"
     fi
 
     # ensure we have a log dir

--- a/tests/nested/core/core20-basic/task.yaml
+++ b/tests/nested/core/core20-basic/task.yaml
@@ -5,6 +5,10 @@ details: |
 
 systems: [ubuntu-20.04-64]
 
+environment:
+    PHYSICAL_4K_SECTOR_SIZE/true: "true"
+    PHYSICAL_4K_SECTOR_SIZE/false: "false"
+
 execute: |
     echo "Wait for the system to be seeded first"
     tests.nested exec "sudo snap wait system seed.loaded"

--- a/tests/nested/core/core20-tpm/task.yaml
+++ b/tests/nested/core/core20-tpm/task.yaml
@@ -5,6 +5,10 @@ details: |
 
 systems: [ubuntu-20.04-64]
 
+environment:
+    PHYSICAL_4K_SECTOR_SIZE/true: "true"
+    PHYSICAL_4K_SECTOR_SIZE/false: "false"
+
 debug: |
     cat modeenv || true
     cat modeenv.after-reboot || true

--- a/tests/nested/core/core20core22-tpm/task.yaml
+++ b/tests/nested/core/core20core22-tpm/task.yaml
@@ -1,9 +1,9 @@
-summary: Check that tpm works properly on UC20
+summary: Check that tpm works properly on UC20+
 
 details: |
     This test check UC20 can boot with secure boot successfully
 
-systems: [ubuntu-20.04-64]
+systems: [ubuntu-20.04-64, ubuntu-22.04-64]
 
 environment:
     PHYSICAL_4K_SECTOR_SIZE/true: "true"

--- a/tests/nested/core/core22-basic/task.yaml
+++ b/tests/nested/core/core22-basic/task.yaml
@@ -5,6 +5,10 @@ details: |
 
 systems: [ubuntu-22.04-64]
 
+environment:
+    PHYSICAL_4K_SECTOR_SIZE/true: "true"
+    PHYSICAL_4K_SECTOR_SIZE/false: "false"
+
 execute: |
     echo "Wait for the system to be seeded first"
     tests.nested exec "sudo snap wait system seed.loaded"


### PR DESCRIPTION
This PR changes the test `core20-tpm` to `core20core22-tpm` and runs it on both 20.04 and 22.04 to ensure we get proper tpm testing on UC22 as well.

Build on https://github.com/snapcore/snapd/pull/11862