### PR TITLE
interfaces/display-control: allow changing brightness value

### DIFF
--- a/interfaces/builtin/display_control.go
+++ b/interfaces/builtin/display_control.go
@@ -83,6 +83,9 @@ dbus (send)
     peer=(label=unconfined),
 
 /sys/class/backlight/ r,
+
+# Allow changing backlight
+/sys/devices/**/**/drm/card[0-9]/card[0-9]*/*_backlight/brightness w,
 `
 
 type displayControlInterface struct {


### PR DESCRIPTION
Once a developer would like to change the brigness of the display, they get the following AppArmor denials. This PR aims to fix that.

```
apparmor="DENIED" operation="open" profile="snap.my-app.awesome-ui" name="/sys/devices/pci0000:00/0000:00:02.0/drm/card0/card0-eDP-1/intel_backlight/brightness" pid=1859 comm="bash" requested_mask="wc" denied_mask="wc" fsuid=0 ouid=0 

```
