### PR TITLE
Support packaged nVidia drivers, improve zoom support with said drivers.

### DIFF
--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -46,6 +46,7 @@
 
 #define SC_VULKAN_SOURCE_DIR "/usr/share/vulkan"
 #define SC_GLVND_VENDOR_SOURCE_DIR "/usr/share/glvnd"
+#define SC_EGL_VENDOR_SOURCE_DIR "/usr/share/egl"
 
 // Location for NVIDIA vulkan files (including _wayland)
 static const char *vulkan_globs[] = {
@@ -62,6 +63,13 @@ static const char *glvnd_vendor_globs[] = {
 
 static const size_t glvnd_vendor_globs_len =
     sizeof glvnd_vendor_globs / sizeof *glvnd_vendor_globs;
+
+static const char *egl_vendor_globs[] = {
+	"egl_external_platform.d/*nvidia*.json",
+};
+
+static const size_t egl_vendor_globs_len =
+    sizeof egl_vendor_globs / sizeof *egl_vendor_globs;
 
 static char *overlay_dir;
 
@@ -89,7 +97,7 @@ static const char *nvidia_globs[] = {
 	"libnvidia-cfg.so*",
 	"libnvidia-compiler.so*",
 	"libnvidia-eglcore.so*",
-	"libnvidia-egl-wayland*",
+	"libnvidia-egl*",
 	"libnvidia-encode.so*",
 	"libnvidia-fatbinaryloader.so*",
 	"libnvidia-fbc.so*",
@@ -608,6 +616,13 @@ static void sc_mount_glvnd(const char *rootfs_dir)
 	sc_mkdir_and_mount_and_glob_files(rootfs_dir, SC_GLVND_VENDOR_SOURCE_DIR, NULL, SC_GLVND_DIR, glvnd_vendor_globs, glvnd_vendor_globs_len);
 }
 
+static void sc_mount_egl(const char *rootfs_dir)
+{
+	sc_mkdir_and_mount_and_glob_files(rootfs_dir, SC_EGL_VENDOR_SOURCE_DIR, NULL, SC_GLVND_DIR, egl_vendor_globs, egl_vendor_globs_len);
+	setenv("__EGL_VENDOR_LIBRARY_DIRS", SC_GLVND_DIR "/egl_vendor.d", true);
+	setenv("__EGL_EXTERNAL_PLATFORM_CONFIG_DIRS", SC_GLVND_DIR "/egl_external_platform.d", true);
+}
+
 void sc_mount_nvidia_driver(const char *rootfs_dir, const char *base_snap_name)
 {
 	/* If NVIDIA module isn't loaded, don't attempt to mount the drivers */
@@ -663,6 +678,7 @@ void sc_mount_nvidia_driver(const char *rootfs_dir, const char *base_snap_name)
 	// Common for both driver mechanisms
 	sc_mount_vulkan(rootfs_dir);
 	sc_mount_glvnd(rootfs_dir);
+	sc_mount_egl(rootfs_dir);
 
 	sc_overlay_final();
 }

--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -45,7 +45,7 @@
 #define SC_GLVND_DIR  SC_EXTRA_LIB_DIR "/glvnd"
 
 #define SC_VULKAN_SOURCE_DIR "/usr/share/vulkan"
-#define SC_EGL_VENDOR_SOURCE_DIR "/usr/share/glvnd"
+#define SC_GLVND_VENDOR_SOURCE_DIR "/usr/share/glvnd"
 
 // Location for NVIDIA vulkan files (including _wayland)
 static const char *vulkan_globs[] = {
@@ -56,12 +56,12 @@ static const size_t vulkan_globs_len =
     sizeof vulkan_globs / sizeof *vulkan_globs;
 
 // Location of EGL vendor files
-static const char *egl_vendor_globs[] = {
+static const char *glvnd_vendor_globs[] = {
 	"egl_vendor.d/*nvidia*.json",
 };
 
-static const size_t egl_vendor_globs_len =
-    sizeof egl_vendor_globs / sizeof *egl_vendor_globs;
+static const size_t glvnd_vendor_globs_len =
+    sizeof glvnd_vendor_globs / sizeof *glvnd_vendor_globs;
 
 static char *overlay_dir;
 
@@ -603,9 +603,9 @@ static void sc_mount_vulkan(const char *rootfs_dir)
 	sc_mkdir_and_mount_and_glob_files(rootfs_dir, SC_VULKAN_SOURCE_DIR, NULL, SC_VULKAN_DIR, vulkan_globs, vulkan_globs_len);
 }
 
-static void sc_mount_egl(const char *rootfs_dir)
+static void sc_mount_glvnd(const char *rootfs_dir)
 {
-	sc_mkdir_and_mount_and_glob_files(rootfs_dir, SC_EGL_VENDOR_SOURCE_DIR, NULL, SC_GLVND_DIR, egl_vendor_globs, egl_vendor_globs_len);
+	sc_mkdir_and_mount_and_glob_files(rootfs_dir, SC_GLVND_VENDOR_SOURCE_DIR, NULL, SC_GLVND_DIR, glvnd_vendor_globs, glvnd_vendor_globs_len);
 }
 
 void sc_mount_nvidia_driver(const char *rootfs_dir, const char *base_snap_name)
@@ -662,7 +662,7 @@ void sc_mount_nvidia_driver(const char *rootfs_dir, const char *base_snap_name)
 
 	// Common for both driver mechanisms
 	sc_mount_vulkan(rootfs_dir);
-	sc_mount_egl(rootfs_dir);
+	sc_mount_glvnd(rootfs_dir);
 
 	sc_overlay_final();
 }

--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -253,7 +253,21 @@ static void sc_populate_libgl_with_hostfs_symlinks(const char *libgl_dir,
 				die("cannot read symbolic link %s", pathname);
 			}
 			hostfs_symlink_target[num_read] = 0;
-			if (hostfs_symlink_target[0] == '/') {
+			if (!strncmp("/etc/alternatives/", hostfs_symlink_target, 18)) {
+				char hostfs_alt_symlink_target[512] = { 0 };
+				hostfs_alt_symlink_target[0] = 0;
+				num_read =
+				    readlink(hostfs_symlink_target, hostfs_alt_symlink_target,
+					    sizeof hostfs_alt_symlink_target - 1);
+				if (num_read == -1) {
+					die("cannot read symbolic link %s", pathname);
+				}
+				hostfs_alt_symlink_target[num_read] = 0;
+				sc_must_snprintf(symlink_target,
+						 sizeof symlink_target,
+						 "/var/lib/snapd/hostfs%s",
+						 hostfs_alt_symlink_target);
+			} else if (hostfs_symlink_target[0] == '/') {
 				sc_must_snprintf(symlink_target,
 						 sizeof symlink_target,
 						 "/var/lib/snapd/hostfs%s",

--- a/cmd/snap-update-ns/utils.go
+++ b/cmd/snap-update-ns/utils.go
@@ -111,7 +111,7 @@ func OpenPath(path string) (int, error) {
 		}
 		fd, err = sysOpenat(fd, iter.CurrentCleanName(), openFlags, 0)
 		if err != nil {
-			return -1, err
+			return -1, fmt.Errorf("Unable to open %s: %w", iter.CurrentPath(), err)
 		}
 	}
 

--- a/cmd/snap-update-ns/utils_test.go
+++ b/cmd/snap-update-ns/utils_test.go
@@ -1165,7 +1165,7 @@ func (s *realSystemSuite) TestSecureOpenPathNotFound(c *C) {
 
 	fd, err := update.OpenPath(path)
 	c.Check(fd, Equals, -1)
-	c.Check(err, ErrorMatches, "no such file or directory")
+	c.Check(err, ErrorMatches, `Unable to open .*: no such file or directory`)
 }
 
 func (s *realSystemSuite) TestSecureOpenPathSymlink(c *C) {
@@ -1195,5 +1195,5 @@ func (s *realSystemSuite) TestSecureOpenPathSymlinkedParent(c *C) {
 
 	fd, err := update.OpenPath(symlinkedPath)
 	c.Check(fd, Equals, -1)
-	c.Check(err, ErrorMatches, "not a directory")
+	c.Check(err, ErrorMatches, `Unable to open .*: not a directory`)
 }

--- a/interfaces/builtin/posix_mq.go
+++ b/interfaces/builtin/posix_mq.go
@@ -222,7 +222,7 @@ func (iface *posixMQInterface) validatePath(name, path string) error {
 		return fmt.Errorf(`posix-mq "path" attribute must conform to the POSIX message queue name specifications (see "man mq_overview"): %v`, path)
 	}
 
-	if err := apparmor_sandbox.ValidateNoAppArmorRegexp(path); err != nil {
+	if _, err := utils.NewPathPattern(path); err != nil {
 		return fmt.Errorf(`posix-mq "path" attribute is invalid: "%v"`, path)
 	}
 

--- a/interfaces/builtin/posix_mq.go
+++ b/interfaces/builtin/posix_mq.go
@@ -28,6 +28,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/seccomp"
+	"github.com/snapcore/snapd/interfaces/utils"
 	"github.com/snapcore/snapd/metautil"
 	apparmor_sandbox "github.com/snapcore/snapd/sandbox/apparmor"
 	"github.com/snapcore/snapd/snap"
@@ -222,7 +223,7 @@ func (iface *posixMQInterface) validatePath(name, path string) error {
 	}
 
 	if err := apparmor_sandbox.ValidateNoAppArmorRegexp(path); err != nil {
-		return fmt.Errorf(`posix-mq "path" attribute is invalid: %v"`, path)
+		return fmt.Errorf(`posix-mq "path" attribute is invalid: "%v"`, path)
 	}
 
 	if !cleanSubPath(path) {

--- a/interfaces/builtin/posix_mq_test.go
+++ b/interfaces/builtin/posix_mq_test.go
@@ -643,7 +643,7 @@ func (s *PosixMQInterfaceSuite) TestPathValidationPosixMQ(c *C) {
 func (s *PosixMQInterfaceSuite) TestPathValidationAppArmorRegex(c *C) {
 	spec := &apparmor.Specification{}
 	err := spec.AddPermanentSlot(s.iface, s.testInvalidPath2SlotInfo)
-	c.Check(err, ErrorMatches, `posix-mq "path" attribute is invalid: /test-invalid-2"\["`)
+	c.Check(err, ErrorMatches, `posix-mq "path" attribute is invalid: "/test-invalid-2"\["`)
 }
 
 func (s *PosixMQInterfaceSuite) TestPathStringValidation(c *C) {
@@ -725,7 +725,7 @@ func (s *PosixMQInterfaceSuite) TestSanitizeSlot(c *C) {
 	c.Check(interfaces.BeforePrepareSlot(s.iface, s.testInvalidPath1SlotInfo), ErrorMatches,
 		`posix-mq "path" attribute must conform to the POSIX message queue name specifications \(see "man mq_overview"\): /../../test-invalid`)
 	c.Check(interfaces.BeforePrepareSlot(s.iface, s.testInvalidPath2SlotInfo), ErrorMatches,
-		`posix-mq "path" attribute is invalid: /test-invalid-2"\["`)
+		`posix-mq "path" attribute is invalid: "/test-invalid-2"\["`)
 	c.Check(interfaces.BeforePrepareSlot(s.iface, s.testInvalidPath3SlotInfo), ErrorMatches,
 		`snap "producer" has interface "posix-mq" with invalid value type map\[string\]interface {} for "path" attribute: \*\[\]string`)
 	c.Check(interfaces.BeforePrepareSlot(s.iface, s.testInvalidPath4SlotInfo), ErrorMatches,

--- a/interfaces/builtin/posix_mq_test.go
+++ b/interfaces/builtin/posix_mq_test.go
@@ -69,6 +69,10 @@ slots:
       - /test-array-2
       - /test-array-3
 
+  test-valid-aare:
+    interface: posix-mq
+    path: /test-aare-1*
+
   test-empty-path-array:
     interface: posix-mq
     path: []
@@ -320,6 +324,9 @@ type PosixMQInterfaceSuite struct {
 	testInvalidPath5SlotInfo *snap.SlotInfo
 	testInvalidPath5Slot     *interfaces.ConnectedSlot
 
+	testValidAARESlotInfo *snap.SlotInfo
+	testValidAARESlot     *interfaces.ConnectedSlot
+
 	testInvalidPerms1SlotInfo *snap.SlotInfo
 	testInvalidPerms1Slot     *interfaces.ConnectedSlot
 	testInvalidPerms1PlugInfo *snap.PlugInfo
@@ -367,6 +374,9 @@ func (s *PosixMQInterfaceSuite) SetUpTest(c *C) {
 
 	s.testPathArraySlotInfo = slotSnap.Slots["test-path-array"]
 	s.testPathArraySlot = interfaces.NewConnectedSlot(s.testPathArraySlotInfo, nil, nil)
+
+	s.testValidAARESlotInfo = slotSnap.Slots["test-valid-aare"]
+	s.testValidAARESlot = interfaces.NewConnectedSlot(s.testValidAARESlotInfo, nil, nil)
 
 	s.testEmptyPathArraySlotInfo = slotSnap.Slots["test-empty-path-array"]
 	s.testEmptyPathArraySlot = interfaces.NewConnectedSlot(s.testEmptyPathArraySlotInfo, nil, nil)
@@ -718,6 +728,8 @@ func (s *PosixMQInterfaceSuite) TestSanitizeSlot(c *C) {
 	s.checkSlotPosixMQAttr(c, s.testAllPermsSlotInfo)
 	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.testPathArraySlotInfo), IsNil)
 	s.checkSlotPosixMQAttr(c, s.testPathArraySlotInfo)
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.testValidAARESlotInfo), IsNil)
+	s.checkSlotPosixMQAttr(c, s.testValidAARESlotInfo)
 	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.testLabelSlotInfo), IsNil)
 	c.Check(s.testLabelSlotInfo.Attrs["posix-mq"], Equals, "this-is-a-test-label")
 

--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -120,6 +120,10 @@ endif
 else
 ifeq ($(shell dpkg-vendor --query Vendor),Debian)
     BUILT_USING_PACKAGES=libcap-dev
+    VENDOR_ARGS=--enable-nvidia-multiarch --with-host-arch-triplet=$(DEB_HOST_MULTIARCH)
+ifeq ($(shell dpkg-architecture -qDEB_HOST_ARCH),amd64)
+		VENDOR_ARGS+= --with-host-arch-32bit-triplet=$(shell dpkg-architecture -f -ai386 -qDEB_HOST_MULTIARCH)
+endif
 else
     VENDOR_ARGS=--disable-apparmor
 endif


### PR DESCRIPTION
For a while now, it has not been possible to use zoom, or any other snap which requires working graphics drivers, if you are using the snap on a Debian derived distribution (including Ubuntu), and you use the packaged nVidia drivers.

This pull request both fixes that issue, and provides support for additional features while using the nVidia drivers, including working EGL support, and working libva acceleration support.