### PR TITLE
snap: introduce ReadProvenanceFromReadFile, have it use a sandboxed ReadFile 

### DIFF
--- a/snap/container.go
+++ b/snap/container.go
@@ -58,6 +58,10 @@ type Container interface {
 	Unpack(src, dst string) error
 }
 
+// ErrUnsupportedContainerFeature signals a feature that is not supported
+// by a snap container implementation on this system.
+var ErrUnsupportedContainerFeature = errors.New("unsupported snap container feature")
+
 // InstallOptions is for customizing the behavior of Install() from a higher
 // level function, i.e. from overlord customizing how a snap file is installed
 // on a system with tmpfs mounted as writable or with full disk encryption and

--- a/snap/info.go
+++ b/snap/info.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2021 Canonical Ltd
+ * Copyright (C) 2014-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -29,6 +29,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"gopkg.in/yaml.v2"
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/metautil"
@@ -1481,4 +1483,21 @@ func (a AppInfoBySnapApp) Less(i, j int) bool {
 		return a[i].Name < a[j].Name
 	}
 	return iName < jName
+}
+
+// ReadProvenanceFromSnapFile reads the provenance field form the given Container metadata.
+// It returns the empty string is the field is not set explicitly.
+func ReadProvenanceFromSnapFile(snapf Container) (string, error) {
+	// XXX use something safer
+	meta, err := snapf.ReadFile("meta/snap.yaml")
+	if err != nil {
+		return "", err
+	}
+	var m struct {
+		Provenance string `yaml:"provenance"`
+	}
+	if err := yaml.Unmarshal(meta, &m); err != nil {
+		return "", fmt.Errorf("cannot unmarshal provenance from snap.yaml: %v", err)
+	}
+	return m.Provenance, nil
 }

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2021 Canonical Ltd
+ * Copyright (C) 2014-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -454,6 +454,42 @@ func makeTestSnap(c *C, snapYaml string) string {
 	c.Assert(err, IsNil)
 
 	return dest
+}
+
+func (s *infoSuite) TestReadProvenanceFromSnapFile(c *C) {
+	yaml := `name: foo
+version: 1
+provenance: prov-1
+`
+	snapPath := snaptest.MakeTestSnapWithFiles(c, yaml, nil)
+	snapf, err := snapfile.Open(snapPath)
+	c.Assert(err, IsNil)
+
+	prov, err := snap.ReadProvenanceFromSnapFile(snapf)
+	c.Assert(err, IsNil)
+	c.Check(prov, Equals, "prov-1")
+
+	yaml = `name: foo
+version: 1
+`
+	snapPath = snaptest.MakeTestSnapWithFiles(c, yaml, nil)
+	snapf, err = snapfile.Open(snapPath)
+	c.Assert(err, IsNil)
+
+	prov, err = snap.ReadProvenanceFromSnapFile(snapf)
+	c.Assert(err, IsNil)
+	c.Check(prov, Equals, "")
+
+	yaml = `name: foo
+version: 1
+provenance: [1]
+`
+	snapPath = snaptest.MakeTestSnapWithFiles(c, yaml, nil)
+	snapf, err = snapfile.Open(snapPath)
+	c.Assert(err, IsNil)
+
+	_, err = snap.ReadProvenanceFromSnapFile(snapf)
+	c.Assert(err, ErrorMatches, `(?s)cannot unmarshal provenance from snap\.yaml: .*`)
 }
 
 // produce descrs for empty hooks suitable for snaptest.PopulateDir

--- a/snap/squashfs/export_test.go
+++ b/snap/squashfs/export_test.go
@@ -92,10 +92,10 @@ func MockIsRootWritableOverlay(new func() (string, error)) (restore func()) {
 }
 
 func MockSystemdVersion(v int) (restore func()) {
-	oldVer := sdVer
-	sdVer = v
+	oldVer := systemdVer
+	systemdVer = v
 	return func() {
-		sdVer = oldVer
+		systemdVer = oldVer
 	}
 }
 

--- a/snap/squashfs/export_test.go
+++ b/snap/squashfs/export_test.go
@@ -25,6 +25,8 @@ import (
 	"time"
 
 	"gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/osutil/sys"
 )
 
 var (
@@ -88,3 +90,25 @@ func MockIsRootWritableOverlay(new func() (string, error)) (restore func()) {
 		isRootWritableOverlay = old
 	}
 }
+
+func MockSystemdVersion(v int) (restore func()) {
+	oldVer := sdVer
+	sdVer = v
+	return func() {
+		sdVer = oldVer
+	}
+}
+
+func MockSysGeteuid(uid sys.UserID) (restore func()) {
+	oldSysGeteuid := sysGeteuid
+	sysGeteuid = func() sys.UserID {
+		return uid
+	}
+	return func() {
+		sysGeteuid = oldSysGeteuid
+	}
+}
+
+var (
+	SandboxParams = sandboxParams
+)

--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -275,7 +275,9 @@ func (s *Snap) ReadFile(filePath string) (content []byte, err error) {
 	return content, nil
 }
 
-var sdVer int
+var (
+	systemdVer int
+)
 
 func init() {
 	// this also avoids calling systemctl all the time which perturbs
@@ -284,7 +286,7 @@ func init() {
 	if err != nil {
 		v = 0
 	}
-	sdVer = v
+	systemdVer = v
 }
 
 var (
@@ -295,7 +297,7 @@ func sandboxParams(sdVer int) (params []string) {
 	if sysGeteuid() != 0 {
 		return nil
 	}
-	// effetive user is 0, use systemd-run to sandbox unsquashfs
+	// effective user is 0, use systemd-run to sandbox unsquashfs
 	params = []string{
 		"--property=KeyringMode=private",
 		"--property=PrivateTmp=true",
@@ -336,19 +338,27 @@ func sandboxParams(sdVer int) (params []string) {
 	return params
 }
 
-// SaferReadFile returns the content of a single file inside a squashfs snap, but it does invoking unsquashfs under a sandbox to handle not yet verified snap files, there is a limit below 16M on the content size.
+// SaferReadFileForProvenanceSystemdVersion is the minimum version of
+// systemd at which SaferReadFile and its sandboxing can be supported.
+const SaferReadFileForProvenanceSystemdVersion = 236
+
+// SaferReadFile returns the content of a single file inside a
+// squashfs snap, but it does invoking unsquashfs under a sandbox to
+// handle not yet verified snap files.
+// It will return snap.ErrUnsupportedContainerFeature if systemd
+// is not at least version SaferReadFileForProvenanceSystemdVersion (236).
 func (s *Snap) SaferReadFile(filePath string) (content []byte, err error) {
 	filePath = filepath.Clean(filePath)
 	if filepath.IsAbs(filePath) {
 		return nil, fmt.Errorf("internal error: SaferReadFile expects a relative path")
 	}
 
-	// systemd-run --collect etc require 236
+	// systemd-run --collect etc require 236+
 	// see https://github.com/systemd/systemd/blob/main/NEWS
-	if sdVer < 236 {
+	if systemdVer < SaferReadFileForProvenanceSystemdVersion {
 		return nil, snap.ErrUnsupportedContainerFeature
 	}
-	runParams := sandboxParams(sdVer)
+	runParams := sandboxParams(systemdVer)
 	sandboxing := len(runParams) != 0
 
 	tmpdir, err := ioutil.TempDir("", "read-file")

--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -315,7 +315,7 @@ func sandboxParams(sdVer int) (params []string) {
 		"--property=RestrictSUIDSGID=true",
 		"--property=SystemCallFilter=@default @basic-io @signal @file-system @chown @process mprotect",
 		"--property=SystemCallErrorNumber=EPERM",
-		"--property=MemoryMax=8M",
+		"--property=MemoryMax=16M",
 	}
 
 	// see https://github.com/systemd/systemd/blob/main/NEWS
@@ -336,7 +336,7 @@ func sandboxParams(sdVer int) (params []string) {
 	return params
 }
 
-// SaferReadFile returns the content of a single file inside a squashfs snap, but it does invoking unsquashfs under a sandbox to handle not yet verified snap files, there is a limit below 8M on the content size.
+// SaferReadFile returns the content of a single file inside a squashfs snap, but it does invoking unsquashfs under a sandbox to handle not yet verified snap files, there is a limit below 16M on the content size.
 func (s *Snap) SaferReadFile(filePath string) (content []byte, err error) {
 	filePath = filepath.Clean(filePath)
 	if filepath.IsAbs(filePath) {
@@ -375,8 +375,12 @@ func (s *Snap) SaferReadFile(filePath string) (content []byte, err error) {
 	} else {
 		// bind mount snap for access, this allows to use
 		// PrivateTmp even the snap itself is under /tmp
+		snapPath, err := filepath.Abs(s.path)
+		if err != nil {
+			return nil, err
+		}
 		runParams = append(runParams, []string{
-			fmt.Sprintf("--property=BindReadOnlyPaths=%s:/tmp/snap", s.path),
+			fmt.Sprintf("--property=BindReadOnlyPaths=%s:/tmp/snap", snapPath),
 			fmt.Sprintf("--property=BindPaths=%s:/tmp/read-file", tmpdir),
 		}...)
 	}

--- a/snap/squashfs/squashfs_test.go
+++ b/snap/squashfs/squashfs_test.go
@@ -1065,11 +1065,11 @@ echo -n "$d" > "$d"/unpack/meta/snap.yaml
 	invo := mockSystemdRun.Calls()[0]
 	c.Check(invo, DeepEquals, append(append([]string{
 		"systemd-run",
+		"--system",
 		"--quiet",
 		"--pipe",
 		"--wait",
 		"--collect",
-		"--system",
 	}, expectedSandboxParams...), []string{
 		fmt.Sprintf("--property=BindReadOnlyPaths=%s:/tmp/snap", sn.Path()),
 		fmt.Sprintf("--property=BindPaths=%s:/tmp/read-file", tmpDir),
@@ -1082,22 +1082,16 @@ echo -n "$d" > "$d"/unpack/meta/snap.yaml
 func (s *SquashfsTestSuite) TestSaferReadFileSandboxLevels(c *C) {
 	defer squashfs.MockSysGeteuid(0)()
 
-	expected := append([]string{"--system"}, expectedSandboxParams...)
+	expected := expectedSandboxParams
 	n := len(expected)
 
-	sandboxParams := func(sdVer int) []string {
-		params, sandboxing := squashfs.SandboxParams(sdVer)
-		c.Assert(sandboxing, Equals, true)
-		return params
-	}
-
-	c.Check(sandboxParams(236), DeepEquals, expected[:n-4])
-	c.Check(sandboxParams(239), DeepEquals, expected[:n-4])
-	c.Check(sandboxParams(240), DeepEquals, expected[:n-3])
-	c.Check(sandboxParams(241), DeepEquals, expected[:n-3])
-	c.Check(sandboxParams(242), DeepEquals, expected[:n-2])
-	c.Check(sandboxParams(243), DeepEquals, expected[:n-2])
-	c.Check(sandboxParams(244), DeepEquals, expected[:n-1])
-	c.Check(sandboxParams(245), DeepEquals, expected)
-	c.Check(sandboxParams(246), DeepEquals, expected)
+	c.Check(squashfs.SandboxParams(236), DeepEquals, expected[:n-4])
+	c.Check(squashfs.SandboxParams(239), DeepEquals, expected[:n-4])
+	c.Check(squashfs.SandboxParams(240), DeepEquals, expected[:n-3])
+	c.Check(squashfs.SandboxParams(241), DeepEquals, expected[:n-3])
+	c.Check(squashfs.SandboxParams(242), DeepEquals, expected[:n-2])
+	c.Check(squashfs.SandboxParams(243), DeepEquals, expected[:n-2])
+	c.Check(squashfs.SandboxParams(244), DeepEquals, expected[:n-1])
+	c.Check(squashfs.SandboxParams(245), DeepEquals, expected)
+	c.Check(squashfs.SandboxParams(246), DeepEquals, expected)
 }

--- a/snap/squashfs/squashfs_test.go
+++ b/snap/squashfs/squashfs_test.go
@@ -1037,7 +1037,7 @@ var expectedSandboxParams = []string{
 	"--property=RestrictSUIDSGID=true",
 	"--property=SystemCallFilter=@default @basic-io @signal @file-system @chown @process mprotect",
 	"--property=SystemCallErrorNumber=EPERM",
-	"--property=MemoryMax=8M",
+	"--property=MemoryMax=16M",
 	"--service-type=exec",
 	"--property=ProtectHostname=true",
 	"--property=ProtectKernelLogs=true",

--- a/snap/squashfs/squashfs_test.go
+++ b/snap/squashfs/squashfs_test.go
@@ -41,7 +41,7 @@ import (
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snapdir"
 	"github.com/snapcore/snapd/snap/squashfs"
-	"github.com/snapcore/snapd/systemd"
+	"github.com/snapcore/snapd/systemd/systemdtest"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -986,15 +986,8 @@ func (s *SquashfsTestSuite) TestSaferReadFileTooOldSystemd(c *C) {
 	c.Check(err, Equals, snap.ErrUnsupportedContainerFeature)
 }
 
-func (s *SquashfsTestSuite) oldSysdSkip(c *C) {
-	sdVer, err := systemd.Version()
-	if err != nil || sdVer < 236 {
-		c.Skip("systemd too old (<236) or missing")
-	}
-}
-
 func (s *SquashfsTestSuite) TestSaferReadFile(c *C) {
-	s.oldSysdSkip(c)
+	systemdtest.AtLeast(c, squashfs.SaferReadFileForProvenanceSystemdVersion)
 	sn := makeSnap(c, "name: foo", "")
 
 	content, err := sn.SaferReadFile("meta/snap.yaml")
@@ -1003,7 +996,7 @@ func (s *SquashfsTestSuite) TestSaferReadFile(c *C) {
 }
 
 func (s *SquashfsTestSuite) TestSaferReadFileMissingFile(c *C) {
-	s.oldSysdSkip(c)
+	systemdtest.AtLeast(c, squashfs.SaferReadFileForProvenanceSystemdVersion)
 	sn := makeSnap(c, "name: foo", "")
 
 	_, err := sn.SaferReadFile("meta/other.yaml")
@@ -1011,7 +1004,7 @@ func (s *SquashfsTestSuite) TestSaferReadFileMissingFile(c *C) {
 }
 
 func (s *SquashfsTestSuite) TestSaferReadFileFail(c *C) {
-	s.oldSysdSkip(c)
+	systemdtest.AtLeast(c, squashfs.SaferReadFileForProvenanceSystemdVersion)
 	mockUnsquashfs := testutil.MockCommand(c, "unsquashfs", `echo boom; exit 1`)
 	defer mockUnsquashfs.Restore()
 

--- a/systemd/systemdtest/systemdtest.go
+++ b/systemd/systemdtest/systemdtest.go
@@ -97,9 +97,9 @@ FragmentPath=%s
 }
 
 // AtLeast skips current test if systemd is not at least the given version.
-func AtLeast(c *check.C, ver int) {
+func AtLeast(c *check.C, minVer int) {
 	sdVer, err := systemd.Version()
-	if err != nil || ver < sdVer {
-		c.Skip(fmt.Sprintf("systemd too old (<%d) or missing", ver))
+	if err != nil || sdVer < minVer {
+		c.Skip(fmt.Sprintf("systemd too old (<%d) or missing", minVer))
 	}
 }

--- a/systemd/systemdtest/systemdtest.go
+++ b/systemd/systemdtest/systemdtest.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2021 Canonical Ltd
+ * Copyright (C) 2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -22,7 +22,10 @@ package systemdtest
 import (
 	"fmt"
 
+	"gopkg.in/check.v1"
+
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/systemd"
 )
 
 type ServiceState struct {
@@ -91,4 +94,12 @@ FragmentPath=%s
 `, mountInfo.Description, mountInfo.Where, mountInfo.FragmentPath))...)
 	}
 	return output, true
+}
+
+// AtLeast skips current test if systemd is not at least the given version.
+func AtLeast(c *check.C, ver int) {
+	sdVer, err := systemd.Version()
+	if err != nil || ver < sdVer {
+		c.Skip(fmt.Sprintf("systemd too old (<%d) or missing", ver))
+	}
 }


### PR DESCRIPTION
This will be used to extract provenance from a to-be-verified snap to find the corresponding snap-revision if any. That's why the extra paranoia.
