### PR TITLE
cmd/snap: improve refresh hold's output

### DIFF
--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -942,9 +942,9 @@ func (x *cmdRefresh) holdRefreshes() (err error) {
 
 	var timeStr string
 	if opts.Time == "forever" {
-		timeStr = "indefinitely"
+		timeStr = i18n.G("indefinitely")
 	} else {
-		timeStr = fmt.Sprintf("until %s", opts.Time)
+		timeStr = fmt.Sprintf(i18n.G("until %s"), opts.Time)
 	}
 
 	if len(names) == 0 {

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -940,16 +940,17 @@ func (x *cmdRefresh) holdRefreshes() (err error) {
 		return err
 	}
 
+	var timeStr string
+	if opts.Time == "forever" {
+		timeStr = "indefinitely"
+	} else {
+		timeStr = fmt.Sprintf("until %s", opts.Time)
+	}
+
 	if len(names) == 0 {
-		var timeStr string
-		if opts.Time == "forever" {
-			timeStr = "indefinitely"
-		} else {
-			timeStr = fmt.Sprintf("until %s", opts.Time)
-		}
 		fmt.Fprintf(Stdout, i18n.G("Auto-refresh of all snaps held %s\n"), timeStr)
 	} else {
-		fmt.Fprintf(Stdout, i18n.G("General refreshes of %s held until %s\n"), strutil.Quoted(names), opts.Time)
+		fmt.Fprintf(Stdout, i18n.G("General refreshes of %s held %s\n"), strutil.Quoted(names), timeStr)
 	}
 
 	return nil

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -941,7 +941,13 @@ func (x *cmdRefresh) holdRefreshes() (err error) {
 	}
 
 	if len(names) == 0 {
-		fmt.Fprintf(Stdout, i18n.G("Auto-refresh of all snaps held until %s\n"), opts.Time)
+		var timeStr string
+		if opts.Time == "forever" {
+			timeStr = "indefinitely"
+		} else {
+			timeStr = fmt.Sprintf("until %s", opts.Time)
+		}
+		fmt.Fprintf(Stdout, i18n.G("Auto-refresh of all snaps held %s\n"), timeStr)
 	} else {
 		fmt.Fprintf(Stdout, i18n.G("General refreshes of %s held until %s\n"), strutil.Quoted(names), opts.Time)
 	}

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -1435,7 +1435,7 @@ func (s *SnapSuite) TestRefreshHoldAllForever(c *check.C) {
 	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--hold"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
-	c.Check(s.Stdout(), check.Equals, "Auto-refresh of all snaps held until forever\n")
+	c.Check(s.Stdout(), check.Equals, "Auto-refresh of all snaps held indefinitely\n")
 	c.Check(s.Stderr(), check.Equals, "")
 }
 

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -1558,7 +1558,7 @@ func (s *SnapSuite) TestRefreshHoldSnapForever(c *check.C) {
 	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--hold", "foo"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
-	c.Check(s.Stdout(), check.Equals, "General refreshes of \"foo\" held until forever\n")
+	c.Check(s.Stdout(), check.Equals, "General refreshes of \"foo\" held indefinitely\n")
 	c.Check(s.Stderr(), check.Equals, "")
 }
 


### PR DESCRIPTION
This PR corrects the output of `snap refresh --hold` which was returning from "Auto-refresh of all snaps held until forever" instead of "... held forever". Thanks @degville for noticing and suggesting a better alternative. Requesting @pedronis' review in case you prefer to keep "forever" for consistency.