### PR TITLE
many: make {Install,Initramfs}{{,Host},Writable}Dir a  function

### DIFF
--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/snapcore/snapd/bootloader/bootloadertest"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/seed"
 	"github.com/snapcore/snapd/snap"
@@ -58,10 +59,13 @@ type baseBootenvSuite struct {
 func (s *baseBootenvSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
 
+	restore := release.MockOnClassic(false)
+	s.AddCleanup(restore)
+
 	s.rootdir = c.MkDir()
 	dirs.SetRootDir(s.rootdir)
 	s.AddCleanup(func() { dirs.SetRootDir("") })
-	restore := snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {})
+	restore = snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {})
 	s.AddCleanup(restore)
 
 	s.bootdir = filepath.Join(s.rootdir, "boot")

--- a/boot/flags.go
+++ b/boot/flags.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/strutil"
@@ -288,7 +289,7 @@ func setNextBootFlags(dev snap.Device, rootDir string, flags []string) error {
 // ubuntu-data in an untrusted manner, but for the purposes of this function
 // that is ignored.
 // This is primarily meant to be consumed by "snap{,ctl} system-mode".
-func HostUbuntuDataForMode(mode string) ([]string, error) {
+func HostUbuntuDataForMode(mode string, mod gadget.Model) ([]string, error) {
 	var runDataRootfsMountLocations []string
 	switch mode {
 	case ModeRun:
@@ -330,7 +331,7 @@ func HostUbuntuDataForMode(mode string) ([]string, error) {
 
 		// note that we may be running in install mode before this directory is
 		// actually created so check if it exists first
-		installModeLocation := filepath.Dir(InstallHostWritableDir)
+		installModeLocation := filepath.Dir(InstallHostWritableDir(mod))
 		if exists, _, _ := osutil.DirExists(installModeLocation); exists {
 			runDataRootfsMountLocations = []string{installModeLocation}
 		}

--- a/boot/flags.go
+++ b/boot/flags.go
@@ -336,12 +336,19 @@ func HostUbuntuDataForMode(mode string, mod gadget.Model) ([]string, error) {
 		// otherwise leave it empty
 
 	case ModeInstall:
-		// the var we have is for /run/mnt/ubuntu-data/writable, but the caller
-		// probably wants /run/mnt/ubuntu-data
+		// On *Core* the var we have is
+		// /run/mnt/ubuntu-data/writable, but the caller
+		// probably wants /run/mnt/ubuntu-data there. For classic
+		// the dir is /run/mnt/ubuntu-data already
 
 		// note that we may be running in install mode before this directory is
 		// actually created so check if it exists first
-		installModeLocation := filepath.Dir(InstallHostWritableDir(mod))
+		var installModeLocation string
+		if mod.Classic() {
+			installModeLocation = InstallHostWritableDir(mod)
+		} else {
+			installModeLocation = filepath.Dir(InstallHostWritableDir(mod))
+		}
 		if exists, _, _ := osutil.DirExists(installModeLocation); exists {
 			runDataRootfsMountLocations = []string{installModeLocation}
 		}
@@ -351,7 +358,12 @@ func HostUbuntuDataForMode(mode string, mod gadget.Model) ([]string, error) {
 		// as we recreate the ubuntu-data partition. Make similar assumptions
 		// and checks like ModeInstall. Take into account ubuntu-data might not
 		// be mounted when this check is called.
-		factoryResetModeLocation := filepath.Dir(InstallHostWritableDir(mod))
+		var factoryResetModeLocation string
+		if mod.Classic() {
+			factoryResetModeLocation = InstallHostWritableDir(mod)
+		} else {
+			factoryResetModeLocation = filepath.Dir(InstallHostWritableDir(mod))
+		}
 		if exists, _, _ := osutil.DirExists(factoryResetModeLocation); exists {
 			runDataRootfsMountLocations = []string{factoryResetModeLocation}
 		}

--- a/boot/flags.go
+++ b/boot/flags.go
@@ -297,6 +297,8 @@ func setNextBootFlags(dev snap.Device, rootDir string, flags []string) error {
 // ubuntu-data in an untrusted manner, but for the purposes of this function
 // that is ignored.
 // This is primarily meant to be consumed by "snap{,ctl} system-mode".
+//
+// TODO: pass a "snap.Device" here and add "SystemMode() string" to that
 func HostUbuntuDataForMode(mode string, mod gadget.Model) ([]string, error) {
 	var runDataRootfsMountLocations []string
 	switch mode {

--- a/boot/flags.go
+++ b/boot/flags.go
@@ -349,7 +349,7 @@ func HostUbuntuDataForMode(mode string, mod gadget.Model) ([]string, error) {
 		// as we recreate the ubuntu-data partition. Make similar assumptions
 		// and checks like ModeInstall. Take into account ubuntu-data might not
 		// be mounted when this check is called.
-		factoryResetModeLocation := filepath.Dir(InstallHostWritableDir)
+		factoryResetModeLocation := filepath.Dir(InstallHostWritableDir(mod))
 		if exists, _, _ := osutil.DirExists(factoryResetModeLocation); exists {
 			runDataRootfsMountLocations = []string{factoryResetModeLocation}
 		}

--- a/boot/flags_test.go
+++ b/boot/flags_test.go
@@ -337,6 +337,8 @@ func (s *bootFlagsSuite) TestUserspaceBootFlagsUC20(c *C) {
 }
 
 func (s *bootFlagsSuite) TestRunModeRootfs(c *C) {
+	uc20Dev := boottest.MockUC20Device("run", nil)
+
 	tt := []struct {
 		mode               string
 		createExpDirs      bool
@@ -461,7 +463,7 @@ func (s *bootFlagsSuite) TestRunModeRootfs(c *C) {
 			}
 		}
 
-		dataMountDirs, err := boot.HostUbuntuDataForMode(t.mode)
+		dataMountDirs, err := boot.HostUbuntuDataForMode(t.mode, uc20Dev.Model())
 		if t.err != "" {
 			c.Assert(err, ErrorMatches, t.err, comment)
 			c.Assert(dataMountDirs, IsNil)

--- a/boot/flags_test.go
+++ b/boot/flags_test.go
@@ -135,7 +135,7 @@ func (s *bootFlagsSuite) TestInitramfsActiveBootFlagsUC20FactoryResetModeHappy(c
 
 	setupRealGrub(c, blDir, "EFI/ubuntu", &bootloader.Options{Role: bootloader.RoleRecovery})
 
-	flags, err := boot.InitramfsActiveBootFlags(boot.ModeFactoryReset, boot.InitramfsWritableDir)
+	flags, err := boot.InitramfsActiveBootFlags(boot.ModeFactoryReset, filepath.Join(dirs.GlobalRootDir, "/run/mnt/data/system-data"))
 	c.Assert(err, IsNil)
 	c.Assert(flags, HasLen, 0)
 
@@ -145,7 +145,7 @@ func (s *bootFlagsSuite) TestInitramfsActiveBootFlagsUC20FactoryResetModeHappy(c
 	err = boot.SetBootFlagsInBootloader([]string{"factory"}, blDir)
 	c.Assert(err, IsNil)
 
-	flags, err = boot.InitramfsActiveBootFlags(boot.ModeFactoryReset, boot.InitramfsWritableDir)
+	flags, err = boot.InitramfsActiveBootFlags(boot.ModeFactoryReset, filepath.Join(dirs.GlobalRootDir, "/run/mnt/data/system-data"))
 	c.Assert(err, IsNil)
 	c.Assert(flags, DeepEquals, []string{"factory"})
 }

--- a/boot/initramfs20dirs.go
+++ b/boot/initramfs20dirs.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/release"
 )
 
 var (
@@ -97,7 +98,13 @@ func setInitramfsDirVars(rootdir string) {
 	InitramfsUbuntuBootDir = filepath.Join(InitramfsRunMntDir, "ubuntu-boot")
 	InitramfsUbuntuSeedDir = filepath.Join(InitramfsRunMntDir, "ubuntu-seed")
 	InitramfsUbuntuSaveDir = filepath.Join(InitramfsRunMntDir, "ubuntu-save")
-	InstallHostWritableDir = filepath.Join(InitramfsRunMntDir, "ubuntu-data", "system-data")
+	// On classic+modes systems the writable dir is directly under
+	// "ubuntu-data"
+	if release.OnClassic {
+		InstallHostWritableDir = filepath.Join(InitramfsRunMntDir, "ubuntu-data")
+	} else {
+		InstallHostWritableDir = filepath.Join(InitramfsRunMntDir, "ubuntu-data", "system-data")
+	}
 	InstallHostDeviceSaveDir = filepath.Join(InitramfsUbuntuSaveDir, "device")
 	InstallHostFDEDataDir = dirs.SnapFDEDirUnder(InstallHostWritableDir)
 	InstallHostFDESaveDir = filepath.Join(InstallHostDeviceSaveDir, "fde")

--- a/boot/initramfs20dirs.go
+++ b/boot/initramfs20dirs.go
@@ -23,7 +23,7 @@ import (
 	"path/filepath"
 
 	"github.com/snapcore/snapd/dirs"
-	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/gadget"
 )
 
 var (
@@ -39,10 +39,6 @@ var (
 	// during the initramfs, typically used in recover mode.
 	InitramfsHostUbuntuDataDir string
 
-	// InitramfsHostWritableDir is the location of the host writable
-	// partition during the initramfs, typically used in recover mode.
-	InitramfsHostWritableDir string
-
 	// InitramfsUbuntuBootDir is the location of ubuntu-boot during the
 	// initramfs.
 	InitramfsUbuntuBootDir string
@@ -54,19 +50,6 @@ var (
 	// InitramfsUbuntuSaveDir is the location of ubuntu-save during the
 	// initramfs.
 	InitramfsUbuntuSaveDir string
-
-	// InitramfsWritableDir is the location of the writable partition during the
-	// initramfs. Note that this may refer to a temporary filesystem or a
-	// physical partition depending on what system mode the system is in.
-	InitramfsWritableDir string
-
-	// InstallHostWritableDir is the location of the writable partition of the
-	// installed host during install mode. This should always be on a physical
-	// partition.
-	InstallHostWritableDir string
-
-	// InstallHostFDEDataDir is the location of the FDE data during install mode.
-	InstallHostFDEDataDir string
 
 	// InstallHostFDESaveDir is the directory of the FDE data on the
 	// ubuntu-save partition during install mode. For other modes,
@@ -90,25 +73,56 @@ var (
 	snapBootFlagsFile string
 )
 
+// InstallHostWritableDir is the location of the writable partition of the
+// installed host during install mode. This should always be on a physical
+// partition.
+func InstallHostWritableDir(mod gadget.Model) string {
+	if mod.Classic() {
+		return filepath.Join(InitramfsRunMntDir, "ubuntu-data")
+	}
+	return filepath.Join(InitramfsRunMntDir, "ubuntu-data", "system-data")
+}
+
+// InitramfsHostWritableDir is the location of the host writable
+// partition during the initramfs, typically used in recover mode.
+func InitramfsHostWritableDir(mod gadget.Model) string {
+	if mod.Classic() {
+		return InitramfsHostUbuntuDataDir
+	}
+	return filepath.Join(InitramfsHostUbuntuDataDir, "system-data")
+}
+
+// InitramfsWritableDir is the location of the writable partition during the
+// initramfs. Note that this may refer to a temporary filesystem or a
+// physical partition depending on what system mode the system is in.
+//
+// This needs the "isRunMode" in the future for when we implement a
+// recovery system on "classic+modes". In this scenario in "run" mode
+// we have the debian based rootfs in /run/mnt/ubuntu-data *but* in
+// "recover" mode the rootfs comes from a base snap like "core22" so
+// we need to generate "ubuntu-core" like paths.
+func InitramfsWritableDir(mod gadget.Model, isRunMode bool) string {
+	if mod.Classic() && isRunMode {
+		return InitramfsDataDir
+	}
+	return filepath.Join(InitramfsDataDir, "system-data")
+}
+
+// InstallHostFDEDataDir is the location of the FDE data during install mode.
+func InstallHostFDEDataDir(mod gadget.Model) string {
+	return dirs.SnapFDEDirUnder(InstallHostWritableDir(mod))
+}
+
 func setInitramfsDirVars(rootdir string) {
 	InitramfsRunMntDir = filepath.Join(rootdir, "run/mnt")
 	InitramfsDataDir = filepath.Join(InitramfsRunMntDir, "data")
 	InitramfsHostUbuntuDataDir = filepath.Join(InitramfsRunMntDir, "host", "ubuntu-data")
-	InitramfsHostWritableDir = filepath.Join(InitramfsHostUbuntuDataDir, "system-data")
 	InitramfsUbuntuBootDir = filepath.Join(InitramfsRunMntDir, "ubuntu-boot")
 	InitramfsUbuntuSeedDir = filepath.Join(InitramfsRunMntDir, "ubuntu-seed")
 	InitramfsUbuntuSaveDir = filepath.Join(InitramfsRunMntDir, "ubuntu-save")
-	// On classic+modes systems the writable dir is directly under
-	// "ubuntu-data"
-	if release.OnClassic {
-		InstallHostWritableDir = filepath.Join(InitramfsRunMntDir, "ubuntu-data")
-	} else {
-		InstallHostWritableDir = filepath.Join(InitramfsRunMntDir, "ubuntu-data", "system-data")
-	}
+
 	InstallHostDeviceSaveDir = filepath.Join(InitramfsUbuntuSaveDir, "device")
-	InstallHostFDEDataDir = dirs.SnapFDEDirUnder(InstallHostWritableDir)
 	InstallHostFDESaveDir = filepath.Join(InstallHostDeviceSaveDir, "fde")
-	InitramfsWritableDir = filepath.Join(InitramfsDataDir, "system-data")
 	InitramfsSeedEncryptionKeyDir = filepath.Join(InitramfsUbuntuSeedDir, "device/fde")
 	InitramfsBootEncryptionKeyDir = filepath.Join(InitramfsUbuntuBootDir, "device/fde")
 

--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -300,13 +300,14 @@ func makeRunnableSystem(model *asserts.Model, bootWith *BootableSet, sealer *Tru
 	if model.Grade() == asserts.ModelGradeUnset {
 		return fmt.Errorf("internal error: cannot make pre-UC20 system runnable")
 	}
+
 	// TODO:UC20:
 	// - figure out what to do for uboot gadgets, currently we require them to
 	//   install the boot.sel onto ubuntu-boot directly, but the file should be
 	//   managed by snapd instead
 
 	// copy kernel/base/gadget into the ubuntu-data partition
-	snapBlobDir := dirs.SnapBlobDirUnder(InstallHostWritableDir)
+	snapBlobDir := dirs.SnapBlobDirUnder(InstallHostWritableDir(model))
 	if err := os.MkdirAll(snapBlobDir, 0755); err != nil {
 		return err
 	}
@@ -330,7 +331,7 @@ func makeRunnableSystem(model *asserts.Model, bootWith *BootableSet, sealer *Tru
 	}
 
 	// replicate the boot assets cache in host's writable
-	if err := CopyBootAssetsCacheToRoot(InstallHostWritableDir); err != nil {
+	if err := CopyBootAssetsCacheToRoot(InstallHostWritableDir(model)); err != nil {
 		return fmt.Errorf("cannot replicate boot assets cache: %v", err)
 	}
 
@@ -452,7 +453,7 @@ func makeRunnableSystem(model *asserts.Model, bootWith *BootableSet, sealer *Tru
 
 	// all fields that needed to be set in the modeenv must have been set by
 	// now, write modeenv to disk
-	if err := modeenv.WriteTo(InstallHostWritableDir); err != nil {
+	if err := modeenv.WriteTo(InstallHostWritableDir(model)); err != nil {
 		return fmt.Errorf("cannot write modeenv: %v", err)
 	}
 

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -465,7 +465,15 @@ func (s *makeBootable20Suite) testMakeSystemRunnable20(c *C, factoryReset, class
 
 	bootloader.Force(nil)
 
-	model := boottest.MakeMockUC20Model()
+	var model *asserts.Model
+	if classic {
+		model = boottest.MakeMockUC20Model(map[string]interface{}{
+			"classic":      "true",
+			"distribution": "ubuntu",
+		})
+	} else {
+		model = boottest.MakeMockUC20Model()
+	}
 	seedSnapsDirs := filepath.Join(s.rootdir, "/snaps")
 	err := os.MkdirAll(seedSnapsDirs, 0755)
 	c.Assert(err, IsNil)
@@ -729,10 +737,17 @@ version: 5.0
 	// ensure grub.cfg in boot was installed from internal assets
 	c.Check(mockBootGrubCfg, testutil.FileEquals, string(grubCfgAsset))
 
+	var installHostWritableDir string
+	if classic {
+		installHostWritableDir = filepath.Join(dirs.GlobalRootDir, "/run/mnt/ubuntu-data")
+	} else {
+		installHostWritableDir = filepath.Join(dirs.GlobalRootDir, "/run/mnt/ubuntu-data/system-data")
+	}
+
 	// ensure base/gadget/kernel got copied to /var/lib/snapd/snaps
-	core20Snap := filepath.Join(dirs.SnapBlobDirUnder(filepath.Join(dirs.GlobalRootDir, "/run/mnt/ubuntu-data/system-data")), "core20_3.snap")
-	gadgetSnap := filepath.Join(dirs.SnapBlobDirUnder(filepath.Join(dirs.GlobalRootDir, "/run/mnt/ubuntu-data/system-data")), "pc_4.snap")
-	pcKernelSnap := filepath.Join(dirs.SnapBlobDirUnder(filepath.Join(dirs.GlobalRootDir, "/run/mnt/ubuntu-data/system-data")), "pc-kernel_5.snap")
+	core20Snap := filepath.Join(dirs.SnapBlobDirUnder(installHostWritableDir), "core20_3.snap")
+	gadgetSnap := filepath.Join(dirs.SnapBlobDirUnder(installHostWritableDir), "pc_4.snap")
+	pcKernelSnap := filepath.Join(dirs.SnapBlobDirUnder(installHostWritableDir), "pc-kernel_5.snap")
 	c.Check(core20Snap, testutil.FilePresent)
 	c.Check(gadgetSnap, testutil.FilePresent)
 	c.Check(pcKernelSnap, testutil.FilePresent)
@@ -763,44 +778,46 @@ version: 5.0
 	c.Check(extractedKernelSymlink, testutil.FilePresent)
 
 	// ensure modeenv looks correct
-	var ubuntuDataModeEnvPath string
+	var ubuntuDataModeEnvPath, classicLine string
 	if classic {
 		ubuntuDataModeEnvPath = filepath.Join(s.rootdir, "/run/mnt/ubuntu-data/var/lib/snapd/modeenv")
+		classicLine = "\nclassic=true"
 	} else {
 		ubuntuDataModeEnvPath = filepath.Join(s.rootdir, "/run/mnt/ubuntu-data/system-data/var/lib/snapd/modeenv")
 	}
-	c.Check(ubuntuDataModeEnvPath, testutil.FileEquals, `mode=run
+	expectedModeenv := fmt.Sprintf(`mode=run
 recovery_system=20191216
 current_recovery_systems=20191216
 good_recovery_systems=20191216
 base=core20_3.snap
 gadget=pc_4.snap
 current_kernels=pc-kernel_5.snap
-model=my-brand/my-model-uc20
+model=my-brand/my-model-uc20%s
 grade=dangerous
 model_sign_key_id=Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij
 current_trusted_boot_assets={"grubx64.efi":["5ee042c15e104b825d6bc15c41cdb026589f1ec57ed966dd3f29f961d4d6924efc54b187743fa3a583b62722882d405d"]}
 current_trusted_recovery_boot_assets={"bootx64.efi":["39efae6545f16e39633fbfbef0d5e9fdd45a25d7df8764978ce4d81f255b038046a38d9855e42e5c7c4024e153fd2e37"],"grubx64.efi":["aa3c1a83e74bf6dd40dd64e5c5bd1971d75cdf55515b23b9eb379f66bf43d4661d22c4b8cf7d7a982d2013ab65c1c4c5"]}
 current_kernel_command_lines=["snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1"]
-`)
+`, classicLine)
+	c.Check(ubuntuDataModeEnvPath, testutil.FileEquals, expectedModeenv)
 	copiedGrubBin := filepath.Join(
-		dirs.SnapBootAssetsDirUnder(filepath.Join(dirs.GlobalRootDir, "/run/mnt/ubuntu-data/system-data")),
+		dirs.SnapBootAssetsDirUnder(installHostWritableDir),
 		"grub",
 		"grubx64.efi-5ee042c15e104b825d6bc15c41cdb026589f1ec57ed966dd3f29f961d4d6924efc54b187743fa3a583b62722882d405d",
 	)
 	copiedRecoveryGrubBin := filepath.Join(
-		dirs.SnapBootAssetsDirUnder(filepath.Join(dirs.GlobalRootDir, "/run/mnt/ubuntu-data/system-data")),
+		dirs.SnapBootAssetsDirUnder(installHostWritableDir),
 		"grub",
 		"grubx64.efi-aa3c1a83e74bf6dd40dd64e5c5bd1971d75cdf55515b23b9eb379f66bf43d4661d22c4b8cf7d7a982d2013ab65c1c4c5",
 	)
 	copiedRecoveryShimBin := filepath.Join(
-		dirs.SnapBootAssetsDirUnder(filepath.Join(dirs.GlobalRootDir, "/run/mnt/ubuntu-data/system-data")),
+		dirs.SnapBootAssetsDirUnder(installHostWritableDir),
 		"grub",
 		"bootx64.efi-39efae6545f16e39633fbfbef0d5e9fdd45a25d7df8764978ce4d81f255b038046a38d9855e42e5c7c4024e153fd2e37",
 	)
 
 	// only one file in the cache under new root
-	checkContentGlob(c, filepath.Join(dirs.SnapBootAssetsDirUnder(filepath.Join(dirs.GlobalRootDir, "/run/mnt/ubuntu-data/system-data")), "grub", "*"), []string{
+	checkContentGlob(c, filepath.Join(dirs.SnapBootAssetsDirUnder(installHostWritableDir), "grub", "*"), []string{
 		copiedRecoveryShimBin,
 		copiedGrubBin,
 		copiedRecoveryGrubBin,
@@ -824,10 +841,10 @@ current_kernel_command_lines=["snapd_recovery_mode=run console=ttyS0 console=tty
 	}
 
 	// make sure the marker file for sealed key was created
-	c.Check(filepath.Join(dirs.SnapFDEDirUnder(filepath.Join(dirs.GlobalRootDir, "/run/mnt/ubuntu-data/system-data")), "sealed-keys"), testutil.FilePresent)
+	c.Check(filepath.Join(installHostWritableDir, "/var/lib/snapd/device/fde/sealed-keys"), testutil.FilePresent)
 
 	// make sure we wrote the boot chains data file
-	c.Check(filepath.Join(dirs.SnapFDEDirUnder(filepath.Join(dirs.GlobalRootDir, "/run/mnt/ubuntu-data/system-data")), "boot-chains"), testutil.FilePresent)
+	c.Check(filepath.Join(installHostWritableDir, "/var/lib/snapd/device/fde/boot-chains"), testutil.FilePresent)
 }
 
 func (s *makeBootable20Suite) TestMakeSystemRunnable20Install(c *C) {

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -1558,7 +1558,6 @@ func generateMountsModeRunCVM(mst *initramfsMountsState) (gadget.Model, error) {
 		return nil, err
 	}
 
-	// XXX: or could we use "return mst.UnverifiedBootModel()" here?
 	return &genericCVMModel{}, nil
 }
 

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -167,7 +167,7 @@ func generateInitramfsMounts() (err error) {
 	}
 	model := mst.verifiedModel
 	if model == nil {
-		return fmt.Errorf("internal error: no validated model set")
+		return fmt.Errorf("internal error: no verified model set")
 	}
 
 	isRunMode := (mode == "run")
@@ -1378,7 +1378,7 @@ func generateMountsCommonInstallRecover(mst *initramfsMountsState) (model *asser
 	if err != nil {
 		return nil, nil, err
 	}
-	// model is now measured
+	// verified model from the seed is now measured
 	mst.SetVerifiedBootModel(model)
 
 	// at this point on a system with TPM-based encryption

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -1681,9 +1681,10 @@ func generateMountsModeRun(mst *initramfsMountsState) error {
 
 	// at this point data was opened so we can consider the model okay
 	mst.SetVerifiedBootModel(model)
+	rootfsDir := boot.InitramfsWritableDir(model, isRunMode)
 
 	// 3.2. mount ubuntu-save (if present)
-	haveSave, err := maybeMountSave(disk, boot.InitramfsWritableDir(model, isRunMode), isEncryptedDev, systemdOpts)
+	haveSave, err := maybeMountSave(disk, rootfsDir, isEncryptedDev, systemdOpts)
 	if err != nil {
 		return err
 	}
@@ -1724,7 +1725,7 @@ func generateMountsModeRun(mst *initramfsMountsState) error {
 			// be locked.
 			// for symmetry with recover code and extra paranoia
 			// though also check that the markers match.
-			paired, err := checkDataAndSavePairing(boot.InitramfsWritableDir(model, isRunMode))
+			paired, err := checkDataAndSavePairing(rootfsDir)
 			if err != nil {
 				return err
 			}
@@ -1735,7 +1736,7 @@ func generateMountsModeRun(mst *initramfsMountsState) error {
 	}
 
 	// 4.2. read modeenv
-	modeEnv, err := boot.ReadModeenv(boot.InitramfsWritableDir(model, isRunMode))
+	modeEnv, err := boot.ReadModeenv(rootfsDir)
 	if err != nil {
 		return err
 	}
@@ -1748,7 +1749,7 @@ func generateMountsModeRun(mst *initramfsMountsState) error {
 
 	// 4.2 choose base, gadget and kernel snaps (this includes updating
 	//     modeenv if needed to try the base snap)
-	mounts, err := boot.InitramfsRunModeSelectSnapsToMount(typs, modeEnv, boot.InitramfsWritableDir(model, isRunMode))
+	mounts, err := boot.InitramfsRunModeSelectSnapsToMount(typs, modeEnv, rootfsDir)
 	if err != nil {
 		return err
 	}
@@ -1762,7 +1763,7 @@ func generateMountsModeRun(mst *initramfsMountsState) error {
 	for _, typ := range typs {
 		if sn, ok := mounts[typ]; ok {
 			dir := snapTypeToMountDir[typ]
-			snapPath := filepath.Join(dirs.SnapBlobDirUnder(boot.InitramfsWritableDir(model, isRunMode)), sn.Filename())
+			snapPath := filepath.Join(dirs.SnapBlobDirUnder(rootfsDir), sn.Filename())
 			if err := doSystemdMount(snapPath, filepath.Join(boot.InitramfsRunMntDir, dir), mountReadOnlyOptions); err != nil {
 				return err
 			}

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -458,7 +458,7 @@ func notFoundPart() secboot.UnlockResult {
 func (s *baseInitramfsMountsSuite) makeSnapFilesOnEarlyBootUbuntuData(c *C, snaps ...snap.PlaceInfo) {
 	snapDir := dirs.SnapBlobDirUnder(filepath.Join(dirs.GlobalRootDir, "/run/mnt/data/system-data"))
 	if s.isClassic {
-		snapDir = dirs.SnapBlobDirUnder(boot.InitramfsDataDir)
+		snapDir = dirs.SnapBlobDirUnder(filepath.Join(dirs.GlobalRootDir, "/run/mnt/data"))
 	}
 	err := os.MkdirAll(snapDir, 0755)
 	c.Assert(err, IsNil)
@@ -612,7 +612,7 @@ func (s *baseInitramfsMountsSuite) makeRunSnapSystemdMount(typ snap.Type, sn sna
 
 	snapDir := filepath.Join(dirs.GlobalRootDir, "/run/mnt/data/system-data")
 	if s.isClassic {
-		snapDir = boot.InitramfsDataDir
+		snapDir = filepath.Join(dirs.GlobalRootDir, "/run/mnt/data/")
 	}
 	mnt.what = filepath.Join(dirs.SnapBlobDirUnder(snapDir), sn.Filename())
 	mnt.where = filepath.Join(boot.InitramfsRunMntDir, dir)

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/snapcore/snapd/bootloader/bootloadertest"
 	main "github.com/snapcore/snapd/cmd/snap-bootstrap"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/disks"
@@ -6532,7 +6533,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsTryRecoveryHealthCheckFails(c 
 	c.Assert(os.MkdirAll(filepath.Dir(mockedState), 0750), IsNil)
 	c.Assert(ioutil.WriteFile(mockedState, []byte(mockStateContent), 0640), IsNil)
 
-	restore = main.MockTryRecoverySystemHealthCheck(func() error {
+	restore = main.MockTryRecoverySystemHealthCheck(func(gadget.Model) error {
 		return fmt.Errorf("mock failure")
 	})
 	defer restore()

--- a/cmd/snap-bootstrap/export_test.go
+++ b/cmd/snap-bootstrap/export_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/osutil/disks"
 	"github.com/snapcore/snapd/secboot"
 )
@@ -164,7 +165,7 @@ func MockPartitionUUIDForBootedKernelDisk(uuid string) (restore func()) {
 	}
 }
 
-func MockTryRecoverySystemHealthCheck(mock func() error) (restore func()) {
+func MockTryRecoverySystemHealthCheck(mock func(gadget.Model) error) (restore func()) {
 	old := tryRecoverySystemHealthCheck
 	tryRecoverySystemHealthCheck = mock
 	return func() {

--- a/cmd/snap-bootstrap/initramfs_mounts_state.go
+++ b/cmd/snap-bootstrap/initramfs_mounts_state.go
@@ -101,7 +101,7 @@ func (mst *initramfsMountsState) ReadEssential(recoverySystem string, essentialT
 // is verified at the time the key auth policy is computed.
 func (mst *initramfsMountsState) UnverifiedBootModel() (*asserts.Model, error) {
 	if mst.mode != "run" {
-		return nil, fmt.Errorf("internal error: unverified boot model access is for limited run mode use")
+		return nil, fmt.Errorf("internal error: unverified boot model access is for limited {run,cloudimg,rootfs} mode use")
 	}
 
 	mf, err := os.Open(filepath.Join(boot.InitramfsUbuntuBootDir, "device/model"))

--- a/cmd/snap-bootstrap/initramfs_mounts_state.go
+++ b/cmd/snap-bootstrap/initramfs_mounts_state.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/seed"
@@ -45,6 +46,8 @@ var (
 type initramfsMountsState struct {
 	mode           string
 	recoverySystem string
+
+	verifiedModel gadget.Model
 }
 
 var errRunModeNoImpliedRecoverySystem = errors.New("internal error: no implied recovery system in run mode")
@@ -92,6 +95,14 @@ func (mst *initramfsMountsState) ReadEssential(recoverySystem string, essentialT
 	}
 
 	return model, snaps, nil
+}
+
+// SetVerifiedBootModel sets the "verifiedModel" field. It should only
+// be called after the model is verified. Either via a successful unlock
+// of the encrypted data or after validating the seed in install/recover
+// mode.
+func (mst *initramfsMountsState) SetVerifiedBootModel(m gadget.Model) {
+	mst.verifiedModel = m
 }
 
 // UnverifiedBootModel returns the unverified model from the

--- a/cmd/snap-bootstrap/initramfs_mounts_state.go
+++ b/cmd/snap-bootstrap/initramfs_mounts_state.go
@@ -101,7 +101,7 @@ func (mst *initramfsMountsState) ReadEssential(recoverySystem string, essentialT
 // is verified at the time the key auth policy is computed.
 func (mst *initramfsMountsState) UnverifiedBootModel() (*asserts.Model, error) {
 	if mst.mode != "run" {
-		return nil, fmt.Errorf("internal error: unverified boot model access is for limited {run,cloudimg,rootfs} mode use")
+		return nil, fmt.Errorf("internal error: unverified boot model access is for limited run mode use")
 	}
 
 	mf, err := os.Open(filepath.Join(boot.InitramfsUbuntuBootDir, "device/model"))

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -78,13 +78,13 @@ func roleNeedsEncryption(role string) bool {
 	return role == gadget.SystemData || role == gadget.SystemSave
 }
 
-func saveStorageTraits(allLaidOutVols map[string]*gadget.LaidOutVolume, optsPerVol map[string]*gadget.DiskVolumeValidationOptions, hasSavePartition bool) error {
+func saveStorageTraits(mod gadget.Model, allLaidOutVols map[string]*gadget.LaidOutVolume, optsPerVol map[string]*gadget.DiskVolumeValidationOptions, hasSavePartition bool) error {
 	allVolTraits, err := gadget.AllDiskVolumeDeviceTraits(allLaidOutVols, optsPerVol)
 	if err != nil {
 		return err
 	}
 	// save the traits to ubuntu-data host
-	if err := gadget.SaveDiskVolumesDeviceTraits(dirs.SnapDeviceDirUnder(boot.InstallHostWritableDir), allVolTraits); err != nil {
+	if err := gadget.SaveDiskVolumesDeviceTraits(dirs.SnapDeviceDirUnder(boot.InstallHostWritableDir(mod)), allVolTraits); err != nil {
 		return fmt.Errorf("cannot save disk to volume device traits: %v", err)
 	}
 	// and also to ubuntu-save if it exists
@@ -309,7 +309,7 @@ func Run(model gadget.Model, gadgetRoot, kernelRoot, bootDevice string, options 
 		},
 	}
 	// save the traits to ubuntu-data host and optionally to ubuntu-save if it exists
-	if err := saveStorageTraits(allLaidOutVols, optsPerVol, hasSavePartition); err != nil {
+	if err := saveStorageTraits(model, allLaidOutVols, optsPerVol, hasSavePartition); err != nil {
 		return nil, err
 	}
 
@@ -425,7 +425,7 @@ func FactoryReset(model gadget.Model, gadgetRoot, kernelRoot, bootDevice string,
 		},
 	}
 	// save the traits to ubuntu-data host and optionally to ubuntu-save if it exists
-	if err := saveStorageTraits(allLaidOutVols, optsPerVol, hasSavePartition); err != nil {
+	if err := saveStorageTraits(model, allLaidOutVols, optsPerVol, hasSavePartition); err != nil {
 		return nil, err
 	}
 

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -1731,7 +1731,7 @@ func (m *DeviceManager) SystemModeInfo() (*SystemModeInfo, error) {
 		}
 		smi.BootFlags = bootFlags
 
-		hostDataLocs, err := boot.HostUbuntuDataForMode(mode)
+		hostDataLocs, err := boot.HostUbuntuDataForMode(mode, deviceCtx.Model())
 		if err != nil {
 			return nil, err
 		}
@@ -2216,13 +2216,20 @@ var (
 // older systems might return both a recovery key for ubuntu-data and a
 // reinstall key for ubuntu-save.
 func (m *DeviceManager) EnsureRecoveryKeys() (*client.SystemRecoveryKeysResponse, error) {
+	deviceCtx, err := DeviceCtx(m.state, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	model := deviceCtx.Model()
+
 	fdeDir := dirs.SnapFDEDir
 	mode := m.SystemMode(SysAny)
 	if mode == "install" {
-		fdeDir = boot.InstallHostFDEDataDir
+		fdeDir = boot.InstallHostFDEDataDir(model)
 	} else if mode != "run" {
 		return nil, fmt.Errorf("cannot ensure recovery keys from system mode %q", mode)
 	}
+
 	sysKeys := &client.SystemRecoveryKeysResponse{}
 	// backward compatibility
 	reinstallKeyFile := filepath.Join(fdeDir, "reinstall.key")
@@ -2243,7 +2250,7 @@ func (m *DeviceManager) EnsureRecoveryKeys() (*client.SystemRecoveryKeysResponse
 	if !device.HasEncryptedMarkerUnder(fdeDir) {
 		return nil, fmt.Errorf("system does not use disk encryption")
 	}
-	dataMountPoints, err := boot.HostUbuntuDataForMode(m.SystemMode(SysHasModeenv))
+	dataMountPoints, err := boot.HostUbuntuDataForMode(m.SystemMode(SysHasModeenv), model)
 	if err != nil {
 		return nil, fmt.Errorf("cannot determine ubuntu-data mount point: %v", err)
 	}
@@ -2279,7 +2286,13 @@ func (m *DeviceManager) RemoveRecoveryKeys() error {
 	if !device.HasEncryptedMarkerUnder(dirs.SnapFDEDir) {
 		return fmt.Errorf("system does not use disk encryption")
 	}
-	dataMountPoints, err := boot.HostUbuntuDataForMode(m.SystemMode(SysHasModeenv))
+	deviceCtx, err := DeviceCtx(m.state, nil, nil)
+	if err != nil {
+		return err
+	}
+	model := deviceCtx.Model()
+
+	dataMountPoints, err := boot.HostUbuntuDataForMode(m.SystemMode(SysHasModeenv), model)
 	if err != nil {
 		return fmt.Errorf("cannot determine ubuntu-data mount point: %v", err)
 	}

--- a/overlord/devicestate/devicestate_recovery_keys_test.go
+++ b/overlord/devicestate/devicestate_recovery_keys_test.go
@@ -47,6 +47,7 @@ func (s *deviceMgrRecoveryKeysSuite) SetUpTest(c *C) {
 		c.Skip("needs working secboot recovery key")
 	}
 	s.deviceMgrBaseSuite.setupBaseTest(c, false)
+	s.setUC20PCModelInState(c)
 
 	devicestate.SetSystemMode(s.mgr, "run")
 }
@@ -72,6 +73,9 @@ func mockSystemRecoveryKeys(c *C, alsoReinstall bool) {
 }
 
 func (s *deviceMgrRecoveryKeysSuite) TestEnsureRecoveryKeysBackwardCompat(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
 	mockSystemRecoveryKeys(c, true)
 
 	keys, err := s.mgr.EnsureRecoveryKeys()
@@ -84,6 +88,9 @@ func (s *deviceMgrRecoveryKeysSuite) TestEnsureRecoveryKeysBackwardCompat(c *C) 
 }
 
 func (s *deviceMgrRecoveryKeysSuite) TestEnsureRecoveryKey(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
 	_, err := s.mgr.EnsureRecoveryKeys()
 	c.Check(err, ErrorMatches, `system does not use disk encryption`)
 
@@ -114,6 +121,9 @@ func (s *deviceMgrRecoveryKeysSuite) TestEnsureRecoveryKey(c *C) {
 }
 
 func (s *deviceMgrRecoveryKeysSuite) TestEnsureRecoveryKeyInstallMode(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
 	devicestate.SetSystemMode(s.mgr, "install")
 
 	rkeystr, err := hex.DecodeString("e1f01302c5d43726a9b85b4a8d9c7f6e")
@@ -150,6 +160,9 @@ func (s *deviceMgrRecoveryKeysSuite) TestEnsureRecoveryKeyInstallMode(c *C) {
 }
 
 func (s *deviceMgrRecoveryKeysSuite) TestEnsureRecoveryKeyRecoverMode(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
 	devicestate.SetSystemMode(s.mgr, "recover")
 
 	_, err := s.mgr.EnsureRecoveryKeys()
@@ -157,6 +170,9 @@ func (s *deviceMgrRecoveryKeysSuite) TestEnsureRecoveryKeyRecoverMode(c *C) {
 }
 
 func (s *deviceMgrRecoveryKeysSuite) TestRemoveRecoveryKeys(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
 	err := s.mgr.RemoveRecoveryKeys()
 	c.Check(err, ErrorMatches, `system does not use disk encryption`)
 
@@ -181,6 +197,9 @@ func (s *deviceMgrRecoveryKeysSuite) TestRemoveRecoveryKeys(c *C) {
 }
 
 func (s *deviceMgrRecoveryKeysSuite) TestRemoveRecoveryKeysBackwardCompat(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
 	called := false
 	rkey := filepath.Join(dirs.SnapFDEDir, "recovery.key")
 	defer devicestate.MockSecbootRemoveRecoveryKeys(func(r2k map[secboot.RecoveryKeyDevice]string) error {

--- a/overlord/devicestate/devicestate_serial_test.go
+++ b/overlord/devicestate/devicestate_serial_test.go
@@ -1919,6 +1919,8 @@ func (s *deviceMgrSerialSuite) TestFullDeviceRegistrationUC20Happy(c *C) {
 	r2 := devicestate.MockBaseStoreURL(mockServer.URL)
 	defer r2()
 
+	s.setUC20PCModelInState(c)
+
 	// setup state as will be done by first-boot
 	s.state.Lock()
 	defer s.state.Unlock()

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -140,6 +140,8 @@ var (
 func (s *deviceMgrBaseSuite) setupBaseTest(c *C, classic bool) {
 	s.BaseTest.SetUpTest(c)
 
+	s.AddCleanup(release.MockOnClassic(classic))
+
 	dirs.SetRootDir(c.MkDir())
 	s.AddCleanup(func() { dirs.SetRootDir("") })
 
@@ -157,8 +159,6 @@ func (s *deviceMgrBaseSuite) setupBaseTest(c *C, classic bool) {
 	s.bootloader = bootloadertest.Mock("mock", c.MkDir())
 	bootloader.Force(s.bootloader)
 	s.AddCleanup(func() { bootloader.Force(nil) })
-
-	s.AddCleanup(release.MockOnClassic(classic))
 
 	s.storeSigning = assertstest.NewStoreStack("canonical", nil)
 	s.restartObserve = nil

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -291,6 +291,37 @@ func (s *deviceMgrBaseSuite) setPCModelInState(c *C) {
 	})
 }
 
+func (s *deviceMgrBaseSuite) setUC20PCModelInState(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+	s.makeModelAssertionInState(c, "canonical", "pc-20", map[string]interface{}{
+		"architecture": "amd64",
+		// UC20
+		"grade": "dangerous",
+		"base":  "core20",
+		"snaps": []interface{}{
+			map[string]interface{}{
+				"name":            "pc-kernel",
+				"id":              snaptest.AssertedSnapID("pc-kernel"),
+				"type":            "kernel",
+				"default-channel": "20",
+			},
+			map[string]interface{}{
+				"name":            "pc",
+				"id":              snaptest.AssertedSnapID("pc"),
+				"type":            "gadget",
+				"default-channel": "20",
+			},
+		},
+	})
+
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
+		Brand:  "canonical",
+		Model:  "pc-20",
+		Serial: "serialserialserial",
+	})
+}
+
 func (s *deviceMgrBaseSuite) setupBrands() {
 	assertstatetest.AddMany(s.state, s.brands.AccountsAndKeys("my-brand")...)
 	otherAcct := assertstest.NewAccount(s.storeSigning, "other-brand", map[string]interface{}{
@@ -1351,35 +1382,10 @@ func (s *deviceMgrSuite) TestDeviceManagerSystemModeInfoUC20Install(c *C) {
 	mgr, err := devicestate.Manager(s.state, s.hookMgr, runner, s.newStore)
 	c.Assert(err, IsNil)
 
+	s.setUC20PCModelInState(c)
+
 	s.state.Lock()
 	defer s.state.Unlock()
-
-	// have a model
-	s.makeModelAssertionInState(c, "canonical", "pc-20", map[string]interface{}{
-		"architecture": "amd64",
-		// UC20
-		"grade": "dangerous",
-		"base":  "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
-				"name":            "pc-kernel",
-				"id":              snaptest.AssertedSnapID("pc-kernel"),
-				"type":            "kernel",
-				"default-channel": "20",
-			},
-			map[string]interface{}{
-				"name":            "pc",
-				"id":              snaptest.AssertedSnapID("pc"),
-				"type":            "gadget",
-				"default-channel": "20",
-			},
-		},
-	})
-
-	devicestatetest.SetDevice(s.state, &auth.DeviceState{
-		Brand: "canonical",
-		Model: "pc-20",
-	})
 
 	// seeded
 	s.state.Set("seeded", true)
@@ -1421,35 +1427,10 @@ func (s *deviceMgrSuite) TestDeviceManagerSystemModeInfoUC20Run(c *C) {
 	mgr, err := devicestate.Manager(s.state, s.hookMgr, runner, s.newStore)
 	c.Assert(err, IsNil)
 
+	s.setUC20PCModelInState(c)
+
 	s.state.Lock()
 	defer s.state.Unlock()
-
-	// have a model
-	s.makeModelAssertionInState(c, "canonical", "pc-20", map[string]interface{}{
-		"architecture": "amd64",
-		// UC20
-		"grade": "dangerous",
-		"base":  "core20",
-		"snaps": []interface{}{
-			map[string]interface{}{
-				"name":            "pc-kernel",
-				"id":              snaptest.AssertedSnapID("pc-kernel"),
-				"type":            "kernel",
-				"default-channel": "20",
-			},
-			map[string]interface{}{
-				"name":            "pc",
-				"id":              snaptest.AssertedSnapID("pc"),
-				"type":            "gadget",
-				"default-channel": "20",
-			},
-		},
-	})
-
-	devicestatetest.SetDevice(s.state, &auth.DeviceState{
-		Brand: "canonical",
-		Model: "pc-20",
-	})
 
 	// not seeded
 	// no flags

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -340,7 +340,7 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	if trustedInstallObserver != nil {
-		if err := prepareEncryptedSystemData(installedSystem.KeyForRole, trustedInstallObserver); err != nil {
+		if err := prepareEncryptedSystemData(model, installedSystem.KeyForRole, trustedInstallObserver); err != nil {
 			return err
 		}
 	}
@@ -376,7 +376,7 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 	return nil
 }
 
-func prepareEncryptedSystemData(keyForRole map[string]keys.EncryptionKey, trustedInstallObserver *boot.TrustedAssetsInstallObserver) error {
+func prepareEncryptedSystemData(model *asserts.Model, keyForRole map[string]keys.EncryptionKey, trustedInstallObserver *boot.TrustedAssetsInstallObserver) error {
 	// validity check
 	if len(keyForRole) == 0 || keyForRole[gadget.SystemData] == nil || keyForRole[gadget.SystemSave] == nil {
 		return fmt.Errorf("internal error: system encryption keys are unset")
@@ -391,11 +391,11 @@ func prepareEncryptedSystemData(keyForRole map[string]keys.EncryptionKey, truste
 	if err := trustedInstallObserver.ObserveExistingTrustedRecoveryAssets(boot.InitramfsUbuntuSeedDir); err != nil {
 		return fmt.Errorf("cannot observe existing trusted recovery assets: err")
 	}
-	if err := saveKeys(keyForRole); err != nil {
+	if err := saveKeys(model, keyForRole); err != nil {
 		return err
 	}
 	// write markers containing a secret to pair data and save
-	if err := writeMarkers(); err != nil {
+	if err := writeMarkers(model); err != nil {
 		return err
 	}
 	return nil
@@ -414,12 +414,12 @@ func prepareRunSystemData(model *asserts.Model, gadgetDir string, perfTimings ti
 
 	// preserve systemd-timesyncd clock timestamp, so that RTC-less devices
 	// can start with a more recent time on the next boot
-	if err := writeTimesyncdClock(dirs.GlobalRootDir, boot.InstallHostWritableDir); err != nil {
+	if err := writeTimesyncdClock(dirs.GlobalRootDir, boot.InstallHostWritableDir(model)); err != nil {
 		return fmt.Errorf("cannot seed timesyncd clock: %v", err)
 	}
 
 	// configure the run system
-	opts := &sysconfig.Options{TargetRootDir: boot.InstallHostWritableDir, GadgetDir: gadgetDir}
+	opts := &sysconfig.Options{TargetRootDir: boot.InstallHostWritableDir(model), GadgetDir: gadgetDir}
 	// configure cloud init
 	setSysconfigCloudOptions(opts, gadgetDir, model)
 	timings.Run(perfTimings, "sysconfig-configure-target-system", "Configure target system", func(timings.Measurer) {
@@ -438,7 +438,7 @@ func prepareRunSystemData(model *asserts.Model, gadgetDir string, perfTimings ti
 	// some files there, this eventually will go away when we introduce a proper
 	// mechanism not using system-files to install files onto the root
 	// filesystem from the install-device hook
-	if err := fixupWritableDefaultDirs(boot.InstallHostWritableDir); err != nil {
+	if err := fixupWritableDefaultDirs(boot.InstallHostWritableDir(model)); err != nil {
 		return err
 	}
 	return nil
@@ -471,9 +471,9 @@ func fixupWritableDefaultDirs(systemDataDir string) error {
 }
 
 // writeMarkers writes markers containing the same secret to pair data and save.
-func writeMarkers() error {
+func writeMarkers(model *asserts.Model) error {
 	// ensure directory for markers exists
-	if err := os.MkdirAll(boot.InstallHostFDEDataDir, 0755); err != nil {
+	if err := os.MkdirAll(boot.InstallHostFDEDataDir(model), 0755); err != nil {
 		return err
 	}
 	if err := os.MkdirAll(boot.InstallHostFDESaveDir, 0755); err != nil {
@@ -486,20 +486,20 @@ func writeMarkers() error {
 		return fmt.Errorf("cannot create ubuntu-data/save marker secret: %v", err)
 	}
 
-	return device.WriteEncryptionMarkers(boot.InstallHostFDEDataDir, boot.InstallHostFDESaveDir, markerSecret)
+	return device.WriteEncryptionMarkers(boot.InstallHostFDEDataDir(model), boot.InstallHostFDESaveDir, markerSecret)
 }
 
-func saveKeys(keyForRole map[string]keys.EncryptionKey) error {
+func saveKeys(model *asserts.Model, keyForRole map[string]keys.EncryptionKey) error {
 	saveEncryptionKey := keyForRole[gadget.SystemSave]
 	if saveEncryptionKey == nil {
 		// no system-save support
 		return nil
 	}
 	// ensure directory for keys exists
-	if err := os.MkdirAll(boot.InstallHostFDEDataDir, 0755); err != nil {
+	if err := os.MkdirAll(boot.InstallHostFDEDataDir(model), 0755); err != nil {
 		return err
 	}
-	if err := saveEncryptionKey.Save(device.SaveKeyUnder(boot.InstallHostFDEDataDir)); err != nil {
+	if err := saveEncryptionKey.Save(device.SaveKeyUnder(boot.InstallHostFDEDataDir(model))); err != nil {
 		return fmt.Errorf("cannot store system save key: %v", err)
 	}
 	return nil
@@ -533,7 +533,13 @@ func (m *DeviceManager) doRestartSystemToRunMode(t *state.Task, _ *tomb.Tomb) er
 		return fmt.Errorf("missing modeenv, cannot proceed")
 	}
 
-	preseeded, err := maybeApplyPreseededData(st, boot.InitramfsUbuntuSeedDir, modeEnv.RecoverySystem, boot.InstallHostWritableDir)
+	// XXX: is there a better way
+	model, err := findModel(st)
+	if err != nil {
+		return err
+	}
+
+	preseeded, err := maybeApplyPreseededData(st, boot.InitramfsUbuntuSeedDir, modeEnv.RecoverySystem, boot.InstallHostWritableDir(model))
 	if err != nil {
 		logger.Noticef("failed to apply preseed data: %v", err)
 		return err
@@ -556,11 +562,11 @@ func (m *DeviceManager) doRestartSystemToRunMode(t *state.Task, _ *tomb.Tomb) er
 	}
 
 	// write timing information
-	if err := writeTimings(st, boot.InstallHostWritableDir, modeEnv.Mode); err != nil {
+	if err := writeTimings(st, boot.InstallHostWritableDir(model), modeEnv.Mode); err != nil {
 		logger.Noticef("cannot write timings: %v", err)
 	}
 	// store install-mode log into ubuntu-data partition
-	if err := writeLogs(boot.InstallHostWritableDir, modeEnv.Mode); err != nil {
+	if err := writeLogs(boot.InstallHostWritableDir(model), modeEnv.Mode); err != nil {
 		logger.Noticef("cannot write installation log: %v", err)
 	}
 
@@ -915,7 +921,7 @@ func (m *DeviceManager) doFactoryResetRunSystem(t *state.Task, _ *tomb.Tomb) err
 		// ubuntu-save was opened during boot, so the removal operation
 		// can be authorized with a key from the keyring
 		err = secbootRemoveRecoveryKeys(map[secboot.RecoveryKeyDevice]string{
-			{Mountpoint: boot.InitramfsUbuntuSaveDir}: device.RecoveryKeyUnder(boot.InstallHostFDEDataDir),
+			{Mountpoint: boot.InitramfsUbuntuSaveDir}: device.RecoveryKeyUnder(boot.InstallHostFDEDataDir(model)),
 		})
 		if err != nil {
 			return fmt.Errorf("cannot remove recovery key: %v", err)
@@ -938,7 +944,7 @@ func (m *DeviceManager) doFactoryResetRunSystem(t *state.Task, _ *tomb.Tomb) err
 		// keep track of the new ubuntu-save encryption key
 		installedSystem.KeyForRole[gadget.SystemSave] = saveEncryptionKey
 
-		if err := prepareEncryptedSystemData(installedSystem.KeyForRole, trustedInstallObserver); err != nil {
+		if err := prepareEncryptedSystemData(model, installedSystem.KeyForRole, trustedInstallObserver); err != nil {
 			return err
 		}
 	}
@@ -976,7 +982,7 @@ func (m *DeviceManager) doFactoryResetRunSystem(t *state.Task, _ *tomb.Tomb) err
 	}
 
 	// leave a marker that factory reset was performed
-	factoryResetMarker := filepath.Join(dirs.SnapDeviceDirUnder(boot.InstallHostWritableDir), "factory-reset")
+	factoryResetMarker := filepath.Join(dirs.SnapDeviceDirUnder(boot.InstallHostWritableDir(model)), "factory-reset")
 	if err := writeFactoryResetMarker(factoryResetMarker, useEncryption); err != nil {
 		return fmt.Errorf("cannot write the marker file: %v", err)
 	}
@@ -1064,7 +1070,7 @@ func restoreDeviceSerialFromSave(model *asserts.Model) error {
 	logger.Debugf("found a serial assertion for %v/%v, with serial %v",
 		model.BrandID(), model.Model(), serialAs.Serial())
 
-	toDB, err := sysdb.OpenAt(filepath.Join(boot.InstallHostWritableDir, "var/lib/snapd/assertions"))
+	toDB, err := sysdb.OpenAt(filepath.Join(boot.InstallHostWritableDir(model), "var/lib/snapd/assertions"))
 	if err != nil {
 		return err
 	}

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -533,11 +533,11 @@ func (m *DeviceManager) doRestartSystemToRunMode(t *state.Task, _ *tomb.Tomb) er
 		return fmt.Errorf("missing modeenv, cannot proceed")
 	}
 
-	// XXX: is there a better way
-	model, err := findModel(st)
+	deviceCtx, err := DeviceCtx(st, t, nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("cannot get device context: %v", err)
 	}
+	model := deviceCtx.Model()
 
 	preseeded, err := maybeApplyPreseededData(st, boot.InitramfsUbuntuSeedDir, modeEnv.RecoverySystem, boot.InstallHostWritableDir(model))
 	if err != nil {


### PR DESCRIPTION
The location of these directories depends on the model.

E.g. `InstallHostWritableDir` is
- on classic: `/run/mnt/ubuntu-data`
- on core: `/run/mnt/ubuntu-data/system-data`

So these dirs need to take a minimal model interface instead
of being strings.

