### PR TITLE
tests: add libfwupd and libfwupdplugin5 to openSUSE dependencies

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -791,6 +791,12 @@ pkg_dependencies_opensuse(){
         xdg-utils
         zsh
         "
+    if os.query is-opensuse tumbleweed; then
+        echo "
+            libfwupd2
+            libfwupdplugin5
+        "
+    fi
 }
 
 pkg_dependencies_arch(){


### PR DESCRIPTION
This should normally not be needed, but unfortunately it's necessary to workaround a test failure in Tumbleweed, where the version of the fwupd service has gone out of sync with the client library:

    systemd[1]: Starting Firmware update daemon...
    fwupd[16167]: Failed to load engine: libfwupd version 1.7.9 does not match daemon 1.7.10
    systemd[1]: fwupd.service: Main process exited, code=exited, status=1/FAILURE
    systemd[1]: fwupd.service: Failed with result 'exit-code'.
    systemd[1]: Failed to start Firmware update daemon.
    dbus-daemon[574]: [system] Failed to activate service 'org.freedesktop.fwupd': timed out (service_start_timeout=25000ms)

Fixes: SNAPDENG-3009