### PR TITLE
interfaces: allow wayland slot snaps to access shm files created by Firefox

### DIFF
--- a/interfaces/builtin/wayland.go
+++ b/interfaces/builtin/wayland.go
@@ -99,6 +99,10 @@ socket AF_NETLINK - NETLINK_KOBJECT_UEVENT
 const waylandConnectedSlotAppArmor = `
 # Allow access to common client Wayland sockets for connected snaps
 owner /run/user/[0-9]*/###PLUG_SECURITY_TAGS###/{mesa,mutter,sdl,wayland-cursor,weston,xwayland}-shared-* rw,
+
+# TODO: this can be removed when Mozilla's WaylandAllocateShmMemory()
+# function is updated to use memfd_create() instead.
+owner /{dev,run}/shm/###PLUG_SECURITY_TAGS###.wayland.mozilla.ipc.[0-9]* rw,
 `
 
 const waylandConnectedPlugAppArmor = `

--- a/interfaces/builtin/wayland_test.go
+++ b/interfaces/builtin/wayland_test.go
@@ -108,6 +108,7 @@ func (s *WaylandInterfaceSuite) TestAppArmorSpec(c *C) {
 	c.Assert(spec.AddConnectedSlot(s.iface, s.plug, s.coreSlot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.wayland.app1"})
 	c.Assert(spec.SnippetForTag("snap.wayland.app1"), testutil.Contains, "owner /run/user/[0-9]*/snap.consumer/{mesa,mutter,sdl,wayland-cursor,weston,xwayland}-shared-* rw,")
+	c.Assert(spec.SnippetForTag("snap.wayland.app1"), testutil.Contains, "owner /{dev,run}/shm/snap.consumer.wayland.mozilla.ipc.[0-9]* rw,")
 
 	// permanent core slot
 	spec = &apparmor.Specification{}


### PR DESCRIPTION
This PR grants snaps with a Wayland slot access to the shm file created by Firefox.

Part of the Wayland protocol involves the client creating a wl_shm_pool to pass data to the server. The `wl_shm_create_pool()` has the client provide a file descriptor that will be mapped locally and sent to the server over the Wayland socket (via SCM_RIGHTS). That means that the server needs to have AppArmor access to whatever the file descriptor points to.

For GTK and Qt apps, no special permissions are needed because they use memfd_create() to create the shm pool: as there is no file name, it doesn't trigger any AppArmor file rules. Unfortunately, Firefox's Wayland code uses a file system backed fd:

https://searchfox.org/mozilla-central/source/widget/gtk/WaylandBuffer.cpp#48-65

Without this change, we see denials like the following:

```
Oct 06 12:13:59 ubuntu kernel: audit: type=1400 audit(1665011639.475:380): apparmor="DENIED" operation="file_receive" profile="snap.ubuntu-desktop-session.ubuntu-desktop-session" name="/dev/shm/snap.firefox.wayland.mozilla.ipc.0" pid=1809 comm="gnome-shell" requested_mask="wr" denied_mask="wr" fsuid=1001 ouid=1001
```