### PR TITLE
restart,snapstate: implement reboot-required notifications on classic

### DIFF
--- a/overlord/devicestate/devicestate_bootconfig_test.go
+++ b/overlord/devicestate/devicestate_bootconfig_test.go
@@ -132,6 +132,10 @@ func (s *deviceMgrBootconfigSuite) testBootConfigUpdateRun(c *C, updateAttempted
 
 	s.state.Lock()
 	tsk := s.state.NewTask("update-managed-boot-config", "update boot config")
+	tsk.Set("snap-setup", &snapstate.SnapSetup{
+		SideInfo: &s.gadgetSnapInfo.SideInfo,
+		Type:     snap.TypeGadget,
+	})
 	chg := s.state.NewChange("sample", "...")
 	chg.AddTask(tsk)
 	chg.Set("system-restart-immediate", true)
@@ -174,6 +178,10 @@ func (s *deviceMgrBootconfigSuite) testBootConfigUpdateRunClassic(c *C, updateAt
 
 	s.state.Lock()
 	tsk := s.state.NewTask("update-managed-boot-config", "update boot config")
+	tsk.Set("snap-setup", &snapstate.SnapSetup{
+		SideInfo: &s.gadgetSnapInfo.SideInfo,
+		Type:     snap.TypeGadget,
+	})
 	chg := s.state.NewChange("sample", "...")
 	chg.AddTask(tsk)
 	chg.Set("system-restart-immediate", true)

--- a/overlord/restart/restart.go
+++ b/overlord/restart/restart.go
@@ -261,9 +261,6 @@ func setWaitForSystemRestart(chg *state.Change) {
 // notifyRebootRequiredClassic will write the
 // /run/reboot-required{,.pkgs} marker file
 func notifyRebootRequiredClassic(rebootRequiredSnap string) error {
-	if rebootRequiredSnap == "" {
-		rebootRequiredSnap = "snapd"
-	}
 	// XXX: This will be replaced once there is a better way to
 	// notify about required reboots.  See
 	// https://github.com/uapi-group/specifications/issues/41
@@ -272,7 +269,12 @@ func notifyRebootRequiredClassic(rebootRequiredSnap string) error {
 	// as apt/dpkg.
 	nrrPath := filepath.Join(dirs.GlobalRootDir, "/usr/share/update-notifier/notify-reboot-required")
 	if osutil.FileExists(nrrPath) {
-		snapStr := fmt.Sprintf("snap:%s", rebootRequiredSnap)
+		var snapStr string
+		if rebootRequiredSnap == "" {
+			snapStr = "snapd"
+		} else {
+			snapStr = fmt.Sprintf("snap:%s", rebootRequiredSnap)
+		}
 		cmd := exec.Command(nrrPath, snapStr)
 		cmd.Env = append(os.Environ(),
 			// XXX: remove once update-notifer can take the

--- a/overlord/restart/restart_test.go
+++ b/overlord/restart/restart_test.go
@@ -250,7 +250,7 @@ func (s *restartSuite) TestFinishTaskWithRestart(c *C) {
 		chg.AddTask(task)
 		task.SetStatus(t.initial)
 
-		err := restart.FinishTaskWithRestart(task, t.final, t.restartType, nil)
+		err := restart.FinishTaskWithRestart(task, t.final, t.restartType, "some-snap", nil)
 		setStatus := t.final
 		if t.wait {
 			setStatus = state.WaitStatus
@@ -305,14 +305,14 @@ func (s *restartSuite) TestStartUpWaitTasks(c *C) {
 
 	t2 := st.NewTask("wait-for-reboot", "...")
 	chg.AddTask(t2)
-	err = restart.FinishTaskWithRestart(t2, state.DoneStatus, restart.RestartSystem, nil)
+	err = restart.FinishTaskWithRestart(t2, state.DoneStatus, restart.RestartSystem, "some-snap", nil)
 	c.Assert(err, FitsTypeOf, &state.Wait{})
 
 	restart.ReplaceBootID(st, "boot-id-2")
 
 	t3 := st.NewTask("wait-for-reboot-same-boot", "...")
 	chg.AddTask(t3)
-	err = restart.FinishTaskWithRestart(t3, state.DoneStatus, restart.RestartSystem, nil)
+	err = restart.FinishTaskWithRestart(t3, state.DoneStatus, restart.RestartSystem, "some-snap", nil)
 	c.Assert(err, FitsTypeOf, &state.Wait{})
 
 	c.Assert(chg.IsReady(), Equals, false)
@@ -374,7 +374,7 @@ func (s *restartSuite) TestPendingForSystemRestart(c *C) {
 	chg2.AddTask(t4)
 	t3.WaitFor(t2)
 	t4.WaitFor(t2)
-	err = restart.FinishTaskWithRestart(t2, state.DoneStatus, restart.RestartSystem, nil)
+	err = restart.FinishTaskWithRestart(t2, state.DoneStatus, restart.RestartSystem, "some-snap", nil)
 	c.Assert(err, FitsTypeOf, &state.Wait{})
 	t3.SetStatus(state.UndoStatus)
 	t4.SetStatus(state.WaitStatus)
@@ -389,7 +389,7 @@ func (s *restartSuite) TestPendingForSystemRestart(c *C) {
 	chg3.AddTask(t7)
 	t6.WaitFor(t5)
 	t7.WaitFor(t5)
-	err = restart.FinishTaskWithRestart(t6, state.DoneStatus, restart.RestartSystem, nil)
+	err = restart.FinishTaskWithRestart(t6, state.DoneStatus, restart.RestartSystem, "some-snap", nil)
 	c.Assert(err, FitsTypeOf, &state.Wait{})
 	t6.SetStatus(state.WaitStatus)
 	t7.SetStatus(state.DoStatus)
@@ -434,7 +434,6 @@ func (s *notifyRebootRequiredSuite) SetUpTest(c *C) {
 	// pretend there is a snap that requires a reboot
 	chg1 := s.st.NewChange("not-ready", "...")
 	s.t1 = s.st.NewTask("task", "...")
-	s.t1.Set("reboot-required-snap", "some-snap")
 	chg1.AddTask(s.t1)
 }
 
@@ -448,10 +447,12 @@ test "$DPKG_MAINTSCRIPT_NAME" = "postinst"
 `)
 	defer mockNrr.Restore()
 
-	restart.FinishTaskWithRestart(s.t1, state.DoneStatus, restart.RestartSystem, nil)
+	err := restart.FinishTaskWithRestart(s.t1, state.DoneStatus, restart.RestartSystem, "some-snap", nil)
+	c.Check(err, DeepEquals, &state.Wait{Reason: "waiting for manual system restart"})
 	c.Check(mockNrr.Calls(), DeepEquals, [][]string{
-		{"notify-reboot-required"},
+		{"notify-reboot-required", "snap:some-snap"},
 	})
+	// nothing in the logs
 	c.Check(s.mockLog.String(), Equals, "")
 }
 
@@ -462,11 +463,18 @@ func (s *notifyRebootRequiredSuite) TestFinishTaskWithRestartNotifiesRebootRequi
 	mockNrr := testutil.MockCommand(c, s.mockNrrPath, `echo fail; exit 1`)
 	defer mockNrr.Restore()
 
-	restart.FinishTaskWithRestart(s.t1, state.DoneStatus, restart.RestartSystem, nil)
+	err := restart.FinishTaskWithRestart(s.t1, state.DoneStatus, restart.RestartSystem, "some-snap", nil)
+	c.Check(err, DeepEquals, &state.Wait{Reason: "waiting for manual system restart"})
 	c.Check(mockNrr.Calls(), DeepEquals, [][]string{
-		{"notify-reboot-required"},
+		{"notify-reboot-required", "snap:some-snap"},
 	})
+	// failures get logged
 	c.Check(s.mockLog.String(), Matches, `(?ms).*: cannot notify about pending reboot: fail`)
+	// and wait-boot-id is setup correctly
+	var waitBootID string
+	err = s.t1.Get("wait-for-system-restart-from-boot-id", &waitBootID)
+	c.Check(err, IsNil)
+	c.Check(waitBootID, Equals, "boot-id-1")
 }
 
 func (s *notifyRebootRequiredSuite) TestFinishTaskWithRestartNotifiesRebootRequiredNotOnCore(c *C) {
@@ -479,7 +487,8 @@ func (s *notifyRebootRequiredSuite) TestFinishTaskWithRestartNotifiesRebootRequi
 	mockNrr := testutil.MockCommand(c, s.mockNrrPath, "")
 	defer mockNrr.Restore()
 
-	restart.FinishTaskWithRestart(s.t1, state.DoneStatus, restart.RestartSystem, nil)
+	err := restart.FinishTaskWithRestart(s.t1, state.DoneStatus, restart.RestartSystem, "some-snap", nil)
+	c.Check(err, IsNil)
 	c.Check(mockNrr.Calls(), HasLen, 0)
 	c.Check(s.mockLog.String(), Equals, "")
 }

--- a/overlord/snapstate/handlers_link_test.go
+++ b/overlord/snapstate/handlers_link_test.go
@@ -860,11 +860,6 @@ func (s *linkSnapSuite) TestDoLinkSnapSuccessRebootForCoreBase(c *C) {
 	c.Check(s.restartRequested, DeepEquals, []restart.RestartType{restart.RestartSystem})
 	c.Assert(t.Log(), HasLen, 1)
 	c.Check(t.Log()[0], Matches, `.*INFO Requested system restart.*`)
-
-	var rebootRequiredSnap string
-	err := t.Get("reboot-required-snap", &rebootRequiredSnap)
-	c.Check(err, IsNil)
-	c.Check(rebootRequiredSnap, Equals, "core18")
 }
 
 func (s *linkSnapSuite) TestDoLinkSnapSuccessRebootForKernelClassicWithModes(c *C) {

--- a/overlord/snapstate/handlers_link_test.go
+++ b/overlord/snapstate/handlers_link_test.go
@@ -860,6 +860,11 @@ func (s *linkSnapSuite) TestDoLinkSnapSuccessRebootForCoreBase(c *C) {
 	c.Check(s.restartRequested, DeepEquals, []restart.RestartType{restart.RestartSystem})
 	c.Assert(t.Log(), HasLen, 1)
 	c.Check(t.Log()[0], Matches, `.*INFO Requested system restart.*`)
+
+	var rebootRequiredSnap string
+	err := t.Get("reboot-required-snap", &rebootRequiredSnap)
+	c.Check(err, IsNil)
+	c.Check(rebootRequiredSnap, Equals, "core18")
 }
 
 func (s *linkSnapSuite) TestDoLinkSnapSuccessRebootForKernelClassicWithModes(c *C) {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -821,15 +821,16 @@ func FinishRestart(task *state.Task, snapsup *SnapSetup) (err error) {
 // It delegates the work to restart.FinishTaskWithRestart which can decide
 // to set the task to wait returning state.Wait.
 func FinishTaskWithRestart(task *state.Task, status state.Status, rt restart.RestartType, rebootInfo *boot.RebootInfo) error {
+	var rebootRequiredSnap string
 	// If system restart is requested, consider how the change the
 	// task belongs to is configured (system-restart-immediate) to
 	// choose whether request an immediate restart or not.
 	if rt == restart.RestartSystem {
 		snapsup, err := TaskSnapSetup(task)
 		if err != nil {
-			return err
+			return fmt.Errorf("cannot get snap that triggered a reboot: %v", err)
 		}
-		task.Set("reboot-required-snap", snapsup.InstanceName())
+		rebootRequiredSnap = snapsup.InstanceName()
 
 		chg := task.Change()
 		var immediate bool
@@ -845,7 +846,7 @@ func FinishTaskWithRestart(task *state.Task, status state.Status, rt restart.Res
 		}
 	}
 
-	return restart.FinishTaskWithRestart(task, status, rt, rebootInfo)
+	return restart.FinishTaskWithRestart(task, status, rt, rebootRequiredSnap, rebootInfo)
 }
 
 // IsErrAndNotWait returns true if err is not nil and neither state.Wait, it is

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -825,6 +825,12 @@ func FinishTaskWithRestart(task *state.Task, status state.Status, rt restart.Res
 	// task belongs to is configured (system-restart-immediate) to
 	// choose whether request an immediate restart or not.
 	if rt == restart.RestartSystem {
+		snapsup, err := TaskSnapSetup(task)
+		if err != nil {
+			return err
+		}
+		task.Set("reboot-required-snap", snapsup.InstanceName())
+
 		chg := task.Change()
 		var immediate bool
 		if chg != nil {

--- a/tests/nested/manual/fde-on-classic/mk-image.sh
+++ b/tests/nested/manual/fde-on-classic/mk-image.sh
@@ -93,7 +93,7 @@ install_data_partition() {
     echo "nameserver 8.8.8.8" | sudo tee -a "$DESTDIR"/etc/resolv.conf
     # install additional packages
     sudo chroot "$DESTDIR" /usr/bin/sh -c "DEBIAN_FRONTEND=noninteractive apt update"
-    local pkgs="snapd ssh openssh-server sudo iproute2 iputils-ping isc-dhcp-client netplan.io vim-tiny kmod cloud-init jq"
+    local pkgs="snapd ssh openssh-server sudo iproute2 iputils-ping isc-dhcp-client netplan.io vim-tiny kmod cloud-init jq update-notifier-common"
     sudo chroot "$DESTDIR" /usr/bin/sh -c \
          "DEBIAN_FRONTEND=noninteractive apt install --no-install-recommends -y $pkgs"
     # netplan config
@@ -224,7 +224,7 @@ set timeout=3
 # the bootenv
 load_env --file /EFI/ubuntu/grubenv kernel_status snapd_extra_cmdline_args snapd_full_cmdline_args
 
-set snapd_static_cmdline_args='console=ttyS0 console=tty1 console=tty1 panic=-1'
+set snapd_static_cmdline_args='console=ttyS0 console=tty1 panic=-1'
 set cmdline_args="$snapd_static_cmdline_args $snapd_extra_cmdline_args"
 if [ -n "$snapd_full_cmdline_args" ]; then
     set cmdline_args="$snapd_full_cmdline_args"

--- a/tests/nested/manual/fde-on-classic/task.yaml
+++ b/tests/nested/manual/fde-on-classic/task.yaml
@@ -54,27 +54,35 @@ execute: |
   remote.exec "snap list core22"
   remote.exec "snap list snapd"
 
+  # no reboot required
+  remote.exec not test -f /run/reboot-required
+
   # refresh kernel snap
   refresh_snap_and_reboot()
   {
       local snap_filename=$1
+      local snap_name=$2
       printf "Test installing snap from file %s\n" "$snap_filename"
       remote.push "$snap_filename"
       boot_id=$(tests.nested boot-id)
       REMOTE_CHG_ID=$(remote.exec sudo snap install --dangerous "$snap_filename" --no-wait)
       # Wait until we stall in the connection of interface as we wait for a reboot
       retry --wait 1 -n 60 sh -c "remote.exec \"snap change $REMOTE_CHG_ID | grep -E 'Wait .*(Make snap .* available to the system|Update assets from gadget .*)'\""
+      # Check that a reboot notification was setup
+      remote.exec test -f /run/reboot-required
+      remote.exec cat /run/reboot-required.pkgs | MATCH "snap:${snap_name}"
       # Check that no reboot has been scheduled, then force a reboot
       remote.exec not test -f /run/systemd/shutdown/scheduled
+
       remote.exec sudo reboot || true
       tests.nested wait-for reboot "$boot_id"
       remote.exec sudo snap watch "$REMOTE_CHG_ID"
   }
 
-  refresh_snap_and_reboot pc-kernel-new.snap
+  refresh_snap_and_reboot pc-kernel-new.snap pc-kernel
 
   echo "Refresh pc gadget and assert assets got updated"
-  refresh_snap_and_reboot pc-new.snap
+  refresh_snap_and_reboot pc-new.snap pc
   for f in /boot/grub/kernel.efi /run/mnt/ubuntu-boot/EFI/boot/bootx64.efi /run/mnt/ubuntu-boot/EFI/boot/grubx64.efi; do
       remote.exec sudo grep -q -a '"This program cannot be run in XXX mode"' "$f"
   done


### PR DESCRIPTION
Trigger the `update-notifier` reboot required helper to inform the users about pending reboots on classic systems.
