### PR TITLE
o/configstate/configcore: do not invoke apparmor_parser when unsupported

### DIFF
--- a/overlord/configstate/configcore/homedirs.go
+++ b/overlord/configstate/configcore/homedirs.go
@@ -74,7 +74,7 @@ func init() {
 	supportedConfigurations["core.homedirs"] = true
 }
 
-func configureAppArmorAndReload(homedirs []string, opts *fsOnlyContext) error {
+func configureHomedirsInAppArmorAndReload(homedirs []string, opts *fsOnlyContext) error {
 	// important to note here that when a configure hook is invoked, handlers are invoked,
 	// so they are not *just* invoked by user-interaction, and we do not want to break those
 	// actions. So no-op on systems that do not support apparmor.
@@ -126,7 +126,7 @@ func updateHomedirsConfig(config string, opts *fsOnlyContext) error {
 	if len(config) > 0 {
 		homedirs = strings.Split(config, ",")
 	}
-	return configureAppArmorAndReload(homedirs, opts)
+	return configureHomedirsInAppArmorAndReload(homedirs, opts)
 }
 
 func handleHomedirsConfiguration(_ sysconfig.Device, tr ConfGetter, opts *fsOnlyContext) error {

--- a/overlord/configstate/configcore/homedirs.go
+++ b/overlord/configstate/configcore/homedirs.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/sandbox/apparmor"
 	"github.com/snapcore/snapd/sysconfig"
 )
@@ -129,12 +130,19 @@ func updateHomedirsConfig(config string, opts *fsOnlyContext) error {
 }
 
 func handleHomedirsConfiguration(_ sysconfig.Device, tr ConfGetter, opts *fsOnlyContext) error {
-	config, err := coreCfg(tr, "homedirs")
+	conf, err := coreCfg(tr, "homedirs")
 	if err != nil {
 		return err
 	}
+	var prevConfig string
+	if err := tr.GetPristine("core", "homedirs", &prevConfig); err != nil && !config.IsNoOption(err) {
+		return err
+	}
+	if conf == prevConfig {
+		return nil
+	}
 
-	if err := updateHomedirsConfig(config, opts); err != nil {
+	if err := updateHomedirsConfig(conf, opts); err != nil {
 		return err
 	}
 

--- a/overlord/configstate/configcore/homedirs_test.go
+++ b/overlord/configstate/configcore/homedirs_test.go
@@ -200,12 +200,12 @@ func (s *homedirsSuite) TestConfigureApparmorReloadFailure(c *C) {
 
 func (s *homedirsSuite) TestConfigureApparmorUnsupported(c *C) {
 	// Currently the homedir option will act more or less as a no-op on
-	// systems that do not have apparmor support. Thus lets test that
+	// systems that do not have apparmor support. So let's test that
 	// both unsupported and unusable will return no error, as it should be
 	// a no-op.
 
-	// let's mock this to ensure we do get an error should the function
-	// *not* act as a no-op
+	// let's mock this to ensure we can track whether this was called, as we don't
+	// want this called when unsupported.
 	var reloadProfilesCalled bool
 	restore := configcore.MockApparmorReloadAllSnapProfiles(func() error {
 		reloadProfilesCalled = true

--- a/overlord/configstate/configcore/homedirs_test.go
+++ b/overlord/configstate/configcore/homedirs_test.go
@@ -95,7 +95,7 @@ func (s *homedirsSuite) TestValidationUnhappy(c *C) {
 	} {
 		err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 			state: s.state,
-			conf: map[string]interface{}{
+			changes: map[string]interface{}{
 				"homedirs": testData.homedirs,
 			},
 		})
@@ -110,7 +110,7 @@ func (s *homedirsSuite) TestConfigureWriteFailure(c *C) {
 	defer restore()
 	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		changes: map[string]interface{}{
 			"homedirs": "/home/existingDir",
 		},
 	})
@@ -138,7 +138,28 @@ func (s *homedirsSuite) TestConfigureUnchanged(c *C) {
 
 	err = configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
+		changes: map[string]interface{}{
+			"homedirs": "/home/existingDir",
+		},
+	})
+	c.Assert(err, IsNil)
+	c.Check(tunableUpdated, Equals, false)
+}
+
+func (s *homedirsSuite) TestConfigureUnchangedConfig(c *C) {
+	tunableUpdated := false
+	restore := configcore.MockApparmorUpdateHomedirsTunable(func(paths []string) error {
+		tunableUpdated = true
+		return nil
+	})
+	defer restore()
+
+	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
+		state: s.state,
 		conf: map[string]interface{}{
+			"homedirs": "/home/existingDir",
+		},
+		changes: map[string]interface{}{
 			"homedirs": "/home/existingDir",
 		},
 	})
@@ -155,7 +176,7 @@ func (s *homedirsSuite) TestConfigureApparmorTunableFailure(c *C) {
 	defer restore()
 	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		changes: map[string]interface{}{
 			"homedirs": "/home/existingDir/one,/home/existingDir/two",
 		},
 	})
@@ -170,7 +191,7 @@ func (s *homedirsSuite) TestConfigureApparmorReloadFailure(c *C) {
 	defer restore()
 	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		changes: map[string]interface{}{
 			"homedirs": "/home/existingDir",
 		},
 	})
@@ -210,7 +231,7 @@ func (s *homedirsSuite) TestConfigureApparmorUnsupported(c *C) {
 
 		err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 			state: s.state,
-			conf: map[string]interface{}{
+			changes: map[string]interface{}{
 				"homedirs": "/home/existingDir",
 			},
 		})
@@ -240,7 +261,7 @@ func (s *homedirsSuite) TestConfigureHomedirsHappy(c *C) {
 
 	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
-		conf: map[string]interface{}{
+		changes: map[string]interface{}{
 			"homedirs": "/home/existingDir",
 		},
 	})

--- a/tests/main/snapd-homedirs/task.yaml
+++ b/tests/main/snapd-homedirs/task.yaml
@@ -2,6 +2,9 @@ summary: Test support for non-standard home directory paths
 
 systems:
     - -ubuntu-core-*  # Home dirs cannot be changed
+    - -centos-*       # No AppArmor support
+    - -fedora-*       # No AppArmor support
+    - -amazon-linux-* # No AppArmor support
 
 environment:
     USERNAME: home-sweet-home


### PR DESCRIPTION
Only invoke apparmor parser and reload profiles if apparmor is actually supported on the host, otherwise homedirs will act as a no-op to not break configure-hooks. Also only update apparmor rules if the homedirs actually change.


This is related to LP2002835.
