### PR TITLE
boot: do not include `base=` in modeenv for classic+modes installs

### DIFF
--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -397,7 +397,6 @@ func makeRunnableSystem(model *asserts.Model, bootWith *BootableSet, sealer *Tru
 		// installed
 		CurrentKernelCommandLines: nil,
 		// keep this comment to make gofmt 1.9 happy
-		Base:           bootWith.Base.Filename(),
 		Gadget:         bootWith.Gadget.Filename(),
 		CurrentKernels: []string{bootWith.Kernel.Filename()},
 		BrandID:        model.BrandID(),
@@ -406,6 +405,12 @@ func makeRunnableSystem(model *asserts.Model, bootWith *BootableSet, sealer *Tru
 		Classic:        model.Classic(),
 		Grade:          string(model.Grade()),
 		ModelSignKeyID: model.SignKeyID(),
+	}
+	// XXX: ideally this would use boot.Participant() but that
+	//  requires quite a bit of refactor because we need to pass a
+	//  snap.Device instead of a model here
+	if !model.Classic() {
+		modeenv.Base = bootWith.Base.Filename()
 	}
 
 	// get the ubuntu-boot bootloader and extract the kernel there

--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -406,9 +406,8 @@ func makeRunnableSystem(model *asserts.Model, bootWith *BootableSet, sealer *Tru
 		Grade:          string(model.Grade()),
 		ModelSignKeyID: model.SignKeyID(),
 	}
-	// XXX: ideally this would use boot.Participant() but that
-	//  requires quite a bit of refactor because we need to pass a
-	//  snap.Device instead of a model here
+	// Note on classic systems there is no boot base, the system boots
+	// from debs.
 	if !model.Classic() {
 		modeenv.Base = bootWith.Base.Filename()
 	}

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -798,18 +798,19 @@ version: 5.0
 	c.Check(extractedKernelSymlink, testutil.FilePresent)
 
 	// ensure modeenv looks correct
-	var ubuntuDataModeEnvPath, classicLine string
+	var ubuntuDataModeEnvPath, classicLine, base string
 	if classic {
+		base = ""
 		ubuntuDataModeEnvPath = filepath.Join(s.rootdir, "/run/mnt/ubuntu-data/var/lib/snapd/modeenv")
 		classicLine = "\nclassic=true"
 	} else {
+		base = "\nbase=core20_3.snap"
 		ubuntuDataModeEnvPath = filepath.Join(s.rootdir, "/run/mnt/ubuntu-data/system-data/var/lib/snapd/modeenv")
 	}
 	expectedModeenv := fmt.Sprintf(`mode=run
 recovery_system=20191216
 current_recovery_systems=20191216
-good_recovery_systems=20191216
-base=core20_3.snap
+good_recovery_systems=20191216%s
 gadget=pc_4.snap
 current_kernels=pc-kernel_5.snap
 model=my-brand/my-model-uc20%s
@@ -818,7 +819,7 @@ model_sign_key_id=Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQu
 current_trusted_boot_assets={"grubx64.efi":["5ee042c15e104b825d6bc15c41cdb026589f1ec57ed966dd3f29f961d4d6924efc54b187743fa3a583b62722882d405d"]}
 current_trusted_recovery_boot_assets={"bootx64.efi":["39efae6545f16e39633fbfbef0d5e9fdd45a25d7df8764978ce4d81f255b038046a38d9855e42e5c7c4024e153fd2e37"],"grubx64.efi":["aa3c1a83e74bf6dd40dd64e5c5bd1971d75cdf55515b23b9eb379f66bf43d4661d22c4b8cf7d7a982d2013ab65c1c4c5"]}
 current_kernel_command_lines=["snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1"]
-`, classicLine)
+`, base, classicLine)
 	c.Check(ubuntuDataModeEnvPath, testutil.FileEquals, expectedModeenv)
 	copiedGrubBin := filepath.Join(
 		dirs.SnapBootAssetsDirUnder(installHostWritableDir),


### PR DESCRIPTION
This is a followup for the PR#12532. Right now the system does put the `base` into the modeenv on `classic+modes` system. But here there is no need to keep track of the base as it is not used for booting, the deb based classic system is used for that.
