### PR TITLE
many: simplify loading and caching of the device seed in devicestate

### DIFF
--- a/daemon/api_base_test.go
+++ b/daemon/api_base_test.go
@@ -275,14 +275,14 @@ func (s *apiBaseSuite) daemonWithStore(c *check.C, sto snapstate.StoreService) *
 	// mark as already seeded
 	st.Lock()
 	st.Set("seeded", true)
+	// and registered
+	s.mockModel(st, nil)
 	st.Unlock()
 	c.Assert(d.Overlord().StartUp(), check.IsNil)
 
 	st.Lock()
 	defer st.Unlock()
 	snapstate.ReplaceStore(st, sto)
-	// registered
-	s.mockModel(st, nil)
 
 	// don't actually try to talk to the store on snapstate.Ensure
 	// needs doing after the call to devicestate.Manager (which

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -591,12 +591,7 @@ func (l *witnessAcceptListener) Close() error {
 func (s *daemonSuite) markSeeded(d *Daemon) {
 	st := d.overlord.State()
 	st.Lock()
-	st.Set("seeded", true)
-	devicestatetest.SetDevice(st, &auth.DeviceState{
-		Brand:  "canonical",
-		Model:  "pc",
-		Serial: "serialserial",
-	})
+	devicestatetest.MarkInitialized(st)
 	st.Unlock()
 }
 

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -821,6 +821,15 @@ func (m *DeviceManager) earlyCleanup() {
 }
 
 func (m *DeviceManager) earlyLoadDeviceSeed() (snapstate.DeviceContext, seed.Seed, error) {
+	var seeded bool
+	err := m.state.Get("seeded", &seeded)
+	if err != nil && !errors.Is(err, state.ErrNoState) {
+		return nil, nil, err
+	}
+	if seeded {
+		return nil, nil, fmt.Errorf("internal error: loading device seed after being seeded already")
+	}
+
 	// consider whether we were called already
 	if m.seedTimings != nil {
 		if m.earlyDeviceCtx != nil {

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -950,7 +950,7 @@ func (m *DeviceManager) ensureSeeded() error {
 
 	var opts *populateStateFromSeedOptions
 	if m.preseed {
-		opts = &populateStateFromSeedOptions{Preseed: true}
+		opts = &populateStateFromSeedOptions{}
 		if !release.OnClassic {
 			opts.Mode = "run"
 			opts.Label = m.systemForPreseeding()

--- a/overlord/devicestate/devicestatetest/state.go
+++ b/overlord/devicestate/devicestatetest/state.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2019 Canonical Ltd
+ * Copyright (C) 2019-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -20,6 +20,8 @@
 package devicestatetest
 
 import (
+	"github.com/snapcore/snapd/asserts/sysdb"
+	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/devicestate/internal"
 	"github.com/snapcore/snapd/overlord/state"
@@ -31,4 +33,20 @@ func Device(st *state.State) (*auth.DeviceState, error) {
 
 func SetDevice(st *state.State, device *auth.DeviceState) error {
 	return internal.SetDevice(st, device)
+}
+
+// MarkInitialized flags the state as seeded and the device registered to avoid
+// running the seeding code etc in tests, it also tries to sets the model to
+// generic-classic.
+// If the initial model is imporant this cannot be used.
+func MarkInitialized(st *state.State) {
+	model := sysdb.GenericClassicModel()
+	// best-effort
+	assertstate.Add(st, model)
+	st.Set("seeded", true)
+	SetDevice(st, &auth.DeviceState{
+		Brand:  model.BrandID(),
+		Model:  model.Model(),
+		Serial: "serialserialserial",
+	})
 }

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -140,7 +140,7 @@ func SetTimeOnce(m *DeviceManager, name string, t time.Time) error {
 
 func EarlyPreloadGadget(m *DeviceManager) (sysconfig.Device, *gadget.Info, error) {
 	// let things fully run again
-	m.seedTimings = nil
+	m.earlyDeviceSeed = nil
 	return m.earlyPreloadGadget()
 }
 
@@ -256,7 +256,6 @@ func RecordSeededSystem(m *DeviceManager, st *state.State, sys *seededSystem) er
 
 var (
 	LoadDeviceSeed               = loadDeviceSeed
-	UnloadDeviceSeed             = unloadDeviceSeed
 	CheckGadgetOrKernel          = checkGadgetOrKernel
 	CheckGadgetValid             = checkGadgetValid
 	CheckGadgetRemodelCompatible = checkGadgetRemodelCompatible

--- a/overlord/devicestate/firstboot.go
+++ b/overlord/devicestate/firstboot.go
@@ -89,17 +89,16 @@ func trivialSeeding(st *state.State) []*state.TaskSet {
 }
 
 type populateStateFromSeedOptions struct {
-	Label   string
-	Mode    string
-	Preseed bool
+	Label string
+	Mode  string
 }
 
 func (m *DeviceManager) populateStateFromSeedImpl(opts *populateStateFromSeedOptions, tm timings.Measurer) ([]*state.TaskSet, error) {
 	st := m.state
+	preseed := m.preseed
 
 	mode := "run"
 	sysLabel := ""
-	preseed := false
 	hasModeenv := false
 	if opts != nil {
 		if opts.Mode != "" {
@@ -107,7 +106,6 @@ func (m *DeviceManager) populateStateFromSeedImpl(opts *populateStateFromSeedOpt
 			hasModeenv = true
 		}
 		sysLabel = opts.Label
-		preseed = opts.Preseed
 	}
 
 	// check that the state is empty

--- a/overlord/devicestate/firstboot20_test.go
+++ b/overlord/devicestate/firstboot20_test.go
@@ -574,10 +574,6 @@ func (s *firstBoot20Suite) TestLoadDeviceSeedCore20(c *C) {
 	})
 	c.Assert(err, IsNil)
 	c.Check(as, DeepEquals, deviceSeed.Model())
-
-	// inconsistent seed request
-	_, err = devicestate.LoadDeviceSeed(st, "20210201")
-	c.Assert(err, ErrorMatches, `internal error: requested inconsistent device seed: 20210201 \(was 20191018\)`)
 }
 
 func (s *firstBoot20Suite) testProcessAutoImportAssertions(c *C, withAutoImportAssertion bool) string {

--- a/overlord/devicestate/firstboot_preseed_test.go
+++ b/overlord/devicestate/firstboot_preseed_test.go
@@ -298,8 +298,7 @@ snaps:
 	st.Lock()
 	defer st.Unlock()
 
-	opts := &devicestate.PopulateStateFromSeedOptions{Preseed: true}
-	tsAll, err := devicestate.PopulateStateFromSeedImpl(s.overlord.DeviceManager(), opts, s.perfTimings)
+	tsAll, err := devicestate.PopulateStateFromSeedImpl(s.overlord.DeviceManager(), nil, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	chg := st.NewChange("seed", "run the populate from seed changes")
@@ -385,8 +384,7 @@ snaps:
 	st.Lock()
 	defer st.Unlock()
 
-	opts := &devicestate.PopulateStateFromSeedOptions{Preseed: true}
-	tsAll, err := devicestate.PopulateStateFromSeedImpl(s.overlord.DeviceManager(), opts, s.perfTimings)
+	tsAll, err := devicestate.PopulateStateFromSeedImpl(s.overlord.DeviceManager(), nil, s.perfTimings)
 	c.Assert(err, IsNil)
 
 	// now run the change and check the result
@@ -518,8 +516,7 @@ snaps:
 	st.Lock()
 	defer st.Unlock()
 
-	opts := &devicestate.PopulateStateFromSeedOptions{Preseed: true}
-	tsAll, err := devicestate.PopulateStateFromSeedImpl(s.overlord.DeviceManager(), opts, s.perfTimings)
+	tsAll, err := devicestate.PopulateStateFromSeedImpl(s.overlord.DeviceManager(), nil, s.perfTimings)
 	c.Assert(err, IsNil)
 	// use the expected kind otherwise settle with start another one
 	chg := st.NewChange("seed", "run the populate from seed changes")

--- a/overlord/devicestate/handlers_test.go
+++ b/overlord/devicestate/handlers_test.go
@@ -568,7 +568,6 @@ func (s *preseedingClassicSuite) TestEnsureSeededPreseedFlag(c *C) {
 	called := false
 	restore := devicestate.MockPopulateStateFromSeed(s.mgr, func(opts *devicestate.PopulateStateFromSeedOptions, tm timings.Measurer) ([]*state.TaskSet, error) {
 		called = true
-		c.Check(opts.Preseed, Equals, true)
 		return nil, nil
 	})
 	defer restore()
@@ -752,7 +751,6 @@ func (s *preseedingUC20Suite) TestEnsureSeededPicksSystemOnCore20(c *C) {
 	c.Assert(err, IsNil)
 	restore := devicestate.MockPopulateStateFromSeed(mgr, func(opts *devicestate.PopulateStateFromSeedOptions, tm timings.Measurer) ([]*state.TaskSet, error) {
 		called = true
-		c.Check(opts.Preseed, Equals, true)
 		c.Check(opts.Label, Equals, "20220105")
 		c.Check(opts.Mode, Equals, "run")
 		return nil, nil

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -258,7 +258,15 @@ func (s *baseMgrsSuite) SetUpTest(c *C) {
 	st := o.State()
 	st.Lock()
 	st.Set("seeded", true)
+	// registered
+	err = assertstate.Add(st, sysdb.GenericClassicModel())
+	devicestatetest.SetDevice(st, &auth.DeviceState{
+		Brand:  "generic",
+		Model:  "generic-classic",
+		Serial: "serialserial",
+	})
 	st.Unlock()
+	c.Assert(err, IsNil)
 	err = o.StartUp()
 	c.Assert(err, IsNil)
 	o.InterfaceManager().DisableUDevMonitor()
@@ -266,14 +274,6 @@ func (s *baseMgrsSuite) SetUpTest(c *C) {
 
 	st.Lock()
 	defer st.Unlock()
-	// registered
-	err = assertstate.Add(st, sysdb.GenericClassicModel())
-	c.Assert(err, IsNil)
-	devicestatetest.SetDevice(st, &auth.DeviceState{
-		Brand:  "generic",
-		Model:  "generic-classic",
-		Serial: "serialserial",
-	})
 
 	// add "core" snap declaration
 	headers := map[string]interface{}{

--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2017 Canonical Ltd
+ * Copyright (C) 2016-2022 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -40,7 +40,6 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord"
-	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/devicestate/devicestatetest"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/ifacestate"
@@ -311,12 +310,7 @@ func (wm *witnessManager) Ensure() error {
 func markSeeded(o *overlord.Overlord) {
 	st := o.State()
 	st.Lock()
-	st.Set("seeded", true)
-	devicestatetest.SetDevice(st, &auth.DeviceState{
-		Brand:  "canonical",
-		Model:  "pc",
-		Serial: "serialserial",
-	})
+	devicestatetest.MarkInitialized(st)
 	st.Unlock()
 }
 


### PR DESCRIPTION
Remove the current double caching both in the state cache and on DeviceManager, keep the latter only and for the happy case.

Start simplifying the arguments to populateFromSeedImpl as well now that is a method on DeviceManager.

See the single commits as well.
