### PR TITLE
tests: fix boringcripto errors in centos7

### DIFF
--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -548,7 +548,7 @@ BUILDTAGS="${BUILDTAGS} nomanagers"
 # To ensure things work correctly with base snaps,
 # snap-exec, snap-update-ns, and snapctl need to be built statically
 (
-%if 0%{?rhel} >= 8
+%if 0%{?rhel} >= 7
     # since 1.12.1, the go-toolset module is built with FIPS compliance that
     # defaults to using libcrypto.so which gets loaded at runtime via dlopen(),
     # disable that functionality for statically built binaries


### PR DESCRIPTION
As go toolset in centos 7 has been updated to 1.17.7-1, we need to
update the spec to reflect that.

This fixes all the boringcripto errors like this:

+ test-snapd-classic-confinement
fatal error: unexpected signal during runtime execution
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x0]

runtime stack:
runtime.throw({0x723818, 0x0})
	/usr/lib/golang/src/runtime/panic.go:1198 +0x71
fp=0x7fff7eebb240 sp=0x7fff7eebb210 pc=0x435211
runtime.sigpanic()
	/usr/lib/golang/src/runtime/signal_unix.go:719 +0x396
fp=0x7fff7eebb290 sp=0x7fff7eebb240 pc=0x44a996

goroutine 1 [syscall, locked to thread]:
runtime.cgocall(0x5e8250, 0xc00009f6c0)
	/usr/lib/golang/src/runtime/cgocall.go:156 +0x5c fp=0xc00009f698
sp=0xc00009f660 pc=0x40551c
crypto/internal/boring._Cfunc__goboringcrypto_DLOPEN_OPENSSL()
	_cgo_gotypes.go:603 +0x49 fp=0xc00009f6c0 sp=0xc00009f698
pc=0x5356e9
crypto/internal/boring.init.0()
	/usr/lib/golang/src/crypto/internal/boring/boring.go:46 +0x45
fp=0xc00009f6f8 sp=0xc00009f6c0 pc=0x536465
runtime.doInit(0xad1480)
	/usr/lib/golang/src/runtime/proc.go:6498 +0x123 fp=0xc00009f830
sp=0xc00009f6f8 pc=0x444923
runtime.doInit(0xacf1a0)
	/usr/lib/golang/src/runtime/proc.go:6475 +0x71 fp=0xc00009f968
sp=0xc00009f830 pc=0x444871
runtime.doInit(0xad2260)
