### PR TITLE
tests: revert disable netplan part of core20-early-config on 22.04-64 

### DIFF
--- a/tests/nested/manual/core20-early-config/task.yaml
+++ b/tests/nested/manual/core20-early-config/task.yaml
@@ -80,22 +80,17 @@ execute: |
         remote.exec "cat /etc/hostname" | MATCH "foo"
         remote.exec "hostname" | MATCH "foo"
 
-        # 2022-11-30: netplan test on ubuntu-22.04-64 disabled until
-        #  https://bugs.launchpad.net/netplan/+bug/1997467
-        # is fixed
-        if os.query is-focal; then
-          # netplan config defaults are applied
-          remote.exec "sudo cat /etc/netplan/0-snapd-defaults.yaml" | MATCH br54
-          remote.exec "sudo netplan get bridges.br54.dhcp4" | MATCH true
-          remote.exec "sudo snap get system system.network.netplan.network.bridges.br54.dhcp4" | MATCH true
-          remote.exec "sudo netplan get ethernets.ens3.dhcp4" | MATCH false
-          # and updating netplan works
-          remote.exec "sudo snap set system system.network.netplan.network.bridges.br54.dhcp4=false"
-          remote.exec "sudo netplan get bridges.br54.dhcp4" | MATCH false
-          remote.exec "sudo snap get system system.network.netplan.network.bridges.br54.dhcp4" | MATCH false
-          # ensure the test can be repeated
-          remote.exec "sudo rm -f /etc/netplan/90-snapd-config.yaml"
-        fi
+        # netplan config defaults are applied
+        remote.exec "sudo cat /etc/netplan/0-snapd-defaults.yaml" | MATCH br54
+        remote.exec "sudo netplan get bridges.br54.dhcp4" | MATCH true
+        remote.exec "sudo snap get system system.network.netplan.network.bridges.br54.dhcp4" | MATCH true
+        remote.exec "sudo netplan get ethernets.ens3.dhcp4" | MATCH false
+        # and updating netplan works
+        remote.exec "sudo snap set system system.network.netplan.network.bridges.br54.dhcp4=false"
+        remote.exec "sudo netplan get bridges.br54.dhcp4" | MATCH false
+        remote.exec "sudo snap get system system.network.netplan.network.bridges.br54.dhcp4" | MATCH false
+        # ensure the test can be repeated
+        remote.exec "sudo rm -f /etc/netplan/90-snapd-config.yaml"
 
         echo "Check the ssh port file is correct"
         remote.exec "sudo cat /etc/ssh/sshd_config.d/listen.conf" | MATCH "ListenAddress 0\.0\.0\.0:8023"


### PR DESCRIPTION
This reverts commit ccc1cde1ee422f7944ccbb57483feb517438ab03.

Once netplan is fixed we can undo https://github.com/snapcore/snapd/pull/12376