### PR TITLE
tests: disable microk8s test on 16.04

### DIFF
--- a/tests/main/microk8s-smoke/task.yaml
+++ b/tests/main/microk8s-smoke/task.yaml
@@ -9,6 +9,7 @@ systems:
   - -fedora-36-*      # fails to start service daemon-containerd
   - -debian-10-*      # doesn't have libseccomp >= 2.4
   - -ubuntu-14.04-*   # doesn't have libseccomp >= 2.4
+  - -ubuntu-16.04-*   # fails to start container runtime network
   - -ubuntu-*-32      # no microk8s snap for 32 bit systems
   - -arch-linux-*     # XXX: no curl to the pod for unknown reasons
   - -ubuntu-*-arm*    # not available on arm


### PR DESCRIPTION
Recently the test started to fail:

microk8s.daemon-apiserver-kicker[27599]: error: error running snapctl: unknown service: "microk8s.daemon-apiserver"
snapd[25465]: daemon.go:217: DEBUG: pid=23473;uid=0;socket=/run/snapd-snap.socket; POST /v2/snapctl 6.431534ms 200
microk8s.daemon-kubelite[27652]: E0804 10:29:54.367901   27652 kubelet.go:2349] "Container runtime network not ready" networkReady="NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: cni plugin not initialized"

Let's temporarily disable it, while we investigate the failure.

The PR to revert this is https://github.com/snapcore/snapd/pull/12015