### PR TITLE
cmd/snap: add '--chain' flag for sign command

### DIFF
--- a/cmd/snap/cmd_known.go
+++ b/cmd/snap/cmd_known.go
@@ -120,7 +120,13 @@ func (x *cmdKnown) Execute(args []string) error {
 	var err error
 	switch {
 	case x.Remote && !x.Direct:
-		assertions, err = knownRemoteWithFallback(x.client, string(x.KnownOptions.AssertTypeName), headers)
+		// --remote will query snapd
+		assertions, err = x.client.Known(string(x.KnownOptions.AssertTypeName), headers, &client.KnownOptions{Remote: true})
+		// if snapd is unavailable automatically fallback
+		var connErr client.ConnectionError
+		if xerrors.As(err, &connErr) {
+			assertions, err = downloadAssertion(string(x.KnownOptions.AssertTypeName), headers)
+		}
 	case x.Direct:
 		// --direct implies remote
 		assertions, err = downloadAssertion(string(x.KnownOptions.AssertTypeName), headers)
@@ -138,16 +144,4 @@ func (x *cmdKnown) Execute(args []string) error {
 	}
 
 	return nil
-}
-
-func knownRemoteWithFallback(cl *client.Client, assertTypeName string, headers map[string]string) ([]asserts.Assertion, error) {
-	// --remote will query snapd
-	assertions, err := cl.Known(assertTypeName, headers, &client.KnownOptions{Remote: true})
-	// if snapd is unavailable automatically fallback
-	var connErr client.ConnectionError
-	if xerrors.As(err, &connErr) {
-		assertions, err = downloadAssertion(assertTypeName, headers)
-	}
-
-	return assertions, err
 }

--- a/cmd/snap/cmd_sign.go
+++ b/cmd/snap/cmd_sign.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2021 Canonical Ltd
+ * Copyright (C) 2014-2023 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -20,12 +20,15 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 
 	"github.com/jessevdk/go-flags"
 
+	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/signtool"
+	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/i18n"
 )
 
@@ -37,11 +40,13 @@ of the assertion can be specified through a "body" pseudo-header.
 `)
 
 type cmdSign struct {
+	clientMixin
 	Positional struct {
 		Filename flags.Filename
 	} `positional-args:"yes"`
 
 	KeyName keyName `short:"k" default:"default"`
+	Chain   string  `long:"chain" optional:"true" optional-value:"remote" choice:"remote" choice:"direct" choice:"local"`
 }
 
 func init() {
@@ -50,6 +55,8 @@ func init() {
 	}, map[string]string{
 		// TRANSLATORS: This should not start with a lowercase letter.
 		"k": i18n.G("Name of the key to use, otherwise use the default key"),
+		// TRANSLATORS: This should not start with a lowercase letter.
+		"chain": i18n.G("Append the account and account-key assertions necessary to allow any device to validate the signed assertion"),
 	}, []argDesc{{
 		// TRANSLATORS: This needs to begin with < and end with >
 		name: i18n.G("<filename>"),
@@ -100,9 +107,87 @@ func (x *cmdSign) Execute(args []string) error {
 		return err
 	}
 
-	_, err = Stdout.Write(encodedAssert)
+	outBuf := bytes.NewBuffer(nil)
+
+	_, err = outBuf.Write(encodedAssert)
+	if err != nil {
+		return err
+	}
+
+	if x.Chain != "" {
+		var known assertKnower
+
+		switch x.Chain {
+		case "remote":
+			known = knownRemoteWithFallback
+		case "direct":
+			known = func(_ *client.Client, assertTypeName string, headers map[string]string) ([]asserts.Assertion, error) {
+				return downloadAssertion(assertTypeName, headers)
+			}
+		case "local":
+			known = func(cl *client.Client, assertTypeName string, headers map[string]string) ([]asserts.Assertion, error) {
+				return cl.Known(assertTypeName, headers, nil)
+			}
+		default:
+			return fmt.Errorf("internal error: impossible value %q for --chain=", x.Chain)
+		}
+
+		// separate asserts with blank line
+		_, err := outBuf.Write([]byte("\n"))
+		if err != nil {
+			return err
+		}
+
+		accountKey, err := mustKnowOneAssert(known, x.client, "account-key", map[string]string{"public-key-sha3-384": privKey.PublicKey().ID()})
+		if err != nil {
+			return err
+		}
+		_, err = outBuf.Write(asserts.Encode(accountKey))
+		if err != nil {
+			return err
+		}
+
+		// separate asserts with blank line
+		_, err = outBuf.Write([]byte("\n"))
+		if err != nil {
+			return err
+		}
+
+		account, err := mustKnowOneAssert(known, x.client, "account", map[string]string{"account-id": accountKey.(*asserts.AccountKey).AccountID()})
+		if err != nil {
+			return err
+		}
+
+		_, err = outBuf.Write(asserts.Encode(account))
+		if err != nil {
+			return err
+		}
+	}
+
+	_, err = Stdout.Write(outBuf.Bytes())
 	if err != nil {
 		return err
 	}
 	return nil
+}
+
+type assertKnower func(cli *client.Client, assertTypeName string, headers map[string]string) ([]asserts.Assertion, error)
+
+// call this function in a way that is guaranteed to specify a unique assertion
+// (i.e. with a header specifying a value for the assertion's primary key)
+func mustKnowOneAssert(known assertKnower, cl *client.Client, assertType string, headers map[string]string) (asserts.Assertion, error) {
+	asserts, err := known(cl, assertType, headers)
+	if err != nil {
+		return nil, err
+	}
+
+	switch len(asserts) {
+	case 0:
+		// TRANSLATORS: %s is the assertion-type
+		return nil, fmt.Errorf(i18n.G("cannot retrieve %s assertion"), assertType)
+	case 1:
+		return asserts[0], nil
+	default:
+		return nil, fmt.Errorf(i18n.G("internal error: cannot identify unique %s assertion for specified headers"), assertType)
+	}
 }

--- a/cmd/snap/cmd_sign.go
+++ b/cmd/snap/cmd_sign.go
@@ -21,6 +21,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io/ioutil"
 
@@ -118,8 +119,11 @@ func (x *cmdSign) Execute(args []string) error {
 		return err
 	}
 
-	// --direct implies --chain
-	if x.Chain || x.Direct {
+	if x.Direct && !x.Chain {
+		return errors.New(i18n.G("signing with --direct requires specifying --chain"))
+	}
+
+	if x.Chain {
 		known := knownRemoteWithFallback
 		if x.Direct {
 			known = func(_ *client.Client, assertTypeName string, headers map[string]string) ([]asserts.Assertion, error) {

--- a/cmd/snap/cmd_sign.go
+++ b/cmd/snap/cmd_sign.go
@@ -120,7 +120,7 @@ func (x *cmdSign) Execute(args []string) error {
 	}
 
 	if x.Direct && !x.Chain {
-		return errors.New(i18n.G("signing with --direct requires specifying --chain"))
+		return errors.New(i18n.G("--direct specified without --chain"))
 	}
 
 	if x.Chain {

--- a/cmd/snap/cmd_sign.go
+++ b/cmd/snap/cmd_sign.go
@@ -150,9 +150,9 @@ func mustGetOneAssert(assertType string, headers map[string]string) (asserts.Ass
 		return nil, fmt.Errorf(i18n.G("cannot create assertion chain: %w"), err)
 	}
 
-	if len(asserts) == 1 {
-		return asserts[0], nil
+	if len(asserts) != 1 {
+		return nil, fmt.Errorf(i18n.G("internal error: cannot identify unique %s assertion for specified headers"), assertType)
 	}
 
-	return nil, fmt.Errorf(i18n.G("internal error: cannot identify unique %s assertion for specified headers"), assertType)
+	return asserts[0], nil
 }

--- a/cmd/snap/cmd_sign.go
+++ b/cmd/snap/cmd_sign.go
@@ -108,8 +108,9 @@ func (x *cmdSign) Execute(args []string) error {
 	}
 
 	outBuf := bytes.NewBuffer(nil)
+	enc := asserts.NewEncoder(outBuf)
 
-	_, err = outBuf.Write(encodedAssert)
+	err = enc.WriteEncoded(encodedAssert)
 	if err != nil {
 		return err
 	}
@@ -132,23 +133,12 @@ func (x *cmdSign) Execute(args []string) error {
 			return fmt.Errorf("internal error: impossible value %q for --chain=", x.Chain)
 		}
 
-		// separate asserts with blank line
-		_, err := outBuf.Write([]byte("\n"))
-		if err != nil {
-			return err
-		}
-
 		accountKey, err := mustKnowOneAssert(known, x.client, "account-key", map[string]string{"public-key-sha3-384": privKey.PublicKey().ID()})
 		if err != nil {
 			return err
 		}
-		_, err = outBuf.Write(asserts.Encode(accountKey))
-		if err != nil {
-			return err
-		}
 
-		// separate asserts with blank line
-		_, err = outBuf.Write([]byte("\n"))
+		err = enc.Encode(accountKey)
 		if err != nil {
 			return err
 		}
@@ -158,7 +148,7 @@ func (x *cmdSign) Execute(args []string) error {
 			return err
 		}
 
-		_, err = outBuf.Write(asserts.Encode(account))
+		err = enc.Encode(account)
 		if err != nil {
 			return err
 		}

--- a/cmd/snap/cmd_sign_test.go
+++ b/cmd/snap/cmd_sign_test.go
@@ -21,12 +21,18 @@ package main_test
 
 import (
 	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"time"
 
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/client"
 	snap "github.com/snapcore/snapd/cmd/snap"
+	"github.com/snapcore/snapd/store"
 )
 
 var statement = []byte(fmt.Sprintf(`{"type": "snap-build",
@@ -61,4 +67,325 @@ func (s *SnapKeysSuite) TestHappyNonDefaultKey(c *C) {
 	a, err := asserts.Decode(s.stdout.Bytes())
 	c.Assert(err, IsNil)
 	c.Check(a.Type(), Equals, asserts.SnapBuildType)
+}
+
+const mockAccountKeyAssertion = `type: account-key
+authority-id: canonical
+revision: 2
+public-key-sha3-384: -CvQKAwRQ5h3Ffn10FILJoEZUXOv6km9FwA80-Rcj-f-6jadQ89VRswHNiEB9Lxk
+account-id: canonical
+name: root
+since: 2016-04-01T00:00:00.0Z
+body-length: 1406
+sign-key-sha3-384: -CvQKAwRQ5h3Ffn10FILJoEZUXOv6km9FwA80-Rcj-f-6jadQ89VRswHNiEB9Lxk
+
+AcbDTQRWhcGAASAA4Zdo3CVpKmTecjd3VDBiFbZTKKhcG0UV3FXxyGIe2UsdnJIks4NkVYO+qYk0
+zW26Svpa5OIOJGO2NcgN9bpCYWZOufO1xTmC7jW/fEtqJpX8Kcq20+X5AarqJ5RBVnGLrlz+ZT99
+aHdRZ4YQ2XUZvhbelzWTdK5+2eMSXNrFjO6WwGh9NRekE/NIBNwvULAtJ5nv1KwZaSpZ+klJrstU
+EHPhs+NGGm1Aru01FFl3cWUm5Ao8i9y+pFcPoaRatgtpYU8mg9gP594lvyJqjFofXvHPwztmySqf
+FVAp4gLLfLvRxbXkOfPUz8guidqvg6r4DUD+kCBjKYoT44PjK6l51MzEL2IEy6jdnFTgjHbaYML8
+/5NpuPu8XiSjCpOTeNR+XKzXC2tHRU7j09Xd44vKRhPk0Hc4XsPNBWqfrcbdWmwsFhjfxFDJajOq
+hzWVoiRc5opB5socbRjLf+gYtncxe99oC2FDA2FcftlFoyztho0bAzeFer1IHJIMYWxKMESjvJUE
+pnMMKpIMYY0QfWEo5hXR0TaT+NxW2Z9Jqclgyw13y5iY72ZparHS66J+C7dxCEOswlw1ypNic6MM
+/OzpafIQ10yAT3HeRCJQQOOSSTaold+WpWsQweYCywPcu9S+wCo6CrPzJCCIxOAnXjLYv2ykTJje
+pNJ2+GZ1WH2UeJdJ5sR8fpxxRupqHuEKNRZ+2CqLmFC5kHNszoGolLEvGcK4BJciO4KihnKtxrdX
+dUJIOPBLktA8XiiHSOmLzs2CFjcvlDuPSpe64HIL5yCxO1/GRux4A1Kht1+DqTrL7DjyIW+vIPro
+A1PQwkcAJyScNRxT4bPpUj8geAXWd3n212W+7QVHuQEFezvXC5GbMyR+Xj47FOFcFcSZID1hTZEu
+uMD+AxaBHQKwPfBx1arVKE1OhkuKHeSFtZRP8K8l3qj5W0sIxxIW19W8aziu8ZeDMT+nIEJrJvhx
+zGEdxwCrp3k2/93oDV7g+nb1ZGfIhtmcrKziijghzPLaYaiM9LggqwTARelk3xSzd8+uk3LPXuVl
+fP8/xHApss6sCE3xk4+F3OGbL7HbGuCnoulf795XKLRTy+xU/78piOMNJJQu+G0lMZIO3cZrP6io
+MYDa+jDZw4V4fBRWce/FA3Ot1eIDxCq5v+vfKw+HfUlWcjm6VUQIFZYbK+Lzj6mpXn81BugG3d+M
+0WNFObXIrUbhnKcYkus3TSJ9M1oMEIMp0WfFGAVTd61u36fdi2e+/xbLN0kbYcFRZwd9CmtEeDZ0
+eYx/pvKKaNz/DfUr0piVCRwxuxQ0kVppklHPO4sOTFZUId8KLHg28LbszvupSsHP/nHlW8l5/VK6
+4+KxRV2XofsUnwARAQAB
+
+AcLDXAQAAQoABgUCV83kkgAKCRDUpVvql9g3IA9hIADAkn4VXnJIFblhMSBe6hbTy7z6AfOhZxXR
+Ds/mHsiWfFT6ifGi9SpZowhRX+ff57YvFCjlBqMYLKYE0NsFQYEUc5uBWiFZwC0ENydNhO23DV1B
+elTSs6mr9duPm1eJAozFrQETOD1kz5BIamqBUeaTczjM+9l5i485Ffknbc+EaGOrtMEap0GqjByQ
+u+ykZGvryVQ447avgjvFsMtA0quFi+SoW9PT/9D26e5rD7RIICYWG8mzFRn5Isqs/X4W1uAiKQe9
+pqHMbdNr/FCWX5ws0/nMaOq+b0z4EIIXIfT0JmIlFDQsAgFVnKwYw+zs32cTw4XuzvMhgMDtCowD
+YodhiO/5AOMsMMV0qBsYxbIPJIEz7b6gwTYEJoTVkqTit6o3UgWrAy+p4Y7t0ickYIHgwiuKRS9E
+fu0Ue+32NFp0XFqZElfXLK/U2yjto+fJXu6uAELsXesfFGIOp/nbRbNavUt9jAJeO7ftQczgf39T
+YfA0OKerP5gAOd4+aO3gATPUjfWPsJ9908XC7QqK2BwS1kh/fMrd95mxcmXdF1bBElszKwaToBVQ
+1m52EYp06kkPyOu+fGKFAoIMafcV/2Ztz1WMo/Vp0iP/r0WAtBDw6sDJyWOfRjUEvP7BBdEzraHV
+VblbSrKzhYeEGdMDi6kFC+KEzfPDPFJX1l3saPBkz9VDuESbktyObQp9VfkFKYBgBnw3msQJk+6k
+G4t0o3/DZ7qz/kTJXMogG26Z/FsMhPERsaLTbWRJ3WRyXX8COaTladSf8bG0Oib19outnjuvpjQ0
+qEV9eeGRBlx9mbidSYH95cj0zD2DKpeSZ83M5K1pFg+8RKToGElGTTk8vtdTfDVbmi3+QntfLq+z
+ZMgs2+SmCWrV/MPC04Dl00CXywdKPyf6toomqRP7A5fS7W8P9fdPn+a8JCblcleGj9nvJXBQjue7
+97rofCEszhKhoE9fMCIUcSoTU9YAm5Jr+qclSEbV1pzwTvZ8auMIXtzEZV5n4aK4WPDV+lYCadrL
+DlvJSJRuXRvIMbmvU9b8NxgG8AS88BkX3L9vlOpkMculwG1/iooQvxuFaJDargt370wAQo0lCpG3
+MxnsSusymwnYegvvvr7Xp/KBLZK1+8Djzm3fwAryp4qNo29ciVw3O9lFKmmuiIcxSY0bauXaK6kv
+pTnYkmx7XGPF7Ahb7Ov0/0FE2Lx3JZXSEKeW+VrCcpYQOY++t67b+jf0AV4rZExcLFJzP6MPMimP
+ZCd383NzlzkXK+vAdvTi40HPiM9FYOp6g8JTs5TTdx2/qs/SWFC8AkahIQmH0IpFBJep2JKl2kyr
+FZMvASkHA9bR/UuXDvbMzsUmT/xnERZosQaZgFEO
+`
+
+const mockAccountAssertion = `type: account
+authority-id: canonical
+account-id: canonical
+display-name: Canonical
+timestamp: 2016-04-01T00:00:00.0Z
+username: canonical
+validation: certified
+sign-key-sha3-384: -CvQKAwRQ5h3Ffn10FILJoEZUXOv6km9FwA80-Rcj-f-6jadQ89VRswHNiEB9Lxk
+
+AcLDXAQAAQoABgUCV7UYzwAKCRDUpVvql9g3IK7uH/4udqNOurx5WYVknzXdwekp0ovHCQJ0iBPw
+TSFxEVr9faZSzb7eqJ1WicHsShf97PYS3ClRYAiluFsjRA8Y03kkSVJHjC+sIwGFubsnkmgflt6D
+WEmYIl0UBmeaEDS8uY4Xvp9NsLTzNEj2kvzy/52gKaTc1ZSl5RDL9ppMav+0V9iBYpiDPBWH2rJ+
+aDSD8Rkyygm0UscfAKyDKH4lrvZ0WkYyi1YVNPrjQ/AtBySh6Q4iJ3LifzKa9woIyAuJET/4/FPY
+oirqHAfuvNod36yNQIyNqEc20AvTvZNH0PSsg4rq3DLjIPzv5KbJO9lhsasNJK1OdL6x8Yqrdsbk
+ldZp4qkzfjV7VOMQKaadfcZPRaVVeJWOBnBiaukzkhoNlQi1sdCdkBB/AJHZF8QXw6c7vPDcfnCV
+1lW7ddQ2p8IsJbT6LzpJu3GW/P4xhNgCjtCJ1AJm9a9RqLwQYgdLZwwDa9iCRtqTbRXBlfy3apps
+1VjbQ3h5iCd0hNfwDBnGVm1rhLKHCD1DUdNE43oN2ZlE7XGyh0HFV6vKlpqoW3eoXCIxWu+HBY96
++LSl/jQgCkb0nxYyzEYK4Reb31D0mYw1Nji5W+MIF5E09+DYZoOT0UvR05YMwMEOeSdI/hLWg/5P
+k+GDK+/KopMmpd4D1+jjtF7ZvqDpmAV98jJGB2F88RyVb4gcjmFFyTi4Kv6vzz/oLpbm0qrizC0W
+HLGDN/ymGA5sHzEgEx7U540vz/q9VX60FKqL2YZr/DcyY9GKX5kCG4sNqIIHbcJneZ4frM99oVDu
+7Jv+DIx/Di6D1ULXol2XjxbbJLKHFtHksR97ceaFvcZwTogC61IYUBJCvvMoqdXAWMhEXCr0QfQ5
+Xbi31XW2d4/lF/zWlAkRnGTzufIXFni7+nEuOK0SQEzO3/WaRedK1SGOOtTDjB8/3OJeW96AUYK5
+oTIynkYkEyHWMNCXALg+WQW6L4/YO7aUjZ97zOWIugd7Xy63aT3r/EHafqaY2nacOhLfkeKZ830b
+o/ezjoZQAxbh6ce7JnXRgE9ELxjdAhBTpGjmmmN2sYrJ7zP9bOgly0BnEPXGSQfFA+NNNw1FADx1
+MUY8q9DBjmVtgqY+1KGTV5X8KvQCBMODZIf/XJPHdCRAHxMd8COypcwgL2vDIIXpOFbi1J/B0GF+
+eklxk9wzBA8AecBMCwCzIRHDNpD1oa2we38bVFrOug6e/VId1k1jYFJjiLyLCDmV8IMYwEllHSXp
+LQAdm3xZ7t4WnxYC8YSCk9mXf3CZg59SpmnV5Q5Z6A5Pl7Nc3sj7hcsMBZEsOMPzNC9dPsBnZvjs
+WpPUffJzEdhHBFhvYMuD4Vqj6ejUv9l3oTrjQWVC
+`
+
+func (s *SnapKeysSuite) checkSignChainResults(c *C, statementType *asserts.AssertionType) {
+	dec := asserts.NewDecoder(s.stdout)
+
+	numAsserts := 0
+
+	foundStatement, foundAccountKey, foundAccount := false, false, false
+
+	for {
+		a, err := dec.Decode()
+		if err == io.EOF {
+			break
+		}
+		c.Assert(err, IsNil)
+		switch a.Type() {
+		case asserts.AccountType:
+			foundAccount = true
+		case asserts.AccountKeyType:
+			foundAccountKey = true
+		case statementType:
+			foundStatement = true
+		default:
+			c.Fatalf("expected %s, account-key, and account asserts, got %q", statementType.Name, a.Type().Name)
+		}
+		numAsserts++
+	}
+
+	c.Assert(numAsserts, Equals, 3)
+
+	c.Assert(foundStatement, Equals, true)
+	c.Assert(foundAccountKey, Equals, true)
+	c.Assert(foundAccount, Equals, true)
+}
+
+func (s *SnapKeysSuite) TestSignChainViaSnapd(c *C) {
+	n := 0
+	expectedAccountKeyQuery := url.Values{
+		"public-key-sha3-384": []string{"g4Pks54W_US4pZuxhgG_RHNAf_UeZBBuZyGRLLmMj1Do3GkE_r_5A5BFjx24ZwVJ"},
+		"remote":              []string{"true"},
+	}
+	expectedAccountQuery := url.Values{
+		"account-id": []string{"canonical"},
+		"remote":     []string{"true"},
+	}
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		switch n {
+		case 0:
+			c.Check(r.URL.Path, Equals, "/v2/assertions/account-key")
+			c.Check(r.URL.Query(), DeepEquals, expectedAccountKeyQuery)
+			w.Header().Set("X-Ubuntu-Assertions-Count", "1")
+			fmt.Fprint(w, mockAccountKeyAssertion)
+		case 1:
+			c.Check(r.URL.Path, Equals, "/v2/assertions/account")
+			c.Check(r.URL.Query(), DeepEquals, expectedAccountQuery)
+			w.Header().Set("X-Ubuntu-Assertions-Count", "1")
+			fmt.Fprintf(w, mockAccountAssertion)
+		default:
+			c.Fatalf("expected to get 2 requests, now on %d", n+1)
+		}
+		n++
+	})
+
+	// first run the default --chain, which should be equivalent to --chain=remote
+	s.stdin.Write([]byte(statement))
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"sign", "--chain"})
+	c.Assert(err, IsNil)
+	c.Assert(rest, DeepEquals, []string{})
+	s.checkSignChainResults(c, asserts.SnapBuildType)
+	c.Assert(n, Equals, 2)
+
+	// then run specifying --chain=remote
+	n = 0
+	s.stdout.Reset()
+	s.stdin.Reset()
+	s.stdin.Write([]byte(statement))
+	rest, err = snap.Parser(snap.Client()).ParseArgs([]string{"sign", "--chain=remote"})
+	c.Assert(err, IsNil)
+	c.Assert(rest, DeepEquals, []string{})
+	s.checkSignChainResults(c, asserts.SnapBuildType)
+	c.Assert(n, Equals, 2)
+
+	// then run specifying --chain=local
+	delete(expectedAccountKeyQuery, "remote")
+	delete(expectedAccountQuery, "remote")
+	n = 0
+	s.stdout.Reset()
+	s.stdin.Reset()
+	s.stdin.Write([]byte(statement))
+	rest, err = snap.Parser(snap.Client()).ParseArgs([]string{"sign", "--chain=local"})
+	c.Assert(err, IsNil)
+	c.Assert(rest, DeepEquals, []string{})
+	s.checkSignChainResults(c, asserts.SnapBuildType)
+	c.Assert(n, Equals, 2)
+}
+
+func (s *SnapKeysSuite) TestSignChainDirect(c *C) {
+	var server *httptest.Server
+
+	restorer := snap.MockStoreNew(func(cfg *store.Config, stoCtx store.DeviceAndAuthContext) *store.Store {
+		if cfg == nil {
+			cfg = store.DefaultConfig()
+		}
+		serverURL, _ := url.Parse(server.URL)
+		cfg.AssertionsBaseURL = serverURL
+		return store.New(cfg, stoCtx)
+	})
+	defer restorer()
+
+	n := 0
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.URL.Path, Matches, ".*/assertions/.*") // basic check for request
+		switch n {
+		case 0:
+			c.Check(r.Method, Equals, "GET")
+			c.Check(r.URL.Path, Equals, "/v2/assertions/account-key/g4Pks54W_US4pZuxhgG_RHNAf_UeZBBuZyGRLLmMj1Do3GkE_r_5A5BFjx24ZwVJ")
+			fmt.Fprint(w, mockAccountKeyAssertion)
+		case 1:
+			c.Check(r.Method, Equals, "GET")
+			c.Check(r.URL.Path, Equals, "/v2/assertions/account/canonical")
+			fmt.Fprint(w, mockAccountAssertion)
+		default:
+			c.Fatalf("expected to get 2 requests, now on %d", n+1)
+		}
+		n++
+	}))
+
+	s.stdin.Write([]byte(statement))
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"sign", "--chain=direct"})
+	c.Assert(err, IsNil)
+	c.Assert(rest, DeepEquals, []string{})
+	s.checkSignChainResults(c, asserts.SnapBuildType)
+	c.Assert(n, Equals, 2)
+}
+
+func (s *SnapKeysSuite) TestSignChainRemoteAutoFallback(c *C) {
+	var server *httptest.Server
+
+	restorer := snap.MockStoreNew(func(cfg *store.Config, stoCtx store.DeviceAndAuthContext) *store.Store {
+		if cfg == nil {
+			cfg = store.DefaultConfig()
+		}
+		serverURL, _ := url.Parse(server.URL)
+		cfg.AssertionsBaseURL = serverURL
+		return store.New(cfg, stoCtx)
+	})
+	defer restorer()
+
+	n := 0
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.URL.Path, Matches, ".*/assertions/.*") // basic check for request
+		switch n {
+		case 0:
+			c.Check(r.Method, Equals, "GET")
+			c.Check(r.URL.Path, Equals, "/v2/assertions/account-key/g4Pks54W_US4pZuxhgG_RHNAf_UeZBBuZyGRLLmMj1Do3GkE_r_5A5BFjx24ZwVJ")
+			fmt.Fprint(w, mockAccountKeyAssertion)
+		case 1:
+			c.Check(r.Method, Equals, "GET")
+			c.Check(r.URL.Path, Equals, "/v2/assertions/account/canonical")
+			fmt.Fprint(w, mockAccountAssertion)
+		default:
+			c.Fatalf("expected to get 2 requests, now on %d", n+1)
+		}
+		n++
+	}))
+
+	cli := snap.Client()
+	cli.Hijack(func(*http.Request) (*http.Response, error) {
+		return nil, client.ConnectionError{Err: fmt.Errorf("no snapd")}
+	})
+
+	s.stdin.Write([]byte(statement))
+	rest, err := snap.Parser(cli).ParseArgs([]string{"sign", "--chain=remote"})
+	c.Assert(err, IsNil)
+	c.Assert(rest, DeepEquals, []string{})
+	s.checkSignChainResults(c, asserts.SnapBuildType)
+	c.Assert(n, Equals, 2)
+	c.Check(s.Stderr(), Equals, "")
+}
+
+func (s *SnapKeysSuite) TestSignChainUnknownAccountOrKey(c *C) {
+	n := 0
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		switch n {
+		case 0:
+			c.Check(r.URL.Path, Equals, "/v2/assertions/account-key")
+			c.Check(r.URL.Query(), DeepEquals, url.Values{
+				"public-key-sha3-384": []string{"g4Pks54W_US4pZuxhgG_RHNAf_UeZBBuZyGRLLmMj1Do3GkE_r_5A5BFjx24ZwVJ"},
+				"remote":              []string{"true"},
+			})
+			w.Header().Set("X-Ubuntu-Assertions-Count", "0")
+		case 1:
+			c.Check(r.URL.Path, Equals, "/v2/assertions/account-key")
+			c.Check(r.URL.Query(), DeepEquals, url.Values{
+				"public-key-sha3-384": []string{"g4Pks54W_US4pZuxhgG_RHNAf_UeZBBuZyGRLLmMj1Do3GkE_r_5A5BFjx24ZwVJ"},
+				"remote":              []string{"true"},
+			})
+			w.Header().Set("X-Ubuntu-Assertions-Count", "1")
+			fmt.Fprint(w, mockAccountKeyAssertion)
+		case 2:
+			c.Check(r.URL.Path, Equals, "/v2/assertions/account")
+			c.Check(r.URL.Query(), DeepEquals, url.Values{
+				"account-id": []string{"canonical"},
+				"remote":     []string{"true"},
+			})
+			w.Header().Set("X-Ubuntu-Assertions-Count", "0")
+		default:
+			c.Fatalf("expected to get 3 requests, now on %d", n+1)
+		}
+		n++
+	})
+
+	// case 1, fail on account-key
+	s.stdin.Write([]byte(statement))
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"sign", "--chain"})
+	c.Assert(err, ErrorMatches, "cannot retrieve account-key assertion")
+	c.Assert(n, Equals, 1)
+	// if we fail in retrieving the account-key assertion, we should not write
+	// partial output
+	c.Assert(s.Stdout(), Equals, "")
+
+	// case 2, fail on account
+	s.stdin.Reset()
+	s.stdout.Reset()
+	s.stdin.Write([]byte(statement))
+	_, err = snap.Parser(snap.Client()).ParseArgs([]string{"sign", "--chain"})
+	c.Assert(err, ErrorMatches, "cannot retrieve account assertion")
+	c.Assert(n, Equals, 3)
+	// if we fail in retrieving the account assertion, we should not write
+	// partial output
+	c.Assert(s.Stdout(), Equals, "")
+}
+
+func (s *SnapKeysSuite) TestSignChainUnknownValue(c *C) {
+
+	s.stdin.Write([]byte(statement))
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"sign", "--chain=badvalue"})
+	c.Assert(err, ErrorMatches, "Invalid value `badvalue' for option `--chain'. Allowed values are: .*")
+	// if we fail we should not write partial output
+	c.Assert(s.Stdout(), Equals, "")
 }

--- a/cmd/snap/cmd_sign_test.go
+++ b/cmd/snap/cmd_sign_test.go
@@ -264,7 +264,7 @@ func (s *SnapKeysSuite) TestSignChainDirect(c *C) {
 	s.stdout.Reset()
 	s.stdin.Reset()
 	s.stdin.Write([]byte(statement))
-	rest, err = snap.Parser(snap.Client()).ParseArgs([]string{"sign", "--direct"})
+	_, err = snap.Parser(snap.Client()).ParseArgs([]string{"sign", "--direct"})
 	c.Assert(err, ErrorMatches, "signing with --direct requires specifying --chain")
 	c.Assert(n, Equals, 0)
 	// if we fail in retrieving the account-key assertion, we should not write

--- a/cmd/snap/cmd_sign_test.go
+++ b/cmd/snap/cmd_sign_test.go
@@ -265,7 +265,7 @@ func (s *SnapKeysSuite) TestSignChainDirect(c *C) {
 	s.stdin.Reset()
 	s.stdin.Write([]byte(statement))
 	_, err = snap.Parser(snap.Client()).ParseArgs([]string{"sign", "--direct"})
-	c.Assert(err, ErrorMatches, "signing with --direct requires specifying --chain")
+	c.Assert(err, ErrorMatches, "--direct specified without --chain")
 	c.Assert(n, Equals, 0)
 	// if we fail in retrieving the account-key assertion, we should not write
 	// partial output

--- a/cmd/snap/cmd_sign_test.go
+++ b/cmd/snap/cmd_sign_test.go
@@ -218,30 +218,6 @@ func (s *SnapKeysSuite) TestSignChainViaSnapd(c *C) {
 	c.Assert(rest, DeepEquals, []string{})
 	s.checkSignChainResults(c, asserts.SnapBuildType)
 	c.Assert(n, Equals, 2)
-
-	// then run specifying --chain=remote
-	n = 0
-	s.stdout.Reset()
-	s.stdin.Reset()
-	s.stdin.Write([]byte(statement))
-	rest, err = snap.Parser(snap.Client()).ParseArgs([]string{"sign", "--chain=remote"})
-	c.Assert(err, IsNil)
-	c.Assert(rest, DeepEquals, []string{})
-	s.checkSignChainResults(c, asserts.SnapBuildType)
-	c.Assert(n, Equals, 2)
-
-	// then run specifying --chain=local
-	delete(expectedAccountKeyQuery, "remote")
-	delete(expectedAccountQuery, "remote")
-	n = 0
-	s.stdout.Reset()
-	s.stdin.Reset()
-	s.stdin.Write([]byte(statement))
-	rest, err = snap.Parser(snap.Client()).ParseArgs([]string{"sign", "--chain=local"})
-	c.Assert(err, IsNil)
-	c.Assert(rest, DeepEquals, []string{})
-	s.checkSignChainResults(c, asserts.SnapBuildType)
-	c.Assert(n, Equals, 2)
 }
 
 func (s *SnapKeysSuite) TestSignChainDirect(c *C) {
@@ -275,8 +251,20 @@ func (s *SnapKeysSuite) TestSignChainDirect(c *C) {
 		n++
 	}))
 
+	// first run --chain --direct
 	s.stdin.Write([]byte(statement))
-	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"sign", "--chain=direct"})
+	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"sign", "--chain", "--direct"})
+	c.Assert(err, IsNil)
+	c.Assert(rest, DeepEquals, []string{})
+	s.checkSignChainResults(c, asserts.SnapBuildType)
+	c.Assert(n, Equals, 2)
+
+	// then run just --direct, which should be equivalent
+	n = 0
+	s.stdout.Reset()
+	s.stdin.Reset()
+	s.stdin.Write([]byte(statement))
+	rest, err = snap.Parser(snap.Client()).ParseArgs([]string{"sign", "--direct"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	s.checkSignChainResults(c, asserts.SnapBuildType)
@@ -320,7 +308,7 @@ func (s *SnapKeysSuite) TestSignChainRemoteAutoFallback(c *C) {
 	})
 
 	s.stdin.Write([]byte(statement))
-	rest, err := snap.Parser(cli).ParseArgs([]string{"sign", "--chain=remote"})
+	rest, err := snap.Parser(cli).ParseArgs([]string{"sign", "--chain"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	s.checkSignChainResults(c, asserts.SnapBuildType)
@@ -378,14 +366,5 @@ func (s *SnapKeysSuite) TestSignChainUnknownAccountOrKey(c *C) {
 	c.Assert(n, Equals, 3)
 	// if we fail in retrieving the account assertion, we should not write
 	// partial output
-	c.Assert(s.Stdout(), Equals, "")
-}
-
-func (s *SnapKeysSuite) TestSignChainUnknownValue(c *C) {
-
-	s.stdin.Write([]byte(statement))
-	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"sign", "--chain=badvalue"})
-	c.Assert(err, ErrorMatches, "Invalid value `badvalue' for option `--chain'. Allowed values are: .*")
-	// if we fail we should not write partial output
 	c.Assert(s.Stdout(), Equals, "")
 }

--- a/cmd/snap/cmd_sign_test.go
+++ b/cmd/snap/cmd_sign_test.go
@@ -265,10 +265,11 @@ func (s *SnapKeysSuite) TestSignChainDirect(c *C) {
 	s.stdin.Reset()
 	s.stdin.Write([]byte(statement))
 	rest, err = snap.Parser(snap.Client()).ParseArgs([]string{"sign", "--direct"})
-	c.Assert(err, IsNil)
-	c.Assert(rest, DeepEquals, []string{})
-	s.checkSignChainResults(c, asserts.SnapBuildType)
-	c.Assert(n, Equals, 2)
+	c.Assert(err, ErrorMatches, "signing with --direct requires specifying --chain")
+	c.Assert(n, Equals, 0)
+	// if we fail in retrieving the account-key assertion, we should not write
+	// partial output
+	c.Assert(s.Stdout(), Equals, "")
 }
 
 func (s *SnapKeysSuite) TestSignChainRemoteAutoFallback(c *C) {


### PR DESCRIPTION
This introduces a `--chain` flag, which causes 'snap sign' to append the corresponding account-key and account assertions to the signed output of the command. This is often critical for creating working system-user assertions, especially for use in air-gapped or offline situations.

Over the years, Field has created a couple of tools that do this, specifically [make-system-user](https://github.com/canonical/make-system-user) (which reinvents the wheel a bit) and @kubiko's `sign-system-user-assertion` script (which just wraps `snap sign` and `snap known`) but for UX, packaging/distribution, and maintainability reasons, I think the `snap sign` command is really the right place for the logic.

The name "chain" is my rough suggestion, but if others have thoughts on naming, I'd appreciate guidance there.