### PR TITLE
many: add experimental support for declaring slots

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -61,6 +61,7 @@ var (
 	SnapRunLockDir         string
 	SnapBootstrapRunDir    string
 	SnapVoidDir            string
+	SnapEtcDir             string
 
 	SnapdMaintenanceFile string
 
@@ -368,6 +369,7 @@ func SetRootDir(rootdir string) {
 	SnapdMaintenanceFile = filepath.Join(rootdir, snappyDir, "maintenance.json")
 	SnapBlobDir = SnapBlobDirUnder(rootdir)
 	SnapVoidDir = filepath.Join(rootdir, snappyDir, "void")
+	SnapEtcDir = filepath.Join(rootdir, "/etc/snapd")
 	// ${snappyDir}/desktop is added to $XDG_DATA_DIRS.
 	// Subdirectories are interpreted according to the relevant
 	// freedesktop.org specifications

--- a/overlord/ifacestate/implicit.go
+++ b/overlord/ifacestate/implicit.go
@@ -87,6 +87,28 @@ func addImplicitSlots(st *state.State, snapInfo *snap.Info) error {
 		}
 	}
 
+	// Classic slots have lowest priority.
+	if release.OnClassic {
+		classicSlots, err := snap.LoadClassicSlots()
+		if err != nil {
+			return err
+		}
+
+		for _, cslotInfo := range classicSlots {
+			if _, ok := snapInfo.Slots[cslotInfo.Name]; ok {
+				return fmt.Errorf("cannot add classic slot %s: slot already exists", cslotInfo.Name)
+			}
+
+			snapInfo.Slots[cslotInfo.Name] = &snap.SlotInfo{
+				Name:      cslotInfo.Name,
+				Label:     cslotInfo.Label,
+				Snap:      snapInfo,
+				Interface: cslotInfo.Interface,
+				Attrs:     cslotInfo.Attrs,
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/snap/classic.go
+++ b/snap/classic.go
@@ -1,0 +1,91 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Zygmunt Krynicki
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snap
+
+import (
+	"errors"
+	"fmt"
+	"github.com/snapcore/snapd/dirs"
+	"os"
+	"path/filepath"
+
+	// Note: upgrading to v3 requires deeper changes, as the output of deserializing differs.
+	"gopkg.in/yaml.v2"
+)
+
+type classicYaml struct {
+	Slots map[string]interface{} `yaml:"slots,omitempty"`
+}
+
+type ClassicSlotInfo struct {
+	Name      string
+	Label     string
+	Interface string
+	Attrs     map[string]interface{}
+}
+
+// LoadClassicSlots loads statically-defined slots.
+//
+// On classic the gadget snap is unavailable, so there is no mechanism
+// to describe certain static hardware elements, like platform serial ports,
+// iio, GPIO or PWM interfaces.
+//
+// The system administrator can describe any such slots using the classic.yaml
+// configuration file located in /etc/snapd/ directory.
+func LoadClassicSlots() ([]ClassicSlotInfo, error) {
+	f, err := os.Open(filepath.Join(dirs.SnapEtcDir, "classic.yaml"))
+
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			err = nil
+		}
+
+		return nil, err
+	}
+
+	defer func() {
+		_ = f.Close()
+	}()
+
+	var y classicYaml
+
+	dec := yaml.NewDecoder(f)
+	if err := dec.Decode(&y); err != nil {
+		return nil, fmt.Errorf("cannot parse classic.yaml: %s", err)
+	}
+
+	slots := make([]ClassicSlotInfo, 0, len(y.Slots))
+
+	for name, data := range y.Slots {
+		iface, label, attrs, err := convertToSlotOrPlugData("slot", name, data)
+		if err != nil {
+			return nil, err
+		}
+
+		slots = append(slots, ClassicSlotInfo{
+			Name:      name,
+			Interface: iface,
+			Attrs:     attrs,
+			Label:     label,
+		})
+	}
+
+	return slots, nil
+}


### PR DESCRIPTION
On certain kinds of systems using snapd but not using ubuntu-core, a number of snapd interfaces, particularly industrial / embedded slots are unavailable, as they are traditionally defined by the gadget snap.

This locks out GPIOs or serial ports on the Raspberry Pi running Raspberry Pi OS, makes using Ubuntu Server for development of future Ubuntu Core devices much harder than it should be.

To address this a new configuration file, read by snapd on startup, is proposed. The file /etc/snapd/classic.yaml can now define any number of named slots, using the same logic that loads slots from snap.yaml files.

A system administrator can create such file, restart snapd and start working on snaps without having to solve catch22 problems of having a fully developed Ubuntu Core device.

The patch is in very early stages of development, and is meant to solicit feedback and design advice from the core development team.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>