### PR TITLE
tests: fix unbound SPREAD_PATH variable on nested debug session

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -982,7 +982,7 @@ suites:
             # Generic imane name which has to be overwritten in the test
             NESTED_IMAGE_ID: "unset"
             # Configuration file used for remote tools
-            REMOTE_CFG_FILE: "$SPREAD_PATH/remote.setup.cfg"
+            REMOTE_CFG_FILE: "$PWD/remote.setup.cfg"
         manual: true
         warn-timeout: 10m
         kill-timeout: 60m
@@ -1035,7 +1035,7 @@ suites:
             # Enable secure boot in the nested vm in case it is supported
             NESTED_ENABLE_SECURE_BOOT: '$(HOST: echo "${NESTED_ENABLE_SECURE_BOOT:-false}")'
             # Configuration file used for remote tools
-            REMOTE_CFG_FILE: "$SPREAD_PATH/remote.setup.cfg"
+            REMOTE_CFG_FILE: "$PWD/remote.setup.cfg"
         manual: true
         prepare: |
             #shellcheck source=tests/lib/pkgdb.sh
@@ -1087,7 +1087,7 @@ suites:
             # Enable secure boot in the nested vm in case it is supported
             NESTED_ENABLE_SECURE_BOOT: '$(HOST: echo "${NESTED_ENABLE_SECURE_BOOT:-}")'
             # Configuration file used for remote tools
-            REMOTE_CFG_FILE: "$SPREAD_PATH/remote.setup.cfg"
+            REMOTE_CFG_FILE: "$PWD/remote.setup.cfg"
         manual: true
         prepare: |
             #shellcheck source=tests/lib/pkgdb.sh

--- a/spread.yaml
+++ b/spread.yaml
@@ -982,7 +982,7 @@ suites:
             # Generic imane name which has to be overwritten in the test
             NESTED_IMAGE_ID: "unset"
             # Configuration file used for remote tools
-            REMOTE_CFG_FILE: "$PWD/remote.setup.cfg"
+            REMOTE_CFG_FILE: "$PROJECT_PATH/remote.setup.cfg"
         manual: true
         warn-timeout: 10m
         kill-timeout: 60m
@@ -1035,7 +1035,7 @@ suites:
             # Enable secure boot in the nested vm in case it is supported
             NESTED_ENABLE_SECURE_BOOT: '$(HOST: echo "${NESTED_ENABLE_SECURE_BOOT:-false}")'
             # Configuration file used for remote tools
-            REMOTE_CFG_FILE: "$PWD/remote.setup.cfg"
+            REMOTE_CFG_FILE: "$PROJECT_PATH/remote.setup.cfg"
         manual: true
         prepare: |
             #shellcheck source=tests/lib/pkgdb.sh
@@ -1087,7 +1087,7 @@ suites:
             # Enable secure boot in the nested vm in case it is supported
             NESTED_ENABLE_SECURE_BOOT: '$(HOST: echo "${NESTED_ENABLE_SECURE_BOOT:-}")'
             # Configuration file used for remote tools
-            REMOTE_CFG_FILE: "$PWD/remote.setup.cfg"
+            REMOTE_CFG_FILE: "$PROJECT_PATH/remote.setup.cfg"
         manual: true
         prepare: |
             #shellcheck source=tests/lib/pkgdb.sh


### PR DESCRIPTION
This change is to fix the error caused by unbound SPREAD_PATH trying to start the debug session

2022-09-19 09:45:58 Starting shell to debug...
/tmp/tmp.bCYtcFnJLJ: line 92: SPREAD_PATH: unbound variable

This is only reproduced when the SPREAD_PATH is used in the suite environment.
