### PR TITLE
client,cmd/snap: add frontend support for per-service quotas (3/3)

### DIFF
--- a/client/quota.go
+++ b/client/quota.go
@@ -33,6 +33,7 @@ type postQuotaData struct {
 	GroupName   string       `json:"group-name"`
 	Parent      string       `json:"parent,omitempty"`
 	Snaps       []string     `json:"snaps,omitempty"`
+	Services    []string     `json:"services,omitempty"`
 	Constraints *QuotaValues `json:"constraints,omitempty"`
 }
 
@@ -41,6 +42,7 @@ type QuotaGroupResult struct {
 	Parent      string       `json:"parent,omitempty"`
 	Subgroups   []string     `json:"subgroups,omitempty"`
 	Snaps       []string     `json:"snaps,omitempty"`
+	Services    []string     `json:"services,omitempty"`
 	Constraints *QuotaValues `json:"constraints,omitempty"`
 	Current     *QuotaValues `json:"current,omitempty"`
 }
@@ -74,7 +76,7 @@ type QuotaValues struct {
 
 // EnsureQuota creates a quota group or updates an existing group.
 // The list of snaps can be empty.
-func (client *Client) EnsureQuota(groupName string, parent string, snaps []string, constraints *QuotaValues) (changeID string, err error) {
+func (client *Client) EnsureQuota(groupName string, parent string, snaps, services []string, constraints *QuotaValues) (changeID string, err error) {
 	if groupName == "" {
 		return "", fmt.Errorf("cannot create or update quota group without a name")
 	}
@@ -85,6 +87,7 @@ func (client *Client) EnsureQuota(groupName string, parent string, snaps []strin
 		GroupName:   groupName,
 		Parent:      parent,
 		Snaps:       snaps,
+		Services:    services,
 		Constraints: constraints,
 	}
 

--- a/client/quota_test.go
+++ b/client/quota_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 func (cs *clientSuite) TestCreateQuotaGroupInvalidName(c *check.C) {
-	_, err := cs.cli.EnsureQuota("", "", nil, nil)
+	_, err := cs.cli.EnsureQuota("", "", nil, nil, nil)
 	c.Check(err, check.ErrorMatches, `cannot create or update quota group without a name`)
 }
 
@@ -64,7 +64,7 @@ func (cs *clientSuite) TestEnsureQuotaGroup(c *check.C) {
 		},
 	}
 
-	chgID, err := cs.cli.EnsureQuota("foo", "bar", []string{"snap-a", "snap-b"}, quotaValues)
+	chgID, err := cs.cli.EnsureQuota("foo", "bar", []string{"snap-a", "snap-b"}, []string{"snap-a.svc1", "snap-b.svc1"}, quotaValues)
 	c.Assert(err, check.IsNil)
 	c.Assert(chgID, check.Equals, "42")
 	c.Check(cs.req.Method, check.Equals, "POST")
@@ -79,6 +79,7 @@ func (cs *clientSuite) TestEnsureQuotaGroup(c *check.C) {
 		"group-name": "foo",
 		"parent":     "bar",
 		"snaps":      []interface{}{"snap-a", "snap-b"},
+		"services":   []interface{}{"snap-a.svc1", "snap-b.svc1"},
 		"constraints": map[string]interface{}{
 			"memory": json.Number("1001"),
 			"cpu": map[string]interface{}{
@@ -101,7 +102,7 @@ func (cs *clientSuite) TestEnsureQuotaGroup(c *check.C) {
 func (cs *clientSuite) TestEnsureQuotaGroupError(c *check.C) {
 	cs.status = 500
 	cs.rsp = `{"type": "error"}`
-	_, err := cs.cli.EnsureQuota("foo", "bar", []string{"snap-a"}, &client.QuotaValues{Memory: quantity.Size(1)})
+	_, err := cs.cli.EnsureQuota("foo", "bar", []string{"snap-a"}, nil, &client.QuotaValues{Memory: quantity.Size(1)})
 	c.Check(err, check.ErrorMatches, `server error: "Internal Server Error"`)
 }
 
@@ -119,6 +120,7 @@ func (cs *clientSuite) TestGetQuotaGroup(c *check.C) {
 			"parent":"bar",
 			"subgroups":["foo-subgrp"],
 			"snaps":["snap-a"],
+			"services":["snap-a.svc1"],
 			"constraints": { "memory": 999 },
 			"current": { "memory": 450 }
 		}
@@ -135,6 +137,7 @@ func (cs *clientSuite) TestGetQuotaGroup(c *check.C) {
 		Constraints: &client.QuotaValues{Memory: quantity.Size(999)},
 		Current:     &client.QuotaValues{Memory: quantity.Size(450)},
 		Snaps:       []string{"snap-a"},
+		Services:    []string{"snap-a.svc1"},
 	})
 }
 

--- a/cmd/snap/cmd_quota.go
+++ b/cmd/snap/cmd_quota.go
@@ -75,7 +75,9 @@ To set limits on individual services, one or more services can be placed into a
 sub-group. The respective snap for each service must belong to the sub-group's
 parent group. These sub-groups will have the same limitations as nested groups
 which means their combined resource usage cannot exceed the resource limits set 
-for the parent group.
+for the parent group. Sub-groups which contain services cannot have their own
+journal quotas set, and instead automatically inherit any journal quota their
+parent quota group may have.
 
 The memory limit for a quota group can be increased but not decreased. To
 decrease the memory limit for a quota group, the entire group must be removed

--- a/cmd/snap/cmd_quota.go
+++ b/cmd/snap/cmd_quota.go
@@ -71,11 +71,11 @@ quota group, the entire group must be removed with remove-quota and recreated
 without the snap. To remove a sub-group from the quota group, the 
 sub-group must be removed directly with the remove-quota command.
 
-A single or multiple services can also be isolated from a snap and put into
-their own sub-groups, as long as the snap they originate from is in the parent
-group. Theses sub-groups fall under same limitations as nested groups, which means
-their resource usage cannot exceed any resources allocated for the parent groups.
-This allows for specific resource restraints on individual services.
+To set limits on individual services, one or more services can be placed into a
+sub-group. The respective snap for each service must belong to the sub-group's
+parent group. These sub-groups will have the same limitations as nested groups
+which means their combined resource usage cannot exceed the resource limits set 
+for the parent group.
 
 The memory limit for a quota group can be increased but not decreased. To
 decrease the memory limit for a quota group, the entire group must be removed

--- a/cmd/snap/cmd_quota_test.go
+++ b/cmd/snap/cmd_quota_test.go
@@ -324,6 +324,7 @@ func (s *quotaSuite) TestGetQuotaGroup(c *check.C) {
 			"parent":"bar",
 			"subgroups":["subgrp1"],
 			"snaps":["snap-a","snap-b"],
+			"services":["snap-a.svc1", "snap-b.svc2"],
 			"constraints": { "memory": 1000 },
 			"current": { "memory": 900 }
 		}
@@ -347,6 +348,9 @@ subgroups:
 snaps:
   - snap-a
   - snap-b
+services:
+  - snap-a.svc1
+  - snap-b.svc2
 `[1:])
 	c.Check(s.quotaGetGroupHandlerCalls, check.Equals, 1)
 	c.Check(s.quotaPostHandlerCalls, check.Equals, 0)

--- a/cmd/snap/cmd_quota_test.go
+++ b/cmd/snap/cmd_quota_test.go
@@ -290,12 +290,12 @@ func (s *quotaSuite) TestSetQuotaCpuHappy(c *check.C) {
 		cpuPercentage: 50,
 	}
 	// this data is not tested against, but it should still be valid
-	const getJsonTemplate = `{
+	const getJson = `{
 		"type": "sync",
 		"status-code": 200,
 		"result": {
 			"group-name":"foo",
-			"constraints": { "cpu":{"count":%d, "percentage":%d} },
+			"constraints": { "cpu":{"count":2, "percentage":50} },
 		}
 	}`
 	routes := map[string]http.HandlerFunc{
@@ -303,7 +303,7 @@ func (s *quotaSuite) TestSetQuotaCpuHappy(c *check.C) {
 			c,
 			fakeHandlerOpts,
 		),
-		"/v2/quotas/foo": s.makeFakeGetQuotaGroupHandler(c, fmt.Sprintf(getJsonTemplate, 2, 50)),
+		"/v2/quotas/foo": s.makeFakeGetQuotaGroupHandler(c, getJson),
 		"/v2/changes/42": makeChangesHandler(c),
 	}
 	s.RedirectClientToTestServer(dispatchFakeHandlers(c, routes))
@@ -327,12 +327,12 @@ func (s *quotaSuite) TestSetQuotaSnapServices(c *check.C) {
 		cpuPercentage: 50,
 	}
 	// this data is not tested against, but it should still be valid
-	const getJsonTemplate = `{
+	const getJson = `{
 		"type": "sync",
 		"status-code": 200,
 		"result": {
 			"group-name":"foo",
-			"constraints": { "cpu":{"count":%d, "percentage":%d} },
+			"constraints": { "cpu":{"count":2, "percentage":50} },
 		}
 	}`
 	routes := map[string]http.HandlerFunc{
@@ -340,7 +340,7 @@ func (s *quotaSuite) TestSetQuotaSnapServices(c *check.C) {
 			c,
 			fakeHandlerOpts,
 		),
-		"/v2/quotas/foo": s.makeFakeGetQuotaGroupHandler(c, fmt.Sprintf(getJsonTemplate, 2, 50)),
+		"/v2/quotas/foo": s.makeFakeGetQuotaGroupHandler(c, getJson),
 		"/v2/changes/42": makeChangesHandler(c),
 	}
 	s.RedirectClientToTestServer(dispatchFakeHandlers(c, routes))

--- a/cmd/snap/complete.go
+++ b/cmd/snap/complete.go
@@ -439,9 +439,9 @@ func (s appName) Complete(match string) []flags.Completion {
 
 type serviceName string
 
-func serviceNames(snaps []serviceName) []string {
-	names := make([]string, len(snaps))
-	for i, name := range snaps {
+func serviceNames(services []serviceName) []string {
+	names := make([]string, len(services))
+	for i, name := range services {
 		names[i] = string(name)
 	}
 

--- a/cmd/snap/complete.go
+++ b/cmd/snap/complete.go
@@ -439,6 +439,15 @@ func (s appName) Complete(match string) []flags.Completion {
 
 type serviceName string
 
+func serviceNames(snaps []serviceName) []string {
+	names := make([]string, len(snaps))
+	for i, name := range snaps {
+		names[i] = string(name)
+	}
+
+	return names
+}
+
 func (s serviceName) Complete(match string) []flags.Completion {
 	cli := mkClient()
 	apps, err := cli.Apps(nil, client.AppOptions{Service: true})

--- a/daemon/api_quotas.go
+++ b/daemon/api_quotas.go
@@ -146,6 +146,7 @@ func getQuotaGroups(c *Command, r *http.Request, _ *auth.UserState) Response {
 			Parent:      group.ParentGroup,
 			Subgroups:   group.SubGroups,
 			Snaps:       group.Snaps,
+			Services:    group.Services,
 			Constraints: createQuotaValues(group),
 			Current:     currentUsage,
 		}

--- a/daemon/api_quotas.go
+++ b/daemon/api_quotas.go
@@ -182,6 +182,7 @@ func getQuotaGroupInfo(c *Command, r *http.Request, _ *auth.UserState) Response 
 		GroupName:   group.Name,
 		Parent:      group.ParentGroup,
 		Snaps:       group.Snaps,
+		Services:    group.Services,
 		Subgroups:   group.SubGroups,
 		Constraints: createQuotaValues(group),
 		Current:     currentUsage,

--- a/daemon/api_quotas_test.go
+++ b/daemon/api_quotas_test.go
@@ -74,9 +74,9 @@ func (s *apiQuotaSuite) SetUpTest(c *check.C) {
 }
 
 func mockQuotas(st *state.State, c *check.C) {
-	err := servicestatetest.MockQuotaInState(st, "foo", "", nil, nil, quota.NewResourcesBuilder().WithMemoryLimit(16*quantity.SizeMiB).Build())
+	err := servicestatetest.MockQuotaInState(st, "foo", "", []string{"test-snap"}, nil, quota.NewResourcesBuilder().WithMemoryLimit(16*quantity.SizeMiB).Build())
 	c.Assert(err, check.IsNil)
-	err = servicestatetest.MockQuotaInState(st, "bar", "foo", nil, nil, quota.NewResourcesBuilder().WithMemoryLimit(4*quantity.SizeMiB).Build())
+	err = servicestatetest.MockQuotaInState(st, "bar", "foo", nil, []string{"test-snap.svc1"}, quota.NewResourcesBuilder().WithMemoryLimit(4*quantity.SizeMiB).Build())
 	c.Assert(err, check.IsNil)
 	err = servicestatetest.MockQuotaInState(st, "baz", "foo", nil, nil, quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build())
 	c.Assert(err, check.IsNil)
@@ -731,6 +731,7 @@ func (s *apiQuotaSuite) TestListQuotas(c *check.C) {
 		{
 			GroupName:   "bar",
 			Parent:      "foo",
+			Services:    []string{"test-snap.svc1"},
 			Constraints: &client.QuotaValues{Memory: 4 * quantity.SizeMiB},
 			Current:     &client.QuotaValues{Memory: quantity.Size(500)},
 		},
@@ -743,6 +744,7 @@ func (s *apiQuotaSuite) TestListQuotas(c *check.C) {
 		{
 			GroupName:   "foo",
 			Subgroups:   []string{"bar", "baz"},
+			Snaps:       []string{"test-snap"},
 			Constraints: &client.QuotaValues{Memory: 16 * quantity.SizeMiB},
 			Current:     &client.QuotaValues{Memory: quantity.Size(5000)},
 		},
@@ -840,6 +842,7 @@ func (s *apiQuotaSuite) TestGetQuota(c *check.C) {
 	c.Check(res, check.DeepEquals, client.QuotaGroupResult{
 		GroupName:   "bar",
 		Parent:      "foo",
+		Services:    []string{"test-snap.svc1"},
 		Constraints: &client.QuotaValues{Memory: quantity.Size(4194304)},
 		Current:     &client.QuotaValues{Memory: quantity.Size(500)},
 	})

--- a/tests/main/snap-quota-services/task.yaml
+++ b/tests/main/snap-quota-services/task.yaml
@@ -48,8 +48,6 @@ execute: |
   MATCH "     7\s+services:$" < details.txt
   MATCH "     8\s+-\s+test-snapd-stressd.stress-sc$" < details.txt
 
-  ls /nono
-  
   #echo "Test that it fails when we apply a journal quota to the sub-group"
   # https://github.com/snapcore/snapd/pull/12401
   #snap set-quota test-sub --journal-size=128MB 2>&1 | tr '\n' ' ' | tr -s ' ' | MATCH 'error: cannot create quota group: cannot add snap "hello-world" to group "group-bad": snap already in quota group "group-one"'
@@ -65,11 +63,11 @@ execute: |
   SUB_SLICENAME="snap.$(systemd-escape --path test-top/test-sub).slice"
 
   echo "Verify that one of the non stress-sc services mention the top group"
-  systemctl show --property=Slice snap.test-snapd-stressd.logger.service | grep -F "Slice=$TOP_SLICENAME"
+  systemctl show --property=Slice snap.test-snapd-stressd.logger.service | grep "Slice=$TOP_SLICENAME"
 
   #echo "Verify that stress-sc service mention the sub group"
   # https://github.com/snapcore/snapd/pull/12395
-  #systemctl show --property=Slice snap.test-snapd-stressd.stress-sc.service | grep -F "Slice=$SUB_SLICENAME"
+  #systemctl show --property=Slice snap.test-snapd-stressd.stress-sc.service | grep "Slice=$SUB_SLICENAME"
 
   # echo "Verify that stress-sc service mention the journal namespace"
   # systemctl show --property=LogNamespace snap.test-snapd-stressd.stress-sc.service | MATCH "LogNamespace=snap-test-sub"

--- a/tests/main/snap-quota-services/task.yaml
+++ b/tests/main/snap-quota-services/task.yaml
@@ -27,9 +27,11 @@ execute: |
   # contains 4 services, which makes it perfect for our testing as we only need
   # this one snap to test isolating services.
   snap set-quota test-top --memory=400MB test-snapd-stressd
+  tests.cleanup defer snap remove-quota test-top
 
   echo "Create a sub-level group for the stress service and put it into that"
   snap set-quota test-sub --parent=test-top --cpu=10% test-snapd-stressd.stress-sc
+  tests.cleanup defer snap remove-quota test-sub
 
   echo "Test the quota groups listings look sane"
   snap quotas | cat -n > quotas.txt
@@ -67,8 +69,6 @@ execute: |
   echo "Verify that stress-sc service mention the sub group"
   systemctl show --property=Slice snap.test-snapd-stressd.stress-sc.service | grep -F "Slice=$SUB_SLICENAME"
 
+  # Enable check when: https://github.com/snapcore/snapd/pull/12449 lands
   # echo "Verify that stress-sc service mention the journal namespace"
   # systemctl show --property=LogNamespace snap.test-snapd-stressd.stress-sc.service | MATCH "LogNamespace=snap-test-sub"
-
-  snap remove-quota test-sub
-  snap remove-quota test-top

--- a/tests/main/snap-quota-services/task.yaml
+++ b/tests/main/snap-quota-services/task.yaml
@@ -1,7 +1,4 @@
-summary: Basic test for quota-related snap commands.
-
-details: |
-  Basic test for snap quota, remove-quota and quotas commands.
+summary: Test for per-service quota-related snap functionality.
 
 # In arm devices using ubuntu core, memory quota cannot be used because
 # memory cgroup is disabled

--- a/tests/main/snap-quota-services/task.yaml
+++ b/tests/main/snap-quota-services/task.yaml
@@ -48,9 +48,8 @@ execute: |
   MATCH "     7\s+services:$" < details.txt
   MATCH "     8\s+-\s+test-snapd-stressd.stress-sc$" < details.txt
 
-  #echo "Test that it fails when we apply a journal quota to the sub-group"
-  # https://github.com/snapcore/snapd/pull/12401
-  #snap set-quota test-sub --journal-size=128MB 2>&1 | tr '\n' ' ' | tr -s ' ' | MATCH 'error: cannot create quota group: cannot add snap "hello-world" to group "group-bad": snap already in quota group "group-one"'
+  echo "Test that it fails when we apply a journal quota to the sub-group"
+  snap set-quota test-sub --journal-size=128MB 2>&1 | tr '\n' ' ' | tr -s ' ' | MATCH 'error: cannot update quota group: cannot update group "test-sub": journal quotas are not supported for individual services'
 
   echo "Test that we can however put a journal quota on the parent group"
   snap set-quota test-top --journal-size=128MB
@@ -60,7 +59,7 @@ execute: |
   # we will expect the unit to mention the top group slice, but for test-snapd-stressd.stress-sc
   # we will expect the unit to mention the sub group slice.
   TOP_SLICENAME="snap.$(systemd-escape --path test-top).slice"
-  SUB_SLICENAME="snap.$(systemd-escape --path test-top/test-sub).slice"
+  #SUB_SLICENAME="snap.$(systemd-escape --path test-top/test-sub).slice"
 
   echo "Verify that one of the non stress-sc services mention the top group"
   systemctl show --property=Slice snap.test-snapd-stressd.logger.service | grep "Slice=$TOP_SLICENAME"

--- a/tests/main/snap-quota-services/task.yaml
+++ b/tests/main/snap-quota-services/task.yaml
@@ -54,8 +54,6 @@ execute: |
   echo "Test that we can however put a journal quota on the parent group"
   snap set-quota test-top --journal-size=128MB
 
-  ls /nono
-
   # Next up is checking for slices and unit contents
   # For test-snapd-stressd.logger (which is another service in test-snapd-stressd)
   # we will expect the unit to mention the top group slice, but for test-snapd-stressd.stress-sc

--- a/tests/main/snap-quota-services/task.yaml
+++ b/tests/main/snap-quota-services/task.yaml
@@ -66,6 +66,5 @@ execute: |
   echo "Verify that stress-sc service mention the sub group"
   systemctl show --property=Slice snap.test-snapd-stressd.stress-sc.service | grep -F "Slice=$SUB_SLICENAME"
 
-  # Enable check when: https://github.com/snapcore/snapd/pull/12449 lands
-  # echo "Verify that stress-sc service mention the journal namespace"
-  # systemctl show --property=LogNamespace snap.test-snapd-stressd.stress-sc.service | MATCH "LogNamespace=snap-test-sub"
+  echo "Verify that stress-sc service mention the journal namespace"
+  systemctl show --property=LogNamespace snap.test-snapd-stressd.stress-sc.service | MATCH "LogNamespace=snap-test-top"

--- a/tests/main/snap-quota-services/task.yaml
+++ b/tests/main/snap-quota-services/task.yaml
@@ -34,7 +34,7 @@ execute: |
   echo "Test the quota groups listings look sane"
   snap quotas | cat -n > quotas.txt
   MATCH "     1\s+Quota\s+Parent\s+Constraints\s+Current$" < quotas.txt
-  MATCH "     2\s+test-top\s+memory=400MB\s+$" < quotas.txt
+  MATCH "     2\s+test-top\s+memory=400MB(\s*|\s*memory=[0-9.a-zA-Z]+)+$" < quotas.txt
   MATCH "     3\s+test-sub\s+test-top\s+cpu=10%\s+$" < quotas.txt
 
   echo "Test that service details are listed correctly in test-sub"
@@ -54,19 +54,20 @@ execute: |
   echo "Test that we can however put a journal quota on the parent group"
   snap set-quota test-top --journal-size=128MB
 
+  ls /nono
+
   # Next up is checking for slices and unit contents
   # For test-snapd-stressd.logger (which is another service in test-snapd-stressd)
   # we will expect the unit to mention the top group slice, but for test-snapd-stressd.stress-sc
   # we will expect the unit to mention the sub group slice.
   TOP_SLICENAME="snap.$(systemd-escape --path test-top).slice"
-  #SUB_SLICENAME="snap.$(systemd-escape --path test-top/test-sub).slice"
+  SUB_SLICENAME="snap.$(systemd-escape --path test-top/test-sub).slice"
 
   echo "Verify that one of the non stress-sc services mention the top group"
-  systemctl show --property=Slice snap.test-snapd-stressd.logger.service | grep "Slice=$TOP_SLICENAME"
+  systemctl show --property=Slice snap.test-snapd-stressd.logger.service | grep -F "Slice=$TOP_SLICENAME"
 
-  #echo "Verify that stress-sc service mention the sub group"
-  # https://github.com/snapcore/snapd/pull/12395
-  #systemctl show --property=Slice snap.test-snapd-stressd.stress-sc.service | grep "Slice=$SUB_SLICENAME"
+  echo "Verify that stress-sc service mention the sub group"
+  systemctl show --property=Slice snap.test-snapd-stressd.stress-sc.service | grep -F "Slice=$SUB_SLICENAME"
 
   # echo "Verify that stress-sc service mention the journal namespace"
   # systemctl show --property=LogNamespace snap.test-snapd-stressd.stress-sc.service | MATCH "LogNamespace=snap-test-sub"

--- a/tests/main/snap-quota-services/task.yaml
+++ b/tests/main/snap-quota-services/task.yaml
@@ -1,8 +1,17 @@
 summary: Test for per-service quota-related snap functionality.
 
-# In arm devices using ubuntu core, memory quota cannot be used because
-# memory cgroup is disabled
-systems: [ -ubuntu-core-*-arm-* ]
+# these systems do not support journal quota groups due to their old systemd versions.
+# requires systemd v245+
+systems:
+  - -amazon-linux-2-*
+  - -centos-7-*
+  - -centos-8-*
+  - -debian-10-64
+  - -ubuntu-14.04-*
+  - -ubuntu-16.04-*
+  - -ubuntu-18.04-*
+  - -ubuntu-core-16-*
+  - -ubuntu-core-18-*
 
 prepare: |
   snap install test-snapd-stressd --edge --devmode
@@ -11,15 +20,6 @@ prepare: |
   tests.cleanup defer snap unset system experimental.quota-groups
 
 execute: |
-  if os.query is-trusty || os.query is-amazon-linux || os.query is-centos 7 || os.query is-xenial || os.query is-core16; then
-    # just check that we can't do anything with quota groups on systems with
-    # old systemd versions, we need at least 230 to avoid buggy slice usage
-    # reporting
-
-    snap set-quota foobar --memory=1MB 2>&1 | tr '\n' ' ' | tr -s ' ' | MATCH "systemd version 2[0-2][0-9] is too old \(expected at least 230\)"
-    exit 0
-  fi
-
   # Create the top level snap group with a memory limit. test-snapd-stressd
   # contains 4 services, which makes it perfect for our testing as we only need
   # this one snap to test isolating services.

--- a/tests/main/snap-quota-services/task.yaml
+++ b/tests/main/snap-quota-services/task.yaml
@@ -1,0 +1,78 @@
+summary: Basic test for quota-related snap commands.
+
+details: |
+  Basic test for snap quota, remove-quota and quotas commands.
+
+# In arm devices using ubuntu core, memory quota cannot be used because
+# memory cgroup is disabled
+systems: [ -ubuntu-core-*-arm-* ]
+
+prepare: |
+  snap install test-snapd-stressd --edge --devmode
+  tests.cleanup defer snap remove --purge test-snapd-stressd
+  snap set system experimental.quota-groups=true
+  tests.cleanup defer snap unset system experimental.quota-groups
+
+execute: |
+  if os.query is-trusty || os.query is-amazon-linux || os.query is-centos 7 || os.query is-xenial || os.query is-core16; then
+    # just check that we can't do anything with quota groups on systems with
+    # old systemd versions, we need at least 230 to avoid buggy slice usage
+    # reporting
+
+    snap set-quota foobar --memory=1MB 2>&1 | tr '\n' ' ' | tr -s ' ' | MATCH "systemd version 2[0-2][0-9] is too old \(expected at least 230\)"
+    exit 0
+  fi
+
+  # Create the top level snap group with a memory limit. test-snapd-stressd
+  # contains 4 services, which makes it perfect for our testing as we only need
+  # this one snap to test isolating services.
+  snap set-quota test-top --memory=400MB test-snapd-stressd
+
+  echo "Create a sub-level group for the stress service and put it into that"
+  snap set-quota test-sub --parent=test-top --cpu=10% test-snapd-stressd.stress-sc
+
+  echo "Test the quota groups listings look sane"
+  snap quotas | cat -n > quotas.txt
+  MATCH "     1\s+Quota\s+Parent\s+Constraints\s+Current$" < quotas.txt
+  MATCH "     2\s+test-top\s+memory=400MB\s+$" < quotas.txt
+  MATCH "     3\s+test-sub\s+test-top\s+cpu=10%\s+$" < quotas.txt
+
+  echo "Test that service details are listed correctly in test-sub"
+  snap quota test-sub | cat -n > details.txt
+  MATCH "     1\s+name:\s+test-sub$" < details.txt
+  MATCH "     2\s+parent:\s+test-top$" < details.txt
+  MATCH "     3\s+constraints:$" < details.txt
+  MATCH "     4\s+cpu-count:\s+0$" < details.txt
+  MATCH "     5\s+cpu-percentage:\s+10$" < details.txt
+  MATCH "     6\s+current:$" < details.txt
+  MATCH "     7\s+services:$" < details.txt
+  MATCH "     8\s+-\s+test-snapd-stressd.stress-sc$" < details.txt
+
+  ls /nono
+  
+  #echo "Test that it fails when we apply a journal quota to the sub-group"
+  # https://github.com/snapcore/snapd/pull/12401
+  #snap set-quota test-sub --journal-size=128MB 2>&1 | tr '\n' ' ' | tr -s ' ' | MATCH 'error: cannot create quota group: cannot add snap "hello-world" to group "group-bad": snap already in quota group "group-one"'
+
+  echo "Test that we can however put a journal quota on the parent group"
+  snap set-quota test-top --journal-size=128MB
+
+  # Next up is checking for slices and unit contents
+  # For test-snapd-stressd.logger (which is another service in test-snapd-stressd)
+  # we will expect the unit to mention the top group slice, but for test-snapd-stressd.stress-sc
+  # we will expect the unit to mention the sub group slice.
+  TOP_SLICENAME="snap.$(systemd-escape --path test-top).slice"
+  SUB_SLICENAME="snap.$(systemd-escape --path test-top/test-sub).slice"
+
+  echo "Verify that one of the non stress-sc services mention the top group"
+  systemctl show --property=Slice snap.test-snapd-stressd.logger.service | grep -F "Slice=$TOP_SLICENAME"
+
+  #echo "Verify that stress-sc service mention the sub group"
+  # https://github.com/snapcore/snapd/pull/12395
+  #systemctl show --property=Slice snap.test-snapd-stressd.stress-sc.service | grep -F "Slice=$SUB_SLICENAME"
+
+  # echo "Verify that stress-sc service mention the journal namespace"
+  # systemctl show --property=LogNamespace snap.test-snapd-stressd.stress-sc.service | MATCH "LogNamespace=snap-test-sub"
+
+  snap remove-quota test-sub
+  snap remove-quota test-top


### PR DESCRIPTION
This is the last PR in the series, and contains the neccessary front-end changes for per-service quota to work. This also includes the spread tests.

This PR needs https://github.com/snapcore/snapd/pull/12316 and https://github.com/snapcore/snapd/pull/12395 to land first.