### PR TITLE
aspects: support placeholders in aspect names

### DIFF
--- a/aspects/aspects.go
+++ b/aspects/aspects.go
@@ -257,10 +257,10 @@ func (p *accessPattern) getPath(name string) (string, error) {
 
 // matchedPlaceholders takes a dot-separated pattern with optional placeholders
 // and a name. To match the pattern, the name's dot-separated parts must be equal
-// to the pattern's non-placeholder parts (a pattern "foo.{bar}" is matched by a
-// name with a part "foo" followed by any part). It returns a map from placeholders
-// to their matches in the name (can be empty, if the path has no placeholders).
-// If there's no match, it returns nil.
+// to the pattern's non-placeholder parts. It returns a map from placeholders to
+// their matches in the name (can be empty, if the path has no placeholders). If
+// there's no match, it returns nil. For example, if pattern="{foo}.b.{bar}" and
+// name="a.b.c", then it returns {"foo": "a", "bar": "c"}.
 func matchedPlaceholders(pattern, name string) map[string]string {
 	patternParts, nameParts := strings.Split(pattern, "."), strings.Split(name, ".")
 
@@ -310,7 +310,7 @@ func fillInPlaceholders(path string, placeholderValues map[string]string) (strin
 			var ok bool
 			part, ok = placeholderValues[trimmedPart]
 			if !ok {
-				return "", fmt.Errorf("path placeholder %q is absent from the name", trimmedPart)
+				return "", fmt.Errorf("cannot find path placeholder %q in the aspect name", trimmedPart)
 			}
 		}
 

--- a/aspects/aspects.go
+++ b/aspects/aspects.go
@@ -256,9 +256,11 @@ func (p *accessPattern) getPath(name string) (string, error) {
 }
 
 // matchedPlaceholders takes a dot-separated pattern with optional placeholders
-// (e.g., "foo.{bar}") and a name. If the name fulfils the pattern, it returns
-// a map from placeholder names to their matches in the name. The map can be non-nil
-// but empty if no placeholders exist in the path. If there's no match, returns nil.
+// and a name. To match the pattern, the name's dot-separated parts must be equal
+// to the pattern's non-placeholder parts (a pattern "foo.{bar}" is matched by a
+// name with a part "foo" followed by any part). It returns a map from placeholders
+// to their matches in the name (can be empty, if the path has no placeholders).
+// If there's no match, it returns nil.
 func matchedPlaceholders(pattern, name string) map[string]string {
 	patternParts, nameParts := strings.Split(pattern, "."), strings.Split(name, ".")
 

--- a/aspects/aspects_test.go
+++ b/aspects/aspects_test.go
@@ -381,5 +381,5 @@ func (s *aspectSuite) TestAspectBadPlaceholderAssertion(c *C) {
 	aspect := aspectDir.Aspect("foo")
 
 	err = aspect.Set("bad.foo", "bar")
-	c.Assert(err, ErrorMatches, "path placeholder \"bar\" is absent from the name")
+	c.Assert(err, ErrorMatches, "cannot find path placeholder \"bar\" in the aspect name")
 }

--- a/aspects/aspects_test.go
+++ b/aspects/aspects_test.go
@@ -271,31 +271,31 @@ func (s *aspectSuite) TestAspectsAccessControl(c *C) {
 	}
 }
 
-type spyDataBag struct {
+type witnessDataBag struct {
 	bag              aspects.DataBag
 	getPath, setPath string
 }
 
-func newSpyDataBag(bag aspects.DataBag) *spyDataBag {
-	return &spyDataBag{bag: bag}
+func newSpyDataBag(bag aspects.DataBag) *witnessDataBag {
+	return &witnessDataBag{bag: bag}
 }
 
-func (s *spyDataBag) Get(path string, value interface{}) error {
+func (s *witnessDataBag) Get(path string, value interface{}) error {
 	s.getPath = path
 	return s.bag.Get(path, value)
 }
 
-func (s *spyDataBag) Set(path string, value interface{}) error {
+func (s *witnessDataBag) Set(path string, value interface{}) error {
 	s.setPath = path
 	return s.bag.Set(path, value)
 }
 
-func (s *spyDataBag) Data() ([]byte, error) {
+func (s *witnessDataBag) Data() ([]byte, error) {
 	return s.bag.Data()
 }
 
 // getLastPaths returns the last paths passed into Get and Set and resets them.
-func (s *spyDataBag) getLastPaths() (get, set string) {
+func (s *witnessDataBag) getLastPaths() (get, set string) {
 	get, set = s.getPath, s.setPath
 	s.getPath, s.setPath = "", ""
 	return get, set


### PR DESCRIPTION
Adds support for placeholders in the aspect's names (in the `{foo}` format) that can then be used to fill in the path.