### PR TITLE
gadget: include OnDiskStructure in LaidOutStructure

### DIFF
--- a/gadget/device_darwin.go
+++ b/gadget/device_darwin.go
@@ -25,6 +25,6 @@ import (
 
 var errNotImplemented = errors.New("not implemented")
 
-func FindDeviceForStructure(ps *LaidOutStructure) (string, error) {
+func FindDeviceForStructure(vs *VolumeStructure) (string, error) {
 	return "", errNotImplemented
 }

--- a/gadget/device_linux.go
+++ b/gadget/device_linux.go
@@ -34,20 +34,20 @@ var evalSymlinks = filepath.EvalSymlinks
 // given volume structure, by inspecting its name and, optionally, the
 // filesystem label. Assumes that the host's udev has set up device symlinks
 // correctly.
-func FindDeviceForStructure(ps *LaidOutStructure) (string, error) {
+func FindDeviceForStructure(vs *VolumeStructure) (string, error) {
 	var candidates []string
 
-	if ps.Name() != "" {
-		byPartlabel := filepath.Join(dirs.GlobalRootDir, "/dev/disk/by-partlabel/", disks.BlkIDEncodeLabel(ps.Name()))
+	if vs.Name != "" {
+		byPartlabel := filepath.Join(dirs.GlobalRootDir, "/dev/disk/by-partlabel/", disks.BlkIDEncodeLabel(vs.Name))
 		candidates = append(candidates, byPartlabel)
 	}
-	if ps.HasFilesystem() {
-		fsLabel := ps.Label()
-		if fsLabel == "" && ps.Name() != "" {
+	if vs.HasFilesystem() {
+		fsLabel := vs.Label
+		if fsLabel == "" && vs.Name != "" {
 			// when image is built and the structure has no
 			// filesystem label, the structure name will be used by
 			// default as the label
-			fsLabel = ps.Name()
+			fsLabel = vs.Name
 		}
 		if fsLabel != "" {
 			byFsLabel := filepath.Join(dirs.GlobalRootDir, "/dev/disk/by-label/", disks.BlkIDEncodeLabel(fsLabel))

--- a/gadget/device_test.go
+++ b/gadget/device_test.go
@@ -74,9 +74,7 @@ func (d *deviceSuite) TestDeviceFindByStructureName(c *C) {
 
 	for _, tc := range names {
 		c.Logf("trying: %q", tc)
-		found, err := gadget.FindDeviceForStructure(&gadget.LaidOutStructure{
-			VolumeStructure: &gadget.VolumeStructure{Name: tc.structure},
-		})
+		found, err := gadget.FindDeviceForStructure(&gadget.VolumeStructure{Name: tc.structure})
 		c.Check(err, IsNil)
 		c.Check(found, Equals, filepath.Join(d.dir, "/dev/fakedevice"))
 	}
@@ -86,9 +84,7 @@ func (d *deviceSuite) TestDeviceFindRelativeSymlink(c *C) {
 	err := os.Symlink("../../fakedevice", filepath.Join(d.dir, "/dev/disk/by-partlabel/relative"))
 	c.Assert(err, IsNil)
 
-	found, err := gadget.FindDeviceForStructure(&gadget.LaidOutStructure{
-		VolumeStructure: &gadget.VolumeStructure{Name: "relative"},
-	})
+	found, err := gadget.FindDeviceForStructure(&gadget.VolumeStructure{Name: "relative"})
 	c.Check(err, IsNil)
 	c.Check(found, Equals, filepath.Join(d.dir, "/dev/fakedevice"))
 }
@@ -112,11 +108,9 @@ func (d *deviceSuite) TestDeviceFindByFilesystemLabel(c *C) {
 
 	for _, tc := range names {
 		c.Logf("trying: %q", tc)
-		found, err := gadget.FindDeviceForStructure(&gadget.LaidOutStructure{
-			VolumeStructure: &gadget.VolumeStructure{
-				Filesystem: "ext4",
-				Label:      tc.structure,
-			},
+		found, err := gadget.FindDeviceForStructure(&gadget.VolumeStructure{
+			Filesystem: "ext4",
+			Label:      tc.structure,
 		})
 		c.Check(err, IsNil)
 		c.Check(found, Equals, filepath.Join(d.dir, "/dev/fakedevice"))
@@ -131,11 +125,9 @@ func (d *deviceSuite) TestDeviceFindChecksPartlabelAndFilesystemLabelHappy(c *C)
 	err = os.Symlink(fakedevice, filepath.Join(d.dir, "/dev/disk/by-partlabel/bar"))
 	c.Assert(err, IsNil)
 
-	found, err := gadget.FindDeviceForStructure(&gadget.LaidOutStructure{
-		VolumeStructure: &gadget.VolumeStructure{
-			Name:  "bar",
-			Label: "foo",
-		},
+	found, err := gadget.FindDeviceForStructure(&gadget.VolumeStructure{
+		Name:  "bar",
+		Label: "foo",
 	})
 	c.Check(err, IsNil)
 	c.Check(found, Equals, filepath.Join(d.dir, "/dev/fakedevice"))
@@ -147,11 +139,9 @@ func (d *deviceSuite) TestDeviceFindFilesystemLabelToNameFallback(c *C) {
 	err := os.Symlink(fakedevice, filepath.Join(d.dir, "/dev/disk/by-label/foo"))
 	c.Assert(err, IsNil)
 
-	found, err := gadget.FindDeviceForStructure(&gadget.LaidOutStructure{
-		VolumeStructure: &gadget.VolumeStructure{
-			Name:       "foo",
-			Filesystem: "ext4",
-		},
+	found, err := gadget.FindDeviceForStructure(&gadget.VolumeStructure{
+		Name:       "foo",
+		Filesystem: "ext4",
 	})
 	c.Check(err, IsNil)
 	c.Check(found, Equals, filepath.Join(d.dir, "/dev/fakedevice"))
@@ -169,23 +159,19 @@ func (d *deviceSuite) TestDeviceFindChecksPartlabelAndFilesystemLabelMismatch(c 
 	err = os.Symlink(fakedeviceOther, filepath.Join(d.dir, "/dev/disk/by-partlabel/bar"))
 	c.Assert(err, IsNil)
 
-	found, err := gadget.FindDeviceForStructure(&gadget.LaidOutStructure{
-		VolumeStructure: &gadget.VolumeStructure{
-			Name:       "bar",
-			Label:      "foo",
-			Filesystem: "ext4",
-		},
+	found, err := gadget.FindDeviceForStructure(&gadget.VolumeStructure{
+		Name:       "bar",
+		Label:      "foo",
+		Filesystem: "ext4",
 	})
 	c.Check(err, ErrorMatches, `conflicting device match, ".*/by-label/foo" points to ".*/fakedevice", previous match ".*/by-partlabel/bar" points to ".*/fakedevice-other"`)
 	c.Check(found, Equals, "")
 }
 
 func (d *deviceSuite) TestDeviceFindNotFound(c *C) {
-	found, err := gadget.FindDeviceForStructure(&gadget.LaidOutStructure{
-		VolumeStructure: &gadget.VolumeStructure{
-			Name:  "bar",
-			Label: "foo",
-		},
+	found, err := gadget.FindDeviceForStructure(&gadget.VolumeStructure{
+		Name:  "bar",
+		Label: "foo",
 	})
 	c.Check(err, ErrorMatches, `device not found`)
 	c.Check(found, Equals, "")
@@ -193,24 +179,20 @@ func (d *deviceSuite) TestDeviceFindNotFound(c *C) {
 
 func (d *deviceSuite) TestDeviceFindNotFoundEmpty(c *C) {
 	// neither name nor filesystem label set
-	found, err := gadget.FindDeviceForStructure(&gadget.LaidOutStructure{
-		VolumeStructure: &gadget.VolumeStructure{
-			Name: "",
-			// structure has no filesystem, fs label check is
-			// ineffective
-			Label: "",
-		},
+	found, err := gadget.FindDeviceForStructure(&gadget.VolumeStructure{
+		Name: "",
+		// structure has no filesystem, fs label check is
+		// ineffective
+		Label: "",
 	})
 	c.Check(err, ErrorMatches, `device not found`)
 	c.Check(found, Equals, "")
 
 	// try with proper filesystem now
-	found, err = gadget.FindDeviceForStructure(&gadget.LaidOutStructure{
-		VolumeStructure: &gadget.VolumeStructure{
-			Name:       "",
-			Label:      "",
-			Filesystem: "ext4",
-		},
+	found, err = gadget.FindDeviceForStructure(&gadget.VolumeStructure{
+		Name:       "",
+		Label:      "",
+		Filesystem: "ext4",
 	})
 	c.Check(err, ErrorMatches, `device not found`)
 	c.Check(found, Equals, "")
@@ -221,10 +203,8 @@ func (d *deviceSuite) TestDeviceFindNotFoundSymlinkPointsNowhere(c *C) {
 	err := os.Symlink(fakedevice, filepath.Join(d.dir, "/dev/disk/by-label/foo"))
 	c.Assert(err, IsNil)
 
-	found, err := gadget.FindDeviceForStructure(&gadget.LaidOutStructure{
-		VolumeStructure: &gadget.VolumeStructure{
-			Label: "foo",
-		},
+	found, err := gadget.FindDeviceForStructure(&gadget.VolumeStructure{
+		Label: "foo",
 	})
 	c.Check(err, ErrorMatches, `device not found`)
 	c.Check(found, Equals, "")
@@ -234,11 +214,9 @@ func (d *deviceSuite) TestDeviceFindNotFoundNotASymlink(c *C) {
 	err := ioutil.WriteFile(filepath.Join(d.dir, "/dev/disk/by-label/foo"), nil, 0644)
 	c.Assert(err, IsNil)
 
-	found, err := gadget.FindDeviceForStructure(&gadget.LaidOutStructure{
-		VolumeStructure: &gadget.VolumeStructure{
-			Filesystem: "ext4",
-			Label:      "foo",
-		},
+	found, err := gadget.FindDeviceForStructure(&gadget.VolumeStructure{
+		Filesystem: "ext4",
+		Label:      "foo",
 	})
 	c.Check(err, ErrorMatches, `candidate .*/dev/disk/by-label/foo is not a symlink`)
 	c.Check(found, Equals, "")
@@ -256,11 +234,9 @@ func (d *deviceSuite) TestDeviceFindBadEvalSymlinks(c *C) {
 	})
 	defer restore()
 
-	found, err := gadget.FindDeviceForStructure(&gadget.LaidOutStructure{
-		VolumeStructure: &gadget.VolumeStructure{
-			Filesystem: "vfat",
-			Label:      "foo",
-		},
+	found, err := gadget.FindDeviceForStructure(&gadget.VolumeStructure{
+		Filesystem: "vfat",
+		Label:      "foo",
 	})
 	c.Check(err, ErrorMatches, `cannot read device link: failed`)
 	c.Check(found, Equals, "")

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -41,6 +41,7 @@ import (
 	"github.com/snapcore/snapd/metautil"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/disks"
+	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/naming"
 	"github.com/snapcore/snapd/snap/snapfile"
@@ -1239,7 +1240,7 @@ func IsCompatible(current, new *Info) error {
 // flashed and managed separately at image build/flash time, while the system
 // volume with all the system-* roles on it can be manipulated during install
 // mode.
-func LaidOutVolumesFromGadget(gadgetRoot, kernelRoot string, model Model) (system *LaidOutVolume, all map[string]*LaidOutVolume, err error) {
+func LaidOutVolumesFromGadget(gadgetRoot, kernelRoot string, model Model, encType secboot.EncryptionType) (system *LaidOutVolume, all map[string]*LaidOutVolume, err error) {
 	all = make(map[string]*LaidOutVolume)
 	// model should never be nil here
 	if model == nil {
@@ -1256,6 +1257,7 @@ func LaidOutVolumesFromGadget(gadgetRoot, kernelRoot string, model Model) (syste
 	opts := &LayoutOptions{
 		GadgetRootDir: gadgetRoot,
 		KernelRootDir: kernelRoot,
+		EncType:       encType,
 	}
 
 	// find the volume with the system-boot role on it, we already validated

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -395,7 +395,7 @@ func AllDiskVolumeDeviceTraits(allLaidOutVols map[string]*LaidOutVolume, optsPer
 		// partitions we can't map to a device directly at first using the
 		// device symlinks that FindDeviceForStructure uses
 		dev := ""
-		for _, vs := range vol.LaidOutStructure {
+		for _, ls := range vol.LaidOutStructure {
 			// TODO: This code works for volumes that have at least one
 			// partition (i.e. not type: bare structure), but does not work for
 			// volumes which contain only type: bare structures with no other
@@ -407,12 +407,12 @@ func AllDiskVolumeDeviceTraits(allLaidOutVols map[string]*LaidOutVolume, optsPer
 			// at the expected locations, but that is probably fragile and very
 			// non-performant.
 
-			if !vs.IsPartition() {
+			if !ls.VolumeStructure.IsPartition() {
 				// skip trying to find non-partitions on disk, it won't work
 				continue
 			}
 
-			structureDevice, err := FindDeviceForStructure(&vs)
+			structureDevice, err := FindDeviceForStructure(ls.VolumeStructure)
 			if err != nil && err != ErrDeviceNotFound {
 				return nil, err
 			}

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -407,7 +407,7 @@ func AllDiskVolumeDeviceTraits(allLaidOutVols map[string]*LaidOutVolume, optsPer
 			// at the expected locations, but that is probably fragile and very
 			// non-performant.
 
-			if !ls.VolumeStructure.IsPartition() {
+			if !ls.IsPartition() {
 				// skip trying to find non-partitions on disk, it won't work
 				continue
 			}

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -2156,9 +2156,10 @@ func (s *gadgetYamlTestSuite) TestLaidOutVolumesFromGadgetMultiVolume(c *C) {
 	c.Assert(all["u-boot-frobinator"].LaidOutStructure, DeepEquals, []gadget.LaidOutStructure{
 		{
 			OnDiskStructure: gadget.OnDiskStructure{
-				Name: "u-boot",
-				Type: "bare",
-				Size: quantity.Size(623000),
+				Name:        "u-boot",
+				Type:        "bare",
+				Size:        quantity.Size(623000),
+				StartOffset: 24576,
 			},
 			VolumeStructure: &gadget.VolumeStructure{
 				VolumeName: "u-boot-frobinator",

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil/disks"
+	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snapfile"
 	"github.com/snapcore/snapd/snap/snaptest"
@@ -2147,7 +2148,7 @@ func (s *gadgetYamlTestSuite) TestLaidOutVolumesFromGadgetMultiVolume(c *C) {
 	err = ioutil.WriteFile(filepath.Join(s.dir, "u-boot.imz"), nil, 0644)
 	c.Assert(err, IsNil)
 
-	systemLv, all, err := gadget.LaidOutVolumesFromGadget(s.dir, "", uc20Mod)
+	systemLv, all, err := gadget.LaidOutVolumesFromGadget(s.dir, "", uc20Mod, secboot.EncryptionTypeNone)
 	c.Assert(err, IsNil)
 
 	c.Assert(all, HasLen, 2)
@@ -2155,6 +2156,8 @@ func (s *gadgetYamlTestSuite) TestLaidOutVolumesFromGadgetMultiVolume(c *C) {
 	c.Assert(all["u-boot-frobinator"].LaidOutStructure, DeepEquals, []gadget.LaidOutStructure{
 		{
 			OnDiskStructure: gadget.OnDiskStructure{
+				Name: "u-boot",
+				Type: "bare",
 				Size: quantity.Size(623000),
 			},
 			VolumeStructure: &gadget.VolumeStructure{
@@ -2191,7 +2194,7 @@ func (s *gadgetYamlTestSuite) TestLaidOutVolumesFromGadgetHappy(c *C) {
 		c.Assert(err, IsNil)
 	}
 
-	systemLv, all, err := gadget.LaidOutVolumesFromGadget(s.dir, "", coreMod)
+	systemLv, all, err := gadget.LaidOutVolumesFromGadget(s.dir, "", coreMod, secboot.EncryptionTypeNone)
 	c.Assert(err, IsNil)
 	c.Assert(all, HasLen, 1)
 	c.Assert(all["pc"], DeepEquals, systemLv)
@@ -2210,7 +2213,7 @@ func (s *gadgetYamlTestSuite) TestLaidOutVolumesFromGadgetNeedsModel(c *C) {
 
 	// need the model in order to lay out system volumes due to the verification
 	// and other metadata we use with the gadget
-	_, _, err = gadget.LaidOutVolumesFromGadget(s.dir, "", nil)
+	_, _, err = gadget.LaidOutVolumesFromGadget(s.dir, "", nil, secboot.EncryptionTypeNone)
 	c.Assert(err, ErrorMatches, "internal error: must have model to lay out system volumes from a gadget")
 }
 
@@ -2222,7 +2225,7 @@ func (s *gadgetYamlTestSuite) TestLaidOutVolumesFromGadgetUC20Happy(c *C) {
 		c.Assert(err, IsNil)
 	}
 
-	systemLv, all, err := gadget.LaidOutVolumesFromGadget(s.dir, "", uc20Mod)
+	systemLv, all, err := gadget.LaidOutVolumesFromGadget(s.dir, "", uc20Mod, secboot.EncryptionTypeNone)
 	c.Assert(err, IsNil)
 	c.Assert(all, HasLen, 1)
 	c.Assert(all["pc"], DeepEquals, systemLv)
@@ -3759,7 +3762,7 @@ func (s *gadgetYamlTestSuite) TestLaidOutVolumesFromClassicWithModesGadgetHappy(
 		c.Assert(err, IsNil)
 	}
 
-	systemLv, all, err := gadget.LaidOutVolumesFromGadget(s.dir, "", classicWithModesMod)
+	systemLv, all, err := gadget.LaidOutVolumesFromGadget(s.dir, "", classicWithModesMod, secboot.EncryptionTypeNone)
 	c.Assert(err, IsNil)
 	c.Assert(all, HasLen, 1)
 	c.Assert(all["pc"], DeepEquals, systemLv)

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -2167,7 +2167,6 @@ func (s *gadgetYamlTestSuite) TestLaidOutVolumesFromGadgetMultiVolume(c *C) {
 					{Image: "u-boot.imz"},
 				},
 			},
-			StartOffset: 24576,
 			LaidOutContent: []gadget.LaidOutContent{
 				{
 					VolumeContent: &gadget.VolumeContent{

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -2154,6 +2154,9 @@ func (s *gadgetYamlTestSuite) TestLaidOutVolumesFromGadgetMultiVolume(c *C) {
 	c.Assert(all["frobinator-image"], DeepEquals, systemLv)
 	c.Assert(all["u-boot-frobinator"].LaidOutStructure, DeepEquals, []gadget.LaidOutStructure{
 		{
+			OnDiskStructure: gadget.OnDiskStructure{
+				Size: quantity.Size(623000),
+			},
 			VolumeStructure: &gadget.VolumeStructure{
 				VolumeName: "u-boot-frobinator",
 				Name:       "u-boot",

--- a/gadget/gadgettest/gadgettest.go
+++ b/gadget/gadgettest/gadgettest.go
@@ -182,11 +182,13 @@ func MockGadgetPartitionedDisk(gadgetYaml, gadgetRoot string) (ginfo *gadget.Inf
 			},
 			{
 				PartitionLabel:   "ubuntu-save",
+				FilesystemLabel:  "ubuntu-save-enc",
 				KernelDeviceNode: "/dev/vda4",
 				DiskIndex:        4,
 			},
 			{
 				PartitionLabel:   "ubuntu-data",
+				FilesystemLabel:  "ubuntu-data-enc",
 				KernelDeviceNode: "/dev/vda5",
 				DiskIndex:        5,
 			},

--- a/gadget/gadgettest/gadgettest.go
+++ b/gadget/gadgettest/gadgettest.go
@@ -29,6 +29,7 @@ import (
 	"github.com/snapcore/snapd/boot/boottest"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/osutil/disks"
+	"github.com/snapcore/snapd/secboot"
 )
 
 // LayoutMultiVolumeFromYaml returns all LaidOutVolumes for the given
@@ -41,7 +42,7 @@ func LayoutMultiVolumeFromYaml(newDir, kernelDir, gadgetYaml string, model gadge
 		return nil, err
 	}
 
-	_, allVolumes, err := gadget.LaidOutVolumesFromGadget(gadgetRoot, kernelDir, model)
+	_, allVolumes, err := gadget.LaidOutVolumesFromGadget(gadgetRoot, kernelDir, model, secboot.EncryptionTypeNone)
 	if err != nil {
 		return nil, fmt.Errorf("cannot layout volumes: %v", err)
 	}
@@ -151,7 +152,7 @@ func MockGadgetPartitionedDisk(gadgetYaml, gadgetRoot string) (ginfo *gadget.Inf
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
-	_, laidVols, err = gadget.LaidOutVolumesFromGadget(gadgetRoot, "", model)
+	_, laidVols, err = gadget.LaidOutVolumesFromGadget(gadgetRoot, "", model, secboot.EncryptionTypeNone)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}

--- a/gadget/gadgettest/gadgettest.go
+++ b/gadget/gadgettest/gadgettest.go
@@ -162,7 +162,10 @@ func MockGadgetPartitionedDisk(gadgetYaml, gadgetRoot string) (ginfo *gadget.Inf
 		return nil, nil, nil, nil, err
 	}
 
-	// "Real" disk data that will be read
+	// "Real" disk data that will be read. Filesystem type and label are not
+	// filled as the filesystem is considered not created yet, which is
+	// expected by some tests (some option would have to be added to fill or
+	// not if this data is needed by some test in the future).
 	vdaSysPath := "/sys/devices/pci0000:00/0000:00:03.0/virtio1/block/vda"
 	disk := &disks.MockDiskMapping{
 		Structure: []disks.Partition{
@@ -183,13 +186,11 @@ func MockGadgetPartitionedDisk(gadgetYaml, gadgetRoot string) (ginfo *gadget.Inf
 			},
 			{
 				PartitionLabel:   "ubuntu-save",
-				FilesystemLabel:  "ubuntu-save-enc",
 				KernelDeviceNode: "/dev/vda4",
 				DiskIndex:        4,
 			},
 			{
 				PartitionLabel:   "ubuntu-data",
-				FilesystemLabel:  "ubuntu-data-enc",
 				KernelDeviceNode: "/dev/vda5",
 				DiskIndex:        5,
 			},

--- a/gadget/install/content.go
+++ b/gadget/install/content.go
@@ -42,14 +42,6 @@ type mkfsParams struct {
 	SectorSize quantity.Size
 }
 
-// onDiskAndLaidoutStructure puts together the on disk and the laid
-// out for a disk structure.
-// TODO This is a temporary structure until we include StorageStructure in LaidOutStructure.
-type onDiskAndLaidoutStructure struct {
-	onDisk  *gadget.OnDiskStructure
-	laidOut *gadget.LaidOutStructure
-}
-
 // makeFilesystem creates a filesystem on the on-disk structure, according
 // to the filesystem type defined in the gadget. If sectorSize is specified,
 // that sector size is used when creating the filesystem, otherwise if it is

--- a/gadget/install/encrypt.go
+++ b/gadget/install/encrypt.go
@@ -57,7 +57,7 @@ var _ = encryptedDevice(&encryptedDeviceLUKS{})
 
 // newEncryptedDeviceLUKS creates an encrypted device in the existing
 // partition using the specified key with the LUKS backend.
-func newEncryptedDeviceLUKS(part *gadget.OnDiskStructure, key keys.EncryptionKey, name string) (encryptedDevice, error) {
+func newEncryptedDeviceLUKS(part *gadget.OnDiskStructure, key keys.EncryptionKey, label, name string) (encryptedDevice, error) {
 	dev := &encryptedDeviceLUKS{
 		parent: part,
 		name:   name,
@@ -67,7 +67,7 @@ func newEncryptedDeviceLUKS(part *gadget.OnDiskStructure, key keys.EncryptionKey
 		node: fmt.Sprintf("/dev/mapper/%s", name),
 	}
 
-	if err := secbootFormatEncryptedDevice(key, name+"-enc", part.Node); err != nil {
+	if err := secbootFormatEncryptedDevice(key, label, part.Node); err != nil {
 		return nil, fmt.Errorf("cannot format encrypted device: %v", err)
 	}
 

--- a/gadget/install/encrypt_test.go
+++ b/gadget/install/encrypt_test.go
@@ -108,7 +108,7 @@ func (s *encryptSuite) TestNewEncryptedDeviceLUKS(c *C) {
 		})
 		defer restore()
 
-		dev, err := install.NewEncryptedDeviceLUKS(&mockDeviceStructure, s.mockedEncryptionKey, "some-label")
+		dev, err := install.NewEncryptedDeviceLUKS(&mockDeviceStructure, s.mockedEncryptionKey, "some-label-enc", "some-label")
 		c.Assert(calls, Equals, 1)
 		if tc.expectedErr == "" {
 			c.Assert(err, IsNil)

--- a/gadget/install/export_test.go
+++ b/gadget/install/export_test.go
@@ -58,7 +58,7 @@ func MockSysUnmount(f func(target string, flags int) error) (restore func()) {
 	}
 }
 
-func MockEnsureNodesExist(f func(dss []gadget.OnDiskStructure, timeout time.Duration) error) (restore func()) {
+func MockEnsureNodesExist(f func(nodes []string, timeout time.Duration) error) (restore func()) {
 	old := ensureNodesExist
 	ensureNodesExist = f
 	return func() {

--- a/gadget/install/export_test.go
+++ b/gadget/install/export_test.go
@@ -59,7 +59,7 @@ func MockSysUnmount(f func(target string, flags int) error) (restore func()) {
 	}
 }
 
-func MockEnsureNodesExist(f func(dss []OnDiskAndLaidoutStructure, timeout time.Duration) error) (restore func()) {
+func MockEnsureNodesExist(f func(dss []gadget.OnDiskStructure, timeout time.Duration) error) (restore func()) {
 	old := ensureNodesExist
 	ensureNodesExist = f
 	return func() {

--- a/gadget/install/export_test.go
+++ b/gadget/install/export_test.go
@@ -28,7 +28,6 @@ import (
 )
 
 type MkfsParams = mkfsParams
-type OnDiskAndLaidoutStructure = onDiskAndLaidoutStructure
 
 var (
 	MakeFilesystem         = makeFilesystem
@@ -101,16 +100,4 @@ func CheckEncryptionSetupData(encryptSetup *EncryptionSetupData, labelToEncDevic
 	}
 
 	return nil
-}
-
-func MockOnDiskAndLaidoutStructure(onDisk *gadget.OnDiskStructure, laidOut *gadget.LaidOutStructure) OnDiskAndLaidoutStructure {
-	return OnDiskAndLaidoutStructure{onDisk, laidOut}
-}
-
-func OnDiskFromOnDiskAndLaidoutStructure(odls OnDiskAndLaidoutStructure) *gadget.OnDiskStructure {
-	return odls.onDisk
-}
-
-func LaidOutFromOnDiskAndLaidoutStructure(odls OnDiskAndLaidoutStructure) *gadget.LaidOutStructure {
-	return odls.laidOut
 }

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -96,10 +96,8 @@ func saveStorageTraits(mod gadget.Model, allLaidOutVols map[string]*gadget.LaidO
 	return nil
 }
 
-func maybeEncryptPartition(odls *onDiskAndLaidoutStructure, encryptionType secboot.EncryptionType, sectorSize quantity.Size, perfTimings timings.Measurer) (fsParams *mkfsParams, encryptionKey keys.EncryptionKey, err error) {
+func maybeEncryptPartition(laidOut *gadget.LaidOutStructure, encryptionType secboot.EncryptionType, sectorSize quantity.Size, perfTimings timings.Measurer) (fsParams *mkfsParams, encryptionKey keys.EncryptionKey, err error) {
 	mustEncrypt := (encryptionType != secboot.EncryptionTypeNone)
-	onDisk := odls.onDisk
-	laidOut := odls.laidOut
 	// fsParams.Device is the kernel device that carries the
 	// filesystem, which is either the raw /dev/<partition>, or
 	// the mapped LUKS device if the structure is encrypted (if

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -450,7 +450,7 @@ func applyLayoutToOnDiskStructure(onDiskVol *gadget.OnDiskVolume, partNode strin
 	if err != nil {
 		return nil, err
 	}
-	logger.Noticef("laidOutStruct.OnDiskStructure: %+v, *onDiskStruct: %+v",
+	logger.Debugf("when applying layout to disk structure: laidOutStruct.OnDiskStructure: %+v, *onDiskStruct: %+v",
 		laidOutStruct.OnDiskStructure, *onDiskStruct)
 
 	// Keep wanted filesystem label and type, as that is what we actually want

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -437,10 +437,10 @@ func onDiskVolumeFromPartitionSysfsPath(partPath string) (*gadget.OnDiskVolume, 
 	return onDiskVol, nil
 }
 
-// applyLayoutToOnDiskStructure finds the on disk structure from a
+// applyOnDiskStructureToLaidOut finds the on disk structure from a
 // partition node and takes the laid out information from laidOutVols
 // and inserts it there.
-func applyLayoutToOnDiskStructure(onDiskVol *gadget.OnDiskVolume, partNode string, laidOutVols map[string]*gadget.LaidOutVolume, gadgetVolName string, creatingPart bool) (*gadget.LaidOutStructure, error) {
+func applyOnDiskStructureToLaidOut(onDiskVol *gadget.OnDiskVolume, partNode string, laidOutVols map[string]*gadget.LaidOutVolume, gadgetVolName string, creatingPart bool) (*gadget.LaidOutStructure, error) {
 	onDiskStruct, err := structureFromPartDevice(onDiskVol, partNode)
 	if err != nil {
 		return nil, fmt.Errorf("cannot find partition %q: %v", partNode, err)
@@ -516,7 +516,7 @@ func WriteContent(onVolumes map[string]*gadget.Volume, allLaidOutVols map[string
 			// sector sizes for the encrypted/unencrypted
 			// cases here?
 			const creatingPart = false
-			laidOut, err := applyLayoutToOnDiskStructure(onDiskVol, volStruct.Device, allLaidOutVols, volName, creatingPart)
+			laidOut, err := applyOnDiskStructureToLaidOut(onDiskVol, volStruct.Device, allLaidOutVols, volName, creatingPart)
 			if err != nil {
 				return nil, fmt.Errorf("cannot retrieve on disk info for %q: %v", volStruct.Device, err)
 			}
@@ -658,7 +658,7 @@ func EncryptPartitions(onVolumes map[string]*gadget.Volume, encryptionType secbo
 			}
 			// Obtain partition data and link with laid out information
 			const creatingPart = true
-			laidOut, err := applyLayoutToOnDiskStructure(onDiskVol, device, allLaidOutVols, volName, creatingPart)
+			laidOut, err := applyOnDiskStructureToLaidOut(onDiskVol, device, allLaidOutVols, volName, creatingPart)
 			if err != nil {
 				return nil, fmt.Errorf("cannot retrieve on disk info for %q: %v", device, err)
 			}

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -46,7 +46,7 @@ func diskWithSystemSeed(lv *gadget.LaidOutVolume) (device string, err error) {
 		// XXX: this part of the finding maybe should be a
 		// method on gadget.*Volume
 		if vs.Role() == gadget.SystemSeed {
-			device, err = gadget.FindDeviceForStructure(&vs)
+			device, err = gadget.FindDeviceForStructure(vs.VolumeStructure)
 			if err != nil {
 				return "", fmt.Errorf("cannot find device for role system-seed: %v", err)
 			}

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -212,7 +212,7 @@ func installOnePartition(laidOut *gadget.LaidOutStructure, encryptionType secboo
 	return fsDevice, encryptionKey, nil
 }
 
-func setCryptoInfoInLaidOuts(encType secboot.EncryptionType, los []gadget.LaidOutStructure) {
+func setCryptoDetailsInLaidOuts(encType secboot.EncryptionType, los []gadget.LaidOutStructure) {
 	if encType != "" {
 		for i := range los {
 			switch los[i].Role() {
@@ -262,7 +262,7 @@ func createPartitions(model gadget.Model, gadgetRoot, kernelRoot, bootDevice str
 	}
 	// Tweak laid out data depending on encryption type
 	// TODO: try to build LaidOutVolume with all info in the future
-	setCryptoInfoInLaidOuts(options.EncryptionType, laidOutBootVol.LaidOutStructure)
+	setCryptoDetailsInLaidOuts(options.EncryptionType, laidOutBootVol.LaidOutStructure)
 
 	// check if the current partition table is compatible with the gadget,
 	// ignoring partitions added by the installer (will be removed later)
@@ -295,7 +295,7 @@ func createPartitions(model gadget.Model, gadgetRoot, kernelRoot, bootDevice str
 	}
 	// Tweak laid out data depending on encryption type
 	// TODO: try to build LaidOutVolume with all info in the future
-	setCryptoInfoInLaidOuts(options.EncryptionType, created)
+	setCryptoDetailsInLaidOuts(options.EncryptionType, created)
 
 	bootVolGadgetName = laidOutBootVol.Name
 	bootVolSectorSize = diskLayout.SectorSize
@@ -368,7 +368,7 @@ func Run(model gadget.Model, gadgetRoot, kernelRoot, bootDevice string, options 
 			keyForRole[laidOut.Role()] = encryptionKey
 			partsEncrypted[laidOut.Name()] = createEncryptionParams(options.EncryptionType)
 		}
-		if options.Mount && laidOut.Label() != "" && laidOut.VolumeStructure.HasFilesystem() {
+		if options.Mount && laidOut.Label() != "" && laidOut.HasFilesystem() {
 			// fs is taken from gadget, as on disk one might be displayed as
 			// crypto_LUKS, which is not useful for formatting.
 			if err := mountFilesystem(fsDevice, laidOut.VolumeStructure.Filesystem, getMntPointForPart(laidOut.VolumeStructure)); err != nil {
@@ -787,7 +787,7 @@ func FactoryReset(model gadget.Model, gadgetRoot, kernelRoot, bootDevice string,
 			}
 			keyForRole[laidOut.Role()] = encryptionKey
 		}
-		if options.Mount && laidOut.Label() != "" && laidOut.VolumeStructure.HasFilesystem() {
+		if options.Mount && laidOut.Label() != "" && laidOut.HasFilesystem() {
 			// fs is taken from gadget, as on disk one might be displayed as
 			// crypto_LUKS, which is not useful for formatting.
 			if err := mountFilesystem(fsDevice, laidOut.VolumeStructure.Filesystem, getMntPointForPart(laidOut.VolumeStructure)); err != nil {

--- a/gadget/install/install_test.go
+++ b/gadget/install/install_test.go
@@ -160,88 +160,39 @@ func (s *installSuite) testInstall(c *C, opts installOpts) {
 		defer mockBlockdev.Restore()
 	}
 
-	restore = install.MockEnsureNodesExist(func(dss []install.OnDiskAndLaidoutStructure, timeout time.Duration) error {
+	restore = install.MockEnsureNodesExist(func(dss []gadget.OnDiskStructure, timeout time.Duration) error {
 		c.Assert(timeout, Equals, 5*time.Second)
-		c.Assert(dss, DeepEquals, []install.OnDiskAndLaidoutStructure{
-			install.MockOnDiskAndLaidoutStructure(
-				&gadget.OnDiskStructure{
-					Name:             "ubuntu-boot",
-					PartitionFSLabel: "ubuntu-boot",
-					Type:             "0C",
-					PartitionFSType:  "vfat",
-					StartOffset:      (1 + 1200) * quantity.OffsetMiB,
-					// note this is YamlIndex + 1, the YamlIndex starts at 0
-					DiskIndex: 2,
-					Node:      "/dev/mmcblk0p2",
-					Size:      750 * quantity.SizeMiB,
-				},
-				&gadget.LaidOutStructure{
-					VolumeStructure: &gadget.VolumeStructure{
-						VolumeName: "pi",
-						Name:       "ubuntu-boot",
-						Label:      "ubuntu-boot",
-						Type:       "0C",
-						Role:       gadget.SystemBoot,
-						Filesystem: "vfat",
-						Offset:     asOffsetPtr((1 + 1200) * quantity.OffsetMiB),
-						Size:       750 * quantity.SizeMiB,
-					},
-					StartOffset: (1 + 1200) * quantity.OffsetMiB,
-					YamlIndex:   1,
-				}),
-			install.MockOnDiskAndLaidoutStructure(
-				&gadget.OnDiskStructure{
-					Name:             "ubuntu-save",
-					PartitionFSLabel: "ubuntu-save",
-					Type:             "83,0FC63DAF-8483-4772-8E79-3D69D8477DE4",
-					PartitionFSType:  "ext4",
-					StartOffset:      (1 + 1200 + 750) * quantity.OffsetMiB,
-					// note this is YamlIndex + 1, the YamlIndex starts at 0
-					DiskIndex: 3,
-					Node:      "/dev/mmcblk0p3",
-					Size:      16 * quantity.SizeMiB,
-				},
-				&gadget.LaidOutStructure{
-					VolumeStructure: &gadget.VolumeStructure{
-						VolumeName: "pi",
-						Name:       "ubuntu-save",
-						Label:      "ubuntu-save",
-						Type:       "83,0FC63DAF-8483-4772-8E79-3D69D8477DE4",
-						Role:       gadget.SystemSave,
-						Filesystem: "ext4",
-						Offset:     asOffsetPtr((1 + 1200 + 750) * quantity.OffsetMiB),
-						Size:       16 * quantity.SizeMiB,
-					},
-					StartOffset: (1 + 1200 + 750) * quantity.OffsetMiB,
-					YamlIndex:   2,
-				}),
-			install.MockOnDiskAndLaidoutStructure(
-				&gadget.OnDiskStructure{
-					Name:             "ubuntu-data",
-					PartitionFSLabel: "ubuntu-data",
-					Type:             "83,0FC63DAF-8483-4772-8E79-3D69D8477DE4",
-					PartitionFSType:  "ext4",
-					StartOffset:      (1 + 1200 + 750 + 16) * quantity.OffsetMiB,
-					// note this is YamlIndex + 1, the YamlIndex starts at 0
-					DiskIndex: 4,
-					Node:      "/dev/mmcblk0p4",
-					Size:      (30528 - (1 + 1200 + 750 + 16)) * quantity.SizeMiB,
-				},
-				&gadget.LaidOutStructure{
-					VolumeStructure: &gadget.VolumeStructure{
-						VolumeName: "pi",
-						Name:       "ubuntu-data",
-						Label:      "ubuntu-data",
-						Type:       "83,0FC63DAF-8483-4772-8E79-3D69D8477DE4",
-						Role:       gadget.SystemData,
-						Filesystem: "ext4",
-						// as set in gadgettest.RaspiSimplifiedYaml
-						Offset: asOffsetPtr((1 + 1200 + 750 + 16) * quantity.OffsetMiB),
-						Size:   1500 * quantity.SizeMiB,
-					},
-					StartOffset: (1 + 1200 + 750 + 16) * quantity.OffsetMiB,
-					YamlIndex:   3,
-				}),
+		c.Assert(dss, DeepEquals, []gadget.OnDiskStructure{{
+			Name:             "ubuntu-boot",
+			PartitionFSLabel: "ubuntu-boot",
+			Type:             "0C",
+			PartitionFSType:  "vfat",
+			StartOffset:      (1 + 1200) * quantity.OffsetMiB,
+			// note this is YamlIndex + 1, the YamlIndex starts at 0
+			DiskIndex: 2,
+			Node:      "/dev/mmcblk0p2",
+			Size:      750 * quantity.SizeMiB,
+		}, {
+			Name:             "ubuntu-save",
+			PartitionFSLabel: "ubuntu-save",
+			Type:             "83,0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+			PartitionFSType:  "ext4",
+			StartOffset:      (1 + 1200 + 750) * quantity.OffsetMiB,
+			// note this is YamlIndex + 1, the YamlIndex starts at 0
+			DiskIndex: 3,
+			Node:      "/dev/mmcblk0p3",
+			Size:      16 * quantity.SizeMiB,
+		}, {
+			Name:             "ubuntu-data",
+			PartitionFSLabel: "ubuntu-data",
+			Type:             "83,0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+			PartitionFSType:  "ext4",
+			StartOffset:      (1 + 1200 + 750 + 16) * quantity.OffsetMiB,
+			// note this is YamlIndex + 1, the YamlIndex starts at 0
+			DiskIndex: 4,
+			Node:      "/dev/mmcblk0p4",
+			Size:      (30528 - (1 + 1200 + 750 + 16)) * quantity.SizeMiB,
+		},
 		})
 
 		// after ensuring that the nodes exist, we now setup a different, full
@@ -678,11 +629,11 @@ func (s *installSuite) testFactoryReset(c *C, opts factoryResetOpts) {
 	if opts.encryption {
 		dataDev = "/dev/mapper/ubuntu-data"
 	}
-	restore = install.MockEnsureNodesExist(func(dss []install.OnDiskAndLaidoutStructure, timeout time.Duration) error {
+	restore = install.MockEnsureNodesExist(func(dss []gadget.OnDiskStructure, timeout time.Duration) error {
 		c.Assert(timeout, Equals, 5*time.Second)
-		expectedDss := []install.OnDiskAndLaidoutStructure{
-			install.MockOnDiskAndLaidoutStructure(
-				&gadget.OnDiskStructure{
+		expectedDss := []gadget.LaidOutStructure{
+			{
+				OnDiskStructure: gadget.OnDiskStructure{
 					Name:             "ubuntu-boot",
 					PartitionFSLabel: "ubuntu-boot",
 					Size:             750 * quantity.SizeMiB,
@@ -693,21 +644,19 @@ func (s *installSuite) testFactoryReset(c *C, opts factoryResetOpts) {
 					DiskIndex: 2,
 					Node:      "/dev/mmcblk0p2",
 				},
-				&gadget.LaidOutStructure{
-					VolumeStructure: &gadget.VolumeStructure{
-						VolumeName: "pi",
-						Filesystem: "vfat",
-						Size:       750 * quantity.SizeMiB,
-					},
-					StartOffset: (1 + 1200) * quantity.OffsetMiB,
-					YamlIndex:   1,
+				VolumeStructure: &gadget.VolumeStructure{
+					VolumeName: "pi",
+					Filesystem: "vfat",
+					Size:       750 * quantity.SizeMiB,
 				},
-			),
+				StartOffset: (1 + 1200) * quantity.OffsetMiB,
+				YamlIndex:   1,
+			},
 		}
 		if opts.noSave {
 			// just data
-			expectedDss = append(expectedDss, install.MockOnDiskAndLaidoutStructure(
-				&gadget.OnDiskStructure{
+			expectedDss = append(expectedDss, gadget.LaidOutStructure{
+				OnDiskStructure: gadget.OnDiskStructure{
 					Name:             "ubuntu-data",
 					PartitionFSLabel: "ubuntu-data",
 					Type:             "83,0FC63DAF-8483-4772-8E79-3D69D8477DE4",
@@ -718,35 +667,34 @@ func (s *installSuite) testFactoryReset(c *C, opts factoryResetOpts) {
 					Node:      dataDev,
 					Size:      (30528 - (1 + 1200 + 750)) * quantity.SizeMiB,
 				},
-				&gadget.LaidOutStructure{
-					VolumeStructure: &gadget.VolumeStructure{
-						VolumeName: "pi",
-						Name:       "ubuntu-data",
-						Label:      "ubuntu-data",
-						Type:       "83,0FC63DAF-8483-4772-8E79-3D69D8477DE4",
-						Role:       gadget.SystemData,
-						Filesystem: "ext4",
-						Size:       (30528 - (1 + 1200 + 750)) * quantity.SizeMiB,
-					},
-					StartOffset: (1 + 1200 + 750) * quantity.OffsetMiB,
-					YamlIndex:   2,
+				VolumeStructure: &gadget.VolumeStructure{
+					VolumeName: "pi",
+					Name:       "ubuntu-data",
+					Label:      "ubuntu-data",
+					Type:       "83,0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+					Role:       gadget.SystemData,
+					Filesystem: "ext4",
+					Size:       (30528 - (1 + 1200 + 750)) * quantity.SizeMiB,
 				},
-			))
+				StartOffset: (1 + 1200 + 750) * quantity.OffsetMiB,
+				YamlIndex:   2,
+			},
+			)
 		} else {
 			// data + save
-			expectedDss = append(expectedDss, install.MockOnDiskAndLaidoutStructure(
-				&gadget.OnDiskStructure{
-					Name:             "ubuntu-save",
-					PartitionFSLabel: "ubuntu-save",
-					Type:             "83,0FC63DAF-8483-4772-8E79-3D69D8477DE4",
-					PartitionFSType:  "ext4",
-					StartOffset:      (1 + 1200 + 750) * quantity.OffsetMiB,
-					// note this is YamlIndex + 1, the YamlIndex starts at 0
-					DiskIndex: 3,
-					Node:      "/dev/mmcblk0p3",
-					Size:      16 * quantity.SizeMiB,
-				},
-				&gadget.LaidOutStructure{
+			expectedDss = append(expectedDss,
+				gadget.LaidOutStructure{
+					OnDiskStructure: gadget.OnDiskStructure{
+						Name:             "ubuntu-save",
+						PartitionFSLabel: "ubuntu-save",
+						Type:             "83,0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+						PartitionFSType:  "ext4",
+						StartOffset:      (1 + 1200 + 750) * quantity.OffsetMiB,
+						// note this is YamlIndex + 1, the YamlIndex starts at 0
+						DiskIndex: 3,
+						Node:      "/dev/mmcblk0p3",
+						Size:      16 * quantity.SizeMiB,
+					},
 					VolumeStructure: &gadget.VolumeStructure{
 						VolumeName: "pi",
 						Name:       "ubuntu-save",
@@ -759,9 +707,9 @@ func (s *installSuite) testFactoryReset(c *C, opts factoryResetOpts) {
 					StartOffset: (1 + 1200 + 750) * quantity.OffsetMiB,
 					YamlIndex:   2,
 				},
-			))
-			expectedDss = append(expectedDss, install.MockOnDiskAndLaidoutStructure(
-				&gadget.OnDiskStructure{
+			)
+			expectedDss = append(expectedDss, gadget.LaidOutStructure{
+				OnDiskStructure: gadget.OnDiskStructure{
 					Name:             "ubuntu-data",
 					PartitionFSLabel: "ubuntu-data",
 					Type:             "83,0FC63DAF-8483-4772-8E79-3D69D8477DE4",
@@ -772,23 +720,22 @@ func (s *installSuite) testFactoryReset(c *C, opts factoryResetOpts) {
 					Node:      dataDev,
 					Size:      (30528 - (1 + 1200 + 750 + 16)) * quantity.SizeMiB,
 				},
-				&gadget.LaidOutStructure{
-					VolumeStructure: &gadget.VolumeStructure{
-						VolumeName: "pi",
-						Name:       "ubuntu-data",
-						Label:      "ubuntu-data",
-						Type:       "83,0FC63DAF-8483-4772-8E79-3D69D8477DE4",
-						Role:       gadget.SystemData,
-						Filesystem: "ext4",
-						// TODO: this is set from the yaml, not from the actual
-						// calculated disk size, probably should be updated
-						// somewhere
-						Size: 1500 * quantity.SizeMiB,
-					},
-					StartOffset: (1 + 1200 + 750 + 16) * quantity.OffsetMiB,
-					YamlIndex:   3,
+				VolumeStructure: &gadget.VolumeStructure{
+					VolumeName: "pi",
+					Name:       "ubuntu-data",
+					Label:      "ubuntu-data",
+					Type:       "83,0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+					Role:       gadget.SystemData,
+					Filesystem: "ext4",
+					// TODO: this is set from the yaml, not from the actual
+					// calculated disk size, probably should be updated
+					// somewhere
+					Size: 1500 * quantity.SizeMiB,
 				},
-			))
+				StartOffset: (1 + 1200 + 750 + 16) * quantity.OffsetMiB,
+				YamlIndex:   3,
+			},
+			)
 		}
 		c.Assert(dss, DeepEquals, expectedDss)
 

--- a/gadget/install/install_test.go
+++ b/gadget/install/install_test.go
@@ -649,8 +649,7 @@ func (s *installSuite) testFactoryReset(c *C, opts factoryResetOpts) {
 					Filesystem: "vfat",
 					Size:       750 * quantity.SizeMiB,
 				},
-				StartOffset: (1 + 1200) * quantity.OffsetMiB,
-				YamlIndex:   1,
+				YamlIndex: 1,
 			},
 		}
 		if opts.noSave {
@@ -676,8 +675,7 @@ func (s *installSuite) testFactoryReset(c *C, opts factoryResetOpts) {
 					Filesystem: "ext4",
 					Size:       (30528 - (1 + 1200 + 750)) * quantity.SizeMiB,
 				},
-				StartOffset: (1 + 1200 + 750) * quantity.OffsetMiB,
-				YamlIndex:   2,
+				YamlIndex: 2,
 			},
 			)
 		} else {
@@ -704,8 +702,7 @@ func (s *installSuite) testFactoryReset(c *C, opts factoryResetOpts) {
 						Filesystem: "ext4",
 						Size:       16 * quantity.SizeMiB,
 					},
-					StartOffset: (1 + 1200 + 750) * quantity.OffsetMiB,
-					YamlIndex:   2,
+					YamlIndex: 2,
 				},
 			)
 			expectedDss = append(expectedDss, gadget.LaidOutStructure{
@@ -732,8 +729,7 @@ func (s *installSuite) testFactoryReset(c *C, opts factoryResetOpts) {
 					// somewhere
 					Size: 1500 * quantity.SizeMiB,
 				},
-				StartOffset: (1 + 1200 + 750 + 16) * quantity.OffsetMiB,
-				YamlIndex:   3,
+				YamlIndex: 3,
 			},
 			)
 		}

--- a/gadget/install/install_test.go
+++ b/gadget/install/install_test.go
@@ -162,6 +162,12 @@ func (s *installSuite) testInstall(c *C, opts installOpts) {
 
 	restore = install.MockEnsureNodesExist(func(dss []gadget.OnDiskStructure, timeout time.Duration) error {
 		c.Assert(timeout, Equals, 5*time.Second)
+		suffix := ""
+		dataPartFs := "ext4"
+		if opts.encryption {
+			suffix = "-enc"
+			dataPartFs = "crypto_LUKS"
+		}
 		c.Assert(dss, DeepEquals, []gadget.OnDiskStructure{{
 			Name:             "ubuntu-boot",
 			PartitionFSLabel: "ubuntu-boot",
@@ -174,9 +180,9 @@ func (s *installSuite) testInstall(c *C, opts installOpts) {
 			Size:      750 * quantity.SizeMiB,
 		}, {
 			Name:             "ubuntu-save",
-			PartitionFSLabel: "ubuntu-save",
+			PartitionFSLabel: "ubuntu-save" + suffix,
 			Type:             "83,0FC63DAF-8483-4772-8E79-3D69D8477DE4",
-			PartitionFSType:  "ext4",
+			PartitionFSType:  dataPartFs,
 			StartOffset:      (1 + 1200 + 750) * quantity.OffsetMiB,
 			// note this is YamlIndex + 1, the YamlIndex starts at 0
 			DiskIndex: 3,
@@ -184,9 +190,9 @@ func (s *installSuite) testInstall(c *C, opts installOpts) {
 			Size:      16 * quantity.SizeMiB,
 		}, {
 			Name:             "ubuntu-data",
-			PartitionFSLabel: "ubuntu-data",
+			PartitionFSLabel: "ubuntu-data" + suffix,
 			Type:             "83,0FC63DAF-8483-4772-8E79-3D69D8477DE4",
-			PartitionFSType:  "ext4",
+			PartitionFSType:  dataPartFs,
 			StartOffset:      (1 + 1200 + 750 + 16) * quantity.OffsetMiB,
 			// note this is YamlIndex + 1, the YamlIndex starts at 0
 			DiskIndex: 4,

--- a/gadget/install/partition.go
+++ b/gadget/install/partition.go
@@ -198,18 +198,13 @@ func buildPartitionList(dl *gadget.OnDiskVolume, lov *gadget.LaidOutVolume, opts
 
 		// synthesize the node name and on disk structure
 		node := deviceName(dl.Device, pIndex)
-		// TODO fill in construction of LaidOutStructure instead?
-		// TODO PartitionFS* needs to be corrected if encryption
-		laidOut.OnDiskStructure = gadget.OnDiskStructure{
-			Name:             laidOut.Name(),
-			PartitionFSLabel: laidOut.Label(),
-			Type:             laidOut.Type(),
-			PartitionFSType:  laidOut.Filesystem(),
-			StartOffset:      laidOut.StartOffset,
-			Node:             node,
-			DiskIndex:        pIndex,
-			Size:             quantity.Size(newSizeInSectors * sectorSize),
-		}
+		// Change bits that depend on the disk, which includes
+		// overriding the size from the gadget as we might be
+		// expanding the data partition.
+		// TODO fill in construction of LaidOutStructure instead if/when possible
+		laidOut.Node = node
+		laidOut.DiskIndex = pIndex
+		laidOut.Size = quantity.Size(newSizeInSectors * sectorSize)
 
 		// format sfdisk input for creating this partition
 		fmt.Fprintf(buf, "%s : start=%12d, size=%12d, type=%s, name=%q\n", node,

--- a/gadget/install/partition.go
+++ b/gadget/install/partition.go
@@ -157,7 +157,7 @@ func buildPartitionList(dl *gadget.OnDiskVolume, lov *gadget.LaidOutVolume, opts
 	canExpandData := false
 	if n := len(lov.LaidOutStructure); n > 0 {
 		last := lov.LaidOutStructure[n-1]
-		if last.VolumeStructure.Role == gadget.SystemData {
+		if last.Role() == gadget.SystemData {
 			canExpandData = true
 		}
 	}
@@ -169,7 +169,7 @@ func buildPartitionList(dl *gadget.OnDiskVolume, lov *gadget.LaidOutVolume, opts
 	// Write new partition data in named-fields format
 	buf := &bytes.Buffer{}
 	for _, laidOut := range lov.LaidOutStructure {
-		if !laidOut.VolumeStructure.IsPartition() {
+		if !laidOut.IsPartition() {
 			continue
 		}
 
@@ -188,7 +188,7 @@ func buildPartitionList(dl *gadget.OnDiskVolume, lov *gadget.LaidOutVolume, opts
 
 		// Check if the data partition should be expanded
 		newSizeInSectors := uint64(laidOut.Size) / sectorSize
-		if laidOut.VolumeStructure.Role == gadget.SystemData && canExpandData && startInSectors+newSizeInSectors < dl.UsableSectorsEnd {
+		if laidOut.Role() == gadget.SystemData && canExpandData && startInSectors+newSizeInSectors < dl.UsableSectorsEnd {
 			// note that if startInSectors + newSizeInSectors == dl.UsableSectorEnd
 			// then we won't hit this branch, but it would be redundant anyways
 			newSizeInSectors = dl.UsableSectorsEnd - startInSectors
@@ -309,7 +309,7 @@ func removeCreatedPartitions(gadgetRoot string, lv *gadget.LaidOutVolume, dl *ga
 func partitionsWithRolesAndContent(lv *gadget.LaidOutVolume, dl *gadget.OnDiskVolume, roles []string) []gadget.LaidOutStructure {
 	roleForOffset := map[quantity.Offset]*gadget.LaidOutStructure{}
 	for idx, los := range lv.LaidOutStructure {
-		if los.VolumeStructure.Role != "" {
+		if los.Role() != "" {
 			roleForOffset[los.StartOffset] = &lv.LaidOutStructure[idx]
 		}
 	}
@@ -317,7 +317,7 @@ func partitionsWithRolesAndContent(lv *gadget.LaidOutVolume, dl *gadget.OnDiskVo
 	var loStructures []gadget.LaidOutStructure
 	for _, part := range dl.Structure {
 		laidOut := roleForOffset[part.StartOffset]
-		if laidOut == nil || laidOut.VolumeStructure.Role == "" || !strutil.ListContains(roles, laidOut.VolumeStructure.Role) {
+		if laidOut == nil || laidOut.Role() == "" || !strutil.ListContains(roles, laidOut.Role()) {
 			continue
 		}
 		// now that we have a match, set the on-disk-structure structure

--- a/gadget/install/partition_test.go
+++ b/gadget/install/partition_test.go
@@ -324,10 +324,10 @@ func (s *partitionTestSuite) TestCreatePartitions(c *C) {
 	defer cmdUdevadm.Restore()
 
 	calls := 0
-	restore = install.MockEnsureNodesExist(func(los []gadget.OnDiskStructure, timeout time.Duration) error {
+	restore = install.MockEnsureNodesExist(func(nodes []string, timeout time.Duration) error {
 		calls++
-		c.Assert(los, HasLen, 1)
-		c.Assert(los[0].Node, Equals, "/dev/node3")
+		c.Assert(nodes, HasLen, 1)
+		c.Assert(nodes[0], Equals, "/dev/node3")
 		return nil
 	})
 	defer restore()
@@ -376,17 +376,12 @@ func (s *partitionTestSuite) TestCreatePartitionsNonRolePartitions(c *C) {
 	defer cmdUdevadm.Restore()
 
 	calls := 0
-	restore = install.MockEnsureNodesExist(func(ds []gadget.OnDiskStructure, timeout time.Duration) error {
+	restore = install.MockEnsureNodesExist(func(nodes []string, timeout time.Duration) error {
 		calls++
-		c.Assert(ds, HasLen, 3)
-		// Ensure all partitions are created as asked for via
-		// the install.CreateOptions
-		c.Assert(ds[0].Node, Equals, "/dev/node1")
-		c.Assert(ds[0].Name, Equals, "BIOS Boot")
-		c.Assert(ds[1].Node, Equals, "/dev/node2")
-		c.Assert(ds[1].Name, Equals, "Recovery")
-		c.Assert(ds[2].Node, Equals, "/dev/node3")
-		c.Assert(ds[2].Name, Equals, "Writable")
+		c.Assert(nodes, HasLen, 3)
+		c.Assert(nodes[0], Equals, "/dev/node1")
+		c.Assert(nodes[1], Equals, "/dev/node2")
+		c.Assert(nodes[2], Equals, "/dev/node3")
 		return nil
 	})
 	defer restore()
@@ -815,8 +810,8 @@ func (s *partitionTestSuite) TestEnsureNodesExist(c *C) {
 		cmdUdevadm := testutil.MockCommand(c, "udevadm", fmt.Sprintf(mockUdevadmScript, tc.utErr))
 		defer cmdUdevadm.Restore()
 
-		los := []gadget.OnDiskStructure{{Node: node}}
-		err = install.EnsureNodesExist(los, 10*time.Millisecond)
+		nodes := []string{node}
+		err = install.EnsureNodesExist(nodes, 10*time.Millisecond)
 		if tc.err == "" {
 			c.Assert(err, IsNil)
 		} else {
@@ -834,10 +829,10 @@ func (s *partitionTestSuite) TestEnsureNodesExistTimeout(c *C) {
 	defer cmdUdevadm.Restore()
 
 	node := filepath.Join(c.MkDir(), "node")
-	los := []gadget.OnDiskStructure{{Node: node}}
+	nodes := []string{node}
 	t := time.Now()
 	timeout := 1 * time.Second
-	err := install.EnsureNodesExist(los, timeout)
+	err := install.EnsureNodesExist(nodes, timeout)
 	c.Assert(err, ErrorMatches, fmt.Sprintf("device %s not available", node))
 	c.Assert(time.Since(t) >= timeout, Equals, true)
 	c.Assert(cmdUdevadm.Calls(), HasLen, 0)

--- a/gadget/install/partition_test.go
+++ b/gadget/install/partition_test.go
@@ -187,8 +187,7 @@ var mockLaidoutStructureWritable = gadget.LaidOutStructure{
 		// yaml structure (the MBR) that does not appear on disk
 		Offset: asOffsetPtr(1260388352),
 	},
-	StartOffset: 1260388352,
-	YamlIndex:   3,
+	YamlIndex: 3,
 }
 
 var mockLaidoutStructureSave = gadget.LaidOutStructure{
@@ -215,8 +214,7 @@ var mockLaidoutStructureSave = gadget.LaidOutStructure{
 		Filesystem: "ext4",
 		Offset:     asOffsetPtr(1260388352),
 	},
-	StartOffset: 1260388352,
-	YamlIndex:   3,
+	YamlIndex: 3,
 }
 
 var mockLaidoutStructureWritableAfterSave = gadget.LaidOutStructure{
@@ -244,8 +242,7 @@ var mockLaidoutStructureWritableAfterSave = gadget.LaidOutStructure{
 		Filesystem: "ext4",
 		Offset:     asOffsetPtr(1394606080),
 	},
-	StartOffset: 1394606080,
-	YamlIndex:   4,
+	YamlIndex: 4,
 }
 
 type uc20Model struct{}

--- a/gadget/install/partition_test.go
+++ b/gadget/install/partition_test.go
@@ -158,8 +158,8 @@ var mockOnDiskStructureWritable = gadget.OnDiskStructure{
 	Size: 2*quantity.SizeGiB + 845*quantity.SizeMiB + 1031680,
 }
 
-var mockOnDiskAndLaidoutStructureWritable = install.MockOnDiskAndLaidoutStructure(
-	&gadget.OnDiskStructure{
+var mockLaidoutStructureWritable = gadget.LaidOutStructure{
+	OnDiskStructure: gadget.OnDiskStructure{
 		Node: "/dev/node3",
 		Name: "Writable",
 		//Size:        1258291200,
@@ -174,27 +174,25 @@ var mockOnDiskAndLaidoutStructureWritable = install.MockOnDiskAndLaidoutStructur
 		// expanded to fill the disk
 		Size: 2*quantity.SizeGiB + 845*quantity.SizeMiB + 1031680,
 	},
-	&gadget.LaidOutStructure{
-		VolumeStructure: &gadget.VolumeStructure{
-			VolumeName: "pc",
-			Name:       "Writable",
-			Offset:     asOffsetPtr(1260388352),
-			Size:       1258291200,
-			Type:       "83,0FC63DAF-8483-4772-8E79-3D69D8477DE4",
-			Role:       "system-data",
-			Label:      "ubuntu-data",
-			Filesystem: "ext4",
-			// Note the DiskIndex appears to be the same as the YamlIndex, but this is
-			// because YamlIndex starts at 0 and DiskIndex starts at 1, and there is a
-			// yaml structure (the MBR) that does not appear on disk
-		},
-		StartOffset: 1260388352,
-		YamlIndex:   3,
+	VolumeStructure: &gadget.VolumeStructure{
+		VolumeName: "pc",
+		Name:       "Writable",
+		Size:       1258291200,
+		Type:       "83,0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+		Role:       "system-data",
+		Label:      "ubuntu-data",
+		Filesystem: "ext4",
+		// Note the DiskIndex appears to be the same as the YamlIndex, but this is
+		// because YamlIndex starts at 0 and DiskIndex starts at 1, and there is a
+		// yaml structure (the MBR) that does not appear on disk
+		Offset: asOffsetPtr(1260388352),
 	},
-)
+	StartOffset: 1260388352,
+	YamlIndex:   3,
+}
 
-var mockOnDiskAndLaidoutStructureSave = install.MockOnDiskAndLaidoutStructure(
-	&gadget.OnDiskStructure{
+var mockLaidoutStructureSave = gadget.LaidOutStructure{
+	OnDiskStructure: gadget.OnDiskStructure{
 		Node:             "/dev/node3",
 		Name:             "Save",
 		Size:             128 * quantity.SizeMiB,
@@ -207,24 +205,22 @@ var mockOnDiskAndLaidoutStructureSave = install.MockOnDiskAndLaidoutStructure(
 		// yaml structure (the MBR) that does not appear on disk
 		DiskIndex: 3,
 	},
-	&gadget.LaidOutStructure{
-		VolumeStructure: &gadget.VolumeStructure{
-			VolumeName: "pc",
-			Name:       "Save",
-			Label:      "ubuntu-save",
-			Offset:     asOffsetPtr(1260388352),
-			Size:       128 * quantity.SizeMiB,
-			Type:       "83,0FC63DAF-8483-4772-8E79-3D69D8477DE4",
-			Role:       "system-save",
-			Filesystem: "ext4",
-		},
-		StartOffset: 1260388352,
-		YamlIndex:   3,
+	VolumeStructure: &gadget.VolumeStructure{
+		VolumeName: "pc",
+		Name:       "Save",
+		Label:      "ubuntu-save",
+		Size:       128 * quantity.SizeMiB,
+		Type:       "83,0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+		Role:       "system-save",
+		Filesystem: "ext4",
+		Offset:     asOffsetPtr(1260388352),
 	},
-)
+	StartOffset: 1260388352,
+	YamlIndex:   3,
+}
 
-var mockOnDiskAndLaidoutStructureWritableAfterSave = install.MockOnDiskAndLaidoutStructure(
-	&gadget.OnDiskStructure{
+var mockLaidoutStructureWritableAfterSave = gadget.LaidOutStructure{
+	OnDiskStructure: gadget.OnDiskStructure{
 		Node: "/dev/node4",
 		Name: "Writable",
 		// expanded to fill the disk
@@ -238,21 +234,19 @@ var mockOnDiskAndLaidoutStructureWritableAfterSave = install.MockOnDiskAndLaidou
 		// yaml structure (the MBR) that does not appear on disk
 		DiskIndex: 4,
 	},
-	&gadget.LaidOutStructure{
-		VolumeStructure: &gadget.VolumeStructure{
-			VolumeName: "pc",
-			Name:       "Writable",
-			Offset:     asOffsetPtr(1394606080),
-			Size:       1200 * quantity.SizeMiB,
-			Type:       "83,0FC63DAF-8483-4772-8E79-3D69D8477DE4",
-			Role:       "system-data",
-			Label:      "ubuntu-data",
-			Filesystem: "ext4",
-		},
-		StartOffset: 1394606080,
-		YamlIndex:   4,
+	VolumeStructure: &gadget.VolumeStructure{
+		VolumeName: "pc",
+		Name:       "Writable",
+		Size:       1200 * quantity.SizeMiB,
+		Type:       "83,0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+		Role:       "system-data",
+		Label:      "ubuntu-data",
+		Filesystem: "ext4",
+		Offset:     asOffsetPtr(1394606080),
 	},
-)
+	StartOffset: 1394606080,
+	YamlIndex:   4,
+}
 
 type uc20Model struct{}
 
@@ -286,9 +280,9 @@ func (s *partitionTestSuite) TestBuildPartitionList(c *C) {
 /dev/node4 : start=     2723840, size=     5664735, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4, name="Writable"
 `)
 	c.Check(create, NotNil)
-	c.Assert(create, DeepEquals, []install.OnDiskAndLaidoutStructure{
-		mockOnDiskAndLaidoutStructureSave,
-		mockOnDiskAndLaidoutStructureWritableAfterSave,
+	c.Assert(create, DeepEquals, []gadget.LaidOutStructure{
+		mockLaidoutStructureSave,
+		mockLaidoutStructureWritableAfterSave,
 	})
 }
 
@@ -333,10 +327,10 @@ func (s *partitionTestSuite) TestCreatePartitions(c *C) {
 	defer cmdUdevadm.Restore()
 
 	calls := 0
-	restore = install.MockEnsureNodesExist(func(ds []install.OnDiskAndLaidoutStructure, timeout time.Duration) error {
+	restore = install.MockEnsureNodesExist(func(los []gadget.OnDiskStructure, timeout time.Duration) error {
 		calls++
-		c.Assert(ds, HasLen, 1)
-		c.Assert(install.OnDiskFromOnDiskAndLaidoutStructure(ds[0]).Node, Equals, "/dev/node3")
+		c.Assert(los, HasLen, 1)
+		c.Assert(los[0].Node, Equals, "/dev/node3")
 		return nil
 	})
 	defer restore()
@@ -353,7 +347,7 @@ func (s *partitionTestSuite) TestCreatePartitions(c *C) {
 	}
 	created, err := install.TestCreateMissingPartitions(dl, pv, opts)
 	c.Assert(err, IsNil)
-	c.Assert(created, DeepEquals, []install.OnDiskAndLaidoutStructure{mockOnDiskAndLaidoutStructureWritable})
+	c.Assert(created, DeepEquals, []gadget.LaidOutStructure{mockLaidoutStructureWritable})
 	c.Assert(calls, Equals, 1)
 
 	// Check partition table write
@@ -385,20 +379,17 @@ func (s *partitionTestSuite) TestCreatePartitionsNonRolePartitions(c *C) {
 	defer cmdUdevadm.Restore()
 
 	calls := 0
-	restore = install.MockEnsureNodesExist(func(ds []install.OnDiskAndLaidoutStructure, timeout time.Duration) error {
+	restore = install.MockEnsureNodesExist(func(ds []gadget.OnDiskStructure, timeout time.Duration) error {
 		calls++
 		c.Assert(ds, HasLen, 3)
 		// Ensure all partitions are created as asked for via
 		// the install.CreateOptions
-		onDisk0 := install.OnDiskFromOnDiskAndLaidoutStructure(ds[0])
-		onDisk1 := install.OnDiskFromOnDiskAndLaidoutStructure(ds[1])
-		onDisk2 := install.OnDiskFromOnDiskAndLaidoutStructure(ds[2])
-		c.Assert(onDisk0.Node, Equals, "/dev/node1")
-		c.Assert(onDisk0.Name, Equals, "BIOS Boot")
-		c.Assert(onDisk1.Node, Equals, "/dev/node2")
-		c.Assert(onDisk1.Name, Equals, "Recovery")
-		c.Assert(onDisk2.Node, Equals, "/dev/node3")
-		c.Assert(onDisk2.Name, Equals, "Writable")
+		c.Assert(ds[0].Node, Equals, "/dev/node1")
+		c.Assert(ds[0].Name, Equals, "BIOS Boot")
+		c.Assert(ds[1].Node, Equals, "/dev/node2")
+		c.Assert(ds[1].Name, Equals, "Recovery")
+		c.Assert(ds[2].Node, Equals, "/dev/node3")
+		c.Assert(ds[2].Name, Equals, "Writable")
 		return nil
 	})
 	defer restore()
@@ -827,13 +818,8 @@ func (s *partitionTestSuite) TestEnsureNodesExist(c *C) {
 		cmdUdevadm := testutil.MockCommand(c, "udevadm", fmt.Sprintf(mockUdevadmScript, tc.utErr))
 		defer cmdUdevadm.Restore()
 
-		ds := []install.OnDiskAndLaidoutStructure{
-			install.MockOnDiskAndLaidoutStructure(
-				&gadget.OnDiskStructure{Node: node},
-				&gadget.LaidOutStructure{},
-			),
-		}
-		err = install.EnsureNodesExist(ds, 10*time.Millisecond)
+		los := []gadget.OnDiskStructure{{Node: node}}
+		err = install.EnsureNodesExist(los, 10*time.Millisecond)
 		if tc.err == "" {
 			c.Assert(err, IsNil)
 		} else {
@@ -851,15 +837,10 @@ func (s *partitionTestSuite) TestEnsureNodesExistTimeout(c *C) {
 	defer cmdUdevadm.Restore()
 
 	node := filepath.Join(c.MkDir(), "node")
-	ds := []install.OnDiskAndLaidoutStructure{
-		install.MockOnDiskAndLaidoutStructure(
-			&gadget.OnDiskStructure{Node: node},
-			&gadget.LaidOutStructure{},
-		),
-	}
+	los := []gadget.OnDiskStructure{{Node: node}}
 	t := time.Now()
 	timeout := 1 * time.Second
-	err := install.EnsureNodesExist(ds, timeout)
+	err := install.EnsureNodesExist(los, timeout)
 	c.Assert(err, ErrorMatches, fmt.Sprintf("device %s not available", node))
 	c.Assert(time.Since(t) >= timeout, Equals, true)
 	c.Assert(cmdUdevadm.Calls(), HasLen, 0)

--- a/gadget/layout.go
+++ b/gadget/layout.go
@@ -73,9 +73,11 @@ type PartiallyLaidOutVolume struct {
 	LaidOutStructure []LaidOutStructure
 }
 
-// LaidOutStructure describes a VolumeStructure that has been placed within the
-// volume
+// LaidOutStructure describes an OnDiskStructure that has been placed within the
+// volume.
 type LaidOutStructure struct {
+	OnDiskStructure
+	// VolumeStructure is the volume structure defined in gadget.yaml
 	VolumeStructure *VolumeStructure
 	// StartOffset defines the start offset of the structure within the
 	// enclosing volume
@@ -205,6 +207,15 @@ func layoutVolumeStructures(volume *Volume) (structures []LaidOutStructure, byNa
 
 		if ps.Name() != "" {
 			byName[ps.Name()] = &ps
+		}
+		// Fill the parts of OnDiskStructure that do not depend on the disk
+		// or on whether we are encrypting or not.
+		// TODO how to fill everything? and about removing startoffset?
+		ps.OnDiskStructure = OnDiskStructure{
+			//Name:        ps.VolumeStructure.Name,
+			//Type:        ps.VolumeStructure.Type,
+			//StartOffset: *volume.Structure[idx].Offset,
+			Size: ps.VolumeStructure.Size,
 		}
 
 		structures[idx] = ps

--- a/gadget/layout.go
+++ b/gadget/layout.go
@@ -255,7 +255,7 @@ func LayoutVolumePartially(volume *Volume) (*PartiallyLaidOutVolume, error) {
 	return vol, nil
 }
 
-func setOnDiskLabelAndTypeInLaidOuts(encType secboot.EncryptionType, los []LaidOutStructure) {
+func setOnDiskLabelAndTypeInLaidOuts(los []LaidOutStructure, encType secboot.EncryptionType) {
 	for i := range los {
 		los[i].PartitionFSLabel = los[i].Label()
 		los[i].PartitionFSType = los[i].Filesystem()
@@ -311,7 +311,7 @@ func LayoutVolume(volume *Volume, opts *LayoutOptions) (*LaidOutVolume, error) {
 
 		// Set appropriately label and type details
 		// TODO: set this in layoutVolumeStructures in the future.
-		setOnDiskLabelAndTypeInLaidOuts(opts.EncType, structures)
+		setOnDiskLabelAndTypeInLaidOuts(structures, opts.EncType)
 
 		// Lay out raw content. This can be skipped when only partition
 		// creation is needed and is safe because each volume structure

--- a/gadget/layout.go
+++ b/gadget/layout.go
@@ -79,9 +79,6 @@ type LaidOutStructure struct {
 	OnDiskStructure
 	// VolumeStructure is the volume structure defined in gadget.yaml
 	VolumeStructure *VolumeStructure
-	// StartOffset defines the start offset of the structure within the
-	// enclosing volume
-	StartOffset quantity.Offset
 	// AbsoluteOffsetWrite is the resolved absolute position of offset-write
 	// for this structure element within the enclosing volume
 	AbsoluteOffsetWrite *quantity.Offset
@@ -201,7 +198,6 @@ func layoutVolumeStructures(volume *Volume) (structures []LaidOutStructure, byNa
 	for idx := range volume.Structure {
 		ps := LaidOutStructure{
 			VolumeStructure: &volume.Structure[idx],
-			StartOffset:     *volume.Structure[idx].Offset,
 			YamlIndex:       idx,
 		}
 
@@ -214,8 +210,8 @@ func layoutVolumeStructures(volume *Volume) (structures []LaidOutStructure, byNa
 		ps.OnDiskStructure = OnDiskStructure{
 			//Name:        ps.VolumeStructure.Name,
 			//Type:        ps.VolumeStructure.Type,
-			//StartOffset: *volume.Structure[idx].Offset,
-			Size: ps.VolumeStructure.Size,
+			StartOffset: *volume.Structure[idx].Offset,
+			Size:        ps.VolumeStructure.Size,
 		}
 
 		structures[idx] = ps

--- a/gadget/layout.go
+++ b/gadget/layout.go
@@ -73,8 +73,9 @@ type PartiallyLaidOutVolume struct {
 	LaidOutStructure []LaidOutStructure
 }
 
-// LaidOutStructure describes an OnDiskStructure that has been placed within the
-// volume.
+// LaidOutStructure describes a VolumeStructure coming from the gadget plus the
+// OnDiskStructure that describes how it would be applied to a given disk and
+// additional data used when writing data in the structure.
 type LaidOutStructure struct {
 	OnDiskStructure
 	// VolumeStructure is the volume structure defined in gadget.yaml
@@ -206,7 +207,7 @@ func layoutVolumeStructures(volume *Volume) (structures []LaidOutStructure, byNa
 		}
 		// Fill the parts of OnDiskStructure that do not depend on the disk
 		// or on whether we are encrypting or not.
-		// TODO how to fill everything? and about removing startoffset?
+		// TODO how to fill everything?
 		ps.OnDiskStructure = OnDiskStructure{
 			//Name:        ps.VolumeStructure.Name,
 			//Type:        ps.VolumeStructure.Type,

--- a/gadget/layout_test.go
+++ b/gadget/layout_test.go
@@ -110,6 +110,7 @@ volumes:
 		LaidOutStructure: []gadget.LaidOutStructure{
 			{
 				OnDiskStructure: gadget.OnDiskStructure{
+					Type:        "00000000-0000-0000-0000-0000deadbeef",
 					Size:        400 * quantity.SizeMiB,
 					StartOffset: 1 * quantity.OffsetMiB,
 				},
@@ -118,6 +119,7 @@ volumes:
 			},
 			{
 				OnDiskStructure: gadget.OnDiskStructure{
+					Type:        "83,00000000-0000-0000-0000-0000feedface",
 					Size:        100 * quantity.SizeMiB,
 					StartOffset: 401 * quantity.OffsetMiB,
 				},
@@ -159,6 +161,7 @@ volumes:
 		LaidOutStructure: []gadget.LaidOutStructure{
 			{
 				OnDiskStructure: gadget.OnDiskStructure{
+					Type:        "00000000-0000-0000-0000-dd00deadbeef",
 					Size:        400 * quantity.SizeMiB,
 					StartOffset: 1 * quantity.OffsetMiB,
 				},
@@ -167,6 +170,7 @@ volumes:
 			},
 			{
 				OnDiskStructure: gadget.OnDiskStructure{
+					Type:        "00000000-0000-0000-0000-cc00deadbeef",
 					Size:        500 * quantity.SizeMiB,
 					StartOffset: 401 * quantity.OffsetMiB,
 				},
@@ -175,6 +179,7 @@ volumes:
 			},
 			{
 				OnDiskStructure: gadget.OnDiskStructure{
+					Type:        "00000000-0000-0000-0000-bb00deadbeef",
 					Size:        100 * quantity.SizeMiB,
 					StartOffset: 901 * quantity.OffsetMiB,
 				},
@@ -183,6 +188,7 @@ volumes:
 			},
 			{
 				OnDiskStructure: gadget.OnDiskStructure{
+					Type:        "00000000-0000-0000-0000-aa00deadbeef",
 					Size:        100 * quantity.SizeMiB,
 					StartOffset: 1001 * quantity.OffsetMiB,
 				},
@@ -228,6 +234,7 @@ volumes:
 		LaidOutStructure: []gadget.LaidOutStructure{
 			{
 				OnDiskStructure: gadget.OnDiskStructure{
+					Type:        "00000000-0000-0000-0000-aa00deadbeef",
 					Size:        100 * quantity.SizeMiB,
 					StartOffset: 1 * quantity.OffsetMiB,
 				},
@@ -236,6 +243,7 @@ volumes:
 			},
 			{
 				OnDiskStructure: gadget.OnDiskStructure{
+					Type:        "00000000-0000-0000-0000-cc00deadbeef",
 					Size:        500 * quantity.SizeMiB,
 					StartOffset: 200 * quantity.OffsetMiB,
 				},
@@ -244,6 +252,7 @@ volumes:
 			},
 			{
 				OnDiskStructure: gadget.OnDiskStructure{
+					Type:        "00000000-0000-0000-0000-dd00deadbeef",
 					Size:        400 * quantity.SizeMiB,
 					StartOffset: 800 * quantity.OffsetMiB,
 				},
@@ -252,6 +261,7 @@ volumes:
 			},
 			{
 				OnDiskStructure: gadget.OnDiskStructure{
+					Type:        "00000000-0000-0000-0000-bb00deadbeef",
 					Size:        100 * quantity.SizeMiB,
 					StartOffset: 1200 * quantity.OffsetMiB,
 				},
@@ -296,6 +306,7 @@ volumes:
 		LaidOutStructure: []gadget.LaidOutStructure{
 			{
 				OnDiskStructure: gadget.OnDiskStructure{
+					Type:        "00000000-0000-0000-0000-aa00deadbeef",
 					Size:        100 * quantity.SizeMiB,
 					StartOffset: 1 * quantity.OffsetMiB,
 				},
@@ -304,6 +315,7 @@ volumes:
 			},
 			{
 				OnDiskStructure: gadget.OnDiskStructure{
+					Type:        "00000000-0000-0000-0000-cc00deadbeef",
 					Size:        500 * quantity.SizeMiB,
 					StartOffset: 200 * quantity.OffsetMiB,
 				},
@@ -312,6 +324,7 @@ volumes:
 			},
 			{
 				OnDiskStructure: gadget.OnDiskStructure{
+					Type:        "00000000-0000-0000-0000-bb00deadbeef",
 					Size:        100 * quantity.SizeMiB,
 					StartOffset: 700 * quantity.OffsetMiB,
 				},
@@ -320,6 +333,7 @@ volumes:
 			},
 			{
 				OnDiskStructure: gadget.OnDiskStructure{
+					Type:        "00000000-0000-0000-0000-dd00deadbeef",
 					Size:        400 * quantity.SizeMiB,
 					StartOffset: 800 * quantity.OffsetMiB,
 				},
@@ -383,6 +397,7 @@ volumes:
 		LaidOutStructure: []gadget.LaidOutStructure{
 			{
 				OnDiskStructure: gadget.OnDiskStructure{
+					Type:        "00000000-0000-0000-0000-dd00deadbeef",
 					Size:        400 * quantity.SizeMiB,
 					StartOffset: 800 * quantity.OffsetMiB,
 				},
@@ -565,6 +580,7 @@ volumes:
 		LaidOutStructure: []gadget.LaidOutStructure{
 			{
 				OnDiskStructure: gadget.OnDiskStructure{
+					Type:        "00000000-0000-0000-0000-0000deadbeef",
 					Size:        2 * quantity.SizeMiB,
 					StartOffset: 1 * quantity.OffsetMiB,
 				},
@@ -620,6 +636,7 @@ volumes:
 		LaidOutStructure: []gadget.LaidOutStructure{
 			{
 				OnDiskStructure: gadget.OnDiskStructure{
+					Type:        "00000000-0000-0000-0000-0000deadbeef",
 					Size:        2 * quantity.SizeMiB,
 					StartOffset: 1 * quantity.OffsetMiB,
 				},
@@ -672,6 +689,7 @@ volumes:
 		LaidOutStructure: []gadget.LaidOutStructure{
 			{
 				OnDiskStructure: gadget.OnDiskStructure{
+					Type:        "00000000-0000-0000-0000-0000deadbeef",
 					Size:        2 * quantity.SizeMiB,
 					StartOffset: 1 * quantity.OffsetMiB,
 				},
@@ -718,8 +736,10 @@ volumes:
 		LaidOutStructure: []gadget.LaidOutStructure{
 			{
 				OnDiskStructure: gadget.OnDiskStructure{
-					Size:        2 * quantity.SizeMiB,
-					StartOffset: 1 * quantity.OffsetMiB,
+					Type:            "00000000-0000-0000-0000-0000deadbeef",
+					PartitionFSType: "ext4",
+					Size:            2 * quantity.SizeMiB,
+					StartOffset:     1 * quantity.OffsetMiB,
 				},
 				VolumeStructure: &vol.Structure[0],
 				ResolvedContent: []gadget.ResolvedContent{
@@ -765,6 +785,8 @@ volumes:
 			{
 				// MBR
 				OnDiskStructure: gadget.OnDiskStructure{
+					Name:        "mbr",
+					Type:        "bare",
 					Size:        quantity.Size(446),
 					StartOffset: 0,
 				},
@@ -772,6 +794,8 @@ volumes:
 				YamlIndex:       0,
 			}, {
 				OnDiskStructure: gadget.OnDiskStructure{
+					Name:        "other",
+					Type:        "00000000-0000-0000-0000-0000deadbeef",
 					Size:        quantity.SizeMiB,
 					StartOffset: 1 * quantity.OffsetMiB,
 				},
@@ -824,6 +848,8 @@ volumes:
 			{
 				// mbr
 				OnDiskStructure: gadget.OnDiskStructure{
+					Name:        "mbr",
+					Type:        "mbr",
 					Size:        quantity.Size(440),
 					StartOffset: 0,
 				},
@@ -832,6 +858,8 @@ volumes:
 			}, {
 				// foo
 				OnDiskStructure: gadget.OnDiskStructure{
+					Name:        "foo",
+					Type:        "DA,21686148-6449-6E6F-744E-656564454649",
 					Size:        quantity.SizeMiB,
 					StartOffset: 1 * quantity.OffsetMiB,
 				},
@@ -851,6 +879,8 @@ volumes:
 			}, {
 				// bar
 				OnDiskStructure: gadget.OnDiskStructure{
+					Name:        "bar",
+					Type:        "DA,21686148-6449-6E6F-744E-656564454649",
 					Size:        quantity.SizeMiB,
 					StartOffset: 2 * quantity.OffsetMiB,
 				},
@@ -1003,6 +1033,7 @@ volumes:
 		LaidOutStructure: []gadget.LaidOutStructure{
 			{
 				OnDiskStructure: gadget.OnDiskStructure{
+					Type:        "00000000-0000-0000-0000-dd00deadbeef",
 					Size:        400 * quantity.SizeMiB,
 					StartOffset: 800 * quantity.OffsetMiB,
 				},
@@ -1047,6 +1078,8 @@ volumes:
 	c.Assert(ps, DeepEquals, gadget.LaidOutStructure{
 		// foo
 		OnDiskStructure: gadget.OnDiskStructure{
+			Name:        "foo",
+			Type:        "DA,21686148-6449-6E6F-744E-656564454649",
 			Size:        quantity.SizeMiB,
 			StartOffset: 1 * quantity.OffsetMiB,
 		},
@@ -1071,6 +1104,8 @@ volumes:
 	c.Assert(shiftedTo0, DeepEquals, gadget.LaidOutStructure{
 		// foo
 		OnDiskStructure: gadget.OnDiskStructure{
+			Name:        "foo",
+			Type:        "DA,21686148-6449-6E6F-744E-656564454649",
 			Size:        quantity.SizeMiB,
 			StartOffset: 0,
 		},
@@ -1095,6 +1130,8 @@ volumes:
 	c.Assert(shiftedTo2M, DeepEquals, gadget.LaidOutStructure{
 		// foo
 		OnDiskStructure: gadget.OnDiskStructure{
+			Name:        "foo",
+			Type:        "DA,21686148-6449-6E6F-744E-656564454649",
 			Size:        quantity.SizeMiB,
 			StartOffset: 2 * quantity.OffsetMiB,
 		},

--- a/gadget/layout_test.go
+++ b/gadget/layout_test.go
@@ -64,6 +64,9 @@ func (p *layoutTestSuite) TestVolumeSize(c *C) {
 		Size:    3 * quantity.SizeMiB,
 		RootDir: p.dir,
 		LaidOutStructure: []gadget.LaidOutStructure{{
+			OnDiskStructure: gadget.OnDiskStructure{
+				Size: 2 * quantity.SizeMiB,
+			},
 			VolumeStructure: &gadget.VolumeStructure{
 				Offset: asOffsetPtr(quantity.OffsetMiB),
 				Size:   2 * quantity.SizeMiB,
@@ -106,11 +109,17 @@ volumes:
 		RootDir: p.dir,
 		LaidOutStructure: []gadget.LaidOutStructure{
 			{
+				OnDiskStructure: gadget.OnDiskStructure{
+					Size: 400 * quantity.SizeMiB,
+				},
 				VolumeStructure: &vol.Structure[0],
 				StartOffset:     1 * quantity.OffsetMiB,
 				YamlIndex:       0,
 			},
 			{
+				OnDiskStructure: gadget.OnDiskStructure{
+					Size: 100 * quantity.SizeMiB,
+				},
 				VolumeStructure: &vol.Structure[1],
 				StartOffset:     401 * quantity.OffsetMiB,
 				YamlIndex:       1,
@@ -149,21 +158,33 @@ volumes:
 		RootDir: p.dir,
 		LaidOutStructure: []gadget.LaidOutStructure{
 			{
+				OnDiskStructure: gadget.OnDiskStructure{
+					Size: 400 * quantity.SizeMiB,
+				},
 				VolumeStructure: &vol.Structure[0],
 				StartOffset:     1 * quantity.OffsetMiB,
 				YamlIndex:       0,
 			},
 			{
+				OnDiskStructure: gadget.OnDiskStructure{
+					Size: 500 * quantity.SizeMiB,
+				},
 				VolumeStructure: &vol.Structure[1],
 				StartOffset:     401 * quantity.OffsetMiB,
 				YamlIndex:       1,
 			},
 			{
+				OnDiskStructure: gadget.OnDiskStructure{
+					Size: 100 * quantity.SizeMiB,
+				},
 				VolumeStructure: &vol.Structure[2],
 				StartOffset:     901 * quantity.OffsetMiB,
 				YamlIndex:       2,
 			},
 			{
+				OnDiskStructure: gadget.OnDiskStructure{
+					Size: 100 * quantity.SizeMiB,
+				},
 				VolumeStructure: &vol.Structure[3],
 				StartOffset:     1001 * quantity.OffsetMiB,
 				YamlIndex:       3,
@@ -206,21 +227,33 @@ volumes:
 		RootDir: p.dir,
 		LaidOutStructure: []gadget.LaidOutStructure{
 			{
+				OnDiskStructure: gadget.OnDiskStructure{
+					Size: 100 * quantity.SizeMiB,
+				},
 				VolumeStructure: &vol.Structure[3],
 				StartOffset:     1 * quantity.OffsetMiB,
 				YamlIndex:       3,
 			},
 			{
+				OnDiskStructure: gadget.OnDiskStructure{
+					Size: 500 * quantity.SizeMiB,
+				},
 				VolumeStructure: &vol.Structure[1],
 				StartOffset:     200 * quantity.OffsetMiB,
 				YamlIndex:       1,
 			},
 			{
+				OnDiskStructure: gadget.OnDiskStructure{
+					Size: 400 * quantity.SizeMiB,
+				},
 				VolumeStructure: &vol.Structure[0],
 				StartOffset:     800 * quantity.OffsetMiB,
 				YamlIndex:       0,
 			},
 			{
+				OnDiskStructure: gadget.OnDiskStructure{
+					Size: 100 * quantity.SizeMiB,
+				},
 				VolumeStructure: &vol.Structure[2],
 				StartOffset:     1200 * quantity.OffsetMiB,
 				YamlIndex:       2,
@@ -262,21 +295,33 @@ volumes:
 		RootDir: p.dir,
 		LaidOutStructure: []gadget.LaidOutStructure{
 			{
+				OnDiskStructure: gadget.OnDiskStructure{
+					Size: 100 * quantity.SizeMiB,
+				},
 				VolumeStructure: &vol.Structure[3],
 				StartOffset:     1 * quantity.OffsetMiB,
 				YamlIndex:       3,
 			},
 			{
+				OnDiskStructure: gadget.OnDiskStructure{
+					Size: 500 * quantity.SizeMiB,
+				},
 				VolumeStructure: &vol.Structure[1],
 				StartOffset:     200 * quantity.OffsetMiB,
 				YamlIndex:       1,
 			},
 			{
+				OnDiskStructure: gadget.OnDiskStructure{
+					Size: 100 * quantity.SizeMiB,
+				},
 				VolumeStructure: &vol.Structure[2],
 				StartOffset:     700 * quantity.OffsetMiB,
 				YamlIndex:       2,
 			},
 			{
+				OnDiskStructure: gadget.OnDiskStructure{
+					Size: 400 * quantity.SizeMiB,
+				},
 				VolumeStructure: &vol.Structure[0],
 				StartOffset:     800 * quantity.OffsetMiB,
 				YamlIndex:       0,
@@ -337,6 +382,9 @@ volumes:
 		RootDir: p.dir,
 		LaidOutStructure: []gadget.LaidOutStructure{
 			{
+				OnDiskStructure: gadget.OnDiskStructure{
+					Size: 400 * quantity.SizeMiB,
+				},
 				StartOffset:     800 * quantity.OffsetMiB,
 				VolumeStructure: &vol.Structure[0],
 			},
@@ -516,6 +564,9 @@ volumes:
 		RootDir: p.dir,
 		LaidOutStructure: []gadget.LaidOutStructure{
 			{
+				OnDiskStructure: gadget.OnDiskStructure{
+					Size: 2 * quantity.SizeMiB,
+				},
 				VolumeStructure: &vol.Structure[0],
 				StartOffset:     1 * quantity.OffsetMiB,
 				LaidOutContent: []gadget.LaidOutContent{
@@ -568,6 +619,9 @@ volumes:
 		RootDir: p.dir,
 		LaidOutStructure: []gadget.LaidOutStructure{
 			{
+				OnDiskStructure: gadget.OnDiskStructure{
+					Size: 2 * quantity.SizeMiB,
+				},
 				VolumeStructure: &vol.Structure[0],
 				StartOffset:     1 * quantity.OffsetMiB,
 				LaidOutContent: []gadget.LaidOutContent{
@@ -617,6 +671,9 @@ volumes:
 		RootDir: p.dir,
 		LaidOutStructure: []gadget.LaidOutStructure{
 			{
+				OnDiskStructure: gadget.OnDiskStructure{
+					Size: 2 * quantity.SizeMiB,
+				},
 				VolumeStructure: &vol.Structure[0],
 				StartOffset:     1 * quantity.OffsetMiB,
 				LaidOutContent: []gadget.LaidOutContent{
@@ -660,6 +717,9 @@ volumes:
 		RootDir: p.dir,
 		LaidOutStructure: []gadget.LaidOutStructure{
 			{
+				OnDiskStructure: gadget.OnDiskStructure{
+					Size: 2 * quantity.SizeMiB,
+				},
 				StartOffset:     1 * quantity.OffsetMiB,
 				VolumeStructure: &vol.Structure[0],
 				ResolvedContent: []gadget.ResolvedContent{
@@ -704,10 +764,16 @@ volumes:
 		LaidOutStructure: []gadget.LaidOutStructure{
 			{
 				// MBR
+				OnDiskStructure: gadget.OnDiskStructure{
+					Size: quantity.Size(446),
+				},
 				VolumeStructure: &vol.Structure[0],
 				StartOffset:     0,
 				YamlIndex:       0,
 			}, {
+				OnDiskStructure: gadget.OnDiskStructure{
+					Size: quantity.SizeMiB,
+				},
 				VolumeStructure: &vol.Structure[1],
 				StartOffset:     1 * quantity.OffsetMiB,
 				YamlIndex:       1,
@@ -757,11 +823,17 @@ volumes:
 		LaidOutStructure: []gadget.LaidOutStructure{
 			{
 				// mbr
+				OnDiskStructure: gadget.OnDiskStructure{
+					Size: quantity.Size(440),
+				},
 				VolumeStructure: &vol.Structure[0],
 				StartOffset:     0,
 				YamlIndex:       0,
 			}, {
 				// foo
+				OnDiskStructure: gadget.OnDiskStructure{
+					Size: quantity.SizeMiB,
+				},
 				VolumeStructure: &vol.Structure[1],
 				StartOffset:     1 * quantity.OffsetMiB,
 				YamlIndex:       1,
@@ -778,6 +850,9 @@ volumes:
 				},
 			}, {
 				// bar
+				OnDiskStructure: gadget.OnDiskStructure{
+					Size: quantity.SizeMiB,
+				},
 				VolumeStructure: &vol.Structure[2],
 				StartOffset:     2 * quantity.OffsetMiB,
 				YamlIndex:       2,
@@ -927,6 +1002,9 @@ volumes:
 		Volume: vol,
 		LaidOutStructure: []gadget.LaidOutStructure{
 			{
+				OnDiskStructure: gadget.OnDiskStructure{
+					Size: 400 * quantity.SizeMiB,
+				},
 				VolumeStructure: &vol.Structure[0],
 				StartOffset:     800 * quantity.OffsetMiB,
 				YamlIndex:       0,
@@ -968,6 +1046,9 @@ volumes:
 
 	c.Assert(ps, DeepEquals, gadget.LaidOutStructure{
 		// foo
+		OnDiskStructure: gadget.OnDiskStructure{
+			Size: quantity.SizeMiB,
+		},
 		VolumeStructure: &vol.Structure[0],
 		StartOffset:     1 * quantity.OffsetMiB,
 		YamlIndex:       0,
@@ -989,6 +1070,9 @@ volumes:
 	shiftedTo0 := gadget.ShiftStructureTo(ps, 0)
 	c.Assert(shiftedTo0, DeepEquals, gadget.LaidOutStructure{
 		// foo
+		OnDiskStructure: gadget.OnDiskStructure{
+			Size: quantity.SizeMiB,
+		},
 		VolumeStructure: &vol.Structure[0],
 		StartOffset:     0,
 		YamlIndex:       0,
@@ -1010,6 +1094,9 @@ volumes:
 	shiftedTo2M := gadget.ShiftStructureTo(ps, 2*quantity.OffsetMiB)
 	c.Assert(shiftedTo2M, DeepEquals, gadget.LaidOutStructure{
 		// foo
+		OnDiskStructure: gadget.OnDiskStructure{
+			Size: quantity.SizeMiB,
+		},
 		VolumeStructure: &vol.Structure[0],
 		StartOffset:     2 * quantity.OffsetMiB,
 		YamlIndex:       0,

--- a/gadget/layout_test.go
+++ b/gadget/layout_test.go
@@ -65,13 +65,13 @@ func (p *layoutTestSuite) TestVolumeSize(c *C) {
 		RootDir: p.dir,
 		LaidOutStructure: []gadget.LaidOutStructure{{
 			OnDiskStructure: gadget.OnDiskStructure{
-				Size: 2 * quantity.SizeMiB,
+				Size:        2 * quantity.SizeMiB,
+				StartOffset: 1 * quantity.OffsetMiB,
 			},
 			VolumeStructure: &gadget.VolumeStructure{
 				Offset: asOffsetPtr(quantity.OffsetMiB),
 				Size:   2 * quantity.SizeMiB,
 			},
-			StartOffset: 1 * quantity.OffsetMiB,
 		}},
 	})
 }
@@ -110,18 +110,18 @@ volumes:
 		LaidOutStructure: []gadget.LaidOutStructure{
 			{
 				OnDiskStructure: gadget.OnDiskStructure{
-					Size: 400 * quantity.SizeMiB,
+					Size:        400 * quantity.SizeMiB,
+					StartOffset: 1 * quantity.OffsetMiB,
 				},
 				VolumeStructure: &vol.Structure[0],
-				StartOffset:     1 * quantity.OffsetMiB,
 				YamlIndex:       0,
 			},
 			{
 				OnDiskStructure: gadget.OnDiskStructure{
-					Size: 100 * quantity.SizeMiB,
+					Size:        100 * quantity.SizeMiB,
+					StartOffset: 401 * quantity.OffsetMiB,
 				},
 				VolumeStructure: &vol.Structure[1],
-				StartOffset:     401 * quantity.OffsetMiB,
 				YamlIndex:       1,
 			},
 		},
@@ -159,34 +159,34 @@ volumes:
 		LaidOutStructure: []gadget.LaidOutStructure{
 			{
 				OnDiskStructure: gadget.OnDiskStructure{
-					Size: 400 * quantity.SizeMiB,
+					Size:        400 * quantity.SizeMiB,
+					StartOffset: 1 * quantity.OffsetMiB,
 				},
 				VolumeStructure: &vol.Structure[0],
-				StartOffset:     1 * quantity.OffsetMiB,
 				YamlIndex:       0,
 			},
 			{
 				OnDiskStructure: gadget.OnDiskStructure{
-					Size: 500 * quantity.SizeMiB,
+					Size:        500 * quantity.SizeMiB,
+					StartOffset: 401 * quantity.OffsetMiB,
 				},
 				VolumeStructure: &vol.Structure[1],
-				StartOffset:     401 * quantity.OffsetMiB,
 				YamlIndex:       1,
 			},
 			{
 				OnDiskStructure: gadget.OnDiskStructure{
-					Size: 100 * quantity.SizeMiB,
+					Size:        100 * quantity.SizeMiB,
+					StartOffset: 901 * quantity.OffsetMiB,
 				},
 				VolumeStructure: &vol.Structure[2],
-				StartOffset:     901 * quantity.OffsetMiB,
 				YamlIndex:       2,
 			},
 			{
 				OnDiskStructure: gadget.OnDiskStructure{
-					Size: 100 * quantity.SizeMiB,
+					Size:        100 * quantity.SizeMiB,
+					StartOffset: 1001 * quantity.OffsetMiB,
 				},
 				VolumeStructure: &vol.Structure[3],
-				StartOffset:     1001 * quantity.OffsetMiB,
 				YamlIndex:       3,
 			},
 		},
@@ -228,34 +228,34 @@ volumes:
 		LaidOutStructure: []gadget.LaidOutStructure{
 			{
 				OnDiskStructure: gadget.OnDiskStructure{
-					Size: 100 * quantity.SizeMiB,
+					Size:        100 * quantity.SizeMiB,
+					StartOffset: 1 * quantity.OffsetMiB,
 				},
 				VolumeStructure: &vol.Structure[3],
-				StartOffset:     1 * quantity.OffsetMiB,
 				YamlIndex:       3,
 			},
 			{
 				OnDiskStructure: gadget.OnDiskStructure{
-					Size: 500 * quantity.SizeMiB,
+					Size:        500 * quantity.SizeMiB,
+					StartOffset: 200 * quantity.OffsetMiB,
 				},
 				VolumeStructure: &vol.Structure[1],
-				StartOffset:     200 * quantity.OffsetMiB,
 				YamlIndex:       1,
 			},
 			{
 				OnDiskStructure: gadget.OnDiskStructure{
-					Size: 400 * quantity.SizeMiB,
+					Size:        400 * quantity.SizeMiB,
+					StartOffset: 800 * quantity.OffsetMiB,
 				},
 				VolumeStructure: &vol.Structure[0],
-				StartOffset:     800 * quantity.OffsetMiB,
 				YamlIndex:       0,
 			},
 			{
 				OnDiskStructure: gadget.OnDiskStructure{
-					Size: 100 * quantity.SizeMiB,
+					Size:        100 * quantity.SizeMiB,
+					StartOffset: 1200 * quantity.OffsetMiB,
 				},
 				VolumeStructure: &vol.Structure[2],
-				StartOffset:     1200 * quantity.OffsetMiB,
 				YamlIndex:       2,
 			},
 		},
@@ -296,34 +296,34 @@ volumes:
 		LaidOutStructure: []gadget.LaidOutStructure{
 			{
 				OnDiskStructure: gadget.OnDiskStructure{
-					Size: 100 * quantity.SizeMiB,
+					Size:        100 * quantity.SizeMiB,
+					StartOffset: 1 * quantity.OffsetMiB,
 				},
 				VolumeStructure: &vol.Structure[3],
-				StartOffset:     1 * quantity.OffsetMiB,
 				YamlIndex:       3,
 			},
 			{
 				OnDiskStructure: gadget.OnDiskStructure{
-					Size: 500 * quantity.SizeMiB,
+					Size:        500 * quantity.SizeMiB,
+					StartOffset: 200 * quantity.OffsetMiB,
 				},
 				VolumeStructure: &vol.Structure[1],
-				StartOffset:     200 * quantity.OffsetMiB,
 				YamlIndex:       1,
 			},
 			{
 				OnDiskStructure: gadget.OnDiskStructure{
-					Size: 100 * quantity.SizeMiB,
+					Size:        100 * quantity.SizeMiB,
+					StartOffset: 700 * quantity.OffsetMiB,
 				},
 				VolumeStructure: &vol.Structure[2],
-				StartOffset:     700 * quantity.OffsetMiB,
 				YamlIndex:       2,
 			},
 			{
 				OnDiskStructure: gadget.OnDiskStructure{
-					Size: 400 * quantity.SizeMiB,
+					Size:        400 * quantity.SizeMiB,
+					StartOffset: 800 * quantity.OffsetMiB,
 				},
 				VolumeStructure: &vol.Structure[0],
-				StartOffset:     800 * quantity.OffsetMiB,
 				YamlIndex:       0,
 			},
 		},
@@ -383,9 +383,9 @@ volumes:
 		LaidOutStructure: []gadget.LaidOutStructure{
 			{
 				OnDiskStructure: gadget.OnDiskStructure{
-					Size: 400 * quantity.SizeMiB,
+					Size:        400 * quantity.SizeMiB,
+					StartOffset: 800 * quantity.OffsetMiB,
 				},
-				StartOffset:     800 * quantity.OffsetMiB,
 				VolumeStructure: &vol.Structure[0],
 			},
 		},
@@ -565,10 +565,10 @@ volumes:
 		LaidOutStructure: []gadget.LaidOutStructure{
 			{
 				OnDiskStructure: gadget.OnDiskStructure{
-					Size: 2 * quantity.SizeMiB,
+					Size:        2 * quantity.SizeMiB,
+					StartOffset: 1 * quantity.OffsetMiB,
 				},
 				VolumeStructure: &vol.Structure[0],
-				StartOffset:     1 * quantity.OffsetMiB,
 				LaidOutContent: []gadget.LaidOutContent{
 					{
 						VolumeContent: &vol.Structure[0].Content[1],
@@ -620,10 +620,10 @@ volumes:
 		LaidOutStructure: []gadget.LaidOutStructure{
 			{
 				OnDiskStructure: gadget.OnDiskStructure{
-					Size: 2 * quantity.SizeMiB,
+					Size:        2 * quantity.SizeMiB,
+					StartOffset: 1 * quantity.OffsetMiB,
 				},
 				VolumeStructure: &vol.Structure[0],
-				StartOffset:     1 * quantity.OffsetMiB,
 				LaidOutContent: []gadget.LaidOutContent{
 					{
 						VolumeContent: &vol.Structure[0].Content[0],
@@ -672,10 +672,10 @@ volumes:
 		LaidOutStructure: []gadget.LaidOutStructure{
 			{
 				OnDiskStructure: gadget.OnDiskStructure{
-					Size: 2 * quantity.SizeMiB,
+					Size:        2 * quantity.SizeMiB,
+					StartOffset: 1 * quantity.OffsetMiB,
 				},
 				VolumeStructure: &vol.Structure[0],
-				StartOffset:     1 * quantity.OffsetMiB,
 				LaidOutContent: []gadget.LaidOutContent{
 					{
 						VolumeContent: &vol.Structure[0].Content[0],
@@ -718,9 +718,9 @@ volumes:
 		LaidOutStructure: []gadget.LaidOutStructure{
 			{
 				OnDiskStructure: gadget.OnDiskStructure{
-					Size: 2 * quantity.SizeMiB,
+					Size:        2 * quantity.SizeMiB,
+					StartOffset: 1 * quantity.OffsetMiB,
 				},
-				StartOffset:     1 * quantity.OffsetMiB,
 				VolumeStructure: &vol.Structure[0],
 				ResolvedContent: []gadget.ResolvedContent{
 					{
@@ -765,17 +765,17 @@ volumes:
 			{
 				// MBR
 				OnDiskStructure: gadget.OnDiskStructure{
-					Size: quantity.Size(446),
+					Size:        quantity.Size(446),
+					StartOffset: 0,
 				},
 				VolumeStructure: &vol.Structure[0],
-				StartOffset:     0,
 				YamlIndex:       0,
 			}, {
 				OnDiskStructure: gadget.OnDiskStructure{
-					Size: quantity.SizeMiB,
+					Size:        quantity.SizeMiB,
+					StartOffset: 1 * quantity.OffsetMiB,
 				},
 				VolumeStructure: &vol.Structure[1],
-				StartOffset:     1 * quantity.OffsetMiB,
 				YamlIndex:       1,
 			},
 		},
@@ -824,18 +824,18 @@ volumes:
 			{
 				// mbr
 				OnDiskStructure: gadget.OnDiskStructure{
-					Size: quantity.Size(440),
+					Size:        quantity.Size(440),
+					StartOffset: 0,
 				},
 				VolumeStructure: &vol.Structure[0],
-				StartOffset:     0,
 				YamlIndex:       0,
 			}, {
 				// foo
 				OnDiskStructure: gadget.OnDiskStructure{
-					Size: quantity.SizeMiB,
+					Size:        quantity.SizeMiB,
+					StartOffset: 1 * quantity.OffsetMiB,
 				},
 				VolumeStructure: &vol.Structure[1],
-				StartOffset:     1 * quantity.OffsetMiB,
 				YamlIndex:       1,
 				// break for gofmt < 1.11
 				AbsoluteOffsetWrite: asOffsetPtr(92),
@@ -851,10 +851,10 @@ volumes:
 			}, {
 				// bar
 				OnDiskStructure: gadget.OnDiskStructure{
-					Size: quantity.SizeMiB,
+					Size:        quantity.SizeMiB,
+					StartOffset: 2 * quantity.OffsetMiB,
 				},
 				VolumeStructure: &vol.Structure[2],
-				StartOffset:     2 * quantity.OffsetMiB,
 				YamlIndex:       2,
 				// break for gofmt < 1.11
 				AbsoluteOffsetWrite: asOffsetPtr(600),
@@ -1003,10 +1003,10 @@ volumes:
 		LaidOutStructure: []gadget.LaidOutStructure{
 			{
 				OnDiskStructure: gadget.OnDiskStructure{
-					Size: 400 * quantity.SizeMiB,
+					Size:        400 * quantity.SizeMiB,
+					StartOffset: 800 * quantity.OffsetMiB,
 				},
 				VolumeStructure: &vol.Structure[0],
-				StartOffset:     800 * quantity.OffsetMiB,
 				YamlIndex:       0,
 			},
 		},
@@ -1047,10 +1047,10 @@ volumes:
 	c.Assert(ps, DeepEquals, gadget.LaidOutStructure{
 		// foo
 		OnDiskStructure: gadget.OnDiskStructure{
-			Size: quantity.SizeMiB,
+			Size:        quantity.SizeMiB,
+			StartOffset: 1 * quantity.OffsetMiB,
 		},
 		VolumeStructure: &vol.Structure[0],
-		StartOffset:     1 * quantity.OffsetMiB,
 		YamlIndex:       0,
 		LaidOutContent: []gadget.LaidOutContent{
 			{
@@ -1071,10 +1071,10 @@ volumes:
 	c.Assert(shiftedTo0, DeepEquals, gadget.LaidOutStructure{
 		// foo
 		OnDiskStructure: gadget.OnDiskStructure{
-			Size: quantity.SizeMiB,
+			Size:        quantity.SizeMiB,
+			StartOffset: 0,
 		},
 		VolumeStructure: &vol.Structure[0],
-		StartOffset:     0,
 		YamlIndex:       0,
 		LaidOutContent: []gadget.LaidOutContent{
 			{
@@ -1095,10 +1095,10 @@ volumes:
 	c.Assert(shiftedTo2M, DeepEquals, gadget.LaidOutStructure{
 		// foo
 		OnDiskStructure: gadget.OnDiskStructure{
-			Size: quantity.SizeMiB,
+			Size:        quantity.SizeMiB,
+			StartOffset: 2 * quantity.OffsetMiB,
 		},
 		VolumeStructure: &vol.Structure[0],
-		StartOffset:     2 * quantity.OffsetMiB,
 		YamlIndex:       0,
 		LaidOutContent: []gadget.LaidOutContent{
 			{

--- a/gadget/ondisk.go
+++ b/gadget/ondisk.go
@@ -173,7 +173,8 @@ func OnDiskStructureFromPartition(p disks.Partition) (OnDiskStructure, error) {
 		return OnDiskStructure{}, fmt.Errorf("cannot decode filesystem label for partition %s: %v", p.KernelDeviceNode, err)
 	}
 
-	logger.Noticef("OnDiskStructureFromPartition: p.FilesystemType %q, p.FilesystemLabel %q", p.FilesystemType, p.FilesystemLabel)
+	logger.Debugf("OnDiskStructureFromPartition: p.FilesystemType %q, p.FilesystemLabel %q",
+		p.FilesystemType, p.FilesystemLabel)
 
 	// TODO add ID in second part of the gadget refactoring?
 	return OnDiskStructure{

--- a/gadget/ondisk.go
+++ b/gadget/ondisk.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 
 	"github.com/snapcore/snapd/gadget/quantity"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil/disks"
 )
 
@@ -171,6 +172,8 @@ func OnDiskStructureFromPartition(p disks.Partition) (OnDiskStructure, error) {
 	if err != nil {
 		return OnDiskStructure{}, fmt.Errorf("cannot decode filesystem label for partition %s: %v", p.KernelDeviceNode, err)
 	}
+
+	logger.Noticef("OnDiskStructureFromPartition: p.FilesystemType %q, p.FilesystemLabel %q", p.FilesystemType, p.FilesystemLabel)
 
 	// TODO add ID in second part of the gadget refactoring?
 	return OnDiskStructure{

--- a/gadget/raw.go
+++ b/gadget/raw.go
@@ -46,7 +46,7 @@ func NewRawStructureWriter(contentDir string, ps *LaidOutStructure) (*RawStructu
 	if ps == nil {
 		return nil, fmt.Errorf("internal error: *LaidOutStructure is nil")
 	}
-	if ps.HasFilesystem() {
+	if ps.VolumeStructure.HasFilesystem() {
 		return nil, fmt.Errorf("internal error: structure %s has a filesystem", ps)
 	}
 	if contentDir == "" {

--- a/gadget/raw.go
+++ b/gadget/raw.go
@@ -46,7 +46,7 @@ func NewRawStructureWriter(contentDir string, ps *LaidOutStructure) (*RawStructu
 	if ps == nil {
 		return nil, fmt.Errorf("internal error: *LaidOutStructure is nil")
 	}
-	if ps.VolumeStructure.HasFilesystem() {
+	if ps.HasFilesystem() {
 		return nil, fmt.Errorf("internal error: structure %s has a filesystem", ps)
 	}
 	if contentDir == "" {

--- a/gadget/raw_test.go
+++ b/gadget/raw_test.go
@@ -298,10 +298,12 @@ func (r *rawTestSuite) TestRawUpdaterBackupUpdateRestoreSame(c *C) {
 	makeSizedFile(c, filepath.Join(r.dir, "foo.img"), 128, []byte("foo foo foo"))
 	makeSizedFile(c, filepath.Join(r.dir, "bar.img"), 128, []byte("bar bar bar"))
 	ps := &gadget.LaidOutStructure{
+		OnDiskStructure: gadget.OnDiskStructure{
+			StartOffset: 1 * quantity.OffsetMiB,
+		},
 		VolumeStructure: &gadget.VolumeStructure{
 			Size: 2048,
 		},
-		StartOffset: 1 * quantity.OffsetMiB,
 		LaidOutContent: []gadget.LaidOutContent{
 			{
 				VolumeContent: &gadget.VolumeContent{
@@ -378,10 +380,12 @@ func (r *rawTestSuite) TestRawUpdaterBackupUpdateRestoreDifferent(c *C) {
 	makeSizedFile(c, filepath.Join(r.dir, "bar.img"), 256, []byte("xxx xxx xxx xxx"))
 	makeSizedFile(c, filepath.Join(r.dir, "unchanged.img"), 128, []byte("unchanged unchanged"))
 	ps := &gadget.LaidOutStructure{
+		OnDiskStructure: gadget.OnDiskStructure{
+			StartOffset: 1 * quantity.OffsetMiB,
+		},
 		VolumeStructure: &gadget.VolumeStructure{
 			Size: 4096,
 		},
-		StartOffset: 1 * quantity.OffsetMiB,
 		LaidOutContent: []gadget.LaidOutContent{
 			{
 				VolumeContent: &gadget.VolumeContent{
@@ -472,12 +476,14 @@ func (r *rawTestSuite) TestRawUpdaterBackupUpdateRestoreNoPartition(c *C) {
 	makeSizedFile(c, filepath.Join(r.dir, "foo.img"), 128, []byte("zzz zzz zzz zzz"))
 	makeSizedFile(c, filepath.Join(r.dir, "bar.img"), 256, []byte("xxx xxx xxx xxx"))
 	ps := &gadget.LaidOutStructure{
+		OnDiskStructure: gadget.OnDiskStructure{
+			StartOffset: 1 * quantity.OffsetMiB,
+		},
 		VolumeStructure: &gadget.VolumeStructure{
 			// No partition table entry, would trigger fallback lookup path.
 			Type: "bare",
 			Size: 2048,
 		},
-		StartOffset: 1 * quantity.OffsetMiB,
 		LaidOutContent: []gadget.LaidOutContent{
 			{
 				VolumeContent: &gadget.VolumeContent{
@@ -534,10 +540,12 @@ func (r *rawTestSuite) TestRawUpdaterBackupUpdateRestoreNoPartition(c *C) {
 func (r *rawTestSuite) TestRawUpdaterBackupErrors(c *C) {
 	diskPath := filepath.Join(r.dir, "disk.img")
 	ps := &gadget.LaidOutStructure{
+		OnDiskStructure: gadget.OnDiskStructure{
+			StartOffset: 0,
+		},
 		VolumeStructure: &gadget.VolumeStructure{
 			Size: 2048,
 		},
-		StartOffset: 0,
 		LaidOutContent: []gadget.LaidOutContent{
 			{
 				VolumeContent: &gadget.VolumeContent{
@@ -583,10 +591,12 @@ func (r *rawTestSuite) TestRawUpdaterBackupIdempotent(c *C) {
 	makeSizedFile(c, diskPath, 0, nil)
 
 	ps := &gadget.LaidOutStructure{
+		OnDiskStructure: gadget.OnDiskStructure{
+			StartOffset: 0,
+		},
 		VolumeStructure: &gadget.VolumeStructure{
 			Size: 2048,
 		},
-		StartOffset: 0,
 		LaidOutContent: []gadget.LaidOutContent{
 			{
 				VolumeContent: &gadget.VolumeContent{
@@ -625,10 +635,12 @@ func (r *rawTestSuite) TestRawUpdaterBackupIdempotent(c *C) {
 
 func (r *rawTestSuite) TestRawUpdaterFindDeviceFailed(c *C) {
 	ps := &gadget.LaidOutStructure{
+		OnDiskStructure: gadget.OnDiskStructure{
+			StartOffset: 0,
+		},
 		VolumeStructure: &gadget.VolumeStructure{
 			Size: 2048,
 		},
-		StartOffset: 0,
 		LaidOutContent: []gadget.LaidOutContent{
 			{
 				VolumeContent: &gadget.VolumeContent{
@@ -671,10 +683,12 @@ func (r *rawTestSuite) TestRawUpdaterRollbackErrors(c *C) {
 	makeSizedFile(c, diskPath, 0, nil)
 
 	ps := &gadget.LaidOutStructure{
+		OnDiskStructure: gadget.OnDiskStructure{
+			StartOffset: 0,
+		},
 		VolumeStructure: &gadget.VolumeStructure{
 			Size: 2048,
 		},
-		StartOffset: 0,
 		LaidOutContent: []gadget.LaidOutContent{
 			{
 				VolumeContent: &gadget.VolumeContent{
@@ -721,10 +735,12 @@ func (r *rawTestSuite) TestRawUpdaterUpdateErrors(c *C) {
 	makeSizedFile(c, diskPath, 2048, nil)
 
 	ps := &gadget.LaidOutStructure{
+		OnDiskStructure: gadget.OnDiskStructure{
+			StartOffset: 0,
+		},
 		VolumeStructure: &gadget.VolumeStructure{
 			Size: 2048,
 		},
-		StartOffset: 0,
 		LaidOutContent: []gadget.LaidOutContent{
 			{
 				VolumeContent: &gadget.VolumeContent{
@@ -766,8 +782,10 @@ func (r *rawTestSuite) TestRawUpdaterUpdateErrors(c *C) {
 
 func (r *rawTestSuite) TestRawUpdaterContentBackupPath(c *C) {
 	ps := &gadget.LaidOutStructure{
+		OnDiskStructure: gadget.OnDiskStructure{
+			StartOffset: 0,
+		},
 		VolumeStructure: &gadget.VolumeStructure{},
-		StartOffset:     0,
 		LaidOutContent: []gadget.LaidOutContent{
 			{
 				VolumeContent: &gadget.VolumeContent{},

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -823,7 +823,7 @@ func buildNewVolumeToDeviceMapping(mod Model, old GadgetData, laidOutVols map[st
 		// here it is okay that we require there to be either a partition label
 		// or a filesystem label since we require there to be a system-boot role
 		// on this volume which by definition must have a filesystem
-		structureDevice, err := FindDeviceForStructure(&vs)
+		structureDevice, err := FindDeviceForStructure(vs.VolumeStructure)
 		if err == ErrDeviceNotFound {
 			continue
 		}

--- a/gadget/update_test.go
+++ b/gadget/update_test.go
@@ -275,46 +275,46 @@ func (u *updateTestSuite) TestCanUpdateOffset(c *C) {
 		{
 			// explicitly declared start offset change
 			from: gadget.LaidOutStructure{
+				OnDiskStructure: gadget.OnDiskStructure{StartOffset: 1024},
 				VolumeStructure: &gadget.VolumeStructure{Size: 1 * quantity.SizeMiB, Offset: asOffsetPtr(1024)},
-				StartOffset:     1024,
 			},
 			to: gadget.LaidOutStructure{
+				OnDiskStructure: gadget.OnDiskStructure{StartOffset: 2048},
 				VolumeStructure: &gadget.VolumeStructure{Size: 1 * quantity.SizeMiB, Offset: asOffsetPtr(2048)},
-				StartOffset:     2048,
 			},
 			err: "cannot change structure offset from [0-9]+ to [0-9]+",
 		}, {
 			// explicitly declared start offset in new structure
 			from: gadget.LaidOutStructure{
+				OnDiskStructure: gadget.OnDiskStructure{StartOffset: 1024},
 				VolumeStructure: &gadget.VolumeStructure{Size: 1 * quantity.SizeMiB, Offset: nil},
-				StartOffset:     1024,
 			},
 			to: gadget.LaidOutStructure{
+				OnDiskStructure: gadget.OnDiskStructure{StartOffset: 2048},
 				VolumeStructure: &gadget.VolumeStructure{Size: 1 * quantity.SizeMiB, Offset: asOffsetPtr(2048)},
-				StartOffset:     2048,
 			},
 			err: "cannot change structure offset from unspecified to [0-9]+",
 		}, {
 			// explicitly declared start offset in old structure,
 			// missing from new
 			from: gadget.LaidOutStructure{
+				OnDiskStructure: gadget.OnDiskStructure{StartOffset: 1024},
 				VolumeStructure: &gadget.VolumeStructure{Size: 1 * quantity.SizeMiB, Offset: asOffsetPtr(1024)},
-				StartOffset:     1024,
 			},
 			to: gadget.LaidOutStructure{
+				OnDiskStructure: gadget.OnDiskStructure{StartOffset: 2048},
 				VolumeStructure: &gadget.VolumeStructure{Size: 1 * quantity.SizeMiB, Offset: nil},
-				StartOffset:     2048,
 			},
 			err: "cannot change structure offset from [0-9]+ to unspecified",
 		}, {
 			// start offset changed due to layout
 			from: gadget.LaidOutStructure{
+				OnDiskStructure: gadget.OnDiskStructure{StartOffset: 1 * quantity.OffsetMiB},
 				VolumeStructure: &gadget.VolumeStructure{Size: 1 * quantity.SizeMiB},
-				StartOffset:     1 * quantity.OffsetMiB,
 			},
 			to: gadget.LaidOutStructure{
+				OnDiskStructure: gadget.OnDiskStructure{StartOffset: 2 * quantity.OffsetMiB},
 				VolumeStructure: &gadget.VolumeStructure{Size: 1 * quantity.SizeMiB},
-				StartOffset:     2 * quantity.OffsetMiB,
 			},
 			err: "cannot change structure start offset from [0-9]+ to [0-9]+",
 		},
@@ -3179,23 +3179,23 @@ func (u *updateTestSuite) TestUpdaterForStructure(c *C) {
 	defer restore()
 
 	psBare := &gadget.LaidOutStructure{
+		OnDiskStructure: gadget.OnDiskStructure{StartOffset: 1 * quantity.OffsetMiB},
 		VolumeStructure: &gadget.VolumeStructure{
 			Filesystem: "none",
 			Size:       10 * quantity.SizeMiB,
 		},
-		StartOffset: 1 * quantity.OffsetMiB,
 	}
 	updater, err := gadget.UpdaterForStructure(gadget.StructureLocation{}, psBare, gadgetRootDir, rollbackDir, nil)
 	c.Assert(err, IsNil)
 	c.Assert(updater, FitsTypeOf, &gadget.RawStructureUpdater{})
 
 	psFs := &gadget.LaidOutStructure{
+		OnDiskStructure: gadget.OnDiskStructure{StartOffset: 1 * quantity.OffsetMiB},
 		VolumeStructure: &gadget.VolumeStructure{
 			Filesystem: "ext4",
 			Size:       10 * quantity.SizeMiB,
 			Label:      "writable",
 		},
-		StartOffset: 1 * quantity.OffsetMiB,
 	}
 	updater, err = gadget.UpdaterForStructure(gadget.StructureLocation{}, psFs, gadgetRootDir, rollbackDir, nil)
 	c.Assert(err, IsNil)

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -1357,9 +1357,13 @@ func (m *DeviceManager) doInstallFinish(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
+	encType := secboot.EncryptionTypeNone
+	if useEncryption {
+		encType = secboot.EncryptionTypeLUKS
+	}
 	// TODO for partial gadgets we should also use the data from onVolumes instead of
 	// using only what comes from gadget.yaml.
-	_, allLaidOutVols, err := gadget.LaidOutVolumesFromGadget(mntPtForType[snap.TypeGadget], mntPtForType[snap.TypeKernel], sys.Model)
+	_, allLaidOutVols, err := gadget.LaidOutVolumesFromGadget(mntPtForType[snap.TypeGadget], mntPtForType[snap.TypeKernel], sys.Model, encType)
 	if err != nil {
 		return fmt.Errorf("on finish install: cannot layout volumes: %v", err)
 	}

--- a/tests/lib/muinstaller/go.mod
+++ b/tests/lib/muinstaller/go.mod
@@ -2,4 +2,7 @@ module github.com/snapcore/snapd/tests/lib/muinstaller
 
 go 1.18
 
+// XXX remove as soon as https://github.com/snapcore/snapd/pull/12515 is merged
+replace github.com/snapcore/snapd => github.com/alfonsosanchezbeato/snapd v0.0.0-20230130182541-16e1bd3b2b6f
+
 require github.com/snapcore/snapd v0.0.0-20221213080842-b3362c5d4b1a

--- a/tests/lib/muinstaller/main.go
+++ b/tests/lib/muinstaller/main.go
@@ -433,7 +433,6 @@ func run(seedLabel, rootfsCreator, bootDevice string) error {
 	if err != nil {
 		return err
 	}
-	logger.Noticef("encrypting: %t", shouldEncrypt)
 	// TODO: grow the data-partition based on disk size
 	encType := secboot.EncryptionTypeNone
 	if shouldEncrypt {

--- a/tests/lib/muinstaller/main.go
+++ b/tests/lib/muinstaller/main.go
@@ -41,6 +41,7 @@ import (
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/disks"
 	"github.com/snapcore/snapd/osutil/mkfs"
+	"github.com/snapcore/snapd/secboot"
 )
 
 func waitForDevice() string {
@@ -152,7 +153,7 @@ func maybeCreatePartitionTable(bootDevice, schema string) error {
 	return nil
 }
 
-func createPartitions(bootDevice string, volumes map[string]*gadget.Volume) ([]gadget.OnDiskStructure, error) {
+func createPartitions(bootDevice string, volumes map[string]*gadget.Volume, encType secboot.EncryptionType) ([]gadget.OnDiskStructure, error) {
 	// TODO: support multiple volumes, see gadget/install/install.go
 	if len(volumes) != 1 {
 		return nil, fmt.Errorf("got unexpected number of volumes %v", len(volumes))
@@ -175,6 +176,7 @@ func createPartitions(bootDevice string, volumes map[string]*gadget.Volume) ([]g
 
 	layoutOpts := &gadget.LayoutOptions{
 		IgnoreContent: true,
+		EncType:       encType,
 	}
 
 	lvol, err := gadget.LayoutVolume(vol, layoutOpts)
@@ -427,14 +429,19 @@ func run(seedLabel, rootfsCreator, bootDevice string) error {
 	if err != nil {
 		return err
 	}
-	// TODO: grow the data-partition based on disk size
-	laidoutStructs, err := createPartitions(bootDevice, details.Volumes)
-	if err != nil {
-		return fmt.Errorf("cannot setup partitions: %v", err)
-	}
 	shouldEncrypt, err := detectStorageEncryption(seedLabel)
 	if err != nil {
 		return err
+	}
+	logger.Noticef("encrypting: %t", shouldEncrypt)
+	// TODO: grow the data-partition based on disk size
+	encType := secboot.EncryptionTypeNone
+	if shouldEncrypt {
+		encType = secboot.EncryptionTypeLUKS
+	}
+	laidoutStructs, err := createPartitions(bootDevice, details.Volumes, encType)
+	if err != nil {
+		return fmt.Errorf("cannot setup partitions: %v", err)
 	}
 	var encryptedDevices = make(map[string]string)
 	if shouldEncrypt {

--- a/tests/nested/manual/muinstaller-real/task.yaml
+++ b/tests/nested/manual/muinstaller-real/task.yaml
@@ -142,6 +142,7 @@ execute: |
       remote.exec "sudo mv $(basename $s) /boot/efi/EFI/$s"
   done
 
+  remote.exec "sudo sh -c 'echo SNAPD_DEBUG=1 >> /etc/environment'"
   # push our snap down
   # TODO: this abuses /var/lib/snapd to store the deb so that mk-initramfs-classic
   # can pick it up. the real installer will also need a very recent snapd


### PR DESCRIPTION
Include OnDiskStructure in LaidOutStructure so we really have all the
needed information to create partitions and content in
LaidOutStructure. Also, remove the now unneeded
onDiskAndLaidoutStructure.