### PR TITLE
tests/fakeinstaller: really use part label to find partitions

### DIFF
--- a/tests/lib/fakeinstaller/main.go
+++ b/tests/lib/fakeinstaller/main.go
@@ -254,7 +254,7 @@ func createAndMountFilesystems(bootDevice string, volumes map[string]*gadget.Vol
 
 	var mountPoints []string
 	for _, volStruct := range vol.Structure {
-		if volStruct.Label == "" || volStruct.Filesystem == "" {
+		if volStruct.Filesystem == "" {
 			continue
 		}
 

--- a/tests/lib/fakeinstaller/main.go
+++ b/tests/lib/fakeinstaller/main.go
@@ -266,7 +266,7 @@ func createAndMountFilesystems(bootDevice string, volumes map[string]*gadget.Vol
 			}
 			partNode = encryptedDevice
 		} else {
-			part, err := disk.FindMatchingPartitionWithPartLabel(volStruct.Label)
+			part, err := disk.FindMatchingPartitionWithPartLabel(volStruct.Name)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Previously we were using the filesystem label, so this was not working
unless partition and filesystem labels were coincident.