### PR TITLE
client: prepare InstallSystemOptions for real use

### DIFF
--- a/client/systems.go
+++ b/client/systems.go
@@ -178,7 +178,7 @@ type InstallSystemOptions struct {
 
 	// OnVolumes is the volume description of the volumes that the
 	// given step should operate on.
-	OnVolumes map[string][]gadget.Volume `json:"on-volumes,omitempty"`
+	OnVolumes map[string]*gadget.Volume `json:"on-volumes,omitempty"`
 }
 
 // InstallSystem will perform the given install step for the given volumes

--- a/client/systems_test.go
+++ b/client/systems_test.go
@@ -331,15 +331,13 @@ func (cs *clientSuite) TestRequestSystemInstallHappy(c *check.C) {
 		"status-code": 202,
 		"change": "42"
 	}`
-	vols := map[string][]gadget.Volume{
+	vols := map[string]*gadget.Volume{
 		"pc": {
-			{
-				Schema:     "dos",
-				Bootloader: "mbr",
-				ID:         "0c",
-				// Note that name is not exported as json
-				Name: "pc",
-			},
+			Schema:     "dos",
+			Bootloader: "mbr",
+			ID:         "0c",
+			// Note that name is not exported as json
+			Name: "pc",
 		},
 	}
 	opts := &client.InstallSystemOptions{
@@ -361,13 +359,11 @@ func (cs *clientSuite) TestRequestSystemInstallHappy(c *check.C) {
 		"action": "install",
 		"step":   "finish",
 		"on-volumes": map[string]interface{}{
-			"pc": []interface{}{
-				map[string]interface{}{
-					"schema":     "dos",
-					"bootloader": "mbr",
-					"id":         "0c",
-					"structure":  nil,
-				},
+			"pc": map[string]interface{}{
+				"schema":     "dos",
+				"bootloader": "mbr",
+				"id":         "0c",
+				"structure":  nil,
 			},
 		},
 	})

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -158,6 +158,11 @@ type VolumeStructure struct {
 	// Content of the structure
 	Content []VolumeContent `yaml:"content" json:"content"`
 	Update  VolumeUpdate    `yaml:"update" json:"update"`
+
+	// Device is only meaningful when used from the install
+	Device string `json:"device,omitempty`
+	// UnenyptedDevice is only meaningful when used from the install
+	UnencryptedDevice string `json:"unencrypted-device,omitempty"`
 }
 
 // HasFilesystem returns true if the structure is using a filesystem.


### PR DESCRIPTION
This commit prepares the `InstallSystemOptions` to be ready for real use inside the installer API. This requires two things:

**1. Add `device` and `unencrypted-device` to `on-volumes`**

This commit just add two new fields to `gadget.VolumeStructure`.

This might be too simplisitic. The alternative is to add it only for the REST api, something like:
```go
diff --git a/client/systems.go b/client/systems.go
index 04312662c3..e050c8ebd5 100644
--- a/client/systems.go
+++ b/client/systems.go
@@ -171,6 +171,19 @@ const (
        InstallStepFinish                 InstallStep = "finish"
 )

+type InstallVolumeStructure struct {
+       *gadget.VolumeStructure
+
+       Device            string `json:"device,omitempty"`
+       UnencryptedDevice string `json:"unencrypted-device,omitempty"`
+}
+
+type InstallVolume struct {
+       *gadget.Volume
+
+       Structure []InstallVolumeStructure `json:"structure"`
+}
+
 type InstallSystemOptions struct {
        // Step is the install step, either "setup-storage-encryption"
        // or "finish".
@@ -178,7 +191,7 @@ type InstallSystemOptions struct {

        // OnVolumes is the volume description of the volumes that the
        // given step should operate on.
-       OnVolumes map[string]*gadget.Volume `json:"on-volumes,omitempty"`
+       OnVolumes map[string]*InstallVolume `json:"on-volumes,omitempty"`
 }
```

**2. Fix type mismatch in `client.InstallSystemOptions.OnVolumes`**

The volume information in snapd is usually encoded as: `map[string]*gadget.Volume`. However due to an oversight in the client code (and because it was not used yet) a small mistake made it into the code and it got encoded as:
`map[string][]gadget.Volume` there.
