### PR TITLE
cmd/snap: error on negative or very short holds 

### DIFF
--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -915,7 +915,7 @@ func (x *cmdRefresh) holdRefreshes() (err error) {
 	} else {
 		dur, err := time.ParseDuration(x.Hold)
 		if err != nil {
-			return fmt.Errorf("hold value must be a number of hours or minutes (e.g., 72h): %v", err)
+			return fmt.Errorf("hold value must be a number of hours, minutes or seconds, or \"forever\": %v", err)
 		} else if dur < time.Second {
 			return fmt.Errorf("cannot hold refreshes for less than a second: %s", x.Hold)
 		}
@@ -1301,7 +1301,7 @@ func init() {
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"transaction": i18n.G("Have one transaction per-snap or one for all the specified snaps"),
 			// TRANSLATORS: This should not start with a lowercase letter.
-			"hold": i18n.G("Hold refreshes for a specified duration (or indefinitely, if none is specified)"),
+			"hold": i18n.G("Hold refreshes for a specified duration (or forever, if no value is specified)"),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"unhold": i18n.G("Remove refresh hold"),
 		}), nil)

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -916,6 +916,8 @@ func (x *cmdRefresh) holdRefreshes() (err error) {
 		dur, err := time.ParseDuration(x.Hold)
 		if err != nil {
 			return fmt.Errorf("hold value must be a number of hours or minutes (e.g., 72h): %v", err)
+		} else if dur < time.Second {
+			return fmt.Errorf("cannot hold refreshes for less than a second: %s", x.Hold)
 		}
 
 		opts.Time = timeNow().Add(dur).Format(time.RFC3339)

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -1710,7 +1710,7 @@ func (s *SnapSuite) TestRefreshHoldBadDuration(c *check.C) {
 	})
 
 	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--hold=1d"})
-	c.Assert(err, check.ErrorMatches, "hold value must be a number of hours or minutes \\(e\\.g\\., 72h\\): time: unknown unit \"?d\"? in duration \"?1d\"?")
+	c.Assert(err, check.ErrorMatches, "hold value must be a number of hours, minutes or seconds, or \"forever\": time: unknown unit \"?d\"? in duration \"?1d\"?")
 	c.Assert(rest, check.DeepEquals, []string{"--hold=1d"})
 	c.Check(s.Stdout(), check.Equals, "")
 	c.Check(s.Stderr(), check.Equals, "")

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -1716,6 +1716,21 @@ func (s *SnapSuite) TestRefreshHoldBadDuration(c *check.C) {
 	c.Check(s.Stderr(), check.Equals, "")
 }
 
+func (s *SnapSuite) TestRefreshHoldNegativeDuration(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Errorf("unexpected request")
+		fmt.Fprintln(w, `{"type": "error", "result": {"message": "received too many requests"}, "status-code": 500}`)
+	})
+
+	for _, dur := range []string{"-5h", "15ns"} {
+		rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"refresh", "--hold=" + dur})
+		c.Assert(err, check.ErrorMatches, "cannot hold refreshes for less than a second: "+dur)
+		c.Assert(rest, check.DeepEquals, []string{"--hold=" + dur})
+		c.Check(s.Stdout(), check.Equals, "")
+		c.Check(s.Stderr(), check.Equals, "")
+	}
+}
+
 func (s *SnapSuite) TestRefreshNoTimerNoSchedule(c *check.C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		c.Check(r.Method, check.Equals, "GET")


### PR DESCRIPTION
The first commit forbids refresh holds that are negative or too short (< 1s). The second commit changes a few things in the command's output and help messages. It's a bit of a drive-by fix but they were pointed out by people outside snapd so I wanted the fix in 2.58 to avoid confusing more people.