### PR TITLE
tests: use the new ubuntu kinetic image

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -135,7 +135,6 @@ backends:
                   storage: 12G
                   workers: 8
             - ubuntu-22.10-64:
-                  image: ubuntu-os-cloud-devel/ubuntu-2210-amd64
                   storage: 12G
                   workers: 8
 


### PR DESCRIPTION
This new image is stored in canonical spread project, including latest dependencies.
It is required to use this image instead of the previous one in the ubuntu-os-cloud-devel project due to the spread pagination issue

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
