### PR TITLE
asserts: add some missing `c.Check()` in the asserts test

### DIFF
--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -630,6 +630,7 @@ func (as *assertsSuite) TestEncoderDecoderHappy(c *C) {
 
 	a, err = decoder.Decode()
 	c.Assert(err, Equals, io.EOF)
+	c.Check(a, IsNil)
 }
 
 func (as *assertsSuite) TestDecodeEmptyStream(c *C) {

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -1547,6 +1547,7 @@ func (safs *signAddFindSuite) TestFindMaxFormat(c *C) {
 		"primary-key": "foo",
 	}, 3)
 	c.Check(err, ErrorMatches, `cannot find "test-only" assertions for format 3 higher than supported format 1`)
+	c.Check(a, IsNil)
 }
 
 func (safs *signAddFindSuite) TestFindOptionalPrimaryKeys(c *C) {

--- a/asserts/fsbackstore_test.go
+++ b/asserts/fsbackstore_test.go
@@ -538,10 +538,12 @@ func (fsbss *fsBackstoreSuite) TestOptionalPrimaryKeys(c *C) {
 	c.Check(err, DeepEquals, &asserts.NotFoundError{
 		Type: asserts.TestOnlyType,
 	})
+	c.Check(a, IsNil)
 	a, err = bs.Get(asserts.TestOnlyType, []string{"k5", "o1-a6"}, 0)
 	c.Check(err, DeepEquals, &asserts.NotFoundError{
 		Type: asserts.TestOnlyType,
 	})
+	c.Check(a, IsNil)
 
 	// revert to initial type definition
 	r()
@@ -555,6 +557,7 @@ func (fsbss *fsBackstoreSuite) TestOptionalPrimaryKeys(c *C) {
 	c.Check(err, DeepEquals, &asserts.NotFoundError{
 		Type: asserts.TestOnlyType,
 	})
+	c.Check(a, IsNil)
 	a, err = bs.Get(asserts.TestOnlyType, []string{"k4"}, 0)
 	c.Assert(err, IsNil)
 	c.Check(a.Ref().PrimaryKey, DeepEquals, []string{"k4"})
@@ -562,6 +565,7 @@ func (fsbss *fsBackstoreSuite) TestOptionalPrimaryKeys(c *C) {
 	c.Check(err, DeepEquals, &asserts.NotFoundError{
 		Type: asserts.TestOnlyType,
 	})
+	c.Check(a, IsNil)
 }
 
 func (fsbss *fsBackstoreSuite) TestOptionalPrimaryKeysSearch(c *C) {

--- a/asserts/membackstore_test.go
+++ b/asserts/membackstore_test.go
@@ -255,12 +255,14 @@ func (mbss *memBackstoreSuite) TestGetFormat(c *C) {
 
 	a, err = bs.Get(asserts.TestOnlyType, []string{"zoo"}, 0)
 	c.Assert(err, FitsTypeOf, &asserts.NotFoundError{})
+	c.Check(a, IsNil)
 
 	err = bs.Put(asserts.TestOnlyType, af2)
 	c.Assert(err, IsNil)
 
 	a, err = bs.Get(asserts.TestOnlyType, []string{"zoo"}, 1)
 	c.Assert(err, FitsTypeOf, &asserts.NotFoundError{})
+	c.Check(a, IsNil)
 
 	a, err = bs.Get(asserts.TestOnlyType, []string{"zoo"}, 2)
 	c.Assert(err, IsNil)
@@ -418,6 +420,7 @@ func (mbss *memBackstoreSuite) TestPutSequence(c *C) {
 	c.Assert(err, DeepEquals, &asserts.NotFoundError{
 		Type: asserts.TestOnlySeqType,
 	})
+	c.Check(a, IsNil)
 
 	a, err = bs.Get(asserts.TestOnlySeqType, []string{"s1", "3"}, 1)
 	c.Assert(err, IsNil)
@@ -587,9 +590,11 @@ func (mbss *memBackstoreSuite) TestOptionalPrimaryKeys(c *C) {
 	c.Check(err, DeepEquals, &asserts.NotFoundError{
 		Type: asserts.TestOnlyType,
 	})
+	c.Check(a, IsNil)
 
 	a, err = bs.Get(asserts.TestOnlyType, []string{}, 0)
 	c.Check(err, ErrorMatches, `internal error: Backstore.Get given a key missing mandatory elements for "test-only":.*`)
+	c.Check(a, IsNil)
 
 	var found map[string]string
 	cb := func(a asserts.Assertion) {


### PR DESCRIPTION
The staticcheck.io complained that in some places in the
assert tests values are assigned but not used. This commit
fixes this by checking the values. Alternatives we could
of course just use `_, err := ...` instead of `a, err := ...`
but checking seems slightly more sensible to me.
