### PR TITLE
tests/lib/muinstaller: build from master again

### DIFF
--- a/tests/lib/muinstaller/go.mod
+++ b/tests/lib/muinstaller/go.mod
@@ -2,7 +2,4 @@ module github.com/snapcore/snapd/tests/lib/muinstaller
 
 go 1.18
 
-// XXX remove as soon as https://github.com/snapcore/snapd/pull/12416 is merged
-replace github.com/snapcore/snapd => github.com/alfonsosanchezbeato/snapd v0.0.0-20221208104831-e59c3215b42c
-
-require github.com/snapcore/snapd v0.0.0-20220929103851-d41483655caf
+require github.com/snapcore/snapd v0.0.0-20221213080842-b3362c5d4b1a


### PR DESCRIPTION
As the PR that changed the API has already been merged.