### PR TITLE
boot,o/devicestate: extend HasFDESetupHook to consider unrelated kernels

### DIFF
--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -226,7 +226,7 @@ func MockRebootArgsPath(argsPath string) (restore func()) {
 	return func() { rebootArgsPath = oldRebootArgsPath }
 }
 
-func MockHasFDESetupHook(f func() (bool, error)) (restore func()) {
+func MockHasFDESetupHook(f func(*snap.Info) (bool, error)) (restore func()) {
 	oldHasFDESetupHook := HasFDESetupHook
 	HasFDESetupHook = f
 	return func() {

--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -497,8 +497,14 @@ func makeRunnableSystem(model *asserts.Model, bootWith *BootableSet, sealer *Tru
 	}
 
 	if sealer != nil {
+		hasHook, err := HasFDESetupHook(bootWith.Kernel)
+		if err != nil {
+			return fmt.Errorf("cannot check for fde-setup hook: %v", err)
+		}
+
 		flags := sealKeyToModeenvFlags{
-			FactoryReset: makeOpts.AfterDataReset,
+			HasFDESetupHook: hasHook,
+			FactoryReset:    makeOpts.AfterDataReset,
 		}
 		if makeOpts.Standalone {
 			flags.SnapsDir = snapBlobDir

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -642,6 +642,14 @@ version: 5.0
 	})
 	defer restore()
 
+	hasFDESetupHoolCalled := false
+	restore = boot.MockHasFDESetupHook(func(kernel *snap.Info) (bool, error) {
+		c.Check(kernel, Equals, kernelInfo)
+		hasFDESetupHoolCalled = true
+		return false, nil
+	})
+	defer restore()
+
 	// set mock key sealing
 	sealKeysCalls := 0
 	restore = boot.MockSecbootSealKeys(func(keys []secboot.SealKeyRequest, params *secboot.SealKeysParams) error {
@@ -839,6 +847,8 @@ current_kernel_command_lines=["snapd_recovery_mode=run console=ttyS0 console=tty
 	c.Check(copiedRecoveryGrubBin, testutil.FileEquals, "recovery grub content")
 	c.Check(copiedRecoveryShimBin, testutil.FileEquals, "recovery shim content")
 
+	// we checked for fde-setup-hook
+	c.Check(hasFDESetupHoolCalled, Equals, true)
 	// make sure TPM was provisioned
 	c.Check(provisionCalls, Equals, 1)
 	// make sure SealKey was called for the run object and the fallback object

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -58,7 +58,10 @@ var (
 // disk encryption implementations. The state must be locked when these
 // functions are called.
 var (
-	HasFDESetupHook = func() (bool, error) {
+	// HasFDESetupHook purpose is to detect if the target kernel has a
+	// fde-setup-hook. If kernelInfo is nil the current kernel is checked
+	// assuming it is representive of the target one.
+	HasFDESetupHook = func(kernelInfo *snap.Info) (bool, error) {
 		return false, nil
 	}
 	RunFDESetupHook fde.RunSetupHookFunc = func(req *fde.SetupRequest) ([]byte, error) {
@@ -96,6 +99,8 @@ func recoveryBootChainsFileUnder(rootdir string) string {
 }
 
 type sealKeyToModeenvFlags struct {
+	// HasFDESetupHook is true if the kernel has a fde-setup hook to use
+	HasFDESetupHook bool
 	// FactoryReset indicates that the sealing is happening during factory
 	// reset.
 	FactoryReset bool
@@ -121,11 +126,11 @@ func sealKeyToModeenv(key, saveKey keys.EncryptionKey, model *asserts.Model, mod
 		}
 	}
 
-	hasHook, err := HasFDESetupHook()
+	/*hasHook, err := HasFDESetupHook()
 	if err != nil {
 		return fmt.Errorf("cannot check for fde-setup hook %v", err)
-	}
-	if hasHook {
+	}*/
+	if flags.HasFDESetupHook {
 		return sealKeyToModeenvUsingFDESetupHook(key, saveKey, model, modeenv, flags)
 	}
 
@@ -891,7 +896,7 @@ func postFactoryResetCleanupSecboot() error {
 }
 
 func postFactoryResetCleanup() error {
-	hasHook, err := HasFDESetupHook()
+	hasHook, err := HasFDESetupHook(nil)
 	if err != nil {
 		return fmt.Errorf("cannot check for fde-setup hook %v", err)
 	}

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -2222,7 +2222,7 @@ func (m *DeviceManager) ntpSyncedOrWaitedLongerThan(maxWait time.Duration) bool 
 	return m.ntpSyncedOrTimedOut
 }
 
-func (m *DeviceManager) hasFDESetupHook() (bool, error) {
+func (m *DeviceManager) hasFDESetupHook(kernelInfo *snap.Info) (bool, error) {
 	// state must be locked
 	st := m.state
 
@@ -2231,9 +2231,12 @@ func (m *DeviceManager) hasFDESetupHook() (bool, error) {
 		return false, fmt.Errorf("cannot get device context: %v", err)
 	}
 
-	kernelInfo, err := snapstate.KernelInfo(st, deviceCtx)
-	if err != nil {
-		return false, fmt.Errorf("cannot get kernel info: %v", err)
+	if kernelInfo == nil {
+		var err error
+		kernelInfo, err = snapstate.KernelInfo(st, deviceCtx)
+		if err != nil {
+			return false, fmt.Errorf("cannot get kernel info: %v", err)
+		}
 	}
 	return hasFDESetupHookInKernel(kernelInfo), nil
 }

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -392,8 +392,8 @@ func MockRestrictCloudInit(f func(sysconfig.CloudInitState, *sysconfig.CloudInit
 	}
 }
 
-func DeviceManagerHasFDESetupHook(mgr *DeviceManager) (bool, error) {
-	return mgr.hasFDESetupHook()
+func DeviceManagerHasFDESetupHook(mgr *DeviceManager, kernelInfo *snap.Info) (bool, error) {
+	return mgr.hasFDESetupHook(kernelInfo)
 }
 
 func DeviceManagerRunFDESetupHook(mgr *DeviceManager, req *fde.SetupRequest) ([]byte, error) {


### PR DESCRIPTION
we need to check for hook presence also in kernels that are not the currently installed kernel if any

