### PR TITLE
packaging/*/tests/integrationtests: reload ssh.service, not sshd.service

### DIFF
--- a/packaging/debian-sid/tests/integrationtests
+++ b/packaging/debian-sid/tests/integrationtests
@@ -26,7 +26,7 @@ cat /proc/meminfo
 # ensure we can do a connect to localhost
 echo ubuntu:ubuntu|chpasswd
 sed -i 's/\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /etc/ssh/sshd_config
-systemctl reload sshd.service
+systemctl reload ssh.service
 
 # Map snapd deb package pockets to core snap channels. This is intended to cope
 # with the autopkgtest execution when testing packages from the different pockets

--- a/packaging/ubuntu-16.04/tests/integrationtests
+++ b/packaging/ubuntu-16.04/tests/integrationtests
@@ -26,7 +26,7 @@ cat /proc/meminfo
 # ensure we can do a connect to localhost
 echo ubuntu:ubuntu|chpasswd
 sed -i 's/\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /etc/ssh/sshd_config
-systemctl reload sshd.service
+systemctl reload ssh.service
 
 # Map snapd deb package pockets to core snap channels. This is intended to cope
 # with the autopkgtest execution when testing packages from the different pockets


### PR DESCRIPTION
In Debian and Ubuntu, sshd.service is an alias for ssh.service and always has
been.  Reload the service by its proper name in our test suite.

This is necessary because ssh is switching to socket activation in later
Ubuntu releases, which means the ssh.service is no longer enabled (in favor
of ssh.socket) and therefore the sshd.service alias is not registered.
