### PR TITLE
daemon: implement api handler for refresh with enforced validation sets

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -140,6 +140,7 @@ var (
 	snapstateUpdateMany        = snapstate.UpdateMany
 	snapstateInstallMany       = snapstate.InstallMany
 	snapstateRemoveMany        = snapstate.RemoveMany
+	snapstateEnforceSnaps      = snapstate.EnforceSnaps
 	snapstateRevert            = snapstate.Revert
 	snapstateRevertToRevision  = snapstate.RevertToRevision
 	snapstateSwitch            = snapstate.Switch

--- a/daemon/api_snaps.go
+++ b/daemon/api_snaps.go
@@ -670,6 +670,11 @@ func snapEnforceValidationSets(inst *snapInstruction, st *state.State) (*snapIns
 		return nil, err
 	}
 
+	// we need refreshed snap-declarations, this ensures that snap-declarations
+	// and their prerequisite assertions are updated regularly; do not update all
+	// validation-set assertions (this is implied by passing nil opts) - only
+	// those requested via inst.ValidationSets will get updated by
+	// assertstateTryEnforceValidationSets below.
 	if err := assertstateRefreshSnapAssertions(st, inst.userID, nil); err != nil {
 		return nil, err
 	}

--- a/daemon/api_snaps.go
+++ b/daemon/api_snaps.go
@@ -665,7 +665,7 @@ func snapEnforceValidationSets(inst *snapInstruction, st *state.State) (*snapIns
 		return nil, fmt.Errorf("snap names cannot be specified with validation sets to enforce")
 	}
 
-	snaps, ignoreValidation, err := snapstate.InstalledSnaps(st)
+	snaps, ignoreValidationSnaps, err := snapstate.InstalledSnaps(st)
 	if err != nil {
 		return nil, err
 	}
@@ -674,16 +674,16 @@ func snapEnforceValidationSets(inst *snapInstruction, st *state.State) (*snapIns
 		return nil, err
 	}
 
-	var validErr *snapasserts.ValidationSetsValidationError
-	err = assertstateTryEnforceValidationSets(st, inst.ValidationSets, inst.userID, snaps, ignoreValidation)
+	var validationErr *snapasserts.ValidationSetsValidationError
+	err = assertstateTryEnforceValidationSets(st, inst.ValidationSets, inst.userID, snaps, ignoreValidationSnaps)
 	if err != nil {
 		var ok bool
-		validErr, ok = err.(*snapasserts.ValidationSetsValidationError)
+		validationErr, ok = err.(*snapasserts.ValidationSetsValidationError)
 		if !ok {
 			return nil, err
 		}
 	}
-	tss, affected, err := snapstateEnforceSnaps(context.TODO(), st, inst.ValidationSets, validErr, inst.userID)
+	tss, affected, err := snapstateEnforceSnaps(context.TODO(), st, inst.ValidationSets, validationErr, inst.userID)
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -36,6 +36,7 @@ import (
 	"gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/arch"
+	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/daemon"
 	"github.com/snapcore/snapd/dirs"
@@ -2300,4 +2301,115 @@ func (s *snapsSuite) TestPostSnapWrongTransaction(c *check.C) {
 		c.Check(rspe.Status, check.Equals, 400, check.Commentf("%q", action))
 		c.Check(rspe.Message, check.Equals, expectedErr, check.Commentf("%q", action))
 	}
+}
+
+func (s *snapsSuite) TestRefreshEnforce(c *check.C) {
+	var refreshSnapAssertions bool
+
+	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int, opts *assertstate.RefreshAssertionsOptions) error {
+		refreshSnapAssertions = true
+		c.Check(opts, check.IsNil)
+		return nil
+	})()
+
+	var tryEnforceValidationSets bool
+	defer daemon.MockAssertstateTryEnforceValidationSets(func(st *state.State, validationSets []string, userID int, snaps []*snapasserts.InstalledSnap, ignoreValidation map[string]bool) error {
+		tryEnforceValidationSets = true
+		return nil
+	})()
+
+	defer daemon.MockSnapstateEnforceSnaps(func(ctx context.Context, st *state.State, validationSets []string, validErr *snapasserts.ValidationSetsValidationError, userID int) ([]*state.TaskSet, []string, error) {
+		c.Check(validationSets, check.DeepEquals, []string{"foo/bar=2", "foo/baz"})
+		t := st.NewTask("fake-enforce-snaps", "...")
+		return []*state.TaskSet{state.NewTaskSet(t)}, []string{"some-snap", "other-snap"}, nil
+	})()
+
+	d := s.daemon(c)
+	inst := &daemon.SnapInstruction{Action: "refresh", ValidationSets: []string{"foo/bar=2", "foo/baz"}}
+
+	st := d.Overlord().State()
+	st.Lock()
+	defer st.Unlock()
+
+	res, err := inst.DispatchForMany()(inst, st)
+	c.Assert(err, check.IsNil)
+	c.Check(res.Summary, check.Equals, `Enforced validation sets: "foo/bar=2", "foo/baz"`)
+	c.Check(res.Affected, check.DeepEquals, []string{"some-snap", "other-snap"})
+	c.Check(refreshSnapAssertions, check.Equals, true)
+	c.Check(tryEnforceValidationSets, check.Equals, true)
+}
+
+func (s *snapsSuite) TestRefreshEnforceTryEnforceValidationSetsError(c *check.C) {
+	var refreshSnapAssertions int
+	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int, opts *assertstate.RefreshAssertionsOptions) error {
+		refreshSnapAssertions++
+		c.Check(opts, check.IsNil)
+		return nil
+	})()
+
+	tryEnforceErr := fmt.Errorf("boom")
+	defer daemon.MockAssertstateTryEnforceValidationSets(func(st *state.State, validationSets []string, userID int, snaps []*snapasserts.InstalledSnap, ignoreValidation map[string]bool) error {
+		return tryEnforceErr
+	})()
+
+	var snapstateEnforceSnaps int
+	defer daemon.MockSnapstateEnforceSnaps(func(ctx context.Context, st *state.State, validationSets []string, validErr *snapasserts.ValidationSetsValidationError, userID int) ([]*state.TaskSet, []string, error) {
+		snapstateEnforceSnaps++
+		c.Check(validErr, check.NotNil)
+		return nil, nil, nil
+	})()
+
+	d := s.daemon(c)
+	inst := &daemon.SnapInstruction{Action: "refresh", ValidationSets: []string{"foo/baz"}}
+
+	st := d.Overlord().State()
+	st.Lock()
+	defer st.Unlock()
+
+	_, err := inst.DispatchForMany()(inst, st)
+	c.Assert(err, check.ErrorMatches, `boom`)
+	c.Check(refreshSnapAssertions, check.Equals, 1)
+	c.Check(snapstateEnforceSnaps, check.Equals, 0)
+
+	// ValidationSetsValidationError is expected and fine
+	tryEnforceErr = &snapasserts.ValidationSetsValidationError{}
+
+	_, err = inst.DispatchForMany()(inst, st)
+	c.Assert(err, check.IsNil)
+	c.Check(refreshSnapAssertions, check.Equals, 2)
+	c.Check(snapstateEnforceSnaps, check.Equals, 1)
+}
+
+func (s *snapsSuite) TestRefreshEnforceWithSnapsIsAnError(c *check.C) {
+	var refreshSnapAssertions bool
+	defer daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int, opts *assertstate.RefreshAssertionsOptions) error {
+		refreshSnapAssertions = true
+		c.Check(opts, check.IsNil)
+		return fmt.Errorf("unexptected")
+	})()
+
+	var tryEnforceValidationSets bool
+	defer daemon.MockAssertstateTryEnforceValidationSets(func(st *state.State, validationSets []string, userID int, snaps []*snapasserts.InstalledSnap, ignoreValidation map[string]bool) error {
+		tryEnforceValidationSets = true
+		return fmt.Errorf("unexpected")
+	})()
+
+	var snapstateEnforceSnaps bool
+	defer daemon.MockSnapstateEnforceSnaps(func(ctx context.Context, st *state.State, validationSets []string, validErr *snapasserts.ValidationSetsValidationError, userID int) ([]*state.TaskSet, []string, error) {
+		snapstateEnforceSnaps = true
+		return nil, nil, fmt.Errorf("unexpected")
+	})()
+
+	d := s.daemon(c)
+	inst := &daemon.SnapInstruction{Action: "refresh", Snaps: []string{"some-snap"}, ValidationSets: []string{"foo/baz"}}
+
+	st := d.Overlord().State()
+	st.Lock()
+	defer st.Unlock()
+
+	_, err := inst.DispatchForMany()(inst, st)
+	c.Assert(err, check.ErrorMatches, `snap names cannot be specified with validation sets to enforce`)
+	c.Check(refreshSnapAssertions, check.Equals, false)
+	c.Check(tryEnforceValidationSets, check.Equals, false)
+	c.Check(snapstateEnforceSnaps, check.Equals, false)
 }

--- a/daemon/api_validate.go
+++ b/daemon/api_validate.go
@@ -272,6 +272,7 @@ func applyValidationSet(c *Command, r *http.Request, user *auth.UserState) Respo
 
 var assertstateMonitorValidationSet = assertstate.MonitorValidationSet
 var assertstateEnforceValidationSet = assertstate.EnforceValidationSet
+var assertstateTryEnforceValidationSets = assertstate.TryEnforceValidationSets
 
 // updateValidationSet handles snap validate --monitor and --enforce accountId/name[=sequence].
 func updateValidationSet(st *state.State, accountID, name string, reqMode string, sequence int, user *auth.UserState) Response {

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/assertstate"
@@ -33,6 +34,7 @@ import (
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
 )
 
 func APICommands() []*Command {
@@ -114,6 +116,12 @@ func MockAssertstateRefreshSnapAssertions(mock func(*state.State, int, *assertst
 	return func() {
 		assertstateRefreshSnapAssertions = oldAssertstateRefreshSnapAssertions
 	}
+}
+
+func MockAssertstateTryEnforceValidationSets(f func(st *state.State, validationSets []string, userID int, snaps []*snapasserts.InstalledSnap, ignoreValidation map[string]bool) error) (restore func()) {
+	r := testutil.Backup(&assertstateTryEnforceValidationSets)
+	assertstateTryEnforceValidationSets = f
+	return r
 }
 
 func MockSnapstateInstall(mock func(context.Context, *state.State, string, *snapstate.RevisionOptions, int, snapstate.Flags) (*state.TaskSet, error)) (restore func()) {
@@ -202,6 +210,12 @@ func MockSnapstateInstallPathMany(f func(context.Context, *state.State, []*snap.
 	return func() {
 		snapstateInstallPathMany = old
 	}
+}
+
+func MockSnapstateEnforceSnaps(f func(ctx context.Context, st *state.State, validationSets []string, validErr *snapasserts.ValidationSetsValidationError, userID int) ([]*state.TaskSet, []string, error)) func() {
+	r := testutil.Backup(&assertstateTryEnforceValidationSets)
+	snapstateEnforceSnaps = f
+	return r
 }
 
 func MockReboot(f func(boot.RebootAction, time.Duration, *boot.RebootInfo) error) func() {

--- a/overlord/assertstate/assertstate.go
+++ b/overlord/assertstate/assertstate.go
@@ -772,6 +772,14 @@ func validationSetAssertionForEnforce(st *state.State, accountID, name string, s
 	return vs, latest, err
 }
 
+// TryEnforceValidationSets tries to fetch the given validation sets and enforce them (together with currently tracked validation sets) against installed snaps,
+// but doesn't update tracking information. It may return snapasserts.ValidationSetsValidationError which can be used to install/remove snaps as required
+// to satisfy validation sets constraints.
+func TryEnforceValidationSets(st *state.State, validationSets []string, userID int, snaps []*snapasserts.InstalledSnap, ignoreValidation map[string]bool) error {
+	// TODO
+	return fmt.Errorf("not implemented")
+}
+
 // EnforceValidationSet tries to fetch the given validation set and enforce it.
 // If all validation sets constrains are satisfied, the current validation sets
 // tracking state is saved in validation sets history.

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1349,11 +1349,11 @@ func UpdateMany(ctx context.Context, st *state.State, names []string, userID int
 	return updateManyFiltered(ctx, st, names, userID, nil, flags, "")
 }
 
-// EnforceSnaps installs/updates/removes snaps reported by validErr.
+// EnforceSnaps installs/updates/removes snaps reported by validationErrorToSolve.
 // validationSets is the list of sets passed by the user and it's used in the
 // final stage to update validation-sets tracking in the state.
 // userID is used for store auth.
-func EnforceSnaps(ctx context.Context, st *state.State, validationSets []string, validErr *snapasserts.ValidationSetsValidationError, userID int) (tasksets []*state.TaskSet, names []string, err error) {
+func EnforceSnaps(ctx context.Context, st *state.State, validationSets []string, validationErrorToSolve *snapasserts.ValidationSetsValidationError, userID int) (tasksets []*state.TaskSet, names []string, err error) {
 	// TODO
 	return nil, nil, fmt.Errorf("not implemented")
 }

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1349,6 +1349,13 @@ func UpdateMany(ctx context.Context, st *state.State, names []string, userID int
 	return updateManyFiltered(ctx, st, names, userID, nil, flags, "")
 }
 
+// EnforceSnaps installs/updates/removes snaps reported by validErr. validationSets is the list of sets passed by the user and it's used in the final
+// stage to update validation-sets tracking in the state.
+func EnforceSnaps(ctx context.Context, st *state.State, validationSets []string, validErr *snapasserts.ValidationSetsValidationError, userID int) (tasksets []*state.TaskSet, names []string, err error) {
+	// TODO
+	return nil, nil, fmt.Errorf("not implemented")
+}
+
 // updateFilter is the type of function that can be passed to
 // updateManyFromChange so it filters the updates.
 //

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1349,8 +1349,10 @@ func UpdateMany(ctx context.Context, st *state.State, names []string, userID int
 	return updateManyFiltered(ctx, st, names, userID, nil, flags, "")
 }
 
-// EnforceSnaps installs/updates/removes snaps reported by validErr. validationSets is the list of sets passed by the user and it's used in the final
-// stage to update validation-sets tracking in the state.
+// EnforceSnaps installs/updates/removes snaps reported by validErr.
+// validationSets is the list of sets passed by the user and it's used in the
+// final stage to update validation-sets tracking in the state.
+// userID is used for store auth.
 func EnforceSnaps(ctx context.Context, st *state.State, validationSets []string, validErr *snapasserts.ValidationSetsValidationError, userID int) (tasksets []*state.TaskSet, names []string, err error) {
 	// TODO
 	return nil, nil, fmt.Errorf("not implemented")


### PR DESCRIPTION
Implement api handler for refresh with validation sets (i.e. for `snap validate --enforce --refresh ...`). 

The two critical functions (`snapstate.EnforceSnaps` and `assertstate.TryEnforceValidationSets`) are stubs in this PR - they are drafted in #11899 
