### PR TITLE
sandbox/apparmor: remove duplicate hook into testing package

### DIFF
--- a/sandbox/apparmor/profile_test.go
+++ b/sandbox/apparmor/profile_test.go
@@ -24,7 +24,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"testing"
 
 	. "gopkg.in/check.v1"
 
@@ -33,10 +32,6 @@ import (
 	"github.com/snapcore/snapd/sandbox/apparmor"
 	"github.com/snapcore/snapd/testutil"
 )
-
-func Test(t *testing.T) {
-	TestingT(t)
-}
 
 type appArmorSuite struct {
 	testutil.BaseTest


### PR DESCRIPTION
This is already present in apparmor_test.go, and having it here too
causes the tests in this package to be executed twice.

Thanks @pedronis for the heads up!
