### PR TITLE
cmd/snap: fix visual representation of 'AxB%' cpu quota modifier.

### DIFF
--- a/cmd/snap/cmd_quota.go
+++ b/cmd/snap/cmd_quota.go
@@ -502,9 +502,8 @@ func (x *cmdQuotas) Execute(args []string) (err error) {
 		// format cpu constraint as cpu=NxM%,cpu-set=x,y,z
 		if q.Constraints.CPU != nil {
 			if q.Constraints.CPU.Count != 0 {
-				grpConstraints = append(grpConstraints, fmt.Sprintf("cpu=%dx", q.Constraints.CPU.Count))
-			}
-			if q.Constraints.CPU.Percentage != 0 {
+				grpConstraints = append(grpConstraints, fmt.Sprintf("cpu=%dx%d%%", q.Constraints.CPU.Count, q.Constraints.CPU.Percentage))
+			} else {
 				grpConstraints = append(grpConstraints, fmt.Sprintf("cpu=%d%%", q.Constraints.CPU.Percentage))
 			}
 		}

--- a/cmd/snap/cmd_quota_test.go
+++ b/cmd/snap/cmd_quota_test.go
@@ -674,10 +674,10 @@ func (s *quotaSuite) TestGetAllQuotaGroups(c *check.C) {
 	c.Check(s.Stdout(), check.Equals, `
 Quota    Parent  Constraints                               Current
 cp0              memory=9.9kB,cpu=90%                      memory=10.0kB
-cp1              cpu=2x,cpu=90%                            
+cp1              cpu=2x90%                                 
 cps0     cp1     cpu=40%                                   
 js0      cp1     journal-size=1.05MB,journal-rate=50/1m0s  
-cp2              cpu=2x,cpu=100%,cpu-set=0,1               
+cp2              cpu=2x100%,cpu-set=0,1                    
 cps1     cp2     memory=9.9kB,cpu=50%,cpu-set=1            memory=10.0kB
 ggg              memory=1000B,threads=100                  memory=3000B
 hhh              threads=100                               


### PR DESCRIPTION
This fixes a weird visual representation in the 'snap quotas' command when a quota group has a specific core multiplier set. There is even a unit test for verifying this (but the test was also wrong) so it was an oversight.

This should clear it up!