### PR TITLE
o/devicestate: support mounting ubuntu-save also on classic with modes

### DIFF
--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -99,6 +99,9 @@ type DeviceManager struct {
 	bootRevisionsUpdated bool
 
 	seedTimings *timings.Timings
+	// these are used as needed as cache during StartUp and cleared after
+	earlyDeviceCtx  snapstate.DeviceContext
+	earlyDeviceSeed seed.Seed
 
 	ensureSeedInConfigRan bool
 
@@ -288,8 +291,20 @@ func (m *DeviceManager) SystemMode(sysExpect SysExpectation) string {
 
 // StartUp implements StateStarterUp.Startup.
 func (m *DeviceManager) StartUp() error {
-	if m.shouldMountUbuntuSave() {
-		if err := m.setupUbuntuSave(); err != nil {
+	m.state.Lock()
+	defer m.state.Unlock()
+	defer m.earlyCleanup()
+
+	var dev snapstate.DeviceContext
+	dev, err := m.earlyDeviceContext()
+	if err != nil && !errors.Is(err, state.ErrNoState) {
+		return err
+	}
+	// if ErrNoState and dev is nil assume classic system here,
+	// any error will re-surface again in the main first boot code
+
+	if m.shouldMountUbuntuSave(dev) {
+		if err := m.setupUbuntuSave(dev); err != nil {
 			return fmt.Errorf("cannot set up ubuntu-save: %v", err)
 		}
 	}
@@ -301,16 +316,11 @@ func (m *DeviceManager) StartUp() error {
 
 	// TODO: setup proper timings measurements for this
 
-	m.state.Lock()
-	defer m.state.Unlock()
-	return EarlyConfig(m.state, m.preloadGadget)
+	return EarlyConfig(m.state, m.earlyPreloadGadget)
 }
 
-func (m *DeviceManager) shouldMountUbuntuSave() bool {
-	// TODO: this should check DeviceCtx.IsClassicBoot() instead
-	// but we should not create per-snap save directories on classic
-	// for now except for maybe gadget and snapd...
-	if release.OnClassic {
+func (m *DeviceManager) shouldMountUbuntuSave(dev snap.Device) bool {
+	if dev == nil || dev.IsClassicBoot() {
 		return false
 	}
 	// TODO:UC20+: ubuntu-save needs to be mounted for recover too
@@ -375,9 +385,6 @@ func (m *DeviceManager) ensureUbuntuSaveIsMounted() error {
 // 2. During install mode for the gadget/kernel/etc, the folders are not created.
 //    So this function can be invoked as a part of system-setup.
 func (m *DeviceManager) ensureUbuntuSaveSnapFolders() error {
-	m.state.Lock()
-	defer m.state.Unlock()
-
 	snaps, err := snapstate.All(m.state)
 	if err != nil {
 		return err
@@ -395,16 +402,21 @@ func (m *DeviceManager) ensureUbuntuSaveSnapFolders() error {
 // setupUbuntuSave sets up ubuntu-save partition. It makes sure
 // to mount ubuntu-save (if feasible), and ensures the correct snap
 // folders are present according to currently installed snaps.
-func (m *DeviceManager) setupUbuntuSave() error {
+func (m *DeviceManager) setupUbuntuSave(dev snap.Device) error {
 	if err := m.ensureUbuntuSaveIsMounted(); err != nil {
 		return err
 	}
 
 	// At this point ubuntu-save should be available under the
 	// /var/lib/snapd/save path, so we mark the partition as such.
+	m.saveAvailable = true
+
 	// The last step is to ensure needed folder structure is present
 	// for the per-snap folder storage.
-	m.saveAvailable = true
+	// We support this only on Core for now.
+	if dev == nil || dev.Classic() {
+		return nil
+	}
 	return m.ensureUbuntuSaveSnapFolders()
 }
 
@@ -788,7 +800,33 @@ func (m *DeviceManager) systemForPreseeding() string {
 	return m.preseedSystemLabel
 }
 
-func (m *DeviceManager) preloadGadget() (sysconfig.Device, *gadget.Info, error) {
+func (m *DeviceManager) earlyDeviceContext() (snapstate.DeviceContext, error) {
+	mod, err := findModel(m.state)
+	if err == nil {
+		return newModelDeviceContext(m, mod), nil
+	}
+	if !errors.Is(err, state.ErrNoState) {
+		return nil, err
+	}
+	dev, _, err := m.earlyLoadDeviceSeed()
+	return dev, err
+}
+
+func (m *DeviceManager) earlyCleanup() {
+	// clear thigs cached in StartUp
+	m.earlyDeviceCtx = nil
+	m.earlyDeviceSeed = nil
+}
+
+func (m *DeviceManager) earlyLoadDeviceSeed() (snapstate.DeviceContext, seed.Seed, error) {
+	// consider whether we were called already
+	if m.seedTimings != nil {
+		if m.earlyDeviceCtx != nil {
+			return m.earlyDeviceCtx, m.earlyDeviceSeed, nil
+		}
+		return nil, nil, state.ErrNoState
+	}
+
 	var sysLabel string
 	if m.preseed && !release.OnClassic {
 		sysLabel = m.systemForPreseeding()
@@ -804,7 +842,7 @@ func (m *DeviceManager) preloadGadget() (sysconfig.Device, *gadget.Info, error) 
 		}
 	}
 
-	// we time preloadGadget + first ensureSeeded together
+	// we time StartUp/earlyPreloadGadget + first ensureSeeded together
 	// under --ensure=seed
 	tm, err := m.seedStart()
 	if err != nil {
@@ -813,6 +851,28 @@ func (m *DeviceManager) preloadGadget() (sysconfig.Device, *gadget.Info, error) 
 	// cached for first ensureSeeded
 	m.seedTimings = tm
 
+	var deviceSeed seed.Seed
+	timings.Run(tm, "import-assertions[early]", "early import assertions from seed", func(nested timings.Measurer) {
+		deviceSeed, err = loadDeviceSeed(m.state, sysLabel)
+	})
+	if err != nil {
+		// this same error will be resurfaced in ensureSeed later
+		if err != seed.ErrNoAssertions {
+			logger.Debugf("early import assertions from seed failed: %v", err)
+		}
+		return nil, nil, state.ErrNoState
+	}
+
+	dev := newModelDeviceContext(m, deviceSeed.Model())
+
+	// cache
+	m.earlyDeviceCtx = dev
+	m.earlyDeviceSeed = deviceSeed
+
+	return dev, deviceSeed, nil
+}
+
+func (m *DeviceManager) earlyPreloadGadget() (sysconfig.Device, *gadget.Info, error) {
 	// Here we behave as if there was no gadget if we encounter
 	// errors, under the assumption that those will be resurfaced
 	// in ensureSeed. This preserves having a failing to seed
@@ -825,24 +885,17 @@ func (m *DeviceManager) preloadGadget() (sysconfig.Device, *gadget.Info, error) 
 	// just by option flags. For example automatic user creation
 	// also requires the model to be known/set. Otherwise ignoring
 	// errors here would be problematic.
-	var deviceSeed seed.Seed
-	timings.Run(tm, "import-assertions[early]", "early import assertions from seed", func(nested timings.Measurer) {
-		deviceSeed, err = loadDeviceSeed(m.state, sysLabel)
-	})
+	dev, deviceSeed, err := m.earlyLoadDeviceSeed()
 	if err != nil {
-		// this same error will be resurfaced in ensureSeed later
-		if err != seed.ErrNoAssertions {
-			logger.Debugf("early import assertions from seed failed: %v", err)
-		}
-		return nil, nil, state.ErrNoState
+		return nil, nil, err
 	}
-	model := deviceSeed.Model()
+	model := dev.Model()
 	if model.Gadget() == "" {
 		// no gadget
 		return nil, nil, state.ErrNoState
 	}
 	var gi *gadget.Info
-	timings.Run(tm, "preload-verified-gadget-metadata", "preload verified gadget metadata from seed", func(nested timings.Measurer) {
+	timings.Run(m.seedTimings, "preload-verified-gadget-metadata", "preload verified gadget metadata from seed", func(nested timings.Measurer) {
 		gi, err = func() (*gadget.Info, error) {
 			if err := deviceSeed.LoadEssentialMeta([]snap.Type{snap.TypeGadget}, nested); err != nil {
 				return nil, err
@@ -863,7 +916,6 @@ func (m *DeviceManager) preloadGadget() (sysconfig.Device, *gadget.Info, error) 
 		return nil, nil, state.ErrNoState
 	}
 
-	dev := newModelDeviceContext(m, model)
 	return dev, gi, nil
 }
 
@@ -892,7 +944,7 @@ func (m *DeviceManager) ensureSeeded() error {
 	if err != nil {
 		return err
 	}
-	// we time preloadGadget + first ensureSeeded together
+	// we time StartUp/earlyPreloadGadget + first ensureSeeded together
 	// succcessive ensureSeeded should be timed separately
 	m.seedTimings = nil
 

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -1484,6 +1484,8 @@ func (s *deviceMgrSuite) TestDeviceManagerStartupUC20UbuntuSaveRunModeHappy(c *C
 	modeEnv := &boot.Modeenv{Mode: "run"}
 	err := modeEnv.WriteTo("")
 	c.Assert(err, IsNil)
+	s.setUC20PCModelInState(c)
+
 	// create a new manager so that the modeenv we mocked in read
 	mgr, err := devicestate.Manager(s.state, s.hookMgr, s.o.TaskRunner(), s.newStore)
 	c.Assert(err, IsNil)
@@ -1521,6 +1523,8 @@ func (s *deviceMgrSuite) TestDeviceManagerStartupUC20UbuntuSaveSystemCtlFails(c 
 	modeEnv := &boot.Modeenv{Mode: "run"}
 	err := modeEnv.WriteTo("")
 	c.Assert(err, IsNil)
+	s.setUC20PCModelInState(c)
+
 	// create a new manager so that the modeenv we mocked in read
 	mgr, err := devicestate.Manager(s.state, s.hookMgr, s.o.TaskRunner(), s.newStore)
 	c.Assert(err, IsNil)
@@ -1553,6 +1557,8 @@ func (s *deviceMgrSuite) TestDeviceManagerStartupUC20UbuntuSaveMountUnitExists(c
 	modeEnv := &boot.Modeenv{Mode: "run"}
 	err := modeEnv.WriteTo("")
 	c.Assert(err, IsNil)
+	s.setUC20PCModelInState(c)
+
 	// create a new manager so that the modeenv we mocked in read
 	mgr, err := devicestate.Manager(s.state, s.hookMgr, s.o.TaskRunner(), s.newStore)
 	c.Assert(err, IsNil)
@@ -1583,6 +1589,8 @@ func (s *deviceMgrSuite) TestDeviceManagerStartupUC20UbuntuSaveAlreadyMounted(c 
 	modeEnv := &boot.Modeenv{Mode: "run"}
 	err := modeEnv.WriteTo("")
 	c.Assert(err, IsNil)
+	s.setUC20PCModelInState(c)
+
 	// create a new manager so that the modeenv we mocked in read
 	mgr, err := devicestate.Manager(s.state, s.hookMgr, s.o.TaskRunner(), s.newStore)
 	c.Assert(err, IsNil)
@@ -1611,6 +1619,8 @@ func (s *deviceMgrSuite) TestDeviceManagerStartupUC20NoUbuntuSave(c *C) {
 	modeEnv := &boot.Modeenv{Mode: "run"}
 	err := modeEnv.WriteTo("")
 	c.Assert(err, IsNil)
+	s.setUC20PCModelInState(c)
+
 	// create a new manager so that the modeenv we mocked in read
 	mgr, err := devicestate.Manager(s.state, s.hookMgr, s.o.TaskRunner(), s.newStore)
 	c.Assert(err, IsNil)
@@ -1631,6 +1641,8 @@ func (s *deviceMgrSuite) TestDeviceManagerStartupUC20UbuntuSaveErr(c *C) {
 	modeEnv := &boot.Modeenv{Mode: "run"}
 	err := modeEnv.WriteTo("")
 	c.Assert(err, IsNil)
+	s.setUC20PCModelInState(c)
+
 	// create a new manager so that the modeenv we mocked in read
 	mgr, err := devicestate.Manager(s.state, s.hookMgr, s.o.TaskRunner(), s.newStore)
 	c.Assert(err, IsNil)

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -137,8 +137,10 @@ func SetTimeOnce(m *DeviceManager, name string, t time.Time) error {
 	return m.setTimeOnce(name, t)
 }
 
-func PreloadGadget(m *DeviceManager) (sysconfig.Device, *gadget.Info, error) {
-	return m.preloadGadget()
+func EarlyPreloadGadget(m *DeviceManager) (sysconfig.Device, *gadget.Info, error) {
+	// let things fully run again
+	m.seedTimings = nil
+	return m.earlyPreloadGadget()
 }
 
 func MockLoadDeviceSeed(f func(st *state.State, sysLabel string) (seed.Seed, error)) func() {

--- a/overlord/devicestate/firstboot.go
+++ b/overlord/devicestate/firstboot.go
@@ -383,6 +383,11 @@ func importAssertionsFromSeed(st *state.State, sysLabel string, isCoreBoot bool)
 // it is meant to be used before and during seeding.
 // It is an error to call it with different sysLabel values once one
 // seed has been loaded and cached.
+//
+// TODO consider making this into a method of DeviceManager to simplify caching
+// and unifying it partly with seedStart and earlyLoadDeviceSeed Mocking will
+// be a bit more cumbersome as other things will need to move there as well,
+// but the baroque cache logic is not great either.
 var loadDeviceSeed = func(st *state.State, sysLabel string) (deviceSeed seed.Seed, err error) {
 	cached := st.Cached(loadedDeviceSeedKey{})
 	if cached != nil {

--- a/overlord/devicestate/firstboot.go
+++ b/overlord/devicestate/firstboot.go
@@ -385,9 +385,11 @@ func importAssertionsFromSeed(st *state.State, sysLabel string, isCoreBoot bool)
 // seed has been loaded and cached.
 //
 // TODO consider making this into a method of DeviceManager to simplify caching
-// and unifying it partly with seedStart and earlyLoadDeviceSeed Mocking will
+// and unifying it partly with seedStart and earlyLoadDeviceSeed. Mocking will
 // be a bit more cumbersome as other things will need to move there as well,
 // but the baroque cache logic is not great either.
+// TODO the name of this doesn't make it very clear that it is committing
+// the assertions to the device database
 var loadDeviceSeed = func(st *state.State, sysLabel string) (deviceSeed seed.Seed, err error) {
 	cached := st.Cached(loadedDeviceSeedKey{})
 	if cached != nil {

--- a/overlord/devicestate/firstboot20_test.go
+++ b/overlord/devicestate/firstboot20_test.go
@@ -298,6 +298,8 @@ func (s *firstBoot20Suite) testPopulateFromSeedCore20Happy(c *C, m *boot.Modeenv
 	// create overlord and pick up the modeenv
 	s.startOverlord(c)
 
+	c.Check(devicestate.SaveAvailable(s.overlord.DeviceManager()), Equals, m.Mode == "run")
+
 	opts := devicestate.PopulateStateFromSeedOptions{
 		Label: m.RecoverySystem,
 		Mode:  m.Mode,

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -284,7 +284,16 @@ func buildInstallObserver(model *asserts.Model, gadgetDir string, useEncryption 
 }
 
 func (m *DeviceManager) doSetupUbuntuSave(t *state.Task, _ *tomb.Tomb) error {
-	return m.setupUbuntuSave()
+	st := t.State()
+	st.Lock()
+	defer st.Unlock()
+
+	deviceCtx, err := DeviceCtx(st, t, nil)
+	if err != nil {
+		return fmt.Errorf("cannot get device context: %v", err)
+	}
+
+	return m.setupUbuntuSave(deviceCtx)
 }
 
 func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {


### PR DESCRIPTION
to do this consistently we need to know the device model even earlier during first boot, this is a bit complicated

the double caching logic for the system/device seed on first boot is not pretty and quite baroque, to avoid this we probably should turn more things into proper DeviceManager methods

we have been reluctant to do that to keep mocking of some first boot logic straightforward but the messiness elsewhere doesn't justify insisting on that

it's too big of a change for this PR though, also because of the test churn, but we should do this in a follow-up soon
