### PR TITLE
i/b/udisks2: multiple fixes

### DIFF
--- a/interfaces/builtin/polkit.go
+++ b/interfaces/builtin/polkit.go
@@ -59,7 +59,7 @@ dbus (send)
     path="/org/freedesktop/PolicyKit1/Authority"
     interface="org.freedesktop.PolicyKit1.Authority"
     member="{,Cancel}CheckAuthorization"
-    peer=(name="org.freedesktop.PolicyKit1", label=unconfined),
+    peer=(label=unconfined),
 dbus (send)
     bus=system
     path="/org/freedesktop/PolicyKit1/Authority"
@@ -70,13 +70,13 @@ dbus (send)
     bus=system
     path="/org/freedesktop/PolicyKit1/Authority"
     interface="org.freedesktop.DBus.Properties"
-    peer=(name="org.freedesktop.PolicyKit1", label=unconfined),
+    peer=(label=unconfined),
 dbus (send)
     bus=system
     path="/org/freedesktop/PolicyKit1/Authority"
     interface="org.freedesktop.DBus.Introspectable"
     member="Introspect"
-    peer=(name="org.freedesktop.PolicyKit1", label=unconfined),
+    peer=(label=unconfined),
 `
 
 type polkitInterface struct {

--- a/interfaces/builtin/udisks2.go
+++ b/interfaces/builtin/udisks2.go
@@ -216,18 +216,10 @@ socket AF_NETLINK - NETLINK_KOBJECT_UEVENT
 const udisks2PermanentSlotDBus = `
 <policy user="root">
     <allow own="org.freedesktop.UDisks2"/>
+</policy>
+
+<policy context="default">
     <allow send_destination="org.freedesktop.UDisks2"/>
-</policy>
-
-<policy context="default">
-    <allow send_destination="org.freedesktop.UDisks2" send_interface="org.freedesktop.DBus.Introspectable" />
-</policy>
-`
-
-const udisks2ConnectedPlugDBus = `
-<policy context="default">
-    <deny own="org.freedesktop.UDisks2"/>
-    <deny send_destination="org.freedesktop.UDisks2"/>
 </policy>
 `
 
@@ -400,13 +392,6 @@ func (iface *udisks2Interface) StaticInfo() interfaces.StaticInfo {
 		ImplicitOnClassic:    true,
 		BaseDeclarationSlots: udisks2BaseDeclarationSlots,
 	}
-}
-
-func (iface *udisks2Interface) DBusConnectedPlug(spec *dbus.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
-	if !implicitSystemConnectedSlot(slot) {
-		spec.AddSnippet(udisks2ConnectedPlugDBus)
-	}
-	return nil
 }
 
 func (iface *udisks2Interface) DBusPermanentSlot(spec *dbus.Specification, slot *snap.SlotInfo) error {

--- a/interfaces/builtin/udisks2.go
+++ b/interfaces/builtin/udisks2.go
@@ -30,6 +30,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/dbus"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/interfaces/udev"
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -440,7 +441,11 @@ func (iface *udisks2Interface) UDevPermanentSlot(spec *udev.Specification, slot 
 		slot.Attr("udev-file", &udevFile)
 		if udevFile != "" {
 			mountDir := slot.Snap.MountDir()
-			data, err := ioutil.ReadFile(filepath.Join(mountDir, udevFile))
+			resolvedPath, err := osutil.ResolvePathInSysroot(mountDir, udevFile)
+			if err != nil {
+				return err
+			}
+			data, err := ioutil.ReadFile(filepath.Join(mountDir, resolvedPath))
 			if err != nil {
 				return fmt.Errorf("cannot open udev-file: %v", err)
 			}

--- a/interfaces/builtin/udisks2.go
+++ b/interfaces/builtin/udisks2.go
@@ -20,6 +20,7 @@
 package builtin
 
 import (
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"strings"
@@ -441,7 +442,7 @@ func (iface *udisks2Interface) UDevPermanentSlot(spec *udev.Specification, slot 
 			mountDir := slot.Snap.MountDir()
 			data, err := ioutil.ReadFile(filepath.Join(mountDir, udevFile))
 			if err != nil {
-				return err
+				return fmt.Errorf("cannot open udev-file: %v", err)
 			}
 			spec.AddSnippet(string(data))
 		} else {

--- a/interfaces/builtin/udisks2.go
+++ b/interfaces/builtin/udisks2.go
@@ -40,6 +40,8 @@ const udisks2BaseDeclarationSlots = `
       slot-snap-type:
         - app
         - core
+      slot-attributes:
+        udev-file: $MISSING
     deny-connection:
       on-classic: false
     deny-auto-connection: true

--- a/interfaces/builtin/udisks2.go
+++ b/interfaces/builtin/udisks2.go
@@ -27,7 +27,6 @@ import (
 	"github.com/snapcore/snapd/interfaces/dbus"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/interfaces/udev"
-	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -404,14 +403,14 @@ func (iface *udisks2Interface) StaticInfo() interfaces.StaticInfo {
 }
 
 func (iface *udisks2Interface) DBusConnectedPlug(spec *dbus.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
-	if !release.OnClassic {
+	if !implicitSystemConnectedSlot(slot) {
 		spec.AddSnippet(udisks2ConnectedPlugDBus)
 	}
 	return nil
 }
 
 func (iface *udisks2Interface) DBusPermanentSlot(spec *dbus.Specification, slot *snap.SlotInfo) error {
-	if !release.OnClassic {
+	if !implicitSystemPermanentSlot(slot) {
 		spec.AddSnippet(udisks2PermanentSlotDBus)
 	}
 	return nil
@@ -420,7 +419,7 @@ func (iface *udisks2Interface) DBusPermanentSlot(spec *dbus.Specification, slot 
 func (iface *udisks2Interface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	old := "###SLOT_SECURITY_TAGS###"
 	var new string
-	if release.OnClassic {
+	if implicitSystemConnectedSlot(slot) {
 		new = "unconfined"
 	} else {
 		new = slotAppLabelExpr(slot)
@@ -431,14 +430,14 @@ func (iface *udisks2Interface) AppArmorConnectedPlug(spec *apparmor.Specificatio
 }
 
 func (iface *udisks2Interface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *snap.SlotInfo) error {
-	if !release.OnClassic {
+	if !implicitSystemPermanentSlot(slot) {
 		spec.AddSnippet(udisks2PermanentSlotAppArmor)
 	}
 	return nil
 }
 
 func (iface *udisks2Interface) UDevPermanentSlot(spec *udev.Specification, slot *snap.SlotInfo) error {
-	if !release.OnClassic {
+	if !implicitSystemPermanentSlot(slot) {
 		spec.AddSnippet(udisks2PermanentSlotUDev)
 		spec.TagDevice(`SUBSYSTEM=="block"`)
 		// # This tags all USB devices, so we'll use AppArmor to mediate specific access (eg, /dev/sd* and /dev/mmcblk*)
@@ -448,7 +447,7 @@ func (iface *udisks2Interface) UDevPermanentSlot(spec *udev.Specification, slot 
 }
 
 func (iface *udisks2Interface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
-	if !release.OnClassic {
+	if !implicitSystemConnectedSlot(slot) {
 		old := "###PLUG_SECURITY_TAGS###"
 		new := plugAppLabelExpr(plug)
 		snippet := strings.Replace(udisks2ConnectedSlotAppArmor, old, new, -1)
@@ -458,7 +457,7 @@ func (iface *udisks2Interface) AppArmorConnectedSlot(spec *apparmor.Specificatio
 }
 
 func (iface *udisks2Interface) SecCompPermanentSlot(spec *seccomp.Specification, slot *snap.SlotInfo) error {
-	if !release.OnClassic {
+	if !implicitSystemPermanentSlot(slot) {
 		spec.AddSnippet(udisks2PermanentSlotSecComp)
 	}
 	return nil

--- a/interfaces/builtin/udisks2.go
+++ b/interfaces/builtin/udisks2.go
@@ -101,8 +101,7 @@ network netlink raw,
 # Mount points could be in /run/media/<user>/* or /media/<user>/*
 /run/systemd/seats/* r,
 /{,run/}media/{,**} rw,
-mount options=(ro,nosuid,nodev) /dev/{sd*,mmcblk*} -> /{,run/}media/**,
-mount options=(rw,nosuid,nodev) /dev/{sd*,mmcblk*} -> /{,run/}media/**,
+mount /dev/{dm-*,nvme*,vd*,hd*,sd*,mmcblk*,fd*,sr*} -> /{,run/}media/**,
 umount /{,run/}media/**,
 
 # This should probably be patched to use $SNAP_DATA/run/...
@@ -117,12 +116,21 @@ umount /{,run/}media/**,
 
 # Udisks2 needs to read the raw device for partition information. These rules
 # give raw read access to the system disks and therefore the entire system.
-/dev/sd* r,
-/dev/mmcblk* r,
-/dev/vd* r,
+/dev/{dm-*,nvme*,vd*,hd*,sd*,mmcblk*,fd*,sr*} r,
 
 # Needed for probing raw devices
 capability sys_rawio,
+
+/run/ rw,
+/run/cryptsetup/{,**} rwk,
+/run/mount/utab.lock rwk,
+/run/mount/utab.* rw,
+/run/mount/utab rw,
+/run/udisks2/{,**} rw,
+/sys/devices/**/block/**/uevent w,
+
+/{usr/,}{sbin,bin}/dumpe2fs ixr,
+/etc/crypttab r,
 `
 
 const udisks2ConnectedSlotAppArmor = `

--- a/interfaces/builtin/udisks2.go
+++ b/interfaces/builtin/udisks2.go
@@ -441,9 +441,9 @@ func (iface *udisks2Interface) UDevPermanentSlot(spec *udev.Specification, slot 
 		slot.Attr("udev-file", &udevFile)
 		if udevFile != "" {
 			mountDir := slot.Snap.MountDir()
-			resolvedPath, err := osutil.ResolvePathInSysroot(mountDir, udevFile)
+			resolvedPath, err := osutil.ResolvePathNoEscape(mountDir, udevFile)
 			if err != nil {
-				return err
+				return fmt.Errorf("cannot resolve udev-file: %v", err)
 			}
 			data, err := ioutil.ReadFile(filepath.Join(mountDir, resolvedPath))
 			if err != nil {

--- a/interfaces/builtin/udisks2_test.go
+++ b/interfaces/builtin/udisks2_test.go
@@ -194,15 +194,9 @@ func (s *UDisks2InterfaceSuite) TestAppArmorSpecOnClassic(c *C) {
 
 func (s *UDisks2InterfaceSuite) TestDBusSpec(c *C) {
 	spec := &dbus.Specification{}
-	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
-	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
-	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `<policy context="default">`)
-
-	spec = &dbus.Specification{}
 	c.Assert(spec.AddPermanentSlot(s.iface, s.slotInfo), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.producer.app"})
 	c.Assert(spec.SnippetForTag("snap.producer.app"), testutil.Contains, `<policy user="root">`)
-	c.Assert(spec.SnippetForTag("snap.producer.app"), testutil.Contains, `send_interface="org.freedesktop.DBus.Introspectable"`)
 }
 
 func (s *UDisks2InterfaceSuite) TestDBusSpecOnClassic(c *C) {

--- a/interfaces/builtin/udisks2_test.go
+++ b/interfaces/builtin/udisks2_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/snapcore/snapd/interfaces/dbus"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/interfaces/udev"
-	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -126,10 +125,6 @@ func (s *UDisks2InterfaceSuite) TestSanitizeSlot(c *C) {
 }
 
 func (s *UDisks2InterfaceSuite) TestAppArmorSpec(c *C) {
-	// on a core system with udisks2 slot coming from a regular app snap.
-	restore := release.MockOnClassic(false)
-	defer restore()
-
 	// The label uses short form when exactly one app is bound to the udisks2 slot
 	spec := &apparmor.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
@@ -180,10 +175,6 @@ func (s *UDisks2InterfaceSuite) TestAppArmorSpec(c *C) {
 }
 
 func (s *UDisks2InterfaceSuite) TestAppArmorSpecOnClassic(c *C) {
-	// on a core system with udisks2 slot coming from a the classic distro.
-	restore := release.MockOnClassic(true)
-	defer restore()
-
 	// connected plug to core slot
 	spec := &apparmor.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.classicSlot), IsNil)
@@ -202,10 +193,6 @@ func (s *UDisks2InterfaceSuite) TestAppArmorSpecOnClassic(c *C) {
 }
 
 func (s *UDisks2InterfaceSuite) TestDBusSpec(c *C) {
-	// on a core system with udisks2 slot coming from a regular app snap.
-	restore := release.MockOnClassic(false)
-	defer restore()
-
 	spec := &dbus.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
@@ -219,10 +206,6 @@ func (s *UDisks2InterfaceSuite) TestDBusSpec(c *C) {
 }
 
 func (s *UDisks2InterfaceSuite) TestDBusSpecOnClassic(c *C) {
-	// on a core system with udisks2 slot coming from a the classic distro.
-	restore := release.MockOnClassic(true)
-	defer restore()
-
 	// connected plug to core slot
 	spec := &dbus.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.classicSlot), IsNil)
@@ -232,10 +215,6 @@ func (s *UDisks2InterfaceSuite) TestDBusSpecOnClassic(c *C) {
 }
 
 func (s *UDisks2InterfaceSuite) TestUDevSpec(c *C) {
-	// on a core system with udisks2 slot coming from a regular app snap.
-	restore := release.MockOnClassic(false)
-	defer restore()
-
 	spec := &udev.Specification{}
 	c.Assert(spec.AddPermanentSlot(s.iface, s.slotInfo), IsNil)
 	c.Assert(spec.Snippets(), HasLen, 4)
@@ -248,20 +227,12 @@ SUBSYSTEM=="usb", TAG+="snap_producer_app"`)
 }
 
 func (s *UDisks2InterfaceSuite) TestUDevSpecOnClassic(c *C) {
-	// on a core system with udisks2 slot coming from a the classic distro.
-	restore := release.MockOnClassic(true)
-	defer restore()
-
 	spec := &udev.Specification{}
 	c.Assert(spec.AddPermanentSlot(s.iface, s.classicSlotInfo), IsNil)
 	c.Assert(spec.Snippets(), HasLen, 0)
 }
 
 func (s *UDisks2InterfaceSuite) TestSecCompSpec(c *C) {
-	// on a core system with udisks2 slot coming from a regular app snap.
-	restore := release.MockOnClassic(false)
-	defer restore()
-
 	spec := &seccomp.Specification{}
 	c.Assert(spec.AddPermanentSlot(s.iface, s.slotInfo), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.producer.app"})
@@ -269,10 +240,6 @@ func (s *UDisks2InterfaceSuite) TestSecCompSpec(c *C) {
 }
 
 func (s *UDisks2InterfaceSuite) TestSecCompSpecOnClassic(c *C) {
-	// on a core system with udisks2 slot coming from a the classic distro.
-	restore := release.MockOnClassic(true)
-	defer restore()
-
 	spec := &seccomp.Specification{}
 	c.Assert(spec.AddPermanentSlot(s.iface, s.classicSlotInfo), IsNil)
 	c.Assert(spec.SecurityTags(), HasLen, 0)

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -921,6 +921,26 @@ slots:
 `)
 	ic.SnapDeclaration = s.mockSnapDecl(c, "snapd", "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4", "canonical", "")
 	c.Assert(ic.Check(), IsNil)
+
+	ic = s.installSlotCand(c, "udisks2", snap.TypeApp, `name: udisks2
+version: 0
+type: app
+slots:
+  udisks2:
+`)
+	err = ic.Check()
+	c.Assert(err, IsNil)
+
+	ic = s.installSlotCand(c, "udisks2", snap.TypeApp, `name: udisks2
+version: 0
+type: app
+slots:
+  udisks2:
+    udev-file: some/file
+`)
+	err = ic.Check()
+	c.Assert(err, Not(IsNil))
+	c.Assert(err, ErrorMatches, "installation not allowed by \"udisks2\" slot rule of interface \"udisks2\"")
 }
 
 func (s *baseDeclSuite) TestPlugInstallation(c *C) {

--- a/osutil/resolve_path.go
+++ b/osutil/resolve_path.go
@@ -1,0 +1,114 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func resolvePathInSysrootRec(sysroot, path string, symlinkRecursion int) (string, error) {
+	if path == "" || path == "/" {
+		// Relative paths are taken from sysroot
+		return "/", nil
+	}
+
+	if strings.HasSuffix(path, "/") {
+		path = path[:len(path)-1]
+	}
+
+	dir, file := filepath.Split(path)
+	resolvedDir, err := resolvePathInSysrootRec(sysroot, dir, symlinkRecursion)
+	if err != nil {
+		return "", err
+	}
+	if file == "" {
+		return resolvedDir, nil
+	}
+	if file == "." {
+		return resolvedDir, nil
+	}
+	if file == ".." {
+		upperDir, _ := filepath.Split(resolvedDir)
+		return upperDir, nil
+	}
+
+	fileInResolvedDir := filepath.Join(resolvedDir, file)
+
+	realPath := filepath.Join(sysroot, fileInResolvedDir)
+	st, err := os.Lstat(realPath)
+	if err != nil {
+		return "", err
+	}
+
+	if st.Mode()&os.ModeSymlink != 0 {
+		if symlinkRecursion < 0 {
+			return "", fmt.Errorf("maximum recursion reached when reading symlinks")
+		}
+		target, err := os.Readlink(realPath)
+		if err != nil {
+			return "", err
+		}
+		if filepath.IsAbs(target) {
+			return resolvePathInSysrootRec(sysroot, target, symlinkRecursion-1)
+		} else {
+			return resolvePathInSysrootRec(sysroot, filepath.Join(resolvedDir, target), symlinkRecursion-1)
+		}
+	}
+
+	return fileInResolvedDir, nil
+}
+
+// ResolvePathInSysroot resolves a path within a sysroot
+//
+// In a sysroot, abolute symlinks should be relative to the sysroot
+// rather than `/`. Also paths with multiple `..` that would escape
+// the sysroot should not do so.
+//
+// The path must point to a file that exists.
+//
+// Example 1:
+//   - /sysroot/path1/a is a symlink pointing to /path2/b
+//   - /sysroot/path2/b is a symlink pointing to /path3/c
+//   - /sysroot/path3/c is a file
+//     ResolvePathInSysroot("/sysroot", "/path1/a") will return "/path3/c"
+//
+// Example 2:
+//   - /sysroot/path1/a  is a symlink pointing to ../../../path2/b
+//   - /sysroot/path2/b  is a symlink pointing to ../../../path3/c
+//   - /sysroot/path3/c  is a file
+//     ResolvePathInSysroot("/sysroot", "../../../path1/a") will return "/path3/c"
+//
+// Example 3:
+//   - /sysroot/path1/a is a symlink pointing to /path2/b
+//   - /sysroot/path2/b does not exist
+//     ResolvePathInSysroot("/sysroot", "/path1/a") will fail (IsNotExist)
+//
+// Example 4:
+//   - /sysroot/foo is a file or a directory
+//   - ResolvePathInSysroot("/sysroot", "/../../../../foo") will return "/foo"
+//
+// The return path is the path within the sysroot. filepath.Join() has
+// to be used to get the path in the sysroot.
+func ResolvePathInSysroot(sysroot, path string) (string, error) {
+	return resolvePathInSysrootRec(sysroot, path, 255)
+}

--- a/osutil/resolve_path_test.go
+++ b/osutil/resolve_path_test.go
@@ -1,0 +1,115 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil_test
+
+import (
+	"os"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/osutil"
+)
+
+type resolvePathSuite struct{}
+
+var _ = Suite(&resolvePathSuite{})
+
+func (s *resolvePathSuite) TestSimple(c *C) {
+	sysroot := c.MkDir()
+	err := os.MkdirAll(filepath.Join(sysroot, "foo/bar"), 0700)
+	c.Assert(err, IsNil)
+
+	resolved, err := osutil.ResolvePathInSysroot(sysroot, "/foo/bar")
+	c.Assert(err, IsNil)
+	c.Assert(resolved, Equals, "/foo/bar")
+}
+
+func (s *resolvePathSuite) TestSimpleRelative(c *C) {
+	sysroot := c.MkDir()
+	err := os.MkdirAll(filepath.Join(sysroot, "foo/bar"), 0700)
+	c.Assert(err, IsNil)
+
+	resolved, err := osutil.ResolvePathInSysroot(sysroot, "foo/bar")
+	c.Assert(err, IsNil)
+	c.Assert(resolved, Equals, "/foo/bar")
+}
+
+func (s *resolvePathSuite) TestDot(c *C) {
+	sysroot := c.MkDir()
+	err := os.MkdirAll(filepath.Join(sysroot, "foo/bar"), 0700)
+	c.Assert(err, IsNil)
+
+	resolved, err := osutil.ResolvePathInSysroot(sysroot, "/./foo/./bar/.")
+	c.Assert(err, IsNil)
+	c.Assert(resolved, Equals, "/foo/bar")
+}
+
+func (s *resolvePathSuite) TestEmpty(c *C) {
+	sysroot := c.MkDir()
+	err := os.MkdirAll(filepath.Join(sysroot, "foo/bar"), 0700)
+	c.Assert(err, IsNil)
+
+	resolved, err := osutil.ResolvePathInSysroot(sysroot, "//foo/////bar//")
+	c.Assert(err, IsNil)
+	c.Assert(resolved, Equals, "/foo/bar")
+}
+
+func (s *resolvePathSuite) TestDotDot(c *C) {
+	sysroot := c.MkDir()
+	err := os.MkdirAll(filepath.Join(sysroot, "foo/bar"), 0700)
+	c.Assert(err, IsNil)
+
+	resolved, err := osutil.ResolvePathInSysroot(sysroot, "../../../../foo/bar")
+	c.Assert(err, IsNil)
+	c.Assert(resolved, Equals, "/foo/bar")
+}
+
+func (s *resolvePathSuite) TestDotDotInSymlink(c *C) {
+	sysroot := c.MkDir()
+	err := os.MkdirAll(filepath.Join(sysroot, "foo"), 0700)
+	c.Assert(err, IsNil)
+	err = os.Symlink("../../../../../../..", filepath.Join(sysroot, "foo", "bar"))
+	c.Assert(err, IsNil)
+	err = os.MkdirAll(filepath.Join(sysroot, "etc"), 0700)
+	c.Assert(err, IsNil)
+	file, err := os.Create(filepath.Join(sysroot, "etc", "passwd"))
+	c.Assert(err, IsNil)
+	defer file.Close()
+
+	resolved, err := osutil.ResolvePathInSysroot(sysroot, "/foo/bar/etc/passwd")
+	c.Assert(err, IsNil)
+	c.Assert(resolved, Equals, "/etc/passwd")
+}
+
+func (s *resolvePathSuite) TestSymlinkRecursion(c *C) {
+	sysroot := c.MkDir()
+	err := os.MkdirAll(filepath.Join(sysroot, "foo"), 0700)
+	c.Assert(err, IsNil)
+	err = os.MkdirAll(filepath.Join(sysroot, "bar"), 0700)
+	c.Assert(err, IsNil)
+	err = os.Symlink("../bar/baz", filepath.Join(sysroot, "foo", "baz"))
+	c.Assert(err, IsNil)
+	err = os.Symlink("../foo/baz", filepath.Join(sysroot, "bar", "baz"))
+	c.Assert(err, IsNil)
+
+	_, err = osutil.ResolvePathInSysroot(sysroot, "/foo/baz/some/path")
+	c.Assert(err, ErrorMatches, "maximum recursion reached when reading symlinks")
+}


### PR DESCRIPTION
Here are 4 commits fixing udisks2 to work with newer version on udisks2 snap. And also on non UC distributions. And using polkit when available.

* allow installation of daemon on classic
* allow users to connect to daemon
* add missing AppArmor permissions
* add attribute to load udev rules

Also a commit fixing polkit. udisksd does send calls to methods with the name of the sender, but directly with the address of polkit. So filtering the peer label does not work and does  not let udiskd talk to polkit.

Tested to work with https://github.com/valentindavid/snap-udisks2