### PR TITLE
cmd/snap-update-ns: prevent keeping unneeded mountpoints

### DIFF
--- a/tests/main/layout-remove/task.yaml
+++ b/tests/main/layout-remove/task.yaml
@@ -1,0 +1,36 @@
+summary: Ensure that removing a layout works as expected
+
+details: |
+  This test installs a test snap that uses layout declarations and
+  then refreshes it with a new version that removes one of the
+  layouts.
+
+# No core22 snap for i386
+systems: [-ubuntu-*-32]
+
+prepare: |
+  "$TESTSTOOLS"/snaps-state install-local test-snapd-layout
+
+execute: |
+  snap pack test-layout-v1
+  snap pack test-layout-v2
+  snap install --dangerous test-layout_1.0_all.snap
+  # Check layouts. Note that the mount namespace is created in the first run.
+  test-layout.test -c "test -d /var/test_tmpfs"
+  test-layout.test -c "test -d /var/lib/test_common"
+  test-layout.test -c "test -d /var/lib/test_data"
+  # Layouts have been configured
+  MATCH test_tmpfs < /run/snapd/ns/snap.test-layout.fstab
+  MATCH test_common < /run/snapd/ns/snap.test-layout.fstab
+  MATCH test_data < /run/snapd/ns/snap.test-layout.fstab
+
+  # Refreshing will update the mount namespace
+  snap install --dangerous test-layout_1.1_all.snap
+  # Should run fine
+  test-layout.test -c "test -d /var/test_tmpfs"
+  not test-layout.test -c "test -d /var/lib/test_common"
+  not test-layout.test -c "test -d /var/lib/test_data"
+  # There is no trace of the removed layouts
+  MATCH test_tmpfs < /run/snapd/ns/snap.test-layout.fstab
+  not MATCH test_common < /run/snapd/ns/snap.test-layout.fstab
+  not MATCH test_data < /run/snapd/ns/snap.test-layout.fstab

--- a/tests/main/layout-remove/test-layout-v1/bin/test
+++ b/tests/main/layout-remove/test-layout-v1/bin/test
@@ -1,0 +1,3 @@
+#!/bin/sh
+PS1='$ '
+exec /bin/sh "$@"

--- a/tests/main/layout-remove/test-layout-v1/meta/snap.yaml
+++ b/tests/main/layout-remove/test-layout-v1/meta/snap.yaml
@@ -1,0 +1,19 @@
+name: test-layout
+version: 1.0
+summary: Test layouts
+description: 'Test layout changes'
+base: core22
+confinement: strict
+grade: devel
+
+layout:
+  /var/lib/test_data:
+    bind: $SNAP_DATA/test_data
+  /var/lib/test_common:
+    bind: $SNAP_COMMON/test_common
+  /var/test_tmpfs:
+    type: tmpfs
+
+apps:
+  test:
+    command: bin/test

--- a/tests/main/layout-remove/test-layout-v2/bin/test
+++ b/tests/main/layout-remove/test-layout-v2/bin/test
@@ -1,0 +1,3 @@
+#!/bin/sh
+PS1='$ '
+exec /bin/sh "$@"

--- a/tests/main/layout-remove/test-layout-v2/meta/snap.yaml
+++ b/tests/main/layout-remove/test-layout-v2/meta/snap.yaml
@@ -1,0 +1,15 @@
+name: test-layout
+version: 1.1
+summary: Test layouts
+description: 'Test layout changes'
+base: core22
+confinement: strict
+grade: devel
+
+layout:
+  /var/test_tmpfs:
+    type: tmpfs
+
+apps:
+  test:
+    command: bin/test


### PR DESCRIPTION
In some cases we were keeping mounts from removed layouts, because we
were not identifying properly the mounts that we wanted to keep, as we
used mountpoint as key for the reuse map used in neededChanges, while
there are corner cases when we mount more that once on a given
mountpoint. This can happen when, say, we have a layout for /dir/sd1
and another one for /dir/sd2/sd3, being the case that /dir/sd1 and
/dir/sd2/sd3 do not exist (but their parent dirs do exist) - /dir/sd2
will be one of the bind mounted directories of the tmpfs that is
created in /dir to have a layout on /dir/sd1, while at the same time a
tmpfs will be mounted in /dir/sd2 so we can have a layout in
/dir/sd2/sd3. So /dir/sd2 is used twice with different filesystem
types (none and tmpfs).

To prevent this, use as key in the reuse map dir+fstype. As we make
sure that mimics are created only once per directory, we should only
have one entry per dir+fstype, being fstype either none or tmpfs.

In the future we should clean-up mountpoints before performing
changes, but that is a bigger change and anyway this fix is needed for
mount namespaces already created by older snapd versions.
