### PR TITLE
systemd: Do not mount snaps before `ostree-remount.service`

### DIFF
--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -1468,6 +1468,10 @@ const snapMountsPreTargetContentExtraZfs = `[Unit]
 After=zfs-mount.service
 `
 
+const snapMountsPreTargetContentExtraOstree = `[Unit]
+After=ostree-remount.service
+`
+
 func ensureTarget(name string, content string) error {
 	if !osutil.FileExists(name) {
 		outf, err := osutil.NewAtomicFile(name, 0644, 0, osutil.NoChown, osutil.NoChown)
@@ -1496,6 +1500,10 @@ func ensureTargets() error {
 	}
 	os.MkdirAll(filepath.Join(dirs.SnapServicesDir, "snap-mounts-pre.target.d"), 0755)
 	err = ensureTarget(filepath.Join(dirs.SnapServicesDir, "snap-mounts-pre.target.d/zfs-mount.conf"), snapMountsPreTargetContentExtraZfs)
+	if err != nil {
+		return err
+	}
+	err = ensureTarget(filepath.Join(dirs.SnapServicesDir, "snap-mounts-pre.target.d/ostree-remount.conf"), snapMountsPreTargetContentExtraOstree)
 	if err != nil {
 		return err
 	}

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -1165,7 +1165,10 @@ func (s *SystemdTestSuite) TestAddMountUnit(c *C) {
 [Unit]
 Description=Mount unit for foo, revision 42
 Before=snapd.service
-After=zfs-mount.service
+After=snap-mounts-pre.target
+Before=snap-mounts.target
+Wants=snap-mounts-pre.target
+Wants=snap-mounts.target
 
 [Mount]
 What=%s
@@ -1199,7 +1202,10 @@ func (s *SystemdTestSuite) TestAddMountUnitForDirs(c *C) {
 [Unit]
 Description=Mount unit for foodir, revision x1
 Before=snapd.service
-After=zfs-mount.service
+After=snap-mounts-pre.target
+Before=snap-mounts.target
+Wants=snap-mounts-pre.target
+Wants=snap-mounts.target
 
 [Mount]
 What=%s
@@ -1245,7 +1251,10 @@ func (s *SystemdTestSuite) TestAddMountUnitTransient(c *C) {
 [Unit]
 Description=Mount unit for foo via bar
 Before=snapd.service
-After=zfs-mount.service
+After=snap-mounts-pre.target
+Before=snap-mounts.target
+Wants=snap-mounts-pre.target
+Wants=snap-mounts.target
 
 [Mount]
 What=%s
@@ -1288,7 +1297,10 @@ func (s *SystemdTestSuite) TestWriteSELinuxMountUnit(c *C) {
 [Unit]
 Description=Mount unit for foo, revision 42
 Before=snapd.service
-After=zfs-mount.service
+After=snap-mounts-pre.target
+Before=snap-mounts.target
+Wants=snap-mounts-pre.target
+Wants=snap-mounts.target
 
 [Mount]
 What=%s
@@ -1332,7 +1344,10 @@ exit 0
 [Unit]
 Description=Mount unit for foo, revision x1
 Before=snapd.service
-After=zfs-mount.service
+After=snap-mounts-pre.target
+Before=snap-mounts.target
+Wants=snap-mounts-pre.target
+Wants=snap-mounts.target
 
 [Mount]
 What=%s
@@ -1372,7 +1387,10 @@ exit 0
 [Unit]
 Description=Mount unit for foo, revision x1
 Before=snapd.service
-After=zfs-mount.service
+After=snap-mounts-pre.target
+Before=snap-mounts.target
+Wants=snap-mounts-pre.target
+Wants=snap-mounts.target
 
 [Mount]
 What=%s
@@ -1636,7 +1654,10 @@ const unitTemplate = `
 [Unit]
 Description=Mount unit for foo, revision 42
 Before=snapd.service
-After=zfs-mount.service
+After=snap-mounts-pre.target
+Before=snap-mounts.target
+Wants=snap-mounts-pre.target
+Wants=snap-mounts.target
 
 [Mount]
 What=%s


### PR DESCRIPTION
This PR is in two parts. We do not really need the second part as it can be done by OSTree based systems. But the first part allows it to be done.

### systemd: Use targets to allow systems to integrate with snap mounts

Some systems require to delay or wait for snap mounts. Adding specific targets to group those mounts makes it possible to add `After=` or `Before=` to all the snap mounts.

That can be useful for example to mount after `zfs-mount.service` on some systems.

This moves the `After=zfs-mount.service` into a drop-in configuration for `snap-mounts-pre.target`. Having seperate drop-in configuration files allows future versions of snapd to add or remove them without having to track the version of target files.

### systemd: Add drop-in configuration for ostree-remount.service dependency

On OSTree systems, we should not mount snaps until `ostree-remount.service` is done. Otherwise we end up with duplicated mounts which prevents the Snap client from uninstalling or updating snaps.