### PR TITLE
tests: improve and standardize debug section on tests

### DIFF
--- a/tests/core/failover/task.yaml
+++ b/tests/core/failover/task.yaml
@@ -75,9 +75,9 @@ restore: |
     rm -rf "$BUILD_DIR"
 
 debug: |
-    snap debug boot-vars
-    snap list
-    snap changes
+    snap debug boot-vars || true
+    snap list || true
+    snap changes || true
 
 execute: |
     if [ "$TARGET_SNAP" = "kernel" ] && os.query is-arm; then

--- a/tests/core/kernel-snap-refresh-on-core/task.yaml
+++ b/tests/core/kernel-snap-refresh-on-core/task.yaml
@@ -18,7 +18,7 @@ prepare: |
     snap install test-snapd-sh
 
 debug: |
-    grub-editenv list
+    grub-editenv list || true
 
 execute: |
     same=$(snap info pc-kernel | awk "

--- a/tests/core/os-release/task.yaml
+++ b/tests/core/os-release/task.yaml
@@ -1,7 +1,7 @@
 summary: check that os-release is correct
 
 debug: |
-    cat /etc/lsb-release
+    cat /etc/lsb-release || true
 
 execute: |
     echo "Check the DISTRIB_RELEASE is correct in /etc/lsb-release file" 

--- a/tests/core/persistent-journal/task.yaml
+++ b/tests/core/persistent-journal/task.yaml
@@ -9,11 +9,11 @@ restore: |
     systemctl kill --signal=SIGUSR1 systemd-journald
 
 debug: |
-    journalctl -u snapd
+    "$TESTSTOOLS"/journal-state get-log -u snapd
     echo "snapd status before the test:"
-    cat before.txt
+    cat before.txt || true
     echo "snapd status after the test:"
-    systemctl status snapd
+    systemctl status snapd || true
 
 execute: |
     echo "Wait for first boot to be done"

--- a/tests/core/snap-auto-mount/task.yaml
+++ b/tests/core/snap-auto-mount/task.yaml
@@ -62,7 +62,7 @@ restore: |
     dmsetup -v --noudevsync --noudevrules  remove dm-ram0
 
 debug: |
-    journalctl -b | tail -100
+    "$TESTSTOOLS"/journal-state get-log -b | tail -100
 
 execute: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then

--- a/tests/core/snapd-failover/task.yaml
+++ b/tests/core/snapd-failover/task.yaml
@@ -30,16 +30,16 @@ restore: |
 
 debug: |
     # dump failure data
-    journalctl -u snapd.failure.service
-    journalctl -u snapd.socket || true
+    "$TESTSTOOLS"/journal-state get-log -u snapd.failure.service
+    "$TESTSTOOLS"/journal-state get-log -u snapd.socket
     if os.query is-core16; then
         # might be useful to know what's up with the core snap too on uc16
-        ls -l /snap/core/
+        ls -l /snap/core/ || true
     fi
-    ls -l /snap/snapd/
+    ls -l /snap/snapd/ || true
 
-    cat /etc/systemd/system/snapd.service
-    cat /etc/systemd/system/usr-lib-snapd.mount
+    cat /etc/systemd/system/snapd.service || true
+    cat /etc/systemd/system/usr-lib-snapd.mount || true
     /snap/snapd/x1/usr/bin/snap debug state /var/lib/snapd/state.json || true
     /snap/snapd/x1/usr/bin/snap debug state --change="$(/snap/snapd/x1/usr/bin/snap debug state /var/lib/snapd/state.json|tail -n1|awk '{print $1}')" /var/lib/snapd/state.json || true
 

--- a/tests/core/uc20-recovery/task.yaml
+++ b/tests/core/uc20-recovery/task.yaml
@@ -13,15 +13,9 @@ restore: |
     fi
 
 debug: |
-    if [ -e systems.json ]; then
-        cat systems.json
-    fi
-    if [ -e system-info ]; then
-        cat system-info
-    fi
-    if [ -e /tmp/mock-shutdown.calls ]; then
-        cat /tmp/mock-shutdown.calls
-    fi
+    cat systems.json || true
+    cat system-info || true
+    cat /tmp/mock-shutdown.calls || true
 
 execute: |
     # shellcheck source=tests/lib/uc20-recovery.sh

--- a/tests/core/upgrade/task.yaml
+++ b/tests/core/upgrade/task.yaml
@@ -32,8 +32,8 @@ restore: |
     snap remove core --revision=x3
 
 debug: |
-    snap list
-    "$TESTSTOOLS"/boot-state bootenv show
+    snap list || true
+    "$TESTSTOOLS"/boot-state bootenv show || true
     cat /proc/cmdline
 
 execute: |

--- a/tests/main/appstream-id/task.yaml
+++ b/tests/main/appstream-id/task.yaml
@@ -8,7 +8,7 @@ prepare: |
     snap install --edge jq
 
 debug: |
-    test -e response && cat response
+    cat response || true
 
 execute: |
     echo "Verify that search results contain common-ids"

--- a/tests/main/auto-refresh-retry/task.yaml
+++ b/tests/main/auto-refresh-retry/task.yaml
@@ -12,7 +12,7 @@ restore: |
 
 debug: |
     systemctl cat snapd.service
-    ip netns list
+    ip netns list || true
     ip netns pids testns || true
 
 execute: |

--- a/tests/main/cgroup-tracking-failure/task.yaml
+++ b/tests/main/cgroup-tracking-failure/task.yaml
@@ -36,13 +36,11 @@ restore: |
     systemctl --user stop dbus.service || true
 
 debug: |
-    set +e  # any of the files below may not exist and this causes the command to be indicated as failure
-    test -e scenario.txt && cat scenario.txt
-    test -e run.txt && cat run.txt
-    test -e debug.txt && head -n 10 debug.txt
-    test -e cgroup.txt && cat cgroup.txt
-    test -e ps.txt && cat ps.txt
-    set -e
+    cat scenario.txt || true
+    cat run.txt || true
+    head -n 10 debug.txt || true
+    cat cgroup.txt || true
+    cat ps.txt || true
 
 execute: |
     #shellcheck source=tests/lib/systems.sh

--- a/tests/main/completion/task.yaml
+++ b/tests/main/completion/task.yaml
@@ -54,7 +54,7 @@ restore: |
 debug: |
     #shellcheck source=tests/lib/random.sh
     . "$TESTSLIB"/random.sh
-    debug_random
+    debug_random || true
 
 execute: |
     for i in *.exp; do

--- a/tests/main/core-snap-not-test-test/task.yaml
+++ b/tests/main/core-snap-not-test-test/task.yaml
@@ -1,7 +1,7 @@
 summary: Files inside the core snap are not owned by test.test
 
 debug: |
-    find /snap/core/current/ -user test
+    find /snap/core/current/ -user test || true
 
 execute: |
     echo "Check there are not files in /snap/core/current/ owned by test user"

--- a/tests/main/create-key/task.yaml
+++ b/tests/main/create-key/task.yaml
@@ -17,7 +17,7 @@ prepare: |
 debug: |
     #shellcheck source=tests/lib/random.sh
     . "$TESTSLIB"/random.sh
-    debug_random
+    debug_random || true
 
 execute: |
     echo "Checking passphrase mismatch error"

--- a/tests/main/docker-smoke/task.yaml
+++ b/tests/main/docker-smoke/task.yaml
@@ -7,7 +7,7 @@ environment:
   SNAPD_NO_MEMORY_LIMIT: 1
 
 debug: |
-  journalctl -u snap.docker.dockerd
+  "$TESTSTOOLS"/journal-state get-log -u snap.docker.dockerd
 
 execute: |
   if ! snap install docker; then

--- a/tests/main/econnreset/task.yaml
+++ b/tests/main/econnreset/task.yaml
@@ -19,9 +19,9 @@ debug: |
     echo "other dir content"
     ls -lh
     echo "download log:"
-    cat snap-download.log
+    cat snap-download.log || true
     echo "iptables rules and counters"
-    iptables -L -n -v
+    iptables -L -n -v || true
 
 execute: |
     echo "Downloading a large snap in the background"

--- a/tests/main/install-fontconfig-cache-gen/task.yaml
+++ b/tests/main/install-fontconfig-cache-gen/task.yaml
@@ -31,7 +31,7 @@ restore: |
 
 debug: |
     ls -lah /var/cache/fontconfig/
-    dpkg-reconfigure fontconfig
+    dpkg-reconfigure fontconfig || true
     ls -lah /var/cache/fontconfig/
 
 execute: |

--- a/tests/main/interfaces-snapd-control-with-manage/task.yaml
+++ b/tests/main/interfaces-snapd-control-with-manage/task.yaml
@@ -55,7 +55,7 @@ restore: |
     teardown_fake_store "$BLOB_DIR"
 
 debug: |
-    jq .data.auth.device /var/lib/snapd/state.json
+    jq .data.auth.device /var/lib/snapd/state.json || true
 
 execute: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then

--- a/tests/main/refresh-with-epoch-bump/task.yaml
+++ b/tests/main/refresh-with-epoch-bump/task.yaml
@@ -11,10 +11,10 @@ prepare: |
     snap install test-snapd-epoch
 
 debug: |
-    snap info test-snapd-epoch
+    snap info test-snapd-epoch || true
     snap list test-snapd-epoch || true
-    snap tasks --last=install
-    snap tasks --last=refresh
+    snap tasks --last=install || true
+    snap tasks --last=refresh || true
 
 execute: |
     SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"

--- a/tests/main/security-setuid-root/task.yaml
+++ b/tests/main/security-setuid-root/task.yaml
@@ -26,7 +26,7 @@ debug: |
     ls -ld "$SNAP_MOUNT_DIR/core/current/usr/lib/snapd/snap-confine" || true
     ls -ld "$SNAP_MOUNT_DIR/ubuntu-core/current/usr/lib/snapd/snap-confine" || true
     ls -ld /usr/lib/snapd/snap-confine || true
-    snap list
+    snap list || true
 
 execute: |
     # NOTE: This has to run as the test user because the protection is only

--- a/tests/main/selinux-lxd/task.yaml
+++ b/tests/main/selinux-lxd/task.yaml
@@ -29,10 +29,8 @@ restore: |
     "$TESTSTOOLS"/lxd-state undo-mount-changes
 
 debug: |
-    if [ -e avc-after ]; then
-        echo "AVC log from the test"
-        cat avc-after
-    fi
+    echo "AVC log from the test"
+    cat avc-after || true
 
 execute: |
     snap install lxd --channel="$LXD_SNAP_CHANNEL"

--- a/tests/main/snap-network-errors/task.yaml
+++ b/tests/main/snap-network-errors/task.yaml
@@ -9,7 +9,7 @@ restore: |
 
 debug: |
     echo "iptables rules:"
-    iptables -L -n -v
+    iptables -L -n -v || true
 
 execute: |
     # Do a store op to avoid an unexpected device auth refresh on snap find

--- a/tests/main/snap-run/task.yaml
+++ b/tests/main/snap-run/task.yaml
@@ -12,9 +12,7 @@ prepare: |
     "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
 
 debug: |
-    if [ -f stderr ]; then
-        cat stderr
-    fi
+    cat stderr || true
 
 execute: |
     echo "Running a trivial command causes no DENIED messages"

--- a/tests/main/snap-sign/task.yaml
+++ b/tests/main/snap-sign/task.yaml
@@ -18,7 +18,7 @@ prepare: |
 debug: |
     #shellcheck source=tests/lib/random.sh
     . "$TESTSLIB"/random.sh
-    debug_random
+    debug_random || true
 
 execute: |
     echo "Creating a new key without a password"

--- a/tests/main/snapd-apparmor/task.yaml
+++ b/tests/main/snapd-apparmor/task.yaml
@@ -4,7 +4,7 @@ environment:
     CONSUMER_SNAP: test-snapd-policy-app-consumer
 
 debug: |
-    journalctl -u snap.apparmor.service
+    "$TESTSTOOLS"/journal-state get-log -u snap.apparmor.service
 
 execute: |
     if ! systemctl is-active snapd.apparmor.service; then

--- a/tests/main/snapd-slow-startup/task.yaml
+++ b/tests/main/snapd-slow-startup/task.yaml
@@ -9,7 +9,7 @@ restore: |
 
 debug: |
     ls /etc/systemd/system/snapd.service.d
-    cat /etc/systemd/system/snapd.service.d/*
+    cat /etc/systemd/system/snapd.service.d/* || true
 
 execute: |
     systemd_ver="$(systemctl --version|head -1|cut -d ' ' -f2)"

--- a/tests/main/uc20-create-partitions-reinstall/task.yaml
+++ b/tests/main/uc20-create-partitions-reinstall/task.yaml
@@ -52,13 +52,15 @@ restore: |
 
 debug: |
     cat /proc/partitions
-    LOOP="$(cat loop.txt)"
-    udevadm info --query property "${LOOP}" || true
-    udevadm info --query property "${LOOP}p1" || true
-    udevadm info --query property "${LOOP}p2" || true
-    udevadm info --query property "${LOOP}p3" || true
-    udevadm info --query property "${LOOP}p4" || true
-    udevadm info --query property "${LOOP}p5" || true
+    if [ -f loop.txt ]; then
+        LOOP="$(cat loop.txt)"
+        udevadm info --query property "${LOOP}" || true
+        udevadm info --query property "${LOOP}p1" || true
+        udevadm info --query property "${LOOP}p2" || true
+        udevadm info --query property "${LOOP}p3" || true
+        udevadm info --query property "${LOOP}p4" || true
+        udevadm info --query property "${LOOP}p5" || true
+    fi
 
 execute: |
     LOOP="$(cat loop.txt)"

--- a/tests/nested/classic/hotplug/task.yaml
+++ b/tests/nested/classic/hotplug/task.yaml
@@ -21,13 +21,11 @@ restore: |
     rm -f /tmp/serialport{0,1}
 
 debug: |
-    set +e
-    tests.nested exec "snap connections --all"
-    tests.nested exec "snap list"
-    tests.nested exec "dmesg"
-    tests.nested exec 'sudo jq -r ".data[\"hotplug-slots\"]" /var/lib/snapd/state.json'
-    tests.nested exec 'lsmod'
-    set -e
+    tests.nested exec "snap connections --all" || true
+    tests.nested exec "snap list" || true
+    tests.nested exec "dmesg" || true
+    tests.nested exec 'sudo jq -r ".data[\"hotplug-slots\"]" /var/lib/snapd/state.json' || true
+    tests.nested exec 'lsmod' || true
 
 execute: |
     #shellcheck source=tests/lib/hotplug.sh

--- a/tests/nested/core/hotplug/task.yaml
+++ b/tests/nested/core/hotplug/task.yaml
@@ -17,12 +17,10 @@ restore: |
     rm -f /tmp/serialport{0,1}
 
 debug: |
-    set +e
-    tests.nested exec "snap connections --all"
-    tests.nested exec "snap list"
-    tests.nested exec "dmesg"
-    tests.nested exec 'sudo jq -r ".data[\"hotplug-slots\"]" /var/lib/snapd/state.json'
-    set -e
+    tests.nested exec "snap connections --all" || true
+    tests.nested exec "snap list" || true
+    tests.nested exec "dmesg" || true
+    tests.nested exec 'sudo jq -r ".data[\"hotplug-slots\"]" /var/lib/snapd/state.json' || true
 
 execute: |
     #shellcheck source=tests/lib/nested.sh

--- a/tests/nested/core/save-data/task.yaml
+++ b/tests/nested/core/save-data/task.yaml
@@ -8,7 +8,7 @@ details: |
 systems: [ubuntu-20.04-64, ubuntu-22.04-64]
 
 debug: |
-    tests.nested exec "lsblk"
+    tests.nested exec "lsblk" || true
 
 execute: |
     echo "Wait for the system to be seeded first"

--- a/tests/nested/manual/cloud-init-never-used-not-vuln/task.yaml
+++ b/tests/nested/manual/cloud-init-never-used-not-vuln/task.yaml
@@ -55,10 +55,9 @@ prepare: |
     tests.nested create-vm core --param-cdrom "-cdrom $(pwd)/seed.iso"
 
 debug: |
-    if [ -f snapd-before-reboot.logs ]; then
-        echo "logs before reboot"
-        cat snapd-before-reboot.logs
-    fi
+    echo "logs before reboot"
+    cat snapd-before-reboot.logs || true
+
     echo "logs from current nested VM boot snapd"
     tests.nested exec "sudo journalctl -e --no-pager -u snapd" || true
 

--- a/tests/nested/manual/cloud-init-nocloud-not-vuln/task.yaml
+++ b/tests/nested/manual/cloud-init-nocloud-not-vuln/task.yaml
@@ -58,10 +58,9 @@ prepare: |
     tests.nested create-vm core --param-cdrom "-cdrom $(pwd)/seed.iso"
 
 debug: |
-    if [ -f snapd-before-reboot.logs ]; then
-        echo "logs before reboot"
-        cat snapd-before-reboot.logs
-    fi
+    echo "logs before reboot"
+    cat snapd-before-reboot.logs || true
+
     echo "logs from current nested VM boot snapd"
     tests.nested exec "sudo journalctl -e --no-pager -u snapd" || true
 

--- a/tests/nested/manual/core20-early-config/task.yaml
+++ b/tests/nested/manual/core20-early-config/task.yaml
@@ -35,7 +35,7 @@ restore: |
 
 debug: |
     # show if anything went wrong during seeding
-    tests.nested exec "snap change 1"
+    tests.nested exec "snap change 1" || true
 
 execute: |
     check_core20_early_config(){

--- a/tests/regression/lp-1803542/task.yaml
+++ b/tests/regression/lp-1803542/task.yaml
@@ -1,9 +1,11 @@
 summary: Regression test for https://bugs.launchpad.net/snapd/+bug/1803542
+
 environment:
     VARIANT/absent: absent
     VARIANT/present: present
     VARIANT/shared: shared
     VARIANT/private: private
+
 prepare: |
     "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
     # Ensure that every snap namespace is discarded.
@@ -19,8 +21,10 @@ prepare: |
         fi
     done
     not findmnt --noheadings /run/snapd/ns
+
 debug: |
     cat /proc/self/mountinfo
+
 execute: |
     case "$VARIANT" in
        absent)

--- a/tests/regression/lp-1813963/task.yaml
+++ b/tests/regression/lp-1813963/task.yaml
@@ -81,9 +81,6 @@ restore: |
 debug: |
     echo "Status of the test service"
     systemctl status snap.test-snapd-simple-service.test-snapd-simple-service.service || true
-    echo "Apparmor denials"
-    dmesg | grep DENIED || true
-
 
 execute: |
     # When snap-update-ns is artificially slowed down so that snap-confine

--- a/tests/regression/lp-1867752/task.yaml
+++ b/tests/regression/lp-1867752/task.yaml
@@ -21,7 +21,7 @@ restore: |
     "$TESTSTOOLS"/lxd-state undo-mount-changes
 
 debug: |
-    lxc exec bionic -- bash -c "SNAPD_DEBUG=1 /usr/lib/snapd/snap-update-ns maas"
+    lxc exec bionic -- bash -c "SNAPD_DEBUG=1 /usr/lib/snapd/snap-update-ns maas" || true
 
 execute: |
     # first command is done twice due to https://bugs.launchpad.net/snapd/+bug/1865503


### PR DESCRIPTION
The idea of this change is to standardize the debug section of the tests
and also to make them more robust.

Debug is shown when the test has failed, so the preconditions for any
step is undefined, this is why we need to suppose it can fail at any
step.

In case the debug section fails for a test, then the generic debug is
not displayed and no useful debug information is shown to understand
the problem.
