### PR TITLE
boot,device: extract SealedKey helpers from boot to device

### DIFF
--- a/boot/assets.go
+++ b/boot/assets.go
@@ -34,6 +34,7 @@ import (
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget"
+	"github.com/snapcore/snapd/gadget/device"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/secboot/keys"
@@ -356,11 +357,11 @@ func TrustedAssetsUpdateObserverForModel(model *asserts.Model, gadgetDir string)
 	// trusted assets need tracking only when the system is using encryption
 	// for its data partitions
 	trackTrustedAssets := false
-	_, err := sealedKeysMethod(dirs.GlobalRootDir)
+	_, err := device.SealedKeysMethod(dirs.GlobalRootDir)
 	switch {
 	case err == nil:
 		trackTrustedAssets = true
-	case err == errNoSealedKeys:
+	case err == device.ErrNoSealedKeys:
 		// nothing to do
 	case err != nil:
 		// all other errors

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/snapcore/snapd/bootloader/ubootenv"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget"
+	"github.com/snapcore/snapd/gadget/device"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/secboot/keys"
@@ -583,7 +584,7 @@ version: 5.0
 	provisionCalls := 0
 	restore = boot.MockSecbootProvisionTPM(func(mode secboot.TPMProvisionMode, lockoutAuthFile string) error {
 		provisionCalls++
-		c.Check(lockoutAuthFile, Equals, filepath.Join(boot.InstallHostFDESaveDir, "tpm-lockout-auth"))
+		c.Check(lockoutAuthFile, Equals, device.TpmLockoutAuthUnder(boot.InstallHostFDESaveDir))
 		if factoryReset {
 			c.Check(mode, Equals, secboot.TPMPartialReprovision)
 		} else {
@@ -1013,7 +1014,7 @@ version: 5.0
 	provisionCalls := 0
 	restore = boot.MockSecbootProvisionTPM(func(mode secboot.TPMProvisionMode, lockoutAuthFile string) error {
 		provisionCalls++
-		c.Check(lockoutAuthFile, Equals, filepath.Join(boot.InstallHostFDESaveDir, "tpm-lockout-auth"))
+		c.Check(lockoutAuthFile, Equals, device.TpmLockoutAuthUnder(boot.InstallHostFDESaveDir))
 		c.Check(mode, Equals, secboot.TPMProvisionFull)
 		return nil
 	})
@@ -1190,7 +1191,7 @@ version: 5.0
 	provisionCalls := 0
 	restore = boot.MockSecbootProvisionTPM(func(mode secboot.TPMProvisionMode, lockoutAuthFile string) error {
 		provisionCalls++
-		c.Check(lockoutAuthFile, Equals, filepath.Join(boot.InstallHostFDESaveDir, "tpm-lockout-auth"))
+		c.Check(lockoutAuthFile, Equals, device.TpmLockoutAuthUnder(boot.InstallHostFDESaveDir))
 		c.Check(mode, Equals, secboot.TPMProvisionFull)
 		return nil
 	})

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -282,7 +282,7 @@ func sealKeyToModeenvUsingSecboot(key, saveKey keys.EncryptionKey, modeenv *Mode
 	}
 
 	// we are preparing a new system, hence the TPM needs to be provisioned
-	lockoutAuthFile := filepath.Join(InstallHostFDESaveDir, "tpm-lockout-auth")
+	lockoutAuthFile := device.TpmLockoutAuthUnder(InstallHostFDESaveDir)
 	tpmProvisionMode := secboot.TPMProvisionFull
 	if flags.FactoryReset {
 		tpmProvisionMode = secboot.TPMPartialReprovision

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -24,9 +24,7 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -66,14 +64,6 @@ var (
 	RunFDESetupHook fde.RunSetupHookFunc = func(req *fde.SetupRequest) ([]byte, error) {
 		return nil, fmt.Errorf("internal error: RunFDESetupHook not set yet")
 	}
-)
-
-type sealingMethod string
-
-const (
-	sealingMethodLegacyTPM    = sealingMethod("")
-	sealingMethodTPM          = sealingMethod("tpm")
-	sealingMethodFDESetupHook = sealingMethod("fde-setup-hook")
 )
 
 // MockSecbootResealKeys is only useful in testing. Note that this is a very low
@@ -194,7 +184,7 @@ func sealKeyToModeenvUsingFDESetupHook(key, saveKey keys.EncryptionKey, modeenv 
 		return err
 	}
 
-	if err := stampSealedKeys(InstallHostWritableDir, "fde-setup-hook"); err != nil {
+	if err := device.StampSealedKeys(InstallHostWritableDir, "fde-setup-hook"); err != nil {
 		return err
 	}
 
@@ -314,7 +304,7 @@ func sealKeyToModeenvUsingSecboot(key, saveKey keys.EncryptionKey, modeenv *Mode
 		return err
 	}
 
-	if err := stampSealedKeys(InstallHostWritableDir, sealingMethodTPM); err != nil {
+	if err := device.StampSealedKeys(InstallHostWritableDir, device.SealingMethodTPM); err != nil {
 		return err
 	}
 
@@ -391,32 +381,6 @@ func sealFallbackObjectKeys(key, saveKey keys.EncryptionKey, pbc predictableBoot
 	return nil
 }
 
-func stampSealedKeys(rootdir string, content sealingMethod) error {
-	stamp := filepath.Join(dirs.SnapFDEDirUnder(rootdir), "sealed-keys")
-	if err := os.MkdirAll(filepath.Dir(stamp), 0755); err != nil {
-		return fmt.Errorf("cannot create device fde state directory: %v", err)
-	}
-
-	if err := osutil.AtomicWriteFile(stamp, []byte(content), 0644, 0); err != nil {
-		return fmt.Errorf("cannot create fde sealed keys stamp file: %v", err)
-	}
-	return nil
-}
-
-var errNoSealedKeys = errors.New("no sealed keys")
-
-// sealedKeysMethod return whether any keys were sealed at all
-func sealedKeysMethod(rootdir string) (sm sealingMethod, err error) {
-	// TODO:UC20: consider more than the marker for cases where we reseal
-	// outside of run mode
-	stamp := filepath.Join(dirs.SnapFDEDirUnder(rootdir), "sealed-keys")
-	content, err := ioutil.ReadFile(stamp)
-	if os.IsNotExist(err) {
-		return sm, errNoSealedKeys
-	}
-	return sealingMethod(content), err
-}
-
 var resealKeyToModeenv = resealKeyToModeenvImpl
 
 // resealKeyToModeenv reseals the existing encryption key to the
@@ -427,8 +391,8 @@ var resealKeyToModeenv = resealKeyToModeenvImpl
 // transient/in-memory information with the risk that successive
 // reseals during in-progress operations produce diverging outcomes.
 func resealKeyToModeenvImpl(rootdir string, modeenv *Modeenv, expectReseal bool) error {
-	method, err := sealedKeysMethod(rootdir)
-	if err == errNoSealedKeys {
+	method, err := device.SealedKeysMethod(rootdir)
+	if err == device.ErrNoSealedKeys {
 		// nothing to do
 		return nil
 	}
@@ -436,9 +400,9 @@ func resealKeyToModeenvImpl(rootdir string, modeenv *Modeenv, expectReseal bool)
 		return err
 	}
 	switch method {
-	case sealingMethodFDESetupHook:
+	case device.SealingMethodFDESetupHook:
 		return resealKeyToModeenvUsingFDESetupHook(rootdir, modeenv, expectReseal)
-	case sealingMethodTPM, sealingMethodLegacyTPM:
+	case device.SealingMethodTPM, device.SealingMethodLegacyTPM:
 		return resealKeyToModeenvSecboot(rootdir, modeenv, expectReseal)
 	default:
 		return fmt.Errorf("unknown key sealing method: %q", method)

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/snapcore/snapd/bootloader/assets"
 	"github.com/snapcore/snapd/bootloader/bootloadertest"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/gadget/device"
 	"github.com/snapcore/snapd/kernel/fde"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/secboot"
@@ -195,7 +196,7 @@ func (s *sealSuite) TestSealKeyToModeenv(c *C) {
 		provisionCalls := 0
 		restore = boot.MockSecbootProvisionTPM(func(mode secboot.TPMProvisionMode, lockoutAuthFile string) error {
 			provisionCalls++
-			c.Check(lockoutAuthFile, Equals, filepath.Join(boot.InstallHostFDESaveDir, "tpm-lockout-auth"))
+			c.Check(lockoutAuthFile, Equals, device.TpmLockoutAuthUnder(boot.InstallHostFDESaveDir))
 			if tc.factoryReset {
 				c.Check(mode, Equals, secboot.TPMPartialReprovision)
 			} else {

--- a/gadget/device/encrypt.go
+++ b/gadget/device/encrypt.go
@@ -92,3 +92,8 @@ func FallbackSaveSealedKeyUnder(seedDeviceFDEDir string) string {
 func FactoryResetFallbackSaveSealedKeyUnder(seedDeviceFDEDir string) string {
 	return filepath.Join(seedDeviceFDEDir, "ubuntu-save.recovery.sealed-key.factory-reset")
 }
+
+// TpmLockoutAuthUnder return the path of the tpm lockout authority key.
+func TpmLockoutAuthUnder(saveDeviceFDEDir string) string {
+	return filepath.Join(saveDeviceFDEDir, "tpm-lockout-auth")
+}

--- a/gadget/device/encrypt_test.go
+++ b/gadget/device/encrypt_test.go
@@ -101,4 +101,7 @@ func (s *deviceSuite) TestLocations(c *C) {
 		"/run/mnt/ubuntu-seed/device/fde/ubuntu-save.recovery.sealed-key")
 	c.Check(device.FactoryResetFallbackSaveSealedKeyUnder(boot.InitramfsSeedEncryptionKeyDir), Equals,
 		"/run/mnt/ubuntu-seed/device/fde/ubuntu-save.recovery.sealed-key.factory-reset")
+
+	c.Check(device.TpmLockoutAuthUnder(dirs.SnapFDEDirUnderSave(dirs.SnapSaveDir)), Equals,
+		"/var/lib/snapd/save/device/fde/tpm-lockout-auth")
 }

--- a/gadget/device/encrypt_test.go
+++ b/gadget/device/encrypt_test.go
@@ -105,3 +105,49 @@ func (s *deviceSuite) TestLocations(c *C) {
 	c.Check(device.TpmLockoutAuthUnder(dirs.SnapFDEDirUnderSave(dirs.SnapSaveDir)), Equals,
 		"/var/lib/snapd/save/device/fde/tpm-lockout-auth")
 }
+
+func (s *deviceSuite) TestStampSealedKeysRunthrough(c *C) {
+	root := c.MkDir()
+
+	for _, tc := range []struct {
+		mth      device.SealingMethod
+		expected string
+	}{
+		{device.SealingMethodLegacyTPM, ""},
+		{device.SealingMethodTPM, "tpm"},
+		{device.SealingMethodFDESetupHook, "fde-setup-hook"},
+	} {
+		err := device.StampSealedKeys(root, tc.mth)
+		c.Assert(err, IsNil)
+
+		mth, err := device.SealedKeysMethod(root)
+		c.Assert(err, IsNil)
+		c.Check(tc.mth, Equals, mth)
+
+		content, err := ioutil.ReadFile(filepath.Join(root, "/var/lib/snapd/device/fde/sealed-keys"))
+		c.Assert(err, IsNil)
+		c.Check(string(content), Equals, tc.expected)
+	}
+}
+
+func (s *deviceSuite) TestStampSealedKeysMissing(c *C) {
+	root := c.MkDir()
+
+	_, err := device.SealedKeysMethod(root)
+	c.Check(err, Equals, device.ErrNoSealedKeys)
+}
+
+func (s *deviceSuite) TestStampSealedKeysWrongContentDoesNotError(c *C) {
+	root := c.MkDir()
+
+	mockSealedKeyPath := filepath.Join(root, "/var/lib/snapd/device/fde/sealed-keys")
+	err := os.MkdirAll(filepath.Dir(mockSealedKeyPath), 0755)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(mockSealedKeyPath, []byte("invalid-sealing-method"), 0600)
+	c.Assert(err, IsNil)
+
+	// invalid/unknown sealing methods do not error
+	mth, err := device.SealedKeysMethod(root)
+	c.Check(err, IsNil)
+	c.Check(string(mth), Equals, "invalid-sealing-method")
+}


### PR DESCRIPTION
The DA lockout reset code will need to be able to read the
`SealedKeysMethod` so this commit moves the code to read/write
the sealing methods from `boot` to `gadget/device` (just like
we did for e.g. `{Has,Read}EncryptionMarkers`).

This is split out of PR #11935  and build on top of PR #11946 
