### PR TITLE
tests: more debug to the nested `connections` test

### DIFF
--- a/tests/nested/manual/connections/task.yaml
+++ b/tests/nested/manual/connections/task.yaml
@@ -52,11 +52,16 @@ restore: |
   teardown_fake_store "$NESTED_FAKESTORE_BLOB_DIR"
 
 debug: |
-  tests.nested exec "snap connections" || true
   tests.nested exec "snap connections --all" || true
   tests.nested exec "snap changes" || true
+  tests.nested exec "snap change 2" || true
+  tests.nested exec "snap model" || true
+  tests.nested exec "snap list" || true
   tests.nested exec "sudo python3 -m json.tool /var/lib/snapd/state.json" || true
-  tests.nested exec "sudo snap debug state --connections /var/lib/snapd/state.json" || true
 
 execute: |
+  # precondition check that the "connections" snap is installed
+  # XXX: the "connections" snap should really be called "test-snapd-connections"
+  tests.nested exec "snap list connections"
+  # check that there is an auto-connection
   tests.nested exec "snap connections" | MATCH 'serial-port  *connections:serial-1  *pc:serial-1'

--- a/tests/nested/manual/connections/task.yaml
+++ b/tests/nested/manual/connections/task.yaml
@@ -55,6 +55,8 @@ debug: |
   tests.nested exec "snap connections" || true
   tests.nested exec "snap connections --all" || true
   tests.nested exec "snap changes" || true
+  tests.nested exec "sudo python3 -m json.tool /var/lib/snapd/state.json" || true
+  tests.nested exec "sudo snap debug state --connections /var/lib/snapd/state.json" || true
 
 execute: |
   tests.nested exec "snap connections" | MATCH 'serial-port  *connections:serial-1  *pc:serial-1'


### PR DESCRIPTION
The test `ubuntu-20.04-64:tests/nested/manual/connections ` fails
sometimes with:
```
2022-07-21T16:57:16.6430568Z + MATCH 'serial-port  *connections:serial-1  *pc:serial-1'
2022-07-21T16:57:16.6431181Z Warning: Permanently added '[localhost]:8022' (ECDSA) to the list of known hosts.
2022-07-21T16:57:16.6431507Z grep error: pattern not found, got:
2022-07-21T16:57:16.6431839Z -----
2022-07-21T16:57:16.6432016Z .
2022-07-21T16:57:17.8543099Z 2022-07-21 16:57:17 Debug output for google-nested:ubuntu-20.04-64:tests/nested/manual/connections (jul211612-334552) :
2022-07-21T16:57:17.8543768Z -----
2022-07-21T16:57:17.8544533Z + tests.nested exec 'snap connections'
2022-07-21T16:57:17.8545357Z Warning: Permanently added '[localhost]:8022' (ECDSA) to the list of known hosts.
2022-07-21T16:57:17.8546447Z + tests.nested exec 'snap connections --all'
2022-07-21T16:57:17.8546969Z Warning: Permanently added '[localhost]:8022' (ECDSA) to the list of known hosts.
2022-07-21T16:57:17.8547400Z + tests.nested exec 'snap changes'
2022-07-21T16:57:17.8548394Z Warning: Permanently added '[localhost]:8022' (ECDSA) to the list of known hosts.
2022-07-21T16:57:17.8548870Z ID   Status  Spawn               Ready               Summary
2022-07-21T16:57:17.8549432Z 1    Done    today at 16:56 UTC  today at 16:57 UTC  Initialize system state
2022-07-21T16:57:17.8576148Z 2    Done    today at 16:57 UTC  today at 16:57 UTC  Initialize device
```
The strange part is that the snap connections command apparently
produces no output at all but also no error. To get more data this
commit outputs the state.json when this fails to see if there are
really no connections availalbe or if there is some issue with the
daemon code.
