### PR TITLE
servicemgr: update mount files

### DIFF
--- a/daemon/api_apps_test.go
+++ b/daemon/api_apps_test.go
@@ -148,6 +148,7 @@ func (s *appsSuite) SetUpTest(c *check.C) {
 	// turn off ensuring snap services which will call systemctl automatically
 	r := servicestate.MockEnsuredSnapServices(s.d.Overlord().ServiceManager(), true)
 	s.AddCleanup(r)
+	s.AddCleanup(snapstate.MockEnsuredMountsUpdated(d.Overlord().SnapManager(), true))
 
 	s.infoA = s.mkInstalledInState(c, s.d, "snap-a", "dev", "v1", snap.R(1), true, "apps: {svc1: {daemon: simple}, svc2: {daemon: simple, reload-command: x}}")
 	s.infoB = s.mkInstalledInState(c, s.d, "snap-b", "dev", "v1", snap.R(1), false, "apps: {svc3: {daemon: simple}, cmd1: {}}")

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -95,7 +95,7 @@ func (s *daemonSuite) TearDownTest(c *check.C) {
 }
 
 // build a new daemon, with only a little of Init(), suitable for the tests
-func newTestDaemon(c *check.C) *Daemon {
+func (s *daemonSuite) newTestDaemon(c *check.C) *Daemon {
 	d, err := New()
 	c.Assert(err, check.IsNil)
 	d.addRoutes()
@@ -104,6 +104,10 @@ func newTestDaemon(c *check.C) *Daemon {
 	// needs doing after the call to devicestate.Manager (which
 	// happens in daemon.New via overlord.New)
 	snapstate.CanAutoRefresh = nil
+
+	if d.Overlord() != nil {
+		s.AddCleanup(snapstate.MockEnsuredMountsUpdated(d.Overlord().SnapManager(), true))
+	}
 
 	return d
 }
@@ -119,7 +123,7 @@ func (mck *mockHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *daemonSuite) TestCommandMethodDispatch(c *check.C) {
-	d := newTestDaemon(c)
+	d := s.newTestDaemon(c)
 	st := d.Overlord().State()
 	st.Lock()
 	authUser, err := auth.NewUser(st, auth.NewUserParams{
@@ -177,7 +181,7 @@ func (s *daemonSuite) TestCommandMethodDispatch(c *check.C) {
 func (s *daemonSuite) TestCommandMethodDispatchRoot(c *check.C) {
 	fakeUserAgent := "some-agent-talking-to-snapd/1.0"
 
-	cmd := &Command{d: newTestDaemon(c)}
+	cmd := &Command{d: s.newTestDaemon(c)}
 	mck := &mockHandler{cmd: cmd}
 	rf := func(innerCmd *Command, req *http.Request, user *auth.UserState) Response {
 		c.Assert(cmd, check.Equals, innerCmd)
@@ -218,7 +222,7 @@ func (s *daemonSuite) TestCommandMethodDispatchRoot(c *check.C) {
 }
 
 func (s *daemonSuite) TestCommandRestartingState(c *check.C) {
-	d := newTestDaemon(c)
+	d := s.newTestDaemon(c)
 
 	cmd := &Command{d: d}
 	cmd.GET = func(*Command, *http.Request, *auth.UserState) Response {
@@ -315,7 +319,7 @@ func (s *daemonSuite) TestMaintenanceJsonDeletedOnStart(c *check.C) {
 	c.Assert(os.MkdirAll(filepath.Dir(dirs.SnapdMaintenanceFile), 0755), check.IsNil)
 	c.Assert(ioutil.WriteFile(dirs.SnapdMaintenanceFile, b, 0644), check.IsNil)
 
-	d := newTestDaemon(c)
+	d := s.newTestDaemon(c)
 	makeDaemonListeners(c, d)
 
 	s.markSeeded(d)
@@ -327,7 +331,7 @@ func (s *daemonSuite) TestMaintenanceJsonDeletedOnStart(c *check.C) {
 }
 
 func (s *daemonSuite) TestFillsWarnings(c *check.C) {
-	d := newTestDaemon(c)
+	d := s.newTestDaemon(c)
 
 	cmd := &Command{d: d}
 	cmd.GET = func(*Command, *http.Request, *auth.UserState) Response {
@@ -371,7 +375,7 @@ func (f accessCheckFunc) CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet
 }
 
 func (s *daemonSuite) TestReadAccess(c *check.C) {
-	cmd := &Command{d: newTestDaemon(c)}
+	cmd := &Command{d: s.newTestDaemon(c)}
 	cmd.GET = func(*Command, *http.Request, *auth.UserState) Response {
 		return SyncResponse(nil)
 	}
@@ -401,7 +405,7 @@ func (s *daemonSuite) TestReadAccess(c *check.C) {
 }
 
 func (s *daemonSuite) TestWriteAccess(c *check.C) {
-	cmd := &Command{d: newTestDaemon(c)}
+	cmd := &Command{d: s.newTestDaemon(c)}
 	cmd.PUT = func(*Command, *http.Request, *auth.UserState) Response {
 		return SyncResponse(nil)
 	}
@@ -442,7 +446,7 @@ func (s *daemonSuite) TestWriteAccess(c *check.C) {
 }
 
 func (s *daemonSuite) TestWriteAccessWithUser(c *check.C) {
-	d := newTestDaemon(c)
+	d := s.newTestDaemon(c)
 	st := d.Overlord().State()
 	st.Lock()
 	authUser, err := auth.NewUser(st, auth.NewUserParams{
@@ -497,7 +501,7 @@ func (s *daemonSuite) TestWriteAccessWithUser(c *check.C) {
 }
 
 func (s *daemonSuite) TestPolkitAccessPath(c *check.C) {
-	cmd := &Command{d: newTestDaemon(c)}
+	cmd := &Command{d: s.newTestDaemon(c)}
 	cmd.POST = func(*Command, *http.Request, *auth.UserState) Response {
 		return SyncResponse(nil)
 	}
@@ -535,7 +539,7 @@ func (s *daemonSuite) TestCommandAccessSane(c *check.C) {
 }
 
 func (s *daemonSuite) TestAddRoutes(c *check.C) {
-	d := newTestDaemon(c)
+	d := s.newTestDaemon(c)
 
 	expected := make([]string, len(api))
 	for i, v := range api {
@@ -596,7 +600,7 @@ func (s *daemonSuite) markSeeded(d *Daemon) {
 }
 
 func (s *daemonSuite) TestStartStop(c *check.C) {
-	d := newTestDaemon(c)
+	d := s.newTestDaemon(c)
 	// mark as already seeded
 	s.markSeeded(d)
 	// and pretend we have snaps
@@ -659,7 +663,7 @@ version: 1`, si)
 }
 
 func (s *daemonSuite) TestRestartWiring(c *check.C) {
-	d := newTestDaemon(c)
+	d := s.newTestDaemon(c)
 	// mark as already seeded
 	s.markSeeded(d)
 
@@ -721,7 +725,7 @@ func (s *daemonSuite) TestRestartWiring(c *check.C) {
 }
 
 func (s *daemonSuite) TestGracefulStop(c *check.C) {
-	d := newTestDaemon(c)
+	d := s.newTestDaemon(c)
 
 	responding := make(chan struct{})
 	doRespond := make(chan bool, 1)
@@ -819,7 +823,7 @@ version: 1`, si)
 }
 
 func (s *daemonSuite) TestGracefulStopHasLimits(c *check.C) {
-	d := newTestDaemon(c)
+	d := s.newTestDaemon(c)
 
 	// mark as already seeded
 	s.markSeeded(d)
@@ -911,7 +915,7 @@ func (s *daemonSuite) TestGracefulStopHasLimits(c *check.C) {
 }
 
 func (s *daemonSuite) testRestartSystemWiring(c *check.C, prep func(d *Daemon), doRestart func(*state.State, restart.RestartType, *boot.RebootInfo), restartKind restart.RestartType, wait time.Duration) {
-	d := newTestDaemon(c)
+	d := s.newTestDaemon(c)
 	// mark as already seeded
 	s.markSeeded(d)
 
@@ -1152,7 +1156,7 @@ func (s *daemonSuite) TestRestartShutdownWithSigtermInBetween(c *check.C) {
 	r := MockReboot(rebootCheck)
 	defer r()
 
-	d := newTestDaemon(c)
+	d := s.newTestDaemon(c)
 	makeDaemonListeners(c, d)
 	s.markSeeded(d)
 
@@ -1205,7 +1209,7 @@ func (s *daemonSuite) TestRestartShutdown(c *check.C) {
 	r := MockReboot(rebootCheck)
 	defer r()
 
-	d := newTestDaemon(c)
+	d := s.newTestDaemon(c)
 	makeDaemonListeners(c, d)
 	s.markSeeded(d)
 
@@ -1257,7 +1261,7 @@ func (s *daemonSuite) TestRestartExpectedRebootDidNotHappen(c *check.C) {
 	r := MockReboot(rebootCheck)
 	defer r()
 
-	d := newTestDaemon(c)
+	d := s.newTestDaemon(c)
 	c.Check(d.overlord, check.IsNil)
 	c.Check(d.expectedRebootDidNotHappen, check.Equals, true)
 
@@ -1294,7 +1298,7 @@ func (s *daemonSuite) TestRestartExpectedRebootOK(c *check.C) {
 	cmd := testutil.MockCommand(c, "shutdown", "")
 	defer cmd.Restore()
 
-	d := newTestDaemon(c)
+	d := s.newTestDaemon(c)
 	c.Assert(d.overlord, check.NotNil)
 
 	st := d.overlord.State()
@@ -1318,7 +1322,7 @@ func (s *daemonSuite) TestRestartExpectedRebootGiveUp(c *check.C) {
 	cmd := testutil.MockCommand(c, "shutdown", "")
 	defer cmd.Restore()
 
-	d := newTestDaemon(c)
+	d := s.newTestDaemon(c)
 	c.Assert(d.overlord, check.NotNil)
 
 	st := d.overlord.State()
@@ -1335,7 +1339,7 @@ func (s *daemonSuite) TestRestartIntoSocketModeNoNewChanges(c *check.C) {
 	restore := standby.MockStandbyWait(5 * time.Millisecond)
 	defer restore()
 
-	d := newTestDaemon(c)
+	d := s.newTestDaemon(c)
 	makeDaemonListeners(c, d)
 
 	// mark as already seeded, we also have no snaps so this will
@@ -1364,7 +1368,7 @@ func (s *daemonSuite) TestRestartIntoSocketModePendingChanges(c *check.C) {
 	restore := standby.MockStandbyWait(5 * time.Millisecond)
 	defer restore()
 
-	d := newTestDaemon(c)
+	d := s.newTestDaemon(c)
 	makeDaemonListeners(c, d)
 
 	// mark as already seeded, we also have no snaps so this will
@@ -1425,7 +1429,7 @@ func doTestReq(c *check.C, cmd *Command, mth string) *httptest.ResponseRecorder 
 }
 
 func (s *daemonSuite) TestDegradedModeReply(c *check.C) {
-	d := newTestDaemon(c)
+	d := s.newTestDaemon(c)
 	cmd := &Command{d: d}
 	cmd.GET = func(*Command, *http.Request, *auth.UserState) Response {
 		return SyncResponse(nil)

--- a/overlord/configstate/configcore/services.go
+++ b/overlord/configstate/configcore/services.go
@@ -373,7 +373,7 @@ func handleServiceConfigSSHListen(dev sysconfig.Device, tr config.ConfGetter, op
 
 	if opts == nil {
 		sysd := systemd.New(systemd.SystemMode, &sysdLogger{})
-		if err := sysd.ReloadOrRestart("ssh.service"); err != nil {
+		if err := sysd.ReloadOrRestart([]string{"ssh.service"}); err != nil {
 			return err
 		}
 	}

--- a/overlord/hookstate/ctlcmd/mount.go
+++ b/overlord/hookstate/ctlcmd/mount.go
@@ -187,7 +187,7 @@ func (m *mountCommand) createMountUnit(sysd systemd.Systemd) (string, error) {
 	if m.Persistent {
 		lifetime = systemd.Persistent
 	}
-	return sysd.AddMountUnitFileWithOptions(&systemd.MountUnitOptions{
+	return sysd.EnsureMountUnitFileWithOptions(&systemd.MountUnitOptions{
 		Lifetime: lifetime,
 		SnapName: snapName,
 		Revision: revision,

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -272,6 +272,8 @@ func (s *baseMgrsSuite) SetUpTest(c *C) {
 	o.InterfaceManager().DisableUDevMonitor()
 	s.o = o
 
+	s.AddCleanup(snapstate.MockEnsuredMountsUpdated(s.o.SnapManager(), true))
+
 	st.Lock()
 	defer st.Unlock()
 

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -8986,7 +8986,7 @@ WantedBy=multi-user.target
 			c.Check(cmd, DeepEquals, []string{"--no-reload", "enable", "snap-snapd-x1.mount"})
 			return nil, nil
 		case 3:
-			c.Check(cmd, DeepEquals, []string{"start", "snap-snapd-x1.mount"})
+			c.Check(cmd, DeepEquals, []string{"reload-or-restart", "snap-snapd-x1.mount"})
 			return nil, nil
 			// next we get the calls for the rewritten service files after snapd
 			// restarts
@@ -9216,7 +9216,7 @@ WantedBy=multi-user.target
 			c.Check(cmd, DeepEquals, []string{"--no-reload", "enable", "snap-snapd-x1.mount"})
 			return nil, nil
 		case 3:
-			c.Check(cmd, DeepEquals, []string{"start", "snap-snapd-x1.mount"})
+			c.Check(cmd, DeepEquals, []string{"reload-or-restart", "snap-snapd-x1.mount"})
 			return nil, nil
 			// next we get the calls for the rewritten service files after snapd
 			// restarts

--- a/overlord/servicestate/servicemgr_test.go
+++ b/overlord/servicestate/servicemgr_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/snapcore/snapd/asserts/assertstest"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/restart"
@@ -135,6 +136,8 @@ func (s *baseServiceMgrTestSuite) SetUpTest(c *C) {
 		Active:   true,
 		SnapType: "app",
 	}
+
+	s.AddCleanup(osutil.MockMountInfo(""))
 }
 
 type expectedSystemctl struct {

--- a/overlord/snapstate/backend/mountunit.go
+++ b/overlord/snapstate/backend/mountunit.go
@@ -36,7 +36,7 @@ func addMountUnit(s *snap.Info, preseed bool, meter progress.Meter) error {
 	} else {
 		sysd = systemd.New(systemd.SystemMode, meter)
 	}
-	_, err := sysd.AddMountUnitFile(s.InstanceName(), s.Revision.String(), squashfsPath, whereDir, "squashfs")
+	_, err := sysd.EnsureMountUnitFile(s.InstanceName(), s.Revision.String(), squashfsPath, whereDir, "squashfs")
 	return err
 }
 

--- a/overlord/snapstate/backend/mountunit_test.go
+++ b/overlord/snapstate/backend/mountunit_test.go
@@ -33,11 +33,11 @@ import (
 	"github.com/snapcore/snapd/testutil"
 )
 
-type ParamsForAddMountUnitFile struct {
+type ParamsForEnsureMountUnitFile struct {
 	name, revision, what, where, fstype string
 }
 
-type ResultForAddMountUnitFile struct {
+type ResultForEnsureMountUnitFile struct {
 	path string
 	err  error
 }
@@ -45,8 +45,8 @@ type ResultForAddMountUnitFile struct {
 type FakeSystemd struct {
 	systemd.Systemd
 
-	AddMountUnitFileCalls  []ParamsForAddMountUnitFile
-	AddMountUnitFileResult ResultForAddMountUnitFile
+	EnsureMountUnitFileCalls  []ParamsForEnsureMountUnitFile
+	EnsureMountUnitFileResult ResultForEnsureMountUnitFile
 
 	RemoveMountUnitFileCalls  []string
 	RemoveMountUnitFileResult error
@@ -55,10 +55,10 @@ type FakeSystemd struct {
 	ListMountUnitsResult ResultForListMountUnits
 }
 
-func (s *FakeSystemd) AddMountUnitFile(name, revision, what, where, fstype string) (string, error) {
-	s.AddMountUnitFileCalls = append(s.AddMountUnitFileCalls,
-		ParamsForAddMountUnitFile{name, revision, what, where, fstype})
-	return s.AddMountUnitFileResult.path, s.AddMountUnitFileResult.err
+func (s *FakeSystemd) EnsureMountUnitFile(name, revision, what, where, fstype string) (string, error) {
+	s.EnsureMountUnitFileCalls = append(s.EnsureMountUnitFileCalls,
+		ParamsForEnsureMountUnitFile{name, revision, what, where, fstype})
+	return s.EnsureMountUnitFileResult.path, s.EnsureMountUnitFileResult.err
 }
 
 func (s *FakeSystemd) RemoveMountUnitFile(mountDir string) error {
@@ -101,7 +101,7 @@ func (s *mountunitSuite) TestAddMountUnit(c *C) {
 	var sysd *FakeSystemd
 	restore := systemd.MockNewSystemd(func(be systemd.Backend, roodDir string, mode systemd.InstanceMode, meter systemd.Reporter) systemd.Systemd {
 		sysd = &FakeSystemd{}
-		sysd.AddMountUnitFileResult = ResultForAddMountUnitFile{"", expectedErr}
+		sysd.EnsureMountUnitFileResult = ResultForEnsureMountUnitFile{"", expectedErr}
 		return sysd
 	})
 	defer restore()
@@ -118,14 +118,14 @@ func (s *mountunitSuite) TestAddMountUnit(c *C) {
 	c.Check(err, Equals, expectedErr)
 
 	// ensure correct parameters
-	expectedParameters := ParamsForAddMountUnitFile{
+	expectedParameters := ParamsForEnsureMountUnitFile{
 		name:     "foo",
 		revision: "13",
 		what:     "/var/lib/snapd/snaps/foo_13.snap",
 		where:    fmt.Sprintf("%s/foo/13", dirs.StripRootDir(dirs.SnapMountDir)),
 		fstype:   "squashfs",
 	}
-	c.Check(sysd.AddMountUnitFileCalls, DeepEquals, []ParamsForAddMountUnitFile{
+	c.Check(sysd.EnsureMountUnitFileCalls, DeepEquals, []ParamsForEnsureMountUnitFile{
 		expectedParameters,
 	})
 }

--- a/overlord/snapstate/backend/setup_test.go
+++ b/overlord/snapstate/backend/setup_test.go
@@ -363,7 +363,7 @@ func (s *setupSuite) TestSetupCleanupAfterFail(c *C) {
 
 	r := systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
 		// mount unit start fails
-		if len(cmd) >= 2 && cmd[0] == "start" && strings.HasSuffix(cmd[1], ".mount") {
+		if len(cmd) >= 2 && cmd[0] == "reload-or-restart" && strings.HasSuffix(cmd[1], ".mount") {
 			return nil, fmt.Errorf("failed")
 		}
 		return []byte("ActiveState=inactive\n"), nil

--- a/overlord/snapstate/handlers_prereq_test.go
+++ b/overlord/snapstate/handlers_prereq_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
@@ -79,6 +80,10 @@ func (s *prereqSuite) SetUpTest(c *C) {
 		return nil, nil
 	})
 	s.AddCleanup(restore)
+
+	s.AddCleanup(osutil.MockMountInfo(``))
+
+	s.AddCleanup(snapstate.MockEnsuredMountsUpdated(s.snapmgr, true))
 }
 
 func (s *prereqSuite) TestDoPrereqNothingToDo(c *C) {

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -66,6 +66,7 @@ import (
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/store"
+	"github.com/snapcore/snapd/systemd"
 	"github.com/snapcore/snapd/testutil"
 	"github.com/snapcore/snapd/timeutil"
 )
@@ -87,6 +88,8 @@ type snapmgrBaseTest struct {
 	user  *auth.UserState
 	user2 *auth.UserState
 	user3 *auth.UserState
+
+	reloadOrRestarts map[string]int
 }
 
 // state must be locked by caller
@@ -118,6 +121,28 @@ func (s *snapmgrBaseTest) logTasks(c *C) {
 }
 
 var fakeRevDateEpoch = time.Date(2018, 1, 0, 0, 0, 0, 0, time.UTC)
+
+func (s *snapmgrBaseTest) mockSystemctlCallsUpdateMounts(c *C) (restore func()) {
+	r := systemd.MockSystemctl(func(args ...string) ([]byte, error) {
+		if len(args) == 1 && args[0] == "daemon-reload" {
+			return []byte(""), nil
+		}
+		if len(args) == 3 && args[0] == "--no-reload" && args[1] == "enable" {
+			return []byte(""), nil
+		}
+		if len(args) == 2 && args[0] == "reload-or-restart" {
+			value, ok := s.reloadOrRestarts[args[1]]
+			if ok {
+				s.reloadOrRestarts[args[1]] = value + 1
+			}
+			return []byte(""), nil
+		}
+		c.Errorf("unexpected and unhandled systemctl command: %+v", args)
+		return nil, fmt.Errorf("broken test")
+	})
+
+	return r
+}
 
 func (s *snapmgrBaseTest) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
@@ -299,6 +324,9 @@ SNAPD_APPARMOR_REEXEC=1
 		return nil
 	}))
 	s.AddCleanup(osutil.MockMountInfo(""))
+
+	s.reloadOrRestarts = make(map[string]int)
+	s.AddCleanup(s.mockSystemctlCallsUpdateMounts(c))
 }
 
 func (s *snapmgrBaseTest) TearDownTest(c *C) {
@@ -7315,7 +7343,7 @@ func (s *snapmgrTestSuite) TestStartSnapServicesWithDisabledServicesNowApp(c *C)
 	s.runStartSnapServicesWithDisabledServices(c, "hello")
 
 	// check the log for the notice
-	c.Assert(buf.String(), Matches, `.*previously disabled service hello is now an app and not a service\n.*`)
+	c.Assert(buf.String(), Matches, `(?s).*previously disabled service hello is now an app and not a service\n.*`)
 }
 
 func (s *snapmgrTestSuite) TestStartSnapServicesWithDisabledServicesMissing(c *C) {
@@ -7326,7 +7354,7 @@ func (s *snapmgrTestSuite) TestStartSnapServicesWithDisabledServicesMissing(c *C
 	s.runStartSnapServicesWithDisabledServices(c, "old-disabled-svc")
 
 	// check the log for the notice
-	c.Assert(buf.String(), Matches, `.*previously disabled service old-disabled-svc no longer exists\n.*`)
+	c.Assert(buf.String(), Matches, `(?s).*previously disabled service old-disabled-svc no longer exists\n.*`)
 }
 
 func (s *snapmgrTestSuite) TestStartSnapServicesUndo(c *C) {
@@ -8630,4 +8658,198 @@ func (s *snapmgrTestSuite) TestResolveValidationSetsEnforcementErrorWithInvalidS
 
 	_, _, err := snapstate.ResolveValidationSetsEnforcementError(context.TODO(), s.state, valErr, nil, s.user.ID)
 	c.Assert(err, ErrorMatches, "cannot auto-resolve validation set constraints that require removing snaps: \"snap-a\"")
+}
+
+func (s *snapmgrTestSuite) TestEnsureSnapStateRewriteMounts(c *C) {
+	restore := snapstate.MockEnsuredMountsUpdated(s.snapmgr, false)
+	defer restore()
+
+	testSnapSideInfo := &snap.SideInfo{RealName: "test-snap", Revision: snap.R(42)}
+	testSnapState := &snapstate.SnapState{
+		Sequence: []*snap.SideInfo{testSnapSideInfo},
+		Current:  snap.R(42),
+		Active:   true,
+		SnapType: "app",
+	}
+	testYaml := `name: test-snap
+version: v1
+apps:
+  test-snap:
+    command: bin.sh
+`
+
+	s.state.Lock()
+	snapstate.Set(s.state, "test-snap", testSnapState)
+	snaptest.MockSnapCurrent(c, testYaml, testSnapSideInfo)
+	s.state.Unlock()
+
+	what := fmt.Sprintf("%s/%s_%s.snap", "/var/lib/snapd/snaps", "test-snap", "42")
+	unitName := systemd.EscapeUnitNamePath(filepath.Join("/snap", "test-snap", fmt.Sprintf("%s.mount", "42")))
+	mountFile := filepath.Join(dirs.SnapServicesDir, unitName)
+	mountContent := fmt.Sprintf(`
+[Unit]
+Description=Mount unit for test-snap, revision 42
+After=snapd.mounts-pre.target
+Before=snapd.mounts.target
+Before=local-fs.target
+
+[Mount]
+What=%s
+Where=/snap/test-snap/42
+Type=squashfs
+Options=nodev,ro,x-gdu.hide,x-gvfs-hide,otheroptions
+LazyUnmount=yes
+
+[Install]
+WantedBy=snapd.mounts.target
+WantedBy=multi-user.target
+`[1:], what)
+	os.MkdirAll(dirs.SnapServicesDir, 0755)
+	err := ioutil.WriteFile(mountFile, []byte(mountContent), 0644)
+	c.Assert(err, IsNil)
+
+	s.reloadOrRestarts[unitName] = 0
+
+	err = s.snapmgr.Ensure()
+	c.Assert(err, IsNil)
+
+	c.Assert(s.reloadOrRestarts[unitName], Equals, 1)
+
+	expectedContent := fmt.Sprintf(`
+[Unit]
+Description=Mount unit for test-snap, revision 42
+After=snapd.mounts-pre.target
+Before=snapd.mounts.target
+Before=local-fs.target
+
+[Mount]
+What=%s
+Where=/snap/test-snap/42
+Type=squashfs
+Options=nodev,ro,x-gdu.hide,x-gvfs-hide
+LazyUnmount=yes
+
+[Install]
+WantedBy=snapd.mounts.target
+WantedBy=multi-user.target
+`[1:], what)
+
+	c.Assert(mountFile, testutil.FileEquals, expectedContent)
+}
+
+func (s *snapmgrTestSuite) TestEnsureSnapStateRewriteMountsNoChange(c *C) {
+	restore := snapstate.MockEnsuredMountsUpdated(s.snapmgr, false)
+	defer restore()
+
+	testSnapSideInfo := &snap.SideInfo{RealName: "test-snap", Revision: snap.R(42)}
+	testSnapState := &snapstate.SnapState{
+		Sequence: []*snap.SideInfo{testSnapSideInfo},
+		Current:  snap.R(42),
+		Active:   true,
+		SnapType: "app",
+	}
+	testYaml := `name: test-snap
+version: v1
+apps:
+  test-snap:
+    command: bin.sh
+`
+
+	s.state.Lock()
+	snapstate.Set(s.state, "test-snap", testSnapState)
+	snaptest.MockSnapCurrent(c, testYaml, testSnapSideInfo)
+	s.state.Unlock()
+
+	what := fmt.Sprintf("%s/%s_%s.snap", "/var/lib/snapd/snaps", "test-snap", "42")
+	unitName := systemd.EscapeUnitNamePath(filepath.Join("/snap", "test-snap", fmt.Sprintf("%s.mount", "42")))
+	mountFile := filepath.Join(dirs.SnapServicesDir, unitName)
+	mountContent := fmt.Sprintf(`
+[Unit]
+Description=Mount unit for test-snap, revision 42
+After=snapd.mounts-pre.target
+Before=snapd.mounts.target
+Before=local-fs.target
+
+[Mount]
+What=%s
+Where=/snap/test-snap/42
+Type=squashfs
+Options=nodev,ro,x-gdu.hide,x-gvfs-hide
+LazyUnmount=yes
+
+[Install]
+WantedBy=snapd.mounts.target
+WantedBy=multi-user.target
+`[1:], what)
+	os.MkdirAll(dirs.SnapServicesDir, 0755)
+	err := ioutil.WriteFile(mountFile, []byte(mountContent), 0644)
+	c.Assert(err, IsNil)
+
+	s.reloadOrRestarts[unitName] = 0
+
+	err = s.snapmgr.Ensure()
+	c.Assert(err, IsNil)
+
+	c.Assert(s.reloadOrRestarts[unitName], Equals, 0)
+
+	c.Assert(mountFile, testutil.FileEquals, mountContent)
+}
+
+func (s *snapmgrTestSuite) TestEnsureSnapStateRewriteMountsCreated(c *C) {
+	testSnapSideInfo := &snap.SideInfo{RealName: "test-snap", Revision: snap.R(42)}
+	testSnapState := &snapstate.SnapState{
+		Sequence: []*snap.SideInfo{testSnapSideInfo},
+		Current:  snap.R(42),
+		Active:   true,
+		SnapType: "app",
+	}
+	testYaml := `name: test-snap
+version: v1
+apps:
+  test-snap:
+    command: bin.sh
+`
+
+	s.state.Lock()
+	snapstate.Set(s.state, "test-snap", testSnapState)
+	snaptest.MockSnapCurrent(c, testYaml, testSnapSideInfo)
+	s.state.Unlock()
+
+	what := fmt.Sprintf("%s/%s_%s.snap", "/var/lib/snapd/snaps", "test-snap", "42")
+	unitName := systemd.EscapeUnitNamePath(filepath.Join("/snap", "test-snap", fmt.Sprintf("%s.mount", "42")))
+	mountFile := filepath.Join(dirs.SnapServicesDir, unitName)
+	if osutil.FileExists(mountFile) {
+		c.Assert(os.Remove(mountFile), IsNil)
+	}
+
+	restore := snapstate.MockEnsuredMountsUpdated(s.snapmgr, false)
+	defer restore()
+
+	s.reloadOrRestarts[unitName] = 0
+
+	err := s.snapmgr.Ensure()
+	c.Assert(err, IsNil)
+
+	c.Assert(s.reloadOrRestarts[unitName], Equals, 1)
+
+	expectedContent := fmt.Sprintf(`
+[Unit]
+Description=Mount unit for test-snap, revision 42
+After=snapd.mounts-pre.target
+Before=snapd.mounts.target
+Before=local-fs.target
+
+[Mount]
+What=%s
+Where=/snap/test-snap/42
+Type=squashfs
+Options=nodev,ro,x-gdu.hide,x-gvfs-hide
+LazyUnmount=yes
+
+[Install]
+WantedBy=snapd.mounts.target
+WantedBy=multi-user.target
+`[1:], what)
+
+	c.Assert(mountFile, testutil.FileEquals, expectedContent)
 }

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -2403,6 +2403,10 @@ func (s *snapmgrTestSuite) TestUpdateMakesConfigSnapshot(c *C) {
 	chg.AddAll(ts)
 
 	defer s.se.Stop()
+
+	restore := snapstate.MockEnsuredMountsUpdated(s.snapmgr, true)
+	defer restore()
+
 	s.settle(c)
 
 	cfgs = nil

--- a/systemd/emulation.go
+++ b/systemd/emulation.go
@@ -134,7 +134,7 @@ func (s *emulation) AddMountUnitFile(snapName, revision, what, where, fstype str
 	// This means that when preseeding in a lxd container, the snap will be
 	// mounted with fuse, but mount unit will use squashfs.
 	mountUnitOptions := append(fsMountOptions(fstype), squashfs.StandardOptions()...)
-	mountUnitName, err := writeMountUnitFile(&MountUnitOptions{
+	mountUnitName, modified, err := ensureMountUnitFile(&MountUnitOptions{
 		Lifetime: Persistent,
 		SnapName: snapName,
 		Revision: revision,
@@ -147,7 +147,14 @@ func (s *emulation) AddMountUnitFile(snapName, revision, what, where, fstype str
 		return "", err
 	}
 
+	if modified == mountUnchanged {
+		return mountUnitName, nil
+	}
+
 	hostFsType, actualOptions := hostFsTypeAndMountOptions(fstype)
+	if modified == mountUpdated {
+		actualOptions = append(actualOptions, "remount")
+	}
 	cmd := exec.Command("mount", "-t", hostFsType, what, where, "-o", strings.Join(actualOptions, ","))
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return "", fmt.Errorf("cannot mount %s (%s) at %s in preseed mode: %s; %s", what, hostFsType, where, err, string(out))

--- a/systemd/emulation.go
+++ b/systemd/emulation.go
@@ -124,7 +124,7 @@ func (s *emulation) LogReader(services []string, n int, follow, namespaces bool)
 	return nil, fmt.Errorf("LogReader")
 }
 
-func (s *emulation) AddMountUnitFile(snapName, revision, what, where, fstype string) (string, error) {
+func (s *emulation) EnsureMountUnitFile(snapName, revision, what, where, fstype string) (string, error) {
 	if osutil.IsDirectory(what) {
 		return "", fmt.Errorf("bind-mounted directory is not supported in emulation mode")
 	}
@@ -167,8 +167,8 @@ func (s *emulation) AddMountUnitFile(snapName, revision, what, where, fstype str
 	return mountUnitName, nil
 }
 
-func (s *emulation) AddMountUnitFileWithOptions(unitOptions *MountUnitOptions) (string, error) {
-	return "", &notImplementedError{"AddMountUnitFileWithOptions"}
+func (s *emulation) EnsureMountUnitFileWithOptions(unitOptions *MountUnitOptions) (string, error) {
+	return "", &notImplementedError{"EnsureMountUnitFileWithOptions"}
 }
 
 func (s *emulation) RemoveMountUnitFile(mountedDir string) error {

--- a/systemd/emulation.go
+++ b/systemd/emulation.go
@@ -88,7 +88,7 @@ func (s *emulation) Restart(services []string) error {
 	return nil
 }
 
-func (s *emulation) ReloadOrRestart(service string) error {
+func (s *emulation) ReloadOrRestart(services []string) error {
 	return &notImplementedError{"ReloadOrRestart"}
 }
 

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -351,7 +351,7 @@ type Systemd interface {
 	// Restart the service, waiting for it to stop before starting it again.
 	Restart(services []string) error
 	// Reload or restart the service via 'systemctl reload-or-restart'
-	ReloadOrRestart(service string) error
+	ReloadOrRestart(services []string) error
 	// RestartAll restarts the given service using systemctl restart --all
 	RestartAll(service string) error
 	// Status fetches the status of given units. Statuses are
@@ -1616,11 +1616,11 @@ func (s *systemd) ListMountUnits(snapName, origin string) ([]string, error) {
 	return mountPoints, nil
 }
 
-func (s *systemd) ReloadOrRestart(serviceName string) error {
+func (s *systemd) ReloadOrRestart(serviceNames []string) error {
 	if s.mode == GlobalUserMode {
 		panic("cannot call restart with GlobalUserMode")
 	}
-	_, err := s.systemctl("reload-or-restart", serviceName)
+	_, err := s.systemctl(append([]string{"reload-or-restart"}, serviceNames...)...)
 	return err
 }
 

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -387,10 +387,10 @@ type Systemd interface {
 	// If namespaces is set to true, the log reader will include journal namespace
 	// logs, and is required to get logs for services which are in journal namespaces.
 	LogReader(services []string, n int, follow, namespaces bool) (io.ReadCloser, error)
-	// AddMountUnitFile adds/enables/starts a mount unit.
-	AddMountUnitFile(name, revision, what, where, fstype string) (string, error)
-	// AddMountUnitFileWithOptions adds/enables/starts a mount unit with options.
-	AddMountUnitFileWithOptions(unitOptions *MountUnitOptions) (string, error)
+	// EnsureMountUnitFile adds/enables/starts a mount unit.
+	EnsureMountUnitFile(name, revision, what, where, fstype string) (string, error)
+	// EnsureMountUnitFileWithOptions adds/enables/starts a mount unit with options.
+	EnsureMountUnitFileWithOptions(unitOptions *MountUnitOptions) (string, error)
 	// RemoveMountUnitFile unmounts/stops/disables/removes a mount unit.
 	RemoveMountUnitFile(baseDir string) error
 	// ListMountUnits gets the list of targets of the mount units created by
@@ -1462,13 +1462,13 @@ func hostFsTypeAndMountOptions(fstype string) (hostFsType string, options []stri
 	return hostFsType, options
 }
 
-func (s *systemd) AddMountUnitFile(snapName, revision, what, where, fstype string) (string, error) {
+func (s *systemd) EnsureMountUnitFile(snapName, revision, what, where, fstype string) (string, error) {
 	hostFsType, options := hostFsTypeAndMountOptions(fstype)
 	if osutil.IsDirectory(what) {
 		options = append(options, "bind")
 		hostFsType = "none"
 	}
-	return s.AddMountUnitFileWithOptions(&MountUnitOptions{
+	return s.EnsureMountUnitFileWithOptions(&MountUnitOptions{
 		Lifetime: Persistent,
 		SnapName: snapName,
 		Revision: revision,
@@ -1479,7 +1479,7 @@ func (s *systemd) AddMountUnitFile(snapName, revision, what, where, fstype strin
 	})
 }
 
-func (s *systemd) AddMountUnitFileWithOptions(unitOptions *MountUnitOptions) (string, error) {
+func (s *systemd) EnsureMountUnitFileWithOptions(unitOptions *MountUnitOptions) (string, error) {
 	daemonReloadLock.Lock()
 	defer daemonReloadLock.Unlock()
 

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -1159,7 +1159,7 @@ func (s *SystemdTestSuite) TestAddMountUnit(c *C) {
 	mockSnapPath := filepath.Join(c.MkDir(), "/var/lib/snappy/snaps/foo_1.0.snap")
 	makeMockFile(c, mockSnapPath)
 
-	mountUnitName, err := NewUnderRoot(rootDir, SystemMode, nil).AddMountUnitFile("foo", "42", mockSnapPath, "/snap/snapname/123", "squashfs")
+	mountUnitName, err := NewUnderRoot(rootDir, SystemMode, nil).EnsureMountUnitFile("foo", "42", mockSnapPath, "/snap/snapname/123", "squashfs")
 	c.Assert(err, IsNil)
 	defer os.Remove(mountUnitName)
 
@@ -1189,7 +1189,7 @@ WantedBy=multi-user.target
 	})
 }
 
-func (s *SystemdTestSuite) TestEnureMountUnitUnchanged(c *C) {
+func (s *SystemdTestSuite) TestEnsureMountUnitUnchanged(c *C) {
 	rootDir := dirs.GlobalRootDir
 
 	restore := squashfs.MockNeedsFuse(false)
@@ -1222,7 +1222,7 @@ WantedBy=multi-user.target
 	err = ioutil.WriteFile(filepath.Join(dirs.SnapServicesDir, "snap-snapname-123.mount"), []byte(content), 0644)
 	c.Assert(err, IsNil)
 
-	mountUnitName, err := NewUnderRoot(rootDir, SystemMode, nil).AddMountUnitFile("foo", "42", mockSnapPath, "/snap/snapname/123", "squashfs")
+	mountUnitName, err := NewUnderRoot(rootDir, SystemMode, nil).EnsureMountUnitFile("foo", "42", mockSnapPath, "/snap/snapname/123", "squashfs")
 	c.Assert(err, IsNil)
 
 	// Should still be the same file
@@ -1282,7 +1282,7 @@ WantedBy=multi-user.target
 	err = ioutil.WriteFile(filepath.Join(dirs.SnapServicesDir, "snap-snapname-123.mount"), []byte(content), 0644)
 	c.Assert(err, IsNil)
 
-	mountUnitName, err := NewUnderRoot(rootDir, SystemMode, nil).AddMountUnitFile("foo", "42", mockSnapPath, "/snap/snapname/123", "squashfs")
+	mountUnitName, err := NewUnderRoot(rootDir, SystemMode, nil).EnsureMountUnitFile("foo", "42", mockSnapPath, "/snap/snapname/123", "squashfs")
 	c.Assert(err, IsNil)
 
 	// Should still be the same file
@@ -1319,7 +1319,7 @@ func (s *SystemdTestSuite) TestAddMountUnitForDirs(c *C) {
 
 	// a directory instead of a file produces a different output
 	snapDir := c.MkDir()
-	mountUnitName, err := New(SystemMode, nil).AddMountUnitFile("foodir", "x1", snapDir, "/snap/snapname/x1", "squashfs")
+	mountUnitName, err := New(SystemMode, nil).EnsureMountUnitFile("foodir", "x1", snapDir, "/snap/snapname/x1", "squashfs")
 	c.Assert(err, IsNil)
 	defer os.Remove(mountUnitName)
 
@@ -1367,7 +1367,7 @@ func (s *SystemdTestSuite) TestAddMountUnitTransient(c *C) {
 		Options:  []string{"remount,ro"},
 		Origin:   "bar",
 	}
-	mountUnitName, err := NewUnderRoot(rootDir, SystemMode, nil).AddMountUnitFileWithOptions(addMountUnitOptions)
+	mountUnitName, err := NewUnderRoot(rootDir, SystemMode, nil).EnsureMountUnitFileWithOptions(addMountUnitOptions)
 	c.Assert(err, IsNil)
 	defer os.Remove(mountUnitName)
 
@@ -1412,7 +1412,7 @@ func (s *SystemdTestSuite) TestWriteSELinuxMountUnit(c *C) {
 	err = ioutil.WriteFile(mockSnapPath, nil, 0644)
 	c.Assert(err, IsNil)
 
-	mountUnitName, err := New(SystemMode, nil).AddMountUnitFile("foo", "42", mockSnapPath, "/snap/snapname/123", "squashfs")
+	mountUnitName, err := New(SystemMode, nil).EnsureMountUnitFile("foo", "42", mockSnapPath, "/snap/snapname/123", "squashfs")
 	c.Assert(err, IsNil)
 	defer os.Remove(mountUnitName)
 
@@ -1458,7 +1458,7 @@ exit 0
 	err = ioutil.WriteFile(mockSnapPath, nil, 0644)
 	c.Assert(err, IsNil)
 
-	mountUnitName, err := New(SystemMode, nil).AddMountUnitFile("foo", "x1", mockSnapPath, "/snap/snapname/123", "squashfs")
+	mountUnitName, err := New(SystemMode, nil).EnsureMountUnitFile("foo", "x1", mockSnapPath, "/snap/snapname/123", "squashfs")
 	c.Assert(err, IsNil)
 	defer os.Remove(mountUnitName)
 
@@ -1500,7 +1500,7 @@ exit 0
 	err = ioutil.WriteFile(mockSnapPath, nil, 0644)
 	c.Assert(err, IsNil)
 
-	mountUnitName, err := New(SystemMode, nil).AddMountUnitFile("foo", "x1", mockSnapPath, "/snap/snapname/123", "squashfs")
+	mountUnitName, err := New(SystemMode, nil).EnsureMountUnitFile("foo", "x1", mockSnapPath, "/snap/snapname/123", "squashfs")
 	c.Assert(err, IsNil)
 	defer os.Remove(mountUnitName)
 
@@ -1681,7 +1681,7 @@ func (s *SystemdTestSuite) testDaemonOpWithMutex(c *C, testFunc func(Systemd) er
 	// daemon-reload. This will be serialized, if not this would
 	// panic because systemd.daemonReloadNoLock ensures the lock is
 	// taken when this happens.
-	_, err := sysd.AddMountUnitFile("foo", "42", mockSnapPath, "/snap/foo/42", "squashfs")
+	_, err := sysd.EnsureMountUnitFile("foo", "42", mockSnapPath, "/snap/foo/42", "squashfs")
 	c.Assert(err, IsNil)
 	close(stopCh)
 	<-stoppedCh
@@ -1801,7 +1801,7 @@ func (s *SystemdTestSuite) TestPreseedModeAddMountUnit(c *C) {
 	mockSnapPath := filepath.Join(c.MkDir(), "/var/lib/snappy/snaps/foo_1.0.snap")
 	makeMockFile(c, mockSnapPath)
 
-	mountUnitName, err := sysd.AddMountUnitFile("foo", "42", mockSnapPath, "/snap/snapname/123", "squashfs")
+	mountUnitName, err := sysd.EnsureMountUnitFile("foo", "42", mockSnapPath, "/snap/snapname/123", "squashfs")
 	c.Assert(err, IsNil)
 	defer os.Remove(mountUnitName)
 
@@ -1846,7 +1846,7 @@ WantedBy=multi-user.target
 	err = ioutil.WriteFile(filepath.Join(dirs.SnapServicesDir, "snap-snapname-123.mount"), []byte(content), 0644)
 	c.Assert(err, IsNil)
 
-	_, err = sysd.AddMountUnitFile("foo", "42", mockSnapPath, "/snap/snapname/123", "squashfs")
+	_, err = sysd.EnsureMountUnitFile("foo", "42", mockSnapPath, "/snap/snapname/123", "squashfs")
 	c.Assert(err, IsNil)
 
 	// systemd was not called
@@ -1891,7 +1891,7 @@ WantedBy=multi-user.target
 	err = ioutil.WriteFile(filepath.Join(dirs.SnapServicesDir, "snap-snapname-123.mount"), []byte(content), 0644)
 	c.Assert(err, IsNil)
 
-	mountUnitName, err := sysd.AddMountUnitFile("foo", "42", mockSnapPath, "/snap/snapname/123", "squashfs")
+	mountUnitName, err := sysd.EnsureMountUnitFile("foo", "42", mockSnapPath, "/snap/snapname/123", "squashfs")
 	c.Assert(err, IsNil)
 
 	c.Check(s.argses, DeepEquals, [][]string{{"--root", dirs.GlobalRootDir, "enable", "snap-snapname-123.mount"}})
@@ -1912,7 +1912,7 @@ func (s *SystemdTestSuite) TestPreseedModeAddMountUnitWithFuse(c *C) {
 	mockSnapPath := filepath.Join(c.MkDir(), "/var/lib/snappy/snaps/foo_1.0.snap")
 	makeMockFile(c, mockSnapPath)
 
-	mountUnitName, err := sysd.AddMountUnitFile("foo", "42", mockSnapPath, "/snap/snapname/123", "squashfs")
+	mountUnitName, err := sysd.EnsureMountUnitFile("foo", "42", mockSnapPath, "/snap/snapname/123", "squashfs")
 	c.Assert(err, IsNil)
 	defer os.Remove(mountUnitName)
 
@@ -1932,7 +1932,7 @@ func (s *SystemdTestSuite) TestPreseedModeMountError(c *C) {
 	mockSnapPath := filepath.Join(c.MkDir(), "/var/lib/snappy/snaps/foo_1.0.snap")
 	makeMockFile(c, mockSnapPath)
 
-	_, err := sysd.AddMountUnitFile("foo", "42", mockSnapPath, "/snap/snapname/123", "squashfs")
+	_, err := sysd.EnsureMountUnitFile("foo", "42", mockSnapPath, "/snap/snapname/123", "squashfs")
 	c.Assert(err, ErrorMatches, `cannot mount .*/var/lib/snappy/snaps/foo_1.0.snap \(squashfs\) at /snap/snapname/123 in preseed mode: exit status 1; some failure\n`)
 }
 
@@ -1998,7 +1998,7 @@ func (s *SystemdTestSuite) TestPreseedModeBindmountNotSupported(c *C) {
 
 	mockSnapPath := c.MkDir()
 
-	_, err := sysd.AddMountUnitFile("foo", "42", mockSnapPath, "/snap/snapname/123", "")
+	_, err := sysd.EnsureMountUnitFile("foo", "42", mockSnapPath, "/snap/snapname/123", "")
 	c.Assert(err, ErrorMatches, `bind-mounted directory is not supported in emulation mode`)
 }
 

--- a/tests/core/snapd-failover/task.yaml
+++ b/tests/core/snapd-failover/task.yaml
@@ -23,7 +23,7 @@ restore: |
         rm -f /etc/systemd/user/snapd.session-agent.service
         rm -f /etc/systemd/user/snapd.session-agent.socket
         rm -f /etc/systemd/user/sockets.target.wants/snapd.session-agent.socket
-        systemctl --user daemon-reload
+        systemctl --user daemon-reload || true
         rm -f /etc/dbus-1/session.d/snapd.session-services.conf
         rm -f /etc/dbus-1/system.d/snapd.system-services.conf
     fi
@@ -152,9 +152,16 @@ execute: |
         # the test's execution on uc16, but just be extra safe
         if os.query is-core16; then
             # now remove the snapd snap since we booted with the core snap
+            # we need first to unmount snapd snaps
+            for mntpnt in /snap/snapd/*; do
+              if mountpoint -q "${mntpnt}"; then
+                unit="$(systemd-escape --path "${mntpnt}").mount"
+                umount "${mntpnt}" || true
+                rm -f "/etc/systemd/system/${unit}"
+              fi
+            done
+            systemctl daemon-reload || true
             snap list
-            # this only succeeds because we reverted back to having the core 
-            # snap on UC16, and the snapd snap is in a broken state
             snap remove snapd
             # and we can still run the rsync snap after the reboot
             rsync --help

--- a/tests/core/snapd16/task.yaml
+++ b/tests/core/snapd16/task.yaml
@@ -11,7 +11,7 @@ restore: |
     rm -f /etc/systemd/user/snapd.session-agent.service
     rm -f /etc/systemd/user/snapd.session-agent.socket
     rm -f /etc/systemd/user/sockets.target.wants/snapd.session-agent.socket
-    systemctl --user daemon-reload
+    systemctl --user daemon-reload || true
     rm -f /etc/dbus-1/session.d/snapd.session-services.conf
     rm -f /etc/dbus-1/system.d/snapd.system-services.conf
 
@@ -52,7 +52,8 @@ execute: |
         # we cannot restore in "restore:" because we need a reboot
         # right now to get a clean state again
         systemctl stop snapd.service snapd.socket snapd.autoimport.service snapd.snap-repair.service snapd.snap-repair.timer
-        umount "/snap/snapd/$(readlink /snap/snapd/current)"
+        umount "/snap/snapd/x2"
+        umount "/snap/snapd/x1"
 
         rm -f /etc/systemd/system/usr-lib-snapd.mount
         rm -f /etc/systemd/system/snap-snapd-*.mount
@@ -66,11 +67,16 @@ execute: |
         umount --lazy /usr/lib/snapd
         systemctl start snapd.service snapd.socket
         systemctl status snapd|MATCH " /usr/lib/snapd/snapd"
+        snap wait system seed.loaded
+
+        umount /snap/snapd/x2
+        rm /etc/systemd/system/snap-snapd-x2.mount
+        systemctl daemon-reload
+        snap list
+        snap remove snapd
 
         echo "And we reboot to get a clean system again"
         REBOOT
     fi
-    snap list
-    snap remove snapd
     # and we can still run the rsync snap after the reboot
     rsync --help

--- a/tests/main/snapd-update-services/task.yaml
+++ b/tests/main/snapd-update-services/task.yaml
@@ -1,0 +1,79 @@
+summary: systemd units get regenerated when snapd is refreshed
+
+systems:
+  # there seems to be some kernel issue with duplicated mounts in
+  # /proc/*/mounts on 14.04 so it makes it more difficult to test
+  # there.
+  - ubuntu-16.04-*
+  - ubuntu-18.04-*
+  - ubuntu-2*
+
+prepare: |
+  # Install a snap with a service running
+  service_snap="$("${TESTSTOOLS}/snaps-state" pack-local test-snapd-service)"
+  snap install --dangerous "${service_snap}"
+  systemctl is-active snap.test-snapd-service.test-snapd-service.service
+
+  # Download current snapd edge
+  snap download --edge snapd --basename=snapd_edge
+
+  # Repack it with currently built snapd
+  unpackdir=/tmp/snapd-update-services
+  unsquashfs -no-progress -d "${unpackdir}" snapd_edge.snap
+  dpkg-deb -x "${GOHOME}"/snapd_*.deb "${unpackdir}"
+  snap pack "${unpackdir}" --filename snapd_modified.snap
+  rm -rf "${unpackdir}"
+
+restore: |
+  rm -rf /tmp/snapd-update-services
+  rm -f snapd_edge.snap
+  rm -f snapd_modified.snap
+
+execute: |
+  snap install --dangerous snapd_edge.snap
+
+  # We simulate TimeoutStopSec= being a new feature
+  systemctl show -p TimeoutStopUSec snap.test-snapd-service.test-snapd-service.service | MATCH 'TimeoutStopUSec=30s'
+
+  sed -i "/^TimeoutStopSec=/d" /etc/systemd/system/snap.test-snapd-service.*.service
+
+  systemctl daemon-reload
+
+  for f in /etc/systemd/system/snap.test-snapd-service.*.service; do
+    unit="$(basename "${f}")"
+    systemctl show -p TimeoutStopUSec "${unit}" | NOMATCH 'TimeoutStopUSec=30s'
+    systemctl reload-or-restart "${unit}"
+  done
+
+  # We simulate Options=dev to Options=nodev update
+  mount_units=()
+  for f in /etc/systemd/system/snap-*.mount; do
+    unit="$(basename "${f}")"
+    case "${unit}" in
+      snap-snapd-*.mount)
+        # This version will get disabled and not updated
+        continue
+        ;;
+    esac
+    mount_units+=("${unit}")
+    sed -i '/^Options=/s/nodev/dev/g' "${f}"
+    systemctl daemon-reload
+    systemctl reload "${unit}"
+    what="$(systemctl show -p What "${unit}")"
+    what="${what#What=}"
+    findmnt -o OPTIONS -n "${what}" | NOMATCH nodev
+  done
+
+  # Snapd update
+  snap install --dangerous snapd_modified.snap
+
+  # Check the service file has been updated
+  systemctl is-active snap.test-snapd-service.test-snapd-service.service
+  systemctl show -p TimeoutStopUSec snap.test-snapd-service.test-snapd-service.service | MATCH 'TimeoutStopUSec=30s'
+
+  # Check the mounts have been updated
+  for unit in "${mount_units[@]}"; do
+    what="$(systemctl show -p What "${unit}")"
+    what="${what#What=}"
+    findmnt -o OPTIONS -n "${what}" | MATCH nodev
+  done

--- a/wrappers/core18.go
+++ b/wrappers/core18.go
@@ -64,7 +64,7 @@ func writeSnapdToolingMountUnit(sysd systemd.Systemd, prefix string, opts *AddSn
 
 	// TODO: the following comment is wrong, we don't need RequiredBy=snapd here?
 
-	// Not using AddMountUnitFile() because we need
+	// Not using EnsureMountUnitFile() because we need
 	// "RequiredBy=snapd.service"
 
 	content := []byte(fmt.Sprintf(`[Unit]

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -1833,7 +1833,7 @@ func RestartServices(svcs []*snap.AppInfo, explicitServices []string,
 		var err error
 		timings.Run(tm, "restart-service", fmt.Sprintf("restart service %s", unit.Name), func(nested timings.Measurer) {
 			if flags != nil && flags.Reload {
-				err = sysd.ReloadOrRestart(unit.Name)
+				err = sysd.ReloadOrRestart([]string{unit.Name})
 			} else {
 				// note: stop followed by start, not just 'restart'
 				err = sysd.Restart([]string{unit.Name})


### PR DESCRIPTION
When updating service files for the snaps, this also verifies the mount unit of the snap is updated. This however does not update mounts generated from `snapctl mount`.

Note that there is a lot or renaming. So to ease the review I have split it in commit with separate concerns.