### PR TITLE
o/snapstate: create pre-dl task even if one is in DoneStatus

### DIFF
--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -385,7 +385,7 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 
 					for _, task := range tasks {
 						switch task.Status() {
-						case state.DoStatus, state.DoneStatus, state.DoingStatus:
+						case state.DoStatus, state.DoingStatus:
 							// there's already a task for this snap/revision combination
 							return nil, busyErr
 						}

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -9144,18 +9144,31 @@ func (s *snapmgrTestSuite) TestAutoRefreshBusySnapButOngoingPreDownload(c *C) {
 	task := s.state.NewTask("pre-download-snap", "")
 	task.Set("snap-setup", snapsup)
 	chg.AddTask(task)
-	chg.SetStatus(state.DoStatus)
 
+	// don't create a pre-download task if one exists w/ these statuses
+	for _, status := range []state.Status{state.DoStatus, state.DoingStatus} {
+		task.SetStatus(status)
+		ts, err := snapstate.DoInstall(s.state, snapst, snapsup, 0, "", inUseCheck)
+
+		var busyErr *snapstate.TimedBusySnapError
+		c.Assert(errors.As(err, &busyErr), Equals, true)
+		refreshInfo := busyErr.PendingSnapRefreshInfo()
+		c.Check(refreshInfo, DeepEquals, &userclient.PendingSnapRefreshInfo{
+			InstanceName:  "some-snap",
+			TimeRemaining: snapstate.MaxInhibition,
+		})
+		c.Assert(ts, IsNil)
+
+		// reset modified state to avoid conflicts
+		snapst.RefreshInhibitedTime = nil
+		snapstate.Set(s.state, "some-snap", snapst)
+	}
+
+	// a "Done" pre-download is ignored since the auto-refresh it causes might also be done
+	task.SetStatus(state.DoneStatus)
 	ts, err := snapstate.DoInstall(s.state, snapst, snapsup, 0, "", inUseCheck)
-
-	var busyErr *snapstate.TimedBusySnapError
-	c.Assert(errors.As(err, &busyErr), Equals, true)
-	refreshInfo := busyErr.PendingSnapRefreshInfo()
-	c.Check(refreshInfo, DeepEquals, &userclient.PendingSnapRefreshInfo{
-		InstanceName:  "some-snap",
-		TimeRemaining: snapstate.MaxInhibition,
-	})
-	c.Assert(ts, IsNil)
+	c.Assert(err, FitsTypeOf, &snapstate.TimedBusySnapError{})
+	c.Assert(ts.Tasks(), HasLen, 1)
 }
 
 func (s *snapmgrTestSuite) TestReRefreshCreatesPreDownloadChange(c *C) {


### PR DESCRIPTION
When deciding whether to create a new pre-download task or not, don't consider "Done" pre-download tasks since we can't know whether the auto-refresh they trigger has finished. If we don't create a new pre-download change because of a "Done" task and the auto-refresh it triggers completed before the current one was inhibited, we would miss a valid pre-download scenario. On the other hand, if we schedule an unnecessary pre-download change, the worst case scenario is that the snap is already in the cache and the auto-refresh is a no-op.