### PR TITLE
packaging: merge changelog for 2.57.5

### DIFF
--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -11,7 +11,7 @@ pkgdesc="Service and tools for management of snap packages."
 depends=('squashfs-tools' 'libseccomp' 'libsystemd' 'apparmor')
 optdepends=('bash-completion: bash completion support'
             'xdg-desktop-portal: desktop integration')
-pkgver=2.57.4
+pkgver=2.57.5
 pkgrel=1
 arch=('x86_64' 'i686' 'armv7h' 'aarch64')
 url="https://github.com/snapcore/snapd"

--- a/packaging/debian-sid/changelog
+++ b/packaging/debian-sid/changelog
@@ -1,3 +1,27 @@
+snapd (2.57.5-1) unstable; urgency=medium
+
+  * New upstream release, LP: #1983035
+    - image: clean snapd mount after preseeding
+    - wrappers,snap/quota: clear LogsDirectory= in the service unit
+      for journal namespaces
+    - cmd/snap,daemon: allow zero values from client to daemon for
+      journal rate-limit
+    - interfaces: steam-support allow pivot /run/media and /etc/nvidia
+      mount
+    - o/ifacestate: introduce DebugAutoConnectCheck hook
+    - release, snapd-apparmor, syscheck: distinguish WSL1 and WSL2
+    - autopkgtests: fix running autopkgtest on kinetic
+    - interfaces: add microceph interface
+    - interfaces: steam-support allow additional mounts
+    - many: add stub services
+    - interfaces: add kconfig paths to system-observe
+    - i/b/system_observe: honour root dir when checking for
+      /boot/config-*
+    - interfaces: grant access to speech-dispatcher socket
+    - interfaces: rework logic of unclashMountEntries
+
+ -- Michael Vogt <michael.vogt@ubuntu.com>  Mon, 17 Oct 2022 18:25:18 +0200
+
 snapd (2.57.4-1) unstable; urgency=medium
 
   * New upstream release, LP: #1983035

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -102,7 +102,7 @@
 %endif
 
 Name:           snapd
-Version:        2.57.4
+Version:        2.57.5
 Release:        0%{?dist}
 Summary:        A transactional software package manager
 License:        GPLv3
@@ -986,6 +986,27 @@ fi
 
 
 %changelog
+* Mon Oct 17 2022 Michael Vogt <michael.vogt@ubuntu.com>
+- New upstream release 2.57.5
+ - image: clean snapd mount after preseeding
+ - wrappers,snap/quota: clear LogsDirectory= in the service unit
+   for journal namespaces
+ - cmd/snap,daemon: allow zero values from client to daemon for
+   journal rate-limit
+ - interfaces: steam-support allow pivot /run/media and /etc/nvidia
+   mount
+ - o/ifacestate: introduce DebugAutoConnectCheck hook
+ - release, snapd-apparmor, syscheck: distinguish WSL1 and WSL2
+ - autopkgtests: fix running autopkgtest on kinetic
+ - interfaces: add microceph interface
+ - interfaces: steam-support allow additional mounts
+ - many: add stub services
+ - interfaces: add kconfig paths to system-observe
+ - i/b/system_observe: honour root dir when checking for
+   /boot/config-*
+ - interfaces: grant access to speech-dispatcher socket
+ - interfaces: rework logic of unclashMountEntries
+
 * Thu Sep 29 2022 Michael Vogt <michael.vogt@ubuntu.com>
 - New upstream release 2.57.4
  - release, snapd-apparmor: fixed outdated WSL detection

--- a/packaging/opensuse/snapd.changes
+++ b/packaging/opensuse/snapd.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Oct 17 16:25:18 UTC 2022 - michael.vogt@ubuntu.com
+
+- Update to upstream release 2.57.5
+
+-------------------------------------------------------------------
 Thu Sep 29 07:54:21 UTC 2022 - michael.vogt@ubuntu.com
 
 - Update to upstream release 2.57.4

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -81,7 +81,7 @@
 
 
 Name:           snapd
-Version:        2.57.4
+Version:        2.57.5
 Release:        0
 Summary:        Tools enabling systems to work with .snap files
 License:        GPL-3.0

--- a/packaging/ubuntu-14.04/changelog
+++ b/packaging/ubuntu-14.04/changelog
@@ -1,3 +1,27 @@
+snapd (2.57.5~14.04) trusty; urgency=medium
+
+  * New upstream release, LP: #1983035
+    - image: clean snapd mount after preseeding
+    - wrappers,snap/quota: clear LogsDirectory= in the service unit
+      for journal namespaces
+    - cmd/snap,daemon: allow zero values from client to daemon for
+      journal rate-limit
+    - interfaces: steam-support allow pivot /run/media and /etc/nvidia
+      mount
+    - o/ifacestate: introduce DebugAutoConnectCheck hook
+    - release, snapd-apparmor, syscheck: distinguish WSL1 and WSL2
+    - autopkgtests: fix running autopkgtest on kinetic
+    - interfaces: add microceph interface
+    - interfaces: steam-support allow additional mounts
+    - many: add stub services
+    - interfaces: add kconfig paths to system-observe
+    - i/b/system_observe: honour root dir when checking for
+      /boot/config-*
+    - interfaces: grant access to speech-dispatcher socket
+    - interfaces: rework logic of unclashMountEntries
+
+ -- Michael Vogt <michael.vogt@ubuntu.com>  Mon, 17 Oct 2022 18:25:18 +0200
+
 snapd (2.57.4~14.04) trusty; urgency=medium
 
   * New upstream release, LP: #1983035

--- a/packaging/ubuntu-16.04/changelog
+++ b/packaging/ubuntu-16.04/changelog
@@ -1,3 +1,27 @@
+snapd (2.57.5) xenial; urgency=medium
+
+  * New upstream release, LP: #1983035
+    - image: clean snapd mount after preseeding
+    - wrappers,snap/quota: clear LogsDirectory= in the service unit
+      for journal namespaces
+    - cmd/snap,daemon: allow zero values from client to daemon for
+      journal rate-limit
+    - interfaces: steam-support allow pivot /run/media and /etc/nvidia
+      mount
+    - o/ifacestate: introduce DebugAutoConnectCheck hook
+    - release, snapd-apparmor, syscheck: distinguish WSL1 and WSL2
+    - autopkgtests: fix running autopkgtest on kinetic
+    - interfaces: add microceph interface
+    - interfaces: steam-support allow additional mounts
+    - many: add stub services
+    - interfaces: add kconfig paths to system-observe
+    - i/b/system_observe: honour root dir when checking for
+      /boot/config-*
+    - interfaces: grant access to speech-dispatcher socket
+    - interfaces: rework logic of unclashMountEntries
+
+ -- Michael Vogt <michael.vogt@ubuntu.com>  Mon, 17 Oct 2022 18:25:18 +0200
+
 snapd (2.57.4) xenial; urgency=medium
 
   * New upstream release, LP: #1983035


### PR DESCRIPTION
This merged the `release/2.57` branch back into master to get the updated changelogs.