### PR TITLE
build-aux,.github/workflows: limit make processes with nproc

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -260,7 +260,7 @@ jobs:
       run: |
           cd ${{ github.workspace }}/src/github.com/snapcore/snapd/cmd/
           ./autogen.sh
-          make -j2
+          make -j$(nproc)
 
     - name: Get deps
       run: |

--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -169,7 +169,7 @@ parts:
       cd $SNAPCRAFT_PART_BUILD/libraries/libapparmor
       ./autogen.sh
       ./configure --prefix=/usr --disable-man-pages --disable-perl --disable-python --disable-ruby
-      make -j4
+      make -j$(nproc)
       # place libapparmor into staging area for use by snap-confine
       make -C src install DESTDIR=$SNAPCRAFT_STAGE
       cd $SNAPCRAFT_PART_BUILD/parser
@@ -184,13 +184,13 @@ parts:
       else
         cp $SNAPCRAFT_PROJECT_DIR/snap/local/apparmor/af_names.h .
       fi
-      make -j4
+      make -j$(nproc)
       mkdir -p $SNAPCRAFT_PART_INSTALL/usr/lib/snapd
       cp -a apparmor_parser $SNAPCRAFT_PART_INSTALL/usr/lib/snapd/
       mkdir -p $SNAPCRAFT_PART_INSTALL/usr/lib/snapd/apparmor
       cp -a parser.conf $SNAPCRAFT_PART_INSTALL/usr/lib/snapd/apparmor/
       cd $SNAPCRAFT_PART_BUILD/profiles
-      make -j4
+      make -j$(nproc)
       mkdir -p $SNAPCRAFT_PART_INSTALL/usr/lib/snapd/apparmor.d
       cp -a apparmor.d/abi $SNAPCRAFT_PART_INSTALL/usr/lib/snapd/apparmor.d/
       cp -a apparmor.d/abstractions $SNAPCRAFT_PART_INSTALL/usr/lib/snapd/apparmor.d/


### PR DESCRIPTION
Limit the number of processes created by make by using the value returned by nproc, so it adapts to the device it is running on.
