### PR TITLE
interfaces: add access to pipewire socket

### DIFF
--- a/interfaces/builtin/pipewire_server.go
+++ b/interfaces/builtin/pipewire_server.go
@@ -56,6 +56,7 @@ const pipewireServerConnectedPlugAppArmor = `
 owner /{,var/}run/user/[0-9]*/ r,
 owner /{,var/}run/user/[0-9]*/pipewire-0 rwk,
 owner /{,var/}run/user/[0-9]*/pipewire-0.lock rwk,
+owner /{,var/}run/user/[0-9]*/pulse/pid rwk,
 `
 
 const pipewireServerConnectedPlugSecComp = `
@@ -83,6 +84,7 @@ network netlink raw,
 owner /{,var/}run/user/[0-9]*/ r,
 owner /{,var/}run/user/[0-9]*/pipewire-0 rwk,
 owner /{,var/}run/user/[0-9]*/pipewire-0.lock rwk,
+owner /{,var/}run/user/[0-9]*/pulse/pid rwk,
 `
 
 const pipewireServerPermanentSlotSecComp = `

--- a/interfaces/builtin/pipewire_server.go
+++ b/interfaces/builtin/pipewire_server.go
@@ -1,0 +1,149 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+import (
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/seccomp"
+	"github.com/snapcore/snapd/interfaces/udev"
+	"github.com/snapcore/snapd/snap"
+)
+
+// The pipewire-server interface is the companion interface to the audio-record
+// interface. The design of this interface is based on the idea that the slot
+// implementation (eg pulseaudio) is expected to query snapd on if the
+// audio-record slot is connected or not and the audio service will mediate
+// recording (ie, the rules below allow connecting to the audio service, but do
+// not implement enforcement rules; it is up to the audio service to provide
+// enforcement). If other audio recording servers require different security
+// policy for record and playback (eg, a different socket path), then those
+// accesses will be added to this interface.
+
+const pipewireServerSummary = `allows full access to the pipewire socket (don't needed for normal apps)`
+
+const pipewireServerBaseDeclarationSlots = `
+  pipewire-server:
+    allow-installation:
+      slot-snap-type:
+        - app
+        - core
+    deny-connection:
+      on-classic: false
+    deny-auto-connection: true
+`
+
+const pipewireServerConnectedPlugAppArmor = `
+# Allow communicating with pulseaudio service
+
+owner /{,var/}run/user/[0-9]*/ r,
+owner /{,var/}run/user/[0-9]*/pipewire-0 rwk,
+owner /{,var/}run/user/[0-9]*/pipewire-0.lock rwk,
+`
+
+const pipewireServerConnectedPlugSecComp = `
+shmctl
+`
+
+const pipewireServerPermanentSlotAppArmor = `
+# When running Pipewire in system mode it will switch to the at
+# build time configured user/group on startup.
+capability setuid,
+capability setgid,
+
+capability sys_nice,
+capability sys_resource,
+
+# For udev
+network netlink raw,
+/sys/devices/virtual/dmi/id/sys_vendor r,
+/sys/devices/virtual/dmi/id/bios_vendor r,
+/sys/**/sound/** r,
+
+
+# Shared memory based communication with clients
+
+owner /{,var/}run/user/[0-9]*/ r,
+owner /{,var/}run/user/[0-9]*/pipewire-0 rwk,
+owner /{,var/}run/user/[0-9]*/pipewire-0.lock rwk,
+`
+
+const pipewireServerPermanentSlotSecComp = `
+# The following are needed for UNIX sockets
+personality
+setpriority
+bind
+listen
+accept
+accept4
+shmctl
+setgroups
+setgroups32
+# libudev
+socket AF_NETLINK - NETLINK_KOBJECT_UEVENT
+`
+
+type pipewireServerInterface struct{}
+
+func (iface *pipewireServerInterface) Name() string {
+	return "pipewire-server"
+}
+
+func (iface *pipewireServerInterface) StaticInfo() interfaces.StaticInfo {
+	return interfaces.StaticInfo{
+		Summary:              pipewireServerSummary,
+		ImplicitOnClassic:    true,
+		ImplicitOnCore:       true,
+		BaseDeclarationSlots: pipewireServerBaseDeclarationSlots,
+	}
+}
+
+func (iface *pipewireServerInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	spec.AddSnippet(pipewireServerConnectedPlugAppArmor)
+	return nil
+}
+
+func (iface *pipewireServerInterface) UDevPermanentSlot(spec *udev.Specification, slot *snap.SlotInfo) error {
+	spec.TagDevice(`KERNEL=="timer"`)
+	return nil
+}
+
+func (iface *pipewireServerInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *snap.SlotInfo) error {
+	spec.AddSnippet(pipewireServerPermanentSlotAppArmor)
+	return nil
+}
+
+func (iface *pipewireServerInterface) SecCompConnectedPlug(spec *seccomp.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	spec.AddSnippet(pipewireServerConnectedPlugSecComp)
+	return nil
+}
+
+func (iface *pipewireServerInterface) SecCompPermanentSlot(spec *seccomp.Specification, slot *snap.SlotInfo) error {
+	spec.AddSnippet(pipewireServerPermanentSlotSecComp)
+	return nil
+}
+
+func (iface *pipewireServerInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
+	return true
+}
+
+func init() {
+	registerIface(&pipewireServerInterface{})
+}

--- a/interfaces/builtin/pipewire_server.go
+++ b/interfaces/builtin/pipewire_server.go
@@ -57,7 +57,7 @@ const pipewireServerBaseDeclarationSlots = `
 `
 
 const pipewireServerConnectedPlugAppArmor = `
-# Allow communicating with pulseaudio service
+# Allow communicating with pipewire service
 
 owner /{,var/}run/user/[0-9]*/ r,
 owner /{,var/}run/user/[0-9]*/pipewire-0 rwk,

--- a/interfaces/builtin/pipewire_server.go
+++ b/interfaces/builtin/pipewire_server.go
@@ -64,13 +64,6 @@ owner /{,var/}run/user/[0-9]*/pipewire-0.lock rwk,
 owner /{,var/}run/user/[0-9]*/pulse/pid rwk,
 `
 
-const pipewireServerPermanentSlotAppArmor = `
-owner /{,var/}run/user/[0-9]*/ r,
-owner /{,var/}run/user/[0-9]*/pipewire-0 rwk,
-owner /{,var/}run/user/[0-9]*/pipewire-0.lock rwk,
-owner /{,var/}run/user/[0-9]*/pulse/pid rwk,
-`
-
 type pipewireServerInterface struct{}
 
 func (iface *pipewireServerInterface) Name() string {
@@ -93,11 +86,6 @@ func (iface *pipewireServerInterface) AppArmorConnectedPlug(spec *apparmor.Speci
 
 func (iface *pipewireServerInterface) UDevPermanentSlot(spec *udev.Specification, slot *snap.SlotInfo) error {
 	spec.TagDevice(`KERNEL=="timer"`)
-	return nil
-}
-
-func (iface *pipewireServerInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *snap.SlotInfo) error {
-	spec.AddSnippet(pipewireServerPermanentSlotAppArmor)
 	return nil
 }
 

--- a/interfaces/builtin/pipewire_server.go
+++ b/interfaces/builtin/pipewire_server.go
@@ -59,7 +59,6 @@ const pipewireServerBaseDeclarationSlots = `
 const pipewireServerConnectedPlugAppArmor = `
 # Allow communicating with pipewire service
 
-owner /{,var/}run/user/[0-9]*/ r,
 owner /{,var/}run/user/[0-9]*/pipewire-0 rwk,
 owner /{,var/}run/user/[0-9]*/pipewire-0.lock rwk,
 owner /{,var/}run/user/[0-9]*/pulse/pid rwk,

--- a/interfaces/builtin/pipewire_server_test.go
+++ b/interfaces/builtin/pipewire_server_test.go
@@ -1,0 +1,208 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	"fmt"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/interfaces/seccomp"
+	"github.com/snapcore/snapd/interfaces/udev"
+	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type PipewireServerInterfaceSuite struct {
+	iface           interfaces.Interface
+	coreSlotInfo    *snap.SlotInfo
+	coreSlot        *interfaces.ConnectedSlot
+	classicSlotInfo *snap.SlotInfo
+	classicSlot     *interfaces.ConnectedSlot
+	plugInfo        *snap.PlugInfo
+	plug            *interfaces.ConnectedPlug
+}
+
+var _ = Suite(&PipewireServerInterfaceSuite{
+	iface: builtin.MustInterface("pipewire-server"),
+})
+
+const pipewireServerMockPlugSnapInfoYaml = `name: consumer
+version: 1.0
+apps:
+ app:
+  command: foo
+  plugs: [pipewire-server]
+`
+
+// a pipewire-server slot on a pipewire-server snap (as installed on a core/all-snap system)
+const pipewireServerMockCoreSlotSnapInfoYaml = `name: pipewire-server
+version: 1.0
+apps:
+ app1:
+  command: foo
+  slots: [pipewire-server]
+`
+
+// a pipewire-server slot on the core snap (as automatically added on classic)
+const pipewireServerMockClassicSlotSnapInfoYaml = `name: core
+version: 0
+type: os
+slots:
+ pipewire-server:
+  interface: pipewire-server
+`
+
+func (s *PipewireServerInterfaceSuite) SetUpTest(c *C) {
+	// pipewire-server snap with pipewire-server slot on an core/all-snap install.
+	snapInfo := snaptest.MockInfo(c, pipewireServerMockCoreSlotSnapInfoYaml, nil)
+	s.coreSlotInfo = snapInfo.Slots["pipewire-server"]
+	s.coreSlot = interfaces.NewConnectedSlot(s.coreSlotInfo, nil, nil)
+	// pipewire-server slot on a core snap in a classic install.
+	snapInfo = snaptest.MockInfo(c, pipewireServerMockClassicSlotSnapInfoYaml, nil)
+	s.classicSlotInfo = snapInfo.Slots["pipewire-server"]
+	s.classicSlot = interfaces.NewConnectedSlot(s.classicSlotInfo, nil, nil)
+	// snap with the pipewire-server plug
+	snapInfo = snaptest.MockInfo(c, pipewireServerMockPlugSnapInfoYaml, nil)
+	s.plugInfo = snapInfo.Plugs["pipewire-server"]
+	s.plug = interfaces.NewConnectedPlug(s.plugInfo, nil, nil)
+}
+
+func (s *PipewireServerInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "pipewire-server")
+}
+
+func (s *PipewireServerInterfaceSuite) TestSanitizeSlot(c *C) {
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.coreSlotInfo), IsNil)
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.classicSlotInfo), IsNil)
+}
+
+func (s *PipewireServerInterfaceSuite) TestSanitizePlug(c *C) {
+	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
+}
+
+func (s *PipewireServerInterfaceSuite) TestSecComp(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	// connected plug to core slot
+	spec := &seccomp.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.coreSlot), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "shmctl\n")
+
+	// connected core slot to plug
+	spec = &seccomp.Specification{}
+	c.Assert(spec.AddConnectedSlot(s.iface, s.plug, s.coreSlot), IsNil)
+	c.Assert(spec.SecurityTags(), HasLen, 0)
+
+	// permanent core slot
+	spec = &seccomp.Specification{}
+	c.Assert(spec.AddPermanentSlot(s.iface, s.coreSlotInfo), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.pipewire-server.app1"})
+	c.Assert(spec.SnippetForTag("snap.pipewire-server.app1"), testutil.Contains, "listen\n")
+}
+
+func (s *PipewireServerInterfaceSuite) TestSecCompOnClassic(c *C) {
+	restore := release.MockOnClassic(true)
+	defer restore()
+
+	// connected plug to classic slot
+	spec := &seccomp.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.classicSlot), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "shmctl\n")
+
+	// connected classic slot to plug
+	spec = &seccomp.Specification{}
+	c.Assert(spec.AddConnectedSlot(s.iface, s.plug, s.classicSlot), IsNil)
+	c.Assert(spec.SecurityTags(), HasLen, 0)
+
+	// permanent classic slot
+	spec = &seccomp.Specification{}
+	c.Assert(spec.AddPermanentSlot(s.iface, s.classicSlotInfo), IsNil)
+	c.Assert(spec.SecurityTags(), HasLen, 0)
+}
+
+func (s *PipewireServerInterfaceSuite) TestAppArmor(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	// connected plug to core slot
+	spec := &apparmor.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.coreSlot), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/{,var/}run/user/[0-9]*/ r,\n")
+	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/{,var/}run/user/[0-9]*/pipewire-0 rwk,\n")
+	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/{,var/}run/user/[0-9]*/pipewire-0.lock rwk,\n")
+
+	// connected core slot to plug
+	spec = &apparmor.Specification{}
+	c.Assert(spec.AddConnectedSlot(s.iface, s.plug, s.coreSlot), IsNil)
+	c.Assert(spec.SecurityTags(), HasLen, 0)
+
+	// permanent core slot
+	spec = &apparmor.Specification{}
+	c.Assert(spec.AddPermanentSlot(s.iface, s.coreSlotInfo), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.pipewire-server.app1"})
+	c.Check(spec.SnippetForTag("snap.pipewire-server.app1"), testutil.Contains, "capability setuid,\n")
+}
+
+func (s *PipewireServerInterfaceSuite) TestAppArmorOnClassic(c *C) {
+	restore := release.MockOnClassic(true)
+	defer restore()
+
+	// connected plug to classic slot
+	spec := &apparmor.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.classicSlot), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/{,var/}run/user/[0-9]*/ r,\n")
+	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/{,var/}run/user/[0-9]*/pipewire-0 rwk,\n")
+	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/{,var/}run/user/[0-9]*/pipewire-0.lock rwk,\n")
+
+	// connected classic slot to plug
+	spec = &apparmor.Specification{}
+	c.Assert(spec.AddConnectedSlot(s.iface, s.plug, s.classicSlot), IsNil)
+	c.Assert(spec.SecurityTags(), HasLen, 0)
+
+	// permanent classic slot
+	spec = &apparmor.Specification{}
+	c.Assert(spec.AddPermanentSlot(s.iface, s.classicSlotInfo), IsNil)
+	c.Assert(spec.SecurityTags(), HasLen, 0)
+}
+
+func (s *PipewireServerInterfaceSuite) TestUDev(c *C) {
+	spec := &udev.Specification{}
+	c.Assert(spec.AddPermanentSlot(s.iface, s.coreSlotInfo), IsNil)
+	c.Assert(spec.Snippets(), HasLen, 2)
+	c.Assert(spec.Snippets(), testutil.Contains, `# pipewire-server
+KERNEL=="timer", TAG+="snap_pipewire-server_app1"`)
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_pipewire-server_app1", RUN+="%v/snap-device-helper $env{ACTION} snap_pipewire-server_app1 $devpath $major:$minor"`, dirs.DistroLibExecDir))
+}
+
+func (s *PipewireServerInterfaceSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}

--- a/interfaces/builtin/pipewire_server_test.go
+++ b/interfaces/builtin/pipewire_server_test.go
@@ -111,19 +111,11 @@ func (s *PipewireServerInterfaceSuite) TestSecComp(c *C) {
 	// connected plug to core slot
 	spec := &seccomp.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.coreSlot), IsNil)
-	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
-	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "shmctl\n")
 
 	// connected core slot to plug
 	spec = &seccomp.Specification{}
 	c.Assert(spec.AddConnectedSlot(s.iface, s.plug, s.coreSlot), IsNil)
 	c.Assert(spec.SecurityTags(), HasLen, 0)
-
-	// permanent core slot
-	spec = &seccomp.Specification{}
-	c.Assert(spec.AddPermanentSlot(s.iface, s.coreSlotInfo), IsNil)
-	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.pipewire-server.app1"})
-	c.Assert(spec.SnippetForTag("snap.pipewire-server.app1"), testutil.Contains, "listen\n")
 }
 
 func (s *PipewireServerInterfaceSuite) TestSecCompOnClassic(c *C) {
@@ -133,8 +125,6 @@ func (s *PipewireServerInterfaceSuite) TestSecCompOnClassic(c *C) {
 	// connected plug to classic slot
 	spec := &seccomp.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.classicSlot), IsNil)
-	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
-	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "shmctl\n")
 
 	// connected classic slot to plug
 	spec = &seccomp.Specification{}
@@ -169,7 +159,6 @@ func (s *PipewireServerInterfaceSuite) TestAppArmor(c *C) {
 	spec = &apparmor.Specification{}
 	c.Assert(spec.AddPermanentSlot(s.iface, s.coreSlotInfo), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.pipewire-server.app1"})
-	c.Check(spec.SnippetForTag("snap.pipewire-server.app1"), testutil.Contains, "capability setuid,\n")
 }
 
 func (s *PipewireServerInterfaceSuite) TestAppArmorOnClassic(c *C) {

--- a/interfaces/builtin/pipewire_server_test.go
+++ b/interfaces/builtin/pipewire_server_test.go
@@ -153,11 +153,6 @@ func (s *PipewireServerInterfaceSuite) TestAppArmor(c *C) {
 	spec = &apparmor.Specification{}
 	c.Assert(spec.AddConnectedSlot(s.iface, s.plug, s.coreSlot), IsNil)
 	c.Assert(spec.SecurityTags(), HasLen, 0)
-
-	// permanent core slot
-	spec = &apparmor.Specification{}
-	c.Assert(spec.AddPermanentSlot(s.iface, s.coreSlotInfo), IsNil)
-	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.pipewire-server.app1"})
 }
 
 func (s *PipewireServerInterfaceSuite) TestAppArmorOnClassic(c *C) {

--- a/interfaces/builtin/pipewire_server_test.go
+++ b/interfaces/builtin/pipewire_server_test.go
@@ -145,7 +145,6 @@ func (s *PipewireServerInterfaceSuite) TestAppArmor(c *C) {
 	spec := &apparmor.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.coreSlot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
-	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/{,var/}run/user/[0-9]*/ r,\n")
 	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/{,var/}run/user/[0-9]*/pipewire-0 rwk,\n")
 	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/{,var/}run/user/[0-9]*/pipewire-0.lock rwk,\n")
 	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/{,var/}run/user/[0-9]*/pulse/pid rwk,\n")
@@ -169,7 +168,6 @@ func (s *PipewireServerInterfaceSuite) TestAppArmorOnClassic(c *C) {
 	spec := &apparmor.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.classicSlot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
-	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/{,var/}run/user/[0-9]*/ r,\n")
 	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/{,var/}run/user/[0-9]*/pipewire-0 rwk,\n")
 	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/{,var/}run/user/[0-9]*/pipewire-0.lock rwk,\n")
 	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/{,var/}run/user/[0-9]*/pulse/pid rwk,\n")

--- a/interfaces/builtin/pipewire_server_test.go
+++ b/interfaces/builtin/pipewire_server_test.go
@@ -158,6 +158,7 @@ func (s *PipewireServerInterfaceSuite) TestAppArmor(c *C) {
 	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/{,var/}run/user/[0-9]*/ r,\n")
 	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/{,var/}run/user/[0-9]*/pipewire-0 rwk,\n")
 	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/{,var/}run/user/[0-9]*/pipewire-0.lock rwk,\n")
+	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/{,var/}run/user/[0-9]*/pulse/pid rwk,\n")
 
 	// connected core slot to plug
 	spec = &apparmor.Specification{}
@@ -182,6 +183,7 @@ func (s *PipewireServerInterfaceSuite) TestAppArmorOnClassic(c *C) {
 	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/{,var/}run/user/[0-9]*/ r,\n")
 	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/{,var/}run/user/[0-9]*/pipewire-0 rwk,\n")
 	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/{,var/}run/user/[0-9]*/pipewire-0.lock rwk,\n")
+	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/{,var/}run/user/[0-9]*/pulse/pid rwk,\n")
 
 	// connected classic slot to plug
 	spec = &apparmor.Specification{}

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -807,6 +807,7 @@ var (
 		"network-status":            {"core"},
 		"ofono":                     {"app", "core"},
 		"online-accounts-service":   {"app"},
+		"pipewire-server":           {"app", "core"},
 		"power-control":             {"core"},
 		"ppp":                       {"core"},
 		"pulseaudio":                {"app", "core"},

--- a/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
@@ -359,6 +359,9 @@ apps:
   physical-memory-observe:
     command: bin/run
     plugs: [ physical-memory-observe ]
+  pipewire-server:
+    command: bin/run
+    plugs: [ pipewire-server ]
   pkcs11:
     command: bin/run
     plugs: [ pkcs11 ]


### PR DESCRIPTION
This MR adds a new interface, 'pipewire-server', that gives full access to the pipewire socket and lock file, and the pulseaudio pid file, located at

    /run/user/XXX/pipewire-0
    /run/user/XXX/pipewire-0.lock
    /run/user/XXX/pulse/pid

It allows not only to read and write to the socket, but also to create it. This is needed for the following things:

    - containerize the Pipewire/Wireplumber/Pipewire-pulse daemons
    - containerize xdg-desktop-portal
    - allow to share the screen in ubuntu-core-desktop
    - have pipewire support in ubuntu-core

This is NOT needed for normal use of pipewire, because xdg-desktop-portal is able to export it in a secure maner inside a container.

https://warthogs.atlassian.net/browse/UCD-102

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
