### PR TITLE
interfaces: add memory stats to system_observe

### DIFF
--- a/interfaces/builtin/system_observe.go
+++ b/interfaces/builtin/system_observe.go
@@ -97,6 +97,7 @@ ptrace (read),
 /sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us r,
 /sys/fs/cgroup/cpu,cpuacct/cpu.shares r,
 /sys/fs/cgroup/cpu,cpuacct/cpu.stat r,
+/sys/fs/cgroup/memory/memory.stat r,
 
 #include <abstractions/dbus-strict>
 


### PR DESCRIPTION
Adds memory stats to the system observe interface.