### PR TITLE
secboot: detect lockout mode in CheckTPMKeySealingSupported

### DIFF
--- a/secboot/export_sb_test.go
+++ b/secboot/export_sb_test.go
@@ -231,3 +231,9 @@ func MockSbTPMDictionaryAttackLockReset(f func(tpm *sb_tpm2.Connection, lockCont
 	sbTPMDictionaryAttackLockReset = f
 	return restore
 }
+
+func MockSbInLockoutMode(f func(tpm *sb_tpm2.Connection) bool) (restore func()) {
+	restore = testutil.Backup(&inDALockoutMode)
+	inDALockoutMode = f
+	return restore
+}


### PR DESCRIPTION
This commit fixes the issue that the detection of TPM key sealing does not take into account if the system is already in DA lockout mode. If this is the case an install will not be successful but currently this is detected very late.
