### PR TITLE
tests: fix an unbound variable in LXD test

### DIFF
--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -83,7 +83,7 @@ execute: |
         lxd.lxc config set core.proxy_http "$http_proxy"
     fi
     if [ -n "${https_proxy:-}" ]; then
-        lxd.lxc config set core.proxy_https "$http_proxy"
+        lxd.lxc config set core.proxy_https "$https_proxy"
     fi
 
     # The snapd package we build as part of the tests will only run on the


### PR DESCRIPTION
The `if` condition checks the `https_proxy` variable, but then `http_proxy` is used instead, and it might be undefined.
