### PR TITLE
overlord/ifacestate: fix conflict detection of auto-connection

### DIFF
--- a/overlord/devicestate/firstboot_preseed_test.go
+++ b/overlord/devicestate/firstboot_preseed_test.go
@@ -619,4 +619,25 @@ snaps:
 	err = st.Get("seed-time", &seedTime)
 	c.Assert(err, IsNil)
 	c.Check(seedTime.IsZero(), Equals, false)
+
+	// verify that connections was made
+	var conns map[string]interface{}
+	c.Assert(st.Get("conns", &conns), IsNil)
+	c.Assert(conns, HasLen, 2)
+
+	repo := o.InterfaceManager().Repository()
+	cn, err := repo.Connected("foo", "shared-data-plug")
+	c.Assert(err, IsNil)
+	c.Assert(cn, HasLen, 1)
+	c.Assert(cn, DeepEquals, []*interfaces.ConnRef{{
+		PlugRef: interfaces.PlugRef{Snap: "foo", Name: "shared-data-plug"},
+		SlotRef: interfaces.SlotRef{Snap: "bar", Name: "shared-data-slot"},
+	}})
+	cn, err = repo.Connected("foo", "network")
+	c.Assert(err, IsNil)
+	c.Assert(cn, HasLen, 1)
+	c.Assert(cn, DeepEquals, []*interfaces.ConnRef{{
+		PlugRef: interfaces.PlugRef{Snap: "foo", Name: "network"},
+		SlotRef: interfaces.SlotRef{Snap: "snapd", Name: "network"},
+	}})
 }

--- a/overlord/devicestate/firstboot_preseed_test.go
+++ b/overlord/devicestate/firstboot_preseed_test.go
@@ -598,7 +598,14 @@ snaps:
 
 	// Update the change pointer to the change in the new state
 	// otherwise we will be referring to the old one.
-	chg = st.Changes()[0]
+	chg = nil
+	for _, c := range st.Changes() {
+		if c.Kind() == "seed" {
+			chg = c
+			break
+		}
+	}
+	c.Assert(chg, NotNil)
 	c.Assert(chg.Err(), IsNil)
 	c.Check(chg.Status(), Equals, state.DoneStatus)
 
@@ -619,7 +626,6 @@ snaps:
 	// verify that connections was made
 	var conns map[string]interface{}
 	c.Assert(st.Get("conns", &conns), IsNil)
-	c.Assert(conns, HasLen, 2)
 	c.Assert(conns, DeepEquals, map[string]interface{}{
 		"foo:network core:network": map[string]interface{}{
 			"auto": true, "interface": "network"},

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -2199,7 +2199,6 @@ snaps:
 	// verify that connections was made
 	var conns map[string]interface{}
 	c.Assert(st.Get("conns", &conns), IsNil)
-	c.Assert(conns, HasLen, 2)
 	c.Assert(conns, DeepEquals, map[string]interface{}{
 		"foo:network snapd:network": map[string]interface{}{
 			"auto": true, "interface": "network"},

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -85,6 +85,7 @@ func (t *firstBootBaseTest) setupBaseTest(c *C, s *seedtest.SeedSnaps) {
 
 	tempdir := c.MkDir()
 	dirs.SetRootDir(tempdir)
+	c.Assert(os.MkdirAll(filepath.Dir(dirs.SnapSystemKeyFile), 0755), IsNil)
 	t.AddCleanup(func() { dirs.SetRootDir("/") })
 
 	t.AddCleanup(release.MockOnClassic(false))
@@ -2076,4 +2077,255 @@ func (s *firstBoot16Suite) TestCriticalTaskEdgesForPreseedMissing(c *C) {
 	ts.MarkEdge(t3, snapstate.HooksEdge)
 	_, _, _, err = devicestate.CriticalTaskEdges(ts)
 	c.Assert(err, NotNil)
+}
+
+func (s *firstBoot16Suite) TestPopulateFromSeedWithConnections(c *C) {
+	bloader := boottest.MockUC16Bootenv(bootloadertest.Mock("mock", c.MkDir()))
+	bootloader.Force(bloader)
+	defer bootloader.Force(nil)
+	bloader.SetBootKernel("pc-kernel_1.snap")
+	bloader.SetBootBase("core_1.snap")
+
+	// needed for preseed
+	// restore := interfaces.MockSystemKey(`{"core": "123"}`)
+	// defer restore()
+
+	coreFname, kernelFname, gadgetFname := s.makeCoreSnaps(c, "")
+	snapFiles := [][]string{
+		{"bin/bar", ``},
+	}
+
+	// put a firstboot snap into the SnapBlobDir
+	snapYaml := `name: foo
+version: 1.0
+plugs:
+ shared-data-plug:
+  interface: content
+  target: import
+  content: mylib
+apps:
+ bar:
+  command: bin/bar
+  plugs: [network]
+`
+	fooFname, fooDecl, fooRev := s.MakeAssertedSnap(c, snapYaml, snapFiles, snap.R(128), "developerid")
+	s.WriteAssertions("foo.asserts", s.devAcct, fooRev, fooDecl)
+
+	// put a 2nd firstboot snap into the SnapBlobDir
+	snapYaml = `name: bar
+version: 1.0
+slots:
+ shared-data-slot:
+  interface: content
+  content: mylib
+  read:
+   - /
+apps:
+ bar:
+  command: bin/bar
+`
+	barFname, barDecl, barRev := s.MakeAssertedSnap(c, snapYaml, snapFiles, snap.R(65), "developerid")
+	s.WriteAssertions("bar.asserts", s.devAcct, barDecl, barRev)
+
+	// add a model assertion and its chain
+	assertsChain := s.makeModelAssertionChain(c, "my-model", nil)
+	s.WriteAssertions("model.asserts", assertsChain...)
+
+	// create a seed.yaml
+	content := []byte(fmt.Sprintf(`
+snaps:
+ - name: core
+   file: %s
+ - name: pc-kernel
+   file: %s
+ - name: pc
+   file: %s
+ - name: foo
+   file: %s
+ - name: bar
+   file: %s
+`, coreFname, kernelFname, gadgetFname, fooFname, barFname))
+	err := ioutil.WriteFile(filepath.Join(dirs.SnapSeedDir, "seed.yaml"), content, 0644)
+	c.Assert(err, IsNil)
+
+	// run the firstboot stuff
+	s.startOverlord(c)
+	st := s.overlord.State()
+	st.Lock()
+	defer st.Unlock()
+
+	tsAll, err := devicestate.PopulateStateFromSeedImpl(st, nil, s.perfTimings)
+	c.Assert(err, IsNil)
+	// use the expected kind otherwise settle with start another one
+	chg := st.NewChange("seed", "run the populate from seed changes")
+	for _, ts := range tsAll {
+		chg.AddAll(ts)
+	}
+	c.Assert(st.Changes(), HasLen, 1)
+
+	// avoid device reg
+	chg1 := st.NewChange("become-operational", "init device")
+	chg1.SetStatus(state.DoingStatus)
+
+	st.Unlock()
+	err = s.overlord.Settle(settleTimeout)
+	st.Lock()
+	c.Assert(chg.Err(), IsNil)
+	c.Assert(err, IsNil)
+
+	// Visualize the task and their dependencies for debugging purposes
+	// 2: task prerequisites
+	// 3: task prepare-snap
+	// waiting for 2
+	// 4: task mount-snap
+	// waiting for 3
+	// 5: task copy-snap-data
+	// waiting for 4
+	// 6: task setup-profiles
+	// waiting for 5
+	// 7: task link-snap
+	// waiting for 6
+	// 8: task auto-connect
+	// waiting for 7
+	// 9: task set-auto-aliases
+	// waiting for 8
+	// 10: task setup-aliases
+	// waiting for 9
+	// 11: task run-hook
+	// waiting for 10
+	// 12: task start-snap-services
+	// waiting for 11
+	// 13: task prerequisites
+	// waiting for 2,3,4,5,6,7,8,9,10,11,12
+	// 14: task prepare-snap
+	// waiting for 13,2,3,4,5,6,7,8,9,10,11,12
+	// 15: task mount-snap
+	// waiting for 14,2,3,4,5,6,7,8,9,10,11,12
+	// 16: task update-gadget-assets
+	// waiting for 15,2,3,4,5,6,7,8,9,10,11,12
+	// 17: task copy-snap-data
+	// waiting for 16,2,3,4,5,6,7,8,9,10,11,12
+	// 18: task setup-profiles
+	// waiting for 17,2,3,4,5,6,7,8,9,10,11,12
+	// 19: task link-snap
+	// waiting for 18,2,3,4,5,6,7,8,9,10,11,12
+	// 20: task auto-connect
+	// waiting for 19,2,3,4,5,6,7,8,9,10,11,12
+	// 21: task set-auto-aliases
+	// waiting for 20,2,3,4,5,6,7,8,9,10,11,12
+	// 22: task setup-aliases
+	// waiting for 21,2,3,4,5,6,7,8,9,10,11,12
+	// 23: task run-hook
+	// waiting for 22,2,3,4,5,6,7,8,9,10,11,12
+	// 24: task start-snap-services
+	// waiting for 23,2,3,4,5,6,7,8,9,10,11,12
+	// 26: task prerequisites
+	// waiting for 13,14,15,16,17,18,19,20,21,22,23,24
+	// 27: task prepare-snap
+	// waiting for 26,13,14,15,16,17,18,19,20,21,22,23,24
+	// 28: task mount-snap
+	// waiting for 27,13,14,15,16,17,18,19,20,21,22,23,24
+	// 29: task update-gadget-assets
+	// waiting for 28,13,14,15,16,17,18,19,20,21,22,23,24
+	// 30: task update-gadget-cmdline
+	// waiting for 29,13,14,15,16,17,18,19,20,21,22,23,24
+	// 31: task copy-snap-data
+	// waiting for 30,13,14,15,16,17,18,19,20,21,22,23,24
+	// 32: task setup-profiles
+	// waiting for 31,13,14,15,16,17,18,19,20,21,22,23,24
+	// 33: task link-snap
+	// waiting for 32,13,14,15,16,17,18,19,20,21,22,23,24
+	// 34: task auto-connect
+	// waiting for 33,13,14,15,16,17,18,19,20,21,22,23,24
+	// 35: task set-auto-aliases
+	// waiting for 34,13,14,15,16,17,18,19,20,21,22,23,24
+	// 36: task setup-aliases
+	// waiting for 35,13,14,15,16,17,18,19,20,21,22,23,24
+	// 37: task run-hook
+	// waiting for 36,13,14,15,16,17,18,19,20,21,22,23,24
+	// 38: task start-snap-services
+	// waiting for 37,13,14,15,16,17,18,19,20,21,22,23,24
+	// 1: task run-hook
+	// waiting for 26,27,28,29,30,31,32,33,34,35,36,37,38
+	// 25: task run-hook
+	// waiting for 1
+	// 39: task run-hook
+	// waiting for 25
+	// 40: task prerequisites
+	// waiting for 39
+	// 41: task prepare-snap
+	// waiting for 40,39
+	// 42: task mount-snap
+	// waiting for 41,39
+	// 43: task copy-snap-data
+	// waiting for 42,39
+	// 44: task setup-profiles
+	// waiting for 43,39
+	// 45: task link-snap
+	// waiting for 44,39
+	// 46: task auto-connect
+	// waiting for 45,39
+	// 47: task set-auto-aliases
+	// waiting for 46,39,68,67
+	// 48: task setup-aliases
+	// waiting for 47,39
+	// 49: task run-hook
+	// waiting for 48,39
+	// 50: task start-snap-services
+	// waiting for 49,39
+	// 51: task run-hook
+	// waiting for 40,41,42,43,44,45,46,47,48,49,50,39,68,67
+	// 52: task run-hook
+	// waiting for 40,41,42,43,44,45,46,47,48,49,50,51,39,68,67
+	// 53: task prerequisites
+	// waiting for 40,41,42,43,44,45,46,47,48,49,50,51,52,68,67
+	// 54: task prepare-snap
+	// waiting for 53,40,41,42,43,44,45,46,47,48,49,50,51,52,68,67
+	// 55: task mount-snap
+	// waiting for 54,40,41,42,43,44,45,46,47,48,49,50,51,52,68,67
+	// 56: task copy-snap-data
+	// waiting for 55,40,41,42,43,44,45,46,47,48,49,50,51,52,68,67
+	// 57: task setup-profiles
+	// waiting for 56,40,41,42,43,44,45,46,47,48,49,50,51,52,68,67
+	// 58: task link-snap
+	// waiting for 57,40,41,42,43,44,45,46,47,48,49,50,51,52,68,67
+	// 59: task auto-connect
+	// waiting for 58,40,41,42,43,44,45,46,47,48,49,50,51,52,68,67
+	// 60: task set-auto-aliases
+	// waiting for 59,40,41,42,43,44,45,46,47,48,49,50,51,52,68,67,70,69
+	// 61: task setup-aliases
+	// waiting for 60,40,41,42,43,44,45,46,47,48,49,50,51,52,68,67
+	// 62: task run-hook
+	// waiting for 61,40,41,42,43,44,45,46,47,48,49,50,51,52,68,67
+	// 63: task start-snap-services
+	// waiting for 62,40,41,42,43,44,45,46,47,48,49,50,51,52,68,67
+	// 64: task run-hook
+	// waiting for 53,54,55,56,57,58,59,60,61,62,63,40,41,42,43,44,45,46,47,48,49,50,51,52,68,67,70,69
+	// 65: task run-hook
+	// waiting for 53,54,55,56,57,58,59,60,61,62,63,64,40,41,42,43,44,45,46,47,48,49,50,51,52,68,67,70,69
+	// 66: task mark-seeded
+	// waiting for 53,54,55,56,57,58,59,60,61,62,63,64,65,70,69
+	// 68: task connect
+	// waiting for 46
+	// 67: task setup-profiles
+	// waiting for 68,46
+	// 70: task connect
+	// waiting for 59
+	// 69: task setup-profiles
+	// waiting for 70,59
+
+	//tasks := chg.Tasks()
+	//for _, tsk := range tasks {
+	//	log.Printf("%s: task %s", tsk.ID(), tsk.Kind())
+	//	if len(tsk.WaitTasks()) > 0 {
+	//		var ids []string
+	//		for _, wtsk := range tsk.WaitTasks() {
+	//			ids = append(ids, wtsk.ID())
+	//		}
+	//		log.Printf("waiting for %s", strings.Join(ids, ","))
+	//	}
+	//	if len(tsk.Log()) > 0 {
+	//		log.Printf("logs: %v", tsk.Log())
+	//	}
+	//}
 }

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/snapcore/snapd/bootloader/bootloadertest"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget"
+	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/assertstate"
@@ -2193,4 +2194,25 @@ snaps:
 
 	c.Assert(hooksCalled, HasLen, 1)
 	c.Check(hooksCalled[0].HookName(), Equals, "connect-plug-network")
+
+	// verify that connections was made
+	var conns map[string]interface{}
+	c.Assert(st.Get("conns", &conns), IsNil)
+	c.Assert(conns, HasLen, 2)
+
+	repo := s.overlord.InterfaceManager().Repository()
+	cn, err := repo.Connected("foo", "shared-data-plug")
+	c.Assert(err, IsNil)
+	c.Assert(cn, HasLen, 1)
+	c.Assert(cn, DeepEquals, []*interfaces.ConnRef{{
+		PlugRef: interfaces.PlugRef{Snap: "foo", Name: "shared-data-plug"},
+		SlotRef: interfaces.SlotRef{Snap: "bar", Name: "shared-data-slot"},
+	}})
+	cn, err = repo.Connected("foo", "network")
+	c.Assert(err, IsNil)
+	c.Assert(cn, HasLen, 1)
+	c.Assert(cn, DeepEquals, []*interfaces.ConnRef{{
+		PlugRef: interfaces.PlugRef{Snap: "foo", Name: "network"},
+		SlotRef: interfaces.SlotRef{Snap: "snapd", Name: "network"},
+	}})
 }

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -85,7 +85,6 @@ func (t *firstBootBaseTest) setupBaseTest(c *C, s *seedtest.SeedSnaps) {
 
 	tempdir := c.MkDir()
 	dirs.SetRootDir(tempdir)
-	c.Assert(os.MkdirAll(filepath.Dir(dirs.SnapSystemKeyFile), 0755), IsNil)
 	t.AddCleanup(func() { dirs.SetRootDir("/") })
 
 	t.AddCleanup(release.MockOnClassic(false))

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -2086,10 +2086,6 @@ func (s *firstBoot16Suite) TestPopulateFromSeedWithConnections(c *C) {
 	bloader.SetBootKernel("pc-kernel_1.snap")
 	bloader.SetBootBase("core_1.snap")
 
-	// needed for preseed
-	// restore := interfaces.MockSystemKey(`{"core": "123"}`)
-	// defer restore()
-
 	hooksCalled := []*hookstate.Context{}
 	restore := hookstate.MockRunHook(func(ctx *hookstate.Context, tomb *tomb.Tomb) ([]byte, error) {
 		ctx.Lock()

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -948,6 +948,12 @@ func checkAutoconnectConflicts(st *state.State, autoconnectTask *state.Task, plu
 
 		k := task.Kind()
 		if k == "connect" || k == "disconnect" {
+			// if the task depends on the auto-connect in some way, then we assume that it is safe to go ahead
+			// as it was scheduled by that exact task, and we should not block for that.
+			if inSameChangeWaitChain(autoconnectTask, task) {
+				continue
+			}
+
 			// retry if we found another connect/disconnect affecting same snap; note we can only encounter
 			// connects/disconnects created by doAutoDisconnect / doAutoConnect here as manual interface ops
 			// are rejected by conflict check logic in snapstate.
@@ -995,6 +1001,24 @@ func checkAutoconnectConflicts(st *state.State, autoconnectTask *state.Task, plu
 			if k == "discard-snap" && autoconnectTask.Change() != nil && autoconnectTask.Change().ID() == task.Change().ID() {
 				continue
 			}
+
+			// setup-profiles will be scheduled when we schedule the connect hooks during pre-seed, and they are postponed until
+			// after pre-seeding. They will still cause a conflict here, so take that into account. We only allow it in the case
+			// that setup-profiles is reliant on "mark-preseeded"
+			if k == "setup-profiles" && autoconnectTask.Change() != nil {
+				tasks := autoconnectTask.Change().Tasks()
+				var preseedTask *state.Task
+				for _, task := range tasks {
+					if task.Kind() == "mark-preseeded" {
+						preseedTask = task
+						break
+					}
+				}
+				if preseedTask != nil && inSameChangeWaitChain(preseedTask, task) {
+					continue
+				}
+			}
+
 			// if snap is getting removed, we will retry but the snap will be gone and auto-connect becomes no-op
 			// if snap is getting installed/refreshed - temporary conflict, retry later
 			return &state.Retry{After: connectRetryTimeout, Reason: fmt.Sprintf("conflicting snap %s with task %q", otherSnapName, k)}

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -1003,20 +1003,9 @@ func checkAutoconnectConflicts(st *state.State, autoconnectTask *state.Task, plu
 			}
 
 			// setup-profiles will be scheduled when we schedule the connect hooks during pre-seed, and they are postponed until
-			// after pre-seeding. They will still cause a conflict here, so take that into account. We only allow it in the case
-			// that setup-profiles is reliant on "mark-preseeded"
-			if k == "setup-profiles" && autoconnectTask.Change() != nil {
-				tasks := autoconnectTask.Change().Tasks()
-				var preseedTask *state.Task
-				for _, task := range tasks {
-					if task.Kind() == "mark-preseeded" {
-						preseedTask = task
-						break
-					}
-				}
-				if preseedTask != nil && inSameChangeWaitChain(preseedTask, task) {
-					continue
-				}
+			// after pre-seeding. They will still cause a conflict here, so take that into account.
+			if k == "setup-profiles" && inSameChangeWaitChain(autoconnectTask, task) {
+				continue
 			}
 
 			// if snap is getting removed, we will retry but the snap will be gone and auto-connect becomes no-op


### PR DESCRIPTION
This is to fix what has been reported in here https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1990884.

It seems, during pre-seed when installing snaps that has connect hooks, we end up in a cylic loop. This is due to the conflict detection waiting for connect's and setup-profiles to finish, but we can end up in a state where the connect and setup-profiles wait for "mark-preseeding" task to finish, which in turn is waiting for the "auto-connect" task of the snap with the connect hooks. So we end up having this infinite loop where pre-seeding gets stuck. 

The fix here is to not report a conflict *as long as they are part of the same wait chain*.
