### PR TITLE
cmd/snap: make local snap detection simpler and more permissive

### DIFF
--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -556,7 +556,7 @@ func (x *cmdInstall) installOne(nameOrPath, desiredName string, opts *client.Sna
 }
 
 func isLocalSnap(name string) bool {
-	return strings.Contains(name, "/") || strings.HasSuffix(name, ".snap") || strings.Contains(name, ".snap.")
+	return strings.Contains(name, "/") || strings.Contains(name, ".")
 }
 
 func (x *cmdInstall) installMany(names []string, opts *client.SnapOptions) error {


### PR DESCRIPTION
Since `.` is illegal within snap names, it's a lot simpler (and more permissive) to just check for the inclusion of a period.