### PR TITLE
tests: fix `core20-new-snapd-does-not-break-old-initrd` test

### DIFF
--- a/tests/nested/manual/core20-new-snapd-does-not-break-old-initrd/task.yaml
+++ b/tests/nested/manual/core20-new-snapd-does-not-break-old-initrd/task.yaml
@@ -83,8 +83,13 @@ prepare: |
 execute: |
   # on the old variant, copy and install the new snapd to it
   if [ "$START_SNAPD_VERSION" = "old" ]; then
-    tests.nested copy snapd-from-branch.snap  
-    tests.nested exec "sudo snap install --dangerous snapd-from-branch.snap"
+    tests.nested copy snapd-from-branch.snap
+    # This may trigger a reboot if the "managed boot config assets" change
+    # (e.g. grub.cfg). Hence this waits unti lthe change is completed even
+    # across reboots (retry will ensure that even if ssh cannot connect
+    # during the reboot it keeps trying).
+    REMOTE_CHG_ID=$(tests.nested exec "sudo snap install --dangerous snapd-from-branch.snap --no-wait")
+    retry --wait 5 -n 24 sh -c "tests.nested exec \"snap changes\" | MATCH ^${REMOTE_CHG_ID}.*Done"
   fi
 
   # try a refresh to a new kernel revision which will trigger a reseal and then


### PR DESCRIPTION
The nested `core20-new-snapd-does-not-break-old-initrd` installs
an old snapd and then refreshes to the new snapd and assume this
only causes a snapd restart. This assumption is incorrect, an
update like this can trigger a reboot if managed assets like
`grub.cfg` or the static commandline change. In this case a
full system reboot is performed.

This commit changes the code to deal with that by simply waiting
for the `snap install new-snapd.snap` to complete via `snap watch`
even if it take a reboot.

