### PR TITLE
daemon: improvements to REST API helper and JSON responses

### DIFF
--- a/client/packages.go
+++ b/client/packages.go
@@ -86,9 +86,9 @@ type Snap struct {
 	Health *SnapHealth `json:"health,omitempty"`
 
 	// Hold is the time until which the snap's refreshes are held by the user.
-	Hold time.Time `json:"hold,omitempty"`
+	Hold *time.Time `json:"hold,omitempty"`
 	// GatingHold is the time until which the snap's refreshes are held by a snap.
-	GatingHold time.Time `json:"gating-hold,omitempty"`
+	GatingHold *time.Time `json:"gating-hold,omitempty"`
 }
 
 type SnapHealth struct {

--- a/cmd/snap/cmd_info.go
+++ b/cmd/snap/cmd_info.go
@@ -269,8 +269,8 @@ func (iw *infoWriter) maybePrintRefreshInfo() {
 		fmt.Fprintf(iw, "refresh-date:\t%s\n", iw.fmtTime(iw.localSnap.InstallDate))
 	}
 
-	maybePrintHold := func(key string, hold time.Time) {
-		if hold.IsZero() {
+	maybePrintHold := func(key string, hold *time.Time) {
+		if hold == nil || hold.Before(timeNow()) {
 			return
 		}
 
@@ -278,7 +278,7 @@ func (iw *infoWriter) maybePrintRefreshInfo() {
 		if hold.After(longTime) {
 			fmt.Fprintf(iw, "%s:\tforever\n", key)
 		} else {
-			fmt.Fprintf(iw, "%s:\t%s\n", key, iw.fmtTime(hold))
+			fmt.Fprintf(iw, "%s:\t%s\n", key, iw.fmtTime(*hold))
 		}
 	}
 

--- a/cmd/snap/cmd_info_test.go
+++ b/cmd/snap/cmd_info_test.go
@@ -381,7 +381,9 @@ func (s *infoSuite) TestMaybePrintHoldingInfo(c *check.C) {
 
 	for _, holdKind := range []string{"hold", "hold-by-gating"} {
 		for hold, expected := range map[string]string{
+			"":                     "",
 			"0001-01-01T00:00:00Z": "",
+			"1999-01-01T00:00:00Z": "",
 			"2000-01-01T11:30:00Z": fmt.Sprintf("%s:\ttoday at 11:30 UTC\n", holdKind),
 			"2000-01-02T12:00:00Z": fmt.Sprintf("%s:\ttomorrow at 12:00 UTC\n", holdKind),
 			"2000-02-01T00:00:00Z": fmt.Sprintf("%s:\tin 31 days, at 00:00 UTC\n", holdKind),
@@ -390,8 +392,12 @@ func (s *infoSuite) TestMaybePrintHoldingInfo(c *check.C) {
 		} {
 			buf.Reset()
 
-			holdTime, err := time.Parse(time.RFC3339, hold)
-			c.Assert(err, check.IsNil)
+			var holdTime *time.Time
+			if hold != "" {
+				t, err := time.Parse(time.RFC3339, hold)
+				c.Assert(err, check.IsNil)
+				holdTime = &t
+			}
 
 			switch holdKind {
 			case "hold":
@@ -437,7 +443,7 @@ func (s *infoSuite) TestMaybePrintHoldingNonUTCLocalTime(c *check.C) {
 		time.Local = oldLocal
 	}()
 
-	snap.SetupSnap(iw, &client.Snap{Hold: holdTime}, nil, nil)
+	snap.SetupSnap(iw, &client.Snap{Hold: &holdTime}, nil, nil)
 
 	snap.MaybePrintRefreshInfo(iw)
 	iw.Flush()

--- a/daemon/snap.go
+++ b/daemon/snap.go
@@ -223,8 +223,13 @@ func mapLocal(about aboutSnap, sd clientutil.StatusDecorator) *client.Snap {
 		result.MountedFrom, _ = os.Readlink(result.MountedFrom)
 	}
 	result.Health = about.health
-	result.Hold = about.hold
-	result.GatingHold = about.gatingHold
+
+	if !about.hold.IsZero() {
+		result.Hold = &about.hold
+	}
+	if !about.gatingHold.IsZero() {
+		result.GatingHold = &about.gatingHold
+	}
 
 	return result
 }

--- a/daemon/snap.go
+++ b/daemon/snap.go
@@ -121,7 +121,6 @@ func allLocalSnapInfos(st *state.State, all bool, wanted map[string]bool) ([]abo
 		return nil, err
 	}
 
-	var firstErr error
 	for name, snapst := range snapStates {
 		if len(wanted) > 0 && !wanted[name] {
 			continue
@@ -145,8 +144,8 @@ func allLocalSnapInfos(st *state.State, all bool, wanted map[string]bool) ([]abo
 					err = nil
 				}
 				info.Publisher, err = assertstate.PublisherStoreAccount(st, seq.SnapID)
-				if err != nil && firstErr == nil {
-					firstErr = err
+				if err != nil {
+					return nil, err
 				}
 				abSnap := aboutSnap{
 					info:   info,
@@ -157,22 +156,15 @@ func allLocalSnapInfos(st *state.State, all bool, wanted map[string]bool) ([]abo
 			}
 		} else {
 			info, err = snapst.CurrentInfo()
-			if err == nil {
-				info.Publisher, err = assertstate.PublisherStoreAccount(st, info.SnapID)
-				abSnap := aboutSnap{
-					info:   info,
-					snapst: snapst,
-					health: health,
-				}
-				aboutThis = append(aboutThis, abSnap)
+			if err != nil {
+				return nil, err
 			}
-		}
 
-		if err != nil {
-			// XXX: aggregate instead?
-			if firstErr == nil {
-				firstErr = err
+			info.Publisher, err = assertstate.PublisherStoreAccount(st, info.SnapID)
+			if err != nil {
+				return nil, err
 			}
+
 			abSnap := aboutSnap{
 				info:   info,
 				snapst: snapst,
@@ -183,7 +175,7 @@ func allLocalSnapInfos(st *state.State, all bool, wanted map[string]bool) ([]abo
 		about = append(about, aboutThis...)
 	}
 
-	return about, firstErr
+	return about, nil
 }
 
 func clientHealthFromHealthstate(h *healthstate.HealthState) *client.SnapHealth {


### PR DESCRIPTION
This refactors some things around the API:
* The first commit removes some unnecessary logic around error handling in a helper (see commit description for more information)
* The second commit avoids always serializing empty `time.Time` values in JSON responses by using `*time.Time` with the `omitempty` tag

