### PR TITLE
tests: skip interfaces-network-control on i386

### DIFF
--- a/tests/main/interfaces-network-control/task.yaml
+++ b/tests/main/interfaces-network-control/task.yaml
@@ -13,7 +13,9 @@ details: |
 
 # ubuntu-14.04: systemd-run not supported
 # ubuntu-18.04-32: network-control-consumer snap not available on i386
-systems: [-fedora-*, -opensuse-*, -ubuntu-14.04*, -ubuntu-18.04-32]
+# ubuntu-core-16-32: cannot install snap base "core20"
+# ubuntu-core-18-32: cannot install snap base "core20"
+systems: [-fedora-*, -opensuse-*, -ubuntu-14.04*, -ubuntu-18.04-32, -ubuntu-core-16-32, -ubuntu-core-18-32]
 
 environment:
     PORT: 8081


### PR DESCRIPTION
The test fails to install network-control-consumer with the error:

Ensure prerequisites for "network-control-consumer" are available
(cannot install snap base "core20": no snap revision available as
specified)
