### PR TITLE
interfaces/network-manager: do not show ptrace read denials

### DIFF
--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -286,7 +286,7 @@ dbus (receive, send)
 # internal process addresses that live in that file, but that has no adverse
 # effects for NetworkManager, which just wants to find out the start time of the
 # process.
-deny ptrace (trace) peer=###PLUG_SECURITY_TAGS###,
+deny ptrace (trace,read) peer=###PLUG_SECURITY_TAGS###,
 `
 
 const networkManagerConnectedPlugAppArmor = `


### PR DESCRIPTION
Some kernels/network-manager versions produce read instead of trace denials, see LP: #1980119. For reference, see [1].

[1] https://gitlab.com/apparmor/apparmor/-/wikis/TechnicalDoc_Proc_and_ptrace#apparmor-3-with-ptrace-rules