### PR TITLE
image,store: ensure to fetch assertions appropriate for the snapd in the image

### DIFF
--- a/image/preseed/preseed_uc20_test.go
+++ b/image/preseed/preseed_uc20_test.go
@@ -78,6 +78,10 @@ func (s *toolingStore) Assertion(assertType *asserts.AssertionType, primaryKey [
 	return as, nil
 }
 
+func (s *toolingStore) SetAssertionMaxFormats(maxFormats map[string]int) {
+	panic("not implemented")
+}
+
 // list of test overlays
 var sysFsOverlaysGood = []string{"class/backlight", "class/bluetooth", "class/gpio", "class/leds", "class/ptp", "class/pwm", "class/rtc", "class/video4linux", "devices/platform", "devices/pci0000:00"}
 

--- a/store/tooling/tooling_test.go
+++ b/store/tooling/tooling_test.go
@@ -57,6 +57,8 @@ type toolingSuite struct {
 	storeActions           []*store.SnapAction
 	curSnaps               [][]*store.CurrentSnap
 
+	assertMaxFormats map[string]int
+
 	tsto *tooling.ToolingStore
 
 	// SeedSnaps helps creating and making available seed snaps
@@ -391,6 +393,21 @@ func (s *toolingSuite) TestDownloadSnap(c *C) {
 	c.Check(logbuf.String(), Matches, `.* DEBUG: Going to download snap "core" `+opts.String()+".\n")
 }
 
+func (s *toolingSuite) TestSetAssertionMaxFormats(c *C) {
+	c.Check(s.tsto.AssertionMaxFormats(), IsNil)
+
+	m := map[string]int{
+		"snap-declaration": 4,
+	}
+	s.tsto.SetAssertionMaxFormats(m)
+	c.Check(s.tsto.AssertionMaxFormats(), DeepEquals, m)
+	c.Check(s.assertMaxFormats, DeepEquals, m)
+
+	s.tsto.SetAssertionMaxFormats(nil)
+	c.Check(s.tsto.AssertionMaxFormats(), IsNil)
+	c.Check(s.assertMaxFormats, IsNil)
+}
+
 // interface for the store
 func (s *toolingSuite) SnapAction(_ context.Context, curSnaps []*store.CurrentSnap, actions []*store.SnapAction, assertQuery store.AssertionQuery, _ *auth.UserState, _ *store.RefreshOptions) ([]store.SnapActionResult, []store.AssertionResult, error) {
 	if assertQuery != nil {
@@ -434,6 +451,10 @@ func (s *toolingSuite) SnapAction(_ context.Context, curSnaps []*store.CurrentSn
 
 func (s *toolingSuite) Download(ctx context.Context, name, targetFn string, downloadInfo *snap.DownloadInfo, pbar progress.Meter, user *auth.UserState, dlOpts *store.DownloadOptions) error {
 	return osutil.CopyFile(s.AssertedSnap(name), targetFn, 0)
+}
+
+func (s *toolingSuite) SetAssertionMaxFormats(m map[string]int) {
+	s.assertMaxFormats = m
 }
 
 func (s *toolingSuite) Assertion(assertType *asserts.AssertionType, primaryKey []string, user *auth.UserState) (asserts.Assertion, error) {


### PR DESCRIPTION
this fetches assertions using the right assertion max formats based
on what is supported by the snapd from the system snap going into the image

a later PR will do as best effort to take the kernel into account as well for UC20+