### PR TITLE
tests: fix snap-network-erros on uc16

### DIFF
--- a/tests/main/snap-network-errors/task.yaml
+++ b/tests/main/snap-network-errors/task.yaml
@@ -20,15 +20,14 @@ execute: |
 
     echo "Disabling DNS queries"
     iptables -I OUTPUT -p udp --dport 53 -j REJECT --reject-with icmp-port-unreachable
-    # centos 7 doesn't support caching dns, so no flushing required
-    if [ "$SPREAD_SYSTEM" != "centos-7-64" ]; then
-        if systemctl is-active systemd-resolved; then
-            if command -v resolvectl ; then
-                resolvectl flush-caches
-            else
-                # before systemd 239, the tool was named systemd-resolve
-                systemd-resolve --flush-caches
-            fi
+    if systemctl is-active systemd-resolved; then
+        # before systemd 239, the tool was named systemd-resolve some systems do not support
+        if command -v resolvectl; then
+            resolvectl flush-caches
+        elif systemd-resolve -h 2&>1 | grep flush-caches; then
+            # centos 7: doesn't support caching dns, so no flushing required
+            # ubuntu-core 16: systemd-resolve doesn't support flush-caches
+            systemd-resolve --flush-caches
         fi
     fi
 

--- a/tests/main/snap-network-errors/task.yaml
+++ b/tests/main/snap-network-errors/task.yaml
@@ -24,7 +24,7 @@ execute: |
         # before systemd 239, the tool was named systemd-resolve some systems do not support
         if command -v resolvectl; then
             resolvectl flush-caches
-        elif systemd-resolve -h 2&>1 | grep flush-caches; then
+        elif systemd-resolve -h | MATCH flush-caches; then
             # centos 7: doesn't support caching dns, so no flushing required
             # ubuntu-core 16: systemd-resolve doesn't support flush-caches
             systemd-resolve --flush-caches


### PR DESCRIPTION
The test is failing in uc 16 with error:

+ systemd-resolve --flush-caches
systemd-resolve: unrecognized option '--flush-caches'

Also the test is simplified to support all the systems
