### PR TITLE
wrappers: fix LogNamespace being written to the wrong file

### DIFF
--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -138,13 +138,6 @@ TasksAccounting=true
 	return buf.String()
 }
 
-func formatLogNamespaceSlice(grp *quota.Group) string {
-	if grp.JournalLimit == nil {
-		return ""
-	}
-	return fmt.Sprintf("LogNamespace=snap-%s\n", grp.Name)
-}
-
 // generateGroupSliceFile generates a systemd slice unit definition for the
 // specified quota group.
 func generateGroupSliceFile(grp *quota.Group) []byte {
@@ -153,7 +146,6 @@ func generateGroupSliceFile(grp *quota.Group) []byte {
 	cpuOptions := formatCpuGroupSlice(grp)
 	memoryOptions := formatMemoryGroupSlice(grp)
 	taskOptions := formatTaskGroupSlice(grp)
-	logOptions := formatLogNamespaceSlice(grp)
 	template := `[Unit]
 Description=Slice for snap quota group %[1]s
 Before=slices.target
@@ -163,7 +155,7 @@ X-Snappy=yes
 `
 
 	fmt.Fprintf(&buf, template, grp.Name)
-	fmt.Fprint(&buf, cpuOptions, memoryOptions, taskOptions, logOptions)
+	fmt.Fprint(&buf, cpuOptions, memoryOptions, taskOptions)
 	return buf.Bytes()
 }
 
@@ -1207,6 +1199,9 @@ OOMScoreAdjust={{.OOMAdjustScore}}
 {{- if .SliceUnit}}
 Slice={{.SliceUnit}}
 {{- end}}
+{{- if .LogNamespace}}
+LogNamespace={{.LogNamespace}}
+{{- end}}
 {{- if not (or .App.Sockets .App.Timer .App.ActivatesOn) }}
 
 [Install]
@@ -1279,6 +1274,7 @@ WantedBy={{.ServicesTarget}}
 		After                    []string
 		InterfaceServiceSnippets string
 		SliceUnit                string
+		LogNamespace             string
 
 		Home    string
 		EnvVars string
@@ -1323,6 +1319,9 @@ WantedBy={{.ServicesTarget}}
 	// check the quota group slice
 	if opts.QuotaGroup != nil {
 		wrapperData.SliceUnit = opts.QuotaGroup.SliceFileName()
+		if opts.QuotaGroup.JournalLimit != nil {
+			wrapperData.LogNamespace = "snap-" + opts.QuotaGroup.Name
+		}
 	}
 
 	// Add extra "After" targets

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -550,6 +550,7 @@ ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
 TimeoutStopSec=30
 Type=forking
 Slice=snap.foogroup.slice
+LogNamespace=snap-foogroup
 
 [Install]
 WantedBy=multi-user.target
@@ -575,7 +576,6 @@ MemoryAccounting=true
 # Always enable task accounting in order to be able to count the processes/
 # threads, etc for a slice
 TasksAccounting=true
-LogNamespace=snap-foogroup
 `
 
 	jconfContent := fmt.Sprintf(jconfTempl, grp.Name)
@@ -653,6 +653,7 @@ ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
 TimeoutStopSec=30
 Type=forking
 Slice=snap.foogroup.slice
+LogNamespace=snap-foogroup
 
 [Install]
 WantedBy=multi-user.target
@@ -682,7 +683,6 @@ MemoryAccounting=true
 # Always enable task accounting in order to be able to count the processes/
 # threads, etc for a slice
 TasksAccounting=true
-LogNamespace=snap-foogroup
 `
 
 	jconfContent := fmt.Sprintf(jconfTempl, grp.Name)


### PR DESCRIPTION
Another issue found by my journal spread tests, was that I was writing the LogNamespace= setting to the wrong unit file.
