### PR TITLE
systemd: use direct-io loop devices

### DIFF
--- a/cmd/snap-mgmt/snap-mgmt.sh.in
+++ b/cmd/snap-mgmt/snap-mgmt.sh.in
@@ -131,7 +131,10 @@ purge() {
         echo "Removing $unit"
         rm -f "/etc/systemd/system/$unit"
         rm -f "/etc/systemd/system/multi-user.target.wants/$unit"
+        rm -f "/etc/systemd/system/snapd.mounts.target.wants/${unit}"
     done
+    # Remove empty ".wants/" directory created by enabling mount units
+    rmdir "/etc/systemd/system/snapd.mounts.target.wants" || true
     # Units may have been removed do a reload
     systemctl -q daemon-reload || true
 

--- a/data/Makefile
+++ b/data/Makefile
@@ -5,3 +5,4 @@ all install clean:
 	$(MAKE) -C dbus $@
 	$(MAKE) -C env $@
 	$(MAKE) -C desktop $@
+	$(MAKE) -C udev $@

--- a/data/systemd/Makefile
+++ b/data/systemd/Makefile
@@ -24,7 +24,7 @@ SYSTEMDSYSTEMUNITDIR := /lib/systemd/system
 # prefix will not be installed on the host!
 SYSTEMD_UNITS_GENERATED := $(wildcard *.in)
 # NOTE: sort removes duplicates so this gives us all the units, generated or otherwise
-SYSTEMD_UNITS = $(sort $(SYSTEMD_UNITS_GENERATED:.in=) $(wildcard *.service) $(wildcard *.timer) $(wildcard *.socket))
+SYSTEMD_UNITS = $(sort $(SYSTEMD_UNITS_GENERATED:.in=) $(wildcard *.service) $(wildcard *.timer) $(wildcard *.socket) $(wildcard *.target))
 
 .PHONY: all
 all: $(SYSTEMD_UNITS) check

--- a/data/systemd/Makefile
+++ b/data/systemd/Makefile
@@ -46,10 +46,15 @@ install: $(SYSTEMD_UNITS)
 clean:
 	rm -f $(SYSTEMD_UNITS_GENERATED:.in=)
 
+LOSETUP_PATH:=$(shell command -v losetup)
+
+SED_SCRIPT:=$\
+	s:@libexecdir@:$(LIBEXECDIR):g;$\
+	s:@SNAPD_ENVIRONMENT_FILE@:$(SNAPD_ENVIRONMENT_FILE):g;$\
+	s:@bindir@:$(BINDIR):g;$\
+	s:@SNAP_MOUNT_DIR@:$(SNAP_MOUNT_DIR):g;$\
+	s:@LOSETUP_PATH@:$(LOSETUP_PATH):g
+
 %: %.in
-	cat $< | \
-		sed s:@libexecdir@:$(LIBEXECDIR):g | \
-		sed s:@SNAPD_ENVIRONMENT_FILE@:$(SNAPD_ENVIRONMENT_FILE):g | \
-		sed s:@bindir@:$(BINDIR):g | \
-		sed s:@SNAP_MOUNT_DIR@:$(SNAP_MOUNT_DIR):g  | \
-		cat > $@
+	sed '$(SED_SCRIPT)' $< >$@.tmp
+	mv $@.tmp $@

--- a/data/systemd/snapd.loop-setup@.service.in
+++ b/data/systemd/snapd.loop-setup@.service.in
@@ -1,0 +1,12 @@
+[Unit]
+Description=Bind %I to loop device
+StopWhenUnneeded=yes
+RefuseManualStart=yes
+DefaultDependencies=no
+After=snapd.mounts-pre.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=@LOSETUP_PATH@ -r -f --direct-io=on /%I
+ExecStop=@LOSETUP_PATH@ -d /dev/disk/by-backing-file/%i

--- a/data/systemd/snapd.mounts-pre.target
+++ b/data/systemd/snapd.mounts-pre.target
@@ -1,0 +1,5 @@
+[Unit]
+Description=Mounting snaps
+RefuseManualStart=yes
+# Started from snapd.mounts.target
+# X-Snapd-Snap: do-not-start

--- a/data/systemd/snapd.mounts-pre.target
+++ b/data/systemd/snapd.mounts-pre.target
@@ -1,5 +1,6 @@
 [Unit]
 Description=Mounting snaps
 RefuseManualStart=yes
+After=zfs-mount.service
 # Started from snapd.mounts.target
 # X-Snapd-Snap: do-not-start

--- a/data/systemd/snapd.mounts.target
+++ b/data/systemd/snapd.mounts.target
@@ -1,0 +1,6 @@
+[Unit]
+Description=Mounted snaps
+Before=local-fs.target
+Wants=snapd.mounts-pre.target
+# Started from snapd.service
+# X-Snapd-Snap: do-not-start

--- a/data/systemd/snapd.service.in
+++ b/data/systemd/snapd.service.in
@@ -1,7 +1,10 @@
 [Unit]
 Description=Snap Daemon
-After=snapd.socket time-set.target
+After=snapd.socket
+After=time-set.target
+After=snapd.mounts.target
 Wants=time-set.target
+Wants=snapd.mounts.target
 Requires=snapd.socket
 OnFailure=snapd.failure.service
 # This is handled by snapd

--- a/data/udev/Makefile
+++ b/data/udev/Makefile
@@ -1,0 +1,11 @@
+UDEVDIR := /lib/udev/rules.d
+
+.PHONY: all
+all:
+
+.PHONY: install
+install:
+	install -Dm0644 -t $(DESTDIR)$(UDEVDIR) rules.d/50-snapd-loop-devices.rules
+
+.PHONY: clean
+clean:

--- a/data/udev/rules.d/50-snapd-loop-devices.rules
+++ b/data/udev/rules.d/50-snapd-loop-devices.rules
@@ -1,0 +1,7 @@
+SUBSYSTEM!="block", GOTO="loop_devices_end"
+ACTION!="add|change", GOTO="loop_devices_end"
+KERNEL!="loop*", GOTO="loop_devices_end"
+
+IMPORT{program}="/bin/sh -c 'echo -n LOOP_BACK_FILE= ; losetup -O BACK-FILE -n $$0' %N"
+IMPORT{program}="/bin/sh -c 'echo -n .LOOP_BACK_FILE_ESCAPED= ; systemd-escape -p $$0' $env{LOOP_BACK_FILE}"
+SYMLINK+="disk/by-backing-file/$env{.LOOP_BACK_FILE_ESCAPED}"

--- a/image/preseed/preseed_classic_test.go
+++ b/image/preseed/preseed_classic_test.go
@@ -285,6 +285,9 @@ func (s *preseedSuite) TestReset(c *C) {
 			{filepath.Join(dirs.SnapServicesDir, "snap.foo.timer"), ""},
 			{filepath.Join(dirs.SnapServicesDir, "snap.foo.socket"), ""},
 			{filepath.Join(dirs.SnapServicesDir, "snap-foo.mount"), ""},
+			// In order to allow preseeding of images with older snapd, we need to also
+			// add the mount in multi-user.target
+			{filepath.Join(dirs.SnapServicesDir, "multi-user.target.wants", "snap-foo.mount"), ""},
 			{filepath.Join(dirs.SnapServicesDir, "snapd.mounts.target.wants", "snap-foo.mount"), ""},
 			{filepath.Join(dirs.SnapDataDir, "foo", "bar"), ""},
 			{filepath.Join(dirs.SnapCacheDir, "foocache", "bar"), ""},

--- a/image/preseed/preseed_classic_test.go
+++ b/image/preseed/preseed_classic_test.go
@@ -285,7 +285,7 @@ func (s *preseedSuite) TestReset(c *C) {
 			{filepath.Join(dirs.SnapServicesDir, "snap.foo.timer"), ""},
 			{filepath.Join(dirs.SnapServicesDir, "snap.foo.socket"), ""},
 			{filepath.Join(dirs.SnapServicesDir, "snap-foo.mount"), ""},
-			{filepath.Join(dirs.SnapServicesDir, "multi-user.target.wants", "snap-foo.mount"), ""},
+			{filepath.Join(dirs.SnapServicesDir, "snapd.mounts.target.wants", "snap-foo.mount"), ""},
 			{filepath.Join(dirs.SnapDataDir, "foo", "bar"), ""},
 			{filepath.Join(dirs.SnapCacheDir, "foocache", "bar"), ""},
 			{filepath.Join(apparmor_sandbox.CacheDir, "foo", "bar"), ""},

--- a/image/preseed/reset.go
+++ b/image/preseed/reset.go
@@ -107,6 +107,8 @@ func ResetPreseededChroot(preseedChroot string) error {
 		filepath.Join(dirs.SnapServicesDir, "snap.*.socket"),
 		filepath.Join(dirs.SnapServicesDir, "snap-*.mount"),
 		filepath.Join(dirs.SnapServicesDir, "multi-user.target.wants", "snap-*.mount"),
+		filepath.Join(dirs.SnapServicesDir, "default.target.wants", "snap-*.mount"),
+		filepath.Join(dirs.SnapServicesDir, "snapd.mounts.target.wants", "snap-*.mount"),
 		filepath.Join(dirs.SnapUserServicesDir, "snap.*.service"),
 		filepath.Join(dirs.SnapUserServicesDir, "snap.*.socket"),
 		filepath.Join(dirs.SnapUserServicesDir, "snap.*.timer"),

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -64,7 +64,7 @@
 %global provider_prefix %{provider}.%{provider_tld}/%{project}/%{repo}
 %global import_path     %{provider_prefix}
 
-%global snappy_svcs      snapd.service snapd.socket snapd.autoimport.service snapd.seeded.service
+%global snappy_svcs      snapd.service snapd.socket snapd.autoimport.service snapd.seeded.service snapd.mounts.target snapd.mounts-pre.target
 %global snappy_user_svcs snapd.session-agent.service snapd.session-agent.socket
 
 # Until we have a way to add more extldflags to gobuild macro...
@@ -829,6 +829,8 @@ popd
 %{_unitdir}/snapd.autoimport.service
 %{_unitdir}/snapd.failure.service
 %{_unitdir}/snapd.seeded.service
+%{_unitdir}/snapd.mounts.target
+%{_unitdir}/snapd.mounts-pre.target
 %{_userunitdir}/snapd.session-agent.service
 %{_userunitdir}/snapd.session-agent.socket
 %{_datadir}/dbus-1/services/io.snapcraft.Launcher.service

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -29,7 +29,7 @@
 
 # The list of systemd services we are expected to ship. Note that this does
 # not include services that are only required on core systems.
-%global systemd_services_list snapd.socket snapd.service snapd.seeded.service snapd.failure.service %{?with_apparmor:snapd.apparmor.service}
+%global systemd_services_list snapd.socket snapd.service snapd.seeded.service snapd.failure.service %{?with_apparmor:snapd.apparmor.service} snapd.mounts.target snapd.mounts-pre.target
 %global systemd_user_services_list snapd.session-agent.socket
 
 # Alternate snap mount directory: not used by openSUSE.
@@ -478,6 +478,8 @@ fi
 %{_unitdir}/snapd.seeded.service
 %{_unitdir}/snapd.service
 %{_unitdir}/snapd.socket
+%{_unitdir}/snapd.mounts.target
+%{_unitdir}/snapd.mounts-pre.target
 %{_userunitdir}/snapd.session-agent.service
 %{_userunitdir}/snapd.session-agent.socket
 

--- a/packaging/ubuntu-14.04/snapd.postrm
+++ b/packaging/ubuntu-14.04/snapd.postrm
@@ -96,7 +96,10 @@ if [ "$1" = "purge" ]; then
         echo "Removing $unit"
         rm -f "/etc/systemd/system/$unit"
         rm -f "/etc/systemd/system/multi-user.target.wants/$unit"
+        rm -f "/etc/systemd/system/snapd.mounts.target.wants/$unit"
     done
+    # Remove empty ".wants/" directory created by enabling mount units
+    rmdir "/etc/systemd/system/snapd.mounts.target.wants" || true
     # Units may have been removed do a reload
     systemctl -q daemon-reload || true
 

--- a/packaging/ubuntu-16.04/snapd.postrm
+++ b/packaging/ubuntu-16.04/snapd.postrm
@@ -102,7 +102,10 @@ if [ "$1" = "purge" ]; then
         echo "Removing $unit"
         rm -f "/etc/systemd/system/$unit"
         rm -f "/etc/systemd/system/multi-user.target.wants/$unit"
+        rm -f "/etc/systemd/system/snapd.mounts.target.wants/$unit"
     done
+    # Remove empty ".wants/" directory created by enabling mount units
+    rmdir "/etc/systemd/system/snapd.mounts.target.wants" || true
     # Units may have been removed do a reload
     systemctl -q daemon-reload || true
 

--- a/systemd/emulation.go
+++ b/systemd/emulation.go
@@ -155,14 +155,14 @@ func (s *emulation) AddMountUnitFile(snapName, revision, what, where, fstype str
 		return "", fmt.Errorf("cannot mount %s (%s) at %s in preseed mode: %s; %s", what, hostFsType, where, err, string(out))
 	}
 
-	multiUserTargetWantsDir := filepath.Join(dirs.SnapServicesDir, "multi-user.target.wants")
-	if err := os.MkdirAll(multiUserTargetWantsDir, 0755); err != nil {
+	snapdMountsTargetWantsDir := filepath.Join(dirs.SnapServicesDir, "snapd.mounts.target.wants")
+	if err := os.MkdirAll(snapdMountsTargetWantsDir, 0755); err != nil {
 		return "", err
 	}
 
-	// cannot call systemd, so manually enable the unit by symlinking into multi-user.target.wants
+	// cannot call systemd, so manually enable the unit by symlinking into snapd.mounts.target.wants
 	mu := MountUnitPath(where)
-	enableUnitPath := filepath.Join(multiUserTargetWantsDir, mountUnitName)
+	enableUnitPath := filepath.Join(snapdMountsTargetWantsDir, mountUnitName)
 	if err := os.Symlink(mu, enableUnitPath); err != nil {
 		return "", fmt.Errorf("cannot enable mount unit %s: %v", mountUnitName, err)
 	}

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -1360,12 +1360,15 @@ func ExistingMountUnitPath(mountPointDir string) string {
 
 var squashfsFsType = squashfs.FsType
 
+// Note that WantedBy=multi-user.target and Before=local-fs.target are
+// only used to allow downgrading to an older version of snapd.
 const mountUnitTemplate = `[Unit]
 Description=Mount unit for {{.SnapName}}
 {{- with .Revision}}, revision {{.}}{{end}}
 {{- with .Origin}} via {{.}}{{end}}
 After=snapd.mounts-pre.target
 Before=snapd.mounts.target
+Before=local-fs.target
 
 [Mount]
 What={{.What}}
@@ -1376,6 +1379,7 @@ LazyUnmount=yes
 
 [Install]
 WantedBy=snapd.mounts.target
+WantedBy=multi-user.target
 {{- with .Origin}}
 X-SnapdOrigin={{.}}
 {{- end}}

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -1360,15 +1360,12 @@ func ExistingMountUnitPath(mountPointDir string) string {
 
 var squashfsFsType = squashfs.FsType
 
-// XXX: After=zfs-mount.service is a workaround for LP: #1922293 (a problem
-// with order of mounting most likely related to zfs-linux and/or systemd).
 const mountUnitTemplate = `[Unit]
 Description=Mount unit for {{.SnapName}}
 {{- with .Revision}}, revision {{.}}{{end}}
 {{- with .Origin}} via {{.}}{{end}}
 After=snapd.mounts-pre.target
 Before=snapd.mounts.target
-After=zfs-mount.service
 
 [Mount]
 What={{.What}}

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -1362,13 +1362,12 @@ var squashfsFsType = squashfs.FsType
 
 // XXX: After=zfs-mount.service is a workaround for LP: #1922293 (a problem
 // with order of mounting most likely related to zfs-linux and/or systemd).
-// XXX: Remove multi-user.target once we are sure it's unnecessary (see the
-// comments in LP: #1983528).
 const mountUnitTemplate = `[Unit]
 Description=Mount unit for {{.SnapName}}
 {{- with .Revision}}, revision {{.}}{{end}}
 {{- with .Origin}} via {{.}}{{end}}
-Before=snapd.service
+After=snapd.mounts-pre.target
+Before=snapd.mounts.target
 After=zfs-mount.service
 
 [Mount]
@@ -1379,7 +1378,7 @@ Options={{join .Options ","}}
 LazyUnmount=yes
 
 [Install]
-WantedBy=default.target multi-user.target
+WantedBy=snapd.mounts.target
 {{- with .Origin}}
 X-SnapdOrigin={{.}}
 {{- end}}

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -1166,7 +1166,6 @@ func (s *SystemdTestSuite) TestAddMountUnit(c *C) {
 Description=Mount unit for foo, revision 42
 After=snapd.mounts-pre.target
 Before=snapd.mounts.target
-After=zfs-mount.service
 
 [Mount]
 What=%s
@@ -1201,7 +1200,6 @@ func (s *SystemdTestSuite) TestAddMountUnitForDirs(c *C) {
 Description=Mount unit for foodir, revision x1
 After=snapd.mounts-pre.target
 Before=snapd.mounts.target
-After=zfs-mount.service
 
 [Mount]
 What=%s
@@ -1248,7 +1246,6 @@ func (s *SystemdTestSuite) TestAddMountUnitTransient(c *C) {
 Description=Mount unit for foo via bar
 After=snapd.mounts-pre.target
 Before=snapd.mounts.target
-After=zfs-mount.service
 
 [Mount]
 What=%s
@@ -1292,7 +1289,6 @@ func (s *SystemdTestSuite) TestWriteSELinuxMountUnit(c *C) {
 Description=Mount unit for foo, revision 42
 After=snapd.mounts-pre.target
 Before=snapd.mounts.target
-After=zfs-mount.service
 
 [Mount]
 What=%s
@@ -1337,7 +1333,6 @@ exit 0
 Description=Mount unit for foo, revision x1
 After=snapd.mounts-pre.target
 Before=snapd.mounts.target
-After=zfs-mount.service
 
 [Mount]
 What=%s
@@ -1378,7 +1373,6 @@ exit 0
 Description=Mount unit for foo, revision x1
 After=snapd.mounts-pre.target
 Before=snapd.mounts.target
-After=zfs-mount.service
 
 [Mount]
 What=%s
@@ -1643,7 +1637,6 @@ const unitTemplate = `
 Description=Mount unit for foo, revision 42
 After=snapd.mounts-pre.target
 Before=snapd.mounts.target
-After=zfs-mount.service
 
 [Mount]
 What=%s

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -1169,9 +1169,11 @@ Description=Mount unit for foo, revision 42
 After=snapd.mounts-pre.target
 Before=snapd.mounts.target
 Before=local-fs.target
+Wants=snapd.loop-setup@%[1]s.service
+After=snapd.loop-setup@%[1]s.service
 
 [Mount]
-What=%s
+What=/dev/disk/by-backing-file/%[1]s
 Where=/snap/snapname/123
 Type=squashfs
 Options=nodev,ro,x-gdu.hide,x-gvfs-hide
@@ -1180,7 +1182,7 @@ LazyUnmount=yes
 [Install]
 WantedBy=snapd.mounts.target
 WantedBy=multi-user.target
-`[1:], mockSnapPath))
+`[1:], EscapeUnitNamePath(mockSnapPath)))
 
 	c.Assert(s.argses, DeepEquals, [][]string{
 		{"daemon-reload"},
@@ -1253,9 +1255,11 @@ Description=Mount unit for foo via bar
 After=snapd.mounts-pre.target
 Before=snapd.mounts.target
 Before=local-fs.target
+Wants=snapd.loop-setup@%[1]s.service
+After=snapd.loop-setup@%[1]s.service
 
 [Mount]
-What=%s
+What=/dev/disk/by-backing-file/%[1]s
 Where=/snap/snapname/345
 Type=squashfs
 Options=remount,ro
@@ -1265,7 +1269,7 @@ LazyUnmount=yes
 WantedBy=snapd.mounts.target
 WantedBy=multi-user.target
 X-SnapdOrigin=bar
-`[1:], mockSnapPath))
+`[1:], EscapeUnitNamePath(mockSnapPath)))
 
 	c.Assert(s.argses, DeepEquals, [][]string{
 		{"daemon-reload"},
@@ -1298,9 +1302,11 @@ Description=Mount unit for foo, revision 42
 After=snapd.mounts-pre.target
 Before=snapd.mounts.target
 Before=local-fs.target
+Wants=snapd.loop-setup@%[1]s.service
+After=snapd.loop-setup@%[1]s.service
 
 [Mount]
-What=%s
+What=/dev/disk/by-backing-file/%[1]s
 Where=/snap/snapname/123
 Type=squashfs
 Options=nodev,context=system_u:object_r:snappy_snap_t:s0,ro,x-gdu.hide,x-gvfs-hide
@@ -1309,7 +1315,7 @@ LazyUnmount=yes
 [Install]
 WantedBy=snapd.mounts.target
 WantedBy=multi-user.target
-`[1:], mockSnapPath))
+`[1:], EscapeUnitNamePath(mockSnapPath)))
 }
 
 func (s *SystemdTestSuite) TestFuseInContainer(c *C) {
@@ -1344,9 +1350,11 @@ Description=Mount unit for foo, revision x1
 After=snapd.mounts-pre.target
 Before=snapd.mounts.target
 Before=local-fs.target
+Wants=snapd.loop-setup@%[1]s.service
+After=snapd.loop-setup@%[1]s.service
 
 [Mount]
-What=%s
+What=/dev/disk/by-backing-file/%[1]s
 Where=/snap/snapname/123
 Type=fuse.squashfuse
 Options=nodev,ro,x-gdu.hide,x-gvfs-hide,allow_other
@@ -1355,7 +1363,7 @@ LazyUnmount=yes
 [Install]
 WantedBy=snapd.mounts.target
 WantedBy=multi-user.target
-`[1:], mockSnapPath))
+`[1:], EscapeUnitNamePath(mockSnapPath)))
 }
 
 func (s *SystemdTestSuite) TestFuseOutsideContainer(c *C) {
@@ -1386,9 +1394,11 @@ Description=Mount unit for foo, revision x1
 After=snapd.mounts-pre.target
 Before=snapd.mounts.target
 Before=local-fs.target
+Wants=snapd.loop-setup@%[1]s.service
+After=snapd.loop-setup@%[1]s.service
 
 [Mount]
-What=%s
+What=/dev/disk/by-backing-file/%[1]s
 Where=/snap/snapname/123
 Type=squashfs
 Options=nodev,ro,x-gdu.hide,x-gvfs-hide
@@ -1397,7 +1407,7 @@ LazyUnmount=yes
 [Install]
 WantedBy=snapd.mounts.target
 WantedBy=multi-user.target
-`[1:], mockSnapPath))
+`[1:], EscapeUnitNamePath(mockSnapPath)))
 }
 
 func (s *SystemdTestSuite) TestJctl(c *C) {
@@ -1652,12 +1662,14 @@ Description=Mount unit for foo, revision 42
 After=snapd.mounts-pre.target
 Before=snapd.mounts.target
 Before=local-fs.target
+Wants=snapd.loop-setup@%[1]s.service
+After=snapd.loop-setup@%[1]s.service
 
 [Mount]
-What=%s
+What=/dev/disk/by-backing-file/%[1]s
 Where=/snap/snapname/123
-Type=%s
-Options=%s
+Type=%[2]s
+Options=%[3]s
 LazyUnmount=yes
 
 [Install]
@@ -1689,7 +1701,7 @@ func (s *SystemdTestSuite) TestPreseedModeAddMountUnit(c *C) {
 	c.Check(osutil.IsSymlink(filepath.Join(dirs.SnapServicesDir, "snapd.mounts.target.wants", mountUnitName)), Equals, true)
 	// This is only to handle older version of snapd
 	c.Check(osutil.IsSymlink(filepath.Join(dirs.SnapServicesDir, "multi-user.target.wants", mountUnitName)), Equals, true)
-	c.Check(filepath.Join(dirs.SnapServicesDir, mountUnitName), testutil.FileEquals, fmt.Sprintf(unitTemplate[1:], mockSnapPath, "squashfs", "nodev,ro,x-gdu.hide,x-gvfs-hide"))
+	c.Check(filepath.Join(dirs.SnapServicesDir, mountUnitName), testutil.FileEquals, fmt.Sprintf(unitTemplate[1:], EscapeUnitNamePath(mockSnapPath), "squashfs", "nodev,ro,x-gdu.hide,x-gvfs-hide"))
 }
 
 func (s *SystemdTestSuite) TestPreseedModeAddMountUnitWithFuse(c *C) {
@@ -1709,7 +1721,7 @@ func (s *SystemdTestSuite) TestPreseedModeAddMountUnitWithFuse(c *C) {
 	defer os.Remove(mountUnitName)
 
 	c.Check(mockMountCmd.Calls()[0], DeepEquals, []string{"mount", "-t", "fuse.squashfuse", mockSnapPath, "/snap/snapname/123", "-o", "nodev,a,b,c"})
-	c.Check(filepath.Join(dirs.SnapServicesDir, mountUnitName), testutil.FileEquals, fmt.Sprintf(unitTemplate[1:], mockSnapPath, "squashfs", "nodev,ro,x-gdu.hide,x-gvfs-hide"))
+	c.Check(filepath.Join(dirs.SnapServicesDir, mountUnitName), testutil.FileEquals, fmt.Sprintf(unitTemplate[1:], EscapeUnitNamePath(mockSnapPath), "squashfs", "nodev,ro,x-gdu.hide,x-gvfs-hide"))
 }
 
 func (s *SystemdTestSuite) TestPreseedModeMountError(c *C) {

--- a/tests/core/config-defaults-once/task.yaml
+++ b/tests/core/config-defaults-once/task.yaml
@@ -81,7 +81,7 @@ restore: |
     if systemctl status "$sysp"; then
        systemctl stop "$sysp"
        rm -f "/etc/systemd/system/$sysp"
-       rm -f "/etc/systemd/system/multi-user.target.wants/$sysp"
+       rm -f "/etc/systemd/system/snapd.mounts.target.wants/$sysp"
        rm -f "/var/lib/snapd/snaps/${SNAP}"_*.snap
        rm -rf "/snap/$SNAP"
        systemctl daemon-reload

--- a/tests/core/config-defaults-once/task.yaml
+++ b/tests/core/config-defaults-once/task.yaml
@@ -81,6 +81,7 @@ restore: |
     if systemctl status "$sysp"; then
        systemctl stop "$sysp"
        rm -f "/etc/systemd/system/$sysp"
+       rm -f "/etc/systemd/system/multi-user.target.wants/$sysp"
        rm -f "/etc/systemd/system/snapd.mounts.target.wants/$sysp"
        rm -f "/var/lib/snapd/snaps/${SNAP}"_*.snap
        rm -rf "/snap/$SNAP"

--- a/tests/core/core-to-snapd-failover16/task.yaml
+++ b/tests/core/core-to-snapd-failover16/task.yaml
@@ -54,5 +54,8 @@ execute: |
 
     test ! -e /etc/systemd/system/snapd.service
     test ! -e /etc/systemd/system/usr-lib-snapd.mount
+    test ! -e /etc/systemd/system/snapd.mounts.target
+    test ! -e /etc/systemd/system/snapd.mounts-pre.target
+    test ! -e /etc/systemd/system/snap-snapd-x1.mount
     test ! -e /snap/snapd/x1
   done

--- a/tests/core/gadget-config-defaults-vitality/task.yaml
+++ b/tests/core/gadget-config-defaults-vitality/task.yaml
@@ -91,6 +91,7 @@ restore: |
        systemctl stop "$(systemd-escape --path "/snap/test-snapd-with-configure${SUFFIX}/$TEST_REVNO.mount")"
        rm -f "/etc/systemd/system/snap-test-snapd-with-configure${SUFFIX}-${TEST_REVNO}.mount"
        rm -f "/etc/systemd/system/snapd.mounts.target.wants/snap-test-snapd-with-configure${SUFFIX}-${TEST_REVNO}.mount"
+       rm -f "/etc/systemd/system/multi-user.target.wants/snap-test-snapd-with-configure${SUFFIX}-${TEST_REVNO}.mount"
        rm -f "/var/lib/snapd/snaps/test-snapd-with-configure${SUFFIX}"_*.snap
        systemctl daemon-reload
     fi

--- a/tests/core/gadget-config-defaults-vitality/task.yaml
+++ b/tests/core/gadget-config-defaults-vitality/task.yaml
@@ -90,7 +90,7 @@ restore: |
     if systemctl status "$(systemd-escape --path "/snap/test-snapd-with-configure${SUFFIX}/$TEST_REVNO.mount")"; then
        systemctl stop "$(systemd-escape --path "/snap/test-snapd-with-configure${SUFFIX}/$TEST_REVNO.mount")"
        rm -f "/etc/systemd/system/snap-test-snapd-with-configure${SUFFIX}-${TEST_REVNO}.mount"
-       rm -f "/etc/systemd/system/multi-user.target.wants/snap-test-snapd-with-configure${SUFFIX}-${TEST_REVNO}.mount"
+       rm -f "/etc/systemd/system/snapd.mounts.target.wants/snap-test-snapd-with-configure${SUFFIX}-${TEST_REVNO}.mount"
        rm -f "/var/lib/snapd/snaps/test-snapd-with-configure${SUFFIX}"_*.snap
        systemctl daemon-reload
     fi

--- a/tests/core/gadget-config-defaults/task.yaml
+++ b/tests/core/gadget-config-defaults/task.yaml
@@ -121,6 +121,7 @@ restore: |
        systemctl stop "$(systemd-escape --path "/snap/test-snapd-with-configure${SUFFIX}/$TEST_REVNO.mount")"
        rm -f "/etc/systemd/system/snap-test-snapd-with-configure${SUFFIX}-${TEST_REVNO}.mount"
        rm -f "/etc/systemd/system/snapd.mounts.target.wants/snap-test-snapd-with-configure${SUFFIX}-${TEST_REVNO}.mount"
+       rm -f "/etc/systemd/system/multi-user.target.wants/snap-test-snapd-with-configure${SUFFIX}-${TEST_REVNO}.mount"
        rm -f "/var/lib/snapd/snaps/test-snapd-with-configure${SUFFIX}"_*.snap
        systemctl daemon-reload
     fi

--- a/tests/core/gadget-config-defaults/task.yaml
+++ b/tests/core/gadget-config-defaults/task.yaml
@@ -120,7 +120,7 @@ restore: |
     if systemctl status "$(systemd-escape --path "/snap/test-snapd-with-configure${SUFFIX}/$TEST_REVNO.mount")"; then
        systemctl stop "$(systemd-escape --path "/snap/test-snapd-with-configure${SUFFIX}/$TEST_REVNO.mount")"
        rm -f "/etc/systemd/system/snap-test-snapd-with-configure${SUFFIX}-${TEST_REVNO}.mount"
-       rm -f "/etc/systemd/system/multi-user.target.wants/snap-test-snapd-with-configure${SUFFIX}-${TEST_REVNO}.mount"
+       rm -f "/etc/systemd/system/snapd.mounts.target.wants/snap-test-snapd-with-configure${SUFFIX}-${TEST_REVNO}.mount"
        rm -f "/var/lib/snapd/snaps/test-snapd-with-configure${SUFFIX}"_*.snap
        systemctl daemon-reload
     fi

--- a/tests/core/snapd-failover/task.yaml
+++ b/tests/core/snapd-failover/task.yaml
@@ -137,6 +137,7 @@ execute: |
             rm -f /etc/systemd/system/snapd.*.{service,timer,socket}
             rm -f /etc/systemd/system/*.wants/snapd.*.{service,timer,socket}
             rm -f /etc/systemd/system/snapd.mounts.target.wants/snap-snapd-*.mount
+            rm -f /etc/systemd/system/multi-user.target.wants/snap-snapd-*.mount
             systemctl daemon-reload
             # this will have the "snapd" snap /usr/lib/snapd bind mounted
             umount --lazy /usr/lib/snapd

--- a/tests/core/snapd-failover/task.yaml
+++ b/tests/core/snapd-failover/task.yaml
@@ -136,6 +136,7 @@ execute: |
             rm -f /etc/systemd/system/snapd.{service,timer,socket}
             rm -f /etc/systemd/system/snapd.*.{service,timer,socket}
             rm -f /etc/systemd/system/*.wants/snapd.*.{service,timer,socket}
+            rm -f /etc/systemd/system/snapd.mounts.target.wants/snap-snapd-*.mount
             systemctl daemon-reload
             # this will have the "snapd" snap /usr/lib/snapd bind mounted
             umount --lazy /usr/lib/snapd

--- a/tests/core/snapd16/task.yaml
+++ b/tests/core/snapd16/task.yaml
@@ -60,6 +60,7 @@ execute: |
         rm -f /etc/systemd/system/snapd.*.{service,timer,socket}
         rm -f /etc/systemd/system/*.wants/snapd.*.{service,timer,socket}
         rm -f /etc/systemd/system/snapd.mounts.target.wants/snap-snapd-*.mount
+        rm -f /etc/systemd/system/multi-user.target.wants/snap-snapd-*.mount
         systemctl daemon-reload
         # this will have the "snapd" snap /usr/lib/snapd bind mounted
         umount --lazy /usr/lib/snapd

--- a/tests/core/snapd16/task.yaml
+++ b/tests/core/snapd16/task.yaml
@@ -59,6 +59,7 @@ execute: |
         rm -f /etc/systemd/system/snapd.{service,timer,socket}
         rm -f /etc/systemd/system/snapd.*.{service,timer,socket}
         rm -f /etc/systemd/system/*.wants/snapd.*.{service,timer,socket}
+        rm -f /etc/systemd/system/snapd.mounts.target.wants/snap-snapd-*.mount
         systemctl daemon-reload
         # this will have the "snapd" snap /usr/lib/snapd bind mounted
         umount --lazy /usr/lib/snapd

--- a/tests/lib/core-config.sh
+++ b/tests/lib/core-config.sh
@@ -70,6 +70,7 @@ restore_pc_snap(){
        systemctl stop snap-pc-x1.mount
        rm -f /etc/systemd/system/snap-pc-x1.mount
        rm -f /etc/systemd/system/snapd.mounts.target.wants/snap-pc-x1.mount
+       rm -f /etc/systemd/system/multi-user.target.wants/snap-pc-x1.mount
        rm -f /var/lib/snapd/snaps/pc_x1.snap
        systemctl daemon-reload
     fi

--- a/tests/lib/core-config.sh
+++ b/tests/lib/core-config.sh
@@ -69,7 +69,7 @@ restore_pc_snap(){
     if systemctl status snap-pc-x1.mount ; then
        systemctl stop snap-pc-x1.mount
        rm -f /etc/systemd/system/snap-pc-x1.mount
-       rm -f /etc/systemd/system/multi-user.target.wants/snap-pc-x1.mount
+       rm -f /etc/systemd/system/snapd.mounts.target.wants/snap-pc-x1.mount
        rm -f /var/lib/snapd/snaps/pc_x1.snap
        systemctl daemon-reload
     fi

--- a/tests/lib/state.sh
+++ b/tests/lib/state.sh
@@ -60,7 +60,7 @@ save_snapd_state() {
             /var/cache/snapd \
             "$SNAP_MOUNT_DIR" \
             /etc/systemd/system/"$escaped_snap_mount_dir"-*core*.mount \
-            /etc/systemd/system/multi-user.target.wants/"$escaped_snap_mount_dir"-*core*.mount \
+            /etc/systemd/system/snapd.mounts.target.wants/"$escaped_snap_mount_dir"-*core*.mount \
             $snap_confine_profiles \
             $snapd_env \
             $snapd_service_env

--- a/tests/lib/state.sh
+++ b/tests/lib/state.sh
@@ -61,6 +61,7 @@ save_snapd_state() {
             "$SNAP_MOUNT_DIR" \
             /etc/systemd/system/"$escaped_snap_mount_dir"-*core*.mount \
             /etc/systemd/system/snapd.mounts.target.wants/"$escaped_snap_mount_dir"-*core*.mount \
+            /etc/systemd/system/multi-user.target.wants/"$escaped_snap_mount_dir"-*core*.mount \
             $snap_confine_profiles \
             $snapd_env \
             $snapd_service_env

--- a/tests/main/basic-target-socket-activation/task.yaml
+++ b/tests/main/basic-target-socket-activation/task.yaml
@@ -1,0 +1,72 @@
+summary: Check that mounts are mounted correctly if snapd gets activated
+
+details: |
+  When booting with basic.target for example, snap mounts are not
+  mounted.  But sockets.target is active, which means snapd.socket
+  is. If a snap command is emitted, then snapd will start. But it
+  expects mounts to be there.
+
+systems: [ubuntu-2*]
+
+prepare: |
+  cat <<\EOF >/etc/default/grub.d/99-basic.cfg
+  # Use basic.target as default target
+  GRUB_CMDLINE_LINUX_DEFAULT="${GRUB_CMDLINE_LINUX_DEFAULT} systemd.unit=basic.target"
+  # spread will need to reconnnect to ssh
+  GRUB_CMDLINE_LINUX_DEFAULT="${GRUB_CMDLINE_LINUX_DEFAULT} systemd.wants=ssh.service"
+  # ... through network
+  GRUB_CMDLINE_LINUX_DEFAULT="${GRUB_CMDLINE_LINUX_DEFAULT} systemd.wants=systemd-networkd.service"
+  # .. as a non-system user
+  GRUB_CMDLINE_LINUX_DEFAULT="${GRUB_CMDLINE_LINUX_DEFAULT} systemd.wants=systemd-user-sessions.service"
+  EOF
+
+  update-grub
+
+restore: |
+  if [ "${SPREAD_REBOOT}" = 0 ]; then
+
+    rm -f /etc/default/grub.d/99-basic.cfg
+    update-grub
+
+    if MATCH 'systemd[.]unit=basic[.]target' </proc/cmdline; then
+      REBOOT
+    fi
+
+  fi
+
+execute: |
+  if [ "${SPREAD_REBOOT}" = 0 ]; then
+
+    REBOOT
+
+  else
+
+    # Wait for systemd to have finished booting
+    systemctl --wait is-system-running | MATCH 'running'
+
+    MATCH 'systemd[.]unit=basic[.]target' </proc/cmdline
+
+    # basic.target and snapd.socket should be active
+    systemctl is-active basic.target
+    systemctl is-active snapd.socket
+
+    # ... but snapd.service and  multi-user.target should not.
+    not systemctl is-active multi-user.target
+    not systemctl is-active snapd.service
+
+    # Let's emit a snap command. That will start snapd.
+    snap list
+
+    # multi-user should still be inactive but snapd active.
+    not systemctl is-active multi-user.target
+    systemctl is-active snapd.service
+
+    # the mounts should be active
+    systemctl show --all -p ActiveState 'snap-*.mount' | tee states.txt | MATCH 'ActiveState=active'
+    NOMATCH 'ActiveState=inactive' <states.txt
+
+    # bonus, we check we did not cheat, nothing should be installed to default.target
+    not [ -d /etc/systemd/system/default.target.wants ]
+    not [ -d /etc/systemd/system/default.target.requires ]
+
+  fi

--- a/tests/main/postrm-purge/task.yaml
+++ b/tests/main/postrm-purge/task.yaml
@@ -106,6 +106,8 @@ execute: |
     test -z "$(find /etc/systemd/system/multi-user.target.wants/ -name 'snap.test-snapd-service.*')"
     # shellcheck disable=SC2251
     ! test -d /etc/systemd/system/snapd.mounts.target.wants
+    # shellcheck disable=SC2251
+    ! test -d /etc/systemd/system/multi-user.target.wants
     test -z "$(find /etc/systemd/system/sockets.target.wants/ -name 'snap.*')"
     test -z "$(find /etc/systemd/system/timers.target.wants/ -name 'snap.*')"
     if ! os.query is-trusty; then

--- a/tests/main/postrm-purge/task.yaml
+++ b/tests/main/postrm-purge/task.yaml
@@ -104,6 +104,8 @@ execute: |
 
     echo "No dangling service symlinks are left behind"
     test -z "$(find /etc/systemd/system/multi-user.target.wants/ -name 'snap.test-snapd-service.*')"
+    # shellcheck disable=SC2251
+    ! test -d /etc/systemd/system/snapd.mounts.target.wants
     test -z "$(find /etc/systemd/system/sockets.target.wants/ -name 'snap.*')"
     test -z "$(find /etc/systemd/system/timers.target.wants/ -name 'snap.*')"
     if ! os.query is-trusty; then

--- a/tests/main/preseed-core20/task.yaml
+++ b/tests/main/preseed-core20/task.yaml
@@ -129,12 +129,16 @@ execute: |
 
   MATCH "^etc/systemd/system/multi-user.target.wants/snapd.core-fixup.service" < files.log
   MATCH "^etc/systemd/system/snapd.mounts.target.wants/snap-pc-.*.mount" < files.log
+  MATCH "^etc/systemd/system/multi-user.target.wants/snap-pc-.*.mount" < files.log
   MATCH "^etc/systemd/system/multi-user.target.wants/snapd.spread-tests-run-mode-tweaks.service" < files.log
   MATCH "^etc/systemd/system/snapd.mounts.target.wants/snap-pc.*kernel-.*.mount" < files.log
+  MATCH "^etc/systemd/system/multi-user.target.wants/snap-pc.*kernel-.*.mount" < files.log
   MATCH "^etc/systemd/system/multi-user.target.wants/snapd.autoimport.service" < files.log
   MATCH "^etc/systemd/system/multi-user.target.wants/snapd.apparmor.service" < files.log
   MATCH "^etc/systemd/system/snapd.mounts.target.wants/snap-core20-.*.mount" < files.log
+  MATCH "^etc/systemd/system/multi-user.target.wants/snap-core20-.*.mount" < files.log
   MATCH "^etc/systemd/system/snapd.mounts.target.wants/snap-snapd-.*.mount" < files.log
+  MATCH "^etc/systemd/system/multi-user.target.wants/snap-snapd-.*.mount" < files.log
   MATCH "^etc/systemd/system/multi-user.target.wants/snapd.seeded.service" < files.log
   MATCH "^etc/systemd/system/multi-user.target.wants/snapd.recovery-chooser-trigger.service" < files.log
   MATCH "^etc/systemd/system/multi-user.target.wants/snapd.service" < files.log

--- a/tests/main/preseed-core20/task.yaml
+++ b/tests/main/preseed-core20/task.yaml
@@ -128,13 +128,13 @@ execute: |
   MATCH "^etc/systemd/system/snapd.service" < files.log
 
   MATCH "^etc/systemd/system/multi-user.target.wants/snapd.core-fixup.service" < files.log
-  MATCH "^etc/systemd/system/multi-user.target.wants/snap-pc-.*.mount" < files.log
+  MATCH "^etc/systemd/system/snapd.mounts.target.wants/snap-pc-.*.mount" < files.log
   MATCH "^etc/systemd/system/multi-user.target.wants/snapd.spread-tests-run-mode-tweaks.service" < files.log
-  MATCH "^etc/systemd/system/multi-user.target.wants/snap-pc.*kernel-.*.mount" < files.log
+  MATCH "^etc/systemd/system/snapd.mounts.target.wants/snap-pc.*kernel-.*.mount" < files.log
   MATCH "^etc/systemd/system/multi-user.target.wants/snapd.autoimport.service" < files.log
   MATCH "^etc/systemd/system/multi-user.target.wants/snapd.apparmor.service" < files.log
-  MATCH "^etc/systemd/system/multi-user.target.wants/snap-core20-.*.mount" < files.log
-  MATCH "^etc/systemd/system/multi-user.target.wants/snap-snapd-.*.mount" < files.log
+  MATCH "^etc/systemd/system/snapd.mounts.target.wants/snap-core20-.*.mount" < files.log
+  MATCH "^etc/systemd/system/snapd.mounts.target.wants/snap-snapd-.*.mount" < files.log
   MATCH "^etc/systemd/system/multi-user.target.wants/snapd.seeded.service" < files.log
   MATCH "^etc/systemd/system/multi-user.target.wants/snapd.recovery-chooser-trigger.service" < files.log
   MATCH "^etc/systemd/system/multi-user.target.wants/snapd.service" < files.log

--- a/tests/main/preseed/task.yaml
+++ b/tests/main/preseed/task.yaml
@@ -122,15 +122,15 @@ execute: |
   echo "Checking that mount units have been created and enabled on the target image"
   SYSTEMD_UNITS="$IMAGE_MOUNTPOINT"/etc/systemd
   test -f "$SYSTEMD_UNITS"/system/snap-lxd-*.mount
-  test -L "$SYSTEMD_UNITS"/system/multi-user.target.wants/snap-lxd-*.mount
+  test -L "$SYSTEMD_UNITS"/system/snapd.mounts.target.wants/snap-lxd-*.mount
   test -f "$SYSTEMD_UNITS"/system/snap-snapd-*.mount
   test -f "$SYSTEMD_UNITS"/system/snap-"${LXD_BASE_SNAP}"-*.mount
-  test -L "$SYSTEMD_UNITS"/system/multi-user.target.wants/snap-"${LXD_BASE_SNAP}"-*.mount
-  test -L "$SYSTEMD_UNITS"/system/multi-user.target.wants/snap-snapd-*.mount
+  test -L "$SYSTEMD_UNITS"/system/snapd.mounts.target.wants/snap-"${LXD_BASE_SNAP}"-*.mount
+  test -L "$SYSTEMD_UNITS"/system/snapd.mounts.target.wants/snap-snapd-*.mount
 
   for unit in snap.lxd.daemon.service snap.lxd.daemon.unix.socket snap.lxd.activate.service; do
     test -f "$SYSTEMD_UNITS/system/$unit"
   done
 
   echo "LXD service shouldn't be enabled at this point"
-  test ! -e "$SYSTEMD_UNITS"/system/multi-user.target.wants/snap.lxd.activate.service
+  test ! -e "$SYSTEMD_UNITS"/system/snapd.mounts.target.wants/snap.lxd.activate.service

--- a/tests/main/preseed/task.yaml
+++ b/tests/main/preseed/task.yaml
@@ -123,10 +123,13 @@ execute: |
   SYSTEMD_UNITS="$IMAGE_MOUNTPOINT"/etc/systemd
   test -f "$SYSTEMD_UNITS"/system/snap-lxd-*.mount
   test -L "$SYSTEMD_UNITS"/system/snapd.mounts.target.wants/snap-lxd-*.mount
+  test -L "$SYSTEMD_UNITS"/system/multi-user.target.wants/snap-lxd-*.mount
   test -f "$SYSTEMD_UNITS"/system/snap-snapd-*.mount
   test -f "$SYSTEMD_UNITS"/system/snap-"${LXD_BASE_SNAP}"-*.mount
   test -L "$SYSTEMD_UNITS"/system/snapd.mounts.target.wants/snap-"${LXD_BASE_SNAP}"-*.mount
+  test -L "$SYSTEMD_UNITS"/system/multi-user.target.wants/snap-"${LXD_BASE_SNAP}"-*.mount
   test -L "$SYSTEMD_UNITS"/system/snapd.mounts.target.wants/snap-snapd-*.mount
+  test -L "$SYSTEMD_UNITS"/system/multi-user.target.wants/snap-snapd-*.mount
 
   for unit in snap.lxd.daemon.service snap.lxd.daemon.unix.socket snap.lxd.activate.service; do
     test -f "$SYSTEMD_UNITS/system/$unit"
@@ -134,3 +137,4 @@ execute: |
 
   echo "LXD service shouldn't be enabled at this point"
   test ! -e "$SYSTEMD_UNITS"/system/snapd.mounts.target.wants/snap.lxd.activate.service
+  test ! -e "$SYSTEMD_UNITS"/system/multi-user.target.wants/snap.lxd.activate.service

--- a/tests/main/snap-mgmt/task.yaml
+++ b/tests/main/snap-mgmt/task.yaml
@@ -134,6 +134,8 @@ execute: |
     test -z "$(find /etc/systemd/system/multi-user.target.wants/ -name 'snap.test-snapd-service.*')"
     # shellcheck disable=SC2251
     ! test -d /etc/systemd/system/snapd.mounts.target.wants
+    # shellcheck disable=SC2251
+    ! test -d /etc/systemd/system/multi-user.target.wants
     test -z "$(find /etc/systemd/system/sockets.target.wants/ -name 'snap.*')"
     test -z "$(find /etc/systemd/system/timers.target.wants/ -name 'snap.*')"
     if ! os.query is-trusty; then

--- a/tests/main/snap-mgmt/task.yaml
+++ b/tests/main/snap-mgmt/task.yaml
@@ -132,6 +132,8 @@ execute: |
 
     echo "No dangling service symlinks are left behind"
     test -z "$(find /etc/systemd/system/multi-user.target.wants/ -name 'snap.test-snapd-service.*')"
+    # shellcheck disable=SC2251
+    ! test -d /etc/systemd/system/snapd.mounts.target.wants
     test -z "$(find /etc/systemd/system/sockets.target.wants/ -name 'snap.*')"
     test -z "$(find /etc/systemd/system/timers.target.wants/ -name 'snap.*')"
     if ! os.query is-trusty; then

--- a/wrappers/core18.go
+++ b/wrappers/core18.go
@@ -180,8 +180,13 @@ func AddSnapdSnapServices(s *snap.Info, opts *AddSnapdSnapServicesOptions, inter
 	if err != nil {
 		return err
 	}
+	targetUnits, err := filepath.Glob(filepath.Join(s.MountDir(), "lib/systemd/system/*.target"))
+	if err != nil {
+		return err
+	}
 	units := append(socketUnits, serviceUnits...)
 	units = append(units, timerUnits...)
+	units = append(units, targetUnits...)
 
 	snapdUnits := make(map[string]osutil.FileState, len(units)+1)
 	for _, unit := range units {
@@ -206,7 +211,7 @@ func AddSnapdSnapServices(s *snap.Info, opts *AddSnapdSnapServicesOptions, inter
 			Mode:    st.Mode(),
 		}
 	}
-	globs := []string{"snapd.service", "snapd.socket", "snapd.*.service", "snapd.*.timer"}
+	globs := []string{"snapd.service", "snapd.socket", "snapd.*.service", "snapd.*.timer", "snapd.*.target"}
 	changed, removed, err := osutil.EnsureDirStateGlobs(dirs.SnapServicesDir, globs, snapdUnits)
 	if err != nil {
 		// TODO: uhhhh, what do we do in this case?
@@ -352,8 +357,13 @@ func undoSnapdServicesOnCore(s *snap.Info, sysd systemd.Systemd) error {
 	if err != nil {
 		return err
 	}
+	targetUnits, err := filepath.Glob(filepath.Join(s.MountDir(), "lib/systemd/system/*.target"))
+	if err != nil {
+		return err
+	}
 	units := append(socketUnits, serviceUnits...)
 	units = append(units, timerUnits...)
+	units = append(units, targetUnits...)
 
 	for _, snapdUnit := range units {
 		sysdUnit := filepath.Base(snapdUnit)


### PR DESCRIPTION
Not to be merged. For the moment this is only for profiling of direct-io loop devices.

There are commits from #12037 in this branch.