### PR TITLE
interfaces: allow access to icon subdirectories

### DIFF
--- a/interfaces/builtin/desktop_launch.go
+++ b/interfaces/builtin/desktop_launch.go
@@ -40,7 +40,7 @@ const desktopLaunchConnectedPlugAppArmor = `
 
 # Access to the desktop and icon files installed by snaps
 /var/lib/snapd/desktop/applications/{,*} r,
-/var/lib/snapd/desktop/icons/{,*} r,
+/var/lib/snapd/desktop/icons/{,**} r,
 
 #include <abstractions/dbus-session-strict>
 


### PR DESCRIPTION
Icons may be in subdirectories of /var/lib/snapd/desktop/icons/ if they are using icon themes, e.g. hicolor/apps/scalable/icon.svg.

