### PR TITLE
cmd/snapd-apparmor: fix unit tests on distros which do not support reexec

### DIFF
--- a/cmd/snapd-apparmor/main_test.go
+++ b/cmd/snapd-apparmor/main_test.go
@@ -25,7 +25,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	. "gopkg.in/check.v1"
@@ -241,7 +240,5 @@ func (s *integrationSuite) TestRunNormalLoadsProfiles(c *C) {
 	err := snapd_apparmor.Run()
 	c.Assert(err, IsNil)
 	c.Assert(s.parserCmd.Calls(), HasLen, 1)
-	logLines := strings.Split(strings.TrimSpace(s.logBuf.String()), "\n")
-	c.Check(logLines, HasLen, 1)
-	c.Check(logLines[0], Matches, `.* main.go:[0-9]+: Loading profiles \[.*/var/lib/snapd/apparmor/profiles/foo\]`)
+	c.Check(s.logBuf.String(), Matches, `(?s).* main.go:[0-9]+: Loading profiles \[.*/var/lib/snapd/apparmor/profiles/foo\].*`)
 }


### PR DESCRIPTION
Distros that do not support reexec have an additional line logged in the output,
such that the overall log looks like this:

... value string = "" +
...     "2022/06/22 14:56:34.246323 tool_linux.go:68: DEBUG: re-exec not supported on distro \"arch\" yet\n" +
...     "2022/06/22 14:56:34.250114 main.go:132: Loading profiles [/tmp/check-228349711/6/var/lib/snapd/apparmor/profiles/foo]\n"

Fix the unit test such that it runs correctly everywhere.


