### PR TITLE
kvm: allow read of AMD-SEV parameters

### DIFF
--- a/interfaces/builtin/kvm.go
+++ b/interfaces/builtin/kvm.go
@@ -52,6 +52,9 @@ const kvmConnectedPlugAppArmor = `
 /sys/module/kvm_amd/parameters/nested r,
 /sys/module/kvm_hv/parameters/nested r, # PPC64.
 /sys/module/kvm/parameters/nested r, # S390.
+
+# Allow AMD SEV checks for AMD CPU's.
+/sys/module/kvm_amd/parameters/sev r,
 `
 
 var kvmConnectedPlugUDev = []string{`KERNEL=="kvm"`}

--- a/interfaces/builtin/kvm_test.go
+++ b/interfaces/builtin/kvm_test.go
@@ -115,6 +115,9 @@ func (s *kvmInterfaceSuite) TestAppArmorSpec(c *C) {
 /sys/module/kvm_amd/parameters/nested r,
 /sys/module/kvm_hv/parameters/nested r, # PPC64.
 /sys/module/kvm/parameters/nested r, # S390.
+
+# Allow AMD SEV checks for AMD CPU's.
+/sys/module/kvm_amd/parameters/sev r,
 `)
 }
 


### PR DESCRIPTION
This allows consuming applications to determine with AMD-SEV is supported by the hypervisor.
