### PR TITLE
tests: re-enable interfaces udisks2

### DIFF
--- a/tests/main/interfaces-udisks2/task.yaml
+++ b/tests/main/interfaces-udisks2/task.yaml
@@ -8,7 +8,7 @@ details: |
 #   Object /org/freedesktop/UDisks2/block_devices/loop200 is not a mountable filesystem.
 # 2021-11-02: disabled ubuntu-18.04-32 because it keeps failing when trying
 #             to create/use /dev/loop200
-systems: [-ubuntu-core-*, -arch-linux-*, -centos-9-*, -ubuntu-18.04-32]
+systems: [-ubuntu-core-*, -arch-linux-*, -centos-9-*, -fedora-*, -ubuntu-18.04-32]
 
 environment:
     FS_PATH: "$(pwd)/dev0-fake0"

--- a/tests/main/interfaces-udisks2/task.yaml
+++ b/tests/main/interfaces-udisks2/task.yaml
@@ -4,11 +4,9 @@ details: |
     The udisks2 interface allows operating as or interacting with the UDisks2 service
 
 # Interfaces not defined for ubuntu core systems
-# FIXME: `udisksctl mount -b  "$device"` fails on arch with:
-#   Object /org/freedesktop/UDisks2/block_devices/loop200 is not a mountable filesystem.
 # 2021-11-02: disabled ubuntu-18.04-32 because it keeps failing when trying
 #             to create/use /dev/loop200
-systems: [-ubuntu-core-*, -arch-linux-*, -centos-9-*, -fedora-*, -ubuntu-18.04-32]
+systems: [-ubuntu-core-*, -ubuntu-18.04-32]
 
 environment:
     FS_PATH: "$(pwd)/dev0-fake0"


### PR DESCRIPTION
This change is created to fix the issue it is being reproduced:

udisksctl mount -b  "$device"` fails on arch with:
-#   Object /org/freedesktop/UDisks2/block_devices/loop200 is not a
mountable filesystem.

This issues is reproduced in centos, arch and fedora systems