### PR TITLE
tests: add `go:build !nosecboot` to avoid sbuild failure

### DIFF
--- a/tests/lib/muinstaller/main.go
+++ b/tests/lib/muinstaller/main.go
@@ -1,4 +1,6 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !nosecboot
+// +build !nosecboot
 
 /*
  * Copyright (C) 2022 Canonical Ltd


### PR DESCRIPTION
The muinstaller imports from gadget/install code that has the `//go:build !nosecboot` build tag. However the muinstaller itself does not have this build tag which means that when building under Debian the build will fail because we set `nosecboot` there.

Tested by running:
```
$ spread -debug -v google:debian-sid-64:tests/nightly/sbuild
2023-01-26 10:42:28 Allocating google:debian-sid-64...
...
2023-01-26 11:17:59 Restoring google:debian-sid-64:tests/nightly/sbuild:normal (jan260942-675130)...
2023-01-26 11:18:23 Restoring google:debian-sid-64:tests/nightly/ (jan260942-675130)...
2023-01-26 11:18:32 Restoring google:debian-sid-64 (jan260942-675130)...
2023-01-26 11:18:32 Discarding google:debian-sid-64 (jan260942-675130)...
2023-01-26 11:21:11 Restoring google:debian-sid-64:tests/nightly/sbuild:i386 (jan260942-675018)...
2023-01-26 11:21:35 Restoring google:debian-sid-64:tests/nightly/ (jan260942-675018)...
2023-01-26 11:21:44 Restoring google:debian-sid-64 (jan260942-675018)...
2023-01-26 11:21:45 Discarding google:debian-sid-64 (jan260942-675018)...
2023-01-26 11:21:46 Successful tasks: 3
2023-01-26 11:21:46 Aborted tasks: 0
```
