### PR TITLE
interfaces/pwm: Remove implicitOnCore/implicitOnClassic

### DIFF
--- a/interfaces/builtin/pwm.go
+++ b/interfaces/builtin/pwm.go
@@ -137,8 +137,6 @@ func init() {
 	registerIface(&pwmInterface{commonInterface{
 		name:                 "pwm",
 		summary:              pwmSummary,
-		implicitOnCore:       true,
-		implicitOnClassic:    true,
 		baseDeclarationSlots: pwmBaseDeclarationSlots,
 	}})
 }


### PR DESCRIPTION
The pwm interface requires a gadget snap to define a slot and so is not
implicit on either core or classic.

Signed-off-by: Alex Murray <alex.murray@canonical.com>
