### PR TITLE
interfaces: add read access to /run for cryptsetup for dm-crypt

### DIFF
--- a/interfaces/builtin/dm_crypt.go
+++ b/interfaces/builtin/dm_crypt.go
@@ -65,6 +65,7 @@ mount options=(rw,nosuid,nodev) /dev/dm-[0-9]* -> /{,run/}media/**,
 # Allow access to the file locking mechanism
 /{,var/}run/cryptsetup/ r,
 /{,var/}run/cryptsetup/* rwk,
+/{,var/}run/ r,
 `
 
 const dmCryptConnectedPlugSecComp = `


### PR DESCRIPTION
When running `cryptsetup luksFormat` cryptsetup attempts to open /run but fails due to a missing apparmor rule

Fixes: https://bugs.launchpad.net/snapd/+bug/1999683

Signed-off-by: Peter Sabaini <peter.sabaini@canonical.com>
