### PR TITLE
tests: Fix calls to systemctl is-system-running

### DIFF
--- a/tests/core/kernel-and-base-single-reboot-failover/task.yaml
+++ b/tests/core/kernel-and-base-single-reboot-failover/task.yaml
@@ -102,7 +102,7 @@ execute: |
 
         # make sure the system is in stable state, no pending reboots
         # XXX systemctl exits with non-0 when in degraded state
-        (systemctl is-system-running || true) | MATCH '(running|degraded)'
+        (systemctl --wait is-system-running || true) | MATCH '(running|degraded)'
 
         # we're expecting the old revisions to be back
         expecting_kernel="$(cat pc-kernel.rev)"

--- a/tests/core/kernel-and-base-single-reboot/task.yaml
+++ b/tests/core/kernel-and-base-single-reboot/task.yaml
@@ -115,7 +115,7 @@ execute: |
         # the system is in a stable state once we have already determined that
         # the change is complete
         # XXX systemctl exits with non-0 when in degraded state
-        (systemctl is-system-running || true) | MATCH '(running|degraded)'
+        (systemctl --wait is-system-running || true) | MATCH '(running|degraded)'
 
         # fake refreshes generate revision numbers that are n+1
         expecting_kernel="$(($(cat pc-kernel.rev) + 1))"

--- a/tests/main/lxd-mount-units/task.yaml
+++ b/tests/main/lxd-mount-units/task.yaml
@@ -41,7 +41,7 @@ execute: |
         lxd.lxc exec ubuntu -- sh -c "echo https_proxy=$https_proxy >> /etc/environment"
     fi
     # wait for the container to be fully up
-    retry -n 30 sh -c 'lxd.lxc exec ubuntu -- systemctl is-system-running | MATCH "(running|degraded)"'
+    (lxd.lxc exec ubuntu -- systemctl --wait is-system-running || true) | MATCH "(running|degraded)"
 
     lxd.lxc file push --quiet "$GOHOME"/snapd_*.deb "ubuntu/root/"
 

--- a/tests/main/lxd-snapfuse/task.yaml
+++ b/tests/main/lxd-snapfuse/task.yaml
@@ -43,7 +43,7 @@ execute: |
         exit 1
     fi
     # wait for the container to be fully up
-    retry -n 30 sh -c 'lxd.lxc exec my-ubuntu -- systemctl is-system-running | MATCH "(running|degraded)"'
+    (lxd.lxc exec my-ubuntu -- systemctl --wait is-system-running || true) | MATCH "(running|degraded)"
 
     echo "Install snapd"
     lxd.lxc exec my-ubuntu -- mkdir -p "$GOHOME"

--- a/tests/main/lxd-try/task.yaml
+++ b/tests/main/lxd-try/task.yaml
@@ -29,7 +29,7 @@ prepare: |
   fi
 
   # wait for the container to be fully up
-  retry -n 30 sh -c 'lxd.lxc exec ubuntu -- systemctl is-system-running | MATCH "(running|degraded)"'
+  (lxd.lxc exec ubuntu -- systemctl --wait is-system-running || true) | MATCH "(running|degraded)"
 
   lxd.lxc file push --quiet "$GOHOME"/snapd_*.deb "ubuntu/root/"
   DEB=$(basename "$GOHOME"/snapd_*.deb)


### PR DESCRIPTION
In a few places we call `systemctl is-system-running` and expect
either `running` or `degraded` to be returned.

But it can all return `starting`. If we want to wait for the system to
have finished starting, the documentation says we need to use
`--wait`.

