### PR TITLE
tests: fix shellcheck warnings on unreachable code and var quoting

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,5 @@
+# Disable "Unreachable code ..." warnings which log a warning for each line (not block)
+# of unreachable code. That code is often meant to be re-enabled later and we can't
+# do file-wide disables in spread tests https://github.com/koalaman/shellcheck/wiki/Ignore
+disable=SC2317
+

--- a/tests/core/basic20plus/task.yaml
+++ b/tests/core/basic20plus/task.yaml
@@ -75,7 +75,7 @@ execute: |
     # b) there was a cloud.cfg.d override (e.g. MAAS), then we must have more
     #    files in writable than in the core20 snap. The core20 content and the
     #    extra config will be merged
-    test -e /writable/system-data/etc/cloud/cloud-init.disabled || [ "$(find /writable/system-data/etc/cloud/cloud.cfg.d/ | wc -l)" -gt "$(find /snap/${base_snap}/current/etc/cloud/cloud.cfg.d/ | wc -l)" ]
+    test -e /writable/system-data/etc/cloud/cloud-init.disabled || [ "$(find /writable/system-data/etc/cloud/cloud.cfg.d/ | wc -l)" -gt "$(find /snap/"${base_snap}"/current/etc/cloud/cloud.cfg.d/ | wc -l)" ]
 
     # ensure that we have no symlinks from /var/lib/snapd/snaps to
     # /var/lib/snapd/seed

--- a/tests/core/kernel-ver/task.yaml
+++ b/tests/core/kernel-ver/task.yaml
@@ -14,4 +14,4 @@ execute: |
     elif os.query is-core22; then
         VER="^5.15"
     fi
-    uname -r | MATCH $VER
+    uname -r | MATCH "$VER"

--- a/tests/lib/tools/boot-state
+++ b/tests/lib/tools/boot-state
@@ -181,7 +181,6 @@ main() {
         bootenv)
             shift
             bootenv "$@"
-            exit
             ;;
         boot-path)
             boot_path

--- a/tests/main/fake-netplan-apply/task.yaml
+++ b/tests/main/fake-netplan-apply/task.yaml
@@ -50,8 +50,8 @@ prepare: |
 
     echo "Backup the dbus service file and policy config if they exist before executing"
     for f in system-services/$NETPLAN.service system.d/$NETPLAN.conf; do
-        if [ -f /usr/share/dbus-1/$f ]; then
-            mv /usr/share/dbus-1/$f /usr/share/dbus-1/$f.backup
+        if [ -f /usr/share/dbus-1/"$f" ]; then
+            mv /usr/share/dbus-1/"$f" /usr/share/dbus-1/"$f".backup
         fi      
     done
 
@@ -84,8 +84,8 @@ restore: |
 
     echo "Restore the dbus service file and policy config file if the backup exists"
     for f in system-services/$NETPLAN.service system.d/$NETPLAN.conf; do
-        if [ -f /usr/share/dbus-1/$f.backup ]; then
-            mv /usr/share/dbus-1/$f.backup /usr/share/dbus-1/$f
+        if [ -f /usr/share/dbus-1/"$f".backup ]; then
+            mv /usr/share/dbus-1/"$f".backup /usr/share/dbus-1/"$f"
         fi      
     done
 

--- a/tests/main/snap-run-symlink-error/task.yaml
+++ b/tests/main/snap-run-symlink-error/task.yaml
@@ -9,13 +9,16 @@ execute: |
     SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
     mkdir -p "$SNAP_MOUNT_DIR/bin"
     ln -s /usr/bin/snap "$SNAP_MOUNT_DIR/bin/xxx"
+
     echo Running unknown command
-    expected="internal error, please report: running \"xxx\" failed: cannot find current revision for snap xxx: readlink $SNAP_MOUNT_DIR/xxx/current: no such file or directory"
     output="$("$SNAP_MOUNT_DIR/bin/xxx" 2>&1 )" && exit 1
-    echo "$output"
     err=$?
+    echo "$output"
+
     echo Verifying error message
-    if [ $err -ne 46 ]; then
-       echo Wrong error code $err
+    if [[ $err -ne 46 ]]; then
+      echo "expected error code 46 but got $err"
+      exit 1
     fi
-    [ "$output" = "$expected" ]
+    expected="internal error, please report: running \"xxx\" failed: cannot find current revision for snap xxx: readlink $SNAP_MOUNT_DIR/xxx/current: no such file or directory"
+    test "$output" = "$expected"

--- a/tests/main/snapd-snap/task.yaml
+++ b/tests/main/snapd-snap/task.yaml
@@ -284,7 +284,7 @@ execute: |
     # shared-memory plug with "private: true" cannot be connected if "/dev/shm" is a symlink)
     if os.query is-trusty; then
         cp -r "$TESTSLIB/snaps/$CONSUMER_SNAP" .
-        sed -e '/shared-memory:/,+2d' -i $CONSUMER_SNAP/meta/snap.yaml
+        sed -e '/shared-memory:/,+2d' -i "$CONSUMER_SNAP"/meta/snap.yaml
     fi
 
     echo "Given a snap is installed"


### PR DESCRIPTION
`master` is currently not building due to the new shellcheck warnings that v0.9.0 brought about. This PR fixes that in 3 commits:
* f8b035be15707f0e476abdca1b4a1c3b1785f4d7 fixes a test that was a bit broken and not always testing what is was supposed to
* 3c068cd7fcf0210076e0e8d7830e6ed3103e63b4 adds some double quoting to prevent string splitting
* 59ec8a39df0777b79b087dae20f1e1dad243a98e disables all unreachable code warnings because file-wide disables doesn't work in spread tests (see commit message for more detail)
