### PR TITLE
gadget: return error if offset is less than 17408 bytes in gpt schema

### DIFF
--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -837,10 +837,6 @@ func validateVolume(vol *Volume) error {
 			return fmt.Errorf("invalid structure %v: %v", fmtIndexAndName(idx, s.Name), err)
 		}
 
-		start := *s.Offset
-		end := start + quantity.Offset(s.Size)
-		// The GPT partition table will start from sector 2 with minimum
-		// length 16384 bytes
 		if vol.Schema == schemaGPT {
 			// If the block size is 512, the First Usable LBA must be greater than or equal to
 			// 34 (allowing 1 block for the Protective MBR, 1 block for the Partition Table
@@ -852,9 +848,11 @@ func validateVolume(vol *Volume) error {
 			// are not able to easily know whether the structure defined in gadget.yaml will
 			// overlap GPT header or GPT partition table, thus we only return error if the
 			// structure overlap the offset between 4096 and 512 * 34
-			if start < (512 * 34) && end > 4096 {
+			start := *s.Offset
+			end := start + quantity.Offset(s.Size)
+			if start < (512*34) && end > 4096 {
 				return fmt.Errorf("invalid structure: GPT header or GPT partition table overlapped with structure \"%s\"\n", s.Name)
-			} else if start < (4096 * 6) && end > 512 {
+			} else if start < (4096*6) && end > 512 {
 				logger.Noticef("WARNING: GPT header or GPT partition table might be overlapped with structure \"%s\"", s.Name)
 			}
 		}

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -37,6 +37,7 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/gadget/edition"
 	"github.com/snapcore/snapd/gadget/quantity"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/metautil"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/disks"
@@ -835,6 +836,29 @@ func validateVolume(vol *Volume) error {
 		if err := validateVolumeStructure(&s, vol); err != nil {
 			return fmt.Errorf("invalid structure %v: %v", fmtIndexAndName(idx, s.Name), err)
 		}
+
+		start := *s.Offset
+		end := start + quantity.Offset(s.Size)
+		// The GPT partition table will start from sector 2 with minimum
+		// length 16384 bytes
+		if vol.Schema == schemaGPT {
+			// If the block size is 512, the First Usable LBA must be greater than or equal to
+			// 34 (allowing 1 block for the Protective MBR, 1 block for the Partition Table
+			// Header, and 32 blocks for the GPT Partition Entry Array); if the logical block
+			// size is 4096, the First Useable LBA must be greater than or equal to 6 (allowing
+			// 1 block for the Protective MBR, 1 block for the GPT Header, and 4
+			// blocks for the GPT Partition Entry Array)
+			// Since we are not able to know the block size when building gadget snap, so we
+			// are not able to easily know whether the structure defined in gadget.yaml will
+			// overlap GPT header or GPT partition table, thus we only return error if the
+			// structure overlap the offset between 4096 and 512 * 34
+			if start < (512 * 34) && end > 4096 {
+				return fmt.Errorf("invalid structure: GPT header or GPT partition table overlapped with structure \"%s\"\n", s.Name)
+			} else if start < (4096 * 6) && end > 512 {
+				logger.Noticef("WARNING: GPT header or GPT partition table might be overlapped with structure \"%s\"", s.Name)
+			}
+		}
+
 		structures[idx] = vol.Structure[idx]
 		if s.Name != "" {
 			if _, ok := knownStructures[s.Name]; ok {

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -116,7 +116,7 @@ volumes:
       - name: u-boot
         type: bare
         size: 623000
-        offset: 0
+        offset: 24576
         content:
           - image: u-boot.imz
 `)
@@ -147,7 +147,7 @@ volumes:
       - name: u-boot
         type: bare
         size: 623000
-        offset: 0
+        offset: 24576
         content:
           - image: u-boot.imz
 `)
@@ -822,7 +822,7 @@ func (s *gadgetYamlTestSuite) TestReadMultiVolumeGadgetYamlValid(c *C) {
 						Name:       "u-boot",
 						Type:       "bare",
 						Size:       623000,
-						Offset:     asOffsetPtr(0),
+						Offset:     asOffsetPtr(24576),
 						Content: []gadget.VolumeContent{
 							{
 								Image: "u-boot.imz",
@@ -1292,6 +1292,40 @@ func (s *gadgetYamlTestSuite) TestValidateVolumeSchema(c *C) {
 	}
 }
 
+func (s *gadgetYamlTestSuite) TestValidateVolumeSchemaNotOverlapWithGPT(c *C) {
+	for i, tc := range []struct {
+		s   string
+		sz  quantity.Size
+		o   quantity.Offset
+		err string
+	}{
+		// in sector 0 only
+		{"gpt", 511, 0, ""},
+		// might overlap with GPT header, print warning only
+		{"gpt", 511, 512, ""},
+		{"gpt", 4096, 0, ""},
+		// overlap GPT partition table
+		{"gpt", 16383, 1024, "invalid structure: GPT header or GPT partition table overlapped with structure \"name\"\n"},
+		{"gpt", 2048, 17407, "invalid structure: GPT header or GPT partition table overlapped with structure \"name\"\n"},
+		// might overlap with GPT partition table, print warning only
+		{"gpt", 2048, 17408, ""},
+	} {
+		c.Logf("tc: %v schema: %+v, size: %d, offset: %d", i, tc.s, tc.sz, tc.o)
+
+		err := gadget.ValidateVolume(&gadget.Volume{
+			Name: "name", Schema: tc.s,
+			Structure: []gadget.VolumeStructure{
+				{Name: "name", Type: "bare", Size: tc.sz, Offset: &tc.o},
+			},
+		})
+		if tc.err != "" {
+			c.Check(err, ErrorMatches, tc.err)
+		} else {
+			c.Check(err, IsNil)
+		}
+	}
+}
+
 func (s *gadgetYamlTestSuite) TestValidateVolumeName(c *C) {
 
 	for i, tc := range []struct {
@@ -1326,8 +1360,8 @@ func (s *gadgetYamlTestSuite) TestValidateVolumeDuplicateStructures(c *C) {
 	err := gadget.ValidateVolume(&gadget.Volume{
 		Name: "name",
 		Structure: []gadget.VolumeStructure{
-			{Name: "duplicate", Type: "bare", Size: 1024},
-			{Name: "duplicate", Type: "21686148-6449-6E6F-744E-656564454649", Size: 2048},
+			{Name: "duplicate", Type: "bare", Size: 1024, Offset: asOffsetPtr(24576)},
+			{Name: "duplicate", Type: "21686148-6449-6E6F-744E-656564454649", Size: 2048, Offset: asOffsetPtr(24576)},
 		},
 	})
 	c.Assert(err, ErrorMatches, `structure name "duplicate" is not unique`)
@@ -1370,8 +1404,8 @@ func (s *gadgetYamlTestSuite) TestValidateVolumeErrorsWrapped(c *C) {
 	err := gadget.ValidateVolume(&gadget.Volume{
 		Name: "name",
 		Structure: []gadget.VolumeStructure{
-			{Type: "bare", Size: 1024},
-			{Type: "bogus", Size: 1024},
+			{Type: "bare", Size: 1024, Offset: asOffsetPtr(24576)},
+			{Type: "bogus", Size: 1024, Offset: asOffsetPtr(24576)},
 		},
 	})
 	c.Assert(err, ErrorMatches, `invalid structure #1: invalid type "bogus": invalid format`)
@@ -1379,8 +1413,8 @@ func (s *gadgetYamlTestSuite) TestValidateVolumeErrorsWrapped(c *C) {
 	err = gadget.ValidateVolume(&gadget.Volume{
 		Name: "name",
 		Structure: []gadget.VolumeStructure{
-			{Type: "bare", Size: 1024},
-			{Type: "bogus", Size: 1024, Name: "foo"},
+			{Type: "bare", Size: 1024, Offset: asOffsetPtr(24576)},
+			{Type: "bogus", Size: 1024, Name: "foo", Offset: asOffsetPtr(24576)},
 		},
 	})
 	c.Assert(err, ErrorMatches, `invalid structure #1 \("foo"\): invalid type "bogus": invalid format`)
@@ -1388,7 +1422,7 @@ func (s *gadgetYamlTestSuite) TestValidateVolumeErrorsWrapped(c *C) {
 	err = gadget.ValidateVolume(&gadget.Volume{
 		Name: "name",
 		Structure: []gadget.VolumeStructure{
-			{Type: "bare", Name: "foo", Size: 1024, Content: []gadget.VolumeContent{{UnresolvedSource: "foo"}}},
+			{Type: "bare", Name: "foo", Size: 1024, Offset: asOffsetPtr(24576), Content: []gadget.VolumeContent{{UnresolvedSource: "foo"}}},
 		},
 	})
 	c.Assert(err, ErrorMatches, `invalid structure #0 \("foo"\): invalid content #0: cannot use non-image content for bare file system`)
@@ -1603,7 +1637,7 @@ volumes:
           - image: pc-boot.img
       - name: other-name
         type: DA,21686148-6449-6E6F-744E-656564454649
-        size: 1M
+        size: 300
         offset: 200
         content:
           - image: pc-core.img
@@ -1623,13 +1657,13 @@ volumes:
     structure:
       - name: overlaps-with-foo
         type: DA,21686148-6449-6E6F-744E-656564454649
-        size: 1M
+        size: 300
         offset: 200
         content:
           - image: pc-core.img
       - name: foo
         type: DA,21686148-6449-6E6F-744E-656564454648
-        size: 1M
+        size: 200
         offset: 100
         filesystem: vfat
 `
@@ -1648,7 +1682,7 @@ volumes:
     structure:
       - name: other-name
         type: DA,21686148-6449-6E6F-744E-656564454649
-        size: 1M
+        size: 10
         offset: 500
         content:
           - image: pc-core.img
@@ -1674,7 +1708,7 @@ volumes:
     structure:
       - name: other-name
         type: DA,21686148-6449-6E6F-744E-656564454649
-        size: 1M
+        size: 10
         offset: 500
         content:
           - image: pc-core.img
@@ -2108,25 +2142,25 @@ func (s *gadgetYamlTestSuite) TestLaidOutVolumesFromGadgetMultiVolume(c *C) {
 
 	c.Assert(all, HasLen, 2)
 	c.Assert(all["frobinator-image"], DeepEquals, systemLv)
-	zero := quantity.Offset(0)
 	c.Assert(all["u-boot-frobinator"].LaidOutStructure, DeepEquals, []gadget.LaidOutStructure{
 		{
 			VolumeStructure: &gadget.VolumeStructure{
 				VolumeName: "u-boot-frobinator",
 				Name:       "u-boot",
-				Offset:     &zero,
+				Offset:     asOffsetPtr(24576),
 				Size:       quantity.Size(623000),
 				Type:       "bare",
 				Content: []gadget.VolumeContent{
 					{Image: "u-boot.imz"},
 				},
 			},
-			StartOffset: 0,
+			StartOffset: 24576,
 			LaidOutContent: []gadget.LaidOutContent{
 				{
 					VolumeContent: &gadget.VolumeContent{
 						Image: "u-boot.imz",
 					},
+					StartOffset: 24576,
 				},
 			},
 		},


### PR DESCRIPTION
Hi, 

I think it would be better if we can check the offset does not overlap with GPT partition table when building gadget snap, here are some testing result if I try to set the offset that overlap with the GPT partition table, the image built by using ubuntu-image will be un-usable

If I understand correctly, the GPT partition table start at sector 2, and will have length 16384 bytes, so if the offset defined in gadget.yaml is less than 17408, then it will overlap the GPT partition table


## Test case 1
Here is the gadget.yaml that will overlap with GPT partition, the offset is 17407
```sh
$ cat gadget/prime/meta/gadget.yaml 
device-tree-origin: kernel
device-tree: XXXXX.dtb
volumes:
  test:
    schema: gpt
    bootloader: u-boot
    structure:
      - name: firmware
        offset: 17407
        size: 64M
        type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
        content:
          - image: firmware.img
      - name: bootloaders
        type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
        filesystem: vfat
        filesystem-label: system-boot
        size: 10M
        content:
          - source: configs/
            target: /
```
Here is the partition table for the image built by using ubuntu-image
```sh
$ mmls out/test.img
GUID Partition Table (EFI)
Offset Sector: 0
Units are in 512-byte sectors

      Slot      Start        End          Length       Description
000:  Meta      0000000000   0000000000   0000000001   Safety Table
001:  -------   0000000000   0000000032   0000000033   Unallocated
002:  Meta      0000000001   0000000001   0000000001   GPT Header
003:  Meta      0000000002   0000000033   0000000032   Partition Table
004:  000       0000000033   0000131104   0000131072   firmware
005:  001       0000131105   0000151584   0000020480   bootloaders
006:  002       0000151585   0007144528   0006992944   writable
007:  124       0003194880   41231719608736   41231716413857   
008:  -------   41231719608737   3692961299186534214   3692920067466925478   Unallocated
009:  125       3692961299186534215   3697464897618051072   4503598431516858   䝇䝇ࢼ㍐
```


## Test case 2
Here is the gadget snap that will not overlap with GPT partition table, the offset is 17408
```sh
$ cat gadget/prime/meta/gadget.yaml 
device-tree-origin: kernel
device-tree: XXXXXX.dtb
volumes:
  test:
    schema: gpt
    bootloader: u-boot
    structure:
      - name: firmware
        offset: 17408
        size: 64M
        type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
        content:
          - image: firmware.img
      - name: bootloaders
        type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
        filesystem: vfat
        filesystem-label: system-boot
        size: 10M
        content:
          - source: configs/
            target: /
```

Here is the partition table for the image built by using ubuntu-image
```
$ mmls out/test.img 
GUID Partition Table (EFI)
Offset Sector: 0
Units are in 512-byte sectors

      Slot      Start        End          Length       Description
000:  Meta      0000000000   0000000000   0000000001   Safety Table
001:  -------   0000000000   0000000033   0000000034   Unallocated
002:  Meta      0000000001   0000000001   0000000001   GPT Header
003:  Meta      0000000002   0000000033   0000000032   Partition Table
004:  000       0000000034   0000131105   0000131072   firmware
005:  001       0000131106   0000151585   0000020480   bootloaders
006:  002       0000151586   0007144517   0006992932   writable
007:  -------   0007144518   0007178239   0000033722   Unallocated
```

Please let me know if I made any mistake, thanks for spending time review this!