### PR TITLE
release, snapd-apparmor, syscheck: distinguish WSL1 and WSL2

### DIFF
--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -384,8 +384,8 @@ func mkClient() *client.Client {
 
 	cli := client.New(cfg)
 	goos := runtime.GOOS
-	if release.OnWSL {
-		goos = "Windows Subsystem for Linux"
+	if release.WSLVersion == 1 {
+		goos = "Windows Subsystem for Linux 1"
 	}
 	if goos != "linux" {
 		cli.Hijack(func(*http.Request) (*http.Response, error) {

--- a/cmd/snapd-apparmor/main.go
+++ b/cmd/snapd-apparmor/main.go
@@ -69,7 +69,7 @@ import (
 // unsupported configuration that cannot be properly handled by this function.
 //
 func isContainerWithInternalPolicy() bool {
-	if release.OnWSL {
+	if release.OnWSL && release.WSLVersion == 1 {
 		return true
 	}
 

--- a/cmd/snapd-apparmor/main.go
+++ b/cmd/snapd-apparmor/main.go
@@ -69,7 +69,7 @@ import (
 // unsupported configuration that cannot be properly handled by this function.
 //
 func isContainerWithInternalPolicy() bool {
-	if release.OnWSL && release.WSLVersion == 1 {
+	if release.OnWSL {
 		return true
 	}
 

--- a/cmd/snapd-apparmor/main_test.go
+++ b/cmd/snapd-apparmor/main_test.go
@@ -53,10 +53,21 @@ func (s *mainSuite) TearDownTest(c *C) {
 	dirs.SetRootDir("/")
 }
 
-func mockWSL(onWSL bool) (restorer func()) {
-	restorer = testutil.Backup(&release.OnWSL)
-	release.OnWSL = onWSL
-	return
+// Mocks WSL check. Values:
+// - 0 to mock not being on WSL.
+// - 1 to mock being on WSL 1.
+// - 2 to mock being on WSL 2.
+func mockWSL(version int) (restore func()) {
+	restoreOnWSL := testutil.Backup(&release.OnWSL)
+	restoreWSLVersion := testutil.Backup(&release.WSLVersion)
+
+	release.OnWSL = version != 0
+	release.WSLVersion = version
+
+	return func() {
+		restoreOnWSL()
+		restoreWSLVersion()
+	}
 }
 
 func (s *mainSuite) TestIsContainerWithInternalPolicy(c *C) {
@@ -71,8 +82,12 @@ func (s *mainSuite) TestIsContainerWithInternalPolicy(c *C) {
 	c.Assert(snapd_apparmor.IsContainerWithInternalPolicy(), Equals, false)
 
 	// simulate being inside WSL
-	restore := mockWSL(true)
+	restore := mockWSL(1)
 	c.Assert(snapd_apparmor.IsContainerWithInternalPolicy(), Equals, true)
+	restore()
+
+	restore = mockWSL(2)
+	c.Assert(snapd_apparmor.IsContainerWithInternalPolicy(), Equals, false)
 	restore()
 
 	// simulate being inside a container environment
@@ -164,7 +179,7 @@ func (s *mainSuite) TestIsContainer(c *C) {
 	// systemd-detect-virt may return a non-zero exit code as it fails to recognize it as WSL
 	// This will happen when the kernel name includes neither "WSL" not "Microsoft"
 	detectCmd = testutil.MockCommand(c, "systemd-detect-virt", "echo none; exit 1")
-	defer mockWSL(true)()
+	defer mockWSL(2)()
 	c.Check(snapd_apparmor.IsContainer(), Equals, true)
 	c.Assert(detectCmd.Calls(), DeepEquals, [][]string(nil))
 }
@@ -237,7 +252,7 @@ func (s *integrationSuite) TestRunInContainerSkipsLoading(c *C) {
 }
 
 func (s *integrationSuite) TestRunInContainerWithInternalPolicyLoadsProfiles(c *C) {
-	defer mockWSL(true)()
+	defer mockWSL(1)()
 	err := snapd_apparmor.Run()
 	c.Assert(err, IsNil)
 	c.Check(s.logBuf.String(), testutil.Contains, "DEBUG: inside container environment")

--- a/cmd/snapd-apparmor/main_test.go
+++ b/cmd/snapd-apparmor/main_test.go
@@ -87,7 +87,7 @@ func (s *mainSuite) TestIsContainerWithInternalPolicy(c *C) {
 	restore()
 
 	restore = mockWSL(2)
-	c.Assert(snapd_apparmor.IsContainerWithInternalPolicy(), Equals, false)
+	c.Assert(snapd_apparmor.IsContainerWithInternalPolicy(), Equals, true)
 	restore()
 
 	// simulate being inside a container environment

--- a/release/export_test.go
+++ b/release/export_test.go
@@ -53,5 +53,6 @@ func MockFilesystemRootType(filesystemID int64) (restorer func()) {
 }
 
 var (
-	GetWSLVersion = getWSLVersion
+	GetWSLVersion      = getWSLVersion
+	FilesystemRootType = filesystemRootType
 )

--- a/release/export_test.go
+++ b/release/export_test.go
@@ -43,14 +43,6 @@ func MockFileExists(mockFileExists func(string) bool) (restorer func()) {
 	}
 }
 
-func MockIoutilReadfile(newReadfile func(string) ([]byte, error)) (restorer func()) {
-	old := ioutilReadFile
-	ioutilReadFile = newReadfile
-	return func() {
-		ioutilReadFile = old
-	}
-}
-
 var (
 	GetWSLVersion = getWSLVersion
 )

--- a/release/export_test.go
+++ b/release/export_test.go
@@ -43,6 +43,15 @@ func MockFileExists(mockFileExists func(string) bool) (restorer func()) {
 	}
 }
 
+func MockIoutilReadfile(newReadfile func(string) ([]byte, error)) (restorer func()) {
+	old := ioutilReadFile
+	ioutilReadFile = newReadfile
+	return func() {
+		ioutilReadFile = old
+	}
+}
+
 var (
-	IsWSL = isWSL
+	IsWSL         = isWSL
+	GetWSLVersion = getWSLVersion
 )

--- a/release/export_test.go
+++ b/release/export_test.go
@@ -52,6 +52,5 @@ func MockIoutilReadfile(newReadfile func(string) ([]byte, error)) (restorer func
 }
 
 var (
-	IsWSL         = isWSL
 	GetWSLVersion = getWSLVersion
 )

--- a/release/export_test.go
+++ b/release/export_test.go
@@ -43,6 +43,15 @@ func MockFileExists(mockFileExists func(string) bool) (restorer func()) {
 	}
 }
 
+func MockFilesystemRootType(filesystemID int64) (restorer func()) {
+	// Cannot use testutil.Backup due to import loop
+	old := filesystemRootType
+	filesystemRootType = func() (int64, error) { return filesystemID, nil }
+	return func() {
+		filesystemRootType = old
+	}
+}
+
 var (
 	GetWSLVersion = getWSLVersion
 )

--- a/release/release_test.go
+++ b/release/release_test.go
@@ -159,10 +159,8 @@ func (s *ReleaseTestSuite) TestNonWSL(c *C) {
 		return []byte("Linux version 2.2.19 (herbert@gondolin) (gcc version 2.7.2.3) #1 Wed Mar 20 19:41:41 EST 2002"), nil
 	})()
 
-	c.Check(release.IsWSL(), Equals, false)
-	v, err := release.GetWSLVersion()
+	v := release.GetWSLVersion()
 	c.Check(v, Equals, 0)
-	c.Check(err, ErrorMatches, "cannot get WSL version while not running WSL.")
 }
 
 func (s *ReleaseTestSuite) TestWSL1(c *C) {
@@ -176,11 +174,8 @@ func (s *ReleaseTestSuite) TestWSL1(c *C) {
 		return []byte("Linux version 4.4.0-22000-Microsoft (Microsoft@Microsoft.com) (gcc version 5.4.0 (GCC) ) #653-Microsoft Wed Apr 27 16:06:00 PST 2022"), nil
 	})()
 
-	v, err := release.GetWSLVersion()
-
-	c.Check(release.IsWSL(), Equals, true)
+	v := release.GetWSLVersion()
 	c.Check(v, Equals, 1)
-	c.Check(err, IsNil)
 }
 
 func (s *ReleaseTestSuite) TestWSL2(c *C) {
@@ -194,11 +189,8 @@ func (s *ReleaseTestSuite) TestWSL2(c *C) {
 		return []byte("Linux version 5.15.57.1-microsoft-standard-WSL2 (oe-user@oe-host) (x86_64-msft-linux-gcc (GCC) 9.3.0, GNU ld (GNU Binutils) 2.34.0.20200220) #1 SMP Wed Jul 27 02:20:31 UTC 2022"), nil
 	})()
 
-	v, err := release.GetWSLVersion()
-
-	c.Check(release.IsWSL(), Equals, true)
+	v := release.GetWSLVersion()
 	c.Check(v, Equals, 2)
-	c.Check(err, IsNil)
 }
 
 func (s *ReleaseTestSuite) TestWSL2Custom(c *C) {
@@ -212,11 +204,8 @@ func (s *ReleaseTestSuite) TestWSL2Custom(c *C) {
 		return []byte("Linux version 3.14.15.92-look-mum-i-compiled-the-linux-kernel"), nil
 	})()
 
-	v, err := release.GetWSLVersion()
-
-	c.Check(release.IsWSL(), Equals, true)
+	v := release.GetWSLVersion()
 	c.Check(v, Equals, 2)
-	c.Check(err, IsNil)
 }
 
 func (s *ReleaseTestSuite) TestSystemctlSupportsUserUnits(c *C) {

--- a/release/release_test.go
+++ b/release/release_test.go
@@ -21,7 +21,10 @@ package release_test
 
 import (
 	"io/ioutil"
+	"os/exec"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 
 	. "gopkg.in/check.v1"
@@ -171,6 +174,22 @@ func (s *ReleaseTestSuite) TestReleaseInfo(c *C) {
 	})
 	defer reset()
 	c.Assert(release.ReleaseInfo.ID, Equals, "distro-id")
+}
+
+func (s *ReleaseTestSuite) TestFilesystemRootType(c *C) {
+	reported_type, err := release.FilesystemRootType()
+	c.Check(err, IsNil)
+
+	// From man stat:
+	// %t   major device type in hex, for character/block device special files
+	output, err := exec.Command("stat", "-f", "-c", "%t", "/").CombinedOutput()
+	c.Check(err, IsNil)
+
+	outstr := strings.TrimSpace(string(output[:]))
+	statted_type, err := strconv.ParseInt(outstr, 16, 64)
+	c.Check(err, IsNil)
+
+	c.Check(reported_type, Equals, statted_type)
 }
 
 func (s *ReleaseTestSuite) TestNonWSL(c *C) {

--- a/release/release_test.go
+++ b/release/release_test.go
@@ -178,16 +178,16 @@ func (s *ReleaseTestSuite) TestReleaseInfo(c *C) {
 
 func (s *ReleaseTestSuite) TestFilesystemRootType(c *C) {
 	reported_type, err := release.FilesystemRootType()
-	c.Check(err, IsNil)
+	c.Assert(err, IsNil)
 
 	// From man stat:
 	// %t   major device type in hex, for character/block device special files
 	output, err := exec.Command("stat", "-f", "-c", "%t", "/").CombinedOutput()
-	c.Check(err, IsNil)
+	c.Assert(err, IsNil)
 
 	outstr := strings.TrimSpace(string(output[:]))
 	statted_type, err := strconv.ParseInt(outstr, 16, 64)
-	c.Check(err, IsNil)
+	c.Assert(err, IsNil)
 
 	c.Check(reported_type, Equals, statted_type)
 }

--- a/syscheck/wsl.go
+++ b/syscheck/wsl.go
@@ -30,8 +30,8 @@ func init() {
 }
 
 func checkWSL() error {
-	if release.OnWSL {
-		return errors.New("snapd does not work inside WSL")
+	if release.WSLVersion == 1 {
+		return errors.New("snapd does not work inside WSL1")
 	}
 
 	return nil


### PR DESCRIPTION
## Context
On Sept 21st, Microsoft anounced systemd support for WSL 2 ([see anouncement](https://devblogs.microsoft.com/commandline/systemd-support-is-now-available-in-wsl/)), and Ubuntu-Preview already ships with systemd enabled by default.

## Changes
Snap now works on WSL 2. Hence some of the current system checks in snapd have to be updated in response.

## Bugfixes
This PR fixes:
- [#1991823](https://bugs.launchpad.net/snapd/+bug/1991823) WSL detection is now incorrect / inappropriate
- [#1991826](https://bugs.launchpad.net/snapd/+bug/1991826) snapd is intentionally broken under WSL and shouldn't be

