### PR TITLE
tests/nested: add test that checks connections after a revert

### DIFF
--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -599,6 +599,7 @@ func (s *daemonSuite) TestStartStop(c *check.C) {
 	st.Lock()
 	si := &snap.SideInfo{RealName: "core", Revision: snap.R(1), SnapID: "core-snap-id"}
 	snapstate.Set(st, "core", &snapstate.SnapState{
+		SnapType: "base",
 		Active:   true,
 		Sequence: []*snap.SideInfo{si},
 		Current:  snap.R(1),
@@ -737,6 +738,7 @@ func (s *daemonSuite) TestGracefulStop(c *check.C) {
 	st.Lock()
 	si := &snap.SideInfo{RealName: "core", Revision: snap.R(1), SnapID: "core-snap-id"}
 	snapstate.Set(st, "core", &snapstate.SnapState{
+		SnapType: "base",
 		Active:   true,
 		Sequence: []*snap.SideInfo{si},
 		Current:  snap.R(1),

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -149,7 +149,9 @@ func (m *InterfaceManager) StartUp() error {
 	// duration of this process always add implicit slots to snapd and not to
 	// any other type: os snap and use a mapper to use names core-snapd-system
 	// on state, in memory and in API responses, respectively.
-	m.selectInterfaceMapper(snaps)
+	if err := m.selectInterfaceMapper(); err != nil {
+		return err
+	}
 
 	if err := m.addInterfaces(m.extraInterfaces); err != nil {
 		return err

--- a/tests/nested/core/connected-after-reboot-revert/task.yaml
+++ b/tests/nested/core/connected-after-reboot-revert/task.yaml
@@ -1,0 +1,82 @@
+summary: Check that a after a revert of a boot snap connections are restored
+
+details: |
+  This test checks that after a revert that involved a boot snap (so we had
+  two reboots, one for installing and one for reverting) in a transactional
+  update, we still have connections to the base snap. It has been detected
+  that this happens if one of the updated snaps is snapd.
+
+systems: [ubuntu-16.04-64, ubuntu-18.04-64, ubuntu-20.04-64, ubuntu-22.04-64]
+
+execute: |
+  echo "Build kernel with failing post-refresh hook"
+  VERSION="$(tests.nested show version)"
+  CHANNEL=$VERSION
+  if [ "$VERSION" -eq 16 ]; then
+      CHANNEL=latest
+  fi
+  rm -rf pc-kernel
+  snap download --basename=pc-kernel --channel="$CHANNEL/edge" pc-kernel
+  unsquashfs -d pc-kernel pc-kernel.snap
+  HOOKS_D=pc-kernel/meta/hooks/
+  POST_REFRESH_P=$HOOKS_D/post-refresh
+  mkdir -p "$HOOKS_D"
+  cat > "$POST_REFRESH_P" << EOF
+  \#!/bin/bash -ex
+  exit 1
+  EOF
+  chmod +x "$POST_REFRESH_P"
+  snap pack pc-kernel/ --filename=pc-kernel_badhook.snap
+
+  echo "Wait for the system to be seeded first"
+  tests.nested exec "sudo snap wait system seed.loaded"
+
+  boot_id="$(tests.nested boot-id)"
+
+  echo "Install kernel with failing post-refresh hook"
+  tests.nested copy pc-kernel_badhook.snap
+
+  # install bluez
+  BLUEZ_CHANNEL=$VERSION
+  if [ "$VERSION" -eq 16 ] || [ "$VERSION" -eq 18 ]; then
+      BLUEZ_CHANNEL=latest
+  fi
+  echo "Install bluez snap and make sure connections to the base are performed"
+  tests.nested exec "sudo snap install --channel=\"$BLUEZ_CHANNEL\" bluez"
+  tests.nested exec "snap connections bluez" | MATCH 'uhid  *bluez:uhid  *:uhid'
+
+  chg_id=$(tests.nested exec 'sudo snap install \
+                              --dangerous --transaction=all-snaps --no-wait \
+                              ./pc-kernel_badhook.snap /var/lib/snapd/snaps/snapd_*.snap')
+
+  echo "Wait for reboot"
+  tests.nested wait-for reboot "$boot_id"
+
+  boot_id="$(tests.nested boot-id)"
+  echo "Wait for second reboot after post-refresh hook failure"
+  tests.nested wait-for reboot "$boot_id"
+
+  boot_id="$(tests.nested boot-id)"
+  # wait for change to finish with error
+  not tests.nested exec sudo snap watch "$chg_id"
+  # make sure that no additional reboots have happened while the change finished
+  test "$boot_id" = "$(tests.nested boot-id)"
+
+  echo "Check that connections to the base are kept"
+  tests.nested exec "snap connections bluez" | MATCH 'uhid  *bluez:uhid  *:uhid'
+
+  echo "Check that change finished with failure and that the old snap is being used"
+  tests.nested exec "snap info pc-kernel | MATCH 'installed:.*\(x1\)'"
+  tests.nested exec "snap changes | MATCH \"^$chg_id.*Error\""
+  if [ "$VERSION" -ge 20 ]; then
+      # shellcheck disable=SC2016
+      tests.nested exec 'test $(readlink /run/mnt/ubuntu-boot/EFI/ubuntu/kernel.efi) = pc-kernel_x1.snap/kernel.efi'
+      tests.nested exec 'cat /run/mnt/ubuntu-boot/EFI/ubuntu/grubenv | MATCH "^kernel_status=$"'
+      echo "Check that modeenv has only the old kernel"
+      tests.nested exec 'cat /var/lib/snapd/modeenv | MATCH "^current_kernels=pc-kernel_x1.snap$"'
+  else
+      tests.nested exec 'cat /boot/grub/grubenv | MATCH "^snap_kernel=pc-kernel_x1.snap$"'
+      tests.nested exec 'cat /boot/grub/grubenv | MATCH "^snap_mode=$"'
+      tests.nested exec 'cat /boot/grub/grubenv | MATCH "^snap_try_kernel=$"'
+      tests.nested exec 'cat /proc/cmdline | MATCH snap_kernel=pc-kernel_x1.snap'
+  fi

--- a/tests/nested/core/connected-after-reboot-revert/task.yaml
+++ b/tests/nested/core/connected-after-reboot-revert/task.yaml
@@ -3,8 +3,8 @@ summary: Check that a after a revert of a boot snap connections are restored
 details: |
   This test checks that after a revert that involved a boot snap (so we had
   two reboots, one for installing and one for reverting) in a transactional
-  update, we still have connections to the base snap. It has been detected
-  that this happens if one of the updated snaps is snapd.
+  update, we still have connections to the base snap. This could happen in
+  the past if one of the updated snaps was snapd.
 
 systems: [ubuntu-16.04-64, ubuntu-18.04-64, ubuntu-20.04-64, ubuntu-22.04-64]
 
@@ -45,15 +45,28 @@ execute: |
   tests.nested exec "sudo snap install --channel=\"$BLUEZ_CHANNEL\" bluez"
   tests.nested exec "snap connections bluez" | MATCH 'uhid  *bluez:uhid  *:uhid'
 
-  chg_id=$(tests.nested exec 'sudo snap install \
+  if [ "$VERSION" -eq 16 ]; then
+      snapd_snap=$(tests.nested exec find /var/lib/snapd/seed/snaps/ -name 'core_*.snap')
+  else
+      snapd_snap=$(tests.nested exec find /var/lib/snapd/seed/snaps/ -name 'snapd_*.snap')
+  fi
+
+  chg_id=$(tests.nested exec "sudo snap install \
                               --dangerous --transaction=all-snaps --no-wait \
-                              ./pc-kernel_badhook.snap /var/lib/snapd/snaps/snapd_*.snap')
+                              ./pc-kernel_badhook.snap \"$snapd_snap\"")
 
   echo "Wait for reboot"
   tests.nested wait-for reboot "$boot_id"
 
+  # For UC16 we get two reboots on install, as both core and kernel are being updated
+  if [ "$VERSION" -eq 16 ]; then
+      boot_id="$(tests.nested boot-id)"
+      echo "Wait for second reboot for UC16"
+      tests.nested wait-for reboot "$boot_id"
+  fi
+
   boot_id="$(tests.nested boot-id)"
-  echo "Wait for second reboot after post-refresh hook failure"
+  echo "Wait for reboot after post-refresh hook failure"
   tests.nested wait-for reboot "$boot_id"
 
   boot_id="$(tests.nested boot-id)"


### PR DESCRIPTION
Add test that checks that after a revert of a boot snap connections
are restored.