### PR TITLE
tests: get the ubuntu-image binary built with test keys

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -976,7 +976,7 @@ suites:
                 # supported yet by the version of mkfs that shipped with Ubuntu 16.04
                 snap install ubuntu-image --channel="$UBUNTU_IMAGE_SNAP_CHANNEL" --classic
             else
-               build_ubuntu_image
+               get_ubuntu_image
             fi
 
             # Install the snapd built
@@ -1022,7 +1022,7 @@ suites:
                 # supported yet by the version of mkfs that shipped with Ubuntu 16.04
                 snap install ubuntu-image --channel="$UBUNTU_IMAGE_SNAP_CHANNEL" --classic
             else
-                build_ubuntu_image
+                get_ubuntu_image
             fi
 
             # Install the snapd built
@@ -1069,7 +1069,7 @@ suites:
                 # supported yet by the version of mkfs that shipped with Ubuntu 16.04
                 snap install ubuntu-image --channel="$UBUNTU_IMAGE_SNAP_CHANNEL" --classic
             else
-                build_ubuntu_image
+                get_ubuntu_image
             fi
 
             # Install the snapd built

--- a/tests/lib/image.sh
+++ b/tests/lib/image.sh
@@ -37,8 +37,8 @@ build_ubuntu_image() {
 
 
 get_ubuntu_image() {
-    wget https://storage.googleapis.com/snapd-spread-tests/ubuntu-image/ubuntu-image-withtestkeys.tar.gz
-    tar -xvzf ubuntu-image-withtestkeys-tmp.tar.gz
+    wget -c https://storage.googleapis.com/snapd-spread-tests/ubuntu-image/ubuntu-image-withtestkeys.tar.gz
+    tar xvzf ubuntu-image-withtestkeys.tar.gz
     test -x ./ubuntu-image
     cp -av ./ubuntu-image "$GOHOME/bin"
 }

--- a/tests/lib/image.sh
+++ b/tests/lib/image.sh
@@ -34,3 +34,11 @@ build_ubuntu_image() {
         cp -av /tmp/ubuntu-image/ubuntu-image "$GOHOME/bin"
     fi
 }
+
+
+get_ubuntu_image() {
+    wget https://storage.googleapis.com/snapd-spread-tests/ubuntu-image/ubuntu-image-withtestkeys.tar.gz
+    tar -xvzf ubuntu-image-withtestkeys-tmp.tar.gz
+    test -x ./ubuntu-image
+    cp -av ./ubuntu-image "$GOHOME/bin"
+}

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -930,7 +930,7 @@ setup_reflash_magic() {
     else
         # shellcheck source=tests/lib/image.sh
         . "$TESTSLIB/image.sh"
-        build_ubuntu_image
+        get_ubuntu_image
     fi
 
     # needs to be under /home because ubuntu-device-flash


### PR DESCRIPTION
The binary is built using snapd master branch and it is uploaded to gce daily

Last binary was built on https://github.com/snapcore/spread-cron/runs/7529001261?check_suite_focus=true

The script used to build the 
https://github.com/snapcore/spread-cron/blob/master/branches/build-ubuntu-image-withtestkeys/target/tasks/build-ubuntu-image/task.yaml