### PR TITLE
tests: fix debug section for test uc20-create-partitions

### DIFF
--- a/tests/main/uc20-create-partitions/task.yaml
+++ b/tests/main/uc20-create-partitions/task.yaml
@@ -65,13 +65,15 @@ restore: |
 
 debug: |
     cat /proc/partitions
-    LOOP="$(cat loop.txt)"
-    udevadm info --query property "${LOOP}" || true
-    udevadm info --query property "${LOOP}p1" || true
-    udevadm info --query property "${LOOP}p2" || true
-    udevadm info --query property "${LOOP}p3" || true
-    udevadm info --query property "${LOOP}p4" || true
-    udevadm info --query property "${LOOP}p5" || true
+    if [ -f loop.txt ]; then
+        LOOP="$(cat loop.txt)"
+        udevadm info --query property "${LOOP}" || true
+        udevadm info --query property "${LOOP}p1" || true
+        udevadm info --query property "${LOOP}p2" || true
+        udevadm info --query property "${LOOP}p3" || true
+        udevadm info --query property "${LOOP}p4" || true
+        udevadm info --query property "${LOOP}p5" || true
+    fi
 
 execute: |
     channel=20


### PR DESCRIPTION
The debug section breaks when the loop.txt file doesn't exist.

