### PR TITLE
interfaces: bluez: allow file descriptors to be shared via dbus

### DIFF
--- a/interfaces/builtin/bluez.go
+++ b/interfaces/builtin/bluez.go
@@ -147,6 +147,9 @@ const bluezConnectedSlotAppArmor = `
 dbus (receive, send)
     bus=system
     peer=(label=###PLUG_SECURITY_TAGS###),
+
+# Allow sharing file descriptors (via DBus)
+unix (send,receive) type="seqpacket" addr=none peer=(addr=none label=###PLUG_SECURITY_TAGS###),
 `
 
 const bluezConnectedPlugAppArmor = `
@@ -186,6 +189,9 @@ dbus (receive)
 
 # Allow access to bluetooth audio streams
 network bluetooth,
+
+# Allow use of shared (via DBus) file descriptors
+unix (send, receive) type="seqpacket" addr=none peer=(addr=none label=###SLOT_SECURITY_TAGS###),
 `
 
 const bluezPermanentSlotSecComp = `


### PR DESCRIPTION
The bluetooth stack implements a way to circumvent the bluez socket and instead communicate over DBus to share a file descriptor between two different process IDs. This apparmor rule allows such file descriptor exchanging to be allowed.

Signed-off-by: Dilyn Corner <dilyn.corner@canonical.com>

Rule was created by Tony Espy after some discussions with John Johansen. 

Essentially, there are some useful rust bindings provided by bluer, a crate providing official rust bindings for bluez. It implements two methods which have the value-add of decreasing latency when interacting with devices connected over BLE. What this amounts to is directly passing a particular file descriptor from one process to another. The added rules should be scoped narrowly enough such that one would have the minimum permissions to communicate over the relevant socket.

I've tested this on a snap I have which hosts a GATT server to connect to some client device, and with this rule added the snap behaves as expected.