### PR TITLE
interfaces: zfs: add zfs interface

### DIFF
--- a/interfaces/builtin/zfs.go
+++ b/interfaces/builtin/zfs.go
@@ -1,0 +1,61 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+const zfsSummary = `allows manipulating ZFS volumes and pools`
+
+const zfsBaseDeclarationPlugs = `
+  zfs:
+    allow-installation: false
+    deny-auto-connection: true
+`
+
+const zfsBaseDeclarationSlots = `
+  zfs:
+    allow-installation:
+      slot-snap-type:
+        - core
+    deny-auto-connection: true
+ `
+
+const zfsConnectedPlugAppArmor = `# Description: Allow access to the ZFS device control interface
+  /dev/zfs rw,
+`
+
+var zfsConnectedPlugUDev = []string{
+	`KERNEL=="zfs"`,
+}
+
+type zfsInterface struct {
+	commonInterface
+}
+
+func init() {
+	registerIface(&zfsInterface{commonInterface{
+		name:                  "zfs",
+		summary:               zfsSummary,
+		implicitOnCore:        true,
+		implicitOnClassic:     true,
+		baseDeclarationSlots:  zfsBaseDeclarationSlots,
+		baseDeclarationPlugs:  zfsBaseDeclarationPlugs,
+		connectedPlugAppArmor: zfsConnectedPlugAppArmor,
+		connectedPlugUDev:     zfsConnectedPlugUDev,
+	}})
+}

--- a/interfaces/builtin/zfs_test.go
+++ b/interfaces/builtin/zfs_test.go
@@ -1,0 +1,113 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/interfaces/udev"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type zfsInterfaceSuite struct {
+	testutil.BaseTest
+
+	iface    interfaces.Interface
+	slotInfo *snap.SlotInfo
+	slot     *interfaces.ConnectedSlot
+	plugInfo *snap.PlugInfo
+	plug     *interfaces.ConnectedPlug
+}
+
+var _ = Suite(&zfsInterfaceSuite{
+	iface: builtin.MustInterface("zfs"),
+})
+
+const zfsConsumerYaml = `
+name: consumer
+version: 0
+type: app
+apps:
+  app:
+    plugs: [zfs]
+`
+
+const zfsCoreYaml = `
+name: core
+version: 0
+type: os
+slots:
+  zfs: {}
+`
+
+func (s *zfsInterfaceSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+
+	s.plug, s.plugInfo = MockConnectedPlug(c, zfsConsumerYaml, nil, "zfs")
+	s.slot, s.slotInfo = MockConnectedSlot(c, zfsCoreYaml, nil, "zfs")
+}
+
+func (s *zfsInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "zfs")
+}
+
+func (s *zfsInterfaceSuite) TestSanitizeSlot(c *C) {
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.slotInfo), IsNil)
+}
+
+func (s *zfsInterfaceSuite) TestSanitizePlug(c *C) {
+	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
+}
+
+func (s *zfsInterfaceSuite) TestAppArmorSpec(c *C) {
+	spec := &apparmor.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `# Description: Allow access to the ZFS device control interface`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/dev/zfs rw,`)
+}
+
+func (s *zfsInterfaceSuite) TestUDevSpec(c *C) {
+	spec := &udev.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.Snippets(), HasLen, 2)
+	c.Assert(spec.Snippets()[0], Equals, `# zfs
+KERNEL=="zfs", TAG+="snap_consumer_app"`)
+}
+
+func (s *zfsInterfaceSuite) TestStaticInfo(c *C) {
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Assert(si.ImplicitOnCore, Equals, true)
+	c.Assert(si.ImplicitOnClassic, Equals, true)
+	c.Assert(si.Summary, Equals, `allows manipulating ZFS volumes and pools`)
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "zfs")
+}
+
+func (s *zfsInterfaceSuite) TestAutoConnect(c *C) {
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.slotInfo), Equals, true)
+}
+
+func (s *zfsInterfaceSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -948,6 +948,7 @@ func (s *baseDeclSuite) TestPlugInstallation(c *C) {
 		"uinput":                true,
 		"unity8":                true,
 		"xilinx-dma":            true,
+		"zfs":                   true,
 	}
 
 	for _, iface := range all {
@@ -1202,6 +1203,7 @@ func (s *baseDeclSuite) TestValidity(c *C) {
 		"unity8":                true,
 		"wayland":               true,
 		"xilinx-dma":            true,
+		"zfs":                   true,
 	}
 
 	for _, iface := range all {

--- a/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
@@ -509,6 +509,9 @@ apps:
   xilinx-dma:
     command: bin/run
     plugs: [ xilinx-dma ]
+  zfs:
+    command: bin/run
+    plugs: [ zfs ]
 
 plugs:
   browser-sandbox:

--- a/tests/main/interfaces-zfs/task.yaml
+++ b/tests/main/interfaces-zfs/task.yaml
@@ -1,0 +1,51 @@
+summary: Ensure that the zfs interface works.
+
+# Only Ubuntu ships the ZFS userpace components
+systems: [ubuntu-2*]
+
+details: |
+    The zfs interface allows manipulating ZFS volumes and pools.
+
+prepare: |
+    # Install kernel module package
+    apt-get update
+    apt-get install -y zfsutils-linux
+
+    # Setup ZFS pool
+    dd if=/dev/zero of=/tmp/zfs.pool bs=1M count=128
+    zpool create -o ashift=12 -m none test /tmp/zfs.pool
+
+    # Setup ZFS volume
+    zfs create test/testvol
+
+    # Install ZFS test snap
+    snap install --edge test-snapd-zfs
+
+restore: |
+    # Remove all ZFS volumes and pools
+    zfs umount -a
+    zpool export -a
+    rm -f /tmp/zfs.pool
+
+    # Remove kernel module package on host
+    apt-get remove -y zfsutils-linux
+
+    snap remove --purge test-snapd-zfs
+
+execute: |
+    echo "The interface is not connected by default"
+    snap interfaces -i zfs | MATCH "\\- +test-zfs:zfs"
+
+    echo "When the interface is connected"
+    snap connect test-zfs:zfs
+
+    echo "Then the snap is able to read the available ZFS volumes and pools"
+    test-zfs.zpool list | MATCH '^test'
+    test-zfs.zfs list | MATCH '^test/testvol'
+
+    echo "When the interface is disconnected"
+    snap disconnect test-zfs:zfs
+
+    echo "Then the ZFS tools should output permission denied errors"
+    test-zfs.zpool list 2>&1 >/dev/null | MATCH '^Permission denied'
+    test-zfs.zfs list 2>&1 >/dev/null | MATCH '^Permission denied'


### PR DESCRIPTION
This interface allows access to the `/dev/zfs` device control interface. Access to this device node is required for the ZFS userspace tools.

This interface should probably be super-privileged, as it allows full access to the ZFS subsystem.