### PR TITLE
interfaces: add microceph interface

### DIFF
--- a/interfaces/builtin/microceph.go
+++ b/interfaces/builtin/microceph.go
@@ -1,0 +1,51 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+const microcephSummary = `allows access to the MicroCeph socket`
+
+const microcephBaseDeclarationSlots = `
+  microceph:
+    allow-installation: false
+    deny-connection: true
+    deny-auto-connection: true
+`
+
+const microcephConnectedPlugAppArmor = `
+# Description: allow access to the MicroCeph control socket.
+
+/var/snap/microceph/common/state/control.socket rw,
+`
+
+const microcephConnectedPlugSecComp = `
+# Description: allow access to the MicroCeph control socket.
+
+socket AF_NETLINK - NETLINK_GENERIC
+`
+
+func init() {
+	registerIface(&commonInterface{
+		name:                  "microceph",
+		summary:               microcephSummary,
+		baseDeclarationSlots:  microcephBaseDeclarationSlots,
+		connectedPlugAppArmor: microcephConnectedPlugAppArmor,
+		connectedPlugSecComp:  microcephConnectedPlugSecComp,
+	})
+}

--- a/interfaces/builtin/microceph_test.go
+++ b/interfaces/builtin/microceph_test.go
@@ -1,0 +1,111 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/interfaces/seccomp"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type MicroCephInterfaceSuite struct {
+	iface    interfaces.Interface
+	slotInfo *snap.SlotInfo
+	slot     *interfaces.ConnectedSlot
+	plugInfo *snap.PlugInfo
+	plug     *interfaces.ConnectedPlug
+}
+
+var _ = Suite(&MicroCephInterfaceSuite{
+	iface: builtin.MustInterface("microceph"),
+})
+
+const microcephConsumerYaml = `name: consumer
+version: 0
+apps:
+ app:
+  plugs: [microceph]
+`
+
+const microcephCoreYaml = `name: core
+version: 0
+type: os
+slots:
+  microceph:
+`
+
+func (s *MicroCephInterfaceSuite) SetUpTest(c *C) {
+	s.plug, s.plugInfo = MockConnectedPlug(c, microcephConsumerYaml, nil, "microceph")
+	s.slot, s.slotInfo = MockConnectedSlot(c, microcephCoreYaml, nil, "microceph")
+}
+
+func (s *MicroCephInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "microceph")
+}
+
+func (s *MicroCephInterfaceSuite) TestSanitizeSlot(c *C) {
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.slotInfo), IsNil)
+	slot := &snap.SlotInfo{
+		Snap:      &snap.Info{SuggestedName: "some-snap"},
+		Name:      "microceph",
+		Interface: "microceph",
+	}
+
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), IsNil)
+}
+
+func (s *MicroCephInterfaceSuite) TestSanitizePlug(c *C) {
+	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
+}
+
+func (s *MicroCephInterfaceSuite) TestAppArmorSpec(c *C) {
+	spec := &apparmor.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/var/snap/microceph/common/state/control.socket rw,\n")
+}
+
+func (s *MicroCephInterfaceSuite) TestSecCompSpec(c *C) {
+	spec := &seccomp.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "socket AF_NETLINK - NETLINK_GENERIC\n")
+}
+
+func (s *MicroCephInterfaceSuite) TestStaticInfo(c *C) {
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Assert(si.ImplicitOnCore, Equals, false)
+	c.Assert(si.ImplicitOnClassic, Equals, false)
+	c.Assert(si.Summary, Equals, `allows access to the MicroCeph socket`)
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "microceph")
+}
+
+func (s *MicroCephInterfaceSuite) TestAutoConnect(c *C) {
+	c.Check(s.iface.AutoConnect(nil, nil), Equals, true)
+}
+
+func (s *MicroCephInterfaceSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -835,6 +835,7 @@ var (
 		"custom-device":   nil,
 		"docker":          nil,
 		"lxd":             nil,
+		"microceph":       nil,
 		"pkcs11":          nil,
 		"posix-mq":        nil,
 		"shared-memory":   nil,
@@ -889,6 +890,12 @@ func (s *baseDeclSuite) TestSlotInstallation(c *C) {
 	err = ic.Check()
 	c.Assert(err, Not(IsNil))
 	c.Assert(err, ErrorMatches, "installation not allowed by \"lxd\" slot rule of interface \"lxd\"")
+
+	// test microceph specially
+	ic = s.installSlotCand(c, "microceph", snap.TypeApp, ``)
+	err = ic.Check()
+	c.Assert(err, Not(IsNil))
+	c.Assert(err, ErrorMatches, "installation not allowed by \"microceph\" slot rule of interface \"microceph\"")
 
 	// test shared-memory specially
 	ic = s.installSlotCand(c, "shared-memory", snap.TypeApp, ``)
@@ -995,6 +1002,7 @@ func (s *baseDeclSuite) TestConnection(c *C) {
 		"location-observe":          true,
 		"lxd":                       true,
 		"maliit":                    true,
+		"microceph":                 true,
 		"mir":                       true,
 		"online-accounts-service":   true,
 		"posix-mq":                  true,

--- a/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
@@ -266,6 +266,9 @@ apps:
   media-hub:
     command: bin/run
     plugs: [ media-hub ]
+  microceph:
+    command: bin/run
+    plugs: [ microceph ]
   microstack-support:
     command: bin/run
     plugs: [ microstack-support ]

--- a/tests/main/interfaces-many-snap-provided/test-snapd-policy-app-provider-classic/meta/snap.yaml
+++ b/tests/main/interfaces-many-snap-provided/test-snapd-policy-app-provider-classic/meta/snap.yaml
@@ -23,6 +23,7 @@ slots:
   lxd: null
   maliit: null
   media-hub: null
+  microceph: null
   mir: null
   mpris:
     name: test-policy-app-provider-classic
@@ -65,6 +66,9 @@ apps:
   media-hub:
     command: bin/run
     slots: [ media-hub ]
+  microceph:
+    command: bin/run
+    slots: [ microceph ]
   mir:
     command: bin/run
     slots: [ mir ]

--- a/tests/main/interfaces-many-snap-provided/test-snapd-policy-app-provider-core/meta/snap.yaml
+++ b/tests/main/interfaces-many-snap-provided/test-snapd-policy-app-provider-core/meta/snap.yaml
@@ -32,6 +32,7 @@ slots:
   lxd: null
   maliit: null
   media-hub: null
+  microceph: null
   mir: null
   modem-manager: null
   network-manager: null
@@ -102,6 +103,9 @@ apps:
   media-hub:
     command: bin/run
     slots: [ media-hub ]
+  microceph:
+    command: bin/run
+    slots: [ microceph ]
   mir:
     command: bin/run
     slots: [ mir ]


### PR DESCRIPTION
This interface makes it possible to control MicroCeph.

It will be used by another snap, MicroCloud to bring up MicroCeph and LXD clusters automatically.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>