### PR TITLE
DT-728: fix "being refreshed" notifications

### DIFF
--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -1839,6 +1839,20 @@ func (s *RunSuite) TestWaitInhibitUnlockWaitsForSpecificHint(c *check.C) {
 	c.Check(called, check.Equals, 5)
 }
 
+func (s *RunSuite) TestWaitInhibitUnlockWaitsForSpecificTimeout(c *check.C) {
+	var called int
+	restore := snaprun.MockIsLocked(func(snapName string) (runinhibit.Hint, error) {
+		called++
+		return runinhibit.HintInhibitedGateRefresh, nil
+	})
+	defer restore()
+
+	notInhibited, err := snaprun.WaitInhibitUnlock("some-snap", runinhibit.HintInhibitedForRefresh, 2*time.Second)
+	c.Assert(err, check.NotNil)
+	c.Assert(err.Error(), check.Equals, "Timeout")
+	c.Check(notInhibited, check.Equals, false)
+}
+
 func (s *RunSuite) TestWaitWhileInhibitedNoop(c *check.C) {
 	var called int
 	restore := snaprun.MockIsLocked(func(snapName string) (runinhibit.Hint, error) {

--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -235,7 +235,7 @@ func (s *RunSuite) TestSnapRunAppRunsChecksInhibitionLock(c *check.C) {
 	c.Assert(ioutil.WriteFile(features.RefreshAppAwareness.ControlFile(), []byte(nil), 0644), check.IsNil)
 
 	var called int
-	restore := snaprun.MockWaitInhibitUnlock(func(snapName string, waitFor runinhibit.Hint) (bool, error) {
+	restore := snaprun.MockWaitInhibitUnlock(func(snapName string, waitFor runinhibit.Hint, timeout time.Duration) (bool, error) {
 		called++
 		return false, nil
 	})
@@ -274,7 +274,7 @@ func (s *RunSuite) TestSnapRunHookNoRuninhibit(c *check.C) {
 	defer restorer()
 
 	var called bool
-	restore := snaprun.MockWaitInhibitUnlock(func(snapName string, waitFor runinhibit.Hint) (bool, error) {
+	restore := snaprun.MockWaitInhibitUnlock(func(snapName string, waitFor runinhibit.Hint, timeout time.Duration) (bool, error) {
 		called = true
 		c.Errorf("WaitInhibitUnlock should not have been called")
 		return false, nil
@@ -318,7 +318,7 @@ func (s *RunSuite) TestSnapRunAppRuninhibitSkipsServices(c *check.C) {
 	c.Assert(ioutil.WriteFile(features.RefreshAppAwareness.ControlFile(), []byte(nil), 0644), check.IsNil)
 
 	var called bool
-	restore := snaprun.MockWaitInhibitUnlock(func(snapName string, waitFor runinhibit.Hint) (bool, error) {
+	restore := snaprun.MockWaitInhibitUnlock(func(snapName string, waitFor runinhibit.Hint, timeout time.Duration) (bool, error) {
 		called = true
 		c.Errorf("WaitInhibitUnlock should not have been called")
 		return false, nil

--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -243,7 +243,7 @@ func (s *RunSuite) TestSnapRunAppRunsChecksInhibitionLock(c *check.C) {
 
 	rest, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--", "snapname.app", "--arg1"})
 	c.Assert(err, check.IsNil)
-	c.Check(called, check.Equals, 1)
+	c.Check(called, check.Equals, 2)
 	c.Assert(rest, check.DeepEquals, []string{"snapname.app", "--arg1"})
 	c.Check(execArg0, check.Equals, filepath.Join(dirs.DistroLibExecDir, "snap-confine"))
 	c.Check(execArgs, check.DeepEquals, []string{
@@ -1873,8 +1873,9 @@ func (s *RunSuite) TestWaitWhileInhibitedNoop(c *check.C) {
 
 	c.Check(meter.Values, check.HasLen, 0)
 	c.Check(meter.Written, check.HasLen, 0)
-	c.Check(meter.Finishes, check.Equals, 1)
-	c.Check(meter.Labels, check.Equals, "please wait...")
+	c.Check(meter.Finishes, check.Equals, 0)
+	c.Check(len(meter.Labels), check.Equals, 1)
+	c.Check(meter.Labels[0], check.Equals, "")
 }
 
 func (s *RunSuite) TestWaitWhileInhibitedTextFlow(c *check.C) {

--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -1874,8 +1874,7 @@ func (s *RunSuite) TestWaitWhileInhibitedNoop(c *check.C) {
 	c.Check(meter.Values, check.HasLen, 0)
 	c.Check(meter.Written, check.HasLen, 0)
 	c.Check(meter.Finishes, check.Equals, 0)
-	c.Check(len(meter.Labels), check.Equals, 1)
-	c.Check(meter.Labels[0], check.Equals, "")
+	c.Check(meter.Labels, check.HasLen, 0)
 }
 
 func (s *RunSuite) TestWaitWhileInhibitedTextFlow(c *check.C) {

--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -243,7 +243,7 @@ func (s *RunSuite) TestSnapRunAppRunsChecksInhibitionLock(c *check.C) {
 
 	rest, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--", "snapname.app", "--arg1"})
 	c.Assert(err, check.IsNil)
-	c.Check(called, check.Equals, 2)
+	c.Check(called, check.Equals, 1)
 	c.Assert(rest, check.DeepEquals, []string{"snapname.app", "--arg1"})
 	c.Check(execArg0, check.Equals, filepath.Join(dirs.DistroLibExecDir, "snap-confine"))
 	c.Check(execArgs, check.DeepEquals, []string{
@@ -1859,9 +1859,8 @@ func (s *RunSuite) TestWaitWhileInhibitedNoop(c *check.C) {
 
 	c.Check(meter.Values, check.HasLen, 0)
 	c.Check(meter.Written, check.HasLen, 0)
-	c.Check(meter.Finishes, check.Equals, 0)
-	c.Check(meter.Labels, check.HasLen, 0)
-	c.Check(meter.Labels, check.HasLen, 0)
+	c.Check(meter.Finishes, check.Equals, 1)
+	c.Check(meter.Labels, check.Equals, "please wait...")
 }
 
 func (s *RunSuite) TestWaitWhileInhibitedTextFlow(c *check.C) {

--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -1816,7 +1816,7 @@ func (s *RunSuite) TestWaitInhibitUnlock(c *check.C) {
 	})
 	defer restore()
 
-	notInhibited, err := snaprun.WaitInhibitUnlock("some-snap", runinhibit.HintNotInhibited)
+	notInhibited, err := snaprun.WaitInhibitUnlock("some-snap", runinhibit.HintNotInhibited, 0)
 	c.Assert(err, check.IsNil)
 	c.Check(notInhibited, check.Equals, true)
 	c.Check(called, check.Equals, 5)
@@ -1833,7 +1833,7 @@ func (s *RunSuite) TestWaitInhibitUnlockWaitsForSpecificHint(c *check.C) {
 	})
 	defer restore()
 
-	notInhibited, err := snaprun.WaitInhibitUnlock("some-snap", runinhibit.HintInhibitedForRefresh)
+	notInhibited, err := snaprun.WaitInhibitUnlock("some-snap", runinhibit.HintInhibitedForRefresh, 0)
 	c.Assert(err, check.IsNil)
 	c.Check(notInhibited, check.Equals, false)
 	c.Check(called, check.Equals, 5)

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -408,7 +408,7 @@ func MockOsChmod(f func(string, os.FileMode) error) (restore func()) {
 	}
 }
 
-func MockWaitInhibitUnlock(f func(snapName string, waitFor runinhibit.Hint) (bool, error)) (restore func()) {
+func MockWaitInhibitUnlock(f func(snapName string, waitFor runinhibit.Hint, timeout time.Duration) (bool, error)) (restore func()) {
 	old := waitInhibitUnlock
 	waitInhibitUnlock = f
 	return func() {

--- a/cmd/snap/inhibit.go
+++ b/cmd/snap/inhibit.go
@@ -40,19 +40,6 @@ func waitWhileInhibited(snapName string) error {
 		return nil
 	}
 
-	// wait for HintInhibitedForRefresh set by gate-auto-refresh hook handler
-	// when it has finished; the hook starts with HintInhibitedGateRefresh lock
-	// and then either unlocks it or changes to HintInhibitedForRefresh (see
-	// gateAutoRefreshHookHandler in hooks.go).
-	// waitInhibitUnlock will return also on HintNotInhibited.
-	notInhibited, err := waitInhibitUnlock(snapName, runinhibit.HintInhibitedForRefresh)
-	if err != nil {
-		return err
-	}
-	if notInhibited {
-		return nil
-	}
-
 	if isGraphicalSession() {
 		return graphicalSessionFlow(snapName, hint)
 	}

--- a/cmd/snap/inhibit.go
+++ b/cmd/snap/inhibit.go
@@ -31,6 +31,8 @@ import (
 	"github.com/snapcore/snapd/usersession/client"
 )
 
+const timeoutValue time.Duration = 2 * time.Second
+
 func waitWhileInhibited(snapName string) error {
 	hint, err := runinhibit.IsLocked(snapName)
 	if err != nil {
@@ -45,7 +47,7 @@ func waitWhileInhibited(snapName string) error {
 	// and then either unlocks it or changes to HintInhibitedForRefresh (see
 	// gateAutoRefreshHookHandler in hooks.go).
 	// waitInhibitUnlock will return also on HintNotInhibited.
-	notInhibited, err := waitInhibitUnlock(snapName, runinhibit.HintInhibitedForRefresh, 2*time.Second)
+	notInhibited, err := waitInhibitUnlock(snapName, runinhibit.HintInhibitedForRefresh, timeoutValue)
 	if (err != nil) && (err.Error() != "Timeout") {
 		return err
 	}


### PR DESCRIPTION
The current code in "snap run" checks if the snap is locked due to being refreshed, and waits until it is unlocked before showing a notification saying that the snap is locked.

This, obviously, is wrong: it should check if the snap is locked, and if it is, first show the notification and after that, wait until it is unlocked.

The bug relies in a single piece of code located before the call that checks whether snap is running in a graphics session or a text one. This MR just removes that piece of code and everything works as expected.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
