### PR TITLE
cmd/snap,daemon: add 'held' to notes in 'snap list'

### DIFF
--- a/cmd/snap/notes.go
+++ b/cmd/snap/notes.go
@@ -63,6 +63,7 @@ type Notes struct {
 	InCohort         bool
 	Health           string
 	Price            string
+	Held             bool
 }
 
 func NotesFromChannelSnapInfo(ref *snap.ChannelSnapInfo) *Notes {
@@ -103,6 +104,7 @@ func NotesFromLocal(snp *client.Snap) *Notes {
 		IgnoreValidation: snp.IgnoreValidation,
 		InCohort:         snp.CohortKey != "",
 		Health:           health,
+		Held:             snp.Hold != nil && snp.Hold.After(timeNow()),
 	}
 }
 
@@ -164,6 +166,10 @@ func (n *Notes) String() string {
 	}
 	if n.Health != "" && n.Health != "okay" {
 		ns = append(ns, n.Health)
+	}
+
+	if n.Held {
+		ns = append(ns, i18n.G("held"))
 	}
 
 	if len(ns) == 0 {

--- a/daemon/snap.go
+++ b/daemon/snap.go
@@ -126,9 +126,14 @@ func allLocalSnapInfos(st *state.State, all bool, wanted map[string]bool) ([]abo
 			continue
 		}
 		health := clientHealthFromHealthstate(healths[name])
+
+		userHold, gatingHold, err := getUserAndGatingHolds(st, name)
+		if err != nil {
+			return nil, err
+		}
+
 		var aboutThis []aboutSnap
 		var info *snap.Info
-		var err error
 		if all {
 			for _, seq := range snapst.Sequence {
 				info, err = snap.ReadInfo(name, seq)
@@ -148,9 +153,11 @@ func allLocalSnapInfos(st *state.State, all bool, wanted map[string]bool) ([]abo
 					return nil, err
 				}
 				abSnap := aboutSnap{
-					info:   info,
-					snapst: snapst,
-					health: health,
+					info:       info,
+					snapst:     snapst,
+					health:     health,
+					hold:       userHold,
+					gatingHold: gatingHold,
 				}
 				aboutThis = append(aboutThis, abSnap)
 			}
@@ -166,9 +173,11 @@ func allLocalSnapInfos(st *state.State, all bool, wanted map[string]bool) ([]abo
 			}
 
 			abSnap := aboutSnap{
-				info:   info,
-				snapst: snapst,
-				health: health,
+				info:       info,
+				snapst:     snapst,
+				health:     health,
+				hold:       userHold,
+				gatingHold: gatingHold,
 			}
 			aboutThis = append(aboutThis, abSnap)
 		}


### PR DESCRIPTION
This PR adds a 'held' tag to the notes in the `snap list`. Per the spec, the tag is only displayed if the hold is placed by the user (not a gating snap) to a specific set of snaps (not an all-snaps hold). It also doesn't display if the hold returned from the API has expired. 
This is based on the refactors in https://github.com/snapcore/snapd/pull/12436 so only 2c85cb40fa08ca1257c675e18281875be170a3a4 applies to this PR.