### PR TITLE
data: start snapd after time-set.target

### DIFF
--- a/data/systemd/snapd.service.in
+++ b/data/systemd/snapd.service.in
@@ -1,6 +1,6 @@
 [Unit]
 Description=Snap Daemon
-After=snapd.socket
+After=snapd.socket time-set.target
 Requires=snapd.socket
 OnFailure=snapd.failure.service
 # This is handled by snapd


### PR DESCRIPTION
Ubuntu Core fails to boot if an RTC is attached because the first time reading from it is incorrect ([issue](https://canonical.lightning.force.com/lightning/r/Case/5004K00000EAIPnQAP/view)). This PR adds a dependency from snapd to [time-set.target](https://www.freedesktop.org/software/systemd/man/systemd.special.html#time-set.target) so that an approximate time is loaded (this target doesn't wait for an NTP sync with a remote source). Opening as a draft to check if any issues crop up in the spread tests.