### PR TITLE
gadget: refactor to allow usage from the installer

### DIFF
--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -1217,15 +1217,15 @@ func LaidOutVolumesFromGadget(gadgetRoot, kernelRoot string, model Model) (syste
 	constraints := LayoutConstraints{
 		NonMBRStartOffset: 1 * quantity.OffsetMiB,
 	}
+	// layout all volumes saving them
+	opts := &LayoutOptions{
+		GadgetRootDir: gadgetRoot,
+		KernelRootDir: kernelRoot,
+	}
 
 	// find the volume with the system-boot role on it, we already validated
 	// that the system-* roles are all on the same volume
 	for name, vol := range info.Volumes {
-		// layout all volumes saving them
-		opts := &LayoutOptions{
-			GadgetRootDir: gadgetRoot,
-			KernelRootDir: kernelRoot,
-		}
 		lvol, err := LayoutVolume(vol, constraints, opts)
 		if err != nil {
 			return nil, nil, err

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -1222,7 +1222,11 @@ func LaidOutVolumesFromGadget(gadgetRoot, kernelRoot string, model Model) (syste
 	// that the system-* roles are all on the same volume
 	for name, vol := range info.Volumes {
 		// layout all volumes saving them
-		lvol, err := LayoutVolume(gadgetRoot, kernelRoot, vol, constraints)
+		opts := &LayoutOptions{
+			GadgetRootDir: gadgetRoot,
+			KernelRootDir: kernelRoot,
+		}
+		lvol, err := LayoutVolume(vol, opts, constraints)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -1226,7 +1226,7 @@ func LaidOutVolumesFromGadget(gadgetRoot, kernelRoot string, model Model) (syste
 			GadgetRootDir: gadgetRoot,
 			KernelRootDir: kernelRoot,
 		}
-		lvol, err := LayoutVolume(vol, opts, constraints)
+		lvol, err := LayoutVolume(vol, constraints, opts)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/gadget/gadgettest/gadgettest.go
+++ b/gadget/gadgettest/gadgettest.go
@@ -93,8 +93,12 @@ func MustLayOutSingleVolumeFromGadget(gadgetRoot, kernelRoot string, model gadge
 	}
 
 	for _, vol := range info.Volumes {
+		opts := &gadget.LayoutOptions{
+			GadgetRootDir: gadgetRoot,
+			KernelRootDir: kernelRoot,
+		}
 		// we know info.Volumes map has size 1 so we can return here
-		return gadget.LayoutVolume(gadgetRoot, kernelRoot, vol, constraints)
+		return gadget.LayoutVolume(vol, opts, constraints)
 	}
 
 	// this is impossible to reach, we already checked that info.Volumes has a

--- a/gadget/gadgettest/gadgettest.go
+++ b/gadget/gadgettest/gadgettest.go
@@ -98,7 +98,7 @@ func MustLayOutSingleVolumeFromGadget(gadgetRoot, kernelRoot string, model gadge
 			KernelRootDir: kernelRoot,
 		}
 		// we know info.Volumes map has size 1 so we can return here
-		return gadget.LayoutVolume(vol, opts, constraints)
+		return gadget.LayoutVolume(vol, constraints, opts)
 	}
 
 	// this is impossible to reach, we already checked that info.Volumes has a

--- a/gadget/gadgettest/gadgettest.go
+++ b/gadget/gadgettest/gadgettest.go
@@ -91,12 +91,11 @@ func MustLayOutSingleVolumeFromGadget(gadgetRoot, kernelRoot string, model gadge
 	constraints := gadget.LayoutConstraints{
 		NonMBRStartOffset: 1 * quantity.OffsetMiB,
 	}
-
+	opts := &gadget.LayoutOptions{
+		GadgetRootDir: gadgetRoot,
+		KernelRootDir: kernelRoot,
+	}
 	for _, vol := range info.Volumes {
-		opts := &gadget.LayoutOptions{
-			GadgetRootDir: gadgetRoot,
-			KernelRootDir: kernelRoot,
-		}
 		// we know info.Volumes map has size 1 so we can return here
 		return gadget.LayoutVolume(vol, constraints, opts)
 	}

--- a/gadget/install/export_test.go
+++ b/gadget/install/export_test.go
@@ -33,7 +33,6 @@ var (
 	WriteFilesystemContent = writeFilesystemContent
 	MountFilesystem        = mountFilesystem
 
-	CreateMissingPartitions = createMissingPartitions
 	BuildPartitionList      = buildPartitionList
 	RemoveCreatedPartitions = removeCreatedPartitions
 	EnsureNodesExist        = ensureNodesExist

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -233,7 +233,10 @@ func Run(model gadget.Model, gadgetRoot, kernelRoot, bootDevice string, options 
 
 	var created []gadget.OnDiskStructure
 	timings.Run(perfTimings, "create-partitions", "Create partitions", func(timings.Measurer) {
-		created, err = createMissingPartitions(gadgetRoot, diskLayout, laidOutBootVol)
+		opts := &CreateOptions{
+			GadgetRootDir: gadgetRoot,
+		}
+		created, err = CreateMissingPartitions(diskLayout, laidOutBootVol, opts)
 	})
 	if err != nil {
 		return nil, fmt.Errorf("cannot create the partitions: %v", err)

--- a/gadget/install/partition.go
+++ b/gadget/install/partition.go
@@ -60,7 +60,9 @@ type CreateOptions struct {
 	// The gadget root dir
 	GadgetRootDir string
 
-	// Allow creating all partitions not just role-* ones
+	// Create all missing partitions. If unset only
+	// role-{data,boot,save} partitions will get created and it's
+	// an error other partition is missing.
 	AllPartitions bool
 }
 

--- a/gadget/install/partition.go
+++ b/gadget/install/partition.go
@@ -63,7 +63,7 @@ type CreateOptions struct {
 	// Create all missing partitions. If unset only
 	// role-{data,boot,save} partitions will get created and it's
 	// an error other partition is missing.
-	AllPartitions bool
+	CreateAllMissingPartitions bool
 }
 
 // createMissingPartitions creates the partitions listed in the laid out volume
@@ -164,7 +164,7 @@ func buildPartitionList(dl *gadget.OnDiskVolume, pv *gadget.LaidOutVolume, opts 
 		}
 
 		// Only allow creating certain partitions, namely the ubuntu-* roles
-		if !opts.AllPartitions && !gadget.IsCreatableAtInstall(p.VolumeStructure) {
+		if !opts.CreateAllMissingPartitions && !gadget.IsCreatableAtInstall(p.VolumeStructure) {
 			return nil, nil, fmt.Errorf("cannot create partition %s", p)
 		}
 

--- a/gadget/install/partition.go
+++ b/gadget/install/partition.go
@@ -62,11 +62,11 @@ type CreateOptions struct {
 
 	// Create all missing partitions. If unset only
 	// role-{data,boot,save} partitions will get created and it's
-	// an error other partition is missing.
+	// an error if other partition are missing.
 	CreateAllMissingPartitions bool
 }
 
-// createMissingPartitions creates the partitions listed in the laid out volume
+// CreateMissingPartitions creates the partitions listed in the laid out volume
 // pv that are missing from the existing device layout, returning a list of
 // structures that have been created.
 func CreateMissingPartitions(dl *gadget.OnDiskVolume, pv *gadget.LaidOutVolume, opts *CreateOptions) ([]gadget.OnDiskStructure, error) {

--- a/gadget/install/partition_test.go
+++ b/gadget/install/partition_test.go
@@ -357,8 +357,8 @@ func (s *partitionTestSuite) TestCreatePartitionsNonRolePartitions(c *C) {
 	dl, err := gadget.OnDiskVolumeFromDevice("/dev/node")
 	c.Assert(err, IsNil)
 	opts := &install.CreateOptions{
-		GadgetRootDir: s.gadgetRoot,
-		AllPartitions: true,
+		GadgetRootDir:              s.gadgetRoot,
+		CreateAllMissingPartitions: true,
 	}
 	created, err := install.CreateMissingPartitions(dl, pv, opts)
 	c.Assert(err, IsNil)

--- a/gadget/install/partition_test.go
+++ b/gadget/install/partition_test.go
@@ -230,7 +230,7 @@ func (s *partitionTestSuite) TestBuildPartitionList(c *C) {
 
 	// the expected expanded writable partition size is:
 	// start offset = (2M + 1200M), expanded size in sectors = (8388575*512 - start offset)/512
-	sfdiskInput, create, err := install.BuildPartitionList(dl, pv)
+	sfdiskInput, create, err := install.BuildPartitionList(dl, pv, nil)
 	c.Assert(err, IsNil)
 	c.Assert(sfdiskInput.String(), Equals,
 		`/dev/node3 : start=     2461696, size=      262144, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4, name="Save"
@@ -262,7 +262,7 @@ func (s *partitionTestSuite) TestBuildPartitionListOnlyCreatablePartitions(c *C)
 	dl, err := gadget.OnDiskVolumeFromDevice("/dev/node")
 	c.Assert(err, IsNil)
 
-	_, _, err = install.BuildPartitionList(dl, pv)
+	_, _, err = install.BuildPartitionList(dl, pv, nil)
 	c.Assert(err, ErrorMatches, `cannot create partition #1 \(\"BIOS Boot\"\)`)
 }
 
@@ -296,7 +296,10 @@ func (s *partitionTestSuite) TestCreatePartitions(c *C) {
 
 	dl, err := gadget.OnDiskVolumeFromDevice("/dev/node")
 	c.Assert(err, IsNil)
-	created, err := install.CreateMissingPartitions(s.gadgetRoot, dl, pv)
+	opts := &install.CreateOptions{
+		GadgetRootDir: s.gadgetRoot,
+	}
+	created, err := install.CreateMissingPartitions(dl, pv, opts)
 	c.Assert(err, IsNil)
 	c.Assert(created, DeepEquals, []gadget.OnDiskStructure{mockOnDiskStructureWritable})
 	c.Assert(calls, Equals, 1)

--- a/gadget/layout.go
+++ b/gadget/layout.go
@@ -218,7 +218,7 @@ func LayoutVolumePartially(volume *Volume, constraints LayoutConstraints) (*Part
 
 // LayoutVolume attempts to completely lay out the volume, that is the
 // structures and their content, using provided constraints
-func LayoutVolume(volume *Volume, opts *LayoutOptions, constraints LayoutConstraints) (*LaidOutVolume, error) {
+func LayoutVolume(volume *Volume, constraints LayoutConstraints, opts *LayoutOptions) (*LaidOutVolume, error) {
 	var err error
 	if opts == nil {
 		opts = &LayoutOptions{}

--- a/gadget/layout.go
+++ b/gadget/layout.go
@@ -42,15 +42,16 @@ type LayoutConstraints struct {
 	// NonMBRStartOffset is the default start offset of non-MBR structure in
 	// the volume.
 	NonMBRStartOffset quantity.Offset
+
 	// SkipResolveContent will skip resolving content paths
 	// and `$kernel:` style references
 	SkipResolveContent bool
 
-	// SkipLayoutStructureContent will skip laying out
-	// content structure data to the volume. This is used when
-	// only the partitions need to get created and content gets
-	// written later.
-	SkipLayoutStructureContent bool
+	// Content will skip laying out content structure data to the
+	// volume. Settings this implies "SkipResolveContent".  This
+	// is used when only the partitions need to get
+	// created and content gets written later.
+	IgnoreContent bool
 }
 
 // LaidOutVolume defines the size of a volume and arrangement of all the
@@ -225,7 +226,7 @@ func LayoutVolume(volume *Volume, constraints LayoutConstraints, opts *LayoutOpt
 	}
 
 	var kernelInfo *kernel.Info
-	if !constraints.SkipResolveContent {
+	if !constraints.IgnoreContent && !constraints.SkipResolveContent {
 		// TODO:UC20: check and error if kernelRootDir == "" here
 		// This needs the upper layer of gadget updates to be
 		// updated to pass the kernel root first.
@@ -259,7 +260,7 @@ func LayoutVolume(volume *Volume, constraints LayoutConstraints, opts *LayoutOpt
 		// creation is needed and is safe because each volume structure
 		// has a size so even without the structure content the layout
 		// can be calculated.
-		if !constraints.SkipLayoutStructureContent {
+		if !constraints.IgnoreContent {
 			content, err := layOutStructureContent(opts.GadgetRootDir, &structures[idx], byName)
 			if err != nil {
 				return nil, err
@@ -273,7 +274,7 @@ func LayoutVolume(volume *Volume, constraints LayoutConstraints, opts *LayoutOpt
 		}
 
 		// resolve filesystem content
-		if !constraints.SkipResolveContent {
+		if !constraints.IgnoreContent && !constraints.SkipResolveContent {
 			resolvedContent, err := resolveVolumeContent(opts.GadgetRootDir, opts.KernelRootDir, kernelInfo, &structures[idx], nil)
 			if err != nil {
 				return nil, err

--- a/gadget/layout.go
+++ b/gadget/layout.go
@@ -47,7 +47,7 @@ type LayoutConstraints struct {
 	// and `$kernel:` style references
 	SkipResolveContent bool
 
-	// Content will skip laying out content structure data to the
+	// IgnoreContent will skip laying out content structure data to the
 	// volume. Settings this implies "SkipResolveContent".  This
 	// is used when only the partitions need to get
 	// created and content gets written later.
@@ -224,9 +224,10 @@ func LayoutVolume(volume *Volume, constraints LayoutConstraints, opts *LayoutOpt
 	if opts == nil {
 		opts = &LayoutOptions{}
 	}
+	doResolveContent := !(constraints.IgnoreContent || constraints.SkipResolveContent)
 
 	var kernelInfo *kernel.Info
-	if !constraints.IgnoreContent && !constraints.SkipResolveContent {
+	if doResolveContent {
 		// TODO:UC20: check and error if kernelRootDir == "" here
 		// This needs the upper layer of gadget updates to be
 		// updated to pass the kernel root first.
@@ -274,7 +275,7 @@ func LayoutVolume(volume *Volume, constraints LayoutConstraints, opts *LayoutOpt
 		}
 
 		// resolve filesystem content
-		if !constraints.IgnoreContent && !constraints.SkipResolveContent {
+		if doResolveContent {
 			resolvedContent, err := resolveVolumeContent(opts.GadgetRootDir, opts.KernelRootDir, kernelInfo, &structures[idx], nil)
 			if err != nil {
 				return nil, err

--- a/gadget/layout.go
+++ b/gadget/layout.go
@@ -30,7 +30,7 @@ import (
 	"github.com/snapcore/snapd/kernel"
 )
 
-// LayoutOptions defines the options to layout a given volume
+// LayoutOptions defines the options to layout a given volume.
 type LayoutOptions struct {
 	GadgetRootDir string
 	KernelRootDir string
@@ -46,8 +46,10 @@ type LayoutConstraints struct {
 	// and `$kernel:` style references
 	SkipResolveContent bool
 
-	// SkipLayoutStructureContent will skipp laying out
-	// content structure data
+	// SkipLayoutStructureContent will skip laying out
+	// content structure data to the volume. This is used when
+	// only the partitions need to get created and content gets
+	// written later.
 	SkipLayoutStructureContent bool
 }
 
@@ -253,13 +255,10 @@ func LayoutVolume(volume *Volume, opts *LayoutOptions, constraints LayoutConstra
 			farthestEnd = end
 		}
 
-		// lay out raw content
-
-		// We need a way to layout volumes
-		// without looking at the content for the installer code.
-		// This needs to at least very that all content using layouts
-		// have a size defined and that it's not implicit from the
-		// size of the content binary (if this is a thing?).
+		// Lay out raw content. This can be skipped when only partition
+		// creation is needed and is safe because each volume structure
+		// has a size so even without the structure content the layout
+		// can be calculated.
 		if !constraints.SkipLayoutStructureContent {
 			content, err := layOutStructureContent(opts.GadgetRootDir, &structures[idx], byName)
 			if err != nil {

--- a/gadget/layout.go
+++ b/gadget/layout.go
@@ -32,6 +32,16 @@ import (
 
 // LayoutOptions defines the options to layout a given volume.
 type LayoutOptions struct {
+	// SkipResolveContent will skip resolving content paths
+	// and `$kernel:` style references
+	SkipResolveContent bool
+
+	// IgnoreContent will skip laying out content structure data to the
+	// volume. Settings this implies "SkipResolveContent".  This
+	// is used when only the partitions need to get
+	// created and content gets written later.
+	IgnoreContent bool
+
 	GadgetRootDir string
 	KernelRootDir string
 }
@@ -42,16 +52,6 @@ type LayoutConstraints struct {
 	// NonMBRStartOffset is the default start offset of non-MBR structure in
 	// the volume.
 	NonMBRStartOffset quantity.Offset
-
-	// SkipResolveContent will skip resolving content paths
-	// and `$kernel:` style references
-	SkipResolveContent bool
-
-	// IgnoreContent will skip laying out content structure data to the
-	// volume. Settings this implies "SkipResolveContent".  This
-	// is used when only the partitions need to get
-	// created and content gets written later.
-	IgnoreContent bool
 }
 
 // LaidOutVolume defines the size of a volume and arrangement of all the
@@ -224,7 +224,7 @@ func LayoutVolume(volume *Volume, constraints LayoutConstraints, opts *LayoutOpt
 	if opts == nil {
 		opts = &LayoutOptions{}
 	}
-	doResolveContent := !(constraints.IgnoreContent || constraints.SkipResolveContent)
+	doResolveContent := !(opts.IgnoreContent || opts.SkipResolveContent)
 
 	var kernelInfo *kernel.Info
 	if doResolveContent {
@@ -261,7 +261,7 @@ func LayoutVolume(volume *Volume, constraints LayoutConstraints, opts *LayoutOpt
 		// creation is needed and is safe because each volume structure
 		// has a size so even without the structure content the layout
 		// can be calculated.
-		if !constraints.IgnoreContent {
+		if !opts.IgnoreContent {
 			content, err := layOutStructureContent(opts.GadgetRootDir, &structures[idx], byName)
 			if err != nil {
 				return nil, err

--- a/gadget/layout_test.go
+++ b/gadget/layout_test.go
@@ -1206,7 +1206,7 @@ func (p *layoutTestSuite) TestResolveContentPathsSkipResolveContent(c *C) {
 	_, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
 	c.Assert(err, ErrorMatches, `cannot resolve content for structure #0 at index 0: cannot find "dtbs" in kernel info from "/.*"`)
 
-	// SkipResolveContent  will all to layout the volume even if
+	// SkipResolveContent will allow to layout the volume even if
 	// files are missing
 	constraints := defaultConstraints
 	constraints.SkipResolveContent = true
@@ -1214,7 +1214,7 @@ func (p *layoutTestSuite) TestResolveContentPathsSkipResolveContent(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(v.Structure, HasLen, 1)
 
-	// As does IgnoreContent  will all to layout the volume even if
+	// As does IgnoreContent will allow to layout the volume even if
 	// files are missing
 	constraints = defaultConstraints
 	constraints.IgnoreContent = true

--- a/gadget/layout_test.go
+++ b/gadget/layout_test.go
@@ -323,15 +323,14 @@ volumes:
 	opts := &gadget.LayoutOptions{
 		GadgetRootDir: p.dir,
 	}
-	constraints := defaultConstraints
 	// LayoutVolume fails with default constraints because the foo.img
 	// file is missing
-	_, err := gadget.LayoutVolume(vol, constraints, opts)
+	_, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
 	c.Assert(err, ErrorMatches, `cannot lay out structure #0: content "foo.img":.*no such file or directory`)
 
 	// But LayoutVolume works with the IgnoreContent works
-	constraints.IgnoreContent = true
-	v, err := gadget.LayoutVolume(vol, constraints, opts)
+	opts.IgnoreContent = true
+	v, err := gadget.LayoutVolume(vol, gadget.DefaultConstraints, opts)
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
 		Volume:  vol,
@@ -1202,23 +1201,25 @@ func (p *layoutTestSuite) TestResolveContentPathsSkipResolveContent(c *C) {
 	c.Assert(vol.Structure, HasLen, 1)
 
 	kernelSnapDir := c.MkDir()
-	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir, KernelRootDir: kernelSnapDir}
+	defaultOpts := &gadget.LayoutOptions{GadgetRootDir: p.dir, KernelRootDir: kernelSnapDir}
+
+	opts := defaultOpts
 	_, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
 	c.Assert(err, ErrorMatches, `cannot resolve content for structure #0 at index 0: cannot find "dtbs" in kernel info from "/.*"`)
 
 	// SkipResolveContent will allow to layout the volume even if
 	// files are missing
-	constraints := defaultConstraints
-	constraints.SkipResolveContent = true
-	v, err := gadget.LayoutVolume(vol, constraints, opts)
+	opts = defaultOpts
+	opts.SkipResolveContent = true
+	v, err := gadget.LayoutVolume(vol, gadget.DefaultConstraints, opts)
 	c.Assert(err, IsNil)
 	c.Assert(v.Structure, HasLen, 1)
 
 	// As does IgnoreContent will allow to layout the volume even if
 	// files are missing
-	constraints = defaultConstraints
-	constraints.IgnoreContent = true
-	v, err = gadget.LayoutVolume(vol, constraints, opts)
+	opts = defaultOpts
+	opts.IgnoreContent = true
+	v, err = gadget.LayoutVolume(vol, gadget.DefaultConstraints, opts)
 	c.Assert(err, IsNil)
 	c.Assert(v.Structure, HasLen, 1)
 }

--- a/gadget/layout_test.go
+++ b/gadget/layout_test.go
@@ -56,7 +56,7 @@ func (p *layoutTestSuite) TestVolumeSize(c *C) {
 		},
 	}
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
-	v, err := gadget.LayoutVolume(&vol, opts, defaultConstraints)
+	v, err := gadget.LayoutVolume(&vol, defaultConstraints, opts)
 	c.Assert(err, IsNil)
 
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
@@ -98,7 +98,7 @@ volumes:
 	c.Assert(vol.Structure, HasLen, 2)
 
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
-	v, err := gadget.LayoutVolume(vol, opts, defaultConstraints)
+	v, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
 	c.Assert(err, IsNil)
 
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
@@ -141,7 +141,7 @@ volumes:
 	c.Assert(vol.Structure, HasLen, 4)
 
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
-	v, err := gadget.LayoutVolume(vol, opts, defaultConstraints)
+	v, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
 	c.Assert(err, IsNil)
 
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
@@ -198,7 +198,7 @@ volumes:
 	c.Assert(vol.Structure, HasLen, 4)
 
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
-	v, err := gadget.LayoutVolume(vol, opts, defaultConstraints)
+	v, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
 	c.Assert(err, IsNil)
 
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
@@ -254,7 +254,7 @@ volumes:
 	c.Assert(vol.Structure, HasLen, 4)
 
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
-	v, err := gadget.LayoutVolume(vol, opts, defaultConstraints)
+	v, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
 	c.Assert(err, IsNil)
 
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
@@ -301,7 +301,7 @@ volumes:
 `
 	vol := mustParseVolume(c, gadgetYaml, "first")
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
-	v, err := gadget.LayoutVolume(vol, opts, defaultConstraints)
+	v, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
 	c.Assert(v, IsNil)
 	c.Assert(err, ErrorMatches, `cannot lay out structure #0: content "foo.img":.*no such file or directory`)
 }
@@ -340,7 +340,7 @@ volumes:
 	vol := mustParseVolume(c, gadgetYaml, "first")
 
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
-	v, err := gadget.LayoutVolume(vol, opts, defaultConstraints)
+	v, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
 	c.Assert(v, IsNil)
 	c.Assert(err, ErrorMatches, `cannot lay out structure #0: content "foo.img" does not fit in the structure`)
 }
@@ -367,7 +367,7 @@ volumes:
 		NonMBRStartOffset: 1 * quantity.OffsetMiB,
 	}
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
-	v, err := gadget.LayoutVolume(vol, opts, constraints)
+	v, err := gadget.LayoutVolume(vol, constraints, opts)
 	c.Assert(v, IsNil)
 	c.Assert(err, ErrorMatches, `cannot lay out structure #0: content "bar.img" does not fit in the structure`)
 }
@@ -391,7 +391,7 @@ volumes:
 	vol := mustParseVolume(c, gadgetYaml, "first")
 
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
-	v, err := gadget.LayoutVolume(vol, opts, defaultConstraints)
+	v, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
 	c.Assert(v, IsNil)
 	c.Assert(err, ErrorMatches, `cannot lay out structure #0: content "foo.img" does not fit in the structure`)
 }
@@ -414,7 +414,7 @@ volumes:
 	vol := mustParseVolume(c, gadgetYaml, "first")
 
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
-	v, err := gadget.LayoutVolume(vol, opts, defaultConstraints)
+	v, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
 	c.Assert(v, IsNil)
 	c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot lay out structure #0: content "foo.img" size %v is larger than declared %v`, quantity.SizeMiB+1, quantity.SizeMiB))
 }
@@ -443,7 +443,7 @@ volumes:
 	vol := mustParseVolume(c, gadgetYaml, "first")
 
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
-	v, err := gadget.LayoutVolume(vol, opts, defaultConstraints)
+	v, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
 	c.Assert(v, IsNil)
 	c.Assert(err, ErrorMatches, `cannot lay out structure #0: content "foo.img" overlaps with preceding image "bar.img"`)
 }
@@ -473,7 +473,7 @@ volumes:
 	c.Assert(vol.Structure[0].Content, HasLen, 2)
 
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
-	v, err := gadget.LayoutVolume(vol, opts, defaultConstraints)
+	v, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
 		Volume:  vol,
@@ -525,7 +525,7 @@ volumes:
 	c.Assert(vol.Structure[0].Content, HasLen, 2)
 
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
-	v, err := gadget.LayoutVolume(vol, opts, defaultConstraints)
+	v, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
 		Volume:  vol,
@@ -574,7 +574,7 @@ volumes:
 	c.Assert(vol.Structure[0].Content, HasLen, 1)
 
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
-	v, err := gadget.LayoutVolume(vol, opts, defaultConstraints)
+	v, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
 		Volume:  vol,
@@ -617,7 +617,7 @@ volumes:
 	c.Assert(vol.Structure[0].Content, HasLen, 1)
 
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
-	v, err := gadget.LayoutVolume(vol, opts, defaultConstraints)
+	v, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
 		Volume:  vol,
@@ -676,7 +676,7 @@ volumes:
 	c.Assert(vol.Structure[1].Content, HasLen, 1)
 
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
-	v, err := gadget.LayoutVolume(vol, opts, defaultConstraints)
+	v, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
 		Volume:  vol,
@@ -702,7 +702,7 @@ volumes:
 		// 512kiB
 		NonMBRStartOffset: 512 * quantity.OffsetKiB,
 	}
-	v, err = gadget.LayoutVolume(vol, opts, constraints)
+	v, err = gadget.LayoutVolume(vol, constraints, opts)
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
 		Volume:  vol,
@@ -729,7 +729,7 @@ volumes:
 	constraintsBad := gadget.LayoutConstraints{
 		NonMBRStartOffset: 400,
 	}
-	v, err = gadget.LayoutVolume(vol, opts, constraintsBad)
+	v, err = gadget.LayoutVolume(vol, constraintsBad, opts)
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
 		Volume:  vol,
@@ -769,7 +769,7 @@ volumes:
 	c.Assert(vol.Structure, HasLen, 2)
 
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
-	v, err := gadget.LayoutVolume(vol, opts, defaultConstraints)
+	v, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
 		Volume:  vol,
@@ -822,7 +822,7 @@ volumes:
 	c.Assert(vol.Structure, HasLen, 3)
 
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
-	v, err := gadget.LayoutVolume(vol, opts, defaultConstraints)
+	v, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
 		Volume:  vol,
@@ -908,11 +908,11 @@ func (p *layoutTestSuite) TestLayoutVolumeOffsetWriteBadRelativeTo(c *C) {
 	makeSizedFile(c, filepath.Join(p.dir, "foo.img"), 200*quantity.SizeKiB, []byte(""))
 
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
-	v, err := gadget.LayoutVolume(&volBadStructure, opts, defaultConstraints)
+	v, err := gadget.LayoutVolume(&volBadStructure, defaultConstraints, opts)
 	c.Check(v, IsNil)
 	c.Check(err, ErrorMatches, `cannot resolve offset-write of structure #0 \("foo"\): refers to an unknown structure "bar"`)
 
-	v, err = gadget.LayoutVolume(&volBadContent, opts, defaultConstraints)
+	v, err = gadget.LayoutVolume(&volBadContent, defaultConstraints, opts)
 	c.Check(v, IsNil)
 	c.Check(err, ErrorMatches, `cannot resolve offset-write of structure #0 \("foo"\) content "foo.img": refers to an unknown structure "bar"`)
 }
@@ -937,7 +937,7 @@ volumes:
 	vol := mustParseVolume(c, gadgetYamlStructure, "pc")
 
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
-	v, err := gadget.LayoutVolume(vol, opts, defaultConstraints)
+	v, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
 	c.Assert(err, IsNil)
 	// offset-write is at 1GB
 	c.Check(v.Size, Equals, 1*quantity.SizeGiB+gadget.SizeLBA48Pointer)
@@ -972,7 +972,7 @@ volumes:
 
 	vol = mustParseVolume(c, gadgetYamlContent, "pc")
 
-	v, err = gadget.LayoutVolume(vol, opts, defaultConstraints)
+	v, err = gadget.LayoutVolume(vol, defaultConstraints, opts)
 	c.Assert(err, IsNil)
 	// foo.img offset-write is at 3GB
 	c.Check(v.Size, Equals, 3*quantity.SizeGiB+gadget.SizeLBA48Pointer)
@@ -1031,7 +1031,7 @@ volumes:
 	vol := mustParseVolume(c, gadgetYamlContent, "pc")
 
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
-	v, err := gadget.LayoutVolume(vol, opts, defaultConstraints)
+	v, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
 	c.Assert(err, IsNil)
 	c.Assert(v.LaidOutStructure, HasLen, 1)
 	c.Assert(v.LaidOutStructure[0].LaidOutContent, HasLen, 2)
@@ -1153,7 +1153,7 @@ func (p *layoutTestSuite) TestResolveContentPathsNotInWantedAssets(c *C) {
 
 	kernelSnapDir := c.MkDir()
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir, KernelRootDir: kernelSnapDir}
-	_, err := gadget.LayoutVolume(vol, opts, defaultConstraints)
+	_, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
 	c.Assert(err, ErrorMatches, `cannot resolve content for structure #0 at index 0: cannot find "dtbs" in kernel info from "/.*"`)
 }
 
@@ -1167,7 +1167,7 @@ func (p *layoutTestSuite) TestResolveContentPathsErrorInKernelRef(c *C) {
 
 	kernelSnapDir := c.MkDir()
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir, KernelRootDir: kernelSnapDir}
-	_, err := gadget.LayoutVolume(vol, opts, defaultConstraints)
+	_, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
 	c.Assert(err, ErrorMatches, `cannot resolve content for structure #0 at index 0: cannot parse kernel ref: invalid asset name in kernel ref "\$kernel:-invalid-kernel-ref/boot-assets/"`)
 }
 
@@ -1187,7 +1187,7 @@ assets:
 		"dtbs/foo.dtb": "foo.dtb content",
 	})
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir, KernelRootDir: kernelSnapDir}
-	_, err := gadget.LayoutVolume(vol, opts, defaultConstraints)
+	_, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
 	c.Assert(err, ErrorMatches, `cannot resolve content for structure #0 at index 0: cannot find wanted kernel content "boot-assets/" in "/.*"`)
 }
 
@@ -1209,7 +1209,7 @@ assets:
 	}
 	kernelSnapDir := mockKernel(c, kernelYaml, kernelSnapFiles)
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir, KernelRootDir: kernelSnapDir}
-	lv, err := gadget.LayoutVolume(vol, opts, defaultConstraints)
+	lv, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
 	c.Assert(err, IsNil)
 	// Volume.Content is unchanged
 	c.Assert(lv.Structure, HasLen, 1)
@@ -1290,7 +1290,7 @@ assets:
 		"dtbs/foo.dtb": "foo.dtb content",
 	})
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir, KernelRootDir: kernelSnapDir}
-	lv, err := gadget.LayoutVolume(vol, opts, defaultConstraints)
+	lv, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
 	c.Assert(err, IsNil)
 	// Volume.Content is unchanged
 	c.Assert(lv.Structure, HasLen, 1)
@@ -1360,6 +1360,6 @@ assets:
 		"a/foo.dtb": "foo.dtb content",
 	})
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir, KernelRootDir: kernelSnapDir}
-	_, err := gadget.LayoutVolume(vol, opts, defaultConstraints)
+	_, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
 	c.Assert(err, ErrorMatches, `.*: cannot find wanted kernel content "ab" in.*`)
 }

--- a/gadget/layout_test.go
+++ b/gadget/layout_test.go
@@ -55,7 +55,8 @@ func (p *layoutTestSuite) TestVolumeSize(c *C) {
 			{Size: 2 * quantity.SizeMiB},
 		},
 	}
-	v, err := gadget.LayoutVolume(p.dir, "", &vol, defaultConstraints)
+	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
+	v, err := gadget.LayoutVolume(&vol, opts, defaultConstraints)
 	c.Assert(err, IsNil)
 
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
@@ -96,7 +97,8 @@ volumes:
 	vol := mustParseVolume(c, gadgetYaml, "first-image")
 	c.Assert(vol.Structure, HasLen, 2)
 
-	v, err := gadget.LayoutVolume(p.dir, "", vol, defaultConstraints)
+	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
+	v, err := gadget.LayoutVolume(vol, opts, defaultConstraints)
 	c.Assert(err, IsNil)
 
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
@@ -138,7 +140,8 @@ volumes:
 	vol := mustParseVolume(c, gadgetYaml, "first")
 	c.Assert(vol.Structure, HasLen, 4)
 
-	v, err := gadget.LayoutVolume(p.dir, "", vol, defaultConstraints)
+	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
+	v, err := gadget.LayoutVolume(vol, opts, defaultConstraints)
 	c.Assert(err, IsNil)
 
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
@@ -194,7 +197,8 @@ volumes:
 	vol := mustParseVolume(c, gadgetYaml, "first")
 	c.Assert(vol.Structure, HasLen, 4)
 
-	v, err := gadget.LayoutVolume(p.dir, "", vol, defaultConstraints)
+	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
+	v, err := gadget.LayoutVolume(vol, opts, defaultConstraints)
 	c.Assert(err, IsNil)
 
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
@@ -249,7 +253,8 @@ volumes:
 	vol := mustParseVolume(c, gadgetYaml, "first")
 	c.Assert(vol.Structure, HasLen, 4)
 
-	v, err := gadget.LayoutVolume(p.dir, "", vol, defaultConstraints)
+	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
+	v, err := gadget.LayoutVolume(vol, opts, defaultConstraints)
 	c.Assert(err, IsNil)
 
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
@@ -295,7 +300,8 @@ volumes:
               - image: foo.img
 `
 	vol := mustParseVolume(c, gadgetYaml, "first")
-	v, err := gadget.LayoutVolume(p.dir, "", vol, defaultConstraints)
+	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
+	v, err := gadget.LayoutVolume(vol, opts, defaultConstraints)
 	c.Assert(v, IsNil)
 	c.Assert(err, ErrorMatches, `cannot lay out structure #0: content "foo.img":.*no such file or directory`)
 }
@@ -333,7 +339,8 @@ volumes:
 
 	vol := mustParseVolume(c, gadgetYaml, "first")
 
-	v, err := gadget.LayoutVolume(p.dir, "", vol, defaultConstraints)
+	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
+	v, err := gadget.LayoutVolume(vol, opts, defaultConstraints)
 	c.Assert(v, IsNil)
 	c.Assert(err, ErrorMatches, `cannot lay out structure #0: content "foo.img" does not fit in the structure`)
 }
@@ -359,7 +366,8 @@ volumes:
 	constraints := gadget.LayoutConstraints{
 		NonMBRStartOffset: 1 * quantity.OffsetMiB,
 	}
-	v, err := gadget.LayoutVolume(p.dir, "", vol, constraints)
+	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
+	v, err := gadget.LayoutVolume(vol, opts, constraints)
 	c.Assert(v, IsNil)
 	c.Assert(err, ErrorMatches, `cannot lay out structure #0: content "bar.img" does not fit in the structure`)
 }
@@ -382,7 +390,8 @@ volumes:
 
 	vol := mustParseVolume(c, gadgetYaml, "first")
 
-	v, err := gadget.LayoutVolume(p.dir, "", vol, defaultConstraints)
+	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
+	v, err := gadget.LayoutVolume(vol, opts, defaultConstraints)
 	c.Assert(v, IsNil)
 	c.Assert(err, ErrorMatches, `cannot lay out structure #0: content "foo.img" does not fit in the structure`)
 }
@@ -404,7 +413,8 @@ volumes:
 
 	vol := mustParseVolume(c, gadgetYaml, "first")
 
-	v, err := gadget.LayoutVolume(p.dir, "", vol, defaultConstraints)
+	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
+	v, err := gadget.LayoutVolume(vol, opts, defaultConstraints)
 	c.Assert(v, IsNil)
 	c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot lay out structure #0: content "foo.img" size %v is larger than declared %v`, quantity.SizeMiB+1, quantity.SizeMiB))
 }
@@ -432,7 +442,8 @@ volumes:
 
 	vol := mustParseVolume(c, gadgetYaml, "first")
 
-	v, err := gadget.LayoutVolume(p.dir, "", vol, defaultConstraints)
+	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
+	v, err := gadget.LayoutVolume(vol, opts, defaultConstraints)
 	c.Assert(v, IsNil)
 	c.Assert(err, ErrorMatches, `cannot lay out structure #0: content "foo.img" overlaps with preceding image "bar.img"`)
 }
@@ -461,7 +472,8 @@ volumes:
 	c.Assert(vol.Structure, HasLen, 1)
 	c.Assert(vol.Structure[0].Content, HasLen, 2)
 
-	v, err := gadget.LayoutVolume(p.dir, "", vol, defaultConstraints)
+	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
+	v, err := gadget.LayoutVolume(vol, opts, defaultConstraints)
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
 		Volume:  vol,
@@ -512,7 +524,8 @@ volumes:
 	c.Assert(vol.Structure, HasLen, 1)
 	c.Assert(vol.Structure[0].Content, HasLen, 2)
 
-	v, err := gadget.LayoutVolume(p.dir, "", vol, defaultConstraints)
+	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
+	v, err := gadget.LayoutVolume(vol, opts, defaultConstraints)
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
 		Volume:  vol,
@@ -560,7 +573,8 @@ volumes:
 	c.Assert(vol.Structure, HasLen, 1)
 	c.Assert(vol.Structure[0].Content, HasLen, 1)
 
-	v, err := gadget.LayoutVolume(p.dir, "", vol, defaultConstraints)
+	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
+	v, err := gadget.LayoutVolume(vol, opts, defaultConstraints)
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
 		Volume:  vol,
@@ -602,7 +616,8 @@ volumes:
 	c.Assert(vol.Structure, HasLen, 1)
 	c.Assert(vol.Structure[0].Content, HasLen, 1)
 
-	v, err := gadget.LayoutVolume(p.dir, "", vol, defaultConstraints)
+	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
+	v, err := gadget.LayoutVolume(vol, opts, defaultConstraints)
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
 		Volume:  vol,
@@ -660,7 +675,8 @@ volumes:
 	c.Assert(vol.Structure, HasLen, 2)
 	c.Assert(vol.Structure[1].Content, HasLen, 1)
 
-	v, err := gadget.LayoutVolume(p.dir, "", vol, defaultConstraints)
+	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
+	v, err := gadget.LayoutVolume(vol, opts, defaultConstraints)
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
 		Volume:  vol,
@@ -686,7 +702,7 @@ volumes:
 		// 512kiB
 		NonMBRStartOffset: 512 * quantity.OffsetKiB,
 	}
-	v, err = gadget.LayoutVolume(p.dir, "", vol, constraints)
+	v, err = gadget.LayoutVolume(vol, opts, constraints)
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
 		Volume:  vol,
@@ -713,7 +729,7 @@ volumes:
 	constraintsBad := gadget.LayoutConstraints{
 		NonMBRStartOffset: 400,
 	}
-	v, err = gadget.LayoutVolume(p.dir, "", vol, constraintsBad)
+	v, err = gadget.LayoutVolume(vol, opts, constraintsBad)
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
 		Volume:  vol,
@@ -752,7 +768,8 @@ volumes:
 	vol := mustParseVolume(c, gadgetYaml, "first")
 	c.Assert(vol.Structure, HasLen, 2)
 
-	v, err := gadget.LayoutVolume(p.dir, "", vol, defaultConstraints)
+	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
+	v, err := gadget.LayoutVolume(vol, opts, defaultConstraints)
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
 		Volume:  vol,
@@ -804,7 +821,8 @@ volumes:
 	vol := mustParseVolume(c, gadgetYaml, "pc")
 	c.Assert(vol.Structure, HasLen, 3)
 
-	v, err := gadget.LayoutVolume(p.dir, "", vol, defaultConstraints)
+	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
+	v, err := gadget.LayoutVolume(vol, opts, defaultConstraints)
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
 		Volume:  vol,
@@ -889,11 +907,12 @@ func (p *layoutTestSuite) TestLayoutVolumeOffsetWriteBadRelativeTo(c *C) {
 
 	makeSizedFile(c, filepath.Join(p.dir, "foo.img"), 200*quantity.SizeKiB, []byte(""))
 
-	v, err := gadget.LayoutVolume(p.dir, "", &volBadStructure, defaultConstraints)
+	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
+	v, err := gadget.LayoutVolume(&volBadStructure, opts, defaultConstraints)
 	c.Check(v, IsNil)
 	c.Check(err, ErrorMatches, `cannot resolve offset-write of structure #0 \("foo"\): refers to an unknown structure "bar"`)
 
-	v, err = gadget.LayoutVolume(p.dir, "", &volBadContent, defaultConstraints)
+	v, err = gadget.LayoutVolume(&volBadContent, opts, defaultConstraints)
 	c.Check(v, IsNil)
 	c.Check(err, ErrorMatches, `cannot resolve offset-write of structure #0 \("foo"\) content "foo.img": refers to an unknown structure "bar"`)
 }
@@ -917,7 +936,8 @@ volumes:
 `
 	vol := mustParseVolume(c, gadgetYamlStructure, "pc")
 
-	v, err := gadget.LayoutVolume(p.dir, "", vol, defaultConstraints)
+	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
+	v, err := gadget.LayoutVolume(vol, opts, defaultConstraints)
 	c.Assert(err, IsNil)
 	// offset-write is at 1GB
 	c.Check(v.Size, Equals, 1*quantity.SizeGiB+gadget.SizeLBA48Pointer)
@@ -952,7 +972,7 @@ volumes:
 
 	vol = mustParseVolume(c, gadgetYamlContent, "pc")
 
-	v, err = gadget.LayoutVolume(p.dir, "", vol, defaultConstraints)
+	v, err = gadget.LayoutVolume(vol, opts, defaultConstraints)
 	c.Assert(err, IsNil)
 	// foo.img offset-write is at 3GB
 	c.Check(v.Size, Equals, 3*quantity.SizeGiB+gadget.SizeLBA48Pointer)
@@ -1010,7 +1030,8 @@ volumes:
 
 	vol := mustParseVolume(c, gadgetYamlContent, "pc")
 
-	v, err := gadget.LayoutVolume(p.dir, "", vol, defaultConstraints)
+	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
+	v, err := gadget.LayoutVolume(vol, opts, defaultConstraints)
 	c.Assert(err, IsNil)
 	c.Assert(v.LaidOutStructure, HasLen, 1)
 	c.Assert(v.LaidOutStructure[0].LaidOutContent, HasLen, 2)
@@ -1131,7 +1152,8 @@ func (p *layoutTestSuite) TestResolveContentPathsNotInWantedAssets(c *C) {
 	c.Assert(vol.Structure, HasLen, 1)
 
 	kernelSnapDir := c.MkDir()
-	_, err := gadget.LayoutVolume(p.dir, kernelSnapDir, vol, defaultConstraints)
+	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir, KernelRootDir: kernelSnapDir}
+	_, err := gadget.LayoutVolume(vol, opts, defaultConstraints)
 	c.Assert(err, ErrorMatches, `cannot resolve content for structure #0 at index 0: cannot find "dtbs" in kernel info from "/.*"`)
 }
 
@@ -1144,7 +1166,8 @@ func (p *layoutTestSuite) TestResolveContentPathsErrorInKernelRef(c *C) {
 	c.Assert(vol.Structure, HasLen, 1)
 
 	kernelSnapDir := c.MkDir()
-	_, err := gadget.LayoutVolume(p.dir, kernelSnapDir, vol, defaultConstraints)
+	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir, KernelRootDir: kernelSnapDir}
+	_, err := gadget.LayoutVolume(vol, opts, defaultConstraints)
 	c.Assert(err, ErrorMatches, `cannot resolve content for structure #0 at index 0: cannot parse kernel ref: invalid asset name in kernel ref "\$kernel:-invalid-kernel-ref/boot-assets/"`)
 }
 
@@ -1163,7 +1186,8 @@ assets:
 	kernelSnapDir := mockKernel(c, kernelYaml, map[string]string{
 		"dtbs/foo.dtb": "foo.dtb content",
 	})
-	_, err := gadget.LayoutVolume(p.dir, kernelSnapDir, vol, defaultConstraints)
+	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir, KernelRootDir: kernelSnapDir}
+	_, err := gadget.LayoutVolume(vol, opts, defaultConstraints)
 	c.Assert(err, ErrorMatches, `cannot resolve content for structure #0 at index 0: cannot find wanted kernel content "boot-assets/" in "/.*"`)
 }
 
@@ -1184,7 +1208,8 @@ assets:
 		"some-file":       "some-file content",
 	}
 	kernelSnapDir := mockKernel(c, kernelYaml, kernelSnapFiles)
-	lv, err := gadget.LayoutVolume(p.dir, kernelSnapDir, vol, defaultConstraints)
+	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir, KernelRootDir: kernelSnapDir}
+	lv, err := gadget.LayoutVolume(vol, opts, defaultConstraints)
 	c.Assert(err, IsNil)
 	// Volume.Content is unchanged
 	c.Assert(lv.Structure, HasLen, 1)
@@ -1264,7 +1289,8 @@ assets:
 	kernelSnapDir := mockKernel(c, kernelYaml, map[string]string{
 		"dtbs/foo.dtb": "foo.dtb content",
 	})
-	lv, err := gadget.LayoutVolume(p.dir, kernelSnapDir, vol, defaultConstraints)
+	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir, KernelRootDir: kernelSnapDir}
+	lv, err := gadget.LayoutVolume(vol, opts, defaultConstraints)
 	c.Assert(err, IsNil)
 	// Volume.Content is unchanged
 	c.Assert(lv.Structure, HasLen, 1)
@@ -1333,6 +1359,7 @@ assets:
 	kernelSnapDir := mockKernel(c, kernelYaml, map[string]string{
 		"a/foo.dtb": "foo.dtb content",
 	})
-	_, err := gadget.LayoutVolume(p.dir, kernelSnapDir, vol, defaultConstraints)
+	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir, KernelRootDir: kernelSnapDir}
+	_, err := gadget.LayoutVolume(vol, opts, defaultConstraints)
 	c.Assert(err, ErrorMatches, `.*: cannot find wanted kernel content "ab" in.*`)
 }

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -1259,7 +1259,11 @@ func Update(model Model, old, new GadgetData, rollbackDirPath string, updatePoli
 		// Layout new volume, delay resolving of filesystem content
 		constraints := DefaultConstraints
 		constraints.SkipResolveContent = true
-		pNew, err := LayoutVolume(new.RootDir, new.KernelRootDir, newVol, constraints)
+		opts := &LayoutOptions{
+			GadgetRootDir: new.RootDir,
+			KernelRootDir: new.KernelRootDir,
+		}
+		pNew, err := LayoutVolume(newVol, opts, constraints)
 		if err != nil {
 			return fmt.Errorf("cannot lay out the new volume %s: %v", volName, err)
 		}

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -1263,7 +1263,7 @@ func Update(model Model, old, new GadgetData, rollbackDirPath string, updatePoli
 			GadgetRootDir: new.RootDir,
 			KernelRootDir: new.KernelRootDir,
 		}
-		pNew, err := LayoutVolume(newVol, opts, constraints)
+		pNew, err := LayoutVolume(newVol, constraints, opts)
 		if err != nil {
 			return fmt.Errorf("cannot lay out the new volume %s: %v", volName, err)
 		}

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -1240,6 +1240,13 @@ func Update(model Model, old, new GadgetData, rollbackDirPath string, updatePoli
 
 	atLeastOneKernelAssetConsumed := false
 
+	// Layout new volume, delay resolving of filesystem content
+	opts := &LayoutOptions{
+		SkipResolveContent: true,
+		GadgetRootDir:      new.RootDir,
+		KernelRootDir:      new.KernelRootDir,
+	}
+
 	allUpdates := []updatePair{}
 	laidOutVols := map[string]*LaidOutVolume{}
 	for volName, oldVol := range old.Info.Volumes {
@@ -1256,12 +1263,6 @@ func Update(model Model, old, new GadgetData, rollbackDirPath string, updatePoli
 			return fmt.Errorf("cannot lay out the old volume %s: %v", volName, err)
 		}
 
-		// Layout new volume, delay resolving of filesystem content
-		opts := &LayoutOptions{
-			SkipResolveContent: true,
-			GadgetRootDir:      new.RootDir,
-			KernelRootDir:      new.KernelRootDir,
-		}
 		pNew, err := LayoutVolume(newVol, DefaultConstraints, opts)
 		if err != nil {
 			return fmt.Errorf("cannot lay out the new volume %s: %v", volName, err)

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -1257,13 +1257,12 @@ func Update(model Model, old, new GadgetData, rollbackDirPath string, updatePoli
 		}
 
 		// Layout new volume, delay resolving of filesystem content
-		constraints := DefaultConstraints
-		constraints.SkipResolveContent = true
 		opts := &LayoutOptions{
-			GadgetRootDir: new.RootDir,
-			KernelRootDir: new.KernelRootDir,
+			SkipResolveContent: true,
+			GadgetRootDir:      new.RootDir,
+			KernelRootDir:      new.KernelRootDir,
 		}
-		pNew, err := LayoutVolume(newVol, constraints, opts)
+		pNew, err := LayoutVolume(newVol, DefaultConstraints, opts)
 		if err != nil {
 			return fmt.Errorf("cannot lay out the new volume %s: %v", volName, err)
 		}

--- a/gadget/update_test.go
+++ b/gadget/update_test.go
@@ -4308,7 +4308,7 @@ func (u *updateTestSuite) TestBuildNewVolumeToDeviceMappingImplicitSystemBootMul
 
 	opts := &gadget.LayoutOptions{GadgetRootDir: gadgetRoot}
 	for volName, vol := range info.Volumes {
-		lvol, err := gadget.LayoutVolume(vol, opts, constraints)
+		lvol, err := gadget.LayoutVolume(vol, constraints, opts)
 		c.Assert(err, IsNil)
 		allLaidOutVolumes[volName] = lvol
 	}

--- a/gadget/update_test.go
+++ b/gadget/update_test.go
@@ -4306,8 +4306,9 @@ func (u *updateTestSuite) TestBuildNewVolumeToDeviceMappingImplicitSystemBootMul
 
 	allLaidOutVolumes := map[string]*gadget.LaidOutVolume{}
 
+	opts := &gadget.LayoutOptions{GadgetRootDir: gadgetRoot}
 	for volName, vol := range info.Volumes {
-		lvol, err := gadget.LayoutVolume(gadgetRoot, "", vol, constraints)
+		lvol, err := gadget.LayoutVolume(vol, opts, constraints)
 		c.Assert(err, IsNil)
 		allLaidOutVolumes[volName] = lvol
 	}

--- a/gadget/validate.go
+++ b/gadget/validate.go
@@ -390,7 +390,7 @@ func ValidateContent(info *Info, gadgetSnapRootDir, kernelSnapRootDir string) er
 			GadgetRootDir: gadgetSnapRootDir,
 			KernelRootDir: kernelSnapRootDir,
 		}
-		lv, err := LayoutVolume(vol, opts, constraints)
+		lv, err := LayoutVolume(vol, constraints, opts)
 		if err != nil {
 			return fmt.Errorf("invalid layout of volume %q: %v", name, err)
 		}

--- a/gadget/validate.go
+++ b/gadget/validate.go
@@ -386,7 +386,11 @@ func ValidateContent(info *Info, gadgetSnapRootDir, kernelSnapRootDir string) er
 		if kernelSnapRootDir == "" {
 			constraints.SkipResolveContent = true
 		}
-		lv, err := LayoutVolume(gadgetSnapRootDir, kernelSnapRootDir, vol, constraints)
+		opts := &LayoutOptions{
+			GadgetRootDir: gadgetSnapRootDir,
+			KernelRootDir: kernelSnapRootDir,
+		}
+		lv, err := LayoutVolume(vol, opts, constraints)
 		if err != nil {
 			return fmt.Errorf("invalid layout of volume %q: %v", name, err)
 		}

--- a/gadget/validate.go
+++ b/gadget/validate.go
@@ -380,17 +380,16 @@ func ValidateContent(info *Info, gadgetSnapRootDir, kernelSnapRootDir string) er
 	// the gadget uses and as such there cannot be more than one
 	// such bootloader
 	for name, vol := range info.Volumes {
-		constraints := DefaultConstraints
-		// At this point we may not know what kernel will be used
-		// with the gadget yet. Skip this check in this case.
-		if kernelSnapRootDir == "" {
-			constraints.SkipResolveContent = true
-		}
 		opts := &LayoutOptions{
 			GadgetRootDir: gadgetSnapRootDir,
 			KernelRootDir: kernelSnapRootDir,
 		}
-		lv, err := LayoutVolume(vol, constraints, opts)
+		// At this point we may not know what kernel will be used
+		// with the gadget yet. Skip this check in this case.
+		if kernelSnapRootDir == "" {
+			opts.SkipResolveContent = true
+		}
+		lv, err := LayoutVolume(vol, DefaultConstraints, opts)
 		if err != nil {
 			return fmt.Errorf("invalid layout of volume %q: %v", name, err)
 		}

--- a/image/helpers.go
+++ b/image/helpers.go
@@ -85,8 +85,12 @@ func writeResolvedContentImpl(prepareDir string, info *gadget.Info, gadgetUnpack
 	}
 	targetDir := filepath.Join(fullPrepareDir, "resolved-content")
 
+	opts := &gadget.LayoutOptions{
+		GadgetRootDir: gadgetUnpackDir,
+		KernelRootDir: kernelUnpackDir,
+	}
 	for volName, vol := range info.Volumes {
-		pvol, err := gadget.LayoutVolume(gadgetUnpackDir, kernelUnpackDir, vol, gadget.DefaultConstraints)
+		pvol, err := gadget.LayoutVolume(vol, opts, gadget.DefaultConstraints)
 		if err != nil {
 			return err
 		}

--- a/image/helpers.go
+++ b/image/helpers.go
@@ -90,7 +90,7 @@ func writeResolvedContentImpl(prepareDir string, info *gadget.Info, gadgetUnpack
 		KernelRootDir: kernelUnpackDir,
 	}
 	for volName, vol := range info.Volumes {
-		pvol, err := gadget.LayoutVolume(vol, opts, gadget.DefaultConstraints)
+		pvol, err := gadget.LayoutVolume(vol, gadget.DefaultConstraints, opts)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This commit refactors the gadget code a bit to make the helpers more suitable for use from an installer.

To see how this is used check https://github.com/snapcore/snapd/pull/12176