### PR TITLE
tests: reduce the number of conections testsed in debian 10

### DIFF
--- a/tests/main/interfaces-many-core-provided/task.yaml
+++ b/tests/main/interfaces-many-core-provided/task.yaml
@@ -63,11 +63,11 @@ execute: |
     SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
     for plugcmd in "$SNAP_MOUNT_DIR"/bin/"$CONSUMER_SNAP".* ; do
 
-        # Just connect 30% of the interfaces on debian 10
+        # Just connect 20% of the interfaces on debian 10
         # Debian 10 has bad performance disconnecting interfaces
         # and the test fails (kill-timeout) trying either to remove
         # interfaces or removing the snap
-        if os.query is-debian 10 && [ "$((RANDOM % 3))" != 0 ]; then
+        if os.query is-debian 10 && [ "$((RANDOM % 5))" != 0 ]; then
             echo "skipping plug: $plugcmd"
             continue
         fi


### PR DESCRIPTION
As the test interfaces-many-core-provided is continuously failing with test kill timeout, the idea is to reduce the number of connections tested to speed up the test. 

This is needed because Debian 10 has bad performance disconnecting interfaces.
