### PR TITLE
multiple: move arguments for auth.NewUser into a struct (auto-removal 1/n)

### DIFF
--- a/daemon/api_base_test.go
+++ b/daemon/api_base_test.go
@@ -346,7 +346,12 @@ func (s *apiBaseSuite) asUserAuth(c *check.C, req *http.Request) {
 	if s.authUser == nil {
 		st := s.d.Overlord().State()
 		st.Lock()
-		u, err := auth.NewUser(st, "username", "email@test.com", "macaroon", []string{"discharge"})
+		u, err := auth.NewUser(st, auth.NewUserData{
+			Username:   "username",
+			Email:      "email@test.com",
+			Macaroon:   "macaroon",
+			Discharges: []string{"discharge"},
+		})
 		st.Unlock()
 		c.Assert(err, check.IsNil)
 		s.authUser = u

--- a/daemon/api_find_test.go
+++ b/daemon/api_find_test.go
@@ -363,7 +363,12 @@ func (s *findSuite) TestFindOneWithAuth(c *check.C) {
 
 	state := d.Overlord().State()
 	state.Lock()
-	user, err := auth.NewUser(state, "username", "email@test.com", "macaroon", []string{"discharge"})
+	user, err := auth.NewUser(state, auth.NewUserData{
+		Username:   "username",
+		Email:      "email@test.com",
+		Macaroon:   "macaroon",
+		Discharges: []string{"discharge"},
+	})
 	state.Unlock()
 	c.Check(err, check.IsNil)
 

--- a/daemon/api_general_test.go
+++ b/daemon/api_general_test.go
@@ -317,7 +317,12 @@ func (s *generalSuite) TestSysInfoIsManaged(c *check.C) {
 
 	st := d.Overlord().State()
 	st.Lock()
-	_, err := auth.NewUser(st, "someuser", "mymail@test.com", "macaroon", []string{"discharge"})
+	_, err := auth.NewUser(st, auth.NewUserData{
+		Username:   "someuser",
+		Email:      "mymail@test.com",
+		Macaroon:   "macaroon",
+		Discharges: []string{"discharge"},
+	})
 	st.Unlock()
 	c.Assert(err, check.IsNil)
 

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -316,7 +316,12 @@ func (s *snapsSuite) TestSnapsInfoStoreWithAuth(c *check.C) {
 
 	state := d.Overlord().State()
 	state.Lock()
-	user, err := auth.NewUser(state, "username", "email@test.com", "macaroon", []string{"discharge"})
+	user, err := auth.NewUser(state, auth.NewUserData{
+		Username:   "username",
+		Email:      "email@test.com",
+		Macaroon:   "macaroon",
+		Discharges: []string{"discharge"},
+	})
 	state.Unlock()
 	c.Check(err, check.IsNil)
 
@@ -1433,7 +1438,12 @@ func (s *snapsSuite) TestPostSnapSetsUser(c *check.C) {
 
 	state := d.Overlord().State()
 	state.Lock()
-	user, err := auth.NewUser(state, "username", "email@test.com", "macaroon", []string{"discharge"})
+	user, err := auth.NewUser(state, auth.NewUserData{
+		Username:   "username",
+		Email:      "email@test.com",
+		Macaroon:   "macaroon",
+		Discharges: []string{"discharge"},
+	})
 	state.Unlock()
 	c.Check(err, check.IsNil)
 

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -98,7 +98,12 @@ func (s *apiSuite) TestUserFromRequestHeaderCorrectMissingUser(c *check.C) {
 
 func (s *apiSuite) TestUserFromRequestHeaderValidUser(c *check.C) {
 	s.st.Lock()
-	expectedUser, err := auth.NewUser(s.st, "username", "email@test.com", "macaroon", []string{"discharge"})
+	expectedUser, err := auth.NewUser(s.st, auth.NewUserData{
+		Username:   "username",
+		Email:      "email@test.com",
+		Macaroon:   "macaroon",
+		Discharges: []string{"discharge"},
+	})
 	s.st.Unlock()
 	c.Check(err, check.IsNil)
 

--- a/daemon/api_users.go
+++ b/daemon/api_users.go
@@ -170,7 +170,12 @@ func loginUser(c *Command, r *http.Request, user *auth.UserState) Response {
 		user.Email = loginData.Email
 		err = auth.UpdateUser(st, user)
 	} else {
-		user, err = auth.NewUser(st, loginData.Username, loginData.Email, macaroon, []string{discharge})
+		user, err = auth.NewUser(st, auth.NewUserData{
+			Username:   loginData.Username,
+			Email:      loginData.Email,
+			Macaroon:   macaroon,
+			Discharges: []string{discharge},
+		})
 	}
 	st.Unlock()
 	if err != nil {
@@ -569,7 +574,12 @@ func setupLocalUser(st *state.State, username, email string) error {
 
 	// setup new user, local-only
 	st.Lock()
-	authUser, err := auth.NewUser(st, username, email, "", nil)
+	authUser, err := auth.NewUser(st, auth.NewUserData{
+		Username:   username,
+		Email:      email,
+		Macaroon:   "",
+		Discharges: nil,
+	})
 	st.Unlock()
 	if err != nil {
 		return fmt.Errorf("cannot persist authentication details: %v", err)

--- a/daemon/api_users_test.go
+++ b/daemon/api_users_test.go
@@ -210,7 +210,12 @@ func (s *userSuite) TestLoginUserNoEmailWithExistentLocalUser(c *check.C) {
 
 	// setup local-only user
 	state.Lock()
-	localUser, err := auth.NewUser(state, "username", "email@test.com", "", nil)
+	localUser, err := auth.NewUser(state, auth.NewUserData{
+		Username:   "username",
+		Email:      "email@test.com",
+		Macaroon:   "",
+		Discharges: nil,
+	})
 	state.Unlock()
 	c.Assert(err, check.IsNil)
 
@@ -253,7 +258,12 @@ func (s *userSuite) TestLoginUserWithExistentLocalUser(c *check.C) {
 
 	// setup local-only user
 	state.Lock()
-	localUser, err := auth.NewUser(state, "username", "email@test.com", "", nil)
+	localUser, err := auth.NewUser(state, auth.NewUserData{
+		Username:   "username",
+		Email:      "email@test.com",
+		Macaroon:   "",
+		Discharges: nil,
+	})
 	state.Unlock()
 	c.Assert(err, check.IsNil)
 
@@ -296,7 +306,12 @@ func (s *userSuite) TestLoginUserNewEmailWithExistentLocalUser(c *check.C) {
 
 	// setup local-only user
 	state.Lock()
-	localUser, err := auth.NewUser(state, "username", "email@test.com", "", nil)
+	localUser, err := auth.NewUser(state, auth.NewUserData{
+		Username:   "username",
+		Email:      "email@test.com",
+		Macaroon:   "",
+		Discharges: nil,
+	})
 	state.Unlock()
 	c.Assert(err, check.IsNil)
 
@@ -339,7 +354,12 @@ func (s *userSuite) TestLogoutUser(c *check.C) {
 	s.expectLoginAccess()
 
 	state.Lock()
-	user, err := auth.NewUser(state, "username", "email@test.com", "macaroon", []string{"discharge"})
+	user, err := auth.NewUser(state, auth.NewUserData{
+		Username:   "username",
+		Email:      "email@test.com",
+		Macaroon:   "macaroon",
+		Discharges: []string{"discharge"},
+	})
 	state.Unlock()
 	c.Assert(err, check.IsNil)
 
@@ -617,7 +637,12 @@ func (s *userSuite) TestPostUserActionRemoveNoUsername(c *check.C) {
 func (s *userSuite) TestPostUserActionRemoveDelUserErr(c *check.C) {
 	st := s.d.Overlord().State()
 	st.Lock()
-	_, err := auth.NewUser(st, "some-user", "email@test.com", "macaroon", []string{"discharge"})
+	_, err := auth.NewUser(st, auth.NewUserData{
+		Username:   "some-user",
+		Email:      "email@test.com",
+		Macaroon:   "macaroon",
+		Discharges: []string{"discharge"},
+	})
 	st.Unlock()
 	c.Check(err, check.IsNil)
 
@@ -680,7 +705,12 @@ func (s *userSuite) TestPostUserActionRemoveNoUserInState(c *check.C) {
 func (s *userSuite) TestPostUserActionRemove(c *check.C) {
 	st := s.d.Overlord().State()
 	st.Lock()
-	user, err := auth.NewUser(st, "some-user", "email@test.com", "macaroon", []string{"discharge"})
+	user, err := auth.NewUser(st, auth.NewUserData{
+		Username:   "some-user",
+		Email:      "email@test.com",
+		Macaroon:   "macaroon",
+		Discharges: []string{"discharge"},
+	})
 	st.Unlock()
 	c.Check(err, check.IsNil)
 
@@ -1058,7 +1088,12 @@ func (s *userSuite) TestPostCreateUserFromAssertionAllKnownButOwnedErrors(c *che
 
 	st := s.d.Overlord().State()
 	st.Lock()
-	_, err := auth.NewUser(st, "username", "email@test.com", "macaroon", []string{"discharge"})
+	_, err := auth.NewUser(st, auth.NewUserData{
+		Username:   "username",
+		Email:      "email@test.com",
+		Macaroon:   "macaroon",
+		Discharges: []string{"discharge"},
+	})
 	st.Unlock()
 	c.Check(err, check.IsNil)
 
@@ -1076,7 +1111,12 @@ func (s *userSuite) TestPostCreateUserAutomaticManagedDoesNotActOrError(c *check
 
 	st := s.d.Overlord().State()
 	st.Lock()
-	_, err := auth.NewUser(st, "username", "email@test.com", "macaroon", []string{"discharge"})
+	_, err := auth.NewUser(st, auth.NewUserData{
+		Username:   "username",
+		Email:      "email@test.com",
+		Macaroon:   "macaroon",
+		Discharges: []string{"discharge"},
+	})
 	st.Unlock()
 	c.Check(err, check.IsNil)
 
@@ -1150,7 +1190,12 @@ func (s *userSuite) TestPostCreateUserFromAssertionAllKnownButOwned(c *check.C) 
 
 	st := s.d.Overlord().State()
 	st.Lock()
-	_, err := auth.NewUser(st, "username", "email@test.com", "macaroon", []string{"discharge"})
+	_, err := auth.NewUser(st, auth.NewUserData{
+		Username:   "username",
+		Email:      "email@test.com",
+		Macaroon:   "macaroon",
+		Discharges: []string{"discharge"},
+	})
 	st.Unlock()
 	c.Check(err, check.IsNil)
 
@@ -1244,7 +1289,12 @@ func (s *userSuite) TestUsersEmpty(c *check.C) {
 func (s *userSuite) TestUsersHasUser(c *check.C) {
 	st := s.d.Overlord().State()
 	st.Lock()
-	u, err := auth.NewUser(st, "someuser", "mymail@test.com", "macaroon", []string{"discharge"})
+	u, err := auth.NewUser(st, auth.NewUserData{
+		Username:   "someuser",
+		Email:      "email@test.com",
+		Macaroon:   "macaroon",
+		Discharges: []string{"discharge"},
+	})
 	st.Unlock()
 	c.Assert(err, check.IsNil)
 

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -122,7 +122,12 @@ func (s *daemonSuite) TestCommandMethodDispatch(c *check.C) {
 	d := newTestDaemon(c)
 	st := d.Overlord().State()
 	st.Lock()
-	authUser, err := auth.NewUser(st, "username", "email@test.com", "macaroon", []string{"discharge"})
+	authUser, err := auth.NewUser(st, auth.NewUserData{
+		Username:   "username",
+		Email:      "email@test.com",
+		Macaroon:   "macaroon",
+		Discharges: []string{"discharge"},
+	})
 	st.Unlock()
 	c.Assert(err, check.IsNil)
 
@@ -440,7 +445,12 @@ func (s *daemonSuite) TestWriteAccessWithUser(c *check.C) {
 	d := newTestDaemon(c)
 	st := d.Overlord().State()
 	st.Lock()
-	authUser, err := auth.NewUser(st, "username", "email@test.com", "macaroon", []string{"discharge"})
+	authUser, err := auth.NewUser(st, auth.NewUserData{
+		Username:   "username",
+		Email:      "email@test.com",
+		Macaroon:   "macaroon",
+		Discharges: []string{"discharge"},
+	})
 	st.Unlock()
 	c.Assert(err, check.IsNil)
 

--- a/overlord/auth/auth.go
+++ b/overlord/auth/auth.go
@@ -139,9 +139,9 @@ type NewUserData struct {
 	Username string
 	// Email is the email associated with the user
 	Email string
-	// Macaroon is the store associated macaroon for the user
+	// Macaroon is the store-associated authentication macaroon
 	Macaroon string
-	// Discharges
+	// Discharges contains discharged store auth caveats.
 	Discharges []string
 }
 

--- a/overlord/auth/auth.go
+++ b/overlord/auth/auth.go
@@ -134,8 +134,19 @@ func newUserMacaroon(macaroonKey []byte, userID int) (string, error) {
 
 // TODO: possibly move users' related functions to a userstate package
 
+type NewUserData struct {
+	// Username is the name of the user on the system
+	Username string
+	// Email is the email associated with the user
+	Email string
+	// Macaroon is the store associated macaroon for the user
+	Macaroon string
+	// Discharges
+	Discharges []string
+}
+
 // NewUser tracks a new authenticated user and saves its details in the state
-func NewUser(st *state.State, username, email, macaroon string, discharges []string) (*UserState, error) {
+func NewUser(st *state.State, userData NewUserData) (*UserState, error) {
 	var authStateData AuthState
 
 	err := st.Get("auth", &authStateData)
@@ -159,15 +170,15 @@ func NewUser(st *state.State, username, email, macaroon string, discharges []str
 		return nil, err
 	}
 
-	sort.Strings(discharges)
+	sort.Strings(userData.Discharges)
 	authenticatedUser := UserState{
 		ID:              authStateData.LastID,
-		Username:        username,
-		Email:           email,
+		Username:        userData.Username,
+		Email:           userData.Email,
 		Macaroon:        localMacaroon,
 		Discharges:      nil,
-		StoreMacaroon:   macaroon,
-		StoreDischarges: discharges,
+		StoreMacaroon:   userData.Macaroon,
+		StoreDischarges: userData.Discharges,
 	}
 	authStateData.Users = append(authStateData.Users, authenticatedUser)
 

--- a/overlord/auth/auth_test.go
+++ b/overlord/auth/auth_test.go
@@ -86,7 +86,12 @@ func (s *authSuite) TestMacaroonDeserializeInvalidData(c *C) {
 
 func (as *authSuite) TestNewUser(c *C) {
 	as.state.Lock()
-	user, err := auth.NewUser(as.state, "username", "email@test.com", "macaroon", []string{"discharge"})
+	user, err := auth.NewUser(as.state, auth.NewUserData{
+		Username:   "username",
+		Email:      "email@test.com",
+		Macaroon:   "macaroon",
+		Discharges: []string{"discharge"},
+	})
 	as.state.Unlock()
 	c.Check(err, IsNil)
 
@@ -116,7 +121,12 @@ func (as *authSuite) TestNewUser(c *C) {
 
 func (as *authSuite) TestNewUserSortsDischarges(c *C) {
 	as.state.Lock()
-	user, err := auth.NewUser(as.state, "", "email@test.com", "macaroon", []string{"discharge2", "discharge1"})
+	user, err := auth.NewUser(as.state, auth.NewUserData{
+		Username:   "",
+		Email:      "email@test.com",
+		Macaroon:   "macaroon",
+		Discharges: []string{"discharge2", "discharge1"},
+	})
 	c.Assert(err, IsNil)
 	as.state.Unlock()
 
@@ -132,13 +142,23 @@ func (as *authSuite) TestNewUserSortsDischarges(c *C) {
 
 func (as *authSuite) TestNewUserAddsToExistent(c *C) {
 	as.state.Lock()
-	firstUser, err := auth.NewUser(as.state, "username", "email@test.com", "macaroon", []string{"discharge"})
+	firstUser, err := auth.NewUser(as.state, auth.NewUserData{
+		Username:   "username",
+		Email:      "email@test.com",
+		Macaroon:   "macaroon",
+		Discharges: []string{"discharge"},
+	})
 	as.state.Unlock()
 	c.Check(err, IsNil)
 
 	// adding a new one
 	as.state.Lock()
-	user, err := auth.NewUser(as.state, "new_username", "new_email@test.com", "new_macaroon", []string{"new_discharge"})
+	user, err := auth.NewUser(as.state, auth.NewUserData{
+		Username:   "new_username",
+		Email:      "new_email@test.com",
+		Macaroon:   "new_macaroon",
+		Discharges: []string{"new_discharge"},
+	})
 	as.state.Unlock()
 	c.Check(err, IsNil)
 	c.Check(user.ID, Equals, 2)
@@ -179,7 +199,12 @@ func (as *authSuite) TestCheckMacaroonInvalidAuth(c *C) {
 	c.Check(user, IsNil)
 
 	as.state.Lock()
-	_, err = auth.NewUser(as.state, "username", "email@test.com", "macaroon", []string{"discharge"})
+	_, err = auth.NewUser(as.state, auth.NewUserData{
+		Username:   "username",
+		Email:      "email@test.com",
+		Macaroon:   "macaroon",
+		Discharges: []string{"discharge"},
+	})
 	as.state.Unlock()
 	c.Check(err, IsNil)
 
@@ -193,7 +218,12 @@ func (as *authSuite) TestCheckMacaroonInvalidAuth(c *C) {
 
 func (as *authSuite) TestCheckMacaroonValidUser(c *C) {
 	as.state.Lock()
-	expectedUser, err := auth.NewUser(as.state, "username", "email@test.com", "macaroon", []string{"discharge"})
+	expectedUser, err := auth.NewUser(as.state, auth.NewUserData{
+		Username:   "username",
+		Email:      "email@test.com",
+		Macaroon:   "macaroon",
+		Discharges: []string{"discharge"},
+	})
 	as.state.Unlock()
 	c.Check(err, IsNil)
 
@@ -213,7 +243,12 @@ func (as *authSuite) TestCheckMacaroonValidUserOldStyle(c *C) {
 	c.Check(err, IsNil)
 
 	as.state.Lock()
-	expectedUser, err := auth.NewUser(as.state, "username", "email@test.com", serializedMacaroon, []string{"discharge"})
+	expectedUser, err := auth.NewUser(as.state, auth.NewUserData{
+		Username:   "username",
+		Email:      "email@test.com",
+		Macaroon:   serializedMacaroon,
+		Discharges: []string{"discharge"},
+	})
 	c.Check(err, IsNil)
 	// set user local macaroons with store macaroons
 	expectedUser.Macaroon = expectedUser.StoreMacaroon
@@ -234,7 +269,12 @@ func (as *authSuite) TestCheckMacaroonInvalidAuthMalformedMacaroon(c *C) {
 	var authStateData auth.AuthState
 	as.state.Lock()
 	// create a new user to ensure there is a MacaroonKey setup
-	_, err := auth.NewUser(as.state, "username", "email@test.com", "macaroon", []string{"discharge"})
+	_, err := auth.NewUser(as.state, auth.NewUserData{
+		Username:   "username",
+		Email:      "email@test.com",
+		Macaroon:   "macaroon",
+		Discharges: []string{"discharge"},
+	})
 	c.Check(err, IsNil)
 	// get AuthState to get signing MacaroonKey
 	err = as.state.Get("auth", &authStateData)
@@ -265,7 +305,12 @@ func (as *authSuite) TestUserForNoAuthInState(c *C) {
 
 func (as *authSuite) TestUserForNonExistent(c *C) {
 	as.state.Lock()
-	_, err := auth.NewUser(as.state, "username", "email@test.com", "macaroon", []string{"discharge"})
+	_, err := auth.NewUser(as.state, auth.NewUserData{
+		Username:   "username",
+		Email:      "email@test.com",
+		Macaroon:   "macaroon",
+		Discharges: []string{"discharge"},
+	})
 	as.state.Unlock()
 	c.Check(err, IsNil)
 
@@ -278,7 +323,12 @@ func (as *authSuite) TestUserForNonExistent(c *C) {
 
 func (as *authSuite) TestUser(c *C) {
 	as.state.Lock()
-	user, err := auth.NewUser(as.state, "username", "email@test.com", "macaroon", []string{"discharge"})
+	user, err := auth.NewUser(as.state, auth.NewUserData{
+		Username:   "username",
+		Email:      "email@test.com",
+		Macaroon:   "macaroon",
+		Discharges: []string{"discharge"},
+	})
 	as.state.Unlock()
 	c.Check(err, IsNil)
 
@@ -293,7 +343,12 @@ func (as *authSuite) TestUser(c *C) {
 
 func (as *authSuite) TestUserByUsername(c *C) {
 	as.state.Lock()
-	user, err := auth.NewUser(as.state, "username", "email@test.com", "macaroon", []string{"discharge"})
+	user, err := auth.NewUser(as.state, auth.NewUserData{
+		Username:   "username",
+		Email:      "email@test.com",
+		Macaroon:   "macaroon",
+		Discharges: []string{"discharge"},
+	})
 	as.state.Unlock()
 	c.Check(err, IsNil)
 
@@ -315,14 +370,24 @@ func (as *authSuite) TestUserHasStoreAuth(c *C) {
 	c.Check(user0.HasStoreAuth(), Equals, false)
 
 	as.state.Lock()
-	user, err := auth.NewUser(as.state, "username", "email@test.com", "macaroon", []string{"discharge"})
+	user, err := auth.NewUser(as.state, auth.NewUserData{
+		Username:   "username",
+		Email:      "email@test.com",
+		Macaroon:   "macaroon",
+		Discharges: []string{"discharge"},
+	})
 	as.state.Unlock()
 	c.Check(err, IsNil)
 	c.Check(user.HasStoreAuth(), Equals, true)
 
 	// no store auth
 	as.state.Lock()
-	user, err = auth.NewUser(as.state, "username", "email@test.com", "", nil)
+	user, err = auth.NewUser(as.state, auth.NewUserData{
+		Username:   "username",
+		Email:      "email@test.com",
+		Macaroon:   "",
+		Discharges: nil,
+	})
 	as.state.Unlock()
 	c.Check(err, IsNil)
 	c.Check(user.HasStoreAuth(), Equals, false)
@@ -330,7 +395,12 @@ func (as *authSuite) TestUserHasStoreAuth(c *C) {
 
 func (as *authSuite) TestUpdateUser(c *C) {
 	as.state.Lock()
-	user, _ := auth.NewUser(as.state, "username", "email@test.com", "macaroon", []string{"discharge"})
+	user, _ := auth.NewUser(as.state, auth.NewUserData{
+		Username:   "username",
+		Email:      "email@test.com",
+		Macaroon:   "macaroon",
+		Discharges: []string{"discharge"},
+	})
 	as.state.Unlock()
 
 	user.Username = "different"
@@ -350,7 +420,12 @@ func (as *authSuite) TestUpdateUser(c *C) {
 
 func (as *authSuite) TestUpdateUserInvalid(c *C) {
 	as.state.Lock()
-	_, _ = auth.NewUser(as.state, "username", "email@test.com", "macaroon", []string{"discharge"})
+	_, _ = auth.NewUser(as.state, auth.NewUserData{
+		Username:   "username",
+		Email:      "email@test.com",
+		Macaroon:   "macaroon",
+		Discharges: []string{"discharge"},
+	})
 	as.state.Unlock()
 
 	user := &auth.UserState{
@@ -367,7 +442,12 @@ func (as *authSuite) TestUpdateUserInvalid(c *C) {
 
 func (as *authSuite) TestRemove(c *C) {
 	as.state.Lock()
-	user, err := auth.NewUser(as.state, "username", "email@test.com", "macaroon", []string{"discharge"})
+	user, err := auth.NewUser(as.state, auth.NewUserData{
+		Username:   "username",
+		Email:      "email@test.com",
+		Macaroon:   "macaroon",
+		Discharges: []string{"discharge"},
+	})
 	as.state.Unlock()
 	c.Check(err, IsNil)
 
@@ -399,7 +479,12 @@ func (as *authSuite) TestRemove(c *C) {
 
 func (as *authSuite) TestRemoveByUsername(c *C) {
 	as.state.Lock()
-	user, err := auth.NewUser(as.state, "username", "email@test.com", "macaroon", []string{"discharge"})
+	user, err := auth.NewUser(as.state, auth.NewUserData{
+		Username:   "username",
+		Email:      "email@test.com",
+		Macaroon:   "macaroon",
+		Discharges: []string{"discharge"},
+	})
 	as.state.Unlock()
 	c.Check(err, IsNil)
 
@@ -431,8 +516,18 @@ func (as *authSuite) TestRemoveByUsername(c *C) {
 
 func (as *authSuite) TestUsers(c *C) {
 	as.state.Lock()
-	user1, err1 := auth.NewUser(as.state, "user1", "email1@test.com", "macaroon", []string{"discharge"})
-	user2, err2 := auth.NewUser(as.state, "user2", "email2@test.com", "macaroon", []string{"discharge"})
+	user1, err1 := auth.NewUser(as.state, auth.NewUserData{
+		Username:   "user1",
+		Email:      "email1@test.com",
+		Macaroon:   "macaroon",
+		Discharges: []string{"discharge"},
+	})
+	user2, err2 := auth.NewUser(as.state, auth.NewUserData{
+		Username:   "user2",
+		Email:      "email2@test.com",
+		Macaroon:   "macaroon",
+		Discharges: []string{"discharge"},
+	})
 	as.state.Unlock()
 	c.Check(err1, IsNil)
 	c.Check(err2, IsNil)

--- a/overlord/snapstate/handlers_link_test.go
+++ b/overlord/snapstate/handlers_link_test.go
@@ -231,7 +231,12 @@ func (s *linkSnapSuite) TestDoLinkSnapSuccessUserIDAlreadySet(c *C) {
 		UserID:  1,
 	})
 	// the user
-	user, err := auth.NewUser(s.state, "username", "email@test.com", "macaroon", []string{"discharge"})
+	user, err := auth.NewUser(s.state, auth.NewUserData{
+		Username:   "username",
+		Email:      "email@test.com",
+		Macaroon:   "macaroon",
+		Discharges: []string{"discharge"},
+	})
 	c.Assert(err, IsNil)
 	c.Assert(user.ID, Equals, 1)
 

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -228,12 +228,27 @@ func (s *snapmgrBaseTest) SetUpTest(c *C) {
 
 	s.state.Lock()
 	snapstate.ReplaceStore(s.state, s.fakeStore)
-	s.user, err = auth.NewUser(s.state, "username", "email@test.com", "macaroon", []string{"discharge"})
+	s.user, err = auth.NewUser(s.state, auth.NewUserData{
+		Username:   "username",
+		Email:      "email@test.com",
+		Macaroon:   "macaroon",
+		Discharges: []string{"discharge"},
+	})
 	c.Assert(err, IsNil)
-	s.user2, err = auth.NewUser(s.state, "username2", "email2@test.com", "macaroon2", []string{"discharge2"})
+	s.user2, err = auth.NewUser(s.state, auth.NewUserData{
+		Username:   "username2",
+		Email:      "email2@test.com",
+		Macaroon:   "macaroon2",
+		Discharges: []string{"discharge2"},
+	})
 	c.Assert(err, IsNil)
 	// 3 has no store auth
-	s.user3, err = auth.NewUser(s.state, "username3", "email2@test.com", "", nil)
+	s.user3, err = auth.NewUser(s.state, auth.NewUserData{
+		Username:   "username3",
+		Email:      "email2@test.com",
+		Macaroon:   "",
+		Discharges: nil,
+	})
 	c.Assert(err, IsNil)
 
 	s.state.Set("seeded", true)

--- a/overlord/storecontext/context_test.go
+++ b/overlord/storecontext/context_test.go
@@ -60,7 +60,12 @@ func (s *storeCtxSuite) SetUpTest(c *C) {
 
 func (s *storeCtxSuite) TestUpdateUserAuth(c *C) {
 	s.state.Lock()
-	user, _ := auth.NewUser(s.state, "username", "email@test.com", "macaroon", []string{"discharge"})
+	user, _ := auth.NewUser(s.state, auth.NewUserData{
+		Username:   "username",
+		Email:      "email@test.com",
+		Macaroon:   "macaroon",
+		Discharges: []string{"discharge"},
+	})
 	s.state.Unlock()
 
 	newDischarges := []string{"updated-discharge"}
@@ -80,7 +85,12 @@ func (s *storeCtxSuite) TestUpdateUserAuth(c *C) {
 
 func (s *storeCtxSuite) TestUpdateUserAuthOtherUpdate(c *C) {
 	s.state.Lock()
-	user, _ := auth.NewUser(s.state, "username", "email@test.com", "macaroon", []string{"discharge"})
+	user, _ := auth.NewUser(s.state, auth.NewUserData{
+		Username:   "username",
+		Email:      "email@test.com",
+		Macaroon:   "macaroon",
+		Discharges: []string{"discharge"},
+	})
 	otherUpdateUser := *user
 	otherUpdateUser.Macaroon = "macaroon2"
 	otherUpdateUser.StoreDischarges = []string{"other-discharges"}
@@ -113,7 +123,12 @@ func (s *storeCtxSuite) TestUpdateUserAuthOtherUpdate(c *C) {
 
 func (s *storeCtxSuite) TestUpdateUserAuthInvalid(c *C) {
 	s.state.Lock()
-	_, _ = auth.NewUser(s.state, "username", "email@test.com", "macaroon", []string{"discharge"})
+	_, _ = auth.NewUser(s.state, auth.NewUserData{
+		Username:   "username",
+		Email:      "email@test.com",
+		Macaroon:   "macaroon",
+		Discharges: []string{"discharge"},
+	})
 	s.state.Unlock()
 
 	user := &auth.UserState{


### PR DESCRIPTION
In preperation for adding a new parameter (expiration date) to the user state in auth, I am moving arguments for auth.NewUser into a struct to avoid having to many parameters.
