### PR TITLE
tests: disable quota tests on arm devices using ubuntu core

### DIFF
--- a/tests/main/quota-groups-systemd-accounting/task.yaml
+++ b/tests/main/quota-groups-systemd-accounting/task.yaml
@@ -12,12 +12,15 @@ details: |
 # we do have a check to do for these systems, but that is just to ensure that
 # we don't allow using quota groups, and that check is done in the snap-quota
 # spread instead
+# In arm devices using ubuntu core, memory quota cannot be used because
+# memory cgroup is disabled
 systems:
   - -ubuntu-14.04-*
   - -centos-7-*
   - -amazon-linux-2-*
   - -ubuntu-16.04-*
   - -ubuntu-core-16-*
+  - -ubuntu-core-*-arm-*
 
 prepare: |
   snap install hello-world go-example-webserver remarshal jq

--- a/tests/main/snap-quota-memory/task.yaml
+++ b/tests/main/snap-quota-memory/task.yaml
@@ -8,12 +8,15 @@ details: |
 # we do have a check to do for these systems, but that is just to ensure that
 # we don't allow using quota groups, and that check is done in the snap-quota
 # spread instead
+# In arm devices using ubuntu core, memory quota cannot be used because
+# memory cgroup is disabled
 systems:
   - -ubuntu-14.04-*
   - -centos-7-*
   - -amazon-linux-2-*
   - -ubuntu-16.04-*
   - -ubuntu-core-16-*
+  - -ubuntu-core-*-arm-*
 
 prepare: |
   snap install go-example-webserver jq remarshal hello-world

--- a/tests/main/snap-quota/task.yaml
+++ b/tests/main/snap-quota/task.yaml
@@ -3,6 +3,10 @@ summary: Basic test for quota-related snap commands.
 details: |
   Basic test for snap quota, remove-quota and quotas commands.
 
+# In arm devices using ubuntu core, memory quota cannot be used because
+# memory cgroup is disabled
+systems: [ -ubuntu-core-*-arm-* ]
+
 prepare: |
   snap install hello-world go-example-webserver test-snapd-tools
   snap set system experimental.quota-groups=true


### PR DESCRIPTION
Quotas have failed with the follwing error in arm devices for beta validation.

+ snap set-quota group-one --memory=100MB go-example-webserver error: cannot create quota group: cannot create quota group "group-one": cannot
       use memory quota: memory cgroup is disabled on this system

We need to skip those tests until the memory cgroup is enabled on the systems
