### PR TITLE
snap/quota,wrappers: support inheritting journal quota for service sub-groups

### DIFF
--- a/snap/quota/quota.go
+++ b/snap/quota/quota.go
@@ -160,10 +160,6 @@ func NewGroup(name string, resourceLimits Resources) (*Group, error) {
 	return grp, nil
 }
 
-func (grp *Group) Parent() *Group {
-	return grp.parentGroup
-}
-
 func (grp *Group) GetQuotaResources() Resources {
 	resourcesBuilder := NewResourcesBuilder()
 	if grp.MemoryLimit != 0 {
@@ -278,8 +274,27 @@ func (grp *Group) SliceFileName() string {
 	return buf.String()
 }
 
-// JournalNamespaceName returns the snap formatted name of the log namespace
+// JournalQuotaSet returns true if the group is subject to
+// a journal quota. This should only be used in cases where the caller
+// is interested in knowing if a quota group is affected by a journal
+// quota, and not in the case where the caller needs to know if the
+// group itself has a journal quota set. For service groups this depends
+// on their parent quota group.
+func (grp *Group) JournalQuotaSet() bool {
+	if grp.parentGroup != nil && len(grp.Services) > 0 {
+		return grp.parentGroup.JournalQuotaSet()
+	}
+	return grp.JournalLimit != nil
+}
+
+// JournalNamespaceName returns the snap formatted name of the log namespace,
+// corresponding to the namespace of the journal quota affecting this group. If
+// this group is a service group, this returns the journal namespace name for the
+// parent group instead.
 func (grp *Group) JournalNamespaceName() string {
+	if grp.parentGroup != nil && len(grp.Services) > 0 {
+		return grp.parentGroup.JournalNamespaceName()
+	}
 	return fmt.Sprintf("snap-%s", grp.Name)
 }
 

--- a/snap/quota/quota.go
+++ b/snap/quota/quota.go
@@ -160,6 +160,10 @@ func NewGroup(name string, resourceLimits Resources) (*Group, error) {
 	return grp, nil
 }
 
+func (grp *Group) Parent() *Group {
+	return grp.parentGroup
+}
+
 func (grp *Group) GetQuotaResources() Resources {
 	resourcesBuilder := NewResourcesBuilder()
 	if grp.MemoryLimit != 0 {

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -24,7 +24,6 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -844,7 +843,6 @@ func (es *ensureSnapServicesContext) ensureJournalQuotaServiceUnits(quotaGroups 
 		if grp.JournalLimit == nil {
 			continue
 		}
-		log.Printf("ensureJournalQuotaServiceUnits %s", grp.Name)
 
 		if err := os.MkdirAll(grp.JournalServiceDropInDir(), 0755); err != nil {
 			return err

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -1372,11 +1372,20 @@ WantedBy={{.ServicesTarget}}
 		panic("unknown snap.DaemonScope")
 	}
 
-	// check the quota group slice
+	// get slice and journal options if a quota group is provided
+	// for the service
 	if opts.QuotaGroup != nil {
-		wrapperData.SliceUnit = opts.QuotaGroup.SliceFileName()
-		if opts.QuotaGroup.JournalLimit != nil {
-			wrapperData.LogNamespace = opts.QuotaGroup.JournalNamespaceName()
+		quotaGrp := opts.QuotaGroup
+		wrapperData.SliceUnit = quotaGrp.SliceFileName()
+
+		// service quota groups inherit their parents journal quotas,
+		// due to limitations in how we do the bind mount layouts for snaps.
+		if len(quotaGrp.Services) != 0 {
+			quotaGrp = quotaGrp.Parent()
+		}
+
+		if quotaGrp.JournalLimit != nil {
+			wrapperData.LogNamespace = quotaGrp.JournalNamespaceName()
 		}
 	}
 

--- a/wrappers/services_gen_test.go
+++ b/wrappers/services_gen_test.go
@@ -1135,25 +1135,22 @@ func (s *servicesWrapperGenSuite) TestQuotaGroupLogNamespaceInheritParent(c *C) 
 		description   string
 	}{
 		{
-			topResources:  quota.NewResourcesBuilder().WithJournalNamespace().Build(),
-			subResources:  quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB / 2).Build(),
-			expectedSlice: "snap.foo-foosub.slice",
-			expectedLog:   "snap-foo",
-			description:   "Setting a namespace on parent, and none on service sub-group, must inherit parent",
+			topResources: quota.NewResourcesBuilder().WithJournalNamespace().Build(),
+			subResources: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB / 2).Build(),
+			expectedLog:  "snap-foo",
+			description:  "Setting a namespace on parent, and none on service sub-group, must inherit parent",
 		},
 		{
-			topResources:  quota.NewResourcesBuilder().WithJournalNamespace().Build(),
-			subResources:  quota.NewResourcesBuilder().WithJournalNamespace().Build(),
-			expectedSlice: "snap.foo-foosub.slice",
-			expectedLog:   "snap-foo",
-			description:   "Setting a namespace on both groups, it should select parent",
+			topResources: quota.NewResourcesBuilder().WithJournalNamespace().Build(),
+			subResources: quota.NewResourcesBuilder().WithJournalNamespace().Build(),
+			expectedLog:  "snap-foo",
+			description:  "Setting a namespace on both groups, it should select parent",
 		},
 		{
-			topResources:  quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
-			subResources:  quota.NewResourcesBuilder().WithJournalNamespace().Build(),
-			expectedSlice: "snap.foo-foosub.slice",
-			expectedLog:   "",
-			description:   "Setting a namespace on only sub-group, no namespace should be selected",
+			topResources: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
+			subResources: quota.NewResourcesBuilder().WithJournalNamespace().Build(),
+			expectedLog:  "",
+			description:  "Setting a namespace on only sub-group, no namespace should be selected",
 		},
 	}
 
@@ -1169,7 +1166,7 @@ func (s *servicesWrapperGenSuite) TestQuotaGroupLogNamespaceInheritParent(c *C) 
 		opts := &wrappers.GenerateSnapServicesOptions{QuotaGroup: sub}
 		generatedWrapper, err := wrappers.GenerateSnapServiceFile(service, opts)
 		c.Assert(err, IsNil)
-		c.Check(string(generatedWrapper), testutil.Contains, fmt.Sprintf("Slice=%s", t.expectedSlice), Commentf("test failed: %s", t.description))
+		c.Check(string(generatedWrapper), testutil.Contains, "Slice=snap.foo-foosub.slice", Commentf("test failed: %s", t.description))
 		if t.expectedLog != "" {
 			c.Check(string(generatedWrapper), testutil.Contains, fmt.Sprintf("LogNamespace=%s", t.expectedLog), Commentf("test failed: %s", t.description))
 		} else {

--- a/wrappers/services_gen_test.go
+++ b/wrappers/services_gen_test.go
@@ -1029,11 +1029,10 @@ func (s *servicesWrapperGenSuite) TestQuotaGroupSlice(c *C) {
 			Version:       "0.3.4",
 			SideInfo:      snap.SideInfo{Revision: snap.R(44)},
 		},
-		Name:         "app",
-		Command:      "bin/foo start",
-		Daemon:       "simple",
-		DaemonScope:  snap.SystemDaemon,
-		RestartDelay: timeout.Timeout(20 * time.Second),
+		Name:        "app",
+		Command:     "bin/foo start",
+		Daemon:      "simple",
+		DaemonScope: snap.SystemDaemon,
 	}
 
 	grp, err := quota.NewGroup("foo", quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build())
@@ -1056,7 +1055,6 @@ EnvironmentFile=-/etc/environment
 ExecStart=/usr/bin/snap run snap.app
 SyslogIdentifier=snap.app
 Restart=on-failure
-RestartSec=20
 WorkingDirectory=/var/snap/snap/44
 TimeoutStopSec=30
 Type=simple
@@ -1074,11 +1072,10 @@ func (s *servicesWrapperGenSuite) TestQuotaGroupLogNamespace(c *C) {
 			Version:       "0.3.4",
 			SideInfo:      snap.SideInfo{Revision: snap.R(44)},
 		},
-		Name:         "app",
-		Command:      "bin/foo start",
-		Daemon:       "simple",
-		DaemonScope:  snap.SystemDaemon,
-		RestartDelay: timeout.Timeout(20 * time.Second),
+		Name:        "app",
+		Command:     "bin/foo start",
+		Daemon:      "simple",
+		DaemonScope: snap.SystemDaemon,
 	}
 
 	grp, err := quota.NewGroup("foo", quota.NewResourcesBuilder().WithJournalNamespace().Build())
@@ -1101,7 +1098,6 @@ EnvironmentFile=-/etc/environment
 ExecStart=/usr/bin/snap run snap.app
 SyslogIdentifier=snap.app
 Restart=on-failure
-RestartSec=20
 WorkingDirectory=/var/snap/snap/44
 TimeoutStopSec=30
 Type=simple
@@ -1120,19 +1116,17 @@ func (s *servicesWrapperGenSuite) TestQuotaGroupLogNamespaceInheritParent(c *C) 
 			Version:       "0.3.4",
 			SideInfo:      snap.SideInfo{Revision: snap.R(44)},
 		},
-		Name:         "app",
-		Command:      "bin/foo start",
-		Daemon:       "simple",
-		DaemonScope:  snap.SystemDaemon,
-		RestartDelay: timeout.Timeout(20 * time.Second),
+		Name:        "app",
+		Command:     "bin/foo start",
+		Daemon:      "simple",
+		DaemonScope: snap.SystemDaemon,
 	}
 
 	testCases := []struct {
-		topResources  quota.Resources
-		subResources  quota.Resources
-		expectedSlice string
-		expectedLog   string
-		description   string
+		topResources quota.Resources
+		subResources quota.Resources
+		expectedLog  string
+		description  string
 	}{
 		{
 			topResources: quota.NewResourcesBuilder().WithJournalNamespace().Build(),


### PR DESCRIPTION
This support was missing for the per-service quotas. Since we no longer allow specifying journal quotas for service sub-groups, they should instead inherit their parent journal quota (if set). This adds this missing code.