### PR TITLE
bootloader: use mtime of input file in go:generate for grub_cfg.go

### DIFF
--- a/bootloader/assets/genasset/main.go
+++ b/bootloader/assets/genasset/main.go
@@ -27,7 +27,6 @@ import (
 	"os"
 	"strconv"
 	"text/template"
-	"time"
 
 	"github.com/snapcore/snapd/osutil"
 )
@@ -100,6 +99,11 @@ func run(assetName, inputFile, outputFile string) error {
 	}
 	defer inf.Close()
 
+	stat, err := inf.Stat()
+	if err != nil {
+		return err
+	}
+
 	var inData bytes.Buffer
 	if _, err := io.Copy(&inData, inf); err != nil {
 		return fmt.Errorf("cannot copy input data: %v", err)
@@ -123,7 +127,7 @@ func run(assetName, inputFile, outputFile string) error {
 		// we use a preformatted lines carrying asset data
 		AssetDataLines: formatLines(inData.Bytes()),
 		AssetName:      assetName,
-		Year:           strconv.Itoa(time.Now().Year()),
+		Year:           strconv.Itoa(stat.ModTime().Year()),
 	}
 	if err := assetTemplate.Execute(outf, &templateData); err != nil {
 		return fmt.Errorf("cannot generate content: %v", err)


### PR DESCRIPTION
Out current edge builds report that the tree is dirty because the code in go:generate that takes the grub.cfg and generates the grub_cfg.go takes the current year as the input. Instead we need to take the modification time of the input file into account.

