### PR TITLE
tests: add extra space to ubuntu bionic

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -108,6 +108,7 @@ backends:
             - ubuntu-18.04-32:
                   workers: 6
             - ubuntu-18.04-64:
+                  storage: 12G
                   workers: 8
             - ubuntu-20.04-64:
                   storage: 12G


### PR DESCRIPTION
This is because preseed-lxd tests is failing with the following error:

Error: write /var/lib/lxd/images/lxd_build_999208398/lxd_post_675612885:
no space left on device
