### PR TITLE
store: use typed valset keys in store package

### DIFF
--- a/asserts/snapasserts/validation_sets.go
+++ b/asserts/snapasserts/validation_sets.go
@@ -85,8 +85,14 @@ func NewValidationSetKey(vs asserts.ValidationSet) ValidationSetKey {
 	return ValidationSetKey(strings.Join(vs.Ref().PrimaryKey, "/"))
 }
 
-func (vsk ValidationSetKey) String() string {
-	return string(vsk)
+func (k ValidationSetKey) String() string {
+	return string(k)
+}
+
+// Components returns the components of the validation set's primary key (see
+// assertion types in asserts/asserts.go).
+func (k ValidationSetKey) Components() []string {
+	return strings.Split(k.String(), "/")
 }
 
 // ValidationSetKeySlice can be used to sort slices of ValidationSetKey.

--- a/asserts/snapasserts/validation_sets.go
+++ b/asserts/snapasserts/validation_sets.go
@@ -81,7 +81,7 @@ type ValidationSetsValidationError struct {
 type ValidationSetKey string
 
 // NewValidationSetKey returns a validation set key for a validation set.
-func NewValidationSetKey(vs asserts.ValidationSet) ValidationSetKey {
+func NewValidationSetKey(vs *asserts.ValidationSet) ValidationSetKey {
 	return ValidationSetKey(strings.Join(vs.Ref().PrimaryKey, "/"))
 }
 
@@ -580,7 +580,7 @@ func (v *ValidationSets) CheckPresenceRequired(snapRef naming.SnapRef) ([]Valida
 			if vs == nil {
 				return nil, unspecifiedRevision, fmt.Errorf("internal error: no validation set for %q", rc.validationSetKey)
 			}
-			keys = append(keys, NewValidationSetKey(*vs))
+			keys = append(keys, NewValidationSetKey(vs))
 			// there may be constraints without revision; only set snapRev if
 			// it wasn't already determined. Note that if revisions are set,
 			// then they are the same, otherwise validation sets would be in
@@ -616,7 +616,7 @@ func (v *ValidationSets) CheckPresenceInvalid(snapRef naming.SnapRef) ([]Validat
 				if vs == nil {
 					return nil, fmt.Errorf("internal error: no validation set for %q", rc.validationSetKey)
 				}
-				keys = append(keys, NewValidationSetKey(*vs))
+				keys = append(keys, NewValidationSetKey(vs))
 			}
 		}
 	}

--- a/asserts/snapasserts/validation_sets_test.go
+++ b/asserts/snapasserts/validation_sets_test.go
@@ -1117,3 +1117,22 @@ func (s *validationSetsSuite) TestValidationSetKeySliceCommaSeparated(c *C) {
 	valSets := snapasserts.ValidationSetKeySlice([]snapasserts.ValidationSetKey{"1/a/a/1", "1/a/b/1", "1/a/b/2", "2/a/a/1"})
 	c.Assert(valSets.CommaSeparated(), Equals, "1/a/a/1,1/a/b/1,1/a/b/2,2/a/a/1")
 }
+
+func (s *validationSetsSuite) TestValidationSetKeyComponents(c *C) {
+	valsetKey := snapasserts.NewValidationSetKey(*assertstest.FakeAssertion(map[string]interface{}{
+		"type":         "validation-set",
+		"series":       "a",
+		"authority-id": "b",
+		"account-id":   "b",
+		"name":         "c",
+		"sequence":     "13",
+		"snaps": []interface{}{
+			map[string]interface{}{
+				"name":     "my-snap",
+				"id":       "mysnapididididididididididididid",
+				"presence": "required",
+			},
+		},
+	}).(*asserts.ValidationSet))
+	c.Assert(valsetKey.Components(), DeepEquals, []string{"a", "b", "c", "13"})
+}

--- a/asserts/snapasserts/validation_sets_test.go
+++ b/asserts/snapasserts/validation_sets_test.go
@@ -1099,7 +1099,7 @@ func (s *validationSetsSuite) TestValidationSetKeyFormat(c *C) {
 		},
 	}).(*asserts.ValidationSet)
 
-	valSetKey := snapasserts.NewValidationSetKey(*valSet)
+	valSetKey := snapasserts.NewValidationSetKey(valSet)
 	c.Assert(valSetKey.String(), Equals, fmt.Sprintf("%s/%s/%s/%d", series, acc, name, sequence))
 }
 
@@ -1119,7 +1119,7 @@ func (s *validationSetsSuite) TestValidationSetKeySliceCommaSeparated(c *C) {
 }
 
 func (s *validationSetsSuite) TestValidationSetKeyComponents(c *C) {
-	valsetKey := snapasserts.NewValidationSetKey(*assertstest.FakeAssertion(map[string]interface{}{
+	valsetKey := snapasserts.NewValidationSetKey(assertstest.FakeAssertion(map[string]interface{}{
 		"type":         "validation-set",
 		"series":       "a",
 		"authority-id": "b",

--- a/overlord/snapstate/autorefresh_gating_test.go
+++ b/overlord/snapstate/autorefresh_gating_test.go
@@ -2916,10 +2916,10 @@ func (s *validationSetsSuite) TestAutoRefreshPhase1WithValidationSets(c *C) {
 	}, {
 		op: "storesvc-snap-action:action",
 		action: store.SnapAction{
-			Action:            "refresh",
-			InstanceName:      "snap-c",
-			SnapID:            "snap-c-id",
-			ValidationSetKeys: []snapasserts.ValidationSetKey{"16/foo/bar/1"},
+			Action:         "refresh",
+			InstanceName:   "snap-c",
+			SnapID:         "snap-c-id",
+			ValidationSets: []snapasserts.ValidationSetKey{"16/foo/bar/1"},
 		},
 		revno: snap.R(11),
 	}, {
@@ -2949,21 +2949,21 @@ func (s *validationSetsSuite) TestAutoRefreshPhase1WithValidationSets(c *C) {
 	c.Check(s.fakeBackend.ops[1], DeepEquals, fakeOp{
 		op: "storesvc-snap-action:action",
 		action: store.SnapAction{
-			Action:            "refresh",
-			InstanceName:      "snap-c",
-			SnapID:            "snap-c-id",
-			ValidationSetKeys: []snapasserts.ValidationSetKey{"16/foo/bar/1"},
+			Action:         "refresh",
+			InstanceName:   "snap-c",
+			SnapID:         "snap-c-id",
+			ValidationSets: []snapasserts.ValidationSetKey{"16/foo/bar/1"},
 		},
 		revno: snap.R(11),
 	})
 	c.Check(s.fakeBackend.ops[3], DeepEquals, fakeOp{
 		op: "storesvc-snap-action:action",
 		action: store.SnapAction{
-			Action:            "refresh",
-			InstanceName:      "some-snap",
-			SnapID:            "some-snap-id",
-			ValidationSetKeys: []snapasserts.ValidationSetKey{"16/foo/bar/1"},
-			Revision:          snap.R(11),
+			Action:         "refresh",
+			InstanceName:   "some-snap",
+			SnapID:         "some-snap-id",
+			ValidationSets: []snapasserts.ValidationSetKey{"16/foo/bar/1"},
+			Revision:       snap.R(11),
 		},
 		revno: snap.R(11),
 	})

--- a/overlord/snapstate/autorefresh_gating_test.go
+++ b/overlord/snapstate/autorefresh_gating_test.go
@@ -2916,10 +2916,10 @@ func (s *validationSetsSuite) TestAutoRefreshPhase1WithValidationSets(c *C) {
 	}, {
 		op: "storesvc-snap-action:action",
 		action: store.SnapAction{
-			Action:         "refresh",
-			InstanceName:   "snap-c",
-			SnapID:         "snap-c-id",
-			ValidationSets: [][]string{{"16", "foo", "bar", "1"}},
+			Action:            "refresh",
+			InstanceName:      "snap-c",
+			SnapID:            "snap-c-id",
+			ValidationSetKeys: []snapasserts.ValidationSetKey{"16/foo/bar/1"},
 		},
 		revno: snap.R(11),
 	}, {
@@ -2949,21 +2949,21 @@ func (s *validationSetsSuite) TestAutoRefreshPhase1WithValidationSets(c *C) {
 	c.Check(s.fakeBackend.ops[1], DeepEquals, fakeOp{
 		op: "storesvc-snap-action:action",
 		action: store.SnapAction{
-			Action:         "refresh",
-			InstanceName:   "snap-c",
-			SnapID:         "snap-c-id",
-			ValidationSets: [][]string{{"16", "foo", "bar", "1"}},
+			Action:            "refresh",
+			InstanceName:      "snap-c",
+			SnapID:            "snap-c-id",
+			ValidationSetKeys: []snapasserts.ValidationSetKey{"16/foo/bar/1"},
 		},
 		revno: snap.R(11),
 	})
 	c.Check(s.fakeBackend.ops[3], DeepEquals, fakeOp{
 		op: "storesvc-snap-action:action",
 		action: store.SnapAction{
-			Action:         "refresh",
-			InstanceName:   "some-snap",
-			SnapID:         "some-snap-id",
-			ValidationSets: [][]string{{"16", "foo", "bar", "1"}},
-			Revision:       snap.R(11),
+			Action:            "refresh",
+			InstanceName:      "some-snap",
+			SnapID:            "some-snap-id",
+			ValidationSetKeys: []snapasserts.ValidationSetKey{"16/foo/bar/1"},
+			Revision:          snap.R(11),
 		},
 		revno: snap.R(11),
 	})

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -2025,11 +2025,11 @@ func Switch(st *state.State, name string, opts *RevisionOptions) (*state.TaskSet
 
 // RevisionOptions control the selection of a snap revision.
 type RevisionOptions struct {
-	Channel           string
-	Revision          snap.Revision
-	ValidationSetKeys []snapasserts.ValidationSetKey
-	CohortKey         string
-	LeaveCohort       bool
+	Channel        string
+	Revision       snap.Revision
+	ValidationSets []snapasserts.ValidationSetKey
+	CohortKey      string
+	LeaveCohort    bool
 }
 
 // Update initiates a change updating a snap.

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -2025,11 +2025,11 @@ func Switch(st *state.State, name string, opts *RevisionOptions) (*state.TaskSet
 
 // RevisionOptions control the selection of a snap revision.
 type RevisionOptions struct {
-	Channel        string
-	Revision       snap.Revision
-	ValidationSets []snapasserts.ValidationSetKey
-	CohortKey      string
-	LeaveCohort    bool
+	Channel           string
+	Revision          snap.Revision
+	ValidationSetKeys []snapasserts.ValidationSetKey
+	CohortKey         string
+	LeaveCohort       bool
 }
 
 // Update initiates a change updating a snap.

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -4051,10 +4051,10 @@ func (s *validationSetsSuite) TestInstallSnapRequiredForValidationSet(c *C) {
 	expectedOp := fakeOp{
 		op: "storesvc-snap-action:action",
 		action: store.SnapAction{
-			Action:         "install",
-			InstanceName:   "some-snap",
-			Channel:        "stable",
-			ValidationSets: [][]string{{"16", "foo", "bar", "1"}},
+			Action:            "install",
+			InstanceName:      "some-snap",
+			Channel:           "stable",
+			ValidationSetKeys: []snapasserts.ValidationSetKey{"16/foo/bar/1"},
 		},
 		revno: snap.R(11),
 	}
@@ -4068,10 +4068,10 @@ func (s *validationSetsSuite) TestInstallSnapRequiredForValidationSetAtRevision(
 	expectedOp := fakeOp{
 		op: "storesvc-snap-action:action",
 		action: store.SnapAction{
-			Action:         "install",
-			Revision:       snap.R(2),
-			InstanceName:   "some-snap",
-			ValidationSets: [][]string{{"16", "foo", "bar", "1"}},
+			Action:            "install",
+			Revision:          snap.R(2),
+			InstanceName:      "some-snap",
+			ValidationSetKeys: []snapasserts.ValidationSetKey{"16/foo/bar/1"},
 		},
 		revno: snap.R(2),
 	}
@@ -4085,10 +4085,10 @@ func (s *validationSetsSuite) TestInstallSnapRequiredForValidationSetCohortIgnor
 	expectedOp := fakeOp{
 		op: "storesvc-snap-action:action",
 		action: store.SnapAction{
-			Action:         "install",
-			Revision:       snap.R(2),
-			InstanceName:   "some-snap",
-			ValidationSets: [][]string{{"16", "foo", "bar", "1"}},
+			Action:            "install",
+			Revision:          snap.R(2),
+			InstanceName:      "some-snap",
+			ValidationSetKeys: []snapasserts.ValidationSetKey{"16/foo/bar/1"},
 		},
 		revno: snap.R(2),
 	}
@@ -4196,10 +4196,10 @@ func (s *validationSetsSuite) TestInstallManyRequiredForValidationSetOK(c *C) {
 	expectedOps := fakeOps{{
 		op: "storesvc-snap-action:action",
 		action: store.SnapAction{
-			Action:         "install",
-			InstanceName:   "one",
-			Channel:        "stable",
-			ValidationSets: [][]string{{"16", "foo", "bar", "1"}},
+			Action:            "install",
+			InstanceName:      "one",
+			Channel:           "stable",
+			ValidationSetKeys: []snapasserts.ValidationSetKey{"16/foo/bar/1"},
 		},
 		revno: snap.R(11),
 	}, {
@@ -4223,19 +4223,19 @@ func (s *validationSetsSuite) TestInstallManyRequiredRevisionForValidationSetOK(
 	expectedOps := fakeOps{{
 		op: "storesvc-snap-action:action",
 		action: store.SnapAction{
-			Action:         "install",
-			InstanceName:   "one",
-			Revision:       snap.R(11),
-			ValidationSets: [][]string{{"16", "foo", "bar", "1"}},
+			Action:            "install",
+			InstanceName:      "one",
+			Revision:          snap.R(11),
+			ValidationSetKeys: []snapasserts.ValidationSetKey{"16/foo/bar/1"},
 		},
 		revno: snap.R(11),
 	}, {
 		op: "storesvc-snap-action:action",
 		action: store.SnapAction{
-			Action:         "install",
-			InstanceName:   "two",
-			Revision:       snap.R(2),
-			ValidationSets: [][]string{{"16", "foo", "bar", "1"}},
+			Action:            "install",
+			InstanceName:      "two",
+			Revision:          snap.R(2),
+			ValidationSetKeys: []snapasserts.ValidationSetKey{"16/foo/bar/1"},
 		},
 		revno: snap.R(2),
 	}}
@@ -4506,10 +4506,10 @@ func (s *validationSetsSuite) TestInstallSnapWithValidationSets(c *C) {
 	expectedOp := fakeOp{
 		op: "storesvc-snap-action:action",
 		action: store.SnapAction{
-			Action:         "install",
-			InstanceName:   "some-snap",
-			ValidationSets: [][]string{{"16", "foo", "bar"}, {"16", "foo", "baz"}},
-			Revision:       snap.R(11),
+			Action:            "install",
+			InstanceName:      "some-snap",
+			ValidationSetKeys: []snapasserts.ValidationSetKey{"16/foo/bar", "16/foo/baz"},
+			Revision:          snap.R(11),
 		},
 		revno: snap.R(11),
 	}

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -4168,7 +4168,7 @@ func (s *validationSetsSuite) TestInstallManyWithRevisionOpts(c *C) {
 
 	// installing "some-snap" with revision opts should succeed because current
 	// validation sets should be ignored
-	revOpts := []*snapstate.RevisionOptions{{Revision: snap.R(2), ValidationSets: []snapasserts.ValidationSetKey{"16/foo/bar/2"}}}
+	revOpts := []*snapstate.RevisionOptions{{Revision: snap.R(2), ValidationSetKeys: []snapasserts.ValidationSetKey{"16/foo/bar/2"}}}
 	affected, tss, err := snapstate.InstallMany(s.state, []string{"some-snap"}, revOpts, 0, nil)
 	c.Assert(err, IsNil)
 	c.Assert(affected, DeepEquals, []string{"some-snap"})
@@ -4498,7 +4498,7 @@ func (s *validationSetsSuite) TestInstallSnapWithValidationSets(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	opts := &snapstate.RevisionOptions{Revision: snap.R(11), ValidationSets: []snapasserts.ValidationSetKey{"16/foo/bar", "16/foo/baz"}}
+	opts := &snapstate.RevisionOptions{Revision: snap.R(11), ValidationSetKeys: []snapasserts.ValidationSetKey{"16/foo/bar", "16/foo/baz"}}
 	_, err := snapstate.Install(context.Background(), s.state, "some-snap", opts, 0, snapstate.Flags{})
 	c.Assert(err, IsNil)
 

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -4051,10 +4051,10 @@ func (s *validationSetsSuite) TestInstallSnapRequiredForValidationSet(c *C) {
 	expectedOp := fakeOp{
 		op: "storesvc-snap-action:action",
 		action: store.SnapAction{
-			Action:            "install",
-			InstanceName:      "some-snap",
-			Channel:           "stable",
-			ValidationSetKeys: []snapasserts.ValidationSetKey{"16/foo/bar/1"},
+			Action:         "install",
+			InstanceName:   "some-snap",
+			Channel:        "stable",
+			ValidationSets: []snapasserts.ValidationSetKey{"16/foo/bar/1"},
 		},
 		revno: snap.R(11),
 	}
@@ -4068,10 +4068,10 @@ func (s *validationSetsSuite) TestInstallSnapRequiredForValidationSetAtRevision(
 	expectedOp := fakeOp{
 		op: "storesvc-snap-action:action",
 		action: store.SnapAction{
-			Action:            "install",
-			Revision:          snap.R(2),
-			InstanceName:      "some-snap",
-			ValidationSetKeys: []snapasserts.ValidationSetKey{"16/foo/bar/1"},
+			Action:         "install",
+			Revision:       snap.R(2),
+			InstanceName:   "some-snap",
+			ValidationSets: []snapasserts.ValidationSetKey{"16/foo/bar/1"},
 		},
 		revno: snap.R(2),
 	}
@@ -4085,10 +4085,10 @@ func (s *validationSetsSuite) TestInstallSnapRequiredForValidationSetCohortIgnor
 	expectedOp := fakeOp{
 		op: "storesvc-snap-action:action",
 		action: store.SnapAction{
-			Action:            "install",
-			Revision:          snap.R(2),
-			InstanceName:      "some-snap",
-			ValidationSetKeys: []snapasserts.ValidationSetKey{"16/foo/bar/1"},
+			Action:         "install",
+			Revision:       snap.R(2),
+			InstanceName:   "some-snap",
+			ValidationSets: []snapasserts.ValidationSetKey{"16/foo/bar/1"},
 		},
 		revno: snap.R(2),
 	}
@@ -4168,7 +4168,7 @@ func (s *validationSetsSuite) TestInstallManyWithRevisionOpts(c *C) {
 
 	// installing "some-snap" with revision opts should succeed because current
 	// validation sets should be ignored
-	revOpts := []*snapstate.RevisionOptions{{Revision: snap.R(2), ValidationSetKeys: []snapasserts.ValidationSetKey{"16/foo/bar/2"}}}
+	revOpts := []*snapstate.RevisionOptions{{Revision: snap.R(2), ValidationSets: []snapasserts.ValidationSetKey{"16/foo/bar/2"}}}
 	affected, tss, err := snapstate.InstallMany(s.state, []string{"some-snap"}, revOpts, 0, nil)
 	c.Assert(err, IsNil)
 	c.Assert(affected, DeepEquals, []string{"some-snap"})
@@ -4196,10 +4196,10 @@ func (s *validationSetsSuite) TestInstallManyRequiredForValidationSetOK(c *C) {
 	expectedOps := fakeOps{{
 		op: "storesvc-snap-action:action",
 		action: store.SnapAction{
-			Action:            "install",
-			InstanceName:      "one",
-			Channel:           "stable",
-			ValidationSetKeys: []snapasserts.ValidationSetKey{"16/foo/bar/1"},
+			Action:         "install",
+			InstanceName:   "one",
+			Channel:        "stable",
+			ValidationSets: []snapasserts.ValidationSetKey{"16/foo/bar/1"},
 		},
 		revno: snap.R(11),
 	}, {
@@ -4223,19 +4223,19 @@ func (s *validationSetsSuite) TestInstallManyRequiredRevisionForValidationSetOK(
 	expectedOps := fakeOps{{
 		op: "storesvc-snap-action:action",
 		action: store.SnapAction{
-			Action:            "install",
-			InstanceName:      "one",
-			Revision:          snap.R(11),
-			ValidationSetKeys: []snapasserts.ValidationSetKey{"16/foo/bar/1"},
+			Action:         "install",
+			InstanceName:   "one",
+			Revision:       snap.R(11),
+			ValidationSets: []snapasserts.ValidationSetKey{"16/foo/bar/1"},
 		},
 		revno: snap.R(11),
 	}, {
 		op: "storesvc-snap-action:action",
 		action: store.SnapAction{
-			Action:            "install",
-			InstanceName:      "two",
-			Revision:          snap.R(2),
-			ValidationSetKeys: []snapasserts.ValidationSetKey{"16/foo/bar/1"},
+			Action:         "install",
+			InstanceName:   "two",
+			Revision:       snap.R(2),
+			ValidationSets: []snapasserts.ValidationSetKey{"16/foo/bar/1"},
 		},
 		revno: snap.R(2),
 	}}
@@ -4498,7 +4498,7 @@ func (s *validationSetsSuite) TestInstallSnapWithValidationSets(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	opts := &snapstate.RevisionOptions{Revision: snap.R(11), ValidationSetKeys: []snapasserts.ValidationSetKey{"16/foo/bar", "16/foo/baz"}}
+	opts := &snapstate.RevisionOptions{Revision: snap.R(11), ValidationSets: []snapasserts.ValidationSetKey{"16/foo/bar", "16/foo/baz"}}
 	_, err := snapstate.Install(context.Background(), s.state, "some-snap", opts, 0, snapstate.Flags{})
 	c.Assert(err, IsNil)
 
@@ -4506,10 +4506,10 @@ func (s *validationSetsSuite) TestInstallSnapWithValidationSets(c *C) {
 	expectedOp := fakeOp{
 		op: "storesvc-snap-action:action",
 		action: store.SnapAction{
-			Action:            "install",
-			InstanceName:      "some-snap",
-			ValidationSetKeys: []snapasserts.ValidationSetKey{"16/foo/bar", "16/foo/baz"},
-			Revision:          snap.R(11),
+			Action:         "install",
+			InstanceName:   "some-snap",
+			ValidationSets: []snapasserts.ValidationSetKey{"16/foo/bar", "16/foo/baz"},
+			Revision:       snap.R(11),
 		},
 		revno: snap.R(11),
 	}

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -5196,7 +5196,7 @@ func (s *validationSetsSuite) TestUpdateManyWithRevisionOpts(c *C) {
 
 	// updating "some-snap" with revision opts should succeed because current
 	// validation sets should be ignored
-	revOpts := []*snapstate.RevisionOptions{{Revision: snap.R(2), ValidationSets: []snapasserts.ValidationSetKey{"16/foo/bar/2"}}}
+	revOpts := []*snapstate.RevisionOptions{{Revision: snap.R(2), ValidationSetKeys: []snapasserts.ValidationSetKey{"16/foo/bar/2"}}}
 	affected, tss, err := snapstate.UpdateMany(context.Background(), s.state, []string{"some-snap"}, revOpts, 0, nil)
 	c.Assert(err, IsNil)
 	c.Assert(affected, DeepEquals, []string{"some-snap"})
@@ -7146,7 +7146,7 @@ func (s *validationSetsSuite) TestUpdateToRevisionWithValidationSets(c *C) {
 
 	refreshedDate := fakeRevDateEpoch.AddDate(0, 0, 1)
 
-	ts, err := snapstate.Update(s.state, "some-snap", &snapstate.RevisionOptions{Revision: snap.R(11), ValidationSets: []snapasserts.ValidationSetKey{"16/foo/bar", "16/foo/baz"}}, 0, snapstate.Flags{})
+	ts, err := snapstate.Update(s.state, "some-snap", &snapstate.RevisionOptions{Revision: snap.R(11), ValidationSetKeys: []snapasserts.ValidationSetKey{"16/foo/bar", "16/foo/baz"}}, 0, snapstate.Flags{})
 	c.Assert(err, IsNil)
 
 	var snapsup snapstate.SnapSetup

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -6521,12 +6521,12 @@ func (s *validationSetsSuite) TestUpdateSnapRequiredByValidationRefreshToRequire
 		}}}, {
 		op: "storesvc-snap-action:action",
 		action: store.SnapAction{
-			Action:         "refresh",
-			InstanceName:   "some-snap",
-			SnapID:         "some-snap-id",
-			Revision:       snap.R(11),
-			ValidationSets: [][]string{{"16", "foo", "bar", "1"}},
-			Flags:          store.SnapActionEnforceValidation,
+			Action:            "refresh",
+			InstanceName:      "some-snap",
+			SnapID:            "some-snap-id",
+			Revision:          snap.R(11),
+			ValidationSetKeys: []snapasserts.ValidationSetKey{"16/foo/bar/1"},
+			Flags:             store.SnapActionEnforceValidation,
 		},
 		revno: snap.R(11),
 	}}
@@ -6591,11 +6591,11 @@ func (s *validationSetsSuite) TestUpdateSnapRequiredByValidationSetAnyRevision(c
 		}}}, {
 		op: "storesvc-snap-action:action",
 		action: store.SnapAction{
-			Action:         "refresh",
-			InstanceName:   "some-snap",
-			SnapID:         "some-snap-id",
-			ValidationSets: [][]string{{"16", "foo", "bar", "2"}},
-			Flags:          store.SnapActionEnforceValidation,
+			Action:            "refresh",
+			InstanceName:      "some-snap",
+			SnapID:            "some-snap-id",
+			ValidationSetKeys: []snapasserts.ValidationSetKey{"16/foo/bar/2"},
+			Flags:             store.SnapActionEnforceValidation,
 		},
 		revno: snap.R(11),
 	}}
@@ -6661,11 +6661,11 @@ func (s *validationSetsSuite) TestUpdateToRevisionSnapRequiredByValidationSetAny
 		}}}, {
 		op: "storesvc-snap-action:action",
 		action: store.SnapAction{
-			Action:         "refresh",
-			InstanceName:   "some-snap",
-			SnapID:         "some-snap-id",
-			Revision:       snap.R(11),
-			ValidationSets: [][]string{{"16", "foo", "bar", "2"}},
+			Action:            "refresh",
+			InstanceName:      "some-snap",
+			SnapID:            "some-snap-id",
+			Revision:          snap.R(11),
+			ValidationSetKeys: []snapasserts.ValidationSetKey{"16/foo/bar/2"},
 		},
 		revno: snap.R(11),
 	}}
@@ -6728,11 +6728,11 @@ func (s *validationSetsSuite) TestUpdateToRevisionSnapRequiredByValidationWithMa
 	}, {
 		op: "storesvc-snap-action:action",
 		action: store.SnapAction{
-			Action:         "refresh",
-			InstanceName:   "some-snap",
-			SnapID:         "some-snap-id",
-			Revision:       snap.R(11),
-			ValidationSets: [][]string{{"16", "foo", "bar", "2"}},
+			Action:            "refresh",
+			InstanceName:      "some-snap",
+			SnapID:            "some-snap-id",
+			Revision:          snap.R(11),
+			ValidationSetKeys: []snapasserts.ValidationSetKey{"16/foo/bar/2"},
 			// XXX: updateToRevisionInfo doesn't set store.SnapActionEnforceValidation flag?
 		},
 		revno: snap.R(11),
@@ -6996,11 +6996,11 @@ func (s *validationSetsSuite) TestUpdateManyRequiredByValidationSetsCohortIgnore
 	}, {
 		op: "storesvc-snap-action:action",
 		action: store.SnapAction{
-			Action:         "refresh",
-			InstanceName:   "some-snap",
-			SnapID:         "some-snap-id",
-			Revision:       snap.R(5),
-			ValidationSets: [][]string{{"16", "foo", "bar", "2"}},
+			Action:            "refresh",
+			InstanceName:      "some-snap",
+			SnapID:            "some-snap-id",
+			Revision:          snap.R(5),
+			ValidationSetKeys: []snapasserts.ValidationSetKey{"16/foo/bar/2"},
 		},
 		revno: snap.R(5),
 	}}
@@ -7168,11 +7168,11 @@ func (s *validationSetsSuite) TestUpdateToRevisionWithValidationSets(c *C) {
 		}}}, {
 		op: "storesvc-snap-action:action",
 		action: store.SnapAction{
-			Action:         "refresh",
-			InstanceName:   "some-snap",
-			SnapID:         "some-snap-id",
-			Revision:       snap.R(11),
-			ValidationSets: [][]string{{"16", "foo", "bar"}, {"16", "foo", "baz"}},
+			Action:            "refresh",
+			InstanceName:      "some-snap",
+			SnapID:            "some-snap-id",
+			Revision:          snap.R(11),
+			ValidationSetKeys: []snapasserts.ValidationSetKey{"16/foo/bar", "16/foo/baz"},
 		},
 		revno: snap.R(11),
 	}}

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -5196,7 +5196,7 @@ func (s *validationSetsSuite) TestUpdateManyWithRevisionOpts(c *C) {
 
 	// updating "some-snap" with revision opts should succeed because current
 	// validation sets should be ignored
-	revOpts := []*snapstate.RevisionOptions{{Revision: snap.R(2), ValidationSetKeys: []snapasserts.ValidationSetKey{"16/foo/bar/2"}}}
+	revOpts := []*snapstate.RevisionOptions{{Revision: snap.R(2), ValidationSets: []snapasserts.ValidationSetKey{"16/foo/bar/2"}}}
 	affected, tss, err := snapstate.UpdateMany(context.Background(), s.state, []string{"some-snap"}, revOpts, 0, nil)
 	c.Assert(err, IsNil)
 	c.Assert(affected, DeepEquals, []string{"some-snap"})
@@ -6521,12 +6521,12 @@ func (s *validationSetsSuite) TestUpdateSnapRequiredByValidationRefreshToRequire
 		}}}, {
 		op: "storesvc-snap-action:action",
 		action: store.SnapAction{
-			Action:            "refresh",
-			InstanceName:      "some-snap",
-			SnapID:            "some-snap-id",
-			Revision:          snap.R(11),
-			ValidationSetKeys: []snapasserts.ValidationSetKey{"16/foo/bar/1"},
-			Flags:             store.SnapActionEnforceValidation,
+			Action:         "refresh",
+			InstanceName:   "some-snap",
+			SnapID:         "some-snap-id",
+			Revision:       snap.R(11),
+			ValidationSets: []snapasserts.ValidationSetKey{"16/foo/bar/1"},
+			Flags:          store.SnapActionEnforceValidation,
 		},
 		revno: snap.R(11),
 	}}
@@ -6591,11 +6591,11 @@ func (s *validationSetsSuite) TestUpdateSnapRequiredByValidationSetAnyRevision(c
 		}}}, {
 		op: "storesvc-snap-action:action",
 		action: store.SnapAction{
-			Action:            "refresh",
-			InstanceName:      "some-snap",
-			SnapID:            "some-snap-id",
-			ValidationSetKeys: []snapasserts.ValidationSetKey{"16/foo/bar/2"},
-			Flags:             store.SnapActionEnforceValidation,
+			Action:         "refresh",
+			InstanceName:   "some-snap",
+			SnapID:         "some-snap-id",
+			ValidationSets: []snapasserts.ValidationSetKey{"16/foo/bar/2"},
+			Flags:          store.SnapActionEnforceValidation,
 		},
 		revno: snap.R(11),
 	}}
@@ -6661,11 +6661,11 @@ func (s *validationSetsSuite) TestUpdateToRevisionSnapRequiredByValidationSetAny
 		}}}, {
 		op: "storesvc-snap-action:action",
 		action: store.SnapAction{
-			Action:            "refresh",
-			InstanceName:      "some-snap",
-			SnapID:            "some-snap-id",
-			Revision:          snap.R(11),
-			ValidationSetKeys: []snapasserts.ValidationSetKey{"16/foo/bar/2"},
+			Action:         "refresh",
+			InstanceName:   "some-snap",
+			SnapID:         "some-snap-id",
+			Revision:       snap.R(11),
+			ValidationSets: []snapasserts.ValidationSetKey{"16/foo/bar/2"},
 		},
 		revno: snap.R(11),
 	}}
@@ -6728,11 +6728,11 @@ func (s *validationSetsSuite) TestUpdateToRevisionSnapRequiredByValidationWithMa
 	}, {
 		op: "storesvc-snap-action:action",
 		action: store.SnapAction{
-			Action:            "refresh",
-			InstanceName:      "some-snap",
-			SnapID:            "some-snap-id",
-			Revision:          snap.R(11),
-			ValidationSetKeys: []snapasserts.ValidationSetKey{"16/foo/bar/2"},
+			Action:         "refresh",
+			InstanceName:   "some-snap",
+			SnapID:         "some-snap-id",
+			Revision:       snap.R(11),
+			ValidationSets: []snapasserts.ValidationSetKey{"16/foo/bar/2"},
 			// XXX: updateToRevisionInfo doesn't set store.SnapActionEnforceValidation flag?
 		},
 		revno: snap.R(11),
@@ -6996,11 +6996,11 @@ func (s *validationSetsSuite) TestUpdateManyRequiredByValidationSetsCohortIgnore
 	}, {
 		op: "storesvc-snap-action:action",
 		action: store.SnapAction{
-			Action:            "refresh",
-			InstanceName:      "some-snap",
-			SnapID:            "some-snap-id",
-			Revision:          snap.R(5),
-			ValidationSetKeys: []snapasserts.ValidationSetKey{"16/foo/bar/2"},
+			Action:         "refresh",
+			InstanceName:   "some-snap",
+			SnapID:         "some-snap-id",
+			Revision:       snap.R(5),
+			ValidationSets: []snapasserts.ValidationSetKey{"16/foo/bar/2"},
 		},
 		revno: snap.R(5),
 	}}
@@ -7146,7 +7146,7 @@ func (s *validationSetsSuite) TestUpdateToRevisionWithValidationSets(c *C) {
 
 	refreshedDate := fakeRevDateEpoch.AddDate(0, 0, 1)
 
-	ts, err := snapstate.Update(s.state, "some-snap", &snapstate.RevisionOptions{Revision: snap.R(11), ValidationSetKeys: []snapasserts.ValidationSetKey{"16/foo/bar", "16/foo/baz"}}, 0, snapstate.Flags{})
+	ts, err := snapstate.Update(s.state, "some-snap", &snapstate.RevisionOptions{Revision: snap.R(11), ValidationSets: []snapasserts.ValidationSetKey{"16/foo/bar", "16/foo/baz"}}, 0, snapstate.Flags{})
 	c.Assert(err, IsNil)
 
 	var snapsup snapstate.SnapSetup
@@ -7168,11 +7168,11 @@ func (s *validationSetsSuite) TestUpdateToRevisionWithValidationSets(c *C) {
 		}}}, {
 		op: "storesvc-snap-action:action",
 		action: store.SnapAction{
-			Action:            "refresh",
-			InstanceName:      "some-snap",
-			SnapID:            "some-snap-id",
-			Revision:          snap.R(11),
-			ValidationSetKeys: []snapasserts.ValidationSetKey{"16/foo/bar", "16/foo/baz"},
+			Action:         "refresh",
+			InstanceName:   "some-snap",
+			SnapID:         "some-snap-id",
+			Revision:       snap.R(11),
+			ValidationSets: []snapasserts.ValidationSetKey{"16/foo/bar", "16/foo/baz"},
 		},
 		revno: snap.R(11),
 	}}

--- a/overlord/snapstate/storehelpers.go
+++ b/overlord/snapstate/storehelpers.go
@@ -24,7 +24,6 @@ import (
 	"errors"
 	"fmt"
 	"sort"
-	"strings"
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/snapasserts"
@@ -213,8 +212,7 @@ var installSize = func(st *state.State, snaps []minimalInstallInfo, userID int) 
 
 func setActionValidationSetsAndRequiredRevision(action *store.SnapAction, valsets []snapasserts.ValidationSetKey, requiredRevision snap.Revision) {
 	for _, vs := range valsets {
-		keyParts := strings.Split(vs.String(), "/")
-		action.ValidationSets = append(action.ValidationSets, keyParts)
+		action.ValidationSetKeys = append(action.ValidationSetKeys, vs)
 	}
 	if !requiredRevision.Unset() {
 		action.Revision = requiredRevision

--- a/overlord/snapstate/storehelpers.go
+++ b/overlord/snapstate/storehelpers.go
@@ -212,7 +212,7 @@ var installSize = func(st *state.State, snaps []minimalInstallInfo, userID int) 
 
 func setActionValidationSetsAndRequiredRevision(action *store.SnapAction, valsets []snapasserts.ValidationSetKey, requiredRevision snap.Revision) {
 	for _, vs := range valsets {
-		action.ValidationSetKeys = append(action.ValidationSetKeys, vs)
+		action.ValidationSets = append(action.ValidationSets, vs)
 	}
 	if !requiredRevision.Unset() {
 		action.Revision = requiredRevision
@@ -251,9 +251,9 @@ func installInfo(ctx context.Context, st *state.State, name string, revOpts *Rev
 	var requiredValSets []snapasserts.ValidationSetKey
 
 	if !flags.IgnoreValidation {
-		if len(revOpts.ValidationSetKeys) > 0 {
+		if len(revOpts.ValidationSets) > 0 {
 			requiredRevision = revOpts.Revision
-			requiredValSets = revOpts.ValidationSetKeys
+			requiredValSets = revOpts.ValidationSets
 		} else {
 			enforcedSets, err := EnforcedValidationSets(st)
 			if err != nil {
@@ -341,7 +341,7 @@ func updateInfo(st *state.State, snapst *SnapState, opts *RevisionOptions, userI
 		Flags:   storeFlags,
 	}
 
-	if len(opts.ValidationSetKeys) > 0 {
+	if len(opts.ValidationSets) > 0 {
 		// update to a specific revision is handled by updateToRevisionInfo.
 		// updating without a revision while enforcing validation sets is not a
 		// viable scenario (although we could handle it if desired), we only install/refresh
@@ -485,9 +485,9 @@ func updateToRevisionInfo(st *state.State, snapst *SnapState, revOpts *RevisionO
 
 	var storeFlags store.SnapActionFlags
 	if !flags.IgnoreValidation {
-		if len(revOpts.ValidationSetKeys) > 0 {
+		if len(revOpts.ValidationSets) > 0 {
 			requiredRevision = revOpts.Revision
-			requiredValsets = revOpts.ValidationSetKeys
+			requiredValsets = revOpts.ValidationSets
 		} else {
 			enforcedSets, err := EnforcedValidationSets(st)
 			if err != nil {
@@ -672,7 +672,7 @@ func refreshCandidates(ctx context.Context, st *state.State, names []string, rev
 
 			if revOpts != nil {
 				opts := revOptsByName[installed.InstanceName]
-				requiredValsets, requiredRevision = opts.ValidationSetKeys, opts.Revision
+				requiredValsets, requiredRevision = opts.ValidationSets, opts.Revision
 			} else if enforcedSets != nil {
 				requiredValsets, requiredRevision, err = enforcedSets.CheckPresenceRequired(naming.Snap(installed.InstanceName))
 				// note, this errors out the entire refresh
@@ -807,7 +807,7 @@ func installCandidates(st *state.State, names []string, revOpts []*RevisionOptio
 		var requiredRevision snap.Revision
 
 		if revOpts != nil {
-			requiredValSets = revOpts[i].ValidationSetKeys
+			requiredValSets = revOpts[i].ValidationSets
 			requiredRevision = revOpts[i].Revision
 		} else if enforcedSets != nil {
 			// check for invalid presence first to have a list of sets where it's invalid

--- a/overlord/snapstate/storehelpers.go
+++ b/overlord/snapstate/storehelpers.go
@@ -251,9 +251,9 @@ func installInfo(ctx context.Context, st *state.State, name string, revOpts *Rev
 	var requiredValSets []snapasserts.ValidationSetKey
 
 	if !flags.IgnoreValidation {
-		if len(revOpts.ValidationSets) > 0 {
+		if len(revOpts.ValidationSetKeys) > 0 {
 			requiredRevision = revOpts.Revision
-			requiredValSets = revOpts.ValidationSets
+			requiredValSets = revOpts.ValidationSetKeys
 		} else {
 			enforcedSets, err := EnforcedValidationSets(st)
 			if err != nil {
@@ -341,7 +341,7 @@ func updateInfo(st *state.State, snapst *SnapState, opts *RevisionOptions, userI
 		Flags:   storeFlags,
 	}
 
-	if len(opts.ValidationSets) > 0 {
+	if len(opts.ValidationSetKeys) > 0 {
 		// update to a specific revision is handled by updateToRevisionInfo.
 		// updating without a revision while enforcing validation sets is not a
 		// viable scenario (although we could handle it if desired), we only install/refresh
@@ -485,9 +485,9 @@ func updateToRevisionInfo(st *state.State, snapst *SnapState, revOpts *RevisionO
 
 	var storeFlags store.SnapActionFlags
 	if !flags.IgnoreValidation {
-		if len(revOpts.ValidationSets) > 0 {
+		if len(revOpts.ValidationSetKeys) > 0 {
 			requiredRevision = revOpts.Revision
-			requiredValsets = revOpts.ValidationSets
+			requiredValsets = revOpts.ValidationSetKeys
 		} else {
 			enforcedSets, err := EnforcedValidationSets(st)
 			if err != nil {
@@ -672,7 +672,7 @@ func refreshCandidates(ctx context.Context, st *state.State, names []string, rev
 
 			if revOpts != nil {
 				opts := revOptsByName[installed.InstanceName]
-				requiredValsets, requiredRevision = opts.ValidationSets, opts.Revision
+				requiredValsets, requiredRevision = opts.ValidationSetKeys, opts.Revision
 			} else if enforcedSets != nil {
 				requiredValsets, requiredRevision, err = enforcedSets.CheckPresenceRequired(naming.Snap(installed.InstanceName))
 				// note, this errors out the entire refresh
@@ -807,7 +807,7 @@ func installCandidates(st *state.State, names []string, revOpts []*RevisionOptio
 		var requiredRevision snap.Revision
 
 		if revOpts != nil {
-			requiredValSets = revOpts[i].ValidationSets
+			requiredValSets = revOpts[i].ValidationSetKeys
 			requiredRevision = revOpts[i].Revision
 		} else if enforcedSets != nil {
 			// check for invalid presence first to have a list of sets where it's invalid

--- a/store/store_action.go
+++ b/store/store_action.go
@@ -57,8 +57,8 @@ type CurrentSnap struct {
 	Block            []snap.Revision
 	Epoch            snap.Epoch
 	CohortKey        string
-	// ValidationSetKeys is an optional array of validation sets primary keys.
-	ValidationSetKeys []snapasserts.ValidationSetKey
+	// ValidationSets is an optional array of validation set primary keys.
+	ValidationSets []snapasserts.ValidationSetKey
 }
 
 type AssertionQuery interface {
@@ -78,7 +78,7 @@ type currentSnapV2JSON struct {
 	RefreshedDate    *time.Time `json:"refreshed-date,omitempty"`
 	IgnoreValidation bool       `json:"ignore-validation,omitempty"`
 	CohortKey        string     `json:"cohort-key,omitempty"`
-	// ValidationSets is an optional array of validation sets primary keys.
+	// ValidationSets is an optional array of validation set primary keys.
 	ValidationSets [][]string `json:"validation-sets,omitempty"`
 }
 
@@ -98,9 +98,9 @@ type SnapAction struct {
 	CohortKey    string
 	Flags        SnapActionFlags
 	Epoch        snap.Epoch
-	// ValidationSetKeys is an optional array of validation sets primary keys
+	// ValidationSets is an optional array of validation set primary keys
 	// (relevant for install and refresh actions).
-	ValidationSetKeys []snapasserts.ValidationSetKey
+	ValidationSets []snapasserts.ValidationSetKey
 }
 
 func isValidAction(action string) bool {
@@ -331,8 +331,8 @@ func (s *Store) snapAction(ctx context.Context, currentSnaps []*CurrentSnap, act
 			refreshedDate = &curSnap.RefreshedDate
 		}
 
-		valsetKeys := make([][]string, 0, len(curSnap.ValidationSetKeys))
-		for _, vsKey := range curSnap.ValidationSetKeys {
+		valsetKeys := make([][]string, 0, len(curSnap.ValidationSets))
+		for _, vsKey := range curSnap.ValidationSets {
 			valsetKeys = append(valsetKeys, vsKey.Components())
 		}
 
@@ -377,8 +377,8 @@ func (s *Store) snapAction(ctx context.Context, currentSnaps []*CurrentSnap, act
 			ignoreValidation = &f
 		}
 
-		valsetKeyComponents := make([][]string, 0, len(a.ValidationSetKeys))
-		for _, vsKey := range a.ValidationSetKeys {
+		valsetKeyComponents := make([][]string, 0, len(a.ValidationSets))
+		for _, vsKey := range a.ValidationSets {
 			valsetKeyComponents = append(valsetKeyComponents, vsKey.Components())
 		}
 

--- a/store/store_action.go
+++ b/store/store_action.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/jsonutil"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/auth"
@@ -56,8 +57,8 @@ type CurrentSnap struct {
 	Block            []snap.Revision
 	Epoch            snap.Epoch
 	CohortKey        string
-	// ValidationSets is an optional array of validation sets primary keys.
-	ValidationSets [][]string
+	// ValidationSetKeys is an optional array of validation sets primary keys.
+	ValidationSetKeys []snapasserts.ValidationSetKey
 }
 
 type AssertionQuery interface {
@@ -97,9 +98,9 @@ type SnapAction struct {
 	CohortKey    string
 	Flags        SnapActionFlags
 	Epoch        snap.Epoch
-	// ValidationSets is an optional array of validation sets primary keys
+	// ValidationSetKeys is an optional array of validation sets primary keys
 	// (relevant for install and refresh actions).
-	ValidationSets [][]string
+	ValidationSetKeys []snapasserts.ValidationSetKey
 }
 
 func isValidAction(action string) bool {
@@ -329,6 +330,12 @@ func (s *Store) snapAction(ctx context.Context, currentSnaps []*CurrentSnap, act
 		if !curSnap.RefreshedDate.IsZero() {
 			refreshedDate = &curSnap.RefreshedDate
 		}
+
+		valsetKeys := make([][]string, 0, len(curSnap.ValidationSetKeys))
+		for _, vsKey := range curSnap.ValidationSetKeys {
+			valsetKeys = append(valsetKeys, vsKey.Components())
+		}
+
 		curSnapJSONs[i] = &currentSnapV2JSON{
 			SnapID:           curSnap.SnapID,
 			InstanceKey:      instanceKey,
@@ -338,7 +345,7 @@ func (s *Store) snapAction(ctx context.Context, currentSnaps []*CurrentSnap, act
 			RefreshedDate:    refreshedDate,
 			Epoch:            curSnap.Epoch,
 			CohortKey:        curSnap.CohortKey,
-			ValidationSets:   curSnap.ValidationSets,
+			ValidationSets:   valsetKeys,
 		}
 	}
 
@@ -370,6 +377,11 @@ func (s *Store) snapAction(ctx context.Context, currentSnaps []*CurrentSnap, act
 			ignoreValidation = &f
 		}
 
+		valsetKeyComponents := make([][]string, 0, len(a.ValidationSetKeys))
+		for _, vsKey := range a.ValidationSetKeys {
+			valsetKeyComponents = append(valsetKeyComponents, vsKey.Components())
+		}
+
 		var instanceKey string
 		aJSON := &snapActionJSON{
 			Action:           a.Action,
@@ -377,7 +389,7 @@ func (s *Store) snapAction(ctx context.Context, currentSnaps []*CurrentSnap, act
 			Channel:          a.Channel,
 			Revision:         a.Revision.N,
 			CohortKey:        a.CohortKey,
-			ValidationSets:   a.ValidationSets,
+			ValidationSets:   valsetKeyComponents,
 			IgnoreValidation: ignoreValidation,
 		}
 		if !a.Revision.Unset() {

--- a/store/store_action_test.go
+++ b/store/store_action_test.go
@@ -1292,11 +1292,11 @@ func (s *storeActionSuite) testSnapActionGet(action, cohort, redirectChannel str
 	results, _, err := sto.SnapAction(s.ctx, nil,
 		[]*store.SnapAction{
 			{
-				Action:            action,
-				InstanceName:      "hello-world",
-				Channel:           "beta",
-				CohortKey:         cohort,
-				ValidationSetKeys: validationSets,
+				Action:         action,
+				InstanceName:   "hello-world",
+				Channel:        "beta",
+				CohortKey:      cohort,
+				ValidationSets: validationSets,
 			},
 		}, nil, nil, nil)
 	c.Assert(err, IsNil)
@@ -2580,15 +2580,15 @@ func (s *storeActionSuite) TestSnapActionRefreshWithValidationSets(c *C) {
 			Revision:        snap.R(1),
 			RefreshedDate:   helloRefreshedDate,
 			// not actually set during refresh, but supported by snapAction
-			ValidationSetKeys: []snapasserts.ValidationSetKey{"foo/other"},
+			ValidationSets: []snapasserts.ValidationSetKey{"foo/other"},
 		},
 	}, []*store.SnapAction{
 		{
-			Action:            "refresh",
-			SnapID:            helloWorldSnapID,
-			Channel:           "stable",
-			InstanceName:      "hello-world",
-			ValidationSetKeys: []snapasserts.ValidationSetKey{"foo/bar", "foo/baz"},
+			Action:         "refresh",
+			SnapID:         helloWorldSnapID,
+			Channel:        "stable",
+			InstanceName:   "hello-world",
+			ValidationSets: []snapasserts.ValidationSetKey{"foo/bar", "foo/baz"},
 		},
 	}, nil, nil, &store.RefreshOptions{PrivacyKey: "123"})
 	c.Assert(err, IsNil)

--- a/store/store_action_test.go
+++ b/store/store_action_test.go
@@ -34,6 +34,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/arch"
+	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/channel"
@@ -754,7 +755,7 @@ func (s *storeActionSuite) TestSnapActionIgnoreValidation(c *C) {
 }
 
 func (s *storeActionSuite) TestSnapActionInstallWithValidationSets(c *C) {
-	s.testSnapActionGet("install", "", "", [][]string{{"foo", "bar"}, {"foo", "baz"}}, c)
+	s.testSnapActionGet("install", "", "", []snapasserts.ValidationSetKey{"foo/bar", "foo/baz"}, c)
 }
 
 func (s *storeActionSuite) TestSnapActionAutoRefresh(c *C) {
@@ -1198,7 +1199,7 @@ func (s *storeActionSuite) TestSnapActionInstallRedirect(c *C) {
 func (s *storeActionSuite) TestSnapActionDownloadRedirect(c *C) {
 	s.testSnapActionGet("download", "", "2.0/candidate", nil, c)
 }
-func (s *storeActionSuite) testSnapActionGet(action, cohort, redirectChannel string, validationSets [][]string, c *C) {
+func (s *storeActionSuite) testSnapActionGet(action, cohort, redirectChannel string, validationSets []snapasserts.ValidationSetKey, c *C) {
 	// action here is one of install or download
 	restore := release.MockOnClassic(false)
 	defer restore()
@@ -1246,7 +1247,7 @@ func (s *storeActionSuite) testSnapActionGet(action, cohort, redirectChannel str
 			var sets []interface{}
 			for _, vs := range validationSets {
 				var vss []interface{}
-				for _, vv := range vs {
+				for _, vv := range vs.Components() {
 					vss = append(vss, vv)
 				}
 				sets = append(sets, vss)
@@ -1291,11 +1292,11 @@ func (s *storeActionSuite) testSnapActionGet(action, cohort, redirectChannel str
 	results, _, err := sto.SnapAction(s.ctx, nil,
 		[]*store.SnapAction{
 			{
-				Action:         action,
-				InstanceName:   "hello-world",
-				Channel:        "beta",
-				CohortKey:      cohort,
-				ValidationSets: validationSets,
+				Action:            action,
+				InstanceName:      "hello-world",
+				Channel:           "beta",
+				CohortKey:         cohort,
+				ValidationSetKeys: validationSets,
 			},
 		}, nil, nil, nil)
 	c.Assert(err, IsNil)
@@ -2579,15 +2580,15 @@ func (s *storeActionSuite) TestSnapActionRefreshWithValidationSets(c *C) {
 			Revision:        snap.R(1),
 			RefreshedDate:   helloRefreshedDate,
 			// not actually set during refresh, but supported by snapAction
-			ValidationSets: [][]string{{"foo", "other"}},
+			ValidationSetKeys: []snapasserts.ValidationSetKey{"foo/other"},
 		},
 	}, []*store.SnapAction{
 		{
-			Action:         "refresh",
-			SnapID:         helloWorldSnapID,
-			Channel:        "stable",
-			InstanceName:   "hello-world",
-			ValidationSets: [][]string{{"foo", "bar"}, {"foo", "baz"}},
+			Action:            "refresh",
+			SnapID:            helloWorldSnapID,
+			Channel:           "stable",
+			InstanceName:      "hello-world",
+			ValidationSetKeys: []snapasserts.ValidationSetKey{"foo/bar", "foo/baz"},
 		},
 	}, nil, nil, &store.RefreshOptions{PrivacyKey: "123"})
 	c.Assert(err, IsNil)


### PR DESCRIPTION
Use a typed ValidationSetKey in the `store` package instead of a `[][]string`, to help prevent incorrectly formatted keys from being passed in. To the same end, also renames the field from ValidationSet to ValidationSetKey. The second commit renames the ValidationSets in the `snapstate` package to ValidationSetKeys, to make it a bit clearer.