### PR TITLE
image: enable sysfs overlay for UC preseeding

### DIFF
--- a/cmd/snap-preseed/export_test.go
+++ b/cmd/snap-preseed/export_test.go
@@ -31,7 +31,7 @@ func MockOsGetuid(f func() int) (restore func()) {
 	return r
 }
 
-func MockPreseedCore20(f func(dir, key, aaDir string) error) (restore func()) {
+func MockPreseedCore20(f func(dir, key, aaDir, sfso string) error) (restore func()) {
 	r := testutil.Backup(&preseedCore20)
 	preseedCore20 = f
 	return r

--- a/cmd/snap-preseed/main.go
+++ b/cmd/snap-preseed/main.go
@@ -50,6 +50,7 @@ type options struct {
 	Reset               bool   `long:"reset"`
 	PreseedSignKey      string `long:"preseed-sign-key"`
 	AppArmorFeaturesDir string `long:"apparmor-features-dir"`
+	SysfsOverlay        string `long:"preseed-sysfs-overlay"`
 }
 
 var (
@@ -120,7 +121,7 @@ func run(parser *flags.Parser, args []string) (err error) {
 	}
 
 	if probeCore20ImageDir(chrootDir) {
-		return preseedCore20(chrootDir, opts.PreseedSignKey, opts.AppArmorFeaturesDir)
+		return preseedCore20(chrootDir, opts.PreseedSignKey, opts.AppArmorFeaturesDir, opts.SysfsOverlay)
 	}
 	return preseedClassic(chrootDir)
 }

--- a/cmd/snap-preseed/preseed_uc20_test.go
+++ b/cmd/snap-preseed/preseed_uc20_test.go
@@ -45,17 +45,18 @@ func (s *startPreseedSuite) TestRunPreseedUC20Happy(c *C) {
 	c.Assert(ioutil.WriteFile(filepath.Join(tmpDir, "system-seed/systems/20220203/preseed.tgz"), nil, 0644), IsNil)
 
 	var called bool
-	restorePreseed := main.MockPreseedCore20(func(dir, key, aaDir string) error {
+	restorePreseed := main.MockPreseedCore20(func(dir, key, aaDir, sfso string) error {
 		c.Check(dir, Equals, tmpDir)
 		c.Check(key, Equals, "key")
 		c.Check(aaDir, Equals, "/custom/aa/features")
+		c.Check(sfso, Equals, "/sysfs-overlay")
 		called = true
 		return nil
 	})
 	defer restorePreseed()
 
 	parser := testParser(c)
-	c.Assert(main.Run(parser, []string{"--preseed-sign-key", "key", "--apparmor-features-dir", "/custom/aa/features", tmpDir}), IsNil)
+	c.Assert(main.Run(parser, []string{"--preseed-sign-key", "key", "--apparmor-features-dir", "/custom/aa/features", "--preseed-sysfs-overlay", "/sysfs-overlay", tmpDir}), IsNil)
 	c.Check(called, Equals, true)
 }
 
@@ -73,10 +74,11 @@ func (s *startPreseedSuite) TestRunPreseedUC20HappyNoArgs(c *C) {
 	c.Assert(ioutil.WriteFile(filepath.Join(tmpDir, "system-seed/systems/20220203/preseed.tgz"), nil, 0644), IsNil)
 
 	var called bool
-	restorePreseed := main.MockPreseedCore20(func(dir, key, aaDir string) error {
+	restorePreseed := main.MockPreseedCore20(func(dir, key, aaDir, sfso string) error {
 		c.Check(dir, Equals, tmpDir)
 		c.Check(key, Equals, "")
 		c.Check(aaDir, Equals, "")
+		c.Check(sfso, Equals, "")
 		called = true
 		return nil
 	})

--- a/cmd/snap/cmd_prepare_image.go
+++ b/cmd/snap/cmd_prepare_image.go
@@ -37,7 +37,9 @@ type cmdPrepareImage struct {
 	PreseedSignKey string `long:"preseed-sign-key"`
 	// optional path to AppArmor kernel features directory
 	AppArmorKernelFeaturesDir string `long:"apparmor-features-dir"`
-	Architecture              string `long:"arch"`
+	// optional sysfs overlay
+	SysfsOverlay string `long:"preseed-sysfs-overlay"`
+	Architecture string `long:"arch"`
 
 	Positional struct {
 		ModelAssertionFn string
@@ -72,6 +74,8 @@ For preparing classic images it supports a --classic mode`),
 			"preseed": i18n.G("Preseed (UC20+ only)"),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"preseed-sign-key": i18n.G("Name of the key to use to sign preseed assertion, otherwise use the default key"),
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"preseed-sysfs-overlay": i18n.G("Optional sysfs overlay to be used when running preseeding steps"),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"apparmor-features-dir": i18n.G("Optional path to apparmor kernel features directory (UC20+ only)"),
 			// TRANSLATORS: This should not start with a lowercase letter.
@@ -145,9 +149,15 @@ func (x *cmdPrepareImage) Execute(args []string) error {
 	if x.PreseedSignKey != "" && !x.Preseed {
 		return fmt.Errorf("--preseed-sign-key cannot be used without --preseed")
 	}
+
+	if x.SysfsOverlay != "" && !x.Preseed {
+		return fmt.Errorf("--preseed-sysfs-overlay cannot be used without --preseed")
+	}
+
 	opts.Preseed = x.Preseed
 	opts.PreseedSignKey = x.PreseedSignKey
 	opts.AppArmorKernelFeaturesDir = x.AppArmorKernelFeaturesDir
+	opts.SysfsOverlay = x.SysfsOverlay
 
 	return imagePrepare(opts)
 }

--- a/cmd/snap/cmd_prepare_image_test.go
+++ b/cmd/snap/cmd_prepare_image_test.go
@@ -188,7 +188,7 @@ func (s *SnapPrepareImageSuite) TestPrepareImagePreseed(c *C) {
 	r := snap.MockImagePrepare(prep)
 	defer r()
 
-	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"prepare-image", "--preseed", "--preseed-sign-key", "key", "--apparmor-features-dir", "aafeatures-dir", "model", "prepare-dir"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"prepare-image", "--preseed", "--preseed-sign-key", "key", "--apparmor-features-dir", "aafeatures-dir", "--preseed-sysfs-overlay", "sys-overlay", "model", "prepare-dir"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 
@@ -197,6 +197,7 @@ func (s *SnapPrepareImageSuite) TestPrepareImagePreseed(c *C) {
 		PrepareDir:                "prepare-dir",
 		Preseed:                   true,
 		PreseedSignKey:            "key",
+		SysfsOverlay:              "sys-overlay",
 		AppArmorKernelFeaturesDir: "aafeatures-dir",
 	})
 }

--- a/image/export_test.go
+++ b/image/export_test.go
@@ -53,7 +53,7 @@ func MockNewToolingStoreFromModel(f func(model *asserts.Model, fallbackArchitect
 	}
 }
 
-func MockPreseedCore20(f func(dir string, key, aaDir string) error) (restore func()) {
+func MockPreseedCore20(f func(dir string, key, aaDir, sfso string) error) (restore func()) {
 	r := testutil.Backup(&preseedCore20)
 	preseedCore20 = f
 	return r

--- a/image/image_linux.go
+++ b/image/image_linux.go
@@ -160,7 +160,7 @@ func Prepare(opts *Options) error {
 		if model.Base() != "core20" {
 			return fmt.Errorf("cannot preseed the image for a model other than core20")
 		}
-		return preseedCore20(opts.PrepareDir, opts.PreseedSignKey, opts.AppArmorKernelFeaturesDir)
+		return preseedCore20(opts.PrepareDir, opts.PreseedSignKey, opts.AppArmorKernelFeaturesDir, opts.SysfsOverlay)
 	}
 
 	return nil

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -3270,11 +3270,12 @@ func (s *imageSuite) TestPrepareWithUC20Preseed(c *C) {
 	defer restoreSetupSeed()
 
 	var preseedCalled bool
-	restorePreseedCore20 := image.MockPreseedCore20(func(dir, key, aaDir string) error {
+	restorePreseedCore20 := image.MockPreseedCore20(func(dir, key, aaDir, sfso string) error {
 		preseedCalled = true
 		c.Assert(dir, Equals, "/a/dir")
 		c.Assert(key, Equals, "foo")
 		c.Assert(aaDir, Equals, "/custom/aa/features")
+		c.Assert(sfso, Equals, "/sysfs-overlay")
 		return nil
 	})
 	defer restorePreseedCore20()
@@ -3288,6 +3289,7 @@ func (s *imageSuite) TestPrepareWithUC20Preseed(c *C) {
 		Preseed:        true,
 		PrepareDir:     "/a/dir",
 		PreseedSignKey: "foo",
+		SysfsOverlay:   "/sysfs-overlay",
 
 		AppArmorKernelFeaturesDir: "/custom/aa/features",
 	})

--- a/image/options.go
+++ b/image/options.go
@@ -34,6 +34,11 @@ type Options struct {
 	// (only for UC20)
 	AppArmorKernelFeaturesDir string
 
+	// sysfs overlay to be used for preseeding.
+	// Directories from /sys/class/* and /sys/devices/platform will be
+	// bind-mounted to the chroot when preseeding.
+	SysfsOverlay string
+
 	Channel string
 
 	// TODO: use OptionsSnap directly here?

--- a/image/preseed/preseed.go
+++ b/image/preseed/preseed.go
@@ -57,6 +57,8 @@ type preseedOpts struct {
 	PreseedSignKey   string
 	// optional path to AppArmor kernel features directory
 	AppArmorKernelFeaturesDir string
+	// optional sysfs overlay
+	SysfsOverlay string
 }
 
 type targetSnapdInfo struct {

--- a/image/preseed/preseed_linux.go
+++ b/image/preseed/preseed_linux.go
@@ -282,11 +282,19 @@ func prepareCore20Mountpoints(prepareImageDir, tmpPreseedChrootDir, snapdSnapBlo
 	if sysfsOverlay != "" {
 		// bind mount permited directories under sys/class from
 		for _, dir := range []string{
-			"sys/class/backlight", "sys/class/gpio", "sys/class/leds",
-			"sys/class/bluetooth", "sys/class/ptp", "sys/class/pwm",
-			"sys/class/rtc", "sys/class/video4linux", "sys/devices/platform"} {
+			"sys/class/backlight", "sys/class/bluetooth", "sys/class/gpio",
+			"sys/class/leds", "sys/class/ptp", "sys/class/pwm",
+			"sys/class/rtc", "sys/class/video4linux", "sys/devices/platform",
+			"sys/devices/pci0000:00"} {
 			info, err := os.Stat(underOverlay(dir))
 			if err == nil && info.IsDir() {
+				// ensure dir exists
+				if _, err := os.Stat(underPreseed(dir)); errors.Is(err, os.ErrNotExist) {
+					err := os.MkdirAll(underPreseed(dir), os.ModePerm)
+					if err != nil {
+						return nil, fmt.Errorf("Failed to cresated overlay dir (%s): %v", underPreseed(dir), err)
+					}
+				}
 				mounts = append(mounts, []string{"--bind", underOverlay(dir), underPreseed(dir)})
 			}
 		}

--- a/image/preseed/preseed_uc20_test.go
+++ b/image/preseed/preseed_uc20_test.go
@@ -209,7 +209,7 @@ func (s *preseedSuite) testRunPreseedUC20Happy(c *C, customAppArmorFeaturesDir s
 	c.Assert(os.MkdirAll(filepath.Join(tmpDir, "system-seed/systems/20220203"), 0755), IsNil)
 	c.Assert(ioutil.WriteFile(filepath.Join(tmpDir, "system-seed/systems/20220203/preseed.tgz"), []byte(`hello world`), 0644), IsNil)
 
-	c.Assert(preseed.Core20(tmpDir, "", customAppArmorFeaturesDir), IsNil)
+	c.Assert(preseed.Core20(tmpDir, "", customAppArmorFeaturesDir, ""), IsNil)
 
 	c.Check(mockChootCmd.Calls()[0], DeepEquals, []string{"chroot", preseedTmpDir, "/usr/lib/snapd/snapd"})
 

--- a/image/preseed/preseed_uc20_test.go
+++ b/image/preseed/preseed_uc20_test.go
@@ -78,7 +78,12 @@ func (s *toolingStore) Assertion(assertType *asserts.AssertionType, primaryKey [
 	return as, nil
 }
 
-func (s *preseedSuite) testRunPreseedUC20Happy(c *C, customAppArmorFeaturesDir string) {
+// list of test overlays
+var sysFsOverlaysGood = []string{"class/backlight", "class/bluetooth", "class/gpio", "class/leds", "class/ptp", "class/pwm", "class/rtc", "class/video4linux", "devices/platform", "devices/pci0000:00"}
+
+var sysFsOverlaysBad = []string{"class/backlight-xxx", "class/spi", "devices/pci"}
+
+func (s *preseedSuite) testRunPreseedUC20Happy(c *C, customAppArmorFeaturesDir, sysfsOverlay string) {
 
 	testKey, _ := assertstest.GenerateKey(752)
 
@@ -209,7 +214,7 @@ func (s *preseedSuite) testRunPreseedUC20Happy(c *C, customAppArmorFeaturesDir s
 	c.Assert(os.MkdirAll(filepath.Join(tmpDir, "system-seed/systems/20220203"), 0755), IsNil)
 	c.Assert(ioutil.WriteFile(filepath.Join(tmpDir, "system-seed/systems/20220203/preseed.tgz"), []byte(`hello world`), 0644), IsNil)
 
-	c.Assert(preseed.Core20(tmpDir, "", customAppArmorFeaturesDir, ""), IsNil)
+	c.Assert(preseed.Core20(tmpDir, "", customAppArmorFeaturesDir, sysfsOverlay), IsNil)
 
 	c.Check(mockChootCmd.Calls()[0], DeepEquals, []string{"chroot", preseedTmpDir, "/usr/lib/snapd/snapd"})
 
@@ -261,6 +266,18 @@ func (s *preseedSuite) testRunPreseedUC20Happy(c *C, customAppArmorFeaturesDir s
 		// from handle-writable-paths
 		{"umount", filepath.Join(preseedTmpDir, "somepath")},
 		{"umount", preseedTmpDir},
+	}
+
+	if sysfsOverlay != "" {
+		for i, dir := range sysFsOverlaysGood {
+			const sysFsMountFirstIndex = 10
+			expectedMountCalls = append(expectedMountCalls[:sysFsMountFirstIndex+i+1], expectedMountCalls[sysFsMountFirstIndex+i:]...)
+			expectedMountCalls[sysFsMountFirstIndex+i] = []string{"mount", "--bind", filepath.Join(sysfsOverlay, "sys", dir), filepath.Join(preseedTmpDir, "sys", dir)}
+			// order of umounts is reversed, prepend
+			const sysFsUmountFirstIndex = 11
+			expectedUmountCalls = append(expectedUmountCalls[:sysFsUmountFirstIndex+1], expectedUmountCalls[sysFsUmountFirstIndex:]...)
+			expectedUmountCalls[sysFsUmountFirstIndex] = []string{"umount", filepath.Join(preseedTmpDir, "sys", dir)}
+		}
 	}
 
 	if customAppArmorFeaturesDir != "" {
@@ -329,11 +346,52 @@ func (s *preseedSuite) testRunPreseedUC20Happy(c *C, customAppArmorFeaturesDir s
 }
 
 func (s *preseedSuite) TestRunPreseedUC20Happy(c *C) {
-	s.testRunPreseedUC20Happy(c, "")
+	s.testRunPreseedUC20Happy(c, "", "")
 }
 
 func (s *preseedSuite) TestRunPreseedUC20HappyCustomApparmorFeaturesDir(c *C) {
-	s.testRunPreseedUC20Happy(c, "/custom-aa-features")
+	s.testRunPreseedUC20Happy(c, "/custom-aa-features", "")
+}
+
+func (s *preseedSuite) TestRunPreseedUC20HappySysfsOverlay(c *C) {
+	// create example sysfs overlay structure
+	// backlight bluetooth gpio leds  ptp pwm rtc video4linux
+	// sys
+	//  ├── class
+	//  │   ├── backlight
+	//  │   │   └── intel_backlight  ->  ../../devices/pci0000:00/0000:00:02.0
+	//  │   ├── bluetooth
+	//  │   │   └── hci0             ->  ../../devices/platform/e4000000.s_ahb
+	//  │   ├── gpio
+	//  │   │   └── gpio1            -> ../../devices/platform/e4000000.s_ahb
+	//  │   ├── leds
+	//  │   │   └── input2::capslock -> ../../devices/platform/e8000000.s_ahb
+	//  │   ├── ptp
+	//  │   │   └── ptp0             -> ../../devices/pci0000:00/0000:00:1d.0
+	//  │   ├── pwm
+	//  │   │   └── pwmchip0         -> ../../devices/platform/e8000000.s_ahb
+	//  │   ├── rtc
+	//  │   │   └── rtc0             -> ../../devices/platform/rtc_cmos/rtc/rtc0
+	//  │   └── video4linux
+	//  │       └── video0           -> ../../devices/platform/e8000000.s_ahb
+	//  └── devices
+	//      ├── platform
+	//      │   └── e8000000.s_ahb
+	//      └── pci0000:00
+	//          └──  0000:00:02.0
+
+	tmpdir := c.MkDir()
+	for _, dir := range sysFsOverlaysGood {
+		err := os.MkdirAll(filepath.Join(tmpdir, "sys", dir), os.ModePerm)
+		c.Assert(err, IsNil)
+	}
+
+	for _, dir := range sysFsOverlaysBad {
+		err := os.MkdirAll(filepath.Join(tmpdir, "sys", dir), os.ModePerm)
+		c.Assert(err, IsNil)
+	}
+
+	s.testRunPreseedUC20Happy(c, "", tmpdir)
 }
 
 func (s *preseedSuite) TestRunPreseedUC20ExecFormatError(c *C) {


### PR DESCRIPTION
When creating preseeded image for Ubuntu Core, certain interface (gpio, pw,..) are resolving symbolic links under `/sys/class` to generate correct aa profile. Those symlinks usually do not exist on the build host. To enable building of preseeded images outside of the target device, overlay sysfs needs to used during preseeding.

For now we only allow overlaying `sysfs` directories which are used by existing interfaces. This can be loosened up in the future.

Overlay itself is enough to contain high-level symbolic links. e.g.
```
sys
  ├── class
  │   ├── backlight
  │   │   └── intel_backlight  ->  ../../devices/pci0000:00/0000:00:02.0
  │   ├── bluetooth
  │   │   └── hci0             ->  ../../devices/platform/e4000000.s_ahb
  └── devices
      ├── platform
      │   └── e8000000.s_ahb
      └── pci0000:00
          └──  0000:00:02.0
```

