### PR TITLE
tests: exclude centos-7 from kernel-module-load test

### DIFF
--- a/tests/main/interfaces-kernel-module-load/task.yaml
+++ b/tests/main/interfaces-kernel-module-load/task.yaml
@@ -4,6 +4,9 @@ details: |
     The kernel-module-load interface allows to statically control kernel module
     loading in a way that can be constrained via snap-declaration.
 
+# The bfq module is not present in centos7
+systems: [-centos-7-*]
+
 environment:
     SNAP_NAME: test-snapd-kernel-module-load
 


### PR DESCRIPTION
The test fails because a module is not found:

    modprobe[28208]: FATAL: Module bfq not found.

Given how hard it is to find kernel modules available on all distros,
just drop Centos7.
