### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/cla-check.yaml
+++ b/.github/workflows/cla-check.yaml
@@ -4,8 +4,13 @@ on:
   pull_request:
     branches: [ "master", "release/**" ]
 
+permissions:
+  contents: read
+
 jobs:
   cla-check:
+    permissions:
+      pull-requests: write  # for canonical/has-signed-canonical-cla to create & update comments
     runs-on: ubuntu-latest
     steps:
       - name: Check if CLA signed

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -2,8 +2,14 @@ name: "Pull Request Labeler"
 on:
   - pull_request_target
 
+permissions:
+  contents: read
+
 jobs:
   triage:
+    permissions:
+      contents: read  # for actions/labeler to determine modified files
+      pull-requests: write  # for actions/labeler to add labels to PRs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@main

--- a/.github/workflows/macos-quick.yaml
+++ b/.github/workflows/macos-quick.yaml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: ["master", "release/**"]
 
+permissions:
+  contents: read
+
 jobs:
   macos-quick:
     runs-on: macos-latest

--- a/.github/workflows/riscv64-builds.yml
+++ b/.github/workflows/riscv64-builds.yml
@@ -5,8 +5,13 @@ on:
   - cron: "0 0 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lp-snap-request-build:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     steps:
       - name: trigger-lp-snap-request-build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -321,6 +321,8 @@ jobs:
         path: "${{ github.workspace }}/src/github.com/snapcore/snapd/.coverage/coverage*.cov"
 
   code-coverage:
+    permissions:
+      contents: none
     needs: [unit-tests]
     runs-on: ubuntu-20.04
     env:


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
