### PR TITLE
cmd/snap: let userd create the XDG directories

### DIFF
--- a/cmd/snap/cmd_userd.go
+++ b/cmd/snap/cmd_userd.go
@@ -96,7 +96,7 @@ func maybeCreateXdgDirectories() error {
 
 	for _, relDir := range []string{".cache", ".config", ".local/share"} {
 		path := filepath.Join(usr.HomeDir, relDir)
-		if err := os.MkdirAll(path, 0700); err != nil && os.IsNotExist(err) {
+		if err := os.MkdirAll(path, 0700); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Create `~/.cache/`, `~/.config/` and `~/.local/share/` on startup of the
user session daemon.

Fixes: https://bugs.launchpad.net/bugs/1988355
