### PR TITLE
tests: add more workers for ubuntu core 20/22

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -124,11 +124,11 @@ backends:
                   workers: 6
             - ubuntu-core-20-64:
                   image: ubuntu-20.04-64
-                  workers: 6
+                  workers: 8
                   storage: 20G
             - ubuntu-core-22-64:
                   image: ubuntu-22.04-64
-                  workers: 6
+                  workers: 8
                   storage: 20G
             - ubuntu-secboot-20.04-64:
                   image: ubuntu-20.04-64


### PR DESCRIPTION
Ubuntu core executions are taking 20 extra minutes to finish. This is caused because even when ubuntu core runs less number of tests, the system setup takes so long compared with the regular ubuntu cloud image.

$ spread -list google:ubuntu-core-20-64: | wc -l
442
$ spread -list google:ubuntu-20.04-64: | wc -l
596

$ spread -list google:ubuntu-core-22-64: | wc -l
421
$ spread -list google:ubuntu-22.04-64: | wc -l
596

