### PR TITLE
interfaces: add token2 fido2 security key in device list of u2f_devices.go

### DIFF
--- a/interfaces/builtin/u2f_devices.go
+++ b/interfaces/builtin/u2f_devices.go
@@ -162,6 +162,11 @@ var u2fDevices = []u2fDevice{
 		VendorIDPattern:  "16d0",
 		ProductIDPattern: "0e90",
 	},
+	{
+		Name:             "TOKEN2 FIDO2 Security Key",
+		VendorIDPattern:  "1ea8",
+		ProductIDPattern: "fc25",
+	},
 }
 
 const u2fDevicesConnectedPlugAppArmor = `


### PR DESCRIPTION
_Token2 is a cybersecurity company specialized in the area of multifactor authentication. Founded by a team of researchers and graduates from the University of Geneva with years of experience in the field of strong security and multifactor authentication, Token2 has invented, designed and developed various hardware and software solutions for user-friendly and secure authentication. Token2 is headquartered in Geneva, Switzerland_
[https://www.token2.eu/about](https://www.token2.eu/about)

This PR Add new device :  TOKEN2 FIDO2 Security Key
[https://www.token2.eu](https://www.token2.eu)

Some technical information : 
```
lsusb | grep FIDO
Bus 001 Device 010: ID 1ea8:fc25 TOKEN2 FIDO2 Security Key

1ea8h = 7848d ==> Shenzhen Excelsecu Data Technology Co., Ltd.
fc25h seems to be this : https://www.excelsecu.com/productdetail/fido2nfckey69.html
```

PS : I doesn't work on Token2 Company.

Thanks, 