### PR TITLE
docs: new labeler rules for "Needs Documentation" label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,3 +6,6 @@
 # Add 'Run nested' label to either any change on nested lib or nested test
 Run nested:
   - any: ["tests/lib/nested.sh", "tests/nested/**/*"]
+
+Needs Documentation:
+  - any: ["cmd/snap/**/*", "daemon/**/*", "overlord/hookstate/ctlcmd/**/*", "overlord/configstate/configcore/**/*"]

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -4,9 +4,11 @@ on:
 
 jobs:
   triage:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@main
-        with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          sync-labels: ""
+    - uses: actions/labeler@v4
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Add the rule to manage the "Needs Documentation" label when a file is modified in 
 . cmd/snap/
 . cdaemon
 . overlord/hookstate/ctlcmd 
 . overlord/configstate/configcore