### PR TITLE
many: support classic snaps in the context of classic and extended models

### DIFF
--- a/asserts/header_checks.go
+++ b/asserts/header_checks.go
@@ -284,13 +284,17 @@ func checkStringMatchesWhat(headers map[string]interface{}, name, what string, p
 }
 
 func checkOptionalBool(headers map[string]interface{}, name string) (bool, error) {
+	return checkOptionalBoolWhat(headers, name, "header")
+}
+
+func checkOptionalBoolWhat(headers map[string]interface{}, name, what string) (bool, error) {
 	value, ok := headers[name]
 	if !ok {
 		return false, nil
 	}
 	s, ok := value.(string)
 	if !ok || (s != "true" && s != "false") {
-		return false, fmt.Errorf("%q header must be 'true' or 'false'", name)
+		return false, fmt.Errorf("%q %s must be 'true' or 'false'", name, what)
 	}
 	return s == "true", nil
 }

--- a/asserts/model.go
+++ b/asserts/model.go
@@ -51,7 +51,7 @@ type ModelSnap struct {
 	PinnedTrack string
 	// Presence is one of: required|optional
 	Presence string
-	// Classic indicates that this classic snap is intenionally
+	// Classic indicates that this classic snap is intentionally
 	// included in a classic model
 	Classic bool
 }
@@ -101,7 +101,7 @@ var (
 	defaultModes       = []string{"run"}
 )
 
-func checkExtendedSnaps(extendedSnaps interface{}, base string, grade ModelGrade, classic bool) (*modelSnaps, error) {
+func checkExtendedSnaps(extendedSnaps interface{}, base string, grade ModelGrade, modelIsClassic bool) (*modelSnaps, error) {
 	const wrongHeaderType = `"snaps" header must be a list of maps`
 
 	entries, ok := extendedSnaps.([]interface{})
@@ -118,7 +118,7 @@ func checkExtendedSnaps(extendedSnaps interface{}, base string, grade ModelGrade
 		if !ok {
 			return nil, fmt.Errorf(wrongHeaderType)
 		}
-		modelSnap, err := checkModelSnap(snap, grade, classic)
+		modelSnap, err := checkModelSnap(snap, grade, modelIsClassic)
 		if err != nil {
 			return nil, err
 		}
@@ -176,7 +176,7 @@ func checkExtendedSnaps(extendedSnaps interface{}, base string, grade ModelGrade
 			modelSnap.Modes = defaultModes
 		}
 		if modelSnap.Classic && (len(modelSnap.Modes) != 1 || modelSnap.Modes[0] != "run") {
-			return nil, fmt.Errorf("classic snap %q now allowed outside of run mode: %v", modelSnap.Name, modelSnap.Modes)
+			return nil, fmt.Errorf("classic snap %q not allowed outside of run mode: %v", modelSnap.Name, modelSnap.Modes)
 		}
 
 		if modelSnap.Presence == "" {
@@ -197,7 +197,7 @@ var (
 	validSnapPresences = []string{"required", "optional"}
 )
 
-func checkModelSnap(snap map[string]interface{}, grade ModelGrade, classic bool) (*ModelSnap, error) {
+func checkModelSnap(snap map[string]interface{}, grade ModelGrade, modelIsClassic bool) (*ModelSnap, error) {
 	name, err := checkNotEmptyStringWhat(snap, "name", "of snap")
 	if err != nil {
 		return nil, err
@@ -267,7 +267,7 @@ func checkModelSnap(snap map[string]interface{}, grade ModelGrade, classic bool)
 	if err != nil {
 		return nil, err
 	}
-	if isClassic && !classic {
+	if isClassic && !modelIsClassic {
 		return nil, fmt.Errorf("snap %q cannot be classic in non-classic model", name)
 	}
 	if isClassic && typ != "app" {

--- a/asserts/model.go
+++ b/asserts/model.go
@@ -51,6 +51,9 @@ type ModelSnap struct {
 	PinnedTrack string
 	// Presence is one of: required|optional
 	Presence string
+	// Classic indicates that this classic snap is intenionally
+	// included in a classic model
+	Classic bool
 }
 
 // SnapName implements naming.SnapRef.
@@ -98,7 +101,7 @@ var (
 	defaultModes       = []string{"run"}
 )
 
-func checkExtendedSnaps(extendedSnaps interface{}, base string, grade ModelGrade) (*modelSnaps, error) {
+func checkExtendedSnaps(extendedSnaps interface{}, base string, grade ModelGrade, classic bool) (*modelSnaps, error) {
 	const wrongHeaderType = `"snaps" header must be a list of maps`
 
 	entries, ok := extendedSnaps.([]interface{})
@@ -115,7 +118,7 @@ func checkExtendedSnaps(extendedSnaps interface{}, base string, grade ModelGrade
 		if !ok {
 			return nil, fmt.Errorf(wrongHeaderType)
 		}
-		modelSnap, err := checkModelSnap(snap, grade)
+		modelSnap, err := checkModelSnap(snap, grade, classic)
 		if err != nil {
 			return nil, err
 		}
@@ -172,6 +175,10 @@ func checkExtendedSnaps(extendedSnaps interface{}, base string, grade ModelGrade
 		if len(modelSnap.Modes) == 0 {
 			modelSnap.Modes = defaultModes
 		}
+		if modelSnap.Classic && (len(modelSnap.Modes) != 1 || modelSnap.Modes[0] != "run") {
+			return nil, fmt.Errorf("classic snap %q now allowed outside of run mode: %v", modelSnap.Name, modelSnap.Modes)
+		}
+
 		if modelSnap.Presence == "" {
 			modelSnap.Presence = "required"
 		}
@@ -190,7 +197,7 @@ var (
 	validSnapPresences = []string{"required", "optional"}
 )
 
-func checkModelSnap(snap map[string]interface{}, grade ModelGrade) (*ModelSnap, error) {
+func checkModelSnap(snap map[string]interface{}, grade ModelGrade, classic bool) (*ModelSnap, error) {
 	name, err := checkNotEmptyStringWhat(snap, "name", "of snap")
 	if err != nil {
 		return nil, err
@@ -256,6 +263,17 @@ func checkModelSnap(snap map[string]interface{}, grade ModelGrade) (*ModelSnap, 
 		return nil, fmt.Errorf("presence of snap %q must be one of required|optional", name)
 	}
 
+	isClassic, err := checkOptionalBoolWhat(snap, "classic", what)
+	if err != nil {
+		return nil, err
+	}
+	if isClassic && !classic {
+		return nil, fmt.Errorf("snap %q cannot be classic in non-classic model", name)
+	}
+	if isClassic && typ != "app" {
+		return nil, fmt.Errorf("snap %q cannot be classic with type %q instead of app", name, typ)
+	}
+
 	return &ModelSnap{
 		Name:           name,
 		SnapID:         snapID,
@@ -263,6 +281,7 @@ func checkModelSnap(snap map[string]interface{}, grade ModelGrade) (*ModelSnap, 
 		Modes:          modes, // can be empty
 		DefaultChannel: defaultChannel,
 		Presence:       presence, // can be empty
+		Classic:        isClassic,
 	}, nil
 }
 
@@ -777,7 +796,7 @@ func assembleModel(assert assertionBase) (Assertion, error) {
 			return nil, fmt.Errorf(`secured grade model must not have storage-safety overridden, only "encrypted" is valid`)
 		}
 
-		modSnaps, err = checkExtendedSnaps(extendedSnaps, base, grade)
+		modSnaps, err = checkExtendedSnaps(extendedSnaps, base, grade, classic)
 		if err != nil {
 			return nil, err
 		}

--- a/asserts/model_test.go
+++ b/asserts/model_test.go
@@ -1032,10 +1032,10 @@ func (mods *modelSuite) testWithSnapsDecodeInvalid(c *C, modelRaw string, isClas
 			{"OTHER", `    modes:
       - ephemeral
       - run
-`, `classic snap "myappopt" now allowed outside of run mode: \[ephemeral run\]`},
+`, `classic snap "myappopt" not allowed outside of run mode: \[ephemeral run\]`},
 			{"OTHER", `    modes:
       - install
-`, `classic snap "myappopt" now allowed outside of run mode: \[install\]`},
+`, `classic snap "myappopt" not allowed outside of run mode: \[install\]`},
 			{`    type: app
     presence: optional
 `, `    type: base

--- a/asserts/model_test.go
+++ b/asserts/model_test.go
@@ -186,6 +186,7 @@ snaps:
     id: myappoptidididididididididididid
     type: app
     presence: optional
+    classic: true
 OTHERgrade: secured
 storage-safety: encrypted
 ` + "TSLINE" +
@@ -783,6 +784,7 @@ func (mods *modelSuite) testWithSnapsDecodeOK(c *C, modelRaw string, isClassic b
 			Modes:          []string{"run"},
 			DefaultChannel: "latest/stable",
 			Presence:       "optional",
+			Classic:        isClassic,
 		},
 	})
 	// essential snaps included
@@ -1026,6 +1028,20 @@ func (mods *modelSuite) testWithSnapsDecodeInvalid(c *C, modelRaw string, isClas
 			{"distribution: ubuntu\n", "distribution: Ubuntu\n", `"distribution" header contains invalid characters: "Ubuntu", see distribution ID in os-release spec`},
 			{"distribution: ubuntu\n", "distribution: *buntu\n", `"distribution" header contains invalid characters: "\*buntu", see distribution ID in os-release spec`},
 			{"type: gadget\n", "type: app\n", `cannot specify a kernel in an extended classic model without a model gadget`},
+			{"  classic: true\n", "  classic: what", `"classic" of snap "myappopt" must be 'true' or 'false'`},
+			{"OTHER", `    modes:
+      - ephemeral
+      - run
+`, `classic snap "myappopt" now allowed outside of run mode: \[ephemeral run\]`},
+			{"OTHER", `    modes:
+      - install
+`, `classic snap "myappopt" now allowed outside of run mode: \[install\]`},
+			{`    type: app
+    presence: optional
+`, `    type: base
+    presence: optional
+`, `snap "myappopt" cannot be classic with type "base" instead of app`},
+			{"\nclassic: true\ndistribution: ubuntu\n", "\nclassic: false\n", `snap "myappopt" cannot be classic in non-classic model`},
 		}
 		invalidTests = append(invalidTests, classicInvalid...)
 	} else {
@@ -1152,6 +1168,7 @@ func (mods *modelSuite) TestClassicWithSnapsMinimalDecodeOK(c *C) {
 				Modes:          []string{"run"},
 				DefaultChannel: "latest/stable",
 				Presence:       "optional",
+				Classic:        true,
 			},
 		})
 		// essential snaps included

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2021 Canonical Ltd
+ * Copyright (C) 2016-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/overlord/devicestate/firstboot.go
+++ b/overlord/devicestate/firstboot.go
@@ -230,6 +230,7 @@ func populateStateFromSeedImpl(st *state.State, opts *populateStateFromSeedOptio
 		configTss = chainTs(configTss, snapstate.ConfigureSnap(st, "core", snapstate.UseConfigDefaults))
 	}
 
+	dangerousModel := model.Grade() == asserts.ModelDangerous
 	for _, seedSnap := range essentialSeedSnaps {
 		flags := snapstate.Flags{
 			SkipConfigure: true,
@@ -240,7 +241,7 @@ func populateStateFromSeedImpl(st *state.State, opts *populateStateFromSeedOptio
 			// XXX: eventually we may need to allow specific snaps to be devmode for
 			// non-dangerous models, we can do that here since that information will
 			// probably be in the model assertion which we have here
-			ApplySnapDevMode: model.Grade() == asserts.ModelDangerous,
+			ApplySnapDevMode: dangerousModel,
 		}
 
 		ts, info, err := installSeedSnap(st, seedSnap, flags)
@@ -278,7 +279,10 @@ func populateStateFromSeedImpl(st *state.State, opts *populateStateFromSeedOptio
 			// XXX: eventually we may need to allow specific snaps to be devmode for
 			// non-dangerous models, we can do that here since that information will
 			// probably be in the model assertion which we have here
-			ApplySnapDevMode: model.Grade() == asserts.ModelDangerous,
+			ApplySnapDevMode: dangerousModel,
+			// for non-dangerous models snaps need to opt-in explicitly
+			// Classic is simply ignored for non-classic snaps, so we do not need to check further
+			Classic: release.OnClassic && dangerousModel,
 		}
 
 		ts, info, err := installSeedSnap(st, seedSnap, flags)

--- a/overlord/devicestate/firstboot.go
+++ b/overlord/devicestate/firstboot.go
@@ -230,7 +230,7 @@ func populateStateFromSeedImpl(st *state.State, opts *populateStateFromSeedOptio
 		configTss = chainTs(configTss, snapstate.ConfigureSnap(st, "core", snapstate.UseConfigDefaults))
 	}
 
-	dangerousModel := model.Grade() == asserts.ModelDangerous
+	modelIsDangerous := model.Grade() == asserts.ModelDangerous
 	for _, seedSnap := range essentialSeedSnaps {
 		flags := snapstate.Flags{
 			SkipConfigure: true,
@@ -241,7 +241,7 @@ func populateStateFromSeedImpl(st *state.State, opts *populateStateFromSeedOptio
 			// XXX: eventually we may need to allow specific snaps to be devmode for
 			// non-dangerous models, we can do that here since that information will
 			// probably be in the model assertion which we have here
-			ApplySnapDevMode: dangerousModel,
+			ApplySnapDevMode: modelIsDangerous,
 		}
 
 		ts, info, err := installSeedSnap(st, seedSnap, flags)
@@ -279,10 +279,10 @@ func populateStateFromSeedImpl(st *state.State, opts *populateStateFromSeedOptio
 			// XXX: eventually we may need to allow specific snaps to be devmode for
 			// non-dangerous models, we can do that here since that information will
 			// probably be in the model assertion which we have here
-			ApplySnapDevMode: dangerousModel,
+			ApplySnapDevMode: modelIsDangerous,
 			// for non-dangerous models snaps need to opt-in explicitly
 			// Classic is simply ignored for non-classic snaps, so we do not need to check further
-			Classic: release.OnClassic && dangerousModel,
+			Classic: release.OnClassic && modelIsDangerous,
 		}
 
 		ts, info, err := installSeedSnap(st, seedSnap, flags)

--- a/overlord/devicestate/firstboot20_test.go
+++ b/overlord/devicestate/firstboot20_test.go
@@ -819,7 +819,7 @@ func (s *firstBoot20Suite) TestPopulateFromSeedClassicWithModesRunModeNoKernelAn
 	}})
 }
 
-func (s *firstBoot20Suite) TestPopulateFromSeedClassicWithModesRunModeNoKernelAndGadgetClassicSnap(c *C) {
+func (s *firstBoot20Suite) testPopulateFromSeedClassicWithModesRunModeNoKernelAndGadgetClassicSnap(c *C, modelGrade asserts.ModelGrade) {
 	defer release.MockReleaseInfo(&release.OS{ID: "ubuntu", VersionID: "20.04"})()
 	// XXX this shouldn't be needed
 	defer release.MockOnClassic(true)()
@@ -831,7 +831,6 @@ func (s *firstBoot20Suite) TestPopulateFromSeedClassicWithModesRunModeNoKernelAn
 		Base:           "core20_1.snap",
 		Classic:        true,
 	}
-	modelGrade := asserts.ModelDangerous
 
 	var sysdLog [][]string
 	systemctlRestorer := systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
@@ -853,9 +852,7 @@ apps:
   inst:
     daemon: simple
 `
-	s.extraSnapModelDetails["classic-installer"] = map[string]interface{}{
-		"modes": []interface{}{"run"},
-	}
+
 	sysLabel := m.RecoverySystem
 	kernelAndGadget := false
 	model := s.setupCore20LikeSeed(c, sysLabel, modelGrade, kernelAndGadget, "", "classic-installer")
@@ -988,4 +985,21 @@ apps:
 		Timestamp: model.Timestamp(),
 		SeedTime:  seedTime,
 	}})
+}
+
+func (s *firstBoot20Suite) TestPopulateFromSeedClassicWithModesDangerousRunModeNoKernelAndGadgetClassicSnap(c *C) {
+	s.extraSnapModelDetails["classic-installer"] = map[string]interface{}{
+		"modes": []interface{}{"run"},
+	}
+
+	s.testPopulateFromSeedClassicWithModesRunModeNoKernelAndGadgetClassicSnap(c, asserts.ModelDangerous)
+}
+
+func (s *firstBoot20Suite) TestPopulateFromSeedClassicWithModesSignedRunModeNoKernelAndGadgetClassicSnap(c *C) {
+	s.extraSnapModelDetails["classic-installer"] = map[string]interface{}{
+		"classic": "true",
+		"modes":   []interface{}{"run"},
+	}
+
+	s.testPopulateFromSeedClassicWithModesRunModeNoKernelAndGadgetClassicSnap(c, asserts.ModelSigned)
 }

--- a/overlord/devicestate/firstboot20_test.go
+++ b/overlord/devicestate/firstboot20_test.go
@@ -993,6 +993,8 @@ apps:
 }
 
 func (s *firstBoot20Suite) TestPopulateFromSeedClassicWithModesDangerousRunModeNoKernelAndGadgetClassicSnap(c *C) {
+	// classic snaps are implicitly allowed and seeded for dangerous
+	// classic models
 	s.extraSnapModelDetails["classic-installer"] = map[string]interface{}{
 		"modes": []interface{}{"run"},
 	}
@@ -1001,6 +1003,7 @@ func (s *firstBoot20Suite) TestPopulateFromSeedClassicWithModesDangerousRunModeN
 }
 
 func (s *firstBoot20Suite) TestPopulateFromSeedClassicWithModesSignedRunModeNoKernelAndGadgetClassicSnap(c *C) {
+	// classic snaps must be declared explicitly for non-dangerous models
 	s.extraSnapModelDetails["classic-installer"] = map[string]interface{}{
 		"classic": "true",
 		"modes":   []interface{}{"run"},
@@ -1010,6 +1013,8 @@ func (s *firstBoot20Suite) TestPopulateFromSeedClassicWithModesSignedRunModeNoKe
 }
 
 func (s *firstBoot20Suite) TestPopulateFromSeedClassicWithModesSignedRunModeNoKernelAndGadgetClassicSnapImplicitFails(c *C) {
+	// classic snaps must be declared explicitly for non-dangerous models,
+	// not doing so results in a seeding error
 	s.extraSnapModelDetails["classic-installer"] = map[string]interface{}{
 		"modes": []interface{}{"run"},
 	}

--- a/seed/seed20.go
+++ b/seed/seed20.go
@@ -406,6 +406,7 @@ func (s *seed20) doLoadMetaOne(sntoc *snapToConsider, handler SnapHandler, tm ti
 	var essential bool
 	var essType snap.Type
 	var required bool
+	var classic bool
 	if sntoc.modelSnap != nil {
 		snapRef = sntoc.modelSnap
 		essential = sntoc.essential
@@ -414,6 +415,7 @@ func (s *seed20) doLoadMetaOne(sntoc *snapToConsider, handler SnapHandler, tm ti
 		}
 		required = essential || sntoc.modelSnap.Presence == "required"
 		channel = sntoc.modelSnap.DefaultChannel
+		classic = sntoc.modelSnap.Classic
 		snapsDir = "../../snaps"
 	} else {
 		snapRef = sntoc.optSnap
@@ -430,6 +432,7 @@ func (s *seed20) doLoadMetaOne(sntoc *snapToConsider, handler SnapHandler, tm ti
 	}
 	seedSnap.Essential = essential
 	seedSnap.Required = required
+	seedSnap.Classic = classic
 	if essential {
 		if sntoc.modelSnap.SnapType == "gadget" {
 			// validity


### PR DESCRIPTION
They are implicitly supported and allowed with dangerous models on classic.

For non-dangerous classic models the model needs to opt-in for each by setting "classic: true" in the snap entry in the "snaps" stanza.
