### PR TITLE
autopkgtests: fix running autopkgtest on kinetic

### DIFF
--- a/packaging/ubuntu-16.04/tests/integrationtests
+++ b/packaging/ubuntu-16.04/tests/integrationtests
@@ -26,7 +26,12 @@ cat /proc/meminfo
 # ensure we can do a connect to localhost
 echo ubuntu:ubuntu|chpasswd
 sed -i 's/\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /etc/ssh/sshd_config
-systemctl reload ssh.service
+if [ -d /etc/ssh/sshd_config.d ]; then
+    printf 'PermitRootLogin=yes\nPasswordAuthentication=yes' > /etc/ssh/sshd_config.d/00-spread-settings.conf
+fi
+if systemctl is-active ssh.service; then
+    systemctl reload ssh.service
+fi
 
 # Map snapd deb package pockets to core snap channels. This is intended to cope
 # with the autopkgtest execution when testing packages from the different pockets

--- a/packaging/ubuntu-16.04/tests/integrationtests
+++ b/packaging/ubuntu-16.04/tests/integrationtests
@@ -25,9 +25,10 @@ cat /proc/meminfo
 
 # ensure we can do a connect to localhost
 echo ubuntu:ubuntu|chpasswd
-sed -i 's/\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /etc/ssh/sshd_config
 if [ -d /etc/ssh/sshd_config.d ]; then
     printf 'PermitRootLogin=yes\nPasswordAuthentication=yes' > /etc/ssh/sshd_config.d/00-spread-settings.conf
+else
+    sed -i 's/\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /etc/ssh/sshd_config
 fi
 if systemctl is-active ssh.service; then
     systemctl reload ssh.service


### PR DESCRIPTION
The autopkgtests fail on kinetic right now because sshd switched from /etc/ssh/sshd_config to /etc/ssh/sshd_config.d which means spread setup on these systems breaks.

