### PR TITLE
inhibit: use hintFile()

### DIFF
--- a/cmd/snaplock/runinhibit/inhibit.go
+++ b/cmd/snaplock/runinhibit/inhibit.go
@@ -118,8 +118,7 @@ func Unlock(snapName string) error {
 // It returns the current, non-empty hint if inhibition is in place. Otherwise
 // it returns an empty hint.
 func IsLocked(snapName string) (Hint, error) {
-	fname := filepath.Join(InhibitDir, snapName+".lock")
-	flock, err := osutil.OpenExistingLockForReading(fname)
+	flock, err := osutil.OpenExistingLockForReading(hintFile(snapName))
 	if os.IsNotExist(err) {
 		return "", nil
 	}


### PR DESCRIPTION
The function IsLocked() manually builds the path of the hint file, instead of rely on the hintFile() function to get it, as all the other functions do.

This patch fixes this.

