### PR TITLE
tests: fix snap-env test on debug section when no var files were created

### DIFF
--- a/tests/main/snap-env/task.yaml
+++ b/tests/main/snap-env/task.yaml
@@ -18,7 +18,7 @@ restore: |
     fi
 
 debug: |
-    cat ./*-vars.txt
+    find . -name '*-vars.txt' -exec cat {} \;
 
 execute: |
     echo "Collect SNAP and XDG environment variables"


### PR DESCRIPTION
This is to avoid this error

2022-09-19 16:50:09 Error debugging
external:ubuntu-core-22-arm-64:tests/main/snap-env:parallel (external:ubuntu-core-22-arm-64) :

+ cat './*-vars.txt' cat: './*-vars.txt': No such file or directory

