### PR TITLE
tests: fix non mountable filesystem error in interfaces-udisks2

### DIFF
--- a/tests/main/interfaces-udisks2/task.yaml
+++ b/tests/main/interfaces-udisks2/task.yaml
@@ -10,14 +10,12 @@ systems: [-ubuntu-core-*, -ubuntu-18.04-32]
 
 environment:
     FS_PATH: "$(pwd)/dev0-fake0"
-    MMCBLK_PATH: /dev/mmcblk-fake0
 
 prepare: |
     snap install test-snapd-udisks2
 
 restore: |
-    losetup -d "$MMCBLK_PATH" || true
-    rm -f "$MMCBLK_PATH" "$FS_PATH"
+    rm -f "$FS_PATH"
 
 execute: |
     echo "The interface is not connected by default"

--- a/tests/main/interfaces-udisks2/task.yaml
+++ b/tests/main/interfaces-udisks2/task.yaml
@@ -15,7 +15,10 @@ prepare: |
     snap install test-snapd-udisks2
 
 restore: |
-    rm -f "$FS_PATH"
+    device="$(losetup -j "$FS_PATH" | cut -d: -f1)"
+    if [ -n "$device" ]; then
+        udisksctl loop-delete -b "$device"
+    fi
 
 execute: |
     echo "The interface is not connected by default"

--- a/tests/main/interfaces-udisks2/task.yaml
+++ b/tests/main/interfaces-udisks2/task.yaml
@@ -35,7 +35,7 @@ execute: |
     dd if=/dev/zero of="$FS_PATH" bs=1M count=10
     mkfs.ext4 -F "$FS_PATH"
     # create the loopback block device
-    udisksctl loop-setup -rf "$FS_PATH"
+    udisksctl loop-setup -f "$FS_PATH"
 
     device="$(losetup -j "$FS_PATH" | cut -d: -f1)"
 

--- a/tests/main/interfaces-udisks2/task.yaml
+++ b/tests/main/interfaces-udisks2/task.yaml
@@ -41,7 +41,7 @@ execute: |
 
     # We retry because there is a race with the device becoming
     # registered by udisks2. The issue can be easily reproduced on ubuntu-20.04
-    retry -n 15 --wait 1 sh -c "test-snapd-udisks2.udisksctl  mount -b \"$device\" -t ext4 | MATCH 'Mounted /dev/'"
+    retry -n 15 --wait 1 sh -c "test-snapd-udisks2.udisksctl mount -b \"$device\" -t ext4 | MATCH 'Mounted /dev/'"
     test-snapd-udisks2.udisksctl unmount -b "$device" | MATCH "Unmounted /dev/"
 
     if [ "$(snap debug confinement)" = partial ] ; then

--- a/tests/main/interfaces-udisks2/task.yaml
+++ b/tests/main/interfaces-udisks2/task.yaml
@@ -4,11 +4,9 @@ details: |
     The udisks2 interface allows operating as or interacting with the UDisks2 service
 
 # Interfaces not defined for ubuntu core systems
-# FIXME: `udisksctl mount -b  "$device"` fails on arch with:
-#   Object /org/freedesktop/UDisks2/block_devices/loop200 is not a mountable filesystem.
 # 2021-11-02: disabled ubuntu-18.04-32 because it keeps failing when trying
 #             to create/use /dev/loop200
-systems: [-ubuntu-core-*, -arch-linux-*, -centos-9-*, -fedora-*, -ubuntu-18.04-32]
+systems: [-ubuntu-core-*, -ubuntu-18.04-32]
 
 environment:
     FS_PATH: "$(pwd)/dev0-fake0"
@@ -39,14 +37,13 @@ execute: |
     dd if=/dev/zero of="$FS_PATH" bs=1M count=10
     mkfs.ext4 -F "$FS_PATH"
     # create the loopback block device
-    mknod "$MMCBLK_PATH" b 7 200
-    losetup "$MMCBLK_PATH" "$FS_PATH"
+    udisksctl loop-setup -rf "$FS_PATH"
 
     device="$(losetup -j "$FS_PATH" | cut -d: -f1)"
 
     # We retry because there is a race with the device becoming
     # registered by udisks2. The issue can be easily reproduced on ubuntu-20.04
-    retry -n 15 --wait 1 sh -c "test-snapd-udisks2.udisksctl mount -b \"$device\" -t ext4 | MATCH 'Mounted /dev/'"
+    retry -n 15 --wait 1 sh -c "test-snapd-udisks2.udisksctl  mount -b \"$device\" -t ext4 | MATCH 'Mounted /dev/'"
     test-snapd-udisks2.udisksctl unmount -b "$device" | MATCH "Unmounted /dev/"
 
     if [ "$(snap debug confinement)" = partial ] ; then


### PR DESCRIPTION
The idea is to use udisksctl loop-setup instead of losetup tool.

This change is making the test work in ubuntu kinetic, arch linux, fedora and centos.
