### PR TITLE
{device,snap}state: fix ineffectual assignments

### DIFF
--- a/overlord/devicestate/handlers_gadget.go
+++ b/overlord/devicestate/handlers_gadget.go
@@ -227,6 +227,9 @@ func (m *DeviceManager) updateGadgetCommandLine(t *state.Task, st *state.State, 
 	if !isUndo {
 		// when updating, command line comes from the new gadget
 		gadgetData, err = pendingGadgetInfo(snapsup, devCtx)
+		if err != nil {
+			return false, err
+		}
 	} else {
 		// but when undoing, we use the current gadget which should have
 		// been restored

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -2379,7 +2379,7 @@ func installModeDisabledServices(st *state.State, snapst *SnapState, currentInfo
 	prevCurrentSvcs := map[string]bool{}
 	if psi := snapst.previousSideInfo(); psi != nil {
 		var prevCurrentInfo *snap.Info
-		if prevCurrentInfo, err = Info(st, snapst.InstanceName(), psi.Revision); prevCurrentInfo != nil {
+		if prevCurrentInfo, _ = Info(st, snapst.InstanceName(), psi.Revision); prevCurrentInfo != nil {
 			for _, prevSvc := range prevCurrentInfo.Services() {
 				prevCurrentSvcs[prevSvc.Name] = true
 			}

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -2379,7 +2379,11 @@ func installModeDisabledServices(st *state.State, snapst *SnapState, currentInfo
 	prevCurrentSvcs := map[string]bool{}
 	if psi := snapst.previousSideInfo(); psi != nil {
 		var prevCurrentInfo *snap.Info
-		if prevCurrentInfo, _ = Info(st, snapst.InstanceName(), psi.Revision); prevCurrentInfo != nil {
+		prevCurrentInfo, err = Info(st, snapst.InstanceName(), psi.Revision)
+		if err != nil {
+			return nil, err
+		}
+		if prevCurrentInfo != nil {
 			for _, prevSvc := range prevCurrentInfo.Services() {
 				prevCurrentSvcs[prevSvc.Name] = true
 			}


### PR DESCRIPTION
The ineffassign checker got smarter and detected two ineffective assignments in our existing code. This breaks CI and this PR fixes this.