### PR TITLE
tests/main/cgroup-tracking-failure: fix rare failure in Xenial and Bionic

### DIFF
--- a/tests/main/cgroup-tracking-failure/task.yaml
+++ b/tests/main/cgroup-tracking-failure/task.yaml
@@ -56,7 +56,7 @@ execute: |
     find /run/user/0 >run.txt
     case "$SPREAD_SYSTEM" in
         ubuntu-1[68].04-*)
-            systemctl --user stop dbus.{socket,service}
+            systemctl --user stop dbus.{socket,service} || true
             systemctl --user mask dbus.socket
             SNAPD_DEBUG=1 snap run test-snapd-sh.sh -c 'exec cat /proc/self/cgroup' >cgroup.txt 2>debug.txt
             systemctl --user unmask dbus.socket || true


### PR DESCRIPTION
This seems to happen very rarely:

    + . /home/gopath/src/github.com/snapcore/snapd/tests/lib/systems.sh
    + echo 'run a snap app as a root user, without session bus'
    + find /run/user/0
    + case "$SPREAD_SYSTEM" in
    + systemctl --user stop dbus.socket dbus.service
    Failed to connect to bus: No such file or directory

It's not clear how we get there, but in any case since the test needs the D-Bus user session to be tore down, there's no harm in ignoring errors occurring while stopping it.

Internal issue: SNAPDENG-2396 