### PR TITLE
tests: add ensure-state-soon to snapd-reexec-snap test

### DIFF
--- a/tests/main/snapd-reexec-snapd-snap/task.yaml
+++ b/tests/main/snapd-reexec-snapd-snap/task.yaml
@@ -27,8 +27,9 @@ execute: |
 
     echo "Enable installing the snapd snap, this happens automatically"
     snap set core experimental.snapd-snap=true
-    # give the state time to create the change and then start watching
-    # it
+    echo "Ensure transition"
+    snap debug ensure-state-soon
+    # give the state time to create the change and then start watching it
     retry -n 30 snap watch --last=transition-to-snapd-snap
     snap list snapd
 


### PR DESCRIPTION
This is needed to make sure the transition is triggered immediately after experimental.snapd-snap=true

This is needed because sometimes it is taking more than 4 minutes to start the transition and the test is just waiting for 30 seconds. 
