### PR TITLE
overlord: frontend for --quota-group support (2/2)

### DIFF
--- a/client/snap_op.go
+++ b/client/snap_op.go
@@ -57,6 +57,7 @@ type SnapOptions struct {
 	Purge            bool            `json:"purge,omitempty"`
 	Amend            bool            `json:"amend,omitempty"`
 	Transaction      TransactionType `json:"transaction,omitempty"`
+	QuotaGroupName   string          `json:"quota-group,omitempty"`
 
 	Users []string `json:"users,omitempty"`
 }
@@ -100,6 +101,11 @@ func (opts *SnapOptions) writeOptionFields(mw *multipart.Writer) error {
 	}
 	if opts.Transaction != "" {
 		if err := mw.WriteField("transaction", string(opts.Transaction)); err != nil {
+			return err
+		}
+	}
+	if opts.QuotaGroupName != "" {
+		if err := mw.WriteField("quota-group", opts.QuotaGroupName); err != nil {
 			return err
 		}
 	}

--- a/client/snap_op_test.go
+++ b/client/snap_op_test.go
@@ -33,6 +33,7 @@ import (
 	"gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/client"
+	"github.com/snapcore/snapd/testutil"
 )
 
 var chanName = "achan"
@@ -293,12 +294,12 @@ func (cs *clientSuite) TestClientOpInstallPath(c *check.C) {
 	body, err := ioutil.ReadAll(cs.req.Body)
 	c.Assert(err, check.IsNil)
 
-	c.Assert(string(body), check.Matches, "(?s).*\r\nsnap-data\r\n.*")
-	c.Assert(string(body), check.Matches, "(?s).*Content-Disposition: form-data; name=\"action\"\r\n\r\ninstall\r\n.*")
+	c.Assert(string(body), testutil.Contains, "\r\nsnap-data\r\n")
+	c.Assert(string(body), testutil.Contains, "Content-Disposition: form-data; name=\"action\"\r\n\r\ninstall\r\n")
 
 	c.Check(cs.req.Method, check.Equals, "POST")
 	c.Check(cs.req.URL.Path, check.Equals, "/v2/snaps")
-	c.Assert(cs.req.Header.Get("Content-Type"), check.Matches, "multipart/form-data; boundary=.*")
+	c.Assert(cs.req.Header.Get("Content-Type"), testutil.Contains, "multipart/form-data; boundary=")
 	_, ok := cs.req.Context().Deadline()
 	c.Assert(ok, check.Equals, false)
 	c.Check(id, check.Equals, "66b3")

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -1159,6 +1159,8 @@ func init() {
 			"ignore-running": i18n.G("Ignore running hooks or applications blocking the installation"),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"transaction": i18n.G("Have one transaction per-snap or one for all the specified snaps"),
+			// TRANSLATORS: This should not start with a lowercase letter.
+			"quota-group": i18n.G("Add the snap to a quota group on install"),
 		}), nil)
 	addCommand("refresh", shortRefreshHelp, longRefreshHelp, func() flags.Commander { return &cmdRefresh{} },
 		colorDescs.also(waitDescs).also(channelDescs).also(modeDescs).also(timeDescs).also(map[string]string{

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -492,6 +492,7 @@ type cmdInstall struct {
 	IgnoreValidation bool                   `long:"ignore-validation"`
 	IgnoreRunning    bool                   `long:"ignore-running" hidden:"yes"`
 	Transaction      client.TransactionType `long:"transaction" default:"per-snap" choice:"all-snaps" choice:"per-snap"`
+	QuotaGroupName   string                 `long:"quota-group"`
 	Positional       struct {
 		Snaps []remoteSnapName `positional-arg-name:"<snap>" required:"1"`
 	} `positional-args:"yes" required:"yes"`
@@ -637,6 +638,7 @@ func (x *cmdInstall) Execute([]string) error {
 		IgnoreValidation: x.IgnoreValidation,
 		IgnoreRunning:    x.IgnoreRunning,
 		Transaction:      x.Transaction,
+		QuotaGroupName:   x.QuotaGroupName,
 	}
 	x.setModes(opts)
 

--- a/daemon/api_sideload_n_try.go
+++ b/daemon/api_sideload_n_try.go
@@ -154,6 +154,13 @@ func sideloadOrTrySnap(c *Command, body io.ReadCloser, boundary string, user *au
 		return trySnap(c.d.overlord.State(), form.Values["snap-path"][0], flags)
 	}
 
+	if len(form.Values["quota-group"]) > 0 {
+		if len(form.Values["quota-group"]) != 1 {
+			return BadRequest("too many names provided for 'quota-group' option")
+		}
+		flags.QuotaGroupName = form.Values["quota-group"][0]
+	}
+
 	flags.RemoveSnapPath = true
 	flags.Unaliased = isTrue(form, "unaliased")
 	flags.IgnoreRunning = isTrue(form, "ignore-running")

--- a/daemon/api_sideload_n_try_test.go
+++ b/daemon/api_sideload_n_try_test.go
@@ -132,6 +132,33 @@ func (s *sideloadSuite) TestSideloadSnapDevMode(c *check.C) {
 	c.Check(chgSummary, check.Equals, `Install "local" snap from file "x"`)
 }
 
+func (s *sideloadSuite) TestSideloadSnapQuotaGroup(c *check.C) {
+	body := "" +
+		"----hello--\r\n" +
+		"Content-Disposition: form-data; name=\"snap\"; filename=\"x\"\r\n" +
+		"\r\n" +
+		"xyzzy\r\n" +
+		"----hello--\r\n" +
+		"Content-Disposition: form-data; name=\"devmode\"\r\n" +
+		"\r\n" +
+		"true\r\n" +
+		"----hello--\r\n" +
+		"Content-Disposition: form-data; name=\"quota-group\"\r\n" +
+		"\r\n" +
+		"foo\r\n" +
+		"----hello--\r\n"
+	head := map[string]string{"Content-Type": "multipart/thing; boundary=--hello--"}
+	// try a multipart/form-data upload
+	flags := snapstate.Flags{
+		RemoveSnapPath: true,
+		DevMode:        true,
+		Transaction:    client.TransactionPerSnap,
+		QuotaGroupName: "foo",
+	}
+	chgSummary, _ := s.sideloadCheck(c, body, head, "local", flags)
+	c.Check(chgSummary, check.Equals, `Install "local" snap from file "x"`)
+}
+
 func (s *sideloadSuite) TestSideloadSnapJailMode(c *check.C) {
 	body := "" +
 		"----hello--\r\n" +

--- a/daemon/api_snaps.go
+++ b/daemon/api_snaps.go
@@ -272,7 +272,7 @@ func (inst *snapInstruction) validate() error {
 		return fmt.Errorf("invalid value for transaction type: %s", inst.Transaction)
 	}
 	if inst.QuotaGroupName != "" && inst.Action != "install" {
-		return fmt.Errorf("quota-group can only be specified for install")
+		return fmt.Errorf("quota-group can only be specified on install")
 	}
 
 	return inst.snapRevisionOptions.validate()

--- a/daemon/api_snaps.go
+++ b/daemon/api_snaps.go
@@ -203,6 +203,7 @@ type snapInstruction struct {
 	Snaps                  []string               `json:"snaps"`
 	Users                  []string               `json:"users"`
 	ValidationSets         []string               `json:"validation-sets"`
+	QuotaGroupName         string                 `json:"quota-group"`
 
 	// The fields below should not be unmarshalled into. Do not export them.
 	userID int
@@ -236,6 +237,7 @@ func (inst *snapInstruction) installFlags() (snapstate.Flags, error) {
 	if inst.IgnoreValidation {
 		flags.IgnoreValidation = true
 	}
+	flags.QuotaGroupName = inst.QuotaGroupName
 
 	return flags, nil
 }

--- a/daemon/api_snaps.go
+++ b/daemon/api_snaps.go
@@ -271,6 +271,9 @@ func (inst *snapInstruction) validate() error {
 	default:
 		return fmt.Errorf("invalid value for transaction type: %s", inst.Transaction)
 	}
+	if inst.QuotaGroupName != "" && inst.Action != "install" {
+		return fmt.Errorf("quota-group can only be specified for install")
+	}
 
 	return inst.snapRevisionOptions.validate()
 }

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -1385,6 +1385,21 @@ func (s *snapsSuite) TestPostSnapCohortUnsupportedAction(c *check.C) {
 	}
 }
 
+func (s *snapsSuite) TestPostSnapQuotaGroupWrongAction(c *check.C) {
+	s.daemonWithOverlordMock()
+	const expectedErr = "quota-group can only be specified for install"
+
+	for _, action := range []string{"remove", "refresh", "revert", "enable", "disable", "xyzzy"} {
+		buf := strings.NewReader(fmt.Sprintf(`{"action": "%s", "quota-group": "foo"}`, action))
+		req, err := http.NewRequest("POST", "/v2/snaps/some-snap", buf)
+		c.Assert(err, check.IsNil)
+
+		rspe := s.errorReq(c, req, nil)
+		c.Check(rspe.Status, check.Equals, 400, check.Commentf("%q", action))
+		c.Check(rspe.Message, check.Equals, expectedErr, check.Commentf("%q", action))
+	}
+}
+
 func (s *snapsSuite) TestPostSnapLeaveCohortUnsupportedAction(c *check.C) {
 	s.daemonWithOverlordMock()
 	const expectedErr = "leave-cohort can only be specified for refresh or switch"

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -1387,7 +1387,7 @@ func (s *snapsSuite) TestPostSnapCohortUnsupportedAction(c *check.C) {
 
 func (s *snapsSuite) TestPostSnapQuotaGroupWrongAction(c *check.C) {
 	s.daemonWithOverlordMock()
-	const expectedErr = "quota-group can only be specified for install"
+	const expectedErr = "quota-group can only be specified on install"
 
 	for _, action := range []string{"remove", "refresh", "revert", "enable", "disable", "xyzzy"} {
 		buf := strings.NewReader(fmt.Sprintf(`{"action": "%s", "quota-group": "foo"}`, action))

--- a/tests/main/snap-quota-install/task.yaml
+++ b/tests/main/snap-quota-install/task.yaml
@@ -1,0 +1,61 @@
+summary: Test for assigning quota group on snap install.
+
+details: |
+  Test support for assigning a snap quota group on install of a snap
+prepare: |
+  snap pack "$TESTSLIB"/snaps/basic
+  snap set system experimental.quota-groups=true
+  tests.cleanup defer snap unset system experimental.quota-groups
+execute: |
+  if os.query is-trusty || os.query is-amazon-linux || os.query is-centos 7 || os.query is-xenial || os.query is-core16; then
+    # just check that we can't do anything with quota groups on systems with
+    # old systemd versions, we need at least 230 to avoid buggy slice usage
+    # reporting
+    snap set-quota foobar --memory=1MB 2>&1 | tr '\n' ' ' | tr -s ' ' | MATCH "systemd version 2[0-2][0-9] is too old \(expected at least 230\)"
+    exit 0
+  fi
+  echo "Installing hello-world and assigning it quota group not-exists"
+  snap install hello-world --quota-group not-exists 2>&1 | tr '\n' ' ' | tr -s ' ' | MATCH "\(group \"not-exists\" does not exist\)"
+  echo "Creating quota group (no snaps)"
+  snap set-quota group-one --memory=400MB
+  echo "Installing hello-world and assigning it quota group group-one"
+  snap install hello-world --quota-group group-one
+  echo "Checking that all quotas can be listed"
+  snap quotas | cat -n > quotas.txt
+  MATCH "     1\s+Quota\s+Parent\s+Constraints\s+Current$" < quotas.txt
+  MATCH "     2\s+group-one\s+memory=400MB\s*$" < quotas.txt
+  echo "Checking quota group details"
+  snap quota group-one | cat -n > details.txt
+  MATCH "     1\s+name:\s+group-one$" < details.txt
+  MATCH "     2\s+constraints:$" < details.txt
+  MATCH "     3\s+memory:\s+400MB$" < details.txt
+  MATCH "     4\s+current:$" < details.txt
+  MATCH "     5\s+memory:\s+[0-9.a-zA-Z]+B$" < details.txt
+  MATCH "     6\s+snaps:$" < details.txt
+  MATCH "     7\s+-\s+hello-world$" < details.txt
+  echo "Removing the snap from the system again"
+  snap remove hello-world
+  echo "Checking that the quota group is now empty"
+  snap quota group-one | cat -n > details2.txt
+  MATCH "     1\s+name:\s+group-one$" < details2.txt
+  MATCH "     2\s+constraints:$" < details2.txt
+  MATCH "     3\s+memory:\s+400MB$" < details2.txt
+  MATCH "     4\s+current:$" < details2.txt
+  MATCH "     5\s+memory:\s+[0-9.a-zA-Z]+B$" < details2.txt
+  if MATCH "     6\s+snaps:$" < details2.txt; then
+    echo "FAIL: Quota group is not empty"
+    exit 1
+  fi
+  echo "Installing a local snap into same group to verify option is supported for sideloaded snaps"
+  snap install --quota-group group-one --dangerous ./basic_1.0_all.snap
+  echo "Checking quota group details again"
+  snap quota group-one | cat -n > details.txt
+  MATCH "     1\s+name:\s+group-one$" < details.txt
+  MATCH "     2\s+constraints:$" < details.txt
+  MATCH "     3\s+memory:\s+400MB$" < details.txt
+  MATCH "     4\s+current:$" < details.txt
+  MATCH "     5\s+memory:\s+[0-9.a-zA-Z]+B$" < details.txt
+  MATCH "     6\s+snaps:$" < details.txt
+  MATCH "     7\s+-\s+basic$" < details.txt
+  echo "Removing the snap from the system again"
+  snap remove basic

--- a/tests/main/snap-quota-install/task.yaml
+++ b/tests/main/snap-quota-install/task.yaml
@@ -2,10 +2,12 @@ summary: Test for assigning quota group on snap install.
 
 details: |
   Test support for assigning a snap quota group on install of a snap
+
 prepare: |
   snap pack "$TESTSLIB"/snaps/basic
   snap set system experimental.quota-groups=true
   tests.cleanup defer snap unset system experimental.quota-groups
+
 execute: |
   if os.query is-trusty || os.query is-amazon-linux || os.query is-centos 7 || os.query is-xenial || os.query is-core16; then
     # just check that we can't do anything with quota groups on systems with
@@ -14,16 +16,21 @@ execute: |
     snap set-quota foobar --memory=1MB 2>&1 | tr '\n' ' ' | tr -s ' ' | MATCH "systemd version 2[0-2][0-9] is too old \(expected at least 230\)"
     exit 0
   fi
+  
   echo "Installing hello-world and assigning it quota group not-exists"
   snap install hello-world --quota-group not-exists 2>&1 | tr '\n' ' ' | tr -s ' ' | MATCH "\(group \"not-exists\" does not exist\)"
+  
   echo "Creating quota group (no snaps)"
   snap set-quota group-one --memory=400MB
+  
   echo "Installing hello-world and assigning it quota group group-one"
   snap install hello-world --quota-group group-one
+  
   echo "Checking that all quotas can be listed"
   snap quotas | cat -n > quotas.txt
   MATCH "     1\s+Quota\s+Parent\s+Constraints\s+Current$" < quotas.txt
   MATCH "     2\s+group-one\s+memory=400MB\s*$" < quotas.txt
+  
   echo "Checking quota group details"
   snap quota group-one | cat -n > details.txt
   MATCH "     1\s+name:\s+group-one$" < details.txt
@@ -33,8 +40,10 @@ execute: |
   MATCH "     5\s+memory:\s+[0-9.a-zA-Z]+B$" < details.txt
   MATCH "     6\s+snaps:$" < details.txt
   MATCH "     7\s+-\s+hello-world$" < details.txt
-  echo "Removing the snap from the system again"
+  
+  echo "Removing the snap from the system"
   snap remove hello-world
+  
   echo "Checking that the quota group is now empty"
   snap quota group-one | cat -n > details2.txt
   MATCH "     1\s+name:\s+group-one$" < details2.txt
@@ -46,8 +55,10 @@ execute: |
     echo "FAIL: Quota group is not empty"
     exit 1
   fi
+  
   echo "Installing a local snap into same group to verify option is supported for sideloaded snaps"
   snap install --quota-group group-one --dangerous ./basic_1.0_all.snap
+  
   echo "Checking quota group details again"
   snap quota group-one | cat -n > details.txt
   MATCH "     1\s+name:\s+group-one$" < details.txt
@@ -57,5 +68,5 @@ execute: |
   MATCH "     5\s+memory:\s+[0-9.a-zA-Z]+B$" < details.txt
   MATCH "     6\s+snaps:$" < details.txt
   MATCH "     7\s+-\s+basic$" < details.txt
-  echo "Removing the snap from the system again"
+  echo "Removing the snap from the system"
   snap remove basic


### PR DESCRIPTION
The second PR for the '--quota-group' option on snap install. This effectively invalidates the original PR https://github.com/snapcore/snapd/pull/11940 and is a followup to https://github.com/snapcore/snapd/pull/12066 which is also contained here.

This PR contains the frontend changes required to support the option, including a spread test.

