### PR TITLE
tests: update mount-ns test for new tmpdir handling

### DIFF
--- a/tests/main/mount-ns/google.ubuntu-16.04-64/PER-SNAP-16.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-16.04-64/PER-SNAP-16.expected.txt
@@ -51,7 +51,7 @@
 +0:+1 / /sys/kernel/debug rw,relatime master:+1 - debugfs debugfs rw
 +0:+1 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime master:+1 - securityfs securityfs rw
 -1:-32 /tmp /tmp rw,relatime master:-39 - ext4 /dev/sda1 rw,data=ordered
-+0:+0 /tmp/snap.test-snapd-mountinfo-core16/tmp /tmp rw,relatime - ext4 /dev/sda1 rw,data=ordered
++0:+0 /tmp/snap-private-tmp/snap.test-snapd-mountinfo-core16/tmp /tmp rw,relatime - ext4 /dev/sda1 rw,data=ordered
 +1:+34 / /usr/share/gdb rw,relatime - tmpfs tmpfs rw,mode=755
 +1:-34 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime master:17 - squashfs /dev/loop0 ro
 -1:+35 / /usr/share/gdb/test rw,relatime - tmpfs tmpfs rw

--- a/tests/main/mount-ns/google.ubuntu-16.04-64/PER-SNAP-18.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-16.04-64/PER-SNAP-18.expected.txt
@@ -51,7 +51,7 @@
 +0:+1 / /sys/kernel/debug rw,relatime master:+1 - debugfs debugfs rw
 +0:+1 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime master:+1 - securityfs securityfs rw
 -1:-32 /tmp /tmp rw,relatime master:-39 - ext4 /dev/sda1 rw,data=ordered
-+0:+0 /tmp/snap.test-snapd-mountinfo-core18/tmp /tmp rw,relatime - ext4 /dev/sda1 rw,data=ordered
++0:+0 /tmp/snap-private-tmp/snap.test-snapd-mountinfo-core18/tmp /tmp rw,relatime - ext4 /dev/sda1 rw,data=ordered
 +2:+0 /usr/lib/snapd /usr/lib/snapd ro,nodev,relatime master:17 - squashfs /dev/loop0 ro
 -1:+34 / /usr/share/gdb rw,relatime - tmpfs tmpfs rw,mode=755
 +1:-33 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime master:18 - squashfs /dev/loop1 ro

--- a/tests/main/mount-ns/google.ubuntu-16.04-64/PER-USER-16.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-16.04-64/PER-USER-16.expected.txt
@@ -51,7 +51,7 @@
 +0:+1 / /sys/kernel/debug rw,relatime master:+1 - debugfs debugfs rw
 +0:+1 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime master:+1 - securityfs securityfs rw
 -1:-32 /tmp /tmp rw,relatime master:-39 - ext4 /dev/sda1 rw,data=ordered
-+0:+0 /tmp/snap.test-snapd-mountinfo-core16/tmp /tmp rw,relatime - ext4 /dev/sda1 rw,data=ordered
++0:+0 /tmp/snap-private-tmp/snap.test-snapd-mountinfo-core16/tmp /tmp rw,relatime - ext4 /dev/sda1 rw,data=ordered
 +1:+34 / /usr/share/gdb rw,relatime - tmpfs tmpfs rw,mode=755
 +1:-34 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime master:17 - squashfs /dev/loop0 ro
 -1:+35 / /usr/share/gdb/test rw,relatime - tmpfs tmpfs rw

--- a/tests/main/mount-ns/google.ubuntu-16.04-64/PER-USER-18.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-16.04-64/PER-USER-18.expected.txt
@@ -51,7 +51,7 @@
 +0:+1 / /sys/kernel/debug rw,relatime master:+1 - debugfs debugfs rw
 +0:+1 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime master:+1 - securityfs securityfs rw
 -1:-32 /tmp /tmp rw,relatime master:-39 - ext4 /dev/sda1 rw,data=ordered
-+0:+0 /tmp/snap.test-snapd-mountinfo-core18/tmp /tmp rw,relatime - ext4 /dev/sda1 rw,data=ordered
++0:+0 /tmp/snap-private-tmp/snap.test-snapd-mountinfo-core18/tmp /tmp rw,relatime - ext4 /dev/sda1 rw,data=ordered
 +2:+0 /usr/lib/snapd /usr/lib/snapd ro,nodev,relatime master:17 - squashfs /dev/loop0 ro
 -1:+34 / /usr/share/gdb rw,relatime - tmpfs tmpfs rw,mode=755
 +1:-33 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime master:18 - squashfs /dev/loop1 ro

--- a/tests/main/mount-ns/google.ubuntu-18.04-64/PER-SNAP-16.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-18.04-64/PER-SNAP-16.expected.txt
@@ -54,7 +54,7 @@
 +0:+1 / /sys/kernel/debug rw,relatime master:+1 - debugfs debugfs rw
 +0:+1 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime master:+1 - securityfs securityfs rw
 -1:-33 /tmp /tmp rw,relatime master:-40 - ext4 /dev/sda1 rw
-+0:+0 /tmp/snap.test-snapd-mountinfo-core16/tmp /tmp rw,relatime - ext4 /dev/sda1 rw
++0:+0 /tmp/snap-private-tmp/snap.test-snapd-mountinfo-core16/tmp /tmp rw,relatime - ext4 /dev/sda1 rw
 +1:+35 / /usr/share/gdb rw,relatime - tmpfs tmpfs rw,mode=755
 +1:-35 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
 -1:+36 / /usr/share/gdb/test rw,relatime - tmpfs tmpfs rw

--- a/tests/main/mount-ns/google.ubuntu-18.04-64/PER-SNAP-18.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-18.04-64/PER-SNAP-18.expected.txt
@@ -54,7 +54,7 @@
 +0:+1 / /sys/kernel/debug rw,relatime master:+1 - debugfs debugfs rw
 +0:+1 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime master:+1 - securityfs securityfs rw
 -1:-33 /tmp /tmp rw,relatime master:-40 - ext4 /dev/sda1 rw
-+0:+0 /tmp/snap.test-snapd-mountinfo-core18/tmp /tmp rw,relatime - ext4 /dev/sda1 rw
++0:+0 /tmp/snap-private-tmp/snap.test-snapd-mountinfo-core18/tmp /tmp rw,relatime - ext4 /dev/sda1 rw
 +2:+0 /usr/lib/snapd /usr/lib/snapd ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
 -1:+35 / /usr/share/gdb rw,relatime - tmpfs tmpfs rw,mode=755
 +1:-34 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime master:17 - squashfs /dev/loop1 ro

--- a/tests/main/mount-ns/google.ubuntu-18.04-64/PER-USER-16.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-18.04-64/PER-USER-16.expected.txt
@@ -54,7 +54,7 @@
 +0:+1 / /sys/kernel/debug rw,relatime master:+1 - debugfs debugfs rw
 +0:+1 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime master:+1 - securityfs securityfs rw
 -1:-33 /tmp /tmp rw,relatime master:-40 - ext4 /dev/sda1 rw
-+0:+0 /tmp/snap.test-snapd-mountinfo-core16/tmp /tmp rw,relatime - ext4 /dev/sda1 rw
++0:+0 /tmp/snap-private-tmp/snap.test-snapd-mountinfo-core16/tmp /tmp rw,relatime - ext4 /dev/sda1 rw
 +1:+35 / /usr/share/gdb rw,relatime - tmpfs tmpfs rw,mode=755
 +1:-35 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
 -1:+36 / /usr/share/gdb/test rw,relatime - tmpfs tmpfs rw

--- a/tests/main/mount-ns/google.ubuntu-18.04-64/PER-USER-18.expected.txt
+++ b/tests/main/mount-ns/google.ubuntu-18.04-64/PER-USER-18.expected.txt
@@ -54,7 +54,7 @@
 +0:+1 / /sys/kernel/debug rw,relatime master:+1 - debugfs debugfs rw
 +0:+1 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime master:+1 - securityfs securityfs rw
 -1:-33 /tmp /tmp rw,relatime master:-40 - ext4 /dev/sda1 rw
-+0:+0 /tmp/snap.test-snapd-mountinfo-core18/tmp /tmp rw,relatime - ext4 /dev/sda1 rw
++0:+0 /tmp/snap-private-tmp/snap.test-snapd-mountinfo-core18/tmp /tmp rw,relatime - ext4 /dev/sda1 rw
 +2:+0 /usr/lib/snapd /usr/lib/snapd ro,nodev,relatime master:16 - squashfs /dev/loop0 ro
 -1:+35 / /usr/share/gdb rw,relatime - tmpfs tmpfs rw,mode=755
 +1:-34 /usr/share/gdb/auto-load /usr/share/gdb/auto-load ro,nodev,relatime master:17 - squashfs /dev/loop1 ro


### PR DESCRIPTION
With commit a9812c467597159dd7fdbbb2da16b41c1a002962 we changed the location of the private tmp directory in snaps. Update the mount-ns test accordingly.

Note that the test is currently executed for Ubuntu 18.04 only. We should probably extend it to newer distros and decide what to do with 16.04.