### PR TITLE
image: cleanup setupSeed before adding support for validation sets

### DIFF
--- a/image/image_linux.go
+++ b/image/image_linux.go
@@ -386,18 +386,19 @@ func manifestFromLocalSnaps(snaps localSnapRefs, opts *Options) (map[string]snap
 }
 
 func localSnapsWithID(snaps localSnapRefs) []*tooling.CurrentSnap {
-	var storeSnaps []*tooling.CurrentSnap
+	var localSnaps []*tooling.CurrentSnap
 	for sn := range snaps {
-		if sn.Info.ID() != "" {
-			storeSnaps = append(storeSnaps, &tooling.CurrentSnap{
-				SnapName: sn.Info.SnapName(),
-				SnapID:   sn.Info.ID(),
-				Revision: sn.Info.Revision,
-				Epoch:    sn.Info.Epoch,
-			})
+		if sn.Info.ID() == "" {
+			continue
 		}
+		localSnaps = append(localSnaps, &tooling.CurrentSnap{
+			SnapName: sn.Info.SnapName(),
+			SnapID:   sn.Info.ID(),
+			Revision: sn.Info.Revision,
+			Epoch:    sn.Info.Epoch,
+		})
 	}
-	return storeSnaps
+	return localSnaps
 }
 
 func downloadSnaps(snapsToDownload []*seedwriter.SeedSnap, curSnaps []*tooling.CurrentSnap, w *seedwriter.Writer, tsto *tooling.ToolingStore, opts *Options) (downloadedSnaps map[string]*tooling.DownloadedSnap, err error) {

--- a/image/image_linux.go
+++ b/image/image_linux.go
@@ -26,6 +26,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"syscall"
 	"time"
@@ -427,6 +428,11 @@ func downloadSnaps(snapsToDownload []*seedwriter.SeedSnap, curSnaps []*tooling.C
 		snapToDownloadOptions[i].Revision = opts.Revisions[sn.SnapName()]
 		snapToDownloadOptions[i].CohortKey = opts.WideCohortKey
 	}
+
+	// sort the curSnaps slice for test consistency
+	sort.Slice(curSnaps, func(i, j int) bool {
+		return curSnaps[i].SnapName < curSnaps[j].SnapName
+	})
 	downloadedSnaps, err = tsto.DownloadMany(snapToDownloadOptions, curSnaps, tooling.DownloadManyOptions{
 		BeforeDownloadFunc: beforeDownload,
 		EnforceValidation:  opts.Customizations.Validation == "enforce",

--- a/image/image_linux.go
+++ b/image/image_linux.go
@@ -688,7 +688,7 @@ var setupSeed = func(tsto *tooling.ToolingStore, model *asserts.Model, opts *Opt
 		return err
 	}
 
-	// Build a map of snaps for the manifest file, but now after
+	// Build a map of snaps for the manifest file, but after
 	// InfoDerived has been called. InfoDerived fills out the snap
 	// revisions for the local snaps, and we need this to verify against
 	// expected revisions.

--- a/image/image_linux.go
+++ b/image/image_linux.go
@@ -689,13 +689,11 @@ func optionSnaps(opts *Options) []*seedwriter.OptionsSnap {
 	return optSnaps
 }
 
+// manifestFromLocalSnaps creates an initial seed manifest based on the locally
+// available snaps. It also performs initial verification against any rules given
+// to seedSetup against these.
 func manifestFromLocalSnaps(snaps localSnapRefs, opts *Options) (map[string]snap.Revision, error) {
-	// Build a map of snaps for the manifest file
 	seedManifest := make(map[string]snap.Revision)
-
-	// Check local snaps again, but now after InfoDerived has been called. InfoDerived
-	// fills out the snap revisions for the local snaps, and we need this to verify against
-	// expected revisions.
 	for sn := range snaps {
 		// Its a bit more tricky to deal with local snaps, as we only have that specific revision
 		// available. Therefore the revision in the local snap must be exactly the revision specified
@@ -766,10 +764,9 @@ var setupSeed = func(tsto *tooling.ToolingStore, model *asserts.Model, opts *Opt
 		return err
 	}
 
-	// Build a map of snaps for the manifest file, but after
-	// InfoDerived has been called. InfoDerived fills out the snap
-	// revisions for the local snaps, and we need this to verify against
-	// expected revisions.
+	// Create the initial manifest, derived from the locally available snaps.
+	// Must be done after deriveInfoForLocalSnaps, as the snap info must have
+	// been derived if possible.
 	imageManifest, err := manifestFromLocalSnaps(localSnaps, opts)
 	if err != nil {
 		return err

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -1495,8 +1495,8 @@ func (s *imageSuite) TestSetupSeedWithBaseLegacySnap(c *C) {
 	c.Check(s.curSnaps[0], HasLen, 0)
 	c.Check(s.curSnaps[1], DeepEquals, []*store.CurrentSnap{
 		{
-			InstanceName:     "snapd",
-			SnapID:           s.AssertedSnapID("snapd"),
+			InstanceName:     "core18",
+			SnapID:           s.AssertedSnapID("core18"),
 			Revision:         snap.R(18),
 			TrackingChannel:  "stable",
 			Epoch:            snap.E("0"),
@@ -1506,14 +1506,6 @@ func (s *imageSuite) TestSetupSeedWithBaseLegacySnap(c *C) {
 			InstanceName:     "pc-kernel",
 			SnapID:           s.AssertedSnapID("pc-kernel"),
 			Revision:         snap.R(2),
-			TrackingChannel:  "stable",
-			Epoch:            snap.E("0"),
-			IgnoreValidation: true,
-		},
-		{
-			InstanceName:     "core18",
-			SnapID:           s.AssertedSnapID("core18"),
-			Revision:         snap.R(18),
 			TrackingChannel:  "stable",
 			Epoch:            snap.E("0"),
 			IgnoreValidation: true,
@@ -1530,6 +1522,14 @@ func (s *imageSuite) TestSetupSeedWithBaseLegacySnap(c *C) {
 			InstanceName:     "required-snap1",
 			SnapID:           s.AssertedSnapID("required-snap1"),
 			Revision:         snap.R(3),
+			TrackingChannel:  "stable",
+			Epoch:            snap.E("0"),
+			IgnoreValidation: true,
+		},
+		{
+			InstanceName:     "snapd",
+			SnapID:           s.AssertedSnapID("snapd"),
+			Revision:         snap.R(18),
 			TrackingChannel:  "stable",
 			Epoch:            snap.E("0"),
 			IgnoreValidation: true,


### PR DESCRIPTION
I have seperated out some of the steps done by SetupSeed in preparation to add support for validation sets. This is *only* cleanup by seperating out some of the code, no functionality have been added or removed. All unit tests still pass, so I feel safe that behaviour is identical.

If anyone wants to suggest any changes or any documentation for the changes please do.