### PR TITLE
tests: add `debug:` section to `tests/nested/manual/connections`

### DIFF
--- a/tests/nested/manual/connections/task.yaml
+++ b/tests/nested/manual/connections/task.yaml
@@ -51,5 +51,10 @@ restore: |
   . "$TESTSLIB"/store.sh
   teardown_fake_store "$NESTED_FAKESTORE_BLOB_DIR"
 
+debug: |
+  tests.nested exec "snap connections" || true
+  tests.nested exec "snap connections --all" || true
+  tests.nested exec "snap changes" || true
+
 execute: |
   tests.nested exec "snap connections" | MATCH 'serial-port  *connections:serial-1  *pc:serial-1'


### PR DESCRIPTION
This test failed in spread with:
```
2022-07-20T15:05:25.9201971Z ##[error]2022-07-20 15:05:25 Error executing google-nested:ubuntu-20.04-64:tests/nested/manual/connections (jul201353-281932) :
...
2022-07-20T15:41:06.8471005Z + tests.nested exec 'snap connections'
2022-07-20T15:41:06.8471500Z + MATCH 'serial-port  *connections:serial-1  *pc:serial-1'
2022-07-20T15:41:06.8472066Z Warning: Permanently added '[localhost]:8022' (ECDSA) to the list of known hosts.
2022-07-20T15:41:06.8472463Z grep error: pattern not found, got:
2022-07-20T15:41:06.8472863Z -----
```

This is obscure, no output from the nested snap connections but
also no error. This commit adds a bit of debug info around this.
