### PR TITLE
client: prepare InstallSystemOptions for real use

### DIFF
--- a/client/systems.go
+++ b/client/systems.go
@@ -174,7 +174,7 @@ const (
 type InstallVolumeStructure struct {
 	*gadget.VolumeStructure
 
-	// The installer need to set those
+	// The installer need to set those as needed depending on step.
 	Device            string `json:"device,omitempty"`
 	UnencryptedDevice string `json:"unencrypted-device,omitempty"`
 }

--- a/client/systems.go
+++ b/client/systems.go
@@ -171,6 +171,20 @@ const (
 	InstallStepFinish                 InstallStep = "finish"
 )
 
+type InstallVolumeStructure struct {
+	*gadget.VolumeStructure
+
+	// The installer need to set those
+	Device            string `json:"device,omitempty"`
+	UnencryptedDevice string `json:"unencrypted-device,omitempty"`
+}
+
+type InstallVolume struct {
+	*gadget.Volume
+
+	Structure []InstallVolumeStructure `json:"structure"`
+}
+
 type InstallSystemOptions struct {
 	// Step is the install step, either "setup-storage-encryption"
 	// or "finish".
@@ -178,7 +192,7 @@ type InstallSystemOptions struct {
 
 	// OnVolumes is the volume description of the volumes that the
 	// given step should operate on.
-	OnVolumes map[string][]gadget.Volume `json:"on-volumes,omitempty"`
+	OnVolumes map[string]*InstallVolume `json:"on-volumes,omitempty"`
 }
 
 // InstallSystem will perform the given install step for the given volumes

--- a/client/systems_test.go
+++ b/client/systems_test.go
@@ -324,7 +324,7 @@ func (cs *clientSuite) TestRequestSystemInstallEmptySystemLabel(c *check.C) {
 	c.Check(cs.req, check.IsNil)
 }
 
-func (cs *clientSuite) TestRequestSystemInstallShadowsExistingStruct(c *check.C) {
+func (cs *clientSuite) TestRequestSystemInstallHappy(c *check.C) {
 	cs.status = 202
 	cs.rsp = `{
 		"type": "async",
@@ -340,7 +340,8 @@ func (cs *clientSuite) TestRequestSystemInstallShadowsExistingStruct(c *check.C)
 				// Note that name is not exported as json
 				Name: "pc",
 				// Note that this will be "shadowed"
-				// and not actually be visible, see
+				// and not actually be visible, as it
+				// is more nested, see
 				// https://pkg.go.dev/encoding/json#Marshal
 				Structure: []gadget.VolumeStructure{
 					{

--- a/client/systems_test.go
+++ b/client/systems_test.go
@@ -324,21 +324,46 @@ func (cs *clientSuite) TestRequestSystemInstallEmptySystemLabel(c *check.C) {
 	c.Check(cs.req, check.IsNil)
 }
 
-func (cs *clientSuite) TestRequestSystemInstallHappy(c *check.C) {
+func (cs *clientSuite) TestRequestSystemInstallShadowsExistingStruct(c *check.C) {
 	cs.status = 202
 	cs.rsp = `{
 		"type": "async",
 		"status-code": 202,
 		"change": "42"
 	}`
-	vols := map[string][]gadget.Volume{
+	vols := map[string]*client.InstallVolume{
 		"pc": {
-			{
+			Volume: &gadget.Volume{
 				Schema:     "dos",
 				Bootloader: "mbr",
-				ID:         "0c",
+				ID:         "id",
 				// Note that name is not exported as json
 				Name: "pc",
+				// Note that this will be "shadowed"
+				// and not actually be visible, see
+				// https://pkg.go.dev/encoding/json#Marshal
+				Structure: []gadget.VolumeStructure{
+					{
+						Name:  "we-do-not-not-see-this-name",
+						Label: "we-do-not-see-this-label",
+					},
+				},
+			},
+			Structure: []client.InstallVolumeStructure{
+				{
+					Device: "/dev/sda1",
+					VolumeStructure: &gadget.VolumeStructure{
+						Label:      "label",
+						Name:       "vol-name",
+						ID:         "id",
+						Size:       1234,
+						Type:       "type",
+						Filesystem: "fs",
+						Role:       "system-boot",
+						// not exported to json
+						VolumeName: "vol-name",
+					},
+				},
 			},
 		},
 	}
@@ -361,12 +386,28 @@ func (cs *clientSuite) TestRequestSystemInstallHappy(c *check.C) {
 		"action": "install",
 		"step":   "finish",
 		"on-volumes": map[string]interface{}{
-			"pc": []interface{}{
-				map[string]interface{}{
-					"schema":     "dos",
-					"bootloader": "mbr",
-					"id":         "0c",
-					"structure":  nil,
+			"pc": map[string]interface{}{
+				"schema":     "dos",
+				"bootloader": "mbr",
+				"id":         "id",
+				"structure": []interface{}{
+					map[string]interface{}{
+						"device":           "/dev/sda1",
+						"filesystem-label": "label",
+						"name":             "vol-name",
+						"id":               "id",
+						"size":             float64(1234),
+						"type":             "type",
+						"filesystem":       "fs",
+						"role":             "system-boot",
+						"offset":           nil,
+						"offset-write":     nil,
+						"content":          nil,
+						"update": map[string]interface{}{
+							"edition":  float64(0),
+							"preserve": nil,
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
This commit prepares the `InstallSystemOptions` to be ready for real use inside the installer API. This requires two things:

**1. Create client.InstallVolume{,Struct}**

The new struct is similar to `gadget.Volume{,Struct}` but tailored towards the installer use-case. The `client.VolumeStructure` contains an extra `Device` and `UnencryptedDevice` field that is filled in from the installer.

**2. Fix type mismatch in `client.InstallSystemOptions.OnVolumes`**

The volume information in snapd is usually encoded as: `map[string]*gadget.Volume`. However due to an oversight in the client code (and because it was not used yet) a small mistake made it into the code and it got encoded as:
`map[string][]gadget.Volume` there.
