### PR TITLE
tests: force version 2.48.3 on xenial ESM

### DIFF
--- a/tests/main/upgrade-from-release/task.yaml
+++ b/tests/main/upgrade-from-release/task.yaml
@@ -35,7 +35,7 @@ execute: |
         # 16.04 is ESM so get the latest version from the official archive
         # (we can't get the very first version because it's so old it
         # cannot run our test snaps)
-        apt install -y snapd
+        apt install -y snapd=2.48.3
     fi
     declare -A EXPECTED_SNAPD_VERSIONS=(
         ["22.04"]='2.55.3\+22.04'


### PR DESCRIPTION
When the "upgrade-from-release" tests runs on 16.04 we know
exactly what version to expect (2.48.3) because 16.04 is in ESM
mode and the archive will never change unless one enables ESM.

So force installing this version to ensure that even if some
test or something enables the ppa:snappy-dev/image PPA we always
get the right version.

We should probably also write an invariant test that ensures that
the sources.list does not change between runs but that would be
a followup.


