### PR TITLE
configcore: add option to set `service.ssh.listen-address`

### DIFF
--- a/overlord/configstate/configcore/corecfg_test.go
+++ b/overlord/configstate/configcore/corecfg_test.go
@@ -210,6 +210,8 @@ func (d mockDev) Kernel() string {
 var (
 	coreDev    = mockDev{classic: false}
 	classicDev = mockDev{classic: true}
+
+	core20Dev = mockDev{classic: false, uc20: true}
 )
 
 // applyCfgSuite tests configcore.Apply()

--- a/overlord/configstate/configcore/handlers.go
+++ b/overlord/configstate/configcore/handlers.go
@@ -74,7 +74,7 @@ func init() {
 	addFSOnlyHandler(validateNetworkSettings, handleNetworkConfiguration, coreOnly)
 
 	// service.*.disable
-	addFSOnlyHandler(nil, handleServiceDisableConfiguration, coreOnly)
+	addFSOnlyHandler(validateServiceConfiguration, handleServiceConfiguration, coreOnly)
 
 	// system.power-key-action
 	addFSOnlyHandler(nil, handlePowerButtonConfiguration, coreOnly)

--- a/overlord/configstate/configcore/services.go
+++ b/overlord/configstate/configcore/services.go
@@ -370,9 +370,8 @@ func handleServiceConfigSSHListen(dev sysconfig.Device, tr config.ConfGetter, op
 		return err
 	}
 
-	var sysd systemd.Systemd
 	if opts == nil {
-		sysd = systemd.New(systemd.SystemMode, &sysdLogger{})
+		sysd := systemd.New(systemd.SystemMode, &sysdLogger{})
 		if err := sysd.ReloadOrRestart("ssh.service"); err != nil {
 			return err
 		}

--- a/overlord/configstate/configcore/services.go
+++ b/overlord/configstate/configcore/services.go
@@ -249,7 +249,8 @@ func handleServiceConfiguration(dev sysconfig.Device, tr config.ConfGetter, opts
 
 func parseOneSSHListenAddr(oneAddr string) (addrs []string, err error) {
 	// 1. check if it's something like "host:port", "[host]:port" etc
-	//    (this will return an error if there is no
+	//    This will return an error if there is no port specified so
+	//    on error it's assume there is no port.
 	host, portStr, err := net.SplitHostPort(oneAddr)
 	if err != nil {
 		// for any error assume there is no port and continue
@@ -314,7 +315,7 @@ func validateServiceConfiguration(tr config.ConfGetter) error {
 }
 
 func handleServiceConfigSSHListen(dev sysconfig.Device, tr config.ConfGetter, opts *fsOnlyContext) error {
-	// see if anything needs to happenhan
+	// see if anything needs to happen
 	var pristineSSHListen, newSSHListen interface{}
 
 	if err := tr.GetPristine("core", sshListenOpt, &pristineSSHListen); err != nil && !config.IsNoOption(err) {

--- a/overlord/configstate/configcore/services.go
+++ b/overlord/configstate/configcore/services.go
@@ -371,14 +371,11 @@ func handleServiceConfigSSHListen(dev sysconfig.Device, tr config.ConfGetter, op
 	}
 
 	var sysd systemd.Systemd
-	if opts != nil {
-		sysd = systemd.NewEmulationMode(opts.RootDir)
-	} else {
+	if opts == nil {
 		sysd = systemd.New(systemd.SystemMode, &sysdLogger{})
-	}
-
-	if err := sysd.ReloadOrRestart("ssh.service"); err != nil {
-		return err
+		if err := sysd.ReloadOrRestart("ssh.service"); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/overlord/configstate/configcore/services.go
+++ b/overlord/configstate/configcore/services.go
@@ -307,7 +307,7 @@ func validateServiceConfiguration(tr config.ConfGetter) error {
 		return nil
 	}
 	if _, err := parseSSHListenCfg(output); err != nil {
-		return err
+		return fmt.Errorf("cannot validate ssh configuration: %v", err)
 	}
 
 	return nil

--- a/overlord/configstate/configcore/services.go
+++ b/overlord/configstate/configcore/services.go
@@ -259,16 +259,16 @@ func parseOneSSHListenAddr(oneAddr string) (addrs []string, err error) {
 	if portStr != "" {
 		port, err := strconv.Atoi(portStr)
 		if err != nil {
-			return nil, fmt.Errorf("cannot parse port number: %v", err)
+			return nil, fmt.Errorf("port must be a number: %v", err)
 		}
 		if port > 65535 || port < 1 {
-			return nil, fmt.Errorf("cannot use port %v: must be in the range 1-65535", port)
+			return nil, fmt.Errorf("port %v must be in the range 1-65535", port)
 		}
 	}
 	// 3. validate host
 	if host != "" {
 		if net.ParseIP(host) == nil && validateHostname(host) != nil {
-			return nil, fmt.Errorf("cannot use %q as hostname", host)
+			return nil, fmt.Errorf("invalid hostname %q", host)
 		}
 	}
 

--- a/overlord/configstate/configcore/services_test.go
+++ b/overlord/configstate/configcore/services_test.go
@@ -384,7 +384,7 @@ func (s *servicesSuite) TestConfigureNetworkIntegrationSSHPort(c *C) {
 	c.Assert(err, IsNil)
 
 	sshPortCfg := filepath.Join(dirs.GlobalRootDir, "/etc/ssh/sshd_config.d/port.conf")
-	c.Check(sshPortCfg, testutil.FileEquals, "Port 8022")
+	c.Check(sshPortCfg, testutil.FileEquals, "Port 8022\n")
 	c.Check(s.systemctlArgs, DeepEquals, [][]string{
 		{"reload-or-restart", "ssh.service"},
 	})

--- a/overlord/configstate/configcore/services_test.go
+++ b/overlord/configstate/configcore/services_test.go
@@ -356,7 +356,7 @@ func (s *servicesSuite) TestConfigureNetworkSSHListenAdressFailsWrongRange(c *C)
 				"service.ssh.listen-address": fmt.Sprintf(":%v", invalidPort),
 			},
 		})
-		c.Check(err, ErrorMatches, fmt.Sprintf("cannot validate ssh configuration: cannot use port %v: must be in the range 1-65535", invalidPort))
+		c.Check(err, ErrorMatches, fmt.Sprintf("cannot validate ssh configuration: port %v must be in the range 1-65535", invalidPort))
 	}
 }
 
@@ -366,14 +366,14 @@ func (s *servicesSuite) TestConfigureNetworkSSHListenAdressFailsWrongAddr(c *C) 
 		errStr  string
 	}{
 		// strange chars
-		{"x!", `cannot validate ssh configuration: cannot use "x!" as hostname`},
+		{"x!", `cannot validate ssh configuration: invalid hostname "x!"`},
 		// invalid ports
-		{"x:x", `cannot validate ssh configuration: cannot parse port number: strconv.Atoi: parsing "x": invalid syntax`},
-		{"x:123456", "cannot validate ssh configuration: cannot use port 123456: must be in the range 1-65535"},
+		{"x:x", `cannot validate ssh configuration: port must be a number: strconv.Atoi: parsing "x": invalid syntax`},
+		{"x:123456", "cannot validate ssh configuration: port 123456 must be in the range 1-65535"},
 		// too long
-		{"1234567890123456789012345678901234567890123456789012345678901234567890", `cannot validate ssh configuration: cannot use "1234567890123456789012345678901234567890123456789012345678901234567890" as hostname`},
+		{"1234567890123456789012345678901234567890123456789012345678901234567890", `cannot validate ssh configuration: invalid hostname "1234567890123456789012345678901234567890123456789012345678901234567890"`},
 		// mixing good/bad also rejected
-		{"valid-hostname,invalid!one", `cannot validate ssh configuration: cannot use "invalid!one" as hostname`},
+		{"valid-hostname,invalid!one", `cannot validate ssh configuration: invalid hostname "invalid!one"`},
 	} {
 		err := configcore.Run(core20Dev, &mockConf{
 			state: s.state,

--- a/overlord/configstate/configcore/services_test.go
+++ b/overlord/configstate/configcore/services_test.go
@@ -356,7 +356,7 @@ func (s *servicesSuite) TestConfigureNetworkSSHListenAdressFailsWrongRange(c *C)
 				"service.ssh.listen-address": fmt.Sprintf(":%v", invalidPort),
 			},
 		})
-		c.Check(err, ErrorMatches, fmt.Sprintf("cannot use port %v: must be in the range 1-65535", invalidPort))
+		c.Check(err, ErrorMatches, fmt.Sprintf("cannot validate ssh configuration: cannot use port %v: must be in the range 1-65535", invalidPort))
 	}
 }
 
@@ -366,14 +366,14 @@ func (s *servicesSuite) TestConfigureNetworkSSHListenAdressFailsWrongAddr(c *C) 
 		errStr  string
 	}{
 		// strange chars
-		{"x!", `cannot use "x!" as hostname`},
+		{"x!", `cannot validate ssh configuration: cannot use "x!" as hostname`},
 		// invalid ports
-		{"x:x", `cannot parse port number: strconv.Atoi: parsing "x": invalid syntax`},
-		{"x:123456", "cannot use port 123456: must be in the range 1-65535"},
+		{"x:x", `cannot validate ssh configuration: cannot parse port number: strconv.Atoi: parsing "x": invalid syntax`},
+		{"x:123456", "cannot validate ssh configuration: cannot use port 123456: must be in the range 1-65535"},
 		// too long
-		{"1234567890123456789012345678901234567890123456789012345678901234567890", `cannot use "1234567890123456789012345678901234567890123456789012345678901234567890" as hostname`},
+		{"1234567890123456789012345678901234567890123456789012345678901234567890", `cannot validate ssh configuration: cannot use "1234567890123456789012345678901234567890123456789012345678901234567890" as hostname`},
 		// mixing good/bad also rejected
-		{"valid-hostname,invalid!one", `cannot use "invalid!one" as hostname`},
+		{"valid-hostname,invalid!one", `cannot validate ssh configuration: cannot use "invalid!one" as hostname`},
 	} {
 		err := configcore.Run(core20Dev, &mockConf{
 			state: s.state,

--- a/overlord/configstate/configcore/services_test.go
+++ b/overlord/configstate/configcore/services_test.go
@@ -338,25 +338,80 @@ func (s *servicesSuite) TestFilesystemOnlyApply(c *C) {
 	})
 }
 
-func (s *servicesSuite) TestConfigureNetworkSSHPortFailsOnNonCore20(c *C) {
+func (s *servicesSuite) TestConfigureNetworkSSHListenAddressFailsOnNonCore20(c *C) {
 	err := configcore.Run(coreDev, &mockConf{
 		state: s.state,
 		changes: map[string]interface{}{
-			"service.ssh.port": 8022,
+			"service.ssh.listen-address": ":8022",
 		},
 	})
-	c.Assert(err, ErrorMatches, "cannot set ssh port configuration on systems older than UC20")
+	c.Assert(err, ErrorMatches, "cannot set ssh listen address configuration on systems older than UC20")
 }
 
-func (s *servicesSuite) TestConfigureNetworkSSHPortFailsWrongRange(c *C) {
+func (s *servicesSuite) TestConfigureNetworkSSHListenAdressFailsWrongRange(c *C) {
 	for _, invalidPort := range []int{0, 65536, -1, 99999} {
 		err := configcore.Run(coreDev, &mockConf{
 			state: s.state,
 			changes: map[string]interface{}{
-				"service.ssh.port": invalidPort,
+				"service.ssh.listen-address": fmt.Sprintf(":%v", invalidPort),
 			},
 		})
-		c.Assert(err, ErrorMatches, fmt.Sprintf("cannot use port %v: must be in the range 1-65535", invalidPort))
+		c.Check(err, ErrorMatches, fmt.Sprintf("cannot use port %v: must be in the range 1-65535", invalidPort))
+	}
+}
+
+func (s *servicesSuite) TestConfigureNetworkSSHListenAdressFailsWrongAddr(c *C) {
+	for _, tc := range []struct {
+		confStr string
+		errStr  string
+	}{
+		// strange chars
+		{"x!", `cannot use "x!" as hostname`},
+		// invalid ports
+		{"x:x", `cannot parse port number: strconv.Atoi: parsing "x": invalid syntax`},
+		{"x:123456", "cannot use port 123456: must be in the range 1-65535"},
+		// too long
+		{"1234567890123456789012345678901234567890123456789012345678901234567890", `cannot use "1234567890123456789012345678901234567890123456789012345678901234567890" as hostname`},
+		// mixing good/bad also rejected
+		{"valid-hostname,invalid!one", `cannot use "invalid!one" as hostname`},
+	} {
+		err := configcore.Run(core20Dev, &mockConf{
+			state: s.state,
+			changes: map[string]interface{}{
+				"service.ssh.listen-address": tc.confStr,
+			},
+		})
+		c.Check(err, ErrorMatches, tc.errStr, Commentf(tc.confStr))
+	}
+}
+
+func (s *servicesSuite) TestConfigureNetworkValid(c *C) {
+	sshListenCfg := filepath.Join(dirs.GlobalRootDir, "/etc/ssh/sshd_config.d/listen.conf")
+
+	for _, tc := range []struct {
+		confStr string
+		sshConf string
+	}{
+		// valid hostnames/IPs
+		{"host", "ListenAddress host\n"},
+		{"10.0.2.2", "ListenAddress 10.0.2.2\n"},
+		{"::1", "ListenAddress ::1\n"},
+		{"[::1]:8022", "ListenAddress [::1]:8022\n"},
+		{"2001", "ListenAddress 2001\n"},
+		{"2001.net", "ListenAddress 2001.net\n"},
+		// port only
+		{":9022", "ListenAddress 0.0.0.0:9022\nListenAddress [::]:9022\n"},
+		// multiple ones
+		{"host1,host2", "ListenAddress host1\nListenAddress host2\n"},
+	} {
+		err := configcore.Run(core20Dev, &mockConf{
+			state: s.state,
+			changes: map[string]interface{}{
+				"service.ssh.listen-address": tc.confStr,
+			},
+		})
+		c.Assert(err, IsNil)
+		c.Check(sshListenCfg, testutil.FileEquals, tc.sshConf)
 	}
 }
 
@@ -364,27 +419,27 @@ func (s *servicesSuite) TestSamePortNoChange(c *C) {
 	err := configcore.Run(core20Dev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
-			"service.ssh.port": 8022,
+			"service.ssh.listen-address": ":8022",
 		},
 		changes: map[string]interface{}{
-			"service.ssh.port": 8022,
+			"service.ssh.listen-address": ":8022",
 		},
 	})
 	c.Assert(err, IsNil)
 	c.Check(s.systemctlArgs, HasLen, 0)
 }
 
-func (s *servicesSuite) TestConfigureNetworkIntegrationSSHPort(c *C) {
+func (s *servicesSuite) TestConfigureNetworkIntegrationSSHListenAddress(c *C) {
 	err := configcore.Run(core20Dev, &mockConf{
 		state: s.state,
 		changes: map[string]interface{}{
-			"service.ssh.port": 8022,
+			"service.ssh.listen-address": ":8022",
 		},
 	})
 	c.Assert(err, IsNil)
 
-	sshPortCfg := filepath.Join(dirs.GlobalRootDir, "/etc/ssh/sshd_config.d/port.conf")
-	c.Check(sshPortCfg, testutil.FileEquals, "Port 8022\n")
+	sshListenCfg := filepath.Join(dirs.GlobalRootDir, "/etc/ssh/sshd_config.d/listen.conf")
+	c.Check(sshListenCfg, testutil.FileEquals, "ListenAddress 0.0.0.0:8022\nListenAddress [::]:8022\n")
 	c.Check(s.systemctlArgs, DeepEquals, [][]string{
 		{"reload-or-restart", "ssh.service"},
 	})
@@ -393,12 +448,28 @@ func (s *servicesSuite) TestConfigureNetworkIntegrationSSHPort(c *C) {
 	err = configcore.Run(core20Dev, &mockConf{
 		state: s.state,
 		conf: map[string]interface{}{
-			"service.ssh.port": 8022,
+			"service.ssh.listen-address": ":8022",
 		},
 		changes: map[string]interface{}{
-			"service.ssh.port": "",
+			"service.ssh.listen-address": "",
 		},
 	})
 	c.Assert(err, IsNil)
-	c.Check(sshPortCfg, testutil.FileAbsent)
+	c.Check(sshListenCfg, testutil.FileAbsent)
+}
+
+func (s *servicesSuite) TestConfigureNetworkIntegrationSSHListenAddressMulti(c *C) {
+	err := configcore.Run(core20Dev, &mockConf{
+		state: s.state,
+		changes: map[string]interface{}{
+			"service.ssh.listen-address": ":8022,192.168.99.4:9922",
+		},
+	})
+	c.Assert(err, IsNil)
+
+	sshListenCfg := filepath.Join(dirs.GlobalRootDir, "/etc/ssh/sshd_config.d/listen.conf")
+	c.Check(sshListenCfg, testutil.FileEquals, "ListenAddress 0.0.0.0:8022\nListenAddress [::]:8022\nListenAddress 192.168.99.4:9922\n")
+	c.Check(s.systemctlArgs, DeepEquals, [][]string{
+		{"reload-or-restart", "ssh.service"},
+	})
 }

--- a/systemd/emulation.go
+++ b/systemd/emulation.go
@@ -91,7 +91,7 @@ func (s *emulation) Restart(services []string) error {
 }
 
 func (s *emulation) ReloadOrRestart(service string) error {
-	return &notImplementedError{"ReloadOrRestart"}
+	return nil
 }
 
 func (s *emulation) RestartAll(service string) error {

--- a/systemd/emulation.go
+++ b/systemd/emulation.go
@@ -91,7 +91,7 @@ func (s *emulation) Restart(services []string) error {
 }
 
 func (s *emulation) ReloadOrRestart(service string) error {
-	return nil
+	return &notImplementedError{"ReloadOrRestart"}
 }
 
 func (s *emulation) RestartAll(service string) error {

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -1002,7 +1002,7 @@ nested_start_core_vm_unit() {
 
     local PARAM_DISPLAY PARAM_NETWORK PARAM_MONITOR PARAM_USB PARAM_CD PARAM_RANDOM PARAM_CPU PARAM_TRACE PARAM_LOG PARAM_SERIAL PARAM_RTC
     PARAM_DISPLAY="-nographic"
-    PARAM_NETWORK="-net nic,model=virtio -net user,hostfwd=tcp::$NESTED_SSH_PORT-:22"
+    PARAM_NETWORK="-net nic,model=virtio -net user,hostfwd=tcp::$NESTED_SSH_PORT-:22,hostfwd=tcp::8023-:8023,hostfwd=tcp::9022-:9022"
     PARAM_MONITOR="-monitor tcp:127.0.0.1:$NESTED_MON_PORT,server=on,wait=off"
     PARAM_USB="-usb"
     PARAM_CD="${NESTED_PARAM_CD:-}"

--- a/tests/nested/manual/core20-early-config/defaults.yaml
+++ b/tests/nested/manual/core20-early-config/defaults.yaml
@@ -6,7 +6,7 @@ defaults:
       console-conf:
         disable: true
       ssh:
-        port: 8023
+        listen-address: :8023,192.168.99.4:9922
     watchdog:
       runtime-timeout: 13m
     system:

--- a/tests/nested/manual/core20-early-config/defaults.yaml
+++ b/tests/nested/manual/core20-early-config/defaults.yaml
@@ -5,6 +5,8 @@ defaults:
         disable: true
       console-conf:
         disable: true
+      ssh:
+        port: 8023
     watchdog:
       runtime-timeout: 13m
     system:

--- a/tests/nested/manual/core20-early-config/task.yaml
+++ b/tests/nested/manual/core20-early-config/task.yaml
@@ -115,7 +115,6 @@ execute: |
 
     check_core20_early_config
 
-    # XXX: this should be a different test maybe?
     echo "Check that switching the ssh port works"
     remote.exec "sudo snap set system service.ssh.listen-address=:9022" || true
     # we need to connect to 9022 now

--- a/tests/nested/manual/core20-early-config/task.yaml
+++ b/tests/nested/manual/core20-early-config/task.yaml
@@ -96,9 +96,9 @@ execute: |
         fi
 
         echo "Check the ssh port file is correct"
-        remote.exec "sudo cat /etc/ssh/sshd_config.d/listen.conf" | MATCH "ListenAddress 0.0.0.0:8023"
-        remote.exec "sudo cat /etc/ssh/sshd_config.d/listen.conf" | MATCH "ListenAddress [::]:8023"
-        remote.exec "sudo cat /etc/ssh/sshd_config.d/listen.conf" | MATCH "ListenAddress 192.168.99.4:9922"
+        remote.exec "sudo cat /etc/ssh/sshd_config.d/listen.conf" | MATCH "ListenAddress 0\.0\.0\.0:8023"
+        remote.exec "sudo cat /etc/ssh/sshd_config.d/listen.conf" | MATCH "ListenAddress \[::\]:8023"
+        remote.exec "sudo cat /etc/ssh/sshd_config.d/listen.conf" | MATCH "ListenAddress 192\.168\.99\.4:9922"
     }
 
     check_core20_early_config
@@ -121,8 +121,8 @@ execute: |
     remote.setup config --host localhost --port 9022 --user user1 --pass ubuntu
     "$TESTSLIB"/external/snapd-testing-tools/remote/remote.wait-for ssh
     remote.exec "sudo snap get system service.ssh.listen-address" | MATCH :9022
-    remote.exec "sudo cat /etc/ssh/sshd_config.d/listen.conf" | MATCH "ListenAddress 0.0.0.0:9022"
-    remote.exec "sudo cat /etc/ssh/sshd_config.d/listen.conf" | MATCH "ListenAddress [::1]:9022"
+    remote.exec "sudo cat /etc/ssh/sshd_config.d/listen.conf" | MATCH "ListenAddress 0\.0\.0\.0:9022"
+    remote.exec "sudo cat /etc/ssh/sshd_config.d/listen.conf" | MATCH "ListenAddress \[::\]:9022"
     echo "Check that unsetting the ssh port works"
     remote.exec "sudo snap unset system service.ssh.listen-address" || true
     # 8022 is the default port that is forwarded to "22" in the guest

--- a/tests/nested/manual/core20-early-config/task.yaml
+++ b/tests/nested/manual/core20-early-config/task.yaml
@@ -96,7 +96,9 @@ execute: |
         fi
 
         echo "Check the ssh port file is correct"
-        remote.exec "sudo cat /etc/ssh/sshd_config.d/port.conf" | MATCH "Port 8023"
+        remote.exec "sudo cat /etc/ssh/sshd_config.d/listen.conf" | MATCH "ListenAddress 0.0.0.0:8023"
+        remote.exec "sudo cat /etc/ssh/sshd_config.d/listen.conf" | MATCH "ListenAddress [::]:8023"
+        remote.exec "sudo cat /etc/ssh/sshd_config.d/listen.conf" | MATCH "ListenAddress 192.168.99.4:9922"
     }
 
     check_core20_early_config
@@ -115,15 +117,16 @@ execute: |
 
     # XXX: this should be a different test maybe?
     echo "Check that switching the ssh port works"
-    remote.exec "sudo snap set system service.ssh.port=9022" || true
+    remote.exec "sudo snap set system service.ssh.listen-address=:9022" || true
     # we need to connect to 9022 now
     remote.setup config --host localhost --port 9022 --user user1 --pass ubuntu
     "$TESTSLIB"/external/snapd-testing-tools/remote/remote.wait-for ssh
-    remote.exec "sudo snap get system service.ssh.port" | MATCH 9022
-    remote.exec "sudo cat /etc/ssh/sshd_config.d/port.conf" | MATCH "Port 9022"
+    remote.exec "sudo snap get system service.ssh.listen-address" | MATCH :9022
+    remote.exec "sudo cat /etc/ssh/sshd_config.d/listen.conf" | MATCH "ListenAddress 0.0.0.0:9022"
+    remote.exec "sudo cat /etc/ssh/sshd_config.d/listen.conf" | MATCH "ListenAddress [::1]:9022"
     echo "Check that unsetting the ssh port works"
-    remote.exec "sudo snap unset system service.ssh.port" || true
+    remote.exec "sudo snap unset system service.ssh.listen-address" || true
     # 8022 is the default port that is forwarded to "22" in the guest
     remote.setup config --host localhost --port 8022 --user user1 --pass ubuntu
     "$TESTSLIB"/external/snapd-testing-tools/remote/remote.wait-for ssh
-    remote.exec "sudo test ! -f /etc/ssh/sshd_config.d/port.conf"
+    remote.exec "sudo test ! -f /etc/ssh/sshd_config.d/listen.conf"

--- a/tests/nested/manual/core20-early-config/task.yaml
+++ b/tests/nested/manual/core20-early-config/task.yaml
@@ -29,7 +29,7 @@ prepare: |
     rm -f "$SNAKEOIL_KEY" "$SNAKEOIL_CERT"
 
     # Note that the early config is configured to set port to 8023 instead
-    # of the default 8022.
+    # of the default 8022 (which maps to 22 on the VM).
     remote.setup config --host localhost --port 8023 --user user1 --pass ubuntu
 
     tests.nested build-image core
@@ -94,6 +94,9 @@ execute: |
           # ensure the test can be repeated
           remote.exec "sudo rm -f /etc/netplan/90-snapd-config.yaml"
         fi
+
+        echo "Check the ssh port file is correct"
+        remote.exec "sudo cat /etc/ssh/sshd_config.d/port.conf" | MATCH "Port 8023"
     }
 
     check_core20_early_config
@@ -110,16 +113,17 @@ execute: |
 
     check_core20_early_config
 
-    echo "Check the ssh port file is correct"
-    remote.exec "cat /etc/ssh/sshd_config.d/port.conf" | MATCH "Port 8023"
+    # XXX: this should be a different test maybe?
     echo "Check that switching the ssh port works"
-    remote.exec "sudo snap set service.ssh.port=9022" || true
+    remote.exec "sudo snap set system service.ssh.port=9022" || true
     # we need to connect to 9022 now
     remote.setup config --host localhost --port 9022 --user user1 --pass ubuntu
-    remote.exec "sudo snap get service.ssh.port" | MATCH 9022
-    remote.exec "cat /etc/ssh/sshd_config.d/port.conf" | MATCH "Port 9022"
+    "$TESTSLIB"/external/snapd-testing-tools/remote/remote.wait-for ssh
+    remote.exec "sudo snap get system service.ssh.port" | MATCH 9022
+    remote.exec "sudo cat /etc/ssh/sshd_config.d/port.conf" | MATCH "Port 9022"
     echo "Check that unsetting the ssh port works"
-    remote.exec "sudo snap unset service.ssh.port" || true
+    remote.exec "sudo snap unset system service.ssh.port" || true
     # 8022 is the default port that is forwarded to "22" in the guest
     remote.setup config --host localhost --port 8022 --user user1 --pass ubuntu
-    remote.exec "not test -f /etc/ssh/sshd_config.d/port.conf"
+    "$TESTSLIB"/external/snapd-testing-tools/remote/remote.wait-for ssh
+    remote.exec "sudo test ! -f /etc/ssh/sshd_config.d/port.conf"

--- a/tests/nested/manual/core20-early-config/task.yaml
+++ b/tests/nested/manual/core20-early-config/task.yaml
@@ -6,6 +6,7 @@ environment:
     NESTED_ENABLE_TPM: true
     NESTED_ENABLE_SECURE_BOOT: true
     NESTED_BUILD_SNAPD_FROM_CURRENT: true
+    # gadget default.yaml uses port 8023
 
 prepare: |
     # Get the snakeoil key and cert
@@ -26,6 +27,10 @@ prepare: |
     snap pack pc-gadget/ "$(tests.nested get extra-snaps-path)"
 
     rm -f "$SNAKEOIL_KEY" "$SNAKEOIL_CERT"
+
+    # Note that the early config is configured to set port to 8023 instead
+    # of the default 8022.
+    remote.setup config --host localhost --port 8023 --user user1 --pass ubuntu
 
     tests.nested build-image core
     tests.nested create-vm core
@@ -104,3 +109,17 @@ execute: |
     remote.exec "sudo snap wait system seed.loaded"
 
     check_core20_early_config
+
+    echo "Check the ssh port file is correct"
+    remote.exec "cat /etc/ssh/sshd_config.d/port.conf" | MATCH "Port 8023"
+    echo "Check that switching the ssh port works"
+    remote.exec "sudo snap set service.ssh.port=9022" || true
+    # we need to connect to 9022 now
+    remote.setup config --host localhost --port 9022 --user user1 --pass ubuntu
+    remote.exec "sudo snap get service.ssh.port" | MATCH 9022
+    remote.exec "cat /etc/ssh/sshd_config.d/port.conf" | MATCH "Port 9022"
+    echo "Check that unsetting the ssh port works"
+    remote.exec "sudo snap unset service.ssh.port" || true
+    # 8022 is the default port that is forwarded to "22" in the guest
+    remote.setup config --host localhost --port 8022 --user user1 --pass ubuntu
+    remote.exec "not test -f /etc/ssh/sshd_config.d/port.conf"


### PR DESCRIPTION
This new config option allows setting the addresses that the ssh
daemon listens to.

Note that this option is only available on UC20+ systems because
to work during first boot it needs to write a default configuration
into the `/etc/ssh/sshd_config.d` directory. This directory is
only available in UC20+ versions of ssh.
