### PR TITLE
interfaces: steam-support allow pivot /run/media and /etc/nvidia mount

### DIFF
--- a/interfaces/builtin/steam_support.go
+++ b/interfaces/builtin/steam_support.go
@@ -137,6 +137,8 @@ mount options=(rw, rbind) /oldroot/home/**/usr/etc/ld.so.cache -> /newroot/run/p
 mount options=(rw, rbind) /oldroot/home/**/usr/etc/ld.so.conf -> /newroot/run/pressure-vessel/ldso/runtime-ld.so.conf,
 mount options=(rw, rbind) /oldroot/mnt/{,**} -> /newroot/mnt/{,**},
 mount options=(rw, rbind) /oldroot/media/{,**} -> /newroot/media/{,**},
+mount options=(rw, rbind) /oldroot/run/media/ -> /newroot/run/media/,
+mount options=(rw, rbind) /oldroot/etc/nvidia/ -> /newroot/etc/nvidia/,
 
 mount options=(rw, rbind) /oldroot/etc/machine-id -> /newroot/etc/machine-id,
 mount options=(rw, rbind) /oldroot/etc/group -> /newroot/etc/group,


### PR DESCRIPTION
Added mount for root pivot `/run/media` directory for Steam. Fixes https://github.com/canonical/steam-snap/issues/59.

Added mount for root pivot `/etc/nvidia` directory for Steam. Fixes https://github.com/canonical/steam-snap/issues/6.