### PR TITLE
data/selinux: allow snaps to read certificates

### DIFF
--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -819,7 +819,7 @@ fs_getattr_cgroup(snappy_cli_t)
 systemd_exec_systemctl(snappy_cli_t)
 
 # allow snap to read SSL certs
-miscfiles_read_all_certs(snappy_t)
+miscfiles_read_all_certs(snappy_cli_t)
 
 ########################################
 #


### PR DESCRIPTION
This fixes an error occurring in our spread tests on Centos:

    2022-08-17T12:52:45.7861235Z type=AVC msg=audit(08/17/22 12:52:06.099:6583) : avc:  denied  { open } for  pid=71804 comm=snap path=/etc/pki/tls/openssl.cnf dev="sda2" ino=33578739 scontext=system_u:system_r:snappy_cli_t:s0 tcontext=system_u:object_r:cert_t:s0 tclass=file permissive=1
    2022-08-17T12:52:45.7898682Z type=AVC msg=audit(08/17/22 12:52:06.099:6583) : avc:  denied  { read } for  pid=71804 comm=snap name=openssl.cnf dev="sda2" ino=33578739 scontext=system_u:system_r:snappy_cli_t:s0 tcontext=system_u:object_r:cert_t:s0 tclass=file permissive=1
    2022-08-17T12:52:45.7899442Z type=AVC msg=audit(08/17/22 12:52:06.099:6583) : avc:  denied  { search } for  pid=71804 comm=snap name=pki dev="sda2" ino=50341665 scontext=system_u:system_r:snappy_cli_t:s0 tcontext=system_u:object_r:cert_t:s0 tclass=dir permissive=1

You can see the error in this PR for example: https://github.com/snapcore/snapd/runs/7878536925?check_suite_focus=true