### PR TITLE
test: print User-Agent on failed checks

### DIFF
--- a/cmd/snap-repair/runner_test.go
+++ b/cmd/snap-repair/runner_test.go
@@ -868,7 +868,7 @@ func makeMockServer(c *C, seqRepairs *[]string, redirectFirst bool) *httptest.Se
 	var mockServer *httptest.Server
 	mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ua := r.Header.Get("User-Agent")
-		c.Check(strings.Contains(ua, "snap-repair"), Equals, true)
+		c.Check(ua, testutil.Contains, "snap-repair")
 
 		urlPath := r.URL.Path
 		if redirectFirst && r.Header.Get("Accept") == asserts.MediaType {


### PR DESCRIPTION
Using a `Matches` checker will cause the Check() function to print the
string being compared. This can give us some hints on where is the
request coming from (sometimes this test randomly fails on CI).
