### PR TITLE
overlord/servicestate: refresh security profiles when services are affected by quotas

### DIFF
--- a/overlord/servicestate/export_test.go
+++ b/overlord/servicestate/export_test.go
@@ -40,8 +40,8 @@ func (m *ServiceManager) DoQuotaControl(t *state.Task, to *tomb.Tomb) error {
 	return m.doQuotaControl(t, to)
 }
 
-func (m *ServiceManager) DoQuotaServiceRestart(t *state.Task, to *tomb.Tomb) error {
-	return m.doQuotaRestartServices(t, to)
+func (m *ServiceManager) DoServiceControl(t *state.Task, to *tomb.Tomb) error {
+	return m.doServiceControl(t, to)
 }
 
 func MockOsutilBootID(mockID string) (restore func()) {

--- a/overlord/servicestate/export_test.go
+++ b/overlord/servicestate/export_test.go
@@ -40,6 +40,10 @@ func (m *ServiceManager) DoQuotaControl(t *state.Task, to *tomb.Tomb) error {
 	return m.doQuotaControl(t, to)
 }
 
+func (m *ServiceManager) DoQuotaServiceRestart(t *state.Task, to *tomb.Tomb) error {
+	return m.doQuotaRestartServices(t, to)
+}
+
 func MockOsutilBootID(mockID string) (restore func()) {
 	old := osutilBootID
 	osutilBootID = func() (string, error) {

--- a/overlord/servicestate/quota_control_test.go
+++ b/overlord/servicestate/quota_control_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	. "gopkg.in/check.v1"
+	tomb "gopkg.in/tomb.v2"
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget/quantity"
@@ -69,6 +70,15 @@ func (s *quotaControlSuite) SetUpTest(c *C) {
 		return nil
 	})
 	s.AddCleanup(r)
+
+	// Add fake handlers for tasks handled by interfaces manager
+	fakeHandler := func(task *state.Task, _ *tomb.Tomb) error {
+		task.State().Lock()
+		_, err := snapstate.TaskSnapSetup(task)
+		task.State().Unlock()
+		return err
+	}
+	s.o.TaskRunner().AddHandler("setup-profiles", fakeHandler, fakeHandler)
 }
 
 type quotaGroupState struct {

--- a/overlord/servicestate/quota_control_test.go
+++ b/overlord/servicestate/quota_control_test.go
@@ -159,10 +159,13 @@ func checkQuotaState(c *C, st *state.State, exp map[string]quotaGroupState) {
 	}
 }
 
+// shouldMentionSlice returns whether or not a slice file
+// should be mentioned in the service unit file. It does in the case
+// when a quota is set.
 func shouldMentionSlice(resources quota.Resources) bool {
-	// If no quota is set, then Validate returns an error. And only
-	// valid quotas will get written to the slice file.
-	if err := resources.Validate(); err != nil {
+	if resources.Memory == nil && resources.CPU == nil &&
+		resources.CPUSet == nil && resources.Threads == nil &&
+		resources.Journal == nil {
 		return false
 	}
 	return true

--- a/overlord/servicestate/quota_control_test.go
+++ b/overlord/servicestate/quota_control_test.go
@@ -89,6 +89,44 @@ type quotaGroupState struct {
 	Snaps          []string
 }
 
+func assertQuotaResources(c *C, grp *quota.Group, expected quota.Resources) {
+	if grp.MemoryLimit != 0 || expected.Memory != nil {
+		c.Assert(expected.Memory, NotNil)
+		c.Assert(grp.MemoryLimit > 0, Equals, true)
+		c.Check(grp.MemoryLimit, Equals, expected.Memory.Limit)
+	}
+	if grp.CPULimit != nil || expected.CPU != nil || expected.CPUSet != nil {
+		c.Assert(grp.CPULimit, NotNil)
+
+		if grp.CPULimit.Count != 0 || grp.CPULimit.Percentage != 0 || expected.CPU != nil {
+			c.Assert(expected.CPU, NotNil)
+			c.Check(grp.CPULimit.Count, Equals, expected.CPU.Count)
+			c.Check(grp.CPULimit.Percentage, Equals, expected.CPU.Percentage)
+		}
+		if len(grp.CPULimit.AllowedCPUs) > 0 || expected.CPUSet != nil {
+			c.Assert(expected.CPUSet, NotNil)
+			c.Check(grp.CPULimit.AllowedCPUs, DeepEquals, expected.CPUSet.CPUs)
+		}
+	}
+	if grp.TaskLimit != 0 || expected.Threads != nil {
+		c.Assert(expected.Threads, NotNil)
+		c.Check(grp.TaskLimit, Equals, expected.Threads.Limit)
+	}
+	if grp.JournalLimit != nil || expected.Journal != nil {
+		c.Assert(grp.JournalLimit, NotNil)
+		c.Assert(expected.Journal, NotNil)
+		if grp.JournalLimit.Size != 0 {
+			c.Assert(expected.Journal.Size, NotNil)
+			c.Check(grp.JournalLimit.Size, Equals, expected.Journal.Size.Limit)
+		}
+		if grp.JournalLimit.RateCount != 0 && grp.JournalLimit.RatePeriod != 0 {
+			c.Assert(expected.Journal.Rate, NotNil)
+			c.Check(grp.JournalLimit.RateCount, Equals, expected.Journal.Rate.Count)
+			c.Check(grp.JournalLimit.RatePeriod, Equals, expected.Journal.Rate.Period)
+		}
+	}
+}
+
 func checkQuotaState(c *C, st *state.State, exp map[string]quotaGroupState) {
 	m, err := servicestate.AllQuotas(st)
 	c.Assert(err, IsNil)
@@ -97,6 +135,7 @@ func checkQuotaState(c *C, st *state.State, exp map[string]quotaGroupState) {
 		expGrp, ok := exp[name]
 		c.Assert(ok, Equals, true, Commentf("unexpected group %q in state", name))
 		c.Assert(grp.ParentGroup, Equals, expGrp.ParentGroup)
+		assertQuotaResources(c, grp, expGrp.ResourceLimits)
 
 		c.Assert(grp.Snaps, HasLen, len(expGrp.Snaps))
 		if len(expGrp.Snaps) != 0 {

--- a/overlord/servicestate/quota_handlers.go
+++ b/overlord/servicestate/quota_handlers.go
@@ -22,7 +22,6 @@ package servicestate
 import (
 	"errors"
 	"fmt"
-	"log"
 	"sort"
 
 	tomb "gopkg.in/tomb.v2"
@@ -157,7 +156,6 @@ func (m *ServiceManager) doQuotaControl(t *state.Task, _ *tomb.Tomb) error {
 		}
 	}
 
-	log.Println("[QUOTA]", "quota-control", len(servicesAffected), refreshProfiles)
 	if len(servicesAffected) > 0 {
 		var prevTaskSet *state.TaskSet
 		chg := t.Change()
@@ -448,7 +446,6 @@ func quotaUpdate(st *state.State, action QuotaControlAction, allGrps map[string]
 	// store the current status of journal quota, if it changes we need
 	// to refresh the profiles for the snaps in the groups
 	refreshProfiles := grp.JournalLimit != nil
-	log.Println("[DEBUG] quotaUpdate: refreshProfiles", refreshProfiles)
 
 	// update resource limits for the group
 	if err := quotaUpdateGroupLimits(grp, action.ResourceLimits); err != nil {
@@ -462,7 +459,6 @@ func quotaUpdate(st *state.State, action QuotaControlAction, allGrps map[string]
 	}
 
 	refreshProfiles = refreshProfiles != (grp.JournalLimit != nil)
-	log.Println("[DEBUG] quotaUpdate: refreshProfiles", refreshProfiles)
 	return grp, allGrps, refreshProfiles, nil
 }
 

--- a/overlord/servicestate/quota_handlers.go
+++ b/overlord/servicestate/quota_handlers.go
@@ -439,7 +439,7 @@ func quotaUpdate(st *state.State, action QuotaControlAction, allGrps map[string]
 
 	// store the current status of journal quota, if it changes we need
 	// to refresh the profiles for the snaps in the groups
-	refreshProfiles := grp.JournalLimit != nil
+	hadJournalLimit := grp.JournalLimit != nil
 
 	// update resource limits for the group
 	if err := quotaUpdateGroupLimits(grp, action.ResourceLimits); err != nil {
@@ -452,7 +452,8 @@ func quotaUpdate(st *state.State, action QuotaControlAction, allGrps map[string]
 		return nil, nil, false, err
 	}
 
-	refreshProfiles = refreshProfiles != (grp.JournalLimit != nil)
+	hasJournalLimit := (grp.JournalLimit != nil)
+	refreshProfiles := hadJournalLimit != hasJournalLimit
 	return grp, allGrps, refreshProfiles, nil
 }
 

--- a/overlord/servicestate/quota_handlers_test.go
+++ b/overlord/servicestate/quota_handlers_test.go
@@ -1278,10 +1278,13 @@ func (s *quotaHandlersSuite) TestCreateJournalQuota(c *C) {
 	// when creating the journal quota.
 	var setupProfilesCalled int
 	fakeHandler := func(task *state.Task, _ *tomb.Tomb) error {
-		task.State().Lock()
-		_, err := snapstate.TaskSnapSetup(task)
-		task.State().Unlock()
 		setupProfilesCalled++
+		task.State().Lock()
+		snapInfo, err := snapstate.TaskSnapSetup(task)
+		task.State().Unlock()
+		c.Assert(err, IsNil)
+		c.Check(snapInfo.InstanceName(), Equals, "test-snap")
+		c.Check(snapInfo.SideInfo.Revision, Equals, s.testSnapSideInfo.Revision)
 		return err
 	}
 	s.o.TaskRunner().AddHandler("setup-profiles", fakeHandler, fakeHandler)
@@ -1336,10 +1339,13 @@ func (s *quotaHandlersSuite) TestAddJournalQuota(c *C) {
 	// when creating the journal quota.
 	var setupProfilesCalled int
 	fakeHandler := func(task *state.Task, _ *tomb.Tomb) error {
-		task.State().Lock()
-		_, err := snapstate.TaskSnapSetup(task)
-		task.State().Unlock()
 		setupProfilesCalled++
+		task.State().Lock()
+		snapInfo, err := snapstate.TaskSnapSetup(task)
+		task.State().Unlock()
+		c.Assert(err, IsNil)
+		c.Check(snapInfo.InstanceName(), Equals, "test-snap")
+		c.Check(snapInfo.SideInfo.Revision, Equals, s.testSnapSideInfo.Revision)
 		return err
 	}
 	s.o.TaskRunner().AddHandler("setup-profiles", fakeHandler, fakeHandler)
@@ -1416,10 +1422,13 @@ func (s *quotaHandlersSuite) TestUpdateJournalQuota(c *C) {
 	// when creating the journal quota.
 	var setupProfilesCalled int
 	fakeHandler := func(task *state.Task, _ *tomb.Tomb) error {
-		task.State().Lock()
-		_, err := snapstate.TaskSnapSetup(task)
-		task.State().Unlock()
 		setupProfilesCalled++
+		task.State().Lock()
+		snapInfo, err := snapstate.TaskSnapSetup(task)
+		task.State().Unlock()
+		c.Assert(err, IsNil)
+		c.Check(snapInfo.InstanceName(), Equals, "test-snap")
+		c.Check(snapInfo.SideInfo.Revision, Equals, s.testSnapSideInfo.Revision)
 		return err
 	}
 	s.o.TaskRunner().AddHandler("setup-profiles", fakeHandler, fakeHandler)
@@ -1475,10 +1484,13 @@ func (s *quotaHandlersSuite) TestRemoveJournalQuota(c *C) {
 	// when creating the journal quota.
 	var setupProfilesCalled int
 	fakeHandler := func(task *state.Task, _ *tomb.Tomb) error {
-		task.State().Lock()
-		_, err := snapstate.TaskSnapSetup(task)
-		task.State().Unlock()
 		setupProfilesCalled++
+		task.State().Lock()
+		snapInfo, err := snapstate.TaskSnapSetup(task)
+		task.State().Unlock()
+		c.Assert(err, IsNil)
+		c.Check(snapInfo.InstanceName(), Equals, "test-snap")
+		c.Check(snapInfo.SideInfo.Revision, Equals, s.testSnapSideInfo.Revision)
 		return err
 	}
 	s.o.TaskRunner().AddHandler("setup-profiles", fakeHandler, fakeHandler)

--- a/overlord/servicestate/servicemgr.go
+++ b/overlord/servicestate/servicemgr.go
@@ -61,6 +61,7 @@ func Manager(st *state.State, runner *state.TaskRunner) *ServiceManager {
 
 	// TODO: undo handler
 	runner.AddHandler("quota-control", m.doQuotaControl, nil)
+	runner.AddHandler("quota-restart-services", m.doQuotaRestartServices, nil)
 
 	snapstate.AddAffectedSnapsByKind("quota-control", quotaControlAffectedSnaps)
 

--- a/overlord/servicestate/servicemgr.go
+++ b/overlord/servicestate/servicemgr.go
@@ -61,7 +61,6 @@ func Manager(st *state.State, runner *state.TaskRunner) *ServiceManager {
 
 	// TODO: undo handler
 	runner.AddHandler("quota-control", m.doQuotaControl, nil)
-	runner.AddHandler("quota-restart-services", m.doQuotaRestartServices, nil)
 
 	snapstate.AddAffectedSnapsByKind("quota-control", quotaControlAffectedSnaps)
 


### PR DESCRIPTION
It was a missing step to get journal quotas to work. The code that adds the redirect in the .fstab for the services is not triggered when putting a snap into or out of a quota group. 

This code now triggers a "setup-profiles" for each snap that is affected by quota changes.