### PR TITLE
systemd: add `WantedBy=default.target` to snap mount units

### DIFF
--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -1362,6 +1362,8 @@ var squashfsFsType = squashfs.FsType
 
 // XXX: After=zfs-mount.service is a workaround for LP: #1922293 (a problem
 // with order of mounting most likely related to zfs-linux and/or systemd).
+// XXX: Remove multi-user.target once we are sure it's unnecessary (see the
+// comments in LP: #1983528).
 const mountUnitTemplate = `[Unit]
 Description=Mount unit for {{.SnapName}}
 {{- with .Revision}}, revision {{.}}{{end}}
@@ -1377,7 +1379,7 @@ Options={{join .Options ","}}
 LazyUnmount=yes
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target multi-user.target
 {{- with .Origin}}
 X-SnapdOrigin={{.}}
 {{- end}}

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -1175,7 +1175,7 @@ Options=nodev,ro,x-gdu.hide,x-gvfs-hide
 LazyUnmount=yes
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target multi-user.target
 `[1:], mockSnapPath))
 
 	c.Assert(s.argses, DeepEquals, [][]string{
@@ -1209,7 +1209,7 @@ Options=nodev,ro,x-gdu.hide,x-gvfs-hide,bind
 LazyUnmount=yes
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target multi-user.target
 `[1:], snapDir))
 
 	c.Assert(s.argses, DeepEquals, [][]string{
@@ -1255,7 +1255,7 @@ Options=remount,ro
 LazyUnmount=yes
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target multi-user.target
 X-SnapdOrigin=bar
 `[1:], mockSnapPath))
 
@@ -1298,7 +1298,7 @@ Options=nodev,context=system_u:object_r:snappy_snap_t:s0,ro,x-gdu.hide,x-gvfs-hi
 LazyUnmount=yes
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target multi-user.target
 `[1:], mockSnapPath))
 }
 
@@ -1342,7 +1342,7 @@ Options=nodev,ro,x-gdu.hide,x-gvfs-hide,allow_other
 LazyUnmount=yes
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target multi-user.target
 `[1:], mockSnapPath))
 }
 
@@ -1382,7 +1382,7 @@ Options=nodev,ro,x-gdu.hide,x-gvfs-hide
 LazyUnmount=yes
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target multi-user.target
 `[1:], mockSnapPath))
 }
 
@@ -1646,7 +1646,7 @@ Options=%s
 LazyUnmount=yes
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target multi-user.target
 `
 
 func (s *SystemdTestSuite) TestPreseedModeAddMountUnit(c *C) {
@@ -1866,7 +1866,7 @@ Type=doesntmatter
 Options=do,not,matter,either
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target multi-user.target
 X-SnapdOrigin=%s
 `, snapName, where, origin)
 		return ioutil.WriteFile(path, []byte(contents), 0644)


### PR DESCRIPTION
When booting in OEM configuration mode, the systemd target is set to
`oem-config.target` instead of the usual `multi-user.target`; if our
mount units require solely the multi-user target, which is not reached
during OEM configuration mode, they won't be started.

So, let's add `default.target` to our mount units: this target is a
symbolic link to the system default target, which is usually
`multi-user.target` for a desktop session.

Most likely, there's no need to keep `multi-user.target` in the
`WantedBy` line, but since this is a hotfix, let's take a defensive
approach and keep it until we have the time to verify that removing it
does not cause any regression.

Fixes LP:#1983528
