### PR TITLE
tests: add 3 tests that update boot assets in gadget on secure boot

### DIFF
--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -352,7 +352,9 @@ nested_secboot_sign_file() {
     local FILE="$1"
     local KEY="$2"
     local CERT="$3"
-    sbattach --remove "$FILE"
+    while sbverify --list "$FILE" | grep "^signature [0-9]*$"; do
+        sbattach --remove "$FILE"
+    done
     sbsign --key "$KEY" --cert "$CERT" --output "$FILE" "$FILE"
 }
 

--- a/tests/nested/manual/uc-update-assets-secure-add-sbat/task.yaml
+++ b/tests/nested/manual/uc-update-assets-secure-add-sbat/task.yaml
@@ -1,0 +1,156 @@
+summary: Update shim from non-sbat to sbat through gadget in secure boot
+
+details: |
+  This will happen on UC20 and we need to make sure that it will
+  continue to boot.
+
+systems: [ubuntu-20.04-64, ubuntu-22.04-64]
+
+environment:
+  NESTED_ENABLE_SECURE_BOOT: true
+
+  UPDATE_BOOT/both: true
+  UPDATE_SEED/both: true
+
+  UPDATE_BOOT/seed: false
+  UPDATE_SEED/seed: true
+
+  UPDATE_BOOT/boot: true
+  UPDATE_SEED/boot: false
+
+  NESTED_IMAGE_ID: "add-sbat-${UPDATE_SEED}-${UPDATE_BOOT}"
+
+prepare: |
+  snap install yq
+
+  apt install -y git-buildpackage dpkg-dev quilt
+  git clone https://git.launchpad.net/ubuntu/+source/shim -b applied/ubuntu/jammy
+
+  # Download and build shim version without sbat support
+  (
+    cd shim
+    git checkout importer/applied/15+1552672080.a4a1fbe-0ubuntu2-0-g5aa624c17de596f3d7e7ea526eea6532b60fa207
+    # Newer GCC does build anymore this package without warning
+    sed -i "s/-Werror //" Make.defaults
+    apt build-dep -y ./
+    debian/rules build
+    cp shimx64.efi ../old-shimx64.efi
+    debian/rules clean
+    rm -rf .pc
+  )
+  # Download and build shim version with sbat support
+  (
+    cd shim
+    git checkout -f importer/applied/15.4-0ubuntu9-0-g1d3b42fd5db818144cb2f60a2959ebd52881d5fd
+    apt build-dep -y ./
+    debian/rules build
+    cp shimx64.efi ../new-shimx64.efi
+    debian/rules clean
+    rm -rf .pc
+  )
+
+  CHANNEL="$(tests.nested show version)/stable"
+  snap download --basename=pc --channel="${CHANNEL}" pc
+  unsquashfs -d pc pc.snap
+  KEY_NAME=$(tests.nested download snakeoil-key)
+  SNAKEOIL_KEY="$PWD/$KEY_NAME.key"
+  SNAKEOIL_CERT="$PWD/$KEY_NAME.pem"
+
+  # Remove signatures on grub
+  while sbverify --list pc/grubx64.efi | grep "^signature [0-9]*$"; do
+    sbattach --remove pc/grubx64.efi
+  done
+  # Remove sbat on grub if it did exist
+  objcopy --remove-section=.sbat pc/grubx64.efi || true
+  # Save that file
+  cp pc/grubx64.efi grubx64.efi
+
+  cp old-shimx64.efi pc/shim.efi.signed
+
+  # Repack pc gadget for the initial image
+  tests.nested secboot-sign file pc/shim.efi.signed "$SNAKEOIL_KEY" "$SNAKEOIL_CERT"
+  tests.nested secboot-sign file pc/grubx64.efi "$SNAKEOIL_KEY" "$SNAKEOIL_CERT"
+  old_shim_sha="$(sha256sum pc/shim.efi.signed | sed "s/ .*//")"
+  old_grub_sha="$(sha256sum pc/grubx64.efi | sed "s/ .*//")"
+  snap pack pc "$(tests.nested get extra-snaps-path)"
+
+  tests.nested build-image core
+  tests.nested create-vm core
+
+  cat <<EOF >sbat.csv
+  sbat,1,SBAT Version,sbat,1,https://github.com/rhboot/shim/blob/main/SBAT.md
+  grub,1,Free Software Foundation,grub,2.06,https://www.gnu.org/software/grub/
+  grub.ubuntu,1,Canonical,grub2,2.06-2ubuntu7,https://packages.ubuntu.com/source/jammy/grub2
+  EOF
+  sbatsize="$(($(stat -c %b sbat.csv)*$(stat -c %B sbat.csv)))"
+  truncate --size "${sbatsize}" sbat.csv
+
+  # Add .sbat at the end
+  grubsize="$(($(stat -c %b grubx64.efi)*$(stat -c %B grubx64.efi)))"
+  objcopy --add-section .sbat=sbat.csv --change-section-address .sbat="${grubsize}" grubx64.efi grubx64-sbat.efi
+
+  cp new-shimx64.efi pc/shim.efi.signed
+  cp grubx64-sbat.efi pc/grubx64.efi
+
+  # Sign modified grub and shim
+  tests.nested secboot-sign file pc/shim.efi.signed "$SNAKEOIL_KEY" "$SNAKEOIL_CERT"
+  tests.nested secboot-sign file pc/grubx64.efi "$SNAKEOIL_KEY" "$SNAKEOIL_CERT"
+  new_shim_sha="$(sha256sum pc/shim.efi.signed | sed "s/ .*//")"
+  new_grub_sha="$(sha256sum pc/grubx64.efi | sed "s/ .*//")"
+
+  if [ "${UPDATE_SEED}" = true ]; then
+    yq -i '(.volumes.pc.structure[] | select(.role == "system-seed") | .update.edition) |= . + 1' pc/meta/gadget.yaml
+  fi
+  if [ "${UPDATE_BOOT}" = true ]; then
+    yq -i '(.volumes.pc.structure[] | select(.role == "system-boot") | .update.edition) |= . + 1' pc/meta/gadget.yaml
+  fi
+
+  cat <<EOF >>expected-before
+  ${old_shim_sha} */boot/efi/EFI/boot/bootx64.efi
+  ${old_grub_sha} */boot/efi/EFI/boot/grubx64.efi
+  EOF
+  if [ "${UPDATE_SEED}" = true ]; then
+    cat <<EOF >>expected-after
+  ${new_shim_sha} */boot/efi/EFI/boot/bootx64.efi
+  ${new_grub_sha} */boot/efi/EFI/boot/grubx64.efi
+  EOF
+  else
+    cat <<EOF >>expected-after
+  ${old_shim_sha} */boot/efi/EFI/boot/bootx64.efi
+  ${old_grub_sha} */boot/efi/EFI/boot/grubx64.efi
+  EOF
+  fi
+
+  cat <<EOF >>expected-before
+  ${old_shim_sha} */run/mnt/ubuntu-boot/EFI/boot/bootx64.efi
+  ${old_grub_sha} */run/mnt/ubuntu-boot/EFI/boot/grubx64.efi
+  EOF
+  if [ "${UPDATE_BOOT}" = true ]; then
+    cat <<EOF >>expected-after
+  ${new_shim_sha} */run/mnt/ubuntu-boot/EFI/boot/bootx64.efi
+  ${new_grub_sha} */run/mnt/ubuntu-boot/EFI/boot/grubx64.efi
+  EOF
+  else
+    cat <<EOF >>expected-after
+  ${old_shim_sha} */run/mnt/ubuntu-boot/EFI/boot/bootx64.efi
+  ${old_grub_sha} */run/mnt/ubuntu-boot/EFI/boot/grubx64.efi
+  EOF
+  fi
+
+  snap pack pc --filename=pc_2.snap
+
+  remote.exec systemctl --wait is-system-running || true
+  tests.nested wait-for snap-command
+  remote.exec "sudo snap wait system seed.loaded"
+
+execute: |
+  remote.exec "sha256sum -c" <expected-before
+
+  remote.push pc_2.snap
+  boot_id="$(tests.nested boot-id)"
+
+  REMOTE_CHG_ID="$(remote.exec "sudo snap install --no-wait --dangerous pc_2.snap")"
+  tests.nested wait-for reboot "${boot_id}"
+  remote.exec sudo snap watch "$REMOTE_CHG_ID"
+
+  remote.exec "sha256sum -c" <expected-after

--- a/tests/nested/manual/uc-update-assets-secure/generate_vendor_cert_section.py
+++ b/tests/nested/manual/uc-update-assets-secure/generate_vendor_cert_section.py
@@ -1,0 +1,45 @@
+# Copyright (C) 2022 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import struct
+import argparse
+
+# The vendor certificate table in created by cert.S in the shim project.
+# See:
+# https://github.com/rhboot/shim/blob/505cdb678b319fcf9a7fdee77c0f091b4147cbe5/cert.S
+
+def main():
+    parser = argparse.ArgumentParser(description='Generate a shim vendor certificate section')
+    parser.add_argument('OUTPUT', help='Output file')
+    parser.add_argument('CERT', help='Vendor certificate')
+    parser.add_argument('DBX', nargs='?', help='Vendor dbx')
+    args = parser.parse_args()
+    with open(args.CERT, 'rb') as f:
+        cert = f.read()
+    if args.DBX is not None:
+        with open(args.DBX, 'rb') as f:
+            dbx = f.read()
+    else:
+        dbx = b''
+
+    header_format = 'IIII'
+    header_size = struct.calcsize(header_format)
+    header = struct.pack(header_format, len(cert), len(dbx), header_size, header_size+len(cert))
+    with open(args.OUTPUT, 'wb') as f:
+        f.write(header)
+        f.write(cert)
+        f.write(dbx)
+
+if __name__ == '__main__':
+    main()

--- a/tests/nested/manual/uc-update-assets-secure/task.yaml
+++ b/tests/nested/manual/uc-update-assets-secure/task.yaml
@@ -1,0 +1,124 @@
+summary: Update boot assets through gadgets in secure boot
+
+systems: [ubuntu-20.04-64, ubuntu-22.04-64]
+
+environment:
+  NESTED_ENABLE_SECURE_BOOT: true
+
+  UPDATE_BOOT/both: true
+  UPDATE_SEED/both: true
+
+  UPDATE_BOOT/seed: false
+  UPDATE_SEED/seed: true
+
+  UPDATE_BOOT/boot: true
+  UPDATE_SEED/boot: false
+
+  NESTED_IMAGE_ID: "update-grub-${UPDATE_SEED}-${UPDATE_BOOT}"
+
+prepare: |
+  snap install yq
+
+  CHANNEL="$(tests.nested show version)/edge"
+  snap download --basename=pc --channel="${CHANNEL}" pc
+  unsquashfs -d pc pc.snap
+  KEY_NAME=$(tests.nested download snakeoil-key)
+  SNAKEOIL_KEY="$PWD/$KEY_NAME.key"
+  SNAKEOIL_CERT="$PWD/$KEY_NAME.pem"
+
+  # Save the shim before resigning
+  cp pc/shim.efi.signed shim.efi.signed
+
+  # Repack pc gadget for the initial image
+  tests.nested secboot-sign file pc/shim.efi.signed "$SNAKEOIL_KEY" "$SNAKEOIL_CERT"
+  tests.nested secboot-sign file pc/grubx64.efi "$SNAKEOIL_KEY" "$SNAKEOIL_CERT"
+  old_shim_sha="$(sha256sum pc/shim.efi.signed | sed "s/ .*//")"
+  old_grub_sha="$(sha256sum pc/grubx64.efi | sed "s/ .*//")"
+  snap pack pc "$(tests.nested get extra-snaps-path)"
+
+  # Remove signatures
+  cp shim.efi.signed shim.efi
+  while sbverify --list shim.efi | grep "^signature [0-9]*$"; do
+    sbattach --remove shim.efi
+  done
+
+  # Add a different vendor certificate
+  openssl req -new -x509 -newkey rsa:2048 -subj "/CN=new vendor certificate/" -keyout new-cert.key -out new-cert.crt -days 3650 -nodes -sha256
+  openssl x509 -outform der -in new-cert.crt -out new-cert
+  python3 generate_vendor_cert_section.py new-section new-cert
+  objcopy --update-section .vendor_cert=new-section shim.efi shim.efi.out
+
+  # Sign modified shim
+  cp shim.efi.out pc/shim.efi.signed
+  tests.nested secboot-sign file pc/shim.efi.signed "${SNAKEOIL_KEY}" "${SNAKEOIL_CERT}"
+
+  if [ "${UPDATE_SEED}" = true ]; then
+    # Resign grub with new vendor key
+    tests.nested secboot-sign file pc/grubx64.efi "new-cert.key" "new-cert.crt"
+  else
+    # If shim is not installed in seed, then we need to keep the snakeoil signature
+    tests.nested secboot-sign file pc/grubx64.efi "${SNAKEOIL_KEY}" "${SNAKEOIL_CERT}"
+  fi
+
+  new_shim_sha="$(sha256sum pc/shim.efi.signed | sed "s/ .*//")"
+  new_grub_sha="$(sha256sum pc/grubx64.efi | sed "s/ .*//")"
+
+  if [ "${UPDATE_SEED}" = true ]; then
+    yq -i '(.volumes.pc.structure[] | select(.role == "system-seed") | .update.edition) |= . + 1' pc/meta/gadget.yaml
+  fi
+  if [ "${UPDATE_BOOT}" = true ]; then
+    yq -i '(.volumes.pc.structure[] | select(.role == "system-boot") | .update.edition) |= . + 1' pc/meta/gadget.yaml
+  fi
+
+  snap pack pc --filename=pc_2.snap
+
+  cat <<EOF >>expected-before
+  ${old_shim_sha} */boot/efi/EFI/boot/bootx64.efi
+  ${old_grub_sha} */boot/efi/EFI/boot/grubx64.efi
+  EOF
+  if [ "${UPDATE_SEED}" = true ]; then
+    cat <<EOF >>expected-after
+  ${new_shim_sha} */boot/efi/EFI/boot/bootx64.efi
+  ${new_grub_sha} */boot/efi/EFI/boot/grubx64.efi
+  EOF
+  else
+    cat <<EOF >>expected-after
+  ${old_shim_sha} */boot/efi/EFI/boot/bootx64.efi
+  ${old_grub_sha} */boot/efi/EFI/boot/grubx64.efi
+  EOF
+  fi
+
+  cat <<EOF >>expected-before
+  ${old_shim_sha} */run/mnt/ubuntu-boot/EFI/boot/bootx64.efi
+  ${old_grub_sha} */run/mnt/ubuntu-boot/EFI/boot/grubx64.efi
+  EOF
+  if [ "${UPDATE_BOOT}" = true ]; then
+    cat <<EOF >>expected-after
+  ${new_shim_sha} */run/mnt/ubuntu-boot/EFI/boot/bootx64.efi
+  ${new_grub_sha} */run/mnt/ubuntu-boot/EFI/boot/grubx64.efi
+  EOF
+  else
+    cat <<EOF >>expected-after
+  ${old_shim_sha} */run/mnt/ubuntu-boot/EFI/boot/bootx64.efi
+  ${old_grub_sha} */run/mnt/ubuntu-boot/EFI/boot/grubx64.efi
+  EOF
+  fi
+
+  tests.nested build-image core
+  tests.nested create-vm core
+
+  remote.exec systemctl --wait is-system-running || true
+  tests.nested wait-for snap-command
+  remote.exec "sudo snap wait system seed.loaded"
+
+execute: |
+  remote.exec "sha256sum -c" <expected-before
+
+  remote.push pc_2.snap
+  boot_id="$(tests.nested boot-id)"
+
+  REMOTE_CHG_ID="$(remote.exec "sudo snap install --no-wait --dangerous pc_2.snap")"
+  tests.nested wait-for reboot "${boot_id}"
+  remote.exec sudo snap watch "$REMOTE_CHG_ID"
+
+  remote.exec "sha256sum -c" <expected-after

--- a/tests/nested/manual/uc-update-command-line-secure/task.yaml
+++ b/tests/nested/manual/uc-update-command-line-secure/task.yaml
@@ -1,0 +1,30 @@
+summary: Update command line from gadget in secure boot
+
+systems: [ubuntu-20.04-64, ubuntu-22.04-64]
+
+environment:
+  NESTED_ENABLE_SECURE_BOOT: true
+
+prepare: |
+  CHANNEL="$(tests.nested show version)/stable"
+  snap download --basename=pc --channel="${CHANNEL}" pc
+  unsquashfs -d pc pc.snap
+  KEY_NAME=$(tests.nested download snakeoil-key)
+  SNAKEOIL_KEY="$PWD/$KEY_NAME.key"
+  SNAKEOIL_CERT="$PWD/$KEY_NAME.pem"
+  tests.nested secboot-sign file pc/shim.efi.signed "$SNAKEOIL_KEY" "$SNAKEOIL_CERT"
+  tests.nested secboot-sign file pc/grubx64.efi "$SNAKEOIL_KEY" "$SNAKEOIL_CERT"
+  snap pack pc "$(tests.nested get extra-snaps-path)"
+
+  echo "some_useless_parameter" >>pc/cmdline.extra
+  snap pack pc --filename=pc_2.snap
+
+  tests.nested build-image core
+  tests.nested create-vm core
+
+execute: |
+  remote.push pc_2.snap
+  boot_id="$(tests.nested boot-id)"
+  remote.exec "sudo snap install --dangerous pc_2.snap"
+  tests.nested wait-for reboot "${boot_id}"
+  remote.exec "MATCH '.*some_useless_parameter.*' </proc/cmdline"


### PR DESCRIPTION
 * Update the command line
 * Update vendor key in shim
 * Update shim from non-sbat to sbat

Also a previous commit fixes re-signing of boot files.