### PR TITLE
bootloader,devicestate: fix failing TestInstallFinishEncryptionHappy on i386

### DIFF
--- a/bootloader/grub.go
+++ b/bootloader/grub.go
@@ -470,7 +470,11 @@ func (g *grub) getGrubBootAssetsForArch() (*grubBootAssetPath, error) {
 	if g.prepareImageTime {
 		return nil, fmt.Errorf("internal error: retrieving boot assets at prepare image time")
 	}
-	assets := grubBootAssetsForArch[arch.DpkgArchitecture()]
+	archi := arch.DpkgArchitecture()
+	assets, ok := grubBootAssetsForArch[archi]
+	if !ok {
+		return nil, fmt.Errorf("cannot find grub assets for %q", archi)
+	}
 	return &assets, nil
 }
 

--- a/bootloader/grub_test.go
+++ b/bootloader/grub_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/mvo5/goconfigparser"
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/arch"
 	"github.com/snapcore/snapd/arch/archtest"
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/bootloader/assets"
@@ -619,6 +620,26 @@ func (s *grubTestSuite) TestKernelExtractionRunImageKernelNoSlashBoot(c *C) {
 	exists, _, err := osutil.DirExists(filepath.Dir(kernefi))
 	c.Assert(err, IsNil)
 	c.Check(exists, Equals, false)
+}
+
+func (s *grubTestSuite) TestListTrustedAssetsNotForArch(c *C) {
+	oldArch := arch.DpkgArchitecture()
+	defer arch.SetArchitecture(arch.ArchitectureType(oldArch))
+	arch.SetArchitecture("non-existing-architecture")
+
+	s.makeFakeGrubEFINativeEnv(c, []byte(`this is
+some random boot config`))
+
+	opts := &bootloader.Options{NoSlashBoot: true}
+	g := bootloader.NewGrub(s.rootdir, opts)
+	c.Assert(g, NotNil)
+
+	tg, ok := g.(bootloader.TrustedAssetsBootloader)
+	c.Assert(ok, Equals, true)
+
+	ta, err := tg.TrustedAssets()
+	c.Check(err, ErrorMatches, `cannot find grub assets for "non-existing-architecture"`)
+	c.Check(ta, HasLen, 0)
 }
 
 func (s *grubTestSuite) TestListManagedAssets(c *C) {

--- a/overlord/devicestate/devicestate_install_api_test.go
+++ b/overlord/devicestate/devicestate_install_api_test.go
@@ -338,7 +338,7 @@ func (s *deviceMgrInstallAPISuite) testInstallFinishStep(c *C, opts finishStepOp
 
 	s.state.Lock()
 	defer s.state.Unlock()
-	c.Check(chg.Err(), IsNil)
+	c.Assert(chg.Err(), IsNil)
 
 	// Checks now
 	kernelDir := filepath.Join(dirs.SnapRunDir, "snap-content/kernel")

--- a/overlord/devicestate/devicestate_install_api_test.go
+++ b/overlord/devicestate/devicestate_install_api_test.go
@@ -28,6 +28,9 @@ import (
 	"os/exec"
 	"path/filepath"
 
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/arch"
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/assertstest"
 	"github.com/snapcore/snapd/asserts/sysdb"
@@ -47,7 +50,6 @@ import (
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
 	"github.com/snapcore/snapd/timings"
-	. "gopkg.in/check.v1"
 )
 
 type deviceMgrInstallAPISuite struct {
@@ -216,6 +218,11 @@ func (s *deviceMgrInstallAPISuite) testInstallFinishStep(c *C, opts finishStepOp
 	// TODO UC case when supported
 	restore := release.MockOnClassic(opts.isClassic)
 	s.AddCleanup(restore)
+
+	// only amd64/arm64 have trusted boot assets
+	oldArch := arch.DpkgArchitecture()
+	defer arch.SetArchitecture(arch.ArchitectureType(oldArch))
+	arch.SetArchitecture("amd64")
 
 	// Mock label
 	label := "classic"


### PR DESCRIPTION
The ubuntu-18.04-32 tests are currently failing because the TestInstallFinishEncryptionHappy cannot find trusted boot assets for grub on non {amd,arm}64 platforms. The error is extremely indirect because the code in the bootloader just returns an empty struct. Hence in addition to fixing the test the code is now also more robust when asking for non-existing boot assets in grub.go.