### PR TITLE
boot: remove leftovers on kernel installation abort

### DIFF
--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -5257,3 +5257,48 @@ func (s *bootenv20Suite) TestInUseClassicWithModes(c *C) {
 	_, err = boot.InUse(snap.TypeBase, classicWithModesDev)
 	c.Check(err, IsNil)
 }
+
+func (s *bootenv20Suite) TestCoreParticipant20SetNextCurrentKernelSnap(c *C) {
+	coreDev := boottest.MockUC20Device("", nil)
+	c.Assert(coreDev.HasModeenv(), Equals, true)
+
+	r := setupUC20Bootenv(
+		c,
+		s.bootloader,
+		s.normalDefaultState,
+	)
+	defer r()
+
+	// get the boot kernel participant from our current kernel snap
+	bootKern := boot.Participant(s.kern1, snap.TypeKernel, coreDev)
+	// make sure it's not a trivial boot participant
+	c.Assert(bootKern.IsTrivial(), Equals, false)
+
+	// Make it the kernel used on next boot. This sort of situation (same
+	// current and next kernel) can happen when an installation of a new
+	// kernel is aborted before we reboot: in that case we need to clean up
+	// some things although the current kernel did not really change.
+	rebootRequired, err := bootKern.SetNextBoot(boot.NextBootContext{BootWithoutTry: true})
+	c.Assert(err, IsNil)
+	c.Assert(rebootRequired, Equals, boot.RebootInfo{RebootRequired: false})
+
+	// make sure that the bootloader was asked for the current kernel
+	_, nKernelCalls := s.bootloader.GetRunKernelImageFunctionSnapCalls("Kernel")
+	c.Assert(nKernelCalls, Equals, 1)
+
+	// ensure that kernel_status is not set
+	c.Assert(s.bootloader.BootVars["kernel_status"], Equals, "")
+
+	// we were not asked to enable a try kernel
+	actual, _ := s.bootloader.GetRunKernelImageFunctionSnapCalls("EnableTryKernel")
+	c.Assert(len(actual), Equals, 0)
+
+	// and we were asked to disable the try kernel
+	_, nDisableTryCalls := s.bootloader.GetRunKernelImageFunctionSnapCalls("DisableTryKernel")
+	c.Assert(nDisableTryCalls, Equals, 1)
+
+	// and that the modeenv has this kernel listed only once
+	m2, err := boot.ReadModeenv("")
+	c.Assert(err, IsNil)
+	c.Assert(m2.CurrentKernels, DeepEquals, []string{s.kern1.Filename()})
+}

--- a/boot/bootstate20_bloader_kernel_state.go
+++ b/boot/bootstate20_bloader_kernel_state.go
@@ -185,6 +185,11 @@ func (bks *extractedRunKernelImageBootloaderKernelState) setNextKernelNoTry(sn s
 		}
 	}
 
+	// Make sure that no try-kernel.efi link is left around. We do
+	// not really care if this method fails as depending on when
+	// we are undoing it might be there or not.
+	bks.ebl.DisableTryKernel()
+
 	if bks.currentKernelStatus != DefaultStatus {
 		m := map[string]string{
 			"kernel_status": DefaultStatus,

--- a/tests/nested/manual/fde-on-classic/task.yaml
+++ b/tests/nested/manual/fde-on-classic/task.yaml
@@ -64,10 +64,14 @@ execute: |
   remote.exec "snap model --serial --assertion" | MATCH "model: ubuntu-core-22-pc-amd64"
 
   # refresh kernel snap
-  refresh_snap_and_reboot()
+  # $1: path to snap file
+  # $2: snap name
+  # $3: reboot action ("reboot"/"no-reboot")
+  refresh_rebooting_snap()
   {
       local snap_filename=$1
       local snap_name=$2
+      local reboot_action=$3
       printf "Test installing snap from file %s\n" "$snap_filename"
       remote.push "$snap_filename"
       boot_id=$(tests.nested boot-id)
@@ -80,15 +84,29 @@ execute: |
       # Check that no reboot has been scheduled, then force a reboot
       remote.exec not test -f /run/systemd/shutdown/scheduled
 
-      remote.exec sudo reboot || true
-      tests.nested wait-for reboot "$boot_id"
-      remote.exec sudo snap watch "$REMOTE_CHG_ID"
+      if [ "$reboot_action" = "reboot" ]; then
+          remote.exec sudo reboot || true
+          tests.nested wait-for reboot "$boot_id"
+          remote.exec sudo snap watch "$REMOTE_CHG_ID"
+      fi
   }
 
-  refresh_snap_and_reboot pc-kernel-new.snap pc-kernel
+  current_kernel_file=$(remote.exec readlink /run/mnt/ubuntu-boot/EFI/ubuntu/kernel.efi)
+  current_kernel_file=${current_kernel_file%/*}
+
+  # Test aborting a kernel installation before a reboot
+  refresh_rebooting_snap pc-kernel-new.snap pc-kernel no-reboot
+  remote.exec sudo snap abort "$REMOTE_CHG_ID"
+  # Make sure everything is in the same state
+  not remote.exec stat /run/mnt/ubuntu-boot/EFI/ubuntu/try-kernel.efi
+  remote.exec cat /var/lib/snapd/modeenv | MATCH "^current_kernels=$current_kernel_file$"
+  remote.exec cat /run/mnt/ubuntu-boot/EFI/ubuntu/grubenv | MATCH -E "^kernel_status=$"
+
+  # Test successful kernel update
+  refresh_rebooting_snap pc-kernel-new.snap pc-kernel reboot
 
   echo "Refresh pc gadget and assert assets got updated"
-  refresh_snap_and_reboot pc-new.snap pc
+  refresh_rebooting_snap pc-new.snap pc reboot
   for f in /boot/grub/kernel.efi /run/mnt/ubuntu-boot/EFI/boot/bootx64.efi /run/mnt/ubuntu-boot/EFI/boot/grubx64.efi; do
       remote.exec sudo grep -q -a '"This program cannot be run in XXX mode"' "$f"
   done


### PR DESCRIPTION
When we were aborting a kernel installation before a reboot happened, a proper clean-up of left-overs was not happening. To fix that, make sure that current kernels in modeenv is always set appropriately and also make sure that the try-kernel.efi symbolic link used by the grub bootloader is removed.
