### PR TITLE
overlord: add kernel command line options

### DIFF
--- a/overlord/configstate/configcore/kernel.go
+++ b/overlord/configstate/configcore/kernel.go
@@ -1,0 +1,215 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !nomanagers
+// +build !nomanagers
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package configcore
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/overlord/devicestate"
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+const (
+	optionKernelCmdlineAppend              = "system.kernel.cmdline-append"
+	optionKernelDangerousCmdlineAppend     = "system.kernel.dangerous-cmdline-append"
+	coreOptionKernelCmdlineAppend          = "core." + optionKernelCmdlineAppend
+	coreOptionKernelDangerousCmdlineAppend = "core." + optionKernelDangerousCmdlineAppend
+)
+
+func init() {
+	supportedConfigurations[coreOptionKernelCmdlineAppend] = true
+	supportedConfigurations[coreOptionKernelDangerousCmdlineAppend] = true
+}
+
+func changedKernelConfigs(c RunTransaction) []string {
+	changed := []string{}
+	for _, name := range c.Changes() {
+		// Note that we cannot just check the prefix as we have
+		// system.kernel.* options also defined in sysctl.go.
+		if name == coreOptionKernelCmdlineAppend || name == coreOptionKernelDangerousCmdlineAppend {
+			nameWithoutSnap := strings.SplitN(name, ".", 2)[1]
+			changed = append(changed, nameWithoutSnap)
+		}
+	}
+	return changed
+}
+
+func validateCmdlineParamsAreAllowed(st *state.State, devCtx snapstate.DeviceContext, params []string) error {
+	// gd, err := devicestate.CurrentGadgetInfo(st, devCtx)
+	// if err != nil {
+	// 	return err
+	// }
+	// logger.Debugf("gadget data read from %s", gd.RootDir)
+	// TODO use gadgetdata to check against allowed values
+
+	return nil
+}
+
+func validateCmdlineAppend(c RunTransaction) error {
+	changed := changedKernelConfigs(c)
+	if len(changed) == 0 {
+		return nil
+	}
+
+	st := c.State()
+	st.Lock()
+	defer st.Unlock()
+	devCtx, err := devicestate.DeviceCtx(st, nil, nil)
+	if err != nil {
+		return err
+	}
+
+	for _, opt := range changed {
+		cmdAppend, err := coreCfg(c, opt)
+		if err != nil {
+			return err
+		}
+
+		logger.Debugf("validating %s=%q", opt, cmdAppend)
+		params, err := osutil.KernelCommandLineSplit(cmdAppend)
+		if err != nil {
+			return err
+		}
+		if opt == optionKernelCmdlineAppend {
+			// check against allowed values from gadget
+			if err := validateCmdlineParamsAreAllowed(c.State(), devCtx, params); err != nil {
+				return err
+			}
+		} else { // OptionKernelDangerousCmdlineAppend
+			if devCtx.Model().Grade() != asserts.ModelDangerous {
+				// TODO we should return an error if this is an API call
+				// and do nothing if setting defaults (so gadget can be
+				// reused with different models).
+				logger.Noticef("WARNING: %s ignored as this is not a dangerous model", opt)
+			}
+		}
+	}
+
+	return nil
+}
+
+func createApplyCmdlineChange(c RunTransaction, kernelOpts []string) (*state.Change, error) {
+	st := c.State()
+	st.Lock()
+	defer st.Unlock()
+
+	// error out if some other change is touching the kernel command line
+	if err := snapstate.CheckUpdateKernelCommandLineConflict(st, ""); err != nil {
+		return nil, err
+	}
+
+	// precalculate task arguments, so we do not need to destroy change/task
+	// if there is an error
+	args := []struct {
+		name    string
+		cmdline string
+	}{}
+	for _, opt := range kernelOpts {
+		cmdline, err := coreCfg(c, opt)
+		if err != nil {
+			return nil, err
+		}
+		// opt must match system.kernel.{dangerous-,}cmdline-append (so the
+		// slice must have size 3 and next expression should not fail).
+		name := strings.Split(opt, ".")[2]
+		args = append(args, struct {
+			name    string
+			cmdline string
+		}{
+			name: name, cmdline: cmdline,
+		})
+	}
+
+	// We need to create a new change that will change the kernel
+	// command line and wait for it to finish, otherwise we cannot
+	// wait on the changes to happen.
+	// TODO fix this in the future.
+	cmdlineChg := st.NewChange("apply-cmdline-append",
+		i18n.G("Update kernel command line due to change in system configuration"))
+	// Add task to the new change to set the new kernel command line
+	t := st.NewTask("update-gadget-cmdline",
+		"Update kernel command line from system configuration")
+	// Pass options to the task (changes in the options are not
+	// committed yet so the task cannot simply get them from the
+	// configuration)
+	for _, arg := range args {
+		t.Set(arg.name, arg.cmdline)
+	}
+
+	cmdlineChg.AddTask(t)
+	st.EnsureBefore(0)
+
+	return cmdlineChg, nil
+}
+
+func isDangerousModel(st *state.State) (bool, error) {
+	st.Lock()
+	defer st.Unlock()
+	devCtx, err := devicestate.DeviceCtx(st, nil, nil)
+	if err != nil {
+		return false, err
+	}
+
+	return devCtx.Model().Grade() == asserts.ModelDangerous, nil
+}
+
+func handleCmdlineAppend(c RunTransaction, opts *fsOnlyContext) error {
+	kernelOpts := changedKernelConfigs(c)
+	if len(kernelOpts) == 0 {
+		return nil
+	}
+	logger.Debugf("handling %v", kernelOpts)
+
+	st := c.State()
+	isDangModel, err := isDangerousModel(st)
+	if err != nil {
+		return err
+	}
+	// nothing to do if non-dangerous model and the only option set is
+	// the dangerous one, we simply return with success
+	if !isDangModel && len(kernelOpts) == 1 && kernelOpts[0] == optionKernelDangerousCmdlineAppend {
+		return nil
+	}
+
+	cmdlineChg, err := createApplyCmdlineChange(c, kernelOpts)
+	if err != nil {
+		return err
+	}
+
+	select {
+	case <-cmdlineChg.Ready():
+		st.Lock()
+		defer st.Unlock()
+		return cmdlineChg.Err()
+	case <-time.After(5 * time.Minute):
+		// Resealing may take a bit of time so we try to stay on the safe side
+		// with a 5 minutes timeout.
+		return fmt.Errorf("%s is taking too long", cmdlineChg.Kind())
+	}
+}

--- a/overlord/configstate/configcore/kernel_test.go
+++ b/overlord/configstate/configcore/kernel_test.go
@@ -1,0 +1,387 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package configcore_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/asserts/assertstest"
+	"github.com/snapcore/snapd/asserts/sysdb"
+	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/bootloader"
+	"github.com/snapcore/snapd/bootloader/bootloadertest"
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/gadget"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/overlord"
+	"github.com/snapcore/snapd/overlord/assertstate"
+	"github.com/snapcore/snapd/overlord/assertstate/assertstatetest"
+	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/overlord/configstate"
+	"github.com/snapcore/snapd/overlord/configstate/config"
+	"github.com/snapcore/snapd/overlord/configstate/configcore"
+	"github.com/snapcore/snapd/overlord/devicestate"
+	"github.com/snapcore/snapd/overlord/devicestate/devicestatetest"
+	"github.com/snapcore/snapd/overlord/hookstate"
+	"github.com/snapcore/snapd/overlord/hookstate/hooktest"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/store/storetest"
+	"github.com/snapcore/snapd/sysconfig"
+	. "gopkg.in/check.v1"
+	"gopkg.in/tomb.v2"
+)
+
+type kernelSuite struct {
+	configcoreSuite
+	storetest.Store
+
+	overlord *overlord.Overlord
+
+	StoreSigning *assertstest.StoreStack
+	Brands       *assertstest.SigningAccounts
+}
+
+var _ = Suite(&kernelSuite{})
+
+var (
+	brandPrivKey, _ = assertstest.GenerateKey(752)
+)
+
+func (s *kernelSuite) SetUpTest(c *C) {
+	s.configcoreSuite.SetUpTest(c)
+
+	var err error
+
+	// File mocking
+	err = os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "/etc/"), 0755)
+	c.Assert(err, IsNil)
+
+	// Bootloader mocking
+	bl := bootloadertest.Mock("mock", "")
+	bootloader.Force(bl)
+	s.AddCleanup(func() { bootloader.Force(nil) })
+	bootVars := make(map[string]string)
+	bootVars["snap_kernel"] = "pc-kernel_1.snap"
+	err = bl.SetBootVars(bootVars)
+	c.Assert(err, IsNil)
+
+	// mock the modeenv file
+	modeenv := boot.Modeenv{
+		// base is base1
+		Base: "core20_1.snap",
+		// no try base
+		TryBase: "",
+		// base status is default
+		BaseStatus: boot.DefaultStatus,
+		// gadget is gadget1
+		Gadget: "pc_1.snap",
+		// current kernels is just kern1
+		CurrentKernels: []string{"pc-kernel_1.snap"},
+		// operating mode is run
+		Mode: "run",
+		// RecoverySystem is unset, as it should be during run mode
+		RecoverySystem: "",
+	}
+	err = modeenv.WriteTo("")
+	c.Assert(err, IsNil)
+
+	s.AddCleanup(osutil.MockMountInfo(""))
+
+	// Force backend building so EnsureBefore works
+	s.overlord = overlord.MockWithState(nil)
+	s.state = s.overlord.State()
+
+	s.StoreSigning = assertstest.NewStoreStack("my-brand", nil)
+	s.AddCleanup(sysdb.InjectTrusted(s.StoreSigning.Trusted))
+
+	s.Brands = assertstest.NewSigningAccounts(s.StoreSigning)
+	s.Brands.Register("my-brand", brandPrivKey, nil)
+
+	db, err := asserts.OpenDatabase(&asserts.DatabaseConfig{
+		Backstore:       asserts.NewMemoryBackstore(),
+		Trusted:         s.StoreSigning.Trusted,
+		OtherPredefined: s.StoreSigning.Generic,
+	})
+	c.Assert(err, IsNil)
+	s.state.Lock()
+	s.state.Set("seeded", true)
+	assertstate.ReplaceDB(s.state, db)
+	s.state.Unlock()
+
+	s.mockEarlyConfig()
+
+	// we need a device context for this option
+	hookMgr, err := hookstate.Manager(s.state, s.overlord.TaskRunner())
+	c.Assert(err, IsNil)
+	err = configstate.Init(s.state, hookMgr)
+	c.Assert(err, IsNil)
+	deviceMgr, err := devicestate.Manager(s.state, hookMgr, s.overlord.TaskRunner(), nil)
+	c.Assert(err, IsNil)
+
+	s.overlord.AddManager(hookMgr)
+	s.overlord.AddManager(deviceMgr)
+	s.overlord.AddManager(s.overlord.TaskRunner())
+
+	s.mockEarlyConfig()
+}
+
+func (s *kernelSuite) mockEarlyConfig() {
+	devicestate.EarlyConfig = func(*state.State, func() (
+		sysconfig.Device, *gadget.Info, error)) error {
+		return nil
+	}
+	s.AddCleanup(func() { devicestate.EarlyConfig = nil })
+}
+
+func (s *kernelSuite) mockModel(st *state.State, grade string) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// model setup
+	model := s.Brands.Model("my-brand", "pc", map[string]interface{}{
+		"architecture": "amd64",
+		"base":         "core20",
+		"grade":        grade,
+		"snaps": []interface{}{
+			map[string]interface{}{
+				"name":            "pc-kernel",
+				"id":              "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza",
+				"type":            "kernel",
+				"default-channel": "20",
+			},
+			map[string]interface{}{
+				"name":            "pc",
+				"id":              "UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH",
+				"type":            "gadget",
+				"default-channel": "20",
+			},
+		},
+	})
+
+	assertstatetest.AddMany(s.state, model)
+
+	devicestatetest.SetDevice(st, &auth.DeviceState{
+		Brand:  model.BrandID(),
+		Model:  model.Model(),
+		Serial: "serialserial",
+	})
+}
+
+type cmdlineOption struct {
+	name    string
+	cmdline string
+}
+
+func (s *kernelSuite) testConfigureKernelCmdlineHappy(c *C, option []cmdlineOption, modelGrade string) {
+	s.mockModel(s.state, modelGrade)
+	doHandlerCalls := 0
+	extraChange := true
+	expectedHandlerCalls := 1
+	expectedChanges := 2
+	if modelGrade != "dangerous" && len(option) == 1 && option[0].name == "system.kernel.dangerous-cmdline-append" {
+		extraChange = false
+		expectedHandlerCalls = 0
+		expectedChanges = 1
+	}
+
+	s.overlord.TaskRunner().AddHandler("update-gadget-cmdline",
+		func(task *state.Task, tomb *tomb.Tomb) error {
+			doHandlerCalls++
+
+			s.state.Lock()
+			defer s.state.Unlock()
+
+			// Check we have set only the needed options
+			for _, optName := range []string{
+				"system.kernel.cmdline-append",
+				"system.kernel.dangerous-cmdline-append"} {
+				shouldHaveBeenSet := false
+				cmdline := ""
+				for _, opt := range option {
+					if optName == opt.name {
+						shouldHaveBeenSet = true
+						cmdline = opt.cmdline
+					}
+				}
+
+				key := strings.Split(optName, ".")[2]
+				var taskCmdline string
+				if shouldHaveBeenSet {
+					err := task.Get(key, &taskCmdline)
+					c.Check(err, IsNil)
+					c.Check(taskCmdline, Equals, cmdline)
+				} else {
+					err := task.Get(key, &taskCmdline)
+					errStr := fmt.Sprintf("no state entry for key %q", key)
+					c.Check(err, ErrorMatches, errStr)
+				}
+			}
+
+			return nil
+		},
+		func(task *state.Task, tomb *tomb.Tomb) error { return nil })
+
+	var err error
+
+	s.state.Lock()
+	ts := s.state.NewTask("run-hook", "system hook task")
+	hsup := &hookstate.HookSetup{
+		Hook: "configure",
+		Snap: "core",
+	}
+	ts.Set("hook-setup", &hsup)
+	hookCtx, err := hookstate.NewContext(ts, ts.State(), hsup,
+		hooktest.NewMockHandler(), "")
+	c.Assert(err, IsNil)
+	s.state.Unlock()
+
+	hookCtx.Lock()
+	patchVals := make(map[string]interface{})
+	for _, opt := range option {
+		patchVals[opt.name] = opt.cmdline
+	}
+	hookCtx.Set("patch", patchVals)
+	hookCtx.Unlock()
+
+	s.state.Lock()
+	chg := s.state.NewChange("system-option", "...")
+	chg.AddTask(ts)
+	s.state.EnsureBefore(0)
+	s.state.Unlock()
+
+	// We need loop instead of settle because we create an
+	// ancillary change when the option is set.
+	c.Assert(s.overlord.StartUp(), IsNil)
+	s.overlord.Loop()
+	select {
+	case <-chg.Ready():
+	case <-time.After(2 * time.Minute):
+		c.Fatal("waiting for too long")
+	}
+	s.overlord.Stop()
+
+	c.Assert(doHandlerCalls, Equals, expectedHandlerCalls)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	changes := s.state.Changes()
+	c.Assert(len(changes), Equals, expectedChanges)
+	var soCh, aecCh *state.Change
+	for _, ch := range changes {
+		switch ch.Kind() {
+		case "system-option":
+			soCh = ch
+		case "apply-cmdline-append":
+			aecCh = ch
+		default:
+			c.Fatal("unexpected change kind")
+		}
+	}
+	// If the handler of these tasks failed it will be an error status
+	c.Assert(soCh.Status(), Equals, state.DoneStatus)
+	if extraChange {
+		c.Assert(aecCh.Status(), Equals, state.DoneStatus)
+		aecTsks := aecCh.Tasks()
+		c.Assert(len(aecTsks), Equals, 1)
+	} else {
+		c.Assert(aecCh, IsNil)
+	}
+
+	var taskCmdline string
+	tr := config.NewTransaction(s.state)
+	for _, opt := range option {
+		c.Assert(tr.Get("core", opt.name, &taskCmdline), IsNil)
+		c.Assert(taskCmdline, Equals, opt.cmdline)
+	}
+}
+
+func (s *kernelSuite) TestConfigureKernelCmdlineDangGrade(c *C) {
+	s.testConfigureKernelCmdlineHappy(c,
+		[]cmdlineOption{{
+			name:    "system.kernel.cmdline-append",
+			cmdline: "par=val param"}},
+		"dangerous")
+}
+
+func (s *kernelSuite) TestConfigureKernelCmdlineSignedGrade(c *C) {
+	s.testConfigureKernelCmdlineHappy(c,
+		[]cmdlineOption{{
+			name:    "system.kernel.cmdline-append",
+			cmdline: "par=val param"}},
+		"signed")
+}
+
+func (s *kernelSuite) TestConfigureKernelCmdlineDangGradeDangCmdline(c *C) {
+	s.testConfigureKernelCmdlineHappy(c,
+		[]cmdlineOption{{
+			name:    "system.kernel.dangerous-cmdline-append",
+			cmdline: "par=val param"}},
+		"dangerous")
+}
+
+func (s *kernelSuite) TestConfigureKernelCmdlineBothOptions(c *C) {
+	s.testConfigureKernelCmdlineHappy(c,
+		[]cmdlineOption{
+			{
+				name:    "system.kernel.cmdline-append",
+				cmdline: "par=val param"},
+			{
+				name:    "system.kernel.dangerous-cmdline-append",
+				cmdline: "dang_par=dang_val dang_param"},
+		},
+		"dangerous")
+}
+
+func (s *kernelSuite) TestConfigureKernelCmdlineSignedGradeDangCmdline(c *C) {
+	s.testConfigureKernelCmdlineHappy(c,
+		[]cmdlineOption{{
+			name:    "system.kernel.dangerous-cmdline-append",
+			cmdline: "par=val param"}},
+		"signed")
+}
+
+func (s *kernelSuite) TestConfigureKernelCmdlineConflict(c *C) {
+	s.mockModel(s.state, "dangerous")
+
+	cmdline := "param1=val1"
+	s.state.Lock()
+
+	tugc := s.state.NewTask("update-gadget-cmdline", "update gadget cmdline")
+	chgUpd := s.state.NewChange("optional-kernel-cmdline", "optional kernel cmdline")
+	chgUpd.AddTask(tugc)
+
+	ts := s.state.NewTask("hook-task", "system hook task")
+	chg := s.state.NewChange("system-option", "...")
+	chg.AddTask(ts)
+	rt := configcore.NewRunTransaction(config.NewTransaction(s.state), ts)
+
+	s.state.Unlock()
+
+	rt.Set("core", "system.kernel.dangerous-cmdline-append", cmdline)
+
+	err := configcore.Run(coreDev, rt)
+	c.Assert(err, ErrorMatches, "kernel command line already being updated, no additional changes for it allowed meanwhile")
+}

--- a/overlord/configstate/configcore/runwithstate.go
+++ b/overlord/configstate/configcore/runwithstate.go
@@ -64,6 +64,10 @@ func init() {
 
 	// netplan.*
 	addWithStateHandler(validateNetplanSettings, handleNetplanConfiguration, &flags{coreOnlyConfig: true})
+
+	// kernel.{,dangerous-}cmdline-append
+	// TODO we actually want this on classic with modes too
+	addWithStateHandler(validateCmdlineAppend, handleCmdlineAppend, coreOnly)
 }
 
 // RunTransaction is an interface describing how to access


### PR DESCRIPTION
Add options that will allow appending new arguments to the kernel command line. These are:
- system.kernel.cmdline-append, valid for any model grade
- system.kernel.dangerous-cmdline-append, valid only for dangerous models