### PR TITLE
tests: remove code for old systems not supported anymore

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -730,11 +730,6 @@ prepare: |
         rmdir "$DELTA_PREFIX"
     fi
 
-    # TODO: drop once 21.10 images are fixed
-    if [[ "$SPREAD_SYSTEM" == ubuntu-21.10-* ]] && [[ -e /home/ubuntu/.ssh ]]; then
-        chown -R ubuntu:ubuntu /home/ubuntu/.ssh
-    fi
-
     # Take the MATCH and REBOOT functions from spread and allow our shell
     # scripts to use them as shell commands. The replacements are real
     # executables in tests/lib/bin (which is on PATH) but they source

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -172,16 +172,6 @@ distro_install_package() {
         ;;
     esac
 
-    # fix dependency issue where libp11-kit0 needs to be downgraded to
-    # install gnome-keyring
-    case "$SPREAD_SYSTEM" in
-        debian-9-*)
-        if [[ "$*" =~ "gnome-keyring" ]]; then
-            eatmydata apt-get remove -y libp11-kit0
-        fi
-        ;;
-    esac
-
     # shellcheck disable=SC2207
     pkg_names=($(
         for pkg in "$@" ; do

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -484,10 +484,7 @@ prepare_project() {
     case "$SPREAD_SYSTEM" in
         debian-*|ubuntu-*)
             best_golang=golang-1.13
-            if [[ "$SPREAD_SYSTEM" == debian-9-* ]]; then
-                echo "debian-9 tests disabled (no golang-1.13)"
-                exit 1
-            elif [[ "$SPREAD_SYSTEM" == debian-10-* ]]; then
+            if [[ "$SPREAD_SYSTEM" == debian-10-* ]]; then
                 # debian-10 needs backports for golang-1.13
                 echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list
                 apt update

--- a/tests/main/cgroup-devices-v2/task.yaml
+++ b/tests/main/cgroup-devices-v2/task.yaml
@@ -8,9 +8,7 @@ systems:
   - -ubuntu-16.04-*
   - -ubuntu-18.04-*
   - -ubuntu-20.04-*
-  - -ubuntu-21.04-*
   - -ubuntu-core-*
-  - -debian-9-*
   - -debian-10-*
   - -centos-7-*
   - -centos-8-*

--- a/tests/main/debug-sandbox/task.yaml
+++ b/tests/main/debug-sandbox/task.yaml
@@ -10,7 +10,7 @@ execute: |
         # Debian, openSUSE, Arch because partial apparmor is enabled
         snap debug sandbox-features | MATCH "apparmor: .+"
         ;;
-    fedora-*|debian-9-*)
+    fedora-*)
         # Fedora because it uses SELinux
         snap debug sandbox-features | NOMATCH "apparmor: .+"
         ;;

--- a/tests/main/system-usernames-illegal/task.yaml
+++ b/tests/main/system-usernames-illegal/task.yaml
@@ -3,7 +3,7 @@ summary: ensure unapproved user cannot be used with system-usernames
 # List of expected snap install failures due to libseccomp/golang-seccomp being
 # too old. Since the illegal name check happens after verifying system support,
 # we can ignore these.
-systems: [-amazon-linux-2-*, -centos-7-*, -debian-9-*, -debian-10-*, -ubuntu-14.04-*]
+systems: [-amazon-linux-2-*, -centos-7-*, -debian-10-*, -ubuntu-14.04-*]
 
 execute: |
     snap_path=$("$TESTSTOOLS"/snaps-state pack-local test-snapd-illegal-system-username)

--- a/tests/main/system-usernames-install-twice/task.yaml
+++ b/tests/main/system-usernames-install-twice/task.yaml
@@ -4,7 +4,7 @@ summary: ensure snap can be installed twice (reusing the created groups)
 # too old. Since the illegal name check happens after verifying system support,
 # we can ignore these. Ignore ubuntu-core since groupdel doesn't support
 # --extrausers
-systems: [-amazon-linux-2-*, -centos-7-*, -debian-9-*, -debian-10-*, -ubuntu-14.04-*, -ubuntu-core-*]
+systems: [-amazon-linux-2-*, -centos-7-*, -debian-10-*, -ubuntu-14.04-*, -ubuntu-core-*]
 
 prepare: |
     snap install --edge test-snapd-daemon-user

--- a/tests/main/system-usernames-missing-user/task.yaml
+++ b/tests/main/system-usernames-missing-user/task.yaml
@@ -4,7 +4,7 @@ summary: ensure snap fails to install if one of user or group doesn't exist
 # too old. Since the illegal name check happens after verifying system support,
 # we can ignore these. Ignore ubuntu-core since groupdel doesn't support
 # --extrausers
-systems: [-amazon-linux-2-*, -centos-7-*, -debian-9-*, -debian-10-*, -ubuntu-14.04-*, -ubuntu-core-*]
+systems: [-amazon-linux-2-*, -centos-7-*, -debian-10-*, -ubuntu-14.04-*, -ubuntu-core-*]
 
 prepare: |
     groupadd --system snap_daemon

--- a/tests/main/system-usernames/task.yaml
+++ b/tests/main/system-usernames/task.yaml
@@ -8,7 +8,7 @@ environment:
     # List of expected snap install failures due to libseccomp/golang-seccomp
     # being too old. This should only reduce with time since new systems should
     # have newer libseccomp and golang-seccomp
-    EXFAIL: "centos-7-64 debian-9-64 debian-10-64 opensuse-15\\.0-64 ubuntu-14"
+    EXFAIL: "centos-7-64 debian-10-64 ubuntu-14"
 
 prepare: |
     echo "Install helper snaps with default confinement"


### PR DESCRIPTION
This change is to remove test code for systems which are not supported anymore.
