### PR TITLE
gadget,osutil: add support for gadget's kernel-cmdline stanza

### DIFF
--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -95,6 +95,14 @@ var (
 	validGUUID      = regexp.MustCompile("^(?i)[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$")
 )
 
+type KernelCmdline struct {
+	// TODO: add append and remove slices that will replace the cmdline*.txt
+	// files that can be included nowadays in the gadget.
+	// Allow is the list of allowed parameters for the system.kernel.cmdline-append
+	// system option
+	Allow []osutil.KernelArgument `yaml:"allow"`
+}
+
 type Info struct {
 	Volumes map[string]*Volume `yaml:"volumes,omitempty"`
 
@@ -102,6 +110,8 @@ type Info struct {
 	Defaults map[string]map[string]interface{} `yaml:"defaults,omitempty"`
 
 	Connections []Connection `yaml:"connections"`
+
+	KernelCmdline KernelCmdline `yaml:"kernel-cmdline"`
 }
 
 // Volume defines the structure and content for the image to be written into a

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/snapcore/snapd/gadget/gadgettest"
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/disks"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snapfile"
@@ -3753,4 +3754,50 @@ func (s *gadgetYamlTestSuite) TestHasRoleUnhappy(c *C) {
 	c.Assert(err, IsNil)
 	_, err = gadget.HasRole(s.dir, []string{gadget.SystemData})
 	c.Check(err, ErrorMatches, `cannot minimally parse gadget metadata: yaml:.*`)
+}
+
+func appendAllowListToYaml(allow []string, templ string) string {
+	for _, arg := range allow {
+		templ += fmt.Sprintf("    - %s\n", arg)
+	}
+	return templ
+}
+
+func (s *gadgetYamlTestSuite) TestKernelCmdlineAllow(c *C) {
+	yamlTemplate := `
+volumes:
+  pc:
+    bootloader: grub
+kernel-cmdline:
+  allow:
+`
+
+	tests := []struct {
+		allowList []string
+		err       string
+	}{
+		{[]string{"foo=bar", "my-param.state=blah"}, ""},
+		{[]string{"foo="}, ""},
+		{[]string{"foo", "bar", `my-param.state="blah"`}, ""},
+		{[]string{"foo bar"}, `cannot parse gadget metadata: "foo bar" is not a unique kernel argument`},
+	}
+
+	for _, t := range tests {
+		c.Logf("allowList %v", t.allowList)
+		yaml := appendAllowListToYaml(t.allowList, yamlTemplate)
+		gi, err := gadget.InfoFromGadgetYaml([]byte(yaml), uc20Mod)
+		if err != nil {
+			c.Assert(err, ErrorMatches, t.err)
+			c.Assert(gi, IsNil)
+		} else {
+			allowed := []osutil.KernelArgument{}
+			for _, arg := range t.allowList {
+				parsed := osutil.ParseKernelCommandline(arg)
+				c.Assert(len(parsed), Equals, 1)
+				allowed = append(allowed, parsed[0])
+			}
+
+			c.Assert(gi.KernelCmdline.Allow, DeepEquals, allowed)
+		}
+	}
 }

--- a/gadget/kcmdline.go
+++ b/gadget/kcmdline.go
@@ -1,0 +1,62 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package gadget
+
+import (
+	"fmt"
+
+	"github.com/snapcore/snapd/osutil"
+)
+
+type kargKey struct{ par, val string }
+type kernelArgsSet map[kargKey]bool
+
+// CheckCmdlineAllowed returns an error if an argument from cmdline is
+// not on a list of allowed kernel arguments. A wild card ('*') can be
+// used in the allow list for the values.
+func CheckCmdlineAllowed(cmdline string, allowedSl []osutil.KernelArgument) error {
+	// Set of allowed arguments
+	allowed := kernelArgsSet{}
+	wildcards := map[string]bool{}
+	for _, p := range allowedSl {
+		if p.Value == "*" && !p.Quoted {
+			// Currently only allowed globbing
+			wildcards[p.Param] = true
+		} else {
+			allowed[kargKey{par: p.Param, val: p.Value}] = true
+		}
+	}
+
+	proposed := osutil.ParseKernelCommandline(cmdline)
+
+	for _, p := range proposed {
+		if allowed[kargKey{par: p.Param, val: p.Value}] {
+			continue
+		}
+		if wildcards[p.Param] {
+			continue
+		}
+
+		return fmt.Errorf("\"%s=%s\" is not an allowed kernel argument",
+			p.Param, p.Value)
+	}
+
+	return nil
+}

--- a/gadget/kcmdline_test.go
+++ b/gadget/kcmdline_test.go
@@ -1,0 +1,104 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package gadget_test
+
+import (
+	"github.com/snapcore/snapd/gadget"
+	. "gopkg.in/check.v1"
+)
+
+func (s *gadgetYamlTestSuite) TestCheckCmdlineAllowed(c *C) {
+	const yaml = `
+volumes:
+  pc:
+    bootloader: grub
+kernel-cmdline:
+  allow:
+    - par1
+    - par2=val
+    - par3=*
+    - par-4=val_1-2
+`
+	tests := []struct {
+		cmdline string
+		err     string
+	}{
+		// Allowed
+		{"par1", ""},
+		{"par2=val", ""},
+		{"par3=random_stuff", ""},
+		{"par3", ""},
+		{"par3=", ""},
+		{`par3=""`, ""},
+		{"", ""},
+		{"par2=val par1 par3=.1.32", ""},
+		{"par_4=val_1-2", ""},
+		// Not allowed
+		{"foo", `"foo=" is not an allowed kernel argument`},
+		{"par2=other", `"par2=other" is not an allowed kernel argument`},
+		{"par2=val par1 par3=.1.32 par2=other", `"par2=other" is not an allowed kernel argument`},
+		{"par-4=val_1_2", `"par_4=val_1_2" is not an allowed kernel argument`},
+	}
+
+	for i, t := range tests {
+		c.Logf("%v: cmdline %q", i, t.cmdline)
+		gi, err := gadget.InfoFromGadgetYaml([]byte(yaml), uc20Mod)
+		c.Assert(err, IsNil)
+		err = gadget.CheckCmdlineAllowed(t.cmdline, gi.KernelCmdline.Allow)
+		if t.err == "" {
+			c.Assert(err, IsNil)
+		} else {
+			c.Assert(err, ErrorMatches, t.err)
+		}
+	}
+}
+
+func (s *gadgetYamlTestSuite) TestCheckCmdlineAllowedStarLiteral(c *C) {
+	const yaml = `
+volumes:
+  pc:
+    bootloader: grub
+kernel-cmdline:
+  allow:
+    - par1="*"
+`
+	tests := []struct {
+		cmdline string
+		err     string
+	}{
+		// Allowed
+		{"par1=*", ""},
+		{`par1="*"`, ""},
+		// Not allowed as only a literal '*' is allowed
+		{"par1=val", `\"par1=val\" is not an allowed kernel argument`},
+	}
+
+	for i, t := range tests {
+		c.Logf("%v: cmdline %q", i, t.cmdline)
+		gi, err := gadget.InfoFromGadgetYaml([]byte(yaml), uc20Mod)
+		c.Assert(err, IsNil)
+		err = gadget.CheckCmdlineAllowed(t.cmdline, gi.KernelCmdline.Allow)
+		if t.err == "" {
+			c.Assert(err, IsNil)
+		} else {
+			c.Assert(err, ErrorMatches, t.err)
+		}
+	}
+}

--- a/osutil/kcmdline_test.go
+++ b/osutil/kcmdline_test.go
@@ -20,10 +20,12 @@
 package osutil_test
 
 import (
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
 
 	. "gopkg.in/check.v1"
+	"gopkg.in/yaml.v2"
 
 	"github.com/snapcore/snapd/osutil"
 )
@@ -207,4 +209,146 @@ func (s *kcmdlineTestSuite) TestKernelCommandLine(c *C) {
 	cmd, err = osutil.KernelCommandLine()
 	c.Assert(err, IsNil)
 	c.Check(cmd, Equals, "foo bar baz panic=-1")
+}
+
+// Outcome of test cases here match the next_arg function from
+// lib/cmdline.c in the linux kernel (minus sometimes the linux code
+// returning NULL or "" while we always return "" in both cases, but
+// that should be irrelevant).
+func (s *kcmdlineTestSuite) TestKernelParseCommandLine(c *C) {
+	for idx, tc := range []struct {
+		cmd string
+		exp []osutil.KernelArgument
+	}{
+		{cmd: ``, exp: []osutil.KernelArgument{}},
+		{cmd: `foo bar baz`, exp: []osutil.KernelArgument{
+			{"foo", "", false}, {"bar", "", false}, {"baz", "", false}}},
+		{cmd: `"foo"=" many   spaces  " bar`, exp: []osutil.KernelArgument{
+			{`foo"`, " many   spaces  ", true}, {"bar", "", false}}},
+		{cmd: `"foo=bar" foo="bar"`, exp: []osutil.KernelArgument{
+			{"foo", "bar", true}, {"foo", "bar", true}}},
+		{cmd: `foo=* baz=bar`, exp: []osutil.KernelArgument{
+			{"foo", "*", false}, {"baz", "bar", false}}},
+		{cmd: `foo_bar-tee=bar_aa-bb`, exp: []osutil.KernelArgument{
+			{"foo_bar_tee", "bar_aa-bb", false}}},
+		{cmd: `foo="1$2"`, exp: []osutil.KernelArgument{{"foo", "1$2", true}}},
+		{cmd: `foo=1$2`, exp: []osutil.KernelArgument{{"foo", "1$2", false}}},
+		{cmd: `foo= bar`, exp: []osutil.KernelArgument{{"foo", "", false}, {"bar", "", false}}},
+		{cmd: `foo=""`, exp: []osutil.KernelArgument{{"foo", "", true}}},
+		{cmd: `   cpu=1,2,3   mem=0x2000;0x4000:$2  `,
+			exp: []osutil.KernelArgument{{"cpu", "1,2,3", false}, {"mem", "0x2000;0x4000:$2", false}}},
+		{cmd: "isolcpus=1,2,10-20,100-2000:2/25",
+			exp: []osutil.KernelArgument{{"isolcpus", "1,2,10-20,100-2000:2/25", false}}},
+		// something more realistic
+		{
+			cmd: `BOOT_IMAGE=/vmlinuz-linux root=/dev/mapper/linux-root rw quiet loglevel=3 rd.udev.log_priority=3 vt.global_cursor_default=0 rd.luks.uuid=1a273f76-3118-434b-8597-a3b12a59e017 rd.luks.uuid=775e4582-33c1-423b-ac19-f734e0d5e21c rd.luks.options=discard,timeout=0 root=/dev/mapper/linux-root apparmor=1 security=apparmor`,
+			exp: []osutil.KernelArgument{
+				{"BOOT_IMAGE", "/vmlinuz-linux", false},
+				{"root", "/dev/mapper/linux-root", false},
+				{"rw", "", false},
+				{"quiet", "", false},
+				{"loglevel", "3", false},
+				{"rd.udev.log_priority", "3", false},
+				{"vt.global_cursor_default", "0", false},
+				{"rd.luks.uuid", "1a273f76-3118-434b-8597-a3b12a59e017", false},
+				{"rd.luks.uuid", "775e4582-33c1-423b-ac19-f734e0d5e21c", false},
+				{"rd.luks.options", "discard,timeout=0", false},
+				{"root", "/dev/mapper/linux-root", false},
+				{"apparmor", "1", false},
+				{"security", "apparmor", false},
+			},
+		},
+		// this is actually ok, eg. rd.luks.options=discard,timeout=0
+		{cmd: `a=b=`, exp: []osutil.KernelArgument{{"a", "b=", false}}},
+		// bad quoting, or otherwise malformed command line
+		{cmd: `foo="1$2`, exp: []osutil.KernelArgument{{"foo", "1$2", true}}},
+		{cmd: `"foo"`, exp: []osutil.KernelArgument{{"foo", "", true}}},
+		{cmd: `foo"foo"`, exp: []osutil.KernelArgument{{`foo"foo"`, "", false}}},
+		{cmd: `foo=foo"`, exp: []osutil.KernelArgument{{"foo", `foo"`, false}}},
+		{cmd: `foo=bar=baz`, exp: []osutil.KernelArgument{{"foo", `bar=baz`, false}}},
+		{cmd: `"f"o"o"="b"a"r"`, exp: []osutil.KernelArgument{{`f"o"o"`, `b"a"r`, true}}},
+		{cmd: `foo="a""b"`, exp: []osutil.KernelArgument{{"foo", `a""b`, true}}},
+		{cmd: `foo="a foo="b`, exp: []osutil.KernelArgument{{"foo", `a foo="b`, true}}},
+		{cmd: `foo="a"="b"`, exp: []osutil.KernelArgument{{"foo", `a"="b`, true}}},
+		{cmd: `=`, exp: []osutil.KernelArgument{{"=", "", false}}},
+		{cmd: `a =`, exp: []osutil.KernelArgument{{"a", "", false}, {"=", "", false}}},
+		{cmd: `="foo"`, exp: []osutil.KernelArgument{{`="foo"`, "", false}}},
+		{cmd: `a==`, exp: []osutil.KernelArgument{{"a", "=", false}}},
+		{cmd: `foo ==a`, exp: []osutil.KernelArgument{{"foo", "", false}, {"=", "a", false}}},
+	} {
+		c.Logf("%v, cmd: %q", idx, tc.cmd)
+		out := osutil.ParseKernelCommandline(tc.cmd)
+		c.Check(out, DeepEquals, tc.exp)
+	}
+}
+
+type argsList struct {
+	Args []osutil.KernelArgument `yaml:"args"`
+}
+
+func buildYamlArgsList(list []string) string {
+	yaml := "args:\n"
+	for _, arg := range list {
+		yaml += fmt.Sprintf("  - %s\n", arg)
+	}
+	return yaml
+}
+
+func (s *kcmdlineTestSuite) TestUnmarshalKernelArgument(c *C) {
+	for idx, tc := range []struct {
+		args   []string
+		exp    argsList
+		errStr string
+	}{
+		{
+			[]string{`par1=val1`, `par2="val2"`},
+			argsList{[]osutil.KernelArgument{{"par1", "val1", false}, {"par2", "val2", true}}},
+			"",
+		},
+		{
+			[]string{`par1="*"`, `par2`},
+			argsList{[]osutil.KernelArgument{{"par1", "*", true}, {"par2", "", false}}},
+			"",
+		},
+		{
+			[]string{`par1=*`, `par2`},
+			argsList{[]osutil.KernelArgument{{"par1", "*", false}, {"par2", "", false}}},
+			"",
+		},
+		{
+			[]string{`par1=val`, `par2=3[a-b]`, `par3=val`},
+			argsList{},
+			`\"3\[a-b\]\" contains globbing characters and is not quoted`,
+		},
+		{
+			[]string{`par=ab*`},
+			argsList{},
+			`\"ab\*\" contains globbing characters and is not quoted`,
+		},
+		{
+			[]string{`par=ab?`},
+			argsList{},
+			`\"ab\?\" contains globbing characters and is not quoted`,
+		},
+		{
+			[]string{`par=\a`},
+			argsList{},
+			`\"\\\\a\" contains globbing characters and is not quoted`,
+		},
+		{
+			[]string{`par="ab?g*[s-d]\q"`},
+			argsList{[]osutil.KernelArgument{{"par", `ab?g*[s-d]\q`, true}}},
+			"",
+		},
+	} {
+		c.Logf("%v, args: %v", idx, tc.args)
+		var args argsList
+		err := yaml.Unmarshal([]byte(buildYamlArgsList(tc.args)), &args)
+		if tc.errStr == "" {
+			c.Check(err, IsNil)
+			c.Check(args, DeepEquals, tc.exp)
+		} else {
+			c.Check(err, ErrorMatches, tc.errStr)
+		}
+	}
 }


### PR DESCRIPTION
Add support for gadget's kernel-cmdline stanza, only for the allow list for the moment.