### PR TITLE
tests: avoid running spread -abend in the github workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -469,8 +469,8 @@ jobs:
           # "pipefail" ensures that a non-zero status from the spread is
           # propagated; and we use a subshell as this option could trigger
           # undesired changes elsewhere
-          echo "Running command: $SPREAD -abend $RUN_TESTS"
-          (set -o pipefail; $SPREAD -abend $RUN_TESTS | tee spread.log)
+          echo "Running command: $SPREAD $RUN_TESTS"
+          (set -o pipefail; $SPREAD $RUN_TESTS | tee spread.log)
 
     - name: Discard spread workers
       if: always()
@@ -601,7 +601,7 @@ jobs:
           # "pipefail" ensures that a non-zero status from the spread is
           # propagated; and we use a subshell as this option could trigger
           # undesired changes elsewhere
-          (set -o pipefail; spread -abend $RUN_TESTS | tee spread.log)
+          (set -o pipefail; spread $RUN_TESTS | tee spread.log)
 
     - name: Discard spread workers
       if: always()


### PR DESCRIPTION
The problem with -abend is that spread discards the worker in case of failure, and it is not allocating a new one. This produces that the executions are delayed when there are tests that fail becuase the number of workers used is being decreased when tests fail.
