### PR TITLE
gadget/install: use laidOut volume info instead of onDisk when mounting partitions during factory reset

### DIFF
--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -779,7 +779,7 @@ func FactoryReset(model gadget.Model, gadgetRoot, kernelRoot, bootDevice string,
 			keyForRole[laidOut.Role] = encryptionKey
 		}
 		if options.Mount && onDisk.Label != "" && laidOut.HasFilesystem() {
-			if err := mountFilesystem(fsDevice, onDisk.Filesystem, filepath.Join(boot.InitramfsRunMntDir, onDisk.Label)); err != nil {
+			if err := mountFilesystem(fsDevice, laidOut.Filesystem, getMntPointForPart(laidOut.VolumeStructure)); err != nil {
 				return nil, err
 			}
 		}


### PR DESCRIPTION
This fixes an mounting issue during factory-reset where we tried to mount ubuntu-data as "crypto_LUKS" instead of "ext4", and now also uses the correct mount point.