### PR TITLE
strutil: go staticcheck (S1008) code simplification

### DIFF
--- a/strutil/version.go
+++ b/strutil/version.go
@@ -101,10 +101,7 @@ func matchEpoch(a string) bool {
 // versionIsValid returns true if the given string is a valid
 // version number according to the debian policy
 func versionIsValid(a string) bool {
-	if matchEpoch(a) {
-		return false
-	}
-	return true
+	return !matchEpoch(a)
 }
 
 func nextFrag(s string) (frag, rest string, numeric bool) {


### PR DESCRIPTION
strutil/version.go:104:2: should use 'return !matchEpoch(a)' instead of 'if matchEpoch(a) { return false }; return true' (S1008)
