### PR TITLE
many: replace IsNotFound usages for errors.Is(err, &NotFoundError{})

### DIFF
--- a/asserts/account_key.go
+++ b/asserts/account_key.go
@@ -20,6 +20,7 @@
 package asserts
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"time"
@@ -150,7 +151,7 @@ func (ak *AccountKey) checkConsistency(db RODatabase, acck *AccountKey) error {
 	_, err := db.Find(AccountType, map[string]string{
 		"account-id": ak.AccountID(),
 	})
-	if IsNotFound(err) {
+	if errors.Is(err, &NotFoundError{}) {
 		return fmt.Errorf("account-key assertion for %q does not have a matching account assertion", ak.AccountID())
 	}
 	if err != nil {
@@ -167,7 +168,7 @@ func (ak *AccountKey) checkConsistency(db RODatabase, acck *AccountKey) error {
 			"account-id": ak.AccountID(),
 			"name":       ak.Name(),
 		})
-		if err != nil && !IsNotFound(err) {
+		if err != nil && !errors.Is(err, &NotFoundError{}) {
 			return err
 		}
 		for _, assertion := range assertions {
@@ -265,7 +266,7 @@ func (akr *AccountKeyRequest) checkConsistency(db RODatabase, acck *AccountKey) 
 	_, err := db.Find(AccountType, map[string]string{
 		"account-id": akr.AccountID(),
 	})
-	if IsNotFound(err) {
+	if errors.Is(err, &NotFoundError{}) {
 		return fmt.Errorf("account-key-request assertion for %q does not have a matching account assertion", akr.AccountID())
 	}
 	if err != nil {

--- a/asserts/assertstest/assertstest.go
+++ b/asserts/assertstest/assertstest.go
@@ -25,6 +25,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"os/exec"
@@ -417,7 +418,7 @@ func (ss *StoreStack) StoreAccountKey(keyID string) *asserts.AccountKey {
 		"account-id":          ss.AuthorityID,
 		"public-key-sha3-384": keyID,
 	})
-	if asserts.IsNotFound(err) {
+	if errors.Is(err, &asserts.NotFoundError{}) {
 		return nil
 	}
 	if err != nil {

--- a/asserts/batch.go
+++ b/asserts/batch.go
@@ -20,6 +20,7 @@
 package asserts
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -203,7 +204,7 @@ func (b *Batch) prereqSort(db *Database) error {
 	ordered := make([]Assertion, 0, len(b.added))
 	retrieve := func(ref *Ref) (Assertion, error) {
 		a, err := b.bs.Get(ref.Type, ref.PrimaryKey, ref.Type.MaxSupportedFormat())
-		if IsNotFound(err) {
+		if errors.Is(err, &NotFoundError{}) {
 			// fallback to pre-existing assertions
 			a, err = ref.Resolve(db.Find)
 		}
@@ -230,7 +231,7 @@ func (b *Batch) prereqSort(db *Database) error {
 }
 
 func resolveError(format string, ref *Ref, err error) error {
-	if IsNotFound(err) {
+	if errors.Is(err, &NotFoundError{}) {
 		return fmt.Errorf(format, ref)
 	} else {
 		return fmt.Errorf(format+": %v", ref, err)

--- a/asserts/batch_test.go
+++ b/asserts/batch_test.go
@@ -21,6 +21,7 @@ package asserts_test
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"time"
 
@@ -407,7 +408,7 @@ func (s *batchSuite) TestPrecheckPartial(c *C) {
 		"series":  "16",
 		"snap-id": "foo-id",
 	})
-	c.Assert(asserts.IsNotFound(err), Equals, true)
+	c.Assert(errors.Is(err, &asserts.NotFoundError{}), Equals, true)
 }
 
 func (s *batchSuite) TestPrecheckHappy(c *C) {
@@ -449,7 +450,7 @@ func (s *batchSuite) TestPrecheckHappy(c *C) {
 		"series":  "16",
 		"snap-id": "foo-id",
 	})
-	c.Assert(asserts.IsNotFound(err), Equals, true)
+	c.Assert(errors.Is(err, &asserts.NotFoundError{}), Equals, true)
 
 	// commit (with precheck)
 	err = batch.CommitTo(s.db, &asserts.CommitOptions{Precheck: true})
@@ -503,7 +504,7 @@ func (s *batchSuite) TestFetch(c *C) {
 		"series":  "16",
 		"snap-id": "foo-id",
 	})
-	c.Assert(asserts.IsNotFound(err), Equals, true)
+	c.Assert(errors.Is(err, &asserts.NotFoundError{}), Equals, true)
 
 	// commit
 	err = batch.CommitTo(s.db, nil)

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -45,7 +45,8 @@ func (e *NotFoundError) Error() string {
 }
 
 func (e *NotFoundError) Is(err error) bool {
-	return errors.Is(err, &NotFoundError{})
+	_, ok := err.(*NotFoundError)
+	return ok
 }
 
 // A Backstore stores assertions. It can store and retrieve assertions

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -777,13 +777,13 @@ func (safs *signAddFindSuite) TestNotFoundError(c *C) {
 			"snap-id": "snap-id",
 		},
 	}
-	c.Check(asserts.IsNotFound(err1), Equals, true)
+	c.Check(errors.Is(err1, &asserts.NotFoundError{}), Equals, true)
 	c.Check(err1.Error(), Equals, "snap-declaration (snap-id; series:16) not found")
 
 	err2 := &asserts.NotFoundError{
 		Type: asserts.SnapRevisionType,
 	}
-	c.Check(asserts.IsNotFound(err1), Equals, true)
+	c.Check(errors.Is(err2, &asserts.NotFoundError{}), Equals, true)
 	c.Check(err2.Error(), Equals, "snap-revision assertion not found")
 }
 
@@ -995,7 +995,7 @@ func (safs *signAddFindSuite) TestFindTrusted(c *C) {
 	_, err = safs.db.FindTrusted(asserts.AccountType, map[string]string{
 		"account-id": "predefined",
 	})
-	c.Check(asserts.IsNotFound(err), Equals, true)
+	c.Check(errors.Is(err, &asserts.NotFoundError{}), Equals, true)
 }
 
 func (safs *signAddFindSuite) TestFindPredefined(c *C) {
@@ -1148,7 +1148,7 @@ func (safs *signAddFindSuite) TestFindManyPredefined(c *C) {
 		"account-id":          acct1.AccountID(),
 		"public-key-sha3-384": acct1Key.PublicKeyID(),
 	})
-	c.Check(asserts.IsNotFound(err), Equals, true)
+	c.Check(errors.Is(err, &asserts.NotFoundError{}), Equals, true)
 }
 
 func (safs *signAddFindSuite) TestDontLetAddConfusinglyAssertionClashingWithTrustedOnes(c *C) {
@@ -1403,7 +1403,7 @@ func (safs *signAddFindSuite) TestWithStackedBackstore(c *C) {
 	_, err = safs.db.Find(asserts.TestOnlyType, map[string]string{
 		"primary-key": "two",
 	})
-	c.Check(asserts.IsNotFound(err), Equals, true)
+	c.Check(errors.Is(err, &asserts.NotFoundError{}), Equals, true)
 
 	_, err = stacked.Find(asserts.AccountKeyType, map[string]string{
 		"public-key-sha3-384": safs.signingKeyID,

--- a/asserts/fetcher.go
+++ b/asserts/fetcher.go
@@ -20,6 +20,7 @@
 package asserts
 
 import (
+	"errors"
 	"fmt"
 )
 
@@ -67,7 +68,7 @@ func (f *fetcher) chase(ref *Ref, a Assertion) error {
 	if err == nil {
 		return nil
 	}
-	if !IsNotFound(err) {
+	if !errors.Is(err, &NotFoundError{}) {
 		return err
 	}
 	u := ref.Unique()

--- a/asserts/pool.go
+++ b/asserts/pool.go
@@ -302,7 +302,7 @@ func (p *Pool) isPredefined(ref *Ref) (bool, error) {
 	if err == nil {
 		return true, nil
 	}
-	if !IsNotFound(err) {
+	if !errors.Is(err, &NotFoundError{}) {
 		return false, err
 	}
 	return false, nil
@@ -316,7 +316,7 @@ func (p *Pool) isResolved(ref *Ref) (bool, error) {
 	if err == nil {
 		return true, nil
 	}
-	if !IsNotFound(err) {
+	if !errors.Is(err, &NotFoundError{}) {
 		return false, err
 	}
 	return false, nil
@@ -324,7 +324,7 @@ func (p *Pool) isResolved(ref *Ref) (bool, error) {
 
 func (p *Pool) curRevision(ref *Ref) (int, error) {
 	a, err := ref.Resolve(p.groundDB.Find)
-	if err != nil && !IsNotFound(err) {
+	if err != nil && !errors.Is(err, &NotFoundError{}) {
 		return 0, err
 	}
 	if err == nil {
@@ -335,7 +335,7 @@ func (p *Pool) curRevision(ref *Ref) (int, error) {
 
 func (p *Pool) curSeqRevision(seq *AtSequence) (int, error) {
 	a, err := seq.Resolve(p.groundDB.Find)
-	if err != nil && !IsNotFound(err) {
+	if err != nil && !errors.Is(err, &NotFoundError{}) {
 		return 0, err
 	}
 	if err == nil {
@@ -957,7 +957,7 @@ func (p *Pool) CommitTo(db *Database) error {
 
 	retrieve := func(ref *Ref) (Assertion, error) {
 		a, err := p.bs.Get(ref.Type, ref.PrimaryKey, ref.Type.MaxSupportedFormat())
-		if IsNotFound(err) {
+		if errors.Is(err, &NotFoundError{}) {
 			// fallback to pre-existing assertions
 			a, err = ref.Resolve(db.Find)
 		}

--- a/asserts/pool_test.go
+++ b/asserts/pool_test.go
@@ -1096,7 +1096,7 @@ func (s *poolSuite) TestUpdateSeqFormingPinnedNewerSequenceSameRevisionNoop(c *C
 
 	// and sequence point 3 revision 5 wasn't added to asserts database.
 	_, err = s.seq3_1111r5.Ref().Resolve(s.db.Find)
-	c.Assert(asserts.IsNotFound(err), Equals, true)
+	c.Assert(errors.Is(err, &asserts.NotFoundError{}), Equals, true)
 }
 
 func (s *poolSuite) TestUpdateSeqFormingPinnedNewerSequenceNewerRevisionNoop(c *C) {
@@ -1147,7 +1147,7 @@ func (s *poolSuite) TestUpdateSeqFormingPinnedNewerSequenceNewerRevisionNoop(c *
 
 	// and sequence point 2 revision 7 wasn't added to asserts database.
 	_, err = s.seq2_1111r7.Ref().Resolve(s.db.Find)
-	c.Assert(asserts.IsNotFound(err), Equals, true)
+	c.Assert(errors.Is(err, &asserts.NotFoundError{}), Equals, true)
 }
 
 func (s *poolSuite) TestUpdateSeqFormingPinnedSameSequenceNewerRevision(c *C) {
@@ -1319,7 +1319,7 @@ func (s *poolSuite) TestAddSeqToUpdateNotFound(c *C) {
 		Sequence:    1,
 	}
 	err := pool.AddSequenceToUpdate(atseq, "for_one")
-	c.Assert(asserts.IsNotFound(err), Equals, true)
+	c.Assert(errors.Is(err, &asserts.NotFoundError{}), Equals, true)
 }
 
 var errBoom = errors.New("boom")

--- a/asserts/serial_asserts.go
+++ b/asserts/serial_asserts.go
@@ -20,6 +20,7 @@
 package asserts
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -69,10 +70,10 @@ func (ser *Serial) checkConsistency(db RODatabase, acck *AccountKey) error {
 			"brand-id": ser.BrandID(),
 			"model":    ser.Model(),
 		})
-		if err != nil && !IsNotFound(err) {
+		if err != nil && !errors.Is(err, &NotFoundError{}) {
 			return err
 		}
-		if IsNotFound(err) || !strutil.ListContains(a.(*Model).SerialAuthority(), ser.AuthorityID()) {
+		if errors.Is(err, &NotFoundError{}) || !strutil.ListContains(a.(*Model).SerialAuthority(), ser.AuthorityID()) {
 			return fmt.Errorf("serial with authority %q different from brand %q without model assertion with serial-authority set to to allow for them", ser.AuthorityID(), ser.BrandID())
 		}
 	}

--- a/asserts/snap_asserts.go
+++ b/asserts/snap_asserts.go
@@ -22,6 +22,7 @@ package asserts
 import (
 	"bytes"
 	"crypto"
+	"errors"
 	"fmt"
 	"time"
 
@@ -122,7 +123,7 @@ func (snapdcl *SnapDeclaration) checkConsistency(db RODatabase, acck *AccountKey
 	_, err := db.Find(AccountType, map[string]string{
 		"account-id": snapdcl.PublisherID(),
 	})
-	if IsNotFound(err) {
+	if errors.Is(err, &NotFoundError{}) {
 		return fmt.Errorf("snap-declaration assertion for %q (id %q) does not have a matching account assertion for the publisher %q", snapdcl.SnapName(), snapdcl.SnapID(), snapdcl.PublisherID())
 	}
 	if err != nil {
@@ -582,7 +583,7 @@ func (snaprev *SnapRevision) checkConsistency(db RODatabase, acck *AccountKey) e
 	_, err := db.Find(AccountType, map[string]string{
 		"account-id": snaprev.DeveloperID(),
 	})
-	if IsNotFound(err) {
+	if errors.Is(err, &NotFoundError{}) {
 		return fmt.Errorf("snap-revision assertion for snap id %q does not have a matching account assertion for the developer %q", snaprev.SnapID(), snaprev.DeveloperID())
 	}
 	if err != nil {
@@ -593,7 +594,7 @@ func (snaprev *SnapRevision) checkConsistency(db RODatabase, acck *AccountKey) e
 		"series":  release.Series,
 		"snap-id": snaprev.SnapID(),
 	})
-	if IsNotFound(err) {
+	if errors.Is(err, &NotFoundError{}) {
 		return fmt.Errorf("snap-revision assertion for snap id %q does not have a matching snap-declaration assertion", snaprev.SnapID())
 	}
 	if err != nil {
@@ -733,7 +734,7 @@ func (validation *Validation) checkConsistency(db RODatabase, acck *AccountKey) 
 		"series":  validation.Series(),
 		"snap-id": validation.ApprovedSnapID(),
 	})
-	if IsNotFound(err) {
+	if errors.Is(err, &NotFoundError{}) {
 		return fmt.Errorf("validation assertion by snap-id %q does not have a matching snap-declaration assertion for approved-snap-id %q", validation.SnapID(), validation.ApprovedSnapID())
 	}
 	if err != nil {
@@ -743,7 +744,7 @@ func (validation *Validation) checkConsistency(db RODatabase, acck *AccountKey) 
 		"series":  validation.Series(),
 		"snap-id": validation.SnapID(),
 	})
-	if IsNotFound(err) {
+	if errors.Is(err, &NotFoundError{}) {
 		return fmt.Errorf("validation assertion by snap-id %q does not have a matching snap-declaration assertion", validation.SnapID())
 	}
 	if err != nil {
@@ -976,7 +977,7 @@ func (snapdev *SnapDeveloper) checkConsistency(db RODatabase, acck *AccountKey) 
 		"snap-id": snapdev.SnapID(),
 	})
 	if err != nil {
-		if IsNotFound(err) {
+		if errors.Is(err, &NotFoundError{}) {
 			return fmt.Errorf("snap-developer assertion for snap id %q does not have a matching snap-declaration assertion", snapdev.SnapID())
 		}
 		return err
@@ -985,7 +986,7 @@ func (snapdev *SnapDeveloper) checkConsistency(db RODatabase, acck *AccountKey) 
 	// check there's an account for the publisher-id
 	_, err = db.Find(AccountType, map[string]string{"account-id": publisherID})
 	if err != nil {
-		if IsNotFound(err) {
+		if errors.Is(err, &NotFoundError{}) {
 			return fmt.Errorf("snap-developer assertion for snap-id %q does not have a matching account assertion for the publisher %q", snapdev.SnapID(), publisherID)
 		}
 		return err
@@ -998,7 +999,7 @@ func (snapdev *SnapDeveloper) checkConsistency(db RODatabase, acck *AccountKey) 
 		}
 		_, err = db.Find(AccountType, map[string]string{"account-id": developerID})
 		if err != nil {
-			if IsNotFound(err) {
+			if errors.Is(err, &NotFoundError{}) {
 				return fmt.Errorf("snap-developer assertion for snap-id %q does not have a matching account assertion for the developer %q", snapdev.SnapID(), developerID)
 			}
 			return err

--- a/asserts/snapasserts/snapasserts.go
+++ b/asserts/snapasserts/snapasserts.go
@@ -21,6 +21,7 @@
 package snapasserts
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/snapcore/snapd/asserts"
@@ -129,7 +130,7 @@ func CrossCheckProvenance(instanceName string, snapRev *asserts.SnapRevision, sn
 		a, err := db.Find(asserts.StoreType, map[string]string{
 			"store": model.Store(),
 		})
-		if err != nil && !asserts.IsNotFound(err) {
+		if err != nil && !errors.Is(err, &asserts.NotFoundError{}) {
 			return "", err
 		}
 		if a != nil {
@@ -198,7 +199,7 @@ func DeriveSideInfoFromDigestAndSize(snapPath string, snapSHA3_384 string, snapS
 		"snap-sha3-384": snapSHA3_384,
 	}
 	a, err := db.Find(asserts.SnapRevisionType, headers)
-	if err != nil && !asserts.IsNotFound(err) {
+	if err != nil && !errors.Is(err, &asserts.NotFoundError{}) {
 		return nil, err
 	}
 	if a == nil {

--- a/asserts/snapasserts/snapasserts_test.go
+++ b/asserts/snapasserts/snapasserts_test.go
@@ -21,6 +21,7 @@ package snapasserts_test
 
 import (
 	"crypto"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
@@ -279,7 +280,7 @@ func (s *snapassertsSuite) TestDeriveSideInfoNoSignatures(c *C) {
 
 	_, err = snapasserts.DeriveSideInfo(snapPath, nil, s.localDB)
 	// cannot find signatures with metadata for snap
-	c.Assert(asserts.IsNotFound(err), Equals, true)
+	c.Assert(errors.Is(err, &asserts.NotFoundError{}), Equals, true)
 }
 
 func (s *snapassertsSuite) TestDeriveSideInfoSizeMismatch(c *C) {

--- a/asserts/store_asserts.go
+++ b/asserts/store_asserts.go
@@ -20,6 +20,7 @@
 package asserts
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"time"
@@ -76,7 +77,7 @@ func (store *Store) checkConsistency(db RODatabase, acck *AccountKey) error {
 
 	_, err := db.Find(AccountType, map[string]string{"account-id": store.OperatorID()})
 	if err != nil {
-		if IsNotFound(err) {
+		if errors.Is(err, &NotFoundError{}) {
 			return fmt.Errorf(
 				"store assertion %q does not have a matching account assertion for the operator %q",
 				store.Store(), store.OperatorID())

--- a/cmd/snap-repair/runner.go
+++ b/cmd/snap-repair/runner.go
@@ -618,10 +618,10 @@ func checkAuthorityID(a asserts.Assertion, trusted asserts.Backstore) error {
 	// a trusted authority
 	acctID := a.AuthorityID()
 	_, err := trusted.Get(asserts.AccountType, []string{acctID}, asserts.AccountType.MaxSupportedFormat())
-	if err != nil && !asserts.IsNotFound(err) {
+	if err != nil && !errors.Is(err, &asserts.NotFoundError{}) {
 		return err
 	}
-	if asserts.IsNotFound(err) {
+	if errors.Is(err, &asserts.NotFoundError{}) {
 		return fmt.Errorf("%v not signed by trusted authority: %s", a.Ref(), acctID)
 	}
 	return nil
@@ -643,17 +643,17 @@ func verifySignatures(a asserts.Assertion, workBS asserts.Backstore, trusted ass
 		seen[u] = true
 		signKey := []string{a.SignKeyID()}
 		key, err := trusted.Get(asserts.AccountKeyType, signKey, acctKeyMaxSuppFormat)
-		if err != nil && !asserts.IsNotFound(err) {
+		if err != nil && !errors.Is(err, &asserts.NotFoundError{}) {
 			return err
 		}
 		if err == nil {
 			bottom = true
 		} else {
 			key, err = workBS.Get(asserts.AccountKeyType, signKey, acctKeyMaxSuppFormat)
-			if err != nil && !asserts.IsNotFound(err) {
+			if err != nil && !errors.Is(err, &asserts.NotFoundError{}) {
 				return err
 			}
-			if asserts.IsNotFound(err) {
+			if errors.Is(err, &asserts.NotFoundError{}) {
 				return fmt.Errorf("cannot find public key %q", signKey[0])
 			}
 			if err := checkAuthorityID(key, trusted); err != nil {

--- a/daemon/api_asserts.go
+++ b/daemon/api_asserts.go
@@ -159,7 +159,7 @@ func assertsFindMany(c *Command, r *http.Request, user *auth.UserState) Response
 	} else {
 		assertions, err = assertsFindManyInState(c, assertType, opts.headers, opts)
 	}
-	if err != nil && !asserts.IsNotFound(err) {
+	if err != nil && !errors.Is(err, &asserts.NotFoundError{}) {
 		return InternalError("searching assertions failed: %v", err)
 	}
 

--- a/daemon/api_sideload_n_try.go
+++ b/daemon/api_sideload_n_try.go
@@ -303,7 +303,7 @@ func readSideInfo(st *state.State, tempPath string, origPath string, flags sidel
 		switch {
 		case err == nil:
 			sideInfo = si
-		case asserts.IsNotFound(err):
+		case errors.Is(err, &asserts.NotFoundError{}):
 			// with devmode we try to find assertions but it's ok
 			// if they are not there (implies --dangerous)
 			if !flags.DevMode {

--- a/image/image_linux.go
+++ b/image/image_linux.go
@@ -20,6 +20,7 @@
 package image
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -387,7 +388,7 @@ var setupSeed = func(tsto *tooling.ToolingStore, model *asserts.Model, opts *Opt
 	var curSnaps []*tooling.CurrentSnap
 	for _, sn := range localSnaps {
 		si, aRefs, err := seedwriter.DeriveSideInfo(sn.Path, model, f, db)
-		if err != nil && !asserts.IsNotFound(err) {
+		if err != nil && !errors.Is(err, &asserts.NotFoundError{}) {
 			return err
 		}
 

--- a/overlord/assertstate/assertstate.go
+++ b/overlord/assertstate/assertstate.go
@@ -49,7 +49,7 @@ func AddBatch(s *state.State, batch *asserts.Batch, opts *asserts.CommitOptions)
 }
 
 func findError(format string, ref *asserts.Ref, err error) error {
-	if asserts.IsNotFound(err) {
+	if errors.Is(err, &asserts.NotFoundError{}) {
 		return fmt.Errorf(format, ref)
 	} else {
 		return fmt.Errorf(format+": %v", ref, err)
@@ -111,7 +111,7 @@ func RefreshSnapDeclarations(s *state.State, userID int, opts *RefreshAssertions
 		// fetch store assertion if available
 		if modelAs.Store() != "" {
 			err := snapasserts.FetchStore(f, modelAs.Store())
-			if err != nil && !asserts.IsNotFound(err) {
+			if err != nil && !errors.Is(err, &asserts.NotFoundError{}) {
 				return err
 			}
 		}
@@ -562,7 +562,7 @@ func validationSetAssertionForMonitor(st *state.State, accountID, name string, s
 		// find latest
 		vs, err = db.FindSequence(asserts.ValidationSetType, headers, -1, -1)
 	}
-	if err != nil && !asserts.IsNotFound(err) {
+	if err != nil && !errors.Is(err, &asserts.NotFoundError{}) {
 		return nil, false, err
 	}
 	if err == nil {
@@ -601,7 +601,7 @@ func validationSetAssertionForMonitor(st *state.State, accountID, name string, s
 	if err := resolvePoolNoFallback(st, pool, nil, userID, deviceCtx, refreshOpts); err != nil {
 		rerr, ok := err.(*resolvePoolError)
 		if ok && as != nil && opts.AllowLocalFallback {
-			if e := rerr.errors[atSeq.Unique()]; asserts.IsNotFound(e) {
+			if e := rerr.errors[atSeq.Unique()]; errors.Is(e, &asserts.NotFoundError{}) {
 				// fallback: support the scenario of local assertion (snap ack)
 				// not available in the store.
 				return as, true, nil
@@ -712,7 +712,7 @@ func validationSetAssertionForEnforce(st *state.State, accountID, name string, s
 			return vs, nil
 		}
 	} else {
-		if !asserts.IsNotFound(err) {
+		if !errors.Is(err, &asserts.NotFoundError{}) {
 			return nil, err
 		}
 
@@ -807,7 +807,7 @@ func TryEnforcedValidationSets(st *state.State, validationSets []string, userID 
 				return err
 			}
 		} else {
-			if !asserts.IsNotFound(err) {
+			if !errors.Is(err, &asserts.NotFoundError{}) {
 				return err
 			}
 			// try to resolve with pool

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -427,7 +427,7 @@ func (s *assertMgrSuite) TestAddBatchPrecheckPartial(c *C) {
 		"series":  "16",
 		"snap-id": "foo-id",
 	})
-	c.Assert(asserts.IsNotFound(err), Equals, true)
+	c.Assert(errors.Is(err, &asserts.NotFoundError{}), Equals, true)
 }
 
 func (s *assertMgrSuite) TestAddBatchPrecheckHappy(c *C) {
@@ -808,7 +808,7 @@ func (s *assertMgrSuite) TestValidateSnapStoreNotFound(c *C) {
 	_, err = assertstate.DB(s.state).Find(asserts.StoreType, map[string]string{
 		"store": "my-brand-store",
 	})
-	c.Assert(asserts.IsNotFound(err), Equals, true)
+	c.Assert(errors.Is(err, &asserts.NotFoundError{}), Equals, true)
 }
 
 func (s *assertMgrSuite) TestValidateSnapMissingSnapSetup(c *C) {
@@ -1228,7 +1228,7 @@ func (s *assertMgrSuite) TestRefreshAssertionsRefreshSnapDeclarationsAndValidati
 		"name":       "bar",
 		"sequence":   "4",
 	})
-	c.Check(asserts.IsNotFound(err), Equals, true)
+	c.Check(errors.Is(err, &asserts.NotFoundError{}), Equals, true)
 }
 
 func (s *assertMgrSuite) TestRefreshSnapDeclarationsTooEarly(c *C) {
@@ -1404,7 +1404,7 @@ func (s *assertMgrSuite) TestRefreshSnapDeclarationsChangingKey(c *C) {
 	c.Assert(err, IsNil)
 
 	_, err = storeKey2.Ref().Resolve(assertstate.DB(s.state).Find)
-	c.Check(asserts.IsNotFound(err), Equals, true)
+	c.Check(errors.Is(err, &asserts.NotFoundError{}), Equals, true)
 
 	err = assertstate.RefreshSnapDeclarations(s.state, 0, nil)
 	c.Assert(err, IsNil)
@@ -2215,7 +2215,7 @@ func (s *assertMgrSuite) TestBaseSnapDeclaration(c *C) {
 	defer r1()
 
 	baseDecl, err := assertstate.BaseDeclaration(s.state)
-	c.Assert(asserts.IsNotFound(err), Equals, true)
+	c.Assert(errors.Is(err, &asserts.NotFoundError{}), Equals, true)
 	c.Check(baseDecl, IsNil)
 
 	r2 := assertstest.MockBuiltinBaseDeclaration([]byte(`
@@ -2247,7 +2247,7 @@ func (s *assertMgrSuite) TestSnapDeclaration(c *C) {
 	c.Assert(err, IsNil)
 
 	_, err = assertstate.SnapDeclaration(s.state, "snap-id-other")
-	c.Check(asserts.IsNotFound(err), Equals, true)
+	c.Check(errors.Is(err, &asserts.NotFoundError{}), Equals, true)
 
 	snapDecl, err := assertstate.SnapDeclaration(s.state, "foo-id")
 	c.Assert(err, IsNil)
@@ -2405,7 +2405,7 @@ func (s *assertMgrSuite) TestPublisher(c *C) {
 	c.Assert(err, IsNil)
 
 	_, err = assertstate.SnapDeclaration(s.state, "snap-id-other")
-	c.Check(asserts.IsNotFound(err), Equals, true)
+	c.Check(errors.Is(err, &asserts.NotFoundError{}), Equals, true)
 
 	acct, err := assertstate.Publisher(s.state, "foo-id")
 	c.Assert(err, IsNil)
@@ -2427,7 +2427,7 @@ func (s *assertMgrSuite) TestPublisherStoreAccount(c *C) {
 	c.Assert(err, IsNil)
 
 	_, err = assertstate.SnapDeclaration(s.state, "snap-id-other")
-	c.Check(asserts.IsNotFound(err), Equals, true)
+	c.Check(errors.Is(err, &asserts.NotFoundError{}), Equals, true)
 
 	acct, err := assertstate.PublisherStoreAccount(s.state, "foo-id")
 	c.Assert(err, IsNil)
@@ -2456,7 +2456,7 @@ func (s *assertMgrSuite) TestStore(c *C) {
 	c.Assert(err, IsNil)
 
 	_, err = assertstate.Store(s.state, "bar")
-	c.Check(asserts.IsNotFound(err), Equals, true)
+	c.Check(errors.Is(err, &asserts.NotFoundError{}), Equals, true)
 
 	store, err := assertstate.Store(s.state, "foo")
 	c.Assert(err, IsNil)
@@ -2531,7 +2531,7 @@ func (s *assertMgrSuite) TestValidationSetAssertionsAutoRefreshError(c *C) {
 	}
 	assertstate.UpdateValidationSet(s.state, &tr)
 	err := assertstate.AutoRefreshAssertions(s.state, 0)
-	c.Assert(asserts.IsNotFound(err), Equals, true)
+	c.Assert(errors.Is(err, &asserts.NotFoundError{}), Equals, true)
 }
 
 func (s *assertMgrSuite) TestRefreshValidationSetAssertionsStoreError(c *C) {
@@ -2620,7 +2620,7 @@ func (s *assertMgrSuite) TestRefreshValidationSetAssertions(c *C) {
 		"name":       "bar",
 		"sequence":   "4",
 	})
-	c.Assert(asserts.IsNotFound(err), Equals, true)
+	c.Assert(errors.Is(err, &asserts.NotFoundError{}), Equals, true)
 
 	s.fakeStore.(*fakeStore).requestedTypes = nil
 	err = assertstate.RefreshValidationSetAssertions(s.state, 0, nil)
@@ -2715,7 +2715,7 @@ func (s *assertMgrSuite) TestRefreshValidationSetAssertionsPinned(c *C) {
 		"name":       "bar",
 		"sequence":   "7",
 	})
-	c.Assert(asserts.IsNotFound(err), Equals, true)
+	c.Assert(errors.Is(err, &asserts.NotFoundError{}), Equals, true)
 
 	// tracking current remains at 2
 	c.Assert(assertstate.GetValidationSet(s.state, s.dev1Acct.AccountID(), "bar", &tr), IsNil)
@@ -3004,7 +3004,7 @@ func (s *assertMgrSuite) TestRefreshValidationSetAssertionsEnforcingModeConflict
 		"name":       "foo",
 		"sequence":   "2",
 	})
-	c.Assert(asserts.IsNotFound(err), Equals, true)
+	c.Assert(errors.Is(err, &asserts.NotFoundError{}), Equals, true)
 
 	c.Check(s.fakeStore.(*fakeStore).requestedTypes, DeepEquals, [][]string{
 		{"account", "account-key", "validation-set"},
@@ -3068,7 +3068,7 @@ func (s *assertMgrSuite) TestRefreshValidationSetAssertionsEnforcingModeMissingS
 		"name":       "foo",
 		"sequence":   "2",
 	})
-	c.Assert(asserts.IsNotFound(err), Equals, true)
+	c.Assert(errors.Is(err, &asserts.NotFoundError{}), Equals, true)
 
 	c.Check(s.fakeStore.(*fakeStore).requestedTypes, DeepEquals, [][]string{
 		{"account", "account-key", "validation-set"},
@@ -3345,7 +3345,7 @@ func (s *assertMgrSuite) TestValidationSetAssertionForEnforceNotPinnedUnhappyMis
 		"name":       "bar",
 		"sequence":   "2",
 	})
-	c.Assert(asserts.IsNotFound(err), Equals, true)
+	c.Assert(errors.Is(err, &asserts.NotFoundError{}), Equals, true)
 }
 
 func (s *assertMgrSuite) TestValidationSetAssertionForEnforceNotPinnedUnhappyConflict(c *C) {
@@ -3392,7 +3392,7 @@ func (s *assertMgrSuite) TestValidationSetAssertionForEnforceNotPinnedUnhappyCon
 		"name":       "bar",
 		"sequence":   "2",
 	})
-	c.Assert(asserts.IsNotFound(err), Equals, true)
+	c.Assert(errors.Is(err, &asserts.NotFoundError{}), Equals, true)
 }
 
 func (s *assertMgrSuite) TestValidationSetAssertionForEnforceNotPinnedAfterForgetHappy(c *C) {
@@ -3535,7 +3535,7 @@ func (s *assertMgrSuite) TestTemporaryDB(c *C) {
 	// model isn't found in the main DB
 	_, err = assertstate.DB(st).Find(asserts.ModelType, hdrs)
 	c.Assert(err, NotNil)
-	c.Assert(asserts.IsNotFound(err), Equals, true)
+	c.Assert(errors.Is(err, &asserts.NotFoundError{}), Equals, true)
 	// let's get a temporary DB
 	tempDB := assertstate.TemporaryDB(st)
 	c.Assert(tempDB, NotNil)
@@ -3548,7 +3548,7 @@ func (s *assertMgrSuite) TestTemporaryDB(c *C) {
 	// the model is only in the temp database
 	_, err = assertstate.DB(st).Find(asserts.ModelType, hdrs)
 	c.Assert(err, NotNil)
-	c.Assert(asserts.IsNotFound(err), Equals, true)
+	c.Assert(errors.Is(err, &asserts.NotFoundError{}), Equals, true)
 
 	// let's add it to the DB now
 	err = assertstate.Add(st, model)
@@ -3963,14 +3963,14 @@ func (s *assertMgrSuite) TestTryEnforceValidationSetsAssertionsValidationError(c
 		"name":       "bar",
 		"sequence":   "2",
 	})
-	c.Assert(asserts.IsNotFound(err), Equals, true)
+	c.Assert(errors.Is(err, &asserts.NotFoundError{}), Equals, true)
 	_, err = assertstate.DB(s.state).Find(asserts.ValidationSetType, map[string]string{
 		"series":     "16",
 		"account-id": s.dev1Acct.AccountID(),
 		"name":       "baz",
 		"sequence":   "1",
 	})
-	c.Assert(asserts.IsNotFound(err), Equals, true)
+	c.Assert(errors.Is(err, &asserts.NotFoundError{}), Equals, true)
 	c.Check(s.fakeStore.(*fakeStore).opts.IsAutoRefresh, Equals, false)
 }
 
@@ -4226,7 +4226,7 @@ func (s *assertMgrSuite) TestTryEnforceValidationSetsAssertionsConflictError(c *
 		"name":       "bar",
 		"sequence":   "2",
 	})
-	c.Assert(asserts.IsNotFound(err), Equals, true)
+	c.Assert(errors.Is(err, &asserts.NotFoundError{}), Equals, true)
 	c.Check(s.fakeStore.(*fakeStore).opts.IsAutoRefresh, Equals, false)
 }
 

--- a/overlord/configstate/configcore/proxy.go
+++ b/overlord/configstate/configcore/proxy.go
@@ -22,6 +22,7 @@
 package configcore
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -118,7 +119,7 @@ func validateProxyStore(tr RunTransaction) error {
 	defer st.Unlock()
 
 	store, err := assertstate.Store(st, proxyStore)
-	if asserts.IsNotFound(err) {
+	if errors.Is(err, &asserts.NotFoundError{}) {
 		return fmt.Errorf("cannot set proxy.store to %q without a matching store assertion", proxyStore)
 	}
 	if err == nil && store.URL() == nil {

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -718,7 +718,7 @@ func (m *DeviceManager) maybeRestoreAfterReset(device *auth.DeviceState) (*asser
 		"model":    device.Model,
 	})
 	if err != nil {
-		if asserts.IsNotFound(err) {
+		if errors.Is(err, &asserts.NotFoundError{}) {
 			// no serial assertion
 			return nil, nil
 		}

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -73,7 +73,7 @@ func findModel(st *state.State) (*asserts.Model, error) {
 		"brand-id": device.Brand,
 		"model":    device.Model,
 	})
-	if asserts.IsNotFound(err) {
+	if errors.Is(err, &asserts.NotFoundError{}) {
 		return nil, state.ErrNoState
 	}
 	if err != nil {
@@ -102,7 +102,7 @@ func findSerial(st *state.State, device *auth.DeviceState) (*asserts.Serial, err
 		"model":    device.Model,
 		"serial":   device.Serial,
 	})
-	if asserts.IsNotFound(err) {
+	if errors.Is(err, &asserts.NotFoundError{}) {
 		return nil, state.ErrNoState
 	}
 	if err != nil {
@@ -265,7 +265,7 @@ func proxyStore(st *state.State, tr *config.Transaction) (*asserts.Store, error)
 	a, err := assertstate.DB(st).Find(asserts.StoreType, map[string]string{
 		"store": proxyStore,
 	})
-	if asserts.IsNotFound(err) {
+	if errors.Is(err, &asserts.NotFoundError{}) {
 		return nil, state.ErrNoState
 	}
 	if err != nil {

--- a/overlord/devicestate/devicestate_serial_test.go
+++ b/overlord/devicestate/devicestate_serial_test.go
@@ -21,6 +21,7 @@ package devicestate_test
 
 import (
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -678,7 +679,7 @@ func (s *deviceMgrSerialSuite) TestDoRequestSerialIdempotentAfterGotSerial(c *C)
 		"model":    "pc",
 		"serial":   "9999",
 	})
-	c.Assert(asserts.IsNotFound(err), Equals, true)
+	c.Assert(errors.Is(err, &asserts.NotFoundError{}), Equals, true)
 
 	s.state.Unlock()
 	s.se.Ensure()

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -1074,7 +1074,7 @@ func restoreDeviceSerialFromSave(model *asserts.Model) error {
 		"brand-id": model.BrandID(),
 		"model":    model.Model(),
 	})
-	if (err != nil && asserts.IsNotFound(err)) || len(serials) == 0 {
+	if (err != nil && errors.Is(err, &asserts.NotFoundError{})) || len(serials) == 0 {
 		// there is no serial assertion in the old system that matches
 		// our model, it is still possible that the old system could
 		// have generated device keys and sent out a serial request, but

--- a/overlord/devicestate/handlers_serial.go
+++ b/overlord/devicestate/handlers_serial.go
@@ -699,7 +699,7 @@ func (m *DeviceManager) doRequestSerial(t *state.Task, _ *tomb.Tomb) error {
 		"model":               device.Model,
 		"device-key-sha3-384": privKey.PublicKey().ID(),
 	})
-	if err != nil && !asserts.IsNotFound(err) {
+	if err != nil && !errors.Is(err, &asserts.NotFoundError{}) {
 		return err
 	}
 

--- a/overlord/devicestate/systems.go
+++ b/overlord/devicestate/systems.go
@@ -325,7 +325,7 @@ func createSystemForModelFromValidatedSnaps(model *asserts.Model, label string, 
 		// better way
 		_, aRefs, err := seedwriter.DeriveSideInfo(sn.Path, model, f, db)
 		if err != nil {
-			if !asserts.IsNotFound(err) {
+			if !errors.Is(err, &asserts.NotFoundError{}) {
 				return recoverySystemDir, err
 			} else if info.SnapID != "" {
 				// snap info from state must have come

--- a/overlord/devicestate/users.go
+++ b/overlord/devicestate/users.go
@@ -204,7 +204,7 @@ var createAllKnownSystemUsers = func(state *state.State, assertDb asserts.ROData
 	}
 
 	assertions, err := assertDb.FindMany(asserts.SystemUserType, headers)
-	if err != nil && !asserts.IsNotFound(err) {
+	if err != nil && !errors.Is(err, &asserts.NotFoundError{}) {
 		return nil, &UserError{Err: fmt.Errorf("cannot find system-user assertion: %s", err)}
 	}
 

--- a/overlord/hookstate/ctlcmd/model.go
+++ b/overlord/hookstate/ctlcmd/model.go
@@ -20,6 +20,7 @@
 package ctlcmd
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"sort"
@@ -253,7 +254,7 @@ func (c *modelCommand) Execute([]string) error {
 	serialAssertion, err := c.findSerialAssertion(st, deviceCtx.Model())
 	// Ignore the error in case the serial assertion wasn't found. We will
 	// then use the model assertion instead.
-	if err != nil && !asserts.IsNotFound(err) {
+	if err != nil && !errors.Is(err, &asserts.NotFoundError{}) {
 		return err
 	}
 

--- a/overlord/hookstate/ctlcmd/model_test.go
+++ b/overlord/hookstate/ctlcmd/model_test.go
@@ -20,6 +20,7 @@
 package ctlcmd_test
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -646,7 +647,7 @@ func (s *modelSuite) TestFindSerialAssertionNone(c *C) {
 	assertstatetest.AddMany(s.state, model)
 
 	result, err := ctlcmd.FindSerialAssertion(s.state, model)
-	c.Assert(asserts.IsNotFound(err), Equals, true)
+	c.Assert(errors.Is(err, &asserts.NotFoundError{}), Equals, true)
 	c.Assert(result, IsNil)
 }
 

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -720,7 +720,7 @@ func (c *autoConnectChecker) check(plug *interfaces.ConnectedPlug, slot *interfa
 	if modelAs.Store() != "" {
 		var err error
 		storeAs, err = assertstate.Store(c.st, modelAs.Store())
-		if err != nil && !asserts.IsNotFound(err) {
+		if err != nil && !errors.Is(err, &asserts.NotFoundError{}) {
 			return false, nil, err
 		}
 	}
@@ -881,7 +881,7 @@ func (c *connectChecker) check(plug *interfaces.ConnectedPlug, slot *interfaces.
 	if modelAs.Store() != "" {
 		var err error
 		storeAs, err = assertstate.Store(c.st, modelAs.Store())
-		if err != nil && !asserts.IsNotFound(err) {
+		if err != nil && !errors.Is(err, &asserts.NotFoundError{}) {
 			return false, err
 		}
 	}
@@ -1080,7 +1080,7 @@ func resolveSnapIDToName(st *state.State, snapID string) (name string, err error
 		return mapper.RemapSnapFromRequest(snapID), nil
 	}
 	decl, err := assertstate.SnapDeclaration(st, snapID)
-	if asserts.IsNotFound(err) {
+	if errors.Is(err, &asserts.NotFoundError{}) {
 		return "", nil
 	}
 	if err != nil {

--- a/overlord/ifacestate/ifacestate.go
+++ b/overlord/ifacestate/ifacestate.go
@@ -485,7 +485,7 @@ func CheckInterfaces(st *state.State, snapInfo *snap.Info, deviceCtx snapstate.D
 	if modelAs.Store() != "" {
 		var err error
 		storeAs, err = assertstate.Store(st, modelAs.Store())
-		if err != nil && !asserts.IsNotFound(err) {
+		if err != nil && !errors.Is(err, &asserts.NotFoundError{}) {
 			return err
 		}
 	}

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -121,7 +121,7 @@ func (am *AssertsMock) MockSnapDecl(c *C, name, publisher string, extraHeaders m
 	_, err := am.Db.Find(asserts.AccountType, map[string]string{
 		"account-id": publisher,
 	})
-	if asserts.IsNotFound(err) {
+	if errors.Is(err, &asserts.NotFoundError{}) {
 		acct := assertstest.NewAccount(am.storeSigning, publisher, map[string]interface{}{
 			"account-id": publisher,
 		}, "")
@@ -2100,7 +2100,7 @@ func (s *interfaceManagerSuite) mockSnapInstance(c *C, instanceName, yamlText st
 		decl := a[0].(*asserts.SnapDeclaration)
 		snapInfo.SnapID = decl.SnapID()
 		sideInfo.SnapID = decl.SnapID()
-	} else if asserts.IsNotFound(err) {
+	} else if errors.Is(err, &asserts.NotFoundError{}) {
 		err = nil
 	}
 	c.Assert(err, IsNil)

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -1100,7 +1100,7 @@ func (s *baseMgrsSuite) mockStore(c *C) *httptest.Server {
 				PrimaryKey: comps[2:],
 			}
 			a, err := ref.Resolve(s.storeSigning.Find)
-			if asserts.IsNotFound(err) {
+			if errors.Is(err, &asserts.NotFoundError{}) {
 				w.Header().Set("Content-Type", "application/problem+json")
 				w.WriteHeader(404)
 				w.Write([]byte(`{"error-list":[{"code":"not-found","message":"..."}]}`))

--- a/seed/seed16.go
+++ b/seed/seed16.go
@@ -30,6 +30,7 @@ package seed
 */
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 
@@ -182,7 +183,7 @@ func (s *seed16) addSnap(sn *internal.Snap16, essType snap.Type, pinnedTrack str
 				// sets si too
 				_, err = deriveRev(snapSHA3_384, snapSize)
 			})
-			if asserts.IsNotFound(err) {
+			if errors.Is(err, &asserts.NotFoundError{}) {
 				return nil, fmt.Errorf("cannot find signatures with metadata for snap %q (%q)", sn.Name, path)
 			}
 			if err != nil {

--- a/seed/seedtest/seedtest.go
+++ b/seed/seedtest/seedtest.go
@@ -20,6 +20,7 @@
 package seedtest
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -305,7 +306,7 @@ func (s *TestingSeed20) MakeSeedWithModel(c *C, label string, model *asserts.Mod
 
 	for _, sn := range localSnaps {
 		si, aRefs, err := seedwriter.DeriveSideInfo(sn.Path, model, rf, db)
-		if !asserts.IsNotFound(err) {
+		if !errors.Is(err, &asserts.NotFoundError{}) {
 			c.Assert(err, IsNil)
 		}
 		f, err := snapfile.Open(sn.Path)

--- a/seed/seedwriter/writer_test.go
+++ b/seed/seedwriter/writer_test.go
@@ -21,6 +21,7 @@ package seedwriter_test
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -1108,7 +1109,7 @@ func (s *writerSuite) TestLocalSnapsCore18FullUse(c *C) {
 
 	for _, sn := range localSnaps {
 		si, aRefs, err := seedwriter.DeriveSideInfo(sn.Path, model, tf, s.db)
-		if !asserts.IsNotFound(err) {
+		if !errors.Is(err, &asserts.NotFoundError{}) {
 			c.Assert(err, IsNil)
 		}
 		f, err := snapfile.Open(sn.Path)
@@ -1765,7 +1766,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaLocalExtraSnaps(c *C) {
 
 	for _, sn := range localSnaps {
 		si, aRefs, err := seedwriter.DeriveSideInfo(sn.Path, model, tf, s.db)
-		if !asserts.IsNotFound(err) {
+		if !errors.Is(err, &asserts.NotFoundError{}) {
 			c.Assert(err, IsNil)
 		}
 		f, err := snapfile.Open(sn.Path)
@@ -2488,7 +2489,7 @@ func (s *writerSuite) TestCore20NonDangerousDisallowedOptionsSnaps(c *C) {
 
 			for _, sn := range localSnaps {
 				si, aRefs, err := seedwriter.DeriveSideInfo(sn.Path, model, tf, s.db)
-				if !asserts.IsNotFound(err) {
+				if !errors.Is(err, &asserts.NotFoundError{}) {
 					c.Assert(err, IsNil)
 				}
 				f, err := snapfile.Open(sn.Path)
@@ -2600,7 +2601,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20LocalSnaps(c *C) {
 
 	for _, sn := range localSnaps {
 		_, _, err := seedwriter.DeriveSideInfo(sn.Path, model, tf, s.db)
-		c.Assert(asserts.IsNotFound(err), Equals, true)
+		c.Assert(errors.Is(err, &asserts.NotFoundError{}), Equals, true)
 		f, err := snapfile.Open(sn.Path)
 		c.Assert(err, IsNil)
 		info, err := snap.ReadInfoFromSnapFile(f, nil)
@@ -2981,7 +2982,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20ExtraSnaps(c *C) {
 
 	for _, sn := range localSnaps {
 		_, _, err := seedwriter.DeriveSideInfo(sn.Path, model, tf, s.db)
-		c.Assert(asserts.IsNotFound(err), Equals, true)
+		c.Assert(errors.Is(err, &asserts.NotFoundError{}), Equals, true)
 		f, err := snapfile.Open(sn.Path)
 		c.Assert(err, IsNil)
 		info, err := snap.ReadInfoFromSnapFile(f, nil)

--- a/store/store_asserts_test.go
+++ b/store/store_asserts_test.go
@@ -21,6 +21,7 @@ package store_test
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -217,7 +218,7 @@ func (s *storeAssertsSuite) TestAssertionNotFoundV1(c *C) {
 	sto := store.New(&cfg, nil)
 
 	_, err := sto.Assertion(asserts.SnapDeclarationType, []string{"16", "snapidfoo"}, nil)
-	c.Check(asserts.IsNotFound(err), Equals, true)
+	c.Check(errors.Is(err, &asserts.NotFoundError{}), Equals, true)
 	c.Check(err, DeepEquals, &asserts.NotFoundError{
 		Type: asserts.SnapDeclarationType,
 		Headers: map[string]string{
@@ -247,7 +248,7 @@ func (s *storeAssertsSuite) TestAssertionNotFoundV2(c *C) {
 	sto := store.New(&cfg, nil)
 
 	_, err := sto.Assertion(asserts.SnapDeclarationType, []string{"16", "snapidfoo"}, nil)
-	c.Check(asserts.IsNotFound(err), Equals, true)
+	c.Check(errors.Is(err, &asserts.NotFoundError{}), Equals, true)
 	c.Check(err, DeepEquals, &asserts.NotFoundError{
 		Type: asserts.SnapDeclarationType,
 		Headers: map[string]string{
@@ -570,7 +571,7 @@ func (s *storeAssertsSuite) TestSeqFormingAssertionNotFound(c *C) {
 	sto := store.New(&cfg, nil)
 
 	_, err := sto.SeqFormingAssertion(asserts.ValidationSetType, []string{"16", "account-foo", "set-bar"}, 1, nil)
-	c.Check(asserts.IsNotFound(err), Equals, true)
+	c.Check(errors.Is(err, &asserts.NotFoundError{}), Equals, true)
 	c.Check(err, DeepEquals, &asserts.NotFoundError{
 		Type: asserts.ValidationSetType,
 		Headers: map[string]string{
@@ -583,7 +584,7 @@ func (s *storeAssertsSuite) TestSeqFormingAssertionNotFound(c *C) {
 
 	// latest requested
 	_, err = sto.SeqFormingAssertion(asserts.ValidationSetType, []string{"16", "account-foo", "set-bar"}, 0, nil)
-	c.Check(asserts.IsNotFound(err), Equals, true)
+	c.Check(errors.Is(err, &asserts.NotFoundError{}), Equals, true)
 	c.Check(err, DeepEquals, &asserts.NotFoundError{
 		Type: asserts.ValidationSetType,
 		Headers: map[string]string{

--- a/tests/lib/fakestore/store/store.go
+++ b/tests/lib/fakestore/store/store.go
@@ -206,7 +206,7 @@ func snapEssentialInfo(w http.ResponseWriter, fn, snapID string, bs asserts.Back
 	}
 
 	snapRev, devAcct, err := findSnapRevision(snapDigest, bs)
-	if err != nil && !asserts.IsNotFound(err) {
+	if err != nil && !errors.Is(err, &asserts.NotFoundError{}) {
 		http.Error(w, fmt.Sprintf("cannot get info for: %v: %v", fn, err), 400)
 		return nil, errInfo
 	}
@@ -275,7 +275,7 @@ func (s *Store) repairsEndpoint(w http.ResponseWriter, req *http.Request) {
 	}
 
 	a, err := s.retrieveAssertion(bs, asserts.RepairType, brandAndRepairID)
-	if asserts.IsNotFound(err) {
+	if errors.Is(err, &asserts.NotFoundError{}) {
 		w.Header().Set("Content-Type", "application/problem+json")
 		w.WriteHeader(404)
 		w.Write([]byte(`{"status": 404}`))
@@ -733,7 +733,7 @@ func (s *Store) snapActionEndpoint(w http.ResponseWriter, req *http.Request) {
 
 func (s *Store) retrieveAssertion(bs asserts.Backstore, assertType *asserts.AssertionType, primaryKey []string) (asserts.Assertion, error) {
 	a, err := bs.Get(assertType, primaryKey, assertType.MaxSupportedFormat())
-	if asserts.IsNotFound(err) && s.assertFallback {
+	if errors.Is(err, &asserts.NotFoundError{}) && s.assertFallback {
 		return s.fallback.Assertion(assertType, primaryKey, nil)
 	}
 	return a, err
@@ -768,7 +768,7 @@ func (s *Store) assertionsEndpoint(w http.ResponseWriter, req *http.Request) {
 	}
 
 	a, err := s.retrieveAssertion(bs, typ, pk)
-	if asserts.IsNotFound(err) {
+	if errors.Is(err, &asserts.NotFoundError{}) {
 		w.Header().Set("Content-Type", "application/problem+json")
 		w.WriteHeader(404)
 		w.Write([]byte(`{"error-list":[{"code":"not-found","message":"not found"}]}`))


### PR DESCRIPTION
This is just a simple refactor to replace [`IsNotFound()`](https://github.com/snapcore/snapd/blob/master/asserts/database.go#L48) usages for `errors.Is(err, &NotFoundError{})`.
