### PR TITLE
o/configstate/configcore: users.go makes sense only with !nomanagers

### DIFF
--- a/overlord/configstate/configcore/users.go
+++ b/overlord/configstate/configcore/users.go
@@ -1,4 +1,6 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !nomanagers
+// +build !nomanagers
 
 /*
  * Copyright (C) 2021 Canonical Ltd


### PR DESCRIPTION
as it is state based

