### PR TITLE
testutil: remove unneeded `fmt.Sprintf`

### DIFF
--- a/testutil/errorischecker.go
+++ b/testutil/errorischecker.go
@@ -21,7 +21,6 @@ package testutil
 
 import (
 	"errors"
-	"fmt"
 
 	"gopkg.in/check.v1"
 )
@@ -42,12 +41,12 @@ func (*errorIsChecker) Check(params []interface{}, names []string) (result bool,
 
 	err, ok := params[0].(error)
 	if !ok {
-		return false, fmt.Sprintf("first argument must be an error")
+		return false, "first argument must be an error"
 	}
 
 	target, ok := params[1].(error)
 	if !ok {
-		return false, fmt.Sprintf("second argument must be an error")
+		return false, "second argument must be an error"
 	}
 
 	return errors.Is(err, target), ""


### PR DESCRIPTION
As suggested by staticcheck.io
