### PR TITLE
randutil: latest RandomKernelUUID() changes from x-go

### DIFF
--- a/randutil/crypto.go
+++ b/randutil/crypto.go
@@ -52,10 +52,10 @@ func CryptoToken(nbytes int) (string, error) {
 // RandomKernelUUID will return a UUID from the kernel's procfs API at
 // /proc/sys/kernel/random/uuid. Only to be used in very specific uses, most
 // random code should use CryptoToken(Bytes) instead.
-func RandomKernelUUID() string {
+func RandomKernelUUID() (string, error) {
 	b, err := ioutil.ReadFile("/proc/sys/kernel/random/uuid")
 	if err != nil {
-		panic("cannot read kernel generated uuid")
+		return "", fmt.Errorf("cannot read kernel generated uuid: %w", err)
 	}
-	return strings.TrimSpace(string(b))
+	return strings.TrimSpace(string(b)), nil
 }

--- a/randutil/crypto.go
+++ b/randutil/crypto.go
@@ -49,11 +49,14 @@ func CryptoToken(nbytes int) (string, error) {
 	return base64.RawURLEncoding.EncodeToString(b), nil
 }
 
+// Allow mocking of the path through an exported reference.
+var kernelUUIDPath = "/proc/sys/kernel/random/uuid"
+
 // RandomKernelUUID will return a UUID from the kernel's procfs API at
 // /proc/sys/kernel/random/uuid. Only to be used in very specific uses, most
 // random code should use CryptoToken(Bytes) instead.
 func RandomKernelUUID() (string, error) {
-	b, err := ioutil.ReadFile("/proc/sys/kernel/random/uuid")
+	b, err := ioutil.ReadFile(kernelUUIDPath)
 	if err != nil {
 		return "", fmt.Errorf("cannot read kernel generated uuid: %w", err)
 	}

--- a/randutil/crypto_test.go
+++ b/randutil/crypto_test.go
@@ -21,6 +21,9 @@ package randutil_test
 
 import (
 	"encoding/base64"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 
 	. "gopkg.in/check.v1"
 
@@ -44,4 +47,70 @@ func (s *cryptoRandutilSuite) TestCryptoToken(c *C) {
 	b, err := base64.RawURLEncoding.DecodeString(x)
 	c.Assert(err, IsNil)
 	c.Check(b, HasLen, 5)
+}
+
+var (
+	kernelTestUUID = "1031319a-b661-4c01-aafa-6def8a118944"
+)
+
+func (s *cryptoRandutilSuite) TestRandomKernelUUIDNoFile(c *C) {
+	uuidPath := filepath.Join(c.MkDir(), "no-file")
+	defer randutil.MockKernelUUIDPath(uuidPath)()
+
+	value, err := randutil.RandomKernelUUID()
+	c.Check(value, Equals, "")
+	c.Check(err, ErrorMatches,
+		"cannot read kernel generated uuid:"+
+			".*no-file: no such file or directory")
+}
+
+func (s *cryptoRandutilSuite) TestRandomKernelUUIDNoPerm(c *C) {
+	if os.Getuid() == 0 {
+		c.Skip("Permission tests will not work when user is root")
+	}
+
+	uuidPath := filepath.Join(c.MkDir(), "no-perm")
+	defer randutil.MockKernelUUIDPath(uuidPath)()
+
+	err := ioutil.WriteFile(uuidPath, []byte(kernelTestUUID), 0)
+	c.Assert(err, IsNil)
+
+	value, err := randutil.RandomKernelUUID()
+	c.Check(value, Equals, "")
+	c.Assert(err, ErrorMatches,
+		"cannot read kernel generated uuid:"+
+			".*no-perm: permission denied")
+}
+
+func (s *cryptoRandutilSuite) TestRandomKernelUUID(c *C) {
+	for _, uuid := range []string{
+		kernelTestUUID,
+		" \t\n " + kernelTestUUID + " \n\t\r\n",
+	} {
+		// Create new path on each iteration because we cannot
+		// reuse previous path to read-only (0444) file.
+		uuidPath := filepath.Join(c.MkDir(), "uuid")
+		defer randutil.MockKernelUUIDPath(uuidPath)()
+
+		err := ioutil.WriteFile(uuidPath, []byte(uuid), 0444)
+		c.Assert(err, IsNil)
+
+		value, err := randutil.RandomKernelUUID()
+		c.Check(value, Equals, kernelTestUUID)
+		c.Assert(err, IsNil)
+	}
+}
+
+func (s *cryptoRandutilSuite) TestRandomKernelUUIDReal(c *C) {
+	if _, err := os.Stat(randutil.KernelUUIDPath); err != nil {
+		c.Skip("Kernel UUID procfs file is not accessible in the current test environment")
+	}
+
+	value, err := randutil.RandomKernelUUID()
+	c.Check(value, Not(Equals), "")
+	// https://www.rfc-editor.org/rfc/rfc4122#section-3
+	// We are not testing the kernel here, so minimal check:
+	// UUID should be 36 bytes in length exactly.
+	c.Check(value, HasLen, 36)
+	c.Assert(err, IsNil)
 }

--- a/randutil/export_test.go
+++ b/randutil/export_test.go
@@ -1,0 +1,30 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package randutil
+
+var KernelUUIDPath = kernelUUIDPath
+
+func MockKernelUUIDPath(newPath string) (restore func()) {
+	kernelUUIDPathDefault := kernelUUIDPath
+	kernelUUIDPath = newPath
+	return func() {
+		kernelUUIDPath = kernelUUIDPathDefault
+	}
+}

--- a/randutil/export_test.go
+++ b/randutil/export_test.go
@@ -19,12 +19,12 @@
 
 package randutil
 
+import "github.com/snapcore/snapd/testutil"
+
 var KernelUUIDPath = kernelUUIDPath
 
 func MockKernelUUIDPath(newPath string) (restore func()) {
-	kernelUUIDPathDefault := kernelUUIDPath
+	restore = testutil.Backup(&kernelUUIDPath)
 	kernelUUIDPath = newPath
-	return func() {
-		kernelUUIDPath = kernelUUIDPathDefault
-	}
+	return restore
 }

--- a/sandbox/cgroup/export_test.go
+++ b/sandbox/cgroup/export_test.go
@@ -50,11 +50,9 @@ func MockFsTypeForPath(mock func(string) (int64, error)) (restore func()) {
 	}
 }
 
-func MockRandomUUID(uuid string) func() {
+func MockRandomUUID(f func() (string, error)) func() {
 	old := randomUUID
-	randomUUID = func() (string, error) {
-		return uuid, nil
-	}
+	randomUUID = f
 	return func() {
 		randomUUID = old
 	}

--- a/sandbox/cgroup/tracking.go
+++ b/sandbox/cgroup/tracking.go
@@ -451,10 +451,8 @@ var doCreateTransientScope = func(conn *dbus.Conn, unitName string, pid int) err
 	return doCreateTransientScopeNoSync(conn, unitName, pid)
 }
 
-var randomUUID = func() (string, error) {
-	// The source of the bytes generated here is the same as that of
-	// /dev/urandom which doesn't block and is sufficient for our purposes
-	// of avoiding clashing UUIDs that are needed for all of the non-service
-	// commands that are started with the help of this UUID.
-	return randutil.RandomKernelUUID(), nil
-}
+// The source of the bytes generated here is the same as that of
+// /dev/urandom which doesn't block and is sufficient for our purposes
+// of avoiding clashing UUIDs that are needed for all of the non-service
+// commands that are started with the help of this UUID.
+var randomUUID = randutil.RandomKernelUUID

--- a/secboot/export_sb_test.go
+++ b/secboot/export_sb_test.go
@@ -169,7 +169,7 @@ func MockSbMeasureSnapModelToTPM(f func(tpm *sb_tpm2.Connection, pcrIndex int, m
 	}
 }
 
-func MockRandomKernelUUID(f func() string) (restore func()) {
+func MockRandomKernelUUID(f func() (string, error)) (restore func()) {
 	old := randutilRandomKernelUUID
 	randutilRandomKernelUUID = f
 	return func() {

--- a/secboot/secboot_sb.go
+++ b/secboot/secboot_sb.go
@@ -94,15 +94,23 @@ func UnlockVolumeUsingSealedKeyIfEncrypted(disk disks.Disk, name string, sealedE
 
 	if !res.IsEncrypted {
 		// if we didn't find an encrypted device just return, don't try to
-		// unlock it
-		// the filesystem device for the unencrypted case is the same as the
-		// partition device
+		// unlock it the filesystem device for the unencrypted case is the
+		// same as the partition device
 		res.PartDevice = partDevice
 		res.FsDevice = res.PartDevice
 		return res, nil
 	}
 
-	mapperName := name + "-" + randutilRandomKernelUUID()
+	uuid, err := randutilRandomKernelUUID()
+	if err != nil {
+		// We failed before we could generate the filsystem device path for
+		// the encrypted partition device, so we return FsDevice empty.
+		res.PartDevice = partDevice
+		return res, err
+	}
+
+	// make up a new name for the mapped device
+	mapperName := name + "-" + uuid
 	sourceDevice := partDevice
 	targetDevice := filepath.Join("/dev/mapper", mapperName)
 
@@ -131,8 +139,16 @@ func UnlockEncryptedVolumeUsingKey(disk disks.Disk, name string, key []byte) (Un
 	// we have a device
 	encdev := filepath.Join("/dev/disk/by-partuuid", partUUID)
 	unlockRes.PartDevice = encdev
+
+	uuid, err := randutilRandomKernelUUID()
+	if err != nil {
+		// We failed before we could generate the filsystem device path for
+		// the encrypted partition device, so we return FsDevice empty.
+		return unlockRes, err
+	}
+
 	// make up a new name for the mapped device
-	mapperName := name + "-" + randutilRandomKernelUUID()
+	mapperName := name + "-" + uuid
 	if err := unlockEncryptedPartitionWithKey(mapperName, encdev, key); err != nil {
 		return unlockRes, err
 	}

--- a/secboot/secboot_sb_test.go
+++ b/secboot/secboot_sb_test.go
@@ -451,6 +451,7 @@ func (s *secbootSuite) TestUnlockVolumeUsingSealedKeyIfEncrypted(c *C) {
 		rkErr               error // recovery key unlock error, only relevant if TPM not available
 		activated           bool  // the activation operation succeeded
 		activateErr         error // the activation error
+		uuidFailure         bool  // failure to get valid uuid
 		err                 string
 		skipDiskEnsureCheck bool // whether to check to ensure the mock disk contains the device label
 		expUnlockMethod     secboot.UnlockMethod
@@ -462,6 +463,11 @@ func (s *secbootSuite) TestUnlockVolumeUsingSealedKeyIfEncrypted(c *C) {
 			activated:       true,
 			disk:            mockDiskWithEncDev,
 			expUnlockMethod: secboot.UnlockedWithSealedKey,
+		}, {
+			// encrypted device: failure to generate uuid based target device name
+			tpmEnabled: true, hasEncdev: true, activated: true, uuidFailure: true,
+			disk: mockDiskWithEncDev,
+			err:  "mocked uuid error",
 		}, {
 			// device activation fails
 			tpmEnabled: true, hasEncdev: true,
@@ -539,13 +545,17 @@ func (s *secbootSuite) TestUnlockVolumeUsingSealedKeyIfEncrypted(c *C) {
 			err: "error enumerating partitions for disk to find unencrypted device \"name\": filesystem label \"name\" not found",
 		},
 	} {
+		c.Logf("tc %v: %+v", idx, tc)
+
 		randomUUID := fmt.Sprintf("random-uuid-for-test-%d", idx)
-		restore := secboot.MockRandomKernelUUID(func() string {
-			return randomUUID
+		restore := secboot.MockRandomKernelUUID(func() (string, error) {
+			if tc.uuidFailure {
+				return "", errors.New("mocked uuid error")
+			}
+			return randomUUID, nil
 		})
 		defer restore()
 
-		c.Logf("tc %v: %+v", idx, tc)
 		_, restoreConnect := mockSbTPMConnection(c, tc.tpmErr)
 		defer restoreConnect()
 
@@ -1298,6 +1308,28 @@ func (s *secbootSuite) TestUnlockEncryptedVolumeUsingKeyBadDisk(c *C) {
 	c.Check(unlockRes, DeepEquals, secboot.UnlockResult{})
 }
 
+func (s *secbootSuite) TestUnlockEncryptedVolumeUsingKeyUUIDError(c *C) {
+	disk := &disks.MockDiskMapping{
+		Structure: []disks.Partition{
+			{
+				FilesystemLabel: "ubuntu-save-enc",
+				PartitionUUID:   "123-123-123",
+			},
+		},
+	}
+	restore := secboot.MockRandomKernelUUID(func() (string, error) {
+		return "", errors.New("mocked uuid error")
+	})
+	defer restore()
+
+	unlockRes, err := secboot.UnlockEncryptedVolumeUsingKey(disk, "ubuntu-save", []byte("fooo"))
+	c.Assert(err, ErrorMatches, "mocked uuid error")
+	c.Check(unlockRes, DeepEquals, secboot.UnlockResult{
+		PartDevice:  "/dev/disk/by-partuuid/123-123-123",
+		IsEncrypted: true,
+	})
+}
+
 func (s *secbootSuite) TestUnlockEncryptedVolumeUsingKeyHappy(c *C) {
 	disk := &disks.MockDiskMapping{
 		Structure: []disks.Partition{
@@ -1307,8 +1339,8 @@ func (s *secbootSuite) TestUnlockEncryptedVolumeUsingKeyHappy(c *C) {
 			},
 		},
 	}
-	restore := secboot.MockRandomKernelUUID(func() string {
-		return "random-uuid-123-123"
+	restore := secboot.MockRandomKernelUUID(func() (string, error) {
+		return "random-uuid-123-123", nil
 	})
 	defer restore()
 	restore = secboot.MockSbActivateVolumeWithKey(func(volumeName, sourceDevicePath string, key []byte,
@@ -1339,8 +1371,8 @@ func (s *secbootSuite) TestUnlockEncryptedVolumeUsingKeyErr(c *C) {
 			},
 		},
 	}
-	restore := secboot.MockRandomKernelUUID(func() string {
-		return "random-uuid-123-123"
+	restore := secboot.MockRandomKernelUUID(func() (string, error) {
+		return "random-uuid-123-123", nil
 	})
 	defer restore()
 	restore = secboot.MockSbActivateVolumeWithKey(func(volumeName, sourceDevicePath string, key []byte,
@@ -1414,8 +1446,8 @@ func (s *secbootSuite) TestUnlockVolumeUsingSealedKeyIfEncryptedFdeRevealKeyV1An
 	})
 	defer restore()
 
-	restore = secboot.MockRandomKernelUUID(func() string {
-		return "random-uuid-for-test"
+	restore = secboot.MockRandomKernelUUID(func() (string, error) {
+		return "random-uuid-for-test", nil
 	})
 	defer restore()
 
@@ -1651,8 +1683,8 @@ func (s *secbootSuite) TestUnlockVolumeUsingSealedKeyIfEncryptedFdeRevealKeyV2(c
 	})
 	defer restore()
 
-	restore = secboot.MockRandomKernelUUID(func() string {
-		return "random-uuid-for-test"
+	restore = secboot.MockRandomKernelUUID(func() (string, error) {
+		return "random-uuid-for-test", nil
 	})
 	defer restore()
 
@@ -1712,8 +1744,8 @@ func (s *secbootSuite) TestUnlockVolumeUsingSealedKeyIfEncryptedFdeRevealKeyV2Mo
 	})
 	defer restore()
 
-	restore = secboot.MockRandomKernelUUID(func() string {
-		return "random-uuid-for-test"
+	restore = secboot.MockRandomKernelUUID(func() (string, error) {
+		return "random-uuid-for-test", nil
 	})
 	defer restore()
 
@@ -1767,8 +1799,8 @@ func (s *secbootSuite) TestUnlockVolumeUsingSealedKeyIfEncryptedFdeRevealKeyV2Mo
 	})
 	defer restore()
 
-	restore = secboot.MockRandomKernelUUID(func() string {
-		return "random-uuid-for-test"
+	restore = secboot.MockRandomKernelUUID(func() (string, error) {
+		return "random-uuid-for-test", nil
 	})
 	defer restore()
 
@@ -1820,8 +1852,8 @@ func (s *secbootSuite) TestUnlockVolumeUsingSealedKeyIfEncryptedFdeRevealKeyV2Al
 	})
 	defer restore()
 
-	restore = secboot.MockRandomKernelUUID(func() string {
-		return "random-uuid-for-test"
+	restore = secboot.MockRandomKernelUUID(func() (string, error) {
+		return "random-uuid-for-test", nil
 	})
 	defer restore()
 
@@ -1880,8 +1912,8 @@ func (s *secbootSuite) checkV2Key(c *C, keyFn string, prefixToDrop, expectedKey,
 	})
 	defer restore()
 
-	restore = secboot.MockRandomKernelUUID(func() string {
-		return "random-uuid-for-test"
+	restore = secboot.MockRandomKernelUUID(func() (string, error) {
+		return "random-uuid-for-test", nil
 	})
 	defer restore()
 
@@ -1948,8 +1980,8 @@ func (s *secbootSuite) TestUnlockVolumeUsingSealedKeyIfEncryptedFdeRevealKeyV1(c
 	})
 	defer restore()
 
-	restore = secboot.MockRandomKernelUUID(func() string {
-		return "random-uuid-for-test"
+	restore = secboot.MockRandomKernelUUID(func() (string, error) {
+		return "random-uuid-for-test", nil
 	})
 	defer restore()
 
@@ -2005,8 +2037,8 @@ func (s *secbootSuite) TestUnlockVolumeUsingSealedKeyIfEncryptedFdeRevealKeyBadJ
 	})
 	defer restore()
 
-	restore = secboot.MockRandomKernelUUID(func() string {
-		return "random-uuid-for-test"
+	restore = secboot.MockRandomKernelUUID(func() (string, error) {
+		return "random-uuid-for-test", nil
 	})
 	defer restore()
 


### PR DESCRIPTION
This patchset includes the following changes:

- Make randutil.RandomKernelUUID() return an error instead of throwing a panic.
- Add unit tests for RandomKernelUUID()
- Modify snapd cgroup code to accommodate RandomKernelUUID() error return.
- Modify snapd secboot code to emulate panic behaviour with new RandomKernelUUID().

