### PR TITLE
i/b/fwupd: allow writing in EFI's fwupd directory

### DIFF
--- a/interfaces/builtin/fwupd.go
+++ b/interfaces/builtin/fwupd.go
@@ -127,6 +127,8 @@ const fwupdPermanentSlotAppArmor = `
   /boot/efi/EFI/*/ rw,
   /boot/efi/EFI/*/fw/ rw,
   /boot/efi/EFI/*/fw/** rw,
+  /boot/efi/EFI/fwupd/ rw,
+  /boot/efi/EFI/fwupd/** rw,
 
   # Allow access from efivar library
   /sys/devices/{pci*,platform}/**/block/**/partition r,


### PR DESCRIPTION
fwupd is going to use its own EFI directory to be able to handle multiple distros from the snap. For that it will need to copy Ubuntu's signed shim. And to not pollute the distro's directory, it will use its own. So we should just give it permission to put any file there.

See https://github.com/fwupd/fwupd/pull/5508
