### PR TITLE
tests/main/snap-quota-{install/journal}: fix unstable spread tests

### DIFF
--- a/tests/lib/snaps/test-snapd-journal-quota/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-journal-quota/meta/snap.yaml
@@ -6,3 +6,4 @@ apps:
     logger:
         command: bin/logger
         daemon: simple
+        restart-condition: always

--- a/tests/main/snap-quota-install/task.yaml
+++ b/tests/main/snap-quota-install/task.yaml
@@ -26,6 +26,8 @@ execute: |
   echo "Installing hello-world and assigning it quota group group-one"
   snap install hello-world --quota-group group-one
   
+  # We expect that group-one will use memory, but we do not care how much memory
+  # it's using, so we just accept whatever (if any) memory in use.
   echo "Checking that all quotas can be listed"
   snap quotas | cat -n > quotas.txt
   MATCH "     1\s+Quota\s+Parent\s+Constraints\s+Current$" < quotas.txt

--- a/tests/main/snap-quota-install/task.yaml
+++ b/tests/main/snap-quota-install/task.yaml
@@ -29,7 +29,7 @@ execute: |
   echo "Checking that all quotas can be listed"
   snap quotas | cat -n > quotas.txt
   MATCH "     1\s+Quota\s+Parent\s+Constraints\s+Current$" < quotas.txt
-  MATCH "     2\s+group-one\s+memory=400MB\s*$" < quotas.txt
+  MATCH "     2\s+group-one\s+memory=400MB(\s*|\s*memory=[0-9.a-zA-Z]+)\s*$" < quotas.txt
   
   echo "Checking quota group details"
   snap quota group-one | cat -n > details.txt

--- a/tests/main/snap-quota-journal/task.yaml
+++ b/tests/main/snap-quota-journal/task.yaml
@@ -46,7 +46,7 @@ execute: |
   systemctl show --property=ControlGroup snap.test-snapd-journal-quota.logger.service | grep -F "$SLICE_REGEXP"
 
   echo "The service should also still be active"
-  snap services test-snapd-journal-quota.logger | MATCH "test-snapd-journal-quota.logger\s+enabled\s+active"
+  retry -n 3 sh -c "snap services test-snapd-journal-quota.logger | MATCH 'test-snapd-journal-quota.logger\s+enabled\s+active'"
 
   # Verify the contents of /etc/systemd/journald@snap-group-one.conf
   echo "Verifying the journal config contents"
@@ -63,7 +63,7 @@ execute: |
   snap set-quota group-one --journal-size=64MB
 
   echo "And the service is still active"
-  snap services test-snapd-journal-quota.logger | MATCH "test-snapd-journal-quota.logger\s+enabled\s+active"
+  retry -n 3 sh -c "snap services test-snapd-journal-quota.logger | MATCH 'test-snapd-journal-quota.logger\s+enabled\s+active'"
 
   # Ensure that the new size is printed in the journal logs. We requested 64MB but
   # this will most likely print out as 61.0M, so lets be a bit flexible
@@ -77,7 +77,7 @@ execute: |
   LOGGER_PID=$(systemctl show --property=MainPID --value snap.test-snapd-journal-quota.logger.service)
   snap remove-quota group-one
   systemctl show --property=MainPID --value snap.test-snapd-journal-quota.logger.service | NOMATCH "$LOGGER_PID"
-  snap services test-snapd-journal-quota.logger | MATCH "test-snapd-journal-quota.logger\s+enabled\s+active"
+  retry -n 3 sh -c "snap services test-snapd-journal-quota.logger | MATCH 'test-snapd-journal-quota.logger\s+enabled\s+active'"
 
   echo "And the service is not in a slice anymore"
   systemctl show --property=ControlGroup snap.test-snapd-journal-quota.logger.service | grep -vF "$SLICE_REGEXP"


### PR DESCRIPTION
**snap-quota-install**
On some versions of systemd, just creating a cgroup implies usage of memory.

**snap-quota-journal**
The test checks to quickly after doing quota changes for the services to be active again, let it retry 3 times to allow for services to come online, and also make sure the restart condition for the test journal snap is set to 'always', as if systemd restarts the journal namespace while the snap is writing to the namespace, then the service will be killed with a SIGPIPE. This is a valid exit condition for systemd, and thus the service will not be restarted as `on-failure` is the default behaviour.