### PR TITLE
asserts: add more context to key expiry error

### DIFF
--- a/asserts/database.go
+++ b/asserts/database.go
@@ -746,8 +746,8 @@ func CheckSigningKeyIsNotExpired(assert Assertion, signingKey *AccountKey, deleg
 		return nil, nil
 	}
 	if !signingKey.isValidAssumingCurTimeWithin(checkTimeEarliest, checkTimeLatest) {
-		timeSuffix := timeMismatchMsg(checkTimeEarliest, checkTimeLatest, signingKey.since, signingKey.until)
-		return nil, fmt.Errorf("assertion is signed with expired public key %q from %q: %s", assert.SignKeyID(), assert.SignatoryID(), timeSuffix)
+		mismatchReason := timeMismatchMsg(checkTimeEarliest, checkTimeLatest, signingKey.since, signingKey.until)
+		return nil, fmt.Errorf("assertion is signed with expired public key %q from %q: %s", assert.SignKeyID(), assert.SignatoryID(), mismatchReason)
 	}
 	return delegationConstraints, nil
 }
@@ -764,7 +764,7 @@ func timeMismatchMsg(earliest, latest, keySince, keyUntil time.Time) string {
 	}
 
 	keyFrom := keySince.Format(time.RFC3339)
-	if !keyUntil.IsZero() && !keyUntil.Equal(keySince) {
+	if !keyUntil.IsZero() {
 		keyTo := keyUntil.Format(time.RFC3339)
 		return msg + fmt.Sprintf(" but key is valid during [%s, %s)", keyFrom, keyTo)
 	}

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -746,7 +746,11 @@ func CheckSigningKeyIsNotExpired(assert Assertion, signingKey *AccountKey, deleg
 		return nil, nil
 	}
 	if !signingKey.isValidAssumingCurTimeWithin(checkTimeEarliest, checkTimeLatest) {
-		return nil, fmt.Errorf("assertion is signed with expired public key %q from %q", assert.SignKeyID(), assert.SignatoryID())
+		validFrom, validTo := checkTimeEarliest.Format(time.RFC3339), checkTimeLatest.Format(time.RFC3339)
+		keyFrom, keyTo := signingKey.since.Format(time.RFC3339), signingKey.until.Format(time.RFC3339)
+
+		return nil, fmt.Errorf("assertion is signed with expired public key %q from %q: expected range is [%s, %s] but key is valid during [%s, %s]",
+			assert.SignKeyID(), assert.SignatoryID(), validFrom, validTo, keyFrom, keyTo)
 	}
 	return delegationConstraints, nil
 }

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -258,7 +258,33 @@ func (chks *checkSuite) TestCheckExpiredPubKey(c *C) {
 	expUntil := regexp.QuoteMeta(expiredAccKey.Until().Format(time.RFC3339))
 	curTime := regexp.QuoteMeta(fixedTimeStr)
 	err = db.Check(chks.a)
-	c.Assert(err, ErrorMatches, fmt.Sprintf(`assertion is signed with expired public key "[[:alnum:]_-]+" from "canonical": expected range is \[%s, %s\] but key is valid during \[%s, %s\]`, curTime, curTime, expSince, expUntil))
+	c.Assert(err, ErrorMatches, fmt.Sprintf(`assertion is signed with expired public key "[[:alnum:]_-]+" from "canonical": current time is %s but key is valid during \[%s, %s\)`, curTime, expSince, expUntil))
+}
+
+func (chks *checkSuite) TestCheckExpiredPubKeyNoUntil(c *C) {
+	curTimeStr := "0002-01-01T00:00:00Z"
+	curTime, err := time.Parse(time.RFC3339, curTimeStr)
+	c.Assert(err, IsNil)
+
+	restore := asserts.MockTimeNow(curTime)
+	defer restore()
+
+	trustedKey := testPrivKey0
+
+	keyTimeStr := "0003-01-01T00:00:00Z"
+	keyTime, err := time.Parse(time.RFC3339, keyTimeStr)
+	c.Assert(err, IsNil)
+	expiredAccKey := asserts.MakeAccountKeyForTestWithUntil("canonical", trustedKey.PublicKey(), keyTime, time.Time{}, 1)
+	cfg := &asserts.DatabaseConfig{
+		Backstore: chks.bs,
+		Trusted:   []asserts.Assertion{expiredAccKey},
+	}
+
+	db, err := asserts.OpenDatabase(cfg)
+	c.Assert(err, IsNil)
+
+	err = db.Check(chks.a)
+	c.Assert(err, ErrorMatches, fmt.Sprintf(`assertion is signed with expired public key "[[:alnum:]_-]+" from "canonical": current time is %s but key is valid from %s`, regexp.QuoteMeta(curTimeStr), regexp.QuoteMeta(keyTimeStr)))
 }
 
 func (chks *checkSuite) TestCheckForgery(c *C) {

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -24,9 +24,11 @@ import (
 	"crypto"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"testing"
 	"time"
@@ -235,17 +237,28 @@ func (chks *checkSuite) TestCheckNoPubKey(c *C) {
 }
 
 func (chks *checkSuite) TestCheckExpiredPubKey(c *C) {
+	fixedTimeStr := "0003-01-01T00:00:00Z"
+	fixedTime, err := time.Parse(time.RFC3339, fixedTimeStr)
+	c.Assert(err, IsNil)
+
+	restore := asserts.MockTimeNow(fixedTime)
+	defer restore()
+
 	trustedKey := testPrivKey0
 
+	expiredAccKey := asserts.ExpiredAccountKeyForTest("canonical", trustedKey.PublicKey())
 	cfg := &asserts.DatabaseConfig{
 		Backstore: chks.bs,
-		Trusted:   []asserts.Assertion{asserts.ExpiredAccountKeyForTest("canonical", trustedKey.PublicKey())},
+		Trusted:   []asserts.Assertion{expiredAccKey},
 	}
 	db, err := asserts.OpenDatabase(cfg)
 	c.Assert(err, IsNil)
 
+	expSince := regexp.QuoteMeta(expiredAccKey.Since().Format(time.RFC3339))
+	expUntil := regexp.QuoteMeta(expiredAccKey.Until().Format(time.RFC3339))
+	curTime := regexp.QuoteMeta(fixedTimeStr)
 	err = db.Check(chks.a)
-	c.Assert(err, ErrorMatches, `assertion is signed with expired public key "[[:alnum:]_-]+" from "canonical"`)
+	c.Assert(err, ErrorMatches, fmt.Sprintf(`assertion is signed with expired public key "[[:alnum:]_-]+" from "canonical": expected range is \[%s, %s\] but key is valid during \[%s, %s\]`, curTime, curTime, expSince, expUntil))
 }
 
 func (chks *checkSuite) TestCheckForgery(c *C) {

--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -69,6 +69,10 @@ func BootstrapAccountForTest(authorityID string) *Account {
 }
 
 func MakeAccountKeyForTest(authorityID string, openPGPPubKey PublicKey, since time.Time, validYears int) *AccountKey {
+	return MakeAccountKeyForTestWithUntil(authorityID, openPGPPubKey, since, since.AddDate(validYears, 0, 0), validYears)
+}
+
+func MakeAccountKeyForTestWithUntil(authorityID string, openPGPPubKey PublicKey, since, until time.Time, validYears int) *AccountKey {
 	return &AccountKey{
 		assertionBase: assertionBase{
 			headers: map[string]interface{}{
@@ -80,7 +84,7 @@ func MakeAccountKeyForTest(authorityID string, openPGPPubKey PublicKey, since ti
 		},
 		sinceUntil: sinceUntil{
 			since: since.UTC(),
-			until: since.UTC().AddDate(validYears, 0, 0),
+			until: until.UTC(),
 		},
 		pubKey: openPGPPubKey,
 	}


### PR DESCRIPTION
Adds a bit more context to the key expiry error.