### PR TITLE
aspects: validate aspect names and paths

### DIFF
--- a/aspects/aspects.go
+++ b/aspects/aspects.go
@@ -94,7 +94,7 @@ type Directory struct {
 // and access patterns.
 func NewAspectDirectory(name string, aspects map[string]interface{}, dataBag DataBag, schema Schema) (*Directory, error) {
 	if len(aspects) == 0 {
-		return nil, errors.New(`cannot create aspects directory: no aspects`)
+		return nil, errors.New(`cannot define aspects directory: no aspects`)
 	}
 
 	aspectDir := &Directory{
@@ -107,14 +107,14 @@ func NewAspectDirectory(name string, aspects map[string]interface{}, dataBag Dat
 	for name, v := range aspects {
 		aspectPatterns, ok := v.([]map[string]string)
 		if !ok {
-			return nil, errors.New("cannot create aspect: access patterns should be a list of maps")
+			return nil, fmt.Errorf("cannot define aspect %q: access patterns should be a list of maps", name)
 		} else if len(aspectPatterns) == 0 {
-			return nil, errors.New("cannot create aspect without access patterns")
+			return nil, fmt.Errorf("cannot define aspect %q: no access patterns found", name)
 		}
 
 		aspect, err := newAspect(aspectDir, name, aspectPatterns)
 		if err != nil {
-			return nil, fmt.Errorf("cannot create aspect %q: %w", name, err)
+			return nil, fmt.Errorf("cannot define aspect %q: %w", name, err)
 		}
 
 		aspectDir.aspects[name] = aspect
@@ -309,7 +309,7 @@ func (a *Aspect) Get(name string, value interface{}) error {
 func newAccessPattern(name, path, accesstype string) (*accessPattern, error) {
 	accType, err := newAccessType(accesstype)
 	if err != nil {
-		return nil, fmt.Errorf("cannot create aspect pattern: %w", err)
+		return nil, fmt.Errorf("cannot  aspect pattern: %w", err)
 	}
 
 	nameSubkeys := strings.Split(name, ".")

--- a/aspects/aspects_test.go
+++ b/aspects/aspects_test.go
@@ -380,12 +380,12 @@ func (s *aspectSuite) TestAspectNameAndPathValidation(c *C) {
 
 	for _, tc := range []testcase{
 		{
-			testName: "empty parts in name",
-			name:     "a..b", path: "a.b", err: `invalid access name "a..b": cannot have empty parts`,
+			testName: "empty subkeys in name",
+			name:     "a..b", path: "a.b", err: `invalid access name "a..b": cannot have empty subkeys`,
 		},
 		{
-			testName: "empty parts in path",
-			name:     "a.b", path: "c..b", err: `invalid path "c..b": cannot have empty parts`,
+			testName: "empty subkeys in path",
+			name:     "a.b", path: "c..b", err: `invalid path "c..b": cannot have empty subkeys`,
 		},
 		{
 			testName: "placeholder mismatch (same number)",
@@ -397,39 +397,39 @@ func (s *aspectSuite) TestAspectNameAndPathValidation(c *C) {
 		},
 		{
 			testName: "invalid character in name: $",
-			name:     "a.b$", path: "bad", err: `invalid access name "a.b$": invalid part "b$"`,
+			name:     "a.b$", path: "bad", err: `invalid access name "a.b$": invalid subkey "b$"`,
 		},
 		{
 			testName: "invalid character in path: é",
-			name:     "a.b", path: "a.é", err: `invalid path "a.é": invalid part "é"`,
+			name:     "a.b", path: "a.é", err: `invalid path "a.é": invalid subkey "é"`,
 		},
 		{
 			testName: "invalid character in name: _",
-			name:     "a.b_c", path: "a.b-c", err: `invalid access name "a.b_c": invalid part "b_c"`,
+			name:     "a.b_c", path: "a.b-c", err: `invalid access name "a.b_c": invalid subkey "b_c"`,
 		},
 		{
 			testName: "invalid leading dash",
-			name:     "-a", path: "a", err: `invalid access name "-a": invalid part "-a"`,
+			name:     "-a", path: "a", err: `invalid access name "-a": invalid subkey "-a"`,
 		},
 		{
 			testName: "invalid trailing dash",
-			name:     "a", path: "a-", err: `invalid path "a-": invalid part "a-"`,
+			name:     "a", path: "a-", err: `invalid path "a-": invalid subkey "a-"`,
 		},
 		{
 			testName: "missing closing curly bracket",
-			name:     "{a{", path: "a", err: `invalid access name "{a{": invalid part "{a{"`,
+			name:     "{a{", path: "a", err: `invalid access name "{a{": invalid subkey "{a{"`,
 		},
 		{
 			testName: "missing opening curly bracket",
-			name:     "a", path: "}a}", err: `invalid path "}a}": invalid part "}a}"`,
+			name:     "a", path: "}a}", err: `invalid path "}a}": invalid subkey "}a}"`,
 		},
 		{
-			testName: "curly brackets not wrapping part",
-			name:     "a", path: "a.b{a}c", err: `invalid path "a.b{a}c": invalid part "b{a}c"`,
+			testName: "curly brackets not wrapping subkey",
+			name:     "a", path: "a.b{a}c", err: `invalid path "a.b{a}c": invalid subkey "b{a}c"`,
 		},
 		{
 			testName: "invalid whitespace character",
-			name:     "a. .c", path: "a.b", err: `invalid access name "a. .c": invalid part " "`,
+			name:     "a. .c", path: "a.b", err: `invalid access name "a. .c": invalid subkey " "`,
 		},
 	} {
 		_, err := aspects.NewAspectDirectory("foo", map[string]interface{}{

--- a/aspects/aspects_test.go
+++ b/aspects/aspects_test.go
@@ -54,14 +54,14 @@ func (*aspectSuite) TestNewAspectDirectory(c *C) {
 			{"path": "foo"},
 		},
 	}, aspects.NewJSONDataBag(), aspects.NewJSONSchema())
-	c.Assert(err, ErrorMatches, `cannot create aspect pattern without a "name" field`)
+	c.Assert(err, ErrorMatches, `cannot create aspect "bar": access patterns must have a "name" field`)
 
 	_, err = aspects.NewAspectDirectory("foo", map[string]interface{}{
 		"bar": []map[string]string{
 			{"name": "foo"},
 		},
 	}, aspects.NewJSONDataBag(), aspects.NewJSONSchema())
-	c.Assert(err, ErrorMatches, `cannot create aspect pattern without a "path" field`)
+	c.Assert(err, ErrorMatches, `cannot create aspect "bar": access patterns must have a "path" field`)
 
 	aspectDir, err := aspects.NewAspectDirectory("foo", map[string]interface{}{
 		"bar": []map[string]string{
@@ -381,55 +381,55 @@ func (s *aspectSuite) TestAspectNameAndPathValidation(c *C) {
 	for _, tc := range []testcase{
 		{
 			testName: "empty parts in name",
-			name:     "a..b", path: "a.b", err: `"a..b" has empty parts`,
+			name:     "a..b", path: "a.b", err: `invalid access name "a..b": cannot have empty parts`,
 		},
 		{
 			testName: "empty parts in path",
-			name:     "a.b", path: "c..b", err: `"c..b" has empty parts`,
+			name:     "a.b", path: "c..b", err: `invalid path "c..b": cannot have empty parts`,
 		},
 		{
 			testName: "placeholder mismatch (same number)",
-			name:     "bad.{foo}", path: "bad.{bar}", err: `placeholder "{foo}" from name "bad.{foo}" is absent from path "bad.{bar}"`,
+			name:     "bad.{foo}", path: "bad.{bar}", err: `placeholder "{foo}" from access name "bad.{foo}" is absent from path "bad.{bar}"`,
 		},
 		{
 			testName: "placeholder mismatch (different number)",
-			name:     "{foo}", path: "{foo}.bad.{bar}", err: `name "{foo}" and path "{foo}.bad.{bar}" have mismatched placeholders`,
+			name:     "{foo}", path: "{foo}.bad.{bar}", err: `access name "{foo}" and path "{foo}.bad.{bar}" have mismatched placeholders`,
 		},
 		{
 			testName: "invalid character in name: $",
-			name:     "a.b$", path: "bad", err: `invalid part: "b$"`,
+			name:     "a.b$", path: "bad", err: `invalid access name "a.b$": invalid part "b$"`,
 		},
 		{
 			testName: "invalid character in path: é",
-			name:     "a.b", path: "a.é", err: `invalid part: "é"`,
+			name:     "a.b", path: "a.é", err: `invalid path "a.é": invalid part "é"`,
 		},
 		{
 			testName: "invalid character in name: _",
-			name:     "a.b_c", path: "a.b-c", err: `invalid part: "b_c"`,
+			name:     "a.b_c", path: "a.b-c", err: `invalid access name "a.b_c": invalid part "b_c"`,
 		},
 		{
 			testName: "invalid leading dash",
-			name:     "-a", path: "a", err: `invalid part: "-a"`,
+			name:     "-a", path: "a", err: `invalid access name "-a": invalid part "-a"`,
 		},
 		{
 			testName: "invalid trailing dash",
-			name:     "a", path: "a-", err: `invalid part: "a-"`,
+			name:     "a", path: "a-", err: `invalid path "a-": invalid part "a-"`,
 		},
 		{
 			testName: "missing closing curly bracket",
-			name:     "{a{", path: "a", err: `invalid part: "{a{"`,
+			name:     "{a{", path: "a", err: `invalid access name "{a{": invalid part "{a{"`,
 		},
 		{
 			testName: "missing opening curly bracket",
-			name:     "a", path: "}a}", err: `invalid part: "}a}"`,
+			name:     "a", path: "}a}", err: `invalid path "}a}": invalid part "}a}"`,
 		},
 		{
 			testName: "curly brackets not wrapping part",
-			name:     "a", path: "a.b{a}c", err: `invalid part: "b{a}c"`,
+			name:     "a", path: "a.b{a}c", err: `invalid path "a.b{a}c": invalid part "b{a}c"`,
 		},
 		{
 			testName: "invalid whitespace character",
-			name:     "a. .c", path: "a.b", err: `invalid part: " "`,
+			name:     "a. .c", path: "a.b", err: `invalid access name "a. .c": invalid part " "`,
 		},
 	} {
 		_, err := aspects.NewAspectDirectory("foo", map[string]interface{}{
@@ -440,6 +440,6 @@ func (s *aspectSuite) TestAspectNameAndPathValidation(c *C) {
 
 		cmt := Commentf("sub-test %q failed", tc.testName)
 		c.Assert(err, Not(IsNil), cmt)
-		c.Assert(err.Error(), Equals, tc.err, cmt)
+		c.Assert(err.Error(), Equals, `cannot create aspect "foo": `+tc.err, cmt)
 	}
 }

--- a/aspects/aspects_test.go
+++ b/aspects/aspects_test.go
@@ -37,31 +37,31 @@ var _ = Suite(&aspectSuite{})
 
 func (*aspectSuite) TestNewAspectDirectory(c *C) {
 	_, err := aspects.NewAspectDirectory("foo", nil, aspects.NewJSONDataBag(), aspects.NewJSONSchema())
-	c.Assert(err, ErrorMatches, `cannot create aspects directory: no aspects`)
+	c.Assert(err, ErrorMatches, `cannot define aspects directory: no aspects`)
 
 	_, err = aspects.NewAspectDirectory("foo", map[string]interface{}{
 		"bar": "baz",
 	}, aspects.NewJSONDataBag(), aspects.NewJSONSchema())
-	c.Assert(err, ErrorMatches, `cannot create aspect: access patterns should be a list of maps`)
+	c.Assert(err, ErrorMatches, `cannot define aspect "bar": access patterns should be a list of maps`)
 
 	_, err = aspects.NewAspectDirectory("foo", map[string]interface{}{
 		"bar": []map[string]string{},
 	}, aspects.NewJSONDataBag(), aspects.NewJSONSchema())
-	c.Assert(err, ErrorMatches, `cannot create aspect without access patterns`)
+	c.Assert(err, ErrorMatches, `cannot define aspect "bar": no access patterns found`)
 
 	_, err = aspects.NewAspectDirectory("foo", map[string]interface{}{
 		"bar": []map[string]string{
 			{"path": "foo"},
 		},
 	}, aspects.NewJSONDataBag(), aspects.NewJSONSchema())
-	c.Assert(err, ErrorMatches, `cannot create aspect "bar": access patterns must have a "name" field`)
+	c.Assert(err, ErrorMatches, `cannot define aspect "bar": access patterns must have a "name" field`)
 
 	_, err = aspects.NewAspectDirectory("foo", map[string]interface{}{
 		"bar": []map[string]string{
 			{"name": "foo"},
 		},
 	}, aspects.NewJSONDataBag(), aspects.NewJSONSchema())
-	c.Assert(err, ErrorMatches, `cannot create aspect "bar": access patterns must have a "path" field`)
+	c.Assert(err, ErrorMatches, `cannot define aspect "bar": access patterns must have a "path" field`)
 
 	aspectDir, err := aspects.NewAspectDirectory("foo", map[string]interface{}{
 		"bar": []map[string]string{
@@ -440,6 +440,6 @@ func (s *aspectSuite) TestAspectNameAndPathValidation(c *C) {
 
 		cmt := Commentf("sub-test %q failed", tc.testName)
 		c.Assert(err, Not(IsNil), cmt)
-		c.Assert(err.Error(), Equals, `cannot create aspect "foo": `+tc.err, cmt)
+		c.Assert(err.Error(), Equals, `cannot define aspect "foo": `+tc.err, cmt)
 	}
 }


### PR DESCRIPTION
Validate names and paths to ensure they're correctly formed (no empty parts, invalid characters, etc) and that placeholders in names are present in paths and vice-versa (such that paths can always be filled if a name was matched).