### PR TITLE
tests: add nested test with very off RTC

### DIFF
--- a/tests/nested/manual/minimal-smoke/task.yaml
+++ b/tests/nested/manual/minimal-smoke/task.yaml
@@ -1,6 +1,6 @@
 summary: execute smoke tests in a nested Ubuntu Core VM that meets the minimal requirements
 
-systems: [ubuntu-16.04-64, ubuntu-18.04-64, ubuntu-20.04-64]
+systems: [ubuntu-16.04-64, ubuntu-18.04-64, ubuntu-20.04-64, ubuntu-22.04-64]
 
 environment:
     NESTED_ENABLE_SECURE_BOOT/secboot_disabled: false

--- a/tests/nested/manual/minimal-smoke/task.yaml
+++ b/tests/nested/manual/minimal-smoke/task.yaml
@@ -7,6 +7,7 @@ environment:
     NESTED_ENABLE_TPM/secboot_disabled: false
     NESTED_ENABLE_SECURE_BOOT/secboot_enabled: true
     NESTED_ENABLE_TPM/secboot_enabled: true
+    NESTED_PARAM_RTC/disable_rtc: -rtc base=2000-01-01,clock=vm
 
 prepare: |
     tests.nested build-image core


### PR DESCRIPTION
This simulates a boot with an RTC that is very outdated (2000-01-01).

When using the epoch (1970-01-01) qemu gets confused inside the
google cloud env and moves us to 2070 instead hence this test
uses 2000-01-01.

This test ensures that UC can boot even if the system clock is
very off.

(it also add  22.04 to the minimal test).