### PR TITLE
snap/quota,wrappers: allow using 0 values for the journal rate limit

### DIFF
--- a/snap/quota/quota.go
+++ b/snap/quota/quota.go
@@ -175,6 +175,10 @@ func (grp *Group) GetQuotaResources() Resources {
 		if grp.JournalLimit.Size != 0 {
 			resourcesBuilder.WithJournalSize(grp.JournalLimit.Size)
 		}
+		// We cannot just check for RateCount and RatePeriod and call WithJournalRate()
+		// only if both are non-zero, because not calling WithJournalRate() causes the
+		// system's default rate count and rate period to be used; what we really want
+		// here is to be able to completely disable the rate-limit for a journal quota.
 		if grp.JournalLimit.RateEnabled {
 			resourcesBuilder.WithJournalRate(grp.JournalLimit.RateCount, grp.JournalLimit.RatePeriod)
 		}

--- a/snap/quota/quota.go
+++ b/snap/quota/quota.go
@@ -69,15 +69,16 @@ type GroupQuotaJournal struct {
 	// journald namespaces is 4GB. A value of 0 here means no limit is present.
 	Size quantity.Size `json:"size,omitempty"`
 
-	// RateCount/RatePeriod determines the maximum rate of journal writes for
-	// the group. The count is the number of journal messages that can be written
-	// in each period. We treat rate values a bit different as 0 are valid values
-	// here and used to override the journal default rate (which is not unlimited),
-	// and thus the reason we have RateEnabled to tell us whether the values are
-	// to be used.
-	RateEnabled bool          `json:"rate-enabled,omitempty"`
-	RateCount   int           `json:"rate-count,omitempty"`
-	RatePeriod  time.Duration `json:"rate-period,omitempty"`
+	// RateEnabled tells us whether or not the values provided in RateCount and
+	// RatePeriod should be written.
+	RateEnabled bool `json:"rate-enabled,omitempty"`
+	// RateCount is the number of messages allowed each RatePeriod. A zero value
+	// in this field will disable the rate-limit.
+	RateCount int `json:"rate-count,omitempty"`
+	// RatePeriod is the time-period for when the rate resets. Each RatePeriod,
+	// RateCount number of messages is allowed. A zero value in this field will
+	// disable the rate-limit.
+	RatePeriod time.Duration `json:"rate-period,omitempty"`
 }
 
 // Group is a quota group of snaps, services or sub-groups that are all subject

--- a/snap/quota/resources.go
+++ b/snap/quota/resources.go
@@ -176,11 +176,9 @@ func (qr *Resources) validateJournalQuota() error {
 	}
 
 	if qr.Journal.Rate != nil {
-		// The only invalid numbers for the count are those less than 0
 		if qr.Journal.Rate.Count < 0 {
 			return fmt.Errorf("journal quota must have a rate count equal to or larger than zero")
 		}
-		// The only invalid numbers for period are values larger than 0 but less than 1us
 		if qr.Journal.Rate.Period > 0 && qr.Journal.Rate.Period < time.Microsecond {
 			return fmt.Errorf("journal quota must have a period of at least 1 microsecond (minimum resolution)")
 		}

--- a/snap/quota/resources_test.go
+++ b/snap/quota/resources_test.go
@@ -47,9 +47,8 @@ func (s *resourcesTestSuite) TestQuotaValidationFails(c *C) {
 		{quota.NewResourcesBuilder().Build(), `quota group must have at least one resource limit set`},
 		{quota.NewResourcesBuilder().WithCPUCount(1).Build(), `invalid cpu quota with count of >0 and percentage of 0`},
 		{quota.NewResourcesBuilder().WithCPUCount(2).WithCPUPercentage(100).WithCPUSet([]int{0}).Build(), `cpu usage 200% is larger than the maximum allowed for provided set \[0\] of 100%`},
-		{quota.NewResourcesBuilder().WithJournalRate(0, 1).Build(), `journal quota must have a rate count larger than zero and period at least 1 microsecond \(minimum resolution\)`},
-		{quota.NewResourcesBuilder().WithJournalRate(1, 0).Build(), `journal quota must have a rate count larger than zero and period at least 1 microsecond \(minimum resolution\)`},
-		{quota.NewResourcesBuilder().WithJournalRate(1, time.Nanosecond).Build(), `journal quota must have a rate count larger than zero and period at least 1 microsecond \(minimum resolution\)`},
+		{quota.NewResourcesBuilder().WithJournalRate(0, 1).Build(), `journal quota must have a period of at least 1 microsecond \(minimum resolution\)`},
+		{quota.NewResourcesBuilder().WithJournalRate(1, time.Nanosecond).Build(), `journal quota must have a period of at least 1 microsecond \(minimum resolution\)`},
 		{quota.NewResourcesBuilder().WithJournalSize(0).Build(), `journal size quota must have a limit set`},
 	}
 
@@ -188,13 +187,8 @@ func (s *resourcesTestSuite) TestQuotaChangeValidationFails(c *C) {
 		},
 		{
 			quota.NewResourcesBuilder().WithJournalRate(1, 1).Build(),
-			quota.NewResourcesBuilder().WithJournalRate(0, 0).Build(),
-			`cannot remove journal rate limit from quota group`,
-		},
-		{
-			quota.NewResourcesBuilder().WithJournalRate(1, 1).Build(),
 			quota.NewResourcesBuilder().WithJournalRate(-2, 0).Build(),
-			`journal quota must have a rate count larger than zero and period at least 1 microsecond \(minimum resolution\)`,
+			`journal quota must have a rate count equal to or larger than zero`,
 		},
 		{
 			quota.NewResourcesBuilder().WithJournalSize(quantity.SizeGiB).Build(),
@@ -288,6 +282,11 @@ func (s *resourcesTestSuite) TestQuotaChangeValidationPasses(c *C) {
 			quota.NewResourcesBuilder().WithJournalRate(15, 5*time.Second).Build(),
 			quota.NewResourcesBuilder().WithJournalSize(quantity.SizeGiB).Build(),
 			quota.NewResourcesBuilder().WithJournalSize(quantity.SizeGiB).WithJournalRate(15, 5*time.Second).Build(),
+		},
+		{
+			quota.NewResourcesBuilder().WithJournalRate(0, 0).Build(),
+			quota.NewResourcesBuilder().WithJournalSize(quantity.SizeGiB).Build(),
+			quota.NewResourcesBuilder().WithJournalSize(quantity.SizeGiB).WithJournalRate(0, 0).Build(),
 		},
 		{
 			quota.NewResourcesBuilder().WithCPUCount(4).WithCPUPercentage(25).Build(),

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -169,7 +169,7 @@ RuntimeMaxUse=%[1]d
 }
 
 func formatJournalRateConf(grp *quota.Group) string {
-	if grp.JournalLimit.RateCount == 0 || grp.JournalLimit.RatePeriod == 0 {
+	if !grp.JournalLimit.RateEnabled {
 		return ""
 	}
 	return fmt.Sprintf(`RateLimitIntervalSec=%dus

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -723,6 +723,110 @@ TasksAccounting=true
 	c.Assert(svcFile, testutil.FileEquals, svcContent)
 }
 
+func (s *servicesTestSuite) TestEnsureSnapServicesWithJournalQuotaRateAsZero(c *C) {
+	// Ensure that the journald.conf file is correctly written
+	info := snaptest.MockSnap(c, packageHello, &snap.SideInfo{Revision: snap.R(12)})
+	svcFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-snap.svc1.service")
+
+	// set up arbitrary quotas for the group to test they get written correctly to the slice
+	resourceLimits := quota.NewResourcesBuilder().
+		WithJournalRate(0, 0).
+		Build()
+	grp, err := quota.NewGroup("foogroup", resourceLimits)
+	c.Assert(err, IsNil)
+
+	m := map[*snap.Info]*wrappers.SnapServiceOptions{
+		info: {QuotaGroup: grp},
+	}
+
+	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
+	svcContent := fmt.Sprintf(`[Unit]
+# Auto-generated, DO NOT EDIT
+Description=Service for snap application hello-snap.svc1
+Requires=%[1]s
+Wants=network.target
+After=%[1]s network.target snapd.apparmor.service
+X-Snappy=yes
+
+[Service]
+EnvironmentFile=-/etc/environment
+ExecStart=/usr/bin/snap run hello-snap.svc1
+SyslogIdentifier=hello-snap.svc1
+Restart=on-failure
+WorkingDirectory=%[2]s/var/snap/hello-snap/12
+ExecStop=/usr/bin/snap run --command=stop hello-snap.svc1
+ExecStopPost=/usr/bin/snap run --command=post-stop hello-snap.svc1
+TimeoutStopSec=30
+Type=forking
+Slice=snap.foogroup.slice
+LogNamespace=snap-foogroup
+
+[Install]
+WantedBy=multi-user.target
+`,
+		systemd.EscapeUnitNamePath(dir),
+		dirs.GlobalRootDir,
+	)
+	jconfTempl := `# Journald configuration for snap quota group %s
+[Journal]
+RateLimitIntervalSec=0us
+RateLimitBurst=0
+`
+
+	sliceTempl := `[Unit]
+Description=Slice for snap quota group %s
+Before=slices.target
+X-Snappy=yes
+
+[Slice]
+# Always enable cpu accounting, so the following cpu quota options have an effect
+CPUAccounting=true
+
+# Always enable memory accounting otherwise the MemoryMax setting does nothing.
+MemoryAccounting=true
+# Always enable task accounting in order to be able to count the processes/
+# threads, etc for a slice
+TasksAccounting=true
+`
+
+	jconfContent := fmt.Sprintf(jconfTempl, grp.Name)
+	sliceContent := fmt.Sprintf(sliceTempl, grp.Name)
+
+	exp := []changesObservation{
+		{
+			grp:      grp,
+			unitType: "journald",
+			new:      jconfContent,
+			old:      "",
+			name:     "foogroup",
+		},
+		{
+			snapName: "hello-snap",
+			unitType: "service",
+			name:     "svc1",
+			old:      "",
+			new:      svcContent,
+		},
+		{
+			grp:      grp,
+			unitType: "slice",
+			new:      sliceContent,
+			old:      "",
+			name:     "foogroup",
+		},
+	}
+	r, observe := expChangeObserver(c, exp)
+	defer r()
+
+	err = wrappers.EnsureSnapServices(m, nil, observe, progress.Null)
+	c.Assert(err, IsNil)
+	c.Check(s.sysdLog, DeepEquals, [][]string{
+		{"daemon-reload"},
+	})
+
+	c.Assert(svcFile, testutil.FileEquals, svcContent)
+}
+
 type changesObservation struct {
 	snapName string
 	grp      *quota.Group


### PR DESCRIPTION
Allow using 0 values for the journal rate to override the system default values, which are not set to unlimited.