### PR TITLE
wrappers: use sorted services for consistent test output

### DIFF
--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -629,7 +629,7 @@ func (es *ensureSnapServicesContext) ensureSnapServiceSystemdUnits(snapInfo *sna
 	}
 
 	// note that the Preseeding option is not used here at all
-	for _, svc := range snapInfo.Services() {
+	for _, svc := range services {
 		// if an inclusion list is provided, then we want to make sure this service
 		// is included.
 		// TODO: add an AppInfo.FullName member


### PR DESCRIPTION
Observed in other PRs that a test was failing due to varying order of generated service units.

We were already sorting the services, just not using the sorted list.

EDIT: Thanks to @MiguelPires, The relevant test is `servicesTestSuite.TestEnsureSnapServicesWithSnapServices`