### PR TITLE
boot: post factory reset cleanup

### DIFF
--- a/boot/boot.go
+++ b/boot/boot.go
@@ -482,7 +482,7 @@ func CompleteFactoryReset(encrypted bool) error {
 		return nil
 	}
 	if err := postFactoryResetCleanup(); err != nil {
-		return fmt.Errorf("cannot perform boot cleanup: %v", err)
+		return fmt.Errorf("cannot perform post factory reset boot cleanup: %v", err)
 	}
 	return nil
 }

--- a/boot/boot.go
+++ b/boot/boot.go
@@ -474,9 +474,9 @@ func UpdateCommandLineForGadgetComponent(dev snap.Device, gadgetSnapOrDir string
 	return cmdlineChange, nil
 }
 
-// CompleteFactoryReset runs a series of steps in a run system that complete a
+// MarkFactoryResetComplete runs a series of steps in a run system that complete a
 // factory reset process.
-func CompleteFactoryReset(encrypted bool) error {
+func MarkFactoryResetComplete(encrypted bool) error {
 	if !encrypted {
 		// there is nothing to do on an unencrypted system
 		return nil

--- a/boot/boot.go
+++ b/boot/boot.go
@@ -473,3 +473,16 @@ func UpdateCommandLineForGadgetComponent(dev snap.Device, gadgetSnapOrDir string
 	}
 	return cmdlineChange, nil
 }
+
+// CompleteFactoryReset runs a series of steps in a run system that complete a
+// factory reset process.
+func CompleteFactoryReset(encrypted bool) error {
+	if !encrypted {
+		// there is nothing to do on an unencrypted system
+		return nil
+	}
+	if err := postFactoryResetCleanup(); err != nil {
+		return fmt.Errorf("cannot perform boot cleanup: %v", err)
+	}
+	return nil
+}

--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -141,6 +141,12 @@ func MockSecbootPCRHandleOfSealedKey(f func(p string) (uint32, error)) (restore 
 	return restore
 }
 
+func MockSecbootReleasePCRResourceHandles(f func(handles ...uint32) error) (restore func()) {
+	restore = testutil.Backup(&secbootReleasePCRResourceHandles)
+	secbootReleasePCRResourceHandles = f
+	return restore
+}
+
 func (o *TrustedAssetsUpdateObserver) InjectChangedAsset(blName, assetName, hash string, recovery bool) {
 	ta := &trackedAsset{
 		blName: blName,

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -147,14 +147,25 @@ func runKeySealRequests(key keys.EncryptionKey) []secboot.SealKeyRequest {
 	}
 }
 
+// FallbackSaveSealedKeyUnder returns the name of a fallback ubuntu save key.
+func FallbackSaveSealedKeyUnder(dir string) string {
+	return filepath.Join(dir, "ubuntu-save.recovery.sealed-key")
+}
+
+// FactoryResetFallbackSaveSealedKeyUnder returns the name of a fallback ubuntu
+// save key object generated during factory reset.
+func FactoryResetFallbackSaveSealedKeyUnder(dir string) string {
+	return filepath.Join(dir, "ubuntu-save.recovery.sealed-key.factory-reset")
+}
+
 func fallbackKeySealRequests(key, saveKey keys.EncryptionKey, factoryReset bool) []secboot.SealKeyRequest {
-	saveFallbackKey := filepath.Join(InitramfsSeedEncryptionKeyDir, "ubuntu-save.recovery.sealed-key")
+	saveFallbackKey := FallbackSaveSealedKeyUnder(InitramfsSeedEncryptionKeyDir)
 
 	if factoryReset {
 		// factory reset uses alternative sealed key location, such that
 		// until we boot into the run mode, both sealed keys are present
 		// on disk
-		saveFallbackKey = filepath.Join(InitramfsSeedEncryptionKeyDir, "ubuntu-save.recovery.sealed-key.factory-reset")
+		saveFallbackKey = FactoryResetFallbackSaveSealedKeyUnder(InitramfsSeedEncryptionKeyDir)
 	}
 	return []secboot.SealKeyRequest{
 		{

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -45,11 +45,12 @@ import (
 )
 
 var (
-	secbootProvisionTPM             = secboot.ProvisionTPM
-	secbootSealKeys                 = secboot.SealKeys
-	secbootSealKeysWithFDESetupHook = secboot.SealKeysWithFDESetupHook
-	secbootResealKeys               = secboot.ResealKeys
-	secbootPCRHandleOfSealedKey     = secboot.PCRHandleOfSealedKey
+	secbootProvisionTPM              = secboot.ProvisionTPM
+	secbootSealKeys                  = secboot.SealKeys
+	secbootSealKeysWithFDESetupHook  = secboot.SealKeysWithFDESetupHook
+	secbootResealKeys                = secboot.ResealKeys
+	secbootPCRHandleOfSealedKey      = secboot.PCRHandleOfSealedKey
+	secbootReleasePCRResourceHandles = secboot.ReleasePCRResourceHandles
 
 	seedReadSystemEssential = seed.ReadSystemEssential
 )
@@ -893,4 +894,51 @@ func isResealNeeded(pbc predictableBootChains, bootChainsFile string, expectRese
 	case bootChainDifferent:
 	}
 	return true, c + 1, nil
+}
+
+func postFactoryResetCleanupSecboot() error {
+	// we are inspecting a key which was generated during factory reset, in
+	// the simplest case the sealed key generated previously used the main
+	// handles, while the current key uses alt handles, hence we need to
+	// release the main handles corresponding to the old key
+	handles := []uint32{secboot.RunObjectPCRPolicyCounterHandle, secboot.FallbackObjectPCRPolicyCounterHandle}
+	usesAlt, err := usesAltPCRHandles()
+	if err != nil {
+		return fmt.Errorf("cannot inspect fallback key: %v", err)
+	}
+	if !usesAlt {
+		// current fallback key using the main handles, which is
+		// possible of there were subsequent factory reset steps,
+		// release the alt handles associated with the old key
+		handles = []uint32{secboot.AltRunObjectPCRPolicyCounterHandle, secboot.AltFallbackObjectPCRPolicyCounterHandle}
+	}
+	return secbootReleasePCRResourceHandles(handles...)
+}
+
+func postFactoryResetCleanup() error {
+	hasHook, err := HasFDESetupHook()
+	if err != nil {
+		return fmt.Errorf("cannot check for fde-setup hook %v", err)
+	}
+
+	saveFallbackKeyFactory := FactoryResetFallbackSaveSealedKeyUnder(InitramfsSeedEncryptionKeyDir)
+	saveFallbackKey := FallbackSaveSealedKeyUnder(InitramfsSeedEncryptionKeyDir)
+	if err := os.Rename(saveFallbackKeyFactory, saveFallbackKey); err != nil {
+		// it is possible that the key file was already renamed if we
+		// came back here after an unexpected reboot
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("cannot rotate fallback key: %v", err)
+		}
+	}
+
+	if hasHook {
+		// TODO: do we need to invoke FDE hook?
+		return nil
+	}
+
+	if err := postFactoryResetCleanupSecboot(); err != nil {
+		return fmt.Errorf("cannot cleanup secboot state: %v", err)
+	}
+
+	return nil
 }

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -2084,7 +2084,7 @@ func (s *sealSuite) TestResealKeyToModeenvWithTryModel(c *C) {
 	})
 }
 
-func (s *sealSuite) TestCompleteFactoryReset(c *C) {
+func (s *sealSuite) TestMarkFactoryResetComplete(c *C) {
 
 	for i, tc := range []struct {
 		encrypted                 bool
@@ -2179,7 +2179,7 @@ func (s *sealSuite) TestCompleteFactoryReset(c *C) {
 		})
 		defer restore()
 
-		err := boot.CompleteFactoryReset(tc.encrypted)
+		err := boot.MarkFactoryResetComplete(tc.encrypted)
 		if tc.err != "" {
 			c.Assert(err, ErrorMatches, tc.err)
 		} else {

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -2123,13 +2123,13 @@ func (s *sealSuite) TestCompleteFactoryReset(c *C) {
 			factoryKeyAlreadyMigrated: true,
 			pcrHandleOfKeyCalls:       1,
 			pcrHandleOfKeyErr:         errors.New("handle error"),
-			err:                       "cannot perform boot cleanup: cannot cleanup secboot state: cannot inspect fallback key: handle error",
+			err:                       "cannot perform post factory reset boot cleanup: cannot cleanup secboot state: cannot inspect fallback key: handle error",
 		}, {
 			encrypted: true, pcrHandleOfKey: secboot.FallbackObjectPCRPolicyCounterHandle,
 			factoryKeyAlreadyMigrated: true,
 			pcrHandleOfKeyCalls:       1, releasePCRHandleCalls: 1,
 			releasePCRHandlesErr: errors.New("release error"),
-			err:                  "cannot perform boot cleanup: cannot cleanup secboot state: release error",
+			err:                  "cannot perform post factory reset boot cleanup: cannot cleanup secboot state: release error",
 		},
 	} {
 		c.Logf("tc %v", i)

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -2083,3 +2083,116 @@ func (s *sealSuite) TestResealKeyToModeenvWithTryModel(c *C) {
 		},
 	})
 }
+
+func (s *sealSuite) TestCompleteFactoryReset(c *C) {
+
+	for i, tc := range []struct {
+		encrypted                 bool
+		factoryKeyAlreadyMigrated bool
+		pcrHandleOfKey            uint32
+		pcrHandleOfKeyErr         error
+		pcrHandleOfKeyCalls       int
+		releasePCRHandlesErr      error
+		releasePCRHandleCalls     int
+		hasFDEHook                bool
+		err                       string
+	}{
+		{
+			// unencrypted is a nop
+			encrypted: false,
+		}, {
+			// the old fallback key uses the main handle
+			encrypted: true, pcrHandleOfKey: secboot.FallbackObjectPCRPolicyCounterHandle,
+			factoryKeyAlreadyMigrated: true, pcrHandleOfKeyCalls: 1, releasePCRHandleCalls: 1,
+		}, {
+			// the old fallback key uses the alt handle
+			encrypted: true, pcrHandleOfKey: secboot.AltFallbackObjectPCRPolicyCounterHandle,
+			factoryKeyAlreadyMigrated: true, pcrHandleOfKeyCalls: 1, releasePCRHandleCalls: 1,
+		}, {
+			// unexpected reboot, the key file was already moved
+			encrypted: true, pcrHandleOfKey: secboot.AltFallbackObjectPCRPolicyCounterHandle,
+			pcrHandleOfKeyCalls: 1, releasePCRHandleCalls: 1,
+		}, {
+			// do nothing if we have the FDE hook
+			encrypted: true, pcrHandleOfKeyErr: errors.New("unexpected call"),
+			hasFDEHook: true,
+		},
+		// error cases
+		{
+			encrypted: true, pcrHandleOfKey: secboot.FallbackObjectPCRPolicyCounterHandle,
+			factoryKeyAlreadyMigrated: true,
+			pcrHandleOfKeyCalls:       1,
+			pcrHandleOfKeyErr:         errors.New("handle error"),
+			err:                       "cannot perform boot cleanup: cannot cleanup secboot state: cannot inspect fallback key: handle error",
+		}, {
+			encrypted: true, pcrHandleOfKey: secboot.FallbackObjectPCRPolicyCounterHandle,
+			factoryKeyAlreadyMigrated: true,
+			pcrHandleOfKeyCalls:       1, releasePCRHandleCalls: 1,
+			releasePCRHandlesErr: errors.New("release error"),
+			err:                  "cannot perform boot cleanup: cannot cleanup secboot state: release error",
+		},
+	} {
+		c.Logf("tc %v", i)
+
+		saveSealedKey := filepath.Join(boot.InitramfsSeedEncryptionKeyDir, "ubuntu-save.recovery.sealed-key")
+		saveSealedKeyByFactoryReset := filepath.Join(boot.InitramfsSeedEncryptionKeyDir, "ubuntu-save.recovery.sealed-key.factory-reset")
+
+		if tc.encrypted {
+			c.Assert(os.MkdirAll(boot.InitramfsSeedEncryptionKeyDir, 0755), IsNil)
+			if tc.factoryKeyAlreadyMigrated {
+				c.Assert(ioutil.WriteFile(saveSealedKey, []byte{'o', 'l', 'd'}, 0644), IsNil)
+				c.Assert(ioutil.WriteFile(saveSealedKeyByFactoryReset, []byte{'n', 'e', 'w'}, 0644), IsNil)
+			} else {
+				c.Assert(ioutil.WriteFile(saveSealedKey, []byte{'n', 'e', 'w'}, 0644), IsNil)
+			}
+		}
+
+		restore := boot.MockHasFDESetupHook(func() (bool, error) {
+			return tc.hasFDEHook, nil
+		})
+		defer restore()
+
+		pcrHandleOfKeyCalls := 0
+		restore = boot.MockSecbootPCRHandleOfSealedKey(func(p string) (uint32, error) {
+			pcrHandleOfKeyCalls++
+			// XXX we're inspecting the current key after it got rotated
+			c.Check(p, Equals, filepath.Join(dirs.GlobalRootDir, "/run/mnt/ubuntu-seed/device/fde/ubuntu-save.recovery.sealed-key"))
+			return tc.pcrHandleOfKey, tc.pcrHandleOfKeyErr
+		})
+		defer restore()
+
+		releasePCRHandleCalls := 0
+		restore = boot.MockSecbootReleasePCRResourceHandles(func(handles ...uint32) error {
+			releasePCRHandleCalls++
+			if tc.pcrHandleOfKey == secboot.FallbackObjectPCRPolicyCounterHandle {
+				c.Check(handles, DeepEquals, []uint32{
+					secboot.AltRunObjectPCRPolicyCounterHandle,
+					secboot.AltFallbackObjectPCRPolicyCounterHandle,
+				})
+			} else {
+				c.Check(handles, DeepEquals, []uint32{
+					secboot.RunObjectPCRPolicyCounterHandle,
+					secboot.FallbackObjectPCRPolicyCounterHandle,
+				})
+			}
+			return tc.releasePCRHandlesErr
+		})
+		defer restore()
+
+		err := boot.CompleteFactoryReset(tc.encrypted)
+		if tc.err != "" {
+			c.Assert(err, ErrorMatches, tc.err)
+		} else {
+			c.Assert(err, IsNil)
+		}
+		c.Check(pcrHandleOfKeyCalls, Equals, tc.pcrHandleOfKeyCalls)
+		c.Check(releasePCRHandleCalls, Equals, tc.releasePCRHandleCalls)
+		if tc.encrypted {
+			c.Check(filepath.Join(boot.InitramfsSeedEncryptionKeyDir, "ubuntu-save.recovery.sealed-key"),
+				testutil.FileEquals, []byte{'n', 'e', 'w'})
+			c.Check(filepath.Join(boot.InitramfsSeedEncryptionKeyDir, "ubuntu-save.recovery.sealed-key.factory-reset"),
+				testutil.FileAbsent)
+		}
+	}
+
+}


### PR DESCRIPTION
A helper in boot that completes the factory reset by rotating the sealed key file and PCR handles.

Contains a small helper from #11870