### PR TITLE
devicestate: return an error in checkEncryption() if KernelInfo fails

### DIFF
--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -1913,6 +1913,8 @@ func (s *deviceMgrInstallModeSuite) TestInstallCheckEncryptedStorageSafety(c *C)
 	s.state.Lock()
 	defer s.state.Unlock()
 
+	s.makeMockInstalledPcGadget(c, "", "")
+
 	restore := devicestate.MockSecbootCheckTPMKeySealingSupported(func() error { return nil })
 	defer restore()
 
@@ -1966,6 +1968,8 @@ func (s *deviceMgrInstallModeSuite) TestInstallCheckEncryptedStorageSafety(c *C)
 func (s *deviceMgrInstallModeSuite) TestInstallCheckEncryptedErrors(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
+
+	s.makeMockInstalledPcGadget(c, "", "")
 
 	restore := devicestate.MockSecbootCheckTPMKeySealingSupported(func() error { return fmt.Errorf("tpm says no") })
 	defer restore()
@@ -2101,6 +2105,8 @@ var checkEncryptionModelHeaders = map[string]interface{}{
 func (s *deviceMgrInstallModeSuite) TestInstallCheckEncryptedErrorsLogsTPM(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
+
+	s.makeMockInstalledPcGadget(c, "", "")
 
 	restore := devicestate.MockSecbootCheckTPMKeySealingSupported(func() error {
 		return fmt.Errorf("tpm says no")

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -123,7 +123,7 @@ const (
 	core20SnapID   = "core20ididididididididididididid"
 )
 
-func (s *deviceMgrInstallModeSuite) makeMockInstalledPcGadget(c *C, installDeviceHook string, gadgetDefaultsYaml string) {
+func (s *deviceMgrInstallModeSuite) makeMockInstalledPcKernelAndGadget(c *C, installDeviceHook string, gadgetDefaultsYaml string) {
 	si := &snap.SideInfo{
 		RealName: "pc-kernel",
 		Revision: snap.R(1),
@@ -272,7 +272,7 @@ func (s *deviceMgrInstallModeSuite) doRunChangeTestWithEncryption(c *C, grade st
 
 	s.state.Lock()
 	mockModel := s.makeMockInstallModel(c, grade)
-	s.makeMockInstalledPcGadget(c, "", "")
+	s.makeMockInstalledPcKernelAndGadget(c, "", "")
 	s.state.Unlock()
 
 	bypassEncryptionPath := filepath.Join(boot.InitramfsUbuntuSeedDir, ".force-unencrypted")
@@ -376,7 +376,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallTaskErrors(c *C) {
 
 	s.state.Lock()
 	s.makeMockInstallModel(c, "dangerous")
-	s.makeMockInstalledPcGadget(c, "", "")
+	s.makeMockInstalledPcKernelAndGadget(c, "", "")
 	devicestate.SetSystemMode(s.mgr, "install")
 	s.state.Unlock()
 
@@ -407,7 +407,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallExpTasks(c *C) {
 
 	s.state.Lock()
 	s.makeMockInstallModel(c, "dangerous")
-	s.makeMockInstalledPcGadget(c, "", "")
+	s.makeMockInstalledPcKernelAndGadget(c, "", "")
 	devicestate.SetSystemMode(s.mgr, "install")
 	s.state.Unlock()
 
@@ -464,7 +464,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallRestoresPreseedArtifact(c *C) {
 
 	s.state.Lock()
 	s.makeMockInstallModel(c, "dangerous")
-	s.makeMockInstalledPcGadget(c, "", "")
+	s.makeMockInstalledPcKernelAndGadget(c, "", "")
 	devicestate.SetSystemMode(s.mgr, "install")
 	s.state.Unlock()
 
@@ -503,7 +503,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallRestoresPreseedArtifactError(c *C
 
 	s.state.Lock()
 	s.makeMockInstallModel(c, "dangerous")
-	s.makeMockInstalledPcGadget(c, "", "")
+	s.makeMockInstalledPcKernelAndGadget(c, "", "")
 	devicestate.SetSystemMode(s.mgr, "install")
 	s.state.Unlock()
 
@@ -1088,7 +1088,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallWithInstallDeviceHookExpTasks(c *
 
 	s.state.Lock()
 	s.makeMockInstallModel(c, "dangerous")
-	s.makeMockInstalledPcGadget(c, "install-device-hook-content", "")
+	s.makeMockInstalledPcKernelAndGadget(c, "install-device-hook-content", "")
 	devicestate.SetSystemMode(s.mgr, "install")
 	s.state.Unlock()
 
@@ -1160,7 +1160,7 @@ func (s *deviceMgrInstallModeSuite) testInstallWithInstallDeviceHookSnapctlReboo
 
 	s.state.Lock()
 	s.makeMockInstallModel(c, "dangerous")
-	s.makeMockInstalledPcGadget(c, "install-device-hook-content", "")
+	s.makeMockInstalledPcKernelAndGadget(c, "install-device-hook-content", "")
 	devicestate.SetSystemMode(s.mgr, "install")
 	s.state.Unlock()
 
@@ -1209,7 +1209,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallWithBrokenInstallDeviceHookUnhapp
 
 	s.state.Lock()
 	s.makeMockInstallModel(c, "dangerous")
-	s.makeMockInstalledPcGadget(c, "install-device-hook-content", "")
+	s.makeMockInstalledPcKernelAndGadget(c, "install-device-hook-content", "")
 	devicestate.SetSystemMode(s.mgr, "install")
 	s.state.Unlock()
 
@@ -1265,7 +1265,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallSetupRunSystemTaskNoRestarts(c *C
 	defer s.state.Unlock()
 
 	s.makeMockInstallModel(c, "dangerous")
-	s.makeMockInstalledPcGadget(c, "", "")
+	s.makeMockInstalledPcKernelAndGadget(c, "", "")
 	devicestate.SetSystemMode(s.mgr, "install")
 
 	// also set the system as installed so that the install-system change
@@ -1456,7 +1456,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallBootloaderVarSetFails(c *C) {
 
 	s.state.Lock()
 	s.makeMockInstallModel(c, "dangerous")
-	s.makeMockInstalledPcGadget(c, "", "")
+	s.makeMockInstalledPcKernelAndGadget(c, "", "")
 	devicestate.SetSystemMode(s.mgr, "install")
 	s.state.Unlock()
 
@@ -1485,7 +1485,7 @@ func (s *deviceMgrInstallModeSuite) testInstallEncryptionValidityChecks(c *C, er
 
 	s.state.Lock()
 	s.makeMockInstallModel(c, "dangerous")
-	s.makeMockInstalledPcGadget(c, "", "")
+	s.makeMockInstalledPcKernelAndGadget(c, "", "")
 	devicestate.SetSystemMode(s.mgr, "install")
 	s.state.Unlock()
 
@@ -1536,7 +1536,7 @@ func (s *deviceMgrInstallModeSuite) mockInstallModeChange(c *C, modelGrade, gadg
 
 	s.state.Lock()
 	mockModel := s.makeMockInstallModel(c, modelGrade)
-	s.makeMockInstalledPcGadget(c, "", gadgetDefaultsYaml)
+	s.makeMockInstalledPcKernelAndGadget(c, "", gadgetDefaultsYaml)
 	s.state.Unlock()
 	c.Check(mockModel.Grade(), Equals, asserts.ModelGrade(modelGrade))
 
@@ -1788,7 +1788,7 @@ func (s *deviceMgrInstallModeSuite) testInstallGadgetNoSave(c *C) {
 
 	s.state.Lock()
 	s.makeMockInstallModel(c, "dangerous")
-	s.makeMockInstalledPcGadget(c, "", "")
+	s.makeMockInstalledPcKernelAndGadget(c, "", "")
 	info, err := snapstate.CurrentInfo(s.state, "pc")
 	c.Assert(err, IsNil)
 	// replace gadget yaml with one that has no ubuntu-save
@@ -1913,7 +1913,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallCheckEncryptedStorageSafety(c *C)
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	s.makeMockInstalledPcGadget(c, "", "")
+	s.makeMockInstalledPcKernelAndGadget(c, "", "")
 
 	restore := devicestate.MockSecbootCheckTPMKeySealingSupported(func() error { return nil })
 	defer restore()
@@ -1969,7 +1969,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallCheckEncryptedErrors(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	s.makeMockInstalledPcGadget(c, "", "")
+	s.makeMockInstalledPcKernelAndGadget(c, "", "")
 
 	restore := devicestate.MockSecbootCheckTPMKeySealingSupported(func() error { return fmt.Errorf("tpm says no") })
 	defer restore()
@@ -2106,7 +2106,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallCheckEncryptedErrorsLogsTPM(c *C)
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	s.makeMockInstalledPcGadget(c, "", "")
+	s.makeMockInstalledPcKernelAndGadget(c, "", "")
 
 	restore := devicestate.MockSecbootCheckTPMKeySealingSupported(func() error {
 		return fmt.Errorf("tpm says no")
@@ -2164,7 +2164,7 @@ echo "mock output of: $(basename "$0") $*"
 	chg := s.state.NewChange("seed", "just for testing")
 	chg.AddTask(s.state.NewTask("test-task", "the change needs a task"))
 	s.makeMockInstallModel(c, "dangerous")
-	s.makeMockInstalledPcGadget(c, "", "")
+	s.makeMockInstalledPcKernelAndGadget(c, "", "")
 	devicestate.SetSystemMode(s.mgr, "install")
 	s.state.Unlock()
 
@@ -2342,7 +2342,7 @@ func (s *deviceMgrInstallModeSuite) doRunFactoryResetChange(c *C, model *asserts
 	}
 
 	s.state.Lock()
-	s.makeMockInstalledPcGadget(c, "", "")
+	s.makeMockInstalledPcKernelAndGadget(c, "", "")
 	s.state.Unlock()
 
 	var saveKey keys.EncryptionKey
@@ -2951,7 +2951,7 @@ func (s *deviceMgrInstallModeSuite) TestFactoryResetExpectedTasks(c *C) {
 
 	s.state.Lock()
 	s.makeMockInstallModel(c, "dangerous")
-	s.makeMockInstalledPcGadget(c, "", "")
+	s.makeMockInstalledPcKernelAndGadget(c, "", "")
 	devicestate.SetSystemMode(s.mgr, "factory-reset")
 	s.state.Unlock()
 

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -540,7 +540,7 @@ func (m *DeviceManager) checkEncryption(st *state.State, deviceCtx snapstate.Dev
 		return res, fmt.Errorf("cannot check encryption support: %v", err)
 	}
 	hasFDESetupHook = hasFDESetupHookInKernel(kernelInfo)
-	// Note that having a fde-setup hook will disable the build-in
+	// Note that having a fde-setup hook will disable the built-in
 	// secboot encryption
 	if hasFDESetupHook {
 		res, checkEncryptionErr = m.checkFDEFeatures()


### PR DESCRIPTION
The current code in DeviceManager.checkEncryption() will not return
an error if getting the KernelInfo fails. It was done this way
because historically we did not mock enough in many places in the
tests.

Now the tests need only a small update to do the proper checking
and error handling here. This commits adds the missing mocks and
updates the code.
