### PR TITLE
tests: ensure that fakeinstaller put the seed into the right place

### DIFF
--- a/tests/lib/fakeinstaller/main.go
+++ b/tests/lib/fakeinstaller/main.go
@@ -278,6 +278,11 @@ func createSeedOnTarget(bootDevice, seedLabel string) error {
 	dataMnt := runMntFor("ubuntu-data")
 	src := dirs.SnapSeedDir
 	dst := dirs.SnapSeedDirUnder(dataMnt)
+	// Remove any existing seed on the target fs and then put the
+	// selected seed in place on the target
+	if err := os.RemoveAll(dst); err != nil {
+		return err
+	}
 	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
 		return err
 	}


### PR DESCRIPTION
When the fakeinstaller installs a system it will copy the selected seed on the target system. However for some pre-generated images there is a seed directory already on the target. In this case the fakeinstaller needs to remove it and make sure that the seed selected for install gets put into that place.

This fixes installing when using the casper.squashfs 