### PR TITLE
o/snapshotstate: check snapshots are self-contained on import

### DIFF
--- a/overlord/snapshotstate/backend/backend.go
+++ b/overlord/snapshotstate/backend/backend.go
@@ -841,6 +841,11 @@ func unpackVerifySnapshotImport(ctx context.Context, r io.Reader, realSetID uint
 			return nil, errors.New("unexpected directory in import file")
 		}
 
+		// files within the snapshot should never use parent elements
+		if strings.Contains(header.Name, "../") {
+			return nil, fmt.Errorf("invalid filename in import file")
+		}
+
 		if header.Name == "content.json" {
 			var ej contentJSON
 			dec := json.NewDecoder(tr)

--- a/tests/main/snapshot-basic/task.yaml
+++ b/tests/main/snapshot-basic/task.yaml
@@ -77,16 +77,19 @@ execute: |
     snap saved --id="$SET_ID" | grep "No snapshots found"
 
     echo "Check import fails if snapshot contains invalid filenames"
-    fname=$(mktemp /tmp/1_XXXX)
-    relpath=$(realpath  --relative-to="$(pwd)" "$fname")
-    cp "${SET_ID}_export.snapshot" "${SET_ID}_export.snapshot.invalid"
-    tar --update -f "${SET_ID}_export.snapshot.invalid" -P "$relpath"
-    # remove the file so we can check that the file does not get created when
-    # snapshot import fails
-    rm "$fname"
-    snap import-snapshot "${SET_ID}_export.snapshot.invalid" && exit 1
-    test ! -e "$fname"
-    rm "${SET_ID}_export.snapshot.invalid"
+    # trusty (14.04) relpath does not support --relative-to
+    if ! os.query is-trusty; then
+        fname=$(mktemp /tmp/1_XXXX)
+        relpath=$(realpath  --relative-to="$(pwd)" "$fname")
+        cp "${SET_ID}_export.snapshot" "${SET_ID}_export.snapshot.invalid"
+        tar --update -f "${SET_ID}_export.snapshot.invalid" -P "$relpath"
+        # remove the file so we can check that the file does not get created when
+        # snapshot import fails
+        rm "$fname"
+        snap import-snapshot "${SET_ID}_export.snapshot.invalid" && exit 1
+        test ! -e "$fname"
+        rm "${SET_ID}_export.snapshot.invalid"
+    fi
 
     echo "Check that import works"
     RESTORE_ID=$( snap import-snapshot "${SET_ID}_export.snapshot" | head -n1 | cut -f2 -d'#' )

--- a/tests/main/snapshot-basic/task.yaml
+++ b/tests/main/snapshot-basic/task.yaml
@@ -76,6 +76,18 @@ execute: |
     snap forget "$SET_ID"
     snap saved --id="$SET_ID" | grep "No snapshots found"
 
+    echo "Check import fails if snapshot contains invalid filenames"
+    fname=$(mktemp /tmp/1_XXXX)
+    relpath=$(realpath  --relative-to="$(pwd)" "$fname")
+    cp "${SET_ID}_export.snapshot" "${SET_ID}_export.snapshot.invalid"
+    tar --update -f "${SET_ID}_export.snapshot.invalid" -P "$relpath"
+    # remove the file so we can check that the file does not get created when
+    # snapshot import fails
+    rm "$fname"
+    snap import-snapshot "${SET_ID}_export.snapshot.invalid" && exit 1
+    test ! -e "$fname"
+    rm "${SET_ID}_export.snapshot.invalid"
+
     echo "Check that import works"
     RESTORE_ID=$( snap import-snapshot "${SET_ID}_export.snapshot" | head -n1 | cut -f2 -d'#' )
     echo "And is valid"


### PR DESCRIPTION
Snapshots require administrator privileges to be imported and hence are assumed to be trusted. However, let's try and be as helpful as possible and validate that they are self-contained on import (ie. there are no files within the snapshot that point outside of the parent directory) and report an error in that case.

Thanks: Sam Sanoop <sams@snyk.io>
Signed-off-by: Alex Murray <alex.murray@canonical.com>
