### PR TITLE
cmd/snap-confine: protective measure against attacks using stderr redirection

### DIFF
--- a/cmd/libsnap-confine-private/utils.c
+++ b/cmd/libsnap-confine-private/utils.c
@@ -28,13 +28,13 @@
 #include "panic.h"
 #include "utils.h"
 
-int sc_nonblocking_stdout(void)
+int sc_nonblocking_stderr(void)
 {
-    int flags = fcntl(STDOUT_FILENO, F_GETFL, 0);
+    int flags = fcntl(STDERR_FILENO, F_GETFL, 0);
     if (flags == -1) {
         return -1;
     }
-    return fcntl(STDOUT_FILENO, F_SETFL, flags | O_NONBLOCK);
+    return fcntl(STDERR_FILENO, F_SETFL, flags | O_NONBLOCK);
 }
 
 void die(const char *msg, ...)

--- a/cmd/libsnap-confine-private/utils.c
+++ b/cmd/libsnap-confine-private/utils.c
@@ -28,6 +28,15 @@
 #include "panic.h"
 #include "utils.h"
 
+int sc_nonblocking_stdout(void)
+{
+    int flags = fcntl(STDOUT_FILENO, F_GETFL, 0);
+    if (flags == -1) {
+        return -1;
+    }
+    return fcntl(STDOUT_FILENO, F_SETFL, flags | O_NONBLOCK);
+}
+
 void die(const char *msg, ...)
 {
 	va_list ap;

--- a/cmd/libsnap-confine-private/utils.h
+++ b/cmd/libsnap-confine-private/utils.h
@@ -28,6 +28,13 @@ __attribute__((format(printf, 1, 2)))
 void debug(const char *fmt, ...);
 
 /**
+ * Sets the stdout stream to use non-blocking i/o.
+ * 
+ * Returns -1 on any errors.
+ **/
+int sc_nonblocking_stdout(void);
+
+/**
  * Get an environment variable and convert it to a boolean.
  *
  * Supported values are those of parse_bool(), namely "yes", "no" as well as "1"

--- a/cmd/libsnap-confine-private/utils.h
+++ b/cmd/libsnap-confine-private/utils.h
@@ -28,11 +28,11 @@ __attribute__((format(printf, 1, 2)))
 void debug(const char *fmt, ...);
 
 /**
- * Sets the stdout stream to use non-blocking i/o.
+ * Sets the stderr stream to use non-blocking i/o.
  * 
  * Returns -1 on any errors.
  **/
-int sc_nonblocking_stdout(void);
+int sc_nonblocking_stderr(void);
 
 /**
  * Get an environment variable and convert it to a boolean.

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -293,8 +293,8 @@ static void log_startup_stage(const char *stage)
 		return;
 	}
 
-	// It has shown that it's possible to single-step through the execution of
-	// snap-confine by turning on the debug output, which makes trivial to exploit
+	// It has been shown that it's possible to single-step through the execution of
+	// snap-confine by turning on the debug output, which makes it trivial to exploit
 	// any weaknesses that may exist related to setting up namespaces. This was
 	// used for instance in the exploitation of CVE-2021-44731. To make it harder to attack
 	// snap-confine by controlling stdout, switch stdout to non-blocking IO.

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -293,14 +293,14 @@ static void log_startup_stage(const char *stage)
 		return;
 	}
 
-	// Prevent the exploitation of CVE-2021-44731 and alike. It was possible
-	// to exploit certain aspects of mount namespace setups by being able to 
-	// single-step through the debug output of snap-confine. To avoid this we switch
-	// stdout to non-blocking IO. By default stdout is usually connected to a pipe, and
+	// It has shown that it's possible to single-step through the execution of
+	// snap-confine by turning on the debug output, which makes trivial to exploit
+	// any weaknesses that may exist related to setting up namespaces. This was
+	// used for instance in the exploitation of CVE-2021-44731. To make it harder to attack
+	// snap-confine by controlling stdout, switch stdout to non-blocking IO.
+	// By default stdout is usually connected to a pipe, and
 	// these pipes have buffers of 65kB (on linux), which means it's highly unlikely 
 	// we should fill it and lose any output unless it's been tampered with.
-	// This was only possible with debugging output enabled, so let's only enable
-	// this when debug is set.
 	if (sc_nonblocking_stdout()) {
 		die("failed to set non-blocking i/o: %s", strerror(errno));
 	}

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -297,11 +297,11 @@ static void log_startup_stage(const char *stage)
 	// snap-confine by turning on the debug output, which makes it trivial to exploit
 	// any weaknesses that may exist related to setting up namespaces. This was
 	// used for instance in the exploitation of CVE-2021-44731. To make it harder to attack
-	// snap-confine by controlling stdout, switch stdout to non-blocking IO.
-	// By default stdout is usually connected to a pipe, and
+	// snap-confine by controlling stderr (where debug output is written), switch stderr 
+	// to non-blocking IO. By default stderr is usually connected to a pipe, and
 	// these pipes have buffers of 65kB (on linux), which means it's highly unlikely 
 	// we should fill it and lose any output unless it's been tampered with.
-	if (sc_nonblocking_stdout()) {
+	if (sc_nonblocking_stderr()) {
 		die("failed to set non-blocking i/o: %s", strerror(errno));
 	}
 


### PR DESCRIPTION
Protective measure against attacks using stderr redirection. When debug output was enabled, due to the verbose nature, it was possible with a small enough redirection buffer to control the flow on snap-confine, and by doing so intercept certain operations performed by snap-confine.

To prevent this switch stderr to be non-blocking in the case when debug is enabled.

This weakness was related to CVE-2021-44731.