### PR TITLE
o/snapstate: support running multiple ops transactionally

### DIFF
--- a/overlord/snapstate/flags.go
+++ b/overlord/snapstate/flags.go
@@ -102,6 +102,9 @@ type Flags struct {
 	// QuotaGroupName represents the quota group a snap should be assigned
 	// to during installation.
 	QuotaGroupName string `json:"quota-group,omitempty"`
+
+	// Lane is the lane that tasks should join if Transaction is set to "all-snaps".
+	Lane int `json:"lane,omitempty"`
 }
 
 // DevModeAllowed returns whether a snap can be installed with devmode

--- a/overlord/snapstate/flags.go
+++ b/overlord/snapstate/flags.go
@@ -121,5 +121,6 @@ func (f Flags) ForSnapSetup() Flags {
 	f.NoReRefresh = false
 	f.RequireTypeBase = false
 	f.ApplySnapDevMode = false
+	f.Lane = 0
 	return f
 }

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1303,6 +1303,11 @@ func InstallMany(st *state.State, names []string, revOpts []*RevisionOptions, us
 		return nil, nil, err
 	}
 
+	// can only specify a lane when running multiple operations transactionally
+	if flags.Transaction != client.TransactionAllSnaps && flags.Lane != 0 {
+		return nil, nil, errors.New("cannot specify a lane without setting transaction to \"all-snaps\"")
+	}
+
 	var transactionLane int
 	if flags.Transaction == client.TransactionAllSnaps {
 		if flags.Lane != 0 {
@@ -1311,6 +1316,7 @@ func InstallMany(st *state.State, names []string, revOpts []*RevisionOptions, us
 			transactionLane = st.NewLane()
 		}
 	}
+
 	tasksets := make([]*state.TaskSet, 0, len(installs))
 	for _, sar := range installs {
 		info := sar.Info
@@ -1617,6 +1623,11 @@ func doUpdate(ctx context.Context, st *state.State, names []string, updates []mi
 		}
 	}
 	var kernelTs, gadgetTs, bootBaseTs *state.TaskSet
+
+	// can only specify a lane when running multiple operations transactionally
+	if globalFlags.Transaction != client.TransactionAllSnaps && globalFlags.Lane != 0 {
+		return nil, nil, errors.New("cannot specify a lane without setting transaction to \"all-snaps\"")
+	}
 
 	// updates is sorted by kind so this will process first core
 	// and bases and then other snaps

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -5507,32 +5507,22 @@ func (s *snapmgrTestSuite) TestInstallManyLaneIgnoredWithoutTransactional(c *C) 
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	checkLaneNotUsed := func(tss []*state.TaskSet, lane int) {
-		for _, ts := range tss {
-			for _, t := range ts.Tasks() {
-				c.Assert(t.Lanes(), Not(DeepEquals), []int{lane})
-			}
-		}
-	}
-
 	lane := s.state.NewLane()
 	flags := &snapstate.Flags{
 		Lane: lane,
 	}
 
 	affected, tss, err := snapstate.InstallMany(s.state, []string{"some-snap", "some-other-snap"}, nil, s.user.ID, flags)
-	c.Assert(err, IsNil)
-	c.Check(affected, DeepEquals, []string{"some-snap", "some-other-snap"})
-	c.Check(tss, HasLen, 2)
-	checkLaneNotUsed(tss, lane)
+	c.Assert(err, ErrorMatches, "cannot specify a lane without setting transaction to \"all-snaps\"")
+	c.Check(affected, IsNil)
+	c.Check(tss, IsNil)
 
 	flags.Transaction = client.TransactionPerSnap
 
 	affected, tss, err = snapstate.InstallMany(s.state, []string{"some-snap", "some-other-snap"}, nil, s.user.ID, flags)
-	c.Assert(err, IsNil)
-	c.Check(affected, DeepEquals, []string{"some-snap", "some-other-snap"})
-	c.Check(tss, HasLen, 2)
-	checkLaneNotUsed(tss, lane)
+	c.Assert(err, ErrorMatches, "cannot specify a lane without setting transaction to \"all-snaps\"")
+	c.Check(affected, IsNil)
+	c.Check(tss, IsNil)
 }
 
 func (s *snapmgrTestSuite) TestInstallPathManyTransactionalWithLane(c *C) {
@@ -5577,14 +5567,6 @@ func (s *snapmgrTestSuite) TestInstallPathManyLaneIgnoredWithoutTransactional(c 
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	checkLaneNotUsed := func(tss []*state.TaskSet, lane int) {
-		for _, ts := range tss {
-			for _, t := range ts.Tasks() {
-				c.Assert(t.Lanes(), Not(DeepEquals), []int{lane})
-			}
-		}
-	}
-
 	lane := s.state.NewLane()
 	flags := &snapstate.Flags{
 		Lane: lane,
@@ -5607,16 +5589,13 @@ epoch: 1
 	}
 
 	tss, err := snapstate.InstallPathMany(context.Background(), s.state, sideInfos, paths, 0, flags)
-	c.Assert(err, IsNil)
-	c.Check(tss, HasLen, 2)
-	checkLaneNotUsed(tss, lane)
+	c.Assert(err, ErrorMatches, "cannot specify a lane without setting transaction to \"all-snaps\"")
+	c.Check(tss, IsNil)
 
 	flags.Transaction = client.TransactionPerSnap
-
 	tss, err = snapstate.InstallPathMany(context.Background(), s.state, sideInfos, paths, 0, flags)
-	c.Assert(err, IsNil)
-	c.Check(tss, HasLen, 2)
-	checkLaneNotUsed(tss, lane)
+	c.Assert(err, ErrorMatches, "cannot specify a lane without setting transaction to \"all-snaps\"")
+	c.Check(tss, IsNil)
 }
 
 func (s *snapmgrTestSuite) TestInstallPathWithTransactionLaneForbidden(c *C) {

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -5503,7 +5503,7 @@ func (s *snapmgrTestSuite) TestInstallManyTransactionalWithLane(c *C) {
 	}
 }
 
-func (s *snapmgrTestSuite) TestInstallManyLaneIgnoredWithoutTransactional(c *C) {
+func (s *snapmgrTestSuite) TestInstallManyErrorsWithLaneButNoTransaction(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -5563,7 +5563,7 @@ epoch: 1
 	}
 }
 
-func (s *snapmgrTestSuite) TestInstallPathManyLaneIgnoredWithoutTransactional(c *C) {
+func (s *snapmgrTestSuite) TestInstallPathManyErrorsWithLaneButNoTransaction(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -8919,7 +8919,7 @@ func (s *snapmgrTestSuite) TestUpdateManyTransactionalWithLane(c *C) {
 	}
 }
 
-func (s *snapmgrTestSuite) TestUpdateManyLaneIgnoredWithoutTransactional(c *C) {
+func (s *snapmgrTestSuite) TestUpdateManyLaneErrorsWithLaneButNoTransaction(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -8990,7 +8990,7 @@ func (s *snapmgrTestSuite) TestUpdateTransactionalWithLane(c *C) {
 	}
 }
 
-func (s *snapmgrTestSuite) TestUpdateLaneIgnoredWithoutTransactional(c *C) {
+func (s *snapmgrTestSuite) TestUpdateLaneErrorsWithLaneButNoTransaction(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -8939,34 +8939,22 @@ func (s *snapmgrTestSuite) TestUpdateManyLaneIgnoredWithoutTransactional(c *C) {
 		})
 	}
 
-	checkLaneNotUsed := func(tss []*state.TaskSet, lane int) {
-		for _, ts := range tss {
-			for _, t := range ts.Tasks() {
-				c.Assert(t.Lanes(), Not(DeepEquals), []int{lane})
-			}
-		}
-	}
-
 	lane := s.state.NewLane()
 	flags := &snapstate.Flags{
 		Lane: lane,
-		// the check rerefresh taskset doesn't run in the same lane
-		NoReRefresh: true,
 	}
 
 	affected, tss, err := snapstate.UpdateMany(context.Background(), s.state, []string{"some-snap", "some-other-snap"}, nil, s.user.ID, flags)
-	c.Assert(err, IsNil)
-	c.Check(affected, testutil.DeepUnsortedMatches, []string{"some-snap", "some-other-snap"})
-	c.Check(tss, HasLen, 2)
-	checkLaneNotUsed(tss, lane)
+	c.Assert(err, ErrorMatches, "cannot specify a lane without setting transaction to \"all-snaps\"")
+	c.Check(tss, IsNil)
+	c.Check(affected, IsNil)
 
 	flags.Transaction = client.TransactionPerSnap
 
 	affected, tss, err = snapstate.UpdateMany(context.Background(), s.state, []string{"some-snap", "some-other-snap"}, nil, s.user.ID, flags)
-	c.Assert(err, IsNil)
-	c.Check(affected, testutil.DeepUnsortedMatches, []string{"some-snap", "some-other-snap"})
-	c.Check(tss, HasLen, 2)
-	checkLaneNotUsed(tss, lane)
+	c.Assert(err, ErrorMatches, "cannot specify a lane without setting transaction to \"all-snaps\"")
+	c.Check(tss, IsNil)
+	c.Check(affected, IsNil)
 }
 
 func (s *snapmgrTestSuite) TestUpdateTransactionalWithLane(c *C) {
@@ -9025,19 +9013,11 @@ func (s *snapmgrTestSuite) TestUpdateLaneIgnoredWithoutTransactional(c *C) {
 	})
 
 	ts, err := snapstate.Update(s.state, "some-snap", nil, s.user.ID, *flags)
-	c.Assert(err, IsNil)
-	c.Assert(ts, Not(IsNil))
-
-	for _, t := range ts.Tasks() {
-		c.Assert(t.Lanes(), Not(DeepEquals), []int{lane})
-	}
+	c.Assert(err, ErrorMatches, "cannot specify a lane without setting transaction to \"all-snaps\"")
+	c.Check(ts, IsNil)
 
 	flags.Transaction = client.TransactionPerSnap
 	ts, err = snapstate.Update(s.state, "some-snap", nil, s.user.ID, *flags)
-	c.Assert(err, IsNil)
-	c.Assert(ts, Not(IsNil))
-
-	for _, t := range ts.Tasks() {
-		c.Assert(t.Lanes(), Not(DeepEquals), []int{lane})
-	}
+	c.Assert(err, ErrorMatches, "cannot specify a lane without setting transaction to \"all-snaps\"")
+	c.Check(ts, IsNil)
 }

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -8879,3 +8879,165 @@ func (s *snapmgrTestSuite) TestGeneralRefreshSkipsGatedSnaps(c *C) {
 	c.Check(chg.IsReady(), Equals, true)
 	c.Check(chg.Status(), Equals, state.DoneStatus)
 }
+
+func (s *snapmgrTestSuite) TestUpdateManyTransactionalWithLane(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	for _, name := range []string{"some-snap", "some-other-snap"} {
+		snapID := fmt.Sprintf("%s-id", name)
+		si := &snap.SideInfo{
+			RealName: name,
+			SnapID:   snapID,
+			Revision: snap.R(7),
+		}
+
+		snaptest.MockSnap(c, `name: some-snap`, si)
+		snapstate.Set(s.state, name, &snapstate.SnapState{
+			Active:   true,
+			Sequence: []*snap.SideInfo{si},
+			Current:  si.Revision,
+		})
+	}
+
+	lane := s.state.NewLane()
+	flags := &snapstate.Flags{
+		Transaction: client.TransactionAllSnaps,
+		Lane:        lane,
+		// the check rerefresh taskset doesn't run in the same lane
+		NoReRefresh: true,
+	}
+	affected, tss, err := snapstate.UpdateMany(context.Background(), s.state, []string{"some-snap", "some-other-snap"}, nil, s.user.ID, flags)
+	c.Assert(err, IsNil)
+	c.Check(affected, testutil.DeepUnsortedMatches, []string{"some-snap", "some-other-snap"})
+	c.Check(tss, HasLen, 2)
+
+	for _, ts := range tss {
+		for _, t := range ts.Tasks() {
+			c.Assert(t.Lanes(), DeepEquals, []int{lane})
+		}
+	}
+}
+
+func (s *snapmgrTestSuite) TestUpdateManyLaneIgnoredWithoutTransactional(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	for _, name := range []string{"some-snap", "some-other-snap"} {
+		snapID := fmt.Sprintf("%s-id", name)
+		si := &snap.SideInfo{
+			RealName: name,
+			SnapID:   snapID,
+			Revision: snap.R(7),
+		}
+
+		snaptest.MockSnap(c, `name: some-snap`, si)
+		snapstate.Set(s.state, name, &snapstate.SnapState{
+			Active:   true,
+			Sequence: []*snap.SideInfo{si},
+			Current:  si.Revision,
+		})
+	}
+
+	checkLaneNotUsed := func(tss []*state.TaskSet, lane int) {
+		for _, ts := range tss {
+			for _, t := range ts.Tasks() {
+				c.Assert(t.Lanes(), Not(DeepEquals), []int{lane})
+			}
+		}
+	}
+
+	lane := s.state.NewLane()
+	flags := &snapstate.Flags{
+		Lane: lane,
+		// the check rerefresh taskset doesn't run in the same lane
+		NoReRefresh: true,
+	}
+
+	affected, tss, err := snapstate.UpdateMany(context.Background(), s.state, []string{"some-snap", "some-other-snap"}, nil, s.user.ID, flags)
+	c.Assert(err, IsNil)
+	c.Check(affected, testutil.DeepUnsortedMatches, []string{"some-snap", "some-other-snap"})
+	c.Check(tss, HasLen, 2)
+	checkLaneNotUsed(tss, lane)
+
+	flags.Transaction = client.TransactionPerSnap
+
+	affected, tss, err = snapstate.UpdateMany(context.Background(), s.state, []string{"some-snap", "some-other-snap"}, nil, s.user.ID, flags)
+	c.Assert(err, IsNil)
+	c.Check(affected, testutil.DeepUnsortedMatches, []string{"some-snap", "some-other-snap"})
+	c.Check(tss, HasLen, 2)
+	checkLaneNotUsed(tss, lane)
+}
+
+func (s *snapmgrTestSuite) TestUpdateTransactionalWithLane(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	si := &snap.SideInfo{
+		RealName: "some-snap",
+		SnapID:   "some-snap-id",
+		Revision: snap.R(7),
+	}
+
+	snaptest.MockSnap(c, `name: some-snap`, si)
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active:   true,
+		Sequence: []*snap.SideInfo{si},
+		Current:  si.Revision,
+	})
+
+	lane := s.state.NewLane()
+	flags := &snapstate.Flags{
+		Transaction: client.TransactionAllSnaps,
+		Lane:        lane,
+		// the check rerefresh taskset doesn't run in the same lane
+		NoReRefresh: true,
+	}
+
+	ts, err := snapstate.Update(s.state, "some-snap", nil, s.user.ID, *flags)
+	c.Assert(err, IsNil)
+	c.Assert(ts, Not(IsNil))
+	for _, t := range ts.Tasks() {
+		c.Assert(t.Lanes(), DeepEquals, []int{lane})
+	}
+}
+
+func (s *snapmgrTestSuite) TestUpdateLaneIgnoredWithoutTransactional(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	lane := s.state.NewLane()
+	flags := &snapstate.Flags{
+		Lane: lane,
+	}
+
+	si := &snap.SideInfo{
+		RealName: "some-snap",
+		SnapID:   "some-snap-id",
+		Revision: snap.R(7),
+	}
+
+	snaptest.MockSnap(c, `name: some-snap`, si)
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active:   true,
+		Sequence: []*snap.SideInfo{si},
+		Current:  si.Revision,
+	})
+
+	ts, err := snapstate.Update(s.state, "some-snap", nil, s.user.ID, *flags)
+	c.Assert(err, IsNil)
+	c.Assert(ts, Not(IsNil))
+
+	for _, t := range ts.Tasks() {
+		c.Assert(t.Lanes(), Not(DeepEquals), []int{lane})
+	}
+
+	flags.Transaction = client.TransactionPerSnap
+	ts, err = snapstate.Update(s.state, "some-snap", nil, s.user.ID, *flags)
+	c.Assert(err, IsNil)
+	c.Assert(ts, Not(IsNil))
+
+	for _, t := range ts.Tasks() {
+		c.Assert(t.Lanes(), Not(DeepEquals), []int{lane})
+	}
+}


### PR DESCRIPTION
Support running multiple InstallMany, UpdateMany, InstallPathMany and
Update operations in the same lane such that one operation failing
causes the others to be rolled back. The InstallMany and UpdateMany
ops will be used transactionally to resolve validation set enforcement
conflicts. The new flag is forbidden in Install and InstallPath since
we don't need those right now.
