### PR TITLE
snapcraft.yaml: Limit the number of processors

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -169,7 +169,7 @@ parts:
       cd $SNAPCRAFT_PART_BUILD/libraries/libapparmor
       ./autogen.sh
       ./configure --prefix=/usr --disable-man-pages --disable-perl --disable-python --disable-ruby
-      make -j$(nproc)
+      make -j4
       # place libapparmor into staging area for use by snap-confine
       make -C src install DESTDIR=$SNAPCRAFT_STAGE
       cd $SNAPCRAFT_PART_BUILD/parser
@@ -184,13 +184,13 @@ parts:
       else
         cp $SNAPCRAFT_PROJECT_DIR/snap/local/apparmor/af_names.h .
       fi
-      make -j$(nproc)
+      make -j4
       mkdir -p $SNAPCRAFT_PART_INSTALL/usr/lib/snapd
       cp -a apparmor_parser $SNAPCRAFT_PART_INSTALL/usr/lib/snapd/
       mkdir -p $SNAPCRAFT_PART_INSTALL/usr/lib/snapd/apparmor
       cp -a parser.conf $SNAPCRAFT_PART_INSTALL/usr/lib/snapd/apparmor/
       cd $SNAPCRAFT_PART_BUILD/profiles
-      make -j$(nproc)
+      make -j4
       mkdir -p $SNAPCRAFT_PART_INSTALL/usr/lib/snapd/apparmor.d
       cp -a apparmor.d/abi $SNAPCRAFT_PART_INSTALL/usr/lib/snapd/apparmor.d/
       cp -a apparmor.d/abstractions $SNAPCRAFT_PART_INSTALL/usr/lib/snapd/apparmor.d/


### PR DESCRIPTION
On snapcraft 4.x, multipass is used by default. The VM has a limit in memory but not in number of cores. Which means building in parallel does not work on machines with many cores since the VM does not have enough memory.