### PR TITLE
tests: skip lxd tests in ubuntu lunar

### DIFF
--- a/tests/main/lxd-mount-units/task.yaml
+++ b/tests/main/lxd-mount-units/task.yaml
@@ -5,7 +5,7 @@ details: |
     are correct for snapfuse.
 
 # only 20.04+, we want lxd images that come with snaps preinstalled.
-systems: [ubuntu-2*]
+systems: [ubuntu-20*, ubuntu-22*]
 
 restore: |
     lxd.lxc stop ubuntu --force || true
@@ -33,7 +33,7 @@ execute: |
         lxd.lxc config set core.proxy_https "$http_proxy"
     fi
 
-    # There isn't an official image for kinetic yet, let's use the community one
+    # There isn't an official image for lunar yet, let's use the community one
     if os.query is-ubuntu 23.04; then
         CODENAME=$(. /etc/os-release && echo "$VERSION_CODENAME")
         lxc launch --quiet "images:ubuntu/$CODENAME" ubuntu
@@ -58,7 +58,7 @@ execute: |
     DEB=$(basename "$GOHOME"/snapd_*.deb)
     
     lxd.lxc exec ubuntu -- apt update
-    # As for ubuntu kinetic it is not using the official image, snapd is not installed by default
+    # As for ubuntu lunar it is not using the official image, snapd is not installed by default
     # This should be removed once the official image is released
     if os.query is-ubuntu 23.04; then
         lxd.lxc exec ubuntu -- apt install -y snapd

--- a/tests/main/lxd-no-fuse/task.yaml
+++ b/tests/main/lxd-no-fuse/task.yaml
@@ -28,14 +28,8 @@ execute: |
         lxd.lxc config set core.proxy_https "$http_proxy"
     fi
 
-    # There isn't an official image for kinetic yet, let's use the community one
-    if os.query is-ubuntu 23.04; then
-        CODENAME=$(. /etc/os-release && echo "$VERSION_CODENAME")
-        lxc launch --quiet "images:ubuntu/$CODENAME" my-ubuntu
-    else
-        VERSION_ID="$(. /etc/os-release && echo "$VERSION_ID" )"
-        lxd.lxc launch --quiet "ubuntu:$VERSION_ID" my-ubuntu
-    fi
+    VERSION_ID="$(. /etc/os-release && echo "$VERSION_ID" )"
+    lxd.lxc launch --quiet "ubuntu:$VERSION_ID" my-ubuntu
 
     if os.query is-pc-amd64 && lxd.lxc info my-ubuntu | grep "Architecture: i686"; then
         echo "LXD spawned 32bit userspace container on a 64bit host, WAT?"

--- a/tests/main/lxd-postrm-purge/task.yaml
+++ b/tests/main/lxd-postrm-purge/task.yaml
@@ -4,7 +4,7 @@ summary: Check that package remove and purge works inside LXD containers
 # couple of systems only. The postrm purge is more thoroughly checked in
 # tests/main/postrm-purge.
 # ubuntu-18.04-32: i386 is not supported by lxd
-systems: [ubuntu-18.04-64, ubuntu-2*]
+systems: [ubuntu-18.04-64, ubuntu-20*, ubuntu-22*]
 
 # start early
 priority: 1000
@@ -27,7 +27,7 @@ prepare: |
     lxd waitready
     lxd init --auto
 
-    # There isn't an official image for kinetic yet, let's use the community one
+    # There isn't an official image for lunar yet, let's use the community one
     if os.query is-ubuntu 23.04; then
         CODENAME=$(. /etc/os-release && echo "$VERSION_CODENAME")
         lxc launch --quiet "images:ubuntu/$CODENAME" my-ubuntu

--- a/tests/main/lxd-services-smoke/task.yaml
+++ b/tests/main/lxd-services-smoke/task.yaml
@@ -11,7 +11,7 @@ details: |
   any of the above.
 
 # ubuntu-18.04-32: i386 is not supported by lxd
-systems: [ubuntu-18.04-64, ubuntu-2*]
+systems: [ubuntu-18.04-64, ubuntu-20*, ubuntu-22*]
 
 environment:
   # apparmor_parser triggers OOM

--- a/tests/main/lxd-try/task.yaml
+++ b/tests/main/lxd-try/task.yaml
@@ -1,6 +1,6 @@
 summary: Check that try command works inside lxd container
 
-systems: [ubuntu-2*]
+systems: [ubuntu-20*, ubuntu-22*]
 
 prepare: |
   echo "Install lxd"
@@ -17,8 +17,8 @@ prepare: |
       lxd.lxc config set core.proxy_https "$http_proxy"
   fi
 
-  # There isn't an official image for kinetic yet, let's use the community one
-  if os.query is-ubuntu 22.10; then
+  # There isn't an official image for lunar yet, let's use the community one
+  if os.query is-ubuntu 23.04; then
       CODENAME=$(. /etc/os-release && echo "$VERSION_CODENAME")
       lxc launch --quiet "images:ubuntu/$CODENAME" ubuntu
   else

--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -7,7 +7,7 @@ backends: [-autopkgtest]
 # Only run this on ubuntu 16+, lxd will not work on !ubuntu systems
 # currently nor on ubuntu 14.04
 # ubuntu-18.04-32: i386 is not supported by lxd
-systems: [ubuntu-16*, ubuntu-18.04-64, ubuntu-2*, ubuntu-core-*]
+systems: [ubuntu-16.04-64, ubuntu-18.04-64, ubuntu-20*, ubuntu-22*, ubuntu-core-*]
 
 # Start before anything else as it can take a really long time.
 priority: 1000
@@ -91,7 +91,7 @@ execute: |
     # prep two containers, the my-ubuntu normal container and the
     # my-nesting-ubuntu nesting container
 
-    # There isn't an official image for kinetic yet, let's use the community one
+    # There isn't an official image for lunar yet, let's use the community one
     if os.query is-ubuntu 23.04; then
         CODENAME=$(. /etc/os-release && echo "$VERSION_CODENAME")
         lxc launch --quiet "images:ubuntu/$CODENAME" my-ubuntu
@@ -170,7 +170,7 @@ execute: |
     lxd.lxc exec my-nesting-ubuntu -- lxd waitready
     lxd.lxc exec my-nesting-ubuntu -- lxd init --auto
 
-    # There isn't an official image for kinetic yet, let's use the community one
+    # There isn't an official image for lunar yet, let's use the community one
     if os.query is-ubuntu 23.04; then
       CODENAME=$(. /etc/os-release && echo "$VERSION_CODENAME")
       lxd.lxc exec my-nesting-ubuntu -- lxc launch --quiet "images:ubuntu/$CODENAME" my-inner-ubuntu


### PR DESCRIPTION
There is no community image published for lunar yet.

When the image is published the tests are going to be updated to include lunar

Also some comments are fixed and not used code is removed

There is a following pr created #12458 to re-enable the lxd tests once the images are published