### PR TITLE
snap-bootstrap: Support umount option to systemd-mount

### DIFF
--- a/cmd/snap-bootstrap/initramfs_systemd_mount.go
+++ b/cmd/snap-bootstrap/initramfs_systemd_mount.go
@@ -75,6 +75,8 @@ type systemdMountOptions struct {
 	ReadOnly bool
 	// Private mount
 	Private bool
+	// Umount the mountpoint
+	Umount bool
 }
 
 // doSystemdMount will mount "what" at "where" using systemd-mount(1) with
@@ -96,6 +98,11 @@ func doSystemdMountImpl(what, where string, opts *systemdMountOptions) error {
 	unitName := whereEscaped + ".mount"
 
 	args := []string{what, where, "--no-pager", "--no-ask-password"}
+
+	if opts.Umount {
+		args = []string{where, "--umount", "--no-pager", "--no-ask-password"}
+	}
+
 	if opts.Tmpfs {
 		args = append(args, "--type=tmpfs")
 	}
@@ -200,7 +207,7 @@ func doSystemdMountImpl(what, where string, opts *systemdMountOptions) error {
 		var now time.Time
 		for now = timeNow(); now.Sub(start) < defaultMountUnitWaitTimeout; now = timeNow() {
 			mounted, err := osutilIsMounted(where)
-			if mounted {
+			if mounted != opts.Umount {
 				break
 			}
 			if err != nil {

--- a/cmd/snap-bootstrap/initramfs_systemd_mount_test.go
+++ b/cmd/snap-bootstrap/initramfs_systemd_mount_test.go
@@ -155,6 +155,16 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			what:  "tmpfs",
 			where: "/run/mnt/data",
 			opts: &main.SystemdMountOptions{
+				Umount: true,
+			},
+			timeNowTimes:     []time.Time{testStart, testStart},
+			isMountedReturns: []bool{false},
+			comment:          "happy umount",
+		},
+		{
+			what:  "tmpfs",
+			where: "/run/mnt/data",
+			opts: &main.SystemdMountOptions{
 				NoSuid: true,
 				Bind:   true,
 			},
@@ -236,6 +246,11 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			call := cmd.Calls()[0]
 			args := []string{
 				"systemd-mount", t.what, t.where, "--no-pager", "--no-ask-password",
+			}
+			if opts.Umount {
+				args = []string{
+					"systemd-mount", t.where, "--umount", "--no-pager", "--no-ask-password",
+				}
 			}
 			c.Assert(call[:len(args)], DeepEquals, args)
 


### PR DESCRIPTION
It is useful to sometimes unmount mount points after they have been
mounted. This will be used in CVM to unmount ubuntu-seed partition,
such that classic system can mount it by itself later.

--

I am not entirely sure if I will need this in Jammy, I did need this on focal, but trying to figure it if i can avoid using this.