### PR TITLE
image: generate seed.manifest

### DIFF
--- a/cmd/snap/cmd_prepare_image.go
+++ b/cmd/snap/cmd_prepare_image.go
@@ -171,6 +171,12 @@ func (x *cmdPrepareImage) Execute(args []string) error {
 	opts.AppArmorKernelFeaturesDir = x.AppArmorKernelFeaturesDir
 	opts.SysfsOverlay = x.SysfsOverlay
 
+	dir, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	opts.SeedManifestDir = dir
+
 	return imagePrepare(opts)
 }
 

--- a/cmd/snap/cmd_prepare_image.go
+++ b/cmd/snap/cmd_prepare_image.go
@@ -51,9 +51,10 @@ type cmdPrepareImage struct {
 	Customize string `long:"customize" hidden:"yes"`
 
 	// TODO: introduce SnapWithChannel?
-	Snaps         []string `long:"snap" value-name:"<snap>[=<channel>]"`
-	ExtraSnaps    []string `long:"extra-snaps" hidden:"yes"` // DEPRECATED
-	RevisionsFile string   `long:"revisions"`
+	Snaps              []string `long:"snap" value-name:"<snap>[=<channel>]"`
+	ExtraSnaps         []string `long:"extra-snaps" hidden:"yes"` // DEPRECATED
+	RevisionsFile      string   `long:"revisions"`
+	WriteRevisionsFile string   `long:"write-revisions" optional:"true" optional-value:"./seed.manifest"`
 }
 
 func init() {
@@ -88,6 +89,8 @@ For preparing classic images it supports a --classic mode`),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"revisions": i18n.G("Specify a seeds.manifest file referencing the exact revisions of the provided snaps which should be installed"),
 			// TRANSLATORS: This should not start with a lowercase letter.
+			"write-revisions": i18n.G("Writes a seed.manifest file containing the exact snap revisions used for the image, optionally at the specified path."),
+			// TRANSLATORS: This should not start with a lowercase letter.
 			"channel": i18n.G("The channel to use"),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"customize": i18n.G("Image customizations specified as JSON file."),
@@ -111,10 +114,11 @@ var imageReadSeedManifest = image.ReadSeedManifest
 
 func (x *cmdPrepareImage) Execute(args []string) error {
 	opts := &image.Options{
-		Snaps:        x.ExtraSnaps,
-		ModelFile:    x.Positional.ModelAssertionFn,
-		Channel:      x.Channel,
-		Architecture: x.Architecture,
+		Snaps:            x.ExtraSnaps,
+		ModelFile:        x.Positional.ModelAssertionFn,
+		Channel:          x.Channel,
+		Architecture:     x.Architecture,
+		SeedManifestPath: x.WriteRevisionsFile,
 	}
 
 	if x.RevisionsFile != "" {
@@ -170,12 +174,6 @@ func (x *cmdPrepareImage) Execute(args []string) error {
 	opts.PreseedSignKey = x.PreseedSignKey
 	opts.AppArmorKernelFeaturesDir = x.AppArmorKernelFeaturesDir
 	opts.SysfsOverlay = x.SysfsOverlay
-
-	dir, err := os.Getwd()
-	if err != nil {
-		return err
-	}
-	opts.SeedManifestDir = dir
 
 	return imagePrepare(opts)
 }

--- a/cmd/snap/cmd_prepare_image.go
+++ b/cmd/snap/cmd_prepare_image.go
@@ -89,7 +89,7 @@ For preparing classic images it supports a --classic mode`),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"revisions": i18n.G("Specify a seeds.manifest file referencing the exact revisions of the provided snaps which should be installed"),
 			// TRANSLATORS: This should not start with a lowercase letter.
-			"write-revisions": i18n.G("Writes a seed.manifest file containing the exact snap revisions used for the image, optionally at the specified path."),
+			"write-revisions": i18n.G("Writes a manifest file containing references to the exact snap revisions used for the image. A path for the manifest is optional."),
 			// TRANSLATORS: This should not start with a lowercase letter.
 			"channel": i18n.G("The channel to use"),
 			// TRANSLATORS: This should not start with a lowercase letter.

--- a/cmd/snap/cmd_prepare_image_test.go
+++ b/cmd/snap/cmd_prepare_image_test.go
@@ -231,3 +231,33 @@ func (s *SnapPrepareImageSuite) TestPrepareImagePreseed(c *C) {
 		AppArmorKernelFeaturesDir: "aafeatures-dir",
 	})
 }
+
+func (s *SnapPrepareImageSuite) TestPrepareImageWriteRevisions(c *C) {
+	var opts *image.Options
+	prep := func(o *image.Options) error {
+		opts = o
+		return nil
+	}
+	r := cmdsnap.MockImagePrepare(prep)
+	defer r()
+
+	rest, err := cmdsnap.Parser(cmdsnap.Client()).ParseArgs([]string{"prepare-image", "model", "prepare-dir", "--write-revisions"})
+	c.Assert(err, IsNil)
+	c.Assert(rest, DeepEquals, []string{})
+
+	c.Check(opts, DeepEquals, &image.Options{
+		ModelFile:        "model",
+		PrepareDir:       "prepare-dir",
+		SeedManifestPath: "./seed.manifest",
+	})
+
+	rest, err = cmdsnap.Parser(cmdsnap.Client()).ParseArgs([]string{"prepare-image", "model", "prepare-dir", "--write-revisions=/tmp/seed.manifest"})
+	c.Assert(err, IsNil)
+	c.Assert(rest, DeepEquals, []string{})
+
+	c.Check(opts, DeepEquals, &image.Options{
+		ModelFile:        "model",
+		PrepareDir:       "prepare-dir",
+		SeedManifestPath: "/tmp/seed.manifest",
+	})
+}

--- a/image/image_linux.go
+++ b/image/image_linux.go
@@ -487,7 +487,7 @@ var setupSeed = func(tsto *tooling.ToolingStore, model *asserts.Model, opts *Opt
 
 			// fetch snap assertions
 			prev := len(f.Refs())
-			if _, err := FetchAndCheckSnapAssertions(dlsn.Path, dlsn.Info, model, f, db); err != nil {
+			if _, err = FetchAndCheckSnapAssertions(dlsn.Path, dlsn.Info, model, f, db); err != nil {
 				return err
 			}
 			if !sn.Info.Revision.Unset() {

--- a/image/image_linux.go
+++ b/image/image_linux.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"syscall"
@@ -648,5 +649,10 @@ var setupSeed = func(tsto *tooling.ToolingStore, model *asserts.Model, opts *Opt
 	// last thing is to generate the image seed manifest file
 	// XXX: is this the correct place to do this? Should we instead
 	// return the "imageManifest" and the let cmd_prepare_image do this?
-	return WriteSeedManifest("seed.manifest", imageManifest)
+	if opts.SeedManifestDir != "" {
+		if err := WriteSeedManifest(path.Join(opts.SeedManifestDir, "seed.manifest"), imageManifest); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/image/image_linux.go
+++ b/image/image_linux.go
@@ -419,6 +419,9 @@ var setupSeed = func(tsto *tooling.ToolingStore, model *asserts.Model, opts *Opt
 		return err
 	}
 
+	// Build a map of snaps for the manifest file
+	imageManifest := make(map[string]snap.Revision)
+
 	// Check local snaps again, but now after InfoDerived has been called. InfoDerived
 	// fills out the snap revisions for the local snaps, and we need this to verify against
 	// expected revisions.
@@ -430,6 +433,9 @@ var setupSeed = func(tsto *tooling.ToolingStore, model *asserts.Model, opts *Opt
 		if !specifiedRevision.Unset() && specifiedRevision != sn.Info.Revision {
 			return fmt.Errorf("cannot use snap %s for image, unknown/local revision does not match the value specified by revisions file (%s != %s)",
 				sn.Path, sn.Info.Revision, specifiedRevision)
+		}
+		if !sn.Info.Revision.Unset() {
+			imageManifest[sn.Info.SnapName()] = sn.Info.Revision
 		}
 	}
 
@@ -481,8 +487,11 @@ var setupSeed = func(tsto *tooling.ToolingStore, model *asserts.Model, opts *Opt
 
 			// fetch snap assertions
 			prev := len(f.Refs())
-			if _, err = FetchAndCheckSnapAssertions(dlsn.Path, dlsn.Info, model, f, db); err != nil {
+			if _, err := FetchAndCheckSnapAssertions(dlsn.Path, dlsn.Info, model, f, db); err != nil {
 				return err
+			}
+			if !sn.Info.Revision.Unset() {
+				imageManifest[sn.Info.SnapName()] = sn.Info.Revision
 			}
 			aRefs := f.Refs()[prev:]
 			sn.ARefs = aRefs
@@ -636,5 +645,8 @@ var setupSeed = func(tsto *tooling.ToolingStore, model *asserts.Model, opts *Opt
 		customizeImage(rootDir, defaultsDir, &opts.Customizations)
 	}
 
-	return nil
+	// last thing is to generate the image seed manifest file
+	// XXX: is this the correct place to do this? Should we instead
+	// return the "imageManifest" and the let cmd_prepare_image do this?
+	return WriteSeedManifest("seed.manifest", imageManifest)
 }

--- a/image/image_linux.go
+++ b/image/image_linux.go
@@ -24,7 +24,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"syscall"
@@ -647,10 +646,8 @@ var setupSeed = func(tsto *tooling.ToolingStore, model *asserts.Model, opts *Opt
 	}
 
 	// last thing is to generate the image seed manifest file
-	// XXX: is this the correct place to do this? Should we instead
-	// return the "imageManifest" and the let cmd_prepare_image do this?
-	if opts.SeedManifestDir != "" {
-		if err := WriteSeedManifest(path.Join(opts.SeedManifestDir, "seed.manifest"), imageManifest); err != nil {
+	if opts.SeedManifestPath != "" {
+		if err := WriteSeedManifest(opts.SeedManifestPath, imageManifest); err != nil {
 			return err
 		}
 	}

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -990,19 +990,19 @@ func (s *imageSuite) TestSetupSeedImageManifest(c *C) {
 	}, "")
 
 	snapFile := snaptest.MakeTestSnapWithFiles(c, devmodeSnap, nil)
+	seedManifestPath := path.Join(rootdir, "seed.manifest")
 
 	opts := &image.Options{
 		Snaps: []string{snapFile},
 
-		PrepareDir:      filepath.Dir(rootdir),
-		SeedManifestDir: rootdir,
-		Channel:         "beta",
+		PrepareDir:       filepath.Dir(rootdir),
+		SeedManifestPath: seedManifestPath,
+		Channel:          "beta",
 	}
 
 	err := image.SetupSeed(s.tsto, s.model, opts)
 	c.Assert(err, IsNil)
 
-	seedManifestPath := path.Join(rootdir, "seed.manifest")
 	c.Assert(seedManifestPath, testutil.FilePresent)
 	c.Check(seedManifestPath, testutil.FileContains, `core 3
 devmode-snap x1

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -974,6 +975,41 @@ func (s *imageSuite) TestSetupSeedDevmodeSnap(c *C) {
 	})
 	// check devmode-snap blob
 	c.Check(runSnaps[1].Path, testutil.FilePresent)
+}
+
+func (s *imageSuite) TestSetupSeedImageManifest(c *C) {
+	// Use almost identical setup as TestSetupSeedDevmodeSnap to
+	// get each type of snap into the manifest
+	restore := image.MockTrusted(s.StoreSigning.Trusted)
+	defer restore()
+
+	rootdir := filepath.Join(c.MkDir(), "image")
+	s.setupSnaps(c, map[string]string{
+		"pc":        "canonical",
+		"pc-kernel": "canonical",
+	}, "")
+
+	snapFile := snaptest.MakeTestSnapWithFiles(c, devmodeSnap, nil)
+
+	opts := &image.Options{
+		Snaps: []string{snapFile},
+
+		PrepareDir:      filepath.Dir(rootdir),
+		SeedManifestDir: rootdir,
+		Channel:         "beta",
+	}
+
+	err := image.SetupSeed(s.tsto, s.model, opts)
+	c.Assert(err, IsNil)
+
+	seedManifestPath := path.Join(rootdir, "seed.manifest")
+	c.Assert(seedManifestPath, testutil.FilePresent)
+	c.Check(seedManifestPath, testutil.FileContains, `core 3
+devmode-snap x1
+pc 1
+pc-kernel 2
+required-snap1 3
+`)
 }
 
 func (s *imageSuite) TestSetupSeedWithClassicSnapFails(c *C) {

--- a/image/manifest.go
+++ b/image/manifest.go
@@ -103,7 +103,7 @@ func WriteSeedManifest(filePath string, revisions map[string]snap.Revision) erro
 	buf := bytes.NewBuffer(nil)
 	for _, key := range keys {
 		rev := revisions[key]
-		if rev.N == 0 {
+		if rev.Unset() {
 			return fmt.Errorf("revision must not be 0 for snap %q", key)
 		}
 		fmt.Fprintf(buf, "%s %s\n", key, rev)

--- a/image/options.go
+++ b/image/options.go
@@ -49,9 +49,9 @@ type Options struct {
 	SnapChannels map[string]string
 	Revisions    map[string]snap.Revision
 
-	// SeedManifestPath if set, specifies the directory where the
-	// seed.manifest file should be generated.
-	SeedManifestDir string
+	// SeedManifestPath if set, specifies the file path where the
+	// seed.manifest file should be written.
+	SeedManifestPath string
 
 	// WideCohortKey can be used to supply a cohort covering all
 	// the snaps in the image, there is no generally suppported API

--- a/image/options.go
+++ b/image/options.go
@@ -49,6 +49,10 @@ type Options struct {
 	SnapChannels map[string]string
 	Revisions    map[string]snap.Revision
 
+	// SeedManifestPath if set, specifies the directory where the
+	// seed.manifest file should be generated.
+	SeedManifestDir string
+
 	// WideCohortKey can be used to supply a cohort covering all
 	// the snaps in the image, there is no generally suppported API
 	// to create such a cohort key.

--- a/tests/main/prepare-image-reproducible/task.yaml
+++ b/tests/main/prepare-image-reproducible/task.yaml
@@ -132,7 +132,7 @@ execute: |
     # verify that we are able to send a specific revision to the store.
     export SNAPPY_FORCE_API_URL=http://$STORE_ADDR
     echo Running prepare-image
-    snap prepare-image --channel edge --snap test-snapd-sh --revisions "$ROOT"/seed.manifest "$TESTSLIB"/assertions/developer1-pc.model $ROOT
+    snap prepare-image --channel edge --snap test-snapd-sh --write-revisions --revisions "$ROOT"/seed.manifest "$TESTSLIB"/assertions/developer1-pc.model $ROOT
     
     echo Verifying the expected revisions were retrieved
     test -e "$IMAGE/var/lib/snapd/seed/snaps/core_1.snap"

--- a/tests/main/prepare-image-reproducible/task.yaml
+++ b/tests/main/prepare-image-reproducible/task.yaml
@@ -145,3 +145,10 @@ execute: |
     journalctl -u fakestore | grep 'requested snap "pc" revision 1'
     journalctl -u fakestore | grep 'requested snap "pc-kernel" revision 1'
     journalctl -u fakestore | grep 'requested snap "test-snapd-sh" revision 23'
+
+    # The generated seed.manifest will be in working directory.
+    echo Verifying the generated manifest has correct contents
+    MATCH "core\s1+$" < seed.manifest
+    MATCH "pc\s1+$" < seed.manifest
+    MATCH "pc-kernel\s1+$" < seed.manifest
+    MATCH "test-snapd-sh\s23+$" < seed.manifest


### PR DESCRIPTION
This enables the generation of the seed.manifest and introduces (thanks to @pedronis) a new option for snapd prepare-image to control the generation.