### PR TITLE
snapdenv: added wsl to userAgent

### DIFF
--- a/snapdenv/useragent.go
+++ b/snapdenv/useragent.go
@@ -44,6 +44,9 @@ func SetUserAgentFromVersion(version string, probeForceDevMode func() bool, extr
 	if Testing() {
 		extras = append(extras, "testing")
 	}
+	if release.OnWSL {
+		extras = append(extras, "wsl")
+	}
 	extraProdStr := ""
 	if len(extraProds) != 0 {
 		extraProdStr = " " + strings.Join(extraProds, " ")

--- a/snapdenv/useragent.go
+++ b/snapdenv/useragent.go
@@ -41,11 +41,11 @@ func SetUserAgentFromVersion(version string, probeForceDevMode func() bool, extr
 	if probeForceDevMode != nil && probeForceDevMode() {
 		extras = append(extras, "devmode")
 	}
-	if Testing() {
-		extras = append(extras, "testing")
-	}
 	if release.OnWSL {
 		extras = append(extras, "wsl")
+	}
+	if Testing() {
+		extras = append(extras, "testing")
 	}
 	extraProdStr := ""
 	if len(extraProds) != 0 {

--- a/snapdenv/useragent_test.go
+++ b/snapdenv/useragent_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snapdenv"
+	"github.com/snapcore/snapd/testutil"
 )
 
 type UASuite struct {
@@ -40,14 +41,6 @@ func (s *UASuite) SetUpTest(c *C) {
 
 func (s *UASuite) TearDownTest(c *C) {
 	s.restore()
-}
-
-func mockWsl(onWSL bool) (restorer func()) {
-	oldWSL := release.OnWSL
-	release.OnWSL = onWSL
-	return func() {
-		release.OnWSL = oldWSL
-	}
 }
 
 func (s *UASuite) TestUserAgent(c *C) {
@@ -74,17 +67,17 @@ func (s *UASuite) TestUserAgent(c *C) {
 }
 
 func (s *UASuite) TestUserAgentWSL(c *C) {
-	restore := mockWsl(false)
+	defer testutil.Backup(&release.OnWSL)
+
+	release.OnWSL = false
 	snapdenv.SetUserAgentFromVersion("10", nil)
 	ua := snapdenv.UserAgent()
 	c.Check(strings.Contains(ua, "wsl"), Equals, false)
-	restore()
 
-	restore = mockWsl(true)
+	release.OnWSL = true
 	snapdenv.SetUserAgentFromVersion("10", nil)
 	ua = snapdenv.UserAgent()
 	c.Check(strings.Contains(ua, "wsl"), Equals, true)
-	restore()
 }
 
 func (s *UASuite) TestStripUnsafeRunes(c *C) {

--- a/snapdenv/useragent_test.go
+++ b/snapdenv/useragent_test.go
@@ -67,7 +67,7 @@ func (s *UASuite) TestUserAgent(c *C) {
 }
 
 func (s *UASuite) TestUserAgentWSL(c *C) {
-	defer testutil.Backup(&release.OnWSL)
+	defer testutil.Backup(&release.OnWSL)()
 
 	release.OnWSL = false
 	snapdenv.SetUserAgentFromVersion("10", nil)


### PR DESCRIPTION
Adds wsl as an extra piece of information to the user agent string.

Snapd is not officially supported but there are workarounds to use it, this identifier would help detecting it when that is the case.

~Will stay as draft until https://github.com/snapcore/snapd/pull/12135 is merged or rejected. The linked PR changes the way to mock the WSL instance check. Once that is done, a check can be added to the unit tests so as to check that the string is indeed only added on (mocked) wsl.~
Nevermind, I found a way simpler to test this.