### PR TITLE
o/snapstate: mk pre-download tasks if running snap blocks autorefresh

### DIFF
--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -3958,14 +3958,10 @@ assumes: [something-that-is-not-provided]
 	// updateMany will just skip snaps with assumes but not error
 	affected, tss, err := snapstate.UpdateMany(context.TODO(), st, nil, nil, 0, nil)
 	c.Assert(err, IsNil)
+	c.Check(tss, HasLen, 0)
 	c.Check(affected, HasLen, 0)
 	// the skipping is logged though
 	c.Check(s.logbuf.String(), testutil.Contains, `cannot update "some-snap": snap "some-snap" assumes unsupported features: something-that-is-not-provided (try`)
-	// XXX: should we really check for re-refreshes if there is nothing
-	// to update?
-	c.Check(tss, HasLen, 1)
-	c.Check(tss[0].Tasks(), HasLen, 1)
-	c.Check(tss[0].Tasks()[0].Kind(), Equals, "check-rerefresh")
 }
 
 type storeCtxSetupSuite struct {

--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -515,7 +515,7 @@ func (m *autoRefresh) launchAutoRefresh() error {
 	m.lastRefreshAttempt = time.Now()
 
 	// NOTE: this will unlock and re-lock state for network ops
-	updated, tasksetGroup, err := AutoRefresh(auth.EnsureContextTODO(), m.state)
+	updated, updateTss, err := AutoRefresh(auth.EnsureContextTODO(), m.state)
 
 	// TODO: we should have some way to lock just creating and starting changes,
 	//       as that would alleviate this race condition we are guarding against
@@ -546,14 +546,14 @@ func (m *autoRefresh) launchAutoRefresh() error {
 		return err
 	}
 
-	if len(tasksetGroup.PreDownload) > 0 {
+	if len(updateTss.PreDownload) > 0 {
 		chg := m.state.NewChange("pre-download", i18n.G("Pre-download tasks for auto-refresh"))
-		for _, ts := range tasksetGroup.PreDownload {
+		for _, ts := range updateTss.PreDownload {
 			chg.AddAll(ts)
 		}
 	}
 
-	if len(tasksetGroup.Refresh) == 0 {
+	if len(updateTss.Refresh) == 0 {
 		return nil
 	}
 
@@ -564,7 +564,7 @@ func (m *autoRefresh) launchAutoRefresh() error {
 	}
 
 	chg := m.state.NewChange("auto-refresh", msg)
-	for _, ts := range tasksetGroup.Refresh {
+	for _, ts := range updateTss.Refresh {
 		chg.AddAll(ts)
 	}
 	chg.Set("snap-names", updated)

--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -546,12 +546,7 @@ func (m *autoRefresh) launchAutoRefresh() error {
 		return err
 	}
 
-	if len(updateTss.PreDownload) > 0 {
-		chg := m.state.NewChange("pre-download", i18n.G("Pre-download tasks for auto-refresh"))
-		for _, ts := range updateTss.PreDownload {
-			chg.AddAll(ts)
-		}
-	}
+	createPreDownloadChange(m.state, updateTss)
 
 	if len(updateTss.Refresh) == 0 {
 		return nil
@@ -572,6 +567,19 @@ func (m *autoRefresh) launchAutoRefresh() error {
 	state.TagTimingsWithChange(perfTimings, chg)
 
 	return nil
+}
+
+// createPreDownloadChange creates a pre-download change if any relevant tasksets
+// exist in the UpdateTaskSets and returns whether or not a change was created.
+func createPreDownloadChange(st *state.State, updateTss *UpdateTaskSets) bool {
+	if updateTss != nil && len(updateTss.PreDownload) > 0 {
+		preDlChg := st.NewChange("pre-download", i18n.G("Pre-download tasks for auto-refresh"))
+		for _, ts := range updateTss.PreDownload {
+			preDlChg.AddAll(ts)
+		}
+		return true
+	}
+	return false
 }
 
 func autoRefreshInFlight(st *state.State) bool {

--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -515,7 +515,7 @@ func (m *autoRefresh) launchAutoRefresh() error {
 	m.lastRefreshAttempt = time.Now()
 
 	// NOTE: this will unlock and re-lock state for network ops
-	updated, tasksets, err := AutoRefresh(auth.EnsureContextTODO(), m.state)
+	updated, tasksetGroup, err := AutoRefresh(auth.EnsureContextTODO(), m.state)
 
 	// TODO: we should have some way to lock just creating and starting changes,
 	//       as that would alleviate this race condition we are guarding against
@@ -546,6 +546,17 @@ func (m *autoRefresh) launchAutoRefresh() error {
 		return err
 	}
 
+	if len(tasksetGroup.PreDownload) > 0 {
+		chg := m.state.NewChange("pre-download", i18n.G("Pre-download tasks for auto-refresh"))
+		for _, ts := range tasksetGroup.PreDownload {
+			chg.AddAll(ts)
+		}
+	}
+
+	if len(tasksetGroup.Refresh) == 0 {
+		return nil
+	}
+
 	msg := autoRefreshSummary(updated)
 	if msg == "" {
 		logger.Noticef(i18n.G("auto-refresh: all snaps are up-to-date"))
@@ -553,7 +564,7 @@ func (m *autoRefresh) launchAutoRefresh() error {
 	}
 
 	chg := m.state.NewChange("auto-refresh", msg)
-	for _, ts := range tasksets {
+	for _, ts := range tasksetGroup.Refresh {
 		chg.AddAll(ts)
 	}
 	chg.Set("snap-names", updated)
@@ -594,6 +605,26 @@ var asyncPendingRefreshNotification = func(context context.Context, client *user
 	}()
 }
 
+type timedBusySnapError struct {
+	err           *BusySnapError
+	timeRemaining time.Duration
+}
+
+func (e *timedBusySnapError) PendingSnapRefreshInfo() *userclient.PendingSnapRefreshInfo {
+	refreshInfo := e.err.PendingSnapRefreshInfo()
+	refreshInfo.TimeRemaining = e.timeRemaining
+	return refreshInfo
+}
+
+func (e *timedBusySnapError) Error() string {
+	return e.err.Error()
+}
+
+func (e *timedBusySnapError) Is(err error) bool {
+	_, ok := err.(*timedBusySnapError)
+	return ok
+}
+
 // inhibitRefresh returns an error if refresh is inhibited by running apps.
 //
 // Internally the snap state is updated to remember when the inhibition first
@@ -605,14 +636,13 @@ func inhibitRefresh(st *state.State, snapst *SnapState, snapsup *SnapSetup, info
 		return nil
 	}
 
-	// Get pending refresh information from compatible errors or synthesize a new one.
-	var refreshInfo *userclient.PendingSnapRefreshInfo
-	if err, ok := checkerErr.(*BusySnapError); ok {
-		refreshInfo = err.PendingSnapRefreshInfo()
-	} else {
-		refreshInfo = &userclient.PendingSnapRefreshInfo{
-			InstanceName: info.InstanceName(),
-		}
+	// carries the remaining inhibition time along with the BusySnapError
+	busyErr := &timedBusySnapError{}
+
+	// if it's not a snap busy error or the refresh is manual, surface the error
+	// to the user instead of notifying or delaying the refresh
+	if !snapsup.IsAutoRefresh || !errors.As(checkerErr, &busyErr.err) {
+		return checkerErr
 	}
 
 	// Decide on what to do depending on the state of the snap and the remaining
@@ -625,29 +655,23 @@ func inhibitRefresh(st *state.State, snapst *SnapState, snapsup *SnapSetup, info
 		// time in the snap state's RefreshInhibitedTime field. This field is
 		// reset to nil on successful refresh.
 		snapst.RefreshInhibitedTime = &now
-		refreshInfo.TimeRemaining = (maxInhibition - now.Sub(*snapst.RefreshInhibitedTime)).Truncate(time.Second)
+		busyErr.timeRemaining = (maxInhibition - now.Sub(*snapst.RefreshInhibitedTime)).Truncate(time.Second)
 		Set(st, info.InstanceName(), snapst)
 	case now.Sub(*snapst.RefreshInhibitedTime) < maxInhibition:
 		// If we are still in the allowed window then just return the error but
 		// don't change the snap state again.
 		// TODO: as time left shrinks, send additional notifications with
 		// increasing frequency, allowing the user to understand the urgency.
-		refreshInfo.TimeRemaining = (maxInhibition - now.Sub(*snapst.RefreshInhibitedTime)).Truncate(time.Second)
+		busyErr.timeRemaining = (maxInhibition - now.Sub(*snapst.RefreshInhibitedTime)).Truncate(time.Second)
 	default:
-		// If we run out of time then consume the error that would normally
-		// inhibit refresh and notify the user that the snap is refreshing right
-		// now, by not setting the TimeRemaining field of the refresh
-		// notification message.
-		checkerErr = nil
-	}
-
-	// if the refresh is manual the error message already carries the information so don't notify
-	if snapsup.IsAutoRefresh {
-		// Send the notification asynchronously to avoid holding the state lock.
+		// if the refresh inhibition window has ended, notify the user that the
+		// refresh is happening now and ignore the error
+		refreshInfo := busyErr.PendingSnapRefreshInfo()
 		asyncPendingRefreshNotification(context.TODO(), userclient.New(), refreshInfo)
+		busyErr = nil
 	}
 
-	return checkerErr
+	return busyErr
 }
 
 // for testing outside of snapstate

--- a/overlord/snapstate/autorefresh_gating_test.go
+++ b/overlord/snapstate/autorefresh_gating_test.go
@@ -1417,9 +1417,9 @@ func (s *autorefreshGatingSuite) TestAutorefreshPhase1FeatureFlag(c *C) {
 	mockInstalledSnap(c, s.state, snapAyaml, useHook)
 
 	// gate-auto-refresh-hook feature not enabled, expect old-style refresh.
-	_, tssGroup, err := snapstate.AutoRefresh(context.TODO(), st)
+	_, updateTss, err := snapstate.AutoRefresh(context.TODO(), st)
 	c.Check(err, IsNil)
-	tss := tssGroup.Refresh
+	tss := updateTss.Refresh
 	c.Assert(tss, HasLen, 2)
 	c.Check(tss[0].Tasks()[0].Kind(), Equals, "prerequisites")
 	c.Check(tss[0].Tasks()[1].Kind(), Equals, "download-snap")
@@ -1430,9 +1430,9 @@ func (s *autorefreshGatingSuite) TestAutorefreshPhase1FeatureFlag(c *C) {
 	tr.Set("core", "experimental.gate-auto-refresh-hook", true)
 	tr.Commit()
 
-	_, tssGroup, err = snapstate.AutoRefresh(context.TODO(), st)
+	_, updateTss, err = snapstate.AutoRefresh(context.TODO(), st)
 	c.Check(err, IsNil)
-	tss = tssGroup.Refresh
+	tss = updateTss.Refresh
 	c.Assert(tss, HasLen, 2)
 	task := tss[0].Tasks()[0]
 	c.Check(task.Kind(), Equals, "conditional-auto-refresh")

--- a/overlord/snapstate/autorefresh_gating_test.go
+++ b/overlord/snapstate/autorefresh_gating_test.go
@@ -1417,8 +1417,9 @@ func (s *autorefreshGatingSuite) TestAutorefreshPhase1FeatureFlag(c *C) {
 	mockInstalledSnap(c, s.state, snapAyaml, useHook)
 
 	// gate-auto-refresh-hook feature not enabled, expect old-style refresh.
-	_, tss, err := snapstate.AutoRefresh(context.TODO(), st)
+	_, tssGroup, err := snapstate.AutoRefresh(context.TODO(), st)
 	c.Check(err, IsNil)
+	tss := tssGroup.Refresh
 	c.Assert(tss, HasLen, 2)
 	c.Check(tss[0].Tasks()[0].Kind(), Equals, "prerequisites")
 	c.Check(tss[0].Tasks()[1].Kind(), Equals, "download-snap")
@@ -1429,8 +1430,9 @@ func (s *autorefreshGatingSuite) TestAutorefreshPhase1FeatureFlag(c *C) {
 	tr.Set("core", "experimental.gate-auto-refresh-hook", true)
 	tr.Commit()
 
-	_, tss, err = snapstate.AutoRefresh(context.TODO(), st)
+	_, tssGroup, err = snapstate.AutoRefresh(context.TODO(), st)
 	c.Check(err, IsNil)
+	tss = tssGroup.Refresh
 	c.Assert(tss, HasLen, 2)
 	task := tss[0].Tasks()[0]
 	c.Check(task.Kind(), Equals, "conditional-auto-refresh")

--- a/overlord/snapstate/conflict.go
+++ b/overlord/snapstate/conflict.go
@@ -184,7 +184,9 @@ func CheckChangeConflictMany(st *state.State, instanceNames []string, ignoreChan
 		}
 		switch chg.Kind() {
 		case "pre-download":
-			// pre-download tasks don't produce conflicts
+			// pre-download changes only have pre-download tasks which don't generate
+			// conflicts because they only download the snap and download tasks check
+			// for them explicitly
 			fallthrough
 		case "become-operational":
 			// become-operational will be retried until success

--- a/overlord/snapstate/conflict.go
+++ b/overlord/snapstate/conflict.go
@@ -182,7 +182,11 @@ func CheckChangeConflictMany(st *state.State, instanceNames []string, ignoreChan
 		if ignoreChangeID != "" && chg.ID() == ignoreChangeID {
 			continue
 		}
-		if chg.Kind() == "become-operational" {
+		switch chg.Kind() {
+		case "pre-download":
+			// pre-download tasks don't produce conflicts
+			fallthrough
+		case "become-operational":
 			// become-operational will be retried until success
 			// and on its own just runs a hook on gadget:
 			// do not make it interfere with user requests

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -240,7 +240,7 @@ var (
 
 type UpdateFilter = updateFilter
 
-func MockReRefreshUpdateMany(f func(context.Context, *state.State, []string, []*RevisionOptions, int, UpdateFilter, *Flags, string) ([]string, []*state.TaskSet, error)) (restore func()) {
+func MockReRefreshUpdateMany(f func(context.Context, *state.State, []string, []*RevisionOptions, int, UpdateFilter, *Flags, string) ([]string, *TaskSetGroup, error)) (restore func()) {
 	old := reRefreshUpdateMany
 	reRefreshUpdateMany = f
 	return func() {
@@ -323,6 +323,7 @@ var (
 )
 
 type RefreshCandidate = refreshCandidate
+type TimedBusySnapError = timedBusySnapError
 
 func NewBusySnapError(info *snap.Info, pids []int, busyAppNames, busyHookNames []string) *BusySnapError {
 	return &BusySnapError{

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -41,6 +41,8 @@ type (
 	ByType              = byType
 	DirMigrationOptions = dirMigrationOptions
 	Migration           = migration
+
+	ReRefreshSetup = reRefreshSetup
 )
 
 const (

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -240,7 +240,7 @@ var (
 
 type UpdateFilter = updateFilter
 
-func MockReRefreshUpdateMany(f func(context.Context, *state.State, []string, []*RevisionOptions, int, UpdateFilter, *Flags, string) ([]string, *TaskSetGroup, error)) (restore func()) {
+func MockReRefreshUpdateMany(f func(context.Context, *state.State, []string, []*RevisionOptions, int, UpdateFilter, *Flags, string) ([]string, *UpdateTaskSets, error)) (restore func()) {
 	old := reRefreshUpdateMany
 	reRefreshUpdateMany = f
 	return func() {

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -3706,7 +3706,7 @@ func (m *SnapManager) doCheckReRefresh(t *state.Task, tomb *tomb.Tomb) error {
 		return err
 	}
 
-	updated, tasksets, err := reRefreshUpdateMany(tomb.Context(nil), st, snaps, nil, re.UserID, reRefreshFilter, re.Flags, chg.ID())
+	updated, tasksetGroup, err := reRefreshUpdateMany(tomb.Context(nil), st, snaps, nil, re.UserID, reRefreshFilter, re.Flags, chg.ID())
 	if err != nil {
 		return err
 	}
@@ -3716,7 +3716,7 @@ func (m *SnapManager) doCheckReRefresh(t *state.Task, tomb *tomb.Tomb) error {
 	} else {
 		t.Logf("Found re-refresh for %s.", strutil.Quoted(updated))
 
-		for _, taskset := range tasksets {
+		for _, taskset := range tasksetGroup.Refresh {
 			chg.AddAll(taskset)
 		}
 		st.EnsureBefore(0)
@@ -3741,28 +3741,37 @@ func (m *SnapManager) doConditionalAutoRefresh(t *state.Task, tomb *tomb.Tomb) e
 		return nil
 	}
 
-	tss, err := autoRefreshPhase2(context.TODO(), st, snaps, t.Change().ID())
+	tssGroup, err := autoRefreshPhase2(context.TODO(), st, snaps, t.Change().ID())
 	if err != nil {
 		return err
 	}
 
-	// update the map of refreshed snaps on the task, this affects
-	// conflict checks (we don't want to conflict on snaps that were held and
-	// won't be refreshed) -  see conditionalAutoRefreshAffectedSnaps().
-	newToUpdate := make(map[string]*refreshCandidate, len(snaps))
-	for _, candidate := range snaps {
-		newToUpdate[candidate.InstanceName()] = candidate
+	if tssGroup.PreDownload != nil {
+		chg := m.state.NewChange("pre-download", i18n.G("Pre-download tasks for auto-refresh"))
+		for _, ts := range tssGroup.PreDownload {
+			chg.AddAll(ts)
+		}
 	}
-	t.Set("snaps", newToUpdate)
 
-	// update original auto-refresh change
-	chg := t.Change()
-	for _, ts := range tss {
-		ts.WaitFor(t)
-		chg.AddAll(ts)
+	if tssGroup.Refresh != nil {
+		// update the map of refreshed snaps on the task, this affects
+		// conflict checks (we don't want to conflict on snaps that were held and
+		// won't be refreshed) -  see conditionalAutoRefreshAffectedSnaps().
+		newToUpdate := make(map[string]*refreshCandidate, len(snaps))
+		for _, candidate := range snaps {
+			newToUpdate[candidate.InstanceName()] = candidate
+		}
+		t.Set("snaps", newToUpdate)
+
+		// update original auto-refresh change
+		chg := t.Change()
+		for _, ts := range tssGroup.Refresh {
+			ts.WaitFor(t)
+			chg.AddAll(ts)
+		}
 	}
+
 	t.SetStatus(state.DoneStatus)
-
 	st.EnsureBefore(0)
 	return nil
 }

--- a/overlord/snapstate/handlers_rerefresh_test.go
+++ b/overlord/snapstate/handlers_rerefresh_test.go
@@ -80,7 +80,7 @@ func (s *reRefreshSuite) TestDoCheckReRefreshFailsWithoutReRefreshSetup(c *C) {
 }
 
 func (s *reRefreshSuite) TestDoCheckReRefreshFailsIfUpdateFails(c *C) {
-	defer snapstate.MockReRefreshUpdateMany(func(context.Context, *state.State, []string, []*snapstate.RevisionOptions, int, snapstate.UpdateFilter, *snapstate.Flags, string) ([]string, *snapstate.TaskSetGroup, error) {
+	defer snapstate.MockReRefreshUpdateMany(func(context.Context, *state.State, []string, []*snapstate.RevisionOptions, int, snapstate.UpdateFilter, *snapstate.Flags, string) ([]string, *snapstate.UpdateTaskSets, error) {
 		return nil, nil, errors.New("bzzt")
 	})()
 
@@ -103,7 +103,7 @@ func (s *reRefreshSuite) TestDoCheckReRefreshFailsIfUpdateFails(c *C) {
 
 func (s *reRefreshSuite) TestDoCheckReRefreshNoReRefreshes(c *C) {
 	updaterCalled := false
-	defer snapstate.MockReRefreshUpdateMany(func(context.Context, *state.State, []string, []*snapstate.RevisionOptions, int, snapstate.UpdateFilter, *snapstate.Flags, string) ([]string, *snapstate.TaskSetGroup, error) {
+	defer snapstate.MockReRefreshUpdateMany(func(context.Context, *state.State, []string, []*snapstate.RevisionOptions, int, snapstate.UpdateFilter, *snapstate.Flags, string) ([]string, *snapstate.UpdateTaskSets, error) {
 		updaterCalled = true
 		return nil, nil, nil
 	})()
@@ -128,7 +128,7 @@ func (s *reRefreshSuite) TestDoCheckReRefreshNoReRefreshes(c *C) {
 
 func (s *reRefreshSuite) TestDoCheckReRefreshPassesReRefreshSetupData(c *C) {
 	var chgID string
-	defer snapstate.MockReRefreshUpdateMany(func(_ context.Context, _ *state.State, snaps []string, _ []*snapstate.RevisionOptions, userID int, _ snapstate.UpdateFilter, flags *snapstate.Flags, changeID string) ([]string, *snapstate.TaskSetGroup, error) {
+	defer snapstate.MockReRefreshUpdateMany(func(_ context.Context, _ *state.State, snaps []string, _ []*snapstate.RevisionOptions, userID int, _ snapstate.UpdateFilter, flags *snapstate.Flags, changeID string) ([]string, *snapstate.UpdateTaskSets, error) {
 		c.Check(changeID, Equals, chgID)
 		expected := []string{"won", "too", "tree"}
 		sort.Strings(expected)
@@ -165,7 +165,7 @@ func (s *reRefreshSuite) TestDoCheckReRefreshPassesReRefreshSetupData(c *C) {
 }
 
 func (s *reRefreshSuite) TestDoCheckReRefreshAddsNewTasks(c *C) {
-	defer snapstate.MockReRefreshUpdateMany(func(_ context.Context, st *state.State, snaps []string, _ []*snapstate.RevisionOptions, _ int, _ snapstate.UpdateFilter, _ *snapstate.Flags, _ string) ([]string, *snapstate.TaskSetGroup, error) {
+	defer snapstate.MockReRefreshUpdateMany(func(_ context.Context, st *state.State, snaps []string, _ []*snapstate.RevisionOptions, _ int, _ snapstate.UpdateFilter, _ *snapstate.Flags, _ string) ([]string, *snapstate.UpdateTaskSets, error) {
 		expected := []string{"won", "too", "tree"}
 		sort.Strings(expected)
 		sort.Strings(snaps)
@@ -173,7 +173,7 @@ func (s *reRefreshSuite) TestDoCheckReRefreshAddsNewTasks(c *C) {
 
 		task := st.NewTask("witness", "...")
 
-		tasksetGrp := &snapstate.TaskSetGroup{Refresh: []*state.TaskSet{state.NewTaskSet(task)}}
+		tasksetGrp := &snapstate.UpdateTaskSets{Refresh: []*state.TaskSet{state.NewTaskSet(task)}}
 		return []string{"won"}, tasksetGrp, nil
 	})()
 

--- a/overlord/snapstate/handlers_rerefresh_test.go
+++ b/overlord/snapstate/handlers_rerefresh_test.go
@@ -80,7 +80,7 @@ func (s *reRefreshSuite) TestDoCheckReRefreshFailsWithoutReRefreshSetup(c *C) {
 }
 
 func (s *reRefreshSuite) TestDoCheckReRefreshFailsIfUpdateFails(c *C) {
-	defer snapstate.MockReRefreshUpdateMany(func(context.Context, *state.State, []string, []*snapstate.RevisionOptions, int, snapstate.UpdateFilter, *snapstate.Flags, string) ([]string, []*state.TaskSet, error) {
+	defer snapstate.MockReRefreshUpdateMany(func(context.Context, *state.State, []string, []*snapstate.RevisionOptions, int, snapstate.UpdateFilter, *snapstate.Flags, string) ([]string, *snapstate.TaskSetGroup, error) {
 		return nil, nil, errors.New("bzzt")
 	})()
 
@@ -103,7 +103,7 @@ func (s *reRefreshSuite) TestDoCheckReRefreshFailsIfUpdateFails(c *C) {
 
 func (s *reRefreshSuite) TestDoCheckReRefreshNoReRefreshes(c *C) {
 	updaterCalled := false
-	defer snapstate.MockReRefreshUpdateMany(func(context.Context, *state.State, []string, []*snapstate.RevisionOptions, int, snapstate.UpdateFilter, *snapstate.Flags, string) ([]string, []*state.TaskSet, error) {
+	defer snapstate.MockReRefreshUpdateMany(func(context.Context, *state.State, []string, []*snapstate.RevisionOptions, int, snapstate.UpdateFilter, *snapstate.Flags, string) ([]string, *snapstate.TaskSetGroup, error) {
 		updaterCalled = true
 		return nil, nil, nil
 	})()
@@ -128,7 +128,7 @@ func (s *reRefreshSuite) TestDoCheckReRefreshNoReRefreshes(c *C) {
 
 func (s *reRefreshSuite) TestDoCheckReRefreshPassesReRefreshSetupData(c *C) {
 	var chgID string
-	defer snapstate.MockReRefreshUpdateMany(func(_ context.Context, _ *state.State, snaps []string, _ []*snapstate.RevisionOptions, userID int, _ snapstate.UpdateFilter, flags *snapstate.Flags, changeID string) ([]string, []*state.TaskSet, error) {
+	defer snapstate.MockReRefreshUpdateMany(func(_ context.Context, _ *state.State, snaps []string, _ []*snapstate.RevisionOptions, userID int, _ snapstate.UpdateFilter, flags *snapstate.Flags, changeID string) ([]string, *snapstate.TaskSetGroup, error) {
 		c.Check(changeID, Equals, chgID)
 		expected := []string{"won", "too", "tree"}
 		sort.Strings(expected)
@@ -165,7 +165,7 @@ func (s *reRefreshSuite) TestDoCheckReRefreshPassesReRefreshSetupData(c *C) {
 }
 
 func (s *reRefreshSuite) TestDoCheckReRefreshAddsNewTasks(c *C) {
-	defer snapstate.MockReRefreshUpdateMany(func(_ context.Context, st *state.State, snaps []string, _ []*snapstate.RevisionOptions, _ int, _ snapstate.UpdateFilter, _ *snapstate.Flags, _ string) ([]string, []*state.TaskSet, error) {
+	defer snapstate.MockReRefreshUpdateMany(func(_ context.Context, st *state.State, snaps []string, _ []*snapstate.RevisionOptions, _ int, _ snapstate.UpdateFilter, _ *snapstate.Flags, _ string) ([]string, *snapstate.TaskSetGroup, error) {
 		expected := []string{"won", "too", "tree"}
 		sort.Strings(expected)
 		sort.Strings(snaps)
@@ -173,7 +173,8 @@ func (s *reRefreshSuite) TestDoCheckReRefreshAddsNewTasks(c *C) {
 
 		task := st.NewTask("witness", "...")
 
-		return []string{"won"}, []*state.TaskSet{state.NewTaskSet(task)}, nil
+		tasksetGrp := &snapstate.TaskSetGroup{Refresh: []*state.TaskSet{state.NewTaskSet(task)}}
+		return []string{"won"}, tasksetGrp, nil
 	})()
 
 	s.state.Lock()

--- a/overlord/snapstate/progress.go
+++ b/overlord/snapstate/progress.go
@@ -43,7 +43,7 @@ func NewTaskProgressAdapterUnlocked(t *state.Task) progress.Meter {
 	return &taskProgressAdapter{task: t, unlocked: true}
 }
 
-// NewTaskProgressAdapterUnlocked creates an adapter of the task into a progress.Meter to use while the state is locked
+// NewTaskProgressAdapterLocked creates an adapter of the task into a progress.Meter to use while the state is locked
 func NewTaskProgressAdapterLocked(t *state.Task) progress.Meter {
 	return &taskProgressAdapter{task: t, unlocked: false}
 }

--- a/overlord/snapstate/refresh.go
+++ b/overlord/snapstate/refresh.go
@@ -140,6 +140,11 @@ func (err *BusySnapError) Error() string {
 	}
 }
 
+func (*BusySnapError) Is(err error) bool {
+	_, ok := err.(*BusySnapError)
+	return ok
+}
+
 // Pids returns the set of process identifiers that are running.
 //
 // Since this list is a snapshot it should be only acted upon if there is an

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -2348,7 +2348,7 @@ func UpdateWithDeviceContext(st *state.State, name string, opts *RevisionOptions
 		return nil, err
 	}
 
-	// pre-download tasksets are only used for auto-refreshes
+	// only auto-refreshes can generate pre-download tasks so we don't need to check them
 	tts := updateTss.Refresh
 
 	// see if we need to switch the channel or cohort, or toggle ignore-validation
@@ -2665,7 +2665,7 @@ func autoRefreshPhase2(ctx context.Context, st *state.State, updates []*refreshC
 		return nil, err
 	}
 
-	// pre-download tasksets are only used for auto-refreshes
+	// only auto-refreshes can generate pre-download tasks so we don't need to check them
 	if len(updateTss.Refresh) > 0 {
 		updateTss.Refresh = finalizeUpdate(st, updateTss.Refresh, len(updates) > 0, updated, userID, flags)
 	}

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -358,6 +358,10 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 		return nil, err
 	}
 
+	targetRevision := snapsup.Revision()
+	revisionStr := fmt.Sprintf(" (%s)", snapsup.Revision())
+
+	ts := state.NewTaskSet()
 	if snapst.IsInstalled() {
 		// consider also the current revision to set plugs-only hint
 		info, err := snapst.CurrentInfo()
@@ -371,6 +375,30 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 			// softCheckNothingRunningForRefresh, this block must be located
 			// after the conflict check done above.
 			if err := softCheckNothingRunningForRefresh(st, snapst, snapsup, info); err != nil {
+				// snap is running; schedule its downloading before notifying to close
+				var busyErr *timedBusySnapError
+				if errors.As(err, &busyErr) && snapsup.IsAutoRefresh {
+					tasks, err := findTasksMatching(st, "pre-download-snap", snapsup.InstanceName(), snapsup.Revision())
+					if err != nil {
+						return nil, err
+					}
+
+					for _, task := range tasks {
+						switch task.Status() {
+						case state.DoStatus, state.DoneStatus, state.DoingStatus:
+							// there's already a task for this snap/revision combination
+							return nil, busyErr
+						}
+					}
+
+					preDownTask := st.NewTask("pre-download-snap", fmt.Sprintf(i18n.G("Pre-download snap %q%s from channel %q"), snapsup.InstanceName(), revisionStr, snapsup.Channel))
+					preDownTask.Set("snap-setup", snapsup)
+					preDownTask.Set("refresh-info", busyErr.PendingSnapRefreshInfo())
+
+					ts.AddTask(preDownTask)
+					return ts, busyErr
+				}
+
 				return nil, err
 			}
 		}
@@ -381,14 +409,6 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 				return nil, err
 			}
 		}
-	}
-
-	ts := state.NewTaskSet()
-
-	targetRevision := snapsup.Revision()
-	revisionStr := ""
-	if snapsup.SideInfo != nil {
-		revisionStr = fmt.Sprintf(" (%s)", targetRevision)
 	}
 
 	// check if we already have the revision locally (alters tasks)
@@ -663,6 +683,26 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 	ts.AddTask(healthCheck)
 
 	return ts, nil
+}
+
+func findTasksMatching(st *state.State, kind string, snapName string, revision snap.Revision) ([]*state.Task, error) {
+	var tasks []*state.Task
+	for _, t := range st.Tasks() {
+		if t.Kind() != kind {
+			continue
+		}
+
+		snapsup, _, err := snapSetupAndState(t)
+		if err != nil {
+			return nil, err
+		}
+
+		if snapsup.InstanceName() == snapName && snapsup.Revision() == revision {
+			tasks = append(tasks, t)
+		}
+	}
+
+	return tasks, nil
 }
 
 // ConfigureSnap returns a set of tasks to configure snapName as done during installation/refresh.
@@ -1279,12 +1319,12 @@ func InstallPathMany(ctx context.Context, st *state.State, sideInfos []*snap.Sid
 		return nil, flagsByInstanceName[name], stateByInstanceName[name]
 	}
 
-	_, tasksets, err := doUpdate(ctx, st, names, updates, params, userID, flags, deviceCtx, "")
+	_, tasksetGroup, err := doUpdate(ctx, st, names, updates, params, userID, flags, deviceCtx, "")
 	if err != nil {
 		return nil, err
 	}
 
-	return tasksets, nil
+	return tasksetGroup.Refresh, nil
 }
 
 // InstallMany installs everything from the given list of names. When specifying
@@ -1418,7 +1458,11 @@ var ValidateRefreshes func(st *state.State, refreshes []*snap.Info, ignoreValida
 // store says is updateable. If the list is empty, update everything.
 // Note that the state must be locked by the caller.
 func UpdateMany(ctx context.Context, st *state.State, names []string, revOpts []*RevisionOptions, userID int, flags *Flags) ([]string, []*state.TaskSet, error) {
-	return updateManyFiltered(ctx, st, names, revOpts, userID, nil, flags, "")
+	updated, tasksetGrp, err := updateManyFiltered(ctx, st, names, revOpts, userID, nil, flags, "")
+	if err != nil {
+		return nil, nil, err
+	}
+	return updated, tasksetGrp.Refresh, nil
 }
 
 // ResolveValidationSetsEnforcementError installs and updates snaps in order to
@@ -1589,7 +1633,7 @@ func rearrangeBaseKernelForSingleReboot(kernelTs, bootBaseTs *state.TaskSet) err
 	return nil
 }
 
-func updateManyFiltered(ctx context.Context, st *state.State, names []string, revOpts []*RevisionOptions, userID int, filter updateFilter, flags *Flags, fromChange string) ([]string, []*state.TaskSet, error) {
+func updateManyFiltered(ctx context.Context, st *state.State, names []string, revOpts []*RevisionOptions, userID int, filter updateFilter, flags *Flags, fromChange string) ([]string, *TaskSetGroup, error) {
 	if flags == nil {
 		flags = &Flags{}
 	}
@@ -1661,12 +1705,17 @@ func updateManyFiltered(ctx context.Context, st *state.State, names []string, re
 		return nil, nil, err
 	}
 
-	updated, tasksets, err := doUpdate(ctx, st, names, toUpdate, params, userID, flags, deviceCtx, fromChange)
+	updated, tasksetGroup, err := doUpdate(ctx, st, names, toUpdate, params, userID, flags, deviceCtx, fromChange)
 	if err != nil {
 		return nil, nil, err
 	}
-	tasksets = finalizeUpdate(st, tasksets, len(updates) > 0, updated, userID, flags)
-	return updated, tasksets, nil
+
+	// if there are only pre-downloads, don't add a check-rerefresh task
+	if len(tasksetGroup.Refresh) > 0 {
+		tasksetGroup.Refresh = finalizeUpdate(st, tasksetGroup.Refresh, len(updates) > 0, updated, userID, flags)
+	}
+
+	return updated, tasksetGroup, nil
 }
 
 // filterHeldSnaps filters held snaps from being updated in a general refresh.
@@ -1690,12 +1739,23 @@ func filterHeldSnaps(st *state.State, updates []minimalInstallInfo, flags *Flags
 	return filteredUpdates, nil
 }
 
-func doUpdate(ctx context.Context, st *state.State, names []string, updates []minimalInstallInfo, params updateParamsFunc, userID int, globalFlags *Flags, deviceCtx DeviceContext, fromChange string) ([]string, []*state.TaskSet, error) {
+// TaskSetGroup distinguishes tasksets for refreshes and pre-downloads since an
+// auto-refresh can return both (even simultaneously).
+type TaskSetGroup struct {
+	// PreDownload holds the pre-downloads tasksets created when there are busy
+	// snaps that can't be refreshed during an auto-refresh.
+	PreDownload []*state.TaskSet
+	// Refresh holds the Refresh tasksets.
+	Refresh []*state.TaskSet
+}
+
+func doUpdate(ctx context.Context, st *state.State, names []string, updates []minimalInstallInfo, params updateParamsFunc, userID int, globalFlags *Flags, deviceCtx DeviceContext, fromChange string) ([]string, *TaskSetGroup, error) {
 	if globalFlags == nil {
 		globalFlags = &Flags{}
 	}
 
-	tasksets := make([]*state.TaskSet, 0, len(updates)+2) // 1 for auto-aliases, 1 for re-refresh
+	var installTasksets []*state.TaskSet
+	var preDlTasksets []*state.TaskSet
 
 	refreshAll := len(names) == 0
 	var nameSet map[string]bool
@@ -1724,7 +1784,7 @@ func doUpdate(ctx context.Context, st *state.State, names []string, updates []mi
 		if err != nil {
 			return nil, nil, err
 		}
-		tasksets = append(tasksets, pruningAutoAliasesTs)
+		installTasksets = append(installTasksets, pruningAutoAliasesTs)
 	}
 
 	// wait for the auto-alias prune tasks as needed
@@ -1773,6 +1833,13 @@ func doUpdate(ctx context.Context, st *state.State, names []string, updates []mi
 
 		ts, err := doInstall(st, snapst, snapsup, 0, fromChange, inUseFor(deviceCtx))
 		if err != nil {
+			if errors.Is(err, &timedBusySnapError{}) && ts != nil {
+				// snap is busy and pre-download tasks were made for it
+				ts.JoinLane(st.NewLane())
+				preDlTasksets = append(preDlTasksets, ts)
+				continue
+			}
+
 			if refreshAll {
 				// doing "refresh all", just skip this snap
 				logger.Noticef("cannot refresh snap %q: %v", update.InstanceName(), err)
@@ -1841,7 +1908,7 @@ func doUpdate(ctx context.Context, st *state.State, names []string, updates []mi
 		}
 
 		scheduleUpdate(update.InstanceName(), ts)
-		tasksets = append(tasksets, ts)
+		installTasksets = append(installTasksets, ts)
 	}
 	// Kernel must wait for gadget because the gadget may define
 	// new "$kernel:refs". Sorting the other way is impossible
@@ -1870,7 +1937,7 @@ func doUpdate(ctx context.Context, st *state.State, names []string, updates []mi
 		if err != nil {
 			return nil, nil, err
 		}
-		tasksets = append(tasksets, addAutoAliasesTs)
+		installTasksets = append(installTasksets, addAutoAliasesTs)
 	}
 
 	updated := make([]string, 0, len(reportUpdated))
@@ -1878,7 +1945,11 @@ func doUpdate(ctx context.Context, st *state.State, names []string, updates []mi
 		updated = append(updated, name)
 	}
 
-	return updated, tasksets, nil
+	group := &TaskSetGroup{
+		Refresh:     installTasksets,
+		PreDownload: preDlTasksets,
+	}
+	return updated, group, nil
 }
 
 func finalizeUpdate(st *state.State, tasksets []*state.TaskSet, hasUpdates bool, updated []string, userID int, globalFlags *Flags) []*state.TaskSet {
@@ -2272,10 +2343,13 @@ func UpdateWithDeviceContext(st *state.State, name string, opts *RevisionOptions
 		return opts, flags, &snapst
 	}
 
-	_, tts, err := doUpdate(context.TODO(), st, []string{name}, toUpdate, params, userID, &flags, deviceCtx, fromChange)
+	_, tasksetGroup, err := doUpdate(context.TODO(), st, []string{name}, toUpdate, params, userID, &flags, deviceCtx, fromChange)
 	if err != nil {
 		return nil, err
 	}
+
+	// pre-download tasksets are only used for auto-refreshes
+	tts := tasksetGroup.Refresh
 
 	// see if we need to switch the channel or cohort, or toggle ignore-validation
 	switchChannel := snapst.TrackingChannel != opts.Channel
@@ -2387,7 +2461,7 @@ var RestoreValidationSetsTracking func(st *state.State) error
 // AutoRefresh is the wrapper that will do a refresh of all the installed
 // snaps on the system. In addition to that it will also refresh important
 // assertions.
-func AutoRefresh(ctx context.Context, st *state.State) ([]string, []*state.TaskSet, error) {
+func AutoRefresh(ctx context.Context, st *state.State) ([]string, *TaskSetGroup, error) {
 	userID := 0
 
 	if AutoRefreshAssertions != nil {
@@ -2405,11 +2479,16 @@ func AutoRefresh(ctx context.Context, st *state.State) ([]string, []*state.TaskS
 	}
 	if !gateAutoRefreshHook {
 		// old-style refresh (gate-auto-refresh-hook feature disabled)
-		return UpdateMany(ctx, st, nil, nil, userID, &Flags{IsAutoRefresh: true})
+		return updateManyFiltered(ctx, st, nil, nil, userID, nil, &Flags{IsAutoRefresh: true}, "")
 	}
 
 	// TODO: rename to autoRefreshTasks when old auto refresh logic gets removed.
-	return autoRefreshPhase1(ctx, st, "")
+	updated, tss, err := autoRefreshPhase1(ctx, st, "")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return updated, &TaskSetGroup{Refresh: tss}, nil
 }
 
 // autoRefreshPhase1 creates gate-auto-refresh hooks and conditional-auto-refresh
@@ -2563,7 +2642,7 @@ func autoRefreshPhase1(ctx context.Context, st *state.State, forGatingSnap strin
 }
 
 // autoRefreshPhase2 creates tasks for refreshing snaps from updates.
-func autoRefreshPhase2(ctx context.Context, st *state.State, updates []*refreshCandidate, fromChange string) ([]*state.TaskSet, error) {
+func autoRefreshPhase2(ctx context.Context, st *state.State, updates []*refreshCandidate, fromChange string) (*TaskSetGroup, error) {
 	flags := &Flags{IsAutoRefresh: true}
 	userID := 0
 
@@ -2581,13 +2660,17 @@ func autoRefreshPhase2(ctx context.Context, st *state.State, updates []*refreshC
 		return nil, err
 	}
 
-	updated, tasksets, err := doUpdate(ctx, st, nil, toUpdate, nil, userID, flags, deviceCtx, fromChange)
+	updated, tasksetGroup, err := doUpdate(ctx, st, nil, toUpdate, nil, userID, flags, deviceCtx, fromChange)
 	if err != nil {
 		return nil, err
 	}
 
-	tasksets = finalizeUpdate(st, tasksets, len(updates) > 0, updated, userID, flags)
-	return tasksets, nil
+	// pre-download tasksets are only used for auto-refreshes
+	if len(tasksetGroup.Refresh) > 0 {
+		tasksetGroup.Refresh = finalizeUpdate(st, tasksetGroup.Refresh, len(updates) > 0, updated, userID, flags)
+	}
+
+	return tasksetGroup, nil
 }
 
 // checkDiskSpace checks if there is enough space for the requested snaps and their prerequisites

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -60,7 +60,6 @@ import (
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/testutil"
-	userclient "github.com/snapcore/snapd/usersession/client"
 )
 
 func expectedDoInstallTasks(typ snap.Type, opts, discards int, startTasks []string, filterOut map[string]bool) []string {
@@ -5614,83 +5613,4 @@ func (s *snapmgrTestSuite) TestInstallWithTransactionLaneForbidden(c *C) {
 	tss, err := snapstate.InstallWithDeviceContext(context.Background(), s.state, "some-snap", nil, 0, snapstate.Flags{Lane: 1}, nil, "")
 	c.Assert(err, ErrorMatches, "transaction lane is unsupported in InstallWithDeviceContext")
 	c.Check(tss, IsNil)
-}
-
-func (s *snapmgrTestSuite) TestAutoRefreshCreatePreDownload(c *C) {
-	restore := snapstate.MockRefreshAppsCheck(func(si *snap.Info) error {
-		return snapstate.NewBusySnapError(si, []int{123}, nil, nil)
-	})
-	defer restore()
-
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	si := &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)}
-	snapst := &snapstate.SnapState{
-		Active:   true,
-		Sequence: []*snap.SideInfo{si},
-		Current:  si.Revision,
-		SnapType: string(snap.TypeApp),
-	}
-	snapstate.Set(s.state, "some-snap", snapst)
-	snapsup := &snapstate.SnapSetup{
-		SideInfo: &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(2)},
-		Flags:    snapstate.Flags{IsAutoRefresh: true},
-	}
-
-	ts, err := snapstate.DoInstall(s.state, snapst, snapsup, 0, "", inUseCheck)
-
-	var busyErr *snapstate.TimedBusySnapError
-	c.Assert(errors.As(err, &busyErr), Equals, true)
-	refreshInfo := busyErr.PendingSnapRefreshInfo()
-	c.Check(refreshInfo, DeepEquals, &userclient.PendingSnapRefreshInfo{
-		InstanceName:  "some-snap",
-		TimeRemaining: snapstate.MaxInhibition,
-	})
-
-	tasks := ts.Tasks()
-	c.Assert(tasks, HasLen, 1)
-	c.Assert(tasks[0].Kind(), Equals, "pre-download-snap")
-	c.Assert(tasks[0].Summary(), testutil.Contains, "Pre-download snap \"some-snap\" (2) from channel")
-}
-
-func (s *snapmgrTestSuite) TestAutoRefreshBusySnapButOngoingPreDownload(c *C) {
-	restore := snapstate.MockRefreshAppsCheck(func(si *snap.Info) error {
-		return snapstate.NewBusySnapError(si, []int{123}, nil, nil)
-	})
-	defer restore()
-
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	si := &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)}
-	snapst := &snapstate.SnapState{
-		Active:   true,
-		Sequence: []*snap.SideInfo{si},
-		Current:  si.Revision,
-		SnapType: string(snap.TypeApp),
-	}
-	snapstate.Set(s.state, "some-snap", snapst)
-	snapsup := &snapstate.SnapSetup{
-		SideInfo: &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(2)},
-		Flags:    snapstate.Flags{IsAutoRefresh: true},
-	}
-
-	// create ongoing pre-download
-	chg := s.state.NewChange("pre-download", "")
-	task := s.state.NewTask("pre-download-snap", "")
-	task.Set("snap-setup", snapsup)
-	chg.AddTask(task)
-	chg.SetStatus(state.DoStatus)
-
-	ts, err := snapstate.DoInstall(s.state, snapst, snapsup, 0, "", inUseCheck)
-
-	var busyErr *snapstate.TimedBusySnapError
-	c.Assert(errors.As(err, &busyErr), Equals, true)
-	refreshInfo := busyErr.PendingSnapRefreshInfo()
-	c.Check(refreshInfo, DeepEquals, &userclient.PendingSnapRefreshInfo{
-		InstanceName:  "some-snap",
-		TimeRemaining: snapstate.MaxInhibition,
-	})
-	c.Assert(ts, IsNil)
 }

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -228,7 +228,7 @@ func (s *snapmgrBaseTest) SetUpTest(c *C) {
 	})
 
 	s.BaseTest.AddCleanup(snapstate.MockReRefreshRetryTimeout(time.Second / 200))
-	s.BaseTest.AddCleanup(snapstate.MockReRefreshUpdateMany(func(context.Context, *state.State, []string, []*snapstate.RevisionOptions, int, snapstate.UpdateFilter, *snapstate.Flags, string) ([]string, *snapstate.TaskSetGroup, error) {
+	s.BaseTest.AddCleanup(snapstate.MockReRefreshUpdateMany(func(context.Context, *state.State, []string, []*snapstate.RevisionOptions, int, snapstate.UpdateFilter, *snapstate.Flags, string) ([]string, *snapstate.UpdateTaskSets, error) {
 		return nil, nil, nil
 	}))
 

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -228,7 +228,7 @@ func (s *snapmgrBaseTest) SetUpTest(c *C) {
 	})
 
 	s.BaseTest.AddCleanup(snapstate.MockReRefreshRetryTimeout(time.Second / 200))
-	s.BaseTest.AddCleanup(snapstate.MockReRefreshUpdateMany(func(context.Context, *state.State, []string, []*snapstate.RevisionOptions, int, snapstate.UpdateFilter, *snapstate.Flags, string) ([]string, []*state.TaskSet, error) {
+	s.BaseTest.AddCleanup(snapstate.MockReRefreshUpdateMany(func(context.Context, *state.State, []string, []*snapstate.RevisionOptions, int, snapstate.UpdateFilter, *snapstate.Flags, string) ([]string, *snapstate.TaskSetGroup, error) {
 		return nil, nil, nil
 	}))
 

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/auth"
+	userclient "github.com/snapcore/snapd/usersession/client"
 
 	// So it registers Configure.
 	_ "github.com/snapcore/snapd/overlord/configstate"
@@ -9076,4 +9077,83 @@ func (s *snapmgrTestSuite) TestConditionalAutoRefreshCreatesPreDownloadChange(c 
 	c.Assert(chgs[0].Status(), Equals, state.DoneStatus)
 
 	checkPreDownloadChange(c, chgs[1], "some-snap", snap.R(2))
+}
+
+func (s *snapmgrTestSuite) TestAutoRefreshCreatePreDownload(c *C) {
+	restore := snapstate.MockRefreshAppsCheck(func(si *snap.Info) error {
+		return snapstate.NewBusySnapError(si, []int{123}, nil, nil)
+	})
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	si := &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)}
+	snapst := &snapstate.SnapState{
+		Active:   true,
+		Sequence: []*snap.SideInfo{si},
+		Current:  si.Revision,
+		SnapType: string(snap.TypeApp),
+	}
+	snapstate.Set(s.state, "some-snap", snapst)
+	snapsup := &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(2)},
+		Flags:    snapstate.Flags{IsAutoRefresh: true},
+	}
+
+	ts, err := snapstate.DoInstall(s.state, snapst, snapsup, 0, "", inUseCheck)
+
+	var busyErr *snapstate.TimedBusySnapError
+	c.Assert(errors.As(err, &busyErr), Equals, true)
+	refreshInfo := busyErr.PendingSnapRefreshInfo()
+	c.Check(refreshInfo, DeepEquals, &userclient.PendingSnapRefreshInfo{
+		InstanceName:  "some-snap",
+		TimeRemaining: snapstate.MaxInhibition,
+	})
+
+	tasks := ts.Tasks()
+	c.Assert(tasks, HasLen, 1)
+	c.Assert(tasks[0].Kind(), Equals, "pre-download-snap")
+	c.Assert(tasks[0].Summary(), testutil.Contains, "Pre-download snap \"some-snap\" (2) from channel")
+}
+
+func (s *snapmgrTestSuite) TestAutoRefreshBusySnapButOngoingPreDownload(c *C) {
+	restore := snapstate.MockRefreshAppsCheck(func(si *snap.Info) error {
+		return snapstate.NewBusySnapError(si, []int{123}, nil, nil)
+	})
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	si := &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)}
+	snapst := &snapstate.SnapState{
+		Active:   true,
+		Sequence: []*snap.SideInfo{si},
+		Current:  si.Revision,
+		SnapType: string(snap.TypeApp),
+	}
+	snapstate.Set(s.state, "some-snap", snapst)
+	snapsup := &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(2)},
+		Flags:    snapstate.Flags{IsAutoRefresh: true},
+	}
+
+	// create ongoing pre-download
+	chg := s.state.NewChange("pre-download", "")
+	task := s.state.NewTask("pre-download-snap", "")
+	task.Set("snap-setup", snapsup)
+	chg.AddTask(task)
+	chg.SetStatus(state.DoStatus)
+
+	ts, err := snapstate.DoInstall(s.state, snapst, snapsup, 0, "", inUseCheck)
+
+	var busyErr *snapstate.TimedBusySnapError
+	c.Assert(errors.As(err, &busyErr), Equals, true)
+	refreshInfo := busyErr.PendingSnapRefreshInfo()
+	c.Check(refreshInfo, DeepEquals, &userclient.PendingSnapRefreshInfo{
+		InstanceName:  "some-snap",
+		TimeRemaining: snapstate.MaxInhibition,
+	})
+	c.Assert(ts, IsNil)
 }


### PR DESCRIPTION
If an auto-refresh is totally or partially prevented due to some snaps being open, create pre-download tasks so that, when the user is asked to close the snap, it's ready to be auto-refreshed as quickly as possible. If the inhibition window has passed, pre-downloads aren't created and instead the user is notified that the refresh is proceeding despite the open snap. The next PR will add the actual pre-download logic as well as the related logic w.r.t waiting for snaps to close, concurrent downloads, continuing delayed auto-refreshes, etc.