### PR TITLE
tests: skip interfaces-udisks2 in fedora

### DIFF
--- a/tests/main/interfaces-udisks2/task.yaml
+++ b/tests/main/interfaces-udisks2/task.yaml
@@ -8,7 +8,7 @@ details: |
 #   Object /org/freedesktop/UDisks2/block_devices/loop200 is not a mountable filesystem.
 # 2021-11-02: disabled ubuntu-18.04-32 because it keeps failing when trying
 #             to create/use /dev/loop200
-systems: [-ubuntu-core-*, -arch-linux-*, -centos-9-*, -ubuntu-18.04-32]
+systems: [-ubuntu-core-*, -arch-linux-*, -centos-9-*, -fedora-*, -ubuntu-18.04-32]
 
 environment:
     FS_PATH: "$(pwd)/dev0-fake0"


### PR DESCRIPTION
This is because the error "Object
/org/freedesktop/UDisks2/block_devices/loop200 is not a mountable
filesystem." is being reproduces also in fedora 35 and 36

In the meantime, I am trying to fix the error so it is possible to run this test in centos, arch and fedora again.