### PR TITLE
tests: re-enable `snap run --strace` test on core22

### DIFF
--- a/tests/main/snap-run/task.yaml
+++ b/tests/main/snap-run/task.yaml
@@ -4,8 +4,6 @@ systems:
   # strace does not support _newselect on s390x
   # (https://github.com/strace/strace/issues/57)
   - -*-s390x
-  # TODO: segfault on core22
-  - -ubuntu-core-22-*
 
 prepare: |
     "$TESTSTOOLS"/snaps-state install-local basic-run


### PR DESCRIPTION
With the updated version of strace in edge core22 should be able to use strace again. Thanks to Tony Espy.
