### PR TITLE
many: expose and support provenance from snap.yaml metadata

### DIFF
--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -31,6 +31,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/snap/naming"
 )
 
 type typeFlags int
@@ -131,7 +132,7 @@ var (
 	BaseDeclarationType     = &AssertionType{"base-declaration", []string{"series"}, nil, assembleBaseDeclaration, 0}
 	SnapDeclarationType     = &AssertionType{"snap-declaration", []string{"series", "snap-id"}, nil, assembleSnapDeclaration, 0}
 	SnapBuildType           = &AssertionType{"snap-build", []string{"snap-sha3-384"}, nil, assembleSnapBuild, 0}
-	SnapRevisionType        = &AssertionType{"snap-revision", []string{"snap-sha3-384", "provenance"}, map[string]string{"provenance": "global-upload"}, assembleSnapRevision, 0}
+	SnapRevisionType        = &AssertionType{"snap-revision", []string{"snap-sha3-384", "provenance"}, map[string]string{"provenance": naming.DefaultProvenance}, assembleSnapRevision, 0}
 	SnapDeveloperType       = &AssertionType{"snap-developer", []string{"snap-id", "publisher-id"}, nil, assembleSnapDeveloper, 0}
 	SystemUserType          = &AssertionType{"system-user", []string{"brand-id", "email"}, nil, assembleSystemUser, 0}
 	ValidationType          = &AssertionType{"validation", []string{"series", "snap-id", "approved-snap-id", "approved-snap-revision"}, nil, assembleValidation, 0}

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -323,6 +323,10 @@ func (f *fakeStore) snap(spec snapSpec) (*snap.Info, error) {
 		slot.Apps["dbus-daemon"] = info.Apps["dbus-daemon"]
 	}
 
+	if spec.Name == "provenance-snap" {
+		info.SnapProvenance = "prov"
+	}
+
 	return info, nil
 }
 
@@ -417,6 +421,8 @@ func (f *fakeStore) lookupRefresh(cand refreshCand) (*snap.Info, error) {
 	// for validation-sets testing
 	case "bgtKhntON3vR7kwEbVPsILm7bUViPDzx":
 		name = "some-other-snap"
+	case "provenance-snap-id":
+		name = "provenance-snap"
 	default:
 		panic(fmt.Sprintf("refresh: unknown snap-id: %s", cand.snapID))
 	}
@@ -475,6 +481,8 @@ func (f *fakeStore) lookupRefresh(cand refreshCand) (*snap.Info, error) {
 				Attrs:     map[string]interface{}{"content": "some-content"},
 			},
 		}
+	} else if name == "provenance-snap" {
+		info.SnapProvenance = "prov"
 	}
 
 	switch cand.channel {

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -98,6 +98,8 @@ type SnapSetup struct {
 
 	SnapPath string `json:"snap-path,omitempty"`
 
+	ExpectedProvenance string `json:"provenance,omitempty"`
+
 	DownloadInfo *snap.DownloadInfo `json:"download-info,omitempty"`
 	SideInfo     *snap.SideInfo     `json:"side-info,omitempty"`
 	auxStoreInfo

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -166,6 +166,7 @@ func (ins installSnapInfo) SnapSetupForUpdate(st *state.State, params updatePara
 			Website: update.Website,
 			Media:   update.Media,
 		},
+		ExpectedProvenance: update.SnapProvenance,
 	}
 	snapsup.IgnoreRunning = globalFlags.IgnoreRunning
 	return &snapsup, snapst, nil
@@ -1142,7 +1143,8 @@ func InstallWithDeviceContext(ctx context.Context, st *state.State, name string,
 			Media:   info.Media,
 			Website: info.Website,
 		},
-		CohortKey: opts.CohortKey,
+		CohortKey:          opts.CohortKey,
+		ExpectedProvenance: info.SnapProvenance,
 	}
 
 	if sar.RedirectChannel != "" {
@@ -1311,6 +1313,7 @@ func InstallMany(st *state.State, names []string, userID int, flags *Flags) ([]s
 			Type:               info.Type(),
 			PlugsOnly:          len(info.Slots) == 0,
 			InstanceKey:        info.InstanceKey,
+			ExpectedProvenance: info.SnapProvenance,
 		}
 
 		ts, err := doInstall(st, &snapst, snapsup, 0, "", inUseFor(deviceCtx))

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -5329,3 +5329,31 @@ func (s *snapmgrTestSuite) testUndoMigrateOnInstallWithCore22(c *C, expectSeqFil
 		c.Assert(err, ErrorMatches, ".*no such file or directory")
 	}
 }
+
+func (s *snapmgrTestSuite) TestInstallConsidersProvenance(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	ts, err := snapstate.Install(context.Background(), s.state, "provenance-snap", &snapstate.RevisionOptions{Channel: "some-channel"}, s.user.ID, snapstate.Flags{})
+	c.Assert(err, IsNil)
+
+	var snapsup snapstate.SnapSetup
+	err = ts.Tasks()[0].Get("snap-setup", &snapsup)
+	c.Assert(err, IsNil)
+
+	c.Check(snapsup.ExpectedProvenance, Equals, "prov")
+}
+
+func (s *snapmgrTestSuite) TestInstallManyConsidersProvenance(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	_, tss, err := snapstate.InstallMany(s.state, []string{"provenance-snap"}, s.user.ID, &snapstate.Flags{})
+	c.Assert(err, IsNil)
+
+	var snapsup snapstate.SnapSetup
+	err = tss[0].Tasks()[0].Get("snap-setup", &snapsup)
+	c.Assert(err, IsNil)
+
+	c.Check(snapsup.ExpectedProvenance, Equals, "prov")
+}

--- a/snap/info.go
+++ b/snap/info.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2021 Canonical Ltd
+ * Copyright (C) 2014-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -296,6 +296,8 @@ type Info struct {
 	OriginalSummary     string
 	OriginalDescription string
 
+	SnapProvenance string
+
 	Environment strutil.OrderedMap
 
 	LicenseAgreement string
@@ -414,6 +416,19 @@ type ChannelSnapInfo struct {
 	Epoch       Epoch           `json:"epoch"`
 	Size        int64           `json:"size"`
 	ReleasedAt  time.Time       `json:"released-at"`
+}
+
+// Provenance returns the provenance of the snap, this is a label set
+// e.g to distinguish snaps that are not expected to be processed by the global
+// store. Constraints on this value are used to allow for delegated
+// snap-revision signing.
+// This returns naming.DefaultProvenance if no value is set explicitly
+// in the snap metadata.
+func (s *Info) Provenance() string {
+	if s.SnapProvenance == "" {
+		return naming.DefaultProvenance
+	}
+	return s.SnapProvenance
 }
 
 // InstanceName returns the blessed name of the snap decorated with instance

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -42,6 +42,7 @@ type snapYaml struct {
 	Title           string                 `yaml:"title"`
 	Description     string                 `yaml:"description"`
 	Summary         string                 `yaml:"summary"`
+	Provenance      string                 `yaml:"provenance"`
 	License         string                 `yaml:"license,omitempty"`
 	Epoch           Epoch                  `yaml:"epoch,omitempty"`
 	Base            string                 `yaml:"base,omitempty"`
@@ -280,6 +281,7 @@ func infoSkeletonFromSnapYaml(y snapYaml) *Info {
 		OriginalTitle:       y.Title,
 		OriginalDescription: y.Description,
 		OriginalSummary:     y.Summary,
+		SnapProvenance:      y.Provenance,
 		License:             y.License,
 		Epoch:               y.Epoch,
 		Confinement:         confinement,

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -28,6 +28,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/naming"
 	"github.com/snapcore/snapd/strutil"
 	"github.com/snapcore/snapd/testutil"
 	"github.com/snapcore/snapd/timeout"
@@ -63,6 +64,8 @@ func (s *InfoSnapYamlTestSuite) TestSimple(c *C) {
 	c.Assert(info.Version, Equals, "1.0")
 	c.Assert(info.Type(), Equals, snap.TypeApp)
 	c.Assert(info.Epoch, DeepEquals, snap.E("0"))
+	c.Assert(info.SnapProvenance, Equals, "")
+	c.Check(info.Provenance(), Equals, naming.DefaultProvenance)
 }
 
 func (s *InfoSnapYamlTestSuite) TestSnapdTypeAddedByMagic(c *C) {
@@ -72,6 +75,15 @@ version: 1.0`))
 	c.Assert(info.InstanceName(), Equals, "snapd")
 	c.Assert(info.Version, Equals, "1.0")
 	c.Assert(info.Type(), Equals, snap.TypeSnapd)
+}
+
+func (s *InfoSnapYamlTestSuite) TestNonDefaultProvenance(c *C) {
+	info, err := snap.InfoFromSnapYaml([]byte(`name: foo
+provenance: delegated-prov
+version: 1.0`))
+	c.Assert(err, IsNil)
+	c.Check(info.Provenance(), Equals, "delegated-prov")
+	c.Check(info.SnapProvenance, Equals, "delegated-prov")
 }
 
 func (s *InfoSnapYamlTestSuite) TestFail(c *C) {

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2021 Canonical Ltd
+ * Copyright (C) 2014-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/snap/naming/validate.go
+++ b/snap/naming/validate.go
@@ -214,3 +214,20 @@ func ValidateQuotaGroup(grp string) error {
 
 	return nil
 }
+
+// ValidProvenance is a regular expression describing a valid provenance.
+var ValidProvenance = regexp.MustCompile("^[a-zA-Z0-9](?:-?[a-zA-Z0-9])*$")
+
+// DefaultProvenance is the default value for provenance, i.e the provenance for snaps uplodaded through the global store pipeline.
+const DefaultProvenance = "global-upload"
+
+// ValidateProvenance checks fi the given string is valid non-empty provenance value.
+func ValidateProvenance(prov string) error {
+	if prov == "" {
+		return fmt.Errorf("invalid provenance: must not be empty")
+	}
+	if !ValidProvenance.MatchString(prov) {
+		return fmt.Errorf("invalid provenance: %q", prov)
+	}
+	return nil
+}

--- a/snap/naming/validate_test.go
+++ b/snap/naming/validate_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -21,6 +21,7 @@ package naming_test
 
 import (
 	"fmt"
+	"regexp"
 
 	. "gopkg.in/check.v1"
 
@@ -367,5 +368,23 @@ func (s *ValidateSuite) TestValidQuotaGroup(c *C) {
 	for _, name := range invalidNames {
 		err := naming.ValidateQuotaGroup(name)
 		c.Assert(err, ErrorMatches, `invalid quota group name:.*`)
+	}
+}
+
+func (s *ValidateSuite) TestValidateProvenance(c *C) {
+	c.Check(naming.ValidateProvenance("a"), IsNil)
+	c.Check(naming.ValidateProvenance("123A-abz-dd3Z9"), IsNil)
+
+	c.Check(naming.ValidateProvenance(""), ErrorMatches, `invalid provenance: must not be empty`)
+
+	invalid := []string{
+		"+",
+		"-",
+		"--",
+		"a--z",
+	}
+	for _, prov := range invalid {
+		err := naming.ValidateProvenance(prov)
+		c.Check(err, ErrorMatches, regexp.QuoteMeta(fmt.Sprintf("invalid provenance: %q", prov)))
 	}
 }

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2021 Canonical Ltd
+ * Copyright (C) 2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -298,11 +298,26 @@ func validateTitle(title string) error {
 	return nil
 }
 
+func validateProvenance(prov string) error {
+	if prov == "" {
+		// empty means default
+		return nil
+	}
+	if prov == naming.DefaultProvenance {
+		return fmt.Errorf("provenance cannot be set to default (global-upload) explicitly")
+	}
+	return naming.ValidateProvenance(prov)
+}
+
 // Validate verifies the content in the info.
 func Validate(info *Info) error {
 	name := info.InstanceName()
 	if name == "" {
 		return errors.New("snap name cannot be empty")
+	}
+
+	if err := validateProvenance(info.SnapProvenance); err != nil {
+		return err
 	}
 
 	if err := ValidateName(info.SnapName()); err != nil {

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2021 Canonical Ltd
+ * Copyright (C) 2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -672,6 +672,28 @@ apps:
 }
 
 // Validate
+
+func (s *ValidateSuite) TestDetectInvalidProvenance(c *C) {
+	info, err := InfoFromSnapYaml([]byte(`name: foo
+version: 1.0
+provenance: "--"
+`))
+	c.Assert(err, IsNil)
+
+	err = Validate(info)
+	c.Check(err, ErrorMatches, `invalid provenance: .*`)
+}
+
+func (s *ValidateSuite) TestDetectExplicitDefaultProvenance(c *C) {
+	info, err := InfoFromSnapYaml([]byte(`name: foo
+version: 1.0
+provenance: global-upload
+`))
+	c.Assert(err, IsNil)
+
+	err = Validate(info)
+	c.Check(err, ErrorMatches, `provenance cannot be set to default \(global-upload\) explicitly`)
+}
 
 func (s *ValidateSuite) TestDetectIllegalYamlBinaries(c *C) {
 	info, err := InfoFromSnapYaml([]byte(`name: foo

--- a/store/details_v2.go
+++ b/store/details_v2.go
@@ -295,7 +295,7 @@ func infoFromStoreSnap(d *storeSnap) (*snap.Info, error) {
 	info.Website = d.Website
 	info.StoreURL = d.StoreURL
 
-	// fill in the plug/slot data
+	// fill in the plug/slot data etc
 	if rawYamlInfo, err := snap.InfoFromSnapYaml([]byte(d.SnapYAML)); err == nil {
 		if info.Plugs == nil {
 			info.Plugs = make(map[string]*snap.PlugInfo)
@@ -314,6 +314,7 @@ func infoFromStoreSnap(d *storeSnap) (*snap.Info, error) {
 		for _, s := range rawYamlInfo.Assumes {
 			info.Assumes = append(info.Assumes, s)
 		}
+		info.SnapProvenance = rawYamlInfo.SnapProvenance
 	}
 
 	// convert prices

--- a/store/details_v2_test.go
+++ b/store/details_v2_test.go
@@ -308,6 +308,7 @@ func (s *detailsV2Suite) TestInfoFromStoreSnap(c *C) {
 		"SideInfo.EditedLinks",         // TODO: take this value from the store
 		"DownloadInfo.AnonDownloadURL", // TODO: going away at some point
 		"SystemUsernames",
+		"SnapProvenance", // TODO: take this value
 	}
 	var checker func(string, reflect.Value)
 	checker = func(pfx string, x reflect.Value) {

--- a/store/details_v2_test.go
+++ b/store/details_v2_test.go
@@ -120,7 +120,7 @@ const (
   },
   "revision": 21,
   "snap-id": "XYZEfjn4WJYnm0FzDKwqqRZZI77awQEV",
-  "snap-yaml": "name: test-snapd-content-plug\nversion: 1.0\nassumes: [snapd2.49]\napps:\n    content-plug:\n        command: bin/content-plug\n        plugs: [shared-content-plug]\nplugs:\n    shared-content-plug:\n        interface: content\n        target: import\n        content: mylib\n        default-provider: test-snapd-content-slot\nslots:\n    shared-content-slot:\n        interface: content\n        content: mylib\n        read:\n            - /\n",
+  "snap-yaml": "name: test-snapd-content-plug\nversion: 1.0\nassumes: [snapd2.49]\napps:\n    content-plug:\n        command: bin/content-plug\n        plugs: [shared-content-plug]\nplugs:\n    shared-content-plug:\n        interface: content\n        target: import\n        content: mylib\n        default-provider: test-snapd-content-slot\nslots:\n    shared-content-slot:\n        interface: content\n        content: mylib\n        read:\n            - /\nprovenance: prov\n",
   "store-url": "https://snapcraft.io/thingy",
   "summary": "useful thingy",
   "title": "This Is The Most Fantastical Snap of Thingy",
@@ -254,9 +254,10 @@ func (s *detailsV2Suite) TestInfoFromStoreSnap(c *C) {
 			{Type: "screenshot", URL: "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/Thingy_01.png"},
 			{Type: "screenshot", URL: "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/Thingy_02.png", Width: 600, Height: 200},
 		},
-		CommonIDs: []string{"org.thingy"},
-		Website:   "http://example.com/thingy",
-		StoreURL:  "https://snapcraft.io/thingy",
+		CommonIDs:      []string{"org.thingy"},
+		Website:        "http://example.com/thingy",
+		StoreURL:       "https://snapcraft.io/thingy",
+		SnapProvenance: "prov",
 	})
 
 	// validate the plugs/slots
@@ -308,7 +309,6 @@ func (s *detailsV2Suite) TestInfoFromStoreSnap(c *C) {
 		"SideInfo.EditedLinks",         // TODO: take this value from the store
 		"DownloadInfo.AnonDownloadURL", // TODO: going away at some point
 		"SystemUsernames",
-		"SnapProvenance", // TODO: take this value
 	}
 	var checker func(string, reflect.Value)
 	checker = func(pfx string, x reflect.Value) {


### PR DESCRIPTION
This adds metadata and snap.Info support including validation for provenance.

Make sure we extract it from store results and make it available as SnapSetup.ExpectedProvenance for installation task for the from-the-store cases.
