### PR TITLE
many: support extended classic models that omit kernel/gadget

### DIFF
--- a/asserts/model.go
+++ b/asserts/model.go
@@ -781,19 +781,18 @@ func assembleModel(assert assertionBase) (Assertion, error) {
 		if err != nil {
 			return nil, err
 		}
+		hasKernel := modSnaps.kernel != nil
+		hasGadget := modSnaps.gadget != nil
 		if !classic {
-			if modSnaps.gadget == nil {
+			if !hasGadget {
 				return nil, fmt.Errorf(`one "snaps" header entry must specify the model gadget`)
 			}
-			if modSnaps.kernel == nil {
+			if !hasKernel {
 				return nil, fmt.Errorf(`one "snaps" header entry must specify the model kernel`)
 			}
 		} else {
-			hasKernel := modSnaps.kernel != nil
-			if modSnaps.gadget == nil {
-				if hasKernel {
-					return nil, fmt.Errorf("cannot specify a kernel in an extended classic model without a model gadget")
-				}
+			if hasKernel && !hasGadget {
+				return nil, fmt.Errorf("cannot specify a kernel in an extended classic model without a model gadget")
 			}
 		}
 

--- a/asserts/model.go
+++ b/asserts/model.go
@@ -781,11 +781,20 @@ func assembleModel(assert assertionBase) (Assertion, error) {
 		if err != nil {
 			return nil, err
 		}
-		if modSnaps.gadget == nil {
-			return nil, fmt.Errorf(`one "snaps" header entry must specify the model gadget`)
-		}
-		if modSnaps.kernel == nil {
-			return nil, fmt.Errorf(`one "snaps" header entry must specify the model kernel`)
+		if !classic {
+			if modSnaps.gadget == nil {
+				return nil, fmt.Errorf(`one "snaps" header entry must specify the model gadget`)
+			}
+			if modSnaps.kernel == nil {
+				return nil, fmt.Errorf(`one "snaps" header entry must specify the model kernel`)
+			}
+		} else {
+			hasKernel := modSnaps.kernel != nil
+			if modSnaps.gadget == nil {
+				if hasKernel {
+					return nil, fmt.Errorf("cannot specify a kernel in an extended classic model without a model gadget")
+				}
+			}
 		}
 
 		if modSnaps.base == nil {

--- a/asserts/model_test.go
+++ b/asserts/model_test.go
@@ -1012,7 +1012,6 @@ func (mods *modelSuite) testWithSnapsDecodeInvalid(c *C, modelRaw string, isClas
 		{"type: gadget\n", "type: gadget\n    modes:\n      - run\n", `essential snaps are always available, cannot specify modes or presence for snap "brand-gadget"`},
 		{"type: kernel\n", "type: kernel\n    presence: required\n", `essential snaps are always available, cannot specify modes or presence for snap "baz-linux"`},
 		{"OTHER", "  -\n    name: core20\n    id: core20ididididididididididididid\n    type: base\n    presence: optional\n", `essential snaps are always available, cannot specify modes or presence for snap "core20"`},
-		// XXX
 		{"OTHER", "  -\n    name: core20\n    id: core20ididididididididididididid\n    type: app\n", `boot base "core20" must specify type "base", not "app"`},
 		{"OTHER", "kernel: foo\n", `cannot specify separate "kernel" header once using the extended snaps header`},
 		{"OTHER", "gadget: foo\n", `cannot specify separate "gadget" header once using the extended snaps header`},

--- a/boot/boottest/device.go
+++ b/boot/boottest/device.go
@@ -107,11 +107,16 @@ func snapAndMode(str string) (snap, mode string, uc20 bool) {
 	return parts[0], parts[1], true
 }
 
-func (d *mockDevice) Kernel() string      { return d.bootSnap }
-func (d *mockDevice) Classic() bool       { return d.isClassic }
-func (d *mockDevice) RunMode() bool       { return d.mode == "run" }
-func (d *mockDevice) HasModeenv() bool    { return d.hasModes }
-func (d *mockDevice) IsCoreBoot() bool    { return d.hasModes || !d.isClassic }
+func (d *mockDevice) Kernel() string   { return d.bootSnap }
+func (d *mockDevice) Classic() bool    { return d.isClassic }
+func (d *mockDevice) RunMode() bool    { return d.mode == "run" }
+func (d *mockDevice) HasModeenv() bool { return d.hasModes }
+func (d *mockDevice) IsCoreBoot() bool {
+	if d.model != nil {
+		return d.model.Kernel() != ""
+	}
+	return d.hasModes || !d.isClassic
+}
 func (d *mockDevice) IsClassicBoot() bool { return !d.IsCoreBoot() }
 func (d *mockDevice) Base() string {
 	if d.model != nil {

--- a/gadget/validate.go
+++ b/gadget/validate.go
@@ -85,6 +85,8 @@ func ruleValidateVolumes(vols map[string]*Volume, model Model, extra *Validation
 
 	hasModes := false
 	// Classic with gadget + kernel snaps
+	// TODO: do the rules need changing now that we allow to omit
+	// gadget and kernel?
 	isClassicWithModes := false
 	if model != nil {
 		hasModes = hasGrade(model)

--- a/overlord/devicestate/devicectx.go
+++ b/overlord/devicestate/devicectx.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2018-2019 Canonical Ltd
+ * Copyright (C) 2018-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -99,16 +99,13 @@ func (dc groundDeviceContext) RunMode() bool {
 }
 
 // HasModeenv is true if the grade is set
-// TODO:UC20: will classic devices with uc20 models have a modeenv? I think so?
 func (dc groundDeviceContext) HasModeenv() bool {
 	return dc.model.Grade() != asserts.ModelGradeUnset
 }
 
-// IsCoreBoot is true when there are modes, or when there are not but
-// we are not in classic (UC16/18 case). If true this implies that a
-// kernel snap is in use.
+// IsCoreBoot is true if the model sports a kernel.
 func (d *groundDeviceContext) IsCoreBoot() bool {
-	return d.HasModeenv() || !d.Classic()
+	return d.model.Kernel() != ""
 }
 
 // IsClassicBoot is true for classic systems with classic initramfs

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -943,10 +943,6 @@ func (m *DeviceManager) ensureBootOk() error {
 	m.state.Lock()
 	defer m.state.Unlock()
 
-	/*if m.isClassicBoot {
-		return nil
-	}*/
-
 	// boot-ok/update-boot-revision is only relevant in run-mode
 	if m.SystemMode(SysAny) != "run" {
 		return nil

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2021 Canonical Ltd
+ * Copyright (C) 2016-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -89,9 +89,6 @@ type DeviceManager struct {
 	// save as rw vs ro, or mount/umount it fully on demand
 	saveAvailable bool
 
-	// isClassicBoot is true if classic system with classic initramfs
-	isClassicBoot bool
-
 	state   *state.State
 	hookMgr *hookstate.HookManager
 
@@ -149,8 +146,6 @@ func Manager(s *state.State, hookManager *hookstate.HookManager, runner *state.T
 		if modeenv != nil {
 			logger.Debugf("modeenv for model %q found", modeenv.Model)
 			m.sysMode = modeenv.Mode
-		} else if release.OnClassic {
-			m.isClassicBoot = true
 		}
 	} else {
 		// cache system label for preseeding of core20; note, this will fail on
@@ -948,9 +943,9 @@ func (m *DeviceManager) ensureBootOk() error {
 	m.state.Lock()
 	defer m.state.Unlock()
 
-	if m.isClassicBoot {
+	/*if m.isClassicBoot {
 		return nil
-	}
+	}*/
 
 	// boot-ok/update-boot-revision is only relevant in run-mode
 	if m.SystemMode(SysAny) != "run" {
@@ -962,13 +957,13 @@ func (m *DeviceManager) ensureBootOk() error {
 		if err != nil && !errors.Is(err, state.ErrNoState) {
 			return err
 		}
-		if err == nil {
+		if err == nil && deviceCtx.Model().KernelSnap() != nil {
 			if err := boot.MarkBootSuccessful(deviceCtx); err != nil {
 				return err
 			}
-		}
-		if err := secbootMarkSuccessful(); err != nil {
-			return err
+			if err := secbootMarkSuccessful(); err != nil {
+				return err
+			}
 		}
 
 		m.bootOkRan = true

--- a/overlord/devicestate/firstboot20_test.go
+++ b/overlord/devicestate/firstboot20_test.go
@@ -94,8 +94,10 @@ func (s *firstBoot20Suite) snapYaml(snp string) string {
 	return s.extraSnapYaml[snp]
 }
 
-func (s *firstBoot20Suite) setupCore20Seed(c *C, sysLabel string, modelGrade asserts.ModelGrade, extraGadgetYaml string, extraSnaps ...string) *asserts.Model {
-	gadgetYaml := `
+func (s *firstBoot20Suite) setupCore20LikeSeed(c *C, sysLabel string, modelGrade asserts.ModelGrade, kernelAndGadget bool, extraGadgetYaml string, extraSnaps ...string) *asserts.Model {
+	var gadgetYaml string
+	if kernelAndGadget {
+		gadgetYaml = `
 volumes:
     volume-id:
         bootloader: grub
@@ -114,7 +116,8 @@ volumes:
           size: 2G
 `
 
-	gadgetYaml += extraGadgetYaml
+		gadgetYaml += extraGadgetYaml
+	}
 
 	makeSnap := func(yamlKey string) {
 		var files [][]string
@@ -128,9 +131,11 @@ volumes:
 	}
 
 	makeSnap("snapd")
-	makeSnap("pc-kernel=20")
 	makeSnap("core20")
-	makeSnap("pc=20")
+	if kernelAndGadget {
+		makeSnap("pc-kernel=20")
+		makeSnap("pc=20")
+	}
 	for _, sn := range extraSnaps {
 		makeSnap(sn)
 	}
@@ -169,6 +174,20 @@ volumes:
 	if release.OnClassic {
 		model["classic"] = "true"
 		model["distribution"] = "ubuntu"
+		if !kernelAndGadget {
+			snaps := model["snaps"].([]interface{})
+			reducedSnaps := []interface{}{}
+			for _, s := range snaps {
+				ms := s.(map[string]interface{})
+				if ms["type"] == "kernel" || ms["type"] == "gadget" {
+					continue
+				}
+				reducedSnaps = append(reducedSnaps, s)
+			}
+			model["snaps"] = reducedSnaps
+		}
+	} else {
+		c.Assert(kernelAndGadget, Equals, true)
 	}
 
 	for _, sn := range extraSnaps {
@@ -241,7 +260,8 @@ func (s *firstBoot20Suite) earlySetup(c *C, m *boot.Modeenv, modelGrade asserts.
 	c.Assert(err, IsNil)
 
 	sysLabel := m.RecoverySystem
-	model = s.setupCore20Seed(c, sysLabel, modelGrade, extraGadgetYaml, extraSnaps...)
+	kernelAndGadget := true
+	model = s.setupCore20LikeSeed(c, sysLabel, modelGrade, kernelAndGadget, extraGadgetYaml, extraSnaps...)
 	// validity check that our returned model has the expected grade
 	c.Assert(model.Grade(), Equals, modelGrade)
 
@@ -407,6 +427,7 @@ func (s *firstBoot20Suite) testPopulateFromSeedCore20Happy(c *C, m *boot.Modeenv
 	dev, err := devicestate.DeviceCtx(s.overlord.State(), nil, nil)
 	c.Assert(err, IsNil)
 	c.Assert(dev.HasModeenv(), Equals, true)
+	c.Assert(dev.IsCoreBoot(), Equals, true)
 
 	// check that we marked the boot successful with bootstate20 methods, namely
 	// that we called SetNext, which since it was called on the kernel we
@@ -629,6 +650,169 @@ func (s *firstBoot20Suite) TestPopulateFromSeedClassicWithModesRunMode(c *C) {
 		Mode:           "run",
 		RecoverySystem: "20191018",
 		Base:           "core20_1.snap",
+		Classic:        true,
 	}
 	s.testPopulateFromSeedCore20Happy(c, &m, asserts.ModelSigned)
+}
+
+func (s *firstBoot20Suite) TestPopulateFromSeedClassicWithModesRunModeNoKernelAndGadget(c *C) {
+	defer release.MockReleaseInfo(&release.OS{ID: "ubuntu", VersionID: "20.04"})()
+	// XXX this shouldn't be needed
+	defer release.MockOnClassic(true)()
+	c.Assert(release.OnClassic, Equals, true)
+
+	m := &boot.Modeenv{
+		Mode:           "run",
+		RecoverySystem: "20191018",
+		Base:           "core20_1.snap",
+		Classic:        true,
+	}
+	modelGrade := asserts.ModelSigned
+
+	var sysdLog [][]string
+	systemctlRestorer := systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
+		sysdLog = append(sysdLog, cmd)
+		return []byte("ActiveState=inactive\n"), nil
+	})
+	defer systemctlRestorer()
+
+	err := m.WriteTo("")
+	c.Assert(err, IsNil)
+
+	sysLabel := m.RecoverySystem
+	kernelAndGadget := false
+	model := s.setupCore20LikeSeed(c, sysLabel, modelGrade, kernelAndGadget, "")
+	// validity check that our returned model has the expected grade
+	c.Assert(model.Grade(), Equals, modelGrade)
+
+	s.startOverlord(c)
+
+	opts := devicestate.PopulateStateFromSeedOptions{
+		Label: m.RecoverySystem,
+		Mode:  m.Mode,
+	}
+
+	// run the firstboot stuff
+	st := s.overlord.State()
+	st.Lock()
+	defer st.Unlock()
+	tsAll, err := devicestate.PopulateStateFromSeedImpl(st, &opts, s.perfTimings)
+	c.Assert(err, IsNil)
+
+	snaps := []string{"snapd", "core20"}
+	checkOrder(c, tsAll, snaps...)
+
+	// now run the change and check the result
+	// use the expected kind otherwise settle with start another one
+	chg := st.NewChange("seed", "run the populate from seed changes")
+	for _, ts := range tsAll {
+		chg.AddAll(ts)
+	}
+	c.Assert(st.Changes(), HasLen, 1)
+
+	c.Assert(chg.Err(), IsNil)
+
+	// avoid device reg
+	chg1 := st.NewChange("become-operational", "init device")
+	chg1.SetStatus(state.DoingStatus)
+
+	// run change until it wants to restart
+	st.Unlock()
+	err = s.overlord.Settle(settleTimeout)
+	st.Lock()
+	c.Assert(err, IsNil)
+
+	// at this point the system is "restarting", pretend the restart has
+	// happened
+	c.Assert(chg.Status(), Equals, state.DoingStatus)
+	restart.MockPending(st, restart.RestartUnset)
+	st.Unlock()
+	err = s.overlord.Settle(settleTimeout)
+	st.Lock()
+	c.Assert(err, IsNil)
+	c.Assert(chg.Status(), Equals, state.DoneStatus, Commentf("%s", chg.Err()))
+
+	// verify
+	f, err := os.Open(dirs.SnapStateFile)
+	c.Assert(err, IsNil)
+	state, err := state.ReadState(nil, f)
+	c.Assert(err, IsNil)
+
+	state.Lock()
+	defer state.Unlock()
+	// check snapd, core20, kernel, gadget
+	_, err = snapstate.CurrentInfo(state, "snapd")
+	c.Check(err, IsNil)
+	_, err = snapstate.CurrentInfo(state, "core20")
+	c.Check(err, IsNil)
+
+	// ensure required flag is set on all essential snaps
+	var snapst snapstate.SnapState
+	for _, reqName := range []string{"snapd", "core20"} {
+		err = snapstate.Get(state, reqName, &snapst)
+		c.Assert(err, IsNil)
+		c.Assert(snapst.Required, Equals, true, Commentf("required not set for %v", reqName))
+
+		if m.Mode == "run" {
+			// also ensure that in run mode none of the snaps are installed as
+			// symlinks, they must be copied onto ubuntu-data
+			files, err := filepath.Glob(filepath.Join(dirs.SnapBlobDir, reqName+"_*.snap"))
+			c.Assert(err, IsNil)
+			c.Assert(files, HasLen, 1)
+			c.Assert(osutil.IsSymlink(files[0]), Equals, false)
+		}
+	}
+
+	// the right systemd commands were run
+	c.Check(sysdLog, Not(testutil.DeepContains), []string{"start", "usr-lib-snapd.mount"})
+
+	// and ensure state is now considered seeded
+	var seeded bool
+	err = state.Get("seeded", &seeded)
+	c.Assert(err, IsNil)
+	c.Check(seeded, Equals, true)
+
+	// check we set seed-time
+	var seedTime time.Time
+	err = state.Get("seed-time", &seedTime)
+	c.Assert(err, IsNil)
+	c.Check(seedTime.IsZero(), Equals, false)
+
+	// check that we removed recovery_system from modeenv
+	m2, err := boot.ReadModeenv("")
+	c.Assert(err, IsNil)
+	if m.Mode == "run" {
+		// recovery system is cleared in run mode
+		c.Assert(m2.RecoverySystem, Equals, "")
+	} else {
+		// but kept intact in other modes
+		c.Assert(m2.RecoverySystem, Equals, m.RecoverySystem)
+	}
+	c.Assert(m2.Base, Equals, m.Base)
+	c.Assert(m2.Mode, Equals, m.Mode)
+	// Note that we don't check CurrentKernels in the modeenv, even though in a
+	// real first boot that would also be set here, because setting that is done
+	// in the snapstate manager, not the devicestate manager
+
+	// check that the default device ctx has a Modeenv
+	dev, err := devicestate.DeviceCtx(s.overlord.State(), nil, nil)
+	c.Assert(err, IsNil)
+	c.Assert(dev.HasModeenv(), Equals, true)
+	c.Assert(dev.IsCoreBoot(), Equals, false)
+
+	var whatseeded []devicestate.SeededSystem
+	err = state.Get("seeded-systems", &whatseeded)
+	if m.Mode == "run" {
+		c.Assert(err, IsNil)
+		c.Assert(whatseeded, DeepEquals, []devicestate.SeededSystem{{
+			System:    m.RecoverySystem,
+			Model:     "my-model",
+			BrandID:   "my-brand",
+			Revision:  model.Revision(),
+			Timestamp: model.Timestamp(),
+			SeedTime:  seedTime,
+		}})
+	} else {
+		c.Assert(err, NotNil)
+	}
 }

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -4901,7 +4901,11 @@ func (a byReadyTime) Len() int           { return len(a) }
 func (a byReadyTime) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a byReadyTime) Less(i, j int) bool { return a[i].ReadyTime().Before(a[j].ReadyTime()) }
 
-func (s *mgrsSuite) TestRemodelRequiredSnapsAdded(c *C) {
+func (s *mgrsSuiteCore) TestRemodelRequiredSnapsAdded(c *C) {
+	bloader := bootloadertest.Mock("mock", c.MkDir())
+	bootloader.Force(bloader)
+	defer bootloader.Force(nil)
+
 	for _, name := range []string{"foo", "bar", "baz"} {
 		s.prereqSnapAssertions(c, map[string]interface{}{
 			"snap-name": name,
@@ -5002,7 +5006,11 @@ func (s *mgrsSuite) TestRemodelRequiredSnapsAdded(c *C) {
 	c.Assert(tasks, HasLen, i+1)
 }
 
-func (s *mgrsSuite) TestRemodelRequiredSnapsAddedUndo(c *C) {
+func (s *mgrsSuiteCore) TestRemodelRequiredSnapsAddedUndo(c *C) {
+	bloader := bootloadertest.Mock("mock", c.MkDir())
+	bootloader.Force(bloader)
+	defer bootloader.Force(nil)
+
 	for _, name := range []string{"foo", "bar", "baz"} {
 		s.prereqSnapAssertions(c, map[string]interface{}{
 			"snap-name": name,
@@ -5085,7 +5093,7 @@ func (s *mgrsSuite) TestRemodelRequiredSnapsAddedUndo(c *C) {
 	c.Assert(model, DeepEquals, curModel)
 }
 
-func (s *mgrsSuite) TestRemodelDifferentBase(c *C) {
+func (s *mgrsSuiteCore) TestRemodelDifferentBase(c *C) {
 	// make "core18" snap available in the store
 	snapYamlContent := `name: core18
 version: 18.04
@@ -5123,7 +5131,7 @@ type: base`
 	c.Assert(chg, IsNil)
 }
 
-func (ms *mgrsSuite) TestRemodelSwitchToDifferentBase(c *C) {
+func (ms *mgrsSuiteCore) TestRemodelSwitchToDifferentBase(c *C) {
 	bloader := bootloadertest.Mock("mock", c.MkDir())
 	bootloader.Force(bloader)
 	defer bootloader.Force(nil)
@@ -6097,7 +6105,11 @@ func (ms *kernelSuite) TestRemodelSwitchToDifferentKernelUndoOnRollback(c *C) {
 	})
 }
 
-func (s *mgrsSuite) TestRemodelStoreSwitch(c *C) {
+func (s *mgrsSuiteCore) TestRemodelStoreSwitch(c *C) {
+	bloader := bootloadertest.Mock("mock", c.MkDir())
+	bootloader.Force(bloader)
+	defer bootloader.Force(nil)
+
 	s.prereqSnapAssertions(c, map[string]interface{}{
 		"snap-name": "foo",
 	})
@@ -6201,7 +6213,7 @@ func (s *mgrsSuite) TestRemodelStoreSwitch(c *C) {
 	c.Check(device.SessionMacaroon, Equals, "switched-store-session")
 }
 
-func (s *mgrsSuite) TestRemodelSwitchGadgetTrack(c *C) {
+func (s *mgrsSuiteCore) TestRemodelSwitchGadgetTrack(c *C) {
 	bloader := bootloadertest.Mock("mock", c.MkDir())
 	bootloader.Force(bloader)
 	defer bootloader.Force(nil)
@@ -6295,7 +6307,7 @@ func (m *mockUpdater) Update() error {
 	return m.onUpdate
 }
 
-func (s *mgrsSuite) TestRemodelSwitchToDifferentGadget(c *C) {
+func (s *mgrsSuiteCore) TestRemodelSwitchToDifferentGadget(c *C) {
 	bloader := bootloadertest.Mock("mock", c.MkDir())
 	bootloader.Force(bloader)
 	defer bootloader.Force(nil)
@@ -6447,7 +6459,7 @@ volumes:
 	c.Assert(tasks, HasLen, i+1)
 }
 
-func (s *mgrsSuite) TestRemodelSwitchToIncompatibleGadget(c *C) {
+func (s *mgrsSuiteCore) TestRemodelSwitchToIncompatibleGadget(c *C) {
 	bloader := bootloadertest.Mock("mock", c.MkDir())
 	bootloader.Force(bloader)
 	defer bootloader.Force(nil)
@@ -6544,7 +6556,11 @@ volumes:
 	c.Assert(chg.Err(), ErrorMatches, `cannot perform the following tasks:\n.*cannot remodel to an incompatible gadget: .*cannot change structure size.*`)
 }
 
-func (s *mgrsSuite) TestHappyDeviceRegistrationWithPrepareDeviceHook(c *C) {
+func (s *mgrsSuiteCore) TestHappyDeviceRegistrationWithPrepareDeviceHook(c *C) {
+	bloader := boottest.MockUC16Bootenv(bootloadertest.Mock("mock", c.MkDir()))
+	bootloader.Force(bloader)
+	defer bootloader.Force(nil)
+
 	// just to 404 locally eager account-key requests
 	mockStoreServer := s.mockStore(c)
 	defer mockStoreServer.Close()
@@ -6650,7 +6666,11 @@ func (s *mgrsSuite) TestHappyDeviceRegistrationWithPrepareDeviceHook(c *C) {
 	c.Check(serial.DeviceKey().ID(), Equals, device.KeyID)
 }
 
-func (s *mgrsSuite) TestRemodelReregistration(c *C) {
+func (s *mgrsSuiteCore) TestRemodelReregistration(c *C) {
+	bloader := bootloadertest.Mock("mock", c.MkDir())
+	bootloader.Force(bloader)
+	defer bootloader.Force(nil)
+
 	s.prereqSnapAssertions(c, map[string]interface{}{
 		"snap-name": "foo",
 	})

--- a/overlord/snapstate/snapstatetest/devicectx.go
+++ b/overlord/snapstate/snapstatetest/devicectx.go
@@ -75,7 +75,7 @@ func (dc *TrivialDeviceContext) HasModeenv() bool {
 }
 
 func (d *TrivialDeviceContext) IsCoreBoot() bool {
-	return d.HasModeenv() || !d.Classic()
+	return d.Model().Kernel() != ""
 }
 
 func (d *TrivialDeviceContext) IsClassicBoot() bool {


### PR DESCRIPTION
redefine IsCoreBoot as the model having a kernel

there are at least tests that show we can seed such systems

the changes ind devicemgr.go prompted fixes for some remodel tests that were
confusingly running wiht OnClassic true though they were using Core models