### PR TITLE
many: Set SNAPD_APPARMOR_REEXEC=1

### DIFF
--- a/mkversion.sh
+++ b/mkversion.sh
@@ -141,6 +141,6 @@ fmts=$(cd "$GO_GENERATE_BUILDDIR" ; go run $MOD ./asserts/info)
 
 cat <<EOF > "$PKG_BUILDDIR/data/info"
 VERSION=$v
-SNAPD_APPARMOR_REEXEC=0
+SNAPD_APPARMOR_REEXEC=1
 ${fmts}
 EOF

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -1386,7 +1386,7 @@ version: 1.0
 	snapdSnapFiles := [][]string{
 		{"usr/lib/snapd/info", `
 VERSION=2.54.3+git1.g479e745-dirty
-SNAPD_APPARMOR_REEXEC=0
+SNAPD_APPARMOR_REEXEC=1
 `},
 	}
 	snapdFname, snapdDecl, snapdRev := s.MakeAssertedSnap(c, snapdYaml, snapdSnapFiles, snap.R(2), "canonical")

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -453,7 +453,7 @@ func (s *baseMgrsSuite) SetUpTest(c *C) {
 	// commonly used core and snapd revisions in tests
 	defaultInfoFile := `
 VERSION=2.54.3+git1.g479e745-dirty
-SNAPD_APPARMOR_REEXEC=0
+SNAPD_APPARMOR_REEXEC=1
 `
 	for _, snapName := range []string{"snapd", "core"} {
 		for _, rev := range []string{"1", "11", "30"} {

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -270,7 +270,7 @@ func (s *snapmgrBaseTest) SetUpTest(c *C) {
 	// commonly used revisions in tests
 	defaultInfoFile := `
 VERSION=2.54.3+git1.g479e745-dirty
-SNAPD_APPARMOR_REEXEC=0
+SNAPD_APPARMOR_REEXEC=1
 `
 	for _, snapName := range []string{"snapd", "core"} {
 		for _, rev := range []string{"1", "11"} {
@@ -3463,11 +3463,11 @@ func (s *snapmgrTestSuite) testEnsureRemovesVulnerableSnap(c *C, snapName string
 	// vulnerable
 	fixedInfoFile := `
 VERSION=2.54.3+git1.g479e745-dirty
-SNAPD_APPARMOR_REEXEC=0
+SNAPD_APPARMOR_REEXEC=1
 `
 	vulnInfoFile := `
 VERSION=2.54.2+git1.g479e745-dirty
-SNAPD_APPARMOR_REEXEC=0
+SNAPD_APPARMOR_REEXEC=1
 `
 
 	// revision 1 vulnerable


### PR DESCRIPTION
Re-exec support for snapd-apparmor was implemented in #11129.

Signed-off-by: Alex Murray <alex.murray@canonical.com>