### PR TITLE
snap,snapdtool: introduce SnapdAssertionMaxFormatsFromSnapFile

### DIFF
--- a/snap/info.go
+++ b/snap/info.go
@@ -21,6 +21,7 @@ package snap
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/url"
@@ -35,6 +36,7 @@ import (
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/sys"
 	"github.com/snapcore/snapd/snap/naming"
+	"github.com/snapcore/snapd/snapdtool"
 	"github.com/snapcore/snapd/strutil"
 	"github.com/snapcore/snapd/timeout"
 )
@@ -1545,4 +1547,86 @@ func (a AppInfoBySnapApp) Less(i, j int) bool {
 		return a[i].Name < a[j].Name
 	}
 	return iName < jName
+}
+
+// SnapdAssertionMaxFormatsFromSnapFile returns the supported assertion max
+// formats for the snapd code carried by the given snap, plus its snapd
+// version. This is only applicable to snapd/core or UC20+ kernel snaps.
+// For kernel snaps that are not UC20+ or that do not carry the necessary
+// explicit information yes, this can return nil and "" respectively for
+// maxFormats and snapdVersion.
+func SnapdAssertionMaxFormatsFromSnapFile(snapf Container) (maxFormats map[string]int, snapdVersion string, err error) {
+	info, err := ReadInfoFromSnapFile(snapf, nil)
+	if err != nil {
+		return nil, "", err
+	}
+	var infoFile string
+	missingOK := false
+	typ := info.Type()
+	switch typ {
+	case TypeOS, TypeSnapd:
+		infoFile = "/usr/lib/snapd/info"
+	case TypeKernel:
+		infoFile = "/snapd-info"
+		// some old kernel file will not contain this
+		missingOK = true
+	default:
+		return nil, "", fmt.Errorf("cannot extract assertion max formats information, snaps of type %s do not carry snapd", typ)
+	}
+	b, err := snapf.ReadFile(infoFile)
+	if err != nil {
+		if missingOK && os.IsNotExist(err) {
+			return nil, "", nil
+		}
+		return nil, "", err
+	}
+	ver, flags, err := snapdtool.ParseInfoFile(bytes.NewBuffer(b), fmt.Sprintf("from %s snap", typ))
+	if err != nil {
+		return nil, "", err
+	}
+	if fmts := flags["SNAPD_ASSERTS_FORMATS"]; fmts != "" {
+		err := json.Unmarshal([]byte(strings.Trim(fmts, "'")), &maxFormats)
+		if err != nil {
+			return nil, "", fmt.Errorf("cannot unmarshal SNAPD_ASSERTS_FORMATS from info file from %s snap", typ)
+		}
+		return maxFormats, ver, nil
+	}
+	// use version
+	sysUser := 0
+	cmp, err := strutil.VersionCompare(ver, "2.46")
+	if err != nil {
+		return nil, "", fmt.Errorf("invalid snapd version in info file from %s snap: %v", typ, err)
+	}
+	if cmp >= 0 {
+		sysUser = 1
+	}
+	snapDecl := 0
+	for _, mapping := range verToSnapDecl {
+		// ignoring error as we validated the version before
+		if cmp, _ := strutil.VersionCompare(ver, mapping.ver); cmp >= 0 {
+			snapDecl = mapping.format
+			break
+		}
+	}
+	maxFormats = make(map[string]int)
+	if sysUser > 0 {
+		maxFormats["system-user"] = sysUser
+	}
+	if snapDecl > 0 {
+		maxFormats["snap-declaration"] = snapDecl
+	}
+	return maxFormats, ver, nil
+}
+
+var verToSnapDecl = []struct {
+	ver    string
+	format int
+}{
+	{"2.54", 5},
+	{"2.44", 4},
+	{"2.36", 3},
+	// old
+	{"2.23", 2},
+	// ancient
+	{"2.17", 1},
 }

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -1946,3 +1946,105 @@ func (s *infoSuite) TestGetAttributeHappy(c *C) {
 	c.Check(err, IsNil)
 	c.Check(intVal, Equals, 12)
 }
+
+func (s *infoSuite) TestSnapdAssertionMaxFormatsFromSnapFileFromSnapd(c *C) {
+	tests := []struct {
+		info     string
+		snapDecl int
+		sysUser  int
+	}{
+		{info: `VERSION=2.58
+SNAPD_ASSERTS_FORMATS='{"snap-declaration":5,"system-user":2}'`, snapDecl: 5, sysUser: 2},
+		{info: `VERSION=2.56
+SNAPD_ASSERTS_FORMATS='{"snap-declaration":5,"system-user":1}'`, snapDecl: 5, sysUser: 1},
+		{info: `VERSION=2.55`, snapDecl: 5, sysUser: 1},
+		{info: `VERSION=2.54`, snapDecl: 5, sysUser: 1},
+		{info: `VERSION=2.47`, snapDecl: 4, sysUser: 1},
+		{info: `VERSION=2.46`, snapDecl: 4, sysUser: 1},
+		{info: `VERSION=2.45`, snapDecl: 4},
+		{info: `VERSION=2.44`, snapDecl: 4},
+		{info: `VERSION=2.36`, snapDecl: 3},
+		// old
+		{info: `VERSION=2.23`, snapDecl: 2},
+		// ancient
+		{info: `VERSION=2.17`, snapDecl: 1},
+		{info: `VERSION=2.16`},
+	}
+	for _, t := range tests {
+		snapdPath := snaptest.MakeTestSnapWithFiles(c, `name: snapd
+type: snapd
+version: 1.0`, [][]string{{
+			"/usr/lib/snapd/info", t.info}})
+		snapf, err := snapfile.Open(snapdPath)
+		c.Assert(err, IsNil)
+
+		maxFormats, ver, err := snap.SnapdAssertionMaxFormatsFromSnapFile(snapf)
+		c.Assert(err, IsNil)
+		expectedMaxFormats := map[string]int{}
+		if t.sysUser > 0 {
+			expectedMaxFormats["system-user"] = t.sysUser
+		}
+		if t.snapDecl > 0 {
+			expectedMaxFormats["snap-declaration"] = t.snapDecl
+		}
+		c.Check(maxFormats, DeepEquals, expectedMaxFormats)
+		c.Check(strings.HasPrefix(t.info, fmt.Sprintf("VERSION=%s", ver)), Equals, true)
+	}
+}
+
+func (s *infoSuite) TestSnapdAssertionMaxFormatsFromSnapFileFromCore(c *C) {
+	corePath := snaptest.MakeTestSnapWithFiles(c, `name: core
+type: os
+version: 1.0`, [][]string{{
+		"/usr/lib/snapd/info", `VERSION=2.47`}})
+	snapf, err := snapfile.Open(corePath)
+	c.Assert(err, IsNil)
+
+	maxFormats, ver, err := snap.SnapdAssertionMaxFormatsFromSnapFile(snapf)
+	c.Assert(err, IsNil)
+	c.Check(ver, Equals, "2.47")
+	c.Check(maxFormats, DeepEquals, map[string]int{
+		"snap-declaration": 4,
+		"system-user":      1,
+	})
+}
+
+func (s *infoSuite) TestSnapdAssertionMaxFormatsFromSnapFileFromKernel(c *C) {
+	krnlPath := snaptest.MakeTestSnapWithFiles(c, `name: krnl
+type: kernel
+version: 1.0`, [][]string{{
+		"/snapd-info", `VERSION=2.56
+SNAPD_ASSERTS_FORMATS='{"snap-declaration":5,"system-user":1}'`}})
+	snapf, err := snapfile.Open(krnlPath)
+	c.Assert(err, IsNil)
+
+	maxFormats, ver, err := snap.SnapdAssertionMaxFormatsFromSnapFile(snapf)
+	c.Assert(err, IsNil)
+	c.Check(ver, Equals, "2.56")
+	c.Check(maxFormats, DeepEquals, map[string]int{
+		"snap-declaration": 5,
+		"system-user":      1,
+	})
+
+	// no snadd-info
+	krnlPath = snaptest.MakeTestSnapWithFiles(c, `name: krnl
+type: kernel
+version: 1.0`, nil)
+	snapf, err = snapfile.Open(krnlPath)
+	c.Assert(err, IsNil)
+
+	maxFormats, ver, err = snap.SnapdAssertionMaxFormatsFromSnapFile(snapf)
+	c.Assert(err, IsNil)
+	c.Check(ver, Equals, "")
+	c.Check(maxFormats, IsNil)
+}
+
+func (s *infoSuite) TestSnapdAssertionMaxFormatsFromSnapFileFromOther(c *C) {
+	appPath := snaptest.MakeTestSnapWithFiles(c, `name: app
+version: 1.0`, nil)
+	snapf, err := snapfile.Open(appPath)
+	c.Assert(err, IsNil)
+
+	_, _, err = snap.SnapdAssertionMaxFormatsFromSnapFile(snapf)
+	c.Check(err, ErrorMatches, `cannot extract assertion max formats information, snaps of type app do not carry snapd`)
+}

--- a/snapdtool/info_file_test.go
+++ b/snapdtool/info_file_test.go
@@ -44,7 +44,7 @@ func (s *infoFileSuite) TestNoVersionData(c *C) {
 	c.Assert(ioutil.WriteFile(infoFile, []byte("foo"), 0644), IsNil)
 
 	_, _, err := snapdtool.SnapdVersionFromInfoFile(top)
-	c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot find snapd version information in file %q`, infoFile))
+	c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot find version in snapd info file %q`, infoFile))
 }
 
 func (s *infoFileSuite) TestVersionHappy(c *C) {


### PR DESCRIPTION
this will be useful to determine supported assertion max formats for snapd/core and kernel snaps that are used to build an image

to do this we split out snapdtool.ParseInfoFile
