### PR TITLE
interfaces: simplify the InstallCandidateMinimalCheck to help expressivity

### DIFF
--- a/interfaces/builtin/shared_memory.go
+++ b/interfaces/builtin/shared_memory.go
@@ -91,9 +91,10 @@ const sharedMemoryBaseDeclarationSlots = `
         - app
         - gadget
         - core
-      slot-snap-id:
-        - PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
-        - 99T7MUlRhtI3U0QFgl5mXXESAiSwt776
+    deny-installation:
+      slot-snap-type:
+        - app
+        - gadget
     deny-auto-connection: true
 `
 

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -901,7 +901,7 @@ func (s *baseDeclSuite) TestSlotInstallation(c *C) {
 	ic = s.installSlotCand(c, "shared-memory", snap.TypeApp, ``)
 	err = ic.Check()
 	c.Assert(err, Not(IsNil))
-	c.Assert(err, ErrorMatches, "installation not allowed by \"shared-memory\" slot rule of interface \"shared-memory\"")
+	c.Assert(err, ErrorMatches, "installation denied by \"shared-memory\" slot rule of interface \"shared-memory\"")
 
 	// The core and snapd snaps may provide a shared-memory slot
 	ic = s.installSlotCand(c, "shared-memory", snap.TypeOS, `name: core

--- a/interfaces/policy/policy.go
+++ b/interfaces/policy/policy.go
@@ -288,10 +288,11 @@ type InstallCandidateMinimalCheck struct {
 }
 
 func (ic *InstallCandidateMinimalCheck) checkSlotRule(slot *snap.SlotInfo, rule *asserts.SlotRule) error {
-	if hasConstraints, err := checkMinimalSlotInstallationAltConstraints(slot, rule.DenyInstallation); hasConstraints && err == nil {
-		return fmt.Errorf("installation denied by %q slot rule of interface %q", slot.Name, slot.Interface)
-	}
-
+	// we use the allow-installation to check if the snap type
+	// is expected to have this kind of slot at all,
+	// the potential deny-installation is ignored here, but allows
+	// to for example constraint super-privileged app-provided slots
+	// while letting user test them locally with --dangerous
 	// TODO check that the snap is an app or gadget if allow-installation had no slot-snap-type constraints
 	if _, err := checkMinimalSlotInstallationAltConstraints(slot, rule.AllowInstallation); err != nil {
 		return fmt.Errorf("installation not allowed by %q slot rule of interface %q", slot.Name, slot.Interface)

--- a/interfaces/policy/policy_test.go
+++ b/interfaces/policy/policy_test.go
@@ -1617,7 +1617,7 @@ version: 0
 type: gadget
 slots:
   install-slot-or:
-`, `installation denied by "install-slot-or" slot rule.*`},
+`, ""}, // we ignore deny-installation rules for the purpose of the minimal check
 		{`name: install-snap
 version: 0
 slots:
@@ -2857,8 +2857,9 @@ slots:
       slot-snap-type:
         - app
         - core
-      slot-snap-id:
-        - PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
+    deny-installation:
+      slot-snap-type:
+        - app
 timestamp: 2022-03-20T12:00:00Z
 sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij
 
@@ -2945,8 +2946,9 @@ plugs:
       plug-snap-type:
         - app
         - core
-      plug-snap-id:
-        - PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
+    deny-installation:
+      plug-snap-type:
+        - app
 timestamp: 2022-03-20T12:00:00Z
 sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij
 
@@ -2964,6 +2966,8 @@ plugs:
 `, nil)
 
 	// ok with dangerous
+	// NB: so far InstallCandidateMinimalCheck simply does not consider
+	// plugs
 	minCand := policy.InstallCandidateMinimalCheck{
 		Snap:            appSnap,
 		BaseDeclaration: baseDecl,


### PR DESCRIPTION
mostly purely for consistency the InstallCandidateMinimalCheck so far took into account both the the allow-installation and deny-installation constraints but only for their snap types and on-classic constraints

so far nothing in the base-declaration was using deny-installation though

switch to ignore deny-installation in the minimal check, this let us express super-privileged app-provided slots even in cases where there can also be system slots while supporting installation via --dangerous as app gets listed in the allow-installation side
