### PR TITLE
tests: update dependencies to fix opensuse tumbleweed update process

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -794,7 +794,6 @@ pkg_dependencies_opensuse(){
     if os.query is-opensuse tumbleweed; then
         echo "
             libfwupd2
-            libfwupdplugin5
         "
     fi
 }


### PR DESCRIPTION
The package libfwupdplugin5 is not available anymore for opensuse tumbleweed.

'libfwupdplugin5' not found in package names. Trying capabilities. No provider of 'libfwupdplugin5' found.
