### PR TITLE
Support raspberry-pi sdtv_mode option

### DIFF
--- a/overlord/configstate/configcore/picfg.go
+++ b/overlord/configstate/configcore/picfg.go
@@ -60,6 +60,7 @@ var piConfigKeys = map[string]bool{
 	"gpu_mem_512":              true,
 	"gpu_mem":                  true,
 	"sdtv_aspect":              true,
+	"sdtv_mode":                true,
 	"config_hdmi_boost":        true,
 	"hdmi_force_hotplug":       true,
 	"start_x":                  true,


### PR DESCRIPTION
Hi guys. I'm trying to set a valid pi option: stdv_mode[1] but it gives me:

```
$ sudo snap set core pi-config.sdtv-mode=1
error: cannot perform the following tasks:
- Run configure hook of "core" snap (run hook "configure": cannot set "core.pi-config.sdtv-mode": unsupported system option)
```

A similar option: pi-config.sdtv-aspect works just fine:

```
$ sudo snap set core pi-config.sdtv-aspect=3
```
1. https://www.raspberrypi.com/documentation/computers/config_txt.html#sdtv_mode

-------

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?

Yes, I think I commited a bugfix earlier.
