### PR TITLE
interfaces: expand block-devices and raw-volume to support mkfs tools

### DIFF
--- a/interfaces/builtin/block_devices.go
+++ b/interfaces/builtin/block_devices.go
@@ -102,6 +102,10 @@ capability sys_admin,
 
 # Allow to use blkid to export key=value pairs such as UUID to get block device attributes
 /{,usr/}sbin/blkid ixr,
+
+# Allow to use mkfs utils to format partitions
+/{,usr/}sbin/mke2fs ixr,
+/{,usr/}sbin/mkfs.fat ixr,
 `
 
 var blockDevicesConnectedPlugUDev = []string{

--- a/interfaces/builtin/raw_volume.go
+++ b/interfaces/builtin/raw_volume.go
@@ -61,6 +61,10 @@ capability sys_admin,
 /run/udev/data/b[0-9]*:[0-9]* r,
 /sys/block/ r,
 /sys/devices/**/block/** r,
+
+# Allow to use mkfs utils to format partitions
+/{,usr/}sbin/mke2fs ixr,
+/{,usr/}sbin/mkfs.fat ixr,
 `
 
 // The type for this interface


### PR DESCRIPTION
Ubuntu Core ships mkfs.ext4 and mkfs.vfat utilities as part of the rootfs. Some developers/customers reported that they are not able to leverage existing e2fsprogs and dosfstools but need to `stage-package` them as part of their snap. This PR provides access to `mkfs.ext4` and `mkfs.vfat` once `block-devices` or `raw-volume` is connected.
