### PR TITLE
interfaces: update AppArmor template to allow read the memory …

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -285,6 +285,7 @@ var templateCommon = `
   /sys/devices/virtual/tty/{console,tty*}/active r,
   /sys/fs/cgroup/memory/{,user.slice/}memory.limit_in_bytes r,
   /sys/fs/cgroup/memory/{,**/}snap.@{SNAP_INSTANCE_NAME}{,.*}/memory.limit_in_bytes r,
+  /sys/fs/cgroup/memory/{,**/}snap.@{SNAP_INSTANCE_NAME}{,.*}/memory.stat r,
   /sys/fs/cgroup/cpu,cpuacct/{,user.slice/}cpu.cfs_{period,quota}_us r,
   /sys/fs/cgroup/cpu,cpuacct/{,**/}snap.@{SNAP_INSTANCE_NAME}{,.*}/cpu.cfs_{period,quota}_us r,
   /sys/fs/cgroup/cpu,cpuacct/{,user.slice/}cpu.shares r,


### PR DESCRIPTION
The customer would like to use the mentioned path below and gets a AppArmor denial. This PR aims to extend `system-observe` interface to provide read access to the required path .

```
= AppArmor =
Time: Jun 15 21:38:49

Log: apparmor="DENIED" operation="open" profile="snap.xxx.xxx-service" name="/sys/fs/cgroup/memory/system.slice/snap.xxx.xxx-service.service/memory.stat" pid=29317 comm="xxx" requested_mask="r" denied_mask="r" fsuid=0 ouid=0

File: /sys/fs/cgroup/memory/system.slice/snap.xxx.xxx.service/memory.stat (read)
```