### PR TITLE
nested: fix core-early-config nested test

### DIFF
--- a/tests/nested/manual/core-early-config/task.yaml
+++ b/tests/nested/manual/core-early-config/task.yaml
@@ -19,10 +19,6 @@ prepare: |
     rm -rf squashfs-root
     mv "$GADGET_SNAP" "$(tests.nested get extra-snaps-path)"
 
-    snap download --channel=18/edge pc-kernel
-    KERNEL_SNAP=$(ls pc-kernel_*.snap)
-    mv "$KERNEL_SNAP" "$(tests.nested get extra-snaps-path)"
-
     tests.nested build-image core 
 
     # Modify seed to use devmode for pc gadget snap. This is needed for the


### PR DESCRIPTION
The kernel is automatically handled by the nesting code so it's
actually harmful if the tests specifies it as it leads to the
kernel being specified twice on the commandline which breaks
ubuntu-image:
```
2022-07-14T23:58:23.7590500Z + /home/gopath/bin/ubuntu-image snap --image-size 10G /home/gopath/src/github.com/snapcore/snapd/tests/lib/assertions/nested-18-amd64.model --channel edge '' --output-dir /tmp/work-dir/images --snap /tmp/work-dir/assets/snapd-from-deb.snap --snap new-kernel.snap --snap /home/gopath/src/github.com/snapcore/snapd/tests/nested/manual/core-early-config/new-core18.snap --snap /home/gopath/src/github.com/snapcore/snapd/tests/nested/manual/core-early-config/extra-snaps/pc_104.snap --snap /home/gopath/src/github.com/snapcore/snapd/tests/nested/manual/core-early-config/extra-snaps/pc-kernel_1056.snap
2022-07-14T23:58:23.7592321Z WARNING: proceeding to download snaps ignoring validations, this default will change in the future. For now use --validation=enforce for validations to be taken into account, pass instead --validation=ignore to preserve current behavior going forward
2022-07-14T23:58:23.7593047Z Error: Error preparing image: local snap "pc-kernel" is repeated in options
```

This commit just removes the kernel part of the tests which is not
needed.
