### PR TITLE
many: support non-default provenance snap-revisions in DeriveSideInfo*

### DIFF
--- a/daemon/api_sideload_n_try_test.go
+++ b/daemon/api_sideload_n_try_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2020 Canonical Ltd
+ * Copyright (C) 2014-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -22,7 +22,6 @@ package daemon_test
 import (
 	"bytes"
 	"context"
-	"crypto"
 	"crypto/rand"
 	"errors"
 	"fmt"
@@ -31,7 +30,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"strconv"
 	"time"
 
 	"gopkg.in/check.v1"
@@ -47,6 +45,7 @@ import (
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/sandbox"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/strutil"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -298,21 +297,28 @@ func (s *sideloadSuite) TestLocalInstallSnapDeriveSideInfo(c *check.C) {
 	// add the assertions first
 	st := d.Overlord().State()
 
+	fooSnap := snaptest.MakeTestSnapWithFiles(c, `name: foo
+version: 1`, nil)
+	digest, size, err := asserts.SnapFileSHA3_384(fooSnap)
+	c.Assert(err, check.IsNil)
+	fooSnapBytes, err := ioutil.ReadFile(fooSnap)
+	c.Assert(err, check.IsNil)
+
 	dev1Acct := assertstest.NewAccount(s.StoreSigning, "devel1", nil, "")
 
 	snapDecl, err := s.StoreSigning.Sign(asserts.SnapDeclarationType, map[string]interface{}{
 		"series":       "16",
-		"snap-id":      "x-id",
-		"snap-name":    "x",
+		"snap-id":      "foo-id",
+		"snap-name":    "foo",
 		"publisher-id": dev1Acct.AccountID(),
 		"timestamp":    time.Now().Format(time.RFC3339),
 	}, nil, "")
 	c.Assert(err, check.IsNil)
 
 	snapRev, err := s.StoreSigning.Sign(asserts.SnapRevisionType, map[string]interface{}{
-		"snap-sha3-384": "YK0GWATaZf09g_fvspYPqm_qtaiqf-KjaNj5uMEQCjQpuXWPjqQbeBINL5H_A0Lo",
-		"snap-size":     "5",
-		"snap-id":       "x-id",
+		"snap-sha3-384": digest,
+		"snap-size":     fmt.Sprintf("%d", size),
+		"snap-id":       "foo-id",
 		"snap-revision": "41",
 		"developer-id":  dev1Acct.AccountID(),
 		"timestamp":     time.Now().Format(time.RFC3339),
@@ -325,25 +331,24 @@ func (s *sideloadSuite) TestLocalInstallSnapDeriveSideInfo(c *check.C) {
 		assertstatetest.AddMany(st, s.StoreSigning.StoreAccountKey(""), dev1Acct, snapDecl, snapRev)
 	}()
 
-	body := "" +
-		"----hello--\r\n" +
-		"Content-Disposition: form-data; name=\"snap\"; filename=\"x.snap\"\r\n" +
-		"\r\n" +
-		"xyzzy\r\n" +
-		"----hello--\r\n"
-	req, err := http.NewRequest("POST", "/v2/snaps", bytes.NewBufferString(body))
+	bodyBuf := new(bytes.Buffer)
+	bodyBuf.WriteString("----hello--\r\n" +
+		"Content-Disposition: form-data; name=\"snap\"; filename=\"foo.snap\"\r\n\r\n")
+	bodyBuf.Write(fooSnapBytes)
+	bodyBuf.WriteString("\r\n----hello--\r\n")
+	req, err := http.NewRequest("POST", "/v2/snaps", bodyBuf)
 	c.Assert(err, check.IsNil)
 	req.Header.Set("Content-Type", "multipart/thing; boundary=--hello--")
 
 	defer daemon.MockSnapstateInstallPath(func(s *state.State, si *snap.SideInfo, path, name, channel string, flags snapstate.Flags) (*state.TaskSet, *snap.Info, error) {
 		c.Check(flags, check.Equals, snapstate.Flags{RemoveSnapPath: true, Transaction: client.TransactionPerSnap})
 		c.Check(si, check.DeepEquals, &snap.SideInfo{
-			RealName: "x",
-			SnapID:   "x-id",
+			RealName: "foo",
+			SnapID:   "foo-id",
 			Revision: snap.R(41),
 		})
 
-		return state.NewTaskSet(), &snap.Info{SuggestedName: "x"}, nil
+		return state.NewTaskSet(), &snap.Info{SuggestedName: "foo"}, nil
 	})()
 
 	rsp := s.asyncReq(c, req, nil)
@@ -352,16 +357,16 @@ func (s *sideloadSuite) TestLocalInstallSnapDeriveSideInfo(c *check.C) {
 	defer st.Unlock()
 	chg := st.Change(rsp.Change)
 	c.Assert(chg, check.NotNil)
-	c.Check(chg.Summary(), check.Equals, `Install "x" snap from file "x.snap"`)
+	c.Check(chg.Summary(), check.Equals, `Install "foo" snap from file "foo.snap"`)
 	var names []string
 	err = chg.Get("snap-names", &names)
 	c.Assert(err, check.IsNil)
-	c.Check(names, check.DeepEquals, []string{"x"})
+	c.Check(names, check.DeepEquals, []string{"foo"})
 	var apiData map[string]interface{}
 	err = chg.Get("api-data", &apiData)
 	c.Assert(err, check.IsNil)
 	c.Check(apiData, check.DeepEquals, map[string]interface{}{
-		"snap-name": "x",
+		"snap-name": "foo",
 	})
 }
 
@@ -841,75 +846,10 @@ func (s *sideloadSuite) TestSideloadManySnapsAsserted(c *check.C) {
 	s.markSeeded(d)
 	st := d.Overlord().State()
 	snaps := []string{"one", "two"}
-	s.mockAssertions(c, st, snaps)
+	snapData := s.mockAssertions(c, st, snaps)
 
-	body := "----hello--\r\n"
 	expectedFlags := snapstate.Flags{RemoveSnapPath: true, Transaction: client.TransactionPerSnap}
-	s.testSideloadManySnaps(c, st, body, snaps, expectedFlags)
-}
 
-func (s *sideloadSuite) TestSideloadManySnapsOneNotAsserted(c *check.C) {
-	d := s.daemonWithOverlordMockAndStore()
-	s.markSeeded(d)
-	st := d.Overlord().State()
-	snaps := []string{"one", "two"}
-	s.mockAssertions(c, st, []string{"one"})
-
-	body := "----hello--\r\n"
-
-	fileSnaps := make([]string, len(snaps))
-	for i, snap := range snaps {
-		fileSnaps[i] = "file-" + snap
-		body += "Content-Disposition: form-data; name=\"snap\"; filename=\"" + fileSnaps[i] + "\"\r\n" +
-			"\r\n" +
-			snap + "\r\n" +
-			"----hello--\r\n"
-	}
-
-	req, err := http.NewRequest("POST", "/v2/snaps", bytes.NewBufferString(body))
-	c.Assert(err, check.IsNil)
-	req.Header.Set("Content-Type", "multipart/thing; boundary=--hello--")
-	rsp := s.errorReq(c, req, nil)
-
-	c.Check(rsp.Status, check.Equals, 400)
-	c.Check(rsp.Message, check.Matches, "cannot find signatures with metadata for snap \"file-two\"")
-}
-
-func (s *sideloadSuite) mockAssertions(c *check.C, st *state.State, snaps []string) {
-	for _, snap := range snaps {
-		hash := crypto.SHA3_384.New()
-		data := []byte(snap)
-		hash.Write(data)
-		digest := hash.Sum(nil)
-
-		base64Digest, err := asserts.EncodeDigest(crypto.SHA3_384, digest)
-		c.Assert(err, check.IsNil)
-		dev1Acct := assertstest.NewAccount(s.StoreSigning, "devel1", nil, "")
-		snapDecl, err := s.StoreSigning.Sign(asserts.SnapDeclarationType, map[string]interface{}{
-			"series":       "16",
-			"snap-id":      snap + "-id",
-			"snap-name":    snap,
-			"publisher-id": dev1Acct.AccountID(),
-			"timestamp":    time.Now().Format(time.RFC3339),
-		}, nil, "")
-		c.Assert(err, check.IsNil)
-		snapRev, err := s.StoreSigning.Sign(asserts.SnapRevisionType, map[string]interface{}{
-			"snap-sha3-384": base64Digest,
-			"snap-size":     strconv.Itoa(len(data)),
-			"snap-id":       snap + "-id",
-			"snap-revision": "41",
-			"developer-id":  dev1Acct.AccountID(),
-			"timestamp":     time.Now().Format(time.RFC3339),
-		}, nil, "")
-		c.Assert(err, check.IsNil)
-
-		st.Lock()
-		assertstatetest.AddMany(st, s.StoreSigning.StoreAccountKey(""), dev1Acct, snapDecl, snapRev)
-		st.Unlock()
-	}
-}
-
-func (s *sideloadSuite) testSideloadManySnaps(c *check.C, st *state.State, body string, snaps []string, expectedFlags snapstate.Flags) {
 	restore := daemon.MockSnapstateInstallPathMany(func(_ context.Context, s *state.State, infos []*snap.SideInfo, paths []string, userID int, flags *snapstate.Flags) ([]*state.TaskSet, error) {
 		c.Check(*flags, check.DeepEquals, expectedFlags)
 
@@ -929,16 +869,16 @@ func (s *sideloadSuite) testSideloadManySnaps(c *check.C, st *state.State, body 
 	})
 	defer restore()
 
+	bodyBuf := bytes.NewBufferString("----hello--\r\n")
 	fileSnaps := make([]string, len(snaps))
 	for i, snap := range snaps {
 		fileSnaps[i] = "file-" + snap
-		body += "Content-Disposition: form-data; name=\"snap\"; filename=\"" + fileSnaps[i] + "\"\r\n" +
-			"\r\n" +
-			snap + "\r\n" +
-			"----hello--\r\n"
+		bodyBuf.WriteString("Content-Disposition: form-data; name=\"snap\"; filename=\"" + fileSnaps[i] + "\"\r\n\r\n")
+		bodyBuf.Write(snapData[i])
+		bodyBuf.WriteString("\r\n----hello--\r\n")
 	}
 
-	req, err := http.NewRequest("POST", "/v2/snaps", bytes.NewBufferString(body))
+	req, err := http.NewRequest("POST", "/v2/snaps", bodyBuf)
 	c.Assert(err, check.IsNil)
 	req.Header.Set("Content-Type", "multipart/thing; boundary=--hello--")
 	rsp := s.asyncReq(c, req, nil)
@@ -949,6 +889,75 @@ func (s *sideloadSuite) testSideloadManySnaps(c *check.C, st *state.State, body 
 	chg := st.Change(rsp.Change)
 	c.Assert(chg, check.NotNil)
 	c.Check(chg.Summary(), check.Equals, fmt.Sprintf(`Install snaps %s from files %s`, strutil.Quoted(snaps), strutil.Quoted(fileSnaps)))
+
+}
+
+func (s *sideloadSuite) TestSideloadManySnapsOneNotAsserted(c *check.C) {
+	d := s.daemonWithOverlordMockAndStore()
+	s.markSeeded(d)
+	st := d.Overlord().State()
+	snaps := []string{"one", "two"}
+	snapData := s.mockAssertions(c, st, []string{"one"})
+	// unasserted snap
+	twoSnap := snaptest.MakeTestSnapWithFiles(c, `name: two
+version: 1`, nil)
+	twoSnapData, err := ioutil.ReadFile(twoSnap)
+	c.Assert(err, check.IsNil)
+	snapData = append(snapData, twoSnapData)
+
+	bodyBuf := bytes.NewBufferString("----hello--\r\n")
+	fileSnaps := make([]string, len(snaps))
+	for i, snap := range snaps {
+		fileSnaps[i] = "file-" + snap
+		bodyBuf.WriteString("Content-Disposition: form-data; name=\"snap\"; filename=\"" + fileSnaps[i] + "\"\r\n\r\n")
+		bodyBuf.Write(snapData[i])
+		bodyBuf.WriteString("\r\n----hello--\r\n")
+	}
+
+	req, err := http.NewRequest("POST", "/v2/snaps", bodyBuf)
+	c.Assert(err, check.IsNil)
+	req.Header.Set("Content-Type", "multipart/thing; boundary=--hello--")
+	rsp := s.errorReq(c, req, nil)
+
+	c.Check(rsp.Status, check.Equals, 400)
+	c.Check(rsp.Message, check.Matches, "cannot find signatures with metadata for snap \"file-two\"")
+}
+
+func (s *sideloadSuite) mockAssertions(c *check.C, st *state.State, snaps []string) (snapData [][]byte) {
+	for _, snap := range snaps {
+		thisSnap := snaptest.MakeTestSnapWithFiles(c, fmt.Sprintf(`name: %s
+version: 1`, snap), nil)
+		digest, size, err := asserts.SnapFileSHA3_384(thisSnap)
+		c.Assert(err, check.IsNil)
+		thisSnapData, err := ioutil.ReadFile(thisSnap)
+		c.Assert(err, check.IsNil)
+		snapData = append(snapData, thisSnapData)
+
+		dev1Acct := assertstest.NewAccount(s.StoreSigning, "devel1", nil, "")
+		snapDecl, err := s.StoreSigning.Sign(asserts.SnapDeclarationType, map[string]interface{}{
+			"series":       "16",
+			"snap-id":      snap + "-id",
+			"snap-name":    snap,
+			"publisher-id": dev1Acct.AccountID(),
+			"timestamp":    time.Now().Format(time.RFC3339),
+		}, nil, "")
+		c.Assert(err, check.IsNil)
+		snapRev, err := s.StoreSigning.Sign(asserts.SnapRevisionType, map[string]interface{}{
+			"snap-sha3-384": digest,
+			"snap-size":     fmt.Sprintf("%d", size),
+			"snap-id":       snap + "-id",
+			"snap-revision": "41",
+			"developer-id":  dev1Acct.AccountID(),
+			"timestamp":     time.Now().Format(time.RFC3339),
+		}, nil, "")
+		c.Assert(err, check.IsNil)
+
+		st.Lock()
+		assertstatetest.AddMany(st, s.StoreSigning.StoreAccountKey(""), dev1Acct, snapDecl, snapRev)
+		st.Unlock()
+	}
+
+	return snapData
 }
 
 type trySuite struct {

--- a/overlord/devicestate/systems_test.go
+++ b/overlord/devicestate/systems_test.go
@@ -22,7 +22,6 @@ package devicestate_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -559,7 +558,9 @@ func (s *createSystemSuite) TestCreateSystemInfoAndAssertsChecks(c *C) {
 	infos["other-required"] = s.makeSnap(c, "other-required", snap.R(5))
 
 	// but change the file contents of 'pc' snap so that deriving side info fails
-	c.Assert(ioutil.WriteFile(infos["pc"].MountFile(), []byte("canary"), 0644), IsNil)
+	randomSnap := snaptest.MakeTestSnapWithFiles(c, `name: random
+version: 1`, nil)
+	c.Assert(osutil.CopyFile(randomSnap, infos["pc"].MountFile(), osutil.CopyFlagOverwrite), IsNil)
 	dir, err = devicestate.CreateSystemForModelFromValidatedSnaps(model, "1234", s.db,
 		infoGetter, snapWriteObserver)
 	c.Assert(err, ErrorMatches, `internal error: no assertions for asserted snap with ID: pcididididididididididididididid`)

--- a/seed/seedwriter/helpers.go
+++ b/seed/seedwriter/helpers.go
@@ -26,6 +26,7 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snapfile"
 )
 
 // A RefAssertsFetcher is a Fetcher that can at any point return
@@ -136,36 +137,31 @@ func (s seedSnapsByType) Less(i, j int) bool {
 	return s[i].Info.Type().SortsBefore(s[j].Info.Type())
 }
 
-// finderFromFetcher exposes an assertion Finder interface out of a Fetcher.
-type finderFromFetcher struct {
-	f  asserts.Fetcher
-	db asserts.RODatabase
-}
-
-func (fnd *finderFromFetcher) Find(assertionType *asserts.AssertionType, headers map[string]string) (asserts.Assertion, error) {
-	pk, err := asserts.PrimaryKeyFromHeaders(assertionType, headers)
-	if err != nil {
-		return nil, err
-	}
-	ref := &asserts.Ref{
-		Type:       assertionType,
-		PrimaryKey: pk,
-	}
-	if err := fnd.f.Fetch(ref); err != nil {
-		return nil, err
-	}
-	return fnd.db.Find(assertionType, headers)
-}
-
 // DeriveSideInfo tries to construct a SideInfo for the given snap
 // using its digest to fetch the relevant snap assertions. It will
 // fail with an asserts.NotFoundError if it cannot find them.
 // model is used to cross check that the found snap-revision is applicable
 // on the device.
 func DeriveSideInfo(snapPath string, model *asserts.Model, rf RefAssertsFetcher, db asserts.RODatabase) (*snap.SideInfo, []*asserts.Ref, error) {
-	fnd := &finderFromFetcher{f: rf, db: db}
+	digest, size, err := asserts.SnapFileSHA3_384(snapPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	// XXX assume that the input to the writer is trusted or the whole
+	// build is isolated
+	snapf, err := snapfile.Open(snapPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	info, err := snap.ReadInfoFromSnapFile(snapf, nil)
+	if err != nil {
+		return nil, nil, err
+	}
 	prev := len(rf.Refs())
-	si, err := snapasserts.DeriveSideInfo(snapPath, model, fnd)
+	if err := snapasserts.FetchSnapAssertions(rf, digest, info.Provenance()); err != nil {
+		return nil, nil, err
+	}
+	si, err := snapasserts.DeriveSideInfoFromDigestAndSize(snapPath, digest, size, model, db)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
snapasserts.DeriveSideInfo* cannot deal with snap-revisions with the
same hash but different provenance in the local system assertion
database, this should be an acceptable limitation for a while

the seedwriter code now assumes that the input can be trusted, this is
reasonable

systems.go uses already installed snaps, so it's fine but probably
would still be good to address the TODO in it for efficiency/clarity
as the code in seedwriter DeriveSideInfo is even more clunky now for
this use case, we should be able to find an applicable snap-revisions
by other means
