### PR TITLE
preseed: suggest to install "qemu-user-static"

### DIFF
--- a/image/preseed/export_test.go
+++ b/image/preseed/export_test.go
@@ -31,6 +31,7 @@ var (
 	SystemSnapFromSeed       = systemSnapFromSeed
 	ChooseTargetSnapdVersion = chooseTargetSnapdVersion
 	CreatePreseedArtifact    = createPreseedArtifact
+	RunUC20PreseedMode       = runUC20PreseedMode
 )
 
 type PreseedOpts = preseedOpts

--- a/image/preseed/preseed_linux.go
+++ b/image/preseed/preseed_linux.go
@@ -22,6 +22,7 @@ package preseed
 import (
 	"crypto"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -539,6 +540,11 @@ func runUC20PreseedMode(opts *preseedOpts) error {
 	fmt.Fprintf(Stdout, "starting to preseed UC20+ system: %s\n", opts.PreseedChrootDir)
 
 	if err := cmd.Run(); err != nil {
+		var errno syscall.Errno
+		if errors.As(err, &errno) && errno == syscall.ENOEXEC {
+			return fmt.Errorf(`error running snapd, please try installing the "qemu-user-static" package: %v`, err)
+		}
+
 		return fmt.Errorf("error running snapd in preseed mode: %v\n", err)
 	}
 

--- a/image/preseed/preseed_uc20_test.go
+++ b/image/preseed/preseed_uc20_test.go
@@ -333,3 +333,21 @@ func (s *preseedSuite) TestRunPreseedUC20Happy(c *C) {
 func (s *preseedSuite) TestRunPreseedUC20HappyCustomApparmorFeaturesDir(c *C) {
 	s.testRunPreseedUC20Happy(c, "/custom-aa-features")
 }
+
+func (s *preseedSuite) TestRunPreseedUC20ExecFormatError(c *C) {
+	tmpdir := c.MkDir()
+
+	// Mock an exec-format error - the first thing that runUC20PreseedMode
+	// does is start snapd in a chroot. So we can override the "chroot"
+	// call with a simulated exec format error to simulate the error a
+	// user would get when running preseeding on a architecture that is
+	// not the image target architecture.
+	mockChrootCmd := testutil.MockCommand(c, "chroot", "")
+	defer mockChrootCmd.Restore()
+	err := ioutil.WriteFile(mockChrootCmd.Exe(), []byte("invalid-exe"), 0755)
+	c.Check(err, IsNil)
+
+	opts := &preseed.PreseedOpts{PreseedChrootDir: tmpdir}
+	err = preseed.RunUC20PreseedMode(opts)
+	c.Check(err, ErrorMatches, `error running snapd, please try installing the "qemu-user-static" package: fork/exec .* exec format error`)
+}


### PR DESCRIPTION
When preseeding fails with an exec-format error this is most likely
because the image is build from a system that has a different
architecture than the target architecture. Here installing the
`qemu-user-static` package is enough to preseed.

This commit adds a slightly more helpful error message in this
situation.
