### PR TITLE
tests: unify the way the snapd/core and kernel are repacked in nested helper

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -961,6 +961,8 @@ suites:
             NESTED_ENABLE_TPM: '$(HOST: echo "${NESTED_ENABLE_TPM:-}")'
             # Enable secure boot in the nested vm in case it is supported
             NESTED_ENABLE_SECURE_BOOT: '$(HOST: echo "${NESTED_ENABLE_SECURE_BOOT:-}")'
+            # Generic imane name which has to be overwritten in the test
+            NESTED_IMAGE_ID: "unset"
         manual: true
         warn-timeout: 10m
         kill-timeout: 60m

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -490,7 +490,7 @@ nested_get_image_name() {
     # Use task name to build the image in case the NESTED_IMAGE_ID is unset
     # This scenario is valid on manual tests when it is required to set the NESTED_IMAGE_ID
     if [ "$NAME" = "unset" ]; then
-        NAME="$SPREAD_TASK"
+        NAME="$(basename "$SPREAD_TASK")"
         if [ -n "$SPREAD_VARIANT" ]; then
             NAME="${NAME}_${SPREAD_VARIANT}"
         fi

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -833,6 +833,7 @@ EOF
                 "${UBUNTU_IMAGE_PRESEED_ARGS[@]:-}" \
                 --output-dir "$NESTED_IMAGES_DIR" \
                 --sector-size "${NESTED_DISK_LOGICAL_BLOCK_SIZE}" \
+                $EXTRA_FUNDAMENTAL \
                 $EXTRA_SNAPS
 
             # ubuntu-image dropped the --output parameter, so we have to rename
@@ -962,7 +963,7 @@ nested_add_file_to_vm() {
     ubuntuSeedDev="${devloop}p2"
 
     # Wait for the partition to show up
-    retry -n 2 --wait test -b "${ubuntuSeedDev}" || true
+    retry -n 2 --wait 1 test -b "${ubuntuSeedDev}" || true
 
     # losetup does not set the right block size on LOOP_CONFIGURE
     # but with LOOP_SET_BLOCK_SIZE later. So the block size might have

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -487,13 +487,22 @@ nested_get_image_name() {
         VERSION="18"
     fi
 
+    # Use task name to build the image in case the NESTED_IMAGE_ID is unset
+    # This scenario is valid on manual tests when it is required to set the NESTED_IMAGE_ID
+    if [ "$NAME" = "unset" ]; then
+        NAME="$SPREAD_TASK"
+        if [ -n "$SPREAD_VARIANT" ]; then
+            NAME="$NAME_$SPREAD_VARIANT"
+        fi
+    fi
+
     if [ "$NESTED_BUILD_SNAPD_FROM_CURRENT" = "true" ]; then
         SOURCE="custom"
     fi
     if [ "$(nested_get_extra_snaps | wc -l)" != "0" ]; then
         SOURCE="custom"
     fi
-    echo "ubuntu-${TYPE}-${VERSION}-${SOURCE}-${NAME}-${NESTED_DISK_LOGICAL_BLOCK_SIZE}.img"
+    echo "ubuntu-${TYPE}-${VERSION}-${SOURCE}-${NAME}.img"
 }
 
 nested_is_generic_image() {

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -612,7 +612,7 @@ prepare_snapd() {
             snap_id="PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4"
         fi
 
-        "$TESTSTOOLS"/snaps-state repack_snapd_deb_into_snap "$snap" "$NESTED_ASSETS_DIR"
+        "$TESTSTOOLS"/snaps-state repack_snapd_deb_into_snap "$snap_name" "$NESTED_ASSETS_DIR"
         mv "$NESTED_ASSETS_DIR/$output_name" "$(nested_get_extra_snaps_path)/$output_name"
 
         # sign the snapd snap with fakestore if requested

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -613,7 +613,7 @@ prepare_snapd() {
         fi
 
         "$TESTSTOOLS"/snaps-state repack_snapd_deb_into_snap "$snap_name" "$NESTED_ASSETS_DIR"
-        mv "$NESTED_ASSETS_DIR/$output_name" "$(nested_get_extra_snaps_path)/$output_name"
+        cp "$NESTED_ASSETS_DIR/$output_name" "$(nested_get_extra_snaps_path)/$output_name"
 
         # sign the snapd snap with fakestore if requested
         if [ "$NESTED_SIGN_SNAPS_FAKESTORE" = "true" ]; then
@@ -651,7 +651,7 @@ prepare_kernel() {
             kernel_snap=$(ls "$NESTED_ASSETS_DIR"/pc-kernel_*.snap)
             chmod 0600 "$kernel_snap"
         fi
-        mv "$kernel_snap" "$(nested_get_extra_snaps_path)/$output_name"
+        cp "$kernel_snap" "$(nested_get_extra_snaps_path)/$output_name"
         # sign the pc-kernel snap with fakestore if requested
         if [ "$NESTED_SIGN_SNAPS_FAKESTORE" = "true" ]; then
             make_snap_installable_with_id --noack "$NESTED_FAKESTORE_BLOB_DIR" "$(nested_get_extra_snaps_path)/$output_name" "$snap_id"

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -492,7 +492,7 @@ nested_get_image_name() {
     if [ "$NAME" = "unset" ]; then
         NAME="$SPREAD_TASK"
         if [ -n "$SPREAD_VARIANT" ]; then
-            NAME="$NAME_$SPREAD_VARIANT"
+            NAME="${NAME}_${SPREAD_VARIANT}"
         fi
     fi
 

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -603,13 +603,13 @@ prepare_snapd() {
         echo "Repacking snapd snap"
         local snap_name output_name snap_id
         if nested_is_core_16_system; then
-            snap_name=core
-            output_name=core-from-snapd-deb.snap
-            snap_id=99T7MUlRhtI3U0QFgl5mXXESAiSwt776
+            snap_name="core"
+            output_name="core-from-snapd-deb.snap"
+            snap_id="99T7MUlRhtI3U0QFgl5mXXESAiSwt776"
         else
-            snap_name=snapd
-            output_name=snapd-from-deb.snap
-            snap_id=PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
+            snap_name="snapd"
+            output_name="snapd-from-deb.snap"
+            snap_id="PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4"
         fi
 
         "$TESTSTOOLS"/snaps-state repack_snapd_deb_into_snap "$snap" "$NESTED_ASSETS_DIR"
@@ -628,7 +628,7 @@ prepare_kernel() {
         echo "Repacking kernel snap"
         local kernel_snap output_name snap_id
         output_name="pc-kernel.snap"
-        snap_id=pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza
+        snap_id="pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza"
 
         if nested_is_core_16_system || nested_is_core_18_system; then
             kernel_snap=pc-kernel-new.snap

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -599,30 +599,32 @@ nested_ensure_ubuntu_save() {
 }
 
 prepare_snapd() {
-    echo "Repacking snapd snap"
-    local snap_name output_name snap_id
-    if nested_is_core_16_system; then
-        snap_name=core
-        output_name=core-from-snapd-deb.snap
-        snap_id=99T7MUlRhtI3U0QFgl5mXXESAiSwt776
-    else
-        snap_name=snapd
-        output_name=snapd-from-deb.snap
-        snap_id=PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
-    fi
+    if [ "$NESTED_BUILD_SNAPD_FROM_CURRENT" = "true" ]; then
+        echo "Repacking snapd snap"
+        local snap_name output_name snap_id
+        if nested_is_core_16_system; then
+            snap_name=core
+            output_name=core-from-snapd-deb.snap
+            snap_id=99T7MUlRhtI3U0QFgl5mXXESAiSwt776
+        else
+            snap_name=snapd
+            output_name=snapd-from-deb.snap
+            snap_id=PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
+        fi
 
-    "$TESTSTOOLS"/snaps-state repack_snapd_deb_into_snap "$snap" "$NESTED_ASSETS_DIR"
-    mv "$NESTED_ASSETS_DIR/$output_name" "$(nested_get_extra_snaps_path)/$output_name"
+        "$TESTSTOOLS"/snaps-state repack_snapd_deb_into_snap "$snap" "$NESTED_ASSETS_DIR"
+        mv "$NESTED_ASSETS_DIR/$output_name" "$(nested_get_extra_snaps_path)/$output_name"
 
-    # sign the snapd snap with fakestore if requested
-    if [ "$NESTED_SIGN_SNAPS_FAKESTORE" = "true" ]; then
-        make_snap_installable_with_id --noack "$NESTED_FAKESTORE_BLOB_DIR" "$(nested_get_extra_snaps_path)/$output_name" "$snap_id"
+        # sign the snapd snap with fakestore if requested
+        if [ "$NESTED_SIGN_SNAPS_FAKESTORE" = "true" ]; then
+            make_snap_installable_with_id --noack "$NESTED_FAKESTORE_BLOB_DIR" "$(nested_get_extra_snaps_path)/$output_name" "$snap_id"
+        fi
     fi
 }
 
 prepare_kernel() {
     # allow repacking the kernel
-    if [ "$NESTED_REPACK_KERNEL_SNAP" = "true" ]
+    if [ "$NESTED_REPACK_KERNEL_SNAP" = "true" ]; then
         echo "Repacking kernel snap"
         local kernel_snap output_name snap_id
         output_name="pc-kernel.snap"

--- a/tests/nested/manual/core20-remodel/task.yaml
+++ b/tests/nested/manual/core20-remodel/task.yaml
@@ -4,7 +4,7 @@ systems: [ubuntu-20.04-64, ubuntu-22.04-64]
 
 environment:
   NESTED_CUSTOM_MODEL: $TESTSLIB/assertions/valid-for-testing-pc-{VERSION}.model
-  NESTED_IMAGE_ID: uc20-remodel-testing
+  NESTED_IMAGE_ID: uc20-remodel
   NESTED_ENABLE_TPM: true
   NESTED_ENABLE_SECURE_BOOT: true
   NESTED_BUILD_SNAPD_FROM_CURRENT: true

--- a/tests/nested/manual/remodel-cross-store/task.yaml
+++ b/tests/nested/manual/remodel-cross-store/task.yaml
@@ -11,7 +11,7 @@ systems: [ubuntu-18.04-64, ubuntu-20.04-64]
 
 environment:
     NESTED_CUSTOM_AUTO_IMPORT_ASSERTION: $TESTSLIB/assertions/test-snapd-remodel-auto-import.assert
-    NESTED_IMAGE_ID: uc20-remodel-testing-cross-store
+    NESTED_IMAGE_ID: remodel-cross-store
     NESTED_ENABLE_TPM: false
     NESTED_ENABLE_SECURE_BOOT: false
     NESTED_USE_CLOUD_INIT: false

--- a/tests/nested/manual/remodel-simple/task.yaml
+++ b/tests/nested/manual/remodel-simple/task.yaml
@@ -8,7 +8,7 @@ systems: [ubuntu-18.04-64, ubuntu-20.04-64]
 
 environment:
     NESTED_CUSTOM_AUTO_IMPORT_ASSERTION: $TESTSLIB/assertions/test-snapd-remodel-auto-import.assert
-    NESTED_IMAGE_ID: uc20-remodel-testing
+    NESTED_IMAGE_ID: remodel-simple
     NESTED_ENABLE_TPM: false
     NESTED_ENABLE_SECURE_BOOT: false
     NESTED_USE_CLOUD_INIT: false


### PR DESCRIPTION
The idea is to simplify the code used to create images by creating
functions to prepare the snaps used to build the source images for the
nested tests.

This initial change includes snapd and kernel preparation.
