### PR TITLE
DT-878: Original patch re-applied with conditionals

### DIFF
--- a/usersession/userd/launcher.go
+++ b/usersession/userd/launcher.go
@@ -210,9 +210,9 @@ func (s *Launcher) OpenURL(addr string, sender dbus.Sender) *dbus.Error {
 
 	if u.Scheme == "help" {
 		// This is a hack to allow to find the help files in the confined applications
-		snap, err := snapFromSender(s.conn, sender)
-		if err != nil {
-			return dbus.MakeFailedError(err)
+		snap, errS := snapFromSender(s.conn, sender)
+		if errS != nil {
+			return dbus.MakeFailedError(errS)
 		}
 		xdg_data_dirs := []string{}
 		xdg_data_dirs = append(xdg_data_dirs, fmt.Sprintf(filepath.Join(dirs.SnapMountDir, snap, "current/usr/share")))


### PR DESCRIPTION
Three years ago, a patch was applied to allow to open "help:" URIs from inside a snap container by using the io.snapcraft.Launcher.OpenURL() DBus method (https://github.com/snapcore/snapd/pull/6493).

For some reason, this code was removed, and the "help" URIs stopped working (https://bugs.launchpad.net/snapd/+bug/1998538).

After bisecting the repository, found that the code was removed in a commit with the text "usersession/userd: do not modify XDG_DATA_DIRS when calling xdg-open". This sounds like a bug fix, so this MR just re-applies the change only for the help:// URIs, which are the only ones that need it. It also adds a comment explaining why XDG_DATA_DIRS is being modified, in the hope that the code won't be removed again in the future.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
