### PR TITLE
tests/main/degraded: ignore man-db update failures in CentOS

### DIFF
--- a/tests/main/degraded/task.yaml
+++ b/tests/main/degraded/task.yaml
@@ -31,6 +31,9 @@ execute: |
         centos-8-*)
             # tries to load ipmi_si module which fails with ENODEV
             systemctl reset-failed systemd-modules-load.service
+            # These transient units attempt to update the man page cache, but
+            # fail with the error "Warning! D-Bus connection terminated."
+            systemctl reset-failed 'run-*'
             ;;
     esac
 


### PR DESCRIPTION
There usually are three failed transient units with the "run-*" name, which behave like this:

    ● run-r0b8a16d6cda843a490480bf722d1dbce.service - /usr/bin/systemctl start man-db-cache-update
       Loaded: loaded (/run/systemd/transient/run-r0b8a16d6cda843a490480bf722d1dbce.service; transient)
    Transient: yes
       Active: failed (Result: exit-code) since Wed 2022-11-02 12:43:51 UTC; 1min 48s ago
     Main PID: 1793 (code=exited, status=1/FAILURE)

    Nov 02 12:33:24 nov021231-806690 systemd[1]: Started /usr/bin/systemctl start man-db-cache-update.
    Nov 02 12:43:51 nov021231-806690 systemctl[1793]: Warning! D-Bus connection terminated.
    Nov 02 12:43:51 nov021231-806690 systemctl[1793]: Failed to wait for response: Connection reset by peer
