### PR TITLE
o/state: Hold pseudo-error for explicit holding, concept of pending changes in prune logic

### DIFF
--- a/overlord/state/change.go
+++ b/overlord/state/change.go
@@ -38,7 +38,9 @@ const (
 	// to an aggregation of its tasks' statuses. See Change.Status for details.
 	DefaultStatus Status = 0
 
-	// HoldStatus means the task should not run, perhaps as a consequence of an error on another task.
+	// HoldStatus means the task should not run for the moment, perhaps as a
+	// consequence of an error on another task or because an external action
+	// is needed.
 	HoldStatus Status = 1
 
 	// DoStatus means the change or task is ready to start.

--- a/overlord/state/state_test.go
+++ b/overlord/state/state_test.go
@@ -826,6 +826,55 @@ func (ss *stateSuite) TestPrune(c *C) {
 	c.Check(st.AllWarnings(), HasLen, 1)
 }
 
+func (ss *stateSuite) TestRegisterPendingChangeByAttr(c *C) {
+	st := state.New(&fakeStateBackend{})
+	st.Lock()
+	defer st.Unlock()
+
+	now := time.Now()
+	pruneWait := 1 * time.Hour
+	abortWait := 3 * time.Hour
+
+	unset := time.Time{}
+
+	t1 := st.NewTask("foo", "...")
+	t2 := st.NewTask("foo", "...")
+	t3 := st.NewTask("foo", "...")
+	t4 := st.NewTask("foo", "...")
+
+	chg1 := st.NewChange("abort", "...")
+	chg1.AddTask(t1)
+	chg1.AddTask(t2)
+	state.MockChangeTimes(chg1, now.Add(-abortWait), unset)
+
+	chg2 := st.NewChange("pending", "...")
+	chg2.AddTask(t3)
+	chg2.AddTask(t4)
+	state.MockChangeTimes(chg2, now.Add(-abortWait), unset)
+	chg2.Set("pending-flag", true)
+	t3.SetStatus(state.HoldStatus)
+
+	st.RegisterPendingChangeByAttr("pending-flag", func(chg *state.Change) bool {
+		c.Check(chg.ID(), Equals, chg2.ID())
+		return true
+	})
+
+	past := time.Now().AddDate(-1, 0, 0)
+	st.Prune(past, pruneWait, abortWait, 100)
+
+	c.Assert(st.Change(chg1.ID()), Equals, chg1)
+	c.Assert(st.Change(chg2.ID()), Equals, chg2)
+	c.Assert(st.Task(t1.ID()), Equals, t1)
+	c.Assert(st.Task(t2.ID()), Equals, t2)
+	c.Assert(st.Task(t3.ID()), Equals, t3)
+	c.Assert(st.Task(t4.ID()), Equals, t4)
+
+	c.Assert(t1.Status(), Equals, state.HoldStatus)
+	c.Assert(t2.Status(), Equals, state.HoldStatus)
+	c.Assert(t3.Status(), Equals, state.HoldStatus)
+	c.Assert(t4.Status(), Equals, state.DoStatus)
+}
+
 func (ss *stateSuite) TestPruneEmptyChange(c *C) {
 	// Empty changes are a bit special because they start out on Hold
 	// which is a Ready status, but the change itself is not considered Ready

--- a/overlord/state/taskrunner_test.go
+++ b/overlord/state/taskrunner_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -807,6 +807,37 @@ func (ts *taskRunnerSuite) TestStopAskForRetry(c *C) {
 	defer st.Unlock()
 	c.Check(t.Status(), Equals, state.DoingStatus)
 	c.Check(t.AtTime().IsZero(), Equals, false)
+}
+
+func (ts *taskRunnerSuite) TestTaskReturningHold(c *C) {
+	sb := &stateBackend{}
+	st := state.New(sb)
+	r := state.NewTaskRunner(st)
+	defer r.Stop()
+
+	r.AddHandler("ask-for-hold", func(t *state.Task, tb *tomb.Tomb) error {
+		// ask for hold
+		return &state.Hold{}
+	}, nil)
+
+	st.Lock()
+	chg := st.NewChange("install", "...")
+	t := st.NewTask("ask-for-hold", "...")
+	chg.AddTask(t)
+	st.Unlock()
+
+	r.Ensure()
+	// wait for handler to finish
+	r.Wait()
+
+	st.Lock()
+	defer st.Unlock()
+	c.Check(t.Status(), Equals, state.HoldStatus)
+
+	// NB: such a change, finishing in a held task is ready; this is a bit
+	// odd, but usually this would be done for tasks that expect more tasks
+	// to follow them
+	c.Check(chg.Status().Ready(), Equals, true)
 }
 
 func (ts *taskRunnerSuite) TestRetryAfterDuration(c *C) {


### PR DESCRIPTION
these are overlord/state changes in preparation to support holding changes until a reboot has occurred instead of automatic rebooting for the kernels/gadgets in classic. 

the first commit here is tweaked code from #12102

next PR will have the changes in overlord/restart itself