### PR TITLE
cmd/snap: validation set refresh-enforce CLI support + spread test

### DIFF
--- a/client/snap_op.go
+++ b/client/snap_op.go
@@ -58,6 +58,7 @@ type SnapOptions struct {
 	Amend            bool            `json:"amend,omitempty"`
 	Transaction      TransactionType `json:"transaction,omitempty"`
 	QuotaGroupName   string          `json:"quota-group,omitempty"`
+	ValidationSets   []string        `json:"validation-sets,omitempty"`
 
 	Users []string `json:"users,omitempty"`
 }
@@ -120,12 +121,13 @@ type actionData struct {
 }
 
 type multiActionData struct {
-	Action        string          `json:"action"`
-	Snaps         []string        `json:"snaps,omitempty"`
-	Users         []string        `json:"users,omitempty"`
-	Transaction   TransactionType `json:"transaction,omitempty"`
-	IgnoreRunning bool            `json:"ignore-running,omitempty"`
-	Purge         bool            `json:"purge,omitempty"`
+	Action         string          `json:"action"`
+	Snaps          []string        `json:"snaps,omitempty"`
+	Users          []string        `json:"users,omitempty"`
+	Transaction    TransactionType `json:"transaction,omitempty"`
+	IgnoreRunning  bool            `json:"ignore-running,omitempty"`
+	Purge          bool            `json:"purge,omitempty"`
+	ValidationSets []string        `json:"validation-sets,omitempty"`
 }
 
 // Install adds the snap with the given name from the given channel (or
@@ -233,6 +235,7 @@ func (client *Client) doMultiSnapActionFull(actionName string, snaps []string, o
 		action.Transaction = options.Transaction
 		action.IgnoreRunning = options.IgnoreRunning
 		action.Purge = options.Purge
+		action.ValidationSets = options.ValidationSets
 	}
 
 	data, err := json.Marshal(&action)

--- a/cmd/snap/cmd_validate_test.go
+++ b/cmd/snap/cmd_validate_test.go
@@ -233,3 +233,67 @@ func (s *validateSuite) TestValidationSetsListEmpty(c *check.C) {
 	c.Check(s.Stderr(), check.Equals, "No validations are available\n")
 	c.Check(s.Stdout(), check.Equals, "")
 }
+
+func (s *validateSuite) TestValidateRefreshOnlyUsedWithEnforce(c *check.C) {
+	rest, err := main.Parser(main.Client()).ParseArgs([]string{"validate", "--refresh", "--monitor", "foo/bar"})
+	c.Assert(err, check.ErrorMatches, "--refresh can only be used together with --enforce")
+	c.Check(rest, check.HasLen, 1)
+	c.Check(s.Stderr(), check.Equals, "")
+	c.Check(s.Stdout(), check.Equals, "")
+}
+
+func (s *validateSuite) TestValidationSetsRefreshEnforce(c *check.C) {
+	n := 0
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		switch n {
+		case 0:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Check(r.URL.Path, check.Equals, "/v2/snaps")
+			w.WriteHeader(202)
+			fmt.Fprintln(w, `{"type": "async", "change": "42", "status-code": 202}`)
+		case 1:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/changes/42")
+			fmt.Fprintln(w, `{"type": "sync", "result": {"ready": true, "status": "Done", "data": {"snap-names": ["one","two"]}}}`)
+
+		default:
+			c.Fatalf("expected to get 2 requests, now on %d", n+1)
+		}
+
+		n++
+	})
+
+	rest, err := main.Parser(main.Client()).ParseArgs([]string{"validate", "--refresh", "--enforce", "foo/bar"})
+	c.Assert(err, check.IsNil)
+	c.Check(rest, check.HasLen, 0)
+	c.Check(s.Stderr(), check.Equals, "")
+	c.Check(s.Stdout(), check.Equals, "Refreshed/installed snaps \"one\", \"two\" to enforce validation set \"foo/bar\"\n")
+}
+
+func (s *validateSuite) TestValidationSetsRefreshEnforceNoUnmetConstraints(c *check.C) {
+	n := 0
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		switch n {
+		case 0:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Check(r.URL.Path, check.Equals, "/v2/snaps")
+			w.WriteHeader(202)
+			fmt.Fprintln(w, `{"type": "async", "change": "42", "status-code": 202}`)
+		case 1:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/changes/42")
+			fmt.Fprintln(w, `{"type": "sync", "result": {"ready": true, "status": "Done"}}`)
+
+		default:
+			c.Fatalf("expected to get 2 requests, now on %d", n+1)
+		}
+
+		n++
+	})
+
+	rest, err := main.Parser(main.Client()).ParseArgs([]string{"validate", "--refresh", "--enforce", "foo/bar"})
+	c.Assert(err, check.IsNil)
+	c.Check(rest, check.HasLen, 0)
+	c.Check(s.Stderr(), check.Equals, "")
+	c.Check(s.Stdout(), check.Equals, "Enforced validation set \"foo/bar\"\n")
+}

--- a/tests/main/snap-refresh-enforce/refresh-enforce-set.yaml
+++ b/tests/main/snap-refresh-enforce/refresh-enforce-set.yaml
@@ -1,0 +1,14 @@
+account-id: NI7Jstuu8gffcoXr02i1kYt898p6Co0A
+name: refresh-enforce-set
+sequence: 1
+snaps:
+  - name: test-snapd-tools
+    id: eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw
+    presence: required
+  - name: test-snapd-public
+    id: CWlm9w1mF4AShlK1fEPkB2FWS1W36cbF
+    presence: required
+    revision: 1
+  - name: hello-world
+    id: buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ
+    presence: invalid

--- a/tests/main/snap-refresh-enforce/task.yaml
+++ b/tests/main/snap-refresh-enforce/task.yaml
@@ -1,0 +1,45 @@
+summary: |
+  Ensure `snap validate --enforce --refresh` resolves validation set enforcement errors automatically.
+
+environment:
+  ACCOUNT_ID: NI7Jstuu8gffcoXr02i1kYt898p6Co0A
+
+restore: |
+  snap validate --forget "$ACCOUNT_ID"/refresh-enforce-set || true
+
+execute: |
+  echo "Check that --enforce --refresh installs required snaps"
+  # TODO: test the auto-resolution for wrong revisions by installing revision 2
+  # and checking it's moved to revision 1
+  snap install --channel=latest/stable test-snapd-public | MATCH "test-snapd-public 1\.0.+"
+  snap validate --refresh --enforce "$ACCOUNT_ID"/refresh-enforce-set
+
+  snap list | MATCH "test-snapd-tools +1\.0 +[0-9]+ +latest/stable"
+  snap list | MATCH "test-snapd-public +1\.0 +1 +latest/stable"
+
+  echo "Check that an invalid snap cannot be installed"
+  if snap install hello-world > log.txt 2>&1; then
+    echo "Expected snap install to fail"
+    exit 1
+  fi
+
+  "$TESTSTOOLS"/to-one-line "$(cat log.txt)" | MATCH "error: cannot install \"hello-world\": cannot install snap \"hello-world\" due to enforcing rules of validation set 16/$ACCOUNT_ID/refresh-enforce-set/1"
+
+  echo "Check that a required snap or revision cannot be removed"
+  if snap remove --purge test-snapd-tools > log.txt 2>&1; then
+    echo "Expected snap remove to fail"
+    exit 1
+  fi
+
+  "$TESTSTOOLS"/to-one-line "$(cat log.txt)" | MATCH "error: cannot remove \"test-snapd-tools\": snap \"test-snapd-tools\" is not removable: snap \"test-snapd-tools\" is required by validation sets: 16/$ACCOUNT_ID/refresh-enforce-set/1"
+
+  echo "Check that --enforce --refresh can't auto-resolve if it requires removing snaps"
+  snap validate --forget "$ACCOUNT_ID"/refresh-enforce-set
+  snap install hello-world
+
+  if snap validate --refresh --enforce "$ACCOUNT_ID"/refresh-enforce-set > log.txt 2>&1; then
+    echo "Expected snap validate --refresh --enforce to fail"
+    exit 1
+  fi
+
+  "$TESTSTOOLS"/to-one-line "$(cat log.txt)" | MATCH "error: cannot refresh: cannot auto-resolve validation set constraints that require removing snaps: \"hello-world\""


### PR DESCRIPTION
* 67ea0ac10f20d0c8fe9087cc42e59b31763d8055 adds CLI support for a `snap validate --refresh --enforce` command
* 5dfbde21e2c4f1953d27dc714e4d5589effbda9c adds a spread test providing integration test coverage of validation set constraint auto-resolution 