### PR TITLE
tests: remove NESTED_IMAGE_ID from nested manual tests

### DIFF
--- a/tests/nested/manual/cloud-init-never-used-not-vuln/task.yaml
+++ b/tests/nested/manual/cloud-init-never-used-not-vuln/task.yaml
@@ -10,7 +10,6 @@ environment:
     NESTED_BUILD_SNAPD_FROM_CURRENT/refresh: false
     NESTED_BUILD_SNAPD_FROM_CURRENT/firstboot: true
     NESTED_USE_CLOUD_INIT: false
-    NESTED_IMAGE_ID: cloud-init-never-$NESTED_BUILD_SNAPD_FROM_CURRENT
 
     # this test is only running on nested systems, so only amd64 for now
     SNAPD_2_45_SNAPD_SNAP: https://storage.googleapis.com/snapd-spread-tests/snaps/snapd_2.45_7777.snap

--- a/tests/nested/manual/cloud-init-nocloud-not-vuln/task.yaml
+++ b/tests/nested/manual/cloud-init-nocloud-not-vuln/task.yaml
@@ -14,7 +14,6 @@ environment:
     NESTED_BUILD_SNAPD_FROM_CURRENT/refresh: false
     # this variant ensures that new images with the fix are not vulnerable
     NESTED_BUILD_SNAPD_FROM_CURRENT/firstboot: true
-    NESTED_IMAGE_ID: cloud-init-nocloud-$NESTED_BUILD_SNAPD_FROM_CURRENT
 
     # this test is only running on nested systems, so only amd64 for now
     SNAPD_2_45_SNAPD_SNAP: https://storage.googleapis.com/snapd-spread-tests/snaps/snapd_2.45_7777.snap

--- a/tests/nested/manual/core-early-config/task.yaml
+++ b/tests/nested/manual/core-early-config/task.yaml
@@ -3,9 +3,6 @@ summary: Test that config defaults are applied early when image is created.
 # core18 specific test (and nested vm is derived from host system)
 systems: [ubuntu-18.04-64]
 
-environment:
-    NESTED_IMAGE_ID: core-early-config
-
 prepare: |
     # modify and repack gadget snap (add defaults section and install hook)
     snap download --channel=18/stable pc

--- a/tests/nested/manual/core-seeding-devmode/task.yaml
+++ b/tests/nested/manual/core-seeding-devmode/task.yaml
@@ -3,9 +3,6 @@ summary: Test that devmode snaps can be installed during seeding.
 # testing with core16 (no snapd snap) and core18 (with snapd snap) is enough
 systems: [ubuntu-16.04-64, ubuntu-18.04-64]
 
-environment:
-    NESTED_IMAGE_ID: core-seeding-devmode
-
 prepare: |
     # seed a devmode snap
     snap download --beta godd

--- a/tests/nested/manual/core20-4k-sector-size/task.yaml
+++ b/tests/nested/manual/core20-4k-sector-size/task.yaml
@@ -3,7 +3,6 @@ summary: verify a simple UC2* scenario with 4k sector size
 systems: [ubuntu-20.04-64, ubuntu-22.04-64]
 
 environment:
-  NESTED_IMAGE_ID: core20-4k-sector-size
   NESTED_ENABLE_TPM: true
   NESTED_ENABLE_SECURE_BOOT: true
   NESTED_BUILD_SNAPD_FROM_CURRENT: true

--- a/tests/nested/manual/core20-boot-config-update/task.yaml
+++ b/tests/nested/manual/core20-boot-config-update/task.yaml
@@ -4,11 +4,8 @@ systems: [ubuntu-20.04-64, ubuntu-22.04-64]
 
 environment:
   VARIANT/nogadget: "no-gadget"
-  NESTED_IMAGE_ID/nogadget: core20-kernel-commandline-bootconfig-no-gadget
   VARIANT/gadgetextra: "gadget-extra"
-  NESTED_IMAGE_ID/gadgetextra: core20-kernel-commandline-bootconfig-gadget-extra
   VARIANT/gadgetfull: "gadget-full"
-  NESTED_IMAGE_ID/gadgetfull: core20-kernel-commandline-bootconfig-gadget-full
 
   NESTED_BUILD_SNAPD_FROM_CURRENT: true
   NESTED_ENABLE_TPM: true

--- a/tests/nested/manual/core20-cloud-init-maas-signed-seed-data/task.yaml
+++ b/tests/nested/manual/core20-cloud-init-maas-signed-seed-data/task.yaml
@@ -33,7 +33,6 @@ environment:
   NESTED_CUSTOM_AUTO_IMPORT_ASSERTION: $TESTSLIB/assertions/developer1-{VERSION}-auto-import.assert
 
   NESTED_CUSTOM_MODEL: $TESTSLIB/assertions/developer1-{VERSION}-signed.model
-  NESTED_IMAGE_ID: grade-signed-cloud-init-maas-$GADGET_DATASOURCE
 
   # for the fake store
   NESTED_FAKESTORE_BLOB_DIR: $(pwd)/fake-store-blobdir

--- a/tests/nested/manual/core20-custom-kernel-commandline/task.yaml
+++ b/tests/nested/manual/core20-custom-kernel-commandline/task.yaml
@@ -6,7 +6,6 @@ details: |
 systems: [ubuntu-20.04-64, ubuntu-22.04-64]
 
 environment:
-    NESTED_IMAGE_ID: core20-kernel-commandline
     NESTED_BUILD_SNAPD_FROM_CURRENT: true
     NESTED_ENABLE_TPM: true
     NESTED_ENABLE_SECURE_BOOT: true

--- a/tests/nested/manual/core20-early-config/task.yaml
+++ b/tests/nested/manual/core20-early-config/task.yaml
@@ -3,7 +3,6 @@ summary: Test that gadget config defaults are applied early on core20.
 systems: [ubuntu-20.04-64, ubuntu-22.04-64]
 
 environment:
-    NESTED_IMAGE_ID: core20-early-config
     NESTED_ENABLE_TPM: true
     NESTED_ENABLE_SECURE_BOOT: true
     NESTED_BUILD_SNAPD_FROM_CURRENT: true

--- a/tests/nested/manual/core20-gadget-cloud-conf/task.yaml
+++ b/tests/nested/manual/core20-gadget-cloud-conf/task.yaml
@@ -30,9 +30,7 @@ environment:
 
   # TODO: enable after creating an associated auto-import assertion + model
   # MODEL_GRADE/dangerous: dangerous
-
   NESTED_CUSTOM_MODEL: $TESTSLIB/assertions/developer1-{VERSION}-${MODEL_GRADE}.model
-  NESTED_IMAGE_ID: gadget-cloud-conf-testkeys-${MODEL_GRADE}
 
   # for the fake store
   NESTED_FAKESTORE_BLOB_DIR: $(pwd)/fake-store-blobdir

--- a/tests/nested/manual/core20-grade-signed-above-testkeys-boot/task.yaml
+++ b/tests/nested/manual/core20-grade-signed-above-testkeys-boot/task.yaml
@@ -28,7 +28,6 @@ environment:
   MODEL_GRADE/signed: signed
 
   NESTED_CUSTOM_MODEL: $TESTSLIB/assertions/developer1-{VERSION}-${MODEL_GRADE}.model
-  NESTED_IMAGE_ID: testkeys-${MODEL_GRADE}
 
   # for the fake store
   NESTED_FAKESTORE_BLOB_DIR: $(pwd)/fake-store-blobdir

--- a/tests/nested/manual/core20-grade-signed-cloud-init-testkeys/task.yaml
+++ b/tests/nested/manual/core20-grade-signed-cloud-init-testkeys/task.yaml
@@ -22,9 +22,7 @@ environment:
   # use the testrootorg auto-import assertion
   # TODO: commit the Go code used to create this assertion from the json file
   NESTED_CUSTOM_AUTO_IMPORT_ASSERTION: $TESTSLIB/assertions/developer1-{VERSION}-auto-import.assert
-
   NESTED_CUSTOM_MODEL: $TESTSLIB/assertions/developer1-{VERSION}-signed.model
-  NESTED_IMAGE_ID: cloud-init-signed-testkeys
 
   # for the fake store
   NESTED_FAKESTORE_BLOB_DIR: $(pwd)/fake-store-blobdir

--- a/tests/nested/manual/core20-initramfs-time-moves-forward/task.yaml
+++ b/tests/nested/manual/core20-initramfs-time-moves-forward/task.yaml
@@ -3,7 +3,6 @@ summary: Test that time moves forward when the RTC is broken/unavailable in UC20
 systems: [ubuntu-20.04-64, ubuntu-22.04-64]
 
 environment:
-  NESTED_IMAGE_ID: core20-initramfs-time-moves-forward
   NESTED_BUILD_SNAPD_FROM_CURRENT: true
   NESTED_USE_CLOUD_INIT: true
 

--- a/tests/nested/manual/core20-install-device-file-install-via-hook-hack/task.yaml
+++ b/tests/nested/manual/core20-install-device-file-install-via-hook-hack/task.yaml
@@ -9,8 +9,6 @@ details: |
 systems: [ubuntu-20.04-64, ubuntu-22.04-64]
 
 environment:
-    NESTED_IMAGE_ID: core20-install-device-system-files-hack
-
     # use snapd from the spread run so that we have testkeys trusted in the
     # snapd run
     NESTED_BUILD_SNAPD_FROM_CURRENT: true

--- a/tests/nested/manual/core20-install-mode-shutdown-via-hook/task.yaml
+++ b/tests/nested/manual/core20-install-mode-shutdown-via-hook/task.yaml
@@ -7,7 +7,6 @@ details: |
 systems: [ubuntu-20.04-64, ubuntu-22.04-64]
 
 environment:
-    NESTED_IMAGE_ID: core20-install-device
     NESTED_BUILD_SNAPD_FROM_CURRENT: true
     NESTED_ENABLE_TPM: true
     NESTED_ENABLE_SECURE_BOOT: true

--- a/tests/nested/manual/core20-new-snapd-does-not-break-old-initrd/task.yaml
+++ b/tests/nested/manual/core20-new-snapd-does-not-break-old-initrd/task.yaml
@@ -29,8 +29,6 @@ environment:
   START_SNAPD_VERSION/startwithnew: new
   START_SNAPD_VERSION/startwithold: old
 
-  NESTED_IMAGE_ID: uc20-breakages-testing-$START_SNAPD_VERSION
-
   # all variants need encryption turned on
   NESTED_ENABLE_TPM: true
   NESTED_ENABLE_SECURE_BOOT: true

--- a/tests/nested/manual/core20-preseed/task.yaml
+++ b/tests/nested/manual/core20-preseed/task.yaml
@@ -8,7 +8,6 @@ systems: [ubuntu-20.04-64]
 
 environment:
   NESTED_UBUNTU_IMAGE_PRESEED_KEY: "\" (test)\""
-  NESTED_IMAGE_ID: core20-preseeding
   NESTED_ENABLE_TPM: false
   NESTED_ENABLE_SECURE_BOOT: true
   NESTED_BUILD_SNAPD_FROM_CURRENT: true

--- a/tests/nested/manual/core20-remodel/task.yaml
+++ b/tests/nested/manual/core20-remodel/task.yaml
@@ -4,7 +4,6 @@ systems: [ubuntu-20.04-64, ubuntu-22.04-64]
 
 environment:
   NESTED_CUSTOM_MODEL: $TESTSLIB/assertions/valid-for-testing-pc-{VERSION}.model
-  NESTED_IMAGE_ID: uc20-remodel
   NESTED_ENABLE_TPM: true
   NESTED_ENABLE_SECURE_BOOT: true
   NESTED_BUILD_SNAPD_FROM_CURRENT: true

--- a/tests/nested/manual/core20-save/task.yaml
+++ b/tests/nested/manual/core20-save/task.yaml
@@ -12,19 +12,16 @@ environment:
   NESTED_ENABLE_TPM/encrypted: "true"
   NESTED_ENABLE_SECURE_BOOT/encrypted: "true"
   NESTED_UBUNTU_SAVE/encrypted: "add"
-  NESTED_IMAGE_ID/encrypted: core20-encrypted
 
   # add ubuntu-save, but but no TPM or secure boot support
   NESTED_ENABLE_TPM/plainwithsave: "false"
   NESTED_ENABLE_SECURE_BOOT/plainwithsave: "false"
   NESTED_UBUNTU_SAVE/plainwithsave: "add"
-  NESTED_IMAGE_ID/plainwithsave: core20-plain-with-ubuntu-save
 
   # no ubuntu-save, no TPM, no secure boot
   NESTED_ENABLE_TPM/plain: "false"
   NESTED_ENABLE_SECURE_BOOT/plain: "false"
   NESTED_UBUNTU_SAVE/plain: "remove"
-  NESTED_IMAGE_ID/plain: core20-plain-no-ubuntu-save
 
 prepare: |
     # NESTED_ENABLE_TPM and NESTED_UBUNTU_SAVE are used by build-image

--- a/tests/nested/manual/core20-to-core22/task.yaml
+++ b/tests/nested/manual/core20-to-core22/task.yaml
@@ -11,7 +11,6 @@ manual: true
 
 environment:
   NESTED_CUSTOM_MODEL: $TESTSLIB/assertions/valid-for-testing-pc-{VERSION}.model
-  NESTED_IMAGE_ID: uc22-remodel-testing
   # TODO: disable TPM for now and investigate why the system cannot be booted
   # after remodel completes
   NESTED_ENABLE_TPM: false

--- a/tests/nested/manual/devmode-snap-seeded-dangerous/task.yaml
+++ b/tests/nested/manual/devmode-snap-seeded-dangerous/task.yaml
@@ -4,7 +4,6 @@ summary: Check that devmode snaps can be seeded with a dangerous uc20 model
 systems: [ubuntu-20.04-64, ubuntu-22.04-64]
 
 environment:
-  NESTED_IMAGE_ID: core20-devmode-seeding
   NESTED_BUILD_SNAPD_FROM_CURRENT: true
 
 prepare: |

--- a/tests/nested/manual/gadget-connections/task.yaml
+++ b/tests/nested/manual/gadget-connections/task.yaml
@@ -8,7 +8,6 @@ environment:
   NESTED_UBUNTU_IMAGE_SNAPPY_FORCE_SAS_URL: http://localhost:11028
   NESTED_CUSTOM_AUTO_IMPORT_ASSERTION: $TESTSLIB/assertions/developer1-auto-import.assert
   NESTED_CUSTOM_MODEL: $TESTSLIB/assertions/nested-20-amd64-connections.model
-  NESTED_IMAGE_ID: gadget-connections
   NESTED_ENABLE_TPM: false
   NESTED_ENABLE_SECURE_BOOT: false
 

--- a/tests/nested/manual/remodel-cross-store/task.yaml
+++ b/tests/nested/manual/remodel-cross-store/task.yaml
@@ -11,7 +11,6 @@ systems: [ubuntu-18.04-64, ubuntu-20.04-64]
 
 environment:
     NESTED_CUSTOM_AUTO_IMPORT_ASSERTION: $TESTSLIB/assertions/test-snapd-remodel-auto-import.assert
-    NESTED_IMAGE_ID: remodel-cross-store
     NESTED_ENABLE_TPM: false
     NESTED_ENABLE_SECURE_BOOT: false
     NESTED_USE_CLOUD_INIT: false

--- a/tests/nested/manual/remodel-simple/task.yaml
+++ b/tests/nested/manual/remodel-simple/task.yaml
@@ -8,7 +8,6 @@ systems: [ubuntu-18.04-64, ubuntu-20.04-64]
 
 environment:
     NESTED_CUSTOM_AUTO_IMPORT_ASSERTION: $TESTSLIB/assertions/test-snapd-remodel-auto-import.assert
-    NESTED_IMAGE_ID: remodel-simple
     NESTED_ENABLE_TPM: false
     NESTED_ENABLE_SECURE_BOOT: false
     NESTED_USE_CLOUD_INIT: false

--- a/tests/nested/manual/snapd-refresh-from-old/task.yaml
+++ b/tests/nested/manual/snapd-refresh-from-old/task.yaml
@@ -12,7 +12,6 @@ environment:
   VARIANT/latest_only: latest_only
   VARIANT/edge_first: edge_first
   NESTED_BUILD_SNAPD_FROM_CURRENT: false
-  NESTED_IMAGE_ID: snapd-refresh-from-old
   SNAPD_SNAP_URL: https://storage.googleapis.com/snapd-spread-tests/snaps/snapd_2.45.2_5760.snap
   CORE18_SNAP_URL: https://storage.googleapis.com/snapd-spread-tests/snaps/core18_20191126_1279.snap
 

--- a/tests/nested/manual/snapd-removes-vulnerable-snap-confine-revs/task.yaml
+++ b/tests/nested/manual/snapd-removes-vulnerable-snap-confine-revs/task.yaml
@@ -9,9 +9,6 @@ environment:
   SNAPD_SOURCE_SNAP/snapd: snapd
   SNAPD_SOURCE_SNAP/core: core
 
-  # needed to get a custom image
-  NESTED_IMAGE_ID: vuln-$SNAPD_SOURCE_SNAP-auto-removed
-
   # where we mount the image
   IMAGE_MOUNTPOINT: /mnt/cloudimg
 

--- a/tests/nested/manual/uc20-fde-hooks-v1/task.yaml
+++ b/tests/nested/manual/uc20-fde-hooks-v1/task.yaml
@@ -4,7 +4,6 @@ summary: Check that the deprecated v1 fde-setup hooks keep working
 systems: [ubuntu-20.04-64, ubuntu-22.04-64]
 
 environment:
-    NESTED_IMAGE_ID: core20-fde-setup
     NESTED_ENABLE_TPM: false
     NESTED_ENABLE_SECURE_BOOT: false
     NESTED_BUILD_SNAPD_FROM_CURRENT: true

--- a/tests/nested/manual/uc20-fde-hooks/task.yaml
+++ b/tests/nested/manual/uc20-fde-hooks/task.yaml
@@ -4,7 +4,6 @@ summary: Check that the fde-setup hooks work
 systems: [ubuntu-20.04-64, ubuntu-22.04-64]
 
 environment:
-    NESTED_IMAGE_ID: core20-fde-setup
     NESTED_ENABLE_TPM: false
     NESTED_ENABLE_SECURE_BOOT: false
     NESTED_BUILD_SNAPD_FROM_CURRENT: true

--- a/tests/nested/manual/uc20-storage-safety/task.yaml
+++ b/tests/nested/manual/uc20-storage-safety/task.yaml
@@ -10,7 +10,6 @@ environment:
 
     MODEL_STORAGE_SAFETY/preferunencrypted: prefer-unencrypted
     NESTED_CUSTOM_MODEL: $TESTSLIB/assertions/developer1-{VERSION}-storage-safety-${MODEL_STORAGE_SAFETY}.model
-    NESTED_IMAGE_ID: core20-storage-safety-${MODEL_STORAGE_SAFETY}
     NESTED_UBUNTU_IMAGE_SNAPPY_FORCE_SAS_URL: http://localhost:11028
     NESTED_FAKESTORE_BLOB_DIR: $(pwd)/fake-store-blobdir
 


### PR DESCRIPTION
As now the image name is calculated automatically based on the test name
and variant for manual nested tests, it is not required anymore to setup
that in the test environment.

This was causing problems in some tests, i.e. the core20-4k-sector-size
test was setting just 1 NESTED_IMAGE_ID but it had 2 variants, so when
both variants were executed in the same host, both variants were using
the same image and the second execution was failing because of that.
