### PR TITLE
snapstate: fix update boot revisions for classic+modes devices

### DIFF
--- a/overlord/snapstate/booted.go
+++ b/overlord/snapstate/booted.go
@@ -56,11 +56,14 @@ func UpdateBootRevisions(st *state.State) error {
 
 	var tsAll []*state.TaskSet
 	for _, typ := range []snap.Type{snap.TypeKernel, snap.TypeBase} {
+		if !boot.SnapTypeParticipatesInBoot(typ, deviceCtx) {
+			continue
+		}
+
 		actual, err := boot.GetCurrentBoot(typ, deviceCtx)
 		if err != nil {
 			return fmt.Errorf(errorPrefix+"%s", err)
 		}
-
 		info, err := CurrentInfo(st, actual.SnapName())
 		if err != nil {
 			logger.Noticef("cannot get info for %q: %s", actual.SnapName(), err)

--- a/overlord/snapstate/booted.go
+++ b/overlord/snapstate/booted.go
@@ -54,17 +54,13 @@ func UpdateBootRevisions(st *state.State) error {
 		return err
 	}
 
-	kernel, err := boot.GetCurrentBoot(snap.TypeKernel, deviceCtx)
-	if err != nil {
-		return fmt.Errorf(errorPrefix+"%s", err)
-	}
-	base, err := boot.GetCurrentBoot(snap.TypeBase, deviceCtx)
-	if err != nil {
-		return fmt.Errorf(errorPrefix+"%s", err)
-	}
-
 	var tsAll []*state.TaskSet
-	for _, actual := range []snap.PlaceInfo{kernel, base} {
+	for _, typ := range []snap.Type{snap.TypeKernel, snap.TypeBase} {
+		actual, err := boot.GetCurrentBoot(typ, deviceCtx)
+		if err != nil {
+			return fmt.Errorf(errorPrefix+"%s", err)
+		}
+
 		info, err := CurrentInfo(st, actual.SnapName())
 		if err != nil {
 			logger.Noticef("cannot get info for %q: %s", actual.SnapName(), err)

--- a/tests/nested/manual/fde-on-classic/task.yaml
+++ b/tests/nested/manual/fde-on-classic/task.yaml
@@ -111,4 +111,25 @@ execute: |
       remote.exec sudo grep -q -a '"This program cannot be run in XXX mode"' "$f"
   done
 
+  # Test that installing a different base and a reboot cause no reverts
+  # (regression test for SNAPDENG-4975)
+
+  # precondition, the core22 is not a local version
+  remote.exec snap list core22 | NOMATCH " x1 "
+  # create modified core22
+  unsquashfs -d core22 "$CACHE_D"/core22_*.snap
+  touch core22/empty-file
+  snap pack --filename=core22-new.snap core22
+  remote.push "core22-new.snap"
+  # install and validate its now a local version
+  remote.exec sudo snap install --dangerous "core22-new.snap"
+  remote.exec sudo snap list core22 | MATCH " x1 "
+  # wait for reboot
+  boot_id=$(tests.nested boot-id)
+  remote.exec sudo reboot || true
+  tests.nested wait-for reboot "$boot_id"
+  # ensure that no revert of core22 happened after the reboot
+  remote.exec sudo snap changes | NOMATCH "Update kernel and core snap revisions"
+  remote.exec sudo snap list core22 | MATCH " x1 "
+
   rm -rf "$CACHE_D"


### PR DESCRIPTION
The existing `UpdateBootRevisions()` does not take into account that not all systems use the base as a boot participant. On a classic+modes system only the kernel is relevant. This PR updates this code to skip non-boot participants when checking if there were rollbacks across reboots.