### PR TITLE
tests: fix the tests.session-support test

### DIFF
--- a/tests/lib/tools/suite/tests.session-support/task.yaml
+++ b/tests/lib/tools/suite/tests.session-support/task.yaml
@@ -1,5 +1,14 @@
 summary: check the session support status of various distributions
 execute: |
+
+    # In case ubuntu core is not already built in prepare helper, the check for uc18
+    # is the same than for ubuntu 18.04
+    if [[ "$SPREAD_SYSTEM" = ubuntu-core-18-* ]]; then
+        if MATCH '^ID=ubuntu$' < /etc/os-release; then
+            exit 0
+        fi
+    fi
+
     case "$SPREAD_SYSTEM/$USER" in
         amazon-linux-2-*|centos-7-*)
             tests.session has-system-systemd-and-dbus | MATCH 'ok'
@@ -27,7 +36,7 @@ execute: |
             tests.session has-session-systemd-and-dbus | MATCH 'ok'
             tests.session has-session-systemd-and-dbus
             ;;
-        ubuntu-core-16-*)
+        ubuntu-core-1[68]-*)
             tests.session has-system-systemd-and-dbus | MATCH 'ok'
             tests.session has-system-systemd-and-dbus
             # Ubuntu Core 16 did not support user sessions.


### PR DESCRIPTION
This test fails because the user session behaves different in ubuntu 18.04 than in uc18.

The test suite tests/lib/tools/suite is no preparing ubuntu core as the main suite does, so then a test in the main suite is executed before the tests.session-support, then the system under test is uc18, but if for example we execute teh test tests/lib/tools/suite/tests.session-support alone, then the system under test is ubuntu-18.04 because the prepare helper is not executed and the uc18 system is not built.

So to fix that, when the system under test matches "$SPREAD_SYSTEM" = ubuntu-core-18-*, but the actual system is '^ID=ubuntu$', in the case the test is not executed because it is the same than the test we do when "$SPREAD_SYSTEM" = ubuntu-18.04
