### PR TITLE
interfaces/apparmor: add missing apparmor rules for journal namespaces

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -190,7 +190,9 @@ var templateCommon = `
   /usr/lib/os-release k,
 
   # systemd native journal API (see sd_journal_print(4)). This should be in
-  # AppArmor's base abstraction, but until it is, include here.
+  # AppArmor's base abstraction, but until it is, include here. We include
+  # the base journal path as well as the journal namespace pattern path. Each
+  # journal namespace for quota groups will be prefixed with 'snap-'.
   /run/systemd/journal{,.snap-*}/socket w,
   /run/systemd/journal{,.snap-*}/stdout rw, # 'r' shouldn't be needed, but journald
                                             # doesn't leak anything so allow

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -191,9 +191,9 @@ var templateCommon = `
 
   # systemd native journal API (see sd_journal_print(4)). This should be in
   # AppArmor's base abstraction, but until it is, include here.
-  /run/systemd/journal{,.*}/socket w,
-  /run/systemd/journal{,.*}/stdout rw, # 'r' shouldn't be needed, but journald
-                                  # doesn't leak anything so allow
+  /run/systemd/journal{,.snap-*}/socket w,
+  /run/systemd/journal{,.snap-*}/stdout rw, # 'r' shouldn't be needed, but journald
+                                            # doesn't leak anything so allow
 
   # snapctl and its requirements
   /usr/bin/snapctl ixr,

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -191,8 +191,8 @@ var templateCommon = `
 
   # systemd native journal API (see sd_journal_print(4)). This should be in
   # AppArmor's base abstraction, but until it is, include here.
-  /run/systemd/journal/socket w,
-  /run/systemd/journal/stdout rw, # 'r' shouldn't be needed, but journald
+  /run/systemd/journal{,.*}/socket w,
+  /run/systemd/journal{,.*}/stdout rw, # 'r' shouldn't be needed, but journald
                                   # doesn't leak anything so allow
 
   # snapctl and its requirements


### PR DESCRIPTION
Currently the path in apparmor allows writes to the journal socket/stdout, which resides in `/run/systemd/journal`, which is fine for the default journal. However when journal namespaces are used, a new folder will be created for each namespace. Their paths will look like `/run/systemd/journal.{namespace}`

To support journal namespaces, this change is needed