### PR TITLE
cmd/snap: fix test failing due to timezone differences

### DIFF
--- a/cmd/snap/cmd_debug_state_test.go
+++ b/cmd/snap/cmd_debug_state_test.go
@@ -22,6 +22,7 @@ package main_test
 import (
 	"io/ioutil"
 	"path/filepath"
+	"time"
 
 	. "gopkg.in/check.v1"
 
@@ -271,6 +272,14 @@ func (s *SnapSuite) TestDebugTasksWithCycles(c *C) {
 }
 
 func (s *SnapSuite) TestDebugCheckForCycles(c *C) {
+	// we use local time when printing times in a human-friendly format, which can
+	// break the comparison below
+	oldLoc := time.Local
+	time.Local = time.UTC
+	defer func() {
+		time.Local = oldLoc
+	}()
+
 	dir := c.MkDir()
 	stateFile := filepath.Join(dir, "test-state.json")
 	c.Assert(ioutil.WriteFile(stateFile, stateCyclesJSON, 0644), IsNil)


### PR DESCRIPTION
TestDebugCheckForCycles was failing locally with something like (I truncated the output for brevity): 
```
FAIL: cmd_debug_state_test.go:273: SnapSuite.TestDebugCheckForCycles
... String difference:
...     [2]: "1,2    11   Done    0000-12-31  0000-12-31  foo   Foo task  []     [13]" != "1,2    11   Done    0001-01-01  0001-01-01  foo   Foo task  []     [13]"
...     [3]: "1      12   Do      0000-12-31  0000-12-31  bar   Bar task  []     [13]" != "1      12   Do      0001-01-01  0001-01-01  bar   Bar task  []     [13]"
...     [4]: "2      13   Do      0000-12-31  0000-12-31  bar   Bar task  []     [11,12]" != "2      13   Do      0001-01-01  0001-01-01  bar   Bar task  []     [11,12]"
```
When we print human friendly times, we use the local timezone. In this test, the spawn and ready times weren't set in the mock state, so a zero value `time.Time` was used. The local time (in my system) subtracted an hour from it, causing the month and day to be `0000-12-31` instead of the expected zero value `0001-01-01`.
