### PR TITLE
gadget: add inline crypto engine support

### DIFF
--- a/gadget/install/encrypt.go
+++ b/gadget/install/encrypt.go
@@ -57,7 +57,7 @@ var _ = encryptedDevice(&encryptedDeviceLUKS{})
 
 // newEncryptedDeviceLUKS creates an encrypted device in the existing
 // partition using the specified key with the LUKS backend.
-func newEncryptedDeviceLUKS(part *gadget.OnDiskStructure, key keys.EncryptionKey, label, name string) (encryptedDevice, error) {
+func newEncryptedDeviceLUKS(part *gadget.OnDiskStructure, key keys.EncryptionKey, ice bool, label, name string) (encryptedDevice, error) {
 	dev := &encryptedDeviceLUKS{
 		parent: part,
 		name:   name,
@@ -67,7 +67,7 @@ func newEncryptedDeviceLUKS(part *gadget.OnDiskStructure, key keys.EncryptionKey
 		node: fmt.Sprintf("/dev/mapper/%s", name),
 	}
 
-	if err := secbootFormatEncryptedDevice(key, label, part.Node); err != nil {
+	if err := secbootFormatEncryptedDevice(key, label, part.Node, ice); err != nil {
 		return nil, fmt.Errorf("cannot format encrypted device: %v", err)
 	}
 

--- a/gadget/install/encrypt_test.go
+++ b/gadget/install/encrypt_test.go
@@ -99,7 +99,7 @@ func (s *encryptSuite) TestNewEncryptedDeviceLUKS(c *C) {
 		s.AddCleanup(s.mockCryptsetup.Restore)
 
 		calls := 0
-		restore := install.MockSecbootFormatEncryptedDevice(func(key keys.EncryptionKey, label, node string) error {
+		restore := install.MockSecbootFormatEncryptedDevice(func(key keys.EncryptionKey, label, node string, ice bool) error {
 			calls++
 			c.Assert(key, DeepEquals, s.mockedEncryptionKey)
 			c.Assert(label, Equals, "some-label-enc")
@@ -108,7 +108,7 @@ func (s *encryptSuite) TestNewEncryptedDeviceLUKS(c *C) {
 		})
 		defer restore()
 
-		dev, err := install.NewEncryptedDeviceLUKS(&mockDeviceStructure, s.mockedEncryptionKey, "some-label-enc", "some-label")
+		dev, err := install.NewEncryptedDeviceLUKS(&mockDeviceStructure, s.mockedEncryptionKey, false, "some-label-enc", "some-label")
 		c.Assert(calls, Equals, 1)
 		if tc.expectedErr == "" {
 			c.Assert(err, IsNil)

--- a/gadget/install/export_secboot_test.go
+++ b/gadget/install/export_secboot_test.go
@@ -34,7 +34,7 @@ var (
 	CreateEncryptedDeviceWithSetupHook = createEncryptedDeviceWithSetupHook
 )
 
-func MockSecbootFormatEncryptedDevice(f func(key keys.EncryptionKey, label, node string) error) (restore func()) {
+func MockSecbootFormatEncryptedDevice(f func(key keys.EncryptionKey, label, node string, ice bool) error) (restore func()) {
 	r := testutil.Backup(&secbootFormatEncryptedDevice)
 	secbootFormatEncryptedDevice = f
 	return r

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -32,6 +32,7 @@ import (
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/disks"
 	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/secboot/keys"
@@ -96,7 +97,7 @@ func saveStorageTraits(mod gadget.Model, allLaidOutVols map[string]*gadget.LaidO
 	return nil
 }
 
-func maybeEncryptPartition(laidOut *gadget.LaidOutStructure, encryptionType secboot.EncryptionType, sectorSize quantity.Size, perfTimings timings.Measurer) (fsParams *mkfsParams, encryptionKey keys.EncryptionKey, err error) {
+func maybeEncryptPartition(laidOut *gadget.LaidOutStructure, encryptionType secboot.EncryptionType, ice bool, sectorSize quantity.Size, perfTimings timings.Measurer) (fsParams *mkfsParams, encryptionKey keys.EncryptionKey, err error) {
 	mustEncrypt := (encryptionType != secboot.EncryptionTypeNone)
 	// fsParams.Device is the kernel device that carries the
 	// filesystem, which is either the raw /dev/<partition>, or
@@ -131,7 +132,7 @@ func maybeEncryptPartition(laidOut *gadget.LaidOutStructure, encryptionType secb
 			timings.Run(perfTimings, fmt.Sprintf("new-encrypted-device[%s]", laidOut.Role()),
 				fmt.Sprintf("Create encryption device for %s", laidOut.Role()),
 				func(timings.Measurer) {
-					dataPart, err = newEncryptedDeviceLUKS(&laidOut.OnDiskStructure, encryptionKey, laidOut.PartitionFSLabel, laidOut.Name())
+					dataPart, err = newEncryptedDeviceLUKS(&laidOut.OnDiskStructure, encryptionKey, ice, laidOut.PartitionFSLabel, laidOut.Name())
 				})
 			if err != nil {
 				return nil, nil, err
@@ -190,10 +191,10 @@ func writePartitionContent(laidOut *gadget.LaidOutStructure, fsDevice string, ob
 	return nil
 }
 
-func installOnePartition(laidOut *gadget.LaidOutStructure, encryptionType secboot.EncryptionType, sectorSize quantity.Size, observer gadget.ContentObserver, perfTimings timings.Measurer) (fsDevice string, encryptionKey keys.EncryptionKey, err error) {
+func installOnePartition(laidOut *gadget.LaidOutStructure, encryptionType secboot.EncryptionType, ice bool, sectorSize quantity.Size, observer gadget.ContentObserver, perfTimings timings.Measurer) (fsDevice string, encryptionKey keys.EncryptionKey, err error) {
 	// 1. Encrypt
 	role := laidOut.Role()
-	fsParams, encryptionKey, err := maybeEncryptPartition(laidOut, encryptionType, sectorSize, perfTimings)
+	fsParams, encryptionKey, err := maybeEncryptPartition(laidOut, encryptionType, ice, sectorSize, perfTimings)
 	if err != nil {
 		return "", nil, fmt.Errorf("cannot encrypt partition %s: %v", role, err)
 	}
@@ -299,6 +300,12 @@ func createEncryptionParams(encTyp secboot.EncryptionType) gadget.StructureEncry
 	return gadget.StructureEncryptionParameters{}
 }
 
+// check is device supports ICE fde
+func isIceSupported(gadgetRoot string) bool {
+	// check is device supports ICE fde
+	return osutil.FileExists(filepath.Join(gadgetRoot, "meta", "use-ice-fde"))
+}
+
 // Run creates partitions, encrypts them when expected, creates
 // filesystems, and finally writes content on them.
 func Run(model gadget.Model, gadgetRoot, kernelRoot, bootDevice string, options Options, observer gadget.ContentObserver, perfTimings timings.Measurer) (*InstalledSystemSideData, error) {
@@ -316,6 +323,8 @@ func Run(model gadget.Model, gadgetRoot, kernelRoot, bootDevice string, options 
 	partsEncrypted := map[string]gadget.StructureEncryptionParameters{}
 
 	hasSavePartition := false
+
+	ice := options.EncryptionType != "" && isIceSupported(gadgetRoot)
 
 	// Note that all partitions here will have a role (see
 	// gadget.IsCreatableAtInstall() which defines the list)
@@ -338,7 +347,7 @@ func Run(model gadget.Model, gadgetRoot, kernelRoot, bootDevice string, options 
 		// for encrypted device the filesystem device it will point to
 		// the mapper device otherwise it's the raw device node
 		fsDevice, encryptionKey, err := installOnePartition(&laidOut, options.EncryptionType,
-			bootVolSectorSize, observer, perfTimings)
+			ice, bootVolSectorSize, observer, perfTimings)
 		if err != nil {
 			return nil, err
 		}
@@ -630,6 +639,8 @@ func EncryptPartitions(onVolumes map[string]*gadget.Volume, encryptionType secbo
 		return nil, fmt.Errorf("when encrypting partitions: cannot layout volumes: %v", err)
 	}
 
+	ice := isIceSupported(gadgetRoot)
+
 	setupData := &EncryptionSetupData{
 		parts: make(map[string]partEncryptionData),
 	}
@@ -666,7 +677,7 @@ func EncryptPartitions(onVolumes map[string]*gadget.Volume, encryptionType secbo
 			logger.Debugf("encrypting partition %s", device)
 
 			fsParams, encryptionKey, err :=
-				maybeEncryptPartition(laidOut, encryptionType, onDiskVol.SectorSize, perfTimings)
+				maybeEncryptPartition(laidOut, encryptionType, ice, onDiskVol.SectorSize, perfTimings)
 			if err != nil {
 				return nil, fmt.Errorf("cannot encrypt %q: %v", device, err)
 			}
@@ -754,6 +765,8 @@ func FactoryReset(model gadget.Model, gadgetRoot, kernelRoot, bootDevice string,
 	var keyForRole map[string]keys.EncryptionKey
 	deviceForRole := map[string]string{}
 
+	ice := options.EncryptionType != "" && isIceSupported(gadgetRoot)
+
 	savePart := partitionsWithRolesAndContent(laidOutBootVol, diskLayout, []string{gadget.SystemSave})
 	hasSavePartition := len(savePart) != 0
 	if hasSavePartition {
@@ -769,7 +782,7 @@ func FactoryReset(model gadget.Model, gadgetRoot, kernelRoot, bootDevice string,
 		// device) for each role
 		deviceForRole[laidOut.Role()] = laidOut.Node
 
-		fsDevice, encryptionKey, err := installOnePartition(&laidOut, options.EncryptionType,
+		fsDevice, encryptionKey, err := installOnePartition(&laidOut, options.EncryptionType, ice,
 			diskLayout.SectorSize, observer, perfTimings)
 		if err != nil {
 			return nil, err

--- a/gadget/install/install_test.go
+++ b/gadget/install/install_test.go
@@ -308,7 +308,7 @@ func (s *installSuite) testInstall(c *C, opts installOpts) {
 	var saveEncryptionKey, dataEncryptionKey keys.EncryptionKey
 
 	secbootFormatEncryptedDeviceCall := 0
-	restore = install.MockSecbootFormatEncryptedDevice(func(key keys.EncryptionKey, label, node string) error {
+	restore = install.MockSecbootFormatEncryptedDevice(func(key keys.EncryptionKey, label, node string, ice bool) error {
 		if !opts.encryption {
 			c.Error("unexpected call to secboot.FormatEncryptedDevice when encryption is off")
 			return fmt.Errorf("no encryption functions should be called")
@@ -694,7 +694,7 @@ func (s *installSuite) testFactoryReset(c *C, opts factoryResetOpts) {
 
 	var dataPrimaryKey keys.EncryptionKey
 	secbootFormatEncryptedDeviceCall := 0
-	restore = install.MockSecbootFormatEncryptedDevice(func(key keys.EncryptionKey, label, node string) error {
+	restore = install.MockSecbootFormatEncryptedDevice(func(key keys.EncryptionKey, label, node string, ice bool) error {
 		if !opts.encryption {
 			c.Error("unexpected call to secboot.FormatEncryptedDevice")
 			return fmt.Errorf("unexpected call")

--- a/secboot/encrypt_sb.go
+++ b/secboot/encrypt_sb.go
@@ -49,7 +49,7 @@ const metadataKiBSize = 2048     // 2MB
 // FormatEncryptedDevice initializes an encrypted volume on the block device
 // given by node, setting the specified label. The key used to unlock the volume
 // is provided using the key argument.
-func FormatEncryptedDevice(key keys.EncryptionKey, label, node string) error {
+func FormatEncryptedDevice(key keys.EncryptionKey, label, node string, ice bool) error {
 	opts := &sb.InitializeLUKS2ContainerOptions{
 		// use a lower, but still reasonable size that should give us
 		// enough room
@@ -63,6 +63,7 @@ func FormatEncryptedDevice(key keys.EncryptionKey, label, node string) error {
 			MemoryKiB:       32,
 			ForceIterations: 4,
 		},
+		InlineCryptoEngine: ice,
 	}
 	return sbInitializeLUKS2Container(node, label, key[:], opts)
 }

--- a/secboot/encrypt_sb_test.go
+++ b/secboot/encrypt_sb_test.go
@@ -73,7 +73,7 @@ func (s *encryptSuite) TestFormatEncryptedDevice(c *C) {
 		})
 		defer restore()
 
-		err := secboot.FormatEncryptedDevice(myKey, "my label", "/dev/node")
+		err := secboot.FormatEncryptedDevice(myKey, "my label", "/dev/node", false)
 		c.Assert(calls, Equals, 1)
 		if tc.err == "" {
 			c.Assert(err, IsNil)


### PR DESCRIPTION
Add support for Inline Crypto Engine.

Have the ability to set in gadget snap flag to use ICE disk encryption. This flag is transparent to snapd and is passed down to sec boot.

This PR depends on https://github.com/snapcore/secboot/pull/221

