### PR TITLE
asserts: add keyword 'user-presence' keyword in system-user assertion (auto-removal 3/n)

### DIFF
--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -201,7 +201,8 @@ func init() {
 	maxSupportedFormat[SnapDeclarationType.Name] = 5
 
 	// 1: support to limit to device serials
-	maxSupportedFormat[SystemUserType.Name] = 1
+	// 2: support for user-presence constraint
+	maxSupportedFormat[SystemUserType.Name] = 2
 
 	for _, at := range typeRegistry {
 		at.validate()

--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -82,7 +82,7 @@ func (as *assertsSuite) TestMaxSupportedFormats(c *C) {
 	systemUserMaxFormat := asserts.SystemUserType.MaxSupportedFormat()
 	// validity
 	c.Check(snapDeclMaxFormat >= 4, Equals, true)
-	c.Check(systemUserMaxFormat >= 1, Equals, true)
+	c.Check(systemUserMaxFormat >= 2, Equals, true)
 	c.Check(asserts.MaxSupportedFormats(1), DeepEquals, map[string]int{
 		"snap-declaration": snapDeclMaxFormat,
 		"system-user":      systemUserMaxFormat,

--- a/asserts/header_checks.go
+++ b/asserts/header_checks.go
@@ -314,19 +314,3 @@ func checkMapWhat(m map[string]interface{}, name, what string) (map[string]inter
 	}
 	return mv, nil
 }
-
-func checkDuration(headers map[string]interface{}, name string) (time.Duration, error) {
-	return checkDurationWhat(headers, name, "header")
-}
-
-func checkDurationWhat(m map[string]interface{}, name, what string) (time.Duration, error) {
-	value, ok := m[name]
-	if !ok {
-		return 0, nil
-	}
-	mv, ok := value.(string)
-	if !ok {
-		return 0, fmt.Errorf("%q %s must be a string", name, what)
-	}
-	return time.ParseDuration(mv)
-}

--- a/asserts/header_checks.go
+++ b/asserts/header_checks.go
@@ -314,3 +314,19 @@ func checkMapWhat(m map[string]interface{}, name, what string) (map[string]inter
 	}
 	return mv, nil
 }
+
+func checkDuration(headers map[string]interface{}, name string) (time.Duration, error) {
+	return checkDurationWhat(headers, name, "header")
+}
+
+func checkDurationWhat(m map[string]interface{}, name, what string) (time.Duration, error) {
+	value, ok := m[name]
+	if !ok {
+		return 0, nil
+	}
+	mv, ok := value.(string)
+	if !ok {
+		return 0, fmt.Errorf("%q %s must be a string", name, what)
+	}
+	return time.ParseDuration(mv)
+}

--- a/asserts/system_user.go
+++ b/asserts/system_user.go
@@ -115,8 +115,9 @@ func (su *SystemUser) Until() time.Time {
 // returned.
 //
 // If a duration is provided, then the timestamp returned will be the absolute
-// time as a result of from + duration.  It's possible to provide the start
-// point in time for easier testing, and is only needed when a duration was provided.
+// time as a result of from + duration.
+// It is necessary to provide the time of user creation as the assertion has
+// no concept of when the assertion is actually used.
 func (su *SystemUser) Expiration(from time.Time) time.Time {
 	// In this function we can make the following assumption;
 	// su.expiration is either empty, 'until-expiration' or a valid
@@ -128,7 +129,8 @@ func (su *SystemUser) Expiration(from time.Time) time.Time {
 		return su.until
 	}
 	if d, err := time.ParseDuration(su.expiration); err == nil {
-		// err being non-nil should not happen
+		// an error should not happen, at this point the
+		// duration in su.expiration have already been verified.
 		return from.Add(d)
 	}
 	return time.Time{}
@@ -252,7 +254,7 @@ func parseSystemUserExpiration(headers map[string]interface{}, until time.Time) 
 
 	str, ok := value.(string)
 	if !ok {
-		return "", fmt.Errorf("cannot parse value 'user-valid-for': not a string")
+		return "", fmt.Errorf("cannot parse 'user-valid-for': not a string")
 	}
 
 	if strings.ToLower(str) == "until-expiration" {
@@ -263,7 +265,7 @@ func parseSystemUserExpiration(headers map[string]interface{}, until time.Time) 
 	// be a duration.
 	_, err := checkDuration(headers, "user-valid-for")
 	if err != nil {
-		return "", fmt.Errorf("cannot parse value 'user-valid-for': %q is invalid", str)
+		return "", fmt.Errorf("cannot parse 'user-valid-for': %q is invalid", str)
 	}
 	return str, nil
 }

--- a/asserts/system_user.go
+++ b/asserts/system_user.go
@@ -109,7 +109,7 @@ func (su *SystemUser) Until() time.Time {
 
 // UserExpiration returns the expiration or validity duration of the user created.
 //
-// If no expiration was specified, this will return an empty time.Time structure.
+// If no expiration was specified, this will return an zero time.Time structure.
 //
 // If expiration was set to 'until-expiration' then the .Until() time will be
 // returned.
@@ -242,7 +242,7 @@ func checkSystemUserPresence(assert assertionBase) (string, error) {
 	if str == "until-expiration" {
 		return str, nil
 	}
-	return "", fmt.Errorf("cannot parse 'user-presence': %q is invalid", str)
+	return "", fmt.Errorf(`invalid "user-presence" header, only explicit valid value is "until-expiration": %q`, str)
 }
 
 func assembleSystemUser(assert assertionBase) (Assertion, error) {

--- a/asserts/system_user.go
+++ b/asserts/system_user.go
@@ -114,11 +114,6 @@ func (su *SystemUser) Until() time.Time {
 // If expiration was set to 'until-expiration' then the .Until() time will be
 // returned.
 func (su *SystemUser) UserExpiration() time.Time {
-	// In this function we can make the following assumption;
-	// su.expiration is either empty or set to'until-expiration'
-	if su.expiration == "" {
-		return time.Time{}
-	}
 	if su.expiration == "until-expiration" {
 		return su.until
 	}
@@ -236,15 +231,15 @@ func checkHashedPassword(headers map[string]interface{}, name string) (string, e
 }
 
 func checkSystemUserExpiration(headers map[string]interface{}) (string, error) {
-	str, err := checkOptionalString(headers, "user-valid-for")
-	if err != nil {
+	str, err := checkOptionalString(headers, "user-presence")
+	if err != nil || str == "" {
 		return "", err
 	}
 
 	if str == "until-expiration" {
 		return str, nil
 	}
-	return "", fmt.Errorf("cannot parse 'user-valid-for': %q is invalid", str)
+	return "", fmt.Errorf("cannot parse 'user-presence': %q is invalid", str)
 }
 
 func assembleSystemUser(assert assertionBase) (Assertion, error) {

--- a/asserts/system_user.go
+++ b/asserts/system_user.go
@@ -239,10 +239,10 @@ func checkSystemUserPresence(assert assertionBase) (string, error) {
 		return "", fmt.Errorf(`the "user-presence" header is only supported for format 2 or greater`)
 	}
 
-	if str == "until-expiration" {
-		return str, nil
+	if str != "until-expiration" {
+		return "", fmt.Errorf(`invalid "user-presence" header, only explicit valid value is "until-expiration": %q`, str)
 	}
-	return "", fmt.Errorf(`invalid "user-presence" header, only explicit valid value is "until-expiration": %q`, str)
+	return str, nil
 }
 
 func assembleSystemUser(assert assertionBase) (Assertion, error) {

--- a/asserts/system_user_test.go
+++ b/asserts/system_user_test.go
@@ -302,7 +302,7 @@ func (s *systemUserSuite) TestUserValidForDuration(c *C) {
 func (s *systemUserSuite) TestUserValidForInvalidValue(c *C) {
 	s.systemUserStr = strings.Replace(s.systemUserStr, s.userValidForLine, "user-valid-for: tomorrow\n", 1)
 	_, err := asserts.Decode([]byte(s.systemUserStr))
-	c.Assert(err, ErrorMatches, `assertion system-user: cannot parse value 'user-valid-for': "tomorrow" is invalid`)
+	c.Assert(err, ErrorMatches, `assertion system-user: cannot parse 'user-valid-for': "tomorrow" is invalid`)
 }
 
 func (s *systemUserSuite) TestUserValidForMissing(c *C) {

--- a/asserts/system_user_test.go
+++ b/asserts/system_user_test.go
@@ -97,6 +97,7 @@ func (s *systemUserSuite) TestDecodeOK(c *C) {
 	c.Check(systemUser.SSHKeys(), DeepEquals, []string{"ssh-rsa AAAABcdefg"})
 	c.Check(systemUser.Since().Equal(s.since), Equals, true)
 	c.Check(systemUser.Until().Equal(s.until), Equals, true)
+	c.Check(systemUser.UserExpiration().Equal(s.until), Equals, true)
 }
 
 func (s *systemUserSuite) TestDecodePasswd(c *C) {
@@ -273,12 +274,4 @@ func (s *systemUserSuite) TestSuggestedFormat(c *C) {
 	fmtnum, err = asserts.SuggestFormat(asserts.SystemUserType, headers, nil)
 	c.Assert(err, IsNil)
 	c.Check(fmtnum, Equals, 1)
-}
-
-func (s *systemUserSuite) TestUserValidForExpiration(c *C) {
-	a, err := asserts.Decode([]byte(s.systemUserStr))
-	c.Assert(err, IsNil)
-	c.Check(a.Type(), Equals, asserts.SystemUserType)
-	su := a.(*asserts.SystemUser)
-	c.Check(su.UserExpiration(), Equals, s.until)
 }

--- a/asserts/system_user_test.go
+++ b/asserts/system_user_test.go
@@ -97,6 +97,7 @@ func (s *systemUserSuite) TestDecodeOK(c *C) {
 	c.Check(systemUser.SSHKeys(), DeepEquals, []string{"ssh-rsa AAAABcdefg"})
 	c.Check(systemUser.Since().Equal(s.since), Equals, true)
 	c.Check(systemUser.Until().Equal(s.until), Equals, true)
+	c.Check(systemUser.UserExpiration().IsZero(), Equals, true)
 }
 
 func (s *systemUserSuite) TestDecodePasswd(c *C) {

--- a/asserts/system_user_test.go
+++ b/asserts/system_user_test.go
@@ -264,8 +264,8 @@ func (s *systemUserSuite) TestDecodeInvalidFormat2UserPresence(c *C) {
 	s.systemUserStr = strings.Replace(s.systemUserStr, s.formatLine, "format: 2\n", 1)
 
 	invalidTests := []struct{ original, invalid, expectedErr string }{
-		{s.userPresenceLine, "user-presence: tomorrow\n", `cannot parse 'user-presence': "tomorrow" is invalid`},
-		{s.userPresenceLine, "user-presence: 0\n", `cannot parse 'user-presence': "0" is invalid`},
+		{s.userPresenceLine, "user-presence: tomorrow\n", `invalid "user-presence" header, only explicit valid value is "until-expiration": "tomorrow"`},
+		{s.userPresenceLine, "user-presence: 0\n", `invalid "user-presence" header, only explicit valid value is "until-expiration": "0"`},
 	}
 	for _, test := range invalidTests {
 		invalid := strings.Replace(s.systemUserStr, test.original, test.invalid, 1)


### PR DESCRIPTION
This PR adds a new member 'user-presence' which can (for now atleast) be set to 'until-expiration', which means that the user will be auto-removed once the assertion is longer valid.