### PR TITLE
Added Support For: Nano S Plus

### DIFF
--- a/interfaces/builtin/u2f_devices.go
+++ b/interfaces/builtin/u2f_devices.go
@@ -138,9 +138,9 @@ var u2fDevices = []u2fDevice{
 		ProductIDPattern: "a2ac",
 	},
 	{
-		Name:             "Ledger Blue + Nano S + Nano X",
+		Name:             "Ledger Blue + Nano S + Nano X + Nano S Plus",
 		VendorIDPattern:  "2c97",
-		ProductIDPattern: "0000|0001|0004|0005|0015|1005|1015|4005|4015",
+		ProductIDPattern: "0000|0001|0004|0005|0015|1005|1015|4005|4015|5011",
 	},
 	{
 		Name:             "GoTrust Idem Key",


### PR DESCRIPTION
This PR adds support for Ledger's Nano S Plus cryptocurrency hardware wallet. 

dmesg output for my nano s plus device (on ubuntu 22.04):
```
[  259.899494] usb 2-1.4: new full-speed USB device number 3 using ehci-pci
[  260.022588] usb 2-1.4: New USB device found, idVendor=2c97, idProduct=5011, bcdDevice= 2.01
[  260.022596] usb 2-1.4: New USB device strings: Mfr=1, Product=2, SerialNumber=3
[  260.022600] usb 2-1.4: Product: Nano S Plus
[  260.022602] usb 2-1.4: Manufacturer: Ledger
[  260.022604] usb 2-1.4: SerialNumber: 0001
```

3rd party related links:
https://github.com/LedgerHQ/udev-rules/blob/master/20-hw1.rules
https://shop.ledger.com/pages/ledger-nano-s-plus

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
