### PR TITLE
sandbox/cgroup: don't check V1 cgroup if V2 is active

### DIFF
--- a/sandbox/cgroup/cgroup.go
+++ b/sandbox/cgroup/cgroup.go
@@ -259,10 +259,12 @@ func ProcessPathInTrackingCgroup(pid int) (string, error) {
 	// 1:name=systemd:/user.slice/user-1000.slice/user@1000.service/tmux.slice/tmux@default.service
 	// 0::/user.slice/user-1000.slice/user@1000.service/tmux.slice/tmux@default.service
 
-	// It seems cgroupv2 can be "dangling" after being mounted and unmounted.
-	// It will forever stay present in the kernel but will not be present in
-	// the file-system. As such, allow v2 to register only if it is really
-	// mounted on the system.
+	// The cgroup hierarchy (both v1 and v2) can be "dangling" after being
+	// mounted and unmounted.
+	// It will stay present in the kernel (and therefore its paths may appear
+	// in the /proc/<pid>/cgroup file) as long as there are some processes in
+	// it, but it will not be present in the file-system. As such, allow v2 to
+	// register only if it is really mounted on the system.
 	var useV2 bool
 	if ver, err := Version(); err != nil {
 		return "", err

--- a/sandbox/cgroup/cgroup.go
+++ b/sandbox/cgroup/cgroup.go
@@ -259,12 +259,12 @@ func ProcessPathInTrackingCgroup(pid int) (string, error) {
 	// 1:name=systemd:/user.slice/user-1000.slice/user@1000.service/tmux.slice/tmux@default.service
 	// 0::/user.slice/user-1000.slice/user@1000.service/tmux.slice/tmux@default.service
 
-	// The cgroup hierarchy (both v1 and v2) can be "dangling" after being
+	// A cgroup hierarchy (both v1 and v2) can be "dangling" after being
 	// mounted and unmounted.
 	// It will stay present in the kernel (and therefore its paths may appear
 	// in the /proc/<pid>/cgroup file) as long as there are some processes in
-	// it, but it will not be present in the file-system. As such, allow v2 to
-	// register only if it is really mounted on the system.
+	// it, but it will not be present in the file-system. As such, use v2
+	// if it is really mounted on the filesystem, otherwise try v1.
 	var useV2 bool
 	if ver, err := Version(); err != nil {
 		return "", err

--- a/sandbox/cgroup/cgroup.go
+++ b/sandbox/cgroup/cgroup.go
@@ -263,18 +263,21 @@ func ProcessPathInTrackingCgroup(pid int) (string, error) {
 	// It will forever stay present in the kernel but will not be present in
 	// the file-system. As such, allow v2 to register only if it is really
 	// mounted on the system.
-	var allowV2 bool
+	var useV2 bool
 	if ver, err := Version(); err != nil {
 		return "", err
 	} else if ver == V2 {
-		allowV2 = true
+		useV2 = true
 	}
 	entry, err := scanProcCgroupFile(fname, func(e *procInfoEntry) bool {
-		if e.CgroupID == 0 && allowV2 {
-			return true
-		}
-		if len(e.Controllers) == 1 && e.Controllers[0] == "name=systemd" {
-			return true
+		if useV2 {
+			if e.CgroupID == 0 {
+				return true
+			}
+		} else {
+			if len(e.Controllers) == 1 && e.Controllers[0] == "name=systemd" {
+				return true
+			}
 		}
 		return false
 	})

--- a/sandbox/cgroup/cgroup_test.go
+++ b/sandbox/cgroup/cgroup_test.go
@@ -251,30 +251,38 @@ func (s *cgroupSuite) TestProcessPathInTrackingCgroup(c *C) {
 	defer dirs.SetRootDir(dirs.GlobalRootDir)
 	dirs.SetRootDir(d)
 
-	restore := cgroup.MockVersion(cgroup.V2, nil)
-	defer restore()
-
 	f := filepath.Join(d, "proc", "1234", "cgroup")
 	c.Assert(os.MkdirAll(filepath.Dir(f), 0755), IsNil)
 
-	for _, scenario := range []struct{ cgroups, path, errMsg string }{
-		{cgroups: "", path: "", errMsg: "cannot find tracking cgroup"},
-		{cgroups: noise + "", path: "", errMsg: "cannot find tracking cgroup"},
-		{cgroups: noise + "0::/foo", path: "/foo"},
-		{cgroups: noise + "1:name=systemd:/bar", path: "/bar"},
+	for _, scenario := range []struct {
+		cgVersion             int
+		cgroups, path, errMsg string
+	}{
+		{cgVersion: cgroup.V2, cgroups: "", path: "", errMsg: "cannot find tracking cgroup"},
+		{cgVersion: cgroup.V2, cgroups: noise + "", path: "", errMsg: "cannot find tracking cgroup"},
+		{cgVersion: cgroup.V2, cgroups: noise + "0::/foo", path: "/foo"},
+		{cgVersion: cgroup.V2, cgroups: noise + "1:name=systemd:/bar", errMsg: "cannot find tracking cgroup"},
+		// In only V1 is mounted, then the same configuration works
+		{cgVersion: cgroup.V1, cgroups: noise + "1:name=systemd:/bar", path: "/bar"},
 		// First match wins (normally they are in sync).
-		{cgroups: noise + "1:name=systemd:/bar\n0::/foo", path: "/bar"},
-		{cgroups: "0::/tricky:path", path: "/tricky:path"},
-		{cgroups: "1:ctrl" /* no path */, errMsg: `cannot parse proc cgroup entry ".*": expected three fields`},
-		{cgroups: "potato:foo:/bar" /* bad ID number */, errMsg: `cannot parse proc cgroup entry ".*": cannot parse cgroup id "potato"`},
+		{cgVersion: cgroup.V1, cgroups: noise + "1:name=systemd:/bar\n0::/foo", path: "/bar"},
+		{cgVersion: cgroup.V2, cgroups: noise + "1:name=systemd:/bar\n0::/foo", path: "/foo"},
+		{cgVersion: cgroup.V2, cgroups: "0::/tricky:path", path: "/tricky:path"},
+		{cgVersion: cgroup.V2, cgroups: "1:ctrl" /* no path */, errMsg: `cannot parse proc cgroup entry ".*": expected three fields`},
+		{cgVersion: cgroup.V2, cgroups: "potato:foo:/bar" /* bad ID number */, errMsg: `cannot parse proc cgroup entry ".*": cannot parse cgroup id "potato"`},
 	} {
+		restoreCGVersion := cgroup.MockVersion(scenario.cgVersion, nil)
+
 		c.Assert(ioutil.WriteFile(f, []byte(scenario.cgroups), 0644), IsNil)
 		path, err := cgroup.ProcessPathInTrackingCgroup(1234)
 		if scenario.errMsg != "" {
 			c.Assert(err, ErrorMatches, scenario.errMsg)
 		} else {
 			c.Assert(path, Equals, scenario.path)
+			c.Assert(err, IsNil)
 		}
+
+		restoreCGVersion()
 	}
 }
 

--- a/sandbox/cgroup/cgroup_test.go
+++ b/sandbox/cgroup/cgroup_test.go
@@ -262,7 +262,7 @@ func (s *cgroupSuite) TestProcessPathInTrackingCgroup(c *C) {
 		{cgVersion: cgroup.V2, cgroups: noise + "", path: "", errMsg: "cannot find tracking cgroup"},
 		{cgVersion: cgroup.V2, cgroups: noise + "0::/foo", path: "/foo"},
 		{cgVersion: cgroup.V2, cgroups: noise + "1:name=systemd:/bar", errMsg: "cannot find tracking cgroup"},
-		// In only V1 is mounted, then the same configuration works
+		// If only V1 is mounted, then the same configuration works
 		{cgVersion: cgroup.V1, cgroups: noise + "1:name=systemd:/bar", path: "/bar"},
 		// First match wins (normally they are in sync).
 		{cgVersion: cgroup.V1, cgroups: noise + "1:name=systemd:/bar\n0::/foo", path: "/bar"},

--- a/sandbox/cgroup/process_test.go
+++ b/sandbox/cgroup/process_test.go
@@ -64,6 +64,8 @@ func (s *cgroupSuite) TestV1SnapNameFromPidEmptyName(c *C) {
 }
 
 func (s *cgroupSuite) TestSnapNameFromPidTracking(c *C) {
+	restore := cgroup.MockVersion(cgroup.V1, nil)
+	defer restore()
 	pid := s.mockPidCgroup(c, "1:name=systemd:/user.slice/user-1000.slice/user@1000.service/apps.slice/snap.foo.bar.00000-1111-3333.service\n")
 	name, err := cgroup.SnapNameFromPid(pid)
 	c.Assert(err, IsNil)

--- a/tests/main/cgroup-devices-v2/task.yaml
+++ b/tests/main/cgroup-devices-v2/task.yaml
@@ -27,9 +27,27 @@ prepare: |
     fi
 
 restore: |
+    systemctl stop snap.test-snapd-service.test-snapd-service.service
+    rm -f /sys/fs/bpf/snap/snap_test-snapd-service_sh
     tests.session -u test restore
     if test -f enforcing.mode; then
         setenforce "$(cat enforcing.mode)"
+    fi
+
+debug: |
+    if test -f "cgroup_device.progs-1" -a -f "cgroup_device.progs-2"; then
+        echo "cgroup devices before:"
+        cat "cgroup_device.progs-1"
+        echo "cgroup devices after installation:"
+        cat "cgroup_device.progs-2"
+    fi
+    if test -f "cgroup_device.progs-3"; then
+        echo "cgroup devices after connecting the interface:"
+        cat "cgroup_device.progs-3"
+    fi
+    if test -f "cgroup_device.progs-4"; then
+        echo "cgroup devices after restarting the service:"
+        cat "cgroup_device.progs-4"
     fi
 
 execute: |


### PR DESCRIPTION
The cgroup V1 hierarchy behaves similarly to the V2 one when it is
unmounted: the hierarchy will be visible on the filesystem while there
is at least one process using it, but it will not appear as mounted in
/proc/mounts. Even more importantly, when systemd creates a transient
scope in such a situation, the cgroup V2 will be correctly reported in
`/proc/<self>/cgroup`, whereas the V1 group will be

    1:name=systemd:/

(that is, the cgroup path is incorrect). In such cases, depending on the
order in which the entries appear in the `/proc/<self>/cgroup` file, snapd
could incorrectly think that the process has been placed in the `/`
cgroup path.

To fix the above, we consider the V1 hierarchy only if the V2 one has
not been mounted: when the V2 hierarchy is mounted, we know that this is
what will be used by us and by systemd.

Issue raised in https://forum.snapcraft.io/t/snap-freezes-after-update-to-ubuntu-22-04/31413
