### PR TITLE
tests: fix nested save-data test on 22.04

### DIFF
--- a/tests/nested/core/save-data/task.yaml
+++ b/tests/nested/core/save-data/task.yaml
@@ -7,12 +7,15 @@ details: |
 
 systems: [ubuntu-20.04-64, ubuntu-22.04-64]
 
+debug: |
+    tests.nested exec "lsblk"
+
 execute: |
     echo "Wait for the system to be seeded first"
     tests.nested exec "sudo snap wait system seed.loaded"
 
     echo "Ensuring the presence of ubuntu-save"
-    tests.nested exec "lsblk -oLABEL" | MATCH '^ubuntu-save$'
+    tests.nested exec "blkid -L ubuntu-save"
 
     echo "Ensuring the path /var/lib/snapd/save exists"
     tests.nested exec "ls -l /var/lib/snapd/save"

--- a/tests/nested/core/save-data/task.yaml
+++ b/tests/nested/core/save-data/task.yaml
@@ -28,8 +28,7 @@ execute: |
     tests.nested exec "ls -l /var/lib/snapd/save/snap/test-snapd-sh"
 
     # instance environment variables are correctly set up
-    tests.nested exec "snap run test-snapd-sh.sh -c 'env' test > snap_foo-env.txt"
-    tests.nested exec "grep 'SNAP_SAVE_DATA=/var/lib/snapd/save/snap/test-snapd-sh' < snap_foo-env.txt"
+    tests.nested exec "snap run test-snapd-sh.sh -c 'env' test" | MATCH 'SNAP_SAVE_DATA=/var/lib/snapd/save/snap/test-snapd-sh'
 
     echo "Ensuring we can write a file to /var/lib/snapd/save/snap/test-snapd-sh"
     tests.nested exec "sudo snap run test-snapd-sh.sh -c \"echo 'hello world' > /var/lib/snapd/save/snap/test-snapd-sh/hello.txt\""

--- a/tests/nested/core/save-data/task.yaml
+++ b/tests/nested/core/save-data/task.yaml
@@ -12,7 +12,7 @@ execute: |
     tests.nested exec "sudo snap wait system seed.loaded"
 
     echo "Ensuring the presence of ubuntu-save"
-    tests.nested exec "lsblk -f -m -l | awk '{ print \$3 }' | grep ubuntu-save"
+    tests.nested exec "lsblk -oLABEL" | MATCH '^ubuntu-save$'
 
     echo "Ensuring the path /var/lib/snapd/save exists"
     tests.nested exec "ls -l /var/lib/snapd/save"


### PR DESCRIPTION
The output of `lsblk` apparently changed between 20.04 and 22.04.
But fortuantely because we are only interested in the LABEL in
this test the way it's run can be simplified a bit.

This also includes a drive-by simplification for another use of `grep` in the test.