### PR TITLE
github: add codecov 

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true

--- a/strutil/strutil.go
+++ b/strutil/strutil.go
@@ -355,3 +355,10 @@ func WordWrapPadded(out io.Writer, text []rune, pad string, termWidth int) error
 	}
 	return WordWrap(out, text, indent, indent, termWidth)
 }
+
+func UntestedCode(s string) bool {
+	if s == "test-me" {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
In the x-go project there is a visible representation for untested code. It seems their codecov.yml is generating this so this PR tries to explore how to archive the same for us. The second commit is just here for testing and will be removed.