### PR TITLE
release: version 2.56.3

### DIFF
--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -11,7 +11,7 @@ pkgdesc="Service and tools for management of snap packages."
 depends=('squashfs-tools' 'libseccomp' 'libsystemd' 'apparmor')
 optdepends=('bash-completion: bash completion support'
             'xdg-desktop-portal: desktop integration')
-pkgver=2.56.2
+pkgver=2.56.3
 pkgrel=1
 arch=('x86_64' 'i686' 'armv7h' 'aarch64')
 url="https://github.com/snapcore/snapd"

--- a/packaging/debian-sid/changelog
+++ b/packaging/debian-sid/changelog
@@ -1,3 +1,26 @@
+snapd (2.56.3-1) unstable; urgency=medium
+
+  * New upstream release, LP: #1974147
+    - devicestate: add more path to `fixupWritableDefaultDirs()`
+    - many: introduce IsUndo flag in LinkContext
+    - i/apparmor: allow calling which.debianutils
+    - interfaces: update AppArmor template to allow reading snap's
+      memory statistics
+    - interfaces: add memory stats to system_observe
+    - i/b/{mount,system}-observe: extend access for htop
+    - features: disable refresh-app-awarness by default again
+    - image: fix handling of var/lib/extrausers when preseeding
+      uc20
+    - interfaces/modem-manager: Don't generate DBus policy for plugs
+    - interfaces/modem-manager: Only generate DBus plug policy on
+      Core
+    - interfaces/serial_port_test: fix static-checks errors
+    - interfaces/serial-port: add USB gadget serial devices (ttyGSX) to
+      allowed list
+    - interface/serial_port_test: adjust variable IDs
+
+ -- Michael Vogt <michael.vogt@ubuntu.com>  Wed, 13 Jul 2022 09:26:57 +0200
+
 snapd (2.56.2-1) unstable; urgency=medium
 
   * New upstream release, LP: #1974147

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -102,7 +102,7 @@
 %endif
 
 Name:           snapd
-Version:        2.56.2
+Version:        2.56.3
 Release:        0%{?dist}
 Summary:        A transactional software package manager
 License:        GPLv3
@@ -981,6 +981,26 @@ fi
 
 
 %changelog
+* Wed Jul 13 2022 Michael Vogt <michael.vogt@ubuntu.com>
+- New upstream release 2.56.3
+ - devicestate: add more path to `fixupWritableDefaultDirs()`
+ - many: introduce IsUndo flag in LinkContext
+ - i/apparmor: allow calling which.debianutils
+ - interfaces: update AppArmor template to allow reading snap's
+   memory statistics
+ - interfaces: add memory stats to system_observe
+ - i/b/{mount,system}-observe: extend access for htop
+ - features: disable refresh-app-awarness by default again
+ - image: fix handling of var/lib/extrausers when preseeding
+   uc20
+ - interfaces/modem-manager: Don't generate DBus policy for plugs
+ - interfaces/modem-manager: Only generate DBus plug policy on
+   Core
+ - interfaces/serial_port_test: fix static-checks errors
+ - interfaces/serial-port: add USB gadget serial devices (ttyGSX) to
+   allowed list
+ - interface/serial_port_test: adjust variable IDs
+
 * Wed Jun 15 2022 Michael Vogt <michael.vogt@ubuntu.com>
 - New upstream release 2.56.2
  - o/snapstate: exclude services from refresh app awareness hard

--- a/packaging/opensuse/snapd.changes
+++ b/packaging/opensuse/snapd.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Jul 13 07:26:57 UTC 2022 - michael.vogt@ubuntu.com
+
+- Update to upstream release 2.56.3
+
+-------------------------------------------------------------------
 Wed Jun 15 12:22:31 UTC 2022 - michael.vogt@ubuntu.com
 
 - Update to upstream release 2.56.2

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -81,7 +81,7 @@
 
 
 Name:           snapd
-Version:        2.56.2
+Version:        2.56.3
 Release:        0
 Summary:        Tools enabling systems to work with .snap files
 License:        GPL-3.0

--- a/packaging/ubuntu-14.04/changelog
+++ b/packaging/ubuntu-14.04/changelog
@@ -1,3 +1,26 @@
+snapd (2.56.3~14.04) trusty; urgency=medium
+
+  * New upstream release, LP: #1974147
+    - devicestate: add more path to `fixupWritableDefaultDirs()`
+    - many: introduce IsUndo flag in LinkContext
+    - i/apparmor: allow calling which.debianutils
+    - interfaces: update AppArmor template to allow reading snap's
+      memory statistics
+    - interfaces: add memory stats to system_observe
+    - i/b/{mount,system}-observe: extend access for htop
+    - features: disable refresh-app-awarness by default again
+    - image: fix handling of var/lib/extrausers when preseeding
+      uc20
+    - interfaces/modem-manager: Don't generate DBus policy for plugs
+    - interfaces/modem-manager: Only generate DBus plug policy on
+      Core
+    - interfaces/serial_port_test: fix static-checks errors
+    - interfaces/serial-port: add USB gadget serial devices (ttyGSX) to
+      allowed list
+    - interface/serial_port_test: adjust variable IDs
+
+ -- Michael Vogt <michael.vogt@ubuntu.com>  Wed, 13 Jul 2022 09:26:57 +0200
+
 snapd (2.56.2~14.04) trusty; urgency=medium
 
   * New upstream release, LP: #1974147

--- a/packaging/ubuntu-16.04/changelog
+++ b/packaging/ubuntu-16.04/changelog
@@ -1,3 +1,26 @@
+snapd (2.56.3) xenial; urgency=medium
+
+  * New upstream release, LP: #1974147
+    - devicestate: add more path to `fixupWritableDefaultDirs()`
+    - many: introduce IsUndo flag in LinkContext
+    - i/apparmor: allow calling which.debianutils
+    - interfaces: update AppArmor template to allow reading snap's
+      memory statistics
+    - interfaces: add memory stats to system_observe
+    - i/b/{mount,system}-observe: extend access for htop
+    - features: disable refresh-app-awarness by default again
+    - image: fix handling of var/lib/extrausers when preseeding
+      uc20
+    - interfaces/modem-manager: Don't generate DBus policy for plugs
+    - interfaces/modem-manager: Only generate DBus plug policy on
+      Core
+    - interfaces/serial_port_test: fix static-checks errors
+    - interfaces/serial-port: add USB gadget serial devices (ttyGSX) to
+      allowed list
+    - interface/serial_port_test: adjust variable IDs
+
+ -- Michael Vogt <michael.vogt@ubuntu.com>  Wed, 13 Jul 2022 09:26:57 +0200
+
 snapd (2.56.2) xenial; urgency=medium
 
   * New upstream release, LP: #1974147


### PR DESCRIPTION
This is the 2.56.3 point release. This should be the last 2.56 release and I would like to release 2.57 to beta as soon as this hits candidate.

Note that this does not include https://github.com/snapcore/snapd/pull/11935 (and it's prerequisites) because there are various cherry pick conflicts and I felt it's probably ok to have this in 2.57 (given that it's coming very soon and this is an issue that is already present for some time).