### PR TITLE
ci: update labeler configuration

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,12 +3,13 @@
 # - https://github.com/actions/labeler/issues/112
 # - https://github.com/actions/labeler/issues/104
 
-# Add 'Run nested' label to either any change on nested lib or nested test
-Run nested:
+# Add 'Run nested -auto-' label to either any change on nested lib or nested test
+Run nested -auto-:
   - tests/lib/nested.sh
   - tests/nested/**/*
 
-Needs Documentation:
+# Add 'Needs Documentation -auto-' label to indicate a change needs changes in the docs
+Needs Documentation -auto-:
   - cmd/snap/**/*"
   - daemon/**/*
   - overlord/hookstate/ctlcmd/**/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,7 +5,11 @@
 
 # Add 'Run nested' label to either any change on nested lib or nested test
 Run nested:
-  - any: ["tests/lib/nested.sh", "tests/nested/**/*"]
+  - tests/lib/nested.sh
+  - tests/nested/**/*
 
 Needs Documentation:
-  - any: ["cmd/snap/**/*", "daemon/**/*", "overlord/hookstate/ctlcmd/**/*", "overlord/configstate/configcore/**/*"]
+  - cmd/snap/**/*"
+  - daemon/**/*
+  - overlord/hookstate/ctlcmd/**/*
+  - overlord/configstate/configcore/**/*

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -12,3 +12,4 @@ jobs:
     - uses: actions/labeler@v4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        sync-labels: "true"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -585,7 +585,7 @@ jobs:
     - name: Run spread tests
       # run if the commit is pushed to the release/* branch or there is a 'Run
       # nested' label set on the PR
-      if: "contains(github.event.pull_request.labels.*.name, 'Run nested') || contains(github.ref, 'refs/heads/release/')"
+      if: "contains(github.event.pull_request.labels.*.name, 'Run nested') || contains(github.event.pull_request.labels.*.name, 'Run nested -auto-') || contains(github.ref, 'refs/heads/release/')"
       env:
           SPREAD_GOOGLE_KEY: ${{ secrets.SPREAD_GOOGLE_KEY }}
       run: |


### PR DESCRIPTION
the any: [] just works when all: [] is used, otherwise weeeee need to use a list that means the same than any.

I tested that in the snapd-testing-tools project

Then "sync-labels" by default is false, it means that when a file is removed from the pr, the label is not removed. But if we manually remove the label, then when the workflow is executed again, la label will be applied again following the rules defined.
