### PR TITLE
features,overlord: move quota groups out of experimental stage

### DIFF
--- a/daemon/api_quotas_test.go
+++ b/daemon/api_quotas_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/daemon"
 	"github.com/snapcore/snapd/gadget/quantity"
-	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/servicestate"
 	"github.com/snapcore/snapd/overlord/servicestate/servicestatetest"
 	"github.com/snapcore/snapd/overlord/snapstate"
@@ -56,9 +55,6 @@ func (s *apiQuotaSuite) SetUpTest(c *check.C) {
 	st := s.d.Overlord().State()
 	st.Lock()
 	defer st.Unlock()
-	tr := config.NewTransaction(st)
-	tr.Set("core", "experimental.quota-groups", true)
-	tr.Commit()
 
 	r := systemd.MockSystemdVersion(248, nil)
 	s.AddCleanup(r)

--- a/features/features.go
+++ b/features/features.go
@@ -64,9 +64,6 @@ const (
 	// GateAutoRefreshHook enables refresh control from snaps via gate-auto-refresh hook.
 	GateAutoRefreshHook
 
-	// QuotaGroups enable creating resource quota groups for snaps via the rest API and cli.
-	QuotaGroups
-
 	// JournalQuota enables journal quotas for quota groups.
 	JournalQuota
 
@@ -108,7 +105,6 @@ var featureNames = map[SnapdFeature]string{
 
 	GateAutoRefreshHook: "gate-auto-refresh-hook",
 
-	QuotaGroups:  "quota-groups",
 	JournalQuota: "journal-quota",
 }
 

--- a/features/features_test.go
+++ b/features/features_test.go
@@ -55,7 +55,6 @@ func (*featureSuite) TestName(c *C) {
 	c.Check(features.CheckDiskSpaceRefresh.String(), Equals, "check-disk-space-refresh")
 	c.Check(features.CheckDiskSpaceRemove.String(), Equals, "check-disk-space-remove")
 	c.Check(features.GateAutoRefreshHook.String(), Equals, "gate-auto-refresh-hook")
-	c.Check(features.QuotaGroups.String(), Equals, "quota-groups")
 	c.Check(features.JournalQuota.String(), Equals, "journal-quota")
 	c.Check(func() { _ = features.SnapdFeature(1000).String() }, PanicMatches, "unknown feature flag code 1000")
 }

--- a/overlord/configstate/configcore/vitality_test.go
+++ b/overlord/configstate/configcore/vitality_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/snapcore/snapd/asserts/assertstest"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget/quantity"
-	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/configstate/configcore"
 	"github.com/snapcore/snapd/overlord/servicestate"
 	"github.com/snapcore/snapd/overlord/servicestate/servicestatetest"
@@ -194,9 +193,6 @@ func (s *vitalitySuite) TestConfigureVitalityWithQuotaGroup(c *C) {
 		return nil, nil
 	})
 	s.AddCleanup(systemctlRestorer)
-	tr := config.NewTransaction(s.state)
-	tr.Set("core", "experimental.quota-groups", true)
-	tr.Commit()
 
 	// make a new quota group with this snap in it
 	err := servicestatetest.MockQuotaInState(s.state, "foogroup", "", []string{"test-snap"}, nil,

--- a/overlord/ifacestate/handlers_test.go
+++ b/overlord/ifacestate/handlers_test.go
@@ -25,7 +25,6 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/dirs"
-	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/ifacestate"
 	"github.com/snapcore/snapd/overlord/servicestate/servicestatetest"
 	"github.com/snapcore/snapd/overlord/snapstate"
@@ -143,10 +142,6 @@ func (s *handlersSuite) TestBuildConfinementOptions(c *C) {
 func (s *handlersSuite) TestBuildConfinementOptionsWithLogNamespace(c *C) {
 	s.st.Lock()
 	defer s.st.Unlock()
-
-	tr := config.NewTransaction(s.st)
-	tr.Set("core", "experimental.quota-groups", true)
-	tr.Commit()
 
 	snapInfo := mockInstalledSnap(c, s.st, snapAyaml)
 

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -787,10 +787,6 @@ apps:
 `
 	s.installLocalTestSnap(c, snapYamlContent+"version: 1.0")
 
-	tr := config.NewTransaction(st)
-	c.Assert(tr.Set("core", "experimental.quota-groups", "true"), IsNil)
-	tr.Commit()
-
 	// put the snap in a quota group
 	err := servicestatetest.MockQuotaInState(st, "quota-grp", "", []string{"foo"}, nil,
 		quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build())
@@ -838,10 +834,6 @@ apps:
   daemon: simple
 `
 	si := s.installLocalTestSnap(c, snapYamlContent+"version: 1.0")
-
-	tr := config.NewTransaction(st)
-	c.Assert(tr.Set("core", "experimental.quota-groups", "true"), IsNil)
-	tr.Commit()
 
 	// add the snap to a quota group
 	ts, err := servicestate.CreateQuota(st, "grp", servicestate.CreateQuotaOptions{

--- a/overlord/servicestate/quota_control.go
+++ b/overlord/servicestate/quota_control.go
@@ -70,17 +70,6 @@ func quotaGroupsAvailable(st *state.State) error {
 	if systemdVersionError != nil {
 		return fmt.Errorf("cannot use quotas with incompatible systemd: %v", systemdVersionError)
 	}
-
-	// TODO: remove this check
-	tr := config.NewTransaction(st)
-	enableQuotaGroups, err := features.Flag(tr, features.QuotaGroups)
-	if err != nil && !config.IsNoOption(err) {
-		return err
-	}
-	if !enableQuotaGroups {
-		return fmt.Errorf("experimental feature disabled - test it by setting 'experimental.quota-groups' to true")
-	}
-
 	return nil
 }
 

--- a/overlord/servicestate/quota_handlers_test.go
+++ b/overlord/servicestate/quota_handlers_test.go
@@ -32,7 +32,6 @@ import (
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget/quantity"
-	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/servicestate"
 	"github.com/snapcore/snapd/overlord/servicestate/servicestatetest"
 	"github.com/snapcore/snapd/overlord/snapstate"
@@ -60,9 +59,6 @@ func (s *quotaHandlersSuite) SetUpTest(c *C) {
 	// we enable quota-groups by default
 	s.state.Lock()
 	defer s.state.Unlock()
-	tr := config.NewTransaction(s.state)
-	tr.Set("core", "experimental.quota-groups", true)
-	tr.Commit()
 
 	// mock that we have a new enough version of systemd by default
 	systemdRestore := systemd.MockSystemdVersion(248, nil)

--- a/tests/core/mem-cgroup-disabled/task.yaml
+++ b/tests/core/mem-cgroup-disabled/task.yaml
@@ -53,9 +53,6 @@ execute: |
       # install a snap with a service
       "$TESTSTOOLS"/snaps-state install-local test-snapd-simple-service
 
-      # enable quota groups
-      snap set system experimental.quota-groups=true
-
       # put it in a quota group
       snap set-quota grp --memory=100MB test-snapd-simple-service
 

--- a/tests/core/persistent-journal-namespace/task.yaml
+++ b/tests/core/persistent-journal-namespace/task.yaml
@@ -8,8 +8,6 @@ systems:
 
 prepare: |
   "$TESTSTOOLS"/snaps-state install-local test-snapd-journal-quota
-  snap set system experimental.quota-groups=true
-  tests.cleanup defer snap unset system experimental.quota-groups
 
 restore: |
   # Stop test service and cleanup

--- a/tests/main/postrm-purge/task.yaml
+++ b/tests/main/postrm-purge/task.yaml
@@ -9,7 +9,6 @@ prepare: |
     # and snapd won't be around to respond, much less remove any state since
     # the state should be removed by the test
     snap set system experimental.user-daemons=true
-    snap set system experimental.quota-groups=true
 
     echo "When some snaps are installed"
     # Install a number of snaps that contain various features that have

--- a/tests/main/quota-groups-systemd-accounting/task.yaml
+++ b/tests/main/quota-groups-systemd-accounting/task.yaml
@@ -24,8 +24,6 @@ systems:
 
 prepare: |
   snap install hello-world go-example-webserver remarshal jq
-  snap set system experimental.quota-groups=true
-  tests.cleanup defer snap unset system experimental.quota-groups
 
 execute: |
   # the bug mainly happens when we create a quota group with nothing in it,

--- a/tests/main/snap-logs-journal/task.yaml
+++ b/tests/main/snap-logs-journal/task.yaml
@@ -18,9 +18,7 @@ systems:
 prepare: |
   "$TESTSTOOLS"/snaps-state install-local test-snapd-journal-quota
   tests.cleanup defer snap remove --purge test-snapd-journal-quota
-  snap set system experimental.quota-groups=true
   snap set system experimental.journal-quota=true
-  tests.cleanup defer snap unset system experimental.quota-groups
   tests.cleanup defer snap unset system experimental.journal-quota
 
 restore: |

--- a/tests/main/snap-logs-journal/task.yaml
+++ b/tests/main/snap-logs-journal/task.yaml
@@ -19,7 +19,9 @@ prepare: |
   "$TESTSTOOLS"/snaps-state install-local test-snapd-journal-quota
   tests.cleanup defer snap remove --purge test-snapd-journal-quota
   snap set system experimental.quota-groups=true
+  snap set system experimental.journal-quota=true
   tests.cleanup defer snap unset system experimental.quota-groups
+  tests.cleanup defer snap unset system experimental.journal-quota
 
 restore: |
   echo "Stopping the service"

--- a/tests/main/snap-mgmt/task.yaml
+++ b/tests/main/snap-mgmt/task.yaml
@@ -13,7 +13,6 @@ prepare: |
     # and snapd won't be around to respond, much less remove any state since
     # the state should be removed by the test
     snap set system experimental.user-daemons=true
-    snap set system experimental.quota-groups=true
 
     # Install a number of snaps that contain various features that have
     # representation in the file system.

--- a/tests/main/snap-quota-cpu/task.yaml
+++ b/tests/main/snap-quota-cpu/task.yaml
@@ -16,8 +16,6 @@ systems:
 prepare: |
   snap install test-snapd-stressd --edge --devmode
   tests.cleanup defer snap remove --purge test-snapd-stressd
-  snap set system experimental.quota-groups=true
-  tests.cleanup defer snap unset system experimental.quota-groups
 
 restore: |
   echo "Stopping the service"

--- a/tests/main/snap-quota-install/task.yaml
+++ b/tests/main/snap-quota-install/task.yaml
@@ -5,8 +5,6 @@ details: |
 
 prepare: |
   snap pack "$TESTSLIB"/snaps/basic
-  snap set system experimental.quota-groups=true
-  tests.cleanup defer snap unset system experimental.quota-groups
 
 execute: |
   if os.query is-trusty || os.query is-amazon-linux || os.query is-centos 7 || os.query is-xenial || os.query is-core16; then

--- a/tests/main/snap-quota-journal/task.yaml
+++ b/tests/main/snap-quota-journal/task.yaml
@@ -19,8 +19,6 @@ systems:
 
 prepare: |
   "$TESTSTOOLS"/snaps-state install-local test-snapd-journal-quota
-  snap set system experimental.quota-groups=true
-  tests.cleanup defer snap unset system experimental.quota-groups
 
 execute: |
   echo "Starting service and verifying that log messages are sent to default journal namespace"

--- a/tests/main/snap-quota-journal/task.yaml
+++ b/tests/main/snap-quota-journal/task.yaml
@@ -18,6 +18,8 @@ systems:
   - -ubuntu-core-18-*
 
 prepare: |
+  snap set system experimental.journal-quota=true
+  tests.cleanup defer snap unset system experimental.journal-quota
   "$TESTSTOOLS"/snaps-state install-local test-snapd-journal-quota
 
 execute: |

--- a/tests/main/snap-quota-memory/task.yaml
+++ b/tests/main/snap-quota-memory/task.yaml
@@ -21,8 +21,6 @@ systems:
 prepare: |
   snap install go-example-webserver jq remarshal hello-world
   snap install test-snapd-curl --edge --devmode
-  snap set system experimental.quota-groups=true
-  tests.cleanup defer snap unset system experimental.quota-groups
 
 execute: |
   echo "Create a group with a snap in it"

--- a/tests/main/snap-quota-services/task.yaml
+++ b/tests/main/snap-quota-services/task.yaml
@@ -14,6 +14,8 @@ systems:
   - -ubuntu-core-18-*
 
 prepare: |
+  snap set system experimental.journal-quota=true
+  tests.cleanup defer snap unset system experimental.journal-quota
   snap install test-snapd-stressd --edge --devmode
   tests.cleanup defer snap remove --purge test-snapd-stressd
 

--- a/tests/main/snap-quota-services/task.yaml
+++ b/tests/main/snap-quota-services/task.yaml
@@ -16,8 +16,6 @@ systems:
 prepare: |
   snap install test-snapd-stressd --edge --devmode
   tests.cleanup defer snap remove --purge test-snapd-stressd
-  snap set system experimental.quota-groups=true
-  tests.cleanup defer snap unset system experimental.quota-groups
 
 execute: |
   # Create the top level snap group with a memory limit. test-snapd-stressd

--- a/tests/main/snap-quota-thread/task.yaml
+++ b/tests/main/snap-quota-thread/task.yaml
@@ -18,8 +18,6 @@ systems:
 prepare: |
   snap install test-snapd-stressd --edge --devmode
   snap install test-snapd-curl --edge --devmode
-  snap set system experimental.quota-groups=true
-  tests.cleanup defer snap unset system experimental.quota-groups
 
 restore: |
   echo "Stop the service"

--- a/tests/main/snap-quota/task.yaml
+++ b/tests/main/snap-quota/task.yaml
@@ -9,8 +9,6 @@ systems: [ -ubuntu-core-*-arm-* ]
 
 prepare: |
   snap install hello-world go-example-webserver test-snapd-tools
-  snap set system experimental.quota-groups=true
-  tests.cleanup defer snap unset system experimental.quota-groups
 
 execute: |
   if os.query is-trusty || os.query is-amazon-linux || os.query is-centos 7 || os.query is-xenial || os.query is-core16; then


### PR DESCRIPTION
As discussed a few times, we are aiming to move quota groups out of experimental, but only for memory and cpu quotas. To support this we need https://github.com/snapcore/snapd/pull/11962 to land first. 11962 is contained in here as well

This PR is in draft untill then, and untill we are ready to pull the trigger :-)
