### PR TITLE
tests: add executions for ubuntu 22.04

### DIFF
--- a/tests/main/cgroup-tracking-failure/task.yaml
+++ b/tests/main/cgroup-tracking-failure/task.yaml
@@ -12,8 +12,7 @@ systems:
     - ubuntu-14.04-*
     - ubuntu-16.04-*  # tracking works correctly, caveats apply
     - ubuntu-18.04-*
-    - ubuntu-20.04-*  # tracking works correctly, for completeness
-    - ubuntu-21*
+    - ubuntu-2*       # tracking works correctly, for completeness
     - ubuntu-core-16-*
     - ubuntu-core-18-*
     - ubuntu-core-20-*  # tracking works correctly, for completeness

--- a/tests/main/fake-netplan-apply/task.yaml
+++ b/tests/main/fake-netplan-apply/task.yaml
@@ -16,7 +16,7 @@ details: |
 systems:
     - ubuntu-16.04*
     - ubuntu-18.04*
-    - ubuntu-20.04*
+    - ubuntu-2*
 
 environment:
     NETPLAN: io.netplan.Netplan

--- a/tests/main/install-fontconfig-cache-gen/task.yaml
+++ b/tests/main/install-fontconfig-cache-gen/task.yaml
@@ -2,7 +2,7 @@ summary: Check that install works
 
 # limiting to ubuntu because we need a known fonts package
 # to install so that actual caches get generated
-systems: [ubuntu-16.04-64, ubuntu-18.04-64, ubuntu-20.04-64]
+systems: [ubuntu-16.04-64, ubuntu-18.04-64, ubuntu-2*]
 
 prepare: |
     if os.query is-xenial; then

--- a/tests/main/interfaces-libvirt/task.yaml
+++ b/tests/main/interfaces-libvirt/task.yaml
@@ -12,7 +12,7 @@ details: |
     The test uses a snap that carries a unikernel built to be run on top of qemu, boot and
     respond to ping. Once the domain is created, the test checks connectivity to the unikernel.
 
-systems: [ubuntu-20.04-64]
+systems: [ubuntu-2*]
 
 prepare: |
     # Given test user is added to the libvirt group

--- a/tests/main/interfaces-opengl-nvidia/task.yaml
+++ b/tests/main/interfaces-opengl-nvidia/task.yaml
@@ -1,6 +1,6 @@
 summary: Ensure that basic opengl works with faked nvidia
 
-systems: [ubuntu-16.04-*, ubuntu-18.04-*, ubuntu-20.04-*]
+systems: [ubuntu-16.04-*, ubuntu-18.04-*, ubuntu-2*]
 
 environment:
     NV_VERSION/stable: "123.456"

--- a/tests/main/lxd-mount-units/task.yaml
+++ b/tests/main/lxd-mount-units/task.yaml
@@ -5,7 +5,7 @@ details: |
     are correct for snapfuse.
 
 # only 20.04+, we want lxd images that come with snaps preinstalled.
-systems: [ubuntu-20*, ubuntu-21.10*]
+systems: [ubuntu-2*]
 
 restore: |
     lxd.lxc stop ubuntu --force || true

--- a/tests/main/lxd-no-fuse/task.yaml
+++ b/tests/main/lxd-no-fuse/task.yaml
@@ -1,7 +1,7 @@
 summary: Check that we can install snaps when fuse is missing in lxd
 
 # we just need a single system to verify this
-systems: [ubuntu-18.04-64]
+systems: [ubuntu-22.04-64]
 
 restore: |
     lxc delete --force my-ubuntu

--- a/tests/main/lxd-postrm-purge/task.yaml
+++ b/tests/main/lxd-postrm-purge/task.yaml
@@ -4,7 +4,7 @@ summary: Check that package remove and purge works inside LXD containers
 # couple of systems only. The postrm purge is more thoroughly checked in
 # tests/main/postrm-purge.
 # ubuntu-18.04-32: i386 is not supported by lxd
-systems: [ubuntu-18.04-64, ubuntu-20.04-*]
+systems: [ubuntu-18.04-64, ubuntu-2*]
 
 # start early
 priority: 1000

--- a/tests/main/lxd-services-smoke/task.yaml
+++ b/tests/main/lxd-services-smoke/task.yaml
@@ -11,7 +11,7 @@ details: |
   any of the above.
 
 # ubuntu-18.04-32: i386 is not supported by lxd
-systems: [ubuntu-18.04-64, ubuntu-20.04*]
+systems: [ubuntu-18.04-64, ubuntu-2*]
 
 environment:
   # apparmor_parser triggers OOM

--- a/tests/main/lxd-snapfuse/task.yaml
+++ b/tests/main/lxd-snapfuse/task.yaml
@@ -1,7 +1,7 @@
 summary: Check snapfuse works
 
 # we just need a single system to verify this
-systems: [ubuntu-18.04-64]
+systems: [ubuntu-22.04-64]
 
 restore: |
     lxc delete --force my-ubuntu

--- a/tests/main/lxd-try/task.yaml
+++ b/tests/main/lxd-try/task.yaml
@@ -1,6 +1,6 @@
 summary: Check that try command works inside lxd container
 
-systems: [ubuntu-20.04-*, ubuntu-21.10-*]
+systems: [ubuntu-2*]
 
 prepare: |
   echo "Install lxd"

--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -7,7 +7,7 @@ backends: [-autopkgtest]
 # Only run this on ubuntu 16+, lxd will not work on !ubuntu systems
 # currently nor on ubuntu 14.04
 # ubuntu-18.04-32: i386 is not supported by lxd
-systems: [ubuntu-16*, ubuntu-18.04-64, ubuntu-20*, ubuntu-core-*]
+systems: [ubuntu-16*, ubuntu-18.04-64, ubuntu-2*, ubuntu-core-*]
 
 # Start before anything else as it can take a really long time.
 priority: 1000

--- a/tests/main/special-home-can-run-classic-snaps/task.yaml
+++ b/tests/main/special-home-can-run-classic-snaps/task.yaml
@@ -1,6 +1,6 @@
 summary: Check that users with homes in /var/lib can run *classic* snaps
 
-systems: [ubuntu-20.04-64]
+systems: [ubuntu-2*]
 
 environment:
     SPECIAL_USER_NAME/jenkins: jenkins

--- a/tests/main/uc20-create-partitions-encrypt/task.yaml
+++ b/tests/main/uc20-create-partitions-encrypt/task.yaml
@@ -1,7 +1,7 @@
 summary: Integration tests for the snap-bootstrap binary
 
 # use the same system and tooling as uc20
-systems: [ubuntu-20.04-64, ubuntu-22.04-64]
+systems: [ubuntu-2*]
 
 environment:
     SNAPD_DEBUG: "1"

--- a/tests/main/uc20-create-partitions-reinstall/task.yaml
+++ b/tests/main/uc20-create-partitions-reinstall/task.yaml
@@ -1,9 +1,7 @@
 summary: Integration tests for the bootstrap.Run autodetect
 
 # use the same system and tooling as uc20
-systems:
-  - ubuntu-20.04-64
-  - ubuntu-22.04-64
+systems: [ubuntu-2*]
 
 environment:
     SNAPD_DEBUG: "1"

--- a/tests/main/uc20-create-partitions/task.yaml
+++ b/tests/main/uc20-create-partitions/task.yaml
@@ -1,7 +1,7 @@
 summary: Integration tests for the bootstrap.Run
 
 # use the same system and tooling as uc20/uc22
-systems: [ubuntu-20.04-64, ubuntu-22.04-64]
+systems: [ubuntu-2*]
 
 environment:
     SNAPD_DEBUG: "1"

--- a/tests/upgrade/sudoers-conffile-removal/task.yaml
+++ b/tests/upgrade/sudoers-conffile-removal/task.yaml
@@ -7,7 +7,7 @@ details: |
     The exact version of snapd is a bit arbitrary (anything before
     2.46 is fine).
 
-systems: [ubuntu-20.04-64]
+systems: [ubuntu-2*]
 
 execute: |
     echo "download snapd 2.45.1"


### PR DESCRIPTION
There are some tests that are not been executed in Jammy

This change adds ubuntu 2* to supported systems on spread tests
