### PR TITLE
tests: add `snapd.debug=1 systemd.journald.forward_to_console=1`

### DIFF
--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -744,6 +744,10 @@ defaults:
     journal:
       persistent: true
 EOF
+                        # add snapd debug and log to serial console for extra
+                        # visibility what happens when a machine fails to boot
+                        echo 'snapd.debug=1 systemd.journald.forward_to_console=1 ' > pc-gadget/cmdline.extra
+                        # pack it
                         snap pack pc-gadget/ "$NESTED_ASSETS_DIR"
 
                         GADGET_SNAP=$(ls "$NESTED_ASSETS_DIR"/pc_*.snap)

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -746,7 +746,7 @@ defaults:
 EOF
                         # add snapd debug and log to serial console for extra
                         # visibility what happens when a machine fails to boot
-                        echo 'snapd.debug=1 systemd.journald.forward_to_console=1 ' > pc-gadget/cmdline.extra
+                        echo 'console=ttyS0 snapd.debug=1 systemd.journald.forward_to_console=1 ' > pc-gadget/cmdline.extra
                         # pack it
                         snap pack pc-gadget/ "$NESTED_ASSETS_DIR"
 


### PR DESCRIPTION
This commit adds more debug help to the kernel commandline when
the "pc" gadget is repacked. It adds
- `snapd.debug=1` which will put the snap logger into "debug" mode
- `systemd.journald.forward_to_console=1`: forward journal message
  to the (serial) console for better visbility of failing boots

This should make nested test failures that do not result in a
booting system easier to understand..

