### PR TITLE
o/configstate: add Task() method to config.Conf interface

### DIFF
--- a/overlord/configstate/config/helpers.go
+++ b/overlord/configstate/config/helpers.go
@@ -291,6 +291,7 @@ type Conf interface {
 	Get(snapName, key string, result interface{}) error
 	GetMaybe(snapName, key string, result interface{}) error
 	GetPristine(snapName, key string, result interface{}) error
+	Task() *state.Task
 	Set(snapName, key string, value interface{}) error
 	Changes() []string
 	State() *state.State

--- a/overlord/configstate/config/helpers_test.go
+++ b/overlord/configstate/config/helpers_test.go
@@ -327,12 +327,12 @@ func (s *configHelpersSuite) TestPatch(c *C) {
 		"a.b2": map[string]interface{}{"c": "C"},
 	}
 
-	tr := config.NewTransaction(s.state)
-	err := config.Patch(tr, "some-snap", patch)
+	rt := config.NewRunTransaction(config.NewTransaction(s.state), nil)
+	err := config.Patch(rt, "some-snap", patch)
 	c.Assert(err, IsNil)
 
 	var a map[string]interface{}
-	err = tr.Get("some-snap", "a", &a)
+	err = rt.Get("some-snap", "a", &a)
 	c.Check(err, IsNil)
 
 	c.Check(a, DeepEquals, map[string]interface{}{

--- a/overlord/configstate/config/transaction.go
+++ b/overlord/configstate/config/transaction.go
@@ -46,6 +46,23 @@ type Transaction struct {
 	changes  map[string]map[string]interface{}
 }
 
+// RunTransaction holds a transaction with a task that is in charge of
+// appliying a change to the configuration. It is used in the context of
+// configcore.
+type RunTransaction struct {
+	*Transaction
+	task *state.Task
+}
+
+func (rt *RunTransaction) Task() *state.Task {
+	return rt.task
+}
+
+func NewRunTransaction(tr *Transaction, tk *state.Task) *RunTransaction {
+	runTransaction := &RunTransaction{Transaction: tr, task: tk}
+	return runTransaction
+}
+
 // NewTransaction creates a new configuration transaction initialized with the given state.
 //
 // The provided state must be locked by the caller.

--- a/overlord/configstate/configcore/corecfg_test.go
+++ b/overlord/configstate/configcore/corecfg_test.go
@@ -45,6 +45,7 @@ type mockConf struct {
 	conf    map[string]interface{}
 	changes map[string]interface{}
 	err     error
+	task    *state.Task
 }
 
 func (cfg *mockConf) Get(snapName, key string, result interface{}) error {
@@ -94,6 +95,10 @@ func (cfg *mockConf) GetPristineMaybe(snapName, key string, result interface{}) 
 		return err
 	}
 	return nil
+}
+
+func (cfg *mockConf) Task() *state.Task {
+	return cfg.task
 }
 
 func (cfg *mockConf) Set(snapName, key string, v interface{}) error {

--- a/overlord/configstate/configcore/netplan_test.go
+++ b/overlord/configstate/configcore/netplan_test.go
@@ -304,11 +304,12 @@ func (s *netplanSuite) TestNetplanWriteConfigSetReturnsFalse(c *C) {
 	s.backend.ConfigApiCancelRet = true
 
 	s.state.Lock()
-	tr := config.NewTransaction(s.state)
-	s.state.Unlock()
-	tr.Set("core", "system.network.netplan.network.ethernets.eth0.dhcp4", true)
+	rt := config.NewRunTransaction(config.NewTransaction(s.state), nil)
 
-	err := configcore.Run(coreDev, tr)
+	s.state.Unlock()
+	rt.Set("core", "system.network.netplan.network.ethernets.eth0.dhcp4", true)
+
+	err := configcore.Run(coreDev, rt)
 	c.Assert(err, ErrorMatches, "cannot set netplan config: no specific reason returned from netplan")
 }
 
@@ -319,11 +320,11 @@ func (s *netplanSuite) TestNetplanWriteConfigSetFailsDBusErr(c *C) {
 	s.backend.ConfigApiSetErr = dbus.MakeFailedError(fmt.Errorf("netplan failed with some error"))
 
 	s.state.Lock()
-	tr := config.NewTransaction(s.state)
+	rt := config.NewRunTransaction(config.NewTransaction(s.state), nil)
 	s.state.Unlock()
-	tr.Set("core", "system.network.netplan.network.ethernets.eth0.dhcp4", true)
+	rt.Set("core", "system.network.netplan.network.ethernets.eth0.dhcp4", true)
 
-	err := configcore.Run(coreDev, tr)
+	err := configcore.Run(coreDev, rt)
 	c.Assert(err, ErrorMatches, "cannot set netplan config: netplan failed with some error")
 }
 
@@ -334,11 +335,11 @@ func (s *netplanSuite) TestNetplanWriteConfigTryReturnsFalse(c *C) {
 	s.backend.ConfigApiCancelRet = true
 
 	s.state.Lock()
-	tr := config.NewTransaction(s.state)
+	rt := config.NewRunTransaction(config.NewTransaction(s.state), nil)
 	s.state.Unlock()
-	tr.Set("core", "system.network.netplan.network.ethernets.eth0.dhcp4", true)
+	rt.Set("core", "system.network.netplan.network.ethernets.eth0.dhcp4", true)
 
-	err := configcore.Run(coreDev, tr)
+	err := configcore.Run(coreDev, rt)
 	c.Assert(err, ErrorMatches, "cannot try netplan config: no specific reason returned from netplan")
 }
 
@@ -349,11 +350,11 @@ func (s *netplanSuite) TestNetplanWriteConfigTryFailsDBusErr(c *C) {
 	s.backend.ConfigApiCancelRet = true
 
 	s.state.Lock()
-	tr := config.NewTransaction(s.state)
+	rt := config.NewRunTransaction(config.NewTransaction(s.state), nil)
 	s.state.Unlock()
-	tr.Set("core", "system.network.netplan.network.ethernets.eth0.dhcp4", true)
+	rt.Set("core", "system.network.netplan.network.ethernets.eth0.dhcp4", true)
 
-	err := configcore.Run(coreDev, tr)
+	err := configcore.Run(coreDev, rt)
 	c.Assert(err, ErrorMatches, "cannot try netplan config: netplan failed with some error")
 }
 
@@ -380,12 +381,12 @@ func (s *netplanSuite) testNetplanWriteConfigHappy(c *C, seeded bool, expectedOr
 	s.backend.ConfigApiApplyRet = true
 
 	s.state.Lock()
-	tr := config.NewTransaction(s.state)
+	rt := config.NewRunTransaction(config.NewTransaction(s.state), nil)
 	s.state.Unlock()
-	tr.Set("core", "system.network.netplan.network.ethernets.eth0.dhcp4", true)
-	tr.Set("core", "system.network.netplan.network.wifi.wlan0.dhcp4", true)
+	rt.Set("core", "system.network.netplan.network.ethernets.eth0.dhcp4", true)
+	rt.Set("core", "system.network.netplan.network.wifi.wlan0.dhcp4", true)
 
-	err := configcore.Run(coreDev, tr)
+	err := configcore.Run(coreDev, rt)
 	c.Assert(err, IsNil)
 
 	c.Check(s.backend.ConfigApiSetCalls, DeepEquals, []string{
@@ -408,12 +409,12 @@ func (s *netplanSuite) TestNetplanApplyConfigFails(c *C) {
 	s.backend.ConfigApiApplyRet = false
 
 	s.state.Lock()
-	tr := config.NewTransaction(s.state)
+	rt := config.NewRunTransaction(config.NewTransaction(s.state), nil)
 	s.state.Unlock()
-	tr.Set("core", "system.network.netplan.network.ethernets.eth0.dhcp4", true)
-	tr.Set("core", "system.network.netplan.network.wifi.wlan0.dhcp4", true)
+	rt.Set("core", "system.network.netplan.network.ethernets.eth0.dhcp4", true)
+	rt.Set("core", "system.network.netplan.network.wifi.wlan0.dhcp4", true)
 
-	err := configcore.Run(coreDev, tr)
+	err := configcore.Run(coreDev, rt)
 	c.Assert(err, ErrorMatches, "cannot apply netplan config: no specific reason returned from netplan")
 }
 
@@ -429,12 +430,12 @@ func (s *netplanSuite) TestNetplanApplyConfigErr(c *C) {
 	s.backend.ConfigApiApplyErr = dbus.MakeFailedError(fmt.Errorf("netplan failed with some error"))
 
 	s.state.Lock()
-	tr := config.NewTransaction(s.state)
+	rt := config.NewRunTransaction(config.NewTransaction(s.state), nil)
 	s.state.Unlock()
-	tr.Set("core", "system.network.netplan.network.ethernets.eth0.dhcp4", true)
-	tr.Set("core", "system.network.netplan.network.wifi.wlan0.dhcp4", true)
+	rt.Set("core", "system.network.netplan.network.ethernets.eth0.dhcp4", true)
+	rt.Set("core", "system.network.netplan.network.wifi.wlan0.dhcp4", true)
 
-	err := configcore.Run(coreDev, tr)
+	err := configcore.Run(coreDev, rt)
 	c.Assert(err, ErrorMatches, "cannot apply netplan config: netplan failed with some error")
 }
 
@@ -458,11 +459,11 @@ func (s *netplanSuite) TestNetplanWriteConfigNoNetworkAfterTry(c *C) {
 	s.backend.ConfigApiCancelRet = true
 
 	s.state.Lock()
-	tr := config.NewTransaction(s.state)
+	rt := config.NewRunTransaction(config.NewTransaction(s.state), nil)
 	s.state.Unlock()
-	tr.Set("core", "system.network.netplan.ethernets.eth0.dhcp4", true)
+	rt.Set("core", "system.network.netplan.ethernets.eth0.dhcp4", true)
 
-	err := configcore.Run(coreDev, tr)
+	err := configcore.Run(coreDev, rt)
 	c.Assert(err, ErrorMatches, `cannot set netplan config: store no longer reachable`)
 
 	c.Check(s.backend.ConfigApiTryCalls, Equals, 1)
@@ -489,11 +490,11 @@ func (s *netplanSuite) TestNetplanWriteConfigCancelFails(c *C) {
 	s.backend.ConfigApiCancelRet = false
 
 	s.state.Lock()
-	tr := config.NewTransaction(s.state)
+	rt := config.NewRunTransaction(config.NewTransaction(s.state), nil)
 	s.state.Unlock()
-	tr.Set("core", "system.network.netplan.ethernets.eth0.dhcp4", true)
+	rt.Set("core", "system.network.netplan.ethernets.eth0.dhcp4", true)
 
-	err := configcore.Run(coreDev, tr)
+	err := configcore.Run(coreDev, rt)
 	c.Assert(err, ErrorMatches, `cannot set netplan config: store no longer reachable and cannot cancel netplan config: no specific reason returned from netplan`)
 }
 
@@ -515,11 +516,11 @@ func (s *netplanSuite) TestNetplanWriteConfigCancelFailsWithDbusErr(c *C) {
 	s.backend.ConfigApiCancelErr = dbus.MakeFailedError(fmt.Errorf("netplan failed with some error"))
 
 	s.state.Lock()
-	tr := config.NewTransaction(s.state)
+	rt := config.NewRunTransaction(config.NewTransaction(s.state), nil)
 	s.state.Unlock()
-	tr.Set("core", "system.network.netplan.ethernets.eth0.dhcp4", true)
+	rt.Set("core", "system.network.netplan.ethernets.eth0.dhcp4", true)
 
-	err := configcore.Run(coreDev, tr)
+	err := configcore.Run(coreDev, rt)
 	c.Assert(err, ErrorMatches, `cannot set netplan config: store no longer reachable and cannot cancel netplan config: netplan failed with some error`)
 }
 
@@ -544,11 +545,11 @@ network:
 	// we cannot use mockConf because we need the external config
 	// integration from the config.Transaction
 	s.state.Lock()
-	tr := config.NewTransaction(s.state)
+	rt := config.NewRunTransaction(config.NewTransaction(s.state), nil)
 	s.state.Unlock()
-	tr.Set("core", "system.network.netplan.network.bridges.br54.dhcp4", nil)
+	rt.Set("core", "system.network.netplan.network.bridges.br54.dhcp4", nil)
 
-	err := configcore.Run(coreDev, tr)
+	err := configcore.Run(coreDev, rt)
 	c.Assert(err, IsNil)
 
 	c.Check(s.backend.ConfigApiSetCalls, DeepEquals, []string{

--- a/overlord/configstate/configmgr.go
+++ b/overlord/configstate/configmgr.go
@@ -58,7 +58,8 @@ func Init(st *state.State, hookManager *hookstate.HookManager) error {
 			if err != nil {
 				return nil, nil, err
 			}
-			return dev, ContextTransaction(ctx), nil
+			rt := config.NewRunTransaction(ContextTransaction(ctx), task)
+			return dev, rt, nil
 		}()
 		if err != nil {
 			return err

--- a/overlord/configstate/configstate.go
+++ b/overlord/configstate/configstate.go
@@ -168,9 +168,10 @@ func EarlyConfig(st *state.State, preloadGadget func() (sysconfig.Device, *gadge
 	if err != nil {
 		return err
 	}
-	tr := config.NewTransaction(st)
+	// No task is associated to the transaction if it is an early config
+	rt := config.NewRunTransaction(config.NewTransaction(st), nil)
 	if configed {
-		if err := configcoreExportExperimentalFlags(tr); err != nil {
+		if err := configcoreExportExperimentalFlags(rt); err != nil {
 			return fmt.Errorf("cannot export experimental config flags: %v", err)
 		}
 		return nil
@@ -185,10 +186,10 @@ func EarlyConfig(st *state.State, preloadGadget func() (sysconfig.Device, *gadge
 			return err
 		}
 		values := gadget.SystemDefaults(gi.Defaults)
-		if err := configcoreEarly(dev, tr, values); err != nil {
+		if err := configcoreEarly(dev, rt, values); err != nil {
 			return err
 		}
-		tr.Commit()
+		rt.Commit()
 	}
 	return nil
 }

--- a/overlord/configstate/hooks.go
+++ b/overlord/configstate/hooks.go
@@ -73,7 +73,8 @@ func (h *configureHandler) Before() error {
 	h.context.Lock()
 	defer h.context.Unlock()
 
-	tr := ContextTransaction(h.context)
+	task, _ := h.context.Task()
+	rt := config.NewRunTransaction(ContextTransaction(h.context), task)
 
 	// Initialize the transaction if there's a patch provided in the
 	// context or useDefaults is set in which case gadget defaults are used.
@@ -115,7 +116,7 @@ func (h *configureHandler) Before() error {
 		}
 	}
 
-	if err := config.Patch(tr, instanceName, patch); err != nil {
+	if err := config.Patch(rt, instanceName, patch); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
The new Task() method lets configcore handlers access and modify the hook task/change in case it is needed to add new tasks.
