### PR TITLE
o/snapstate: remove duplicated refresh checks

### DIFF
--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -599,8 +599,8 @@ var asyncPendingRefreshNotification = func(context context.Context, client *user
 // Internally the snap state is updated to remember when the inhibition first
 // took place. Apps can inhibit refreshes for up to "maxInhibition", beyond
 // that period the refresh will go ahead despite application activity.
-func inhibitRefresh(st *state.State, snapst *SnapState, snapsup *SnapSetup, info *snap.Info, checker func(*snap.Info) error) error {
-	checkerErr := checker(info)
+func inhibitRefresh(st *state.State, snapst *SnapState, snapsup *SnapSetup, info *snap.Info) error {
+	checkerErr := refreshCheck(info)
 	if checkerErr == nil {
 		return nil
 	}

--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -600,7 +600,7 @@ var asyncPendingRefreshNotification = func(context context.Context, client *user
 // took place. Apps can inhibit refreshes for up to "maxInhibition", beyond
 // that period the refresh will go ahead despite application activity.
 func inhibitRefresh(st *state.State, snapst *SnapState, snapsup *SnapSetup, info *snap.Info) error {
-	checkerErr := refreshCheck(info)
+	checkerErr := refreshAppsCheck(info)
 	if checkerErr == nil {
 		return nil
 	}

--- a/overlord/snapstate/autorefresh_test.go
+++ b/overlord/snapstate/autorefresh_test.go
@@ -944,7 +944,7 @@ func (s *autoRefreshTestSuite) TestInitialInhibitRefreshWithinInhibitWindow(c *C
 	}
 	snapsup := &snapstate.SnapSetup{Flags: snapstate.Flags{IsAutoRefresh: true}}
 
-	restore = snapstate.MockRefreshCheck(func(si *snap.Info) error {
+	restore = snapstate.MockRefreshAppsCheck(func(si *snap.Info) error {
 		return snapstate.NewBusySnapError(si, []int{123}, nil, nil)
 	})
 	defer restore()
@@ -980,7 +980,7 @@ func (s *autoRefreshTestSuite) TestSubsequentInhibitRefreshWithinInhibitWindow(c
 	}
 	snapsup := &snapstate.SnapSetup{Flags: snapstate.Flags{IsAutoRefresh: true}}
 
-	restore = snapstate.MockRefreshCheck(func(si *snap.Info) error {
+	restore = snapstate.MockRefreshAppsCheck(func(si *snap.Info) error {
 		return snapstate.NewBusySnapError(si, []int{123}, nil, nil)
 	})
 	defer restore()
@@ -1014,7 +1014,7 @@ func (s *autoRefreshTestSuite) TestInhibitRefreshRefreshesWhenOverdue(c *C) {
 	}
 	snapsup := &snapstate.SnapSetup{Flags: snapstate.Flags{IsAutoRefresh: true}}
 
-	restore = snapstate.MockRefreshCheck(func(si *snap.Info) error {
+	restore = snapstate.MockRefreshAppsCheck(func(si *snap.Info) error {
 		return &snapstate.BusySnapError{SnapInfo: si}
 	})
 	defer restore()
@@ -1045,7 +1045,7 @@ func (s *autoRefreshTestSuite) TestInhibitNoNotificationOnManualRefresh(c *C) {
 	// manual refresh
 	snapsup := &snapstate.SnapSetup{Flags: snapstate.Flags{IsAutoRefresh: false}}
 
-	restore = snapstate.MockRefreshCheck(func(si *snap.Info) error {
+	restore = snapstate.MockRefreshAppsCheck(func(si *snap.Info) error {
 		return &snapstate.BusySnapError{SnapInfo: si}
 	})
 	defer restore()

--- a/overlord/snapstate/autorefresh_test.go
+++ b/overlord/snapstate/autorefresh_test.go
@@ -944,9 +944,12 @@ func (s *autoRefreshTestSuite) TestInitialInhibitRefreshWithinInhibitWindow(c *C
 	}
 	snapsup := &snapstate.SnapSetup{Flags: snapstate.Flags{IsAutoRefresh: true}}
 
-	err := snapstate.InhibitRefresh(s.state, snapst, snapsup, info, func(si *snap.Info) error {
+	restore = snapstate.MockRefreshCheck(func(si *snap.Info) error {
 		return snapstate.NewBusySnapError(si, []int{123}, nil, nil)
 	})
+	defer restore()
+
+	err := snapstate.InhibitRefresh(s.state, snapst, snapsup, info)
 	c.Assert(err, ErrorMatches, `snap "pkg" has running apps or hooks, pids: 123`)
 	c.Check(notificationCount, Equals, 1)
 }
@@ -977,9 +980,12 @@ func (s *autoRefreshTestSuite) TestSubsequentInhibitRefreshWithinInhibitWindow(c
 	}
 	snapsup := &snapstate.SnapSetup{Flags: snapstate.Flags{IsAutoRefresh: true}}
 
-	err := snapstate.InhibitRefresh(s.state, snapst, snapsup, info, func(si *snap.Info) error {
+	restore = snapstate.MockRefreshCheck(func(si *snap.Info) error {
 		return snapstate.NewBusySnapError(si, []int{123}, nil, nil)
 	})
+	defer restore()
+
+	err := snapstate.InhibitRefresh(s.state, snapst, snapsup, info)
 	c.Assert(err, ErrorMatches, `snap "pkg" has running apps or hooks, pids: 123`)
 	c.Check(notificationCount, Equals, 1)
 }
@@ -1008,9 +1014,12 @@ func (s *autoRefreshTestSuite) TestInhibitRefreshRefreshesWhenOverdue(c *C) {
 	}
 	snapsup := &snapstate.SnapSetup{Flags: snapstate.Flags{IsAutoRefresh: true}}
 
-	err := snapstate.InhibitRefresh(s.state, snapst, snapsup, info, func(si *snap.Info) error {
+	restore = snapstate.MockRefreshCheck(func(si *snap.Info) error {
 		return &snapstate.BusySnapError{SnapInfo: si}
 	})
+	defer restore()
+
+	err := snapstate.InhibitRefresh(s.state, snapst, snapsup, info)
 	c.Assert(err, IsNil)
 	c.Check(notificationCount, Equals, 1)
 }
@@ -1036,8 +1045,11 @@ func (s *autoRefreshTestSuite) TestInhibitNoNotificationOnManualRefresh(c *C) {
 	// manual refresh
 	snapsup := &snapstate.SnapSetup{Flags: snapstate.Flags{IsAutoRefresh: false}}
 
-	err := snapstate.InhibitRefresh(s.state, snapst, snapsup, info, func(si *snap.Info) error {
+	restore = snapstate.MockRefreshCheck(func(si *snap.Info) error {
 		return &snapstate.BusySnapError{SnapInfo: si}
 	})
+	defer restore()
+
+	err := snapstate.InhibitRefresh(s.state, snapst, snapsup, info)
 	c.Assert(err, IsNil)
 }

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -333,10 +333,10 @@ func NewBusySnapError(info *snap.Info, pids []int, busyAppNames, busyHookNames [
 	}
 }
 
-func MockGenericRefreshCheck(fn func(info *snap.Info, canAppRunDuringRefresh func(app *snap.AppInfo) bool) error) (restore func()) {
-	old := genericRefreshCheck
-	genericRefreshCheck = fn
-	return func() { genericRefreshCheck = old }
+func MockRefreshCheck(fn func(info *snap.Info) error) (restore func()) {
+	old := refreshCheck
+	refreshCheck = fn
+	return func() { refreshCheck = old }
 }
 
 func (m *autoRefresh) EnsureRefreshHoldAtLeast(d time.Duration) error {
@@ -363,6 +363,7 @@ var (
 	CreateGateAutoRefreshHooks = createGateAutoRefreshHooks
 	AutoRefreshPhase1          = autoRefreshPhase1
 	RefreshRetain              = refreshRetain
+	RefreshCheck               = refreshCheck
 
 	ExcludeFromRefreshAppAwareness = excludeFromRefreshAppAwareness
 )

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -333,10 +333,10 @@ func NewBusySnapError(info *snap.Info, pids []int, busyAppNames, busyHookNames [
 	}
 }
 
-func MockRefreshCheck(fn func(info *snap.Info) error) (restore func()) {
-	old := refreshCheck
-	refreshCheck = fn
-	return func() { refreshCheck = old }
+func MockRefreshAppsCheck(fn func(info *snap.Info) error) (restore func()) {
+	old := refreshAppsCheck
+	refreshAppsCheck = fn
+	return func() { refreshAppsCheck = old }
 }
 
 func (m *autoRefresh) EnsureRefreshHoldAtLeast(d time.Duration) error {
@@ -363,7 +363,7 @@ var (
 	CreateGateAutoRefreshHooks = createGateAutoRefreshHooks
 	AutoRefreshPhase1          = autoRefreshPhase1
 	RefreshRetain              = refreshRetain
-	RefreshCheck               = refreshCheck
+	RefreshCheck               = refreshAppsCheck
 
 	ExcludeFromRefreshAppAwareness = excludeFromRefreshAppAwareness
 )

--- a/overlord/snapstate/refresh.go
+++ b/overlord/snapstate/refresh.go
@@ -38,7 +38,9 @@ import (
 // pidsOfSnap is a mockable version of PidsOfSnap
 var pidsOfSnap = cgroup.PidsOfSnap
 
-var genericRefreshCheck = func(info *snap.Info, canAppRunDuringRefresh func(app *snap.AppInfo) bool) error {
+// refreshCheck returns an error if the snap has processes running that aren't
+// services and aren't marked to be ignored (refresh-mode: "ignore-running").
+var refreshCheck = func(info *snap.Info) error {
 	knownPids, err := pidsOfSnap(info.InstanceName())
 	if err != nil {
 		return err
@@ -57,7 +59,7 @@ var genericRefreshCheck = func(info *snap.Info, canAppRunDuringRefresh func(app 
 	}
 
 	for name, app := range info.Apps {
-		if canAppRunDuringRefresh(app) {
+		if app.IsService() || app.RefreshMode == "ignore-running" {
 			continue
 		}
 		if PIDs := knownPids[app.SecurityTag()]; len(PIDs) > 0 {
@@ -87,46 +89,6 @@ var genericRefreshCheck = func(info *snap.Info, canAppRunDuringRefresh func(app 
 		busyHookNames: busyHookNames,
 		pids:          busyPIDs,
 	}
-}
-
-// SoftNothingRunningRefreshCheck looks if there are at most only service processes alive.
-//
-// The check is designed to run early in the refresh pipeline. Before
-// downloading or stopping services for the update, we can check that only
-// services or snaps that explicitly allow refreshes are running, that is,
-// that no non-service apps or hooks are currently running.
-//
-// Since services are stopped during the update this provides a good early
-// precondition check. The check is also deliberately racy as existing snap
-// commands can fork new processes or existing processes can die. After the
-// soft check passes the user is free to start snap applications and block the
-// hard check.
-//
-// Apart from ignoring services, the check allows apps that want not to
-// block refresh to continue executing.
-func SoftNothingRunningRefreshCheck(info *snap.Info) error {
-	return genericRefreshCheck(info, func(app *snap.AppInfo) bool {
-		return app.IsService() || app.RefreshMode == "ignore-running"
-	})
-}
-
-// HardNothingRunningRefreshCheck looks if there are any undesired processes alive.
-//
-// The check is designed to run late in the refresh pipeline, after stopping
-// snap services. At this point non-enduring services should be stopped, hooks
-// should no longer run, and applications should be barred from running
-// externally (e.g. by using a new inhibition mechanism for snap run).
-//
-// The check fails if any process belonging to the snap, apart from services
-// and snaps that explicitly allow refreshes, is still alive. If a snap is busy
-// it cannot be refreshed and the refresh process is aborted.
-//
-// Apart from ignoring services, the check allows apps that want not to
-// block refresh to continue executing.
-func HardNothingRunningRefreshCheck(info *snap.Info) error {
-	return genericRefreshCheck(info, func(app *snap.AppInfo) bool {
-		return app.IsService() || app.RefreshMode == "ignore-running"
-	})
 }
 
 // BusySnapError indicates that snap has apps or hooks running and cannot refresh.
@@ -192,9 +154,10 @@ func (err BusySnapError) Pids() []int {
 
 // hardEnsureNothingRunningDuringRefresh performs the complete hard refresh interaction.
 //
-// This check uses HardNothingRunningRefreshCheck along with interaction with
-// two locks - the snap lock, shared by snap-confine and snapd and the snap run
-// inhibition lock, shared by snapd and snap run.
+// The check is designed to run late in the refresh pipeline, after stopping
+// snap services. At this point non-enduring services should be stopped, hooks
+// should no longer run, and applications should be barred from running
+// externally (e.g. by using a new inhibition mechanism for snap run).
 //
 // On success this function returns a locked snap lock, allowing the caller to
 // atomically, with regards to "snap-confine", finish any action that required
@@ -210,16 +173,17 @@ func hardEnsureNothingRunningDuringRefresh(backend managerBackend, st *state.Sta
 		// to indicate when the refresh was first inhibited. If the first
 		// refresh inhibition is outside of a grace period then refresh
 		// proceeds regardless of the existing processes.
-		return inhibitRefresh(st, snapst, snapsup, info, HardNothingRunningRefreshCheck)
+		return inhibitRefresh(st, snapst, snapsup, info)
 	})
 }
 
 // softCheckNothingRunningForRefresh checks if non-service apps are off for a snap refresh.
 //
-// The details of the check are explained by SoftNothingRunningRefreshCheck.
-// The check is performed while holding the snap lock, which ensures that we
-// are not racing with snap-confine, which is starting a new process in the
-// context of the given snap.
+// The check is designed to run early in the refresh pipeline. Before downloading
+// or stopping services for the update, that is, that no non-service apps or hooks
+// are currently running. This checks if a non-service and non-ignored snap is
+// running  while holding the snap lock, which ensures that we are not racing with
+// snap-confine, which is starting a new process in the context of the given snap.
 //
 // In the case that the check fails, the state is modified to reflect when the
 // refresh was first postponed. Eventually the check does not fail, even if
@@ -233,6 +197,6 @@ func softCheckNothingRunningForRefresh(st *state.State, snapst *SnapState, snaps
 	return backend.WithSnapLock(info, func() error {
 		// Perform the soft refresh viability check, possibly writing to the state
 		// on failure.
-		return inhibitRefresh(st, snapst, snapsup, info, SoftNothingRunningRefreshCheck)
+		return inhibitRefresh(st, snapst, snapsup, info)
 	})
 }

--- a/overlord/snapstate/refresh.go
+++ b/overlord/snapstate/refresh.go
@@ -38,9 +38,9 @@ import (
 // pidsOfSnap is a mockable version of PidsOfSnap
 var pidsOfSnap = cgroup.PidsOfSnap
 
-// refreshCheck returns an error if the snap has processes running that aren't
+// refreshAppsCheck returns an error if the snap has processes running that aren't
 // services and aren't marked to be ignored (refresh-mode: "ignore-running").
-var refreshCheck = func(info *snap.Info) error {
+var refreshAppsCheck = func(info *snap.Info) error {
 	knownPids, err := pidsOfSnap(info.InstanceName())
 	if err != nil {
 		return err

--- a/overlord/snapstate/refresh_test.go
+++ b/overlord/snapstate/refresh_test.go
@@ -69,13 +69,13 @@ hooks:
 	s.state = state.New(nil)
 }
 
-func (s *refreshSuite) TestSoftNothingRunningRefreshCheck(c *C) {
+func (s *refreshSuite) TestRefreshCheck(c *C) {
 	// Services are not blocking soft refresh check,
 	// they will be stopped before refresh.
 	s.pids = map[string][]int{
 		"snap.pkg.daemon": {100},
 	}
-	err := snapstate.SoftNothingRunningRefreshCheck(s.info)
+	err := snapstate.RefreshCheck(s.info)
 	c.Check(err, IsNil)
 
 	// Apps are blocking soft refresh check. They are not stopped by
@@ -85,14 +85,14 @@ func (s *refreshSuite) TestSoftNothingRunningRefreshCheck(c *C) {
 		"snap.pkg.daemon": {100},
 		"snap.pkg.app":    {101},
 	}
-	err = snapstate.SoftNothingRunningRefreshCheck(s.info)
+	err = snapstate.RefreshCheck(s.info)
 	c.Assert(err, NotNil)
 	c.Check(err.Error(), Equals, `snap "pkg" has running apps (app), pids: 101`)
 	c.Check(err.(*snapstate.BusySnapError).Pids(), DeepEquals, []int{101})
 
 	// Unless refresh-mode is set to "ignore-running"
 	s.info.Apps["app"].RefreshMode = "ignore-running"
-	err = snapstate.SoftNothingRunningRefreshCheck(s.info)
+	err = snapstate.RefreshCheck(s.info)
 	c.Assert(err, IsNil)
 	s.info.Apps["app"].RefreshMode = ""
 
@@ -101,7 +101,7 @@ func (s *refreshSuite) TestSoftNothingRunningRefreshCheck(c *C) {
 	s.pids = map[string][]int{
 		"snap.pkg.hook.configure": {105},
 	}
-	err = snapstate.SoftNothingRunningRefreshCheck(s.info)
+	err = snapstate.RefreshCheck(s.info)
 	c.Assert(err, NotNil)
 	c.Check(err.Error(), Equals, `snap "pkg" has running hooks (configure), pids: 105`)
 	c.Check(err.(*snapstate.BusySnapError).Pids(), DeepEquals, []int{105})
@@ -111,51 +111,10 @@ func (s *refreshSuite) TestSoftNothingRunningRefreshCheck(c *C) {
 		"snap.pkg.hook.configure": {105},
 		"snap.pkg.app":            {106},
 	}
-	err = snapstate.SoftNothingRunningRefreshCheck(s.info)
+	err = snapstate.RefreshCheck(s.info)
 	c.Assert(err, NotNil)
 	c.Check(err.Error(), Equals, `snap "pkg" has running apps (app) and hooks (configure), pids: 105,106`)
 	c.Check(err.(*snapstate.BusySnapError).Pids(), DeepEquals, []int{105, 106})
-}
-
-func (s *refreshSuite) TestHardNothingRunningRefreshCheck(c *C) {
-	// Services are ignored by hard refresh check.
-	s.pids = map[string][]int{
-		"snap.pkg.daemon": {100},
-	}
-	err := snapstate.HardNothingRunningRefreshCheck(s.info)
-	c.Assert(err, IsNil)
-
-	// When the service is supposed to endure refreshes it will not be
-	// stopped. As such such services cannot block refresh.
-	s.info.Apps["daemon"].RefreshMode = "endure"
-	err = snapstate.HardNothingRunningRefreshCheck(s.info)
-	c.Check(err, IsNil)
-	s.info.Apps["daemon"].RefreshMode = ""
-
-	// Applications are also blocking hard refresh check.
-	s.pids = map[string][]int{
-		"snap.pkg.app": {101},
-	}
-	err = snapstate.HardNothingRunningRefreshCheck(s.info)
-	c.Assert(err, NotNil)
-	c.Check(err.Error(), Equals, `snap "pkg" has running apps (app), pids: 101`)
-	c.Assert(err, FitsTypeOf, &snapstate.BusySnapError{})
-	c.Check(err.(*snapstate.BusySnapError).Pids(), DeepEquals, []int{101})
-
-	// Unless refresh-mode is set to "ignore-running"
-	s.info.Apps["app"].RefreshMode = "ignore-running"
-	err = snapstate.HardNothingRunningRefreshCheck(s.info)
-	c.Assert(err, IsNil)
-	s.info.Apps["app"].RefreshMode = ""
-
-	// Hooks are equally blocking hard refresh check.
-	s.pids = map[string][]int{
-		"snap.pkg.hook.configure": {105},
-	}
-	err = snapstate.HardNothingRunningRefreshCheck(s.info)
-	c.Assert(err, NotNil)
-	c.Check(err.Error(), Equals, `snap "pkg" has running hooks (configure), pids: 105`)
-	c.Check(err.(*snapstate.BusySnapError).Pids(), DeepEquals, []int{105})
 }
 
 func (s *refreshSuite) TestPendingSnapRefreshInfo(c *C) {
@@ -205,7 +164,7 @@ func (s *refreshSuite) TestDoSoftRefreshCheckAllowed(c *C) {
 	snapsup := &snapstate.SnapSetup{Flags: snapstate.Flags{IsAutoRefresh: true}}
 
 	// Pretend that snaps can refresh normally.
-	restore := snapstate.MockGenericRefreshCheck(func(info *snap.Info, canAppRunDuringRefresh func(app *snap.AppInfo) bool) error {
+	restore := snapstate.MockRefreshCheck(func(info *snap.Info) error {
 		return nil
 	})
 	defer restore()
@@ -228,7 +187,7 @@ func (s *refreshSuite) TestDoSoftRefreshCheckDisallowed(c *C) {
 	snapsup := &snapstate.SnapSetup{Flags: snapstate.Flags{IsAutoRefresh: true}}
 
 	// Pretend that snaps cannot refresh.
-	restore := snapstate.MockGenericRefreshCheck(func(info *snap.Info, canAppRunDuringRefresh func(app *snap.AppInfo) bool) error {
+	restore := snapstate.MockRefreshCheck(func(info *snap.Info) error {
 		return snapstate.NewBusySnapError(info, []int{123}, nil, nil)
 	})
 	defer restore()
@@ -252,7 +211,7 @@ func (s *refreshSuite) TestDoHardRefreshFlowRefreshAllowed(c *C) {
 	snapsup := &snapstate.SnapSetup{Flags: snapstate.Flags{IsAutoRefresh: true}}
 
 	// Pretend that snaps can refresh normally.
-	restore := snapstate.MockGenericRefreshCheck(func(info *snap.Info, canAppRunDuringRefresh func(app *snap.AppInfo) bool) error {
+	restore := snapstate.MockRefreshCheck(func(info *snap.Info) error {
 		return nil
 	})
 	defer restore()
@@ -281,7 +240,7 @@ func (s *refreshSuite) TestDoHardRefreshFlowRefreshDisallowed(c *C) {
 	snapsup := &snapstate.SnapSetup{Flags: snapstate.Flags{IsAutoRefresh: true}}
 
 	// Pretend that snaps cannot refresh.
-	restore := snapstate.MockGenericRefreshCheck(func(info *snap.Info, canAppRunDuringRefresh func(app *snap.AppInfo) bool) error {
+	restore := snapstate.MockRefreshCheck(func(info *snap.Info) error {
 		return snapstate.NewBusySnapError(info, []int{123}, nil, nil)
 	})
 	defer restore()

--- a/overlord/snapstate/refresh_test.go
+++ b/overlord/snapstate/refresh_test.go
@@ -164,7 +164,7 @@ func (s *refreshSuite) TestDoSoftRefreshCheckAllowed(c *C) {
 	snapsup := &snapstate.SnapSetup{Flags: snapstate.Flags{IsAutoRefresh: true}}
 
 	// Pretend that snaps can refresh normally.
-	restore := snapstate.MockRefreshCheck(func(info *snap.Info) error {
+	restore := snapstate.MockRefreshAppsCheck(func(info *snap.Info) error {
 		return nil
 	})
 	defer restore()
@@ -187,7 +187,7 @@ func (s *refreshSuite) TestDoSoftRefreshCheckDisallowed(c *C) {
 	snapsup := &snapstate.SnapSetup{Flags: snapstate.Flags{IsAutoRefresh: true}}
 
 	// Pretend that snaps cannot refresh.
-	restore := snapstate.MockRefreshCheck(func(info *snap.Info) error {
+	restore := snapstate.MockRefreshAppsCheck(func(info *snap.Info) error {
 		return snapstate.NewBusySnapError(info, []int{123}, nil, nil)
 	})
 	defer restore()
@@ -211,7 +211,7 @@ func (s *refreshSuite) TestDoHardRefreshFlowRefreshAllowed(c *C) {
 	snapsup := &snapstate.SnapSetup{Flags: snapstate.Flags{IsAutoRefresh: true}}
 
 	// Pretend that snaps can refresh normally.
-	restore := snapstate.MockRefreshCheck(func(info *snap.Info) error {
+	restore := snapstate.MockRefreshAppsCheck(func(info *snap.Info) error {
 		return nil
 	})
 	defer restore()
@@ -240,7 +240,7 @@ func (s *refreshSuite) TestDoHardRefreshFlowRefreshDisallowed(c *C) {
 	snapsup := &snapstate.SnapSetup{Flags: snapstate.Flags{IsAutoRefresh: true}}
 
 	// Pretend that snaps cannot refresh.
-	restore := snapstate.MockRefreshCheck(func(info *snap.Info) error {
+	restore := snapstate.MockRefreshAppsCheck(func(info *snap.Info) error {
 		return snapstate.NewBusySnapError(info, []int{123}, nil, nil)
 	})
 	defer restore()


### PR DESCRIPTION
Remove the soft and hard check functions which have grown into the same check (`app.IsService() || app.RefreshMode == "ignore-running"`). Since these were being passed into a function which was itself called in a lambda passed into different locking functions, this also simplifies the logic surround the refresh checks.