### PR TITLE
o/devicestate: post factory reset ensure, spread test update

### DIFF
--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -2340,6 +2340,11 @@ func (s *deviceMgrInstallModeSuite) doRunFactoryResetChange(c *C, model *asserts
 	s.state.Unlock()
 
 	var saveKey keys.EncryptionKey
+	restore = devicestate.MockSecbootTransitionEncryptionKeyChange(func(node string, key keys.EncryptionKey) error {
+		c.Errorf("unexpected call")
+		return fmt.Errorf("unexpected call")
+	})
+	defer restore()
 	restore = devicestate.MockSecbootStageEncryptionKeyChange(func(node string, key keys.EncryptionKey) error {
 		if tc.encrypt {
 			c.Check(node, Equals, "/dev/foo-save")

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -22,6 +22,7 @@ package devicestate_test
 import (
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1898,4 +1899,168 @@ func (s *deviceMgrSuite) TestVoidDirPermissionsGetFixed(c *C) {
 	msgs := strings.TrimSpace(logbuf.String())
 	c.Check(msgs, Matches, "(?sm).*fixing permissions of .*/var/lib/snapd/void to 0111")
 	c.Check(strings.Split(msgs, "\n"), HasLen, 1)
+}
+
+func (s *deviceMgrSuite) TestDeviceManagerEnsurePostFactoryResetEncrypted(c *C) {
+	defer release.MockOnClassic(false)
+
+	s.state.Lock()
+	s.state.Set("seeded", true)
+	s.state.Unlock()
+	devicestate.SetBootOkRan(s.mgr, false)
+	devicestate.SetSystemMode(s.mgr, "run")
+
+	// encrypted system
+	mockSnapFDEFile(c, "marker", nil)
+	err := ioutil.WriteFile(filepath.Join(dirs.SnapFDEDir, "ubuntu-save.key"),
+		[]byte("save-key"), 0644)
+	c.Assert(err, IsNil)
+	c.Assert(os.MkdirAll(boot.InitramfsSeedEncryptionKeyDir, 0755), IsNil)
+	err = ioutil.WriteFile(filepath.Join(boot.InitramfsSeedEncryptionKeyDir, "ubuntu-save.recovery.sealed-key"),
+		[]byte("old"), 0644)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(filepath.Join(boot.InitramfsSeedEncryptionKeyDir, "ubuntu-save.recovery.sealed-key.factory-reset"),
+		[]byte("save"), 0644)
+	c.Assert(err, IsNil)
+	// matches the .factory key
+	factoryResetMarkercontent := []byte(`{"fallback-save-key-sha3-384":"d192153f0a50e826c6eb400c8711750ed0466571df1d151aaecc8c73095da7ec104318e7bf74d5e5ae2940827bf8402b"}
+`)
+	c.Assert(ioutil.WriteFile(filepath.Join(dirs.SnapDeviceDir, "factory-reset"), factoryResetMarkercontent, 0644), IsNil)
+
+	completeCalls := 0
+	restore := devicestate.MockMarkFactoryResetComplete(func(encrypted bool) error {
+		completeCalls++
+		c.Check(encrypted, Equals, true)
+		return nil
+	})
+	defer restore()
+	transitionCalls := 0
+	restore = devicestate.MockSecbootTransitionEncryptionKeyChange(func(mountpoint string, key keys.EncryptionKey) error {
+		transitionCalls++
+		c.Check(mountpoint, Equals, boot.InitramfsUbuntuSaveDir)
+		c.Check(key, DeepEquals, keys.EncryptionKey([]byte("save-key")))
+		return nil
+	})
+	defer restore()
+
+	err = s.mgr.Ensure()
+	c.Assert(err, IsNil)
+
+	c.Check(completeCalls, Equals, 1)
+	c.Check(transitionCalls, Equals, 1)
+	// factory reset marker is gone, the key was verified successfully
+	c.Check(filepath.Join(dirs.SnapDeviceDir, "factory-reset"), testutil.FileAbsent)
+	c.Check(filepath.Join(dirs.SnapFDEDir, "marker"), testutil.FilePresent)
+
+	completeCalls = 0
+	transitionCalls = 0
+	// try again, no marker, nothing should happen
+	devicestate.SetPostFactoryResetRan(s.mgr, false)
+	err = s.mgr.Ensure()
+	c.Assert(err, IsNil)
+	// nothing was called
+	c.Check(completeCalls, Equals, 0)
+	c.Check(transitionCalls, Equals, 0)
+
+	// have the marker, but migrate the key as if boot code would do it and
+	// try again, in this setup the marker hash matches the migrated key
+	c.Check(os.Rename(filepath.Join(boot.InitramfsSeedEncryptionKeyDir, "ubuntu-save.recovery.sealed-key.factory-reset"),
+		filepath.Join(boot.InitramfsSeedEncryptionKeyDir, "ubuntu-save.recovery.sealed-key")),
+		IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(dirs.SnapDeviceDir, "factory-reset"), factoryResetMarkercontent, 0644), IsNil)
+
+	devicestate.SetPostFactoryResetRan(s.mgr, false)
+	err = s.mgr.Ensure()
+	c.Assert(err, IsNil)
+	c.Check(completeCalls, Equals, 1)
+	c.Check(transitionCalls, Equals, 1)
+	// the marker was again removed
+	c.Check(filepath.Join(dirs.SnapDeviceDir, "factory-reset"), testutil.FileAbsent)
+}
+
+func (s *deviceMgrSuite) TestDeviceManagerEnsurePostFactoryResetEncryptedError(c *C) {
+	defer release.MockOnClassic(false)
+
+	s.state.Lock()
+	s.state.Set("seeded", true)
+	s.state.Unlock()
+	devicestate.SetBootOkRan(s.mgr, false)
+	devicestate.SetSystemMode(s.mgr, "run")
+
+	// encrypted system
+	mockSnapFDEFile(c, "marker", nil)
+	c.Assert(os.MkdirAll(boot.InitramfsSeedEncryptionKeyDir, 0755), IsNil)
+	err := ioutil.WriteFile(filepath.Join(boot.InitramfsSeedEncryptionKeyDir, "ubuntu-save.recovery.sealed-key"),
+		[]byte("old"), 0644)
+	c.Check(err, IsNil)
+	err = ioutil.WriteFile(filepath.Join(boot.InitramfsSeedEncryptionKeyDir, "ubuntu-save.recovery.sealed-key.factory-reset"),
+		[]byte("save"), 0644)
+	c.Check(err, IsNil)
+	// does not match the save key
+	factoryResetMarkercontent := []byte(`{"fallback-save-key-sha3-384":"uh-oh"}
+`)
+	c.Assert(ioutil.WriteFile(filepath.Join(dirs.SnapDeviceDir, "factory-reset"), factoryResetMarkercontent, 0644), IsNil)
+
+	completeCalls := 0
+	restore := devicestate.MockMarkFactoryResetComplete(func(encrypted bool) error {
+		completeCalls++
+		c.Check(encrypted, Equals, true)
+		return nil
+	})
+	defer restore()
+
+	err = s.mgr.Ensure()
+	c.Assert(err, ErrorMatches, "devicemgr: cannot verify factory reset marker: fallback sealed key digest mismatch, got d192153f0a50e826c6eb400c8711750ed0466571df1d151aaecc8c73095da7ec104318e7bf74d5e5ae2940827bf8402b expected uh-oh")
+
+	c.Check(completeCalls, Equals, 0)
+	// factory reset marker is gone, the key was verified successfully
+	c.Check(filepath.Join(dirs.SnapDeviceDir, "factory-reset"), testutil.FilePresent)
+	c.Check(filepath.Join(dirs.SnapFDEDir, "marker"), testutil.FilePresent)
+
+	// try again, no marker, hit the same error
+	devicestate.SetPostFactoryResetRan(s.mgr, false)
+	err = s.mgr.Ensure()
+	c.Assert(err, ErrorMatches, "devicemgr: cannot verify factory reset marker: fallback sealed key digest mismatch, got d192153f0a50e826c6eb400c8711750ed0466571df1d151aaecc8c73095da7ec104318e7bf74d5e5ae2940827bf8402b expected uh-oh")
+	c.Check(completeCalls, Equals, 0)
+
+	// and again, but not resetting the 'ran' check, so nothing is checked or called
+	err = s.mgr.Ensure()
+	c.Assert(err, IsNil)
+	c.Check(completeCalls, Equals, 0)
+}
+
+func (s *deviceMgrSuite) TestDeviceManagerEnsurePostFactoryResetUnencrypted(c *C) {
+	defer release.MockOnClassic(false)
+
+	s.state.Lock()
+	s.state.Set("seeded", true)
+	s.state.Unlock()
+	devicestate.SetBootOkRan(s.mgr, false)
+	devicestate.SetSystemMode(s.mgr, "run")
+
+	// encrypted system
+	c.Assert(os.MkdirAll(dirs.SnapDeviceDir, 0755), IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(dirs.SnapDeviceDir, "factory-reset"), []byte("{}"), 0644), IsNil)
+
+	completeCalls := 0
+	restore := devicestate.MockMarkFactoryResetComplete(func(encrypted bool) error {
+		completeCalls++
+		c.Check(encrypted, Equals, false)
+		return nil
+	})
+	defer restore()
+
+	err := s.mgr.Ensure()
+	c.Assert(err, IsNil)
+
+	c.Check(completeCalls, Equals, 1)
+	// factory reset marker is gone
+	c.Check(filepath.Join(dirs.SnapDeviceDir, "factory-reset"), testutil.FileAbsent)
+
+	// try again, no marker, nothing should happen
+	devicestate.SetPostFactoryResetRan(s.mgr, false)
+	err = s.mgr.Ensure()
+	c.Assert(err, IsNil)
+	// nothing was called
+	c.Check(completeCalls, Equals, 1)
 }

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -2038,7 +2038,7 @@ func (s *deviceMgrSuite) TestDeviceManagerEnsurePostFactoryResetUnencrypted(c *C
 	devicestate.SetBootOkRan(s.mgr, false)
 	devicestate.SetSystemMode(s.mgr, "run")
 
-	// encrypted system
+	// mock the factory reset marker of a system that isn't encrypted
 	c.Assert(os.MkdirAll(dirs.SnapDeviceDir, 0755), IsNil)
 	c.Assert(ioutil.WriteFile(filepath.Join(dirs.SnapDeviceDir, "factory-reset"), []byte("{}"), 0644), IsNil)
 

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -207,6 +207,10 @@ func SetTriedSystemsRan(m *DeviceManager, b bool) {
 	m.ensureTriedRecoverySystemRan = b
 }
 
+func SetPostFactoryResetRan(m *DeviceManager, b bool) {
+	m.ensurePostFactoryResetRan = b
+}
+
 func StartTime() time.Time {
 	return startTime
 }
@@ -360,6 +364,12 @@ func MockSecbootStageEncryptionKeyChange(f func(node string, key keys.Encryption
 	return restore
 }
 
+func MockSecbootTransitionEncryptionKeyChange(f func(mountpoint string, key keys.EncryptionKey) error) (restore func()) {
+	restore = testutil.Backup(&secbootTransitionEncryptionKeyChange)
+	secbootTransitionEncryptionKeyChange = f
+	return restore
+}
+
 func MockCloudInitStatus(f func() (sysconfig.CloudInitState, error)) (restore func()) {
 	old := cloudInitStatus
 	cloudInitStatus = f
@@ -421,5 +431,11 @@ func MockSecbootEnsureRecoveryKey(f func(recoveryKeyFile string, rkeyDevs []secb
 func MockSecbootRemoveRecoveryKeys(f func(rkeyDevToKey map[secboot.RecoveryKeyDevice]string) error) (restore func()) {
 	restore = testutil.Backup(&secbootRemoveRecoveryKeys)
 	secbootRemoveRecoveryKeys = f
+	return restore
+}
+
+func MockMarkFactoryResetComplete(f func(encrypted bool) error) (restore func()) {
+	restore = testutil.Backup(&bootMarkFactoryResetComplete)
+	bootMarkFactoryResetComplete = f
 	return restore
 }

--- a/tests/nested/core/core20-factory-reset/task.yaml
+++ b/tests/nested/core/core20-factory-reset/task.yaml
@@ -91,19 +91,36 @@ execute: |
     tests.nested exec test -e /run/mnt/ubuntu-seed/marker
 
     # the temp factory-reset key is gone
-    # TODO enable those checks one cleanup lands
     # TODO this is a very weak check
-    # tests.nested exec test ! -e /run/mnt/ubuntu-seed/device/fde/ubuntu-save.recovery.sealed-key.factory-reset
+    tests.nested exec test ! -e /run/mnt/ubuntu-seed/device/fde/ubuntu-save.recovery.sealed-key.factory-reset
     # no factory reset marker
-    # tests.nested exec test ! -e /var/lib/snapd/device/factory-reset
+    tests.nested exec test ! -e /var/lib/snapd/device/factory-reset
 
     # verify that the factory-reset log was collected
     tests.nested exec "zcat /var/log/factory-reset-mode.log.gz" | MATCH 'performing factory reset on an installed system'
 
-    # TODO enable checks once the save fallback key is rotated
-    #tests.nested exec cat /run/mnt/ubuntu-seed/device/fde/ubuntu-save.recovery.sealed-key > post-reset-save-fallback-key
+    tests.nested exec cat /run/mnt/ubuntu-seed/device/fde/ubuntu-save.recovery.sealed-key > post-reset-save-fallback-key
     # not a great check as the fallback key may have been resealed, but it
     # should be different nonetheless
-    #not cmp pre-reset-save-fallback-key post-reset-save-fallback-key
+    not cmp pre-reset-save-fallback-key post-reset-save-fallback-key
 
-    # TODO perform subsequent factory reset once post-factory reset cleanup lands
+    echo "Perform subsequent factory reset"
+    tests.nested exec "sudo snap reboot --factory-reset" || true
+    tests.nested wait-for reboot "${boot_id}"
+    tests.nested exec cat /proc/cmdline | MATCH 'snapd_recovery_mode=run'
+    tests.nested wait-for snap-command
+    # TODO investigate why does this have to be much longer than what is needed for the
+    # initial wait and one after the first reset?
+    retry -n 60 --wait 2 tests.nested exec "sudo snap wait system seed.loaded"
+    retry -n 60 --wait 2 tests.nested exec snap model --serial
+    tests.nested exec snap model --serial > subsequent-serial
+    # still the same serial
+    diff -u initial-serial subsequent-serial
+
+    # the markers are still there
+    tests.nested exec test -e /run/mnt/ubuntu-save/marker
+    tests.nested exec test -e /run/mnt/ubuntu-seed/marker
+    # get the key
+    tests.nested exec cat /run/mnt/ubuntu-seed/device/fde/ubuntu-save.recovery.sealed-key > subsequent-reset-save-fallback-key
+    # and the key is different again
+    not cmp post-reset-save-fallback-key subsequent-reset-save-fallback-key


### PR DESCRIPTION
Hopefully the last patches for factory reset. The branch adds support for post-factory-reset ensure step, where we verify the fallback key, rotate the encryption keys and drop the marker.