### PR TITLE
many: add system-seed-null partition role

### DIFF
--- a/boot/initramfs20dirs.go
+++ b/boot/initramfs20dirs.go
@@ -68,6 +68,10 @@ var (
 	// keys during the initramfs on ubuntu-boot.
 	InitramfsBootEncryptionKeyDir string
 
+	// InstallUbuntuDataDir is the location of the data partition during
+	// install mode. This should always be on a physical partition.
+	InstallUbuntuDataDir string
+
 	// snapBootFlagsFile is the location of the file that is used
 	// internally for saving the current boot flags active for this boot.
 	snapBootFlagsFile string
@@ -78,9 +82,9 @@ var (
 // partition.
 func InstallHostWritableDir(mod gadget.Model) string {
 	if mod.Classic() {
-		return filepath.Join(InitramfsRunMntDir, "ubuntu-data")
+		return InstallUbuntuDataDir
 	}
-	return filepath.Join(InitramfsRunMntDir, "ubuntu-data", "system-data")
+	return filepath.Join(InstallUbuntuDataDir, "system-data")
 }
 
 // InitramfsHostWritableDir is the location of the host writable
@@ -125,6 +129,8 @@ func setInitramfsDirVars(rootdir string) {
 	InstallHostFDESaveDir = filepath.Join(InstallHostDeviceSaveDir, "fde")
 	InitramfsSeedEncryptionKeyDir = filepath.Join(InitramfsUbuntuSeedDir, "device/fde")
 	InitramfsBootEncryptionKeyDir = filepath.Join(InitramfsUbuntuBootDir, "device/fde")
+
+	InstallUbuntuDataDir = filepath.Join(InitramfsRunMntDir, "ubuntu-data")
 
 	snapBootFlagsFile = filepath.Join(dirs.SnapRunDir, "boot-flags")
 }

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -53,10 +53,11 @@ const (
 	// schemaGPT identifies a GUID Partition Table partitioning schema
 	schemaGPT = "gpt"
 
-	SystemBoot = "system-boot"
-	SystemData = "system-data"
-	SystemSeed = "system-seed"
-	SystemSave = "system-save"
+	SystemBoot     = "system-boot"
+	SystemData     = "system-data"
+	SystemSeed     = "system-seed"
+	SystemSeedNull = "system-seed-null"
+	SystemSave     = "system-save"
 
 	// extracted kernels for all uc systems
 	bootImage = "system-boot-image"
@@ -1018,7 +1019,7 @@ func validateRole(vs *VolumeStructure) error {
 	}
 
 	switch vsRole {
-	case SystemData, SystemSeed, SystemSave:
+	case SystemData, SystemSeed, SystemSeedNull, SystemSave:
 		// roles have cross dependencies, consistency checks are done at
 		// the volume level
 	case schemaMBR:

--- a/gadget/gadgettest/examples.go
+++ b/gadget/gadgettest/examples.go
@@ -824,6 +824,75 @@ const MultiVolumeUC20GadgetYaml = SingleVolumeUC20GadgetYaml + `
         size: 1G
 `
 
+const SingleVolumeClassicwithModesNoEncryptGadgetYaml = `
+volumes:
+  pc:
+    schema: gpt
+    bootloader: grub
+    structure:
+      - name: mbr
+        type: mbr
+        size: 440
+      - name: BIOS Boot
+        type: DA,21686148-6449-6E6F-744E-656564454649
+        size: 1M
+        offset: 1M
+        offset-write: mbr+92
+      - name: EFI System Partition
+        role: system-seed-null
+        filesystem: vfat
+        # UEFI will boot the ESP partition by default first
+        type: EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+        size: 1200M
+      - name: ubuntu-boot
+        role: system-boot
+        filesystem: ext4
+        type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
+        size: 750M
+      - name: ubuntu-data
+        role: system-data
+        filesystem: ext4
+        type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
+        size: 1G
+`
+
+const SingleVolumeClassicwithModesEncryptGadgetYaml = `
+volumes:
+  pc:
+    schema: gpt
+    bootloader: grub
+    structure:
+      - name: mbr
+        type: mbr
+        size: 440
+      - name: BIOS Boot
+        type: DA,21686148-6449-6E6F-744E-656564454649
+        size: 1M
+        offset: 1M
+        offset-write: mbr+92
+      - name: EFI System Partition
+        role: system-seed-null
+        filesystem: vfat
+        # UEFI will boot the ESP partition by default first
+        type: EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+        size: 1200M
+      - name: ubuntu-boot
+        role: system-boot
+        filesystem: ext4
+        type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
+        size: 750M
+      - name: ubuntu-save
+        role: system-save
+        filesystem: ext4
+        type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
+        size: 16M
+      - name: ubuntu-data
+        role: system-data
+        filesystem: ext4
+        type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
+        size: 1G
+`
+
 var VMExtraVolumeDiskMapping = &disks.MockDiskMapping{
 	DevNode: "/dev/vdb",
 	DevPath: "/sys/devices/pci0000:00/0000:00:04.0/virtio2/block/vdb",

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/boot"
@@ -356,7 +355,7 @@ func Run(model gadget.Model, gadgetRoot, kernelRoot, bootDevice string, options 
 			partsEncrypted[part.Name] = createEncryptionParams(options.EncryptionType)
 		}
 		if options.Mount && part.Label != "" && part.HasFilesystem() {
-			if err := mountFilesystem(fsDevice, part.Filesystem, filepath.Join(boot.InitramfsRunMntDir, part.Label)); err != nil {
+			if err := mountFilesystem(fsDevice, part.Filesystem, getMntPointForPart(part.VolumeStructure)); err != nil {
 				return nil, err
 			}
 		}
@@ -526,12 +525,30 @@ func WriteContent(onVolumes map[string]*gadget.Volume, allLaidOutVols map[string
 	return onDiskVols, nil
 }
 
+// getMntPointForPart tells us where to mount a given structure so we
+// match what the functions that write something expect.
+func getMntPointForPart(part *gadget.VolumeStructure) (mntPt string) {
+	switch part.Role {
+	case gadget.SystemSeed, gadget.SystemSeedNull:
+		mntPt = boot.InitramfsUbuntuSeedDir
+	case gadget.SystemBoot:
+		mntPt = boot.InitramfsUbuntuBootDir
+	case gadget.SystemSave:
+		mntPt = boot.InitramfsUbuntuSaveDir
+	case gadget.SystemData:
+		mntPt = boot.InstallUbuntuDataDir
+	default:
+		mntPt = filepath.Join(boot.InitramfsRunMntDir, part.Name)
+	}
+	return mntPt
+}
+
 // MountVolumes mounts partitions for the volumes specified by
-// onVolumes. It returns the ESP partition and a function that needs
-// to be called for unmounting them.
-func MountVolumes(onVolumes map[string]*gadget.Volume, encSetupData *EncryptionSetupData) (espMntDir string, unmount func() error, err error) {
+// onVolumes. It returns the partition with the system-seed{,-null}
+// role and a function that needs to be called for unmounting them.
+func MountVolumes(onVolumes map[string]*gadget.Volume, encSetupData *EncryptionSetupData) (seedMntDir string, unmount func() error, err error) {
 	var mountPoints []string
-	numEsp := 0
+	numSeedPart := 0
 	unmount = func() (err error) {
 		for _, mntPt := range mountPoints {
 			errUnmount := sysUnmount(mntPt, 0)
@@ -550,7 +567,12 @@ func MountVolumes(onVolumes map[string]*gadget.Volume, encSetupData *EncryptionS
 			if part.Filesystem == "" {
 				continue
 			}
-			mntPt := filepath.Join(boot.InitramfsRunMntDir, part.Name)
+			mntPt := getMntPointForPart(&part)
+			switch part.Role {
+			case gadget.SystemSeed, gadget.SystemSeedNull:
+				seedMntDir = mntPt
+				numSeedPart++
+			}
 			// Device might have been encrypted
 			device := deviceForMaybeEncryptedVolume(&part, encSetupData)
 
@@ -559,19 +581,14 @@ func MountVolumes(onVolumes map[string]*gadget.Volume, encSetupData *EncryptionS
 				return "", nil, fmt.Errorf("cannot mount %q at %q: %v", device, mntPt, err)
 			}
 			mountPoints = append(mountPoints, mntPt)
-
-			if strings.Contains(strings.ToUpper(part.Type), gadget.GPTPartitionGUIDESP) {
-				espMntDir = mntPt
-				numEsp++
-			}
 		}
 	}
-	if numEsp != 1 {
+	if numSeedPart != 1 {
 		defer unmount()
-		return "", nil, fmt.Errorf("there are %d ESP partitions, expected one", numEsp)
+		return "", nil, fmt.Errorf("there are %d system-seed{,-null} partitions, expected one", numSeedPart)
 	}
 
-	return espMntDir, unmount, nil
+	return seedMntDir, unmount, nil
 }
 
 func SaveStorageTraits(model gadget.Model, allLaidOutVols map[string]*gadget.LaidOutVolume, encryptSetupData *EncryptionSetupData) error {

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -425,7 +425,7 @@ func prepareEncryptedSystemData(model *asserts.Model, keyForRole map[string]keys
 
 	// keep track of recovery assets
 	if err := trustedInstallObserver.ObserveExistingTrustedRecoveryAssets(boot.InitramfsUbuntuSeedDir); err != nil {
-		return fmt.Errorf("cannot observe existing trusted recovery assets: err")
+		return fmt.Errorf("cannot observe existing trusted recovery assets: %v", err)
 	}
 	if err := saveKeys(model, keyForRole); err != nil {
 		return err

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -1360,8 +1360,8 @@ func (m *DeviceManager) doInstallFinish(t *state.Task, _ *tomb.Tomb) error {
 		return fmt.Errorf("cannot write content: %v", err)
 	}
 
-	// Mount the partitions and find ESP partition
-	espMntDir, unmountParts, err := installMountVolumes(onVolumes, encryptSetupData)
+	// Mount the partitions and find the system-seed{,-null} partition
+	seedMntDir, unmountParts, err := installMountVolumes(onVolumes, encryptSetupData)
 	if err != nil {
 		return fmt.Errorf("cannot mount partitions for installation: %v", err)
 	}
@@ -1391,15 +1391,15 @@ func (m *DeviceManager) doInstallFinish(t *state.Task, _ *tomb.Tomb) error {
 		RecoverySystemLabel: systemLabel,
 	}
 
-	// installs in ESP: grub.cfg, grubenv
-	logger.Debugf("making the ESP partition bootable, mount dir is %q", espMntDir)
+	// installs in system-seed{,-null} partition: grub.cfg, grubenv
+	logger.Debugf("making the system-seed{,-null} partition bootable, mount dir is %q", seedMntDir)
 	opts := &bootloader.Options{
 		PrepareImageTime: false,
 		// We need the same configuration that a recovery partition,
 		// as we will chainload to grub in the boot partition.
 		Role: bootloader.RoleRecovery,
 	}
-	if err := bootMakeBootablePartition(espMntDir, opts, bootWith, boot.ModeRun, nil); err != nil {
+	if err := bootMakeBootablePartition(seedMntDir, opts, bootWith, boot.ModeRun, nil); err != nil {
 		return err
 	}
 

--- a/tests/lib/fakeinstaller/main.go
+++ b/tests/lib/fakeinstaller/main.go
@@ -254,7 +254,7 @@ func createAndMountFilesystems(bootDevice string, volumes map[string]*gadget.Vol
 
 	var mountPoints []string
 	for _, volStruct := range vol.Structure {
-		if volStruct.Label == "" || volStruct.Filesystem == "" {
+		if volStruct.Filesystem == "" {
 			continue
 		}
 

--- a/tests/lib/fakeinstaller/main.go
+++ b/tests/lib/fakeinstaller/main.go
@@ -266,7 +266,7 @@ func createAndMountFilesystems(bootDevice string, volumes map[string]*gadget.Vol
 			}
 			partNode = encryptedDevice
 		} else {
-			part, err := disk.FindMatchingPartitionWithPartLabel(volStruct.Label)
+			part, err := disk.FindMatchingPartitionWithPartLabel(volStruct.Name)
 			if err != nil {
 				return nil, err
 			}

--- a/tests/nested/manual/fakeinstaller/task.yaml
+++ b/tests/nested/manual/fakeinstaller/task.yaml
@@ -80,6 +80,13 @@ execute: |
   uc20_build_initramfs_kernel_snap "$PWD/pc-kernel.snap" "$NESTED_ASSETS_DIR"
   mv "${NESTED_ASSETS_DIR}"/pc-kernel_*.snap pc-kernel.snap
 
+  # Prepare gadget with the right gadget.yaml
+  snap download --basename=pc --channel="$version/edge" pc
+  unsquashfs -d pc pc.snap
+  sed -i 's/name: ubuntu-seed/name: EFI System partition/' pc/meta/gadget.yaml
+  sed -i 's/role: system-seed/role: system-seed-null/' pc/meta/gadget.yaml
+  snap pack --filename=pc-new.snap pc
+
   # prepare a classic seed
   # TODO:
   # - create pc-classic custom gadget
@@ -90,6 +97,7 @@ execute: |
   snap prepare-image --classic \
       --channel=edge \
       --snap ./pc-kernel.snap \
+      --snap ./pc-new.snap \
       my.model \
       ./classic-seed
   cp -a ./classic-seed/system-seed/ /var/lib/snapd/seed
@@ -112,7 +120,7 @@ execute: |
   MATCH "${loop_device}p1 .* name=\"BIOS Boot\""   < fdisk_output
   # TODO: the real MVP hybrid device will not contain a ubuntu-seed
   #       partition (needs a different gadget)
-  MATCH "${loop_device}p2 .* name=\"ubuntu-seed\"" < fdisk_output
+  MATCH "${loop_device}p2 .* name=\"EFI System partition\"" < fdisk_output
   MATCH "${loop_device}p3 .* name=\"ubuntu-boot\"" < fdisk_output
   MATCH "${loop_device}p4 .* name=\"ubuntu-save\"" < fdisk_output
   MATCH "${loop_device}p5 .* name=\"ubuntu-data\"" < fdisk_output

--- a/tests/nested/manual/fde-on-classic/gadget.yaml
+++ b/tests/nested/manual/fde-on-classic/gadget.yaml
@@ -20,6 +20,7 @@ volumes:
         content:
           - image: pc-core.img
       - name: EFI System partition
+        role: system-seed-null
         filesystem: vfat
         # UEFI will boot the ESP partition by default first
         type: EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B
@@ -46,8 +47,7 @@ volumes:
           - source: shim.efi.signed
             target: EFI/boot/bootx64.efi
       - name: ubuntu-save
-        # XXX this makes snap pack unhappy ATM!
-        # role: system-save
+        role: system-save
         filesystem: ext4
         type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
         size: 16M


### PR DESCRIPTION
The system-seed-null partition role will be used when there is a boot partition which bootloader runs before the bootloader/kernel in the boot partition. The difference with system-seed is that for this one there are no system seeds available, although eventually it could happen that those are added.