### PR TITLE
client: remove misleading comments in ValidateApplyOptions

### DIFF
--- a/client/validate.go
+++ b/client/validate.go
@@ -38,10 +38,10 @@ type ValidateApplyOptions struct {
 type ValidationSetResult struct {
 	AccountID string `json:"account-id"`
 	Name      string `json:"name"`
-	// set sequence key and optional pinned-at (=)
+
 	Sequence int `json:"sequence,omitempty"`
 	PinnedAt int `json:"pinned-at,omitempty"`
-	// set current state
+
 	Mode  string `json:"mode"`
 	Valid bool   `json:"valid"`
 	// TODO: flags/states for notes column


### PR DESCRIPTION
We noticed some copy/paste comments in client/validate.go in ValidationSetResult. This commit removes them as they are misleading.
