### PR TITLE
systemd: bind mount units to basic.target not to default.target

### DIFF
--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -1362,8 +1362,6 @@ var squashfsFsType = squashfs.FsType
 
 // XXX: After=zfs-mount.service is a workaround for LP: #1922293 (a problem
 // with order of mounting most likely related to zfs-linux and/or systemd).
-// XXX: Remove multi-user.target once we are sure it's unnecessary (see the
-// comments in LP: #1983528).
 const mountUnitTemplate = `[Unit]
 Description=Mount unit for {{.SnapName}}
 {{- with .Revision}}, revision {{.}}{{end}}
@@ -1379,7 +1377,7 @@ Options={{join .Options ","}}
 LazyUnmount=yes
 
 [Install]
-WantedBy=default.target multi-user.target
+WantedBy=basic.target
 {{- with .Origin}}
 X-SnapdOrigin={{.}}
 {{- end}}

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -1175,7 +1175,7 @@ Options=nodev,ro,x-gdu.hide,x-gvfs-hide
 LazyUnmount=yes
 
 [Install]
-WantedBy=default.target multi-user.target
+WantedBy=basic.target
 `[1:], mockSnapPath))
 
 	c.Assert(s.argses, DeepEquals, [][]string{
@@ -1209,7 +1209,7 @@ Options=nodev,ro,x-gdu.hide,x-gvfs-hide,bind
 LazyUnmount=yes
 
 [Install]
-WantedBy=default.target multi-user.target
+WantedBy=basic.target
 `[1:], snapDir))
 
 	c.Assert(s.argses, DeepEquals, [][]string{
@@ -1255,7 +1255,7 @@ Options=remount,ro
 LazyUnmount=yes
 
 [Install]
-WantedBy=default.target multi-user.target
+WantedBy=basic.target
 X-SnapdOrigin=bar
 `[1:], mockSnapPath))
 
@@ -1298,7 +1298,7 @@ Options=nodev,context=system_u:object_r:snappy_snap_t:s0,ro,x-gdu.hide,x-gvfs-hi
 LazyUnmount=yes
 
 [Install]
-WantedBy=default.target multi-user.target
+WantedBy=basic.target
 `[1:], mockSnapPath))
 }
 
@@ -1342,7 +1342,7 @@ Options=nodev,ro,x-gdu.hide,x-gvfs-hide,allow_other
 LazyUnmount=yes
 
 [Install]
-WantedBy=default.target multi-user.target
+WantedBy=basic.target
 `[1:], mockSnapPath))
 }
 
@@ -1382,7 +1382,7 @@ Options=nodev,ro,x-gdu.hide,x-gvfs-hide
 LazyUnmount=yes
 
 [Install]
-WantedBy=default.target multi-user.target
+WantedBy=basic.target
 `[1:], mockSnapPath))
 }
 
@@ -1646,7 +1646,7 @@ Options=%s
 LazyUnmount=yes
 
 [Install]
-WantedBy=default.target multi-user.target
+WantedBy=basic.target
 `
 
 func (s *SystemdTestSuite) TestPreseedModeAddMountUnit(c *C) {
@@ -1866,7 +1866,7 @@ Type=doesntmatter
 Options=do,not,matter,either
 
 [Install]
-WantedBy=default.target multi-user.target
+WantedBy=basic.target
 X-SnapdOrigin=%s
 `, snapName, where, origin)
 		return ioutil.WriteFile(path, []byte(contents), 0644)

--- a/tests/lib/state.sh
+++ b/tests/lib/state.sh
@@ -60,7 +60,7 @@ save_snapd_state() {
             /var/cache/snapd \
             "$SNAP_MOUNT_DIR" \
             /etc/systemd/system/"$escaped_snap_mount_dir"-*core*.mount \
-            /etc/systemd/system/multi-user.target.wants/"$escaped_snap_mount_dir"-*core*.mount \
+            /etc/systemd/system/basic.target.wants/"$escaped_snap_mount_dir"-*core*.mount \
             $snap_confine_profiles \
             $snapd_env \
             $snapd_service_env


### PR DESCRIPTION
As @xnox pointed out in the comments in [1], depending on
"default.target" can have some undesired consequences, since
default.target is a dynamic target that could be set to special targets
like "emergency.target", which are meant for specific scopes where one
should strive to start as few unneeded units as possible.

"basic.target" means that the local filesystems have been mounted, as
well as /var and other directories which might be remote (read more
about this target in the man page [2]); it is a dependency for the
multi-user target (which we can therefore remove from the `WantedBy`
list) and for the oem-config target which we use in the OEM
configuration [3].

[1]: https://github.com/snapcore/snapd/pull/12011
[2]: https://manpages.ubuntu.com/manpages/kinetic/en/man7/systemd.special.7.html
[3]: https://git.launchpad.net/ubiquity/tree/data/oem-config.target
