### PR TITLE
o/snapstate: don't notify of pending refresh if it's manual

### DIFF
--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -641,8 +641,12 @@ func inhibitRefresh(st *state.State, snapst *SnapState, info *snap.Info, checker
 		checkerErr = nil
 	}
 
-	// Send the notification asynchronously to avoid holding the state lock.
-	asyncPendingRefreshNotification(context.TODO(), userclient.New(), refreshInfo)
+	// if the refresh is manual the error message already carries the information so don't notify
+	if snapst.IsAutoRefresh {
+		// Send the notification asynchronously to avoid holding the state lock.
+		asyncPendingRefreshNotification(context.TODO(), userclient.New(), refreshInfo)
+	}
+
 	return checkerErr
 }
 

--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -599,7 +599,7 @@ var asyncPendingRefreshNotification = func(context context.Context, client *user
 // Internally the snap state is updated to remember when the inhibition first
 // took place. Apps can inhibit refreshes for up to "maxInhibition", beyond
 // that period the refresh will go ahead despite application activity.
-func inhibitRefresh(st *state.State, snapsup *SnapSetup, snapst *SnapState, info *snap.Info, checker func(*snap.Info) error) error {
+func inhibitRefresh(st *state.State, snapst *SnapState, snapsup *SnapSetup, info *snap.Info, checker func(*snap.Info) error) error {
 	checkerErr := checker(info)
 	if checkerErr == nil {
 		return nil

--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -599,7 +599,7 @@ var asyncPendingRefreshNotification = func(context context.Context, client *user
 // Internally the snap state is updated to remember when the inhibition first
 // took place. Apps can inhibit refreshes for up to "maxInhibition", beyond
 // that period the refresh will go ahead despite application activity.
-func inhibitRefresh(st *state.State, snapst *SnapState, info *snap.Info, checker func(*snap.Info) error) error {
+func inhibitRefresh(st *state.State, snapsup *SnapSetup, snapst *SnapState, info *snap.Info, checker func(*snap.Info) error) error {
 	checkerErr := checker(info)
 	if checkerErr == nil {
 		return nil
@@ -642,7 +642,7 @@ func inhibitRefresh(st *state.State, snapst *SnapState, info *snap.Info, checker
 	}
 
 	// if the refresh is manual the error message already carries the information so don't notify
-	if snapst.IsAutoRefresh {
+	if snapsup.IsAutoRefresh {
 		// Send the notification asynchronously to avoid holding the state lock.
 		asyncPendingRefreshNotification(context.TODO(), userclient.New(), refreshInfo)
 	}

--- a/overlord/snapstate/autorefresh_test.go
+++ b/overlord/snapstate/autorefresh_test.go
@@ -944,7 +944,7 @@ func (s *autoRefreshTestSuite) TestInitialInhibitRefreshWithinInhibitWindow(c *C
 	}
 	snapsup := &snapstate.SnapSetup{Flags: snapstate.Flags{IsAutoRefresh: true}}
 
-	err := snapstate.InhibitRefresh(s.state, snapsup, snapst, info, func(si *snap.Info) error {
+	err := snapstate.InhibitRefresh(s.state, snapst, snapsup, info, func(si *snap.Info) error {
 		return snapstate.NewBusySnapError(si, []int{123}, nil, nil)
 	})
 	c.Assert(err, ErrorMatches, `snap "pkg" has running apps or hooks, pids: 123`)
@@ -977,7 +977,7 @@ func (s *autoRefreshTestSuite) TestSubsequentInhibitRefreshWithinInhibitWindow(c
 	}
 	snapsup := &snapstate.SnapSetup{Flags: snapstate.Flags{IsAutoRefresh: true}}
 
-	err := snapstate.InhibitRefresh(s.state, snapsup, snapst, info, func(si *snap.Info) error {
+	err := snapstate.InhibitRefresh(s.state, snapst, snapsup, info, func(si *snap.Info) error {
 		return snapstate.NewBusySnapError(si, []int{123}, nil, nil)
 	})
 	c.Assert(err, ErrorMatches, `snap "pkg" has running apps or hooks, pids: 123`)
@@ -1008,7 +1008,7 @@ func (s *autoRefreshTestSuite) TestInhibitRefreshRefreshesWhenOverdue(c *C) {
 	}
 	snapsup := &snapstate.SnapSetup{Flags: snapstate.Flags{IsAutoRefresh: true}}
 
-	err := snapstate.InhibitRefresh(s.state, snapsup, snapst, info, func(si *snap.Info) error {
+	err := snapstate.InhibitRefresh(s.state, snapst, snapsup, info, func(si *snap.Info) error {
 		return &snapstate.BusySnapError{SnapInfo: si}
 	})
 	c.Assert(err, IsNil)
@@ -1036,7 +1036,7 @@ func (s *autoRefreshTestSuite) TestInhibitNoNotificationOnManualRefresh(c *C) {
 	// manual refresh
 	snapsup := &snapstate.SnapSetup{Flags: snapstate.Flags{IsAutoRefresh: false}}
 
-	err := snapstate.InhibitRefresh(s.state, snapsup, snapst, info, func(si *snap.Info) error {
+	err := snapstate.InhibitRefresh(s.state, snapst, snapsup, info, func(si *snap.Info) error {
 		return &snapstate.BusySnapError{SnapInfo: si}
 	})
 	c.Assert(err, IsNil)

--- a/overlord/snapstate/autorefresh_test.go
+++ b/overlord/snapstate/autorefresh_test.go
@@ -941,9 +941,10 @@ func (s *autoRefreshTestSuite) TestInitialInhibitRefreshWithinInhibitWindow(c *C
 	snapst := &snapstate.SnapState{
 		Sequence: []*snap.SideInfo{si},
 		Current:  si.Revision,
-		Flags:    snapstate.Flags{IsAutoRefresh: true},
 	}
-	err := snapstate.InhibitRefresh(s.state, snapst, info, func(si *snap.Info) error {
+	snapsup := &snapstate.SnapSetup{Flags: snapstate.Flags{IsAutoRefresh: true}}
+
+	err := snapstate.InhibitRefresh(s.state, snapsup, snapst, info, func(si *snap.Info) error {
 		return snapstate.NewBusySnapError(si, []int{123}, nil, nil)
 	})
 	c.Assert(err, ErrorMatches, `snap "pkg" has running apps or hooks, pids: 123`)
@@ -973,10 +974,10 @@ func (s *autoRefreshTestSuite) TestSubsequentInhibitRefreshWithinInhibitWindow(c
 		Sequence:             []*snap.SideInfo{si},
 		Current:              si.Revision,
 		RefreshInhibitedTime: &pastInstant,
-		Flags:                snapstate.Flags{IsAutoRefresh: true},
 	}
+	snapsup := &snapstate.SnapSetup{Flags: snapstate.Flags{IsAutoRefresh: true}}
 
-	err := snapstate.InhibitRefresh(s.state, snapst, info, func(si *snap.Info) error {
+	err := snapstate.InhibitRefresh(s.state, snapsup, snapst, info, func(si *snap.Info) error {
 		return snapstate.NewBusySnapError(si, []int{123}, nil, nil)
 	})
 	c.Assert(err, ErrorMatches, `snap "pkg" has running apps or hooks, pids: 123`)
@@ -1004,9 +1005,10 @@ func (s *autoRefreshTestSuite) TestInhibitRefreshRefreshesWhenOverdue(c *C) {
 		Sequence:             []*snap.SideInfo{si},
 		Current:              si.Revision,
 		RefreshInhibitedTime: &pastInstant,
-		Flags:                snapstate.Flags{IsAutoRefresh: true},
 	}
-	err := snapstate.InhibitRefresh(s.state, snapst, info, func(si *snap.Info) error {
+	snapsup := &snapstate.SnapSetup{Flags: snapstate.Flags{IsAutoRefresh: true}}
+
+	err := snapstate.InhibitRefresh(s.state, snapsup, snapst, info, func(si *snap.Info) error {
 		return &snapstate.BusySnapError{SnapInfo: si}
 	})
 	c.Assert(err, IsNil)
@@ -1031,7 +1033,10 @@ func (s *autoRefreshTestSuite) TestInhibitNoNotificationOnManualRefresh(c *C) {
 		Current:              si.Revision,
 		RefreshInhibitedTime: &pastInstant,
 	}
-	err := snapstate.InhibitRefresh(s.state, snapst, info, func(si *snap.Info) error {
+	// manual refresh
+	snapsup := &snapstate.SnapSetup{Flags: snapstate.Flags{IsAutoRefresh: false}}
+
+	err := snapstate.InhibitRefresh(s.state, snapsup, snapst, info, func(si *snap.Info) error {
 		return &snapstate.BusySnapError{SnapInfo: si}
 	})
 	c.Assert(err, IsNil)

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1033,7 +1033,7 @@ func (m *SnapManager) doUnlinkCurrentSnap(t *state.Task, _ *tomb.Tomb) (err erro
 		// held to prevent snap-run from advancing until UnlinkSnap, executed
 		// below, completes.
 		// XXX: should we skip it if type is snap.TypeSnapd?
-		lock, err := hardEnsureNothingRunningDuringRefresh(m.backend, st, snapst, oldInfo)
+		lock, err := hardEnsureNothingRunningDuringRefresh(m.backend, st, snapst, snapsup, oldInfo)
 		if err != nil {
 			return err
 		}

--- a/overlord/snapstate/refresh.go
+++ b/overlord/snapstate/refresh.go
@@ -204,13 +204,13 @@ func (err BusySnapError) Pids() []int {
 //
 // In practice, we either inhibit app startup and refresh the snap _or_ inhibit
 // the refresh change and continue running existing app processes.
-func hardEnsureNothingRunningDuringRefresh(backend managerBackend, st *state.State, snapst *SnapState, info *snap.Info) (*osutil.FileLock, error) {
+func hardEnsureNothingRunningDuringRefresh(backend managerBackend, st *state.State, snapst *SnapState, snapsup *SnapSetup, info *snap.Info) (*osutil.FileLock, error) {
 	return backend.RunInhibitSnapForUnlink(info, runinhibit.HintInhibitedForRefresh, func() error {
 		// In case of successful refresh inhibition the snap state is modified
 		// to indicate when the refresh was first inhibited. If the first
 		// refresh inhibition is outside of a grace period then refresh
 		// proceeds regardless of the existing processes.
-		return inhibitRefresh(st, snapst, info, HardNothingRunningRefreshCheck)
+		return inhibitRefresh(st, snapsup, snapst, info, HardNothingRunningRefreshCheck)
 	})
 }
 
@@ -225,7 +225,7 @@ func hardEnsureNothingRunningDuringRefresh(backend managerBackend, st *state.Sta
 // refresh was first postponed. Eventually the check does not fail, even if
 // non-service apps are running, because this mechanism only allows postponing
 // refreshes for a bounded amount of time.
-func softCheckNothingRunningForRefresh(st *state.State, snapst *SnapState, info *snap.Info) error {
+func softCheckNothingRunningForRefresh(st *state.State, snapst *SnapState, snapsup *SnapSetup, info *snap.Info) error {
 	// Grab per-snap lock to prevent new processes from starting. This is
 	// sufficient to perform the check, even though individual processes may
 	// fork or exit, we will have per-security-tag information about what is
@@ -233,6 +233,6 @@ func softCheckNothingRunningForRefresh(st *state.State, snapst *SnapState, info 
 	return backend.WithSnapLock(info, func() error {
 		// Perform the soft refresh viability check, possibly writing to the state
 		// on failure.
-		return inhibitRefresh(st, snapst, info, SoftNothingRunningRefreshCheck)
+		return inhibitRefresh(st, snapsup, snapst, info, SoftNothingRunningRefreshCheck)
 	})
 }

--- a/overlord/snapstate/refresh.go
+++ b/overlord/snapstate/refresh.go
@@ -210,7 +210,7 @@ func hardEnsureNothingRunningDuringRefresh(backend managerBackend, st *state.Sta
 		// to indicate when the refresh was first inhibited. If the first
 		// refresh inhibition is outside of a grace period then refresh
 		// proceeds regardless of the existing processes.
-		return inhibitRefresh(st, snapsup, snapst, info, HardNothingRunningRefreshCheck)
+		return inhibitRefresh(st, snapst, snapsup, info, HardNothingRunningRefreshCheck)
 	})
 }
 
@@ -233,6 +233,6 @@ func softCheckNothingRunningForRefresh(st *state.State, snapst *SnapState, snaps
 	return backend.WithSnapLock(info, func() error {
 		// Perform the soft refresh viability check, possibly writing to the state
 		// on failure.
-		return inhibitRefresh(st, snapsup, snapst, info, SoftNothingRunningRefreshCheck)
+		return inhibitRefresh(st, snapst, snapsup, info, SoftNothingRunningRefreshCheck)
 	})
 }

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -370,7 +370,7 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 			// Note that because we are modifying the snap state inside
 			// softCheckNothingRunningForRefresh, this block must be located
 			// after the conflict check done above.
-			if err := softCheckNothingRunningForRefresh(st, snapst, info); err != nil {
+			if err := softCheckNothingRunningForRefresh(st, snapst, snapsup, info); err != nil {
 				return nil, err
 			}
 		}


### PR DESCRIPTION
Per the refresh app awareness UX improvement spec, don't trigger a notification stating that a refresh is pending due to a running snap if the refresh was triggered by the user. It's unnecessary since the error message will already carry the same information. We'll still trigger the notification when auto-refreshes are blocked by a running snap.