### PR TITLE
tests/main/lxd-mount-units: fix a check

### DIFF
--- a/tests/main/lxd-mount-units/task.yaml
+++ b/tests/main/lxd-mount-units/task.yaml
@@ -70,7 +70,11 @@ execute: |
 
     echo "Precondition check that mount overrides were generated inside the container"
     lxd.lxc exec ubuntu -- find /var/run/systemd/generator/ -name container.conf | MATCH "/var/run/systemd/generator/snap-${core_snap}.*mount.d/container.conf"
-    lxd.lxc exec ubuntu -- test -f /var/run/systemd/generator/snap.mount
+
+    # On older LXD, we work around / with private propagation by
+    # creating a shared /snap mount point with snapd-generator (LP#1668659).
+    # The unit does not exist in newer LXD images where root is shared.
+    lxd.lxc exec ubuntu -- findmnt / -o PROPAGATION --noheadings | MATCH shared || lxd.lxc exec ubuntu -- test -f /var/run/systemd/generator/snap.mount
 
     echo "Precondition check that $core_snap snap is mounted correctly"
     # Make sure $core_snap is mounted and readable for a regular user

--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -151,6 +151,10 @@ execute: |
 
     echo "Sanity check that mount overrides were generated inside the container"
     lxd.lxc exec my-ubuntu -- find /var/run/systemd/generator/ -name container.conf | MATCH "/var/run/systemd/generator/snap-core-.*mount.d/container.conf"
+
+    # On older LXD, we work around / with private propagation by
+    # creating a shared /snap mount point with snapd-generator (LP#1668659).
+    # The unit does not exist in newer LXD images where root is shared.
     lxd.lxc exec my-ubuntu -- findmnt / -o PROPAGATION --noheadings | MATCH shared || lxd.lxc exec my-ubuntu -- test -f /var/run/systemd/generator/snap.mount
 
     # Ensure that we can run lxd as a snap inside a container to create a nested


### PR DESCRIPTION
snap.mount is not generated by snapd-generator if / is shared.

Like #12492
