### PR TITLE
cmd/snap: expose validate command

### DIFF
--- a/cmd/snap/cmd_help.go
+++ b/cmd/snap/cmd_help.go
@@ -257,17 +257,19 @@ var helpCategories = []helpCategory{
 		Description:     i18n.G("introspection and debugging of snapd"),
 		Commands:        []string{"version"},
 		AllOnlyCommands: []string{"debug"},
-	},
-	{
+	}, {
 		Label:           i18n.G("Development"),
 		Description:     i18n.G("developer-oriented features"),
 		Commands:        []string{"download", "pack", "run", "try"},
 		AllOnlyCommands: []string{"prepare-image"},
-	},
-	{
+	}, {
 		Label:       i18n.G("Quota Groups"),
 		Description: i18n.G("Manage quota groups for snaps"),
 		Commands:    []string{"set-quota", "remove-quota", "quotas", "quota"},
+	}, {
+		Label:       i18n.G("Validation Sets"),
+		Description: i18n.G("Manage validation sets"),
+		Commands:    []string{"validate"},
 	},
 }
 

--- a/cmd/snap/cmd_validate.go
+++ b/cmd/snap/cmd_validate.go
@@ -56,7 +56,7 @@ operations which would result in snaps breaking the validation set's constraints
 `)
 
 func init() {
-	cmd := addCommand("validate", shortValidateHelp, longValidateHelp, func() flags.Commander { return &cmdValidate{} }, waitDescs.also(colorDescs.also(map[string]string{
+	addCommand("validate", shortValidateHelp, longValidateHelp, func() flags.Commander { return &cmdValidate{} }, waitDescs.also(colorDescs.also(map[string]string{
 		// TRANSLATORS: This should not start with a lowercase letter.
 		"monitor": i18n.G("Monitor the given validations set"),
 		// TRANSLATORS: This should not start with a lowercase letter.
@@ -64,15 +64,13 @@ func init() {
 		// TRANSLATORS: This should not start with a lowercase letter.
 		"forget": i18n.G("Forget the given validation set"),
 		// TRANSLATORS: This should not start with a lowercase letter.
-		"refresh": i18n.G("Refresh or remove snaps to satisfy enforced validation sets"),
+		"refresh": i18n.G("Refresh or install snaps to satisfy enforced validation sets"),
 	})), []argDesc{{
 		// TRANSLATORS: This needs to begin with < and end with >
 		name: i18n.G("<validation-set>"),
 		// TRANSLATORS: This should not start with a lowercase letter.
 		desc: i18n.G("Validation set with an optional pinned sequence point, i.e. account-id/name[=seq]"),
 	}})
-	// XXX: remove once api has landed
-	cmd.hidden = true
 }
 
 func fmtValid(res *client.ValidationSetResult) string {

--- a/cmd/snap/cmd_validate.go
+++ b/cmd/snap/cmd_validate.go
@@ -46,7 +46,13 @@ type cmdValidate struct {
 
 var shortValidateHelp = i18n.G("List or apply validation sets")
 var longValidateHelp = i18n.G(`
-The validate command lists or applies validations sets
+The validate command lists or applies validation sets that state which snaps
+are required or permitted to be installed together, optionally constrained to
+fixed revisions.
+
+A validation set can either be in monitoring mode, in which case its constraints
+aren't enforced, or in enforcing mode, in which case snapd will not allow
+operations which would result in snaps breaking the validation set's constraints.
 `)
 
 func init() {

--- a/tests/main/snap-validate-basic/task.yaml
+++ b/tests/main/snap-validate-basic/task.yaml
@@ -31,7 +31,7 @@ prepare : |
   snap known validation-set | MATCH "name: hello-world"
 
 execute: |
-  snap validate --help | MATCH "The validate command lists or applies validations sets"
+  snap validate --help | MATCH "The validate command lists or applies validation sets"
   snap validate 2>&1 | MATCH "No validations are available"
 
   snap validate --monitor 2>&1 | MATCH "missing validation set argument"


### PR DESCRIPTION
Expose the `snap validate` command in the help info