### PR TITLE
o/configstate/configcore: missing apparmor mocking for non-aa hosts

### DIFF
--- a/overlord/configstate/configcore/homedirs_test.go
+++ b/overlord/configstate/configcore/homedirs_test.go
@@ -168,12 +168,16 @@ func (s *homedirsSuite) TestConfigureUnchangedConfig(c *C) {
 }
 
 func (s *homedirsSuite) TestConfigureApparmorTunableFailure(c *C) {
+	restore := apparmor.MockLevel(apparmor.Full)
+	defer restore()
+
 	var homedirs []string
-	restore := configcore.MockApparmorUpdateHomedirsTunable(func(paths []string) error {
+	restore = configcore.MockApparmorUpdateHomedirsTunable(func(paths []string) error {
 		homedirs = paths
 		return errors.New("tunable error")
 	})
 	defer restore()
+
 	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
 		changes: map[string]interface{}{
@@ -185,7 +189,10 @@ func (s *homedirsSuite) TestConfigureApparmorTunableFailure(c *C) {
 }
 
 func (s *homedirsSuite) TestConfigureApparmorReloadFailure(c *C) {
-	restore := configcore.MockApparmorReloadAllSnapProfiles(func() error {
+	restore := apparmor.MockLevel(apparmor.Full)
+	defer restore()
+
+	restore = configcore.MockApparmorReloadAllSnapProfiles(func() error {
 		return errors.New("reload error")
 	})
 	defer restore()
@@ -246,8 +253,11 @@ func (s *homedirsSuite) TestConfigureApparmorUnsupported(c *C) {
 }
 
 func (s *homedirsSuite) TestConfigureHomedirsHappy(c *C) {
+	restore := apparmor.MockLevel(apparmor.Full)
+	defer restore()
+
 	reloadProfilesCallCount := 0
-	restore := configcore.MockApparmorReloadAllSnapProfiles(func() error {
+	restore = configcore.MockApparmorReloadAllSnapProfiles(func() error {
 		reloadProfilesCallCount++
 		return nil
 	})

--- a/overlord/configstate/configcore/homedirs_test.go
+++ b/overlord/configstate/configcore/homedirs_test.go
@@ -74,6 +74,9 @@ func (s *homedirsSuite) SetUpTest(c *C) {
 		}
 	})
 	s.AddCleanup(restore)
+
+	// Mock full apparmor support by default for the tests here
+	s.AddCleanup(apparmor.MockLevel(apparmor.Full))
 }
 
 func (s *homedirsSuite) TestValidationUnhappy(c *C) {
@@ -168,11 +171,8 @@ func (s *homedirsSuite) TestConfigureUnchangedConfig(c *C) {
 }
 
 func (s *homedirsSuite) TestConfigureApparmorTunableFailure(c *C) {
-	restore := apparmor.MockLevel(apparmor.Full)
-	defer restore()
-
 	var homedirs []string
-	restore = configcore.MockApparmorUpdateHomedirsTunable(func(paths []string) error {
+	restore := configcore.MockApparmorUpdateHomedirsTunable(func(paths []string) error {
 		homedirs = paths
 		return errors.New("tunable error")
 	})
@@ -189,10 +189,7 @@ func (s *homedirsSuite) TestConfigureApparmorTunableFailure(c *C) {
 }
 
 func (s *homedirsSuite) TestConfigureApparmorReloadFailure(c *C) {
-	restore := apparmor.MockLevel(apparmor.Full)
-	defer restore()
-
-	restore = configcore.MockApparmorReloadAllSnapProfiles(func() error {
+	restore := configcore.MockApparmorReloadAllSnapProfiles(func() error {
 		return errors.New("reload error")
 	})
 	defer restore()
@@ -253,11 +250,8 @@ func (s *homedirsSuite) TestConfigureApparmorUnsupported(c *C) {
 }
 
 func (s *homedirsSuite) TestConfigureHomedirsHappy(c *C) {
-	restore := apparmor.MockLevel(apparmor.Full)
-	defer restore()
-
 	reloadProfilesCallCount := 0
-	restore = configcore.MockApparmorReloadAllSnapProfiles(func() error {
+	restore := configcore.MockApparmorReloadAllSnapProfiles(func() error {
 		reloadProfilesCallCount++
 		return nil
 	})


### PR DESCRIPTION
This lack of apparmor mocking made the launchpad builder fail. => https://launchpadlibrarian.net/649167600/buildlog_ubuntu-trusty-amd64.snapd_2.58.2~14.04+git4377.4e4abef0d~ubuntu14.04.1_BUILDING.txt.gz

My earlier PR touching the homedir code introduced this, as we now do an apparmor check, and if no apparmor is present, then homedir option acts as a no-op, and this messed up some of the unit tests when run on a host where no apparmor is supported.

Verified failing on Fedora 37 host, and they pass with this PR.