### PR TITLE
i/b/mount-control: allow custom filesystem types

### DIFF
--- a/interfaces/builtin/mount_control.go
+++ b/interfaces/builtin/mount_control.go
@@ -106,22 +106,9 @@ var optionsWithoutFsType = []string{
 	// - "remount"
 }
 
-// List of allowed filesystem types. This can be extended, keeping in mind that
-// the filesystems in the following list were considered either dangerous or
-// not relevant for this interface:
-//   bpf
-//   cgroup
-//   cgroup2
-//   debugfs
-//   devpts
-//   ecryptfs
-//   hugetlbfs
-//   overlayfs
-//   proc
-//   securityfs
-//   sysfs
-//   tracefs
-var allowedFSTypes = []string{
+// List of filesystem types to allow if the plug declaration does not
+// explicitly specify a filesystem type.
+var defaultFSTypes = []string{
 	"aufs",
 	"autofs",
 	"btrfs",
@@ -143,6 +130,23 @@ var allowedFSTypes = []string{
 	"vfat",
 	"zfs",
 	"xfs",
+}
+
+// The filesystems in the following list were considered either dangerous or
+// not relevant for this interface:
+var disallowedFSTypes = []string{
+	"bpf",
+	"cgroup",
+	"cgroup2",
+	"debugfs",
+	"devpts",
+	"ecryptfs",
+	"hugetlbfs",
+	"overlayfs",
+	"proc",
+	"securityfs",
+	"sysfs",
+	"tracefs",
 }
 
 // mountControlInterface allows creating transient and persistent mounts
@@ -300,7 +304,7 @@ func validateMountTypes(types []string) error {
 		if !typeRegexp.MatchString(t) {
 			return fmt.Errorf(`mount-control filesystem type invalid: %q`, t)
 		}
-		if !strutil.ListContains(allowedFSTypes, t) {
+		if strutil.ListContains(disallowedFSTypes, t) {
 			return fmt.Errorf(`mount-control forbidden filesystem type: %q`, t)
 		}
 		if t == "tmpfs" {
@@ -453,7 +457,7 @@ func (iface *mountControlInterface) AppArmorConnectedPlug(spec *apparmor.Specifi
 			if len(mountInfo.types) > 0 {
 				types = mountInfo.types
 			} else {
-				types = allowedFSTypes
+				types = defaultFSTypes
 			}
 			typeRule = "fstype=(" + strings.Join(types, ",") + ")"
 		}

--- a/interfaces/builtin/mount_control_test.go
+++ b/interfaces/builtin/mount_control_test.go
@@ -65,6 +65,7 @@ plugs:
     options: [ro]
   - what: /dev/sda[0-1]
     where: $SNAP_COMMON/{foo,other,**}
+    type: [mycustomfs]
     options: [sync]
 apps:
  app:
@@ -296,10 +297,8 @@ func (s *MountControlInterfaceSuite) TestAppArmorSpec(c *C) {
 		`) options=(ro) "/dev/sda{0,1}" -> "/var/snap/consumer/common/**{,/}",`
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, expectedMountLine3)
 
-	expectedMountLine4 := `mount fstype=(` +
-		`aufs,autofs,btrfs,ext2,ext3,ext4,hfs,iso9660,jfs,msdos,ntfs,ramfs,` +
-		`reiserfs,squashfs,tmpfs,ubifs,udf,ufs,vfat,zfs,xfs` +
-		`) options=(sync) "/dev/sda[0-1]" -> "/var/snap/consumer/common/{foo,other,**}{,/}",`
+	expectedMountLine4 := `mount fstype=(mycustomfs) options=(sync) ` +
+		`"/dev/sda[0-1]" -> "/var/snap/consumer/common/{foo,other,**}{,/}",`
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, expectedMountLine4)
 }
 


### PR DESCRIPTION
Instead of hardcoding a list of allowed FS types, create a list of the
disallowed ones based on the previous review feedback from security,
which got captured in a comment. Continue using the old list of allowed
FS types as the list of FS types to be used in case the plug declaration
does not explicitly mention a FS types.

The reason for this change is that some customers are using their own
custom filesystem; since this interface is super-privileged anyway, and
any plug must be approved by the Snap Store reviewers, it doesn't seem
that this change should pose a security risk.