### PR TITLE
interfaces: login-session-control: add further D-Bus interfaces

### DIFF
--- a/interfaces/builtin/login_session_control.go
+++ b/interfaces/builtin/login_session_control.go
@@ -45,14 +45,12 @@ dbus (send,receive)
     bus=system
     path=/org/freedesktop/login1/seat/**
     interface=org.freedesktop.login1.Seat
-    member={ActiveSession,SwitchTo}
     peer=(label=unconfined),
 
 dbus (send,receive)
     bus=system
     path=/org/freedesktop/login1/session/**
     interface=org.freedesktop.login1.Session
-    member={TakeControl,TakeDevice,PauseDevice,PauseDeviceComplete,ResumeDevice,ReleaseDevice,Active,State,Lock,Unlock,Activate,ReleaseControl}
     peer=(label=unconfined),
 
 dbus (send,receive)

--- a/interfaces/builtin/login_session_control.go
+++ b/interfaces/builtin/login_session_control.go
@@ -59,7 +59,7 @@ dbus (send,receive)
     bus=system
     path=/org/freedesktop/login1
     interface=org.freedesktop.login1.Manager
-    member={GetSession,GetSeat}
+    member={ActivateSession,GetSession,GetSeat,KillSession,ListSessions,LockSession,TerminateSession,UnlockSession}
     peer=(label=unconfined),
 `
 

--- a/interfaces/builtin/login_session_control_test.go
+++ b/interfaces/builtin/login_session_control_test.go
@@ -91,13 +91,11 @@ func (s *loginSessionControlSuite) TestConnectedPlugSnippet(c *C) {
     bus=system
     path=/org/freedesktop/login1/seat/**
     interface=org.freedesktop.login1.Seat
-    member={ActiveSession,SwitchTo}
     peer=(label=unconfined),`)
 	c.Assert(snippet, testutil.Contains, `dbus (send,receive)
     bus=system
     path=/org/freedesktop/login1/session/**
     interface=org.freedesktop.login1.Session
-    member={TakeControl,TakeDevice,PauseDevice,PauseDeviceComplete,ResumeDevice,ReleaseDevice,Active,State,Lock,Unlock,Activate,ReleaseControl}
     peer=(label=unconfined),`)
 	c.Assert(snippet, testutil.Contains, `dbus (send,receive)
     bus=system

--- a/interfaces/builtin/login_session_control_test.go
+++ b/interfaces/builtin/login_session_control_test.go
@@ -78,7 +78,33 @@ func (s *loginSessionControlSuite) TestConnectedPlugSnippet(c *C) {
 	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
 	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
-	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, `Can setup login session & seat.`)
+	snippet := apparmorSpec.SnippetForTag("snap.other.app")
+	c.Assert(snippet, testutil.Contains, `Can setup login session & seat.`)
+
+	c.Assert(snippet, testutil.Contains, `dbus (send,receive)
+    bus=system
+    path=/org/freedesktop/login1/{seat,session}/**
+    interface=org.freedesktop.DBus.Properties
+    member={GetAll,PropertiesChanged,Get}
+    peer=(label=unconfined),`)
+	c.Assert(snippet, testutil.Contains, `dbus (send,receive)
+    bus=system
+    path=/org/freedesktop/login1/seat/**
+    interface=org.freedesktop.login1.Seat
+    member={ActiveSession,SwitchTo}
+    peer=(label=unconfined),`)
+	c.Assert(snippet, testutil.Contains, `dbus (send,receive)
+    bus=system
+    path=/org/freedesktop/login1/session/**
+    interface=org.freedesktop.login1.Session
+    member={TakeControl,TakeDevice,PauseDevice,PauseDeviceComplete,ResumeDevice,ReleaseDevice,Active,State,Lock,Unlock,Activate,ReleaseControl}
+    peer=(label=unconfined),`)
+	c.Assert(snippet, testutil.Contains, `dbus (send,receive)
+    bus=system
+    path=/org/freedesktop/login1
+    interface=org.freedesktop.login1.Manager
+    member={ActivateSession,GetSession,GetSeat,KillSession,ListSessions,LockSession,TerminateSession,UnlockSession}
+    peer=(label=unconfined),`)
 }
 
 func (s *loginSessionControlSuite) TestInterfaces(c *C) {


### PR DESCRIPTION
These new D-Bus interfaces allow the snaps to additionally control login sessions. This includes the ability to terminate or kill login sessions. These new interfaces were obtained from https://www.freedesktop.org/software/systemd/man/org.freedesktop.login1.html.

The unit tests have also been extended to add a check to ensure that the D-Bus rules are correctly included in the AppArmor snippet.