### PR TITLE
tests: test kernel/gadget refresh as part of muinstaller-real for both encrypted/unencrypted use-cases

### DIFF
--- a/tests/lib/fakestore/cmd/fakestore/cmd_make_refreshable.go
+++ b/tests/lib/fakestore/cmd/fakestore/cmd_make_refreshable.go
@@ -26,9 +26,10 @@ import (
 )
 
 type cmdMakeRefreshable struct {
-	TopDir     string `long:"dir" description:"Directory to be used by the store to keep and serve snaps, <dir>/asserts is used for assertions"`
-	SnapBlob   string `long:"snap-blob" description:"File or directory with new snap revision contents"`
-	Positional struct {
+	TopDir       string `long:"dir" description:"Directory to be used by the store to keep and serve snaps, <dir>/asserts is used for assertions"`
+	SnapBlob     string `long:"snap-blob" description:"File or directory with new snap revision contents"`
+	SnapOrigBlob string `long:"snap-orig-blob" description:"File or directory with original snap revision contents"`
+	Positional   struct {
 		SnapName string `description:"snap name" positional-arg-name:"snap-name"`
 	} `positional-args:"yes" required:"1"`
 }
@@ -38,7 +39,7 @@ func (x *cmdMakeRefreshable) Execute(args []string) error {
 		return fmt.Errorf("unexpected additional arguments %v", args)
 	}
 	// setup fake new revisions of snaps for refresh
-	return refresh.MakeFakeRefreshForSnaps(x.Positional.SnapName, x.TopDir, x.SnapBlob)
+	return refresh.MakeFakeRefreshForSnaps(x.Positional.SnapName, x.TopDir, x.SnapBlob, x.SnapOrigBlob)
 }
 
 var shortMakeRefreshableHelp = "Makes new versions of the given snaps"

--- a/tests/nested/manual/muinstaller-real/task.yaml
+++ b/tests/nested/manual/muinstaller-real/task.yaml
@@ -58,6 +58,8 @@ execute: |
   # build updated shim
   version=22
   snap download --basename=pc --channel="$version/edge" pc
+  cp pc.snap pc.snap.orig
+  snap ack pc.assert
   unsquashfs -d pc-gadget pc.snap
   echo 'console=ttyS0 systemd.journald.forward_to_console=1' > pc-gadget/cmdline.extra
   # use the system-seed-null classic role
@@ -71,6 +73,8 @@ execute: |
 
   # get an updated kernel
   snap download --basename=pc-kernel --channel="$version/edge" pc-kernel
+  cp pc-kernel.snap pc-kernel.snap.orig
+  snap ack pc-kernel.assert
   uc20_build_initramfs_kernel_snap "$PWD/pc-kernel.snap" "$NESTED_ASSETS_DIR"
   mv "${NESTED_ASSETS_DIR}"/pc-kernel_*.snap pc-kernel.snap
 
@@ -214,7 +218,7 @@ execute: |
   # TODO: make this nicer
   export NESTED_TPM_NO_RESTART=1
   nested_start_core_vm
-  unset  NESTED_TPM_NO_RESTART
+  unset NESTED_TPM_NO_RESTART
   
   # things look fine
   remote.exec "cat /etc/os-release" | MATCH 'NAME="Ubuntu"'
@@ -252,3 +256,60 @@ execute: |
       jq '.result."storage-encryption".support' < system | MATCH "unavailable"
       jq '.result."storage-encryption"."unavailable-reason"' < system | MATCH "not encrypting device storage as checking TPM gave: the TPM is in DA lockout mode"
   fi
+
+
+  # test kernel/gadget refreshes via the fake-store
+
+  # setup fake store again and make it available inside the nested vm
+  setup_fake_store "$STORE_DIR"
+  export NESTED_FAKESTORE_BLOB_DIR="$STORE_DIR"
+  export NESTED_UBUNTU_IMAGE_SNAPPY_FORCE_SAS_URL="$SNAPPY_FORCE_SAS_URL"
+
+  #shellcheck source=tests/lib/store.sh  
+  . "$TESTSLIB"/store.sh  
+
+  # nested vm needs to restart for fake-store
+  nested_shutdown
+  export NESTED_TPM_NO_RESTART=1
+  nested_start_core_vm
+  unset NESTED_TPM_NO_RESTART
+
+  # make new gadget
+  fakestore make-refreshable --dir "$STORE_DIR" --snap-orig-blob pc.snap.orig --snap-blob ./pc-gadget pc
+
+  # refresh gadget
+  boot_id="$(tests.nested boot-id)"
+  remote.exec "sudo snap refresh --amend --no-wait --channel=$version/edge pc" > refresh-change-id
+  change_id="$(cat refresh-change-id)"
+  while true; do
+      if remote.exec "snap change $change_id" | grep "Task set to wait until a manual system restart"; then
+          break
+      fi
+  done
+  remote.exec "sudo reboot" || true
+  tests.nested wait-for reboot "$boot_id"
+  remote.exec "snap watch $change_id"
+  remote.exec "snap change $change_id" | NOMATCH Error
+
+  # TODO: enable once the kernel is ready
+  exit 0
+  # XXX: todo this fails today because:
+  #    snap-bootstrap[162]: error: seed partition found but not defined in the gadget
+  # which happens because the released kernel is not supporting the new
+  # "ubuntu-seed-null" role yet
+  # make new kernel
+  fakestore make-refreshable --dir "$STORE_DIR" --snap-orig-blob pc-kernel.snap.orig --snap-blob ./pc-kernel pc-kernel
+
+  # refresh kernel
+  boot_id="$(tests.nested boot-id)"
+  remote.exec "sudo snap refresh --amend --no-wait --channel=$version/edge pc-kernel" > refresh-change-id
+  change_id="$(cat refresh-change-id)"
+  while true; do
+      if remote.exec "snap change $change_id" | grep "Task set to wait until a manual system restart"; then
+          break
+      fi
+  done
+  remote.exec "sudo reboot" || true
+  tests.nested wait-for reboot "$boot_id"
+  remote.exec "snap watch $change_id"
+  remote.exec "snap change $change_id" | NOMATCH Error

--- a/tests/nested/manual/muinstaller-real/task.yaml
+++ b/tests/nested/manual/muinstaller-real/task.yaml
@@ -314,6 +314,8 @@ execute: |
   # (see https://github.com/snapcore/snapd/pull/12532)
   snap download --basename="core${version}" --channel="edge" "core${version}"
   cp "core${version}".snap "core${version}".snap.orig
+  # the fakestore needs the assertion
+  snap ack "core${version}".assert
   unsquashfs -d "core${version}" "core${version}".snap
   echo "modified" >> ./"core${version}"/etc/motd
   snap pack --filename="core${version}".snap ./"core${version}"

--- a/tests/nested/manual/muinstaller-real/task.yaml
+++ b/tests/nested/manual/muinstaller-real/task.yaml
@@ -285,6 +285,7 @@ execute: |
       tests.nested wait-for reboot "$boot_id"
       remote.exec sudo snap watch "$REMOTE_CHG_ID"
       remote.exec "snap change $REMOTE_CHG_ID" | NOMATCH Error
+      remote.exec "journalctl -u snapd" | NOMATCH "cannot mark boot successful"
   }
   # ensure update-notifier-common is installed so that reboot notification works
   remote.exec "sudo apt install -y update-notifier-common"

--- a/tests/nested/manual/muinstaller-real/task.yaml
+++ b/tests/nested/manual/muinstaller-real/task.yaml
@@ -59,6 +59,7 @@ execute: |
   version=22
   snap download --basename=pc --channel="$version/edge" pc
   cp pc.snap pc.snap.orig
+  # the fakestore needs the assertion
   snap ack pc.assert
   unsquashfs -d pc-gadget pc.snap
   echo 'console=ttyS0 systemd.journald.forward_to_console=1' > pc-gadget/cmdline.extra
@@ -74,6 +75,7 @@ execute: |
   # get an updated kernel
   snap download --basename=pc-kernel --channel="$version/edge" pc-kernel
   cp pc-kernel.snap pc-kernel.snap.orig
+  # the fakestore needs this assertion
   snap ack pc-kernel.assert
   uc20_build_initramfs_kernel_snap "$PWD/pc-kernel.snap" "$NESTED_ASSETS_DIR"
   mv "${NESTED_ASSETS_DIR}"/pc-kernel_*.snap pc-kernel.snap
@@ -257,8 +259,36 @@ execute: |
       jq '.result."storage-encryption"."unavailable-reason"' < system | MATCH "not encrypting device storage as checking TPM gave: the TPM is in DA lockout mode"
   fi
 
-
   # test kernel/gadget refreshes via the fake-store
+
+  # setup refresh for a rebooting snap
+  refresh_rebooting_snap()
+  {
+      local snap_name=$1
+      local snap_orig_blob=$2
+      local snap_new_dir=$3
+
+      local reboot_action=$3
+      printf "Test installing snap from file %s\n" "$snap_name"
+      fakestore make-refreshable --dir "$STORE_DIR" --snap-orig-blob "$snap_orig_blob" --snap-blob "$snap_new_dir" "$snap_name"
+      boot_id=$(tests.nested boot-id)
+      REMOTE_CHG_ID=$(remote.exec sudo snap refresh --amend --no-wait --channel="$version/edge" "$snap_name")
+      # Wait until we stall in the connection of interface as we wait for a reboot
+      retry --wait 1 -n 120 sh -c "remote.exec \"snap change $REMOTE_CHG_ID | grep -E 'Task set to wait until a manual system restart'\""
+
+      # Check that a reboot notification was setup
+      remote.exec test -f /run/reboot-required
+      remote.exec cat /run/reboot-required.pkgs | MATCH "snap:${snap_name}"
+      # Check that no reboot has been scheduled, then force a reboot
+      remote.exec not test -f /run/systemd/shutdown/scheduled
+
+      remote.exec sudo reboot || true
+      tests.nested wait-for reboot "$boot_id"
+      remote.exec sudo snap watch "$REMOTE_CHG_ID"
+      remote.exec "snap change $REMOTE_CHG_ID" | NOMATCH Error
+  }
+  # ensure update-notifier-common is installed so that reboot notification works
+  remote.exec "sudo apt install -y update-notifier-common"
 
   # setup fake store again and make it available inside the nested vm
   setup_fake_store "$STORE_DIR"
@@ -274,40 +304,27 @@ execute: |
   nested_start_core_vm
   unset NESTED_TPM_NO_RESTART
 
-  # make new gadget
-  fakestore make-refreshable --dir "$STORE_DIR" --snap-orig-blob pc.snap.orig --snap-blob ./pc-gadget pc
+  # test gadget/kernel refresh
+  refresh_rebooting_snap pc pc.snap.orig ./pc-gadget
 
-  # refresh gadget
-  boot_id="$(tests.nested boot-id)"
-  remote.exec "sudo snap refresh --amend --no-wait --channel=$version/edge pc" > refresh-change-id
-  change_id="$(cat refresh-change-id)"
-  while true; do
-      if remote.exec "snap change $change_id" | grep "Task set to wait until a manual system restart"; then
-          break
-      fi
-  done
-  remote.exec "sudo reboot" || true
-  tests.nested wait-for reboot "$boot_id"
-  remote.exec "snap watch $change_id"
-  remote.exec "snap change $change_id" | NOMATCH Error
-
-  # make new kernel
   unsquashfs -d pc-kernel pc-kernel.snap
-  fakestore make-refreshable --dir "$STORE_DIR" --snap-orig-blob pc-kernel.snap.orig --snap-blob ./pc-kernel pc-kernel
+  refresh_rebooting_snap pc-kernel pc-kernel.snap.orig ./pc-kernel
 
-  # refresh kernel
-  boot_id="$(tests.nested boot-id)"
-  remote.exec "sudo snap refresh --amend --no-wait --channel=$version/edge pc-kernel" > refresh-change-id
-  change_id="$(cat refresh-change-id)"
-  while true; do
-      if remote.exec "snap change $change_id" | grep "Task set to wait until a manual system restart"; then
-          break
-      fi
-  done
-  remote.exec "sudo reboot" || true
+  # test that core22+ refreshes fine and does not revert after a reboot
+  # (see https://github.com/snapcore/snapd/pull/12532)
+  snap download --basename="core${version}" --channel="edge" "core${version}"
+  cp "core${version}".snap "core${version}".snap.orig
+  unsquashfs -d "core${version}" "core${version}".snap
+  echo "modified" >> ./"core${version}"/etc/motd
+  snap pack --filename="core${version}".snap ./"core${version}"
+  fakestore make-refreshable --dir "$STORE_DIR" --snap-orig-blob "core${version}.snap.orig" --snap-blob "./core${version}" "core${version}"
+  remote.exec sudo snap refresh --amend --channel="edge" "core${version}"
+  remote.exec snap list "core${version}" > "core${version}".before-boot
+  boot_id=$(tests.nested boot-id)
+  remote.exec sudo reboot || true
   tests.nested wait-for reboot "$boot_id"
-  remote.exec "snap watch $change_id"
-  remote.exec "snap change $change_id" | NOMATCH Error
-
-  # TODO test core22 refresh and that after a reboot the core22 is not
-  # reverted
+  # ensure no revert of core22+ was performed
+  remote.exec sudo snap changes | NOMATCH "Update kernel and core snap revisions"
+  remote.exec snap list "core${version}" > "core${version}".after-boot
+  # and check that the versions are the same after boot
+  diff -u "core${version}".before-boot "core${version}".after-boot

--- a/tests/nested/manual/muinstaller-real/task.yaml
+++ b/tests/nested/manual/muinstaller-real/task.yaml
@@ -291,13 +291,8 @@ execute: |
   remote.exec "snap watch $change_id"
   remote.exec "snap change $change_id" | NOMATCH Error
 
-  # TODO: enable once the kernel is ready
-  exit 0
-  # XXX: todo this fails today because:
-  #    snap-bootstrap[162]: error: seed partition found but not defined in the gadget
-  # which happens because the released kernel is not supporting the new
-  # "ubuntu-seed-null" role yet
   # make new kernel
+  unsquashfs -d pc-kernel pc-kernel.snap
   fakestore make-refreshable --dir "$STORE_DIR" --snap-orig-blob pc-kernel.snap.orig --snap-blob ./pc-kernel pc-kernel
 
   # refresh kernel
@@ -313,3 +308,6 @@ execute: |
   tests.nested wait-for reboot "$boot_id"
   remote.exec "snap watch $change_id"
   remote.exec "snap change $change_id" | NOMATCH Error
+
+  # TODO test core22 refresh and that after a reboot the core22 is not
+  # reverted

--- a/tests/nested/manual/muinstaller-real/task.yaml
+++ b/tests/nested/manual/muinstaller-real/task.yaml
@@ -268,7 +268,6 @@ execute: |
       local snap_orig_blob=$2
       local snap_new_dir=$3
 
-      local reboot_action=$3
       printf "Test installing snap from file %s\n" "$snap_name"
       fakestore make-refreshable --dir "$STORE_DIR" --snap-orig-blob "$snap_orig_blob" --snap-blob "$snap_new_dir" "$snap_name"
       boot_id=$(tests.nested boot-id)


### PR DESCRIPTION
To ensure the kernel/gadget refresh works correctly for the encrypted cases this commit adds a new test that creates a new gadget and kernel snap and refreshes those.

The test will also check that the reboot will not happen automatically.
