### PR TITLE
apparmor: revert "apparmor: disable vendoring again"

### DIFF
--- a/sandbox/apparmor/apparmor.go
+++ b/sandbox/apparmor/apparmor.go
@@ -408,29 +408,22 @@ func AppArmorParser() (cmd *exec.Cmd, internal bool, err error) {
 	// snapd snap (likely) or be part of the snapd distro package (unlikely)
 	// - but only use the internal one when we know that the system
 	// installed snapd-apparmor support re-exec
-
-	// TODO:apparmor-vendoring
-	// disabled until the test failures:
-	// - ubuntu-core-18-64:tests/core/snapd-refresh-vs-services
-	// and similar are fixed
-	/*
-		if path, err := snapdtool.InternalToolPath("apparmor_parser"); err == nil {
-			if osutil.IsExecutable(path) && snapdAppArmorSupportsReexec() {
-				prefix := strings.TrimSuffix(path, "apparmor_parser")
-				// when using the internal apparmor_parser also use
-				// its own configuration and includes etc plus
-				// also ensure we use the 3.0 feature ABI to get
-				// the widest array of policy features across the
-				// widest array of kernel versions
-				args := []string{
-					"--config-file", filepath.Join(prefix, "/apparmor/parser.conf"),
-					"--base", filepath.Join(prefix, "/apparmor.d"),
-					"--policy-features", filepath.Join(prefix, "/apparmor.d/abi/3.0"),
-				}
-				return exec.Command(path, args...), true, nil
+	if path, err := snapdtool.InternalToolPath("apparmor_parser"); err == nil {
+		if osutil.IsExecutable(path) && snapdAppArmorSupportsReexec() {
+			prefix := strings.TrimSuffix(path, "apparmor_parser")
+			// when using the internal apparmor_parser also use
+			// its own configuration and includes etc plus
+			// also ensure we use the 3.0 feature ABI to get
+			// the widest array of policy features across the
+			// widest array of kernel versions
+			args := []string{
+				"--config-file", filepath.Join(prefix, "/apparmor/parser.conf"),
+				"--base", filepath.Join(prefix, "/apparmor.d"),
+				"--policy-features", filepath.Join(prefix, "/apparmor.d/abi/3.0"),
 			}
+			return exec.Command(path, args...), true, nil
 		}
-	*/
+	}
 
 	// now search for one in the configured parserSearchPath
 	for _, dir := range filepath.SplitList(parserSearchPath) {

--- a/sandbox/apparmor/apparmor_test.go
+++ b/sandbox/apparmor/apparmor_test.go
@@ -78,34 +78,31 @@ func (*apparmorSuite) TestAppArmorParser(c *C) {
 }
 
 func (*apparmorSuite) TestAppArmorInternalAppArmorParser(c *C) {
-	// TODO:apparmor-vendoring
-	/*
-		fakeroot := c.MkDir()
-		dirs.SetRootDir(fakeroot)
+	fakeroot := c.MkDir()
+	dirs.SetRootDir(fakeroot)
 
-		d := filepath.Join(dirs.SnapMountDir, "/snapd/42", "/usr/lib/snapd")
-		c.Assert(os.MkdirAll(d, 0755), IsNil)
-		p := filepath.Join(d, "apparmor_parser")
-		c.Assert(ioutil.WriteFile(p, nil, 0755), IsNil)
-		restore := snapdtool.MockOsReadlink(func(path string) (string, error) {
-			c.Assert(path, Equals, "/proc/self/exe")
-			return filepath.Join(d, "snapd"), nil
-		})
-		defer restore()
-		restore = apparmor.MockSnapdAppArmorSupportsReexec(func() bool { return true })
-		defer restore()
+	d := filepath.Join(dirs.SnapMountDir, "/snapd/42", "/usr/lib/snapd")
+	c.Assert(os.MkdirAll(d, 0755), IsNil)
+	p := filepath.Join(d, "apparmor_parser")
+	c.Assert(ioutil.WriteFile(p, nil, 0755), IsNil)
+	restore := snapdtool.MockOsReadlink(func(path string) (string, error) {
+		c.Assert(path, Equals, "/proc/self/exe")
+		return filepath.Join(d, "snapd"), nil
+	})
+	defer restore()
+	restore = apparmor.MockSnapdAppArmorSupportsReexec(func() bool { return true })
+	defer restore()
 
-		cmd, internal, err := apparmor.AppArmorParser()
-		c.Check(err, IsNil)
-		c.Check(cmd.Path, Equals, p)
-		c.Check(cmd.Args, DeepEquals, []string{
-			p,
-			"--config-file", filepath.Join(d, "/apparmor/parser.conf"),
-			"--base", filepath.Join(d, "/apparmor.d"),
-			"--policy-features", filepath.Join(d, "/apparmor.d/abi/3.0"),
-		})
-		c.Check(internal, Equals, true)
-	*/
+	cmd, internal, err := apparmor.AppArmorParser()
+	c.Check(err, IsNil)
+	c.Check(cmd.Path, Equals, p)
+	c.Check(cmd.Args, DeepEquals, []string{
+		p,
+		"--config-file", filepath.Join(d, "/apparmor/parser.conf"),
+		"--base", filepath.Join(d, "/apparmor.d"),
+		"--policy-features", filepath.Join(d, "/apparmor.d/abi/3.0"),
+	})
+	c.Check(internal, Equals, true)
 }
 
 func (*apparmorSuite) TestAppArmorLevelTypeStringer(c *C) {
@@ -351,14 +348,9 @@ profile snap-test {
 	defer restore()
 	restore = apparmor.MockSnapdAppArmorSupportsReexec(func() bool { return true })
 	defer restore()
-
-	// TODO:apparmor-vendoring
-	// disabled until the spread test failures are fixed
-	/*
-		features, err = apparmor.ProbeParserFeatures()
-		c.Check(err, Equals, nil)
-		c.Check(features, DeepEquals, []string{"snapd-internal"})
-	*/
+	features, err = apparmor.ProbeParserFeatures()
+	c.Check(err, Equals, nil)
+	c.Check(features, DeepEquals, []string{"snapd-internal"})
 }
 
 func (s *apparmorSuite) TestInterfaceSystemKey(c *C) {

--- a/tests/main/snapd-snap/task.yaml
+++ b/tests/main/snapd-snap/task.yaml
@@ -232,10 +232,6 @@ execute: |
 
     unsquashfs -ll snapd_spread-test.snap | MATCH libc.so
 
-    # TODO:apparmor-vendoring
-    # remove this "exit 0" once apparmor-vendoring is ready
-    exit 0
-
     echo "Ensure we have apparmor_parser"
     unsquashfs -ll snapd_spread-test.snap | MATCH usr/lib/snapd/apparmor_parser
 


### PR DESCRIPTION
This reverts commit 9ad372eae09554292fad1616440bd0e173f99ba7.

This will need work as some of the tests are failing with apparmor vendoring current when reverting snapd from vendored to unvendored.