### PR TITLE
build-aux: move snapcraft branch to 2.57

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -30,7 +30,7 @@ parts:
     plugin: nil
     source-type: git
     source: https://git.launchpad.net/snapd
-    source-branch: release/2.56
+    source-branch: release/2.57
     build-snaps:
       - on riscv64: [go/1.16/stable]
       - else: [go/1.13/stable]


### PR DESCRIPTION
We need to move our riscv beta build to 2.57 as well