### PR TITLE
cmd/snap-bootstrap: changes to be able to boot classic rootfs (2.57)

### DIFF
--- a/boot/bootstate20.go
+++ b/boot/bootstate20.go
@@ -387,8 +387,7 @@ func (ks20 *bootState20Kernel) setNext(next snap.PlaceInfo, bootCtx NextBootCont
 // kernel snap.
 func (ks20 *bootState20Kernel) selectAndCommitSnapInitramfsMount(modeenv *Modeenv, rootfsDir string) (sn snap.PlaceInfo, err error) {
 	// first do the generic choice of which snap to use
-	first, second, err :=
-		genericInitramfsSelectSnap(ks20, modeenv, rootfsDir, TryingStatus, "kernel")
+	first, second, err := genericInitramfsSelectSnap(ks20, modeenv, rootfsDir, TryingStatus, "kernel")
 	if err != nil && err != errTrySnapFallback {
 		return nil, err
 	}

--- a/boot/cmdline.go
+++ b/boot/cmdline.go
@@ -44,10 +44,12 @@ const (
 	// ModeFactoryReset is a mode in which the device performs a factory
 	// reset.
 	ModeFactoryReset = "factory-reset"
+	// ModeRunCVM is Azure CVM specific run mode fde + classic debs
+	ModeRunCVM = "cloudimg-rootfs"
 )
 
 var (
-	validModes = []string{ModeInstall, ModeRecover, ModeFactoryReset, ModeRun}
+	validModes = []string{ModeInstall, ModeRecover, ModeFactoryReset, ModeRun, ModeRunCVM}
 )
 
 // ModeAndRecoverySystemFromKernelCommandLine returns the current system mode

--- a/boot/cmdline_test.go
+++ b/boot/cmdline_test.go
@@ -108,6 +108,9 @@ func (s *kernelCommandLineSuite) TestModeAndLabel(c *C) {
 		cmd:   "snapd_recovery_system=not-this-one snapd_recovery_mode=install snapd_recovery_system=1234",
 		mode:  "install",
 		label: "1234",
+	}, {
+		cmd:  "snapd_recovery_mode=cloudimg-rootfs",
+		mode: boot.ModeRunCVM,
 	}} {
 		c.Logf("tc: %q", tc)
 		s.mockProcCmdlineContent(c, tc.cmd)

--- a/boot/flags.go
+++ b/boot/flags.go
@@ -137,7 +137,7 @@ func setImageBootFlags(flags []string, blVars map[string]string) error {
 // used by a userspace that is newer than the initramfs, but empty flags will be
 // dropped automatically.
 // Only to be used on UC20+ systems with recovery systems.
-func InitramfsActiveBootFlags(mode string) ([]string, error) {
+func InitramfsActiveBootFlags(mode string, rootfsDir string) ([]string, error) {
 	switch mode {
 	case ModeRecover:
 		// no boot flags are consumed / used on recover mode, so return nothing
@@ -149,7 +149,7 @@ func InitramfsActiveBootFlags(mode string) ([]string, error) {
 
 	case ModeRun:
 		// boot flags come from the modeenv
-		modeenv, err := ReadModeenv(InitramfsWritableDir)
+		modeenv, err := ReadModeenv(rootfsDir)
 		if err != nil {
 			return nil, err
 		}

--- a/boot/flags.go
+++ b/boot/flags.go
@@ -143,6 +143,10 @@ func InitramfsActiveBootFlags(mode string) ([]string, error) {
 		// no boot flags are consumed / used on recover mode, so return nothing
 		return nil, nil
 
+	case ModeRunCVM:
+		// no boot flags are consumed / used on CVM mode, so return nothing
+		return nil, nil
+
 	case ModeRun:
 		// boot flags come from the modeenv
 		modeenv, err := ReadModeenv(InitramfsWritableDir)

--- a/boot/flags_test.go
+++ b/boot/flags_test.go
@@ -107,7 +107,7 @@ func (s *bootFlagsSuite) TestInitramfsActiveBootFlagsUC20InstallModeHappy(c *C) 
 
 	setupRealGrub(c, blDir, "EFI/ubuntu", &bootloader.Options{Role: bootloader.RoleRecovery})
 
-	flags, err := boot.InitramfsActiveBootFlags(boot.ModeInstall)
+	flags, err := boot.InitramfsActiveBootFlags(boot.ModeInstall, boot.InitramfsWritableDir)
 	c.Assert(err, IsNil)
 	c.Assert(flags, HasLen, 0)
 
@@ -117,7 +117,7 @@ func (s *bootFlagsSuite) TestInitramfsActiveBootFlagsUC20InstallModeHappy(c *C) 
 	err = boot.SetBootFlagsInBootloader([]string{"factory"}, blDir)
 	c.Assert(err, IsNil)
 
-	flags, err = boot.InitramfsActiveBootFlags(boot.ModeInstall)
+	flags, err = boot.InitramfsActiveBootFlags(boot.ModeInstall, boot.InitramfsWritableDir)
 	c.Assert(err, IsNil)
 	c.Assert(flags, DeepEquals, []string{"factory"})
 }
@@ -163,7 +163,7 @@ func (s *bootFlagsSuite) TestInitramfsActiveBootFlagsUC20RecoverModeNoop(c *C) {
 	err = m.WriteTo(boot.InitramfsWritableDir)
 	c.Assert(err, IsNil)
 
-	flags, err := boot.InitramfsActiveBootFlags(boot.ModeRecover)
+	flags, err := boot.InitramfsActiveBootFlags(boot.ModeRecover, boot.InitramfsWritableDir)
 	c.Assert(err, IsNil)
 	c.Assert(flags, HasLen, 0)
 
@@ -175,7 +175,7 @@ func (s *bootFlagsSuite) TestInitramfsActiveBootFlagsUC20RecoverModeNoop(c *C) {
 	c.Assert(err, IsNil)
 
 	// still no flags since we are in recovery mode
-	flags, err = boot.InitramfsActiveBootFlags(boot.ModeRecover)
+	flags, err = boot.InitramfsActiveBootFlags(boot.ModeRecover, boot.InitramfsWritableDir)
 	c.Assert(err, IsNil)
 	c.Assert(flags, HasLen, 0)
 }
@@ -198,7 +198,7 @@ func (s *bootFlagsSuite) TestInitramfsActiveBootFlagsUC20RRunModeHappy(c *C) {
 	err = m.WriteTo(boot.InitramfsWritableDir)
 	c.Assert(err, IsNil)
 
-	flags, err := boot.InitramfsActiveBootFlags(boot.ModeRun)
+	flags, err := boot.InitramfsActiveBootFlags(boot.ModeRun, boot.InitramfsWritableDir)
 	c.Assert(err, IsNil)
 	c.Assert(flags, HasLen, 0)
 
@@ -207,7 +207,7 @@ func (s *bootFlagsSuite) TestInitramfsActiveBootFlagsUC20RRunModeHappy(c *C) {
 	c.Assert(err, IsNil)
 
 	// now some flags after we set them in the modeenv
-	flags, err = boot.InitramfsActiveBootFlags(boot.ModeRun)
+	flags, err = boot.InitramfsActiveBootFlags(boot.ModeRun, boot.InitramfsWritableDir)
 	c.Assert(err, IsNil)
 	c.Assert(flags, DeepEquals, []string{"factory", "other-flag"})
 }

--- a/boot/flags_test.go
+++ b/boot/flags_test.go
@@ -180,7 +180,7 @@ func (s *bootFlagsSuite) TestInitramfsActiveBootFlagsUC20RecoverModeNoop(c *C) {
 	c.Assert(flags, HasLen, 0)
 }
 
-func (s *bootFlagsSuite) TestInitramfsActiveBootFlagsUC20RRunModeHappy(c *C) {
+func (s *bootFlagsSuite) testInitramfsActiveBootFlagsUC20RRunModeHappy(c *C, flagsDir string) {
 	dir := c.MkDir()
 
 	dirs.SetRootDir(dir)
@@ -192,24 +192,29 @@ func (s *bootFlagsSuite) TestInitramfsActiveBootFlagsUC20RRunModeHappy(c *C) {
 		BootFlags: []string{},
 	}
 
-	err := os.MkdirAll(boot.InitramfsWritableDir, 0755)
+	err := os.MkdirAll(flagsDir, 0755)
 	c.Assert(err, IsNil)
 
-	err = m.WriteTo(boot.InitramfsWritableDir)
+	err = m.WriteTo(flagsDir)
 	c.Assert(err, IsNil)
 
-	flags, err := boot.InitramfsActiveBootFlags(boot.ModeRun, boot.InitramfsWritableDir)
+	flags, err := boot.InitramfsActiveBootFlags(boot.ModeRun, flagsDir)
 	c.Assert(err, IsNil)
 	c.Assert(flags, HasLen, 0)
 
 	m.BootFlags = []string{"factory", "other-flag"}
-	err = m.WriteTo(boot.InitramfsWritableDir)
+	err = m.WriteTo(flagsDir)
 	c.Assert(err, IsNil)
 
 	// now some flags after we set them in the modeenv
-	flags, err = boot.InitramfsActiveBootFlags(boot.ModeRun, boot.InitramfsWritableDir)
+	flags, err = boot.InitramfsActiveBootFlags(boot.ModeRun, flagsDir)
 	c.Assert(err, IsNil)
 	c.Assert(flags, DeepEquals, []string{"factory", "other-flag"})
+}
+
+func (s *bootFlagsSuite) TestInitramfsActiveBootFlagsUC20RRunModeHappy(c *C) {
+	s.testInitramfsActiveBootFlagsUC20RRunModeHappy(c, boot.InitramfsWritableDir)
+	s.testInitramfsActiveBootFlagsUC20RRunModeHappy(c, c.MkDir())
 }
 
 func (s *bootFlagsSuite) TestInitramfsSetBootFlags(c *C) {

--- a/boot/initramfs.go
+++ b/boot/initramfs.go
@@ -34,13 +34,14 @@ import (
 func InitramfsRunModeSelectSnapsToMount(
 	typs []snap.Type,
 	modeenv *Modeenv,
+	rootfsDir string,
 ) (map[snap.Type]snap.PlaceInfo, error) {
 	var sn snap.PlaceInfo
 	var err error
 	m := make(map[snap.Type]snap.PlaceInfo)
 	for _, typ := range typs {
 		// TODO: consider passing a bootStateUpdate20 instead?
-		var selectSnapFn func(*Modeenv) (snap.PlaceInfo, error)
+		var selectSnapFn func(*Modeenv, string) (snap.PlaceInfo, error)
 		switch typ {
 		case snap.TypeBase:
 			bs := &bootState20Base{}
@@ -63,7 +64,7 @@ func InitramfsRunModeSelectSnapsToMount(
 			}
 			selectSnapFn = bs.selectAndCommitSnapInitramfsMount
 		}
-		sn, err = selectSnapFn(modeenv)
+		sn, err = selectSnapFn(modeenv, rootfsDir)
 		if err != nil {
 			return nil, err
 		}

--- a/boot/initramfs_test.go
+++ b/boot/initramfs_test.go
@@ -620,10 +620,10 @@ func (s *initramfsSuite) TestInitramfsRunModeSelectSnapsToMount(c *C) {
 			c.Assert(err, IsNil, comment)
 
 			if t.expRebootPanic != "" {
-				f := func() { boot.InitramfsRunModeSelectSnapsToMount(t.typs, m) }
+				f := func() { boot.InitramfsRunModeSelectSnapsToMount(t.typs, m, boot.InitramfsWritableDir) }
 				c.Assert(f, PanicMatches, t.expRebootPanic, comment)
 			} else {
-				mountSnaps, err := boot.InitramfsRunModeSelectSnapsToMount(t.typs, m)
+				mountSnaps, err := boot.InitramfsRunModeSelectSnapsToMount(t.typs, m, boot.InitramfsWritableDir)
 				if t.errPattern != "" {
 					c.Assert(err, ErrorMatches, t.errPattern, comment)
 				} else {

--- a/boot/initramfs_test.go
+++ b/boot/initramfs_test.go
@@ -96,9 +96,9 @@ func (s *initramfsSuite) TestEnsureNextBootToRunModeRealBootloader(c *C) {
 	})
 }
 
-func makeSnapFilesOnInitramfsUbuntuData(c *C, comment CommentInterface, snaps ...snap.PlaceInfo) (restore func()) {
+func makeSnapFilesOnInitramfsUbuntuData(c *C, rootfsDir string, comment CommentInterface, snaps ...snap.PlaceInfo) (restore func()) {
 	// also make sure the snaps also exist on ubuntu-data
-	snapDir := dirs.SnapBlobDirUnder(boot.InitramfsWritableDir)
+	snapDir := dirs.SnapBlobDirUnder(rootfsDir)
 	err := os.MkdirAll(snapDir, 0755)
 	c.Assert(err, IsNil, comment)
 	paths := make([]string, 0, len(snaps))
@@ -147,8 +147,9 @@ func (s *initramfsSuite) TestInitramfsRunModeSelectSnapsToMount(c *C) {
 		snapsToMake    []snap.PlaceInfo
 		expected       map[snap.Type]snap.PlaceInfo
 		errPattern     string
-		comment        string
 		expRebootPanic string
+		rootfsDir      string
+		comment        string
 	}{
 		//
 		// default paths
@@ -160,6 +161,7 @@ func (s *initramfsSuite) TestInitramfsRunModeSelectSnapsToMount(c *C) {
 			typs:        []snap.Type{baseT},
 			snapsToMake: []snap.PlaceInfo{base1},
 			expected:    map[snap.Type]snap.PlaceInfo{baseT: base1},
+			rootfsDir:   boot.InitramfsWritableDir,
 			comment:     "default base path",
 		},
 		// gadget base path
@@ -168,6 +170,7 @@ func (s *initramfsSuite) TestInitramfsRunModeSelectSnapsToMount(c *C) {
 			typs:        []snap.Type{gadgetT},
 			snapsToMake: []snap.PlaceInfo{gadget},
 			expected:    map[snap.Type]snap.PlaceInfo{gadgetT: gadget},
+			rootfsDir:   boot.InitramfsWritableDir,
 			comment:     "default gadget path",
 		},
 		// gadget base path, but not in modeenv, so it is not selected
@@ -176,6 +179,7 @@ func (s *initramfsSuite) TestInitramfsRunModeSelectSnapsToMount(c *C) {
 			typs:        []snap.Type{gadgetT},
 			snapsToMake: []snap.PlaceInfo{gadget},
 			expected:    map[snap.Type]snap.PlaceInfo{},
+			rootfsDir:   boot.InitramfsWritableDir,
 			comment:     "default gadget path",
 		},
 		// default kernel path
@@ -185,7 +189,27 @@ func (s *initramfsSuite) TestInitramfsRunModeSelectSnapsToMount(c *C) {
 			typs:        []snap.Type{kernelT},
 			snapsToMake: []snap.PlaceInfo{kernel1},
 			expected:    map[snap.Type]snap.PlaceInfo{kernelT: kernel1},
+			rootfsDir:   boot.InitramfsWritableDir,
 			comment:     "default kernel path",
+		},
+		// gadget base path for classic with modes
+		{
+			m:           &boot.Modeenv{Mode: "run", Gadget: gadget.Filename()},
+			typs:        []snap.Type{gadgetT},
+			snapsToMake: []snap.PlaceInfo{gadget},
+			expected:    map[snap.Type]snap.PlaceInfo{gadgetT: gadget},
+			rootfsDir:   boot.InitramfsDataDir,
+			comment:     "default gadget path for classic with modes",
+		},
+		// default kernel path for classic with modes
+		{
+			m:           &boot.Modeenv{Mode: "run", CurrentKernels: []string{kernel1.Filename()}},
+			kernel:      kernel1,
+			typs:        []snap.Type{kernelT},
+			snapsToMake: []snap.PlaceInfo{kernel1},
+			expected:    map[snap.Type]snap.PlaceInfo{kernelT: kernel1},
+			rootfsDir:   boot.InitramfsDataDir,
+			comment:     "default kernel path for classic with modes",
 		},
 
 		//
@@ -201,6 +225,7 @@ func (s *initramfsSuite) TestInitramfsRunModeSelectSnapsToMount(c *C) {
 			blvars:      map[string]string{"kernel_status": boot.TryingStatus},
 			snapsToMake: []snap.PlaceInfo{kernel1, kernel2},
 			expected:    map[snap.Type]snap.PlaceInfo{kernelT: kernel2},
+			rootfsDir:   boot.InitramfsWritableDir,
 			comment:     "successful kernel upgrade path",
 		},
 		// extraneous kernel extracted/set, but kernel_status is default,
@@ -218,6 +243,7 @@ func (s *initramfsSuite) TestInitramfsRunModeSelectSnapsToMount(c *C) {
 			blvars:      map[string]string{"kernel_status": boot.DefaultStatus},
 			snapsToMake: []snap.PlaceInfo{kernel1, kernel2},
 			expected:    map[snap.Type]snap.PlaceInfo{kernelT: kernel1},
+			rootfsDir:   boot.InitramfsWritableDir,
 			comment:     "fallback kernel upgrade path, due to kernel_status empty (default)",
 		},
 
@@ -234,6 +260,7 @@ func (s *initramfsSuite) TestInitramfsRunModeSelectSnapsToMount(c *C) {
 			blvars:         map[string]string{"kernel_status": boot.TryingStatus},
 			snapsToMake:    []snap.PlaceInfo{kernel1, kernel2},
 			expRebootPanic: "reboot due to modeenv untrusted try kernel",
+			rootfsDir:      boot.InitramfsWritableDir,
 			comment:        "fallback kernel upgrade path, due to modeenv untrusted try kernel",
 		},
 		// kernel upgrade path, but reboots to fallback due to try kernel file not existing
@@ -245,6 +272,7 @@ func (s *initramfsSuite) TestInitramfsRunModeSelectSnapsToMount(c *C) {
 			blvars:         map[string]string{"kernel_status": boot.TryingStatus},
 			snapsToMake:    []snap.PlaceInfo{kernel1},
 			expRebootPanic: "reboot due to try kernel file not existing",
+			rootfsDir:      boot.InitramfsWritableDir,
 			comment:        "fallback kernel upgrade path, due to try kernel file not existing",
 		},
 		// kernel upgrade path, but reboots to fallback due to invalid kernel_status
@@ -256,6 +284,7 @@ func (s *initramfsSuite) TestInitramfsRunModeSelectSnapsToMount(c *C) {
 			blvars:         map[string]string{"kernel_status": boot.TryStatus},
 			snapsToMake:    []snap.PlaceInfo{kernel1, kernel2},
 			expRebootPanic: "reboot due to kernel_status wrong",
+			rootfsDir:      boot.InitramfsWritableDir,
 			comment:        "fallback kernel upgrade path, due to kernel_status wrong",
 		},
 
@@ -270,6 +299,7 @@ func (s *initramfsSuite) TestInitramfsRunModeSelectSnapsToMount(c *C) {
 			typs:        []snap.Type{kernelT},
 			snapsToMake: []snap.PlaceInfo{kernel1},
 			errPattern:  fmt.Sprintf("fallback kernel snap %q is not trusted in the modeenv", kernel1.Filename()),
+			rootfsDir:   boot.InitramfsWritableDir,
 			comment:     "fallback kernel not trusted in modeenv",
 		},
 		// fallback kernel file doesn't exist
@@ -278,6 +308,7 @@ func (s *initramfsSuite) TestInitramfsRunModeSelectSnapsToMount(c *C) {
 			kernel:     kernel1,
 			typs:       []snap.Type{kernelT},
 			errPattern: fmt.Sprintf("kernel snap %q does not exist on ubuntu-data", kernel1.Filename()),
+			rootfsDir:  boot.InitramfsWritableDir,
 			comment:    "fallback kernel file doesn't exist",
 		},
 
@@ -302,6 +333,7 @@ func (s *initramfsSuite) TestInitramfsRunModeSelectSnapsToMount(c *C) {
 			typs:        []snap.Type{baseT},
 			snapsToMake: []snap.PlaceInfo{base1, base2},
 			expected:    map[snap.Type]snap.PlaceInfo{baseT: base2},
+			rootfsDir:   boot.InitramfsWritableDir,
 			comment:     "successful base upgrade path",
 		},
 		// base upgrade path, but uses fallback due to try base file not existing
@@ -321,6 +353,7 @@ func (s *initramfsSuite) TestInitramfsRunModeSelectSnapsToMount(c *C) {
 			typs:        []snap.Type{baseT},
 			snapsToMake: []snap.PlaceInfo{base1},
 			expected:    map[snap.Type]snap.PlaceInfo{baseT: base1},
+			rootfsDir:   boot.InitramfsWritableDir,
 			comment:     "fallback base upgrade path, due to missing try base file",
 		},
 		// base upgrade path, but uses fallback due to base_status trying
@@ -340,6 +373,7 @@ func (s *initramfsSuite) TestInitramfsRunModeSelectSnapsToMount(c *C) {
 			typs:        []snap.Type{baseT},
 			snapsToMake: []snap.PlaceInfo{base1, base2},
 			expected:    map[snap.Type]snap.PlaceInfo{baseT: base1},
+			rootfsDir:   boot.InitramfsWritableDir,
 			comment:     "fallback base upgrade path, due to base_status trying",
 		},
 		// base upgrade path, but uses fallback due to base_status default
@@ -359,6 +393,7 @@ func (s *initramfsSuite) TestInitramfsRunModeSelectSnapsToMount(c *C) {
 			typs:        []snap.Type{baseT},
 			snapsToMake: []snap.PlaceInfo{base1, base2},
 			expected:    map[snap.Type]snap.PlaceInfo{baseT: base1},
+			rootfsDir:   boot.InitramfsWritableDir,
 			comment:     "fallback base upgrade path, due to missing base_status",
 		},
 
@@ -372,6 +407,7 @@ func (s *initramfsSuite) TestInitramfsRunModeSelectSnapsToMount(c *C) {
 			typs:        []snap.Type{baseT},
 			snapsToMake: []snap.PlaceInfo{base1},
 			errPattern:  "fallback base snap unusable: cannot get snap revision: modeenv base boot variable is empty",
+			rootfsDir:   boot.InitramfsWritableDir,
 			comment:     "base snap unset in modeenv",
 		},
 		// base snap file doesn't exist
@@ -379,6 +415,7 @@ func (s *initramfsSuite) TestInitramfsRunModeSelectSnapsToMount(c *C) {
 			m:          &boot.Modeenv{Mode: "run", Base: base1.Filename()},
 			typs:       []snap.Type{baseT},
 			errPattern: fmt.Sprintf("base snap %q does not exist on ubuntu-data", base1.Filename()),
+			rootfsDir:  boot.InitramfsWritableDir,
 			comment:    "base snap unset in modeenv",
 		},
 		// unhappy, but silent path with fallback, due to invalid try base snap name
@@ -392,6 +429,7 @@ func (s *initramfsSuite) TestInitramfsRunModeSelectSnapsToMount(c *C) {
 			typs:        []snap.Type{baseT},
 			snapsToMake: []snap.PlaceInfo{base1},
 			expected:    map[snap.Type]snap.PlaceInfo{baseT: base1},
+			rootfsDir:   boot.InitramfsWritableDir,
 			comment:     "corrupted base snap name",
 		},
 
@@ -418,7 +456,8 @@ func (s *initramfsSuite) TestInitramfsRunModeSelectSnapsToMount(c *C) {
 				baseT:   base1,
 				kernelT: kernel1,
 			},
-			comment: "default combined kernel + base",
+			rootfsDir: boot.InitramfsWritableDir,
+			comment:   "default combined kernel + base",
 		},
 		// combined, upgrade only the kernel
 		{
@@ -441,7 +480,8 @@ func (s *initramfsSuite) TestInitramfsRunModeSelectSnapsToMount(c *C) {
 				baseT:   base1,
 				kernelT: kernel2,
 			},
-			comment: "combined kernel + base, successful kernel upgrade",
+			rootfsDir: boot.InitramfsWritableDir,
+			comment:   "combined kernel + base, successful kernel upgrade",
 		},
 		// combined, upgrade only the base
 		{
@@ -466,7 +506,8 @@ func (s *initramfsSuite) TestInitramfsRunModeSelectSnapsToMount(c *C) {
 				baseT:   base2,
 				kernelT: kernel1,
 			},
-			comment: "combined kernel + base, successful base upgrade",
+			rootfsDir: boot.InitramfsWritableDir,
+			comment:   "combined kernel + base, successful base upgrade",
 		},
 		// bonus points: combined upgrade kernel and base
 		{
@@ -493,7 +534,8 @@ func (s *initramfsSuite) TestInitramfsRunModeSelectSnapsToMount(c *C) {
 				baseT:   base2,
 				kernelT: kernel2,
 			},
-			comment: "combined kernel + base, successful base + kernel upgrade",
+			rootfsDir: boot.InitramfsWritableDir,
+			comment:   "combined kernel + base, successful base + kernel upgrade",
 		},
 		// combined, fallback upgrade on kernel
 		{
@@ -516,7 +558,8 @@ func (s *initramfsSuite) TestInitramfsRunModeSelectSnapsToMount(c *C) {
 				baseT:   base1,
 				kernelT: kernel1,
 			},
-			comment: "combined kernel + base, fallback kernel upgrade, due to missing boot var",
+			rootfsDir: boot.InitramfsWritableDir,
+			comment:   "combined kernel + base, fallback kernel upgrade, due to missing boot var",
 		},
 		// combined, fallback upgrade on base
 		{
@@ -541,7 +584,8 @@ func (s *initramfsSuite) TestInitramfsRunModeSelectSnapsToMount(c *C) {
 				baseT:   base1,
 				kernelT: kernel1,
 			},
-			comment: "combined kernel + base, fallback base upgrade, due to base_status trying",
+			rootfsDir: boot.InitramfsWritableDir,
+			comment:   "combined kernel + base, fallback base upgrade, due to base_status trying",
 		},
 	}
 
@@ -603,27 +647,27 @@ func (s *initramfsSuite) TestInitramfsRunModeSelectSnapsToMount(c *C) {
 			}
 
 			if len(t.snapsToMake) != 0 {
-				r := makeSnapFilesOnInitramfsUbuntuData(c, comment, t.snapsToMake...)
+				r := makeSnapFilesOnInitramfsUbuntuData(c, t.rootfsDir, comment, t.snapsToMake...)
 				cleanups = append(cleanups, r)
 			}
 
 			// write the modeenv to somewhere so we can read it and pass that to
 			// InitramfsRunModeChooseSnapsToMount
-			err := t.m.WriteTo(boot.InitramfsWritableDir)
+			err := t.m.WriteTo(t.rootfsDir)
 			// remove it because we are writing many modeenvs in this single test
 			cleanups = append(cleanups, func() {
-				c.Assert(os.Remove(dirs.SnapModeenvFileUnder(boot.InitramfsWritableDir)), IsNil, Commentf(t.comment))
+				c.Assert(os.Remove(dirs.SnapModeenvFileUnder(t.rootfsDir)), IsNil, Commentf(t.comment))
 			})
 			c.Assert(err, IsNil, comment)
 
-			m, err := boot.ReadModeenv(boot.InitramfsWritableDir)
+			m, err := boot.ReadModeenv(t.rootfsDir)
 			c.Assert(err, IsNil, comment)
 
 			if t.expRebootPanic != "" {
-				f := func() { boot.InitramfsRunModeSelectSnapsToMount(t.typs, m, boot.InitramfsWritableDir) }
+				f := func() { boot.InitramfsRunModeSelectSnapsToMount(t.typs, m, t.rootfsDir) }
 				c.Assert(f, PanicMatches, t.expRebootPanic, comment)
 			} else {
-				mountSnaps, err := boot.InitramfsRunModeSelectSnapsToMount(t.typs, m, boot.InitramfsWritableDir)
+				mountSnaps, err := boot.InitramfsRunModeSelectSnapsToMount(t.typs, m, t.rootfsDir)
 				if t.errPattern != "" {
 					c.Assert(err, ErrorMatches, t.errPattern, comment)
 				} else {
@@ -634,7 +678,7 @@ func (s *initramfsSuite) TestInitramfsRunModeSelectSnapsToMount(c *C) {
 
 			// check that the modeenv changed as expected
 			if t.expectedM != nil {
-				newM, err := boot.ReadModeenv(boot.InitramfsWritableDir)
+				newM, err := boot.ReadModeenv(t.rootfsDir)
 				c.Assert(err, IsNil, comment)
 				c.Assert(newM.Base, Equals, t.expectedM.Base, comment)
 				c.Assert(newM.BaseStatus, Equals, t.expectedM.BaseStatus, comment)

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -1753,8 +1753,7 @@ func generateMountsModeRun(mst *initramfsMountsState) (string, error) {
 	volLoop:
 		for _, vol := range gadgetInfo.Volumes {
 			for _, part := range vol.Structure {
-				if part.Role == gadget.SystemSeed &&
-					part.Name == "ubuntu-seed" {
+				if part.Role == gadget.SystemSeed {
 					seedDefinedInGadget = true
 					break volLoop
 				}

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -1743,8 +1743,7 @@ func generateMountsModeRun(mst *initramfsMountsState) (string, error) {
 
 	// 4.4 check if we expected a ubuntu-seed partition from the gadget data
 	if isClassic {
-		gadgetDir := filepath.Join(boot.InitramfsRunMntDir,
-			snapTypeToMountDir[snap.TypeGadget])
+		gadgetDir := filepath.Join(boot.InitramfsRunMntDir, snapTypeToMountDir[snap.TypeGadget])
 		gadgetInfo, err := gadget.ReadInfo(gadgetDir, model)
 		if err != nil {
 			return "", err

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -1773,7 +1773,9 @@ func generateMountsModeRun(mst *initramfsMountsState) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("cannot load metadata and verify snapd snap: %v", err)
 		}
-		return "", doSystemdMount(essSnaps[0].Path, filepath.Join(boot.InitramfsRunMntDir, "snapd"), mountReadOnlyOptions)
+		if err := doSystemdMount(essSnaps[0].Path, filepath.Join(boot.InitramfsRunMntDir, "snapd"), mountReadOnlyOptions); err != nil {
+			return "", fmt.Errorf("cannot mount snapd snap: %v", err)
+		}
 	}
 
 	return rootfsDir, nil

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_nosecboot.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_nosecboot.go
@@ -34,6 +34,9 @@ var (
 )
 
 func init() {
+	secbootProvisionForCVM = func(_ string) error {
+		return errNotImplemented
+	}
 	secbootMeasureSnapSystemEpochWhenPossible = func() error {
 		return errNotImplemented
 	}

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_secboot.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_secboot.go
@@ -26,6 +26,7 @@ import (
 )
 
 func init() {
+	secbootProvisionForCVM = secboot.ProvisionForCVM
 	secbootMeasureSnapSystemEpochWhenPossible = secboot.MeasureSnapSystemEpochWhenPossible
 	secbootMeasureSnapModelWhenPossible = secboot.MeasureSnapModelWhenPossible
 	secbootUnlockVolumeUsingSealedKeyIfEncrypted = secboot.UnlockVolumeUsingSealedKeyIfEncrypted

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -141,6 +141,12 @@ var (
 		KernelDeviceNode: "/dev/sda5",
 	}
 
+	cvmEncPart = disks.Partition{
+		FilesystemLabel:  "cloudimg-rootfs-enc",
+		PartitionUUID:    "cloudimg-rootfs-enc-partuuid",
+		KernelDeviceNode: "/dev/sda1",
+	}
+
 	// a boot disk without ubuntu-save
 	defaultBootDisk = &disks.MockDiskMapping{
 		Structure: []disks.Partition{
@@ -172,6 +178,15 @@ var (
 		},
 		DiskHasPartitions: true,
 		DevNum:            "defaultEncDev",
+	}
+
+	defaultCVMDisk = &disks.MockDiskMapping{
+		Structure: []disks.Partition{
+			seedPart,
+			cvmEncPart,
+		},
+		DiskHasPartitions: true,
+		DevNum:            "defaultCVMDev",
 	}
 
 	mockStateContent = `{"data":{"auth":{"users":[{"id":1,"name":"mvo"}],"macaroon-key":"not-a-cookie","last-id":1}},"some":{"other":"stuff"}}`
@@ -281,6 +296,9 @@ func (s *initramfsMountsSuite) SetUpTest(c *C) {
 	// by default mock that we don't have UEFI vars, etc. to get the booted
 	// kernel partition partition uuid
 	s.AddCleanup(main.MockPartitionUUIDForBootedKernelDisk(""))
+	s.AddCleanup(main.MockSecbootProvisionForCVM(func(_ string) error {
+		return nil
+	}))
 	s.AddCleanup(main.MockSecbootMeasureSnapSystemEpochWhenPossible(func() error {
 		return nil
 	}))
@@ -2306,6 +2324,116 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeEncryptedDataHappy(c *C
 
 	c.Assert(filepath.Join(dirs.SnapBootstrapRunDir, "secboot-epoch-measured"), testutil.FilePresent)
 	c.Assert(filepath.Join(dirs.SnapBootstrapRunDir, "run-model-measured"), testutil.FilePresent)
+}
+
+func (s *initramfsMountsSuite) TestInitramfsMountsRunCVMModeHappy(c *C) {
+	s.mockProcCmdlineContent(c, "snapd_recovery_mode=cloudimg-rootfs")
+
+	restore := main.MockPartitionUUIDForBootedKernelDisk("specific-ubuntu-seed-partuuid")
+	defer restore()
+
+	restore = disks.MockMountPointDisksToPartitionMapping(
+		map[disks.Mountpoint]*disks.MockDiskMapping{
+			{Mountpoint: boot.InitramfsUbuntuSeedDir}:                    defaultCVMDisk,
+			{Mountpoint: boot.InitramfsDataDir, IsDecryptedDevice: true}: defaultCVMDisk,
+		},
+	)
+	defer restore()
+
+	// don't do anything from systemd-mount, we verify the arguments passed at
+	// the end with cmd.Calls
+	cmd := testutil.MockCommand(c, "systemd-mount", ``)
+	defer cmd.Restore()
+
+	// mock that in turn, /run/mnt/ubuntu-boot, /run/mnt/ubuntu-seed, etc. are
+	// mounted
+	n := 0
+	restore = main.MockOsutilIsMounted(func(where string) (bool, error) {
+		n++
+		switch n {
+		// first call for each mount returns false, then returns true, this
+		// tests in the case where systemd is racy / inconsistent and things
+		// aren't mounted by the time systemd-mount returns
+		case 1, 2:
+			c.Assert(where, Equals, boot.InitramfsUbuntuSeedDir)
+		case 3, 4:
+			c.Assert(where, Equals, boot.InitramfsDataDir)
+		case 5, 6:
+			c.Assert(where, Equals, boot.InitramfsUbuntuSeedDir)
+		default:
+			c.Errorf("unexpected IsMounted check on %s", where)
+			return false, fmt.Errorf("unexpected IsMounted check on %s", where)
+		}
+		return n%2 == 0, nil
+	})
+	defer restore()
+
+	// Mock the call to TPMCVM, to ensure that TPM provisioning is
+	// done before unlock attempt
+	provisionTPMCVMCalled := false
+	restore = main.MockSecbootProvisionForCVM(func(_ string) error {
+		// Ensure this function is only called once
+		c.Assert(provisionTPMCVMCalled, Equals, false)
+		provisionTPMCVMCalled = true
+		return nil
+	})
+	defer restore()
+
+	cloudimgActivated := false
+	restore = main.MockSecbootUnlockVolumeUsingSealedKeyIfEncrypted(func(disk disks.Disk, name string, sealedEncryptionKeyFile string, opts *secboot.UnlockVolumeUsingSealedKeyOptions) (secboot.UnlockResult, error) {
+		c.Assert(provisionTPMCVMCalled, Equals, true)
+		c.Assert(name, Equals, "cloudimg-rootfs")
+		c.Assert(sealedEncryptionKeyFile, Equals, filepath.Join(s.tmpDir, "run/mnt/ubuntu-seed/device/fde/cloudimg-rootfs.sealed-key"))
+		c.Assert(opts.AllowRecoveryKey, Equals, true)
+		c.Assert(opts.WhichModel, IsNil)
+
+		cloudimgActivated = true
+		// return true because we are using an encrypted device
+		return happyUnlocked("cloudimg-rootfs", secboot.UnlockedWithSealedKey), nil
+	})
+	defer restore()
+
+	_, err := main.Parser().ParseArgs([]string{"initramfs-mounts"})
+	c.Assert(err, IsNil)
+	c.Check(s.Stdout.String(), Equals, "")
+
+	// 2 per mountpoint + 1 more for cross check
+	c.Assert(n, Equals, 5)
+
+	// failed to use mockSystemdMountSequence way of asserting this
+	// note that other test cases also mix & match using
+	// mockSystemdMountSequence & DeepEquals
+	c.Assert(cmd.Calls(), DeepEquals, [][]string{
+		{
+			"systemd-mount",
+			"/dev/disk/by-partuuid/specific-ubuntu-seed-partuuid",
+			boot.InitramfsUbuntuSeedDir,
+			"--no-pager",
+			"--no-ask-password",
+			"--fsck=yes",
+			"--options=private",
+			"--property=Before=initrd-fs.target",
+		},
+		{
+			"systemd-mount",
+			"/dev/mapper/cloudimg-rootfs-random",
+			boot.InitramfsDataDir,
+			"--no-pager",
+			"--no-ask-password",
+			"--fsck=yes",
+		},
+		{
+			"systemd-mount",
+			boot.InitramfsUbuntuSeedDir,
+			"--umount",
+			"--no-pager",
+			"--no-ask-password",
+			"--fsck=no",
+		},
+	})
+
+	c.Check(provisionTPMCVMCalled, Equals, true)
+	c.Check(cloudimgActivated, Equals, true)
 }
 
 func (s *initramfsMountsSuite) TestInitramfsMountsRunModeEncryptedDataUnhappyNoSave(c *C) {

--- a/cmd/snap-bootstrap/export_test.go
+++ b/cmd/snap-bootstrap/export_test.go
@@ -117,6 +117,14 @@ func MockSecbootUnlockEncryptedVolumeUsingKey(f func(disk disks.Disk, name strin
 	}
 }
 
+func MockSecbootProvisionForCVM(f func(_ string) error) (restore func()) {
+	old := secbootProvisionForCVM
+	secbootProvisionForCVM = f
+	return func() {
+		secbootProvisionForCVM = old
+	}
+}
+
 func MockSecbootMeasureSnapSystemEpochWhenPossible(f func() error) (restore func()) {
 	old := secbootMeasureSnapSystemEpochWhenPossible
 	secbootMeasureSnapSystemEpochWhenPossible = f

--- a/cmd/snap-bootstrap/initramfs_systemd_mount.go
+++ b/cmd/snap-bootstrap/initramfs_systemd_mount.go
@@ -75,6 +75,8 @@ type systemdMountOptions struct {
 	ReadOnly bool
 	// Private mount
 	Private bool
+	// Umount the mountpoint
+	Umount bool
 }
 
 // doSystemdMount will mount "what" at "where" using systemd-mount(1) with
@@ -96,6 +98,11 @@ func doSystemdMountImpl(what, where string, opts *systemdMountOptions) error {
 	unitName := whereEscaped + ".mount"
 
 	args := []string{what, where, "--no-pager", "--no-ask-password"}
+
+	if opts.Umount {
+		args = []string{where, "--umount", "--no-pager", "--no-ask-password"}
+	}
+
 	if opts.Tmpfs {
 		args = append(args, "--type=tmpfs")
 	}
@@ -200,7 +207,7 @@ func doSystemdMountImpl(what, where string, opts *systemdMountOptions) error {
 		var now time.Time
 		for now = timeNow(); now.Sub(start) < defaultMountUnitWaitTimeout; now = timeNow() {
 			mounted, err := osutilIsMounted(where)
-			if mounted {
+			if mounted == !opts.Umount {
 				break
 			}
 			if err != nil {

--- a/cmd/snap-bootstrap/initramfs_systemd_mount_test.go
+++ b/cmd/snap-bootstrap/initramfs_systemd_mount_test.go
@@ -155,6 +155,16 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			what:  "tmpfs",
 			where: "/run/mnt/data",
 			opts: &main.SystemdMountOptions{
+				Umount: true,
+			},
+			timeNowTimes:     []time.Time{testStart, testStart},
+			isMountedReturns: []bool{false},
+			comment:          "happy umount",
+		},
+		{
+			what:  "tmpfs",
+			where: "/run/mnt/data",
+			opts: &main.SystemdMountOptions{
 				NoSuid: true,
 				Bind:   true,
 			},
@@ -236,6 +246,11 @@ func (s *doSystemdMountSuite) TestDoSystemdMount(c *C) {
 			call := cmd.Calls()[0]
 			args := []string{
 				"systemd-mount", t.what, t.where, "--no-pager", "--no-ask-password",
+			}
+			if opts.Umount {
+				args = []string{
+					"systemd-mount", t.where, "--umount", "--no-pager", "--no-ask-password",
+				}
 			}
 			c.Assert(call[:len(args)], DeepEquals, args)
 

--- a/cmd/snap-bootstrap/main.go
+++ b/cmd/snap-bootstrap/main.go
@@ -66,6 +66,9 @@ func parseArgs(args []string) error {
 	p := parser()
 
 	_, err := p.ParseArgs(args)
+	if err != nil {
+		logger.Noticef("execution error: %v", err)
+	}
 	return err
 }
 

--- a/secboot/export_sb_test.go
+++ b/secboot/export_sb_test.go
@@ -51,6 +51,12 @@ func MockSbTPMEnsureProvisioned(f func(tpm *sb_tpm2.Connection, mode sb_tpm2.Pro
 	return restore
 }
 
+func MockSbTPMEnsureProvisionedWithCustomSRK(f func(tpm *sb_tpm2.Connection, mode sb_tpm2.ProvisionMode, newLockoutAuth []byte, srkTemplate *tpm2.Public) error) (restore func()) {
+	restore = testutil.Backup(&sbTPMEnsureProvisionedWithCustomSRK)
+	sbTPMEnsureProvisionedWithCustomSRK = f
+	return restore
+}
+
 func MockTPMReleaseResources(f func(tpm *sb_tpm2.Connection, handle tpm2.Handle) error) (restore func()) {
 	restore = testutil.Backup(&tpmReleaseResources)
 	tpmReleaseResources = f

--- a/secboot/secboot.go
+++ b/secboot/secboot.go
@@ -107,6 +107,10 @@ const (
 	// authorization data from TPMLockoutAuthFile will be used to authorize
 	// provisioning and will get overwritten in the process.
 	TPMPartialReprovision
+	// TPMProvisionFullWithoutLockout indicates full provisioning
+	// without using lockout authorization data, as currently used
+	// by Azure CVM
+	TPMProvisionFullWithoutLockout
 )
 
 type SealKeysParams struct {


### PR DESCRIPTION
This is https://github.com/snapcore/snapd/pull/12046 cherry picked for 2.57. 

Note that it also includes https://github.com/snapcore/snapd/commit/a3a2c22af3936987fcf08a07d9a69551a6bb74ea to avoid merge conflicts (which is slightly unfortunate as it makes the diff bigger).