### PR TITLE
interfaces/apparmor: add read of /proc/PID/cpuset to base template

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -252,6 +252,7 @@ var templateCommon = `
   /etc/{,writable/}mailname r,
   /etc/{,writable/}timezone r,
   owner @{PROC}/@{pid}/cgroup rk,
+  @{PROC}/@{pid}/cpuset r,
   @{PROC}/@{pid}/io r,
   owner @{PROC}/@{pid}/limits r,
   owner @{PROC}/@{pid}/loginuid r,


### PR DESCRIPTION
See https://forum.snapcraft.io/t/interface-for-reading-proc-pid-cpuset/33886 for discussion but basically this is unprivileged information that is consistent with other similar pieces of information already exposed in the base template.
