### PR TITLE
many: add Is{Core,Classic}Boot() to DeviceContext

### DIFF
--- a/boot/boottest/device.go
+++ b/boot/boottest/device.go
@@ -54,12 +54,12 @@ func MockDevice(s string) snap.Device {
 	}
 }
 
-// MockDeviceWithModes implements boot.Device and returns true for
+// mockDeviceWithModes implements boot.Device and returns true for
 // HasModeenv.  Arguments are mode (empty means "run"), model, and a
 // boolean specifying if this is a classic with modes or a UC device.
 // If model is nil a default model is used (MakeMockUC20Model or
 // MakeMockClassicWithModesModel is called).
-func MockDeviceWithModes(mode string, model *asserts.Model, isClassic bool) snap.Device {
+func mockDeviceWithModes(mode string, model *asserts.Model, isClassic bool) snap.Device {
 	if mode == "" {
 		mode = "run"
 	}
@@ -82,15 +82,21 @@ func MockDeviceWithModes(mode string, model *asserts.Model, isClassic bool) snap
 // MockUC20Device mocks a UC with modes device.
 // Arguments are mode (empty means "run"), and model.
 func MockUC20Device(mode string, model *asserts.Model) snap.Device {
+	if model.Classic() {
+		panic("MockUC20Device called with classic model")
+	}
 	isClassic := false
-	return MockDeviceWithModes(mode, model, isClassic)
+	return mockDeviceWithModes(mode, model, isClassic)
 }
 
-// MockClassicBootDevice mocks a classic with modes device.
+// MockClassicWithModesDevice mocks a classic with modes device.
 // Arguments are mode (empty means "run"), and model.
-func MockClassicBootDevice(mode string, model *asserts.Model) snap.Device {
+func MockClassicWithModesDevice(mode string, model *asserts.Model) snap.Device {
+	if !model.Classic() {
+		panic("MockClassicWithModesDevice called with Ubuntu Core model")
+	}
 	isClassic := true
-	return MockDeviceWithModes(mode, model, isClassic)
+	return mockDeviceWithModes(mode, model, isClassic)
 }
 
 func snapAndMode(str string) (snap, mode string, uc20 bool) {

--- a/boot/boottest/device.go
+++ b/boot/boottest/device.go
@@ -82,7 +82,7 @@ func mockDeviceWithModes(mode string, model *asserts.Model, isClassic bool) snap
 // MockUC20Device mocks a UC with modes device.
 // Arguments are mode (empty means "run"), and model.
 func MockUC20Device(mode string, model *asserts.Model) snap.Device {
-	if model.Classic() {
+	if model != nil && model.Classic() {
 		panic("MockUC20Device called with classic model")
 	}
 	isClassic := false
@@ -92,7 +92,7 @@ func MockUC20Device(mode string, model *asserts.Model) snap.Device {
 // MockClassicWithModesDevice mocks a classic with modes device.
 // Arguments are mode (empty means "run"), and model.
 func MockClassicWithModesDevice(mode string, model *asserts.Model) snap.Device {
-	if !model.Classic() {
+	if model != nil && !model.Classic() {
 		panic("MockClassicWithModesDevice called with Ubuntu Core model")
 	}
 	isClassic := true

--- a/boot/boottest/device.go
+++ b/boot/boottest/device.go
@@ -27,9 +27,10 @@ import (
 )
 
 type mockDevice struct {
-	bootSnap string
-	mode     string
-	uc20     bool
+	bootSnap  string
+	mode      string
+	hasModes  bool
+	isClassic bool
 
 	model *asserts.Model
 }
@@ -46,28 +47,50 @@ func MockDevice(s string) snap.Device {
 		panic("MockDevice with no snap name and @mode is unsupported")
 	}
 	return &mockDevice{
-		bootSnap: bootsnap,
-		mode:     mode,
-		uc20:     uc20,
+		bootSnap:  bootsnap,
+		mode:      mode,
+		hasModes:  uc20,
+		isClassic: bootsnap == "",
 	}
 }
 
-// MockUC20Device implements boot.Device and returns true for HasModeenv.
-// Arguments are mode (empty means "run"), and model.
-// If model is nil a default model is used (same as MakeMockUC20Model).
-func MockUC20Device(mode string, model *asserts.Model) snap.Device {
+// MockDeviceWithModes implements boot.Device and returns true for
+// HasModeenv.  Arguments are mode (empty means "run"), model, and a
+// boolean specifying if this is a classic with modes or a UC device.
+// If model is nil a default model is used (MakeMockUC20Model or
+// MakeMockClassicWithModesModel is called).
+func MockDeviceWithModes(mode string, model *asserts.Model, isClassic bool) snap.Device {
 	if mode == "" {
 		mode = "run"
 	}
 	if model == nil {
-		model = MakeMockUC20Model()
+		if isClassic {
+			model = MakeMockClassicWithModesModel()
+		} else {
+			model = MakeMockUC20Model()
+		}
 	}
 	return &mockDevice{
-		bootSnap: model.Kernel(),
-		mode:     mode,
-		uc20:     true,
-		model:    model,
+		bootSnap:  model.Kernel(),
+		mode:      mode,
+		hasModes:  true,
+		isClassic: isClassic,
+		model:     model,
 	}
+}
+
+// MockUC20Device mocks a UC with modes device.
+// Arguments are mode (empty means "run"), and model.
+func MockUC20Device(mode string, model *asserts.Model) snap.Device {
+	isClassic := false
+	return MockDeviceWithModes(mode, model, isClassic)
+}
+
+// MockClassicBootDevice mocks a classic with modes device.
+// Arguments are mode (empty means "run"), and model.
+func MockClassicBootDevice(mode string, model *asserts.Model) snap.Device {
+	isClassic := true
+	return MockDeviceWithModes(mode, model, isClassic)
 }
 
 func snapAndMode(str string) (snap, mode string, uc20 bool) {
@@ -78,10 +101,12 @@ func snapAndMode(str string) (snap, mode string, uc20 bool) {
 	return parts[0], parts[1], true
 }
 
-func (d *mockDevice) Kernel() string   { return d.bootSnap }
-func (d *mockDevice) Classic() bool    { return d.bootSnap == "" }
-func (d *mockDevice) RunMode() bool    { return d.mode == "run" }
-func (d *mockDevice) HasModeenv() bool { return d.uc20 }
+func (d *mockDevice) Kernel() string      { return d.bootSnap }
+func (d *mockDevice) Classic() bool       { return d.isClassic }
+func (d *mockDevice) RunMode() bool       { return d.mode == "run" }
+func (d *mockDevice) HasModeenv() bool    { return d.hasModes }
+func (d *mockDevice) IsCoreBoot() bool    { return d.hasModes || !d.isClassic }
+func (d *mockDevice) IsClassicBoot() bool { return !d.IsCoreBoot() }
 func (d *mockDevice) Base() string {
 	if d.model != nil {
 		return d.model.Base()

--- a/boot/boottest/device_test.go
+++ b/boot/boottest/device_test.go
@@ -85,13 +85,15 @@ func (s *boottestSuite) TestMockDeviceBaseOrKernel(c *C) {
 }
 
 func (s *boottestSuite) testMockDeviceWithModes(c *C, isUC bool) {
-	mockBuilder := boottest.MockClassicWithModesDevice
+	makeMockModel := boottest.MakeMockClassicWithModesModel
+	makeMockDevice := boottest.MockClassicWithModesDevice
 	modelName := "my-model-classic-modes"
 	if isUC {
-		mockBuilder = boottest.MockUC20Device
+		makeMockModel = boottest.MakeMockUC20Model
+		makeMockDevice = boottest.MockUC20Device
 		modelName = "my-model-uc20"
 	}
-	dev := mockBuilder("", nil)
+	dev := makeMockDevice("", nil)
 	c.Check(dev.HasModeenv(), Equals, true)
 	c.Check(dev.Classic(), Equals, !isUC)
 	c.Check(dev.RunMode(), Equals, true)
@@ -103,13 +105,13 @@ func (s *boottestSuite) testMockDeviceWithModes(c *C, isUC bool) {
 
 	c.Check(dev.Model().Model(), Equals, modelName)
 
-	dev = mockBuilder("run", nil)
+	dev = makeMockDevice("run", nil)
 	c.Check(dev.RunMode(), Equals, true)
 
-	dev = mockBuilder("recover", nil)
+	dev = makeMockDevice("recover", nil)
 	c.Check(dev.RunMode(), Equals, false)
 
-	model := boottest.MakeMockUC20Model(map[string]interface{}{
+	model := makeMockModel(map[string]interface{}{
 		"model": "other-model-uc20",
 		"snaps": []interface{}{
 			map[string]interface{}{
@@ -124,7 +126,7 @@ func (s *boottestSuite) testMockDeviceWithModes(c *C, isUC bool) {
 			},
 		},
 	})
-	dev = mockBuilder("recover", model)
+	dev = makeMockDevice("recover", model)
 	c.Check(dev.RunMode(), Equals, false)
 	c.Check(dev.Kernel(), Equals, "pc-linux")
 	c.Check(dev.Model().Model(), Equals, "other-model-uc20")

--- a/boot/boottest/device_test.go
+++ b/boot/boottest/device_test.go
@@ -85,7 +85,7 @@ func (s *boottestSuite) TestMockDeviceBaseOrKernel(c *C) {
 }
 
 func (s *boottestSuite) testMockDeviceWithModes(c *C, isUC bool) {
-	mockBuilder := boottest.MockClassicBootDevice
+	mockBuilder := boottest.MockClassicWithModesDevice
 	modelName := "my-model-classic-modes"
 	if isUC {
 		mockBuilder = boottest.MockUC20Device

--- a/boot/boottest/model.go
+++ b/boot/boottest/model.go
@@ -68,3 +68,33 @@ func MakeMockUC20Model(overrides ...map[string]interface{}) *asserts.Model {
 	}
 	return assertstest.FakeAssertion(append([]map[string]interface{}{headers}, overrides...)...).(*asserts.Model)
 }
+
+func MakeMockClassicWithModesModel(overrides ...map[string]interface{}) *asserts.Model {
+	headers := map[string]interface{}{
+		"type":         "model",
+		"classic":      "true",
+		"distribution": "ubuntu",
+		"authority-id": "my-brand",
+		"series":       "16",
+		"brand-id":     "my-brand",
+		"model":        "my-model-classic-modes",
+		"display-name": "My Model",
+		"architecture": "amd64",
+		"base":         "core20",
+		"grade":        "dangerous",
+		"timestamp":    "2019-11-01T08:00:00+00:00",
+		"snaps": []interface{}{
+			map[string]interface{}{
+				"name": "pc-kernel",
+				"id":   "pckernelidididididididididididid",
+				"type": "kernel",
+			},
+			map[string]interface{}{
+				"name": "pc",
+				"id":   "pcididididididididididididididid",
+				"type": "gadget",
+			},
+		},
+	}
+	return assertstest.FakeAssertion(append([]map[string]interface{}{headers}, overrides...)...).(*asserts.Model)
+}

--- a/overlord/devicestate/devicectx.go
+++ b/overlord/devicestate/devicectx.go
@@ -105,13 +105,15 @@ func (dc groundDeviceContext) HasModeenv() bool {
 }
 
 // IsCoreBoot is true when there are modes, or when there are not but
-// we are not in classic (UC16/18 case)
+// we are not in classic (UC16/18 case). If true this implies that a
+// kernel snap is in use.
 func (d *groundDeviceContext) IsCoreBoot() bool {
 	return d.HasModeenv() || !d.Classic()
 }
 
-// IsClassicBoot is true for classic systems with classic initramfs (there
-// are no system modes in this case)
+// IsClassicBoot is true for classic systems with classic initramfs
+// (there are no system modes in this case). If true, the kernel comes
+// from debian packages.
 func (d *groundDeviceContext) IsClassicBoot() bool {
 	return !d.IsCoreBoot()
 }

--- a/overlord/devicestate/devicectx.go
+++ b/overlord/devicestate/devicectx.go
@@ -104,6 +104,17 @@ func (dc groundDeviceContext) HasModeenv() bool {
 	return dc.model.Grade() != asserts.ModelGradeUnset
 }
 
+// IsCoreBoot is true when there are modes, or when there are not but
+// we are not in classic (UC16/18 case)
+func (d *groundDeviceContext) IsCoreBoot() bool {
+	return d.HasModeenv() || !d.Classic()
+}
+
+// IsClassicBoot is true for classic systems with classic initramfs
+func (d *groundDeviceContext) IsClassicBoot() bool {
+	return !d.IsCoreBoot()
+}
+
 // expected interface is implemented
 var _ snapstate.DeviceContext = &groundDeviceContext{}
 

--- a/overlord/devicestate/devicectx.go
+++ b/overlord/devicestate/devicectx.go
@@ -110,7 +110,8 @@ func (d *groundDeviceContext) IsCoreBoot() bool {
 	return d.HasModeenv() || !d.Classic()
 }
 
-// IsClassicBoot is true for classic systems with classic initramfs
+// IsClassicBoot is true for classic systems with classic initramfs (there
+// are no system modes in this case)
 func (d *groundDeviceContext) IsClassicBoot() bool {
 	return !d.IsCoreBoot()
 }

--- a/overlord/devicestate/devicectx_test.go
+++ b/overlord/devicestate/devicectx_test.go
@@ -42,6 +42,15 @@ var _ = Suite(&deviceCtxSuite{})
 func (s *deviceCtxSuite) SetUpTest(c *C) {
 }
 
+func testGroundDeviceContextCommonChecks(c *C, devCtx snapstate.DeviceContext) {
+	c.Check(devCtx.RunMode(), Equals, true)
+	c.Check(devCtx.GroundContext(), Equals, devCtx)
+	c.Check(func() { devCtx.Store() }, PanicMatches,
+		"retrieved ground context is not intended to drive store operations")
+	c.Check(devCtx.ForRemodeling(), Equals, false)
+	c.Check(devCtx.SystemMode(), Equals, "run")
+}
+
 func (s *deviceCtxSuite) TestGroundDeviceContext(c *C) {
 	var devCtx snapstate.DeviceContext
 
@@ -58,7 +67,6 @@ func (s *deviceCtxSuite) TestGroundDeviceContext(c *C) {
 		"timestamp":    "2018-01-01T08:00:00+00:00",
 	}).(*asserts.Model)
 	devCtx = devicestate.BuildGroundDeviceContext(classModel, "run")
-	c.Check(devCtx.RunMode(), Equals, true)
 	c.Check(devCtx.Classic(), Equals, true)
 	c.Check(devCtx.Kernel(), Equals, "")
 	c.Check(devCtx.Base(), Equals, "")
@@ -67,6 +75,7 @@ func (s *deviceCtxSuite) TestGroundDeviceContext(c *C) {
 	c.Check(devCtx.IsCoreBoot(), Equals, false)
 	c.Check(devCtx.IsClassicBoot(), Equals, true)
 	c.Check(devCtx.Model(), DeepEquals, classModel)
+	testGroundDeviceContextCommonChecks(c, devCtx)
 
 	// UC16/18
 	legacyUCModel := boottest.MakeMockModel()
@@ -80,6 +89,7 @@ func (s *deviceCtxSuite) TestGroundDeviceContext(c *C) {
 	c.Check(devCtx.IsCoreBoot(), Equals, true)
 	c.Check(devCtx.IsClassicBoot(), Equals, false)
 	c.Check(devCtx.Model(), DeepEquals, legacyUCModel)
+	testGroundDeviceContextCommonChecks(c, devCtx)
 
 	// UC20+
 	ucModel := boottest.MakeMockUC20Model()
@@ -93,6 +103,7 @@ func (s *deviceCtxSuite) TestGroundDeviceContext(c *C) {
 	c.Check(devCtx.IsCoreBoot(), Equals, true)
 	c.Check(devCtx.IsClassicBoot(), Equals, false)
 	c.Check(devCtx.Model(), DeepEquals, ucModel)
+	testGroundDeviceContextCommonChecks(c, devCtx)
 
 	// Classic with modes
 	classWithModes := boottest.MakeMockClassicWithModesModel()
@@ -106,4 +117,5 @@ func (s *deviceCtxSuite) TestGroundDeviceContext(c *C) {
 	c.Check(devCtx.IsCoreBoot(), Equals, true)
 	c.Check(devCtx.IsClassicBoot(), Equals, false)
 	c.Check(devCtx.Model(), DeepEquals, classWithModes)
+	testGroundDeviceContextCommonChecks(c, devCtx)
 }

--- a/overlord/devicestate/devicectx_test.go
+++ b/overlord/devicestate/devicectx_test.go
@@ -42,9 +42,10 @@ var _ = Suite(&deviceCtxSuite{})
 func (s *deviceCtxSuite) SetUpTest(c *C) {
 }
 
-func (s *deviceCtxSuite) TestInUseClassic(c *C) {
+func (s *deviceCtxSuite) TestGroundDeviceContext(c *C) {
 	var devCtx snapstate.DeviceContext
 
+	// Classic with classic initramfs
 	classModel := assertstest.FakeAssertion(map[string]interface{}{
 		"type":         "model",
 		"classic":      "true",
@@ -67,6 +68,7 @@ func (s *deviceCtxSuite) TestInUseClassic(c *C) {
 	c.Check(devCtx.IsClassicBoot(), Equals, true)
 	c.Check(devCtx.Model(), DeepEquals, classModel)
 
+	// UC16/18
 	legacyUCModel := boottest.MakeMockModel()
 	devCtx = devicestate.BuildGroundDeviceContext(legacyUCModel, "run")
 	c.Check(devCtx.RunMode(), Equals, true)
@@ -79,6 +81,7 @@ func (s *deviceCtxSuite) TestInUseClassic(c *C) {
 	c.Check(devCtx.IsClassicBoot(), Equals, false)
 	c.Check(devCtx.Model(), DeepEquals, legacyUCModel)
 
+	// UC20+
 	ucModel := boottest.MakeMockUC20Model()
 	devCtx = devicestate.BuildGroundDeviceContext(ucModel, "run")
 	c.Check(devCtx.RunMode(), Equals, true)
@@ -91,6 +94,7 @@ func (s *deviceCtxSuite) TestInUseClassic(c *C) {
 	c.Check(devCtx.IsClassicBoot(), Equals, false)
 	c.Check(devCtx.Model(), DeepEquals, ucModel)
 
+	// Classic with modes
 	classWithModes := boottest.MakeMockClassicWithModesModel()
 	devCtx = devicestate.BuildGroundDeviceContext(classWithModes, "run")
 	c.Check(devCtx.RunMode(), Equals, true)

--- a/overlord/devicestate/devicectx_test.go
+++ b/overlord/devicestate/devicectx_test.go
@@ -1,0 +1,105 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package devicestate_test
+
+import (
+	"testing"
+
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/asserts/assertstest"
+	"github.com/snapcore/snapd/boot/boottest"
+	"github.com/snapcore/snapd/overlord/devicestate"
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/testutil"
+	. "gopkg.in/check.v1"
+)
+
+func TestBoot(t *testing.T) { TestingT(t) }
+
+type deviceCtxSuite struct {
+	testutil.BaseTest
+}
+
+var _ = Suite(&deviceCtxSuite{})
+
+func (s *deviceCtxSuite) SetUpTest(c *C) {
+}
+
+func (s *deviceCtxSuite) TestInUseClassic(c *C) {
+	var devCtx snapstate.DeviceContext
+
+	classModel := assertstest.FakeAssertion(map[string]interface{}{
+		"type":         "model",
+		"classic":      "true",
+		"authority-id": "my-brand",
+		"series":       "16",
+		"brand-id":     "my-brand",
+		"model":        "my-model",
+		"display-name": "My Model",
+		"architecture": "amd64",
+		"timestamp":    "2018-01-01T08:00:00+00:00",
+	}).(*asserts.Model)
+	devCtx = devicestate.BuildGroundDeviceContext(classModel, "run")
+	c.Check(devCtx.RunMode(), Equals, true)
+	c.Check(devCtx.Classic(), Equals, true)
+	c.Check(devCtx.Kernel(), Equals, "")
+	c.Check(devCtx.Base(), Equals, "")
+	c.Check(devCtx.Gadget(), Equals, "")
+	c.Check(devCtx.HasModeenv(), Equals, false)
+	c.Check(devCtx.IsCoreBoot(), Equals, false)
+	c.Check(devCtx.IsClassicBoot(), Equals, true)
+	c.Check(devCtx.Model(), DeepEquals, classModel)
+
+	legacyUCModel := boottest.MakeMockModel()
+	devCtx = devicestate.BuildGroundDeviceContext(legacyUCModel, "run")
+	c.Check(devCtx.RunMode(), Equals, true)
+	c.Check(devCtx.Classic(), Equals, false)
+	c.Check(devCtx.Kernel(), Equals, "pc-kernel")
+	c.Check(devCtx.Base(), Equals, "core18")
+	c.Check(devCtx.Gadget(), Equals, "pc")
+	c.Check(devCtx.HasModeenv(), Equals, false)
+	c.Check(devCtx.IsCoreBoot(), Equals, true)
+	c.Check(devCtx.IsClassicBoot(), Equals, false)
+	c.Check(devCtx.Model(), DeepEquals, legacyUCModel)
+
+	ucModel := boottest.MakeMockUC20Model()
+	devCtx = devicestate.BuildGroundDeviceContext(ucModel, "run")
+	c.Check(devCtx.RunMode(), Equals, true)
+	c.Check(devCtx.Classic(), Equals, false)
+	c.Check(devCtx.Kernel(), Equals, "pc-kernel")
+	c.Check(devCtx.Base(), Equals, "core20")
+	c.Check(devCtx.Gadget(), Equals, "pc")
+	c.Check(devCtx.HasModeenv(), Equals, true)
+	c.Check(devCtx.IsCoreBoot(), Equals, true)
+	c.Check(devCtx.IsClassicBoot(), Equals, false)
+	c.Check(devCtx.Model(), DeepEquals, ucModel)
+
+	classWithModes := boottest.MakeMockClassicWithModesModel()
+	devCtx = devicestate.BuildGroundDeviceContext(classWithModes, "run")
+	c.Check(devCtx.RunMode(), Equals, true)
+	c.Check(devCtx.Classic(), Equals, true)
+	c.Check(devCtx.Kernel(), Equals, "pc-kernel")
+	c.Check(devCtx.Base(), Equals, "core20")
+	c.Check(devCtx.Gadget(), Equals, "pc")
+	c.Check(devCtx.HasModeenv(), Equals, true)
+	c.Check(devCtx.IsCoreBoot(), Equals, true)
+	c.Check(devCtx.IsClassicBoot(), Equals, false)
+	c.Check(devCtx.Model(), DeepEquals, classWithModes)
+}

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -445,3 +445,7 @@ func MockSecbootMarkSuccessful(f func() error) (restore func()) {
 	secbootMarkSuccessful = f
 	return r
 }
+
+func BuildGroundDeviceContext(model *asserts.Model, mode string) snapstate.DeviceContext {
+	return &groundDeviceContext{model: model, systemMode: mode}
+}

--- a/overlord/snapstate/snapstatetest/devicectx.go
+++ b/overlord/snapstate/snapstatetest/devicectx.go
@@ -74,6 +74,14 @@ func (dc *TrivialDeviceContext) HasModeenv() bool {
 	return dc.Model().Grade() != asserts.ModelGradeUnset
 }
 
+func (d *TrivialDeviceContext) IsCoreBoot() bool {
+	return d.HasModeenv() || !d.Classic()
+}
+
+func (d *TrivialDeviceContext) IsClassicBoot() bool {
+	return !d.IsCoreBoot()
+}
+
 func (dc *TrivialDeviceContext) RunMode() bool {
 	return dc.SystemMode() == "run"
 }

--- a/snap/device.go
+++ b/snap/device.go
@@ -33,6 +33,8 @@ type Device interface {
 	Gadget() string
 
 	HasModeenv() bool
+	IsCoreBoot() bool    // true if UC or classic with modes
+	IsClassicBoot() bool // true if classic with classic initramfs
 
 	Model() *asserts.Model
 }

--- a/snap/device.go
+++ b/snap/device.go
@@ -33,8 +33,8 @@ type Device interface {
 	Gadget() string
 
 	HasModeenv() bool
-	IsCoreBoot() bool    // true if UC or classic with modes
-	IsClassicBoot() bool // true if classic with classic initramfs
+	IsCoreBoot() bool    // true if UC or classic with modes (kernel is a snap)
+	IsClassicBoot() bool // true if classic with classic initramfs (kernel from debs)
 
 	Model() *asserts.Model
 }


### PR DESCRIPTION
Is{Core,Classic}Boot() will be used to find if we are in a Ubuntu Core
device and if we are in a classic with modes (there is a modeenv file)
device respectively. That is determined by the information found in
the model assertion.
