### PR TITLE
many: device and provenance revision authority cross checks

### DIFF
--- a/asserts/snapasserts/snapasserts.go
+++ b/asserts/snapasserts/snapasserts.go
@@ -62,7 +62,7 @@ func findSnapDeclaration(snapID, name string, db Finder) (*asserts.SnapDeclarati
 // The optional model assertion must be passed to have full cross
 // checks in the case of delegated authority snap-revisions before
 // installing a snap.
-// It returns also the provenance if different from the default.
+// It also returns the provenance if is is different from the default.
 // Ultimately if not default the provenance must also be checked
 // with the provenance in the snap metadata by the caller as well,
 // if the provenance provided to the function was not read safely from
@@ -111,7 +111,7 @@ func CrossCheck(instanceName, snapSHA3_384, provenance string, snapSize uint64, 
 // if it has a non default provenance with the revision-authority
 // constraints of the given snap-declaration including any device
 // scope constraints using model (and implied store).
-// It returns also the provenance if different from the default.
+// It also returns the provenance if it is different from the default.
 // Ultimately if not default the provenance must also be checked
 // with the provenance in the snap metadata by the caller.
 func CrossCheckProvenance(instanceName string, snapRev *asserts.SnapRevision, snapDecl *asserts.SnapDeclaration, model *asserts.Model, db Finder) (signedProvenance string, err error) {

--- a/image/helpers.go
+++ b/image/helpers.go
@@ -33,7 +33,10 @@ import (
 	"github.com/snapcore/snapd/snap"
 )
 
-// FetchAndCheckSnapAssertions fetches and cross checks the snap assertions matching the given snap file using the provided asserts.Fetcher and assertion database. The optional model assertion must be passed for full cross checks.
+// FetchAndCheckSnapAssertions fetches and cross checks the snap assertions
+// matching the given snap file using the provided asserts.Fetcher and
+// assertion database.
+// The optional model assertion must be passed for full cross checks.
 func FetchAndCheckSnapAssertions(snapPath string, info *snap.Info, model *asserts.Model, f asserts.Fetcher, db asserts.RODatabase) (*asserts.SnapDeclaration, error) {
 	sha3_384, size, err := asserts.SnapFileSHA3_384(snapPath)
 	if err != nil {

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -3308,3 +3308,40 @@ func (s *imageSuite) TestPrepareWithClassicPreseedError(c *C) {
 	})
 	c.Assert(err, ErrorMatches, `cannot preseed the image for a classic model`)
 }
+
+func (s *imageSuite) TestSetupSeedCore20DelegatedSnap(c *C) {
+	bootloader.Force(nil)
+	restore := image.MockTrusted(s.StoreSigning.Trusted)
+	defer restore()
+
+	// a model that uses core20
+	model := s.makeUC20Model(nil)
+
+	prepareDir := c.MkDir()
+
+	s.makeSnap(c, "snapd", nil, snap.R(1), "")
+	s.makeSnap(c, "core20", nil, snap.R(20), "")
+	s.makeSnap(c, "pc-kernel=20", nil, snap.R(1), "")
+	gadgetContent := [][]string{
+		{"grub.conf", "# boot grub.cfg"},
+		{"meta/gadget.yaml", pcUC20GadgetYaml},
+	}
+	s.makeSnap(c, "pc=20", gadgetContent, snap.R(22), "")
+
+	ra := map[string]interface{}{
+		"account-id": "my-brand",
+		"provenance": []interface{}{"delegated-prov"},
+	}
+	s.MakeAssertedDelegatedSnap(c, seedtest.SampleSnapYaml["required20"]+"\nprovenance: delegated-prov\n", nil, snap.R(1), "my-brand", "my-brand", "delegated-prov", ra, s.StoreSigning.Database)
+
+	opts := &image.Options{
+		PrepareDir: prepareDir,
+		Customizations: image.Customizations{
+			BootFlags:  []string{"factory"},
+			Validation: "ignore",
+		},
+	}
+
+	err := image.SetupSeed(s.tsto, model, opts)
+	c.Check(err, IsNil)
+}

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2021 Canonical Ltd
+ * Copyright (C) 2016-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -25,8 +25,6 @@ import (
 	"crypto"
 	"errors"
 	"fmt"
-	"io/ioutil"
-	"path/filepath"
 	"sort"
 	"strings"
 	"testing"
@@ -494,7 +492,16 @@ func makeDigest(rev int) string {
 	return string(d)
 }
 
-func (s *assertMgrSuite) prereqSnapAssertions(c *C, revisions ...int) {
+func (s *assertMgrSuite) makeTestSnap(c *C, r int, extra string) string {
+	yaml := `name: foo
+version: %d
+%s
+`
+	yaml = fmt.Sprintf(yaml, r, extra)
+	return snaptest.MakeTestSnapWithFiles(c, yaml, nil)
+}
+
+func (s *assertMgrSuite) prereqSnapAssertions(c *C, revisions ...int) (paths map[int]string, digests map[int]string) {
 	headers := map[string]interface{}{
 		"series":       "16",
 		"snap-id":      "snap-id-1",
@@ -507,11 +514,20 @@ func (s *assertMgrSuite) prereqSnapAssertions(c *C, revisions ...int) {
 	err = s.storeSigning.Add(snapDecl)
 	c.Assert(err, IsNil)
 
+	paths = make(map[int]string)
+	digests = make(map[int]string)
+
 	for _, rev := range revisions {
+		snapPath := s.makeTestSnap(c, rev, "")
+		digest, sz, err := asserts.SnapFileSHA3_384(snapPath)
+		c.Assert(err, IsNil)
+		paths[rev] = snapPath
+		digests[rev] = digest
+
 		headers = map[string]interface{}{
 			"snap-id":       "snap-id-1",
-			"snap-sha3-384": makeDigest(rev),
-			"snap-size":     fmt.Sprintf("%d", len(fakeSnap(rev))),
+			"snap-sha3-384": digest,
+			"snap-size":     fmt.Sprintf("%d", sz),
 			"snap-revision": fmt.Sprintf("%d", rev),
 			"developer-id":  s.dev1Acct.AccountID(),
 			"timestamp":     time.Now().Format(time.RFC3339),
@@ -521,17 +537,19 @@ func (s *assertMgrSuite) prereqSnapAssertions(c *C, revisions ...int) {
 		err = s.storeSigning.Add(snapRev)
 		c.Assert(err, IsNil)
 	}
+
+	return paths, digests
 }
 
 func (s *assertMgrSuite) TestDoFetch(c *C) {
-	s.prereqSnapAssertions(c, 10)
+	_, digests := s.prereqSnapAssertions(c, 10)
 
 	s.state.Lock()
 	defer s.state.Unlock()
 
 	ref := &asserts.Ref{
 		Type:       asserts.SnapRevisionType,
-		PrimaryKey: []string{makeDigest(10)},
+		PrimaryKey: []string{digests[10]},
 	}
 
 	err := assertstate.DoFetch(s.state, 0, s.trivialDeviceCtx, func(f asserts.Fetcher) error {
@@ -545,14 +563,14 @@ func (s *assertMgrSuite) TestDoFetch(c *C) {
 }
 
 func (s *assertMgrSuite) TestFetchIdempotent(c *C) {
-	s.prereqSnapAssertions(c, 10, 11)
+	_, digests := s.prereqSnapAssertions(c, 10, 11)
 
 	s.state.Lock()
 	defer s.state.Unlock()
 
 	ref := &asserts.Ref{
 		Type:       asserts.SnapRevisionType,
-		PrimaryKey: []string{makeDigest(10)},
+		PrimaryKey: []string{digests[10]},
 	}
 	fetching := func(f asserts.Fetcher) error {
 		return f.Fetch(ref)
@@ -563,7 +581,7 @@ func (s *assertMgrSuite) TestFetchIdempotent(c *C) {
 
 	ref = &asserts.Ref{
 		Type:       asserts.SnapRevisionType,
-		PrimaryKey: []string{makeDigest(11)},
+		PrimaryKey: []string{digests[11]},
 	}
 
 	err = assertstate.DoFetch(s.state, 0, s.trivialDeviceCtx, fetching)
@@ -701,19 +719,15 @@ func (s *assertMgrSuite) setupModelAndStore(c *C) *asserts.Store {
 }
 
 func (s *assertMgrSuite) TestValidateSnap(c *C) {
-	s.prereqSnapAssertions(c, 10)
-
-	tempdir := c.MkDir()
-	snapPath := filepath.Join(tempdir, "foo.snap")
-	err := ioutil.WriteFile(snapPath, fakeSnap(10), 0644)
-	c.Assert(err, IsNil)
+	paths, digests := s.prereqSnapAssertions(c, 10)
+	snapPath := paths[10]
 
 	s.state.Lock()
 	defer s.state.Unlock()
 
 	// have a model and the store assertion available
 	storeAs := s.setupModelAndStore(c)
-	err = s.storeSigning.Add(storeAs)
+	err := s.storeSigning.Add(storeAs)
 	c.Assert(err, IsNil)
 
 	chg := s.state.NewChange("install", "...")
@@ -739,7 +753,7 @@ func (s *assertMgrSuite) TestValidateSnap(c *C) {
 
 	snapRev, err := assertstate.DB(s.state).Find(asserts.SnapRevisionType, map[string]string{
 		"snap-id":       "snap-id-1",
-		"snap-sha3-384": makeDigest(10),
+		"snap-sha3-384": digests[10],
 	})
 	c.Assert(err, IsNil)
 	c.Check(snapRev.(*asserts.SnapRevision).SnapRevision(), Equals, 10)
@@ -752,12 +766,9 @@ func (s *assertMgrSuite) TestValidateSnap(c *C) {
 }
 
 func (s *assertMgrSuite) TestValidateSnapStoreNotFound(c *C) {
-	s.prereqSnapAssertions(c, 10)
+	paths, digests := s.prereqSnapAssertions(c, 10)
 
-	tempdir := c.MkDir()
-	snapPath := filepath.Join(tempdir, "foo.snap")
-	err := ioutil.WriteFile(snapPath, fakeSnap(10), 0644)
-	c.Assert(err, IsNil)
+	snapPath := paths[10]
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -788,7 +799,7 @@ func (s *assertMgrSuite) TestValidateSnapStoreNotFound(c *C) {
 
 	snapRev, err := assertstate.DB(s.state).Find(asserts.SnapRevisionType, map[string]string{
 		"snap-id":       "snap-id-1",
-		"snap-sha3-384": makeDigest(10),
+		"snap-sha3-384": digests[10],
 	})
 	c.Assert(err, IsNil)
 	c.Check(snapRev.(*asserts.SnapRevision).SnapRevision(), Equals, 10)
@@ -817,10 +828,7 @@ func (s *assertMgrSuite) TestValidateSnapMissingSnapSetup(c *C) {
 }
 
 func (s *assertMgrSuite) TestValidateSnapNotFound(c *C) {
-	tempdir := c.MkDir()
-	snapPath := filepath.Join(tempdir, "foo.snap")
-	err := ioutil.WriteFile(snapPath, fakeSnap(33), 0644)
-	c.Assert(err, IsNil)
+	snapPath := s.makeTestSnap(c, 33, "")
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -850,12 +858,9 @@ func (s *assertMgrSuite) TestValidateSnapNotFound(c *C) {
 }
 
 func (s *assertMgrSuite) TestValidateSnapCrossCheckFail(c *C) {
-	s.prereqSnapAssertions(c, 10)
+	paths, _ := s.prereqSnapAssertions(c, 10)
 
-	tempdir := c.MkDir()
-	snapPath := filepath.Join(tempdir, "foo.snap")
-	err := ioutil.WriteFile(snapPath, fakeSnap(10), 0644)
-	c.Assert(err, IsNil)
+	snapPath := paths[10]
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -882,6 +887,197 @@ func (s *assertMgrSuite) TestValidateSnapCrossCheckFail(c *C) {
 	s.state.Lock()
 
 	c.Assert(chg.Err(), ErrorMatches, `(?s).*cannot install "f", snap "f" is undergoing a rename to "foo".*`)
+}
+
+func (s *assertMgrSuite) TestValidateDelegatedSnap(c *C) {
+	snapPath := s.makeTestSnap(c, 10, `provenance: delegated-prov`)
+	digest, sz, err := asserts.SnapFileSHA3_384(snapPath)
+	c.Assert(err, IsNil)
+
+	headers := map[string]interface{}{
+		"series":       "16",
+		"snap-id":      "snap-id-1",
+		"snap-name":    "foo",
+		"publisher-id": s.dev1Acct.AccountID(),
+		"revision-authority": []interface{}{
+			map[string]interface{}{
+				"account-id": s.dev1Acct.AccountID(),
+				"provenance": []interface{}{"delegated-prov"},
+				"on-store":   []interface{}{"my-brand-store"},
+				"on-model":   []interface{}{"my-brand/my-model"},
+			},
+		},
+		"timestamp": time.Now().Format(time.RFC3339),
+	}
+	snapDecl, err := s.storeSigning.Sign(asserts.SnapDeclarationType, headers, nil, "")
+	c.Assert(err, IsNil)
+	err = s.storeSigning.Add(snapDecl)
+	c.Assert(err, IsNil)
+
+	headers = map[string]interface{}{
+		"authority-id":  s.dev1Acct.AccountID(),
+		"series":        "16",
+		"snap-id":       "snap-id-1",
+		"snap-sha3-384": digest,
+		"provenance":    "delegated-prov",
+		"snap-size":     fmt.Sprintf("%d", sz),
+		"snap-revision": "10",
+		"developer-id":  s.dev1Acct.AccountID(),
+		"timestamp":     time.Now().Format(time.RFC3339),
+	}
+	snapRev, err := s.dev1Signing.Sign(asserts.SnapRevisionType, headers, nil, "")
+	c.Assert(err, IsNil)
+	err = s.storeSigning.Add(snapRev)
+	c.Assert(err, IsNil)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// have a model and the store assertion available
+	storeAs := s.setupModelAndStore(c)
+	err = s.storeSigning.Add(storeAs)
+	c.Assert(err, IsNil)
+
+	chg := s.state.NewChange("install", "...")
+	t := s.state.NewTask("validate-snap", "Fetch and check snap assertions")
+	snapsup := snapstate.SnapSetup{
+		SnapPath: snapPath,
+		UserID:   0,
+		SideInfo: &snap.SideInfo{
+			RealName: "foo",
+			SnapID:   "snap-id-1",
+			Revision: snap.R(10),
+		},
+		ExpectedProvenance: "delegated-prov",
+	}
+	t.Set("snap-setup", snapsup)
+	chg.AddTask(t)
+
+	s.state.Unlock()
+	defer s.se.Stop()
+	s.settle(c)
+	s.state.Lock()
+
+	c.Assert(chg.Err(), IsNil)
+
+	snapRev1, err := assertstate.DB(s.state).Find(asserts.SnapRevisionType, map[string]string{
+		"snap-id":       "snap-id-1",
+		"snap-sha3-384": digest,
+		"provenance":    "delegated-prov",
+	})
+	c.Assert(err, IsNil)
+	c.Check(snapRev1.(*asserts.SnapRevision).SnapRevision(), Equals, 10)
+
+	// store assertion was also fetched
+	_, err = assertstate.DB(s.state).Find(asserts.StoreType, map[string]string{
+		"store": "my-brand-store",
+	})
+	c.Assert(err, IsNil)
+}
+
+func (s *assertMgrSuite) TestValidateDelegatedSnapProvenanceMismatch(c *C) {
+	err := s.testValidateDelegatedSnapMismatch(c, `provenance: delegated-prov-other`, "delegated-prov-other", "delegated-prov", map[string]interface{}{
+		"account-id": s.dev1Acct.AccountID(),
+		"provenance": []interface{}{"delegated-prov"},
+	})
+	c.Check(err, ErrorMatches, `(?s).*cannot verify snap "foo", no matching signatures found.*`)
+}
+
+func (s *assertMgrSuite) TestValidateDelegatedSnapStoreProvenanceMismatch(c *C) {
+	// this is a scenario where a store is serving information matching
+	// the assertions which themselves don't match the snap
+	err := s.testValidateDelegatedSnapMismatch(c, `provenance: delegated-prov-other`, "delegated-prov", "delegated-prov", map[string]interface{}{
+		"account-id": s.dev1Acct.AccountID(),
+		"provenance": []interface{}{"delegated-prov"},
+	})
+	c.Check(err, ErrorMatches, `(?s).*snap ".*foo.*\.snap" has been signed under provenance "delegated-prov" different from the metadata one: "delegated-prov-other".*`)
+}
+
+func (s *assertMgrSuite) testValidateDelegatedSnapMismatch(c *C, provenanceFrag, expectedProv, revProvenance string, revisionAuthority map[string]interface{}) error {
+	snapPath := s.makeTestSnap(c, 10, provenanceFrag)
+	digest, sz, err := asserts.SnapFileSHA3_384(snapPath)
+	c.Assert(err, IsNil)
+
+	headers := map[string]interface{}{
+		"series":       "16",
+		"snap-id":      "snap-id-1",
+		"snap-name":    "foo",
+		"publisher-id": s.dev1Acct.AccountID(),
+		"revision-authority": []interface{}{
+			revisionAuthority,
+		},
+		"timestamp": time.Now().Format(time.RFC3339),
+	}
+	snapDecl, err := s.storeSigning.Sign(asserts.SnapDeclarationType, headers, nil, "")
+	c.Assert(err, IsNil)
+	err = s.storeSigning.Add(snapDecl)
+	c.Assert(err, IsNil)
+
+	headers = map[string]interface{}{
+		"authority-id":  s.dev1Acct.AccountID(),
+		"series":        "16",
+		"snap-id":       "snap-id-1",
+		"snap-sha3-384": digest,
+		"snap-size":     fmt.Sprintf("%d", sz),
+		"snap-revision": "10",
+		"developer-id":  s.dev1Acct.AccountID(),
+		"timestamp":     time.Now().Format(time.RFC3339),
+	}
+	if revProvenance != "" {
+		headers["provenance"] = revProvenance
+	}
+	snapRev, err := s.dev1Signing.Sign(asserts.SnapRevisionType, headers, nil, "")
+	c.Assert(err, IsNil)
+	err = s.storeSigning.Add(snapRev)
+	c.Assert(err, IsNil)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// have a model and the store assertion available
+	storeAs := s.setupModelAndStore(c)
+	err = s.storeSigning.Add(storeAs)
+	c.Assert(err, IsNil)
+
+	chg := s.state.NewChange("install", "...")
+	t := s.state.NewTask("validate-snap", "Fetch and check snap assertions")
+	snapsup := snapstate.SnapSetup{
+		SnapPath: snapPath,
+		UserID:   0,
+		SideInfo: &snap.SideInfo{
+			RealName: "foo",
+			SnapID:   "snap-id-1",
+			Revision: snap.R(10),
+		},
+		ExpectedProvenance: expectedProv,
+	}
+	t.Set("snap-setup", snapsup)
+	chg.AddTask(t)
+
+	s.state.Unlock()
+	defer s.se.Stop()
+	s.settle(c)
+	s.state.Lock()
+
+	return chg.Err()
+}
+
+func (s *assertMgrSuite) TestValidateDelegatedSnapDeviceMismatch(c *C) {
+	err := s.testValidateDelegatedSnapMismatch(c, `provenance: delegated-prov`, "delegated-prov", "delegated-prov", map[string]interface{}{
+		"account-id": s.dev1Acct.AccountID(),
+		"provenance": []interface{}{"delegated-prov"},
+		"on-store":   []interface{}{"other-store"},
+	})
+	c.Check(err, ErrorMatches, `(?s).*snap "foo" revision assertion with provenance "delegated-prov" is not signed by an authority authorized on this device: .*`)
+}
+
+func (s *assertMgrSuite) TestValidateDelegatedSnapDefaultProvenanceMismatch(c *C) {
+	err := s.testValidateDelegatedSnapMismatch(c, "", "", "delegated-prov", map[string]interface{}{
+		"account-id": s.dev1Acct.AccountID(),
+		"provenance": []interface{}{"delegated-prov"},
+		"on-store":   []interface{}{"my-brand-store"},
+	})
+	c.Check(err, ErrorMatches, `(?s).*cannot verify snap "foo", no matching signatures found.*`)
 }
 
 func (s *assertMgrSuite) validationSetAssert(c *C, name, sequence, revision string, snapPresence, requiredRevision string) *asserts.ValidationSet {

--- a/seed/seed20.go
+++ b/seed/seed20.go
@@ -318,6 +318,18 @@ func (s *seed20) lookupVerifiedRevision(snapRef naming.SnapRef, essType snap.Typ
 		snapPath = newPath
 	}
 
+	signedProv, err := snapasserts.CrossCheckProvenance(snapName, snapRev, snapDecl, s.model, s.db)
+	if err != nil {
+		return "", nil, nil, err
+	}
+
+	// we have an authorized snap-revision with matching hash for
+	// the blob, double check that the snap metadata provenance is
+	// as expected
+	if err := snapasserts.CheckProvenance(snapPath, signedProv); err != nil {
+		return "", nil, nil, err
+	}
+
 	return snapPath, snapRev, snapDecl, nil
 }
 

--- a/seed/seedtest/seedtest.go
+++ b/seed/seedtest/seedtest.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015-2019 Canonical Ltd
+ * Copyright (C) 2015-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -79,6 +79,10 @@ func (ss *SeedSnaps) SetSnapAssertionNow(t time.Time) {
 }
 
 func (ss *SeedSnaps) MakeAssertedSnap(c *C, snapYaml string, files [][]string, revision snap.Revision, developerID string, dbs ...*asserts.Database) (*asserts.SnapDeclaration, *asserts.SnapRevision) {
+	return ss.makeAssertedSnap(c, snapYaml, files, revision, developerID, ss.StoreSigning.SigningDB, "", nil, dbs...)
+}
+
+func (ss *SeedSnaps) makeAssertedSnap(c *C, snapYaml string, files [][]string, revision snap.Revision, developerID string, revSigning *assertstest.SigningDB, revProvenance string, revisionAuthority map[string]interface{}, dbs ...*asserts.Database) (*asserts.SnapDeclaration, *asserts.SnapRevision) {
 	info, err := snap.InfoFromSnapYaml([]byte(snapYaml))
 	c.Assert(err, IsNil)
 	snapName := info.SnapName()
@@ -86,26 +90,35 @@ func (ss *SeedSnaps) MakeAssertedSnap(c *C, snapYaml string, files [][]string, r
 	snapFile := snaptest.MakeTestSnapWithFiles(c, snapYaml, files)
 
 	snapID := ss.AssertedSnapID(snapName)
-	declA, err := ss.StoreSigning.Sign(asserts.SnapDeclarationType, map[string]interface{}{
+	headers := map[string]interface{}{
 		"series":       "16",
 		"snap-id":      snapID,
 		"publisher-id": developerID,
 		"snap-name":    snapName,
 		"timestamp":    ss.snapAssertionNow().UTC().Format(time.RFC3339),
-	}, nil, "")
+	}
+	if revisionAuthority != nil {
+		headers["revision-authority"] = []interface{}{revisionAuthority}
+	}
+	declA, err := ss.StoreSigning.Sign(asserts.SnapDeclarationType, headers, nil, "")
 	c.Assert(err, IsNil)
 
 	sha3_384, size, err := asserts.SnapFileSHA3_384(snapFile)
 	c.Assert(err, IsNil)
 
-	revA, err := ss.StoreSigning.Sign(asserts.SnapRevisionType, map[string]interface{}{
+	revHeaders := map[string]interface{}{
+		"authority-id":  revSigning.AuthorityID,
 		"snap-sha3-384": sha3_384,
 		"snap-size":     fmt.Sprintf("%d", size),
 		"snap-id":       snapID,
 		"developer-id":  developerID,
 		"snap-revision": revision.String(),
 		"timestamp":     ss.snapAssertionNow().UTC().Format(time.RFC3339),
-	}, nil, "")
+	}
+	if revProvenance != "" {
+		revHeaders["provenance"] = revProvenance
+	}
+	revA, err := revSigning.Sign(asserts.SnapRevisionType, revHeaders, nil, "")
 	c.Assert(err, IsNil)
 
 	if !revision.Unset() {
@@ -134,6 +147,10 @@ func (ss *SeedSnaps) MakeAssertedSnap(c *C, snapYaml string, files [][]string, r
 	ss.snapRevs[snapName] = snapRev
 
 	return snapDecl, snapRev
+}
+
+func (ss *SeedSnaps) MakeAssertedDelegatedSnap(c *C, snapYaml string, files [][]string, revision snap.Revision, developerID, delegateID, revProvenance string, revisionAuthority map[string]interface{}, dbs ...*asserts.Database) (*asserts.SnapDeclaration, *asserts.SnapRevision) {
+	return ss.makeAssertedSnap(c, snapYaml, files, revision, developerID, ss.Brands.Signing(delegateID), revProvenance, revisionAuthority, dbs...)
 }
 
 func (ss *SeedSnaps) AssertedSnap(snapName string) (snapFile string) {

--- a/tests/lib/fakestore/refresh/refresh.go
+++ b/tests/lib/fakestore/refresh/refresh.go
@@ -273,7 +273,8 @@ func buildSnap(snapDir, targetDir string) (*info, error) {
 }
 
 func copySnapAsserts(info *info, f asserts.Fetcher) error {
-	return snapasserts.FetchSnapAssertions(f, info.digest)
+	// assume provenance is unset
+	return snapasserts.FetchSnapAssertions(f, info.digest, "")
 }
 
 func makeNewSnapRevision(orig, new *info, targetDir string, db *asserts.Database) error {


### PR DESCRIPTION
snap revision fetching and cross-checking should take provenance into
account and also verify device scope constraints for revision
authority delegation

provenance is taken as a hint from the store, but then matching
assertions must be found and then provenance is double checked

a failure of the latter check is likely a sign of a bug or
error as an attacker that can submit or forge/sign a blob could
as well do one with the expected provenance

provenance goals are tracing and avoiding the risk of polluting
the snap-revision namespace

this leaves alone the DeriveSideInfo* functions, mainly used for
asserted local installs, this means they might fail to find a
snap-revision sometimes, they will be updated in a different branch.

This is based on #11969  and is an alternative approach to #11943 and #11944, it avoids having to open the blob before we verified the hash vs signatures by using the fact that the store can give us the provenance information separately before hand, it is still case that we do not proceed further unless valid/authorized snap-revision/snap-declaration exist for the pair hash and provenance.

This will need to be split a bit even once #11969 lands.