### PR TITLE
secboot: detect lockout mode in CheckTPMKeySealingSupported

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/seccomp/libseccomp-golang v0.9.2-0.20220502024300-f57e1d55ea18
 	github.com/snapcore/bolt v1.3.2-0.20210908134111-63c8bfcf7af8
 	github.com/snapcore/go-gettext v0.0.0-20191107141714-82bbea49e785
-	github.com/snapcore/secboot v0.0.0-20220922155412-5d2b29ff0ee2
+	github.com/snapcore/secboot v0.0.0-20230119174011-57239c9f324a
 	golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90
 	golang.org/x/net v0.0.0-20220826154423-83b083e8dc8b // indirect
 	golang.org/x/sys v0.0.0-20220829200755-d48e67d00261

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/snapcore/secboot v0.0.0-20220905094328-6a625ee231d3 h1:58BNTUsb16y89b
 github.com/snapcore/secboot v0.0.0-20220905094328-6a625ee231d3/go.mod h1:72paVOkm4sJugXt+v9ItmnjXgO921D8xqsbH2OekouY=
 github.com/snapcore/secboot v0.0.0-20220922155412-5d2b29ff0ee2 h1:sPC5tmNoJ6H8Pu9OHZiYP1YIAlG98Nm44CYS9nliPz0=
 github.com/snapcore/secboot v0.0.0-20220922155412-5d2b29ff0ee2/go.mod h1:72paVOkm4sJugXt+v9ItmnjXgO921D8xqsbH2OekouY=
+github.com/snapcore/secboot v0.0.0-20230119174011-57239c9f324a h1:MwEn6ADhO9DYtqRnat71TOYxcNxBVUeqfDCBtrYcu7Y=
+github.com/snapcore/secboot v0.0.0-20230119174011-57239c9f324a/go.mod h1:72paVOkm4sJugXt+v9ItmnjXgO921D8xqsbH2OekouY=
 github.com/snapcore/snapd v0.0.0-20201005140838-501d14ac146e/go.mod h1:3xrn7QDDKymcE5VO2rgWEQ5ZAUGb9htfwlXnoel6Io8=
 go.mozilla.org/pkcs7 v0.0.0-20200128120323-432b2356ecb1 h1:A/5uWzF44DlIgdm/PQFwfMkW0JX+cIcQi/SwLAmZP5M=
 go.mozilla.org/pkcs7 v0.0.0-20200128120323-432b2356ecb1/go.mod h1:SNgMg+EgDFwmvSmLRTNKC5fegJjB7v23qTQ0XLGUNHk=

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -2603,7 +2603,7 @@ func (m *DeviceManager) checkEncryption(st *state.State, deviceCtx snapstate.Dev
 	return res.Type, res.UnavailableErr
 }
 
-func (m *DeviceManager) encryptionSupportInfo(model *asserts.Model, mode secboot.TPMProvisionMode, kernelInfo *snap.Info, gadgetInfo *gadget.Info) (EncryptionSupportInfo, error) {
+func (m *DeviceManager) encryptionSupportInfo(model *asserts.Model, tpmMode secboot.TPMProvisionMode, kernelInfo *snap.Info, gadgetInfo *gadget.Info) (EncryptionSupportInfo, error) {
 	secured := model.Grade() == asserts.ModelSecured
 	dangerous := model.Grade() == asserts.ModelDangerous
 	encrypted := model.StorageSafety() == asserts.StorageSafetyEncrypted
@@ -2630,7 +2630,7 @@ func (m *DeviceManager) encryptionSupportInfo(model *asserts.Model, mode secboot
 	case checkFDESetupHookEncryption:
 		res.Type, checkEncryptionErr = m.checkFDEFeatures()
 	case checkSecbootEncryption:
-		checkEncryptionErr = secbootCheckTPMKeySealingSupported(mode)
+		checkEncryptionErr = secbootCheckTPMKeySealingSupported(tpmMode)
 		if checkEncryptionErr == nil {
 			res.Type = secboot.EncryptionTypeLUKS
 		}

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -2026,7 +2026,7 @@ func (m *DeviceManager) SystemAndGadgetAndEncryptionInfo(wantedSystemLabel strin
 	}
 
 	// Encryption details
-	encInfo, err := m.encryptionSupportInfo(sys.Model, snapInfos[snap.TypeKernel], gadgetInfo)
+	encInfo, err := m.encryptionSupportInfo(sys.Model, secboot.TPMProvisionFull, snapInfos[snap.TypeKernel], gadgetInfo)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -2572,7 +2572,7 @@ var secbootCheckTPMKeySealingSupported = secboot.CheckTPMKeySealingSupported
 // checkEncryption verifies whether encryption should be used based on the
 // model grade and the availability of a TPM device or a fde-setup hook
 // in the kernel.
-func (m *DeviceManager) checkEncryption(st *state.State, deviceCtx snapstate.DeviceContext) (secboot.EncryptionType, error) {
+func (m *DeviceManager) checkEncryption(st *state.State, deviceCtx snapstate.DeviceContext, mode secboot.TPMProvisionMode) (secboot.EncryptionType, error) {
 	model := deviceCtx.Model()
 
 	kernelInfo, err := snapstate.KernelInfo(st, deviceCtx)
@@ -2588,7 +2588,7 @@ func (m *DeviceManager) checkEncryption(st *state.State, deviceCtx snapstate.Dev
 		return "", err
 	}
 
-	res, err := m.encryptionSupportInfo(model, kernelInfo, gadgetInfo)
+	res, err := m.encryptionSupportInfo(model, mode, kernelInfo, gadgetInfo)
 	if err != nil {
 		return "", err
 	}
@@ -2603,7 +2603,7 @@ func (m *DeviceManager) checkEncryption(st *state.State, deviceCtx snapstate.Dev
 	return res.Type, res.UnavailableErr
 }
 
-func (m *DeviceManager) encryptionSupportInfo(model *asserts.Model, kernelInfo *snap.Info, gadgetInfo *gadget.Info) (EncryptionSupportInfo, error) {
+func (m *DeviceManager) encryptionSupportInfo(model *asserts.Model, mode secboot.TPMProvisionMode, kernelInfo *snap.Info, gadgetInfo *gadget.Info) (EncryptionSupportInfo, error) {
 	secured := model.Grade() == asserts.ModelSecured
 	dangerous := model.Grade() == asserts.ModelDangerous
 	encrypted := model.StorageSafety() == asserts.StorageSafetyEncrypted
@@ -2630,7 +2630,7 @@ func (m *DeviceManager) encryptionSupportInfo(model *asserts.Model, kernelInfo *
 	case checkFDESetupHookEncryption:
 		res.Type, checkEncryptionErr = m.checkFDEFeatures()
 	case checkSecbootEncryption:
-		checkEncryptionErr = secbootCheckTPMKeySealingSupported()
+		checkEncryptionErr = secbootCheckTPMKeySealingSupported(mode)
 		if checkEncryptionErr == nil {
 			res.Type = secboot.EncryptionTypeLUKS
 		}

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -2572,7 +2572,7 @@ var secbootCheckTPMKeySealingSupported = secboot.CheckTPMKeySealingSupported
 // checkEncryption verifies whether encryption should be used based on the
 // model grade and the availability of a TPM device or a fde-setup hook
 // in the kernel.
-func (m *DeviceManager) checkEncryption(st *state.State, deviceCtx snapstate.DeviceContext, mode secboot.TPMProvisionMode) (secboot.EncryptionType, error) {
+func (m *DeviceManager) checkEncryption(st *state.State, deviceCtx snapstate.DeviceContext, tpmMode secboot.TPMProvisionMode) (secboot.EncryptionType, error) {
 	model := deviceCtx.Model()
 
 	kernelInfo, err := snapstate.KernelInfo(st, deviceCtx)
@@ -2588,7 +2588,7 @@ func (m *DeviceManager) checkEncryption(st *state.State, deviceCtx snapstate.Dev
 		return "", err
 	}
 
-	res, err := m.encryptionSupportInfo(model, mode, kernelInfo, gadgetInfo)
+	res, err := m.encryptionSupportInfo(model, tpmMode, kernelInfo, gadgetInfo)
 	if err != nil {
 		return "", err
 	}

--- a/overlord/devicestate/devicestate_install_api_test.go
+++ b/overlord/devicestate/devicestate_install_api_test.go
@@ -287,7 +287,10 @@ func (s *deviceMgrInstallAPISuite) testInstallFinishStep(c *C, opts finishStepOp
 	// Insert encryption data when enabled
 	if opts.encrypted {
 		// Mock TPM and sealing
-		restore := devicestate.MockSecbootCheckTPMKeySealingSupported(func(secboot.TPMProvisionMode) error { return nil })
+		restore := devicestate.MockSecbootCheckTPMKeySealingSupported(func(tpmMode secboot.TPMProvisionMode) error {
+			c.Check(tpmMode, Equals, secboot.TPMProvisionFull)
+			return nil
+		})
 		s.AddCleanup(restore)
 		restore = boot.MockSealKeyToModeenv(func(key, saveKey keys.EncryptionKey, model *asserts.Model, modeenv *boot.Modeenv, flags boot.MockSealKeyToModeenvFlags) error {
 			c.Check(model.Classic(), Equals, opts.isClassic)
@@ -434,7 +437,10 @@ func (s *deviceMgrInstallAPISuite) testInstallSetupStorageEncryption(c *C, hasTP
 
 	// Simulate system with TPM
 	if hasTPM {
-		restore := devicestate.MockSecbootCheckTPMKeySealingSupported(func(secboot.TPMProvisionMode) error { return nil })
+		restore := devicestate.MockSecbootCheckTPMKeySealingSupported(func(tpmMode secboot.TPMProvisionMode) error {
+			c.Check(tpmMode, Equals, secboot.TPMProvisionFull)
+			return nil
+		})
 		s.AddCleanup(restore)
 	}
 

--- a/overlord/devicestate/devicestate_install_api_test.go
+++ b/overlord/devicestate/devicestate_install_api_test.go
@@ -287,7 +287,7 @@ func (s *deviceMgrInstallAPISuite) testInstallFinishStep(c *C, opts finishStepOp
 	// Insert encryption data when enabled
 	if opts.encrypted {
 		// Mock TPM and sealing
-		restore := devicestate.MockSecbootCheckTPMKeySealingSupported(func() error { return nil })
+		restore := devicestate.MockSecbootCheckTPMKeySealingSupported(func(secboot.TPMProvisionMode) error { return nil })
 		s.AddCleanup(restore)
 		restore = boot.MockSealKeyToModeenv(func(key, saveKey keys.EncryptionKey, model *asserts.Model, modeenv *boot.Modeenv, flags boot.MockSealKeyToModeenvFlags) error {
 			c.Check(model.Classic(), Equals, opts.isClassic)
@@ -434,7 +434,7 @@ func (s *deviceMgrInstallAPISuite) testInstallSetupStorageEncryption(c *C, hasTP
 
 	// Simulate system with TPM
 	if hasTPM {
-		restore := devicestate.MockSecbootCheckTPMKeySealingSupported(func() error { return nil })
+		restore := devicestate.MockSecbootCheckTPMKeySealingSupported(func(secboot.TPMProvisionMode) error { return nil })
 		s.AddCleanup(restore)
 	}
 

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -108,7 +108,7 @@ func (s *deviceMgrInstallModeSuite) SetUpTest(c *C) {
 	})
 	s.AddCleanup(restore)
 
-	restore = devicestate.MockSecbootCheckTPMKeySealingSupported(func() error {
+	restore = devicestate.MockSecbootCheckTPMKeySealingSupported(func(secboot.TPMProvisionMode) error {
 		return fmt.Errorf("TPM not available")
 	})
 	s.AddCleanup(restore)
@@ -266,7 +266,7 @@ func (s *deviceMgrInstallModeSuite) doRunChangeTestWithEncryption(c *C, grade st
 	})
 	defer restore()
 
-	restore = devicestate.MockSecbootCheckTPMKeySealingSupported(func() error {
+	restore = devicestate.MockSecbootCheckTPMKeySealingSupported(func(secboot.TPMProvisionMode) error {
 		if tc.tpm {
 			return nil
 		} else {
@@ -1481,7 +1481,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallBootloaderVarSetFails(c *C) {
 	})
 	defer restore()
 
-	restore = devicestate.MockSecbootCheckTPMKeySealingSupported(func() error { return fmt.Errorf("no encrypted soup for you") })
+	restore = devicestate.MockSecbootCheckTPMKeySealingSupported(func(secboot.TPMProvisionMode) error { return fmt.Errorf("no encrypted soup for you") })
 	defer restore()
 
 	err := ioutil.WriteFile(filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/modeenv"),
@@ -1510,7 +1510,7 @@ func (s *deviceMgrInstallModeSuite) testInstallEncryptionValidityChecks(c *C, er
 	restore := release.MockOnClassic(false)
 	defer restore()
 
-	restore = devicestate.MockSecbootCheckTPMKeySealingSupported(func() error { return nil })
+	restore = devicestate.MockSecbootCheckTPMKeySealingSupported(func(secboot.TPMProvisionMode) error { return nil })
 	defer restore()
 
 	err := ioutil.WriteFile(filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/modeenv"),
@@ -1845,7 +1845,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallWithEncryptionValidatesGadgetErr(
 	defer restore()
 
 	// pretend we have a TPM
-	restore = devicestate.MockSecbootCheckTPMKeySealingSupported(func() error { return nil })
+	restore = devicestate.MockSecbootCheckTPMKeySealingSupported(func(secboot.TPMProvisionMode) error { return nil })
 	defer restore()
 
 	// must be a model that requires encryption to error
@@ -1874,7 +1874,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallWithEncryptionValidatesGadgetWarn
 	defer restore()
 
 	// pretend we have a TPM
-	restore = devicestate.MockSecbootCheckTPMKeySealingSupported(func() error { return nil })
+	restore = devicestate.MockSecbootCheckTPMKeySealingSupported(func(secboot.TPMProvisionMode) error { return nil })
 	defer restore()
 
 	s.testInstallGadgetNoSave(c, "dangerous")
@@ -1898,7 +1898,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallWithoutEncryptionValidatesGadgetW
 	defer restore()
 
 	// pretend we have a TPM
-	restore = devicestate.MockSecbootCheckTPMKeySealingSupported(func() error { return fmt.Errorf("TPM2 not available") })
+	restore = devicestate.MockSecbootCheckTPMKeySealingSupported(func(secboot.TPMProvisionMode) error { return fmt.Errorf("TPM2 not available") })
 	defer restore()
 
 	s.testInstallGadgetNoSave(c, "dangerous")
@@ -1976,7 +1976,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallCheckEncrypted(c *C) {
 		} else {
 			makeInstalledMockKernelSnap(c, st, kernelYamlNoFdeSetup)
 		}
-		restore := devicestate.MockSecbootCheckTPMKeySealingSupported(func() error {
+		restore := devicestate.MockSecbootCheckTPMKeySealingSupported(func(secboot.TPMProvisionMode) error {
 			if tc.hasTPM {
 				return nil
 			}
@@ -1984,7 +1984,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallCheckEncrypted(c *C) {
 		})
 		defer restore()
 
-		encryptionType, err := devicestate.DeviceManagerCheckEncryption(s.mgr, st, deviceCtx)
+		encryptionType, err := devicestate.DeviceManagerCheckEncryption(s.mgr, st, deviceCtx, secboot.TPMProvisionFull)
 		c.Assert(err, IsNil)
 		c.Check(encryptionType, Equals, tc.encryptionType, Commentf("%v", tc))
 		if !tc.hasTPM {
@@ -1999,7 +1999,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallCheckEncryptedStorageSafety(c *C)
 
 	s.makeMockInstalledPcKernelAndGadget(c, "", "")
 
-	restore := devicestate.MockSecbootCheckTPMKeySealingSupported(func() error { return nil })
+	restore := devicestate.MockSecbootCheckTPMKeySealingSupported(func(secboot.TPMProvisionMode) error { return nil })
 	defer restore()
 
 	var testCases = []struct {
@@ -2042,7 +2042,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallCheckEncryptedStorageSafety(c *C)
 		})
 		deviceCtx := &snapstatetest.TrivialDeviceContext{DeviceModel: mockModel}
 
-		encryptionType, err := devicestate.DeviceManagerCheckEncryption(s.mgr, s.state, deviceCtx)
+		encryptionType, err := devicestate.DeviceManagerCheckEncryption(s.mgr, s.state, deviceCtx, secboot.TPMProvisionFull)
 		c.Assert(err, IsNil)
 		encrypt := (encryptionType != secboot.EncryptionTypeNone)
 		c.Check(encrypt, Equals, tc.expectedEncryption, Commentf("%v", tc))
@@ -2055,7 +2055,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallCheckEncryptedErrors(c *C) {
 
 	s.makeMockInstalledPcKernelAndGadget(c, "", "")
 
-	restore := devicestate.MockSecbootCheckTPMKeySealingSupported(func() error { return fmt.Errorf("tpm says no") })
+	restore := devicestate.MockSecbootCheckTPMKeySealingSupported(func(secboot.TPMProvisionMode) error { return fmt.Errorf("tpm says no") })
 	defer restore()
 
 	var testCases = []struct {
@@ -2101,7 +2101,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallCheckEncryptedErrors(c *C) {
 				}},
 		})
 		deviceCtx := &snapstatetest.TrivialDeviceContext{DeviceModel: mockModel}
-		_, err := devicestate.DeviceManagerCheckEncryption(s.mgr, s.state, deviceCtx)
+		_, err := devicestate.DeviceManagerCheckEncryption(s.mgr, s.state, deviceCtx, secboot.TPMProvisionFull)
 		c.Check(err, ErrorMatches, tc.expectedErr, Commentf("%s %s", tc.grade, tc.storageSafety))
 	}
 }
@@ -2192,7 +2192,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallCheckEncryptedErrorsLogsTPM(c *C)
 
 	s.makeMockInstalledPcKernelAndGadget(c, "", "")
 
-	restore := devicestate.MockSecbootCheckTPMKeySealingSupported(func() error {
+	restore := devicestate.MockSecbootCheckTPMKeySealingSupported(func(secboot.TPMProvisionMode) error {
 		return fmt.Errorf("tpm says no")
 	})
 	defer restore()
@@ -2202,7 +2202,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallCheckEncryptedErrorsLogsTPM(c *C)
 
 	mockModel := s.makeModelAssertionInState(c, "my-brand", "my-model", checkEncryptionModelHeaders)
 	deviceCtx := &snapstatetest.TrivialDeviceContext{DeviceModel: mockModel}
-	_, err := devicestate.DeviceManagerCheckEncryption(s.mgr, s.state, deviceCtx)
+	_, err := devicestate.DeviceManagerCheckEncryption(s.mgr, s.state, deviceCtx, secboot.TPMProvisionFull)
 	c.Check(err, IsNil)
 	c.Check(logbuf.String(), Matches, "(?s).*: not encrypting device storage as checking TPM gave: tpm says no\n")
 }
@@ -2221,7 +2221,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallCheckEncryptedErrorsLogsHook(c *C
 	makeInstalledMockKernelSnap(c, s.state, kernelYamlWithFdeSetup)
 
 	deviceCtx := &snapstatetest.TrivialDeviceContext{DeviceModel: mockModel}
-	_, err := devicestate.DeviceManagerCheckEncryption(s.mgr, s.state, deviceCtx)
+	_, err := devicestate.DeviceManagerCheckEncryption(s.mgr, s.state, deviceCtx, secboot.TPMProvisionFull)
 	c.Check(err, IsNil)
 	c.Check(logbuf.String(), Matches, "(?s).*: not encrypting device storage as querying kernel fde-setup hook did not succeed:.*\n")
 }
@@ -2405,7 +2405,7 @@ func (s *deviceMgrInstallModeSuite) doRunFactoryResetChange(c *C, model *asserts
 	})
 	defer restore()
 
-	restore = devicestate.MockSecbootCheckTPMKeySealingSupported(func() error {
+	restore = devicestate.MockSecbootCheckTPMKeySealingSupported(func(secboot.TPMProvisionMode) error {
 		if tc.tpm {
 			return nil
 		} else {
@@ -3014,7 +3014,7 @@ func (s *deviceMgrInstallModeSuite) TestFactoryResetExpectedTasks(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 
-	restore = devicestate.MockSecbootCheckTPMKeySealingSupported(func() error {
+	restore = devicestate.MockSecbootCheckTPMKeySealingSupported(func(secboot.TPMProvisionMode) error {
 		return fmt.Errorf("TPM not available")
 	})
 	defer restore()
@@ -3074,7 +3074,7 @@ func (s *deviceMgrInstallModeSuite) TestFactoryResetInstallDeviceHook(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 
-	restore = devicestate.MockSecbootCheckTPMKeySealingSupported(func() error {
+	restore = devicestate.MockSecbootCheckTPMKeySealingSupported(func(secboot.TPMProvisionMode) error {
 		return fmt.Errorf("TPM not available")
 	})
 	defer restore()
@@ -3329,7 +3329,7 @@ func (s *deviceMgrInstallModeSuite) TestEncryptionSupportInfoForceUnencrypted(c 
 	}
 
 	for _, tc := range testCases {
-		restore := devicestate.MockSecbootCheckTPMKeySealingSupported(func() error { return tc.tpmErr })
+		restore := devicestate.MockSecbootCheckTPMKeySealingSupported(func(secboot.TPMProvisionMode) error { return tc.tpmErr })
 		defer restore()
 
 		mockModel := s.makeModelAssertionInState(c, "my-brand", "my-model", map[string]interface{}{
@@ -3362,7 +3362,7 @@ func (s *deviceMgrInstallModeSuite) TestEncryptionSupportInfoForceUnencrypted(c 
 			c.Assert(err, IsNil)
 		}
 
-		res, err := devicestate.DeviceManagerEncryptionSupportInfo(s.mgr, mockModel, kernelInfo, gadgetInfo)
+		res, err := devicestate.DeviceManagerEncryptionSupportInfo(s.mgr, mockModel, secboot.TPMProvisionFull, kernelInfo, gadgetInfo)
 		c.Assert(err, IsNil)
 		c.Check(res, DeepEquals, tc.expected, Commentf("%v", tc))
 	}
@@ -3401,7 +3401,7 @@ func (s *deviceMgrInstallModeSuite) TestEncryptionSupportInfoGadgetIncompatibleW
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	restore := devicestate.MockSecbootCheckTPMKeySealingSupported(func() error { return nil })
+	restore := devicestate.MockSecbootCheckTPMKeySealingSupported(func(secboot.TPMProvisionMode) error { return nil })
 	defer restore()
 
 	kernelInfo := makeInstalledMockKernelSnap(c, s.state, kernelYamlNoFdeSetup)
@@ -3495,7 +3495,7 @@ func (s *deviceMgrInstallModeSuite) TestEncryptionSupportInfoGadgetIncompatibleW
 					"default-channel": "20",
 				}},
 		})
-		res, err := devicestate.DeviceManagerEncryptionSupportInfo(s.mgr, mockModel, kernelInfo, tc.gadgetInfo)
+		res, err := devicestate.DeviceManagerEncryptionSupportInfo(s.mgr, mockModel, secboot.TPMProvisionFull, kernelInfo, tc.gadgetInfo)
 		c.Assert(err, IsNil)
 		c.Check(res, DeepEquals, tc.expected, Commentf("%v", tc))
 	}
@@ -3627,7 +3627,7 @@ func (s *deviceMgrInstallModeSuite) TestEncryptionSupportInfoWithTPM(c *C) {
 		},
 	}
 	for _, tc := range testCases {
-		restore := devicestate.MockSecbootCheckTPMKeySealingSupported(func() error { return tc.tpmErr })
+		restore := devicestate.MockSecbootCheckTPMKeySealingSupported(func(secboot.TPMProvisionMode) error { return tc.tpmErr })
 		defer restore()
 
 		mockModel := s.makeModelAssertionInState(c, "my-brand", "my-model", map[string]interface{}{
@@ -3650,7 +3650,7 @@ func (s *deviceMgrInstallModeSuite) TestEncryptionSupportInfoWithTPM(c *C) {
 					"default-channel": "20",
 				}},
 		})
-		res, err := devicestate.DeviceManagerEncryptionSupportInfo(s.mgr, mockModel, kernelInfo, gadgetInfo)
+		res, err := devicestate.DeviceManagerEncryptionSupportInfo(s.mgr, mockModel, secboot.TPMProvisionFull, kernelInfo, gadgetInfo)
 		c.Assert(err, IsNil)
 		c.Check(res, DeepEquals, tc.expected, Commentf("%v", tc))
 	}
@@ -3775,7 +3775,7 @@ func (s *deviceMgrInstallModeSuite) TestEncryptionSupportInfoWithFdeHook(c *C) {
 					"default-channel": "20",
 				}},
 		})
-		res, err := devicestate.DeviceManagerEncryptionSupportInfo(s.mgr, mockModel, kernelInfo, gadgetInfo)
+		res, err := devicestate.DeviceManagerEncryptionSupportInfo(s.mgr, mockModel, secboot.TPMProvisionFull, kernelInfo, gadgetInfo)
 		c.Assert(err, IsNil)
 		c.Check(res, DeepEquals, tc.expected, Commentf("%v", tc))
 	}

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -108,7 +108,8 @@ func (s *deviceMgrInstallModeSuite) SetUpTest(c *C) {
 	})
 	s.AddCleanup(restore)
 
-	restore = devicestate.MockSecbootCheckTPMKeySealingSupported(func(secboot.TPMProvisionMode) error {
+	restore = devicestate.MockSecbootCheckTPMKeySealingSupported(func(tpmMode secboot.TPMProvisionMode) error {
+		c.Check(tpmMode, Equals, secboot.TPMProvisionFull)
 		return fmt.Errorf("TPM not available")
 	})
 	s.AddCleanup(restore)
@@ -266,7 +267,8 @@ func (s *deviceMgrInstallModeSuite) doRunChangeTestWithEncryption(c *C, grade st
 	})
 	defer restore()
 
-	restore = devicestate.MockSecbootCheckTPMKeySealingSupported(func(secboot.TPMProvisionMode) error {
+	restore = devicestate.MockSecbootCheckTPMKeySealingSupported(func(tpmMode secboot.TPMProvisionMode) error {
+		c.Check(tpmMode, Equals, secboot.TPMProvisionFull)
 		if tc.tpm {
 			return nil
 		} else {
@@ -1845,7 +1847,10 @@ func (s *deviceMgrInstallModeSuite) TestInstallWithEncryptionValidatesGadgetErr(
 	defer restore()
 
 	// pretend we have a TPM
-	restore = devicestate.MockSecbootCheckTPMKeySealingSupported(func(secboot.TPMProvisionMode) error { return nil })
+	restore = devicestate.MockSecbootCheckTPMKeySealingSupported(func(tpmMode secboot.TPMProvisionMode) error {
+		c.Check(tpmMode, Equals, secboot.TPMProvisionFull)
+		return nil
+	})
 	defer restore()
 
 	// must be a model that requires encryption to error
@@ -3014,7 +3019,8 @@ func (s *deviceMgrInstallModeSuite) TestFactoryResetExpectedTasks(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 
-	restore = devicestate.MockSecbootCheckTPMKeySealingSupported(func(secboot.TPMProvisionMode) error {
+	restore = devicestate.MockSecbootCheckTPMKeySealingSupported(func(tpmMode secboot.TPMProvisionMode) error {
+		c.Check(tpmMode, Equals, secboot.TPMPartialReprovision)
 		return fmt.Errorf("TPM not available")
 	})
 	defer restore()
@@ -3074,7 +3080,8 @@ func (s *deviceMgrInstallModeSuite) TestFactoryResetInstallDeviceHook(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 
-	restore = devicestate.MockSecbootCheckTPMKeySealingSupported(func(secboot.TPMProvisionMode) error {
+	restore = devicestate.MockSecbootCheckTPMKeySealingSupported(func(tpmMode secboot.TPMProvisionMode) error {
+		c.Check(tpmMode, Equals, secboot.TPMPartialReprovision)
 		return fmt.Errorf("TPM not available")
 	})
 	defer restore()

--- a/overlord/devicestate/devicestate_systems_test.go
+++ b/overlord/devicestate/devicestate_systems_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/seed"
 	"github.com/snapcore/snapd/seed/seedtest"
 	"github.com/snapcore/snapd/snap"
@@ -2366,7 +2367,7 @@ func (s *modelAndGadgetInfoSuite) TestSystemAndGadgetAndEncyptionInfoHappy(c *C)
 	expectedGadgetInfo, err := gadget.InfoFromGadgetYaml([]byte(mockGadgetUCYaml), fakeModel)
 	c.Assert(err, IsNil)
 
-	restore := devicestate.MockSecbootCheckTPMKeySealingSupported(func() error { return fmt.Errorf("really no tpm") })
+	restore := devicestate.MockSecbootCheckTPMKeySealingSupported(func(secboot.TPMProvisionMode) error { return fmt.Errorf("really no tpm") })
 	defer restore()
 
 	system, gadgetInfo, encInfo, err := s.mgr.SystemAndGadgetAndEncryptionInfo("some-label")

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -337,7 +337,7 @@ func MockBootEnsureNextBootToRunMode(f func(systemLabel string) error) (restore 
 	}
 }
 
-func MockSecbootCheckTPMKeySealingSupported(f func() error) (restore func()) {
+func MockSecbootCheckTPMKeySealingSupported(f func(mode secboot.TPMProvisionMode) error) (restore func()) {
 	old := secbootCheckTPMKeySealingSupported
 	secbootCheckTPMKeySealingSupported = f
 	return func() {
@@ -443,12 +443,12 @@ func DeviceManagerRunFDESetupHook(mgr *DeviceManager, req *fde.SetupRequest) ([]
 	return mgr.runFDESetupHook(req)
 }
 
-func DeviceManagerCheckEncryption(mgr *DeviceManager, st *state.State, deviceCtx snapstate.DeviceContext) (secboot.EncryptionType, error) {
-	return mgr.checkEncryption(st, deviceCtx)
+func DeviceManagerCheckEncryption(mgr *DeviceManager, st *state.State, deviceCtx snapstate.DeviceContext, mode secboot.TPMProvisionMode) (secboot.EncryptionType, error) {
+	return mgr.checkEncryption(st, deviceCtx, mode)
 }
 
-func DeviceManagerEncryptionSupportInfo(mgr *DeviceManager, model *asserts.Model, kernelInfo *snap.Info, gadgetInfo *gadget.Info) (EncryptionSupportInfo, error) {
-	return mgr.encryptionSupportInfo(model, kernelInfo, gadgetInfo)
+func DeviceManagerEncryptionSupportInfo(mgr *DeviceManager, model *asserts.Model, mode secboot.TPMProvisionMode, kernelInfo *snap.Info, gadgetInfo *gadget.Info) (EncryptionSupportInfo, error) {
+	return mgr.encryptionSupportInfo(model, mode, kernelInfo, gadgetInfo)
 }
 
 func DeviceManagerCheckFDEFeatures(mgr *DeviceManager, st *state.State) (secboot.EncryptionType, error) {

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -337,7 +337,7 @@ func MockBootEnsureNextBootToRunMode(f func(systemLabel string) error) (restore 
 	}
 }
 
-func MockSecbootCheckTPMKeySealingSupported(f func(mode secboot.TPMProvisionMode) error) (restore func()) {
+func MockSecbootCheckTPMKeySealingSupported(f func(tpmMode secboot.TPMProvisionMode) error) (restore func()) {
 	old := secbootCheckTPMKeySealingSupported
 	secbootCheckTPMKeySealingSupported = f
 	return func() {

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -334,7 +334,7 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 	bopts := install.Options{
 		Mount: true,
 	}
-	encryptionType, err := m.checkEncryption(st, deviceCtx)
+	encryptionType, err := m.checkEncryption(st, deviceCtx, secboot.TPMProvisionFull)
 	if err != nil {
 		return err
 	}
@@ -893,7 +893,7 @@ func (m *DeviceManager) doFactoryResetRunSystem(t *state.Task, _ *tomb.Tomb) err
 	bopts := install.Options{
 		Mount: true,
 	}
-	encryptionType, err := m.checkEncryption(st, deviceCtx)
+	encryptionType, err := m.checkEncryption(st, deviceCtx, secboot.TPMPartialReprovision)
 	if err != nil {
 		return err
 	}
@@ -1466,7 +1466,7 @@ func (m *DeviceManager) doInstallSetupStorageEncryption(t *state.Task, _ *tomb.T
 		return fmt.Errorf("reading gadget information: %v", err)
 	}
 
-	encryptInfo, err := m.encryptionSupportInfo(sys.Model, snapInfos[snap.TypeKernel], gadgetInfo)
+	encryptInfo, err := m.encryptionSupportInfo(sys.Model, secboot.TPMProvisionFull, snapInfos[snap.TypeKernel], gadgetInfo)
 	if err != nil {
 		return err
 	}

--- a/secboot/export_sb_test.go
+++ b/secboot/export_sb_test.go
@@ -231,3 +231,9 @@ func MockSbTPMDictionaryAttackLockReset(f func(tpm *sb_tpm2.Connection, lockCont
 	sbTPMDictionaryAttackLockReset = f
 	return restore
 }
+
+func MockSbLockoutAuthSet(f func(tpm *sb_tpm2.Connection) bool) (restore func()) {
+	restore = testutil.Backup(&lockoutAuthSet)
+	lockoutAuthSet = f
+	return restore
+}

--- a/secboot/secboot_dummy.go
+++ b/secboot/secboot_dummy.go
@@ -29,7 +29,7 @@ import (
 
 var errBuildWithoutSecboot = errors.New("build without secboot support")
 
-func CheckTPMKeySealingSupported() error {
+func CheckTPMKeySealingSupported(mode TPMProvisionMode) error {
 	return errBuildWithoutSecboot
 }
 

--- a/secboot/secboot_sb_test.go
+++ b/secboot/secboot_sb_test.go
@@ -82,32 +82,38 @@ func (s *secbootSuite) TestCheckTPMKeySealingSupported(c *C) {
 	efiNotSupported := []uint8(nil)
 	tpmErr := errors.New("TPM error")
 
+	tpmModesBoth := []secboot.TPMProvisionMode{secboot.TPMProvisionFull, secboot.TPMPartialReprovision}
 	type testCase struct {
 		tpmErr     error
 		tpmEnabled bool
 		tpmLockout bool
+		tpmModes   []secboot.TPMProvisionMode
 		sbData     []uint8
 		err        string
 	}
 	for i, tc := range []testCase{
 		// happy case
-		{tpmErr: nil, tpmEnabled: true, tpmLockout: false, sbData: sbEnabled, err: ""},
+		{tpmErr: nil, tpmEnabled: true, tpmLockout: false, tpmModes: tpmModesBoth, sbData: sbEnabled, err: ""},
 		// secure boot EFI var is empty
-		{tpmErr: nil, tpmEnabled: true, tpmLockout: false, sbData: sbEmpty, err: "secure boot variable does not exist"},
+		{tpmErr: nil, tpmEnabled: true, tpmLockout: false, tpmModes: tpmModesBoth, sbData: sbEmpty, err: "secure boot variable does not exist"},
 		// secure boot is disabled
-		{tpmErr: nil, tpmEnabled: true, tpmLockout: false, sbData: sbDisabled, err: "secure boot is disabled"},
+		{tpmErr: nil, tpmEnabled: true, tpmLockout: false, tpmModes: tpmModesBoth, sbData: sbDisabled, err: "secure boot is disabled"},
 		// EFI not supported
-		{tpmErr: nil, tpmEnabled: true, tpmLockout: false, sbData: efiNotSupported, err: "not a supported EFI system"},
+		{tpmErr: nil, tpmEnabled: true, tpmLockout: false, tpmModes: tpmModesBoth, sbData: efiNotSupported, err: "not a supported EFI system"},
 		// TPM connection error
-		{tpmErr: tpmErr, sbData: sbEnabled, tpmLockout: false, err: "cannot connect to TPM device: TPM error"},
+		{tpmErr: tpmErr, sbData: sbEnabled, tpmLockout: false, tpmModes: tpmModesBoth, err: "cannot connect to TPM device: TPM error"},
 		// TPM was detected but it's not enabled
-		{tpmErr: nil, tpmEnabled: false, tpmLockout: false, sbData: sbEnabled, err: "TPM device is not enabled"},
+		{tpmErr: nil, tpmEnabled: false, tpmLockout: false, tpmModes: tpmModesBoth, sbData: sbEnabled, err: "TPM device is not enabled"},
 		// No TPM device
-		{tpmErr: sb_tpm2.ErrNoTPM2Device, tpmLockout: false, sbData: sbEnabled, err: "cannot connect to TPM device: no TPM2 device is available"},
-		// In DA lockout mode
-		{tpmErr: nil, tpmEnabled: true, tpmLockout: true, sbData: sbEnabled, err: "the TPM is in DA lockout mode"},
+		{tpmErr: sb_tpm2.ErrNoTPM2Device, tpmLockout: false, tpmModes: tpmModesBoth, sbData: sbEnabled, err: "cannot connect to TPM device: no TPM2 device is available"},
+
+		// In DA lockout mode full provision errors
+		{tpmErr: nil, tpmEnabled: true, tpmLockout: true, tpmModes: []secboot.TPMProvisionMode{secboot.TPMProvisionFull}, sbData: sbEnabled, err: "the TPM is in DA lockout mode"},
+
+		// In DA lockout mode partial provision is fine
+		{tpmErr: nil, tpmEnabled: true, tpmLockout: true, tpmModes: []secboot.TPMProvisionMode{secboot.TPMPartialReprovision}, sbData: sbEnabled, err: ""},
 	} {
-		c.Logf("%d: %v %v %v %q", i, tc.tpmErr, tc.tpmEnabled, tc.sbData, tc.err)
+		c.Logf("%d: %v %v %v %v %q", i, tc.tpmErr, tc.tpmEnabled, tc.tpmModes, tc.sbData, tc.err)
 
 		_, restore := mockSbTPMConnection(c, tc.tpmErr)
 		defer restore()
@@ -129,11 +135,13 @@ func (s *secbootSuite) TestCheckTPMKeySealingSupported(c *C) {
 		restoreEfiVars := efi.MockVars(vars, nil)
 		defer restoreEfiVars()
 
-		err := secboot.CheckTPMKeySealingSupported(secboot.TPMProvisionFull)
-		if tc.err == "" {
-			c.Assert(err, IsNil)
-		} else {
-			c.Assert(err, ErrorMatches, tc.err)
+		for _, tpmMode := range tc.tpmModes {
+			err := secboot.CheckTPMKeySealingSupported(tpmMode)
+			if tc.err == "" {
+				c.Assert(err, IsNil)
+			} else {
+				c.Assert(err, ErrorMatches, tc.err)
+			}
 		}
 	}
 }

--- a/secboot/secboot_sb_test.go
+++ b/secboot/secboot_sb_test.go
@@ -85,28 +85,36 @@ func (s *secbootSuite) TestCheckTPMKeySealingSupported(c *C) {
 	type testCase struct {
 		tpmErr     error
 		tpmEnabled bool
+		tpmLockout bool
 		sbData     []uint8
 		err        string
 	}
 	for i, tc := range []testCase{
 		// happy case
-		{tpmErr: nil, tpmEnabled: true, sbData: sbEnabled, err: ""},
+		{tpmErr: nil, tpmEnabled: true, tpmLockout: false, sbData: sbEnabled, err: ""},
 		// secure boot EFI var is empty
-		{tpmErr: nil, tpmEnabled: true, sbData: sbEmpty, err: "secure boot variable does not exist"},
+		{tpmErr: nil, tpmEnabled: true, tpmLockout: false, sbData: sbEmpty, err: "secure boot variable does not exist"},
 		// secure boot is disabled
-		{tpmErr: nil, tpmEnabled: true, sbData: sbDisabled, err: "secure boot is disabled"},
+		{tpmErr: nil, tpmEnabled: true, tpmLockout: false, sbData: sbDisabled, err: "secure boot is disabled"},
 		// EFI not supported
-		{tpmErr: nil, tpmEnabled: true, sbData: efiNotSupported, err: "not a supported EFI system"},
+		{tpmErr: nil, tpmEnabled: true, tpmLockout: false, sbData: efiNotSupported, err: "not a supported EFI system"},
 		// TPM connection error
-		{tpmErr: tpmErr, sbData: sbEnabled, err: "cannot connect to TPM device: TPM error"},
+		{tpmErr: tpmErr, sbData: sbEnabled, tpmLockout: false, err: "cannot connect to TPM device: TPM error"},
 		// TPM was detected but it's not enabled
-		{tpmErr: nil, tpmEnabled: false, sbData: sbEnabled, err: "TPM device is not enabled"},
+		{tpmErr: nil, tpmEnabled: false, tpmLockout: false, sbData: sbEnabled, err: "TPM device is not enabled"},
 		// No TPM device
-		{tpmErr: sb_tpm2.ErrNoTPM2Device, sbData: sbEnabled, err: "cannot connect to TPM device: no TPM2 device is available"},
+		{tpmErr: sb_tpm2.ErrNoTPM2Device, tpmLockout: false, sbData: sbEnabled, err: "cannot connect to TPM device: no TPM2 device is available"},
+		// In DA lockout mode
+		{tpmErr: nil, tpmEnabled: true, tpmLockout: true, sbData: sbEnabled, err: "the TPM is in DA lockout mode"},
 	} {
 		c.Logf("%d: %v %v %v %q", i, tc.tpmErr, tc.tpmEnabled, tc.sbData, tc.err)
 
 		_, restore := mockSbTPMConnection(c, tc.tpmErr)
+		defer restore()
+
+		restore = secboot.MockSbLockoutAuthSet(func(tpm *sb_tpm2.Connection) bool {
+			return tc.tpmLockout
+		})
 		defer restore()
 
 		restore = secboot.MockIsTPMEnabled(func(tpm *sb_tpm2.Connection) bool {
@@ -121,7 +129,7 @@ func (s *secbootSuite) TestCheckTPMKeySealingSupported(c *C) {
 		restoreEfiVars := efi.MockVars(vars, nil)
 		defer restoreEfiVars()
 
-		err := secboot.CheckTPMKeySealingSupported()
+		err := secboot.CheckTPMKeySealingSupported(secboot.TPMProvisionFull)
 		if tc.err == "" {
 			c.Assert(err, IsNil)
 		} else {

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -68,6 +68,7 @@ var (
 	randutilRandomKernelUUID = randutil.RandomKernelUUID
 
 	isTPMEnabled                        = (*sb_tpm2.Connection).IsEnabled
+	lockoutAuthSet                      = (*sb_tpm2.Connection).LockoutAuthSet
 	sbTPMEnsureProvisioned              = (*sb_tpm2.Connection).EnsureProvisioned
 	sbTPMEnsureProvisionedWithCustomSRK = (*sb_tpm2.Connection).EnsureProvisionedWithCustomSRK
 	tpmReleaseResources                 = tpmReleaseResourcesImpl
@@ -109,16 +110,6 @@ func CheckTPMKeySealingSupported(mode TPMProvisionMode) error {
 	logger.Noticef("TPM device detected and enabled")
 
 	return nil
-}
-
-// TODO: use secboot for this once
-// https://github.com/snapcore/secboot/pull/220 is available
-var lockoutAuthSet = func(tpm *sb_tpm2.Connection) bool {
-	value, err := tpm.TPMContext.GetCapabilityTPMProperty(tpm2.PropertyPermanent)
-	if err != nil {
-		return false
-	}
-	return tpm2.PermanentAttributes(value)&tpm2.AttrLockoutAuthSet > 0
 }
 
 func checkSecureBootEnabled() error {

--- a/tests/nested/manual/muinstaller-real/task.yaml
+++ b/tests/nested/manual/muinstaller-real/task.yaml
@@ -243,4 +243,12 @@ execute: |
           remote.exec "sudo cat $DM | jq '.pc.\"structure-encryption\".\"ubuntu-save\".method'" | MATCH '"LUKS"'
           remote.exec "sudo cat $DM | jq '.pc.\"structure-encryption\".\"ubuntu-data\".method'" | MATCH '"LUKS"'
       done
+
+      # check that on an already provisioned system the API will give a
+      # sensible reason why the system cannot be installed without further
+      # action.
+      remote.exec "sudo apt install -y curl"
+      remote.exec "sudo curl -s --unix-socket /run/snapd.socket http://localhost/v2/systems/$LABEL" > system
+      jq '.result."storage-encryption".support' < system | MATCH "unavailable"
+      jq '.result."storage-encryption"."unavailable-reason"' < system | MATCH "not encrypting device storage as checking TPM gave: the TPM is in DA lockout mode"
   fi


### PR DESCRIPTION
This commit fixes the issue that the detection of TPM key sealing does not take into account if the system is already has the lockout auth attribute set. If this is the case an install will not be successful but currently this is detected very late.

