### PR TITLE
boot,image: make mode an argument for MakeBootableImage

### DIFF
--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -64,7 +64,7 @@ type BootableSet struct {
 // from UC20 install mode.
 // For a UC20 image a set of boot flags that will be set in the recovery
 // boot environment can be specified.
-func MakeBootableImage(model *asserts.Model, rootdir string, bootWith *BootableSet, bootFlags []string) error {
+func MakeBootableImage(model *asserts.Model, rootdir string, bootWith *BootableSet, recoveryMode string, bootFlags []string) error {
 	if model.Grade() == asserts.ModelGradeUnset {
 		if len(bootFlags) != 0 {
 			return fmt.Errorf("no boot flags support for UC16/18")
@@ -75,7 +75,7 @@ func MakeBootableImage(model *asserts.Model, rootdir string, bootWith *BootableS
 	if !bootWith.Recovery {
 		return fmt.Errorf("internal error: MakeBootableImage called at runtime, use MakeRunnableSystem instead")
 	}
-	return makeBootable20(rootdir, bootWith, bootFlags)
+	return makeBootable20(rootdir, bootWith, recoveryMode, bootFlags)
 }
 
 // makeBootable16 setups the image filesystem for boot with UC16
@@ -155,7 +155,7 @@ func makeBootable16(model *asserts.Model, rootdir string, bootWith *BootableSet)
 	return nil
 }
 
-func makeBootable20(rootdir string, bootWith *BootableSet, bootFlags []string) error {
+func makeBootable20(rootdir string, bootWith *BootableSet, recoveryMode string, bootFlags []string) error {
 	// we can only make a single recovery system bootable right now
 	recoverySystems, err := filepath.Glob(filepath.Join(rootdir, "systems/*"))
 	if err != nil {
@@ -201,7 +201,7 @@ func makeBootable20(rootdir string, bootWith *BootableSet, bootFlags []string) e
 	// ubuntu-seed
 	blVars["snapd_recovery_system"] = bootWith.RecoverySystemLabel
 	// always set the mode as install
-	blVars["snapd_recovery_mode"] = ModeInstall
+	blVars["snapd_recovery_mode"] = recoveryMode
 	if err := bl.SetBootVars(blVars); err != nil {
 		return fmt.Errorf("cannot set recovery environment: %v", err)
 	}

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -124,7 +124,7 @@ version: 4.0
 		UnpackedGadgetDir: unpackedGadgetDir,
 	}
 
-	err = boot.MakeBootableImage(model, s.rootdir, bootWith, nil)
+	err = boot.MakeBootableImage(model, s.rootdir, bootWith, boot.ModeInstall, nil)
 	c.Assert(err, IsNil)
 
 	// check the bootloader config
@@ -237,7 +237,7 @@ version: 5.0
 		Recovery:            true,
 	}
 
-	err = boot.MakeBootableImage(model, s.rootdir, bootWith, nil)
+	err = boot.MakeBootableImage(model, s.rootdir, bootWith, boot.ModeInstall, nil)
 	c.Assert(err, IsNil)
 
 	// ensure only a single file got copied (the grub.cfg)
@@ -256,6 +256,7 @@ version: 5.0
 	seedGenv := grubenv.NewEnv(filepath.Join(s.rootdir, "EFI/ubuntu/grubenv"))
 	c.Assert(seedGenv.Load(), IsNil)
 	c.Check(seedGenv.Get("snapd_recovery_system"), Equals, label)
+	c.Check(seedGenv.Get("snapd_recovery_mode"), Equals, boot.ModeInstall)
 
 	systemGenv := grubenv.NewEnv(filepath.Join(s.rootdir, recoverySystemDir, "grubenv"))
 	c.Assert(systemGenv.Load(), IsNil)
@@ -314,13 +315,14 @@ version: 5.0
 	}
 	bootFlags := []string{"factory"}
 
-	err = boot.MakeBootableImage(model, s.rootdir, bootWith, bootFlags)
+	err = boot.MakeBootableImage(model, s.rootdir, bootWith, boot.ModeInstall, bootFlags)
 	c.Assert(err, IsNil)
 
 	// ensure the correct recovery system configuration was set
 	seedGenv := grubenv.NewEnv(filepath.Join(s.rootdir, "EFI/ubuntu/grubenv"))
 	c.Assert(seedGenv.Load(), IsNil)
 	c.Check(seedGenv.Get("snapd_recovery_system"), Equals, label)
+	c.Check(seedGenv.Get("snapd_recovery_mode"), Equals, boot.ModeInstall)
 	c.Check(seedGenv.Get("snapd_boot_flags"), Equals, "factory")
 
 	systemGenv := grubenv.NewEnv(filepath.Join(s.rootdir, recoverySystemDir, "grubenv"))
@@ -376,7 +378,7 @@ version: 5.0
 		Recovery:            true,
 	}
 
-	err = boot.MakeBootableImage(model, s.rootdir, bootWith, nil)
+	err = boot.MakeBootableImage(model, s.rootdir, bootWith, boot.ModeInstall, nil)
 	if errMsg != "" {
 		c.Assert(err, ErrorMatches, errMsg)
 		return
@@ -391,6 +393,7 @@ version: 5.0
 	systemGenv := grubenv.NewEnv(filepath.Join(s.rootdir, recoverySystemDir, "grubenv"))
 	c.Assert(systemGenv.Load(), IsNil)
 	c.Check(systemGenv.Get("snapd_recovery_kernel"), Equals, "/snaps/pc-kernel_5.snap")
+	c.Check(seedGenv.Get("snapd_recovery_mode"), Equals, boot.ModeInstall)
 	switch whichFile {
 	case "cmdline.extra":
 		c.Check(systemGenv.Get("snapd_extra_cmdline_args"), Equals, content)
@@ -433,7 +436,7 @@ func (s *makeBootable20Suite) TestMakeBootableImage20UnsetRecoverySystemLabelErr
 		Recovery:          true,
 	}
 
-	err = boot.MakeBootableImage(model, s.rootdir, bootWith, nil)
+	err = boot.MakeBootableImage(model, s.rootdir, bootWith, boot.ModeInstall, nil)
 	c.Assert(err, ErrorMatches, "internal error: recovery system label unset")
 }
 
@@ -446,7 +449,7 @@ func (s *makeBootable20Suite) TestMakeBootableImage20MultipleRecoverySystemsErro
 	err = os.MkdirAll(filepath.Join(s.rootdir, "systems/20191205"), 0755)
 	c.Assert(err, IsNil)
 
-	err = boot.MakeBootableImage(model, s.rootdir, bootWith, nil)
+	err = boot.MakeBootableImage(model, s.rootdir, bootWith, boot.ModeInstall, nil)
 	c.Assert(err, ErrorMatches, "cannot make multiple recovery systems bootable yet")
 }
 
@@ -1500,7 +1503,7 @@ version: 5.0
 	}
 
 	// TODO:UC20: enable this use case
-	err = boot.MakeBootableImage(model, s.rootdir, bootWith, nil)
+	err = boot.MakeBootableImage(model, s.rootdir, bootWith, boot.ModeInstall, nil)
 	c.Assert(err, ErrorMatches, `non-empty uboot.env not supported on UC20\+ yet`)
 }
 
@@ -1550,7 +1553,7 @@ version: 5.0
 		Recovery:            true,
 	}
 
-	err = boot.MakeBootableImage(model, s.rootdir, bootWith, nil)
+	err = boot.MakeBootableImage(model, s.rootdir, bootWith, boot.ModeInstall, nil)
 	c.Assert(err, IsNil)
 
 	// since uboot.conf was absent, we won't have installed the uboot.env, as

--- a/image/image_linux.go
+++ b/image/image_linux.go
@@ -585,7 +585,7 @@ var setupSeed = func(tsto *tooling.ToolingStore, model *asserts.Model, opts *Opt
 		return err
 	}
 
-	if err := boot.MakeBootableImage(model, bootRootDir, bootWith, opts.Customizations.BootFlags); err != nil {
+	if err := boot.MakeBootableImage(model, bootRootDir, bootWith, boot.ModeInstall, opts.Customizations.BootFlags); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
MakeBootableImage always assumed that the mode would be "install" as it was used when creating images, but we need to make it configurable so we can handle installations on a device that will write mode "run" in the bootloader configuration.
