### PR TITLE
many: start of mini unattended installer

### DIFF
--- a/tests/lib/muinstaller/go.mod
+++ b/tests/lib/muinstaller/go.mod
@@ -1,0 +1,6 @@
+module example.com/muinstaller
+
+go 1.18
+
+require github.com/snapcore/snapd v0.0.0-20220922070203-6aeec92d1054
+

--- a/tests/lib/muinstaller/main.go
+++ b/tests/lib/muinstaller/main.go
@@ -1,0 +1,280 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/snapcore/snapd/client"
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/gadget"
+	"github.com/snapcore/snapd/gadget/install"
+	"github.com/snapcore/snapd/gadget/quantity"
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/osutil/disks"
+	"github.com/snapcore/snapd/osutil/mkfs"
+)
+
+func firstVol(volumes map[string]*gadget.Volume) *gadget.Volume {
+	for _, vol := range volumes {
+		return vol
+	}
+	return nil
+}
+
+func createPartitions(bootDevice string, volumes map[string]*gadget.Volume) ([]gadget.OnDiskStructure, error) {
+	if len(volumes) != 1 {
+		return nil, fmt.Errorf("got unexpected number of volumes %v", len(volumes))
+	}
+
+	diskLayout, err := gadget.OnDiskVolumeFromDevice(bootDevice)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read %v partitions: %v", bootDevice, err)
+	}
+	if len(diskLayout.Structure) > 0 {
+		return nil, fmt.Errorf("cannot yet install on a disk that has partitions")
+	}
+
+	constraints := gadget.LayoutConstraints{
+		// XXX: cargo-culted
+		NonMBRStartOffset: 1 * quantity.OffsetMiB,
+		// at this point we only care about creating partitions
+		SkipResolveContent:         true,
+		SkipLayoutStructureContent: true,
+	}
+
+	// TODO: support multiple volumes, see gadget/install/install.go
+	vol := firstVol(volumes)
+	lvol, err := gadget.LayoutVolume(vol, nil, constraints)
+	if err != nil {
+		return nil, fmt.Errorf("cannot layout volume: %v", err)
+	}
+
+	opts := &install.CreateOptions{
+		AllPartitions: true,
+	}
+	created, err := install.CreateMissingPartitions(diskLayout, lvol, opts)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create parititons: %v", err)
+	}
+	logger.Noticef("created %v partitions", created)
+
+	return created, nil
+}
+
+func runMntFor(label string) string {
+	return filepath.Join(dirs.GlobalRootDir, "/run/mnt/", label)
+}
+
+// XXX: reuse/extract cmd/snap/wait.go:waitMixin()
+func waitChange(chgId string) error {
+	cli := client.New(nil)
+	for {
+		chg, err := cli.Change(chgId)
+		if err != nil {
+			return err
+		}
+
+		if chg.Err != "" {
+			return errors.New(chg.Err)
+		}
+		if chg.Ready {
+			return nil
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+func postSystemsInstallSetupStorageEncryption(details *client.SystemDetails) error {
+	// TODO: check details.StorageEncryption and call POST
+	// /systems/<seed-label> with "action":"install" and
+	// "step":"setup-storage-encryption"
+	return nil
+}
+
+// TODO laidoutStructs is used to get the devices, when encryption is
+// happening maybe we need to find the information differently.
+func postSystemsInstallFinish(cli *client.Client, details *client.SystemDetails, bootDevice string, laidoutStructs []gadget.OnDiskStructure) error {
+	// set "device" field everywhere
+	vols := make(map[string]*gadget.Volume)
+	for volName, gadgetVol := range details.Volumes {
+		laidIdx := 0
+		for i := range gadgetVol.Structure {
+			// TODO mbr is special, what is the device for that?
+			var device string
+			if gadgetVol.Structure[i].Role == "mbr" {
+				device = bootDevice
+			} else {
+				device = laidoutStructs[laidIdx].Node
+				laidIdx++
+			}
+			gadgetVol.Structure[i].Device = device
+		}
+		vols[volName] = gadgetVol
+	}
+
+	// Finish steps does the writing of assets
+	opts := &client.InstallSystemOptions{
+		Step:      client.InstallStepFinish,
+		OnVolumes: vols,
+	}
+	chgId, err := cli.InstallSystem(details.Label, opts)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Change %s created\n", chgId)
+	return waitChange(chgId)
+}
+
+// XXX: pass in created partitions instead?
+// XXX2: should we mount or will snapd mount?
+func createAndMountFilesystems(bootDevice string, volumes map[string]*gadget.Volume) error {
+	// only support a single volume for now
+	if len(volumes) != 1 {
+		return fmt.Errorf("got unexpected number of volumes %v", len(volumes))
+	}
+
+	disk, err := disks.DiskFromDeviceName(bootDevice)
+	if err != nil {
+		return err
+	}
+	vol := firstVol(volumes)
+
+	for _, stru := range vol.Structure {
+		if stru.Label == "" || stru.Filesystem == "" {
+			continue
+		}
+
+		part, err := disk.FindMatchingPartitionWithPartLabel(stru.Label)
+		if err != nil {
+			return err
+		}
+		// XXX: reuse
+		// gadget/install/content.go:mountFilesystem() instead
+		// (it will also call udevadm)
+		if err := mkfs.Make(stru.Filesystem, part.KernelDeviceNode, stru.Label, 0, 0); err != nil {
+			return err
+		}
+
+		// mount
+		mountPoint := runMntFor(stru.Label)
+		if err := os.MkdirAll(mountPoint, 0755); err != nil {
+			return err
+		}
+		// XXX: is there a better way?
+		if output, err := exec.Command("mount", part.KernelDeviceNode, mountPoint).CombinedOutput(); err != nil {
+			return osutil.OutputErr(output, err)
+		}
+	}
+	return nil
+}
+
+func createClassicRootfsIfNeeded(rootfsCreator string) error {
+	dst := runMntFor("ubuntu-data")
+	if output, err := exec.Command(rootfsCreator, dst).CombinedOutput(); err != nil {
+		return osutil.OutputErr(output, err)
+	}
+
+	return nil
+}
+
+func createSeedOnTarget(bootDevice, seedLabel string) error {
+	dataMnt := runMntFor("ubuntu-data")
+	src := dirs.SnapSeedDir
+	dst := dirs.SnapSeedDirUnder(dataMnt)
+	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+		return err
+	}
+	if output, err := exec.Command("cp", "-a", src, dst).CombinedOutput(); err != nil {
+		return osutil.OutputErr(output, err)
+	}
+
+	return nil
+}
+
+// XXX: or will POST {"action":"install","step":"finalize"} do that?
+func writeModeenvOnTarget(seedLabel string) error {
+	// TODO: write modeenv
+	return nil
+}
+
+func run(seedLabel, bootDevice, rootfsCreator string) error {
+	os.Setenv("SNAPD_DEBUG", "1")
+	logger.SimpleSetup()
+
+	logger.Noticef("installing on %q", bootDevice)
+
+	cli := client.New(nil)
+	details, err := cli.SystemDetails(seedLabel)
+	if err != nil {
+		return err
+	}
+	// TODO: grow the data-partition based on disk size
+	laidoutStructs, err := createPartitions(bootDevice, details.Volumes)
+	if err != nil {
+		return fmt.Errorf("cannot setup partitions: %v", err)
+	}
+	if err := postSystemsInstallSetupStorageEncryption(details); err != nil {
+		return fmt.Errorf("cannot setup storage encryption: %v", err)
+	}
+	if err := createAndMountFilesystems(bootDevice, details.Volumes); err != nil {
+		return fmt.Errorf("cannot create filesystems: %v", err)
+	}
+	if err := createClassicRootfsIfNeeded(rootfsCreator); err != nil {
+		return fmt.Errorf("cannot create classic rootfs: %v", err)
+	}
+	if err := createSeedOnTarget(bootDevice, seedLabel); err != nil {
+		return fmt.Errorf("cannot create seed on target: %v", err)
+	}
+	// XXX: or will POST {"action":"install","step":"finalize"} do that?
+	if err := writeModeenvOnTarget(seedLabel); err != nil {
+		return fmt.Errorf("cannot write modeenv on target: %v", err)
+	}
+	//XXX: will the POST below trigger a reboot on the snapd side? if
+	//     not we need to reboot here
+	if err := postSystemsInstallFinish(cli, details, bootDevice, laidoutStructs); err != nil {
+		return fmt.Errorf("cannot finalize install: %v", err)
+	}
+
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 4 {
+		fmt.Fprintf(os.Stderr, "need seed-label, target-device and classic-rootfs as argument\n")
+		os.Exit(1)
+	}
+
+	seedLabel := os.Args[1]
+	bootDevice := os.Args[2]
+	// TODO: allow installing real UC without a classic-rootfs later
+	rootfsCreator := os.Args[3]
+
+	if err := run(seedLabel, bootDevice, rootfsCreator); err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		os.Exit(1)
+	}
+}

--- a/tests/lib/muinstaller/main.go
+++ b/tests/lib/muinstaller/main.go
@@ -31,7 +31,6 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/gadget/install"
-	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/disks"
@@ -58,23 +57,19 @@ func createPartitions(bootDevice string, volumes map[string]*gadget.Volume) ([]g
 		return nil, fmt.Errorf("cannot yet install on a disk that has partitions")
 	}
 
-	constraints := gadget.LayoutConstraints{
-		// XXX: cargo-culted
-		NonMBRStartOffset: 1 * quantity.OffsetMiB,
-		// at this point we only care about creating partitions
-		SkipResolveContent:         true,
-		SkipLayoutStructureContent: true,
+	layoutOpts := &gadget.LayoutOptions{
+		IgnoreContent: true,
 	}
 
 	// TODO: support multiple volumes, see gadget/install/install.go
 	vol := firstVol(volumes)
-	lvol, err := gadget.LayoutVolume(vol, nil, constraints)
+	lvol, err := gadget.LayoutVolume(vol, gadget.DefaultConstraints, layoutOpts)
 	if err != nil {
 		return nil, fmt.Errorf("cannot layout volume: %v", err)
 	}
 
 	opts := &install.CreateOptions{
-		AllPartitions: true,
+		CreateAllMissingPartitions: true,
 	}
 	created, err := install.CreateMissingPartitions(diskLayout, lvol, opts)
 	if err != nil {

--- a/tests/lib/muinstaller/mk-classic-rootfs.sh
+++ b/tests/lib/muinstaller/mk-classic-rootfs.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+set -e
+
+# uncomment for better debug messages
+#set -x
+#exec > /tmp/mk-classic-rootfs.sh.log
+#exec 2>&1
+
+
+# XXX: merge with the work from alfonso in
+# tests/nested/manual/fde-on-classic/mk-image.sh (PR:12102)
+create_classic_rootfs() {
+    set -x
+    local DESTDIR="$1"
+    local BASETAR="$2"
+
+    # Copy base filesystem
+    sudo tar -C "$DESTDIR" -xf "$BASETAR"
+
+    # Create basic devices to be able to install packages
+    [ -e "$DESTDIR"/dev/null ] || sudo mknod -m 666 "$DESTDIR"/dev/null c 1 3
+    [ -e "$DESTDIR"/dev/zero ] || sudo mknod -m 666 "$DESTDIR"/dev/zero c 1 5
+    [ -e "$DESTDIR"/dev/random ] || sudo mknod -m 666 "$DESTDIR"/dev/random c 1 8
+    [ -e "$DESTDIR"/dev/urandom ] || sudo mknod -m 666 "$DESTDIR"/dev/urandom c 1 9
+    # ensure resolving works inside the chroot
+    echo "nameserver 8.8.8.8" | sudo tee -a "$DESTDIR"/etc/resolv.conf
+    # install additional packages
+    sudo chroot "$DESTDIR" /usr/bin/sh -c "DEBIAN_FRONTEND=noninteractive apt update"
+    local pkgs="snapd ssh openssh-server sudo iproute2 iputils-ping isc-dhcp-client netplan.io vim-tiny kmod cloud-init"
+    sudo chroot "$DESTDIR" /usr/bin/sh -c \
+         "DEBIAN_FRONTEND=noninteractive apt install --no-install-recommends -y $pkgs"
+    # netplan config
+    cat <<'EOF' | sudo tee "$DESTDIR"/etc/netplan/00-ethernet.yaml
+network:
+  ethernets:
+    any:
+      match:
+        name: e*
+      dhcp4: true
+  version: 2
+EOF
+
+    # ensure we can login
+    sudo chroot "$DESTDIR" /usr/sbin/adduser --disabled-password --gecos "" user1
+    printf "ubuntu\nubuntu\n" | sudo chroot "$DESTDIR" /usr/bin/passwd user1
+    echo "user1 ALL=(ALL) NOPASSWD:ALL" | sudo tee -a "$DESTDIR"/etc/sudoers
+
+    # set password for root user
+    sudo chroot "$DESTDIR" /usr/bin/sh -c 'echo root:root | chpasswd'
+    sudo tee -a "$DESTDIR/etc/ssh/sshd_config" <<'EOF'
+PermitRootLogin yes
+PasswordAuthentication yes
+EOF
+
+    # install the current in-development version of snapd when available,
+    # this will give us seeding support
+    GOPATH="${GOPATH:-./}"
+    package=$(find "$GOPATH" -maxdepth 1 -name "snapd_*.deb")
+    if [ -e "$package"  ]; then
+        cp "$package" "$DESTDIR"/var/cache/apt/archives
+        sudo chroot "$DESTDIR" /usr/bin/sh -c \
+             "DEBIAN_FRONTEND=noninteractive apt install -y /var/cache/apt/archives/$(basename "$package")"
+    fi
+}
+
+# get target dir from user
+DST="$1"
+if [ ! -d "$DST" ]; then
+    echo "target dir $DST is not a directory"
+    exit 1
+fi
+
+# get the base
+wget -c http://cdimage.ubuntu.com/ubuntu-base/releases/22.04/release/ubuntu-base-22.04-base-amd64.tar.gz
+
+# create minitmal rootfs
+create_classic_rootfs "$DST" "ubuntu-base-22.04-base-amd64.tar.gz"

--- a/tests/lib/muinstaller/snapcraft.yaml
+++ b/tests/lib/muinstaller/snapcraft.yaml
@@ -1,0 +1,21 @@
+name: muinstaller
+version: "0.1"
+summary: Minimal Unattended Installer
+description: |
+  Minimal Unattended Installer (muinstaller) is a minimal installer
+  for Ubuntu Core
+confinement: classic
+base: core22
+
+apps:
+  muinstaller:
+    # XXX: make this a daemon
+    command: bin/muinstaller
+
+# TODO: add spread test that builds the muinstaller from snapd to ensure
+#       we don't accidentally break it
+parts:
+  muinstaller:
+    plugin: go
+    source: .
+    build-snaps: [go/1.13/stable]

--- a/tests/nested/manual/muinstaller/task.yaml
+++ b/tests/nested/manual/muinstaller/task.yaml
@@ -1,0 +1,119 @@
+summary: Check that the installer API works
+
+# this is a UC20+ specific test
+systems: [ubuntu-20.04-64, ubuntu-22.04-64]
+
+environment:
+    # nested test so that we can test encryted installs eventually
+    # TODO enable tpm variant too for testing of encryption installs
+    NESTED_ENABLE_TPM: false
+    NESTED_ENABLE_SECURE_BOOT: false
+    NESTED_BUILD_SNAPD_FROM_CURRENT: true
+    NESTED_ENABLE_OVMF: true
+    STORE_ADDR: localhost:11028
+    STORE_DIR: $(pwd)/fake-store-blobdir
+
+prepare: |
+  if [ "$TRUST_TEST_KEYS" = "false" ]; then
+      echo "This test needs test keys to be trusted"
+      exit
+  fi
+  echo "Install used snaps"
+  snap install test-snapd-curl --devmode --edge
+  snap install jq --devmode --edge
+  if [ -d /var/lib/snapd/seed ]; then
+      mv /var/lib/snapd/seed /var/lib/snapd/seed.orig
+  fi
+  #shellcheck source=tests/lib/store.sh
+  . "$TESTSLIB"/store.sh
+  setup_fake_store "$STORE_DIR"
+
+restore: |
+  if [ "$TRUST_TEST_KEYS" = "false" ]; then
+      echo "This test needs test keys to be trusted"
+      exit
+  fi
+  if [ -d /var/lib/snapd/seed.orig ]; then
+      rm -rf /var/lib/snapd/seed
+      mv /var/lib/snapd/seed.orig /var/lib/snapd/seed
+  fi
+  #shellcheck source=tests/lib/store.sh
+  . "$TESTSLIB"/store.sh
+  teardown_fake_store "$STORE_DIR"
+  rm -rf ./classic-root
+
+execute: |
+  if [ "$TRUST_TEST_KEYS" = "false" ]; then
+      echo "This test needs test keys to be trusted"
+      exit
+  fi
+
+  # XXX: the code in DeviceManager.SystemAndGadgetInfo() will only work on
+  # classic systems with modeenv right now (which is something we may need
+  # to fix to work from the classic installer).
+  # For now pretend we have a modeenv
+  echo "mode=run" > /var/lib/snapd/modeenv
+  tests.cleanup defer rm -f /var/lib/snapd/modeenv
+  # need snapd restart as GET /systems/<label> is only available on systems
+  # with a modeenv
+  systemctl restart snapd
+
+  echo Expose the needed assertions through the fakestore
+  cp "$TESTSLIB"/assertions/developer1.account "$STORE_DIR/asserts"
+  cp "$TESTSLIB"/assertions/developer1.account-key "$STORE_DIR/asserts"
+  cp "$TESTSLIB"/assertions/testrootorg-store.account-key "$STORE_DIR/asserts" 
+  export SNAPPY_FORCE_SAS_URL=http://$STORE_ADDR
+  # prepare a classic seed
+  # TODO:
+  # - create pc-classic custom gadget (once PR#12174 is merged)
+  # - kernel with updated initrd
+  # - repacked snapd snap
+  # (should be as simple as addinga "--snap=./local-gadget.snap ...")
+  LABEL="$(date +%Y%m%d)"
+  gendeveloper1 sign-model < "$TESTSLIB"/assertions/developer1-22-classic-dangerous.json > my.model
+  snap prepare-image --classic --channel=edge my.model ./classic-seed
+  cp -a ./classic-seed/system-seed/ /var/lib/snapd/seed
+
+  # do some light checking that the system is valid
+  test-snapd-curl.curl -s --unix-socket /run/snapd.socket http://localhost/v2/systems | jq '.result.systems[0].label' | MATCH "$LABEL"
+  test-snapd-curl.curl -s --unix-socket /run/snapd.socket http://localhost/v2/systems/"$LABEL" > system
+  jq '.result.model.distribution' system | MATCH "ubuntu"
+
+  # build muinstaller and put in place
+  go build -o muinstaller "$TESTSLIB"/muinstaller/main.go
+
+  # create boot disk for the installer to work on
+  truncate --size=4G boot.img
+  loop_device=$(losetup --show -f ./boot.img)
+  # TODO: this works around the fact that a "loop" device has no
+  #       ID_PART_TABLE_TYPE udev attribute that our code in
+  #       osutil/disks/disks_linux.go expected in diskFromUDevProps()
+  #       over a completely empty disk
+  echo "label: gpt" | sfdisk "$loop_device"
+  # and "install" the current seed to the boot disk
+  # NOTE that this currently is expected to fail because the "finish" step
+  #      in snapd is not done yet
+  not ./muinstaller "$LABEL" "$loop_device" "$TESTSLIB"/muinstaller/mk-classic-rootfs.sh 2> stderr
+  MATCH "finish install step not implemented" < stderr
+
+  # validate that the muinstaller created the expected partitions
+  fdisk -x "$loop_device" > fdisk_output
+  MATCH "${loop_device}p1 .* BIOS Boot"   < fdisk_output
+  # TODO: the real MVP classic+modes device will not contain a ubuntu-seed
+  #       partition (needs the gadget from #12174)
+  MATCH "${loop_device}p2 .* ubuntu-seed" < fdisk_output
+  MATCH "${loop_device}p3 .* ubuntu-boot" < fdisk_output
+  MATCH "${loop_device}p4 .* ubuntu-save" < fdisk_output
+  MATCH "${loop_device}p5 .* ubuntu-data" < fdisk_output
+
+  # seed is populated
+  test -d /run/mnt/ubuntu-data/var/lib/snapd/seed/systems/"$LABEL"
+  MATCH "classic: true" < /run/mnt/ubuntu-data/var/lib/snapd/seed/systems/"$LABEL"/model
+  # rootfs is there
+  test -x /run/mnt/ubuntu-data/usr/lib/systemd/systemd
+  # ensure not "ubuntu-data/system-data" is generated, this is a dir only
+  # used on core and should not be there on classic
+  not test -d /run/mnt/ubuntu-data/system-data
+
+  # TODO: eventually this is a bootable image, boot into it here and
+  # do light checking


### PR DESCRIPTION
In order to test the installation of Ubuntu Core this commit adds a new Minimal Unattended Installer (muinstaller) that can be used to test the installer API. The initial focus is to test the classic+modes install but it will be able to install core later too.

This also includes a refactor for some gadget code to make it more consumable from the muinstaller.
