### PR TITLE
interface/hardware-observe: allow reading product serial

### DIFF
--- a/interfaces/builtin/hardware_observe.go
+++ b/interfaces/builtin/hardware_observe.go
@@ -146,6 +146,7 @@ network netlink raw,
 
 # some devices use this information to set serial, etc. for Ubuntu Core devices
 /sys/devices/virtual/dmi/id/product_name r,
+/sys/devices/virtual/dmi/id/product_serial r,
 /sys/devices/virtual/dmi/id/sys_vendor r,
 
 # allow read access to thermal sysfs


### PR DESCRIPTION
The developers would like to use product_serial reported under `/sys/devices/virtual/dmi/id/product_serial` for either setting the serial-number in the gadget or as a hostname.
