### PR TITLE
o/snapstate: support passing validation sets to storehelpers via RevisionOptions

### DIFF
--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1977,9 +1977,9 @@ func Switch(st *state.State, name string, opts *RevisionOptions) (*state.TaskSet
 type RevisionOptions struct {
 	Channel        string
 	Revision       snap.Revision
+	ValidationSets []string
 	CohortKey      string
 	LeaveCohort    bool
-	ValidationSets []string
 }
 
 // Update initiates a change updating a snap.

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1975,10 +1975,11 @@ func Switch(st *state.State, name string, opts *RevisionOptions) (*state.TaskSet
 
 // RevisionOptions control the selection of a snap revision.
 type RevisionOptions struct {
-	Channel     string
-	Revision    snap.Revision
-	CohortKey   string
-	LeaveCohort bool
+	Channel        string
+	Revision       snap.Revision
+	CohortKey      string
+	LeaveCohort    bool
+	ValidationSets []string
 }
 
 // Update initiates a change updating a snap.
@@ -2169,7 +2170,7 @@ func infoForUpdate(st *state.State, snapst *SnapState, name string, opts *Revisi
 	}
 	if sideInfo == nil {
 		// refresh from given revision from store
-		return updateToRevisionInfo(st, snapst, opts.Revision, userID, flags, deviceCtx)
+		return updateToRevisionInfo(st, snapst, opts, userID, flags, deviceCtx)
 	}
 
 	// refresh-to-local, this assumes the snap revision is mounted

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -4410,7 +4410,7 @@ func (s *validationSetsSuite) TestInstallSnapWithValidationSets(c *C) {
 	_, err := snapstate.Install(context.Background(), s.state, "some-snap", opts, 0, snapstate.Flags{})
 	c.Assert(err, IsNil)
 
-	// validation sets are not set on the action
+	// validation sets are set on the action
 	expectedOp := fakeOp{
 		op: "storesvc-snap-action:action",
 		action: store.SnapAction{

--- a/overlord/snapstate/storehelpers.go
+++ b/overlord/snapstate/storehelpers.go
@@ -253,33 +253,38 @@ func installInfo(ctx context.Context, st *state.State, name string, revOpts *Rev
 	var requiredValSets []string
 
 	if !flags.IgnoreValidation {
-		enforcedSets, err := EnforcedValidationSets(st)
-		if err != nil {
-			return store.SnapActionResult{}, err
-		}
-
-		if enforcedSets != nil {
-			// check for invalid presence first to have a list of sets where it's invalid
-			invalidForValSets, err := enforcedSets.CheckPresenceInvalid(naming.Snap(name))
-			if err != nil {
-				if _, ok := err.(*snapasserts.PresenceConstraintError); !ok {
-					return store.SnapActionResult{}, err
-				} // else presence is optional or required, carry on
-			}
-			if len(invalidForValSets) > 0 {
-				return store.SnapActionResult{}, fmt.Errorf("cannot install snap %q due to enforcing rules of validation set %s", name, strings.Join(invalidForValSets, ","))
-			}
-			requiredValSets, requiredRevision, err = enforcedSets.CheckPresenceRequired(naming.Snap(name))
+		if len(revOpts.ValidationSets) > 0 {
+			requiredRevision = revOpts.Revision
+			requiredValSets = revOpts.ValidationSets
+		} else {
+			enforcedSets, err := EnforcedValidationSets(st)
 			if err != nil {
 				return store.SnapActionResult{}, err
 			}
-		}
-	}
 
-	// check if desired revision matches the revision required by validation sets
-	if !requiredRevision.Unset() && !revOpts.Revision.Unset() && revOpts.Revision.N != requiredRevision.N {
-		return store.SnapActionResult{}, fmt.Errorf("cannot install snap %q at requested revision %s without --ignore-validation, revision %s required by validation sets: %s",
-			name, revOpts.Revision, requiredRevision, strings.Join(requiredValSets, ","))
+			if enforcedSets != nil {
+				// check for invalid presence first to have a list of sets where it's invalid
+				invalidForValSets, err := enforcedSets.CheckPresenceInvalid(naming.Snap(name))
+				if err != nil {
+					if _, ok := err.(*snapasserts.PresenceConstraintError); !ok {
+						return store.SnapActionResult{}, err
+					} // else presence is optional or required, carry on
+				}
+				if len(invalidForValSets) > 0 {
+					return store.SnapActionResult{}, fmt.Errorf("cannot install snap %q due to enforcing rules of validation set %s", name, strings.Join(invalidForValSets, ","))
+				}
+				requiredValSets, requiredRevision, err = enforcedSets.CheckPresenceRequired(naming.Snap(name))
+				if err != nil {
+					return store.SnapActionResult{}, err
+				}
+			}
+
+			// check if desired revision matches the revision required by validation sets
+			if !requiredRevision.Unset() && !revOpts.Revision.Unset() && revOpts.Revision.N != requiredRevision.N {
+				return store.SnapActionResult{}, fmt.Errorf("cannot install snap %q at requested revision %s without --ignore-validation, revision %s required by validation sets: %s",
+					name, revOpts.Revision, requiredRevision, strings.Join(requiredValSets, ","))
+			}
+		}
 	}
 
 	if len(requiredValSets) > 0 {
@@ -338,13 +343,24 @@ func updateInfo(st *state.State, snapst *SnapState, opts *RevisionOptions, userI
 		Flags:   storeFlags,
 	}
 
+	if len(opts.ValidationSets) > 0 {
+		// update to a specific revision is handled by updateToRevisionInfo.
+		// updating without a revision while enforcing validation sets is not a
+		// viable scenario (although we could handle it if desired), we only install/refresh
+		// what's missing and explicitly required by requested validation sets.
+		return nil, fmt.Errorf("internal error: list of validation sets is not expected for update without revision")
+	}
+
+	var requiredRevision snap.Revision
+	var requiredValsets []string
+
 	if !flags.IgnoreValidation {
 		enforcedSets, err := EnforcedValidationSets(st)
 		if err != nil {
 			return nil, err
 		}
 		if enforcedSets != nil {
-			requiredValsets, requiredRevision, err := enforcedSets.CheckPresenceRequired(naming.Snap(curInfo.InstanceName()))
+			requiredValsets, requiredRevision, err = enforcedSets.CheckPresenceRequired(naming.Snap(curInfo.InstanceName()))
 			if err != nil {
 				return nil, err
 			}
@@ -442,7 +458,7 @@ func singleActionResult(name, action string, results []store.SnapActionResult, e
 	return store.SnapActionResult{}, e
 }
 
-func updateToRevisionInfo(st *state.State, snapst *SnapState, revision snap.Revision, userID int, flags Flags, deviceCtx DeviceContext) (*snap.Info, error) {
+func updateToRevisionInfo(st *state.State, snapst *SnapState, revOpts *RevisionOptions, userID int, flags Flags, deviceCtx DeviceContext) (*snap.Info, error) {
 	curSnaps, err := currentSnaps(st)
 	if err != nil {
 		return nil, err
@@ -463,42 +479,51 @@ func updateToRevisionInfo(st *state.State, snapst *SnapState, revision snap.Revi
 		SnapID:       curInfo.SnapID,
 		InstanceName: curInfo.InstanceName(),
 		// the desired revision
-		Revision: revision,
+		Revision: revOpts.Revision,
 	}
+
+	var requiredRevision snap.Revision
+	var requiredValsets []string
 
 	var storeFlags store.SnapActionFlags
 	if !flags.IgnoreValidation {
-		enforcedSets, err := EnforcedValidationSets(st)
-		if err != nil {
-			return nil, err
-		}
-		if enforcedSets != nil {
-			requiredValsets, requiredRevision, err := enforcedSets.CheckPresenceRequired(naming.Snap(curInfo.InstanceName()))
+		if len(revOpts.ValidationSets) > 0 {
+			requiredRevision = revOpts.Revision
+			requiredValsets = revOpts.ValidationSets
+		} else {
+			enforcedSets, err := EnforcedValidationSets(st)
 			if err != nil {
 				return nil, err
 			}
-			if !requiredRevision.Unset() {
-				if revision != requiredRevision {
-					return nil, fmt.Errorf("cannot update snap %q to revision %s without --ignore-validation, revision %s is required by validation sets: %s",
-						curInfo.InstanceName(), revision, requiredRevision, strings.Join(requiredValsets, ","))
+			if enforcedSets != nil {
+				requiredValsets, requiredRevision, err = enforcedSets.CheckPresenceRequired(naming.Snap(curInfo.InstanceName()))
+				if err != nil {
+					return nil, err
 				}
-				// note, not checking if required revision matches snapst.Current because
-				// this is already indirectly prevented by infoForUpdate().
+				if !requiredRevision.Unset() {
+					if revOpts.Revision != requiredRevision {
+						return nil, fmt.Errorf("cannot update snap %q to revision %s without --ignore-validation, revision %s is required by validation sets: %s",
+							curInfo.InstanceName(), revOpts.Revision, requiredRevision, strings.Join(requiredValsets, ","))
+					}
+					// note, not checking if required revision matches snapst.Current because
+					// this is already indirectly prevented by infoForUpdate().
 
-				// specific revision is required, reset cohort in current snaps
-				for _, sn := range curSnaps {
-					if sn.InstanceName == curInfo.InstanceName() {
-						sn.CohortKey = ""
-						break
+					// specific revision is required, reset cohort in current snaps
+					for _, sn := range curSnaps {
+						if sn.InstanceName == curInfo.InstanceName() {
+							sn.CohortKey = ""
+							break
+						}
 					}
 				}
-			}
-			if len(requiredValsets) > 0 {
-				setActionValidationSetsAndRequiredRevision(action, requiredValsets, requiredRevision)
 			}
 		}
 	} else {
 		storeFlags = store.SnapActionIgnoreValidation
+	}
+
+	if len(requiredValsets) > 0 {
+		setActionValidationSetsAndRequiredRevision(action, requiredValsets, requiredRevision)
 	}
 
 	action.Flags = storeFlags


### PR DESCRIPTION
Support requesting validation sets via RevisionOptions and handle them in `installInfo` and `updateToRevisionInfo` store helpers. This is to allow enforcing new validation sets and install/refresh required snaps to satisfy their constraints.
