### PR TITLE
interfaces/apparmor: add permissions for per-snap directory on ubuntu-save partition

### DIFF
--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -905,6 +905,11 @@ func (b *Backend) addContent(securityTag string, snapInfo *snap.Info, cmdName st
 					snippet := strings.Replace(overlayRootSnippet, "###UPPERDIR###", overlayRoot, -1)
 					tagSnippets += snippet
 				}
+
+				// Add core specific snippets when not on classic
+				if !release.OnClassic {
+					tagSnippets += coreSnippet
+				}
 			}
 
 			if !ignoreSnippets {

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -2549,3 +2549,60 @@ func (s *backendSuite) TestSetupManyInPreseedMode(c *C) {
 		s.RemoveSnap(c, snapInfo2)
 	}
 }
+
+func (s *backendSuite) TestCoreSnippetOnCoreSystem(c *C) {
+	dirs.SetRootDir(s.RootDir)
+
+	// NOTE: replace the real template with a shorter variant
+	restoreTemplate := apparmor.MockTemplate("\n" +
+		"###SNIPPETS###\n" +
+		"\n")
+	defer restoreTemplate()
+
+	expectedContents := `
+# Allow each snaps to access each their own folder on the
+# ubuntu-save partition, with write permissions.
+/var/lib/snapd/save/snap/@{SNAP_INSTANCE_NAME}/ rw,
+/var/lib/snapd/save/snap/@{SNAP_INSTANCE_NAME}/** mrwklix,
+`
+
+	tests := []struct {
+		onClassic            bool
+		classicConfinement   bool
+		jailMode             bool
+		shouldContainSnippet bool
+	}{
+		// XXX: Is it possible for someone to make this nicer?
+		{onClassic: false, classicConfinement: false, jailMode: false, shouldContainSnippet: true},
+		{onClassic: false, classicConfinement: false, jailMode: true, shouldContainSnippet: true},
+
+		// Rest of the cases the core-specific snippet shouldn't turn up.
+		{onClassic: false, classicConfinement: true, jailMode: false, shouldContainSnippet: false},
+		{onClassic: false, classicConfinement: true, jailMode: true, shouldContainSnippet: false},
+		{onClassic: true, classicConfinement: false, jailMode: false, shouldContainSnippet: false},
+		{onClassic: true, classicConfinement: true, jailMode: false, shouldContainSnippet: false},
+		{onClassic: true, classicConfinement: false, jailMode: true, shouldContainSnippet: false},
+		{onClassic: true, classicConfinement: true, jailMode: true, shouldContainSnippet: false},
+	}
+
+	for _, t := range tests {
+		restore := release.MockOnClassic(t.onClassic)
+
+		opts := interfaces.ConfinementOptions{
+			Classic:  t.classicConfinement,
+			JailMode: t.jailMode,
+		}
+		snapInfo := s.InstallSnap(c, opts, "", ifacetest.SambaYamlV1, 1)
+		profile := filepath.Join(dirs.SnapAppArmorDir, "snap.samba.smbd")
+		if t.shouldContainSnippet {
+			c.Check(profile, testutil.FileContains, expectedContents, Commentf("Classic %t, JailMode %t", t.onClassic, t.jailMode))
+		} else {
+			c.Check(profile, Not(testutil.FileContains), expectedContents, Commentf("Classic %t, JailMode %t", t.onClassic, t.jailMode))
+		}
+		stat, err := os.Stat(profile)
+		c.Assert(err, IsNil)
+		c.Check(stat.Mode(), Equals, os.FileMode(0644))
+		s.RemoveSnap(c, snapInfo)
+		restore()
+	}
+}

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -2587,6 +2587,7 @@ func (s *backendSuite) TestCoreSnippetOnCoreSystem(c *C) {
 
 	for _, t := range tests {
 		restore := release.MockOnClassic(t.onClassic)
+		defer restore()
 
 		opts := interfaces.ConfinementOptions{
 			Classic:  t.classicConfinement,
@@ -2603,6 +2604,5 @@ func (s *backendSuite) TestCoreSnippetOnCoreSystem(c *C) {
 		c.Assert(err, IsNil)
 		c.Check(stat.Mode(), Equals, os.FileMode(0644))
 		s.RemoveSnap(c, snapInfo)
-		restore()
 	}
 }

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -470,7 +470,11 @@ var templateCommon = `
   /run/lock/ r,
   /run/lock/snap.@{SNAP_INSTANCE_NAME}/ rw,
   /run/lock/snap.@{SNAP_INSTANCE_NAME}/** mrwklix,
-
+  
+  # Allow each snaps to access each their own folder on the
+  # ubuntu-save partition, with write permissions.
+  /var/lib/snapd/save/snap/@{SNAP_INSTANCE_NAME}/ rw,
+  /var/lib/snapd/save/snap/@{SNAP_INSTANCE_NAME}/** mrwklix,
 
   ###DEVMODE_SNAP_CONFINE###
 `

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -471,11 +471,6 @@ var templateCommon = `
   /run/lock/snap.@{SNAP_INSTANCE_NAME}/ rw,
   /run/lock/snap.@{SNAP_INSTANCE_NAME}/** mrwklix,
   
-  # Allow each snaps to access each their own folder on the
-  # ubuntu-save partition, with write permissions.
-  /var/lib/snapd/save/snap/@{SNAP_INSTANCE_NAME}/ rw,
-  /var/lib/snapd/save/snap/@{SNAP_INSTANCE_NAME}/** mrwklix,
-
   ###DEVMODE_SNAP_CONFINE###
 `
 
@@ -817,6 +812,16 @@ var privDropAndChownRules = `
   # processes that ultimately run as non-root will send signals to those
   # processes as the matching non-root user.
   #capability kill,
+`
+
+// coreSnippet contains apparmor rules specific only for
+// snaps on native core systems.
+//
+var coreSnippet = `
+# Allow each snaps to access each their own folder on the
+# ubuntu-save partition, with write permissions.
+/var/lib/snapd/save/snap/@{SNAP_INSTANCE_NAME}/ rw,
+/var/lib/snapd/save/snap/@{SNAP_INSTANCE_NAME}/** mrwklix,
 `
 
 // classicTemplate contains apparmor template used for snaps with classic


### PR DESCRIPTION
As a part of the support for per-snap directories on the ubuntu-save partition, we need to allow snaps to access their own folder with read/write permissions. The ubuntu-save partition is mounted at /var/lib/snapd/save.
