### PR TITLE
interfaces: add flipper zero to u2f devices under existing STMicro based products

### DIFF
--- a/interfaces/builtin/u2f_devices.go
+++ b/interfaces/builtin/u2f_devices.go
@@ -118,9 +118,9 @@ var u2fDevices = []u2fDevice{
 		ProductIDPattern: "5026",
 	},
 	{
-		Name:             "Tomu board + chopstx U2F + SoloKeys",
+		Name:             "Tomu board + chopstx U2F + SoloKeys + Flipper zero",
 		VendorIDPattern:  "0483",
-		ProductIDPattern: "cdab|a2ca",
+		ProductIDPattern: "cdab|a2ca|5741",
 	},
 	{
 		Name:             "SoloKeys",


### PR DESCRIPTION
Instead of adding it as a new device I added it under the existing entry for STMicroelectronics based devices which use the same VendorID for STM
