### PR TITLE
build-aux/snap: build against the snappy-dev/image PPA

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -12,6 +12,9 @@ adopt-info: snapd-deb
 # build-base is needed here for snapcraft to build this snap as with "modern"
 # snapcraft
 build-base: core
+package-repositories:
+  - type: apt
+    ppa: snappy-dev/image
 grade: stable
 license: GPL-3.0
 


### PR DESCRIPTION
At present, the build recipes used to build the official snapd snaps (e.g. https://launchpad.net/~snappy-dev/+snap/snapd-master)  use a PPA to pull in updated versions of some packages in the build. However, the snap built as an artifact of the CI process does not.

Among other things, this means it will be built against an older libseccomp (at present, 2.5.3 is in the PPA, while 2.5.1. is in the base archive), making the snap built by CI less useful for testing.

This PR makes use of [the `package-repositories' section](https://snapcraft.io/docs/package-repositories) to specify the PPA dependency directly in the `snapcraft.yaml` file, so that the snap is built more similarly to official releases.