### PR TITLE
interfaces: Allow desktop_launch interface to access all snap metadata

### DIFF
--- a/interfaces/builtin/desktop_launch.go
+++ b/interfaces/builtin/desktop_launch.go
@@ -42,6 +42,9 @@ const desktopLaunchConnectedPlugAppArmor = `
 /var/lib/snapd/desktop/applications/{,*} r,
 /var/lib/snapd/desktop/icons/{,**} r,
 
+# Allow access to all snap metadata
+/snap/*/*/** r,
+
 #include <abstractions/dbus-session-strict>
 
 dbus (send)


### PR DESCRIPTION
Many snaps put their icons inside the snap metadata directory (e.g. gnome-calculator). If you have a confined launcher app (e.g. a shell in a core desktop) it cannot access these icons unless they are moved to a public location like `/var/lib/snapd/desktop/icons/`. This change allows a snap with the desktop_launch plug to access metadata for all snaps, and so the icons show without modifying the snap.

This change is based on the fact that a snap using the desktop_launch is already aware of all the snaps installed on the system, so accessing the metadata is a reasonable thing to do. The metadata is not expected to contain anything considered a security issue for the consuming snap to know.