### PR TITLE
interfaces/screen-inhibit-control: Add support for xfce-power-manager

### DIFF
--- a/interfaces/builtin/screen_inhibit_control.go
+++ b/interfaces/builtin/screen_inhibit_control.go
@@ -64,6 +64,15 @@ dbus (send)
     member={Inhibit,UnInhibit,SimulateUserActivity}
     peer=(label=unconfined),
 
+# xfce4-power-manager -
+# https://github.com/xfce-mirror/xfce4-power-manager/blob/0b3ad06ad4f51eae1aea3cdc26f434d8b5ce763e/src/org.freedesktop.PowerManagement.Inhibit.xml
+dbus (send)
+    bus=session
+    path=/org/freedesktop/PowerManagement/Inhibit
+    interface=org.freedesktop.PowerManagement.Inhibit
+    member={Inhibit,UnInhibit}
+    peer=(label=unconfined),
+
 # API rule
 dbus (send)
     bus=session


### PR DESCRIPTION
This is required for firefox
https://bugzilla.mozilla.org/show_bug.cgi?id=1785799
