### PR TITLE
image: make sure file customizations happen also when we have defaults

### DIFF
--- a/image/image_linux.go
+++ b/image/image_linux.go
@@ -608,7 +608,9 @@ var setupSeed = func(tsto *tooling.ToolingStore, model *asserts.Model, opts *Opt
 			if err := os.MkdirAll(sysconfig.WritableDefaultsDir(rootDir, "/etc"), 0755); err != nil {
 				return err
 			}
-			return sysconfig.ApplyFilesystemOnlyDefaults(model, defaultsDir, defaults)
+			if err := sysconfig.ApplyFilesystemOnlyDefaults(model, defaultsDir, defaults); err != nil {
+				return err
+			}
 		}
 
 		customizeImage(rootDir, defaultsDir, &opts.Customizations)


### PR DESCRIPTION
Some customizations (cloud init configuration seeding, disabling of console conf) were not happening for UC16/18 if there were also defaults in the gadget. This fixes an early return that was the
cause (LP: #1997494).
