### PR TITLE
cmd/snap-update-ns: add /run/systemd to unrestricted paths

### DIFF
--- a/cmd/snap-update-ns/system.go
+++ b/cmd/snap-update-ns/system.go
@@ -69,7 +69,7 @@ func (upCtx *SystemProfileUpdateContext) Assumptions() *Assumptions {
 	// remapping for parallel installs only when the snap has an instance key
 	as := &Assumptions{}
 	instanceName := upCtx.InstanceName()
-	as.AddUnrestrictedPaths("/tmp", "/var/snap", "/snap/"+instanceName, "/dev/shm")
+	as.AddUnrestrictedPaths("/tmp", "/var/snap", "/snap/"+instanceName, "/dev/shm", "/run/systemd")
 	if snapName := snap.InstanceSnap(instanceName); snapName != instanceName {
 		as.AddUnrestrictedPaths("/snap/" + snapName)
 	}

--- a/cmd/snap-update-ns/system_test.go
+++ b/cmd/snap-update-ns/system_test.go
@@ -74,7 +74,7 @@ func (s *systemSuite) TestAssumptions(c *C) {
 	// Non-instances can access /tmp, /var/snap and /snap/$SNAP_NAME
 	upCtx := update.NewSystemProfileUpdateContext("foo", false)
 	as := upCtx.Assumptions()
-	c.Check(as.UnrestrictedPaths(), DeepEquals, []string{"/tmp", "/var/snap", "/snap/foo", "/dev/shm", "/var/lib/snapd/hostfs/tmp"})
+	c.Check(as.UnrestrictedPaths(), DeepEquals, []string{"/tmp", "/var/snap", "/snap/foo", "/dev/shm", "/run/systemd", "/var/lib/snapd/hostfs/tmp"})
 	c.Check(as.ModeForPath("/stuff"), Equals, os.FileMode(0755))
 	c.Check(as.ModeForPath("/tmp"), Equals, os.FileMode(0755))
 	c.Check(as.ModeForPath("/var/lib/snapd/hostfs/tmp"), Equals, os.FileMode(0755))
@@ -87,7 +87,7 @@ func (s *systemSuite) TestAssumptions(c *C) {
 	// Instances can, in addition, access /snap/$SNAP_INSTANCE_NAME
 	upCtx = update.NewSystemProfileUpdateContext("foo_instance", false)
 	as = upCtx.Assumptions()
-	c.Check(as.UnrestrictedPaths(), DeepEquals, []string{"/tmp", "/var/snap", "/snap/foo_instance", "/dev/shm", "/snap/foo", "/var/lib/snapd/hostfs/tmp"})
+	c.Check(as.UnrestrictedPaths(), DeepEquals, []string{"/tmp", "/var/snap", "/snap/foo_instance", "/dev/shm", "/run/systemd", "/snap/foo", "/var/lib/snapd/hostfs/tmp"})
 }
 
 func (s *systemSuite) TestLoadDesiredProfile(c *C) {

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -945,6 +945,10 @@ func (s *ValidateSuite) TestValidateLayout(c *C) {
 		ErrorMatches, `layout "/sys" in an off-limits area`)
 	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/run", Type: "tmpfs"}, nil),
 		ErrorMatches, `layout "/run" in an off-limits area`)
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/run/foo", Type: "tmpfs"}, nil),
+		ErrorMatches, `layout "/run/foo" in an off-limits area`)
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/run/systemd", Type: "tmpfs"}, nil),
+		ErrorMatches, `layout "/run/systemd" in an off-limits area`)
 	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/boot", Type: "tmpfs"}, nil),
 		ErrorMatches, `layout "/boot" in an off-limits area`)
 	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/lost+found", Type: "tmpfs"}, nil),


### PR DESCRIPTION
This allows the bind mount of /run/systemd/journal.<namespace> to /run/systemd/journal which is required to enable log namespaces.