### PR TITLE
gadget: add inline crypto engine support using the device hook

### DIFF
--- a/daemon/api_debug.go
+++ b/daemon/api_debug.go
@@ -304,6 +304,7 @@ func getGadgetDiskMapping(st *state.State) Response {
 		switch sealingMethod {
 		case device.SealingMethodLegacyTPM, device.SealingMethodTPM:
 			encType = secboot.EncryptionTypeLUKS
+			// TODO:ICE: device setup hook support goes away
 		case device.SealingMethodFDESetupHook:
 			encType = secboot.EncryptionTypeDeviceSetupHook
 		default:

--- a/daemon/api_debug.go
+++ b/daemon/api_debug.go
@@ -304,8 +304,10 @@ func getGadgetDiskMapping(st *state.State) Response {
 		switch sealingMethod {
 		case device.SealingMethodLegacyTPM, device.SealingMethodTPM:
 			encType = secboot.EncryptionTypeLUKS
-			// TODO:ICE: device setup hook support goes away
 		case device.SealingMethodFDESetupHook:
+			// TODO:ICE: device setup hook support goes away
+			// XXX: this also seems to be broken already, this sealing
+			// method should not imply ICE
 			encType = secboot.EncryptionTypeDeviceSetupHook
 		default:
 			return InternalError("unknown sealing method: %s", sealingMethod)

--- a/gadget/install/encrypt.go
+++ b/gadget/install/encrypt.go
@@ -57,7 +57,7 @@ var _ = encryptedDevice(&encryptedDeviceLUKS{})
 
 // newEncryptedDeviceLUKS creates an encrypted device in the existing
 // partition using the specified key with the LUKS backend.
-func newEncryptedDeviceLUKS(part *gadget.OnDiskStructure, key keys.EncryptionKey, label, name string) (encryptedDevice, error) {
+func newEncryptedDeviceLUKS(part *gadget.OnDiskStructure, key keys.EncryptionKey, ice bool, label, name string) (encryptedDevice, error) {
 	dev := &encryptedDeviceLUKS{
 		parent: part,
 		name:   name,
@@ -67,7 +67,7 @@ func newEncryptedDeviceLUKS(part *gadget.OnDiskStructure, key keys.EncryptionKey
 		node: fmt.Sprintf("/dev/mapper/%s", name),
 	}
 
-	if err := secbootFormatEncryptedDevice(key, label, part.Node); err != nil {
+	if err := secbootFormatEncryptedDevice(key, label, part.Node, ice); err != nil {
 		return nil, fmt.Errorf("cannot format encrypted device: %v", err)
 	}
 

--- a/gadget/install/encrypt.go
+++ b/gadget/install/encrypt.go
@@ -57,7 +57,7 @@ var _ = encryptedDevice(&encryptedDeviceLUKS{})
 
 // newEncryptedDeviceLUKS creates an encrypted device in the existing
 // partition using the specified key with the LUKS backend.
-func newEncryptedDeviceLUKS(part *gadget.OnDiskStructure, key keys.EncryptionKey, ice bool, label, name string) (encryptedDevice, error) {
+func newEncryptedDeviceLUKS(part *gadget.OnDiskStructure, encType secboot.EncryptionType, key keys.EncryptionKey, label, name string) (encryptedDevice, error) {
 	dev := &encryptedDeviceLUKS{
 		parent: part,
 		name:   name,
@@ -67,7 +67,7 @@ func newEncryptedDeviceLUKS(part *gadget.OnDiskStructure, key keys.EncryptionKey
 		node: fmt.Sprintf("/dev/mapper/%s", name),
 	}
 
-	if err := secbootFormatEncryptedDevice(key, label, part.Node, ice); err != nil {
+	if err := secbootFormatEncryptedDevice(key, encType, label, part.Node); err != nil {
 		return nil, fmt.Errorf("cannot format encrypted device: %v", err)
 	}
 

--- a/gadget/install/encrypt_test.go
+++ b/gadget/install/encrypt_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/snapcore/snapd/gadget/install"
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/kernel/fde"
+	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/secboot/keys"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -99,7 +100,7 @@ func (s *encryptSuite) TestNewEncryptedDeviceLUKS(c *C) {
 		s.AddCleanup(s.mockCryptsetup.Restore)
 
 		calls := 0
-		restore := install.MockSecbootFormatEncryptedDevice(func(key keys.EncryptionKey, label, node string, ice bool) error {
+		restore := install.MockSecbootFormatEncryptedDevice(func(key keys.EncryptionKey, encType secboot.EncryptionType, label, node string) error {
 			calls++
 			c.Assert(key, DeepEquals, s.mockedEncryptionKey)
 			c.Assert(label, Equals, "some-label-enc")
@@ -108,7 +109,7 @@ func (s *encryptSuite) TestNewEncryptedDeviceLUKS(c *C) {
 		})
 		defer restore()
 
-		dev, err := install.NewEncryptedDeviceLUKS(&mockDeviceStructure, s.mockedEncryptionKey, false, "some-label-enc", "some-label")
+		dev, err := install.NewEncryptedDeviceLUKS(&mockDeviceStructure, secboot.EncryptionTypeLUKS, s.mockedEncryptionKey, "some-label-enc", "some-label")
 		c.Assert(calls, Equals, 1)
 		if tc.expectedErr == "" {
 			c.Assert(err, IsNil)

--- a/gadget/install/encrypt_test.go
+++ b/gadget/install/encrypt_test.go
@@ -99,7 +99,7 @@ func (s *encryptSuite) TestNewEncryptedDeviceLUKS(c *C) {
 		s.AddCleanup(s.mockCryptsetup.Restore)
 
 		calls := 0
-		restore := install.MockSecbootFormatEncryptedDevice(func(key keys.EncryptionKey, label, node string) error {
+		restore := install.MockSecbootFormatEncryptedDevice(func(key keys.EncryptionKey, label, node string, ice bool) error {
 			calls++
 			c.Assert(key, DeepEquals, s.mockedEncryptionKey)
 			c.Assert(label, Equals, "some-label-enc")
@@ -108,7 +108,7 @@ func (s *encryptSuite) TestNewEncryptedDeviceLUKS(c *C) {
 		})
 		defer restore()
 
-		dev, err := install.NewEncryptedDeviceLUKS(&mockDeviceStructure, s.mockedEncryptionKey, "some-label-enc", "some-label")
+		dev, err := install.NewEncryptedDeviceLUKS(&mockDeviceStructure, s.mockedEncryptionKey, false, "some-label-enc", "some-label")
 		c.Assert(calls, Equals, 1)
 		if tc.expectedErr == "" {
 			c.Assert(err, IsNil)

--- a/gadget/install/export_secboot_test.go
+++ b/gadget/install/export_secboot_test.go
@@ -24,6 +24,7 @@ package install
 import (
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/kernel/fde"
+	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/secboot/keys"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -34,7 +35,7 @@ var (
 	CreateEncryptedDeviceWithSetupHook = createEncryptedDeviceWithSetupHook
 )
 
-func MockSecbootFormatEncryptedDevice(f func(key keys.EncryptionKey, label, node string, ice bool) error) (restore func()) {
+func MockSecbootFormatEncryptedDevice(f func(key keys.EncryptionKey, encType secboot.EncryptionType, label, node string) error) (restore func()) {
 	r := testutil.Backup(&secbootFormatEncryptedDevice)
 	secbootFormatEncryptedDevice = f
 	return r

--- a/gadget/install/export_secboot_test.go
+++ b/gadget/install/export_secboot_test.go
@@ -34,7 +34,7 @@ var (
 	CreateEncryptedDeviceWithSetupHook = createEncryptedDeviceWithSetupHook
 )
 
-func MockSecbootFormatEncryptedDevice(f func(key keys.EncryptionKey, label, node string) error) (restore func()) {
+func MockSecbootFormatEncryptedDevice(f func(key keys.EncryptionKey, label, node string, ice bool) error) (restore func()) {
 	r := testutil.Backup(&secbootFormatEncryptedDevice)
 	secbootFormatEncryptedDevice = f
 	return r

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -32,6 +32,7 @@ import (
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/disks"
 	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/secboot/keys"
@@ -96,7 +97,7 @@ func saveStorageTraits(mod gadget.Model, allLaidOutVols map[string]*gadget.LaidO
 	return nil
 }
 
-func maybeEncryptPartition(laidOut *gadget.LaidOutStructure, encryptionType secboot.EncryptionType, sectorSize quantity.Size, perfTimings timings.Measurer) (fsParams *mkfsParams, encryptionKey keys.EncryptionKey, err error) {
+func maybeEncryptPartition(laidOut *gadget.LaidOutStructure, encryptionType secboot.EncryptionType, ice bool, sectorSize quantity.Size, perfTimings timings.Measurer) (fsParams *mkfsParams, encryptionKey keys.EncryptionKey, err error) {
 	mustEncrypt := (encryptionType != secboot.EncryptionTypeNone)
 	// fsParams.Device is the kernel device that carries the
 	// filesystem, which is either the raw /dev/<partition>, or
@@ -131,7 +132,7 @@ func maybeEncryptPartition(laidOut *gadget.LaidOutStructure, encryptionType secb
 			timings.Run(perfTimings, fmt.Sprintf("new-encrypted-device[%s]", laidOut.Role()),
 				fmt.Sprintf("Create encryption device for %s", laidOut.Role()),
 				func(timings.Measurer) {
-					dataPart, err = newEncryptedDeviceLUKS(&laidOut.OnDiskStructure, encryptionKey, laidOut.PartitionFSLabel, laidOut.Name())
+					dataPart, err = newEncryptedDeviceLUKS(&laidOut.OnDiskStructure, encryptionKey, ice, laidOut.PartitionFSLabel, laidOut.Name())
 				})
 			if err != nil {
 				return nil, nil, err
@@ -190,10 +191,10 @@ func writePartitionContent(laidOut *gadget.LaidOutStructure, fsDevice string, ob
 	return nil
 }
 
-func installOnePartition(laidOut *gadget.LaidOutStructure, encryptionType secboot.EncryptionType, sectorSize quantity.Size, observer gadget.ContentObserver, perfTimings timings.Measurer) (fsDevice string, encryptionKey keys.EncryptionKey, err error) {
+func installOnePartition(laidOut *gadget.LaidOutStructure, encryptionType secboot.EncryptionType, ice bool, sectorSize quantity.Size, observer gadget.ContentObserver, perfTimings timings.Measurer) (fsDevice string, encryptionKey keys.EncryptionKey, err error) {
 	// 1. Encrypt
 	role := laidOut.Role()
-	fsParams, encryptionKey, err := maybeEncryptPartition(laidOut, encryptionType, sectorSize, perfTimings)
+	fsParams, encryptionKey, err := maybeEncryptPartition(laidOut, encryptionType, ice, sectorSize, perfTimings)
 	if err != nil {
 		return "", nil, fmt.Errorf("cannot encrypt partition %s: %v", role, err)
 	}
@@ -299,6 +300,12 @@ func createEncryptionParams(encTyp secboot.EncryptionType) gadget.StructureEncry
 	return gadget.StructureEncryptionParameters{}
 }
 
+// check is device supports ICE fde
+func isIceSupported(gadgetRoot string) bool {
+	// check is device supports ICE fde
+	return osutil.FileExists(filepath.Join(gadgetRoot, "meta", "use-ice-fde"))
+}
+
 // Run creates partitions, encrypts them when expected, creates
 // filesystems, and finally writes content on them.
 func Run(model gadget.Model, gadgetRoot, kernelRoot, bootDevice string, options Options, observer gadget.ContentObserver, perfTimings timings.Measurer) (*InstalledSystemSideData, error) {
@@ -316,6 +323,8 @@ func Run(model gadget.Model, gadgetRoot, kernelRoot, bootDevice string, options 
 	partsEncrypted := map[string]gadget.StructureEncryptionParameters{}
 
 	hasSavePartition := false
+
+	ice := options.EncryptionType != "" && isIceSupported(gadgetRoot)
 
 	// Note that all partitions here will have a role (see
 	// gadget.IsCreatableAtInstall() which defines the list)
@@ -338,7 +347,7 @@ func Run(model gadget.Model, gadgetRoot, kernelRoot, bootDevice string, options 
 		// for encrypted device the filesystem device it will point to
 		// the mapper device otherwise it's the raw device node
 		fsDevice, encryptionKey, err := installOnePartition(&laidOut, options.EncryptionType,
-			bootVolSectorSize, observer, perfTimings)
+			ice, bootVolSectorSize, observer, perfTimings)
 		if err != nil {
 			return nil, err
 		}
@@ -630,6 +639,8 @@ func EncryptPartitions(onVolumes map[string]*gadget.Volume, encryptionType secbo
 		return nil, fmt.Errorf("when encrypting partitions: cannot layout volumes: %v", err)
 	}
 
+	ice := isIceSupported(gadgetRoot)
+
 	setupData := &EncryptionSetupData{
 		parts: make(map[string]partEncryptionData),
 	}
@@ -666,7 +677,7 @@ func EncryptPartitions(onVolumes map[string]*gadget.Volume, encryptionType secbo
 			logger.Debugf("encrypting partition %s", device)
 
 			fsParams, encryptionKey, err :=
-				maybeEncryptPartition(laidOut, encryptionType, onDiskVol.SectorSize, perfTimings)
+				maybeEncryptPartition(laidOut, encryptionType, ice, onDiskVol.SectorSize, perfTimings)
 			if err != nil {
 				return nil, fmt.Errorf("cannot encrypt %q: %v", device, err)
 			}
@@ -754,6 +765,8 @@ func FactoryReset(model gadget.Model, gadgetRoot, kernelRoot, bootDevice string,
 	var keyForRole map[string]keys.EncryptionKey
 	deviceForRole := map[string]string{}
 
+	ice := options.EncryptionType != "" && isIceSupported(gadgetRoot)
+
 	savePart := partitionsWithRolesAndContent(laidOutBootVol, diskLayout, []string{gadget.SystemSave})
 	hasSavePartition := len(savePart) != 0
 	if hasSavePartition {
@@ -769,7 +782,7 @@ func FactoryReset(model gadget.Model, gadgetRoot, kernelRoot, bootDevice string,
 		// device) for each role
 		deviceForRole[laidOut.Role()] = laidOut.Node
 
-		fsDevice, encryptionKey, err := installOnePartition(&laidOut, options.EncryptionType,
+		fsDevice, encryptionKey, err := installOnePartition(&laidOut, options.EncryptionType, ice,
 			diskLayout.SectorSize, observer, perfTimings)
 		if err != nil {
 			return nil, err

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -287,7 +287,7 @@ func createPartitions(model gadget.Model, gadgetRoot, kernelRoot, bootDevice str
 
 func createEncryptionParams(encTyp secboot.EncryptionType) gadget.StructureEncryptionParameters {
 	switch encTyp {
-	case secboot.EncryptionTypeLUKS, EncryptionTypeLUKSWithICE:
+	case secboot.EncryptionTypeLUKS, secboot.EncryptionTypeLUKSWithICE:
 		return gadget.StructureEncryptionParameters{
 			Method: gadget.EncryptionLUKS,
 		}
@@ -733,7 +733,7 @@ func FactoryReset(model gadget.Model, gadgetRoot, kernelRoot, bootDevice string,
 	if options.EncryptionType != secboot.EncryptionTypeNone {
 		var encryptionParam gadget.StructureEncryptionParameters
 		switch options.EncryptionType {
-		case secboot.EncryptionTypeLUKS:
+		case secboot.EncryptionTypeLUKS, secboot.EncryptionTypeLUKSWithICE:
 			encryptionParam = gadget.StructureEncryptionParameters{Method: gadget.EncryptionLUKS}
 		default:
 			// XXX what about ICE?

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -127,18 +127,9 @@ func maybeEncryptPartition(laidOut *gadget.LaidOutStructure, encryptionType secb
 		logger.Noticef("encrypting partition device %v", laidOut.Node)
 		var dataPart encryptedDevice
 		switch encryptionType {
-		case secboot.EncryptionTypeLUKS:
-			timings.Run(perfTimings, fmt.Sprintf("new-encrypted-device[%s]", laidOut.Role()),
-				fmt.Sprintf("Create encryption device for %s", laidOut.Role()),
-				func(timings.Measurer) {
-					dataPart, err = newEncryptedDeviceLUKS(&laidOut.OnDiskStructure, encryptionType, encryptionKey, laidOut.PartitionFSLabel, laidOut.Name())
-				})
-			if err != nil {
-				return nil, nil, err
-			}
-		case secboot.EncryptionTypeLUKSWithICE:
-			timings.Run(perfTimings, fmt.Sprintf("new-encrypted-device-with-ice[%s]", laidOut.Role()),
-				fmt.Sprintf("Create encryption device for %s using ICE", laidOut.Role()),
+		case secboot.EncryptionTypeLUKS, secboot.EncryptionTypeLUKSWithICE:
+			timings.Run(perfTimings, fmt.Sprintf("new-encrypted-device[%s] (%v)", laidOut.Role(), encryptionType),
+				fmt.Sprintf("Create encryption device for %s (%s)", laidOut.Role(), encryptionType),
 				func(timings.Measurer) {
 					dataPart, err = newEncryptedDeviceLUKS(&laidOut.OnDiskStructure, encryptionType, encryptionKey, laidOut.PartitionFSLabel, laidOut.Name())
 				})
@@ -146,6 +137,7 @@ func maybeEncryptPartition(laidOut *gadget.LaidOutStructure, encryptionType secb
 				return nil, nil, err
 			}
 
+			//TODO:ICE: device-setup hook support goes away
 		case secboot.EncryptionTypeDeviceSetupHook:
 			timings.Run(perfTimings, fmt.Sprintf("new-encrypted-device-setup-hook[%s]", laidOut.Role()),
 				fmt.Sprintf("Create encryption device for %s using device-setup-hook", laidOut.Role()),
@@ -295,7 +287,7 @@ func createPartitions(model gadget.Model, gadgetRoot, kernelRoot, bootDevice str
 
 func createEncryptionParams(encTyp secboot.EncryptionType) gadget.StructureEncryptionParameters {
 	switch encTyp {
-	case secboot.EncryptionTypeLUKS:
+	case secboot.EncryptionTypeLUKS, EncryptionTypeLUKSWithICE:
 		return gadget.StructureEncryptionParameters{
 			Method: gadget.EncryptionLUKS,
 		}

--- a/gadget/install/install_test.go
+++ b/gadget/install/install_test.go
@@ -313,6 +313,7 @@ func (s *installSuite) testInstall(c *C, opts installOpts) {
 			c.Error("unexpected call to secboot.FormatEncryptedDevice when encryption is off")
 			return fmt.Errorf("no encryption functions should be called")
 		}
+		c.Check(encType, Equals, secboot.EncryptionTypeLUKS)
 		secbootFormatEncryptedDeviceCall++
 		switch secbootFormatEncryptedDeviceCall {
 		case 1:
@@ -699,6 +700,7 @@ func (s *installSuite) testFactoryReset(c *C, opts factoryResetOpts) {
 			c.Error("unexpected call to secboot.FormatEncryptedDevice")
 			return fmt.Errorf("unexpected call")
 		}
+		c.Check(encType, Equals, secboot.EncryptionTypeLUKS)
 		secbootFormatEncryptedDeviceCall++
 		switch secbootFormatEncryptedDeviceCall {
 		case 1:

--- a/gadget/install/install_test.go
+++ b/gadget/install/install_test.go
@@ -308,7 +308,7 @@ func (s *installSuite) testInstall(c *C, opts installOpts) {
 	var saveEncryptionKey, dataEncryptionKey keys.EncryptionKey
 
 	secbootFormatEncryptedDeviceCall := 0
-	restore = install.MockSecbootFormatEncryptedDevice(func(key keys.EncryptionKey, label, node string) error {
+	restore = install.MockSecbootFormatEncryptedDevice(func(key keys.EncryptionKey, label, node string, ice bool) error {
 		if !opts.encryption {
 			c.Error("unexpected call to secboot.FormatEncryptedDevice when encryption is off")
 			return fmt.Errorf("no encryption functions should be called")
@@ -694,7 +694,7 @@ func (s *installSuite) testFactoryReset(c *C, opts factoryResetOpts) {
 
 	var dataPrimaryKey keys.EncryptionKey
 	secbootFormatEncryptedDeviceCall := 0
-	restore = install.MockSecbootFormatEncryptedDevice(func(key keys.EncryptionKey, label, node string) error {
+	restore = install.MockSecbootFormatEncryptedDevice(func(key keys.EncryptionKey, label, node string, ice bool) error {
 		if !opts.encryption {
 			c.Error("unexpected call to secboot.FormatEncryptedDevice")
 			return fmt.Errorf("unexpected call")

--- a/gadget/install/install_test.go
+++ b/gadget/install/install_test.go
@@ -308,7 +308,7 @@ func (s *installSuite) testInstall(c *C, opts installOpts) {
 	var saveEncryptionKey, dataEncryptionKey keys.EncryptionKey
 
 	secbootFormatEncryptedDeviceCall := 0
-	restore = install.MockSecbootFormatEncryptedDevice(func(key keys.EncryptionKey, label, node string, ice bool) error {
+	restore = install.MockSecbootFormatEncryptedDevice(func(key keys.EncryptionKey, encType secboot.EncryptionType, label, node string) error {
 		if !opts.encryption {
 			c.Error("unexpected call to secboot.FormatEncryptedDevice when encryption is off")
 			return fmt.Errorf("no encryption functions should be called")
@@ -694,7 +694,7 @@ func (s *installSuite) testFactoryReset(c *C, opts factoryResetOpts) {
 
 	var dataPrimaryKey keys.EncryptionKey
 	secbootFormatEncryptedDeviceCall := 0
-	restore = install.MockSecbootFormatEncryptedDevice(func(key keys.EncryptionKey, label, node string, ice bool) error {
+	restore = install.MockSecbootFormatEncryptedDevice(func(key keys.EncryptionKey, encType secboot.EncryptionType, label, node string) error {
 		if !opts.encryption {
 			c.Error("unexpected call to secboot.FormatEncryptedDevice")
 			return fmt.Errorf("unexpected call")

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -579,6 +579,7 @@ func EnsureLayoutCompatibility(gadgetLayout *LaidOutVolume, diskLayout *OnDiskVo
 	return nil
 }
 
+// TODO:ICE: remove this as we only support LUKS (and ICE is a variant of LUKS now)
 type DiskEncryptionMethod string
 
 const (
@@ -587,8 +588,8 @@ const (
 	// standard LUKS as it is used for automatic FDE using SecureBoot and TPM
 	// 2.0 in UC20+
 	EncryptionLUKS DiskEncryptionMethod = "LUKS"
-	// ICE stands for Inline Crypto Engine, used on specific (usually embedded)
-	// devices
+
+	// TODO:ICE: remove this
 	EncryptionICE DiskEncryptionMethod = "ICE"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/seccomp/libseccomp-golang v0.9.2-0.20220502024300-f57e1d55ea18
 	github.com/snapcore/bolt v1.3.2-0.20210908134111-63c8bfcf7af8
 	github.com/snapcore/go-gettext v0.0.0-20191107141714-82bbea49e785
-	github.com/snapcore/secboot v0.0.0-20230119174011-57239c9f324a
+	github.com/snapcore/secboot v0.0.0-20230228104443-f41f07c101e1
 	golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90
 	golang.org/x/net v0.0.0-20220826154423-83b083e8dc8b // indirect
 	golang.org/x/sys v0.0.0-20220829200755-d48e67d00261

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,8 @@ github.com/snapcore/secboot v0.0.0-20220922155412-5d2b29ff0ee2 h1:sPC5tmNoJ6H8Pu
 github.com/snapcore/secboot v0.0.0-20220922155412-5d2b29ff0ee2/go.mod h1:72paVOkm4sJugXt+v9ItmnjXgO921D8xqsbH2OekouY=
 github.com/snapcore/secboot v0.0.0-20230119174011-57239c9f324a h1:MwEn6ADhO9DYtqRnat71TOYxcNxBVUeqfDCBtrYcu7Y=
 github.com/snapcore/secboot v0.0.0-20230119174011-57239c9f324a/go.mod h1:72paVOkm4sJugXt+v9ItmnjXgO921D8xqsbH2OekouY=
+github.com/snapcore/secboot v0.0.0-20230228104443-f41f07c101e1 h1:HANKyba/BJ8iWRlcrkWG1SQt2CY0jPnCj/zO3mcz/WM=
+github.com/snapcore/secboot v0.0.0-20230228104443-f41f07c101e1/go.mod h1:72paVOkm4sJugXt+v9ItmnjXgO921D8xqsbH2OekouY=
 github.com/snapcore/snapd v0.0.0-20201005140838-501d14ac146e/go.mod h1:3xrn7QDDKymcE5VO2rgWEQ5ZAUGb9htfwlXnoel6Io8=
 go.mozilla.org/pkcs7 v0.0.0-20200128120323-432b2356ecb1 h1:A/5uWzF44DlIgdm/PQFwfMkW0JX+cIcQi/SwLAmZP5M=
 go.mozilla.org/pkcs7 v0.0.0-20200128120323-432b2356ecb1/go.mod h1:SNgMg+EgDFwmvSmLRTNKC5fegJjB7v23qTQ0XLGUNHk=

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -2388,9 +2388,13 @@ func (m *DeviceManager) checkFDEFeatures() (et secboot.EncryptionType, err error
 	if err != nil {
 		return et, err
 	}
-	if strutil.ListContains(features, "device-setup") {
+	switch {
+	// XXX: is this a good string?
+	case strutil.ListContains(features, "use-ice"):
+		et = secboot.EncryptionTypeLUKSWithICE
+	case strutil.ListContains(features, "device-setup"):
 		et = secboot.EncryptionTypeDeviceSetupHook
-	} else {
+	default:
 		et = secboot.EncryptionTypeLUKS
 	}
 

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -2389,9 +2389,9 @@ func (m *DeviceManager) checkFDEFeatures() (et secboot.EncryptionType, err error
 		return et, err
 	}
 	switch {
-	// XXX: is this a good string?
-	case strutil.ListContains(features, "use-ice"):
+	case strutil.ListContains(features, "inline-crypto-engine"):
 		et = secboot.EncryptionTypeLUKSWithICE
+		// TODO:ICE: remove this
 	case strutil.ListContains(features, "device-setup"):
 		et = secboot.EncryptionTypeDeviceSetupHook
 	default:

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -2151,6 +2151,8 @@ func (s *deviceMgrInstallModeSuite) TestInstallCheckEncryptedFDEHook(c *C) {
 		// valid and switches to "device-setup"
 		{`{"features":["device-setup"]}`, "", secboot.EncryptionTypeDeviceSetupHook},
 		{`{"features":["a","device-setup","b"]}`, "", secboot.EncryptionTypeDeviceSetupHook},
+		// valid and uses ice
+		{`{"features":["a","use-ice","b"]}`, "", secboot.EncryptionTypeLUKSWithICE},
 	} {
 		hookInvoke := func(ctx *hookstate.Context, tomb *tomb.Tomb) ([]byte, error) {
 			ctx.Lock()

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -2152,7 +2152,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallCheckEncryptedFDEHook(c *C) {
 		{`{"features":["device-setup"]}`, "", secboot.EncryptionTypeDeviceSetupHook},
 		{`{"features":["a","device-setup","b"]}`, "", secboot.EncryptionTypeDeviceSetupHook},
 		// valid and uses ice
-		{`{"features":["a","use-ice","b"]}`, "", secboot.EncryptionTypeLUKSWithICE},
+		{`{"features":["a","inline-crypto-engine","b"]}`, "", secboot.EncryptionTypeLUKSWithICE},
 	} {
 		hookInvoke := func(ctx *hookstate.Context, tomb *tomb.Tomb) ([]byte, error) {
 			ctx.Lock()

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -1358,6 +1358,7 @@ func (m *DeviceManager) doInstallFinish(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	encType := secboot.EncryptionTypeNone
+	// TODO:ICE: support secboot.EncryptionTypeLUKSWithICE in the API
 	if useEncryption {
 		encType = secboot.EncryptionTypeLUKS
 	}
@@ -1484,7 +1485,9 @@ func (m *DeviceManager) doInstallSetupStorageEncryption(t *state.Task, _ *tomb.T
 		return fmt.Errorf("encryption unavailable on this device: %v", whyStr)
 	}
 
-	encryptionSetupData, err := installEncryptPartitions(onVolumes, secboot.EncryptionTypeLUKS, sys.Model, mntPtForType[snap.TypeGadget], mntPtForType[snap.TypeKernel], perfTimings)
+	// TODO:ICE: support secboot.EncryptionTypeLUKSWithICE in the API
+	encType := secboot.EncryptionTypeLUKS
+	encryptionSetupData, err := installEncryptPartitions(onVolumes, encType, sys.Model, mntPtForType[snap.TypeGadget], mntPtForType[snap.TypeKernel], perfTimings)
 	if err != nil {
 		return err
 	}

--- a/secboot/encrypt.go
+++ b/secboot/encrypt.go
@@ -26,7 +26,7 @@ const (
 	EncryptionTypeNone            EncryptionType = ""
 	EncryptionTypeLUKS            EncryptionType = "cryptsetup"
 	EncryptionTypeDeviceSetupHook EncryptionType = "device-setup-hook"
-	EncryptionTypeLUKSWithICE     EncryptionType = "luks-with-ice"
+	EncryptionTypeLUKSWithICE     EncryptionType = "cryptsetup-with-inline-crypto-engine"
 )
 
 type RecoveryKeyDevice struct {

--- a/secboot/encrypt.go
+++ b/secboot/encrypt.go
@@ -26,6 +26,7 @@ const (
 	EncryptionTypeNone            EncryptionType = ""
 	EncryptionTypeLUKS            EncryptionType = "cryptsetup"
 	EncryptionTypeDeviceSetupHook EncryptionType = "device-setup-hook"
+	EncryptionTypeLUKSWithICE     EncryptionType = "luks-with-ice"
 )
 
 type RecoveryKeyDevice struct {

--- a/secboot/encrypt.go
+++ b/secboot/encrypt.go
@@ -23,10 +23,12 @@ package secboot
 type EncryptionType string
 
 const (
-	EncryptionTypeNone            EncryptionType = ""
-	EncryptionTypeLUKS            EncryptionType = "cryptsetup"
+	EncryptionTypeNone        EncryptionType = ""
+	EncryptionTypeLUKS        EncryptionType = "cryptsetup"
+	EncryptionTypeLUKSWithICE EncryptionType = "cryptsetup-with-inline-crypto-engine"
+
+	// TODO:ICE: remove this
 	EncryptionTypeDeviceSetupHook EncryptionType = "device-setup-hook"
-	EncryptionTypeLUKSWithICE     EncryptionType = "cryptsetup-with-inline-crypto-engine"
 )
 
 type RecoveryKeyDevice struct {

--- a/secboot/encrypt.go
+++ b/secboot/encrypt.go
@@ -31,6 +31,11 @@ const (
 	EncryptionTypeDeviceSetupHook EncryptionType = "device-setup-hook"
 )
 
+// TODO:ICE: once all EncryptionTypes are LUKS based this can probably go
+func (et EncryptionType) IsLUKS() bool {
+	return et == EncryptionTypeLUKS || et == EncryptionTypeLUKSWithICE
+}
+
 type RecoveryKeyDevice struct {
 	// Mountpoint of the device
 	Mountpoint string

--- a/secboot/encrypt_sb.go
+++ b/secboot/encrypt_sb.go
@@ -49,7 +49,10 @@ const metadataKiBSize = 2048     // 2MB
 // FormatEncryptedDevice initializes an encrypted volume on the block device
 // given by node, setting the specified label. The key used to unlock the volume
 // is provided using the key argument.
-func FormatEncryptedDevice(key keys.EncryptionKey, label, node string, ice bool) error {
+func FormatEncryptedDevice(key keys.EncryptionKey, encType EncryptionType, label, node string) error {
+	useICE := encType == EncryptionTypeLUKSWithICE
+	logger.Debugf("using ICE: %v", useICE)
+
 	opts := &sb.InitializeLUKS2ContainerOptions{
 		// use a lower, but still reasonable size that should give us
 		// enough room
@@ -63,7 +66,8 @@ func FormatEncryptedDevice(key keys.EncryptionKey, label, node string, ice bool)
 			MemoryKiB:       32,
 			ForceIterations: 4,
 		},
-		InlineCryptoEngine: ice,
+		//TODO: enable once secboot PR is merged
+		//InlineCryptoEngine: useICE,
 	}
 	return sbInitializeLUKS2Container(node, label, key[:], opts)
 }

--- a/secboot/encrypt_sb.go
+++ b/secboot/encrypt_sb.go
@@ -50,6 +50,10 @@ const metadataKiBSize = 2048     // 2MB
 // given by node, setting the specified label. The key used to unlock the volume
 // is provided using the key argument.
 func FormatEncryptedDevice(key keys.EncryptionKey, encType EncryptionType, label, node string) error {
+	if encType != EncryptionTypeLUKS && encType != EncryptionTypeLUKSWithICE {
+		return fmt.Errorf("cannot use encryption type %q when formating device %q", encType, node)
+	}
+
 	useICE := encType == EncryptionTypeLUKSWithICE
 	logger.Debugf("using ICE: %v", useICE)
 

--- a/secboot/encrypt_sb.go
+++ b/secboot/encrypt_sb.go
@@ -50,7 +50,7 @@ const metadataKiBSize = 2048     // 2MB
 // given by node, setting the specified label. The key used to unlock the volume
 // is provided using the key argument.
 func FormatEncryptedDevice(key keys.EncryptionKey, encType EncryptionType, label, node string) error {
-	if encType != EncryptionTypeLUKS && encType != EncryptionTypeLUKSWithICE {
+	if !encType.IsLUKS() {
 		return fmt.Errorf("cannot use encryption type %q when formating device %q", encType, node)
 	}
 

--- a/secboot/encrypt_sb.go
+++ b/secboot/encrypt_sb.go
@@ -55,7 +55,7 @@ func FormatEncryptedDevice(key keys.EncryptionKey, encType EncryptionType, label
 	}
 
 	useICE := encType == EncryptionTypeLUKSWithICE
-	logger.Debugf("using ICE: %v", useICE)
+	logger.Debugf("node %q uses ICE: %v", node, useICE)
 
 	opts := &sb.InitializeLUKS2ContainerOptions{
 		// use a lower, but still reasonable size that should give us

--- a/secboot/encrypt_sb.go
+++ b/secboot/encrypt_sb.go
@@ -70,8 +70,7 @@ func FormatEncryptedDevice(key keys.EncryptionKey, encType EncryptionType, label
 			MemoryKiB:       32,
 			ForceIterations: 4,
 		},
-		//TODO: enable once secboot PR is merged
-		//InlineCryptoEngine: useICE,
+		InlineCryptoEngine: useICE,
 	}
 	return sbInitializeLUKS2Container(node, label, key[:], opts)
 }

--- a/secboot/encrypt_sb.go
+++ b/secboot/encrypt_sb.go
@@ -49,7 +49,7 @@ const metadataKiBSize = 2048     // 2MB
 // FormatEncryptedDevice initializes an encrypted volume on the block device
 // given by node, setting the specified label. The key used to unlock the volume
 // is provided using the key argument.
-func FormatEncryptedDevice(key keys.EncryptionKey, label, node string) error {
+func FormatEncryptedDevice(key keys.EncryptionKey, label, node string, ice bool) error {
 	opts := &sb.InitializeLUKS2ContainerOptions{
 		// use a lower, but still reasonable size that should give us
 		// enough room
@@ -63,6 +63,7 @@ func FormatEncryptedDevice(key keys.EncryptionKey, label, node string) error {
 			MemoryKiB:       32,
 			ForceIterations: 4,
 		},
+		InlineCryptoEngine: ice,
 	}
 	return sbInitializeLUKS2Container(node, label, key[:], opts)
 }

--- a/secboot/encrypt_sb.go
+++ b/secboot/encrypt_sb.go
@@ -51,7 +51,7 @@ const metadataKiBSize = 2048     // 2MB
 // is provided using the key argument.
 func FormatEncryptedDevice(key keys.EncryptionKey, encType EncryptionType, label, node string) error {
 	if !encType.IsLUKS() {
-		return fmt.Errorf("cannot use encryption type %q when formating device %q", encType, node)
+		return fmt.Errorf("internal error: FormatEncryptedDevice for %q expects a LUKS encryption type, not %q", node, encType)
 	}
 
 	useICE := encType == EncryptionTypeLUKSWithICE

--- a/secboot/encrypt_sb_test.go
+++ b/secboot/encrypt_sb_test.go
@@ -83,6 +83,11 @@ func (s *encryptSuite) TestFormatEncryptedDevice(c *C) {
 	}
 }
 
+func (s *encryptSuite) TestFormatEncryptedDeviceInvalidEncType(c *C) {
+	err := secboot.FormatEncryptedDevice(keys.EncryptionKey{}, secboot.EncryptionType("other-enc-type"), "my label", "/dev/node")
+	c.Check(err, ErrorMatches, `cannot use encryption type "other-enc-type" when formating device "/dev/node"`)
+}
+
 type keymgrSuite struct {
 	testutil.BaseTest
 

--- a/secboot/encrypt_sb_test.go
+++ b/secboot/encrypt_sb_test.go
@@ -73,7 +73,7 @@ func (s *encryptSuite) TestFormatEncryptedDevice(c *C) {
 		})
 		defer restore()
 
-		err := secboot.FormatEncryptedDevice(myKey, "my label", "/dev/node")
+		err := secboot.FormatEncryptedDevice(myKey, "my label", "/dev/node", false)
 		c.Assert(calls, Equals, 1)
 		if tc.err == "" {
 			c.Assert(err, IsNil)

--- a/secboot/encrypt_sb_test.go
+++ b/secboot/encrypt_sb_test.go
@@ -73,7 +73,7 @@ func (s *encryptSuite) TestFormatEncryptedDevice(c *C) {
 		})
 		defer restore()
 
-		err := secboot.FormatEncryptedDevice(myKey, "my label", "/dev/node", false)
+		err := secboot.FormatEncryptedDevice(myKey, secboot.EncryptionTypeLUKS, "my label", "/dev/node")
 		c.Assert(calls, Equals, 1)
 		if tc.err == "" {
 			c.Assert(err, IsNil)

--- a/tests/lib/fde-setup-hook/fde-setup.go
+++ b/tests/lib/fde-setup-hook/fde-setup.go
@@ -90,8 +90,10 @@ func runFdeSetup() error {
 	var fdeSetupResult []byte
 	switch js.Op {
 	case "features":
-		// no special features supported by this hook
 		fdeSetupResult = []byte(`{"features":[]}`)
+		if osutil.FileExists(filepath.Join(filepath.Dir(os.Args[0]), "enable-ice-support")) {
+			fdeSetupResult = []byte(`{"features":["inline-crypto-engine"]}`)
+		}
 	case "initial-setup":
 		// "seal" using a really bad crypto algorithm
 		res := fdeSetupResultJSON{

--- a/tests/nested/manual/uc20-fde-hooks-ice/task.yaml
+++ b/tests/nested/manual/uc20-fde-hooks-ice/task.yaml
@@ -1,0 +1,53 @@
+summary: Check that fde-setup with feature "inline-cryto-engin" works
+
+systems: [ubuntu-22.04-64]
+
+environment:
+    NESTED_ENABLE_TPM: false
+    NESTED_ENABLE_SECURE_BOOT: false
+    NESTED_BUILD_SNAPD_FROM_CURRENT: true
+    NESTED_ENABLE_OVMF: true
+
+prepare: |
+  echo "Build a kernel snap with the fde-setup hook with device-setup support"
+  # shellcheck source=tests/lib/prepare.sh
+  . "$TESTSLIB/prepare.sh"
+
+  # add wrapper around cryptsetup that filters "--inline-crypto-engine"
+  # as qemu has no ICE driver
+  snap download --basename=core22 core22
+  unsquashfs -d core22 core22.snap
+  mv core22/sbin/cryptsetup core22/sbin/cryptsetup.real
+  cat >core22/sbin/cryptsetup <<'EOF'
+  #!/usr/bin/python3
+  import os,sys
+  with open("/run/mnt/ubuntu-seed/cryptsetup.calls", "a") as fp:
+    fp.write(f"{sys.argv}\n")
+  needle = "--inline-crypto-engine"
+  if needle in sys.argv:
+    sys.argv.remove(needle)
+  os.execv("/sbin/cryptsetup.real", sys.argv)
+  EOF
+  chmod +x core22/sbin/cryptsetup
+  snap pack ./core22 --filename=core22-new.snap
+  mv core22-new.snap "$(tests.nested get extra-snaps-path)" 
+
+  # build fde-reveal-key hook into the "extra-initrd"
+  # nested_create_core_vm picks this up
+  mkdir -p ./extra-initrd/usr/bin/
+  go build -o ./extra-initrd/usr/bin/fde-reveal-key "$TESTSLIB"/fde-setup-hook/fde-setup.go
+  (cd ./extra-initrd/usr/bin/ ; ln -s fde-reveal-key fde-device-unlock)
+  # create fde-setup hook inside the kernel and hint that "ice"
+  # support should be enabled
+  mkdir -p ./extra-kernel-snap/meta/hooks
+  go build -o ./extra-kernel-snap/meta/hooks/fde-setup "$TESTSLIB"/fde-setup-hook/fde-setup.go
+  (cd ./extra-kernel-snap/meta/hooks ; touch enable-ice-support; chmod +x enable-ice-support)
+
+  tests.nested build-image core
+  tests.nested create-vm core
+execute: |
+  echo "Check that we have an encrypted system"
+  remote.exec "find /dev/mapper" | MATCH ubuntu-data
+  remote.exec "test -e /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key"
+  echo "Check that the --inline-crypto-engine flag was passed"
+  remote.exec "cat /run/mnt/ubuntu-seed/cryptsetup.calls" | MATCH "inline-crypto-engine"

--- a/tests/nested/manual/uc20-fde-hooks-ice/task.yaml
+++ b/tests/nested/manual/uc20-fde-hooks-ice/task.yaml
@@ -1,4 +1,4 @@
-summary: Check that fde-setup with feature "inline-cryto-engin" works
+summary: Check that fde-setup with feature "inline-cryto-engine" works
 
 systems: [ubuntu-22.04-64]
 
@@ -47,6 +47,7 @@ prepare: |
 
   tests.nested build-image core
   tests.nested create-vm core
+
 execute: |
   echo "Check that we have an encrypted system"
   remote.exec "find /dev/mapper" | MATCH ubuntu-data

--- a/tests/nested/manual/uc20-fde-hooks-ice/task.yaml
+++ b/tests/nested/manual/uc20-fde-hooks-ice/task.yaml
@@ -29,6 +29,8 @@ prepare: |
   os.execv("/sbin/cryptsetup.real", sys.argv)
   EOF
   chmod +x core22/sbin/cryptsetup
+  # ensure the install-mode.log.gz contains all DEBUG messages
+  echo "SNAPD_DEBUG=1" >> core22/etc/environment
   snap pack ./core22 --filename=core22-new.snap
   mv core22-new.snap "$(tests.nested get extra-snaps-path)" 
 
@@ -49,5 +51,7 @@ execute: |
   echo "Check that we have an encrypted system"
   remote.exec "find /dev/mapper" | MATCH ubuntu-data
   remote.exec "test -e /run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key"
+  echo "Check that ICE was used"
+  remote.exec "zcat /var/log/install-mode.log.gz" | MATCH "node.* uses ICE: true"
   echo "Check that the --inline-crypto-engine flag was passed"
   remote.exec "cat /run/mnt/ubuntu-seed/cryptsetup.calls" | MATCH "inline-crypto-engine"


### PR DESCRIPTION
This is a continuation of the work from Ondra based on input from Samuele.

Followup for https://github.com/snapcore/snapd/pull/12553

Added "skip-spread" until https://github.com/snapcore/secboot/pull/221/files gets merged