### PR TITLE
many: change the quota backend to support per-service quotas (1/4)

### DIFF
--- a/daemon/api_quotas.go
+++ b/daemon/api_quotas.go
@@ -53,6 +53,7 @@ type postQuotaGroupData struct {
 	GroupName   string             `json:"group-name"`
 	Parent      string             `json:"parent,omitempty"`
 	Snaps       []string           `json:"snaps,omitempty"`
+	Services    []string           `json:"services,omitempty"`
 	Constraints client.QuotaValues `json:"constraints,omitempty"`
 }
 
@@ -255,6 +256,7 @@ func postQuotaGroup(c *Command, r *http.Request, _ *auth.UserState) Response {
 			ts, err = servicestateCreateQuota(st, data.GroupName, servicestate.CreateQuotaOptions{
 				ParentName:     data.Parent,
 				Snaps:          data.Snaps,
+				Services:       data.Services,
 				ResourceLimits: resourceLimits,
 			})
 			if err != nil {
@@ -265,6 +267,7 @@ func postQuotaGroup(c *Command, r *http.Request, _ *auth.UserState) Response {
 			// the quota group already exists, update it
 			updateOpts := servicestate.UpdateQuotaOptions{
 				AddSnaps:          data.Snaps,
+				AddServices:       data.Services,
 				NewResourceLimits: resourceLimits,
 			}
 			ts, err = servicestateUpdateQuota(st, data.GroupName, updateOpts)

--- a/daemon/api_quotas_test.go
+++ b/daemon/api_quotas_test.go
@@ -74,18 +74,18 @@ func (s *apiQuotaSuite) SetUpTest(c *check.C) {
 }
 
 func mockQuotas(st *state.State, c *check.C) {
-	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, quota.NewResourcesBuilder().WithMemoryLimit(16*quantity.SizeMiB).Build())
+	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, nil, quota.NewResourcesBuilder().WithMemoryLimit(16*quantity.SizeMiB).Build())
 	c.Assert(err, check.IsNil)
-	err = servicestatetest.MockQuotaInState(st, "bar", "foo", nil, quota.NewResourcesBuilder().WithMemoryLimit(4*quantity.SizeMiB).Build())
+	err = servicestatetest.MockQuotaInState(st, "bar", "foo", nil, nil, quota.NewResourcesBuilder().WithMemoryLimit(4*quantity.SizeMiB).Build())
 	c.Assert(err, check.IsNil)
-	err = servicestatetest.MockQuotaInState(st, "baz", "foo", nil, quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build())
+	err = servicestatetest.MockQuotaInState(st, "baz", "foo", nil, nil, quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build())
 	c.Assert(err, check.IsNil)
 }
 
 func (s *apiQuotaSuite) TestCreateQuotaValues(c *check.C) {
 	st := s.d.Overlord().State()
 	st.Lock()
-	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", nil,
+	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", nil, nil,
 		quota.NewResourcesBuilder().
 			WithMemoryLimit(quantity.SizeMiB).
 			WithCPUCount(1).
@@ -261,6 +261,40 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaCreateQuotaConflicts(c *check.C) {
 	c.Assert(createCalled, check.Equals, 2)
 }
 
+func (s *apiQuotaSuite) TestPostEnsureQuotaCreateServicesHappy(c *check.C) {
+	var createCalled int
+	r := daemon.MockServicestateCreateQuota(func(st *state.State, name string, parentName string, snaps, services []string, resourceLimits quota.Resources) (*state.TaskSet, error) {
+		createCalled++
+		c.Check(name, check.Equals, "booze")
+		c.Check(parentName, check.Equals, "foo")
+		c.Check(snaps, check.DeepEquals, []string{"some-snap"})
+		c.Check(services, check.DeepEquals, []string{"some-snap.svc1"})
+		c.Check(resourceLimits, check.DeepEquals, quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
+		ts := state.NewTaskSet(st.NewTask("foo-quota", "..."))
+		return ts, nil
+	})
+	defer r()
+
+	data, err := json.Marshal(daemon.PostQuotaGroupData{
+		Action:    "ensure",
+		GroupName: "booze",
+		Parent:    "foo",
+		Snaps:     []string{"some-snap"},
+		Services:  []string{"some-snap.svc1"},
+		Constraints: client.QuotaValues{
+			Memory: quantity.SizeGiB,
+		},
+	})
+	c.Assert(err, check.IsNil)
+
+	req, err := http.NewRequest("POST", "/v2/quotas", bytes.NewBuffer(data))
+	c.Assert(err, check.IsNil)
+	rsp := s.asyncReq(c, req, nil)
+	c.Assert(rsp.Status, check.Equals, 202)
+	c.Assert(createCalled, check.Equals, 1)
+	c.Assert(s.ensureSoonCalled, check.Equals, 1)
+}
+
 func (s *apiQuotaSuite) TestPostEnsureQuotaCreateJournalRateZeroHappy(c *check.C) {
 	var createCalled int
 	r := daemon.MockServicestateCreateQuota(func(st *state.State, name string, createOpts servicestate.CreateQuotaOptions) (*state.TaskSet, error) {
@@ -301,7 +335,7 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaCreateJournalRateZeroHappy(c *check.C
 func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateCpuHappy(c *check.C) {
 	st := s.d.Overlord().State()
 	st.Lock()
-	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", nil,
+	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", nil, nil,
 		quota.NewResourcesBuilder().
 			WithMemoryLimit(quantity.SizeMiB).
 			WithCPUCount(1).
@@ -355,7 +389,7 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateCpuHappy(c *check.C) {
 func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateCpu2Happy(c *check.C) {
 	st := s.d.Overlord().State()
 	st.Lock()
-	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", nil,
+	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", nil, nil,
 		quota.NewResourcesBuilder().
 			WithMemoryLimit(quantity.SizeMiB).
 			WithCPUCount(1).
@@ -411,7 +445,7 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateCpu2Happy(c *check.C) {
 func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateMemoryHappy(c *check.C) {
 	st := s.d.Overlord().State()
 	st.Lock()
-	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", nil,
+	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", nil, nil,
 		quota.NewResourcesBuilder().
 			WithMemoryLimit(quantity.SizeMiB).
 			WithCPUCount(1).
@@ -461,7 +495,7 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateMemoryHappy(c *check.C) {
 func (s *apiQuotaSuite) TestPostEnsureQuotaUpdateConflicts(c *check.C) {
 	st := s.d.Overlord().State()
 	st.Lock()
-	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", nil, quota.NewResourcesBuilder().WithMemoryLimit(650*quantity.SizeKiB).Build())
+	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", nil, nil, quota.NewResourcesBuilder().WithMemoryLimit(650*quantity.SizeKiB).Build())
 	st.Unlock()
 	c.Assert(err, check.IsNil)
 
@@ -557,7 +591,7 @@ func (s *apiQuotaSuite) TestPostRemoveQuotaHappy(c *check.C) {
 func (s *apiQuotaSuite) TestPostRemoveQuotaConflict(c *check.C) {
 	st := s.d.Overlord().State()
 	st.Lock()
-	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", []string{"some-snap"}, quota.NewResourcesBuilder().WithMemoryLimit(650*quantity.SizeKiB).Build())
+	err := servicestatetest.MockQuotaInState(st, "ginger-ale", "", []string{"some-snap"}, nil, quota.NewResourcesBuilder().WithMemoryLimit(650*quantity.SizeKiB).Build())
 	st.Unlock()
 	c.Assert(err, check.IsNil)
 
@@ -719,11 +753,11 @@ func (s *apiQuotaSuite) TestListQuotas(c *check.C) {
 func (s *apiQuotaSuite) TestListJournalQuotas(c *check.C) {
 	st := s.d.Overlord().State()
 	st.Lock()
-	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, quota.NewResourcesBuilder().WithJournalSize(64*quantity.SizeMiB).Build())
+	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, nil, quota.NewResourcesBuilder().WithJournalSize(64*quantity.SizeMiB).Build())
 	c.Assert(err, check.IsNil)
-	err = servicestatetest.MockQuotaInState(st, "bar", "foo", nil, quota.NewResourcesBuilder().WithJournalRate(100, time.Hour).Build())
+	err = servicestatetest.MockQuotaInState(st, "bar", "foo", nil, nil, quota.NewResourcesBuilder().WithJournalRate(100, time.Hour).Build())
 	c.Assert(err, check.IsNil)
-	err = servicestatetest.MockQuotaInState(st, "baz", "foo", nil, quota.NewResourcesBuilder().WithJournalRate(0, 0).Build())
+	err = servicestatetest.MockQuotaInState(st, "baz", "foo", nil, nil, quota.NewResourcesBuilder().WithJournalRate(0, 0).Build())
 	c.Assert(err, check.IsNil)
 	st.Unlock()
 

--- a/daemon/api_quotas_test.go
+++ b/daemon/api_quotas_test.go
@@ -263,13 +263,13 @@ func (s *apiQuotaSuite) TestPostEnsureQuotaCreateQuotaConflicts(c *check.C) {
 
 func (s *apiQuotaSuite) TestPostEnsureQuotaCreateServicesHappy(c *check.C) {
 	var createCalled int
-	r := daemon.MockServicestateCreateQuota(func(st *state.State, name string, parentName string, snaps, services []string, resourceLimits quota.Resources) (*state.TaskSet, error) {
+	r := daemon.MockServicestateCreateQuota(func(st *state.State, name string, createOpts servicestate.CreateQuotaOptions) (*state.TaskSet, error) {
 		createCalled++
 		c.Check(name, check.Equals, "booze")
-		c.Check(parentName, check.Equals, "foo")
-		c.Check(snaps, check.DeepEquals, []string{"some-snap"})
-		c.Check(services, check.DeepEquals, []string{"some-snap.svc1"})
-		c.Check(resourceLimits, check.DeepEquals, quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
+		c.Check(createOpts.ParentName, check.Equals, "foo")
+		c.Check(createOpts.Snaps, check.DeepEquals, []string{"some-snap"})
+		c.Check(createOpts.Services, check.DeepEquals, []string{"some-snap.svc1"})
+		c.Check(createOpts.ResourceLimits, check.DeepEquals, quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
 		ts := state.NewTaskSet(st.NewTask("foo-quota", "..."))
 		return ts, nil
 	})

--- a/overlord/configstate/configcore/vitality_test.go
+++ b/overlord/configstate/configcore/vitality_test.go
@@ -197,7 +197,7 @@ func (s *vitalitySuite) TestConfigureVitalityWithQuotaGroup(c *C) {
 	tr.Commit()
 
 	// make a new quota group with this snap in it
-	err := servicestatetest.MockQuotaInState(s.state, "foogroup", "", []string{"test-snap"},
+	err := servicestatetest.MockQuotaInState(s.state, "foogroup", "", []string{"test-snap"}, nil,
 		quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build())
 	c.Assert(err, IsNil)
 

--- a/overlord/ifacestate/handlers_test.go
+++ b/overlord/ifacestate/handlers_test.go
@@ -151,7 +151,7 @@ func (s *handlersSuite) TestBuildConfinementOptionsWithLogNamespace(c *C) {
 	snapInfo := mockInstalledSnap(c, s.st, snapAyaml)
 
 	// Create a new quota group with a journal quota
-	err := servicestatetest.MockQuotaInState(s.st, "foo", "", []string{snapInfo.InstanceName()}, quota.NewResourcesBuilder().WithJournalNamespace().Build())
+	err := servicestatetest.MockQuotaInState(s.st, "foo", "", []string{snapInfo.InstanceName()}, nil, quota.NewResourcesBuilder().WithJournalNamespace().Build())
 	c.Assert(err, IsNil)
 
 	flags := snapstate.Flags{}

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -790,7 +790,7 @@ apps:
 	tr.Commit()
 
 	// put the snap in a quota group
-	err := servicestatetest.MockQuotaInState(st, "quota-grp", "", []string{"foo"},
+	err := servicestatetest.MockQuotaInState(st, "quota-grp", "", []string{"foo"}, nil,
 		quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build())
 	c.Assert(err, IsNil)
 

--- a/overlord/servicestate/export_test.go
+++ b/overlord/servicestate/export_test.go
@@ -28,10 +28,11 @@ import (
 )
 
 var (
-	UpdateSnapstateServices  = updateSnapstateServices
-	CheckSystemdVersion      = checkSystemdVersion
-	QuotaStateAlreadyUpdated = quotaStateAlreadyUpdated
-	ServiceControlTs         = serviceControlTs
+	UpdateSnapstateServices              = updateSnapstateServices
+	CheckSystemdVersion                  = checkSystemdVersion
+	QuotaStateAlreadyUpdated             = quotaStateAlreadyUpdated
+	ServiceControlTs                     = serviceControlTs
+	ValidateSnapServicesForAddingToGroup = validateSnapServicesForAddingToGroup
 )
 
 type QuotaStateUpdated = quotaStateUpdated

--- a/overlord/servicestate/internal/quotas.go
+++ b/overlord/servicestate/internal/quotas.go
@@ -107,7 +107,7 @@ func PatchQuotas(st *state.State, grps ...*quota.Group) (map[string]*quota.Group
 	// correct nesting of groups. Execute this verification after updating
 	// group pointers in ResolveCrossReferences.
 	for _, grp := range grps {
-		if err := grp.VerifyNestingAndMixingIsAllowed(); err != nil {
+		if err := grp.ValidateNestingAndSnaps(); err != nil {
 			return nil, fmt.Errorf("cannot update quota %q: %v", grp.Name, err)
 		}
 	}

--- a/overlord/servicestate/internal/quotas.go
+++ b/overlord/servicestate/internal/quotas.go
@@ -107,7 +107,7 @@ func PatchQuotas(st *state.State, grps ...*quota.Group) (map[string]*quota.Group
 	// correct nesting of groups. Execute this verification after updating
 	// group pointers in ResolveCrossReferences.
 	for _, grp := range grps {
-		if err := grp.VerifyNesting(); err != nil {
+		if err := grp.VerifyNestingAndMixingIsAllowed(); err != nil {
 			return nil, fmt.Errorf("cannot update quota %q: %v", grp.Name, err)
 		}
 	}

--- a/overlord/servicestate/internal/quotas.go
+++ b/overlord/servicestate/internal/quotas.go
@@ -107,7 +107,7 @@ func PatchQuotas(st *state.State, grps ...*quota.Group) (map[string]*quota.Group
 	// correct nesting of groups. Execute this verification after updating
 	// group pointers in ResolveCrossReferences.
 	for _, grp := range grps {
-		if err := grp.VerifyGroupNesting(); err != nil {
+		if err := grp.VerifyNesting(); err != nil {
 			return nil, fmt.Errorf("cannot update quota %q: %v", grp.Name, err)
 		}
 	}

--- a/overlord/servicestate/internal/quotas.go
+++ b/overlord/servicestate/internal/quotas.go
@@ -103,13 +103,22 @@ func PatchQuotas(st *state.State, grps ...*quota.Group) (map[string]*quota.Group
 		return nil, fmt.Errorf("cannot update quota%s %s: %v", plural, updated, err)
 	}
 
+	// Verify that the update of the new quota groups will result in
+	// correct nesting of groups. Execute this verification after updating
+	// group pointers in ResolveCrossReferences.
+	for _, grp := range grps {
+		if err := grp.VerifyGroupNesting(); err != nil {
+			return nil, fmt.Errorf("cannot update quota %q: %v", grp.Name, err)
+		}
+	}
+
 	st.Set("quotas", allGrps)
 	return allGrps, nil
 }
 
-// CreateQuotaInState creates a quota group with the given paremeters
+// CreateQuotaInState creates a quota group with the given parameters
 // in the state.  It takes the current map of all quota groups.
-func CreateQuotaInState(st *state.State, quotaName string, parentGrp *quota.Group, snaps []string, resourceLimits quota.Resources, allGrps map[string]*quota.Group) (*quota.Group, map[string]*quota.Group, error) {
+func CreateQuotaInState(st *state.State, quotaName string, parentGrp *quota.Group, snaps, services []string, resourceLimits quota.Resources, allGrps map[string]*quota.Group) (*quota.Group, map[string]*quota.Group, error) {
 	// make sure that the parent group exists if we are creating a sub-group
 	var grp *quota.Group
 	var err error
@@ -130,8 +139,9 @@ func CreateQuotaInState(st *state.State, quotaName string, parentGrp *quota.Grou
 	}
 	updatedGrps = append(updatedGrps, grp)
 
-	// put the snaps in the group
+	// put the snaps and services in the group
 	grp.Snaps = snaps
+	grp.Services = services
 	// update the modified groups in state
 	newAllGrps, err := PatchQuotas(st, updatedGrps...)
 	if err != nil {

--- a/overlord/servicestate/internal/quotas_test.go
+++ b/overlord/servicestate/internal/quotas_test.go
@@ -135,7 +135,7 @@ func (s *servicestateQuotasSuite) TestCreateQuotaInState(c *C) {
 		Name:        "foogroup",
 		MemoryLimit: quantity.SizeGiB,
 	}
-	grp1, newGrps, err := internal.CreateQuotaInState(st, "foogroup", nil, nil, quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(), nil)
+	grp1, newGrps, err := internal.CreateQuotaInState(st, "foogroup", nil, nil, nil, quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(), nil)
 	c.Assert(err, IsNil)
 	c.Check(grp1, DeepEquals, grp)
 	c.Check(newGrps, DeepEquals, map[string]*quota.Group{
@@ -156,12 +156,13 @@ func (s *servicestateQuotasSuite) TestCreateQuotaInState(c *C) {
 		ParentGroup: "foogroup",
 		Snaps:       []string{"snap1", "snap2"},
 	}
-	grp3, newGrps, err := internal.CreateQuotaInState(st, "group-2", grp1, []string{"snap1", "snap2"}, quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(), nil)
+	grp3, newGrps, err := internal.CreateQuotaInState(st, "group-2", grp1, []string{"snap1", "snap2"}, []string{"snap1.svc1", "snap2.svc2"}, quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(), nil)
 	c.Assert(err, IsNil)
 	c.Check(grp3.Name, Equals, grp2.Name)
 	c.Check(grp3.MemoryLimit, Equals, grp2.MemoryLimit)
 	c.Check(grp3.ParentGroup, Equals, grp2.ParentGroup)
 	c.Check(grp3.Snaps, DeepEquals, grp2.Snaps)
+	c.Check(grp3.Services, DeepEquals, []string{"snap1.svc1", "snap2.svc2"})
 	c.Check(newGrps, HasLen, 2)
 	c.Check(newGrps["foogroup"].SubGroups, DeepEquals, []string{"group-2"})
 

--- a/overlord/servicestate/internal/quotas_test.go
+++ b/overlord/servicestate/internal/quotas_test.go
@@ -123,6 +123,31 @@ func (s *servicestateQuotasSuite) TestQuotas(c *C) {
 	_, err = internal.PatchQuotas(st, otherGrp2, otherGrp)
 	// either group can get checked first
 	c.Assert(err, ErrorMatches, `cannot update quotas "other-group", "other-group2": group "other-group2?" is invalid: quota group must have at least one resource limit set`)
+
+	// test that patching quotas with invalid nesting causes an error
+	nestGrp1 := &quota.Group{
+		Name:        "nest-root",
+		MemoryLimit: quantity.SizeGiB,
+		SubGroups:   []string{"nest-sub1"},
+		Snaps:       []string{"foo"},
+	}
+
+	nestGrp2 := &quota.Group{
+		Name:        "nest-sub1",
+		ParentGroup: "nest-root",
+		SubGroups:   []string{"nest-sub2"},
+		MemoryLimit: quantity.SizeGiB / 2,
+		Services:    []string{"foo.bar"},
+	}
+
+	nestGrp3 := &quota.Group{
+		Name:        "nest-sub2",
+		ParentGroup: "nest-sub1",
+		MemoryLimit: quantity.SizeGiB / 4,
+	}
+
+	_, err = internal.PatchQuotas(st, nestGrp1, nestGrp2, nestGrp3)
+	c.Assert(err, ErrorMatches, `cannot update quota "nest-root": group "nest-sub2" is invalid: only one level of sub-groups are allowed for groups with snaps`)
 }
 
 func (s *servicestateQuotasSuite) TestCreateQuotaInState(c *C) {

--- a/overlord/servicestate/quota_control.go
+++ b/overlord/servicestate/quota_control.go
@@ -319,9 +319,8 @@ func remove(slice []string, i int) []string {
 // removeServicesFromSubGroups removes all service references of a snap in
 // sub-groups related to the group of the snap, and returns the groups that were modified.
 func removeServicesFromSubGroups(grp *quota.Group, snap string, allGrps map[string]*quota.Group) ([]*quota.Group, error) {
-	// When removing a snap we assume that if it has services in
-	// sub-groups there will be only one level of sub-groups, so we can
-	// avoid checking any nested sub-groups.
+	// If a snap has services in sub-groups, the services must be in the first level of sub-groups only,
+	// that's why the code here does not check for nested sub-groups.
 	var modifiedGrps []*quota.Group
 	for _, name := range grp.SubGroups {
 		subgrp, ok := allGrps[name]

--- a/overlord/servicestate/quota_control.go
+++ b/overlord/servicestate/quota_control.go
@@ -320,7 +320,7 @@ func remove(slice []string, i int) []string {
 // sub-groups related to the group of the snap, and returns the groups that were modified.
 func removeServicesFromSubGroups(grp *quota.Group, snap string, allGrps map[string]*quota.Group) ([]*quota.Group, error) {
 	// When removing a snap we assume that if it has services in
-	// sub-groups that there will be only one level of sub-groups, so we can
+	// sub-groups there will be only one level of sub-groups, so we can
 	// avoid checking any nested sub-groups.
 	var modifiedGrps []*quota.Group
 	for _, name := range grp.SubGroups {

--- a/overlord/servicestate/quota_control_test.go
+++ b/overlord/servicestate/quota_control_test.go
@@ -598,7 +598,11 @@ func (s *quotaControlSuite) TestEnsureSnapAbsentFromQuotaGroup(c *C) {
 
 	// create a sub-group containing services to ensure these are removed too
 	subConstraints := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB / 2).Build()
-	ts2, err := servicestate.CreateQuota(s.state, "foo2", "foo", nil, []string{"test-snap.svc1"}, subConstraints)
+	ts2, err := servicestate.CreateQuota(s.state, "foo2", servicestate.CreateQuotaOptions{
+		ParentName:     "foo",
+		Services:       []string{"test-snap.svc1"},
+		ResourceLimits: subConstraints,
+	})
 	c.Assert(err, IsNil)
 	ts2.WaitAll(ts1)
 

--- a/overlord/servicestate/quota_control_test.go
+++ b/overlord/servicestate/quota_control_test.go
@@ -1145,25 +1145,6 @@ func (s *quotaControlSuite) TestCreateQuotaCreateQuotaConflict(c *C) {
 	c.Assert(err, ErrorMatches, `quota group "foo" has "quota-control" change in progress`)
 }
 
-func (s *quotaControlSuite) TestUpdateQuotaModifyExistingMixable(c *C) {
-	st := s.state
-	st.Lock()
-	defer st.Unlock()
-
-	// setup the snap so it exists
-	snapstate.Set(s.state, "test-snap", s.testSnapState)
-	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
-
-	err := mockMixedQuotaGroup(st, "mixed-grp", []string{"test-snap"})
-	c.Assert(err, IsNil)
-
-	// try to update a quota value, this must fail
-	_, err = servicestate.UpdateQuota(st, "mixed-grp", servicestate.UpdateQuotaOptions{
-		NewResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB * 2).Build(),
-	})
-	c.Assert(err, ErrorMatches, `quota group "mixed-grp" has mixed snaps and sub-groups, which is no longer supported; removal and re-creation is necessary to modify it`)
-}
-
 func (s *quotaControlSuite) TestAddSnapToQuotaGroup(c *C) {
 	st := s.state
 	st.Lock()

--- a/overlord/servicestate/quota_control_test.go
+++ b/overlord/servicestate/quota_control_test.go
@@ -87,6 +87,7 @@ type quotaGroupState struct {
 	SubGroups      []string
 	ParentGroup    string
 	Snaps          []string
+	Services       []string
 }
 
 func checkQuotaState(c *C, st *state.State, exp map[string]quotaGroupState) {
@@ -115,6 +116,10 @@ func checkQuotaState(c *C, st *state.State, exp map[string]quotaGroupState) {
 			}
 		}
 
+		c.Assert(grp.Services, HasLen, len(expGrp.Services))
+		if len(expGrp.Services) != 0 {
+			c.Assert(grp.Services, DeepEquals, expGrp.Services)
+		}
 		c.Assert(grp.SubGroups, HasLen, len(expGrp.SubGroups))
 		if len(expGrp.SubGroups) != 0 {
 			c.Assert(grp.SubGroups, DeepEquals, expGrp.SubGroups)
@@ -277,23 +282,26 @@ func (s *quotaControlSuite) TestCreateQuotaPrecond(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB*2).Build())
+	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, nil, quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB*2).Build())
 	c.Assert(err, IsNil)
 
 	tests := []struct {
-		name  string
-		mem   quantity.Size
-		snaps []string
-		err   string
+		name     string
+		mem      quantity.Size
+		snaps    []string
+		services []string
+		err      string
 	}{
-		{"foo", quantity.SizeMiB, nil, `group "foo" already exists`},
-		{"new", 0, nil, `cannot create quota group "new": memory quota must have a limit set`},
-		{"new", quantity.SizeMiB, []string{"baz"}, `cannot use snap "baz" in group "new": snap "baz" is not installed`},
+		{"foo", quantity.SizeMiB, nil, nil, `group "foo" already exists`},
+		{"new", 0, nil, nil, `cannot create quota group "new": memory quota must have a limit set`},
+		{"new", quantity.SizeMiB, []string{"baz"}, nil, `cannot use snap "baz" in group "new": snap "baz" is not installed`},
+		{"new", quantity.SizeMiB, []string{"baz"}, []string{"baz.foo"}, `cannot mix services and snaps in the same quota group`},
 	}
 
 	for _, t := range tests {
 		_, err := servicestate.CreateQuota(st, t.name, servicestate.CreateQuotaOptions{
 			Snaps:          t.snaps,
+			Services:       t.services,
 			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(t.mem).Build(),
 		})
 		c.Check(err, ErrorMatches, t.err)
@@ -549,13 +557,12 @@ func (s *quotaControlSuite) TestEnsureSnapAbsentFromQuotaGroup(c *C) {
 		// CreateQuota for foo
 		systemctlCallsForCreateQuota("foo", "test-snap", "test-snap2"),
 
+		// CreateQuota for foo2
+		systemctlCallsForCreateQuota("foo/foo2"),
+
 		// EnsureSnapAbsentFromQuota with just test-snap restarted since it is
 		// no longer in the group
-		[]expectedSystemctl{{expArgs: []string{"daemon-reload"}}},
 		systemctlCallsForServiceRestart("test-snap"),
-
-		// another identical call to EnsureSnapAbsentFromQuota does nothing
-		// since the function is idempotent
 
 		// EnsureSnapAbsentFromQuota with just test-snap2 restarted since it is no
 		// longer in the group
@@ -589,17 +596,30 @@ func (s *quotaControlSuite) TestEnsureSnapAbsentFromQuotaGroup(c *C) {
 	})
 	c.Assert(err, IsNil)
 
-	chg := st.NewChange("quota-control", "...")
-	chg.AddAll(ts)
+	// create a sub-group containing services to ensure these are removed too
+	subConstraints := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB / 2).Build()
+	ts2, err := servicestate.CreateQuota(s.state, "foo2", "foo", nil, []string{"test-snap.svc1"}, subConstraints)
+	c.Assert(err, IsNil)
+	ts2.WaitAll(ts1)
 
-	exp := &servicestate.QuotaControlAction{
+	chg1 := st.NewChange("quota-control", "...")
+	chg1.AddAll(ts1)
+	checkQuotaControlTasks(c, chg1.Tasks(), &servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo",
 		AddSnaps:       []string{"test-snap", "test-snap2"},
 		ResourceLimits: quotaConstraits,
-	}
+	})
 
-	checkQuotaControlTasks(c, chg.Tasks(), exp)
+	chg2 := st.NewChange("quota-control-sub", "...")
+	chg2.AddAll(ts2)
+	checkQuotaControlTasks(c, chg2.Tasks(), &servicestate.QuotaControlAction{
+		Action:         "create",
+		QuotaName:      "foo2",
+		ParentName:     "foo",
+		AddServices:    []string{"test-snap.svc1"},
+		ResourceLimits: subConstraints,
+	})
 
 	// run the change
 	st.Unlock()
@@ -612,6 +632,12 @@ func (s *quotaControlSuite) TestEnsureSnapAbsentFromQuotaGroup(c *C) {
 		"foo": {
 			ResourceLimits: quotaConstraits,
 			Snaps:          []string{"test-snap", "test-snap2"},
+			SubGroups:      []string{"foo2"},
+		},
+		"foo2": {
+			ResourceLimits: subConstraints,
+			Services:       []string{"test-snap.svc1"},
+			ParentGroup:    "foo",
 		},
 	})
 
@@ -623,6 +649,11 @@ func (s *quotaControlSuite) TestEnsureSnapAbsentFromQuotaGroup(c *C) {
 		"foo": {
 			ResourceLimits: quotaConstraits,
 			Snaps:          []string{"test-snap2"},
+			SubGroups:      []string{"foo2"},
+		},
+		"foo2": {
+			ResourceLimits: subConstraints,
+			ParentGroup:    "foo",
 		},
 	})
 
@@ -638,6 +669,11 @@ func (s *quotaControlSuite) TestEnsureSnapAbsentFromQuotaGroup(c *C) {
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
 			ResourceLimits: quotaConstraits,
+			SubGroups:      []string{"foo2"},
+		},
+		"foo2": {
+			ResourceLimits: subConstraints,
+			ParentGroup:    "foo",
 		},
 	})
 
@@ -665,7 +701,7 @@ func (s *quotaControlSuite) TestUpdateQuotaPrecond(c *C) {
 	defer st.Unlock()
 
 	quotaConstraits := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB * 2).Build()
-	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, quotaConstraits)
+	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, nil, quotaConstraits)
 	c.Assert(err, IsNil)
 
 	newConstraits := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
@@ -674,9 +710,12 @@ func (s *quotaControlSuite) TestUpdateQuotaPrecond(c *C) {
 		opts servicestate.UpdateQuotaOptions
 		err  string
 	}{
-		{"what", servicestate.UpdateQuotaOptions{}, `group "what" does not exist`},
-		{"foo", servicestate.UpdateQuotaOptions{NewResourceLimits: newConstraits}, `cannot update group "foo": cannot decrease memory limit, remove and re-create it to decrease the limit`},
-		{"foo", servicestate.UpdateQuotaOptions{AddSnaps: []string{"baz"}}, `cannot use snap "baz" in group "foo": snap "baz" is not installed`},
+		{"what", servicestate.QuotaGroupUpdate{}, `group "what" does not exist`},
+		{"foo", servicestate.QuotaGroupUpdate{NewResourceLimits: newConstraits}, `cannot update group "foo": cannot decrease memory limit, remove and re-create it to decrease the limit`},
+		{"foo", servicestate.QuotaGroupUpdate{AddSnaps: []string{"baz"}}, `cannot use snap "baz" in group "foo": snap "baz" is not installed`},
+		{"foo", servicestate.QuotaGroupUpdate{AddSnaps: []string{"baz"}, AddServices: []string{"baz.svc"}}, `cannot mix services and snaps in the same quota group`},
+		{"foo", servicestate.QuotaGroupUpdate{AddServices: []string{"baz"}}, `invalid snap service: baz`},
+		{"foo", servicestate.QuotaGroupUpdate{AddServices: []string{"baz.svc"}}, `cannot use snap service in group "foo": snap "baz" is not installed`},
 	}
 
 	for _, t := range tests {
@@ -691,11 +730,11 @@ func (s *quotaControlSuite) TestRemoveQuotaPrecond(c *C) {
 	defer st.Unlock()
 
 	quotaConstraits2GB := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
-	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, quotaConstraits2GB)
+	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, nil, quotaConstraits2GB)
 	c.Assert(err, IsNil)
 
 	quotaConstraits1GB := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
-	err = servicestatetest.MockQuotaInState(st, "bar", "foo", nil, quotaConstraits1GB)
+	err = servicestatetest.MockQuotaInState(st, "bar", "foo", nil, nil, quotaConstraits1GB)
 	c.Assert(err, IsNil)
 
 	_, err = servicestate.RemoveQuota(st, "what")

--- a/overlord/servicestate/quota_control_test.go
+++ b/overlord/servicestate/quota_control_test.go
@@ -590,7 +590,7 @@ func (s *quotaControlSuite) TestEnsureSnapAbsentFromQuotaGroup(c *C) {
 
 	// create a quota group
 	quotaConstraits := quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build()
-	ts, err := servicestate.CreateQuota(s.state, "foo", servicestate.CreateQuotaOptions{
+	ts1, err := servicestate.CreateQuota(s.state, "foo", servicestate.CreateQuotaOptions{
 		Snaps:          []string{"test-snap", "test-snap2"},
 		ResourceLimits: quotaConstraits,
 	})
@@ -710,12 +710,12 @@ func (s *quotaControlSuite) TestUpdateQuotaPrecond(c *C) {
 		opts servicestate.UpdateQuotaOptions
 		err  string
 	}{
-		{"what", servicestate.QuotaGroupUpdate{}, `group "what" does not exist`},
-		{"foo", servicestate.QuotaGroupUpdate{NewResourceLimits: newConstraits}, `cannot update group "foo": cannot decrease memory limit, remove and re-create it to decrease the limit`},
-		{"foo", servicestate.QuotaGroupUpdate{AddSnaps: []string{"baz"}}, `cannot use snap "baz" in group "foo": snap "baz" is not installed`},
-		{"foo", servicestate.QuotaGroupUpdate{AddSnaps: []string{"baz"}, AddServices: []string{"baz.svc"}}, `cannot mix services and snaps in the same quota group`},
-		{"foo", servicestate.QuotaGroupUpdate{AddServices: []string{"baz"}}, `invalid snap service: baz`},
-		{"foo", servicestate.QuotaGroupUpdate{AddServices: []string{"baz.svc"}}, `cannot use snap service in group "foo": snap "baz" is not installed`},
+		{"what", servicestate.UpdateQuotaOptions{}, `group "what" does not exist`},
+		{"foo", servicestate.UpdateQuotaOptions{NewResourceLimits: newConstraits}, `cannot update group "foo": cannot decrease memory limit, remove and re-create it to decrease the limit`},
+		{"foo", servicestate.UpdateQuotaOptions{AddSnaps: []string{"baz"}}, `cannot use snap "baz" in group "foo": snap "baz" is not installed`},
+		{"foo", servicestate.UpdateQuotaOptions{AddSnaps: []string{"baz"}, AddServices: []string{"baz.svc"}}, `cannot mix services and snaps in the same quota group`},
+		{"foo", servicestate.UpdateQuotaOptions{AddServices: []string{"baz"}}, `invalid snap service: baz`},
+		{"foo", servicestate.UpdateQuotaOptions{AddServices: []string{"baz.svc"}}, `cannot use snap service in group "foo": snap "baz" is not installed`},
 	}
 
 	for _, t := range tests {

--- a/overlord/servicestate/quota_handlers.go
+++ b/overlord/servicestate/quota_handlers.go
@@ -918,10 +918,10 @@ func validateSnapServicesForAddingToGroup(st *state.State, services []string, gr
 			return err
 		}
 		if err = ensureAppReferenceIsService(st, snap, service); err != nil {
-			return fmt.Errorf("cannot use snap service in group %q: %v", group, err)
+			return fmt.Errorf("cannot use snap service %q: %v", group, err)
 		}
-		if parentGroup != nil && !parentGroup.IsSnapRelated(snap) {
-			return fmt.Errorf("cannot use snap %q: the snap must be in a parent group of group %q", snap, group)
+		if parentGroup == nil || !strutil.ListContains(parentGroup.Snaps, snap) {
+			return fmt.Errorf("cannot use snap service %q: the snap %q must be in a direct parent group of group %q", service, snap, group)
 		}
 	}
 	return nil

--- a/overlord/servicestate/quota_handlers_test.go
+++ b/overlord/servicestate/quota_handlers_test.go
@@ -1569,7 +1569,7 @@ func (s *quotaHandlersSuite) TestQuotaSnapAddSnapServicesFailOnInvalidSnapServic
 	}
 
 	err = s.callDoQuotaControl(&qc3)
-	c.Assert(err, ErrorMatches, `cannot use snap service in group "foo2": invalid service "svc-none"`)
+	c.Assert(err, ErrorMatches, `cannot use snap service "foo2": invalid service "svc-none"`)
 
 	qc4 := servicestate.QuotaControlAction{
 		Action:      "update",
@@ -1578,7 +1578,7 @@ func (s *quotaHandlersSuite) TestQuotaSnapAddSnapServicesFailOnInvalidSnapServic
 	}
 
 	err = s.callDoQuotaControl(&qc4)
-	c.Assert(err, ErrorMatches, `cannot use snap service in group "foo2": snap "no-snap" is not installed`)
+	c.Assert(err, ErrorMatches, `cannot use snap service "foo2": snap "no-snap" is not installed`)
 
 	// also test adding a valid snap, but the snap is not relevant for this quota group
 	qc5 := servicestate.QuotaControlAction{
@@ -1588,7 +1588,7 @@ func (s *quotaHandlersSuite) TestQuotaSnapAddSnapServicesFailOnInvalidSnapServic
 	}
 
 	err = s.callDoQuotaControl(&qc5)
-	c.Assert(err, ErrorMatches, `cannot use snap "test-snap2": the snap must be in a parent group of group "foo2"`)
+	c.Assert(err, ErrorMatches, `cannot use snap service "svc1": the snap "test-snap2" must be in a direct parent group of group "foo2"`)
 
 	// check that the quota groups was created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{

--- a/overlord/servicestate/quota_handlers_test.go
+++ b/overlord/servicestate/quota_handlers_test.go
@@ -20,7 +20,6 @@
 package servicestate_test
 
 import (
-	"errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -69,38 +68,6 @@ func (s *quotaHandlersSuite) SetUpTest(c *C) {
 
 	usabilityErrRestore := servicestate.EnsureQuotaUsability()
 	s.AddCleanup(usabilityErrRestore)
-}
-
-// mockMixedQuotaGroup creates a new quota group mixed with the provided snaps and
-// a single sub-group with the same name appended with 'sub'. The group is created with
-// the memory limit of 1GB, and the subgroup has a limit of 512MB. We do this test as
-// this type of mixed groups were supported when the feature was experimental.
-func mockMixedQuotaGroup(st *state.State, name string, snaps []string) error {
-	// create the quota group
-	grp, err := quota.NewGroup(name, quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
-	if err != nil {
-		return err
-	}
-
-	subGrpName := name + "-sub"
-	subGrp, err := grp.NewSubGroup(subGrpName, quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB/2).Build())
-	if err != nil {
-		return err
-	}
-
-	grp.Snaps = snaps
-
-	var quotas map[string]*quota.Group
-	if err := st.Get("quotas", &quotas); err != nil {
-		if !errors.Is(err, state.ErrNoState) {
-			return err
-		}
-		quotas = make(map[string]*quota.Group)
-	}
-	quotas[name] = grp
-	quotas[subGrpName] = subGrp
-	st.Set("quotas", quotas)
-	return nil
 }
 
 func (s *quotaHandlersSuite) TestDoQuotaControlCreate(c *C) {
@@ -925,7 +892,7 @@ func (s *quotaHandlersSuite) TestQuotaRemoveWithLimitSetFails(c *C) {
 	snapstate.Set(s.state, "test-snap", s.testSnapState)
 	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
 
-	err := servicestatetest.MockQuotaInState(st, "foo", "", []string{"test-snap"},
+	err := servicestatetest.MockQuotaInState(st, "foo", "", []string{"test-snap"}, nil,
 		quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
 	c.Assert(err, IsNil)
 
@@ -940,69 +907,7 @@ func (s *quotaHandlersSuite) TestQuotaRemoveWithLimitSetFails(c *C) {
 	c.Assert(err, ErrorMatches, `internal error, quota limit options cannot be used with remove action`)
 }
 
-func (s *quotaHandlersSuite) TestQuotaSnapModifyExistingMixable(c *C) {
-	st := s.state
-	st.Lock()
-	defer st.Unlock()
-
-	// setup the snap so it exists
-	snapstate.Set(s.state, "test-snap", s.testSnapState)
-	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
-
-	err := mockMixedQuotaGroup(st, "mixed-grp", []string{"test-snap"})
-	c.Assert(err, IsNil)
-
-	// try to update the memory limit for the mixed group
-	qc := servicestate.QuotaControlAction{
-		Action:         "update",
-		QuotaName:      "mixed-grp",
-		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB * 2).Build(),
-	}
-	err = s.callDoQuotaControl(&qc)
-	c.Assert(err, ErrorMatches, `quota group "mixed-grp" has mixed snaps and sub-groups, which is no longer supported; removal and re-creation is necessary to modify it`)
-}
-
-func (s *quotaHandlersSuite) TestQuotaSnapCanRemoveMixed(c *C) {
-	r := s.mockSystemctlCalls(c, join(
-		// handle the removal of the sub-group
-		systemctlCallsForSliceStop("mixed-grp/mixed-grp-sub"),
-		[]expectedSystemctl{{expArgs: []string{"daemon-reload"}}},
-
-		// handle removal of parent group with snap in
-		systemctlCallsForSliceStop("mixed-grp"),
-		systemctlCallsForServiceRestart("test-snap"),
-	))
-	defer r()
-
-	st := s.state
-	st.Lock()
-	defer st.Unlock()
-
-	// setup the snap so it exists
-	snapstate.Set(s.state, "test-snap", s.testSnapState)
-	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
-
-	err := mockMixedQuotaGroup(st, "mixed-grp", []string{"test-snap"})
-	c.Assert(err, IsNil)
-
-	// first we remove the sub-group
-	qc := servicestate.QuotaControlAction{
-		Action:    "remove",
-		QuotaName: "mixed-grp-sub",
-	}
-	err = s.callDoQuotaControl(&qc)
-	c.Assert(err, IsNil)
-
-	// then we remove the parent group
-	qc2 := servicestate.QuotaControlAction{
-		Action:    "remove",
-		QuotaName: "mixed-grp",
-	}
-	err = s.callDoQuotaControl(&qc2)
-	c.Assert(err, IsNil)
-}
-
-func (s *quotaHandlersSuite) TestQuotaSnapFailToMixSubgroupWithSnaps(c *C) {
+func (s *quotaHandlersSuite) TestQuotaSnapMixSubgroupWithSnapsHappy(c *C) {
 	r := s.mockSystemctlCalls(c, join(
 		// CreateQuota for foo
 		systemctlCallsForCreateQuota("foo", "test-snap"),
@@ -1027,7 +932,7 @@ func (s *quotaHandlersSuite) TestQuotaSnapFailToMixSubgroupWithSnaps(c *C) {
 	err := s.callDoQuotaControl(&qc)
 	c.Assert(err, IsNil)
 
-	// try to create a subgroup in a group that already has snaps, this call should fail
+	// try to create a subgroup in a group that already has snaps
 	qc2 := servicestate.QuotaControlAction{
 		Action:         "create",
 		QuotaName:      "foo2",
@@ -1036,18 +941,37 @@ func (s *quotaHandlersSuite) TestQuotaSnapFailToMixSubgroupWithSnaps(c *C) {
 	}
 
 	err = s.callDoQuotaControl(&qc2)
-	c.Assert(err, ErrorMatches, `cannot mix sub groups with snaps in the same group`)
+	c.Assert(err, IsNil)
 
 	// check that the quota groups was created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
 		"foo": {
 			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 			Snaps:          []string{"test-snap"},
+			SubGroups:      []string{"foo2"},
+		},
+		"foo2": {
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB / 2).Build(),
+			ParentGroup:    "foo",
 		},
 	})
 }
 
-func (s *quotaHandlersSuite) TestQuotaSnapFailToMixSnapsWithSubgroups(c *C) {
+func (s *quotaHandlersSuite) TestQuotaSnapMixSnapsWithSubgroupsHappy(c *C) {
+	r := s.mockSystemctlCalls(c, join(
+		[]expectedSystemctl{{expArgs: []string{"daemon-reload"}}},
+
+		// CreateQuota for foo
+		systemctlCallsForSliceStart("foo"),
+
+		// CreateQuota for foo2
+		systemctlCallsForSliceStart("foo/foo2"),
+
+		// UpdateQuota for foo2 - just the slice changes
+		systemctlCallsForServiceRestart("test-snap"),
+	))
+	defer r()
+
 	st := s.state
 	st.Lock()
 	defer st.Unlock()
@@ -1076,7 +1000,7 @@ func (s *quotaHandlersSuite) TestQuotaSnapFailToMixSnapsWithSubgroups(c *C) {
 	err = s.callDoQuotaControl(&qc2)
 	c.Assert(err, IsNil)
 
-	// now we try to add snaps to the foo group which already has subgroups, this should fail
+	// now we try to add snaps to the foo group which already has subgroups
 	qc3 := servicestate.QuotaControlAction{
 		Action:    "update",
 		QuotaName: "foo",
@@ -1084,7 +1008,548 @@ func (s *quotaHandlersSuite) TestQuotaSnapFailToMixSnapsWithSubgroups(c *C) {
 	}
 
 	err = s.callDoQuotaControl(&qc3)
-	c.Assert(err, ErrorMatches, `cannot mix snaps and sub groups in the group \"foo\"`)
+	c.Assert(err, IsNil)
+
+	// check that the quota groups was created in the state
+	checkQuotaState(c, st, map[string]quotaGroupState{
+		"foo": {
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
+			SubGroups:      []string{"foo2"},
+			Snaps:          []string{"test-snap"},
+		},
+		"foo2": {
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB / 2).Build(),
+			ParentGroup:    "foo",
+		},
+	})
+}
+
+func (s *quotaHandlersSuite) TestQuotaSnapFailToMixSubgroupWithServices(c *C) {
+	r := s.mockSystemctlCalls(c, join(
+		[]expectedSystemctl{{expArgs: []string{"daemon-reload"}}},
+
+		// CreateQuota for foo
+		systemctlCallsForSliceStart("foo"),
+
+		// UpdateQuota for foo2 - just the slice changes
+		systemctlCallsForServiceRestart("test-snap"),
+	))
+	defer r()
+
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	// setup the snap so it exists
+	snapstate.Set(s.state, "test-snap", s.testSnapState)
+	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
+
+	qc := servicestate.QuotaControlAction{
+		Action:         "create",
+		QuotaName:      "foo",
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
+		AddSnaps:       []string{"test-snap"},
+	}
+
+	err := s.callDoQuotaControl(&qc)
+	c.Assert(err, IsNil)
+
+	// create a subgroup in a group that already has snaps
+	qc2 := servicestate.QuotaControlAction{
+		Action:         "create",
+		QuotaName:      "foo2",
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB / 2).Build(),
+		ParentName:     "foo",
+	}
+
+	err = s.callDoQuotaControl(&qc2)
+	c.Assert(err, IsNil)
+
+	// then, we try to put another subgroup into the new sub-group, before we add services
+	// this should fail as only one level of sub-grouping is allowed with mixed parents
+	qc3 := servicestate.QuotaControlAction{
+		Action:         "create",
+		QuotaName:      "foo3",
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB / 4).Build(),
+		ParentName:     "foo2",
+	}
+
+	err = s.callDoQuotaControl(&qc3)
+	c.Assert(err, ErrorMatches, `cannot update quota "foo3": group "foo3" is invalid: only one level of sub-groups are allowed for groups mixed with snaps and sub-groups`)
+
+	// and at last, we add services from test-snap into the sub-group, which itself already
+	// has a subgroup.
+	qc4 := servicestate.QuotaControlAction{
+		Action:      "update",
+		QuotaName:   "foo2",
+		AddServices: []string{"test-snap.svc1"},
+	}
+
+	err = s.callDoQuotaControl(&qc4)
+	c.Assert(err, IsNil)
+
+	// now try to trigger the unmixable error by trying to create a new
+	// sub-group in the group we just created services in.
+	qc5 := servicestate.QuotaControlAction{
+		Action:         "create",
+		QuotaName:      "foo3",
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB / 4).Build(),
+		ParentName:     "foo2",
+	}
+
+	err = s.callDoQuotaControl(&qc5)
+	c.Assert(err, ErrorMatches, `cannot mix sub groups with services in the same group`)
+
+	// check that the quota groups was created in the state
+	checkQuotaState(c, st, map[string]quotaGroupState{
+		"foo": {
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
+			Snaps:          []string{"test-snap"},
+			SubGroups:      []string{"foo2"},
+		},
+		"foo2": {
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB / 2).Build(),
+			ParentGroup:    "foo",
+			Services:       []string{"test-snap.svc1"},
+		},
+	})
+}
+
+func (s *quotaHandlersSuite) TestQuotaSnapFailToMixServicesWithSubgroups(c *C) {
+	r := s.mockSystemctlCalls(c, join(
+		[]expectedSystemctl{{expArgs: []string{"daemon-reload"}}},
+
+		// CreateQuota for foo
+		systemctlCallsForSliceStart("foo"),
+
+		// UpdateQuota for foo2 - just the slice changes
+		systemctlCallsForServiceRestart("test-snap"),
+	))
+	defer r()
+
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	// setup the snap so it exists
+	snapstate.Set(s.state, "test-snap", s.testSnapState)
+	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
+
+	qc := servicestate.QuotaControlAction{
+		Action:         "create",
+		QuotaName:      "foo",
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
+		AddSnaps:       []string{"test-snap"},
+	}
+
+	err := s.callDoQuotaControl(&qc)
+	c.Assert(err, IsNil)
+
+	// create a subgroup in a group that already has snaps
+	qc2 := servicestate.QuotaControlAction{
+		Action:         "create",
+		QuotaName:      "foo2",
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB / 2).Build(),
+		ParentName:     "foo",
+	}
+
+	err = s.callDoQuotaControl(&qc2)
+	c.Assert(err, IsNil)
+
+	// add services to the new sub group
+	qc3 := servicestate.QuotaControlAction{
+		Action:      "update",
+		QuotaName:   "foo2",
+		AddServices: []string{"test-snap.svc1"},
+	}
+
+	err = s.callDoQuotaControl(&qc3)
+	c.Assert(err, IsNil)
+
+	// now we try to create a sub-group in foo2, this should fail
+	qc4 := servicestate.QuotaControlAction{
+		Action:         "create",
+		QuotaName:      "foo3",
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB / 4).Build(),
+		ParentName:     "foo2",
+	}
+
+	err = s.callDoQuotaControl(&qc4)
+	c.Assert(err, ErrorMatches, `cannot mix sub groups with services in the same group`)
+
+	// check that the quota groups was created in the state
+	checkQuotaState(c, st, map[string]quotaGroupState{
+		"foo": {
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
+			Snaps:          []string{"test-snap"},
+			SubGroups:      []string{"foo2"},
+		},
+		"foo2": {
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB / 2).Build(),
+			ParentGroup:    "foo",
+			Services:       []string{"test-snap.svc1"},
+		},
+	})
+}
+
+func (s *quotaHandlersSuite) TestQuotaSnapAddSnapServices(c *C) {
+	r := s.mockSystemctlCalls(c, join(
+		[]expectedSystemctl{{expArgs: []string{"daemon-reload"}}},
+
+		// CreateQuota for foo
+		systemctlCallsForSliceStart("foo"),
+
+		// UpdateQuota for foo2 - just the slice changes
+		systemctlCallsForServiceRestart("test-snap"),
+	))
+	defer r()
+
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	// setup the snap so it exists
+	snapstate.Set(s.state, "test-snap", s.testSnapState)
+	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
+
+	qc := servicestate.QuotaControlAction{
+		Action:         "create",
+		QuotaName:      "foo",
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
+		AddSnaps:       []string{"test-snap"},
+	}
+
+	err := s.callDoQuotaControl(&qc)
+	c.Assert(err, IsNil)
+
+	// create a subgroup in a group that already has snaps
+	qc2 := servicestate.QuotaControlAction{
+		Action:         "create",
+		QuotaName:      "foo2",
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB / 2).Build(),
+		ParentName:     "foo",
+	}
+
+	err = s.callDoQuotaControl(&qc2)
+	c.Assert(err, IsNil)
+
+	// and at last, we add services from test-snap into the sub-group
+	qc3 := servicestate.QuotaControlAction{
+		Action:      "update",
+		QuotaName:   "foo2",
+		AddServices: []string{"test-snap.svc1"},
+	}
+
+	err = s.callDoQuotaControl(&qc3)
+	c.Assert(err, IsNil)
+
+	// check that the quota groups was created in the state
+	checkQuotaState(c, st, map[string]quotaGroupState{
+		"foo": {
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
+			Snaps:          []string{"test-snap"},
+			SubGroups:      []string{"foo2"},
+		},
+		"foo2": {
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB / 2).Build(),
+			ParentGroup:    "foo",
+			Services:       []string{"test-snap.svc1"},
+		},
+	})
+}
+
+func (s *quotaHandlersSuite) TestQuotaSnapAddSnapNestedFails(c *C) {
+	r := s.mockSystemctlCalls(c, join(
+		[]expectedSystemctl{{expArgs: []string{"daemon-reload"}}},
+
+		// CreateQuota for foo
+		systemctlCallsForSliceStart("foo"),
+
+		// UpdateQuota for foo2 - just the slice changes
+		systemctlCallsForServiceRestart("test-snap"),
+	))
+	defer r()
+
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	// setup the snap so it exists
+	snapstate.Set(s.state, "test-snap", s.testSnapState)
+	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
+	// and test-snap2
+	si2 := &snap.SideInfo{RealName: "test-snap2", Revision: snap.R(42)}
+	snapst2 := &snapstate.SnapState{
+		Sequence: []*snap.SideInfo{si2},
+		Current:  si2.Revision,
+		Active:   true,
+		SnapType: "app",
+	}
+	snapstate.Set(s.state, "test-snap2", snapst2)
+	snaptest.MockSnapCurrent(c, testYaml2, si2)
+
+	qc := servicestate.QuotaControlAction{
+		Action:         "create",
+		QuotaName:      "foo",
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
+		AddSnaps:       []string{"test-snap"},
+	}
+
+	err := s.callDoQuotaControl(&qc)
+	c.Assert(err, IsNil)
+
+	// create a subgroup in a group that already has snaps
+	qc2 := servicestate.QuotaControlAction{
+		Action:         "create",
+		QuotaName:      "foo2",
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB / 2).Build(),
+		ParentName:     "foo",
+	}
+
+	err = s.callDoQuotaControl(&qc2)
+	c.Assert(err, IsNil)
+
+	// and at last, we add a new snap into that sub-group, this is not allowed
+	qc3 := servicestate.QuotaControlAction{
+		Action:    "update",
+		QuotaName: "foo2",
+		AddSnaps:  []string{"test-snap2"},
+	}
+
+	err = s.callDoQuotaControl(&qc3)
+	c.Assert(err, ErrorMatches, `cannot add snaps to group "foo2": only services are allowed in this sub-group`)
+
+	// check that the quota groups was created in the state
+	checkQuotaState(c, st, map[string]quotaGroupState{
+		"foo": {
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
+			Snaps:          []string{"test-snap"},
+			SubGroups:      []string{"foo2"},
+		},
+		"foo2": {
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB / 2).Build(),
+			ParentGroup:    "foo",
+		},
+	})
+}
+
+func (s *quotaHandlersSuite) TestQuotaSnapAddSnapAndServicesFail(c *C) {
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	// setup the snap so it exists
+	snapstate.Set(s.state, "test-snap", s.testSnapState)
+	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
+
+	qc := servicestate.QuotaControlAction{
+		Action:         "create",
+		QuotaName:      "foo",
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
+		AddSnaps:       []string{"test-snap"},
+		AddServices:    []string{"test-snap.svc1"},
+	}
+
+	err := s.callDoQuotaControl(&qc)
+	c.Assert(err, ErrorMatches, `cannot mix services and snaps in the same quota group`)
+}
+
+func (s *quotaHandlersSuite) TestQuotaSnapAddSnapServicesFailOnInvalidSnapService(c *C) {
+	r := s.mockSystemctlCalls(c, join(
+		[]expectedSystemctl{{expArgs: []string{"daemon-reload"}}},
+
+		// CreateQuota for foo
+		systemctlCallsForSliceStart("foo"),
+
+		// UpdateQuota for foo2 - just the slice changes
+		systemctlCallsForServiceRestart("test-snap"),
+	))
+	defer r()
+
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	// setup the snap so it exists
+	snapstate.Set(s.state, "test-snap", s.testSnapState)
+	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
+	// and test-snap2
+	si2 := &snap.SideInfo{RealName: "test-snap2", Revision: snap.R(42)}
+	snapst2 := &snapstate.SnapState{
+		Sequence: []*snap.SideInfo{si2},
+		Current:  si2.Revision,
+		Active:   true,
+		SnapType: "app",
+	}
+	snapstate.Set(s.state, "test-snap2", snapst2)
+	snaptest.MockSnapCurrent(c, testYaml2, si2)
+
+	qc := servicestate.QuotaControlAction{
+		Action:         "create",
+		QuotaName:      "foo",
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
+		AddSnaps:       []string{"test-snap"},
+	}
+
+	err := s.callDoQuotaControl(&qc)
+	c.Assert(err, IsNil)
+
+	// create a subgroup in a group that already has snaps
+	qc2 := servicestate.QuotaControlAction{
+		Action:         "create",
+		QuotaName:      "foo2",
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB / 2).Build(),
+		ParentName:     "foo",
+	}
+
+	err = s.callDoQuotaControl(&qc2)
+	c.Assert(err, IsNil)
+
+	// now we test both invalid service name, and an invalid snap name
+	qc3 := servicestate.QuotaControlAction{
+		Action:      "update",
+		QuotaName:   "foo2",
+		AddServices: []string{"test-snap.svc-none"},
+	}
+
+	err = s.callDoQuotaControl(&qc3)
+	c.Assert(err, ErrorMatches, `cannot use snap service in group "foo2": invalid service "svc-none"`)
+
+	qc4 := servicestate.QuotaControlAction{
+		Action:      "update",
+		QuotaName:   "foo2",
+		AddServices: []string{"no-snap.svc1"},
+	}
+
+	err = s.callDoQuotaControl(&qc4)
+	c.Assert(err, ErrorMatches, `cannot use snap service in group "foo2": snap "no-snap" is not installed`)
+
+	// also test adding a valid snap, but the snap is not relevant for this quota group
+	qc5 := servicestate.QuotaControlAction{
+		Action:      "update",
+		QuotaName:   "foo2",
+		AddServices: []string{"test-snap2.svc1"},
+	}
+
+	err = s.callDoQuotaControl(&qc5)
+	c.Assert(err, ErrorMatches, `cannot use snap "test-snap2": the snap must be in a parent group of group "foo2"`)
+
+	// check that the quota groups was created in the state
+	checkQuotaState(c, st, map[string]quotaGroupState{
+		"foo": {
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
+			Snaps:          []string{"test-snap"},
+			SubGroups:      []string{"foo2"},
+		},
+		"foo2": {
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB / 2).Build(),
+			ParentGroup:    "foo",
+		},
+	})
+}
+
+func (s *quotaHandlersSuite) TestQuotaSnapCorrectlyDetectErrorsIfCreatingSubgroupsFirst(c *C) {
+	r := s.mockSystemctlCalls(c, join(
+		[]expectedSystemctl{{expArgs: []string{"daemon-reload"}}},
+
+		// CreateQuota for foo
+		systemctlCallsForSliceStart("foo"),
+
+		// CreateQuota for foo2
+		systemctlCallsForSliceStart("foo/foo2"),
+
+		// CreateQuota for foo3
+		systemctlCallsForSliceStart("foo/foo2/foo3"),
+
+		// UpdateQuota for foo - just the slice changes
+		systemctlCallsForServiceRestart("test-snap"),
+	))
+	defer r()
+
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	// setup the snap so it exists
+	snapstate.Set(s.state, "test-snap", s.testSnapState)
+	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
+	// and test-snap2
+	si2 := &snap.SideInfo{RealName: "test-snap2", Revision: snap.R(42)}
+	snapst2 := &snapstate.SnapState{
+		Sequence: []*snap.SideInfo{si2},
+		Current:  si2.Revision,
+		Active:   true,
+		SnapType: "app",
+	}
+	snapstate.Set(s.state, "test-snap2", snapst2)
+	snaptest.MockSnapCurrent(c, testYaml2, si2)
+
+	// Create 3 levels of quota groups
+	//         foo
+	//         /  \
+	//        X   foo2
+	//              \
+	//             foo3
+	// The theory is, that if we just create the groups before inserting snaps
+	// and services, maybe we can end up in a state we don't want. If we insert
+	// a snap in foo, then we end up with a group foo3 which will be unusable. This
+	// is the intended behavior, it's important to test that we won't be allowed to use it, but
+	// that we can indeed remove it
+	err := s.callDoQuotaControl(&servicestate.QuotaControlAction{
+		Action:         "create",
+		QuotaName:      "foo",
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
+	})
+	c.Assert(err, IsNil)
+
+	err = s.callDoQuotaControl(&servicestate.QuotaControlAction{
+		Action:         "create",
+		QuotaName:      "foo2",
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB / 2).Build(),
+		ParentName:     "foo",
+	})
+	c.Assert(err, IsNil)
+
+	err = s.callDoQuotaControl(&servicestate.QuotaControlAction{
+		Action:         "create",
+		QuotaName:      "foo3",
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB / 4).Build(),
+		ParentName:     "foo2",
+	})
+	c.Assert(err, IsNil)
+
+	// Should fail: insert snap into foo. When snaps are mixed with sub-groups
+	// then only one level of sub-groups are allowed.
+	err = s.callDoQuotaControl(&servicestate.QuotaControlAction{
+		Action:    "update",
+		QuotaName: "foo",
+		AddSnaps:  []string{"test-snap"},
+	})
+	c.Assert(err, ErrorMatches, `cannot update quota "foo": group "foo3" is invalid: only one level of sub-groups are allowed for groups mixed with snaps and sub-groups`)
+
+	// Should work: insert snap into foo2
+	err = s.callDoQuotaControl(&servicestate.QuotaControlAction{
+		Action:    "update",
+		QuotaName: "foo2",
+		AddSnaps:  []string{"test-snap"},
+	})
+	c.Assert(err, IsNil)
+
+	// Should fail: insert snap into foo3
+	err = s.callDoQuotaControl(&servicestate.QuotaControlAction{
+		Action:    "update",
+		QuotaName: "foo3",
+		AddSnaps:  []string{"test-snap2"},
+	})
+	c.Assert(err, ErrorMatches, `cannot add snaps to group "foo3": only services are allowed in this sub-group`)
+
+	// Must work: insert services from foo2 into foo3
+	err = s.callDoQuotaControl(&servicestate.QuotaControlAction{
+		Action:      "update",
+		QuotaName:   "foo3",
+		AddServices: []string{"test-snap.svc1"},
+	})
+	c.Assert(err, IsNil)
 
 	// check that the quota groups was created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
@@ -1094,7 +1559,14 @@ func (s *quotaHandlersSuite) TestQuotaSnapFailToMixSnapsWithSubgroups(c *C) {
 		},
 		"foo2": {
 			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB / 2).Build(),
+			Snaps:          []string{"test-snap"},
 			ParentGroup:    "foo",
+			SubGroups:      []string{"foo3"},
+		},
+		"foo3": {
+			ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB / 4).Build(),
+			ParentGroup:    "foo2",
+			Services:       []string{"test-snap.svc1"},
 		},
 	})
 }
@@ -1478,7 +1950,7 @@ func (s *quotaHandlersSuite) TestUpdateJournalQuota(c *C) {
 	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
 
 	// setup an existing quota group we can update it
-	err := servicestatetest.MockQuotaInState(st, "foo", "", []string{"test-snap"}, quota.NewResourcesBuilder().WithJournalSize(16*quantity.SizeMiB).Build())
+	err := servicestatetest.MockQuotaInState(st, "foo", "", []string{"test-snap"}, nil, quota.NewResourcesBuilder().WithJournalSize(16*quantity.SizeMiB).Build())
 	c.Assert(err, check.IsNil)
 
 	// Create the journald config file in /etc/systemd/journald@snap-foo.conf
@@ -1551,7 +2023,7 @@ func (s *quotaHandlersSuite) TestRemoveJournalQuota(c *C) {
 	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
 
 	// setup an existing quota group we can remove
-	err := servicestatetest.MockQuotaInState(st, "foo", "", []string{"test-snap"}, quota.NewResourcesBuilder().WithJournalSize(16*quantity.SizeMiB).Build())
+	err := servicestatetest.MockQuotaInState(st, "foo", "", []string{"test-snap"}, nil, quota.NewResourcesBuilder().WithJournalSize(16*quantity.SizeMiB).Build())
 	c.Assert(err, check.IsNil)
 
 	qc := servicestate.QuotaControlAction{
@@ -1811,7 +2283,7 @@ func (s *quotaHandlersSuite) TestDoQuotaAddSnapQuotaConflict(c *C) {
 	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
 
 	// setup an existing quota group we can update it
-	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, quota.NewResourcesBuilder().WithMemoryLimit(1*quantity.SizeGiB).Build())
+	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, nil, quota.NewResourcesBuilder().WithMemoryLimit(1*quantity.SizeGiB).Build())
 	c.Assert(err, check.IsNil)
 
 	// Create a change that has a quota-control task in it for quota group foo
@@ -1841,7 +2313,7 @@ func (s *quotaHandlersSuite) TestDoQuotaAddSnapSnapConflict(c *C) {
 	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
 
 	// setup an existing quota group we can update it
-	err := servicestatetest.MockQuotaInState(st, "foo2", "", nil, quota.NewResourcesBuilder().WithMemoryLimit(1*quantity.SizeGiB).Build())
+	err := servicestatetest.MockQuotaInState(st, "foo2", "", nil, nil, quota.NewResourcesBuilder().WithMemoryLimit(1*quantity.SizeGiB).Build())
 	c.Assert(err, check.IsNil)
 
 	// Create the initial change which will contain AddSnapToQuotaGroup

--- a/overlord/servicestate/quota_handlers_test.go
+++ b/overlord/servicestate/quota_handlers_test.go
@@ -1075,7 +1075,7 @@ func (s *quotaHandlersSuite) TestQuotaSnapFailToMixSubgroupWithServices(c *C) {
 	}
 
 	err = s.callDoQuotaControl(&qc3)
-	c.Assert(err, ErrorMatches, `cannot update quota "foo3": group "foo3" is invalid: only one level of sub-groups are allowed for groups mixed with snaps and sub-groups`)
+	c.Assert(err, ErrorMatches, `cannot update quota "foo2": group "foo2" is invalid: only one level of sub-groups are allowed for groups mixed with snaps and sub-groups`)
 
 	// and at last, we add services from test-snap into the sub-group, which itself already
 	// has a subgroup.

--- a/overlord/servicestate/servicestatetest/quotas.go
+++ b/overlord/servicestate/servicestatetest/quotas.go
@@ -33,7 +33,7 @@ func PatchQuotas(st *state.State, grps ...*quota.Group) (map[string]*quota.Group
 	return internal.PatchQuotas(st, grps...)
 }
 
-func MockQuotaInState(st *state.State, quotaName string, parentName string, snaps []string, resourceLimits quota.Resources) error {
+func MockQuotaInState(st *state.State, quotaName string, parentName string, snaps, services []string, resourceLimits quota.Resources) error {
 	allGrps, err := internal.AllQuotas(st)
 	if err != nil {
 		return nil
@@ -48,6 +48,6 @@ func MockQuotaInState(st *state.State, quotaName string, parentName string, snap
 		}
 	}
 
-	_, _, err = internal.CreateQuotaInState(st, quotaName, parentGrp, snaps, resourceLimits, allGrps)
+	_, _, err = internal.CreateQuotaInState(st, quotaName, parentGrp, snaps, services, resourceLimits, allGrps)
 	return err
 }

--- a/snap/quota/quota.go
+++ b/snap/quota/quota.go
@@ -852,7 +852,11 @@ func (grp *Group) NewSubGroup(name string, resourceLimits Resources) (*Group, er
 	return subGrp, nil
 }
 
-func (grp *Group) VerifyGroupNesting() error {
+// VerifyNesting takes a group and verifies that it satisfies the following conditions:
+// 1. That if any parent is mixed (has both snaps and sub-groups), it must be the immediate
+//    parent group.
+// 2. If the group itself is mixed, that it has only one level of sub-grouping.
+func (grp *Group) VerifyNesting() error {
 	// A parent group is only allowed to contain a mixture of snaps
 	// and sub-groups if it's a direct parent. Introducing this limitation
 	// will not affect anything as we didn't allow mixing snaps and sub-groups

--- a/snap/quota/quota.go
+++ b/snap/quota/quota.go
@@ -851,7 +851,9 @@ func (grp *Group) ValidateNestingAndSnaps() error {
 	// prior to this change.
 	parent := grp.parentGroup
 	for parent != nil {
-		if len(parent.Snaps) > 0 && len(parent.SubGroups) > 0 {
+		// We know that the parent contains sub-groups (grp), so just
+		// do a check for snaps
+		if len(parent.Snaps) > 0 {
 			// then the group must be a direct parent
 			// and we must not have any sub-groups
 			if grp.parentGroup != parent || len(grp.SubGroups) > 0 {

--- a/snap/quota/quota_test.go
+++ b/snap/quota/quota_test.go
@@ -565,6 +565,150 @@ func (ts *quotaTestSuite) TestResolveCrossReferences(c *C) {
 	}
 }
 
+func (ts *quotaTestSuite) TestVerifyNestingAndMixingIsAllowed(c *C) {
+	tt := []struct {
+		grps    map[string]*quota.Group
+		check   string
+		err     string
+		comment string
+	}{
+		{
+			grps: map[string]*quota.Group{
+				"foogroup": {
+					Name:        "foogroup",
+					MemoryLimit: quantity.SizeMiB * 16,
+					Snaps:       []string{"test-snap"},
+				},
+			},
+			check:   "foogroup",
+			comment: "single group with a snap",
+		},
+		{
+			grps: map[string]*quota.Group{
+				"foogroup": {
+					Name:        "foogroup",
+					MemoryLimit: quantity.SizeMiB * 16,
+					Snaps:       []string{"test-snap"},
+					SubGroups:   []string{"foo-sub"},
+				},
+				"foo-sub": {
+					Name:        "foo-sub",
+					MemoryLimit: quantity.SizeMiB * 8,
+					ParentGroup: "foogroup",
+				},
+			},
+			check:   "foogroup",
+			comment: "mixed group, with a single sub-group",
+		},
+		{
+			grps: map[string]*quota.Group{
+				"foogroup": {
+					Name:        "foogroup",
+					MemoryLimit: quantity.SizeMiB * 16,
+					Snaps:       []string{"test-snap"},
+					SubGroups:   []string{"foo-sub"},
+				},
+				"foo-sub": {
+					Name:        "foo-sub",
+					MemoryLimit: quantity.SizeMiB * 8,
+					ParentGroup: "foogroup",
+					SubGroups:   []string{"foo-sub-sub"},
+				},
+				"foo-sub-sub": {
+					Name:        "foo-sub-sub",
+					MemoryLimit: quantity.SizeMiB * 4,
+					ParentGroup: "foo-sub",
+				},
+			},
+			check:   "foogroup",
+			err:     `group "foo-sub-sub" is invalid: only one level of sub-groups are allowed for groups mixed with snaps and sub-groups`,
+			comment: "mixed parent group with more than 1 level of sub-grouping",
+		},
+		{
+			grps: map[string]*quota.Group{
+				"foogroup": {
+					Name:        "foogroup",
+					MemoryLimit: quantity.SizeMiB * 16,
+					Snaps:       []string{"test-snap"},
+					SubGroups:   []string{"foo-sub"},
+				},
+				"foo-sub": {
+					Name:        "foo-sub",
+					MemoryLimit: quantity.SizeMiB * 8,
+					ParentGroup: "foogroup",
+					SubGroups:   []string{"foo-sub-sub"},
+				},
+				"foo-sub-sub": {
+					Name:        "foo-sub-sub",
+					MemoryLimit: quantity.SizeMiB * 4,
+					ParentGroup: "foo-sub",
+				},
+			},
+			check:   "foo-sub",
+			err:     `group "foo-sub" is invalid: only one level of sub-groups are allowed for groups mixed with snaps and sub-groups`,
+			comment: "mixed parent group with more than 1 level of sub-grouping, verifying foo-sub",
+		},
+		{
+			grps: map[string]*quota.Group{
+				"foogroup": {
+					Name:        "foogroup",
+					MemoryLimit: quantity.SizeMiB * 16,
+					Snaps:       []string{"test-snap"},
+					SubGroups:   []string{"foo-sub"},
+				},
+				"foo-sub": {
+					Name:        "foo-sub",
+					MemoryLimit: quantity.SizeMiB * 8,
+					ParentGroup: "foogroup",
+					SubGroups:   []string{"foo-sub-sub"},
+				},
+				"foo-sub-sub": {
+					Name:        "foo-sub-sub",
+					MemoryLimit: quantity.SizeMiB * 4,
+					ParentGroup: "foo-sub",
+				},
+			},
+			check:   "foo-sub-sub",
+			err:     `group "foo-sub-sub" is invalid: only one level of sub-groups are allowed for groups mixed with snaps and sub-groups`,
+			comment: "mixed parent group with more than 1 level of sub-grouping, verifying foo-sub-sub",
+		},
+		{
+			grps: map[string]*quota.Group{
+				"foogroup": {
+					Name:        "foogroup",
+					MemoryLimit: quantity.SizeMiB * 16,
+					Snaps:       []string{"test-snap"},
+					SubGroups:   []string{"foo-sub"},
+				},
+				"foo-sub": {
+					Name:        "foo-sub",
+					MemoryLimit: quantity.SizeMiB * 8,
+					ParentGroup: "foogroup",
+					Snaps:       []string{"test-snap"},
+				},
+			},
+			check:   "foogroup",
+			err:     `group "foogroup" is invalid: nesting of snaps is not supported`,
+			comment: "mixed parent group with nested snap, verifying foogroup",
+		},
+	}
+
+	for _, t := range tt {
+		comment := Commentf(t.comment)
+		// resolve cross references as we need group pointers to be updated
+		err := quota.ResolveCrossReferences(t.grps)
+		c.Assert(err, IsNil, comment)
+		grpToCheck := t.grps[t.check]
+		c.Assert(grpToCheck, NotNil, comment)
+		err = grpToCheck.VerifyNestingAndMixingIsAllowed()
+		if t.err != "" {
+			c.Assert(err, ErrorMatches, t.err, comment)
+		} else {
+			c.Assert(err, IsNil, comment)
+		}
+	}
+}
+
 func (ts *quotaTestSuite) TestChangingRequirementsDoesNotBreakExistingGroups(c *C) {
 	tt := []struct {
 		grp     *quota.Group

--- a/snap/quota/quota_test.go
+++ b/snap/quota/quota_test.go
@@ -621,7 +621,7 @@ func (ts *quotaTestSuite) TestVerifyNestingAndMixingIsAllowed(c *C) {
 				},
 			},
 			check:   "foogroup",
-			err:     `group "foo-sub-sub" is invalid: only one level of sub-groups are allowed for groups mixed with snaps and sub-groups`,
+			err:     `group "foo-sub-sub" is invalid: only one level of sub-groups are allowed for groups with snaps`,
 			comment: "mixed parent group with more than 1 level of sub-grouping",
 		},
 		{
@@ -645,7 +645,7 @@ func (ts *quotaTestSuite) TestVerifyNestingAndMixingIsAllowed(c *C) {
 				},
 			},
 			check:   "foo-sub",
-			err:     `group "foo-sub" is invalid: only one level of sub-groups are allowed for groups mixed with snaps and sub-groups`,
+			err:     `group "foo-sub" is invalid: only one level of sub-groups are allowed for groups with snaps`,
 			comment: "mixed parent group with more than 1 level of sub-grouping, verifying foo-sub",
 		},
 		{
@@ -669,7 +669,7 @@ func (ts *quotaTestSuite) TestVerifyNestingAndMixingIsAllowed(c *C) {
 				},
 			},
 			check:   "foo-sub-sub",
-			err:     `group "foo-sub-sub" is invalid: only one level of sub-groups are allowed for groups mixed with snaps and sub-groups`,
+			err:     `group "foo-sub-sub" is invalid: only one level of sub-groups are allowed for groups with snaps`,
 			comment: "mixed parent group with more than 1 level of sub-grouping, verifying foo-sub-sub",
 		},
 		{
@@ -700,7 +700,7 @@ func (ts *quotaTestSuite) TestVerifyNestingAndMixingIsAllowed(c *C) {
 		c.Assert(err, IsNil, comment)
 		grpToCheck := t.grps[t.check]
 		c.Assert(grpToCheck, NotNil, comment)
-		err = grpToCheck.VerifyNestingAndMixingIsAllowed()
+		err = grpToCheck.ValidateNestingAndSnaps()
 		if t.err != "" {
 			c.Assert(err, ErrorMatches, t.err, comment)
 		} else {
@@ -1510,33 +1510,4 @@ func (ts *quotaTestSuite) TestJournalQuotasUpdatesCorrectly(c *C) {
 	c.Check(grp1.JournalLimit.Size, Equals, quantity.SizeMiB)
 	c.Check(grp1.JournalLimit.RateCount, Equals, 15)
 	c.Check(grp1.JournalLimit.RatePeriod, Equals, time.Microsecond*5)
-}
-
-func (ts *quotaTestSuite) TestIsSnapRelatedHappy(c *C) {
-	grp1, err := quota.NewGroup("grp1", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
-	c.Assert(err, IsNil)
-
-	grp1.Snaps = []string{"my-snap"}
-
-	grp2, err := grp1.NewSubGroup("grp1-sub", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB*128).Build())
-	c.Assert(err, IsNil)
-	c.Check(grp2.IsSnapRelated("my-snap"), Equals, true)
-}
-
-func (ts *quotaTestSuite) TestIsSnapRelatedSameGroupHappy(c *C) {
-	grp1, err := quota.NewGroup("grp1", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
-	c.Assert(err, IsNil)
-	grp1.Snaps = []string{"my-snap"}
-	c.Check(grp1.IsSnapRelated("my-snap"), Equals, true)
-}
-
-func (ts *quotaTestSuite) TestIsSnapRelatedNoMatchingSnap(c *C) {
-	grp1, err := quota.NewGroup("grp1", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
-	c.Assert(err, IsNil)
-
-	grp1.Snaps = []string{"my-snap"}
-
-	grp2, err := grp1.NewSubGroup("grp1-sub", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB*128).Build())
-	c.Assert(err, IsNil)
-	c.Check(grp2.IsSnapRelated("not-in-group"), Equals, false)
 }

--- a/snap/quota/quota_test.go
+++ b/snap/quota/quota_test.go
@@ -688,7 +688,7 @@ func (ts *quotaTestSuite) TestVerifyNestingAndMixingIsAllowed(c *C) {
 				},
 			},
 			check:   "foogroup",
-			err:     `group "foogroup" is invalid: nesting of snaps is not supported`,
+			err:     `group "foogroup" is invalid: nesting of groups with snaps is not supported`,
 			comment: "mixed parent group with nested snap, verifying foogroup",
 		},
 	}

--- a/tests/main/snap-quota/task.yaml
+++ b/tests/main/snap-quota/task.yaml
@@ -30,8 +30,21 @@ execute: |
   snap set-quota group-one --parent=group-top1 --memory=100MB hello-world
   snap set-quota group-two --parent=group-top1 --memory=2MB test-snapd-tools
 
-  echo "Creating a nested empty quota groups which fails"
-  snap set-quota group-sub-one --parent=group-one --memory=1MB 2>&1 | tr '\n' ' ' | tr -s ' ' | MATCH 'cannot mix sub groups with snaps in the same group'
+  echo "Creating a nested empty quota groups"
+  snap set-quota group-sub-one --parent=group-one --memory=1MB
+
+  # Only services are allowed to be put into nested sub-groups, not snaps
+  # so this should now fail.
+  echo "Put a snap into the new nested group, this should fail"
+  snap set-quota group-sub-one go-example-webserver 2>&1 | tr '\n' ' ' | tr -s ' ' | MATCH 'error: cannot update quota group: cannot add snaps to group "group-sub-one": only services are allowed in this sub-group'
+
+  # Also try to further create a sub-group in that sub-group, should not be allowed
+  # as the parent is now mixed.
+  echo "Add another sub-group to the sub-group, this should fail"
+  snap set-quota group-sub-one-sub --parent=group-sub-one --memory=768KB 2>&1 | tr '\n' ' ' | tr -s ' ' | MATCH 'cannot update quota "group-sub-one-sub": group "group-sub-one-sub" is invalid: only one level of sub-groups are allowed for groups mixed with snaps and sub-groups'
+
+  echo "Removing the nested sub-group again"
+  snap remove-quota group-sub-one
 
   echo "Creating some empty quota sub groups"
   snap set-quota group-three --parent=group-top1 --memory=15MB

--- a/tests/main/snap-quota/task.yaml
+++ b/tests/main/snap-quota/task.yaml
@@ -41,7 +41,7 @@ execute: |
   # Also try to further create a sub-group in that sub-group, should not be allowed
   # as the parent is now mixed.
   echo "Add another sub-group to the sub-group, this should fail"
-  snap set-quota group-sub-one-sub --parent=group-sub-one --memory=768KB 2>&1 | tr '\n' ' ' | tr -s ' ' | MATCH 'cannot update quota "group-sub-one-sub": group "group-sub-one-sub" is invalid: only one level of sub-groups are allowed for groups with snaps'
+  snap set-quota group-sub-one-sub --parent=group-sub-one --memory=768KB 2>&1 | tr '\n' ' ' | tr -s ' ' | MATCH 'cannot update quota "group-sub-one": group "group-sub-one" is invalid: only one level of sub-groups are allowed for groups with snaps'
 
   echo "Removing the nested sub-group again"
   snap remove-quota group-sub-one

--- a/tests/main/snap-quota/task.yaml
+++ b/tests/main/snap-quota/task.yaml
@@ -41,7 +41,7 @@ execute: |
   # Also try to further create a sub-group in that sub-group, should not be allowed
   # as the parent is now mixed.
   echo "Add another sub-group to the sub-group, this should fail"
-  snap set-quota group-sub-one-sub --parent=group-sub-one --memory=768KB 2>&1 | tr '\n' ' ' | tr -s ' ' | MATCH 'cannot update quota "group-sub-one-sub": group "group-sub-one-sub" is invalid: only one level of sub-groups are allowed for groups mixed with snaps and sub-groups'
+  snap set-quota group-sub-one-sub --parent=group-sub-one --memory=768KB 2>&1 | tr '\n' ' ' | tr -s ' ' | MATCH 'cannot update quota "group-sub-one-sub": group "group-sub-one-sub" is invalid: only one level of sub-groups are allowed for groups with snaps'
 
   echo "Removing the nested sub-group again"
   snap remove-quota group-sub-one


### PR DESCRIPTION
This is the first PR in the per-service quota series. I'm sorry for the size of this PR, it's a bit bigger than I wanted it to be, I have tried to encapsulate changes in commits to make reviewing easier, but I believe most of the changes are unit test changes.

This adds support for per-service quota groups. There are some limitations that have been changed, and new ones introduced. The most important is that this PR changes the current limitation of not being able to mix snaps and sub-groups, which is now allowed to some extent.

If you mix snaps and sub-groups, you are not allowed to further put snaps into the sub-groups, only services as we do not allow nesting of snaps and sub-groups.

Instead you must only put services into sub-groups of groups that contain snaps.
Neither do we allow mixing sub-groups and services. A sub-group containing services must be the last sub-group in that tree.

All of these constraints introduce some complexity, hopefully all captured by unit tests.