### PR TITLE
Allow access to Wayland sockets in subdirectories

### DIFF
--- a/interfaces/builtin/wayland.go
+++ b/interfaces/builtin/wayland.go
@@ -103,7 +103,7 @@ owner /run/user/[0-9]*/###PLUG_SECURITY_TAGS###/{mesa,mutter,sdl,wayland-cursor,
 
 const waylandConnectedPlugAppArmor = `
 # Allow access to the Wayland compositor server socket
-owner /run/user/[0-9]*/wayland-[0-9]* rw,
+owner /run/user/[0-9]*/{,*/}wayland-[0-9]* rw,
 
 # Needed when using QT_QPA_PLATFORM=wayland-egl (MESA dri config)
 /etc/drirc r,


### PR DESCRIPTION
This is the case for a confined server.


