### PR TITLE
packing: link snap-seccomp against static libseccomp

### DIFF
--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -207,8 +207,9 @@ override_dh_auto_build:
 	$(shell	if ldd _build/bin/snap-update-ns; then false "need static build"; fi)
 	$(shell	if ldd _build/bin/snapctl; then false "need static build"; fi)
 
-	# ensure snap-seccomp is build with a static libseccomp on Ubuntu
-ifeq ($(shell dpkg-vendor --query Vendor),Ubuntu)
+	# ensure snap-seccomp is build with a static libseccomp
+	# to avoid having seccomp profile issues on hosts that do not
+	# ship newer libseccomp, but still need allowing newer syscalls.
 	sed -i "s|#cgo LDFLAGS:|#cgo LDFLAGS: /usr/lib/$(shell dpkg-architecture -qDEB_TARGET_MULTIARCH)/libseccomp.a|" _build/src/$(DH_GOPKG)/cmd/snap-seccomp/main.go
 	(cd _build/src/$(DH_GOPKG) && GOCACHE=/tmp/go-build CGO_LDFLAGS_ALLOW="/.*/libseccomp.a" go build -o ../../../../bin/snap-seccomp -mod=vendor $(GCCGOFLAGS) ./cmd/snap-seccomp)
 	# ensure that libseccomp is not dynamically linked
@@ -216,7 +217,6 @@ ifeq ($(shell dpkg-vendor --query Vendor),Ubuntu)
 	test "$$(ldd _build/bin/snap-seccomp | grep libseccomp)" = ""
 	# revert again so that the subsequent tests work
 	sed -i "s|#cgo LDFLAGS: -l/usr/lib/$(shell dpkg-architecture -qDEB_TARGET_MULTIARCH)/libseccomp.a|#cgo LDFLAGS:|" _build/src/$(DH_GOPKG)/cmd/snap-seccomp/main.go
-endif
 
 	# Build C bits, sadly manually
 	cd cmd && ( autoreconf -i -f )

--- a/tests/main/snap-seccomp/task.yaml
+++ b/tests/main/snap-seccomp/task.yaml
@@ -13,16 +13,23 @@ priority: 100
 
 environment:
     PROFILE: /var/lib/snapd/seccomp/bpf/snap.test-snapd-sh.sh
-    SNAP_SECCOMP: /usr/lib/snapd/snap-seccomp
 
 execute: |
     echo "Install test-snapd-sh and verify it works"
     snap install test-snapd-sh
     test-snapd-sh.sh -c 'echo hello' | MATCH hello
 
+    if [ -e /usr/lib/snapd/snap-seccomp ]; then
+        SNAP_SECCOMP=/usr/lib/snapd/snap-seccomp
+    elif [ -e /usr/libexec/snapd/snap-seccomp ]; then
+        SNAP_SECCOMP=/usr/libexec/snapd/snap-seccomp
+    else
+        echo "missing path for snap-seccomp for this platform"
+    fi
+
     # FIXME: use dirs.sh in 2.27+
     echo "Ensure snap-seccomp is statically linked"
-    if ldd /usr/lib/snapd/snap-seccomp | MATCH libseccomp ; then
+    if ldd "$SNAP_SECCOMP" | MATCH libseccomp ; then
         echo "found dynamically linked libseccomp, we need a staticly linked one"
         exit 1
     fi

--- a/tests/main/snap-seccomp/task.yaml
+++ b/tests/main/snap-seccomp/task.yaml
@@ -6,7 +6,7 @@ summary: Ensure that the snap-seccomp bpf handling works
 systems:
 - ubuntu-16*
 - ubuntu-18*
-- centos*
+- centos-*
 
 # Start early as it takes a long time.
 priority: 100

--- a/tests/main/snap-seccomp/task.yaml
+++ b/tests/main/snap-seccomp/task.yaml
@@ -2,7 +2,11 @@ summary: Ensure that the snap-seccomp bpf handling works
 
 # FIXME: once $(snap debug confinment) can be used (in 2.27+) remove
 #        the systems line
-systems: [ubuntu-16*, ubuntu-18*]
+# XXX: Can i remove this?
+systems:
+- ubuntu-16*
+- ubuntu-18*
+- centos*
 
 # Start early as it takes a long time.
 priority: 100


### PR DESCRIPTION
Currently we only statically link libseccomp on Ubuntu, but I want to extend this to all.

Link snap-seccomp statically against libseccomp to avoid profile issues with newer syscalls that are not present in the hosts installation of libseccomp. This is related to the recent issues there was on CentOS 7, which ships an older libseccomp on the system, which unfortunately causes newer system calls to be excluded from the generated seccomp profile, causing snaps based on core22 to stop working, as newer glibc probes for clone3 system call, which it expects to return ENOSYS, but because it's missing from the seccomp profile, returns EPERMS. This causes a startup error.

The fix for the above issue is to manually build and install libseccomp from source, but this is not a sustainable fix, and will be an issue again at some point on other distributions.

As we are already using this setup for our ubuntu distributions, I don't see this as a high risk to enable for all, unless I am missing something, which I probably am. 

Opened this in draft to explore this and get peoples opinions