### PR TITLE
devicestate: fix serial acquire when custom SSL certificates are needed

### DIFF
--- a/overlord/devicestate/devicestate_serial_test.go
+++ b/overlord/devicestate/devicestate_serial_test.go
@@ -954,7 +954,7 @@ func (s *deviceMgrSerialSuite) TestDoRequestSerialCertExpired(c *C) {
 	}
 
 	c.Check(chg.Status(), Equals, state.ErrorStatus)
-	c.Assert(chg.Err(), ErrorMatches, `(?ms).*cannot retrieve request-id for making a request for a serial: Post \"?http://.*/request-id\"?: x509: certificate has expired or is not yet valid.*`)
+	c.Assert(chg.Err(), ErrorMatches, `(?ms).*cannot retrieve request-id for making a request for a serial: Post \"?https://.*/request-id\"?: x509: certificate has expired or is not yet valid.*`)
 
 	var nTentatives int
 	err := t.Get("pre-poll-tentatives", &nTentatives)
@@ -1165,7 +1165,7 @@ func (s *deviceMgrSerialSuite) testFullDeviceRegistrationHappyWithHookAndProxy(c
 		reqID = "REQID-42"
 		storeVersion = "6"
 		bhv.PostPreflight = func(c *C, bhv *devicestatetest.DeviceServiceBehavior, w http.ResponseWriter, r *http.Request) {
-			c.Check(r.Header.Get("X-Snap-Device-Service-URL"), Matches, "http://[^/]*/bad/svc/")
+			c.Check(r.Header.Get("X-Snap-Device-Service-URL"), Matches, "https://[^/]*/bad/svc/")
 			c.Check(r.Header.Get("X-Extra-Header"), Equals, "extra")
 		}
 		svcPath = "/bad/svc/"

--- a/overlord/devicestate/devicestate_serial_test.go
+++ b/overlord/devicestate/devicestate_serial_test.go
@@ -112,7 +112,13 @@ func (s *deviceMgrSerialSuite) mockServer(c *C, reqID string, bhv *devicestatete
 	bhv.SignSerial = s.signSerial
 	bhv.ExpectedCapabilities = "serial-stream"
 
-	return devicestatetest.MockDeviceService(c, bhv)
+	mockServer, extraCerts := devicestatetest.MockDeviceService(c, bhv)
+	fname := filepath.Join(dirs.SnapdStoreSSLCertsDir, "test-server-certs.pem")
+	err := os.MkdirAll(filepath.Dir(fname), 0755)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(fname, extraCerts, 0644)
+	c.Assert(err, IsNil)
+	return mockServer
 }
 
 func (s *deviceMgrSerialSuite) findBecomeOperationalChange(skipIDs ...string) *state.Change {

--- a/overlord/devicestate/devicestate_serial_test.go
+++ b/overlord/devicestate/devicestate_serial_test.go
@@ -1690,14 +1690,13 @@ func (s *deviceMgrSerialSuite) TestNewEnoughProxyParse(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	log, restore := logger.MockLogger()
-	defer restore()
 	os.Setenv("SNAPD_DEBUG", "1")
 	defer os.Unsetenv("SNAPD_DEBUG")
 
 	badURL := &url.URL{Opaque: "%a"} // url.Parse(badURL.String()) needs to fail, which isn't easy :-)
-	c.Check(devicestate.NewEnoughProxy(s.state, badURL, http.DefaultClient), Equals, false)
-	c.Check(log.String(), Matches, "(?m).* DEBUG: Cannot check whether proxy store supports a custom serial vault: parse .*")
+	newEnoughProxy, err := devicestate.NewEnoughProxy(s.state, badURL, http.DefaultClient)
+	c.Check(err, ErrorMatches, "cannot check whether proxy store supports a custom serial vault: parse .*")
+	c.Check(newEnoughProxy, Equals, false)
 }
 
 func (s *deviceMgrSerialSuite) TestNewEnoughProxy(c *C) {
@@ -1746,18 +1745,19 @@ func (s *deviceMgrSerialSuite) TestNewEnoughProxy(c *C) {
 	u, err := url.Parse(server.URL)
 	c.Assert(err, IsNil)
 	for _, expected := range expecteds {
-		log.Reset()
-		c.Check(devicestate.NewEnoughProxy(s.state, u, http.DefaultClient), Equals, false)
-		if len(expected) > 0 {
-			expected = "(?m).* DEBUG: Cannot check whether proxy store supports a custom serial vault: " + expected
+		newEnoughProxy, err := devicestate.NewEnoughProxy(s.state, u, http.DefaultClient)
+		if expected != "" {
+			expected = "cannot check whether proxy store supports a custom serial vault: " + expected
+			c.Check(err, ErrorMatches, expected)
 		}
-		c.Check(log.String(), Matches, expected)
+		c.Check(newEnoughProxy, Equals, false)
 	}
 	c.Check(n, Equals, len(expecteds))
 
 	// and success at last
-	log.Reset()
-	c.Check(devicestate.NewEnoughProxy(s.state, u, http.DefaultClient), Equals, true)
+	newEnoughProxy, err := devicestate.NewEnoughProxy(s.state, u, http.DefaultClient)
+	c.Check(err, IsNil)
+	c.Check(newEnoughProxy, Equals, true)
 	c.Check(log.String(), Equals, "")
 	c.Check(n, Equals, len(expecteds)+1)
 }

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -2182,7 +2182,13 @@ func (s *firstBoot16Suite) mockServer(c *C, reqID string) *httptest.Server {
 		ExpectedCapabilities: "serial-stream",
 	}
 
-	return devicestatetest.MockDeviceService(c, bhv)
+	mockServer, extraCerts := devicestatetest.MockDeviceService(c, bhv)
+	fname := filepath.Join(dirs.SnapdStoreSSLCertsDir, "test-server-certs.pem")
+	err := os.MkdirAll(filepath.Dir(fname), 0755)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(fname, extraCerts, 0644)
+	c.Assert(err, IsNil)
+	return mockServer
 }
 
 func (s *firstBoot16Suite) signSerial(c *C, bhv *devicestatetest.DeviceServiceBehavior, headers map[string]interface{}, body []byte) (serial asserts.Assertion, ancillary []asserts.Assertion, err error) {

--- a/overlord/devicestate/handlers_serial.go
+++ b/overlord/devicestate/handlers_serial.go
@@ -34,6 +34,7 @@ import (
 	"gopkg.in/tomb.v2"
 
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/httputil"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/assertstate"
@@ -523,6 +524,9 @@ func getSerial(t *state.Task, regCtx registrationContext, privKey asserts.Privat
 		MayLogBody:         true,
 		Proxy:              proxyConf.Conf,
 		ProxyConnectHeader: http.Header{"User-Agent": []string{snapdenv.UserAgent()}},
+		ExtraSSLCerts: &httputil.ExtraSSLCertsFromDir{
+			Dir: dirs.SnapdStoreSSLCertsDir,
+		},
 	})
 
 	cfg, err := getSerialRequestConfig(t, regCtx, client)

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -6599,8 +6599,13 @@ func (s *mgrsSuiteCore) TestHappyDeviceRegistrationWithPrepareDeviceHook(c *C) {
 		SignSerial:       signSerial,
 	}
 
-	mockServer := devicestatetest.MockDeviceService(c, bhv)
+	mockServer, extraCerts := devicestatetest.MockDeviceService(c, bhv)
 	defer mockServer.Close()
+	fname := filepath.Join(dirs.SnapdStoreSSLCertsDir, "test-server-certs.pem")
+	err = os.MkdirAll(filepath.Dir(fname), 0755)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(fname, extraCerts, 0644)
+	c.Assert(err, IsNil)
 
 	pDBhv := &devicestatetest.PrepareDeviceBehavior{
 		DeviceSvcURL: mockServer.URL + "/svc/",
@@ -6744,8 +6749,13 @@ func (s *mgrsSuiteCore) TestRemodelReregistration(c *C) {
 		SignSerial:       signSerial,
 	}
 
-	mockDeviceService := devicestatetest.MockDeviceService(c, bhv)
+	mockDeviceService, extraCerts := devicestatetest.MockDeviceService(c, bhv)
 	defer mockDeviceService.Close()
+	fname := filepath.Join(dirs.SnapdStoreSSLCertsDir, "test-server-certs.pem")
+	err = os.MkdirAll(filepath.Dir(fname), 0755)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(fname, extraCerts, 0644)
+	c.Assert(err, IsNil)
 
 	r := devicestatetest.MockGadget(c, st, "gadget", snap.R(2), nil)
 	defer r()


### PR DESCRIPTION
This PR fixes the issue that getting the serial fails in confusing ways when a custom SSL certificate is needed to connect
to get the serial. The error message in this case is:
```
handlers_serial.go:659: Proxy store does not support custom serial vault; ignoring the proxy
```
which is not at all true.

The root cause for the bug is that the used http client does
set `ExtraSSLCerts`. However there are more issues with the
code, e.g. that `newEnoughProxy` does not return an error but
instead just debug lots it and does nothing less.

The initial commit is a minimal fix, then a unit test change to ensure the MockDeviceService uses https with custom certificates and then a refactor of `newEnoughProxy` to ensure that errors are properly surfaced.

One open question is if `httputil.NewHTTPClient` should by default set: `ExtraSSLCerts: &httputil.ExtraSSLCertsFromDir{Dir: dirs.SnapdStoreSSLCertsDir}` unless disabled to avoid similar issues in the future. All places in our code that call `httputil.NewHTTPClient()` set this option anyway AFAICT.