### PR TITLE
gadget,image: remove LayoutConstraints struct

### DIFF
--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -1192,11 +1192,11 @@ func IsCompatible(current, new *Info) error {
 	// layout both volumes partially, without going deep into the layout of
 	// structure content, we only want to make sure that structures are
 	// comapatible
-	pCurrent, err := LayoutVolumePartially(currentVol, DefaultConstraints)
+	pCurrent, err := LayoutVolumePartially(currentVol)
 	if err != nil {
 		return fmt.Errorf("cannot lay out the current volume: %v", err)
 	}
-	pNew, err := LayoutVolumePartially(newVol, DefaultConstraints)
+	pNew, err := LayoutVolumePartially(newVol)
 	if err != nil {
 		return fmt.Errorf("cannot lay out the new volume: %v", err)
 	}
@@ -1226,9 +1226,6 @@ func LaidOutVolumesFromGadget(gadgetRoot, kernelRoot string, model Model) (syste
 		return nil, nil, err
 	}
 
-	constraints := LayoutConstraints{
-		NonMBRStartOffset: 1 * quantity.OffsetMiB,
-	}
 	// layout all volumes saving them
 	opts := &LayoutOptions{
 		GadgetRootDir: gadgetRoot,
@@ -1238,7 +1235,7 @@ func LaidOutVolumesFromGadget(gadgetRoot, kernelRoot string, model Model) (syste
 	// find the volume with the system-boot role on it, we already validated
 	// that the system-* roles are all on the same volume
 	for name, vol := range info.Volumes {
-		lvol, err := LayoutVolume(vol, constraints, opts)
+		lvol, err := LayoutVolume(vol, opts)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -1854,8 +1854,6 @@ volumes:
 		"pc":      gadgetYamlPC,
 	}
 
-	constr := gadget.LayoutConstraints{NonMBRStartOffset: 1 * quantity.OffsetMiB}
-
 	for volName, yaml := range tests {
 		giMeta, err := gadget.InfoFromGadgetYaml(yaml, nil)
 		c.Assert(err, IsNil)
@@ -1865,7 +1863,7 @@ volumes:
 
 		// also layout the volume and check that when laying out the MBR
 		// structure it retains the role of MBR, as validated by IsRoleMBR
-		ls, err := gadget.LayoutVolumePartially(giMeta.Volumes[volName], constr)
+		ls, err := gadget.LayoutVolumePartially(giMeta.Volumes[volName])
 		c.Assert(err, IsNil)
 		c.Check(gadget.IsRoleMBR(ls.LaidOutStructure[0]), Equals, true)
 	}

--- a/gadget/gadgettest/gadgettest.go
+++ b/gadget/gadgettest/gadgettest.go
@@ -28,7 +28,6 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/boot/boottest"
 	"github.com/snapcore/snapd/gadget"
-	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/osutil/disks"
 )
 
@@ -90,16 +89,13 @@ func MustLayOutSingleVolumeFromGadget(gadgetRoot, kernelRoot string, model gadge
 		return nil, fmt.Errorf("only single volumes supported in test helper")
 	}
 
-	constraints := gadget.LayoutConstraints{
-		NonMBRStartOffset: 1 * quantity.OffsetMiB,
-	}
 	opts := &gadget.LayoutOptions{
 		GadgetRootDir: gadgetRoot,
 		KernelRootDir: kernelRoot,
 	}
 	for _, vol := range info.Volumes {
 		// we know info.Volumes map has size 1 so we can return here
-		return gadget.LayoutVolume(vol, constraints, opts)
+		return gadget.LayoutVolume(vol, opts)
 	}
 
 	// this is impossible to reach, we already checked that info.Volumes has a

--- a/gadget/layout.go
+++ b/gadget/layout.go
@@ -46,13 +46,10 @@ type LayoutOptions struct {
 	KernelRootDir string
 }
 
-// LayoutConstraints defines the constraints for arranging structures within a
-// volume
-type LayoutConstraints struct {
-	// NonMBRStartOffset is the default start offset of non-MBR structure in
-	// the volume.
-	NonMBRStartOffset quantity.Offset
-}
+// NonMBRStartOffset is the minimum start offset of the first non-MBR structure
+// in the volume that does not specify explicitly an offset. It can be ignored
+// by setting explicitly offsets.
+const NonMBRStartOffset = 1 * quantity.OffsetMiB
 
 // LaidOutVolume defines the size of a volume and arrangement of all the
 // structures within it
@@ -150,7 +147,7 @@ type ResolvedContent struct {
 	KernelUpdate bool
 }
 
-func layoutVolumeStructures(volume *Volume, constraints LayoutConstraints) (structures []LaidOutStructure, byName map[string]*LaidOutStructure, err error) {
+func layoutVolumeStructures(volume *Volume) (structures []LaidOutStructure, byName map[string]*LaidOutStructure, err error) {
 	previousEnd := quantity.Offset(0)
 	structures = make([]LaidOutStructure, len(volume.Structure))
 	byName = make(map[string]*LaidOutStructure, len(volume.Structure))
@@ -158,8 +155,8 @@ func layoutVolumeStructures(volume *Volume, constraints LayoutConstraints) (stru
 	for idx, s := range volume.Structure {
 		var start quantity.Offset
 		if s.Offset == nil {
-			if s.Role != schemaMBR && previousEnd < constraints.NonMBRStartOffset {
-				start = constraints.NonMBRStartOffset
+			if s.Role != schemaMBR && previousEnd < NonMBRStartOffset {
+				start = NonMBRStartOffset
 			} else {
 				start = previousEnd
 			}
@@ -203,9 +200,9 @@ func layoutVolumeStructures(volume *Volume, constraints LayoutConstraints) (stru
 	return structures, byName, nil
 }
 
-// LayoutVolumePartially attempts to lay out only the structures in the volume using provided constraints
-func LayoutVolumePartially(volume *Volume, constraints LayoutConstraints) (*PartiallyLaidOutVolume, error) {
-	structures, _, err := layoutVolumeStructures(volume, constraints)
+// LayoutVolumePartially attempts to lay out only the structures in the volume.
+func LayoutVolumePartially(volume *Volume) (*PartiallyLaidOutVolume, error) {
+	structures, _, err := layoutVolumeStructures(volume)
 	if err != nil {
 		return nil, err
 	}
@@ -218,8 +215,8 @@ func LayoutVolumePartially(volume *Volume, constraints LayoutConstraints) (*Part
 }
 
 // LayoutVolume attempts to completely lay out the volume, that is the
-// structures and their content, using provided constraints
-func LayoutVolume(volume *Volume, constraints LayoutConstraints, opts *LayoutOptions) (*LaidOutVolume, error) {
+// structures and their content, using provided options.
+func LayoutVolume(volume *Volume, opts *LayoutOptions) (*LaidOutVolume, error) {
 	var err error
 	if opts == nil {
 		opts = &LayoutOptions{}
@@ -241,7 +238,7 @@ func LayoutVolume(volume *Volume, constraints LayoutConstraints, opts *LayoutOpt
 		}
 	}
 
-	structures, byName, err := layoutVolumeStructures(volume, constraints)
+	structures, byName, err := layoutVolumeStructures(volume)
 	if err != nil {
 		return nil, err
 	}

--- a/gadget/layout_test.go
+++ b/gadget/layout_test.go
@@ -45,10 +45,6 @@ func (p *layoutTestSuite) SetUpTest(c *C) {
 	p.dir = c.MkDir()
 }
 
-var defaultConstraints = gadget.LayoutConstraints{
-	NonMBRStartOffset: 1 * quantity.OffsetMiB,
-}
-
 func (p *layoutTestSuite) TestVolumeSize(c *C) {
 	vol := gadget.Volume{
 		Structure: []gadget.VolumeStructure{
@@ -56,7 +52,7 @@ func (p *layoutTestSuite) TestVolumeSize(c *C) {
 		},
 	}
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
-	v, err := gadget.LayoutVolume(&vol, defaultConstraints, opts)
+	v, err := gadget.LayoutVolume(&vol, opts)
 	c.Assert(err, IsNil)
 
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
@@ -98,7 +94,7 @@ volumes:
 	c.Assert(vol.Structure, HasLen, 2)
 
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
-	v, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
+	v, err := gadget.LayoutVolume(vol, opts)
 	c.Assert(err, IsNil)
 
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
@@ -141,7 +137,7 @@ volumes:
 	c.Assert(vol.Structure, HasLen, 4)
 
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
-	v, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
+	v, err := gadget.LayoutVolume(vol, opts)
 	c.Assert(err, IsNil)
 
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
@@ -198,7 +194,7 @@ volumes:
 	c.Assert(vol.Structure, HasLen, 4)
 
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
-	v, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
+	v, err := gadget.LayoutVolume(vol, opts)
 	c.Assert(err, IsNil)
 
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
@@ -254,7 +250,7 @@ volumes:
 	c.Assert(vol.Structure, HasLen, 4)
 
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
-	v, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
+	v, err := gadget.LayoutVolume(vol, opts)
 	c.Assert(err, IsNil)
 
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
@@ -301,7 +297,7 @@ volumes:
 `
 	vol := mustParseVolume(c, gadgetYaml, "first")
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
-	v, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
+	v, err := gadget.LayoutVolume(vol, opts)
 	c.Assert(v, IsNil)
 	c.Assert(err, ErrorMatches, `cannot lay out structure #0: content "foo.img":.*no such file or directory`)
 }
@@ -323,14 +319,14 @@ volumes:
 	opts := &gadget.LayoutOptions{
 		GadgetRootDir: p.dir,
 	}
-	// LayoutVolume fails with default constraints because the foo.img
+	// LayoutVolume fails with default options because the foo.img
 	// file is missing
-	_, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
+	_, err := gadget.LayoutVolume(vol, opts)
 	c.Assert(err, ErrorMatches, `cannot lay out structure #0: content "foo.img":.*no such file or directory`)
 
 	// But LayoutVolume works with the IgnoreContent works
 	opts.IgnoreContent = true
-	v, err := gadget.LayoutVolume(vol, gadget.DefaultConstraints, opts)
+	v, err := gadget.LayoutVolume(vol, opts)
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
 		Volume:  vol,
@@ -379,7 +375,7 @@ volumes:
 	vol := mustParseVolume(c, gadgetYaml, "first")
 
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
-	v, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
+	v, err := gadget.LayoutVolume(vol, opts)
 	c.Assert(v, IsNil)
 	c.Assert(err, ErrorMatches, `cannot lay out structure #0: content "foo.img" does not fit in the structure`)
 }
@@ -402,11 +398,8 @@ volumes:
 
 	vol := mustParseVolume(c, gadgetYaml, "first")
 
-	constraints := gadget.LayoutConstraints{
-		NonMBRStartOffset: 1 * quantity.OffsetMiB,
-	}
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
-	v, err := gadget.LayoutVolume(vol, constraints, opts)
+	v, err := gadget.LayoutVolume(vol, opts)
 	c.Assert(v, IsNil)
 	c.Assert(err, ErrorMatches, `cannot lay out structure #0: content "bar.img" does not fit in the structure`)
 }
@@ -430,7 +423,7 @@ volumes:
 	vol := mustParseVolume(c, gadgetYaml, "first")
 
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
-	v, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
+	v, err := gadget.LayoutVolume(vol, opts)
 	c.Assert(v, IsNil)
 	c.Assert(err, ErrorMatches, `cannot lay out structure #0: content "foo.img" does not fit in the structure`)
 }
@@ -453,7 +446,7 @@ volumes:
 	vol := mustParseVolume(c, gadgetYaml, "first")
 
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
-	v, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
+	v, err := gadget.LayoutVolume(vol, opts)
 	c.Assert(v, IsNil)
 	c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot lay out structure #0: content "foo.img" size %v is larger than declared %v`, quantity.SizeMiB+1, quantity.SizeMiB))
 }
@@ -482,7 +475,7 @@ volumes:
 	vol := mustParseVolume(c, gadgetYaml, "first")
 
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
-	v, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
+	v, err := gadget.LayoutVolume(vol, opts)
 	c.Assert(v, IsNil)
 	c.Assert(err, ErrorMatches, `cannot lay out structure #0: content "foo.img" overlaps with preceding image "bar.img"`)
 }
@@ -512,7 +505,7 @@ volumes:
 	c.Assert(vol.Structure[0].Content, HasLen, 2)
 
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
-	v, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
+	v, err := gadget.LayoutVolume(vol, opts)
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
 		Volume:  vol,
@@ -564,7 +557,7 @@ volumes:
 	c.Assert(vol.Structure[0].Content, HasLen, 2)
 
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
-	v, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
+	v, err := gadget.LayoutVolume(vol, opts)
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
 		Volume:  vol,
@@ -613,7 +606,7 @@ volumes:
 	c.Assert(vol.Structure[0].Content, HasLen, 1)
 
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
-	v, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
+	v, err := gadget.LayoutVolume(vol, opts)
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
 		Volume:  vol,
@@ -656,7 +649,7 @@ volumes:
 	c.Assert(vol.Structure[0].Content, HasLen, 1)
 
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
-	v, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
+	v, err := gadget.LayoutVolume(vol, opts)
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
 		Volume:  vol,
@@ -680,116 +673,7 @@ volumes:
 	})
 }
 
-func (p *layoutTestSuite) TestLayoutVolumeConstraintsChange(c *C) {
-	gadgetYaml := `
-volumes:
-  first:
-    schema: gpt
-    bootloader: grub
-    structure:
-        - role: mbr
-          type: bare
-          size: 446
-          offset: 0
-        - type: 00000000-0000-0000-0000-0000deadbeef
-          filesystem: ext4
-          size: 2M
-          content:
-              - source: foo.txt
-                target: /boot
-`
-	resolvedContent := []gadget.ResolvedContent{
-		{
-			VolumeContent: &gadget.VolumeContent{
-				UnresolvedSource: "foo.txt",
-				Target:           "/boot",
-			},
-			ResolvedSource: filepath.Join(p.dir, "foo.txt"),
-		},
-	}
-
-	makeSizedFile(c, filepath.Join(p.dir, "foo.txt"), 0, []byte("foobar\n"))
-
-	vol := mustParseVolume(c, gadgetYaml, "first")
-	c.Assert(vol.Structure, HasLen, 2)
-	c.Assert(vol.Structure[1].Content, HasLen, 1)
-
-	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
-	v, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
-	c.Assert(err, IsNil)
-	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
-		Volume:  vol,
-		Size:    3 * quantity.SizeMiB,
-		RootDir: p.dir,
-		LaidOutStructure: []gadget.LaidOutStructure{
-			{
-				VolumeStructure: &vol.Structure[0],
-				StartOffset:     0,
-				YamlIndex:       0,
-			},
-			{
-				VolumeStructure: &vol.Structure[1],
-				StartOffset:     1 * quantity.OffsetMiB,
-				YamlIndex:       1,
-				ResolvedContent: resolvedContent,
-			},
-		},
-	})
-
-	// still valid
-	constraints := gadget.LayoutConstraints{
-		// 512kiB
-		NonMBRStartOffset: 512 * quantity.OffsetKiB,
-	}
-	v, err = gadget.LayoutVolume(vol, constraints, opts)
-	c.Assert(err, IsNil)
-	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
-		Volume:  vol,
-		Size:    2*quantity.SizeMiB + 512*quantity.SizeKiB,
-		RootDir: p.dir,
-		LaidOutStructure: []gadget.LaidOutStructure{
-			{
-				VolumeStructure: &vol.Structure[0],
-				StartOffset:     0,
-				YamlIndex:       0,
-			},
-			{
-				VolumeStructure: &vol.Structure[1],
-				StartOffset:     512 * quantity.OffsetKiB,
-				YamlIndex:       1,
-				ResolvedContent: resolvedContent,
-			},
-		},
-	})
-
-	// constraints would make a non MBR structure overlap with MBR, but
-	// structures start one after another unless offset is specified
-	// explicitly
-	constraintsBad := gadget.LayoutConstraints{
-		NonMBRStartOffset: 400,
-	}
-	v, err = gadget.LayoutVolume(vol, constraintsBad, opts)
-	c.Assert(err, IsNil)
-	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
-		Volume:  vol,
-		Size:    2*quantity.SizeMiB + 446,
-		RootDir: p.dir,
-		LaidOutStructure: []gadget.LaidOutStructure{
-			{
-				VolumeStructure: &vol.Structure[0],
-				YamlIndex:       0,
-			},
-			{
-				VolumeStructure: &vol.Structure[1],
-				StartOffset:     446,
-				YamlIndex:       1,
-				ResolvedContent: resolvedContent,
-			},
-		},
-	})
-}
-
-func (p *layoutTestSuite) TestLayoutVolumeMBRImplicitConstraints(c *C) {
+func (p *layoutTestSuite) TestLayoutVolumeMBR(c *C) {
 	gadgetYaml := `
 volumes:
   first:
@@ -808,7 +692,7 @@ volumes:
 	c.Assert(vol.Structure, HasLen, 2)
 
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
-	v, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
+	v, err := gadget.LayoutVolume(vol, opts)
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
 		Volume:  vol,
@@ -861,7 +745,7 @@ volumes:
 	c.Assert(vol.Structure, HasLen, 3)
 
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
-	v, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
+	v, err := gadget.LayoutVolume(vol, opts)
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
 		Volume:  vol,
@@ -947,11 +831,11 @@ func (p *layoutTestSuite) TestLayoutVolumeOffsetWriteBadRelativeTo(c *C) {
 	makeSizedFile(c, filepath.Join(p.dir, "foo.img"), 200*quantity.SizeKiB, []byte(""))
 
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
-	v, err := gadget.LayoutVolume(&volBadStructure, defaultConstraints, opts)
+	v, err := gadget.LayoutVolume(&volBadStructure, opts)
 	c.Check(v, IsNil)
 	c.Check(err, ErrorMatches, `cannot resolve offset-write of structure #0 \("foo"\): refers to an unknown structure "bar"`)
 
-	v, err = gadget.LayoutVolume(&volBadContent, defaultConstraints, opts)
+	v, err = gadget.LayoutVolume(&volBadContent, opts)
 	c.Check(v, IsNil)
 	c.Check(err, ErrorMatches, `cannot resolve offset-write of structure #0 \("foo"\) content "foo.img": refers to an unknown structure "bar"`)
 }
@@ -976,7 +860,7 @@ volumes:
 	vol := mustParseVolume(c, gadgetYamlStructure, "pc")
 
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
-	v, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
+	v, err := gadget.LayoutVolume(vol, opts)
 	c.Assert(err, IsNil)
 	// offset-write is at 1GB
 	c.Check(v.Size, Equals, 1*quantity.SizeGiB+gadget.SizeLBA48Pointer)
@@ -1011,7 +895,7 @@ volumes:
 
 	vol = mustParseVolume(c, gadgetYamlContent, "pc")
 
-	v, err = gadget.LayoutVolume(vol, defaultConstraints, opts)
+	v, err = gadget.LayoutVolume(vol, opts)
 	c.Assert(err, IsNil)
 	// foo.img offset-write is at 3GB
 	c.Check(v.Size, Equals, 3*quantity.SizeGiB+gadget.SizeLBA48Pointer)
@@ -1033,7 +917,7 @@ volumes:
 	vol := mustParseVolume(c, gadgetYaml, "first")
 	c.Assert(vol.Structure, HasLen, 1)
 
-	v, err := gadget.LayoutVolumePartially(vol, defaultConstraints)
+	v, err := gadget.LayoutVolumePartially(vol)
 	c.Assert(v, DeepEquals, &gadget.PartiallyLaidOutVolume{
 		Volume: vol,
 		LaidOutStructure: []gadget.LaidOutStructure{
@@ -1070,7 +954,7 @@ volumes:
 	vol := mustParseVolume(c, gadgetYamlContent, "pc")
 
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
-	v, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
+	v, err := gadget.LayoutVolume(vol, opts)
 	c.Assert(err, IsNil)
 	c.Assert(v.LaidOutStructure, HasLen, 1)
 	c.Assert(v.LaidOutStructure[0].LaidOutContent, HasLen, 2)
@@ -1192,7 +1076,7 @@ func (p *layoutTestSuite) TestResolveContentPathsNotInWantedAssets(c *C) {
 
 	kernelSnapDir := c.MkDir()
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir, KernelRootDir: kernelSnapDir}
-	_, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
+	_, err := gadget.LayoutVolume(vol, opts)
 	c.Assert(err, ErrorMatches, `cannot resolve content for structure #0 at index 0: cannot find "dtbs" in kernel info from "/.*"`)
 }
 
@@ -1204,14 +1088,14 @@ func (p *layoutTestSuite) TestResolveContentPathsSkipResolveContent(c *C) {
 	defaultOpts := &gadget.LayoutOptions{GadgetRootDir: p.dir, KernelRootDir: kernelSnapDir}
 
 	opts := defaultOpts
-	_, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
+	_, err := gadget.LayoutVolume(vol, opts)
 	c.Assert(err, ErrorMatches, `cannot resolve content for structure #0 at index 0: cannot find "dtbs" in kernel info from "/.*"`)
 
 	// SkipResolveContent will allow to layout the volume even if
 	// files are missing
 	opts = defaultOpts
 	opts.SkipResolveContent = true
-	v, err := gadget.LayoutVolume(vol, gadget.DefaultConstraints, opts)
+	v, err := gadget.LayoutVolume(vol, opts)
 	c.Assert(err, IsNil)
 	c.Assert(v.Structure, HasLen, 1)
 
@@ -1219,7 +1103,7 @@ func (p *layoutTestSuite) TestResolveContentPathsSkipResolveContent(c *C) {
 	// files are missing
 	opts = defaultOpts
 	opts.IgnoreContent = true
-	v, err = gadget.LayoutVolume(vol, gadget.DefaultConstraints, opts)
+	v, err = gadget.LayoutVolume(vol, opts)
 	c.Assert(err, IsNil)
 	c.Assert(v.Structure, HasLen, 1)
 }
@@ -1234,7 +1118,7 @@ func (p *layoutTestSuite) TestResolveContentPathsErrorInKernelRef(c *C) {
 
 	kernelSnapDir := c.MkDir()
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir, KernelRootDir: kernelSnapDir}
-	_, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
+	_, err := gadget.LayoutVolume(vol, opts)
 	c.Assert(err, ErrorMatches, `cannot resolve content for structure #0 at index 0: cannot parse kernel ref: invalid asset name in kernel ref "\$kernel:-invalid-kernel-ref/boot-assets/"`)
 }
 
@@ -1254,7 +1138,7 @@ assets:
 		"dtbs/foo.dtb": "foo.dtb content",
 	})
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir, KernelRootDir: kernelSnapDir}
-	_, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
+	_, err := gadget.LayoutVolume(vol, opts)
 	c.Assert(err, ErrorMatches, `cannot resolve content for structure #0 at index 0: cannot find wanted kernel content "boot-assets/" in "/.*"`)
 }
 
@@ -1276,7 +1160,7 @@ assets:
 	}
 	kernelSnapDir := mockKernel(c, kernelYaml, kernelSnapFiles)
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir, KernelRootDir: kernelSnapDir}
-	lv, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
+	lv, err := gadget.LayoutVolume(vol, opts)
 	c.Assert(err, IsNil)
 	// Volume.Content is unchanged
 	c.Assert(lv.Structure, HasLen, 1)
@@ -1357,7 +1241,7 @@ assets:
 		"dtbs/foo.dtb": "foo.dtb content",
 	})
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir, KernelRootDir: kernelSnapDir}
-	lv, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
+	lv, err := gadget.LayoutVolume(vol, opts)
 	c.Assert(err, IsNil)
 	// Volume.Content is unchanged
 	c.Assert(lv.Structure, HasLen, 1)
@@ -1427,6 +1311,6 @@ assets:
 		"a/foo.dtb": "foo.dtb content",
 	})
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir, KernelRootDir: kernelSnapDir}
-	_, err := gadget.LayoutVolume(vol, defaultConstraints, opts)
+	_, err := gadget.LayoutVolume(vol, opts)
 	c.Assert(err, ErrorMatches, `.*: cannot find wanted kernel content "ab" in.*`)
 }

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -39,13 +39,6 @@ var (
 	ErrNoUpdate = errors.New("nothing to update")
 )
 
-var (
-	// default positioning constraints that match ubuntu-image
-	DefaultConstraints = LayoutConstraints{
-		NonMBRStartOffset: 1 * quantity.OffsetMiB,
-	}
-)
-
 // GadgetData holds references to a gadget revision metadata and its data directory.
 type GadgetData struct {
 	// Info is the gadget metadata
@@ -1257,12 +1250,12 @@ func Update(model Model, old, new GadgetData, rollbackDirPath string, updatePoli
 
 		// layout old partially, without going deep into the layout of structure
 		// content
-		pOld, err := LayoutVolumePartially(oldVol, DefaultConstraints)
+		pOld, err := LayoutVolumePartially(oldVol)
 		if err != nil {
 			return fmt.Errorf("cannot lay out the old volume %s: %v", volName, err)
 		}
 
-		pNew, err := LayoutVolume(newVol, DefaultConstraints, opts)
+		pNew, err := LayoutVolume(newVol, opts)
 		if err != nil {
 			return fmt.Errorf("cannot lay out the new volume %s: %v", volName, err)
 		}

--- a/gadget/update_test.go
+++ b/gadget/update_test.go
@@ -4297,10 +4297,6 @@ func (u *updateTestSuite) TestBuildNewVolumeToDeviceMappingImplicitSystemBootMul
 	gadgetRoot, err := gadgettest.WriteGadgetYaml(c.MkDir(), implicitSystemBootVolumeYAML)
 	c.Assert(err, IsNil)
 
-	constraints := gadget.LayoutConstraints{
-		NonMBRStartOffset: 1 * quantity.OffsetMiB,
-	}
-
 	info, err := gadget.ReadInfo(gadgetRoot, uc16Model)
 	c.Assert(err, IsNil)
 
@@ -4308,7 +4304,7 @@ func (u *updateTestSuite) TestBuildNewVolumeToDeviceMappingImplicitSystemBootMul
 
 	opts := &gadget.LayoutOptions{GadgetRootDir: gadgetRoot}
 	for volName, vol := range info.Volumes {
-		lvol, err := gadget.LayoutVolume(vol, constraints, opts)
+		lvol, err := gadget.LayoutVolume(vol, opts)
 		c.Assert(err, IsNil)
 		allLaidOutVolumes[volName] = lvol
 	}

--- a/gadget/validate.go
+++ b/gadget/validate.go
@@ -403,7 +403,7 @@ func ValidateContent(info *Info, gadgetSnapRootDir, kernelSnapRootDir string) er
 		if kernelSnapRootDir == "" {
 			opts.SkipResolveContent = true
 		}
-		lv, err := LayoutVolume(vol, DefaultConstraints, opts)
+		lv, err := LayoutVolume(vol, opts)
 		if err != nil {
 			return fmt.Errorf("invalid layout of volume %q: %v", name, err)
 		}

--- a/image/helpers.go
+++ b/image/helpers.go
@@ -90,7 +90,7 @@ func writeResolvedContentImpl(prepareDir string, info *gadget.Info, gadgetUnpack
 		KernelRootDir: kernelUnpackDir,
 	}
 	for volName, vol := range info.Volumes {
-		pvol, err := gadget.LayoutVolume(vol, gadget.DefaultConstraints, opts)
+		pvol, err := gadget.LayoutVolume(vol, opts)
 		if err != nil {
 			return err
 		}

--- a/tests/lib/muinstaller/go.mod
+++ b/tests/lib/muinstaller/go.mod
@@ -2,5 +2,7 @@ module github.com/snapcore/snapd/tests/lib/muinstaller
 
 go 1.18
 
-require github.com/snapcore/snapd v0.0.0-20220929103851-d41483655caf
+// XXX remove as soon as https://github.com/snapcore/snapd/pull/12416 is merged
+replace github.com/snapcore/snapd => github.com/alfonsosanchezbeato/snapd v0.0.0-20221208104831-e59c3215b42c
 
+require github.com/snapcore/snapd v0.0.0-20220929103851-d41483655caf

--- a/tests/lib/muinstaller/main.go
+++ b/tests/lib/muinstaller/main.go
@@ -175,7 +175,7 @@ func createPartitions(bootDevice string, volumes map[string]*gadget.Volume) ([]g
 		IgnoreContent: true,
 	}
 
-	lvol, err := gadget.LayoutVolume(vol, gadget.DefaultConstraints, layoutOpts)
+	lvol, err := gadget.LayoutVolume(vol, layoutOpts)
 	if err != nil {
 		return nil, fmt.Errorf("cannot layout volume: %v", err)
 	}


### PR DESCRIPTION
LayoutConstraints was used only for the NonMBRStartOffset, which was actually always the same value unless used by ubuntu-image. It is possible to override this offset by setting explicitly offsets in gadget.yaml, so we do not need it to be configurable.

When used from ubuntu-image it was being set to zero, but anyway u-i calculates explicitly all offsets and inserts them in VolumeStructure, so this change should not be an issue for it.