### PR TITLE
tests: remove leaking `pc-kernel.snap` in `repack_kernel_snap`

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -458,7 +458,7 @@ repack_kernel_snap() {
     unsquashfs -no-progress -d "$UNPACK_DIR" pc-kernel.snap
     snap pack --filename="$TARGET" "$UNPACK_DIR"
 
-    rm -rf "$UNPACK_DIR"
+    rm -rf pc-kernel.snap "$UNPACK_DIR"
 }
 
 repack_snapd_snap_with_deb_content_and_run_mode_firstboot_tweaks() {


### PR DESCRIPTION
The
```
google-nested:ubuntu-18.04-64:tests/nested/manual/devmode-snaps-can-run-other-snaps
```
test is currently failing with:
```
...
2022-07-20T10:57:51.7437272Z + snap run snapcraft snap --output snapd-from-branch.snap
...
2022-07-20T10:57:51.8182845Z Pulling snapd-deb
2022-07-20T10:57:51.8182927Z + snapcraftctl pull
2022-07-20T10:57:51.8183224Z [Errno 13] Permission denied: '/root/project/tests/nested/core/hotplug/pc-kernel.snap'
2022-07-20T10:57:51.8183334Z Traceback (most recent call last):
2022-07-20T10:57:51.8183669Z   File "/snap/snapcraft/6512/lib/python3.6/site-packages/snapcraft/file_utils.py", line 105, in link_or_copy
2022-07-20T10:57:51.8183821Z     link(source, destination, follow_symlinks=follow_symlinks)
2022-07-20T10:57:51.8184139Z   File "/snap/snapcraft/6512/lib/python3.6/site-packages/snapcraft/file_utils.py", line 139, in link
2022-07-20T10:57:51.8184373Z     os.link(source_path, destination, follow_symlinks=False)
2022-07-20T10:57:51.8184907Z OSError: [Errno 18] Invalid cross-device link: '/root/project/tests/nested/core/hotplug/pc-kernel.snap' -> '/root/parts/snapd-deb/src/tests/nested/core/hotplug/pc-kernel.snap'
2022-07-20T10:57:51.8184916Z
...
```

we are now repacking the kernel snap on uc18 as well so this is
most likely a side effect of this.

The reason for the failure is that there is a leaked `pc-kernel.snap`
during `repack_kernel_snap` that just needs to get deleted.
