### PR TITLE
o/assertstate: don't refresh enforced validation sets during check

### DIFF
--- a/overlord/assertstate/assertstate.go
+++ b/overlord/assertstate/assertstate.go
@@ -636,20 +636,10 @@ func getSpecificSequenceOrLatest(db *asserts.Database, headers map[string]string
 
 // validationSetAssertionForEnforce tries to fetch the validation set assertion
 // with the given accountID/name/sequence (sequence is optional) using pool and
-// checks if it's not in conflict with existing validation sets in enforcing mode
-// (all currently tracked validation set assertions get refreshed), and if they
-// are valid for installed snaps.
+// checks if it's not in conflict with existing validation sets in enforcing mode.
 func validationSetAssertionForEnforce(st *state.State, accountID, name string, sequence int, userID int, snaps []*snapasserts.InstalledSnap, ignoreValidation map[string]bool) (vs *asserts.ValidationSet, current int, err error) {
 	deviceCtx, err := snapstate.DevicePastSeeding(st, nil)
 	if err != nil {
-		return nil, 0, err
-	}
-
-	opts := &RefreshAssertionsOptions{IsAutoRefresh: false}
-
-	// refresh all currently tracked validation set assertions (this may or may not
-	// include the one requested by the caller).
-	if err = RefreshValidationSetAssertions(st, userID, opts); err != nil {
 		return nil, 0, err
 	}
 
@@ -761,6 +751,7 @@ func validationSetAssertionForEnforce(st *state.State, accountID, name string, s
 		return nil
 	}
 
+	opts := &RefreshAssertionsOptions{IsAutoRefresh: false}
 	if err := resolvePoolNoFallback(st, pool, checkBeforeCommit, userID, deviceCtx, opts); err != nil {
 		return nil, 0, err
 	}

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -3477,17 +3477,17 @@ func (s *assertMgrSuite) TestValidationSetAssertionForEnforceNotPinnedAfterMonit
 	sequence := 0
 	vs, cur, err := assertstate.ValidationSetAssertionForEnforce(st, s.dev1Acct.AccountID(), "bar", sequence, 0, snaps, nil)
 	c.Assert(err, IsNil)
-	// new assertion got fetched
-	c.Check(vs.Revision(), Equals, 5)
-	c.Check(vs.Sequence(), Equals, 3)
-	c.Check(cur, Equals, 3)
+	// doesn't fetch new assertion
+	c.Check(vs.Revision(), Equals, 1)
+	c.Check(vs.Sequence(), Equals, 1)
+	c.Check(cur, Equals, 1)
 
-	// and it has been committed
+	// old assertion is stil in the database
 	_, err = assertstate.DB(s.state).Find(asserts.ValidationSetType, map[string]string{
 		"series":     "16",
 		"account-id": s.dev1Acct.AccountID(),
 		"name":       "bar",
-		"sequence":   "3",
+		"sequence":   "1",
 	})
 	c.Assert(err, IsNil)
 }


### PR DESCRIPTION
Check the validation set against the enforced validation sets without refreshing them, since we're not refreshing the snaps as well to try to satisfy the constraints.