### PR TITLE
many: support refresh hold/unhold to API and CLI

### DIFF
--- a/client/snap_op.go
+++ b/client/snap_op.go
@@ -60,6 +60,7 @@ type SnapOptions struct {
 	QuotaGroupName   string          `json:"quota-group,omitempty"`
 	ValidationSets   []string        `json:"validation-sets,omitempty"`
 	Time             string          `json:"time,omitempty"`
+	HoldLevel        string          `json:"hold-level,omitempty"`
 
 	Users []string `json:"users,omitempty"`
 }
@@ -130,6 +131,7 @@ type multiActionData struct {
 	Purge          bool            `json:"purge,omitempty"`
 	ValidationSets []string        `json:"validation-sets,omitempty"`
 	Time           string          `json:"time,omitempty"`
+	HoldLevel      string          `json:"hold-level,omitempty"`
 }
 
 // Install adds the snap with the given name from the given channel (or
@@ -255,6 +257,7 @@ func (client *Client) doMultiSnapActionFull(actionName string, snaps []string, o
 		action.Purge = options.Purge
 		action.ValidationSets = options.ValidationSets
 		action.Time = options.Time
+		action.HoldLevel = options.HoldLevel
 	}
 
 	data, err := json.Marshal(&action)

--- a/client/snap_op.go
+++ b/client/snap_op.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2017 Canonical Ltd
+ * Copyright (C) 2016-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -59,6 +59,7 @@ type SnapOptions struct {
 	Transaction      TransactionType `json:"transaction,omitempty"`
 	QuotaGroupName   string          `json:"quota-group,omitempty"`
 	ValidationSets   []string        `json:"validation-sets,omitempty"`
+	Time             string          `json:"time,omitempty"`
 
 	Users []string `json:"users,omitempty"`
 }
@@ -128,6 +129,7 @@ type multiActionData struct {
 	IgnoreRunning  bool            `json:"ignore-running,omitempty"`
 	Purge          bool            `json:"purge,omitempty"`
 	ValidationSets []string        `json:"validation-sets,omitempty"`
+	Time           string          `json:"time,omitempty"`
 }
 
 // Install adds the snap with the given name from the given channel (or
@@ -157,6 +159,22 @@ func (client *Client) Refresh(name string, options *SnapOptions) (changeID strin
 
 func (client *Client) RefreshMany(names []string, options *SnapOptions) (changeID string, err error) {
 	return client.doMultiSnapAction("refresh", names, options)
+}
+
+func (client *Client) HoldRefreshes(name string, options *SnapOptions) (changeID string, err error) {
+	return client.doSnapAction("hold", name, options)
+}
+
+func (client *Client) HoldRefreshesMany(name []string, options *SnapOptions) (changeID string, err error) {
+	return client.doMultiSnapAction("hold", name, options)
+}
+
+func (client *Client) UnholdRefreshes(name string, options *SnapOptions) (changeID string, err error) {
+	return client.doSnapAction("unhold", name, options)
+}
+
+func (client *Client) UnholdRefreshesMany(name []string, options *SnapOptions) (changeID string, err error) {
+	return client.doMultiSnapAction("unhold", name, options)
 }
 
 func (client *Client) Enable(name string, options *SnapOptions) (changeID string, err error) {
@@ -236,6 +254,7 @@ func (client *Client) doMultiSnapActionFull(actionName string, snaps []string, o
 		action.IgnoreRunning = options.IgnoreRunning
 		action.Purge = options.Purge
 		action.ValidationSets = options.ValidationSets
+		action.Time = options.Time
 	}
 
 	data, err := json.Marshal(&action)

--- a/client/snap_op.go
+++ b/client/snap_op.go
@@ -165,16 +165,16 @@ func (client *Client) HoldRefreshes(name string, options *SnapOptions) (changeID
 	return client.doSnapAction("hold", name, options)
 }
 
-func (client *Client) HoldRefreshesMany(name []string, options *SnapOptions) (changeID string, err error) {
-	return client.doMultiSnapAction("hold", name, options)
+func (client *Client) HoldRefreshesMany(names []string, options *SnapOptions) (changeID string, err error) {
+	return client.doMultiSnapAction("hold", names, options)
 }
 
 func (client *Client) UnholdRefreshes(name string, options *SnapOptions) (changeID string, err error) {
 	return client.doSnapAction("unhold", name, options)
 }
 
-func (client *Client) UnholdRefreshesMany(name []string, options *SnapOptions) (changeID string, err error) {
-	return client.doMultiSnapAction("unhold", name, options)
+func (client *Client) UnholdRefreshesMany(names []string, options *SnapOptions) (changeID string, err error) {
+	return client.doMultiSnapAction("unhold", names, options)
 }
 
 func (client *Client) Enable(name string, options *SnapOptions) (changeID string, err error) {

--- a/client/snap_op_test.go
+++ b/client/snap_op_test.go
@@ -49,6 +49,8 @@ var ops = []struct {
 	{(*client.Client).Enable, "enable"},
 	{(*client.Client).Disable, "disable"},
 	{(*client.Client).Switch, "switch"},
+	{(*client.Client).HoldRefreshes, "hold"},
+	{(*client.Client).UnholdRefreshes, "unhold"},
 }
 
 var multiOps = []struct {
@@ -58,6 +60,8 @@ var multiOps = []struct {
 	{(*client.Client).RefreshMany, "refresh"},
 	{(*client.Client).InstallMany, "install"},
 	{(*client.Client).RemoveMany, "remove"},
+	{(*client.Client).HoldRefreshesMany, "hold"},
+	{(*client.Client).UnholdRefreshesMany, "unhold"},
 }
 
 func (cs *clientSuite) TestClientOpSnapServerError(c *check.C) {

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2017 Canonical Ltd
+ * Copyright (C) 2016-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -94,6 +94,10 @@ have developer access to the snap, either directly or through the
 store's collaboration feature, and to be logged in (see 'snap help login').
 
 Note a later refresh will typically undo a revision override.
+
+Using --hold without specifying any snaps will hold all snap refreshes. Holds
+are only applied to general refreshes (including auto-refreshes), but snaps can
+still be refreshed in specific refreshes (i.e, 'snap refresh snap-a snap-b').
 `)
 
 var longTryHelp = i18n.G(`
@@ -682,6 +686,8 @@ type cmdRefresh struct {
 	IgnoreValidation bool                   `long:"ignore-validation"`
 	IgnoreRunning    bool                   `long:"ignore-running" hidden:"yes"`
 	Transaction      client.TransactionType `long:"transaction" default:"per-snap" choice:"all-snaps" choice:"per-snap"`
+	Hold             string                 `long:"hold" optional:"yes" optional-value:"forever"`
+	Unhold           bool                   `long:"unhold"`
 	Positional       struct {
 		Snaps []installedSnapName `positional-arg-name:"<snap>"`
 	} `positional-args:"yes"`
@@ -841,6 +847,20 @@ func (x *cmdRefresh) Execute([]string) error {
 		return nil
 	}
 
+	otherFlags := x.Amend || x.Revision != "" || x.Cohort != "" ||
+		x.LeaveCohort || x.List || x.Time || x.IgnoreValidation || x.IgnoreRunning ||
+		x.Transaction != client.TransactionPerSnap
+
+	if x.Hold != "" && (x.Unhold || otherFlags) {
+		return errors.New(i18n.G("cannot use --hold with other flags"))
+	} else if x.Unhold && (x.Hold != "" || otherFlags) {
+		return errors.New(i18n.G("cannot use --unhold with other flags"))
+	} else if x.Hold != "" {
+		return x.holdRefreshes()
+	} else if x.Unhold {
+		return x.unholdRefreshes()
+	}
+
 	names := installedSnapNames(x.Positional.Snaps)
 	if len(names) == 1 {
 		opts := &client.SnapOptions{
@@ -872,6 +892,81 @@ func (x *cmdRefresh) Execute([]string) error {
 	}
 
 	return x.refreshMany(names, opts)
+}
+
+func (x *cmdRefresh) holdRefreshes() (err error) {
+	var opts client.SnapOptions
+
+	if x.Hold == "forever" {
+		opts.Time = "forever"
+	} else {
+		dur, err := time.ParseDuration(x.Hold)
+		if err != nil {
+			return fmt.Errorf("hold value must be a number of hours or minutes (e.g., 72h): %v", err)
+		}
+
+		opts.Time = timeNow().Add(dur).Format(time.RFC3339)
+	}
+
+	names := installedSnapNames(x.Positional.Snaps)
+	var changeID, snapStr string
+	if len(names) == 1 {
+		changeID, err = x.client.HoldRefreshes(names[0], &opts)
+		snapStr = names[0]
+	} else {
+		changeID, err = x.client.HoldRefreshesMany(names, &opts)
+		if len(names) == 0 {
+			snapStr = "all snaps"
+		} else {
+			snapStr = strutil.Quoted(names)
+		}
+	}
+
+	if err != nil {
+		return err
+	}
+
+	_, err = x.wait(changeID)
+	if err != nil {
+		if err == noWait {
+			return nil
+		}
+		return err
+	}
+
+	fmt.Fprintf(Stdout, i18n.G("Held refreshes of %s until %s\n"), snapStr, opts.Time)
+	return nil
+}
+
+func (x *cmdRefresh) unholdRefreshes() (err error) {
+	names := installedSnapNames(x.Positional.Snaps)
+	var changeID, snapStr string
+	if len(names) == 1 {
+		changeID, err = x.client.UnholdRefreshes(names[0], nil)
+		snapStr = names[0]
+	} else {
+		changeID, err = x.client.UnholdRefreshesMany(names, nil)
+		if len(names) == 0 {
+			snapStr = "all snaps"
+		} else {
+			snapStr = strutil.Quoted(names)
+		}
+	}
+
+	if err != nil {
+		return err
+	}
+
+	_, err = x.wait(changeID)
+	if err != nil {
+		if err == noWait {
+			return nil
+		}
+		return err
+	}
+
+	fmt.Fprintf(Stdout, i18n.G("Removed hold on refreshes for %s\n"), snapStr)
+	return nil
 }
 
 type cmdTry struct {
@@ -1182,6 +1277,10 @@ func init() {
 			"leave-cohort": i18n.G("Refresh the snap out of its cohort"),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"transaction": i18n.G("Have one transaction per-snap or one for all the specified snaps"),
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"hold": i18n.G("Hold refreshes for a specified duration (or indefinitely, if none is specified"),
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"unhold": i18n.G("Remove hold on refreshes"),
 		}), nil)
 	addCommand("try", shortTryHelp, longTryHelp, func() flags.Commander { return &cmdTry{} }, waitDescs.also(modeDescs), nil)
 	addCommand("enable", shortEnableHelp, longEnableHelp, func() flags.Commander { return &cmdEnable{} }, waitDescs, nil)

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -95,10 +95,17 @@ store's collaboration feature, and to be logged in (see 'snap help login').
 
 Note a later refresh will typically undo a revision override.
 
-Holds (--hold) specified for snaps are only applied to general refreshes ('snap 
-refresh' without specifying snaps and auto-refreshes), but snaps can still be
-refreshed in specific refreshes (i.e, 'snap refresh snap-a snap-b'). Using
---hold without specifying any snaps will only hold auto-refreshes for all snaps.
+Hold (--hold) is used to postpone snap refresh updates for all snaps when no
+snaps are specified, or for the specified snaps.
+
+When no snaps are specified --hold is only effective on auto-refreshes and will
+not block either general refresh requests from 'snap refresh' or specific snap
+requests from 'snap refresh target-snap'.
+
+When specific snaps are mentioned --hold is effective on their auto-refreshes
+and will also silently block general refresh requests from 'snap refresh' of
+those snaps while explicit targeted 'snap refresh target-snap' will not be
+blocked.
 `)
 
 var longTryHelp = i18n.G(`
@@ -911,6 +918,10 @@ func (x *cmdRefresh) holdRefreshes() (err error) {
 
 	names := installedSnapNames(x.Positional.Snaps)
 	var changeID string
+	opts.HoldLevel = "general"
+	if len(names) == 0 {
+		opts.HoldLevel = "auto-refresh"
+	}
 	if len(names) == 1 {
 		changeID, err = x.client.HoldRefreshes(names[0], &opts)
 	} else {
@@ -930,9 +941,9 @@ func (x *cmdRefresh) holdRefreshes() (err error) {
 	}
 
 	if len(names) == 0 {
-		fmt.Fprintf(Stdout, i18n.G("Held auto-refreshes of all snaps until %s\n"), opts.Time)
+		fmt.Fprintf(Stdout, i18n.G("Auto-refresh of all snaps held until %s\n"), opts.Time)
 	} else {
-		fmt.Fprintf(Stdout, i18n.G("Held general refreshes of %s until %s\n"), strutil.Quoted(names), opts.Time)
+		fmt.Fprintf(Stdout, i18n.G("General refreshes of %s held until %s\n"), strutil.Quoted(names), opts.Time)
 	}
 
 	return nil
@@ -960,9 +971,9 @@ func (x *cmdRefresh) unholdRefreshes() (err error) {
 	}
 
 	if len(names) == 0 {
-		fmt.Fprintf(Stdout, i18n.G("Removed hold on auto-refreshes of all snaps\n"))
+		fmt.Fprintf(Stdout, i18n.G("Removed auto-refresh hold on all snaps\n"))
 	} else {
-		fmt.Fprintf(Stdout, i18n.G("Removed hold on general refreshes of %s\n"), strutil.Quoted(names))
+		fmt.Fprintf(Stdout, i18n.G("Removed general refresh hold of %s\n"), strutil.Quoted(names))
 	}
 
 	return nil
@@ -1277,9 +1288,9 @@ func init() {
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"transaction": i18n.G("Have one transaction per-snap or one for all the specified snaps"),
 			// TRANSLATORS: This should not start with a lowercase letter.
-			"hold": i18n.G("Hold refreshes for a specified duration (or indefinitely, if none is specified"),
+			"hold": i18n.G("Hold refreshes for a specified duration (or indefinitely, if none is specified)"),
 			// TRANSLATORS: This should not start with a lowercase letter.
-			"unhold": i18n.G("Remove hold on refreshes"),
+			"unhold": i18n.G("Remove refresh hold"),
 		}), nil)
 	addCommand("try", shortTryHelp, longTryHelp, func() flags.Commander { return &cmdTry{} }, waitDescs.also(modeDescs), nil)
 	addCommand("enable", shortEnableHelp, longEnableHelp, func() flags.Commander { return &cmdEnable{} }, waitDescs, nil)

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -1434,7 +1434,7 @@ func (s *SnapSuite) TestRefreshHoldAllForever(c *check.C) {
 	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--hold"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
-	c.Check(s.Stdout(), check.Equals, "Held refreshes of all snaps until forever\n")
+	c.Check(s.Stdout(), check.Equals, "Held auto-refreshes of all snaps until forever\n")
 	c.Check(s.Stderr(), check.Equals, "")
 }
 
@@ -1477,7 +1477,7 @@ func (s *SnapSuite) TestRefreshHoldManySpecificTime(c *check.C) {
 	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--hold=7h", "foo", "bar"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
-	c.Check(s.Stdout(), check.Equals, "Held refreshes of \"foo\", \"bar\" until 3000-01-01T07:00:00Z\n")
+	c.Check(s.Stdout(), check.Equals, "Held general refreshes of \"foo\", \"bar\" until 3000-01-01T07:00:00Z\n")
 	c.Check(s.Stderr(), check.Equals, "")
 }
 
@@ -1519,7 +1519,7 @@ func (s *SnapSuite) TestRefreshHoldSnapUntilSpecificTime(c *check.C) {
 	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--hold=7h", "foo"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
-	c.Check(s.Stdout(), check.Equals, "Held refreshes of foo until 3000-01-01T07:00:00Z\n")
+	c.Check(s.Stdout(), check.Equals, "Held general refreshes of \"foo\" until 3000-01-01T07:00:00Z\n")
 	c.Check(s.Stderr(), check.Equals, "")
 }
 
@@ -1554,7 +1554,7 @@ func (s *SnapSuite) TestRefreshHoldSnapForever(c *check.C) {
 	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--hold", "foo"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
-	c.Check(s.Stdout(), check.Equals, "Held refreshes of foo until forever\n")
+	c.Check(s.Stdout(), check.Equals, "Held general refreshes of \"foo\" until forever\n")
 	c.Check(s.Stderr(), check.Equals, "")
 }
 
@@ -1588,7 +1588,7 @@ func (s *SnapSuite) TestRefreshUnholdAllSnaps(c *check.C) {
 	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--unhold"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
-	c.Check(s.Stdout(), check.Equals, "Removed hold on refreshes for all snaps\n")
+	c.Check(s.Stdout(), check.Equals, "Removed hold on auto-refreshes of all snaps\n")
 	c.Check(s.Stderr(), check.Equals, "")
 }
 
@@ -1622,7 +1622,7 @@ func (s *SnapSuite) TestRefreshUnholdOneSnap(c *check.C) {
 	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--unhold", "foo"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
-	c.Check(s.Stdout(), check.Equals, "Removed hold on refreshes for foo\n")
+	c.Check(s.Stdout(), check.Equals, "Removed hold on general refreshes of \"foo\"\n")
 	c.Check(s.Stderr(), check.Equals, "")
 }
 
@@ -1657,7 +1657,7 @@ func (s *SnapSuite) TestRefreshUnholdManySnaps(c *check.C) {
 	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--unhold", "foo", "bar"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
-	c.Check(s.Stdout(), check.Equals, "Removed hold on refreshes for \"foo\", \"bar\"\n")
+	c.Check(s.Stdout(), check.Equals, "Removed hold on general refreshes of \"foo\", \"bar\"\n")
 	c.Check(s.Stderr(), check.Equals, "")
 }
 

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -1376,7 +1376,7 @@ next: 2017-04-26T00:58:00+02:00
 	c.Check(n, check.Equals, 1)
 }
 
-func (s *SnapSuite) TestRefreshHold(c *check.C) {
+func (s *SnapSuite) TestRefreshTimeShowsHolds(c *check.C) {
 	n := 0
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		switch n {
@@ -1401,6 +1401,292 @@ next: 2017-04-26T00:58:00+02:00 (but held)
 	c.Check(s.Stderr(), check.Equals, "")
 	// ensure that the fake server api was actually hit
 	c.Check(n, check.Equals, 1)
+}
+
+func (s *SnapSuite) TestRefreshHoldAllForever(c *check.C) {
+	var n int
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		switch n {
+		case 0:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Check(r.URL.Path, check.Equals, "/v2/snaps")
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+				"action": "hold",
+				"time":   "forever",
+			})
+			w.WriteHeader(202)
+			fmt.Fprintln(w, `{"type": "async", "change": "42", "status-code": 202}`)
+
+		case 1:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/changes/42")
+			w.WriteHeader(200)
+			fmt.Fprintln(w, `{"type": "sync", "result": {"ready": true, "status": "Done"}}`)
+
+		default:
+			c.Errorf("expected to get 2 requests, now on %d", n+1)
+			fmt.Fprintln(w, `{"type": "error", "result": {"message": "received too many requests"}, "status-code": 500}`)
+		}
+
+		n++
+	})
+
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--hold"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.DeepEquals, []string{})
+	c.Check(s.Stdout(), check.Equals, "Held refreshes of all snaps until forever\n")
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *SnapSuite) TestRefreshHoldManySpecificTime(c *check.C) {
+	t, err := time.Parse(time.RFC3339, "3000-01-01T00:00:00Z")
+	c.Assert(err, check.IsNil)
+	restore := snap.MockTimeNow(func() time.Time {
+		return t
+	})
+	defer restore()
+
+	var n int
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		switch n {
+		case 0:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Check(r.URL.Path, check.Equals, "/v2/snaps")
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+				"action": "hold",
+				"time":   "3000-01-01T07:00:00Z",
+				"snaps":  []interface{}{"foo", "bar"},
+			})
+			w.WriteHeader(202)
+			fmt.Fprintln(w, `{"type": "async", "change": "42", "status-code": 202}`)
+
+		case 1:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/changes/42")
+			w.WriteHeader(200)
+			fmt.Fprintln(w, `{"type": "sync", "result": {"ready": true, "status": "Done"}}`)
+
+		default:
+			c.Errorf("expected to get 2 requests, now on %d", n+1)
+			fmt.Fprintln(w, `{"type": "error", "result": {"message": "received too many requests"}, "status-code": 500}`)
+		}
+
+		n++
+	})
+
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--hold=7h", "foo", "bar"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.DeepEquals, []string{})
+	c.Check(s.Stdout(), check.Equals, "Held refreshes of \"foo\", \"bar\" until 3000-01-01T07:00:00Z\n")
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *SnapSuite) TestRefreshHoldSnapUntilSpecificTime(c *check.C) {
+	t, err := time.Parse(time.RFC3339, "3000-01-01T00:00:00Z")
+	c.Assert(err, check.IsNil)
+	restore := snap.MockTimeNow(func() time.Time {
+		return t
+	})
+	defer restore()
+
+	var n int
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		switch n {
+		case 0:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+				"action": "hold",
+				"time":   "3000-01-01T07:00:00Z",
+			})
+			w.WriteHeader(202)
+			fmt.Fprintln(w, `{"type": "async", "change": "42", "status-code": 202}`)
+
+		case 1:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/changes/42")
+			w.WriteHeader(200)
+			fmt.Fprintln(w, `{"type": "sync", "result": {"ready": true, "status": "Done"}}`)
+
+		default:
+			c.Errorf("expected to get 2 requests, now on %d", n+1)
+			fmt.Fprintln(w, `{"type": "error", "result": {"message": "received too many requests"}, "status-code": 500}`)
+		}
+
+		n++
+	})
+
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--hold=7h", "foo"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.DeepEquals, []string{})
+	c.Check(s.Stdout(), check.Equals, "Held refreshes of foo until 3000-01-01T07:00:00Z\n")
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *SnapSuite) TestRefreshHoldSnapForever(c *check.C) {
+	var n int
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		switch n {
+		case 0:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+				"action": "hold",
+				"time":   "forever",
+			})
+			w.WriteHeader(202)
+			fmt.Fprintln(w, `{"type": "async", "change": "42", "status-code": 202}`)
+
+		case 1:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/changes/42")
+			w.WriteHeader(200)
+			fmt.Fprintln(w, `{"type": "sync", "result": {"ready": true, "status": "Done"}}`)
+
+		default:
+			c.Errorf("expected to get 2 requests, now on %d", n+1)
+			fmt.Fprintln(w, `{"type": "error", "result": {"message": "received too many requests"}, "status-code": 500}`)
+		}
+
+		n++
+	})
+
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--hold", "foo"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.DeepEquals, []string{})
+	c.Check(s.Stdout(), check.Equals, "Held refreshes of foo until forever\n")
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *SnapSuite) TestRefreshUnholdAllSnaps(c *check.C) {
+	var n int
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		switch n {
+		case 0:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Check(r.URL.Path, check.Equals, "/v2/snaps")
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+				"action": "unhold",
+			})
+			w.WriteHeader(202)
+			fmt.Fprintln(w, `{"type": "async", "change": "42", "status-code": 202}`)
+
+		case 1:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/changes/42")
+			w.WriteHeader(200)
+			fmt.Fprintln(w, `{"type": "sync", "result": {"ready": true, "status": "Done"}}`)
+
+		default:
+			c.Errorf("expected to get 2 requests, now on %d", n+1)
+			fmt.Fprintln(w, `{"type": "error", "result": {"message": "received too many requests"}, "status-code": 500}`)
+		}
+
+		n++
+	})
+
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--unhold"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.DeepEquals, []string{})
+	c.Check(s.Stdout(), check.Equals, "Removed hold on refreshes for all snaps\n")
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *SnapSuite) TestRefreshUnholdOneSnap(c *check.C) {
+	var n int
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		switch n {
+		case 0:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+				"action": "unhold",
+			})
+			w.WriteHeader(202)
+			fmt.Fprintln(w, `{"type": "async", "change": "42", "status-code": 202}`)
+
+		case 1:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/changes/42")
+			w.WriteHeader(200)
+			fmt.Fprintln(w, `{"type": "sync", "result": {"ready": true, "status": "Done"}}`)
+
+		default:
+			c.Errorf("expected to get 2 requests, now on %d", n+1)
+			fmt.Fprintln(w, `{"type": "error", "result": {"message": "received too many requests"}, "status-code": 500}`)
+		}
+
+		n++
+	})
+
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--unhold", "foo"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.DeepEquals, []string{})
+	c.Check(s.Stdout(), check.Equals, "Removed hold on refreshes for foo\n")
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *SnapSuite) TestRefreshUnholdManySnaps(c *check.C) {
+	var n int
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		switch n {
+		case 0:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Check(r.URL.Path, check.Equals, "/v2/snaps")
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+				"action": "unhold",
+				"snaps":  []interface{}{"foo", "bar"},
+			})
+			w.WriteHeader(202)
+			fmt.Fprintln(w, `{"type": "async", "change": "42", "status-code": 202}`)
+
+		case 1:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/changes/42")
+			w.WriteHeader(200)
+			fmt.Fprintln(w, `{"type": "sync", "result": {"ready": true, "status": "Done"}}`)
+
+		default:
+			c.Errorf("expected to get 2 requests, now on %d", n+1)
+			fmt.Fprintln(w, `{"type": "error", "result": {"message": "received too many requests"}, "status-code": 500}`)
+		}
+
+		n++
+	})
+
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--unhold", "foo", "bar"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.DeepEquals, []string{})
+	c.Check(s.Stdout(), check.Equals, "Removed hold on refreshes for \"foo\", \"bar\"\n")
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *SnapSuite) TestRefreshHoldAndUnholdFailWithOtherFlags(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Errorf("unexpected request")
+		fmt.Fprintln(w, `{"type": "error", "result": {"message": "received too many requests"}, "status-code": 500}`)
+	})
+
+	for _, flag := range []string{"--hold", "--unhold"} {
+		rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", flag, "--amend"})
+		c.Assert(err, check.ErrorMatches, fmt.Sprintf("cannot use %s with other flags", flag))
+		c.Assert(rest, check.DeepEquals, []string{"--amend"})
+		c.Check(s.Stdout(), check.Equals, "")
+		c.Check(s.Stderr(), check.Equals, "")
+	}
+}
+
+func (s *SnapSuite) TestRefreshHoldBadDuration(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Errorf("unexpected request")
+		fmt.Fprintln(w, `{"type": "error", "result": {"message": "received too many requests"}, "status-code": 500}`)
+	})
+
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--hold=1d"})
+	c.Assert(err, check.ErrorMatches, "hold value must be a number of hours or minutes \\(e\\.g\\., 72h\\): time: unknown unit \"?d\"? in duration \"?1d\"?")
+	c.Assert(rest, check.DeepEquals, []string{"--hold=1d"})
+	c.Check(s.Stdout(), check.Equals, "")
+	c.Check(s.Stderr(), check.Equals, "")
 }
 
 func (s *SnapSuite) TestRefreshNoTimerNoSchedule(c *check.C) {

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015-2020 Canonical Ltd
+ * Copyright (C) 2015-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -29,6 +29,7 @@ import (
 
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/overlord/configstate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/strutil"
@@ -144,6 +145,10 @@ var (
 	snapstateRevert                         = snapstate.Revert
 	snapstateRevertToRevision               = snapstate.RevertToRevision
 	snapstateSwitch                         = snapstate.Switch
+	snapstateProceedWithRefresh             = snapstate.ProceedWithRefresh
+	snapstateHoldRefreshesBySystem          = snapstate.HoldRefreshesBySystem
+
+	configstateConfigureInstalled = configstate.ConfigureInstalled
 
 	assertstateRefreshSnapAssertions         = assertstate.RefreshSnapAssertions
 	assertstateRestoreValidationSetsTracking = assertstate.RestoreValidationSetsTracking

--- a/daemon/api_snaps.go
+++ b/daemon/api_snaps.go
@@ -924,15 +924,15 @@ func snapHoldMany(inst *snapInstruction, st *state.State) (res *snapInstructionR
 		}
 
 		tss = []*state.TaskSet{ts}
-		msg = i18n.G("Hold auto-refreshes for all snaps.")
+		msg = i18n.G("Hold auto-refreshes for all snaps")
 	} else {
 		holdLevel := inst.holdLevel()
 		if err := snapstateHoldRefreshesBySystem(st, holdLevel, inst.Time, inst.Snaps); err != nil {
 			return nil, err
 		}
-		msgFmt := i18n.G("Hold general refreshes for %s.")
+		msgFmt := i18n.G("Hold general refreshes for %s")
 		if holdLevel == snapstate.HoldAutoRefresh {
-			msgFmt = i18n.G("Hold auto-refreshes for %s.")
+			msgFmt = i18n.G("Hold auto-refreshes for %s")
 		}
 		msg = fmt.Sprintf(msgFmt, strutil.Quoted(inst.Snaps))
 	}
@@ -956,13 +956,13 @@ func snapUnholdMany(inst *snapInstruction, st *state.State) (res *snapInstructio
 		}
 
 		tss = []*state.TaskSet{ts}
-		msg = i18n.G("Remove hold on auto-refreshes of all snaps.")
+		msg = i18n.G("Remove auto-refresh hold on all snaps")
 	} else {
 		if err := snapstateProceedWithRefresh(st, "system", inst.Snaps); err != nil {
 			return nil, err
 		}
 
-		msg = fmt.Sprintf(i18n.G("Remove hold on refreshes of %s."), strutil.Quoted(inst.Snaps))
+		msg = fmt.Sprintf(i18n.G("Remove refresh hold on %s"), strutil.Quoted(inst.Snaps))
 	}
 
 	return &snapInstructionResult{

--- a/daemon/api_snaps.go
+++ b/daemon/api_snaps.go
@@ -152,13 +152,13 @@ func postSnap(c *Command, r *http.Request, user *auth.UserState) Response {
 	chg := newChange(st, inst.Action+"-snap", msg, tsets, inst.Snaps)
 	if len(tsets) == 0 {
 		chg.SetStatus(state.DoneStatus)
-	} else {
-		ensureStateSoon(st)
 	}
 
 	if inst.SystemRestartImmediate {
 		chg.Set("system-restart-immediate", true)
 	}
+
+	ensureStateSoon(st)
 
 	return AsyncResponse(nil, chg.ID())
 }
@@ -590,13 +590,13 @@ func snapOpMany(c *Command, r *http.Request, user *auth.UserState) Response {
 	chg := newChange(st, inst.Action+"-snap", res.Summary, res.Tasksets, res.Affected)
 	if len(res.Tasksets) == 0 {
 		chg.SetStatus(state.DoneStatus)
-	} else {
-		ensureStateSoon(st)
 	}
 
 	if inst.SystemRestartImmediate {
 		chg.Set("system-restart-immediate", true)
 	}
+
+	ensureStateSoon(st)
 
 	chg.Set("api-data", map[string]interface{}{"snap-names": res.Affected})
 
@@ -899,14 +899,14 @@ func snapHoldMany(inst *snapInstruction, st *state.State) (res *snapInstructionR
 		}
 
 		tss = []*state.TaskSet{ts}
-		msg = i18n.G("Hold refreshes for all snaps.")
+		msg = i18n.G("Hold auto-refreshes for all snaps.")
 	} else {
 		// XXX take level from request
 		if err := snapstateHoldRefreshesBySystem(st, snapstate.HoldGeneral, inst.Time, inst.Snaps); err != nil {
 			return nil, err
 		}
 
-		msg = fmt.Sprintf(i18n.G("Hold refreshes for %s."), strutil.Quoted(inst.Snaps))
+		msg = fmt.Sprintf(i18n.G("Hold general refreshes for %s."), strutil.Quoted(inst.Snaps))
 	}
 
 	return &snapInstructionResult{
@@ -928,13 +928,13 @@ func snapUnholdMany(inst *snapInstruction, st *state.State) (res *snapInstructio
 		}
 
 		tss = []*state.TaskSet{ts}
-		msg = i18n.G("Remove hold on refreshes of all snaps.")
+		msg = i18n.G("Remove hold on auto-refreshes of all snaps.")
 	} else {
 		if err := snapstateProceedWithRefresh(st, "system", inst.Snaps); err != nil {
 			return nil, err
 		}
 
-		msg = fmt.Sprintf(i18n.G("Remove hold on refreshes of %s."), strutil.Quoted(inst.Snaps))
+		msg = fmt.Sprintf(i18n.G("Remove hold on general refreshes of %s."), strutil.Quoted(inst.Snaps))
 	}
 
 	return &snapInstructionResult{

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -2599,7 +2599,7 @@ func (s *snapsSuite) TestHoldAllRefreshes(c *check.C) {
 		c.Assert(err, check.IsNil)
 		c.Assert(res.Tasksets, check.Not(check.IsNil))
 		c.Assert(res.Affected, check.IsNil)
-		c.Assert(res.Summary, check.Equals, `Hold auto-refreshes for all snaps.`)
+		c.Assert(res.Summary, check.Equals, `Hold auto-refreshes for all snaps`)
 		c.Assert(called, check.Equals, true)
 		restore()
 	}
@@ -2633,7 +2633,7 @@ func (s *snapsSuite) TestHoldManyRefreshes(c *check.C) {
 		c.Assert(err, check.IsNil)
 		c.Assert(res.Tasksets, check.IsNil)
 		c.Assert(res.Affected, check.DeepEquals, snaps)
-		c.Assert(res.Summary, check.Equals, fmt.Sprintf(`Hold auto-refreshes for %s.`, strutil.Quoted(snaps)))
+		c.Assert(res.Summary, check.Equals, fmt.Sprintf(`Hold auto-refreshes for %s`, strutil.Quoted(snaps)))
 		c.Assert(called, check.Equals, true)
 		restore()
 	}
@@ -2665,7 +2665,7 @@ func (s *snapsSuite) TestHoldRefresh(c *check.C) {
 		summary, tasksets, err := inst.Dispatch()(inst, st)
 		c.Assert(err, check.IsNil)
 		c.Assert(tasksets, check.IsNil)
-		c.Assert(summary, check.Equals, `Hold general refreshes for "some-snap".`)
+		c.Assert(summary, check.Equals, `Hold general refreshes for "some-snap"`)
 		c.Assert(called, check.Equals, true)
 		restore()
 	}
@@ -2692,7 +2692,7 @@ func (s *snapsSuite) TestUnholdAllRefreshes(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(res.Tasksets, check.Not(check.IsNil))
 	c.Assert(res.Affected, check.IsNil)
-	c.Assert(res.Summary, check.Equals, `Remove hold on auto-refreshes of all snaps.`)
+	c.Assert(res.Summary, check.Equals, `Remove auto-refresh hold on all snaps`)
 }
 
 func (s *snapsSuite) TestUnholdManyRefreshes(c *check.C) {
@@ -2719,7 +2719,7 @@ func (s *snapsSuite) TestUnholdManyRefreshes(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(res.Tasksets, check.IsNil)
 	c.Assert(res.Affected, check.DeepEquals, snaps)
-	c.Assert(res.Summary, check.Equals, fmt.Sprintf(`Remove hold on refreshes of %s.`, strutil.Quoted(inst.Snaps)))
+	c.Assert(res.Summary, check.Equals, fmt.Sprintf(`Remove refresh hold on %s`, strutil.Quoted(inst.Snaps)))
 }
 
 func (s *snapsSuite) TestUnholdRefresh(c *check.C) {
@@ -2744,7 +2744,7 @@ func (s *snapsSuite) TestUnholdRefresh(c *check.C) {
 
 	c.Assert(err, check.IsNil)
 	c.Assert(tasksets, check.IsNil)
-	c.Assert(summary, check.Equals, `Remove hold on refreshes of "some-snap".`)
+	c.Assert(summary, check.Equals, `Remove refresh hold on "some-snap"`)
 }
 
 func (s *snapsSuite) TestHoldWithInvalidTime(c *check.C) {

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -2596,7 +2596,7 @@ func (s *snapsSuite) TestHoldAllRefreshes(c *check.C) {
 		c.Assert(err, check.IsNil)
 		c.Assert(res.Tasksets, check.Not(check.IsNil))
 		c.Assert(res.Affected, check.IsNil)
-		c.Assert(res.Summary, check.Equals, `Hold refreshes for all snaps.`)
+		c.Assert(res.Summary, check.Equals, `Hold auto-refreshes for all snaps.`)
 		restore()
 	}
 }
@@ -2625,7 +2625,7 @@ func (s *snapsSuite) TestHoldManyRefreshes(c *check.C) {
 		c.Assert(err, check.IsNil)
 		c.Assert(res.Tasksets, check.IsNil)
 		c.Assert(res.Affected, check.DeepEquals, snaps)
-		c.Assert(res.Summary, check.Equals, fmt.Sprintf(`Hold refreshes for %s.`, strutil.Quoted(snaps)))
+		c.Assert(res.Summary, check.Equals, fmt.Sprintf(`Hold general refreshes for %s.`, strutil.Quoted(snaps)))
 		restore()
 	}
 }
@@ -2652,7 +2652,7 @@ func (s *snapsSuite) TestHoldRefresh(c *check.C) {
 		summary, tasksets, err := inst.Dispatch()(inst, st)
 		c.Assert(err, check.IsNil)
 		c.Assert(tasksets, check.IsNil)
-		c.Assert(summary, check.Equals, `Hold refreshes for "some-snap".`)
+		c.Assert(summary, check.Equals, `Hold general refreshes for "some-snap".`)
 		restore()
 	}
 }
@@ -2678,7 +2678,7 @@ func (s *snapsSuite) TestUnholdAllRefreshes(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(res.Tasksets, check.Not(check.IsNil))
 	c.Assert(res.Affected, check.IsNil)
-	c.Assert(res.Summary, check.Equals, `Remove hold on refreshes of all snaps.`)
+	c.Assert(res.Summary, check.Equals, `Remove hold on auto-refreshes of all snaps.`)
 }
 
 func (s *snapsSuite) TestUnholdManyRefreshes(c *check.C) {
@@ -2705,7 +2705,7 @@ func (s *snapsSuite) TestUnholdManyRefreshes(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(res.Tasksets, check.IsNil)
 	c.Assert(res.Affected, check.DeepEquals, snaps)
-	c.Assert(res.Summary, check.Equals, fmt.Sprintf(`Remove hold on refreshes of %s.`, strutil.Quoted(inst.Snaps)))
+	c.Assert(res.Summary, check.Equals, fmt.Sprintf(`Remove hold on general refreshes of %s.`, strutil.Quoted(inst.Snaps)))
 }
 
 func (s *snapsSuite) TestUnholdRefresh(c *check.C) {
@@ -2730,7 +2730,7 @@ func (s *snapsSuite) TestUnholdRefresh(c *check.C) {
 
 	c.Assert(err, check.IsNil)
 	c.Assert(tasksets, check.IsNil)
-	c.Assert(summary, check.Equals, `Remove hold on refreshes of "some-snap".`)
+	c.Assert(summary, check.Equals, `Remove hold on general refreshes of "some-snap".`)
 }
 
 func (s *snapsSuite) TestHoldWithInvalidTime(c *check.C) {

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2018-2021 Canonical Ltd
+ * Copyright (C) 2018-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -227,6 +227,30 @@ func MockSnapstateMigrate(mock func(*state.State, []string) ([]*state.TaskSet, e
 	snapstateMigrateHome = mock
 	return func() {
 		snapstateMigrateHome = oldSnapstateMigrate
+	}
+}
+
+func MockSnapstateProceedWithRefresh(f func(st *state.State, gatingSnap string, snaps []string) error) (restore func()) {
+	old := snapstateProceedWithRefresh
+	snapstateProceedWithRefresh = f
+	return func() {
+		snapstateProceedWithRefresh = old
+	}
+}
+
+func MockSnapstateHoldRefreshesBySystem(f func(st *state.State, level snapstate.HoldLevel, time string, snaps []string) error) (restore func()) {
+	old := snapstateHoldRefreshesBySystem
+	snapstateHoldRefreshesBySystem = f
+	return func() {
+		snapstateHoldRefreshesBySystem = old
+	}
+}
+
+func MockConfigstateConfigureInstalled(f func(st *state.State, name string, patchValues map[string]interface{}, flags int) (*state.TaskSet, error)) (restore func()) {
+	old := configstateConfigureInstalled
+	configstateConfigureInstalled = f
+	return func() {
+		configstateConfigureInstalled = old
 	}
 }
 

--- a/tests/main/snap-refresh-hold/task.yaml
+++ b/tests/main/snap-refresh-hold/task.yaml
@@ -49,7 +49,7 @@ execute: |
 
   echo "Snaps auto-refresh without holds"
   reset
-  CHANGE_ID=$(snap changes | tail -2 | grep "Done.*Remove hold on refreshes of all snaps" | awk '{print $1}')
+  CHANGE_ID=$(snap changes | tail -2 | grep "Done.*Remove auto-refresh hold on all snaps" | awk '{print $1}')
 
   systemctl stop snapd.{service,socket}
   "$TESTSTOOLS"/snapd-state change-snap-channel test-snapd-tools edge

--- a/tests/main/snap-refresh-hold/task.yaml
+++ b/tests/main/snap-refresh-hold/task.yaml
@@ -2,6 +2,8 @@ summary: Check snap refresh hold and unhold
 
 prepare: |
   snap install test-snapd-tools
+  snap set system experimental.parallel-instances=true
+  snap install test-snapd-tools_instance
   snap install --devmode jq
 
 restore: |
@@ -12,6 +14,7 @@ restore: |
 execute: |
   reset() {
     snap refresh --channel=latest/stable test-snapd-tools
+    snap refresh --channel=latest/stable test-snapd-tools_instance
     snap refresh --unhold test-snapd-tools
     snap refresh --unhold
   }
@@ -35,10 +38,11 @@ execute: |
 
   systemctl stop snapd.{service,socket}
   "$TESTSTOOLS"/snapd-state change-snap-channel test-snapd-tools edge
+  "$TESTSTOOLS"/snapd-state change-snap-channel test-snapd-tools_instance edge
   "$TESTSTOOLS"/snapd-state force-autorefresh
   systemctl start snapd.{socket,service}
 
-  if retry -n 5 --quiet sh -c 'snap changes | tail -2 | grep "Done.*Auto-refresh"'; then
+  if retry -n 5 --quiet sh -c 'snap changes | tail -2 | grep "Done.*Auto-refresh snap "test-snapd-tools_instance""'; then
     echo "expected 'snap refresh --hold' to prevent auto-refresh"
     exit 1
   fi
@@ -57,7 +61,8 @@ execute: |
   echo "Held snaps don't refresh in general refreshes"
   reset
   snap refresh --hold=forever test-snapd-tools
-  snap refresh 2>&1 | MATCH "All snaps up to date."
+  snap switch --edge test-snapd-tools_instance
+  snap refresh 2>&1 | MATCH "test-snapd-tools_instance .* refreshed"
 
   echo "Held snaps are refreshed in specific refreshes"
   reset

--- a/tests/main/snap-refresh-hold/task.yaml
+++ b/tests/main/snap-refresh-hold/task.yaml
@@ -1,0 +1,75 @@
+summary: Check snap refresh hold and unhold
+
+prepare: |
+  snap install test-snapd-tools
+  snap install --devmode jq
+
+restore: |
+  snap refresh --unhold || true
+  snap refresh --unhold test-snapd-tools || true
+  snap remove --purge test-snapd-tools || true
+
+execute: |
+  reset() {
+    snap refresh --channel=latest/stable test-snapd-tools
+    snap refresh --unhold test-snapd-tools
+    snap refresh --unhold
+  }
+
+  echo "No snaps auto-refresh in an all-snaps hold"
+  snap refresh --hold=forever
+
+  systemctl stop snapd.{service,socket}
+  "$TESTSTOOLS"/snapd-state change-snap-channel test-snapd-tools edge
+  "$TESTSTOOLS"/snapd-state force-autorefresh
+  systemctl start snapd.{socket,service}
+
+  if retry -n 5 --quiet sh -c 'snap changes | tail -2 | grep "Done.*Auto-refresh"'; then
+    echo "expected 'snap refresh --hold' to prevent auto-refresh"
+    exit 1
+  fi
+
+  echo "Snap doesn't auto-refresh with a specific hold"
+  reset
+  snap refresh --hold test-snapd-tools
+
+  systemctl stop snapd.{service,socket}
+  "$TESTSTOOLS"/snapd-state change-snap-channel test-snapd-tools edge
+  "$TESTSTOOLS"/snapd-state force-autorefresh
+  systemctl start snapd.{socket,service}
+
+  if retry -n 5 --quiet sh -c 'snap changes | tail -2 | grep "Done.*Auto-refresh"'; then
+    echo "expected 'snap refresh --hold' to prevent auto-refresh"
+    exit 1
+  fi
+
+  echo "Snaps auto-refresh without holds"
+  reset
+  CHANGE_ID=$(snap changes | tail -2 | grep "Done.*Remove hold on refreshes of all snaps" | awk '{print $1}')
+
+  systemctl stop snapd.{service,socket}
+  "$TESTSTOOLS"/snapd-state change-snap-channel test-snapd-tools edge
+  "$TESTSTOOLS"/snapd-state force-autorefresh
+  systemctl start snapd.{socket,service}
+
+  "$TESTSTOOLS"/snapd-state wait-for-autorefresh "$CHANGE_ID"
+
+  echo "Held snaps don't refresh in general refreshes"
+  reset
+  snap refresh --hold=forever test-snapd-tools
+  snap refresh 2>&1 | MATCH "All snaps up to date."
+
+  echo "Held snaps are refreshed in specific refreshes"
+  reset
+  snap refresh --hold test-snapd-tools
+  snap refresh --channel=latest/edge test-snapd-tools 2>&1 | MATCH "test-snapd-tools .* refreshed"
+
+  echo "Generic refreshes ignore holds on all snaps"
+  reset
+  snap refresh --hold
+
+  systemctl stop snapd.{service,socket}
+  "$TESTSTOOLS"/snapd-state change-snap-channel test-snapd-tools edge
+  systemctl start snapd.{socket,service}
+
+  snap refresh 2>&1 | MATCH "test-snapd-tools .* refreshed"

--- a/tests/main/snap-refresh-hold/task.yaml
+++ b/tests/main/snap-refresh-hold/task.yaml
@@ -27,7 +27,7 @@ execute: |
   "$TESTSTOOLS"/snapd-state force-autorefresh
   systemctl start snapd.{socket,service}
 
-  if retry -n 5 --quiet sh -c 'snap changes | tail -2 | grep "Done.*Auto-refresh"'; then
+  if retry -n 10 --quiet sh -c 'snap changes | tail -2 | grep "Done.*Auto-refresh"'; then
     echo "expected 'snap refresh --hold' to prevent auto-refresh"
     exit 1
   fi
@@ -42,10 +42,13 @@ execute: |
   "$TESTSTOOLS"/snapd-state force-autorefresh
   systemctl start snapd.{socket,service}
 
-  if retry -n 5 --quiet sh -c 'snap changes | tail -2 | grep "Done.*Auto-refresh snap "test-snapd-tools_instance""'; then
-    echo "expected 'snap refresh --hold' to prevent auto-refresh"
+  if ! retry -n 10 --quiet sh -c 'snap changes | tail -2 | grep "Done.*Auto-refresh snap \"test-snapd-tools_instance\""'; then
+    echo 'expected "test-snapd-tools_instance" to have been auto-refreshed'
     exit 1
   fi
+
+  # check that "test-snapd-tools" wasn't auto-refreshed before "test-snapd-tools_instance"
+  snap changes | tail -3 | NOMATCH 'Auto-refresh snap "test-snapd-tools"'
 
   echo "Snaps auto-refresh without holds"
   reset


### PR DESCRIPTION
 * 40ee105a662eabcabd28994da4c2a76e8bfdc8b8 adds support for hold and unholding refreshes to the snapd REST API
 * bde49218f74ffc7d54e18a206aab0961ebd2a0e7 adds support for the `snap refresh --hold/--unhold` commands to the `snap` tool
 * 13ebf7d9a58627ff5ac031cb1bc45a5ffb2853b5 adds a spread test to integration test this feature