### PR TITLE
autorefresh: snapd refresh awareness ux implementation refresh available hook

### DIFF
--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -615,7 +615,7 @@ func inhibitRefresh(st *state.State, snapst *SnapState, info *snap.Info, checker
 		}
 	}
 
-	refreshInfo.HooksDirectory = info.HooksDir()
+	refreshInfo.UserHooksDirectory = info.UserHooksDir()
 
 	// Decide on what to do depending on the state of the snap and the remaining
 	// inhibition time.

--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -615,6 +615,8 @@ func inhibitRefresh(st *state.State, snapst *SnapState, info *snap.Info, checker
 		}
 	}
 
+	refreshInfo.HooksDirectory = info.HooksDir()
+
 	// Decide on what to do depending on the state of the snap and the remaining
 	// inhibition time.
 	now := time.Now()

--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -615,7 +615,7 @@ func inhibitRefresh(st *state.State, snapst *SnapState, info *snap.Info, checker
 		}
 	}
 
-	refreshInfo.UserHooksDirectory = info.UserHooksDir()
+	refreshInfo.UserHooks = info.UserHooks()
 
 	// Decide on what to do depending on the state of the snap and the remaining
 	// inhibition time.

--- a/snap/info.go
+++ b/snap/info.go
@@ -581,7 +581,7 @@ func (s *Info) HooksDir() string {
 // UserHooks returns a list containing the snap's userhooks.
 func (s *Info) UserHooks() map[string]string {
 	userhooks := make(map[string]string)
-	for appName, _ := range s.Apps {
+	for appName := range s.Apps {
 		if strings.HasPrefix(appName, "userhook-") {
 			userhooks[appName[9:]] = fmt.Sprintf("%s.%s", s.InstanceName(), appName)
 		}

--- a/snap/info.go
+++ b/snap/info.go
@@ -66,9 +66,6 @@ type PlaceInfo interface {
 	// HooksDir returns the directory containing the snap's hooks.
 	HooksDir() string
 
-	// UserHooksDir returns the directory containing the snap's userhooks.
-	UserHooksDir() string
-
 	// DataDir returns the data directory of the snap.
 	DataDir() string
 
@@ -212,12 +209,6 @@ func CommonDataDir(name string) string {
 // name. The name can be either a snap name or snap instance name.
 func HooksDir(name string, revision Revision) string {
 	return filepath.Join(MountDir(name, revision), "meta", "hooks")
-}
-
-// UserHooksDir returns the directory containing the snap's userhooks for given snap
-// name. The name can be either a snap name or snap instance name.
-func UserHooksDir(name string, revision Revision) string {
-	return filepath.Join(MountDir(name, revision), "meta", "userhooks")
 }
 
 func snapDataDir(opts *dirs.SnapDirOptions) string {
@@ -587,9 +578,15 @@ func (s *Info) HooksDir() string {
 	return HooksDir(s.InstanceName(), s.Revision)
 }
 
-// UserHooksDir returns the directory containing the snap's userhooks.
-func (s *Info) UserHooksDir() string {
-	return UserHooksDir(s.InstanceName(), s.Revision)
+// UserHooks returns a list containing the snap's userhooks.
+func (s *Info) UserHooks() map[string]string {
+	userhooks := make(map[string]string)
+	for appName, _ := range s.Apps {
+		if strings.HasPrefix(appName, "userhook-") {
+			userhooks[appName[9:]] = fmt.Sprintf("%s.%s", s.InstanceName(), appName)
+		}
+	}
+	return userhooks
 }
 
 // DataDir returns the data directory of the snap.

--- a/snap/info.go
+++ b/snap/info.go
@@ -66,6 +66,9 @@ type PlaceInfo interface {
 	// HooksDir returns the directory containing the snap's hooks.
 	HooksDir() string
 
+	// UserHooksDir returns the directory containing the snap's userhooks.
+	UserHooksDir() string
+
 	// DataDir returns the data directory of the snap.
 	DataDir() string
 
@@ -209,6 +212,12 @@ func CommonDataDir(name string) string {
 // name. The name can be either a snap name or snap instance name.
 func HooksDir(name string, revision Revision) string {
 	return filepath.Join(MountDir(name, revision), "meta", "hooks")
+}
+
+// UserHooksDir returns the directory containing the snap's userhooks for given snap
+// name. The name can be either a snap name or snap instance name.
+func UserHooksDir(name string, revision Revision) string {
+	return filepath.Join(MountDir(name, revision), "meta", "userhooks")
 }
 
 func snapDataDir(opts *dirs.SnapDirOptions) string {
@@ -576,6 +585,11 @@ func (s *Info) MountFile() string {
 // HooksDir returns the directory containing the snap's hooks.
 func (s *Info) HooksDir() string {
 	return HooksDir(s.InstanceName(), s.Revision)
+}
+
+// UserHooksDir returns the directory containing the snap's userhooks.
+func (s *Info) UserHooksDir() string {
+	return UserHooksDir(s.InstanceName(), s.Revision)
 }
 
 // DataDir returns the data directory of the snap.

--- a/usersession/agent/rest_api.go
+++ b/usersession/agent/rest_api.go
@@ -24,11 +24,10 @@ import (
 	"fmt"
 	"mime"
 	"net/http"
-	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/mvo5/goconfigparser"
@@ -236,8 +235,10 @@ func postPendingRefreshNotification(c *Command, r *http.Request) Response {
 
 	// If there exists a "refresh-available" userhook, call it instead of showing a notification
 	if command := refreshInfo.UserHooks["refresh-available"]; command != "" {
-		argv := []string{"snap", "run", command}
-		syscall.Exec("/proc/self/exe", argv, os.Environ())
+		go func() {
+			cmd := exec.Command("snap", "run", command)
+			cmd.Run()
+		}()
 		return SyncResponse(nil)
 	}
 

--- a/usersession/agent/rest_api.go
+++ b/usersession/agent/rest_api.go
@@ -35,6 +35,7 @@ import (
 	"github.com/snapcore/snapd/desktop/notification"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/systemd"
 	"github.com/snapcore/snapd/usersession/client"
 )
@@ -236,6 +237,11 @@ func postPendingRefreshNotification(c *Command, r *http.Request) Response {
 	// If there exists a "refresh-available" userhook, call it instead of showing a notification
 	if command := refreshInfo.UserHooks["refresh-available"]; command != "" {
 		go func() {
+			defer func() {
+				if e := recover(); e != nil {
+					logger.Debugf("Recovered from panic while calling 'refresh-available' userhook for %s", command)
+				}
+			}()
 			cmd := exec.Command("snap", "run", command)
 			cmd.Run()
 		}()

--- a/usersession/agent/rest_api.go
+++ b/usersession/agent/rest_api.go
@@ -237,12 +237,14 @@ func postPendingRefreshNotification(c *Command, r *http.Request) Response {
 	}
 
 	// If there exists a "refresh-available" hook, call it instead of showing a notification
-	if refreshInfo.HooksDirectory != "" {
-		hookPath := path.Join(refreshInfo.HooksDirectory, "refresh-available")
+	if refreshInfo.UserHooksDirectory != "" {
+		hookPath := path.Join(refreshInfo.UserHooksDirectory, "refresh-available")
 		_, err := os.Stat(hookPath)
 		if !errors.Is(err, os.ErrNotExist) {
-			cmd := exec.Command(hookPath)
-			if cmd.Run() == nil {
+			command := fmt.Sprintf("%s.userhook-refresh-available", refreshInfo.InstanceName)
+			cmd := exec.Command("snap", "run", command)
+			retval := cmd.Run()
+			if retval == nil {
 				return SyncResponse(nil)
 			}
 		}

--- a/usersession/agent/rest_api.go
+++ b/usersession/agent/rest_api.go
@@ -26,11 +26,11 @@ import (
 	"mime"
 	"net/http"
 	"os"
-	"os/exec"
 	"path"
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/mvo5/goconfigparser"
@@ -242,11 +242,9 @@ func postPendingRefreshNotification(c *Command, r *http.Request) Response {
 		_, err := os.Stat(hookPath)
 		if !errors.Is(err, os.ErrNotExist) {
 			command := fmt.Sprintf("%s.userhook-refresh-available", refreshInfo.InstanceName)
-			cmd := exec.Command("snap", "run", command)
-			retval := cmd.Run()
-			if retval == nil {
-				return SyncResponse(nil)
-			}
+			argv := []string{"snap", "run", command}
+			syscall.Exec("/proc/self/exe", argv, os.Environ())
+			return SyncResponse(nil)
 		}
 	}
 

--- a/usersession/client/client.go
+++ b/usersession/client/client.go
@@ -313,7 +313,7 @@ type PendingSnapRefreshInfo struct {
 	TimeRemaining       time.Duration `json:"time-remaining,omitempty"`
 	BusyAppName         string        `json:"busy-app-name,omitempty"`
 	BusyAppDesktopEntry string        `json:"busy-app-desktop-entry,omitempty"`
-	HooksDirectory      string        `json:"busy-app-hooks-directory,omitempty"`
+	UserHooksDirectory  string        `json:"busy-app-user-hooks-directory,omitempty"`
 }
 
 // PendingRefreshNotification broadcasts information about a refresh.

--- a/usersession/client/client.go
+++ b/usersession/client/client.go
@@ -313,6 +313,7 @@ type PendingSnapRefreshInfo struct {
 	TimeRemaining       time.Duration `json:"time-remaining,omitempty"`
 	BusyAppName         string        `json:"busy-app-name,omitempty"`
 	BusyAppDesktopEntry string        `json:"busy-app-desktop-entry,omitempty"`
+	HooksDirectory      string        `json:"busy-app-hooks-directory,omitempty"`
 }
 
 // PendingRefreshNotification broadcasts information about a refresh.

--- a/usersession/client/client.go
+++ b/usersession/client/client.go
@@ -309,11 +309,11 @@ func (client *Client) ServicesStop(ctx context.Context, services []string) (stop
 
 // PendingSnapRefreshInfo holds information about pending snap refresh provided to userd.
 type PendingSnapRefreshInfo struct {
-	InstanceName        string        `json:"instance-name"`
-	TimeRemaining       time.Duration `json:"time-remaining,omitempty"`
-	BusyAppName         string        `json:"busy-app-name,omitempty"`
-	BusyAppDesktopEntry string        `json:"busy-app-desktop-entry,omitempty"`
-	UserHooksDirectory  string        `json:"busy-app-user-hooks-directory,omitempty"`
+	InstanceName        string            `json:"instance-name"`
+	TimeRemaining       time.Duration     `json:"time-remaining,omitempty"`
+	BusyAppName         string            `json:"busy-app-name,omitempty"`
+	BusyAppDesktopEntry string            `json:"busy-app-desktop-entry,omitempty"`
+	UserHooks           map[string]string `json:"busy-app-user-hooks,omitempty"`
 }
 
 // PendingRefreshNotification broadcasts information about a refresh.


### PR DESCRIPTION
Implements an "user hook" called "refresh-available". This "user hook" is called as a user program, and must be defined in the snap's YAML file as an app entry with the name "userhook-refresh-available".

THIS IS STILL A DRAFT!!! This code is only a proof-of-concept to help discuss possible implementations for SD136.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
