### PR TITLE
tests: add minimal-smoke test for UC22 and increase minimal RAM

### DIFF
--- a/tests/nested/manual/minimal-smoke/task.yaml
+++ b/tests/nested/manual/minimal-smoke/task.yaml
@@ -1,6 +1,6 @@
 summary: execute smoke tests in a nested Ubuntu Core VM that meets the minimal requirements
 
-systems: [ubuntu-16.04-64, ubuntu-18.04-64, ubuntu-20.04-64]
+systems: [ubuntu-16.04-64, ubuntu-18.04-64, ubuntu-20.04-64, ubuntu-22.04-64]
 
 environment:
     NESTED_ENABLE_SECURE_BOOT/secboot_disabled: false
@@ -20,12 +20,11 @@ execute: |
 
     if tests.nested is-nested uc20; then
         # TODO:UC20: this should written down in the official docs
-        if tests.nested is-enabled secboot; then
-            MINIMAL_MEM=512
-        else
-            MINIMAL_MEM=384
-        fi
+        MINIMAL_MEM=512
         NESTED_SPREAD_SYSTEM=ubuntu-core-20-64
+    elif tests.nested is-nested uc22; then
+        MINIMAL_MEM=512
+        NESTED_SPREAD_SYSTEM=ubuntu-core-22-64
     elif tests.nested is-nested uc18; then
         NESTED_SPREAD_SYSTEM=ubuntu-core-18-64
     elif tests.nested is-nested uc16; then


### PR DESCRIPTION
I noticed that our minimal smoke spread test is failing right now with:
```
BdsDxe: loading Boot0002 "UEFI Misc Device" from PciRoot(0x0)/Pci(0x5,0x0)
BdsDxe: starting Boot0002 "UEFI Misc Device" from PciRoot(0x0)/Pci(0x5,0x0)
EFI stub: ERROR: Failed to allocate usable memory for kernel.
efi_relocate_kernel() failed!
efi_main() failed!
```
which indicates that our kernels are too big for 384MB. This should probably be escalated to the kernel team too.

As a drive-by change it also adds a run for UC22.

