### PR TITLE
i/b/fwupd: allow to write to some EFI path for some capsules

### DIFF
--- a/interfaces/builtin/fwupd.go
+++ b/interfaces/builtin/fwupd.go
@@ -221,6 +221,7 @@ const fwupdPermanentSlotAppArmorClassic = `
   # allow access to fwupd* and fw/ under any distro for classic systems
   /boot/efi/EFI/*/fwupd*.efi* rw,
   /boot/efi/EFI/*/fw/** rw,
+  /boot/efi/EFI/UpdateCapsule/** rw,
 `
 
 const fwupdConnectedPlugAppArmor = `


### PR DESCRIPTION
See https://github.com/fwupd/fwupd/blob/e69ffa1b713b7e21177bae7483cbbff1596a6284/plugins/uefi-capsule/fu-uefi-cod-device.c#L177
