### PR TITLE
devicestate: retry serial acquire on time based certificate  errors

### DIFF
--- a/httputil/client_test.go
+++ b/httputil/client_test.go
@@ -259,7 +259,7 @@ func (s *tlsSuite) TestClientMaxTLS11Error(c *check.C) {
 	// - golang < 1.12: tls: server selected unsupported protocol version 302
 	// - golang >= 1.12: tls: protocol version not supported
 	c.Assert(err, check.ErrorMatches, ".* tls: (server selected unsupported protocol version 302|protocol version not supported)")
-	c.Check(httputil.CertExpiredOrNotValidYet(err), check.Equals, false)
+	c.Check(httputil.IsCertExpiredOrNotValidYetError(err), check.Equals, false)
 }
 
 func (s *tlsSuite) TestClientMaxTLS12Ok(c *check.C) {
@@ -287,7 +287,7 @@ func (s *tlsSuite) TestClientMaxTLS12Ok(c *check.C) {
 	// this is testing the protocol, the self-signed certificate error is
 	// fine and expected.
 	c.Assert(err, check.ErrorMatches, ".* certificate signed by unknown authority")
-	c.Check(httputil.CertExpiredOrNotValidYet(err), check.Equals, false)
+	c.Check(httputil.IsCertExpiredOrNotValidYetError(err), check.Equals, false)
 }
 
 func (s *tlsSuite) TestCertExpireOrNotValidYet(c *check.C) {
@@ -312,5 +312,5 @@ func (s *tlsSuite) TestCertExpireOrNotValidYet(c *check.C) {
 
 	_, err = cli.Get(srv.URL)
 	c.Assert(err, check.ErrorMatches, ".*: x509: certificate has expired or is not yet valid.*")
-	c.Check(httputil.CertExpiredOrNotValidYet(err), check.Equals, true)
+	c.Check(httputil.IsCertExpiredOrNotValidYetError(err), check.Equals, true)
 }

--- a/httputil/client_test.go
+++ b/httputil/client_test.go
@@ -104,13 +104,17 @@ var privKey, _ = rsa.GenerateKey(rand.Reader, 768)
 
 // see crypto/tls/generate_cert.go
 func generateTestCert(c *check.C, certpath, keypath string) {
+	generateTestCertWithDates(c, certpath, keypath, time.Now(), time.Now().Add(24*time.Hour))
+}
+
+func generateTestCertWithDates(c *check.C, certpath, keypath string, notBefore, notAfter time.Time) {
 	template := x509.Certificate{
 		SerialNumber: big.NewInt(123456789),
 		Subject: pkix.Name{
 			Organization: []string{"Snapd testers"},
 		},
-		NotBefore:   time.Now(),
-		NotAfter:    time.Now().Add(24 * time.Hour),
+		NotBefore:   notBefore,
+		NotAfter:    notAfter,
 		IPAddresses: []net.IP{net.IPv4(127, 0, 0, 1)},
 		DNSNames:    []string{"localhost"},
 		IsCA:        true,
@@ -255,6 +259,7 @@ func (s *tlsSuite) TestClientMaxTLS11Error(c *check.C) {
 	// - golang < 1.12: tls: server selected unsupported protocol version 302
 	// - golang >= 1.12: tls: protocol version not supported
 	c.Assert(err, check.ErrorMatches, ".* tls: (server selected unsupported protocol version 302|protocol version not supported)")
+	c.Check(httputil.CertExpiredOrNotValidYet(err), check.Equals, false)
 }
 
 func (s *tlsSuite) TestClientMaxTLS12Ok(c *check.C) {
@@ -282,4 +287,30 @@ func (s *tlsSuite) TestClientMaxTLS12Ok(c *check.C) {
 	// this is testing the protocol, the self-signed certificate error is
 	// fine and expected.
 	c.Assert(err, check.ErrorMatches, ".* certificate signed by unknown authority")
+	c.Check(httputil.CertExpiredOrNotValidYet(err), check.Equals, false)
+}
+
+func (s *tlsSuite) TestCertExpireOrNotValidYet(c *check.C) {
+	generateTestCertWithDates(c, s.certpath, s.keypath, time.Time{}, time.Time{})
+
+	// create a server that uses our certs
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, `all good`)
+	}))
+	cert, err := tls.LoadX509KeyPair(s.certpath, s.keypath)
+	c.Assert(err, check.IsNil)
+	srv.TLS = &tls.Config{
+		Certificates: []tls.Certificate{cert},
+	}
+	srv.StartTLS()
+	s.AddCleanup(srv.Close)
+
+	// Server running only TLS1.1 doesn't work
+	cli := httputil.NewHTTPClient(nil)
+	c.Assert(cli, check.NotNil)
+	c.Assert(s.logbuf.String(), check.Equals, "")
+
+	_, err = cli.Get(srv.URL)
+	c.Assert(err, check.ErrorMatches, ".*: x509: certificate has expired or is not yet valid")
+	c.Check(httputil.CertExpiredOrNotValidYet(err), check.Equals, true)
 }

--- a/httputil/client_test.go
+++ b/httputil/client_test.go
@@ -311,6 +311,6 @@ func (s *tlsSuite) TestCertExpireOrNotValidYet(c *check.C) {
 	c.Assert(s.logbuf.String(), check.Equals, "")
 
 	_, err = cli.Get(srv.URL)
-	c.Assert(err, check.ErrorMatches, ".*: x509: certificate has expired or is not yet valid")
+	c.Assert(err, check.ErrorMatches, ".*: x509: certificate has expired or is not yet valid.*")
 	c.Check(httputil.CertExpiredOrNotValidYet(err), check.Equals, true)
 }

--- a/httputil/retry.go
+++ b/httputil/retry.go
@@ -293,7 +293,7 @@ func RetryRequest(endpoint string, doRequest func() (*http.Response, error), rea
 	return resp, err
 }
 
-func CertExpiredOrNotValidYet(err error) bool {
+func IsCertExpiredOrNotValidYetError(err error) bool {
 	if err == nil {
 		return false
 	}

--- a/httputil/retry.go
+++ b/httputil/retry.go
@@ -20,6 +20,7 @@
 package httputil
 
 import (
+	"crypto/x509"
 	"fmt"
 	"io"
 	"net"
@@ -290,4 +291,19 @@ func RetryRequest(endpoint string, doRequest func() (*http.Response, error), rea
 	maybeLogRetrySummary(startTime, endpoint, attempt, resp, err)
 
 	return resp, err
+}
+
+func CertExpiredOrNotValidYet(err error) bool {
+	if err == nil {
+		return false
+	}
+	if urlErr, ok := err.(*url.Error); ok {
+		err = urlErr.Err
+	}
+	if certErr, ok := err.(x509.CertificateInvalidError); ok {
+		// Expired is misleading, also means not valid yet
+		return certErr.Reason == x509.Expired
+	}
+
+	return false
 }

--- a/overlord/devicestate/devicestate_serial_test.go
+++ b/overlord/devicestate/devicestate_serial_test.go
@@ -953,7 +953,7 @@ func (s *deviceMgrSerialSuite) TestDoRequestSerialCertExpired(c *C) {
 	}
 
 	c.Check(chg.Status(), Equals, state.ErrorStatus)
-	c.Assert(chg.Err(), ErrorMatches, "(?ms).*: x509: certificate has expired or is not yet valid.*")
+	c.Assert(chg.Err(), ErrorMatches, `(?ms).*cannot retrieve request-id for making a request for a serial: Post "http://.*/request-id": x509: certificate has expired or is not yet valid.*`)
 
 	var nTentatives int
 	err := t.Get("pre-poll-tentatives", &nTentatives)

--- a/overlord/devicestate/devicestate_serial_test.go
+++ b/overlord/devicestate/devicestate_serial_test.go
@@ -940,7 +940,7 @@ func (s *deviceMgrSerialSuite) TestDoRequestSerialCertExpired(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	// keep trying well above maxTentativesCertExpired (35)
+	// keep trying well beyond the 21 retry attempts we do
 	for i := 0; i < 100; i++ {
 		s.state.Unlock()
 		s.se.Ensure()
@@ -959,7 +959,7 @@ func (s *deviceMgrSerialSuite) TestDoRequestSerialCertExpired(c *C) {
 	err := t.Get("pre-poll-tentatives", &nTentatives)
 	c.Assert(err, IsNil)
 	// this is one above maxTentativesCertExpired (35)
-	c.Check(nTentatives, Equals, 36)
+	c.Check(nTentatives, Equals, 21)
 
 }
 

--- a/overlord/devicestate/devicestate_serial_test.go
+++ b/overlord/devicestate/devicestate_serial_test.go
@@ -827,18 +827,6 @@ func (s *deviceMgrSerialSuite) TestDoRequestSerialNoNetwork(c *C) {
 	s.testDoRequestSerialKeepsRetrying(c, &simulateNoNetRoundTripper{})
 }
 
-type simulateCertExpiredErrorRoundTripper struct{}
-
-func (s *simulateCertExpiredErrorRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
-	return nil, x509.CertificateInvalidError{
-		Reason: x509.Expired,
-	}
-}
-
-func (s *deviceMgrSerialSuite) TestDoRequestSerialCertExpired(c *C) {
-	s.testDoRequestSerialKeepsRetrying(c, &simulateCertExpiredErrorRoundTripper{})
-}
-
 type simulateNoDNSRoundTripper struct{}
 
 func (s *simulateNoDNSRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
@@ -859,30 +847,55 @@ func (s *deviceMgrSerialSuite) TestDoRequestSerialNoReachableDNS(c *C) {
 }
 
 func (s *deviceMgrSerialSuite) testDoRequestSerialKeepsRetrying(c *C, rt http.RoundTripper) {
+	chg, t := s.makeRequestChangeWithTransport(c, rt)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// ensure we keep trying even if we are well above maxTentative
+	for i := 0; i < 10; i++ {
+		s.state.Unlock()
+		s.se.Ensure()
+		s.se.Wait()
+		s.state.Lock()
+
+		c.Check(chg.Status(), Equals, state.DoingStatus)
+		c.Assert(chg.Err(), IsNil)
+	}
+
+	c.Check(chg.Status(), Equals, state.DoingStatus)
+
+	var nTentatives int
+	err := t.Get("pre-poll-tentatives", &nTentatives)
+	c.Assert(err, IsNil)
+	c.Check(nTentatives, Equals, 0)
+}
+
+func (s *deviceMgrSerialSuite) makeRequestChangeWithTransport(c *C, rt http.RoundTripper) (*state.Change, *state.Task) {
 	privKey, _ := assertstest.GenerateKey(testKeyLength)
 
 	// immediate
 	r := devicestate.MockRetryInterval(0)
-	defer r()
+	s.AddCleanup(r)
 
 	// set a low maxRetry value
 	r = devicestate.MockMaxTentatives(3)
-	defer r()
+	s.AddCleanup(r)
 
 	mockServer := s.mockServer(c, "REQID-1", nil)
-	defer mockServer.Close()
+	s.AddCleanup(mockServer.Close)
 
 	restore := devicestate.MockBaseStoreURL(mockServer.URL)
-	defer restore()
+	s.AddCleanup(restore)
 
 	restore = devicestate.MockRepeatRequestSerial("after-add-serial")
-	defer restore()
+	s.AddCleanup(restore)
 
 	restore = devicestate.MockHttputilNewHTTPClient(func(opts *httputil.ClientOptions) *http.Client {
 		c.Check(opts.ProxyConnectHeader, NotNil)
 		return &http.Client{Transport: rt}
 	})
-	defer restore()
+	s.AddCleanup(restore)
 
 	// setup state as done by first-boot/Ensure/doGenerateDeviceKey
 	s.state.Lock()
@@ -910,23 +923,44 @@ func (s *deviceMgrSerialSuite) testDoRequestSerialKeepsRetrying(c *C, rt http.Ro
 	// avoid full seeding
 	s.seeding()
 
-	// ensure we keep trying even if we are well above maxTentative
-	for i := 0; i < 10; i++ {
+	return chg, t
+}
+
+type simulateCertExpiredErrorRoundTripper struct{}
+
+func (s *simulateCertExpiredErrorRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	return nil, x509.CertificateInvalidError{
+		Reason: x509.Expired,
+	}
+}
+
+func (s *deviceMgrSerialSuite) TestDoRequestSerialCertExpired(c *C) {
+	chg, t := s.makeRequestChangeWithTransport(c, &simulateCertExpiredErrorRoundTripper{})
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// keep trying well above maxTentativesCertExpired (35)
+	for i := 0; i < 100; i++ {
 		s.state.Unlock()
 		s.se.Ensure()
 		s.se.Wait()
 		s.state.Lock()
 
-		c.Check(chg.Status(), Equals, state.DoingStatus)
-		c.Assert(chg.Err(), IsNil)
+		if chg.Status() == state.ErrorStatus {
+			break
+		}
 	}
 
-	c.Check(chg.Status(), Equals, state.DoingStatus)
+	c.Check(chg.Status(), Equals, state.ErrorStatus)
+	c.Assert(chg.Err(), ErrorMatches, "(?ms).*: x509: certificate has expired or is not yet valid.*")
 
 	var nTentatives int
 	err := t.Get("pre-poll-tentatives", &nTentatives)
 	c.Assert(err, IsNil)
-	c.Check(nTentatives, Equals, 0)
+	// this is one above maxTentativesCertExpired (35)
+	c.Check(nTentatives, Equals, 36)
+
 }
 
 func (s *deviceMgrSerialSuite) TestFullDeviceRegistrationPollHappy(c *C) {

--- a/overlord/devicestate/devicestate_serial_test.go
+++ b/overlord/devicestate/devicestate_serial_test.go
@@ -953,7 +953,7 @@ func (s *deviceMgrSerialSuite) TestDoRequestSerialCertExpired(c *C) {
 	}
 
 	c.Check(chg.Status(), Equals, state.ErrorStatus)
-	c.Assert(chg.Err(), ErrorMatches, `(?ms).*cannot retrieve request-id for making a request for a serial: Post "http://.*/request-id": x509: certificate has expired or is not yet valid.*`)
+	c.Assert(chg.Err(), ErrorMatches, `(?ms).*cannot retrieve request-id for making a request for a serial: Post \"?http://.*/request-id\"?: x509: certificate has expired or is not yet valid.*`)
 
 	var nTentatives int
 	err := t.Get("pre-poll-tentatives", &nTentatives)

--- a/overlord/devicestate/handlers_serial.go
+++ b/overlord/devicestate/handlers_serial.go
@@ -370,8 +370,6 @@ func prepareSerialRequest(t *state.Task, regCtx registrationContext, privKey ass
 				return "", &state.Retry{After: retryInterval * 2}
 			case nTentatives <= 20:
 				return "", &state.Retry{After: retryInterval * 4}
-			default:
-				return "", err
 			}
 		}
 		if !httputil.ShouldRetryError(err) {

--- a/overlord/devicestate/handlers_serial.go
+++ b/overlord/devicestate/handlers_serial.go
@@ -353,7 +353,7 @@ func prepareSerialRequest(t *state.Task, regCtx registrationContext, privKey ass
 			noNetworkRetryInterval := retryInterval / 2
 			return "", &state.Retry{After: noNetworkRetryInterval}
 		}
-		if httputil.CertExpiredOrNotValidYet(err) {
+		if httputil.IsCertExpiredOrNotValidYetError(err) {
 			// If the cert is expired/not-valid yet that
 			// most likely means that the devices has no
 			// ntp-synced time yet. We will retry for up


### PR DESCRIPTION
When the serial assertion cannot be acquired because the certificate
of the remote system is expired or not yet valid then the most
likely reason for this is that the system clock is off. This case
is now treated in the same way as no network errors, i.e. snapd
will retry to acquire the serial and will not go into the backoff
mode. This helps with the issue that on systems without a RTC
when the device comes up and the NTP sync is slow the serial
is (re)tried 3 times and then it goes into a very long backoff
(as defined in DeviceManager.ensureOperationalShouldBackoff()).
