### PR TITLE
tests: fix prepare task for arch linux

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -135,7 +135,7 @@ update_core_snap_for_classic_reexec() {
 
     # First of all, unmount the core
     core="$(readlink -f "$SNAP_MOUNT_DIR/core/current" || readlink -f "$SNAP_MOUNT_DIR/ubuntu-core/current")"
-    snap="$(mount | grep " $core" | awk '{print $1}')"
+    snap="$(mount | grep " $core" | head -n 1 | awk '{print $1}')"
     umount --verbose "$core"
 
     # Now unpack the core, inject the new snap-exec/snapctl into it


### PR DESCRIPTION
When we get mount for the core snap, in arch linux the mount entry matches with 2 lines.

/var/lib/snapd/snaps/core_14940.snap on /var/lib/snapd/snap/core/14940 type squashfs (ro,nodev,relatime,errors=continue)
/var/lib/snapd/snaps/core_14940.snap on /var/lib/snapd/snap/core/14940 type squashfs (ro,nodev,relatime,errors=continue,x-gdu.hide,x-gvfs-hide)

The change is done to get one of them, otherwise it fails like this:

+ unsquashfs -no-progress '/var/lib/snapd/snaps/core_14940.snap /var/lib/snapd/snaps/core_14940.snap'

Could not open /var/lib/snapd/snaps/core_14940.snap /var/lib/snapd/snaps/core_14940.snap, because No such file or directory

Also for some reason (possibly a bug) in arch linux, the dbus interface for systemd is not returning the JobRemoved dbus signal, even when it is executed and finished successfully.

The proposed temporal solution is done to redirect the output to a tmp file in arch and read it from there.
