### PR TITLE
image/preseed: add missing new line

### DIFF
--- a/image/preseed/preseed_linux.go
+++ b/image/preseed/preseed_linux.go
@@ -117,7 +117,7 @@ var systemSnapFromSeed = func(seedDir, sysLabel string) (systemSnap string, base
 	}
 
 	if model.Classic() {
-		fmt.Fprintf(Stdout, "ubuntu classic preseeding")
+		fmt.Fprintf(Stdout, "ubuntu classic preseeding\n")
 	} else {
 		if model.Base() == "core20" {
 			fmt.Fprintf(Stdout, "UC20+ preseeding\n")


### PR DESCRIPTION
When I execute the command `/usr/lib/snapd/snap-preseed /MY_ROOT_DIR`, it will produce the message `ubuntu classic preseedingstarting to preseed root`, I expect there should be a new line after `preseeding`