### PR TITLE
many: support logging HTTP requests in the client

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -36,6 +36,7 @@ import (
 	"time"
 
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/httputil"
 	"github.com/snapcore/snapd/jsonutil"
 )
 
@@ -92,6 +93,10 @@ type Client struct {
 	warningTimestamp time.Time
 
 	userAgent string
+
+	// SetMayLogBody controls whether a request or response's body may be logged
+	// if the appropriate environment variable is set
+	SetMayLogBody func(bool)
 }
 
 // New returns a new instance of Client
@@ -100,31 +105,41 @@ func New(config *Config) *Client {
 		config = &Config{}
 	}
 
+	var baseURL *url.URL
+	var dial func(network, addr string) (net.Conn, error)
+
 	// By default talk over an UNIX socket.
 	if config.BaseURL == "" {
-		transport := &http.Transport{Dial: unixDialer(config.Socket), DisableKeepAlives: config.DisableKeepAlive}
-		return &Client{
-			baseURL: url.URL{
-				Scheme: "http",
-				Host:   "localhost",
-			},
-			doer:        &http.Client{Transport: transport},
-			disableAuth: config.DisableAuth,
-			interactive: config.Interactive,
-			userAgent:   config.UserAgent,
+		dial = unixDialer(config.Socket)
+		baseURL = &url.URL{
+			Scheme: "http",
+			Host:   "localhost",
+		}
+	} else {
+		var err error
+		baseURL, err = url.Parse(config.BaseURL)
+		if err != nil {
+			panic(fmt.Sprintf("cannot parse server base URL: %q (%v)", config.BaseURL, err))
 		}
 	}
 
-	baseURL, err := url.Parse(config.BaseURL)
-	if err != nil {
-		panic(fmt.Sprintf("cannot parse server base URL: %q (%v)", config.BaseURL, err))
+	transport := &httputil.LoggedTransport{
+		Transport: &http.Transport{
+			Dial:              dial,
+			DisableKeepAlives: config.DisableKeepAlive,
+		},
+		Key:        "SNAP_CLIENT_DEBUG_HTTP",
+		MayLogBody: true,
 	}
 	return &Client{
 		baseURL:     *baseURL,
-		doer:        &http.Client{Transport: &http.Transport{DisableKeepAlives: config.DisableKeepAlive}},
+		doer:        &http.Client{Transport: transport},
 		disableAuth: config.DisableAuth,
 		interactive: config.Interactive,
 		userAgent:   config.UserAgent,
+		SetMayLogBody: func(logBody bool) {
+			transport.MayLogBody = logBody
+		},
 	}
 }
 

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -516,6 +516,8 @@ func (x *cmdInstall) installOne(nameOrPath, desiredName string, opts *client.Sna
 	var path string
 
 	if isLocalSnap(nameOrPath) {
+		// don't log the request's body because the encoded snap is large.
+		x.client.SetMayLogBody(false)
 		path = nameOrPath
 		changeID, err = x.client.InstallPath(path, x.Name, opts)
 	} else {
@@ -569,6 +571,8 @@ func (x *cmdInstall) installMany(names []string, opts *client.SnapOptions) error
 	var err error
 
 	if isLocal {
+		// don't log the request's body because the encoded snap is large
+		x.client.SetMayLogBody(false)
 		changeID, err = x.client.InstallPathMany(names, opts)
 	} else {
 		if x.asksForMode() {

--- a/httputil/client.go
+++ b/httputil/client.go
@@ -152,7 +152,7 @@ type ClientOptions struct {
 	ExtraSSLCerts ExtraSSLCerts
 }
 
-// NewHTTPCLient returns a new http.Client with a LoggedTransport, a
+// NewHTTPClient returns a new http.Client with a LoggedTransport, a
 // Timeout and preservation of range requests across redirects
 func NewHTTPClient(opts *ClientOptions) *http.Client {
 	if opts == nil {

--- a/httputil/client.go
+++ b/httputil/client.go
@@ -177,9 +177,9 @@ func NewHTTPClient(opts *ClientOptions) *http.Client {
 
 	return &http.Client{
 		Transport: &LoggedTransport{
-			Transport: transport,
-			Key:       "SNAPD_DEBUG_HTTP",
-			body:      opts.MayLogBody,
+			Transport:  transport,
+			Key:        "SNAPD_DEBUG_HTTP",
+			MayLogBody: opts.MayLogBody,
 		},
 		Timeout:       opts.Timeout,
 		CheckRedirect: checkRedirect,

--- a/httputil/logger.go
+++ b/httputil/logger.go
@@ -53,9 +53,9 @@ func (f debugflag) debugBody() bool {
 // LoggedTransport is an http.RoundTripper that can be used by
 // http.Client to log request/response roundtrips.
 type LoggedTransport struct {
-	Transport http.RoundTripper
-	Key       string
-	body      bool
+	Transport  http.RoundTripper
+	Key        string
+	MayLogBody bool
 }
 
 // RoundTrip is from the http.RoundTripper interface.
@@ -63,14 +63,14 @@ func (tr *LoggedTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	flags := tr.getFlags()
 
 	if flags.debugRequest() {
-		buf, _ := httputil.DumpRequestOut(req, tr.body && flags.debugBody())
+		buf, _ := httputil.DumpRequestOut(req, tr.MayLogBody && flags.debugBody())
 		logger.NoGuardDebugf("> %q", buf)
 	}
 
 	rsp, err := tr.Transport.RoundTrip(req)
 
 	if err == nil && flags.debugResponse() {
-		buf, _ := httputil.DumpResponse(rsp, tr.body && flags.debugBody())
+		buf, _ := httputil.DumpResponse(rsp, tr.MayLogBody && flags.debugBody())
 		logger.NoGuardDebugf("< %q", buf)
 	}
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -102,7 +102,7 @@ func NoGuardDebugf(format string, v ...interface{}) {
 	logger.NoGuardDebug(msg)
 }
 
-// MockLogger replaces the exiting logger with a buffer and returns
+// MockLogger replaces the existing logger with a buffer and returns
 // the log buffer and a restore function.
 func MockLogger() (buf *bytes.Buffer, restore func()) {
 	buf = &bytes.Buffer{}


### PR DESCRIPTION
Add a SNAP_CLIENT_DEBUG_HTTP bitfield environment variable that allows logging requests, responses and bodies that the client receives from the REST API. Bodies are never logged in local installs because, since they contain packaged snaps, their size would make the log unreadable.
