### PR TITLE
o/ifacestate: do not disconnect unmounted snaps

### DIFF
--- a/tests/regression/lp-1983528/task.yaml
+++ b/tests/regression/lp-1983528/task.yaml
@@ -1,0 +1,37 @@
+summary: Valid but unmounted snaps should stay connected
+
+details: |
+    If snapd starts up when the snap mount units have not been run yet, the
+    existing snap connections should not be considered stale and removed.
+
+prepare: |
+    #shellcheck source=tests/lib/snaps.sh
+    . "$TESTSLIB"/snaps.sh
+    install_generic_consumer home
+
+execute: |
+    SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
+
+    echo "Connect the interface"
+    snap connect generic-consumer:home
+
+    snap connections generic-consumer | MATCH home
+
+    echo "Stop snapd, unmount the test snap"
+    systemctl stop snapd.service
+    umount "$SNAP_MOUNT_DIR/generic-consumer/current"  # this follows symlinks
+
+    echo "Start snapd, verify that the connection does not get deleted"
+    systemctl start snapd.service
+    # This wait ensures that snapd has went through removeStaleConnections(),
+    # since the reloadConnections() function is called after it.
+    retry -n 20 --wait 0.5 journalctl -u snapd | MATCH "Snap \"generic-consumer\" is broken, ignored by reloadConnections"
+    journalctl -u snapd | NOMATCH "removed stale connections: .*generic-consumer.*"
+
+    echo "Restore the snap"
+    mount /var/lib/snapd/snaps/generic-consumer_x1.snap "$SNAP_MOUNT_DIR/generic-consumer/current"
+
+    echo "We need to restart snapd so that the connections gets reloaded"
+    systemctl restart snapd.service
+
+    retry -n 20 --wait 0.5 sh -c "snap connections generic-consumer | MATCH home"


### PR DESCRIPTION
Note: draft because we already merged a hotfix for the bug, and this branch shows another possible approach which needs to be discussed first (that's why there are no unit tests).

I think that this code is incomplete and that we should also check that either the mount unit exists, or that the snap binary file exists.

If a snap is currently unmounted, do not treat its connections as stale.

Fixes: [LP#1983528](https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1983528)
