### PR TITLE
tests: tweak the libvirt interface test to work on 22.10

### DIFF
--- a/tests/lib/snaps/store/test-snapd-libvirt-consumer/vm/ping-unikernel.xml
+++ b/tests/lib/snaps/store/test-snapd-libvirt-consumer/vm/ping-unikernel.xml
@@ -10,8 +10,9 @@
     <target port='0'/>
   </serial>
   <qemu:commandline>
+    <!-- Workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2034160 -->
     <qemu:arg value='-device'/>
-    <qemu:arg value='virtio-net,netdev=n0'/>
+    <qemu:arg value='virtio-net-pci,netdev=n0,bus=pci.0,addr=03.0'/>
     <qemu:arg value='-netdev'/>
     <qemu:arg value='tap,id=n0,ifname=tap100,script=no,downscript=no'/>
     <qemu:arg value='-device'/>

--- a/tests/main/interfaces-libvirt/task.yaml
+++ b/tests/main/interfaces-libvirt/task.yaml
@@ -33,6 +33,9 @@ prepare: |
 
     echo "And a snap declaring a plug on the libvirt interface is installed"
     snap install --edge test-snapd-libvirt-consumer
+    # Temporary workaround until the updated test snap is released
+    mount -o bind "$TESTSLIB/snaps/store/test-snapd-libvirt-consumer/vm/ping-unikernel.xml" \
+        /snap/test-snapd-libvirt-consumer/current/vm/ping-unikernel.xml
 
     echo "And the required tap interface is in place"
     ip tuntap add tap100 mode tap


### PR DESCRIPTION
The test is failing with a non critical AppArmor error message, but the real failure is due to QEMU command-line parsing:

    error: internal error: qemu unexpectedly closed the monitor:
    2022-10-03T11:56:15.932697Z qemu-system-x86_64:
    -device {"driver":"virtio-balloon-pci","id":"balloon0","bus":"pci.0","addr":"0x2"}:
    PCI: slot 2 function 0 not available for virtio-balloon-pci, in use by virtio-net-pci,id=(null)

This happens because something in libvirt (or maybe QEMU itself) adds an implicit PCI device on address 0x2 -- the log line pasted above shows what device is being added. This bug has also been noticed by other projects, see comment 45 on https://bugzilla.redhat.com/show_bug.cgi?id=2034160

The workaround we use is to specify a virtio-net-pci device on another PCI address, in order to avoid the address conflict.
