### PR TITLE
tests: detect 403 in apt-hooks and skip test in this case

### DIFF
--- a/tests/main/apt-hooks/task.yaml
+++ b/tests/main/apt-hooks/task.yaml
@@ -35,8 +35,8 @@ execute: |
 
     if ! stat /var/cache/snapd/commands.db; then
         # workaround for misbehaving store
-        if "$TESTSTOOLS"/journal-state get-log -u snapd | MATCH "429 Too Many Requests"; then
-            echo "Store is reporting 429 (too many requests), skipping the test"
+        if "$TESTSTOOLS"/journal-state get-log -u snapd | grep -E "(429 Too Many Requests|403 Forbidden)"; then
+            echo "Store is reporting 429 (too many requests) or 403, skipping the test"
             exit 0
         fi
         if "$TESTSTOOLS"/journal-state get-log -u snapd | MATCH "Catalog refresh failed: cannot retrieve sections"; then


### PR DESCRIPTION
When the store releases core or snapd it will disable the `names`
endpoint and return 403. Example:
```
Jul 08 10:06:01 autopkgtest snapd[46568]: retry.go:61: DEBUG: The retry loop for https://api.snapcraft.io/api/v1/snaps/names?confinement=strict%2Cclassic finished after 1 retries, elapsed time=91.88602ms, status: cannot decode new commands catalog: got unexpected HTTP status code 403 via GET to "https://api.snapcraft.io/api/v1/snaps/names?confinement=strict%2Cclassic"
```
Detect this and skip the test if that happens.

Note that we already support skipping the test if we get 429 but
the store seems to have changed behavior here.
