### PR TITLE
snapcraft: update libgcc1->libgcc-s1

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -99,7 +99,7 @@ parts:
     stage-packages:
       - libc6
       - libc-bin
-      - libgcc1
+      - libgcc-s1
     stage:
       - lib/*
       - usr/lib/*


### PR DESCRIPTION
There is no libgcc1 package anymore on 20.04 and later. To get the needed `libgcc_s.so.1` library the package `libgcc-s1` is needed instead (the riscv snap is build with build-base: core20).

This should fix running `snap pack` on risc-v.

