### PR TITLE
daemon: simplify time handling in REST API

### DIFF
--- a/client/packages.go
+++ b/client/packages.go
@@ -20,7 +20,6 @@
 package client
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
@@ -41,7 +40,7 @@ type Snap struct {
 	DownloadSize  int64              `json:"download-size,omitempty"`
 	Icon          string             `json:"icon,omitempty"`
 	InstalledSize int64              `json:"installed-size,omitempty"`
-	InstallDate   time.Time          `json:"install-date,omitempty"`
+	InstallDate   *time.Time         `json:"install-date,omitempty"`
 	Name          string             `json:"name"`
 	Publisher     *snap.StoreAccount `json:"publisher,omitempty"`
 	StoreURL      string             `json:"store-url,omitempty"`
@@ -97,21 +96,6 @@ type SnapHealth struct {
 	Status    string        `json:"status"`
 	Message   string        `json:"message,omitempty"`
 	Code      string        `json:"code,omitempty"`
-}
-
-func (s *Snap) MarshalJSON() ([]byte, error) {
-	type auxSnap Snap // use auxiliary type so that Go does not call Snap.MarshalJSON()
-	// separate type just for marshalling
-	m := struct {
-		auxSnap
-		InstallDate *time.Time `json:"install-date,omitempty"`
-	}{
-		auxSnap: auxSnap(*s),
-	}
-	if !s.InstallDate.IsZero() {
-		m.InstallDate = &s.InstallDate
-	}
-	return json.Marshal(&m)
 }
 
 // Statuses and types a snap may have.

--- a/client/packages_test.go
+++ b/client/packages_test.go
@@ -274,6 +274,10 @@ func (cs *clientSuite) TestClientSnap(c *check.C) {
 	c.Assert(cs.req.Method, check.Equals, "GET")
 	c.Assert(cs.req.URL.Path, check.Equals, fmt.Sprintf("/v2/snaps/%s", pkgName))
 	c.Assert(err, check.IsNil)
+
+	c.Assert(pkg.InstallDate.Equal(time.Date(2016, 1, 2, 15, 4, 5, 0, time.UTC)), check.Equals, true)
+	pkg.InstallDate = nil
+
 	c.Assert(pkg, check.DeepEquals, &client.Snap{
 		ID:            "funky-snap-id",
 		Summary:       "bla bla",
@@ -282,7 +286,6 @@ func (cs *clientSuite) TestClientSnap(c *check.C) {
 		DownloadSize:  6930947,
 		Icon:          "/v2/icons/chatroom.ogra/icon",
 		InstalledSize: 18976651,
-		InstallDate:   time.Date(2016, 1, 2, 15, 4, 5, 0, time.UTC),
 		License:       "GPL-3.0",
 		Name:          "chatroom",
 		Developer:     "ogra",

--- a/cmd/snap/cmd_info.go
+++ b/cmd/snap/cmd_info.go
@@ -265,8 +265,8 @@ func (iw *infoWriter) maybePrintRefreshInfo() {
 		return
 	}
 
-	if !iw.localSnap.InstallDate.IsZero() {
-		fmt.Fprintf(iw, "refresh-date:\t%s\n", iw.fmtTime(iw.localSnap.InstallDate))
+	if iw.localSnap.InstallDate != nil && !iw.localSnap.InstallDate.IsZero() {
+		fmt.Fprintf(iw, "refresh-date:\t%s\n", iw.fmtTime(*iw.localSnap.InstallDate))
 	}
 
 	maybePrintHold := func(key string, hold *time.Time) {

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -1000,8 +1000,8 @@ UnitFileState=enabled
 	c.Check(m.InstalledSize, check.FitsTypeOf, int64(0))
 	m.InstalledSize = 0
 	// ditto install-date
-	c.Check(m.InstallDate, check.FitsTypeOf, time.Time{})
-	m.InstallDate = time.Time{}
+	c.Check(m.InstallDate, check.FitsTypeOf, &time.Time{})
+	m.InstallDate = nil
 
 	expected := &daemon.RespJSON{
 		Type:   daemon.ResponseTypeSync,

--- a/snap/info.go
+++ b/snap/info.go
@@ -690,18 +690,19 @@ func (s *Info) ExpandSnapVariables(path string) string {
 
 // InstallDate returns the "install date" of the snap.
 //
-// If the snap is not active, it'll return a zero time; otherwise
+// If the snap is not active, it'll return nil; otherwise
 // it'll return the modtime of the "current" symlink. Sneaky.
-func (s *Info) InstallDate() time.Time {
+func (s *Info) InstallDate() *time.Time {
 	dir, rev := filepath.Split(s.MountDir())
 	cur := filepath.Join(dir, "current")
 	tag, err := os.Readlink(cur)
 	if err == nil && tag == rev {
 		if st, err := os.Lstat(cur); err == nil {
-			return st.ModTime()
+			modTime := st.ModTime()
+			return &modTime
 		}
 	}
-	return time.Time{}
+	return nil
 }
 
 // IsActive returns whether this snap revision is active.

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -389,7 +389,7 @@ func (s *infoSuite) TestInstallDate(c *C) {
 	si := &snap.SideInfo{Revision: snap.R(1)}
 	info := snaptest.MockSnap(c, sampleYaml, si)
 	// not current -> Zero
-	c.Check(info.InstallDate().IsZero(), Equals, true)
+	c.Check(info.InstallDate(), IsNil)
 	c.Check(snap.InstallDate(info.InstanceName()).IsZero(), Equals, true)
 
 	mountdir := info.MountDir()


### PR DESCRIPTION
The `InstallDate` field used in an API response was a `time.Time` that would then be mapped to `*time.Time` in a custom `MarshalJSON`. I couldn't find a reason why this was different in the original PR (https://github.com/snapcore/snapd/pull/4260) or by asking around (like compatibility, etc). So I changed the field to a `*time.Time` which I think is more expected and less complicated.