### PR TITLE
many: revert "features: disable refresh-app-awarness by default again"

### DIFF
--- a/features/features.go
+++ b/features/features.go
@@ -111,6 +111,7 @@ var featureNames = map[SnapdFeature]string{
 // featuresEnabledWhenUnset contains a set of features that are enabled when not explicitly configured.
 var featuresEnabledWhenUnset = map[SnapdFeature]bool{
 	Layouts:                       true,
+	RefreshAppAwareness:           true,
 	RobustMountNamespaceUpdates:   true,
 	ClassicPreservesXdgRuntimeDir: true,
 	DbusActivation:                true,

--- a/features/features_test.go
+++ b/features/features_test.go
@@ -112,6 +112,7 @@ func (*featureSuite) TestIsEnabledWhenUnset(c *C) {
 	c.Check(features.Hotplug.IsEnabledWhenUnset(), Equals, false)
 	c.Check(features.SnapdSnap.IsEnabledWhenUnset(), Equals, false)
 	c.Check(features.PerUserMountNamespace.IsEnabledWhenUnset(), Equals, false)
+	c.Check(features.RefreshAppAwareness.IsEnabledWhenUnset(), Equals, true)
 	c.Check(features.ClassicPreservesXdgRuntimeDir.IsEnabledWhenUnset(), Equals, true)
 	c.Check(features.RobustMountNamespaceUpdates.IsEnabledWhenUnset(), Equals, true)
 	c.Check(features.UserDaemons.IsEnabledWhenUnset(), Equals, false)

--- a/overlord/hookstate/hooks_test.go
+++ b/overlord/hookstate/hooks_test.go
@@ -67,8 +67,7 @@ func (s *gateAutoRefreshHookSuite) SetUpTest(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	// disable refresh-app-awareness (it's disable by default right now
-	// but it will be enabled by default at some point);
+	// disable refresh-app-awareness (it's enabled by default);
 	// specific tests below enable it back.
 	tr := config.NewTransaction(s.state)
 	tr.Set("core", "experimental.refresh-app-awareness", false)

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -227,7 +227,6 @@ func (s *snapmgrBaseTest) SetUpTest(c *C) {
 	})
 
 	s.state.Lock()
-	defer s.state.Unlock()
 	snapstate.ReplaceStore(s.state, s.fakeStore)
 	s.user, err = auth.NewUser(s.state, "username", "email@test.com", "macaroon", []string{"discharge"})
 	c.Assert(err, IsNil)
@@ -268,14 +267,9 @@ SNAPD_APPARMOR_REEXEC=0
 		}
 	}
 
-	// enable refresh-app-awareness (it's disabled by default) but we
-	// want to enable soon(ish) so testing with it is preferred
-	tr := config.NewTransaction(s.state)
-	tr.Set("core", "experimental.refresh-app-awareness", true)
-	tr.Commit()
-
 	repo := interfaces.NewRepository()
 	ifacerepo.Replace(s.state, repo)
+	s.state.Unlock()
 
 	snapstate.AutoAliases = func(*state.State, *snap.Info) (map[string]string, error) {
 		return nil, nil

--- a/tests/main/cgroup-tracking/task.yaml
+++ b/tests/main/cgroup-tracking/task.yaml
@@ -14,10 +14,6 @@ environment:
     USER/test: test
 
 prepare: |
-    # This feature depends on the release-app-awareness feature
-    snap set core experimental.refresh-app-awareness=true
-    tests.cleanup defer snap unset core experimental.refresh-app-awareness
-
     snap pack test-snapd-tracking
     tests.cleanup defer rm -f test-snapd-tracking_1_all.snap
 

--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -50,8 +50,7 @@ restore: |
 
     "$TESTSTOOLS"/lxd-state undo-mount-changes
 
-    # unset refresh-app-awareness to ensure the defaults are used and not
-    # interfere with lxd
+    # unset refresh-app-awareness, this means it's enabled by default.
     snap unset system experimental.refresh-app-awareness
     # Stop the dbus.service of the user session of the root user. This test
     # runs in several configurations, not all of which have this capability.

--- a/tests/main/refresh-app-awareness/task.yaml
+++ b/tests/main/refresh-app-awareness/task.yaml
@@ -11,8 +11,6 @@ environment:
     CONFINEMENT/strict: strict
 
 prepare: |
-    # This feature depends on the release-app-awareness feature
-    snap set core experimental.refresh-app-awareness=true 
     sed -e "s/@CONFINEMENT@/$CONFINEMENT/g" <test-snapd-refresh.v1/meta/snap.yaml.in >test-snapd-refresh.v1/meta/snap.yaml
     sed -e "s/@CONFINEMENT@/$CONFINEMENT/g" <test-snapd-refresh.v2/meta/snap.yaml.in >test-snapd-refresh.v2/meta/snap.yaml
     snap pack test-snapd-refresh.v1
@@ -23,7 +21,6 @@ restore: |
     snap remove --purge test-snapd-refresh
     rm -f test-snapd-refresh-{1,2}_all.snap
     rm -f test-snapd-refresh.*/meta/snap.yaml
-    snap unset core experimental.refresh-app-awareness
 
     # Stop the dbus.service of the user session of the root user. This test
     # runs in several configurations, not all of which have this capability.

--- a/tests/main/refresh/task.yaml
+++ b/tests/main/refresh/task.yaml
@@ -104,12 +104,6 @@ execute: |
     #
     # echo "================================="
 
-    # Set refresh app awareness even on core systems, where we do not have
-    # inotify tools, so that we exercise that code path, even if it is not
-    # measured in the test.
-    snap set system experimental.refresh-app-awareness=true
-    tests.cleanup defer snap unset system experimental.refresh-app-awareness
-
     #shellcheck source=tests/lib/pkgdb.sh
     if os.query is-classic && not os.query is-trusty && not os.query is-amazon-linux && not os.query is-centos 9; then
       . "$TESTSLIB/pkgdb.sh"
@@ -129,7 +123,7 @@ execute: |
     fi
 
     echo "When the snap is refreshed"
-    snap refresh --ignore-running --channel=edge "$SNAP_NAME"
+    snap refresh --channel=edge "$SNAP_NAME"
 
     if [ -f /tmp/inhibit.events ]; then
       echo "During the refresh process, the inhibition lock was established and released"
@@ -139,7 +133,6 @@ execute: |
       tests.cleanup pop  # stop the inotifywait unit
       tests.cleanup pop  # remove inotify-tools
     fi
-    tests.cleanup pop  # unset refresh-app-awareness
 
     echo "Then the new version is listed"
     expected="$SNAP_NAME +$SNAP_VERSION_PATTERN"


### PR DESCRIPTION
This reverts commit db339ccd371811225555afb1690ef8a0fecf379f.

The desktop team is very nervous about disabling
refresh-app-awareness, especially this close to the release of
22.04.1. The worry is that unknown bugs during a refresh may
cause firefox to crash. Given the really good progress we had
with the startup performance and other improvements this would
be very unfortunate. Fwiw, there are no refresh bugs known right
now but the risk is there. The desktop team feels that the
shortcoming in the UX are a better tradeoff than to risk crashes.

We fixed the known issues around refresh-app-awareness:
https://bugs.launchpad.net/snapd/+bug/1975714
https://bugs.launchpad.net/snapd/+bug/1978834
https://github.com/snapcore/snapd/pull/11834
https://github.com/snapcore/snapd/pull/11976
https://github.com/snapcore/snapd/pull/11855

so hopefully this does not hit the other side of this too
hard. Sorry to everyone for yet another flip-flop on this,
it's really hard to find the right trade-off here.

This reverts https://github.com/snapcore/snapd/pull/11912
