### PR TITLE
release: Fix WSL detection in LXD (LP1995083)

### DIFF
--- a/release/export_test.go
+++ b/release/export_test.go
@@ -56,3 +56,9 @@ var (
 	GetWSLVersion      = getWSLVersion
 	FilesystemRootType = filesystemRootType
 )
+
+const (
+	Wslfs = wslfs
+	Lxfs  = lxfs
+	Ext4  = ext4
+)

--- a/release/export_test.go
+++ b/release/export_test.go
@@ -43,16 +43,8 @@ func MockFileExists(mockFileExists func(string) bool) (restorer func()) {
 	}
 }
 
-func MockFilesystemRootType(filesystemName string) (restorer func()) {
-	// Cannot use testutil.Backup due to import loop
-	old := filesystemRootType
-	filesystemRootType = func() (string, error) { return filesystemName, nil }
-	return func() {
-		filesystemRootType = old
-	}
-}
-
 var (
 	GetWSLVersion      = getWSLVersion
 	FilesystemRootType = filesystemRootType
+	ProcMountsPath     = &procMountsPath
 )

--- a/release/export_test.go
+++ b/release/export_test.go
@@ -43,10 +43,10 @@ func MockFileExists(mockFileExists func(string) bool) (restorer func()) {
 	}
 }
 
-func MockFilesystemRootType(filesystemID int64) (restorer func()) {
+func MockFilesystemRootType(filesystemName string) (restorer func()) {
 	// Cannot use testutil.Backup due to import loop
 	old := filesystemRootType
-	filesystemRootType = func() (int64, error) { return filesystemID, nil }
+	filesystemRootType = func() (string, error) { return filesystemName, nil }
 	return func() {
 		filesystemRootType = old
 	}
@@ -55,10 +55,4 @@ func MockFilesystemRootType(filesystemID int64) (restorer func()) {
 var (
 	GetWSLVersion      = getWSLVersion
 	FilesystemRootType = filesystemRootType
-)
-
-const (
-	Wslfs = wslfs
-	Lxfs  = lxfs
-	Ext4  = ext4
 )

--- a/release/release.go
+++ b/release/release.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"syscall"
 	"unicode"
 
 	"github.com/snapcore/snapd/strutil"
@@ -111,39 +110,50 @@ var fileExists = func(path string) bool {
 	return err == nil
 }
 
-var filesystemRootType = func() (int64, error) {
-	var statfs syscall.Statfs_t
-	if err := syscall.Statfs("/", &statfs); err != nil {
-		return 0, fmt.Errorf("cannot statfs filesystem root")
+// filesystemRootType returns the filesystem type mounted at "/".
+var filesystemRootType = func() (string, error) {
+	// We scan /proc/mounts, which contains space-separated values:
+	// [irrelevant] [mount point] [fstype] [irrelevant...]
+	// Here are some examples on some platforms:
+	// WSL1       :  rootfs / wslfs rw,noatime 0 0
+	// WSL2       :  /dev/sdc / ext4 rw,relatime,discard,errors=remount-ro,data=ordered 0 0
+	// lxc on WSL2:  /dev/loop0 / btrfs rw,relatime,idmapped,space_cache,user_subvol_rm_allowed,subvolid=259,subvol=/containers/testlxd 0 0
+	// We search for mount point = "/", and return the fstype.
+	file, err := os.Open("/proc/mounts")
+	if err != nil {
+		return "", fmt.Errorf("failed to find root filesystem type: %v", err)
 	}
-	// Type is int32 on 386, use explicit conversion to keep the code
-	// working for both
-	return int64(statfs.Type), nil
-}
+	defer file.Close()
 
-const (
-	wslfs int64 = 0x53464846
-	lxfs  int64 = 0x0 // ??? TODO: Find out
-	ext4  int64 = 0xef53
-)
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		data := strings.Fields(scanner.Text())
+		if len(data) < 3 || data[1] != "/" {
+			continue
+		}
+		return data[2], nil
+	}
+
+	return "", fmt.Errorf("failed to find root filesystem type: not in list")
+}
 
 // We detect WSL via the existence of /proc/sys/fs/binfmt_misc/WSLInterop
 // Under some undocumented circumstances this file may be missing. We have /run/WSL as a backup.
 //
 // We detect WSL1 via the root filesystem type:
-// - ext4 (Kernel magic: 0xef53) means WSL2
-// - wslfs (Kernel magic: 0x53464846) and  lxfs (Kernel magic: ?) mean WSL1
-// After knowing we're in WSL, if any error occurs we assume WSL1 as it is the more restrictive version
+// - wslfs or lxfs mean WSL1
+// - Anything else means WSL2
+// After knowing we're in WSL, if any error occurs we assume WSL2 as it is the more flexible version
 func getWSLVersion() int {
 	if !fileExists("/proc/sys/fs/binfmt_misc/WSLInterop") && !fileExists("/run/WSL") {
 		return 0
 	}
 	fstype, err := filesystemRootType()
 	if err != nil {
-		return 1
+		return 2
 	}
 
-	if fstype == wslfs || fstype == lxfs {
+	if fstype == "wslfs" || fstype == "lxfs" {
 		return 1
 	}
 	return 2

--- a/release/release.go
+++ b/release/release.go
@@ -121,6 +121,12 @@ var filesystemRootType = func() (int64, error) {
 	return int64(statfs.Type), nil
 }
 
+const (
+	wslfs int64 = 0x53464846
+	lxfs  int64 = 0x0 // ??? TODO: Find out
+	ext4  int64 = 0xef53
+)
+
 // We detect WSL via the existence of /proc/sys/fs/binfmt_misc/WSLInterop
 // Under some undocumented circumstances this file may be missing. We have /run/WSL as a backup.
 //
@@ -137,10 +143,10 @@ func getWSLVersion() int {
 		return 1
 	}
 
-	if fstype == 0xef53 { // ext
-		return 2
+	if fstype == wslfs {
+		return 1
 	}
-	return 1
+	return 2
 }
 
 // SystemctlSupportsUserUnits returns true if the systemctl utility

--- a/release/release.go
+++ b/release/release.go
@@ -110,8 +110,10 @@ var fileExists = func(path string) bool {
 	return err == nil
 }
 
+var procMountsPath = "/proc/mounts"
+
 // filesystemRootType returns the filesystem type mounted at "/".
-var filesystemRootType = func() (string, error) {
+func filesystemRootType() (string, error) {
 	// We scan /proc/mounts, which contains space-separated values:
 	// [irrelevant] [mount point] [fstype] [irrelevant...]
 	// Here are some examples on some platforms:
@@ -121,7 +123,7 @@ var filesystemRootType = func() (string, error) {
 	// We search for mount point = "/", and return the fstype.
 	//
 	// This should be done by osutil.LoadMountInfo but that would cause a dependency cycle
-	file, err := os.Open("/proc/mounts")
+	file, err := os.Open(procMountsPath)
 	if err != nil {
 		return "", fmt.Errorf("cannot find root filesystem type: %v", err)
 	}

--- a/release/release.go
+++ b/release/release.go
@@ -119,6 +119,8 @@ var filesystemRootType = func() (string, error) {
 	// WSL2       :  /dev/sdc / ext4 rw,relatime,discard,errors=remount-ro,data=ordered 0 0
 	// lxc on WSL2:  /dev/loop0 / btrfs rw,relatime,idmapped,space_cache,user_subvol_rm_allowed,subvolid=259,subvol=/containers/testlxd 0 0
 	// We search for mount point = "/", and return the fstype.
+	//
+	// This should be done by osutil.LoadMountInfo but that would cause a dependency cycle
 	file, err := os.Open("/proc/mounts")
 	if err != nil {
 		return "", fmt.Errorf("cannot find root filesystem type: %v", err)

--- a/release/release.go
+++ b/release/release.go
@@ -121,7 +121,7 @@ var filesystemRootType = func() (string, error) {
 	// We search for mount point = "/", and return the fstype.
 	file, err := os.Open("/proc/mounts")
 	if err != nil {
-		return "", fmt.Errorf("failed to find root filesystem type: %v", err)
+		return "", fmt.Errorf("cannot find root filesystem type: %v", err)
 	}
 	defer file.Close()
 

--- a/release/release.go
+++ b/release/release.go
@@ -137,10 +137,10 @@ var filesystemRootType = func() (string, error) {
 	}
 
 	if err = scanner.Err(); err != nil {
-		return "", fmt.Errorf("failed to find root filesystem type: %v", err)
+		return "", fmt.Errorf("cannot find root filesystem type: %v", err)
 	}
 
-	return "", fmt.Errorf("failed to find root filesystem type: not in list")
+	return "", fmt.Errorf("cannot find root filesystem type: not in list")
 }
 
 // We detect WSL via the existence of /proc/sys/fs/binfmt_misc/WSLInterop

--- a/release/release.go
+++ b/release/release.go
@@ -143,7 +143,7 @@ func getWSLVersion() int {
 		return 1
 	}
 
-	if fstype == wslfs {
+	if fstype == wslfs || fstype == lxfs {
 		return 1
 	}
 	return 2

--- a/release/release.go
+++ b/release/release.go
@@ -136,6 +136,10 @@ var filesystemRootType = func() (string, error) {
 		return data[2], nil
 	}
 
+	if err = scanner.Err(); err != nil {
+		return "", fmt.Errorf("failed to find root filesystem type: %v", err)
+	}
+
 	return "", fmt.Errorf("failed to find root filesystem type: not in list")
 }
 

--- a/release/release.go
+++ b/release/release.go
@@ -156,6 +156,7 @@ func getWSLVersion() int {
 	}
 	fstype, err := filesystemRootType()
 	if err != nil {
+		// TODO log error here once logger can be imported without circular imports
 		return 2
 	}
 

--- a/release/release_test.go
+++ b/release/release_test.go
@@ -21,9 +21,7 @@ package release_test
 
 import (
 	"io/ioutil"
-	"os/exec"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	. "gopkg.in/check.v1"
@@ -167,25 +165,6 @@ func (s *ReleaseTestSuite) TestReleaseInfo(c *C) {
 	})
 	defer reset()
 	c.Assert(release.ReleaseInfo.ID, Equals, "distro-id")
-}
-
-func (s *ReleaseTestSuite) TestFilesystemRootType(c *C) {
-	output, err := exec.Command("df", "--output=fstype", "/").CombinedOutput()
-	c.Assert(err, IsNil)
-	// $ df --output=fstype / # Example output on WSL1
-	// Type
-	// wslfs
-
-	fields := strings.Fields(string(output))
-	c.Check(len(fields), Equals, 2)
-
-	wants := strings.TrimSpace(fields[1])
-	c.Assert(err, IsNil)
-
-	got, err := release.FilesystemRootType()
-	c.Assert(err, IsNil)
-
-	c.Check(wants, Equals, got)
 }
 
 func (s *ReleaseTestSuite) TestNonWSL(c *C) {

--- a/release/release_test.go
+++ b/release/release_test.go
@@ -66,12 +66,6 @@ BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"
 	return mockOSRelease
 }
 
-// Kernel magic numbers
-const (
-	wslfs int64 = 0x53464846
-	ext4  int64 = 0xef53
-)
-
 func mockWSLsetup(c *C, existsWSLinterop bool, existsRunWSL bool, filesystemID int64) func() {
 	restoreFileExists := release.MockFileExists(func(s string) bool {
 		if s == "/proc/sys/fs/binfmt_misc/WSLInterop" {
@@ -193,25 +187,31 @@ func (s *ReleaseTestSuite) TestFilesystemRootType(c *C) {
 }
 
 func (s *ReleaseTestSuite) TestNonWSL(c *C) {
-	defer mockWSLsetup(c, false, false, ext4)()
+	defer mockWSLsetup(c, false, false, Ext4)()
 	v := release.GetWSLVersion()
 	c.Check(v, Equals, 0)
 }
 
 func (s *ReleaseTestSuite) TestWSL1(c *C) {
-	defer mockWSLsetup(c, true, true, wslfs)()
+	defer mockWSLsetup(c, true, true, Wslfs)()
+	v := release.GetWSLVersion()
+	c.Check(v, Equals, 1)
+}
+
+func (s *ReleaseTestSuite) TestWSL1(c *C) {
+	defer mockWSLsetup(c, true, true, Lxfs)()
 	v := release.GetWSLVersion()
 	c.Check(v, Equals, 1)
 }
 
 func (s *ReleaseTestSuite) TestWSL2(c *C) {
-	defer mockWSLsetup(c, true, true, ext4)()
+	defer mockWSLsetup(c, true, true, Ext4)()
 	v := release.GetWSLVersion()
 	c.Check(v, Equals, 2)
 }
 
 func (s *ReleaseTestSuite) TestWSL2NoInterop(c *C) {
-	defer mockWSLsetup(c, false, true, ext4)()
+	defer mockWSLsetup(c, false, true, Ext4)()
 	v := release.GetWSLVersion()
 	c.Check(v, Equals, 2)
 }

--- a/release/release_test.go
+++ b/release/release_test.go
@@ -72,10 +72,11 @@ func MockFilesystemRootType(c *C, fsType string) (restorer func()) {
 	c.Assert(err, IsNil)
 
 	// Sample contents of /proc/mounts. The second line is the one that matters.
-	tmpfile.Write([]byte(fmt.Sprintf(`none /usr/lib/wsl/lib overlay rw,relatime,lowerdir=/gpu_lib_packaged:/gpu_lib_inbox,upperdir=/gpu_lib/rw/upper,workdir=/gpu_lib/rw/work 0 0
+	_, err = tmpfile.Write([]byte(fmt.Sprintf(`none /usr/lib/wsl/lib overlay rw,relatime,lowerdir=/gpu_lib_packaged:/gpu_lib_inbox,upperdir=/gpu_lib/rw/upper,workdir=/gpu_lib/rw/work 0 0
 /dev/sdc / %s rw,relatime,discard,errors=remount-ro,data=ordered 0 0
 none /mnt/wslg tmpfs rw,relatime 0 0
 `, fsType)))
+	c.Assert(err, IsNil)
 
 	restorer = testutil.Backup(release.ProcMountsPath)
 	*release.ProcMountsPath = tmpfile.Name()

--- a/release/release_test.go
+++ b/release/release_test.go
@@ -187,31 +187,31 @@ func (s *ReleaseTestSuite) TestFilesystemRootType(c *C) {
 }
 
 func (s *ReleaseTestSuite) TestNonWSL(c *C) {
-	defer mockWSLsetup(c, false, false, Ext4)()
+	defer mockWSLsetup(c, false, false, release.Ext4)()
 	v := release.GetWSLVersion()
 	c.Check(v, Equals, 0)
 }
 
 func (s *ReleaseTestSuite) TestWSL1(c *C) {
-	defer mockWSLsetup(c, true, true, Wslfs)()
+	defer mockWSLsetup(c, true, true, release.Wslfs)()
 	v := release.GetWSLVersion()
 	c.Check(v, Equals, 1)
 }
 
-func (s *ReleaseTestSuite) TestWSL1(c *C) {
-	defer mockWSLsetup(c, true, true, Lxfs)()
+func (s *ReleaseTestSuite) TestWSL1Old(c *C) {
+	defer mockWSLsetup(c, true, true, release.Lxfs)()
 	v := release.GetWSLVersion()
 	c.Check(v, Equals, 1)
 }
 
 func (s *ReleaseTestSuite) TestWSL2(c *C) {
-	defer mockWSLsetup(c, true, true, Ext4)()
+	defer mockWSLsetup(c, true, true, release.Ext4)()
 	v := release.GetWSLVersion()
 	c.Check(v, Equals, 2)
 }
 
 func (s *ReleaseTestSuite) TestWSL2NoInterop(c *C) {
-	defer mockWSLsetup(c, false, true, Ext4)()
+	defer mockWSLsetup(c, false, true, release.Ext4)()
 	v := release.GetWSLVersion()
 	c.Check(v, Equals, 2)
 }


### PR DESCRIPTION
The bug report is quite thorough:

---

###  [LP1995083](https://bugs.launchpad.net/snapd/+bug/1995083): Snapd broken in LXD container on WSL2

This was the report that made me investigate:
https://github.com/ubuntu/WSL/issues/299#issuecomment-1294232561

The issue is that snapd correctly identifies that it is running on WSL, but cannot detect it is running on WSL2 so it falls back to thinking it is running on WSL1. The issue happens here:
https://github.com/snapcore/snapd/blob/3c05e535e5cff4b64e4427e38494795fbbfd5122/release/release.go#L140-L245

In particular, this happens because WSL2 is detected by finding when the root filesystem is of type ext, but on LXC it is btrfs.

Once snapd thinks it is running on WSL1, it refuses to perform any action:
```
# snap list
Interacting with snapd is not yet supported on Windows Subsystem for Linux 1.
This command has been left available for documentation purposes only.
```

---

The fix is to default to WSL2 when the filesystem type is not any of the expected ones.