### PR TITLE
many: move memory,cpu and thread quota out of experimental

### DIFF
--- a/cmd/snap/cmd_help.go
+++ b/cmd/snap/cmd_help.go
@@ -264,6 +264,11 @@ var helpCategories = []helpCategory{
 		Commands:        []string{"download", "pack", "run", "try"},
 		AllOnlyCommands: []string{"prepare-image"},
 	},
+	{
+		Label:       i18n.G("Quota Groups"),
+		Description: i18n.G("Manage quota groups for snaps"),
+		Commands:    []string{"set-quota", "remove-quota", "quotas", "quota"},
+	},
 }
 
 var (

--- a/cmd/snap/cmd_quota.go
+++ b/cmd/snap/cmd_quota.go
@@ -113,8 +113,7 @@ An existing sub group cannot be moved from one parent to another.
 `)
 
 func init() {
-	// TODO: unhide the commands when non-experimental
-	cmd := addCommand("set-quota", shortSetQuotaHelp, longSetQuotaHelp,
+	addCommand("set-quota", shortSetQuotaHelp, longSetQuotaHelp,
 		func() flags.Commander { return &cmdSetQuota{} },
 		waitDescs.also(map[string]string{
 			"memory":             i18n.G("Memory quota"),
@@ -125,16 +124,9 @@ func init() {
 			"journal-rate-limit": i18n.G("Journal rate limit as <message count>/<message period>"),
 			"parent":             i18n.G("Parent quota group"),
 		}), nil)
-	cmd.hidden = true
-
-	cmd = addCommand("quota", shortQuotaHelp, longQuotaHelp, func() flags.Commander { return &cmdQuota{} }, nil, nil)
-	cmd.hidden = true
-
-	cmd = addCommand("quotas", shortQuotasHelp, longQuotasHelp, func() flags.Commander { return &cmdQuotas{} }, nil, nil)
-	cmd.hidden = true
-
-	cmd = addCommand("remove-quota", shortRemoveQuotaHelp, longRemoveQuotaHelp, func() flags.Commander { return &cmdRemoveQuota{} }, nil, nil)
-	cmd.hidden = true
+	addCommand("quota", shortQuotaHelp, longQuotaHelp, func() flags.Commander { return &cmdQuota{} }, nil, nil)
+	addCommand("quotas", shortQuotasHelp, longQuotasHelp, func() flags.Commander { return &cmdQuotas{} }, nil, nil)
+	addCommand("remove-quota", shortRemoveQuotaHelp, longRemoveQuotaHelp, func() flags.Commander { return &cmdRemoveQuota{} }, nil, nil)
 }
 
 type cmdSetQuota struct {

--- a/daemon/api_quotas_test.go
+++ b/daemon/api_quotas_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/daemon"
 	"github.com/snapcore/snapd/gadget/quantity"
-	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/servicestate"
 	"github.com/snapcore/snapd/overlord/servicestate/servicestatetest"
 	"github.com/snapcore/snapd/overlord/snapstate"
@@ -56,9 +55,6 @@ func (s *apiQuotaSuite) SetUpTest(c *check.C) {
 	st := s.d.Overlord().State()
 	st.Lock()
 	defer st.Unlock()
-	tr := config.NewTransaction(st)
-	tr.Set("core", "experimental.quota-groups", true)
-	tr.Commit()
 
 	r := systemd.MockSystemdVersion(248, nil)
 	s.AddCleanup(r)

--- a/features/features.go
+++ b/features/features.go
@@ -64,11 +64,8 @@ const (
 	// GateAutoRefreshHook enables refresh control from snaps via gate-auto-refresh hook.
 	GateAutoRefreshHook
 
-	// QuotaGroups enable creating resource quota groups for snaps via the rest API and cli.
+	// QuotaGroups enables experimental features related to the Quota Groups API.
 	QuotaGroups
-
-	// JournalQuota enables journal quotas for quota groups.
-	JournalQuota
 
 	// lastFeature is the final known feature, it is only used for testing.
 	lastFeature
@@ -108,8 +105,7 @@ var featureNames = map[SnapdFeature]string{
 
 	GateAutoRefreshHook: "gate-auto-refresh-hook",
 
-	QuotaGroups:  "quota-groups",
-	JournalQuota: "journal-quota",
+	QuotaGroups: "quota-groups",
 }
 
 // featuresEnabledWhenUnset contains a set of features that are enabled when not explicitly configured.

--- a/features/features.go
+++ b/features/features.go
@@ -63,8 +63,10 @@ const (
 	CheckDiskSpaceRefresh
 	// GateAutoRefreshHook enables refresh control from snaps via gate-auto-refresh hook.
 	GateAutoRefreshHook
-
-	// QuotaGroups enables experimental features related to the Quota Groups API.
+	// QuotaGroups enables any current experimental features related to the Quota Groups API, on top of the features
+	// already graduated past experimental:
+	//  * journal quotas are still experimental
+	// while guota groups creation and management and memory, cpu, quotas are no longer experimental.
 	QuotaGroups
 
 	// lastFeature is the final known feature, it is only used for testing.

--- a/features/features_test.go
+++ b/features/features_test.go
@@ -56,7 +56,6 @@ func (*featureSuite) TestName(c *C) {
 	c.Check(features.CheckDiskSpaceRemove.String(), Equals, "check-disk-space-remove")
 	c.Check(features.GateAutoRefreshHook.String(), Equals, "gate-auto-refresh-hook")
 	c.Check(features.QuotaGroups.String(), Equals, "quota-groups")
-	c.Check(features.JournalQuota.String(), Equals, "journal-quota")
 	c.Check(func() { _ = features.SnapdFeature(1000).String() }, PanicMatches, "unknown feature flag code 1000")
 }
 

--- a/overlord/configstate/configcore/vitality_test.go
+++ b/overlord/configstate/configcore/vitality_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/snapcore/snapd/asserts/assertstest"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget/quantity"
-	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/configstate/configcore"
 	"github.com/snapcore/snapd/overlord/servicestate"
 	"github.com/snapcore/snapd/overlord/servicestate/servicestatetest"
@@ -194,9 +193,6 @@ func (s *vitalitySuite) TestConfigureVitalityWithQuotaGroup(c *C) {
 		return nil, nil
 	})
 	s.AddCleanup(systemctlRestorer)
-	tr := config.NewTransaction(s.state)
-	tr.Set("core", "experimental.quota-groups", true)
-	tr.Commit()
 
 	// make a new quota group with this snap in it
 	err := servicestatetest.MockQuotaInState(s.state, "foogroup", "", []string{"test-snap"}, nil,

--- a/overlord/ifacestate/handlers_test.go
+++ b/overlord/ifacestate/handlers_test.go
@@ -144,6 +144,8 @@ func (s *handlersSuite) TestBuildConfinementOptionsWithLogNamespace(c *C) {
 	s.st.Lock()
 	defer s.st.Unlock()
 
+	// journal quota is still experimental, so we must enable the experimental
+	// quota-groups option
 	tr := config.NewTransaction(s.st)
 	tr.Set("core", "experimental.quota-groups", true)
 	tr.Commit()

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -787,10 +787,6 @@ apps:
 `
 	s.installLocalTestSnap(c, snapYamlContent+"version: 1.0")
 
-	tr := config.NewTransaction(st)
-	c.Assert(tr.Set("core", "experimental.quota-groups", "true"), IsNil)
-	tr.Commit()
-
 	// put the snap in a quota group
 	err := servicestatetest.MockQuotaInState(st, "quota-grp", "", []string{"foo"}, nil,
 		quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeMiB).Build())
@@ -838,10 +834,6 @@ apps:
   daemon: simple
 `
 	si := s.installLocalTestSnap(c, snapYamlContent+"version: 1.0")
-
-	tr := config.NewTransaction(st)
-	c.Assert(tr.Set("core", "experimental.quota-groups", "true"), IsNil)
-	tr.Commit()
 
 	// add the snap to a quota group
 	ts, err := servicestate.CreateQuota(st, "grp", servicestate.CreateQuotaOptions{

--- a/overlord/servicestate/quota_control.go
+++ b/overlord/servicestate/quota_control.go
@@ -73,14 +73,14 @@ func quotaGroupsAvailable(st *state.State) error {
 	return nil
 }
 
-func isQuotaAvailable(st *state.State, feature features.SnapdFeature, settingName string) error {
+func isExperimentalQuotasAvailable(st *state.State, quotaName string) error {
 	tr := config.NewTransaction(st)
-	status, err := features.Flag(tr, feature)
+	status, err := features.Flag(tr, features.QuotaGroups)
 	if err != nil && !config.IsNoOption(err) {
 		return err
 	}
 	if !status {
-		return fmt.Errorf("experimental feature disabled - test it by setting 'experimental.%s' to true", settingName)
+		return fmt.Errorf("%s quota options are experimental - test it by setting 'experimental.quota-groups' to true", quotaName)
 	}
 	return nil
 }
@@ -112,8 +112,8 @@ func verifyQuotaRequirements(st *state.State, resourceLimits quota.Resources) er
 			return fmt.Errorf("cannot use journal quota with incompatible systemd: %v", err)
 		}
 
-		// To use journal quotas, the quota-groups experimental feature must be enabled.
-		if err := isQuotaAvailable(st, features.QuotaGroups, "quota-groups"); err != nil {
+		// To use journal quotas, the quota-group experimental features must be enabled.
+		if err := isExperimentalQuotasAvailable(st, "journal"); err != nil {
 			return err
 		}
 	}

--- a/overlord/servicestate/quota_control_test.go
+++ b/overlord/servicestate/quota_control_test.go
@@ -296,11 +296,11 @@ func (s *quotaControlSuite) TestCreateQuotaExperimentalNotEnabled(c *C) {
 	tr.Set("core", "experimental.quota-groups", false)
 	tr.Commit()
 
-	// Journal Quotas is experimental, must give an error
+	// Journal Quota is experimental, must give an error
 	_, err := servicestate.CreateQuota(s.state, "foo", servicestate.CreateQuotaOptions{
 		ResourceLimits: quota.NewResourcesBuilder().WithJournalNamespace().Build(),
 	})
-	c.Assert(err, ErrorMatches, `experimental feature disabled - test it by setting 'experimental.quota-groups' to true`)
+	c.Assert(err, ErrorMatches, `journal quota options are experimental - test it by setting 'experimental.quota-groups' to true`)
 }
 
 func (s *quotaControlSuite) TestCreateQuotaSystemdTooOld(c *C) {
@@ -361,7 +361,7 @@ func (s *quotaControlSuite) TestCreateQuotaJournalNotEnabled(c *C) {
 	_, err := servicestate.CreateQuota(s.state, "foo", servicestate.CreateQuotaOptions{
 		ResourceLimits: quotaConstraits,
 	})
-	c.Assert(err, ErrorMatches, `experimental feature disabled - test it by setting 'experimental.quota-groups' to true`)
+	c.Assert(err, ErrorMatches, `journal quota options are experimental - test it by setting 'experimental.quota-groups' to true`)
 }
 
 func (s *quotaControlSuite) TestCreateQuotaJournalEnabled(c *C) {
@@ -812,7 +812,7 @@ func (s *quotaControlSuite) TestUpdateQuotaGroupExperimentalNotEnabled(c *C) {
 		NewResourceLimits: quota.NewResourcesBuilder().WithJournalNamespace().Build(),
 	}
 	_, err := servicestate.UpdateQuota(s.state, "foo", opts)
-	c.Assert(err, ErrorMatches, `experimental feature disabled - test it by setting 'experimental.quota-groups' to true`)
+	c.Assert(err, ErrorMatches, `journal quota options are experimental - test it by setting 'experimental.quota-groups' to true`)
 }
 
 func (s *quotaControlSuite) TestUpdateQuotaPrecond(c *C) {

--- a/overlord/servicestate/quota_control_test.go
+++ b/overlord/servicestate/quota_control_test.go
@@ -56,12 +56,8 @@ func (s *quotaControlSuite) SetUpTest(c *C) {
 	// we don't need the EnsureSnapServices ensure loop to run by default
 	servicestate.MockEnsuredSnapServices(s.mgr, true)
 
-	// we enable quota-groups by default
 	s.state.Lock()
 	defer s.state.Unlock()
-	tr := config.NewTransaction(s.state)
-	tr.Set("core", "experimental.quota-groups", true)
-	tr.Commit()
 
 	// mock that we have a new enough version of systemd by default
 	r := systemd.MockSystemdVersion(248, nil)
@@ -290,16 +286,19 @@ func checkQuotaControlTasks(c *C, tasks []*state.Task, expAction *servicestate.Q
 	c.Assert(qcs[0], DeepEquals, expAction)
 }
 
-func (s *quotaControlSuite) TestCreateQuotaNotEnabled(c *C) {
+func (s *quotaControlSuite) TestCreateQuotaExperimentalNotEnabled(c *C) {
+	// Test experimental quota group features that should not be enabled when
+	// quota-groups feature is disabled
 	s.state.Lock()
 	defer s.state.Unlock()
+
 	tr := config.NewTransaction(s.state)
 	tr.Set("core", "experimental.quota-groups", false)
 	tr.Commit()
 
-	// try to create an empty quota group
+	// Journal Quotas is experimental, must give an error
 	_, err := servicestate.CreateQuota(s.state, "foo", servicestate.CreateQuotaOptions{
-		ResourceLimits: quota.NewResourcesBuilder().WithMemoryLimit(quantity.SizeGiB).Build(),
+		ResourceLimits: quota.NewResourcesBuilder().WithJournalNamespace().Build(),
 	})
 	c.Assert(err, ErrorMatches, `experimental feature disabled - test it by setting 'experimental.quota-groups' to true`)
 }
@@ -370,7 +369,7 @@ func (s *quotaControlSuite) TestCreateQuotaJournalEnabled(c *C) {
 	defer s.state.Unlock()
 
 	tr := config.NewTransaction(s.state)
-	tr.Set("core", "experimental.journal-quota", true)
+	tr.Set("core", "experimental.quota-groups", true)
 	tr.Commit()
 
 	quotaConstraits := quota.NewResourcesBuilder().WithJournalNamespace().Build()
@@ -799,14 +798,19 @@ func (s *quotaControlSuite) TestEnsureSnapAbsentFromQuotaGroup(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *quotaControlSuite) TestUpdateQuotaGroupNotEnabled(c *C) {
+func (s *quotaControlSuite) TestUpdateQuotaGroupExperimentalNotEnabled(c *C) {
+	// Test experimental quota group features that should not be enabled when
+	// quota-groups feature is disabled
 	s.state.Lock()
 	defer s.state.Unlock()
 	tr := config.NewTransaction(s.state)
 	tr.Set("core", "experimental.quota-groups", false)
 	tr.Commit()
 
-	opts := servicestate.UpdateQuotaOptions{}
+	// Journal Quotas is experimental, must give an error
+	opts := servicestate.UpdateQuotaOptions{
+		NewResourceLimits: quota.NewResourcesBuilder().WithJournalNamespace().Build(),
+	}
 	_, err := servicestate.UpdateQuota(s.state, "foo", opts)
 	c.Assert(err, ErrorMatches, `experimental feature disabled - test it by setting 'experimental.quota-groups' to true`)
 }
@@ -1320,7 +1324,7 @@ func (s *quotaControlSuite) TestAddJournalQuotaToGroupWithServicesFail(c *C) {
 	defer st.Unlock()
 
 	tr := config.NewTransaction(s.state)
-	tr.Set("core", "experimental.journal-quota", true)
+	tr.Set("core", "experimental.quota-groups", true)
 	tr.Commit()
 
 	// setup test-snap

--- a/overlord/servicestate/quota_handlers_test.go
+++ b/overlord/servicestate/quota_handlers_test.go
@@ -32,7 +32,6 @@ import (
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget/quantity"
-	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/servicestate"
 	"github.com/snapcore/snapd/overlord/servicestate/servicestatetest"
 	"github.com/snapcore/snapd/overlord/snapstate"
@@ -57,12 +56,8 @@ func (s *quotaHandlersSuite) SetUpTest(c *C) {
 	// we don't need the EnsureSnapServices ensure loop to run by default
 	servicestate.MockEnsuredSnapServices(s.mgr, true)
 
-	// we enable quota-groups by default
 	s.state.Lock()
 	defer s.state.Unlock()
-	tr := config.NewTransaction(s.state)
-	tr.Set("core", "experimental.quota-groups", true)
-	tr.Commit()
 
 	// mock that we have a new enough version of systemd by default
 	systemdRestore := systemd.MockSystemdVersion(248, nil)

--- a/tests/core/mem-cgroup-disabled/task.yaml
+++ b/tests/core/mem-cgroup-disabled/task.yaml
@@ -53,9 +53,6 @@ execute: |
       # install a snap with a service
       "$TESTSTOOLS"/snaps-state install-local test-snapd-simple-service
 
-      # enable quota groups
-      snap set system experimental.quota-groups=true
-
       # put it in a quota group
       snap set-quota grp --memory=100MB test-snapd-simple-service
 

--- a/tests/main/postrm-purge/task.yaml
+++ b/tests/main/postrm-purge/task.yaml
@@ -9,7 +9,6 @@ prepare: |
     # and snapd won't be around to respond, much less remove any state since
     # the state should be removed by the test
     snap set system experimental.user-daemons=true
-    snap set system experimental.quota-groups=true
 
     echo "When some snaps are installed"
     # Install a number of snaps that contain various features that have

--- a/tests/main/quota-groups-systemd-accounting/task.yaml
+++ b/tests/main/quota-groups-systemd-accounting/task.yaml
@@ -24,8 +24,6 @@ systems:
 
 prepare: |
   snap install hello-world go-example-webserver remarshal jq
-  snap set system experimental.quota-groups=true
-  tests.cleanup defer snap unset system experimental.quota-groups
 
 execute: |
   # the bug mainly happens when we create a quota group with nothing in it,

--- a/tests/main/snap-mgmt/task.yaml
+++ b/tests/main/snap-mgmt/task.yaml
@@ -13,7 +13,6 @@ prepare: |
     # and snapd won't be around to respond, much less remove any state since
     # the state should be removed by the test
     snap set system experimental.user-daemons=true
-    snap set system experimental.quota-groups=true
 
     # Install a number of snaps that contain various features that have
     # representation in the file system.

--- a/tests/main/snap-quota-cpu/task.yaml
+++ b/tests/main/snap-quota-cpu/task.yaml
@@ -16,8 +16,6 @@ systems:
 prepare: |
   snap install test-snapd-stressd --edge --devmode
   tests.cleanup defer snap remove --purge test-snapd-stressd
-  snap set system experimental.quota-groups=true
-  tests.cleanup defer snap unset system experimental.quota-groups
 
 restore: |
   echo "Stopping the service"

--- a/tests/main/snap-quota-install/task.yaml
+++ b/tests/main/snap-quota-install/task.yaml
@@ -5,8 +5,6 @@ details: |
 
 prepare: |
   snap pack "$TESTSLIB"/snaps/basic
-  snap set system experimental.quota-groups=true
-  tests.cleanup defer snap unset system experimental.quota-groups
 
 execute: |
   if os.query is-trusty || os.query is-amazon-linux || os.query is-centos 7 || os.query is-xenial || os.query is-core16; then

--- a/tests/main/snap-quota-memory/task.yaml
+++ b/tests/main/snap-quota-memory/task.yaml
@@ -21,8 +21,6 @@ systems:
 prepare: |
   snap install go-example-webserver jq remarshal hello-world
   snap install test-snapd-curl --edge --devmode
-  snap set system experimental.quota-groups=true
-  tests.cleanup defer snap unset system experimental.quota-groups
 
 execute: |
   echo "Create a group with a snap in it"

--- a/tests/main/snap-quota-thread/task.yaml
+++ b/tests/main/snap-quota-thread/task.yaml
@@ -18,8 +18,6 @@ systems:
 prepare: |
   snap install test-snapd-stressd --edge --devmode
   snap install test-snapd-curl --edge --devmode
-  snap set system experimental.quota-groups=true
-  tests.cleanup defer snap unset system experimental.quota-groups
 
 restore: |
   echo "Stop the service"

--- a/tests/main/snap-quota/task.yaml
+++ b/tests/main/snap-quota/task.yaml
@@ -9,8 +9,6 @@ systems: [ -ubuntu-core-*-arm-* ]
 
 prepare: |
   snap install hello-world go-example-webserver test-snapd-tools
-  snap set system experimental.quota-groups=true
-  tests.cleanup defer snap unset system experimental.quota-groups
 
 execute: |
   if os.query is-trusty || os.query is-amazon-linux || os.query is-centos 7 || os.query is-xenial || os.query is-core16; then


### PR DESCRIPTION
Also repurpose quota-groups experimental feature instead of introducing a new feature flag.

This is a different approach that I think would be better, and also avoids introducing a new feature flag. This PR superseeds https://github.com/snapcore/snapd/pull/11991