### PR TITLE
boot: add factory-reset cases for boot-flags

### DIFF
--- a/boot/flags.go
+++ b/boot/flags.go
@@ -158,14 +158,13 @@ func InitramfsActiveBootFlags(mode string, rootfsDir string) ([]string, error) {
 		// to reduce the number of times we read the modeenv ?
 		return modeenv.BootFlags, nil
 
-	case ModeInstall:
-		// boot flags always come from the bootenv of the recovery bootloader
-		// in install mode
-		return readBootFlagsFromRecoveryBootloader()
-
 	case ModeFactoryReset:
 		// Reuse the code from ModeInstall as we have a lot of
 		// identical conditions.
+		fallthrough
+	case ModeInstall:
+		// boot flags always come from the bootenv of the recovery bootloader
+		// in install mode
 		return readBootFlagsFromRecoveryBootloader()
 
 	default:
@@ -347,8 +346,8 @@ func HostUbuntuDataForMode(mode string) ([]string, error) {
 	case ModeFactoryReset:
 		// In factory reset, our conditions are a lot similar to install mode,
 		// as we recreate the ubuntu-data partition. Make similar assumptions
-		// and checks like ModeInstall. We also make sure to check as we don't even
-		// know if ubuntu-data has been mounted yet.
+		// and checks like ModeInstall. Take into account ubuntu-data might not
+		// be mounted when this check is called.
 		factoryResetModeLocation := filepath.Dir(InstallHostWritableDir)
 		if exists, _, _ := osutil.DirExists(factoryResetModeLocation); exists {
 			runDataRootfsMountLocations = []string{factoryResetModeLocation}

--- a/boot/flags_test.go
+++ b/boot/flags_test.go
@@ -122,6 +122,34 @@ func (s *bootFlagsSuite) TestInitramfsActiveBootFlagsUC20InstallModeHappy(c *C) 
 	c.Assert(flags, DeepEquals, []string{"factory"})
 }
 
+func (s *bootFlagsSuite) TestInitramfsActiveBootFlagsUC20FactoryResetModeHappy(c *C) {
+	// FactoryReset and Install run identical code, as their condition match pretty closely
+	// so this unit test is to reconfirm that we expect same behavior as we see in the unit
+	// test for install mode.
+	dir := c.MkDir()
+
+	dirs.SetRootDir(dir)
+	defer func() { dirs.SetRootDir("") }()
+
+	blDir := boot.InitramfsUbuntuSeedDir
+
+	setupRealGrub(c, blDir, "EFI/ubuntu", &bootloader.Options{Role: bootloader.RoleRecovery})
+
+	flags, err := boot.InitramfsActiveBootFlags(boot.ModeFactoryReset, boot.InitramfsWritableDir)
+	c.Assert(err, IsNil)
+	c.Assert(flags, HasLen, 0)
+
+	// if we set some flags via ubuntu-image customizations then we get them
+	// back
+
+	err = boot.SetBootFlagsInBootloader([]string{"factory"}, blDir)
+	c.Assert(err, IsNil)
+
+	flags, err = boot.InitramfsActiveBootFlags(boot.ModeFactoryReset, boot.InitramfsWritableDir)
+	c.Assert(err, IsNil)
+	c.Assert(flags, DeepEquals, []string{"factory"})
+}
+
 func (s *bootFlagsSuite) TestSetImageBootFlagsVerification(c *C) {
 	longVal := "longer-than-256-char-value"
 	for i := 0; i < 256; i++ {
@@ -356,10 +384,20 @@ func (s *bootFlagsSuite) TestRunModeRootfs(c *C) {
 			comment: "install mode before partition creation",
 		},
 		{
+			mode:    boot.ModeFactoryReset,
+			comment: "factory-reset mode before partition is recreated",
+		},
+		{
 			mode:          boot.ModeInstall,
 			expDirs:       []string{"/run/mnt/ubuntu-data"},
 			createExpDirs: true,
 			comment:       "install mode after partition creation",
+		},
+		{
+			mode:          boot.ModeFactoryReset,
+			expDirs:       []string{"/run/mnt/ubuntu-data"},
+			createExpDirs: true,
+			comment:       "factory-reset mode after partition creation",
 		},
 		{
 			mode: boot.ModeRecover,


### PR DESCRIPTION
We do this to allow the usage of `snapctl system-mode` during factory-reset as a pre-requisite to running the install-device hook during factory-reset. The second PR will run the install-device hook and includes a spread test verifying that it is possible to run `snapctl system-mode`.

PR for this https://github.com/snapcore/snapd/pull/12154

