### PR TITLE
go.mod: replace maze.io/x/crypto with local repo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,9 @@ module github.com/snapcore/snapd
 
 go 1.13
 
+// maze.io/x/crypto/afis imported by github.com/snapcore/secboot/tpm2
+replace maze.io/x/crypto => github.com/snapcore/maze.io-x-crypto v0.0.0-20190131090603-9b94c9afe066
+
 require (
 	github.com/canonical/go-efilib v0.0.0-20210909101908-41435fa545d4 // indirect
 	github.com/canonical/go-sp800.90a-drbg v0.0.0-20210314144037-6eeb1040d6c3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/snapcore/bolt v1.3.2-0.20210908134111-63c8bfcf7af8 h1:WmyDfH38e3MaMWr
 github.com/snapcore/bolt v1.3.2-0.20210908134111-63c8bfcf7af8/go.mod h1:Z6z3sf12AMDjT/4tbT/PmzzdACAxkWGhkuKWiVpTWLM=
 github.com/snapcore/go-gettext v0.0.0-20191107141714-82bbea49e785 h1:PaunR+BhraKSLxt2awQ42zofkP+NKh/VjQ0PjIMk/y4=
 github.com/snapcore/go-gettext v0.0.0-20191107141714-82bbea49e785/go.mod h1:D3SsWAXK7wCCBZu+Vk5hc1EuKj/L3XN1puEMXTU4LrQ=
+github.com/snapcore/maze.io-x-crypto v0.0.0-20190131090603-9b94c9afe066 h1:InG0EmriMOiI4YgtQNOo+6fNxzLCYioo3Q3BCVLdMCE=
+github.com/snapcore/maze.io-x-crypto v0.0.0-20190131090603-9b94c9afe066/go.mod h1:VuAdaITF1MrGzxPU+8GxagM1HW2vg7QhEFEeGHbmEMU=
 github.com/snapcore/secboot v0.0.0-20211018143212-802bb19ca263 h1:cq2rG4JcNBCwHvo7iNdJL4nb8Ns7L/aOUd1EFs2toFs=
 github.com/snapcore/secboot v0.0.0-20211018143212-802bb19ca263/go.mod h1:72paVOkm4sJugXt+v9ItmnjXgO921D8xqsbH2OekouY=
 github.com/snapcore/snapd v0.0.0-20201005140838-501d14ac146e/go.mod h1:3xrn7QDDKymcE5VO2rgWEQ5ZAUGb9htfwlXnoel6Io8=
@@ -85,5 +87,3 @@ gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-maze.io/x/crypto v0.0.0-20190131090603-9b94c9afe066 h1:UrD21H1Ue5Nl8f2x/NQJBRdc49YGmla3mRStinH8CCE=
-maze.io/x/crypto v0.0.0-20190131090603-9b94c9afe066/go.mod h1:DEvumi+swYmlKxSlnsvPwS15tRjoypCCeJFXswU5FfQ=

--- a/spread.yaml
+++ b/spread.yaml
@@ -3,10 +3,11 @@ project: snapd
 environment:
     GOHOME: /home/gopath
     GOPATH: $GOHOME
-    # on some distros the default GOPROXY setting is 'direct' (eg. Fedora), the
-    # go import tags of packages such as maze.io/x/crypt (which is one of
-    # secboot dependencies), cannot be obtained when poking the import URL
-    # directly, thus we need to force the golang.org hosted proxy to be used
+    # On some distros the default GOPROXY setting is 'direct' (eg. Fedora).
+    # Some of the external go packages may get removed or could be temporary
+    # offline (as happened with maze.io/x/crypt), and then the sources are
+    # only available through the proxy cache. Play it safe and enable the
+    # proxy to allow for least CI interruptions.
     GOPROXY: https://proxy.golang.org,direct
     REUSE_PROJECT: '$(HOST: echo "$REUSE_PROJECT")'
     PROJECT_PATH: $GOHOME/src/github.com/snapcore/snapd


### PR DESCRIPTION
The repo for maze.io/x/crypto is no longer accessible directly
(The Google cache date is May 2022).

If GOPROXY is enabled, the repo can still be indirectly located
through the proxy cache.

It is sometimes useful to have the proxy disabled (GOPROXY=direct)
as any upstream repository changes can take time to propagate to
the proxy (https://github.com/golang/go/issues/42449).

The crypto packages are currently needed in the secboot codebase
TPM package (https://github.com/snapcore/secboot). The secboot
repository is not currently a go module (no go.mod/go.sum) and is
built as part of the snapd build process.

Update the snapd module dependencies to redirect the old URL to
point to the exact same version on the Canonical hosted version of
the repository.

Tested with Go v1.13 and v1.18 running ./get-deps.sh

Signed-off-by: Fred Lotter <fred.lotter@canonical.com>

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
