### PR TITLE
devicestate: fix unit test failure on non-amd64 systems

### DIFF
--- a/overlord/devicestate/devicestate_install_api_test.go
+++ b/overlord/devicestate/devicestate_install_api_test.go
@@ -300,8 +300,9 @@ func (s *deviceMgrInstallAPISuite) testInstallFinishStep(c *C, opts finishStepOp
 			c.Check(modeenv.CurrentTrustedRecoveryBootAssets["bootx64.efi"], DeepEquals, []string{"0c63a75b845e4f7d01107d852e4c2485c51a50aaaa94fc61995e71bbee983a2ac3713831264adb47fb6bd1e058d5f004"})
 			c.Check(modeenv.CurrentTrustedRecoveryBootAssets["grubx64.efi"], DeepEquals, []string{"0c63a75b845e4f7d01107d852e4c2485c51a50aaaa94fc61995e71bbee983a2ac3713831264adb47fb6bd1e058d5f004"})
 			c.Check(len(modeenv.CurrentKernelCommandLines), Equals, 1)
-			c.Check(modeenv.CurrentKernelCommandLines[0], Equals,
-				"snapd_recovery_mode=run console=ttyS0,115200n8 console=tty1 panic=-1")
+			// exact cmdline depends on arch, see
+			// bootloader/assets/grub.go:init()
+			c.Check(modeenv.CurrentKernelCommandLines[0], testutil.Contains, "snapd_recovery_mode=run")
 			return nil
 		})
 		s.AddCleanup(restore)


### PR DESCRIPTION
The `testInstallFinishStep` test will fail on non-amd64 systems right now because it also matches the generated kernel commandline. This is however architecture depedant and generated in a way that is not easily mockable (right now) because it runs as part of the `init()` in `bootloader/assets/grub.go`.

So instead of using the exact match this commit will just check that the common commandline (`snapd_recovery_mode=run`) is generated and leave the exact match to the unit tests of the `assets` pkg.

This will fix the FTBFS we see in the PPAs right now.
