### PR TITLE
cmd/snap: display refresh holds over 100y as forever

### DIFF
--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -782,7 +782,13 @@ func (x *cmdRefresh) showRefreshTimes() error {
 		fmt.Fprintf(Stdout, "last: n/a\n")
 	}
 	if !hold.IsZero() {
-		fmt.Fprintf(Stdout, "hold: %s\n", x.fmtTime(hold))
+		// show holds over 100 years as "forever", like in the input of 'snap refresh
+		// --hold', instead of as a distant time (how they're internally represented)
+		if hold.After(timeNow().Add(100 * 365 * 24 * time.Hour)) {
+			fmt.Fprintf(Stdout, "hold: forever\n")
+		} else {
+			fmt.Fprintf(Stdout, "hold: %s\n", x.fmtTime(hold))
+		}
 	}
 	// only show "next" if its after "hold" to not confuse users
 	if !next.IsZero() {

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -1377,30 +1377,53 @@ next: 2017-04-26T00:58:00+02:00
 }
 
 func (s *SnapSuite) TestRefreshTimeShowsHolds(c *check.C) {
-	n := 0
-	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
-		switch n {
-		case 0:
-			c.Check(r.Method, check.Equals, "GET")
-			c.Check(r.URL.Path, check.Equals, "/v2/system-info")
-			fmt.Fprintln(w, `{"type": "sync", "status-code": 200, "result": {"refresh": {"timer": "0:00-24:00/4", "last": "2017-04-25T17:35:00+02:00", "next": "2017-04-26T00:58:00+02:00", "hold": "2017-04-28T00:00:00+02:00"}}}`)
-		default:
-			c.Fatalf("expected to get 1 requests, now on %d", n+1)
-		}
+	type testcase struct {
+		in  string
+		out string
+	}
 
-		n++
-	})
-	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--time", "--abs-time"})
+	curTime, err := time.Parse(time.RFC3339, "2017-04-27T23:00:00+02:00")
 	c.Assert(err, check.IsNil)
-	c.Assert(rest, check.DeepEquals, []string{})
-	c.Check(s.Stdout(), check.Equals, `timer: 0:00-24:00/4
+	restore := snap.MockTimeNow(func() time.Time {
+		return curTime
+	})
+	defer restore()
+
+	for _, tc := range []testcase{
+		{in: "2017-04-28T00:00:00+02:00", out: "2017-04-28T00:00:00+02:00"},
+		{in: "2117-04-28T00:00:00+02:00", out: "forever"},
+	} {
+		n := 0
+		s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+			switch n {
+			case 0:
+				c.Check(r.Method, check.Equals, "GET")
+				c.Check(r.URL.Path, check.Equals, "/v2/system-info")
+				fmt.Fprintf(w, `{"type": "sync", "status-code": 200, "result": {"refresh": {"timer": "0:00-24:00/4", "last": "2017-04-25T17:35:00+02:00", "next": "2017-04-26T00:58:00+02:00", "hold": %q}}}`, tc.in)
+			default:
+				errMsg := fmt.Sprintf("expected to get 1 requests, now on %d", n+1)
+				c.Error(errMsg)
+				w.WriteHeader(500)
+				w.Write([]byte(errMsg))
+			}
+
+			n++
+		})
+
+		rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--time", "--abs-time"})
+		c.Assert(err, check.IsNil)
+		c.Assert(rest, check.DeepEquals, []string{})
+		expectedOutput := fmt.Sprintf(`timer: 0:00-24:00/4
 last: 2017-04-25T17:35:00+02:00
-hold: 2017-04-28T00:00:00+02:00
+hold: %s
 next: 2017-04-26T00:58:00+02:00 (but held)
-`)
-	c.Check(s.Stderr(), check.Equals, "")
-	// ensure that the fake server api was actually hit
-	c.Check(n, check.Equals, 1)
+`, tc.out)
+		c.Check(s.Stdout(), check.Equals, expectedOutput)
+		c.Check(s.Stderr(), check.Equals, "")
+		// ensure that the fake server api was actually hit
+		c.Check(n, check.Equals, 1)
+		s.ResetStdStreams()
+	}
 }
 
 func (s *SnapSuite) TestRefreshHoldAllForever(c *check.C) {


### PR DESCRIPTION
The user can place an indefinite refresh hold which is internally represented as a maximum duration hold (in order to be compatible with the previous `snap set` mechanism). To check active holds the user can run `snap refresh --time` which currently returns a very distant time like `hold: 2315-03-07` for indefinite holds. This PR changes this so that indefinite/very long holds are displayed consistently as "forever" in the output of `snap refresh --time`.