### PR TITLE
cmd/snap-update-ns: minor fixes

### DIFF
--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -505,7 +505,7 @@ func neededChanges(currentProfile, desiredProfile *osutil.MountProfile) []*Chang
 			logger.Debugf("- %v", en)
 		}
 	}
-	dumpMountEntries(desired, "desired mount entries")
+	dumpMountEntries(current, "current mount entries")
 	// Sort only the desired lists by directory name with implicit trailing
 	// slash and the mount kind.
 	// Note that the current profile is a log of what was applied and should

--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -499,6 +499,13 @@ func neededChanges(currentProfile, desiredProfile *osutil.MountProfile) []*Chang
 		desired[i].Dir = filepath.Clean(desired[i].Dir)
 	}
 
+	// Make yet another copy of the current entries, to retain their original
+	// order (the "current" variable is going to be sorted soon); just using
+	// currentProfile.Entries is not reliable because it didn't undergo the
+	// cleanup of the Dir paths.
+	unsortedCurrent := make([]osutil.MountEntry, len(current))
+	copy(unsortedCurrent, current)
+
 	dumpMountEntries := func(entries []osutil.MountEntry, pfx string) {
 		logger.Debugf(pfx)
 		for _, en := range entries {
@@ -582,7 +589,7 @@ func neededChanges(currentProfile, desiredProfile *osutil.MountProfile) []*Chang
 	var changes []*Change
 
 	// Unmount entries not reused in reverse to handle children before their parent.
-	unmountOrder := currentProfile.Entries
+	unmountOrder := unsortedCurrent
 	for i := len(unmountOrder) - 1; i >= 0; i-- {
 		if reuse[unmountOrder[i].Dir] {
 			changes = append(changes, &Change{Action: Keep, Entry: unmountOrder[i]})


### PR DESCRIPTION
Spin off from https://github.com/snapcore/snapd/pull/11914, which was meant to fix an EBUsy error when removing a mount-point, but turned out to be a wrong solution. That branch contained a couple of commits, though, which should be worth merging:

- Print the current mount entries to the log. Note that the desired mount
entries are printed once more after the sort; since we do not care about
their original order, let's change that debug statement to print the
current mount entries instead.

- The `reuse` map uses cleaned paths as keys, so we should ensure that the
paths we use for the look-up are cleaned, too.
