### PR TITLE
boot: on classic+modes `MarkBootSuccessfull` does not need a base (2.58)

### DIFF
--- a/boot/boot.go
+++ b/boot/boot.go
@@ -364,6 +364,9 @@ func MarkBootSuccessful(dev snap.Device) error {
 
 	var u bootStateUpdate
 	for _, t := range []snap.Type{snap.TypeBase, snap.TypeKernel} {
+		if !SnapTypeParticipatesInBoot(t, dev) {
+			continue
+		}
 		s, err := bootStateFor(t, dev)
 		if err != nil {
 			return err

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -5221,3 +5221,35 @@ func (s *bootenv20Suite) TestCoreParticipant20UndoBaseSnapInstallNewNoReseal(c *
 	// no reseal
 	c.Check(resealCalls, Equals, 0)
 }
+
+func (s *bootenv20Suite) TestMarkBootSuccessfulClassModes(c *C) {
+	// MarkBootSuccessful on classic+modes will not have a "base"
+	// in the modeenv
+	m := &boot.Modeenv{
+		Mode:           "run",
+		CurrentKernels: []string{s.kern1.Filename()},
+	}
+	r := setupUC20Bootenv(
+		c,
+		s.bootloader,
+		&bootenv20Setup{
+			modeenv:    m,
+			kern:       s.kern1,
+			kernStatus: boot.DefaultStatus,
+		},
+	)
+	defer r()
+
+	classicWithModesDev := boottest.MockClassicWithModesDevice("", nil)
+	c.Assert(classicWithModesDev.HasModeenv(), Equals, true)
+
+	// mark successful
+	err := boot.MarkBootSuccessful(classicWithModesDev)
+	c.Assert(err, IsNil)
+
+	// no error, modeenv is unchanged
+	m2, err := boot.ReadModeenv("")
+	c.Assert(err, IsNil)
+	c.Check(m2.Base, Equals, "")
+	c.Check(m2.TryBase, Equals, "")
+}


### PR DESCRIPTION
This commit fixes a a bug in master that will prevent `MarkBootSuccessful` from working. The issue is that on classic+modes the modeenv no longer contains a `base=` field but the MarkBootSuccessful code will fail if it is missing. This results in a system that never marks the boot as successful on classic+modes.

This is https://github.com/snapcore/snapd/pull/12549 for 2.58
