### PR TITLE
httputil: fix checking x509 certification error on Go1.20

### DIFF
--- a/httputil/retry.go
+++ b/httputil/retry.go
@@ -21,6 +21,7 @@ package httputil
 
 import (
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -300,7 +301,8 @@ func IsCertExpiredOrNotValidYetError(err error) bool {
 	if urlErr, ok := err.(*url.Error); ok {
 		err = urlErr.Err
 	}
-	if certErr, ok := err.(x509.CertificateInvalidError); ok {
+	var certErr x509.CertificateInvalidError
+	if errors.As(err, &certErr) {
 		// Expired is misleading, also means not valid yet
 		return certErr.Reason == x509.Expired
 	}


### PR DESCRIPTION
The error is wrapped in Go1.20 so we need to unwrap first.

Fix https://bugs.launchpad.net/snapd/+bug/2006676