### PR TITLE
update-copyright.sh: add tool to update copyright year

### DIFF
--- a/update-copyright.sh
+++ b/update-copyright.sh
@@ -1,0 +1,16 @@
+#! /bin/sh
+
+CURRENT_YEAR="$(date +%Y)"
+AUTHOR_TAG="${1:-"Canonical Ltd"}"
+
+for i in $(git ls-files | grep '.\(h\|c\|go\)$')
+do
+    LINE="$(grep Copyright.*"${AUTHOR_TAG}" "$i")"
+    SINGLE_YEAR=$(echo "$LINE" | sed -n 's/ \* Copyright .* \([0-9]\+\) .*/\1/p')
+    RANGE_YEAR=$(echo "$LINE" | sed -n 's/ \* Copyright .* [0-9]\+-\([0-9]\+\) .*/\1/p')
+    if [ -n "$SINGLE_YEAR" ] && [ "$SINGLE_YEAR" -ne "$CURRENT_YEAR" ]; then
+        sed -i"" -e 's/\( \* Copyright .*\) '"$SINGLE_YEAR"' \(.*\)/\1 '"${SINGLE_YEAR}-$CURRENT_YEAR"' \2/' "$i"
+    elif [ -n "$RANGE_YEAR" ]; then
+        sed -i"" -e 's/\( \* Copyright .*\)-'"$RANGE_YEAR"' \(.*\)/\1-'"$CURRENT_YEAR"' \2/' "$i"
+    fi
+done


### PR DESCRIPTION
We will actually update the copyright in another PR, to avoid conflicts. For the moment, just run this tool locally (without parameters) and see what it does.
