### PR TITLE
snapd-apparmor: add more integration-ish tests

### DIFF
--- a/cmd/snapd-apparmor/main.go
+++ b/cmd/snapd-apparmor/main.go
@@ -113,8 +113,7 @@ func isContainerWithInternalPolicy() bool {
 func loadAppArmorProfiles() error {
 	candidates, err := filepath.Glob(dirs.SnapAppArmorDir + "/*")
 	if err != nil {
-		err = fmt.Errorf("Failed to glob profiles from snap apparmor dir %s: %v", dirs.SnapAppArmorDir, err)
-		return err
+		return fmt.Errorf("Failed to glob profiles from snap apparmor dir %s: %v", dirs.SnapAppArmorDir, err)
 	}
 
 	profiles := make([]string, 0, len(candidates))

--- a/cmd/snapd-apparmor/main_test.go
+++ b/cmd/snapd-apparmor/main_test.go
@@ -25,6 +25,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	. "gopkg.in/check.v1"
@@ -240,4 +241,7 @@ func (s *integrationSuite) TestRunNormalLoadsProfiles(c *C) {
 	err := snapd_apparmor.Run()
 	c.Assert(err, IsNil)
 	c.Assert(s.parserCmd.Calls(), HasLen, 1)
+	logLines := strings.Split(strings.TrimSpace(s.logBuf.String()), "\n")
+	c.Check(logLines, HasLen, 1)
+	c.Check(logLines[0], Matches, `.* main.go:[0-9]+: Loading profiles \[.*/var/lib/snapd/apparmor/profiles/foo\]`)
 }

--- a/cmd/snapd-apparmor/main_test.go
+++ b/cmd/snapd-apparmor/main_test.go
@@ -20,6 +20,7 @@
 package main_test
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -30,6 +31,7 @@ import (
 
 	snapd_apparmor "github.com/snapcore/snapd/cmd/snapd-apparmor"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -179,15 +181,63 @@ func (s *mainSuite) TestValidateArgs(c *C) {
 	}
 }
 
-func (s *mainSuite) TestRun(c *C) {
+type integrationSuite struct {
+	testutil.BaseTest
+
+	logBuf    *bytes.Buffer
+	parserCmd *testutil.MockCmd
+}
+
+var _ = Suite(&integrationSuite{})
+
+func (s *integrationSuite) SetUpTest(c *C) {
+	dirs.SetRootDir(c.MkDir())
+	s.AddCleanup(func() { dirs.SetRootDir("/") })
+
+	logBuf, r := logger.MockLogger()
+	s.AddCleanup(r)
+	s.logBuf = logBuf
+
+	// simulate a single profile to load
+	s.parserCmd = testutil.MockCommand(c, "apparmor_parser", "")
+	s.AddCleanup(s.parserCmd.Restore)
+	err := os.MkdirAll(dirs.SnapAppArmorDir, 0755)
+	c.Assert(err, IsNil)
+	profile := filepath.Join(dirs.SnapAppArmorDir, "foo")
+	err = ioutil.WriteFile(profile, nil, 0644)
+	c.Assert(err, IsNil)
+
 	os.Args = []string{"snapd-apparmor", "start"}
+}
+
+func (s *integrationSuite) TestRunInContainerSkipsLoading(c *C) {
+	testutil.MockCommand(c, "systemd-detect-virt", "exit 0")
+
 	err := snapd_apparmor.Run()
 	c.Assert(err, IsNil)
+	c.Check(s.logBuf.String(), testutil.Contains, "DEBUG: inside container environment")
+	c.Check(s.logBuf.String(), testutil.Contains, "Inside container environment without internal policy")
+	c.Assert(s.parserCmd.Calls(), HasLen, 0)
+}
 
-	// simulate being inside a container environment
-	detectCmd := testutil.MockCommand(c, "systemd-detect-virt", "echo wsl")
+func (s *integrationSuite) TestRunInContainerWithInternalPolicyLoadsProfiles(c *C) {
+	testutil.MockCommand(c, "systemd-detect-virt", "echo wsl")
+
+	err := snapd_apparmor.Run()
+	c.Assert(err, IsNil)
+	c.Check(s.logBuf.String(), testutil.Contains, "DEBUG: inside container environment")
+	c.Check(s.logBuf.String(), Not(testutil.Contains), "Inside container environment without internal policy")
+	c.Assert(s.parserCmd.Calls(), HasLen, 1)
+}
+
+func (s *integrationSuite) TestRunNormalLoadsProfiles(c *C) {
+	// simulate a normal system (not a container)
+	testutil.MockCommand(c, "systemd-detect-virt", "exit 1")
+
+	detectCmd := testutil.MockCommand(c, "systemd-detect-virt", "exit 1")
 	defer detectCmd.Restore()
 
-	err = snapd_apparmor.Run()
+	err := snapd_apparmor.Run()
 	c.Assert(err, IsNil)
+	c.Assert(s.parserCmd.Calls(), HasLen, 1)
 }


### PR DESCRIPTION
This is a small followup for PR#11129 that tests the "main()"
function a bit more.
