### PR TITLE
o/snapstate: do not infinitely retry when an update fails during seeding

### DIFF
--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -337,15 +337,6 @@ func (m *SnapManager) installOneBaseOrRequired(t *state.Task, snapName string, c
 	return ts, err
 }
 
-func isSeeded(st *state.State) (bool, error) {
-	var seeded bool
-	err := st.Get("seeded", &seeded)
-	if err != nil && !errors.Is(err, state.ErrNoState) {
-		return false, err
-	}
-	return seeded, nil
-}
-
 // updates a prerequisite, if it's not providing a content interface that a plug expects it to
 func updatePrereqIfOutdated(t *state.Task, snapName string, contentAttrs []string, userID int, flags Flags) (*state.TaskSet, error) {
 	if len(contentAttrs) == 0 {
@@ -380,7 +371,7 @@ func updatePrereqIfOutdated(t *state.Task, snapName string, contentAttrs []strin
 		if conflErr, ok := err.(*ChangeConflictError); ok {
 			// If we aren't seeded, then it's to early to do any updates and we cannot
 			// handle this during seeding, so expect the ChangeConflictError in this scenario.
-			if seeded, err := isSeeded(st); err != nil || !seeded {
+			if conflErr.ChangeKind == "seed" {
 				t.Logf("failed to update %q, will not have required content %q: %s", snapName, strings.Join(contentAttrs, ", "), conflErr)
 				return nil, nil
 			}

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -337,6 +337,15 @@ func (m *SnapManager) installOneBaseOrRequired(t *state.Task, snapName string, c
 	return ts, err
 }
 
+func isSeeded(st *state.State) (bool, error) {
+	var seeded bool
+	err := st.Get("seeded", &seeded)
+	if err != nil && !errors.Is(err, state.ErrNoState) {
+		return false, err
+	}
+	return seeded, nil
+}
+
 // updates a prerequisite, if it's not providing a content interface that a plug expects it to
 func updatePrereqIfOutdated(t *state.Task, snapName string, contentAttrs []string, userID int, flags Flags) (*state.TaskSet, error) {
 	if len(contentAttrs) == 0 {
@@ -369,6 +378,13 @@ func updatePrereqIfOutdated(t *state.Task, snapName string, contentAttrs []strin
 	ts, err := UpdateWithDeviceContext(st, snapName, nil, userID, flags, deviceCtx, "")
 	if err != nil {
 		if conflErr, ok := err.(*ChangeConflictError); ok {
+			// If we aren't seeded, then it's to early to do any updates and we cannot
+			// handle this during seeding, so expect the ChangeConflictError in this scenario.
+			if seeded, err := isSeeded(st); err != nil || !seeded {
+				t.Logf("failed to update %q, will not have required content %q: %s", snapName, strings.Join(contentAttrs, ", "), conflErr)
+				return nil, nil
+			}
+
 			// there's already an update for the same snap in this change,
 			// just skip this one
 			if conflErr.ChangeID == t.Change().ID() {

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -372,7 +372,7 @@ func updatePrereqIfOutdated(t *state.Task, snapName string, contentAttrs []strin
 			// If we aren't seeded, then it's to early to do any updates and we cannot
 			// handle this during seeding, so expect the ChangeConflictError in this scenario.
 			if conflErr.ChangeKind == "seed" {
-				t.Logf("failed to update %q, will not have required content %q: %s", snapName, strings.Join(contentAttrs, ", "), conflErr)
+				t.Logf("cannot update %q during seeding, will not have required content %q: %s", snapName, strings.Join(contentAttrs, ", "), conflErr)
 				return nil, nil
 			}
 
@@ -387,7 +387,7 @@ func updatePrereqIfOutdated(t *state.Task, snapName string, contentAttrs []strin
 
 		// don't propagate error to avoid failing the main install since the
 		// content provider is (for now) a soft dependency
-		t.Logf("failed to update %q, will not have required content %q: %s", snapName, strings.Join(contentAttrs, ", "), err)
+		t.Logf("cannot update %q, will not have required content %q: %s", snapName, strings.Join(contentAttrs, ", "), err)
 		return nil, nil
 	}
 

--- a/overlord/snapstate/handlers_prereq_test.go
+++ b/overlord/snapstate/handlers_prereq_test.go
@@ -820,5 +820,5 @@ func (s *prereqSuite) TestPreReqContentAttrsNotSatisfiedSeeding(c *C) {
 	c.Check(chg.Err(), IsNil)
 	c.Assert(chg.Tasks(), HasLen, 1)
 	c.Assert(chg.Tasks()[0].Log(), HasLen, 1)
-	c.Check(chg.Tasks()[0].Log()[0], testutil.Contains, `too early for operation, device not yet seeded or device model not acknowledged`)
+	c.Check(chg.Tasks()[0].Log()[0], testutil.Contains, `cannot update "some-snap" during seeding, will not have required content "this-does-not-match": too early for operation, device not yet seeded or device model not acknowledged`)
 }

--- a/overlord/snapstate/handlers_prereq_test.go
+++ b/overlord/snapstate/handlers_prereq_test.go
@@ -732,3 +732,93 @@ func (s *prereqSuite) TestDoPrereqSnapdNoRevision(c *C) {
 	c.Check(chg.Status(), Equals, state.ErrorStatus)
 	c.Check(chg.Err(), ErrorMatches, `cannot perform the following tasks:\n.*- test \(cannot install system snap "snapd": no snap revision available as specified\)`)
 }
+
+func (s *prereqSuite) TestPreReqContentAttrsNotSatisfied(c *C) {
+	snapstate.AutoAliases = func(*state.State, *snap.Info) (map[string]string, error) {
+		return nil, nil
+	}
+	s.AddCleanup(func() { snapstate.AutoAliases = nil })
+
+	st := s.state
+	st.Lock()
+
+	// mock the snap which is the default-provider
+	mockInstalledSnap(c, st, `name: some-snap`, false)
+
+	t := s.state.NewTask("prerequisites", "test")
+	t.Set("snap-setup", &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{
+			RealName: "foo",
+			Revision: snap.R(33),
+		},
+		Channel:            "beta",
+		Base:               "core",
+		PrereqContentAttrs: map[string][]string{"some-snap": {"this-does-not-match"}},
+	})
+	chg := s.state.NewChange("sample", "...")
+	chg.AddTask(t)
+	st.Unlock()
+
+	s.se.Ensure()
+	s.se.Wait()
+
+	st.Lock()
+	defer st.Unlock()
+
+	// As we are not seeding, expect no messages being logged for the task. Instead
+	// the update should have added a lot of tasks, so the resulting change should
+	// contain the update for some-snap.
+	c.Check(chg.Err(), IsNil)
+	c.Check(len(chg.Tasks()) > 1, Equals, true)
+
+	// Expect the initial prerequisites task to have completed
+	c.Check(chg.Tasks()[0].Kind(), Equals, "prerequisites")
+	c.Check(chg.Tasks()[0].Status(), Equals, state.DoneStatus)
+	c.Check(chg.Tasks()[0].Log(), HasLen, 0)
+}
+
+func (s *prereqSuite) TestPreReqContentAttrsNotSatisfiedSeeding(c *C) {
+	snapstate.AutoAliases = func(*state.State, *snap.Info) (map[string]string, error) {
+		return nil, nil
+	}
+	s.AddCleanup(func() { snapstate.AutoAliases = nil })
+
+	// mock that we are not seeded
+	r := snapstatetest.MockDeviceModelAndMode(DefaultModel(), "install")
+	defer r()
+
+	st := s.state
+	st.Lock()
+	st.Set("seeded", false)
+
+	// mock the snap which is the default-provider
+	mockInstalledSnap(c, st, `name: some-snap`, false)
+
+	t := s.state.NewTask("prerequisites", "test")
+	t.Set("snap-setup", &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{
+			RealName: "foo",
+			Revision: snap.R(33),
+		},
+		Channel:            "beta",
+		Base:               "core",
+		PrereqContentAttrs: map[string][]string{"some-snap": {"this-does-not-match"}},
+	})
+	chg := s.state.NewChange("sample", "...")
+	chg.AddTask(t)
+	st.Unlock()
+
+	s.se.Ensure()
+	s.se.Wait()
+
+	st.Lock()
+	defer st.Unlock()
+
+	// We expect the change to complete without error, even if updating a snap is not
+	// allowed during seeding. Instead what we expect, is a task log message noting that
+	// updating the snap was not allowed due to the seeding stage.
+	c.Check(chg.Err(), IsNil)
+	c.Assert(chg.Tasks(), HasLen, 1)
+	c.Assert(chg.Tasks()[0].Log(), HasLen, 1)
+	c.Check(chg.Tasks()[0].Log()[0], testutil.Contains, `too early for operation, device not yet seeded or device model not acknowledged`)
+}


### PR DESCRIPTION
During seeding, UpdateWithDeviceContext will fail with a conflict error describing that it is too early to update snaps, as we have not been seeded. Handle this and log that it was not possible, but do not return an error as this will break seeding, also do not return a state.Retry in this case as this will result in an infinite loop which will halt seeding.

This is related to https://github.com/canonical/workshops/issues/32 