### PR TITLE
tests: add more disk space to ubuntu-22.04 for nested tests

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -233,7 +233,7 @@ backends:
                   workers: 8
             - ubuntu-22.04-64:
                   image: ubuntu-2204-64-virt-enabled
-                  storage: 20G
+                  storage: 25G
                   workers: 8
 
 


### PR DESCRIPTION
After a set of nested tests is executed, the images saved in the disk use space that is required to create new images.

The test tests/nested/manual/muinstaller-real is failing because of not enough space in the disk. This is the error:

2022-12-12T13:07:17.7233318Z
'/tmp/work-dir/images/ubuntu-core-22-custom-muinstaller-real_encrypted.img' -> '/tmp/work-dir/images/ubuntu-core-current.img'
2022-12-12T13:07:17.7233828Z cp: error writing
'/tmp/work-dir/images/ubuntu-core-current.img': No space left on device 2022-12-12T13:07:17.7234006Z -----
2022-12-12T13:07:17.7234125Z .
2022-12-12T13:07:18.1915543Z 2022-12-12 13:07:18 Debug output for google-nested:ubuntu-22.04-64:tests/nested/manual/muinstaller-real:encrypted (dec121149-734952) :
