### PR TITLE
interfaces: relax rules for mount-control `what` for functionfs

### DIFF
--- a/interfaces/builtin/mount_control.go
+++ b/interfaces/builtin/mount_control.go
@@ -278,7 +278,10 @@ func validateWhatAttr(mountInfo *MountInfo) error {
 	// with "functionfs" the "what" can essentially be anything, see
 	// https://www.kernel.org/doc/html/latest/usb/functionfs.html
 	if len(mountInfo.types) == 1 && mountInfo.types[0] == "functionfs" {
-		return apparmor_sandbox.ValidateNoAppArmorRegexp(what)
+		if err := apparmor_sandbox.ValidateNoAppArmorRegexp(what); err != nil {
+			return fmt.Errorf(`cannot use mount-control "what" attribute: %w`, err)
+		}
+		return nil
 	}
 
 	if !whatRegexp.MatchString(what) {

--- a/interfaces/builtin/mount_control.go
+++ b/interfaces/builtin/mount_control.go
@@ -29,6 +29,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/utils"
+	apparmor_sandbox "github.com/snapcore/snapd/sandbox/apparmor"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/strutil"
 	"github.com/snapcore/snapd/systemd"
@@ -272,13 +273,14 @@ func enumerateMounts(plug interfaces.Attrer, fn func(mountInfo *MountInfo) error
 }
 
 func validateWhatAttr(mountInfo *MountInfo) error {
+	what := mountInfo.what
+
 	// with "functionfs" the "what" can essentially be anything, see
 	// https://www.kernel.org/doc/html/latest/usb/functionfs.html
 	if len(mountInfo.types) == 1 && mountInfo.types[0] == "functionfs" {
-		return nil
+		return apparmor_sandbox.ValidateNoAppArmorRegexp(what)
 	}
 
-	what := mountInfo.what
 	if !whatRegexp.MatchString(what) {
 		return fmt.Errorf(`mount-control "what" attribute is invalid: must start with / and not contain special characters`)
 	}

--- a/interfaces/builtin/mount_control.go
+++ b/interfaces/builtin/mount_control.go
@@ -346,8 +346,14 @@ func optionIncompatibleWithFsType(options []string) string {
 }
 
 func validateMountInfo(mountInfo *MountInfo) error {
-	if err := validateWhatAttr(mountInfo.what); err != nil {
-		return err
+	// with "functionfs" the "what" can essentially be anything, see
+	// https://www.kernel.org/doc/html/latest/usb/functionfs.html
+	isFunctionfs := len(mountInfo.types) == 1 && mountInfo.types[0] == "functionfs"
+
+	if !isFunctionfs {
+		if err := validateWhatAttr(mountInfo.what); err != nil {
+			return err
+		}
 	}
 
 	if err := validateWhereAttr(mountInfo.where); err != nil {

--- a/interfaces/builtin/mount_control_test.go
+++ b/interfaces/builtin/mount_control_test.go
@@ -260,6 +260,10 @@ func (s *MountControlInterfaceSuite) TestSanitizePlugUnhappy(c *C) {
 			"mount:\n  - what: /\n    where: $SNAP_DATA/foo\n    options: [ro]\n    persistent: true",
 			`mount-control "persistent" attribute cannot be used to mount onto \$SNAP_DATA`,
 		},
+		{
+			"mount:\n  - what: a?\n    where: /dev/ffs-diag\n    type: [functionfs]\n    options: [rw]",
+			`"a\?" contains a reserved apparmor char from.*`,
+		},
 	}
 
 	for _, testData := range data {

--- a/interfaces/builtin/mount_control_test.go
+++ b/interfaces/builtin/mount_control_test.go
@@ -262,7 +262,7 @@ func (s *MountControlInterfaceSuite) TestSanitizePlugUnhappy(c *C) {
 		},
 		{
 			"mount:\n  - what: a?\n    where: /dev/ffs-diag\n    type: [functionfs]\n    options: [rw]",
-			`"a\?" contains a reserved apparmor char from.*`,
+			`cannot use mount-control "what" attribute: "a\?" contains a reserved apparmor char from.*`,
 		},
 	}
 

--- a/interfaces/builtin/mount_control_test.go
+++ b/interfaces/builtin/mount_control_test.go
@@ -249,7 +249,7 @@ func (s *MountControlInterfaceSuite) TestSanitizePlugUnhappy(c *C) {
 			`mount-control "what" attribute can be "none" only with "tmpfs"`,
 		},
 		{
-			"mount:\n  - what: none\n    where: /media/*\n    options: [rw]\n    type: [tmpfs,ext4]",
+			"mount:\n  - what: /\n    where: /media/*\n    options: [rw]\n    type: [tmpfs,ext4]",
 			`mount-control filesystem type "tmpfs" cannot be listed with other types`,
 		},
 		{


### PR DESCRIPTION
The `functionfs` `what` rules are too strict. With functionfs pretty much anything can be in the `what` line so best to not bother, especially since functionfs requires a explicit mention in the plug declaration.

