### PR TITLE
release, snapd-apparmor: fixed outdated WSL detection

### DIFF
--- a/cmd/snapd-apparmor/export_test.go
+++ b/cmd/snapd-apparmor/export_test.go
@@ -19,8 +19,6 @@
 
 package main
 
-import "github.com/snapcore/snapd/release"
-
 var (
 	Run                           = run
 	ValidateArgs                  = validateArgs
@@ -28,12 +26,3 @@ var (
 	IsContainerWithInternalPolicy = isContainerWithInternalPolicy
 	LoadAppArmorProfiles          = loadAppArmorProfiles
 )
-
-func MockWSL(onWSL bool) (restorer func()) {
-	oldWSL := release.OnWSL
-
-	release.OnWSL = onWSL
-	return func() {
-		release.OnWSL = oldWSL
-	}
-}

--- a/cmd/snapd-apparmor/export_test.go
+++ b/cmd/snapd-apparmor/export_test.go
@@ -29,11 +29,11 @@ var (
 	LoadAppArmorProfiles          = loadAppArmorProfiles
 )
 
-func MockWSL(on_wsl bool) (restorer func()) {
-	old_wsl := release.OnWSL
+func MockWSL(onWSL bool) (restorer func()) {
+	oldWSL := release.OnWSL
 
-	release.OnWSL = on_wsl
+	release.OnWSL = onWSL
 	return func() {
-		release.OnWSL = old_wsl
+		release.OnWSL = oldWSL
 	}
 }

--- a/cmd/snapd-apparmor/export_test.go
+++ b/cmd/snapd-apparmor/export_test.go
@@ -19,6 +19,8 @@
 
 package main
 
+import "github.com/snapcore/snapd/release"
+
 var (
 	Run                           = run
 	ValidateArgs                  = validateArgs
@@ -27,10 +29,12 @@ var (
 	LoadAppArmorProfiles          = loadAppArmorProfiles
 )
 
-func MockWSL(mock func() bool) (restorer func()) {
-	old := isWSL
-	isWSL = mock
+// version should be 0 outside wsl, and 1 or 2 within wsl
+func MockWSL(on_wsl bool) (restorer func()) {
+	old_wsl := release.OnWSL
+
+	release.OnWSL = on_wsl
 	return func() {
-		isWSL = old
+		release.OnWSL = old_wsl
 	}
 }

--- a/cmd/snapd-apparmor/export_test.go
+++ b/cmd/snapd-apparmor/export_test.go
@@ -27,11 +27,10 @@ var (
 	LoadAppArmorProfiles          = loadAppArmorProfiles
 )
 
-func MockWSL(fun func()) {
-	old := isWsl
-	isWsl = func() bool {
-		return true
+func MockWSL(mock func() bool) (restorer func()) {
+	old := isWSL
+	isWSL = mock
+	return func() {
+		isWSL = old
 	}
-	fun()
-	isWsl = old
 }

--- a/cmd/snapd-apparmor/export_test.go
+++ b/cmd/snapd-apparmor/export_test.go
@@ -29,7 +29,6 @@ var (
 	LoadAppArmorProfiles          = loadAppArmorProfiles
 )
 
-// version should be 0 outside wsl, and 1 or 2 within wsl
 func MockWSL(on_wsl bool) (restorer func()) {
 	old_wsl := release.OnWSL
 

--- a/cmd/snapd-apparmor/export_test.go
+++ b/cmd/snapd-apparmor/export_test.go
@@ -26,3 +26,12 @@ var (
 	IsContainerWithInternalPolicy = isContainerWithInternalPolicy
 	LoadAppArmorProfiles          = loadAppArmorProfiles
 )
+
+func MockWSL(fun func()) {
+	old := isWsl
+	isWsl = func() bool {
+		return true
+	}
+	fun()
+	isWsl = old
+}

--- a/cmd/snapd-apparmor/main.go
+++ b/cmd/snapd-apparmor/main.go
@@ -49,10 +49,6 @@ import (
 	"github.com/snapcore/snapd/snapdtool"
 )
 
-var isWSL = func() bool {
-	return release.OnWSL
-}
-
 // Checks to see if the current container is capable of having internal AppArmor
 // profiles that should be loaded.
 //
@@ -73,7 +69,7 @@ var isWSL = func() bool {
 // unsupported configuration that cannot be properly handled by this function.
 //
 func isContainerWithInternalPolicy() bool {
-	if isWSL() {
+	if release.OnWSL {
 		return true
 	}
 

--- a/cmd/snapd-apparmor/main.go
+++ b/cmd/snapd-apparmor/main.go
@@ -131,7 +131,8 @@ func loadAppArmorProfiles() error {
 }
 
 func isContainer() bool {
-	return (exec.Command("systemd-detect-virt", "--quiet", "--container").Run() == nil)
+	// systemd's implementation may fail on WSL2 with custom kernels
+	return release.OnWSL || (exec.Command("systemd-detect-virt", "--quiet", "--container").Run() == nil)
 }
 
 func validateArgs(args []string) error {

--- a/cmd/snapd-apparmor/main.go
+++ b/cmd/snapd-apparmor/main.go
@@ -44,17 +44,10 @@ import (
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/release"
 	apparmor_sandbox "github.com/snapcore/snapd/sandbox/apparmor"
 	"github.com/snapcore/snapd/snapdtool"
 )
-
-func isWSL() bool {
-	if output, err := exec.Command("systemd-detect-virt", "--container").Output(); err == nil {
-		virt := strings.TrimSpace(string(output))
-		return virt == "wsl"
-	}
-	return false
-}
 
 // Checks to see if the current container is capable of having internal AppArmor
 // profiles that should be loaded.
@@ -80,7 +73,7 @@ func isContainerWithInternalPolicy() bool {
 	var nsStackedPath = filepath.Join(appArmorSecurityFSPath, ".ns_stacked")
 	var nsNamePath = filepath.Join(appArmorSecurityFSPath, ".ns_name")
 
-	if isWSL() {
+	if release.OnWSL {
 		return true
 	}
 

--- a/cmd/snapd-apparmor/main.go
+++ b/cmd/snapd-apparmor/main.go
@@ -49,7 +49,7 @@ import (
 	"github.com/snapcore/snapd/snapdtool"
 )
 
-var isWsl = func() bool {
+var isWSL = func() bool {
 	return release.OnWSL
 }
 
@@ -73,7 +73,7 @@ var isWsl = func() bool {
 // unsupported configuration that cannot be properly handled by this function.
 //
 func isContainerWithInternalPolicy() bool {
-	if isWsl() {
+	if isWSL() {
 		return true
 	}
 

--- a/cmd/snapd-apparmor/main.go
+++ b/cmd/snapd-apparmor/main.go
@@ -49,6 +49,10 @@ import (
 	"github.com/snapcore/snapd/snapdtool"
 )
 
+var isWsl = func() bool {
+	return release.OnWSL
+}
+
 // Checks to see if the current container is capable of having internal AppArmor
 // profiles that should be loaded.
 //
@@ -69,13 +73,13 @@ import (
 // unsupported configuration that cannot be properly handled by this function.
 //
 func isContainerWithInternalPolicy() bool {
+	if isWsl() {
+		return true
+	}
+
 	var appArmorSecurityFSPath = filepath.Join(dirs.GlobalRootDir, "/sys/kernel/security/apparmor")
 	var nsStackedPath = filepath.Join(appArmorSecurityFSPath, ".ns_stacked")
 	var nsNamePath = filepath.Join(appArmorSecurityFSPath, ".ns_name")
-
-	if release.OnWSL {
-		return true
-	}
 
 	contents, err := ioutil.ReadFile(nsStackedPath)
 	if err != nil && !errors.Is(err, os.ErrNotExist) {

--- a/cmd/snapd-apparmor/main_test.go
+++ b/cmd/snapd-apparmor/main_test.go
@@ -65,7 +65,7 @@ func (s *mainSuite) TestIsContainerWithInternalPolicy(c *C) {
 
 	// simulate being inside WSL
 	func() {
-		defer snapd_apparmor.MockWSL(func() bool { return true })
+		defer snapd_apparmor.MockWSL(true)
 		c.Assert(snapd_apparmor.IsContainerWithInternalPolicy(), Equals, true)
 	}()
 
@@ -232,7 +232,7 @@ func (s *integrationSuite) TestRunInContainerSkipsLoading(c *C) {
 }
 
 func (s *integrationSuite) TestRunInContainerWithInternalPolicyLoadsProfiles(c *C) {
-	snapd_apparmor.MockWSL(func() bool { return true })
+	snapd_apparmor.MockWSL(true)
 	err := snapd_apparmor.Run()
 	c.Assert(err, IsNil)
 	c.Check(s.logBuf.String(), testutil.Contains, "DEBUG: inside container environment")

--- a/cmd/snapd-apparmor/main_test.go
+++ b/cmd/snapd-apparmor/main_test.go
@@ -153,6 +153,15 @@ func (s *mainSuite) TestIsContainer(c *C) {
 	c.Check(snapd_apparmor.IsContainer(), Equals, false)
 	c.Assert(detectCmd.Calls(), DeepEquals, [][]string{
 		{"systemd-detect-virt", "--quiet", "--container"}})
+
+	// Test WSL2 with custom kernel
+	detectCmd = testutil.MockCommand(c, "systemd-detect-virt", "echo failed > /dev/stderr; exit 1")
+	defer detectCmd.Restore()
+	defer snapd_apparmor.MockWSL(true)
+	c.Check(snapd_apparmor.IsContainer(), Equals, true)
+	c.Assert(detectCmd.Calls(), DeepEquals, [][]string{
+		{"systemd-detect-virt", "--quiet", "--container"}})
+
 }
 
 func (s *mainSuite) TestValidateArgs(c *C) {

--- a/cmd/snapd-apparmor/main_test.go
+++ b/cmd/snapd-apparmor/main_test.go
@@ -54,7 +54,7 @@ func (s *mainSuite) TearDownTest(c *C) {
 }
 
 func MockWSL(onWSL bool) (restorer func()) {
-	restorer = testutil.Backup(release.OnWSL)
+	restorer = testutil.Backup(&release.OnWSL)
 	release.OnWSL = onWSL
 	return
 }

--- a/cmd/snapd-apparmor/main_test.go
+++ b/cmd/snapd-apparmor/main_test.go
@@ -54,12 +54,9 @@ func (s *mainSuite) TearDownTest(c *C) {
 }
 
 func MockWSL(onWSL bool) (restorer func()) {
-	oldWSL := release.OnWSL
-
+	restorer = testutil.Backup(release.OnWSL)
 	release.OnWSL = onWSL
-	return func() {
-		release.OnWSL = oldWSL
-	}
+	return
 }
 
 func (s *mainSuite) TestIsContainerWithInternalPolicy(c *C) {

--- a/cmd/snapd-apparmor/main_test.go
+++ b/cmd/snapd-apparmor/main_test.go
@@ -159,9 +159,7 @@ func (s *mainSuite) TestIsContainer(c *C) {
 	defer detectCmd.Restore()
 	defer snapd_apparmor.MockWSL(true)()
 	c.Check(snapd_apparmor.IsContainer(), Equals, true)
-	c.Assert(detectCmd.Calls(), DeepEquals, [][]string{
-		{"systemd-detect-virt", "--quiet", "--container"}})
-
+	c.Assert(detectCmd.Calls(), DeepEquals, [][]string(nil))
 }
 
 func (s *mainSuite) TestValidateArgs(c *C) {

--- a/cmd/snapd-apparmor/main_test.go
+++ b/cmd/snapd-apparmor/main_test.go
@@ -53,6 +53,15 @@ func (s *mainSuite) TearDownTest(c *C) {
 	dirs.SetRootDir("/")
 }
 
+func MockWSL(onWSL bool) (restorer func()) {
+	oldWSL := release.OnWSL
+
+	release.OnWSL = onWSL
+	return func() {
+		release.OnWSL = oldWSL
+	}
+}
+
 func (s *mainSuite) TestIsContainerWithInternalPolicy(c *C) {
 	// since "apparmorfs" is not present within our test root dir setup
 	// we expect this to return false
@@ -65,8 +74,7 @@ func (s *mainSuite) TestIsContainerWithInternalPolicy(c *C) {
 	c.Assert(snapd_apparmor.IsContainerWithInternalPolicy(), Equals, false)
 
 	// simulate being inside WSL
-	restore := testutil.Backup(release.OnWSL)
-	release.OnWSL = true
+	restore := MockWSL(true)
 	c.Assert(snapd_apparmor.IsContainerWithInternalPolicy(), Equals, true)
 	restore()
 
@@ -157,8 +165,7 @@ func (s *mainSuite) TestIsContainer(c *C) {
 
 	// Test WSL2 with custom kernel
 	detectCmd = testutil.MockCommand(c, "systemd-detect-virt", "echo failed > /dev/stderr; exit 1")
-	defer testutil.Backup(release.OnWSL)()
-	release.OnWSL = true
+	defer MockWSL(true)()
 	c.Check(snapd_apparmor.IsContainer(), Equals, true)
 	c.Assert(detectCmd.Calls(), DeepEquals, [][]string(nil))
 }
@@ -231,8 +238,7 @@ func (s *integrationSuite) TestRunInContainerSkipsLoading(c *C) {
 }
 
 func (s *integrationSuite) TestRunInContainerWithInternalPolicyLoadsProfiles(c *C) {
-	defer testutil.Backup(release.OnWSL)()
-	release.OnWSL = true
+	defer MockWSL(true)()
 	err := snapd_apparmor.Run()
 	c.Assert(err, IsNil)
 	c.Check(s.logBuf.String(), testutil.Contains, "DEBUG: inside container environment")

--- a/cmd/snapd-apparmor/main_test.go
+++ b/cmd/snapd-apparmor/main_test.go
@@ -161,6 +161,8 @@ func (s *mainSuite) TestIsContainer(c *C) {
 		{"systemd-detect-virt", "--quiet", "--container"}})
 
 	// Test WSL2 with custom kernel
+	// systemd-detect-virt may return a non-zero exit code as it fails to recognize it as WSL
+	// This will happen when the kernel name includes neither "WSL" not "Microsoft"
 	detectCmd = testutil.MockCommand(c, "systemd-detect-virt", "echo none; exit 1")
 	defer mockWSL(true)()
 	c.Check(snapd_apparmor.IsContainer(), Equals, true)

--- a/cmd/snapd-apparmor/main_test.go
+++ b/cmd/snapd-apparmor/main_test.go
@@ -53,15 +53,6 @@ func (s *mainSuite) TearDownTest(c *C) {
 	dirs.SetRootDir("/")
 }
 
-func MockWSL(onWSL bool) (restorer func()) {
-	oldWSL := release.OnWSL
-
-	release.OnWSL = onWSL
-	return func() {
-		release.OnWSL = oldWSL
-	}
-}
-
 func (s *mainSuite) TestIsContainerWithInternalPolicy(c *C) {
 	// since "apparmorfs" is not present within our test root dir setup
 	// we expect this to return false
@@ -74,7 +65,8 @@ func (s *mainSuite) TestIsContainerWithInternalPolicy(c *C) {
 	c.Assert(snapd_apparmor.IsContainerWithInternalPolicy(), Equals, false)
 
 	// simulate being inside WSL
-	restore := MockWSL(true)
+	restore := testutil.Backup(release.OnWSL)
+	release.OnWSL = true
 	c.Assert(snapd_apparmor.IsContainerWithInternalPolicy(), Equals, true)
 	restore()
 
@@ -165,7 +157,8 @@ func (s *mainSuite) TestIsContainer(c *C) {
 
 	// Test WSL2 with custom kernel
 	detectCmd = testutil.MockCommand(c, "systemd-detect-virt", "echo failed > /dev/stderr; exit 1")
-	defer MockWSL(true)()
+	defer testutil.Backup(release.OnWSL)()
+	release.OnWSL = true
 	c.Check(snapd_apparmor.IsContainer(), Equals, true)
 	c.Assert(detectCmd.Calls(), DeepEquals, [][]string(nil))
 }
@@ -238,7 +231,8 @@ func (s *integrationSuite) TestRunInContainerSkipsLoading(c *C) {
 }
 
 func (s *integrationSuite) TestRunInContainerWithInternalPolicyLoadsProfiles(c *C) {
-	defer MockWSL(true)()
+	defer testutil.Backup(release.OnWSL)()
+	release.OnWSL = true
 	err := snapd_apparmor.Run()
 	c.Assert(err, IsNil)
 	c.Check(s.logBuf.String(), testutil.Contains, "DEBUG: inside container environment")

--- a/cmd/snapd-apparmor/main_test.go
+++ b/cmd/snapd-apparmor/main_test.go
@@ -165,7 +165,6 @@ func (s *mainSuite) TestIsContainer(c *C) {
 
 	// Test WSL2 with custom kernel
 	detectCmd = testutil.MockCommand(c, "systemd-detect-virt", "echo failed > /dev/stderr; exit 1")
-	defer detectCmd.Restore()
 	defer MockWSL(true)()
 	c.Check(snapd_apparmor.IsContainer(), Equals, true)
 	c.Assert(detectCmd.Calls(), DeepEquals, [][]string(nil))

--- a/cmd/snapd-apparmor/main_test.go
+++ b/cmd/snapd-apparmor/main_test.go
@@ -53,7 +53,7 @@ func (s *mainSuite) TearDownTest(c *C) {
 	dirs.SetRootDir("/")
 }
 
-func MockWSL(onWSL bool) (restorer func()) {
+func mockWSL(onWSL bool) (restorer func()) {
 	restorer = testutil.Backup(&release.OnWSL)
 	release.OnWSL = onWSL
 	return
@@ -71,7 +71,7 @@ func (s *mainSuite) TestIsContainerWithInternalPolicy(c *C) {
 	c.Assert(snapd_apparmor.IsContainerWithInternalPolicy(), Equals, false)
 
 	// simulate being inside WSL
-	restore := MockWSL(true)
+	restore := mockWSL(true)
 	c.Assert(snapd_apparmor.IsContainerWithInternalPolicy(), Equals, true)
 	restore()
 
@@ -162,7 +162,7 @@ func (s *mainSuite) TestIsContainer(c *C) {
 
 	// Test WSL2 with custom kernel
 	detectCmd = testutil.MockCommand(c, "systemd-detect-virt", "echo failed > /dev/stderr; exit 1")
-	defer MockWSL(true)()
+	defer mockWSL(true)()
 	c.Check(snapd_apparmor.IsContainer(), Equals, true)
 	c.Assert(detectCmd.Calls(), DeepEquals, [][]string(nil))
 }
@@ -235,7 +235,7 @@ func (s *integrationSuite) TestRunInContainerSkipsLoading(c *C) {
 }
 
 func (s *integrationSuite) TestRunInContainerWithInternalPolicyLoadsProfiles(c *C) {
-	defer MockWSL(true)()
+	defer mockWSL(true)()
 	err := snapd_apparmor.Run()
 	c.Assert(err, IsNil)
 	c.Check(s.logBuf.String(), testutil.Contains, "DEBUG: inside container environment")

--- a/cmd/snapd-apparmor/main_test.go
+++ b/cmd/snapd-apparmor/main_test.go
@@ -161,7 +161,7 @@ func (s *mainSuite) TestIsContainer(c *C) {
 		{"systemd-detect-virt", "--quiet", "--container"}})
 
 	// Test WSL2 with custom kernel
-	detectCmd = testutil.MockCommand(c, "systemd-detect-virt", "echo failed > /dev/stderr; exit 1")
+	detectCmd = testutil.MockCommand(c, "systemd-detect-virt", "echo none; exit 1")
 	defer mockWSL(true)()
 	c.Check(snapd_apparmor.IsContainer(), Equals, true)
 	c.Assert(detectCmd.Calls(), DeepEquals, [][]string(nil))

--- a/cmd/snapd-apparmor/main_test.go
+++ b/cmd/snapd-apparmor/main_test.go
@@ -64,10 +64,9 @@ func (s *mainSuite) TestIsContainerWithInternalPolicy(c *C) {
 	c.Assert(snapd_apparmor.IsContainerWithInternalPolicy(), Equals, false)
 
 	// simulate being inside WSL
-	func() {
-		defer snapd_apparmor.MockWSL(true)()
-		c.Assert(snapd_apparmor.IsContainerWithInternalPolicy(), Equals, true)
-	}()
+	restore := snapd_apparmor.MockWSL(true)
+	c.Assert(snapd_apparmor.IsContainerWithInternalPolicy(), Equals, true)
+	restore()
 
 	// simulate being inside a container environment
 	testutil.MockCommand(c, "systemd-detect-virt", "echo lxc")

--- a/cmd/snapd-apparmor/main_test.go
+++ b/cmd/snapd-apparmor/main_test.go
@@ -65,7 +65,7 @@ func (s *mainSuite) TestIsContainerWithInternalPolicy(c *C) {
 
 	// simulate being inside WSL
 	func() {
-		defer snapd_apparmor.MockWSL(true)
+		defer snapd_apparmor.MockWSL(true)()
 		c.Assert(snapd_apparmor.IsContainerWithInternalPolicy(), Equals, true)
 	}()
 
@@ -157,7 +157,7 @@ func (s *mainSuite) TestIsContainer(c *C) {
 	// Test WSL2 with custom kernel
 	detectCmd = testutil.MockCommand(c, "systemd-detect-virt", "echo failed > /dev/stderr; exit 1")
 	defer detectCmd.Restore()
-	defer snapd_apparmor.MockWSL(true)
+	defer snapd_apparmor.MockWSL(true)()
 	c.Check(snapd_apparmor.IsContainer(), Equals, true)
 	c.Assert(detectCmd.Calls(), DeepEquals, [][]string{
 		{"systemd-detect-virt", "--quiet", "--container"}})
@@ -232,7 +232,7 @@ func (s *integrationSuite) TestRunInContainerSkipsLoading(c *C) {
 }
 
 func (s *integrationSuite) TestRunInContainerWithInternalPolicyLoadsProfiles(c *C) {
-	snapd_apparmor.MockWSL(true)
+	defer snapd_apparmor.MockWSL(true)()
 	err := snapd_apparmor.Run()
 	c.Assert(err, IsNil)
 	c.Check(s.logBuf.String(), testutil.Contains, "DEBUG: inside container environment")

--- a/release/export_test.go
+++ b/release/export_test.go
@@ -35,6 +35,7 @@ func MockOSReleasePath(filename string) (restore func()) {
 }
 
 func MockFileExists(mockFileExists func(string) bool) (restorer func()) {
+	// Cannot use testutil.Backup due to import loop
 	old := fileExists
 	fileExists = mockFileExists
 	return func() {

--- a/release/export_test.go
+++ b/release/export_test.go
@@ -34,11 +34,11 @@ func MockOSReleasePath(filename string) (restore func()) {
 	}
 }
 
-func MockIoutilReadfile(newReadfile func(string) ([]byte, error)) (restorer func()) {
-	old := ioutilReadFile
-	ioutilReadFile = newReadfile
+func MockFileExists(mockFileExists func(string) bool) (restorer func()) {
+	old := fileExists
+	fileExists = mockFileExists
 	return func() {
-		ioutilReadFile = old
+		fileExists = old
 	}
 }
 

--- a/release/release.go
+++ b/release/release.go
@@ -103,6 +103,7 @@ func readOSRelease() OS {
 	return osRelease
 }
 
+// Note that osutil.FileExists cannot be used here as an osutil import will create a cyclic import
 var fileExists = func(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil

--- a/release/release.go
+++ b/release/release.go
@@ -21,8 +21,6 @@ package release
 
 import (
 	"bufio"
-	"bytes"
-	"io/ioutil"
 	"os"
 	"strings"
 	"unicode"
@@ -105,15 +103,13 @@ func readOSRelease() OS {
 	return osRelease
 }
 
-var ioutilReadFile = ioutil.ReadFile
+var fileExists = func(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
 
 func isWSL() bool {
-	version, err := ioutilReadFile("/proc/version")
-	if err == nil && bytes.Contains(version, []byte("Microsoft")) {
-		return true
-	}
-
-	return false
+	return fileExists("/proc/sys/fs/binfmt_misc/WSLInterop")
 }
 
 // SystemctlSupportsUserUnits returns true if the systemctl utility

--- a/release/release_test.go
+++ b/release/release_test.go
@@ -149,7 +149,7 @@ func (s *ReleaseTestSuite) TestReleaseInfo(c *C) {
 }
 
 func (s *ReleaseTestSuite) TestNonWSL(c *C) {
-	defer release.MockFileExists(func(string) bool {
+	defer release.MockFileExists(func(s string) bool {
 		c.Check(s, Equals, "/proc/sys/fs/binfmt_misc/WSLInterop")
 		return false
 	})()
@@ -158,7 +158,7 @@ func (s *ReleaseTestSuite) TestNonWSL(c *C) {
 }
 
 func (s *ReleaseTestSuite) TestWSL(c *C) {
-	defer release.MockFileExists(func(string) bool {
+	defer release.MockFileExists(func(s string) bool {
 		c.Check(s, Equals, "/proc/sys/fs/binfmt_misc/WSLInterop")
 		return true
 	})()

--- a/release/release_test.go
+++ b/release/release_test.go
@@ -149,18 +149,18 @@ func (s *ReleaseTestSuite) TestReleaseInfo(c *C) {
 }
 
 func (s *ReleaseTestSuite) TestNonWSL(c *C) {
-	defer release.MockIoutilReadfile(func(s string) ([]byte, error) {
-		c.Check(s, Equals, "/proc/version")
-		return []byte("Linux version 2.2.19 (herbert@gondolin) (gcc version 2.7.2.3) #1 Wed Mar 20 19:41:41 EST 2002"), nil
+	defer release.MockFileExists(func(string) bool {
+		c.Check(s, Equals, "/proc/sys/fs/binfmt_misc/WSLInterop")
+		return false
 	})()
 
 	c.Check(release.IsWSL(), Equals, false)
 }
 
 func (s *ReleaseTestSuite) TestWSL(c *C) {
-	defer release.MockIoutilReadfile(func(s string) ([]byte, error) {
-		c.Check(s, Equals, "/proc/version")
-		return []byte("Linux version 3.4.0-Microsoft (Microsoft@Microsoft.com) (gcc version 4.7 (GCC) ) #1 SMP PREEMPT Wed Dec 31 14:42:53 PST 2014"), nil
+	defer release.MockFileExists(func(string) bool {
+		c.Check(s, Equals, "/proc/sys/fs/binfmt_misc/WSLInterop")
+		return true
 	})()
 
 	c.Check(release.IsWSL(), Equals, true)


### PR DESCRIPTION
# Summary
This PR fixes three problems:
- `isWSL`had two separate implementations. One in *snapd-apparmor* and one in *release*. The former has been removed.
- `release.isWSL` works by detecting `Microsoft` in the kernel name. This only works on WSL1. A more robust solution has been implemented.
- `snapd_apparmor.IsContainer` depends on systemd's detection of WSL, which is not 100% robust. The previous solution has been used here as well.


# Background

### WSL2 custom kernel
Users are free to specify the kernel they run, so the kernel name can really take any value. This makes kernel-name-based WSL2 detection mechanisms insufficient. For WSL1 the kernel is always Microsoft's.

### snapd's WSL detection
Current method of detecting if snapd is running on WSL only works for WSL1, but will return false in most instances of WSL2. It checks that the kernel version string contains the word `Microsoft`. But in the default WS2 kernel, this string is:
```
$ cat /proc/version
Linux version 5.15.57.1-microsoft-standard-WSL2 (oe-user@oe-host) (x86_64-msft-linux-gcc
(GCC) 9.3.0, GNU ld (GNU Binutils) 2.34.0.20200220) #1 SMP Wed Jul 27 02:20:31 UTC 2022
```
Notice that microsoft is lower case.

### systemd's WSL detection
This is used by `snapd_apparmor.IsContainer`. Systemd's implementation is also kernel-name-based, hence lackluster. It searches for a mach with either `Microsoft` or `WSL`. This will match all WSL1 and most WSL2 kernel names, but will miss custom kernels with none of these two words in their name.

### A more robust solution
The method we've been using for Ubuntu WSL is to check for file `/proc/sys/fs/binfmt_misc/WSLInterop` (it exists both in WSL1 and WSL2). You can see an example here: https://git.launchpad.net/ubuntu-release-upgrader/tree/DistUpgrade/DistUpgradeController.py#n2134.
