### PR TITLE
store: fix cache miss when snap was already in download path

### DIFF
--- a/store/cache.go
+++ b/store/cache.go
@@ -103,8 +103,8 @@ func (cm *CacheManager) GetPath(cacheKey string) string {
 
 // Get gets the given cacheKey content and puts it into targetPath
 func (cm *CacheManager) Get(cacheKey, targetPath string) bool {
-	if err := os.Link(cm.path(cacheKey), targetPath); err != nil {
-		return errors.Is(err, os.ErrExist)
+	if err := os.Link(cm.path(cacheKey), targetPath); err != nil && !errors.Is(err, os.ErrExist) {
+		return false
 	}
 
 	logger.Debugf("using cache for %s", targetPath)

--- a/store/cache.go
+++ b/store/cache.go
@@ -38,7 +38,7 @@ var osRemove = os.Remove
 
 // downloadCache is the interface that a store download cache must provide
 type downloadCache interface {
-	// Get gets the given cacheKey content and puts it into targetPath. Returns
+	// Get retrieves the given cacheKey content and puts it into targetPath. Returns
 	// true if a cached file was moved to targetPath or if one was already there.
 	Get(cacheKey, targetPath string) bool
 	// Put adds a new file to the cache
@@ -101,7 +101,8 @@ func (cm *CacheManager) GetPath(cacheKey string) string {
 	return cm.path(cacheKey)
 }
 
-// Get gets the given cacheKey content and puts it into targetPath
+// Get retrieves the given cacheKey content and puts it into targetPath. Returns
+// true if a cached file was moved to targetPath or if one was already there.
 func (cm *CacheManager) Get(cacheKey, targetPath string) bool {
 	if err := os.Link(cm.path(cacheKey), targetPath); err != nil && !errors.Is(err, os.ErrExist) {
 		return false
@@ -109,7 +110,9 @@ func (cm *CacheManager) Get(cacheKey, targetPath string) bool {
 
 	logger.Debugf("using cache for %s", targetPath)
 	now := time.Now()
-	return os.Chtimes(targetPath, now, now) == nil
+	// the modification time is updated on a best-effort basis
+	_ = os.Chtimes(targetPath, now, now)
+	return true
 }
 
 // Put adds a new file to the cache with the given cacheKey

--- a/store/cache_test.go
+++ b/store/cache_test.go
@@ -132,7 +132,7 @@ func (s *cacheSuite) makeTestFiles(c *C, n int) (cacheKeys []string, testFiles [
 	return cacheKeys, testFiles
 }
 
-func (s *cacheSuite) TestClenaup(c *C) {
+func (s *cacheSuite) TestCleanup(c *C) {
 	cacheKeys, testFiles := s.makeTestFiles(c, s.maxItems+2)
 
 	// Nothing was removed at this point because the test files are

--- a/store/store_download.go
+++ b/store/store_download.go
@@ -196,7 +196,7 @@ func (s *Store) Download(ctx context.Context, name string, targetPath string, do
 		return err
 	}
 
-	if err := s.cacher.Get(downloadInfo.Sha3_384, targetPath); err == nil || errors.Is(err, os.ErrExist) {
+	if s.cacher.Get(downloadInfo.Sha3_384, targetPath) {
 		logger.Debugf("Cache hit for SHA3_384 …%.5s.", downloadInfo.Sha3_384)
 		return nil
 	}

--- a/store/store_download.go
+++ b/store/store_download.go
@@ -196,7 +196,7 @@ func (s *Store) Download(ctx context.Context, name string, targetPath string, do
 		return err
 	}
 
-	if err := s.cacher.Get(downloadInfo.Sha3_384, targetPath); err == nil {
+	if err := s.cacher.Get(downloadInfo.Sha3_384, targetPath); err == nil || errors.Is(err, os.ErrExist) {
 		logger.Debugf("Cache hit for SHA3_384 …%.5s.", downloadInfo.Sha3_384)
 		return nil
 	}

--- a/store/store_download_test.go
+++ b/store/store_download_test.go
@@ -697,18 +697,27 @@ type cacheObserver struct {
 
 	gets []string
 	puts []string
+
+	getErr error
 }
 
 func (co *cacheObserver) Get(cacheKey, targetPath string) error {
 	co.gets = append(co.gets, fmt.Sprintf("%s:%s", cacheKey, targetPath))
+
+	if co.getErr != nil {
+		return co.getErr
+	}
+
 	if !co.inCache[cacheKey] {
 		return fmt.Errorf("cannot find %s in cache", cacheKey)
 	}
 	return nil
 }
+
 func (co *cacheObserver) GetPath(cacheKey string) string {
 	return ""
 }
+
 func (co *cacheObserver) Put(cacheKey, sourcePath string) error {
 	co.puts = append(co.puts, fmt.Sprintf("%s:%s", cacheKey, sourcePath))
 	return nil
@@ -758,6 +767,31 @@ func (s *storeDownloadSuite) TestDownloadCacheMiss(c *C) {
 
 	c.Check(obs.gets, DeepEquals, []string{fmt.Sprintf("the-snaps-sha3_384:%s", path)})
 	c.Check(obs.puts, DeepEquals, []string{fmt.Sprintf("the-snaps-sha3_384:%s", path)})
+}
+
+func (s *storeDownloadSuite) TestDownloadCacheHitIfAlreadyThere(c *C) {
+	obs := &cacheObserver{inCache: map[string]bool{}, getErr: os.ErrExist}
+	restore := s.store.MockCacher(obs)
+	defer restore()
+
+	restore = store.MockDownload(func(ctx context.Context, name, sha3, url string, user *auth.UserState, s *store.Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter, dlOpts *store.DownloadOptions) error {
+		c.Fatal("unexpected download call (cache miss)")
+		return nil
+	})
+	defer restore()
+
+	snap := &snap.Info{
+		DownloadInfo: snap.DownloadInfo{
+			Sha3_384: "the-snaps-sha3_384",
+		},
+	}
+	path := filepath.Join(c.MkDir(), "downloaded-file")
+
+	err := s.store.Download(s.ctx, "foo", path, &snap.DownloadInfo, nil, nil, nil)
+	c.Assert(err, IsNil)
+
+	c.Check(obs.gets, DeepEquals, []string{fmt.Sprintf("the-snaps-sha3_384:%s", path)})
+	c.Check(obs.puts, HasLen, 0)
 }
 
 func (s *storeDownloadSuite) TestDownloadStreamOK(c *C) {


### PR DESCRIPTION
If a snap was already in the target path, the cache would try to link the cached file to that path, fail and return an os.ErrExist. Since the store code was interpreting any error from the cache as a cache miss, it would re-download it. In practice this didn't happen often because when installing/refreshing a snap the file is eventually deleted from that location so subsequent downloads wouldn't hit the issue unless the install/refresh is aborted. However, when we start pre-downloading snaps we would start hitting this in every delayed auto-refresh (that's how I noticed it).

