### PR TITLE
store/tooling: support using snapcraft v7+ base64-encoded auth data

### DIFF
--- a/store/auth.go
+++ b/store/auth.go
@@ -42,6 +42,9 @@ type Authorizer interface {
 	// errors, as the higher-level code might as well treat Authorize
 	// as best-effort and only log any returned error.
 	Authorize(r *http.Request, dauthCtx DeviceAndAuthContext, user *auth.UserState, opts *AuthorizeOptions) error
+
+	// HasAuth returns whether is possible to authorize requests for user.
+	HasAuth(user *auth.UserState) bool
 }
 
 type AuthorizeOptions struct {

--- a/store/auth.go
+++ b/store/auth.go
@@ -43,8 +43,12 @@ type Authorizer interface {
 	// as best-effort and only log any returned error.
 	Authorize(r *http.Request, dauthCtx DeviceAndAuthContext, user *auth.UserState, opts *AuthorizeOptions) error
 
-	// HasAuth returns whether is possible to authorize requests for user.
-	HasAuth(user *auth.UserState) bool
+	// CanAuthorizeForUser should return true if the Authorizer
+	// can authorize requests on behalf of a user, either
+	// by the Authorizer using implicit data or by using auth data
+	// carried by UserState, in which case the availability of
+	// that explicit data in user should be checked.
+	CanAuthorizeForUser(user *auth.UserState) bool
 }
 
 type AuthorizeOptions struct {

--- a/store/auth_u1.go
+++ b/store/auth_u1.go
@@ -81,7 +81,7 @@ func (a UserAuthorizer) Authorize(r *http.Request, _ DeviceAndAuthContext, user 
 	return nil
 }
 
-func (a UserAuthorizer) HasAuth(user *auth.UserState) bool {
+func (a UserAuthorizer) CanAuthorizeForUser(user *auth.UserState) bool {
 	return user.HasStoreAuth()
 }
 

--- a/store/auth_u1.go
+++ b/store/auth_u1.go
@@ -81,6 +81,10 @@ func (a UserAuthorizer) Authorize(r *http.Request, _ DeviceAndAuthContext, user 
 	return nil
 }
 
+func (a UserAuthorizer) HasAuth(user *auth.UserState) bool {
+	return user.HasStoreAuth()
+}
+
 func (a UserAuthorizer) RefreshAuth(need AuthRefreshNeed, dauthCtx DeviceAndAuthContext, user *auth.UserState, client *http.Client) error {
 	if user == nil || !need.User {
 		return nil

--- a/store/store.go
+++ b/store/store.go
@@ -709,7 +709,7 @@ func (s *Store) doRequest(ctx context.Context, client *http.Client, reqOptions *
 			// and device need refreshing
 			wwwAuth := resp.Header.Get("WWW-Authenticate")
 			var refreshNeed AuthRefreshNeed
-			if user != nil && strings.Contains(wwwAuth, "needs_refresh=1") {
+			if strings.Contains(wwwAuth, "needs_refresh=1") {
 				// refresh user
 				refreshNeed.User = true
 			}
@@ -844,7 +844,7 @@ func (s *Store) decorateOrders(snaps []*snap.Info, user *auth.UserState) error {
 		}
 	}
 
-	if user == nil {
+	if !s.auth.HasAuth(user) {
 		return nil
 	}
 
@@ -987,7 +987,7 @@ type Search struct {
 // Find finds  (installable) snaps from the store, matching the
 // given Search.
 func (s *Store) Find(ctx context.Context, search *Search, user *auth.UserState) ([]*snap.Info, error) {
-	if search.Private && user == nil {
+	if search.Private && !s.auth.HasAuth(user) {
 		return nil, ErrUnauthenticated
 	}
 
@@ -1317,7 +1317,7 @@ func (s *Store) Buy(options *client.BuyOptions, user *auth.UserState) (*client.B
 	if options.Currency == "" {
 		return buyOptionError("currency missing")
 	}
-	if user == nil {
+	if !s.auth.HasAuth(user) {
 		return nil, ErrUnauthenticated
 	}
 
@@ -1392,7 +1392,7 @@ type storeCustomer struct {
 
 // ReadyToBuy returns nil if the user's account has accepted T&Cs and has a payment method registered, and an error otherwise
 func (s *Store) ReadyToBuy(user *auth.UserState) error {
-	if user == nil {
+	if !s.auth.HasAuth(user) {
 		return ErrUnauthenticated
 	}
 

--- a/store/store.go
+++ b/store/store.go
@@ -844,7 +844,7 @@ func (s *Store) decorateOrders(snaps []*snap.Info, user *auth.UserState) error {
 		}
 	}
 
-	if !s.auth.HasAuth(user) {
+	if !s.auth.CanAuthorizeForUser(user) {
 		return nil
 	}
 
@@ -987,7 +987,7 @@ type Search struct {
 // Find finds  (installable) snaps from the store, matching the
 // given Search.
 func (s *Store) Find(ctx context.Context, search *Search, user *auth.UserState) ([]*snap.Info, error) {
-	if search.Private && !s.auth.HasAuth(user) {
+	if search.Private && !s.auth.CanAuthorizeForUser(user) {
 		return nil, ErrUnauthenticated
 	}
 
@@ -1317,7 +1317,7 @@ func (s *Store) Buy(options *client.BuyOptions, user *auth.UserState) (*client.B
 	if options.Currency == "" {
 		return buyOptionError("currency missing")
 	}
-	if !s.auth.HasAuth(user) {
+	if !s.auth.CanAuthorizeForUser(user) {
 		return nil, ErrUnauthenticated
 	}
 
@@ -1392,7 +1392,7 @@ type storeCustomer struct {
 
 // ReadyToBuy returns nil if the user's account has accepted T&Cs and has a payment method registered, and an error otherwise
 func (s *Store) ReadyToBuy(user *auth.UserState) error {
-	if !s.auth.HasAuth(user) {
+	if !s.auth.CanAuthorizeForUser(user) {
 		return ErrUnauthenticated
 	}
 

--- a/store/tooling/auth.go
+++ b/store/tooling/auth.go
@@ -220,11 +220,13 @@ type UbuntuOneCreds struct {
 var _ store.Authorizer = (*UbuntuOneCreds)(nil)
 var _ store.RefreshingAuthorizer = (*UbuntuOneCreds)(nil)
 
-func (c *UbuntuOneCreds) Authorize(r *http.Request, _ store.DeviceAndAuthContext, user *auth.UserState, _ *store.AuthorizeOptions) error {
+func (c *UbuntuOneCreds) Authorize(r *http.Request, _ store.DeviceAndAuthContext, _ *auth.UserState, _ *store.AuthorizeOptions) error {
 	return store.UserAuthorizer{}.Authorize(r, nil, &c.User, nil)
 }
 
-func (c *UbuntuOneCreds) HasAuth(_ *auth.UserState) bool {
+func (c *UbuntuOneCreds) CanAuthorizeForUser(_ *auth.UserState) bool {
+	// UbuntuOneCreds carries a UserState with auth data by construction
+	// so we can authorize using that
 	return true
 }
 
@@ -248,6 +250,8 @@ func (c *SimpleCreds) Authorize(r *http.Request, _ store.DeviceAndAuthContext, u
 	return nil
 }
 
-func (c *SimpleCreds) HasAuth(_ *auth.UserState) bool {
+func (c *SimpleCreds) CanAuthorizeForUser(_ *auth.UserState) bool {
+	// SimpleCreds can authorize with the implicit auth data it carries
+	// on behalf of the user they were generated for
 	return true
 }

--- a/store/tooling/auth.go
+++ b/store/tooling/auth.go
@@ -1,0 +1,143 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package tooling
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/url"
+
+	"github.com/mvo5/goconfigparser"
+	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/snapdenv"
+	"github.com/snapcore/snapd/store"
+)
+
+type authData struct {
+	Macaroon   string   `json:"macaroon"`
+	Discharges []string `json:"discharges"`
+}
+
+func readAuthFile(authFn string) (*auth.UserState, error) {
+	data, err := ioutil.ReadFile(authFn)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read auth file %q: %v", authFn, err)
+	}
+
+	creds, err := parseAuthFile(authFn, data)
+	if err != nil {
+		// try snapcraft login format instead
+		var err2 error
+		creds, err2 = parseSnapcraftLoginFile(authFn, data)
+		if err2 != nil {
+			trimmed := bytes.TrimSpace(data)
+			if len(trimmed) > 0 && trimmed[0] == '[' {
+				return nil, err2
+			}
+			return nil, err
+		}
+	}
+
+	return &auth.UserState{
+		StoreMacaroon:   creds.Macaroon,
+		StoreDischarges: creds.Discharges,
+	}, nil
+}
+
+func parseAuthFile(authFn string, data []byte) (*authData, error) {
+	var creds authData
+	err := json.Unmarshal(data, &creds)
+	if err != nil {
+		return nil, fmt.Errorf("cannot decode auth file %q: %v", authFn, err)
+	}
+	if creds.Macaroon == "" || len(creds.Discharges) == 0 {
+		return nil, fmt.Errorf("invalid auth file %q: missing fields", authFn)
+	}
+	return &creds, nil
+}
+
+func snapcraftLoginSection() string {
+	if snapdenv.UseStagingStore() {
+		return "login.staging.ubuntu.com"
+	}
+	return "login.ubuntu.com"
+}
+
+func parseSnapcraftLoginFile(authFn string, data []byte) (*authData, error) {
+	errPrefix := fmt.Sprintf("invalid snapcraft login file %q", authFn)
+
+	cfg := goconfigparser.New()
+	if err := cfg.ReadString(string(data)); err != nil {
+		return nil, fmt.Errorf("%s: %v", errPrefix, err)
+	}
+	sec := snapcraftLoginSection()
+	macaroon, err := cfg.Get(sec, "macaroon")
+	if err != nil {
+		return nil, fmt.Errorf("%s: %s", errPrefix, err)
+	}
+	unboundDischarge, err := cfg.Get(sec, "unbound_discharge")
+	if err != nil {
+		return nil, fmt.Errorf("%s: %v", errPrefix, err)
+	}
+	if macaroon == "" || unboundDischarge == "" {
+		return nil, fmt.Errorf("invalid snapcraft login file %q: empty fields", authFn)
+	}
+	return &authData{
+		Macaroon:   macaroon,
+		Discharges: []string{unboundDischarge},
+	}, nil
+}
+
+// toolingStoreContext implements trivially store.DeviceAndAuthContext
+// except implementing UpdateUserAuth properly to be used to refresh a
+// soft-expired user macaroon.
+// XXX this will not be needed anymore
+type toolingStoreContext struct{}
+
+func (tac toolingStoreContext) CloudInfo() (*auth.CloudInfo, error) {
+	return nil, nil
+}
+
+func (tac toolingStoreContext) Device() (*auth.DeviceState, error) {
+	return &auth.DeviceState{}, nil
+}
+
+func (tac toolingStoreContext) DeviceSessionRequestParams(_ string) (*store.DeviceSessionRequestParams, error) {
+	return nil, store.ErrNoSerial
+}
+
+func (tac toolingStoreContext) ProxyStoreParams(defaultURL *url.URL) (proxyStoreID string, proxySroreURL *url.URL, err error) {
+	return "", defaultURL, nil
+}
+
+func (tac toolingStoreContext) StoreID(fallback string) (string, error) {
+	return fallback, nil
+}
+
+func (tac toolingStoreContext) UpdateDeviceAuth(_ *auth.DeviceState, newSessionMacaroon string) (*auth.DeviceState, error) {
+	return nil, fmt.Errorf("internal error: no device state in tools")
+}
+
+func (tac toolingStoreContext) UpdateUserAuth(user *auth.UserState, discharges []string) (*auth.UserState, error) {
+	user.StoreDischarges = discharges
+	return user, nil
+}

--- a/store/tooling/export_test.go
+++ b/store/tooling/export_test.go
@@ -20,7 +20,6 @@
 package tooling
 
 import (
-	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/store"
 )
 
@@ -29,12 +28,8 @@ var (
 	ErrPathInBase        = errPathInBase
 )
 
-func (tsto *ToolingStore) User() *auth.UserState {
-	return tsto.user
-}
-
-func ToolingStoreContext() store.DeviceAndAuthContext {
-	return toolingStoreContext{}
+func (tsto *ToolingStore) Creds() store.Authorizer {
+	return tsto.creds
 }
 
 func (opts *DownloadSnapOptions) Validate() error {

--- a/store/tooling/tooling.go
+++ b/store/tooling/tooling.go
@@ -20,22 +20,17 @@
 package tooling
 
 import (
-	"bytes"
 	"context"
 	"crypto"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
-	"net/url"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"strings"
 	"syscall"
 
-	"github.com/mvo5/goconfigparser"
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
@@ -43,7 +38,6 @@ import (
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/naming"
-	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/strutil"
 )
@@ -88,115 +82,6 @@ func newToolingStore(arch, storeID string) (*ToolingStore, error) {
 		sto:  sto,
 		user: user,
 	}, nil
-}
-
-type authData struct {
-	Macaroon   string   `json:"macaroon"`
-	Discharges []string `json:"discharges"`
-}
-
-func readAuthFile(authFn string) (*auth.UserState, error) {
-	data, err := ioutil.ReadFile(authFn)
-	if err != nil {
-		return nil, fmt.Errorf("cannot read auth file %q: %v", authFn, err)
-	}
-
-	creds, err := parseAuthFile(authFn, data)
-	if err != nil {
-		// try snapcraft login format instead
-		var err2 error
-		creds, err2 = parseSnapcraftLoginFile(authFn, data)
-		if err2 != nil {
-			trimmed := bytes.TrimSpace(data)
-			if len(trimmed) > 0 && trimmed[0] == '[' {
-				return nil, err2
-			}
-			return nil, err
-		}
-	}
-
-	return &auth.UserState{
-		StoreMacaroon:   creds.Macaroon,
-		StoreDischarges: creds.Discharges,
-	}, nil
-}
-
-func parseAuthFile(authFn string, data []byte) (*authData, error) {
-	var creds authData
-	err := json.Unmarshal(data, &creds)
-	if err != nil {
-		return nil, fmt.Errorf("cannot decode auth file %q: %v", authFn, err)
-	}
-	if creds.Macaroon == "" || len(creds.Discharges) == 0 {
-		return nil, fmt.Errorf("invalid auth file %q: missing fields", authFn)
-	}
-	return &creds, nil
-}
-
-func snapcraftLoginSection() string {
-	if snapdenv.UseStagingStore() {
-		return "login.staging.ubuntu.com"
-	}
-	return "login.ubuntu.com"
-}
-
-func parseSnapcraftLoginFile(authFn string, data []byte) (*authData, error) {
-	errPrefix := fmt.Sprintf("invalid snapcraft login file %q", authFn)
-
-	cfg := goconfigparser.New()
-	if err := cfg.ReadString(string(data)); err != nil {
-		return nil, fmt.Errorf("%s: %v", errPrefix, err)
-	}
-	sec := snapcraftLoginSection()
-	macaroon, err := cfg.Get(sec, "macaroon")
-	if err != nil {
-		return nil, fmt.Errorf("%s: %s", errPrefix, err)
-	}
-	unboundDischarge, err := cfg.Get(sec, "unbound_discharge")
-	if err != nil {
-		return nil, fmt.Errorf("%s: %v", errPrefix, err)
-	}
-	if macaroon == "" || unboundDischarge == "" {
-		return nil, fmt.Errorf("invalid snapcraft login file %q: empty fields", authFn)
-	}
-	return &authData{
-		Macaroon:   macaroon,
-		Discharges: []string{unboundDischarge},
-	}, nil
-}
-
-// toolingStoreContext implements trivially store.DeviceAndAuthContext
-// except implementing UpdateUserAuth properly to be used to refresh a
-// soft-expired user macaroon.
-type toolingStoreContext struct{}
-
-func (tac toolingStoreContext) CloudInfo() (*auth.CloudInfo, error) {
-	return nil, nil
-}
-
-func (tac toolingStoreContext) Device() (*auth.DeviceState, error) {
-	return &auth.DeviceState{}, nil
-}
-
-func (tac toolingStoreContext) DeviceSessionRequestParams(_ string) (*store.DeviceSessionRequestParams, error) {
-	return nil, store.ErrNoSerial
-}
-
-func (tac toolingStoreContext) ProxyStoreParams(defaultURL *url.URL) (proxyStoreID string, proxySroreURL *url.URL, err error) {
-	return "", defaultURL, nil
-}
-
-func (tac toolingStoreContext) StoreID(fallback string) (string, error) {
-	return fallback, nil
-}
-
-func (tac toolingStoreContext) UpdateDeviceAuth(_ *auth.DeviceState, newSessionMacaroon string) (*auth.DeviceState, error) {
-	return nil, fmt.Errorf("internal error: no device state in tools")
-}
-
-func (tac toolingStoreContext) UpdateUserAuth(user *auth.UserState, discharges []string) (*auth.UserState, error) {
-	user.StoreDischarges = discharges
-	return user, nil
 }
 
 // NewToolingStoreFromModel creates ToolingStore for the snap store used by the given model.

--- a/store/tooling/tooling_test.go
+++ b/store/tooling/tooling_test.go
@@ -428,7 +428,7 @@ func (s *toolingSuite) TestSimpleCreds(c *C) {
 		Scheme: "Auth-Scheme",
 		Value:  "auth-value",
 	}
-	c.Check(creds.HasAuth(nil), Equals, true)
+	c.Check(creds.CanAuthorizeForUser(nil), Equals, true)
 	r, err := http.NewRequest("POST", "http://svc", nil)
 	c.Assert(err, IsNil)
 	c.Assert(creds.Authorize(r, nil, nil, nil), IsNil)

--- a/store/tooling/tooling_test.go
+++ b/store/tooling/tooling_test.go
@@ -159,8 +159,13 @@ func (s *toolingSuite) TestNewToolingStoreWithAuthErrors(c *C) {
 		data string
 		err  string
 	}{
+		{"", `invalid auth file ".*/creds": empty`},
 		{" {}", `invalid auth file ".*/creds": missing fields`},
 		{" [...", `invalid snapcraft login file ".*/creds": No section: login.ubuntu.com`},
+		{`[login.ubuntu.com]
+macaroon =
+unbound_discharge =
+`, `invalid snapcraft login file ".*/creds": empty fields`},
 	}
 
 	for _, t := range tests {


### PR DESCRIPTION
including the simple credentials cases

this also starts supporting UBUNTU_STORE_AUTH taking diretcly the auth data instead of a filename.

to achieve this, we:
* reorg ToolingStore auth code
* fully allow for implicit user cred authorizing in store
* have the ToolingStore use and pass an Authorizer
