### PR TITLE
boot: avoid reboot loop if there is a bad try kernel

### DIFF
--- a/boot/bootstate20.go
+++ b/boot/bootstate20.go
@@ -392,6 +392,9 @@ func (ks20 *bootState20Kernel) selectAndCommitSnapInitramfsMount(modeenv *Modeen
 		return nil, err
 	}
 
+	// If errTrySnapFallback it means that we are trying a new kernel
+	// but somewhat the status does not look correct of we cannot find
+	// the snap. Reboot so bootloader reverts to using the old kernel.
 	if err == errTrySnapFallback {
 		// this should not actually return, it should immediately reboot
 		return nil, initramfsReboot()
@@ -408,7 +411,6 @@ func (ks20 *bootState20Kernel) selectAndCommitSnapInitramfsMount(modeenv *Modeen
 	// but we need to fallback to the second kernel, but we can't do that in the
 	// initramfs, we need to reboot so the bootloader boots the fallback kernel
 	// for us
-
 	if second != nil {
 		// this should not actually return, it should immediately reboot
 		return nil, initramfsReboot()
@@ -710,7 +712,7 @@ func genericInitramfsSelectSnap(bs bootState20, modeenv *Modeenv, rootfsDir stri
 		} else {
 			// No current snap information found in modeenv for base,
 			// or cannot get information from bootloader for kernel.
-			return nil, nil, fmt.Errorf("current %s snap unusable: %v", typeString, err)
+			return nil, nil, fmt.Errorf("no currently usable %s snaps: %v", typeString, err)
 		}
 	}
 

--- a/boot/initramfs_test.go
+++ b/boot/initramfs_test.go
@@ -219,10 +219,9 @@ func (s *initramfsSuite) TestInitramfsRunModeSelectSnapsToMount(c *C) {
 		{
 			m:                      &boot.Modeenv{Mode: "run", CurrentKernels: []string{kernel1.Filename(), "pc-kernel_badrev.snap"}},
 			kernel:                 kernel1,
-			trykernel:              kernel2,
 			typs:                   []snap.Type{kernelT},
 			blvars:                 map[string]string{"kernel_status": boot.DefaultStatus},
-			snapsToMake:            []snap.PlaceInfo{kernel1, kernel2},
+			snapsToMake:            []snap.PlaceInfo{kernel1},
 			expected:               map[snap.Type]snap.PlaceInfo{kernelT: kernel1},
 			rootfsDir:              filepath.Join(dirs.GlobalRootDir, "/run/mnt/data/system-data"),
 			comment:                "bad try kernel but we don't reboot",
@@ -304,6 +303,20 @@ func (s *initramfsSuite) TestInitramfsRunModeSelectSnapsToMount(c *C) {
 			expRebootPanic: "reboot due to kernel_status wrong",
 			rootfsDir:      filepath.Join(dirs.GlobalRootDir, "/run/mnt/data/system-data"),
 			comment:        "fallback kernel upgrade path, due to kernel_status wrong",
+		},
+		// bad try status and no try kernel found
+		{
+			m:                      &boot.Modeenv{Mode: "run", CurrentKernels: []string{kernel1.Filename(), "pc-kernel_badrev.snap"}},
+			kernel:                 kernel1,
+			typs:                   []snap.Type{kernelT},
+			blvars:                 map[string]string{"kernel_status": boot.TryStatus},
+			snapsToMake:            []snap.PlaceInfo{kernel1},
+			expected:               map[snap.Type]snap.PlaceInfo{kernelT: kernel1},
+			rootfsDir:              filepath.Join(dirs.GlobalRootDir, "/run/mnt/data/system-data"),
+			comment:                "bad try status, we reboot",
+			runBootEnvMethodToFail: "TryKernel",
+			runBootEnvError:        fmt.Errorf("cannot read dangling symlink"),
+			expRebootPanic:         "reboot due to bad try status",
 		},
 
 		//
@@ -424,7 +437,7 @@ func (s *initramfsSuite) TestInitramfsRunModeSelectSnapsToMount(c *C) {
 			m:           &boot.Modeenv{Mode: "run"},
 			typs:        []snap.Type{baseT},
 			snapsToMake: []snap.PlaceInfo{base1},
-			errPattern:  "current base snap unusable: cannot get snap revision: modeenv base boot variable is empty",
+			errPattern:  "no currently usable base snaps: cannot get snap revision: modeenv base boot variable is empty",
 			rootfsDir:   filepath.Join(dirs.GlobalRootDir, "/run/mnt/data/system-data"),
 			comment:     "base snap unset in modeenv",
 		},

--- a/boot/initramfs_test.go
+++ b/boot/initramfs_test.go
@@ -140,18 +140,20 @@ func (s *initramfsSuite) TestInitramfsRunModeSelectSnapsToMount(c *C) {
 	gadgetT := snap.TypeGadget
 
 	tt := []struct {
-		m              *boot.Modeenv
-		expectedM      *boot.Modeenv
-		typs           []snap.Type
-		kernel         snap.PlaceInfo
-		trykernel      snap.PlaceInfo
-		blvars         map[string]string
-		snapsToMake    []snap.PlaceInfo
-		expected       map[snap.Type]snap.PlaceInfo
-		errPattern     string
-		expRebootPanic string
-		rootfsDir      string
-		comment        string
+		m                      *boot.Modeenv
+		expectedM              *boot.Modeenv
+		typs                   []snap.Type
+		kernel                 snap.PlaceInfo
+		trykernel              snap.PlaceInfo
+		blvars                 map[string]string
+		snapsToMake            []snap.PlaceInfo
+		expected               map[snap.Type]snap.PlaceInfo
+		errPattern             string
+		expRebootPanic         string
+		rootfsDir              string
+		comment                string
+		runBootEnvMethodToFail string
+		runBootEnvError        error
 	}{
 		//
 		// default paths
@@ -212,6 +214,20 @@ func (s *initramfsSuite) TestInitramfsRunModeSelectSnapsToMount(c *C) {
 			expected:    map[snap.Type]snap.PlaceInfo{kernelT: kernel1},
 			rootfsDir:   boot.InitramfsDataDir,
 			comment:     "default kernel path for classic with modes",
+		},
+		// dangling link for try kernel should be ignored if not trying status
+		{
+			m:                      &boot.Modeenv{Mode: "run", CurrentKernels: []string{kernel1.Filename(), "pc-kernel_badrev.snap"}},
+			kernel:                 kernel1,
+			trykernel:              kernel2,
+			typs:                   []snap.Type{kernelT},
+			blvars:                 map[string]string{"kernel_status": boot.DefaultStatus},
+			snapsToMake:            []snap.PlaceInfo{kernel1, kernel2},
+			expected:               map[snap.Type]snap.PlaceInfo{kernelT: kernel1},
+			rootfsDir:              filepath.Join(dirs.GlobalRootDir, "/run/mnt/data/system-data"),
+			comment:                "bad try kernel but we don't reboot",
+			runBootEnvMethodToFail: "TryKernel",
+			runBootEnvError:        fmt.Errorf("cannot read dangling symlink"),
 		},
 
 		//
@@ -408,7 +424,7 @@ func (s *initramfsSuite) TestInitramfsRunModeSelectSnapsToMount(c *C) {
 			m:           &boot.Modeenv{Mode: "run"},
 			typs:        []snap.Type{baseT},
 			snapsToMake: []snap.PlaceInfo{base1},
-			errPattern:  "fallback base snap unusable: cannot get snap revision: modeenv base boot variable is empty",
+			errPattern:  "current base snap unusable: cannot get snap revision: modeenv base boot variable is empty",
 			rootfsDir:   filepath.Join(dirs.GlobalRootDir, "/run/mnt/data/system-data"),
 			comment:     "base snap unset in modeenv",
 		},
@@ -616,6 +632,12 @@ func (s *initramfsSuite) TestInitramfsRunModeSelectSnapsToMount(c *C) {
 			var cleanups []func()
 
 			comment := Commentf("[%s] %s", tbl.name, t.comment)
+			if t.runBootEnvMethodToFail != "" {
+				if rbe, ok := tbl.bl.(*boottest.RunBootenv20); ok {
+					cleanups = append(cleanups, rbe.MockExtractedRunKernelImageMixin.SetRunKernelImageFunctionError(
+						t.runBootEnvMethodToFail, t.runBootEnvError))
+				}
+			}
 
 			// we use a panic to simulate a reboot
 			if t.expRebootPanic != "" {

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -2963,7 +2963,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeUpgradeScenarios(c *C) 
 			modeenv: &boot.Modeenv{
 				Mode: "run",
 			},
-			expError: "current base snap unusable: cannot get snap revision: modeenv base boot variable is empty",
+			expError: "no currently usable base snaps: cannot get snap revision: modeenv base boot variable is empty",
 			comment:  "unhappy empty modeenv",
 		},
 		{

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -2963,7 +2963,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeUpgradeScenarios(c *C) 
 			modeenv: &boot.Modeenv{
 				Mode: "run",
 			},
-			expError: "fallback base snap unusable: cannot get snap revision: modeenv base boot variable is empty",
+			expError: "current base snap unusable: cannot get snap revision: modeenv base boot variable is empty",
 			comment:  "unhappy empty modeenv",
 		},
 		{

--- a/tests/nested/core/bad-try-kernel-no-reboot/task.yaml
+++ b/tests/nested/core/bad-try-kernel-no-reboot/task.yaml
@@ -1,0 +1,18 @@
+summary: Make sure that a bad try-kernel.efi does not provoke reboot loops
+
+details: |
+  Make sure that a bad try-kernel.efi does not provoke reboot loops
+
+systems: [ubuntu-20.04-64, ubuntu-22.04-64]
+
+execute: |
+  echo "Wait for the system to be seeded first"
+  remote.exec "sudo snap wait system seed.loaded"
+
+  remote.exec "sudo ln -s badlink /run/mnt/ubuntu-boot/EFI/ubuntu/try-kernel.efi"
+
+  boot_id="$(tests.nested boot-id)"
+  remote.exec "sudo reboot" || true
+
+  echo "Wait for reboot - we will timeout it there was a boot loop"
+  tests.nested wait-for reboot "$boot_id"


### PR DESCRIPTION
In case a bad try kernel was in the disk (i.e. by just a simple
dangling symlink try-kernel.efi), we entered a boot loop. Avoid that.