### PR TITLE
cgroup: add Snap/Cgroup monitoring capabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/canonical/tcglog-parser v0.0.0-20210824131805-69fa1e9f0ad2 // indirect
 	github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7
 	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2
+	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.7.4-0.20190701202633-d83b6ffe499a
 	github.com/gvalkov/golang-evdev v0.0.0-20191114124502-287e62b94bcb
 	github.com/jessevdk/go-flags v1.5.1-0.20210607101731-3927b71304df

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 h1:ZpnhV/YsD2/4cESfV5+
 github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2/go.mod h1:bBOAhwG1umN6/6ZUMtDFBMQR8jRg9O75tm9K00oMsK4=
 github.com/google/go-cmp v0.2.1-0.20190312032427-6f77996f0c42 h1:q3pnF5JFBNRz8sRD+IRj7Y6DMyYGTNqnZ9axTbSfoNI=
 github.com/google/go-cmp v0.2.1-0.20190312032427-6f77996f0c42/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/mux v1.7.4-0.20190701202633-d83b6ffe499a h1:Rhv8JUcDkZJkUmzzjpysRtn5joJ/3T8Lt9QpdJZUz1c=
 github.com/gorilla/mux v1.7.4-0.20190701202633-d83b6ffe499a/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gvalkov/golang-evdev v0.0.0-20191114124502-287e62b94bcb h1:WHSAxLz3P5t4DKukfJ5wu7+aMyVkuTNSbCiAjVS92sM=

--- a/sandbox/cgroup/export_test.go
+++ b/sandbox/cgroup/export_test.go
@@ -111,3 +111,23 @@ func MockCgroupsFilePath(path string) (restore func()) {
 	cgroupsFilePath = path
 	return r
 }
+
+// MonitorFiles is currently used for testing. It allows to monitor a group of files/folders
+// and, when all of them have been deleted, emits the specified name through the channel.
+func (this *CGroupMonitor) MonitorFiles(name string, folders []string, channel chan string) {
+	data := appMonitorData{
+		name:        name,
+		cgroupPaths: folders,
+		channel:     channel,
+		npaths:      len(folders),
+	}
+	this.channel <- data
+}
+
+// NumberOfWaitingMonitors is currently used for testing. It returns the number of folders being
+// watched. This may not match the number of paths passed in MonitorFiles, because
+// the main loop monitors the parent folder, so if several monitored files/folders
+// are in the same parent folder, they will count as only one for this method.
+func (this *CGroupMonitor) NumberOfWaitingMonitors() int {
+	return len(this.watched)
+}

--- a/sandbox/cgroup/export_test.go
+++ b/sandbox/cgroup/export_test.go
@@ -111,23 +111,3 @@ func MockCgroupsFilePath(path string) (restore func()) {
 	cgroupsFilePath = path
 	return r
 }
-
-// MonitorFiles is currently used for testing. It allows to monitor a group of files/folders
-// and, when all of them have been deleted, emits the specified name through the channel.
-func (this *CGroupMonitor) MonitorFiles(name string, folders []string, channel chan string) {
-	data := appMonitorData{
-		name:        name,
-		cgroupPaths: folders,
-		channel:     channel,
-		npaths:      len(folders),
-	}
-	this.channel <- data
-}
-
-// NumberOfWaitingMonitors is currently used for testing. It returns the number of folders being
-// watched. This may not match the number of paths passed in MonitorFiles, because
-// the main loop monitors the parent folder, so if several monitored files/folders
-// are in the same parent folder, they will count as only one for this method.
-func (this *CGroupMonitor) NumberOfWaitingMonitors() int {
-	return len(this.watched)
-}

--- a/sandbox/cgroup/inotify/LICENSE
+++ b/sandbox/cgroup/inotify/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/sandbox/cgroup/inotify/PATENTS
+++ b/sandbox/cgroup/inotify/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/sandbox/cgroup/inotify/README.md
+++ b/sandbox/cgroup/inotify/README.md
@@ -1,0 +1,1 @@
+These files were downloaded from https://github.com/kubernetes/utils/tree/master/inotify

--- a/sandbox/cgroup/inotify/inotify.go
+++ b/sandbox/cgroup/inotify/inotify.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inotify
+
+import (
+	"sync"
+)
+
+// Event represents a notification
+type Event struct {
+	Mask   uint32 // Mask of events
+	Cookie uint32 // Unique cookie associating related events (for rename(2))
+	Name   string // File name (optional)
+}
+
+type watch struct {
+	wd    uint32 // Watch descriptor (as returned by the inotify_add_watch() syscall)
+	flags uint32 // inotify flags of this watch (see inotify(7) for the list of valid flags)
+}
+
+// Watcher represents an inotify instance
+type Watcher struct {
+	mu       sync.Mutex
+	fd       int               // File descriptor (as returned by the inotify_init() syscall)
+	watches  map[string]*watch // Map of inotify watches (key: path)
+	paths    map[int]string    // Map of watched paths (key: watch descriptor)
+	Error    chan error        // Errors are sent on this channel
+	Event    chan *Event       // Events are returned on this channel
+	done     chan bool         // Channel for sending a "quit message" to the reader goroutine
+	isClosed bool              // Set to true when Close() is first called
+}

--- a/sandbox/cgroup/inotify/inotify_linux.go
+++ b/sandbox/cgroup/inotify/inotify_linux.go
@@ -1,0 +1,315 @@
+//go:build linux
+// +build linux
+
+// Copyright 2010 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+/*
+Package inotify implements a wrapper for the Linux inotify system.
+
+Example:
+    watcher, err := inotify.NewWatcher()
+    if err != nil {
+        log.Fatal(err)
+    }
+    err = watcher.Watch("/tmp")
+    if err != nil {
+        log.Fatal(err)
+    }
+    for {
+        select {
+        case ev := <-watcher.Event:
+            log.Println("event:", ev)
+        case err := <-watcher.Error:
+            log.Println("error:", err)
+        }
+    }
+
+*/
+package inotify
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"syscall"
+	"unsafe"
+)
+
+// NewWatcher creates and returns a new inotify instance using inotify_init(2)
+func NewWatcher() (*Watcher, error) {
+	fd, errno := syscall.InotifyInit1(syscall.IN_CLOEXEC)
+	if fd == -1 {
+		return nil, os.NewSyscallError("inotify_init", errno)
+	}
+	w := &Watcher{
+		fd:      fd,
+		watches: make(map[string]*watch),
+		paths:   make(map[int]string),
+		Event:   make(chan *Event),
+		Error:   make(chan error),
+		done:    make(chan bool, 1),
+	}
+
+	go w.readEvents()
+	return w, nil
+}
+
+// Close closes an inotify watcher instance
+// It sends a message to the reader goroutine to quit and removes all watches
+// associated with the inotify instance
+func (w *Watcher) Close() error {
+	if w.isClosed {
+		return nil
+	}
+	w.isClosed = true
+
+	// Send "quit" message to the reader goroutine
+	w.done <- true
+	for path := range w.watches {
+		w.RemoveWatch(path)
+	}
+
+	return nil
+}
+
+// AddWatch adds path to the watched file set.
+// The flags are interpreted as described in inotify_add_watch(2).
+func (w *Watcher) AddWatch(path string, flags uint32) error {
+	if w.isClosed {
+		return errors.New("inotify instance already closed")
+	}
+
+	watchEntry, found := w.watches[path]
+	if found {
+		watchEntry.flags |= flags
+		flags |= syscall.IN_MASK_ADD
+	}
+
+	w.mu.Lock() // synchronize with readEvents goroutine
+
+	wd, err := syscall.InotifyAddWatch(w.fd, path, flags)
+	if err != nil {
+		w.mu.Unlock()
+		return &os.PathError{
+			Op:   "inotify_add_watch",
+			Path: path,
+			Err:  err,
+		}
+	}
+
+	if !found {
+		w.watches[path] = &watch{wd: uint32(wd), flags: flags}
+		w.paths[wd] = path
+	}
+	w.mu.Unlock()
+	return nil
+}
+
+// Watch adds path to the watched file set, watching all events.
+func (w *Watcher) Watch(path string) error {
+	return w.AddWatch(path, InAllEvents)
+}
+
+// RemoveWatch removes path from the watched file set.
+func (w *Watcher) RemoveWatch(path string) error {
+	watch, ok := w.watches[path]
+	if !ok {
+		return fmt.Errorf("can't remove non-existent inotify watch for: %s", path)
+	}
+	success, errno := syscall.InotifyRmWatch(w.fd, watch.wd)
+	if success == -1 {
+		// when file descriptor or watch descriptor not found, InotifyRmWatch syscall return EINVAL error
+		// if return error, it may lead this path remain in watches and paths map, and no other event can trigger remove action.
+		if errno != syscall.EINVAL {
+			return os.NewSyscallError("inotify_rm_watch", errno)
+		}
+	}
+	delete(w.watches, path)
+	// Locking here to protect the read from paths in readEvents.
+	w.mu.Lock()
+	delete(w.paths, int(watch.wd))
+	w.mu.Unlock()
+	return nil
+}
+
+// readEvents reads from the inotify file descriptor, converts the
+// received events into Event objects and sends them via the Event channel
+func (w *Watcher) readEvents() {
+	var buf [syscall.SizeofInotifyEvent * 4096]byte
+
+	for {
+		n, err := syscall.Read(w.fd, buf[:])
+		// See if there is a message on the "done" channel
+		var done bool
+		select {
+		case done = <-w.done:
+		default:
+		}
+
+		// If EOF or a "done" message is received
+		if n == 0 || done {
+			// The syscall.Close can be slow.  Close
+			// w.Event first.
+			close(w.Event)
+			err := syscall.Close(w.fd)
+			if err != nil {
+				w.Error <- os.NewSyscallError("close", err)
+			}
+			close(w.Error)
+			return
+		}
+		if n < 0 {
+			w.Error <- os.NewSyscallError("read", err)
+			continue
+		}
+		if n < syscall.SizeofInotifyEvent {
+			w.Error <- errors.New("inotify: short read in readEvents()")
+			continue
+		}
+
+		var offset uint32
+		// We don't know how many events we just read into the buffer
+		// While the offset points to at least one whole event...
+		for offset <= uint32(n-syscall.SizeofInotifyEvent) {
+			// Point "raw" to the event in the buffer
+			raw := (*syscall.InotifyEvent)(unsafe.Pointer(&buf[offset]))
+			event := new(Event)
+			event.Mask = uint32(raw.Mask)
+			event.Cookie = uint32(raw.Cookie)
+			nameLen := uint32(raw.Len)
+			// If the event happened to the watched directory or the watched file, the kernel
+			// doesn't append the filename to the event, but we would like to always fill the
+			// the "Name" field with a valid filename. We retrieve the path of the watch from
+			// the "paths" map.
+			w.mu.Lock()
+			name, ok := w.paths[int(raw.Wd)]
+			w.mu.Unlock()
+			if ok {
+				event.Name = name
+				if nameLen > 0 {
+					// Point "bytes" at the first byte of the filename
+					bytes := (*[syscall.PathMax]byte)(unsafe.Pointer(&buf[offset+syscall.SizeofInotifyEvent]))
+					// The filename is padded with NUL bytes. TrimRight() gets rid of those.
+					event.Name += "/" + strings.TrimRight(string(bytes[0:nameLen]), "\000")
+				}
+				// Send the event on the events channel
+				w.Event <- event
+			}
+			// Move to the next event in the buffer
+			offset += syscall.SizeofInotifyEvent + nameLen
+		}
+	}
+}
+
+// String formats the event e in the form
+// "filename: 0xEventMask = IN_ACCESS|IN_ATTRIB_|..."
+func (e *Event) String() string {
+	var events string
+
+	m := e.Mask
+	for _, b := range eventBits {
+		if m&b.Value == b.Value {
+			m &^= b.Value
+			events += "|" + b.Name
+		}
+	}
+
+	if m != 0 {
+		events += fmt.Sprintf("|%#x", m)
+	}
+	if len(events) > 0 {
+		events = " == " + events[1:]
+	}
+
+	return fmt.Sprintf("%q: %#x%s", e.Name, e.Mask, events)
+}
+
+const (
+	// Options for inotify_init() are not exported
+	// IN_CLOEXEC    uint32 = syscall.IN_CLOEXEC
+	// IN_NONBLOCK   uint32 = syscall.IN_NONBLOCK
+
+	// Options for AddWatch
+
+	// InDontFollow : Don't dereference pathname if it is a symbolic link
+	InDontFollow uint32 = syscall.IN_DONT_FOLLOW
+	// InOneshot : Monitor the filesystem object corresponding to pathname for one event, then remove from watch list
+	InOneshot uint32 = syscall.IN_ONESHOT
+	// InOnlydir : Watch pathname only if it is a directory
+	InOnlydir uint32 = syscall.IN_ONLYDIR
+
+	// The "IN_MASK_ADD" option is not exported, as AddWatch
+	// adds it automatically, if there is already a watch for the given path
+	// IN_MASK_ADD      uint32 = syscall.IN_MASK_ADD
+
+	// Events
+
+	// InAccess : File was accessed
+	InAccess uint32 = syscall.IN_ACCESS
+	// InAllEvents : Bit mask for all notify events
+	InAllEvents uint32 = syscall.IN_ALL_EVENTS
+	// InAttrib : Metadata changed
+	InAttrib uint32 = syscall.IN_ATTRIB
+	// InClose : Equates to IN_CLOSE_WRITE | IN_CLOSE_NOWRITE
+	InClose uint32 = syscall.IN_CLOSE
+	// InCloseNowrite : File or directory not opened for writing was closed
+	InCloseNowrite uint32 = syscall.IN_CLOSE_NOWRITE
+	// InCloseWrite : File opened for writing was closed
+	InCloseWrite uint32 = syscall.IN_CLOSE_WRITE
+	// InCreate : File/directory created in watched directory
+	InCreate uint32 = syscall.IN_CREATE
+	// InDelete : File/directory deleted from watched directory
+	InDelete uint32 = syscall.IN_DELETE
+	// InDeleteSelf : Watched file/directory was itself deleted
+	InDeleteSelf uint32 = syscall.IN_DELETE_SELF
+	// InModify : File was modified
+	InModify uint32 = syscall.IN_MODIFY
+	// InMove : Equates to IN_MOVED_FROM | IN_MOVED_TO
+	InMove uint32 = syscall.IN_MOVE
+	// InMovedFrom : Generated for the directory containing the old filename when a file is renamed
+	InMovedFrom uint32 = syscall.IN_MOVED_FROM
+	// InMovedTo : Generated for the directory containing the new filename when a file is renamed
+	InMovedTo uint32 = syscall.IN_MOVED_TO
+	// InMoveSelf : Watched file/directory was itself moved
+	InMoveSelf uint32 = syscall.IN_MOVE_SELF
+	// InOpen : File or directory was opened
+	InOpen uint32 = syscall.IN_OPEN
+
+	// Special events
+
+	// InIsdir : Subject of this event is a directory
+	InIsdir uint32 = syscall.IN_ISDIR
+	// InIgnored : Watch was removed explicitly or automatically
+	InIgnored uint32 = syscall.IN_IGNORED
+	// InQOverflow : Event queue overflowed
+	InQOverflow uint32 = syscall.IN_Q_OVERFLOW
+	// InUnmount : Filesystem containing watched object was unmounted
+	InUnmount uint32 = syscall.IN_UNMOUNT
+)
+
+var eventBits = []struct {
+	Value uint32
+	Name  string
+}{
+	{InAccess, "IN_ACCESS"},
+	{InAttrib, "IN_ATTRIB"},
+	{InClose, "IN_CLOSE"},
+	{InCloseNowrite, "IN_CLOSE_NOWRITE"},
+	{InCloseWrite, "IN_CLOSE_WRITE"},
+	{InCreate, "IN_CREATE"},
+	{InDelete, "IN_DELETE"},
+	{InDeleteSelf, "IN_DELETE_SELF"},
+	{InModify, "IN_MODIFY"},
+	{InMove, "IN_MOVE"},
+	{InMovedFrom, "IN_MOVED_FROM"},
+	{InMovedTo, "IN_MOVED_TO"},
+	{InMoveSelf, "IN_MOVE_SELF"},
+	{InOpen, "IN_OPEN"},
+	{InIsdir, "IN_ISDIR"},
+	{InIgnored, "IN_IGNORED"},
+	{InQOverflow, "IN_Q_OVERFLOW"},
+	{InUnmount, "IN_UNMOUNT"},
+}

--- a/sandbox/cgroup/inotify/inotify_linux_test.go
+++ b/sandbox/cgroup/inotify/inotify_linux_test.go
@@ -1,0 +1,110 @@
+//go:build linux
+// +build linux
+
+// Copyright 2010 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package inotify_test
+
+import (
+	"io/ioutil"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/snapcore/snapd/sandbox/cgroup/inotify"
+)
+
+func TestInotifyEvents(t *testing.T) {
+	// Create an inotify watcher instance and initialize it
+	watcher, err := inotify.NewWatcher()
+	if err != nil {
+		t.Fatalf("NewWatcher failed: %s", err)
+	}
+
+	dir, err := ioutil.TempDir("", "inotify")
+	if err != nil {
+		t.Fatalf("TempDir failed: %s", err)
+	}
+	defer os.RemoveAll(dir)
+
+	// Add a watch for "_test"
+	err = watcher.Watch(dir)
+	if err != nil {
+		t.Fatalf("Watch failed: %s", err)
+	}
+
+	// Receive errors on the error channel on a separate goroutine
+	go func() {
+		for err := range watcher.Error {
+			t.Errorf("error received: %s", err)
+		}
+	}()
+
+	testFile := dir + "/TestInotifyEvents.testfile"
+
+	// Receive events on the event channel on a separate goroutine
+	eventstream := watcher.Event
+	var eventsReceived int32
+	done := make(chan bool)
+	go func() {
+		for event := range eventstream {
+			// Only count relevant events
+			if event.Name == testFile {
+				atomic.AddInt32(&eventsReceived, 1)
+				t.Logf("event received: %s", event)
+			} else {
+				t.Logf("unexpected event received: %s", event)
+			}
+		}
+		done <- true
+	}()
+
+	// Create a file
+	// This should add at least one event to the inotify event queue
+	_, err = os.OpenFile(testFile, os.O_WRONLY|os.O_CREATE, 0666)
+	if err != nil {
+		t.Fatalf("creating test file: %s", err)
+	}
+
+	// We expect this event to be received almost immediately, but let's wait 1 s to be sure
+	time.Sleep(1 * time.Second)
+	if atomic.AddInt32(&eventsReceived, 0) == 0 {
+		t.Fatal("inotify event hasn't been received after 1 second")
+	}
+
+	// Try closing the inotify instance
+	t.Log("calling Close()")
+	watcher.Close()
+	t.Log("waiting for the event channel to become closed...")
+	select {
+	case <-done:
+		t.Log("event channel closed")
+	case <-time.After(1 * time.Second):
+		t.Fatal("event stream was not closed after 1 second")
+	}
+}
+
+func TestInotifyClose(t *testing.T) {
+	watcher, _ := inotify.NewWatcher()
+	watcher.Close()
+
+	done := make(chan bool)
+	go func() {
+		watcher.Close()
+		done <- true
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(50 * time.Millisecond):
+		t.Fatal("double Close() test failed: second Close() call didn't return")
+	}
+
+	err := watcher.Watch(os.TempDir())
+	if err == nil {
+		t.Fatal("expected error on Watch() after Close(), got nil")
+	}
+}

--- a/sandbox/cgroup/inotify/inotify_others.go
+++ b/sandbox/cgroup/inotify/inotify_others.go
@@ -1,0 +1,59 @@
+//go:build !linux
+// +build !linux
+
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inotify // import "k8s.io/utils/inotify"
+
+import (
+	"fmt"
+	"runtime"
+)
+
+var errNotSupported = fmt.Errorf("watch not supported on %s", runtime.GOOS)
+
+const (
+	InDelete uint32 = 0
+)
+
+// NewWatcher creates and returns a new inotify instance using inotify_init(2)
+func NewWatcher() (*Watcher, error) {
+	return nil, errNotSupported
+}
+
+// Close closes an inotify watcher instance
+// It sends a message to the reader goroutine to quit and removes all watches
+// associated with the inotify instance
+func (w *Watcher) Close() error {
+	return errNotSupported
+}
+
+// AddWatch adds path to the watched file set.
+// The flags are interpreted as described in inotify_add_watch(2).
+func (w *Watcher) AddWatch(path string, flags uint32) error {
+	return errNotSupported
+}
+
+// Watch adds path to the watched file set, watching all events.
+func (w *Watcher) Watch(path string) error {
+	return errNotSupported
+}
+
+// RemoveWatch removes path from the watched file set.
+func (w *Watcher) RemoveWatch(path string) error {
+	return errNotSupported
+}

--- a/sandbox/cgroup/monitor.go
+++ b/sandbox/cgroup/monitor.go
@@ -119,7 +119,6 @@ func monitorMainLoop() {
 }
 
 // GetDefaultCGroupMonitor launches the main loop and returns the CGroup singleton
-
 func GetDefaultCGroupMonitor() *CGroupMonitor {
 	if currentCGroupMonitor.watcher == nil {
 		wd, err := inotify.NewWatcher()

--- a/sandbox/cgroup/monitor.go
+++ b/sandbox/cgroup/monitor.go
@@ -1,0 +1,161 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package cgroup
+
+import (
+	"errors"
+	"os"
+	"path"
+
+	"github.com/snapcore/snapd/sandbox/cgroup/inotify"
+)
+
+type appData struct {
+	name        string
+	cgroupPaths []string
+	npaths      int
+	channel     chan string
+}
+
+// This class allows to monitor a CGroup and detect when all the running
+// instances have been closed
+
+type CGroupMonitor struct {
+	watched map[string][]*appData
+	watcher *inotify.Watcher
+	channel chan appData
+}
+
+var currentCGroupMonitor = CGroupMonitor{
+	watcher: nil,
+	channel: make(chan appData),
+	watched: make(map[string][]*appData),
+}
+
+func monitorMainLoop() {
+	for {
+		select {
+		case event := <-currentCGroupMonitor.watcher.Event:
+			if event.Mask&inotify.InDelete != 0 {
+				basePath := path.Dir(event.Name)
+				entry := currentCGroupMonitor.watched[basePath]
+				var newList []*appData
+				for _, app := range entry {
+					for _, folder := range app.cgroupPaths {
+						if folder == event.Name {
+							app.npaths--
+						}
+					}
+					if app.npaths == 0 {
+						// all the folders have disappeared, so notify that this app has no more instances running
+						app.channel <- app.name
+					} else {
+						if app.npaths > 0 {
+							newList = append(newList, app)
+						}
+					}
+				}
+				if len(newList) != 0 {
+					currentCGroupMonitor.watched[basePath] = newList
+				} else {
+					delete(currentCGroupMonitor.watched, basePath)
+					currentCGroupMonitor.watcher.RemoveWatch(basePath)
+				}
+			}
+		case newApp := <-currentCGroupMonitor.channel:
+			if newApp.npaths == 0 {
+				newApp.channel <- newApp.name
+			} else {
+				addedPaths := false
+				for _, fullPath := range newApp.cgroupPaths {
+					basePath := path.Dir(fullPath) // Monitor the path containing this folder
+					_, exists := currentCGroupMonitor.watched[basePath]
+					if !exists {
+						err := currentCGroupMonitor.watcher.AddWatch(basePath, inotify.InDelete)
+						if err != nil {
+							continue
+						}
+						if _, err := os.Stat(fullPath); errors.Is(err, os.ErrNotExist) {
+							// if the file/folder to monitor doesn't exist after the parent being added, remove it
+							currentCGroupMonitor.watcher.RemoveWatch(basePath)
+							continue
+						}
+						currentCGroupMonitor.watched[basePath] = append(currentCGroupMonitor.watched[basePath], &newApp)
+						addedPaths = true
+					}
+				}
+				if !addedPaths {
+					// if the files/folders to monitor don't exist, send the notification now
+					newApp.channel <- newApp.name
+				}
+			}
+		}
+	}
+}
+
+// Launches the main loop and returns the CGroup singleton
+
+func GetDefaultCGroupMonitor() *CGroupMonitor {
+	if currentCGroupMonitor.watcher == nil {
+		wd, err := inotify.NewWatcher()
+		if err != nil {
+			return nil
+		}
+		currentCGroupMonitor.watcher = wd
+		go monitorMainLoop()
+	}
+	return &currentCGroupMonitor
+}
+
+// This is the method to call to monitor the running instances of an specific Snap.
+// It receives the name of the snap to monitor (for example, "firefox" or "steam")
+// and a channel. The caller can wait on the channel, and when all the instances of
+// the specific snap have ended, the name of the snap will be sent through the channel.
+// This allows to use the same channel to monitor several snaps
+func (this CGroupMonitor) MonitorSnap(snapName string, channel chan string) {
+	paths, _ := InstancePathsOfSnap(snapName, InstancePathsFlagsOnlyPaths)
+	data := appData{
+		name:        snapName,
+		cgroupPaths: paths,
+		channel:     channel,
+		npaths:      len(paths),
+	}
+	this.channel <- data
+}
+
+// This method is currently used for testing. It allows to monitor a group of files/folders
+// and, when all of them have been deleted, emits the specified name through the channel.
+func (this CGroupMonitor) MonitorFiles(name string, folders []string, channel chan string) {
+	data := appData{
+		name:        name,
+		cgroupPaths: folders,
+		channel:     channel,
+		npaths:      len(folders),
+	}
+	this.channel <- data
+}
+
+// This method is currently used for testing. It returns the number of folders being
+// watched. This may not match the number of paths passed in MonitorFiles, because
+// the main loop monitors the parent folder, so if several monitores files/folders
+// are in the same parent folder, they will count as only one for this method.
+func (this CGroupMonitor) NumberOfWaitingMonitors() int {
+	return len(this.watched)
+}

--- a/sandbox/cgroup/monitor.go
+++ b/sandbox/cgroup/monitor.go
@@ -40,7 +40,7 @@ type appMonitorData struct {
 // CGroupMonitor allows to monitor several CGroups, detect when all
 // the running instances of each one have been closed, and notify
 // them separately. It should be considered a singleton, and
-// obtained using DefaultCGroupMonitor().
+// obtained using MonitorSingleton().
 type CGroupMonitor struct {
 	watched map[string][]*appMonitorData
 	watcher *inotify.Watcher
@@ -121,8 +121,8 @@ func monitorMainLoop() {
 	}
 }
 
-// DefaultCGroupMonitor launches the main loop and returns the CGroup singleton
-func DefaultCGroupMonitor() *CGroupMonitor {
+// MonitorSingleton launches the main loop and returns the CGroupMonitor singleton
+func MonitorSingleton() *CGroupMonitor {
 	if currentCGroupMonitor.watcher == nil {
 		wd, err := inotify.NewWatcher()
 		if err != nil {

--- a/sandbox/cgroup/monitor.go
+++ b/sandbox/cgroup/monitor.go
@@ -49,63 +49,71 @@ var currentCGroupMonitor = CGroupMonitor{
 	watched: make(map[string][]*appData),
 }
 
+func deletedFile(filename string) {
+	basePath := path.Dir(filename)
+	entry := currentCGroupMonitor.watched[basePath]
+	var newList []*appData
+	for _, app := range entry {
+		for _, folder := range app.cgroupPaths {
+			if folder == filename {
+				app.npaths--
+			}
+		}
+		if app.npaths == 0 {
+			// all the folders have disappeared, so notify that this app has no more instances running
+			app.channel <- app.name
+		} else {
+			if app.npaths > 0 {
+				newList = append(newList, app)
+			}
+		}
+	}
+	if len(newList) != 0 {
+		currentCGroupMonitor.watched[basePath] = newList
+	} else {
+		delete(currentCGroupMonitor.watched, basePath)
+		currentCGroupMonitor.watcher.RemoveWatch(basePath)
+	}
+}
+
+func addFiles(newApp *appData) {
+	if newApp.npaths == 0 {
+		newApp.channel <- newApp.name
+	} else {
+		addedPaths := false
+		for _, fullPath := range newApp.cgroupPaths {
+			basePath := path.Dir(fullPath) // Monitor the path containing this folder
+			_, exists := currentCGroupMonitor.watched[basePath]
+			if !exists {
+				err := currentCGroupMonitor.watcher.AddWatch(basePath, inotify.InDelete)
+				if err != nil {
+					continue
+				}
+				if _, err := os.Stat(fullPath); errors.Is(err, os.ErrNotExist) {
+					// if the file/folder to monitor doesn't exist after the parent being added, remove it
+					currentCGroupMonitor.watcher.RemoveWatch(basePath)
+					continue
+				}
+				currentCGroupMonitor.watched[basePath] = append(currentCGroupMonitor.watched[basePath], newApp)
+				addedPaths = true
+			}
+		}
+		if !addedPaths {
+			// if the files/folders to monitor don't exist, send the notification now
+			newApp.channel <- newApp.name
+		}
+	}
+}
+
 func monitorMainLoop() {
 	for {
 		select {
 		case event := <-currentCGroupMonitor.watcher.Event:
 			if event.Mask&inotify.InDelete != 0 {
-				basePath := path.Dir(event.Name)
-				entry := currentCGroupMonitor.watched[basePath]
-				var newList []*appData
-				for _, app := range entry {
-					for _, folder := range app.cgroupPaths {
-						if folder == event.Name {
-							app.npaths--
-						}
-					}
-					if app.npaths == 0 {
-						// all the folders have disappeared, so notify that this app has no more instances running
-						app.channel <- app.name
-					} else {
-						if app.npaths > 0 {
-							newList = append(newList, app)
-						}
-					}
-				}
-				if len(newList) != 0 {
-					currentCGroupMonitor.watched[basePath] = newList
-				} else {
-					delete(currentCGroupMonitor.watched, basePath)
-					currentCGroupMonitor.watcher.RemoveWatch(basePath)
-				}
+				deletedFile(event.Name)
 			}
 		case newApp := <-currentCGroupMonitor.channel:
-			if newApp.npaths == 0 {
-				newApp.channel <- newApp.name
-			} else {
-				addedPaths := false
-				for _, fullPath := range newApp.cgroupPaths {
-					basePath := path.Dir(fullPath) // Monitor the path containing this folder
-					_, exists := currentCGroupMonitor.watched[basePath]
-					if !exists {
-						err := currentCGroupMonitor.watcher.AddWatch(basePath, inotify.InDelete)
-						if err != nil {
-							continue
-						}
-						if _, err := os.Stat(fullPath); errors.Is(err, os.ErrNotExist) {
-							// if the file/folder to monitor doesn't exist after the parent being added, remove it
-							currentCGroupMonitor.watcher.RemoveWatch(basePath)
-							continue
-						}
-						currentCGroupMonitor.watched[basePath] = append(currentCGroupMonitor.watched[basePath], &newApp)
-						addedPaths = true
-					}
-				}
-				if !addedPaths {
-					// if the files/folders to monitor don't exist, send the notification now
-					newApp.channel <- newApp.name
-				}
-			}
+			addFiles(&newApp)
 		}
 	}
 }

--- a/sandbox/cgroup/monitor.go
+++ b/sandbox/cgroup/monitor.go
@@ -149,23 +149,3 @@ func (this *CGroupMonitor) MonitorSnap(snapName string, channel chan string) {
 	}
 	this.channel <- data
 }
-
-// MonitorFiles is currently used for testing. It allows to monitor a group of files/folders
-// and, when all of them have been deleted, emits the specified name through the channel.
-func (this *CGroupMonitor) MonitorFiles(name string, folders []string, channel chan string) {
-	data := appMonitorData{
-		name:        name,
-		cgroupPaths: folders,
-		channel:     channel,
-		npaths:      len(folders),
-	}
-	this.channel <- data
-}
-
-// NumberOfWaitingMonitors is currently used for testing. It returns the number of folders being
-// watched. This may not match the number of paths passed in MonitorFiles, because
-// the main loop monitors the parent folder, so if several monitored files/folders
-// are in the same parent folder, they will count as only one for this method.
-func (this *CGroupMonitor) NumberOfWaitingMonitors() int {
-	return len(this.watched)
-}

--- a/sandbox/cgroup/monitor.go
+++ b/sandbox/cgroup/monitor.go
@@ -27,7 +27,7 @@ import (
 	"github.com/snapcore/snapd/sandbox/cgroup/inotify"
 )
 
-// appMonitorData contains all the data to monitor an specific Snap:
+// appMonitorData contains all the data to monitor a specific Snap:
 // its name, the list of paths to monitor, and the channel to send
 // the notification when all the paths have been deleted.
 type appMonitorData struct {

--- a/sandbox/cgroup/monitor.go
+++ b/sandbox/cgroup/monitor.go
@@ -53,7 +53,7 @@ var currentCGroupMonitor = CGroupMonitor{
 	watched: make(map[string][]*appMonitorData),
 }
 
-func deletedFile(filename string) {
+func onFilesDeleted(filename string) {
 	basePath := path.Dir(filename)
 	entry := currentCGroupMonitor.watched[basePath]
 	var newList []*appMonitorData
@@ -78,7 +78,7 @@ func deletedFile(filename string) {
 	}
 }
 
-func addFiles(newApp *appMonitorData) {
+func onFilesAdded(newApp *appMonitorData) {
 	if newApp.npaths == 0 {
 		newApp.channel <- newApp.name
 	} else {
@@ -113,10 +113,10 @@ func monitorMainLoop() {
 		select {
 		case event := <-currentCGroupMonitor.watcher.Event:
 			if event.Mask&inotify.InDelete != 0 {
-				deletedFile(event.Name)
+				onFilesDeleted(event.Name)
 			}
 		case newApp := <-currentCGroupMonitor.channel:
-			addFiles(&newApp)
+			onFilesAdded(&newApp)
 		}
 	}
 }

--- a/sandbox/cgroup/monitor.go
+++ b/sandbox/cgroup/monitor.go
@@ -139,7 +139,7 @@ func MonitorSingleton() *CGroupMonitor {
 // and a channel. The caller can wait on the channel, and when all the instances of
 // the specific snap have ended, the name of the snap will be sent through the channel.
 // This allows to use the same channel to monitor several snaps
-func (this CGroupMonitor) MonitorSnap(snapName string, channel chan string) {
+func (this *CGroupMonitor) MonitorSnap(snapName string, channel chan string) {
 	paths, _ := InstancePathsOfSnap(snapName, InstancePathsFlagsOnlyPaths)
 	data := appMonitorData{
 		name:        snapName,
@@ -152,7 +152,7 @@ func (this CGroupMonitor) MonitorSnap(snapName string, channel chan string) {
 
 // MonitorFiles is currently used for testing. It allows to monitor a group of files/folders
 // and, when all of them have been deleted, emits the specified name through the channel.
-func (this CGroupMonitor) MonitorFiles(name string, folders []string, channel chan string) {
+func (this *CGroupMonitor) MonitorFiles(name string, folders []string, channel chan string) {
 	data := appMonitorData{
 		name:        name,
 		cgroupPaths: folders,
@@ -166,6 +166,6 @@ func (this CGroupMonitor) MonitorFiles(name string, folders []string, channel ch
 // watched. This may not match the number of paths passed in MonitorFiles, because
 // the main loop monitors the parent folder, so if several monitored files/folders
 // are in the same parent folder, they will count as only one for this method.
-func (this CGroupMonitor) NumberOfWaitingMonitors() int {
+func (this *CGroupMonitor) NumberOfWaitingMonitors() int {
 	return len(this.watched)
 }

--- a/sandbox/cgroup/monitor.go
+++ b/sandbox/cgroup/monitor.go
@@ -132,7 +132,10 @@ func (this *CGroupMonitor) monitorMainLoop() {
 // the specific snap have ended, the name of the snap will be sent through the channel.
 // This allows to use the same channel to monitor several snaps
 func MonitorSnap(snapName string, channel chan string) bool {
-	paths, _ := InstancePathsOfSnap(snapName, InstancePathsFlagsOnlyPaths)
+	options := InstancePathsOptions{
+		returnCGroupPath: true,
+	}
+	paths, _ := InstancePathsOfSnap(snapName, options)
 	return MonitorFiles(snapName, paths, channel)
 }
 

--- a/sandbox/cgroup/monitor.go
+++ b/sandbox/cgroup/monitor.go
@@ -160,7 +160,7 @@ func (this CGroupMonitor) MonitorFiles(name string, folders []string, channel ch
 	this.channel <- data
 }
 
-// This method is currently used for testing. It returns the number of folders being
+// NumberOfWaitingMonitors is currently used for testing. It returns the number of folders being
 // watched. This may not match the number of paths passed in MonitorFiles, because
 // the main loop monitors the parent folder, so if several monitored files/folders
 // are in the same parent folder, they will count as only one for this method.

--- a/sandbox/cgroup/monitor.go
+++ b/sandbox/cgroup/monitor.go
@@ -67,9 +67,7 @@ func deletedFile(filename string) {
 			// all the folders have disappeared, so notify that this app has no more instances running
 			app.channel <- app.name
 		} else {
-			if app.npaths > 0 {
-				newList = append(newList, app)
-			}
+			newList = append(newList, app)
 		}
 	}
 	if len(newList) != 0 {

--- a/sandbox/cgroup/monitor.go
+++ b/sandbox/cgroup/monitor.go
@@ -55,9 +55,9 @@ var currentCGroupMonitor = CGroupMonitor{
 
 func onFilesDeleted(filename string) {
 	basePath := path.Dir(filename)
-	entry := currentCGroupMonitor.watched[basePath]
+	appWatchers := currentCGroupMonitor.watched[basePath]
 	var newList []*appMonitorData
-	for _, app := range entry {
+	for _, app := range appWatchers {
 		for _, folder := range app.cgroupPaths {
 			if folder == filename {
 				app.npaths--

--- a/sandbox/cgroup/monitor.go
+++ b/sandbox/cgroup/monitor.go
@@ -118,7 +118,7 @@ func monitorMainLoop() {
 	}
 }
 
-// Launches the main loop and returns the CGroup singleton
+// GetDefaultCGroupMonitor launches the main loop and returns the CGroup singleton
 
 func GetDefaultCGroupMonitor() *CGroupMonitor {
 	if currentCGroupMonitor.watcher == nil {

--- a/sandbox/cgroup/monitor.go
+++ b/sandbox/cgroup/monitor.go
@@ -154,7 +154,7 @@ func (this CGroupMonitor) MonitorFiles(name string, folders []string, channel ch
 
 // This method is currently used for testing. It returns the number of folders being
 // watched. This may not match the number of paths passed in MonitorFiles, because
-// the main loop monitors the parent folder, so if several monitores files/folders
+// the main loop monitors the parent folder, so if several monitored files/folders
 // are in the same parent folder, they will count as only one for this method.
 func (this CGroupMonitor) NumberOfWaitingMonitors() int {
 	return len(this.watched)

--- a/sandbox/cgroup/monitor.go
+++ b/sandbox/cgroup/monitor.go
@@ -40,7 +40,7 @@ type appMonitorData struct {
 // CGroupMonitor allows to monitor several CGroups, detect when all
 // the running instances of each one have been closed, and notify
 // them separately. It should be considered a singleton, and
-// obtained using GetDefaultCGroupMonitor().
+// obtained using DefaultCGroupMonitor().
 type CGroupMonitor struct {
 	watched map[string][]*appMonitorData
 	watcher *inotify.Watcher
@@ -121,8 +121,8 @@ func monitorMainLoop() {
 	}
 }
 
-// GetDefaultCGroupMonitor launches the main loop and returns the CGroup singleton
-func GetDefaultCGroupMonitor() *CGroupMonitor {
+// DefaultCGroupMonitor launches the main loop and returns the CGroup singleton
+func DefaultCGroupMonitor() *CGroupMonitor {
 	if currentCGroupMonitor.watcher == nil {
 		wd, err := inotify.NewWatcher()
 		if err != nil {

--- a/sandbox/cgroup/monitor.go
+++ b/sandbox/cgroup/monitor.go
@@ -40,9 +40,13 @@ type snapAppMonitorState struct {
 
 // CGroupMonitor allows to monitor several CGroups, detect when all
 // the running instances of each one have been closed, and notify
-// them separately. It should be considered a singleton, and
-// obtained using MonitorSingleton().
+// them separately.
 type CGroupMonitor struct {
+	// The key is the base path of all the files/folders being monitored
+	// this way, paths 'XXXX/folder1' and 'XXXX/file2' would be monitored
+	// using a single inotify call for 'XXXX' folder, and their respective
+	// snapAppMonitorState structs would be stored in the 'XXXX' key of this
+	// map.
 	monitored map[string][]*snapAppMonitorState
 	watcher   *inotify.Watcher
 	channel   chan snapAppMonitorState

--- a/sandbox/cgroup/monitor.go
+++ b/sandbox/cgroup/monitor.go
@@ -148,7 +148,7 @@ func (this CGroupMonitor) MonitorSnap(snapName string, channel chan string) {
 	this.channel <- data
 }
 
-// This method is currently used for testing. It allows to monitor a group of files/folders
+// MonitorFiles is currently used for testing. It allows to monitor a group of files/folders
 // and, when all of them have been deleted, emits the specified name through the channel.
 func (this CGroupMonitor) MonitorFiles(name string, folders []string, channel chan string) {
 	data := appData{

--- a/sandbox/cgroup/monitor.go
+++ b/sandbox/cgroup/monitor.go
@@ -86,19 +86,20 @@ func addFiles(newApp *appMonitorData) {
 		for _, fullPath := range newApp.cgroupPaths {
 			basePath := path.Dir(fullPath) // Monitor the path containing this folder
 			_, exists := currentCGroupMonitor.watched[basePath]
-			if !exists {
-				err := currentCGroupMonitor.watcher.AddWatch(basePath, inotify.InDelete)
-				if err != nil {
-					continue
-				}
-				if _, err := os.Stat(fullPath); errors.Is(err, os.ErrNotExist) {
-					// if the file/folder to monitor doesn't exist after the parent being added, remove it
-					currentCGroupMonitor.watcher.RemoveWatch(basePath)
-					continue
-				}
-				currentCGroupMonitor.watched[basePath] = append(currentCGroupMonitor.watched[basePath], newApp)
-				addedPaths = true
+			if exists {
+				continue
 			}
+			err := currentCGroupMonitor.watcher.AddWatch(basePath, inotify.InDelete)
+			if err != nil {
+				continue
+			}
+			if _, err := os.Stat(fullPath); errors.Is(err, os.ErrNotExist) {
+				// if the file/folder to monitor doesn't exist after the parent being added, remove it
+				currentCGroupMonitor.watcher.RemoveWatch(basePath)
+				continue
+			}
+			currentCGroupMonitor.watched[basePath] = append(currentCGroupMonitor.watched[basePath], newApp)
+			addedPaths = true
 		}
 		if !addedPaths {
 			// if the files/folders to monitor don't exist, send the notification now

--- a/sandbox/cgroup/monitor.go
+++ b/sandbox/cgroup/monitor.go
@@ -133,7 +133,7 @@ func (this *CGroupMonitor) monitorMainLoop() {
 // This allows to use the same channel to monitor several snaps
 func MonitorSnap(snapName string, channel chan string) bool {
 	options := InstancePathsOptions{
-		returnCGroupPath: true,
+		ReturnCGroupPath: true,
 	}
 	paths, _ := InstancePathsOfSnap(snapName, options)
 	return MonitorFiles(snapName, paths, channel)

--- a/sandbox/cgroup/monitor.go
+++ b/sandbox/cgroup/monitor.go
@@ -132,7 +132,7 @@ func GetDefaultCGroupMonitor() *CGroupMonitor {
 	return &currentCGroupMonitor
 }
 
-// This is the method to call to monitor the running instances of an specific Snap.
+// MonitorSnap is the method to call to monitor the running instances of an specific Snap.
 // It receives the name of the snap to monitor (for example, "firefox" or "steam")
 // and a channel. The caller can wait on the channel, and when all the instances of
 // the specific snap have ended, the name of the snap will be sent through the channel.

--- a/sandbox/cgroup/monitor_test.go
+++ b/sandbox/cgroup/monitor_test.go
@@ -41,7 +41,7 @@ var _ = Suite(&monitorSuite{})
 func (s *monitorSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
 
-	s.monitor = cgroup.GetDefaultCGroupMonitor()
+	s.monitor = cgroup.DefaultCGroupMonitor()
 	c.Assert(s.monitor, NotNil)
 }
 

--- a/sandbox/cgroup/monitor_test.go
+++ b/sandbox/cgroup/monitor_test.go
@@ -41,7 +41,7 @@ var _ = Suite(&monitorSuite{})
 func (s *monitorSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
 
-	s.monitor = cgroup.DefaultCGroupMonitor()
+	s.monitor = cgroup.MonitorSingleton()
 	c.Assert(s.monitor, NotNil)
 }
 

--- a/sandbox/cgroup/monitor_test.go
+++ b/sandbox/cgroup/monitor_test.go
@@ -1,0 +1,124 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package cgroup_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/snapcore/snapd/sandbox/cgroup"
+	"github.com/snapcore/snapd/testutil"
+	. "gopkg.in/check.v1"
+)
+
+type monitorSuite struct {
+	testutil.BaseTest
+	monitor *cgroup.CGroupMonitor
+}
+
+var _ = Suite(&monitorSuite{})
+
+func (s *monitorSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+
+	s.monitor = cgroup.GetDefaultCGroupMonitor()
+	c.Assert(s.monitor, NotNil)
+}
+
+func (s *monitorSuite) TestMonitorSnap1(c *C) {
+	tmpfile, err := ioutil.TempFile("", "prefix")
+	c.Assert(err, IsNil)
+
+	var filelist []string
+	filelist = append(filelist, tmpfile.Name())
+
+	channel := make(chan string)
+
+	s.monitor.MonitorFiles("test1", filelist, channel)
+	c.Assert(s.monitor, NotNil)
+
+	for i := 0; i < 2; i++ {
+		select {
+		case <-channel:
+			c.Fail()
+		case <-time.After(1 * time.Second):
+			continue
+		}
+	}
+
+	os.Remove(tmpfile.Name())
+	event := <-channel
+	c.Assert(event, Equals, "test1")
+	c.Assert(s.monitor.NumberOfWaitingMonitors(), Equals, 0)
+}
+
+func (s *monitorSuite) TestMonitorSnap2(c *C) {
+	tmpfile1, err := ioutil.TempFile("", "prefix")
+	c.Assert(err, IsNil)
+	tmpfile2, err := ioutil.TempFile("", "prefix")
+	c.Assert(err, IsNil)
+
+	var filelist []string
+	filelist = append(filelist, tmpfile1.Name())
+	filelist = append(filelist, tmpfile2.Name())
+
+	channel := make(chan string)
+
+	s.monitor.MonitorFiles("test2", filelist, channel)
+
+	for i := 0; i < 2; i++ {
+		select {
+		case <-channel:
+			c.Fail()
+		case <-time.After(1 * time.Second):
+			continue
+		}
+	}
+	os.Remove(tmpfile1.Name())
+	for i := 0; i < 2; i++ {
+		select {
+		case <-channel:
+			c.Fail()
+		case <-time.After(1 * time.Second):
+			continue
+		}
+	}
+	os.Remove(tmpfile2.Name())
+
+	event := <-channel
+	c.Assert(event, Equals, "test2")
+	c.Assert(s.monitor.NumberOfWaitingMonitors(), Equals, 0)
+}
+
+func (s *monitorSuite) TestMonitorSnap3(c *C) {
+	filename := fmt.Sprintf("aFileNameThatDoesntExist%s", uuid.New().String())
+	var filelist []string
+	filelist = append(filelist, filename)
+
+	channel := make(chan string)
+	s.monitor.MonitorFiles("test3", filelist, channel)
+	c.Assert(s.monitor, NotNil)
+	event := <-channel
+	c.Assert(event, Equals, "test3")
+	c.Assert(s.monitor.NumberOfWaitingMonitors(), Equals, 0)
+}

--- a/sandbox/cgroup/monitor_test.go
+++ b/sandbox/cgroup/monitor_test.go
@@ -45,7 +45,7 @@ func (s *monitorSuite) SetUpTest(c *C) {
 	c.Assert(s.monitor, NotNil)
 }
 
-func (s *monitorSuite) TestMonitorSnap1(c *C) {
+func (s *monitorSuite) TestMonitorSnapBasicWork(c *C) {
 	tmpfile, err := ioutil.TempFile("", "prefix")
 	c.Assert(err, IsNil)
 
@@ -72,7 +72,7 @@ func (s *monitorSuite) TestMonitorSnap1(c *C) {
 	c.Assert(s.monitor.NumberOfWaitingMonitors(), Equals, 0)
 }
 
-func (s *monitorSuite) TestMonitorSnap2(c *C) {
+func (s *monitorSuite) TestMonitorSnapTwoSnapsAtTheSameTime(c *C) {
 	tmpfile1, err := ioutil.TempFile("", "prefix")
 	c.Assert(err, IsNil)
 	tmpfile2, err := ioutil.TempFile("", "prefix")
@@ -110,7 +110,7 @@ func (s *monitorSuite) TestMonitorSnap2(c *C) {
 	c.Assert(s.monitor.NumberOfWaitingMonitors(), Equals, 0)
 }
 
-func (s *monitorSuite) TestMonitorSnap3(c *C) {
+func (s *monitorSuite) TestMonitorSnapSnapAlreadyStopped(c *C) {
 	filename := fmt.Sprintf("aFileNameThatDoesntExist%s", uuid.New().String())
 	var filelist []string
 	filelist = append(filelist, filename)

--- a/sandbox/cgroup/scanning.go
+++ b/sandbox/cgroup/scanning.go
@@ -180,13 +180,14 @@ func InstancePathsOfSnap(snapInstanceName string, flags InstancePathsFlags) ([]s
 // This can be used to classify the activity of a given snap into activity
 // classes, based on the nature of the security tags encountered.
 func PidsOfSnap(snapInstanceName string) (map[string][]int, error) {
-	// pidsByTag maps security tag to a list of pids.
-	pidsByTag := make(map[string][]int)
 
 	paths, err := InstancePathsOfSnap(snapInstanceName, 0)
 	if err != nil {
 		return nil, err
 	}
+
+	// pidsByTag maps security tag to a list of pids.
+	pidsByTag := make(map[string][]int)
 
 	for _, path := range paths {
 		pids, err := pidsInFile(path)

--- a/sandbox/cgroup/scanning.go
+++ b/sandbox/cgroup/scanning.go
@@ -68,7 +68,7 @@ func securityTagFromCgroupPath(path string) naming.SecurityTag {
 }
 
 type InstancePathsOptions struct {
-	returnCGroupPath bool
+	ReturnCGroupPath bool
 }
 
 // InstancePathsOfSnap returns the list of active cgroup paths for a given snap
@@ -140,7 +140,7 @@ func InstancePathsOfSnap(snapInstanceName string, options InstancePathsOptions) 
 		if parsedTag.InstanceName() != snapInstanceName {
 			return nil
 		}
-		if options.returnCGroupPath {
+		if options.ReturnCGroupPath {
 			pathList = append(pathList, cgroupPath)
 		} else {
 			pathList = append(pathList, path)
@@ -180,7 +180,7 @@ func InstancePathsOfSnap(snapInstanceName string, options InstancePathsOptions) 
 // classes, based on the nature of the security tags encountered.
 func PidsOfSnap(snapInstanceName string) (map[string][]int, error) {
 	options := InstancePathsOptions{
-		returnCGroupPath: false,
+		ReturnCGroupPath: false,
 	}
 	paths, err := InstancePathsOfSnap(snapInstanceName, options)
 	if err != nil {

--- a/sandbox/cgroup/scanning.go
+++ b/sandbox/cgroup/scanning.go
@@ -180,7 +180,6 @@ func InstancePathsOfSnap(snapInstanceName string, flags InstancePathsFlags) ([]s
 // This can be used to classify the activity of a given snap into activity
 // classes, based on the nature of the security tags encountered.
 func PidsOfSnap(snapInstanceName string) (map[string][]int, error) {
-
 	paths, err := InstancePathsOfSnap(snapInstanceName, 0)
 	if err != nil {
 		return nil, err

--- a/sandbox/cgroup/scanning_test.go
+++ b/sandbox/cgroup/scanning_test.go
@@ -72,7 +72,17 @@ func (s *scanningSuite) TestSecurityTagFromCgroupPath(c *C) {
 	c.Check(cgroup.SecurityTagFromCgroupPath("/a/b/snap.foo.foo.service/"), DeepEquals, mustParseTag("snap.foo.foo"))
 }
 
-func (s *scanningSuite) writePids(c *C, dir string, pids []int) {
+func arrayContainsString(arr []string, needle string) int {
+	counter := 0
+	for _, v := range arr {
+		if v == needle {
+			counter++
+		}
+	}
+	return counter
+}
+
+func (s *scanningSuite) writePids(c *C, dir string, pids []int) string {
 	var buf bytes.Buffer
 	for _, pid := range pids {
 		fmt.Fprintf(&buf, "%d\n", pid)
@@ -90,7 +100,9 @@ func (s *scanningSuite) writePids(c *C, dir string, pids []int) {
 	}
 
 	c.Assert(os.MkdirAll(path, 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(path, "cgroup.procs"), buf.Bytes(), 0644), IsNil)
+	finalPath := filepath.Join(path, "cgroup.procs")
+	c.Assert(ioutil.WriteFile(finalPath, buf.Bytes(), 0644), IsNil)
+	return finalPath
 }
 
 func (s *scanningSuite) TestPidsOfSnapEmpty(c *C) {
@@ -101,6 +113,19 @@ func (s *scanningSuite) TestPidsOfSnapEmpty(c *C) {
 	pids, err := cgroup.PidsOfSnap("pkg")
 	c.Assert(err, IsNil)
 	c.Check(pids, HasLen, 0)
+}
+
+func (s *scanningSuite) TestPathsOfSnapEmpty(c *C) {
+	restore := cgroup.MockVersion(cgroup.V1, nil)
+	defer restore()
+
+	// Not having any cgroup directories is not an error.
+	options := cgroup.InstancePathsOptions{
+		ReturnCGroupPath: true,
+	}
+	paths, err := cgroup.InstancePathsOfSnap("pkg", options)
+	c.Assert(err, IsNil)
+	c.Check(paths, HasLen, 0)
 }
 
 func (s *scanningSuite) TestPidsOfSnapUnrelatedStuff(c *C) {
@@ -124,6 +149,30 @@ func (s *scanningSuite) TestPidsOfSnapUnrelatedStuff(c *C) {
 	}
 }
 
+func (s *scanningSuite) TestPathsOfSnapUnrelatedStuff(c *C) {
+	options := cgroup.InstancePathsOptions{
+		ReturnCGroupPath: true,
+	}
+	for _, ver := range []int{cgroup.V2, cgroup.V1} {
+		comment := Commentf("cgroup version %v", ver)
+		restore := cgroup.MockVersion(ver, nil)
+		defer restore()
+
+		// Things that are not related to the snap are not being picked up.
+		s.writePids(c, "udisks2.service", []int{100})
+		s.writePids(c, "snap..service", []int{101})
+		s.writePids(c, "snap..scope", []int{102})
+		s.writePids(c, "snap.*.service", []int{103})
+		s.writePids(c, "snap.*.scope", []int{104})
+		s.writePids(c, "snapd.service", []int{105})
+		s.writePids(c, "snap-spotify-35.mount", []int{106})
+
+		paths, err := cgroup.InstancePathsOfSnap("pkg", options)
+		c.Assert(err, IsNil, comment)
+		c.Check(paths, HasLen, 0, comment)
+	}
+}
+
 func (s *scanningSuite) TestPidsOfSnapSecurityTags(c *C) {
 	for _, ver := range []int{cgroup.V2, cgroup.V1} {
 		comment := Commentf("cgroup version %v", ver)
@@ -140,6 +189,27 @@ func (s *scanningSuite) TestPidsOfSnapSecurityTags(c *C) {
 			"snap.pkg.hook.configure": {1},
 			"snap.pkg.daemon":         {2},
 		}, comment)
+	}
+}
+
+func (s *scanningSuite) TestPathsOfSnapWithSecurityTags(c *C) {
+	options := cgroup.InstancePathsOptions{
+		ReturnCGroupPath: true,
+	}
+	for _, ver := range []int{cgroup.V2, cgroup.V1} {
+		comment := Commentf("cgroup version %v", ver)
+		restore := cgroup.MockVersion(ver, nil)
+		defer restore()
+
+		// Pids are collected and assigned to bins by security tag
+		path1 := s.writePids(c, "system.slice/snap.pkg.hook.configure.$RANDOM.scope", []int{1})
+		path2 := s.writePids(c, "system.slice/snap.pkg.daemon.service", []int{2})
+
+		paths, err := cgroup.InstancePathsOfSnap("pkg", options)
+		c.Assert(err, IsNil, comment)
+		c.Check(paths, HasLen, 2)
+		c.Check(arrayContainsString(paths, filepath.Dir(path1)), Equals, 1)
+		c.Check(arrayContainsString(paths, filepath.Dir(path2)), Equals, 1)
 	}
 }
 
@@ -177,6 +247,40 @@ func (s *scanningSuite) TestPidsOfInstances(c *C) {
 	}
 }
 
+func (s *scanningSuite) TestPathsOfInstances(c *C) {
+	options := cgroup.InstancePathsOptions{
+		ReturnCGroupPath: true,
+	}
+	for _, ver := range []int{cgroup.V2, cgroup.V1} {
+		comment := Commentf("cgroup version %v", ver)
+		restore := cgroup.MockVersion(ver, nil)
+		defer restore()
+
+		// Instances are not confused between themselves and between the non-instance version.
+		path1 := s.writePids(c, "system.slice/snap.pkg_prod.daemon.service", []int{1})
+		path2 := s.writePids(c, "system.slice/snap.pkg_devel.daemon.service", []int{2})
+		path3 := s.writePids(c, "system.slice/snap.pkg.daemon.service", []int{3})
+
+		// The main one
+		paths, err := cgroup.InstancePathsOfSnap("pkg", options)
+		c.Assert(err, IsNil, comment)
+		c.Check(paths, HasLen, 1)
+		c.Check(paths[0], Equals, filepath.Dir(path3))
+
+		// The development one
+		paths, err = cgroup.InstancePathsOfSnap("pkg_devel", options)
+		c.Assert(err, IsNil, comment)
+		c.Check(paths, HasLen, 1)
+		c.Check(paths[0], Equals, filepath.Dir(path2))
+
+		// The production one
+		paths, err = cgroup.InstancePathsOfSnap("pkg_prod", options)
+		c.Assert(err, IsNil, comment)
+		c.Check(paths, HasLen, 1)
+		c.Check(paths[0], Equals, filepath.Dir(path1))
+	}
+}
+
 func (s *scanningSuite) TestPidsOfAggregation(c *C) {
 	for _, ver := range []int{cgroup.V2, cgroup.V1} {
 		comment := Commentf("cgroup version %v", ver)
@@ -195,6 +299,32 @@ func (s *scanningSuite) TestPidsOfAggregation(c *C) {
 		c.Check(pids, DeepEquals, map[string][]int{
 			"snap.pkg.app": {1, 2, 3, 4},
 		}, comment)
+	}
+}
+
+func (s *scanningSuite) TestPathsOfAggregation(c *C) {
+	options := cgroup.InstancePathsOptions{
+		ReturnCGroupPath: true,
+	}
+	for _, ver := range []int{cgroup.V2, cgroup.V1} {
+		comment := Commentf("cgroup version %v", ver)
+		restore := cgroup.MockVersion(ver, nil)
+		defer restore()
+
+		// A single snap may be invoked by multiple users in different sessions.
+		// All of their PIDs are collected though.
+		path1 := s.writePids(c, "user.slice/user-1000.slice/user@1000.service/gnome-shell-wayland.service/snap.pkg.app.$RANDOM1.scope", []int{1}) // mock 1st invocation
+		path2 := s.writePids(c, "user.slice/user-1000.slice/user@1000.service/gnome-shell-wayland.service/snap.pkg.app.$RANDOM2.scope", []int{2}) // mock fork() by pid 1
+		path3 := s.writePids(c, "user.slice/user-1001.slice/user@1001.service/gnome-shell-wayland.service/snap.pkg.app.$RANDOM3.scope", []int{3}) // mock 2nd invocation
+		path4 := s.writePids(c, "user.slice/user-1001.slice/user@1001.service/gnome-shell-wayland.service/snap.pkg.app.$RANDOM4.scope", []int{4}) // mock fork() by pid 3
+
+		paths, err := cgroup.InstancePathsOfSnap("pkg", options)
+		c.Assert(err, IsNil, comment)
+		c.Check(paths, HasLen, 4)
+		c.Check(arrayContainsString(paths, filepath.Dir(path1)), Equals, 1)
+		c.Check(arrayContainsString(paths, filepath.Dir(path2)), Equals, 1)
+		c.Check(arrayContainsString(paths, filepath.Dir(path3)), Equals, 1)
+		c.Check(arrayContainsString(paths, filepath.Dir(path4)), Equals, 1)
 	}
 }
 
@@ -225,6 +355,38 @@ func (s *scanningSuite) TestPidsOfSnapUnrelated(c *C) {
 	}
 }
 
+func (s *scanningSuite) TestPathsOfSnapUnrelated(c *C) {
+	options := cgroup.InstancePathsOptions{
+		ReturnCGroupPath: true,
+	}
+	for _, ver := range []int{cgroup.V2, cgroup.V1} {
+		comment := Commentf("cgroup version %v", ver)
+		restore := cgroup.MockVersion(ver, nil)
+		defer restore()
+
+		// We are not confusing snaps with other snaps, instances of our snap, and
+		// with non-snap hierarchies.
+		path1 := s.writePids(c, "user.slice/.../snap.pkg.app.$RANDOM1.scope", []int{1})
+		path2 := s.writePids(c, "user.slice/.../snap.other.snap.$RANDOM2.scope", []int{2})
+		path3 := s.writePids(c, "user.slice/.../pkg.service", []int{3})
+		path4 := s.writePids(c, "user.slice/.../snap.pkg_instance.app.$RANDOM3.scope", []int{4})
+
+		// Write a file which is not cgroup.procs with the number 666 inside.
+		// We want to ensure this is not read by accident.
+		f := filepath.Join(s.rootDir, "/sys/fs/cgroup/unrelated.txt")
+		c.Assert(os.MkdirAll(filepath.Dir(f), 0755), IsNil)
+		c.Assert(ioutil.WriteFile(f, []byte("666"), 0644), IsNil)
+
+		paths, err := cgroup.InstancePathsOfSnap("pkg", options)
+		c.Assert(err, IsNil, comment)
+		c.Check(paths, HasLen, 1)
+		c.Check(arrayContainsString(paths, filepath.Dir(path1)), Equals, 1)
+		c.Check(arrayContainsString(paths, filepath.Dir(path2)), Equals, 0)
+		c.Check(arrayContainsString(paths, filepath.Dir(path3)), Equals, 0)
+		c.Check(arrayContainsString(paths, filepath.Dir(path4)), Equals, 0)
+	}
+}
+
 func (s *scanningSuite) TestContainerPidsAreIgnored(c *C) {
 	for _, ver := range []int{cgroup.V2, cgroup.V1} {
 		comment := Commentf("cgroup version %v", ver)
@@ -241,5 +403,31 @@ func (s *scanningSuite) TestContainerPidsAreIgnored(c *C) {
 		c.Assert(err, IsNil, comment)
 		c.Check(pids, HasLen, 1, comment)
 		c.Check(pids["snap.foo.bar"], testutil.DeepUnsortedMatches, []int{1, 2}, comment)
+	}
+}
+
+func (s *scanningSuite) TestContainerPathsAreIgnored(c *C) {
+	options := cgroup.InstancePathsOptions{
+		ReturnCGroupPath: true,
+	}
+	for _, ver := range []int{cgroup.V2, cgroup.V1} {
+		comment := Commentf("cgroup version %v", ver)
+		restore := cgroup.MockVersion(ver, nil)
+		defer restore()
+
+		path1 := s.writePids(c, "user.slice/user-1000.slice/user@1000.service/snap.foo.bar.scope", []int{1})
+		path2 := s.writePids(c, "system.slice/snap.foo.bar.service", []int{2})
+		path3 := s.writePids(c, "lxc.payload.my-container/system.slice/snap.foo.bar.service", []int{3})
+		path4 := s.writePids(c, "machine.slice/snap.foo.bar.service", []int{4})
+		path5 := s.writePids(c, "docker/snap.foo.bar.service", []int{5})
+
+		paths, err := cgroup.InstancePathsOfSnap("foo", options)
+		c.Assert(err, IsNil, comment)
+		c.Check(paths, HasLen, 2, comment)
+		c.Check(arrayContainsString(paths, filepath.Dir(path1)), Equals, 1)
+		c.Check(arrayContainsString(paths, filepath.Dir(path2)), Equals, 1)
+		c.Check(arrayContainsString(paths, filepath.Dir(path3)), Equals, 0)
+		c.Check(arrayContainsString(paths, filepath.Dir(path4)), Equals, 0)
+		c.Check(arrayContainsString(paths, filepath.Dir(path5)), Equals, 0)
 	}
 }


### PR DESCRIPTION
This MR adds a Snap/Cgroup monitor that allows other parts of the code to wait until all the instances of a Snap have ended and it can be safely refreshed. It is the first step for a bigger MR that will allow to automagically refresh a snap after the system has notified the user that there is a refresh available and that they must close it.

This MR and a future one overrides https://github.com/snapcore/snapd/pull/12155 . The changes from that MR will be proposed in a step-by-step manner to simplify the revision process.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
