### PR TITLE
o/servicestate: handle quota changes on a service level instead of on a snap level (3/4)

### DIFF
--- a/overlord/configstate/configcore/vitality.go
+++ b/overlord/configstate/configcore/vitality.go
@@ -127,7 +127,7 @@ func handleVitalityConfiguration(tr config.Conf, opts *fsOnlyContext) error {
 		}
 
 		// get the options for this snap service
-		snapSvcOpts, err := servicestate.SnapServiceOptions(st, instanceName, grps)
+		snapSvcOpts, err := servicestate.SnapServiceOptions(st, info, grps)
 		if err != nil {
 			return err
 		}

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -68,7 +68,12 @@ func journalQuotaLayout(quotaGroup *quota.Group) []snap.Layout {
 // a snap instance. These are the layouts which can change during the lifetime of a snap
 // like for instance mimicking systemd journal namespace mount layouts.
 func getExtraLayouts(st *state.State, snapInstanceName string) ([]snap.Layout, error) {
-	snapOpts, err := servicestate.SnapServiceOptions(st, snapInstanceName, nil)
+	info, err := snapstate.CurrentInfo(st, snapInstanceName)
+	if err != nil {
+		return nil, err
+	}
+
+	snapOpts, err := servicestate.SnapServiceOptions(st, info, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/overlord/servicestate/export_test.go
+++ b/overlord/servicestate/export_test.go
@@ -33,6 +33,7 @@ var (
 	QuotaStateAlreadyUpdated             = quotaStateAlreadyUpdated
 	ServiceControlTs                     = serviceControlTs
 	ValidateSnapServicesForAddingToGroup = validateSnapServicesForAddingToGroup
+	AffectedSnapServices                 = affectedSnapServices
 )
 
 type QuotaStateUpdated = quotaStateUpdated
@@ -51,6 +52,13 @@ func (m *ServiceManager) DoQuotaAddSnap(t *state.Task, to *tomb.Tomb) error {
 
 func (m *ServiceManager) UndoQuotaAddSnap(t *state.Task, to *tomb.Tomb) error {
 	return m.undoQuotaAddSnap(t, to)
+}
+
+func EnsureSnapServicesForGroupOptions(allGrps map[string]*quota.Group, extraSnaps []string) *ensureSnapServicesForGroupOptions {
+	return &ensureSnapServicesForGroupOptions{
+		allGrps:    allGrps,
+		extraSnaps: extraSnaps,
+	}
 }
 
 func MockOsutilBootID(mockID string) (restore func()) {

--- a/overlord/servicestate/quota_handlers.go
+++ b/overlord/servicestate/quota_handlers.go
@@ -560,6 +560,65 @@ type ensureSnapServicesForGroupOptions struct {
 	extraSnaps []string
 }
 
+func filterApps(apps []*snap.AppInfo, include []string) []*snap.AppInfo {
+	var out []*snap.AppInfo
+	for _, app := range apps {
+		if strutil.ListContains(include, app.Name) {
+			out = append(out, app)
+		}
+	}
+	return out
+}
+
+// affectedSnapServices returns a map of snaps and the services affected
+// by performing changes to a quota group. For groups that contain just snaps, all
+// services are added to the map, for groups that contain specific services, only those
+// services are affected.
+func affectedSnapServices(st *state.State, grp *quota.Group, opts *ensureSnapServicesForGroupOptions) (map[*snap.Info]*wrappers.SnapServiceOptions, error) {
+
+	snapSvcMap := map[*snap.Info]*wrappers.SnapServiceOptions{}
+	setSnapServices := func(snapName string, services []string) {
+		for info, opts := range snapSvcMap {
+			if info.InstanceName() == snapName {
+				opts.Services = filterApps(opts.Services, services)
+				return
+			}
+		}
+	}
+	addSnap := func(snapName string) error {
+		info, err := snapstate.CurrentInfo(st, snapName)
+		if err != nil {
+			return err
+		}
+		opts, err := SnapServiceOptions(st, info, opts.allGrps)
+		if err != nil {
+			return err
+		}
+		snapSvcMap[info] = opts
+		return nil
+	}
+
+	// handle extra snaps also passed here, so that they get included
+	// in any case
+	for _, sn := range append(grp.Snaps, opts.extraSnaps...) {
+		if err := addSnap(sn); err != nil {
+			return nil, err
+		}
+	}
+
+	// if the group is a service group, then we need to get the affected
+	// snaps from the service names, which are of format 'snap.service'
+	services := make(map[string][]string)
+	for _, sn := range grp.Services {
+		parts := strings.Split(sn, ".")
+		services[parts[0]] = append(services[parts[0]], parts[1])
+	}
+	for sn, svcs := range services {
+		setSnapServices(sn, svcs)
+	}
+	return snapSvcMap, nil
+}
+
 // ensureSnapServicesForGroup will handle updating changes to a given
 // quota group on disk, including re-generating systemd slice files,
 // as well as starting newly created quota groups and stopping and
@@ -576,8 +635,6 @@ func ensureSnapServicesForGroup(st *state.State, t *state.Task, grp *quota.Group
 		return nil, fmt.Errorf("internal error: unset group information for ensuring")
 	}
 
-	allGrps := opts.allGrps
-
 	var meterLocked progress.Meter
 	if t == nil {
 		meterLocked = progress.Null
@@ -586,19 +643,9 @@ func ensureSnapServicesForGroup(st *state.State, t *state.Task, grp *quota.Group
 	}
 
 	// build the map of snap infos to options to provide to EnsureSnapServices
-	snapSvcMap := map[*snap.Info]*wrappers.SnapServiceOptions{}
-	for _, sn := range append(grp.Snaps, opts.extraSnaps...) {
-		info, err := snapstate.CurrentInfo(st, sn)
-		if err != nil {
-			return nil, err
-		}
-
-		opts, err := SnapServiceOptions(st, sn, allGrps)
-		if err != nil {
-			return nil, err
-		}
-
-		snapSvcMap[info] = opts
+	snapSvcMap, err := affectedSnapServices(st, grp, opts)
+	if err != nil {
+		return nil, err
 	}
 
 	// TODO: the following lines should maybe be EnsureOptionsForDevice() or
@@ -728,6 +775,7 @@ func ensureSnapServicesForGroup(st *state.State, t *state.Task, grp *quota.Group
 	// we need to handle the case where a quota was removed, this will only
 	// happen one at a time and can be identified by the grp provided to us
 	// not existing in the state
+	allGrps := opts.allGrps
 	if _, ok := allGrps[grp.Name]; !ok {
 		// stop the quota group, then remove it
 		if !ensureOpts.Preseeding {

--- a/overlord/servicestate/quota_handlers_test.go
+++ b/overlord/servicestate/quota_handlers_test.go
@@ -40,7 +40,9 @@ import (
 	"github.com/snapcore/snapd/snap/quota"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/snapdenv"
+	"github.com/snapcore/snapd/strutil"
 	"github.com/snapcore/snapd/systemd"
+	"github.com/snapcore/snapd/wrappers"
 )
 
 type quotaHandlersSuite struct {
@@ -2725,4 +2727,107 @@ func (s *quotaHandlersSuite) TestValidateSnapServicesForAddingToGroupHappy(c *C)
 
 	err := servicestate.ValidateSnapServicesForAddingToGroup(st, []string{"test-snap.svc1"}, "foo2", allQuotas["foo"], allQuotas)
 	c.Assert(err, IsNil)
+}
+
+func (s *quotaHandlersSuite) checkServiceMap(c *C, obtained map[*snap.Info]*wrappers.SnapServiceOptions, expected map[string][]string) {
+	c.Assert(len(expected), Equals, len(obtained))
+	for info, opts := range obtained {
+		expectedSvcs, ok := expected[info.InstanceName()]
+		c.Assert(ok, Equals, true)
+		c.Assert(len(opts.Services), Equals, len(expectedSvcs))
+		for _, svc := range opts.Services {
+			c.Assert(strutil.ListContains(expectedSvcs, svc.Name), Equals, true)
+		}
+	}
+}
+
+func (s *quotaHandlersSuite) TestAffectedSnapServices(c *C) {
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	// setup test-snap
+	snapstate.Set(s.state, "test-snap", s.testSnapState)
+	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
+	// and test-snap2
+	si2 := &snap.SideInfo{RealName: "test-snap2", Revision: snap.R(42)}
+	snapst2 := &snapstate.SnapState{
+		Sequence: []*snap.SideInfo{si2},
+		Current:  si2.Revision,
+		Active:   true,
+		SnapType: "app",
+	}
+	snapstate.Set(s.state, "test-snap2", snapst2)
+	snaptest.MockSnapCurrent(c, testYaml2, si2)
+
+	// Create the root group with snaps in them
+	servicestatetest.MockQuotaInState(st, "foo", "", []string{"test-snap", "test-snap2"}, nil,
+		quota.NewResourcesBuilder().WithJournalNamespace().Build())
+
+	// Create a sub-group containing just service from test-snap
+	servicestatetest.MockQuotaInState(st, "foo-svc", "foo", nil, []string{"test-snap.svc1"},
+		quota.NewResourcesBuilder().WithJournalNamespace().Build())
+
+	// Get all quotas currently in state
+	allGrps, err := servicestate.AllQuotas(st)
+	c.Assert(err, IsNil)
+	c.Assert(allGrps["foo"], NotNil)
+	c.Assert(allGrps["foo-svc"], NotNil)
+
+	// Now, we get a list of services affected if we were to do changes
+	// to the sub-group containing just services
+	opts := servicestate.EnsureSnapServicesForGroupOptions(allGrps, nil)
+	affectedServices, err := servicestate.AffectedSnapServices(st, allGrps["foo-svc"], opts)
+	c.Assert(err, IsNil)
+	s.checkServiceMap(c, affectedServices, map[string][]string{
+		"test-snap": {"svc1"},
+	})
+
+	// However, if we get affected services from the group containing snaps,
+	// we should expect to see all services
+	affectedServices, err = servicestate.AffectedSnapServices(st, allGrps["foo"], opts)
+	c.Assert(err, IsNil)
+	s.checkServiceMap(c, affectedServices, map[string][]string{
+		"test-snap":  {"svc1"},
+		"test-snap2": {"svc1"},
+	})
+}
+
+func (s *quotaHandlersSuite) TestAffectedSnapServicesExtraSnaps(c *C) {
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	// setup test-snap
+	snapstate.Set(s.state, "test-snap", s.testSnapState)
+	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
+	// and test-snap2
+	si2 := &snap.SideInfo{RealName: "test-snap2", Revision: snap.R(42)}
+	snapst2 := &snapstate.SnapState{
+		Sequence: []*snap.SideInfo{si2},
+		Current:  si2.Revision,
+		Active:   true,
+		SnapType: "app",
+	}
+	snapstate.Set(s.state, "test-snap2", snapst2)
+	snaptest.MockSnapCurrent(c, testYaml2, si2)
+
+	// Create the root group with only test-snap in it
+	servicestatetest.MockQuotaInState(st, "foo", "", []string{"test-snap"}, nil,
+		quota.NewResourcesBuilder().WithJournalNamespace().Build())
+
+	// Get all quotas currently in state
+	allGrps, err := servicestate.AllQuotas(st)
+	c.Assert(err, IsNil)
+	c.Assert(allGrps["foo"], NotNil)
+
+	// Now, we get a list of services affected for foo, which should return only
+	// test-snap.svc1, but add in test-snap2 using the ExtraSnaps property.
+	opts := servicestate.EnsureSnapServicesForGroupOptions(allGrps, []string{"test-snap2"})
+	affectedServices, err := servicestate.AffectedSnapServices(st, allGrps["foo"], opts)
+	c.Assert(err, IsNil)
+	s.checkServiceMap(c, affectedServices, map[string][]string{
+		"test-snap":  {"svc1"},
+		"test-snap2": {"svc1"},
+	})
 }

--- a/overlord/servicestate/servicemgr.go
+++ b/overlord/servicestate/servicemgr.go
@@ -136,7 +136,7 @@ func (m *ServiceManager) ensureSnapServicesUpdated() (err error) {
 		}
 
 		// use the cached copy of all quota groups
-		snapSvcOpts, err := SnapServiceOptions(m.state, info.InstanceName(), allGrps)
+		snapSvcOpts, err := SnapServiceOptions(m.state, info, allGrps)
 		if err != nil {
 			return err
 		}

--- a/overlord/servicestate/servicestate.go
+++ b/overlord/servicestate/servicestate.go
@@ -364,7 +364,7 @@ func (sd *StatusDecorator) DecorateWithStatus(appInfo *client.AppInfo, snapApp *
 // optimization, the map if non-nil is used in place of checking state for
 // whether or not the specified snap is in a quota group or not. If nil, state
 // is consulted directly instead.
-func SnapServiceOptions(st *state.State, instanceName string, quotaGroups map[string]*quota.Group) (opts *wrappers.SnapServiceOptions, err error) {
+func SnapServiceOptions(st *state.State, snapInfo *snap.Info, quotaGroups map[string]*quota.Group) (opts *wrappers.SnapServiceOptions, err error) {
 	// if quotaGroups was not provided to us, then go get that
 	if quotaGroups == nil {
 		allGrps, err := AllQuotas(st)
@@ -383,7 +383,7 @@ func SnapServiceOptions(st *state.State, instanceName string, quotaGroups map[st
 		return nil, err
 	}
 	for i, s := range strings.Split(vitalityStr, ",") {
-		if s == instanceName {
+		if s == snapInfo.InstanceName() {
 			opts.VitalityRank = i + 1
 			break
 		}
@@ -391,12 +391,13 @@ func SnapServiceOptions(st *state.State, instanceName string, quotaGroups map[st
 
 	// also check for quota group for this instance name
 	for _, grp := range quotaGroups {
-		if strutil.ListContains(grp.Snaps, instanceName) {
+		if strutil.ListContains(grp.Snaps, snapInfo.InstanceName()) {
 			opts.QuotaGroup = grp
 			break
 		}
 	}
 
+	opts.Services = snapInfo.Services()
 	return opts, nil
 }
 

--- a/overlord/servicestate/servicestate_test.go
+++ b/overlord/servicestate/servicestate_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/quota"
+	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/systemd"
 	"github.com/snapcore/snapd/testutil"
 	"github.com/snapcore/snapd/wrappers"
@@ -292,20 +293,27 @@ func (s *snapServiceOptionsSuite) TestSnapServiceOptionsVitalityRank(c *C) {
 	c.Assert(err, IsNil)
 	t.Commit()
 
-	opts, err := servicestate.SnapServiceOptions(st, "foo", nil)
+	fooInfo := snaptest.MockInfo(c, "name: foo\nversion: 0", nil)
+	barInfo := snaptest.MockInfo(c, "name: bar\nversion: 0", nil)
+	bazInfo := snaptest.MockInfo(c, "name: baz\nversion: 0", nil)
+
+	opts, err := servicestate.SnapServiceOptions(st, fooInfo, nil)
 	c.Assert(err, IsNil)
 	c.Check(opts, DeepEquals, &wrappers.SnapServiceOptions{
 		VitalityRank: 2,
+		Services:     []*snap.AppInfo{},
 	})
-	opts, err = servicestate.SnapServiceOptions(st, "bar", nil)
+	opts, err = servicestate.SnapServiceOptions(st, barInfo, nil)
 	c.Assert(err, IsNil)
 	c.Check(opts, DeepEquals, &wrappers.SnapServiceOptions{
 		VitalityRank: 1,
+		Services:     []*snap.AppInfo{},
 	})
-	opts, err = servicestate.SnapServiceOptions(st, "unknown", nil)
+	opts, err = servicestate.SnapServiceOptions(st, bazInfo, nil)
 	c.Assert(err, IsNil)
 	c.Check(opts, DeepEquals, &wrappers.SnapServiceOptions{
 		VitalityRank: 0,
+		Services:     []*snap.AppInfo{},
 	})
 }
 
@@ -313,6 +321,11 @@ func (s *snapServiceOptionsSuite) TestSnapServiceOptionsQuotaGroups(c *C) {
 	st := s.state
 	st.Lock()
 	defer st.Unlock()
+
+	fooInfo := snaptest.MockInfo(c, `
+name: foosnap
+version: 0
+`, nil)
 
 	// make a quota group
 	grp, err := quota.NewGroup("foogroup", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
@@ -327,10 +340,11 @@ func (s *snapServiceOptionsSuite) TestSnapServiceOptionsQuotaGroups(c *C) {
 		"foogroup": grp,
 	})
 
-	opts, err := servicestate.SnapServiceOptions(st, "foosnap", nil)
+	opts, err := servicestate.SnapServiceOptions(st, fooInfo, nil)
 	c.Assert(err, IsNil)
 	c.Check(opts, DeepEquals, &wrappers.SnapServiceOptions{
 		QuotaGroup: grp,
+		Services:   []*snap.AppInfo{},
 	})
 
 	// save the current state of the quota group before modifying it to prove
@@ -348,24 +362,29 @@ func (s *snapServiceOptionsSuite) TestSnapServiceOptionsQuotaGroups(c *C) {
 
 	// we can still get the quota group using the local map we got before
 	// modifying state
-	opts, err = servicestate.SnapServiceOptions(st, "foosnap", grps)
+	opts, err = servicestate.SnapServiceOptions(st, fooInfo, grps)
 	c.Assert(err, IsNil)
 	grp.Snaps = []string{"foosnap"}
 	c.Check(opts, DeepEquals, &wrappers.SnapServiceOptions{
 		QuotaGroup: grp,
+		Services:   []*snap.AppInfo{},
 	})
 
 	// but using state produces nothing for the non-instance name snap
-	opts, err = servicestate.SnapServiceOptions(st, "foosnap", nil)
+	opts, err = servicestate.SnapServiceOptions(st, fooInfo, nil)
 	c.Assert(err, IsNil)
-	c.Check(opts, DeepEquals, &wrappers.SnapServiceOptions{})
+	c.Check(opts, DeepEquals, &wrappers.SnapServiceOptions{
+		Services: []*snap.AppInfo{},
+	})
 
 	// but it does work with instance names
+	fooInfo.InstanceKey = "instance"
 	grp.Snaps = []string{"foosnap_instance"}
-	opts, err = servicestate.SnapServiceOptions(st, "foosnap_instance", nil)
+	opts, err = servicestate.SnapServiceOptions(st, fooInfo, nil)
 	c.Assert(err, IsNil)
 	c.Check(opts, DeepEquals, &wrappers.SnapServiceOptions{
 		QuotaGroup: grp,
+		Services:   []*snap.AppInfo{},
 	})
 
 	// works with vitality rank for the snap too
@@ -374,12 +393,45 @@ func (s *snapServiceOptionsSuite) TestSnapServiceOptionsQuotaGroups(c *C) {
 	c.Assert(err, IsNil)
 	t.Commit()
 
-	opts, err = servicestate.SnapServiceOptions(st, "foosnap_instance", nil)
+	opts, err = servicestate.SnapServiceOptions(st, fooInfo, nil)
 	c.Assert(err, IsNil)
 	c.Check(opts, DeepEquals, &wrappers.SnapServiceOptions{
 		VitalityRank: 2,
 		QuotaGroup:   grp,
+		Services:     []*snap.AppInfo{},
 	})
+}
+
+func (s *snapServiceOptionsSuite) TestSnapServiceOptionsServices(c *C) {
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	fooInfo := snaptest.MockInfo(c, `
+name: foo
+version: 0
+apps:
+ app1:
+  command: foo
+`, nil)
+
+	opts, err := servicestate.SnapServiceOptions(st, fooInfo, nil)
+	c.Assert(err, IsNil)
+	c.Check(len(opts.Services), Equals, 0)
+
+	barInfo := snaptest.MockInfo(c, `
+name: bar
+version: 0
+apps:
+ app1:
+  command: foo
+  daemon: simple
+`, nil)
+
+	opts, err = servicestate.SnapServiceOptions(st, barInfo, nil)
+	c.Assert(err, IsNil)
+	c.Assert(len(opts.Services), Equals, 1)
+	c.Check(opts.Services[0].Name, Equals, "app1")
 }
 
 func (s *snapServiceOptionsSuite) TestServiceControlTaskSummaries(c *C) {

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -62,7 +62,7 @@ import (
 )
 
 // SnapServiceOptions is a hook set by servicestate.
-var SnapServiceOptions = func(st *state.State, instanceName string, grps map[string]*quota.Group) (opts *wrappers.SnapServiceOptions, err error) {
+var SnapServiceOptions = func(st *state.State, snapInfo *snap.Info, grps map[string]*quota.Group) (opts *wrappers.SnapServiceOptions, err error) {
 	panic("internal error: snapstate.SnapServiceOptions is unset")
 }
 
@@ -1179,7 +1179,7 @@ func (m *SnapManager) undoUnlinkCurrentSnap(t *state.Task, _ *tomb.Tomb) error {
 
 	snapst.Active = true
 
-	opts, err := SnapServiceOptions(st, snapsup.InstanceName(), nil)
+	opts, err := SnapServiceOptions(st, oldInfo, nil)
 	if err != nil {
 		return err
 	}
@@ -1731,7 +1731,7 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (err error) {
 		return err
 	}
 
-	opts, err := SnapServiceOptions(st, snapsup.InstanceName(), nil)
+	opts, err := SnapServiceOptions(st, newInfo, nil)
 	if err != nil {
 		return err
 	}
@@ -2753,7 +2753,7 @@ func (m *SnapManager) undoUnlinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	snapst.Active = true
 	Set(st, snapsup.InstanceName(), snapst)
 
-	opts, err := SnapServiceOptions(st, snapsup.InstanceName(), nil)
+	opts, err := SnapServiceOptions(st, info, nil)
 	if err != nil {
 		return err
 	}

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -233,7 +233,10 @@ func (s *servicesTestSuite) TestEnsureSnapServicesWithQuotas(c *C) {
 	c.Assert(err, IsNil)
 
 	m := map[*snap.Info]*wrappers.SnapServiceOptions{
-		info: {QuotaGroup: grp},
+		info: {
+			QuotaGroup: grp,
+			Services:   info.Services(),
+		},
 	}
 
 	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
@@ -336,7 +339,10 @@ func (s *servicesTestSuite) TestEnsureSnapServicesWithZeroCpuCountQuotas(c *C) {
 	c.Assert(err, IsNil)
 
 	m := map[*snap.Info]*wrappers.SnapServiceOptions{
-		info: {QuotaGroup: grp},
+		info: {
+			QuotaGroup: grp,
+			Services:   info.Services(),
+		},
 	}
 
 	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
@@ -435,7 +441,10 @@ func (s *servicesTestSuite) TestEnsureSnapServicesWithZeroCpuCountAndCpuSetQuota
 	c.Assert(err, IsNil)
 
 	m := map[*snap.Info]*wrappers.SnapServiceOptions{
-		info: {QuotaGroup: grp},
+		info: {
+			QuotaGroup: grp,
+			Services:   info.Services(),
+		},
 	}
 
 	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
@@ -527,7 +536,10 @@ func (s *servicesTestSuite) TestEnsureSnapServicesWithJournalNamespaceOnly(c *C)
 	c.Assert(err, IsNil)
 
 	m := map[*snap.Info]*wrappers.SnapServiceOptions{
-		info: {QuotaGroup: grp},
+		info: {
+			QuotaGroup: grp,
+			Services:   info.Services(),
+		},
 	}
 
 	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
@@ -642,7 +654,10 @@ func (s *servicesTestSuite) TestEnsureSnapServicesWithJournalQuotas(c *C) {
 	c.Assert(err, IsNil)
 
 	m := map[*snap.Info]*wrappers.SnapServiceOptions{
-		info: {QuotaGroup: grp},
+		info: {
+			QuotaGroup: grp,
+			Services:   info.Services(),
+		},
 	}
 
 	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
@@ -760,7 +775,10 @@ func (s *servicesTestSuite) TestEnsureSnapServicesWithJournalQuotaRateAsZero(c *
 	c.Assert(err, IsNil)
 
 	m := map[*snap.Info]*wrappers.SnapServiceOptions{
-		info: {QuotaGroup: grp},
+		info: {
+			QuotaGroup: grp,
+			Services:   info.Services(),
+		},
 	}
 
 	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
@@ -891,7 +909,10 @@ func (s *servicesTestSuite) TestEnsureSnapServicesWithSnapServices(c *C) {
 	sub.Services = []string{"hello-snap.svc1"}
 
 	m := map[*snap.Info]*wrappers.SnapServiceOptions{
-		info: {QuotaGroup: grp},
+		info: {
+			QuotaGroup: grp,
+			Services:   info.Services(),
+		},
 	}
 
 	dir := filepath.Join(dirs.SnapMountDir, "hello-snap", "12.mount")
@@ -1150,7 +1171,10 @@ WantedBy=multi-user.target
 	c.Assert(err, IsNil)
 
 	m := map[*snap.Info]*wrappers.SnapServiceOptions{
-		info: {QuotaGroup: grp},
+		info: {
+			QuotaGroup: grp,
+			Services:   info.Services(),
+		},
 	}
 
 	newContent := fmt.Sprintf(sliceTempl, "foogroup", memLimit2.String())
@@ -1250,7 +1274,10 @@ WantedBy=multi-user.target
 	c.Assert(err, IsNil)
 
 	m := map[*snap.Info]*wrappers.SnapServiceOptions{
-		info: {QuotaGroup: grp},
+		info: {
+			QuotaGroup: grp,
+			Services:   info.Services(),
+		},
 	}
 
 	observe := func(app *snap.AppInfo, grp *quota.Group, unitType, name, old, new string) {
@@ -1359,8 +1386,14 @@ apps:
 	subSliceFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.foogroup-subgroup.slice")
 
 	m := map[*snap.Info]*wrappers.SnapServiceOptions{
-		info1: {QuotaGroup: grp},
-		info2: {QuotaGroup: subgrp},
+		info1: {
+			QuotaGroup: grp,
+			Services:   info1.Services(),
+		},
+		info2: {
+			QuotaGroup: subgrp,
+			Services:   info2.Services(),
+		},
 	}
 
 	sliceTempl := `[Unit]
@@ -1499,7 +1532,10 @@ func (s *servicesTestSuite) TestEnsureSnapServicesWithSubGroupQuotaGroupsGenerat
 	subSliceFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.foogroup-subgroup.slice")
 
 	m := map[*snap.Info]*wrappers.SnapServiceOptions{
-		info: {QuotaGroup: subgrp},
+		info: {
+			QuotaGroup: subgrp,
+			Services:   info.Services(),
+		},
 	}
 
 	err = wrappers.EnsureSnapServices(m, nil, nil, progress.Null)
@@ -1681,7 +1717,10 @@ apps:
 
 	// some options per-snap
 	m := map[*snap.Info]*wrappers.SnapServiceOptions{
-		info1: {VitalityRank: 1},
+		info1: {
+			VitalityRank: 1,
+			Services:     info1.Services(),
+		},
 		info2: nil,
 	}
 
@@ -1791,7 +1830,10 @@ WantedBy=multi-user.target
 
 	// both will be written, one is new
 	m := map[*snap.Info]*wrappers.SnapServiceOptions{
-		info: {VitalityRank: 1},
+		info: {
+			VitalityRank: 1,
+			Services:     info.Services(),
+		},
 	}
 
 	seen := make(map[string][]string)
@@ -2023,7 +2065,10 @@ WantedBy=multi-user.target
 
 	// now ensuring with the VitalityRank set will modify the file
 	m := map[*snap.Info]*wrappers.SnapServiceOptions{
-		info: {VitalityRank: 1},
+		info: {
+			VitalityRank: 1,
+			Services:     info.Services(),
+		},
 	}
 
 	err = wrappers.EnsureSnapServices(m, nil, cb, progress.Null)
@@ -2116,7 +2161,10 @@ WantedBy=multi-user.target
 
 	// now ensuring with the VitalityRank set will modify the file
 	m := map[*snap.Info]*wrappers.SnapServiceOptions{
-		info: {VitalityRank: 1},
+		info: {
+			VitalityRank: 1,
+			Services:     info.Services(),
+		},
 	}
 
 	err = wrappers.EnsureSnapServices(m, nil, nil, progress.Null)
@@ -2331,7 +2379,10 @@ func (s *servicesTestSuite) TestEnsureSnapServicesSubunits(c *C) {
 `, &snap.SideInfo{Revision: snap.R(12)})
 
 	m = map[*snap.Info]*wrappers.SnapServiceOptions{
-		info: {VitalityRank: 1},
+		info: {
+			VitalityRank: 1,
+			Services:     info.Services(),
+		},
 	}
 	err = wrappers.EnsureSnapServices(m, nil, cb, progress.Null)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
This PR improves how we deal with detecting services that have changed. Before we did this on a snap-level, which made sense since all changes done to quota-groups affected entire snaps, but now that we can split services into quota groups, we can instead deal with changes on a service-level.

This PR relies on https://github.com/snapcore/snapd/pull/12316 landing first, so it remains in draft