### PR TITLE
sandbox: fix `apparmorSuite.SetUpTest`  when home.d/snap file exists

### DIFF
--- a/sandbox/apparmor/apparmor_test.go
+++ b/sandbox/apparmor/apparmor_test.go
@@ -48,10 +48,12 @@ var _ = Suite(&apparmorSuite{})
 
 func (s *apparmorSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
+
+	dirs.SetRootDir(c.MkDir())
 	s.AddCleanup(func() {
 		configFile := filepath.Join(dirs.GlobalRootDir, "/etc/apparmor.d/tunables/home.d/snapd")
-		if err := os.Remove(configFile); err != nil {
-			c.Assert(os.IsNotExist(err), Equals, true)
+		if err := os.RemoveAll(configFile); err != nil {
+			panic(err)
 		}
 	})
 }


### PR DESCRIPTION
The current `apparmorSuite.SetUpTest` has confusing behavior when there is a host file `/etc/apparmor.d/tunables/home.d/snapd`. In this case the tests fail with:
```
PANIC: apparmor_test.go:49: apparmorSuite.SetUpTest

... Panic: BaseTest cleanup handlers were not consumed before a new test start, missing BaseTest.TearDownTest call? (PC=0x437966)

/usr/lib/go-1.18/src/runtime/panic.go:838
  in gopanic
/home/egon/devel/go/src/github.com/snapcore/snapd/testutil/base.go:38
  in BaseTest.SetUpTest
apparmor_test.go:50
  in apparmorSuite.SetUpTest
/usr/lib/go-1.18/src/reflect/value.go:339
  in Value.Call
/usr/lib/go-1.18/src/runtime/asm_amd64.s:1571
  in goexit
```

This is because not all tests set the `dirs.GlobalRootDir` but the cleanup handlers try to remove the file
`filepath.Join(dirs.GlobalRootDir, "/etc/apparmor.d/tunables/home.d/snapd")` and assert that this works.

This commit fixes this in two ways:
1. always set the GlobalRootDir
2. instead of asserting in the cleanup handler use a panic

With the panic the error becomes obvious:
```
----------------------------------------------------------------------
PANIC: <autogenerated>:1: apparmorSuite.TearDownTest

... Panic: remove /etc/apparmor.d/tunables/home.d/snapd: permission denied (PC=0x437966)

/usr/lib/go-1.18/src/runtime/panic.go:838
  in gopanic
apparmor_test.go:55
  in apparmorSuite.SetUpTest.func1
/home/egon/devel/go/src/github.com/snapcore/snapd/testutil/base.go:55
  in BaseTest.TearDownTest
/usr/lib/go-1.18/src/reflect/value.go:339
  in Value.Call
/usr/lib/go-1.18/src/runtime/asm_amd64.s:1571
  in goexit

----------------------------------------------------------------------
PANIC: apparmor_test.go:60: apparmorSuite.TestAppArmorLevelTypeStringer
```
