### PR TITLE
many: gadget.HasRole, ubuntu-seed can come also from system-seed-null

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -1782,7 +1782,7 @@ func generateMountsModeRun(mst *initramfsMountsState) error {
 			return fmt.Errorf("ubuntu-seed partition found but not defined in the gadget")
 		}
 		if !hasSeedPart && seedDefinedInGadget {
-			return fmt.Errorf("ubuntu-seed partition not found but defined in the gadget")
+			return fmt.Errorf("ubuntu-seed partition not found but defined in the gadget (%s)", foundRole)
 		}
 	}
 

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -1773,25 +1773,16 @@ func generateMountsModeRun(mst *initramfsMountsState) error {
 	// 4.4 check if we expected a ubuntu-seed partition from the gadget data
 	if isClassic {
 		gadgetDir := filepath.Join(boot.InitramfsRunMntDir, snapTypeToMountDir[snap.TypeGadget])
-		gadgetInfo, err := gadget.ReadInfo(gadgetDir, model)
+		foundRole, err := gadget.HasRole(gadgetDir, []string{gadget.SystemSeed, gadget.SystemSeedNull})
 		if err != nil {
 			return err
 		}
-		seedDefinedInGadget := false
-	volLoop:
-		for _, vol := range gadgetInfo.Volumes {
-			for _, part := range vol.Structure {
-				if part.Role == gadget.SystemSeed {
-					seedDefinedInGadget = true
-					break volLoop
-				}
-			}
-		}
+		seedDefinedInGadget := foundRole != ""
 		if hasSeedPart && !seedDefinedInGadget {
-			return fmt.Errorf("seed partition found but not defined in the gadget")
+			return fmt.Errorf("ubuntu-seed partition found but not defined in the gadget")
 		}
 		if !hasSeedPart && seedDefinedInGadget {
-			return fmt.Errorf("seed partition not found but defined in the gadget")
+			return fmt.Errorf("ubuntu-seed partition not found but defined in the gadget")
 		}
 	}
 

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -7345,7 +7345,7 @@ func (s *initramfsClassicMountsSuite) TestInitramfsMountsRunModeUnencryptedSeedP
 	writeGadget(c, "EFI System partition", "")
 
 	_, err = main.Parser().ParseArgs([]string{"initramfs-mounts"})
-	c.Assert(err, ErrorMatches, "seed partition found but not defined in the gadget")
+	c.Assert(err, ErrorMatches, "ubuntu-seed partition found but not defined in the gadget")
 }
 
 func (s *initramfsClassicMountsSuite) TestInitramfsMountsRunModeUnencryptedSeedInGadgetNotInVolume(c *C) {
@@ -7394,7 +7394,7 @@ func (s *initramfsClassicMountsSuite) TestInitramfsMountsRunModeUnencryptedSeedI
 	writeGadget(c, "ubuntu-seed", "system-seed")
 
 	_, err = main.Parser().ParseArgs([]string{"initramfs-mounts"})
-	c.Assert(err, ErrorMatches, "seed partition not found but defined in the gadget")
+	c.Assert(err, ErrorMatches, "ubuntu-seed partition not found but defined in the gadget")
 }
 
 func (s *initramfsClassicMountsSuite) TestInitramfsMountsRunModeUnencryptedNoSeedHappy(c *C) {
@@ -7439,11 +7439,14 @@ func (s *initramfsClassicMountsSuite) TestInitramfsMountsRunModeUnencryptedNoSee
 	err := modeEnv.WriteTo(boot.InitramfsDataDir)
 	c.Assert(err, IsNil)
 
+	// write gadget.yaml with no ubuntu-seed label and no role
+	writeGadget(c, "EFI System partition", "")
+
 	_, err = main.Parser().ParseArgs([]string{"initramfs-mounts"})
 	c.Assert(err, IsNil)
 }
 
-func (s *initramfsClassicMountsSuite) TestInitramfsMountsRunModeHappyNoGadgetMount(c *C) {
+func (s *initramfsClassicMountsSuite) TestInitramfsMountsRunModeHappySystemSeedNull(c *C) {
 	s.mockProcCmdlineContent(c, "snapd_recovery_mode=run")
 
 	restore := disks.MockMountPointDisksToPartitionMapping(
@@ -7461,6 +7464,7 @@ func (s *initramfsClassicMountsSuite) TestInitramfsMountsRunModeHappyNoGadgetMou
 		s.ubuntuPartUUIDMount("ubuntu-seed-partuuid", "run"),
 		s.ubuntuPartUUIDMount("ubuntu-data-partuuid", "run"),
 		s.ubuntuPartUUIDMount("ubuntu-save-partuuid", "run"),
+		s.makeRunSnapSystemdMount(snap.TypeGadget, s.gadget),
 		s.makeRunSnapSystemdMount(snap.TypeKernel, s.kernel),
 	}, nil)
 	defer restore()
@@ -7480,13 +7484,14 @@ func (s *initramfsClassicMountsSuite) TestInitramfsMountsRunModeHappyNoGadgetMou
 	modeEnv := boot.Modeenv{
 		Mode:           "run",
 		Base:           s.core20.Filename(),
+		Gadget:         s.gadget.Filename(),
 		CurrentKernels: []string{s.kernel.Filename()},
 	}
 	err := modeEnv.WriteTo(boot.InitramfsDataDir)
 	c.Assert(err, IsNil)
 
 	// write gadget.yaml, which is checked for classic
-	writeGadget(c, "ubuntu-seed", "system-seed")
+	writeGadget(c, "ubuntu-seed", "system-seed-null")
 
 	_, err = main.Parser().ParseArgs([]string{"initramfs-mounts"})
 	c.Assert(err, IsNil)

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -7394,7 +7394,7 @@ func (s *initramfsClassicMountsSuite) TestInitramfsMountsRunModeUnencryptedSeedI
 	writeGadget(c, "ubuntu-seed", "system-seed")
 
 	_, err = main.Parser().ParseArgs([]string{"initramfs-mounts"})
-	c.Assert(err, ErrorMatches, "ubuntu-seed partition not found but defined in the gadget")
+	c.Assert(err, ErrorMatches, `ubuntu-seed partition not found but defined in the gadget \(system-seed\)`)
 }
 
 func (s *initramfsClassicMountsSuite) TestInitramfsMountsRunModeUnencryptedNoSeedHappy(c *C) {

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -1385,3 +1385,33 @@ func parseCommandLineFromGadget(content []byte) (string, error) {
 	}
 	return strings.Join(kargs, " "), nil
 }
+
+// HasRole reads the gadget specific metadata from meta/gadget.yaml in the snap
+// root directory with minimal validation and checks whether any volume
+// structure has one of the given roles returning it, otherwhise it returns the
+// empty string.
+func HasRole(gadgetSnapRootDir string, roles []string) (foundRole string, err error) {
+	gadgetYamlFn := filepath.Join(gadgetSnapRootDir, "meta", "gadget.yaml")
+	gadgetYaml, err := ioutil.ReadFile(gadgetYamlFn)
+	if err != nil {
+		return "", err
+	}
+	var minInfo struct {
+		Volumes map[string]struct {
+			Structure []struct {
+				Role string `yaml:"role"`
+			} `yaml:"structure"`
+		} `yaml:"volumes"`
+	}
+	if err := yaml.Unmarshal(gadgetYaml, &minInfo); err != nil {
+		return "", fmt.Errorf("cannot minimally parse gadget metadata: %v", err)
+	}
+	for _, vol := range minInfo.Volumes {
+		for _, s := range vol.Structure {
+			if strutil.ListContains(roles, s.Role) {
+				return s.Role, nil
+			}
+		}
+	}
+	return "", nil
+}

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -1390,6 +1390,8 @@ func parseCommandLineFromGadget(content []byte) (string, error) {
 // root directory with minimal validation and checks whether any volume
 // structure has one of the given roles returning it, otherwhise it returns the
 // empty string.
+// This is mainly intended to avoid compatibility issues from snap-bootstrap
+// but could be used on any known to be properly installed gadget.
 func HasRole(gadgetSnapRootDir string, roles []string) (foundRole string, err error) {
 	gadgetYamlFn := filepath.Join(gadgetSnapRootDir, "meta", "gadget.yaml")
 	gadgetYaml, err := ioutil.ReadFile(gadgetYamlFn)


### PR DESCRIPTION
use HasRole in snap-bootstrap and cover the point about both system-seed and system-seed-null getting mounted as ubuntu-seed
