### PR TITLE
many: ensure Current in val set tracking matches PinnedAt (if != 0)

### DIFF
--- a/daemon/api_validate.go
+++ b/daemon/api_validate.go
@@ -113,7 +113,7 @@ func listValidationSets(c *Command, r *http.Request, _ *auth.UserState) Response
 	results := make([]validationSetResult, len(names))
 	for i, vs := range names {
 		tr := validationSets[vs]
-		sets, err := validationSetForTracked(st, tr)
+		sets, err := validationSetsForTracking(st, tr)
 		if err != nil {
 			return InternalError("cannot get assertion for validation set tracking %s/%s/%d: %v", tr.AccountID, tr.Name, tr.Sequence(), err)
 		}
@@ -146,7 +146,7 @@ func validationSetResultFromTracking(st *state.State, tr *assertstate.Validation
 		return nil, err
 	}
 
-	sets, err := validationSetForTracked(st, tr)
+	sets, err := validationSetsForTracking(st, tr)
 	if err != nil {
 		return nil, err
 	}
@@ -315,7 +315,7 @@ func forgetValidationSet(st *state.State, accountID, name string, sequence int) 
 	return SyncResponse(nil)
 }
 
-func validationSetForTracked(st *state.State, tr *assertstate.ValidationSetTracking) (*snapasserts.ValidationSets, error) {
+func validationSetsForTracking(st *state.State, tr *assertstate.ValidationSetTracking) (*snapasserts.ValidationSets, error) {
 	as, err := validationSetAssertFromDb(st, tr.AccountID, tr.Name, tr.Sequence())
 	if err != nil {
 		return nil, err

--- a/daemon/api_validate_test.go
+++ b/daemon/api_validate_test.go
@@ -102,7 +102,8 @@ func (s *apiValidationSetsSuite) mockValidationSetsTracking(st *state.State) {
 			"name":       "foo",
 			"mode":       assertstate.Enforce,
 			"pinned-at":  9,
-			"current":    99,
+			// Current should equal pinned-at if pinned-at != 0 but let's check api_validate is robust
+			"current": 99,
 		},
 		fmt.Sprintf("%s/baz", s.dev1acct.AccountID()): map[string]interface{}{
 			"account-id": s.dev1acct.AccountID(),
@@ -247,7 +248,7 @@ func (s *apiValidationSetsSuite) TestListValidationSets(c *check.C) {
 			Name:      "foo",
 			PinnedAt:  9,
 			Mode:      "enforce",
-			Sequence:  99,
+			Sequence:  9,
 			Valid:     false,
 		},
 	})
@@ -304,7 +305,7 @@ func (s *apiValidationSetsSuite) TestGetValidationSetPinned(c *check.C) {
 		Name:      "foo",
 		PinnedAt:  9,
 		Mode:      "enforce",
-		Sequence:  99,
+		Sequence:  9,
 		Valid:     false,
 	})
 }
@@ -614,6 +615,7 @@ func (s *apiValidationSetsSuite) TestApplyValidationSetMonitorModePinnedLocalOnl
 		c.Assert(name, check.Equals, "bar")
 		c.Assert(sequence, check.Equals, 99)
 		called++
+		// Current should be the same as PinnedAt when PinnedAt != 0 but let's check api_validate is robust
 		return &assertstate.ValidationSetTracking{AccountID: accountID, Name: name, PinnedAt: 99, Current: 99999}, nil
 	})
 	defer restore()
@@ -636,7 +638,7 @@ func (s *apiValidationSetsSuite) TestApplyValidationSetMonitorModePinnedLocalOnl
 		Name:      "bar",
 		Mode:      "monitor",
 		PinnedAt:  99,
-		Sequence:  99999,
+		Sequence:  99,
 		Valid:     true,
 	})
 	c.Check(called, check.Equals, 1)

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -3256,7 +3256,7 @@ func (s *assertMgrSuite) TestValidationSetAssertionForEnforceNotPinnedHappy(c *C
 	}
 
 	sequence := 0
-	vs, _, err := assertstate.ValidationSetAssertionForEnforce(st, s.dev1Acct.AccountID(), "bar", sequence, 0, snaps, nil)
+	vs, err := assertstate.ValidationSetAssertionForEnforce(st, s.dev1Acct.AccountID(), "bar", sequence, 0, snaps, nil)
 	c.Assert(err, IsNil)
 	c.Check(vs.Revision(), Equals, 2)
 	c.Check(vs.Sequence(), Equals, 2)
@@ -3293,11 +3293,10 @@ func (s *assertMgrSuite) TestValidationSetAssertionForEnforcePinnedHappy(c *C) {
 	}
 
 	sequence := 2
-	vs, cur, err := assertstate.ValidationSetAssertionForEnforce(st, s.dev1Acct.AccountID(), "bar", sequence, 0, snaps, nil)
+	vs, err := assertstate.ValidationSetAssertionForEnforce(st, s.dev1Acct.AccountID(), "bar", sequence, 0, snaps, nil)
 	c.Assert(err, IsNil)
 	c.Check(vs.Revision(), Equals, 2)
 	c.Check(vs.Sequence(), Equals, 2)
-	c.Check(cur, Equals, 2)
 
 	// and it has been committed
 	_, err = assertstate.DB(s.state).Find(asserts.ValidationSetType, map[string]string{
@@ -3329,7 +3328,7 @@ func (s *assertMgrSuite) TestValidationSetAssertionForEnforceNotPinnedUnhappyMis
 
 	snaps := []*snapasserts.InstalledSnap{}
 	sequence := 0
-	_, _, err := assertstate.ValidationSetAssertionForEnforce(st, s.dev1Acct.AccountID(), "bar", sequence, 0, snaps, nil)
+	_, err := assertstate.ValidationSetAssertionForEnforce(st, s.dev1Acct.AccountID(), "bar", sequence, 0, snaps, nil)
 	c.Assert(err, NotNil)
 	verr, ok := err.(*snapasserts.ValidationSetsValidationError)
 	c.Assert(ok, Equals, true)
@@ -3383,7 +3382,7 @@ func (s *assertMgrSuite) TestValidationSetAssertionForEnforceNotPinnedUnhappyCon
 
 	snaps := []*snapasserts.InstalledSnap{}
 	sequence := 0
-	_, _, err := assertstate.ValidationSetAssertionForEnforce(st, s.dev1Acct.AccountID(), "bar", sequence, 0, snaps, nil)
+	_, err := assertstate.ValidationSetAssertionForEnforce(st, s.dev1Acct.AccountID(), "bar", sequence, 0, snaps, nil)
 	c.Check(err, ErrorMatches, fmt.Sprintf(`validation sets are in conflict:\n- cannot constrain snap "foo" as both invalid \(%s/boo\) and required at revision 1 \(%s/bar\)`, s.dev1Acct.AccountID(), s.dev1Acct.AccountID()))
 
 	// and it hasn't been committed
@@ -3423,12 +3422,11 @@ func (s *assertMgrSuite) TestValidationSetAssertionForEnforceNotPinnedAfterForge
 	}
 
 	sequence := 0
-	vs, cur, err := assertstate.ValidationSetAssertionForEnforce(st, s.dev1Acct.AccountID(), "bar", sequence, 0, snaps, nil)
+	vs, err := assertstate.ValidationSetAssertionForEnforce(st, s.dev1Acct.AccountID(), "bar", sequence, 0, snaps, nil)
 	c.Assert(err, IsNil)
 	// new assertion got fetched
 	c.Check(vs.Revision(), Equals, 5)
 	c.Check(vs.Sequence(), Equals, 3)
-	c.Check(cur, Equals, 3)
 
 	// and it has been committed
 	_, err = assertstate.DB(s.state).Find(asserts.ValidationSetType, map[string]string{
@@ -3475,12 +3473,11 @@ func (s *assertMgrSuite) TestValidationSetAssertionForEnforceNotPinnedAfterMonit
 	}
 
 	sequence := 0
-	vs, cur, err := assertstate.ValidationSetAssertionForEnforce(st, s.dev1Acct.AccountID(), "bar", sequence, 0, snaps, nil)
+	vs, err := assertstate.ValidationSetAssertionForEnforce(st, s.dev1Acct.AccountID(), "bar", sequence, 0, snaps, nil)
 	c.Assert(err, IsNil)
 	// doesn't fetch new assertion
 	c.Check(vs.Revision(), Equals, 1)
 	c.Check(vs.Sequence(), Equals, 1)
-	c.Check(cur, Equals, 1)
 
 	// old assertion is stil in the database
 	_, err = assertstate.DB(s.state).Find(asserts.ValidationSetType, map[string]string{
@@ -3765,8 +3762,8 @@ func (s *assertMgrSuite) TestEnforceValidationSetAssertionPinToOlderSequence(c *
 		Name:      "bar",
 		Mode:      assertstate.Enforce,
 		PinnedAt:  1,
-		// and current points at the latest sequence available
-		Current: 2,
+		// and current points at the pinned sequence number
+		Current: 1,
 	})
 	c.Check(tr, DeepEquals, *tracking)
 }

--- a/overlord/assertstate/validation_set_tracking.go
+++ b/overlord/assertstate/validation_set_tracking.go
@@ -67,6 +67,17 @@ func (vs *ValidationSetTracking) sameAs(tr *ValidationSetTracking) bool {
 		vs.Name == tr.Name && vs.PinnedAt == tr.PinnedAt
 }
 
+// Sequence returns the sequence number of the currently used validation set.
+func (vs *ValidationSetTracking) Sequence() int {
+	// Current was occasionally set to the latest sequence number even when Pinned != 0,
+	// this should no longer happen but return PinnedAt anyway to be safe
+	if vs.PinnedAt > 0 {
+		return vs.PinnedAt
+	}
+
+	return vs.Current
+}
+
 // ValidationSetKey formats the given account id and name into a validation set key.
 func ValidationSetKey(accountID, name string) string {
 	return fmt.Sprintf("%s/%s", accountID, name)

--- a/overlord/assertstate/validation_set_tracking_test.go
+++ b/overlord/assertstate/validation_set_tracking_test.go
@@ -537,3 +537,17 @@ func (s *validationSetTrackingSuite) TestRestoreValidationSetsTracking(c *C) {
 		"foo/bar": &tr1,
 	})
 }
+
+func (s *validationSetTrackingSuite) TestValidationSetSequence(c *C) {
+	tr := assertstate.ValidationSetTracking{
+		AccountID: "foo",
+		Name:      "bar",
+		Mode:      assertstate.Enforce,
+		PinnedAt:  0,
+		Current:   2,
+	}
+
+	c.Check(tr.Sequence(), Equals, 2)
+	tr.PinnedAt = 1
+	c.Check(tr.Sequence(), Equals, 1)
+}

--- a/tests/main/snap-validate-enforce/task.yaml
+++ b/tests/main/snap-validate-enforce/task.yaml
@@ -85,12 +85,12 @@ execute: |
 
   echo "Check that enforcing can be updated to pin and un-pin and pin at a different sequence"
   snap validate --enforce "$ACCOUNT_ID"/testenforce1=1
-  snap validate | MATCH "^$ACCOUNT_ID/testenforce1=1 +enforce +2 +valid"
+  snap validate | MATCH "^$ACCOUNT_ID/testenforce1=1 +enforce +1 +valid"
   snap validate --enforce "$ACCOUNT_ID"/testenforce1
   snap validate | MATCH "^$ACCOUNT_ID/testenforce1 +enforce +2 +valid"
   snap validate --enforce "$ACCOUNT_ID"/testenforce1=2
   snap validate | MATCH "^$ACCOUNT_ID/testenforce1=2 +enforce +2 +valid"
   snap validate --enforce "$ACCOUNT_ID"/testenforce1=1
-  snap validate | MATCH "^$ACCOUNT_ID/testenforce1=1 +enforce +2 +valid"
+  snap validate | MATCH "^$ACCOUNT_ID/testenforce1=1 +enforce +1 +valid"
   snap validate --enforce "$ACCOUNT_ID"/testenforce1=3 2>&1 | MATCH "error: cannot find validation set assertion: validation-set \(3; series:16 account-id:$ACCOUNT_ID name:testenforce1\) not found"
-  snap validate | MATCH "^$ACCOUNT_ID/testenforce1=1 +enforce +2 +valid"
+  snap validate | MATCH "^$ACCOUNT_ID/testenforce1=1 +enforce +1 +valid"


### PR DESCRIPTION
Some places were setting ValidationSetTracking's Current to the currently active sequence and others were setting it to the latest, if an older sequence was pinned (see: https://github.com/snapcore/snapd/pull/11707). This was reflected in the output of `snap validate`; even when a previous sequence was pinned, the output always showed the latest one. The first commit of this PR changes this so Current is always equal to PinnedAt, when Pinned != 0 (i.e., there is a pinned assertion). The second commit introduces a Sequence() method that checks the PinnedAt before returning the Current sequence number, to be even more robust.