### PR TITLE
many: expand fully handling links mapping in all components, in the API and in snap info

### DIFF
--- a/client/clientutil/snapinfo.go
+++ b/client/clientutil/snapinfo.go
@@ -74,7 +74,6 @@ func ClientSnapFromSnapInfo(snapInfo *snap.Info, decorator StatusDecorator) (*cl
 		Confinement: string(confinement),
 		Apps:        apps,
 		Broken:      snapInfo.Broken,
-		Contact:     snapInfo.Contact(),
 		Title:       snapInfo.Title(),
 		License:     snapInfo.License,
 		Media:       snapInfo.Media,
@@ -82,7 +81,9 @@ func ClientSnapFromSnapInfo(snapInfo *snap.Info, decorator StatusDecorator) (*cl
 		Channels:    snapInfo.Channels,
 		Tracks:      snapInfo.Tracks,
 		CommonIDs:   snapInfo.CommonIDs,
-		Website:     snapInfo.Website,
+		Links:       snapInfo.Links(),
+		Contact:     snapInfo.Contact(),
+		Website:     snapInfo.Website(),
 		StoreURL:    snapInfo.StoreURL,
 	}
 

--- a/client/clientutil/snapinfo_test.go
+++ b/client/clientutil/snapinfo_test.go
@@ -72,8 +72,12 @@ func (*cmdSuite) TestClientSnapFromSnapInfo(c *C) {
 			EditedSummary:     "the-summary",
 			EditedDescription: "the-description",
 			Channel:           "latest/stable",
-			EditedContact:     "https://thingy.com",
-			Private:           true,
+			EditedLinks: map[string][]string{
+				"contact": {"https://thingy.com"},
+				"website": {"http://example.com/thingy"},
+			},
+			LegacyEditedContact: "https://thingy.com",
+			Private:             true,
 		},
 		Channels: map[string]*snap.ChannelSnapInfo{},
 		Tracks:   []string{},
@@ -84,7 +88,6 @@ func (*cmdSuite) TestClientSnapFromSnapInfo(c *C) {
 			{Type: "screenshot", URL: "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/Thingy_02.png", Width: 600, Height: 200},
 		},
 		CommonIDs: []string{"org.thingy"},
-		Website:   "http://example.com/thingy",
 		StoreURL:  "https://snapcraft.io/thingy",
 		Broken:    "broken",
 	}
@@ -146,7 +149,10 @@ func (*cmdSuite) TestClientSnapFromSnapInfo(c *C) {
 	c.Check(ci.Summary, Equals, "the-summary")
 	c.Check(ci.Description, Equals, "the-description")
 	c.Check(ci.Icon, Equals, si.Media.IconURL())
-	c.Check(ci.Website, Equals, si.Website)
+	c.Check(ci.Links, DeepEquals, si.Links())
+	c.Check(ci.Links, DeepEquals, si.EditedLinks)
+	c.Check(ci.Contact, Equals, si.Contact())
+	c.Check(ci.Website, Equals, si.Website())
 	c.Check(ci.StoreURL, Equals, si.StoreURL)
 	c.Check(ci.Developer, Equals, "thingyinc")
 	c.Check(ci.Publisher, DeepEquals, &si.Publisher)

--- a/client/packages.go
+++ b/client/packages.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015-2016 Canonical Ltd
+ * Copyright (C) 2015-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -62,12 +62,16 @@ type Snap struct {
 	TryMode          bool          `json:"trymode,omitempty"`
 	Apps             []AppInfo     `json:"apps,omitempty"`
 	Broken           string        `json:"broken,omitempty"`
-	Contact          string        `json:"contact"`
 	License          string        `json:"license,omitempty"`
 	CommonIDs        []string      `json:"common-ids,omitempty"`
 	MountedFrom      string        `json:"mounted-from,omitempty"`
 	CohortKey        string        `json:"cohort-key,omitempty"`
-	Website          string        `json:"website,omitempty"`
+
+	Links map[string][]string `json:"links,omitempy"`
+
+	// legacy fields before we had links
+	Contact string `json:"contact"`
+	Website string `json:"website,omitempty"`
 
 	Prices      map[string]float64    `json:"prices,omitempty"`
 	Screenshots []snap.ScreenshotInfo `json:"screenshots,omitempty"`

--- a/client/packages_test.go
+++ b/client/packages_test.go
@@ -262,6 +262,9 @@ func (cs *clientSuite) TestClientSnap(c *check.C) {
                             {"type": "screenshot", "url":"http://example.com/shot2.png"}
                         ],
                         "cohort-key": "some-long-cohort-key",
+                        "links": {
+                            "website": ["http://example.com/funky"]
+                        },
                         "website": "http://example.com/funky",
                         "common-ids": ["org.funky.snap"],
                         "store-url": "https://snapcraft.io/chatroom"
@@ -308,8 +311,11 @@ func (cs *clientSuite) TestClientSnap(c *check.C) {
 		},
 		CommonIDs: []string{"org.funky.snap"},
 		CohortKey: "some-long-cohort-key",
-		Website:   "http://example.com/funky",
-		StoreURL:  "https://snapcraft.io/chatroom",
+		Links: map[string][]string{
+			"website": {"http://example.com/funky"},
+		},
+		Website:  "http://example.com/funky",
+		StoreURL: "https://snapcraft.io/chatroom",
 	})
 }
 

--- a/cmd/snap/cmd_info.go
+++ b/cmd/snap/cmd_info.go
@@ -76,41 +76,6 @@ func init() {
 		}), nil)
 }
 
-func (iw *infoWriter) maybePrintHealth() {
-	if iw.localSnap == nil {
-		return
-	}
-	health := iw.localSnap.Health
-	if health == nil {
-		if !iw.verbose {
-			return
-		}
-		health = &client.SnapHealth{
-			Status:  "unknown",
-			Message: "health has not been set",
-		}
-	}
-	if health.Status == "okay" && !iw.verbose {
-		return
-	}
-
-	fmt.Fprintln(iw, "health:")
-	fmt.Fprintf(iw, "  status:\t%s\n", health.Status)
-	if health.Message != "" {
-		strutil.WordWrap(iw, quotedIfNeeded(health.Message), "  message:\t", "    ", iw.termWidth)
-	}
-	if health.Code != "" {
-		fmt.Fprintf(iw, "  code:\t%s\n", health.Code)
-	}
-	if !health.Timestamp.IsZero() {
-		fmt.Fprintf(iw, "  checked:\t%s\n", iw.fmtTime(health.Timestamp))
-	}
-	if !health.Revision.Unset() {
-		fmt.Fprintf(iw, "  revision:\t%s\n", health.Revision)
-	}
-	iw.Flush()
-}
-
 func clientSnapFromPath(path string) (*client.Snap, error) {
 	snapf, err := snapfile.Open(path)
 	if err != nil {
@@ -247,6 +212,41 @@ func (iw *infoWriter) maybePrintID() {
 	if iw.theSnap.ID != "" {
 		fmt.Fprintf(iw, "snap-id:\t%s\n", iw.theSnap.ID)
 	}
+}
+
+func (iw *infoWriter) maybePrintHealth() {
+	if iw.localSnap == nil {
+		return
+	}
+	health := iw.localSnap.Health
+	if health == nil {
+		if !iw.verbose {
+			return
+		}
+		health = &client.SnapHealth{
+			Status:  "unknown",
+			Message: "health has not been set",
+		}
+	}
+	if health.Status == "okay" && !iw.verbose {
+		return
+	}
+
+	fmt.Fprintln(iw, "health:")
+	fmt.Fprintf(iw, "  status:\t%s\n", health.Status)
+	if health.Message != "" {
+		strutil.WordWrap(iw, quotedIfNeeded(health.Message), "  message:\t", "    ", iw.termWidth)
+	}
+	if health.Code != "" {
+		fmt.Fprintf(iw, "  code:\t%s\n", health.Code)
+	}
+	if !health.Timestamp.IsZero() {
+		fmt.Fprintf(iw, "  checked:\t%s\n", iw.fmtTime(health.Timestamp))
+	}
+	if !health.Revision.Unset() {
+		fmt.Fprintf(iw, "  revision:\t%s\n", health.Revision)
+	}
+	iw.Flush()
 }
 
 func (iw *infoWriter) maybePrintTrackingChannel() {

--- a/cmd/snap/cmd_info_test.go
+++ b/cmd/snap/cmd_info_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -338,7 +338,7 @@ func (s *infoSuite) TestMaybePrintSum(c *check.C) {
 	c.Check(buf.String(), check.Equals, "")
 }
 
-func (s *infoSuite) TestMaybePrintContact(c *check.C) {
+func (s *infoSuite) TestMaybePrintLinksContact(c *check.C) {
 	var buf flushBuffer
 	iw := snap.NewInfoWriter(&buf)
 
@@ -350,9 +350,37 @@ func (s *infoSuite) TestMaybePrintContact(c *check.C) {
 	} {
 		buf.Reset()
 		snap.SetupDiskSnap(iw, "", &client.Snap{Contact: contact})
-		snap.MaybePrintContact(iw)
+		snap.MaybePrintLinks(iw)
 		c.Check(buf.String(), check.Equals, expected, check.Commentf("%q", contact))
 	}
+}
+
+func (s *infoSuite) TestMaybePrintLinksVerbose(c *check.C) {
+	var buf flushBuffer
+	iw := snap.NewInfoWriter(&buf)
+	snap.SetVerbose(iw, true)
+
+	const contact = "mailto:joe@example.com"
+	const website1 = "http://example.com/www1"
+	const website2 = "http://example.com/www2"
+	snap.SetupDiskSnap(iw, "", &client.Snap{
+		Links: map[string][]string{
+			"contact": {contact},
+			"website": {website1, website2},
+		},
+		Contact: contact,
+		Website: website1,
+	})
+
+	snap.MaybePrintLinks(iw)
+	c.Check(buf.String(), check.Equals, "contact:\tjoe@example.com\n"+
+		`links:
+  contact:
+    - mailto:joe@example.com
+  website:
+    - http://example.com/www1
+    - http://example.com/www2
+`)
 }
 
 func (s *infoSuite) TestMaybePrintBase(c *check.C) {

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -132,7 +132,7 @@ var (
 	MaybePrintNotes             = (*infoWriter).maybePrintNotes
 	MaybePrintStandaloneVersion = (*infoWriter).maybePrintStandaloneVersion
 	MaybePrintBuildDate         = (*infoWriter).maybePrintBuildDate
-	MaybePrintContact           = (*infoWriter).maybePrintContact
+	MaybePrintLinks             = (*infoWriter).maybePrintLinks
 	MaybePrintBase              = (*infoWriter).maybePrintBase
 	MaybePrintPath              = (*infoWriter).maybePrintPath
 	MaybePrintSum               = (*infoWriter).maybePrintSum

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2021 Canonical Ltd
+ * Copyright (C) 2014-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -1166,9 +1166,12 @@ func (s *snapsSuite) TestMapLocalFields(c *check.C) {
 			EditedSummary:     "a summary",
 			EditedDescription: "the\nlong\ndescription",
 			Channel:           "bleeding/edge",
-			EditedContact:     "mailto:alice@example.com",
-			Revision:          snap.R(7),
-			Private:           true,
+			EditedLinks: map[string][]string{
+				"contact": {"mailto:alice@example.com"},
+			},
+			LegacyEditedContact: "mailto:alice@example.com",
+			Revision:            snap.R(7),
+			Private:             true,
 		},
 		InstanceKey: "instance",
 		SnapType:    "app",
@@ -1229,12 +1232,15 @@ func (s *snapsSuite) TestMapLocalFields(c *check.C) {
 		JailMode:         true,
 		Private:          true,
 		Broken:           "very",
-		Contact:          "mailto:alice@example.com",
-		Title:            "A Title",
-		License:          "MIT",
-		CommonIDs:        []string{"foo", "bar"},
-		MountedFrom:      filepath.Join(dirs.SnapBlobDir, "some-snap_instance_7.snap"),
-		Media:            media,
+		Links: map[string][]string{
+			"contact": {"mailto:alice@example.com"},
+		},
+		Contact:     "mailto:alice@example.com",
+		Title:       "A Title",
+		License:     "MIT",
+		CommonIDs:   []string{"foo", "bar"},
+		MountedFrom: filepath.Join(dirs.SnapBlobDir, "some-snap_instance_7.snap"),
+		Media:       media,
 		Apps: []client.AppInfo{
 			{Snap: "some-snap_instance", Name: "bar"},
 			{Snap: "some-snap_instance", Name: "foo"},

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -573,10 +573,10 @@ func (s *imageSuite) setupSnaps(c *C, publishers map[string]string, defaultsYaml
 	s.MakeAssertedSnap(c, snapReqCore16Base, nil, snap.R(16), "other")
 
 	s.MakeAssertedSnap(c, requiredSnap1, nil, snap.R(3), "other")
-	s.AssertedSnapInfo("required-snap1").EditedContact = "mailto:foo@example.com"
+	s.AssertedSnapInfo("required-snap1").LegacyEditedContact = "mailto:foo@example.com"
 
 	s.MakeAssertedSnap(c, requiredSnap18, nil, snap.R(6), "other")
-	s.AssertedSnapInfo("required-snap18").EditedContact = "mailto:foo@example.com"
+	s.AssertedSnapInfo("required-snap18").LegacyEditedContact = "mailto:foo@example.com"
 
 	s.MakeAssertedSnap(c, defaultTrackSnap18, nil, snap.R(5), "other")
 
@@ -1802,10 +1802,10 @@ func (s *imageSuite) TestSetupSeedLocalSnapsWithStoreAssertsValidationEnforce(c 
 		Path:     filepath.Join(seedsnapsdir, "required-snap1_3.snap"),
 		Required: true,
 		SideInfo: &snap.SideInfo{
-			RealName:      "required-snap1",
-			SnapID:        s.AssertedSnapID("required-snap1"),
-			Revision:      snap.R(3),
-			EditedContact: "mailto:foo@example.com",
+			RealName:            "required-snap1",
+			SnapID:              s.AssertedSnapID("required-snap1"),
+			Revision:            snap.R(3),
+			LegacyEditedContact: "mailto:foo@example.com",
 		},
 		Channel: stableChannel,
 	})

--- a/overlord/snapstate/aux_store_info.go
+++ b/overlord/snapstate/aux_store_info.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2018 Canonical Ltd
+ * Copyright (C) 2018-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -35,8 +35,10 @@ import (
 // returned for locally-installed snaps
 type auxStoreInfo struct {
 	Media    snap.MediaInfos `json:"media,omitempty"`
-	Website  string          `json:"website,omitempty"`
 	StoreURL string          `json:"store-url,omitempty"`
+	// XXX this is now included in snap.SideInfo.EditedLinks but
+	// continue having this to support old snapd
+	Website string `json:"website,omitempty"`
 }
 
 func auxStoreInfoFilename(snapID string) string {
@@ -67,7 +69,10 @@ func retrieveAuxStoreInfo(info *snap.Info) error {
 	}
 
 	info.Media = aux.Media
-	info.Website = aux.Website
+	if len(info.EditedLinks) == 0 {
+		// XXX we set this to use old snapd info if it's all we have
+		info.LegacyWebsite = aux.Website
+	}
 	info.StoreURL = aux.StoreURL
 
 	return nil

--- a/overlord/snapstate/refreshhints.go
+++ b/overlord/snapstate/refreshhints.go
@@ -184,8 +184,10 @@ func refreshHintsFromCandidates(st *state.State, updates []*snap.Info, ignoreVal
 				PlugsOnly:    len(update.Slots) == 0,
 				InstanceKey:  update.InstanceKey,
 				auxStoreInfo: auxStoreInfo{
-					Website: update.Website,
-					Media:   update.Media,
+					Media: update.Media,
+					// XXX we store this for the benefit of
+					// old snapd
+					Website: update.Website(),
 				},
 			},
 			Version: update.Version,

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -163,8 +163,9 @@ func (ins installSnapInfo) SnapSetupForUpdate(st *state.State, params updatePara
 		PlugsOnly:          len(update.Slots) == 0,
 		InstanceKey:        update.InstanceKey,
 		auxStoreInfo: auxStoreInfo{
-			Website: update.Website,
-			Media:   update.Media,
+			Media: update.Media,
+			// XXX we store this for the benefit of old snapd
+			Website: update.Website(),
 		},
 		ExpectedProvenance: update.SnapProvenance,
 	}
@@ -1184,8 +1185,9 @@ func InstallWithDeviceContext(ctx context.Context, st *state.State, name string,
 		PlugsOnly:          len(info.Slots) == 0,
 		InstanceKey:        info.InstanceKey,
 		auxStoreInfo: auxStoreInfo{
-			Media:   info.Media,
-			Website: info.Website,
+			Media: info.Media,
+			// XXX we store this for the benefit of old snapd
+			Website: info.Website(),
 		},
 		CohortKey:          opts.CohortKey,
 		ExpectedProvenance: info.SnapProvenance,

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -4447,7 +4447,7 @@ func (s *snapmgrQuerySuite) TestSnapStateCurrentInfo(c *C) {
 	c.Check(info.Version, Equals, "1.2")
 	c.Check(info.Description(), Equals, "Lots of text")
 	c.Check(info.Media, IsNil)
-	c.Check(info.Website, Equals, "")
+	c.Check(info.Website(), Equals, "")
 }
 
 func (s *snapmgrQuerySuite) TestSnapStateCurrentInfoLoadsAuxiliaryStoreInfo(c *C) {
@@ -4478,7 +4478,7 @@ func (s *snapmgrQuerySuite) TestSnapStateCurrentInfoLoadsAuxiliaryStoreInfo(c *C
 	c.Check(info.Version, Equals, "1.2")
 	c.Check(info.Description(), Equals, "Lots of text")
 	c.Check(info.Media, DeepEquals, storeInfo.Media)
-	c.Check(info.Website, Equals, storeInfo.Website)
+	c.Check(info.Website(), Equals, storeInfo.Website)
 }
 
 func (s *snapmgrQuerySuite) TestSnapStateCurrentInfoParallelInstall(c *C) {

--- a/seed/internal/auxinfo20.go
+++ b/seed/internal/auxinfo20.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2019 Canonical Ltd
+ * Copyright (C) 2019-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -21,6 +21,7 @@ package internal
 
 // AuxInfo20 is an entry in the per-snap-id map that is aux-json
 type AuxInfo20 struct {
-	Private bool   `json:"private,omitempty"`
-	Contact string `json:"contact,omitempty"`
+	Private bool                `json:"private,omitempty"`
+	Links   map[string][]string `json:"links,omitempty"`
+	Contact string              `json:"contact,omitempty"`
 }

--- a/seed/seed16.go
+++ b/seed/seed16.go
@@ -190,8 +190,7 @@ func (s *seed16) addSnap(sn *internal.Snap16, essType snap.Type, pinnedTrack str
 			}
 			sideInfo = *si
 			sideInfo.Private = sn.Private
-			// TODO: consider whether to use this if we have links?
-			sideInfo.EditedContact = sn.Contact
+			sideInfo.LegacyEditedContact = sn.Contact
 		}
 		origPath := path
 		if newPath != "" {

--- a/seed/seed16_test.go
+++ b/seed/seed16_test.go
@@ -1137,7 +1137,7 @@ func (s *seed16Suite) TestLoadMetaCore18StoreInfo(c *C) {
 	privateSnapSideInfo := s.AssertedSnapInfo("private-snap").SideInfo
 	privateSnapSideInfo.Private = true
 	contactableSnapSideInfo := s.AssertedSnapInfo("contactable-snap").SideInfo
-	contactableSnapSideInfo.EditedContact = "mailto:author@example.com"
+	contactableSnapSideInfo.LegacyEditedContact = "mailto:author@example.com"
 
 	// these are not sorted by type, firstboot will do that
 	c.Check(runSnaps, DeepEquals, []*seed.Snap{

--- a/seed/seed20.go
+++ b/seed/seed20.go
@@ -374,8 +374,8 @@ func (s *seed20) lookupSnap(snapRef naming.SnapRef, essType snap.Type, optSnap *
 	auxInfo := s.auxInfos[sideInfo.SnapID]
 	if auxInfo != nil {
 		sideInfo.Private = auxInfo.Private
-		// TODO: consider whether to use this if we have links
-		sideInfo.EditedContact = auxInfo.Contact
+		sideInfo.EditedLinks = auxInfo.Links
+		sideInfo.LegacyEditedContact = auxInfo.Contact
 	}
 
 	return &Snap{

--- a/seed/seed20_test.go
+++ b/seed/seed20_test.go
@@ -639,6 +639,14 @@ func (s *seed20Suite) TestLoadMetaWrongGadgetBase(c *C) {
 	c.Check(err, ErrorMatches, `cannot use gadget snap because its base "core18" is different from model base "core20"`)
 }
 
+func (s *seed20Suite) setSnapContact(snapName, contact string) {
+	info := s.AssertedSnapInfo(snapName)
+	info.EditedLinks = map[string][]string{
+		"contact": {contact},
+	}
+	info.LegacyEditedContact = contact
+}
+
 func (s *seed20Suite) TestLoadMetaCore20(c *C) {
 	s.makeSnap(c, "snapd", "")
 	s.makeSnap(c, "core20", "")
@@ -646,7 +654,7 @@ func (s *seed20Suite) TestLoadMetaCore20(c *C) {
 	s.makeSnap(c, "pc=20", "")
 	s.makeSnap(c, "required20", "developerid")
 
-	s.AssertedSnapInfo("required20").EditedContact = "mailto:author@example.com"
+	s.setSnapContact("required20", "mailto:author@example.com")
 
 	sysLabel := "20191018"
 	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
@@ -752,7 +760,7 @@ func (s *seed20Suite) TestLoadMetaCore20DelegatedSnap(c *C) {
 	}
 	s.MakeAssertedDelegatedSnap(c, snapYaml["required20"]+"\nprovenance: delegated-prov\n", nil, snap.R(1), "developerid", "my-brand", "delegated-prov", ra, s.StoreSigning.Database)
 
-	s.AssertedSnapInfo("required20").EditedContact = "mailto:author@example.com"
+	s.setSnapContact("required20", "mailto:author@example.com")
 
 	sysLabel := "20220705"
 	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
@@ -1812,7 +1820,7 @@ func (s *seed20Suite) TestLoadMetaCore20ChannelOverride(c *C) {
 	s.makeSnap(c, "pc=20", "")
 	s.makeSnap(c, "required20", "developerid")
 
-	s.AssertedSnapInfo("required20").EditedContact = "mailto:author@example.com"
+	s.setSnapContact("required20", "mailto:author@example.com")
 
 	sysLabel := "20191018"
 	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
@@ -1907,7 +1915,7 @@ func (s *seed20Suite) TestLoadMetaCore20ChannelOverrideSnapd(c *C) {
 	s.makeSnap(c, "pc=20", "")
 	s.makeSnap(c, "required20", "developerid")
 
-	s.AssertedSnapInfo("required20").EditedContact = "mailto:author@example.com"
+	s.setSnapContact("required20", "mailto:author@example.com")
 
 	sysLabel := "20191121"
 	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{

--- a/seed/seedwriter/seed16.go
+++ b/seed/seedwriter/seed16.go
@@ -246,7 +246,6 @@ func (tr *tree16) writeMeta(snapsFromModel []*SeedSnap, extraSnaps []*SeedSnap) 
 			File:    filepath.Base(sn.Path),
 			DevMode: info.NeedsDevMode(),
 			Classic: info.NeedsClassic(),
-			// TODO: set this only if the snap has no links?
 			Contact: info.Contact(),
 			// no assertions for this snap were put in the seed
 			Unasserted: unasserted,

--- a/seed/seedwriter/seed20.go
+++ b/seed/seedwriter/seed20.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2019 Canonical Ltd
+ * Copyright (C) 2014-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -367,10 +367,10 @@ func (tr *tree20) writeMeta(snapsFromModel []*SeedSnap, extraSnaps []*SeedSnap) 
 	addAuxInfos := func(seedSnaps []*SeedSnap) {
 		for _, sn := range seedSnaps {
 			if sn.Info.ID() != "" {
-				if sn.Info.EditedContact != "" || sn.Info.Private {
+				if len(sn.Info.Links()) != 0 || sn.Info.Private {
 					auxInfos[sn.Info.ID()] = &internal.AuxInfo20{
 						Private: sn.Info.Private,
-						// TODO: set this only if the snap has no links
+						Links:   sn.Info.Links(),
 						Contact: sn.Info.Contact(),
 					}
 				}

--- a/seed/seedwriter/writer_test.go
+++ b/seed/seedwriter/writer_test.go
@@ -899,7 +899,9 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore18(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(snaps, HasLen, 6)
 
-	s.AssertedSnapInfo("cont-producer").EditedContact = "mailto:author@cont-producer.net"
+	s.AssertedSnapInfo("cont-producer").EditedLinks = map[string][]string{
+		"contact": {"mailto:author@cont-producer.net"},
+	}
 	for _, sn := range snaps {
 		s.fillDownloadedSnap(c, w, sn)
 	}
@@ -1636,7 +1638,9 @@ func (s *writerSuite) TestSeedSnapsWriteMetaExtraSnaps(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(snaps, HasLen, 6)
 
-	s.AssertedSnapInfo("cont-producer").EditedContact = "mailto:author@cont-producer.net"
+	s.AssertedSnapInfo("cont-producer").EditedLinks = map[string][]string{
+		"contact": {"mailto:author@cont-producer.net"},
+	}
 	for _, sn := range snaps {
 		s.fillDownloadedSnap(c, w, sn)
 	}
@@ -1779,7 +1783,9 @@ func (s *writerSuite) TestSeedSnapsWriteMetaLocalExtraSnaps(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(snaps, HasLen, 6)
 
-	s.AssertedSnapInfo("cont-producer").EditedContact = "mailto:author@cont-producer.net"
+	s.AssertedSnapInfo("cont-producer").EditedLinks = map[string][]string{
+		"contact": {"mailto:author@cont-producer.net"},
+	}
 	for _, sn := range snaps {
 		s.fillDownloadedSnap(c, w, sn)
 	}
@@ -1935,7 +1941,9 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(snaps, HasLen, 7)
 
-	s.AssertedSnapInfo("cont-producer").EditedContact = "mailto:author@cont-producer.net"
+	s.AssertedSnapInfo("cont-producer").EditedLinks = map[string][]string{
+		"contact": {"mailto:author@cont-producer.net"},
+	}
 	s.AssertedSnapInfo("cont-consumer").Private = true
 	for _, sn := range snaps {
 		// check the used channel at this level because in the
@@ -2057,6 +2065,9 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20(c *C) {
 			"private": true,
 		},
 		s.AssertedSnapID("cont-producer"): {
+			"links": map[string]interface{}{
+				"contact": []interface{}{"mailto:author@cont-producer.net"},
+			},
 			"contact": "mailto:author@cont-producer.net",
 		},
 	})

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -107,7 +107,7 @@ func (s *infoSuite) TestContactFromEdited(c *C) {
 	}
 
 	info.SideInfo = snap.SideInfo{
-		EditedContact: "mailto:econtact",
+		LegacyEditedContact: "mailto:econtact",
 	}
 
 	c.Check(info.Contact(), Equals, "mailto:econtact")
@@ -153,27 +153,66 @@ func (s *infoSuite) TestLinks(c *C) {
 	info := &snap.Info{
 		OriginalLinks: map[string][]string{
 			"contact": {"ocontact"},
-			"website": {"owebsite"},
+			"website": {"http://owebsite"},
 		},
 	}
 
 	info.SideInfo = snap.SideInfo{
 		EditedLinks: map[string][]string{
-			"contact": {"econtact"},
-			"website": {"ewebsite"},
+			"contact": {"mailto:econtact"},
+			"website": {"http://ewebsite"},
 		},
 	}
 
 	c.Check(info.Links(), DeepEquals, map[string][]string{
-		"contact": {"econtact"},
-		"website": {"ewebsite"},
+		"contact": {"mailto:econtact"},
+		"website": {"http://ewebsite"},
 	})
 
 	info.EditedLinks = nil
 	c.Check(info.Links(), DeepEquals, map[string][]string{
-		"contact": {"ocontact"},
-		"website": {"owebsite"},
+		"contact": {"mailto:ocontact"},
+		"website": {"http://owebsite"},
 	})
+}
+
+func (s *infoSuite) TestNormalizeOriginalLinks(c *C) {
+	info := &snap.Info{
+		OriginalLinks: map[string][]string{
+			"contact": {"ocontact", "mailto:ocontact"},
+			"website": {":", "http://owebsite", ""},
+		},
+	}
+
+	c.Check(info.Links(), DeepEquals, map[string][]string{
+		"contact": {"mailto:ocontact"},
+		"website": {"http://owebsite"},
+	})
+}
+
+func (s *infoSuite) TestWebsiteFromLegacy(c *C) {
+	info := &snap.Info{
+		OriginalLinks: nil,
+		LegacyWebsite: "http://website",
+	}
+
+	c.Check(info.Website(), Equals, "http://website")
+}
+
+func (s *infoSuite) TestNoWebsite(c *C) {
+	info := &snap.Info{}
+
+	c.Check(info.Website(), Equals, "")
+}
+
+func (s *infoSuite) TestWebsiteFromLinks(c *C) {
+	info := &snap.Info{
+		OriginalLinks: map[string][]string{
+			"website": {"http://website1", "http://website2"},
+		},
+	}
+
+	c.Check(info.Website(), Equals, "http://website1")
 }
 
 func (s *infoSuite) TestAppInfoSecurityTag(c *C) {

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -396,7 +396,7 @@ func Validate(info *Info) error {
 	}
 
 	// Ensure links are valid
-	if err := ValidateLinks(info.Links()); err != nil {
+	if err := ValidateLinks(info.OriginalLinks); err != nil {
 		return err
 	}
 

--- a/store/details.go
+++ b/store/details.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2016 Canonical Ltd
+ * Copyright (C) 2014-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -103,7 +103,7 @@ func infoFromRemote(d *snapDetails) *snap.Info {
 	info.Private = d.Private
 	info.Paid = len(info.Prices) > 0
 	info.Confinement = snap.ConfinementType(d.Confinement)
-	info.EditedContact = d.Contact
+	info.LegacyEditedContact = d.Contact
 	info.License = d.License
 	info.Base = d.Base
 	info.CommonIDs = d.CommonIDs
@@ -112,8 +112,8 @@ func infoFromRemote(d *snapDetails) *snap.Info {
 
 	// FIXME: once the store sends "contact" for everything, remove
 	//        the "SupportURL" part of the if
-	if info.EditedContact == "" {
-		info.EditedContact = d.SupportURL
+	if info.LegacyEditedContact == "" {
+		info.LegacyEditedContact = d.SupportURL
 	}
 
 	return info

--- a/store/details_v2.go
+++ b/store/details_v2.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2021 Canonical Ltd
+ * Copyright (C) 2021-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -33,28 +33,29 @@ import (
 
 // storeSnap holds the information sent as JSON by the store for a snap.
 type storeSnap struct {
-	Architectures []string           `json:"architectures"`
-	Base          string             `json:"base"`
-	Confinement   string             `json:"confinement"`
-	Contact       string             `json:"contact"`
-	CreatedAt     string             `json:"created-at"` // revision timestamp
-	Description   safejson.Paragraph `json:"description"`
-	Download      storeSnapDownload  `json:"download"`
-	Epoch         snap.Epoch         `json:"epoch"`
-	License       string             `json:"license"`
-	Name          string             `json:"name"`
-	Prices        map[string]string  `json:"prices"` // currency->price,  free: {"USD": "0"}
-	Private       bool               `json:"private"`
-	Publisher     snap.StoreAccount  `json:"publisher"`
-	Revision      int                `json:"revision"` // store revisions are ints starting at 1
-	SnapID        string             `json:"snap-id"`
-	SnapYAML      string             `json:"snap-yaml"` // optional
-	Summary       safejson.String    `json:"summary"`
-	Title         safejson.String    `json:"title"`
-	Type          snap.Type          `json:"type"`
-	Version       string             `json:"version"`
-	Website       string             `json:"website"`
-	StoreURL      string             `json:"store-url"`
+	Architectures []string            `json:"architectures"`
+	Base          string              `json:"base"`
+	Confinement   string              `json:"confinement"`
+	Links         map[string][]string `json:"links"`
+	Contact       string              `json:"contact"`
+	CreatedAt     string              `json:"created-at"` // revision timestamp
+	Description   safejson.Paragraph  `json:"description"`
+	Download      storeSnapDownload   `json:"download"`
+	Epoch         snap.Epoch          `json:"epoch"`
+	License       string              `json:"license"`
+	Name          string              `json:"name"`
+	Prices        map[string]string   `json:"prices"` // currency->price,  free: {"USD": "0"}
+	Private       bool                `json:"private"`
+	Publisher     snap.StoreAccount   `json:"publisher"`
+	Revision      int                 `json:"revision"` // store revisions are ints starting at 1
+	SnapID        string              `json:"snap-id"`
+	SnapYAML      string              `json:"snap-yaml"` // optional
+	Summary       safejson.String     `json:"summary"`
+	Title         safejson.String     `json:"title"`
+	Type          snap.Type           `json:"type"`
+	Version       string              `json:"version"`
+	Website       string              `json:"website"`
+	StoreURL      string              `json:"store-url"`
 
 	// TODO: not yet defined: channel map
 
@@ -185,6 +186,9 @@ func copyNonZeroFrom(src, dst *storeSnap) {
 	if src.Confinement != "" {
 		dst.Confinement = src.Confinement
 	}
+	if len(src.Links) != 0 {
+		dst.Links = src.Links
+	}
 	if src.Contact != "" {
 		dst.Contact = src.Contact
 	}
@@ -265,7 +269,9 @@ func infoFromStoreSnap(d *storeSnap) (*snap.Info, error) {
 	info.EditedSummary = d.Summary.Clean()
 	info.EditedDescription = d.Description.Clean()
 	info.Private = d.Private
-	info.EditedContact = d.Contact
+	// needs to be set for old snapd
+	info.LegacyEditedContact = d.Contact
+	info.EditedLinks = d.Links
 	info.Architectures = d.Architectures
 	info.SnapType = d.Type
 	info.Version = d.Version
@@ -292,7 +298,11 @@ func infoFromStoreSnap(d *storeSnap) (*snap.Info, error) {
 		info.Deltas = deltas
 	}
 	info.CommonIDs = d.CommonIDs
-	info.Website = d.Website
+	if len(info.EditedLinks) == 0 {
+		// if non empty links was provided, no need to set this
+		// separately as in itself it is not persisted
+		info.LegacyWebsite = d.Website
+	}
 	info.StoreURL = d.StoreURL
 
 	// fill in the plug/slot data etc

--- a/store/details_v2_test.go
+++ b/store/details_v2_test.go
@@ -118,6 +118,11 @@ const (
      "display-name": "Thingy Inc.",
      "validation": "unproven"
   },
+  "links": {
+    "contact": ["https://thingy.com","mailto:thingy@thingy.com"],
+    "website": ["http://example.com/thingy"],
+    "issues": ["mailto:bugs@thingy.com"]
+  },
   "revision": 21,
   "snap-id": "XYZEfjn4WJYnm0FzDKwqqRZZI77awQEV",
   "snap-yaml": "name: test-snapd-content-plug\nversion: 1.0\nassumes: [snapd2.49]\napps:\n    content-plug:\n        command: bin/content-plug\n        plugs: [shared-content-plug]\nplugs:\n    shared-content-plug:\n        interface: content\n        target: import\n        content: mylib\n        default-provider: test-snapd-content-slot\nslots:\n    shared-content-slot:\n        interface: content\n        content: mylib\n        read:\n            - /\nprovenance: prov\n",
@@ -144,7 +149,7 @@ func (s *detailsV2Suite) TearDownTest(c *C) {
 	s.BaseTest.TearDownTest(c)
 }
 
-func (s *detailsV2Suite) TestInfoFromStoreSnapSimple(c *C) {
+func (s *detailsV2Suite) TestInfoFromStoreSnapSimpleAndLegacy(c *C) {
 	var snp storeSnap
 	err := json.Unmarshal([]byte(coreStoreJSON), &snp)
 	c.Assert(err, IsNil)
@@ -156,15 +161,15 @@ func (s *detailsV2Suite) TestInfoFromStoreSnapSimple(c *C) {
 	c.Check(info, DeepEquals, &snap.Info{
 		Architectures: []string{"amd64"},
 		SideInfo: snap.SideInfo{
-			RealName:          "core",
-			SnapID:            "99T7MUlRhtI3U0QFgl5mXXESAiSwt776",
-			Revision:          snap.R(3887),
-			EditedContact:     "mailto:snappy-canonical-storeaccount@canonical.com",
-			EditedTitle:       "core",
-			EditedSummary:     "snapd runtime environment",
-			EditedDescription: "The core runtime environment for snapd",
-			Private:           false,
-			Paid:              false,
+			RealName:            "core",
+			SnapID:              "99T7MUlRhtI3U0QFgl5mXXESAiSwt776",
+			Revision:            snap.R(3887),
+			LegacyEditedContact: "mailto:snappy-canonical-storeaccount@canonical.com",
+			EditedTitle:         "core",
+			EditedSummary:       "snapd runtime environment",
+			EditedDescription:   "The core runtime environment for snapd",
+			Private:             false,
+			Paid:                false,
 		},
 		Epoch:       snap.E("0"),
 		SnapType:    snap.TypeOS,
@@ -181,10 +186,10 @@ func (s *detailsV2Suite) TestInfoFromStoreSnapSimple(c *C) {
 			Sha3_384:    "b691f6dde3d8022e4db563840f0ef82320cb824b6292ffd027dbc838535214dac31c3512c619beaf73f1aeaf35ac62d5",
 			Size:        85291008,
 		},
-		Plugs:    make(map[string]*snap.PlugInfo),
-		Slots:    make(map[string]*snap.SlotInfo),
-		Website:  "http://example.com/core",
-		StoreURL: "https://snapcraft.io/core",
+		Plugs:         make(map[string]*snap.PlugInfo),
+		Slots:         make(map[string]*snap.SlotInfo),
+		LegacyWebsite: "http://example.com/core",
+		StoreURL:      "https://snapcraft.io/core",
 	})
 }
 
@@ -207,15 +212,20 @@ func (s *detailsV2Suite) TestInfoFromStoreSnap(c *C) {
 		Assumes:       []string{"snapd2.49"},
 		Base:          "base-18",
 		SideInfo: snap.SideInfo{
-			RealName:          "thingy",
-			SnapID:            "XYZEfjn4WJYnm0FzDKwqqRZZI77awQEV",
-			Revision:          snap.R(21),
-			EditedContact:     "https://thingy.com",
-			EditedTitle:       "This Is The Most Fantastical Snap of Th…",
-			EditedSummary:     "useful thingy",
-			EditedDescription: "Useful thingy for thinging",
-			Private:           false,
-			Paid:              true,
+			RealName: "thingy",
+			SnapID:   "XYZEfjn4WJYnm0FzDKwqqRZZI77awQEV",
+			Revision: snap.R(21),
+			EditedLinks: map[string][]string{
+				"contact": {"https://thingy.com", "mailto:thingy@thingy.com"},
+				"website": {"http://example.com/thingy"},
+				"issues":  {"mailto:bugs@thingy.com"},
+			},
+			LegacyEditedContact: "https://thingy.com",
+			EditedTitle:         "This Is The Most Fantastical Snap of Th…",
+			EditedSummary:       "useful thingy",
+			EditedDescription:   "Useful thingy for thinging",
+			Private:             false,
+			Paid:                true,
 		},
 		Epoch: snap.Epoch{
 			Read:  []uint32{0, 1},
@@ -255,7 +265,6 @@ func (s *detailsV2Suite) TestInfoFromStoreSnap(c *C) {
 			{Type: "screenshot", URL: "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/Thingy_02.png", Width: 600, Height: 200},
 		},
 		CommonIDs:      []string{"org.thingy"},
-		Website:        "http://example.com/thingy",
 		StoreURL:       "https://snapcraft.io/thingy",
 		SnapProvenance: "prov",
 	})
@@ -306,8 +315,8 @@ func (s *detailsV2Suite) TestInfoFromStoreSnap(c *C) {
 		"Tracks",   // handled at a different level (see TestInfo)
 		"Layout",
 		"SideInfo.Channel",
-		"SideInfo.EditedLinks", // TODO: take this value from the store
 		"SystemUsernames",
+		"LegacyWebsite",
 	}
 	var checker func(string, reflect.Value)
 	checker = func(pfx string, x reflect.Value) {
@@ -390,6 +399,10 @@ func fillStruct(a interface{}, c *C) {
 				Type: "potato",
 				URL:  "http://example.com/foo.pot",
 			}}
+		case map[string][]string:
+			x = map[string][]string{
+				"contact": {"mailto:foo", "mailto:bar"},
+			}
 		default:
 			c.Fatalf("unhandled field type %T", field.Interface())
 		}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -1071,9 +1071,9 @@ const mockSingleOrderJSON = `{
 
 /* acquired via
 
-http --pretty=format --print b https://api.snapcraft.io/v2/snaps/info/hello-world architecture==amd64 fields==architectures,base,confinement,contact,created-at,description,download,epoch,license,name,prices,private,publisher,revision,snap-id,snap-yaml,summary,title,type,version,media,common-ids Snap-Device-Series:16 | xsel -b
+http --pretty=format --print b https://api.snapcraft.io/v2/snaps/info/hello-world architecture==amd64 fields==architectures,base,confinement,links,contact,created-at,description,download,epoch,license,name,prices,private,publisher,revision,snap-id,snap-yaml,summary,title,type,version,media,common-ids,website Snap-Device-Series:16 | xsel -b
 
-on 2018-06-13 (note snap-yaml is currently excluded from that list). Then, by hand:
+on 2022-10-20. Then, by hand:
 - set prices to {"EUR": "0.99", "USD": "1.23"},
 - set base in first channel-map entry to "bogus-base",
 - set snap-yaml in first channel-map entry to the one from the 'edge', plus the following pastiche:
@@ -1094,7 +1094,7 @@ slots:
     read:
       - /
 
-- add "released-at" to something randomish
+- change edge entry to have different revision, version and "released-at" to something randomish
 
 */
 const mockInfoJSON = `{
@@ -1107,18 +1107,18 @@ const mockInfoJSON = `{
             "channel": {
                 "architecture": "amd64",
                 "name": "stable",
-                "released-at": "2019-01-01T10:11:12.123456789+00:00",
+                "released-at": "2019-04-17T16:47:59.117114+00:00",
                 "risk": "stable",
                 "track": "latest"
             },
             "common-ids": [],
             "confinement": "strict",
-            "created-at": "2016-07-12T16:37:23.960632+00:00",
+            "created-at": "2019-04-17T16:43:58.548661+00:00",
             "download": {
                 "deltas": [],
-                "sha3-384": "eed62063c04a8c3819eb71ce7d929cc8d743b43be9e7d86b397b6d61b66b0c3a684f3148a9dbe5821360ae32105c1bd9",
+                "sha3-384": "b07bdb78e762c2e6020c75fafc92055b323a6f8da3ab42a3963da5ade386aba11f77e3c8f919b8aa23f3aa5c06c844f9",
                 "size": 20480,
-                "url": "https://api.snapcraft.io/api/v1/snaps/download/buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ_27.snap"
+                "url": "https://api.snapcraft.io/api/v1/snaps/download/buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ_29.snap"
             },
             "epoch": {
                 "read": [
@@ -1128,10 +1128,10 @@ const mockInfoJSON = `{
                     0
                 ]
             },
-            "revision": 27,
-            "snap-yaml": "name: hello-world\nversion: 6.3\narchitectures: [ all ]\nsummary: The 'hello-world' of snaps\ndescription: |\n    This is a simple snap example that includes a few interesting binaries\n    to demonstrate snaps and their confinement.\n    * hello-world.env  - dump the env of commands run inside app sandbox\n    * hello-world.evil - show how snappy sandboxes binaries\n    * hello-world.sh   - enter interactive shell that runs in app sandbox\n    * hello-world      - simply output text\napps:\n env:\n   command: bin/env\n evil:\n   command: bin/evil\n sh:\n   command: bin/sh\n hello-world:\n   command: bin/echo\n content-plug:\n   command: bin/content-plug\n   plugs: [shared-content-plug]\nplugs:\n  shared-content-plug:\n    interface: content\n    target: import\n    content: mylib\n    default-provider: test-snapd-content-slot\nslots:\n  shared-content-slot:\n    interface: content\n    content: mylib\n    read:\n      - /\n",
+            "revision": 29,
+            "snap-yaml": "name: hello-world\nversion: 6.4\narchitectures: [ all ]\nsummary: The 'hello-world' of snaps\ndescription: |\n    This is a simple snap example that includes a few interesting binaries\n    to demonstrate snaps and their confinement.\n    * hello-world.env  - dump the env of commands run inside app sandbox\n    * hello-world.evil - show how snappy sandboxes binaries\n    * hello-world.sh   - enter interactive shell that runs in app sandbox\n    * hello-world      - simply output text\napps:\n env:\n   command: bin/env\n evil:\n   command: bin/evil\n sh:\n   command: bin/sh\n hello-world:\n   command: bin/echo\n content-plug:\n   command: bin/content-plug\n   plugs: [shared-content-plug]\nplugs:\n  shared-content-plug:\n    interface: content\n    target: import\n    content: mylib\n    default-provider: test-snapd-content-slot\nslots:\n  shared-content-slot:\n    interface: content\n    content: mylib\n    read:\n      - /\n",
             "type": "app",
-            "version": "6.3"
+            "version": "6.4"
         },
         {
             "architectures": [
@@ -1141,18 +1141,18 @@ const mockInfoJSON = `{
             "channel": {
                 "architecture": "amd64",
                 "name": "candidate",
-                "released-at": "2019-01-02T10:11:12.123456789+00:00",
+                "released-at": "2019-04-17T16:47:59.117114+00:00",
                 "risk": "candidate",
                 "track": "latest"
             },
             "common-ids": [],
             "confinement": "strict",
-            "created-at": "2016-07-12T16:37:23.960632+00:00",
+            "created-at": "2019-04-17T16:43:58.548661+00:00",
             "download": {
                 "deltas": [],
-                "sha3-384": "eed62063c04a8c3819eb71ce7d929cc8d743b43be9e7d86b397b6d61b66b0c3a684f3148a9dbe5821360ae32105c1bd9",
+                "sha3-384": "b07bdb78e762c2e6020c75fafc92055b323a6f8da3ab42a3963da5ade386aba11f77e3c8f919b8aa23f3aa5c06c844f9",
                 "size": 20480,
-                "url": "https://api.snapcraft.io/api/v1/snaps/download/buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ_27.snap"
+                "url": "https://api.snapcraft.io/api/v1/snaps/download/buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ_29.snap"
             },
             "epoch": {
                 "read": [
@@ -1162,10 +1162,9 @@ const mockInfoJSON = `{
                     0
                 ]
             },
-            "revision": 27,
-            "snap-yaml": "",
+            "revision": 29,
             "type": "app",
-            "version": "6.3"
+            "version": "6.4"
         },
         {
             "architectures": [
@@ -1175,18 +1174,18 @@ const mockInfoJSON = `{
             "channel": {
                 "architecture": "amd64",
                 "name": "beta",
-                "released-at": "2019-01-03T10:11:12.123456789+00:00",
+                "released-at": "2019-04-17T16:48:09.906850+00:00",
                 "risk": "beta",
                 "track": "latest"
             },
             "common-ids": [],
             "confinement": "strict",
-            "created-at": "2016-07-12T16:37:23.960632+00:00",
+            "created-at": "2019-04-17T16:43:58.548661+00:00",
             "download": {
                 "deltas": [],
-                "sha3-384": "eed62063c04a8c3819eb71ce7d929cc8d743b43be9e7d86b397b6d61b66b0c3a684f3148a9dbe5821360ae32105c1bd9",
+                "sha3-384": "b07bdb78e762c2e6020c75fafc92055b323a6f8da3ab42a3963da5ade386aba11f77e3c8f919b8aa23f3aa5c06c844f9",
                 "size": 20480,
-                "url": "https://api.snapcraft.io/api/v1/snaps/download/buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ_27.snap"
+                "url": "https://api.snapcraft.io/api/v1/snaps/download/buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ_29.snap"
             },
             "epoch": {
                 "read": [
@@ -1196,10 +1195,9 @@ const mockInfoJSON = `{
                     0
                 ]
             },
-            "revision": 27,
-            "snap-yaml": "",
+            "revision": 29,
             "type": "app",
-            "version": "6.3"
+            "version": "6.4"
         },
         {
             "architectures": [
@@ -1209,18 +1207,18 @@ const mockInfoJSON = `{
             "channel": {
                 "architecture": "amd64",
                 "name": "edge",
-                "released-at": "2019-01-04T10:11:12.123456789+00:00",
+                "released-at": "2022-10-19T17:00:00+00:00",
                 "risk": "edge",
                 "track": "latest"
             },
             "common-ids": [],
             "confinement": "strict",
-            "created-at": "2017-11-20T07:59:46.563940+00:00",
+            "created-at": "2019-04-17T16:43:58.548661+00:00",
             "download": {
                 "deltas": [],
-                "sha3-384": "d888ed75a9071ace39fed922aa799cad4081de79fda650fbbf75e1bae780dae2c24a19aab8db5059c6ad0d0533d90c04",
+                "sha3-384": "b07bdb78e762c2e6020c75fafc92055b323a6f8da3ab42a3963da5ade386aba11f77e3c8f919b8aa23f3aa5c06c844f9",
                 "size": 20480,
-                "url": "https://api.snapcraft.io/api/v1/snaps/download/buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ_28.snap"
+                "url": "https://api.snapcraft.io/api/v1/snaps/download/buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ_30.snap"
             },
             "epoch": {
                 "read": [
@@ -1230,28 +1228,40 @@ const mockInfoJSON = `{
                     0
                 ]
             },
-            "revision": 28,
+            "revision": 30,
             "snap-yaml": "",
             "type": "app",
-            "version": "6.3"
+            "version": "6.5"
         }
     ],
+    "default-track": null,
     "name": "hello-world",
     "snap": {
-        "contact": "mailto:snappy-devel@lists.ubuntu.com",
+        "contact": "mailto:snaps@canonical.com",
         "description": "This is a simple hello world example.",
         "license": "MIT",
+        "links": {
+            "contact": [
+                "mailto:snaps@canonical.com"
+            ]
+        },
         "media": [
             {
-                "height": null,
+                "height": 256,
                 "type": "icon",
                 "url": "https://dashboard.snapcraft.io/site_media/appmedia/2015/03/hello.svg_NZLfWbh.png",
-                "width": null
+                "width": 256
+            },
+            {
+                "height": 118,
+                "type": "screenshot",
+                "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/06/Screenshot_from_2018-06-14_09-33-31.png",
+                "width": 199
             },
             {
                 "height": null,
-                "type": "screenshot",
-                "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/06/Screenshot_from_2018-06-14_09-33-31.png",
+                "type": "video",
+                "url": "https://vimeo.com/194577403",
                 "width": null
             }
         ],
@@ -1266,7 +1276,8 @@ const mockInfoJSON = `{
         },
         "snap-id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
         "summary": "The 'hello-world' of snaps",
-        "title": "Hello World"
+        "title": "Hello World",
+        "website": null
     },
     "snap-id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ"
 }`
@@ -1315,7 +1326,7 @@ func (s *storeTestSuite) TestInfo(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(result.InstanceName(), Equals, "hello-world")
 	c.Check(result.Architectures, DeepEquals, []string{"all"})
-	c.Check(result.Revision, Equals, snap.R(27))
+	c.Check(result.Revision, Equals, snap.R(29))
 	c.Check(result.SnapID, Equals, helloWorldSnapID)
 	c.Check(result.Publisher, Equals, snap.StoreAccount{
 		ID:          "canonical",
@@ -1323,7 +1334,7 @@ func (s *storeTestSuite) TestInfo(c *C) {
 		DisplayName: "Canonical",
 		Validation:  "verified",
 	})
-	c.Check(result.Version, Equals, "6.3")
+	c.Check(result.Version, Equals, "6.4")
 	c.Check(result.Sha3_384, Matches, `[[:xdigit:]]{96}`)
 	c.Check(result.Size, Equals, int64(20480))
 	c.Check(result.Channel, Equals, "stable")
@@ -1335,15 +1346,25 @@ func (s *storeTestSuite) TestInfo(c *C) {
 	c.Check(result.Paid, Equals, true)
 	c.Check(result.Media, DeepEquals, snap.MediaInfos{
 		{
-			Type: "icon",
-			URL:  "https://dashboard.snapcraft.io/site_media/appmedia/2015/03/hello.svg_NZLfWbh.png",
+			Type:   "icon",
+			URL:    "https://dashboard.snapcraft.io/site_media/appmedia/2015/03/hello.svg_NZLfWbh.png",
+			Width:  256,
+			Height: 256,
 		}, {
-			Type: "screenshot",
-			URL:  "https://dashboard.snapcraft.io/site_media/appmedia/2018/06/Screenshot_from_2018-06-14_09-33-31.png",
+			Type:   "screenshot",
+			URL:    "https://dashboard.snapcraft.io/site_media/appmedia/2018/06/Screenshot_from_2018-06-14_09-33-31.png",
+			Width:  199,
+			Height: 118,
+		}, {
+			Type: "video",
+			URL:  "https://vimeo.com/194577403",
 		},
 	})
 	c.Check(result.MustBuy, Equals, true)
-	c.Check(result.Contact(), Equals, "mailto:snappy-devel@lists.ubuntu.com")
+	c.Check(result.Links(), DeepEquals, map[string][]string{
+		"contact": {"mailto:snaps@canonical.com"},
+	})
+	c.Check(result.Contact(), Equals, "mailto:snaps@canonical.com")
 	c.Check(result.Base, Equals, "bogus-base")
 	c.Check(result.Epoch.String(), Equals, "0")
 	c.Check(sto.SuggestedCurrency(), Equals, "GBP")
@@ -1554,40 +1575,40 @@ func (s *storeTestSuite) TestInfoAndChannels(c *C) {
 	c.Check(result.InstanceName(), Equals, "hello-world")
 	expected := map[string]*snap.ChannelSnapInfo{
 		"latest/stable": {
-			Revision:    snap.R(27),
-			Version:     "6.3",
+			Revision:    snap.R(29),
+			Version:     "6.4",
 			Confinement: snap.StrictConfinement,
 			Channel:     "latest/stable",
 			Size:        20480,
 			Epoch:       snap.E("0"),
-			ReleasedAt:  time.Date(2019, 1, 1, 10, 11, 12, 123456789, time.UTC),
+			ReleasedAt:  time.Date(2019, 4, 17, 16, 47, 59, 117114000, time.UTC),
 		},
 		"latest/candidate": {
-			Revision:    snap.R(27),
-			Version:     "6.3",
+			Revision:    snap.R(29),
+			Version:     "6.4",
 			Confinement: snap.StrictConfinement,
 			Channel:     "latest/candidate",
 			Size:        20480,
 			Epoch:       snap.E("0"),
-			ReleasedAt:  time.Date(2019, 1, 2, 10, 11, 12, 123456789, time.UTC),
+			ReleasedAt:  time.Date(2019, 4, 17, 16, 47, 59, 117114000, time.UTC),
 		},
 		"latest/beta": {
-			Revision:    snap.R(27),
-			Version:     "6.3",
+			Revision:    snap.R(29),
+			Version:     "6.4",
 			Confinement: snap.StrictConfinement,
 			Channel:     "latest/beta",
 			Size:        20480,
 			Epoch:       snap.E("0"),
-			ReleasedAt:  time.Date(2019, 1, 3, 10, 11, 12, 123456789, time.UTC),
+			ReleasedAt:  time.Date(2019, 4, 17, 16, 48, 9, 906850000, time.UTC),
 		},
 		"latest/edge": {
-			Revision:    snap.R(28),
-			Version:     "6.3",
+			Revision:    snap.R(30),
+			Version:     "6.5",
 			Confinement: snap.StrictConfinement,
 			Channel:     "latest/edge",
 			Size:        20480,
 			Epoch:       snap.E("0"),
-			ReleasedAt:  time.Date(2019, 1, 4, 10, 11, 12, 123456789, time.UTC),
+			ReleasedAt:  time.Date(2022, 10, 19, 17, 0, 0, 0, time.UTC),
 		},
 	}
 	for k, v := range result.Channels {
@@ -2005,7 +2026,7 @@ curl -s -H "accept: application/hal+json" -H "X-Ubuntu-Release: 16" -H "X-Ubuntu
 
 And then add base and prices, increase title's length, and remove the _links dict
 */
-const MockSearchJSON = `{
+const mockSearchJSON = `{
     "_embedded": {
         "clickindex:package": [
             {
@@ -2018,7 +2039,7 @@ const MockSearchJSON = `{
                 "channel": "stable",
                 "common_ids": [],
                 "confinement": "strict",
-                "contact": "mailto:snappy-devel@lists.ubuntu.com",
+                "contact": "mailto:snaps@canonical.com",
                 "content": "application",
                 "description": "This is a simple hello world example.",
                 "developer_id": "canonical",
@@ -2056,52 +2077,60 @@ const MockSearchJSON = `{
 }
 `
 
-// curl -H 'Snap-Device-Series:16' 'https://api.snapcraft.io/v2/snaps/search?architecture=amd64&confinement=strict%2Cclassic&fields=base%2Cconfinement%2Ccontact%2Cdescription%2Cdownload%2Clicense%2Cprices%2Cprivate%2Cpublisher%2Crevision%2Csummary%2Ctitle%2Ctype%2Cversion%2Cmedia%2Cchannel&q=hello-world+of+snaps'
-const MockSearchJSONv2 = `
+// curl -H 'Snap-Device-Series:16' 'https://api.snapcraft.io/v2/snaps/find?architecture=amd64&confinement=strict%2Cclassic&fields=base%2Cconfinement%2Ccontact%2Cdescription%2Cdownload%2Clicense%2Clinks%2Cprices%2Cprivate%2Cpublisher%2Crevision%2Cstore-url%2Csummary%2Ctitle%2Ctype%2Cversion%2Cmedia%2Cchannel&q=hello-world+of+snaps'
+const mockSearchJSONv2 = `
 {
 	"results" : [
 	   {
-		  "name" : "hello-world",
-		  "snap-id" : "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
-		  "revision" : {
-			 "base" : "bare-base",
-			 "download" : {
-				"size" : 20480
-			 },
-			 "type" : "app",
-			 "version" : "6.3",
-			 "confinement" : "strict",
-			 "revision" : 27,
-			 "common-ids" : ["aaa", "bbb"],
-			 "channel" : "stable"
-		  },
-		  "snap" : {
-			 "publisher" : {
-				"username" : "canonical",
-				"validation" : "verified",
-				"id" : "canonical",
-				"display-name" : "Canonical"
-			 },
-			 "contact" : "mailto:snappy-devel@lists.ubuntu.com",
-			 "media" : [
-				{
-				   "type" : "icon",
-				   "url" : "https://dashboard.snapcraft.io/site_media/appmedia/2015/03/hello.svg_NZLfWbh.png"
-				},
-				{
-				   "type" : "screenshot",
-				   "url" : "https://dashboard.snapcraft.io/site_media/appmedia/2018/06/Screenshot_from_2018-06-14_09-33-31.png"
-				}
-			 ],
-			 "summary" : "The 'hello-world' of snaps",
-			 "store-url" : "https://snapcraft.io/hello-world",
-			 "website": "https://ubuntu.com",
-			 "private" : false,
-			 "prices": {"EUR": "2.99", "USD": "3.49"},
-			 "description" : "This is a simple hello world example.",
-			 "license" : "MIT",
-			 "title" : "This Is The Most Fantastical Snap of Hello World"
-		  }
+              "name": "hello-world",
+              "revision": {
+                "base": "bare-base",
+                "channel": "stable",
+                "confinement": "strict",
+                "download": {
+                  "size": 20480
+                },
+                "revision": 27,
+                "common-ids" : ["aaa", "bbb"],
+                "type": "app",
+                "version": "6.3"
+              },
+              "snap": {
+                "contact": "mailto:snaps@canonical.com",
+                "description": "This is a simple hello world example.",
+                "license": "MIT",
+                "links": {
+                  "contact": [
+                    "mailto:snaps@canonical.com"
+                  ],
+                  "website": [
+                    "https://ubuntu.com"
+                  ]
+                },
+                "media": [
+                  {
+                    "type": "icon",
+                    "url": "https://dashboard.snapcraft.io/site_media/appmedia/2015/03/hello.svg_NZLfWbh.png"
+                  },
+                  {
+                    "type": "screenshot",
+                    "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/06/Screenshot_from_2018-06-14_09-33-31.png"
+                  }
+                ],
+                "prices": {"EUR": "2.99", "USD": "3.49"},
+                "private": false,
+                "publisher": {
+                  "display-name": "Canonical",
+                  "id": "canonical",
+                  "username": "canonical",
+                  "validation": "verified"
+                },
+                "store-url": "https://snapcraft.io/hello-world",
+                "summary": "The 'hello-world' of snaps",
+                "website": "https://ubuntu.com",
+                "title": "This Is The Most Fantastical Snap of Hello World"
+              },
+              "snap-id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ"
 	   }
 	]
  }
@@ -2514,7 +2543,7 @@ func (s *storeTestSuite) testFind(c *C, apiV1 bool) {
 			w.Header().Set("Content-Type", "application/hal+json")
 			w.WriteHeader(200)
 
-			io.WriteString(w, MockSearchJSON)
+			io.WriteString(w, mockSearchJSON)
 		} else {
 
 			// check device authorization is set, implicitly checking doRequest was used
@@ -2535,7 +2564,7 @@ func (s *storeTestSuite) testFind(c *C, apiV1 bool) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(200)
 
-			io.WriteString(w, MockSearchJSONv2)
+			io.WriteString(w, mockSearchJSONv2)
 		}
 	}))
 
@@ -2587,7 +2616,7 @@ func (s *storeTestSuite) testFind(c *C, apiV1 bool) {
 		},
 	})
 	c.Check(snp.MustBuy, Equals, true)
-	c.Check(snp.Contact(), Equals, "mailto:snappy-devel@lists.ubuntu.com")
+	c.Check(snp.Contact(), Equals, "mailto:snaps@canonical.com")
 	c.Check(snp.Base, Equals, "bare-base")
 
 	// Make sure the epoch (currently not sent by the store) defaults to "0"
@@ -2600,7 +2629,11 @@ func (s *storeTestSuite) testFind(c *C, apiV1 bool) {
 		c.Check(snp.Sha3_384, Matches, `[[:xdigit:]]{96}`)
 		c.Check(v1Fallback, Equals, true)
 	} else {
-		c.Check(snp.Website, Equals, "https://ubuntu.com")
+		c.Check(snp.Links(), DeepEquals, map[string][]string{
+			"contact": {"mailto:snaps@canonical.com"},
+			"website": {"https://ubuntu.com"},
+		})
+		c.Check(snp.Website(), Equals, "https://ubuntu.com")
 		c.Check(snp.StoreURL, Equals, "https://snapcraft.io/hello-world")
 		c.Check(snp.CommonIDs, DeepEquals, []string{"aaa", "bbb"})
 		c.Check(v2Hit, Equals, true)
@@ -2624,7 +2657,7 @@ func (s *storeTestSuite) TestFindV2FindFields(c *C) {
 	sort.Strings(findFields)
 	c.Assert(findFields, DeepEquals, []string{
 		"base", "channel", "common-ids", "confinement", "contact",
-		"description", "download", "license", "media", "prices", "private",
+		"description", "download", "license", "links", "media", "prices", "private",
 		"publisher", "revision", "store-url", "summary", "title", "type",
 		"version", "website"})
 }
@@ -2675,12 +2708,12 @@ func (s *storeTestSuite) testFindPrivate(c *C, apiV1 bool) {
 		if apiV1 {
 			w.Header().Set("Content-Type", "application/hal+json")
 			w.WriteHeader(200)
-			io.WriteString(w, strings.Replace(MockSearchJSON, `"EUR": 2.99, "USD": 3.49`, "", -1))
+			io.WriteString(w, strings.Replace(mockSearchJSON, `"EUR": 2.99, "USD": 3.49`, "", -1))
 
 		} else {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(200)
-			io.WriteString(w, strings.Replace(MockSearchJSON, `"EUR": "2.99", "USD": "3.49"`, "", -1))
+			io.WriteString(w, strings.Replace(mockSearchJSON, `"EUR": "2.99", "USD": "3.49"`, "", -1))
 		}
 
 		n++
@@ -2832,9 +2865,9 @@ func (s *storeTestSuite) testFindBadContentType(c *C, apiV1 bool) {
 		}
 		c.Check(r.URL.Query().Get("q"), Equals, "hello")
 		if apiV1 {
-			io.WriteString(w, MockSearchJSON)
+			io.WriteString(w, mockSearchJSON)
 		} else {
-			io.WriteString(w, MockSearchJSONv2)
+			io.WriteString(w, mockSearchJSONv2)
 		}
 	}))
 	c.Assert(mockServer, NotNil)
@@ -3019,11 +3052,11 @@ func (s *storeTestSuite) testFind500OnceThenSucceed(c *C, apiV1 bool) {
 			if apiV1 {
 				w.Header().Set("Content-Type", "application/hal+json")
 				w.WriteHeader(200)
-				io.WriteString(w, strings.Replace(MockSearchJSON, `"EUR": 2.99, "USD": 3.49`, "", -1))
+				io.WriteString(w, strings.Replace(mockSearchJSON, `"EUR": 2.99, "USD": 3.49`, "", -1))
 			} else {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(200)
-				io.WriteString(w, strings.Replace(MockSearchJSONv2, `"EUR": "2.99", "USD": "3.49"`, "", -1))
+				io.WriteString(w, strings.Replace(mockSearchJSONv2, `"EUR": "2.99", "USD": "3.49"`, "", -1))
 			}
 		}
 	}))
@@ -3084,10 +3117,10 @@ func (s *storeTestSuite) testFindAuthFailed(c *C, apiV1 bool) {
 			}
 			if apiV1 {
 				w.Header().Set("Content-Type", "application/hal+json")
-				io.WriteString(w, MockSearchJSON)
+				io.WriteString(w, mockSearchJSON)
 			} else {
 				w.Header().Set("Content-Type", "application/json")
-				io.WriteString(w, MockSearchJSONv2)
+				io.WriteString(w, mockSearchJSONv2)
 			}
 		case ordersPath:
 			c.Check(r.Header.Get("Authorization"), Equals, expectedAuthorization(c, s.user))
@@ -3164,13 +3197,13 @@ func (s *storeTestSuite) testFindCommonIDs(c *C, apiV1 bool) {
 		if apiV1 {
 			w.Header().Set("Content-Type", "application/hal+json")
 			w.WriteHeader(200)
-			io.WriteString(w, strings.Replace(MockSearchJSON,
+			io.WriteString(w, strings.Replace(mockSearchJSON,
 				`"common_ids": []`,
 				`"common_ids": ["org.hello"]`, -1))
 		} else {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(200)
-			io.WriteString(w, MockSearchJSONv2)
+			io.WriteString(w, mockSearchJSONv2)
 		}
 
 		n++
@@ -3235,13 +3268,13 @@ func (s *storeTestSuite) testFindByCommonID(c *C, apiV1 bool) {
 		if apiV1 {
 			w.Header().Set("Content-Type", "application/hal+json")
 			w.WriteHeader(200)
-			io.WriteString(w, strings.Replace(MockSearchJSON,
+			io.WriteString(w, strings.Replace(mockSearchJSON,
 				`"common_ids": []`,
 				`"common_ids": ["org.hello"]`, -1))
 		} else {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(200)
-			io.WriteString(w, MockSearchJSONv2)
+			io.WriteString(w, mockSearchJSONv2)
 		}
 
 		n++


### PR DESCRIPTION
to be backward compatible both in terms of what happens on a snapd revert or
dealing with data saved by an old snapd we still need to operate on the
fields/storage locations previously used for contact and website
