### PR TITLE
tests: make more robust the files check in preseed-core20 test

### DIFF
--- a/tests/main/preseed-core20/task.yaml
+++ b/tests/main/preseed-core20/task.yaml
@@ -35,10 +35,6 @@ prepare: |
   mkdir -p ~/.snap/gnupg
   gendeveloper1 show-key | gpg --homedir=~/.snap/gnupg --import
 
-  echo "Downloading the apparmor features directory"
-  wget -O apparmor-features-dir-uc20.tar.gz https://storage.googleapis.com/snapd-spread-tests/dependencies/apparmor-features-dir-uc20.tar.gz
-  tar -xvzf apparmor-features-dir-uc20.tar.gz
-
 restore: |
   rm -rf "$PREPARE_IMAGE_DIR"
 
@@ -57,7 +53,7 @@ execute: |
   SNAPD_SNAP=$(ls /tmp/snapd*.snap)
 
   # XXX: confusingly, the name of our test key is actually " (test)".
-  snap prepare-image --preseed --preseed-sign-key=" (test)" --channel=stable --snap="$SNAPD_SNAP" --snap systemusers-snap_1.0_all.snap --apparmor-features-dir="$PWD/apparmor-features-dir" "$TESTSLIB"/assertions/developer1-20-dangerous.model "$PREPARE_IMAGE_DIR" > preseed.log 2>&1
+  snap prepare-image --preseed --preseed-sign-key=" (test)" --channel=stable --snap="$SNAPD_SNAP" --snap systemusers-snap_1.0_all.snap "$TESTSLIB"/assertions/developer1-20-dangerous.model "$PREPARE_IMAGE_DIR" > preseed.log 2>&1
 
   echo "Make sure no umount errors were reported during preseeding cleanup"
   NOMATCH "umount.*failed" < preseed.log
@@ -148,9 +144,9 @@ execute: |
   MATCH "^snap/core20/current" < files.log
   MATCH "^snap/snapd/current" < files.log
 
-  MATCH "^var/cache/apparmor/b678de58.0/snap.pc.hook.configure" < files.log
-  MATCH "^var/cache/apparmor/b678de58.0/snap-update-ns.pc" < files.log
-  MATCH "^var/cache/apparmor/b678de58.0/snap-confine.snapd.x1" < files.log
+  MATCH "^var/cache/apparmor/.*.0/snap.pc.hook.configure" < files.log
+  MATCH "^var/cache/apparmor/.*.0/snap-update-ns.pc" < files.log
+  MATCH "^var/cache/apparmor/.*.0/snap-confine.snapd.x1" < files.log
 
   MATCH "^var/lib/snapd/apparmor/profiles/snap.pc.hook.configure" < files.log
   MATCH "^var/lib/snapd/apparmor/profiles/snap-update-ns.pc" < files.log


### PR DESCRIPTION
The idea is to revert the change to use --apparmor-features-dir.

In the other hand the --apparmor-features-dir option seems to be not
working well, so it should be tested as well.

In the logs I see the dire created is var/cache/apparmor/a938305e.0/ but it should be var/cache/apparmor/b678de58.0/ instead because we are using a predefined apparmor-features-dir.
