### PR TITLE
tests: new remote tools - part 1

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -41,27 +41,26 @@ var (
 
 	HiddenSnapDataHomeGlob string
 
-	SnapBlobDir               string
-	SnapDataDir               string
-	SnapDataHomeGlob          string
-	SnapDownloadCacheDir      string
-	SnapAppArmorDir           string
-	SnapAppArmorAdditionalDir string
-	SnapConfineAppArmorDir    string
-	SnapSeccompBase           string
-	SnapSeccompDir            string
-	SnapMountPolicyDir        string
-	SnapUdevRulesDir          string
-	SnapKModModulesDir        string
-	SnapKModModprobeDir       string
-	LocaleDir                 string
-	SnapdSocket               string
-	SnapSocket                string
-	SnapRunDir                string
-	SnapRunNsDir              string
-	SnapRunLockDir            string
-	SnapBootstrapRunDir       string
-	SnapVoidDir               string
+	SnapBlobDir            string
+	SnapDataDir            string
+	SnapDataHomeGlob       string
+	SnapDownloadCacheDir   string
+	SnapAppArmorDir        string
+	SnapConfineAppArmorDir string
+	SnapSeccompBase        string
+	SnapSeccompDir         string
+	SnapMountPolicyDir     string
+	SnapUdevRulesDir       string
+	SnapKModModulesDir     string
+	SnapKModModprobeDir    string
+	LocaleDir              string
+	SnapdSocket            string
+	SnapSocket             string
+	SnapRunDir             string
+	SnapRunNsDir           string
+	SnapRunLockDir         string
+	SnapBootstrapRunDir    string
+	SnapVoidDir            string
 
 	SnapdMaintenanceFile string
 
@@ -361,7 +360,6 @@ func SetRootDir(rootdir string) {
 	HiddenSnapDataHomeGlob = filepath.Join(rootdir, "/home/*/", HiddenSnapDataHomeDir)
 	SnapAppArmorDir = filepath.Join(rootdir, snappyDir, "apparmor", "profiles")
 	SnapConfineAppArmorDir = filepath.Join(rootdir, snappyDir, "apparmor", "snap-confine")
-	SnapAppArmorAdditionalDir = filepath.Join(rootdir, snappyDir, "apparmor", "additional")
 	SnapDownloadCacheDir = filepath.Join(rootdir, snappyDir, "cache")
 	SnapSeccompBase = filepath.Join(rootdir, snappyDir, "seccomp")
 	SnapSeccompDir = filepath.Join(SnapSeccompBase, "bpf")

--- a/spread.yaml
+++ b/spread.yaml
@@ -755,6 +755,7 @@ prepare: |
     # Copy external tools from the subtree to the "$TESTSLIB"/tools directory
     # The idea is to have a single directory with all the testing tools
     cp -f "$TESTSLIB"/external/snapd-testing-tools/tools/* "$TESTSTOOLS"
+    cp -f "$TESTSLIB"/external/snapd-testing-tools/remote/* "$TESTSTOOLS"
 
     # ensure there are no broken snaps or the invariant test will fail later
     if command -v snap; then
@@ -991,6 +992,9 @@ suites:
 
             # Install the snapd built
             dpkg -i "$SPREAD_PATH"/../snapd_*.deb
+
+            # Configure the ssh connection to the test vm
+            remote.setup config --host localhost --port 8022 --user user1 --pass ubuntu
         prepare-each: |
             "$TESTSLIB"/prepare-restore.sh --prepare-suite-each
             tests.nested prepare
@@ -1038,6 +1042,9 @@ suites:
             # Install the snapd built
             dpkg -i "$SPREAD_PATH"/../snapd_*.deb
 
+            # Configure the ssh connection to the test vm
+            remote.setup config --host localhost --port 8022 --user user1 --pass ubuntu
+
             tests.nested prepare
             tests.nested build-image classic
         prepare-each: |
@@ -1084,6 +1091,9 @@ suites:
 
             # Install the snapd built
             dpkg -i "$SPREAD_PATH"/../snapd_*.deb
+
+            # Configure the ssh connection to the test vm
+            remote.setup config --host localhost --port 8022 --user user1 --pass ubuntu
 
             tests.nested prepare
             tests.nested build-image core

--- a/tests/bin/remote.exec
+++ b/tests/bin/remote.exec
@@ -1,0 +1,1 @@
+../lib/tools/remote.exec

--- a/tests/bin/remote.push
+++ b/tests/bin/remote.push
@@ -1,0 +1,1 @@
+../lib/tools/remote.push

--- a/tests/lib/external/snapd-testing-tools/.github/workflows/tests.yaml
+++ b/tests/lib/external/snapd-testing-tools/.github/workflows/tests.yaml
@@ -41,4 +41,4 @@ jobs:
 
     - name: Run test
       run: |
-          spread google:tests/
+          spread google:tests/ google-nested:tests/

--- a/tests/lib/external/snapd-testing-tools/remote/remote.exec
+++ b/tests/lib/external/snapd-testing-tools/remote/remote.exec
@@ -35,6 +35,7 @@ _get_cert() {
 
 remote_exec() {
     local user pass
+    local timeout=10
     while [ $# -gt 0 ]; do
         case "$1" in
             -h|--help)
@@ -47,6 +48,10 @@ remote_exec() {
                 ;;
             --pass)
                 pass="$2"
+                shift 2
+                ;;
+            --timeout)
+                timeout="$2"
                 shift 2
                 ;;
             -*)
@@ -71,7 +76,7 @@ remote_exec() {
     SSH_PASS="$(_get_pass)"
     SSH_CERT="$(_get_cert)"
 
-    $SSH_PASS ssh $SSH_CERT -p "$TESTS_REMOTE_PORT" -o ConnectTimeout=10 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "$TESTS_REMOTE_USER"@"$TESTS_REMOTE_HOST" "$@"
+    $SSH_PASS ssh $SSH_CERT -p "$TESTS_REMOTE_PORT" -o LogLevel=ERROR -o ConnectTimeout="$timeout" -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "$TESTS_REMOTE_USER"@"$TESTS_REMOTE_HOST" "$@"
 }
 
 main() {    

--- a/tests/lib/external/snapd-testing-tools/remote/remote.refresh
+++ b/tests/lib/external/snapd-testing-tools/remote/remote.refresh
@@ -1,0 +1,258 @@
+#!/bin/bash -e
+
+show_help() {
+    echo "usage: remote.refresh snap [--channel CHANNEL] <SNAPNAME>"
+    echo "usage: remote.refresh full [--channel CHANNEL]"
+    echo ""
+    echo "SNAPNAME: allowed options are: kernel, core, base, gadget, snapd or the snap name"
+    echo ""
+    echo "Available options:"
+    echo "  -h --help   show this help message."
+    echo ""
+}
+
+check_refresh_after_reboot() {
+    local refresh_channel=$1
+    local snap=$2
+
+    remote.wait-for no-ssh -n 60 --wait 2
+    remote.wait-for ssh -n 120 --wait 2
+    remote.wait-for snap-command
+    remote.retry -n 10 --wait 2  "snap info $snap | grep -q -E \"tracking: +(latest/${refresh_channel}|${refresh_channel})\""
+}
+
+check_refresh() {
+    local refresh_channel=$1
+    local snap=$2
+
+    remote.wait-for ssh -n 60 --wait 2
+    remote.wait-for snap-command
+    remote.retry -n 10 --wait 2  "snap info $snap | grep -q -E \"tracking: +(latest/${refresh_channel}|${refresh_channel})\""
+}
+
+do_refresh() {
+    local snap_name=$1
+    local refresh_channel=$2
+
+    output=$(remote.exec "sudo snap refresh --channel ${refresh_channel} $snap_name 2>&1" || echo "snapd is about to reboot the system")
+    if echo "$output" | grep -E "(no updates available|cannot refresh \"$snap_name\"|is not installed)"; then
+        echo "remote.refresh: snap \"$snap_name\" has no updates available"
+    elif echo "$output" | grep -E "snapd is about to reboot the system"; then
+        remote.exec --timeout 3 "sudo reboot" || true
+        check_refresh_after_reboot "$refresh_channel" "$snap_name"
+    else
+        check_refresh "$refresh_channel" "$snap_name"
+    fi
+}
+
+process_refresh() {
+    local snap_name=$1
+    local refresh_channel=$2
+    
+    if [ -z "$refresh_channel" ]; then
+        # Tracking is retrieved from snap info command because in old versions of
+        # snapd the tracking is not included in the snap list output
+        refresh_channel="$(remote.exec "snap info $snap_name" | grep -E '^tracking:' |  awk '{ print $2 }')"
+    fi
+
+    do_refresh "$snap_name" "$refresh_channel"
+}
+
+refresh_kernel() {
+    local refresh_channel=$1
+    local snap_name
+
+    check_ubuntu_core
+    snap_name="$(remote.exec "snap list" | grep -E '(kernel$|kernel,)' | awk '{ print $1 }')"
+    if [ -z "$snap_name" ]; then
+        echo "remote.refresh: no kernel snap to update"
+        return
+    fi
+
+    process_refresh "$snap_name" "$refresh_channel"
+}
+
+refresh_gadget() {
+    local refresh_channel=$1
+    local snap_name
+
+    check_ubuntu_core
+    snap_name="$(remote.exec "snap list" | grep -E '(gadget$|gadget,)' | awk '{ print $1 }')"
+    if [ -z "$snap_name" ]; then
+        echo "remote.refresh: no gadget snap to update"
+        return
+    fi
+    
+    process_refresh "$snap_name" "$refresh_channel"
+}
+
+refresh_snapd() {
+    local refresh_channel=$1
+    local snap_name
+
+    snap_name="$(remote.exec "snap list" | grep -E '^snapd.*(snapd$|snapd,)' | awk '{ print $1 }')"
+    if [ -z "$snap_name" ]; then
+        echo "remote.refresh: no snapd snap to update"
+        return 0
+    fi
+
+    process_refresh "$snap_name" "$refresh_channel"
+}
+
+refresh_core() {
+    local refresh_channel=$1
+    local snap_name
+
+    snap_name="$(remote.exec "snap list" | grep -E '^core.*(core$|core,)' | awk '{ print $1 }')"
+    if [ -z "$snap_name" ]; then
+        echo "remote.refresh: no core snap to update"
+        return 0
+    fi
+
+    process_refresh "$snap_name" "$refresh_channel"
+}
+
+refresh_core_base() {
+    local refresh_channel=$1
+    local base_line snap_name core_channel
+
+    if ! base_line="$(remote.exec "snap list | grep -E '^core.* (base$|base,)'")"; then
+        echo "remote.refresh: no core base snap to update"
+        return 0
+    fi
+
+    if [ "$(echo "$base_line" | wc -l)" -gt 1 ]; then
+        echo "remote.refresh: there is more than 1 core base snap to update, skipping"
+        return 0
+    fi
+
+    process_refresh "$base_line" "$refresh_channel"
+}
+
+refresh_snap() {
+    local snapname=$1
+    local refresh_channel=$2
+
+    if [ -z "$snapname" ]; then
+        echo "remote.refresh: snap name to refresh is not specified"
+        return 1
+    fi
+
+    if ! remote.exec "snap list $snapname"; then
+        echo "remote.refresh: no $snapname snap to update"
+        return 0
+    fi
+
+    snap_line="$(remote.exec "snap list $snapname" | tail -1)"
+    process_refresh "$snap_line" "$refresh_channel"
+}
+
+refresh_all() {
+    # Run update and make "|| true" to continue when the connection is closed by remote host or not any snap to update
+    remote.exec "sudo snap refresh" || true
+    remote.wait-for ssh
+}
+
+
+get_boot_id() {
+    remote.exec "cat /proc/sys/kernel/random/boot_id"
+}
+
+full_refresh() {
+    remote.wait-for auto-refresh
+    refresh_core
+    remote.wait-for auto-refresh
+    refresh_core_base
+    remote.wait-for auto-refresh
+    refresh_snapd
+    remote.wait-for auto-refresh
+    refresh_kernel
+    refresh_all
+}
+
+snap_refresh() {
+    local channel snapname
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --channel)
+                channel=$2
+                shift 2
+                ;;
+            *)
+                snapname=$1
+                shift
+                ;;
+        esac
+    done
+
+    if [ -z "$snapname" ]; then
+        echo "remote.refresh: snap name to refresh is not specified"
+        return 1
+    fi
+
+    case "$snapname" in
+        core)
+            refresh_core "$channel"
+            ;;
+        base)
+            refresh_core_base "$channel"
+            ;;
+        snapd)
+            refresh_snapd "$channel"
+            ;;
+        kernel)
+            refresh_kernel "$channel"
+            ;;
+        gadget)
+            refresh_gadget "$channel"
+            ;;
+        *)
+            refresh_snap "$snapname" "$channel"
+            ;;
+    esac
+}
+
+check_ubuntu_core() {
+    if ! remote.exec "cat /etc/os-release | grep ID=ubuntu-core"; then
+        echo "remote.refresh: this function can be used just with ubuntu core systems"
+        return 1
+    fi
+}
+
+main() {
+    if [ $# -eq 0 ]; then
+        show_help
+        exit
+    fi
+
+    local action
+    case "$1" in
+        -h|--help)
+            show_help
+            exit
+            ;;
+        full)
+            action=full_refresh
+            shift
+            ;;
+        snap)
+            action=snap_refresh
+            shift
+            ;;
+        *)
+            echo "remote.refresh: unsupported parameter $1" >&2
+            exit 1
+            ;;
+    esac
+
+    if [ -z "$(declare -f "$action")" ]; then
+        echo "remote.refresh: no such command: $action"
+        show_help
+        exit 1
+    fi
+
+    "$action" "$@"
+}
+
+main "$@"

--- a/tests/lib/external/snapd-testing-tools/remote/remote.retry
+++ b/tests/lib/external/snapd-testing-tools/remote/remote.retry
@@ -1,0 +1,59 @@
+#!/bin/bash -e
+
+show_help() {
+    echo "usage: remote.retry [--wait WAIT] [-n|--attempts ATTEMPTS] <CMD>"
+    echo ""
+    echo "Available options:"
+    echo "  -h --help   show this help message."
+    echo ""
+}
+
+remote_retry(){
+    local attempts=$1
+    local wait=$2
+    local cmd=$3
+
+    while ! remote.exec "$cmd"; do
+        attempts=$(( attempts - 1 ))
+        if [ $attempts -le 0 ]; then
+            echo "remote.retry: timed out retrying command"
+            return 1
+        fi
+        sleep "$wait"
+    done
+}
+
+main() {
+    local wait attempts cmd
+    wait=1
+    attempts=30
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            -h|--help)
+                show_help
+                exit
+                ;;
+            --wait)
+                wait=$2
+                shift 2
+                ;;
+            --attempts|-n)
+                attempts=$2
+                shift 2
+                ;;
+            *)
+                break
+                ;;
+        esac
+    done
+
+    if [ $# -eq 0 ]; then
+        echo "remote.retry: command to retry not specified"
+        return 1
+    fi
+
+    remote_retry "$attempts" "$wait" "$@"
+}
+
+main "$@"

--- a/tests/lib/external/snapd-testing-tools/remote/remote.wait-for
+++ b/tests/lib/external/snapd-testing-tools/remote/remote.wait-for
@@ -1,0 +1,197 @@
+#!/bin/bash -e
+
+show_help() {
+    echo "usage: remote.wait-for ssh [--wait WAIT] [-n|--attempts ATTEMPTS]"
+    echo "       remote.wait-for no-ssh  [--wait WAIT] [-n|--attempts ATTEMPTS]"
+    echo "       remote.wait-for snap-command [--wait WAIT] [-n|--attempts ATTEMPTS]"
+    echo "       remote.wait-for reboot [--wait WAIT] [-n|--attempts ATTEMPTS]"
+    echo "       remote.wait-for device-initialized [--wait WAIT] [-n|--attempts ATTEMPTS]"
+    echo "       remote.wait-for auto-refresh [--wait WAIT] [-n|--attempts ATTEMPTS]"
+    echo ""
+    echo "Available options:"
+    echo "  -h --help   show this help message."
+    echo ""
+}
+
+wait_for_ssh() {
+    local attempts=$1
+    local wait=$2
+
+    until remote.exec "true"; do
+        attempts=$(( attempts - 1 ))
+        if [ $attempts -le 0 ]; then
+            echo "remote.wait-for: timed out waiting for ssh connection to succeed"
+            return 1
+        fi
+        sleep "$wait"
+    done
+}
+
+wait_for_no_ssh() {
+    local attempts=$1
+    local wait=$2
+
+    while remote.exec "true"; do
+        attempts=$(( attempts - 1 ))
+        if [ $attempts -le 0 ]; then
+            echo "remote.wait-for: timed out waiting for ssh connection to fail"
+            return 1
+        fi
+        sleep "$wait"
+    done
+}
+
+
+wait_for_snap_command() {
+    local attempts=$1
+    local wait=$2
+
+    while ! remote.exec "command -v snap >/dev/null"; do
+        attempts=$(( attempts - 1 ))
+        if [ $attempts -le 0 ]; then
+            echo "remote.wait-for: timed out waiting for snap command to succeed"
+            return 1
+        fi
+        sleep "$wait"
+    done
+}
+
+get_boot_id() {
+    remote.exec "cat /proc/sys/kernel/random/boot_id"
+}
+
+wait_for_reboot() {
+    local attempts=$1
+    local wait=$2
+    local initial_boot_id=$3
+    local last_boot_id
+
+    if [ -z "$initial_boot_id" ]; then
+        echo "remote.wait-for: initial boot id not set"
+        return 1
+    fi
+
+    while [ $attempts -ge 0 ]; do
+        attempts=$(( attempts - 1 ))
+        # The get_boot_id could fail because the connection is broken due to the reboot
+        last_boot_id="$(get_boot_id)" || true
+        if [[ "$last_boot_id" =~ .*-.*-.*-.*-.* ]] && [ "$last_boot_id" != "$initial_boot_id" ]; then
+            break
+        fi
+        sleep "$wait"
+    done
+
+    [ "$last_boot_id" != "$initial_boot_id" ]
+}
+
+wait_for_device_initialized() {
+    local attempts=$1
+    local wait=$2
+
+    while ! remote.exec "snap changes" | grep -Eq "Done.*Initialize device"; do
+        attempts=$(( attempts - 1 ))
+        if [ $attempts -le 0 ]; then
+            echo "remote.wait-for: timed out waiting for device to be fully initialized. Aborting!"
+            return 1
+        fi
+        sleep "$wait"
+    done
+}
+
+wait_auto_refresh(){
+    if remote.exec "snap changes" | grep -q -E "Doing.*Auto-refresh snap.*"; then
+        remote.retry -n 120 --wait 5  "snap changes | grep \"Doing.*Auto-refresh.*\""
+        wait_for_ssh -n 120 --wait 5
+        
+        if remote.exec "snap changes" | grep "Error.*Auto-refresh.*"; then
+            echo "remote.wait-for: auto-refresh failed"
+            return 1
+        fi
+
+        remote.retry -n 120 --wait 4  "snap changes | grep \"Done.*Auto-refresh.*\""
+    fi
+}
+
+main() {
+    if [ $# -eq 0 ]; then
+        show_help
+        exit
+    fi
+
+    local action wait attempts others
+    case "$1" in
+        -h|--help)
+            show_help
+            exit
+            ;;
+        ssh)
+            action=wait_for_ssh
+            attempts=800
+            wait=1
+            shift
+            ;;
+        no-ssh)
+            action=wait_for_no_ssh
+            attempts=200
+            wait=1
+            shift
+            ;;
+        snap-command)
+            action=wait_for_snap_command
+            attempts=200
+            wait=1
+            shift
+            ;;
+        reboot)
+            action=wait_for_reboot
+            attempts=150
+            wait=5
+            shift
+            ;;
+        device-initialized)
+            action=wait_for_device_initialized
+            attempts=60
+            wait=1
+            shift
+            ;;
+        auto-refresh)
+            action=wait_auto_refresh
+            shift
+            ;;
+        *)
+            echo "remote.wait-for: unsupported parameter $1" >&2
+            exit 1
+            ;;
+    esac
+
+    if [ -z "$(declare -f "$action")" ]; then
+        echo "remote.wait-for: no such command: $action"
+        show_help
+        exit 1
+    fi
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --wait)
+                wait=$2
+                shift 2
+                ;;
+            --attempts|-n)
+                attempts=$2
+                shift 2
+                ;;
+            *)
+                if [ -z "$others" ]; then
+                    others=$1
+                else
+                    others="$others $1"
+                fi
+                shift
+                ;;
+        esac
+    done
+
+    "$action" "$attempts" "$wait" "$others"
+}
+
+main "$@"

--- a/tests/lib/external/snapd-testing-tools/setup.sh
+++ b/tests/lib/external/snapd-testing-tools/setup.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# This script is used to setup the path and other environment variables needed
+# to run the tools when the tools aren't used as part of a spread test.
+# The steps are:
+# 1. source the file: `. <PATH_TO_PROJECT>/setup.sh`
+# 2. run any tool: `retry true`
+
+PROJECT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+export PATH=$PATH:$PROJECT_DIR/tools:$PROJECT_DIR/utils:$PROJECT_DIR/remote

--- a/tests/lib/external/snapd-testing-tools/spread.yaml
+++ b/tests/lib/external/snapd-testing-tools/spread.yaml
@@ -18,9 +18,10 @@ backends:
             - ubuntu-21.10-64:
             - ubuntu-22.04-64:
             - debian-10-64:
+            - debian-11-64:
             - debian-sid-64:            
-            - fedora-34-64:
             - fedora-35-64:
+            - fedora-36-64:
             - arch-linux-64:
             - amazon-linux-2-64:
                 storage: preserve-size
@@ -28,7 +29,24 @@ backends:
                 storage: preserve-size
             - centos-8-64:
                 storage: preserve-size
+            - centos-9-64:
+                storage: preserve-size
             - opensuse-15.3-64:
+            - opensuse-15.4-64:
+            - opensuse-tumbleweed-64:
+
+    google-nested:
+        type: google
+        key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'
+        location: snapd-spread/us-east1-b
+        plan: n2-standard-2
+        halt-timeout: 2h
+        cpu-family: "Intel Cascade Lake"
+        systems:
+            - ubuntu-20.04-64:
+                  image: ubuntu-2004-64-virt-enabled
+                  storage: 20G
+                  workers: 1
 
 path: /root/snapd-testing-tools
 

--- a/tests/lib/external/snapd-testing-tools/tests/check-test-format/task.yaml
+++ b/tests/lib/external/snapd-testing-tools/tests/check-test-format/task.yaml
@@ -1,5 +1,7 @@
 summary: smoke test for the spread checker tool
 
+backends: [google]
+
 systems: [ ubuntu-20.04-64 ]
 
 prepare: |

--- a/tests/lib/external/snapd-testing-tools/tests/log-analyzer/task.yaml
+++ b/tests/lib/external/snapd-testing-tools/tests/log-analyzer/task.yaml
@@ -1,5 +1,7 @@
 summary: integration tests for log-analyzer tool
 
+backends: [google]
+
 # Github actions agents are just running in bionic and focal
 systems: [ubuntu-18.04-64, ubuntu-20.04-64]
 

--- a/tests/lib/external/snapd-testing-tools/tests/log-parser/task.yaml
+++ b/tests/lib/external/snapd-testing-tools/tests/log-parser/task.yaml
@@ -1,5 +1,7 @@
 summary: test for the log parser tool
 
+backends: [google]
+
 # Github actions agents are just running in bionic and focal
 systems: [ubuntu-18.04-64, ubuntu-20.04-64]
 

--- a/tests/lib/external/snapd-testing-tools/tests/not/task.yaml
+++ b/tests/lib/external/snapd-testing-tools/tests/not/task.yaml
@@ -1,4 +1,6 @@
 summary: test for the not tool
 
+backends: [google]
+
 execute: |
     not false && echo test | MATCH test

--- a/tests/lib/external/snapd-testing-tools/tests/os.paths/task.yaml
+++ b/tests/lib/external/snapd-testing-tools/tests/os.paths/task.yaml
@@ -1,5 +1,7 @@
 summary: smoke test for the os.paths tool
 
+backends: [google]
+
 execute: |
     os.paths --help | MATCH 'usage: os.paths snap-mount-dir, media-dir, libexec-dir'
     os.paths -h | MATCH 'usage: os.paths snap-mount-dir, media-dir, libexec-dir'

--- a/tests/lib/external/snapd-testing-tools/tests/os.query/task.yaml
+++ b/tests/lib/external/snapd-testing-tools/tests/os.query/task.yaml
@@ -1,5 +1,7 @@
 summary: smoke test for the os.query tool
 
+backends: [google]
+
 execute: |
     os.query --help | MATCH 'usage: os.query is-core, is-classic'
     os.query -h | MATCH 'usage: os.query is-core, is-classic'
@@ -8,28 +10,39 @@ execute: |
         ubuntu-14.04-64)
             os.query is-trusty
             os.query is-classic
+            os.query is-ubuntu 14.04
+            ! os.query is-ubuntu 18.04
             ! os.query is-core
             ! os.query is-s390x
             ;;
         ubuntu-16.04-64)
             os.query is-xenial
             os.query is-classic
+            os.query is-ubuntu 16.04
+            ! os.query is-ubuntu 14.04
             ! os.query is-core
             ;;
         ubuntu-18.04-32)
             os.query is-bionic
             os.query is-classic
+            os.query is-ubuntu 18.04
+            ! os.query is-ubuntu 14.04
             ! os.query is-core
             os.query is-pc-i386
             ;;       
         ubuntu-18.04-64)
             os.query is-bionic
             os.query is-classic
+            os.query is-ubuntu 18.04
+            ! os.query is-ubuntu 14.04
             ! os.query is-core
+            os.query is-pc-amd64
             ;;
         ubuntu-20.04-64)
             os.query is-focal
             os.query is-ubuntu
+            os.query is-ubuntu 20.04
+            ! os.query is-ubuntu 21.04
             ! os.query is-debian
             os.query is-classic
             ! os.query is-core
@@ -37,34 +50,47 @@ execute: |
             ! os.query is-arm
             ;;
         ubuntu-21.10-64)
-            os.query is-impish
             os.query is-classic
+            os.query is-ubuntu 21.10
+            ! os.query is-ubuntu 21.04
             ! os.query is-core
             ;;
         ubuntu-22.04-64)
             os.query is-jammy
             os.query is-classic
+            os.query is-ubuntu 22.04
+            ! os.query is-ubuntu 20.04
             ! os.query is-core
             ;;
         debian-10-64)
             os.query is-debian
-            os.query is-debian-10
+            os.query is-debian 10
+            os.query is-classic
+            ! os.query is-core
+            ;;
+        debian-11-64)
+            os.query is-debian
+            os.query is-debian 11
             os.query is-classic
             ! os.query is-core
             ;;
         debian-sid-64)
             os.query is-debian
-            os.query is-debian-sid
-            os.query is-classic
-            ! os.query is-core
-            ;;
-        fedora-34-64)
-            os.query is-fedora
+            os.query is-debian sid
             os.query is-classic
             ! os.query is-core
             ;;
         fedora-35-64)
             os.query is-fedora
+            os.query is-fedora 35
+            ! os.query is-fedora rawhide
+            os.query is-classic
+            ! os.query is-core
+            ;;
+        fedora-36-64)
+            os.query is-fedora
+            os.query is-fedora 36
+            ! os.query is-fedora rawhide
             os.query is-classic
             ! os.query is-core
             ;;
@@ -78,19 +104,38 @@ execute: |
             os.query is-classic
             ! os.query is-core
             ;;
-        centos-7-64)
-            os.query is-centos-7
+        centos-7-64)            
             os.query is-centos
+            os.query is-centos 7
             os.query is-classic
             ! os.query is-core
             ;;
-        centos-8-64)
-            os.query is-centos-8
+        centos-8-64)            
+            os.query is-centos
+            os.query is-centos 8
+            ! os.query is-core
+            ;;
+        centos-9-64)            
+            os.query is-centos 9
             os.query is-centos
             ! os.query is-core
             ;;
         opensuse-15.3-64)
             os.query is-opensuse
+            os.query is-opensuse 15.3
+            os.query is-classic
+            ! os.query is-core
+            ;;
+        opensuse-15.4-64)
+            os.query is-opensuse
+            os.query is-opensuse 15.4
+            ! os.query is-opensuse tumbleweed
+            os.query is-classic
+            ! os.query is-core
+            ;;
+        opensuse-tumbleweed-64)
+            os.query is-opensuse
+            os.query is-opensuse tumbleweed
             os.query is-classic
             ! os.query is-core
             ;;

--- a/tests/lib/external/snapd-testing-tools/tests/remote.exec/task.yaml
+++ b/tests/lib/external/snapd-testing-tools/tests/remote.exec/task.yaml
@@ -1,10 +1,13 @@
 summary: smoke test for the remote.exec tool
 
+backends: [google]
+
 # Amazon linux is skipped because no sshpass available
 systems: [-amazon-linux-*]
 
 prepare: |
     tests.pkgs install sshpass
+    remote.setup config --host localhost --port 22 --user tools-user-1 --pass tools-user-1
 
 restore: |
     tests.pkgs remove sshpass
@@ -12,9 +15,7 @@ restore: |
 
 execute: |
     remote.exec --help | MATCH 'usage: remote.exec \[--user <USER>\] \[--pass <PASS>\] <CMD>'
-    remote.exec -h | MATCH 'usage: remote.exec \[--user <USER>\] \[--pass <PASS>\] <CMD>'
-
-    remote.setup config --host localhost --port 22 --user tools-user-1 --pass tools-user-1
+    remote.exec -h | MATCH 'usage: remote.exec \[--user <USER>\] \[--pass <PASS>\] <CMD>'    
 
     remote.exec "touch testfile"
     test -f /home/tools-user-1/testfile

--- a/tests/lib/external/snapd-testing-tools/tests/remote.pull/task.yaml
+++ b/tests/lib/external/snapd-testing-tools/tests/remote.pull/task.yaml
@@ -1,10 +1,13 @@
 summary: smoke test for the remote.pull tool
 
+backends: [google]
+
 # Amazon linux is skipped because no sshpass available
 systems: [-amazon-linux-*]
 
 prepare: |
     tests.pkgs install sshpass
+    remote.setup config --host localhost --port 22 --user tools-user-1 --pass tools-user-1
 
 restore: |
     tests.pkgs remove sshpass
@@ -15,7 +18,6 @@ execute: |
     remote.pull -h | MATCH 'usage: remote.pull <REMOTE_PATH> <LOCAL_PATH>'
 
     # check basic pull 
-    remote.setup config --host localhost --port 22 --user tools-user-1 --pass tools-user-1
     touch /home/tools-user-1/testfile
     remote.pull testfile .
     test -f testfile

--- a/tests/lib/external/snapd-testing-tools/tests/remote.push/task.yaml
+++ b/tests/lib/external/snapd-testing-tools/tests/remote.push/task.yaml
@@ -1,10 +1,13 @@
 summary: smoke test for the remote.push tool
 
+backends: [google]
+
 # Amazon linux is skipped because no sshpass available
 systems: [-amazon-linux-*]
 
 prepare: |
     tests.pkgs install sshpass
+    remote.setup config --host localhost --port 22 --user tools-user-1 --pass tools-user-1
 
 restore: |
     tests.pkgs remove sshpass
@@ -15,7 +18,6 @@ execute: |
     remote.push -h | MATCH 'usage: remote.push <LOCAL_PATH> <REMOTE_PATH>'
 
     # check basic push 
-    remote.setup config --host localhost --port 22 --user tools-user-1 --pass tools-user-1
     touch testfile
     remote.push testfile "/home/tools-user-1"
     test -f /home/tools-user-1/testfile

--- a/tests/lib/external/snapd-testing-tools/tests/remote.refresh/task.yaml
+++ b/tests/lib/external/snapd-testing-tools/tests/remote.refresh/task.yaml
@@ -1,0 +1,54 @@
+summary: smoke test for the remote.wait-for tool
+
+backends: [google-nested]
+
+systems: [ubuntu-20.04-64]
+
+environment:
+    user: test
+    pass: ubuntu
+    host: localhost
+    port: 8022
+    unit: nested-vm
+    TARGET/xenial: xenial
+    TARGET/bionic: bionic
+
+prepare: |
+    if [ "$TARGET" = xenial ]; then
+        wget -O pc.img.xz https://storage.googleapis.com/snapd-spread-tests/images/booted/pc-amd64-16-stable-core_beta_2.56.2.img.xz
+    elif [ "$TARGET" = bionic ]; then
+        wget -O pc.img.xz https://storage.googleapis.com/snapd-spread-tests/images/booted/pc-amd64-18-stable-snapd_beta_2.56.2.img.xz
+    fi
+    unxz pc.img.xz
+
+    service_line="kvm -nographic -snapshot -smp 2 -m 1500 -net nic,model=virtio -net user,hostfwd=tcp::$port-:22 -serial mon:stdio $PWD/pc.img"
+    tests.systemd create-and-start-unit "$unit" "$service_line"
+
+    remote.setup config --host "$host" --port "$port" --user "$user" --pass "$pass"
+
+restore: |
+    tests.systemd stop-and-remove-unit "$unit"    
+    rm -f pc.img "$(remote.setup get-config-path)"
+
+execute: |
+    remote.refresh | MATCH 'usage: remote.refresh snap'
+    remote.refresh -h | MATCH 'usage: remote.refresh snap'
+    remote.refresh --help | MATCH 'usage: remote.refresh snap'
+
+    # check the vm already started
+    remote.wait-for ssh
+    remote.wait-for device-initialized
+    remote.wait-for snap-command
+
+    # Check waiting when reboot
+    remote.refresh full
+
+    if [ "$TARGET" = xenial ]; then
+        remote.refresh snap kernel --channel latest/beta
+        remote.wait-for auto-refresh
+        remote.refresh snap core --channel stable
+    elif [ "$TARGET" = bionic ]; then
+        remote.refresh snap kernel --channel 18/beta
+        remote.wait-for auto-refresh
+        remote.refresh snap snapd --channel stable
+    fi

--- a/tests/lib/external/snapd-testing-tools/tests/remote.retry/task.yaml
+++ b/tests/lib/external/snapd-testing-tools/tests/remote.retry/task.yaml
@@ -1,0 +1,43 @@
+summary: smoke test for the remote.retry tool
+
+backends: [google]
+
+# Amazon linux is skipped because no sshpass available
+systems: [-amazon-linux-*]
+
+prepare: |
+    tests.pkgs install sshpass
+    remote.setup config --host localhost --port 22 --user tools-user-1 --pass tools-user-1
+
+restore: |
+    tests.pkgs remove sshpass
+    rm -rf remote.setup.cfg /tmp/my-remote-retry-test
+
+execute: |
+    remote.retry --help | MATCH 'usage: remote.retry'
+    remote.retry -h | MATCH 'usage: remote.retry'
+
+    # check the positive scenario without parameters
+    remote.retry "true"
+
+    # check negative scenario
+    not remote.retry --wait 1 -attempts 2 "false"
+
+    # check the command is executed correctly
+    rm -f /tmp/my-remote-retry-test
+    remote.retry "touch /tmp/my-remote-retry-test"
+    test -f /tmp/my-remote-retry-test
+
+    # check the --attempts and --wait parameter
+    not remote.retry --wait 0.5 --attempts 5 "echo 1 >> /tmp/my-remote-retry-test && exit 1"
+    test "$(grep -c 1 /tmp/my-remote-retry-test)" = 5
+    rm -f /tmp/my-remote-retry-test
+
+    # check the -n parameter
+    not remote.retry --wait 0.5 -n 8 "echo 1 >> /tmp/my-remote-retry-test && exit 1"
+    test "$(grep -c 1 /tmp/my-remote-retry-test)" = 8
+    rm -f /tmp/my-remote-retry-test
+
+    # check errors
+    remote.retry --wait 0.5 -n 2 "false" 2>&1 | MATCH "remote.retry: timed out retrying command"
+    remote.retry 2>&1 | MATCH "remote.retry: command to retry not specified"

--- a/tests/lib/external/snapd-testing-tools/tests/remote.setup/task.yaml
+++ b/tests/lib/external/snapd-testing-tools/tests/remote.setup/task.yaml
@@ -1,5 +1,7 @@
 summary: smoke test for the remote.setup tool
 
+backends: [google]
+
 restore: |
     rm -f remote.setup.cfg my-key my-key-2
 

--- a/tests/lib/external/snapd-testing-tools/tests/remote.wait-for/task.yaml
+++ b/tests/lib/external/snapd-testing-tools/tests/remote.wait-for/task.yaml
@@ -1,0 +1,77 @@
+summary: smoke test for the remote.wait-for tool
+
+backends: [google-nested]
+
+systems: [ubuntu-20.04-64]
+
+environment:
+    user: test
+    pass: ubuntu
+    host: localhost
+    port: 8022
+    unit: nested-vm
+    TARGET/xenial: xenial
+    TARGET/bionic: bionic
+
+prepare: |
+    if [ "$TARGET" = xenial ]; then
+        wget -O pc.img.xz https://storage.googleapis.com/snapd-spread-tests/images/booted/pc-amd64-16-stable-core_beta_2.56.2.img.xz
+    elif [ "$TARGET" = bionic ]; then
+        wget -O pc.img.xz https://storage.googleapis.com/snapd-spread-tests/images/booted/pc-amd64-18-stable-snapd_beta_2.56.2.img.xz
+    fi
+    unxz pc.img.xz
+
+    service_line="kvm -nographic -snapshot -smp 2 -m 1500 -net nic,model=virtio -net user,hostfwd=tcp::$port-:22 -serial mon:stdio $PWD/pc.img"
+    tests.systemd create-and-start-unit "$unit" "$service_line"
+
+    remote.setup config --host "$host" --port "$port" --user "$user" --pass "$pass"
+
+restore: |
+    tests.systemd stop-and-remove-unit "$unit"    
+    rm -f pc.img "$(remote.setup get-config-path)"
+
+execute: |
+    remote.wait-for | MATCH 'usage: remote.wait-for ssh'
+    remote.wait-for -h | MATCH 'usage: remote.wait-for ssh'
+    remote.wait-for --help | MATCH 'usage: remote.wait-for ssh'
+
+    # check the vm already started
+    remote.wait-for ssh
+
+    # Check if the device has been initialized
+    remote.wait-for device-initialized
+
+    # Check if the device has snap command
+    remote.wait-for snap-command
+
+    # Check waiting when reboot
+    remote.exec "sudo reboot" || true
+    remote.wait-for no-ssh --wait 1 -n 20
+    remote.wait-for ssh --wait 1 -n 60
+
+    # Check waiting for reboot
+    initial_boot_id="$(remote.exec "cat /proc/sys/kernel/random/boot_id")"
+    remote.exec "sudo reboot" || true
+    remote.wait-for reboot --wait 5 -n 20 "$initial_boot_id"
+
+    # Check waiting for reboot with not enough time
+    # shellcheck disable=SC2016
+    remote.retry --wait 1 -n 10 'test -n "$(cat /proc/sys/kernel/random/boot_id)"'    
+    second_boot_id="$(remote.exec "cat /proc/sys/kernel/random/boot_id")"
+
+    remote.exec "sudo reboot" || true
+    # shellcheck disable=SC2251
+    ! remote.wait-for reboot --wait 0.5 -n 5 "$second_boot_id"
+
+    # Check again if the device has been initialized and the snap command
+    remote.wait-for device-initialized --wait 1 -n 60
+    remote.wait-for snap-command
+
+    # shellcheck disable=SC2016
+    remote.retry --wait 1 -n 10 'test -n "$(cat /proc/sys/kernel/random/boot_id)"'
+    third_boot_id="$(remote.exec "cat /proc/sys/kernel/random/boot_id")"
+
+    # Check boot ids are different
+    test "$initial_boot_id" != "$second_boot_id"
+    test "$second_boot_id" != "$third_boot_id"
+    

--- a/tests/lib/external/snapd-testing-tools/tests/repack-kernel/task.yaml
+++ b/tests/lib/external/snapd-testing-tools/tests/repack-kernel/task.yaml
@@ -1,5 +1,7 @@
 summary: tests for the repack-kernel tool
 
+backends: [google]
+
 # ubuntu-core-initramfs seems to be only available on ubuntu-20.04
 systems: [ubuntu-20.04-64]
 

--- a/tests/lib/external/snapd-testing-tools/tests/retry/task.yaml
+++ b/tests/lib/external/snapd-testing-tools/tests/retry/task.yaml
@@ -1,5 +1,7 @@
 summary: smoke test for the retry tool
 
+backends: [google]
+
 execute: |
     # Retry runs the command that was passed as argument and returns the exit
     # code of that command.

--- a/tests/lib/external/snapd-testing-tools/tests/snaps.cleanup/task.yaml
+++ b/tests/lib/external/snapd-testing-tools/tests/snaps.cleanup/task.yaml
@@ -1,5 +1,7 @@
 summary: smoke test for the snaps.cleanup tool
 
+backends: [google]
+
 systems: [ubuntu-16.04-64, ubuntu-18.04-64, ubuntu-20.04-64, ubuntu-22.04-64]
 
 execute: |

--- a/tests/lib/external/snapd-testing-tools/tests/snaps.name/task.yaml
+++ b/tests/lib/external/snapd-testing-tools/tests/snaps.name/task.yaml
@@ -1,5 +1,7 @@
 summary: smoke test for the snaps.name tool
 
+backends: [google]
+
 execute: |
     snaps.name --help | MATCH 'usage: snaps.name gadget, kernel, core'
     snaps.name -h | MATCH 'usage: snaps.name gadget, kernel, core'

--- a/tests/lib/external/snapd-testing-tools/tests/spread-manager/task.yaml
+++ b/tests/lib/external/snapd-testing-tools/tests/spread-manager/task.yaml
@@ -1,5 +1,7 @@
 summary: smoke test for the spread-manager tool
 
+backends: [google]
+
 systems: [ ubuntu-20.04-64 ]
 
 prepare: |

--- a/tests/lib/external/snapd-testing-tools/tests/spread-shellcheck/task.yaml
+++ b/tests/lib/external/snapd-testing-tools/tests/spread-shellcheck/task.yaml
@@ -1,5 +1,7 @@
 summary: smoke test for the spread-shellcheck tool
 
+backends: [google]
+
 systems: [ ubuntu-20.04-64 ]
 
 prepare: |

--- a/tests/lib/external/snapd-testing-tools/tests/tests.backup/task.yaml
+++ b/tests/lib/external/snapd-testing-tools/tests/tests.backup/task.yaml
@@ -1,5 +1,7 @@
 summary: tests for the tests.backup tool
 
+backends: [google]
+
 execute: |
     # Without any arguments a help message is printed.
     tests.backup | MATCH "usage: tests.backup prepare"

--- a/tests/lib/external/snapd-testing-tools/tests/tests.cleanup/task.yaml
+++ b/tests/lib/external/snapd-testing-tools/tests/tests.cleanup/task.yaml
@@ -1,5 +1,7 @@
 summary: tests for the tests.cleanup tool
 
+backends: [google]
+
 systems: [ubuntu-18.04-64]
 
 execute: |

--- a/tests/lib/external/snapd-testing-tools/tests/tests.pkgs/task.yaml
+++ b/tests/lib/external/snapd-testing-tools/tests/tests.pkgs/task.yaml
@@ -1,5 +1,7 @@
 summary: Smoke test for tests.pkgs tool
 
+backends: [google]
+
 execute: |
     if os.query is-core; then
         tests.pkgs -h 2>&1 | MATCH 'tests.pkgs: Ubuntu Core is not supported'

--- a/tests/lib/external/snapd-testing-tools/tests/tests.systemd/task.yaml
+++ b/tests/lib/external/snapd-testing-tools/tests/tests.systemd/task.yaml
@@ -1,0 +1,44 @@
+summary: smoke test for the tests.systemd tool
+
+backends: [google]
+
+systems: [-ubuntu-14.04-64]
+
+restore: |
+    tests.systemd stop-and-remove-unit my-test || true
+
+execute: |
+    tests.systemd | MATCH 'usage: tests.systemd create-and-start-unit'
+    tests.systemd -h | MATCH 'usage: tests.systemd create-and-start-unit'
+    tests.systemd --help | MATCH 'usage: tests.systemd create-and-start-unit'
+
+    # check a simple unit
+    tests.systemd create-and-start-unit my-test "/bin/sleep 500"
+    systemctl is-active my-test
+    tests.systemd stop-and-remove-unit my-test
+    not systemctl is-active my-test
+
+    # check the wait-for-service works when unit is inactive
+    tests.systemd create-and-start-unit my-test "/bin/sleep 5"
+    tests.systemd wait-for-service my-test active
+    tests.systemd wait-for-service my-test inactive
+    tests.systemd stop-and-remove-unit my-test
+    systemctl list-unit-files | NOMATCH my-test
+
+    # check missing parameters and start twice the same unit
+    tests.systemd create-and-start-unit 2>&1 | MATCH "tests.systemd: unit name cannot be empty"
+    tests.systemd create-and-start-unit my-test  2>&1 | MATCH "tests.systemd: unit command line cannot be empty"
+    tests.systemd create-and-start-unit my-test "/bin/sleep 5"
+    tests.systemd create-and-start-unit my-test "/bin/sleep 5" 2>&1 | MATCH "tests.systemd: unit service file already exist"
+    tests.systemd stop-and-remove-unit 2>&1 | MATCH "tests.systemd: unit name cannot be empty"
+    tests.systemd stop-and-remove-unit 2>&1 | MATCH "tests.systemd: unit name cannot be empty"
+    tests.systemd stop-and-remove-unit my-test
+
+    # check unit override
+    tests.systemd create-and-start-unit my-test "/bin/sleep 100" "[Unit]\nAfter=foo"
+    systemctl cat my-test | MATCH "^ExecStart=/bin/sleep 100$"
+    systemctl cat my-test | MATCH "^After=foo$"
+    tests.systemd stop-and-remove-unit my-test
+
+    # check a unit can be removed when it already was removed
+    tests.systemd stop-and-remove-unit my-test

--- a/tests/lib/external/snapd-testing-tools/tools/os.paths
+++ b/tests/lib/external/snapd-testing-tools/tools/os.paths
@@ -7,42 +7,27 @@ show_help() {
 }
 
 snap_mount_dir() {
-    local SNAP_MOUNT_DIR=/snap
-
-    case "$SPREAD_SYSTEM" in
-        fedora-*|amazon-*|centos-*|arch-*)
-            SNAP_MOUNT_DIR=/var/lib/snapd/snap
-            ;;
-        *)
-            ;;
-    esac
-    echo "$SNAP_MOUNT_DIR"
+    if os.query is-fedora || os.query is-amazon-linux || os.query is-centos || os.query is-arch-linux; then
+        echo "/var/lib/snapd/snap"
+    else
+        echo "/snap"
+    fi
 }
 
 media_dir() {
-    local MEDIA_DIR=/media
-
-    case "$SPREAD_SYSTEM" in
-        fedora-*|amazon-*|centos-*|arch-*|opensuse-*)
-            MEDIA_DIR=/run/media
-            ;;
-        *)
-            ;;
-    esac
-    echo "$MEDIA_DIR"
+    if os.query is-fedora || os.query is-amazon-linux || os.query is-centos || os.query is-arch-linux || os.query is-opensuse; then
+        echo "/run/media"
+    else
+        echo "/media"
+    fi
 }
 
 libexec_dir() {
-    local LIBEXEC_DIR=/usr/lib
-
-    case "$SPREAD_SYSTEM" in
-        fedora-*|amazon-*|centos-*|opensuse-tumbleweed-*)
-            LIBEXEC_DIR=/usr/libexec
-            ;;
-        *)
-            ;;
-    esac
-    echo "$LIBEXEC_DIR"
+    if os.query is-fedora || os.query is-amazon-linux || os.query is-centos || os.query is-opensuse tumbleweed; then
+        echo "/usr/libexec"
+    else
+        echo "/usr/lib"
+    fi
 }
 
 main() {

--- a/tests/lib/external/snapd-testing-tools/tools/os.query
+++ b/tests/lib/external/snapd-testing-tools/tools/os.query
@@ -3,32 +3,61 @@
 show_help() {
     echo "usage: os.query is-core, is-classic"
     echo "       os.query is-core16, is-core18, is-core20, is-core22"
-    echo "       os.query is-trusty, is-xenial, is-bionic, is-focal, is-impish, is-jammy"
-    echo "       os.query is-ubuntu, is-debian, is-fedora, is-amazon-linux, is-arch-linux, is-centos, is-centos-7, is-centos-8, is-opensuse"
-    echo "       os.query is-opensuse-tumbleweed, is-debian-sid, is-debian-11, is-debian-10"
+    echo "       os.query is-trusty, is-xenial, is-bionic, is-focal, is-jammy"
+    echo "       os.query is-ubuntu [ID], is-debian [ID], is-fedora [ID], is-amazon-linux, is-arch-linux, is-centos [ID], is-opensuse [ID]"
     echo "       os.query is-pc-amd64, is-pc-i386, is-arm, is-armhf, is-arm64, is-s390x"
     echo ""
     echo "Get general information about the current system"
 }
 
 is_core() {
-    [[ "$SPREAD_SYSTEM" == ubuntu-core-* ]]
+    # We need to check $SPREAD_SYSTEM var because in snapd the os-release file does
+    # not contain the ubuntu-core info while the system is being prepared
+    if [ -n "$SPREAD_SYSTEM" ]; then
+        [[ "$SPREAD_SYSTEM" == ubuntu-core-* ]]
+    else
+        grep -qFx 'ID=ubuntu-core' /etc/os-release
+    fi
 }
 
 is_core16() {
-    [[ "$SPREAD_SYSTEM" == ubuntu-core-16-* ]]
+    # We need to check $SPREAD_SYSTEM var because in snapd the os-release file does
+    # not contain the ubuntu-core info while the system is being prepared
+    if [ -n "$SPREAD_SYSTEM" ]; then
+        [[ "$SPREAD_SYSTEM" == ubuntu-core-16-* ]]
+    else
+        grep -qFx 'ID=ubuntu-core' /etc/os-release && grep -qFx 'VERSION_ID="16"' /etc/os-release
+    fi
 }
 
 is_core18() {
-    [[ "$SPREAD_SYSTEM" == ubuntu-core-18-* ]]
+    # We need to check $SPREAD_SYSTEM var because in snapd the os-release file does
+    # not contain the ubuntu-core info while the system is being prepared
+    if [ -n "$SPREAD_SYSTEM" ]; then
+        [[ "$SPREAD_SYSTEM" == ubuntu-core-18-* ]]
+    else
+        grep -qFx 'ID=ubuntu-core' /etc/os-release && grep -qFx 'VERSION_ID="18"' /etc/os-release
+    fi
 }
 
 is_core20() {
-    [[ "$SPREAD_SYSTEM" == ubuntu-core-20-* ]]
+    # We need to check $SPREAD_SYSTEM var because in snapd the os-release file does
+    # not contain the ubuntu-core info while the system is being prepared
+    if [ -n "$SPREAD_SYSTEM" ]; then
+        [[ "$SPREAD_SYSTEM" == ubuntu-core-20-* ]]
+    else
+        grep -qFx 'ID=ubuntu-core' /etc/os-release && grep -qFx 'VERSION_ID="20"' /etc/os-release
+    fi
 }
 
 is_core22() {
-    [[ "$SPREAD_SYSTEM" == ubuntu-core-22-* ]]
+    # We need to check $SPREAD_SYSTEM var because in snapd the os-release file does
+    # not contain the ubuntu-core info while the system is being prepared
+    if [ -n "$SPREAD_SYSTEM" ]; then
+        [[ "$SPREAD_SYSTEM" == ubuntu-core-22-* ]]
+    else
+        grep -qFx 'ID=ubuntu-core' /etc/os-release && grep -qFx 'VERSION_ID="22"' /etc/os-release
+    fi
 }
 
 is_classic() {
@@ -51,36 +80,47 @@ is_focal() {
     grep -qFx 'UBUNTU_CODENAME=focal' /etc/os-release
 }
 
-is_impish() {
-    grep -qFx 'UBUNTU_CODENAME=impish' /etc/os-release
-}
-
 is_jammy() {
     grep -qFx 'UBUNTU_CODENAME=jammy' /etc/os-release
 }
 
 is_ubuntu() {
-    grep -qFx 'ID=ubuntu' /etc/os-release || grep -qFx 'ID=ubuntu-core' /etc/os-release
+    VERSION=$1
+    if [ -z "$VERSION" ]; then
+        grep -qFx 'ID=ubuntu' /etc/os-release || grep -qFx 'ID=ubuntu-core' /etc/os-release
+    else
+        grep -qFx 'ID=ubuntu' /etc/os-release && grep -qFx "VERSION_ID=\"$VERSION\"" /etc/os-release
+    fi
 }
 
 is_debian() {
-    grep -qFx 'ID=debian' /etc/os-release
-}
-
-is_debian_10() {
-    grep -qFx 'ID=debian' /etc/os-release && grep -qFx 'VERSION_ID="10"' /etc/os-release
-}
-
-is_debian_11() {
-    grep -qFx 'ID=debian' /etc/os-release && grep -qFx 'VERSION_ID="11"' /etc/os-release
-}
-
-is_debian_sid() {
-    [[ "$SPREAD_SYSTEM" == debian-sid-* ]]
+    VERSION=$1
+    if [ -z "$VERSION" ]; then
+        grep -qFx 'ID=debian' /etc/os-release
+    elif [ "$VERSION" == "sid" ]; then
+        if [ -n "$SPREAD_SYSTEM" ]; then
+            [[ "$SPREAD_SYSTEM" == debian-sid-* ]]
+        else
+            grep -qFx 'ID=debian' /etc/os-release && grep -qE '^PRETTY_NAME=.*/sid"$' /etc/os-release
+        fi
+    else
+        grep -qFx 'ID=debian' /etc/os-release && grep -qFx "VERSION_ID=\"$VERSION\"" /etc/os-release
+    fi
 }
 
 is_fedora() {
-    grep -qFx 'ID=fedora' /etc/os-release
+    VERSION=$1
+    if [ -z "$VERSION" ]; then
+        grep -qFx 'ID=fedora' /etc/os-release
+    elif [ "$VERSION" == "rawhide" ]; then
+        if [ -n "$SPREAD_SYSTEM" ]; then
+            [[ "$SPREAD_SYSTEM" == fedora-rawhide-* ]]
+        else
+            grep -qFx 'ID=fedora' /etc/os-release && grep -qFx "REDHAT_BUGZILLA_PRODUCT_VERSION=rawhide" /etc/os-release
+        fi
+    else
+        grep -qFx 'ID=fedora' /etc/os-release && grep -qFx "VERSION_ID=$VERSION" /etc/os-release
+    fi
 }
 
 is_amazon_linux() {
@@ -88,15 +128,12 @@ is_amazon_linux() {
 }
 
 is_centos() {
-    grep -qFx 'ID="centos"' /etc/os-release
-}
-
-is_centos_7() {
-    grep -qFx 'ID="centos"' /etc/os-release && grep -qFx 'VERSION_ID="7"' /etc/os-release
-}
-
-is_centos_8() {
-    grep -qFx 'ID="centos"' /etc/os-release && grep -qFx 'VERSION_ID="8"' /etc/os-release
+    VERSION=$1
+    if [ -z "$VERSION" ]; then
+        grep -qFx 'ID="centos"' /etc/os-release
+    else
+        grep -qFx 'ID="centos"' /etc/os-release && grep -qFx "VERSION_ID=\"$VERSION\"" /etc/os-release
+    fi
 }
 
 is_arch_linux() {
@@ -104,11 +141,14 @@ is_arch_linux() {
 }
 
 is_opensuse() {
-    grep -qFx 'ID="opensuse-leap"' /etc/os-release || grep -qFx 'ID="opensuse-tumbleweed"' /etc/os-release
-}
-
-is_opensuse_tumbleweed() {
-    grep -qFx 'ID="opensuse-tumbleweed"' /etc/os-release
+    VERSION=$1
+    if [ -z "$VERSION" ]; then
+        grep -qFx 'ID="opensuse-leap"' /etc/os-release || grep -qFx 'ID="opensuse-tumbleweed"' /etc/os-release
+    elif [ "$VERSION" == "tumbleweed" ]; then
+        grep -qFx 'ID="opensuse-tumbleweed"' /etc/os-release
+    else
+        grep -qFx 'ID="opensuse-leap"' /etc/os-release && grep -qFx "VERSION_ID=\"$VERSION\"" /etc/os-release
+    fi
 }
 
 is_pc_amd64() {

--- a/tests/lib/external/snapd-testing-tools/tools/tests.pkgs
+++ b/tests/lib/external/snapd-testing-tools/tools/tests.pkgs
@@ -64,40 +64,33 @@ import_backend() {
         TOOLS_DIR="$TESTSTOOLS"
     fi
     
-    case "$1" in
-        ubuntu-core-*)
-            echo "tests.pkgs: Ubuntu Core is not supported" >&2
-            exit 1
-            ;;
-        ubuntu-*|debian-*)
-            # Disabled because when the project is imported as a submodule the
-            # source is not found failing with SC1090 and SC1091
-            #shellcheck disable=SC1090,SC1091
-            . "$TOOLS_DIR/tests.pkgs.apt.sh"
-            ;;
-        fedora-*|centos-*|redhat-*|amazon-*)
-            # Disabled because when the project is imported as a submodule the
-            # source is not found failing with SC1090 and SC1091
-            #shellcheck disable=SC1090,SC1091
-            . "$TOOLS_DIR/tests.pkgs.dnf-yum.sh"
-            ;;
-        opensuse-*)
-            # Disabled because when the project is imported as a submodule the
-            # source is not found failing with SC1090 and SC1091
-            #shellcheck disable=SC1090,SC1091
-            . "$TOOLS_DIR/tests.pkgs.zypper.sh"
-            ;;
-        arch-*)
-            # Disabled because when the project is imported as a submodule the
-            # source is not found failing with SC1090 and SC1091
-            #shellcheck disable=SC1090,SC1091
-            . "$TOOLS_DIR/tests.pkgs.pacman.sh"
-            ;;
-        *)
-            echo "tests.pkgs: cannot import packaging backend $1" >&2
-            exit 1
-            ;;
-    esac
+    if os.query is-core; then
+        echo "tests.pkgs: Ubuntu Core is not supported" >&2
+        return 1
+    elif os.query is-ubuntu || os.query is-debian; then
+        # Disabled because when the project is imported as a submodule the
+        # source is not found failing with SC1090 and SC1091
+        #shellcheck disable=SC1090,SC1091
+        . "$TOOLS_DIR/tests.pkgs.apt.sh"
+    elif os.query is-fedora || os.query is-centos || os.query is-amazon-linux; then
+        # Disabled because when the project is imported as a submodule the
+        # source is not found failing with SC1090 and SC1091
+        #shellcheck disable=SC1090,SC1091
+        . "$TOOLS_DIR/tests.pkgs.dnf-yum.sh"
+    elif os.query is-opensuse; then
+        # Disabled because when the project is imported as a submodule the
+        # source is not found failing with SC1090 and SC1091
+        #shellcheck disable=SC1090,SC1091
+        . "$TOOLS_DIR/tests.pkgs.zypper.sh"
+    elif os.query is-arch-linux; then
+        # Disabled because when the project is imported as a submodule the
+        # source is not found failing with SC1090 and SC1091
+        #shellcheck disable=SC1090,SC1091
+        . "$TOOLS_DIR/tests.pkgs.pacman.sh"
+    else
+        echo "tests.pkgs: cannot import packaging backend $1" >&2
+        return 1
+    fi
 }
 
 main() {
@@ -106,11 +99,7 @@ main() {
         exit 1
     fi
 
-    if [ -z "${SPREAD_SYSTEM:-}" ]; then
-        echo "tests.pkg: cannot manage packages without knowing SPREAD_SYSTEM" >&2
-        exit 1
-    fi
-    import_backend "$SPREAD_SYSTEM"
+    import_backend
 
     action=
     while [ $# -gt 0 ]; do

--- a/tests/lib/external/snapd-testing-tools/tools/tests.systemd
+++ b/tests/lib/external/snapd-testing-tools/tools/tests.systemd
@@ -1,0 +1,114 @@
+#!/bin/bash -e
+
+show_help() {
+    echo "usage: tests.systemd create-and-start-unit <UNIT-NAME> <UNIT-COMMAND-LINE> <UNIT-OVERRIDE>"
+    echo "       tests.systemd stop-and-remove-unit <UNIT-NAME>"
+    echo "       tests.systemd wait-for-service <UNIT-NAME> <UNIT-STATE>"
+}
+
+# Create and start a persistent systemd unit that survives reboots. Use as:
+#   systemd_create_and_start_unit "name" "my-service --args"
+# The third arg supports "overrides" which allow to customize the service
+# as needed, e.g.:
+#   systemd_create_and_start_unit "name" "start" "[Unit]\nAfter=foo"
+create_and_start_unit() {
+    local name=$1
+    local start_line=$2
+    local override=$3
+
+    if [ -z "$name" ]; then
+        echo "tests.systemd: unit name cannot be empty"
+        return 1
+    fi
+    if [ -z "$start_line" ]; then
+        echo "tests.systemd: unit command line cannot be empty"
+        return 1
+    fi
+    if [ -f "/etc/systemd/system/$name.service" ]; then
+        echo "tests.systemd: unit service file already exist"
+        return 1  
+    fi
+
+    printf '[Unit]\nDescription=Support for test %s\n[Service]\nType=simple\nExecStart=%s\n[Install]\nWantedBy=multi-user.target\n' "unknown" "$start_line" > "/etc/systemd/system/$name.service"
+    if [ -n "$override" ]; then
+        mkdir -p "/etc/systemd/system/$name.service.d"
+        # shellcheck disable=SC2059
+        printf "$override" >> "/etc/systemd/system/$name.service.d/override.conf"
+    fi
+
+    systemctl daemon-reload
+    systemctl enable "$name"
+    systemctl start "$name"
+    wait_for_service "$name"
+}
+
+stop_and_remove_unit() {
+    local name=$1
+
+    if [ -z "$name" ]; then
+        echo "tests.systemd: unit name cannot be empty"
+        return 1
+    fi
+
+    systemctl stop "$name" || true
+    systemctl disable "$name" || true
+
+    rm -f "/etc/systemd/system/$name.service"
+    rm -rf "/etc/systemd/system/$name.service.d"
+    systemctl daemon-reload
+}
+
+wait_for_service() {
+    local service_name="$1"
+    local state="${2:-active}"
+
+    if [ -z "$service_name" ]; then
+        echo "tests.systemd: unit name cannot be empty"
+        return 1
+    fi
+
+    for i in $(seq 300); do
+        if systemctl show -p ActiveState "$service_name" | grep -q "ActiveState=$state"; then
+            return
+        fi
+        # show debug output every 1min
+        if [ "$i" -gt 0 ] && [ $(( i % 60 )) = 0 ]; then
+            systemctl status "$service_name" || true
+        fi
+        sleep 1
+    done
+
+    echo "tests.systemd: service $service_name did not become $state"
+    return 1
+}
+
+main() {
+    if [ $# -eq 0 ]; then
+        show_help
+        exit 0
+    fi
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            -h|--help)
+                show_help
+                exit
+                ;;
+            *)
+                action=$(echo "$1" | tr '-' '_')
+                shift
+                break
+                ;;
+        esac
+    done
+
+    if [ -z "$(declare -f "$action")" ]; then
+        echo "tests.systemd: no such command: $action" >&2
+        show_help
+        exit 1
+    fi
+
+    "$action" "$@"
+}
+
+main "$@"

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -31,7 +31,7 @@ nested_wait_for_ssh() {
     local retry=800
     local wait=1
 
-    until nested_exec "true"; do
+    until remote.exec "true"; do
         retry=$(( retry - 1 ))
         if [ $retry -le 0 ]; then
             echo "Timed out waiting for command 'true' to succeed. Aborting!"
@@ -45,7 +45,7 @@ nested_wait_for_no_ssh() {
     local retry=200
     local wait=1
 
-    while nested_exec "true"; do
+    while remote.exec "true"; do
         retry=$(( retry - 1 ))
         if [ $retry -le 0 ]; then
             echo "Timed out waiting for command 'true' to fail. Aborting!"
@@ -61,7 +61,7 @@ nested_wait_for_snap_command() {
     local retry=200
     local wait=1
 
-    while ! nested_exec "command -v snap"; do
+    while ! remote.exec "command -v snap"; do
         retry=$(( retry - 1 ))
         if [ $retry -le 0 ]; then
             echo "Timed out waiting for command 'command -v snap' to success. Aborting!"
@@ -120,7 +120,7 @@ nested_retry_start_with_boot_errors() {
 }
 
 nested_get_boot_id() {
-    nested_exec "cat /proc/sys/kernel/random/boot_id"
+    remote.exec "cat /proc/sys/kernel/random/boot_id"
 }
 
 nested_wait_for_reboot() {
@@ -153,11 +153,11 @@ nested_uc20_transition_to_system_mode() {
 
     local current_boot_id
     current_boot_id=$(nested_get_boot_id)
-    nested_exec "sudo snap reboot --$mode $recovery_system"
+    remote.exec "sudo snap reboot --$mode $recovery_system"
     nested_wait_for_reboot "$current_boot_id"
 
     # verify we are now in the requested mode
-    if ! nested_exec "cat /proc/cmdline" | MATCH "snapd_recovery_mode=$mode"; then
+    if ! remote.exec "cat /proc/cmdline" | MATCH "snapd_recovery_mode=$mode"; then
         return 1
     fi
 
@@ -166,17 +166,17 @@ nested_uc20_transition_to_system_mode() {
 }
 
 nested_prepare_ssh() {
-    nested_exec "sudo adduser --uid 12345 --extrausers --quiet --disabled-password --gecos '' test"
-    nested_exec "echo test:ubuntu | sudo chpasswd"
-    nested_exec "echo 'test ALL=(ALL) NOPASSWD:ALL' | sudo tee /etc/sudoers.d/create-user-test"
+    remote.exec "sudo adduser --uid 12345 --extrausers --quiet --disabled-password --gecos '' test"
+    remote.exec "echo test:ubuntu | sudo chpasswd"
+    remote.exec "echo 'test ALL=(ALL) NOPASSWD:ALL' | sudo tee /etc/sudoers.d/create-user-test"
     # Check we can connect with the new test user and make sudo
-    nested_exec_as test ubuntu "sudo true"
+    remote.exec --user test --pass ubuntu "sudo true"
 
-    nested_exec "sudo adduser --extrausers --quiet --disabled-password --gecos '' external"
-    nested_exec "echo external:ubuntu | sudo chpasswd"
-    nested_exec "echo 'external ALL=(ALL) NOPASSWD:ALL' | sudo tee /etc/sudoers.d/create-user-external"
+    remote.exec "sudo adduser --extrausers --quiet --disabled-password --gecos '' external"
+    remote.exec "echo external:ubuntu | sudo chpasswd"
+    remote.exec "echo 'external ALL=(ALL) NOPASSWD:ALL' | sudo tee /etc/sudoers.d/create-user-external"
     # Check we can connect with the new external user and make sudo
-    nested_exec_as external ubuntu "sudo true"
+    remote.exec --user external --pass ubuntu "sudo true"
 }
 
 
@@ -419,22 +419,22 @@ nested_refresh_to_new_core() {
     else
         echo "Refreshing the core/snapd snap"
         if nested_is_classic_nested_system; then
-            nested_exec "sudo snap refresh core --${NEW_CHANNEL}"
-            nested_exec "snap info core" | grep -E "^tracking: +latest/${NEW_CHANNEL}"
+            remote.exec "sudo snap refresh core --${NEW_CHANNEL}"
+            remote.exec "snap info core" | grep -E "^tracking: +latest/${NEW_CHANNEL}"
         fi
 
         if nested_is_core_18_system || nested_is_core_20_system || nested_is_core_22_system; then
-            nested_exec "sudo snap refresh snapd --${NEW_CHANNEL}"
-            nested_exec "snap info snapd" | grep -E "^tracking: +latest/${NEW_CHANNEL}"
+            remote.exec "sudo snap refresh snapd --${NEW_CHANNEL}"
+            remote.exec "snap info snapd" | grep -E "^tracking: +latest/${NEW_CHANNEL}"
         else
-            CHANGE_ID=$(nested_exec "sudo snap refresh core --${NEW_CHANNEL} --no-wait")
+            CHANGE_ID=$(remote.exec "sudo snap refresh core --${NEW_CHANNEL} --no-wait")
             nested_wait_for_no_ssh
             nested_wait_for_ssh
             # wait for the refresh to be done before checking, if we check too
             # quickly then operations on the core snap like reverting, etc. may
             # fail because it will have refresh-snap change in progress
-            nested_exec "snap watch $CHANGE_ID"
-            nested_exec "snap info core" | grep -E "^tracking: +latest/${NEW_CHANNEL}"
+            remote.exec "snap watch $CHANGE_ID"
+            remote.exec "snap info core" | grep -E "^tracking: +latest/${NEW_CHANNEL}"
         fi
     fi
 }
@@ -1197,7 +1197,7 @@ nested_start_core_vm_unit() {
         # where the snap command appears, then immediately disappears and then 
         # re-appears immediately after and so the next command fails
         attempts=0
-        until nested_exec "sudo snap wait system seed.loaded"; do
+        until remote.exec "sudo snap wait system seed.loaded"; do
             attempts=$(( attempts + 1))
             if [ "$attempts" = 3 ]; then
                 echo "failed to wait for snap wait command to return successfully"
@@ -1209,7 +1209,7 @@ nested_start_core_vm_unit() {
         nested_prepare_tools
         # Wait for cloud init to be done if the system is using cloud-init
         if [ "$NESTED_USE_CLOUD_INIT" = true ]; then
-            nested_exec "retry --wait 1 -n 5 sh -c 'cloud-init status --wait'"
+            remote.exec "retry --wait 1 -n 5 sh -c 'cloud-init status --wait'"
         fi
     fi
 }
@@ -1275,8 +1275,8 @@ nested_shutdown() {
     # written become empty all of a sudden, so doing a sync here in the VM, and
     # another one in the host when done probably helps to avoid that, and at
     # least can't hurt anything
-    nested_exec "sync"
-    nested_exec "sudo shutdown now" || true
+    remote.exec "sync"
+    remote.exec "sudo shutdown now" || true
     nested_wait_for_no_ssh
     nested_force_stop_vm
     wait_for_service "$NESTED_VM" inactive
@@ -1430,69 +1430,50 @@ nested_status_vm() {
     systemctl status "$NESTED_VM" || true
 }
 
-nested_exec() {
-    sshpass -p ubuntu ssh -p "$NESTED_SSH_PORT" -o ConnectTimeout=10 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no user1@localhost "$@"
-}
-
-nested_exec_as() {
-    local USER="$1"
-    local PASSWD="$2"
-    shift 2
-    sshpass -p "$PASSWD" ssh -p "$NESTED_SSH_PORT" -o ConnectTimeout=10 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "$USER"@localhost "$@"
-}
-
 nested_prepare_tools() {
     TOOLS_PATH=/writable/test-tools
-    if ! nested_exec "test -d $TOOLS_PATH" &>/dev/null; then
-        nested_exec "sudo mkdir -p $TOOLS_PATH"
-        nested_exec "sudo chown user1:user1 $TOOLS_PATH"
+    if ! remote.exec "test -d $TOOLS_PATH" &>/dev/null; then
+        remote.exec "sudo mkdir -p $TOOLS_PATH"
+        remote.exec "sudo chown user1:user1 $TOOLS_PATH"
     fi
 
-    if ! nested_exec "test -e $TOOLS_PATH/retry" &>/dev/null; then
-        nested_copy "$TESTSTOOLS/retry"
-        nested_exec "mv retry $TOOLS_PATH/retry"
+    if ! remote.exec "test -e $TOOLS_PATH/retry" &>/dev/null; then
+        remote.push "$TESTSTOOLS/retry"
+        remote.exec "mv retry $TOOLS_PATH/retry"
     fi
 
-    if ! nested_exec "test -e $TOOLS_PATH/not" &>/dev/null; then
-        nested_copy "$TESTSTOOLS/not"
-        nested_exec "mv not $TOOLS_PATH/not"
+    if ! remote.exec "test -e $TOOLS_PATH/not" &>/dev/null; then
+        remote.push "$TESTSTOOLS/not"
+        remote.exec "mv not $TOOLS_PATH/not"
     fi
 
-    if ! nested_exec "test -e $TOOLS_PATH/MATCH" &>/dev/null; then
+    if ! remote.exec "test -e $TOOLS_PATH/MATCH" &>/dev/null; then
         . "$TESTSLIB"/spread-funcs.sh
         echo '#!/bin/bash' > MATCH_FILE
         type MATCH | tail -n +2 >> MATCH_FILE
         echo 'MATCH "$@"' >> MATCH_FILE
         chmod +x MATCH_FILE
-        nested_copy "MATCH_FILE"
-        nested_exec "mv MATCH_FILE $TOOLS_PATH/MATCH"
+        remote.push "MATCH_FILE"
+        remote.exec "mv MATCH_FILE $TOOLS_PATH/MATCH"
         rm -f MATCH_FILE
     fi
 
-    if ! nested_exec "test -e $TOOLS_PATH/NOMATCH" &>/dev/null; then
+    if ! remote.exec "test -e $TOOLS_PATH/NOMATCH" &>/dev/null; then
         . "$TESTSLIB"/spread-funcs.sh
         echo '#!/bin/bash' > NOMATCH_FILE
         type NOMATCH | tail -n +2 >> NOMATCH_FILE
         echo 'NOMATCH "$@"' >> NOMATCH_FILE
         chmod +x NOMATCH_FILE
-        nested_copy "NOMATCH_FILE"
-        nested_exec "mv NOMATCH_FILE $TOOLS_PATH/NOMATCH"
+        remote.push "NOMATCH_FILE"
+        remote.exec "mv NOMATCH_FILE $TOOLS_PATH/NOMATCH"
         rm -f NOMATCH_FILE
     fi
 
-    if ! nested_exec "grep -qE PATH=.*$TOOLS_PATH /etc/environment"; then
+    if ! remote.exec "grep -qE PATH=.*$TOOLS_PATH /etc/environment"; then
         # shellcheck disable=SC2016
-        REMOTE_PATH="$(nested_exec 'echo $PATH')"
-        nested_exec "echo PATH=$TOOLS_PATH:$REMOTE_PATH | sudo tee -a /etc/environment"
+        REMOTE_PATH="$(remote.exec 'echo $PATH')"
+        remote.exec "echo PATH=$TOOLS_PATH:$REMOTE_PATH | sudo tee -a /etc/environment"
     fi
-}
-
-nested_copy() {
-    sshpass -p ubuntu scp -P "$NESTED_SSH_PORT" -o ConnectTimeout=10 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "$@" user1@localhost:~
-}
-
-nested_copy_from_remote() {
-    sshpass -p ubuntu scp -P "$SSH_PORT" -o ConnectTimeout=10 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no user1@localhost:"$1" "$2"
 }
 
 nested_add_tty_chardev() {
@@ -1524,11 +1505,11 @@ nested_del_device() {
 
 nested_get_core_revision_for_channel() {
     local CHANNEL=$1
-    nested_exec "snap info core" | awk "/${CHANNEL}: / {print(\$4)}" | sed -e 's/(\(.*\))/\1/'
+    remote.exec "snap info core" | awk "/${CHANNEL}: / {print(\$4)}" | sed -e 's/(\(.*\))/\1/'
 }
 
 nested_get_core_revision_installed() {
-    nested_exec "snap info core" | awk "/installed: / {print(\$3)}" | sed -e 's/(\(.*\))/\1/'
+    remote.exec "snap info core" | awk "/installed: / {print(\$3)}" | sed -e 's/(\(.*\))/\1/'
 }
 
 nested_fetch_spread() {
@@ -1559,7 +1540,7 @@ nested_wait_for_device_initialized_change() {
     local retry=60
     local wait=1
 
-    while ! nested_exec "snap changes" | MATCH "Done.*Initialize device"; do
+    while ! remote.exec "snap changes" | MATCH "Done.*Initialize device"; do
         retry=$(( retry - 1 ))
         if [ $retry -le 0 ]; then
             echo "Timed out waiting for device to be fully initialized. Aborting!"

--- a/tests/lib/tools/remote.exec
+++ b/tests/lib/tools/remote.exec
@@ -1,0 +1,5 @@
+# This is a placeholder for the tool which is copied from snapd-testing-tools project
+# The tool is copied from the tests/lib/external/snapd-testing-tools/tools directory
+# while the project is being prepared
+echo "placeholder called, source tree not properly setup"
+exit 1

--- a/tests/lib/tools/remote.push
+++ b/tests/lib/tools/remote.push
@@ -1,0 +1,5 @@
+# This is a placeholder for the tool which is copied from snapd-testing-tools project
+# The tool is copied from the tests/lib/external/snapd-testing-tools/tools directory
+# while the project is being prepared
+echo "placeholder called, source tree not properly setup"
+exit 1

--- a/tests/lib/tools/tests.nested
+++ b/tests/lib/tools/tests.nested
@@ -219,38 +219,6 @@ vm() {
     esac
 }
 
-exec() {
-    local user pwd
-    while [ $# -gt 0 ]; do
-        case "$1" in
-            --user)
-                user="$2"
-                shift 2
-                ;;
-            --pwd)
-                pwd="$2"
-                shift 2
-                ;;
-            *)
-                break
-                ;;
-        esac
-    done
-    if [ -n "$user" ]; then
-        if [ -z "$pwd" ]; then
-                echo "tests.nested: password needed to execute command" >&2
-                exit 1
-        fi
-        nested_exec_as "$user" "$pwd" "$@"
-    else
-        nested_exec "$@"
-    fi    
-}
-
-copy() {
-    nested_copy "$@"
-}
-
 get() {
     if [ $# -eq 0 ]; then
         show_help

--- a/tests/nested/classic/hotplug/task.yaml
+++ b/tests/nested/classic/hotplug/task.yaml
@@ -2,31 +2,31 @@ summary: Create ubuntu classic image, install snapd and test hotplug feature
 
 prepare: |
     echo "Install snapd.deb in the nested vm"
-    tests.nested copy "${GOHOME}"/snapd_*.deb
-    tests.nested exec "sudo apt update"
-    tests.nested exec "sudo apt install -y ./snapd_*.deb"
+    remote.push "${GOHOME}"/snapd_*.deb
+    remote.exec "sudo apt update"
+    remote.exec "sudo apt install -y ./snapd_*.deb"
     
     echo "Install linux-modules-extra package as it provides ftdi_sio and usbserial kernel modules"
     #shellcheck disable=SC2016
-    tests.nested exec 'DEBIAN_FRONTEND=noninteractive sudo -E apt install -y "linux-modules-extra-$(uname -r)"'
+    remote.exec 'DEBIAN_FRONTEND=noninteractive sudo -E apt install -y "linux-modules-extra-$(uname -r)"'
 
     snap pack "$TESTSLIB"/snaps/serial-port-hotplug
-    tests.nested copy serial-port-hotplug_1.0_all.snap
+    remote.push serial-port-hotplug_1.0_all.snap
     echo "Add test user to dialout group required for ttyUSB* devices"
-    tests.nested exec "sudo usermod -a -G dialout user1"
+    remote.exec "sudo usermod -a -G dialout user1"
 
-    tests.nested exec "sudo snap install --devmode jq"
+    remote.exec "sudo snap install --devmode jq"
 
 restore: |
     rm -f /tmp/serialport{0,1}
 
 debug: |
     set +e
-    tests.nested exec "snap connections --all"
-    tests.nested exec "snap list"
-    tests.nested exec "dmesg"
-    tests.nested exec 'sudo jq -r ".data[\"hotplug-slots\"]" /var/lib/snapd/state.json'
-    tests.nested exec 'lsmod'
+    remote.exec "snap connections --all"
+    remote.exec "snap list"
+    remote.exec "dmesg"
+    remote.exec 'sudo jq -r ".data[\"hotplug-slots\"]" /var/lib/snapd/state.json'
+    remote.exec 'lsmod'
     set -e
 
 execute: |
@@ -35,23 +35,23 @@ execute: |
     #shellcheck source=tests/lib/nested.sh
     . "$TESTSLIB/nested.sh"
     
-    if tests.nested exec "udevadm info -e" | MATCH "ID_MODEL=QEMU_USB_SERIAL"; then
+    if remote.exec "udevadm info -e" | MATCH "ID_MODEL=QEMU_USB_SERIAL"; then
         echo "USB serial already registered, exiting..."
         exit 1
     fi
 
-    tests.nested exec "sudo snap install hello-world"
+    remote.exec "sudo snap install hello-world"
 
     echo "Enabling hotplug"
-    tests.nested exec "sudo snap set core experimental.hotplug=true"
+    remote.exec "sudo snap set core experimental.hotplug=true"
 
     echo "Plugging the device"
     hotplug_add_dev1
 
     # precondition checks to make sure qemu setup is correct
-    tests.nested exec "retry --wait 1 -n 5 sh -c 'udevadm info -e | MATCH ID_MODEL=QEMU_USB_SERIAL'"
+    remote.exec "retry --wait 1 -n 5 sh -c 'udevadm info -e | MATCH ID_MODEL=QEMU_USB_SERIAL'"
 
-    tests.nested exec "ls /dev/tty*" | MATCH "ttyUSB0"
+    remote.exec "ls /dev/tty*" | MATCH "ttyUSB0"
 
     echo "Checking that qemuusbserial hotplug slot is present"
     check_slot_present qemuusbserial
@@ -62,8 +62,8 @@ execute: |
     hotplug_del_dev1
 
     # precondition check to make sure qemu event was triggered correctly
-    tests.nested exec "retry --wait 1 -n 5 sh -c 'udevadm info -e | NOMATCH ID_MODEL=QEMU_USB_SERIAL'"
-    if tests.nested exec "udevadm info -e" | MATCH "ID_MODEL=QEMU_USB_SERIAL"; then
+    remote.exec "retry --wait 1 -n 5 sh -c 'udevadm info -e | NOMATCH ID_MODEL=QEMU_USB_SERIAL'"
+    if remote.exec "udevadm info -e" | MATCH "ID_MODEL=QEMU_USB_SERIAL"; then
         echo "USB serial should not be registered anymore, exiting..."
         exit 1
     fi
@@ -79,16 +79,16 @@ execute: |
     check_slot_present qemuusbserial
 
     echo "Installing test snap with serial port plug"
-    tests.nested exec "sudo snap install --dangerous serial-port-hotplug_1.0_all.snap"
+    remote.exec "sudo snap install --dangerous serial-port-hotplug_1.0_all.snap"
 
     echo "Connecting hotplug slot of the first device"
-    tests.nested exec "sudo snap connect serial-port-hotplug:serial-port :qemuusbserial"
+    remote.exec "sudo snap connect serial-port-hotplug:serial-port :qemuusbserial"
     check_slot_connected qemuusbserial
 
     echo "Veryfing serial-port permissions of the snap"
     verify_apparmor_profile "/dev/ttyUSB0"
-    tests.nested exec "/snap/bin/serial-port-hotplug.consumer write-1" | MATCH "Access to /dev/ttyUSB0 ok"
-    tests.nested exec "/snap/bin/serial-port-hotplug.consumer write-2" | MATCH "Access to /dev/ttyUSB1 failed"
+    remote.exec "/snap/bin/serial-port-hotplug.consumer write-1" | MATCH "Access to /dev/ttyUSB0 ok"
+    remote.exec "/snap/bin/serial-port-hotplug.consumer write-2" | MATCH "Access to /dev/ttyUSB1 failed"
     MATCH "write-1 on /dev/ttyUSB0" < /tmp/serialport1
 
     echo "Unplugging the device"
@@ -124,23 +124,23 @@ execute: |
     echo "Veryfing serial-port permissions of the snap, the first device is now expected on ttyUSB1"
     check_slot_device_path qemuusbserial "/dev/ttyUSB1"
     verify_apparmor_profile "/dev/ttyUSB1"
-    tests.nested exec "/snap/bin/serial-port-hotplug.consumer write-3" | MATCH "Access to /dev/ttyUSB0 failed"
-    tests.nested exec "/snap/bin/serial-port-hotplug.consumer write-4" | MATCH "Access to /dev/ttyUSB1 ok"
+    remote.exec "/snap/bin/serial-port-hotplug.consumer write-3" | MATCH "Access to /dev/ttyUSB0 failed"
+    remote.exec "/snap/bin/serial-port-hotplug.consumer write-4" | MATCH "Access to /dev/ttyUSB1 ok"
     MATCH "write-3 on /dev/ttyUSB1" < /tmp/serialport1
 
     echo "Restarting snapd should restore both hotplug slots since devices are still present"
-    tests.nested exec "sudo systemctl stop snapd.service snapd.socket"
-    tests.nested exec "sudo systemctl start snapd.service snapd.socket"
+    remote.exec "sudo systemctl stop snapd.service snapd.socket"
+    remote.exec "sudo systemctl start snapd.service snapd.socket"
     check_slot_connected qemuusbserial
     check_slot_not_gone qemuusbserial
     check_slot_present qemuusbserial-1
-    tests.nested exec "/snap/bin/serial-port-hotplug.consumer write-5" | MATCH "Access to /dev/ttyUSB1 ok"
+    remote.exec "/snap/bin/serial-port-hotplug.consumer write-5" | MATCH "Access to /dev/ttyUSB1 ok"
     MATCH "write-5 on /dev/ttyUSB1" < /tmp/serialport1
 
     echo "Unplugging first device while snapd is stopped and then starting snapd remembers the slot internally due to connection"
-    tests.nested exec "sudo systemctl stop snapd.service snapd.socket"
+    remote.exec "sudo systemctl stop snapd.service snapd.socket"
     hotplug_del_dev1
-    tests.nested exec "sudo systemctl start snapd.service snapd.socket"
+    remote.exec "sudo systemctl start snapd.service snapd.socket"
     check_slot_not_present qemuusbserial
     check_slot_gone qemuusbserial
 
@@ -152,7 +152,7 @@ execute: |
     echo "Disconnecting first slot and then unplugging the device removes the slot completely"
     # manual snap disconnect doesn't implement retry and errors out if there are conflicting changes, so wait for hotplug changes to complete
     wait_for_all_changes
-    tests.nested exec "sudo snap disconnect serial-port-hotplug:serial-port :qemuusbserial"
+    remote.exec "sudo snap disconnect serial-port-hotplug:serial-port :qemuusbserial"
     check_slot_present qemuusbserial
     hotplug_del_dev1
     check_slot_not_present qemuusbserial
@@ -170,12 +170,12 @@ execute: |
     check_slot_device_path qemuusbserial "/dev/ttyUSB0"
 
     echo "Connecting hotplug slot of the first device again"
-    tests.nested exec "sudo snap connect serial-port-hotplug:serial-port :qemuusbserial"
+    remote.exec "sudo snap connect serial-port-hotplug:serial-port :qemuusbserial"
     check_slot_connected qemuusbserial
 
-    tests.nested exec "cat /var/snap/serial-port-hotplug/common/connect-plug-done" | MATCH "/dev/ttyUSB0"
+    remote.exec "cat /var/snap/serial-port-hotplug/common/connect-plug-done" | MATCH "/dev/ttyUSB0"
 
     echo "Hotplug slot stays after removing the snap"
-    tests.nested exec "sudo snap remove serial-port-hotplug"
+    remote.exec "sudo snap remove serial-port-hotplug"
     check_slot_present qemuusbserial
     check_slot_not_gone qemuusbserial

--- a/tests/nested/classic/snapshots-with-core-refresh-revert/task.yaml
+++ b/tests/nested/classic/snapshots-with-core-refresh-revert/task.yaml
@@ -3,48 +3,48 @@ summary: test snapshots work when core snap is refreshed and reverted
 prepare: |
     echo "Configure hosts file"
     # shellcheck disable=SC2016
-    tests.nested exec 'echo "127.0.1.1 $HOSTNAME" | sudo tee /etc/hosts'
+    remote.exec 'echo "127.0.1.1 $HOSTNAME" | sudo tee /etc/hosts'
 
     echo "Install snapd and snaps on nested vm"
-    tests.nested copy "${GOHOME}"/snapd_*.deb
-    tests.nested exec "sudo apt update"
-    tests.nested exec "sudo apt install -y ./snapd_*.deb"
-    tests.nested exec "sudo snap install test-snapd-sh"
-    tests.nested exec "sudo snap install test-snapd-rsync"
+    remote.push "${GOHOME}"/snapd_*.deb
+    remote.exec "sudo apt update"
+    remote.exec "sudo apt install -y ./snapd_*.deb"
+    remote.exec "sudo snap install test-snapd-sh"
+    remote.exec "sudo snap install test-snapd-rsync"
 
 execute: |
     echo "Make sure the core in the nested vm is the correct one"
-    tests.nested exec "sudo snap refresh core --${NESTED_CORE_CHANNEL}"
+    remote.exec "sudo snap refresh core --${NESTED_CORE_CHANNEL}"
 
     echo "Use the snaps, so they create the dirs:"
-    tests.nested exec "sudo test-snapd-sh.sh -c 'true'"
-    tests.nested exec "sudo test-snapd-rsync.rsync --version >/dev/null"
+    remote.exec "sudo test-snapd-sh.sh -c 'true'"
+    remote.exec "sudo test-snapd-rsync.rsync --version >/dev/null"
     for snap in test-snapd-sh test-snapd-rsync; do
-       tests.nested exec "echo "hello versioned $snap" | sudo tee /root/snap/$snap/current/canary.txt"
-       tests.nested exec "echo "hello common $snap" | sudo tee /root/snap/$snap/common/canary.txt"
+       remote.exec "echo "hello versioned $snap" | sudo tee /root/snap/$snap/current/canary.txt"
+       remote.exec "echo "hello common $snap" | sudo tee /root/snap/$snap/common/canary.txt"
     done
 
     echo "Create snapshot, grab its id"
-    SET_ID=$( tests.nested exec "sudo snap save test-snapd-sh test-snapd-rsync" | cut -d\  -f1 | tail -n1 )
+    SET_ID=$( remote.exec "sudo snap save test-snapd-sh test-snapd-rsync" | cut -d\  -f1 | tail -n1 )
 
     echo "Delete the canary files"
-    tests.nested exec "sudo rm /root/snap/test-snapd-sh/{current,common}/canary.txt"
-    tests.nested exec "sudo rm /root/snap/test-snapd-rsync/{current,common}/canary.txt"
+    remote.exec "sudo rm /root/snap/test-snapd-sh/{current,common}/canary.txt"
+    remote.exec "sudo rm /root/snap/test-snapd-rsync/{current,common}/canary.txt"
 
     echo "When the core is refreshed the snap snapshot can be restored"
-    tests.nested exec "sudo snap refresh core --${NESTED_CORE_REFRESH_CHANNEL}"
-    tests.nested exec "sudo snap restore $SET_ID test-snapd-rsync"
-    test "$( tests.nested exec "sudo cat /root/snap/test-snapd-rsync/current/canary.txt" )" = "hello versioned test-snapd-rsync"
-    test "$( tests.nested exec "sudo cat /root/snap/test-snapd-rsync/common/canary.txt" )" = "hello common test-snapd-rsync"
-    tests.nested exec "sudo test ! -f /root/snap/test-snapd-sh/common/canary.txt"
-    tests.nested exec "sudo test ! -f /root/snap/test-snapd-sh/current/canary.txt"
+    remote.exec "sudo snap refresh core --${NESTED_CORE_REFRESH_CHANNEL}"
+    remote.exec "sudo snap restore $SET_ID test-snapd-rsync"
+    test "$( remote.exec "sudo cat /root/snap/test-snapd-rsync/current/canary.txt" )" = "hello versioned test-snapd-rsync"
+    test "$( remote.exec "sudo cat /root/snap/test-snapd-rsync/common/canary.txt" )" = "hello common test-snapd-rsync"
+    remote.exec "sudo test ! -f /root/snap/test-snapd-sh/common/canary.txt"
+    remote.exec "sudo test ! -f /root/snap/test-snapd-sh/current/canary.txt"
 
     echo "When the core is reverted the snap snapshot can be restored"
-    tests.nested exec "sudo snap revert core"
-    tests.nested exec "sudo snap restore $SET_ID test-snapd-sh"
-    test "$( tests.nested exec "sudo cat /root/snap/test-snapd-sh/current/canary.txt" )" = "hello versioned test-snapd-sh"
-    test "$( tests.nested exec "sudo cat /root/snap/test-snapd-sh/common/canary.txt" )" = "hello common test-snapd-sh"
+    remote.exec "sudo snap revert core"
+    remote.exec "sudo snap restore $SET_ID test-snapd-sh"
+    test "$( remote.exec "sudo cat /root/snap/test-snapd-sh/current/canary.txt" )" = "hello versioned test-snapd-sh"
+    test "$( remote.exec "sudo cat /root/snap/test-snapd-sh/common/canary.txt" )" = "hello common test-snapd-sh"
 
     echo "And the snapshot can be removed"
-    tests.nested exec "sudo snap forget $SET_ID"
-    tests.nested exec "sudo snap saved --id=$SET_ID" | MATCH "No snapshots found"
+    remote.exec "sudo snap forget $SET_ID"
+    remote.exec "sudo snap saved --id=$SET_ID" | MATCH "No snapshots found"

--- a/tests/nested/core/base-revert-after-boot/task.yaml
+++ b/tests/nested/core/base-revert-after-boot/task.yaml
@@ -34,13 +34,13 @@ execute: |
   snap pack "$base"/ --filename="$base"_badhook.snap
 
   echo "Wait for the system to be seeded first"
-  tests.nested exec "sudo snap wait system seed.loaded"
+  remote.exec "sudo snap wait system seed.loaded"
 
   boot_id="$(tests.nested boot-id)"
 
   echo "Install base with failing post-refresh hook"
-  tests.nested copy "$base"_badhook.snap
-  chg_id=$(tests.nested exec "sudo snap install --dangerous --no-wait ./${base}_badhook.snap")
+  remote.push "$base"_badhook.snap
+  chg_id=$(remote.exec "sudo snap install --dangerous --no-wait ./${base}_badhook.snap")
 
   echo "Wait for reboot"
   tests.nested wait-for reboot "$boot_id"
@@ -51,16 +51,16 @@ execute: |
 
   boot_id="$(tests.nested boot-id)"
   # wait for change to finish with error
-  not tests.nested exec sudo snap watch "$chg_id"
+  not remote.exec sudo snap watch "$chg_id"
   # make sure that no additional reboots have happened while the change finished
   test "$boot_id" = "$(tests.nested boot-id)"
 
   echo "Check that change finished with failure and that the old snap is being used"
-  tests.nested exec "snap info $base | MATCH 'installed:.*\(x1\)'"
-  tests.nested exec "snap changes | MATCH \"^$chg_id.*Error\""
+  remote.exec "snap info $base | MATCH 'installed:.*\(x1\)'"
+  remote.exec "snap changes | MATCH \"^$chg_id.*Error\""
 
   if [ "$VERSION" -ge 20 ]; then
-      modeenv_data=$(tests.nested exec 'cat /var/lib/snapd/modeenv')
+      modeenv_data=$(remote.exec 'cat /var/lib/snapd/modeenv')
       if ! [[ "$modeenv_data" == *base=${base}_x1.snap* ]]; then
               echo "Incorrect base in modeenv: $modeenv_data"
               exit 1
@@ -78,8 +78,8 @@ execute: |
       if [ "$VERSION" -eq 16 ]; then
           SNAP=core
       fi
-      tests.nested exec "cat /boot/grub/grubenv | MATCH \"^snap_core=${SNAP}_x1.snap$\""
-      tests.nested exec 'cat /boot/grub/grubenv | MATCH "^snap_mode=$"'
-      tests.nested exec 'cat /boot/grub/grubenv | MATCH "^snap_try_core=$"'
-      tests.nested exec "cat /proc/cmdline | MATCH snap_core=${SNAP}_x1.snap"
+      remote.exec "cat /boot/grub/grubenv | MATCH \"^snap_core=${SNAP}_x1.snap$\""
+      remote.exec 'cat /boot/grub/grubenv | MATCH "^snap_mode=$"'
+      remote.exec 'cat /boot/grub/grubenv | MATCH "^snap_try_core=$"'
+      remote.exec "cat /proc/cmdline | MATCH snap_core=${SNAP}_x1.snap"
   fi

--- a/tests/nested/core/core-revert/task.yaml
+++ b/tests/nested/core/core-revert/task.yaml
@@ -31,8 +31,8 @@ execute: |
     fi
 
     echo "Refresh the core snap to $NESTED_CORE_REFRESH_CHANNEL channel"
-    tests.nested exec "snap info core" | MATCH "tracking: +latest/${NESTED_CORE_CHANNEL}"
-    tests.nested exec "sudo snap refresh --${NESTED_CORE_REFRESH_CHANNEL} core" || true
+    remote.exec "snap info core" | MATCH "tracking: +latest/${NESTED_CORE_CHANNEL}"
+    remote.exec "sudo snap refresh --${NESTED_CORE_REFRESH_CHANNEL} core" || true
 
     if ! tests.nested wait-for ssh; then
         echo "ssh not stablished, exiting..."
@@ -40,14 +40,14 @@ execute: |
     fi
 
     echo "Wait until the refresh is completed"
-    tests.nested exec "retry --wait 1 -n 180 --env NESTED_CORE_REFRESH_CHANNEL=$NESTED_CORE_REFRESH_CHANNEL sh -c 'snap changes | MATCH "Done.*Refresh \"core\" snap from \""${NESTED_CORE_REFRESH_CHANNEL}"\" channel"'"
-    tests.nested exec "snap info core" | MATCH "tracking: +latest/${NESTED_CORE_REFRESH_CHANNEL}"
+    remote.exec "retry --wait 1 -n 180 --env NESTED_CORE_REFRESH_CHANNEL=$NESTED_CORE_REFRESH_CHANNEL sh -c 'snap changes | MATCH "Done.*Refresh \"core\" snap from \""${NESTED_CORE_REFRESH_CHANNEL}"\" channel"'"
+    remote.exec "snap info core" | MATCH "tracking: +latest/${NESTED_CORE_REFRESH_CHANNEL}"
 
     echo "Precondition check, no refresh should be done here but the command shouldn't fail"
-    tests.nested exec "sudo snap refresh"
+    remote.exec "sudo snap refresh"
 
     echo "Revert the core snap"
-    tests.nested exec "sudo snap revert core" || true
+    remote.exec "sudo snap revert core" || true
 
     if ! tests.nested wait-for ssh; then
         echo "ssh not stablished, exiting..."
@@ -55,12 +55,12 @@ execute: |
     fi
 
     echo "Wait until the revert is completed"
-    tests.nested exec "retry --wait 1 -n 180 sh -c 'snap changes" | MATCH "Done.*Revert \"core\" snap'"
+    remote.exec "retry --wait 1 -n 180 sh -c 'snap changes" | MATCH "Done.*Revert \"core\" snap'"
 
     echo "Check the revert was done properly"
-    tests.nested exec "snap info core" | MATCH "tracking: +latest/${NESTED_CORE_REFRESH_CHANNEL}"
-    tests.nested exec "ifconfig" | MATCH eth0
+    remote.exec "snap info core" | MATCH "tracking: +latest/${NESTED_CORE_REFRESH_CHANNEL}"
+    remote.exec "ifconfig" | MATCH eth0
 
 
-    tests.nested exec "sudo snap refresh"
-    tests.nested exec "sudo cat /var/log/syslog" | NOMATCH "hsearch_r failed for.* No such process"
+    remote.exec "sudo snap refresh"
+    remote.exec "sudo cat /var/log/syslog" | NOMATCH "hsearch_r failed for.* No such process"

--- a/tests/nested/core/core-snap-refresh-on-core/task.yaml
+++ b/tests/nested/core/core-snap-refresh-on-core/task.yaml
@@ -17,21 +17,21 @@ execute: |
     fi
 
     echo "Install test snap"
-    tests.nested exec "sudo snap install test-snapd-sh"
+    remote.exec "sudo snap install test-snapd-sh"
 
     echo "Ensure we have a good starting place"
-    tests.nested exec "test-snapd-sh.sh -c 'echo hello'" | MATCH hello
+    remote.exec "test-snapd-sh.sh -c 'echo hello'" | MATCH hello
 
     echo "Go to known good starting place"
-    tests.nested exec "snap download core --${NESTED_CORE_CHANNEL}"
-    tests.nested exec "sudo snap ack core_*.assert"
-    tests.nested exec "sudo snap install core_*.snap"
+    remote.exec "snap download core --${NESTED_CORE_CHANNEL}"
+    remote.exec "sudo snap ack core_*.assert"
+    remote.exec "sudo snap install core_*.snap"
 
     echo "Check the initial core is installed and snaps can be executed"
     test "$(tests.nested snap-rev core)" = "${INITIAL_REV}"
 
     echo "Ensure test-snapd-sh works"
-    tests.nested exec "test-snapd-sh.sh -c 'echo hello'" | MATCH hello
+    remote.exec "test-snapd-sh.sh -c 'echo hello'" | MATCH hello
 
     echo "Refresh core snap to $NESTED_CORE_REFRESH_CHANNEL"
     refresh_to_new_core "$NESTED_CORE_REFRESH_CHANNEL"
@@ -40,10 +40,10 @@ execute: |
     test "$(tests.nested snap-rev core)" = "${NEW_REV}"
 
     echo "Ensure test-snapd-sh works"
-    tests.nested exec "test-snapd-sh.sh -c 'echo hello'" | MATCH hello
+    remote.exec "test-snapd-sh.sh -c 'echo hello'" | MATCH hello
 
     echo "Revert core"
-    tests.nested exec "sudo snap revert core" || true
+    remote.exec "sudo snap revert core" || true
     tests.nested wait-for no-ssh
     nested_tests.nested wait-for ssh
 
@@ -51,4 +51,4 @@ execute: |
     test "$(tests.nested snap-rev core)" = "${INITIAL_REV}"
 
     echo "Ensure test-snapd-sh works"
-    tests.nested exec "test-snapd-sh.sh -c 'echo hello'" | MATCH hello
+    remote.exec "test-snapd-sh.sh -c 'echo hello'" | MATCH hello

--- a/tests/nested/core/core20-basic/task.yaml
+++ b/tests/nested/core/core20-basic/task.yaml
@@ -7,88 +7,88 @@ systems: [ubuntu-20.04-64]
 
 execute: |
     echo "Wait for the system to be seeded first"
-    tests.nested exec "sudo snap wait system seed.loaded"
+    remote.exec "sudo snap wait system seed.loaded"
 
     echo "Wait for device initialisation to be done"
-    tests.nested exec "retry --wait 5 -n 10 sh -c 'snap changes | MATCH \"Done.*Initialize device\"'"
+    remote.exec "retry --wait 5 -n 10 sh -c 'snap changes | MATCH \"Done.*Initialize device\"'"
 
     echo "Ensure 'snap install' works"
     # The install command could cause a ssh break, so || true is used
     # and then we check the installation was completed successfully
-    tests.nested exec "sudo snap install test-snapd-sh" || true
+    remote.exec "sudo snap install test-snapd-sh" || true
 
     echo "Ensure 'snap list' works and test-snapd-sh snap is installed"
-    tests.nested exec "snap list" | MATCH test-snapd-sh
+    remote.exec "snap list" | MATCH test-snapd-sh
 
     echo "Ensure 'snap find' works"
-    tests.nested exec "snap find test-snapd-sh" | MATCH ^test-snapd-sh
+    remote.exec "snap find test-snapd-sh" | MATCH ^test-snapd-sh
 
     echo "Ensure 'snap info' works"
-    tests.nested exec "snap info test-snapd-sh" | MATCH '^name:\ +test-snapd-sh'
+    remote.exec "snap info test-snapd-sh" | MATCH '^name:\ +test-snapd-sh'
 
     echo "Ensure 'snap remove' works"
     # The install command could cause a ssh break, so || true is used
     # and then we check the removal was completed successfully
-    tests.nested exec "sudo snap remove test-snapd-sh" || true
+    remote.exec "sudo snap remove test-snapd-sh" || true
 
     echo "Ensure 'snap list' works and test-snapd-sh snap is removed"
-    tests.nested exec "! snap list test-snapd-sh"
+    remote.exec "! snap list test-snapd-sh"
 
     echo "Ensure that recovery keys are not present in fresh install"
-    tests.nested exec "test ! -f /var/lib/snapd/device/fde/recovery.key"
-    tests.nested exec "test ! -f /var/lib/snapd/device/fde/reinstall.key"
+    remote.exec "test ! -f /var/lib/snapd/device/fde/recovery.key"
+    remote.exec "test ! -f /var/lib/snapd/device/fde/reinstall.key"
 
     # single key for ubuntu-data and ubuntu-save
-    test "$(tests.nested exec "sudo cryptsetup luksDump /dev/vda4 |grep Key:" | wc -l)" = "1"
-    test "$(tests.nested exec "sudo cryptsetup luksDump /dev/vda5 |grep Key:" | wc -l)" = "1"
+    test "$(remote.exec "sudo cryptsetup luksDump /dev/vda4 |grep Key:" | wc -l)" = "1"
+    test "$(remote.exec "sudo cryptsetup luksDump /dev/vda5 |grep Key:" | wc -l)" = "1"
 
     echo "Ensure 'snap debug show-keys' works as root"
-    tests.nested exec "sudo snap recovery --show-keys" > show-keys.out
+    remote.exec "sudo snap recovery --show-keys" > show-keys.out
     MATCH 'recovery:\s+[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}' < show-keys.out
     # reinstall key is not generated anymore
     # show-keys should be idempotent, so let's call it multiple times
-    tests.nested exec "sudo snap recovery --show-keys" > show-keys-again.out
+    remote.exec "sudo snap recovery --show-keys" > show-keys-again.out
     # outputs are identical
     diff -u show-keys.out show-keys-again.out
 
     # key files are present
-    tests.nested exec "test -f /var/lib/snapd/device/fde/recovery.key"
-    tests.nested exec "test ! -f /var/lib/snapd/device/fde/reinstall.key"
+    remote.exec "test -f /var/lib/snapd/device/fde/recovery.key"
+    remote.exec "test ! -f /var/lib/snapd/device/fde/reinstall.key"
     # and each partition has 2 keys now
-    test "$(tests.nested exec "sudo cryptsetup luksDump /dev/vda4 |grep Key:" | wc -l)" = "2"
-    test "$(tests.nested exec "sudo cryptsetup luksDump /dev/vda5 |grep Key:" | wc -l)" = "2"
+    test "$(remote.exec "sudo cryptsetup luksDump /dev/vda4 |grep Key:" | wc -l)" = "2"
+    test "$(remote.exec "sudo cryptsetup luksDump /dev/vda5 |grep Key:" | wc -l)" = "2"
 
     echo "But not as user (normal file permissions prevent this)"
-    if tests.nested exec "snap recovery --show-keys"; then
+    if remote.exec "snap recovery --show-keys"; then
         echo "snap recovery --show-keys should not work as a user"
         exit 1
     fi
 
     # the remove API isn't exposed by snap recovery yet
-    tests.nested exec "sudo snap install --devmode --edge test-snapd-curl"
-    tests.nested exec "sudo test-snapd-curl.curl --unix-socket /run/snapd.socket -D- -d '{\"action\":\"remove\"}' http://localhost/v2/system-recovery-keys"
+    remote.exec "sudo snap install --devmode --edge test-snapd-curl"
+    remote.exec "sudo test-snapd-curl.curl --unix-socket /run/snapd.socket -D- -d '{\"action\":\"remove\"}' http://localhost/v2/system-recovery-keys"
 
     # keys were removed
-    tests.nested exec "test ! -f /var/lib/snapd/device/fde/recovery.key"
-    tests.nested exec "test ! -f /var/lib/snapd/device/fde/reinstall.key"
+    remote.exec "test ! -f /var/lib/snapd/device/fde/recovery.key"
+    remote.exec "test ! -f /var/lib/snapd/device/fde/reinstall.key"
     # back to having just one key
-    test "$(tests.nested exec "sudo cryptsetup luksDump /dev/vda4 |grep Key:" | wc -l)" = "1"
-    test "$(tests.nested exec "sudo cryptsetup luksDump /dev/vda5 |grep Key:" | wc -l)" = "1"
+    test "$(remote.exec "sudo cryptsetup luksDump /dev/vda4 |grep Key:" | wc -l)" = "1"
+    test "$(remote.exec "sudo cryptsetup luksDump /dev/vda5 |grep Key:" | wc -l)" = "1"
 
     echo "Check that the serial backed up to save is as expected"
-    tests.nested exec 'cat /var/lib/snapd/save/device/asserts-v0/serial/'"$(tests.nested get model-authority)"'/pc/*/active' >serial.saved
-    tests.nested exec snap model --serial --assertion >serial
+    remote.exec 'cat /var/lib/snapd/save/device/asserts-v0/serial/'"$(tests.nested get model-authority)"'/pc/*/active' >serial.saved
+    remote.exec snap model --serial --assertion >serial
     cmp serial serial.saved
 
     echo "Check that we go the install log after the transition to run mode"
-    tests.nested exec "test -e /var/log/install-mode.log.gz"
+    remote.exec "test -e /var/log/install-mode.log.gz"
 
     echo "Transparently verify that the format is gzip"
-    tests.nested exec "zcat /var/log/install-mode.log.gz" | MATCH 'installing a new system'
+    remote.exec "zcat /var/log/install-mode.log.gz" | MATCH 'installing a new system'
 
     echo "Check that we go the timings after the transition to run mode"
-    tests.nested exec "test -e /var/log/install-timings.txt.gz"
-    tests.nested exec "zcat /var/log/install-timings.txt.gz" > install-timings.txt
+    remote.exec "test -e /var/log/install-timings.txt.gz"
+    remote.exec "zcat /var/log/install-timings.txt.gz" > install-timings.txt
     MATCH "Install the system"        < install-timings.txt
     MATCH "^seed"                     < install-timings.txt
     MATCH "Mark system seeded"        < install-timings.txt
@@ -96,5 +96,5 @@ execute: |
     MATCH "ensure=install-system"     < install-timings.txt
 
     echo "Check seeding info"
-    tests.nested exec "snap debug seeding" | MATCH "^seeded: +true"
-    tests.nested exec "snap debug seeding" | MATCH "^preseeded: +false"
+    remote.exec "snap debug seeding" | MATCH "^seeded: +true"
+    remote.exec "snap debug seeding" | MATCH "^preseeded: +false"

--- a/tests/nested/core/core20-create-recovery/task.yaml
+++ b/tests/nested/core/core20-create-recovery/task.yaml
@@ -3,37 +3,37 @@ summary: verify creating recovery system on UC20
 systems: [ubuntu-20.04-64, ubuntu-22.04-64]
 
 prepare: |
-    tests.nested exec sudo snap install test-snapd-curl --edge --devmode
+    remote.exec sudo snap install test-snapd-curl --edge --devmode
 
 execute: |
     echo "Create a recovery system with a typical recovery system label"
     boot_id="$( tests.nested boot-id )"
     echo '{"action":"create-recovery-system","params":{"recovery-system-label":"1234"}}' | \
-        tests.nested exec sudo test-snapd-curl.curl -X POST -d @- --unix-socket /run/snapd.socket http://localhost/v2/debug > change.out
+        remote.exec sudo test-snapd-curl.curl -X POST -d @- --unix-socket /run/snapd.socket http://localhost/v2/debug > change.out
     REMOTE_CHG_ID=$(jq -r .change < change.out)
     tests.nested wait-for reboot "${boot_id}"
-    tests.nested exec sudo snap watch "${REMOTE_CHG_ID}"
+    remote.exec sudo snap watch "${REMOTE_CHG_ID}"
 
     echo "Verify the system is back in run mode"
-    tests.nested exec "sudo cat /proc/cmdline" | MATCH snapd_recovery_mode=run
+    remote.exec "sudo cat /proc/cmdline" | MATCH snapd_recovery_mode=run
 
-    tests.nested exec "test -f /run/mnt/ubuntu-seed/systems/1234/model"
-    tests.nested exec "sudo cat /var/lib/snapd/modeenv" > modeenv
+    remote.exec "test -f /run/mnt/ubuntu-seed/systems/1234/model"
+    remote.exec "sudo cat /var/lib/snapd/modeenv" > modeenv
     MATCH 'current_recovery_systems=.*,1234' < modeenv
     MATCH 'good_recovery_systems=.*,1234' < modeenv
 
     echo "Create a recovery system with an alternative recovery system label"
     boot_id="$( tests.nested boot-id )"
     echo '{"action":"create-recovery-system","params":{"recovery-system-label":"1234-1"}}' | \
-        tests.nested exec sudo test-snapd-curl.curl -X POST -d @- --unix-socket /run/snapd.socket http://localhost/v2/debug > change.out
+        remote.exec sudo test-snapd-curl.curl -X POST -d @- --unix-socket /run/snapd.socket http://localhost/v2/debug > change.out
     REMOTE_CHG_ID=$(jq -r .change < change.out)
     tests.nested wait-for reboot "${boot_id}"
-    tests.nested exec sudo snap watch "${REMOTE_CHG_ID}"
+    remote.exec sudo snap watch "${REMOTE_CHG_ID}"
 
     echo "Verify the system is back in run mode again"
-    tests.nested exec "sudo cat /proc/cmdline" | MATCH snapd_recovery_mode=run
+    remote.exec "sudo cat /proc/cmdline" | MATCH snapd_recovery_mode=run
 
-    tests.nested exec "test -f /run/mnt/ubuntu-seed/systems/1234-1/model"
-    tests.nested exec "sudo cat /var/lib/snapd/modeenv" > modeenv
+    remote.exec "test -f /run/mnt/ubuntu-seed/systems/1234-1/model"
+    remote.exec "sudo cat /var/lib/snapd/modeenv" > modeenv
     MATCH 'current_recovery_systems=.*,1234-1' < modeenv
     MATCH 'good_recovery_systems=.*,1234-1' < modeenv

--- a/tests/nested/core/core20-degraded/task.yaml
+++ b/tests/nested/core/core20-degraded/task.yaml
@@ -8,41 +8,41 @@ environment:
 execute: |
   # wait for the system to be seeded first
   tests.nested wait-for snap-command
-  tests.nested exec "sudo snap wait system seed.loaded"
+  remote.exec "sudo snap wait system seed.loaded"
 
   echo "Install jq in the host environment"
   snap install jq
   tests.cleanup defer snap remove jq
 
   echo "Move the run key for ubuntu-save out of the way so we use the fallback key to unlock ubuntu-save"
-  tests.nested exec "sudo mv /run/mnt/data/system-data/var/lib/snapd/device/fde/ubuntu-save.key /run/mnt/data/system-data/var/lib/snapd/device/fde/ubuntu-save.key.bk"
+  remote.exec "sudo mv /run/mnt/data/system-data/var/lib/snapd/device/fde/ubuntu-save.key /run/mnt/data/system-data/var/lib/snapd/device/fde/ubuntu-save.key.bk"
 
-  recoverySystem=$(tests.nested exec "sudo snap recovery | grep -v Notes | grep -Po '^[0-9]+'")
+  recoverySystem=$(remote.exec "sudo snap recovery | grep -v Notes | grep -Po '^[0-9]+'")
 
   echo "Transition to recover mode"
   tests.nested transition "$recoverySystem" recover
 
   tests.nested wait-for snap-command
-  tests.nested exec "sudo snap wait system seed.loaded"
+  remote.exec "sudo snap wait system seed.loaded"
 
   echo "Check degraded.json exists and has the unlock-key for ubuntu-save as the fallback key"
-  tests.nested exec "test -f $DEGRADED_JSON"
-  test "$(tests.nested exec "cat $DEGRADED_JSON" | jq -r '."ubuntu-save" | ."unlock-key"')" = fallback
+  remote.exec "test -f $DEGRADED_JSON"
+  test "$(remote.exec "cat $DEGRADED_JSON" | jq -r '."ubuntu-save" | ."unlock-key"')" = fallback
 
   echo "Move the run object key for ubuntu-save back and go back to run mode"
-  tests.nested exec "sudo mv /run/mnt/host/ubuntu-data/system-data/var/lib/snapd/device/fde/ubuntu-save.key.bk /run/mnt/host/ubuntu-data/system-data/var/lib/snapd/device/fde/ubuntu-save.key"
+  remote.exec "sudo mv /run/mnt/host/ubuntu-data/system-data/var/lib/snapd/device/fde/ubuntu-save.key.bk /run/mnt/host/ubuntu-data/system-data/var/lib/snapd/device/fde/ubuntu-save.key"
   tests.nested transition "$recoverySystem" run
 
   tests.nested wait-for snap-command
-  tests.nested exec "sudo snap wait system seed.loaded"
+  remote.exec "sudo snap wait system seed.loaded"
 
   echo "Now move the run object key on ubuntu-boot out of the way so we use the fallback key to unlock ubuntu-data"
-  tests.nested exec "sudo mv /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key.bk"
+  remote.exec "sudo mv /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key.bk"
   tests.nested transition "$recoverySystem" recover
 
   tests.nested wait-for snap-command
-  tests.nested exec "sudo snap wait system seed.loaded"
+  remote.exec "sudo snap wait system seed.loaded"
 
   echo "Check degraded.json exists and has the unlock-key for ubuntu-data as the fallback key"
-  tests.nested exec "test -f $DEGRADED_JSON"
-  test "$(tests.nested exec "cat $DEGRADED_JSON" | jq -r '."ubuntu-data" | ."unlock-key"')" = fallback
+  remote.exec "test -f $DEGRADED_JSON"
+  test "$(remote.exec "cat $DEGRADED_JSON" | jq -r '."ubuntu-data" | ."unlock-key"')" = fallback

--- a/tests/nested/core/core20-factory-reset/task.yaml
+++ b/tests/nested/core/core20-factory-reset/task.yaml
@@ -11,46 +11,46 @@ environment:
 
 execute: |
     echo "Wait for the system to be seeded first"
-    tests.nested exec "sudo snap wait system seed.loaded"
+    remote.exec "sudo snap wait system seed.loaded"
     tests.nested wait-for device-initialized
 
-    tests.nested exec snap model > initial-model
-    tests.nested exec snap model --serial > initial-serial
-    tests.nested exec sudo blkid |grep -v /dev/loop > initial-disk
+    remote.exec snap model > initial-model
+    remote.exec snap model --serial > initial-serial
+    remote.exec sudo blkid |grep -v /dev/loop > initial-disk
 
     echo "Request factory reset"
     boot_id=$(tests.nested boot-id)
 
     # leave some marker files
-    tests.nested exec sudo touch /run/mnt/ubuntu-seed/marker
-    tests.nested exec sudo touch /run/mnt/ubuntu-save/marker
-    tests.nested exec sudo touch /run/mnt/ubuntu-boot/marker
-    tests.nested exec sudo touch /writable/marker
+    remote.exec sudo touch /run/mnt/ubuntu-seed/marker
+    remote.exec sudo touch /run/mnt/ubuntu-save/marker
+    remote.exec sudo touch /run/mnt/ubuntu-boot/marker
+    remote.exec sudo touch /writable/marker
 
     # grab the ubuntu-save key
-    tests.nested exec cat /run/mnt/ubuntu-seed/device/fde/ubuntu-save.recovery.sealed-key > pre-reset-save-fallback-key
+    remote.exec cat /run/mnt/ubuntu-seed/device/fde/ubuntu-save.recovery.sealed-key > pre-reset-save-fallback-key
 
     # add || true in case the SSH connection is broken while executing this
     # since this command causes an immediate reboot
-    tests.nested exec "sudo snap reboot --factory-reset" || true
+    remote.exec "sudo snap reboot --factory-reset" || true
 
     tests.nested wait-for reboot "${boot_id}"
 
     # check that we are back in run mode
-    tests.nested exec cat /proc/cmdline | MATCH 'snapd_recovery_mode=run'
+    remote.exec cat /proc/cmdline | MATCH 'snapd_recovery_mode=run'
 
     # wait for the system to get setup and finish seeding
     tests.nested wait-for snap-command
-    retry -n 10 --wait 2 tests.nested exec "sudo snap wait system seed.loaded"
+    retry -n 10 --wait 2 remote.exec "sudo snap wait system seed.loaded"
 
     # wait up to two minutes for serial registration
-    retry -n 60 --wait 2 tests.nested exec snap model --serial
+    retry -n 60 --wait 2 remote.exec snap model --serial
 
     # post factory reset world
 
-    tests.nested exec snap model > current-model
-    tests.nested exec snap model --serial > current-serial
-    tests.nested exec sudo blkid |grep -v /dev/loop > current-disk
+    remote.exec snap model > current-model
+    remote.exec snap model --serial > current-serial
+    remote.exec sudo blkid |grep -v /dev/loop > current-disk
     # serials should be identical
     diff -u initial-model current-model
     diff -u initial-serial current-serial
@@ -85,42 +85,42 @@ execute: |
 
     # reaffirm that marker files are gone where we expected new partitions, but
     # are still present where we expected the partitions to be preserved
-    tests.nested exec test ! -e /run/mnt/ubuntu-boot/marker
-    tests.nested exec test ! -e /writable/marker
-    tests.nested exec test -e /run/mnt/ubuntu-save/marker
-    tests.nested exec test -e /run/mnt/ubuntu-seed/marker
+    remote.exec test ! -e /run/mnt/ubuntu-boot/marker
+    remote.exec test ! -e /writable/marker
+    remote.exec test -e /run/mnt/ubuntu-save/marker
+    remote.exec test -e /run/mnt/ubuntu-seed/marker
 
     # the temp factory-reset key is gone
     # TODO this is a very weak check
-    tests.nested exec test ! -e /run/mnt/ubuntu-seed/device/fde/ubuntu-save.recovery.sealed-key.factory-reset
+    remote.exec test ! -e /run/mnt/ubuntu-seed/device/fde/ubuntu-save.recovery.sealed-key.factory-reset
     # no factory reset marker
-    tests.nested exec test ! -e /var/lib/snapd/device/factory-reset
+    remote.exec test ! -e /var/lib/snapd/device/factory-reset
 
     # verify that the factory-reset log was collected
-    tests.nested exec "zcat /var/log/factory-reset-mode.log.gz" | MATCH 'performing factory reset on an installed system'
+    remote.exec "zcat /var/log/factory-reset-mode.log.gz" | MATCH 'performing factory reset on an installed system'
 
-    tests.nested exec cat /run/mnt/ubuntu-seed/device/fde/ubuntu-save.recovery.sealed-key > post-reset-save-fallback-key
+    remote.exec cat /run/mnt/ubuntu-seed/device/fde/ubuntu-save.recovery.sealed-key > post-reset-save-fallback-key
     # not a great check as the fallback key may have been resealed, but it
     # should be different nonetheless
     not cmp pre-reset-save-fallback-key post-reset-save-fallback-key
 
     echo "Perform subsequent factory reset"
-    tests.nested exec "sudo snap reboot --factory-reset" || true
+    remote.exec "sudo snap reboot --factory-reset" || true
     tests.nested wait-for reboot "${boot_id}"
-    tests.nested exec cat /proc/cmdline | MATCH 'snapd_recovery_mode=run'
+    remote.exec cat /proc/cmdline | MATCH 'snapd_recovery_mode=run'
     tests.nested wait-for snap-command
     # TODO investigate why does this have to be much longer than what is needed for the
     # initial wait and one after the first reset?
-    retry -n 60 --wait 2 tests.nested exec "sudo snap wait system seed.loaded"
-    retry -n 60 --wait 2 tests.nested exec snap model --serial
-    tests.nested exec snap model --serial > subsequent-serial
+    retry -n 60 --wait 2 remote.exec "sudo snap wait system seed.loaded"
+    retry -n 60 --wait 2 remote.exec snap model --serial
+    remote.exec snap model --serial > subsequent-serial
     # still the same serial
     diff -u initial-serial subsequent-serial
 
     # the markers are still there
-    tests.nested exec test -e /run/mnt/ubuntu-save/marker
-    tests.nested exec test -e /run/mnt/ubuntu-seed/marker
+    remote.exec test -e /run/mnt/ubuntu-save/marker
+    remote.exec test -e /run/mnt/ubuntu-seed/marker
     # get the key
-    tests.nested exec cat /run/mnt/ubuntu-seed/device/fde/ubuntu-save.recovery.sealed-key > subsequent-reset-save-fallback-key
+    remote.exec cat /run/mnt/ubuntu-seed/device/fde/ubuntu-save.recovery.sealed-key > subsequent-reset-save-fallback-key
     # and the key is different again
     not cmp post-reset-save-fallback-key subsequent-reset-save-fallback-key

--- a/tests/nested/core/core20-fault-inject/task.yaml
+++ b/tests/nested/core/core20-fault-inject/task.yaml
@@ -16,29 +16,29 @@ execute: |
     EOF
 
     echo "Wait for the system to be seeded first"
-    tests.nested exec "sudo snap wait system seed.loaded"
+    remote.exec "sudo snap wait system seed.loaded"
 
-    tests.nested copy fault-inject.conf
-    tests.nested exec "sudo mkdir -p /etc/systemd/system/snapd.service.d"
-    tests.nested exec "sudo cp -v fault-inject.conf /etc/systemd/system/snapd.service.d/"
-    tests.nested exec "sudo systemctl daemon-reload"
-    tests.nested exec "sudo systemctl restart snapd.service"
+    remote.push fault-inject.conf
+    remote.exec "sudo mkdir -p /etc/systemd/system/snapd.service.d"
+    remote.exec "sudo cp -v fault-inject.conf /etc/systemd/system/snapd.service.d/"
+    remote.exec "sudo systemctl daemon-reload"
+    remote.exec "sudo systemctl restart snapd.service"
 
     boot_id="$(tests.nested boot-id)"
     echo "We should observe a reboot being triggered when linking the snap"
-    change_id="$(tests.nested exec 'sudo snap install --no-wait test-snapd-sh')"
+    change_id="$(remote.exec 'sudo snap install --no-wait test-snapd-sh')"
 
     echo "Wait for system reboot"
     tests.nested wait-for reboot "$boot_id"
 
     echo "Ensure that stamp file is present"
-    tests.nested exec "test -e /var/lib/snapd/faults/link-snap:reboot"
+    remote.exec "test -e /var/lib/snapd/faults/link-snap:reboot"
 
     echo "And snap install completes"
-    tests.nested exec "snap watch $change_id"
+    remote.exec "snap watch $change_id"
 
     echo "Remove the snap now"
-    tests.nested exec "sudo snap remove test-snapd-sh"
+    remote.exec "sudo snap remove test-snapd-sh"
 
     echo "Inject a panic on link-snap"
     # prepare a variant with a panic
@@ -48,13 +48,13 @@ execute: |
     Environment=SNAPD_FAULT_INJECT=link-snap:panic
     EOF
     # replace the existing file
-    tests.nested copy fault-inject.conf
-    tests.nested exec "sudo cp -v fault-inject.conf /etc/systemd/system/snapd.service.d/"
-    tests.nested exec "sudo systemctl daemon-reload"
-    tests.nested exec "sudo systemctl restart snapd.service"
+    remote.push fault-inject.conf
+    remote.exec "sudo cp -v fault-inject.conf /etc/systemd/system/snapd.service.d/"
+    remote.exec "sudo systemctl daemon-reload"
+    remote.exec "sudo systemctl restart snapd.service"
 
     echo "Install the snap again"
-    change_id="$(tests.nested exec 'sudo snap install --no-wait test-snapd-sh')"
-    tests.nested exec "snap watch $change_id"
-    tests.nested exec systemctl show --property NRestarts snapd.service | MATCH NRestarts=1
-    tests.nested exec sudo journalctl -u snapd.service | MATCH 'panic: fault "link-snap:panic"'
+    change_id="$(remote.exec 'sudo snap install --no-wait test-snapd-sh')"
+    remote.exec "snap watch $change_id"
+    remote.exec systemctl show --property NRestarts snapd.service | MATCH NRestarts=1
+    remote.exec sudo journalctl -u snapd.service | MATCH 'panic: fault "link-snap:panic"'

--- a/tests/nested/core/core20-gadget-reseal/task.yaml
+++ b/tests/nested/core/core20-gadget-reseal/task.yaml
@@ -3,19 +3,19 @@ summary: Check that a gadget refresh reseals
 systems: [ubuntu-20.04-64, ubuntu-22.04-64]
 
 execute: |
-    SEALED_KEY_MTIME_1="$(tests.nested exec sudo stat --format="%Y" /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key)"
-    RESEAL_COUNT_1="$(tests.nested exec sudo cat /var/lib/snapd/device/fde/boot-chains | python3 -m json.tool | grep reseal-count|cut -f2 -d: | tr ',' ' ')"
+    SEALED_KEY_MTIME_1="$(remote.exec sudo stat --format="%Y" /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key)"
+    RESEAL_COUNT_1="$(remote.exec sudo cat /var/lib/snapd/device/fde/boot-chains | python3 -m json.tool | grep reseal-count|cut -f2 -d: | tr ',' ' ')"
     
     echo "Install new (unasserted) gadget without changes and wait for change without reboot"
     boot_id="$( tests.nested boot-id )"
-    REMOTE_CHG_ID=$(tests.nested exec sudo snap install --dangerous /var/lib/snapd/snaps/pc_*.snap --no-wait)
+    REMOTE_CHG_ID=$(remote.exec sudo snap install --dangerous /var/lib/snapd/snaps/pc_*.snap --no-wait)
     # no reboot here, no gadget changes
-    tests.nested exec sudo snap watch "${REMOTE_CHG_ID}"
+    remote.exec sudo snap watch "${REMOTE_CHG_ID}"
   
     echo "Check nothing in the gadget has changed so no reseal was needed"
-    SEALED_KEY_MTIME_2="$(tests.nested exec sudo stat --format="%Y" /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key)"
+    SEALED_KEY_MTIME_2="$(remote.exec sudo stat --format="%Y" /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key)"
     test "$SEALED_KEY_MTIME_2" -eq "$SEALED_KEY_MTIME_1"
-    RESEAL_COUNT_2="$(tests.nested exec sudo cat /var/lib/snapd/device/fde/boot-chains | python3 -m json.tool | grep reseal-count|cut -f2 -d: | tr ',' ' ')"
+    RESEAL_COUNT_2="$(remote.exec sudo cat /var/lib/snapd/device/fde/boot-chains | python3 -m json.tool | grep reseal-count|cut -f2 -d: | tr ',' ' ')"
     test "$RESEAL_COUNT_2" = "$RESEAL_COUNT_1"
 
     echo "Create modified boot assets"
@@ -42,16 +42,16 @@ execute: |
     snap pack pc-gadget/
 
     echo "Install newly created gadget (which will trigger a reboot)"
-    tests.nested copy ./pc_*.snap
-    REMOTE_CHG_ID=$(tests.nested exec sudo snap install --dangerous ./pc_*.snap --no-wait)
+    remote.push ./pc_*.snap
+    REMOTE_CHG_ID=$(remote.exec sudo snap install --dangerous ./pc_*.snap --no-wait)
     tests.nested wait-for reboot "${boot_id}"
-    tests.nested exec sudo snap watch "${REMOTE_CHG_ID}"
+    remote.exec sudo snap watch "${REMOTE_CHG_ID}"
 
     echo "Check that the gadget asset was changed"
-    tests.nested exec sudo grep -q -a "This program cannot be run in XXX mode" /run/mnt/ubuntu-boot/EFI/boot/grubx64.efi
+    remote.exec sudo grep -q -a "This program cannot be run in XXX mode" /run/mnt/ubuntu-boot/EFI/boot/grubx64.efi
 
     echo "The gadget has changed, we should see resealing"
-    SEALED_KEY_MTIME_3="$(tests.nested exec sudo stat --format="%Y" /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key)"
+    SEALED_KEY_MTIME_3="$(remote.exec sudo stat --format="%Y" /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key)"
     test "$SEALED_KEY_MTIME_3" -gt "$SEALED_KEY_MTIME_2"
-    RESEAL_COUNT_3="$(tests.nested exec sudo cat /var/lib/snapd/device/fde/boot-chains | python3 -m json.tool | grep reseal-count|cut -f2 -d: | tr ',' ' ')"
+    RESEAL_COUNT_3="$(remote.exec sudo cat /var/lib/snapd/device/fde/boot-chains | python3 -m json.tool | grep reseal-count|cut -f2 -d: | tr ',' ' ')"
     test "$RESEAL_COUNT_3" -gt "1"

--- a/tests/nested/core/core20-kernel-failover/task.yaml
+++ b/tests/nested/core/core20-kernel-failover/task.yaml
@@ -24,17 +24,17 @@ prepare: |
 
 execute: |
   echo "Copy the broken initramfs kernel snap to the UC20 VM"
-  tests.nested copy panicking-initramfs-kernel.snap
+  remote.push panicking-initramfs-kernel.snap
 
   echo "Wait for snapd to be available"
   tests.nested wait-for snap-command
 
   echo "Wait for snapd to be seeded"
-  tests.nested exec sudo snap wait system seed.loaded
+  remote.exec sudo snap wait system seed.loaded
 
   # Get the current revision of the kernel snap
   # TODO:UC20: enable for pi-kernel, etc. when used with external systems
-  startRevision=$(tests.nested exec sudo snap list pc-kernel | grep pc-kernel | awk '{print $3}')
+  startRevision=$(remote.exec sudo snap list pc-kernel | grep pc-kernel | awk '{print $3}')
   if [ -z "${startRevision}" ]; then
     echo "missing pc-kernel revision"
     exit 1
@@ -43,39 +43,39 @@ execute: |
   boot_id="$( tests.nested boot-id )"
 
   echo "Install it and get the ID for the change"
-  REMOTE_CHG_ID=$(tests.nested exec sudo snap install --dangerous panicking-initramfs-kernel.snap --no-wait)
+  REMOTE_CHG_ID=$(remote.exec sudo snap install --dangerous panicking-initramfs-kernel.snap --no-wait)
 
   # wait for a reboot
   tests.nested wait-for reboot "${boot_id}"
 
   # Wait for the change to finish - note it will exit with non-zero since the 
   # change will fail, so don't let that kill the test here
-  if tests.nested exec sudo snap watch "${REMOTE_CHG_ID}"; then 
+  if remote.exec sudo snap watch "${REMOTE_CHG_ID}"; then 
     echo "remote snap change ${REMOTE_CHG_ID} for broken kernel snap refresh should have failed!"
     exit 1
   fi
 
   echo "Check that the refresh failed"
-  tests.nested exec sudo snap changes | grep "${REMOTE_CHG_ID}" | MATCH Error
-  tests.nested exec sudo snap tasks "${REMOTE_CHG_ID}" | MATCH "cannot finish .* installation, there was a rollback across reboot"
+  remote.exec sudo snap changes | grep "${REMOTE_CHG_ID}" | MATCH Error
+  remote.exec sudo snap tasks "${REMOTE_CHG_ID}" | MATCH "cannot finish .* installation, there was a rollback across reboot"
 
   echo "Check We should be on the same revision of the kernel snap"
-  if [ "$(tests.nested exec sudo snap list pc-kernel | grep pc-kernel | awk '{print $3}')" != "${startRevision}" ]; then
+  if [ "$(remote.exec sudo snap list pc-kernel | grep pc-kernel | awk '{print $3}')" != "${startRevision}" ]; then
     echo "pc-kernel is on the wrong revision"
     exit 1
   fi
 
   echo "Check we don't have leftover bootenv"
-  tests.nested exec sudo snap debug boot-vars --uc20 | MATCH '^kernel_status=$'
+  remote.exec sudo snap debug boot-vars --uc20 | MATCH '^kernel_status=$'
 
   echo "Check that we don't have extra assets in the ubuntu-boot dir and that the currently enabled kernel is the original kernel"
 
   # kernel.efi symlink should point to the original kernel
-  tests.nested exec readlink /run/mnt/ubuntu-boot/EFI/ubuntu/kernel.efi | MATCH "pc-kernel_${startRevision}.snap/kernel.efi"
+  remote.exec readlink /run/mnt/ubuntu-boot/EFI/ubuntu/kernel.efi | MATCH "pc-kernel_${startRevision}.snap/kernel.efi"
   # should still have pc-kernel_$rev.snap dir
-  tests.nested exec test -d "/run/mnt/ubuntu-boot/EFI/ubuntu/pc-kernel_${startRevision}.snap"
-  if [ "$(tests.nested exec ls /run/mnt/ubuntu-boot/EFI/ubuntu/pc-kernel_*.snap | wc -l)" != 1 ]; then
+  remote.exec test -d "/run/mnt/ubuntu-boot/EFI/ubuntu/pc-kernel_${startRevision}.snap"
+  if [ "$(remote.exec ls /run/mnt/ubuntu-boot/EFI/ubuntu/pc-kernel_*.snap | wc -l)" != 1 ]; then
     echo "Extra leftover pc-kernel assets in ubuntu-boot:"
-    tests.nested exec ls /run/mnt/ubuntu-boot/EFI/ubuntu/pc-kernel_*.snap
+    remote.exec ls /run/mnt/ubuntu-boot/EFI/ubuntu/pc-kernel_*.snap
     exit 1
   fi

--- a/tests/nested/core/core20-kernel-reseal/task.yaml
+++ b/tests/nested/core/core20-kernel-reseal/task.yaml
@@ -23,27 +23,27 @@ prepare: |
   snap pack pc-kernel
   rm -rf pc-kernel
   mv pc-kernel_*.snap new-pc-kernel.snap
-  tests.nested copy new-pc-kernel.snap
+  remote.push new-pc-kernel.snap
 
 execute: |
-  SEALED_KEY_MTIME_1="$(tests.nested exec sudo stat --format="%Y" /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key)"
-  RESEAL_COUNT_1="$(tests.nested exec sudo cat /var/lib/snapd/device/fde/boot-chains | python3 -m json.tool | grep reseal-count|cut -f2 -d: | tr ',' ' ')"
+  SEALED_KEY_MTIME_1="$(remote.exec sudo stat --format="%Y" /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key)"
+  RESEAL_COUNT_1="$(remote.exec sudo cat /var/lib/snapd/device/fde/boot-chains | python3 -m json.tool | grep reseal-count|cut -f2 -d: | tr ',' ' ')"
 
   echo "Install new (unasserted) kernel and wait for reboot/change finishing"
   boot_id="$( tests.nested boot-id )"
-  REMOTE_CHG_ID=$(tests.nested exec sudo snap install --dangerous new-pc-kernel.snap --no-wait)
+  REMOTE_CHG_ID=$(remote.exec sudo snap install --dangerous new-pc-kernel.snap --no-wait)
   tests.nested wait-for reboot "${boot_id}"
-  tests.nested exec sudo snap watch "${REMOTE_CHG_ID}"
+  remote.exec sudo snap watch "${REMOTE_CHG_ID}"
 
   echo "Check that we are using the right kernel"
-  tests.nested exec sudo grep -q -a "This program cannot be run in XXX mode" /boot/grub/kernel.efi
+  remote.exec sudo grep -q -a "This program cannot be run in XXX mode" /boot/grub/kernel.efi
 
   echo "Check ubuntu-data.sealed-key mtime is newer"
-  SEALED_KEY_MTIME_2="$(tests.nested exec sudo stat --format="%Y" /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key)"
+  SEALED_KEY_MTIME_2="$(remote.exec sudo stat --format="%Y" /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key)"
   test "$SEALED_KEY_MTIME_2" -gt "$SEALED_KEY_MTIME_1"
 
   echo "Check that we have boot chains"
-  tests.nested exec sudo test -e /var/lib/snapd/device/fde/boot-chains
+  remote.exec sudo test -e /var/lib/snapd/device/fde/boot-chains
 
-  RESEAL_COUNT_2="$(tests.nested exec sudo cat /var/lib/snapd/device/fde/boot-chains | python3 -m json.tool | grep reseal-count|cut -f2 -d: | tr ',' ' ')"
+  RESEAL_COUNT_2="$(remote.exec sudo cat /var/lib/snapd/device/fde/boot-chains | python3 -m json.tool | grep reseal-count|cut -f2 -d: | tr ',' ' ')"
   test "$RESEAL_COUNT_2" -gt "$RESEAL_COUNT_1"

--- a/tests/nested/core/core20-reinstall-partitions/task.yaml
+++ b/tests/nested/core/core20-reinstall-partitions/task.yaml
@@ -14,30 +14,30 @@ environment:
 
 execute: |
     echo "Wait for the system to be seeded first"
-    tests.nested exec "sudo snap wait system seed.loaded"
+    remote.exec "sudo snap wait system seed.loaded"
     tests.nested wait-for device-initialized
 
-    INITIAL_SERIAL=$(tests.nested exec snap model --serial | grep -Po 'serial:\s+\K.*')
+    INITIAL_SERIAL=$(remote.exec snap model --serial | grep -Po 'serial:\s+\K.*')
 
     echo "Reinstall the system"
     boot_id=$(tests.nested boot-id)
     # add || true in case the SSH connection is broken while executing this 
     # since this command causes an immediate reboot
-    tests.nested exec "sudo snap reboot --install" || true
+    remote.exec "sudo snap reboot --install" || true
 
     tests.nested wait-for reboot "${boot_id}"
 
     # check that we are back in run mode
-    tests.nested exec cat /proc/cmdline | MATCH 'snapd_recovery_mode=run'
+    remote.exec cat /proc/cmdline | MATCH 'snapd_recovery_mode=run'
 
     # wait for the system to get setup and finish seeding
     tests.nested wait-for snap-command
-    tests.nested exec "sudo snap wait system seed.loaded"
+    remote.exec "sudo snap wait system seed.loaded"
 
     # wait up to two minutes for serial registration
-    retry -n 60 --wait 2 tests.nested exec snap model --serial
+    retry -n 60 --wait 2 remote.exec snap model --serial
 
-    END_SERIAL=$(tests.nested exec snap model --serial | grep -Po 'serial:\s+\K.*')
+    END_SERIAL=$(remote.exec snap model --serial | grep -Po 'serial:\s+\K.*')
     if [ "$INITIAL_SERIAL" = "$END_SERIAL" ]; then
         echo "test failed, same serial assertion after reinstallation"
         exit 1

--- a/tests/nested/core/core20-tpm/task.yaml
+++ b/tests/nested/core/core20-tpm/task.yaml
@@ -11,39 +11,39 @@ debug: |
 
 execute: |
     echo "Verifying tpm working on the nested vm"
-    tests.nested exec "dmesg | grep -i tpm" | MATCH "efi: +SMBIOS=.* +TPMFinalLog=.*"
-    tests.nested exec "test -e /sys/kernel/security/tpm0/binary_bios_measurements"
+    remote.exec "dmesg | grep -i tpm" | MATCH "efi: +SMBIOS=.* +TPMFinalLog=.*"
+    remote.exec "test -e /sys/kernel/security/tpm0/binary_bios_measurements"
 
     echo "and secure boot is enabled on the nested vm"
-    tests.nested exec "xxd /sys/firmware/efi/efivars/SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c" | MATCH "00000000: 0600 0000 01\s+....."
+    remote.exec "xxd /sys/firmware/efi/efivars/SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c" | MATCH "00000000: 0600 0000 01\s+....."
 
     echo "and the recovery key is unavailable"
-    tests.nested exec "test ! -e /var/lib/snapd/device/fde/recovery.key"
+    remote.exec "test ! -e /var/lib/snapd/device/fde/recovery.key"
     # the first request to show the keys will create them
-    tests.nested exec "sudo snap recovery --show-keys"
+    remote.exec "sudo snap recovery --show-keys"
     echo "the recovery key is available now"
-    tests.nested exec "test -e /var/lib/snapd/device/fde/recovery.key"
+    remote.exec "test -e /var/lib/snapd/device/fde/recovery.key"
     echo "and has the expected size"
-    tests.nested exec "stat --printf=%s /var/lib/snapd/device/fde/recovery.key" | MATCH '^16$'
+    remote.exec "stat --printf=%s /var/lib/snapd/device/fde/recovery.key" | MATCH '^16$'
     echo "and has the expected owner and permissions"
-    tests.nested exec "stat --printf='%u:%g %a' /var/lib/snapd/device/fde/recovery.key" | MATCH '^0:0 600$'
+    remote.exec "stat --printf='%u:%g %a' /var/lib/snapd/device/fde/recovery.key" | MATCH '^0:0 600$'
 
     echo "verify that recovery key can be removed"
-    tests.nested exec "sudo snap install --devmode --edge test-snapd-curl"
-    tests.nested exec "sudo test-snapd-curl.curl --unix-socket /run/snapd.socket -D- -d '{\"action\":\"remove\"}' http://localhost/v2/system-recovery-keys"
+    remote.exec "sudo snap install --devmode --edge test-snapd-curl"
+    remote.exec "sudo test-snapd-curl.curl --unix-socket /run/snapd.socket -D- -d '{\"action\":\"remove\"}' http://localhost/v2/system-recovery-keys"
     echo "and the key is no longer available"
-    tests.nested exec "test ! -e /var/lib/snapd/device/fde/recovery.key"
+    remote.exec "test ! -e /var/lib/snapd/device/fde/recovery.key"
 
 
     echo "and the tpm-{policy-auth-key,lockout-auth} files are in ubuntu-save"
-    tests.nested exec "test -e /var/lib/snapd/save/device/fde/tpm-policy-auth-key"
-    tests.nested exec "test -e /var/lib/snapd/save/device/fde/tpm-lockout-auth"
+    remote.exec "test -e /var/lib/snapd/save/device/fde/tpm-policy-auth-key"
+    remote.exec "test -e /var/lib/snapd/save/device/fde/tpm-lockout-auth"
 
     echo "Grab modeenv content and checksums"
-    tests.nested exec "cat /var/lib/snapd/modeenv" > modeenv
-    boot_grub_sha3="$(tests.nested exec "cat /run/mnt/ubuntu-boot/EFI/boot/grubx64.efi" | "$TESTSLIB"/tools/sha3-384)"
-    seed_grub_sha3="$(tests.nested exec "cat /run/mnt/ubuntu-seed/EFI/boot/grubx64.efi" | "$TESTSLIB"/tools/sha3-384)"
-    seed_shim_sha3="$(tests.nested exec "cat /run/mnt/ubuntu-seed/EFI/boot/bootx64.efi" | "$TESTSLIB"/tools/sha3-384)"
+    remote.exec "cat /var/lib/snapd/modeenv" > modeenv
+    boot_grub_sha3="$(remote.exec "cat /run/mnt/ubuntu-boot/EFI/boot/grubx64.efi" | "$TESTSLIB"/tools/sha3-384)"
+    seed_grub_sha3="$(remote.exec "cat /run/mnt/ubuntu-seed/EFI/boot/grubx64.efi" | "$TESTSLIB"/tools/sha3-384)"
+    seed_shim_sha3="$(remote.exec "cat /run/mnt/ubuntu-seed/EFI/boot/bootx64.efi" | "$TESTSLIB"/tools/sha3-384)"
 
     # modeenv entries look like this:
     # current_trusted_boot_assets={"grubx64.efi":["2e03571ce08de6cdde8a0ad80db8777c411af66073b795e514ad365da842920c9d50eaa0c3b45e878b9c8723cb22e0df"]}
@@ -55,19 +55,19 @@ execute: |
     grep current_trusted_recovery_boot_assets= < modeenv  | MATCH "\"bootx64.efi\":\[\"$seed_shim_sha3\"\]"
 
     echo "Check that files exist too"
-    tests.nested exec "cat /var/lib/snapd/boot-assets/grub/grubx64.efi-${boot_grub_sha3}" | \
+    remote.exec "cat /var/lib/snapd/boot-assets/grub/grubx64.efi-${boot_grub_sha3}" | \
         "$TESTSLIB"/tools/sha3-384 | MATCH "^$boot_grub_sha3\$"
-    tests.nested exec "cat /var/lib/snapd/boot-assets/grub/grubx64.efi-${seed_grub_sha3}" | \
+    remote.exec "cat /var/lib/snapd/boot-assets/grub/grubx64.efi-${seed_grub_sha3}" | \
         "$TESTSLIB"/tools/sha3-384 | MATCH "^$seed_grub_sha3\$"
-    tests.nested exec "cat /var/lib/snapd/boot-assets/grub/bootx64.efi-${seed_shim_sha3}" | \
+    remote.exec "cat /var/lib/snapd/boot-assets/grub/bootx64.efi-${seed_shim_sha3}" | \
         "$TESTSLIB"/tools/sha3-384 | MATCH "^$seed_shim_sha3\$"
 
     echo "Check for sealed keys marker"
-    tests.nested exec "test -f /var/lib/snapd/device/fde/sealed-keys"
+    remote.exec "test -f /var/lib/snapd/device/fde/sealed-keys"
 
     echo "Check that kernel command line is properly recorded"
     cmdline_modeenv="$(grep current_kernel_command_lines= < modeenv  | sed -e 's/current_kernel_command_lines=//' | jq -r '.[0]')"
-    cmdline="$(tests.nested exec "cat /proc/cmdline")"
+    cmdline="$(remote.exec "cat /proc/cmdline")"
     test "$cmdline" = "$cmdline_modeenv"
     echo "$cmdline" | MATCH "snapd_recovery_mode=run "
 
@@ -79,16 +79,16 @@ execute: |
 
     echo "Check compatibility scenarios:"
     echo "1. that kernel command lines is restored when booted successfully"
-    tests.nested exec "sudo sed -i -e 's/current_kernel_command_lines=.*/current_kernel_command_lines=/' /var/lib/snapd/modeenv"
+    remote.exec "sudo sed -i -e 's/current_kernel_command_lines=.*/current_kernel_command_lines=/' /var/lib/snapd/modeenv"
     echo "2. good recovery systems is populated with current systems"
-    tests.nested exec "sudo sed -i -e 's/good_recovery_systems=.*/good_recovery_systems=/' /var/lib/snapd/modeenv"
+    remote.exec "sudo sed -i -e 's/good_recovery_systems=.*/good_recovery_systems=/' /var/lib/snapd/modeenv"
 
     boot_id="$( tests.nested boot-id )"
-    tests.nested exec "sudo reboot" || true
+    remote.exec "sudo reboot" || true
     tests.nested wait-for reboot "${boot_id}"
     echo "Check the test will race with snapd updating the modeenv, wait for the modenv to have a good state"
-    tests.nested exec "retry --wait 5 -n 10 sh -c 'MATCH current_kernel_command_lines=.*snapd_recovery_mode=run < /var/lib/snapd/modeenv'"
-    tests.nested exec "cat /var/lib/snapd/modeenv" > modeenv.after-reboot
+    remote.exec "retry --wait 5 -n 10 sh -c 'MATCH current_kernel_command_lines=.*snapd_recovery_mode=run < /var/lib/snapd/modeenv'"
+    remote.exec "cat /var/lib/snapd/modeenv" > modeenv.after-reboot
     echo "Check the kernel command line is restored"
     cmdline_modeenv_restored="$(grep current_kernel_command_lines= < modeenv.after-reboot  | sed -e 's/current_kernel_command_lines=//' | jq -r '.[0]')"
     test "$cmdline_modeenv_restored" = "$cmdline_modeenv"

--- a/tests/nested/core/core22-basic/task.yaml
+++ b/tests/nested/core/core22-basic/task.yaml
@@ -7,30 +7,30 @@ systems: [ubuntu-22.04-64]
 
 execute: |
     echo "Wait for the system to be seeded first"
-    tests.nested exec "sudo snap wait system seed.loaded"
+    remote.exec "sudo snap wait system seed.loaded"
 
     echo "Ensure 'snap install' works"
-    tests.nested exec "sudo snap install test-snapd-sh"
+    remote.exec "sudo snap install test-snapd-sh"
 
     echo "Ensure 'snap list' works and test-snapd-sh snap is installed"
-    tests.nested exec "snap list" | MATCH test-snapd-sh
+    remote.exec "snap list" | MATCH test-snapd-sh
 
     echo "Ensure 'snap find' works"
-    tests.nested exec "snap find test-snapd-sh" | MATCH ^test-snapd-sh
+    remote.exec "snap find test-snapd-sh" | MATCH ^test-snapd-sh
 
     echo "Ensure 'snap info' works"
-    tests.nested exec "snap info test-snapd-sh" | MATCH '^name:\ +test-snapd-sh'
+    remote.exec "snap info test-snapd-sh" | MATCH '^name:\ +test-snapd-sh'
 
     echo "Ensure 'snap remove' works"
-    tests.nested exec "sudo snap remove test-snapd-sh"
+    remote.exec "sudo snap remove test-snapd-sh"
 
     echo "Ensure 'snap list' works and test-snapd-sh snap is removed"
-    tests.nested exec "! snap list test-snapd-sh"
+    remote.exec "! snap list test-snapd-sh"
 
     echo "Ensure 'snap recovery show-keys' works as root"
-    tests.nested exec "sudo snap recovery --show-keys" | MATCH 'recovery:\s+[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}'
+    remote.exec "sudo snap recovery --show-keys" | MATCH 'recovery:\s+[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}'
     echo "But not as user (normal file permissions prevent this)"
-    if tests.nested exec "snap recovery --show-keys"; then
+    if remote.exec "snap recovery --show-keys"; then
         echo "snap recovery --show-key should not work as a user"
         exit 1
     fi

--- a/tests/nested/core/coreconfig-services/task.yaml
+++ b/tests/nested/core/coreconfig-services/task.yaml
@@ -3,17 +3,17 @@ summary: Disable and enable back core services via snap set with reboot.
 systems: [ubuntu-18.04-64, ubuntu-20.04-64, ubuntu-22.04-64]
 
 execute: |
-  tests.nested exec "systemctl status systemd-resolved.service" | MATCH "Active: +active"
+  remote.exec "systemctl status systemd-resolved.service" | MATCH "Active: +active"
 
   echo "Disabling systemd-resolved service"
-  tests.nested exec "sudo snap set system service.systemd-resolved.disable=true"
-  tests.nested exec "systemctl status systemd-resolved.service" | MATCH "Active: +inactive"
+  remote.exec "sudo snap set system service.systemd-resolved.disable=true"
+  remote.exec "systemctl status systemd-resolved.service" | MATCH "Active: +inactive"
 
   current_boot_id=$(tests.nested boot-id)
-  tests.nested exec "sudo reboot" || true
+  remote.exec "sudo reboot" || true
   tests.nested wait-for reboot "$current_boot_id"
 
   echo "Enabling systemd-resolved service back"
-  tests.nested exec "systemctl status systemd-resolved.service" | MATCH "Active: +inactive"
-  tests.nested exec "sudo snap set system service.systemd-resolved.disable=false"
-  tests.nested exec "systemctl status systemd-resolved.service" | MATCH "Active: +active"
+  remote.exec "systemctl status systemd-resolved.service" | MATCH "Active: +inactive"
+  remote.exec "sudo snap set system service.systemd-resolved.disable=false"
+  remote.exec "systemctl status systemd-resolved.service" | MATCH "Active: +active"

--- a/tests/nested/core/hotplug/task.yaml
+++ b/tests/nested/core/hotplug/task.yaml
@@ -4,13 +4,13 @@ systems: [ubuntu-16.04-64, ubuntu-18.04-64]
 
 prepare: |
     snap pack "$TESTSLIB"/snaps/serial-port-hotplug
-    tests.nested copy serial-port-hotplug_1.0_all.snap
+    remote.push serial-port-hotplug_1.0_all.snap
 
     if nested_is_core_18_system; then
-        tests.nested exec "sudo snap install --devmode jq-core18"
-        tests.nested exec "sudo snap alias jq-core18.jq jq"
+        remote.exec "sudo snap install --devmode jq-core18"
+        remote.exec "sudo snap alias jq-core18.jq jq"
     else
-        tests.nested exec "sudo snap install --devmode jq"
+        remote.exec "sudo snap install --devmode jq"
     fi
 
 restore: |
@@ -18,10 +18,10 @@ restore: |
 
 debug: |
     set +e
-    tests.nested exec "snap connections --all"
-    tests.nested exec "snap list"
-    tests.nested exec "dmesg"
-    tests.nested exec 'sudo jq -r ".data[\"hotplug-slots\"]" /var/lib/snapd/state.json'
+    remote.exec "snap connections --all"
+    remote.exec "snap list"
+    remote.exec "dmesg"
+    remote.exec 'sudo jq -r ".data[\"hotplug-slots\"]" /var/lib/snapd/state.json'
     set -e
 
 execute: |
@@ -35,21 +35,21 @@ execute: |
         nested_refresh_to_new_core "$NESTED_CORE_REFRESH_CHANNEL"
     fi
 
-    if tests.nested exec "udevadm info -e" | MATCH "ID_MODEL=QEMU_USB_SERIAL"; then
+    if remote.exec "udevadm info -e" | MATCH "ID_MODEL=QEMU_USB_SERIAL"; then
         echo "USB serial already registered, exiting..."
         exit 1
     fi
 
     echo "Enabling hotplug"
-    tests.nested exec "sudo snap set core experimental.hotplug=true"
+    remote.exec "sudo snap set core experimental.hotplug=true"
 
     echo "Plugging the device"
     hotplug_add_dev1
 
     # precondition checks to make sure qemu setup is correct
-    tests.nested exec "retry --wait 1 -n 5 sh -c 'udevadm info -e | MATCH ID_MODEL=QEMU_USB_SERIAL'"
+    remote.exec "retry --wait 1 -n 5 sh -c 'udevadm info -e | MATCH ID_MODEL=QEMU_USB_SERIAL'"
 
-    tests.nested exec "ls /dev/tty*" | MATCH "ttyUSB0"
+    remote.exec "ls /dev/tty*" | MATCH "ttyUSB0"
 
     echo "Checking that qemuusbserial hotplug slot is present"
     check_slot_present qemuusbserial
@@ -60,8 +60,8 @@ execute: |
     hotplug_del_dev1
 
     # precondition check to make sure qemu event was triggered correctly
-    tests.nested exec "retry --wait 1 -n 5 sh -c 'udevadm info -e | NOMATCH ID_MODEL=QEMU_USB_SERIAL'"
-    if tests.nested exec "udevadm info -e" | MATCH "ID_MODEL=QEMU_USB_SERIAL"; then
+    remote.exec "retry --wait 1 -n 5 sh -c 'udevadm info -e | NOMATCH ID_MODEL=QEMU_USB_SERIAL'"
+    if remote.exec "udevadm info -e" | MATCH "ID_MODEL=QEMU_USB_SERIAL"; then
         echo "USB serial should not be registered anymore, exiting..."
         exit 1
     fi
@@ -77,10 +77,10 @@ execute: |
     check_slot_present qemuusbserial
 
     echo "Installing test snap with serial port plug"
-    tests.nested exec "sudo snap install --dangerous serial-port-hotplug_1.0_all.snap"
+    remote.exec "sudo snap install --dangerous serial-port-hotplug_1.0_all.snap"
 
     echo "Connecting hotplug slot of the first device"
-    tests.nested exec "sudo snap connect serial-port-hotplug:serial-port :qemuusbserial"
+    remote.exec "sudo snap connect serial-port-hotplug:serial-port :qemuusbserial"
     check_slot_connected qemuusbserial
 
     echo "Veryfing serial-port permissions of the snap"
@@ -121,16 +121,16 @@ execute: |
     verify_apparmor_profile "/dev/ttyUSB1"
 
     echo "Restarting snapd should restore both hotplug slots since devices are still present"
-    tests.nested exec "sudo systemctl stop snapd.service snapd.socket"
-    tests.nested exec "sudo systemctl start snapd.service snapd.socket"
+    remote.exec "sudo systemctl stop snapd.service snapd.socket"
+    remote.exec "sudo systemctl start snapd.service snapd.socket"
     check_slot_connected qemuusbserial
     check_slot_not_gone qemuusbserial
     check_slot_present qemuusbserial-1
 
     echo "Unplugging first device while snapd is stopped and then starting snapd remembers the slot internally due to connection"
-    tests.nested exec "sudo systemctl stop snapd.service snapd.socket"
+    remote.exec "sudo systemctl stop snapd.service snapd.socket"
     hotplug_del_dev1
-    tests.nested exec "sudo systemctl start snapd.service snapd.socket"
+    remote.exec "sudo systemctl start snapd.service snapd.socket"
     check_slot_not_present qemuusbserial
     check_slot_gone qemuusbserial
 
@@ -142,7 +142,7 @@ execute: |
     echo "Disconnecting first slot and then unplugging the device removes the slot completely"
     # manual snap disconnect doesn't implement retry and errors out if there are conflicting changes, so wait for hotplug changes to complete
     wait_for_all_changes
-    tests.nested exec "sudo snap disconnect serial-port-hotplug:serial-port :qemuusbserial"
+    remote.exec "sudo snap disconnect serial-port-hotplug:serial-port :qemuusbserial"
     check_slot_present qemuusbserial
     hotplug_del_dev1
     check_slot_not_present qemuusbserial
@@ -160,10 +160,10 @@ execute: |
     check_slot_device_path qemuusbserial "/dev/ttyUSB0"
 
     echo "Connecting hotplug slot of the first device again"
-    tests.nested exec "sudo snap connect serial-port-hotplug:serial-port :qemuusbserial"
+    remote.exec "sudo snap connect serial-port-hotplug:serial-port :qemuusbserial"
     check_slot_connected qemuusbserial
 
     echo "Hotplug slot stays after removing the snap"
-    tests.nested exec "sudo snap remove serial-port-hotplug"
+    remote.exec "sudo snap remove serial-port-hotplug"
     check_slot_present qemuusbserial
     check_slot_not_gone qemuusbserial

--- a/tests/nested/core/interfaces-custom-devices/task.yaml
+++ b/tests/nested/core/interfaces-custom-devices/task.yaml
@@ -36,20 +36,20 @@ prepare: |
               attr2: two
     EOF
     snap pack pc-gadget/ --filename=pc-gadget-v4l.snap
-    tests.nested copy pc-gadget-v4l.snap
-    tests.nested exec sudo snap install --dangerous pc-gadget-v4l.snap
+    remote.push pc-gadget-v4l.snap
+    remote.exec sudo snap install --dangerous pc-gadget-v4l.snap
 
     # create and install consumer snap
     snap pack devices-plug
-    tests.nested copy devices-plug_1.0_all.snap
-    tests.nested exec sudo snap install --dangerous devices-plug_1.0_all.snap
+    remote.push devices-plug_1.0_all.snap
+    remote.exec sudo snap install --dangerous devices-plug_1.0_all.snap
 
 execute: |
     echo "When the interface is connected"
-    tests.nested exec sudo snap connect devices-plug:v4l pc:v4l
+    remote.exec sudo snap connect devices-plug:v4l pc:v4l
 
     echo "Verify that the udev rule has been generated"
-    UDEV_RULE="$(tests.nested exec grep -v '^#' /etc/udev/rules.d/70-snap.devices-plug.rules)"
+    UDEV_RULE="$(remote.exec grep -v '^#' /etc/udev/rules.d/70-snap.devices-plug.rules)"
 
     # Since ENV and ATTR elements appear in random order, we first match the
     # rule in its entirety, but without specifying the exact values of ENV and
@@ -62,12 +62,12 @@ execute: |
     echo "$UDEV_RULE" | MATCH 'ATTR{attr2}=="two"'
 
     echo "Verify that the snap can write to the writable paths"
-    OLD_VALUE="$(tests.nested exec sudo devices-plug.cmd cat /proc/sys/vm/stat_interval)"
+    OLD_VALUE="$(remote.exec sudo devices-plug.cmd cat /proc/sys/vm/stat_interval)"
     # The double quotation is needed or our command will get split and the
     # shell redirection will not happen in the right session
-    tests.nested exec sudo devices-plug.cmd sh -c "'echo 3 > /proc/sys/vm/stat_interval'"
-    tests.nested exec sudo devices-plug.cmd cat /proc/sys/vm/stat_interval | MATCH "3"
-    tests.nested exec sudo devices-plug.cmd sh -c "'echo $OLD_VALUE > /proc/sys/vm/stat_interval'"
+    remote.exec sudo devices-plug.cmd sh -c "'echo 3 > /proc/sys/vm/stat_interval'"
+    remote.exec sudo devices-plug.cmd cat /proc/sys/vm/stat_interval | MATCH "3"
+    remote.exec sudo devices-plug.cmd sh -c "'echo $OLD_VALUE > /proc/sys/vm/stat_interval'"
 
     echo "And can read the readable paths"
-    tests.nested exec sudo devices-plug.cmd cat /sys/kernel/debug/sleep_time | MATCH "time"
+    remote.exec sudo devices-plug.cmd cat /sys/kernel/debug/sleep_time | MATCH "time"

--- a/tests/nested/core/kernel-revert-after-boot/task.yaml
+++ b/tests/nested/core/kernel-revert-after-boot/task.yaml
@@ -28,13 +28,13 @@ execute: |
   snap pack pc-kernel/ --filename=pc-kernel_badhook.snap
 
   echo "Wait for the system to be seeded first"
-  tests.nested exec "sudo snap wait system seed.loaded"
+  remote.exec "sudo snap wait system seed.loaded"
 
   boot_id="$(tests.nested boot-id)"
 
   echo "Install kernel with failing post-refresh hook"
-  tests.nested copy pc-kernel_badhook.snap
-  chg_id=$(tests.nested exec 'sudo snap install --dangerous --no-wait ./pc-kernel_badhook.snap')
+  remote.push pc-kernel_badhook.snap
+  chg_id=$(remote.exec 'sudo snap install --dangerous --no-wait ./pc-kernel_badhook.snap')
 
   echo "Wait for reboot"
   tests.nested wait-for reboot "$boot_id"
@@ -45,22 +45,22 @@ execute: |
 
   boot_id="$(tests.nested boot-id)"
   # wait for change to finish with error
-  not tests.nested exec sudo snap watch "$chg_id"
+  not remote.exec sudo snap watch "$chg_id"
   # make sure that no additional reboots have happened while the change finished
   test "$boot_id" = "$(tests.nested boot-id)"
 
   echo "Check that change finished with failure and that the old snap is being used"
-  tests.nested exec "snap info pc-kernel | MATCH 'installed:.*\(x1\)'"
-  tests.nested exec "snap changes | MATCH \"^$chg_id.*Error\""
+  remote.exec "snap info pc-kernel | MATCH 'installed:.*\(x1\)'"
+  remote.exec "snap changes | MATCH \"^$chg_id.*Error\""
   if [ "$VERSION" -ge 20 ]; then
       # shellcheck disable=SC2016
-      tests.nested exec 'test $(readlink /run/mnt/ubuntu-boot/EFI/ubuntu/kernel.efi) = pc-kernel_x1.snap/kernel.efi'
-      tests.nested exec 'cat /run/mnt/ubuntu-boot/EFI/ubuntu/grubenv | MATCH "^kernel_status=$"'
+      remote.exec 'test $(readlink /run/mnt/ubuntu-boot/EFI/ubuntu/kernel.efi) = pc-kernel_x1.snap/kernel.efi'
+      remote.exec 'cat /run/mnt/ubuntu-boot/EFI/ubuntu/grubenv | MATCH "^kernel_status=$"'
       echo "Check that modeenv has only the old kernel"
-      tests.nested exec 'cat /var/lib/snapd/modeenv | MATCH "^current_kernels=pc-kernel_x1.snap$"'
+      remote.exec 'cat /var/lib/snapd/modeenv | MATCH "^current_kernels=pc-kernel_x1.snap$"'
   else
-      tests.nested exec 'cat /boot/grub/grubenv | MATCH "^snap_kernel=pc-kernel_x1.snap$"'
-      tests.nested exec 'cat /boot/grub/grubenv | MATCH "^snap_mode=$"'
-      tests.nested exec 'cat /boot/grub/grubenv | MATCH "^snap_try_kernel=$"'
-      tests.nested exec 'cat /proc/cmdline | MATCH snap_kernel=pc-kernel_x1.snap'
+      remote.exec 'cat /boot/grub/grubenv | MATCH "^snap_kernel=pc-kernel_x1.snap$"'
+      remote.exec 'cat /boot/grub/grubenv | MATCH "^snap_mode=$"'
+      remote.exec 'cat /boot/grub/grubenv | MATCH "^snap_try_kernel=$"'
+      remote.exec 'cat /proc/cmdline | MATCH snap_kernel=pc-kernel_x1.snap'
   fi

--- a/tests/nested/manual/cloud-init-never-used-not-vuln/task.yaml
+++ b/tests/nested/manual/cloud-init-never-used-not-vuln/task.yaml
@@ -61,7 +61,7 @@ debug: |
         cat snapd-before-reboot.logs
     fi
     echo "logs from current nested VM boot snapd"
-    tests.nested exec "sudo journalctl -e --no-pager -u snapd" || true
+    remote.exec "sudo journalctl -e --no-pager -u snapd" || true
 
 execute: |
     echo "The VM here will not ever had used cloud-init so snapd should disable"
@@ -69,7 +69,7 @@ execute: |
 
     echo "Wait for done seeding"
     tests.nested wait-for snap-command
-    tests.nested exec "sudo snap wait system seed.loaded"
+    remote.exec "sudo snap wait system seed.loaded"
 
     echo "Prepare snapd snapto install with the fix"
     # if we are not building from current, then we need to prep the snapd snap
@@ -79,10 +79,10 @@ execute: |
         if os.query is-xenial; then
             # build the core snap for this run
             "$TESTSTOOLS"/snaps-state repack_snapd_deb_into_snap core "$PWD"
-            tests.nested copy "$PWD/core-from-snapd-deb.snap"
+            remote.push "$PWD/core-from-snapd-deb.snap"
 
             # install the core snap
-            tests.nested exec "sudo snap install core-from-snapd-deb.snap --dangerous"
+            remote.exec "sudo snap install core-from-snapd-deb.snap --dangerous"
 
             # now we wait for the reboot for the new core snap
             tests.nested wait-for no-ssh
@@ -91,10 +91,10 @@ execute: |
         else
             # build the snapd snap for this run
             "$TESTSTOOLS"/snaps-state repack_snapd_deb_into_snap snapd
-            tests.nested copy "$PWD/snapd-from-deb.snap"
+            remote.push "$PWD/snapd-from-deb.snap"
 
             # install the snapd snap
-            tests.nested exec "sudo snap install snapd-from-deb.snap --dangerous"
+            remote.exec "sudo snap install snapd-from-deb.snap --dangerous"
         fi
     fi
 
@@ -112,20 +112,20 @@ execute: |
     # not have been triggered. 
 
     echo "Waiting for cloud-init..."
-    tests.nested exec "cloud-init status --wait"
+    remote.exec "cloud-init status --wait"
 
     echo "Waiting for snapd to react to cloud-init"
     # It is needed || true because in ubuntu-core-16 there is not any cloud-init message in the journal log
-    retry --wait 1 -n 60 sh -c 'tests.nested exec sudo journalctl --no-pager -u snapd | MATCH "cloud-init reported"'
+    retry --wait 1 -n 60 sh -c 'remote.exec sudo journalctl --no-pager -u snapd | MATCH "cloud-init reported"'
 
     # ensure that snapd disabled cloud-init with the cloud-init.disabled file
     echo "Ensuring that snapd restricted cloud-init"
-    tests.nested exec "cloud-init status" | MATCH "status: disabled"
-    tests.nested exec "test -f /etc/cloud/cloud-init.disabled"
-    tests.nested exec "! test -f /etc/cloud/cloud.cfg.d/zzzz_snapd.cfg"
+    remote.exec "cloud-init status" | MATCH "status: disabled"
+    remote.exec "test -f /etc/cloud/cloud-init.disabled"
+    remote.exec "! test -f /etc/cloud/cloud.cfg.d/zzzz_snapd.cfg"
 
     echo "Save snapd logs before continuing as the logs are not persistent"
-    tests.nested exec "sudo journalctl -e --no-pager -u snapd" > snapd-before-reboot.logs
+    remote.exec "sudo journalctl -e --no-pager -u snapd" > snapd-before-reboot.logs
 
     echo "Gracefully shutting down the nested VM to prepare a simulated attack"
     boot_id="$(tests.nested boot-id)"
@@ -143,14 +143,14 @@ execute: |
     # it is "done" or at least steady before ensuring that the attacker-user was
     # not created.
     echo "Waiting for cloud-init..."
-    tests.nested exec "cloud-init status --wait"
+    remote.exec "cloud-init status --wait"
 
     # the attacker-user should not have been created
     echo "The cloud-init user was not created"
-    tests.nested exec "cat /var/lib/extrausers/passwd" | NOMATCH attacker-user
+    remote.exec "cat /var/lib/extrausers/passwd" | NOMATCH attacker-user
 
     # cloud-init should still be disabled
     echo "cloud-init is still disabled"
-    tests.nested exec "cloud-init status" | MATCH "status: disabled"
-    tests.nested exec "test -f /etc/cloud/cloud-init.disabled"
-    tests.nested exec "! test -f /etc/cloud/cloud.cfg.d/zzzz_snapd.cfg"
+    remote.exec "cloud-init status" | MATCH "status: disabled"
+    remote.exec "test -f /etc/cloud/cloud-init.disabled"
+    remote.exec "! test -f /etc/cloud/cloud.cfg.d/zzzz_snapd.cfg"

--- a/tests/nested/manual/cloud-init-nocloud-not-vuln/task.yaml
+++ b/tests/nested/manual/cloud-init-nocloud-not-vuln/task.yaml
@@ -64,7 +64,7 @@ debug: |
         cat snapd-before-reboot.logs
     fi
     echo "logs from current nested VM boot snapd"
-    tests.nested exec "sudo journalctl -e --no-pager -u snapd" || true
+    remote.exec "sudo journalctl -e --no-pager -u snapd" || true
 
 execute: |
     # the VM here will use both system-user assertions and cloud-init to create
@@ -72,14 +72,14 @@ execute: |
     # the legitimate cloud-init user is the normal-user user
 
     # wait for cloud-init to finish importing the first seed
-    tests.nested exec "sudo cloud-init status --wait"
+    remote.exec "sudo cloud-init status --wait"
 
     echo "The initial cloud-init user was created"
-    tests.nested exec "cat /var/lib/extrausers/passwd" | MATCH normal-user
+    remote.exec "cat /var/lib/extrausers/passwd" | MATCH normal-user
 
     # wait for snap seeding to be done
     tests.nested wait-for snap-command
-    tests.nested exec "sudo snap wait system seed.loaded"
+    remote.exec "sudo snap wait system seed.loaded"
 
     # if we are not building from current, then we need to prep the snapd snap
     # to install with the fix, this simulates/verifies that devices in the field
@@ -89,10 +89,10 @@ execute: |
         if os.query is-xenial; then
             # build the core snap for this run
             "$TESTSTOOLS"/snaps-state repack_snapd_deb_into_snap core
-            tests.nested copy "$PWD/core-from-snapd-deb.snap"
+            remote.push "$PWD/core-from-snapd-deb.snap"
 
             # install the core snap
-            tests.nested exec "sudo snap install core-from-snapd-deb.snap --dangerous"
+            remote.exec "sudo snap install core-from-snapd-deb.snap --dangerous"
 
             # now we wait for the reboot for the new core snap
             tests.nested wait-for no-ssh
@@ -100,10 +100,10 @@ execute: |
         else
             # build the snapd snap for this run
             "$TESTSTOOLS"/snaps-state repack_snapd_deb_into_snap snapd
-            tests.nested copy "$PWD/snapd-from-deb.snap"
+            remote.push "$PWD/snapd-from-deb.snap"
 
             # install the snapd snap
-            tests.nested exec "sudo snap install snapd-from-deb.snap --dangerous"
+            remote.exec "sudo snap install snapd-from-deb.snap --dangerous"
         fi
     fi
 
@@ -119,21 +119,21 @@ execute: |
     # action that we can test for.
 
     echo "Waiting for cloud-init..."
-    tests.nested exec "cloud-init status --wait"
+    remote.exec "cloud-init status --wait"
 
     echo "Waiting for snapd to react to cloud-init"
     # It is needed || true because in ubuntu-core-16 there is not any cloud-init message in the journal log
-    retry --wait 1 -n 60 sh -c 'tests.nested exec sudo journalctl --no-pager -u snapd | MATCH "cloud-init reported"'
+    retry --wait 1 -n 60 sh -c 'remote.exec sudo journalctl --no-pager -u snapd | MATCH "cloud-init reported"'
 
     # ensure that snapd restricted cloud-init with the zzzz_snapd.cfg file
     echo "Ensuring that snapd restricted cloud-init"
-    tests.nested exec "cloud-init status" | MATCH "status: done"
-    tests.nested exec "test ! -f /etc/cloud/cloud-init.disabled"
-    tests.nested exec "test -f /etc/cloud/cloud.cfg.d/zzzz_snapd.cfg"
-    tests.nested exec "cat /etc/cloud/cloud.cfg.d/zzzz_snapd.cfg" | MATCH "manual_cache_clean: true"
+    remote.exec "cloud-init status" | MATCH "status: done"
+    remote.exec "test ! -f /etc/cloud/cloud-init.disabled"
+    remote.exec "test -f /etc/cloud/cloud.cfg.d/zzzz_snapd.cfg"
+    remote.exec "cat /etc/cloud/cloud.cfg.d/zzzz_snapd.cfg" | MATCH "manual_cache_clean: true"
 
     # save snapd logs before continuing as the logs are not persistent
-    tests.nested exec "sudo journalctl -e --no-pager -u snapd" > snapd-before-reboot.logs
+    remote.exec "sudo journalctl -e --no-pager -u snapd" > snapd-before-reboot.logs
 
     # gracefully shutdown so that we don't have file corruption
     echo "Gracefully shutting down the nested VM to prepare a simulated attack"
@@ -151,13 +151,13 @@ execute: |
     # provided a cloud-init drive but importantly, it will not import the drive,
     # so wait for cloud-init to settle down before continuing
     echo "Waiting for cloud-init..."
-    tests.nested exec "cloud-init status --wait"
+    remote.exec "cloud-init status --wait"
 
     # the attacker-user should not have been created
     echo "The cloud-init attacker user was not created"
-    tests.nested exec "cat /var/lib/extrausers/passwd" | NOMATCH attacker-user
+    remote.exec "cat /var/lib/extrausers/passwd" | NOMATCH attacker-user
 
     echo "cloud-init is still restricted"
-    tests.nested exec "cloud-init status" | MATCH "status: done"
-    tests.nested exec "test ! -f /etc/cloud/cloud-init.disabled"
-    tests.nested exec "test -f /etc/cloud/cloud.cfg.d/zzzz_snapd.cfg"
+    remote.exec "cloud-init status" | MATCH "status: done"
+    remote.exec "test ! -f /etc/cloud/cloud-init.disabled"
+    remote.exec "test -f /etc/cloud/cloud.cfg.d/zzzz_snapd.cfg"

--- a/tests/nested/manual/connections/task.yaml
+++ b/tests/nested/manual/connections/task.yaml
@@ -52,4 +52,4 @@ restore: |
   teardown_fake_store "$NESTED_FAKESTORE_BLOB_DIR"
 
 execute: |
-  tests.nested exec "snap connections" | MATCH 'serial-port  *connections:serial-1  *pc:serial-1'
+  remote.exec "snap connections" | MATCH 'serial-port  *connections:serial-1  *pc:serial-1'

--- a/tests/nested/manual/core-early-config/task.yaml
+++ b/tests/nested/manual/core-early-config/task.yaml
@@ -41,20 +41,20 @@ prepare: |
     tests.nested create-vm core
 
 execute: |
-    tests.nested exec "sudo snap wait system seed.loaded"
+    remote.exec "sudo snap wait system seed.loaded"
 
     echo "Test that rsyslog was disabled early."
     # early config is witnessed by install hook of the pc gadget
-    tests.nested exec "cat /var/snap/pc/common/debug.txt" | MATCH "rsyslog symlink: /dev/null"
-    tests.nested exec "test -L /etc/systemd/system/rsyslog.service"
+    remote.exec "cat /var/snap/pc/common/debug.txt" | MATCH "rsyslog symlink: /dev/null"
+    remote.exec "test -L /etc/systemd/system/rsyslog.service"
 
     echo "Check that the timezone is set"
-    tests.nested exec "cat /etc/timezone" | MATCH "Europe/Malta"
-    tests.nested exec "readlink -f /etc/localtime" | MATCH "Europe/Malta"
-    tests.nested exec "cat /var/snap/pc/common/debug.txt" | MATCH "localtime symlink: /usr/share/zoneinfo/Europe/Malta"
+    remote.exec "cat /etc/timezone" | MATCH "Europe/Malta"
+    remote.exec "readlink -f /etc/localtime" | MATCH "Europe/Malta"
+    remote.exec "cat /var/snap/pc/common/debug.txt" | MATCH "localtime symlink: /usr/share/zoneinfo/Europe/Malta"
 
     echo "Check that console-conf is disabled"
-    tests.nested exec "cat /var/lib/console-conf/complete" | MATCH "console-conf has been disabled by the snapd system configuration"
+    remote.exec "cat /var/lib/console-conf/complete" | MATCH "console-conf has been disabled by the snapd system configuration"
 
     # hostname is set
-    tests.nested exec "cat /etc/hostname" | MATCH "F00"
+    remote.exec "cat /etc/hostname" | MATCH "F00"

--- a/tests/nested/manual/core-seeding-devmode/task.yaml
+++ b/tests/nested/manual/core-seeding-devmode/task.yaml
@@ -16,7 +16,7 @@ prepare: |
     tests.nested create-vm core
 
 execute: |
-    tests.nested exec "sudo snap wait system seed.loaded"
+    remote.exec "sudo snap wait system seed.loaded"
 
     # godd is installed
-    tests.nested exec "snap list godd" | MATCH "godd"
+    remote.exec "snap list godd" | MATCH "godd"

--- a/tests/nested/manual/core20-4k-sector-size/task.yaml
+++ b/tests/nested/manual/core20-4k-sector-size/task.yaml
@@ -15,37 +15,37 @@ prepare: |
 
 execute: |
     echo "Wait for the system to be seeded first"
-    tests.nested exec "sudo snap wait system seed.loaded"
+    remote.exec "sudo snap wait system seed.loaded"
 
     echo "Ensure 'snap install' works"
-    tests.nested exec "sudo snap install test-snapd-sh"
+    remote.exec "sudo snap install test-snapd-sh"
 
     echo "Ensure 'snap list' works and test-snapd-sh snap is installed"
-    tests.nested exec "snap list" | MATCH test-snapd-sh
+    remote.exec "snap list" | MATCH test-snapd-sh
 
     echo "Ensure 'snap find' works"
-    tests.nested exec "snap find test-snapd-sh" | MATCH ^test-snapd-sh
+    remote.exec "snap find test-snapd-sh" | MATCH ^test-snapd-sh
 
     echo "Ensure 'snap info' works"
-    tests.nested exec "snap info test-snapd-sh" | MATCH '^name:\ +test-snapd-sh'
+    remote.exec "snap info test-snapd-sh" | MATCH '^name:\ +test-snapd-sh'
 
     echo "Ensure 'snap remove' works"
-    tests.nested exec "sudo snap remove test-snapd-sh"
+    remote.exec "sudo snap remove test-snapd-sh"
 
     echo "Ensure 'snap list' works and test-snapd-sh snap is removed"
-    tests.nested exec "! snap list test-snapd-sh"
+    remote.exec "! snap list test-snapd-sh"
 
     echo "Verifying tpm working on the nested vm"
-    tests.nested exec "sudo dmesg | grep -i tpm" | MATCH "efi: +SMBIOS=.* +TPMFinalLog=.*"
-    tests.nested exec "test -e /sys/kernel/security/tpm0/binary_bios_measurements"
+    remote.exec "sudo dmesg | grep -i tpm" | MATCH "efi: +SMBIOS=.* +TPMFinalLog=.*"
+    remote.exec "test -e /sys/kernel/security/tpm0/binary_bios_measurements"
 
     echo "and secure boot is enabled on the nested vm"
-    tests.nested exec "xxd /sys/firmware/efi/efivars/SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c" | MATCH "00000000: 0600 0000 01\s+....."
+    remote.exec "xxd /sys/firmware/efi/efivars/SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c" | MATCH "00000000: 0600 0000 01\s+....."
 
     echo "Ensure 'snap recovery show-keys' works as root"
-    tests.nested exec "sudo snap recovery --show-keys" | MATCH 'recovery:\s+[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}'
+    remote.exec "sudo snap recovery --show-keys" | MATCH 'recovery:\s+[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}-[0-9]{5}'
     echo "But not as user (normal file permissions prevent this)"
-    if tests.nested exec "snap recovery --show-keys"; then
+    if remote.exec "snap recovery --show-keys"; then
         echo "snap recovery --show-key should not work as a user"
         exit 1
     fi

--- a/tests/nested/manual/core20-boot-config-update/task.yaml
+++ b/tests/nested/manual/core20-boot-config-update/task.yaml
@@ -64,7 +64,7 @@ prepare: |
   tests.nested build-image core
   tests.nested create-vm core
 
-  tests.nested copy snapd-boot-config-update.snap
+  remote.push snapd-boot-config-update.snap
 
 debug: |
   cat boot-chains-before.json || true
@@ -76,8 +76,8 @@ execute: |
       exit
   fi
 
-  tests.nested exec sudo cat /var/lib/snapd/device/fde/boot-chains > boot-chains-before.json
-  SEALED_KEY_MTIME_1="$(tests.nested exec sudo stat --format="%Y" /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key)"
+  remote.exec sudo cat /var/lib/snapd/device/fde/boot-chains > boot-chains-before.json
+  SEALED_KEY_MTIME_1="$(remote.exec sudo stat --format="%Y" /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key)"
   RESEAL_COUNT_1="$(jq -r '.["reseal-count"]' < boot-chains-before.json )"
   jq -r '.["boot-chains"][]["kernel-cmdlines"][]' < boot-chains-before.json | NOMATCH ' bootassetstesting'
   case "$VARIANT" in
@@ -94,8 +94,8 @@ execute: |
 
   echo "Install new (unasserted) snapd and wait for reboot/change finishing"
   boot_id="$( tests.nested boot-id )"
-  REMOTE_CHG_ID=$(tests.nested exec sudo snap install --dangerous snapd-boot-config-update.snap --no-wait)
-  tests.nested exec sudo snap watch "${REMOTE_CHG_ID}"
+  REMOTE_CHG_ID=$(remote.exec sudo snap install --dangerous snapd-boot-config-update.snap --no-wait)
+  remote.exec sudo snap watch "${REMOTE_CHG_ID}"
   if [ "$VARIANT" != "gadget-full" ]; then
     # reboot is automatically requested by snapd only if part of the command
     # line is changed, in case of gadget overriding the command line fully
@@ -105,10 +105,10 @@ execute: |
   fi
   
   echo "check boot assets have been updated"
-  tests.nested exec "sudo cat /boot/grub/grub.cfg" | MATCH "Snapd-Boot-Config-Edition: 2"
-  tests.nested exec "sudo cat /boot/grub/grub.cfg" | MATCH "set snapd_static_cmdline_args='.*bootassetstesting'"
+  remote.exec "sudo cat /boot/grub/grub.cfg" | MATCH "Snapd-Boot-Config-Edition: 2"
+  remote.exec "sudo cat /boot/grub/grub.cfg" | MATCH "set snapd_static_cmdline_args='.*bootassetstesting'"
 
-  tests.nested exec "cat /proc/cmdline" > system.cmdline
+  remote.exec "cat /proc/cmdline" > system.cmdline
 
   case "$VARIANT" in
     no-gadget)
@@ -128,7 +128,7 @@ execute: |
   esac
 
   echo "Check ubuntu-data.sealed-key mtime is newer or not depending on test variant"
-  SEALED_KEY_MTIME_2="$(tests.nested exec sudo stat --format="%Y" /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key)"
+  SEALED_KEY_MTIME_2="$(remote.exec sudo stat --format="%Y" /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key)"
   case "$VARIANT" in
     no-gadget|gadget-extra)
       test "$SEALED_KEY_MTIME_2" -gt "$SEALED_KEY_MTIME_1"
@@ -138,7 +138,7 @@ execute: |
       ;;
   esac
 
-  tests.nested exec sudo cat /var/lib/snapd/device/fde/boot-chains > boot-chains-after.json
+  remote.exec sudo cat /var/lib/snapd/device/fde/boot-chains > boot-chains-after.json
   RESEAL_COUNT_2="$(jq -r '.["reseal-count"]' < boot-chains-after.json )"
   case "$VARIANT" in
     no-gadget|gadget-extra)

--- a/tests/nested/manual/core20-cloud-init-maas-signed-seed-data/task.yaml
+++ b/tests/nested/manual/core20-cloud-init-maas-signed-seed-data/task.yaml
@@ -156,11 +156,11 @@ restore: |
   teardown_fake_store "$NESTED_FAKESTORE_BLOB_DIR"
 
 debug: |
-  tests.nested exec "snap changes" || true
-  tests.nested exec "snap tasks 1" || true
-  tests.nested exec "snap tasks 2" || true
+  remote.exec "snap changes" || true
+  remote.exec "snap tasks 1" || true
+  remote.exec "snap tasks 2" || true
 
-  tests.nested exec "cloud-init status --long" || true
+  remote.exec "cloud-init status --long" || true
 
 execute: |
   if [ "$TRUST_TEST_KEYS" = "false" ]; then
@@ -192,12 +192,12 @@ execute: |
   sudo journalctl --no-pager -u snapd | MATCH "cloud-init reported to be in error state after 3 minutes"
   EOF
 
-  tests.nested copy /tmp/snapd-journal-match-script-disable-state.sh
-  tests.nested copy /tmp/snapd-journal-match-script-error-notice-state.sh
-  tests.nested copy /tmp/snapd-journal-match-script-error-disable-state.sh
-  tests.nested exec "chmod +x /home/user1/snapd-journal-match-script-disable-state.sh"
-  tests.nested exec "chmod +x /home/user1/snapd-journal-match-script-error-notice-state.sh"
-  tests.nested exec "chmod +x /home/user1/snapd-journal-match-script-error-disable-state.sh"
+  remote.push /tmp/snapd-journal-match-script-disable-state.sh
+  remote.push /tmp/snapd-journal-match-script-error-notice-state.sh
+  remote.push /tmp/snapd-journal-match-script-error-disable-state.sh
+  remote.exec "chmod +x /home/user1/snapd-journal-match-script-disable-state.sh"
+  remote.exec "chmod +x /home/user1/snapd-journal-match-script-error-notice-state.sh"
+  remote.exec "chmod +x /home/user1/snapd-journal-match-script-error-disable-state.sh"
 
   # there are two options here, one is where we actually let cloud-init stay 
   # enabled with the variant where the gadget allowed it, in which case 
@@ -206,20 +206,20 @@ execute: |
   # all datasources in which case snapd notices cloud-init as being disabled
   if [ "$GADGET_DATASOURCE" = "explicitly-none" ]; then
     # snapd should disable cloud-init
-    retry --wait 1 -n 60 sh -c 'tests.nested exec /home/user1/snapd-journal-match-script-disable-state.sh'
+    retry --wait 1 -n 60 sh -c 'remote.exec /home/user1/snapd-journal-match-script-disable-state.sh'
 
-    tests.nested exec "cloud-init status" | MATCH "status: disabled"
+    remote.exec "cloud-init status" | MATCH "status: disabled"
   else
     # the first message is about snapd noticing that cloud-init is in error, and
     # for how long snapd will wait for cloud-init, this message should show up
     # relatively quickly
-    retry --wait 1 -n 60 sh -c 'tests.nested exec /home/user1/snapd-journal-match-script-error-notice-state.sh'
+    retry --wait 1 -n 60 sh -c 'remote.exec /home/user1/snapd-journal-match-script-error-notice-state.sh'
 
     # we now wait for 3 minutes before snapd gives up waiting and disables 
     # cloud-init
-    retry --wait 4 -n 60 sh -c 'tests.nested exec /home/user1/snapd-journal-match-script-error-disable-state.sh'
+    retry --wait 4 -n 60 sh -c 'remote.exec /home/user1/snapd-journal-match-script-error-disable-state.sh'
 
-    tests.nested exec "cloud-init status" | MATCH "status: error"
+    remote.exec "cloud-init status" | MATCH "status: error"
   fi
 
   echo "Ensuring that cloud-init got disabled"
@@ -227,7 +227,7 @@ execute: |
   # MAAS datasource being broken and thus getting eventually disabled by snapd
   # uggggggghhhhhhhhhh bash quoting strikes again - arguments to the test 
   # command do not get passed if we do something obvious like
-  # retry --wait 1 -n 240 sh -c "tests.nested exec sh -c 'test -f /etc/cloud/cloud-init.disabled'"
+  # retry --wait 1 -n 240 sh -c "remote.exec sh -c 'test -f /etc/cloud/cloud-init.disabled'"
   # so instead we must put this command into a file, copy it over and then
   # execute this file, putting the scoreboard at BASH ∞ + 1, IAN 0
   cat > /tmp/snapd-cloud-init-disabled-check.sh << 'EOF'
@@ -235,36 +235,36 @@ execute: |
   test -f /etc/cloud/cloud-init.disabled
   EOF
 
-  tests.nested copy /tmp/snapd-cloud-init-disabled-check.sh
-  tests.nested exec "chmod +x /home/user1/snapd-cloud-init-disabled-check.sh"
+  remote.push /tmp/snapd-cloud-init-disabled-check.sh
+  remote.exec "chmod +x /home/user1/snapd-cloud-init-disabled-check.sh"
 
-  retry --wait 1 -n 240 sh -c "tests.nested exec /home/user1/snapd-cloud-init-disabled-check.sh"
+  retry --wait 1 -n 240 sh -c "remote.exec /home/user1/snapd-cloud-init-disabled-check.sh"
 
   echo "Relevant files were copied"
   if [ "$GADGET_DATASOURCE" = "explicitly-none" ]; then
     # gadget said no datasources so nothing was copied
-    tests.nested exec "! test -f /etc/cloud/cloud.cfg.d/90_50-cloudconfig-maas-cloud-config.cfg"
-    tests.nested exec "! test -f /etc/cloud/cloud.cfg.d/90_50-cloudconfig-maas-datasource.cfg"
-    tests.nested exec "! test -f /etc/cloud/cloud.cfg.d/90_50-cloudconfig-maas-reporting.cfg"
-    tests.nested exec "! test -f /etc/cloud/cloud.cfg.d/90_50-curtin-networking.cfg"
+    remote.exec "! test -f /etc/cloud/cloud.cfg.d/90_50-cloudconfig-maas-cloud-config.cfg"
+    remote.exec "! test -f /etc/cloud/cloud.cfg.d/90_50-cloudconfig-maas-datasource.cfg"
+    remote.exec "! test -f /etc/cloud/cloud.cfg.d/90_50-cloudconfig-maas-reporting.cfg"
+    remote.exec "! test -f /etc/cloud/cloud.cfg.d/90_50-curtin-networking.cfg"
   else
-    tests.nested exec "test -f /etc/cloud/cloud.cfg.d/90_50-cloudconfig-maas-cloud-config.cfg"
-    tests.nested exec "test -f /etc/cloud/cloud.cfg.d/90_50-cloudconfig-maas-datasource.cfg"
-    tests.nested exec "test -f /etc/cloud/cloud.cfg.d/90_50-cloudconfig-maas-reporting.cfg"
-    tests.nested exec "test -f /etc/cloud/cloud.cfg.d/90_50-curtin-networking.cfg"
+    remote.exec "test -f /etc/cloud/cloud.cfg.d/90_50-cloudconfig-maas-cloud-config.cfg"
+    remote.exec "test -f /etc/cloud/cloud.cfg.d/90_50-cloudconfig-maas-datasource.cfg"
+    remote.exec "test -f /etc/cloud/cloud.cfg.d/90_50-cloudconfig-maas-reporting.cfg"
+    remote.exec "test -f /etc/cloud/cloud.cfg.d/90_50-curtin-networking.cfg"
   fi
 
   echo "Filtered files were not copied"
-  tests.nested exec "! test -f /etc/cloud/cloud.cfg.d/90_50-cloudconfig-maas-ubuntu-sso.cfg"
-  tests.nested exec "! test -f /etc/cloud/cloud.cfg.d/90_50-cloudconfig-gce-unsupported-config.cfg"
+  remote.exec "! test -f /etc/cloud/cloud.cfg.d/90_50-cloudconfig-maas-ubuntu-sso.cfg"
+  remote.exec "! test -f /etc/cloud/cloud.cfg.d/90_50-cloudconfig-gce-unsupported-config.cfg"
 
   # check that the gadget cloud.conf was copied too if it exists and is 
   # meaningful
   echo "The gadget cloud.conf was copied if it was in the gadget"
   if [ "$GADGET_DATASOURCE" = absent ]; then
-    tests.nested exec "! test -f /etc/cloud/cloud.cfg.d/80_device_gadget.cfg"
+    remote.exec "! test -f /etc/cloud/cloud.cfg.d/80_device_gadget.cfg"
   else
-    tests.nested exec "test -f /etc/cloud/cloud.cfg.d/80_device_gadget.cfg"
+    remote.exec "test -f /etc/cloud/cloud.cfg.d/80_device_gadget.cfg"
   fi
 
   echo "The datasource_list restriction file was installed if we copied files"
@@ -275,10 +275,10 @@ execute: |
     # statically support and what the gadget says and what ubuntu-seed says is
     # not empty, so the only case where files don't get installed of the 3 
     # variants is where the gadget datasource says explicitly none
-    tests.nested exec "! test -f /etc/cloud/cloud.cfg.d/99_snapd_datasource.cfg"
+    remote.exec "! test -f /etc/cloud/cloud.cfg.d/99_snapd_datasource.cfg"
   else
-    tests.nested exec "test -f /etc/cloud/cloud.cfg.d/99_snapd_datasource.cfg"
-    tests.nested exec "cat /etc/cloud/cloud.cfg.d/99_snapd_datasource.cfg" > datasource_restrict.cfg
+    remote.exec "test -f /etc/cloud/cloud.cfg.d/99_snapd_datasource.cfg"
+    remote.exec "cat /etc/cloud/cloud.cfg.d/99_snapd_datasource.cfg" > datasource_restrict.cfg
     # check that it has only MAAS
     #shellcheck disable=SC2002
     cat datasource_restrict.cfg | yaml2json | jq -r '."datasource_list" | .[]' | MATCH MAAS

--- a/tests/nested/manual/core20-custom-kernel-commandline/task.yaml
+++ b/tests/nested/manual/core20-custom-kernel-commandline/task.yaml
@@ -48,7 +48,7 @@ prepare: |
     tests.nested create-vm core
 
     for f in pc-gadget-cmdline-extra-updated.snap pc-gadget-cmdline-full.snap pc-gadget-cmdline-none.snap; do
-        tests.nested copy "$f"
+        remote.push "$f"
     done
 
 debug: |
@@ -60,49 +60,49 @@ execute: |
 
     echo "Make sure the system is encrypted"
     # in which case the boot chains must exist
-    tests.nested exec sudo cat /var/lib/snapd/device/fde/boot-chains
+    remote.exec sudo cat /var/lib/snapd/device/fde/boot-chains
 
     # system is in run mode
     echo "Make sure the system is in run mode"
-    tests.nested exec 'sudo cat /proc/cmdline' > system.cmdline.run
+    remote.exec 'sudo cat /proc/cmdline' > system.cmdline.run
     MATCH snapd_recovery_mode=run < system.cmdline.run
 
     echo "Verify kernel command line in run mode"
     MATCH 'snapd_recovery_mode=run .* hello from test$' < system.cmdline.run
 
     echo "Perform an update of the gadget"
-    REMOTE_CHG_ID=$(tests.nested exec 'sudo snap install --dangerous --no-wait ./pc-gadget-cmdline-extra-updated.snap')
+    REMOTE_CHG_ID=$(remote.exec 'sudo snap install --dangerous --no-wait ./pc-gadget-cmdline-extra-updated.snap')
 
     echo "Wait for reboot"
     tests.nested wait-for reboot "${boot_id}"
     boot_id="$(tests.nested boot-id)"
-    tests.nested exec 'sudo cat /proc/cmdline' | MATCH 'snapd_recovery_mode=run .* updated hello from test'
+    remote.exec 'sudo cat /proc/cmdline' | MATCH 'snapd_recovery_mode=run .* updated hello from test'
     # wait for previous change to finish before proceeding
-    tests.nested exec sudo snap watch "$REMOTE_CHG_ID"
+    remote.exec sudo snap watch "$REMOTE_CHG_ID"
 
     echo "Update to gadget with no command line"
-    REMOTE_CHG_ID=$(tests.nested exec 'sudo snap install --dangerous --no-wait ./pc-gadget-cmdline-none.snap')
+    REMOTE_CHG_ID=$(remote.exec 'sudo snap install --dangerous --no-wait ./pc-gadget-cmdline-none.snap')
     tests.nested wait-for reboot "${boot_id}"
     boot_id="$(tests.nested boot-id)"
     echo "Verify that custom command line elements are not present"
-    tests.nested exec 'sudo cat /proc/cmdline' | NOMATCH 'hello from test'
+    remote.exec 'sudo cat /proc/cmdline' | NOMATCH 'hello from test'
     # wait for previous change to finish before proceeding
-    tests.nested exec sudo snap watch "$REMOTE_CHG_ID"
+    remote.exec sudo snap watch "$REMOTE_CHG_ID"
 
     echo "Update to gadget with full command line"
-    REMOTE_CHG_ID=$(tests.nested exec 'sudo snap install --dangerous --no-wait ./pc-gadget-cmdline-full.snap')
+    REMOTE_CHG_ID=$(remote.exec 'sudo snap install --dangerous --no-wait ./pc-gadget-cmdline-full.snap')
     tests.nested wait-for reboot "${boot_id}"
     boot_id="$(tests.nested boot-id)"
-    tests.nested exec 'sudo cat /proc/cmdline' | MATCH 'snapd_recovery_mode=run snapd.debug=1 console=ttyS0 full hello from test'
+    remote.exec 'sudo cat /proc/cmdline' | MATCH 'snapd_recovery_mode=run snapd.debug=1 console=ttyS0 full hello from test'
     # wait for previous change to finish before proceeding
-    tests.nested exec sudo snap watch "$REMOTE_CHG_ID"
+    remote.exec sudo snap watch "$REMOTE_CHG_ID"
 
     echo "Transition to recover mode to verify kernel command line"
-    tests.nested exec 'sudo snap reboot --recover'
+    remote.exec 'sudo snap reboot --recover'
     tests.nested wait-for reboot "${boot_id}"
 
     echo "Check the vm is in recover mode"
-    tests.nested exec 'sudo cat /proc/cmdline' > system.cmdline.recover
+    remote.exec 'sudo cat /proc/cmdline' > system.cmdline.recover
     MATCH snapd_recovery_mode=recover < system.cmdline.recover
 
     MATCH 'snapd_recovery_mode=recover snapd_recovery_system=.* .* hello from test$' < system.cmdline.recover

--- a/tests/nested/manual/core20-early-config/task.yaml
+++ b/tests/nested/manual/core20-early-config/task.yaml
@@ -32,71 +32,71 @@ prepare: |
     tests.nested create-vm core
 
 restore: |
-    tests.nested exec "sudo rm -f /etc/netplan/90-snapd-config.yaml" || true
+    remote.exec "sudo rm -f /etc/netplan/90-snapd-config.yaml" || true
 
 debug: |
     # show if anything went wrong during seeding
-    tests.nested exec "snap change 1"
+    remote.exec "snap change 1"
 
 execute: |
     check_core20_early_config(){
         # precondition - check that defaults were applied; note this doesn't guarantee
         # that defaults were applied early - that is checked further down.
         echo "Precondition check of the gadget defaults"
-        tests.nested exec "sudo snap get system service.rsyslog.disable" | MATCH "true"
-        tests.nested exec "sudo snap get system watchdog.runtime-timeout" | MATCH "13m"
-        tests.nested exec "sudo snap get system system.power-key-action" | MATCH "ignore"
-        tests.nested exec "sudo snap get system system.ctrl-alt-del-action" | MATCH "none"
-        tests.nested exec "sudo snap get system system.disable-backlight-service" | MATCH "true"
+        remote.exec "sudo snap get system service.rsyslog.disable" | MATCH "true"
+        remote.exec "sudo snap get system watchdog.runtime-timeout" | MATCH "13m"
+        remote.exec "sudo snap get system system.power-key-action" | MATCH "ignore"
+        remote.exec "sudo snap get system system.ctrl-alt-del-action" | MATCH "none"
+        remote.exec "sudo snap get system system.disable-backlight-service" | MATCH "true"
 
-        tests.nested exec "test -L /etc/systemd/system/rsyslog.service"
-        tests.nested exec "cat /etc/systemd/logind.conf.d/00-snap-core.conf" | MATCH "HandlePowerKey=ignore"
-        tests.nested exec "cat /etc/systemd/system.conf.d/10-snapd-watchdog.conf" | MATCH "RuntimeWatchdogSec=780"
-        tests.nested exec "test -L /etc/systemd/system/systemd-backlight@.service"
+        remote.exec "test -L /etc/systemd/system/rsyslog.service"
+        remote.exec "cat /etc/systemd/logind.conf.d/00-snap-core.conf" | MATCH "HandlePowerKey=ignore"
+        remote.exec "cat /etc/systemd/system.conf.d/10-snapd-watchdog.conf" | MATCH "RuntimeWatchdogSec=780"
+        remote.exec "test -L /etc/systemd/system/systemd-backlight@.service"
 
         echo "Test that defaults were applied early."
         # early config is witnessed by install hook of the pc gadget. Note we can
         # only check rsyslog/backlight symlinks as other core settings cannot be
         # inspected from install hook of the gadget.
-        tests.nested exec "cat /var/snap/pc/common/debug.txt" | MATCH "rsyslog symlink: /dev/null"
-        tests.nested exec "cat /var/snap/pc/common/debug.txt" | MATCH "backlight symlink: /dev/null"
+        remote.exec "cat /var/snap/pc/common/debug.txt" | MATCH "rsyslog symlink: /dev/null"
+        remote.exec "cat /var/snap/pc/common/debug.txt" | MATCH "backlight symlink: /dev/null"
 
         # timezone is set
-        tests.nested exec "cat /etc/timezone" | MATCH "Europe/Malta"
-        tests.nested exec "readlink -f /etc/localtime" | MATCH "Europe/Malta"
-        tests.nested exec "cat /var/snap/pc/common/debug.txt" | MATCH "localtime symlink: /usr/share/zoneinfo/Europe/Malta"
+        remote.exec "cat /etc/timezone" | MATCH "Europe/Malta"
+        remote.exec "readlink -f /etc/localtime" | MATCH "Europe/Malta"
+        remote.exec "cat /var/snap/pc/common/debug.txt" | MATCH "localtime symlink: /usr/share/zoneinfo/Europe/Malta"
 
         # check console-conf disabled
-        tests.nested exec "cat /var/lib/console-conf/complete" | MATCH "console-conf has been disabled by the snapd system configuration"
+        remote.exec "cat /var/lib/console-conf/complete" | MATCH "console-conf has been disabled by the snapd system configuration"
 
         # hostname is set
-        tests.nested exec "cat /var/snap/pc/common/debug.txt" | MATCH "hostname: foo"
-        tests.nested exec "cat /etc/hostname" | MATCH "foo"
-        tests.nested exec "hostname" | MATCH "foo"
+        remote.exec "cat /var/snap/pc/common/debug.txt" | MATCH "hostname: foo"
+        remote.exec "cat /etc/hostname" | MATCH "foo"
+        remote.exec "hostname" | MATCH "foo"
 
         # netplan config defaults are applied
-        tests.nested exec "cat /etc/netplan/0-snapd-defaults.yaml" | MATCH br54
-        tests.nested exec "netplan get bridges.br54.dhcp4" | MATCH true
-        tests.nested exec "sudo snap get system system.network.netplan.network.bridges.br54.dhcp4" | MATCH true
-        tests.nested exec "netplan get ethernets.ens3.dhcp4" | MATCH false
+        remote.exec "cat /etc/netplan/0-snapd-defaults.yaml" | MATCH br54
+        remote.exec "netplan get bridges.br54.dhcp4" | MATCH true
+        remote.exec "sudo snap get system system.network.netplan.network.bridges.br54.dhcp4" | MATCH true
+        remote.exec "netplan get ethernets.ens3.dhcp4" | MATCH false
         # and updating netplan works
-        tests.nested exec "sudo snap set system system.network.netplan.network.bridges.br54.dhcp4=false"
-        tests.nested exec "netplan get bridges.br54.dhcp4" | MATCH false
-        tests.nested exec "sudo snap get system system.network.netplan.network.bridges.br54.dhcp4" | MATCH false
+        remote.exec "sudo snap set system system.network.netplan.network.bridges.br54.dhcp4=false"
+        remote.exec "netplan get bridges.br54.dhcp4" | MATCH false
+        remote.exec "sudo snap get system system.network.netplan.network.bridges.br54.dhcp4" | MATCH false
         # ensure the test can be repeated
-        tests.nested exec "sudo rm -f /etc/netplan/90-snapd-config.yaml"
+        remote.exec "sudo rm -f /etc/netplan/90-snapd-config.yaml"
     }
 
     check_core20_early_config
 
     echo "Transition to recover mode and check it again"
-    recoverySystem=$(tests.nested exec "sudo snap recovery | grep -v Notes | grep -Po '^[0-9]+'")
+    recoverySystem=$(remote.exec "sudo snap recovery | grep -v Notes | grep -Po '^[0-9]+'")
     tests.nested transition "$recoverySystem" recover
 
     echo "Wait for the snap command to be available since recover mode needs to seed itself"
     tests.nested wait-for snap-command
 
     echo "Wait for snap seeding to be done"
-    tests.nested exec "sudo snap wait system seed.loaded"
+    remote.exec "sudo snap wait system seed.loaded"
 
     check_core20_early_config

--- a/tests/nested/manual/core20-gadget-cloud-conf/task.yaml
+++ b/tests/nested/manual/core20-gadget-cloud-conf/task.yaml
@@ -126,19 +126,19 @@ execute: |
   fi
 
   echo "The initial cloud-init user was created"
-  tests.nested exec "cat /var/lib/extrausers/passwd" | MATCH normal-user
+  remote.exec "cat /var/lib/extrausers/passwd" | MATCH normal-user
 
   echo "And we can run things as the normal user"
-  tests.nested exec --user normal-user --pwd ubuntu "sudo true"
+  remote.exec --user normal-user --pwd ubuntu "sudo true"
 
   echo "Waiting for snapd to react to cloud-init"
-  retry --wait 1 -n 60 sh -c 'tests.nested exec sudo journalctl --no-pager -u snapd | MATCH "cloud-init reported"'
+  retry --wait 1 -n 60 sh -c 'remote.exec sudo journalctl --no-pager -u snapd | MATCH "cloud-init reported"'
 
   echo "Ensuring that cloud-init got disabled after running"
-  tests.nested exec "cloud-init status" | MATCH "status: disabled"
-  tests.nested exec "test -f /etc/cloud/cloud-init.disabled"
-  tests.nested exec "test -f /etc/cloud/cloud.cfg.d/80_device_gadget.cfg"
-  tests.nested exec "! test -f /etc/cloud/cloud.cfg.d/zzzz_snapd.cfg"
+  remote.exec "cloud-init status" | MATCH "status: disabled"
+  remote.exec "test -f /etc/cloud/cloud-init.disabled"
+  remote.exec "test -f /etc/cloud/cloud.cfg.d/80_device_gadget.cfg"
+  remote.exec "! test -f /etc/cloud/cloud.cfg.d/zzzz_snapd.cfg"
 
   # TODO: if we ever decide to leave NoCloud datasources enabled if the source
   # is the gadget, check that here too

--- a/tests/nested/manual/core20-grade-signed-above-testkeys-boot/task.yaml
+++ b/tests/nested/manual/core20-grade-signed-above-testkeys-boot/task.yaml
@@ -123,12 +123,12 @@ execute: |
   fi
 
   # wait for the initialize device task to be done
-  retry -n 200 --wait 1 sh -c "tests.nested exec snap changes | MATCH 'Done.*Initialize device'"
+  retry -n 200 --wait 1 sh -c "remote.exec snap changes | MATCH 'Done.*Initialize device'"
 
   # Get the nested system version
   VERSION="$(tests.nested show version)"
 
   echo "Check we have the right model from snap model"
-  tests.nested exec "sudo snap model --verbose" | MATCH "model:\s+testkeys-snapd-${MODEL_GRADE}-core-$VERSION-amd64"
-  tests.nested exec "sudo snap model --verbose" | MATCH "grade:\s+${MODEL_GRADE}"
-  tests.nested exec "sudo snap model --verbose --serial" | MATCH "serial:\s+7777"
+  remote.exec "sudo snap model --verbose" | MATCH "model:\s+testkeys-snapd-${MODEL_GRADE}-core-$VERSION-amd64"
+  remote.exec "sudo snap model --verbose" | MATCH "grade:\s+${MODEL_GRADE}"
+  remote.exec "sudo snap model --verbose --serial" | MATCH "serial:\s+7777"

--- a/tests/nested/manual/core20-grade-signed-cloud-init-testkeys/task.yaml
+++ b/tests/nested/manual/core20-grade-signed-cloud-init-testkeys/task.yaml
@@ -126,24 +126,24 @@ execute: |
   fi
 
   # wait for the initialize device task to be done
-  retry -n 200 --wait 1 sh -c "tests.nested exec snap changes | MATCH 'Done.*Initialize device'"
+  retry -n 200 --wait 1 sh -c "remote.exec snap changes | MATCH 'Done.*Initialize device'"
 
   echo "The initial cloud-init user was created"
-  tests.nested exec "cat /var/lib/extrausers/passwd" | MATCH normal-user
+  remote.exec "cat /var/lib/extrausers/passwd" | MATCH normal-user
 
   echo "And we can run things as the normal user"
-  tests.nested exec --user normal-user --pwd ubuntu "sudo true"
+  remote.exec --user normal-user --pwd ubuntu "sudo true"
 
   echo "And we got a serial assertion from the fakestore"
-  tests.nested exec "sudo snap model --verbose --serial" | MATCH "serial:\s+7777"
+  remote.exec "sudo snap model --verbose --serial" | MATCH "serial:\s+7777"
 
   echo "Waiting for snapd to react to cloud-init"
-  retry --wait 1 -n 60 sh -c 'tests.nested exec sudo journalctl --no-pager -u snapd | MATCH "cloud-init reported"'
+  retry --wait 1 -n 60 sh -c 'remote.exec sudo journalctl --no-pager -u snapd | MATCH "cloud-init reported"'
 
   echo "Ensuring that cloud-init got disabled after running"
-  tests.nested exec "cloud-init status" | MATCH "status: disabled"
-  tests.nested exec "test -f /etc/cloud/cloud-init.disabled"
-  tests.nested exec "! test -f /etc/cloud/cloud.cfg.d/zzzz_snapd.cfg"
+  remote.exec "cloud-init status" | MATCH "status: disabled"
+  remote.exec "test -f /etc/cloud/cloud-init.disabled"
+  remote.exec "! test -f /etc/cloud/cloud.cfg.d/zzzz_snapd.cfg"
 
   # gracefully shutdown so that we don't have file corruption
   echo "Gracefully shutting down the nested VM to prepare a simulated attack"
@@ -158,9 +158,9 @@ execute: |
   tests.nested wait-for reboot "${boot_id}"
 
   echo "The cloud-init attacker user was not created"
-  tests.nested exec "cat /var/lib/extrausers/passwd" | NOMATCH attacker-user
+  remote.exec "cat /var/lib/extrausers/passwd" | NOMATCH attacker-user
 
   echo "cloud-init is still disabled"
-  tests.nested exec "cloud-init status" | MATCH "status: disabled"
-  tests.nested exec "test -f /etc/cloud/cloud-init.disabled"
-  tests.nested exec "! test -f /etc/cloud/cloud.cfg.d/zzzz_snapd.cfg"
+  remote.exec "cloud-init status" | MATCH "status: disabled"
+  remote.exec "test -f /etc/cloud/cloud-init.disabled"
+  remote.exec "! test -f /etc/cloud/cloud.cfg.d/zzzz_snapd.cfg"

--- a/tests/nested/manual/core20-initramfs-time-moves-forward/task.yaml
+++ b/tests/nested/manual/core20-initramfs-time-moves-forward/task.yaml
@@ -27,7 +27,7 @@ prepare: |
 
 execute: |
   echo "Verify that the current time in the VM is newer than the model assertion sign time"
-  test "$(tests.nested exec date --utc '+%s')" -ge "$MODEL_ASSERTION_SIGN_TIME"
+  test "$(remote.exec date --utc '+%s')" -ge "$MODEL_ASSERTION_SIGN_TIME"
 
   echo "Verify that the timestamp from after snap-bootstrap ran is greater than the time from the model assertion"
-  test "$(tests.nested exec "cat /run/mnt/ubuntu-seed/test/install-after-snap-bootstrap-date")" -ge "$MODEL_ASSERTION_SIGN_TIME"
+  test "$(remote.exec "cat /run/mnt/ubuntu-seed/test/install-after-snap-bootstrap-date")" -ge "$MODEL_ASSERTION_SIGN_TIME"

--- a/tests/nested/manual/core20-install-device-file-install-via-hook-hack/task.yaml
+++ b/tests/nested/manual/core20-install-device-file-install-via-hook-hack/task.yaml
@@ -138,26 +138,26 @@ execute: |
     fi
 
     # wait for the initialize device task to be done
-    retry -n 200 --wait 1 sh -c "tests.nested exec snap changes | MATCH 'Done.*Initialize device'"
+    retry -n 200 --wait 1 sh -c "remote.exec snap changes | MATCH 'Done.*Initialize device'"
 
     VERSION="$(tests.nested show version)"
 
     echo "Check we have the right model from snap model"
-    tests.nested exec "sudo snap model --verbose" | MATCH "model:\s+testkeys-snapd-secured-core-$VERSION-amd64"
-    tests.nested exec "sudo snap model --verbose" | MATCH "grade:\s+secured"
-    tests.nested exec "sudo snap model --verbose --serial" | MATCH "serial:\s+7777"
+    remote.exec "sudo snap model --verbose" | MATCH "model:\s+testkeys-snapd-secured-core-$VERSION-amd64"
+    remote.exec "sudo snap model --verbose" | MATCH "grade:\s+secured"
+    remote.exec "sudo snap model --verbose --serial" | MATCH "serial:\s+7777"
 
     echo "Check that the system-files interface is connected for the pc snap"
-    tests.nested exec "snap connections pc" | MATCH 'system-files\s+pc:modprobe-conf\s+:system-files'
-    tests.nested exec "snap connections pc" | MATCH 'system-files\s+pc:modules-load-conf\s+:system-files'
-    tests.nested exec "snap connections pc" | MATCH 'system-files\s+pc:udev-rules-conf\s+:system-files'
+    remote.exec "snap connections pc" | MATCH 'system-files\s+pc:modprobe-conf\s+:system-files'
+    remote.exec "snap connections pc" | MATCH 'system-files\s+pc:modules-load-conf\s+:system-files'
+    remote.exec "snap connections pc" | MATCH 'system-files\s+pc:udev-rules-conf\s+:system-files'
 
     echo "Check that the directories have the right permissions"
-    tests.nested exec "stat /etc/modprobe.d/ -c %a" | MATCH 755
-    tests.nested exec "stat /etc/modules-load.d/ -c %a" | MATCH 755
-    tests.nested exec "stat /etc/udev/rules.d/ -c %a" | MATCH 755
+    remote.exec "stat /etc/modprobe.d/ -c %a" | MATCH 755
+    remote.exec "stat /etc/modules-load.d/ -c %a" | MATCH 755
+    remote.exec "stat /etc/udev/rules.d/ -c %a" | MATCH 755
 
     echo "Check that the files from install-device were installed"
-    tests.nested exec "cat /etc/modprobe.d/my-modprobe.conf" | MATCH '# configure modprobe here'
-    tests.nested exec "cat /etc/modules-load.d/my-modules-load.conf" | MATCH '# load modules here'
-    tests.nested exec "cat /etc/udev/rules.d/09-my-custom-udev.rules" | MATCH  '# do udev rules things here'
+    remote.exec "cat /etc/modprobe.d/my-modprobe.conf" | MATCH '# configure modprobe here'
+    remote.exec "cat /etc/modules-load.d/my-modules-load.conf" | MATCH '# load modules here'
+    remote.exec "cat /etc/udev/rules.d/09-my-custom-udev.rules" | MATCH  '# do udev rules things here'

--- a/tests/nested/manual/core20-install-mode-shutdown-via-hook/task.yaml
+++ b/tests/nested/manual/core20-install-mode-shutdown-via-hook/task.yaml
@@ -88,10 +88,10 @@ execute: |
     # things here, so wait for those too
     tests.nested wait-for snap-command
     # Wait for snap seeding to be done
-    tests.nested exec "sudo snap wait system seed.loaded"
+    remote.exec "sudo snap wait system seed.loaded"
     # Wait for cloud init to be done
-    tests.nested exec "cloud-init status --wait"
+    remote.exec "cloud-init status --wait"
 
     echo "The device is using encrypted ubuntu-data and is in run mode now"
-    tests.nested exec test -L /dev/disk/by-label/ubuntu-data-enc
-    tests.nested exec cat /proc/cmdline | MATCH "snapd_recovery_mode=run"
+    remote.exec test -L /dev/disk/by-label/ubuntu-data-enc
+    remote.exec cat /proc/cmdline | MATCH "snapd_recovery_mode=run"

--- a/tests/nested/manual/core20-new-snapd-does-not-break-old-initrd/task.yaml
+++ b/tests/nested/manual/core20-new-snapd-does-not-break-old-initrd/task.yaml
@@ -83,19 +83,19 @@ prepare: |
 execute: |
   # on the old variant, copy and install the new snapd to it
   if [ "$START_SNAPD_VERSION" = "old" ]; then
-    tests.nested copy snapd-from-branch.snap  
-    tests.nested exec "sudo snap install --dangerous snapd-from-branch.snap"
+    remote.push snapd-from-branch.snap  
+    remote.exec "sudo snap install --dangerous snapd-from-branch.snap"
   fi
 
   # try a refresh to a new kernel revision which will trigger a reseal and then
   # a reboot
-  tests.nested copy new-kernel.snap
+  remote.push new-kernel.snap
 
   boot_id="$( tests.nested boot-id )"
-  REMOTE_CHG_ID=$(tests.nested exec "sudo snap install --dangerous new-kernel.snap --no-wait")
+  REMOTE_CHG_ID=$(remote.exec "sudo snap install --dangerous new-kernel.snap --no-wait")
   tests.nested wait-for reboot "${boot_id}"
-  tests.nested exec sudo snap watch "${REMOTE_CHG_ID}"
+  remote.exec sudo snap watch "${REMOTE_CHG_ID}"
 
-  tests.nested exec "snap changes" | tail -n +2 | awk '{print $2}' | NOMATCH Error
+  remote.exec "snap changes" | tail -n +2 | awk '{print $2}' | NOMATCH Error
 
   # TODO: also check transitioning to the recovery seed system too?

--- a/tests/nested/manual/core20-preseed/task.yaml
+++ b/tests/nested/manual/core20-preseed/task.yaml
@@ -46,7 +46,7 @@ restore: |
 
 debug: |
   # show if anything went wrong during seeding
-  tests.nested exec "snap change 1" || true
+  remote.exec "snap change 1" || true
   echo "gpg key id:$NESTED_UBUNTU_IMAGE_PRESEED_KEY"
 
 execute: |
@@ -58,12 +58,12 @@ execute: |
   tests.nested create-vm core
 
   echo "Wait for snap seeding to be done"
-  tests.nested exec "sudo snap wait system seed.loaded"
+  remote.exec "sudo snap wait system seed.loaded"
 
   echo "Verify that the image was preseeded"
-  tests.nested exec "snap debug seeding" | MATCH "^preseeded: +true"
+  remote.exec "snap debug seeding" | MATCH "^preseeded: +true"
 
   echo "Check that no snaps are broken"
-  tests.nested exec "snap list" | NOMATCH "broken"
-  tests.nested exec "snap list" | MATCH "core20"
-  tests.nested exec "snap list" | MATCH "snapd"
+  remote.exec "snap list" | NOMATCH "broken"
+  remote.exec "snap list" | MATCH "core20"
+  remote.exec "snap list" | MATCH "snapd"

--- a/tests/nested/manual/core20-remodel/task.yaml
+++ b/tests/nested/manual/core20-remodel/task.yaml
@@ -17,11 +17,11 @@ execute: |
     # shellcheck source=tests/lib/nested.sh
     . "$TESTSLIB/nested.sh"
     boot_id="$(tests.nested boot-id)"
-    tests.nested exec snap model |MATCH 'model +my-model$'
+    remote.exec snap model |MATCH 'model +my-model$'
     # XXX: recovery system label is based on a date; we may end up with a
     # different label if the remodel runs around midnight; the label will
     # conflict with an existing system label
-    label_base=$(tests.nested exec "date '+%Y%m%d'")
+    label_base=$(remote.exec "date '+%Y%m%d'")
 
     # wait until device is initialized and has a serial
     tests.nested wait-for device-initialized
@@ -30,70 +30,70 @@ execute: |
     VERSION="$(tests.nested show version)"
 
     echo "Refresh model assertion to revision 2"
-    tests.nested copy "$TESTSLIB/assertions/valid-for-testing-pc-revno-2-$VERSION.model"
-    REMOTE_CHG_ID="$(tests.nested exec sudo snap remodel --no-wait "valid-for-testing-pc-revno-2-$VERSION.model")"
+    remote.push "$TESTSLIB/assertions/valid-for-testing-pc-revno-2-$VERSION.model"
+    REMOTE_CHG_ID="$(remote.exec sudo snap remodel --no-wait "valid-for-testing-pc-revno-2-$VERSION.model")"
     tests.nested wait-for reboot "${boot_id}"
-    tests.nested exec sudo snap watch "${REMOTE_CHG_ID}"
+    remote.exec sudo snap watch "${REMOTE_CHG_ID}"
 
     echo "Verify the system is back in run mode"
-    tests.nested exec "sudo cat /proc/cmdline" | MATCH snapd_recovery_mode=run
+    remote.exec "sudo cat /proc/cmdline" | MATCH snapd_recovery_mode=run
 
     # this is a simple model revision refresh
     echo "Verify the model"
-    tests.nested exec snap model --verbose > rev-2-model
+    remote.exec snap model --verbose > rev-2-model
     MATCH 'model: +my-model' < rev-2-model
     MATCH 'revision: +2' < rev-2-model
 
     # seed system was created
     revno2_label="${label_base}-1"
     echo "Verify seed system with label $revno2_label"
-    tests.nested exec "sudo cat /run/mnt/ubuntu-seed/systems/${revno2_label}/model" > revno-2-from-seed.model
+    remote.exec "sudo cat /run/mnt/ubuntu-seed/systems/${revno2_label}/model" > revno-2-from-seed.model
     MATCH 'model: my-model' < revno-2-from-seed.model
     MATCH 'revision: 2' < revno-2-from-seed.model
-    tests.nested exec "sudo cat /var/lib/snapd/modeenv" > modeenv
+    remote.exec "sudo cat /var/lib/snapd/modeenv" > modeenv
     MATCH "current_recovery_systems=.*,${revno2_label}" < modeenv
     MATCH "good_recovery_systems=.*,${revno2_label}" < modeenv
-    tests.nested exec "sudo snap debug boot-vars --root-dir=/run/mnt/ubuntu-seed" | MATCH "snapd_good_recovery_systems=${label_base},${revno2_label}"
+    remote.exec "sudo snap debug boot-vars --root-dir=/run/mnt/ubuntu-seed" | MATCH "snapd_good_recovery_systems=${label_base},${revno2_label}"
 
     # the revision pulls in test-snapd-tools-core2* snap
     echo "Verify new model revision snaps"
-    tests.nested exec snap list "test-snapd-tools-core$VERSION"
+    remote.exec snap list "test-snapd-tools-core$VERSION"
     # the snap is pulled in from the store, so it should be located in shared
     # snaps directory
-    tests.nested exec find /run/mnt/ubuntu-seed/snaps -name "test-snapd-tools-core${VERSION}_*.snap" | MATCH "test-snapd-tools-core$VERSION"
+    remote.exec find /run/mnt/ubuntu-seed/snaps -name "test-snapd-tools-core${VERSION}_*.snap" | MATCH "test-snapd-tools-core$VERSION"
 
     boot_id="$(tests.nested boot-id)"
 
     echo "Refresh model assertion to revision 3"
-    tests.nested copy "$TESTSLIB/assertions/valid-for-testing-pc-revno-3-$VERSION.model"
-    REMOTE_CHG_ID="$(tests.nested exec sudo snap remodel --no-wait "valid-for-testing-pc-revno-3-$VERSION.model")"
+    remote.push "$TESTSLIB/assertions/valid-for-testing-pc-revno-3-$VERSION.model"
+    REMOTE_CHG_ID="$(remote.exec sudo snap remodel --no-wait "valid-for-testing-pc-revno-3-$VERSION.model")"
     tests.nested wait-for reboot "${boot_id}"
-    tests.nested exec sudo snap watch "${REMOTE_CHG_ID}"
+    remote.exec sudo snap watch "${REMOTE_CHG_ID}"
 
     echo "Verify the model"
-    tests.nested exec snap model --verbose > rev-3-model
+    remote.exec snap model --verbose > rev-3-model
     MATCH 'model: +my-model' < rev-3-model
     MATCH 'revision: +3' < rev-3-model
 
     # seed system was created
     revno3_label="${label_base}-2"
     echo "Verify seed system with label $revno3_label"
-    tests.nested exec "sudo cat /run/mnt/ubuntu-seed/systems/${revno3_label}/model" > revno-3-from-seed.model
+    remote.exec "sudo cat /run/mnt/ubuntu-seed/systems/${revno3_label}/model" > revno-3-from-seed.model
     MATCH 'model: my-model' < revno-3-from-seed.model
     MATCH 'revision: 3' < revno-3-from-seed.model
-    tests.nested exec "sudo cat /var/lib/snapd/modeenv" > modeenv
+    remote.exec "sudo cat /var/lib/snapd/modeenv" > modeenv
     MATCH "current_recovery_systems=.*,${revno3_label}" < modeenv
     MATCH "good_recovery_systems=.*,${revno3_label}" < modeenv
-    tests.nested exec "sudo snap debug boot-vars --root-dir=/run/mnt/ubuntu-seed" | MATCH "snapd_good_recovery_systems=${label_base},${revno2_label},${revno3_label}"
+    remote.exec "sudo snap debug boot-vars --root-dir=/run/mnt/ubuntu-seed" | MATCH "snapd_good_recovery_systems=${label_base},${revno2_label},${revno3_label}"
 
     # because the system is considered 'seeded' we are able to switch to the
     # recover mode
     echo "Switch to recover mode of new seed system"
     boot_id="$(tests.nested boot-id)"
-    tests.nested exec sudo snap reboot --recover "${revno3_label}" | MATCH 'Reboot into ".*" "recover" mode'
+    remote.exec sudo snap reboot --recover "${revno3_label}" | MATCH 'Reboot into ".*" "recover" mode'
     tests.nested wait-for reboot "${boot_id}"
     # Verify we are in recover mode with the expected system label
-    tests.nested exec 'sudo cat /proc/cmdline' | MATCH "snapd_recovery_mode=recover snapd_recovery_system=${revno3_label} "
+    remote.exec 'sudo cat /proc/cmdline' | MATCH "snapd_recovery_mode=recover snapd_recovery_system=${revno3_label} "
 
     # we are in recover mode, so tools need to be set up again
     nested_prepare_tools
@@ -101,13 +101,13 @@ execute: |
     boot_id="$(tests.nested boot-id)"
     echo "And back to run mode"
     tests.nested wait-for snap-command
-    tests.nested exec "sudo snap wait system seed.loaded"
-    tests.nested exec sudo snap reboot --run | MATCH 'Reboot into "run" mode.'
+    remote.exec "sudo snap wait system seed.loaded"
+    remote.exec sudo snap reboot --run | MATCH 'Reboot into "run" mode.'
     tests.nested wait-for reboot "${boot_id}"
-    tests.nested exec 'sudo cat /proc/cmdline' | MATCH "snapd_recovery_mode=run "
+    remote.exec 'sudo cat /proc/cmdline' | MATCH "snapd_recovery_mode=run "
 
     echo "Verify all recovery systems are listed"
-    tests.nested exec "sudo snap recovery" > recovery.out
+    remote.exec "sudo snap recovery" > recovery.out
     for label in "$label_base" "$revno2_label" "$revno3_label"; do
         MATCH "$label " < recovery.out
     done

--- a/tests/nested/manual/core20-save/task.yaml
+++ b/tests/nested/manual/core20-save/task.yaml
@@ -43,14 +43,14 @@ debug: |
 execute: |
     if [ "${NESTED_UBUNTU_SAVE:-}" != "add" ] && ! tests.nested is-enabled tpm; then
         echo "Check that ubuntu-save is not mounted"
-        tests.nested exec "! mountpoint /run/mnt/ubuntu-save"
-        tests.nested exec "! mountpoint /var/lib/snapd/save"
+        remote.exec "! mountpoint /run/mnt/ubuntu-save"
+        remote.exec "! mountpoint /var/lib/snapd/save"
     else
         echo "Check that ubuntu-save is mounted and has a reasonable amount of free space"
         #example df output:
         # Filesystem                                                   1B-blocks  Used Available Use% Mounted on
         # /dev/mapper/ubuntu-save-0bed13ef-f71f-418f-b046-b1ce32dd04a7   5079040 28672   4390912   1% /run/mnt/ubuntu-save
-        save_out="$(tests.nested exec "df -B1 /run/mnt/ubuntu-save | tail -1")"
+        save_out="$(remote.exec "df -B1 /run/mnt/ubuntu-save | tail -1")"
         if tests.nested is-enabled tpm; then
             # when encrypted, ubuntu-save is mounted from a dm device
             echo "$save_out" | MATCH '^/dev/mapper/ubuntu-save-[0-9a-z-]+\s+'
@@ -64,27 +64,27 @@ execute: |
         test "$save_size" -gt "$((6*1024*1024))"
 
         # leave a canary
-        tests.nested exec "sudo touch /run/mnt/ubuntu-save/canary"
+        remote.exec "sudo touch /run/mnt/ubuntu-save/canary"
 
-        tests.nested exec mountpoint /var/lib/snapd/save
+        remote.exec mountpoint /var/lib/snapd/save
         # we know that save is mounted using a systemd unit
-        tests.nested exec systemctl status var-lib-snapd-save.mount
+        remote.exec systemctl status var-lib-snapd-save.mount
         # and a canary exists
-        tests.nested exec "test -f /var/lib/snapd/save/canary"
+        remote.exec "test -f /var/lib/snapd/save/canary"
     fi
 
     echo "Transition to recovery mode and check again"
-    recovery_system=$(tests.nested exec "sudo snap recovery | grep -v Notes | grep -Po '^[0-9]+'")
+    recovery_system=$(remote.exec "sudo snap recovery | grep -v Notes | grep -Po '^[0-9]+'")
     tests.nested transition "$recovery_system" "recover"
 
     # happily running in recover mode
 
     if [ "${NESTED_UBUNTU_SAVE:-}" != "add" ] && ! tests.nested is-enabled tpm; then
         # no ubuntu-save
-        tests.nested exec "! mountpoint /run/mnt/ubuntu-save"
-        tests.nested exec "! mountpoint /var/lib/snapd/save"
+        remote.exec "! mountpoint /run/mnt/ubuntu-save"
+        remote.exec "! mountpoint /var/lib/snapd/save"
     else
-        recover_save_out="$(tests.nested exec "df -B1 /run/mnt/ubuntu-save | tail -1")"
+        recover_save_out="$(remote.exec "df -B1 /run/mnt/ubuntu-save | tail -1")"
         if tests.nested is-enabled tpm; then
             # when encrypted, ubuntu-save is mounted from a dm device
             echo "$recover_save_out" | MATCH '^/dev/mapper/ubuntu-save-[0-9a-z-]+\s+'
@@ -93,5 +93,5 @@ execute: |
             echo "$recover_save_out" | MATCH '^/dev/vda[0-9]\s+'
         fi
         # and a canary exists
-        tests.nested exec "test -f /run/mnt/ubuntu-save/canary"
+        remote.exec "test -f /run/mnt/ubuntu-save/canary"
     fi

--- a/tests/nested/manual/core20-to-core22/task.yaml
+++ b/tests/nested/manual/core20-to-core22/task.yaml
@@ -31,58 +31,58 @@ execute: |
     . "$TESTSLIB/nested.sh"
 
     boot_id="$(tests.nested boot-id)"
-    tests.nested exec snap model |MATCH 'model +my-model$'
+    remote.exec snap model |MATCH 'model +my-model$'
 
     # XXX: recovery system label is based on a date; we may end up with a
     # different label if the remodel runs around midnight; the label will
     # conflict with an existing system label
-    label_base=$(tests.nested exec "date '+%Y%m%d'")
+    label_base=$(remote.exec "date '+%Y%m%d'")
     label="${label_base}-1"
 
     # wait until device is initialized and has a serial
     tests.nested wait-for device-initialized
 
     echo "Remodel to UC22"
-    tests.nested copy "$TESTSLIB/assertions/valid-for-testing-pc-22-from-20.model"
-    REMOTE_CHG_ID="$(tests.nested exec sudo snap remodel --no-wait valid-for-testing-pc-22-from-20.model)"
+    remote.push "$TESTSLIB/assertions/valid-for-testing-pc-22-from-20.model"
+    REMOTE_CHG_ID="$(remote.exec sudo snap remodel --no-wait valid-for-testing-pc-22-from-20.model)"
     test -n "$REMOTE_CHG_ID"
     # very long retry wait for the change to be in stable state, once it's
     # stable it does not mean that the change was successful yet
-    retry -n 100 --wait 5 sh -c "tests.nested exec sudo snap changes | grep -E '^${REMOTE_CHG_ID}\s+(Done|Undone|Error)'"
+    retry -n 100 --wait 5 sh -c "remote.exec sudo snap changes | grep -E '^${REMOTE_CHG_ID}\s+(Done|Undone|Error)'"
     # check that now
-    tests.nested exec sudo snap changes | grep -E "^${REMOTE_CHG_ID}\s+Done"
+    remote.exec sudo snap changes | grep -E "^${REMOTE_CHG_ID}\s+Done"
 
     # we should have rebooted a couple of times (at least twice for the recovery
     # system and the base), so boot-id should be different
     current_boot_id="$(tests.nested boot-id)"
     test "$boot_id" != "$current_boot_id"
 
-    tests.nested exec sudo snap list pc | MATCH " 22/edge "
-    tests.nested exec sudo snap list pc-kernel | MATCH " 22/edge "
-    tests.nested exec sudo snap list core22 | MATCH "core22 "
+    remote.exec sudo snap list pc | MATCH " 22/edge "
+    remote.exec sudo snap list pc-kernel | MATCH " 22/edge "
+    remote.exec sudo snap list core22 | MATCH "core22 "
 
     echo "Verify seed system with label $label"
-    tests.nested exec "sudo cat /run/mnt/ubuntu-seed/systems/${label}/model" > model-from-seed.model
+    remote.exec "sudo cat /run/mnt/ubuntu-seed/systems/${label}/model" > model-from-seed.model
     MATCH core22 < model-from-seed.model
     NOMATCH core20 < model-from-seed.model
 
     echo "Verify that UC22 recover system is usable"
     boot_id="$(tests.nested boot-id)"
-    tests.nested exec sudo snap reboot --recover "${label}" | MATCH 'Reboot into ".*" "recover" mode'
+    remote.exec sudo snap reboot --recover "${label}" | MATCH 'Reboot into ".*" "recover" mode'
     tests.nested wait-for reboot "${boot_id}"
     # Verify we are in recover mode with the expected system label
-    tests.nested exec 'sudo cat /proc/cmdline' | MATCH "snapd_recovery_mode=recover snapd_recovery_system=${label} "
+    remote.exec 'sudo cat /proc/cmdline' | MATCH "snapd_recovery_mode=recover snapd_recovery_system=${label} "
 
     # we are in recover mode, so tools need to be set up again
     nested_prepare_tools
 
     tests.nested wait-for snap-command
     # there should be no core20 since the seed is UC22
-    tests.nested exec sudo snap list | NOMATCH core20
+    remote.exec sudo snap list | NOMATCH core20
 
     boot_id="$(tests.nested boot-id)"
     echo "And back to run mode"
-    tests.nested exec "sudo snap wait system seed.loaded"
-    tests.nested exec sudo snap reboot --run | MATCH 'Reboot into "run" mode.'
+    remote.exec "sudo snap wait system seed.loaded"
+    remote.exec sudo snap reboot --run | MATCH 'Reboot into "run" mode.'
     tests.nested wait-for reboot "${boot_id}"
-    tests.nested exec 'sudo cat /proc/cmdline' | MATCH "snapd_recovery_mode=run "
+    remote.exec 'sudo cat /proc/cmdline' | MATCH "snapd_recovery_mode=run "

--- a/tests/nested/manual/devmode-snap-seeded-dangerous/task.yaml
+++ b/tests/nested/manual/devmode-snap-seeded-dangerous/task.yaml
@@ -19,9 +19,9 @@ prepare: |
 execute: |
   echo "Check that the devmode snap is installed"
   VERSION="$(tests.nested show version)"
-  tests.nested exec "snap list test-snapd-devmode-core$VERSION"
-  tests.nested exec "snap info --verbose test-snapd-devmode-core$VERSION" | MATCH "confinement:\s+devmode"
-  tests.nested exec "snap info --verbose test-snapd-devmode-core$VERSION" | MATCH "devmode:\s+true"
+  remote.exec "snap list test-snapd-devmode-core$VERSION"
+  remote.exec "snap info --verbose test-snapd-devmode-core$VERSION" | MATCH "confinement:\s+devmode"
+  remote.exec "snap info --verbose test-snapd-devmode-core$VERSION" | MATCH "devmode:\s+true"
   
   echo "Check that the devmode snap can be run"
-  tests.nested exec "test-snapd-devmode-core$VERSION"
+  remote.exec "test-snapd-devmode-core$VERSION"

--- a/tests/nested/manual/devmode-snaps-can-run-other-snaps/task.yaml
+++ b/tests/nested/manual/devmode-snaps-can-run-other-snaps/task.yaml
@@ -115,12 +115,12 @@ execute: |
 
   # wait for snap seeding to be done
   tests.nested wait-for snap-command
-  tests.nested exec "sudo snap wait system seed.loaded"
+  remote.exec "sudo snap wait system seed.loaded"
 
   # push both snaps to the vm
-  tests.nested copy core-from-branch.snap
+  remote.push core-from-branch.snap
 
-  tests.nested copy snapd-from-branch.snap
+  remote.push snapd-from-branch.snap
 
   if os.query is-xenial; then
     # on UC16, initially we will only have the core snap installed, run those
@@ -128,15 +128,15 @@ execute: |
 
     # this will reboot as we refresh to our core snap
     boot_id="$( tests.nested boot-id )"
-    REMOTE_CHG_ID="$(tests.nested exec sudo snap install --no-wait --dangerous core-from-branch.snap)"
+    REMOTE_CHG_ID="$(remote.exec sudo snap install --no-wait --dangerous core-from-branch.snap)"
     tests.nested wait-for reboot "${boot_id}"
-    tests.nested exec sudo snap watch "${REMOTE_CHG_ID}"
+    remote.exec sudo snap watch "${REMOTE_CHG_ID}"
 
-    tests.nested exec sudo snap install --devmode --beta "$BASE_CORE_DEVMODE_SNAP"
-    tests.nested exec sudo snap install "$BASE_CORE_STRICT_SNAP"
+    remote.exec sudo snap install --devmode --beta "$BASE_CORE_DEVMODE_SNAP"
+    remote.exec sudo snap install "$BASE_CORE_STRICT_SNAP"
 
     # umask is the command we execute to avoid yet another layer of quoting
-    OUTPUT=$(echo "snap run ${BASE_CORE_STRICT_SNAP}.sh -c umask" | tests.nested exec "snap run --shell ${BASE_CORE_DEVMODE_SNAP}")
+    OUTPUT=$(echo "snap run ${BASE_CORE_STRICT_SNAP}.sh -c umask" | remote.exec "snap run --shell ${BASE_CORE_DEVMODE_SNAP}")
     if [ "$OUTPUT" != "0002" ]; then
       echo "test failed"
       exit 1
@@ -144,12 +144,12 @@ execute: |
 
     # now install the snapd snap and run those tests
     echo "install the snapd snap"
-    tests.nested exec sudo snap install --dangerous snapd-from-branch.snap
+    remote.exec sudo snap install --dangerous snapd-from-branch.snap
 
     # trigger regeneration of profiles
-    tests.nested exec sudo systemctl stop snapd.socket snapd.service
-    tests.nested exec sudo rm -f /var/lib/snapd/system-key
-    tests.nested exec sudo systemctl start snapd.socket snapd.service
+    remote.exec sudo systemctl stop snapd.socket snapd.service
+    remote.exec sudo rm -f /var/lib/snapd/system-key
+    remote.exec sudo systemctl start snapd.socket snapd.service
 
     # also install the non-core base snap, note that we can install and use it
     # even without the snapd snap, but we cannot execute other snaps from this 
@@ -158,16 +158,16 @@ execute: |
     # /usr/bin/snap -> /snap/snapd/current/usr/bin/snap
     # which effectively requires the snapd snap to be installed to execute other
     # snaps from inside the devmode non-core based snap
-    tests.nested exec sudo snap install --devmode "$BASE_NON_CORE_DEVMODE_SNAP"
+    remote.exec sudo snap install --devmode "$BASE_NON_CORE_DEVMODE_SNAP"
 
     # umask is the command we execute to avoid yet another layer of quoting
-    OUTPUT=$(echo "snap run ${BASE_CORE_STRICT_SNAP}.sh -c umask" | tests.nested exec "snap run --shell ${BASE_CORE_DEVMODE_SNAP}")
+    OUTPUT=$(echo "snap run ${BASE_CORE_STRICT_SNAP}.sh -c umask" | remote.exec "snap run --shell ${BASE_CORE_DEVMODE_SNAP}")
     if [ "$OUTPUT" != "0002" ]; then
       echo "test failed"
       exit 1
     fi
 
-    OUTPUT=$(echo "snap run ${BASE_CORE_STRICT_SNAP}.sh -c umask" | tests.nested exec "snap run --shell ${BASE_NON_CORE_DEVMODE_SNAP}.sh")
+    OUTPUT=$(echo "snap run ${BASE_CORE_STRICT_SNAP}.sh -c umask" | remote.exec "snap run --shell ${BASE_NON_CORE_DEVMODE_SNAP}.sh")
     if [ "$OUTPUT" != "0002" ]; then
       echo "test failed"
       exit 1
@@ -176,15 +176,15 @@ execute: |
   elif os.query is-bionic; then
     # on UC18, initially we will only have the snapd snap installed, run those
     # tests first
-    tests.nested exec sudo snap install  --dangerous snapd-from-branch.snap
+    remote.exec sudo snap install  --dangerous snapd-from-branch.snap
 
     # snaps that don't depend on the core snap
-    tests.nested exec sudo snap install --devmode "$BASE_NON_CORE_DEVMODE_SNAP"
-    tests.nested exec sudo snap install "$BASE_NON_CORE_STRICT_SNAP"
+    remote.exec sudo snap install --devmode "$BASE_NON_CORE_DEVMODE_SNAP"
+    remote.exec sudo snap install "$BASE_NON_CORE_STRICT_SNAP"
 
 
     # umask is the command we execute to avoid yet another layer of quoting
-    OUTPUT=$(echo "snap run ${BASE_NON_CORE_STRICT_SNAP}.sh -c umask" | tests.nested exec "snap run --shell ${BASE_NON_CORE_DEVMODE_SNAP}.sh" )
+    OUTPUT=$(echo "snap run ${BASE_NON_CORE_STRICT_SNAP}.sh -c umask" | remote.exec "snap run --shell ${BASE_NON_CORE_DEVMODE_SNAP}.sh" )
     if [ "$OUTPUT" != "0002" ]; then
       echo "test failed"
       exit 1
@@ -192,24 +192,24 @@ execute: |
 
     # now install the core snap and run those tests
     echo "install the core snap"
-    tests.nested exec sudo snap install --dangerous core-from-branch.snap
+    remote.exec sudo snap install --dangerous core-from-branch.snap
 
     # trigger regeneration of profiles
-    tests.nested exec sudo systemctl stop snapd.socket snapd.service
-    tests.nested exec sudo rm -f /var/lib/snapd/system-key
-    tests.nested exec sudo systemctl start snapd.socket snapd.service
+    remote.exec sudo systemctl stop snapd.socket snapd.service
+    remote.exec sudo rm -f /var/lib/snapd/system-key
+    remote.exec sudo systemctl start snapd.socket snapd.service
 
     # snap that does depend on the core snap
-    tests.nested exec sudo snap install --devmode --beta "$BASE_CORE_DEVMODE_SNAP"
-    tests.nested exec sudo snap install "$BASE_CORE_STRICT_SNAP"
+    remote.exec sudo snap install --devmode --beta "$BASE_CORE_DEVMODE_SNAP"
+    remote.exec sudo snap install "$BASE_CORE_STRICT_SNAP"
 
-    OUTPUT=$(echo "snap run ${BASE_CORE_STRICT_SNAP}.sh -c umask" | tests.nested exec "snap run --shell ${BASE_CORE_DEVMODE_SNAP}")
+    OUTPUT=$(echo "snap run ${BASE_CORE_STRICT_SNAP}.sh -c umask" | remote.exec "snap run --shell ${BASE_CORE_DEVMODE_SNAP}")
     if [ "$OUTPUT" != "0002" ]; then
       echo "test failed"
       exit 1
     fi
 
-    OUTPUT=$(echo "snap run ${BASE_CORE_STRICT_SNAP}.sh -c umask" | tests.nested exec "snap run --shell ${BASE_NON_CORE_DEVMODE_SNAP}.sh")
+    OUTPUT=$(echo "snap run ${BASE_CORE_STRICT_SNAP}.sh -c umask" | remote.exec "snap run --shell ${BASE_NON_CORE_DEVMODE_SNAP}.sh")
     if [ "$OUTPUT" != "0002" ]; then
       echo "test failed"
       exit 1

--- a/tests/nested/manual/preseed/task.yaml
+++ b/tests/nested/manual/preseed/task.yaml
@@ -83,8 +83,8 @@ execute: |
   tests.nested create-vm classic
 
   echo "Waiting for firstboot seeding to finish"
-  tests.nested exec "sudo snap wait system seed.loaded"
-  tests.nested exec "snap changes" | MATCH "Done .+ Initialize system state"
+  remote.exec "sudo snap wait system seed.loaded"
+  remote.exec "snap changes" | MATCH "Done .+ Initialize system state"
 
   echo "Checking that the system-key after first boot is the same as that from preseeding"
 
@@ -97,41 +97,41 @@ execute: |
     # the test is run against a vm image with ubuntu release matching that from spread host;
     # system-key check can fail if the nested vm image differs too much from the spread host system,
     # e.g. when the list of apparmor features differs due to significant kernel update.
-    tests.nested exec "cat /var/lib/snapd/system-key" > system-key.real
+    remote.exec "cat /var/lib/snapd/system-key" > system-key.real
     diff -u -w system-key.real system-key.preseeded
 
     # also check the system-key diff using snap debug seeding
 
     # we should not have had any system-key difference as per above, so we 
     # shouldn't output the preseed system-key or the seed-restart-system-key
-    tests.nested exec "snap debug seeding" | NOMATCH "preseed-system-key:"
-    tests.nested exec "snap debug seeding" | NOMATCH "seed-restart-system-key:"
+    remote.exec "snap debug seeding" | NOMATCH "preseed-system-key:"
+    remote.exec "snap debug seeding" | NOMATCH "seed-restart-system-key:"
   fi
 
-  tests.nested exec "snap debug seeding" | MATCH "preseeded:\s+true"
-  tests.nested exec "snap debug seeding" | MATCH "seeded:\s+true"
+  remote.exec "snap debug seeding" | MATCH "preseeded:\s+true"
+  remote.exec "snap debug seeding" | MATCH "seeded:\s+true"
   # FIXME: this just checks that the time is of the form "xxx.xxxs", which could
   # break if the preseeding takes more than 60s and golang formats the 
   # time.Duration as "1m2.03s", etc. but for now this should be good enough
-  tests.nested exec "snap debug seeding" | MATCH "image-preseeding:\s+[0-9]+\.[0-9]+s"
-  tests.nested exec "snap debug seeding" | MATCH "seed-completion:\s+[0-9]+\.[0-9]+s"
+  remote.exec "snap debug seeding" | MATCH "image-preseeding:\s+[0-9]+\.[0-9]+s"
+  remote.exec "snap debug seeding" | MATCH "seed-completion:\s+[0-9]+\.[0-9]+s"
 
   echo "Checking that lxd snap is operational"
-  tests.nested exec "snap list" | NOMATCH "broken"
-  tests.nested exec "snap services" | MATCH "lxd.activate +enabled +inactive"
-  tests.nested exec "snap services" | MATCH "lxd.daemon +enabled +inactive +socket-activated"
-  tests.nested exec "sudo lxd init --auto"
-  tests.nested exec "snap services" | MATCH "+lxd.daemon +enabled +active +socket-activated"
+  remote.exec "snap list" | NOMATCH "broken"
+  remote.exec "snap services" | MATCH "lxd.activate +enabled +inactive"
+  remote.exec "snap services" | MATCH "lxd.daemon +enabled +inactive +socket-activated"
+  remote.exec "sudo lxd init --auto"
+  remote.exec "snap services" | MATCH "+lxd.daemon +enabled +active +socket-activated"
 
   echo "Checking that the test-postgres-system-usernames snap is operational"
-  tests.nested exec "sudo snap start --enable test-postgres-system-usernames.postgres"
+  remote.exec "sudo snap start --enable test-postgres-system-usernames.postgres"
   # wait for postgres to come online
   sleep 10
-  tests.nested exec "snap services" | MATCH "+test-postgres-system-usernames.postgres +enabled +active"
+  remote.exec "snap services" | MATCH "+test-postgres-system-usernames.postgres +enabled +active"
 
   echo "Checking that mark-seeded task was executed last"
   # snap debug timings are sorts by read-time, mark-seeded should be last
-  tests.nested exec "sudo snap debug timings 1" | tail -2 | MATCH "Mark system seeded"
+  remote.exec "sudo snap debug timings 1" | tail -2 | MATCH "Mark system seeded"
   # no task should have ready time after mark-seeded
   # shellcheck disable=SC2046
   MARK_SEEDED_TIME=$(date -d $(snap change 1 --abs-time | grep "Mark system seeded" | awk '{print $3}') "+%s")

--- a/tests/nested/manual/refresh-revert-fundamentals/task.yaml
+++ b/tests/nested/manual/refresh-revert-fundamentals/task.yaml
@@ -40,7 +40,7 @@ prepare: |
     tests.nested create-vm core
 
 debug: |
-    tests.nested exec "snap changes" || true
+    remote.exec "snap changes" || true
 
 execute: |
     if [ -f skip.test ]; then
@@ -50,11 +50,11 @@ execute: |
     FROM_REV="$(tests.nested snap-rev "$SNAP" $TRACK/$NESTED_CORE_CHANNEL)"
     TO_REV="$(tests.nested snap-rev "$SNAP" $TRACK/$NESTED_CORE_REFRESH_CHANNEL)"
 
-    tests.nested exec "snap list $SNAP" | MATCH "^${SNAP}.*${FROM_REV}.*${TRACK}/${NESTED_CORE_CHANNEL}.*"
+    remote.exec "snap list $SNAP" | MATCH "^${SNAP}.*${FROM_REV}.*${TRACK}/${NESTED_CORE_CHANNEL}.*"
 
     echo "Refresh the snap $SNAP"
     INITIAL_BOOT_ID=$(tests.nested boot-id)
-    REFRESH_ID=$(tests.nested exec "sudo snap refresh --no-wait --channel $NESTED_CORE_REFRESH_CHANNEL $SNAP")
+    REFRESH_ID=$(remote.exec "sudo snap refresh --no-wait --channel $NESTED_CORE_REFRESH_CHANNEL $SNAP")
 
     case "$SNAP" in
         snapd|pc)
@@ -62,8 +62,8 @@ execute: |
             # resealing took place we are still able to boot
             # The following commands could fails in case the connection is suddenly
             # stopped because of the reboot in the nested machine
-            tests.nested exec "snap watch $REFRESH_ID" || true
-            tests.nested exec "sudo reboot" || true
+            remote.exec "snap watch $REFRESH_ID" || true
+            remote.exec "sudo reboot" || true
             ;;
         pc-kernel|core20)
             # don't manually reboot, wait for automatic snapd reboot
@@ -73,19 +73,19 @@ execute: |
     SECOND_BOOT_ID=$(tests.nested boot-id)
 
     echo "Check the new version of the snaps is correct after the system reboot"
-    tests.nested exec "snap list $SNAP" | MATCH "^${SNAP}.*${TO_REV}.*${TRACK}/${NESTED_CORE_REFRESH_CHANNEL}.*"
+    remote.exec "snap list $SNAP" | MATCH "^${SNAP}.*${TO_REV}.*${TRACK}/${NESTED_CORE_REFRESH_CHANNEL}.*"
 
     echo "Check the change is completed"
     case "$SNAP" in
         pc-kernel|core20)
             #shellcheck disable=SC2098
             #shellcheck disable=SC2097
-            retry --wait 1 -n 10 --env REFRESH_ID="$REFRESH_ID" sh -c "tests.nested exec snap changes | MATCH \"$REFRESH_ID\s+Done\s+.*\""
+            retry --wait 1 -n 10 --env REFRESH_ID="$REFRESH_ID" sh -c "remote.exec snap changes | MATCH \"$REFRESH_ID\s+Done\s+.*\""
             ;;
     esac
 
     echo "Revert the snap $SNAP"
-    REVERT_ID=$(tests.nested exec "sudo snap revert --no-wait $SNAP")
+    REVERT_ID=$(remote.exec "sudo snap revert --no-wait $SNAP")
 
     case "$SNAP" in
         snapd|pc)
@@ -93,8 +93,8 @@ execute: |
             # resealing took place we are still able to boot
             # The following commands could fails in case the connection is suddenly
             # stopped because of the reboot in the nested machine
-            tests.nested exec "snap watch $REVERT_ID" || true
-            tests.nested exec "sudo reboot" || true
+            remote.exec "snap watch $REVERT_ID" || true
+            remote.exec "sudo reboot" || true
             ;;
         pc-kernel|core20)
             # don't manually reboot, wait for automatic snapd reboot
@@ -103,11 +103,11 @@ execute: |
     tests.nested wait-for reboot "$SECOND_BOOT_ID"
 
     echo "Check the version of the snaps after the revert is correct"
-    tests.nested exec "snap list $SNAP" | MATCH "^${SNAP}.*${FROM_REV}.*${TRACK}/${NESTED_CORE_REFRESH_CHANNEL}.*"
+    remote.exec "snap list $SNAP" | MATCH "^${SNAP}.*${FROM_REV}.*${TRACK}/${NESTED_CORE_REFRESH_CHANNEL}.*"
 
     echo "Check the change is completed"
     case "$SNAP" in
         pc-kernel|core20)
-            retry --wait 1 -n 10 --env REVERT_ID="$REVERT_ID" sh -c "tests.nested exec snap changes | MATCH \"$REVERT_ID\s+Done\s+.*\""
+            retry --wait 1 -n 10 --env REVERT_ID="$REVERT_ID" sh -c "remote.exec snap changes | MATCH \"$REVERT_ID\s+Done\s+.*\""
             ;;
     esac

--- a/tests/nested/manual/remodel-cross-store/task.yaml
+++ b/tests/nested/manual/remodel-cross-store/task.yaml
@@ -54,23 +54,23 @@ execute: |
     # wait until device is initialized and has a serial
     tests.nested wait-for device-initialized
 
-    tests.nested exec "snap model --assertion" | MATCH "brand-id: $SNAPD_TEST_BRAND\$"
-    tests.nested exec "snap model --assertion" | MATCH "store: $SNAPD_STORE_WHITEBOX\$"
-    tests.nested exec "snap model --assertion" | MATCH '^model: test-snapd-remodel-pc$'
-    tests.nested exec "snap model --assertion --serial" | MATCH "serial: ${SERIAL}\$"
+    remote.exec "snap model --assertion" | MATCH "brand-id: $SNAPD_TEST_BRAND\$"
+    remote.exec "snap model --assertion" | MATCH "store: $SNAPD_STORE_WHITEBOX\$"
+    remote.exec "snap model --assertion" | MATCH '^model: test-snapd-remodel-pc$'
+    remote.exec "snap model --assertion --serial" | MATCH "serial: ${SERIAL}\$"
 
     # the new model requires test-snapd-tools-core* snap to be present, make
     # sure that the snap isn't installed yet
-    tests.nested exec "snap list" | NOMATCH test-snapd-tools
+    remote.exec "snap list" | NOMATCH test-snapd-tools
 
-    tests.nested copy "$TESTSLIB/assertions/test-snapd-remodel-pc-cross-store-$variant.model"
-    CHANGE_ID="$(tests.nested exec "sudo snap remodel --no-wait test-snapd-remodel-pc-cross-store-$variant.model")"
+    remote.push "$TESTSLIB/assertions/test-snapd-remodel-pc-cross-store-$variant.model"
+    CHANGE_ID="$(remote.exec "sudo snap remodel --no-wait test-snapd-remodel-pc-cross-store-$variant.model")"
     test -n "$CHANGE_ID"
     # very long retry wait for the change to be in stable state, once it's
     # stable it does not mean that the change was successful yet
-    retry -n 100 --wait 5 sh -c "tests.nested exec sudo snap changes | grep -E '^${CHANGE_ID}\s+(Done|Undone|Error)'"
+    retry -n 100 --wait 5 sh -c "remote.exec sudo snap changes | grep -E '^${CHANGE_ID}\s+(Done|Undone|Error)'"
     # check that now
-    tests.nested exec sudo snap changes | MATCH "^${CHANGE_ID}\s+Done"
+    remote.exec sudo snap changes | MATCH "^${CHANGE_ID}\s+Done"
 
     current_boot_id="$( tests.nested boot-id )"
     if [ "$variant" = "20" ] || [ "$variant" = "22" ]; then
@@ -83,15 +83,15 @@ execute: |
     fi
 
     # we are remodeling within the same store
-    tests.nested exec "snap model --assertion" | MATCH "brand-id: $SNAPD_TEST_BRAND\$"
+    remote.exec "snap model --assertion" | MATCH "brand-id: $SNAPD_TEST_BRAND\$"
     # new model
-    tests.nested exec "snap model --assertion" | MATCH '^model: test-snapd-remodel-pc-cross-store$'
+    remote.exec "snap model --assertion" | MATCH '^model: test-snapd-remodel-pc-cross-store$'
     # new store
-    tests.nested exec "snap model --assertion" | MATCH "store: $SNAPD_STORE_REMODEL\$"
+    remote.exec "snap model --assertion" | MATCH "store: $SNAPD_STORE_REMODEL\$"
     # but the same serial
-    tests.nested exec "snap model --assertion --serial" | MATCH "serial: ${SERIAL}\$"
+    remote.exec "snap model --assertion --serial" | MATCH "serial: ${SERIAL}\$"
 
     # new snap is installed
-    tests.nested exec "snap list test-snapd-tools-core${variant}"
+    remote.exec "snap list test-snapd-tools-core${variant}"
     # and it's possible to run hello-world
-    tests.nested exec "test-snapd-tools-core${variant}.cmd echo 'Hello World'" | MATCH 'Hello World'
+    remote.exec "test-snapd-tools-core${variant}.cmd echo 'Hello World'" | MATCH 'Hello World'

--- a/tests/nested/manual/remodel-simple/task.yaml
+++ b/tests/nested/manual/remodel-simple/task.yaml
@@ -47,31 +47,31 @@ execute: |
     # wait until device is initialized and has a serial
     tests.nested wait-for device-initialized
 
-    tests.nested exec "snap model --assertion" | MATCH "brand-id: $SNAPD_TEST_BRAND\$"
-    tests.nested exec "snap model --assertion" | MATCH "store: $SNAPD_STORE_WHITEBOX\$"
-    tests.nested exec "snap model --assertion" | MATCH '^model: test-snapd-remodel-pc$'
-    tests.nested exec "snap model --assertion --serial" | MATCH "serial: ${SERIAL}\$"
+    remote.exec "snap model --assertion" | MATCH "brand-id: $SNAPD_TEST_BRAND\$"
+    remote.exec "snap model --assertion" | MATCH "store: $SNAPD_STORE_WHITEBOX\$"
+    remote.exec "snap model --assertion" | MATCH '^model: test-snapd-remodel-pc$'
+    remote.exec "snap model --assertion --serial" | MATCH "serial: ${SERIAL}\$"
 
     # the new model requires hello-world snap to be present, make sure that the
     # snap and its dependency core aren't installed yet
-    not tests.nested exec "snap list hello-world"
-    not tests.nested exec "snap list core"
+    not remote.exec "snap list hello-world"
+    not remote.exec "snap list core"
 
     # snapd gets stuck ensuring prerequisites of hello-world, which is the
     # installation of core, workaround this problem by installing core
     # explicitly
     # TODO: drop this once prereq is fixed
-    tests.nested exec "snap install core"
+    remote.exec "snap install core"
 
-    tests.nested copy "$TESTSLIB/assertions/test-snapd-remodel-pc-just-model-$variant.model"
-    CHANGE_ID="$(tests.nested exec "sudo snap remodel --no-wait test-snapd-remodel-pc-just-model-$variant.model")"
+    remote.push "$TESTSLIB/assertions/test-snapd-remodel-pc-just-model-$variant.model"
+    CHANGE_ID="$(remote.exec "sudo snap remodel --no-wait test-snapd-remodel-pc-just-model-$variant.model")"
     test -n "$CHANGE_ID"
     # very long retry wait for the change to be in stable state, where stable
     # means that it's done or failed in which case we fail the test on the next
     # check just below
-    retry -n 100 --wait 5 sh -c "tests.nested exec sudo snap changes | grep -E '^${CHANGE_ID}\s+(Done|Undone|Error)'"
+    retry -n 100 --wait 5 sh -c "remote.exec sudo snap changes | grep -E '^${CHANGE_ID}\s+(Done|Undone|Error)'"
     # check that the change was successful
-    tests.nested exec sudo snap changes | MATCH "^${CHANGE_ID}\s+Done"
+    remote.exec sudo snap changes | MATCH "^${CHANGE_ID}\s+Done"
 
     current_boot_id="$( tests.nested boot-id )"
     if [ "$variant" = "20" ] || [ "$variant" = "22" ]; then
@@ -84,15 +84,15 @@ execute: |
     fi
 
     # we are remodeling within the same brand and store
-    tests.nested exec "snap model --assertion" | MATCH "brand-id: $SNAPD_TEST_BRAND\$"
-    tests.nested exec "snap model --assertion" | MATCH "store: $SNAPD_STORE_WHITEBOX\$"
+    remote.exec "snap model --assertion" | MATCH "brand-id: $SNAPD_TEST_BRAND\$"
+    remote.exec "snap model --assertion" | MATCH "store: $SNAPD_STORE_WHITEBOX\$"
     # new model
-    tests.nested exec "snap model --assertion" | MATCH '^model: test-snapd-remodel-pc-just-model$'
+    remote.exec "snap model --assertion" | MATCH '^model: test-snapd-remodel-pc-just-model$'
     # but the same serial
-    tests.nested exec "snap model --assertion --serial" | MATCH "serial: ${SERIAL}\$"
+    remote.exec "snap model --assertion --serial" | MATCH "serial: ${SERIAL}\$"
 
     # both new snaps are installed now
-    tests.nested exec "snap list hello-world"
-    tests.nested exec "snap list core"
+    remote.exec "snap list hello-world"
+    remote.exec "snap list core"
     # and it's possible to run hello-world
-    tests.nested exec "hello-world" | MATCH 'Hello World!'
+    remote.exec "hello-world" | MATCH 'Hello World!'

--- a/tests/nested/manual/snapd-refresh-from-old/task.yaml
+++ b/tests/nested/manual/snapd-refresh-from-old/task.yaml
@@ -27,27 +27,27 @@ prepare: |
   "$TESTSTOOLS"/snaps-state repack_snapd_deb_into_snap snapd
 
 execute: |
-  tests.nested exec "sudo snap wait system seed.loaded"
-  tests.nested exec "snap list" | MATCH "snapd.*5760"
-  tests.nested exec "snap list" | MATCH "core18.*1279"
+  remote.exec "sudo snap wait system seed.loaded"
+  remote.exec "snap list" | MATCH "snapd.*5760"
+  remote.exec "snap list" | MATCH "core18.*1279"
 
   INITIAL_BOOT_ID=$(tests.nested boot-id)
 
   if [ "$SPREAD_VARIANT" = "edge_first" ]; then
     # refresh to latest snapd from store, this will drop from ssh.
     echo "Refreshing snapd and core18 from the store"
-    tests.nested exec "sudo snap refresh" || true
+    remote.exec "sudo snap refresh" || true
 
     tests.nested wait-for reboot "$INITIAL_BOOT_ID"
-    tests.nested exec "retry --wait 2 -n 10 sh -c 'snap list snapd | NOMATCH \"snapd.*5760\"'"
+    remote.exec "retry --wait 2 -n 10 sh -c 'snap list snapd | NOMATCH \"snapd.*5760\"'"
 
     # this change is not immediately done and needs a retry
     #shellcheck disable=SC2140
     #shellcheck disable=SC2140
-    tests.nested exec "retry --wait 1 -n 10 sh -c 'snap changes | MATCH \".* Done .* Refresh snaps.*"core18"\"'"
+    remote.exec "retry --wait 1 -n 10 sh -c 'snap changes | MATCH \".* Done .* Refresh snaps.*"core18"\"'"
   fi
 
   echo "Now refresh snapd with current tree"
-  tests.nested copy "snapd-from-deb.snap"
-  tests.nested exec "sudo snap install snapd-from-deb.snap --dangerous" || true
-  tests.nested exec "snap list snapd" | MATCH "snapd .* x1 "
+  remote.push "snapd-from-deb.snap"
+  remote.exec "sudo snap install snapd-from-deb.snap --dangerous" || true
+  remote.exec "snap list snapd" | MATCH "snapd .* x1 "

--- a/tests/nested/manual/snapd-removes-vulnerable-snap-confine-revs/task.yaml
+++ b/tests/nested/manual/snapd-removes-vulnerable-snap-confine-revs/task.yaml
@@ -65,27 +65,27 @@ prepare: |
 
 execute: |
   # check the current snapd snap is vulnerable
-  tests.nested exec cat /snap/$SNAPD_SOURCE_SNAP/current/usr/lib/snapd/info | MATCH '^VERSION=2\.54\.2$'
-  VULN_REV=$(tests.nested exec "snap list $SNAPD_SOURCE_SNAP" | tail -n +2 | awk '{print $3}')
+  remote.exec cat /snap/$SNAPD_SOURCE_SNAP/current/usr/lib/snapd/info | MATCH '^VERSION=2\.54\.2$'
+  VULN_REV=$(remote.exec "snap list $SNAPD_SOURCE_SNAP" | tail -n +2 | awk '{print $3}')
 
   # now install our snapd deb from the branch - this is so we know the patched
   # snapd is always executing, regardless of which snapd/core snap re-exec 
   # nonsense is going on
   SNAPD_DEB_ARR=( "$SPREAD_PATH"/../snapd_*.deb )
   SNAPD_DEB=${SNAPD_DEB_ARR[0]}
-  tests.nested copy "$SNAPD_DEB"
-  tests.nested exec "sudo dpkg -i $(basename "$SNAPD_DEB")"
+  remote.push "$SNAPD_DEB"
+  remote.exec "sudo dpkg -i $(basename "$SNAPD_DEB")"
 
   # now send the snap version of snapd under test to the VM
-  tests.nested copy "$REPACKED_SNAP_NAME"
-  tests.nested exec "sudo snap install $REPACKED_SNAP_NAME --dangerous"
+  remote.push "$REPACKED_SNAP_NAME"
+  remote.exec "sudo snap install $REPACKED_SNAP_NAME --dangerous"
 
   # there is a race between the snap install finishing and removing the 
   # vulnerable revision, so we have to wait a bit
   VULN_SNAP_REMOVED=false
   #shellcheck disable=SC2034
   for i in $(seq 1 60); do
-    if tests.nested exec "snap list $SNAPD_SOURCE_SNAP --all" | NOMATCH "$VULN_REV"; then
+    if remote.exec "snap list $SNAPD_SOURCE_SNAP --all" | NOMATCH "$VULN_REV"; then
       VULN_SNAP_REMOVED=true
       break
     fi
@@ -98,10 +98,10 @@ execute: |
   fi
 
   # check that the current revision is not vulnerable
-  tests.nested exec cat /snap/$SNAPD_SOURCE_SNAP/current/usr/lib/snapd/info | NOMATCH '^VERSION=2\.54\.2$'
+  remote.exec cat /snap/$SNAPD_SOURCE_SNAP/current/usr/lib/snapd/info | NOMATCH '^VERSION=2\.54\.2$'
 
   # and there are no other revisions
-  if [ "$(tests.nested exec "snap list $SNAPD_SOURCE_SNAP" | tail -n +2 | wc -l)"  != "1" ]; then
+  if [ "$(remote.exec "snap list $SNAPD_SOURCE_SNAP" | tail -n +2 | wc -l)"  != "1" ]; then
     echo "unexpected extra revision of $SNAPD_SOURCE_SNAP installed"
     exit 1
   fi

--- a/tests/nested/manual/uc20-fde-hooks-v1/task.yaml
+++ b/tests/nested/manual/uc20-fde-hooks-v1/task.yaml
@@ -26,8 +26,8 @@ prepare: |
 
 execute: |
   echo "Check that we have an encrypted system"
-  tests.nested exec "find /dev/mapper" | MATCH ubuntu-data-[0-9a-f-]+
-  tests.nested exec "test ! -e /var/lib/snapd/device/fde/recovery.key"
-  tests.nested exec "test -e /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key"
-  tests.nested exec "test -e /run/mnt/ubuntu-seed/device/fde/ubuntu-data.recovery.sealed-key"
-  tests.nested exec "test -e /run/mnt/ubuntu-seed/device/fde/ubuntu-save.recovery.sealed-key"
+  remote.exec "find /dev/mapper" | MATCH ubuntu-data-[0-9a-f-]+
+  remote.exec "test ! -e /var/lib/snapd/device/fde/recovery.key"
+  remote.exec "test -e /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key"
+  remote.exec "test -e /run/mnt/ubuntu-seed/device/fde/ubuntu-data.recovery.sealed-key"
+  remote.exec "test -e /run/mnt/ubuntu-seed/device/fde/ubuntu-save.recovery.sealed-key"

--- a/tests/nested/manual/uc20-fde-hooks/task.yaml
+++ b/tests/nested/manual/uc20-fde-hooks/task.yaml
@@ -29,8 +29,8 @@ prepare: |
 
 execute: |
   echo "Check that we have an encrypted system"
-  tests.nested exec "find /dev/mapper" | MATCH ubuntu-data-[0-9a-f-]+
-  tests.nested exec "test ! -e /var/lib/snapd/device/fde/recovery.key"
-  tests.nested exec "test -e /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key"
-  tests.nested exec "test -e /run/mnt/ubuntu-seed/device/fde/ubuntu-data.recovery.sealed-key"
-  tests.nested exec "test -e /run/mnt/ubuntu-seed/device/fde/ubuntu-save.recovery.sealed-key"
+  remote.exec "find /dev/mapper" | MATCH ubuntu-data-[0-9a-f-]+
+  remote.exec "test ! -e /var/lib/snapd/device/fde/recovery.key"
+  remote.exec "test -e /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key"
+  remote.exec "test -e /run/mnt/ubuntu-seed/device/fde/ubuntu-data.recovery.sealed-key"
+  remote.exec "test -e /run/mnt/ubuntu-seed/device/fde/ubuntu-save.recovery.sealed-key"

--- a/tests/nested/manual/uc20-storage-safety/task.yaml
+++ b/tests/nested/manual/uc20-storage-safety/task.yaml
@@ -56,10 +56,10 @@ execute: |
     fi
 
     echo "Verify that no fde keys are generated"
-    tests.nested exec "test ! -d /var/lib/snapd/device/fde"
+    remote.exec "test ! -d /var/lib/snapd/device/fde"
 
     # TODO: once we have a install-mode log (PR#9545) we could grep
     #       "installing system unencrypted because of ..."
 
     echo "Check that data is mounted from a regular device, not a mapper"
-    tests.nested exec "mount" | MATCH "/dev/[svh]da[45] on /run/mnt/data"
+    remote.exec "mount" | MATCH "/dev/[svh]da[45] on /run/mnt/data"


### PR DESCRIPTION
This change introduces the new tools for remote commands from the snapd-testing-tools project

This change starts using the remote.exec which replaces the tests.nested exec and the remote.push by the tests.nested copy

The new remote commands have the same implementation then the tests.nested but those include tests and are being used in other projects successfully.
