### PR TITLE
i/b/fwupd: add more permissions

### DIFF
--- a/interfaces/builtin/fwupd.go
+++ b/interfaces/builtin/fwupd.go
@@ -110,6 +110,9 @@ const fwupdPermanentSlotAppArmor = `
   /dev/wmi/dell-smbios rw,
   # MTD plugin
   /dev/mtd[0-9]* rw,
+  # Plugin for Logitech Whiteboard camera
+  /dev/bus/usb/[0-9][0-9][0-9]/[0-9][0-9][0-9] r,
+  /dev/video[0-9]* r,
   # Realtek MST plugin
   /dev/i2c-[0-9]* rw,
 

--- a/interfaces/builtin/fwupd.go
+++ b/interfaces/builtin/fwupd.go
@@ -278,14 +278,13 @@ const fwupdConnectedSlotAppArmor = `
 const fwupdPermanentSlotDBus = `
 <policy user="root">
     <allow own="org.freedesktop.fwupd"/>
+</policy>
+<policy context="default">
+    <deny own="org.freedesktop.fwupd"/>
     <allow send_destination="org.freedesktop.fwupd" send_interface="org.freedesktop.fwupd"/>
     <allow send_destination="org.freedesktop.fwupd" send_interface="org.freedesktop.DBus.Properties"/>
     <allow send_destination="org.freedesktop.fwupd" send_interface="org.freedesktop.DBus.Introspectable"/>
     <allow send_destination="org.freedesktop.fwupd" send_interface="org.freedesktop.DBus.Peer"/>
-</policy>
-<policy context="default">
-    <deny own="org.freedesktop.fwupd"/>
-    <deny send_destination="org.freedesktop.fwupd" send_interface="org.freedesktop.fwupd"/>
 </policy>
 `
 

--- a/interfaces/builtin/fwupd.go
+++ b/interfaces/builtin/fwupd.go
@@ -52,10 +52,19 @@ const fwupdPermanentSlotAppArmor = `
 # access to the system.
 
   # Allow read/write access for old efivars sysfs interface
+  # Also NVME_IOCTL_ADMIN_CMD (NVME plugin)
   capability sys_admin,
   # Allow libfwup to access efivarfs with immutable flag
   capability linux_immutable,
 
+  # SIOCETHTOOL (BCM57xx)
+  capability net_admin,
+
+  # SG_IO
+  # MMC_IOC_CMD, MMC_IOC_MULTI_CMD (eMMC plugin)
+  capability sys_rawio,
+
+  capability sys_nice,
   capability dac_read_search,
   capability dac_override,
   capability sys_rawio,
@@ -97,6 +106,16 @@ const fwupdPermanentSlotAppArmor = `
   /dev/nvme[0-9]* rw,
   /dev/gpiochip[0-9]* rw,
   /dev/drm_dp_aux[0-9]* rw,
+  # Dell plugin
+  /dev/wmi/dell-smbios rw,
+  # MTD plugin
+  /dev/mtd[0-9]* rw,
+  # Realtek MST plugin
+  /dev/i2c-[0-9]* rw,
+
+  # MMC boot partitions
+  /dev/mmcblk[0-9]{,[0-9],[0-9][0-9]}boot[0-9]* rwk,
+  /sys/devices/**/mmcblk[0-9]{,[0-9],[0-9][0-9]}boot[0-9]*/force_ro rw,
 
   # Allow write access for efi firmware updater
   /boot/efi/{,**/} r,

--- a/interfaces/builtin/fwupd.go
+++ b/interfaces/builtin/fwupd.go
@@ -123,12 +123,10 @@ const fwupdPermanentSlotAppArmor = `
   # Allow write access for efi firmware updater
   /boot/efi/{,**/} r,
   # allow access to fwupd* and fw/ under boot/ for core systems
-  /boot/efi/EFI/boot/fwupd*.efi* rw,
-  /boot/efi/EFI/boot/fw/** rw,
-  # allow access to fwupd* and fw/ under ubuntu/ for classic systems
-  # but it should be deprecated once old uefi-fw-tools is no longer used
-  /boot/efi/EFI/ubuntu/fwupd*.efi* rw,
-  /boot/efi/EFI/ubuntu/fw/** rw,
+  /boot/efi/EFI/*/fwupd*.efi* rw,
+  /boot/efi/EFI/*/ rw,
+  /boot/efi/EFI/*/fw/ rw,
+  /boot/efi/EFI/*/fw/** rw,
 
   # Allow access from efivar library
   /sys/devices/{pci*,platform}/**/block/**/partition r,
@@ -202,6 +200,13 @@ const fwupdPermanentSlotAppArmor = `
       interface=org.freedesktop.systemd1.Manager
       member="Job{New,Removed}"
       peer=(label=unconfined),
+
+  dbus (send)
+      bus=system
+      path=/org/freedesktop/login1
+      interface=org.freedesktop.login1.Manager
+      member={Inhibit,Reboot}
+      peer=(label=unconfined),
 `
 
 const fwupdPermanentSlotAppArmorClassic = `
@@ -264,6 +269,27 @@ const fwupdConnectedPlugAppArmor = `
       interface=org.freedesktop.DBus.Introspectable
       member=Introspect
       peer=(label=###SLOT_SECURITY_TAGS###),
+
+  dbus (send)
+      bus=system
+      path=/org/freedesktop/systemd1
+      interface=org.freedesktop.systemd1.Manager
+      member="GetDefaultTarget"
+      peer=(label=unconfined),
+
+  dbus (send)
+      bus=system
+      interface=org.freedesktop.DBus.Properties
+      path=/org/freedesktop/systemd1
+      member=Get{,All}
+      peer=(label=unconfined),
+
+  dbus (send)
+      bus=system
+      path=/org/freedesktop/systemd1
+      interface=org.freedesktop.systemd1.Manager
+      member=GetUnit
+      peer=(label=unconfined),
 `
 
 const fwupdConnectedSlotAppArmor = `

--- a/interfaces/builtin/fwupd_test.go
+++ b/interfaces/builtin/fwupd_test.go
@@ -277,3 +277,11 @@ func (s *FwupdInterfaceSuite) TestConnectedPlugSnippetSecComp(c *C) {
 func (s *FwupdInterfaceSuite) TestInterfaces(c *C) {
 	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
 }
+
+func (s *FwupdInterfaceSuite) TestStaticInfo(c *C) {
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Assert(si.ImplicitOnCore, Equals, false)
+	c.Assert(si.ImplicitOnClassic, Equals, true)
+	c.Assert(si.Summary, Equals, "allows operating as the fwupd service")
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "fwupd")
+}

--- a/interfaces/builtin/polkit.go
+++ b/interfaces/builtin/polkit.go
@@ -63,6 +63,12 @@ dbus (send)
 dbus (send)
     bus=system
     path="/org/freedesktop/PolicyKit1/Authority"
+    interface="org.freedesktop.PolicyKit1.Authority"
+    member="RegisterAuthenticationAgentWithOptions"
+    peer=(label=unconfined),
+dbus (send)
+    bus=system
+    path="/org/freedesktop/PolicyKit1/Authority"
     interface="org.freedesktop.DBus.Properties"
     peer=(name="org.freedesktop.PolicyKit1", label=unconfined),
 dbus (send)


### PR DESCRIPTION
This is what is needed to run `get-devices` fwupd on an Intel NUC.

Note for review, this has been tested with fwupd/fwupd#5062