### PR TITLE
tests: get microk8s from another branch

### DIFF
--- a/tests/main/microk8s-smoke/task.yaml
+++ b/tests/main/microk8s-smoke/task.yaml
@@ -14,7 +14,7 @@ systems:
   - -ubuntu-*-arm*    # not available on arm
 
 environment:
-    CHANNEL/edge: latest/edge/strict
+    CHANNEL/edge: 1.25-strict/edge
 
 prepare: |
     # ensure curl is available (needed for Ubuntu Core)


### PR DESCRIPTION
The latest/edge/strict branch does not exist anymore, and latest/edge is a classic snap.
