### PR TITLE
tests: remove ubuntu 21.10 from sru validation

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -183,7 +183,7 @@ backends:
                   workers: 6
             - ubuntu-20.04-64:
                   workers: 6
-            - ubuntu-21.10-64:
+            - ubuntu-22.04-64:
                   workers: 6
 
     google-nested:


### PR DESCRIPTION
Now 22.04 is included for sru validation