### PR TITLE
snap-confine: disable -Werror=array-bounds in __overflow tests

### DIFF
--- a/cmd/libsnap-confine-private/string-utils-test.c
+++ b/cmd/libsnap-confine-private/string-utils-test.c
@@ -164,10 +164,11 @@ static void test_sc_string_append__overflow(void)
 {
 	if (g_test_subprocess()) {
 		char buf[4] = { 0 };
-
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
 		// Try to append a string that's one character too long.
 		sc_string_append(buf, sizeof buf, "1234");
-
+#pragma GCC diagnostic pop
 		g_test_message("expected sc_string_append not to return");
 		g_test_fail();
 		return;
@@ -304,8 +305,10 @@ static void test_sc_string_append_char__overflow(void)
 {
 	if (g_test_subprocess()) {
 		char buf[1] = { 0 };
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
 		sc_string_append_char(buf, sizeof buf, 'a');
-
+#pragma GCC diagnostic pop
 		g_test_message("expected sc_string_append_char not to return");
 		g_test_fail();
 		return;
@@ -392,8 +395,10 @@ static void test_sc_string_append_char_pair__overflow(void)
 {
 	if (g_test_subprocess()) {
 		char buf[2] = { 0 };
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
 		sc_string_append_char_pair(buf, sizeof buf, 'a', 'b');
-
+#pragma GCC diagnostic pop
 		g_test_message
 		    ("expected sc_string_append_char_pair not to return");
 		g_test_fail();


### PR DESCRIPTION
This should fix error on Ubuntu 22.10 for ppc64el (see https://launchpad.net/ubuntu/+source/snapd/2.57+22.10)
```
gcc -DHAVE_CONFIG_H -I.   -Wdate-time -D_FORTIFY_SOURCE=2 -Wall -Wextra -Wmissing-prototypes -Wstrict-prototypes -Wno-missing-field-initializers -Wno-unused-parameter -Werror  -I/usr/include/glib-2.0 -I/usr/lib/powerpc64le-linux-gnu/glib-2.0/include -D_ENABLE_FAULT_INJECTION -g -O3 -ffile-prefix-map=/<<PKGBUILDDIR>>=. -flto=auto -ffat-lto-objects -flto=auto -ffat-lto-objects -fstack-protector-strong -Wformat -Werror=format-security -MT libsnap-confine-private/libsnap_confine_private_unit_tests-string-utils-test.o -MD -MP -MF libsnap-confine-private/.deps/libsnap_confine_private_unit_tests-string-utils-test.Tpo -c -o libsnap-confine-private/libsnap_confine_private_unit_tests-string-utils-test.o `test -f 'libsnap-confine-private/string-utils-test.c' || echo './'`libsnap-confine-private/string-utils-test.c
In file included from libsnap-confine-private/string-utils-test.c:19:
In function ‘sc_string_append_char_pair’,
    inlined from ‘test_sc_string_append_char_pair__overflow’ at libsnap-confine-private/string-utils-test.c:395:3,
    inlined from ‘test_sc_string_append_char_pair__overflow’ at libsnap-confine-private/string-utils-test.c:391:13:
libsnap-confine-private/string-utils.c:169:26: error: array subscript [3, 9223372036854775807] is outside array bounds of ‘char[2]’ [-Werror=array-bounds]
  169 |         dst[dst_len + 0] = c1;
      |         ~~~~~~~~~~~~~~~~~^~~~
libsnap-confine-private/string-utils-test.c: In function ‘test_sc_string_append_char_pair__overflow’:
libsnap-confine-private/string-utils-test.c:394:22: note: at offset 3 into object ‘buf’ of size 2
  394 |                 char buf[2] = { 0 };
      |                      ^~~
In function ‘sc_string_append_char’,
    inlined from ‘test_sc_string_append_char__overflow’ at libsnap-confine-private/string-utils-test.c:307:3,
    inlined from ‘test_sc_string_append_char__overflow’ at libsnap-confine-private/string-utils-test.c:303:13:
libsnap-confine-private/string-utils.c:144:26: error: array subscript [2, 9223372036854775807] is outside array bounds of ‘char[1]’ [-Werror=array-bounds]
  144 |         dst[dst_len + 0] = c;
      |         ~~~~~~~~~~~~~~~~~^~~
libsnap-confine-private/string-utils-test.c: In function ‘test_sc_string_append_char__overflow’:
libsnap-confine-private/string-utils-test.c:306:22: note: at offset 2 into object ‘buf’ of size 1
  306 |                 char buf[1] = { 0 };
      |                      ^~~
```
