### PR TITLE
tests: make muinstaller *not* start automatically

### DIFF
--- a/gadget/install/params.go
+++ b/gadget/install/params.go
@@ -50,8 +50,9 @@ type partEncryptionData struct {
 	device          string
 	encryptedDevice string
 
-	volName             string
-	encryptionKey       keys.EncryptionKey
+	volName       string
+	encryptionKey keys.EncryptionKey
+	// TODO: this is currently not used
 	encryptedSectorSize quantity.Size
 	encryptionParams    gadget.StructureEncryptionParameters
 }

--- a/spread.yaml
+++ b/spread.yaml
@@ -497,7 +497,8 @@ debug-each: |
     if tests.nested is-nested; then
         echo '# nested VM status'
         tests.nested vm status
-        tests.nested get serial-log
+        # filter out ^[ to ensure that the debug output gets not messed up
+        tests.nested get serial-log | sed 's/\x1b//g'
         # add another echo in case the serial log is missing a newline
         echo
 

--- a/tests/lib/fakeinstaller/go.mod
+++ b/tests/lib/fakeinstaller/go.mod
@@ -1,0 +1,6 @@
+module github.com/snapcore/snapd/tests/lib/muinstaller
+
+go 1.18
+
+require github.com/snapcore/snapd v0.0.0-20220929103851-d41483655caf
+

--- a/tests/lib/fakeinstaller/go.mod
+++ b/tests/lib/fakeinstaller/go.mod
@@ -2,5 +2,5 @@ module github.com/snapcore/snapd/tests/lib/muinstaller
 
 go 1.18
 
-require github.com/snapcore/snapd v0.0.0-20220929103851-d41483655caf
+require github.com/snapcore/snapd v0.0.0-20221014094459-09df0fed87a6
 

--- a/tests/lib/fakeinstaller/main.go
+++ b/tests/lib/fakeinstaller/main.go
@@ -462,17 +462,24 @@ func run(seedLabel, rootfsCreator, bootDevice string) error {
 }
 
 func main() {
-	if len(os.Args) != 4 {
-		// XXX: allow installing real UC without a classic-rootfs later
-		fmt.Fprintf(os.Stderr, "need seed-label, target-device and classic-rootfs as argument\n")
-		os.Exit(1)
-	}
 	os.Setenv("SNAPD_DEBUG", "1")
 	logger.SimpleSetup()
 
-	seedLabel := os.Args[1]
-	rootfsCreator := os.Args[2]
-	bootDevice := os.Args[3]
+	// poor mans arg handling
+	seedLabel := "classic"
+	rootfsCreator := os.ExpandEnv("$SNAP/bin/mk-classic-rootfs.sh")
+	bootDevice := "auto"
+	switch len(os.Args) {
+	case 4:
+		bootDevice = os.Args[3]
+		fallthrough
+	case 3:
+		rootfsCreator = os.Args[2]
+		fallthrough
+	case 2:
+		seedLabel = os.Args[1]
+	}
+
 	if bootDevice == "auto" {
 		bootDevice = waitForDevice()
 	}

--- a/tests/lib/fakeinstaller/main.go
+++ b/tests/lib/fakeinstaller/main.go
@@ -22,9 +22,12 @@ package main
 import (
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/snapcore/snapd/client"
@@ -35,8 +38,70 @@ import (
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/disks"
 	"github.com/snapcore/snapd/osutil/mkfs"
-	"github.com/snapcore/snapd/overlord/state"
 )
+
+func waitForDevice() string {
+	for {
+		devices, err := emptyFixedBlockDevices()
+		if err != nil {
+			logger.Noticef("cannot list devices: %v", err)
+		}
+		switch len(devices) {
+		case 0:
+			logger.Noticef("cannot use automatic mode, no empty disk found")
+		case 1:
+			// found exactly one target
+			return devices[0]
+		default:
+			logger.Noticef("cannot use automatic mode, multiple empty disks found: %v", devices)
+		}
+		time.Sleep(5 * time.Second)
+	}
+}
+
+// emptyFixedBlockDevices finds any non-removalble physical disk that has
+// no partitions. It will exclude loop devices.
+func emptyFixedBlockDevices() (devices []string, err error) {
+	// eg. /sys/block/sda/removable
+	removable, err := filepath.Glob(filepath.Join(dirs.GlobalRootDir, "/sys/block/*/removable"))
+	if err != nil {
+		return nil, err
+	}
+	for _, removableAttr := range removable {
+		val, err := ioutil.ReadFile(removableAttr)
+		if err != nil || string(val) != "0\n" {
+			// removable, ignore
+			continue
+		}
+		// let's see if it has partitions
+		dev := filepath.Base(filepath.Dir(removableAttr))
+		if strings.HasPrefix(dev, "loop") {
+			// is loop device, ignore
+			continue
+		}
+		pattern := fmt.Sprintf(filepath.Join(dirs.GlobalRootDir, "/sys/block/%s/%s*/partition"), dev, dev)
+		// eg. /sys/block/sda/sda1/partition
+		partitionAttrs, _ := filepath.Glob(pattern)
+		if len(partitionAttrs) != 0 {
+			// has partitions, ignore
+			continue
+		}
+		devNode := fmt.Sprintf("/dev/%s", dev)
+		output, err := exec.Command("lsblk", "--output", "fstype", "--json", devNode).CombinedOutput()
+		if err != nil {
+			return nil, osutil.OutputErr(output, err)
+		}
+		// TODO: parser proper json
+		if !strings.Contains(string(output), "null") {
+			// found a filesystem, ignore
+			continue
+		}
+
+		devices = append(devices, devNode)
+	}
+	sort.Strings(devices)
+	return devices, nil
+}
 
 func firstVol(volumes map[string]*gadget.Volume) *gadget.Volume {
 	for _, vol := range volumes {
@@ -125,7 +190,7 @@ func postSystemsInstallSetupStorageEncryption(cli *client.Client,
 	}
 
 	var encryptedDevices = make(map[string]string)
-	if err := chg.Get("encrypted-devices", &encryptedDevices); err != nil && !errors.Is(err, state.ErrNoState) {
+	if err := chg.Get("encrypted-devices", &encryptedDevices); err != nil {
 		return nil, fmt.Errorf("cannot get encrypted-devices from change: %v", err)
 	}
 
@@ -301,14 +366,7 @@ func detectStorageEncryption(seedLabel string) (bool, error) {
 	return details.StorageEncryption.Support == client.StorageEncryptionSupportAvailable, nil
 }
 
-func run(seedLabel, bootDevice, rootfsCreator string) error {
-	if len(os.Args) != 4 {
-		// xxx: allow installing real UC without a classic-rootfs later
-		return fmt.Errorf("need seed-label, target-device and classic-rootfs as argument\n")
-	}
-	os.Setenv("SNAPD_DEBUG", "1")
-	logger.SimpleSetup()
-
+func run(seedLabel, rootfsCreator, bootDevice string) error {
 	logger.Noticef("installing on %q", bootDevice)
 
 	cli := client.New(nil)
@@ -354,13 +412,27 @@ func run(seedLabel, bootDevice, rootfsCreator string) error {
 }
 
 func main() {
-	seedLabel := os.Args[1]
-	bootDevice := os.Args[2]
-	rootfsCreator := os.Args[3]
+	if len(os.Args) != 4 {
+		// XXX: allow installing real UC without a classic-rootfs later
+		fmt.Fprintf(os.Stderr, "need seed-label, target-device and classic-rootfs as argument\n")
+		os.Exit(1)
+	}
+	os.Setenv("SNAPD_DEBUG", "1")
+	logger.SimpleSetup()
 
-	if err := run(seedLabel, bootDevice, rootfsCreator); err != nil {
+	seedLabel := os.Args[1]
+	rootfsCreator := os.Args[2]
+	bootDevice := os.Args[3]
+	if bootDevice == "auto" {
+		bootDevice = waitForDevice()
+	}
+
+	if err := run(seedLabel, rootfsCreator, bootDevice); err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n", err)
 		os.Exit(1)
 	}
-	logger.Noticef("install done, please reboot")
+
+	msg := "install done, please remove installation media and reboot"
+	fmt.Println(msg)
+	exec.Command("wall", msg).Run()
 }

--- a/tests/lib/fakeinstaller/mk-classic-rootfs.sh
+++ b/tests/lib/fakeinstaller/mk-classic-rootfs.sh
@@ -52,7 +52,9 @@ EOF
 
     # install the current in-development version of snapd when available,
     # this will give us seeding support
-    GOPATH="${GOPATH:-./}"
+    #
+    # TODO: find a better way to do this?
+    GOPATH="${GOPATH:-/var/lib/snapd}"
     package=$(find "$GOPATH" -maxdepth 1 -name "snapd_*.deb")
     if [ -e "$package"  ]; then
         cp "$package" "$DESTDIR"/var/cache/apt/archives
@@ -78,11 +80,16 @@ if [ ! -d "$DST" ]; then
 fi
 
 # extract the base
+# get/extract the base
+# XXX: example of the livefs from liveinstaller
+#wget -q https://launchpad.net/~mwhudson/+livefs/ubuntu/jammy/test/+build/377517/+files/livecd.ubuntu.base.squashfs
+#sudo unsquashfs -f -d "$DST" livecd.ubuntu.base.squashfs
 if [ -f /cdrom/casper/base.squashfs ]; then
-    sudo unsquashfs -d "$DST" /cdrom/casper/base.squashfs
+    sudo unsquashfs -f -d "$DST" /cdrom/casper/base.squashfs
 else
     BASETAR=ubuntu-base.tar.gz
-    wget -c http://cdimage.ubuntu.com/ubuntu-base/releases/22.04/release/ubuntu-base-22.04.1-base-amd64.tar.gz -O "$BASETAR"
+    # important to use "-q" to avoid journalctl suppressing  log output
+    wget -q -c http://cdimage.ubuntu.com/ubuntu-base/releases/22.04/release/ubuntu-base-22.04.1-base-amd64.tar.gz -O "$BASETAR"
     sudo tar -C "$DST" -xf "$BASETAR"
 fi
 

--- a/tests/lib/fakeinstaller/snapcraft.yaml
+++ b/tests/lib/fakeinstaller/snapcraft.yaml
@@ -1,0 +1,26 @@
+name: muinstaller
+version: "0.1"
+summary: Minimal Unattended Installer
+description: |
+  Minimal Unattended Installer (muinstaller) is a minimal installer
+  for Ubuntu Core
+confinement: classic
+base: core22
+
+apps:
+  muinstaller:
+    command: bin/muinstaller classic $SNAP/bin/mk-classic-rootfs.sh auto
+    daemon: simple
+  cli:
+    command: bin/muinstaller
+
+# TODO: add spread test that builds the muinstaller from snapd to ensure
+#       we don't accidentally break it
+parts:
+  muinstaller:
+    plugin: go
+    source: .
+    build-snaps: [go/1.13/stable]
+    override-build: |
+      snapcraftctl build
+      cp -a mk-classic-rootfs.sh $SNAPCRAFT_PART_INSTALL/bin

--- a/tests/lib/fakeinstaller/snapcraft.yaml
+++ b/tests/lib/fakeinstaller/snapcraft.yaml
@@ -11,6 +11,9 @@ apps:
   muinstaller:
     command: bin/muinstaller classic $SNAP/bin/mk-classic-rootfs.sh auto
     daemon: simple
+    # this means "snap enable muinstaller.muinstaller" needs to run
+    # after boot to get it run automatically
+    install-mode: disable
   cli:
     command: bin/muinstaller
 

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -436,7 +436,7 @@ nested_download_image() {
     local IMAGE_URL=$1
     local IMAGE_NAME=$2
 
-    curl -L -o "${NESTED_IMAGES_DIR}/${IMAGE_NAME}" "$IMAGE_URL"
+    curl -C - -L -o "${NESTED_IMAGES_DIR}/${IMAGE_NAME}" "$IMAGE_URL"
 
     if [[ "$IMAGE_URL" == *.img.xz ]]; then
         mv "${NESTED_IMAGES_DIR}/${IMAGE_NAME}" "${NESTED_IMAGES_DIR}/${IMAGE_NAME}.xz"
@@ -985,6 +985,7 @@ nested_start_core_vm_unit() {
     PARAM_TRACE="-d cpu_reset"
     PARAM_LOG="-D $NESTED_LOGS_DIR/qemu.log"
     PARAM_RTC="${NESTED_PARAM_RTC:-}"
+    PARAM_EXTRA="${NESTED_PARAM_EXTRA:-}"
 
     # Open port 7777 on the host so that failures in the nested VM (e.g. to
     # create users) can be debugged interactively via
@@ -1074,9 +1075,11 @@ nested_start_core_vm_unit() {
 
         if nested_is_tpm_enabled; then
             if snap list swtpm-mvo >/dev/null; then
-                # reset the tpm state
-                rm /var/snap/swtpm-mvo/current/tpm2-00.permall
-                snap restart swtpm-mvo > /dev/null
+                if [ -z "$NESTED_TPM_NO_RESTART" ]; then
+                    # reset the tpm state
+                    rm /var/snap/swtpm-mvo/current/tpm2-00.permall
+                    snap restart swtpm-mvo > /dev/null
+                fi
             else
                 snap install swtpm-mvo --edge
             fi
@@ -1121,7 +1124,8 @@ nested_start_core_vm_unit() {
         ${PARAM_SERIAL} \
         ${PARAM_MONITOR} \
         ${PARAM_USB} \
-        ${PARAM_CD} " "${PARAM_REEXEC_ON_FAILURE}"
+        ${PARAM_CD}  \
+        ${PARAM_EXTRA} " "${PARAM_REEXEC_ON_FAILURE}"
 
     # wait for the $NESTED_VM service to appear active
     wait_for_service "$NESTED_VM"
@@ -1294,7 +1298,20 @@ nested_start_classic_vm() {
     PARAM_CPU=""
     PARAM_CD="${NESTED_PARAM_CD:-}"
     PARAM_RANDOM="-object rng-random,id=rng0,filename=/dev/urandom -device virtio-rng-pci,rng=rng0"
-    PARAM_SNAPSHOT="-snapshot"
+    # TODO: can this be removed? we create a "pristine" copy above?
+    #PARAM_SNAPSHOT="-snapshot"
+    PARAM_SNAPSHOT=""
+    PARAM_EXTRA="${NESTED_PARAM_EXTRA:-}"
+
+    # XXX: duplicated from nested core vm
+    # Set kvm attribute
+    local ATTR_KVM
+    ATTR_KVM=""
+    if nested_is_kvm_enabled; then
+        ATTR_KVM=",accel=kvm"
+        # CPU can be defined just when kvm is enabled
+        PARAM_CPU="-cpu host"
+    fi
 
     local PARAM_MACHINE PARAM_IMAGE PARAM_SEED PARAM_SERIAL PARAM_BIOS PARAM_TPM
     if [ "$SPREAD_BACKEND" = "google-nested" ]; then
@@ -1355,6 +1372,7 @@ nested_start_classic_vm() {
         ${PARAM_SERIAL} \
         ${PARAM_MONITOR} \
         ${PARAM_USB} \
+        ${PARAM_EXTRA} \
         ${PARAM_CD} "
 
     nested_wait_for_ssh

--- a/tests/nested/manual/fakeinstaller-real/task.yaml
+++ b/tests/nested/manual/fakeinstaller-real/task.yaml
@@ -1,0 +1,253 @@
+summary: End-to-end test for install via muinstaller
+
+systems: [ubuntu-22.04-64]
+
+environment:
+    # Test both encrypted and unencrypted install using the muinstaller
+    NESTED_ENABLE_TPM/encrypted: true
+    NESTED_ENABLE_SECURE_BOOT/encrypted: true
+
+    # unencrypted case
+    NESTED_ENABLE_TPM/plain: false
+    NESTED_ENABLE_SECURE_BOOT/plain: false
+
+    # ensure we use our latest code
+    NESTED_BUILD_SNAPD_FROM_CURRENT: true
+    NESTED_REPACK_KERNEL_SNAP: true
+    NESTED_ENABLE_OVMF: true
+    # store related setup
+    STORE_ADDR: localhost:11028
+    STORE_DIR: $(pwd)/fake-store-blobdir
+    # image
+    IMAGE_MOUNTPOINT: /mnt/cloudimg
+
+prepare: |
+  if [ "$TRUST_TEST_KEYS" = "false" ]; then
+      echo "This test needs test keys to be trusted"
+      exit
+  fi
+  snap install jq
+   #shellcheck source=tests/lib/store.sh
+   . "$TESTSLIB"/store.sh
+  setup_fake_store "$STORE_DIR"
+
+
+restore: |
+  if [ "$TRUST_TEST_KEYS" = "false" ]; then
+      echo "This test needs test keys to be trusted"
+      exit
+  fi
+  #shellcheck source=tests/lib/store.sh
+  . "$TESTSLIB"/store.sh
+  teardown_fake_store "$STORE_DIR"
+  rm -rf ./classic-root
+
+execute: |
+  if [ "$TRUST_TEST_KEYS" = "false" ]; then
+      echo "This test needs test keys to be trusted"
+      exit
+  fi
+  # shellcheck source=tests/lib/prepare.sh
+  . "$TESTSLIB/prepare.sh"
+  #shellcheck source=tests/lib/nested.sh
+  . "$TESTSLIB"/nested.sh
+
+  # install the snapd deb from spread so we are using the same version to 
+  # validate the seed as well as call preseed, etc. 
+  dpkg -i "$SPREAD_PATH"/../snapd_*.deb
+
+  echo Expose the needed assertions through the fakestore
+  cp "$TESTSLIB"/assertions/developer1.account "$STORE_DIR/asserts"
+  cp "$TESTSLIB"/assertions/developer1.account-key "$STORE_DIR/asserts"
+  cp "$TESTSLIB"/assertions/testrootorg-store.account-key "$STORE_DIR/asserts" 
+  export SNAPPY_FORCE_SAS_URL=http://$STORE_ADDR
+
+  version="$(nested_get_version)"
+
+  # build updated shim
+  version=22
+  snap download --basename=pc --channel="$version/edge" pc
+  unsquashfs -d pc-gadget pc.snap
+  echo 'console=ttyS0 systemd.journald.forward_to_console=1' > pc-gadget/cmdline.extra
+  echo "Sign the shim binary"
+  KEY_NAME=$(tests.nested download snakeoil-key)
+  SNAKEOIL_KEY="$PWD/$KEY_NAME.key"
+  SNAKEOIL_CERT="$PWD/$KEY_NAME.pem"
+  tests.nested secboot-sign gadget pc-gadget "$SNAKEOIL_KEY" "$SNAKEOIL_CERT"
+  snap pack --filename=pc.snap pc-gadget/ 
+
+  # get an updated kernel
+  snap download --basename=pc-kernel --channel="$version/edge" pc-kernel
+  uc20_build_initramfs_kernel_snap "$PWD/pc-kernel.snap" "$NESTED_ASSETS_DIR"
+  mv "${NESTED_ASSETS_DIR}"/pc-kernel_*.snap pc-kernel.snap
+
+  # prepare a classic seed
+  # TODO:
+  # - create pc-classic custom gadget
+  # - repacked snapd snap
+  # (should be as simple as addinga "--snap=./local-gadget.snap ...")
+  LABEL="$(date +%Y%m%d)"
+  gendeveloper1 sign-model < "$TESTSLIB"/assertions/developer1-22-classic-dangerous.json > my.model
+  snap prepare-image --classic \
+      --channel=edge \
+      --snap ./pc-kernel.snap \
+      --snap ./pc.snap \
+      my.model \
+      ./classic-seed
+  # make the seed label more predictable for fake-installer auto-mode
+  NEW_LABEL=classic
+  mv ./classic-seed/system-seed/systems/"$LABEL" ./classic-seed/system-seed/systems/"$NEW_LABEL"
+  LABEL="$NEW_LABEL"
+
+  # we don't need the fakestore anymore
+  teardown_fake_store "$STORE_DIR"
+
+
+  # build the fake-installer snap
+  snap install snapcraft --candidate --classic
+  snap install lxd --candidate
+  snap set lxd waitready.timeout=240
+  lxd waitready
+  lxd init --auto
+  echo "Setting up proxy for lxc"
+  if [ -n "${http_proxy:-}" ]; then
+    lxd.lxc config set core.proxy_http "$http_proxy"
+  fi
+  if [ -n "${https_proxy:-}" ]; then
+    lxd.lxc config set core.proxy_https "$http_proxy"
+  fi
+  (cd "$TESTSLIB"/fakeinstaller && snapcraft)
+  FAKEINSTALLER_SNAP="$(ls "$TESTSLIB"/fakeinstaller/*.snap)"
+  echo "found $FAKEINSTALLER_SNAP"
+
+  # create new disk for the installer to work on and attach to VM
+  truncate --size=4G fake-disk.img
+  # TODO: XXX: fakeinstaller should work on a empty disk too, it errors
+  # right now with "device with name "/dev/vdc" is not a physical disk
+  echo "label: gpt" | sfdisk "fake-disk.img"
+
+  NESTED_PARAM_EXTRA="-drive file=$(pwd)/fake-disk.img,if=virtio,snapshot=off"
+  export NESTED_PARAM_EXTRA
+
+  # create a VM and mount a cloud image
+  tests.nested build-image classic
+
+  # TODO: nested classic images do not support secure boot today so
+  #       this will not work to test the secure boot installer. So for
+  #       now the workaround is to boot classic to create user/ssh
+  #       keys, shutdown down, convert disk from qcow2->raw and rename
+  #       from classic->core and use nested_start_core_vm (like below)
+  #
+  # start it so that cloud-init creates ssh keys and user
+  nested_start_classic_vm
+
+  # make sure classic image is bootable with snakeoil keys
+  # TODO: move to nested_create_classic_image
+  # XXX: use assets from gadget instead?
+  for s in BOOT/BOOTX64.EFI ubuntu/shimx64.efi; do
+      remote.exec "sudo cp -a /boot/efi/EFI/$s /tmp"
+      remote.exec "sudo chmod 755 /tmp/$(basename $s)"
+      remote.pull /tmp/"$(basename $s)" .
+      nested_secboot_sign_file "$(basename $s)" "$SNAKEOIL_KEY" "$SNAKEOIL_CERT"
+      remote.push "$(basename $s)"
+      remote.exec "sudo mv $(basename $s) /boot/efi/EFI/$s"
+  done
+
+  # push our snap down
+  # TODO: this abuses /var/lib/snapd to store the deb so that mk-initramfs-classic
+  # can pick it up. the real installer will also need a very recent snapd
+  # in it's on disk-image to supprot seeding
+  remote.push "$SPREAD_PATH"/../snapd_*.deb
+  remote.exec "sudo mv snapd_*.deb /var/lib/snapd/"
+  remote.exec "sudo apt install -y /var/lib/snapd/snapd_*.deb"
+    
+  # push our seed down
+  # TODO: merge with classic /var/lib/snapd/seed eventually
+  # XXX: port scp -r to remote.push
+  #remote.push ./classic-seed/system-seed/ '~/'
+  sshpass -p ubuntu scp -r -P 8022 -o ConnectTimeout=10 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ./classic-seed/system-seed/ user1@localhost:~/install-seed
+  remote.exec "sudo mv /home/user1/install-seed /var/lib/snapd/"
+
+  # XXX: the code in DeviceManager.SystemAndGadgetInfo() will only work on
+  # classic systems with modeenv right now (which is something we may need
+  # to fix to work from the classic installer).
+  # For now pretend we have a modeenv
+  remote.exec 'echo "mode=run" | sudo tee -a /var/lib/snapd/modeenv'
+  remote.exec 'sudo systemctl restart snapd'
+
+  # shutdown the classic vm to install with a core VM that supports
+  # secboot/tpm
+  nested_shutdown
+  sync
+
+  # HACK: convert "classic" qcow2 to raw "core" image because we need
+  # to boot with OVMF we really should fix this so that classic and
+  # core VMs are more similar
+  qemu-img convert -f qcow2 -O raw "$NESTED_IMAGES_DIR/$(nested_get_image_name classic)" "$NESTED_IMAGES_DIR/$(nested_get_image_name core)"
+  # and we don't need the classic image anymore
+  # TODO: uncomment
+  #rm -f  "$NESTED_IMAGES_DIR/$(nested_get_image_name classic)"
+  # TODO: this prevents "nested_prepare_ssh" inside nested_start_core_vm
+  #       from running, we already have a user so this is not needed
+  IMAGE_NAME="$(nested_get_image_name core)"
+  touch "$NESTED_IMAGES_DIR/$IMAGE_NAME.configured"
+  nested_start_core_vm
+  
+  # bind mount new seed
+  remote.exec "sudo mount -o bind /var/lib/snapd/install-seed /var/lib/snapd/seed"
+  # push the fakeinstaller
+  remote.push "$FAKEINSTALLER_SNAP"
+  remote.exec "sudo snap install --classic --dangerous $(basename "$FAKEINSTALLER_SNAP")"
+
+  # TODO: use retry
+  while true; do
+    if remote.exec "sudo snap logs muinstaller" | MATCH "install done"; then
+        break
+    fi
+    sleep 5
+  done
+  remote.exec "sudo sync"
+
+  # boot into the just installed drive
+  nested_shutdown
+  sync
+
+  # HACK: rename to "core" image because we need to boot with OVMF
+  # we really should fix this so that classic and core VMs are more similar
+  mv fake-disk.img "$NESTED_IMAGES_DIR/$IMAGE_NAME"
+  unset NESTED_PARAM_EXTRA
+
+  # remove cached image
+  # TODO: find a more elegant way
+  rm -f "$NESTED_IMAGES_DIR"/ubuntu-core-current.img
+
+  # and start again
+  # TODO: make this nicer
+  export NESTED_TPM_NO_RESTART=1
+  nested_start_core_vm
+  unset  NESTED_TPM_NO_RESTART
+  
+  # things look fine
+  remote.exec "cat /etc/os-release" | MATCH 'NAME="Ubuntu"'
+  remote.exec "snap changes" | MATCH "Done.* Initialize system state"
+  remote.exec "snap list" | MATCH pc-kernel
+
+  # check encryption
+  if [ "$NESTED_ENABLE_TPM" = true ]; then
+      remote.exec "sudo test -d /var/lib/snapd/device/fde"
+      remote.exec "sudo test -e /var/lib/snapd/device/fde/marker"
+      remote.exec "sudo test -e /var/lib/snapd/device/fde/marker"
+      remote.exec "sudo blkid /dev/disk/by-label/ubuntu-data-enc" | MATCH crypto_LUKS
+  
+      # check disk mappings
+      remote.exec "sudo snap install jq"
+      # TODO: no ubuntu-save right now because:
+      #       "ERROR cannot store device key pair: internal error: cannot access device keypair manager if ubuntu-save is unavailable"
+      #DISK_MAPPINGS=(/run/mnt/ubuntu-save/device/disk-mapping.json
+      #               /run/mnt/data/var/lib/snapd/device/disk-mapping.json)
+      DISK_MAPPINGS=(/run/mnt/data/var/lib/snapd/device/disk-mapping.json)
+      for DM in "${DISK_MAPPINGS[@]}"; do
+          remote.exec "sudo cat $DM | jq '.pc.\"structure-encryption\".\"ubuntu-save\".method'" | MATCH '"LUKS"'
+          remote.exec "sudo cat $DM | jq '.pc.\"structure-encryption\".\"ubuntu-data\".method'" | MATCH '"LUKS"'
+      done
+  fi

--- a/tests/nested/manual/fakeinstaller-real/task.yaml
+++ b/tests/nested/manual/fakeinstaller-real/task.yaml
@@ -198,6 +198,7 @@ execute: |
   # push the fakeinstaller
   remote.push "$FAKEINSTALLER_SNAP"
   remote.exec "sudo snap install --classic --dangerous $(basename "$FAKEINSTALLER_SNAP")"
+  remote.exec "sudo snap enable muinstaller.muinstaller"
 
   # TODO: use retry
   while true; do

--- a/tests/nested/manual/fakeinstaller/task.yaml
+++ b/tests/nested/manual/fakeinstaller/task.yaml
@@ -92,6 +92,10 @@ execute: |
       --snap ./pc-kernel.snap \
       my.model \
       ./classic-seed
+  # make the seed label more predictable for fake-installer auto-mode
+  NEW_LABEL=classic
+  mv ./classic-seed/system-seed/systems/"$LABEL" ./classic-seed/system-seed/systems/"$NEW_LABEL"
+  LABEL="$NEW_LABEL"
   cp -a ./classic-seed/system-seed/ /var/lib/snapd/seed
 
   # do some light checking that the system is valid
@@ -108,7 +112,7 @@ execute: |
   # TODO: fakeinstaller should work on a empty disk too
   echo "label: gpt" | sfdisk "$loop_device"
   # and "install" the current seed to the fake disk
-  ./fakeinstaller "$LABEL" "$loop_device" "$TESTSLIB"/fakeinstaller/mk-classic-rootfs.sh
+  ./fakeinstaller "$LABEL" "$TESTSLIB"/fakeinstaller/mk-classic-rootfs.sh "$loop_device"
   # validate that the fake installer created the expected partitions
   sfdisk -d "$loop_device" > fdisk_output
   MATCH "${loop_device}p1 .* name=\"BIOS Boot\""   < fdisk_output


### PR DESCRIPTION
This commit make the muinstaller not run automatically as it appears
that on real hardware there are often steps and reboots required
before this is ready.

Based on https://github.com/snapcore/snapd/pull/12246
Relevant commit: https://github.com/snapcore/snapd/commit/9b2affb97d77f5e6b21bb762aa0ab183587d5b11