### PR TITLE
tests: Work-around non-functional --wait on systemctl

### DIFF
--- a/tests/core/kernel-and-base-single-reboot-failover/task.yaml
+++ b/tests/core/kernel-and-base-single-reboot-failover/task.yaml
@@ -102,7 +102,8 @@ execute: |
 
         # make sure the system is in stable state, no pending reboots
         # XXX systemctl exits with non-0 when in degraded state
-        (systemctl --wait is-system-running || true) | MATCH '(running|degraded)'
+        # Note: on bionic, is-system-running does not support --wait
+        retry -n 30 sh -c '(systemctl is-system-running || true) | MATCH "(running|degraded)"'
 
         # we're expecting the old revisions to be back
         expecting_kernel="$(cat pc-kernel.rev)"

--- a/tests/core/kernel-and-base-single-reboot/task.yaml
+++ b/tests/core/kernel-and-base-single-reboot/task.yaml
@@ -115,7 +115,8 @@ execute: |
         # the system is in a stable state once we have already determined that
         # the change is complete
         # XXX systemctl exits with non-0 when in degraded state
-        (systemctl --wait is-system-running || true) | MATCH '(running|degraded)'
+        # Note: on bionic, is-system-running does not support --wait
+        retry -n 30 sh -c '(systemctl is-system-running || true) | MATCH "(running|degraded)"'
 
         # fake refreshes generate revision numbers that are n+1
         expecting_kernel="$(($(cat pc-kernel.rev) + 1))"


### PR DESCRIPTION
`systemctctl is-system-running` does not support `--wait` in
bionic. So we need to call it several times instead.
