### PR TITLE
o/snapstate: fix snaps-hold pruning/reset in the presence of system holding

### DIFF
--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -380,9 +380,15 @@ func MockHoldState(firstHeld string, holdUntil string) *HoldState {
 	if err != nil {
 		panic(err)
 	}
-	until, err := time.Parse(time.RFC3339, holdUntil)
-	if err != nil {
-		panic(err)
+	var until time.Time
+	if holdUntil != "forever" {
+		var err error
+		until, err = time.Parse(time.RFC3339, holdUntil)
+		if err != nil {
+			panic(err)
+		}
+	} else {
+		until = first.Add(maxDuration)
 	}
 	return &holdState{
 		FirstHeld: first,


### PR DESCRIPTION
while refreshes should forget the holds by other snaps on the refreshed snap, this should not be the case for holds set up by the user/system
