### PR TITLE
interfaces: add read access to /proc/cgroups and /proc/sys/vm/swappiness to system-observe

### DIFF
--- a/interfaces/builtin/system_observe.go
+++ b/interfaces/builtin/system_observe.go
@@ -62,6 +62,7 @@ const systemObserveConnectedPlugAppArmor = `
 ptrace (read),
 
 # Other miscellaneous accesses for observing the system
+@{PROC}/cgroups r,
 @{PROC}/locks r,
 @{PROC}/modules r,
 @{PROC}/stat r,
@@ -78,6 +79,7 @@ ptrace (read),
 @{PROC}/sys/kernel/sched_autogroup_enabled r,
 @{PROC}/sys/vm/max_map_count r,
 @{PROC}/sys/vm/panic_on_oom r,
+@{PROC}/sys/vm/swappiness r,
 
 # These are not process-specific (/proc/*/... and /proc/*/task/*/...)
 @{PROC}/*/{,task/,task/*/} r,


### PR DESCRIPTION
This PR is based on the conversation [here](https://forum.snapcraft.io/t/auto-connect-request-for-opensearch-snap/31746/6) 

It adds read access to `/proc/cgroups` and `/proc/sys/vm/swappiness` to the `system_observe` interface 