### PR TITLE
tests: fix issues related to dbus session and localtime in uc18

### DIFF
--- a/tests/core/snap-set-core-config/task.yaml
+++ b/tests/core/snap-set-core-config/task.yaml
@@ -142,9 +142,9 @@ execute: |
     python3 -c 'import json,sys; j=json.loads(sys.stdin.read()); print(j["data"]["config"]);' < /var/lib/snapd/state.json | NOMATCH Europe/Malta
 
     echo "and setting it again in snapd also works"
-    snap set system system.timezone=Europe/Berlin
-    MATCH "Europe/Berlin" < /etc/timezone
-    test "$(readlink -f /etc/localtime)" = "/usr/share/zoneinfo/Europe/Berlin"
+    snap set system system.timezone=America/Cordoba
+    MATCH "America/Cordoba" < /etc/timezone
+    test "$(readlink -f /etc/localtime)" = "/usr/share/zoneinfo/America/Cordoba"
     
     echo "and setting the timezone outside of snapd is reflected by snap get"
     timedatectl set-timezone "America/Denver"

--- a/tests/core/snap-set-core-config/task.yaml
+++ b/tests/core/snap-set-core-config/task.yaml
@@ -142,9 +142,9 @@ execute: |
     python3 -c 'import json,sys; j=json.loads(sys.stdin.read()); print(j["data"]["config"]);' < /var/lib/snapd/state.json | NOMATCH Europe/Malta
 
     echo "and setting it again in snapd also works"
-    snap set system system.timezone=America/Cordoba
-    MATCH "America/Cordoba" < /etc/timezone
-    test "$(readlink -f /etc/localtime)" = "/usr/share/zoneinfo/America/Cordoba"
+    snap set system system.timezone=America/Lima
+    MATCH "America/Lima" < /etc/timezone
+    test "$(readlink -f /etc/localtime)" = "/usr/share/zoneinfo/America/Lima"
     
     echo "and setting the timezone outside of snapd is reflected by snap get"
     timedatectl set-timezone "America/Denver"

--- a/tests/core/system-settings/task.yaml
+++ b/tests/core/system-settings/task.yaml
@@ -16,7 +16,7 @@ execute: |
 
     echo "Check that setting the timezone works"
     timedatectl set-timezone "America/Cordoba"
-    date +"%Z" | MATCH 'CE[S]?T'
+    date +"%Z" | MATCH '-03'
     timedatectl | MATCH "Time zone: America/Cordoba"
     MATCH "America/Cordoba" < /etc/timezone
     test "$(readlink -f /etc/localtime)" = "/usr/share/zoneinfo/America/Cordoba"

--- a/tests/core/system-settings/task.yaml
+++ b/tests/core/system-settings/task.yaml
@@ -15,8 +15,8 @@ execute: |
     hostname | MATCH coole-kiste
 
     echo "Check that setting the timezone works"
-    timedatectl set-timezone "Europe/Berlin"
+    timedatectl set-timezone "America/Cordoba"
     date +"%Z" | MATCH 'CE[S]?T'
-    timedatectl | MATCH "Time zone: Europe/Berlin"
-    MATCH "Europe/Berlin" < /etc/timezone
-    test "$(readlink -f /etc/localtime)" = "/usr/share/zoneinfo/Europe/Berlin"
+    timedatectl | MATCH "Time zone: America/Cordoba"
+    MATCH "America/Cordoba" < /etc/timezone
+    test "$(readlink -f /etc/localtime)" = "/usr/share/zoneinfo/America/Cordoba"

--- a/tests/core/system-settings/task.yaml
+++ b/tests/core/system-settings/task.yaml
@@ -16,7 +16,7 @@ execute: |
 
     echo "Check that setting the timezone works"
     timedatectl set-timezone "America/Cordoba"
-    date +"%Z" | MATCH '-03'
+    date +"%Z" | MATCH '\-03'
     timedatectl | MATCH "Time zone: America/Cordoba"
     MATCH "America/Cordoba" < /etc/timezone
     test "$(readlink -f /etc/localtime)" = "/usr/share/zoneinfo/America/Cordoba"

--- a/tests/core/system-settings/task.yaml
+++ b/tests/core/system-settings/task.yaml
@@ -15,8 +15,8 @@ execute: |
     hostname | MATCH coole-kiste
 
     echo "Check that setting the timezone works"
-    timedatectl set-timezone "America/Cordoba"
-    date +"%Z" | MATCH '\-03'
-    timedatectl | MATCH "Time zone: America/Cordoba"
-    MATCH "America/Cordoba" < /etc/timezone
-    test "$(readlink -f /etc/localtime)" = "/usr/share/zoneinfo/America/Cordoba"
+    timedatectl set-timezone "America/Lima"
+    date +"%Z" | MATCH '\-05'
+    timedatectl | MATCH "Time zone: America/Lima"
+    MATCH "America/Lima" < /etc/timezone
+    test "$(readlink -f /etc/localtime)" = "/usr/share/zoneinfo/America/Lima"

--- a/tests/lib/tools/suite/tests.session-support/task.yaml
+++ b/tests/lib/tools/suite/tests.session-support/task.yaml
@@ -27,11 +27,11 @@ execute: |
             tests.session has-session-systemd-and-dbus | MATCH 'ok'
             tests.session has-session-systemd-and-dbus
             ;;
-        ubuntu-core-16-*)
+        ubuntu-core-1[68]-*)
             tests.session has-system-systemd-and-dbus | MATCH 'ok'
             tests.session has-system-systemd-and-dbus
-            # Ubuntu Core 16 did not support user sessions.
-            # Note that Ubuntu Core 18/20/22 are in the default case down below, and
+            # Ubuntu Core 16 and Ubuntu Core 18 did not support user sessions.
+            # Note that Ubuntu Core 20 is in the default case down below, and
             # does support this feature.
             tests.session has-session-systemd-and-dbus | MATCH 'no user dbus.socket'
             not tests.session has-session-systemd-and-dbus

--- a/tests/lib/tools/suite/tests.session-support/task.yaml
+++ b/tests/lib/tools/suite/tests.session-support/task.yaml
@@ -27,11 +27,11 @@ execute: |
             tests.session has-session-systemd-and-dbus | MATCH 'ok'
             tests.session has-session-systemd-and-dbus
             ;;
-        ubuntu-core-1[68]-*)
+        ubuntu-core-16-*)
             tests.session has-system-systemd-and-dbus | MATCH 'ok'
             tests.session has-system-systemd-and-dbus
-            # Ubuntu Core 16 and Ubuntu Core 18 did not support user sessions.
-            # Note that Ubuntu Core 20 is in the default case down below, and
+            # Ubuntu Core 16 did not support user sessions.
+            # Note that Ubuntu Core 18/20/22 are in the default case down below, and
             # does support this feature.
             tests.session has-session-systemd-and-dbus | MATCH 'no user dbus.socket'
             not tests.session has-session-systemd-and-dbus


### PR DESCRIPTION
This change includes 2 fixes:

The first is to update the timezone used by tests, Europe/Berlin is broken: readlink -f /etc/localtime -> /usr/share/zoneinfo/Arctic/Longyearbyen 
The other timezones are ok

The second, Ubuntu Core 18 supports user sessions now, so the tests.session-support test is updated accordingly
