### PR TITLE
tests/main/snapd-apparmor: make log parsing more robust

### DIFF
--- a/tests/main/snapd-apparmor/task.yaml
+++ b/tests/main/snapd-apparmor/task.yaml
@@ -55,7 +55,7 @@ execute: |
     systemctl restart snapd.apparmor.service
 
     # check that logging from snapd-apparmor works
-    journalctl -u snapd.apparmor | MATCH "Loading profiles "
+    "$TESTSTOOLS"/journal-state match-log "Loading profiles " -u snapd.apparmor
 
     # get the set of profiles which now exist
     grep -v / /sys/kernel/security/apparmor/profiles | cut -f1 -d" " | sort > profiles_after_reload.txt


### PR DESCRIPTION
This line of the test would be succeeding even if no additional output was emitted by snapd-apparmor, if th expected line was already present in the logs (maybe written at boot time or by some other test).

Use the `journal-state` program to read the logs, since it uses a cursor to limit the search to the logs emitted during the current test execution.

It also comes with a retry mechanism that can help to make the test more robust.
