### PR TITLE
boot: apply boot logic also for classic with modes boot snaps

### DIFF
--- a/boot/boot.go
+++ b/boot/boot.go
@@ -141,8 +141,28 @@ func Kernel(s snap.PlaceInfo, t snap.Type, dev snap.Device) BootKernel {
 	return trivial{}
 }
 
+// SnapTypeParticipatesInBoot returns whether a snap type participates in the
+// boot for a given device.
+func SnapTypeParticipatesInBoot(t snap.Type, dev snap.Device) bool {
+	if dev.IsClassicBoot() {
+		return false
+	}
+	switch t {
+	case snap.TypeBase, snap.TypeOS:
+		// Bases are not boot participants for classic with modes
+		if dev.Classic() {
+			return false
+		}
+	case snap.TypeKernel, snap.TypeGadget:
+	default:
+		return false
+	}
+
+	return true
+}
+
 func applicable(s snap.PlaceInfo, t snap.Type, dev snap.Device) bool {
-	if dev.Classic() {
+	if !SnapTypeParticipatesInBoot(t, dev) {
 		return false
 	}
 	// In ephemeral modes we never need to care about updating the boot


### PR DESCRIPTION
this introduces also a helper SnapTypeParticipatesInBoot that can be used to make decisions combining snap type and model information
