### PR TITLE
tests: add kinetic images to the gce bucket for preseed test

### DIFF
--- a/tests/lib/image.sh
+++ b/tests/lib/image.sh
@@ -64,6 +64,9 @@ get_google_image_url_for_vm() {
         ubuntu-22.04-arm-64*)
             echo "https://storage.googleapis.com/snapd-spread-tests/images/cloudimg/jammy-server-cloudimg-arm64.img"
             ;;
+        ubuntu-22.10-64*)
+            echo "https://storage.googleapis.com/snapd-spread-tests/images/cloudimg/kinetic-server-cloudimg-amd64.img"
+            ;;
         *)
             echo "unsupported system"
             exit 1
@@ -91,6 +94,9 @@ get_ubuntu_image_url_for_vm() {
             ;;
         ubuntu-22.04-arm-64*)
             echo "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-arm64.img"
+            ;;
+        ubuntu-22.10-64*)
+            echo "https://cloud-images.ubuntu.com/kinetic/current/kinetic-server-cloudimg-amd64.img"
             ;;
         *)
             echo "unsupported system"


### PR DESCRIPTION
This is to make preseed tests work in kinetic
