### PR TITLE
interfaces: make polkit implicit on core if /usr/libexec/polkitd exists

### DIFF
--- a/interfaces/builtin/polkit.go
+++ b/interfaces/builtin/polkit.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/polkit"
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/polkit/validate"
 	"github.com/snapcore/snapd/snap"
 )
@@ -146,7 +147,7 @@ func init() {
 		commonInterface{
 			name:                  "polkit",
 			summary:               polkitSummary,
-			implicitOnCore:        false,
+			implicitOnCore:        osutil.IsExecutable("/usr/libexec/polkitd"),
 			implicitOnClassic:     true,
 			baseDeclarationPlugs:  polkitBaseDeclarationPlugs,
 			baseDeclarationSlots:  polkitBaseDeclarationSlots,

--- a/interfaces/builtin/polkit_test.go
+++ b/interfaces/builtin/polkit_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/polkit"
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
@@ -269,6 +270,15 @@ apps:
 	polkitSpec := &polkit.Specification{}
 	err := polkitSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, ErrorMatches, `snap "other" has interface "polkit" with invalid value type bool for "action-prefix" attribute: \*string`)
+}
+
+func (s *polkitInterfaceSuite) TestStaticInfo(c *C) {
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Check(si.ImplicitOnCore, Equals, osutil.IsExecutable("/usr/libexec/polkitd"))
+	c.Check(si.ImplicitOnClassic, Equals, true)
+	c.Check(si.Summary, Equals, "allows access to polkitd to check authorisation")
+	c.Check(si.BaseDeclarationPlugs, testutil.Contains, "polkit")
+	c.Check(si.BaseDeclarationSlots, testutil.Contains, "polkit")
 }
 
 func (s *polkitInterfaceSuite) TestInterfaces(c *C) {


### PR DESCRIPTION
This PR implements the change suggested here:

https://forum.snapcraft.io/t/enabling-polkitd-on-ubuntu-core/31295?u=jamesh

We want to be able to use the polkit interface on Ubuntu Core Desktop, so need an implicit system slot to be present there. Currently we've been using a patched snapd that sets the interface to `implicitOnCore: true` unconditionally. That clearly wouldn't be acceptable to merge to master, since the standard Ubuntu Core releases don't support polkit.

This PR takes the approach of providing an implicit slot if the executable `/usr/libexec/polkitd` exists. This should be true for Core Desktop, and false for regular Core. It'd also start being true if future versions of Core ship polkit.

Note that old versions of Debian/Ubuntu installed polkitd to `/usr/lib/policykit-1/polkitd`. I chose not to check for this second path, since it seems unlikely that we'll ever add polkit support to Core releases based on these old Ubuntu versions.
