### PR TITLE
seccomp: allow opening XDP sockets

### DIFF
--- a/cmd/snap-seccomp/main.go
+++ b/cmd/snap-seccomp/main.go
@@ -74,6 +74,11 @@ package main
 //#define PF_QIPCRTR AF_QIPCRTR
 //#endif				// AF_QIPCRTR
 //
+//#ifndef AF_XDP
+//#define AF_XDP 42
+//#define PF_XDP AF_XDP
+//#endif				// AF_XDP
+//
 // // https://github.com/sctplab/usrsctp/blob/master/usrsctplib/usrsctp.h
 //#ifndef AF_CONN
 //#define AF_CONN 123
@@ -286,6 +291,8 @@ var seccompResolver = map[string]uint64{
 	"PF_CONN":    C.PF_CONN,
 	"AF_QIPCRTR": C.AF_QIPCRTR, // 42
 	"PF_QIPCRTR": C.PF_QIPCRTR,
+	"AF_XDP":     C.AF_XDP, // 44
+	"PF_XDP":     C.PF_XDP,
 
 	// man 2 socket - type
 	"SOCK_STREAM":    syscall.SOCK_STREAM,

--- a/interfaces/seccomp/template.go
+++ b/interfaces/seccomp/template.go
@@ -444,6 +444,7 @@ socket AF_LOCAL
 socket AF_INET
 socket AF_INET6
 socket AF_IPX
+socket AF_XDP
 socket AF_X25
 socket AF_AX25
 socket AF_ATMPVC


### PR DESCRIPTION
This is the first step to allow applications to open AF_XDP sockets. This change is limited to SecComp and is not enough to deliver the XDP functionality. Two more obstables remain:

1) AppArmor: profiles need to have the rule `network xdp,`
2) Capabilities: the net_raw capability is needed to use XDP

This change basically just registers the XDP protocol as allowed in the BPF profile of a snap.

From: https://bugs.launchpad.net/bugs/1990827

I could add the missing bit to this branch, too, if we know which interface should provide access to this protocol.