### PR TITLE
rfc: i/b/shutdown: allow systemctl daemon-reload

### DIFF
--- a/interfaces/builtin/shutdown.go
+++ b/interfaces/builtin/shutdown.go
@@ -38,7 +38,7 @@ dbus (send)
     bus=system
     path=/org/freedesktop/systemd1
     interface=org.freedesktop.systemd1.Manager
-    member={Reboot,PowerOff,Halt}
+    member={Reboot,PowerOff,Halt,Reload}
     peer=(label=unconfined),
 
 dbus (send)


### PR DESCRIPTION
As discussed with @mvo5, opening this as an RFC. I manually confirmed that this is sufficient to allow a script to call `systemctl daemon-reload`. Interested in feedback on if this is the right place for it; conceptually feels a bit odd, but there didn't seem to be another interface which seemed better. As a note, I put it here *not* because of the power management related justification below, but because this was where all the other methods for the systemd manager interface are.

## Reasoning

Enabling hardware with quirky power managment schemes on Ubuntu Core sometimes as a workaround requires injecting extra targets into the systemd dependency tree, specifically as dependencies of the reboot/poweroff/halt targets. This can be done as part of the install-device hook script, but then the device is stuck as it needs to call systemctl daemon-reload for the changes to take effect before the device can reboot from install mode to run mode.
