### PR TITLE
cmd/snap: improved robustness of unit tests TestWaitWhileInhibitedGraphicalSession*

### DIFF
--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -1899,6 +1899,11 @@ func (s *RunSuite) TestWaitWhileInhibitedGraphicalSessionFlow(c *check.C) {
 	restoreIsGraphicalSession := snaprun.MockIsGraphicalSession(true)
 	defer restoreIsGraphicalSession()
 
+	restoreTryNotifyRefresh := snaprun.MockTryNotifyRefreshViaSnapDesktopIntegrationFlow(func(snapName string) (bool, error) {
+		return false, nil
+	})
+	defer restoreTryNotifyRefresh()
+
 	var notification *usersessionclient.PendingSnapRefreshInfo
 	restorePendingRefreshNotification := snaprun.MockPendingRefreshNotification(func(refreshInfo *usersessionclient.PendingSnapRefreshInfo) error {
 		notification = refreshInfo
@@ -1944,6 +1949,11 @@ func (s *RunSuite) TestWaitWhileInhibitedGraphicalSessionFlowError(c *check.C) {
 	restoreIsGraphicalSession := snaprun.MockIsGraphicalSession(true)
 	defer restoreIsGraphicalSession()
 
+	restoreTryNotifyRefresh := snaprun.MockTryNotifyRefreshViaSnapDesktopIntegrationFlow(func(snapName string) (bool, error) {
+		return false, nil
+	})
+	defer restoreTryNotifyRefresh()
+
 	restorePendingRefreshNotification := snaprun.MockPendingRefreshNotification(func(refreshInfo *usersessionclient.PendingSnapRefreshInfo) error {
 		return fmt.Errorf("boom")
 	})
@@ -1964,6 +1974,11 @@ func (s *RunSuite) TestWaitWhileInhibitedGraphicalSessionFlowErrorOnFinish(c *ch
 
 	restoreIsGraphicalSession := snaprun.MockIsGraphicalSession(true)
 	defer restoreIsGraphicalSession()
+
+	restoreTryNotifyRefresh := snaprun.MockTryNotifyRefreshViaSnapDesktopIntegrationFlow(func(snapName string) (bool, error) {
+		return false, nil
+	})
+	defer restoreTryNotifyRefresh()
 
 	restorePendingRefreshNotification := snaprun.MockPendingRefreshNotification(func(refreshInfo *usersessionclient.PendingSnapRefreshInfo) error {
 		return nil

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -461,6 +461,14 @@ func MockFinishRefreshNotification(f func(refreshInfo *usersessionclient.Finishe
 	}
 }
 
+func MockTryNotifyRefreshViaSnapDesktopIntegrationFlow(f func(snapName string) (bool, error)) (restore func()) {
+	old := tryNotifyRefreshViaSnapDesktopIntegrationFlow
+	tryNotifyRefreshViaSnapDesktopIntegrationFlow = f
+	return func() {
+		tryNotifyRefreshViaSnapDesktopIntegrationFlow = old
+	}
+}
+
 func MockAutostartSessionApps(f func(string) error) func() {
 	old := autostartSessionApps
 	autostartSessionApps = f

--- a/cmd/snap/inhibit.go
+++ b/cmd/snap/inhibit.go
@@ -99,7 +99,7 @@ var finishRefreshNotification = func(refreshInfo *client.FinishedSnapRefreshInfo
 	return nil
 }
 
-func tryNotifyRefreshViaSnapDesktopIntegrationFlow(snapName string) (bool, error) {
+var tryNotifyRefreshViaSnapDesktopIntegrationFlow = func(snapName string) (bool, error) {
 	// Check if Snapd-Desktop-Integration is available
 	conn, err := dbusutil.SessionBus()
 	if err != nil {


### PR DESCRIPTION
**Problem:**
When running `run-checks --unit` with snap `snapd-desktop-integration installed` in `devmode`, the unit tests `TestWaitWhileInhibitedGraphicalSessionFlow`, `TestWaitWhileInhibitedGraphicalSessionFlowError`, `TestWaitWhileInhibitedGraphicalSessionFlowErrorOnFinish` fails and or timeout.

The underlying issue in all three test is that the target function `graphicalSessionFlow` does not get called due to the presence of DBus and `snapd-desktop-integration` affecting the return values from function `tryNotifyRefreshViaSnapDesktopIntegrationFlow` in an unexpected way. Also, when inhibit state is not unlocked with a mock, `tryNotifyRefreshViaSnapDesktopIntegrationFlow` is stuck in `waitInhibitUnlock` loop until timeout (the case with test `TestWaitWhileInhibitedGraphicalSessionFlowError`).

**Solution:**
Enabled mocking of `tryNotifyRefreshViaSnapDesktopIntegrationFlow` to predictably exercise `graphicalSessionFlow` as intended.