### PR TITLE
overlord: avoid logging Requested system restart on classic with modes

### DIFF
--- a/overlord/devicestate/devicestate_bootconfig_test.go
+++ b/overlord/devicestate/devicestate_bootconfig_test.go
@@ -159,8 +159,9 @@ func (s *deviceMgrBootconfigSuite) testBootConfigUpdateRun(c *C, updateAttempted
 		if errMatch == "" && applied {
 			// we log on success
 			log := tsk.Log()
-			c.Assert(log, HasLen, 1)
+			c.Assert(log, HasLen, 2)
 			c.Check(log[0], Matches, ".* updated boot config assets")
+			c.Check(log[1], Matches, ".* Requested system restart")
 			// update was applied, thus a restart was requested
 			c.Check(s.restartRequests, DeepEquals, []restart.RestartType{restart.RestartSystemNow})
 		} else {

--- a/overlord/devicestate/devicestate_gadget_test.go
+++ b/overlord/devicestate/devicestate_gadget_test.go
@@ -1204,14 +1204,12 @@ func (s *deviceMgrGadgetSuite) testGadgetCommandlineUpdateRun(c *C, fromFiles, t
 		// we log on success
 		log := tsk.Log()
 		if logMatch != "" {
-			if !isClassic {
-				c.Assert(log, HasLen, 1)
-			} else {
-				c.Assert(log, HasLen, 2)
-			}
+			c.Assert(log, HasLen, 2)
 			c.Check(log[0], Matches, fmt.Sprintf(".* %v", logMatch))
 			if isClassic {
 				c.Check(log[1], Matches, ".* Task set to wait until a manual system restart allows to continue")
+			} else {
+				c.Check(log[1], Matches, ".* Requested system restart")
 			}
 		} else {
 			c.Check(log, HasLen, 0)
@@ -1608,9 +1606,11 @@ func (s *deviceMgrGadgetSuite) TestGadgetCommandlineUpdateUndo(c *C) {
 	c.Check(chg.Err(), ErrorMatches, "(?s)cannot perform the following tasks.*total undo.*")
 	c.Check(tsk.Status(), Equals, state.UndoneStatus)
 	log := tsk.Log()
-	c.Assert(log, HasLen, 2)
+	c.Assert(log, HasLen, 4)
 	c.Check(log[0], Matches, ".* Updated kernel command line")
-	c.Check(log[1], Matches, ".* Reverted kernel command line change")
+	c.Check(log[1], Matches, ".* Requested system restart")
+	c.Check(log[2], Matches, ".* Reverted kernel command line change")
+	c.Check(log[3], Matches, ".* Requested system restart")
 	// update was applied and then undone
 	c.Check(s.restartRequests, DeepEquals, []restart.RestartType{restart.RestartSystemNow, restart.RestartSystemNow})
 	c.Check(restartCount, Equals, 2)

--- a/overlord/restart/restart.go
+++ b/overlord/restart/restart.go
@@ -333,6 +333,8 @@ func FinishTaskWithRestart(task *state.Task, status state.Status, rt RestartType
 				task.Logf("Skipped automatic system restart on classic system when undoing changes back to previous state")
 				return nil
 			}
+		} else {
+			task.Logf("Requested system restart")
 		}
 	}
 	task.SetStatus(status)

--- a/overlord/restart/restart_test.go
+++ b/overlord/restart/restart_test.go
@@ -228,15 +228,16 @@ func (s *restartSuite) TestFinishTaskWithRestart(c *C) {
 		classic        bool
 		restart        bool
 		wait           bool
+		log            string
 	}{
 		{initial: state.DoStatus, final: state.DoneStatus, restartType: restart.RestartDaemon, classic: false, restart: true},
 		{initial: state.DoStatus, final: state.DoneStatus, restartType: restart.RestartDaemon, classic: true, restart: true},
 		{initial: state.UndoStatus, final: state.UndoneStatus, restartType: restart.RestartDaemon, classic: false, restart: true},
-		{initial: state.DoStatus, final: state.DoneStatus, restartType: restart.RestartSystem, classic: false, restart: true},
-		{initial: state.DoStatus, final: state.DoneStatus, restartType: restart.RestartSystem, classic: true, restart: false, wait: true},
-		{initial: state.DoStatus, final: state.DoneStatus, restartType: restart.RestartSystemNow, classic: true, restart: false, wait: true},
-		{initial: state.UndoStatus, final: state.UndoneStatus, restartType: restart.RestartSystem, classic: true, restart: false},
-		{initial: state.UndoStatus, final: state.UndoneStatus, restartType: restart.RestartSystem, classic: false, restart: true},
+		{initial: state.DoStatus, final: state.DoneStatus, restartType: restart.RestartSystem, classic: false, restart: true, log: ".* INFO Requested system restart"},
+		{initial: state.DoStatus, final: state.DoneStatus, restartType: restart.RestartSystem, classic: true, restart: false, wait: true, log: ".* INFO Task set to wait until a manual system restart allows to continue"},
+		{initial: state.DoStatus, final: state.DoneStatus, restartType: restart.RestartSystemNow, classic: true, restart: false, wait: true, log: ".* INFO Task set to wait until a manual system restart allows to continue"},
+		{initial: state.UndoStatus, final: state.UndoneStatus, restartType: restart.RestartSystem, classic: true, restart: false, log: ".* INFO Skipped automatic system restart on classic system when undoing changes back to previous state"},
+		{initial: state.UndoStatus, final: state.UndoneStatus, restartType: restart.RestartSystem, classic: false, restart: true, log: ".* INFO Requested system restart"},
 	}
 
 	chg := st.NewChange("chg", "...")
@@ -279,6 +280,12 @@ func (s *restartSuite) TestFinishTaskWithRestart(c *C) {
 				c.Check(waitBootID, Equals, "")
 			}
 			c.Check(ok, Equals, false)
+		}
+		if t.log == "" {
+			c.Check(task.Log(), HasLen, 0)
+		} else {
+			c.Check(task.Log(), HasLen, 1)
+			c.Check(task.Log()[0], Matches, t.log)
 		}
 	}
 }

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1964,7 +1964,6 @@ func (m *SnapManager) finishTaskWithMaybeRestart(t *state.Task, status state.Sta
 	st := t.State()
 
 	if restartPoss.RebootRequired {
-		t.Logf("Requested system restart.")
 		return FinishTaskWithRestart(t, status, restart.RestartSystem, &restartPoss.RebootInfo)
 	}
 

--- a/overlord/snapstate/handlers_link_test.go
+++ b/overlord/snapstate/handlers_link_test.go
@@ -903,9 +903,8 @@ func (s *linkSnapSuite) TestDoLinkSnapSuccessRebootForKernelClassicWithModes(c *
 
 	c.Check(t.Status(), Equals, state.WaitStatus)
 	c.Check(s.restartRequested, HasLen, 0)
-	// XXX avoid logging Requested system restart?
-	c.Assert(t.Log(), HasLen, 2)
-	c.Check(t.Log()[1], Matches, `.*INFO Task set to wait until a manual system restart allows to continue`)
+	c.Assert(t.Log(), HasLen, 1)
+	c.Check(t.Log()[0], Matches, `.*INFO Task set to wait until a manual system restart allows to continue`)
 }
 
 func (s *linkSnapSuite) TestDoLinkSnapSuccessRebootForCoreBaseSystemRestartImmediate(c *C) {


### PR DESCRIPTION
move the "requested system restart" logging to overlord/restart

