### PR TITLE
overlord/servicestate: disallow removal of quota group with any limits set

### DIFF
--- a/overlord/servicestate/quota_handlers.go
+++ b/overlord/servicestate/quota_handlers.go
@@ -416,8 +416,8 @@ func quotaRemove(st *state.State, action QuotaControlAction, allGrps map[string]
 		return nil, nil, false, fmt.Errorf("internal error, AddSnaps option cannot be used with remove action")
 	}
 
-	if action.ResourceLimits.Memory != nil {
-		return nil, nil, false, fmt.Errorf("internal error, MemoryLimit option cannot be used with remove action")
+	if !action.ResourceLimits.IsZero() {
+		return nil, nil, false, fmt.Errorf("internal error, quota limit options cannot be used with remove action")
 	}
 
 	// XXX: remove this limitation eventually

--- a/overlord/servicestate/quota_handlers.go
+++ b/overlord/servicestate/quota_handlers.go
@@ -416,7 +416,7 @@ func quotaRemove(st *state.State, action QuotaControlAction, allGrps map[string]
 		return nil, nil, false, fmt.Errorf("internal error, AddSnaps option cannot be used with remove action")
 	}
 
-	if !action.ResourceLimits.IsZero() {
+	if !action.ResourceLimits.Unset() {
 		return nil, nil, false, fmt.Errorf("internal error, quota limit options cannot be used with remove action")
 	}
 

--- a/snap/quota/resources.go
+++ b/snap/quota/resources.go
@@ -203,6 +203,11 @@ func (qr *Resources) CheckFeatureRequirements() error {
 	return nil
 }
 
+// IsZero returns whether or not there is at least one limit set
+func (qr *Resources) IsZero() bool {
+	return qr.Memory == nil && qr.CPU == nil && qr.CPUSet == nil && qr.Threads == nil && qr.Journal == nil
+}
+
 // Validate performs basic validation of the provided quota resources for a group.
 // The restrictions imposed are that at least one limit should be set, and each
 // of the imposed limits are not zero.
@@ -210,7 +215,7 @@ func (qr *Resources) CheckFeatureRequirements() error {
 // Note that before applying the quota to the system
 // CheckFeatureRequirements() should be called.
 func (qr *Resources) Validate() error {
-	if qr.Memory == nil && qr.CPU == nil && qr.CPUSet == nil && qr.Threads == nil && qr.Journal == nil {
+	if qr.IsZero() {
 		return fmt.Errorf("quota group must have at least one resource limit set")
 	}
 

--- a/snap/quota/resources.go
+++ b/snap/quota/resources.go
@@ -203,7 +203,7 @@ func (qr *Resources) CheckFeatureRequirements() error {
 	return nil
 }
 
-// IsZero returns whether or not there is at least one limit set
+// IsZero returns true if there is no limit set
 func (qr *Resources) IsZero() bool {
 	return qr.Memory == nil && qr.CPU == nil && qr.CPUSet == nil && qr.Threads == nil && qr.Journal == nil
 }

--- a/snap/quota/resources.go
+++ b/snap/quota/resources.go
@@ -203,8 +203,8 @@ func (qr *Resources) CheckFeatureRequirements() error {
 	return nil
 }
 
-// IsZero returns true if there is no limit set
-func (qr *Resources) IsZero() bool {
+// Unset returns true if there is no limit set
+func (qr *Resources) Unset() bool {
 	return qr.Memory == nil && qr.CPU == nil && qr.CPUSet == nil && qr.Threads == nil && qr.Journal == nil
 }
 
@@ -215,7 +215,7 @@ func (qr *Resources) IsZero() bool {
 // Note that before applying the quota to the system
 // CheckFeatureRequirements() should be called.
 func (qr *Resources) Validate() error {
-	if qr.IsZero() {
+	if qr.Unset() {
 		return fmt.Errorf("quota group must have at least one resource limit set")
 	}
 

--- a/snap/quota/resources.go
+++ b/snap/quota/resources.go
@@ -205,7 +205,7 @@ func (qr *Resources) CheckFeatureRequirements() error {
 
 // Unset returns true if there is no limit set
 func (qr *Resources) Unset() bool {
-	return qr.Memory == nil && qr.CPU == nil && qr.CPUSet == nil && qr.Threads == nil && qr.Journal == nil
+	return *qr == Resources{}
 }
 
 // Validate performs basic validation of the provided quota resources for a group.


### PR DESCRIPTION
Missing case when removing a quota group with a limit set.