### PR TITLE
wrappers: journal namespaces did not honor journal.persistent

### DIFF
--- a/tests/core/persistent-journal-namespace/task.yaml
+++ b/tests/core/persistent-journal-namespace/task.yaml
@@ -13,6 +13,10 @@ prepare: |
   tests.cleanup defer snap unset system experimental.quota-groups
 
 restore: |
+  # Stop test service and cleanup
+  snap stop test-snapd-journal-quota.logger
+  snap remove-quota group-one
+
   # disable persistent journal
   rm -rf /var/log/journal
   systemctl kill --signal=SIGUSR1 systemd-journald
@@ -55,7 +59,3 @@ execute: |
     echo "Journal path was recreated, it shouldn't have happened"
     exit 1
   fi
-
-  # Stop and cleanup
-  snap stop test-snapd-journal-quota.logger
-  snap remove-quota group-one

--- a/tests/core/persistent-journal-namespace/task.yaml
+++ b/tests/core/persistent-journal-namespace/task.yaml
@@ -7,7 +7,6 @@ systems:
   - -ubuntu-core-18-*
 
 prepare: |
-  systemctl status snapd > before.txt
   "$TESTSTOOLS"/snaps-state install-local test-snapd-journal-quota
   snap set system experimental.quota-groups=true
   tests.cleanup defer snap unset system experimental.quota-groups
@@ -17,7 +16,7 @@ restore: |
   snap stop test-snapd-journal-quota.logger
   snap remove-quota group-one
 
-  # disable persistent journal
+  # disable persistent journal and reload the journal
   rm -rf /var/log/journal
   systemctl kill --signal=SIGUSR1 systemd-journald
     
@@ -40,7 +39,7 @@ execute: |
   # this check relies on *anything* getting logged; enabling persistent
   # journal writes an entry about journal size, which should be sufficient.
   MACHINE_ID=$(cat /etc/machine-id)
-  retry -n30 --wait 1 test -e "/var/log/journal/$MACHINE_ID"
+  retry -n 30 --wait 1 test -e "/var/log/journal/$MACHINE_ID"
 
   echo "Starting service to fill namespace with logs"
   snap start test-snapd-journal-quota.logger
@@ -55,7 +54,7 @@ execute: |
 
   # Verify that, over a few seconds, nothing is created
   # to make sure the namespace is not recreating the path
-  if retry -n 3 sh -c "test -e /var/log/journal"; then
+  if retry -n 2 sh -c "test -e /var/log/journal"; then
     echo "Journal path was recreated, it shouldn't have happened"
     exit 1
   fi

--- a/tests/core/persistent-journal-namespace/task.yaml
+++ b/tests/core/persistent-journal-namespace/task.yaml
@@ -1,0 +1,62 @@
+summary: Test journal.persistent core config option is honored by journal namespaces
+
+# these systems do not support journal quota groups due to their old systemd versions.
+# requires systemd v245+
+systems:
+  - -ubuntu-core-16-*
+  - -ubuntu-core-18-*
+
+prepare: |
+  systemctl status snapd > before.txt
+  "$TESTSTOOLS"/snaps-state install-local test-snapd-journal-quota
+  snap set system experimental.quota-groups=true
+  tests.cleanup defer snap unset system experimental.quota-groups
+
+restore: |
+  # disable persistent journal
+  rm -rf /var/log/journal
+  systemctl kill --signal=SIGUSR1 systemd-journald
+    
+execute: |
+  echo "Wait for first boot to be done"
+  snap wait system seed.loaded
+
+  echo "Precondition check, persistent journal is not available by default"
+  not test -e /var/log/journal
+
+  echo "Check that persistent journal can be enabled"
+  snap set core journal.persistent=true
+  test -e /var/log/journal/
+  test -e /var/log/journal/.snapd-created
+
+  # Create a journal quota group and set arbitrary limits
+  echo "Create a journal namespace with the logger snap in it"
+  snap set-quota group-one --journal-size=16MB --journal-rate-limit=100/10ms test-snapd-journal-quota
+
+  # this check relies on *anything* getting logged; enabling persistent
+  # journal writes an entry about journal size, which should be sufficient.
+  MACHINE_ID=$(cat /etc/machine-id)
+  retry -n30 --wait 1 test -e "/var/log/journal/$MACHINE_ID"
+
+  echo "Starting service to fill namespace with logs"
+  snap start test-snapd-journal-quota.logger
+
+  # Verify the presence of the namespace log, and do this with retries as
+  # the logger writes onces every second
+  retry -n 5 sh -c "test -e /var/log/journal/$MACHINE_ID.snap-group-one"
+
+  echo "Check that persistent journal can be disabled"
+  snap set core journal.persistent=false
+  not test -e /var/log/journal
+
+  # Verify that, over a few seconds, nothing is created
+  # to make sure the namespace is not recreating the path
+  for i in {1..3}
+  do 
+    not test -e /var/log/journal
+    sleep 1
+  done
+
+  # Stop and cleanup
+  snap stop test-snapd-journal-quota.logger
+  snap remove-quota group-one

--- a/tests/core/persistent-journal-namespace/task.yaml
+++ b/tests/core/persistent-journal-namespace/task.yaml
@@ -51,11 +51,10 @@ execute: |
 
   # Verify that, over a few seconds, nothing is created
   # to make sure the namespace is not recreating the path
-  for i in {1..3}
-  do 
-    not test -e /var/log/journal
-    sleep 1
-  done
+  if retry -n 3 sh -c "test -e /var/log/journal"; then
+    echo "Journal path was recreated, it shouldn't have happened"
+    exit 1
+  fi
 
   # Stop and cleanup
   snap stop test-snapd-journal-quota.logger

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -184,8 +184,15 @@ func generateJournaldConfFile(grp *quota.Group) []byte {
 
 	sizeOptions := formatJournalSizeConf(grp)
 	rateOptions := formatJournalRateConf(grp)
+	// Set Storage=auto for all journal namespaces we create. This is
+	// the setting for the default namespace, and 'persistent' is the default
+	// setting for all namespaces. However we want namespaces to honor the
+	// journal.persistent setting, and this only works if Storage is set
+	// to 'auto'.
+	// See https://www.freedesktop.org/software/systemd/man/journald.conf.html#Storage=
 	template := `# Journald configuration for snap quota group %[1]s
 [Journal]
+Storage=auto
 `
 	buf := bytes.Buffer{}
 	fmt.Fprintf(&buf, template, grp.Name)

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -560,6 +560,7 @@ WantedBy=multi-user.target
 	)
 	jconfTempl := `# Journald configuration for snap quota group %s
 [Journal]
+Storage=auto
 `
 
 	sliceTempl := `[Unit]
@@ -663,6 +664,7 @@ WantedBy=multi-user.target
 	)
 	jconfTempl := `# Journald configuration for snap quota group %s
 [Journal]
+Storage=auto
 SystemMaxUse=10485760
 RuntimeMaxUse=10485760
 RateLimitIntervalSec=5000000us
@@ -769,6 +771,7 @@ WantedBy=multi-user.target
 	)
 	jconfTempl := `# Journald configuration for snap quota group %s
 [Journal]
+Storage=auto
 RateLimitIntervalSec=0us
 RateLimitBurst=0
 `


### PR DESCRIPTION
As described in the journal doc the default value for 'Storage=' varies. 

For the default namespace, 'Storage' is set to 'auto', but for all other namespaces, 'Storage' defaults to 'persistent', which unfortunately then ignores the 'journal.persistent' setting in snapd. The solution is to explicitly set 'Storage' to 'auto' for namespaces created through snap.
