### PR TITLE
many: progress bars should use the overridable stdouts

### DIFF
--- a/cmd/snap/cmd_download.go
+++ b/cmd/snap/cmd_download.go
@@ -122,6 +122,7 @@ func downloadDirectImpl(snapName string, revision snap.Revision, dlOpts tooling.
 	if err != nil {
 		return err
 	}
+	tsto.Stdout = Stdout
 
 	fmt.Fprintf(Stdout, i18n.G("Fetching snap %q\n"), snapName)
 	dlSnap, err := tsto.DownloadSnap(snapName, dlOpts)

--- a/cmd/snap/inhibit.go
+++ b/cmd/snap/inhibit.go
@@ -110,7 +110,7 @@ func graphicalSessionFlow(snapName string, hint runinhibit.Hint) error {
 
 func textFlow(snapName string, hint runinhibit.Hint) error {
 	fmt.Fprintf(Stdout, "%s\n", inhibitMessage(snapName, hint))
-	pb := progress.MakeProgressBar()
+	pb := progress.MakeProgressBar(Stdout)
 	pb.Spin(i18n.G("please wait..."))
 	_, err := waitInhibitUnlock(snapName, runinhibit.HintNotInhibited)
 	pb.Finished()

--- a/cmd/snap/wait.go
+++ b/cmd/snap/wait.go
@@ -70,7 +70,7 @@ func (wmx waitMixin) wait(id string) (*client.Change, error) {
 		}
 	}()
 
-	pb := progress.MakeProgressBar()
+	pb := progress.MakeProgressBar(Stdout)
 	defer func() {
 		pb.Finished()
 		// next two not strictly needed for CLI, but without

--- a/image/image_linux.go
+++ b/image/image_linux.go
@@ -138,6 +138,7 @@ func Prepare(opts *Options) error {
 	if err != nil {
 		return err
 	}
+	tsto.Stdout = Stdout
 
 	// FIXME: limitation until we can pass series parametrized much more
 	if model.Series() != release.Series {

--- a/image/preseed/preseed.go
+++ b/image/preseed/preseed.go
@@ -175,6 +175,8 @@ func writePreseedAssertion(artifactDigest []byte, opts *preseedOpts) error {
 	if err != nil {
 		return err
 	}
+	tsto.Stdout = Stdout
+
 	newFetcher := func(save func(asserts.Assertion) error) asserts.Fetcher {
 		return tsto.AssertionFetcher(adb, save)
 	}

--- a/progress/export_test.go
+++ b/progress/export_test.go
@@ -21,6 +21,8 @@ package progress
 
 import (
 	"io"
+
+	"github.com/snapcore/snapd/testutil"
 )
 
 var (
@@ -86,6 +88,14 @@ func MockTermWidth(f func() int) func() {
 	return func() {
 		termWidth = origTermWidth
 	}
+}
+
+func MockIsTerminal(isTerm bool) (restore func()) {
+	r := testutil.Backup(&isTerminal)
+	isTerminal = func() bool {
+		return isTerm
+	}
+	return r
 }
 
 func MockStdout(w io.Writer) func() {

--- a/progress/progress.go
+++ b/progress/progress.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2015 Canonical Ltd
+ * Copyright (C) 2014-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -101,11 +101,10 @@ var isTerminal = func() bool {
 // which it is called:
 //
 // * if MockMeter has been called, return that.
-// * if no terminal is attached, or we think we're running a test, a
-//   minimalistic QuietMeter is returned.
+// * if w is not nil nor os.Stdout, a QuietMeter outputting to it is returned.
+// * if no terminal is attached, or we think we're running a test,
+//   a minimalistic QuietMeter outputting to stdout is returned.
 // * otherwise, an ANSIMeter is returned.
-//
-// TODO: instead of making the pivot at creation time, do it at every call.
 func MakeProgressBar(w io.Writer) Meter {
 	if testMeter != nil {
 		return testMeter

--- a/store/tooling/tooling.go
+++ b/store/tooling/tooling.go
@@ -50,7 +50,7 @@ import (
 
 // ToolingStore wraps access to the store for tools.
 type ToolingStore struct {
-	// Stdout is for output, mainly progess bars
+	// Stdout is for output, mainly progress bars
 	// left unset stdout is used
 	Stdout io.Writer
 

--- a/store/tooling/tooling.go
+++ b/store/tooling/tooling.go
@@ -26,6 +26,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/url"
 	"os"
@@ -49,6 +50,10 @@ import (
 
 // ToolingStore wraps access to the store for tools.
 type ToolingStore struct {
+	// Stdout is for output, mainly progess bars
+	// left unset stdout is used
+	Stdout io.Writer
+
 	sto  StoreImpl
 	user *auth.UserState
 }
@@ -335,7 +340,7 @@ func (tsto *ToolingStore) snapDownload(targetFn string, sar *store.SnapActionRes
 		logger.Debugf("File exists but has wrong hash, ignoring (here).")
 	}
 
-	pb := progress.MakeProgressBar()
+	pb := progress.MakeProgressBar(tsto.Stdout)
 	defer pb.Finished()
 
 	// Intercept sigint


### PR DESCRIPTION
making progress bars should take a stdout io.Writer

ToolingStore should carry an overridable stdout

make sure in image, preseed and cmd/snap code the overridable
top-level Stdout is passed along to make progress bars
