### PR TITLE
overlord/*: make SnapServiceOptions take snap.Info instead of the instanceName

### DIFF
--- a/overlord/configstate/configcore/vitality.go
+++ b/overlord/configstate/configcore/vitality.go
@@ -127,7 +127,7 @@ func handleVitalityConfiguration(tr config.Conf, opts *fsOnlyContext) error {
 		}
 
 		// get the options for this snap service
-		snapSvcOpts, err := servicestate.SnapServiceOptions(st, instanceName, grps)
+		snapSvcOpts, err := servicestate.SnapServiceOptions(st, info, grps)
 		if err != nil {
 			return err
 		}

--- a/overlord/ifacestate/handlers_test.go
+++ b/overlord/ifacestate/handlers_test.go
@@ -131,7 +131,7 @@ func (s *handlersSuite) TestBuildConfinementOptions(c *C) {
 
 	snapInfo := mockInstalledSnap(c, s.st, snapAyaml)
 	flags := snapstate.Flags{}
-	opts, err := ifacestate.BuildConfinementOptions(s.st, snapInfo.InstanceName(), snapstate.Flags{})
+	opts, err := ifacestate.BuildConfinementOptions(s.st, snapInfo, snapstate.Flags{})
 
 	c.Check(err, IsNil)
 	c.Check(len(opts.ExtraLayouts), Equals, 0)
@@ -155,7 +155,7 @@ func (s *handlersSuite) TestBuildConfinementOptionsWithLogNamespace(c *C) {
 	c.Assert(err, IsNil)
 
 	flags := snapstate.Flags{}
-	opts, err := ifacestate.BuildConfinementOptions(s.st, snapInfo.InstanceName(), snapstate.Flags{})
+	opts, err := ifacestate.BuildConfinementOptions(s.st, snapInfo, snapstate.Flags{})
 
 	c.Check(err, IsNil)
 	c.Assert(len(opts.ExtraLayouts), Equals, 1)

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -189,8 +189,14 @@ func (m *InterfaceManager) regenerateAllSecurityProfiles(tm timings.Measurer) er
 		var snapst snapstate.SnapState
 		if err := snapstate.Get(m.state, snapName, &snapst); err != nil {
 			logger.Noticef("cannot get state of snap %q: %s", snapName, err)
+			return interfaces.ConfinementOptions{}
 		}
-		opts, err := buildConfinementOptions(m.state, snapst.InstanceName(), snapst.Flags)
+		snapInfo, err := snapst.CurrentInfo()
+		if err != nil {
+			logger.Noticef("cannot get current info for snap %q: %s", snapName, err)
+			return interfaces.ConfinementOptions{}
+		}
+		opts, err := buildConfinementOptions(m.state, snapInfo, snapst.Flags)
 		if err != nil {
 			logger.Noticef("cannot get confinement options for snap %q: %s", snapName, err)
 		}

--- a/overlord/servicestate/quota_handlers.go
+++ b/overlord/servicestate/quota_handlers.go
@@ -593,7 +593,7 @@ func ensureSnapServicesForGroup(st *state.State, t *state.Task, grp *quota.Group
 			return nil, err
 		}
 
-		opts, err := SnapServiceOptions(st, sn, allGrps)
+		opts, err := SnapServiceOptions(st, info, allGrps)
 		if err != nil {
 			return nil, err
 		}

--- a/overlord/servicestate/servicemgr.go
+++ b/overlord/servicestate/servicemgr.go
@@ -136,7 +136,7 @@ func (m *ServiceManager) ensureSnapServicesUpdated() (err error) {
 		}
 
 		// use the cached copy of all quota groups
-		snapSvcOpts, err := SnapServiceOptions(m.state, info.InstanceName(), allGrps)
+		snapSvcOpts, err := SnapServiceOptions(m.state, info, allGrps)
 		if err != nil {
 			return err
 		}

--- a/overlord/servicestate/servicestate.go
+++ b/overlord/servicestate/servicestate.go
@@ -359,12 +359,11 @@ func (sd *StatusDecorator) DecorateWithStatus(appInfo *client.AppInfo, snapApp *
 }
 
 // SnapServiceOptions computes the options to configure services for
-// the given snap. This function might not check for the existence
-// of instanceName. It also takes as argument a map of all quota groups as an
+// the given snap. It also takes as argument a map of all quota groups as an
 // optimization, the map if non-nil is used in place of checking state for
 // whether or not the specified snap is in a quota group or not. If nil, state
 // is consulted directly instead.
-func SnapServiceOptions(st *state.State, instanceName string, quotaGroups map[string]*quota.Group) (opts *wrappers.SnapServiceOptions, err error) {
+func SnapServiceOptions(st *state.State, snapInfo *snap.Info, quotaGroups map[string]*quota.Group) (opts *wrappers.SnapServiceOptions, err error) {
 	// if quotaGroups was not provided to us, then go get that
 	if quotaGroups == nil {
 		allGrps, err := AllQuotas(st)
@@ -383,7 +382,7 @@ func SnapServiceOptions(st *state.State, instanceName string, quotaGroups map[st
 		return nil, err
 	}
 	for i, s := range strings.Split(vitalityStr, ",") {
-		if s == instanceName {
+		if s == snapInfo.InstanceName() {
 			opts.VitalityRank = i + 1
 			break
 		}
@@ -391,7 +390,7 @@ func SnapServiceOptions(st *state.State, instanceName string, quotaGroups map[st
 
 	// also check for quota group for this instance name
 	for _, grp := range quotaGroups {
-		if strutil.ListContains(grp.Snaps, instanceName) {
+		if strutil.ListContains(grp.Snaps, snapInfo.InstanceName()) {
 			opts.QuotaGroup = grp
 			break
 		}

--- a/overlord/servicestate/servicestate_test.go
+++ b/overlord/servicestate/servicestate_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/quota"
+	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/systemd"
 	"github.com/snapcore/snapd/testutil"
 	"github.com/snapcore/snapd/wrappers"
@@ -292,17 +293,21 @@ func (s *snapServiceOptionsSuite) TestSnapServiceOptionsVitalityRank(c *C) {
 	c.Assert(err, IsNil)
 	t.Commit()
 
-	opts, err := servicestate.SnapServiceOptions(st, "foo", nil)
+	fooInfo := snaptest.MockInfo(c, "name: foo\nversion: 0", nil)
+	barInfo := snaptest.MockInfo(c, "name: bar\nversion: 0", nil)
+	bazInfo := snaptest.MockInfo(c, "name: baz\nversion: 0", nil)
+
+	opts, err := servicestate.SnapServiceOptions(st, fooInfo, nil)
 	c.Assert(err, IsNil)
 	c.Check(opts, DeepEquals, &wrappers.SnapServiceOptions{
 		VitalityRank: 2,
 	})
-	opts, err = servicestate.SnapServiceOptions(st, "bar", nil)
+	opts, err = servicestate.SnapServiceOptions(st, barInfo, nil)
 	c.Assert(err, IsNil)
 	c.Check(opts, DeepEquals, &wrappers.SnapServiceOptions{
 		VitalityRank: 1,
 	})
-	opts, err = servicestate.SnapServiceOptions(st, "unknown", nil)
+	opts, err = servicestate.SnapServiceOptions(st, bazInfo, nil)
 	c.Assert(err, IsNil)
 	c.Check(opts, DeepEquals, &wrappers.SnapServiceOptions{
 		VitalityRank: 0,
@@ -313,6 +318,11 @@ func (s *snapServiceOptionsSuite) TestSnapServiceOptionsQuotaGroups(c *C) {
 	st := s.state
 	st.Lock()
 	defer st.Unlock()
+
+	fooInfo := snaptest.MockInfo(c, `
+name: foosnap
+version: 0
+`, nil)
 
 	// make a quota group
 	grp, err := quota.NewGroup("foogroup", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
@@ -327,7 +337,7 @@ func (s *snapServiceOptionsSuite) TestSnapServiceOptionsQuotaGroups(c *C) {
 		"foogroup": grp,
 	})
 
-	opts, err := servicestate.SnapServiceOptions(st, "foosnap", nil)
+	opts, err := servicestate.SnapServiceOptions(st, fooInfo, nil)
 	c.Assert(err, IsNil)
 	c.Check(opts, DeepEquals, &wrappers.SnapServiceOptions{
 		QuotaGroup: grp,
@@ -348,7 +358,7 @@ func (s *snapServiceOptionsSuite) TestSnapServiceOptionsQuotaGroups(c *C) {
 
 	// we can still get the quota group using the local map we got before
 	// modifying state
-	opts, err = servicestate.SnapServiceOptions(st, "foosnap", grps)
+	opts, err = servicestate.SnapServiceOptions(st, fooInfo, grps)
 	c.Assert(err, IsNil)
 	grp.Snaps = []string{"foosnap"}
 	c.Check(opts, DeepEquals, &wrappers.SnapServiceOptions{
@@ -356,13 +366,14 @@ func (s *snapServiceOptionsSuite) TestSnapServiceOptionsQuotaGroups(c *C) {
 	})
 
 	// but using state produces nothing for the non-instance name snap
-	opts, err = servicestate.SnapServiceOptions(st, "foosnap", nil)
+	opts, err = servicestate.SnapServiceOptions(st, fooInfo, nil)
 	c.Assert(err, IsNil)
 	c.Check(opts, DeepEquals, &wrappers.SnapServiceOptions{})
 
 	// but it does work with instance names
+	fooInfo.InstanceKey = "instance"
 	grp.Snaps = []string{"foosnap_instance"}
-	opts, err = servicestate.SnapServiceOptions(st, "foosnap_instance", nil)
+	opts, err = servicestate.SnapServiceOptions(st, fooInfo, nil)
 	c.Assert(err, IsNil)
 	c.Check(opts, DeepEquals, &wrappers.SnapServiceOptions{
 		QuotaGroup: grp,
@@ -374,7 +385,7 @@ func (s *snapServiceOptionsSuite) TestSnapServiceOptionsQuotaGroups(c *C) {
 	c.Assert(err, IsNil)
 	t.Commit()
 
-	opts, err = servicestate.SnapServiceOptions(st, "foosnap_instance", nil)
+	opts, err = servicestate.SnapServiceOptions(st, fooInfo, nil)
 	c.Assert(err, IsNil)
 	c.Check(opts, DeepEquals, &wrappers.SnapServiceOptions{
 		VitalityRank: 2,

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -62,7 +62,7 @@ import (
 )
 
 // SnapServiceOptions is a hook set by servicestate.
-var SnapServiceOptions = func(st *state.State, instanceName string, grps map[string]*quota.Group) (opts *wrappers.SnapServiceOptions, err error) {
+var SnapServiceOptions = func(st *state.State, snapInfo *snap.Info, grps map[string]*quota.Group) (opts *wrappers.SnapServiceOptions, err error) {
 	panic("internal error: snapstate.SnapServiceOptions is unset")
 }
 
@@ -1179,7 +1179,7 @@ func (m *SnapManager) undoUnlinkCurrentSnap(t *state.Task, _ *tomb.Tomb) error {
 
 	snapst.Active = true
 
-	opts, err := SnapServiceOptions(st, snapsup.InstanceName(), nil)
+	opts, err := SnapServiceOptions(st, oldInfo, nil)
 	if err != nil {
 		return err
 	}
@@ -1731,7 +1731,7 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (err error) {
 		return err
 	}
 
-	opts, err := SnapServiceOptions(st, snapsup.InstanceName(), nil)
+	opts, err := SnapServiceOptions(st, newInfo, nil)
 	if err != nil {
 		return err
 	}
@@ -2753,7 +2753,7 @@ func (m *SnapManager) undoUnlinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	snapst.Active = true
 	Set(st, snapsup.InstanceName(), snapst)
 
-	opts, err := SnapServiceOptions(st, snapsup.InstanceName(), nil)
+	opts, err := SnapServiceOptions(st, info, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This is in preparation for extending the usage of SnapServiceOptions where we need more info from snap.Info.