### PR TITLE
Add Flipper Zero U2F

### DIFF
--- a/interfaces/builtin/u2f_devices.go
+++ b/interfaces/builtin/u2f_devices.go
@@ -162,6 +162,11 @@ var u2fDevices = []u2fDevice{
 		VendorIDPattern:  "16d0",
 		ProductIDPattern: "0e90",
 	},
+	{
+		Name:             "Flipper Devices Inc. U2F Token",
+		VendorIDPattern:  "0483",
+		ProductIDPattern: "5741",
+	},
 }
 
 const u2fDevicesConnectedPlugAppArmor = `

--- a/interfaces/builtin/u2f_devices_test.go
+++ b/interfaces/builtin/u2f_devices_test.go
@@ -89,7 +89,7 @@ func (s *u2fDevicesInterfaceSuite) TestAppArmorSpec(c *C) {
 func (s *u2fDevicesInterfaceSuite) TestUDevSpec(c *C) {
 	spec := &udev.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 25)
+	c.Assert(spec.Snippets(), HasLen, 26)
 	c.Assert(spec.Snippets(), testutil.Contains, `# u2f-devices
 # Yubico YubiKey
 SUBSYSTEM=="hidraw", KERNEL=="hidraw*", ATTRS{idVendor}=="1050", ATTRS{idProduct}=="0113|0114|0115|0116|0120|0121|0200|0402|0403|0406|0407|0410", TAG+="snap_consumer_app"`)


### PR DESCRIPTION
Add the Flipper Zero to the list of U2F devices that is used to generate the UDEV rules.
