### PR TITLE
interfaces: make upower-observe implicit on core if /usr/libexec/upowerd exists

### DIFF
--- a/interfaces/builtin/upower_observe.go
+++ b/interfaces/builtin/upower_observe.go
@@ -26,6 +26,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/dbus"
 	"github.com/snapcore/snapd/interfaces/seccomp"
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -219,6 +220,7 @@ func (iface *upowerObserveInterface) Name() string {
 func (iface *upowerObserveInterface) StaticInfo() interfaces.StaticInfo {
 	return interfaces.StaticInfo{
 		Summary:              upowerObserveSummary,
+		ImplicitOnCore:       osutil.IsExecutable("/usr/libexec/upowerd"),
 		ImplicitOnClassic:    true,
 		BaseDeclarationSlots: upowerObserveBaseDeclarationSlots,
 	}

--- a/interfaces/builtin/upower_observe_test.go
+++ b/interfaces/builtin/upower_observe_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/seccomp"
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
@@ -216,6 +217,14 @@ func (s *UPowerObserveInterfaceSuite) TestConnectedSlotSnippetUsesPlugLabelOne(c
 	c.Assert(err, IsNil)
 	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.upowerd.app"})
 	c.Assert(apparmorSpec.SnippetForTag("snap.upowerd.app"), testutil.Contains, `peer=(label="snap.upower.app"),`)
+}
+
+func (s *UPowerObserveInterfaceSuite) TestStaticInfo(c *C) {
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Check(si.ImplicitOnCore, Equals, osutil.IsExecutable("/usr/libexec/upowerd"))
+	c.Check(si.ImplicitOnClassic, Equals, true)
+	c.Check(si.Summary, Equals, "allows operating as or reading from the UPower service")
+	c.Check(si.BaseDeclarationSlots, testutil.Contains, "upower-observe")
 }
 
 func (s *UPowerObserveInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -1130,7 +1130,6 @@ func (s *baseDeclSuite) TestConnectionImplicitOnClassicOrAppSnap(c *C) {
 		"network-manager": true,
 		"ofono":           true,
 		"pulseaudio":      true,
-		"upower-observe":  true,
 	}
 
 	for _, iface := range all {


### PR DESCRIPTION
This change is similar to one done for [polkit](https://github.com/snapcore/snapd/pull/12071).

We want to be able to use the upower-observe interface on Ubuntu Core Desktop, so need an implicit system slot to be present there. This PR takes the approach of providing an implicit slot if the executable /usr/libexec/upowerd exists. This should be true for Core Desktop, and false for regular Core.

Note that there used to be a upower snap, but this was [deprecated](https://forum.snapcraft.io/t/upower-snap-deprecation/14772).