### PR TITLE
daemon: add `ensureStateSoon()` when calling systems POST api

### DIFF
--- a/daemon/api_systems.go
+++ b/daemon/api_systems.go
@@ -258,12 +258,14 @@ func postSystemActionInstall(c *Command, systemLabel string, req *systemActionRe
 		if err != nil {
 			return BadRequest("cannot setup storage encryption for install from %q: %v", systemLabel, err)
 		}
+		ensureStateSoon(st)
 		return AsyncResponse(nil, chg.ID())
 	case client.InstallStepFinish:
 		chg, err := devicestateInstallFinish(st, systemLabel, req.OnVolumes)
 		if err != nil {
 			return BadRequest("cannot finish install for %q: %v", systemLabel, err)
 		}
+		ensureStateSoon(st)
 		return AsyncResponse(nil, chg.ID())
 	default:
 		return BadRequest("unsupported install step %q", req.Step)


### PR DESCRIPTION
This commit adds the missing `ensureStateSoon()` when the POST /systems/<label> is called. With that the generated change will actually start to be processed immediately.

Thanks to Alfonso for noticing.
