### PR TITLE
progress: export stdout so it can be overridden by ubuntu-image

### DIFF
--- a/progress/ansimeter.go
+++ b/progress/ansimeter.go
@@ -31,7 +31,7 @@ import (
 	"github.com/snapcore/snapd/strutil/quantity"
 )
 
-var stdout io.Writer = os.Stdout
+var Stdout io.Writer = os.Stdout
 
 // ANSIMeter is a progress.Meter that uses ANSI escape codes to make
 // better use of the available horizontal space.
@@ -71,7 +71,7 @@ func (p *ANSIMeter) Start(label string, total float64) {
 	p.label = []rune(label)
 	p.total = total
 	p.t0 = time.Now().UTC()
-	fmt.Fprint(stdout, cursorInvisible)
+	fmt.Fprint(Stdout, cursorInvisible)
 }
 
 func norm(col int, msg []rune) []rune {
@@ -157,7 +157,7 @@ func (p *ANSIMeter) Set(current float64) {
 	msg = append(msg, rspeed...)
 	msg = append(msg, rtimeleft...)
 	i := int(current * float64(col) / p.total)
-	fmt.Fprint(stdout, "\r", enterReverseMode, string(msg[:i]), exitAttributeMode, string(msg[i:]))
+	fmt.Fprint(Stdout, "\r", enterReverseMode, string(msg[:i]), exitAttributeMode, string(msg[i:]))
 }
 
 var spinner = []string{"/", "-", "\\", "|"}
@@ -166,23 +166,23 @@ func (p *ANSIMeter) Spin(msgstr string) {
 	msg := []rune(msgstr)
 	col := termWidth()
 	if col-2 >= len(msg) {
-		fmt.Fprint(stdout, "\r", string(norm(col-2, msg)), " ", spinner[p.spin])
+		fmt.Fprint(Stdout, "\r", string(norm(col-2, msg)), " ", spinner[p.spin])
 		p.spin++
 		if p.spin >= len(spinner) {
 			p.spin = 0
 		}
 	} else {
-		fmt.Fprint(stdout, "\r", string(norm(col, msg)))
+		fmt.Fprint(Stdout, "\r", string(norm(col, msg)))
 	}
 }
 
 func (*ANSIMeter) Finished() {
-	fmt.Fprint(stdout, "\r", exitAttributeMode, cursorVisible, clrEOL)
+	fmt.Fprint(Stdout, "\r", exitAttributeMode, cursorVisible, clrEOL)
 }
 
 func (*ANSIMeter) Notify(msgstr string) {
 	col := termWidth()
-	fmt.Fprint(stdout, "\r", exitAttributeMode, clrEOL)
+	fmt.Fprint(Stdout, "\r", exitAttributeMode, clrEOL)
 
 	msg := []rune(msgstr)
 	var i int
@@ -194,15 +194,15 @@ func (*ANSIMeter) Notify(msgstr string) {
 		}
 		if i < 1 {
 			// didn't find anything; print the whole thing and try again
-			fmt.Fprintln(stdout, string(msg[:col]))
+			fmt.Fprintln(Stdout, string(msg[:col]))
 			msg = msg[col:]
 		} else {
 			// found a space; print up to but not including it, and skip it
-			fmt.Fprintln(stdout, string(msg[:i]))
+			fmt.Fprintln(Stdout, string(msg[:i]))
 			msg = msg[i+1:]
 		}
 	}
-	fmt.Fprintln(stdout, string(msg))
+	fmt.Fprintln(Stdout, string(msg))
 }
 
 func (p *ANSIMeter) Write(bs []byte) (n int, err error) {

--- a/progress/export_test.go
+++ b/progress/export_test.go
@@ -89,10 +89,10 @@ func MockTermWidth(f func() int) func() {
 }
 
 func MockStdout(w io.Writer) func() {
-	origStdout := stdout
-	stdout = w
+	origStdout := Stdout
+	Stdout = w
 	return func() {
-		stdout = origStdout
+		Stdout = origStdout
 	}
 }
 

--- a/progress/progress.go
+++ b/progress/progress.go
@@ -70,7 +70,7 @@ func (NullMeter) Spin(msg string)             {}
 type QuietMeter struct{ NullMeter }
 
 func (QuietMeter) Notify(msg string) {
-	fmt.Fprintln(stdout, msg)
+	fmt.Fprintln(Stdout, msg)
 }
 
 // testMeter, if set, is returned by MakeProgressBar; set it from tests.


### PR DESCRIPTION
ubuntu-image has a `--quiet` flag that should suppress all output besides error messages. This is done per the [Ubuntu CLI tool guidelines](https://discourse.ubuntu.com/t/cli-verbosity-levels/26973)

When calling image.Prepare, there are two default outputs: "Fetching <snap_name>", and a progress bar for the download of the snap. The variable Stdout is already exported for the `image` package that prints the "Fetching" message. This PR exports the Stdout variable for the `progress` package as well so the progress bar can also be suppressed.