### PR TITLE
tests/lib: support for sequence forming assertions in fakestore code

### DIFF
--- a/tests/lib/fakestore/store/store.go
+++ b/tests/lib/fakestore/store/store.go
@@ -783,7 +783,6 @@ func (s *Store) assertTypeAndKey(urlPath string) (*asserts.AssertionType, []stri
 }
 
 func (s *Store) retrieveAssertionWrapper(bs asserts.Backstore, assertType *asserts.AssertionType, keyParts []string, values url.Values) (asserts.Assertion, error) {
-
 	pk := keyParts
 	if assertType.SequenceForming() {
 		seq, err := s.sequenceFromQueryValues(values)

--- a/tests/lib/fakestore/store/store.go
+++ b/tests/lib/fakestore/store/store.go
@@ -757,7 +757,11 @@ func (s *Store) sequenceFromQueryValues(values url.Values) (int, error) {
 			if err != nil {
 				return -1, fmt.Errorf("cannot parse sequence %s: %v", val[0], err)
 			}
-			return seq, nil
+			// XXX: Treat values 0 and below as error? Anyone know the official store
+			// behavior on this?
+			if seq > 0 {
+				return seq, nil
+			}
 		}
 	}
 	return -1, nil

--- a/tests/lib/fakestore/store/store.go
+++ b/tests/lib/fakestore/store/store.go
@@ -799,7 +799,7 @@ func (s *Store) retrieveAssertionWrapper(bs asserts.Backstore, assertType *asser
 		}
 
 		// If no sequence key is present, then we use a special lookup to
-		// retreive the latest sequence of the sequence forming assertion.
+		// retrieve the latest sequence of the sequence forming assertion.
 		if seq <= 0 {
 			return s.retrieveSequenceFormingAssertion(bs, assertType, keyParts, seq)
 		}

--- a/tests/lib/fakestore/store/store.go
+++ b/tests/lib/fakestore/store/store.go
@@ -757,11 +757,12 @@ func (s *Store) sequenceFromQueryValues(values url.Values) (int, error) {
 			if err != nil {
 				return -1, fmt.Errorf("cannot parse sequence %s: %v", val[0], err)
 			}
-			// XXX: Treat values 0 and below as error? Anyone know the official store
-			// behavior on this?
-			if seq > 0 {
-				return seq, nil
+
+			// Only positive integers and 'latest' are valid
+			if seq <= 0 {
+				return -1, fmt.Errorf("the requested sequence must be above 0")
 			}
+			return seq, nil
 		}
 	}
 	return -1, nil

--- a/tests/lib/fakestore/store/store_test.go
+++ b/tests/lib/fakestore/store/store_test.go
@@ -443,6 +443,23 @@ timestamp: 2016-08-19T19:19:19Z
 sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij
 
 AXNpZw=`
+	exampleValidationSet = `type: validation-set
+authority-id: canonical
+account-id: canonical
+name: base-set
+sequence: 2
+revision: 1
+series: 16
+snaps:
+  -
+    id: yOqKhntON3vR7kwEbVPsILm7bUViPDzz
+    name: snap-b
+    presence: required
+    revision: 1
+timestamp: 2020-11-06T09:16:26Z
+sign-key-sha3-384: 7bbncP0c4RcufwReeiylCe0S7IMCn-tHLNSCgeOVmV3K-7_MzpAHgJDYeOjldefE
+
+AXNpZw==`
 )
 
 func (s *storeTestSuite) TestAssertionsEndpointPreloaded(c *C) {
@@ -476,6 +493,45 @@ func (s *storeTestSuite) TestAssertionsEndpointFromAssertsDir(c *C) {
 	body, err := ioutil.ReadAll(resp.Body)
 	c.Assert(err, IsNil)
 	c.Check(string(body), Equals, exampleSnapRev)
+}
+
+func (s *storeTestSuite) TestAssertionsEndpointSequenceAssertion(c *C) {
+	err := ioutil.WriteFile(filepath.Join(s.store.assertDir, "base-set.validation-set"), []byte(exampleValidationSet), 0655)
+	c.Assert(err, IsNil)
+
+	resp, err := s.StoreGet(`/v2/assertions/validation-set/16/canonical/base-set?sequence=2`)
+	c.Assert(err, IsNil)
+	defer resp.Body.Close()
+
+	c.Check(resp.StatusCode, Equals, 200)
+	body, err := ioutil.ReadAll(resp.Body)
+	c.Assert(err, IsNil)
+	c.Check(string(body), Equals, exampleValidationSet)
+}
+
+func (s *storeTestSuite) TestAssertionsEndpointSequenceAssertionLatest(c *C) {
+	err := ioutil.WriteFile(filepath.Join(s.store.assertDir, "base-set.validation-set"), []byte(exampleValidationSet), 0655)
+	c.Assert(err, IsNil)
+
+	resp, err := s.StoreGet(`/v2/assertions/validation-set/16/canonical/base-set?sequence=latest`)
+	c.Assert(err, IsNil)
+	defer resp.Body.Close()
+
+	c.Check(resp.StatusCode, Equals, 200)
+	body, err := ioutil.ReadAll(resp.Body)
+	c.Assert(err, IsNil)
+	c.Check(string(body), Equals, exampleValidationSet)
+}
+
+func (s *storeTestSuite) TestAssertionsEndpointSequenceInvalid(c *C) {
+	resp, err := s.StoreGet(`/v2/assertions/validation-set/16/canonical/base-set?sequence=foo`)
+	c.Assert(err, IsNil)
+	defer resp.Body.Close()
+
+	c.Assert(resp.StatusCode, Equals, 400)
+	body, err := ioutil.ReadAll(resp.Body)
+	c.Assert(err, IsNil)
+	c.Check(string(body), Equals, "cannot retrieve assertion [16 canonical base-set]: cannot parse sequence foo: strconv.Atoi: parsing \"foo\": invalid syntax\n")
 }
 
 func (s *storeTestSuite) TestAssertionsEndpointNotFound(c *C) {

--- a/tests/lib/fakestore/store/store_test.go
+++ b/tests/lib/fakestore/store/store_test.go
@@ -523,20 +523,18 @@ func (s *storeTestSuite) TestAssertionsEndpointSequenceAssertionLatest(c *C) {
 	c.Check(string(body), Equals, exampleValidationSet)
 }
 
-func (s *storeTestSuite) TestAssertionsEndpointSequenceAssertionZero(c *C) {
+func (s *storeTestSuite) TestAssertionsEndpointSequenceAssertionInvalidSequence(c *C) {
 	err := ioutil.WriteFile(filepath.Join(s.store.assertDir, "base-set.validation-set"), []byte(exampleValidationSet), 0655)
 	c.Assert(err, IsNil)
 
-	// Setting sequence to zero or any value below zero will translate to -1 sequence, meaning
-	// unknown.
 	resp, err := s.StoreGet(`/v2/assertions/validation-set/16/canonical/base-set?sequence=0`)
 	c.Assert(err, IsNil)
 	defer resp.Body.Close()
 
-	c.Check(resp.StatusCode, Equals, 200)
+	c.Assert(resp.StatusCode, Equals, 400)
 	body, err := ioutil.ReadAll(resp.Body)
 	c.Assert(err, IsNil)
-	c.Check(string(body), Equals, exampleValidationSet)
+	c.Check(string(body), Equals, "cannot retrieve assertion [16 canonical base-set]: the requested sequence must be above 0\n")
 }
 
 func (s *storeTestSuite) TestAssertionsEndpointSequenceInvalid(c *C) {

--- a/tests/lib/fakestore/store/store_test.go
+++ b/tests/lib/fakestore/store/store_test.go
@@ -523,6 +523,21 @@ func (s *storeTestSuite) TestAssertionsEndpointSequenceAssertionLatest(c *C) {
 	c.Check(string(body), Equals, exampleValidationSet)
 }
 
+func (s *storeTestSuite) TestAssertionsEndpointSequenceAssertionZero(c *C) {
+	err := ioutil.WriteFile(filepath.Join(s.store.assertDir, "base-set.validation-set"), []byte(exampleValidationSet), 0655)
+	c.Assert(err, IsNil)
+
+	// Setting sequence to zero or any value below zero will translate to 'latest' sequence.
+	resp, err := s.StoreGet(`/v2/assertions/validation-set/16/canonical/base-set?sequence=0`)
+	c.Assert(err, IsNil)
+	defer resp.Body.Close()
+
+	c.Check(resp.StatusCode, Equals, 200)
+	body, err := ioutil.ReadAll(resp.Body)
+	c.Assert(err, IsNil)
+	c.Check(string(body), Equals, exampleValidationSet)
+}
+
 func (s *storeTestSuite) TestAssertionsEndpointSequenceInvalid(c *C) {
 	resp, err := s.StoreGet(`/v2/assertions/validation-set/16/canonical/base-set?sequence=foo`)
 	c.Assert(err, IsNil)

--- a/tests/lib/fakestore/store/store_test.go
+++ b/tests/lib/fakestore/store/store_test.go
@@ -527,7 +527,8 @@ func (s *storeTestSuite) TestAssertionsEndpointSequenceAssertionZero(c *C) {
 	err := ioutil.WriteFile(filepath.Join(s.store.assertDir, "base-set.validation-set"), []byte(exampleValidationSet), 0655)
 	c.Assert(err, IsNil)
 
-	// Setting sequence to zero or any value below zero will translate to 'latest' sequence.
+	// Setting sequence to zero or any value below zero will translate to -1 sequence, meaning
+	// unknown.
 	resp, err := s.StoreGet(`/v2/assertions/validation-set/16/canonical/base-set?sequence=0`)
 	c.Assert(err, IsNil)
 	defer resp.Body.Close()

--- a/tests/lib/gendeveloper1/main.go
+++ b/tests/lib/gendeveloper1/main.go
@@ -71,10 +71,10 @@ func main() {
 		log.Fatalf("failed to decode model headers data: %v", err)
 	}
 
-	assertName, _ := headers["type"]
+	headerType := headers["type"]
 	assertType := asserts.ModelType
-	if assertName == "system-user" {
-		assertType = asserts.SystemUserType
+	if assertTypeStr, ok := headerType.(string); ok {
+		assertType = asserts.Type(assertTypeStr)
 	}
 
 	clModel, err := devSigning.Sign(assertType, headers, nil, "")


### PR DESCRIPTION
This adds support for fetching sequence forming assertions, and teaches fakestore how to return these.
