### PR TITLE
tests: create partition table in fakeinstaller

### DIFF
--- a/tests/lib/fakeinstaller/main.go
+++ b/tests/lib/fakeinstaller/main.go
@@ -91,8 +91,8 @@ func createPartitions(bootDevice string, volumes map[string]*gadget.Volume) ([]g
 	}
 
 	vol := firstVol(volumes)
-	// XXX: snapd does not create partition tables so we do it here
-	//      needs to happen early or gadget.OnDiskVolumeFromDevice() fails
+	// snapd does not create partition tables so we have to do it here
+	// or gadget.OnDiskVolumeFromDevice() will fail
 	if err := maybeCreatePartitionTable(bootDevice, vol.Schema); err != nil {
 		return nil, err
 	}

--- a/tests/lib/fakeinstaller/main.go
+++ b/tests/lib/fakeinstaller/main.go
@@ -20,6 +20,7 @@
 package main
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
@@ -45,10 +46,55 @@ func firstVol(volumes map[string]*gadget.Volume) *gadget.Volume {
 	return nil
 }
 
+func maybeCreatePartitionTable(bootDevice, schema string) error {
+	switch schema {
+	case "dos":
+		return fmt.Errorf("cannot use partition schema %v yet", schema)
+	case "gpt":
+		// ok
+	default:
+		return fmt.Errorf("cannot use unknown partition schema %v", schema)
+	}
+
+	// check if there is a GPT partition table already
+	output, err := exec.Command("blkid", "--probe", "--match-types", "gpt", bootDevice).CombinedOutput()
+	exitCode, err := osutil.ExitCode(err)
+	if err != nil {
+		return err
+	}
+	switch exitCode {
+	case 0:
+		// partition table already exists, nothing to do
+	case 2:
+		// no match found, create partition table
+		cmd := exec.Command("sfdisk", bootDevice)
+		cmd.Stdin = bytes.NewBufferString("label: gpt\n")
+		if output, err := cmd.CombinedOutput(); err != nil {
+			return osutil.OutputErr(output, err)
+		}
+		// ensure udev is aware of the new attributes
+		if output, err := exec.Command("udevadm", "settle").CombinedOutput(); err != nil {
+			return osutil.OutputErr(output, err)
+		}
+	default:
+		// unknown error
+		return fmt.Errorf("unexpected exit code from blkid: %v", osutil.OutputErr(output, err))
+	}
+
+	return nil
+}
+
 func createPartitions(bootDevice string, volumes map[string]*gadget.Volume) ([]gadget.OnDiskStructure, error) {
 	// TODO: support multiple volumes, see gadget/install/install.go
 	if len(volumes) != 1 {
 		return nil, fmt.Errorf("got unexpected number of volumes %v", len(volumes))
+	}
+
+	vol := firstVol(volumes)
+	// XXX: snapd does not create partition tables so we do it here
+	//      needs to happen early or gadget.OnDiskVolumeFromDevice() fails
+	if err := maybeCreatePartitionTable(bootDevice, vol.Schema); err != nil {
+		return nil, err
 	}
 
 	diskLayout, err := gadget.OnDiskVolumeFromDevice(bootDevice)
@@ -63,7 +109,6 @@ func createPartitions(bootDevice string, volumes map[string]*gadget.Volume) ([]g
 		IgnoreContent: true,
 	}
 
-	vol := firstVol(volumes)
 	lvol, err := gadget.LayoutVolume(vol, gadget.DefaultConstraints, layoutOpts)
 	if err != nil {
 		return nil, fmt.Errorf("cannot layout volume: %v", err)

--- a/tests/nested/manual/fakeinstaller/task.yaml
+++ b/tests/nested/manual/fakeinstaller/task.yaml
@@ -105,8 +105,6 @@ execute: |
   # create fake disk for the installer to work on
   truncate --size=4G fake-disk.img
   loop_device=$(losetup --show -f ./fake-disk.img)
-  # TODO: fakeinstaller should work on a empty disk too
-  echo "label: gpt" | sfdisk "$loop_device"
   # and "install" the current seed to the fake disk
   ./fakeinstaller "$LABEL" "$loop_device" "$TESTSLIB"/fakeinstaller/mk-classic-rootfs.sh
   # validate that the fake installer created the expected partitions


### PR DESCRIPTION
Snapd will currently not deal with disks that have no partition table and error. To workaround this limitation the installer will now create the partition table.
