### PR TITLE
interfaces: steam-support allow additional mounts

### DIFF
--- a/interfaces/builtin/steam_support.go
+++ b/interfaces/builtin/steam_support.go
@@ -126,11 +126,10 @@ remount options=(bind, silent, nosuid, ro, nodev, noexec, relatime, nodiratime) 
 
 /newroot/** rwkl,
 /bindfile* rw,
-mount options=(rw, rbind) /oldroot/home/ -> /newroot/home/,
 mount options=(rw, rbind) /oldroot/opt/ -> /newroot/opt/,
 mount options=(rw, rbind) /oldroot/srv/ -> /newroot/srv/,
 mount options=(rw, rbind) /oldroot/run/udev/ -> /newroot/run/udev/,
-mount options=(rw, rbind) /oldroot/home/** -> /newroot/home/**,
+mount options=(rw, rbind) /oldroot/home/{,**} -> /newroot/home/{,**},
 mount options=(rw, rbind) /oldroot/snap/** -> /newroot/snap/**,
 mount options=(rw, rbind) /oldroot/home/**/usr/ -> /newroot/usr/,
 mount options=(rw, rbind) /oldroot/home/**/usr/etc/** -> /newroot/etc/**,

--- a/interfaces/builtin/steam_support.go
+++ b/interfaces/builtin/steam_support.go
@@ -129,7 +129,6 @@ remount options=(bind, silent, nosuid, ro, nodev, noexec, relatime, nodiratime) 
 mount options=(rw, rbind) /oldroot/home/ -> /newroot/home/,
 mount options=(rw, rbind) /oldroot/opt/ -> /newroot/opt/,
 mount options=(rw, rbind) /oldroot/srv/ -> /newroot/srv/,
-mount options=(rw, rbind) /oldroot/tmp/.X11-unix/X0 -> /newroot/tmp/.X11-unix/X0,
 mount options=(rw, rbind) /oldroot/run/udev/ -> /newroot/run/udev/,
 mount options=(rw, rbind) /oldroot/home/** -> /newroot/home/**,
 mount options=(rw, rbind) /oldroot/snap/** -> /newroot/snap/**,
@@ -161,7 +160,7 @@ mount options=(rw, rbind) /oldroot/usr/share/icons/ -> /newroot/run/host/share/i
 mount options=(rw, rbind) /oldroot/home/**/.local/share/icons/ -> /newroot/run/host/user-share/icons/,
 
 mount options=(rw, rbind) /oldroot/run/user/[0-9]*/wayland-* -> /newroot/run/pressure-vessel/wayland-*,
-mount options=(rw, rbind) /oldroot/tmp/.X11-unix/X* -> /newroot/tmp/.X11-unix/X99,
+mount options=(rw, rbind) /oldroot/tmp/.X11-unix/X* -> /newroot/tmp/.X11-unix/X*,
 mount options=(rw, rbind) /bindfile* -> /newroot/run/pressure-vessel/Xauthority,
 
 mount options=(rw, rbind) /bindfile* -> /newroot/run/pressure-vessel/pulse/config,

--- a/interfaces/builtin/steam_support.go
+++ b/interfaces/builtin/steam_support.go
@@ -126,6 +126,11 @@ remount options=(bind, silent, nosuid, ro, nodev, noexec, relatime, nodiratime) 
 
 /newroot/** rwkl,
 /bindfile* rw,
+mount options=(rw, rbind) /oldroot/home/ -> /newroot/home/,
+mount options=(rw, rbind) /oldroot/opt/ -> /newroot/opt/,
+mount options=(rw, rbind) /oldroot/srv/ -> /newroot/srv/,
+mount options=(rw, rbind) /oldroot/tmp/.X11-unix/X0 -> /newroot/tmp/.X11-unix/X0,
+mount options=(rw, rbind) /oldroot/run/udev/ -> /newroot/run/udev/,
 mount options=(rw, rbind) /oldroot/home/** -> /newroot/home/**,
 mount options=(rw, rbind) /oldroot/snap/** -> /newroot/snap/**,
 mount options=(rw, rbind) /oldroot/home/**/usr/ -> /newroot/usr/,


### PR DESCRIPTION
Added additional mounts allowed in the steam-support interface, necessary for proton support.  Fixes https://github.com/canonical/steam-snap/issues/6

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
