### PR TITLE
daemon: implement stub `"action": "install"`

### DIFF
--- a/client/systems.go
+++ b/client/systems.go
@@ -147,7 +147,7 @@ const (
 	InstallStepFinish                 InstallStep = "finish"
 )
 
-type SystemActionInstall struct {
+type systemActionInstall struct {
 	// Step is the install step, either "setup-storage-encryption"
 	// or "finish".
 	Step InstallStep `json:"step,omitempty"`
@@ -156,16 +156,15 @@ type SystemActionInstall struct {
 	OnVolumes map[string][]gadget.Volume `json:"on-volumes,omitempty"`
 }
 
-// XXX: or SystemInstallStep() ?
 // InstallSystem will perform the given install step for the given volumes
 func (client *Client) InstallSystem(systemLabel string, step InstallStep, volumes map[string][]gadget.Volume) (changeID string, err error) {
 	// verification is done by the backend
 	req := struct {
 		Action string `json:"action"`
-		*SystemActionInstall
+		*systemActionInstall
 	}{
 		Action: "install",
-		SystemActionInstall: &SystemActionInstall{
+		systemActionInstall: &systemActionInstall{
 			Step:      step,
 			OnVolumes: volumes,
 		},

--- a/client/systems.go
+++ b/client/systems.go
@@ -183,6 +183,10 @@ type InstallSystemOptions struct {
 
 // InstallSystem will perform the given install step for the given volumes
 func (client *Client) InstallSystem(systemLabel string, opts *InstallSystemOptions) (changeID string, err error) {
+	if systemLabel == "" {
+		return "", fmt.Errorf("cannot install with an empty system label")
+	}
+
 	// verification is done by the backend
 	req := struct {
 		Action string `json:"action"`
@@ -198,10 +202,7 @@ func (client *Client) InstallSystem(systemLabel string, opts *InstallSystemOptio
 	}
 	chgID, err := client.doAsync("POST", "/v2/systems/"+systemLabel, nil, nil, &body)
 	if err != nil {
-		if systemLabel != "" {
-			return "", xerrors.Errorf("cannot request system install for %q: %v", systemLabel, err)
-		}
-		return "", xerrors.Errorf("cannot request system install: %v", err)
+		return "", xerrors.Errorf("cannot request system install for %q: %v", systemLabel, err)
 	}
 	return chgID, nil
 }

--- a/client/systems.go
+++ b/client/systems.go
@@ -147,7 +147,7 @@ const (
 	InstallStepFinish                 InstallStep = "finish"
 )
 
-type systemActionInstall struct {
+type SystemActionInstall struct {
 	// Step is the install step, either "setup-storage-encryption"
 	// or "finish".
 	Step InstallStep `json:"step,omitempty"`
@@ -166,10 +166,10 @@ func (client *Client) InstallSystem(systemLabel string, opts *InstallSystemOptio
 	// verification is done by the backend
 	req := struct {
 		Action string `json:"action"`
-		*systemActionInstall
+		*SystemActionInstall
 	}{
 		Action: "install",
-		systemActionInstall: &systemActionInstall{
+		SystemActionInstall: &SystemActionInstall{
 			Step:      opts.Step,
 			OnVolumes: opts.Volumes,
 		},

--- a/client/systems.go
+++ b/client/systems.go
@@ -156,8 +156,13 @@ type systemActionInstall struct {
 	OnVolumes map[string][]gadget.Volume `json:"on-volumes,omitempty"`
 }
 
+type InstallSystemOptions struct {
+	Step    InstallStep
+	Volumes map[string][]gadget.Volume
+}
+
 // InstallSystem will perform the given install step for the given volumes
-func (client *Client) InstallSystem(systemLabel string, step InstallStep, volumes map[string][]gadget.Volume) (changeID string, err error) {
+func (client *Client) InstallSystem(systemLabel string, opts *InstallSystemOptions) (changeID string, err error) {
 	// verification is done by the backend
 	req := struct {
 		Action string `json:"action"`
@@ -165,8 +170,8 @@ func (client *Client) InstallSystem(systemLabel string, step InstallStep, volume
 	}{
 		Action: "install",
 		systemActionInstall: &systemActionInstall{
-			Step:      step,
-			OnVolumes: volumes,
+			Step:      opts.Step,
+			OnVolumes: opts.Volumes,
 		},
 	}
 

--- a/client/systems.go
+++ b/client/systems.go
@@ -164,7 +164,6 @@ func (client *Client) SystemDetails(seedLabel string) (*SystemDetails, error) {
 	return &rsp, nil
 }
 
-
 type InstallStep string
 
 const (
@@ -172,18 +171,14 @@ const (
 	InstallStepFinish                 InstallStep = "finish"
 )
 
-type SystemActionInstall struct {
+type InstallSystemOptions struct {
 	// Step is the install step, either "setup-storage-encryption"
 	// or "finish".
 	Step InstallStep `json:"step,omitempty"`
+
 	// OnVolumes is the volume description of the volumes that the
 	// given step should operate on.
 	OnVolumes map[string][]gadget.Volume `json:"on-volumes,omitempty"`
-}
-
-type InstallSystemOptions struct {
-	Step    InstallStep
-	Volumes map[string][]gadget.Volume
 }
 
 // InstallSystem will perform the given install step for the given volumes
@@ -191,13 +186,10 @@ func (client *Client) InstallSystem(systemLabel string, opts *InstallSystemOptio
 	// verification is done by the backend
 	req := struct {
 		Action string `json:"action"`
-		*SystemActionInstall
+		*InstallSystemOptions
 	}{
-		Action: "install",
-		SystemActionInstall: &SystemActionInstall{
-			Step:      opts.Step,
-			OnVolumes: opts.Volumes,
-		},
+		Action:               "install",
+		InstallSystemOptions: opts,
 	}
 
 	var body bytes.Buffer

--- a/client/systems_test.go
+++ b/client/systems_test.go
@@ -312,6 +312,18 @@ func (cs *clientSuite) TestRequestSystemInstallErrorNoSystem(c *check.C) {
 	c.Check(cs.req.URL.Path, check.Equals, "/v2/systems/1234")
 }
 
+func (cs *clientSuite) TestRequestSystemInstallEmptySystemLabel(c *check.C) {
+	cs.rsp = `{
+	    "type": "error",
+	    "status-code": 500,
+	    "result": {"message": "failed"}
+	}`
+	_, err := cs.cli.InstallSystem("", nil)
+	c.Assert(err, check.ErrorMatches, `cannot install with an empty system label`)
+	// no request was performed
+	c.Check(cs.req, check.IsNil)
+}
+
 func (cs *clientSuite) TestRequestSystemInstallHappy(c *check.C) {
 	cs.status = 202
 	cs.rsp = `{

--- a/client/systems_test.go
+++ b/client/systems_test.go
@@ -227,15 +227,19 @@ func (cs *clientSuite) TestRequestSystemInstallHappy(c *check.C) {
 	vols := map[string][]gadget.Volume{
 		"pc": {
 			{
-				Schema: "dos",
+				Schema:     "dos",
 				Bootloader: "mbr",
-				ID: "0c",
+				ID:         "0c",
 				// Note that name is not exported as json
 				Name: "pc",
 			},
 		},
 	}
-	chgID, err := cs.cli.InstallSystem("1234", client.InstallStepFinish, vols)
+	opts := &client.InstallSystemOptions{
+		Step:    client.InstallStepFinish,
+		Volumes: vols,
+	}
+	chgID, err := cs.cli.InstallSystem("1234", opts)
 	c.Assert(err, check.IsNil)
 	c.Assert(chgID, check.Equals, "42")
 	c.Check(cs.req.Method, check.Equals, "POST")
@@ -268,7 +272,10 @@ func (cs *clientSuite) TestRequestSystemInstallErrorNoSystem(c *check.C) {
 	    "status-code": 500,
 	    "result": {"message": "failed"}
 	}`
-	_, err := cs.cli.InstallSystem("1234", client.InstallStepFinish, nil)
+	opts := &client.InstallSystemOptions{
+		Step: client.InstallStepFinish,
+	}
+	_, err := cs.cli.InstallSystem("1234", opts)
 	c.Assert(err, check.ErrorMatches, `cannot request system install for "1234": failed`)
 	c.Check(cs.req.Method, check.Equals, "POST")
 	c.Check(cs.req.URL.Path, check.Equals, "/v2/systems/1234")

--- a/client/systems_test.go
+++ b/client/systems_test.go
@@ -331,8 +331,8 @@ func (cs *clientSuite) TestRequestSystemInstallHappy(c *check.C) {
 		},
 	}
 	opts := &client.InstallSystemOptions{
-		Step:    client.InstallStepFinish,
-		Volumes: vols,
+		Step:      client.InstallStepFinish,
+		OnVolumes: vols,
 	}
 	chgID, err := cs.cli.InstallSystem("1234", opts)
 	c.Assert(err, check.IsNil)

--- a/client/systems_test.go
+++ b/client/systems_test.go
@@ -226,7 +226,13 @@ func (cs *clientSuite) TestRequestSystemInstallHappy(c *check.C) {
 	}`
 	vols := map[string][]gadget.Volume{
 		"pc": {
-			{Schema: "dos", Bootloader: "mbr", ID: "0c", Name: "pc"},
+			{
+				Schema: "dos",
+				Bootloader: "mbr",
+				ID: "0c",
+				// Note that name is not exported as json
+				Name: "pc",
+			},
 		},
 	}
 	chgID, err := cs.cli.InstallSystem("1234", client.InstallStepFinish, vols)
@@ -249,7 +255,6 @@ func (cs *clientSuite) TestRequestSystemInstallHappy(c *check.C) {
 					"schema":     "dos",
 					"bootloader": "mbr",
 					"id":         "0c",
-					"name":       "pc",
 					"structure":  nil,
 				},
 			},

--- a/daemon/api_systems.go
+++ b/daemon/api_systems.go
@@ -144,7 +144,7 @@ type systemActionRequest struct {
 	Action string `json:"action"`
 
 	client.SystemAction
-	client.SystemActionInstall
+	client.InstallSystemOptions
 }
 
 func postSystemsAction(c *Command, r *http.Request, user *auth.UserState) Response {

--- a/daemon/api_systems.go
+++ b/daemon/api_systems.go
@@ -216,5 +216,6 @@ func postSystemActionDo(c *Command, systemLabel string, req *systemActionRequest
 
 func postSystemActionInstall(c *Command, systemLabel string, req *systemActionRequest) Response {
 	// TODO: call new devicestate.InstallStep()
+	// TODO2: ensure devicestate.InstallStep() checks that systemLabel is not empty
 	return BadRequest("system action install is not implemented yet")
 }

--- a/daemon/api_systems_test.go
+++ b/daemon/api_systems_test.go
@@ -52,6 +52,7 @@ import (
 	"github.com/snapcore/snapd/seed/seedtest"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
 )
 
 var _ = check.Suite(&systemsSuite{})
@@ -973,4 +974,27 @@ func (s *systemsSuite) TestSystemsGetSpecificLabelIntegration(c *check.C) {
 			},
 		},
 	})
+}
+
+// TODO: update once "action":"install" is actually doing something :)
+func (s *systemsSuite) TestSystemInstallActionNotImplementedYet(c *check.C) {
+	s.daemon(c)
+
+	body := map[string]string{
+		"action": "install",
+		"step":   "finish",
+	}
+	b, err := json.Marshal(body)
+	c.Assert(err, check.IsNil)
+	buf := bytes.NewBuffer(b)
+	req, err := http.NewRequest("POST", "/v2/systems/20191119", buf)
+	c.Assert(err, check.IsNil)
+
+	// as root
+	s.asRootAuth(req)
+	rec := httptest.NewRecorder()
+	s.serveHTTP(c, rec, req)
+	c.Check(rec.Code, check.Equals, 400)
+	// TODO: update once it actually does something
+	c.Check(rec.Body.String(), testutil.Contains, "system action install is not implemented yet")
 }


### PR DESCRIPTION
This implements a stub `"action": "install"` for `POST /systems/<label>` and also adds the corresponding client interface code.


