### PR TITLE
daemon,overlord/servicestate: followup changes from PR #11960 to snap logs

### DIFF
--- a/daemon/api_apps.go
+++ b/daemon/api_apps.go
@@ -208,7 +208,7 @@ func getLogs(c *Command, r *http.Request, user *auth.UserState) Response {
 		return AppNotFound("no matching services")
 	}
 
-	reader, err := servicestate.SnapAppsLogReader(appInfos, n, follow)
+	reader, err := servicestate.LogReader(appInfos, n, follow)
 	if err != nil {
 		return InternalError("cannot get logs: %v", err)
 	}

--- a/overlord/servicestate/servicestate.go
+++ b/overlord/servicestate/servicestate.go
@@ -400,12 +400,15 @@ func SnapServiceOptions(st *state.State, instanceName string, quotaGroups map[st
 	return opts, nil
 }
 
-// SnapAppsLogReader returns an io.ReadCloser which produce logs for the provided
+// LogReader returns an io.ReadCloser which produce logs for the provided
 // snap AppInfo's. It is a convenience wrapper around the systemd.LogReader
 // implementation.
-func SnapAppsLogReader(appInfos []*snap.AppInfo, n int, follow bool) (io.ReadCloser, error) {
+func LogReader(appInfos []*snap.AppInfo, n int, follow bool) (io.ReadCloser, error) {
 	serviceNames := make([]string, len(appInfos))
 	for i, appInfo := range appInfos {
+		if !appInfo.IsService() {
+			return nil, fmt.Errorf("cannot read logs for app %q: not a service", appInfo.Name)
+		}
 		serviceNames[i] = appInfo.ServiceName()
 	}
 


### PR DESCRIPTION
These are followup changes to the remaining review comments in https://github.com/snapcore/snapd/pull/11960

Including rename of function, and return an error if one of the AppInfo's received is not a service. (The current usage already makes sure to only provide services)