### PR TITLE
data: include snapd/mounts in preseeded blob

### DIFF
--- a/data/preseed.json
+++ b/data/preseed.json
@@ -14,6 +14,7 @@
         "var/lib/snapd/sequence",
         "var/lib/snapd/cookie",
         "var/lib/snapd/dbus-1",
+        "var/lib/snapd/mount",
         "var/snap",
         "var/cache/snapd/aux",
         "var/cache/apparmor"


### PR DESCRIPTION
When collecting preseeded data, include also snapd/mounts.
This directory contains layout info and is essential to have a correct layout functionality on presseded system.