### PR TITLE
seed/seedwriter,o/devicestate: classic snaps w/o flag and model grade higher than signed fail

### DIFF
--- a/seed/seedtest/seedtest.go
+++ b/seed/seedtest/seedtest.go
@@ -212,7 +212,7 @@ func (s *TestingSeed16) WriteAssertions(fn string, assertions ...asserts.Asserti
 }
 
 func WriteAssertions(fn string, assertions ...asserts.Assertion) {
-	f, err := os.OpenFile(fn, os.O_CREATE|os.O_WRONLY, 0644)
+	f, err := os.OpenFile(fn, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
 		panic(err)
 	}

--- a/seed/seedwriter/seed16.go
+++ b/seed/seedwriter/seed16.go
@@ -60,6 +60,11 @@ func (pol *policy16) checkSnapChannel(_ channel.Channel, whichSnap string) error
 	return nil
 }
 
+func (pol *policy16) checkClassicSnap(_ *SeedSnap) error {
+	// Core 16/18 have no constraints on classic snaps
+	return nil
+}
+
 func makeSystemSnap(snapName string) *asserts.ModelSnap {
 	return internal.MakeSystemSnap(snapName, "", []string{"run"})
 }

--- a/seed/seedwriter/seed20.go
+++ b/seed/seedwriter/seed20.go
@@ -61,6 +61,21 @@ func (pol *policy20) checkSnapChannel(ch channel.Channel, whichSnap string) erro
 	return pol.checkAllowedDangerous()
 }
 
+func (pol *policy20) checkClassicSnap(sn *SeedSnap) error {
+	if pol.model.Grade() == asserts.ModelDangerous {
+		// implicit classic snaps are accepted
+		return nil
+	}
+	modSnap, ok := sn.SnapRef.(*asserts.ModelSnap)
+	if !ok {
+		return fmt.Errorf("internal error: extra snap with non-dangerous grade")
+	}
+	if !modSnap.Classic {
+		return fmt.Errorf("cannot use classic snap %q with a model of grade higher than dangerous that does not allow it explicitly (missing classic: true in snap stanza)", modSnap.Name)
+	}
+	return nil
+}
+
 func (pol *policy20) systemSnap() *asserts.ModelSnap {
 	return internal.MakeSystemSnap("snapd", "latest/stable", []string{"run", "ephemeral"})
 }

--- a/seed/seedwriter/writer.go
+++ b/seed/seedwriter/writer.go
@@ -213,6 +213,8 @@ type policy interface {
 
 	checkAvailable(snpRef naming.SnapRef, modes []string, availableByMode map[string]*naming.SnapSet) bool
 
+	checkClassicSnap(sn *SeedSnap) error
+
 	needsImplicitSnaps(availableByMode map[string]*naming.SnapSet) (bool, error)
 	implicitSnaps(availableByMode map[string]*naming.SnapSet) []*asserts.ModelSnap
 	implicitExtraSnaps(availableByMode map[string]*naming.SnapSet) []*OptionsSnap
@@ -912,8 +914,13 @@ func (w *Writer) downloaded(seedSnaps []*SeedSnap) error {
 		}
 
 		needsClassic := info.NeedsClassic()
-		if needsClassic && !w.model.Classic() {
-			return fmt.Errorf("cannot use classic snap %q in a core system", info.SnapName())
+		if needsClassic {
+			if !w.model.Classic() {
+				return fmt.Errorf("cannot use classic snap %q in a core system", info.SnapName())
+			}
+			if err := w.policy.checkClassicSnap(sn); err != nil {
+				return err
+			}
 		}
 
 		modes := sn.modes()

--- a/seed/seedwriter/writer.go
+++ b/seed/seedwriter/writer.go
@@ -570,7 +570,7 @@ func (w *Writer) InfoDerived() error {
 // SetInfo sets Info of the SeedSnap and possibly computes its
 // destination Path.
 func (w *Writer) SetInfo(sn *SeedSnap, info *snap.Info) error {
-	if info.Confinement == snap.DevModeConfinement {
+	if info.NeedsDevMode() {
 		if err := w.policy.allowsDangerousFeatures(); err != nil {
 			return err
 		}


### PR DESCRIPTION
This avoids failing only later at seeding time.
