### PR TITLE
daemon: return `storage-encryption` in /systems/<label> reply

### DIFF
--- a/client/systems.go
+++ b/client/systems.go
@@ -140,6 +140,21 @@ func (client *Client) RebootToSystem(systemLabel, mode string) error {
 	return nil
 }
 
+type StorageEncryption struct {
+	// string: "yes"/"no-but-optional"/"no-and-required"
+	Available string `json:"available,omitempty"`
+
+	// StorageSafety can have values of asserts.StorageSafety
+	// and also "disabled" if the encryption got forcefully disabled
+	StorageSafety string `json:"storage-safety,omitempty"`
+
+	// Type have values of secboot.Type: "", "cryptsetup",
+	// "device-setup-hook"
+	Type string `json:"encryption-type"`
+
+	UnavailableReason string `json:"unavailalbe-reason,omitempty"`
+}
+
 type SystemDetails struct {
 	// First part is designed to look like `client.System` - the
 	// only difference is how the model is represented
@@ -152,7 +167,7 @@ type SystemDetails struct {
 	// Volumes contains the volumes defined from the gadget snap
 	Volumes map[string]*gadget.Volume `json:"volumes,omitempty"`
 
-	// TODO: add EncryptionSupportInfo here too
+	StorageEncryption *StorageEncryption `json:"storage-encryption,omitempty"`
 }
 
 func (client *Client) SystemDetails(seedLabel string) (*SystemDetails, error) {

--- a/client/systems.go
+++ b/client/systems.go
@@ -168,7 +168,7 @@ type StorageEncryption struct {
 	// available in a human readable form. Depending on if
 	// encryption is required or not this should be presented to
 	// the user as either an error or as information.
-	UnavailableReason string `json:"unavailalbe-reason,omitempty"`
+	UnavailableReason string `json:"unavailable-reason,omitempty"`
 }
 
 type SystemDetails struct {

--- a/client/systems.go
+++ b/client/systems.go
@@ -140,15 +140,22 @@ func (client *Client) RebootToSystem(systemLabel, mode string) error {
 	return nil
 }
 
+type StorageEncryptionSupport string
+
+const (
+	// forcefull disabled by the device
+	StorageEncryptionSupportDisabled = "disabled"
+	// encryption available and usable
+	StorageEncryptionSupportAvailable = "available"
+	// encryption unavailable but not required
+	StorageEncryptionSupportUnavailable = "unavailable"
+	// encryption unavailable and required, this is an error
+	StorageEncryptionSupportDefective = "defective"
+)
+
 type StorageEncryption struct {
-	// Support describes the level of hardware support available,
-	// it can have the values:
-	//
-	// "disabled"    - forcefull disabled by the device
-	// "available"   - encryption usable
-	// "unavailable" - encryption unavailable but not required
-	// "defective"   - encryption unavailable and required, this is an error
-	Support string `json:"support"`
+	// Support describes the level of hardware support available.
+	Support StorageEncryptionSupport `json:"support"`
 
 	// StorageSafety can have values of asserts.StorageSafety
 	StorageSafety string `json:"storage-safety,omitempty"`

--- a/client/systems.go
+++ b/client/systems.go
@@ -141,8 +141,10 @@ func (client *Client) RebootToSystem(systemLabel, mode string) error {
 }
 
 type StorageEncryption struct {
-	// A string that can contain:
-	// "disabled"    - forcefull disabled the device
+	// Support describes the level of hardware support available,
+	// it can have the values:
+	//
+	// "disabled"    - forcefull disabled by the device
 	// "available"   - encryption usable
 	// "unavailable" - encryption unavailable but not required
 	// "defective"   - encryption unavailable and required, this is an error

--- a/client/systems.go
+++ b/client/systems.go
@@ -141,17 +141,24 @@ func (client *Client) RebootToSystem(systemLabel, mode string) error {
 }
 
 type StorageEncryption struct {
-	// string: "yes"/"no-but-optional"/"no-and-required"
-	Available string `json:"available,omitempty"`
+	// A string that can contain:
+	// "disabled"    - forcefull disabled the device
+	// "available"   - encryption usable
+	// "unavailable" - encryption unavailable but not required
+	// "defective"   - encryption unavailable and required, this is an error
+	Support string `json:"support,omitempty"`
 
 	// StorageSafety can have values of asserts.StorageSafety
-	// and also "disabled" if the encryption got forcefully disabled
 	StorageSafety string `json:"storage-safety,omitempty"`
 
 	// Type have values of secboot.Type: "", "cryptsetup",
 	// "device-setup-hook"
 	Type string `json:"encryption-type"`
 
+	// UnavailableReason describes why the encryption is not
+	// available in a human readable form. Depending on if
+	// encryption is required or not this should be presented to
+	// the user as either an error or as information.
 	UnavailableReason string `json:"unavailalbe-reason,omitempty"`
 }
 

--- a/client/systems.go
+++ b/client/systems.go
@@ -160,7 +160,7 @@ type StorageEncryption struct {
 	// StorageSafety can have values of asserts.StorageSafety
 	StorageSafety string `json:"storage-safety,omitempty"`
 
-	// Type have values of secboot.Type: "", "cryptsetup",
+	// Type has values of secboot.Type: "", "cryptsetup",
 	// "device-setup-hook"
 	Type string `json:"encryption-type,omitempty"`
 

--- a/client/systems.go
+++ b/client/systems.go
@@ -148,14 +148,14 @@ type StorageEncryption struct {
 	// "available"   - encryption usable
 	// "unavailable" - encryption unavailable but not required
 	// "defective"   - encryption unavailable and required, this is an error
-	Support string `json:"support,omitempty"`
+	Support string `json:"support"`
 
 	// StorageSafety can have values of asserts.StorageSafety
 	StorageSafety string `json:"storage-safety,omitempty"`
 
 	// Type have values of secboot.Type: "", "cryptsetup",
 	// "device-setup-hook"
-	Type string `json:"encryption-type"`
+	Type string `json:"encryption-type,omitempty"`
 
 	// UnavailableReason describes why the encryption is not
 	// available in a human readable form. Depending on if

--- a/client/systems_test.go
+++ b/client/systems_test.go
@@ -254,6 +254,11 @@ func (cs *clientSuite) TestSystemDetailsHappy(c *check.C) {
                     {"title": "recover", "mode": "recover"},
                     {"title": "reinstall", "mode": "install"}
                 ],
+                "storage-encryption": {
+                    "available":"yes",
+                    "storage-safety":"prefer-encrypted",
+                    "encryption-type":"cryptsetup"
+                },
                 "volumes": {
                     "pc": {
                         "schema":"gpt",
@@ -284,6 +289,11 @@ func (cs *clientSuite) TestSystemDetailsHappy(c *check.C) {
 		Actions: []client.SystemAction{
 			{Title: "recover", Mode: "recover"},
 			{Title: "reinstall", Mode: "install"},
+		},
+		StorageEncryption: &client.StorageEncryption{
+			Available:     "yes",
+			StorageSafety: "prefer-encrypted",
+			Type:          "cryptsetup",
 		},
 		Volumes: map[string]*gadget.Volume{
 			"pc": {

--- a/client/systems_test.go
+++ b/client/systems_test.go
@@ -255,7 +255,7 @@ func (cs *clientSuite) TestSystemDetailsHappy(c *check.C) {
                     {"title": "reinstall", "mode": "install"}
                 ],
                 "storage-encryption": {
-                    "available":"yes",
+                    "support":"available",
                     "storage-safety":"prefer-encrypted",
                     "encryption-type":"cryptsetup"
                 },
@@ -291,7 +291,7 @@ func (cs *clientSuite) TestSystemDetailsHappy(c *check.C) {
 			{Title: "reinstall", Mode: "install"},
 		},
 		StorageEncryption: &client.StorageEncryption{
-			Available:     "yes",
+			Support:       "available",
 			StorageSafety: "prefer-encrypted",
 			Type:          "cryptsetup",
 		},

--- a/daemon/api_systems.go
+++ b/daemon/api_systems.go
@@ -110,13 +110,14 @@ var deviceManagerSystemAndGadgetAndEncryptionInfo = func(dm *devicestate.DeviceM
 }
 
 func storageEncryption(encInfo *devicestate.EncryptionSupportInfo) *client.StorageEncryption {
+	if encInfo.Disabled {
+		return &client.StorageEncryption{
+			Support: "disabled",
+		}
+	}
 	storageEnc := &client.StorageEncryption{
 		StorageSafety: string(encInfo.StorageSafety),
 		Type:          string(encInfo.Type),
-	}
-	if encInfo.Disabled {
-		storageEnc.Support = "disabled"
-		return storageEnc
 	}
 	required := (encInfo.StorageSafety == asserts.StorageSafetyEncrypted)
 	switch {

--- a/daemon/api_systems.go
+++ b/daemon/api_systems.go
@@ -120,19 +120,20 @@ func storageEncryption(encInfo *devicestate.EncryptionSupportInfo) *client.Stora
 		Type:          string(encInfo.Type),
 	}
 	if encInfo.Disabled {
-		storageEnc.StorageSafety = "disabled"
+		storageEnc.Support = "disabled"
+		return storageEnc
 	}
 	required := (encInfo.StorageSafety == asserts.StorageSafetyEncrypted)
 	switch {
 	case required && encInfo.Available:
-		storageEnc.Available = "yes"
+		storageEnc.Support = "available"
 	case !required && encInfo.Available:
-		storageEnc.Available = "yes"
+		storageEnc.Support = "available"
 	case required && !encInfo.Available:
-		storageEnc.Available = "no-and-required"
+		storageEnc.Support = "defective"
 		storageEnc.UnavailableReason = encInfo.UnavailableErr.Error()
 	case !required && !encInfo.Available:
-		storageEnc.Available = "no-but-optional"
+		storageEnc.Support = "unavailable"
 		storageEnc.UnavailableReason = encInfo.UnavailableWarning
 	}
 

--- a/daemon/api_systems.go
+++ b/daemon/api_systems.go
@@ -112,7 +112,7 @@ var deviceManagerSystemAndGadgetAndEncryptionInfo = func(dm *devicestate.DeviceM
 func storageEncryption(encInfo *devicestate.EncryptionSupportInfo) *client.StorageEncryption {
 	if encInfo.Disabled {
 		return &client.StorageEncryption{
-			Support: "disabled",
+			Support: client.StorageEncryptionSupportDisabled,
 		}
 	}
 	storageEnc := &client.StorageEncryption{
@@ -122,12 +122,12 @@ func storageEncryption(encInfo *devicestate.EncryptionSupportInfo) *client.Stora
 	required := (encInfo.StorageSafety == asserts.StorageSafetyEncrypted)
 	switch {
 	case encInfo.Available:
-		storageEnc.Support = "available"
+		storageEnc.Support = client.StorageEncryptionSupportAvailable
 	case !encInfo.Available && required:
-		storageEnc.Support = "defective"
+		storageEnc.Support = client.StorageEncryptionSupportDefective
 		storageEnc.UnavailableReason = encInfo.UnavailableErr.Error()
 	case !encInfo.Available && !required:
-		storageEnc.Support = "unavailable"
+		storageEnc.Support = client.StorageEncryptionSupportUnavailable
 		storageEnc.UnavailableReason = encInfo.UnavailableWarning
 	}
 

--- a/daemon/api_systems_test.go
+++ b/daemon/api_systems_test.go
@@ -839,7 +839,7 @@ func (s *systemsSuite) TestSystemsGetSpecificLabelHappy(c *check.C) {
 			Validation:  "unproven",
 		},
 		StorageEncryption: &client.StorageEncryption{
-			Available:         "no-but-optional",
+			Support:           "unavailable",
 			StorageSafety:     "prefer-encrypted",
 			UnavailableReason: "not encrypting device storage as checking TPM gave: some reason",
 		},
@@ -918,7 +918,7 @@ func (s *systemsSuite) TestSystemsGetSpecificLabelIntegration(c *check.C) {
 			Validation:  "unproven",
 		},
 		StorageEncryption: &client.StorageEncryption{
-			Available:         "no-but-optional",
+			Support:           "unavailable",
 			StorageSafety:     "prefer-encrypted",
 			UnavailableReason: "not encrypting device storage as checking TPM gave: some reason",
 		},

--- a/daemon/api_systems_test.go
+++ b/daemon/api_systems_test.go
@@ -885,7 +885,7 @@ func (s *systemsSuite) TestSystemsGetSpecificLabelIntegration(c *check.C) {
 		// mockSystemSeed will ensure everything here is coming from
 		// the mocked seed except the encryptionInfo
 		sys, gadgetInfo, encInfo, err := deviceMgr.SystemAndGadgetAndEncryptionInfo(label)
-		// encryptionInfo needs get overriden here to get reliable tests
+		// encryptionInfo needs get overridden here to get reliable tests
 		encInfo.Available = false
 		encInfo.StorageSafety = asserts.StorageSafetyPreferEncrypted
 		encInfo.UnavailableWarning = "not encrypting device storage as checking TPM gave: some reason"

--- a/daemon/export_api_systems_test.go
+++ b/daemon/export_api_systems_test.go
@@ -20,10 +20,8 @@
 package daemon
 
 import (
-	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/overlord/devicestate"
-	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -39,14 +37,8 @@ type (
 	SystemsResponse = systemsResponse
 )
 
-func MockDeviceManagerSystemAndGadgetAndKernelInfo(f func(*devicestate.DeviceManager, string) (*devicestate.System, *gadget.Info, *snap.Info, error)) (restore func()) {
-	restore = testutil.Backup(&deviceManagerSystemAndGadgetAndKernelInfo)
-	deviceManagerSystemAndGadgetAndKernelInfo = f
-	return restore
-}
-
-func MockDeviceManagerEncryptionSupportInfo(f func(dm *devicestate.DeviceManager, model *asserts.Model, kernelInfo *snap.Info, gadgetInfo *gadget.Info) (devicestate.EncryptionSupportInfo, error)) (restore func()) {
-	restore = testutil.Backup(&deviceManagerEncryptionSupportInfo)
-	deviceManagerEncryptionSupportInfo = f
+func MockDeviceManagerSystemAndGadgetAndEncryptionInfo(f func(*devicestate.DeviceManager, string) (*devicestate.System, *gadget.Info, *devicestate.EncryptionSupportInfo, error)) (restore func()) {
+	restore = testutil.Backup(&deviceManagerSystemAndGadgetAndEncryptionInfo)
+	deviceManagerSystemAndGadgetAndEncryptionInfo = f
 	return restore
 }

--- a/daemon/export_api_systems_test.go
+++ b/daemon/export_api_systems_test.go
@@ -20,8 +20,10 @@
 package daemon
 
 import (
+	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/overlord/devicestate"
+	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -37,8 +39,14 @@ type (
 	SystemsResponse = systemsResponse
 )
 
-func MockDeviceManagerSystemAndGadgetInfo(f func(*devicestate.DeviceManager, string) (*devicestate.System, *gadget.Info, error)) (restore func()) {
-	restore = testutil.Backup(&deviceManagerSystemAndGadgetInfo)
-	deviceManagerSystemAndGadgetInfo = f
+func MockDeviceManagerSystemAndGadgetAndKernelInfo(f func(*devicestate.DeviceManager, string) (*devicestate.System, *gadget.Info, *snap.Info, error)) (restore func()) {
+	restore = testutil.Backup(&deviceManagerSystemAndGadgetAndKernelInfo)
+	deviceManagerSystemAndGadgetAndKernelInfo = f
+	return restore
+}
+
+func MockDeviceManagerEncryptionSupportInfo(f func(dm *devicestate.DeviceManager, model *asserts.Model, kernelInfo *snap.Info, gadgetInfo *gadget.Info) (devicestate.EncryptionSupportInfo, error)) (restore func()) {
+	restore = testutil.Backup(&deviceManagerEncryptionSupportInfo)
+	deviceManagerEncryptionSupportInfo = f
 	return restore
 }

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -1820,10 +1820,12 @@ func (m *DeviceManager) SystemAndGadgetAndEncryptionInfo(wantedSystemLabel strin
 
 	// 2. get the gadget volumes for the given seed-label
 	perf := &timings.Timings{}
-	if err := s.LoadEssentialMeta([]snap.Type{snap.TypeGadget}, perf); err != nil {
+	if err := s.LoadEssentialMeta([]snap.Type{snap.TypeKernel, snap.TypeGadget}, perf); err != nil {
 		return nil, nil, nil, fmt.Errorf("cannot load gadget snap metadata: %v", err)
 	}
-	gadgetSnap := s.EssentialSnaps()[0]
+	// EssentialSnaps is always ordered, see asserts.Model.EssentialSnaps:
+	// "snapd, kernel, boot base, gadget."
+	gadgetSnap := s.EssentialSnaps()[1]
 	if gadgetSnap.Path == "" {
 		return nil, nil, nil, fmt.Errorf("internal error: cannot get gadget snap path")
 	}
@@ -1839,11 +1841,7 @@ func (m *DeviceManager) SystemAndGadgetAndEncryptionInfo(wantedSystemLabel strin
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("cannot parse gadget.yaml: %v", err)
 	}
-
-	// need kernel details to validate storage against encryption
-	if err := s.LoadEssentialMeta([]snap.Type{snap.TypeKernel}, perf); err != nil {
-		return nil, nil, nil, fmt.Errorf("cannot load kernel snap metadata: %v", err)
-	}
+	// get kernel to check encryptionSupport
 	kernelSnap := s.EssentialSnaps()[0]
 	if kernelSnap.Path == "" {
 		return nil, nil, nil, fmt.Errorf("internal error: cannot get kernel snap path")

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -1832,7 +1832,7 @@ func (m *DeviceManager) SystemAndGadgetAndEncryptionInfo(wantedSystemLabel strin
 	if kernelSnap.Path == "" {
 		return nil, nil, nil, fmt.Errorf("internal error: cannot get kernel snap path")
 	}
-	snapf, err := snapfile.Open(gadgetSnap.Path)
+	snapf, err := snapfile.Open(kernelSnap.Path)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("cannot open kernel snap: %v", err)
 	}

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -1824,7 +1824,8 @@ func (m *DeviceManager) SystemAndGadgetAndEncryptionInfo(wantedSystemLabel strin
 		return nil, nil, nil, fmt.Errorf("cannot load gadget snap metadata: %v", err)
 	}
 	// EssentialSnaps is always ordered, see asserts.Model.EssentialSnaps:
-	// "snapd, kernel, boot base, gadget."
+	// "snapd, kernel, boot base, gadget." and snaps not loaded above
+	// like "snapd" will be skipped and not part of the EssentialSnaps list
 	//
 	// kernel info needed to check encryptionSupport
 	kernelSnap := s.EssentialSnaps()[0]

--- a/overlord/devicestate/devicestate_systems_test.go
+++ b/overlord/devicestate/devicestate_systems_test.go
@@ -2333,8 +2333,8 @@ func (s *modelAndGadgetInfoSuite) TestModelAndGadgetInfoHappy(c *C) {
 	expectedGadgetInfo, err := gadget.InfoFromGadgetYaml([]byte(mockGadgetUCYaml), fakeModel)
 	c.Assert(err, IsNil)
 
-	// TODO: use kernelInfo
-	system, gadgetInfo, _, err := s.mgr.SystemAndGadgetAndKernelInfo("some-label")
+	// TODO: check encryptionInfo
+	system, gadgetInfo, _, err := s.mgr.SystemAndGadgetAndEncryptionInfo("some-label")
 	c.Assert(err, IsNil)
 	c.Check(system, DeepEquals, &devicestate.System{
 		Label: "some-label",
@@ -2348,12 +2348,12 @@ func (s *modelAndGadgetInfoSuite) TestModelAndGadgetInfoHappy(c *C) {
 }
 
 func (s *modelAndGadgetInfoSuite) TestSystemAndGadgetInfoErrorInvalidLabel(c *C) {
-	_, _, _, err := s.mgr.SystemAndGadgetAndKernelInfo("invalid/label")
+	_, _, _, err := s.mgr.SystemAndGadgetAndEncryptionInfo("invalid/label")
 	c.Assert(err, ErrorMatches, `cannot open: invalid seed system label: "invalid/label"`)
 }
 
 func (s *modelAndGadgetInfoSuite) TestSystemAndGadgetInfoErrorNoSeedDir(c *C) {
-	_, _, _, err := s.mgr.SystemAndGadgetAndKernelInfo("no-such-seed")
+	_, _, _, err := s.mgr.SystemAndGadgetAndEncryptionInfo("no-such-seed")
 	c.Assert(err, ErrorMatches, `cannot load assertions for label "no-such-seed": no seed assertions`)
 }
 
@@ -2363,7 +2363,7 @@ func (s *modelAndGadgetInfoSuite) TestSystemAndGadgetInfoErrorNoGadget(c *C) {
 	err := os.Remove(filepath.Join(dirs.SnapSeedDir, "snaps", "pc_1.snap"))
 	c.Assert(err, IsNil)
 
-	_, _, _, err = s.mgr.SystemAndGadgetAndKernelInfo("some-label")
+	_, _, _, err = s.mgr.SystemAndGadgetAndEncryptionInfo("some-label")
 	c.Assert(err, ErrorMatches, "cannot load gadget snap metadata: cannot stat snap:.*: no such file or directory")
 }
 
@@ -2373,14 +2373,14 @@ func (s *modelAndGadgetInfoSuite) TestSystemAndGadgetInfoErrorWrongGadget(c *C) 
 	err := ioutil.WriteFile(filepath.Join(dirs.SnapSeedDir, "snaps", "pc_1.snap"), []byte(`content-changed`), 0644)
 	c.Assert(err, IsNil)
 
-	_, _, _, err = s.mgr.SystemAndGadgetAndKernelInfo("some-label")
+	_, _, _, err = s.mgr.SystemAndGadgetAndEncryptionInfo("some-label")
 	c.Assert(err, ErrorMatches, `cannot load gadget snap metadata: cannot validate "/.*/pc_1.snap".* wrong size`)
 }
 
 func (s *modelAndGadgetInfoSuite) TestSystemAndGadgetInfoErrorInvalidGadgetYaml(c *C) {
 	s.makeMockUC20SeedWithGadgetYaml(c, "some-label", "")
 
-	_, _, _, err := s.mgr.SystemAndGadgetAndKernelInfo("some-label")
+	_, _, _, err := s.mgr.SystemAndGadgetAndEncryptionInfo("some-label")
 	c.Assert(err, ErrorMatches, "cannot parse gadget.yaml: bootloader not declared in any volume")
 }
 
@@ -2392,6 +2392,6 @@ func (s *modelAndGadgetInfoSuite) TestSystemAndGadgetInfoErrorNoSeed(c *C) {
 	mgr, err := devicestate.Manager(s.state, s.hookMgr, s.o.TaskRunner(), nil)
 	c.Assert(err, IsNil)
 
-	_, _, _, err = mgr.SystemAndGadgetAndKernelInfo("some-label")
+	_, _, _, err = mgr.SystemAndGadgetAndEncryptionInfo("some-label")
 	c.Assert(err, ErrorMatches, "cannot get model and gadget information on a classic boot system")
 }

--- a/overlord/devicestate/devicestate_systems_test.go
+++ b/overlord/devicestate/devicestate_systems_test.go
@@ -2333,7 +2333,8 @@ func (s *modelAndGadgetInfoSuite) TestModelAndGadgetInfoHappy(c *C) {
 	expectedGadgetInfo, err := gadget.InfoFromGadgetYaml([]byte(mockGadgetUCYaml), fakeModel)
 	c.Assert(err, IsNil)
 
-	system, gadgetInfo, err := s.mgr.SystemAndGadgetInfo("some-label")
+	// TODO: use kernelInfo
+	system, gadgetInfo, _, err := s.mgr.SystemAndGadgetAndKernelInfo("some-label")
 	c.Assert(err, IsNil)
 	c.Check(system, DeepEquals, &devicestate.System{
 		Label: "some-label",
@@ -2347,12 +2348,12 @@ func (s *modelAndGadgetInfoSuite) TestModelAndGadgetInfoHappy(c *C) {
 }
 
 func (s *modelAndGadgetInfoSuite) TestSystemAndGadgetInfoErrorInvalidLabel(c *C) {
-	_, _, err := s.mgr.SystemAndGadgetInfo("invalid/label")
+	_, _, _, err := s.mgr.SystemAndGadgetAndKernelInfo("invalid/label")
 	c.Assert(err, ErrorMatches, `cannot open: invalid seed system label: "invalid/label"`)
 }
 
 func (s *modelAndGadgetInfoSuite) TestSystemAndGadgetInfoErrorNoSeedDir(c *C) {
-	_, _, err := s.mgr.SystemAndGadgetInfo("no-such-seed")
+	_, _, _, err := s.mgr.SystemAndGadgetAndKernelInfo("no-such-seed")
 	c.Assert(err, ErrorMatches, `cannot load assertions for label "no-such-seed": no seed assertions`)
 }
 
@@ -2362,7 +2363,7 @@ func (s *modelAndGadgetInfoSuite) TestSystemAndGadgetInfoErrorNoGadget(c *C) {
 	err := os.Remove(filepath.Join(dirs.SnapSeedDir, "snaps", "pc_1.snap"))
 	c.Assert(err, IsNil)
 
-	_, _, err = s.mgr.SystemAndGadgetInfo("some-label")
+	_, _, _, err = s.mgr.SystemAndGadgetAndKernelInfo("some-label")
 	c.Assert(err, ErrorMatches, "cannot load gadget snap metadata: cannot stat snap:.*: no such file or directory")
 }
 
@@ -2372,14 +2373,14 @@ func (s *modelAndGadgetInfoSuite) TestSystemAndGadgetInfoErrorWrongGadget(c *C) 
 	err := ioutil.WriteFile(filepath.Join(dirs.SnapSeedDir, "snaps", "pc_1.snap"), []byte(`content-changed`), 0644)
 	c.Assert(err, IsNil)
 
-	_, _, err = s.mgr.SystemAndGadgetInfo("some-label")
+	_, _, _, err = s.mgr.SystemAndGadgetAndKernelInfo("some-label")
 	c.Assert(err, ErrorMatches, `cannot load gadget snap metadata: cannot validate "/.*/pc_1.snap".* wrong size`)
 }
 
 func (s *modelAndGadgetInfoSuite) TestSystemAndGadgetInfoErrorInvalidGadgetYaml(c *C) {
 	s.makeMockUC20SeedWithGadgetYaml(c, "some-label", "")
 
-	_, _, err := s.mgr.SystemAndGadgetInfo("some-label")
+	_, _, _, err := s.mgr.SystemAndGadgetAndKernelInfo("some-label")
 	c.Assert(err, ErrorMatches, "cannot parse gadget.yaml: bootloader not declared in any volume")
 }
 
@@ -2391,6 +2392,6 @@ func (s *modelAndGadgetInfoSuite) TestSystemAndGadgetInfoErrorNoSeed(c *C) {
 	mgr, err := devicestate.Manager(s.state, s.hookMgr, s.o.TaskRunner(), nil)
 	c.Assert(err, IsNil)
 
-	_, _, err = mgr.SystemAndGadgetInfo("some-label")
+	_, _, _, err = mgr.SystemAndGadgetAndKernelInfo("some-label")
 	c.Assert(err, ErrorMatches, "cannot get model and gadget information on a classic boot system")
 }

--- a/overlord/devicestate/devicestate_systems_test.go
+++ b/overlord/devicestate/devicestate_systems_test.go
@@ -2328,7 +2328,7 @@ func (s *modelAndGadgetInfoSuite) makeMockUC20SeedWithGadgetYaml(c *C, label, ga
 	}, nil)
 }
 
-func (s *modelAndGadgetInfoSuite) TestModelAndGadgetInfoHappy(c *C) {
+func (s *modelAndGadgetInfoSuite) TestSystemAndGadgetAndEncyptionInfoHappy(c *C) {
 	fakeModel := s.makeMockUC20SeedWithGadgetYaml(c, "some-label", mockGadgetUCYaml)
 	expectedGadgetInfo, err := gadget.InfoFromGadgetYaml([]byte(mockGadgetUCYaml), fakeModel)
 	c.Assert(err, IsNil)

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -400,7 +400,7 @@ func DeviceManagerCheckEncryption(mgr *DeviceManager, st *state.State, deviceCtx
 }
 
 func DeviceManagerEncryptionSupportInfo(mgr *DeviceManager, model *asserts.Model, kernelInfo *snap.Info, gadgetInfo *gadget.Info) (EncryptionSupportInfo, error) {
-	return mgr.encryptionSupportInfo(model, kernelInfo, gadgetInfo)
+	return mgr.EncryptionSupportInfo(model, kernelInfo, gadgetInfo)
 }
 
 func DeviceManagerCheckFDEFeatures(mgr *DeviceManager, st *state.State) (secboot.EncryptionType, error) {

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -400,7 +400,7 @@ func DeviceManagerCheckEncryption(mgr *DeviceManager, st *state.State, deviceCtx
 }
 
 func DeviceManagerEncryptionSupportInfo(mgr *DeviceManager, model *asserts.Model, kernelInfo *snap.Info, gadgetInfo *gadget.Info) (EncryptionSupportInfo, error) {
-	return mgr.EncryptionSupportInfo(model, kernelInfo, gadgetInfo)
+	return mgr.encryptionSupportInfo(model, kernelInfo, gadgetInfo)
 }
 
 func DeviceManagerCheckFDEFeatures(mgr *DeviceManager, st *state.State) (secboot.EncryptionType, error) {


### PR DESCRIPTION
This commit implements the API response for `/system/<label>` to
include the `storage-encryption` details for the current device.

