### PR TITLE
many: support '--purge' when removing multiple snaps

### DIFF
--- a/client/snap_op.go
+++ b/client/snap_op.go
@@ -119,6 +119,7 @@ type multiActionData struct {
 	Users         []string        `json:"users,omitempty"`
 	Transaction   TransactionType `json:"transaction,omitempty"`
 	IgnoreRunning bool            `json:"ignore-running,omitempty"`
+	Purge         bool            `json:"purge,omitempty"`
 }
 
 // Install adds the snap with the given name from the given channel (or
@@ -225,6 +226,7 @@ func (client *Client) doMultiSnapActionFull(actionName string, snaps []string, o
 		action.Users = options.Users
 		action.Transaction = options.Transaction
 		action.IgnoreRunning = options.IgnoreRunning
+		action.Purge = options.Purge
 	}
 
 	data, err := json.Marshal(&action)

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -210,10 +210,10 @@ func (x *cmdRemove) Execute([]string) error {
 		return x.removeOne(opts)
 	}
 
-	if x.Purge || x.Revision != "" {
-		return errors.New(i18n.G("a single snap name is needed to specify options"))
+	if x.Revision != "" {
+		return errors.New(i18n.G("cannot use --revision with multiple snap names"))
 	}
-	return x.removeMany(nil)
+	return x.removeMany(opts)
 }
 
 type channelMixin struct {

--- a/daemon/api_snaps.go
+++ b/daemon/api_snaps.go
@@ -701,7 +701,8 @@ func snapEnforceValidationSets(inst *snapInstruction, st *state.State) (*snapIns
 }
 
 func snapRemoveMany(inst *snapInstruction, st *state.State) (*snapInstructionResult, error) {
-	removed, tasksets, err := snapstateRemoveMany(st, inst.Snaps)
+	flags := &snapstate.RemoveFlags{Purge: inst.Purge}
+	removed, tasksets, err := snapstateRemoveMany(st, inst.Snaps, flags)
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -198,7 +198,7 @@ func MockSnapstateUpdateMany(mock func(context.Context, *state.State, []string, 
 	}
 }
 
-func MockSnapstateRemoveMany(mock func(*state.State, []string) ([]string, []*state.TaskSet, error)) (restore func()) {
+func MockSnapstateRemoveMany(mock func(*state.State, []string, *snapstate.RemoveFlags) ([]string, []*state.TaskSet, error)) (restore func()) {
 	oldSnapstateRemoveMany := snapstateRemoveMany
 	snapstateRemoveMany = mock
 	return func() {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -3142,7 +3142,10 @@ func removeInactiveRevision(st *state.State, name, snapID string, revision snap.
 
 // RemoveMany removes everything from the given list of names.
 // Note that the state must be locked by the caller.
-func RemoveMany(st *state.State, names []string) ([]string, []*state.TaskSet, error) {
+func RemoveMany(st *state.State, names []string, flags *RemoveFlags) ([]string, []*state.TaskSet, error) {
+	if flags == nil {
+		flags = &RemoveFlags{}
+	}
 	names = strutil.Deduplicate(names)
 
 	if err := validateSnapNames(names); err != nil {
@@ -3156,7 +3159,7 @@ func RemoveMany(st *state.State, names []string) ([]string, []*state.TaskSet, er
 	path := dirs.SnapdStateDir(dirs.GlobalRootDir)
 
 	for _, name := range names {
-		ts, snapshotSize, err := removeTasks(st, name, snap.R(0), nil)
+		ts, snapshotSize, err := removeTasks(st, name, snap.R(0), flags)
 		// FIXME: is this expected behavior?
 		if _, ok := err.(*snap.NotInstalledError); ok {
 			continue


### PR DESCRIPTION
The `--purge` flag prevents snapd from taking a snapshot when removing a snap but it couldn't with more than one snap. This PR adds support for `--purge` when removing multiple snaps.