### PR TITLE
fde: run fde-reveal-key with `DefaultDependencies=no`

### DIFF
--- a/kernel/fde/cmd_helper.go
+++ b/kernel/fde/cmd_helper.go
@@ -97,6 +97,9 @@ func runFDEinitramfsHelper(name string, stdin []byte) (output []byte, err error)
 		// making sure that people using the hook know that we do not
 		// want them to mess around outside of just providing unseal.
 		"--property=SystemCallFilter=~@mount",
+		// We do not need any systemd unit dependencies for this
+		// call.
+		"--property=DefaultDependencies=no",
 		// WORKAROUNDS
 		// workaround the lack of "--pipe"
 		fmt.Sprintf("--property=StandardInput=file:%s/%s.stdin", runDir, name),

--- a/kernel/fde/fde_test.go
+++ b/kernel/fde/fde_test.go
@@ -516,6 +516,7 @@ func (s *fdeSuite) TestRevealErr(c *C) {
 			"systemd-run", "--collect", "--service-type=exec", "--quiet",
 			"--property=RuntimeMaxSec=2m0s",
 			"--property=SystemCallFilter=~@mount",
+			"--property=DefaultDependencies=no",
 			fmt.Sprintf("--property=StandardInput=file:%s/run/fde-reveal-key/fde-reveal-key.stdin", root),
 			fmt.Sprintf("--property=StandardOutput=file:%s/run/fde-reveal-key/fde-reveal-key.stdout", root),
 			fmt.Sprintf("--property=StandardError=file:%s/run/fde-reveal-key/fde-reveal-key.stderr", root),


### PR DESCRIPTION
We hit an issue in initrd where the basic.target had an implicit dependency on the snap-intiramfs-mounts unit. Part of snap-initramfs-mounts is to use `systemd-run` to run `fde-reveal-key`, without this `snap-initramfs-mounts` cannot complete. So this situation lead to a deadlock and an unbootable system.

While this is getting fixed in initrd the fde-reveal-key code should also be more robust and not hang like this. So this commits adds `--property=DefaultDependencies=no` which will avoid that fde-reveal-key needs basic.target to run.

This should fix the failure in the core22 `fde-reveal-test`  test.