### PR TITLE
logger: allow logging HTTP traffic w/o logging everything

### DIFF
--- a/httputil/logger.go
+++ b/httputil/logger.go
@@ -64,14 +64,14 @@ func (tr *LoggedTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 
 	if flags.debugRequest() {
 		buf, _ := httputil.DumpRequestOut(req, tr.body && flags.debugBody())
-		logger.Debugf("> %q", buf)
+		logger.NoGuardDebugf("> %q", buf)
 	}
 
 	rsp, err := tr.Transport.RoundTrip(req)
 
 	if err == nil && flags.debugResponse() {
 		buf, _ := httputil.DumpResponse(rsp, tr.body && flags.debugBody())
-		logger.Debugf("< %q", buf)
+		logger.NoGuardDebugf("< %q", buf)
 	}
 
 	return rsp, err

--- a/httputil/logger_test.go
+++ b/httputil/logger_test.go
@@ -46,12 +46,10 @@ type loggerSuite struct {
 var _ = check.Suite(&loggerSuite{})
 
 func (s *loggerSuite) TearDownTest(c *check.C) {
-	os.Unsetenv("SNAPD_DEBUG")
 	s.restoreLogger()
 }
 
 func (s *loggerSuite) SetUpTest(c *check.C) {
-	os.Setenv("SNAPD_DEBUG", "true")
 	s.logbuf = bytes.NewBuffer(nil)
 	s.logbuf, s.restoreLogger = logger.MockLogger()
 }

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -131,6 +131,19 @@ func (s *LogSuite) TestWithLoggerLock(c *C) {
 	c.Check(called, Equals, true)
 }
 
+func (s *LogSuite) TestNoGuardDebug(c *C) {
+	debugValue, ok := os.LookupEnv("SNAPD_DEBUG")
+	if ok {
+		defer func() {
+			os.Setenv("SNAPD_DEBUG", debugValue)
+		}()
+		os.Unsetenv("SNAPD_DEBUG")
+	}
+
+	logger.NoGuardDebugf("xyzzy")
+	c.Check(s.logbuf.String(), testutil.Contains, `DEBUG: xyzzy`)
+}
+
 func (s *LogSuite) TestIntegrationDebugFromKernelCmdline(c *C) {
 	// must enable actually checking the command line, because by default the
 	// logger package will skip checking for the kernel command line parameter


### PR DESCRIPTION
Previously, for anything to be logged SNAPD_DEBUG had to be set to a true value (1, true, etc) even if SNAPD_DEBUG_HTTP was already set. In practice, this meant that we couldn't get HTTP logs w/o getting all other logging. This changes that so we can log only HTTP traffic by setting SNAPD_DEBUG_HTTP.