### PR TITLE
tests: improve 'ignore-running' spread test

### DIFF
--- a/tests/main/refresh-mode-ignore-running/task.yaml
+++ b/tests/main/refresh-mode-ignore-running/task.yaml
@@ -17,14 +17,17 @@ execute: |
 
   trap 'touch stamp' EXIT
 
+  # refresh app awareness prevents the snap from being refreshed while it's running
   test-snapd-refresh.sh -c "while [ ! -e stamp ]; do sleep 1; done" &
-  not snap install --dangerous ./test-snapd-refresh_1_all.snap
+  snap install --dangerous ./test-snapd-refresh_1_all.snap 2>&1 | tr -s "\n" " " | MATCH ".*snap \"test-snapd-refresh\" has running apps \(sh\), pids:.*"
   touch stamp
   wait
 
   rm -f stamp
 
+  # the snap isn't prevented from being refreshed because it sets
+  # `refresh-mode: ignore-running` in its snap.yaml
   test-snapd-refresh.refresh-allowed-sh -c "while [ ! -e stamp ]; do sleep 1; done" &
-  snap install --dangerous ./test-snapd-refresh_1_all.snap
+  snap install --dangerous ./test-snapd-refresh_1_all.snap | MATCH "installed"
   touch stamp
   wait

--- a/tests/main/refresh-mode-ignore-running/task.yaml
+++ b/tests/main/refresh-mode-ignore-running/task.yaml
@@ -19,7 +19,8 @@ execute: |
 
   # refresh app awareness prevents the snap from being refreshed while it's running
   test-snapd-refresh.sh -c "while [ ! -e stamp ]; do sleep 1; done" &
-  snap install --dangerous ./test-snapd-refresh_1_all.snap 2>&1 | tr -s "\n" " " | MATCH ".*snap \"test-snapd-refresh\" has running apps \(sh\), pids:.*"
+  not snap install --dangerous ./test-snapd-refresh_1_all.snap 2> error.txt
+  tr -s "\n" " " < error.txt | MATCH ".*snap \"test-snapd-refresh\" has running apps \(sh\), pids:.*"
   touch stamp
   wait
 


### PR DESCRIPTION
Adds some comments to the new refresh-app-awareness test for `refresh-mode: ignore-running` and makes some of its checks a bit more strict.