### PR TITLE
squashfs: improve error reporting when `unsquashfs` fails

### DIFF
--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -204,12 +204,16 @@ func (s *Snap) Unpack(src, dstDir string) error {
 
 	cmd := exec.Command("unsquashfs", "-n", "-f", "-d", dstDir, s.path, src)
 	cmd.Stderr = usw
-	if err := cmd.Run(); err != nil {
-		return err
-	}
+	err := cmd.Run()
+	// check unsquashfs errors first
 	if usw.Err() != nil {
 		return fmt.Errorf("cannot extract %q to %q: %v", src, dstDir, usw.Err())
 	}
+	// only if none are found report generic errors
+	if err != nil {
+		return fmt.Errorf("cannot run unsquashfs: %v", err)
+	}
+
 	return nil
 }
 

--- a/snap/squashfs/squashfs_test.go
+++ b/snap/squashfs/squashfs_test.go
@@ -569,7 +569,7 @@ EOF
 cat >&2 <<EOF
 Write on output file failed because No space left on device
 
-FATAL ERROR: writer: failed to write file squashfs-root/etc/modprobe.d/blacklist.conf
+FATAL ERROR: writer: failed to write file squashfs-root/etc/modprobe.d/some.conf
 EOF
 exit 1
 `)
@@ -583,7 +583,7 @@ exit 1
 -----
 Write on output file failed because No space left on device
 
-FATAL ERROR: writer: failed to write file squashfs-root/etc/modprobe.d/blacklist.conf
+FATAL ERROR: writer: failed to write file squashfs-root/etc/modprobe.d/some.conf
 -----`)
 }
 

--- a/snap/squashfs/squashfs_test.go
+++ b/snap/squashfs/squashfs_test.go
@@ -559,6 +559,34 @@ EOF
 	c.Check(err.Error(), Equals, `cannot extract "*" to "some-output-dir": failed: "Failed to write /tmp/1/modules/4.4.0-112-generic/modules.symbols, skipping", "Write on output file failed because No space left on device", "writer: failed to write data block 0", "Failed to write /tmp/1/modules/4.4.0-112-generic/modules.symbols.bin, skipping", and 15 more`)
 }
 
+func (s *SquashfsTestSuite) TestUnpackDetectsFailuresViaExitCode(c *C) {
+	mockUnsquashfs := testutil.MockCommand(c, "unsquashfs", `
+cat <<EOF
+Parallel unsquashfs: Using 16 processors
+10522 inodes (11171 blocks) to write
+EOF
+
+cat >&2 <<EOF
+Write on output file failed because No space left on device
+
+FATAL ERROR: writer: failed to write file squashfs-root/etc/modprobe.d/blacklist.conf
+EOF
+exit 1
+`)
+	defer mockUnsquashfs.Restore()
+
+	data := "mock kernel snap"
+	sn := makeSnap(c, "", data)
+	err := sn.Unpack("*", "some-output-dir")
+	c.Assert(err, NotNil)
+	c.Check(err.Error(), Equals, `cannot extract "*" to "some-output-dir": 
+-----
+Write on output file failed because No space left on device
+
+FATAL ERROR: writer: failed to write file squashfs-root/etc/modprobe.d/blacklist.conf
+-----`)
+}
+
 func (s *SquashfsTestSuite) TestBuildAll(c *C) {
 	// please keep TestBuildUsesExcludes in sync with this one so it makes sense.
 	buildDir := c.MkDir()


### PR DESCRIPTION
The current code in Snap.Unpack() will report a very generic:
` exit status 1` error if `unsquashfs` fails. This commit changes
the code to first look at any unsquashfs errors reported on stderr
and only if none of these are found it will report a (slightly less)
generic error.

This should help diagnose a bug in the pi-kernel refresh where
the Snap.Unpack() of the kernel assets fails.

