### PR TITLE
tests: fix date and makefile for systemd-tmpfiles in snapd.spec

### DIFF
--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -696,7 +696,8 @@ pushd ./data
 %make_install BINDIR="%{_bindir}" LIBEXECDIR="%{_libexecdir}" DATADIR="%{_datadir}" \
               SYSTEMDSYSTEMUNITDIR="%{_unitdir}" SYSTEMDUSERUNITDIR="%{_userunitdir}" \
               SNAP_MOUNT_DIR="%{_sharedstatedir}/snapd/snap" \
-              SNAPD_ENVIRONMENT_FILE="%{_sysconfdir}/sysconfig/snapd"
+              SNAPD_ENVIRONMENT_FILE="%{_sysconfdir}/sysconfig/snapd" \
+              TMPFILESDIR="%{_tmpfilesdir}"
 popd
 
 %if 0%{?rhel} == 7
@@ -4229,7 +4230,7 @@ fi
    1.11 update
  - cmd/snap-bootstrap, secboot, tests: misc cleanups, add spread test
 
-* Thu Dec 15 2020 Michael Vogt <mvo@ubuntu.com>
+* Tue Dec 15 2020 Michael Vogt <mvo@ubuntu.com>
 - New upstream release 2.48.2
  - tests: sign new nested-18|20* models to allow for generic serials
  - secboot: add extra paranoia when waiting for that fde-reveal-key

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -272,11 +272,12 @@ done
 %install
 # Install all systemd and dbus units, and env files.
 %make_install -C %{indigo_srcdir}/data \
-		BINDIR=%{_bindir} \
-		LIBEXECDIR=%{_libexecdir} \
-		DATADIR=%{_datadir} \
-		SYSTEMDSYSTEMUNITDIR=%{_unitdir} \
-		SNAP_MOUNT_DIR=%{snap_mount_dir}
+        BINDIR=%{_bindir} \
+        LIBEXECDIR=%{_libexecdir} \
+        DATADIR=%{_datadir} \
+        SYSTEMDSYSTEMUNITDIR=%{_unitdir} \
+        SNAP_MOUNT_DIR=%{snap_mount_dir} \
+        TMPFILESDIR="%{_tmpfilesdir}"
 # Install all the C executables.
 %make_install -C %{indigo_srcdir}/cmd
 # Use the common packaging helper for bulk of installation.


### PR DESCRIPTION
Changes:

. Update the date in the changelog to the correct format. 
. Use the correct TMPFILESDIR var in the Makefile

This is needed to fix systems where libexec is /usr/libexec instead of /usr/lib

