### PR TITLE
tests: ensure that microk8s does not produce DENIED messages

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -606,6 +606,9 @@ prepare_suite_each() {
     touch "$RUNTIME_STATE_PATH/runs"
     touch "$RUNTIME_STATE_PATH/journalctl_cursor"
 
+    # Clean the dmesg log
+    dmesg --read-clear
+
     # Start fs monitor
     "$TESTSTOOLS"/fs-state start-monitor
 

--- a/tests/main/microk8s-smoke/task.yaml
+++ b/tests/main/microk8s-smoke/task.yaml
@@ -66,3 +66,6 @@ execute: |
 
     echo "Test if nginx can be connected"
     retry -n 15 sh -c "curl --max-time 3 'http://localhost:31313/' | MATCH 'Welcome to nginx'"
+
+    echo "Running a microk8s causes no DENIED messages"
+    dmesg | not grep DENIED


### PR DESCRIPTION
The `tests/main/snap-run` test started to fail recently with:
```
2022-07-15T09:44:48.5703039Z [ 3998.633647] audit: type=1400 audit(1657878283.165:55207): apparmor="DENIED" operation="sendmsg" profile="snap.microk8s.daemon-containerd" pid=207855 comm="calico-node" family="netlink" sock_type="raw" protocol=0 requested_mask="send" denied_mask="send"
```

The most likely reason is that the `tests/main/microk8s-smoke` test
started to produce DENIALS. To ensure we catch this early this
commit adds a check for "DENIED" messages.

Maybe we should even create an invariant test for new DENIALS?
