### PR TITLE
many: add migrate-home debug command

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -769,3 +769,18 @@ func (client *Client) SystemRecoveryKeys(result interface{}) error {
 	_, err := client.doSync("GET", "/v2/system-recovery-keys", nil, nil, nil, &result)
 	return err
 }
+
+func (c *Client) MigrateSnapHome(snaps []string) (changeID string, err error) {
+	body, err := json.Marshal(struct {
+		Action string   `json:"action"`
+		Snaps  []string `json:"snaps"`
+	}{
+		Action: "migrate-home",
+		Snaps:  snaps,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return c.doAsync("POST", "/v2/debug", nil, nil, bytes.NewReader(body))
+}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -629,6 +629,23 @@ func (cs *clientSuite) TestDebugGet(c *C) {
 	c.Check(cs.reqs[0].URL.Query(), DeepEquals, url.Values{"aspect": []string{"do-something"}, "foo": []string{"bar"}})
 }
 
+func (cs *clientSuite) TestDebugMigrateHome(c *C) {
+	cs.status = 202
+	cs.rsp = `{"type": "async", "status-code": 202, "change": "123"}`
+
+	snaps := []string{"foo", "bar"}
+	changeID, err := cs.cli.MigrateSnapHome(snaps)
+	c.Check(err, IsNil)
+	c.Check(changeID, Equals, "123")
+
+	c.Check(cs.reqs, HasLen, 1)
+	c.Check(cs.reqs[0].Method, Equals, "POST")
+	c.Check(cs.reqs[0].URL.Path, Equals, "/v2/debug")
+	data, err := ioutil.ReadAll(cs.reqs[0].Body)
+	c.Assert(err, IsNil)
+	c.Check(string(data), Equals, `{"action":"migrate-home","snaps":["foo","bar"]}`)
+}
+
 type integrationSuite struct{}
 
 var _ = Suite(&integrationSuite{})

--- a/cmd/snap/cmd_debug_migrate.go
+++ b/cmd/snap/cmd_debug_migrate.go
@@ -1,0 +1,80 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/jessevdk/go-flags"
+	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/strutil"
+)
+
+type cmdMigrateHome struct {
+	waitMixin
+
+	Positional struct {
+		Snaps []string `positional-arg-name:"<snap>" required:"1"`
+	} `positional-args:"yes" required:"yes"`
+}
+
+func init() {
+	addDebugCommand("migrate-home",
+		"Migrate snaps' directory to ~/Snap.",
+		"Migrate snaps' directory to ~/Snap.",
+		func() flags.Commander {
+			return &cmdMigrateHome{}
+		}, nil, nil)
+}
+
+func (x *cmdMigrateHome) Execute(args []string) error {
+	chgID, err := x.client.MigrateSnapHome(x.Positional.Snaps)
+	if err != nil {
+		msg, err := errorToCmdMessage("", "migrate-home", err, nil)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(Stderr, msg)
+		return nil
+	}
+
+	chg, err := x.wait(chgID)
+	if err != nil {
+		return err
+	}
+
+	var snaps []string
+	if err := chg.Get("snap-names", &snaps); err != nil {
+		return errors.New(`cannot get "snap-names" from change`)
+	}
+
+	if len(snaps) == 0 {
+		return errors.New(`expected "migrate-home" change to have non-empty "snap-names"`)
+	}
+
+	msg := fmt.Sprintf("%s's home directory was migrated to ~/Snap\n", snaps[0])
+	if len(snaps) > 1 {
+		msg = fmt.Sprintf(i18n.G("%s migrated their home directories to ~/Snap\n"), strutil.Quoted(snaps))
+	}
+
+	fmt.Fprintf(Stdout, msg)
+	return nil
+}

--- a/cmd/snap/cmd_debug_migrate_test.go
+++ b/cmd/snap/cmd_debug_migrate_test.go
@@ -1,0 +1,160 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main_test
+
+import (
+	"fmt"
+	"net/http"
+
+	snap "github.com/snapcore/snapd/cmd/snap"
+	"gopkg.in/check.v1"
+	. "gopkg.in/check.v1"
+)
+
+type MigrateHomeSuite struct {
+	BaseSnapSuite
+}
+
+var _ = check.Suite(&MigrateHomeSuite{})
+
+// failRequest logs an error message, fails the test and returns a proper error
+// to the client. Use this instead of panic() or c.Fatal() because those crash
+// the server and leave the client hanging/retrying.
+func failRequest(msg string, w http.ResponseWriter, c *C) {
+	c.Error(msg)
+	w.WriteHeader(400)
+	fmt.Fprintf(w, `{"type": "error", "status-code": 400, "result": {"message": %q}}`, msg)
+}
+
+func serverWithChange(chgRsp string, c *C) func(w http.ResponseWriter, r *http.Request) {
+	var n int
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch n {
+		case 0:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Check(r.URL.Path, check.Equals, "/v2/debug")
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+				"action": "migrate-home",
+				"snaps":  []interface{}{"foo"},
+			})
+			w.WriteHeader(202)
+			fmt.Fprintln(w, `{"type": "async", "status-code": 202, "result": {}, "change": "12"}`)
+
+		case 1:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/changes/12")
+			fmt.Fprintf(w, chgRsp)
+
+		default:
+			failRequest(fmt.Sprintf("server expected to get 2 requests, now on %d", n+1), w, c)
+		}
+
+		n++
+	}
+}
+
+func (s *MigrateHomeSuite) TestMigrateHome(c *C) {
+	rsp := serverWithChange(`{"type": "sync", "result": {"ready": true, "status": "Done", "data": {"snap-names": ["foo"]}}}\n`, c)
+	s.RedirectClientToTestServer(rsp)
+
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "migrate-home", "foo"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.DeepEquals, []string{})
+	c.Check(s.Stdout(), check.Equals, "foo's home directory was migrated to ~/Snap\n")
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *MigrateHomeSuite) TestMigrateHomeManySnaps(c *C) {
+	n := 0
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		switch n {
+		case 0:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Check(r.URL.Path, check.Equals, "/v2/debug")
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+				"action": "migrate-home",
+				"snaps":  []interface{}{"foo", "bar"},
+			})
+			w.WriteHeader(202)
+			fmt.Fprintln(w, `{"type": "async", "status-code": 202, "result": {}, "change": "12"}`)
+
+		case 1:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/changes/12")
+			fmt.Fprintf(w, `{"type": "sync", "result": {"ready": true, "status": "Done", "data": {"snap-names": ["foo", "bar"]}}}\n`)
+
+		default:
+			failRequest(fmt.Sprintf("server expected to get 2 requests, now on %d", n+1), w, c)
+		}
+
+		n++
+	})
+
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "migrate-home", "foo", "bar"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.DeepEquals, []string{})
+	c.Check(s.Stdout(), check.Equals, "\"foo\", \"bar\" migrated their home directories to ~/Snap\n")
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *MigrateHomeSuite) TestMigrateHomeNoSnaps(c *C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		failRequest("unexpected request on server", w, c)
+	})
+
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "migrate-home"})
+	c.Assert(err, check.ErrorMatches, "the required argument .* was not provided")
+	c.Check(s.Stdout(), check.Equals, "")
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *MigrateHomeSuite) TestMigrateHomeServerError(c *C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+		fmt.Fprintf(w, `{"type": "error", "status-code": 500, "result": {"message": "boom"}}`)
+	})
+
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "migrate-home", "foo"})
+	c.Assert(err, check.ErrorMatches, "boom")
+	c.Check(s.Stdout(), check.Equals, "")
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *MigrateHomeSuite) TestMigrateHomeBadChangeNoSnaps(c *C) {
+	// broken change response: missing required "snap-names"
+	srv := serverWithChange(`{"type": "sync", "result": {"ready": true, "status": "Done", "data": {"snap-names": []}}}\n`, c)
+	s.RedirectClientToTestServer(srv)
+
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "migrate-home", "foo"})
+	c.Assert(err, check.ErrorMatches, `expected "migrate-home" change to have non-empty "snap-names"`)
+	c.Check(s.Stdout(), check.Equals, "")
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *MigrateHomeSuite) TestMigrateHomeBadChangeNoData(c *C) {
+	// broken change response: missing data
+	srv := serverWithChange(`{"type": "sync", "result": {"ready": true, "status": "Done"}}\n`, c)
+	s.RedirectClientToTestServer(srv)
+
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"debug", "migrate-home", "foo"})
+	c.Assert(err, check.ErrorMatches, `cannot get "snap-names" from change`)
+	c.Check(s.Stdout(), check.Equals, "")
+	c.Check(s.Stderr(), check.Equals, "")
+}

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -2288,6 +2288,7 @@ func (s *SnapOpSuite) TestWaitServerError(c *check.C) {
 		{"disable", "foo"},
 		{"try", "."},
 		{"switch", "--channel=foo", "bar"},
+		{"debug", "migrate-home", "foo"},
 		// commands that use waitMixin from elsewhere
 		{"start", "foo"},
 		{"stop", "foo"},

--- a/daemon/api_debug.go
+++ b/daemon/api_debug.go
@@ -53,6 +53,7 @@ type debugAction struct {
 
 		RecoverySystemLabel string `json:"recovery-system-label"`
 	} `json:"params"`
+	Snaps []string `json:"snaps"`
 }
 
 type connectivityStatus struct {
@@ -411,6 +412,8 @@ func postDebug(c *Command, r *http.Request, user *auth.UserState) Response {
 		return getStacktraces()
 	case "create-recovery-system":
 		return createRecovery(st, a.Params.RecoverySystemLabel)
+	case "migrate-home":
+		return migrateHome(st, a.Snaps)
 	default:
 		return BadRequest("unknown debug action: %v", a.Action)
 	}

--- a/daemon/api_debug_migrate.go
+++ b/daemon/api_debug_migrate.go
@@ -1,0 +1,55 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package daemon
+
+import (
+	"fmt"
+
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/strutil"
+)
+
+var snapstateMigrateHome = snapstate.MigrateHome
+
+func migrateHome(st *state.State, snaps []string) Response {
+	if len(snaps) == 0 {
+		return BadRequest("no snaps were provided")
+	}
+
+	tss, err := snapstateMigrateHome(st, snaps)
+	if err != nil {
+		if terr, ok := err.(snap.NotInstalledError); ok {
+			return SnapNotFound(terr.Snap, err)
+		}
+
+		return InternalError(err.Error())
+	}
+
+	chg := st.NewChange("migrate-home", fmt.Sprintf("Migrate snap homes to ~/Snap for snaps %s", strutil.Quoted(snaps)))
+	for _, ts := range tss {
+		chg.AddAll(ts)
+	}
+	chg.Set("api-data", map[string][]string{"snap-names": snaps})
+
+	ensureStateSoon(st)
+	return AsyncResponse(nil, chg.ID())
+}

--- a/daemon/api_debug_test.go
+++ b/daemon/api_debug_test.go
@@ -22,12 +22,16 @@ package daemon_test
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"net/http"
+	"strings"
 
 	"gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/daemon"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
 	"github.com/snapcore/snapd/timings"
 )
@@ -237,4 +241,98 @@ func (s *postDebugSuite) TestMinLane(c *check.C) {
 
 	// validity
 	c.Check(t.Lanes(), check.DeepEquals, []int{lane1, lane2})
+}
+
+func (s *postDebugSuite) TestMigrateHome(c *check.C) {
+	d := s.daemonWithOverlordMock()
+	s.expectRootAccess()
+
+	restore := daemon.MockSnapstateMigrate(func(*state.State, []string) ([]*state.TaskSet, error) {
+		st := state.New(nil)
+		st.Lock()
+		defer st.Unlock()
+
+		var ts state.TaskSet
+		ts.AddTask(st.NewTask("bar", ""))
+		return []*state.TaskSet{&ts}, nil
+	})
+	defer restore()
+
+	body := strings.NewReader(`{"action": "migrate-home", "snaps": ["foo", "bar"]}`)
+	req, err := http.NewRequest("POST", "/v2/debug", body)
+	c.Assert(err, check.IsNil)
+
+	rsp := s.req(c, req, nil)
+	c.Assert(rsp, check.FitsTypeOf, &daemon.RespJSON{})
+
+	rspJSON := rsp.(*daemon.RespJSON)
+
+	st := d.Overlord().State()
+	st.Lock()
+	defer st.Unlock()
+
+	chg := st.Change(rspJSON.Change)
+	var snaps map[string][]string
+	c.Assert(chg.Get("api-data", &snaps), check.IsNil)
+	c.Assert(snaps["snap-names"], check.DeepEquals, []string{"foo", "bar"})
+}
+
+func (s *postDebugSuite) TestMigrateHomeNoSnaps(c *check.C) {
+	s.daemonWithOverlordMock()
+	s.expectRootAccess()
+
+	body := strings.NewReader(`{"action": "migrate-home"}`)
+	req, err := http.NewRequest("POST", "/v2/debug", body)
+	c.Assert(err, check.IsNil)
+
+	rsp := s.req(c, req, nil)
+	c.Assert(rsp, check.FitsTypeOf, &daemon.APIError{})
+	apiErr := rsp.(*daemon.APIError)
+
+	c.Check(apiErr.Status, check.Equals, 400)
+	c.Check(apiErr.Message, check.Equals, "no snaps were provided")
+}
+
+func (s *postDebugSuite) TestMigrateHomeNotInstalled(c *check.C) {
+	s.daemonWithOverlordMock()
+	s.expectRootAccess()
+
+	restore := daemon.MockSnapstateMigrate(func(*state.State, []string) ([]*state.TaskSet, error) {
+		return nil, snap.NotInstalledError{Snap: "some-snap"}
+	})
+	defer restore()
+
+	body := strings.NewReader(`{"action": "migrate-home", "snaps": ["some-snap"]}`)
+	req, err := http.NewRequest("POST", "/v2/debug", body)
+	c.Assert(err, check.IsNil)
+
+	rsp := s.req(c, req, nil)
+	c.Assert(rsp, check.FitsTypeOf, &daemon.APIError{})
+	apiErr := rsp.(*daemon.APIError)
+
+	c.Check(apiErr.Status, check.Equals, 404)
+	c.Check(apiErr.Message, check.Equals, `snap "some-snap" is not installed`)
+	c.Check(apiErr.Kind, check.Equals, client.ErrorKindSnapNotFound)
+	c.Check(apiErr.Value, check.Equals, "some-snap")
+}
+
+func (s *postDebugSuite) TestMigrateHomeInternalError(c *check.C) {
+	s.daemonWithOverlordMock()
+	s.expectRootAccess()
+
+	restore := daemon.MockSnapstateMigrate(func(*state.State, []string) ([]*state.TaskSet, error) {
+		return nil, errors.New("boom")
+	})
+	defer restore()
+
+	body := strings.NewReader(`{"action": "migrate-home", "snaps": ["some-snap"]}`)
+	req, err := http.NewRequest("POST", "/v2/debug", body)
+	c.Assert(err, check.IsNil)
+
+	rsp := s.req(c, req, nil)
+	c.Assert(rsp, check.FitsTypeOf, &daemon.APIError{})
+	apiErr := rsp.(*daemon.APIError)
+
+	c.Check(apiErr.Status, check.Equals, 500)
+	c.Check(apiErr.Message, check.Equals, `boom`)
 }

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -204,6 +204,14 @@ func MockSnapstateInstallPathMany(f func(context.Context, *state.State, []*snap.
 	}
 }
 
+func MockSnapstateMigrate(mock func(*state.State, []string) ([]*state.TaskSet, error)) (restore func()) {
+	oldSnapstateMigrate := snapstateMigrateHome
+	snapstateMigrateHome = mock
+	return func() {
+		snapstateMigrateHome = oldSnapstateMigrate
+	}
+}
+
 func MockReboot(f func(boot.RebootAction, time.Duration, *boot.RebootInfo) error) func() {
 	reboot = f
 	return func() { reboot = boot.Reboot }


### PR DESCRIPTION
Adds a "migrate-home" action to the /v2/debug endpoint and a corresponding debug command. Based on https://github.com/snapcore/snapd/pull/11858