### PR TITLE
boot,o/devicestate: introduce and use MakeRunnableStandaloneSystem

### DIFF
--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -312,6 +312,7 @@ func MakeRecoverySystemBootable(rootdir string, relativeRecoverySystemDir string
 }
 
 type makeRunnableOptions struct {
+	Standalone     bool
 	AfterDataReset bool
 }
 
@@ -499,6 +500,9 @@ func makeRunnableSystem(model *asserts.Model, bootWith *BootableSet, sealer *Tru
 		flags := sealKeyToModeenvFlags{
 			FactoryReset: makeOpts.AfterDataReset,
 		}
+		if makeOpts.Standalone {
+			flags.SnapsDir = snapBlobDir
+		}
 		// seal the encryption key to the parameters specified in modeenv
 		if err := sealKeyToModeenv(sealer.dataEncryptionKey, sealer.saveEncryptionKey, model, modeenv, flags); err != nil {
 			return err
@@ -524,6 +528,17 @@ func makeRunnableSystem(model *asserts.Model, bootWith *BootableSet, sealer *Tru
 // running in between.
 func MakeRunnableSystem(model *asserts.Model, bootWith *BootableSet, sealer *TrustedAssetsInstallObserver) error {
 	return makeRunnableSystem(model, bootWith, sealer, makeRunnableOptions{})
+}
+
+// MakeRunnableStandaloneSystem operates like MakeRunnableSystem but does
+// assume that the run system being set up is related to the current
+// system. This is appropriate e.g when installing from a classic installer.
+func MakeRunnableStandaloneSystem(model *asserts.Model, bootWith *BootableSet, sealer *TrustedAssetsInstallObserver) error {
+	// TODO consider merging this back into MakeRunnableSystem but need
+	// to consider the properties of the different input used for sealing
+	return makeRunnableSystem(model, bootWith, sealer, makeRunnableOptions{
+		Standalone: true,
+	})
 }
 
 // MakeRunnableSystemAfterDataReset sets up the system to be able to boot, but it is

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -99,6 +99,9 @@ type sealKeyToModeenvFlags struct {
 	// FactoryReset indicates that the sealing is happening during factory
 	// reset.
 	FactoryReset bool
+	// SnapsDir is set to provide a non-default directory to find
+	// run mode snaps in.
+	SnapsDir string
 }
 
 // sealKeyToModeenv seals the supplied keys to the parameters specified
@@ -228,7 +231,7 @@ func sealKeyToModeenvUsingSecboot(key, saveKey keys.EncryptionKey, model *assert
 
 	// kernel command lines are filled during install
 	cmdlines := modeenv.CurrentKernelCommandLines
-	runModeBootChains, err := runModeBootChains(rbl, bl, modeenv, cmdlines)
+	runModeBootChains, err := runModeBootChains(rbl, bl, modeenv, cmdlines, flags.SnapsDir)
 	if err != nil {
 		return fmt.Errorf("cannot compose run mode boot chains: %v", err)
 	}
@@ -490,7 +493,7 @@ func resealKeyToModeenvSecboot(rootdir string, modeenv *Modeenv, expectReseal bo
 	if err != nil {
 		return err
 	}
-	runModeBootChains, err := runModeBootChains(rbl, bl, modeenv, cmdlines)
+	runModeBootChains, err := runModeBootChains(rbl, bl, modeenv, cmdlines, "")
 	if err != nil {
 		return fmt.Errorf("cannot compose run mode boot chains: %v", err)
 	}
@@ -719,7 +722,7 @@ func recoveryBootChainsForSystems(systems []string, modesForSystems map[string][
 	return chains, nil
 }
 
-func runModeBootChains(rbl, bl bootloader.Bootloader, modeenv *Modeenv, cmdlines []string) ([]bootChain, error) {
+func runModeBootChains(rbl, bl bootloader.Bootloader, modeenv *Modeenv, cmdlines []string, runSnapsDir string) ([]bootChain, error) {
 	tbl, ok := rbl.(bootloader.TrustedAssetsBootloader)
 	if !ok {
 		return nil, fmt.Errorf("recovery bootloader doesn't support trusted assets")
@@ -732,7 +735,13 @@ func runModeBootChains(rbl, bl bootloader.Bootloader, modeenv *Modeenv, cmdlines
 			if err != nil {
 				return err
 			}
-			runModeBootChain, err := tbl.BootChain(bl, info.MountFile())
+			var kernelPath string
+			if runSnapsDir == "" {
+				kernelPath = info.MountFile()
+			} else {
+				kernelPath = filepath.Join(runSnapsDir, info.Filename())
+			}
+			runModeBootChain, err := tbl.BootChain(bl, kernelPath)
 			if err != nil {
 				return err
 			}

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -66,6 +66,7 @@ import (
 var (
 	bootMakeBootablePartition            = boot.MakeBootablePartition
 	bootMakeRunnable                     = boot.MakeRunnableSystem
+	bootMakeRunnableStandalone           = boot.MakeRunnableStandaloneSystem
 	bootMakeRunnableAfterDataReset       = boot.MakeRunnableSystemAfterDataReset
 	bootEnsureNextBootToRunMode          = boot.EnsureNextBootToRunMode
 	installRun                           = install.Run
@@ -1343,7 +1344,7 @@ func (m *DeviceManager) doInstallFinish(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	logger.Debugf("making the installed system runnable for systemLabel %s", systemLabel)
-	if err := bootMakeRunnable(sys.Model, bootWith, trustedInstallObserver); err != nil {
+	if err := bootMakeRunnableStandalone(sys.Model, bootWith, trustedInstallObserver); err != nil {
 		return err
 	}
 

--- a/tests/nested/manual/fakeinstaller/task.yaml
+++ b/tests/nested/manual/fakeinstaller/task.yaml
@@ -1,7 +1,8 @@
 summary: Check that the /system/<label> API works via fake installer
 
 # this is a UC20+ specific test
-systems: [ubuntu-20.04-64, ubuntu-22.04-64]
+# TODO this currently fails on ubuntu-20.04-64 timing out
+systems: [ubuntu-22.04-64]
 
 environment:
     # nested test so that we can test encryted installs eventually


### PR DESCRIPTION
MakeRunnableSystem implicitly assumes that the run system is a clone
of the current system, usually a UC20 ephemeral mode system

introduce MakeRunnableStandaloneSystem that does not make this assumption
and use it for the finish step of the install API

in theory we could change MakeRunnableSystem itself not to make the assumption
but it changes a bit its properties so it is something to maybe consider for
later