### PR TITLE
o/snapstate: check for kernel cmdline update conflicts

### DIFF
--- a/overlord/snapstate/conflict.go
+++ b/overlord/snapstate/conflict.go
@@ -157,6 +157,34 @@ func CheckChangeConflictRunExclusively(st *state.State, newChangeKind string) er
 	return checkChangeConflictExclusiveKinds(st, newChangeKind, "")
 }
 
+// isIrrelevantChange checks if a change is ready or it can be ignored
+// if matching the passed ID, for conflict checking purposes.
+func isIrrelevantChange(chg *state.Change, ignoreChangeID string) bool {
+	if chg == nil || chg.Status().Ready() {
+		return true
+	}
+	if ignoreChangeID != "" && chg.ID() == ignoreChangeID {
+		return true
+	}
+	switch chg.Kind() {
+	case "pre-download":
+		// pre-download changes only have pre-download tasks
+		// which don't generate conflicts because they only
+		// download the snap and download tasks check for them
+		// explicitly
+		fallthrough
+	case "become-operational":
+		// become-operational will be retried until success
+		// and on its own just runs a hook on gadget:
+		// do not make it interfere with user requests
+		// TODO: consider a use vs change modeling of
+		// conflicts
+		return true
+	}
+
+	return false
+}
+
 // CheckChangeConflictMany ensures that for the given instanceNames no other
 // changes that alters the snaps (like remove, install, refresh) are in
 // progress. If a conflict is detected an error is returned.
@@ -176,24 +204,7 @@ func CheckChangeConflictMany(st *state.State, instanceNames []string, ignoreChan
 
 	for _, task := range st.Tasks() {
 		chg := task.Change()
-		if chg == nil || chg.Status().Ready() {
-			continue
-		}
-		if ignoreChangeID != "" && chg.ID() == ignoreChangeID {
-			continue
-		}
-		switch chg.Kind() {
-		case "pre-download":
-			// pre-download changes only have pre-download tasks which don't generate
-			// conflicts because they only download the snap and download tasks check
-			// for them explicitly
-			fallthrough
-		case "become-operational":
-			// become-operational will be retried until success
-			// and on its own just runs a hook on gadget:
-			// do not make it interfere with user requests
-			// TODO: consider a use vs change modeling of
-			// conflicts
+		if isIrrelevantChange(chg, ignoreChangeID) {
 			continue
 		}
 
@@ -244,6 +255,40 @@ func checkChangeConflictIgnoringOneChange(st *state.State, instanceName string, 
 		// TODO: implement the rather-boring-but-more-performant SnapState.Equals
 		if !reflect.DeepEqual(snapst, &cursnapst) {
 			return &ChangeConflictError{Snap: instanceName}
+		}
+	}
+
+	return nil
+}
+
+// CheckUpdateKernelCommandLineConflict checks that no active change other
+// than ignoreChangeID has a task that touches the kernel command
+// line.
+func CheckUpdateKernelCommandLineConflict(st *state.State, ignoreChangeID string) error {
+	// check whether there are other changes that need to run exclusively
+	if err := checkChangeConflictExclusiveKinds(st, "", ignoreChangeID); err != nil {
+		return err
+	}
+
+	for _, task := range st.Tasks() {
+		chg := task.Change()
+		if isIrrelevantChange(chg, ignoreChangeID) {
+			continue
+		}
+
+		switch task.Kind() {
+		case "update-gadget-cmdline":
+			return &ChangeConflictError{
+				Message:    "kernel command line already being updated, no additional changes for it allowed meanwhile",
+				ChangeKind: task.Kind(),
+				ChangeID:   chg.ID(),
+			}
+		case "update-managed-boot-config":
+			return &ChangeConflictError{
+				Message:    "boot config is being updated, no change in kernel commnd line is allowed meanwhile",
+				ChangeKind: task.Kind(),
+				ChangeID:   chg.ID(),
+			}
 		}
 	}
 

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -614,6 +614,38 @@ func (s *snapmgrTestSuite) TestInstallConflict(c *C) {
 	c.Assert(err, ErrorMatches, `snap "some-snap" has "install" change in progress`)
 }
 
+func (s *snapmgrTestSuite) TestGadgetInstallConflict(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	tugc := s.state.NewTask("update-managed-boot-config", "update managed boot config")
+	chg := s.state.NewChange("snapd-update", "snapd update")
+	chg.AddTask(tugc)
+
+	_, err := snapstate.Install(context.Background(), s.state, "brand-gadget",
+		nil, 0, snapstate.Flags{})
+	c.Assert(err, ErrorMatches, "boot config is being updated, no change in kernel commnd line is allowed meanwhile")
+}
+
+func (s *snapmgrTestSuite) TestInstallSnapdConflict(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	tugc := s.state.NewTask("update-gadget-cmdline", "update gadget cmdline")
+	chg := s.state.NewChange("optional-kernel-cmdline", "optional kernel cmdline")
+	chg.AddTask(tugc)
+
+	_, err := snapstate.Install(context.Background(), s.state, "snapd",
+		nil, 0, snapstate.Flags{})
+	c.Assert(err, ErrorMatches, "kernel command line already being updated, no additional changes for it allowed meanwhile")
+}
+
 func (s *snapmgrTestSuite) TestInstallAliasConflict(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()


### PR DESCRIPTION
Add helper function that checks if there are active tasks that will affect the kernel command line, and use it in corresponding handlers.