### PR TITLE
snap,store: drop support/consideration for anonymous download urls

### DIFF
--- a/daemon/api_download_test.go
+++ b/daemon/api_download_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2019 Canonical Ltd
+ * Copyright (C) 2019-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -65,9 +65,9 @@ var storeSnaps = map[string]*snap.Info{
 			Revision: snap.R(1),
 		},
 		DownloadInfo: snap.DownloadInfo{
-			Size:            int64(len(snapContent)),
-			AnonDownloadURL: "http://localhost/bar",
-			Sha3_384:        "sha3sha3sha3",
+			Size:        int64(len(snapContent)),
+			DownloadURL: "http://localhost/bar",
+			Sha3_384:    "sha3sha3sha3",
 		},
 	},
 	"edge-bar": {
@@ -78,9 +78,9 @@ var storeSnaps = map[string]*snap.Info{
 			Channel: "edge",
 		},
 		DownloadInfo: snap.DownloadInfo{
-			Size:            int64(len(snapContent)),
-			AnonDownloadURL: "http://localhost/edge-bar",
-			Sha3_384:        "sha3sha3sha3",
+			Size:        int64(len(snapContent)),
+			DownloadURL: "http://localhost/edge-bar",
+			Sha3_384:    "sha3sha3sha3",
 		},
 	},
 	"rev7-bar": {
@@ -90,16 +90,16 @@ var storeSnaps = map[string]*snap.Info{
 			Revision: snap.R(7),
 		},
 		DownloadInfo: snap.DownloadInfo{
-			Size:            int64(len(snapContent)),
-			AnonDownloadURL: "http://localhost/rev7-bar",
-			Sha3_384:        "sha3sha3sha3",
+			Size:        int64(len(snapContent)),
+			DownloadURL: "http://localhost/rev7-bar",
+			Sha3_384:    "sha3sha3sha3",
 		},
 	},
 	"download-error-trigger-snap": {
 		DownloadInfo: snap.DownloadInfo{
-			Size:            100,
-			AnonDownloadURL: "http://localhost/foo",
-			Sha3_384:        "sha3sha3sha3",
+			Size:        100,
+			DownloadURL: "http://localhost/foo",
+			Sha3_384:    "sha3sha3sha3",
 		},
 	},
 	"foo-resume-3": {
@@ -108,9 +108,9 @@ var storeSnaps = map[string]*snap.Info{
 			Revision: snap.R(1),
 		},
 		DownloadInfo: snap.DownloadInfo{
-			Size:            int64(len(snapContent)),
-			AnonDownloadURL: "http://localhost/foo-resume-3",
-			Sha3_384:        "sha3sha3sha3",
+			Size:        int64(len(snapContent)),
+			DownloadURL: "http://localhost/foo-resume-3",
+			Sha3_384:    "sha3sha3sha3",
 		},
 	},
 }

--- a/snap/info.go
+++ b/snap/info.go
@@ -723,8 +723,7 @@ func (s *Info) DesktopPrefix() string {
 // DownloadInfo contains the information to download a snap.
 // It can be marshalled.
 type DownloadInfo struct {
-	AnonDownloadURL string `json:"anon-download-url,omitempty"`
-	DownloadURL     string `json:"download-url,omitempty"`
+	DownloadURL string `json:"download-url,omitempty"`
 
 	Size     int64  `json:"size,omitempty"`
 	Sha3_384 string `json:"sha3-384,omitempty"`
@@ -739,13 +738,12 @@ type DownloadInfo struct {
 // DeltaInfo contains the information to download a delta
 // from one revision to another.
 type DeltaInfo struct {
-	FromRevision    int    `json:"from-revision,omitempty"`
-	ToRevision      int    `json:"to-revision,omitempty"`
-	Format          string `json:"format,omitempty"`
-	AnonDownloadURL string `json:"anon-download-url,omitempty"`
-	DownloadURL     string `json:"download-url,omitempty"`
-	Size            int64  `json:"size,omitempty"`
-	Sha3_384        string `json:"sha3-384,omitempty"`
+	FromRevision int    `json:"from-revision,omitempty"`
+	ToRevision   int    `json:"to-revision,omitempty"`
+	Format       string `json:"format,omitempty"`
+	DownloadURL  string `json:"download-url,omitempty"`
+	Size         int64  `json:"size,omitempty"`
+	Sha3_384     string `json:"sha3-384,omitempty"`
 }
 
 // check that Info is a PlaceInfo

--- a/store/details.go
+++ b/store/details.go
@@ -27,7 +27,6 @@ import (
 
 // snapDetails encapsulates the data sent to us from the store as JSON.
 type snapDetails struct {
-	AnonDownloadURL  string             `json:"anon_download_url,omitempty"`
 	Architectures    []string           `json:"architecture"`
 	Channel          string             `json:"channel,omitempty"`
 	DownloadSha3_384 string             `json:"download_sha3_384,omitempty"`
@@ -99,7 +98,6 @@ func infoFromRemote(d *snapDetails) *snap.Info {
 	info.Channel = d.Channel
 	info.Sha3_384 = d.DownloadSha3_384
 	info.Size = d.DownloadSize
-	info.AnonDownloadURL = d.AnonDownloadURL
 	info.DownloadURL = d.DownloadURL
 	info.Prices = d.Prices
 	info.Private = d.Private

--- a/store/details_v2_test.go
+++ b/store/details_v2_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2018 Canonical Ltd
+ * Copyright (C) 2018-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -306,8 +306,7 @@ func (s *detailsV2Suite) TestInfoFromStoreSnap(c *C) {
 		"Tracks",   // handled at a different level (see TestInfo)
 		"Layout",
 		"SideInfo.Channel",
-		"SideInfo.EditedLinks",         // TODO: take this value from the store
-		"DownloadInfo.AnonDownloadURL", // TODO: going away at some point
+		"SideInfo.EditedLinks", // TODO: take this value from the store
 		"SystemUsernames",
 	}
 	var checker func(string, reflect.Value)

--- a/store/download_test.go
+++ b/store/download_test.go
@@ -611,9 +611,9 @@ var deltaTests = []struct {
 		{url: "delta-url"},
 	},
 	info: snap.DownloadInfo{
-		AnonDownloadURL: "full-snap-url",
+		DownloadURL: "full-snap-url",
 		Deltas: []snap.DeltaInfo{
-			{AnonDownloadURL: "delta-url", Format: "xdelta3"},
+			{DownloadURL: "delta-url", Format: "xdelta3"},
 		},
 	},
 	expectedContent: "snap-content-via-delta",
@@ -625,9 +625,9 @@ var deltaTests = []struct {
 		{url: "full-snap-url"},
 	},
 	info: snap.DownloadInfo{
-		AnonDownloadURL: "full-snap-url",
+		DownloadURL: "full-snap-url",
 		Deltas: []snap.DeltaInfo{
-			{AnonDownloadURL: "delta-url", Format: "xdelta3"},
+			{DownloadURL: "delta-url", Format: "xdelta3"},
 		},
 	},
 	expectedContent: "full-snap-url-content",
@@ -638,10 +638,10 @@ var deltaTests = []struct {
 		{url: "full-snap-url"},
 	},
 	info: snap.DownloadInfo{
-		AnonDownloadURL: "full-snap-url",
+		DownloadURL: "full-snap-url",
 		Deltas: []snap.DeltaInfo{
-			{AnonDownloadURL: "delta-url", Format: "xdelta3"},
-			{AnonDownloadURL: "delta-url-2", Format: "xdelta3"},
+			{DownloadURL: "delta-url", Format: "xdelta3"},
+			{DownloadURL: "delta-url-2", Format: "xdelta3"},
 		},
 	},
 	expectedContent: "full-snap-url-content",

--- a/store/store.go
+++ b/store/store.go
@@ -494,23 +494,6 @@ func (s *Store) LoginUser(username, password, otp string) (string, string, error
 	return macaroon, discharge, nil
 }
 
-// authAvailable returns true if there is a user and/or device session setup
-func (s *Store) authAvailable(user *auth.UserState) (bool, error) {
-	if user.HasStoreAuth() {
-		return true, nil
-	} else {
-		var device *auth.DeviceState
-		var err error
-		if s.dauthCtx != nil {
-			device, err = s.dauthCtx.Device()
-			if err != nil {
-				return false, err
-			}
-		}
-		return device != nil && device.SessionMacaroon != "", nil
-	}
-}
-
 // authenticateUser will add the store expected Macaroon Authorization header for user
 func authenticateUser(r *http.Request, user *auth.UserState) {
 	var buf bytes.Buffer

--- a/store/store_download.go
+++ b/store/store_download.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2020 Canonical Ltd
+ * Copyright (C) 2014-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -264,16 +264,7 @@ func (s *Store) Download(ctx context.Context, name string, targetPath string, do
 		logger.Debugf("Starting download of %q.", partialPath)
 	}
 
-	authAvail, err := s.authAvailable(user)
-	if err != nil {
-		return err
-	}
-
-	url := downloadInfo.AnonDownloadURL
-	if url == "" || authAvail {
-		url = downloadInfo.DownloadURL
-	}
-
+	url := downloadInfo.DownloadURL
 	if downloadInfo.Size == 0 || resume < downloadInfo.Size {
 		err = download(ctx, name, downloadInfo.Sha3_384, url, user, s, w, resume, pbar, dlOpts)
 		if err != nil {
@@ -626,17 +617,7 @@ func (s *Store) DownloadStream(ctx context.Context, name string, downloadInfo *s
 		return file, 206, nil
 	}
 
-	authAvail, err := s.authAvailable(user)
-	if err != nil {
-		return nil, 0, err
-	}
-
-	downloadURL := downloadInfo.AnonDownloadURL
-	if downloadURL == "" || authAvail {
-		downloadURL = downloadInfo.DownloadURL
-	}
-
-	storeURL, err := url.Parse(downloadURL)
+	storeURL, err := url.Parse(downloadInfo.DownloadURL)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -677,15 +658,7 @@ func (s *Store) downloadDelta(deltaName string, downloadInfo *snap.DownloadInfo,
 		return fmt.Errorf("store returned unsupported delta format %q (only xdelta3 currently)", deltaInfo.Format)
 	}
 
-	authAvail, err := s.authAvailable(user)
-	if err != nil {
-		return err
-	}
-
-	url := deltaInfo.AnonDownloadURL
-	if url == "" || authAvail {
-		url = deltaInfo.DownloadURL
-	}
+	url := deltaInfo.DownloadURL
 
 	return download(context.TODO(), deltaName, deltaInfo.Sha3_384, url, user, s, w, 0, pbar, dlOpts)
 }

--- a/store/store_download_test.go
+++ b/store/store_download_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2020 Canonical Ltd
+ * Copyright (C) 2014-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -87,7 +87,7 @@ func (s *storeDownloadSuite) TestDownloadOK(c *C) {
 	expectedContent := []byte("I was downloaded")
 
 	restore := store.MockDownload(func(ctx context.Context, name, sha3, url string, user *auth.UserState, s *store.Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter, dlOpts *store.DownloadOptions) error {
-		c.Check(url, Equals, "anon-url")
+		c.Check(url, Equals, "URL")
 		w.Write(expectedContent)
 		return nil
 	})
@@ -95,8 +95,7 @@ func (s *storeDownloadSuite) TestDownloadOK(c *C) {
 
 	snap := &snap.Info{}
 	snap.RealName = "foo"
-	snap.AnonDownloadURL = "anon-url"
-	snap.DownloadURL = "AUTH-URL"
+	snap.DownloadURL = "URL"
 	snap.Size = int64(len(expectedContent))
 
 	path := filepath.Join(c.MkDir(), "downloaded-file")
@@ -114,7 +113,7 @@ func (s *storeDownloadSuite) TestDownloadRangeRequest(c *C) {
 
 	restore := store.MockDownload(func(ctx context.Context, name, sha3, url string, user *auth.UserState, s *store.Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter, dlOpts *store.DownloadOptions) error {
 		c.Check(resume, Equals, int64(len(partialContentStr)))
-		c.Check(url, Equals, "anon-url")
+		c.Check(url, Equals, "URL")
 		w.Write([]byte(missingContentStr))
 		return nil
 	})
@@ -122,8 +121,7 @@ func (s *storeDownloadSuite) TestDownloadRangeRequest(c *C) {
 
 	snap := &snap.Info{}
 	snap.RealName = "foo"
-	snap.AnonDownloadURL = "anon-url"
-	snap.DownloadURL = "AUTH-URL"
+	snap.DownloadURL = "URL"
 	snap.Sha3_384 = "abcdabcd"
 	snap.Size = int64(len(expectedContentStr))
 
@@ -142,8 +140,7 @@ func (s *storeDownloadSuite) TestResumeOfCompleted(c *C) {
 
 	snap := &snap.Info{}
 	snap.RealName = "foo"
-	snap.AnonDownloadURL = "anon-url"
-	snap.DownloadURL = "AUTH-URL"
+	snap.DownloadURL = "URL"
 	snap.Sha3_384 = fmt.Sprintf("%x", sha3.Sum384([]byte(expectedContentStr)))
 	snap.Size = int64(len(expectedContentStr))
 
@@ -189,8 +186,7 @@ func (s *storeDownloadSuite) TestDownloadEOFHandlesResumeHashCorrectly(c *C) {
 
 	snap := &snap.Info{}
 	snap.RealName = "foo"
-	snap.AnonDownloadURL = mockServer.URL
-	snap.DownloadURL = "AUTH-URL"
+	snap.DownloadURL = mockServer.URL
 	snap.Sha3_384 = fmt.Sprintf("%x", h.Sum(nil))
 	snap.Size = 50000
 
@@ -233,8 +229,7 @@ func (s *storeDownloadSuite) TestDownloadRetryHashErrorIsFullyRetried(c *C) {
 
 	snap := &snap.Info{}
 	snap.RealName = "foo"
-	snap.AnonDownloadURL = mockServer.URL
-	snap.DownloadURL = "AUTH-URL"
+	snap.DownloadURL = mockServer.URL
 	snap.Sha3_384 = fmt.Sprintf("%x", h.Sum(nil))
 	snap.Size = 50000
 
@@ -269,8 +264,7 @@ func (s *storeDownloadSuite) TestResumeOfCompletedRetriedOnHashFailure(c *C) {
 
 	snap := &snap.Info{}
 	snap.RealName = "foo"
-	snap.AnonDownloadURL = mockServer.URL
-	snap.DownloadURL = "AUTH-URL"
+	snap.DownloadURL = mockServer.URL
 	snap.Sha3_384 = fmt.Sprintf("%x", h.Sum(nil))
 	snap.Size = 50000
 
@@ -305,8 +299,7 @@ func (s *storeDownloadSuite) TestResumeOfTooMuchDataWorks(c *C) {
 
 	snap := &snap.Info{}
 	snap.RealName = "foo"
-	snap.AnonDownloadURL = mockServer.URL
-	snap.DownloadURL = "AUTH-URL"
+	snap.DownloadURL = mockServer.URL
 	snap.Sha3_384 = fmt.Sprintf("%x", h.Sum(nil))
 	snap.Size = int64(len(snapContent))
 
@@ -335,8 +328,7 @@ func (s *storeDownloadSuite) TestDownloadRetryHashErrorIsFullyRetriedOnlyOnce(c 
 
 	snap := &snap.Info{}
 	snap.RealName = "foo"
-	snap.AnonDownloadURL = mockServer.URL
-	snap.DownloadURL = "AUTH-URL"
+	snap.DownloadURL = mockServer.URL
 	snap.Sha3_384 = "invalid-hash"
 	snap.Size = int64(len("something invalid"))
 
@@ -368,8 +360,7 @@ func (s *storeDownloadSuite) TestDownloadRangeRequestRetryOnHashError(c *C) {
 
 	snap := &snap.Info{}
 	snap.RealName = "foo"
-	snap.AnonDownloadURL = "anon-url"
-	snap.DownloadURL = "AUTH-URL"
+	snap.DownloadURL = "URL"
 	snap.Sha3_384 = ""
 	snap.Size = int64(len(expectedContentStr))
 
@@ -396,8 +387,7 @@ func (s *storeDownloadSuite) TestDownloadRangeRequestFailOnHashError(c *C) {
 
 	snap := &snap.Info{}
 	snap.RealName = "foo"
-	snap.AnonDownloadURL = "anon-url"
-	snap.DownloadURL = "AUTH-URL"
+	snap.DownloadURL = "URL"
 	snap.Sha3_384 = ""
 	snap.Size = int64(len(partialContentStr) + 1)
 
@@ -411,12 +401,12 @@ func (s *storeDownloadSuite) TestDownloadRangeRequestFailOnHashError(c *C) {
 	c.Assert(n, Equals, 2)
 }
 
-func (s *storeDownloadSuite) TestAuthenticatedDownloadDoesNotUseAnonURL(c *C) {
+func (s *storeDownloadSuite) TestDownloadWithUser(c *C) {
 	expectedContent := []byte("I was downloaded")
 	restore := store.MockDownload(func(ctx context.Context, name, sha3, url string, user *auth.UserState, _ *store.Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter, dlOpts *store.DownloadOptions) error {
 		// check user is pass and auth url is used
 		c.Check(user, Equals, s.user)
-		c.Check(url, Equals, "AUTH-URL")
+		c.Check(url, Equals, "URL")
 
 		w.Write(expectedContent)
 		return nil
@@ -425,8 +415,7 @@ func (s *storeDownloadSuite) TestAuthenticatedDownloadDoesNotUseAnonURL(c *C) {
 
 	snap := &snap.Info{}
 	snap.RealName = "foo"
-	snap.AnonDownloadURL = "anon-url"
-	snap.DownloadURL = "AUTH-URL"
+	snap.DownloadURL = "URL"
 	snap.Size = int64(len(expectedContent))
 
 	path := filepath.Join(c.MkDir(), "downloaded-file")
@@ -435,58 +424,6 @@ func (s *storeDownloadSuite) TestAuthenticatedDownloadDoesNotUseAnonURL(c *C) {
 	defer os.Remove(path)
 
 	c.Assert(path, testutil.FileEquals, expectedContent)
-}
-
-func (s *storeDownloadSuite) TestAuthenticatedDeviceDoesNotUseAnonURL(c *C) {
-	expectedContent := []byte("I was downloaded")
-	restore := store.MockDownload(func(ctx context.Context, name, sha3, url string, user *auth.UserState, s *store.Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter, dlOpts *store.DownloadOptions) error {
-		// check auth url is used
-		c.Check(url, Equals, "AUTH-URL")
-
-		w.Write(expectedContent)
-		return nil
-	})
-	defer restore()
-
-	snap := &snap.Info{}
-	snap.RealName = "foo"
-	snap.AnonDownloadURL = "anon-url"
-	snap.DownloadURL = "AUTH-URL"
-	snap.Size = int64(len(expectedContent))
-
-	dauthCtx := &testDauthContext{c: c, device: s.device}
-	sto := store.New(&store.Config{}, dauthCtx)
-
-	path := filepath.Join(c.MkDir(), "downloaded-file")
-	err := sto.Download(s.ctx, "foo", path, &snap.DownloadInfo, nil, nil, nil)
-	c.Assert(err, IsNil)
-	defer os.Remove(path)
-
-	c.Assert(path, testutil.FileEquals, expectedContent)
-}
-
-func (s *storeDownloadSuite) TestLocalUserDownloadUsesAnonURL(c *C) {
-	expectedContentStr := "I was downloaded"
-	restore := store.MockDownload(func(ctx context.Context, name, sha3, url string, user *auth.UserState, s *store.Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter, dlOpts *store.DownloadOptions) error {
-		c.Check(url, Equals, "anon-url")
-
-		w.Write([]byte(expectedContentStr))
-		return nil
-	})
-	defer restore()
-
-	snap := &snap.Info{}
-	snap.RealName = "foo"
-	snap.AnonDownloadURL = "anon-url"
-	snap.DownloadURL = "AUTH-URL"
-	snap.Size = int64(len(expectedContentStr))
-
-	path := filepath.Join(c.MkDir(), "downloaded-file")
-	err := s.store.Download(s.ctx, "foo", path, &snap.DownloadInfo, nil, s.localUser, nil)
-	c.Assert(err, IsNil)
-	defer os.Remove(path)
-
-	c.Assert(path, testutil.FileEquals, expectedContentStr)
 }
 
 func (s *storeDownloadSuite) TestDownloadFails(c *C) {
@@ -499,8 +436,7 @@ func (s *storeDownloadSuite) TestDownloadFails(c *C) {
 
 	snap := &snap.Info{}
 	snap.RealName = "foo"
-	snap.AnonDownloadURL = "anon-url"
-	snap.DownloadURL = "AUTH-URL"
+	snap.DownloadURL = "URL"
 	snap.Size = 1
 	// simulate a failed download
 	path := filepath.Join(c.MkDir(), "downloaded-file")
@@ -523,8 +459,7 @@ func (s *storeDownloadSuite) TestDownloadFailsLeavePartial(c *C) {
 
 	snap := &snap.Info{}
 	snap.RealName = "foo"
-	snap.AnonDownloadURL = "anon-url"
-	snap.DownloadURL = "AUTH-URL"
+	snap.DownloadURL = "URL"
 	snap.Size = 1
 	// simulate a failed download
 	path := filepath.Join(c.MkDir(), "downloaded-file")
@@ -547,8 +482,7 @@ func (s *storeDownloadSuite) TestDownloadFailsDoesNotLeavePartialIfEmpty(c *C) {
 
 	snap := &snap.Info{}
 	snap.RealName = "foo"
-	snap.AnonDownloadURL = "anon-url"
-	snap.DownloadURL = "AUTH-URL"
+	snap.DownloadURL = "URL"
 	snap.Size = 1
 	// simulate a failed download
 	path := filepath.Join(c.MkDir(), "downloaded-file")
@@ -573,8 +507,7 @@ func (s *storeDownloadSuite) TestDownloadSyncFails(c *C) {
 
 	snap := &snap.Info{}
 	snap.RealName = "foo"
-	snap.AnonDownloadURL = "anon-url"
-	snap.DownloadURL = "AUTH-URL"
+	snap.DownloadURL = "URL"
 	snap.Size = int64(len("sync will fail"))
 
 	// simulate a failed sync
@@ -588,68 +521,34 @@ func (s *storeDownloadSuite) TestDownloadSyncFails(c *C) {
 }
 
 var downloadDeltaTests = []struct {
-	info          snap.DownloadInfo
-	authenticated bool
-	deviceSession bool
-	useLocalUser  bool
-	format        string
-	expectedURL   string
-	expectError   bool
+	info        snap.DownloadInfo
+	withUser    bool
+	format      string
+	expectedURL string
+	expectError bool
 }{{
-	// An unauthenticated request downloads the anonymous delta url.
+	// No user delta download.
 	info: snap.DownloadInfo{
 		Sha3_384: "sha3",
 		Deltas: []snap.DeltaInfo{
-			{AnonDownloadURL: "anon-delta-url", Format: "xdelta3", FromRevision: 24, ToRevision: 26},
+			{DownloadURL: "delta-url", Format: "xdelta3", FromRevision: 24, ToRevision: 26},
 		},
 	},
-	authenticated: false,
-	deviceSession: false,
-	format:        "xdelta3",
-	expectedURL:   "anon-delta-url",
-	expectError:   false,
+	format:      "xdelta3",
+	expectedURL: "delta-url",
+	expectError: false,
 }, {
-	// An authenticated request downloads the authenticated delta url.
+	// With user detla download.
 	info: snap.DownloadInfo{
 		Sha3_384: "sha3",
 		Deltas: []snap.DeltaInfo{
-			{AnonDownloadURL: "anon-delta-url", DownloadURL: "auth-delta-url", Format: "xdelta3", FromRevision: 24, ToRevision: 26},
+			{DownloadURL: "delta-url", Format: "xdelta3", FromRevision: 24, ToRevision: 26},
 		},
 	},
-	authenticated: true,
-	deviceSession: false,
-	useLocalUser:  false,
-	format:        "xdelta3",
-	expectedURL:   "auth-delta-url",
-	expectError:   false,
-}, {
-	// A device-authenticated request downloads the authenticated delta url.
-	info: snap.DownloadInfo{
-		Sha3_384: "sha3",
-		Deltas: []snap.DeltaInfo{
-			{AnonDownloadURL: "anon-delta-url", DownloadURL: "auth-delta-url", Format: "xdelta3", FromRevision: 24, ToRevision: 26},
-		},
-	},
-	authenticated: false,
-	deviceSession: true,
-	useLocalUser:  false,
-	format:        "xdelta3",
-	expectedURL:   "auth-delta-url",
-	expectError:   false,
-}, {
-	// A local authenticated request downloads the anonymous delta url.
-	info: snap.DownloadInfo{
-		Sha3_384: "sha3",
-		Deltas: []snap.DeltaInfo{
-			{AnonDownloadURL: "anon-delta-url", Format: "xdelta3", FromRevision: 24, ToRevision: 26},
-		},
-	},
-	authenticated: true,
-	deviceSession: false,
-	useLocalUser:  true,
-	format:        "xdelta3",
-	expectedURL:   "anon-delta-url",
-	expectError:   false,
+	withUser:    true,
+	format:      "xdelta3",
+	expectedURL: "delta-url",
+	expectError: false,
 }, {
 	// An error is returned if more than one matching delta is returned by the store,
 	// though this may be handled in the future.
@@ -660,11 +559,9 @@ var downloadDeltaTests = []struct {
 			{DownloadURL: "bsdiff-delta-url", Format: "xdelta3", FromRevision: 25, ToRevision: 26},
 		},
 	},
-	authenticated: false,
-	deviceSession: false,
-	format:        "xdelta3",
-	expectedURL:   "",
-	expectError:   true,
+	format:      "xdelta3",
+	expectedURL: "",
+	expectError: true,
 }, {
 	// If the supported format isn't available, an error is returned.
 	info: snap.DownloadInfo{
@@ -674,11 +571,9 @@ var downloadDeltaTests = []struct {
 			{DownloadURL: "ydelta-delta-url", Format: "ydelta", FromRevision: 24, ToRevision: 26},
 		},
 	},
-	authenticated: false,
-	deviceSession: false,
-	format:        "bsdiff",
-	expectedURL:   "",
-	expectError:   true,
+	format:      "bsdiff",
+	expectedURL: "",
+	expectError: true,
 }}
 
 func (s *storeDownloadSuite) TestDownloadDelta(c *C) {
@@ -694,10 +589,7 @@ func (s *storeDownloadSuite) TestDownloadDelta(c *C) {
 		restore := store.MockDownload(func(ctx context.Context, name, sha3, url string, user *auth.UserState, _ *store.Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter, dlOpts *store.DownloadOptions) error {
 			c.Check(dlOpts, DeepEquals, &store.DownloadOptions{IsAutoRefresh: true})
 			expectedUser := s.user
-			if testCase.useLocalUser {
-				expectedUser = s.localUser
-			}
-			if !testCase.authenticated {
+			if !testCase.withUser {
 				expectedUser = nil
 			}
 			c.Check(user, Equals, expectedUser)
@@ -711,16 +603,8 @@ func (s *storeDownloadSuite) TestDownloadDelta(c *C) {
 		c.Assert(err, IsNil)
 		defer os.Remove(w.Name())
 
-		dauthCtx.device = nil
-		if testCase.deviceSession {
-			dauthCtx.device = s.device
-		}
-
 		authedUser := s.user
-		if testCase.useLocalUser {
-			authedUser = s.localUser
-		}
-		if !testCase.authenticated {
+		if !testCase.withUser {
 			authedUser = nil
 		}
 
@@ -879,7 +763,7 @@ func (s *storeDownloadSuite) TestDownloadCacheMiss(c *C) {
 func (s *storeDownloadSuite) TestDownloadStreamOK(c *C) {
 	expectedContent := []byte("I was downloaded")
 	restore := store.MockDoDownloadReq(func(ctx context.Context, url *url.URL, cdnHeader string, resume int64, s *store.Store, user *auth.UserState) (*http.Response, error) {
-		c.Check(url.String(), Equals, "http://anon-url")
+		c.Check(url.String(), Equals, "URL")
 		r := &http.Response{
 			Body: ioutil.NopCloser(bytes.NewReader(expectedContent[resume:])),
 		}
@@ -894,8 +778,7 @@ func (s *storeDownloadSuite) TestDownloadStreamOK(c *C) {
 
 	snap := &snap.Info{}
 	snap.RealName = "foo"
-	snap.AnonDownloadURL = "http://anon-url"
-	snap.DownloadURL = "AUTH-URL"
+	snap.DownloadURL = "URL"
 	snap.Size = int64(len(expectedContent))
 
 	stream, status, err := s.store.DownloadStream(context.TODO(), "foo", &snap.DownloadInfo, 0, nil)
@@ -930,8 +813,7 @@ func (s *storeDownloadSuite) TestDownloadStreamCachedOK(c *C) {
 
 	snap := &snap.Info{}
 	snap.RealName = "foo"
-	snap.AnonDownloadURL = "http://anon-url"
-	snap.DownloadURL = "AUTH-URL"
+	snap.DownloadURL = "URL"
 	snap.Size = int64(len(expectedContent))
 	snap.Sha3_384 = "sha3_384-of-foo"
 
@@ -987,8 +869,7 @@ func (s *storeDownloadSuite) TestDownloadTimeout(c *C) {
 
 	snap := &snap.Info{}
 	snap.RealName = "foo"
-	snap.AnonDownloadURL = mockServer.URL
-	snap.DownloadURL = "AUTH-URL"
+	snap.DownloadURL = mockServer.URL
 	snap.Sha3_384 = fmt.Sprintf("%x", h.Sum(nil))
 	snap.Size = 50000
 
@@ -1071,8 +952,7 @@ func (s *storeDownloadSuite) TestDownloadTimeoutOnHeaders(c *C) {
 
 	snap := &snap.Info{}
 	snap.RealName = "foo"
-	snap.AnonDownloadURL = mockServer.URL
-	snap.DownloadURL = "AUTH-URL"
+	snap.DownloadURL = mockServer.URL
 	snap.Sha3_384 = "1234"
 	snap.Size = 50000
 


### PR DESCRIPTION
v2 store APIs never provided them

v1 has for a long time returned the same value for both kind of URLs