### PR TITLE
tests: enable snapd.apparmor service in all the opensuse systems

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -479,7 +479,7 @@ distro_install_build_snapd(){
             fi
         fi
 
-        if os.query is-opensuse-tumbleweed || os.query is-arch-linux; then
+        if os.query is-opensuse || os.query is-arch-linux; then
             # Package installation applies vendor presets only, which leaves
             # snapd.apparmor disabled.
             systemctl enable --now snapd.apparmor.service


### PR DESCRIPTION
In opensuse leap 13 I see the following error generated
WARNING: There is 1 new warning. See 'snap warnings'.

and then after run snap warning:

last-occurrence:  today at 14:01 UTC
warning: |
the snapd.apparmor service is disabled; snap applications will likely
not start.
  Run "systemctl enable --now snapd.apparmor" to correct this.


This change is fixing 2 tests:
tests/main/snap-info
tests/main/bad-interfaces-warn