### PR TITLE
devicestate: add more path to `fixupWritableDefaultDirs()`

### DIFF
--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -414,7 +414,7 @@ func fixupWritableDefaultDirs(systemDataDir string) error {
 	// this restriction to let the device create one specific file, and then
 	// we behind the scenes just create the directories for the device
 
-	for _, subDirToCreate := range []string{"/etc/udev/rules.d", "/etc/modprobe.d", "/etc/modules-load.d/"} {
+	for _, subDirToCreate := range []string{"/etc/udev/rules.d", "/etc/modprobe.d", "/etc/modules-load.d/", "/etc/systemd/network"} {
 		dirToCreate := sysconfig.WritableDefaultsDir(systemDataDir, subDirToCreate)
 
 		if err := os.MkdirAll(dirToCreate, 0755); err != nil {


### PR DESCRIPTION
There is a use-case for fixupWritableDefaultDirs() to include
the dirs:
```
- /etc/systemd/network
```
to support rename to predicable network names. Eventually this
is something that snapd/netplan will support but to unblock
users this workaround is needed.
