### PR TITLE
client: add API for GET /systems/<label>

### DIFF
--- a/client/systems.go
+++ b/client/systems.go
@@ -140,7 +140,7 @@ func (client *Client) RebootToSystem(systemLabel, mode string) error {
 	return nil
 }
 
-type SystemDetailsData struct {
+type SystemDetails struct {
 	// First part is designed to look like `client.System` - the
 	// only difference is how the model is represented
 	Current bool                   `json:"current,omitempty"`
@@ -155,8 +155,8 @@ type SystemDetailsData struct {
 	// TODO: add EncryptionSupportInfo here too
 }
 
-func (client *Client) SystemDetails(seedLabel string) (*SystemDetailsData, error) {
-	var rsp SystemDetailsData
+func (client *Client) SystemDetails(seedLabel string) (*SystemDetails, error) {
+	var rsp SystemDetails
 
 	if _, err := client.doSync("GET", "/v2/systems/"+seedLabel, nil, nil, nil, &rsp); err != nil {
 		return nil, xerrors.Errorf("cannot get details for system %q: %v", seedLabel, err)

--- a/client/systems.go
+++ b/client/systems.go
@@ -26,6 +26,7 @@ import (
 
 	"golang.org/x/xerrors"
 
+	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -137,4 +138,28 @@ func (client *Client) RebootToSystem(systemLabel, mode string) error {
 		return xerrors.Errorf("cannot request system reboot: %v", err)
 	}
 	return nil
+}
+
+type SystemDetailsData struct {
+	// First part is designed to look like `client.System` - the
+	// only difference is how the model is represented
+	Current bool                   `json:"current,omitempty"`
+	Label   string                 `json:"label,omitempty"`
+	Model   map[string]interface{} `json:"model,omitempty"`
+	Brand   snap.StoreAccount      `json:"brand,omitempty"`
+	Actions []SystemAction         `json:"actions,omitempty"`
+
+	// Volumes contains the volumes defined from the gadget snap
+	Volumes map[string]*gadget.Volume `json:"volumes,omitempty"`
+
+	// TODO: add EncryptionSupportInfo here too
+}
+
+func (client *Client) SystemDetails(seedLabel string) (*SystemDetailsData, error) {
+	var rsp SystemDetailsData
+
+	if _, err := client.doSync("GET", "/v2/systems/"+seedLabel, nil, nil, nil, &rsp); err != nil {
+		return nil, xerrors.Errorf("cannot get details for system %q: %v", seedLabel, err)
+	}
+	return &rsp, nil
 }

--- a/client/systems_test.go
+++ b/client/systems_test.go
@@ -267,7 +267,7 @@ func (cs *clientSuite) TestSystemDetailsHappy(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Check(cs.req.Method, check.Equals, "GET")
 	c.Check(cs.req.URL.Path, check.Equals, "/v2/systems/20190102")
-	c.Check(sys, check.DeepEquals, &client.SystemDetailsData{
+	c.Check(sys, check.DeepEquals, &client.SystemDetails{
 		Current: true,
 		Label:   "20200101",
 		Model: map[string]interface{}{

--- a/daemon/api_systems.go
+++ b/daemon/api_systems.go
@@ -117,7 +117,7 @@ func getSystemDetails(c *Command, r *http.Request, user *auth.UserState) Respons
 	if err != nil {
 		return InternalError(err.Error())
 	}
-	rsp := client.SystemDetailsData{
+	rsp := client.SystemDetails{
 		Current: sys.Current,
 		Label:   sys.Label,
 		Brand: snap.StoreAccount{

--- a/daemon/api_systems.go
+++ b/daemon/api_systems.go
@@ -103,22 +103,6 @@ func getAllSystems(c *Command, r *http.Request, user *auth.UserState) Response {
 	return SyncResponse(&rsp)
 }
 
-type oneSystemResponse struct {
-	// First part is designed to look like `client.System` - the
-	// only difference is how the model is represented
-	Current bool                   `json:"current,omitempty"`
-	Label   string                 `json:"label,omitempty"`
-	Model   map[string]interface{} `json:"model,omitempty"`
-	Actions []client.SystemAction  `json:"actions,omitempty"`
-	Brand   snap.StoreAccount      `json:"brand"`
-
-	// Volumes contains the volumes defined from the gadget snap
-	Volumes map[string]*gadget.Volume `json:"volumes,omitempty"`
-
-	// TODO: add "storage-encryption" via the
-	// devicestate.EncryptionSupportInfo() here too
-}
-
 // wrapped for unit tests
 var deviceManagerSystemAndGadgetInfo = func(dm *devicestate.DeviceManager, systemLabel string) (*devicestate.System, *gadget.Info, error) {
 	return dm.SystemAndGadgetInfo(systemLabel)
@@ -133,7 +117,7 @@ func getSystemDetails(c *Command, r *http.Request, user *auth.UserState) Respons
 	if err != nil {
 		return InternalError(err.Error())
 	}
-	rsp := oneSystemResponse{
+	rsp := client.SystemDetailsData{
 		Current: sys.Current,
 		Label:   sys.Label,
 		Brand: snap.StoreAccount{

--- a/daemon/api_systems_test.go
+++ b/daemon/api_systems_test.go
@@ -814,8 +814,8 @@ func (s *systemsSuite) TestSystemsGetSpecificLabelHappy(c *check.C) {
 	rsp := s.syncReq(c, req, nil)
 
 	c.Assert(rsp.Status, check.Equals, 200)
-	sys := rsp.Result.(client.SystemDetailsData)
-	c.Assert(sys, check.DeepEquals, client.SystemDetailsData{
+	sys := rsp.Result.(client.SystemDetails)
+	c.Assert(sys, check.DeepEquals, client.SystemDetails{
 		Label: "20191119",
 		Model: s.seedModelForLabel20191119.Headers(),
 		Brand: snap.StoreAccount{
@@ -874,9 +874,9 @@ func (s *systemsSuite) TestSystemsGetSpecificLabelIntegration(c *check.C) {
 	rsp := s.syncReq(c, req, nil)
 
 	c.Assert(rsp.Status, check.Equals, 200)
-	sys := rsp.Result.(client.SystemDetailsData)
+	sys := rsp.Result.(client.SystemDetails)
 
-	c.Assert(sys, check.DeepEquals, client.SystemDetailsData{
+	c.Assert(sys, check.DeepEquals, client.SystemDetails{
 		Label: "20191119",
 		Model: s.seedModelForLabel20191119.Headers(),
 		Actions: []client.SystemAction{

--- a/daemon/api_systems_test.go
+++ b/daemon/api_systems_test.go
@@ -814,8 +814,8 @@ func (s *systemsSuite) TestSystemsGetSpecificLabelHappy(c *check.C) {
 	rsp := s.syncReq(c, req, nil)
 
 	c.Assert(rsp.Status, check.Equals, 200)
-	sys := rsp.Result.(daemon.OneSystemResponse)
-	c.Assert(sys, check.DeepEquals, daemon.OneSystemResponse{
+	sys := rsp.Result.(client.SystemDetailsData)
+	c.Assert(sys, check.DeepEquals, client.SystemDetailsData{
 		Label: "20191119",
 		Model: s.seedModelForLabel20191119.Headers(),
 		Brand: snap.StoreAccount{
@@ -874,9 +874,9 @@ func (s *systemsSuite) TestSystemsGetSpecificLabelIntegration(c *check.C) {
 	rsp := s.syncReq(c, req, nil)
 
 	c.Assert(rsp.Status, check.Equals, 200)
-	sys := rsp.Result.(daemon.OneSystemResponse)
+	sys := rsp.Result.(client.SystemDetailsData)
 
-	c.Assert(sys, check.DeepEquals, daemon.OneSystemResponse{
+	c.Assert(sys, check.DeepEquals, client.SystemDetailsData{
 		Label: "20191119",
 		Model: s.seedModelForLabel20191119.Headers(),
 		Actions: []client.SystemAction{

--- a/daemon/export_api_systems_test.go
+++ b/daemon/export_api_systems_test.go
@@ -34,8 +34,7 @@ func MockDeviceManagerReboot(f func(*devicestate.DeviceManager, string, string) 
 }
 
 type (
-	SystemsResponse   = systemsResponse
-	OneSystemResponse = oneSystemResponse
+	SystemsResponse = systemsResponse
 )
 
 func MockDeviceManagerSystemAndGadgetInfo(f func(*devicestate.DeviceManager, string) (*devicestate.System, *gadget.Info, error)) (restore func()) {


### PR DESCRIPTION
This commit implements the `client.SystemDetails()` call that will
return the data from the `/systems/<label>/` get endpoint.
