### PR TITLE
tests: add suport fof uc22 in test uboot-unpacked-assets

### DIFF
--- a/tests/core/uboot-unpacked-assets/task.yaml
+++ b/tests/core/uboot-unpacked-assets/task.yaml
@@ -7,8 +7,8 @@ environment:
     NAME/kernelimg: kernel.img
 
 execute: |
-    if os.query is-core20; then
-        echo "Check that on UC20, the kernel snap is extracted onto ubuntu-seed, not on ubuntu-boot"
+    if os.query is-core20 || os.query is-core22; then
+        echo "Check that on UC20 and UC22, the kernel snap is extracted onto ubuntu-seed, not on ubuntu-boot"
         output=$(find /run/mnt/ubuntu-seed/systems/*/kernel/ -name "$NAME" )
         if [ -z "$output" ]; then
             echo "Not found expected file $NAME in /run/mnt/ubuntu-seed/systems/*/kernel/"


### PR DESCRIPTION
Simple fix to make the test work on devices using uc22
