### PR TITLE
devicestate,boot,tests: make `fakeinstaller` test work

### DIFF
--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -82,6 +82,9 @@ func MakeBootableImage(model *asserts.Model, rootdir string, bootWith *BootableS
 // using information from bootWith and bootFlags. Contrarily to
 // MakeBootableImage this happens in a live system.
 func MakeBootablePartition(partDir string, opts *bootloader.Options, bootWith *BootableSet, bootMode string, bootFlags []string) error {
+	if bootWith.RecoverySystemDir != "" {
+		return fmt.Errorf("internal error: RecoverySystemDir unexpectedly set for MakeBootablePartition")
+	}
 	return configureBootloader(partDir, opts, bootWith, bootMode, bootFlags)
 }
 
@@ -335,6 +338,9 @@ func makeRunnableSystem(model *asserts.Model, bootWith *BootableSet, sealer *Tru
 	if model.Grade() == asserts.ModelGradeUnset {
 		return fmt.Errorf("internal error: cannot make pre-UC20 system runnable")
 	}
+	if bootWith.RecoverySystemDir != "" {
+		return fmt.Errorf("internal error: RecoverySystemDir unexpectedly set for MakeRunnableSystem")
+	}
 
 	// TODO:UC20:
 	// - figure out what to do for uboot gadgets, currently we require them to
@@ -369,11 +375,7 @@ func makeRunnableSystem(model *asserts.Model, bootWith *BootableSet, sealer *Tru
 		currentTrustedBootAssets = sealer.currentTrustedBootAssetsMap()
 		currentTrustedRecoveryBootAssets = sealer.currentTrustedRecoveryBootAssetsMap()
 	}
-	// filepath.Base("") returns ".", so we need to be a bit careful here
-	recoverySystemLabel := ""
-	if bootWith.RecoverySystemDir != "" {
-		recoverySystemLabel = filepath.Base(bootWith.RecoverySystemDir)
-	}
+	recoverySystemLabel := bootWith.RecoverySystemLabel
 	// write modeenv on the ubuntu-data partition
 	modeenv := &Modeenv{
 		Mode:           "run",

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -554,15 +554,15 @@ version: 5.0
 	c.Assert(err, IsNil)
 
 	bootWith := &boot.BootableSet{
-		RecoverySystemDir: "20191216",
-		BasePath:          baseInSeed,
-		Base:              baseInfo,
-		Gadget:            gadgetInfo,
-		GadgetPath:        gadgetInSeed,
-		KernelPath:        kernelInSeed,
-		Kernel:            kernelInfo,
-		Recovery:          false,
-		UnpackedGadgetDir: unpackedGadgetDir,
+		RecoverySystemLabel: "20191216",
+		BasePath:            baseInSeed,
+		Base:                baseInfo,
+		Gadget:              gadgetInfo,
+		GadgetPath:          gadgetInSeed,
+		KernelPath:          kernelInSeed,
+		Kernel:              kernelInfo,
+		Recovery:            false,
+		UnpackedGadgetDir:   unpackedGadgetDir,
 	}
 
 	// set up observer state
@@ -924,15 +924,15 @@ version: 5.0
 	c.Assert(err, IsNil)
 
 	bootWith := &boot.BootableSet{
-		RecoverySystemDir: "20191216",
-		BasePath:          baseInSeed,
-		Base:              baseInfo,
-		KernelPath:        kernelInSeed,
-		Kernel:            kernelInfo,
-		Gadget:            gadgetInfo,
-		GadgetPath:        gadgetInSeed,
-		Recovery:          false,
-		UnpackedGadgetDir: unpackedGadgetDir,
+		RecoverySystemLabel: "20191216",
+		BasePath:            baseInSeed,
+		Base:                baseInfo,
+		KernelPath:          kernelInSeed,
+		Kernel:              kernelInfo,
+		Gadget:              gadgetInfo,
+		GadgetPath:          gadgetInSeed,
+		Recovery:            false,
+		UnpackedGadgetDir:   unpackedGadgetDir,
 	}
 
 	// no grub marker in gadget directory raises an error
@@ -1033,15 +1033,15 @@ version: 5.0
 	c.Assert(err, IsNil)
 
 	bootWith := &boot.BootableSet{
-		RecoverySystemDir: "20191216",
-		BasePath:          baseInSeed,
-		Base:              baseInfo,
-		KernelPath:        kernelInSeed,
-		Kernel:            kernelInfo,
-		Gadget:            gadgetInfo,
-		GadgetPath:        gadgetInSeed,
-		Recovery:          false,
-		UnpackedGadgetDir: unpackedGadgetDir,
+		RecoverySystemLabel: "20191216",
+		BasePath:            baseInSeed,
+		Base:                baseInfo,
+		KernelPath:          kernelInSeed,
+		Kernel:              kernelInfo,
+		Gadget:              gadgetInfo,
+		GadgetPath:          gadgetInSeed,
+		Recovery:            false,
+		UnpackedGadgetDir:   unpackedGadgetDir,
 	}
 
 	// set up observer state
@@ -1228,15 +1228,15 @@ version: 5.0
 	c.Assert(err, IsNil)
 
 	bootWith := &boot.BootableSet{
-		RecoverySystemDir: "20191216",
-		BasePath:          baseInSeed,
-		Base:              baseInfo,
-		Gadget:            gadgetInfo,
-		GadgetPath:        gadgetInSeed,
-		KernelPath:        kernelInSeed,
-		Kernel:            kernelInfo,
-		Recovery:          false,
-		UnpackedGadgetDir: unpackedGadgetDir,
+		RecoverySystemLabel: "20191216",
+		BasePath:            baseInSeed,
+		Base:                baseInfo,
+		Gadget:              gadgetInfo,
+		GadgetPath:          gadgetInSeed,
+		KernelPath:          kernelInSeed,
+		Kernel:              kernelInfo,
+		Recovery:            false,
+		UnpackedGadgetDir:   unpackedGadgetDir,
 	}
 
 	// set up observer state
@@ -1469,15 +1469,15 @@ version: 5.0
 	c.Assert(err, IsNil)
 
 	bootWith := &boot.BootableSet{
-		RecoverySystemDir: "20191216",
-		BasePath:          baseInSeed,
-		Base:              baseInfo,
-		KernelPath:        kernelInSeed,
-		Kernel:            kernelInfo,
-		Gadget:            gadgetInfo,
-		GadgetPath:        gadgetInSeed,
-		Recovery:          false,
-		UnpackedGadgetDir: unpackedGadgetDir,
+		RecoverySystemLabel: "20191216",
+		BasePath:            baseInSeed,
+		Base:                baseInfo,
+		KernelPath:          kernelInSeed,
+		Kernel:              kernelInfo,
+		Gadget:              gadgetInfo,
+		GadgetPath:          gadgetInSeed,
+		Recovery:            false,
+		UnpackedGadgetDir:   unpackedGadgetDir,
 	}
 
 	// set a mock recovery kernel
@@ -1671,15 +1671,15 @@ version: 5.0
 	c.Assert(err, IsNil)
 
 	bootWith := &boot.BootableSet{
-		RecoverySystemDir: "20191216",
-		BasePath:          baseInSeed,
-		Base:              baseInfo,
-		Gadget:            gadgetInfo,
-		GadgetPath:        gadgetInSeed,
-		KernelPath:        kernelInSeed,
-		Kernel:            kernelInfo,
-		Recovery:          false,
-		UnpackedGadgetDir: unpackedGadgetDir,
+		RecoverySystemLabel: "20191216",
+		BasePath:            baseInSeed,
+		Base:                baseInfo,
+		Gadget:              gadgetInfo,
+		GadgetPath:          gadgetInSeed,
+		KernelPath:          kernelInSeed,
+		Kernel:              kernelInfo,
+		Recovery:            false,
+		UnpackedGadgetDir:   unpackedGadgetDir,
 	}
 	err = boot.MakeRunnableSystem(model, bootWith, nil)
 	c.Assert(err, IsNil)
@@ -1857,7 +1857,6 @@ version: 5.0
 		KernelPath:          kernelInSeed,
 		Gadget:              gadgetInfo,
 		GadgetPath:          gadgetInSeed,
-		RecoverySystemDir:   "",
 		RecoverySystemLabel: "",
 		UnpackedGadgetDir:   unpackedGadgetDir,
 		Recovery:            false,
@@ -1962,7 +1961,6 @@ version: 5.0
 	c.Assert(err, IsNil)
 
 	bootWith := &boot.BootableSet{
-		RecoverySystemDir: "",
 		BasePath:          baseInSeed,
 		Base:              baseInfo,
 		KernelPath:        kernelInSeed,
@@ -1976,7 +1974,7 @@ version: 5.0
 	err = boot.MakeRunnableSystem(model, bootWith, nil)
 	c.Assert(err, IsNil)
 
-	// ensure that there are no good recovery systems as RecoverySystemDir was empty
+	// ensure that there are no good recovery systems as RecoverySystemLabel was empty
 	mockSeedGrubenv := filepath.Join(mockSeedGrubDir, "grubenv")
 	c.Check(mockSeedGrubenv, testutil.FilePresent)
 	systemGenv := grubenv.NewEnv(mockSeedGrubenv)

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -310,6 +310,8 @@ func (m *DeviceManager) StartUp() error {
 
 func (m *DeviceManager) shouldMountUbuntuSave() bool {
 	// TODO: this should check DeviceCtx.IsClassicBoot() instead
+	// but we should not create per-snap save directories on classic
+	// for now except for maybe gadget and snapd...
 	if release.OnClassic {
 		return false
 	}

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -85,8 +85,6 @@ type DeviceManager struct {
 	// saveAvailable keeps track whether /var/lib/snapd/save
 	// is available, i.e. exists and is mounted from ubuntu-save
 	// if the latter exists.
-	// TODO: evolve this to state to track things if we start mounting
-	// save as rw vs ro, or mount/umount it fully on demand
 	saveAvailable bool
 
 	state   *state.State
@@ -1697,10 +1695,6 @@ func (m *DeviceManager) withKeypairMgr(f func(asserts.KeypairManager) error) err
 	}
 	return f(keypairMgr)
 }
-
-// TODO:UC20: we need proper encapsulated support to read
-// tpm-policy-auth-key from save if the latter can get unmounted on
-// demand
 
 func (m *DeviceManager) keyPair() (asserts.PrivateKey, error) {
 	device, err := m.device()

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -309,6 +309,7 @@ func (m *DeviceManager) StartUp() error {
 }
 
 func (m *DeviceManager) shouldMountUbuntuSave() bool {
+	// TODO: this should check DeviceCtx.IsClassicBoot() instead
 	if release.OnClassic {
 		return false
 	}

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -296,7 +296,8 @@ func (s *deviceMgrInstallModeSuite) doRunChangeTestWithEncryption(c *C, grade st
 		c.Check(model, DeepEquals, mockModel)
 		c.Check(bootWith.KernelPath, Matches, ".*/var/lib/snapd/snaps/pc-kernel_1.snap")
 		c.Check(bootWith.BasePath, Matches, ".*/var/lib/snapd/snaps/core20_2.snap")
-		c.Check(bootWith.RecoverySystemDir, Matches, "/systems/20191218")
+		c.Check(bootWith.RecoverySystemLabel, Equals, "20191218")
+		c.Check(bootWith.RecoverySystemDir, Equals, "")
 		c.Check(bootWith.UnpackedGadgetDir, Equals, filepath.Join(dirs.SnapMountDir, "pc/1"))
 		if tc.encrypt {
 			c.Check(seal, NotNil)
@@ -2445,7 +2446,8 @@ func (s *deviceMgrInstallModeSuite) doRunFactoryResetChange(c *C, model *asserts
 		c.Check(makeRunnableModel, DeepEquals, model)
 		c.Check(bootWith.KernelPath, Matches, ".*/var/lib/snapd/snaps/pc-kernel_1.snap")
 		c.Check(bootWith.BasePath, Matches, ".*/var/lib/snapd/snaps/core20_2.snap")
-		c.Check(bootWith.RecoverySystemDir, Matches, "/systems/20191218")
+		c.Check(bootWith.RecoverySystemLabel, Equals, "20191218")
+		c.Check(bootWith.RecoverySystemDir, Equals, "")
 		c.Check(bootWith.UnpackedGadgetDir, Equals, filepath.Join(dirs.SnapMountDir, "pc/1"))
 		if tc.encrypt {
 			c.Check(seal, NotNil)

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -1321,6 +1321,12 @@ func (m *DeviceManager) doInstallFinish(t *state.Task, _ *tomb.Tomb) error {
 		Gadget:     snapInfos[snap.TypeGadget],
 		GadgetPath: snapSeeds[snap.TypeGadget].Path,
 
+		// modeenv:recovery_system will be set based on
+		// RecoverySystemDir and seeding reads this var
+		// from modeenv to know what it's seeding from
+		RecoverySystemDir:   systemLabel,
+		RecoverySystemLabel: systemLabel,
+
 		UnpackedGadgetDir: mntPtForType[snap.TypeGadget],
 	}
 

--- a/tests/lib/fakeinstaller/mk-classic-rootfs.sh
+++ b/tests/lib/fakeinstaller/mk-classic-rootfs.sh
@@ -13,10 +13,7 @@ set -e
 create_classic_rootfs() {
     set -x
     local DESTDIR="$1"
-    local BASETAR="$2"
 
-    # Copy base filesystem
-    sudo tar -C "$DESTDIR" -xf "$BASETAR"
 
     # Create basic devices to be able to install packages
     [ -e "$DESTDIR"/dev/null ] || sudo mknod -m 666 "$DESTDIR"/dev/null c 1 3
@@ -80,8 +77,13 @@ if [ ! -d "$DST" ]; then
     exit 1
 fi
 
-# get the base
-wget -c http://cdimage.ubuntu.com/ubuntu-base/releases/22.04/release/ubuntu-base-22.04.1-base-amd64.tar.gz -O ubuntu-base.tar.gz
+# extract the base
+if [ -f /cdrom/casper/base.squashfs ]; then
+    sudo unsquashfs -d "$DESTDIR" /cdrom/casper/base.squashfs
+else
+    wget -c http://cdimage.ubuntu.com/ubuntu-base/releases/22.04/release/ubuntu-base-22.04.1-base-amd64.tar.gz -O ubuntu-base.tar.gz
+    sudo tar -C "$DESTDIR" -xf "$BASETAR"
+fi
 
 # create minimal rootfs
-create_classic_rootfs "$DST" ubuntu-base.tar.gz
+create_classic_rootfs "$DST"

--- a/tests/lib/fakeinstaller/mk-classic-rootfs.sh
+++ b/tests/lib/fakeinstaller/mk-classic-rootfs.sh
@@ -81,7 +81,8 @@ fi
 if [ -f /cdrom/casper/base.squashfs ]; then
     sudo unsquashfs -d "$DESTDIR" /cdrom/casper/base.squashfs
 else
-    wget -c http://cdimage.ubuntu.com/ubuntu-base/releases/22.04/release/ubuntu-base-22.04.1-base-amd64.tar.gz -O ubuntu-base.tar.gz
+    BASETAR=ubuntu-base.tar.gz
+    wget -c http://cdimage.ubuntu.com/ubuntu-base/releases/22.04/release/ubuntu-base-22.04.1-base-amd64.tar.gz -O "$BASETAR"
     sudo tar -C "$DESTDIR" -xf "$BASETAR"
 fi
 

--- a/tests/lib/fakeinstaller/mk-classic-rootfs.sh
+++ b/tests/lib/fakeinstaller/mk-classic-rootfs.sh
@@ -79,11 +79,11 @@ fi
 
 # extract the base
 if [ -f /cdrom/casper/base.squashfs ]; then
-    sudo unsquashfs -d "$DESTDIR" /cdrom/casper/base.squashfs
+    sudo unsquashfs -d "$DST" /cdrom/casper/base.squashfs
 else
     BASETAR=ubuntu-base.tar.gz
     wget -c http://cdimage.ubuntu.com/ubuntu-base/releases/22.04/release/ubuntu-base-22.04.1-base-amd64.tar.gz -O "$BASETAR"
-    sudo tar -C "$DESTDIR" -xf "$BASETAR"
+    sudo tar -C "$DST" -xf "$BASETAR"
 fi
 
 # create minimal rootfs

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -944,8 +944,8 @@ nested_force_stop_vm() {
 nested_force_start_vm() {
     # if the $NESTED_VM is using a swtpm, we need to wait until the file exists
     # because the file disappears temporarily after qemu exits
-    if systemctl show "$NESTED_VM" -p ExecStart | grep -q test-snapd-swtpm; then
-        retry -n 10 --wait 1 test -S /var/snap/test-snapd-swtpm/current/swtpm-sock
+    if systemctl show "$NESTED_VM" -p ExecStart | grep -q swtpm-mvo; then
+        retry -n 10 --wait 1 test -S /var/snap/swtpm-mvo/current/swtpm-sock
     fi
     systemctl start "$NESTED_VM"
 }
@@ -1073,16 +1073,16 @@ nested_start_core_vm_unit() {
         fi
 
         if nested_is_tpm_enabled; then
-            if snap list test-snapd-swtpm >/dev/null; then
+            if snap list swtpm-mvo >/dev/null; then
                 # reset the tpm state
-                rm /var/snap/test-snapd-swtpm/current/tpm2-00.permall
-                snap restart test-snapd-swtpm > /dev/null
+                rm /var/snap/swtpm-mvo/current/tpm2-00.permall
+                snap restart swtpm-mvo > /dev/null
             else
-                snap install test-snapd-swtpm --beta
+                snap install swtpm-mvo --edge
             fi
             # wait for the tpm sock file to exist
-            retry -n 10 --wait 1 test -S /var/snap/test-snapd-swtpm/current/swtpm-sock
-            PARAM_TPM="-chardev socket,id=chrtpm,path=/var/snap/test-snapd-swtpm/current/swtpm-sock -tpmdev emulator,id=tpm0,chardev=chrtpm -device tpm-tis,tpmdev=tpm0"
+            retry -n 10 --wait 1 test -S /var/snap/swtpm-mvo/current/swtpm-sock
+            PARAM_TPM="-chardev socket,id=chrtpm,path=/var/snap/swtpm-mvo/current/swtpm-sock -tpmdev emulator,id=tpm0,chardev=chrtpm -device tpm-tis,tpmdev=tpm0"
         fi
         PARAM_IMAGE="-drive file=$CURRENT_IMAGE,cache=none,format=raw,id=disk1,if=none -device virtio-blk-pci,drive=disk1,bootindex=1"
     else

--- a/tests/nested/manual/fakeinstaller/task.yaml
+++ b/tests/nested/manual/fakeinstaller/task.yaml
@@ -157,9 +157,8 @@ execute: |
   # TODO: this prevents "nested_prepare_ssh" inside nested_start_core_vm
   #       from running, we already have a user so this is not needed
   touch "$NESTED_IMAGES_DIR/$IMAGE_NAME.configured"
-  # TODO: disabled until https://github.com/mvo5/snappy/commit/71e39c73f7662c386eaf86f021ec443d7fa380c0 lands
-  #nested_start_core_vm
-  #
-  #remote.exec "cat /etc/os-release" | MATCH 'NAME="Ubuntu"'
-  #remote.exec "snap changes" | MATCH "Done.* Initialize system state"
-  #remote.exec "snap list" | MATCH pc-kernel
+  nested_start_core_vm
+
+  remote.exec "cat /etc/os-release" | MATCH 'NAME="Ubuntu"'
+  remote.exec "snap changes" | MATCH "Done.* Initialize system state"
+  remote.exec "snap list" | MATCH pc-kernel

--- a/tests/nested/manual/fakeinstaller/task.yaml
+++ b/tests/nested/manual/fakeinstaller/task.yaml
@@ -107,14 +107,14 @@ execute: |
   # and "install" the current seed to the fake disk
   ./fakeinstaller "$LABEL" "$loop_device" "$TESTSLIB"/fakeinstaller/mk-classic-rootfs.sh
   # validate that the fake installer created the expected partitions
-  fdisk -x "$loop_device" > fdisk_output
-  MATCH "${loop_device}p1 .* BIOS Boot"   < fdisk_output
+  sfdisk -d "$loop_device" > fdisk_output
+  MATCH "${loop_device}p1 .* name=\"BIOS Boot\""   < fdisk_output
   # TODO: the real MVP hybrid device will not contain a ubuntu-seed
   #       partition (needs a different gadget)
-  MATCH "${loop_device}p2 .* ubuntu-seed" < fdisk_output
-  MATCH "${loop_device}p3 .* ubuntu-boot" < fdisk_output
-  MATCH "${loop_device}p4 .* ubuntu-save" < fdisk_output
-  MATCH "${loop_device}p5 .* ubuntu-data" < fdisk_output
+  MATCH "${loop_device}p2 .* name=\"ubuntu-seed\"" < fdisk_output
+  MATCH "${loop_device}p3 .* name=\"ubuntu-boot\"" < fdisk_output
+  MATCH "${loop_device}p4 .* name=\"ubuntu-save\"" < fdisk_output
+  MATCH "${loop_device}p5 .* name=\"ubuntu-data\"" < fdisk_output
 
   # image partitions are not mounted anymore
   for d in ubuntu-seed ubuntu-boot ubuntu-data ubuntu-save; do


### PR DESCRIPTION
Further adjustments and cleanups to ensure that the full `fakeinstaller` nested test that can boot into the generated image.