### PR TITLE
bootloader,systemd: fix `don't use Yoda conditions (ST1017)`

### DIFF
--- a/bootloader/lkenv/lkenv.go
+++ b/bootloader/lkenv/lkenv.go
@@ -559,7 +559,7 @@ func (matr bootimgMatrixGeneric) initializeBootPartitions(bootPartLabels []strin
 // any kind).
 func (matr bootimgMatrixGeneric) dropBootPartValue(bootPartValue string) error {
 	for x := range matr {
-		if "" != cToGoString(matr[x][MATRIX_ROW_PARTITION][:]) {
+		if cToGoString(matr[x][MATRIX_ROW_PARTITION][:]) != "" {
 			if bootPartValue == cToGoString(matr[x][MATRIX_ROW_VALUE][:]) {
 				// clear the string by setting the first element to 0 or NUL
 				matr[x][MATRIX_ROW_VALUE][0] = 0

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -566,7 +566,7 @@ func (s *systemd) DaemonReexec() error {
 }
 
 func (s *systemd) EnableNoReload(serviceNames []string) error {
-	if 0 == len(serviceNames) {
+	if len(serviceNames) == 0 {
 		return nil
 	}
 	var args []string
@@ -593,7 +593,7 @@ func (s *systemd) Unmask(serviceName string) error {
 }
 
 func (s *systemd) DisableNoReload(serviceNames []string) error {
-	if 0 == len(serviceNames) {
+	if len(serviceNames) == 0 {
 		return nil
 	}
 	var args []string


### PR DESCRIPTION
Fix all the `don't use Yoda conditions (ST1017)` warnings found by staticcheck.io.

(see https://staticcheck.io/docs/checks#ST1017 for details).