### PR TITLE
sandbox/cgroup: tweak the creation/stop of the inotify code a bit

### DIFF
--- a/sandbox/cgroup/export_test.go
+++ b/sandbox/cgroup/export_test.go
@@ -112,6 +112,6 @@ func MockCgroupsFilePath(path string) (restore func()) {
 	return r
 }
 
-func MonitorDelete(folders []string, name string, channel chan string) error {
-	return currentWatcher.monitorDelete(folders, name, channel)
+func NewInotifyWatcher() (*inotifyWatcher, error) {
+	return newInotifyWatcher()
 }

--- a/sandbox/cgroup/monitor.go
+++ b/sandbox/cgroup/monitor.go
@@ -99,7 +99,7 @@ func newInotifyWatcher() (*inotifyWatcher, error) {
 
 // MonitorDelete monitors the specified paths for deletion.
 // Once all of them have been deleted, it pushes the specified name through the channel.
-func (iw *inotifyWatcher) MonitorDelete(folders []string, name string, channel chan<- string) (err error) {
+func (iw *inotifyWatcher) MonitorDelete(folders []string, name string, channel chan<- string) error {
 	iw.mu.Lock()
 	defer iw.mu.Unlock()
 
@@ -210,7 +210,7 @@ type SnapWatcher struct {
 }
 
 // NewSnapWatcher returns a watcher that can monitor when all processes
-// of the given snapName are finished.
+// of a snap are finished.
 //
 // Use "Stop()" when done with the watching.
 func NewSnapWatcher() (*SnapWatcher, error) {

--- a/sandbox/cgroup/monitor.go
+++ b/sandbox/cgroup/monitor.go
@@ -81,17 +81,17 @@ func (gtw *groupToWatch) sendClosedNotification() {
 
 // newInotifyWatcher will create a new inotifyWatcher and starts
 // a monitor go-routine. Use "Stop()" when finished.
-func newInotifyWatcher() (iw *inotifyWatcher, err error) {
-	iw = &inotifyWatcher{
-		wd:       nil,
-		pathList: make(map[string]int32),
-	}
-	iw.wd, err = inotify.NewWatcher()
+func newInotifyWatcher() (*inotifyWatcher, error) {
+	wd, err := inotify.NewWatcher()
 	if err != nil {
 		return nil, err
 	}
-	if iw.wd == nil {
-		return nil, errors.New("cannot initialise Inotify.")
+	if wd == nil {
+		return nil, errors.New("cannot initialise inotify")
+	}
+	iw := &inotifyWatcher{
+		wd:       wd,
+		pathList: make(map[string]int32),
 	}
 	go iw.watcherMainLoop()
 	return iw, nil

--- a/sandbox/cgroup/monitor.go
+++ b/sandbox/cgroup/monitor.go
@@ -67,7 +67,7 @@ type groupToWatch struct {
 	// This channel is used to notify to the requester that this CGroup has been
 	// destroyed. The watcher writes the CGroup identifier on it; this way, the
 	// same channel can be shared to monitor several CGroups.
-	channel chan<- string
+	notify chan<- string
 }
 
 func (gtw *groupToWatch) sendClosedNotification() {
@@ -76,7 +76,7 @@ func (gtw *groupToWatch) sendClosedNotification() {
 			logger.Noticef("Failed to send Closed notification for %s", gtw.name)
 		}
 	}()
-	gtw.channel <- gtw.name
+	gtw.notify <- gtw.name
 }
 
 // newInotifyWatcher will create a new inotifyWatcher and starts
@@ -106,7 +106,7 @@ func (iw *inotifyWatcher) MonitorDelete(folders []string, name string, channel c
 	newWatch := &groupToWatch{
 		name:    name,
 		folders: folders,
-		channel: channel,
+		notify:  channel,
 	}
 
 	var folderList []string

--- a/sandbox/cgroup/monitor.go
+++ b/sandbox/cgroup/monitor.go
@@ -155,7 +155,7 @@ func (iw *inotifyWatcher) processDeletedPath(watch *groupToWatch, deletedPath st
 		if fullPath == deletedPath {
 			// if the folder name is in the list of folders to monitor, decrement the
 			// parent's usage counter, and remove it from the list of folders to watch
-			// in this CGroup (by not adding it to tmpFolders)
+			// in this CGroup
 			iw.removePath(fullPath)
 			watch.folders = append(watch.folders[:i], watch.folders[i+1:]...)
 			break
@@ -189,13 +189,11 @@ func (iw *inotifyWatcher) watcherMainLoop() {
 			if event.Mask&inotify.InDelete == 0 {
 				continue
 			}
-			var newGroupList []*groupToWatch
-			for _, watch := range iw.groupList {
-				if iw.processDeletedPath(watch, event.Name) {
-					newGroupList = append(newGroupList, watch)
+			for i, watch := range iw.groupList {
+				if !iw.processDeletedPath(watch, event.Name) {
+					iw.groupList = append(iw.groupList[:i], iw.groupList[i+1:]...)
 				}
 			}
-			iw.groupList = newGroupList
 		}
 	}
 }

--- a/sandbox/cgroup/monitor_test.go
+++ b/sandbox/cgroup/monitor_test.go
@@ -65,9 +65,8 @@ func (s *monitorSuite) calibrateInotifyDelay(c *C) {
 
 	err = iw.MonitorDelete(filelist, "test1", s.eventsCh)
 	c.Assert(err, IsNil)
-	var start time.Time
+	start := time.Now()
 	go func() {
-		start = time.Now()
 		err = os.Remove(folder1)
 		c.Assert(err, IsNil)
 	}()


### PR DESCRIPTION
This commit tweaks the inotify sandbox code a bit to follow some more go conventions:
- adds constructors for inotifyWatcher
- avoid singleton `currentWatcher`
- add way to Stop() the watcher
- add new `SnapWatcher` that knows about snaps
- add new `SnapWatcher.AllProcessesEnded`

