### PR TITLE
cmd/snap: improved robustness of unit test TestDesktopIntegrationNoDBus

### DIFF
--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -2081,6 +2081,10 @@ func (s *RunSuite) TestDesktopIntegrationNoDBus(c *check.C) {
 	_, r := logger.MockLogger()
 	defer r()
 
+	noDBus := func() (*dbus.Conn, error) { return nil, fmt.Errorf("dbus not available") }
+	restore := dbusutil.MockConnections(noDBus, noDBus)
+	defer restore()
+
 	sent, err := snaprun.TryNotifyRefreshViaSnapDesktopIntegrationFlow("Test")
 	c.Assert(sent, check.Equals, false)
 	c.Assert(err, check.IsNil)


### PR DESCRIPTION
**Problem:**
When running `run-checks --unit` with snap `snapd-desktop-integration` installed in devmode, the unit test `RunSuite. TestDesktopIntegrationNoDBus` fails. This is because there is no mocking and a DBus message is successfully send which is not expected.

**Solution:**
Added DBus mocking.