### PR TITLE
o/devicestate: do not run tests in this folder twice

### DIFF
--- a/overlord/devicestate/devicectx_test.go
+++ b/overlord/devicestate/devicectx_test.go
@@ -20,8 +20,6 @@
 package devicestate_test
 
 import (
-	"testing"
-
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/assertstest"
 	"github.com/snapcore/snapd/boot/boottest"
@@ -30,8 +28,6 @@ import (
 	"github.com/snapcore/snapd/testutil"
 	. "gopkg.in/check.v1"
 )
-
-func TestBoot(t *testing.T) { TestingT(t) }
 
 type deviceCtxSuite struct {
 	testutil.BaseTest


### PR DESCRIPTION
Which was happening because of duplicated wiring to go's testing
framework.
