### PR TITLE
many: add todos discussed in the review in tests/nested/manual/fde-on-classic, snapstate cleanups

### DIFF
--- a/overlord/snapstate/policy.go
+++ b/overlord/snapstate/policy.go
@@ -48,8 +48,6 @@ func isCoreBootDevice(st *state.State) (bool, error) {
 			return false, err
 		}
 		return false, nil
-	} else {
-		return deviceCtx.IsCoreBoot(), nil
 	}
-
+	return deviceCtx.IsCoreBoot(), nil
 }

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -473,13 +473,13 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 	}
 
 	if isCoreBoot && (snapsup.Type == snap.TypeGadget || (snapsup.Type == snap.TypeKernel && !TestingLeaveOutKernelUpdateGadgetAssets)) {
-		// XXX: gadget update currently for core systems only
+		// gadget update currently for core boot systems only
 		gadgetUpdate := st.NewTask("update-gadget-assets", fmt.Sprintf(i18n.G("Update assets from %s %q%s"), snapsup.Type, snapsup.InstanceName(), revisionStr))
 		addTask(gadgetUpdate)
 		prev = gadgetUpdate
 	}
 	if isCoreBoot && snapsup.Type == snap.TypeGadget {
-		// kernel command line from gadget is for core systems only
+		// kernel command line from gadget is for core boot systems only
 		gadgetCmdline := st.NewTask("update-gadget-cmdline", fmt.Sprintf(i18n.G("Update kernel command line from gadget %q%s"), snapsup.InstanceName(), revisionStr))
 		addTask(gadgetCmdline)
 		prev = gadgetCmdline

--- a/tests/nested/manual/fde-on-classic/gadget.yaml
+++ b/tests/nested/manual/fde-on-classic/gadget.yaml
@@ -23,6 +23,7 @@ volumes:
         filesystem: vfat
         # UEFI will boot the ESP partition by default first
         type: EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+        # TODO make this realistically smaller?
         size: 99M
         update:
           edition: 2
@@ -45,6 +46,8 @@ volumes:
           - source: shim.efi.signed
             target: EFI/boot/bootx64.efi
       - name: ubuntu-save
+        # XXX this makes snap pack unhappy ATM!
+        # role: system-save
         filesystem: ext4
         type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
         size: 16M

--- a/tests/nested/manual/fde-on-classic/mk-image.sh
+++ b/tests/nested/manual/fde-on-classic/mk-image.sh
@@ -145,6 +145,7 @@ EOF
     sudo cp modeenv "$DESTDIR"/var/lib/snapd/
     # needed from the beginning in ubuntu-data as these are mounted by snap-bootstrap
     # (UC also has base here, but we do not mount it from initramfs in classic)
+    # TODO use prepare-image --classic for this
     sudo mkdir -p "$DESTDIR"/var/lib/snapd/snaps/
     sudo cp "${SNAP_P[kernel]}" "${SNAP_P[gadget]}" \
          "$DESTDIR"/var/lib/snapd/snaps/

--- a/tests/nested/manual/fde-on-classic/replace-image-files.sh
+++ b/tests/nested/manual/fde-on-classic/replace-image-files.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -exu
 
 replace_initramfs_bits() {
+    # TODO is there code to share with uc20_build_initramfs_kernel_snap in prepare.sh?
     KERNEL_EFI_ORIG="$CACHE_DIR"/snap-pc-kernel/kernel.efi
     if [ ! -d initrd ]; then
         objcopy -O binary -j .initrd "$KERNEL_EFI_ORIG" initrd.img
@@ -57,6 +58,7 @@ main() {
 
     # copy kernel.efi with modified initramfs
     subpath=$(readlink "$MNT"/ubuntu-boot/EFI/ubuntu/kernel.efi)
+    # TODO we should also repack kernel snap and replace the one in the rootfs too, and also re-sign
     cp -a "$CACHE_DIR"/snap-pc-kernel/kernel.efi "$MNT"/ubuntu-boot/EFI/ubuntu/"$subpath"
 
     # replace snapd in data partition with the one compiled in the test

--- a/tests/nested/manual/fde-on-classic/task.yaml
+++ b/tests/nested/manual/fde-on-classic/task.yaml
@@ -24,7 +24,6 @@ prepare: |
   # run outside of spread easily for quick interactive testing
   ./mk-image.sh ./boot.img "$CACHE_D" "./mnt" ./pc_x1.snap
   # replaces snap-bootstrap in initramfs and snapd in rootfs
-  # TODO chroot install of deb? /home/gopath/src/github.com/snapcore/snapd_*_amd64.deb
   ./replace-image-files.sh ./boot.img "$CACHE_D"
   # We will need yq
   snap install yq


### PR DESCRIPTION
this is a follow up to #12174, see the comments there.

The prepare-image and snap pack issues are probably the most important TODOs. They merit dedicated attention. This PR just tries to leave trace in the code of the comments in the original PR.
