### PR TITLE
image: show snap revision when fetching

### DIFF
--- a/image/image_linux.go
+++ b/image/image_linux.go
@@ -455,7 +455,7 @@ var setupSeed = func(tsto *tooling.ToolingStore, model *asserts.Model, opts *Opt
 			if !rev.Unset() {
 				fmt.Fprintf(Stdout, "Fetching %s (%d)\n", sn.SnapName(), rev)
 			} else {
-				fmt.Fprintf(Stdout, "Fetching %s\n", sn.SnapName())
+				fmt.Fprintf(Stdout, "Fetching %s (%d)\n", sn.SnapName(), info.Revision)
 			}
 			if err := w.SetInfo(sn, info); err != nil {
 				return "", err


### PR DESCRIPTION
Hi, 

IMO, I think it would be helpful to show the revision of snaps when building Ubuntu Core image, most of the time I need to spend quite some time(depends on the download speed, it might take more than 10 mins to download kernel snap) to fetch at least 4 snaps for building image, so if somehow I made a mistake and downloading the snap with incorrect revision, I can notice that in a relative early stage and save some time since I need to build image over and over again

thanks in advance!