### PR TITLE
tests: skip snap-quota-install in arm core systems

### DIFF
--- a/tests/main/snap-quota-install/task.yaml
+++ b/tests/main/snap-quota-install/task.yaml
@@ -3,6 +3,10 @@ summary: Test for assigning quota group on snap install.
 details: |
   Test support for assigning a snap quota group on install of a snap
 
+# In arm devices using ubuntu core, memory quota cannot be used because
+# memory cgroup is disabled
+systems: [-ubuntu-core-*-arm-*]
+
 prepare: |
   snap pack "$TESTSLIB"/snaps/basic
   snap set system experimental.quota-groups=true


### PR DESCRIPTION
The following error is displayed when the test is executed

snap set-quota group-one --memory=400MB
error: cannot create quota group: cannot create quota group "group-one": cannot
       use memory quota: memory cgroup is disabled on this system
