### PR TITLE
o/servicestate,snap/quota: check against adding the same service twice in quota groups

### DIFF
--- a/overlord/servicestate/quota_control_test.go
+++ b/overlord/servicestate/quota_control_test.go
@@ -726,7 +726,7 @@ func (s *quotaControlSuite) TestUpdateQuotaPrecond(c *C) {
 		{"foo", servicestate.UpdateQuotaOptions{AddSnaps: []string{"baz"}}, `cannot use snap "baz" in group "foo": snap "baz" is not installed`},
 		{"foo", servicestate.UpdateQuotaOptions{AddSnaps: []string{"baz"}, AddServices: []string{"baz.svc"}}, `cannot mix services and snaps in the same quota group`},
 		{"foo", servicestate.UpdateQuotaOptions{AddServices: []string{"baz"}}, `invalid snap service: baz`},
-		{"foo", servicestate.UpdateQuotaOptions{AddServices: []string{"baz.svc"}}, `cannot use snap service "foo": snap "baz" is not installed`},
+		{"foo", servicestate.UpdateQuotaOptions{AddServices: []string{"baz.svc"}}, `cannot add snap service "foo": snap "baz" is not installed`},
 	}
 
 	for _, t := range tests {

--- a/overlord/servicestate/quota_handlers.go
+++ b/overlord/servicestate/quota_handlers.go
@@ -912,8 +912,7 @@ func validateSnapServicesForAddingToGroup(st *state.State, services []string, gr
 		if parentGroup == nil || !strutil.ListContains(parentGroup.Snaps, snap) {
 			return fmt.Errorf("cannot use snap service %q: the snap %q must be in a direct parent group of group %q", service, snap, group)
 		}
-		serviceGrp := parentGroup.GroupForService(name)
-		if serviceGrp != nil {
+		if serviceGrp := parentGroup.GroupForService(name); serviceGrp != nil {
 			return fmt.Errorf("cannot use snap service %q: the service is already in group %q", service, serviceGrp.Name)
 		}
 	}

--- a/overlord/servicestate/quota_handlers.go
+++ b/overlord/servicestate/quota_handlers.go
@@ -907,13 +907,13 @@ func validateSnapServicesForAddingToGroup(st *state.State, services []string, gr
 			return err
 		}
 		if err = ensureAppReferenceIsService(st, snap, service); err != nil {
-			return fmt.Errorf("cannot use snap service %q: %v", group, err)
+			return fmt.Errorf("cannot add snap service %q: %v", group, err)
 		}
 		if parentGroup == nil || !strutil.ListContains(parentGroup.Snaps, snap) {
-			return fmt.Errorf("cannot use snap service %q: the snap %q must be in a direct parent group of group %q", service, snap, group)
+			return fmt.Errorf("cannot add snap service %q: the snap %q must be in a direct parent group of group %q", service, snap, group)
 		}
 		if serviceGrp := parentGroup.GroupForService(name); serviceGrp != nil {
-			return fmt.Errorf("cannot use snap service %q: the service is already in group %q", service, serviceGrp.Name)
+			return fmt.Errorf("cannot add snap service %q: the service is already in group %q", service, serviceGrp.Name)
 		}
 	}
 	return nil

--- a/overlord/servicestate/quota_handlers.go
+++ b/overlord/servicestate/quota_handlers.go
@@ -912,6 +912,10 @@ func validateSnapServicesForAddingToGroup(st *state.State, services []string, gr
 		if parentGroup == nil || !strutil.ListContains(parentGroup.Snaps, snap) {
 			return fmt.Errorf("cannot use snap service %q: the snap %q must be in a direct parent group of group %q", service, snap, group)
 		}
+		serviceGrp := parentGroup.GroupForService(name)
+		if serviceGrp != nil {
+			return fmt.Errorf("cannot use snap service %q: the service is already in group %q", service, serviceGrp.Name)
+		}
 	}
 	return nil
 }

--- a/overlord/servicestate/quota_handlers_test.go
+++ b/overlord/servicestate/quota_handlers_test.go
@@ -1208,7 +1208,7 @@ func (s *quotaHandlersSuite) TestQuotaSnapFailToAddServicesToNewTopGroup(c *C) {
 		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
 		AddServices:    []string{"test-snap.svc1"},
 	})
-	c.Assert(err, ErrorMatches, `cannot use snap service "svc1": the snap "test-snap" must be in a direct parent group of group "foo"`)
+	c.Assert(err, ErrorMatches, `cannot add snap service "svc1": the snap "test-snap" must be in a direct parent group of group "foo"`)
 }
 
 func (s *quotaHandlersSuite) TestQuotaSnapFailToAddServicesToExistingTopGroup(c *C) {
@@ -1234,7 +1234,7 @@ func (s *quotaHandlersSuite) TestQuotaSnapFailToAddServicesToExistingTopGroup(c 
 		QuotaName:   "foo",
 		AddServices: []string{"test-snap.svc1"},
 	})
-	c.Assert(err, ErrorMatches, `cannot use snap service "svc1": the snap "test-snap" must be in a direct parent group of group "foo"`)
+	c.Assert(err, ErrorMatches, `cannot add snap service "svc1": the snap "test-snap" must be in a direct parent group of group "foo"`)
 }
 
 func (s *quotaHandlersSuite) TestQuotaSnapFailToAddServicesToGroupWithSubgroups(c *C) {
@@ -1563,14 +1563,14 @@ func (s *quotaHandlersSuite) TestQuotaSnapAddSnapServicesFailOnInvalidSnapServic
 		QuotaName:   "foo2",
 		AddServices: []string{"test-snap.svc-none"},
 	})
-	c.Assert(err, ErrorMatches, `cannot use snap service "foo2": invalid service "svc-none"`)
+	c.Assert(err, ErrorMatches, `cannot add snap service "foo2": invalid service "svc-none"`)
 
 	err = s.callDoQuotaControl(&servicestate.QuotaControlAction{
 		Action:      "update",
 		QuotaName:   "foo2",
 		AddServices: []string{"no-snap.svc1"},
 	})
-	c.Assert(err, ErrorMatches, `cannot use snap service "foo2": snap "no-snap" is not installed`)
+	c.Assert(err, ErrorMatches, `cannot add snap service "foo2": snap "no-snap" is not installed`)
 
 	// also test adding a valid snap, but the snap is not relevant for this quota group
 	err = s.callDoQuotaControl(&servicestate.QuotaControlAction{
@@ -1578,7 +1578,7 @@ func (s *quotaHandlersSuite) TestQuotaSnapAddSnapServicesFailOnInvalidSnapServic
 		QuotaName:   "foo2",
 		AddServices: []string{"test-snap2.svc1"},
 	})
-	c.Assert(err, ErrorMatches, `cannot use snap service "svc1": the snap "test-snap2" must be in a direct parent group of group "foo2"`)
+	c.Assert(err, ErrorMatches, `cannot add snap service "svc1": the snap "test-snap2" must be in a direct parent group of group "foo2"`)
 
 	// check that the quota groups was created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
@@ -1661,7 +1661,7 @@ func (s *quotaHandlersSuite) TestQuotaSnapAddSnapServicesFailOnServiceTwice(c *C
 		QuotaName:   "foo3",
 		AddServices: []string{"test-snap.svc1"},
 	})
-	c.Assert(err, ErrorMatches, `cannot use snap service "svc1": the service is already in group "foo2"`)
+	c.Assert(err, ErrorMatches, `cannot add snap service "svc1": the service is already in group "foo2"`)
 
 	// check that the quota groups was created in the state
 	checkQuotaState(c, st, map[string]quotaGroupState{
@@ -2751,7 +2751,7 @@ func (s *quotaHandlersSuite) TestValidateSnapServicesForAddingToGroupServiceSnap
 	}
 
 	err := servicestate.ValidateSnapServicesForAddingToGroup(st, []string{"test-snap.svc1"}, "foo2", allQuotas["foo"], allQuotas)
-	c.Assert(err, ErrorMatches, `cannot use snap service "svc1": the snap "test-snap" must be in a direct parent group of group "foo2"`)
+	c.Assert(err, ErrorMatches, `cannot add snap service "svc1": the snap "test-snap" must be in a direct parent group of group "foo2"`)
 }
 
 func (s *quotaHandlersSuite) TestValidateSnapServicesForAddingToGroupInvalidService(c *C) {
@@ -2776,7 +2776,7 @@ func (s *quotaHandlersSuite) TestValidateSnapServicesForAddingToGroupInvalidServ
 	}
 
 	err := servicestate.ValidateSnapServicesForAddingToGroup(st, []string{"test-snap.svc2"}, "foo2", allQuotas["foo"], allQuotas)
-	c.Assert(err, ErrorMatches, `cannot use snap service "foo2": invalid service "svc2"`)
+	c.Assert(err, ErrorMatches, `cannot add snap service "foo2": invalid service "svc2"`)
 }
 
 func (s *quotaHandlersSuite) TestValidateSnapServicesForAddingToGroupHappy(c *C) {

--- a/snap/quota/quota.go
+++ b/snap/quota/quota.go
@@ -34,6 +34,7 @@ import (
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/snap/naming"
+	"github.com/snapcore/snapd/strutil"
 	"github.com/snapcore/snapd/systemd"
 )
 
@@ -301,6 +302,18 @@ func (grp *Group) JournalServiceDropInDir() string {
 // file for the quota group.
 func (grp *Group) JournalServiceDropInFile() string {
 	return filepath.Join(grp.JournalServiceDropInDir(), "00-snap.conf")
+}
+
+// GroupForService returns the quota group for the given
+// service name if found in one of the sub-groups of the current group. If the
+// service is not found, this will return nil.
+func (grp *Group) GroupForService(serviceName string) *Group {
+	for _, subgrp := range grp.subGroups {
+		if strutil.ListContains(subgrp.Services, serviceName) {
+			return subgrp
+		}
+	}
+	return nil
 }
 
 // groupQuotaAllocations contains information about current quotas of a group


### PR DESCRIPTION
The function `GroupForService` is also needed by https://github.com/snapcore/snapd/pull/12395