### PR TITLE
client: remove classic check for `snap recovery --show-keys`

### DIFF
--- a/cmd/snap/cmd_recovery.go
+++ b/cmd/snap/cmd_recovery.go
@@ -20,7 +20,6 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -29,7 +28,6 @@ import (
 
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/i18n"
-	"github.com/snapcore/snapd/release"
 )
 
 type cmdRecovery struct {
@@ -65,9 +63,6 @@ func notesForSystem(sys *client.System) string {
 }
 
 func (x *cmdRecovery) showKeys(w io.Writer) error {
-	if release.OnClassic {
-		return errors.New(`command "show-keys" is not available on classic systems`)
-	}
 	var srk *client.SystemRecoveryKeysResponse
 	err := x.client.SystemRecoveryKeys(&srk)
 	if err != nil {

--- a/cmd/snap/cmd_recovery_test.go
+++ b/cmd/snap/cmd_recovery_test.go
@@ -154,17 +154,6 @@ func (s *SnapSuite) TestNoRecoverySystemsError(c *C) {
 	c.Check(err, ErrorMatches, `cannot list recovery systems: permission denied`)
 }
 
-func (s *SnapSuite) TestRecoveryShowRecoveryKeyOnClassicErrors(c *C) {
-	restore := release.MockOnClassic(true)
-	defer restore()
-
-	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
-		c.Fatalf("unexpected server call")
-	})
-	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"recovery", "--show-keys"})
-	c.Assert(err, ErrorMatches, `command "show-keys" is not available on classic systems`)
-}
-
 func (s *SnapSuite) TestRecoveryShowRecoveryKeyHappy(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()


### PR DESCRIPTION
The current client code has a check for `release.OnClassic` when running: `snap recovery --show-keys`. This check is silly because 
a) if anything it needs to be on the daemon side
b) now with classic+modes systems it's no longer valid

Hence this commit removes the check entirely. The error on a classic system without encryption is still sensible:
```
$ snap recovery --show-keys
error: system does not use disk encryption
```
