### PR TITLE
.shellcheckrc, tests/lib: fix unreachable code warnings without global disable

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,5 +1,0 @@
-# Disable "Unreachable code ..." warnings which log a warning for each line (not block)
-# of unreachable code. That code is often meant to be re-enabled later and we can't
-# do file-wide disables in spread tests https://github.com/koalaman/shellcheck/wiki/Ignore
-disable=SC2317
-

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -6,6 +6,7 @@
 debian_name_package() {
     #shellcheck source=tests/lib/tools/tests.pkgs.apt.sh
     . "$TESTSLIB/tools/tests.pkgs.apt.sh"
+    #shellcheck disable=SC2317
     for i in "$@"; do
         remap_one "$i"
     done
@@ -14,6 +15,7 @@ debian_name_package() {
 ubuntu_14_04_name_package() {
     #shellcheck source=tests/lib/tools/tests.pkgs.apt.sh
     . "$TESTSLIB/tools/tests.pkgs.apt.sh"
+    #shellcheck disable=SC2317
     for i in "$@"; do
         remap_one "$i"
     done
@@ -22,6 +24,7 @@ ubuntu_14_04_name_package() {
 fedora_name_package() {
     #shellcheck source=tests/lib/tools/tests.pkgs.dnf-yum.sh
     . "$TESTSLIB/tools/tests.pkgs.dnf-yum.sh"
+    #shellcheck disable=SC2317
     for i in "$@"; do
         remap_one "$i"
     done
@@ -30,6 +33,7 @@ fedora_name_package() {
 amazon_name_package() {
     #shellcheck source=tests/lib/tools/tests.pkgs.dnf-yum.sh
     . "$TESTSLIB/tools/tests.pkgs.dnf-yum.sh"
+    #shellcheck disable=SC2317
     for i in "$@"; do
         remap_one "$i"
     done
@@ -38,6 +42,7 @@ amazon_name_package() {
 opensuse_name_package() {
     #shellcheck source=tests/lib/tools/tests.pkgs.zypper.sh
     . "$TESTSLIB/tools/tests.pkgs.zypper.sh"
+    #shellcheck disable=SC2317
     for i in "$@"; do
         remap_one "$i"
     done
@@ -46,6 +51,7 @@ opensuse_name_package() {
 arch_name_package() {
     #shellcheck source=tests/lib/tools/tests.pkgs.pacman.sh
     . "$TESTSLIB/tools/tests.pkgs.pacman.sh"
+    #shellcheck disable=SC2317
     for i in "$@"; do
         remap_one "$i"
     done

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -735,28 +735,29 @@ EOF
         # current host, this should work for most cases, since the image will be
         # running on the same host
         # TODO:UC20: enable when ready
-        exit 0
+        local uc20_is_ready=false
 
-        # drop unnecessary modules
-        awk '{print $1}' <  /proc/modules  | sort > /tmp/mods
-        #shellcheck disable=SC2044
-        for m in $(find modules/ -name '*.ko'); do
-            noko=$(basename "$m"); noko="${noko%.ko}"
-            if echo "$noko" | grep -f /tmp/mods -q ; then
-                echo "keeping $m - $noko"
-            else
-                rm -f "$m"
-            fi
-        done
+        if [ "$uc20_is_ready" = "true" ]; then
+            # drop unnecessary modules
+            awk '{print $1}' <  /proc/modules  | sort > /tmp/mods
+            #shellcheck disable=SC2044
+            for m in $(find modules/ -name '*.ko'); do
+                noko=$(basename "$m"); noko="${noko%.ko}"
+                if echo "$noko" | grep -f /tmp/mods -q ; then
+                    echo "keeping $m - $noko"
+                else
+                    rm -f "$m"
+                fi
+            done
+            #shellcheck disable=SC2010
+            kver=$(ls "config"-* | grep -Po 'config-\K.*')
 
-        #shellcheck disable=SC2010
-        kver=$(ls "config"-* | grep -Po 'config-\K.*')
-
-        # depmod assumes that /lib/modules/$kver is under basepath
-        mkdir -p fake/lib
-        ln -s "$PWD/modules" fake/lib/modules
-        depmod -b "$PWD/fake" -A -v "$kver"
-        rm -rf fake
+            # depmod assumes that /lib/modules/$kver is under basepath
+            mkdir -p fake/lib
+            ln -s "$PWD/modules" fake/lib/modules
+            depmod -b "$PWD/fake" -A -v "$kver"
+            rm -rf fake
+        fi
     )
 
     # copy any extra files that tests may need for the kernel

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -735,9 +735,13 @@ EOF
         # current host, this should work for most cases, since the image will be
         # running on the same host
         # TODO:UC20: enable when ready
-        local uc20_is_ready=false
 
-        if [ "$uc20_is_ready" = "true" ]; then
+        # To avoid shellcheck unused code warning, we cannot use "exit 0" to disable
+        # the module drop code. To avoid commented out code, we use a flag instead.
+        # Strip off the check when this UC20 code is enabled.
+        uc20Ready=false
+
+        if [ "$uc20Ready" = "true" ]; then
             # drop unnecessary modules
             awk '{print $1}' <  /proc/modules  | sort > /tmp/mods
             #shellcheck disable=SC2044


### PR DESCRIPTION
Shellcheck v0.9.0 added [SC2317](https://github.com/koalaman/shellcheck/commit/642ad8612597b28af4026bde289985583fddb69d) to detect unreachable code.
This caused shellcheck failures that is already addressed with [this approach](https://github.com/ernestl/snapd/commit/1d417aa3d0ed4a105162840412ef57d49dd97951).

This proposal is an alternative approach to avoid global disable of the unreachable code check:
1. Excluding the error at specific places as required for placeholder scripts that need to exit with failure if not populated (tests/lib/pkgdb.sh)
2. Avoiding the error by disabling unused code in if statement (tests/lib/prepare.sh)