### PR TITLE
daemon,usersession: switch from HeaderMap to Header in tests

### DIFF
--- a/daemon/api_apps_test.go
+++ b/daemon/api_apps_test.go
@@ -657,7 +657,7 @@ func (s *appsSuite) TestLogs(c *check.C) {
 	c.Check(s.jctlNamespaces, check.DeepEquals, []bool{false})
 
 	c.Check(rec.Code, check.Equals, 200)
-	c.Check(rec.HeaderMap.Get("Content-Type"), check.Equals, "application/json-seq")
+	c.Check(rec.Header().Get("Content-Type"), check.Equals, "application/json-seq")
 	c.Check(rec.Body.String(), check.Equals, `
 {"timestamp":"1970-01-01T00:00:00.000042Z","message":"hello1","sid":"xyzzy","pid":"42"}
 {"timestamp":"1970-01-01T00:00:00.000044Z","message":"hello2","sid":"xyzzy","pid":"42"}

--- a/daemon/api_asserts_test.go
+++ b/daemon/api_asserts_test.go
@@ -167,8 +167,8 @@ func (s *assertsSuite) TestAssertsFindManyAll(c *check.C) {
 	s.serveHTTP(c, rec, req)
 	// Verify
 	c.Check(rec.Code, check.Equals, 200, check.Commentf("body %q", rec.Body))
-	c.Check(rec.HeaderMap.Get("Content-Type"), check.Equals, "application/x.ubuntu.assertion; bundle=y")
-	c.Check(rec.HeaderMap.Get("X-Ubuntu-Assertions-Count"), check.Equals, "4")
+	c.Check(rec.Header().Get("Content-Type"), check.Equals, "application/x.ubuntu.assertion; bundle=y")
+	c.Check(rec.Header().Get("X-Ubuntu-Assertions-Count"), check.Equals, "4")
 	dec := asserts.NewDecoder(rec.Body)
 	a1, err := dec.Decode()
 	c.Assert(err, check.IsNil)
@@ -204,7 +204,7 @@ func (s *assertsSuite) TestAssertsFindManyFilter(c *check.C) {
 	s.serveHTTP(c, rec, req)
 	// Verify
 	c.Check(rec.Code, check.Equals, 200, check.Commentf("body %q", rec.Body))
-	c.Check(rec.HeaderMap.Get("X-Ubuntu-Assertions-Count"), check.Equals, "1")
+	c.Check(rec.Header().Get("X-Ubuntu-Assertions-Count"), check.Equals, "1")
 	dec := asserts.NewDecoder(rec.Body)
 	a1, err := dec.Decode()
 	c.Assert(err, check.IsNil)
@@ -228,7 +228,7 @@ func (s *assertsSuite) TestAssertsFindManyNoResults(c *check.C) {
 	s.serveHTTP(c, rec, req)
 	// Verify
 	c.Check(rec.Code, check.Equals, 200, check.Commentf("body %q", rec.Body))
-	c.Check(rec.HeaderMap.Get("X-Ubuntu-Assertions-Count"), check.Equals, "0")
+	c.Check(rec.Header().Get("X-Ubuntu-Assertions-Count"), check.Equals, "0")
 	dec := asserts.NewDecoder(rec.Body)
 	_, err = dec.Decode()
 	c.Check(err, check.Equals, io.EOF)
@@ -269,7 +269,7 @@ func (s *assertsSuite) testAssertsFindManyJSONFilter(c *check.C, urlPath string)
 	s.serveHTTP(c, rec, req)
 	// Verify
 	c.Check(rec.Code, check.Equals, 200, check.Commentf("body %q", rec.Body))
-	c.Check(rec.HeaderMap.Get("Content-Type"), check.Equals, "application/json")
+	c.Check(rec.Header().Get("Content-Type"), check.Equals, "application/json")
 
 	var body map[string]interface{}
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
@@ -294,7 +294,7 @@ func (s *assertsSuite) TestAssertsFindManyJSONNoResults(c *check.C) {
 	s.serveHTTP(c, rec, req)
 	// Verify
 	c.Check(rec.Code, check.Equals, 200, check.Commentf("body %q", rec.Body))
-	c.Check(rec.HeaderMap.Get("Content-Type"), check.Equals, "application/json")
+	c.Check(rec.Header().Get("Content-Type"), check.Equals, "application/json")
 
 	var body map[string]interface{}
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
@@ -315,7 +315,7 @@ func (s *assertsSuite) TestAssertsFindManyJSONWithBody(c *check.C) {
 	s.serveHTTP(c, rec, req)
 	// Verify
 	c.Check(rec.Code, check.Equals, 200, check.Commentf("body %q", rec.Body))
-	c.Check(rec.HeaderMap.Get("Content-Type"), check.Equals, "application/json")
+	c.Check(rec.Header().Get("Content-Type"), check.Equals, "application/json")
 
 	var got []string
 	var body map[string]interface{}
@@ -346,7 +346,7 @@ func (s *assertsSuite) TestAssertsFindManyJSONHeadersOnly(c *check.C) {
 	s.serveHTTP(c, rec, req)
 	// Verify
 	c.Check(rec.Code, check.Equals, 200, check.Commentf("body %q", rec.Body))
-	c.Check(rec.HeaderMap.Get("Content-Type"), check.Equals, "application/json")
+	c.Check(rec.Header().Get("Content-Type"), check.Equals, "application/json")
 
 	var got []string
 	var body map[string]interface{}
@@ -376,7 +376,7 @@ func (s *assertsSuite) TestAssertsFindManyJSONInvalidParam(c *check.C) {
 	s.serveHTTP(c, rec, req)
 	// Verify
 	c.Check(rec.Code, check.Equals, 400, check.Commentf("body %q", rec.Body))
-	c.Check(rec.HeaderMap.Get("Content-Type"), check.Equals, "application/json")
+	c.Check(rec.Header().Get("Content-Type"), check.Equals, "application/json")
 
 	var rsp daemon.RespJSON
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), check.IsNil)
@@ -400,7 +400,7 @@ func (s *assertsSuite) TestAssertsFindManyJSONNopFilter(c *check.C) {
 	s.serveHTTP(c, rec, req)
 	// Verify
 	c.Check(rec.Code, check.Equals, 200, check.Commentf("body %q", rec.Body))
-	c.Check(rec.HeaderMap.Get("X-Ubuntu-Assertions-Count"), check.Equals, "1")
+	c.Check(rec.Header().Get("X-Ubuntu-Assertions-Count"), check.Equals, "1")
 	dec := asserts.NewDecoder(rec.Body)
 	a1, err := dec.Decode()
 	c.Assert(err, check.IsNil)
@@ -421,7 +421,7 @@ func (s *assertsSuite) TestAssertsFindManyRemoteInvalidParam(c *check.C) {
 	s.serveHTTP(c, rec, req)
 	// Verify
 	c.Check(rec.Code, check.Equals, 400, check.Commentf("body %q", rec.Body))
-	c.Check(rec.HeaderMap.Get("Content-Type"), check.Equals, "application/json")
+	c.Check(rec.Header().Get("Content-Type"), check.Equals, "application/json")
 	var rsp daemon.RespJSON
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), check.IsNil)
 	c.Check(rsp.Status, check.Equals, 400)
@@ -457,7 +457,7 @@ func (s *assertsSuite) TestAssertsFindManyRemote(c *check.C) {
 	// Verify
 	c.Check(assertFnCalled, check.Equals, 1)
 	c.Check(rec.Code, check.Equals, 200, check.Commentf("body %q", rec.Body))
-	c.Check(rec.HeaderMap.Get("Content-Type"), check.Equals, "application/x.ubuntu.assertion; bundle=y")
+	c.Check(rec.Header().Get("Content-Type"), check.Equals, "application/x.ubuntu.assertion; bundle=y")
 
 	data := rec.Body.Bytes()
 	c.Check(string(data), check.Matches, `(?ms)type: account

--- a/daemon/api_general_test.go
+++ b/daemon/api_general_test.go
@@ -61,7 +61,7 @@ func (s *generalSuite) TestRoot(c *check.C) {
 	rec := httptest.NewRecorder()
 	s.req(c, req, nil).ServeHTTP(rec, nil)
 	c.Check(rec.Code, check.Equals, 200)
-	c.Check(rec.HeaderMap.Get("Content-Type"), check.Equals, "application/json")
+	c.Check(rec.Header().Get("Content-Type"), check.Equals, "application/json")
 
 	expected := []interface{}{"TBD"}
 	var rsp daemon.RespJSON
@@ -107,7 +107,7 @@ func (s *generalSuite) TestSysInfo(c *check.C) {
 	rec := httptest.NewRecorder()
 	s.req(c, req, nil).ServeHTTP(rec, nil)
 	c.Check(rec.Code, check.Equals, 200)
-	c.Check(rec.HeaderMap.Get("Content-Type"), check.Equals, "application/json")
+	c.Check(rec.Header().Get("Content-Type"), check.Equals, "application/json")
 
 	expected := map[string]interface{}{
 		"series":  "16",
@@ -185,7 +185,7 @@ func (s *generalSuite) TestSysInfoLegacyRefresh(c *check.C) {
 	rec := httptest.NewRecorder()
 	s.req(c, req, nil).ServeHTTP(rec, nil)
 	c.Check(rec.Code, check.Equals, 200)
-	c.Check(rec.HeaderMap.Get("Content-Type"), check.Equals, "application/json")
+	c.Check(rec.Header().Get("Content-Type"), check.Equals, "application/json")
 
 	expected := map[string]interface{}{
 		"series":  "16",
@@ -265,7 +265,7 @@ func (s *generalSuite) testSysInfoSystemMode(c *check.C, mode string) {
 	rec := httptest.NewRecorder()
 	s.req(c, req, nil).ServeHTTP(rec, nil)
 	c.Check(rec.Code, check.Equals, 200)
-	c.Check(rec.HeaderMap.Get("Content-Type"), check.Equals, "application/json")
+	c.Check(rec.Header().Get("Content-Type"), check.Equals, "application/json")
 
 	expected := map[string]interface{}{
 		"series":  "16",

--- a/daemon/api_model_test.go
+++ b/daemon/api_model_test.go
@@ -178,7 +178,7 @@ func (s *modelSuite) TestGetModelHasModelAssertion(c *check.C) {
 
 	// check that we get an assertion response
 	c.Check(rec.Code, check.Equals, 200, check.Commentf("body %q", rec.Body))
-	c.Check(rec.HeaderMap.Get("Content-Type"), check.Equals, "application/x.ubuntu.assertion")
+	c.Check(rec.Header().Get("Content-Type"), check.Equals, "application/x.ubuntu.assertion")
 
 	// check that there is only one assertion
 	dec := asserts.NewDecoder(rec.Body)
@@ -300,7 +300,7 @@ func (s *modelSuite) TestGetModelHasSerialAssertion(c *check.C) {
 
 	// check that we get an assertion response
 	c.Check(rec.Code, check.Equals, 200, check.Commentf("body %q", rec.Body))
-	c.Check(rec.HeaderMap.Get("Content-Type"), check.Equals, "application/x.ubuntu.assertion")
+	c.Check(rec.Header().Get("Content-Type"), check.Equals, "application/x.ubuntu.assertion")
 
 	// check that there is only one assertion
 	dec := asserts.NewDecoder(rec.Body)

--- a/usersession/agent/rest_api_test.go
+++ b/usersession/agent/rest_api_test.go
@@ -103,7 +103,7 @@ func (s *restSuite) TestSessionInfo(c *C) {
 	rec := httptest.NewRecorder()
 	agent.SessionInfoCmd.GET(agent.SessionInfoCmd, nil).ServeHTTP(rec, nil)
 	c.Check(rec.Code, Equals, 200)
-	c.Check(rec.HeaderMap.Get("Content-Type"), Equals, "application/json")
+	c.Check(rec.Header().Get("Content-Type"), Equals, "application/json")
 
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), IsNil)
@@ -147,7 +147,7 @@ func (s *restSuite) testServiceControlDaemonReload(c *C, contentType string) {
 	rec := httptest.NewRecorder()
 	agent.ServiceControlCmd.POST(agent.ServiceControlCmd, req).ServeHTTP(rec, req)
 	c.Check(rec.Code, Equals, 200)
-	c.Check(rec.HeaderMap.Get("Content-Type"), Equals, "application/json")
+	c.Check(rec.Header().Get("Content-Type"), Equals, "application/json")
 
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), IsNil)
@@ -165,7 +165,7 @@ func (s *restSuite) TestServiceControlStart(c *C) {
 	rec := httptest.NewRecorder()
 	agent.ServiceControlCmd.POST(agent.ServiceControlCmd, req).ServeHTTP(rec, req)
 	c.Check(rec.Code, Equals, 200)
-	c.Check(rec.HeaderMap.Get("Content-Type"), Equals, "application/json")
+	c.Check(rec.Header().Get("Content-Type"), Equals, "application/json")
 
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), IsNil)
@@ -184,7 +184,7 @@ func (s *restSuite) TestServicesStartNonSnap(c *C) {
 	rec := httptest.NewRecorder()
 	agent.ServiceControlCmd.POST(agent.ServiceControlCmd, req).ServeHTTP(rec, req)
 	c.Check(rec.Code, Equals, 500)
-	c.Check(rec.HeaderMap.Get("Content-Type"), Equals, "application/json")
+	c.Check(rec.Header().Get("Content-Type"), Equals, "application/json")
 
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), IsNil)
@@ -213,7 +213,7 @@ func (s *restSuite) TestServicesStartFailureStopsServices(c *C) {
 	rec := httptest.NewRecorder()
 	agent.ServiceControlCmd.POST(agent.ServiceControlCmd, req).ServeHTTP(rec, req)
 	c.Check(rec.Code, Equals, 500)
-	c.Check(rec.HeaderMap.Get("Content-Type"), Equals, "application/json")
+	c.Check(rec.Header().Get("Content-Type"), Equals, "application/json")
 
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), IsNil)
@@ -256,7 +256,7 @@ func (s *restSuite) TestServicesStartFailureReportsStopFailures(c *C) {
 	rec := httptest.NewRecorder()
 	agent.ServiceControlCmd.POST(agent.ServiceControlCmd, req).ServeHTTP(rec, req)
 	c.Check(rec.Code, Equals, 500)
-	c.Check(rec.HeaderMap.Get("Content-Type"), Equals, "application/json")
+	c.Check(rec.Header().Get("Content-Type"), Equals, "application/json")
 
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), IsNil)
@@ -288,7 +288,7 @@ func (s *restSuite) TestServicesStop(c *C) {
 	rec := httptest.NewRecorder()
 	agent.ServiceControlCmd.POST(agent.ServiceControlCmd, req).ServeHTTP(rec, req)
 	c.Check(rec.Code, Equals, 200)
-	c.Check(rec.HeaderMap.Get("Content-Type"), Equals, "application/json")
+	c.Check(rec.Header().Get("Content-Type"), Equals, "application/json")
 
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), IsNil)
@@ -309,7 +309,7 @@ func (s *restSuite) TestServicesStopNonSnap(c *C) {
 	rec := httptest.NewRecorder()
 	agent.ServiceControlCmd.POST(agent.ServiceControlCmd, req).ServeHTTP(rec, req)
 	c.Check(rec.Code, Equals, 500)
-	c.Check(rec.HeaderMap.Get("Content-Type"), Equals, "application/json")
+	c.Check(rec.Header().Get("Content-Type"), Equals, "application/json")
 
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), IsNil)
@@ -341,7 +341,7 @@ func (s *restSuite) TestServicesStopReportsError(c *C) {
 	rec := httptest.NewRecorder()
 	agent.ServiceControlCmd.POST(agent.ServiceControlCmd, req).ServeHTTP(rec, req)
 	c.Check(rec.Code, Equals, 500)
-	c.Check(rec.HeaderMap.Get("Content-Type"), Equals, "application/json")
+	c.Check(rec.Header().Get("Content-Type"), Equals, "application/json")
 
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), IsNil)
@@ -368,7 +368,7 @@ func (s *restSuite) TestPostPendingRefreshNotificationMalformedContentType(c *C)
 	rec := httptest.NewRecorder()
 	agent.PendingRefreshNotificationCmd.POST(agent.PendingRefreshNotificationCmd, req).ServeHTTP(rec, req)
 	c.Check(rec.Code, Equals, 400)
-	c.Check(rec.HeaderMap.Get("Content-Type"), Equals, "application/json")
+	c.Check(rec.Header().Get("Content-Type"), Equals, "application/json")
 
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), IsNil)
@@ -382,7 +382,7 @@ func (s *restSuite) TestPostPendingRefreshNotificationUnsupportedContentType(c *
 	rec := httptest.NewRecorder()
 	agent.PendingRefreshNotificationCmd.POST(agent.PendingRefreshNotificationCmd, req).ServeHTTP(rec, req)
 	c.Check(rec.Code, Equals, 400)
-	c.Check(rec.HeaderMap.Get("Content-Type"), Equals, "application/json")
+	c.Check(rec.Header().Get("Content-Type"), Equals, "application/json")
 
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), IsNil)
@@ -396,7 +396,7 @@ func (s *restSuite) TestPostPendingRefreshNotificationUnsupportedContentEncoding
 	rec := httptest.NewRecorder()
 	agent.PendingRefreshNotificationCmd.POST(agent.PendingRefreshNotificationCmd, req).ServeHTTP(rec, req)
 	c.Check(rec.Code, Equals, 400)
-	c.Check(rec.HeaderMap.Get("Content-Type"), Equals, "application/json")
+	c.Check(rec.Header().Get("Content-Type"), Equals, "application/json")
 
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), IsNil)
@@ -411,7 +411,7 @@ func (s *restSuite) TestPostPendingRefreshNotificationMalformedRequestBody(c *C)
 	rec := httptest.NewRecorder()
 	agent.PendingRefreshNotificationCmd.POST(agent.PendingRefreshNotificationCmd, req).ServeHTTP(rec, req)
 	c.Check(rec.Code, Equals, 400)
-	c.Check(rec.HeaderMap.Get("Content-Type"), Equals, "application/json")
+	c.Check(rec.Header().Get("Content-Type"), Equals, "application/json")
 
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), IsNil)
@@ -429,7 +429,7 @@ func (s *restSuite) TestPostPendingRefreshNotificationNoSessionBus(c *C) {
 	rec := httptest.NewRecorder()
 	agent.PendingRefreshNotificationCmd.POST(agent.PendingRefreshNotificationCmd, req).ServeHTTP(rec, req)
 	c.Check(rec.Code, Equals, 500)
-	c.Check(rec.HeaderMap.Get("Content-Type"), Equals, "application/json")
+	c.Check(rec.Header().Get("Content-Type"), Equals, "application/json")
 
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), IsNil)
@@ -445,7 +445,7 @@ func (s *restSuite) testPostPendingRefreshNotificationBody(c *C, refreshInfo *cl
 	rec := httptest.NewRecorder()
 	agent.PendingRefreshNotificationCmd.POST(agent.PendingRefreshNotificationCmd, req).ServeHTTP(rec, req)
 	c.Check(rec.Code, Equals, 200)
-	c.Check(rec.HeaderMap.Get("Content-Type"), Equals, "application/json")
+	c.Check(rec.Header().Get("Content-Type"), Equals, "application/json")
 
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), IsNil)
@@ -589,7 +589,7 @@ func (s *restSuite) TestPostPendingRefreshNotificationNotificationServerFailure(
 	rec := httptest.NewRecorder()
 	agent.PendingRefreshNotificationCmd.POST(agent.PendingRefreshNotificationCmd, req).ServeHTTP(rec, req)
 	c.Check(rec.Code, Equals, 500)
-	c.Check(rec.HeaderMap.Get("Content-Type"), Equals, "application/json")
+	c.Check(rec.Header().Get("Content-Type"), Equals, "application/json")
 
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), IsNil)
@@ -605,7 +605,7 @@ func (s *restSuite) testPostFinishRefreshNotificationBody(c *C, refreshInfo *cli
 	rec := httptest.NewRecorder()
 	agent.FinishRefreshNotificationCmd.POST(agent.PendingRefreshNotificationCmd, req).ServeHTTP(rec, req)
 	c.Check(rec.Code, Equals, 200)
-	c.Check(rec.HeaderMap.Get("Content-Type"), Equals, "application/json")
+	c.Check(rec.Header().Get("Content-Type"), Equals, "application/json")
 
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), IsNil)


### PR DESCRIPTION
The `rec.HeaderMap` is deprecated since go1.11 and the
`rec.Header()` method should be used instead. This commit
does this switch.

Found by https://staticcheck.io/ which was suggested by Fred,
thanks for this.
