### PR TITLE
many: stub devicestate.Install{Finish,SetupStorageEncryption}()

### DIFF
--- a/client/systems.go
+++ b/client/systems.go
@@ -155,11 +155,11 @@ type SystemDetails struct {
 	// TODO: add EncryptionSupportInfo here too
 }
 
-func (client *Client) SystemDetails(seedLabel string) (*SystemDetails, error) {
+func (client *Client) SystemDetails(systemLabel string) (*SystemDetails, error) {
 	var rsp SystemDetails
 
-	if _, err := client.doSync("GET", "/v2/systems/"+seedLabel, nil, nil, nil, &rsp); err != nil {
-		return nil, xerrors.Errorf("cannot get details for system %q: %v", seedLabel, err)
+	if _, err := client.doSync("GET", "/v2/systems/"+systemLabel, nil, nil, nil, &rsp); err != nil {
+		return nil, xerrors.Errorf("cannot get details for system %q: %v", systemLabel, err)
 	}
 	return &rsp, nil
 }

--- a/client/systems.go
+++ b/client/systems.go
@@ -179,20 +179,6 @@ const (
 	InstallStepFinish InstallStep = "finish"
 )
 
-type InstallVolumeStructure struct {
-	*gadget.VolumeStructure
-
-	// The installer need to set those as needed depending on step.
-	Device            string `json:"device,omitempty"`
-	UnencryptedDevice string `json:"unencrypted-device,omitempty"`
-}
-
-type InstallVolume struct {
-	*gadget.Volume
-
-	Structure []InstallVolumeStructure `json:"structure"`
-}
-
 type InstallSystemOptions struct {
 	// Step is the install step, either "setup-storage-encryption"
 	// or "finish".
@@ -200,7 +186,7 @@ type InstallSystemOptions struct {
 
 	// OnVolumes is the volume description of the volumes that the
 	// given step should operate on.
-	OnVolumes map[string]*InstallVolume `json:"on-volumes,omitempty"`
+	OnVolumes map[string]*gadget.Volume `json:"on-volumes,omitempty"`
 }
 
 // InstallSystem will perform the given install step for the given volumes

--- a/client/systems_test.go
+++ b/client/systems_test.go
@@ -331,39 +331,26 @@ func (cs *clientSuite) TestRequestSystemInstallHappy(c *check.C) {
 		"status-code": 202,
 		"change": "42"
 	}`
-	vols := map[string]*client.InstallVolume{
+	vols := map[string]*gadget.Volume{
 		"pc": {
-			Volume: &gadget.Volume{
-				Schema:     "dos",
-				Bootloader: "mbr",
-				ID:         "id",
-				// Note that name is not exported as json
-				Name: "pc",
-				// Note that this will be "shadowed"
-				// and not actually be visible, as it
-				// is more nested, see
-				// https://pkg.go.dev/encoding/json#Marshal
-				Structure: []gadget.VolumeStructure{
-					{
-						Name:  "we-do-not-not-see-this-name",
-						Label: "we-do-not-see-this-label",
-					},
-				},
-			},
-			Structure: []client.InstallVolumeStructure{
+			Schema:     "dos",
+			Bootloader: "mbr",
+			ID:         "id",
+			// Note that name is not exported as json
+			Name: "pc",
+			Structure: []gadget.VolumeStructure{
 				{
 					Device: "/dev/sda1",
-					VolumeStructure: &gadget.VolumeStructure{
-						Label:      "label",
-						Name:       "vol-name",
-						ID:         "id",
-						Size:       1234,
-						Type:       "type",
-						Filesystem: "fs",
-						Role:       "system-boot",
-						// not exported to json
-						VolumeName: "vol-name",
-					},
+
+					Label:      "label",
+					Name:       "vol-name",
+					ID:         "id",
+					Size:       1234,
+					Type:       "type",
+					Filesystem: "fs",
+					Role:       "system-boot",
+					// not exported to json
+					VolumeName: "vol-name",
 				},
 			},
 		},

--- a/daemon/api_systems.go
+++ b/daemon/api_systems.go
@@ -108,6 +108,11 @@ var deviceManagerSystemAndGadgetInfo = func(dm *devicestate.DeviceManager, syste
 	return dm.SystemAndGadgetInfo(systemLabel)
 }
 
+var (
+	devicestateInstallFinish                 = devicestate.InstallFinish
+	devicestateInstallSetupStorageEncryption = devicestate.InstallSetupStorageEncryption
+)
+
 func getSystemDetails(c *Command, r *http.Request, user *auth.UserState) Response {
 	wantedSystemLabel := muxVars(r)["label"]
 
@@ -215,7 +220,24 @@ func postSystemActionDo(c *Command, systemLabel string, req *systemActionRequest
 }
 
 func postSystemActionInstall(c *Command, systemLabel string, req *systemActionRequest) Response {
-	// TODO: call new devicestate.InstallStep()
-	// TODO2: ensure devicestate.InstallStep() checks that systemLabel is not empty
-	return BadRequest("system action install is not implemented yet")
+	st := c.d.overlord.State()
+	st.Lock()
+	defer st.Unlock()
+
+	switch req.Step {
+	case client.InstallStepSetupStorageEncryption:
+		chg, err := devicestateInstallSetupStorageEncryption(st, systemLabel, req.OnVolumes)
+		if err != nil {
+			return BadRequest("cannot setup storage encryption for install from %q: %v", systemLabel, err)
+		}
+		return AsyncResponse(nil, chg.ID())
+	case client.InstallStepFinish:
+		chg, err := devicestateInstallFinish(st, systemLabel, req.OnVolumes)
+		if err != nil {
+			return BadRequest("cannot finish install for %q: %v", systemLabel, err)
+		}
+		return AsyncResponse(nil, chg.ID())
+	default:
+		return BadRequest("unsupported install step %q", req.Step)
+	}
 }

--- a/daemon/api_systems_test.go
+++ b/daemon/api_systems_test.go
@@ -984,14 +984,14 @@ func (s *systemsSuite) TestSystemInstallActionFinishCallsDevicestate(c *check.C)
 	s.testSystemInstallActionCallsDevicestate(c, "finish", daemon.MockDevicestateInstallFinish)
 }
 
-func (s *systemsSuite) testSystemInstallActionCallsDevicestate(c *check.C, step string, mocker func(func(st *state.State, label string, onVolumes map[string]*client.InstallVolume) (*state.Change, error)) (restore func())) {
+func (s *systemsSuite) testSystemInstallActionCallsDevicestate(c *check.C, step string, mocker func(func(st *state.State, label string, onVolumes map[string]*gadget.Volume) (*state.Change, error)) (restore func())) {
 	d := s.daemon(c)
 	st := d.Overlord().State()
 
 	nCalls := 0
-	var gotOnVolumes map[string]*client.InstallVolume
+	var gotOnVolumes map[string]*gadget.Volume
 	var gotLabel string
-	r := mocker(func(st *state.State, label string, onVolumes map[string]*client.InstallVolume) (*state.Change, error) {
+	r := mocker(func(st *state.State, label string, onVolumes map[string]*gadget.Volume) (*state.Change, error) {
 		gotLabel = label
 		gotOnVolumes = onVolumes
 		nCalls++
@@ -1023,11 +1023,9 @@ func (s *systemsSuite) testSystemInstallActionCallsDevicestate(c *check.C, step 
 	c.Check(chg.ID(), check.Equals, "1")
 	c.Check(nCalls, check.Equals, 1)
 	c.Check(gotLabel, check.Equals, "20191119")
-	c.Check(gotOnVolumes, check.DeepEquals, map[string]*client.InstallVolume{
+	c.Check(gotOnVolumes, check.DeepEquals, map[string]*gadget.Volume{
 		"pc": {
-			Volume: &gadget.Volume{
-				Bootloader: "grub",
-			},
+			Bootloader: "grub",
 		},
 	})
 }

--- a/daemon/export_api_systems_test.go
+++ b/daemon/export_api_systems_test.go
@@ -20,8 +20,10 @@
 package daemon
 
 import (
+	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/overlord/devicestate"
+	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -40,5 +42,17 @@ type (
 func MockDeviceManagerSystemAndGadgetInfo(f func(*devicestate.DeviceManager, string) (*devicestate.System, *gadget.Info, error)) (restore func()) {
 	restore = testutil.Backup(&deviceManagerSystemAndGadgetInfo)
 	deviceManagerSystemAndGadgetInfo = f
+	return restore
+}
+
+func MockDevicestateInstallFinish(f func(*state.State, string, map[string]*client.InstallVolume) (*state.Change, error)) (restore func()) {
+	restore = testutil.Backup(&devicestateInstallFinish)
+	devicestateInstallFinish = f
+	return restore
+}
+
+func MockDevicestateInstallSetupStorageEncryption(f func(*state.State, string, map[string]*client.InstallVolume) (*state.Change, error)) (restore func()) {
+	restore = testutil.Backup(&devicestateInstallSetupStorageEncryption)
+	devicestateInstallSetupStorageEncryption = f
 	return restore
 }

--- a/daemon/export_api_systems_test.go
+++ b/daemon/export_api_systems_test.go
@@ -20,7 +20,6 @@
 package daemon
 
 import (
-	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/state"
@@ -45,13 +44,13 @@ func MockDeviceManagerSystemAndGadgetInfo(f func(*devicestate.DeviceManager, str
 	return restore
 }
 
-func MockDevicestateInstallFinish(f func(*state.State, string, map[string]*client.InstallVolume) (*state.Change, error)) (restore func()) {
+func MockDevicestateInstallFinish(f func(*state.State, string, map[string]*gadget.Volume) (*state.Change, error)) (restore func()) {
 	restore = testutil.Backup(&devicestateInstallFinish)
 	devicestateInstallFinish = f
 	return restore
 }
 
-func MockDevicestateInstallSetupStorageEncryption(f func(*state.State, string, map[string]*client.InstallVolume) (*state.Change, error)) (restore func()) {
+func MockDevicestateInstallSetupStorageEncryption(f func(*state.State, string, map[string]*gadget.Volume) (*state.Change, error)) (restore func()) {
 	restore = testutil.Backup(&devicestateInstallSetupStorageEncryption)
 	devicestateInstallSetupStorageEncryption = f
 	return restore

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -158,6 +158,12 @@ type VolumeStructure struct {
 	// Content of the structure
 	Content []VolumeContent `yaml:"content" json:"content"`
 	Update  VolumeUpdate    `yaml:"update" json:"update"`
+
+	// Note that the Device and UnencryptedDevice fields will never
+	// be part of the yaml and just used as part of the POST
+	// /systems/<label> API that is used by an installer.
+	Device            string `yaml:"-" json:"device,omitempty"`
+	UnencryptedDevice string `yaml:"-" json:"unencrypted-device,omitempty"`
 }
 
 // HasFilesystem returns true if the structure is using a filesystem.

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snapfile"
 	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/strutil"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -3614,10 +3615,13 @@ func (s *gadgetYamlTestSuite) TestGadgetInfoHasSameYamlAndJsonTags(c *C) {
 		return s.PkgPath == ""
 	}
 
-	tagsValid := func(c *C, i interface{}) {
+	tagsValid := func(c *C, i interface{}, skip []string) {
 		st := reflect.TypeOf(i).Elem()
 		num := st.NumField()
 		for i := 0; i < num; i++ {
+			if strutil.ListContains(skip, st.Field(i).Name) {
+				continue
+			}
 			// ensure yaml/json is consistent
 			tagYaml := st.Field(i).Tag.Get("yaml")
 			tagJSON := st.Field(i).Tag.Get("json")
@@ -3634,11 +3638,12 @@ func (s *gadgetYamlTestSuite) TestGadgetInfoHasSameYamlAndJsonTags(c *C) {
 		}
 	}
 
-	tagsValid(c, &gadget.Volume{})
-	tagsValid(c, &gadget.VolumeStructure{})
-	tagsValid(c, &gadget.VolumeContent{})
-	tagsValid(c, &gadget.RelativeOffset{})
-	tagsValid(c, &gadget.VolumeUpdate{})
+	tagsValid(c, &gadget.Volume{}, nil)
+	skip := []string{"Device", "UnencryptedDevice"}
+	tagsValid(c, &gadget.VolumeStructure{}, skip)
+	tagsValid(c, &gadget.VolumeContent{}, nil)
+	tagsValid(c, &gadget.RelativeOffset{}, nil)
+	tagsValid(c, &gadget.VolumeUpdate{}, nil)
 }
 
 func (s *gadgetYamlTestSuite) TestGadgetInfoVolumeInternalFieldsNoJSON(c *C) {

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -206,6 +206,10 @@ func Manager(s *state.State, hookManager *hookstate.HookManager, runner *state.T
 	runner.AddHandler("finalize-recovery-system", m.doFinalizeTriedRecoverySystem, m.undoFinalizeTriedRecoverySystem)
 	runner.AddCleanup("finalize-recovery-system", m.cleanupRecoverySystem)
 
+	// used from the install API
+	runner.AddHandler("install-finish", m.doInstallFinish, nil)
+	runner.AddHandler("install-setup-storage-encryption", m.doInstallSetupStorageEncryption, nil)
+
 	runner.AddBlocked(gadgetUpdateBlocked)
 
 	// wire FDE kernel hook support into boot

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -207,6 +207,7 @@ func Manager(s *state.State, hookManager *hookstate.HookManager, runner *state.T
 	runner.AddCleanup("finalize-recovery-system", m.cleanupRecoverySystem)
 
 	// used from the install API
+	// TODO: use better task names that are close to our usual pattern
 	runner.AddHandler("install-finish", m.doInstallFinish, nil)
 	runner.AddHandler("install-setup-storage-encryption", m.doInstallSetupStorageEncryption, nil)
 
@@ -1821,7 +1822,7 @@ func (m *DeviceManager) SystemAndGadgetInfo(wantedSystemLabel string) (*System, 
 		return nil, nil, err
 	}
 
-	// 2. get the gadget volumes for the given seed-label
+	// 2. get the gadget volumes for the given system-label
 	perf := &timings.Timings{}
 	if err := s.LoadEssentialMeta([]snap.Type{snap.TypeGadget}, perf); err != nil {
 		return nil, nil, fmt.Errorf("cannot load gadget snap metadata: %v", err)

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/logger"
@@ -1073,5 +1074,45 @@ func CreateRecoverySystem(st *state.State, label string) (*state.Change, error) 
 		return nil, err
 	}
 	chg.AddAll(ts)
+	return chg, nil
+}
+
+// InstallFinish creates a change that will finish the install for the given
+// label and volumes. This includes writing missing volume content, seting
+// up the bootloader and installing the kernel.
+func InstallFinish(st *state.State, label string, onVolumes map[string]*client.InstallVolume) (*state.Change, error) {
+	if label == "" {
+		return nil, fmt.Errorf("cannot finish install with an empty system label")
+	}
+	if onVolumes == nil {
+		return nil, fmt.Errorf("cannot finish install without volumes data")
+	}
+
+	chg := st.NewChange("install-step-finish", fmt.Sprintf("Finish install for label %q", label))
+	finishTask := st.NewTask("install-finish", fmt.Sprintf("Finish install for label %q", label))
+	finishTask.Set("seed-label", label)
+	finishTask.Set("on-volumes", onVolumes)
+	chg.AddTask(finishTask)
+
+	return chg, nil
+}
+
+// InstallSetupStorageEncryption creates a change that will setup the
+// storage encryption for the install of the given label and
+// volumes.
+func InstallSetupStorageEncryption(st *state.State, label string, onVolumes map[string]*client.InstallVolume) (*state.Change, error) {
+	if label == "" {
+		return nil, fmt.Errorf("cannot setup storage encryption with an empty system label")
+	}
+	if onVolumes == nil {
+		return nil, fmt.Errorf("cannot setup storage encryption without volumes data")
+	}
+
+	chg := st.NewChange("install-step-setup-storage-encryption", fmt.Sprintf("Setup storage encryption for label %q", label))
+	setupStorageEncryptionTask := st.NewTask("install-setup-storage-encryption", fmt.Sprintf("Setup storage encryption for label %q", label))
+	setupStorageEncryptionTask.Set("seed-label", label)
+	setupStorageEncryptionTask.Set("on-volumes", onVolumes)
+	chg.AddTask(setupStorageEncryptionTask)
+
 	return chg, nil
 }

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -33,7 +33,6 @@ import (
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/boot"
-	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/logger"
@@ -1080,7 +1079,7 @@ func CreateRecoverySystem(st *state.State, label string) (*state.Change, error) 
 // InstallFinish creates a change that will finish the install for the given
 // label and volumes. This includes writing missing volume content, seting
 // up the bootloader and installing the kernel.
-func InstallFinish(st *state.State, label string, onVolumes map[string]*client.InstallVolume) (*state.Change, error) {
+func InstallFinish(st *state.State, label string, onVolumes map[string]*gadget.Volume) (*state.Change, error) {
 	if label == "" {
 		return nil, fmt.Errorf("cannot finish install with an empty system label")
 	}
@@ -1100,7 +1099,7 @@ func InstallFinish(st *state.State, label string, onVolumes map[string]*client.I
 // InstallSetupStorageEncryption creates a change that will setup the
 // storage encryption for the install of the given label and
 // volumes.
-func InstallSetupStorageEncryption(st *state.State, label string, onVolumes map[string]*client.InstallVolume) (*state.Change, error) {
+func InstallSetupStorageEncryption(st *state.State, label string, onVolumes map[string]*gadget.Volume) (*state.Change, error) {
 	if label == "" {
 		return nil, fmt.Errorf("cannot setup storage encryption with an empty system label")
 	}

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -1088,9 +1088,9 @@ func InstallFinish(st *state.State, label string, onVolumes map[string]*client.I
 		return nil, fmt.Errorf("cannot finish install without volumes data")
 	}
 
-	chg := st.NewChange("install-step-finish", fmt.Sprintf("Finish install for label %q", label))
-	finishTask := st.NewTask("install-finish", fmt.Sprintf("Finish install for label %q", label))
-	finishTask.Set("seed-label", label)
+	chg := st.NewChange("install-step-finish", fmt.Sprintf("Finish setup of run system for %q", label))
+	finishTask := st.NewTask("install-finish", fmt.Sprintf("Finish setup of run system for %q", label))
+	finishTask.Set("system-label", label)
 	finishTask.Set("on-volumes", onVolumes)
 	chg.AddTask(finishTask)
 
@@ -1108,9 +1108,9 @@ func InstallSetupStorageEncryption(st *state.State, label string, onVolumes map[
 		return nil, fmt.Errorf("cannot setup storage encryption without volumes data")
 	}
 
-	chg := st.NewChange("install-step-setup-storage-encryption", fmt.Sprintf("Setup storage encryption for label %q", label))
-	setupStorageEncryptionTask := st.NewTask("install-setup-storage-encryption", fmt.Sprintf("Setup storage encryption for label %q", label))
-	setupStorageEncryptionTask.Set("seed-label", label)
+	chg := st.NewChange("install-step-setup-storage-encryption", fmt.Sprintf("Setup storage encryption for installing system %q", label))
+	setupStorageEncryptionTask := st.NewTask("install-setup-storage-encryption", fmt.Sprintf("Setup storage encryption for installing system %q", label))
+	setupStorageEncryptionTask.Set("system-label", label)
 	setupStorageEncryptionTask.Set("on-volumes", onVolumes)
 	chg.AddTask(setupStorageEncryptionTask)
 

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -3670,7 +3670,7 @@ type installStepSuite struct {
 var _ = Suite(&installStepSuite{})
 
 func (s *installStepSuite) SetUpTest(c *C) {
-	classic := false
+	classic := true
 	s.deviceMgrBaseSuite.setupBaseTest(c, classic)
 }
 

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -39,7 +39,6 @@ import (
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/bootloader/bootloadertest"
-	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/gadget/install"
@@ -3675,11 +3674,9 @@ func (s *installStepSuite) SetUpTest(c *C) {
 	s.deviceMgrBaseSuite.setupBaseTest(c, classic)
 }
 
-var mockOnVolumes = map[string]*client.InstallVolume{
+var mockOnVolumes = map[string]*gadget.Volume{
 	"pc": {
-		Volume: &gadget.Volume{
-			Bootloader: "grub",
-		},
+		Bootloader: "grub",
 	},
 }
 
@@ -3717,7 +3714,7 @@ func (s *installStepSuite) TestDeviceManagerInstallFinishTasksAndChange(c *C) {
 	err = tskInstallFinish.Get("system-label", &onLabel)
 	c.Assert(err, IsNil)
 	c.Assert(onLabel, Equals, "1234")
-	var onVols map[string]*client.InstallVolume
+	var onVols map[string]*gadget.Volume
 	err = tskInstallFinish.Get("on-volumes", &onVols)
 	c.Assert(err, IsNil)
 	c.Assert(onVols, DeepEquals, mockOnVolumes)
@@ -3775,7 +3772,7 @@ func (s *installStepSuite) TestDeviceManagerInstallSetupStorageEncryptionTasksAn
 	err = tskInstallFinish.Get("system-label", &onLabel)
 	c.Assert(err, IsNil)
 	c.Assert(onLabel, Equals, "1234")
-	var onVols map[string]*client.InstallVolume
+	var onVols map[string]*gadget.Volume
 	err = tskInstallFinish.Get("on-volumes", &onVols)
 	c.Assert(err, IsNil)
 	c.Assert(onVols, DeepEquals, mockOnVolumes)

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -3708,13 +3708,13 @@ func (s *installStepSuite) TestDeviceManagerInstallFinishTasksAndChange(c *C) {
 	chg, err := devicestate.InstallFinish(s.state, "1234", mockOnVolumes)
 	c.Assert(err, IsNil)
 	c.Assert(chg, NotNil)
-	c.Check(chg.Summary(), Matches, `Finish install for label "1234"`)
+	c.Check(chg.Summary(), Matches, `Finish setup of run system for "1234"`)
 	tsks := chg.Tasks()
 	c.Check(tsks, HasLen, 1)
 	tskInstallFinish := tsks[0]
-	c.Check(tskInstallFinish.Summary(), Matches, `Finish install for label "1234"`)
+	c.Check(tskInstallFinish.Summary(), Matches, `Finish setup of run system for "1234"`)
 	var onLabel string
-	err = tskInstallFinish.Get("seed-label", &onLabel)
+	err = tskInstallFinish.Get("system-label", &onLabel)
 	c.Assert(err, IsNil)
 	c.Assert(onLabel, Equals, "1234")
 	var onVols map[string]*client.InstallVolume
@@ -3766,13 +3766,13 @@ func (s *installStepSuite) TestDeviceManagerInstallSetupStorageEncryptionTasksAn
 	chg, err := devicestate.InstallSetupStorageEncryption(s.state, "1234", mockOnVolumes)
 	c.Assert(err, IsNil)
 	c.Assert(chg, NotNil)
-	c.Check(chg.Summary(), Matches, `Setup storage encryption for label "1234"`)
+	c.Check(chg.Summary(), Matches, `Setup storage encryption for installing system "1234"`)
 	tsks := chg.Tasks()
 	c.Check(tsks, HasLen, 1)
 	tskInstallFinish := tsks[0]
-	c.Check(tskInstallFinish.Summary(), Matches, `Setup storage encryption for label "1234"`)
+	c.Check(tskInstallFinish.Summary(), Matches, `Setup storage encryption for installing system "1234"`)
 	var onLabel string
-	err = tskInstallFinish.Get("seed-label", &onLabel)
+	err = tskInstallFinish.Get("system-label", &onLabel)
 	c.Assert(err, IsNil)
 	c.Assert(onLabel, Equals, "1234")
 	var onVols map[string]*client.InstallVolume

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -1184,7 +1184,7 @@ func (m *DeviceManager) doInstallFinish(t *state.Task, _ *tomb.Tomb) error {
 	defer st.Unlock()
 
 	var seedLabel string
-	if err := t.Get("seed-label", &seedLabel); err != nil {
+	if err := t.Get("system-label", &seedLabel); err != nil {
 		return err
 	}
 	var onVolumes map[string]*client.InstallVolume
@@ -1207,7 +1207,7 @@ func (m *DeviceManager) doInstallSetupStorageEncryption(t *state.Task, _ *tomb.T
 	defer st.Unlock()
 
 	var seedLabel string
-	if err := t.Get("seed-label", &seedLabel); err != nil {
+	if err := t.Get("system-label", &seedLabel); err != nil {
 		return err
 	}
 	var onVolumes map[string]*client.InstallVolume

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -40,7 +40,6 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/sysdb"
 	"github.com/snapcore/snapd/boot"
-	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/gadget/device"
@@ -1187,7 +1186,7 @@ func (m *DeviceManager) doInstallFinish(t *state.Task, _ *tomb.Tomb) error {
 	if err := t.Get("system-label", &seedLabel); err != nil {
 		return err
 	}
-	var onVolumes map[string]*client.InstallVolume
+	var onVolumes map[string]*gadget.Volume
 	if err := t.Get("on-volumes", &onVolumes); err != nil {
 		return err
 	}
@@ -1210,7 +1209,7 @@ func (m *DeviceManager) doInstallSetupStorageEncryption(t *state.Task, _ *tomb.T
 	if err := t.Get("system-label", &seedLabel); err != nil {
 		return err
 	}
-	var onVolumes map[string]*client.InstallVolume
+	var onVolumes map[string]*gadget.Volume
 	if err := t.Get("on-volumes", &onVolumes); err != nil {
 		return err
 	}

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -40,6 +40,7 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/sysdb"
 	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/gadget/device"
@@ -1175,4 +1176,47 @@ func rotateEncryptionKeys() error {
 		return fmt.Errorf("cannot transition the encryption key: %v", err)
 	}
 	return nil
+}
+
+func (m *DeviceManager) doInstallFinish(t *state.Task, _ *tomb.Tomb) error {
+	st := t.State()
+	st.Lock()
+	defer st.Unlock()
+
+	var seedLabel string
+	if err := t.Get("seed-label", &seedLabel); err != nil {
+		return err
+	}
+	var onVolumes map[string]*client.InstallVolume
+	if err := t.Get("on-volumes", &onVolumes); err != nil {
+		return err
+	}
+	logger.Debugf("install-finish for %q on %v", seedLabel, onVolumes)
+	// TODO: use the seed to get gadget/kernel
+	// - install missing volumes structure content
+	// - install gadget assets
+	// - install kenrel
+	// - make system bootable (include writing modeenv)
+
+	return fmt.Errorf("finish install step not implemented yet")
+}
+
+func (m *DeviceManager) doInstallSetupStorageEncryption(t *state.Task, _ *tomb.Tomb) error {
+	st := t.State()
+	st.Lock()
+	defer st.Unlock()
+
+	var seedLabel string
+	if err := t.Get("seed-label", &seedLabel); err != nil {
+		return err
+	}
+	var onVolumes map[string]*client.InstallVolume
+	if err := t.Get("on-volumes", &onVolumes); err != nil {
+		return err
+	}
+	logger.Debugf("install-setup-storage-encyption for %q on %v", seedLabel, onVolumes)
+	// TODO: find device with role system-{data,seed} and setup
+	// storage encryption
+
+	return fmt.Errorf("setup storage encryption step not implemented yet")
 }

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -1182,15 +1182,15 @@ func (m *DeviceManager) doInstallFinish(t *state.Task, _ *tomb.Tomb) error {
 	st.Lock()
 	defer st.Unlock()
 
-	var seedLabel string
-	if err := t.Get("system-label", &seedLabel); err != nil {
+	var systemLabel string
+	if err := t.Get("system-label", &systemLabel); err != nil {
 		return err
 	}
 	var onVolumes map[string]*gadget.Volume
 	if err := t.Get("on-volumes", &onVolumes); err != nil {
 		return err
 	}
-	logger.Debugf("install-finish for %q on %v", seedLabel, onVolumes)
+	logger.Debugf("install-finish for %q on %v", systemLabel, onVolumes)
 	// TODO: use the seed to get gadget/kernel
 	// - install missing volumes structure content
 	// - install gadget assets
@@ -1205,15 +1205,15 @@ func (m *DeviceManager) doInstallSetupStorageEncryption(t *state.Task, _ *tomb.T
 	st.Lock()
 	defer st.Unlock()
 
-	var seedLabel string
-	if err := t.Get("system-label", &seedLabel); err != nil {
+	var systemLabel string
+	if err := t.Get("system-label", &systemLabel); err != nil {
 		return err
 	}
 	var onVolumes map[string]*gadget.Volume
 	if err := t.Get("on-volumes", &onVolumes); err != nil {
 		return err
 	}
-	logger.Debugf("install-setup-storage-encyption for %q on %v", seedLabel, onVolumes)
+	logger.Debugf("install-setup-storage-encyption for %q on %v", systemLabel, onVolumes)
 	// TODO: find device with role system-{data,seed} and setup
 	// storage encryption
 


### PR DESCRIPTION
This commit adds code in the snapd daemon so that the installer
API calls `devicestate.InstallFinish()` and
`devicestate.InstallSetupStorageEncryption()` when the
`/systems/<label>` POST endpoint is called.

The devicestate part will create a change that sets up the
respective action and wires the tasks into the device managers
task handlers. The tasks itself are stubs and just return an
error for now. A followup will be used to write them up.

A bit of a question if devicestate should take `client.InstallVolume`
directly or if this needs to be moved or wrapped (we do use
`client` in `overlord` for some specific things already so not
a red flag it seems).

