### PR TITLE
o/servicestate: disallow mixing journal quotas and services

### DIFF
--- a/overlord/servicestate/quota_control.go
+++ b/overlord/servicestate/quota_control.go
@@ -257,8 +257,7 @@ func UpdateQuota(st *state.State, name string, updateOpts UpdateQuotaOptions) (*
 		return nil, fmt.Errorf("group %q does not exist", name)
 	}
 
-	currentQuotas := grp.GetQuotaResources()
-	if err := currentQuotas.ValidateChange(updateOpts.NewResourceLimits); err != nil {
+	if err := validateQuotaLimitsChange(grp, updateOpts.NewResourceLimits); err != nil {
 		return nil, fmt.Errorf("cannot update group %q: %v", name, err)
 	}
 	// validate that the system has the features needed for this resource

--- a/overlord/servicestate/quota_control.go
+++ b/overlord/servicestate/quota_control.go
@@ -257,7 +257,8 @@ func UpdateQuota(st *state.State, name string, updateOpts UpdateQuotaOptions) (*
 		return nil, fmt.Errorf("group %q does not exist", name)
 	}
 
-	if err := validateQuotaLimitsChange(grp, updateOpts.NewResourceLimits); err != nil {
+	currentQuotas := grp.GetQuotaResources()
+	if err := validateQuotaLimitsChange(grp, currentQuotas, updateOpts.NewResourceLimits); err != nil {
 		return nil, fmt.Errorf("cannot update group %q: %v", name, err)
 	}
 	// validate that the system has the features needed for this resource

--- a/overlord/servicestate/quota_handlers.go
+++ b/overlord/servicestate/quota_handlers.go
@@ -488,12 +488,23 @@ func quotaRemove(st *state.State, action QuotaControlAction, allGrps map[string]
 	return grp, allGrps, refreshProfiles, nil
 }
 
-func quotaUpdateGroupLimits(grp *quota.Group, limits quota.Resources) error {
+func validateQuotaLimitsChange(grp *quota.Group, limits quota.Resources) error {
 	// Do not allow setting a journal limit on any group which has
 	// services in them. Due to mounts being generated per-snap we cannot
 	// support per-service journal namespaces currently.
 	if limits.Journal != nil && len(grp.Services) > 0 {
-		return fmt.Errorf("cannot update limits for group %q: journal quotas are not supported for individual services", grp.Name)
+		return fmt.Errorf("journal quotas are not supported for individual services")
+	}
+	currentQuotas := grp.GetQuotaResources()
+	if err := currentQuotas.ValidateChange(limits); err != nil {
+		return err
+	}
+	return nil
+}
+
+func quotaUpdateGroupLimits(grp *quota.Group, limits quota.Resources) error {
+	if err := validateQuotaLimitsChange(grp, limits); err != nil {
+		return fmt.Errorf("cannot update limits for group %q: %v", grp.Name, err)
 	}
 
 	currentQuotas := grp.GetQuotaResources()

--- a/overlord/servicestate/quota_handlers_test.go
+++ b/overlord/servicestate/quota_handlers_test.go
@@ -1272,6 +1272,41 @@ func (s *quotaHandlersSuite) TestQuotaSnapFailToAddServicesToGroupWithSubgroups(
 	c.Assert(err, ErrorMatches, `cannot mix services and sub groups in the group "foo"`)
 }
 
+func (s *quotaHandlersSuite) TestQuotaSnapFailToAddServicesToGroupWithJournalQuota(c *C) {
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	// setup the snap so it exists
+	snapstate.Set(s.state, "test-snap", s.testSnapState)
+	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
+
+	// Create root group
+	err := s.callDoQuotaControl(&servicestate.QuotaControlAction{
+		Action:         "create",
+		QuotaName:      "foo",
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
+	})
+	c.Assert(err, IsNil)
+
+	// Create a sub-group for foo with a journal limit set
+	err = s.callDoQuotaControl(&servicestate.QuotaControlAction{
+		Action:         "create",
+		QuotaName:      "foo2",
+		ResourceLimits: quota.NewResourcesBuilder().WithJournalNamespace().Build(),
+		ParentName:     "foo",
+	})
+	c.Assert(err, IsNil)
+
+	// Try to add services to that sub-group
+	err = s.callDoQuotaControl(&servicestate.QuotaControlAction{
+		Action:      "update",
+		QuotaName:   "foo2",
+		AddServices: []string{"test-snap.svc1"},
+	})
+	c.Assert(err, ErrorMatches, `cannot put services into group "foo2": journal quotas are not supported for individual services`)
+}
+
 func (s *quotaHandlersSuite) TestQuotaSnapAddSnapServices(c *C) {
 	r := s.mockSystemctlCalls(c, join(
 		[]expectedSystemctl{{expArgs: []string{"daemon-reload"}}},
@@ -1999,6 +2034,49 @@ func (s *quotaHandlersSuite) TestQuotaUpdateChangeMemLimit(c *C) {
 	}
 	err = s.callDoQuotaControl(&qc3)
 	c.Assert(err, ErrorMatches, "cannot update limits for group \"foo\": cannot decrease memory limit, remove and re-create it to decrease the limit")
+}
+
+func (s *quotaHandlersSuite) TestQuotaUpdateJournalQuotaNotAllowedForServices(c *C) {
+	r := s.mockSystemctlCalls(c, join(
+		// CreateQuota for foo
+		systemctlCallsForCreateQuota("foo", "test-snap"),
+	))
+	defer r()
+
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	// setup the snap so it exists
+	snapstate.Set(s.state, "test-snap", s.testSnapState)
+	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
+
+	// create a quota group with the test snap
+	err := s.callDoQuotaControl(&servicestate.QuotaControlAction{
+		Action:         "create",
+		QuotaName:      "foo",
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
+		AddSnaps:       []string{"test-snap"},
+	})
+	c.Assert(err, IsNil)
+
+	// create the sub-group which contain just the service
+	err = s.callDoQuotaControl(&servicestate.QuotaControlAction{
+		Action:         "create",
+		QuotaName:      "foo2",
+		ParentName:     "foo",
+		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB / 2).Build(),
+		AddServices:    []string{"test-snap.svc1"},
+	})
+	c.Assert(err, IsNil)
+
+	// try to impose the journal quota on the sub-group that contains services
+	err = s.callDoQuotaControl(&servicestate.QuotaControlAction{
+		Action:         "update",
+		QuotaName:      "foo2",
+		ResourceLimits: quota.NewResourcesBuilder().WithJournalNamespace().Build(),
+	})
+	c.Assert(err, ErrorMatches, `cannot update limits for group "foo2": journal quotas are not supported for individual services`)
 }
 
 func (s *quotaHandlersSuite) TestCreateJournalQuota(c *C) {

--- a/snap/quota/quota.go
+++ b/snap/quota/quota.go
@@ -809,6 +809,12 @@ func (grp *Group) validate() error {
 			}
 		}
 	}
+
+	// We don't support mixing services and the journal quota, the journal quota
+	// must be applied to the parent group, and services will inherit that one.
+	if len(grp.Services) > 0 && grp.JournalLimit != nil {
+		return fmt.Errorf("journal quota is not supported for individual services")
+	}
 	return nil
 }
 

--- a/snap/quota/quota_test.go
+++ b/snap/quota/quota_test.go
@@ -552,6 +552,17 @@ func (ts *quotaTestSuite) TestResolveCrossReferences(c *C) {
 			err:     `missing group "other-missing" referenced as the parent of group "foogroup"`,
 			comment: "missing sub-group name",
 		},
+		{
+			grps: map[string]*quota.Group{
+				"foogroup": {
+					Name:         "foogroup",
+					JournalLimit: &quota.GroupQuotaJournal{},
+					Services:     []string{"snap.svc"},
+				},
+			},
+			err:     `group "foogroup" is invalid: journal quota is not supported for individual services`,
+			comment: "setting a journal quota for a group with services is not allowed",
+		},
 	}
 
 	for _, t := range tt {


### PR DESCRIPTION
Now that we support sub-groups for individual services with their own quotas, we need to impose some strict limitations in regards to journal quotas. Since mounts are generated per snap, it means we can't support multiple journal namespaces per snap. So we introduce a limitation in form of not allowing journal quotas on service sub-groups. They instead inherit the journal quota from their parent group (which contains the snap).
