### PR TITLE
many: implementation file monitoring for snap cgroups

### DIFF
--- a/osutil/inotify/LICENSE
+++ b/osutil/inotify/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/osutil/inotify/PATENTS
+++ b/osutil/inotify/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/osutil/inotify/README.md
+++ b/osutil/inotify/README.md
@@ -1,0 +1,1 @@
+These files were downloaded from https://github.com/kubernetes/utils/tree/master/inotify

--- a/osutil/inotify/inotify.go
+++ b/osutil/inotify/inotify.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inotify
+
+import (
+	"os"
+	"sync"
+)
+
+// Event represents a notification
+type Event struct {
+	Mask   uint32 // Mask of events
+	Cookie uint32 // Unique cookie associating related events (for rename(2))
+	Name   string // File name (optional)
+}
+
+type watch struct {
+	wd    uint32 // Watch descriptor (as returned by the inotify_add_watch() syscall)
+	flags uint32 // inotify flags of this watch (see inotify(7) for the list of valid flags)
+}
+
+// Watcher represents an inotify instance
+type Watcher struct {
+	mu         sync.Mutex
+	fd         int               // File descriptor (as returned by the inotify_init() syscall)
+	notifyFile os.File           // An os.File object mapped onto the inotify file descriptor
+	watches    map[string]*watch // Map of inotify watches (key: path)
+	paths      map[int]string    // Map of watched paths (key: watch descriptor)
+	Error      chan error        // Errors are sent on this channel
+	Event      chan *Event       // Events are returned on this channel
+	done       chan bool         // Channel for sending a "quit message" to the reader goroutine
+	isClosed   bool              // Set to true when Close() is first called
+}

--- a/osutil/inotify/inotify_linux.go
+++ b/osutil/inotify/inotify_linux.go
@@ -1,0 +1,311 @@
+//go:build linux
+// +build linux
+
+// Copyright 2010 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+/*
+Package inotify implements a wrapper for the Linux inotify system.
+
+Example:
+
+	watcher, err := inotify.NewWatcher()
+	if err != nil {
+	    log.Fatal(err)
+	}
+	err = watcher.Watch("/tmp")
+	if err != nil {
+	    log.Fatal(err)
+	}
+	for {
+	    select {
+	    case ev := <-watcher.Event:
+	        log.Println("event:", ev)
+	    case err := <-watcher.Error:
+	        log.Println("error:", err)
+	    }
+	}
+*/
+package inotify
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"syscall"
+	"unsafe"
+)
+
+// NewWatcher creates and returns a new inotify instance using inotify_init(2)
+func NewWatcher() (*Watcher, error) {
+	fd, errno := syscall.InotifyInit1(syscall.IN_CLOEXEC | syscall.IN_NONBLOCK)
+	if fd == -1 {
+		return nil, os.NewSyscallError("inotify_init", errno)
+	}
+	w := &Watcher{
+		fd:         fd,
+		notifyFile: *os.NewFile(uintptr(fd), ""),
+		watches:    make(map[string]*watch),
+		paths:      make(map[int]string),
+		Event:      make(chan *Event),
+		Error:      make(chan error),
+		done:       make(chan bool),
+	}
+
+	go w.readEvents()
+	return w, nil
+}
+
+// Close closes an inotify watcher instance
+// It sends a message to the reader goroutine to quit and removes all watches
+// associated with the inotify instance
+func (w *Watcher) Close() error {
+	if w.isClosed {
+		return nil
+	}
+	w.isClosed = true
+	for path := range w.watches {
+		w.RemoveWatch(path)
+	}
+	close(w.done)
+	w.notifyFile.Close()
+	return nil
+}
+
+// AddWatch adds path to the watched file set.
+// The flags are interpreted as described in inotify_add_watch(2).
+func (w *Watcher) AddWatch(path string, flags uint32) error {
+	if w.isClosed {
+		return errors.New("inotify instance already closed")
+	}
+
+	watchEntry, found := w.watches[path]
+	if found {
+		watchEntry.flags |= flags
+		flags |= syscall.IN_MASK_ADD
+	}
+
+	w.mu.Lock() // synchronize with readEvents goroutine
+
+	wd, err := syscall.InotifyAddWatch(w.fd, path, flags)
+	if err != nil {
+		w.mu.Unlock()
+		return &os.PathError{
+			Op:   "inotify_add_watch",
+			Path: path,
+			Err:  err,
+		}
+	}
+
+	if !found {
+		w.watches[path] = &watch{wd: uint32(wd), flags: flags}
+		w.paths[wd] = path
+	}
+	w.mu.Unlock()
+	return nil
+}
+
+// Watch adds path to the watched file set, watching all events.
+func (w *Watcher) Watch(path string) error {
+	return w.AddWatch(path, InAllEvents)
+}
+
+// RemoveWatch removes path from the watched file set.
+func (w *Watcher) RemoveWatch(path string) error {
+	watch, ok := w.watches[path]
+	if !ok {
+		return fmt.Errorf("can't remove non-existent inotify watch for: %s", path)
+	}
+	success, errno := syscall.InotifyRmWatch(w.fd, watch.wd)
+	if success == -1 {
+		// when file descriptor or watch descriptor not found, InotifyRmWatch syscall return EINVAL error
+		// if return error, it may lead this path remain in watches and paths map, and no other event can trigger remove action.
+		if errno != syscall.EINVAL {
+			return os.NewSyscallError("inotify_rm_watch", errno)
+		}
+	}
+	delete(w.watches, path)
+	// Locking here to protect the read from paths in readEvents.
+	w.mu.Lock()
+	delete(w.paths, int(watch.wd))
+	w.mu.Unlock()
+	return nil
+}
+
+// readEvents reads from the inotify file descriptor, converts the
+// received events into Event objects and sends them via the Event channel
+func (w *Watcher) readEvents() {
+	var buf [syscall.SizeofInotifyEvent * 4096]byte
+	defer func() {
+		// Close w.Event first.
+		close(w.Event)
+		close(w.Error)
+	}()
+
+	for {
+		// wait until there are events from the kernel
+		n, err := w.notifyFile.Read(buf[:])
+
+		// If EOF is received
+		if n == 0 {
+			return
+		}
+		if n < 0 {
+			select {
+			case w.Error <- os.NewSyscallError("read", err):
+				continue
+			case <-w.done:
+				return
+			}
+		}
+
+		var offset uint32
+		// We don't know how many events we just read into the buffer
+		// While the offset points to at least one whole event...
+		for offset <= uint32(n-syscall.SizeofInotifyEvent) {
+			// Point "raw" to the event in the buffer
+			raw := (*syscall.InotifyEvent)(unsafe.Pointer(&buf[offset]))
+			event := new(Event)
+			event.Mask = uint32(raw.Mask)
+			event.Cookie = uint32(raw.Cookie)
+			nameLen := uint32(raw.Len)
+			// The raw event received from the kernel contains only the file/folder name, but
+			// not the full path. To fix this, and fill the Event.Name field with the complete
+			// path of the file/folder, we retrieve it from the "paths" map using the Watch
+			// Descriptor (which is the one returned by InotifyAddWatch when we added the
+			// file/folder to being monitored).
+			w.mu.Lock()
+			name, ok := w.paths[int(raw.Wd)]
+			w.mu.Unlock()
+			if ok {
+				event.Name = name
+				if nameLen > 0 {
+					// Point "bytes" at the first byte of the filename
+					bytes := buf[offset+syscall.SizeofInotifyEvent : offset+syscall.SizeofInotifyEvent+nameLen]
+					// The filename is padded with NUL bytes. TrimRight() gets rid of those.
+					event.Name += "/" + strings.TrimRight(string(bytes), "\000")
+				}
+				// Send the event on the events channel
+				select {
+				case w.Event <- event:
+				case <-w.done:
+					return
+				}
+			}
+			// Move to the next event in the buffer
+			offset += syscall.SizeofInotifyEvent + nameLen
+		}
+	}
+}
+
+// String formats the event e in the form
+// "filename: 0xEventMask = IN_ACCESS|IN_ATTRIB_|..."
+func (e *Event) String() string {
+	var events string
+
+	m := e.Mask
+	for _, b := range eventBits {
+		if m&b.Value == b.Value {
+			m &^= b.Value
+			events += "|" + b.Name
+		}
+	}
+
+	if m != 0 {
+		events += fmt.Sprintf("|%#x", m)
+	}
+	if len(events) > 0 {
+		events = " == " + events[1:]
+	}
+
+	return fmt.Sprintf("%q: %#x%s", e.Name, e.Mask, events)
+}
+
+const (
+	// Options for inotify_init() are not exported
+	// IN_CLOEXEC    uint32 = syscall.IN_CLOEXEC
+	// IN_NONBLOCK   uint32 = syscall.IN_NONBLOCK
+
+	// Options for AddWatch
+
+	// InDontFollow : Don't dereference pathname if it is a symbolic link
+	InDontFollow uint32 = syscall.IN_DONT_FOLLOW
+	// InOneshot : Monitor the filesystem object corresponding to pathname for one event, then remove from watch list
+	InOneshot uint32 = syscall.IN_ONESHOT
+	// InOnlydir : Watch pathname only if it is a directory
+	InOnlydir uint32 = syscall.IN_ONLYDIR
+
+	// The "IN_MASK_ADD" option is not exported, as AddWatch
+	// adds it automatically, if there is already a watch for the given path
+	// IN_MASK_ADD      uint32 = syscall.IN_MASK_ADD
+
+	// Events
+
+	// InAccess : File was accessed
+	InAccess uint32 = syscall.IN_ACCESS
+	// InAllEvents : Bit mask for all notify events
+	InAllEvents uint32 = syscall.IN_ALL_EVENTS
+	// InAttrib : Metadata changed
+	InAttrib uint32 = syscall.IN_ATTRIB
+	// InClose : Equates to IN_CLOSE_WRITE | IN_CLOSE_NOWRITE
+	InClose uint32 = syscall.IN_CLOSE
+	// InCloseNowrite : File or directory not opened for writing was closed
+	InCloseNowrite uint32 = syscall.IN_CLOSE_NOWRITE
+	// InCloseWrite : File opened for writing was closed
+	InCloseWrite uint32 = syscall.IN_CLOSE_WRITE
+	// InCreate : File/directory created in watched directory
+	InCreate uint32 = syscall.IN_CREATE
+	// InDelete : File/directory deleted from watched directory
+	InDelete uint32 = syscall.IN_DELETE
+	// InDeleteSelf : Watched file/directory was itself deleted
+	InDeleteSelf uint32 = syscall.IN_DELETE_SELF
+	// InModify : File was modified
+	InModify uint32 = syscall.IN_MODIFY
+	// InMove : Equates to IN_MOVED_FROM | IN_MOVED_TO
+	InMove uint32 = syscall.IN_MOVE
+	// InMovedFrom : Generated for the directory containing the old filename when a file is renamed
+	InMovedFrom uint32 = syscall.IN_MOVED_FROM
+	// InMovedTo : Generated for the directory containing the new filename when a file is renamed
+	InMovedTo uint32 = syscall.IN_MOVED_TO
+	// InMoveSelf : Watched file/directory was itself moved
+	InMoveSelf uint32 = syscall.IN_MOVE_SELF
+	// InOpen : File or directory was opened
+	InOpen uint32 = syscall.IN_OPEN
+
+	// Special events
+
+	// InIsdir : Subject of this event is a directory
+	InIsdir uint32 = syscall.IN_ISDIR
+	// InIgnored : Watch was removed explicitly or automatically
+	InIgnored uint32 = syscall.IN_IGNORED
+	// InQOverflow : Event queue overflowed
+	InQOverflow uint32 = syscall.IN_Q_OVERFLOW
+	// InUnmount : Filesystem containing watched object was unmounted
+	InUnmount uint32 = syscall.IN_UNMOUNT
+)
+
+var eventBits = []struct {
+	Value uint32
+	Name  string
+}{
+	{InAccess, "IN_ACCESS"},
+	{InAttrib, "IN_ATTRIB"},
+	{InClose, "IN_CLOSE"},
+	{InCloseNowrite, "IN_CLOSE_NOWRITE"},
+	{InCloseWrite, "IN_CLOSE_WRITE"},
+	{InCreate, "IN_CREATE"},
+	{InDelete, "IN_DELETE"},
+	{InDeleteSelf, "IN_DELETE_SELF"},
+	{InModify, "IN_MODIFY"},
+	{InMove, "IN_MOVE"},
+	{InMovedFrom, "IN_MOVED_FROM"},
+	{InMovedTo, "IN_MOVED_TO"},
+	{InMoveSelf, "IN_MOVE_SELF"},
+	{InOpen, "IN_OPEN"},
+	{InIsdir, "IN_ISDIR"},
+	{InIgnored, "IN_IGNORED"},
+	{InQOverflow, "IN_Q_OVERFLOW"},
+	{InUnmount, "IN_UNMOUNT"},
+}

--- a/osutil/inotify/inotify_linux_test.go
+++ b/osutil/inotify/inotify_linux_test.go
@@ -1,0 +1,142 @@
+//go:build linux
+// +build linux
+
+// Copyright 2010 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package inotify_test
+
+import (
+	"io/ioutil"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/snapcore/snapd/osutil/inotify"
+)
+
+func TestInotifyEvents(t *testing.T) {
+	// Create an inotify watcher instance and initialize it
+	watcher, err := inotify.NewWatcher()
+	if err != nil {
+		t.Fatalf("NewWatcher failed: %s", err)
+	}
+
+	dir, err := ioutil.TempDir("", "inotify")
+	if err != nil {
+		t.Fatalf("TempDir failed: %s", err)
+	}
+	defer os.RemoveAll(dir)
+
+	// Add a watch for "_test"
+	err = watcher.Watch(dir)
+	if err != nil {
+		t.Fatalf("Watch failed: %s", err)
+	}
+
+	// Receive errors on the error channel on a separate goroutine
+	go func() {
+		for err := range watcher.Error {
+			t.Errorf("error received: %s", err)
+		}
+	}()
+
+	testFile := dir + "/TestInotifyEvents.testfile"
+
+	// Receive events on the event channel on a separate goroutine
+	eventstream := watcher.Event
+	var eventsReceived int32
+	done := make(chan bool)
+	go func() {
+		for event := range eventstream {
+			// Only count relevant events
+			if event.Name == testFile {
+				atomic.AddInt32(&eventsReceived, 1)
+				t.Logf("event received: %s", event)
+			} else {
+				t.Logf("unexpected event received: %s", event)
+			}
+		}
+		done <- true
+	}()
+
+	// Create a file
+	// This should add at least one event to the inotify event queue
+	_, err = os.OpenFile(testFile, os.O_WRONLY|os.O_CREATE, 0666)
+	if err != nil {
+		t.Fatalf("creating test file: %s", err)
+	}
+
+	// We expect this event to be received almost immediately, but let's wait 1 s to be sure
+	time.Sleep(1 * time.Second)
+	if atomic.AddInt32(&eventsReceived, 0) == 0 {
+		t.Fatal("inotify event hasn't been received after 1 second")
+	}
+
+	// Try closing the inotify instance
+	t.Log("calling Close()")
+	watcher.Close()
+	t.Log("waiting for the event channel to become closed...")
+	select {
+	case <-done:
+		t.Log("event channel closed")
+	case <-time.After(1 * time.Second):
+		t.Fatal("event stream was not closed after 1 second")
+	}
+}
+
+func TestInotifyClose(t *testing.T) {
+	watcher, _ := inotify.NewWatcher()
+	watcher.Close()
+
+	done := make(chan bool)
+	go func() {
+		watcher.Close()
+		done <- true
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(50 * time.Millisecond):
+		t.Fatal("double Close() test failed: second Close() call didn't return")
+	}
+
+	err := watcher.Watch(os.TempDir())
+	if err == nil {
+		t.Fatal("expected error on Watch() after Close(), got nil")
+	}
+}
+
+func TestLockOnEvent(t *testing.T) {
+	watcher, err := inotify.NewWatcher()
+
+	if err != nil {
+		t.Fatalf("NewWatcher failed: %s", err)
+	}
+
+	dir, err := ioutil.TempDir("", "inotify")
+	if err != nil {
+		t.Fatalf("TempDir failed: %s", err)
+	}
+	defer os.RemoveAll(dir)
+
+	// Add a watch for "_test"
+	err = watcher.Watch(dir)
+	if err != nil {
+		t.Fatalf("Watch failed: %s", err)
+	}
+	os.Mkdir(dir+"/TestInotifyEvents.testfile", 0)
+	// wait one second to ensure that the event is created
+	time.Sleep(1 * time.Second)
+	// now close the watcher. It must close everything and unlock from the event
+	watcher.Close()
+	// wait another second to ensure that the thread is executed and everything is processed
+	time.Sleep(1 * time.Second)
+	// this must fail because the queue is closed
+	data, ok := <-watcher.Event
+	if (data != nil) || (ok != false) {
+		t.Fatalf("Watcher event queue isn't closed")
+	}
+}

--- a/osutil/inotify/inotify_others.go
+++ b/osutil/inotify/inotify_others.go
@@ -1,0 +1,60 @@
+//go:build !linux
+// +build !linux
+
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inotify // import "k8s.io/utils/inotify"
+
+import (
+	"fmt"
+	"runtime"
+)
+
+var errNotSupported = fmt.Errorf("watch not supported on %s", runtime.GOOS)
+
+const (
+	InDelete     uint32 = 0
+	InDeleteSelf uint32 = 0
+)
+
+// NewWatcher creates and returns a new inotify instance using inotify_init(2)
+func NewWatcher() (*Watcher, error) {
+	return nil, errNotSupported
+}
+
+// Close closes an inotify watcher instance
+// It sends a message to the reader goroutine to quit and removes all watches
+// associated with the inotify instance
+func (w *Watcher) Close() error {
+	return errNotSupported
+}
+
+// AddWatch adds path to the watched file set.
+// The flags are interpreted as described in inotify_add_watch(2).
+func (w *Watcher) AddWatch(path string, flags uint32) error {
+	return errNotSupported
+}
+
+// Watch adds path to the watched file set, watching all events.
+func (w *Watcher) Watch(path string) error {
+	return errNotSupported
+}
+
+// RemoveWatch removes path from the watched file set.
+func (w *Watcher) RemoveWatch(path string) error {
+	return errNotSupported
+}

--- a/sandbox/cgroup/export_test.go
+++ b/sandbox/cgroup/export_test.go
@@ -111,3 +111,7 @@ func MockCgroupsFilePath(path string) (restore func()) {
 	cgroupsFilePath = path
 	return r
 }
+
+func MonitorFullDelete(name string, folders []string, channel chan string) error {
+	return currentWatcher.monitorFullDelete(name, folders, channel)
+}

--- a/sandbox/cgroup/export_test.go
+++ b/sandbox/cgroup/export_test.go
@@ -112,6 +112,6 @@ func MockCgroupsFilePath(path string) (restore func()) {
 	return r
 }
 
-func MonitorFullDelete(name string, folders []string, channel chan string) error {
-	return currentWatcher.monitorFullDelete(name, folders, channel)
+func MonitorDelete(folders []string, name string, channel chan string) error {
+	return currentWatcher.monitorDelete(folders, name, channel)
 }

--- a/sandbox/cgroup/monitor.go
+++ b/sandbox/cgroup/monitor.go
@@ -76,10 +76,10 @@ var currentWatcher *inotifyWatcher = &inotifyWatcher{
 	addWatchChan: make(chan *groupToWatch),
 }
 
-func (gtw *groupToWatch) sendNotification() {
+func (gtw *groupToWatch) sendClosedNotification() {
 	defer func() {
 		if err := recover(); err != nil {
-			logger.Noticef("Failed to send Close notification for %s", gtw.name)
+			logger.Noticef("Failed to send Closed notification for %s", gtw.name)
 		}
 	}()
 	gtw.channel <- gtw.name
@@ -110,7 +110,7 @@ func (iw *inotifyWatcher) addWatch(newWatch *groupToWatch) {
 		}
 	}
 	if len(folderList) == 0 {
-		newWatch.sendNotification()
+		newWatch.sendClosedNotification()
 	} else {
 		newWatch.folders = folderList
 		iw.groupList = append(iw.groupList, newWatch)
@@ -143,7 +143,7 @@ func (iw *inotifyWatcher) processDeletedPath(watch *groupToWatch, deletedPath st
 	if len(watch.folders) == 0 {
 		// if all the files/folders of this CGroup have been deleted, notify the
 		// client that it is done.
-		watch.sendNotification()
+		watch.sendClosedNotification()
 		return false
 	}
 	return true

--- a/sandbox/cgroup/monitor.go
+++ b/sandbox/cgroup/monitor.go
@@ -47,7 +47,7 @@ type inotifyWatcher struct {
 	// time a new CGroup paths have to be monitored, the parent paths are
 	// checked in the map, and if they already exist, the usage counter is
 	// incremented by one (of course, if a parent path isn't in the map,
-	// it is initialized to 'one'). Every time the path of a CGroup is deleted,
+	// it is initialized to one). Every time the path of a CGroup is deleted,
 	// the corresponding usage counter here corresponding to the parent path
 	// is decremented, and when it reaches zero, it is removed and inotify is
 	// notified to stop monitoring it.

--- a/sandbox/cgroup/monitor.go
+++ b/sandbox/cgroup/monitor.go
@@ -175,11 +175,9 @@ func (iw *inotifyWatcher) monitorDelete(folders []string, name string, channel c
 	return nil
 }
 
-// MonitorSnapEnded is the method to call to monitor the running instances of an specific Snap.
-// It receives the name of the snap to monitor (for example, "firefox" or "steam")
-// and a channel. The caller can wait on the channel, and when all the instances of
-// the specific snap have ended, the name of the snap will be sent through the channel.
-// This allows to use the same channel to monitor several snaps
+// MonitorSnapEnded monitors the running instances of a snap. Once all 
+// instances of the snap have stopped, its name is pushed through the supplied 
+// channel. This allows the caller to use the same channel to monitor several snaps.
 func MonitorSnapEnded(snapName string, channel chan string) error {
 	options := InstancePathsOptions{
 		ReturnCGroupPath: true,

--- a/sandbox/cgroup/monitor.go
+++ b/sandbox/cgroup/monitor.go
@@ -128,6 +128,7 @@ func (iw *inotifyWatcher) processDeletedPath(watch *groupToWatch, deletedPath st
 			// in this CGroup (by not adding it to tmpFolders)
 			iw.removePath(fullPath)
 			watch.folders = append(watch.folders[:i], watch.folders[i+1:]...)
+			break
 		}
 	}
 	if len(watch.folders) == 0 {

--- a/sandbox/cgroup/monitor.go
+++ b/sandbox/cgroup/monitor.go
@@ -1,0 +1,194 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package cgroup
+
+import (
+	"errors"
+	"path"
+	"sync"
+
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/osutil/inotify"
+)
+
+// Manages the inotify watcher, allowing to have a single watch descriptor open
+type inotifyWatcher struct {
+	// The watch object
+	wd *inotify.Watcher
+	// This is used to ensure that the watcher goroutine is launched only once
+	doOnce sync.Once
+	// This channel is used to add a new CGroup that has to be checked
+	addWatchChan chan *groupToWatch
+	// Contains the list of groups to monitor, to detect when they have been deleted
+	groupList []*groupToWatch
+	// Contains the list of paths being monitored by the inotify watcher.
+	// The paths monitored aren't the CGroup paths, but the parent ones, because
+	// in /sys/fs is not possible to detect the InDeleteSelf message, only the
+	// InDelete one, so we must monitor the parent folder and detect when a
+	// specific folder, corresponding to a CGroup, has been deleted.
+	// Each path has associated an integer, which is an usage counter. Every
+	// time a new CGroup paths have to be monitored, the parent paths are
+	// checked in the map, and if they already exist, the usage counter is
+	// incremented by one (of course, if a parent path isn't in the map,
+	// it is initialized to 'one'). Every time the path of a CGroup is deleted,
+	// the corresponding usage counter here corresponding to the parent path
+	// is decremented, and when it reaches zero, it is removed and inotify is
+	// notified to stop monitoring it.
+	pathList map[string]int32
+}
+
+// Contains the data corresponding to a CGroup that must be watched to detect
+// when it is destroyed
+type groupToWatch struct {
+	// This is the CGroup identifier
+	name string
+	// This contains a list of folders to monitor. When all of them have been
+	// deleted, the CGroup has been destroyed and there are no processes running
+	folders []string
+	// This channel is used to notify to the requester that this CGroup has been
+	// destroyed. The watcher writes the CGroup identifier on it; this way, the
+	// same channel can be shared to monitor several CGroups.
+	channel chan string
+}
+
+var currentWatcher *inotifyWatcher = &inotifyWatcher{
+	wd:           nil,
+	pathList:     make(map[string]int32),
+	addWatchChan: make(chan *groupToWatch),
+}
+
+func (iw *inotifyWatcher) addWatch(newWatch *groupToWatch) {
+	var folderList []string
+	for _, fullPath := range newWatch.folders {
+		// It's not possible to use inotify.InDeleteSelf in /sys/fs because it
+		// isn't triggered, so we must monitor the parent folder and use InDelete
+		basePath := path.Dir(fullPath)
+		if _, exists := iw.pathList[basePath]; !exists {
+			iw.pathList[basePath] = 0
+			if err := iw.wd.AddWatch(basePath, inotify.InDelete); err != nil {
+				delete(iw.pathList, basePath)
+				continue
+			}
+		}
+		iw.pathList[fullPath]++
+		if osutil.FileExists(fullPath) {
+			folderList = append(folderList, fullPath)
+		} else {
+			iw.removePath(fullPath)
+		}
+	}
+	if len(folderList) == 0 {
+		newWatch.channel <- newWatch.name
+	} else {
+		newWatch.folders = folderList
+		iw.groupList = append(iw.groupList, newWatch)
+	}
+}
+
+func (iw *inotifyWatcher) removePath(fullPath string) {
+	iw.pathList[fullPath]--
+	if iw.pathList[fullPath] == 0 {
+		iw.wd.RemoveWatch(fullPath)
+		delete(iw.pathList, fullPath)
+	}
+}
+
+func (iw *inotifyWatcher) processEvent(watch *groupToWatch, event *inotify.Event) bool {
+	var tmpFolders []string
+	// every time an "InDelete" event is received, check if this CGroup is waiting for
+	// that file/folder deletion event
+	for _, fullPath := range watch.folders {
+		if fullPath != event.Name {
+			tmpFolders = append(tmpFolders, fullPath)
+		} else {
+			// if the folder name is in the list of folders to monitor, decrement the
+			// parent's usage counter, and remove it from the list of folders to watch
+			// in this CGroup (by not adding it to tmpFolders)
+			iw.removePath(fullPath)
+		}
+	}
+	watch.folders = tmpFolders
+	if len(tmpFolders) == 0 {
+		// if all the files/folders of this CGroup have been deleted, notify the
+		// client that it is done.
+		watch.channel <- watch.name
+		// By returning FALSE, the caller is notified to remove this CGroup from
+		// the list of watched CGroups.
+		return false
+	}
+	// Returning TRUE means that this CGroup still have files/folders to be
+	// monitored, and must be kept in the CGroup list.
+	return true
+}
+
+func (iw *inotifyWatcher) watcherMainLoop() {
+	for {
+		select {
+		case event := <-iw.wd.Event:
+			if event.Mask&inotify.InDelete == 0 {
+				continue
+			}
+			var newGroupList []*groupToWatch
+			for _, watch := range iw.groupList {
+				if iw.processEvent(watch, event) {
+					newGroupList = append(newGroupList, watch)
+				}
+			}
+			iw.groupList = newGroupList
+		case newWatch := <-iw.addWatchChan:
+			iw.addWatch(newWatch)
+		}
+	}
+}
+
+// MonitorFullDelete allows to monitor a group of files/folders
+// and, when all of them have been deleted, emits the specified name through the channel.
+func (iw *inotifyWatcher) monitorFullDelete(name string, folders []string, channel chan string) error {
+	iw.doOnce.Do(func() {
+		wd, err := inotify.NewWatcher()
+		if err == nil {
+			iw.wd = wd
+			go iw.watcherMainLoop()
+		}
+	})
+
+	if iw.wd == nil {
+		return errors.New("Inotify failed to initialize")
+	}
+	iw.addWatchChan <- &groupToWatch{
+		name:    name,
+		folders: folders,
+		channel: channel,
+	}
+	return nil
+}
+
+// MonitorSnapEnded is the method to call to monitor the running instances of an specific Snap.
+// It receives the name of the snap to monitor (for example, "firefox" or "steam")
+// and a channel. The caller can wait on the channel, and when all the instances of
+// the specific snap have ended, the name of the snap will be sent through the channel.
+// This allows to use the same channel to monitor several snaps
+func MonitorSnapEnded(snapName string, channel chan string) error {
+	options := InstancePathsOptions{
+		ReturnCGroupPath: true,
+	}
+	paths, _ := InstancePathsOfSnap(snapName, options)
+	return currentWatcher.monitorFullDelete(snapName, paths, channel)
+}

--- a/sandbox/cgroup/monitor.go
+++ b/sandbox/cgroup/monitor.go
@@ -110,10 +110,10 @@ func (iw *inotifyWatcher) removePath(fullPath string) {
 	}
 }
 
-// processDeletedPath checks if the received "path corresponds to the passed
+// processDeletedPath checks if the received path corresponds to the passed
 // CGroup, removing it from the list of folders being watched in that CGroup if
-// needed. It returns TRUE if there remain folders to be monitored in that CGroup,
-// or FALSE if all the folders of that CGroup have been deleted.
+// needed. It returns true if there remain folders to be monitored in that CGroup,
+// or false if all the folders of that CGroup have been deleted.
 func (iw *inotifyWatcher) processDeletedPath(watch *groupToWatch, deletedPath string) bool {
 	for i, fullPath := range watch.folders {
 		if fullPath == deletedPath {

--- a/sandbox/cgroup/monitor_test.go
+++ b/sandbox/cgroup/monitor_test.go
@@ -36,7 +36,6 @@ import (
 type monitorSuite struct {
 	testutil.BaseTest
 
-	tmp      string
 	eventsCh chan string
 
 	inotifyWait time.Duration
@@ -47,8 +46,7 @@ var _ = Suite(&monitorSuite{})
 func (s *monitorSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
 
-	s.tmp = c.MkDir()
-	dirs.SetRootDir(s.tmp)
+	dirs.SetRootDir(c.MkDir())
 	s.AddCleanup(func() { dirs.SetRootDir("/") })
 
 	s.eventsCh = make(chan string)
@@ -83,7 +81,7 @@ func (s *monitorSuite) calibrateInotifyDelay(c *C) {
 }
 
 func (s *monitorSuite) makeTestFolder(c *C, name string) (fullPath string) {
-	fullPath = path.Join(s.tmp, name)
+	fullPath = path.Join(c.MkDir(), name)
 	err := os.Mkdir(fullPath, 0755)
 	c.Assert(err, IsNil)
 	return fullPath
@@ -167,7 +165,7 @@ func (s *monitorSuite) TestMonitorSnapSnapAlreadyStopped(c *C) {
 	// Note that there is no dir created in this test so
 	// this checks that the monitoring is correct is there
 	// is no dir
-	nonExistingFolder := path.Join(s.tmp, "non-exiting-dir")
+	nonExistingFolder := path.Join(c.MkDir(), "non-exiting-dir")
 
 	filelist := []string{nonExistingFolder}
 	err := cgroup.MonitorDelete(filelist, "test3", s.eventsCh)

--- a/sandbox/cgroup/monitor_test.go
+++ b/sandbox/cgroup/monitor_test.go
@@ -1,0 +1,236 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package cgroup_test
+
+import (
+	"os"
+	"path"
+	"time"
+
+	"github.com/snapcore/snapd/sandbox/cgroup"
+	. "gopkg.in/check.v1"
+)
+
+type monitorSuite struct{}
+
+var _ = Suite(&monitorSuite{})
+
+func (s *monitorSuite) TestMonitorSnapBasicWork(c *C) {
+	tmpcontainer := c.MkDir()
+
+	folder1 := path.Join(tmpcontainer, "folder1")
+	err := os.Mkdir(folder1, 0755)
+	c.Assert(err, IsNil)
+
+	folder2 := path.Join(tmpcontainer, "folder2")
+	err = os.Mkdir(folder2, 0755)
+	c.Assert(err, IsNil)
+
+	filelist := []string{folder1}
+
+	channel := make(chan string)
+	defer close(channel)
+
+	retval := cgroup.MonitorFullDelete("test1", filelist, channel)
+	c.Assert(retval, IsNil)
+
+	time.Sleep(1 * time.Second)
+
+	err = os.Remove(folder2)
+	c.Assert(err, IsNil)
+
+	// Wait for two seconds to ensure that nothing spurious
+	// is received from the channel due to removing folder2
+	for i := 0; i < 2; i++ {
+		select {
+		case <-channel:
+			c.Fail()
+		case <-time.After(1 * time.Second):
+			continue
+		}
+	}
+
+	err = os.Remove(folder1)
+	c.Assert(err, IsNil)
+	event := <-channel
+	c.Assert(event, Equals, "test1")
+}
+
+func (s *monitorSuite) TestMonitorSnapTwoSnapsAtTheSameTime(c *C) {
+	tmpcontainer := c.MkDir()
+
+	folder1 := path.Join(tmpcontainer, "folder1")
+	err := os.Mkdir(folder1, 0755)
+	c.Assert(err, IsNil)
+
+	folder2 := path.Join(tmpcontainer, "folder2")
+	err = os.Mkdir(folder2, 0755)
+	c.Assert(err, IsNil)
+
+	filelist := []string{folder1, folder2}
+
+	channel := make(chan string)
+	defer close(channel)
+
+	retval := cgroup.MonitorFullDelete("test2", filelist, channel)
+	c.Assert(retval, Equals, nil)
+
+	time.Sleep(1 * time.Second)
+
+	folder3 := path.Join(tmpcontainer, "folder3")
+	err = os.Mkdir(folder3, 0755)
+	c.Assert(err, IsNil)
+
+	time.Sleep(1 * time.Second)
+
+	err = os.Remove(folder3)
+	c.Assert(err, IsNil)
+
+	// Wait for two seconds to ensure that nothing spurious
+	// is received from the channel due to creating or
+	// removing folder3
+	for i := 0; i < 2; i++ {
+		select {
+		case <-channel:
+			c.Fail()
+		case <-time.After(1 * time.Second):
+			continue
+		}
+	}
+	err = os.Remove(folder1)
+	c.Assert(err, IsNil)
+	// Only one file has been removed, so wait two seconds
+	// two ensure that nothing spurious is received from
+	// the channel
+	for i := 0; i < 2; i++ {
+		select {
+		case <-channel:
+			c.Fail()
+		case <-time.After(1 * time.Second):
+			continue
+		}
+	}
+	err = os.Remove(folder2)
+	c.Assert(err, IsNil)
+
+	// All files have been deleted, so NOW we must receive
+	// something from the channel
+	event := <-channel
+	c.Assert(event, Equals, "test2")
+}
+
+func (s *monitorSuite) TestMonitorSnapSnapAlreadyStopped(c *C) {
+	tmpcontainer := c.MkDir()
+
+	folder1 := path.Join(tmpcontainer, "folder1")
+
+	filelist := []string{folder1}
+
+	channel := make(chan string)
+	defer close(channel)
+
+	retval := cgroup.MonitorFullDelete("test3", filelist, channel)
+	c.Assert(retval, Equals, nil)
+	event := <-channel
+	c.Assert(event, Equals, "test3")
+}
+
+func (s *monitorSuite) TestMonitorSnapTwoProcessesAtTheSameTime(c *C) {
+	tmpcontainer := c.MkDir()
+
+	folder1 := path.Join(tmpcontainer, "folder1")
+	err := os.Mkdir(folder1, 0755)
+	c.Assert(err, IsNil)
+
+	folder2 := path.Join(tmpcontainer, "folder2")
+	err = os.Mkdir(folder2, 0755)
+	c.Assert(err, IsNil)
+
+	filelist1 := []string{folder1}
+	filelist2 := []string{folder2}
+
+	channel1 := make(chan string)
+	defer close(channel1)
+
+	channel2 := make(chan string)
+	defer close(channel2)
+
+	retval := cgroup.MonitorFullDelete("test4a", filelist1, channel1)
+	c.Assert(retval, Equals, nil)
+	retval = cgroup.MonitorFullDelete("test4b", filelist2, channel2)
+	c.Assert(retval, Equals, nil)
+
+	time.Sleep(1 * time.Second)
+
+	folder3 := path.Join(tmpcontainer, "folder3")
+	err = os.Mkdir(folder3, 0755)
+	c.Assert(err, IsNil)
+
+	time.Sleep(1 * time.Second)
+
+	err = os.Remove(folder3)
+	c.Assert(err, IsNil)
+
+	// Wait for two seconds to ensure that nothing spurious
+	// is received from the channel due to creating or
+	// removing folder3
+	for i := 0; i < 2; i++ {
+		select {
+		case <-channel1:
+			c.Fail()
+		case <-channel2:
+			c.Fail()
+		case <-time.After(1 * time.Second):
+			continue
+		}
+	}
+	err = os.Remove(folder1)
+	c.Assert(err, IsNil)
+	// Only one file has been removed, so wait two seconds
+	// two ensure that nothing spurious is received from
+	// the channel
+	var receivedEvent = ""
+	for i := 0; i < 2; i++ {
+		select {
+		case receivedEvent = <-channel1:
+		case <-channel2:
+			c.Fail()
+		case <-time.After(1 * time.Second):
+			continue
+		}
+	}
+	c.Assert(receivedEvent, Equals, "test4a")
+	err = os.Remove(folder2)
+	c.Assert(err, IsNil)
+
+	// All files have been deleted, so NOW we must receive
+	// something from the channel
+	receivedEvent = ""
+	for i := 0; i < 2; i++ {
+		select {
+		case receivedEvent = <-channel2:
+		case <-channel1:
+			c.Fail()
+		case <-time.After(1 * time.Second):
+			continue
+		}
+	}
+	c.Assert(receivedEvent, Equals, "test4b")
+}

--- a/sandbox/cgroup/monitor_test.go
+++ b/sandbox/cgroup/monitor_test.go
@@ -156,18 +156,16 @@ func (s *monitorSuite) TestMonitorSnapTwoSnapsAtTheSameTime(c *C) {
 }
 
 func (s *monitorSuite) TestMonitorSnapSnapAlreadyStopped(c *C) {
-	tmpcontainer := c.MkDir()
+	// Note that there is no dir created in this test so
+	// this checks that the monitoring is correct is there
+	// is no dir
+	nonExistingFolder := path.Join(s.tmp, "non-exiting-dir")
 
-	folder1 := path.Join(tmpcontainer, "folder1")
-
-	filelist := []string{folder1}
-
-	channel := make(chan string)
-	defer close(channel)
-
-	err := cgroup.MonitorDelete(filelist, "test3", channel)
+	filelist := []string{nonExistingFolder}
+	err := cgroup.MonitorDelete(filelist, "test3", s.ch)
 	c.Assert(err, Equals, nil)
-	event := <-channel
+
+	event := <-s.ch
 	c.Assert(event, Equals, "test3")
 }
 

--- a/sandbox/cgroup/monitor_test.go
+++ b/sandbox/cgroup/monitor_test.go
@@ -291,11 +291,8 @@ func (s *monitorSuite) TestMonitorCloseChannel(c *C) {
 	err = os.Remove(folder2)
 	c.Assert(err, IsNil)
 
-	// Wait for two seconds to ensure that nothing spurious
-	// is received from the channel due to removing folder2
-	// Wait for two seconds to ensure that nothing spurious
-	// is received from the channel due to creating or
-	// removing folder3
+	// Wait for a bit to ensure that
+	// nothing spurious is received from the channel
 	select {
 	case event := <-ch:
 		c.Fatalf("unexpected channel read of event %q", event)

--- a/sandbox/cgroup/monitor_test.go
+++ b/sandbox/cgroup/monitor_test.go
@@ -48,8 +48,8 @@ func (s *monitorSuite) TestMonitorSnapBasicWork(c *C) {
 	channel := make(chan string)
 	defer close(channel)
 
-	retval := cgroup.MonitorDelete(filelist, "test1", channel)
-	c.Assert(retval, IsNil)
+	err = cgroup.MonitorDelete(filelist, "test1", channel)
+	c.Assert(err, IsNil)
 
 	time.Sleep(1 * time.Second)
 
@@ -89,8 +89,8 @@ func (s *monitorSuite) TestMonitorSnapTwoSnapsAtTheSameTime(c *C) {
 	channel := make(chan string)
 	defer close(channel)
 
-	retval := cgroup.MonitorDelete(filelist, "test2", channel)
-	c.Assert(retval, Equals, nil)
+	err = cgroup.MonitorDelete(filelist, "test2", channel)
+	c.Assert(err, Equals, nil)
 
 	time.Sleep(1 * time.Second)
 
@@ -140,8 +140,8 @@ func (s *monitorSuite) TestMonitorSnapSnapAlreadyStopped(c *C) {
 	channel := make(chan string)
 	defer close(channel)
 
-	retval := cgroup.MonitorDelete(filelist, "test3", channel)
-	c.Assert(retval, Equals, nil)
+	err := cgroup.MonitorDelete(filelist, "test3", channel)
+	c.Assert(err, Equals, nil)
 	event := <-channel
 	c.Assert(event, Equals, "test3")
 }
@@ -166,10 +166,10 @@ func (s *monitorSuite) TestMonitorSnapTwoProcessesAtTheSameTime(c *C) {
 	channel2 := make(chan string)
 	defer close(channel2)
 
-	retval := cgroup.MonitorDelete(filelist1, "test4a", channel1)
-	c.Assert(retval, Equals, nil)
-	retval = cgroup.MonitorDelete(filelist2, "test4b", channel2)
-	c.Assert(retval, Equals, nil)
+	err = cgroup.MonitorDelete(filelist1, "test4a", channel1)
+	c.Assert(err, Equals, nil)
+	err = cgroup.MonitorDelete(filelist2, "test4b", channel2)
+	c.Assert(err, Equals, nil)
 
 	time.Sleep(1 * time.Second)
 

--- a/sandbox/cgroup/monitor_test.go
+++ b/sandbox/cgroup/monitor_test.go
@@ -70,7 +70,7 @@ func (s *monitorSuite) calibrateInotifyDelay(c *C) {
 	d := time.Now().Sub(start)
 	// On a modern machine the duration "d" for inotify delivery is
 	// around 30-100µs so even the very conservative multiplication means
-	// the delay is typcially 3ms-10ms.
+	// the delay is typically 3ms-10ms.
 	s.inotifyWait = 100 * d
 	switch {
 	case s.inotifyWait > 1*time.Second:

--- a/sandbox/cgroup/monitor_test.go
+++ b/sandbox/cgroup/monitor_test.go
@@ -64,8 +64,10 @@ func (s *monitorSuite) calibrateInotifyDelay(c *C) {
 	}()
 	<-s.ch
 	d := time.Now().Sub(start)
-	// be very conservative
-	s.inotifyWait = 10 * d
+	// On a modern machine the dureation "d" for inotify delivery is
+	// around 30-100µs so even the very conservative multiplication means
+	// the delay is typcially 3ms-10ms.
+	s.inotifyWait = 100 * d
 	switch {
 	case s.inotifyWait > 1*time.Second:
 		s.inotifyWait = 1 * time.Second

--- a/sandbox/cgroup/monitor_test.go
+++ b/sandbox/cgroup/monitor_test.go
@@ -68,7 +68,7 @@ func (s *monitorSuite) calibrateInotifyDelay(c *C) {
 	}()
 	<-s.eventsCh
 	d := time.Now().Sub(start)
-	// On a modern machine the dureation "d" for inotify delivery is
+	// On a modern machine the duration "d" for inotify delivery is
 	// around 30-100µs so even the very conservative multiplication means
 	// the delay is typcially 3ms-10ms.
 	s.inotifyWait = 100 * d
@@ -100,9 +100,9 @@ func (s *monitorSuite) TestMonitorSnapBasicWork(c *C) {
 	err = os.Remove(folder2)
 	c.Assert(err, IsNil)
 
-	// Wait for two seconds to ensure that nothing spurious
+	// Wait for bit to ensure that nothing spurious
 	// is received from the channel due to removing folder2
-	// Wait for two seconds to ensure that nothing spurious
+	// Wait for a bit to ensure that nothing spurious
 	// is received from the channel due to creating or
 	// removing folder3
 	select {
@@ -134,7 +134,7 @@ func (s *monitorSuite) TestMonitorSnapTwoSnapsAtTheSameTime(c *C) {
 	err = os.Remove(folder3)
 	c.Assert(err, IsNil)
 
-	// Wait for two seconds to ensure that nothing spurious
+	// Wait for a bit to ensure that nothing spurious
 	// is received from the channel due to creating or
 	// removing folder3
 	select {
@@ -144,9 +144,8 @@ func (s *monitorSuite) TestMonitorSnapTwoSnapsAtTheSameTime(c *C) {
 	}
 	err = os.Remove(folder1)
 	c.Assert(err, IsNil)
-	// Only one file has been removed, so wait two seconds
-	// two ensure that nothing spurious is received from
-	// the channel
+	// Only one file has been removed, so wait a bit to ensure
+	// that nothing spurious is received from the channel
 	select {
 	case event := <-s.eventsCh:
 		c.Fatalf("unexpected channel read of event %q", event)
@@ -202,7 +201,7 @@ func (s *monitorSuite) TestMonitorSnapTwoProcessesAtTheSameTime(c *C) {
 	err = os.Remove(folder3)
 	c.Assert(err, IsNil)
 
-	// Wait for two seconds to ensure that nothing spurious
+	// Wait for a bit to ensure that nothing spurious
 	// is received from the channel due to creating or
 	// removing folder3
 	select {
@@ -214,9 +213,8 @@ func (s *monitorSuite) TestMonitorSnapTwoProcessesAtTheSameTime(c *C) {
 	}
 	err = os.Remove(folder1)
 	c.Assert(err, IsNil)
-	// Only one file has been removed, so wait two seconds
-	// two ensure that nothing spurious is received from
-	// the channel
+	// Only one file has been removed, so wait a bit to ensure
+	// that nothing spurious is received from the channel
 	var receivedEvent string
 	select {
 	case receivedEvent = <-channel1:

--- a/sandbox/cgroup/monitor_test.go
+++ b/sandbox/cgroup/monitor_test.go
@@ -58,13 +58,13 @@ func (s *monitorSuite) TestMonitorSnapBasicWork(c *C) {
 
 	// Wait for two seconds to ensure that nothing spurious
 	// is received from the channel due to removing folder2
-	for i := 0; i < 2; i++ {
-		select {
-		case <-channel:
-			c.Fail()
-		case <-time.After(1 * time.Second):
-			continue
-		}
+	// Wait for two seconds to ensure that nothing spurious
+	// is received from the channel due to creating or
+	// removing folder3
+	select {
+	case <-channel:
+		c.Fail()
+	case <-time.After(2 * time.Second):
 	}
 
 	err = os.Remove(folder1)

--- a/sandbox/cgroup/monitor_test.go
+++ b/sandbox/cgroup/monitor_test.go
@@ -172,15 +172,8 @@ func (s *monitorSuite) TestMonitorSnapSnapAlreadyStopped(c *C) {
 }
 
 func (s *monitorSuite) TestMonitorSnapTwoProcessesAtTheSameTime(c *C) {
-	tmpcontainer := c.MkDir()
-
-	folder1 := path.Join(tmpcontainer, "folder1")
-	err := os.Mkdir(folder1, 0755)
-	c.Assert(err, IsNil)
-
-	folder2 := path.Join(tmpcontainer, "folder2")
-	err = os.Mkdir(folder2, 0755)
-	c.Assert(err, IsNil)
+	folder1 := s.makeTestFolder(c, "folder1")
+	folder2 := s.makeTestFolder(c, "folder2")
 
 	filelist1 := []string{folder1}
 	filelist2 := []string{folder2}
@@ -191,16 +184,14 @@ func (s *monitorSuite) TestMonitorSnapTwoProcessesAtTheSameTime(c *C) {
 	channel2 := make(chan string)
 	defer close(channel2)
 
-	err = cgroup.MonitorDelete(filelist1, "test4a", channel1)
+	err := cgroup.MonitorDelete(filelist1, "test4a", channel1)
 	c.Assert(err, Equals, nil)
 	err = cgroup.MonitorDelete(filelist2, "test4b", channel2)
 	c.Assert(err, Equals, nil)
 
 	time.Sleep(s.inotifyWait)
 
-	folder3 := path.Join(tmpcontainer, "folder3")
-	err = os.Mkdir(folder3, 0755)
-	c.Assert(err, IsNil)
+	folder3 := s.makeTestFolder(c, "folder3")
 
 	time.Sleep(s.inotifyWait)
 

--- a/sandbox/cgroup/monitor_test.go
+++ b/sandbox/cgroup/monitor_test.go
@@ -62,8 +62,8 @@ func (s *monitorSuite) TestMonitorSnapBasicWork(c *C) {
 	// is received from the channel due to creating or
 	// removing folder3
 	select {
-	case <-channel:
-		c.Fail()
+	case event := <-channel:
+		c.Fatalf("unexpected channel read of event %q", event)
 	case <-time.After(2 * time.Second):
 	}
 
@@ -107,8 +107,8 @@ func (s *monitorSuite) TestMonitorSnapTwoSnapsAtTheSameTime(c *C) {
 	// is received from the channel due to creating or
 	// removing folder3
 	select {
-	case <-channel:
-		c.Fail()
+	case event := <-channel:
+		c.Fatalf("unexpected channel read of event %q", event)
 	case <-time.After(2 * time.Second):
 	}
 	err = os.Remove(folder1)
@@ -117,8 +117,8 @@ func (s *monitorSuite) TestMonitorSnapTwoSnapsAtTheSameTime(c *C) {
 	// two ensure that nothing spurious is received from
 	// the channel
 	select {
-	case <-channel:
-		c.Fail()
+	case event := <-channel:
+		c.Fatalf("unexpected channel read of event %q", event)
 	case <-time.After(2 * time.Second):
 	}
 	err = os.Remove(folder2)
@@ -186,10 +186,10 @@ func (s *monitorSuite) TestMonitorSnapTwoProcessesAtTheSameTime(c *C) {
 	// is received from the channel due to creating or
 	// removing folder3
 	select {
-	case <-channel1:
-		c.Fail()
-	case <-channel2:
-		c.Fail()
+	case event := <-channel1:
+		c.Fatalf("unexpected channel read of event %q", event)
+	case event := <-channel2:
+		c.Fatalf("unexpected channel read of event %q", event)
 	case <-time.After(2 * time.Second):
 	}
 	err = os.Remove(folder1)
@@ -200,8 +200,8 @@ func (s *monitorSuite) TestMonitorSnapTwoProcessesAtTheSameTime(c *C) {
 	var receivedEvent string
 	select {
 	case receivedEvent = <-channel1:
-	case <-channel2:
-		c.Fail()
+	case event := <-channel2:
+		c.Fatalf("unexpected channel read of event %q", event)
 	case <-time.After(2 * time.Second):
 	}
 
@@ -214,8 +214,8 @@ func (s *monitorSuite) TestMonitorSnapTwoProcessesAtTheSameTime(c *C) {
 	receivedEvent = ""
 	select {
 	case receivedEvent = <-channel2:
-	case <-channel1:
-		c.Fail()
+	case event := <-channel1:
+		c.Fatalf("unexpected channel read of event %q", event)
 	case <-time.After(1 * time.Second):
 	}
 	c.Assert(receivedEvent, Equals, "test4b")

--- a/sandbox/cgroup/monitor_test.go
+++ b/sandbox/cgroup/monitor_test.go
@@ -108,7 +108,7 @@ func (s *monitorSuite) TestMonitorSnapBasicWork(c *C) {
 	select {
 	case event := <-s.eventsCh:
 		c.Fatalf("unexpected channel read of event %q", event)
-	case <-time.After(2 * s.inotifyWait):
+	case <-time.After(s.inotifyWait):
 	}
 
 	err = os.Remove(folder1)
@@ -140,7 +140,7 @@ func (s *monitorSuite) TestMonitorSnapTwoSnapsAtTheSameTime(c *C) {
 	select {
 	case event := <-s.eventsCh:
 		c.Fatalf("unexpected channel read of event %q", event)
-	case <-time.After(2 * s.inotifyWait):
+	case <-time.After(s.inotifyWait):
 	}
 	err = os.Remove(folder1)
 	c.Assert(err, IsNil)
@@ -149,7 +149,7 @@ func (s *monitorSuite) TestMonitorSnapTwoSnapsAtTheSameTime(c *C) {
 	select {
 	case event := <-s.eventsCh:
 		c.Fatalf("unexpected channel read of event %q", event)
-	case <-time.After(2 * s.inotifyWait):
+	case <-time.After(s.inotifyWait):
 	}
 	err = os.Remove(folder2)
 	c.Assert(err, IsNil)
@@ -209,7 +209,7 @@ func (s *monitorSuite) TestMonitorSnapTwoProcessesAtTheSameTime(c *C) {
 		c.Fatalf("unexpected channel read of event %q", event)
 	case event := <-channel2:
 		c.Fatalf("unexpected channel read of event %q", event)
-	case <-time.After(2 * s.inotifyWait):
+	case <-time.After(s.inotifyWait):
 	}
 	err = os.Remove(folder1)
 	c.Assert(err, IsNil)
@@ -220,7 +220,7 @@ func (s *monitorSuite) TestMonitorSnapTwoProcessesAtTheSameTime(c *C) {
 	case receivedEvent = <-channel1:
 	case event := <-channel2:
 		c.Fatalf("unexpected channel read of event %q", event)
-	case <-time.After(2 * s.inotifyWait):
+	case <-time.After(s.inotifyWait):
 	}
 
 	c.Assert(receivedEvent, Equals, "test4a")
@@ -265,7 +265,7 @@ func (s *monitorSuite) TestMonitorSnapEndedIntegration(c *C) {
 	select {
 	case snapName := <-s.eventsCh:
 		c.Fatalf("unexpected stop reported for snap %v", snapName)
-	case <-time.After(2 * s.inotifyWait):
+	case <-time.After(s.inotifyWait):
 	}
 
 	// simulate cgroup getting removed because firefox stopped

--- a/sandbox/cgroup/monitor_test.go
+++ b/sandbox/cgroup/monitor_test.go
@@ -197,7 +197,7 @@ func (s *monitorSuite) TestMonitorSnapTwoProcessesAtTheSameTime(c *C) {
 	// Only one file has been removed, so wait two seconds
 	// two ensure that nothing spurious is received from
 	// the channel
-	var receivedEvent = ""
+	var receivedEvent string
 	select {
 	case receivedEvent = <-channel1:
 	case <-channel2:

--- a/sandbox/cgroup/monitor_test.go
+++ b/sandbox/cgroup/monitor_test.go
@@ -30,6 +30,11 @@ import (
 	"github.com/snapcore/snapd/testutil"
 )
 
+const (
+	spuriousMontiorChWait = 2 * time.Second
+	spuriousWaits         = 1 * time.Second
+)
+
 type monitorSuite struct {
 	testutil.BaseTest
 
@@ -62,7 +67,7 @@ func (s *monitorSuite) TestMonitorSnapBasicWork(c *C) {
 	err := cgroup.MonitorDelete(filelist, "test1", s.ch)
 	c.Assert(err, IsNil)
 
-	time.Sleep(1 * time.Second)
+	time.Sleep(spuriousWaits)
 
 	err = os.Remove(folder2)
 	c.Assert(err, IsNil)
@@ -75,7 +80,7 @@ func (s *monitorSuite) TestMonitorSnapBasicWork(c *C) {
 	select {
 	case event := <-s.ch:
 		c.Fatalf("unexpected channel read of event %q", event)
-	case <-time.After(2 * time.Second):
+	case <-time.After(spuriousMontiorChWait):
 	}
 
 	err = os.Remove(folder1)
@@ -92,11 +97,11 @@ func (s *monitorSuite) TestMonitorSnapTwoSnapsAtTheSameTime(c *C) {
 	err := cgroup.MonitorDelete(filelist, "test2", s.ch)
 	c.Assert(err, Equals, nil)
 
-	time.Sleep(1 * time.Second)
+	time.Sleep(spuriousWaits)
 
 	folder3 := s.makeTestFolder(c, "folder3")
 
-	time.Sleep(1 * time.Second)
+	time.Sleep(spuriousWaits)
 
 	err = os.Remove(folder3)
 	c.Assert(err, IsNil)
@@ -107,7 +112,7 @@ func (s *monitorSuite) TestMonitorSnapTwoSnapsAtTheSameTime(c *C) {
 	select {
 	case event := <-s.ch:
 		c.Fatalf("unexpected channel read of event %q", event)
-	case <-time.After(2 * time.Second):
+	case <-time.After(spuriousMontiorChWait):
 	}
 	err = os.Remove(folder1)
 	c.Assert(err, IsNil)
@@ -117,7 +122,7 @@ func (s *monitorSuite) TestMonitorSnapTwoSnapsAtTheSameTime(c *C) {
 	select {
 	case event := <-s.ch:
 		c.Fatalf("unexpected channel read of event %q", event)
-	case <-time.After(2 * time.Second):
+	case <-time.After(spuriousMontiorChWait):
 	}
 	err = os.Remove(folder2)
 	c.Assert(err, IsNil)
@@ -169,13 +174,13 @@ func (s *monitorSuite) TestMonitorSnapTwoProcessesAtTheSameTime(c *C) {
 	err = cgroup.MonitorDelete(filelist2, "test4b", channel2)
 	c.Assert(err, Equals, nil)
 
-	time.Sleep(1 * time.Second)
+	time.Sleep(spuriousWaits)
 
 	folder3 := path.Join(tmpcontainer, "folder3")
 	err = os.Mkdir(folder3, 0755)
 	c.Assert(err, IsNil)
 
-	time.Sleep(1 * time.Second)
+	time.Sleep(spuriousWaits)
 
 	err = os.Remove(folder3)
 	c.Assert(err, IsNil)
@@ -188,7 +193,7 @@ func (s *monitorSuite) TestMonitorSnapTwoProcessesAtTheSameTime(c *C) {
 		c.Fatalf("unexpected channel read of event %q", event)
 	case event := <-channel2:
 		c.Fatalf("unexpected channel read of event %q", event)
-	case <-time.After(2 * time.Second):
+	case <-time.After(spuriousMontiorChWait):
 	}
 	err = os.Remove(folder1)
 	c.Assert(err, IsNil)
@@ -200,7 +205,7 @@ func (s *monitorSuite) TestMonitorSnapTwoProcessesAtTheSameTime(c *C) {
 	case receivedEvent = <-channel1:
 	case event := <-channel2:
 		c.Fatalf("unexpected channel read of event %q", event)
-	case <-time.After(2 * time.Second):
+	case <-time.After(spuriousMontiorChWait):
 	}
 
 	c.Assert(receivedEvent, Equals, "test4a")
@@ -214,7 +219,7 @@ func (s *monitorSuite) TestMonitorSnapTwoProcessesAtTheSameTime(c *C) {
 	case receivedEvent = <-channel2:
 	case event := <-channel1:
 		c.Fatalf("unexpected channel read of event %q", event)
-	case <-time.After(1 * time.Second):
+	case <-time.After(spuriousWaits):
 	}
 	c.Assert(receivedEvent, Equals, "test4b")
 }

--- a/sandbox/cgroup/scanning.go
+++ b/sandbox/cgroup/scanning.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2019 Canonical Ltd
+ * Copyright (C) 2019-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -67,33 +67,25 @@ func securityTagFromCgroupPath(path string) naming.SecurityTag {
 	return nil
 }
 
-// PidsOfSnap returns the association of security tags to PIDs.
+type InstancePathsOptions struct {
+	ReturnCGroupPath bool
+}
+
+// InstancePathsOfSnap returns the list of active cgroup paths for a given snap
+// If options.returnCGroupPath is TRUE, it will return the path of the CGroup itself;
+// but if it is FALSE, it will return the path of the file with the PIDs of the running snap
 //
-// NOTE: This function returns a reliable result only if the refresh-app-awareness
-// feature was enabled before all processes related to the given snap were started.
-// If the feature wasn't always enabled then only service process are correctly
-// accounted for.
-//
-// The return value is a snapshot of the pids for a given snap, grouped by
-// security tag. The result may be immediately stale as processes fork and
-// exit.
-//
-// Importantly, if the per-snap lock is held while computing the set, then the
-// following guarantee is true: if a security tag is not among the results then
-// no such tag can come into existence while the lock is held.
-//
-// This can be used to classify the activity of a given snap into activity
-// classes, based on the nature of the security tags encountered.
-func PidsOfSnap(snapInstanceName string) (map[string][]int, error) {
-	// pidsByTag maps security tag to a list of pids.
-	pidsByTag := make(map[string][]int)
+// The return value is a snapshot of the cgroup paths
+
+func InstancePathsOfSnap(snapInstanceName string, options InstancePathsOptions) ([]string, error) {
+	var cgroupPathToScan string
+	var pathList []string
 
 	ver, err := Version()
 	if err != nil {
 		return nil, err
 	}
 
-	var cgroupPathToScan string
 	if ver == V2 {
 		// In v2 mode scan all of /sys/fs/cgroup as there is no specialization
 		// anymore (each directory represents a hierarchy with equal
@@ -148,12 +140,11 @@ func PidsOfSnap(snapInstanceName string) (map[string][]int, error) {
 		if parsedTag.InstanceName() != snapInstanceName {
 			return nil
 		}
-		pids, err := pidsInFile(path)
-		if err != nil {
-			return err
+		if options.ReturnCGroupPath {
+			pathList = append(pathList, cgroupPath)
+		} else {
+			pathList = append(pathList, path)
 		}
-		tag := parsedTag.String()
-		pidsByTag[tag] = append(pidsByTag[tag], pids...)
 		// Since we've found the file we are looking for (cgroup.procs) we no
 		// longer need to scan the remaining files of this directory.
 		return filepath.SkipDir
@@ -166,6 +157,51 @@ func PidsOfSnap(snapInstanceName string) (map[string][]int, error) {
 			return nil, nil
 		}
 		return nil, err
+	}
+	return pathList, nil
+}
+
+// PidsOfSnap returns the association of security tags to PIDs.
+//
+// NOTE: This function returns a reliable result only if the refresh-app-awareness
+// feature was enabled before all processes related to the given snap were started.
+// If the feature wasn't always enabled then only service process are correctly
+// accounted for.
+//
+// The return value is a snapshot of the pids for a given snap, grouped by
+// security tag. The result may be immediately stale as processes fork and
+// exit.
+//
+// Importantly, if the per-snap lock is held while computing the set, then the
+// following guarantee is true: if a security tag is not among the results then
+// no such tag can come into existence while the lock is held.
+//
+// This can be used to classify the activity of a given snap into activity
+// classes, based on the nature of the security tags encountered.
+func PidsOfSnap(snapInstanceName string) (map[string][]int, error) {
+	options := InstancePathsOptions{
+		ReturnCGroupPath: false,
+	}
+	paths, err := InstancePathsOfSnap(snapInstanceName, options)
+	if err != nil {
+		return nil, err
+	}
+
+	// pidsByTag maps security tag to a list of pids.
+	pidsByTag := make(map[string][]int)
+
+	for _, path := range paths {
+		pids, err := pidsInFile(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil, nil
+			}
+			return nil, err
+		}
+		cgroupPath := filepath.Dir(path)
+		parsedTag := securityTagFromCgroupPath(cgroupPath)
+		tag := parsedTag.String()
+		pidsByTag[tag] = append(pidsByTag[tag], pids...)
 	}
 
 	return pidsByTag, nil

--- a/sandbox/cgroup/scanning_test.go
+++ b/sandbox/cgroup/scanning_test.go
@@ -72,7 +72,18 @@ func (s *scanningSuite) TestSecurityTagFromCgroupPath(c *C) {
 	c.Check(cgroup.SecurityTagFromCgroupPath("/a/b/snap.foo.foo.service/"), DeepEquals, mustParseTag("snap.foo.foo"))
 }
 
-func (s *scanningSuite) writePids(c *C, dir string, pids []int) {
+// Returns the number of ocurrencies of 'needle' in the array 'arr'
+func matchesInArray(arr []string, needle string) int {
+	counter := 0
+	for _, v := range arr {
+		if v == needle {
+			counter++
+		}
+	}
+	return counter
+}
+
+func (s *scanningSuite) writePids(c *C, dir string, pids []int) string {
 	var buf bytes.Buffer
 	for _, pid := range pids {
 		fmt.Fprintf(&buf, "%d\n", pid)
@@ -90,7 +101,9 @@ func (s *scanningSuite) writePids(c *C, dir string, pids []int) {
 	}
 
 	c.Assert(os.MkdirAll(path, 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(path, "cgroup.procs"), buf.Bytes(), 0644), IsNil)
+	finalPath := filepath.Join(path, "cgroup.procs")
+	c.Assert(ioutil.WriteFile(finalPath, buf.Bytes(), 0644), IsNil)
+	return finalPath
 }
 
 func (s *scanningSuite) TestPidsOfSnapEmpty(c *C) {
@@ -101,6 +114,19 @@ func (s *scanningSuite) TestPidsOfSnapEmpty(c *C) {
 	pids, err := cgroup.PidsOfSnap("pkg")
 	c.Assert(err, IsNil)
 	c.Check(pids, HasLen, 0)
+}
+
+func (s *scanningSuite) TestPathsOfSnapEmpty(c *C) {
+	restore := cgroup.MockVersion(cgroup.V1, nil)
+	defer restore()
+
+	// Not having any cgroup directories is not an error.
+	options := cgroup.InstancePathsOptions{
+		ReturnCGroupPath: true,
+	}
+	paths, err := cgroup.InstancePathsOfSnap("pkg", options)
+	c.Assert(err, IsNil)
+	c.Check(paths, HasLen, 0)
 }
 
 func (s *scanningSuite) TestPidsOfSnapUnrelatedStuff(c *C) {
@@ -124,6 +150,30 @@ func (s *scanningSuite) TestPidsOfSnapUnrelatedStuff(c *C) {
 	}
 }
 
+func (s *scanningSuite) TestPathsOfSnapUnrelatedStuff(c *C) {
+	options := cgroup.InstancePathsOptions{
+		ReturnCGroupPath: true,
+	}
+	for _, ver := range []int{cgroup.V2, cgroup.V1} {
+		comment := Commentf("cgroup version %v", ver)
+		restore := cgroup.MockVersion(ver, nil)
+		defer restore()
+
+		// Things that are not related to the snap are not being picked up.
+		s.writePids(c, "udisks2.service", []int{100})
+		s.writePids(c, "snap..service", []int{101})
+		s.writePids(c, "snap..scope", []int{102})
+		s.writePids(c, "snap.*.service", []int{103})
+		s.writePids(c, "snap.*.scope", []int{104})
+		s.writePids(c, "snapd.service", []int{105})
+		s.writePids(c, "snap-spotify-35.mount", []int{106})
+
+		paths, err := cgroup.InstancePathsOfSnap("pkg", options)
+		c.Assert(err, IsNil, comment)
+		c.Check(paths, HasLen, 0, comment)
+	}
+}
+
 func (s *scanningSuite) TestPidsOfSnapSecurityTags(c *C) {
 	for _, ver := range []int{cgroup.V2, cgroup.V1} {
 		comment := Commentf("cgroup version %v", ver)
@@ -140,6 +190,27 @@ func (s *scanningSuite) TestPidsOfSnapSecurityTags(c *C) {
 			"snap.pkg.hook.configure": {1},
 			"snap.pkg.daemon":         {2},
 		}, comment)
+	}
+}
+
+func (s *scanningSuite) TestPathsOfSnapWithSecurityTags(c *C) {
+	options := cgroup.InstancePathsOptions{
+		ReturnCGroupPath: true,
+	}
+	for _, ver := range []int{cgroup.V2, cgroup.V1} {
+		comment := Commentf("cgroup version %v", ver)
+		restore := cgroup.MockVersion(ver, nil)
+		defer restore()
+
+		// Pids are collected and assigned to bins by security tag
+		path1 := s.writePids(c, "system.slice/snap.pkg.hook.configure.$RANDOM.scope", []int{1})
+		path2 := s.writePids(c, "system.slice/snap.pkg.daemon.service", []int{2})
+
+		paths, err := cgroup.InstancePathsOfSnap("pkg", options)
+		c.Assert(err, IsNil, comment)
+		c.Check(paths, HasLen, 2)
+		c.Check(matchesInArray(paths, filepath.Dir(path1)), Equals, 1)
+		c.Check(matchesInArray(paths, filepath.Dir(path2)), Equals, 1)
 	}
 }
 
@@ -177,6 +248,40 @@ func (s *scanningSuite) TestPidsOfInstances(c *C) {
 	}
 }
 
+func (s *scanningSuite) TestPathsOfInstances(c *C) {
+	options := cgroup.InstancePathsOptions{
+		ReturnCGroupPath: true,
+	}
+	for _, ver := range []int{cgroup.V2, cgroup.V1} {
+		comment := Commentf("cgroup version %v", ver)
+		restore := cgroup.MockVersion(ver, nil)
+		defer restore()
+
+		// Instances are not confused between themselves and between the non-instance version.
+		path1 := s.writePids(c, "system.slice/snap.pkg_prod.daemon.service", []int{1})
+		path2 := s.writePids(c, "system.slice/snap.pkg_devel.daemon.service", []int{2})
+		path3 := s.writePids(c, "system.slice/snap.pkg.daemon.service", []int{3})
+
+		// The main one
+		paths, err := cgroup.InstancePathsOfSnap("pkg", options)
+		c.Assert(err, IsNil, comment)
+		c.Check(paths, HasLen, 1)
+		c.Check(paths[0], Equals, filepath.Dir(path3))
+
+		// The development one
+		paths, err = cgroup.InstancePathsOfSnap("pkg_devel", options)
+		c.Assert(err, IsNil, comment)
+		c.Check(paths, HasLen, 1)
+		c.Check(paths[0], Equals, filepath.Dir(path2))
+
+		// The production one
+		paths, err = cgroup.InstancePathsOfSnap("pkg_prod", options)
+		c.Assert(err, IsNil, comment)
+		c.Check(paths, HasLen, 1)
+		c.Check(paths[0], Equals, filepath.Dir(path1))
+	}
+}
+
 func (s *scanningSuite) TestPidsOfAggregation(c *C) {
 	for _, ver := range []int{cgroup.V2, cgroup.V1} {
 		comment := Commentf("cgroup version %v", ver)
@@ -195,6 +300,32 @@ func (s *scanningSuite) TestPidsOfAggregation(c *C) {
 		c.Check(pids, DeepEquals, map[string][]int{
 			"snap.pkg.app": {1, 2, 3, 4},
 		}, comment)
+	}
+}
+
+func (s *scanningSuite) TestPathsOfAggregation(c *C) {
+	options := cgroup.InstancePathsOptions{
+		ReturnCGroupPath: true,
+	}
+	for _, ver := range []int{cgroup.V2, cgroup.V1} {
+		comment := Commentf("cgroup version %v", ver)
+		restore := cgroup.MockVersion(ver, nil)
+		defer restore()
+
+		// A single snap may be invoked by multiple users in different sessions.
+		// All of their PIDs are collected though.
+		path1 := s.writePids(c, "user.slice/user-1000.slice/user@1000.service/gnome-shell-wayland.service/snap.pkg.app.$RANDOM1.scope", []int{1}) // mock 1st invocation
+		path2 := s.writePids(c, "user.slice/user-1000.slice/user@1000.service/gnome-shell-wayland.service/snap.pkg.app.$RANDOM2.scope", []int{2}) // mock fork() by pid 1
+		path3 := s.writePids(c, "user.slice/user-1001.slice/user@1001.service/gnome-shell-wayland.service/snap.pkg.app.$RANDOM3.scope", []int{3}) // mock 2nd invocation
+		path4 := s.writePids(c, "user.slice/user-1001.slice/user@1001.service/gnome-shell-wayland.service/snap.pkg.app.$RANDOM4.scope", []int{4}) // mock fork() by pid 3
+
+		paths, err := cgroup.InstancePathsOfSnap("pkg", options)
+		c.Assert(err, IsNil, comment)
+		c.Check(paths, HasLen, 4)
+		c.Check(matchesInArray(paths, filepath.Dir(path1)), Equals, 1)
+		c.Check(matchesInArray(paths, filepath.Dir(path2)), Equals, 1)
+		c.Check(matchesInArray(paths, filepath.Dir(path3)), Equals, 1)
+		c.Check(matchesInArray(paths, filepath.Dir(path4)), Equals, 1)
 	}
 }
 
@@ -225,6 +356,38 @@ func (s *scanningSuite) TestPidsOfSnapUnrelated(c *C) {
 	}
 }
 
+func (s *scanningSuite) TestPathsOfSnapUnrelated(c *C) {
+	options := cgroup.InstancePathsOptions{
+		ReturnCGroupPath: true,
+	}
+	for _, ver := range []int{cgroup.V2, cgroup.V1} {
+		comment := Commentf("cgroup version %v", ver)
+		restore := cgroup.MockVersion(ver, nil)
+		defer restore()
+
+		// We are not confusing snaps with other snaps, instances of our snap, and
+		// with non-snap hierarchies.
+		path1 := s.writePids(c, "user.slice/.../snap.pkg.app.$RANDOM1.scope", []int{1})
+		path2 := s.writePids(c, "user.slice/.../snap.other.snap.$RANDOM2.scope", []int{2})
+		path3 := s.writePids(c, "user.slice/.../pkg.service", []int{3})
+		path4 := s.writePids(c, "user.slice/.../snap.pkg_instance.app.$RANDOM3.scope", []int{4})
+
+		// Write a file which is not cgroup.procs with the number 666 inside.
+		// We want to ensure this is not read by accident.
+		f := filepath.Join(s.rootDir, "/sys/fs/cgroup/unrelated.txt")
+		c.Assert(os.MkdirAll(filepath.Dir(f), 0755), IsNil)
+		c.Assert(ioutil.WriteFile(f, []byte("666"), 0644), IsNil)
+
+		paths, err := cgroup.InstancePathsOfSnap("pkg", options)
+		c.Assert(err, IsNil, comment)
+		c.Check(paths, HasLen, 1)
+		c.Check(matchesInArray(paths, filepath.Dir(path1)), Equals, 1)
+		c.Check(matchesInArray(paths, filepath.Dir(path2)), Equals, 0)
+		c.Check(matchesInArray(paths, filepath.Dir(path3)), Equals, 0)
+		c.Check(matchesInArray(paths, filepath.Dir(path4)), Equals, 0)
+	}
+}
+
 func (s *scanningSuite) TestContainerPidsAreIgnored(c *C) {
 	for _, ver := range []int{cgroup.V2, cgroup.V1} {
 		comment := Commentf("cgroup version %v", ver)
@@ -241,5 +404,31 @@ func (s *scanningSuite) TestContainerPidsAreIgnored(c *C) {
 		c.Assert(err, IsNil, comment)
 		c.Check(pids, HasLen, 1, comment)
 		c.Check(pids["snap.foo.bar"], testutil.DeepUnsortedMatches, []int{1, 2}, comment)
+	}
+}
+
+func (s *scanningSuite) TestContainerPathsAreIgnored(c *C) {
+	options := cgroup.InstancePathsOptions{
+		ReturnCGroupPath: true,
+	}
+	for _, ver := range []int{cgroup.V2, cgroup.V1} {
+		comment := Commentf("cgroup version %v", ver)
+		restore := cgroup.MockVersion(ver, nil)
+		defer restore()
+
+		path1 := s.writePids(c, "user.slice/user-1000.slice/user@1000.service/snap.foo.bar.scope", []int{1})
+		path2 := s.writePids(c, "system.slice/snap.foo.bar.service", []int{2})
+		path3 := s.writePids(c, "lxc.payload.my-container/system.slice/snap.foo.bar.service", []int{3})
+		path4 := s.writePids(c, "machine.slice/snap.foo.bar.service", []int{4})
+		path5 := s.writePids(c, "docker/snap.foo.bar.service", []int{5})
+
+		paths, err := cgroup.InstancePathsOfSnap("foo", options)
+		c.Assert(err, IsNil, comment)
+		c.Check(paths, HasLen, 2, comment)
+		c.Check(matchesInArray(paths, filepath.Dir(path1)), Equals, 1)
+		c.Check(matchesInArray(paths, filepath.Dir(path2)), Equals, 1)
+		c.Check(matchesInArray(paths, filepath.Dir(path3)), Equals, 0)
+		c.Check(matchesInArray(paths, filepath.Dir(path4)), Equals, 0)
+		c.Check(matchesInArray(paths, filepath.Dir(path5)), Equals, 0)
 	}
 }

--- a/sandbox/cgroup/scanning_test.go
+++ b/sandbox/cgroup/scanning_test.go
@@ -72,7 +72,7 @@ func (s *scanningSuite) TestSecurityTagFromCgroupPath(c *C) {
 	c.Check(cgroup.SecurityTagFromCgroupPath("/a/b/snap.foo.foo.service/"), DeepEquals, mustParseTag("snap.foo.foo"))
 }
 
-// Returns the number of ocurrencies of 'needle' in the array 'arr'
+// Returns the number of occurrences of 'needle' in the array 'arr'
 func matchesInArray(arr []string, needle string) int {
 	counter := 0
 	for _, v := range arr {


### PR DESCRIPTION
cgroup: Add Snap/Cgroup monitoring capabilities (alternative MR)

This is an alternative MR for adding a Snap/Cgroup monitor that allows other parts of the code to wait until all the instances of a Snap have ended and it can be safely refreshed. It is the first step for a bigger MR that will allow to automagically refresh a snap after the system has notified the user that there is a refresh available and that they must close it.
