### PR TITLE
tests/core20-early-config: change watchdog timeout

### DIFF
--- a/tests/nested/manual/core20-early-config/defaults.yaml
+++ b/tests/nested/manual/core20-early-config/defaults.yaml
@@ -6,7 +6,7 @@ defaults:
       console-conf:
         disable: true
     watchdog:
-      runtime-timeout: 13m
+      runtime-timeout: 1m
     system:
       power-key-action: ignore
       ctrl-alt-del-action: none

--- a/tests/nested/manual/core20-early-config/defaults.yaml
+++ b/tests/nested/manual/core20-early-config/defaults.yaml
@@ -6,7 +6,8 @@ defaults:
       console-conf:
         disable: true
     watchdog:
-      runtime-timeout: 1m
+      # nested test uses iTCO_wdt with a maxmium timeout of 613s so stay below
+      runtime-timeout: 10m
     system:
       power-key-action: ignore
       ctrl-alt-del-action: none

--- a/tests/nested/manual/core20-early-config/task.yaml
+++ b/tests/nested/manual/core20-early-config/task.yaml
@@ -43,14 +43,14 @@ execute: |
         # that defaults were applied early - that is checked further down.
         echo "Precondition check of the gadget defaults"
         remote.exec "sudo snap get system service.rsyslog.disable" | MATCH "true"
-        remote.exec "sudo snap get system watchdog.runtime-timeout" | MATCH "13m"
+        remote.exec "sudo snap get system watchdog.runtime-timeout" | MATCH "1m"
         remote.exec "sudo snap get system system.power-key-action" | MATCH "ignore"
         remote.exec "sudo snap get system system.ctrl-alt-del-action" | MATCH "none"
         remote.exec "sudo snap get system system.disable-backlight-service" | MATCH "true"
 
         remote.exec "test -L /etc/systemd/system/rsyslog.service"
         remote.exec "cat /etc/systemd/logind.conf.d/00-snap-core.conf" | MATCH "HandlePowerKey=ignore"
-        remote.exec "cat /etc/systemd/system.conf.d/10-snapd-watchdog.conf" | MATCH "RuntimeWatchdogSec=780"
+        remote.exec "cat /etc/systemd/system.conf.d/10-snapd-watchdog.conf" | MATCH "RuntimeWatchdogSec=60"
         remote.exec "test -L /etc/systemd/system/systemd-backlight@.service"
 
         echo "Test that defaults were applied early."

--- a/tests/nested/manual/core20-early-config/task.yaml
+++ b/tests/nested/manual/core20-early-config/task.yaml
@@ -43,14 +43,16 @@ execute: |
         # that defaults were applied early - that is checked further down.
         echo "Precondition check of the gadget defaults"
         remote.exec "sudo snap get system service.rsyslog.disable" | MATCH "true"
-        remote.exec "sudo snap get system watchdog.runtime-timeout" | MATCH "1m"
+        remote.exec "sudo snap get system watchdog.runtime-timeout" | MATCH "10m"
         remote.exec "sudo snap get system system.power-key-action" | MATCH "ignore"
         remote.exec "sudo snap get system system.ctrl-alt-del-action" | MATCH "none"
         remote.exec "sudo snap get system system.disable-backlight-service" | MATCH "true"
 
         remote.exec "test -L /etc/systemd/system/rsyslog.service"
         remote.exec "cat /etc/systemd/logind.conf.d/00-snap-core.conf" | MATCH "HandlePowerKey=ignore"
-        remote.exec "cat /etc/systemd/system.conf.d/10-snapd-watchdog.conf" | MATCH "RuntimeWatchdogSec=60"
+        remote.exec "cat /etc/systemd/system.conf.d/10-snapd-watchdog.conf" | MATCH "RuntimeWatchdogSec=600"
+        # ensure it was possible to set the timeout
+        remote.exec "sudo journalctl" | NOMATCH "Failed to set timeout to"
         remote.exec "test -L /etc/systemd/system/systemd-backlight@.service"
 
         echo "Test that defaults were applied early."


### PR DESCRIPTION
As the previous value was too high and systemd complained.
