### PR TITLE
multiple: clear up naming convention for thread quota

### DIFF
--- a/daemon/api_quotas.go
+++ b/daemon/api_quotas.go
@@ -73,7 +73,7 @@ var getQuotaUsage = func(grp *quota.Group) (*client.QuotaValues, error) {
 		currentUsage.Memory = mem
 	}
 
-	if grp.TaskLimit != 0 {
+	if grp.ThreadLimit != 0 {
 		threads, err := grp.CurrentTaskUsage()
 		if err != nil {
 			return nil, err
@@ -87,7 +87,7 @@ var getQuotaUsage = func(grp *quota.Group) (*client.QuotaValues, error) {
 func createQuotaValues(grp *quota.Group) *client.QuotaValues {
 	var constraints client.QuotaValues
 	constraints.Memory = grp.MemoryLimit
-	constraints.Threads = grp.TaskLimit
+	constraints.Threads = grp.ThreadLimit
 
 	if grp.CPULimit != nil {
 		constraints.CPU = &client.QuotaCPUValues{

--- a/snap/quota/quota.go
+++ b/snap/quota/quota.go
@@ -107,10 +107,10 @@ type Group struct {
 	// and which cores (requires cgroupsv2) are allowed to be used.
 	CPULimit *GroupQuotaCPU `json:"cpu-limit,omitempty"`
 
-	// TaskLimit is the limit of threads/processes that can be active at once in
+	// ThreadLimit is the limit of threads/processes that can be active at once in
 	// the group. Once the limit is reached, further forks() or clones() will be blocked
 	// for processes in the group.
-	TaskLimit int `json:"task-limit,omitempty"`
+	ThreadLimit int `json:"task-limit,omitempty"`
 
 	// JournalLimit is the limits that apply to the journal for this quota group. When
 	// this limit is present, then the quota group will be assigned a log namespace for
@@ -163,8 +163,8 @@ func (grp *Group) GetQuotaResources() Resources {
 			resourcesBuilder.WithCPUSet(grp.CPULimit.CPUSet)
 		}
 	}
-	if grp.TaskLimit != 0 {
-		resourcesBuilder.WithThreadLimit(grp.TaskLimit)
+	if grp.ThreadLimit != 0 {
+		resourcesBuilder.WithThreadLimit(grp.ThreadLimit)
 	}
 	if grp.JournalLimit != nil {
 		resourcesBuilder.WithJournalNamespace()
@@ -379,7 +379,7 @@ func (grp *Group) getQuotaAllocations(allQuotas map[string]*groupQuotaAllocation
 	limits := &groupQuotaAllocations{
 		MemoryLimit:  grp.MemoryLimit,
 		CPULimit:     grp.getCurrentCPUAllocation(),
-		ThreadsLimit: grp.TaskLimit,
+		ThreadsLimit: grp.ThreadLimit,
 		CPUSetLimit:  grp.GetLocalCPUSetQuota(),
 	}
 
@@ -611,7 +611,7 @@ func (grp *Group) validateThreadResourceFit(allQuotas map[string]*groupQuotaAllo
 	// make sure current usage does not exceed the new limit, we can avoid any
 	// recursive descent as we already have counted up the usage of our children.
 	currentLimits := allQuotas[grp.Name]
-	threadsReserved := grp.TaskLimit
+	threadsReserved := grp.ThreadLimit
 	if currentLimits != nil {
 		if currentLimits.ThreadsReservedByChildren > threadLimit {
 			return fmt.Errorf("group thread limit of %d is too small to fit current subgroup usage of %d",
@@ -620,7 +620,7 @@ func (grp *Group) validateThreadResourceFit(allQuotas map[string]*groupQuotaAllo
 
 		// if we are reducing the limit, then we don't need to check upper parents,
 		// as we can assume it will fit by this point
-		if threadLimit < grp.TaskLimit {
+		if threadLimit < grp.ThreadLimit {
 			return nil
 		}
 
@@ -716,7 +716,7 @@ func (grp *Group) UpdateQuotaLimits(resourceLimits Resources) error {
 		grp.CPULimit.CPUSet = resourceLimits.CPUSet.CPUs
 	}
 	if resourceLimits.Threads != nil {
-		grp.TaskLimit = resourceLimits.Threads.Limit
+		grp.ThreadLimit = resourceLimits.Threads.Limit
 	}
 	if resourceLimits.Journal != nil {
 		if grp.JournalLimit == nil {

--- a/snap/quota/quota_test.go
+++ b/snap/quota/quota_test.go
@@ -1114,7 +1114,7 @@ func (ts *quotaTestSuite) TestChangingParentCpuSetLimits(c *C) {
 	c.Check(err, ErrorMatches, `group cpu-set \[0\] is not a superset of current subgroup usage of \[0 1\]`)
 }
 
-func (ts *quotaTestSuite) TestChangingParentTaskLimits(c *C) {
+func (ts *quotaTestSuite) TestChangingParentThreadLimits(c *C) {
 	// The purpose here is to make sure we can't change the limits of the parent group
 	// that would otherwise conflict with the current usage of limits by children of the
 	// parent.

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -132,8 +132,8 @@ TasksAccounting=true
 `
 	buf := bytes.NewBufferString(header)
 
-	if grp.TaskLimit != 0 {
-		fmt.Fprintf(buf, "TasksMax=%d\n", grp.TaskLimit)
+	if grp.ThreadLimit != 0 {
+		fmt.Fprintf(buf, "TasksMax=%d\n", grp.ThreadLimit)
 	}
 	return buf.String()
 }


### PR DESCRIPTION
Clear up naming convention for threads, use threads internally and task when interacting with systemd