### PR TITLE
snap: provide more error context in `NotSnapError`

### DIFF
--- a/secboot/secboot_sb_test.go
+++ b/secboot/secboot_sb_test.go
@@ -670,12 +670,12 @@ func (s *secbootSuite) TestEFIImageFromBootFile(c *C) {
 		{
 			// invalid snap file
 			bootFile: bootloader.NewBootFile(existingFile, "rel", bootloader.RoleRecovery),
-			err:      fmt.Sprintf(`"%s/foo" is not a snap or snapdir`, tmpDir),
+			err:      fmt.Sprintf(`cannot process snap or snapdir: cannot read "%s/foo": EOF`, tmpDir),
 		},
 		{
 			// missing snap file
 			bootFile: bootloader.NewBootFile(missingFile, "rel", bootloader.RoleRecovery),
-			err:      fmt.Sprintf(`"%s/bar" is not a snap or snapdir`, tmpDir),
+			err:      fmt.Sprintf(`cannot process snap or snapdir: open %s/bar: no such file or directory`, tmpDir),
 		},
 	} {
 		o, err := secboot.EFIImageFromBootFile(&tc.bootFile)
@@ -777,7 +777,7 @@ func (s *secbootSuite) TestSealKey(c *C) {
 		{tpmErr: mockErr, expectedErr: "cannot connect to TPM: some error"},
 		{tpmEnabled: false, expectedErr: "TPM device is not enabled"},
 		{tpmEnabled: true, missingFile: true, expectedErr: "cannot build EFI image load sequences: file /does/not/exist does not exist"},
-		{tpmEnabled: true, badSnapFile: true, expectedErr: `.*/kernel.snap" is not a snap or snapdir`},
+		{tpmEnabled: true, badSnapFile: true, expectedErr: `cannot build EFI image load sequences: cannot process snap or snapdir: cannot read ".*/kernel.snap": EOF`},
 		{tpmEnabled: true, addEFISbPolicyErr: mockErr, expectedErr: "cannot add EFI secure boot policy profile: some error"},
 		{tpmEnabled: true, addEFIBootManagerErr: mockErr, expectedErr: "cannot add EFI boot manager profile: some error"},
 		{tpmEnabled: true, addSystemdEFIStubErr: mockErr, expectedErr: "cannot add systemd EFI stub profile: some error"},

--- a/snap/errors.go
+++ b/snap/errors.go
@@ -43,7 +43,7 @@ func (e NotInstalledError) Error() string {
 	return fmt.Sprintf("revision %s of snap %q is not installed", e.Rev, e.Snap)
 }
 
-// NotSnapError is returned if a operation expects a snap file or snap dir
+// NotSnapError is returned if an operation expects a snap file or snap dir
 // but no valid input is provided. When creating it ensure "Err" is set
 // so that a useful error can be displayed to the user.
 type NotSnapError struct {

--- a/snap/errors_test.go
+++ b/snap/errors_test.go
@@ -20,8 +20,7 @@
 package snap_test
 
 import (
-	"io/ioutil"
-	"path/filepath"
+	"fmt"
 
 	. "gopkg.in/check.v1"
 
@@ -32,28 +31,12 @@ type errorsSuite struct{}
 
 var _ = Suite(&errorsSuite{})
 
-func (s *errorsSuite) TestNotSnapErrorNoSuchFile(c *C) {
-	err := snap.NewNotSnapErrorWithContext("non-existing-file")
-	c.Check(err, ErrorMatches, `cannot process snap or snapdir: open non-existing-file: no such file or directory`)
+func (s *errorsSuite) TestNotSnapErrorNoDetails(c *C) {
+	err := snap.NotSnapError{Path: "some-path"}
+	c.Check(err, ErrorMatches, `cannot process snap or snapdir "some-path"`)
 }
 
-func (s *errorsSuite) TestNotSnapErrorEmptyDir(c *C) {
-	err := snap.NewNotSnapErrorWithContext(c.MkDir())
-	c.Check(err, ErrorMatches, `cannot process snap or snapdir: directory ".*" is empty`)
-}
-
-func (s *errorsSuite) TestNotSnapErrorInvalidDir(c *C) {
-	tmpdir := c.MkDir()
-	err := ioutil.WriteFile(filepath.Join(tmpdir, "foo"), nil, 0644)
-	c.Assert(err, IsNil)
-	err = snap.NewNotSnapErrorWithContext(tmpdir)
-	c.Check(err, ErrorMatches, `cannot process snap or snapdir: directory ".*" is invalid`)
-}
-
-func (s *errorsSuite) TestNotSnapErrorInvalidFile(c *C) {
-	badFile := filepath.Join(c.MkDir(), "foo")
-	err := ioutil.WriteFile(badFile, []byte("not-a-snap-and-much-much-more-content"), 0644)
-	c.Assert(err, IsNil)
-	err = snap.NewNotSnapErrorWithContext(badFile)
-	c.Check(err, ErrorMatches, `cannot process snap or snapdir: file ".*" is invalid \(header \[110 111 116 45 97 45 115 110 97 112\]\)`)
+func (s *errorsSuite) TestNotSnapErrorWithDetails(c *C) {
+	err := snap.NotSnapError{Path: "some-path", Err: fmt.Errorf(`cannot open "some path"`)}
+	c.Check(err, ErrorMatches, `cannot process snap or snapdir: cannot open "some path"`)
 }

--- a/snap/errors_test.go
+++ b/snap/errors_test.go
@@ -1,0 +1,59 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snap_test
+
+import (
+	"io/ioutil"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/snap"
+)
+
+type errorsSuite struct{}
+
+var _ = Suite(&errorsSuite{})
+
+func (s *errorsSuite) TestNotSnapErrorNoSuchFile(c *C) {
+	err := snap.NewNotSnapErrorWithContext("non-existing-file")
+	c.Check(err, ErrorMatches, `cannot process snap or snapdir: open non-existing-file: no such file or directory`)
+}
+
+func (s *errorsSuite) TestNotSnapErrorEmptyDir(c *C) {
+	err := snap.NewNotSnapErrorWithContext(c.MkDir())
+	c.Check(err, ErrorMatches, `cannot process snap or snapdir: directory ".*" is empty`)
+}
+
+func (s *errorsSuite) TestNotSnapErrorInvalidDir(c *C) {
+	tmpdir := c.MkDir()
+	err := ioutil.WriteFile(filepath.Join(tmpdir, "foo"), nil, 0644)
+	c.Assert(err, IsNil)
+	err = snap.NewNotSnapErrorWithContext(tmpdir)
+	c.Check(err, ErrorMatches, `cannot process snap or snapdir: directory ".*" is invalid`)
+}
+
+func (s *errorsSuite) TestNotSnapErrorInvalidFile(c *C) {
+	badFile := filepath.Join(c.MkDir(), "foo")
+	err := ioutil.WriteFile(badFile, []byte("not-a-snap-and-much-much-more-content"), 0644)
+	c.Assert(err, IsNil)
+	err = snap.NewNotSnapErrorWithContext(badFile)
+	c.Check(err, ErrorMatches, `cannot process snap or snapdir: file ".*" is invalid \(header \[110 111 116 45 97 45 115 110 97 112\]\)`)
+}

--- a/snap/snapfile/snapfile.go
+++ b/snap/snapfile/snapfile.go
@@ -52,6 +52,5 @@ func Open(path string) (snap.Container, error) {
 			return h.open(path)
 		}
 	}
-
-	return nil, snap.NotSnapError{Path: path}
+	return nil, snap.NewNotSnapErrorWithContext(path)
 }

--- a/snap/snapfile/snapfile.go
+++ b/snap/snapfile/snapfile.go
@@ -20,6 +20,10 @@
 package snapfile
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snapdir"
 	"github.com/snapcore/snapd/snap/squashfs"
@@ -45,6 +49,35 @@ var formatHandlers = []snapFormat{
 	},
 }
 
+// notSnapErrorDetails gathers some generic details about why the
+// snap/snapdir could not be opened (e.g. file not found or dir
+// empty).
+func notSnapErrorDetails(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	stat, err := f.Stat()
+	if err != nil {
+		return err
+	}
+	if stat.IsDir() {
+		if _, err := f.Readdir(1); err == io.EOF {
+			return fmt.Errorf("directory %q is empty", path)
+		}
+		return fmt.Errorf("directory %q is invalid", path)
+	}
+	// Arbitrary value but big enough to show some header
+	// information (the squashfs header is type u32)
+	var header [5]byte
+	if _, err := f.Read(header[:]); err != nil {
+		return err
+	}
+	return fmt.Errorf("file %q is invalid (header %v)", path, header)
+}
+
 // Open opens a given snap file with the right backend.
 func Open(path string) (snap.Container, error) {
 	for _, h := range formatHandlers {
@@ -52,5 +85,6 @@ func Open(path string) (snap.Container, error) {
 			return h.open(path)
 		}
 	}
-	return nil, snap.NewNotSnapErrorWithContext(path)
+
+	return nil, snap.NotSnapError{Path: path, Err: notSnapErrorDetails(path)}
 }

--- a/snap/snapfile/snapfile.go
+++ b/snap/snapfile/snapfile.go
@@ -73,7 +73,7 @@ func notSnapErrorDetails(path string) error {
 	// information (the squashfs header is type u32)
 	var header [5]byte
 	if _, err := f.Read(header[:]); err != nil {
-		return err
+		return fmt.Errorf("cannot read %q: %v", path, err)
 	}
 	return fmt.Errorf("file %q is invalid (header %v)", path, header)
 }

--- a/snap/snapfile/snapfile_test.go
+++ b/snap/snapfile/snapfile_test.go
@@ -144,5 +144,5 @@ func (s *snapFileTestSuite) TestFileOpenForSnapDirErrors(c *C) {
 	// no snap.yaml file
 	_, err := snapfile.Open(c.MkDir())
 	c.Assert(err, FitsTypeOf, snap.NotSnapError{})
-	c.Assert(err, ErrorMatches, `"/.*" is not a snap or snapdir`)
+	c.Assert(err, ErrorMatches, `cannot process snap or snapdir: directory ".*" is empty`)
 }

--- a/snap/snapfile/snapfile_test.go
+++ b/snap/snapfile/snapfile_test.go
@@ -132,12 +132,14 @@ func (s *snapFileTestSuite) TestOpenSnapdirUnsupportedFormat(c *C) {
 
 	_, err = snapfile.Open(fn)
 	c.Assert(err, FitsTypeOf, snap.NotSnapError{})
+	c.Check(err, ErrorMatches, `cannot process snap or snapdir: file ".*" is invalid \(header \[110 111 116 45 97\]\)`)
 }
 
 func (s *snapFileTestSuite) TestOpenSnapdirFileNoExists(c *C) {
 	dir := c.MkDir()
-	_, err := snapfile.Open(filepath.Join(dir, "garbage"))
+	_, err := snapfile.Open(filepath.Join(dir, "non-existing-file"))
 	c.Assert(err, FitsTypeOf, snap.NotSnapError{})
+	c.Check(err, ErrorMatches, `cannot process snap or snapdir: open /.*/non-existing-file: no such file or directory`)
 }
 
 func (s *snapFileTestSuite) TestFileOpenForSnapDirErrors(c *C) {
@@ -145,4 +147,13 @@ func (s *snapFileTestSuite) TestFileOpenForSnapDirErrors(c *C) {
 	_, err := snapfile.Open(c.MkDir())
 	c.Assert(err, FitsTypeOf, snap.NotSnapError{})
 	c.Assert(err, ErrorMatches, `cannot process snap or snapdir: directory ".*" is empty`)
+}
+
+func (s *snapFileTestSuite) TestNotSnapErrorInvalidDir(c *C) {
+	tmpdir := c.MkDir()
+	err := ioutil.WriteFile(filepath.Join(tmpdir, "foo"), nil, 0644)
+	c.Assert(err, IsNil)
+	_, err = snapfile.Open(tmpdir)
+	c.Assert(err, FitsTypeOf, snap.NotSnapError{})
+	c.Check(err, ErrorMatches, `cannot process snap or snapdir: directory ".*" is invalid`)
 }

--- a/snap/snapfile/snapfile_test.go
+++ b/snap/snapfile/snapfile_test.go
@@ -142,6 +142,15 @@ func (s *snapFileTestSuite) TestOpenSnapdirFileNoExists(c *C) {
 	c.Check(err, ErrorMatches, `cannot process snap or snapdir: open /.*/non-existing-file: no such file or directory`)
 }
 
+func (s *snapFileTestSuite) TestOpenSnapdirFileEmpty(c *C) {
+	emptyFile := filepath.Join(c.MkDir(), "foo")
+	err := ioutil.WriteFile(emptyFile, nil, 0644)
+	c.Assert(err, IsNil)
+	_, err = snapfile.Open(emptyFile)
+	c.Assert(err, FitsTypeOf, snap.NotSnapError{})
+	c.Check(err, ErrorMatches, `cannot process snap or snapdir: cannot read "/.*/foo": EOF`)
+}
+
 func (s *snapFileTestSuite) TestFileOpenForSnapDirErrors(c *C) {
 	// no snap.yaml file
 	_, err := snapfile.Open(c.MkDir())


### PR DESCRIPTION
When a NotSnapError is returned right now there is no context provided what went wrong. This makes debugging issues difficult when the user just reports:
```
2022-11-23T14:47:57Z ERROR "/var/lib/snapd/snaps/.local-install-130452292" is not a snap or snapdir
```

This commit creates a constructor `snap.NewNotSnapErrorWithContext()` that provides some context like:
```
cannot process snap or snapdir: open non-existing-file: no such file or directory
cannot process snap or snapdir: directory "empty-dir" is empty
cannot process snap or snapdir: directory "invalid-dir" is invalid
cannot process snap or snapdir: file "not-snap" is invalid header [110 111 116 45 97 45 115 110 97 112])
```
