### PR TITLE
cmd/snap-confine: do not discard const qualifier, FTBFS on Rawhide fix

### DIFF
--- a/cmd/snap-confine/selinux-support.c
+++ b/cmd/snap-confine/selinux-support.c
@@ -82,7 +82,7 @@ int sc_selinux_set_snap_execcon(void) {
         }
 
         /* freed by context_free(ctx) */
-        char *new_ctx_str = context_str(ctx);
+        const char *new_ctx_str = context_str(ctx);
         if (new_ctx_str == NULL) {
             die("cannot obtain updated SELinux context string");
         }


### PR DESCRIPTION
GCC 12.2.1 with the default build flags in Rawhide is more picky than usual, and fails with this:

```
snap-confine/selinux-support.c:85:29: error: initialization discards 'const' qualifier from pointer target type [-Werror=discarded-qualifiers]
   85 |         char *new_ctx_str = context_str(ctx);
      |                             ^~~~~~~~~~~
cc1: all warnings being treated as errors
```

Can this be cherry picked to 2.57? cc @mvo5 
