### PR TITLE
image: don't return prematurely when defaults are used

### DIFF
--- a/image/image_linux.go
+++ b/image/image_linux.go
@@ -576,7 +576,9 @@ func setupSeed(tsto *ToolingStore, model *asserts.Model, opts *Options) error {
 			if err := os.MkdirAll(sysconfig.WritableDefaultsDir(rootDir, "/etc"), 0755); err != nil {
 				return err
 			}
-			return sysconfig.ApplyFilesystemOnlyDefaults(model, defaultsDir, defaults)
+			if err := sysconfig.ApplyFilesystemOnlyDefaults(model, defaultsDir, defaults); err != nil {
+				return err
+			}
 		}
 
 		customizeImage(rootDir, defaultsDir, &opts.Customizations)


### PR DESCRIPTION
Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?

See https://bugs.launchpad.net/snapd/+bug/1997494