### PR TITLE
tests: update fake-netplan-apply test for 22.04

### DIFF
--- a/tests/main/fake-netplan-apply/task.yaml
+++ b/tests/main/fake-netplan-apply/task.yaml
@@ -16,7 +16,7 @@ details: |
 systems:
     - ubuntu-16.04*
     - ubuntu-18.04*
-    - ubuntu-20.04-*
+    - ubuntu-2*
 
 environment:
     NETPLAN: io.netplan.Netplan
@@ -38,6 +38,11 @@ prepare: |
         sed "$TESTSLIB/snaps/netplan-snap/meta/snap.yaml.in" -e "s/base: BASESNAP/base: core20/" > "$TESTSLIB/snaps/netplan-snap/meta/snap.yaml"
         snap pack "$TESTSLIB/snaps/netplan-snap" --filename=netplan-snap-20.snap
         snap install --dangerous netplan-snap-20.snap
+    elif os.query is-jammy; then
+        # use base: core22
+        sed "$TESTSLIB/snaps/netplan-snap/meta/snap.yaml.in" -e "s/base: BASESNAP/base: core22/" > "$TESTSLIB/snaps/netplan-snap/meta/snap.yaml"
+        snap pack "$TESTSLIB/snaps/netplan-snap" --filename=netplan-snap-22.snap
+        snap install --dangerous netplan-snap-22.snap
     else
         echo "new core release, please update test for new ubuntu core version"
         exit 1


### PR DESCRIPTION
This test requires a small tweak to the fake `netplan-snap` that
is build during the test.

