### PR TITLE
interfaces: add kconfig paths to system-observe

### DIFF
--- a/interfaces/builtin/system_observe.go
+++ b/interfaces/builtin/system_observe.go
@@ -94,7 +94,6 @@ ptrace (read),
 # Allow discovering the Kernel build config
 @{PROC}/config.gz r,
 /boot/config* r,
-/lib/modules/*/build/.config r,
 
 # Allow discovering system-wide CFS Bandwidth Control information
 # https://www.kernel.org/doc/html/latest/scheduler/sched-bwc.html

--- a/interfaces/builtin/system_observe.go
+++ b/interfaces/builtin/system_observe.go
@@ -92,7 +92,7 @@ ptrace (read),
 /var/lib/snapd/hostfs/usr/lib/os-release rk,
 
 # Allow discovering the Kernel build config
-/proc/config.gz r,
+@{PROC}/config.gz r,
 /boot/config* r,
 /lib/modules/*/build/.config r,
 

--- a/interfaces/builtin/system_observe.go
+++ b/interfaces/builtin/system_observe.go
@@ -91,6 +91,11 @@ ptrace (read),
 /var/lib/snapd/hostfs/etc/os-release rk,
 /var/lib/snapd/hostfs/usr/lib/os-release rk,
 
+# Allow discovering the Kernel build config
+/proc/config.gz r,
+/boot/config* r,
+/lib/modules/*/build/.config r,
+
 # Allow discovering system-wide CFS Bandwidth Control information
 # https://www.kernel.org/doc/html/latest/scheduler/sched-bwc.html
 /sys/fs/cgroup/cpu,cpuacct/cpu.cfs_period_us r,


### PR DESCRIPTION
This PR adds three paths to the `system-observe` interface to allow read-only access to the kernel build config.

x-ref: https://forum.snapcraft.io/t/new-interface-proposal-kernel-config/31253

