### PR TITLE
ci: update golangci-lint to v1.50.1 in order to support Go 1.19

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -153,7 +153,7 @@ jobs:
       with:
         # version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest`
         # to use the latest version
-        version: v1.45.2
+        version: v1.50.1
         working-directory: ./src/github.com/snapcore/snapd
         # show only new issues
         # use empty path prefix to make annotations work


### PR DESCRIPTION
The Go snap's stable channel was updated to 1.19.4, and golangci-lint 1.45.2 now produces failures like:

```
  Running [/home/runner/golangci-lint-1.45.2-linux-amd64/golangci-lint run --out-format=github-actions --new-from-rev=master --path-prefix=] in [/home/runner/work/snapd/snapd/src/github.com/snapcore/snapd] ...
  panic: load embedded ruleguard rules: rules/rules.go:13: can't load fmt
  
  goroutine 1 [running]:
  github.com/go-critic/go-critic/checkers.init.22()
  	github.com/go-critic/go-critic@v0.6.2/checkers/embedded_rules.go:46 +0x4b4
  
  Error: golangci-lint exit with code 2
```

[v1.48.0](https://github.com/golangci/golangci-lint/releases/tag/v1.48.0) is the first with Go 1.19 support, but we may as well move to the latest version if we're changing at all.