### PR TITLE
many: preparations for revision authority cross checks including device scope

### DIFF
--- a/asserts/snapasserts/snapasserts.go
+++ b/asserts/snapasserts/snapasserts.go
@@ -96,20 +96,24 @@ func CrossCheck(instanceName, snapSHA3_384 string, snapSize uint64, si *snap.Sid
 // using its digest to find the relevant snap assertions with the
 // information in the given database. It will fail with an
 // asserts.NotFoundError if it cannot find them.
-func DeriveSideInfo(snapPath string, db Finder) (*snap.SideInfo, error) {
+// model is used to cross check that the found snap-revision is applicable
+// on the device.
+func DeriveSideInfo(snapPath string, model *asserts.Model, db Finder) (*snap.SideInfo, error) {
 	snapSHA3_384, snapSize, err := asserts.SnapFileSHA3_384(snapPath)
 	if err != nil {
 		return nil, err
 	}
 
-	return DeriveSideInfoFromDigestAndSize(snapPath, snapSHA3_384, snapSize, db)
+	return DeriveSideInfoFromDigestAndSize(snapPath, snapSHA3_384, snapSize, model, db)
 }
 
 // DeriveSideInfoFromDigestAndSize tries to construct a SideInfo
 // using digest and size as provided for the snap to find the relevant
 // snap assertions with the information in the given database. It will
 // fail with an asserts.NotFoundError if it cannot find them.
-func DeriveSideInfoFromDigestAndSize(snapPath string, snapSHA3_384 string, snapSize uint64, db Finder) (*snap.SideInfo, error) {
+// model is used to cross check that the found snap-revision is applicable
+// on the device.
+func DeriveSideInfoFromDigestAndSize(snapPath string, snapSHA3_384 string, snapSize uint64, model *asserts.Model, db Finder) (*snap.SideInfo, error) {
 	// get relevant assertions and reconstruct metadata
 	a, err := db.Find(asserts.SnapRevisionType, map[string]string{
 		"snap-sha3-384": snapSHA3_384,

--- a/asserts/snapasserts/snapasserts.go
+++ b/asserts/snapasserts/snapasserts.go
@@ -53,8 +53,14 @@ func findSnapDeclaration(snapID, name string, db Finder) (*asserts.SnapDeclarati
 	return snapDecl, nil
 }
 
-// CrossCheck tries to cross check the instance name, hash digest and size of a snap plus its metadata in a SideInfo with the relevant snap assertions in a database that should have been populated with them.
-func CrossCheck(instanceName, snapSHA3_384 string, snapSize uint64, si *snap.SideInfo, db Finder) error {
+// CrossCheck tries to cross check the instance name, hash digest and
+// size of a snap plus its metadata in a SideInfo with the relevant
+// snap assertions in a database that should have been populated with
+// them.
+// The optional model assertion must be passed to have full cross
+// checks in the case of delegated authority snap-revisions before
+// installing a snap.
+func CrossCheck(instanceName, snapSHA3_384 string, snapSize uint64, si *snap.SideInfo, model *asserts.Model, db Finder) error {
 	// get relevant assertions and do cross checks
 	a, err := db.Find(asserts.SnapRevisionType, map[string]string{
 		"snap-sha3-384": snapSHA3_384,

--- a/asserts/snapasserts/snapasserts_test.go
+++ b/asserts/snapasserts/snapasserts_test.go
@@ -248,7 +248,7 @@ func (s *snapassertsSuite) TestDeriveSideInfoHappy(c *C) {
 	err = ioutil.WriteFile(snapPath, fakeSnap(42), 0644)
 	c.Assert(err, IsNil)
 
-	si, err := snapasserts.DeriveSideInfo(snapPath, s.localDB)
+	si, err := snapasserts.DeriveSideInfo(snapPath, nil, s.localDB)
 	c.Assert(err, IsNil)
 	c.Check(si, DeepEquals, &snap.SideInfo{
 		RealName: "foo",
@@ -264,7 +264,7 @@ func (s *snapassertsSuite) TestDeriveSideInfoNoSignatures(c *C) {
 	err := ioutil.WriteFile(snapPath, fakeSnap(42), 0644)
 	c.Assert(err, IsNil)
 
-	_, err = snapasserts.DeriveSideInfo(snapPath, s.localDB)
+	_, err = snapasserts.DeriveSideInfo(snapPath, nil, s.localDB)
 	// cannot find signatures with metadata for snap
 	c.Assert(asserts.IsNotFound(err), Equals, true)
 }
@@ -290,7 +290,7 @@ func (s *snapassertsSuite) TestDeriveSideInfoSizeMismatch(c *C) {
 	err = ioutil.WriteFile(snapPath, fakeSnap(42), 0644)
 	c.Assert(err, IsNil)
 
-	_, err = snapasserts.DeriveSideInfo(snapPath, s.localDB)
+	_, err = snapasserts.DeriveSideInfo(snapPath, nil, s.localDB)
 	c.Check(err, ErrorMatches, fmt.Sprintf(`snap %q does not have expected size according to signatures \(broken or tampered\): %d != %d`, snapPath, size, size+5))
 }
 
@@ -329,6 +329,6 @@ func (s *snapassertsSuite) TestDeriveSideInfoRevokedSnapDecl(c *C) {
 	err = ioutil.WriteFile(snapPath, fakeSnap(42), 0644)
 	c.Assert(err, IsNil)
 
-	_, err = snapasserts.DeriveSideInfo(snapPath, s.localDB)
+	_, err = snapasserts.DeriveSideInfo(snapPath, nil, s.localDB)
 	c.Check(err, ErrorMatches, fmt.Sprintf(`cannot install snap %q with a revoked snap declaration`, snapPath))
 }

--- a/asserts/snapasserts/snapasserts_test.go
+++ b/asserts/snapasserts/snapasserts_test.go
@@ -79,6 +79,7 @@ func (s *snapassertsSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 }
 
+// XXX will need more realistic snaps
 func fakeSnap(rev int) []byte {
 	fake := fmt.Sprintf("hsqs________________%d", rev)
 	return []byte(fake)
@@ -119,10 +120,10 @@ func (s *snapassertsSuite) TestCrossCheckHappy(c *C) {
 	}
 
 	// everything cross checks, with the regular snap name
-	err = snapasserts.CrossCheck("foo", digest, size, si, s.localDB)
+	err = snapasserts.CrossCheck("foo", digest, size, si, nil, s.localDB)
 	c.Check(err, IsNil)
 	// and a snap instance name
-	err = snapasserts.CrossCheck("foo_instance", digest, size, si, s.localDB)
+	err = snapasserts.CrossCheck("foo_instance", digest, size, si, nil, s.localDB)
 	c.Check(err, IsNil)
 }
 
@@ -148,39 +149,39 @@ func (s *snapassertsSuite) TestCrossCheckErrors(c *C) {
 	}
 
 	// different size
-	err = snapasserts.CrossCheck("foo", digest, size+1, si, s.localDB)
+	err = snapasserts.CrossCheck("foo", digest, size+1, si, nil, s.localDB)
 	c.Check(err, ErrorMatches, fmt.Sprintf(`snap "foo" file does not have expected size according to signatures \(download is broken or tampered\): %d != %d`, size+1, size))
-	err = snapasserts.CrossCheck("foo_instance", digest, size+1, si, s.localDB)
+	err = snapasserts.CrossCheck("foo_instance", digest, size+1, si, nil, s.localDB)
 	c.Check(err, ErrorMatches, fmt.Sprintf(`snap "foo_instance" file does not have expected size according to signatures \(download is broken or tampered\): %d != %d`, size+1, size))
 
 	// mismatched revision vs what we got from store original info
 	err = snapasserts.CrossCheck("foo", digest, size, &snap.SideInfo{
 		SnapID:   "snap-id-1",
 		Revision: snap.R(21),
-	}, s.localDB)
+	}, nil, s.localDB)
 	c.Check(err, ErrorMatches, `snap "foo" does not have expected ID or revision according to assertions \(metadata is broken or tampered\): 21 / snap-id-1 != 12 / snap-id-1`)
 	err = snapasserts.CrossCheck("foo_instance", digest, size, &snap.SideInfo{
 		SnapID:   "snap-id-1",
 		Revision: snap.R(21),
-	}, s.localDB)
+	}, nil, s.localDB)
 	c.Check(err, ErrorMatches, `snap "foo_instance" does not have expected ID or revision according to assertions \(metadata is broken or tampered\): 21 / snap-id-1 != 12 / snap-id-1`)
 
 	// mismatched snap id vs what we got from store original info
 	err = snapasserts.CrossCheck("foo", digest, size, &snap.SideInfo{
 		SnapID:   "snap-id-other",
 		Revision: snap.R(12),
-	}, s.localDB)
+	}, nil, s.localDB)
 	c.Check(err, ErrorMatches, `snap "foo" does not have expected ID or revision according to assertions \(metadata is broken or tampered\): 12 / snap-id-other != 12 / snap-id-1`)
 	err = snapasserts.CrossCheck("foo_instance", digest, size, &snap.SideInfo{
 		SnapID:   "snap-id-other",
 		Revision: snap.R(12),
-	}, s.localDB)
+	}, nil, s.localDB)
 	c.Check(err, ErrorMatches, `snap "foo_instance" does not have expected ID or revision according to assertions \(metadata is broken or tampered\): 12 / snap-id-other != 12 / snap-id-1`)
 
 	// changed name
-	err = snapasserts.CrossCheck("baz", digest, size, si, s.localDB)
+	err = snapasserts.CrossCheck("baz", digest, size, si, nil, s.localDB)
 	c.Check(err, ErrorMatches, `cannot install "baz", snap "baz" is undergoing a rename to "foo"`)
-	err = snapasserts.CrossCheck("baz_instance", digest, size, si, s.localDB)
+	err = snapasserts.CrossCheck("baz_instance", digest, size, si, nil, s.localDB)
 	c.Check(err, ErrorMatches, `cannot install "baz_instance", snap "baz" is undergoing a rename to "foo"`)
 
 }
@@ -220,9 +221,9 @@ func (s *snapassertsSuite) TestCrossCheckRevokedSnapDecl(c *C) {
 		Revision: snap.R(12),
 	}
 
-	err = snapasserts.CrossCheck("foo", digest, size, si, s.localDB)
+	err = snapasserts.CrossCheck("foo", digest, size, si, nil, s.localDB)
 	c.Check(err, ErrorMatches, `cannot install snap "foo" with a revoked snap declaration`)
-	err = snapasserts.CrossCheck("foo_instance", digest, size, si, s.localDB)
+	err = snapasserts.CrossCheck("foo_instance", digest, size, si, nil, s.localDB)
 	c.Check(err, ErrorMatches, `cannot install snap "foo_instance" with a revoked snap declaration`)
 }
 

--- a/cmd/snap/cmd_download.go
+++ b/cmd/snap/cmd_download.go
@@ -94,7 +94,7 @@ func fetchSnapAssertionsDirect(tsto *tooling.ToolingStore, snapPath string, snap
 	}
 	f := tsto.AssertionFetcher(db, save)
 
-	_, err = image.FetchAndCheckSnapAssertions(snapPath, snapInfo, f, db)
+	_, err = image.FetchAndCheckSnapAssertions(snapPath, snapInfo, nil, f, db)
 	return assertPath, err
 }
 

--- a/image/helpers.go
+++ b/image/helpers.go
@@ -33,8 +33,8 @@ import (
 	"github.com/snapcore/snapd/snap"
 )
 
-// FetchAndCheckSnapAssertions fetches and cross checks the snap assertions matching the given snap file using the provided asserts.Fetcher and assertion database.
-func FetchAndCheckSnapAssertions(snapPath string, info *snap.Info, f asserts.Fetcher, db asserts.RODatabase) (*asserts.SnapDeclaration, error) {
+// FetchAndCheckSnapAssertions fetches and cross checks the snap assertions matching the given snap file using the provided asserts.Fetcher and assertion database. The optional model assertion must be passed for full cross checks.
+func FetchAndCheckSnapAssertions(snapPath string, info *snap.Info, model *asserts.Model, f asserts.Fetcher, db asserts.RODatabase) (*asserts.SnapDeclaration, error) {
 	sha3_384, size, err := asserts.SnapFileSHA3_384(snapPath)
 	if err != nil {
 		return nil, err
@@ -46,7 +46,7 @@ func FetchAndCheckSnapAssertions(snapPath string, info *snap.Info, f asserts.Fet
 	}
 
 	// cross checks
-	if err := snapasserts.CrossCheck(info.InstanceName(), sha3_384, size, &info.SideInfo, db); err != nil {
+	if err := snapasserts.CrossCheck(info.InstanceName(), sha3_384, size, &info.SideInfo, model, db); err != nil {
 		return nil, err
 	}
 

--- a/image/image_linux.go
+++ b/image/image_linux.go
@@ -454,7 +454,7 @@ var setupSeed = func(tsto *tooling.ToolingStore, model *asserts.Model, opts *Opt
 
 			// fetch snap assertions
 			prev := len(f.Refs())
-			if _, err = FetchAndCheckSnapAssertions(dlsn.Path, dlsn.Info, f, db); err != nil {
+			if _, err = FetchAndCheckSnapAssertions(dlsn.Path, dlsn.Info, model, f, db); err != nil {
 				return err
 			}
 			aRefs := f.Refs()[prev:]

--- a/image/image_linux.go
+++ b/image/image_linux.go
@@ -379,7 +379,7 @@ var setupSeed = func(tsto *tooling.ToolingStore, model *asserts.Model, opts *Opt
 
 	var curSnaps []*tooling.CurrentSnap
 	for _, sn := range localSnaps {
-		si, aRefs, err := seedwriter.DeriveSideInfo(sn.Path, f, db)
+		si, aRefs, err := seedwriter.DeriveSideInfo(sn.Path, model, f, db)
 		if err != nil && !asserts.IsNotFound(err) {
 			return err
 		}

--- a/overlord/assertstate/assertmgr.go
+++ b/overlord/assertstate/assertmgr.go
@@ -134,7 +134,7 @@ func doValidateSnap(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	db := DB(st)
-	err = snapasserts.CrossCheck(snapsup.InstanceName(), sha3_384, snapSize, snapsup.SideInfo, db)
+	err = snapasserts.CrossCheck(snapsup.InstanceName(), sha3_384, snapSize, snapsup.SideInfo, modelAs, db)
 	if err != nil {
 		// TODO: trigger a global validity check
 		// that will generate the changes to deal with this

--- a/overlord/devicestate/systems.go
+++ b/overlord/devicestate/systems.go
@@ -318,7 +318,7 @@ func createSystemForModelFromValidatedSnaps(model *asserts.Model, label string, 
 		// we have in snap.Info, but getting it this way can be
 		// expensive as we need to compute the hash, try to find a
 		// better way
-		_, aRefs, err := seedwriter.DeriveSideInfo(sn.Path, f, db)
+		_, aRefs, err := seedwriter.DeriveSideInfo(sn.Path, model, f, db)
 		if err != nil {
 			if !asserts.IsNotFound(err) {
 				return recoverySystemDir, err

--- a/seed/seed16.go
+++ b/seed/seed16.go
@@ -165,7 +165,7 @@ func (s *seed16) addSnap(sn *internal.Snap16, essType snap.Type, pinnedTrack str
 			deriveRev := func(snapSHA3_384 string, snapSize uint64) (snap.Revision, error) {
 				if si == nil {
 					var err error
-					si, err = snapasserts.DeriveSideInfoFromDigestAndSize(path, snapSHA3_384, snapSize, s.db)
+					si, err = snapasserts.DeriveSideInfoFromDigestAndSize(path, snapSHA3_384, snapSize, s.model, s.db)
 					if err != nil {
 						return snap.Revision{}, err
 					}

--- a/seed/seedtest/seedtest.go
+++ b/seed/seedtest/seedtest.go
@@ -287,7 +287,7 @@ func (s *TestingSeed20) MakeSeedWithModel(c *C, label string, model *asserts.Mod
 	c.Assert(err, IsNil)
 
 	for _, sn := range localSnaps {
-		si, aRefs, err := seedwriter.DeriveSideInfo(sn.Path, rf, db)
+		si, aRefs, err := seedwriter.DeriveSideInfo(sn.Path, model, rf, db)
 		if !asserts.IsNotFound(err) {
 			c.Assert(err, IsNil)
 		}

--- a/seed/seedwriter/helpers.go
+++ b/seed/seedwriter/helpers.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2019 Canonical Ltd
+ * Copyright (C) 2014-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -160,10 +160,12 @@ func (fnd *finderFromFetcher) Find(assertionType *asserts.AssertionType, headers
 // DeriveSideInfo tries to construct a SideInfo for the given snap
 // using its digest to fetch the relevant snap assertions. It will
 // fail with an asserts.NotFoundError if it cannot find them.
-func DeriveSideInfo(snapPath string, rf RefAssertsFetcher, db asserts.RODatabase) (*snap.SideInfo, []*asserts.Ref, error) {
+// model is used to cross check that the found snap-revision is applicable
+// on the device.
+func DeriveSideInfo(snapPath string, model *asserts.Model, rf RefAssertsFetcher, db asserts.RODatabase) (*snap.SideInfo, []*asserts.Ref, error) {
 	fnd := &finderFromFetcher{f: rf, db: db}
 	prev := len(rf.Refs())
-	si, err := snapasserts.DeriveSideInfo(snapPath, fnd)
+	si, err := snapasserts.DeriveSideInfo(snapPath, model, fnd)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/seed/seedwriter/writer_test.go
+++ b/seed/seedwriter/writer_test.go
@@ -1105,7 +1105,7 @@ func (s *writerSuite) TestLocalSnapsCore18FullUse(c *C) {
 	c.Assert(localSnaps, HasLen, 5)
 
 	for _, sn := range localSnaps {
-		si, aRefs, err := seedwriter.DeriveSideInfo(sn.Path, tf, s.db)
+		si, aRefs, err := seedwriter.DeriveSideInfo(sn.Path, model, tf, s.db)
 		if !asserts.IsNotFound(err) {
 			c.Assert(err, IsNil)
 		}
@@ -1760,7 +1760,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaLocalExtraSnaps(c *C) {
 	c.Assert(localSnaps, HasLen, 1)
 
 	for _, sn := range localSnaps {
-		si, aRefs, err := seedwriter.DeriveSideInfo(sn.Path, tf, s.db)
+		si, aRefs, err := seedwriter.DeriveSideInfo(sn.Path, model, tf, s.db)
 		if !asserts.IsNotFound(err) {
 			c.Assert(err, IsNil)
 		}
@@ -2476,7 +2476,7 @@ func (s *writerSuite) TestCore20NonDangerousDisallowedOptionsSnaps(c *C) {
 			c.Assert(localSnaps, HasLen, 1)
 
 			for _, sn := range localSnaps {
-				si, aRefs, err := seedwriter.DeriveSideInfo(sn.Path, tf, s.db)
+				si, aRefs, err := seedwriter.DeriveSideInfo(sn.Path, model, tf, s.db)
 				if !asserts.IsNotFound(err) {
 					c.Assert(err, IsNil)
 				}
@@ -2588,7 +2588,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20LocalSnaps(c *C) {
 	c.Assert(localSnaps, HasLen, 1)
 
 	for _, sn := range localSnaps {
-		_, _, err := seedwriter.DeriveSideInfo(sn.Path, tf, s.db)
+		_, _, err := seedwriter.DeriveSideInfo(sn.Path, model, tf, s.db)
 		c.Assert(asserts.IsNotFound(err), Equals, true)
 		f, err := snapfile.Open(sn.Path)
 		c.Assert(err, IsNil)
@@ -2969,7 +2969,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20ExtraSnaps(c *C) {
 	c.Assert(localSnaps, HasLen, 1)
 
 	for _, sn := range localSnaps {
-		_, _, err := seedwriter.DeriveSideInfo(sn.Path, tf, s.db)
+		_, _, err := seedwriter.DeriveSideInfo(sn.Path, model, tf, s.db)
 		c.Assert(asserts.IsNotFound(err), Equals, true)
 		f, err := snapfile.Open(sn.Path)
 		c.Assert(err, IsNil)
@@ -3141,7 +3141,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20LocalAssertedSnaps(c *C) {
 	c.Assert(localSnaps, HasLen, 2)
 
 	for _, sn := range localSnaps {
-		si, aRefs, err := seedwriter.DeriveSideInfo(sn.Path, tf, s.db)
+		si, aRefs, err := seedwriter.DeriveSideInfo(sn.Path, model, tf, s.db)
 		c.Assert(err, IsNil)
 		f, err := snapfile.Open(sn.Path)
 		c.Assert(err, IsNil)
@@ -3265,7 +3265,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20SignedLocalAssertedSnaps(c *C)
 	c.Assert(localSnaps, HasLen, 1)
 
 	for _, sn := range localSnaps {
-		si, aRefs, err := seedwriter.DeriveSideInfo(sn.Path, tf, s.db)
+		si, aRefs, err := seedwriter.DeriveSideInfo(sn.Path, model, tf, s.db)
 		c.Assert(err, IsNil)
 		f, err := snapfile.Open(sn.Path)
 		c.Assert(err, IsNil)


### PR DESCRIPTION
RevisionAuthority.Check should check device scope contraints if provided device information (model, store)

snapasserts helpers should take a model