### PR TITLE
many: introduce IsUndo flag in LinkContext

### DIFF
--- a/boot/boot.go
+++ b/boot/boot.go
@@ -53,8 +53,9 @@ type RebootInfo struct {
 // NextBootContext carries additional significative information used when
 // setting the next boot.
 type NextBootContext struct {
-	// IsUndoingInstall specifies if the next boot is part of an installation undo
-	IsUndoingInstall bool
+	// BootWithoutTry is sets if we don't want to use the "try" logic. This
+	// is useful if the next boot is part of an installation undo.
+	BootWithoutTry bool
 }
 
 // A BootParticipant handles the boot process details for a snap involved in it.

--- a/boot/boot_robustness_test.go
+++ b/boot/boot_robustness_test.go
@@ -304,7 +304,7 @@ func (s *bootenv20Suite) TestHappySetNextBoot20KernelUpgradeUnexpectedReboots(c 
 
 		setNextFunc := func(snap.Device) error {
 			// we don't care about the reboot required logic here
-			_, err := bootKern.SetNextBoot()
+			_, err := bootKern.SetNextBoot(false)
 			return err
 		}
 

--- a/boot/boot_robustness_test.go
+++ b/boot/boot_robustness_test.go
@@ -304,7 +304,7 @@ func (s *bootenv20Suite) TestHappySetNextBoot20KernelUpgradeUnexpectedReboots(c 
 
 		setNextFunc := func(snap.Device) error {
 			// we don't care about the reboot required logic here
-			_, err := bootKern.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
+			_, err := bootKern.SetNextBoot(boot.NextBootContext{BootWithoutTry: false})
 			return err
 		}
 

--- a/boot/boot_robustness_test.go
+++ b/boot/boot_robustness_test.go
@@ -304,7 +304,7 @@ func (s *bootenv20Suite) TestHappySetNextBoot20KernelUpgradeUnexpectedReboots(c 
 
 		setNextFunc := func(snap.Device) error {
 			// we don't care about the reboot required logic here
-			_, err := bootKern.SetNextBoot(false)
+			_, err := bootKern.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
 			return err
 		}
 

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -764,7 +764,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameKernelSnap(c *C) {
 	c.Assert(bootKern.IsTrivial(), Equals, false)
 
 	// make the kernel used on next boot
-	rebootRequired, err := bootKern.SetNextBoot()
+	rebootRequired, err := bootKern.SetNextBoot(false)
 	c.Assert(err, IsNil)
 	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: false})
 
@@ -807,7 +807,7 @@ func (s *bootenv20EnvRefKernelSuite) TestCoreParticipant20SetNextSameKernelSnap(
 	c.Assert(bootKern.IsTrivial(), Equals, false)
 
 	// make the kernel used on next boot
-	rebootRequired, err := bootKern.SetNextBoot()
+	rebootRequired, err := bootKern.SetNextBoot(false)
 	c.Assert(err, IsNil)
 	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: false})
 
@@ -847,7 +847,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewKernelSnap(c *C) {
 	c.Assert(bootKern.IsTrivial(), Equals, false)
 
 	// make the kernel used on next boot
-	rebootRequired, err := bootKern.SetNextBoot()
+	rebootRequired, err := bootKern.SetNextBoot(false)
 	c.Assert(err, IsNil)
 	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: true})
 
@@ -960,7 +960,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewKernelSnapWithReseal(c *
 	c.Assert(bootKern.IsTrivial(), Equals, false)
 
 	// make the kernel used on next boot
-	rebootRequired, err := bootKern.SetNextBoot()
+	rebootRequired, err := bootKern.SetNextBoot(false)
 	c.Assert(err, IsNil)
 	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: true})
 
@@ -1073,7 +1073,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewUnassertedKernelSnapWith
 	c.Assert(bootKern.IsTrivial(), Equals, false)
 
 	// make the kernel used on next boot
-	rebootRequired, err := bootKern.SetNextBoot()
+	rebootRequired, err := bootKern.SetNextBoot(false)
 	c.Assert(err, IsNil)
 	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: true})
 
@@ -1185,7 +1185,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameKernelSnapNoReseal(c *C
 	c.Assert(err, IsNil)
 
 	// make the kernel used on next boot
-	rebootRequired, err := bootKern.SetNextBoot()
+	rebootRequired, err := bootKern.SetNextBoot(false)
 	c.Assert(err, IsNil)
 	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: false})
 
@@ -1303,7 +1303,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameUnassertedKernelSnapNoR
 	c.Assert(err, IsNil)
 
 	// make the kernel used on next boot
-	rebootRequired, err := bootKern.SetNextBoot()
+	rebootRequired, err := bootKern.SetNextBoot(false)
 	c.Assert(err, IsNil)
 	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: false})
 
@@ -1346,7 +1346,7 @@ func (s *bootenv20EnvRefKernelSuite) TestCoreParticipant20SetNextNewKernelSnap(c
 	c.Assert(bootKern.IsTrivial(), Equals, false)
 
 	// make the kernel used on next boot
-	rebootRequired, err := bootKern.SetNextBoot()
+	rebootRequired, err := bootKern.SetNextBoot(false)
 	c.Assert(err, IsNil)
 	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: true})
 
@@ -1534,7 +1534,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameBaseSnap(c *C) {
 	c.Assert(bootBase.IsTrivial(), Equals, false)
 
 	// make the base used on next boot
-	rebootRequired, err := bootBase.SetNextBoot()
+	rebootRequired, err := bootBase.SetNextBoot(false)
 	c.Assert(err, IsNil)
 
 	// we don't need to reboot because it's the same base snap
@@ -1573,7 +1573,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewBaseSnap(c *C) {
 	c.Assert(bootBase.IsTrivial(), Equals, false)
 
 	// make the base used on next boot
-	rebootRequired, err := bootBase.SetNextBoot()
+	rebootRequired, err := bootBase.SetNextBoot(false)
 	c.Assert(err, IsNil)
 	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: true})
 
@@ -1667,7 +1667,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewBaseSnapNoReseal(c *C) {
 	c.Assert(bootBase.IsTrivial(), Equals, false)
 
 	// make the base used on next boot
-	rebootRequired, err := bootBase.SetNextBoot()
+	rebootRequired, err := bootBase.SetNextBoot(false)
 	c.Assert(err, IsNil)
 	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: true})
 
@@ -4207,7 +4207,7 @@ func (s *bootenv20RebootBootloaderSuite) TestCoreParticipant20WithRebootBootload
 	c.Assert(bootKern.IsTrivial(), Equals, false)
 
 	// make the kernel used on next boot
-	rebootRequired, err := bootKern.SetNextBoot()
+	rebootRequired, err := bootKern.SetNextBoot(false)
 	c.Assert(err, IsNil)
 	c.Assert(rebootRequired.RebootRequired, Equals, true)
 	// Test that we retrieve a RebootBootloader interface

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -764,7 +764,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameKernelSnap(c *C) {
 	c.Assert(bootKern.IsTrivial(), Equals, false)
 
 	// make the kernel used on next boot
-	rebootRequired, err := bootKern.SetNextBoot(false)
+	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
 	c.Assert(err, IsNil)
 	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: false})
 
@@ -807,7 +807,7 @@ func (s *bootenv20EnvRefKernelSuite) TestCoreParticipant20SetNextSameKernelSnap(
 	c.Assert(bootKern.IsTrivial(), Equals, false)
 
 	// make the kernel used on next boot
-	rebootRequired, err := bootKern.SetNextBoot(false)
+	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
 	c.Assert(err, IsNil)
 	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: false})
 
@@ -847,7 +847,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewKernelSnap(c *C) {
 	c.Assert(bootKern.IsTrivial(), Equals, false)
 
 	// make the kernel used on next boot
-	rebootRequired, err := bootKern.SetNextBoot(false)
+	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
 	c.Assert(err, IsNil)
 	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: true})
 
@@ -960,7 +960,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewKernelSnapWithReseal(c *
 	c.Assert(bootKern.IsTrivial(), Equals, false)
 
 	// make the kernel used on next boot
-	rebootRequired, err := bootKern.SetNextBoot(false)
+	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
 	c.Assert(err, IsNil)
 	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: true})
 
@@ -1073,7 +1073,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewUnassertedKernelSnapWith
 	c.Assert(bootKern.IsTrivial(), Equals, false)
 
 	// make the kernel used on next boot
-	rebootRequired, err := bootKern.SetNextBoot(false)
+	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
 	c.Assert(err, IsNil)
 	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: true})
 
@@ -1185,7 +1185,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameKernelSnapNoReseal(c *C
 	c.Assert(err, IsNil)
 
 	// make the kernel used on next boot
-	rebootRequired, err := bootKern.SetNextBoot(false)
+	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
 	c.Assert(err, IsNil)
 	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: false})
 
@@ -1303,7 +1303,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameUnassertedKernelSnapNoR
 	c.Assert(err, IsNil)
 
 	// make the kernel used on next boot
-	rebootRequired, err := bootKern.SetNextBoot(false)
+	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
 	c.Assert(err, IsNil)
 	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: false})
 
@@ -1346,7 +1346,7 @@ func (s *bootenv20EnvRefKernelSuite) TestCoreParticipant20SetNextNewKernelSnap(c
 	c.Assert(bootKern.IsTrivial(), Equals, false)
 
 	// make the kernel used on next boot
-	rebootRequired, err := bootKern.SetNextBoot(false)
+	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
 	c.Assert(err, IsNil)
 	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: true})
 
@@ -1534,7 +1534,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameBaseSnap(c *C) {
 	c.Assert(bootBase.IsTrivial(), Equals, false)
 
 	// make the base used on next boot
-	rebootRequired, err := bootBase.SetNextBoot(false)
+	rebootRequired, err := bootBase.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
 	c.Assert(err, IsNil)
 
 	// we don't need to reboot because it's the same base snap
@@ -1573,7 +1573,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewBaseSnap(c *C) {
 	c.Assert(bootBase.IsTrivial(), Equals, false)
 
 	// make the base used on next boot
-	rebootRequired, err := bootBase.SetNextBoot(false)
+	rebootRequired, err := bootBase.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
 	c.Assert(err, IsNil)
 	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: true})
 
@@ -1667,7 +1667,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewBaseSnapNoReseal(c *C) {
 	c.Assert(bootBase.IsTrivial(), Equals, false)
 
 	// make the base used on next boot
-	rebootRequired, err := bootBase.SetNextBoot(false)
+	rebootRequired, err := bootBase.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
 	c.Assert(err, IsNil)
 	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: true})
 
@@ -4207,7 +4207,7 @@ func (s *bootenv20RebootBootloaderSuite) TestCoreParticipant20WithRebootBootload
 	c.Assert(bootKern.IsTrivial(), Equals, false)
 
 	// make the kernel used on next boot
-	rebootRequired, err := bootKern.SetNextBoot(false)
+	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
 	c.Assert(err, IsNil)
 	c.Assert(rebootRequired.RebootRequired, Equals, true)
 	// Test that we retrieve a RebootBootloader interface

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -764,7 +764,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameKernelSnap(c *C) {
 	c.Assert(bootKern.IsTrivial(), Equals, false)
 
 	// make the kernel used on next boot
-	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
+	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{BootWithoutTry: false})
 	c.Assert(err, IsNil)
 	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: false})
 
@@ -807,7 +807,7 @@ func (s *bootenv20EnvRefKernelSuite) TestCoreParticipant20SetNextSameKernelSnap(
 	c.Assert(bootKern.IsTrivial(), Equals, false)
 
 	// make the kernel used on next boot
-	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
+	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{BootWithoutTry: false})
 	c.Assert(err, IsNil)
 	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: false})
 
@@ -847,7 +847,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewKernelSnap(c *C) {
 	c.Assert(bootKern.IsTrivial(), Equals, false)
 
 	// make the kernel used on next boot
-	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
+	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{BootWithoutTry: false})
 	c.Assert(err, IsNil)
 	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: true})
 
@@ -960,7 +960,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewKernelSnapWithReseal(c *
 	c.Assert(bootKern.IsTrivial(), Equals, false)
 
 	// make the kernel used on next boot
-	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
+	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{BootWithoutTry: false})
 	c.Assert(err, IsNil)
 	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: true})
 
@@ -1073,7 +1073,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewUnassertedKernelSnapWith
 	c.Assert(bootKern.IsTrivial(), Equals, false)
 
 	// make the kernel used on next boot
-	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
+	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{BootWithoutTry: false})
 	c.Assert(err, IsNil)
 	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: true})
 
@@ -1185,7 +1185,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameKernelSnapNoReseal(c *C
 	c.Assert(err, IsNil)
 
 	// make the kernel used on next boot
-	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
+	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{BootWithoutTry: false})
 	c.Assert(err, IsNil)
 	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: false})
 
@@ -1303,7 +1303,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameUnassertedKernelSnapNoR
 	c.Assert(err, IsNil)
 
 	// make the kernel used on next boot
-	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
+	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{BootWithoutTry: false})
 	c.Assert(err, IsNil)
 	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: false})
 
@@ -1346,7 +1346,7 @@ func (s *bootenv20EnvRefKernelSuite) TestCoreParticipant20SetNextNewKernelSnap(c
 	c.Assert(bootKern.IsTrivial(), Equals, false)
 
 	// make the kernel used on next boot
-	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
+	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{BootWithoutTry: false})
 	c.Assert(err, IsNil)
 	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: true})
 
@@ -1534,7 +1534,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameBaseSnap(c *C) {
 	c.Assert(bootBase.IsTrivial(), Equals, false)
 
 	// make the base used on next boot
-	rebootRequired, err := bootBase.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
+	rebootRequired, err := bootBase.SetNextBoot(boot.NextBootContext{BootWithoutTry: false})
 	c.Assert(err, IsNil)
 
 	// we don't need to reboot because it's the same base snap
@@ -1573,7 +1573,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewBaseSnap(c *C) {
 	c.Assert(bootBase.IsTrivial(), Equals, false)
 
 	// make the base used on next boot
-	rebootRequired, err := bootBase.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
+	rebootRequired, err := bootBase.SetNextBoot(boot.NextBootContext{BootWithoutTry: false})
 	c.Assert(err, IsNil)
 	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: true})
 
@@ -1667,7 +1667,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewBaseSnapNoReseal(c *C) {
 	c.Assert(bootBase.IsTrivial(), Equals, false)
 
 	// make the base used on next boot
-	rebootRequired, err := bootBase.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
+	rebootRequired, err := bootBase.SetNextBoot(boot.NextBootContext{BootWithoutTry: false})
 	c.Assert(err, IsNil)
 	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: true})
 
@@ -4207,7 +4207,7 @@ func (s *bootenv20RebootBootloaderSuite) TestCoreParticipant20WithRebootBootload
 	c.Assert(bootKern.IsTrivial(), Equals, false)
 
 	// make the kernel used on next boot
-	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
+	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{BootWithoutTry: false})
 	c.Assert(err, IsNil)
 	c.Assert(rebootRequired.RebootRequired, Equals, true)
 	// Test that we retrieve a RebootBootloader interface
@@ -4245,7 +4245,7 @@ func (s *bootenv20Suite) TestCoreParticipant20UndoKernelSnapInstallSame(c *C) {
 	c.Assert(bootKern.IsTrivial(), Equals, false)
 
 	// make the kernel used on next boot
-	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{IsUndoingInstall: true})
+	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{BootWithoutTry: true})
 	c.Assert(err, IsNil)
 	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: false})
 
@@ -4288,7 +4288,7 @@ func (s *bootenv20EnvRefKernelSuite) TestCoreParticipant20UndoKernelSnapInstallS
 	c.Assert(bootKern.IsTrivial(), Equals, false)
 
 	// make the kernel used on next boot
-	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{IsUndoingInstall: true})
+	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{BootWithoutTry: true})
 	c.Assert(err, IsNil)
 	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: false})
 
@@ -4328,7 +4328,7 @@ func (s *bootenv20Suite) TestCoreParticipant20UndoKernelSnapInstallNew(c *C) {
 	c.Assert(bootKern.IsTrivial(), Equals, false)
 
 	// make the kernel used on next boot, reverting the installation
-	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{IsUndoingInstall: true})
+	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{BootWithoutTry: true})
 	c.Assert(err, IsNil)
 	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: true})
 
@@ -4368,7 +4368,7 @@ func (s *bootenv20EnvRefKernelSuite) TestCoreParticipant20UndoKernelSnapInstallN
 	c.Assert(bootKern.IsTrivial(), Equals, false)
 
 	// make the kernel used on next boot
-	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{IsUndoingInstall: true})
+	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{BootWithoutTry: true})
 	c.Assert(err, IsNil)
 	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: true})
 
@@ -4474,7 +4474,7 @@ func (s *bootenv20Suite) TestCoreParticipant20UndoKernelSnapInstallNewWithReseal
 	c.Assert(bootKern.IsTrivial(), Equals, false)
 
 	// make the kernel used on next boot
-	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{IsUndoingInstall: true})
+	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{BootWithoutTry: true})
 	c.Assert(err, IsNil)
 	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: true})
 
@@ -4581,7 +4581,7 @@ func (s *bootenv20Suite) TestCoreParticipant20UndoUnassertedKernelSnapInstallNew
 	c.Assert(bootKern.IsTrivial(), Equals, false)
 
 	// make the kernel used on next boot
-	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{IsUndoingInstall: true})
+	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{BootWithoutTry: true})
 	c.Assert(err, IsNil)
 	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: true})
 
@@ -4693,7 +4693,7 @@ func (s *bootenv20Suite) TestCoreParticipant20UndoKernelSnapInstallSameNoReseal(
 	c.Assert(err, IsNil)
 
 	// make the kernel used on next boot
-	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{IsUndoingInstall: true})
+	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{BootWithoutTry: true})
 	c.Assert(err, IsNil)
 	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: false})
 
@@ -4811,7 +4811,7 @@ func (s *bootenv20Suite) TestCoreParticipant20UndoUnassertedKernelSnapInstallSam
 	c.Assert(err, IsNil)
 
 	// make the kernel used on next boot
-	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{IsUndoingInstall: true})
+	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{BootWithoutTry: true})
 	c.Assert(err, IsNil)
 	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: false})
 
@@ -4861,7 +4861,7 @@ func (s *bootenv20Suite) TestCoreParticipant20UndoBaseSnapInstallSame(c *C) {
 	c.Assert(bootBase.IsTrivial(), Equals, false)
 
 	// make the base used on next boot
-	rebootRequired, err := bootBase.SetNextBoot(boot.NextBootContext{IsUndoingInstall: true})
+	rebootRequired, err := bootBase.SetNextBoot(boot.NextBootContext{BootWithoutTry: true})
 	c.Assert(err, IsNil)
 
 	// we don't need to reboot because it's the same base snap
@@ -4900,7 +4900,7 @@ func (s *bootenv20Suite) TestCoreParticipant20UndoBaseSnapInstallNew(c *C) {
 	c.Assert(bootBase.IsTrivial(), Equals, false)
 
 	// make the base used on next boot, reverting the current one installed
-	rebootRequired, err := bootBase.SetNextBoot(boot.NextBootContext{IsUndoingInstall: true})
+	rebootRequired, err := bootBase.SetNextBoot(boot.NextBootContext{BootWithoutTry: true})
 	c.Assert(err, IsNil)
 	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: true})
 
@@ -4994,7 +4994,7 @@ func (s *bootenv20Suite) TestCoreParticipant20UndoBaseSnapInstallNewNoReseal(c *
 	c.Assert(bootBase.IsTrivial(), Equals, false)
 
 	// make the base used on next boot
-	rebootRequired, err := bootBase.SetNextBoot(boot.NextBootContext{IsUndoingInstall: true})
+	rebootRequired, err := bootBase.SetNextBoot(boot.NextBootContext{BootWithoutTry: true})
 	c.Assert(err, IsNil)
 	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: true})
 

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -4227,7 +4227,7 @@ func (s *bootenv20RebootBootloaderSuite) TestCoreParticipant20WithRebootBootload
 	c.Assert(m2.CurrentKernels, DeepEquals, []string{s.kern1.Filename(), s.kern2.Filename()})
 }
 
-func (s *bootenv20Suite) TestCoreParticipant20SetNextSameKernelSnapSame(c *C) {
+func (s *bootenv20Suite) TestCoreParticipant20UndoKernelSnapInstallSame(c *C) {
 	coreDev := boottest.MockUC20Device("", nil)
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 
@@ -4270,7 +4270,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameKernelSnapSame(c *C) {
 	c.Assert(s.bootloader.SetBootVarsCalls, Equals, 0)
 }
 
-func (s *bootenv20EnvRefKernelSuite) TestCoreParticipant20SetNextSameKernelSnapSame(c *C) {
+func (s *bootenv20EnvRefKernelSuite) TestCoreParticipant20UndoKernelSnapInstallSame(c *C) {
 	coreDev := boottest.MockUC20Device("", nil)
 	c.Assert(coreDev.HasModeenv(), Equals, true)
 

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -4226,3 +4226,785 @@ func (s *bootenv20RebootBootloaderSuite) TestCoreParticipant20WithRebootBootload
 	c.Assert(err, IsNil)
 	c.Assert(m2.CurrentKernels, DeepEquals, []string{s.kern1.Filename(), s.kern2.Filename()})
 }
+
+func (s *bootenv20Suite) TestCoreParticipant20SetNextSameKernelSnapSame(c *C) {
+	coreDev := boottest.MockUC20Device("", nil)
+	c.Assert(coreDev.HasModeenv(), Equals, true)
+
+	r := setupUC20Bootenv(
+		c,
+		s.bootloader,
+		s.normalDefaultState,
+	)
+	defer r()
+
+	// get the boot kernel participant from our kernel snap
+	bootKern := boot.Participant(s.kern1, snap.TypeKernel, coreDev)
+
+	// make sure it's not a trivial boot participant
+	c.Assert(bootKern.IsTrivial(), Equals, false)
+
+	// make the kernel used on next boot
+	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{IsUndoingInstall: true})
+	c.Assert(err, IsNil)
+	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: false})
+
+	// make sure that the bootloader was asked for the current kernel
+	_, nKernelCalls := s.bootloader.GetRunKernelImageFunctionSnapCalls("Kernel")
+	c.Assert(nKernelCalls, Equals, 1)
+
+	// ensure that kernel_status is still empty
+	c.Assert(s.bootloader.BootVars["kernel_status"], Equals, boot.DefaultStatus)
+
+	// there was no attempt to try a kernel
+	_, enableKernelCalls := s.bootloader.GetRunKernelImageFunctionSnapCalls("EnableTryKernel")
+	c.Assert(enableKernelCalls, Equals, 0)
+
+	// the modeenv is still the same as well
+	m2, err := boot.ReadModeenv("")
+	c.Assert(err, IsNil)
+	c.Assert(m2.CurrentKernels, DeepEquals, []string{s.kern1.Filename()})
+
+	// finally we didn't call SetBootVars on the bootloader because nothing
+	// changed
+	c.Assert(s.bootloader.SetBootVarsCalls, Equals, 0)
+}
+
+func (s *bootenv20EnvRefKernelSuite) TestCoreParticipant20SetNextSameKernelSnapSame(c *C) {
+	coreDev := boottest.MockUC20Device("", nil)
+	c.Assert(coreDev.HasModeenv(), Equals, true)
+
+	r := setupUC20Bootenv(
+		c,
+		s.bootloader,
+		s.normalDefaultState,
+	)
+	defer r()
+
+	// get the boot kernel participant from our kernel snap
+	bootKern := boot.Participant(s.kern1, snap.TypeKernel, coreDev)
+
+	// make sure it's not a trivial boot participant
+	c.Assert(bootKern.IsTrivial(), Equals, false)
+
+	// make the kernel used on next boot
+	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{IsUndoingInstall: true})
+	c.Assert(err, IsNil)
+	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: false})
+
+	// ensure that bootenv is unchanged
+	m, err := s.bootloader.GetBootVars("kernel_status", "snap_kernel", "snap_try_kernel")
+	c.Assert(err, IsNil)
+	c.Assert(m, DeepEquals, map[string]string{
+		"kernel_status":   boot.DefaultStatus,
+		"snap_kernel":     s.kern1.Filename(),
+		"snap_try_kernel": "",
+	})
+
+	// the modeenv is still the same as well
+	m2, err := boot.ReadModeenv("")
+	c.Assert(err, IsNil)
+	c.Assert(m2.CurrentKernels, DeepEquals, []string{s.kern1.Filename()})
+
+	// finally we didn't call SetBootVars on the bootloader because nothing
+	// changed
+	c.Assert(s.bootloader.SetBootVarsCalls, Equals, 0)
+}
+
+func (s *bootenv20Suite) TestCoreParticipant20UndoKernelSnapInstallNew(c *C) {
+	coreDev := boottest.MockUC20Device("", nil)
+	c.Assert(coreDev.HasModeenv(), Equals, true)
+
+	r := setupUC20Bootenv(
+		c,
+		s.bootloader,
+		s.normalDefaultState,
+	)
+	defer r()
+
+	// get the boot kernel participant from our new kernel snap
+	bootKern := boot.Participant(s.kern2, snap.TypeKernel, coreDev)
+	// make sure it's not a trivial boot participant
+	c.Assert(bootKern.IsTrivial(), Equals, false)
+
+	// make the kernel used on next boot, reverting the installation
+	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{IsUndoingInstall: true})
+	c.Assert(err, IsNil)
+	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: true})
+
+	// make sure that the bootloader was asked for the current kernel
+	_, nKernelCalls := s.bootloader.GetRunKernelImageFunctionSnapCalls("Kernel")
+	c.Assert(nKernelCalls, Equals, 1)
+
+	// ensure that kernel_status is the default
+	c.Assert(s.bootloader.BootVars["kernel_status"], Equals, boot.DefaultStatus)
+
+	// and we were asked to enable kernel2 as kernel, not as try kernel
+	_, numTry := s.bootloader.GetRunKernelImageFunctionSnapCalls("EnableTryKernel")
+	c.Assert(numTry, Equals, 0)
+	actual, _ := s.bootloader.GetRunKernelImageFunctionSnapCalls("EnableKernel")
+	c.Assert(actual, DeepEquals, []snap.PlaceInfo{s.kern2})
+
+	// and that the modeenv now has only this kernel listed
+	m2, err := boot.ReadModeenv("")
+	c.Assert(err, IsNil)
+	c.Assert(m2.CurrentKernels, DeepEquals, []string{s.kern2.Filename()})
+}
+
+func (s *bootenv20EnvRefKernelSuite) TestCoreParticipant20UndoKernelSnapInstallNew(c *C) {
+	coreDev := boottest.MockUC20Device("", nil)
+	c.Assert(coreDev.HasModeenv(), Equals, true)
+
+	r := setupUC20Bootenv(
+		c,
+		s.bootloader,
+		s.normalDefaultState,
+	)
+	defer r()
+
+	// get the boot kernel participant from our new kernel snap
+	bootKern := boot.Participant(s.kern2, snap.TypeKernel, coreDev)
+	// make sure it's not a trivial boot participant
+	c.Assert(bootKern.IsTrivial(), Equals, false)
+
+	// make the kernel used on next boot
+	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{IsUndoingInstall: true})
+	c.Assert(err, IsNil)
+	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: true})
+
+	// make sure the env was updated
+	m := s.bootloader.BootVars
+	c.Assert(m, DeepEquals, map[string]string{
+		"kernel_status":   boot.DefaultStatus,
+		"snap_kernel":     s.kern2.Filename(),
+		"snap_try_kernel": "",
+	})
+
+	// and that the modeenv now has this kernel listed
+	m2, err := boot.ReadModeenv("")
+	c.Assert(err, IsNil)
+	c.Assert(m2.CurrentKernels, DeepEquals, []string{s.kern2.Filename()})
+}
+
+func (s *bootenv20Suite) TestCoreParticipant20UndoKernelSnapInstallNewWithReseal(c *C) {
+	// checked by resealKeyToModeenv
+	s.stampSealedKeys(c, dirs.GlobalRootDir)
+
+	tab := s.bootloaderWithTrustedAssets(c, []string{"asset"})
+
+	data := []byte("foobar")
+	// SHA3-384
+	dataHash := "0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"
+
+	c.Assert(os.MkdirAll(filepath.Join(boot.InitramfsUbuntuBootDir), 0755), IsNil)
+	c.Assert(os.MkdirAll(filepath.Join(boot.InitramfsUbuntuSeedDir), 0755), IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), data, 0644), IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
+
+	// mock the files in cache
+	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
+		"asset-" + dataHash,
+	})
+
+	assetBf := bootloader.NewBootFile("", filepath.Join(dirs.SnapBootAssetsDir,
+		"trusted", fmt.Sprintf("asset-%s", dataHash)), bootloader.RoleRunMode)
+	runKernelBf := bootloader.NewBootFile(filepath.Join(s.kern2.Filename()),
+		"kernel.efi", bootloader.RoleRunMode)
+
+	tab.BootChainList = []bootloader.BootFile{
+		bootloader.NewBootFile("", "asset", bootloader.RoleRunMode),
+		// TODO:UC20: fix mocked trusted assets bootloader to actually
+		// geenerate kernel boot files
+		runKernelBf,
+	}
+
+	coreDev := boottest.MockUC20Device("", nil)
+	c.Assert(coreDev.HasModeenv(), Equals, true)
+	model := coreDev.Model()
+
+	m := &boot.Modeenv{
+		Mode:           "run",
+		Base:           s.base1.Filename(),
+		CurrentKernels: []string{s.kern1.Filename()},
+		CurrentTrustedBootAssets: boot.BootAssetsMap{
+			"asset": {dataHash},
+		},
+		Model:          model.Model(),
+		BrandID:        model.BrandID(),
+		Grade:          string(model.Grade()),
+		ModelSignKeyID: model.SignKeyID(),
+	}
+
+	r := setupUC20Bootenv(
+		c,
+		tab.MockBootloader,
+		&bootenv20Setup{
+			modeenv:    m,
+			kern:       s.kern1,
+			kernStatus: boot.DefaultStatus,
+		},
+	)
+	defer r()
+
+	resealCalls := 0
+	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+		resealCalls++
+
+		c.Assert(params.ModelParams, HasLen, 1)
+		mp := params.ModelParams[0]
+		c.Check(mp.Model.Model(), Equals, model.Model())
+		for _, ch := range mp.EFILoadChains {
+			printChain(c, ch, "-")
+		}
+		c.Check(mp.EFILoadChains, DeepEquals, []*secboot.LoadChain{
+			secboot.NewLoadChain(assetBf,
+				secboot.NewLoadChain(runKernelBf)),
+		})
+		// actual paths are seen only here
+		c.Check(tab.BootChainKernelPath, DeepEquals, []string{
+			s.kern2.MountFile(),
+		})
+		return nil
+	})
+	defer restore()
+
+	// get the boot kernel participant from our new kernel snap
+	bootKern := boot.Participant(s.kern2, snap.TypeKernel, coreDev)
+	// make sure it's not a trivial boot participant
+	c.Assert(bootKern.IsTrivial(), Equals, false)
+
+	// make the kernel used on next boot
+	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{IsUndoingInstall: true})
+	c.Assert(err, IsNil)
+	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: true})
+
+	// make sure the env was updated
+	bvars, err := tab.GetBootVars("kernel_status", "snap_kernel", "snap_try_kernel")
+	c.Assert(err, IsNil)
+	c.Assert(bvars, DeepEquals, map[string]string{
+		"kernel_status":   boot.DefaultStatus,
+		"snap_kernel":     s.kern2.Filename(),
+		"snap_try_kernel": "",
+	})
+
+	// and that the modeenv now has this kernel listed
+	m2, err := boot.ReadModeenv("")
+	c.Assert(err, IsNil)
+	c.Assert(m2.CurrentKernels, DeepEquals, []string{s.kern2.Filename()})
+
+	c.Check(resealCalls, Equals, 1)
+}
+
+func (s *bootenv20Suite) TestCoreParticipant20UndoUnassertedKernelSnapInstallNewWithReseal(c *C) {
+	// checked by resealKeyToModeenv
+	s.stampSealedKeys(c, dirs.GlobalRootDir)
+
+	tab := s.bootloaderWithTrustedAssets(c, []string{"asset"})
+
+	data := []byte("foobar")
+	// SHA3-384
+	dataHash := "0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"
+
+	c.Assert(os.MkdirAll(filepath.Join(boot.InitramfsUbuntuBootDir), 0755), IsNil)
+	c.Assert(os.MkdirAll(filepath.Join(boot.InitramfsUbuntuSeedDir), 0755), IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), data, 0644), IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
+
+	// mock the files in cache
+	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
+		"asset-" + dataHash,
+	})
+
+	assetBf := bootloader.NewBootFile("", filepath.Join(dirs.SnapBootAssetsDir, "trusted", fmt.Sprintf("asset-%s", dataHash)), bootloader.RoleRunMode)
+	runKernelBf := bootloader.NewBootFile(filepath.Join(s.ukern2.Filename()), "kernel.efi", bootloader.RoleRunMode)
+
+	tab.BootChainList = []bootloader.BootFile{
+		bootloader.NewBootFile("", "asset", bootloader.RoleRunMode),
+		// TODO:UC20: fix mocked trusted assets bootloader to actually
+		// geenerate kernel boot files
+		runKernelBf,
+	}
+
+	uc20Model := boottest.MakeMockUC20Model()
+	coreDev := boottest.MockUC20Device("", uc20Model)
+	c.Assert(coreDev.HasModeenv(), Equals, true)
+
+	m := &boot.Modeenv{
+		Mode:           "run",
+		Base:           s.base1.Filename(),
+		CurrentKernels: []string{s.ukern1.Filename()},
+		CurrentTrustedBootAssets: boot.BootAssetsMap{
+			"asset": {dataHash},
+		},
+		Model:          uc20Model.Model(),
+		BrandID:        uc20Model.BrandID(),
+		Grade:          string(uc20Model.Grade()),
+		ModelSignKeyID: uc20Model.SignKeyID(),
+	}
+
+	r := setupUC20Bootenv(
+		c,
+		tab.MockBootloader,
+		&bootenv20Setup{
+			modeenv:    m,
+			kern:       s.ukern1,
+			kernStatus: boot.DefaultStatus,
+		},
+	)
+	defer r()
+
+	resealCalls := 0
+	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+		resealCalls++
+
+		c.Assert(params.ModelParams, HasLen, 1)
+		mp := params.ModelParams[0]
+		c.Check(mp.Model.Model(), Equals, uc20Model.Model())
+		for _, ch := range mp.EFILoadChains {
+			printChain(c, ch, "-")
+		}
+		c.Check(mp.EFILoadChains, DeepEquals, []*secboot.LoadChain{
+			secboot.NewLoadChain(assetBf,
+				secboot.NewLoadChain(runKernelBf)),
+		})
+		// actual paths are seen only here
+		c.Check(tab.BootChainKernelPath, DeepEquals, []string{
+			s.ukern2.MountFile(),
+		})
+		return nil
+	})
+	defer restore()
+
+	// get the boot kernel participant from our new kernel snap
+	bootKern := boot.Participant(s.ukern2, snap.TypeKernel, coreDev)
+	// make sure it's not a trivial boot participant
+	c.Assert(bootKern.IsTrivial(), Equals, false)
+
+	// make the kernel used on next boot
+	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{IsUndoingInstall: true})
+	c.Assert(err, IsNil)
+	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: true})
+
+	bvars, err := tab.GetBootVars("kernel_status", "snap_kernel", "snap_try_kernel")
+	c.Assert(err, IsNil)
+	c.Assert(bvars, DeepEquals, map[string]string{
+		"kernel_status":   boot.DefaultStatus,
+		"snap_kernel":     s.ukern2.Filename(),
+		"snap_try_kernel": "",
+	})
+
+	// and that the modeenv now has this kernel listed
+	m2, err := boot.ReadModeenv("")
+	c.Assert(err, IsNil)
+	c.Assert(m2.CurrentKernels, DeepEquals, []string{s.ukern2.Filename()})
+
+	c.Check(resealCalls, Equals, 1)
+}
+
+func (s *bootenv20Suite) TestCoreParticipant20UndoKernelSnapInstallSameNoReseal(c *C) {
+	// checked by resealKeyToModeenv
+	s.stampSealedKeys(c, dirs.GlobalRootDir)
+
+	tab := s.bootloaderWithTrustedAssets(c, []string{"asset"})
+
+	data := []byte("foobar")
+	// SHA3-384
+	dataHash := "0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"
+
+	c.Assert(os.MkdirAll(filepath.Join(boot.InitramfsUbuntuBootDir), 0755), IsNil)
+	c.Assert(os.MkdirAll(filepath.Join(boot.InitramfsUbuntuSeedDir), 0755), IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), data, 0644), IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
+
+	// mock the files in cache
+	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
+		"asset-" + dataHash,
+	})
+
+	runKernelBf := bootloader.NewBootFile(filepath.Join(s.kern1.Filename()), "kernel.efi", bootloader.RoleRunMode)
+
+	tab.BootChainList = []bootloader.BootFile{
+		bootloader.NewBootFile("", "asset", bootloader.RoleRunMode),
+		runKernelBf,
+	}
+
+	uc20Model := boottest.MakeMockUC20Model()
+	coreDev := boottest.MockUC20Device("", uc20Model)
+	c.Assert(coreDev.HasModeenv(), Equals, true)
+
+	m := &boot.Modeenv{
+		Mode:           "run",
+		Base:           s.base1.Filename(),
+		CurrentKernels: []string{s.kern1.Filename()},
+		CurrentTrustedBootAssets: boot.BootAssetsMap{
+			"asset": {dataHash},
+		},
+		CurrentKernelCommandLines: boot.BootCommandLines{"snapd_recovery_mode=run"},
+
+		Model:          uc20Model.Model(),
+		BrandID:        uc20Model.BrandID(),
+		Grade:          string(uc20Model.Grade()),
+		ModelSignKeyID: uc20Model.SignKeyID(),
+	}
+
+	r := setupUC20Bootenv(
+		c,
+		tab.MockBootloader,
+		&bootenv20Setup{
+			modeenv:    m,
+			kern:       s.kern1,
+			kernStatus: boot.DefaultStatus,
+		},
+	)
+	defer r()
+
+	resealCalls := 0
+	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+		resealCalls++
+		return fmt.Errorf("unexpected call to mocked secbootResealKeys")
+	})
+	defer restore()
+
+	// get the boot kernel participant from our kernel snap
+	bootKern := boot.Participant(s.kern1, snap.TypeKernel, coreDev)
+	// make sure it's not a trivial boot participant
+	c.Assert(bootKern.IsTrivial(), Equals, false)
+
+	// write boot-chains for current state that will stay unchanged
+	bootChains := []boot.BootChain{{
+		BrandID:        "my-brand",
+		Model:          "my-model-uc20",
+		Grade:          "dangerous",
+		ModelSignKeyID: "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij",
+		AssetChain: []boot.BootAsset{
+			{
+				Role: bootloader.RoleRunMode,
+				Name: "asset",
+				Hashes: []string{
+					"0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8",
+				},
+			},
+		},
+		Kernel:         "pc-kernel",
+		KernelRevision: "1",
+		KernelCmdlines: []string{"snapd_recovery_mode=run"},
+	}}
+	err := boot.WriteBootChains(bootChains, filepath.Join(dirs.SnapFDEDir, "boot-chains"), 0)
+	c.Assert(err, IsNil)
+
+	// make the kernel used on next boot
+	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{IsUndoingInstall: true})
+	c.Assert(err, IsNil)
+	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: false})
+
+	// make sure the env is as expected
+	bvars, err := tab.GetBootVars("kernel_status", "snap_kernel", "snap_try_kernel")
+	c.Assert(err, IsNil)
+	c.Assert(bvars, DeepEquals, map[string]string{
+		"kernel_status":   boot.DefaultStatus,
+		"snap_kernel":     s.kern1.Filename(),
+		"snap_try_kernel": "",
+	})
+
+	// and that the modeenv now has the one kernel listed
+	m2, err := boot.ReadModeenv("")
+	c.Assert(err, IsNil)
+	c.Assert(m2.CurrentKernels, DeepEquals, []string{s.kern1.Filename()})
+
+	// boot chains were built
+	c.Check(tab.BootChainKernelPath, DeepEquals, []string{
+		s.kern1.MountFile(),
+	})
+	// no actual reseal
+	c.Check(resealCalls, Equals, 0)
+}
+
+func (s *bootenv20Suite) TestCoreParticipant20UndoUnassertedKernelSnapInstallSameNoReseal(c *C) {
+	// checked by resealKeyToModeenv
+	s.stampSealedKeys(c, dirs.GlobalRootDir)
+
+	tab := s.bootloaderWithTrustedAssets(c, []string{"asset"})
+
+	data := []byte("foobar")
+	// SHA3-384
+	dataHash := "0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"
+
+	c.Assert(os.MkdirAll(filepath.Join(boot.InitramfsUbuntuBootDir), 0755), IsNil)
+	c.Assert(os.MkdirAll(filepath.Join(boot.InitramfsUbuntuSeedDir), 0755), IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), data, 0644), IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
+
+	// mock the files in cache
+	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
+		"asset-" + dataHash,
+	})
+
+	runKernelBf := bootloader.NewBootFile(filepath.Join(s.ukern1.Filename()), "kernel.efi", bootloader.RoleRunMode)
+
+	tab.BootChainList = []bootloader.BootFile{
+		bootloader.NewBootFile("", "asset", bootloader.RoleRunMode),
+		runKernelBf,
+	}
+
+	uc20Model := boottest.MakeMockUC20Model()
+	coreDev := boottest.MockUC20Device("", uc20Model)
+	c.Assert(coreDev.HasModeenv(), Equals, true)
+
+	m := &boot.Modeenv{
+		Mode:           "run",
+		Base:           s.base1.Filename(),
+		CurrentKernels: []string{s.ukern1.Filename()},
+		CurrentTrustedBootAssets: boot.BootAssetsMap{
+			"asset": {dataHash},
+		},
+		CurrentKernelCommandLines: boot.BootCommandLines{"snapd_recovery_mode=run"},
+
+		Model:          uc20Model.Model(),
+		BrandID:        uc20Model.BrandID(),
+		Grade:          string(uc20Model.Grade()),
+		ModelSignKeyID: uc20Model.SignKeyID(),
+	}
+
+	r := setupUC20Bootenv(
+		c,
+		tab.MockBootloader,
+		&bootenv20Setup{
+			modeenv:    m,
+			kern:       s.ukern1,
+			kernStatus: boot.DefaultStatus,
+		},
+	)
+	defer r()
+
+	resealCalls := 0
+	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+		resealCalls++
+		return fmt.Errorf("unexpected call")
+	})
+	defer restore()
+
+	// get the boot kernel participant from our kernel snap
+	bootKern := boot.Participant(s.ukern1, snap.TypeKernel, coreDev)
+	// make sure it's not a trivial boot participant
+	c.Assert(bootKern.IsTrivial(), Equals, false)
+
+	// write boot-chains for current state that will stay unchanged
+	bootChains := []boot.BootChain{{
+		BrandID:        "my-brand",
+		Model:          "my-model-uc20",
+		Grade:          "dangerous",
+		ModelSignKeyID: "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij",
+		AssetChain: []boot.BootAsset{
+			{
+				Role: bootloader.RoleRunMode,
+				Name: "asset",
+				Hashes: []string{
+					"0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8",
+				},
+			},
+		},
+		Kernel:         "pc-kernel",
+		KernelRevision: "",
+		KernelCmdlines: []string{"snapd_recovery_mode=run"},
+	}}
+	err := boot.WriteBootChains(bootChains, filepath.Join(dirs.SnapFDEDir, "boot-chains"), 0)
+	c.Assert(err, IsNil)
+
+	// make the kernel used on next boot
+	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{IsUndoingInstall: true})
+	c.Assert(err, IsNil)
+	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: false})
+
+	// make sure the env is as expected
+	bvars, err := tab.GetBootVars("kernel_status", "snap_kernel", "snap_try_kernel")
+	c.Assert(err, IsNil)
+	c.Assert(bvars, DeepEquals, map[string]string{
+		"kernel_status":   boot.DefaultStatus,
+		"snap_kernel":     s.ukern1.Filename(),
+		"snap_try_kernel": "",
+	})
+
+	// and that the modeenv now has the one kernel listed
+	m2, err := boot.ReadModeenv("")
+	c.Assert(err, IsNil)
+	c.Assert(m2.CurrentKernels, DeepEquals, []string{s.ukern1.Filename()})
+
+	// boot chains were built
+	c.Check(tab.BootChainKernelPath, DeepEquals, []string{
+		s.ukern1.MountFile(),
+	})
+	// no actual reseal
+	c.Check(resealCalls, Equals, 0)
+}
+
+func (s *bootenv20Suite) TestCoreParticipant20UndoBaseSnapInstallSame(c *C) {
+	coreDev := boottest.MockUC20Device("", nil)
+	c.Assert(coreDev.HasModeenv(), Equals, true)
+
+	m := &boot.Modeenv{
+		Mode: "run",
+		Base: s.base1.Filename(),
+	}
+	r := setupUC20Bootenv(
+		c,
+		s.bootloader,
+		&bootenv20Setup{
+			modeenv: m,
+			// no kernel setup necessary
+		},
+	)
+	defer r()
+
+	// get the boot base participant from our base snap
+	bootBase := boot.Participant(s.base1, snap.TypeBase, coreDev)
+	// make sure it's not a trivial boot participant
+	c.Assert(bootBase.IsTrivial(), Equals, false)
+
+	// make the base used on next boot
+	rebootRequired, err := bootBase.SetNextBoot(boot.NextBootContext{IsUndoingInstall: true})
+	c.Assert(err, IsNil)
+
+	// we don't need to reboot because it's the same base snap
+	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: false})
+
+	// make sure the modeenv wasn't changed
+	m2, err := boot.ReadModeenv("")
+	c.Assert(err, IsNil)
+	c.Assert(m2.Base, Equals, m.Base)
+	c.Assert(m2.BaseStatus, Equals, m.BaseStatus)
+	c.Assert(m2.TryBase, Equals, m.TryBase)
+}
+
+func (s *bootenv20Suite) TestCoreParticipant20UndoBaseSnapInstallNew(c *C) {
+	coreDev := boottest.MockUC20Device("", nil)
+	c.Assert(coreDev.HasModeenv(), Equals, true)
+
+	// default state
+	m := &boot.Modeenv{
+		Mode: "run",
+		Base: s.base1.Filename(),
+	}
+	r := setupUC20Bootenv(
+		c,
+		s.bootloader,
+		&bootenv20Setup{
+			modeenv: m,
+			// no kernel setup necessary
+		},
+	)
+	defer r()
+
+	// get the boot base participant from our new base snap
+	bootBase := boot.Participant(s.base2, snap.TypeBase, coreDev)
+	// make sure it's not a trivial boot participant
+	c.Assert(bootBase.IsTrivial(), Equals, false)
+
+	// make the base used on next boot, reverting the current one installed
+	rebootRequired, err := bootBase.SetNextBoot(boot.NextBootContext{IsUndoingInstall: true})
+	c.Assert(err, IsNil)
+	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: true})
+
+	// make sure the modeenv was updated
+	m2, err := boot.ReadModeenv("")
+	c.Assert(err, IsNil)
+	c.Assert(m2.Base, Equals, s.base2.Filename())
+	c.Assert(m2.BaseStatus, Equals, "")
+	c.Assert(m2.TryBase, Equals, "")
+}
+
+func (s *bootenv20Suite) TestCoreParticipant20UndoBaseSnapInstallNewNoReseal(c *C) {
+	// checked by resealKeyToModeenv
+	s.stampSealedKeys(c, dirs.GlobalRootDir)
+
+	// set up all the bits required for an encrypted system
+	tab := s.bootloaderWithTrustedAssets(c, []string{"asset"})
+	data := []byte("foobar")
+	// SHA3-384
+	dataHash := "0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"
+	c.Assert(os.MkdirAll(filepath.Join(boot.InitramfsUbuntuBootDir), 0755), IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), data, 0644), IsNil)
+	// mock the files in cache
+	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
+		"asset-" + dataHash,
+	})
+	runKernelBf := bootloader.NewBootFile(filepath.Join(s.kern1.Filename()), "kernel.efi", bootloader.RoleRunMode)
+	// write boot-chains for current state that will stay unchanged even
+	// though base is changed
+	bootChains := []boot.BootChain{{
+		BrandID:        "my-brand",
+		Model:          "my-model-uc20",
+		Grade:          "dangerous",
+		ModelSignKeyID: "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij",
+		AssetChain: []boot.BootAsset{{
+			Role: bootloader.RoleRunMode, Name: "asset", Hashes: []string{
+				"0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8",
+			},
+		}},
+		Kernel:         "pc-kernel",
+		KernelRevision: "1",
+		KernelCmdlines: []string{"snapd_recovery_mode=run"},
+	}}
+
+	err := boot.WriteBootChains(boot.ToPredictableBootChains(bootChains), filepath.Join(dirs.SnapFDEDir, "boot-chains"), 0)
+	c.Assert(err, IsNil)
+
+	coreDev := boottest.MockUC20Device("", nil)
+	c.Assert(coreDev.HasModeenv(), Equals, true)
+	model := coreDev.Model()
+
+	resealCalls := 0
+	restore := boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
+		resealCalls++
+		return nil
+	})
+	defer restore()
+
+	tab.BootChainList = []bootloader.BootFile{
+		bootloader.NewBootFile("", "asset", bootloader.RoleRunMode),
+		runKernelBf,
+	}
+
+	// default state
+	m := &boot.Modeenv{
+		Mode:           "run",
+		Base:           s.base1.Filename(),
+		CurrentKernels: []string{s.kern1.Filename()},
+		CurrentTrustedBootAssets: boot.BootAssetsMap{
+			"asset": {dataHash},
+		},
+
+		Model:          model.Model(),
+		BrandID:        model.BrandID(),
+		Grade:          string(model.Grade()),
+		ModelSignKeyID: model.SignKeyID(),
+	}
+	r := setupUC20Bootenv(
+		c,
+		tab.MockBootloader,
+		&bootenv20Setup{
+			modeenv: m,
+			// no kernel setup necessary
+		},
+	)
+	defer r()
+
+	// get the boot base participant from our new base snap
+	bootBase := boot.Participant(s.base2, snap.TypeBase, coreDev)
+	// make sure it's not a trivial boot participant
+	c.Assert(bootBase.IsTrivial(), Equals, false)
+
+	// make the base used on next boot
+	rebootRequired, err := bootBase.SetNextBoot(boot.NextBootContext{IsUndoingInstall: true})
+	c.Assert(err, IsNil)
+	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: true})
+
+	// make sure the modeenv was updated
+	m2, err := boot.ReadModeenv("")
+	c.Assert(err, IsNil)
+	c.Assert(m2.Base, Equals, s.base2.Filename())
+	c.Assert(m2.BaseStatus, Equals, boot.DefaultStatus)
+	c.Assert(m2.TryBase, Equals, "")
+
+	// no reseal
+	c.Check(resealCalls, Equals, 0)
+}

--- a/boot/bootstate16.go
+++ b/boot/bootstate16.go
@@ -159,7 +159,7 @@ func (s16 *bootState16) markSuccessful(update bootStateUpdate) (bootStateUpdate,
 	return u16, nil
 }
 
-func (s16 *bootState16) setNext(s snap.PlaceInfo) (rbi RebootInfo, u bootStateUpdate, err error) {
+func (s16 *bootState16) setNext(isUndo bool, s snap.PlaceInfo) (rbi RebootInfo, u bootStateUpdate, err error) {
 	nextBoot := s.Filename()
 
 	nextBootVar := fmt.Sprintf("snap_try_%s", s16.varSuffix)

--- a/boot/bootstate16.go
+++ b/boot/bootstate16.go
@@ -160,8 +160,6 @@ func (s16 *bootState16) markSuccessful(update bootStateUpdate) (bootStateUpdate,
 }
 
 func (s16 *bootState16) setNext(s snap.PlaceInfo, bootCtx NextBootContext) (rbi RebootInfo, u bootStateUpdate, err error) {
-	nextBoot := s.Filename()
-
 	nextBootVar := fmt.Sprintf("snap_try_%s", s16.varSuffix)
 	goodBootVar := fmt.Sprintf("snap_%s", s16.varSuffix)
 
@@ -173,8 +171,9 @@ func (s16 *bootState16) setNext(s snap.PlaceInfo, bootCtx NextBootContext) (rbi 
 	env := u16.env
 	toCommit := u16.toCommit
 
-	snapMode := TryStatus
 	rbi.RebootRequired = true
+	snapMode := TryStatus
+	nextBoot := s.Filename()
 	if env[goodBootVar] == nextBoot {
 		// If we were in anything but default ("") mode before
 		// and switched to the good core/kernel again, make
@@ -188,6 +187,10 @@ func (s16 *bootState16) setNext(s snap.PlaceInfo, bootCtx NextBootContext) (rbi 
 		snapMode = DefaultStatus
 		nextBoot = ""
 		rbi.RebootRequired = false
+	} else if bootCtx.IsUndoingInstall {
+		toCommit[goodBootVar] = nextBoot
+		snapMode = DefaultStatus
+		nextBoot = ""
 	}
 
 	toCommit["snap_mode"] = snapMode

--- a/boot/bootstate16.go
+++ b/boot/bootstate16.go
@@ -159,7 +159,7 @@ func (s16 *bootState16) markSuccessful(update bootStateUpdate) (bootStateUpdate,
 	return u16, nil
 }
 
-func (s16 *bootState16) setNext(isUndo bool, s snap.PlaceInfo) (rbi RebootInfo, u bootStateUpdate, err error) {
+func (s16 *bootState16) setNext(s snap.PlaceInfo, bootCtx NextBootContext) (rbi RebootInfo, u bootStateUpdate, err error) {
 	nextBoot := s.Filename()
 
 	nextBootVar := fmt.Sprintf("snap_try_%s", s16.varSuffix)

--- a/boot/bootstate16.go
+++ b/boot/bootstate16.go
@@ -187,7 +187,7 @@ func (s16 *bootState16) setNext(s snap.PlaceInfo, bootCtx NextBootContext) (rbi 
 		snapMode = DefaultStatus
 		nextBoot = ""
 		rbi.RebootRequired = false
-	} else if bootCtx.IsUndoingInstall {
+	} else if bootCtx.BootWithoutTry {
 		toCommit[goodBootVar] = nextBoot
 		snapMode = DefaultStatus
 		nextBoot = ""

--- a/boot/bootstate20.go
+++ b/boot/bootstate20.go
@@ -315,7 +315,7 @@ func (ks20 *bootState20Kernel) setNext(next snap.PlaceInfo, bootCtx NextBootCont
 	rbi.RebootRequired = rebootRequired
 	if rbi.RebootRequired {
 		// if we need to reboot and we are not undoing, we set the try status
-		if !bootCtx.IsUndoingInstall {
+		if !bootCtx.BootWithoutTry {
 			nextStatus = TryStatus
 		}
 		// kernels are usually loaded directly by the bootloader, for
@@ -330,7 +330,7 @@ func (ks20 *bootState20Kernel) setNext(next snap.PlaceInfo, bootCtx NextBootCont
 	currentKernel := ks20.bks.kernel()
 	if next.Filename() != currentKernel.Filename() {
 		// on commit, add this kernel to the modeenv
-		if bootCtx.IsUndoingInstall {
+		if bootCtx.BootWithoutTry {
 			// when undoing, the current kernel is being removed
 			u20.writeModeenv.CurrentKernels = []string{next.Filename()}
 		} else {
@@ -342,7 +342,7 @@ func (ks20 *bootState20Kernel) setNext(next snap.PlaceInfo, bootCtx NextBootCont
 	}
 
 	bootTask := func() error { return ks20.bks.setNextKernel(next, nextStatus) }
-	if bootCtx.IsUndoingInstall {
+	if bootCtx.BootWithoutTry {
 		// force revert to "next" kernel (actually it is the old one)
 		// and ignore the try status, that will be empty in this case.
 		bootTask = func() error { return ks20.bks.setNextKernelNoTry(next) }
@@ -474,7 +474,7 @@ func (bs20 *bootState20Base) setNext(next snap.PlaceInfo, bootCtx NextBootContex
 	nextStatus := DefaultStatus
 	rbi.RebootRequired = rebootRequired
 	if rbi.RebootRequired {
-		if bootCtx.IsUndoingInstall {
+		if bootCtx.BootWithoutTry {
 			// we must make sure we boot with the base we revert to
 			u20.writeModeenv.Base = next.Filename()
 			u20.writeModeenv.TryBase = ""

--- a/boot/bootstate20.go
+++ b/boot/bootstate20.go
@@ -73,6 +73,12 @@ type bootloaderKernelState20 interface {
 	// markSuccessfulKernel marks the specified kernel as having booted
 	// successfully, whether that kernel is the current kernel or the try-kernel
 	markSuccessfulKernel(sn snap.PlaceInfo) error
+	// setKernel sets the specified kernel as the next boot kernel, without
+	// the "try" logic. This shall be used only when we have already booted
+	// to a new kernel but for some reason we need to revert to the previous
+	// kernel (for instance, in a transactional update when the failing snap
+	// is not the kernel).
+	setKernel(sn snap.PlaceInfo) error
 }
 
 //
@@ -299,16 +305,19 @@ func (ks20 *bootState20Kernel) markSuccessful(update bootStateUpdate) (bootState
 	return u20, nil
 }
 
-func (ks20 *bootState20Kernel) setNext(next snap.PlaceInfo) (rbi RebootInfo, u bootStateUpdate, err error) {
-	u20, nextStatus, err := genericSetNext(ks20, next)
+func (ks20 *bootState20Kernel) setNext(isUndo bool, next snap.PlaceInfo) (rbi RebootInfo, u bootStateUpdate, err error) {
+	u20, rebootRequired, err := genericSetNext(ks20, next)
 	if err != nil {
 		return RebootInfo{RebootRequired: false}, nil, err
 	}
 
-	// if we are setting a snap as a try snap, then we need to reboot
-	rbi.RebootRequired = false
-	if nextStatus == TryStatus {
-		rbi.RebootRequired = true
+	nextStatus := DefaultStatus
+	rbi.RebootRequired = rebootRequired
+	if rbi.RebootRequired {
+		// if we need to reboot and we are not undoing, we set the try status
+		if !isUndo {
+			nextStatus = TryStatus
+		}
 		// kernels are usually loaded directly by the bootloader, for
 		// which we may need to pass additional data to make 'try'
 		// operation more robust - that might be provided by the
@@ -321,10 +330,22 @@ func (ks20 *bootState20Kernel) setNext(next snap.PlaceInfo) (rbi RebootInfo, u b
 	currentKernel := ks20.bks.kernel()
 	if next.Filename() != currentKernel.Filename() {
 		// on commit, add this kernel to the modeenv
-		u20.writeModeenv.CurrentKernels = append(
-			u20.writeModeenv.CurrentKernels,
-			next.Filename(),
-		)
+		if isUndo {
+			// when undoing, the current kernel is being removed
+			u20.writeModeenv.CurrentKernels = []string{next.Filename()}
+		} else {
+			u20.writeModeenv.CurrentKernels = append(
+				u20.writeModeenv.CurrentKernels,
+				next.Filename(),
+			)
+		}
+	}
+
+	bootTask := func() error { return ks20.bks.setNextKernel(next, nextStatus) }
+	if isUndo {
+		// force revert to "next" kernel (actually it is the old one)
+		// and ignore the try status, that will be empty in this case.
+		bootTask = func() error { return ks20.bks.setKernel(next) }
 	}
 
 	// On commit, if we are about to try an update, and need to set the next
@@ -333,7 +354,7 @@ func (ks20 *bootState20Kernel) setNext(next snap.PlaceInfo) (rbi RebootInfo, u b
 	// kernel and updating the modeenv, the initramfs would fail the boot
 	// because the modeenv doesn't "trust" or expect the new kernel that booted.
 	// As such, set the next kernel as a post modeenv task.
-	u20.postModeenv(func() error { return ks20.bks.setNextKernel(next, nextStatus) })
+	u20.postModeenv(bootTask)
 
 	return rbi, u20, nil
 }
@@ -441,21 +462,28 @@ func (bs20 *bootState20Base) markSuccessful(update bootStateUpdate) (bootStateUp
 	return u20, nil
 }
 
-func (bs20 *bootState20Base) setNext(next snap.PlaceInfo) (rbi RebootInfo, u bootStateUpdate, err error) {
-	u20, nextStatus, err := genericSetNext(bs20, next)
+func (bs20 *bootState20Base) setNext(isUndo bool, next snap.PlaceInfo) (rbi RebootInfo, u bootStateUpdate, err error) {
+	u20, rebootRequired, err := genericSetNext(bs20, next)
 	if err != nil {
 		return RebootInfo{RebootRequired: false}, nil, err
 	}
 
-	// if we are setting a snap as a try snap, then we need to reboot
-	rbi.RebootRequired = false
-	if nextStatus == TryStatus {
-		// only update the try base if we are actually in try status
-		u20.writeModeenv.TryBase = next.Filename()
-		// a 'try' base is handled by snap-bootstrap, hence we are not
-		// interested in the bootloader's opinion (no need for
-		// rbi.RebootBootloader, so it is not filled).
-		rbi.RebootRequired = true
+	nextStatus := DefaultStatus
+	rbi.RebootRequired = rebootRequired
+	if rbi.RebootRequired {
+		if isUndo {
+			// we must make sure we boot with the base we revert to
+			u20.writeModeenv.Base = next.Filename()
+			u20.writeModeenv.TryBase = ""
+		} else {
+			// if we need to reboot and we are not undoing, we set the try status
+			// and set appropriately the base we want to try
+			nextStatus = TryStatus
+			u20.writeModeenv.TryBase = next.Filename()
+			// a 'try' base is handled by snap-bootstrap, hence we are not
+			// interested in the bootloader's opinion (no need for
+			// rbi.RebootBootloader, so it is not filled).
+		}
 	}
 
 	// always update the base status
@@ -530,16 +558,16 @@ type bootState20 interface {
 // genericSetNext implements the generic logic for setting up a snap to be tried
 // for boot and works for both kernel and base snaps (though not
 // simultaneously).
-func genericSetNext(b bootState20, next snap.PlaceInfo) (u20 *bootStateUpdate20, setStatus string, err error) {
+func genericSetNext(b bootState20, next snap.PlaceInfo) (u20 *bootStateUpdate20, rebootRequired bool, err error) {
 	u20, err = newBootStateUpdate20(nil)
 	if err != nil {
-		return nil, "", err
+		return nil, false, err
 	}
 
 	// get the current snap
 	current, _, _, err := b.revisionsFromModeenv(u20.modeenv)
 	if err != nil {
-		return nil, "", err
+		return nil, false, err
 	}
 
 	// check if the next snap is really the same as the current snap, in which
@@ -547,12 +575,11 @@ func genericSetNext(b bootState20, next snap.PlaceInfo) (u20 *bootStateUpdate20,
 	if current.SnapName() == next.SnapName() && next.SnapRevision() == current.SnapRevision() {
 		// if we are setting the next snap as the current snap, don't need to
 		// change any snaps, just reset the status to default
-		return u20, DefaultStatus, nil
+		return u20, false, nil
 	}
 
-	// by default we will set the status as "try" to prepare for an update,
-	// which also by default will require a reboot
-	return u20, TryStatus, nil
+	// next != current so we need to reboot
+	return u20, true, nil
 }
 
 func toBootStateUpdate20(update bootStateUpdate) (u20 *bootStateUpdate20, err error) {

--- a/boot/bootstate20_bloader_kernel_state.go
+++ b/boot/bootstate20_bloader_kernel_state.go
@@ -177,6 +177,26 @@ func (bks *extractedRunKernelImageBootloaderKernelState) setNextKernel(sn snap.P
 	return nil
 }
 
+func (bks *extractedRunKernelImageBootloaderKernelState) setKernel(sn snap.PlaceInfo) error {
+	if sn.Filename() != bks.currentKernel.Filename() {
+		err := bks.ebl.EnableKernel(sn)
+		if err != nil {
+			return err
+		}
+	}
+
+	if bks.currentKernelStatus != "" {
+		m := map[string]string{
+			"kernel_status": "",
+		}
+
+		// set the boot variables
+		return bks.ebl.SetBootVars(m)
+	}
+
+	return nil
+}
+
 // envRefExtractedKernelBootloaderKernelState implements bootloaderKernelState20 for
 // bootloaders that only support using bootloader env and i.e. don't support
 // ExtractedRunKernelImageBootloader
@@ -286,6 +306,17 @@ func (envbks *envRefExtractedKernelBootloaderKernelState) markSuccessfulKernel(s
 func (envbks *envRefExtractedKernelBootloaderKernelState) setNextKernel(sn snap.PlaceInfo, status string) error {
 	envbks.toCommit["kernel_status"] = status
 	bootenvChanged := envbks.commonStateCommitUpdate(sn, "snap_try_kernel")
+
+	if bootenvChanged {
+		return envbks.bl.SetBootVars(envbks.toCommit)
+	}
+
+	return nil
+}
+
+func (envbks *envRefExtractedKernelBootloaderKernelState) setKernel(sn snap.PlaceInfo) error {
+	envbks.toCommit["kernel_status"] = ""
+	bootenvChanged := envbks.commonStateCommitUpdate(sn, "snap_kernel")
 
 	if bootenvChanged {
 		return envbks.bl.SetBootVars(envbks.toCommit)

--- a/boot/bootstate20_bloader_kernel_state.go
+++ b/boot/bootstate20_bloader_kernel_state.go
@@ -177,7 +177,7 @@ func (bks *extractedRunKernelImageBootloaderKernelState) setNextKernel(sn snap.P
 	return nil
 }
 
-func (bks *extractedRunKernelImageBootloaderKernelState) setKernel(sn snap.PlaceInfo) error {
+func (bks *extractedRunKernelImageBootloaderKernelState) setNextKernelNoTry(sn snap.PlaceInfo) error {
 	if sn.Filename() != bks.currentKernel.Filename() {
 		err := bks.ebl.EnableKernel(sn)
 		if err != nil {
@@ -314,7 +314,7 @@ func (envbks *envRefExtractedKernelBootloaderKernelState) setNextKernel(sn snap.
 	return nil
 }
 
-func (envbks *envRefExtractedKernelBootloaderKernelState) setKernel(sn snap.PlaceInfo) error {
+func (envbks *envRefExtractedKernelBootloaderKernelState) setNextKernelNoTry(sn snap.PlaceInfo) error {
 	envbks.toCommit["kernel_status"] = ""
 	bootenvChanged := envbks.commonStateCommitUpdate(sn, "snap_kernel")
 

--- a/boot/bootstate20_bloader_kernel_state.go
+++ b/boot/bootstate20_bloader_kernel_state.go
@@ -187,7 +187,7 @@ func (bks *extractedRunKernelImageBootloaderKernelState) setNextKernelNoTry(sn s
 
 	if bks.currentKernelStatus != "" {
 		m := map[string]string{
-			"kernel_status": "",
+			"kernel_status": DefaultStatus,
 		}
 
 		// set the boot variables

--- a/boot/bootstate20_bloader_kernel_state.go
+++ b/boot/bootstate20_bloader_kernel_state.go
@@ -185,7 +185,7 @@ func (bks *extractedRunKernelImageBootloaderKernelState) setNextKernelNoTry(sn s
 		}
 	}
 
-	if bks.currentKernelStatus != "" {
+	if bks.currentKernelStatus != DefaultStatus {
 		m := map[string]string{
 			"kernel_status": DefaultStatus,
 		}

--- a/boot/kernel_os.go
+++ b/boot/kernel_os.go
@@ -36,10 +36,10 @@ var _ BootParticipant = (*coreBootParticipant)(nil)
 
 func (*coreBootParticipant) IsTrivial() bool { return false }
 
-func (bp *coreBootParticipant) SetNextBoot() (rebootInfo RebootInfo, err error) {
+func (bp *coreBootParticipant) SetNextBoot(isUndo bool) (rebootInfo RebootInfo, err error) {
 	const errPrefix = "cannot set next boot: %s"
 
-	rebootInfo, u, err := bp.bs.setNext(bp.s)
+	rebootInfo, u, err := bp.bs.setNext(isUndo, bp.s)
 	if err != nil {
 		return RebootInfo{RebootRequired: false}, fmt.Errorf(errPrefix, err)
 	}

--- a/boot/kernel_os.go
+++ b/boot/kernel_os.go
@@ -36,10 +36,10 @@ var _ BootParticipant = (*coreBootParticipant)(nil)
 
 func (*coreBootParticipant) IsTrivial() bool { return false }
 
-func (bp *coreBootParticipant) SetNextBoot(isUndo bool) (rebootInfo RebootInfo, err error) {
+func (bp *coreBootParticipant) SetNextBoot(bootCtx NextBootContext) (rebootInfo RebootInfo, err error) {
 	const errPrefix = "cannot set next boot: %s"
 
-	rebootInfo, u, err := bp.bs.setNext(isUndo, bp.s)
+	rebootInfo, u, err := bp.bs.setNext(bp.s, bootCtx)
 	if err != nil {
 		return RebootInfo{RebootRequired: false}, fmt.Errorf(errPrefix, err)
 	}

--- a/boot/kernel_os_test.go
+++ b/boot/kernel_os_test.go
@@ -61,11 +61,11 @@ func (s *bootenvSuite) TestSetNextBootError(c *C) {
 	coreDev := boottest.MockDevice("some-snap")
 
 	s.bootloader.GetErr = errors.New("zap")
-	_, err := boot.NewCoreBootParticipant(&snap.Info{}, snap.TypeKernel, coreDev).SetNextBoot()
+	_, err := boot.NewCoreBootParticipant(&snap.Info{}, snap.TypeKernel, coreDev).SetNextBoot(false)
 	c.Check(err, ErrorMatches, `cannot set next boot: zap`)
 
 	bootloader.ForceError(errors.New("brkn"))
-	_, err = boot.NewCoreBootParticipant(&snap.Info{}, snap.TypeKernel, coreDev).SetNextBoot()
+	_, err = boot.NewCoreBootParticipant(&snap.Info{}, snap.TypeKernel, coreDev).SetNextBoot(false)
 	c.Check(err, ErrorMatches, `cannot set next boot: brkn`)
 }
 
@@ -78,7 +78,7 @@ func (s *bootenvSuite) TestSetNextBootForCore(c *C) {
 	info.Revision = snap.R(100)
 
 	bs := boot.NewCoreBootParticipant(info, info.Type(), coreDev)
-	rebootInfo, err := bs.SetNextBoot()
+	rebootInfo, err := bs.SetNextBoot(false)
 	c.Assert(err, IsNil)
 
 	v, err := s.bootloader.GetBootVars("snap_try_core", "snap_mode")
@@ -100,7 +100,7 @@ func (s *bootenvSuite) TestSetNextBootWithBaseForCore(c *C) {
 	info.Revision = snap.R(1818)
 
 	bs := boot.NewCoreBootParticipant(info, info.Type(), coreDev)
-	rebootInfo, err := bs.SetNextBoot()
+	rebootInfo, err := bs.SetNextBoot(false)
 	c.Assert(err, IsNil)
 
 	v, err := s.bootloader.GetBootVars("snap_try_core", "snap_mode")
@@ -122,7 +122,7 @@ func (s *bootenvSuite) TestSetNextBootForKernel(c *C) {
 	info.Revision = snap.R(42)
 
 	bp := boot.NewCoreBootParticipant(info, snap.TypeKernel, coreDev)
-	rebootInfo, err := bp.SetNextBoot()
+	rebootInfo, err := bp.SetNextBoot(false)
 	c.Assert(err, IsNil)
 
 	v, err := s.bootloader.GetBootVars("snap_try_kernel", "snap_mode")
@@ -142,7 +142,7 @@ func (s *bootenvSuite) TestSetNextBootForKernel(c *C) {
 	bootVars = map[string]string{"snap_kernel": "krnl_42.snap"}
 	s.bootloader.SetBootVars(bootVars)
 
-	rebootInfo, err = bp.SetNextBoot()
+	rebootInfo, err = bp.SetNextBoot(false)
 	c.Assert(err, IsNil)
 	c.Check(rebootInfo, Equals, boot.RebootInfo{RebootRequired: false})
 }
@@ -160,7 +160,7 @@ func (s *bootenv20Suite) TestSetNextBoot20ForKernel(c *C) {
 
 	bs := boot.NewCoreBootParticipant(s.kern2, snap.TypeKernel, coreDev)
 	c.Assert(bs.IsTrivial(), Equals, false)
-	rebootInfo, err := bs.SetNextBoot()
+	rebootInfo, err := bs.SetNextBoot(false)
 	c.Assert(err, IsNil)
 
 	// check that kernel_status is now try
@@ -203,7 +203,7 @@ func (s *bootenv20EnvRefKernelSuite) TestSetNextBoot20ForKernel(c *C) {
 
 	bs := boot.NewCoreBootParticipant(s.kern2, snap.TypeKernel, coreDev)
 	c.Assert(bs.IsTrivial(), Equals, false)
-	rebootInfo, err := bs.SetNextBoot()
+	rebootInfo, err := bs.SetNextBoot(false)
 	c.Assert(err, IsNil)
 
 	m := s.bootloader.BootVars
@@ -232,7 +232,7 @@ func (s *bootenvSuite) TestSetNextBootForKernelForTheSameKernel(c *C) {
 	bootVars := map[string]string{"snap_kernel": "krnl_40.snap"}
 	s.bootloader.SetBootVars(bootVars)
 
-	rebootInfo, err := boot.NewCoreBootParticipant(info, snap.TypeKernel, coreDev).SetNextBoot()
+	rebootInfo, err := boot.NewCoreBootParticipant(info, snap.TypeKernel, coreDev).SetNextBoot(false)
 	c.Assert(err, IsNil)
 
 	v, err := s.bootloader.GetBootVars("snap_kernel")
@@ -257,7 +257,7 @@ func (s *bootenv20Suite) TestSetNextBoot20ForKernelForTheSameKernel(c *C) {
 
 	bs := boot.NewCoreBootParticipant(s.kern1, snap.TypeKernel, coreDev)
 	c.Assert(bs.IsTrivial(), Equals, false)
-	rebootInfo, err := bs.SetNextBoot()
+	rebootInfo, err := bs.SetNextBoot(false)
 	c.Assert(err, IsNil)
 
 	// check that kernel_status is cleared
@@ -300,7 +300,7 @@ func (s *bootenv20EnvRefKernelSuite) TestSetNextBoot20ForKernelForTheSameKernel(
 
 	bs := boot.NewCoreBootParticipant(s.kern1, snap.TypeKernel, coreDev)
 	c.Assert(bs.IsTrivial(), Equals, false)
-	rebootInfo, err := bs.SetNextBoot()
+	rebootInfo, err := bs.SetNextBoot(false)
 	c.Assert(err, IsNil)
 
 	// check that kernel_status is cleared
@@ -333,7 +333,7 @@ func (s *bootenvSuite) TestSetNextBootForKernelForTheSameKernelTryMode(c *C) {
 		"snap_mode":       boot.TryStatus}
 	s.bootloader.SetBootVars(bootVars)
 
-	rebootInfo, err := boot.NewCoreBootParticipant(info, snap.TypeKernel, coreDev).SetNextBoot()
+	rebootInfo, err := boot.NewCoreBootParticipant(info, snap.TypeKernel, coreDev).SetNextBoot(false)
 	c.Assert(err, IsNil)
 
 	v, err := s.bootloader.GetBootVars("snap_kernel", "snap_try_kernel", "snap_mode")
@@ -371,7 +371,7 @@ func (s *bootenv20Suite) TestSetNextBoot20ForKernelForTheSameKernelTryMode(c *C)
 
 	bs := boot.NewCoreBootParticipant(s.kern1, snap.TypeKernel, coreDev)
 	c.Assert(bs.IsTrivial(), Equals, false)
-	rebootInfo, err := bs.SetNextBoot()
+	rebootInfo, err := bs.SetNextBoot(false)
 	c.Assert(err, IsNil)
 
 	// check that kernel_status is cleared
@@ -425,7 +425,7 @@ func (s *bootenv20EnvRefKernelSuite) TestSetNextBoot20ForKernelForTheSameKernelT
 
 	bs := boot.NewCoreBootParticipant(s.kern1, snap.TypeKernel, coreDev)
 	c.Assert(bs.IsTrivial(), Equals, false)
-	rebootInfo, err := bs.SetNextBoot()
+	rebootInfo, err := bs.SetNextBoot(false)
 	c.Assert(err, IsNil)
 
 	// check that kernel_status is cleared
@@ -705,7 +705,7 @@ func (s *bootenv20RebootBootloaderSuite) TestSetNextBoot20ForKernel(c *C) {
 
 	bs := boot.NewCoreBootParticipant(s.kern2, snap.TypeKernel, coreDev)
 	c.Assert(bs.IsTrivial(), Equals, false)
-	rebootInfo, err := bs.SetNextBoot()
+	rebootInfo, err := bs.SetNextBoot(false)
 	c.Assert(err, IsNil)
 
 	m := s.bootloader.BootVars

--- a/boot/kernel_os_test.go
+++ b/boot/kernel_os_test.go
@@ -61,11 +61,11 @@ func (s *bootenvSuite) TestSetNextBootError(c *C) {
 	coreDev := boottest.MockDevice("some-snap")
 
 	s.bootloader.GetErr = errors.New("zap")
-	_, err := boot.NewCoreBootParticipant(&snap.Info{}, snap.TypeKernel, coreDev).SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
+	_, err := boot.NewCoreBootParticipant(&snap.Info{}, snap.TypeKernel, coreDev).SetNextBoot(boot.NextBootContext{BootWithoutTry: false})
 	c.Check(err, ErrorMatches, `cannot set next boot: zap`)
 
 	bootloader.ForceError(errors.New("brkn"))
-	_, err = boot.NewCoreBootParticipant(&snap.Info{}, snap.TypeKernel, coreDev).SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
+	_, err = boot.NewCoreBootParticipant(&snap.Info{}, snap.TypeKernel, coreDev).SetNextBoot(boot.NextBootContext{BootWithoutTry: false})
 	c.Check(err, ErrorMatches, `cannot set next boot: brkn`)
 }
 
@@ -78,7 +78,7 @@ func (s *bootenvSuite) TestSetNextBootForCore(c *C) {
 	info.Revision = snap.R(100)
 
 	bs := boot.NewCoreBootParticipant(info, info.Type(), coreDev)
-	rebootInfo, err := bs.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
+	rebootInfo, err := bs.SetNextBoot(boot.NextBootContext{BootWithoutTry: false})
 	c.Assert(err, IsNil)
 
 	v, err := s.bootloader.GetBootVars("snap_try_core", "snap_mode")
@@ -100,7 +100,7 @@ func (s *bootenvSuite) TestSetNextBootWithBaseForCore(c *C) {
 	info.Revision = snap.R(1818)
 
 	bs := boot.NewCoreBootParticipant(info, info.Type(), coreDev)
-	rebootInfo, err := bs.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
+	rebootInfo, err := bs.SetNextBoot(boot.NextBootContext{BootWithoutTry: false})
 	c.Assert(err, IsNil)
 
 	v, err := s.bootloader.GetBootVars("snap_try_core", "snap_mode")
@@ -122,7 +122,7 @@ func (s *bootenvSuite) TestSetNextBootForKernel(c *C) {
 	info.Revision = snap.R(42)
 
 	bp := boot.NewCoreBootParticipant(info, snap.TypeKernel, coreDev)
-	rebootInfo, err := bp.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
+	rebootInfo, err := bp.SetNextBoot(boot.NextBootContext{BootWithoutTry: false})
 	c.Assert(err, IsNil)
 
 	v, err := s.bootloader.GetBootVars("snap_try_kernel", "snap_mode")
@@ -142,7 +142,7 @@ func (s *bootenvSuite) TestSetNextBootForKernel(c *C) {
 	bootVars = map[string]string{"snap_kernel": "krnl_42.snap"}
 	s.bootloader.SetBootVars(bootVars)
 
-	rebootInfo, err = bp.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
+	rebootInfo, err = bp.SetNextBoot(boot.NextBootContext{BootWithoutTry: false})
 	c.Assert(err, IsNil)
 	c.Check(rebootInfo, Equals, boot.RebootInfo{RebootRequired: false})
 }
@@ -160,7 +160,7 @@ func (s *bootenv20Suite) TestSetNextBoot20ForKernel(c *C) {
 
 	bs := boot.NewCoreBootParticipant(s.kern2, snap.TypeKernel, coreDev)
 	c.Assert(bs.IsTrivial(), Equals, false)
-	rebootInfo, err := bs.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
+	rebootInfo, err := bs.SetNextBoot(boot.NextBootContext{BootWithoutTry: false})
 	c.Assert(err, IsNil)
 
 	// check that kernel_status is now try
@@ -203,7 +203,7 @@ func (s *bootenv20EnvRefKernelSuite) TestSetNextBoot20ForKernel(c *C) {
 
 	bs := boot.NewCoreBootParticipant(s.kern2, snap.TypeKernel, coreDev)
 	c.Assert(bs.IsTrivial(), Equals, false)
-	rebootInfo, err := bs.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
+	rebootInfo, err := bs.SetNextBoot(boot.NextBootContext{BootWithoutTry: false})
 	c.Assert(err, IsNil)
 
 	m := s.bootloader.BootVars
@@ -232,7 +232,7 @@ func (s *bootenvSuite) TestSetNextBootForKernelForTheSameKernel(c *C) {
 	bootVars := map[string]string{"snap_kernel": "krnl_40.snap"}
 	s.bootloader.SetBootVars(bootVars)
 
-	rebootInfo, err := boot.NewCoreBootParticipant(info, snap.TypeKernel, coreDev).SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
+	rebootInfo, err := boot.NewCoreBootParticipant(info, snap.TypeKernel, coreDev).SetNextBoot(boot.NextBootContext{BootWithoutTry: false})
 	c.Assert(err, IsNil)
 
 	v, err := s.bootloader.GetBootVars("snap_kernel")
@@ -257,7 +257,7 @@ func (s *bootenv20Suite) TestSetNextBoot20ForKernelForTheSameKernel(c *C) {
 
 	bs := boot.NewCoreBootParticipant(s.kern1, snap.TypeKernel, coreDev)
 	c.Assert(bs.IsTrivial(), Equals, false)
-	rebootInfo, err := bs.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
+	rebootInfo, err := bs.SetNextBoot(boot.NextBootContext{BootWithoutTry: false})
 	c.Assert(err, IsNil)
 
 	// check that kernel_status is cleared
@@ -300,7 +300,7 @@ func (s *bootenv20EnvRefKernelSuite) TestSetNextBoot20ForKernelForTheSameKernel(
 
 	bs := boot.NewCoreBootParticipant(s.kern1, snap.TypeKernel, coreDev)
 	c.Assert(bs.IsTrivial(), Equals, false)
-	rebootInfo, err := bs.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
+	rebootInfo, err := bs.SetNextBoot(boot.NextBootContext{BootWithoutTry: false})
 	c.Assert(err, IsNil)
 
 	// check that kernel_status is cleared
@@ -333,7 +333,7 @@ func (s *bootenvSuite) TestSetNextBootForKernelForTheSameKernelTryMode(c *C) {
 		"snap_mode":       boot.TryStatus}
 	s.bootloader.SetBootVars(bootVars)
 
-	rebootInfo, err := boot.NewCoreBootParticipant(info, snap.TypeKernel, coreDev).SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
+	rebootInfo, err := boot.NewCoreBootParticipant(info, snap.TypeKernel, coreDev).SetNextBoot(boot.NextBootContext{BootWithoutTry: false})
 	c.Assert(err, IsNil)
 
 	v, err := s.bootloader.GetBootVars("snap_kernel", "snap_try_kernel", "snap_mode")
@@ -371,7 +371,7 @@ func (s *bootenv20Suite) TestSetNextBoot20ForKernelForTheSameKernelTryMode(c *C)
 
 	bs := boot.NewCoreBootParticipant(s.kern1, snap.TypeKernel, coreDev)
 	c.Assert(bs.IsTrivial(), Equals, false)
-	rebootInfo, err := bs.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
+	rebootInfo, err := bs.SetNextBoot(boot.NextBootContext{BootWithoutTry: false})
 	c.Assert(err, IsNil)
 
 	// check that kernel_status is cleared
@@ -425,7 +425,7 @@ func (s *bootenv20EnvRefKernelSuite) TestSetNextBoot20ForKernelForTheSameKernelT
 
 	bs := boot.NewCoreBootParticipant(s.kern1, snap.TypeKernel, coreDev)
 	c.Assert(bs.IsTrivial(), Equals, false)
-	rebootInfo, err := bs.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
+	rebootInfo, err := bs.SetNextBoot(boot.NextBootContext{BootWithoutTry: false})
 	c.Assert(err, IsNil)
 
 	// check that kernel_status is cleared
@@ -705,7 +705,7 @@ func (s *bootenv20RebootBootloaderSuite) TestSetNextBoot20ForKernel(c *C) {
 
 	bs := boot.NewCoreBootParticipant(s.kern2, snap.TypeKernel, coreDev)
 	c.Assert(bs.IsTrivial(), Equals, false)
-	rebootInfo, err := bs.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
+	rebootInfo, err := bs.SetNextBoot(boot.NextBootContext{BootWithoutTry: false})
 	c.Assert(err, IsNil)
 
 	m := s.bootloader.BootVars
@@ -734,7 +734,7 @@ func (s *bootenvSuite) TestSetNextBootForCoreUndo(c *C) {
 	info.Revision = snap.R(100)
 
 	bs := boot.NewCoreBootParticipant(info, info.Type(), coreDev)
-	rebootInfo, err := bs.SetNextBoot(boot.NextBootContext{IsUndoingInstall: true})
+	rebootInfo, err := bs.SetNextBoot(boot.NextBootContext{BootWithoutTry: true})
 	c.Assert(err, IsNil)
 
 	v, err := s.bootloader.GetBootVars("snap_core", "snap_try_core", "snap_mode")
@@ -757,7 +757,7 @@ func (s *bootenvSuite) TestSetNextBootWithBaseForCoreUndo(c *C) {
 	info.Revision = snap.R(1818)
 
 	bs := boot.NewCoreBootParticipant(info, info.Type(), coreDev)
-	rebootInfo, err := bs.SetNextBoot(boot.NextBootContext{IsUndoingInstall: true})
+	rebootInfo, err := bs.SetNextBoot(boot.NextBootContext{BootWithoutTry: true})
 	c.Assert(err, IsNil)
 
 	v, err := s.bootloader.GetBootVars("snap_core", "snap_try_core", "snap_mode")
@@ -780,7 +780,7 @@ func (s *bootenvSuite) TestSetNextBootForKernelUndo(c *C) {
 	info.Revision = snap.R(42)
 
 	bp := boot.NewCoreBootParticipant(info, snap.TypeKernel, coreDev)
-	rebootInfo, err := bp.SetNextBoot(boot.NextBootContext{IsUndoingInstall: true})
+	rebootInfo, err := bp.SetNextBoot(boot.NextBootContext{BootWithoutTry: true})
 	c.Assert(err, IsNil)
 
 	v, err := s.bootloader.GetBootVars("snap_kernel", "snap_try_kernel", "snap_mode")

--- a/boot/kernel_os_test.go
+++ b/boot/kernel_os_test.go
@@ -61,11 +61,11 @@ func (s *bootenvSuite) TestSetNextBootError(c *C) {
 	coreDev := boottest.MockDevice("some-snap")
 
 	s.bootloader.GetErr = errors.New("zap")
-	_, err := boot.NewCoreBootParticipant(&snap.Info{}, snap.TypeKernel, coreDev).SetNextBoot(false)
+	_, err := boot.NewCoreBootParticipant(&snap.Info{}, snap.TypeKernel, coreDev).SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
 	c.Check(err, ErrorMatches, `cannot set next boot: zap`)
 
 	bootloader.ForceError(errors.New("brkn"))
-	_, err = boot.NewCoreBootParticipant(&snap.Info{}, snap.TypeKernel, coreDev).SetNextBoot(false)
+	_, err = boot.NewCoreBootParticipant(&snap.Info{}, snap.TypeKernel, coreDev).SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
 	c.Check(err, ErrorMatches, `cannot set next boot: brkn`)
 }
 
@@ -78,7 +78,7 @@ func (s *bootenvSuite) TestSetNextBootForCore(c *C) {
 	info.Revision = snap.R(100)
 
 	bs := boot.NewCoreBootParticipant(info, info.Type(), coreDev)
-	rebootInfo, err := bs.SetNextBoot(false)
+	rebootInfo, err := bs.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
 	c.Assert(err, IsNil)
 
 	v, err := s.bootloader.GetBootVars("snap_try_core", "snap_mode")
@@ -100,7 +100,7 @@ func (s *bootenvSuite) TestSetNextBootWithBaseForCore(c *C) {
 	info.Revision = snap.R(1818)
 
 	bs := boot.NewCoreBootParticipant(info, info.Type(), coreDev)
-	rebootInfo, err := bs.SetNextBoot(false)
+	rebootInfo, err := bs.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
 	c.Assert(err, IsNil)
 
 	v, err := s.bootloader.GetBootVars("snap_try_core", "snap_mode")
@@ -122,7 +122,7 @@ func (s *bootenvSuite) TestSetNextBootForKernel(c *C) {
 	info.Revision = snap.R(42)
 
 	bp := boot.NewCoreBootParticipant(info, snap.TypeKernel, coreDev)
-	rebootInfo, err := bp.SetNextBoot(false)
+	rebootInfo, err := bp.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
 	c.Assert(err, IsNil)
 
 	v, err := s.bootloader.GetBootVars("snap_try_kernel", "snap_mode")
@@ -142,7 +142,7 @@ func (s *bootenvSuite) TestSetNextBootForKernel(c *C) {
 	bootVars = map[string]string{"snap_kernel": "krnl_42.snap"}
 	s.bootloader.SetBootVars(bootVars)
 
-	rebootInfo, err = bp.SetNextBoot(false)
+	rebootInfo, err = bp.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
 	c.Assert(err, IsNil)
 	c.Check(rebootInfo, Equals, boot.RebootInfo{RebootRequired: false})
 }
@@ -160,7 +160,7 @@ func (s *bootenv20Suite) TestSetNextBoot20ForKernel(c *C) {
 
 	bs := boot.NewCoreBootParticipant(s.kern2, snap.TypeKernel, coreDev)
 	c.Assert(bs.IsTrivial(), Equals, false)
-	rebootInfo, err := bs.SetNextBoot(false)
+	rebootInfo, err := bs.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
 	c.Assert(err, IsNil)
 
 	// check that kernel_status is now try
@@ -203,7 +203,7 @@ func (s *bootenv20EnvRefKernelSuite) TestSetNextBoot20ForKernel(c *C) {
 
 	bs := boot.NewCoreBootParticipant(s.kern2, snap.TypeKernel, coreDev)
 	c.Assert(bs.IsTrivial(), Equals, false)
-	rebootInfo, err := bs.SetNextBoot(false)
+	rebootInfo, err := bs.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
 	c.Assert(err, IsNil)
 
 	m := s.bootloader.BootVars
@@ -232,7 +232,7 @@ func (s *bootenvSuite) TestSetNextBootForKernelForTheSameKernel(c *C) {
 	bootVars := map[string]string{"snap_kernel": "krnl_40.snap"}
 	s.bootloader.SetBootVars(bootVars)
 
-	rebootInfo, err := boot.NewCoreBootParticipant(info, snap.TypeKernel, coreDev).SetNextBoot(false)
+	rebootInfo, err := boot.NewCoreBootParticipant(info, snap.TypeKernel, coreDev).SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
 	c.Assert(err, IsNil)
 
 	v, err := s.bootloader.GetBootVars("snap_kernel")
@@ -257,7 +257,7 @@ func (s *bootenv20Suite) TestSetNextBoot20ForKernelForTheSameKernel(c *C) {
 
 	bs := boot.NewCoreBootParticipant(s.kern1, snap.TypeKernel, coreDev)
 	c.Assert(bs.IsTrivial(), Equals, false)
-	rebootInfo, err := bs.SetNextBoot(false)
+	rebootInfo, err := bs.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
 	c.Assert(err, IsNil)
 
 	// check that kernel_status is cleared
@@ -300,7 +300,7 @@ func (s *bootenv20EnvRefKernelSuite) TestSetNextBoot20ForKernelForTheSameKernel(
 
 	bs := boot.NewCoreBootParticipant(s.kern1, snap.TypeKernel, coreDev)
 	c.Assert(bs.IsTrivial(), Equals, false)
-	rebootInfo, err := bs.SetNextBoot(false)
+	rebootInfo, err := bs.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
 	c.Assert(err, IsNil)
 
 	// check that kernel_status is cleared
@@ -333,7 +333,7 @@ func (s *bootenvSuite) TestSetNextBootForKernelForTheSameKernelTryMode(c *C) {
 		"snap_mode":       boot.TryStatus}
 	s.bootloader.SetBootVars(bootVars)
 
-	rebootInfo, err := boot.NewCoreBootParticipant(info, snap.TypeKernel, coreDev).SetNextBoot(false)
+	rebootInfo, err := boot.NewCoreBootParticipant(info, snap.TypeKernel, coreDev).SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
 	c.Assert(err, IsNil)
 
 	v, err := s.bootloader.GetBootVars("snap_kernel", "snap_try_kernel", "snap_mode")
@@ -371,7 +371,7 @@ func (s *bootenv20Suite) TestSetNextBoot20ForKernelForTheSameKernelTryMode(c *C)
 
 	bs := boot.NewCoreBootParticipant(s.kern1, snap.TypeKernel, coreDev)
 	c.Assert(bs.IsTrivial(), Equals, false)
-	rebootInfo, err := bs.SetNextBoot(false)
+	rebootInfo, err := bs.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
 	c.Assert(err, IsNil)
 
 	// check that kernel_status is cleared
@@ -425,7 +425,7 @@ func (s *bootenv20EnvRefKernelSuite) TestSetNextBoot20ForKernelForTheSameKernelT
 
 	bs := boot.NewCoreBootParticipant(s.kern1, snap.TypeKernel, coreDev)
 	c.Assert(bs.IsTrivial(), Equals, false)
-	rebootInfo, err := bs.SetNextBoot(false)
+	rebootInfo, err := bs.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
 	c.Assert(err, IsNil)
 
 	// check that kernel_status is cleared
@@ -705,7 +705,7 @@ func (s *bootenv20RebootBootloaderSuite) TestSetNextBoot20ForKernel(c *C) {
 
 	bs := boot.NewCoreBootParticipant(s.kern2, snap.TypeKernel, coreDev)
 	c.Assert(bs.IsTrivial(), Equals, false)
-	rebootInfo, err := bs.SetNextBoot(false)
+	rebootInfo, err := bs.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
 	c.Assert(err, IsNil)
 
 	m := s.bootloader.BootVars

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -2632,22 +2632,22 @@ type: kernel`
 	c.Check(bloader.BootVars, DeepEquals, map[string]string{
 		"snap_core":       "core18_2.snap",
 		"snap_try_core":   "",
-		"snap_try_kernel": "pc-kernel_123.snap",
-		"snap_kernel":     "pc-kernel_x1.snap",
-		"snap_mode":       boot.TryStatus,
+		"snap_try_kernel": "",
+		"snap_kernel":     "pc-kernel_123.snap",
+		"snap_mode":       boot.DefaultStatus,
 	})
 	restarting, _ = restart.Pending(st)
 	c.Check(restarting, Equals, true)
 
 	// pretend we restarted back to the old kernel
-	s.mockSuccessfulReboot(c, bloader, []snap.Type{snap.TypeKernel})
+	s.mockSuccessfulReboot(c, bloader, nil)
 
 	st.Unlock()
 	err = s.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
-	// and we undo the bootvars and trigger a reboot
+	// bootvars should not have changed
 	c.Check(bloader.BootVars, DeepEquals, map[string]string{
 		"snap_core":       "core18_2.snap",
 		"snap_try_core":   "",
@@ -5380,11 +5380,11 @@ version: 20.04`
 
 	// and the undo gave us our old kernel back
 	c.Assert(bloader.BootVars, DeepEquals, map[string]string{
-		"snap_core":       "core20_2.snap",
-		"snap_try_core":   "core18_1.snap",
+		"snap_core":       "core18_1.snap",
+		"snap_try_core":   "",
 		"snap_kernel":     "pc-kernel_1.snap",
 		"snap_try_kernel": "",
-		"snap_mode":       boot.TryStatus,
+		"snap_mode":       boot.DefaultStatus,
 	})
 }
 
@@ -6018,9 +6018,9 @@ func (ms *kernelSuite) TestRemodelSwitchToDifferentKernelUndo(c *C) {
 	c.Assert(ms.bloader.BootVars, DeepEquals, map[string]string{
 		"snap_core":       "core_1.snap",
 		"snap_try_core":   "",
-		"snap_try_kernel": "pc-kernel_1.snap",
-		"snap_kernel":     "brand-kernel_2.snap",
-		"snap_mode":       boot.TryStatus,
+		"snap_try_kernel": "",
+		"snap_kernel":     "pc-kernel_1.snap",
+		"snap_mode":       boot.DefaultStatus,
 	})
 }
 

--- a/overlord/snapstate/backend/link.go
+++ b/overlord/snapstate/backend/link.go
@@ -44,6 +44,10 @@ type LinkContext struct {
 	// installed
 	FirstInstall bool
 
+	// IsUndo is set when we are installing the previous snap while
+	// performing a revert of the latest one that was installed
+	IsUndo bool
+
 	// ServiceOptions is used to configure services.
 	ServiceOptions *wrappers.SnapServiceOptions
 
@@ -139,7 +143,8 @@ func (b Backend) LinkSnap(info *snap.Info, dev snap.Device, linkCtx LinkContext,
 
 	var rebootInfo boot.RebootInfo
 	if !b.preseed {
-		rebootInfo, err = boot.Participant(info, info.Type(), dev).SetNextBoot()
+		rebootInfo, err = boot.Participant(
+			info, info.Type(), dev).SetNextBoot(linkCtx.IsUndo)
 		if err != nil {
 			return boot.RebootInfo{}, err
 		}

--- a/overlord/snapstate/backend/link.go
+++ b/overlord/snapstate/backend/link.go
@@ -143,7 +143,7 @@ func (b Backend) LinkSnap(info *snap.Info, dev snap.Device, linkCtx LinkContext,
 
 	var rebootInfo boot.RebootInfo
 	if !b.preseed {
-		bootCtx := boot.NextBootContext{IsUndoingInstall: linkCtx.IsUndo}
+		bootCtx := boot.NextBootContext{BootWithoutTry: linkCtx.IsUndo}
 		rebootInfo, err = boot.Participant(
 			info, info.Type(), dev).SetNextBoot(bootCtx)
 		if err != nil {

--- a/overlord/snapstate/backend/link.go
+++ b/overlord/snapstate/backend/link.go
@@ -143,8 +143,9 @@ func (b Backend) LinkSnap(info *snap.Info, dev snap.Device, linkCtx LinkContext,
 
 	var rebootInfo boot.RebootInfo
 	if !b.preseed {
+		bootCtx := boot.NextBootContext{IsUndoingInstall: linkCtx.IsUndo}
 		rebootInfo, err = boot.Participant(
-			info, info.Type(), dev).SetNextBoot(linkCtx.IsUndo)
+			info, info.Type(), dev).SetNextBoot(bootCtx)
 		if err != nil {
 			return boot.RebootInfo{}, err
 		}

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1184,6 +1184,7 @@ func (m *SnapManager) undoUnlinkCurrentSnap(t *state.Task, _ *tomb.Tomb) error {
 	}
 	linkCtx := backend.LinkContext{
 		FirstInstall:   false,
+		IsUndo:         true,
 		ServiceOptions: opts,
 	}
 	reboot, err := m.backend.LinkSnap(oldInfo, deviceCtx, linkCtx, perfTimings)
@@ -2024,7 +2025,7 @@ func (m *SnapManager) maybeUndoRemodelBootChanges(t *state.Task) error {
 		return err
 	}
 	bp := boot.Participant(info, info.Type(), groundDeviceCtx)
-	rebootInfo, err := bp.SetNextBoot()
+	rebootInfo, err := bp.SetNextBoot(false)
 	if err != nil {
 		return err
 	}
@@ -2195,6 +2196,7 @@ func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	firstInstall := oldCurrent.Unset()
 	linkCtx := backend.LinkContext{
 		FirstInstall: firstInstall,
+		IsUndo:       true,
 	}
 	var backendErr error
 	if newInfo.Type() == snap.TypeSnapd && !firstInstall {
@@ -2704,6 +2706,7 @@ func (m *SnapManager) undoUnlinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	}
 	linkCtx := backend.LinkContext{
 		FirstInstall:   false,
+		IsUndo:         true,
 		ServiceOptions: opts,
 	}
 	reboot, err := m.backend.LinkSnap(info, deviceCtx, linkCtx, perfTimings)

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -2025,7 +2025,7 @@ func (m *SnapManager) maybeUndoRemodelBootChanges(t *state.Task) error {
 		return err
 	}
 	bp := boot.Participant(info, info.Type(), groundDeviceCtx)
-	rebootInfo, err := bp.SetNextBoot(false)
+	rebootInfo, err := bp.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
 	if err != nil {
 		return err
 	}

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -2025,7 +2025,7 @@ func (m *SnapManager) maybeUndoRemodelBootChanges(t *state.Task) error {
 		return err
 	}
 	bp := boot.Participant(info, info.Type(), groundDeviceCtx)
-	rebootInfo, err := bp.SetNextBoot(boot.NextBootContext{IsUndoingInstall: false})
+	rebootInfo, err := bp.SetNextBoot(boot.NextBootContext{IsUndoingInstall: true})
 	if err != nil {
 		return err
 	}

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -2025,7 +2025,7 @@ func (m *SnapManager) maybeUndoRemodelBootChanges(t *state.Task) error {
 		return err
 	}
 	bp := boot.Participant(info, info.Type(), groundDeviceCtx)
-	rebootInfo, err := bp.SetNextBoot(boot.NextBootContext{IsUndoingInstall: true})
+	rebootInfo, err := bp.SetNextBoot(boot.NextBootContext{BootWithoutTry: true})
 	if err != nil {
 		return err
 	}

--- a/overlord/snapstate/handlers_link_test.go
+++ b/overlord/snapstate/handlers_link_test.go
@@ -2012,9 +2012,9 @@ func (s *linkSnapSuite) TestMaybeUndoRemodelBootChangesNeedsUndo(c *C) {
 
 	// that will schedule a boot into the previous kernel
 	c.Assert(bloader.BootVars, DeepEquals, map[string]string{
-		"snap_mode":       boot.TryStatus,
-		"snap_kernel":     "new-kernel_1.snap",
-		"snap_try_kernel": "kernel_1.snap",
+		"snap_mode":       boot.DefaultStatus,
+		"snap_kernel":     "kernel_1.snap",
+		"snap_try_kernel": "",
 	})
 	c.Check(s.restartRequested, HasLen, 1)
 	c.Check(s.restartRequested[0], Equals, restart.RestartSystem)

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -644,10 +644,23 @@ nested_create_core_vm() {
                     "$TESTSTOOLS"/snaps-state repack_snapd_deb_into_snap core "$NESTED_ASSETS_DIR"
                     EXTRA_FUNDAMENTAL="$EXTRA_FUNDAMENTAL --snap $NESTED_ASSETS_DIR/core-from-snapd-deb.snap"
 
+                    # allow repacking the kernel
+                    if [ "$NESTED_REPACK_KERNEL_SNAP" = "true" ]; then
+                        KERNEL_SNAP=new-kernel.snap
+                        repack_kernel_snap "$KERNEL_SNAP"
+                        EXTRA_FUNDAMENTAL="$EXTRA_FUNDAMENTAL --snap $KERNEL_SNAP"
+                    fi
                 elif nested_is_core_18_system; then
                     echo "Repacking snapd snap"
                     "$TESTSTOOLS"/snaps-state repack_snapd_deb_into_snap snapd "$NESTED_ASSETS_DIR"
                     EXTRA_FUNDAMENTAL="$EXTRA_FUNDAMENTAL --snap $NESTED_ASSETS_DIR/snapd-from-deb.snap"
+
+                    # allow repacking the kernel
+                    if [ "$NESTED_REPACK_KERNEL_SNAP" = "true" ]; then
+                        KERNEL_SNAP=new-kernel.snap
+                        repack_kernel_snap "$KERNEL_SNAP"
+                        EXTRA_FUNDAMENTAL="$EXTRA_FUNDAMENTAL --snap $KERNEL_SNAP"
+                    fi
 
                     # allow tests to provide their own core18 snap
                     local CORE18_SNAP

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -437,6 +437,27 @@ EOF
     rm -rf "$UNPACK_DIR"
 }
 
+repack_kernel_snap() {
+    local TARGET=$1
+    local VERSION
+    local UNPACK_DIR
+    local CHANNEL
+
+    VERSION=$(nested_get_version)
+    if [ "$VERSION" = 16 ]; then
+        CHANNEL=latest
+    else
+        CHANNEL=$VERSION
+    fi
+
+    echo "Repacking kernel snap"
+    UNPACK_DIR=/tmp/kernel-unpack
+    snap download --basename=pc-kernel --channel="$CHANNEL/edge" pc-kernel
+    unsquashfs -no-progress -d "$UNPACK_DIR" pc-kernel.snap
+    snap pack --filename="$TARGET" "$UNPACK_DIR"
+
+    rm -rf "$UNPACK_DIR"
+}
 
 repack_snapd_snap_with_deb_content_and_run_mode_firstboot_tweaks() {
     local TARGET="$1"

--- a/tests/nested/core/base-revert-after-boot/task.yaml
+++ b/tests/nested/core/base-revert-after-boot/task.yaml
@@ -1,0 +1,69 @@
+summary: Check that a base can be reverted after it has booted
+
+details: |
+  This test checks that a base snap that has not finished installation but
+  that already booted can be reverted properly if something else fails, like a
+  post-refresh hook.
+
+# this is a UC20+ specific test
+systems: [ubuntu-20.04-64, ubuntu-22.04-64]
+
+execute: |
+  echo "Build base with failing post-refresh hook"
+  VERSION="$(tests.nested show version)"
+  base=core"$VERSION"
+  rm -rf "$base"  
+  snap download --basename="$base" "$base"
+  unsquashfs -d "$base" "$base".snap
+  HOOKS_D=$base/meta/hooks/
+  POST_REFRESH_P=$HOOKS_D/post-refresh
+  mkdir -p "$HOOKS_D"
+  # Note that actually the hook will not find bash and will fail with:
+  # ERROR run hook "post-refresh": cannot locate base snap core: No such file or directory
+  # but that is enough for the test to make sense
+  # TODO find out why
+  cat > "$POST_REFRESH_P" << EOF
+  \#!/bin/bash -ex
+  exit 1
+  EOF
+  chmod +x "$POST_REFRESH_P"
+  snap pack "$base"/ --filename="$base"_badhook.snap
+
+  echo "Wait for the system to be seeded first"
+  tests.nested exec "sudo snap wait system seed.loaded"
+
+  boot_id="$(tests.nested boot-id)"
+
+  echo "Install base with failing post-refresh hook"
+  tests.nested copy "$base"_badhook.snap
+  chg_id=$(tests.nested exec "sudo snap install --dangerous --no-wait ./${base}_badhook.snap")
+
+  echo "Wait for reboot"
+  tests.nested wait-for reboot "$boot_id"
+
+  boot_id="$(tests.nested boot-id)"
+  echo "Wait for second reboot after post-refresh hook failure"
+  tests.nested wait-for reboot "$boot_id"
+
+  boot_id="$(tests.nested boot-id)"
+  # wait for change to finish with error
+  not tests.nested exec sudo snap watch "$chg_id"
+  # make sure that no additional reboots have happened while the change finished
+  test "$boot_id" = "$(tests.nested boot-id)"
+
+  echo "Check that change finished with failure and that the old snap is being used"
+  tests.nested exec "snap info $base | MATCH 'installed:.*\(x1\)'"
+  tests.nested exec "snap changes | MATCH \"^$chg_id.*Error\""
+  modeenv_data=$(tests.nested exec 'cat /var/lib/snapd/modeenv')
+  if ! [[ "$modeenv_data" == *base=${base}_x1.snap* ]]; then
+      echo "Incorrect base in modeenv: $modeenv_data"
+      exit 1
+  fi
+  if [[ "$modeenv_data" == *try_base=* ]]; then
+      echo "try_base should not be set in modeenv: $modeenv_data"
+      exit 1
+  fi
+  if [[ "$modeenv_data" == *base_status=* ]]; then
+      echo "base_status should not be set in modeenv: $modeenv_data"
+      exit 1
+  fi

--- a/tests/nested/core/base-revert-after-boot/task.yaml
+++ b/tests/nested/core/base-revert-after-boot/task.yaml
@@ -11,6 +11,9 @@ execute: |
   echo "Build base with failing post-refresh hook"
   VERSION="$(tests.nested show version)"
   base=core"$VERSION"
+  if [ "$VERSION" -eq 16 ]; then
+      base=core
+  fi
   rm -rf "$base"  
   snap download --basename="$base" "$base"
   unsquashfs -d "$base" "$base".snap

--- a/tests/nested/core/base-revert-after-boot/task.yaml
+++ b/tests/nested/core/base-revert-after-boot/task.yaml
@@ -5,8 +5,7 @@ details: |
   that already booted can be reverted properly if something else fails, like a
   post-refresh hook.
 
-# this is a UC20+ specific test
-systems: [ubuntu-20.04-64, ubuntu-22.04-64]
+systems: [ubuntu-16.04-64, ubuntu-18.04-64, ubuntu-20.04-64, ubuntu-22.04-64]
 
 execute: |
   echo "Build base with failing post-refresh hook"
@@ -21,7 +20,9 @@ execute: |
   # Note that actually the hook will not find bash and will fail with:
   # ERROR run hook "post-refresh": cannot locate base snap core: No such file or directory
   # but that is enough for the test to make sense
-  # TODO find out why
+  # This is because support for hooks is broken atm (the base should use itself as base
+  # when running the hook), nonetheless the test result does not depend on that
+  # and should have the same behavior when this gets fixed.
   cat > "$POST_REFRESH_P" << EOF
   \#!/bin/bash -ex
   exit 1
@@ -54,16 +55,30 @@ execute: |
   echo "Check that change finished with failure and that the old snap is being used"
   tests.nested exec "snap info $base | MATCH 'installed:.*\(x1\)'"
   tests.nested exec "snap changes | MATCH \"^$chg_id.*Error\""
-  modeenv_data=$(tests.nested exec 'cat /var/lib/snapd/modeenv')
-  if ! [[ "$modeenv_data" == *base=${base}_x1.snap* ]]; then
-      echo "Incorrect base in modeenv: $modeenv_data"
-      exit 1
-  fi
-  if [[ "$modeenv_data" == *try_base=* ]]; then
-      echo "try_base should not be set in modeenv: $modeenv_data"
-      exit 1
-  fi
-  if [[ "$modeenv_data" == *base_status=* ]]; then
-      echo "base_status should not be set in modeenv: $modeenv_data"
-      exit 1
+
+  if [ "$VERSION" -ge 20 ]; then
+      modeenv_data=$(tests.nested exec 'cat /var/lib/snapd/modeenv')
+      if ! [[ "$modeenv_data" == *base=${base}_x1.snap* ]]; then
+              echo "Incorrect base in modeenv: $modeenv_data"
+              exit 1
+          fi
+          if [[ "$modeenv_data" == *try_base=* ]]; then
+              echo "try_base should not be set in modeenv: $modeenv_data"
+              exit 1
+          fi
+          if [[ "$modeenv_data" == *base_status=* ]]; then
+              echo "base_status should not be set in modeenv: $modeenv_data"
+              exit 1
+          fi
+  else
+      SNAP=core"$VERSION"
+      if [ "$VERSION" -eq 16 ]; then
+          SNAP=core
+      fi
+      # shellcheck disable=SC2016
+      tests.nested exec 'cat /boot/grub/grubenv | MATCH "^snap_core=${SNAP}_x1.snap$"'
+      tests.nested exec 'cat /boot/grub/grubenv | MATCH "^snap_mode=$"'
+      tests.nested exec 'cat /boot/grub/grubenv | MATCH "^snap_try_core=$"'
+      # shellcheck disable=SC2016
+      tests.nested exec 'cat /proc/cmdline | MATCH snap_core=${SNAP}_x1.snap'
   fi

--- a/tests/nested/core/base-revert-after-boot/task.yaml
+++ b/tests/nested/core/base-revert-after-boot/task.yaml
@@ -75,10 +75,8 @@ execute: |
       if [ "$VERSION" -eq 16 ]; then
           SNAP=core
       fi
-      # shellcheck disable=SC2016
-      tests.nested exec 'cat /boot/grub/grubenv | MATCH "^snap_core=${SNAP}_x1.snap$"'
+      tests.nested exec "cat /boot/grub/grubenv | MATCH \"^snap_core=${SNAP}_x1.snap$\""
       tests.nested exec 'cat /boot/grub/grubenv | MATCH "^snap_mode=$"'
       tests.nested exec 'cat /boot/grub/grubenv | MATCH "^snap_try_core=$"'
-      # shellcheck disable=SC2016
-      tests.nested exec 'cat /proc/cmdline | MATCH snap_core=${SNAP}_x1.snap'
+      tests.nested exec "cat /proc/cmdline | MATCH snap_core=${SNAP}_x1.snap"
   fi

--- a/tests/nested/core/kernel-revert-after-boot/task.yaml
+++ b/tests/nested/core/kernel-revert-after-boot/task.yaml
@@ -10,8 +10,12 @@ systems: [ubuntu-16.04-64, ubuntu-18.04-64, ubuntu-20.04-64, ubuntu-22.04-64]
 execute: |
   echo "Build kernel with failing post-refresh hook"
   VERSION="$(tests.nested show version)"
+  CHANNEL=$VERSION
+  if [ "$VERSION" -eq 16 ]; then
+      CHANNEL=latest
+  fi
   rm -rf pc-kernel
-  snap download --basename=pc-kernel --channel="$VERSION/edge" pc-kernel
+  snap download --basename=pc-kernel --channel="$CHANNEL/edge" pc-kernel
   unsquashfs -d pc-kernel pc-kernel.snap
   HOOKS_D=pc-kernel/meta/hooks/
   POST_REFRESH_P=$HOOKS_D/post-refresh

--- a/tests/nested/core/kernel-revert-after-boot/task.yaml
+++ b/tests/nested/core/kernel-revert-after-boot/task.yaml
@@ -1,0 +1,54 @@
+summary: Check that a kernel can be reverted after it has booted
+
+details: |
+  This test checks that a kernel snap that has not finished installation but
+  that already booted can be reverted properly if something else fails, like a
+  post-refresh hook.
+
+# this is a UC20+ specific test
+systems: [ubuntu-20.04-64, ubuntu-22.04-64]
+
+execute: |
+  echo "Build kernel with failing post-refresh hook"
+  VERSION="$(tests.nested show version)"
+  rm -rf pc-kernel
+  snap download --basename=pc-kernel --channel="$VERSION/edge" pc-kernel
+  unsquashfs -d pc-kernel pc-kernel.snap
+  HOOKS_D=pc-kernel/meta/hooks/
+  POST_REFRESH_P=$HOOKS_D/post-refresh
+  mkdir -p "$HOOKS_D"
+  cat > "$POST_REFRESH_P" << EOF
+  \#!/bin/bash -ex
+  exit 1
+  EOF
+  chmod +x "$POST_REFRESH_P"
+  snap pack pc-kernel/ --filename=pc-kernel_badhook.snap
+
+  echo "Wait for the system to be seeded first"
+  tests.nested exec "sudo snap wait system seed.loaded"
+
+  boot_id="$(tests.nested boot-id)"
+
+  echo "Install kernel with failing post-refresh hook"
+  tests.nested copy pc-kernel_badhook.snap
+  chg_id=$(tests.nested exec 'sudo snap install --dangerous --no-wait ./pc-kernel_badhook.snap')
+
+  echo "Wait for reboot"
+  tests.nested wait-for reboot "$boot_id"
+
+  boot_id="$(tests.nested boot-id)"
+  echo "Wait for second reboot after post-refresh hook failure"
+  tests.nested wait-for reboot "$boot_id"
+
+  boot_id="$(tests.nested boot-id)"
+  # wait for change to finish with error
+  not tests.nested exec sudo snap watch "$chg_id"
+  # make sure that no additional reboots have happened while the change finished
+  test "$boot_id" = "$(tests.nested boot-id)"
+
+  echo "Check that change finished with failure and that the old snap is being used"
+  tests.nested exec "snap info pc-kernel | MATCH 'installed:.*\(x1\)'"
+  tests.nested exec "snap changes | MATCH \"^$chg_id.*Error\""
+  # shellcheck disable=SC2016
+  tests.nested exec 'test $(readlink /run/mnt/ubuntu-boot/EFI/ubuntu/kernel.efi) = pc-kernel_x1.snap/kernel.efi'
+  tests.nested exec 'cat /run/mnt/ubuntu-boot/EFI/ubuntu/grubenv | MATCH "^kernel_status=$"'

--- a/tests/nested/core/kernel-revert-after-boot/task.yaml
+++ b/tests/nested/core/kernel-revert-after-boot/task.yaml
@@ -5,8 +5,7 @@ details: |
   that already booted can be reverted properly if something else fails, like a
   post-refresh hook.
 
-# this is a UC20+ specific test
-systems: [ubuntu-20.04-64, ubuntu-22.04-64]
+systems: [ubuntu-16.04-64, ubuntu-18.04-64, ubuntu-20.04-64, ubuntu-22.04-64]
 
 execute: |
   echo "Build kernel with failing post-refresh hook"
@@ -49,6 +48,15 @@ execute: |
   echo "Check that change finished with failure and that the old snap is being used"
   tests.nested exec "snap info pc-kernel | MATCH 'installed:.*\(x1\)'"
   tests.nested exec "snap changes | MATCH \"^$chg_id.*Error\""
-  # shellcheck disable=SC2016
-  tests.nested exec 'test $(readlink /run/mnt/ubuntu-boot/EFI/ubuntu/kernel.efi) = pc-kernel_x1.snap/kernel.efi'
-  tests.nested exec 'cat /run/mnt/ubuntu-boot/EFI/ubuntu/grubenv | MATCH "^kernel_status=$"'
+  if [ "$VERSION" -ge 20 ]; then
+      # shellcheck disable=SC2016
+      tests.nested exec 'test $(readlink /run/mnt/ubuntu-boot/EFI/ubuntu/kernel.efi) = pc-kernel_x1.snap/kernel.efi'
+      tests.nested exec 'cat /run/mnt/ubuntu-boot/EFI/ubuntu/grubenv | MATCH "^kernel_status=$"'
+      echo "Check that modeenv has only the old kernel"
+      tests.nested exec 'cat /var/lib/snapd/modeenv | MATCH "^current_kernels=pc-kernel_x1.snap$"'
+  else
+      tests.nested exec 'cat /boot/grub/grubenv | MATCH "^snap_kernel=pc-kernel_x1.snap$"'
+      tests.nested exec 'cat /boot/grub/grubenv | MATCH "^snap_mode=$"'
+      tests.nested exec 'cat /boot/grub/grubenv | MATCH "^snap_try_kernel=$"'
+      tests.nested exec 'cat /proc/cmdline | MATCH snap_kernel=pc-kernel_x1.snap'
+  fi


### PR DESCRIPTION
Some times LinkSnap is called in an undo task when we want to revert
to a previous snap revision. Introduce a flag to make LinkSnap and
boot code aware of when this happen, as some of the logic for snap
installations should not be applied when doing a revert. Specifically,
avoid the "try" logic that applies to kernels and bases: we are
reverting to a known snap that is expected to work, and making the
current snap the fallback provokes failures as we are removing it (and
also probably we are removing it because it has failed).