### PR TITLE
many: fix unnecessary use of fmt.Sprintf (S1039)

### DIFF
--- a/cmd/snapd-apparmor/main_test.go
+++ b/cmd/snapd-apparmor/main_test.go
@@ -121,7 +121,7 @@ func (s *mainSuite) TestLoadAppArmorProfiles(c *C) {
 	// test error case
 	testutil.MockCommand(c, "apparmor_parser", "echo mocked parser failed > /dev/stderr; exit 1")
 	err = snapd_apparmor.LoadAppArmorProfiles()
-	c.Check(err.Error(), Equals, fmt.Sprintf("cannot load apparmor profiles: exit status 1\napparmor_parser output:\nmocked parser failed\n"))
+	c.Check(err.Error(), Equals, "cannot load apparmor profiles: exit status 1\napparmor_parser output:\nmocked parser failed\n")
 
 	// rename so file is ignored
 	err = os.Rename(profile, profile+"~")

--- a/overlord/configstate/config/transaction_test.go
+++ b/overlord/configstate/config/transaction_test.go
@@ -667,8 +667,8 @@ func (s *transactionSuite) TestExternalDeepNesting(c *C) {
 		c.Check(key, Equals, "key.external.subkey")
 
 		m := make(map[string]string)
-		m["subkey"] = fmt.Sprintf("nested-value")
-		m["other-subkey"] = fmt.Sprintf("other-nested-value")
+		m["subkey"] = "nested-value"
+		m["other-subkey"] = "other-nested-value"
 
 		return m, nil
 	})

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -8091,14 +8091,14 @@ func (s *mgrsSuite) TestRemodelUC20BackToPreviousGadget(c *C) {
 	var i int
 
 	// prepare first
-	c.Assert(tasks[i].Summary(), Equals, fmt.Sprintf(`Prepare snap "old-pc" (1) for remodel`))
+	c.Assert(tasks[i].Summary(), Equals, `Prepare snap "old-pc" (1) for remodel`)
 	i++
 	// then recovery system
 	i += validateRecoverySystemTasks(c, tasks[i:], expectedLabel)
 	// then gadget switch with update of assets and kernel command line
 	i += validateGadgetSwitchTasks(c, tasks[i:], "old-pc", "1")
 	// finally new model assertion
-	c.Assert(tasks[i].Summary(), Equals, fmt.Sprintf(`Set new model assertion`))
+	c.Assert(tasks[i].Summary(), Equals, `Set new model assertion`)
 	i++
 	c.Check(i, Equals, len(tasks))
 }
@@ -8272,14 +8272,14 @@ func (s *mgrsSuite) TestRemodelUC20ExistingGadgetSnapDifferentChannel(c *C) {
 	var i int
 
 	// prepare first
-	c.Assert(tasks[i].Summary(), Equals, fmt.Sprintf(`Switch snap "old-pc" from channel "20/beta" to "20/edge"`))
+	c.Assert(tasks[i].Summary(), Equals, `Switch snap "old-pc" from channel "20/beta" to "20/edge"`)
 	i++
 	// then recovery system
 	i += validateRecoverySystemTasks(c, tasks[i:], expectedLabel)
 	// then gadget switch with update of assets and kernel command line
 	i += validateGadgetSwitchTasks(c, tasks[i:], "old-pc", "1")
 	// finally new model assertion
-	c.Assert(tasks[i].Summary(), Equals, fmt.Sprintf(`Set new model assertion`))
+	c.Assert(tasks[i].Summary(), Equals, `Set new model assertion`)
 	i++
 	c.Check(i, Equals, len(tasks))
 }
@@ -8713,7 +8713,7 @@ func (s *mgrsSuite) TestRemodelUC20ToUC22(c *C) {
 	i += validateInstallTasks(c, tasks[i:], "core22", "1", noConfigure)
 	i += validateRefreshTasks(c, tasks[i:], "pc", "34", isGadget)
 	// finally new model assertion
-	c.Assert(tasks[i].Summary(), Equals, fmt.Sprintf(`Set new model assertion`))
+	c.Assert(tasks[i].Summary(), Equals, `Set new model assertion`)
 	i++
 	c.Check(i, Equals, len(tasks))
 

--- a/overlord/state/taskrunner_test.go
+++ b/overlord/state/taskrunner_test.go
@@ -402,7 +402,7 @@ func (ts *taskRunnerSuite) TestAbortAcrossLanesDescendantTask(c *C) {
 		c.Logf("do %q", task.Summary())
 		label := task.Summary()
 		if label == "t15" {
-			ch <- fmt.Sprintf("t15:error")
+			ch <- "t15:error"
 			return fmt.Errorf("mock error")
 		}
 		ch <- fmt.Sprintf("%s:do", label)
@@ -504,7 +504,7 @@ func (ts *taskRunnerSuite) TestAbortAcrossLanesStriclyOrderedTasks(c *C) {
 		c.Logf("do %q", task.Summary())
 		label := task.Summary()
 		if label == "t24" {
-			ch <- fmt.Sprintf("t24:error")
+			ch <- "t24:error"
 			return fmt.Errorf("mock error")
 		}
 		ch <- fmt.Sprintf("%s:do", label)

--- a/sandbox/seccomp/compiler_test.go
+++ b/sandbox/seccomp/compiler_test.go
@@ -288,11 +288,11 @@ echo "%s"
 }
 
 func (s *compilerSuite) TestCompilerStderrErr(c *C) {
-	cmd := testutil.MockCommand(c, "snap-seccomp", fmt.Sprintf(`
+	cmd := testutil.MockCommand(c, "snap-seccomp", `
 echo "this goes to stderr" >&2
 # this goes to stdout
 echo "this goes to stdout"
-exit 1`))
+exit 1`)
 
 	_, err := seccomp.CompilerVersionInfo(fromCmd(c, cmd))
 	c.Assert(err, ErrorMatches, "this goes to stderr")

--- a/tests/lib/fakedevicesvc/main.go
+++ b/tests/lib/fakedevicesvc/main.go
@@ -69,7 +69,7 @@ func handle(w http.ResponseWriter, r *http.Request) {
 	switch r.URL.Path {
 	case "/request-id":
 		w.WriteHeader(200)
-		io.WriteString(w, fmt.Sprintf(`{"request-id": "REQ-ID"}`))
+		io.WriteString(w, `{"request-id": "REQ-ID"}`)
 	case "/serial":
 		db, err := asserts.OpenDatabase(&asserts.DatabaseConfig{})
 		if err != nil {


### PR DESCRIPTION
This fixes all issues of `unnecessary use of fmt.Sprintf (S1039)` as flagged by staticheck.io.