### PR TITLE
interfaces,metautil: make error handling in getPaths() more  targeted

### DIFF
--- a/interfaces/builtin/posix_mq.go
+++ b/interfaces/builtin/posix_mq.go
@@ -28,6 +28,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/seccomp"
+	"github.com/snapcore/snapd/metautil"
 	apparmor_sandbox "github.com/snapcore/snapd/sandbox/apparmor"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/strutil"
@@ -179,12 +180,14 @@ func (iface *posixMQInterface) getPaths(attrs interfaces.Attrer, name string) ([
 	switch {
 	case errors.Is(err, snap.AttributeNotFoundError{}):
 		return nil, fmt.Errorf(`posix-mq slot requires the "path" attribute`)
-	case err != nil:
+	case errors.Is(err, metautil.AttributeNotCompatibleError{}):
 		// If the attribute exists but reading it as a string didn't work, try reading it as an array
 		if err = attrs.Attr("path", &pathList); err != nil {
 			// If that didn't work, the attribute is an invalid type
 			return nil, err
 		}
+	case err != nil:
+		return nil, err
 	default:
 		// If the path is a single string, turn it into an array
 		pathList = append(pathList, pathStr)

--- a/metautil/type_conversions.go
+++ b/metautil/type_conversions.go
@@ -69,6 +69,17 @@ func convertValue(value reflect.Value, outputType reflect.Type) (reflect.Value, 
 	return nullValue, fmt.Errorf(`cannot convert value "%v" into a %v`, value, outputType)
 }
 
+type AttributeNotCompatibleError struct{ Err error }
+
+func (e AttributeNotCompatibleError) Error() string {
+	return e.Err.Error()
+}
+
+func (e AttributeNotCompatibleError) Is(target error) bool {
+	_, ok := target.(AttributeNotCompatibleError)
+	return ok
+}
+
 // SetValueFromAttribute attempts to convert the attribute value read from the
 // given snap/interface into the desired type.
 //
@@ -84,7 +95,7 @@ func SetValueFromAttribute(snapName string, ifaceName string, attrName string, a
 
 	converted, err := convertValue(reflect.ValueOf(attrVal), rt.Elem())
 	if err != nil {
-		return fmt.Errorf("snap %q has interface %q with invalid value type %T for %q attribute: %T", snapName, ifaceName, attrVal, attrName, val)
+		return AttributeNotCompatibleError{fmt.Errorf("snap %q has interface %q with invalid value type %T for %q attribute: %T", snapName, ifaceName, attrVal, attrName, val)}
 	}
 	rv := reflect.ValueOf(val)
 	rv.Elem().Set(converted)

--- a/metautil/type_conversions_test.go
+++ b/metautil/type_conversions_test.go
@@ -20,11 +20,13 @@
 package metautil_test
 
 import (
+	"errors"
 	"reflect"
 
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/metautil"
+	"github.com/snapcore/snapd/testutil"
 )
 
 type conversionssSuite struct{}
@@ -139,4 +141,9 @@ func (s *conversionssSuite) TestSetValueFromAttributeUnhappy(c *C) {
 		err := metautil.SetValueFromAttribute(td.snapName, td.ifaceName, td.attrName, td.inputValue, td.outputValue)
 		c.Check(err, ErrorMatches, td.expectedError, Commentf("input value %v", td.inputValue))
 	}
+}
+
+func (s *conversionssSuite) TestAttributeNotCompatibleIsTypeCheck(c *C) {
+	c.Assert(metautil.AttributeNotCompatibleError{}, testutil.ErrorIs, metautil.AttributeNotCompatibleError{})
+	c.Assert(metautil.AttributeNotCompatibleError{}, Not(testutil.ErrorIs), errors.New(""))
 }


### PR DESCRIPTION
The existng error handling getPath() when checking if the path
is a list or a string. Instead add a new error type when a value
cannot be set from an attribute and only check for that.

Followup from:
https://github.com/snapcore/snapd/pull/11928#discussion_r928677524

Set as draft as there are questions about naming/location and if it is needed at all :)

Build on top of https://github.com/snapcore/snapd/pull/11928