### PR TITLE
overlord: track security profiles for non-active snaps

### DIFF
--- a/overlord/ifacestate/ifacestate.go
+++ b/overlord/ifacestate/ifacestate.go
@@ -537,7 +537,7 @@ func delayedCrossMgrInit() {
 		snapstate.AddAffectedSnapsByKind("connect", connectDisconnectAffectedSnaps)
 		snapstate.AddAffectedSnapsByKind("disconnect", connectDisconnectAffectedSnaps)
 
-		// hook into snap linking/unling and activation state changes
+		// hook into snap linking/unlinking and activation state changes
 		snapstate.AddLinkSnapParticipant(snapstate.LinkSnapParticipantFunc(OnSnapLinkageChanged))
 	})
 }
@@ -551,7 +551,7 @@ func MockConnectRetryTimeout(d time.Duration) (restore func()) {
 // OnSnapLinkageChanged is used to implement
 // snapstate.LinkSnapParticipant follow activation changes for snaps
 // so that we can track revisions with security profiles on disk for
-// temporarely inactive snaps.
+// temporarily inactive snaps.
 func OnSnapLinkageChanged(st *state.State, instanceName string) error {
 	var snapst snapstate.SnapState
 	if err := snapstate.Get(st, instanceName, &snapst); err != nil && !errors.Is(err, state.ErrNoState) {

--- a/overlord/ifacestate/ifacestate.go
+++ b/overlord/ifacestate/ifacestate.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2017 Canonical Ltd
+ * Copyright (C) 2016-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -22,6 +22,7 @@
 package ifacestate
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -535,6 +536,9 @@ func delayedCrossMgrInit() {
 		// hook into conflict checks mechanisms
 		snapstate.AddAffectedSnapsByKind("connect", connectDisconnectAffectedSnaps)
 		snapstate.AddAffectedSnapsByKind("disconnect", connectDisconnectAffectedSnaps)
+
+		// hook into snap linking/unling and activation state changes
+		snapstate.AddLinkSnapParticipant(snapstate.LinkSnapParticipantFunc(OnSnapLinkageChanged))
 	})
 }
 
@@ -542,4 +546,32 @@ func MockConnectRetryTimeout(d time.Duration) (restore func()) {
 	old := connectRetryTimeout
 	connectRetryTimeout = d
 	return func() { connectRetryTimeout = old }
+}
+
+// OnSnapLinkageChanged is used to implement
+// snapstate.LinkSnapParticipant follow activation changes for snaps
+// so that we can track revisions with security profiles on disk for
+// temporarely inactive snaps.
+func OnSnapLinkageChanged(st *state.State, instanceName string) error {
+	var snapst snapstate.SnapState
+	if err := snapstate.Get(st, instanceName, &snapst); err != nil && !errors.Is(err, state.ErrNoState) {
+		return err
+	}
+	if !snapst.IsInstalled() {
+		// nothing to do
+		return nil
+	}
+
+	if snapst.Active {
+		// nothing to track
+		snapst.PendingSecurity = nil
+	} else {
+		// track the revision that was just unlinked that has
+		// still profiles
+		snapst.PendingSecurity = &snapstate.PendingSecurityState{
+			SideInfo: snapst.CurrentSideInfo(),
+		}
+	}
+	snapstate.Set(st, instanceName, &snapst)
+	return nil
 }

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -2091,6 +2091,7 @@ func (s *interfaceManagerSuite) mockSnapInstance(c *C, instanceName, yamlText st
 	}
 	snapInfo := snaptest.MockSnapInstance(c, instanceName, yamlText, sideInfo)
 	sideInfo.RealName = snapInfo.SnapName()
+	snapInfo.RealName = snapInfo.SnapName()
 
 	a, err := s.Db.FindMany(asserts.SnapDeclarationType, map[string]string{
 		"snap-name": sideInfo.RealName,
@@ -2136,9 +2137,80 @@ func (s *interfaceManagerSuite) mockUpdatedSnap(c *C, yamlText string, revision 
 	return snapInfo
 }
 
-func (s *interfaceManagerSuite) addSetupSnapSecurityChange(snapsup *snapstate.SnapSetup) *state.Change {
+type setupSnapSecurityChangeOptions struct {
+	active  bool
+	install bool
+}
+
+func (s *interfaceManagerSuite) addSetupSnapSecurityChange(c *C, snapsup *snapstate.SnapSetup) *state.Change {
+	// snaps are inactive at the time of setup-profiles
+	return s.addSetupSnapSecurityChangeWithOptions(c, snapsup, setupSnapSecurityChangeOptions{active: false})
+}
+
+func (s *interfaceManagerSuite) addSetupSnapSecurityChangeWithOptions(c *C, snapsup *snapstate.SnapSetup, opts setupSnapSecurityChangeOptions) *state.Change {
 	s.state.Lock()
 	defer s.state.Unlock()
+
+	s.o.TaskRunner().AddHandler("mock-link-snap-n-witness", func(task *state.Task, tomb *tomb.Tomb) error { // do handler
+		s.state.Lock()
+		defer s.state.Unlock()
+		var snapst snapstate.SnapState
+		err := snapstate.Get(s.state, snapsup.InstanceName(), &snapst)
+		if err != nil && !errors.Is(err, state.ErrNoState) {
+			return err
+		}
+		snapst.Active = true
+		if opts.install {
+			c.Check(snapst.IsInstalled(), Equals, false)
+			snapst.Current = snapsup.SideInfo.Revision
+			snapst.Sequence = []*snap.SideInfo{snapsup.SideInfo}
+		} else {
+			c.Check(snapst.PendingSecurity, DeepEquals, &snapstate.PendingSecurityState{
+				SideInfo: snapsup.SideInfo,
+			})
+		}
+		snapstate.Set(s.state, snapsup.InstanceName(), &snapst)
+		c.Check(ifacestate.OnSnapLinkageChanged(s.state, snapsup.InstanceName()), IsNil)
+		return nil
+	}, func(task *state.Task, tomb *tomb.Tomb) error { // undo handler
+		s.state.Lock()
+		defer s.state.Unlock()
+		var snapst snapstate.SnapState
+		err := snapstate.Get(s.state, snapsup.InstanceName(), &snapst)
+		if err != nil && !errors.Is(err, state.ErrNoState) {
+			return err
+		}
+		if opts.install {
+			// unlink completely
+			snapstate.Set(s.state, snapsup.InstanceName(), nil)
+		} else {
+			snapst.Active = false
+			snapstate.Set(s.state, snapsup.InstanceName(), &snapst)
+		}
+		// this is realistic and will move PendingSecurity.SideInfo
+		// on undo already to the previous revision, this should
+		// not be a problem because that is eventually the revision
+		// we want when the snap is activated again
+		c.Check(ifacestate.OnSnapLinkageChanged(s.state, snapsup.InstanceName()), IsNil)
+		if !opts.install {
+			// perturb things to make sure undo-setup-profiles
+			// sets the right value
+			c.Assert(snapstate.Get(s.state, snapsup.InstanceName(), &snapst), IsNil)
+			snapst.PendingSecurity.SideInfo = &snap.SideInfo{}
+			snapstate.Set(s.state, snapsup.InstanceName(), &snapst)
+		}
+		return nil
+	})
+
+	var snapst snapstate.SnapState
+	err := snapstate.Get(s.state, snapsup.InstanceName(), &snapst)
+	if err != nil && !errors.Is(err, state.ErrNoState) {
+		panic(err)
+	}
+	if snapst.IsInstalled() {
+		snapst.Active = opts.active
+		snapstate.Set(s.state, snapsup.InstanceName(), &snapst)
+	}
 
 	change := s.state.NewChange("test", "")
 
@@ -2146,10 +2218,15 @@ func (s *interfaceManagerSuite) addSetupSnapSecurityChange(snapsup *snapstate.Sn
 	task1.Set("snap-setup", snapsup)
 	change.AddTask(task1)
 
-	task2 := s.state.NewTask("auto-connect", "")
+	task2 := s.state.NewTask("mock-link-snap-n-witness", "")
 	task2.Set("snap-setup", snapsup)
 	task2.WaitFor(task1)
 	change.AddTask(task2)
+
+	task3 := s.state.NewTask("auto-connect", "")
+	task3.Set("snap-setup", snapsup)
+	task3.WaitFor(task2)
+	change.AddTask(task3)
 
 	return change
 }
@@ -2401,7 +2478,7 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityHonorsUndesiredFlag(c *C)
 	mgr := s.manager(c)
 
 	// Run the setup-snap-security task and let it finish.
-	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: snapInfo.SnapName(),
 			Revision: snapInfo.Revision,
@@ -2448,7 +2525,7 @@ func (s *interfaceManagerSuite) TestBadInterfacesWarning(c *C) {
 	snapInfo := s.mockSnap(c, sampleSnapYaml)
 
 	// Run the setup-snap-security task and let it finish.
-	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: snapInfo.SnapName(),
 			Revision: snapInfo.Revision,
@@ -2485,7 +2562,7 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityAutoConnectsPlugs(c *C) {
 	snapInfo := s.mockSnap(c, sampleSnapYaml)
 
 	// Run the setup-snap-security task and let it finish.
-	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: snapInfo.SnapName(),
 			Revision: snapInfo.Revision,
@@ -2535,7 +2612,7 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityAutoConnectsSlots(c *C) {
 	snapInfo := s.mockSnap(c, producerYaml)
 
 	// Run the setup-snap-security task and let it finish.
-	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: snapInfo.SnapName(),
 			Revision: snapInfo.Revision,
@@ -2592,7 +2669,7 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityAutoConnectsSlotsMultiple
 	snapInfo := s.mockSnap(c, producerYaml)
 
 	// Run the setup-snap-security task and let it finish.
-	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: snapInfo.SnapName(),
 			Revision: snapInfo.Revision,
@@ -2657,7 +2734,7 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityNoAutoConnectSlotsIfAlter
 	snapInfo := s.mockSnap(c, producerYaml)
 
 	// Run the setup-snap-security task and let it finish.
-	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: snapInfo.SnapName(),
 			Revision: snapInfo.Revision,
@@ -2730,7 +2807,7 @@ slots:
 	snapInfo := s.mockSnap(c, consumerYaml)
 
 	// Run the setup-snap-security task and let it finish.
-	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: snapInfo.SnapName(),
 			SnapID:   snapInfo.SnapID,
@@ -2884,7 +2961,7 @@ slots:
 	snapInfo := s.mockSnap(c, consumerYaml)
 
 	// Run the setup-snap-security task and let it finish.
-	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: snapInfo.SnapName(),
 			SnapID:   snapInfo.SnapID,
@@ -2933,7 +3010,7 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityKeepsExistingConnectionSt
 	s.state.Unlock()
 
 	// Run the setup-snap-security task and let it finish.
-	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: snapInfo.SnapName(),
 			Revision: snapInfo.Revision,
@@ -3366,7 +3443,7 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityIgnoresStrayConnection(c 
 	s.state.Unlock()
 
 	// Run the setup-snap-security task and let it finish.
-	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: snapInfo.SnapName(),
 			Revision: snapInfo.Revision,
@@ -3397,7 +3474,7 @@ func (s *interfaceManagerSuite) TestDoSetupProfilesAddsImplicitSlots(c *C) {
 	snapInfo := s.mockSnap(c, ubuntuCoreSnapYaml)
 
 	// Run the setup-profiles task and let it finish.
-	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: snapInfo.SnapName(),
 			Revision: snapInfo.Revision,
@@ -3466,7 +3543,7 @@ func (s *interfaceManagerSuite) testDoSetupSnapSecurityReloadsConnectionsWhenInv
 	mgr := s.manager(c)
 
 	// Run the setup-profiles task
-	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: snapName,
 			Revision: revision,
@@ -3504,7 +3581,7 @@ func (s *interfaceManagerSuite) TestSetupProfilesHonorsDevMode(c *C) {
 
 	// Run the setup-profiles task and let it finish.
 	// Note that the task will see SnapSetup.Flags equal to DeveloperMode.
-	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: snapInfo.SnapName(),
 			Revision: snapInfo.Revision,
@@ -3539,7 +3616,7 @@ func (s *interfaceManagerSuite) TestSetupProfilesSetupManyError(c *C) {
 	snapInfo := s.mockSnap(c, sampleSnapYaml)
 
 	// Run the setup-profiles task and let it finish.
-	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: snapInfo.SnapName(),
 			Revision: snapInfo.Revision,
@@ -3599,7 +3676,7 @@ func (s *interfaceManagerSuite) TestSetupProfilesUsesFreshSnapInfo(c *C) {
 	c.Assert(newSnapInfo.Revision, Equals, snap.R(42))
 
 	// Run the setup-profiles task for the new revision and let it finish.
-	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: newSnapInfo.SnapName(),
 			Revision: newSnapInfo.Revision,
@@ -3623,6 +3700,42 @@ func (s *interfaceManagerSuite) TestSetupProfilesUsesFreshSnapInfo(c *C) {
 	// The OS snap was setup (because it was affected).
 	c.Check(s.secBackend.SetupCalls[1].SnapInfo.InstanceName(), Equals, coreSnapInfo.InstanceName())
 	c.Check(s.secBackend.SetupCalls[1].SnapInfo.Revision, Equals, coreSnapInfo.Revision)
+}
+
+func (s *interfaceManagerSuite) TestSetupProfilesOnInstall(c *C) {
+	s.MockModel(c, nil)
+
+	installSnapInfo := s.mockSnap(c, sampleSnapYaml)
+	// nothing is in the state yet on install
+	s.state.Lock()
+	snapstate.Set(s.state, "snap", nil)
+	s.state.Unlock()
+
+	// Initialize the manager. This registers both of the snaps and reloads the
+	// connection between them.
+	_ = s.manager(c)
+
+	// Run the setup-profiles task for the new revision and let it finish.
+	change := s.addSetupSnapSecurityChangeWithOptions(c, &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{
+			RealName: installSnapInfo.SnapName(),
+			Revision: installSnapInfo.Revision,
+		},
+	}, setupSnapSecurityChangeOptions{
+		install: true,
+	})
+	s.settle(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// Ensure that the task succeeded.
+	c.Assert(change.Err(), IsNil)
+	c.Check(change.Status(), Equals, state.DoneStatus)
+
+	c.Assert(s.secBackend.SetupCalls, HasLen, 1)
+	c.Check(s.secBackend.SetupCalls[0].SnapInfo.InstanceName(), Equals, installSnapInfo.InstanceName())
+	c.Check(s.secBackend.SetupCalls[0].SnapInfo.Revision, Equals, installSnapInfo.Revision)
 }
 
 func (s *interfaceManagerSuite) TestSetupProfilesKeepsUndesiredConnection(c *C) {
@@ -3668,7 +3781,7 @@ func (s *interfaceManagerSuite) testAutoconnectionsRemovedForMissingPlugs(c *C, 
 	_ = s.manager(c)
 
 	// Run the setup-profiles task for the new revision and let it finish.
-	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: newSnapInfo.SnapName(),
 			Revision: newSnapInfo.Revision,
@@ -3714,7 +3827,7 @@ func (s *interfaceManagerSuite) testAutoconnectionsRemovedForMissingSlots(c *C, 
 	_ = s.manager(c)
 
 	// Run the setup-profiles task for the new revision and let it finish.
-	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: newSnapInfo1.SnapName(),
 			Revision: newSnapInfo1.Revision,
@@ -3749,7 +3862,7 @@ func (s *interfaceManagerSuite) TestAutoConnectSetupSecurityForConnectedSlots(c 
 	snapInfo := s.mockSnap(c, sampleSnapYaml)
 
 	// Run the setup-snap-security task and let it finish.
-	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: snapInfo.SnapName(),
 			Revision: snapInfo.Revision,
@@ -3794,7 +3907,7 @@ func (s *interfaceManagerSuite) TestAutoConnectSetupSecurityOnceWithMultiplePlug
 	snapInfo := s.mockSnap(c, sampleSnapYamlManyPlugs)
 
 	// Run the setup-snap-security task and let it finish.
-	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: snapInfo.SnapName(),
 			Revision: snapInfo.Revision,
@@ -3961,6 +4074,17 @@ slots:
 
 	mgr := s.manager(c)
 
+	func() {
+		s.state.Lock()
+		defer s.state.Unlock()
+		// mock relevant unlink-snap behavior
+		var snapst snapstate.SnapState
+		c.Assert(snapstate.Get(s.state, "consumer", &snapst), IsNil)
+		snapst.Active = false
+		snapstate.Set(s.state, "consumer", &snapst)
+		c.Check(ifacestate.OnSnapLinkageChanged(s.state, "consumer"), IsNil)
+	}()
+
 	// Run the remove-security task
 	change := s.addRemoveSnapSecurityChange("consumer")
 	s.se.Ensure()
@@ -3991,6 +4115,11 @@ slots:
 	c.Check(conns, DeepEquals, map[string]interface{}{
 		"consumer:plug producer:slot": map[string]interface{}{"interface": "test"},
 	})
+
+	// no pending SideInfo
+	var snapst snapstate.SnapState
+	c.Assert(snapstate.Get(s.state, "consumer", &snapst), IsNil)
+	c.Check(snapst.PendingSecurity, DeepEquals, &snapstate.PendingSecurityState{})
 }
 
 func (s *interfaceManagerSuite) TestConnectTracksConnectionsInState(c *C) {
@@ -4568,7 +4697,7 @@ func (s *interfaceManagerSuite) TestSetupProfilesDevModeMultiple(c *C) {
 	_, err = repo.Connect(connRef, nil, nil, nil, nil, nil)
 	c.Assert(err, IsNil)
 
-	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: siC.SnapName(),
 			Revision: siC.Revision,
@@ -4898,25 +5027,23 @@ func (s *interfaceManagerSuite) TestUndoSetupProfilesOnInstall(c *C) {
 	// Create the interface manager
 	_ = s.manager(c)
 
-	// Mock a snap and remove the side info from the state (it is implicitly
-	// added by mockSnap) so that we can emulate a undo during a fresh
-	// install.
 	snapInfo := s.mockSnap(c, sampleSnapYaml)
-	s.state.Lock()
-	snapstate.Set(s.state, snapInfo.InstanceName(), nil)
-	s.state.Unlock()
 
 	// Add a change that undoes "setup-snap-security"
-	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChangeWithOptions(c, &snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: snapInfo.SnapName(),
 			Revision: snapInfo.Revision,
 		},
+	}, setupSnapSecurityChangeOptions{
+		active:  true, // undo case, snap was active after link-snap
+		install: true,
 	})
 	s.state.Lock()
-	c.Assert(change.Tasks(), HasLen, 2)
+	c.Assert(change.Tasks(), HasLen, 3)
 	change.Tasks()[0].SetStatus(state.UndoStatus)
-	change.Tasks()[1].SetStatus(state.UndoneStatus)
+	change.Tasks()[1].SetStatus(state.UndoStatus)
+	change.Tasks()[2].SetStatus(state.UndoneStatus)
 	s.state.Unlock()
 
 	// Turn the crank
@@ -4934,6 +5061,10 @@ func (s *interfaceManagerSuite) TestUndoSetupProfilesOnInstall(c *C) {
 	c.Assert(s.secBackend.SetupCalls, HasLen, 0)
 	c.Assert(s.secBackend.RemoveCalls, HasLen, 1)
 	c.Check(s.secBackend.RemoveCalls, DeepEquals, []string{snapInfo.InstanceName()})
+
+	var snapst snapstate.SnapState
+	err := snapstate.Get(s.state, "snap", &snapst)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 }
 
 // Test that setup-snap-security gets undone correctly when a snap is refreshed
@@ -4947,15 +5078,19 @@ func (s *interfaceManagerSuite) TestUndoSetupProfilesOnRefresh(c *C) {
 	snapInfo := s.mockSnap(c, sampleSnapYaml)
 
 	// Add a change that undoes "setup-snap-security"
-	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChangeWithOptions(c, &snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: snapInfo.SnapName(),
-			Revision: snapInfo.Revision,
+			Revision: snap.R(snapInfo.Revision.N + 1),
 		},
+	}, setupSnapSecurityChangeOptions{
+		active: true, // undo case, snap was active after link-snap
 	})
 	s.state.Lock()
-	c.Assert(change.Tasks(), HasLen, 2)
+	c.Assert(change.Tasks(), HasLen, 3)
+	change.Tasks()[0].SetStatus(state.UndoStatus)
 	change.Tasks()[1].SetStatus(state.UndoStatus)
+	change.Tasks()[2].SetStatus(state.UndoStatus)
 	s.state.Unlock()
 
 	// Turn the crank
@@ -4975,6 +5110,11 @@ func (s *interfaceManagerSuite) TestUndoSetupProfilesOnRefresh(c *C) {
 	c.Check(s.secBackend.SetupCalls[0].SnapInfo.InstanceName(), Equals, snapInfo.InstanceName())
 	c.Check(s.secBackend.SetupCalls[0].SnapInfo.Revision, Equals, snapInfo.Revision)
 	c.Check(s.secBackend.SetupCalls[0].Options, DeepEquals, interfaces.ConfinementOptions{})
+
+	var snapst snapstate.SnapState
+	err := snapstate.Get(s.state, "snap", &snapst)
+	c.Assert(err, IsNil)
+	c.Check(snapst.PendingSecurity.SideInfo.Revision, Equals, snapInfo.Revision)
 }
 
 func (s *interfaceManagerSuite) TestManagerTransitionConnectionsCore(c *C) {
@@ -5141,7 +5281,7 @@ func (s *interfaceManagerSuite) TestAutoConnectDuringCoreTransition(c *C) {
 	snapInfo := s.mockSnap(c, sampleSnapYaml)
 
 	// Run the setup-snap-security task and let it finish.
-	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: snapInfo.SnapName(),
 			Revision: snapInfo.Revision,
@@ -5913,6 +6053,60 @@ func (s *interfaceManagerSuite) TestSnapsWithSecurityProfiles(c *C) {
 		"snap0": snap.R(10),
 		"snap1": snap.R(1),
 		"snap3": snap.R(3),
+	})
+}
+
+func (s *interfaceManagerSuite) TestSnapsWithSecurityProfilesUsesPendingSecuritySideInfo(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	si0 := &snap.SideInfo{
+		RealName: "snap0",
+		Revision: snap.R(10),
+	}
+	snaptest.MockSnap(c, `name: snap0`, si0)
+	snapstate.Set(s.state, "snap0", &snapstate.SnapState{
+		Active:   true,
+		Sequence: []*snap.SideInfo{si0},
+		Current:  si0.Revision,
+	})
+	si1 := &snap.SideInfo{
+		RealName: "snap1",
+		Revision: snap.R(1),
+	}
+	snaptest.MockSnap(c, `name: snap1`, si1)
+	snapstate.Set(s.state, "snap1", &snapstate.SnapState{
+		Active:   false,
+		Sequence: []*snap.SideInfo{si1},
+		Current:  si1.Revision,
+		PendingSecurity: &snapstate.PendingSecurityState{
+			SideInfo: si1,
+		},
+	})
+	si2 := &snap.SideInfo{
+		RealName: "snap2",
+		Revision: snap.R(2),
+	}
+	snaptest.MockSnap(c, `name: snap2`, si2)
+	snapstate.Set(s.state, "snap2", &snapstate.SnapState{
+		Active:   false,
+		Sequence: []*snap.SideInfo{si2},
+		Current:  si2.Revision,
+		PendingSecurity: &snapstate.PendingSecurityState{
+			SideInfo: nil,
+		},
+	})
+
+	infos, err := ifacestate.SnapsWithSecurityProfiles(s.state)
+	c.Assert(err, IsNil)
+	c.Check(infos, HasLen, 2)
+	got := make(map[string]snap.Revision)
+	for _, info := range infos {
+		got[info.InstanceName()] = info.Revision
+	}
+	c.Check(got, DeepEquals, map[string]snap.Revision{
+		"snap0": snap.R(10),
+		"snap1": snap.R(1),
 	})
 }
 
@@ -8211,7 +8405,7 @@ plugs:
 	snapInfo := s.mockSnap(c, themeConsumerYaml)
 
 	// Run the setup-snap-security task and let it finish.
-	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: snapInfo.SnapName(),
 			SnapID:   snapInfo.SnapID,
@@ -8378,7 +8572,7 @@ plugs:
 	snapInfo := s.mockSnap(c, consumerYaml)
 
 	// Run the setup-snap-security task and let it finish.
-	change := s.addSetupSnapSecurityChange(&snapstate.SnapSetup{
+	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: snapInfo.SnapName(),
 			SnapID:   snapInfo.SnapID,
@@ -9057,4 +9251,57 @@ func (s *interfaceManagerSuite) TestConnectionStateActive(c *C) {
 		connState := ifacestate.ConnectionState{Undesired: cs.undesired, HotplugGone: cs.hotplugGone}
 		c.Assert(connState.Active(), Equals, cs.expectedActive, Commentf("#%d: %v", i, cs))
 	}
+}
+
+func (s *interfaceManagerSuite) TestOnSnapLinkageChanged(c *C) {
+	info := s.mockSnapInstance(c, "producer", producerYaml)
+	c.Check(info, NotNil)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	err := ifacestate.OnSnapLinkageChanged(s.state, "not-installed")
+	c.Assert(err, IsNil)
+
+	var snapst snapstate.SnapState
+	err = snapstate.Get(s.state, "producer", &snapst)
+	c.Assert(err, IsNil)
+
+	// same as unlink-snap etc
+	snapst.Active = false
+	snapstate.Set(s.state, "producer", &snapst)
+
+	err = ifacestate.OnSnapLinkageChanged(s.state, "producer")
+	c.Assert(err, IsNil)
+
+	err = snapstate.Get(s.state, "producer", &snapst)
+	c.Assert(err, IsNil)
+
+	c.Check(snapst, DeepEquals, snapstate.SnapState{
+		SnapType: "app",
+		Active:   false,
+		Current:  snap.R(1),
+		Sequence: []*snap.SideInfo{&info.SideInfo},
+		PendingSecurity: &snapstate.PendingSecurityState{
+			SideInfo: &info.SideInfo,
+		},
+	})
+
+	// same as link-snap etc
+	snapst.Active = true
+	snapstate.Set(s.state, "producer", &snapst)
+
+	err = ifacestate.OnSnapLinkageChanged(s.state, "producer")
+	c.Assert(err, IsNil)
+
+	var snapst1 snapstate.SnapState
+	err = snapstate.Get(s.state, "producer", &snapst1)
+	c.Assert(err, IsNil)
+
+	c.Check(snapst1, DeepEquals, snapstate.SnapState{
+		SnapType: "app",
+		Active:   true,
+		Current:  snap.R(1),
+		Sequence: []*snap.SideInfo{&info.SideInfo},
+	})
 }

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2021 Canonical Ltd
+ * Copyright (C) 2016-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -1571,6 +1571,13 @@ type LinkSnapParticipant interface {
 	// SnapLinkageChanged is called when a snap is linked or unlinked.
 	// The error is only logged and does not stop the task it is used from.
 	SnapLinkageChanged(st *state.State, instanceName string) error
+}
+
+// LinkSnapParticipantFunc is an adapter from function to LinkSnapParticipant.
+type LinkSnapParticipantFunc func(st *state.State, instanceName string) error
+
+func (f LinkSnapParticipantFunc) SnapLinkageChanged(st *state.State, instanceName string) error {
+	return f(st, instanceName)
 }
 
 var linkSnapParticipants []LinkSnapParticipant

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -234,6 +234,19 @@ type SnapState struct {
 	// MigratedToExposedHome is set if ~/Snap was created and initialized. If set, ~/Snap
 	// should be used as the snap's HOME.
 	MigratedToExposedHome bool `json:"migrated-exposed-home,omitempty"`
+
+	// PendingSecurity tracks information about snaps that have
+	// their security profiles set up but are not active.
+	// It is managed by ifacestate.
+	PendingSecurity *PendingSecurityState `json:"pending-security,omitempty"`
+}
+
+// PendingSecurityState holds information about snaps that have
+// their security profiles set up but are not active.
+type PendingSecurityState struct {
+	// SideInfo of the revision for which security profiles are or
+	// should be set up if any.
+	SideInfo *snap.SideInfo `json:"side-info,omitempty"`
 }
 
 func (snapst *SnapState) SetTrackingChannel(s string) error {

--- a/tests/nested/core/connected-after-reboot-revert/task.yaml
+++ b/tests/nested/core/connected-after-reboot-revert/task.yaml
@@ -1,0 +1,82 @@
+summary: Check that a after a revert of a boot snap connections are restored
+
+details: |
+  This test checks that after a revert that involved a boot snap (so we had
+  two reboots, one for installing and one for reverting) in a transactional
+  update, we still have connections to the base snap. It has been detected
+  that this happens if one of the updated snaps is snapd.
+
+systems: [ubuntu-16.04-64, ubuntu-18.04-64, ubuntu-20.04-64, ubuntu-22.04-64]
+
+execute: |
+  echo "Build kernel with failing post-refresh hook"
+  VERSION="$(tests.nested show version)"
+  CHANNEL=$VERSION
+  if [ "$VERSION" -eq 16 ]; then
+      CHANNEL=latest
+  fi
+  rm -rf pc-kernel
+  snap download --basename=pc-kernel --channel="$CHANNEL/edge" pc-kernel
+  unsquashfs -d pc-kernel pc-kernel.snap
+  HOOKS_D=pc-kernel/meta/hooks/
+  POST_REFRESH_P=$HOOKS_D/post-refresh
+  mkdir -p "$HOOKS_D"
+  cat > "$POST_REFRESH_P" << EOF
+  \#!/bin/bash -ex
+  exit 1
+  EOF
+  chmod +x "$POST_REFRESH_P"
+  snap pack pc-kernel/ --filename=pc-kernel_badhook.snap
+
+  echo "Wait for the system to be seeded first"
+  tests.nested exec "sudo snap wait system seed.loaded"
+
+  boot_id="$(tests.nested boot-id)"
+
+  echo "Install kernel with failing post-refresh hook"
+  tests.nested copy pc-kernel_badhook.snap
+
+  # install bluez
+  BLUEZ_CHANNEL=$VERSION
+  if [ "$VERSION" -eq 16 ] || [ "$VERSION" -eq 18 ]; then
+      BLUEZ_CHANNEL=latest
+  fi
+  echo "Install bluez snap and make sure connections to the base are performed"
+  tests.nested exec "sudo snap install --channel=\"$BLUEZ_CHANNEL\" bluez"
+  tests.nested exec "snap connections bluez" | MATCH 'uhid  *bluez:uhid  *:uhid'
+
+  chg_id=$(tests.nested exec 'sudo snap install \
+                              --dangerous --transaction=all-snaps --no-wait \
+                              ./pc-kernel_badhook.snap /var/lib/snapd/snaps/snapd_*.snap')
+
+  echo "Wait for reboot"
+  tests.nested wait-for reboot "$boot_id"
+
+  boot_id="$(tests.nested boot-id)"
+  echo "Wait for second reboot after post-refresh hook failure"
+  tests.nested wait-for reboot "$boot_id"
+
+  boot_id="$(tests.nested boot-id)"
+  # wait for change to finish with error
+  not tests.nested exec sudo snap watch "$chg_id"
+  # make sure that no additional reboots have happened while the change finished
+  test "$boot_id" = "$(tests.nested boot-id)"
+
+  echo "Check that connections to the base are kept"
+  tests.nested exec "snap connections bluez" | MATCH 'uhid  *bluez:uhid  *:uhid'
+
+  echo "Check that change finished with failure and that the old snap is being used"
+  tests.nested exec "snap info pc-kernel | MATCH 'installed:.*\(x1\)'"
+  tests.nested exec "snap changes | MATCH \"^$chg_id.*Error\""
+  if [ "$VERSION" -ge 20 ]; then
+      # shellcheck disable=SC2016
+      tests.nested exec 'test $(readlink /run/mnt/ubuntu-boot/EFI/ubuntu/kernel.efi) = pc-kernel_x1.snap/kernel.efi'
+      tests.nested exec 'cat /run/mnt/ubuntu-boot/EFI/ubuntu/grubenv | MATCH "^kernel_status=$"'
+      echo "Check that modeenv has only the old kernel"
+      tests.nested exec 'cat /var/lib/snapd/modeenv | MATCH "^current_kernels=pc-kernel_x1.snap$"'
+  else
+      tests.nested exec 'cat /boot/grub/grubenv | MATCH "^snap_kernel=pc-kernel_x1.snap$"'
+      tests.nested exec 'cat /boot/grub/grubenv | MATCH "^snap_mode=$"'
+      tests.nested exec 'cat /boot/grub/grubenv | MATCH "^snap_try_kernel=$"'
+      tests.nested exec 'cat /proc/cmdline | MATCH snap_kernel=pc-kernel_x1.snap'
+  fi

--- a/tests/nested/core/connected-after-reboot-revert/task.yaml
+++ b/tests/nested/core/connected-after-reboot-revert/task.yaml
@@ -6,7 +6,8 @@ details: |
   update, we still have connections to the base snap. It has been detected
   that this happens if one of the updated snaps is snapd.
 
-systems: [ubuntu-16.04-64, ubuntu-18.04-64, ubuntu-20.04-64, ubuntu-22.04-64]
+# TODO: UC16/ubuntu-16.04-64 needs a different approach as it still uses core
+systems: [ubuntu-18.04-64, ubuntu-20.04-64, ubuntu-22.04-64]
 
 execute: |
   echo "Build kernel with failing post-refresh hook"

--- a/tests/nested/core/connected-after-reboot-revert/task.yaml
+++ b/tests/nested/core/connected-after-reboot-revert/task.yaml
@@ -46,9 +46,7 @@ execute: |
   tests.nested exec "sudo snap install --channel=\"$BLUEZ_CHANNEL\" bluez"
   tests.nested exec "snap connections bluez" | MATCH 'uhid  *bluez:uhid  *:uhid'
 
-  chg_id=$(tests.nested exec 'sudo snap install \
-                              --dangerous --transaction=all-snaps --no-wait \
-                              ./pc-kernel_badhook.snap /var/lib/snapd/snaps/snapd_*.snap')
+  chg_id=$(tests.nested exec 'sudo snap install --dangerous --transaction=all-snaps --no-wait ./pc-kernel_badhook.snap /var/lib/snapd/snaps/snapd_*.snap')
 
   echo "Wait for reboot"
   tests.nested wait-for reboot "$boot_id"


### PR DESCRIPTION
use this new tracking information in snapsWithSecurityProfiles

the main reason to do this is to avoid code using the result of
snapsWithSecurityProfiles to end up considering snaps being refreshed,
in particular when the refresh is being undone, to be gone and remove
connections to them

the tracking code tries to be simple and is based on the relatively
recent SnapLinkParticipant mechanism:
* we track also in situations where the snap will go away soon
* in undo situations we track the revision that ultimately we undo to
  even if on disk there are still the new profiles, this is correct
  anyway as the snap is inactive and that's the final state either way
the tracking is irrelevant and cleared when the snap becomes active again

to cover the new logic I had to increase the realism of some tests in
ifacestate