### PR TITLE
tests: disable core20-to-core22 nested test

### DIFF
--- a/tests/nested/manual/core20-to-core22/task.yaml
+++ b/tests/nested/manual/core20-to-core22/task.yaml
@@ -6,6 +6,9 @@ summary: verify a UC20 to UC22 remodel
 
 systems: [ubuntu-20.04-64]
 
+# TODO: re-enable the test once lp:1979197 is fixed
+manual: true
+
 environment:
   NESTED_CUSTOM_MODEL: $TESTSLIB/assertions/valid-for-testing-pc-{VERSION}.model
   NESTED_IMAGE_ID: uc22-remodel-testing


### PR DESCRIPTION
This test is affected by this issue: https://bugs.launchpad.net/snapd/+bug/1979197

A new PR with the revert for this change is going to be created after this one. 