### PR TITLE
cmd/snap,daemon: allow zero values from client to daemon for journal rate-limit

### DIFF
--- a/client/quota.go
+++ b/client/quota.go
@@ -58,6 +58,7 @@ type QuotaJournalValues struct {
 	Size       quantity.Size `json:"size,omitempty"`
 	RateCount  int           `json:"rate-count,omitempty"`
 	RatePeriod time.Duration `json:"rate-period,omitempty"`
+	RateValid  bool          `json:"rate-valid,omitempty"`
 }
 
 type QuotaValues struct {

--- a/client/quota.go
+++ b/client/quota.go
@@ -54,11 +54,14 @@ type QuotaCPUSetValues struct {
 	CPUs []int `json:"cpus,omitempty"`
 }
 
+type QuotaJournalRate struct {
+	RateCount  int           `json:"rate-count"`
+	RatePeriod time.Duration `json:"rate-period"`
+}
+
 type QuotaJournalValues struct {
-	Size       quantity.Size `json:"size,omitempty"`
-	RateCount  int           `json:"rate-count,omitempty"`
-	RatePeriod time.Duration `json:"rate-period,omitempty"`
-	RateValid  bool          `json:"rate-valid,omitempty"`
+	Size quantity.Size `json:"size,omitempty"`
+	*QuotaJournalRate
 }
 
 type QuotaValues struct {

--- a/client/quota_test.go
+++ b/client/quota_test.go
@@ -56,9 +56,11 @@ func (cs *clientSuite) TestEnsureQuotaGroup(c *check.C) {
 		},
 		Threads: 32,
 		Journal: &client.QuotaJournalValues{
-			Size:       quantity.SizeMiB,
-			RateCount:  150,
-			RatePeriod: time.Minute,
+			Size: quantity.SizeMiB,
+			QuotaJournalRate: &client.QuotaJournalRate{
+				RateCount:  150,
+				RatePeriod: time.Minute,
+			},
 		},
 	}
 

--- a/cmd/snap/cmd_quota.go
+++ b/cmd/snap/cmd_quota.go
@@ -261,6 +261,7 @@ func (x *cmdSetQuota) parseQuotas() (*client.QuotaValues, error) {
 			}
 			quotaValues.Journal.RateCount = count
 			quotaValues.Journal.RatePeriod = period
+			quotaValues.Journal.RateValid = true
 		}
 	}
 

--- a/cmd/snap/cmd_quota.go
+++ b/cmd/snap/cmd_quota.go
@@ -259,9 +259,10 @@ func (x *cmdSetQuota) parseQuotas() (*client.QuotaValues, error) {
 			if err != nil {
 				return nil, fmt.Errorf("cannot parse journal rate limit %q: %v", x.JournalRateLimit, err)
 			}
-			quotaValues.Journal.RateCount = count
-			quotaValues.Journal.RatePeriod = period
-			quotaValues.Journal.RateValid = true
+			quotaValues.Journal.QuotaJournalRate = &client.QuotaJournalRate{
+				RateCount:  count,
+				RatePeriod: period,
+			}
 		}
 	}
 
@@ -412,8 +413,10 @@ func (x *cmdQuota) Execute(args []string) (err error) {
 			val := strings.TrimSpace(fmtSize(int64(group.Constraints.Journal.Size)))
 			fmt.Fprintf(w, "  journal-size:\t%s\n", val)
 		}
-		if group.Constraints.Journal.RateCount != 0 && group.Constraints.Journal.RatePeriod != 0 {
-			fmt.Fprintf(w, "  journal-rate:\t%d/%s\n", group.Constraints.Journal.RateCount, group.Constraints.Journal.RatePeriod)
+		if group.Constraints.Journal.QuotaJournalRate != nil {
+			fmt.Fprintf(w, "  journal-rate:\t%d/%s\n",
+				group.Constraints.Journal.RateCount,
+				group.Constraints.Journal.RatePeriod)
 		}
 	}
 
@@ -524,8 +527,11 @@ func (x *cmdQuotas) Execute(args []string) (err error) {
 			if q.Constraints.Journal.Size != 0 {
 				grpConstraints = append(grpConstraints, "journal-size="+strings.TrimSpace(fmtSize(int64(q.Constraints.Journal.Size))))
 			}
-			if q.Constraints.Journal.RateCount != 0 && q.Constraints.Journal.RatePeriod != 0 {
-				grpConstraints = append(grpConstraints, fmt.Sprintf("journal-rate=%d/%s", q.Constraints.Journal.RateCount, q.Constraints.Journal.RatePeriod))
+
+			if q.Constraints.Journal.QuotaJournalRate != nil {
+				grpConstraints = append(grpConstraints,
+					fmt.Sprintf("journal-rate=%d/%s",
+						q.Constraints.Journal.RateCount, q.Constraints.Journal.RatePeriod))
 			}
 		}
 

--- a/cmd/snap/cmd_quota_test.go
+++ b/cmd/snap/cmd_quota_test.go
@@ -220,9 +220,10 @@ func (s *quotaSuite) TestParseQuotas(c *check.C) {
 		{cpuSet: "1,3", quotas: `{"cpu-set":{"cpus":[1,3]}}`},
 		{threadsMax: "2", quotas: `{"threads":2}`},
 		{journalSizeMax: "16MB", quotas: `{"journal":{"size":16000000}}`},
-		{journalRateLimit: "10/15s", quotas: `{"journal":{"rate-count":10,"rate-period":15000000000}}`},
-		{journalRateLimit: "1500/15ms", quotas: `{"journal":{"rate-count":1500,"rate-period":15000000}}`},
-		{journalRateLimit: "1/15us", quotas: `{"journal":{"rate-count":1,"rate-period":15000}}`},
+		{journalRateLimit: "10/15s", quotas: `{"journal":{"rate-count":10,"rate-period":15000000000,"rate-valid":true}}`},
+		{journalRateLimit: "1500/15ms", quotas: `{"journal":{"rate-count":1500,"rate-period":15000000,"rate-valid":true}}`},
+		{journalRateLimit: "1/15us", quotas: `{"journal":{"rate-count":1,"rate-period":15000,"rate-valid":true}}`},
+		{journalRateLimit: "0/0s", quotas: `{"journal":{"rate-valid":true}}`},
 
 		// Error cases
 		{cpuMax: "ASD", err: `cannot parse cpu quota string "ASD"`},

--- a/cmd/snap/cmd_quota_test.go
+++ b/cmd/snap/cmd_quota_test.go
@@ -220,10 +220,10 @@ func (s *quotaSuite) TestParseQuotas(c *check.C) {
 		{cpuSet: "1,3", quotas: `{"cpu-set":{"cpus":[1,3]}}`},
 		{threadsMax: "2", quotas: `{"threads":2}`},
 		{journalSizeMax: "16MB", quotas: `{"journal":{"size":16000000}}`},
-		{journalRateLimit: "10/15s", quotas: `{"journal":{"rate-count":10,"rate-period":15000000000,"rate-valid":true}}`},
-		{journalRateLimit: "1500/15ms", quotas: `{"journal":{"rate-count":1500,"rate-period":15000000,"rate-valid":true}}`},
-		{journalRateLimit: "1/15us", quotas: `{"journal":{"rate-count":1,"rate-period":15000,"rate-valid":true}}`},
-		{journalRateLimit: "0/0s", quotas: `{"journal":{"rate-valid":true}}`},
+		{journalRateLimit: "10/15s", quotas: `{"journal":{"rate-count":10,"rate-period":15000000000}}`},
+		{journalRateLimit: "1500/15ms", quotas: `{"journal":{"rate-count":1500,"rate-period":15000000}}`},
+		{journalRateLimit: "1/15us", quotas: `{"journal":{"rate-count":1,"rate-period":15000}}`},
+		{journalRateLimit: "0/0s", quotas: `{"journal":{"rate-count":0,"rate-period":0}}`},
 
 		// Error cases
 		{cpuMax: "ASD", err: `cannot parse cpu quota string "ASD"`},
@@ -661,11 +661,12 @@ func (s *quotaSuite) TestGetAllQuotaGroups(c *check.C) {
 			{"group-name":"fff","parent":"aaa","constraints":{"memory":1000},"current":{"memory":0}},
 			{"group-name":"xxx","constraints":{"memory":9900},"current":{"memory":10000}},
 			{"group-name":"cp0","constraints":{"memory":9900, "cpu":{"percentage":90}},"current":{"memory":10000}},
-			{"group-name":"cp1","subgroups":["cps0","js0"],"constraints":{"cpu":{"count":2, "percentage":90}}},
+			{"group-name":"cp1","subgroups":["cps0","js0","js1"],"constraints":{"cpu":{"count":2, "percentage":90}}},
 			{"group-name":"cps0","parent":"cp1","constraints":{"cpu":{"percentage":40}}},
 			{"group-name":"cp2","subgroups":["cps1"],"constraints":{"cpu":{"count":2,"percentage":100},"cpu-set":{"cpus":[0,1]}}},
 			{"group-name":"cps1","parent":"cp2","constraints":{"memory":9900,"cpu":{"percentage":50},"cpu-set":{"cpus":[1]}},"current":{"memory":10000}},
-			{"group-name":"js0","parent":"cp1","constraints":{"journal":{"size":1048576,"rate-count":50,"rate-period":60000000000}}}
+			{"group-name":"js0","parent":"cp1","constraints":{"journal":{"size":1048576,"rate-count":50,"rate-period":60000000000}}},
+			{"group-name":"js1","parent":"cp1","constraints":{"journal":{"rate-count":0,"rate-period":0}}}
 			]}`))
 
 	rest, err := main.Parser(main.Client()).ParseArgs([]string{"quotas"})
@@ -678,6 +679,7 @@ cp0              memory=9.9kB,cpu=90%                      memory=10.0kB
 cp1              cpu=2x90%                                 
 cps0     cp1     cpu=40%                                   
 js0      cp1     journal-size=1.05MB,journal-rate=50/1m0s  
+js1      cp1     journal-rate=0/0s                         
 cp2              cpu=2x100%,cpu-set=0,1                    
 cps1     cp2     memory=9.9kB,cpu=50%,cpu-set=1            memory=10.0kB
 ggg              memory=1000B,threads=100                  memory=3000B

--- a/daemon/api_quotas.go
+++ b/daemon/api_quotas.go
@@ -208,7 +208,7 @@ func quotaValuesToResources(values client.QuotaValues) quota.Resources {
 		if values.Journal.Size != 0 {
 			resourcesBuilder.WithJournalSize(values.Journal.Size)
 		}
-		if values.Journal.RateCount != 0 && values.Journal.RatePeriod != 0 {
+		if values.Journal.RateValid {
 			resourcesBuilder.WithJournalRate(values.Journal.RateCount, values.Journal.RatePeriod)
 		}
 	}

--- a/daemon/api_quotas.go
+++ b/daemon/api_quotas.go
@@ -100,9 +100,13 @@ func createQuotaValues(grp *quota.Group) *client.QuotaValues {
 	}
 	if grp.JournalLimit != nil {
 		constraints.Journal = &client.QuotaJournalValues{
-			Size:       grp.JournalLimit.Size,
-			RateCount:  grp.JournalLimit.RateCount,
-			RatePeriod: grp.JournalLimit.RatePeriod,
+			Size: grp.JournalLimit.Size,
+		}
+		if grp.JournalLimit.RateEnabled {
+			constraints.Journal.QuotaJournalRate = &client.QuotaJournalRate{
+				RateCount:  grp.JournalLimit.RateCount,
+				RatePeriod: grp.JournalLimit.RatePeriod,
+			}
 		}
 	}
 	return &constraints
@@ -208,7 +212,7 @@ func quotaValuesToResources(values client.QuotaValues) quota.Resources {
 		if values.Journal.Size != 0 {
 			resourcesBuilder.WithJournalSize(values.Journal.Size)
 		}
-		if values.Journal.RateValid {
+		if values.Journal.QuotaJournalRate != nil {
 			resourcesBuilder.WithJournalRate(values.Journal.RateCount, values.Journal.RatePeriod)
 		}
 	}

--- a/daemon/api_quotas_test.go
+++ b/daemon/api_quotas_test.go
@@ -116,9 +116,11 @@ func (s *apiQuotaSuite) TestCreateQuotaValues(c *check.C) {
 		CPUs: []int{0, 1},
 	})
 	c.Check(quotaValues.Journal, check.DeepEquals, &client.QuotaJournalValues{
-		Size:       quantity.SizeMiB,
-		RateCount:  150,
-		RatePeriod: time.Second,
+		Size: quantity.SizeMiB,
+		QuotaJournalRate: &client.QuotaJournalRate{
+			RateCount:  150,
+			RatePeriod: time.Second,
+		},
 	})
 }
 
@@ -279,9 +281,10 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaCreateJournalRateZeroHappy(c *check.C
 		Snaps:     []string{"some-snap"},
 		Constraints: client.QuotaValues{
 			Journal: &client.QuotaJournalValues{
-				RateCount:  0,
-				RatePeriod: 0,
-				RateValid:  true,
+				QuotaJournalRate: &client.QuotaJournalRate{
+					RateCount:  0,
+					RatePeriod: 0,
+				},
 			},
 		},
 	})

--- a/tests/main/snap-quota-journal/task.yaml
+++ b/tests/main/snap-quota-journal/task.yaml
@@ -62,13 +62,22 @@ execute: |
   # Now ask for the namespace logs and lets see if we can see messages from 'LogDaemon'
   retry -n 5 sh -c "$TESTSTOOLS/journal-state get-log --namespace snap-group-one | MATCH LogDaemon"
 
-  # Change the size and ensure that the journal is restarted
+  # Change the size and set rate to zero and ensure that the journal is restarted, and that the changes
+  # are correctly reflected in the journal config. We try to set the rate to zero to verify we allow zero
+  # values. This was originally a bug reported (LP1912173).
   echo "Updating size of journal to ensure size changes"
-  snap set-quota group-one --journal-size=64MB
+  snap set-quota group-one --journal-size=64MB --journal-rate-limit=0/0s
 
   echo "And the service is still active"
   retry -n 3 sh -c "snap services test-snapd-journal-quota.logger | MATCH 'test-snapd-journal-quota.logger\s+enabled\s+active'"
 
+  # Verify the new contents of /etc/systemd/journald@snap-group-one.conf
+  echo "Verifying the new journal config contents"
+  MATCH "^SystemMaxUse=64000000"    < /etc/systemd/journald@snap-group-one.conf
+  MATCH "^RuntimeMaxUse=64000000"   < /etc/systemd/journald@snap-group-one.conf
+  MATCH "^RateLimitIntervalSec=0us" < /etc/systemd/journald@snap-group-one.conf
+  MATCH "^RateLimitBurst=0"         < /etc/systemd/journald@snap-group-one.conf
+  
   # Ensure that the new size is printed in the journal logs. We requested 64MB but
   # this will most likely print out as 61.0M, so lets be a bit flexible
   "$TESTSTOOLS"/journal-state get-log --namespace snap-group-one | MATCH "max 6[0-9].[0-9]M,"


### PR DESCRIPTION
It seems I had missed the communication between client and daemon with my fix for allowing zero values for the journal rate-limit. This adds the missing link :-)