### PR TITLE
asserts: store required revisions for missing snaps in CheckInstalledSnaps

### DIFF
--- a/asserts/snapasserts/validation_sets.go
+++ b/asserts/snapasserts/validation_sets.go
@@ -63,8 +63,9 @@ func (e *ValidationSetsConflictError) Error() string {
 // ValidationSetsValidationError describes an error arising
 // from validation of snaps against ValidationSets.
 type ValidationSetsValidationError struct {
-	// MissingSnaps maps missing snap names to the validation sets requiring them.
-	MissingSnaps map[string][]string
+	// MissingSnaps maps missing snap names to the expected revisions and respective validation sets requiring them.
+	// Revisions may be unset if no specific revision is required
+	MissingSnaps map[string]map[snap.Revision][]string
 	// InvalidSnaps maps snap names to the validation sets declaring them invalid.
 	InvalidSnaps map[string][]string
 	// WronRevisionSnaps maps snap names to the expected revisions and respective
@@ -94,9 +95,27 @@ func (e *ValidationSetsValidationError) Error() string {
 		}
 	}
 
-	printDetails("missing required snaps", e.MissingSnaps, func(snapName string, validationSetKeys []string) string {
-		return fmt.Sprintf("%s (required by sets %s)", snapName, strings.Join(validationSetKeys, ","))
-	})
+	if len(e.MissingSnaps) > 0 {
+		fmt.Fprintf(buf, "\n- missing required snaps:")
+		for snapName, revisions := range e.MissingSnaps {
+			revisionsSorted := make([]snap.Revision, 0, len(revisions))
+			for rev := range revisions {
+				revisionsSorted = append(revisionsSorted, rev)
+			}
+			sort.Sort(byRevision(revisionsSorted))
+			t := make([]string, 0, len(revisionsSorted))
+			for _, rev := range revisionsSorted {
+				keys := revisions[rev]
+				if rev.Unset() {
+					t = append(t, fmt.Sprintf("at any revision by sets %s", strings.Join(keys, ",")))
+				} else {
+					t = append(t, fmt.Sprintf("at revision %s by sets %s", rev, strings.Join(keys, ",")))
+				}
+			}
+			fmt.Fprintf(buf, "\n  - %s (required %s)", snapName, strings.Join(t, ", "))
+		}
+	}
+
 	printDetails("invalid snaps", e.InvalidSnaps, func(snapName string, validationSetKeys []string) string {
 		return fmt.Sprintf("%s (invalid for sets %s)", snapName, strings.Join(validationSetKeys, ","))
 	})
@@ -367,7 +386,7 @@ func (v *ValidationSets) CheckInstalledSnaps(snaps []*InstalledSnap, ignoreValid
 
 	// snapName -> validationSet key -> validation set
 	invalid := make(map[string]map[string]bool)
-	missing := make(map[string]map[string]bool)
+	missing := make(map[string]map[snap.Revision]map[string]bool)
 	wrongrev := make(map[string]map[snap.Revision]map[string]bool)
 	sets := make(map[string]*asserts.ValidationSet)
 
@@ -411,9 +430,12 @@ func (v *ValidationSets) CheckInstalledSnaps(snaps []*InstalledSnap, ignoreValid
 					// is only possible to have it with a wrong revision, or installed while invalid, in both
 					// cases through --ignore-validation flag).
 					if missing[rc.Name] == nil {
-						missing[rc.Name] = make(map[string]bool)
+						missing[rc.Name] = make(map[snap.Revision]map[string]bool)
 					}
-					missing[rc.Name][rc.validationSetKey] = true
+					if missing[rc.Name][rev] == nil {
+						missing[rc.Name][rev] = make(map[string]bool)
+					}
+					missing[rc.Name][rev][rc.validationSetKey] = true
 					sets[rc.validationSetKey] = v.sets[rc.validationSetKey]
 				}
 			}
@@ -438,8 +460,19 @@ func (v *ValidationSets) CheckInstalledSnaps(snaps []*InstalledSnap, ignoreValid
 	if len(invalid) > 0 || len(missing) > 0 || len(wrongrev) > 0 {
 		verr := &ValidationSetsValidationError{
 			InvalidSnaps: setsToLists(invalid),
-			MissingSnaps: setsToLists(missing),
 			Sets:         sets,
+		}
+		if len(missing) > 0 {
+			verr.MissingSnaps = make(map[string]map[snap.Revision][]string)
+			for snapName, revs := range missing {
+				verr.MissingSnaps[snapName] = make(map[snap.Revision][]string)
+				for rev, keys := range revs {
+					for key := range keys {
+						verr.MissingSnaps[snapName][rev] = append(verr.MissingSnaps[snapName][rev], key)
+					}
+					sort.Strings(verr.MissingSnaps[snapName][rev])
+				}
+			}
 		}
 		if len(wrongrev) > 0 {
 			verr.WrongRevisionSnaps = make(map[string]map[snap.Revision][]string)

--- a/asserts/snapasserts/validation_sets_test.go
+++ b/asserts/snapasserts/validation_sets_test.go
@@ -400,6 +400,22 @@ func (s *validationSetsSuite) TestCheckInstalledSnaps(c *C) {
 		},
 	}).(*asserts.ValidationSet)
 
+	vs7 := assertstest.FakeAssertion(map[string]interface{}{
+		"type":         "validation-set",
+		"authority-id": "acme",
+		"series":       "16",
+		"account-id":   "acme",
+		"name":         "bahname",
+		"sequence":     "1",
+		"snaps": []interface{}{
+			map[string]interface{}{
+				"name":     "snap-f",
+				"id":       "mysnapffffffffffffffffffffffffff",
+				"presence": "required",
+			},
+		},
+	}).(*asserts.ValidationSet)
+
 	valsets := snapasserts.NewValidationSets()
 	c.Assert(valsets.Add(vs1), IsNil)
 	c.Assert(valsets.Add(vs2), IsNil)
@@ -407,6 +423,7 @@ func (s *validationSetsSuite) TestCheckInstalledSnaps(c *C) {
 	c.Assert(valsets.Add(vs4), IsNil)
 	c.Assert(valsets.Add(vs5), IsNil)
 	c.Assert(valsets.Add(vs6), IsNil)
+	c.Assert(valsets.Add(vs7), IsNil)
 
 	snapA := snapasserts.NewInstalledSnap("snap-a", "mysnapaaaaaaaaaaaaaaaaaaaaaaaaaa", snap.R(1))
 	snapAlocal := snapasserts.NewInstalledSnap("snap-a", "", snap.R("x2"))
@@ -440,6 +457,7 @@ func (s *validationSetsSuite) TestCheckInstalledSnaps(c *C) {
 					snap.R(0): {"acme/barname"},
 				},
 				"snap-f": {
+					snap.R(0): {"acme/bahname"},
 					snap.R(4): {"acme/duhname", "acme/huhname"},
 				},
 			},
@@ -457,6 +475,7 @@ func (s *validationSetsSuite) TestCheckInstalledSnaps(c *C) {
 					snap.R(0): {"acme/barname"},
 				},
 				"snap-f": {
+					snap.R(0): {"acme/bahname"},
 					snap.R(4): {"acme/duhname", "acme/huhname"},
 				},
 			},

--- a/asserts/snapasserts/validation_sets_test.go
+++ b/asserts/snapasserts/validation_sets_test.go
@@ -389,15 +389,19 @@ func (s *validationSetsSuite) TestCheckInstalledSnaps(c *C) {
 	tests := []struct {
 		snaps            []*snapasserts.InstalledSnap
 		expectedInvalid  map[string][]string
-		expectedMissing  map[string][]string
+		expectedMissing  map[string]map[snap.Revision][]string
 		expectedWrongRev map[string]map[snap.Revision][]string
 	}{
 		{
 			// required snaps not installed
 			snaps: nil,
-			expectedMissing: map[string][]string{
-				"snap-b": {"acme/fooname"},
-				"snap-d": {"acme/barname"},
+			expectedMissing: map[string]map[snap.Revision][]string{
+				"snap-b": {
+					snap.R(3): {"acme/fooname"},
+				},
+				"snap-d": {
+					snap.R(0): {"acme/barname"},
+				},
 			},
 		},
 		{
@@ -405,9 +409,13 @@ func (s *validationSetsSuite) TestCheckInstalledSnaps(c *C) {
 			snaps: []*snapasserts.InstalledSnap{
 				snapZ,
 			},
-			expectedMissing: map[string][]string{
-				"snap-b": {"acme/fooname"},
-				"snap-d": {"acme/barname"},
+			expectedMissing: map[string]map[snap.Revision][]string{
+				"snap-b": {
+					snap.R(3): {"acme/fooname"},
+				},
+				"snap-d": {
+					snap.R(0): {"acme/barname"},
+				},
 			},
 		},
 		{
@@ -438,8 +446,10 @@ func (s *validationSetsSuite) TestCheckInstalledSnaps(c *C) {
 			expectedInvalid: map[string][]string{
 				"snap-a": {"acme/booname", "acme/fooname"},
 			},
-			expectedMissing: map[string][]string{
-				"snap-b": {"acme/fooname"},
+			expectedMissing: map[string]map[snap.Revision][]string{
+				"snap-b": {
+					snap.R(3): {"acme/fooname"},
+				},
 			},
 		},
 		{
@@ -482,8 +492,10 @@ func (s *validationSetsSuite) TestCheckInstalledSnaps(c *C) {
 				snapB,
 				// covered by acme/barname validation-set. snap-d not installed.
 				snapE},
-			expectedMissing: map[string][]string{
-				"snap-d": {"acme/barname"},
+			expectedMissing: map[string]map[snap.Revision][]string{
+				"snap-d": {
+					snap.R(0): {"acme/barname"},
+				},
 			},
 		},
 		{
@@ -492,8 +504,10 @@ func (s *validationSetsSuite) TestCheckInstalledSnaps(c *C) {
 				// covered by acme/barname validation-set
 				snapDrev99,
 				snapE},
-			expectedMissing: map[string][]string{
-				"snap-b": {"acme/fooname"},
+			expectedMissing: map[string]map[snap.Revision][]string{
+				"snap-b": {
+					snap.R(3): {"acme/fooname"},
+				},
 			},
 		},
 		{
@@ -502,9 +516,13 @@ func (s *validationSetsSuite) TestCheckInstalledSnaps(c *C) {
 				snapC,
 				// covered by acme/barname validation-set, required missing.
 				snapE},
-			expectedMissing: map[string][]string{
-				"snap-b": {"acme/fooname"},
-				"snap-d": {"acme/barname"},
+			expectedMissing: map[string]map[snap.Revision][]string{
+				"snap-b": {
+					snap.R(3): {"acme/fooname"},
+				},
+				"snap-d": {
+					snap.R(0): {"acme/barname"},
+				},
 			},
 		},
 		// local snaps
@@ -561,9 +579,9 @@ func (s *validationSetsSuite) TestCheckInstalledSnaps(c *C) {
 		}
 		verr, ok := err.(*snapasserts.ValidationSetsValidationError)
 		c.Assert(ok, Equals, true, Commentf("#%d", i))
-		c.Assert(tc.expectedInvalid, DeepEquals, verr.InvalidSnaps, Commentf("#%d", i))
-		c.Assert(tc.expectedMissing, DeepEquals, verr.MissingSnaps, Commentf("#%d", i))
-		c.Assert(tc.expectedWrongRev, DeepEquals, verr.WrongRevisionSnaps, Commentf("#%d", i))
+		c.Assert(verr.InvalidSnaps, DeepEquals, tc.expectedInvalid, Commentf("#%d", i))
+		c.Assert(verr.MissingSnaps, DeepEquals, tc.expectedMissing, Commentf("#%d", i))
+		c.Assert(verr.WrongRevisionSnaps, DeepEquals, tc.expectedWrongRev, Commentf("#%d", i))
 		checkSets(verr.InvalidSnaps, verr.Sets)
 	}
 }
@@ -654,7 +672,6 @@ func (s *validationSetsSuite) TestCheckInstalledSnapsErrorFormat(c *C) {
 			map[string]interface{}{
 				"name":     "snap-b",
 				"id":       "mysnapbbbbbbbbbbbbbbbbbbbbbbbbbb",
-				"revision": "5",
 				"presence": "required",
 			},
 		},
@@ -663,6 +680,9 @@ func (s *validationSetsSuite) TestCheckInstalledSnapsErrorFormat(c *C) {
 	valsets := snapasserts.NewValidationSets()
 	c.Assert(valsets.Add(vs1), IsNil)
 	c.Assert(valsets.Add(vs2), IsNil)
+
+	// not strictly important, but ensures test data makes sense and avoids confusing results
+	c.Assert(valsets.Conflict(), IsNil)
 
 	snapA := snapasserts.NewInstalledSnap("snap-a", "mysnapaaaaaaaaaaaaaaaaaaaaaaaaaa", snap.R(1))
 	snapBlocal := snapasserts.NewInstalledSnap("snap-b", "", snap.R("x3"))
@@ -675,13 +695,13 @@ func (s *validationSetsSuite) TestCheckInstalledSnapsErrorFormat(c *C) {
 			nil,
 			"validation sets assertions are not met:\n" +
 				"- missing required snaps:\n" +
-				"  - snap-b \\(required by sets acme/barname,acme/fooname\\)",
+				"  - snap-b \\(required at any revision by sets acme/barname, at revision 3 by sets acme/fooname\\)",
 		},
 		{
 			[]*snapasserts.InstalledSnap{snapA},
 			"validation sets assertions are not met:\n" +
 				"- missing required snaps:\n" +
-				"  - snap-b \\(required by sets acme/barname,acme/fooname\\)\n" +
+				"  - snap-b \\(required at any revision by sets acme/barname, at revision 3 by sets acme/fooname\\)\n" +
 				"- invalid snaps:\n" +
 				"  - snap-a \\(invalid for sets acme/fooname\\)",
 		},
@@ -689,7 +709,7 @@ func (s *validationSetsSuite) TestCheckInstalledSnapsErrorFormat(c *C) {
 			[]*snapasserts.InstalledSnap{snapBlocal},
 			"validation sets assertions are not met:\n" +
 				"- snaps at wrong revisions:\n" +
-				"  - snap-b \\(required at revision 3 by sets acme/fooname, at revision 5 by sets acme/barname\\)",
+				"  - snap-b \\(required at revision 3 by sets acme/fooname\\)",
 		},
 	}
 

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -2849,7 +2849,7 @@ func (s *assertMgrSuite) TestRefreshValidationSetAssertionsEnforcingModeMissingS
 	assertstate.UpdateValidationSet(s.state, &tr)
 
 	c.Assert(assertstate.RefreshValidationSetAssertions(s.state, 0, nil), IsNil)
-	c.Assert(logbuf.String(), Matches, `.*cannot refresh to validation set assertions that do not satisfy installed snaps: validation sets assertions are not met:\n- missing required snaps:\n  - foo \(required by sets .*/foo\)\n`)
+	c.Assert(logbuf.String(), Matches, `.*cannot refresh to validation set assertions that do not satisfy installed snaps: validation sets assertions are not met:\n- missing required snaps:\n  - foo \(required at any revision by sets .*/foo\)\n`)
 
 	a, err := assertstate.DB(s.state).Find(asserts.ValidationSetType, map[string]string{
 		"series":     "16",
@@ -3133,8 +3133,10 @@ func (s *assertMgrSuite) TestValidationSetAssertionForEnforceNotPinnedUnhappyMis
 	c.Assert(err, NotNil)
 	verr, ok := err.(*snapasserts.ValidationSetsValidationError)
 	c.Assert(ok, Equals, true)
-	c.Check(verr.MissingSnaps, DeepEquals, map[string][]string{
-		"foo": {fmt.Sprintf("%s/bar", s.dev1Acct.AccountID())},
+	c.Check(verr.MissingSnaps, DeepEquals, map[string]map[snap.Revision][]string{
+		"foo": {
+			snap.R(1): []string{fmt.Sprintf("%s/bar", s.dev1Acct.AccountID())},
+		},
 	})
 
 	// and it hasn't been committed

--- a/tests/main/snap-validate-enforce/task.yaml
+++ b/tests/main/snap-validate-enforce/task.yaml
@@ -32,7 +32,7 @@ execute: |
   fi
   MATCH "error: cannot apply validation set: cannot enforce validation set: validation sets assertions are not met:" < log.txt
   MATCH "missing required snaps:" < log.txt
-  MATCH "test-snapd-validation-set-enforcing \(required by sets xSfWKGdLoQBoQx88vIM1MpbFNMq53t1f/testenforce1\)" < log.txt
+  MATCH "test-snapd-validation-set-enforcing \(required at any revision by sets xSfWKGdLoQBoQx88vIM1MpbFNMq53t1f/testenforce1\)" < log.txt
 
   echo "Install the required snap and enable enforcing mode, pinned at sequence point 1"
   snap install --beta test-snapd-validation-set-enforcing


### PR DESCRIPTION
Store required snap revision (if set in the assertion) for missing snaps in CheckInstalledSnaps as they will be needed when installing snaps to satisfy requested validation sets. This wasn't needed before because we were only reporting an error about missing snaps on `snap validate enforce ...`
