### PR TITLE
bootloader: handle uboot with SYS_REDUNDAND_ENVIRONMENT=n

### DIFF
--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -1654,7 +1654,7 @@ func (s *makeBootable20UbootSuite) TestUbootMakeRunnableSystem20RunModeBootSel(c
 	mockSeedUbootBootSel := filepath.Join(boot.InitramfsUbuntuSeedDir, "uboot/ubuntu/boot.sel")
 	err = os.MkdirAll(filepath.Dir(mockSeedUbootBootSel), 0755)
 	c.Assert(err, IsNil)
-	env, err := ubootenv.Create(mockSeedUbootBootSel, 4096)
+	env, err := ubootenv.Create(mockSeedUbootBootSel, 4096, ubootenv.CreateOptions{HeaderFlagByte: true})
 	c.Assert(err, IsNil)
 	c.Assert(env.Save(), IsNil)
 
@@ -1662,7 +1662,7 @@ func (s *makeBootable20UbootSuite) TestUbootMakeRunnableSystem20RunModeBootSel(c
 	mockBootUbootBootSel := filepath.Join(boot.InitramfsUbuntuBootDir, "uboot/ubuntu/boot.sel")
 	err = os.MkdirAll(filepath.Dir(mockBootUbootBootSel), 0755)
 	c.Assert(err, IsNil)
-	env, err = ubootenv.Create(mockBootUbootBootSel, 4096)
+	env, err = ubootenv.Create(mockBootUbootBootSel, 4096, ubootenv.CreateOptions{HeaderFlagByte: true})
 	c.Assert(err, IsNil)
 	c.Assert(env.Save(), IsNil)
 
@@ -1725,6 +1725,7 @@ version: 5.0
 	uenvSeed, err := ubootenv.Open(mockSeedUbootenv)
 	c.Assert(err, IsNil)
 	c.Assert(uenvSeed.Get("snapd_recovery_mode"), Equals, "run")
+	c.Assert(uenvSeed.HeaderFlagByte(), Equals, true)
 
 	// now check ubuntu-boot boot.sel
 	mockBootUbootenv := filepath.Join(boot.InitramfsUbuntuBootDir, "uboot/ubuntu/boot.sel")
@@ -1733,6 +1734,7 @@ version: 5.0
 	c.Assert(uenvBoot.Get("snap_try_kernel"), Equals, "")
 	c.Assert(uenvBoot.Get("snap_kernel"), Equals, "arm-kernel_5.snap")
 	c.Assert(uenvBoot.Get("kernel_status"), Equals, boot.DefaultStatus)
+	c.Assert(uenvBoot.HeaderFlagByte(), Equals, true)
 
 	// check that we have the extracted kernel in the right places, in the
 	// old uc16/uc18 location

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -1642,6 +1642,74 @@ version: 5.0
 	)
 }
 
+func (s *makeBootable20UbootSuite) TestUbootMakeBootableImage20BootSelNoHeaderFlagByte(c *C) {
+	bootloader.Force(nil)
+	model := boottest.MakeMockUC20Model()
+
+	unpackedGadgetDir := c.MkDir()
+	// the uboot.conf must be empty for this to work/do the right thing
+	err := ioutil.WriteFile(filepath.Join(unpackedGadgetDir, "uboot.conf"), nil, 0644)
+	c.Assert(err, IsNil)
+
+	sampleEnv, err := ubootenv.Create(filepath.Join(unpackedGadgetDir, "boot.sel"), 4096, ubootenv.CreateOptions{HeaderFlagByte: false})
+	c.Assert(err, IsNil)
+	err = sampleEnv.Save()
+	c.Assert(err, IsNil)
+
+	// on uc20 the seed layout if different
+	seedSnapsDirs := filepath.Join(s.rootdir, "/snaps")
+	err = os.MkdirAll(seedSnapsDirs, 0755)
+	c.Assert(err, IsNil)
+
+	baseFn, baseInfo := makeSnap(c, "core20", `name: core20
+type: base
+version: 5.0
+`, snap.R(3))
+	baseInSeed := filepath.Join(seedSnapsDirs, baseInfo.Filename())
+	err = os.Rename(baseFn, baseInSeed)
+	c.Assert(err, IsNil)
+	kernelFn, kernelInfo := makeSnapWithFiles(c, "arm-kernel", `name: arm-kernel
+type: kernel
+version: 5.0
+`, snap.R(5), [][]string{
+		{"kernel.img", "I'm a kernel"},
+		{"initrd.img", "...and I'm an initrd"},
+		{"dtbs/foo.dtb", "foo dtb"},
+		{"dtbs/bar.dto", "bar dtbo"},
+	})
+	kernelInSeed := filepath.Join(seedSnapsDirs, kernelInfo.Filename())
+	err = os.Rename(kernelFn, kernelInSeed)
+	c.Assert(err, IsNil)
+
+	label := "20191209"
+	recoverySystemDir := filepath.Join("/systems", label)
+	bootWith := &boot.BootableSet{
+		Base:                baseInfo,
+		BasePath:            baseInSeed,
+		Kernel:              kernelInfo,
+		KernelPath:          kernelInSeed,
+		RecoverySystemDir:   recoverySystemDir,
+		RecoverySystemLabel: label,
+		UnpackedGadgetDir:   unpackedGadgetDir,
+		Recovery:            true,
+	}
+
+	err = boot.MakeBootableImage(model, s.rootdir, bootWith, nil)
+	c.Assert(err, IsNil)
+
+	// since uboot.conf was absent, we won't have installed the uboot.env, as
+	// it is expected that the gadget assets would have installed boot.scr
+	// instead
+	c.Check(filepath.Join(s.rootdir, "uboot.env"), testutil.FileAbsent)
+
+	env, err := ubootenv.Open(filepath.Join(s.rootdir, "/uboot/ubuntu/boot.sel"))
+	c.Assert(err, IsNil)
+
+	// Since we have a boot.sel w/o a header flag byte in our gadget,
+	// our recovery boot sel also should not have a header flag byte
+	c.Check(env.HeaderFlagByte(), Equals, false)
+}
+
 func (s *makeBootable20UbootSuite) TestUbootMakeRunnableSystem20RunModeBootSel(c *C) {
 	bootloader.Force(nil)
 

--- a/bootloader/export_test.go
+++ b/bootloader/export_test.go
@@ -58,7 +58,7 @@ func MockUbootFiles(c *C, rootdir string, blOpts *Options) {
 	c.Assert(err, IsNil)
 
 	// ensure that we have a valid uboot.env too
-	env, err := ubootenv.Create(u.envFile(), 4096)
+	env, err := ubootenv.Create(u.envFile(), 4096, ubootenv.CreateOptions{HeaderFlagByte: true})
 	c.Assert(err, IsNil)
 	err = env.Save()
 	c.Assert(err, IsNil)
@@ -258,7 +258,7 @@ func MockPibootFiles(c *C, rootdir string, blOpts *Options) func() {
 	c.Assert(err, IsNil)
 
 	// ensure that we have a valid piboot.conf
-	env, err := ubootenv.Create(p.envFile(), 4096)
+	env, err := ubootenv.Create(p.envFile(), 4096, ubootenv.CreateOptions{HeaderFlagByte: true})
 	c.Assert(err, IsNil)
 	err = env.Save()
 	c.Assert(err, IsNil)

--- a/bootloader/piboot.go
+++ b/bootloader/piboot.go
@@ -336,7 +336,7 @@ func (p *piboot) InstallBootConfig(gadgetDir string, blOpts *Options) error {
 	}
 
 	// TODO: what's a reasonable size for this file?
-	env, err := ubootenv.Create(p.envFile(), 4096)
+	env, err := ubootenv.Create(p.envFile(), 4096, ubootenv.CreateOptions{HeaderFlagByte: true})
 	if err != nil {
 		return err
 	}

--- a/bootloader/uboot.go
+++ b/bootloader/uboot.go
@@ -112,7 +112,7 @@ func (u *uboot) InstallBootConfig(gadgetDir string, blOpts *Options) error {
 		}
 
 		// TODO:UC20: what's a reasonable size for this file?
-		env, err := ubootenv.Create(u.envFile(), 4096)
+		env, err := ubootenv.Create(u.envFile(), 4096, &ubootenv.CreateOptions{HeaderFlagByte: true})
 		if err != nil {
 			return err
 		}

--- a/bootloader/uboot_test.go
+++ b/bootloader/uboot_test.go
@@ -90,7 +90,7 @@ func (s *ubootTestSuite) TestUbootSetEnvNoUselessWrites(c *C) {
 	c.Assert(u, NotNil)
 
 	envFile := bootloader.UbootConfigFile(u)
-	env, err := ubootenv.Create(envFile, 4096)
+	env, err := ubootenv.Create(envFile, 4096, ubootenv.CreateOptions{HeaderFlagByte: true})
 	c.Assert(err, IsNil)
 	env.Set("snap_ab", "b")
 	env.Set("snap_mode", "")

--- a/bootloader/ubootenv/env_test.go
+++ b/bootloader/ubootenv/env_test.go
@@ -47,7 +47,7 @@ func (u *uenvTestSuite) SetUpTest(c *C) {
 }
 
 func (u *uenvTestSuite) TestSetNoDuplicate(c *C) {
-	env, err := ubootenv.Create(u.envFile, 4096)
+	env, err := ubootenv.Create(u.envFile, 4096, ubootenv.CreateOptions{HeaderFlagByte: true})
 	c.Assert(err, IsNil)
 	env.Set("foo", "bar")
 	env.Set("foo", "bar")
@@ -55,7 +55,20 @@ func (u *uenvTestSuite) TestSetNoDuplicate(c *C) {
 }
 
 func (u *uenvTestSuite) TestOpenEnv(c *C) {
-	env, err := ubootenv.Create(u.envFile, 4096)
+	env, err := ubootenv.Create(u.envFile, 4096, ubootenv.CreateOptions{HeaderFlagByte: true})
+	c.Assert(err, IsNil)
+	env.Set("foo", "bar")
+	c.Assert(env.String(), Equals, "foo=bar\n")
+	err = env.Save()
+	c.Assert(err, IsNil)
+
+	env2, err := ubootenv.Open(u.envFile)
+	c.Assert(err, IsNil)
+	c.Assert(env2.String(), Equals, "foo=bar\n")
+}
+
+func (u *uenvTestSuite) TestOpenEnvNoHeaderFlagByte(c *C) {
+	env, err := ubootenv.Create(u.envFile, 4096, ubootenv.CreateOptions{HeaderFlagByte: false})
 	c.Assert(err, IsNil)
 	env.Set("foo", "bar")
 	c.Assert(env.String(), Equals, "foo=bar\n")
@@ -74,7 +87,7 @@ func (u *uenvTestSuite) TestOpenEnvBadEmpty(c *C) {
 	c.Assert(err, IsNil)
 
 	_, err = ubootenv.Open(empty)
-	c.Assert(err, ErrorMatches, `cannot open ".*": smaller than expected header`)
+	c.Assert(err, ErrorMatches, `cannot open ".*": smaller than expected environment block`)
 }
 
 func (u *uenvTestSuite) TestOpenEnvBadCRC(c *C) {
@@ -89,20 +102,20 @@ func (u *uenvTestSuite) TestOpenEnvBadCRC(c *C) {
 }
 
 func (u *uenvTestSuite) TestGetSimple(c *C) {
-	env, err := ubootenv.Create(u.envFile, 4096)
+	env, err := ubootenv.Create(u.envFile, 4096, ubootenv.CreateOptions{HeaderFlagByte: true})
 	c.Assert(err, IsNil)
 	env.Set("foo", "bar")
 	c.Assert(env.Get("foo"), Equals, "bar")
 }
 
 func (u *uenvTestSuite) TestGetNoSuchEntry(c *C) {
-	env, err := ubootenv.Create(u.envFile, 4096)
+	env, err := ubootenv.Create(u.envFile, 4096, ubootenv.CreateOptions{HeaderFlagByte: true})
 	c.Assert(err, IsNil)
 	c.Assert(env.Get("no-such-entry"), Equals, "")
 }
 
 func (u *uenvTestSuite) TestImport(c *C) {
-	env, err := ubootenv.Create(u.envFile, 4096)
+	env, err := ubootenv.Create(u.envFile, 4096, ubootenv.CreateOptions{HeaderFlagByte: true})
 	c.Assert(err, IsNil)
 
 	r := strings.NewReader("foo=bar\n#comment\n\nbaz=baz")
@@ -113,7 +126,7 @@ func (u *uenvTestSuite) TestImport(c *C) {
 }
 
 func (u *uenvTestSuite) TestImportHasError(c *C) {
-	env, err := ubootenv.Create(u.envFile, 4096)
+	env, err := ubootenv.Create(u.envFile, 4096, ubootenv.CreateOptions{HeaderFlagByte: true})
 	c.Assert(err, IsNil)
 
 	r := strings.NewReader("foxy")
@@ -122,7 +135,7 @@ func (u *uenvTestSuite) TestImportHasError(c *C) {
 }
 
 func (u *uenvTestSuite) TestSetEmptyUnsets(c *C) {
-	env, err := ubootenv.Create(u.envFile, 4096)
+	env, err := ubootenv.Create(u.envFile, 4096, ubootenv.CreateOptions{HeaderFlagByte: true})
 	c.Assert(err, IsNil)
 
 	env.Set("foo", "bar")
@@ -131,11 +144,13 @@ func (u *uenvTestSuite) TestSetEmptyUnsets(c *C) {
 	c.Assert(env.String(), Equals, "")
 }
 
-func (u *uenvTestSuite) makeUbootEnvFromData(c *C, mockData []byte) {
+func (u *uenvTestSuite) makeUbootEnvFromData(c *C, mockData []byte, useHeaderFlagByte bool) {
 	w := bytes.NewBuffer(nil)
 	crc := crc32.ChecksumIEEE(mockData)
 	w.Write(ubootenv.WriteUint32(crc))
-	w.Write([]byte{0})
+	if useHeaderFlagByte {
+		w.Write([]byte{0})
+	}
 	w.Write(mockData)
 
 	f, err := os.Create(u.envFile)
@@ -158,11 +173,19 @@ func (u *uenvTestSuite) TestReadStopsAfterDoubleNull(c *C) {
 		// empty
 		0xff, 0xff,
 	}
-	u.makeUbootEnvFromData(c, mockData)
+	u.makeUbootEnvFromData(c, mockData, true)
 
 	env, err := ubootenv.Open(u.envFile)
 	c.Assert(err, IsNil)
 	c.Assert(env.String(), Equals, "foo=bar\n")
+	c.Assert(env.HeaderFlagByte(), Equals, true)
+
+	u.makeUbootEnvFromData(c, mockData, false)
+
+	env, err = ubootenv.Open(u.envFile)
+	c.Assert(err, IsNil)
+	c.Assert(env.String(), Equals, "foo=bar\n")
+	c.Assert(env.HeaderFlagByte(), Equals, false)
 }
 
 // ensure that the malformed data is not causing us to panic.
@@ -173,10 +196,16 @@ func (u *uenvTestSuite) TestErrorOnMalformedData(c *C) {
 		// eof
 		0x00, 0x00,
 	}
-	u.makeUbootEnvFromData(c, mockData)
+	u.makeUbootEnvFromData(c, mockData, true)
 
 	env, err := ubootenv.Open(u.envFile)
-	c.Assert(err, ErrorMatches, `cannot parse line "foo" as key=value pair`)
+	c.Assert(err, ErrorMatches, `cannot open ".*": cannot parse line "foo" as key=value pair`)
+	c.Assert(env, IsNil)
+
+	u.makeUbootEnvFromData(c, mockData, false)
+
+	env, err = ubootenv.Open(u.envFile)
+	c.Assert(err, ErrorMatches, `cannot open ".*": cannot parse line "foo" as key=value pair`)
 	c.Assert(env, IsNil)
 }
 
@@ -206,11 +235,19 @@ func (u *uenvTestSuite) TestOpenBestEffort(c *C) {
 		0x66, 0x6f, 0x6f, 0x00,
 	}}
 	for testName, mockData := range testCases {
-		u.makeUbootEnvFromData(c, mockData)
+		u.makeUbootEnvFromData(c, mockData, true)
 
 		env, err := ubootenv.OpenWithFlags(u.envFile, ubootenv.OpenBestEffort)
 		c.Assert(err, IsNil, Commentf(testName))
 		c.Check(env.String(), Equals, "key1=value1\nkey2=value2\n", Commentf(testName))
+		c.Assert(env.HeaderFlagByte(), Equals, true)
+
+		u.makeUbootEnvFromData(c, mockData, false)
+
+		env, err = ubootenv.OpenWithFlags(u.envFile, ubootenv.OpenBestEffort)
+		c.Assert(err, IsNil, Commentf(testName))
+		c.Check(env.String(), Equals, "key1=value1\nkey2=value2\n", Commentf(testName))
+		c.Assert(env.HeaderFlagByte(), Equals, false)
 	}
 }
 
@@ -221,10 +258,16 @@ func (u *uenvTestSuite) TestErrorOnMissingKeyInKeyValuePair(c *C) {
 		// eof
 		0x00, 0x00,
 	}
-	u.makeUbootEnvFromData(c, mockData)
+	u.makeUbootEnvFromData(c, mockData, true)
 
 	env, err := ubootenv.Open(u.envFile)
-	c.Assert(err, ErrorMatches, `cannot parse line "=foo" as key=value pair`)
+	c.Assert(err, ErrorMatches, `cannot open ".*": cannot parse line "=foo" as key=value pair`)
+	c.Assert(env, IsNil)
+
+	u.makeUbootEnvFromData(c, mockData, false)
+
+	env, err = ubootenv.Open(u.envFile)
+	c.Assert(err, ErrorMatches, `cannot open ".*": cannot parse line "=foo" as key=value pair`)
 	c.Assert(env, IsNil)
 }
 
@@ -235,15 +278,23 @@ func (u *uenvTestSuite) TestReadEmptyFile(c *C) {
 		// empty
 		0xff, 0xff,
 	}
-	u.makeUbootEnvFromData(c, mockData)
+	u.makeUbootEnvFromData(c, mockData, true)
 
 	env, err := ubootenv.Open(u.envFile)
 	c.Assert(err, IsNil)
 	c.Assert(env.String(), Equals, "")
+	c.Assert(env.HeaderFlagByte(), Equals, true)
+
+	u.makeUbootEnvFromData(c, mockData, false)
+
+	env, err = ubootenv.Open(u.envFile)
+	c.Assert(err, IsNil)
+	c.Assert(env.String(), Equals, "")
+	c.Assert(env.HeaderFlagByte(), Equals, false)
 }
 
 func (u *uenvTestSuite) TestWritesEmptyFileWithDoubleNewline(c *C) {
-	env, err := ubootenv.Create(u.envFile, 12)
+	env, err := ubootenv.Create(u.envFile, 12, ubootenv.CreateOptions{HeaderFlagByte: true})
 	c.Assert(err, IsNil)
 	err = env.Save()
 	c.Assert(err, IsNil)
@@ -267,12 +318,39 @@ func (u *uenvTestSuite) TestWritesEmptyFileWithDoubleNewline(c *C) {
 	env, err = ubootenv.Open(u.envFile)
 	c.Assert(err, IsNil)
 	c.Assert(env.String(), Equals, "")
+	c.Assert(env.HeaderFlagByte(), Equals, true)
+}
+
+func (u *uenvTestSuite) TestWritesEmptyFileWithDoubleNewlineNoHeaderFlagByte(c *C) {
+	env, err := ubootenv.Create(u.envFile, 11, ubootenv.CreateOptions{HeaderFlagByte: false})
+	c.Assert(err, IsNil)
+	err = env.Save()
+	c.Assert(err, IsNil)
+
+	r, err := os.Open(u.envFile)
+	c.Assert(err, IsNil)
+	defer r.Close()
+	content, err := ioutil.ReadAll(r)
+	c.Assert(err, IsNil)
+	c.Assert(content, DeepEquals, []byte{
+		// crc
+		0x11, 0x38, 0xb3, 0x89,
+		// eof
+		0x0, 0x0,
+		// footer
+		0xff, 0xff, 0xff, 0xff, 0xff,
+	})
+
+	env, err = ubootenv.Open(u.envFile)
+	c.Assert(err, IsNil)
+	c.Assert(env.String(), Equals, "")
+	c.Assert(env.HeaderFlagByte(), Equals, false)
 }
 
 func (u *uenvTestSuite) TestWritesContentCorrectly(c *C) {
 	totalSize := 16
 
-	env, err := ubootenv.Create(u.envFile, totalSize)
+	env, err := ubootenv.Create(u.envFile, totalSize, ubootenv.CreateOptions{HeaderFlagByte: true})
 	c.Assert(err, IsNil)
 	env.Set("a", "b")
 	env.Set("c", "d")
@@ -305,4 +383,42 @@ func (u *uenvTestSuite) TestWritesContentCorrectly(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(env.String(), Equals, "a=b\nc=d\n")
 	c.Assert(env.Size(), Equals, totalSize)
+	c.Assert(env.HeaderFlagByte(), Equals, true)
+}
+
+func (u *uenvTestSuite) TestWritesContentCorrectlyNoHeaderFlagByte(c *C) {
+	totalSize := 15
+
+	env, err := ubootenv.Create(u.envFile, totalSize, ubootenv.CreateOptions{HeaderFlagByte: false})
+	c.Assert(err, IsNil)
+	env.Set("a", "b")
+	env.Set("c", "d")
+	err = env.Save()
+	c.Assert(err, IsNil)
+
+	r, err := os.Open(u.envFile)
+	c.Assert(err, IsNil)
+	defer r.Close()
+	content, err := ioutil.ReadAll(r)
+	c.Assert(err, IsNil)
+	c.Assert(content, DeepEquals, []byte{
+		// crc
+		0xc7, 0xd9, 0x6b, 0xc5,
+		// a=b
+		0x61, 0x3d, 0x62,
+		// eol
+		0x0,
+		// c=d
+		0x63, 0x3d, 0x64,
+		// eof
+		0x0, 0x0,
+		// footer
+		0xff, 0xff,
+	})
+
+	env, err = ubootenv.Open(u.envFile)
+	c.Assert(err, IsNil)
+	c.Assert(env.String(), Equals, "a=b\nc=d\n")
+	c.Assert(env.Size(), Equals, totalSize)
+	c.Assert(env.HeaderFlagByte(), Equals, false)
 }


### PR DESCRIPTION
First commit adapts ubootenv code to successfully read both formats of environments (uboot details [here](https://github.com/u-boot/u-boot/blob/7b84c973b96775576dcff228d865e8570be26c82/include/env_internal.h#L58) and [here](https://github.com/u-boot/u-boot/blob/7b84c973b96775576dcff228d865e8570be26c82/include/env_internal.h#L80)). The only really interesting thing here is that when `Open`ing an existing env file, it autodetects the format, and the caller only needs to specify the format when creating a new environment from scratch using `Create`.

For uboot, `Create` is only really called in one place (outside of unit tests and piboot), which is when creating the recovery boot.sel file (run mode boot.sel comes directly from gadget). This proposal reads that boot.sel file that is in the gadget and mirrors its format.

Probably worth noting here that @kubiko had an alternative suggestion which would involve implementing a second, parallel bootloader implementation called `uboot-no-redund-env` or something of the sort, which snapd would then detect via a `uboot-no-redund-env.conf` file in the gadget. I also have an implementation of this, which reuses the existing uboot code. It felt a bit awkward in comparison, but I'm happy to open another PR so you can see the two alternatives.