### PR TITLE
tests: revert the skip for change in nested test core20-to-core22

### DIFF
--- a/tests/nested/manual/core20-to-core22/task.yaml
+++ b/tests/nested/manual/core20-to-core22/task.yaml
@@ -1,5 +1,10 @@
 summary: verify a UC20 to UC22 remodel
 
+details: |
+    This test verifies remodeling from UC20 to UC22 works. Once the remodeling
+    is done and the machine boots into UC22 the test verifies that recover system
+    is usable and there should be no core20 since the new UC22 is seeded.
+
 # the test may be unstable as UC22 is effectively a work-in-progress thing, and
 # the model in question uses latest/edge of core22 and 22/edge of pc and
 # pc-kernel snaps

--- a/tests/nested/manual/core20-to-core22/task.yaml
+++ b/tests/nested/manual/core20-to-core22/task.yaml
@@ -6,9 +6,6 @@ summary: verify a UC20 to UC22 remodel
 
 systems: [ubuntu-20.04-64]
 
-# TODO: re-enable the test once lp:1979197 is fixed
-manual: true
-
 environment:
   NESTED_CUSTOM_MODEL: $TESTSLIB/assertions/valid-for-testing-pc-{VERSION}.model
   # TODO: disable TPM for now and investigate why the system cannot be booted


### PR DESCRIPTION
Tests should pass once lp:1979197 is fixed