### PR TITLE
o/snapstate: refactor managed refresh schedule logic

### DIFF
--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -487,7 +487,9 @@ func (m *autoRefresh) refreshScheduleWithDefaultsFallback() (sched []*timeutil.S
 	}
 
 	if err != nil {
-		return nil, "", false, fmt.Errorf("%s: %w", errPrefix, err)
+		// log instead of fail in order not to prevent auto-refreshes
+		logger.Noticef("%s: %v", errPrefix, err)
+		return defaultRefreshSchedule, defaultRefreshScheduleStr, false, nil
 	}
 
 	return sched, scheduleConf, legacy, nil

--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -423,7 +423,7 @@ func (m *autoRefresh) ensureLastRefreshAnchor() {
 	}
 }
 
-func readRefreshScheduleConf(st *state.State) (confStr string, legacy bool, err error) {
+func getRefreshScheduleConf(st *state.State) (confStr string, legacy bool, err error) {
 	tr := config.NewTransaction(st)
 
 	err = tr.Get("core", "refresh.timer", &confStr)
@@ -445,7 +445,7 @@ func readRefreshScheduleConf(st *state.State) (confStr string, legacy bool, err 
 // refreshScheduleWithDefaultsFallback returns the current refresh schedule
 // and refresh string.
 func (m *autoRefresh) refreshScheduleWithDefaultsFallback() (sched []*timeutil.Schedule, scheduleConf string, legacy bool, err error) {
-	scheduleConf, legacy, err = readRefreshScheduleConf(m.state)
+	scheduleConf, legacy, err = getRefreshScheduleConf(m.state)
 	if err != nil {
 		return nil, "", false, err
 	}

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -106,7 +106,7 @@ var (
 	CanRemove              = canRemove
 	CanDisable             = canDisable
 	CachedStore            = cachedStore
-	DefaultRefreshSchedule = defaultRefreshSchedule
+	DefaultRefreshSchedule = defaultRefreshScheduleStr
 	DoInstall              = doInstall
 	UserFromUserID         = userFromUserID
 	ValidateFeatureFlags   = validateFeatureFlags

--- a/overlord/snapstate/refreshhints.go
+++ b/overlord/snapstate/refreshhints.go
@@ -70,7 +70,7 @@ func (r *refreshHints) needsUpdate() (bool, error) {
 }
 
 func (r *refreshHints) refresh() error {
-	scheduleConf, _, _ := readRefreshScheduleConf(r.state)
+	scheduleConf, _, _ := getRefreshScheduleConf(r.state)
 	refreshManaged := scheduleConf == "managed" && CanManageRefreshes(r.state)
 
 	var err error

--- a/overlord/snapstate/refreshhints.go
+++ b/overlord/snapstate/refreshhints.go
@@ -70,8 +70,8 @@ func (r *refreshHints) needsUpdate() (bool, error) {
 }
 
 func (r *refreshHints) refresh() error {
-	var refreshManaged bool
-	refreshManaged, _, _ = refreshScheduleManaged(r.state)
+	scheduleConf, _, _ := readRefreshScheduleConf(r.state)
+	refreshManaged := scheduleConf == "managed" && CanManageRefreshes(r.state)
 
 	var err error
 	perfTimings := timings.New(map[string]string{"ensure": "refresh-hints"})

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -3753,9 +3753,6 @@ func (s *snapmgrTestSuite) TestEnsureRefreshRefusesLegacyWeekdaySchedules(c *C) 
 	defer s.state.Unlock()
 	snapstate.CanAutoRefresh = func(*state.State) (bool, error) { return true, nil }
 
-	logbuf, restore := logger.MockLogger()
-	defer restore()
-
 	s.state.Set("last-refresh", time.Date(2009, 8, 13, 8, 0, 5, 0, time.UTC))
 	tr := config.NewTransaction(s.state)
 	tr.Set("core", "refresh.timer", "")
@@ -3767,10 +3764,9 @@ func (s *snapmgrTestSuite) TestEnsureRefreshRefusesLegacyWeekdaySchedules(c *C) 
 	s.se.Ensure()
 	s.state.Lock()
 
-	c.Check(logbuf.String(), testutil.Contains, `cannot use refresh.schedule configuration: cannot parse "mon@12:00": not a valid time`)
 	schedule, legacy, err := s.snapmgr.RefreshSchedule()
-	c.Assert(err, IsNil)
-	c.Check(schedule, Equals, "00:00~24:00/4")
+	c.Assert(err, ErrorMatches, `cannot use refresh.schedule configuration: cannot parse "mon@12:00": not a valid time`)
+	c.Check(schedule, Equals, "")
 	c.Check(legacy, Equals, false)
 
 	tr = config.NewTransaction(s.state)
@@ -3829,37 +3825,6 @@ func (s *snapmgrTestSuite) TestEnsureRefreshFallbackToLegacySchedule(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(schedule, Equals, "00:00-23:59")
 	c.Check(legacy, Equals, true)
-}
-
-func (s *snapmgrTestSuite) TestEnsureRefreshFallbackToDefaultOnError(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-	snapstate.CanAutoRefresh = func(*state.State) (bool, error) { return true, nil }
-
-	tr := config.NewTransaction(s.state)
-	tr.Set("core", "refresh.timer", "garbage-in")
-	tr.Set("core", "refresh.schedule", "00:00-23:59")
-	tr.Commit()
-
-	// Ensure() also runs ensureRefreshes()
-	s.state.Unlock()
-	s.se.Ensure()
-	s.state.Lock()
-
-	// automatic fallback to default schedule if refresh.timer is set but
-	// cannot be parsed
-	schedule, legacy, err := s.snapmgr.RefreshSchedule()
-	c.Assert(err, IsNil)
-	c.Check(schedule, Equals, "00:00~24:00/4")
-	c.Check(legacy, Equals, false)
-
-	tr = config.NewTransaction(s.state)
-	refreshTimer := "canary"
-	refreshSchedule := "canary"
-	c.Assert(tr.Get("core", "refresh.timer", &refreshTimer), IsNil)
-	c.Assert(tr.Get("core", "refresh.schedule", &refreshSchedule), IsNil)
-	c.Check(refreshTimer, Equals, "garbage-in")
-	c.Check(refreshSchedule, Equals, "00:00-23:59")
 }
 
 func (s *snapmgrTestSuite) TestEnsureRefreshFallbackOnEmptyToDefaultSchedule(c *C) {
@@ -6522,15 +6487,16 @@ func (s *snapmgrTestSuite) TestSnapManagerLegacyRefreshSchedule(c *C) {
 	for _, t := range []struct {
 		in     string
 		out    string
+		errMsg string
 		legacy bool
 	}{
-		{"", snapstate.DefaultRefreshSchedule, false},
-		{"invalid schedule", snapstate.DefaultRefreshSchedule, false},
-		{"8:00-12:00", "8:00-12:00", true},
+		{"", snapstate.DefaultRefreshSchedule, "", false},
+		{"invalid schedule", "", `cannot use refresh.schedule configuration: cannot parse "invalid schedule": not a valid interval`, false},
+		{"8:00-12:00", "8:00-12:00", "", true},
 		// using the legacy configuration option with a new-style
 		// refresh.timer string is rejected (i.e. the legacy parser is
 		// used for the parsing)
-		{"0:00~24:00/24", snapstate.DefaultRefreshSchedule, false},
+		{"0:00~24:00/24", "", `cannot use refresh.schedule configuration: cannot parse "0:00~24:00": not a valid interval`, false},
 	} {
 		if t.in != "" {
 			tr := config.NewTransaction(s.state)
@@ -6539,7 +6505,11 @@ func (s *snapmgrTestSuite) TestSnapManagerLegacyRefreshSchedule(c *C) {
 			tr.Commit()
 		}
 		scheduleStr, legacy, err := s.snapmgr.RefreshSchedule()
-		c.Check(err, IsNil)
+		if t.errMsg != "" {
+			c.Check(err, ErrorMatches, t.errMsg)
+		} else {
+			c.Check(err, IsNil)
+		}
 		c.Check(scheduleStr, Equals, t.out)
 		c.Check(legacy, Equals, t.legacy)
 	}
@@ -6550,14 +6520,15 @@ func (s *snapmgrTestSuite) TestSnapManagerRefreshSchedule(c *C) {
 	defer s.state.Unlock()
 
 	for _, t := range []struct {
-		in  string
-		out string
+		in     string
+		out    string
+		errMsg string
 	}{
-		{"", snapstate.DefaultRefreshSchedule},
-		{"invalid schedule", snapstate.DefaultRefreshSchedule},
-		{"8:00-12:00", "8:00-12:00"},
+		{"", snapstate.DefaultRefreshSchedule, ""},
+		{"invalid schedule", "", `cannot use refresh.timer configuration: cannot parse "invalid schedule": "invalid schedule" is not a valid weekday`},
+		{"8:00-12:00", "8:00-12:00", ""},
 		// this is only valid under the new schedule parser
-		{"9:00~15:00/2,,mon,20:00", "9:00~15:00/2,,mon,20:00"},
+		{"9:00~15:00/2,,mon,20:00", "9:00~15:00/2,,mon,20:00", ""},
 	} {
 		if t.in != "" {
 			tr := config.NewTransaction(s.state)
@@ -6565,7 +6536,11 @@ func (s *snapmgrTestSuite) TestSnapManagerRefreshSchedule(c *C) {
 			tr.Commit()
 		}
 		scheduleStr, legacy, err := s.snapmgr.RefreshSchedule()
-		c.Check(err, IsNil)
+		if t.errMsg != "" {
+			c.Check(err, ErrorMatches, t.errMsg)
+		} else {
+			c.Check(err, IsNil)
+		}
 		c.Check(scheduleStr, Equals, t.out)
 		c.Check(legacy, Equals, false)
 	}


### PR DESCRIPTION
This PR refactors the logic in `autorefresh.go` that reads the refresh schedule and checks if can be managed. The logic was split around several functions in a (IMO) confusing way. Essentially, this function checks if the refresh config value is "managed" and, if it is, checks if there's a snap to manage. If not, then the refresh schedule value is parsed and the schedule is returned.