### PR TITLE
gadget/install: do not assume dm device has same block size as disk (2.56)

### DIFF
--- a/osutil/disks/disks_darwin.go
+++ b/osutil/disks/disks_darwin.go
@@ -74,3 +74,7 @@ func PartitionUUIDFromMountPoint(mountpoint string, opts *Options) (string, erro
 func PartitionUUID(node string) (string, error) {
 	return "", osutil.ErrDarwin
 }
+
+func SectorSize(devname string) (uint64, error) {
+	return 0, osutil.ErrDarwin
+}

--- a/osutil/disks/disks_linux.go
+++ b/osutil/disks/disks_linux.go
@@ -977,3 +977,7 @@ func PartitionUUID(node string) (string, error) {
 	}
 	return partUUID, nil
 }
+
+func SectorSize(devname string) (uint64, error) {
+	return blockDeviceSectorSize(devname)
+}


### PR DESCRIPTION
This is https://github.com/snapcore/snapd/pull/11857 backported to 2.56. Quite a bit of the install.go file changed so a careful look from @bboozzoo is appreciated. 

I tested this locally by cherry-picking https://github.com/snapcore/snapd/pull/11862 [1] to 2.56 and running:
```
$ spread -v qemu-nested:ubuntu-22.04-64:tests/nested/manual/core20-4k-sector-size
...
2022-06-13 13:19:44 Preparing qemu-nested:ubuntu-22.04-64:tests/nested/manual/ (qemu-nested:ubuntu-22.04-64)...
2022-06-13 13:21:13 Preparing qemu-nested:ubuntu-22.04-64:tests/nested/manual/core20-4k-sector-size (qemu-nested:ubuntu-22.04-64)...
2022-06-13 13:31:08 Executing qemu-nested:ubuntu-22.04-64:tests/nested/manual/core20-4k-sector-size (qemu-nested:ubuntu-22.04-64) (1/1)...
2022-06-13 13:31:35 Restoring qemu-nested:ubuntu-22.04-64:tests/nested/manual/core20-4k-sector-size (qemu-nested:ubuntu-22.04-64)...
2022-06-13 13:31:56 Restoring qemu-nested:ubuntu-22.04-64:tests/nested/manual/ (qemu-nested:ubuntu-22.04-64)...
2022-06-13 13:31:58 Restoring qemu-nested:ubuntu-22.04-64 (qemu-nested:ubuntu-22.04-64)...
2022-06-13 13:31:58 Discarding qemu-nested:ubuntu-22.04-64...
2022-06-13 13:31:58 Successful tasks: 1
2022-06-13 13:31:58 Aborted tasks: 0
```

[1] and removed the `snap recovery show-ekys` call which is not supported with 2.56 yet.