### PR TITLE
o/devicestate,daemon: use the expiration date from the assertion in user-state and REST api (user-removal 4/n)

### DIFF
--- a/daemon/api_users_test.go
+++ b/daemon/api_users_test.go
@@ -953,7 +953,7 @@ func (s *userSuite) TestPostCreateUserExpirationHappy(c *check.C) {
 	// strip away subsecond values which are lost during json marshal/unmarshalling
 	expectedTime := time.Now().Add(time.Hour * 24).Round(time.Second)
 
-	var deviceStateCreateUserCalled bool
+	var deviceStateCreateUserCalls int
 	defer daemon.MockDeviceStateCreateUser(func(st *state.State, sudoer bool, email string, expiration time.Time) (*devicestate.CreatedUser, error) {
 		c.Check(email, check.Equals, expectedEmail)
 		c.Check(sudoer, check.Equals, false)
@@ -965,7 +965,7 @@ func (s *userSuite) TestPostCreateUserExpirationHappy(c *check.C) {
 				`ssh2 # snapd {"origin":"store","email":"popper@lse.ac.uk"}`,
 			},
 		}
-		deviceStateCreateUserCalled = true
+		deviceStateCreateUserCalls++
 		return expected, nil
 	})()
 
@@ -982,7 +982,7 @@ func (s *userSuite) TestPostCreateUserExpirationHappy(c *check.C) {
 			`ssh2 # snapd {"origin":"store","email":"popper@lse.ac.uk"}`,
 		},
 	})
-	c.Check(deviceStateCreateUserCalled, check.Equals, true)
+	c.Check(deviceStateCreateUserCalls, check.Equals, 1)
 }
 
 func (s *userSuite) TestPostCreateUserExpirationDateSetInPast(c *check.C) {

--- a/daemon/api_users_test.go
+++ b/daemon/api_users_test.go
@@ -957,7 +957,7 @@ func (s *userSuite) TestPostCreateUserExpirationHappy(c *check.C) {
 	defer daemon.MockDeviceStateCreateUser(func(st *state.State, sudoer bool, email string, expiration time.Time) (*devicestate.CreatedUser, error) {
 		c.Check(email, check.Equals, expectedEmail)
 		c.Check(sudoer, check.Equals, false)
-		c.Check(expiration, check.Equals, expectedTime)
+		c.Check(expiration.Equal(expectedTime), check.Equals, true)
 		expected := &devicestate.CreatedUser{
 			Username: expectedUsername,
 			SSHKeys: []string{

--- a/daemon/export_api_users_test.go
+++ b/daemon/export_api_users_test.go
@@ -20,6 +20,8 @@
 package daemon
 
 import (
+	"time"
+
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/state"
@@ -32,7 +34,7 @@ func MockHasUserAdmin(mockHasUserAdmin bool) (restore func()) {
 	return restore
 }
 
-func MockDeviceStateCreateUser(createUser func(st *state.State, sudoer bool, email string) (*devicestate.CreatedUser, error)) (restore func()) {
+func MockDeviceStateCreateUser(createUser func(st *state.State, sudoer bool, email string, expiration time.Time) (*devicestate.CreatedUser, error)) (restore func()) {
 	restore = testutil.Backup(&deviceStateCreateUser)
 	deviceStateCreateUser = createUser
 	return restore

--- a/overlord/devicestate/users.go
+++ b/overlord/devicestate/users.go
@@ -62,7 +62,7 @@ type CreatedUser struct {
 // CreateUser creates a Linux user based on the specified email.
 // The username and public ssh keys for the created account are
 // determined from Ubuntu store based on the email.
-func CreateUser(st *state.State, sudoer bool, email string) (*CreatedUser, error) {
+func CreateUser(st *state.State, sudoer bool, email string, expiration time.Time) (*CreatedUser, error) {
 	if email == "" {
 		return nil, &UserError{Err: fmt.Errorf("cannot create user: 'email' field is empty")}
 	}
@@ -74,7 +74,7 @@ func CreateUser(st *state.State, sudoer bool, email string) (*CreatedUser, error
 	}
 
 	opts.Sudoer = sudoer
-	return addUser(st, username, email, opts)
+	return addUser(st, username, email, expiration, opts)
 }
 
 // CreateKnownUsers creates known users. The user details are fetched
@@ -97,13 +97,13 @@ func CreateKnownUsers(st *state.State, sudoer bool, email string) ([]*CreatedUse
 		return createAllKnownSystemUsers(st, db, model, serial, sudoer)
 	}
 
-	username, opts, err := getUserDetailsFromAssertion(db, model, serial, email)
+	username, expiration, opts, err := getUserDetailsFromAssertion(db, model, serial, email)
 	if err != nil {
 		return nil, &UserError{Err: fmt.Errorf("cannot create user %q: %v", email, err)}
 	}
 
 	opts.Sudoer = sudoer
-	createdUser, err := addUser(st, username, email, opts)
+	createdUser, err := addUser(st, username, email, expiration, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +172,7 @@ func createKnownSystemUser(state *state.State, userAssertion *asserts.SystemUser
 	email := userAssertion.Email()
 	// we need to use getUserDetailsFromAssertion as this verifies
 	// the assertion against the current brand/model/time
-	username, addUserOpts, err := getUserDetailsFromAssertion(assertDb, model, serial, email)
+	username, expiration, addUserOpts, err := getUserDetailsFromAssertion(assertDb, model, serial, email)
 	if err != nil {
 		logger.Noticef("ignoring system-user assertion for %q: %s", email, err)
 		return nil, nil
@@ -184,7 +184,7 @@ func createKnownSystemUser(state *state.State, userAssertion *asserts.SystemUser
 	}
 
 	addUserOpts.Sudoer = sudoer
-	return addUser(state, username, email, addUserOpts)
+	return addUser(state, username, email, expiration, addUserOpts)
 }
 
 var createAllKnownSystemUsers = func(state *state.State, assertDb asserts.RODatabase, model *asserts.Model, serial *asserts.Serial, sudoer bool) ([]*CreatedUser, error) {
@@ -212,7 +212,7 @@ var createAllKnownSystemUsers = func(state *state.State, assertDb asserts.ROData
 	return createdUsers, nil
 }
 
-func getUserDetailsFromAssertion(assertDb asserts.RODatabase, modelAs *asserts.Model, serialAs *asserts.Serial, email string) (string, *osutil.AddUserOptions, error) {
+func getUserDetailsFromAssertion(assertDb asserts.RODatabase, modelAs *asserts.Model, serialAs *asserts.Serial, email string) (string, time.Time, *osutil.AddUserOptions, error) {
 	brandID := modelAs.BrandID()
 	series := modelAs.Series()
 	model := modelAs.Model()
@@ -222,7 +222,7 @@ func getUserDetailsFromAssertion(assertDb asserts.RODatabase, modelAs *asserts.M
 		"email":    email,
 	})
 	if err != nil {
-		return "", nil, err
+		return "", time.Time{}, nil, err
 	}
 	// the asserts package guarantees that this cast will work
 	su := a.(*asserts.SystemUser)
@@ -230,27 +230,27 @@ func getUserDetailsFromAssertion(assertDb asserts.RODatabase, modelAs *asserts.M
 	// check that the signer of the assertion is one of the accepted ones
 	sysUserAuths := modelAs.SystemUserAuthority()
 	if len(sysUserAuths) > 0 && !strutil.ListContains(sysUserAuths, su.AuthorityID()) {
-		return "", nil, fmt.Errorf("%q not in accepted authorities %q", su.AuthorityID(), sysUserAuths)
+		return "", time.Time{}, nil, fmt.Errorf("%q not in accepted authorities %q", su.AuthorityID(), sysUserAuths)
 	}
 	// cross check that the assertion is valid for the given series/model
 	if len(su.Series()) > 0 && !strutil.ListContains(su.Series(), series) {
-		return "", nil, fmt.Errorf("%q not in series %q", series, su.Series())
+		return "", time.Time{}, nil, fmt.Errorf("%q not in series %q", series, su.Series())
 	}
 	if len(su.Models()) > 0 && !strutil.ListContains(su.Models(), model) {
-		return "", nil, fmt.Errorf("%q not in models %q", model, su.Models())
+		return "", time.Time{}, nil, fmt.Errorf("%q not in models %q", model, su.Models())
 	}
 	if len(su.Serials()) > 0 {
 		if serialAs == nil {
-			return "", nil, fmt.Errorf("bound to serial assertion but device not yet registered")
+			return "", time.Time{}, nil, fmt.Errorf("bound to serial assertion but device not yet registered")
 		}
 		serial := serialAs.Serial()
 		if !strutil.ListContains(su.Serials(), serial) {
-			return "", nil, fmt.Errorf("%q not in serials %q", serial, su.Serials())
+			return "", time.Time{}, nil, fmt.Errorf("%q not in serials %q", serial, su.Serials())
 		}
 	}
 
 	if !su.ValidAt(time.Now()) {
-		return "", nil, fmt.Errorf("assertion not valid anymore")
+		return "", time.Time{}, nil, fmt.Errorf("assertion not valid anymore")
 	}
 
 	gecos := fmt.Sprintf("%s,%s", email, su.Name())
@@ -260,10 +260,10 @@ func getUserDetailsFromAssertion(assertDb asserts.RODatabase, modelAs *asserts.M
 		Password:            su.Password(),
 		ForcePasswordChange: su.ForcePasswordChange(),
 	}
-	return su.Username(), opts, nil
+	return su.Username(), su.Expiration(timeNow()), opts, nil
 }
 
-func setupLocalUser(state *state.State, username, email string) error {
+func setupLocalUser(state *state.State, username, email string, expiration time.Time) error {
 	user, err := userLookup(username)
 	if err != nil {
 		return fmt.Errorf("cannot lookup user %q: %s", username, err)
@@ -283,6 +283,7 @@ func setupLocalUser(state *state.State, username, email string) error {
 		Email:      email,
 		Macaroon:   "",
 		Discharges: nil,
+		Expiration: expiration,
 	})
 	if err != nil {
 		return fmt.Errorf("cannot persist authentication details: %v", err)
@@ -310,12 +311,12 @@ func setupLocalUser(state *state.State, username, email string) error {
 	return nil
 }
 
-func addUser(state *state.State, username string, email string, opts *osutil.AddUserOptions) (*CreatedUser, error) {
+func addUser(state *state.State, username string, email string, expiration time.Time, opts *osutil.AddUserOptions) (*CreatedUser, error) {
 	opts.ExtraUsers = !release.OnClassic
 	if err := osutilAddUser(username, opts); err != nil {
 		return nil, fmt.Errorf("cannot add user %q: %s", username, err)
 	}
-	if err := setupLocalUser(state, username, email); err != nil {
+	if err := setupLocalUser(state, username, email, expiration); err != nil {
 		return nil, err
 	}
 

--- a/overlord/devicestate/users.go
+++ b/overlord/devicestate/users.go
@@ -260,7 +260,7 @@ func getUserDetailsFromAssertion(assertDb asserts.RODatabase, modelAs *asserts.M
 		Password:            su.Password(),
 		ForcePasswordChange: su.ForcePasswordChange(),
 	}
-	return su.Username(), su.Expiration(timeNow()), opts, nil
+	return su.Username(), su.UserExpiration(), opts, nil
 }
 
 func setupLocalUser(state *state.State, username, email string, expiration time.Time) error {

--- a/overlord/devicestate/users_test.go
+++ b/overlord/devicestate/users_test.go
@@ -178,7 +178,7 @@ func (s *usersSuite) TestCreateUser(c *check.C) {
 	c.Check(user.Email, check.Equals, s.userInfoExpectedEmail)
 	c.Check(user.Macaroon, check.NotNil)
 	c.Check(addUserCalled, check.Equals, true)
-	c.Check(user.Expiration, check.Equals, expectedExpiration)
+	c.Check(user.Expiration.Equal(expectedExpiration), check.Equals, true)
 	// auth saved to user home dir
 	outfile := filepath.Join(s.mockUserHome, ".snap", "auth.json")
 	c.Check(osutil.FileExists(outfile), check.Equals, true)

--- a/overlord/devicestate/users_test.go
+++ b/overlord/devicestate/users_test.go
@@ -486,7 +486,7 @@ func (s *usersSuite) TestGetUserDetailsFromAssertionHappy(c *check.C) {
 		Gecos:    "foo@bar.com,Boring Guy",
 		Password: "$6$salt$hash",
 	})
-	c.Check(expiration, check.Equals, time.Time{})
+	c.Check(expiration.IsZero(), check.Equals, true)
 }
 
 func (s *usersSuite) TestCreateUserFromAssertion(c *check.C) {
@@ -500,7 +500,7 @@ func (s *usersSuite) TestCreateUserExpireFromAssertion(c *check.C) {
 	c.Assert(len(users), check.Equals, 1)
 	until, err := time.Parse(time.RFC3339, expireUser["until"].(string))
 	c.Assert(err, check.IsNil)
-	c.Check(users[0].Expiration, check.Equals, until)
+	c.Check(users[0].Expiration.Equal(until), check.Equals, true)
 }
 
 func (s *usersSuite) TestCreateUserFromAssertionWithForcePasswordChange(c *check.C) {
@@ -694,7 +694,7 @@ func (s *usersSuite) TestCreateAllKnownUsersWithExpiration(c *check.C) {
 	// Verify expiration
 	until, err := time.Parse(time.RFC3339, expireUser["until"].(string))
 	c.Assert(err, check.IsNil)
-	c.Check(users[0].Expiration, check.Equals, until)
+	c.Check(users[0].Expiration.Equal(until), check.Equals, true)
 }
 
 func (s *usersSuite) TestCreateUserFromAssertionAllKnownNoModelError(c *check.C) {

--- a/overlord/devicestate/users_test.go
+++ b/overlord/devicestate/users_test.go
@@ -452,31 +452,18 @@ var unknownUser = map[string]interface{}{
 }
 
 var expireUser = map[string]interface{}{
-	"authority-id":   "my-brand",
-	"brand-id":       "my-brand",
-	"email":          "foo@bar.com",
-	"series":         []interface{}{"16", "18"},
-	"models":         []interface{}{"my-model", "other-model"},
-	"name":           "Boring Guy",
-	"username":       "guy",
-	"password":       "$6$salt$hash",
-	"user-valid-for": "until-expiration",
-	"since":          time.Now().Format(time.RFC3339),
-	"until":          time.Now().Add(24 * 30 * time.Hour).Format(time.RFC3339),
-}
-
-var durationUser = map[string]interface{}{
-	"authority-id":   "my-brand",
-	"brand-id":       "my-brand",
-	"email":          "foo@bar.com",
-	"series":         []interface{}{"16", "18"},
-	"models":         []interface{}{"my-model", "other-model"},
-	"name":           "Boring Guy",
-	"username":       "guy",
-	"password":       "$6$salt$hash",
-	"user-valid-for": "24h",
-	"since":          time.Now().Format(time.RFC3339),
-	"until":          time.Now().Add(24 * 30 * time.Hour).Format(time.RFC3339),
+	"format":        "2",
+	"authority-id":  "my-brand",
+	"brand-id":      "my-brand",
+	"email":         "foo@bar.com",
+	"series":        []interface{}{"16", "18"},
+	"models":        []interface{}{"my-model", "other-model"},
+	"name":          "Boring Guy",
+	"username":      "guy",
+	"password":      "$6$salt$hash",
+	"user-presence": "until-expiration",
+	"since":         time.Now().Format(time.RFC3339),
+	"until":         time.Now().Add(24 * 30 * time.Hour).Format(time.RFC3339),
 }
 
 func (s *usersSuite) TestGetUserDetailsFromAssertionHappy(c *check.C) {
@@ -512,25 +499,6 @@ func (s *usersSuite) TestCreateUserExpireFromAssertion(c *check.C) {
 	until, err := time.Parse(time.RFC3339, expireUser["until"].(string))
 	c.Assert(err, check.IsNil)
 	c.Check(users[0].Expiration, check.Equals, until)
-}
-
-func (s *usersSuite) TestCreateUserDurationFromAssertion(c *check.C) {
-	// In order to do an exact calculation of the expiration date
-	// for duration values, we must mock the current time call. Strip
-	// the monotonic clock away as this will interfere with the test.
-	creationTime := time.Now().Round(0)
-
-	// No reason to validate this was called, if it isn't the expiration
-	// time will not be correct
-	restore := devicestate.MockTimeNow(func() time.Time {
-		return creationTime
-	})
-	defer restore()
-
-	s.makeSystemUsers(c, []map[string]interface{}{durationUser})
-	users := s.createUserFromAssertion(c, false)
-	c.Assert(len(users), check.Equals, 1)
-	c.Check(users[0].Expiration, check.Equals, creationTime.Add(time.Hour*24))
 }
 
 func (s *usersSuite) TestCreateUserFromAssertionWithForcePasswordChange(c *check.C) {


### PR DESCRIPTION
The final functionality for automatic user removal. This binds together the expiration provided in the assertion/REST with the expiration date in user state. The final PR will be a spread test that verifies this is correctly working E2E (most likely a manual test as it will be slow due to timings).

I split up the REST api functionality and the devicestate changes in each their commit so it's easier to review

