### PR TITLE
ci: update various Github actions to Node 16.x versions

### DIFF
--- a/.github/workflows/macos-quick.yaml
+++ b/.github/workflows/macos-quick.yaml
@@ -8,12 +8,12 @@ jobs:
   macos-quick:
     runs-on: macos-latest
     steps:
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: "1.14.x"
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install squashfs from homebrew
         run: |

--- a/.github/workflows/naming.yml
+++ b/.github/workflows/naming.yml
@@ -8,6 +8,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - uses: tj-actions/changed-files@v34.5.1
         id: files

--- a/.github/workflows/naming.yml
+++ b/.github/workflows/naming.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - uses: tj-actions/changed-files@v18.7
+      - uses: tj-actions/changed-files@v34.5.1
         id: files
 
       - name: woke

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -153,7 +153,7 @@ jobs:
       with:
         # version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest`
         # to use the latest version
-        version: v1.45.2
+        version: v1.50.1
         working-directory: ./src/github.com/snapcore/snapd
         # show only new issues
         # use empty path prefix to make annotations work

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Build snapd snap
       uses: snapcore/action-build@v1
@@ -40,7 +40,7 @@ jobs:
         fi
 
     - name: Uploading snapd snap artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: snap-files
         path: "*.snap"
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         # needed for git commit history
         fetch-depth: 0
@@ -75,7 +75,7 @@ jobs:
         sudo tar cvf cached-apt.tar /var/cache/apt
 
     - name: upload Debian dependencies
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: debian-dependencies
         path: ./cached-apt.tar
@@ -103,7 +103,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         # needed for git commit history
         fetch-depth: 0
@@ -149,7 +149,7 @@ jobs:
 
     - name: golangci-lint
       if: ${{ matrix.gochannel == 'latest/stable' }}
-      uses: golangci/golangci-lint-action@v2
+      uses: golangci/golangci-lint-action@v3
       with:
         # version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest`
         # to use the latest version
@@ -167,7 +167,7 @@ jobs:
 
     - name: Get changed files
       id: changed-files
-      uses: tj-actions/changed-files@v19
+      uses: tj-actions/changed-files@v34.5.1
       with:
         path: ./src/github.com/snapcore/snapd
 
@@ -221,7 +221,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         # needed for git commit history
         fetch-depth: 0
@@ -315,7 +315,7 @@ jobs:
 
     - name: Upload the coverage results
       if: ${{ matrix.gochannel != 'latest/stable' }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: coverage-files
         path: "${{ github.workspace }}/src/github.com/snapcore/snapd/.coverage/coverage*.cov"
@@ -349,7 +349,7 @@ jobs:
         covertool merge -o .coverage/all.cov .coverage/coverage*.cov
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       # uploading to codecov occasionally fails, so continue running the test
       # workflow regardless of the upload
       continue-on-error: true
@@ -409,14 +409,14 @@ jobs:
           mkdir "${{ github.workspace }}"
 
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         # spread uses tags as delta reference
         fetch-depth: 0
 
     - name: Cache snapd test results
       id: cache-snapd-test-results
-      uses: pat-s/always-upload-cache@v2.1.5
+      uses: pat-s/always-upload-cache@v3.0.11
       with:
         path: "${{ github.workspace }}/.test-results"
         key: "${{ github.run_id }}-${{ github.job }}-${{ matrix.system }}-results"
@@ -549,11 +549,11 @@ jobs:
           mkdir "${{ github.workspace }}"
 
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Cache snapd test results
       id: cache-snapd-test-results
-      uses: pat-s/always-upload-cache@v2.1.5
+      uses: pat-s/always-upload-cache@v3.0.11
       with:
         path: "${{ github.workspace }}/.test-results"
         key: "${{ github.run_id }}-${{ github.job }}-${{ matrix.system }}-results"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -159,7 +159,6 @@ jobs:
         # use empty path prefix to make annotations work
         args: --new-from-rev=${{ github.base_ref }} --path-prefix=
         # skip all additional steps
-        skip-go-installation: true
         skip-pkg-cache: true
         skip-build-cache: true
         # XXX: does no work with working-directory


### PR DESCRIPTION
At the moment, CI runs spit out a large number of warnings like:

```
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/upload-artifact@v2
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

The second two are a side effect of the first one. When Github upgraded their own actions to run on Node 16.x, they increased the major version number (despite them behaving identically). That's left us running outdated versions of the actions, triggering the other warnings.

This PR updates the action versions to fix the warnings.