### PR TITLE
asserts: support validation-sets in model assertion

### DIFF
--- a/asserts/header_checks.go
+++ b/asserts/header_checks.go
@@ -107,24 +107,20 @@ func checkAssertType(assertType *AssertionType) error {
 }
 
 // use 'defl' default if missing
-func checkIntWithDefaultWhat(headers map[string]interface{}, name, what string, defl int) (int, error) {
+func checkIntWithDefault(headers map[string]interface{}, name string, defl int) (int, error) {
 	value, ok := headers[name]
 	if !ok {
 		return defl, nil
 	}
 	s, ok := value.(string)
 	if !ok {
-		return -1, fmt.Errorf("%q %s is not an integer: %v", name, what, value)
+		return -1, fmt.Errorf("%q header is not an integer: %v", name, value)
 	}
-	m, err := atoi(s, "%q %s", name, what)
+	m, err := atoi(s, "%q %s", name, "header")
 	if err != nil {
 		return -1, err
 	}
 	return m, nil
-}
-
-func checkIntWithDefault(headers map[string]interface{}, name string, defl int) (int, error) {
-	return checkIntWithDefaultWhat(headers, name, "header", defl)
 }
 
 func checkInt(headers map[string]interface{}, name string) (int, error) {

--- a/asserts/header_checks.go
+++ b/asserts/header_checks.go
@@ -107,7 +107,7 @@ func checkAssertType(assertType *AssertionType) error {
 }
 
 // use 'defl' default if missing
-func checkIntWithDefault(headers map[string]interface{}, name string, defl int) (int, error) {
+func checkIntWithDefaultWhat(headers map[string]interface{}, name, what string, defl int) (int, error) {
 	value, ok := headers[name]
 	if !ok {
 		return defl, nil
@@ -116,11 +116,15 @@ func checkIntWithDefault(headers map[string]interface{}, name string, defl int) 
 	if !ok {
 		return -1, fmt.Errorf("%q header is not an integer: %v", name, value)
 	}
-	m, err := atoi(s, "%q %s", name, "header")
+	m, err := atoi(s, "%q %s", name, what)
 	if err != nil {
 		return -1, err
 	}
 	return m, nil
+}
+
+func checkIntWithDefault(headers map[string]interface{}, name string, defl int) (int, error) {
+	return checkIntWithDefaultWhat(headers, name, "header", defl)
 }
 
 func checkInt(headers map[string]interface{}, name string) (int, error) {

--- a/asserts/header_checks.go
+++ b/asserts/header_checks.go
@@ -114,7 +114,7 @@ func checkIntWithDefaultWhat(headers map[string]interface{}, name, what string, 
 	}
 	s, ok := value.(string)
 	if !ok {
-		return -1, fmt.Errorf("%q header is not an integer: %v", name, value)
+		return -1, fmt.Errorf("%q %s is not an integer: %v", name, what, value)
 	}
 	m, err := atoi(s, "%q %s", name, what)
 	if err != nil {

--- a/asserts/model.go
+++ b/asserts/model.go
@@ -707,10 +707,10 @@ func checkModelValidationSetAccountID(headers map[string]interface{}, what, bran
 	return accountID, nil
 }
 
-// checkModelValidationSetSequence reads the optional 'sequence' member, if
+// checkOptionalModelValidationSetSequence reads the optional 'sequence' member, if
 // not set, returns 0 as this means unpinned. Unfortunately we are not able
 // to reuse `checkSequence` as it operates inside different parameters.
-func checkModelValidationSetSequence(headers map[string]interface{}, what string) (int, error) {
+func checkOptionalModelValidationSetSequence(headers map[string]interface{}, what string) (int, error) {
 	// Default to 0 when the sequence header is not present
 	if _, ok := headers["sequence"]; !ok {
 		return 0, nil
@@ -753,7 +753,7 @@ func checkModelValidationSet(headers map[string]interface{}, brandID string) (*M
 	}
 
 	what = fmt.Sprintf("of validation-set \"%s/%s\"", accountID, name)
-	seq, err := checkModelValidationSetSequence(headers, what)
+	seq, err := checkOptionalModelValidationSetSequence(headers, what)
 	if err != nil {
 		return nil, err
 	}
@@ -787,7 +787,7 @@ func checkOptionalModelValidationSets(headers map[string]interface{}, brandID st
 	for i, entry := range entries {
 		data, ok := entry.(map[string]interface{})
 		if !ok {
-			return nil, fmt.Errorf(`"validation-sets" must contain a list of validation sets`)
+			return nil, fmt.Errorf(`entry in "validation-sets" is not a valid validation-set`)
 		}
 
 		vs, err := checkModelValidationSet(data, brandID)

--- a/asserts/model.go
+++ b/asserts/model.go
@@ -405,13 +405,11 @@ func (mg ModelGrade) Code() uint32 {
 type ModelValidationSetMode string
 
 const (
-	ModelValidationSetModeMonitor        ModelValidationSetMode = "monitor"
 	ModelValidationSetModePreferEnforced ModelValidationSetMode = "prefer-enforce"
 	ModelValidationSetModeEnforced       ModelValidationSetMode = "enforce"
 )
 
 var validModelValidationSetModes = []string{
-	string(ModelValidationSetModeMonitor),
 	string(ModelValidationSetModePreferEnforced),
 	string(ModelValidationSetModeEnforced),
 }

--- a/asserts/model.go
+++ b/asserts/model.go
@@ -723,7 +723,7 @@ func checkModelValidationSetSequence(headers map[string]interface{}, what string
 
 	// If sequence is provided, only accept positive values above 0
 	if seq <= 0 {
-		return 0, fmt.Errorf("\"sequence\" %s must be larger than 0", what)
+		return 0, fmt.Errorf("\"sequence\" %s must be larger than 0 or left unspecified (meaning tracking latest)", what)
 	}
 	return seq, nil
 }

--- a/asserts/model.go
+++ b/asserts/model.go
@@ -711,14 +711,18 @@ func checkModelValidationSetAccountID(headers map[string]interface{}, what, bran
 // not set, returns 0 as this means unpinned. Unfortunately we are not able
 // to reuse `checkSequence` as it operates inside different parameters.
 func checkModelValidationSetSequence(headers map[string]interface{}, what string) (int, error) {
-	seq, err := checkIntWithDefaultWhat(headers, "sequence", what, 0)
+	// Default to 0 when the sequence header is not present
+	if _, ok := headers["sequence"]; !ok {
+		return 0, nil
+	}
+
+	seq, err := checkIntWhat(headers, "sequence", what)
 	if err != nil {
 		return 0, err
 	}
 
-	// Assert that sequence number is not zero, as zero will be interpreted as not specified,
-	// which means that the validation-set is unpinned.
-	if seq < 0 {
+	// If sequence is provided, only accept positive values above 0
+	if seq <= 0 {
 		return 0, fmt.Errorf("\"sequence\" %s must be larger than 0", what)
 	}
 	return seq, nil

--- a/asserts/model_test.go
+++ b/asserts/model_test.go
@@ -1202,12 +1202,12 @@ func (mods *modelSuite) TestValidationSetsDecodeFAIL(c *C) {
 		{`validation-sets:
   -
     mode: prefer-enforce
-`, "assertion model: \"name\" header is mandatory"},
+`, "assertion model: \"name\" of validation-set is mandatory"},
 		// missing mode
 		{`validation-sets:
   -
     name: my-set
-`, "assertion model: \"mode\" header is mandatory"},
+`, "assertion model: \"mode\" of validation-set \"brand-id1/my-set\" is mandatory"},
 		// invalid value in mode
 		{`validation-sets:
   -
@@ -1215,15 +1215,23 @@ func (mods *modelSuite) TestValidationSetsDecodeFAIL(c *C) {
     name: my-set
     sequence: 10
     mode: hello
-`, "assertion model: validation-set mode for model must be prefer-enforce|enforce, not \"hello\""},
-		// sequence number invalid
+`, "assertion model: \"mode\" of validation-set \"brand-id1/my-set\" must be prefer-enforce|enforce, not \"hello\""},
+		// sequence number invalid (not an integer)
+		{`validation-sets:
+  -
+    account-id: developer1
+    sequence: foo
+    name: my-set
+    mode: enforce
+`, "assertion model: \"sequence\" of validation-set \"developer1/my-set\" is not an integer: foo"},
+		// sequence number invalid (below 0)
 		{`validation-sets:
   -
     account-id: developer1
     sequence: -1
     name: my-set
     mode: enforce
-`, "assertion model: invalid sequence number for validation set, sequence must be larger than 0"},
+`, "assertion model: \"sequence\" of validation-set \"developer1/my-set\" must be larger than 0"},
 		// duplicate validation-set
 		{`validation-sets:
   -

--- a/asserts/model_test.go
+++ b/asserts/model_test.go
@@ -1215,21 +1215,21 @@ func (mods *modelSuite) TestValidationSetsDecodeFAIL(c *C) {
     name: my-set
     sequence: 10
     mode: hello
-`, "assertion model: validation-set mode for model must be monitor|prefer-enforce|enforce, not \"hello\""},
+`, "assertion model: validation-set mode for model must be prefer-enforce|enforce, not \"hello\""},
 		// sequence number invalid
 		{`validation-sets:
   -
     account-id: developer1
     sequence: -1
     name: my-set
-    mode: monitor
+    mode: enforce
 `, "assertion model: invalid sequence number for validation set, sequence must be larger than 0"},
 		// duplicate validation-set
 		{`validation-sets:
   -
     account-id: developer1
     name: my-set
-    mode: monitor
+    mode: prefer-enforce
   -
     account-id: developer1
     name: my-set
@@ -1285,13 +1285,13 @@ func (mods *modelSuite) TestValidationSetsDecodeOK(c *C) {
   -
     account-id: developer1
     name: my-set
-    mode: monitor
+    mode: prefer-enforce
 `,
 			[]*asserts.ModelValidationSet{
 				{
 					AccountID: "developer1",
 					Name:      "my-set",
-					Mode:      asserts.ModelValidationSetModeMonitor,
+					Mode:      asserts.ModelValidationSetModePreferEnforced,
 				},
 			}},
 	}

--- a/asserts/model_test.go
+++ b/asserts/model_test.go
@@ -1246,7 +1246,7 @@ func (mods *modelSuite) TestValidationSetsDecodeInvalid(c *C) {
     sequence: -1
     name: my-set
     mode: enforce
-`, "assertion model: \"sequence\" of validation-set \"developer1/my-set\" must be larger than 0"},
+`, "assertion model: \"sequence\" of validation-set \"developer1/my-set\" must be larger than 0 or left unspecified \\(meaning tracking latest\\)"},
 		// sequence number invalid (0 is not allowed)
 		{`validation-sets:
   -
@@ -1254,7 +1254,7 @@ func (mods *modelSuite) TestValidationSetsDecodeInvalid(c *C) {
     sequence: 0
     name: my-set
     mode: enforce
-`, "assertion model: \"sequence\" of validation-set \"developer1/my-set\" must be larger than 0"},
+`, "assertion model: \"sequence\" of validation-set \"developer1/my-set\" must be larger than 0 or left unspecified \\(meaning tracking latest\\)"},
 		// duplicate validation-set
 		{`validation-sets:
   -

--- a/asserts/model_test.go
+++ b/asserts/model_test.go
@@ -1250,7 +1250,8 @@ func (mods *modelSuite) TestValidationSetsDecodeOK(c *C) {
 		frag     string
 		expected []*asserts.ModelValidationSet
 	}{
-		// brand validation-set
+		// brand validation-set, this should instead use the brand specified
+		// by the core20ModelExample, as account-id is not set
 		{`validation-sets:
   -
     name: my-set
@@ -1258,7 +1259,7 @@ func (mods *modelSuite) TestValidationSetsDecodeOK(c *C) {
 `,
 			[]*asserts.ModelValidationSet{
 				{
-					AccountID: "",
+					AccountID: "brand-id1",
 					Name:      "my-set",
 					Mode:      asserts.ModelValidationSetModePreferEnforced,
 				},

--- a/asserts/model_test.go
+++ b/asserts/model_test.go
@@ -1239,11 +1239,19 @@ func (mods *modelSuite) TestValidationSetsDecodeInvalid(c *C) {
     name: my-set
     mode: enforce
 `, "assertion model: \"sequence\" of validation-set \"developer1/my-set\" is not an integer: foo"},
-		// sequence number invalid (below 0)
+		// sequence number invalid (below)
 		{`validation-sets:
   -
     account-id: developer1
     sequence: -1
+    name: my-set
+    mode: enforce
+`, "assertion model: \"sequence\" of validation-set \"developer1/my-set\" must be larger than 0"},
+		// sequence number invalid (0 is not allowed)
+		{`validation-sets:
+  -
+    account-id: developer1
+    sequence: 0
     name: my-set
     mode: enforce
 `, "assertion model: \"sequence\" of validation-set \"developer1/my-set\" must be larger than 0"},

--- a/asserts/model_test.go
+++ b/asserts/model_test.go
@@ -1204,7 +1204,7 @@ func (mods *modelSuite) TestValidationSetsDecodeInvalid(c *C) {
 		// invalid format 2
 		{`validation-sets:
   - test
-`, "assertion model: \"validation-sets\" must contain a list of validation sets"},
+`, "assertion model: entry in \"validation-sets\" is not a valid validation-set"},
 		// missing name
 		{`validation-sets:
   -


### PR DESCRIPTION
Add `validation-sets` support to the model assertion.
