### PR TITLE
image: clean snapd mount after preseeding

### DIFF
--- a/image/preseed/preseed_linux.go
+++ b/image/preseed/preseed_linux.go
@@ -390,6 +390,9 @@ func prepareCore20Chroot(prepareImageDir, aaFeaturesDir string) (preseed *presee
 		if err := os.RemoveAll(writableTmpDir); err != nil {
 			fmt.Fprintf(Stdout, "%v", err)
 		}
+		if err := os.RemoveAll(snapdMountPath); err != nil {
+			fmt.Fprintf(Stdout, "%v", err)
+		}
 	}
 
 	opts := &preseedOpts{

--- a/image/preseed/preseed_uc20_test.go
+++ b/image/preseed/preseed_uc20_test.go
@@ -285,6 +285,11 @@ func (s *preseedSuite) testRunPreseedUC20Happy(c *C, customAppArmorFeaturesDir s
 	c.Assert(err, IsNil)
 	defer r.Close()
 
+	// check directory targetSnapdRoot was deleted
+	_, err = os.Stat(targetSnapdRoot)
+	c.Assert(err, NotNil)
+	c.Check(os.IsNotExist(err), Equals, true)
+
 	seen := make(map[string]bool)
 	dec := asserts.NewDecoder(r)
 	for {


### PR DESCRIPTION
Clean left behind tmp dir for snapd mount.

This is directory where snapd snap is mounted when running preseeding. 