### PR TITLE
overlord: introduce hold levels in the snapstate.Hold* APIs

### DIFF
--- a/overlord/hookstate/ctlcmd/refresh.go
+++ b/overlord/hookstate/ctlcmd/refresh.go
@@ -273,7 +273,8 @@ func (c *refreshCommand) hold() error {
 
 	// no duration specified, use maximum allowed for this gating snap.
 	var holdDuration time.Duration
-	remaining, err := snapstate.HoldRefresh(st, ctx.InstanceName(), holdDuration, affecting...)
+	// XXX for now snaps hold other snaps only for auto-refreshes
+	remaining, err := snapstate.HoldRefresh(st, snapstate.HoldAutoRefresh, ctx.InstanceName(), holdDuration, affecting...)
 	if err != nil {
 		// TODO: let a snap hold again once for 1h.
 		return err

--- a/overlord/hookstate/ctlcmd/refresh_test.go
+++ b/overlord/hookstate/ctlcmd/refresh_test.go
@@ -223,7 +223,7 @@ version: 1
 `, "")
 
 	// pretend snap foo is held initially
-	_, err = snapstate.HoldRefresh(s.st, "snap1", 0, "foo")
+	_, err = snapstate.HoldRefresh(s.st, snapstate.HoldAutoRefresh, "snap1", 0, "foo")
 	c.Check(err, IsNil)
 	s.st.Unlock()
 

--- a/overlord/hookstate/hooks.go
+++ b/overlord/hookstate/hooks.go
@@ -241,7 +241,7 @@ func (h *gateAutoRefreshHookHandler) Error(hookErr error) (ignoreHookErr bool, e
 
 	// no duration specified, use maximum allowed for this gating snap.
 	var holdDuration time.Duration
-	if _, err := snapstate.HoldRefresh(st, snapName, holdDuration, affecting...); err != nil {
+	if _, err := snapstate.HoldRefresh(st, snapstate.HoldAutoRefresh, snapName, holdDuration, affecting...); err != nil {
 		// log the original hook error as we either ignore it or error out from
 		// this handler, in both cases hookErr won't be logged by hook manager.
 		h.context.Errorf("error: %v (while handling previous hook error: %v)", err, hookErr)

--- a/overlord/hookstate/hooks_test.go
+++ b/overlord/hookstate/hooks_test.go
@@ -248,7 +248,7 @@ func (s *gateAutoRefreshHookSuite) TestGateAutorefreshDefaultProceedUnlocksRunin
 	defer st.Unlock()
 
 	// pretend that snap-a is initially held by itself.
-	_, err := snapstate.HoldRefresh(st, "snap-a", 0, "snap-a")
+	_, err := snapstate.HoldRefresh(st, snapstate.HoldAutoRefresh, "snap-a", 0, "snap-a")
 	c.Assert(err, IsNil)
 	// validity
 	checkIsHeld(c, st, "snap-a", "snap-a")
@@ -299,7 +299,7 @@ func (s *gateAutoRefreshHookSuite) TestGateAutorefreshDefaultProceed(c *C) {
 	defer st.Unlock()
 
 	// pretend that snap-b is initially held by snap-a.
-	_, err := snapstate.HoldRefresh(st, "snap-a", 0, "snap-b")
+	_, err := snapstate.HoldRefresh(st, snapstate.HoldAutoRefresh, "snap-a", 0, "snap-b")
 	c.Assert(err, IsNil)
 	// validity
 	checkIsHeld(c, st, "snap-b", "snap-a")

--- a/overlord/snapstate/autorefresh_gating.go
+++ b/overlord/snapstate/autorefresh_gating.go
@@ -80,11 +80,24 @@ func lastRefreshed(st *state.State, snapName string) (time.Time, error) {
 	return fst.ModTime(), nil
 }
 
+// HoldLevel determines which refresh operations are controlled by the hold.
+// Levels are ordered and higher levels imply lower ones.
+type HoldLevel int
+
+const (
+	// HoldAutoRefresh holds snaps only in auto-refresh operations
+	HoldAutoRefresh HoldLevel = iota
+	// HoldGeneral holds snaps in general and auto-refresh operations
+	HoldGeneral
+)
+
 type holdState struct {
 	// FirstHeld keeps the time when the given snap was first held for refresh by a gating snap.
 	FirstHeld time.Time `json:"first-held"`
 	// HoldUntil stores the desired end time for holding.
 	HoldUntil time.Time `json:"hold-until"`
+	// Level of this hold.
+	Level HoldLevel `json:"level,omitempty"`
 }
 
 func refreshGating(st *state.State) (map[string]map[string]*holdState, error) {
@@ -147,7 +160,9 @@ func holdDurationLeft(now time.Time, lastRefresh, firstHeld time.Time, maxDurati
 // HoldRefreshesBySystem is used to hold snaps by the sys admin (denoted by the
 // "system" holding snap). HoldTime can be "forever" to denote an indefinite hold
 // or any RFC3339 timestamp.
-func HoldRefreshesBySystem(st *state.State, holdTime string, holdSnaps []string) error {
+// A hold level can be specified indicating which operations are affected by the
+// hold.
+func HoldRefreshesBySystem(st *state.State, level HoldLevel, holdTime string, holdSnaps []string) error {
 	snaps, err := All(st)
 	if err != nil {
 		return err
@@ -170,7 +185,7 @@ func HoldRefreshesBySystem(st *state.State, holdTime string, holdSnaps []string)
 		holdDuration = holdTime.Sub(timeNow())
 	}
 
-	_, err = HoldRefresh(st, "system", holdDuration, holdSnaps...)
+	_, err = HoldRefresh(st, level, "system", holdDuration, holdSnaps...)
 	return err
 }
 
@@ -180,7 +195,9 @@ func HoldRefreshesBySystem(st *state.State, holdTime string, holdSnaps []string)
 // and it contains the details of snaps that prevented holding. On success the
 // function returns the remaining hold time. The remaining hold time is the
 // minimum of the remaining hold time for all affecting snaps.
-func HoldRefresh(st *state.State, gatingSnap string, holdDuration time.Duration, affectingSnaps ...string) (time.Duration, error) {
+// A hold level can be specified indicating which operations are affected by the
+// hold.
+func HoldRefresh(st *state.State, level HoldLevel, gatingSnap string, holdDuration time.Duration, affectingSnaps ...string) (time.Duration, error) {
 	gating, err := refreshGating(st)
 	if err != nil {
 		return 0, err
@@ -201,6 +218,7 @@ func HoldRefresh(st *state.State, gatingSnap string, holdDuration time.Duration,
 				FirstHeld: now,
 			}
 		}
+		hold.Level = level
 
 		if gatingSnap == "system" {
 			if holdDuration == 0 {
@@ -425,8 +443,9 @@ func pruneSnapsHold(st *state.State, snapName string) error {
 	return nil
 }
 
-// HeldSnaps returns all snaps that are gated and shouldn't be refreshed.
-func HeldSnaps(st *state.State) (map[string]bool, error) {
+// HeldSnaps returns all snaps that are held for at least at the given level
+// and shouldn't be refreshed.
+func HeldSnaps(st *state.State, level HoldLevel) (map[string]bool, error) {
 	gating, err := refreshGating(st)
 	if err != nil {
 		return nil, err
@@ -446,6 +465,10 @@ Loop:
 		}
 
 		for holdingSnap, hold := range holds {
+			// hold.Level is at least level
+			if hold.Level < level {
+				continue
+			}
 			// enforce the maxPostponement limit on a hold, unless it's held by the user
 			if holdingSnap != "system" && lastRefresh.Add(maxPostponement).Before(now) {
 				continue
@@ -695,7 +718,7 @@ var snapsToRefresh = func(gatingTask *state.Task) ([]*refreshCandidate, error) {
 		return nil, err
 	}
 
-	held, err := HeldSnaps(gatingTask.State())
+	held, err := HeldSnaps(gatingTask.State(), HoldAutoRefresh)
 	if err != nil {
 		return nil, err
 	}

--- a/overlord/snapstate/autorefresh_gating.go
+++ b/overlord/snapstate/autorefresh_gating.go
@@ -465,7 +465,9 @@ Loop:
 		}
 
 		for holdingSnap, hold := range holds {
-			// hold.Level is at least level
+			// the snap is not considered held for the given
+			// level (e.g HoldGeneral) but only for lower
+			// levels (e.g. HoldAutorefresh)
 			if hold.Level < level {
 				continue
 			}

--- a/overlord/snapstate/autorefresh_gating.go
+++ b/overlord/snapstate/autorefresh_gating.go
@@ -443,8 +443,8 @@ func pruneSnapsHold(st *state.State, snapName string) error {
 	return nil
 }
 
-// HeldSnaps returns all snaps that are held for at least at the given level
-// and shouldn't be refreshed.
+// HeldSnaps returns all snaps that are held at the given level or at more
+// restricting ones and shouldn't be refreshed.
 func HeldSnaps(st *state.State, level HoldLevel) (map[string]bool, error) {
 	gating, err := refreshGating(st)
 	if err != nil {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1637,7 +1637,7 @@ func updateManyFiltered(ctx context.Context, st *state.State, names []string, re
 
 	// don't refresh held snaps in a general refresh
 	if len(names) == 0 {
-		toUpdate, err = filterHeldSnaps(st, toUpdate)
+		toUpdate, err = filterHeldSnaps(st, toUpdate, flags)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -1656,8 +1656,12 @@ func updateManyFiltered(ctx context.Context, st *state.State, names []string, re
 }
 
 // filterHeldSnaps filters held snaps from being updated in a general refresh.
-func filterHeldSnaps(st *state.State, updates []minimalInstallInfo) ([]minimalInstallInfo, error) {
-	heldSnaps, err := HeldSnaps(st)
+func filterHeldSnaps(st *state.State, updates []minimalInstallInfo, flags *Flags) ([]minimalInstallInfo, error) {
+	holdLevel := HoldGeneral
+	if flags.IsAutoRefresh {
+		holdLevel = HoldAutoRefresh
+	}
+	heldSnaps, err := HeldSnaps(st, holdLevel)
 	if err != nil {
 		return nil, err
 	}

--- a/overlord/snapstate/snapstate_remove_test.go
+++ b/overlord/snapstate/snapstate_remove_test.go
@@ -1709,12 +1709,12 @@ func (s *snapmgrTestSuite) TestRemovePrunesRefreshGatingDataOnLastRevision(c *C)
 	}
 	st.Set("refresh-candidates", rc)
 
-	_, err := snapstate.HoldRefresh(st, "some-snap", 0, "foo-snap")
+	_, err := snapstate.HoldRefresh(st, snapstate.HoldAutoRefresh, "some-snap", 0, "foo-snap")
 	c.Assert(err, IsNil)
-	_, err = snapstate.HoldRefresh(st, "another-snap", 0, "some-snap")
+	_, err = snapstate.HoldRefresh(st, snapstate.HoldAutoRefresh, "another-snap", 0, "some-snap")
 	c.Assert(err, IsNil)
 
-	held, err := snapstate.HeldSnaps(st)
+	held, err := snapstate.HeldSnaps(st, snapstate.HoldAutoRefresh)
 	c.Assert(err, IsNil)
 	c.Check(held, DeepEquals, map[string]bool{
 		"foo-snap":  true,
@@ -1735,7 +1735,7 @@ func (s *snapmgrTestSuite) TestRemovePrunesRefreshGatingDataOnLastRevision(c *C)
 	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 
 	// held snaps were updated
-	held, err = snapstate.HeldSnaps(st)
+	held, err = snapstate.HeldSnaps(st, snapstate.HoldAutoRefresh)
 	c.Assert(err, IsNil)
 	c.Check(held, HasLen, 0)
 
@@ -1766,10 +1766,10 @@ func (s *snapmgrTestSuite) TestRemoveKeepsGatingDataIfNotLastRevision(c *C) {
 	rc := map[string]*snapstate.RefreshCandidate{"some-snap": {}}
 	st.Set("refresh-candidates", rc)
 
-	_, err := snapstate.HoldRefresh(st, "some-snap", 0, "some-snap")
+	_, err := snapstate.HoldRefresh(st, snapstate.HoldAutoRefresh, "some-snap", 0, "some-snap")
 	c.Assert(err, IsNil)
 
-	held, err := snapstate.HeldSnaps(st)
+	held, err := snapstate.HeldSnaps(st, snapstate.HoldAutoRefresh)
 	c.Assert(err, IsNil)
 	c.Check(held, DeepEquals, map[string]bool{"some-snap": true})
 
@@ -1786,7 +1786,7 @@ func (s *snapmgrTestSuite) TestRemoveKeepsGatingDataIfNotLastRevision(c *C) {
 	c.Assert(snapstate.Get(st, "some-snap", &snapst), IsNil)
 
 	// held snaps are intact
-	held, err = snapstate.HeldSnaps(st)
+	held, err = snapstate.HeldSnaps(st, snapstate.HoldAutoRefresh)
 	c.Assert(err, IsNil)
 	c.Check(held, DeepEquals, map[string]bool{"some-snap": true})
 

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -1191,10 +1191,10 @@ func (s *snapmgrTestSuite) TestUpdateResetsHoldState(c *C) {
 	tr.Commit()
 
 	// pretend that the snap was held during last auto-refresh
-	_, err := snapstate.HoldRefresh(s.state, "gating-snap", 0, "some-snap", "other-snap")
+	_, err := snapstate.HoldRefresh(s.state, snapstate.HoldAutoRefresh, "gating-snap", 0, "some-snap", "other-snap")
 	c.Assert(err, IsNil)
 	// validity check
-	held, err := snapstate.HeldSnaps(s.state)
+	held, err := snapstate.HeldSnaps(s.state, snapstate.HoldAutoRefresh)
 	c.Assert(err, IsNil)
 	c.Check(held, DeepEquals, map[string]bool{
 		"some-snap":  true,
@@ -1205,7 +1205,7 @@ func (s *snapmgrTestSuite) TestUpdateResetsHoldState(c *C) {
 	c.Assert(err, IsNil)
 
 	// and it is not held anymore (but other-snap still is)
-	held, err = snapstate.HeldSnaps(s.state)
+	held, err = snapstate.HeldSnaps(s.state, snapstate.HoldAutoRefresh)
 	c.Assert(err, IsNil)
 	c.Check(held, DeepEquals, map[string]bool{
 		"other-snap": true,
@@ -8858,7 +8858,7 @@ func (s *snapmgrTestSuite) TestGeneralRefreshSkipsGatedSnaps(c *C) {
 		})
 	}
 
-	err := snapstate.HoldRefreshesBySystem(s.state, "forever", []string{"some-snap"})
+	err := snapstate.HoldRefreshesBySystem(s.state, snapstate.HoldGeneral, "forever", []string{"some-snap"})
 	c.Assert(err, IsNil)
 
 	// advance time by a year (the last refreshed is determined by the snap file's


### PR DESCRIPTION
levels are ordered and higher levels imply lower ones

there are two levels for now:

* HoldAutoRefresh that affects auto-refresh operations
* HoldGeneral that affects general refresh operations (no specific snap
  mentioned) and implies HoldAutoRefresh