### PR TITLE
o/devicestate: turn populateFromSeed into a DeviceManager method

### DIFF
--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -184,15 +184,21 @@ func EnsureCloudInitRestricted(m *DeviceManager) error {
 	return m.ensureCloudInitRestricted()
 }
 
-var PopulateStateFromSeedImpl = populateStateFromSeedImpl
+func ImportAssertionsFromSeed(m *DeviceManager, sysLabel string, isCoreBoot bool) (seed.Seed, error) {
+	return m.importAssertionsFromSeed(sysLabel, isCoreBoot)
+}
+
+func PopulateStateFromSeedImpl(m *DeviceManager, opts *PopulateStateFromSeedOptions, tm timings.Measurer) ([]*state.TaskSet, error) {
+	return m.populateStateFromSeedImpl(opts, tm)
+}
 
 type PopulateStateFromSeedOptions = populateStateFromSeedOptions
 
-func MockPopulateStateFromSeed(f func(*state.State, *PopulateStateFromSeedOptions, timings.Measurer) ([]*state.TaskSet, error)) (restore func()) {
-	old := populateStateFromSeed
-	populateStateFromSeed = f
+func MockPopulateStateFromSeed(m *DeviceManager, f func(*PopulateStateFromSeedOptions, timings.Measurer) ([]*state.TaskSet, error)) (restore func()) {
+	old := m.populateStateFromSeed
+	m.populateStateFromSeed = f
 	return func() {
-		populateStateFromSeed = old
+		m.populateStateFromSeed = old
 	}
 }
 
@@ -251,7 +257,6 @@ func RecordSeededSystem(m *DeviceManager, st *state.State, sys *seededSystem) er
 var (
 	LoadDeviceSeed               = loadDeviceSeed
 	UnloadDeviceSeed             = unloadDeviceSeed
-	ImportAssertionsFromSeed     = importAssertionsFromSeed
 	CheckGadgetOrKernel          = checkGadgetOrKernel
 	CheckGadgetValid             = checkGadgetValid
 	CheckGadgetRemodelCompatible = checkGadgetRemodelCompatible

--- a/overlord/devicestate/firstboot.go
+++ b/overlord/devicestate/firstboot.go
@@ -94,7 +94,9 @@ type populateStateFromSeedOptions struct {
 	Preseed bool
 }
 
-func populateStateFromSeedImpl(st *state.State, opts *populateStateFromSeedOptions, tm timings.Measurer) ([]*state.TaskSet, error) {
+func (m *DeviceManager) populateStateFromSeedImpl(opts *populateStateFromSeedOptions, tm timings.Measurer) ([]*state.TaskSet, error) {
+	st := m.state
+
 	mode := "run"
 	sysLabel := ""
 	preseed := false
@@ -122,7 +124,7 @@ func populateStateFromSeedImpl(st *state.State, opts *populateStateFromSeedOptio
 	// ack all initial assertions
 	timings.Run(tm, "import-assertions[finish]", "finish importing assertions from seed", func(nested timings.Measurer) {
 		isCoreBoot := hasModeenv || !release.OnClassic
-		deviceSeed, err = importAssertionsFromSeed(st, sysLabel, isCoreBoot)
+		deviceSeed, err = m.importAssertionsFromSeed(sysLabel, isCoreBoot)
 	})
 	if err != nil && err != errNothingToDo {
 		return nil, err
@@ -342,7 +344,9 @@ func populateStateFromSeedImpl(st *state.State, opts *populateStateFromSeedOptio
 	return tsAll, nil
 }
 
-func importAssertionsFromSeed(st *state.State, sysLabel string, isCoreBoot bool) (seed.Seed, error) {
+func (m *DeviceManager) importAssertionsFromSeed(sysLabel string, isCoreBoot bool) (seed.Seed, error) {
+	st := m.state
+
 	// TODO: use some kind of context fo Device/SetDevice?
 	device, err := internal.Device(st)
 	if err != nil {

--- a/overlord/devicestate/firstboot20_test.go
+++ b/overlord/devicestate/firstboot20_test.go
@@ -311,7 +311,9 @@ func (s *firstBoot20Suite) testPopulateFromSeedCore20Happy(c *C, m *boot.Modeenv
 	// create overlord and pick up the modeenv
 	s.startOverlord(c)
 
-	c.Check(devicestate.SaveAvailable(s.overlord.DeviceManager()), Equals, m.Mode == "run")
+	mgr := s.overlord.DeviceManager()
+
+	c.Check(devicestate.SaveAvailable(mgr), Equals, m.Mode == "run")
 
 	opts := devicestate.PopulateStateFromSeedOptions{
 		Label: m.RecoverySystem,
@@ -322,7 +324,7 @@ func (s *firstBoot20Suite) testPopulateFromSeedCore20Happy(c *C, m *boot.Modeenv
 	st := s.overlord.State()
 	st.Lock()
 	defer st.Unlock()
-	tsAll, err := devicestate.PopulateStateFromSeedImpl(st, &opts, s.perfTimings)
+	tsAll, err := devicestate.PopulateStateFromSeedImpl(mgr, &opts, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	snaps := []string{"snapd", "pc-kernel", "core20", "pc"}
@@ -712,7 +714,7 @@ defaults:
 		Mode:  m.Mode,
 	}
 
-	_, err = devicestate.PopulateStateFromSeedImpl(st, &opts, s.perfTimings)
+	_, err = devicestate.PopulateStateFromSeedImpl(o.DeviceManager(), &opts, s.perfTimings)
 	c.Assert(err, IsNil)
 }
 
@@ -807,7 +809,7 @@ func (s *firstBoot20Suite) TestPopulateFromSeedClassicWithModesRunModeNoKernelAn
 	st := s.overlord.State()
 	st.Lock()
 	defer st.Unlock()
-	tsAll, err := devicestate.PopulateStateFromSeedImpl(st, &opts, s.perfTimings)
+	tsAll, err := devicestate.PopulateStateFromSeedImpl(s.overlord.DeviceManager(), &opts, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	snaps := []string{"snapd", "core20"}
@@ -977,7 +979,7 @@ apps:
 	st := s.overlord.State()
 	st.Lock()
 	defer st.Unlock()
-	tsAll, err := devicestate.PopulateStateFromSeedImpl(st, &opts, s.perfTimings)
+	tsAll, err := devicestate.PopulateStateFromSeedImpl(s.overlord.DeviceManager(), &opts, s.perfTimings)
 	if expectedErr != "" {
 		c.Check(err, ErrorMatches, expectedErr)
 		return

--- a/overlord/devicestate/firstboot_preseed_test.go
+++ b/overlord/devicestate/firstboot_preseed_test.go
@@ -299,7 +299,7 @@ snaps:
 	defer st.Unlock()
 
 	opts := &devicestate.PopulateStateFromSeedOptions{Preseed: true}
-	tsAll, err := devicestate.PopulateStateFromSeedImpl(st, opts, s.perfTimings)
+	tsAll, err := devicestate.PopulateStateFromSeedImpl(s.overlord.DeviceManager(), opts, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	chg := st.NewChange("seed", "run the populate from seed changes")
@@ -386,7 +386,7 @@ snaps:
 	defer st.Unlock()
 
 	opts := &devicestate.PopulateStateFromSeedOptions{Preseed: true}
-	tsAll, err := devicestate.PopulateStateFromSeedImpl(st, opts, s.perfTimings)
+	tsAll, err := devicestate.PopulateStateFromSeedImpl(s.overlord.DeviceManager(), opts, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	// now run the change and check the result
@@ -519,7 +519,7 @@ snaps:
 	defer st.Unlock()
 
 	opts := &devicestate.PopulateStateFromSeedOptions{Preseed: true}
-	tsAll, err := devicestate.PopulateStateFromSeedImpl(st, opts, s.perfTimings)
+	tsAll, err := devicestate.PopulateStateFromSeedImpl(s.overlord.DeviceManager(), opts, s.perfTimings)
 	c.Assert(err, IsNil)
 	// use the expected kind otherwise settle with start another one
 	chg := st.NewChange("seed", "run the populate from seed changes")


### PR DESCRIPTION
also importAssertionsFromSeed

adjust the tests

the reason for this change is to be able to unify the early seed loading double caching that now exists both in loadDeviceSeed and earlyLoadDeviceSeed