### PR TITLE
tests: update test now that core18 supports sessions

### DIFF
--- a/tests/lib/tools/suite/tests.session-support/task.yaml
+++ b/tests/lib/tools/suite/tests.session-support/task.yaml
@@ -27,12 +27,12 @@ execute: |
             tests.session has-session-systemd-and-dbus | MATCH 'ok'
             tests.session has-session-systemd-and-dbus
             ;;
-        ubuntu-core-1[68]-*)
+        ubuntu-core-16-*)
             tests.session has-system-systemd-and-dbus | MATCH 'ok'
             tests.session has-system-systemd-and-dbus
-            # Ubuntu Core 16 and Ubuntu Core 18 did not support user sessions.
-            # Note that Ubuntu Core 20 is in the default case down below, and
-            # does support this feature.
+            # Ubuntu Core 16 did not support user sessions.
+            # Note that Ubuntu Core 18 and later are in the default case down
+            # below, and do support this feature.
             tests.session has-session-systemd-and-dbus | MATCH 'no user dbus.socket'
             not tests.session has-session-systemd-and-dbus
             ;;


### PR DESCRIPTION
The test has recently started failing because the command prints "ok". I'm not sure what happened, maybe something was backported there.
