### PR TITLE
i/b/system-observe: allow reading processes security label

### DIFF
--- a/interfaces/builtin/system_observe.go
+++ b/interfaces/builtin/system_observe.go
@@ -87,6 +87,9 @@ ptrace (read),
 @{PROC}/*/{,task/*/}status r,
 @{PROC}/*/{,task/*/}wchan r,
 
+# Allow reading processes security label
+@{PROC}/*/{,task/*/}attr/{,apparmor/}current r,
+
 # Allow discovering the os-release of the host
 /var/lib/snapd/hostfs/etc/os-release rk,
 /var/lib/snapd/hostfs/usr/lib/os-release rk,


### PR DESCRIPTION
Some programs might want to show security label information. For
instance, netstat when using --context or --program options.
