### PR TITLE
tests: add ubuntu kinetic to google-sru backend

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -213,6 +213,8 @@ backends:
                   workers: 6
             - ubuntu-22.04-64:
                   workers: 6
+            - ubuntu-22.10-64:
+                  workers: 6
 
     google-nested:
         type: google


### PR DESCRIPTION
This is needed to keep updated the sru systems

