### PR TITLE
interfaces: add microovn interface

### DIFF
--- a/interfaces/builtin/microovn.go
+++ b/interfaces/builtin/microovn.go
@@ -1,0 +1,51 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+const microovnSummary = `allows access to the MicroOVN socket`
+
+const microovnBaseDeclarationSlots = `
+  microovn:
+    allow-installation: false
+    deny-connection: true
+    deny-auto-connection: true
+`
+
+const microovnConnectedPlugAppArmor = `
+# Description: allow access to the MicroOVN control socket.
+
+/var/snap/microovn/common/state/control.socket rw,
+`
+
+const microovnConnectedPlugSecComp = `
+# Description: allow access to the MicroOVN control socket.
+
+socket AF_NETLINK - NETLINK_GENERIC
+`
+
+func init() {
+	registerIface(&commonInterface{
+		name:                  "microovn",
+		summary:               microovnSummary,
+		baseDeclarationSlots:  microovnBaseDeclarationSlots,
+		connectedPlugAppArmor: microovnConnectedPlugAppArmor,
+		connectedPlugSecComp:  microovnConnectedPlugSecComp,
+	})
+}

--- a/interfaces/builtin/microovn_test.go
+++ b/interfaces/builtin/microovn_test.go
@@ -1,0 +1,111 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/interfaces/seccomp"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type MicroOVNInterfaceSuite struct {
+	iface    interfaces.Interface
+	slotInfo *snap.SlotInfo
+	slot     *interfaces.ConnectedSlot
+	plugInfo *snap.PlugInfo
+	plug     *interfaces.ConnectedPlug
+}
+
+var _ = Suite(&MicroOVNInterfaceSuite{
+	iface: builtin.MustInterface("microovn"),
+})
+
+const microovnConsumerYaml = `name: consumer
+version: 0
+apps:
+ app:
+  plugs: [microovn]
+`
+
+const microovnCoreYaml = `name: core
+version: 0
+type: os
+slots:
+  microovn:
+`
+
+func (s *MicroOVNInterfaceSuite) SetUpTest(c *C) {
+	s.plug, s.plugInfo = MockConnectedPlug(c, microovnConsumerYaml, nil, "microovn")
+	s.slot, s.slotInfo = MockConnectedSlot(c, microovnCoreYaml, nil, "microovn")
+}
+
+func (s *MicroOVNInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "microovn")
+}
+
+func (s *MicroOVNInterfaceSuite) TestSanitizeSlot(c *C) {
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.slotInfo), IsNil)
+	slot := &snap.SlotInfo{
+		Snap:      &snap.Info{SuggestedName: "some-snap"},
+		Name:      "microovn",
+		Interface: "microovn",
+	}
+
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), IsNil)
+}
+
+func (s *MicroOVNInterfaceSuite) TestSanitizePlug(c *C) {
+	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
+}
+
+func (s *MicroOVNInterfaceSuite) TestAppArmorSpec(c *C) {
+	spec := &apparmor.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/var/snap/microovn/common/state/control.socket rw,\n")
+}
+
+func (s *MicroOVNInterfaceSuite) TestSecCompSpec(c *C) {
+	spec := &seccomp.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "socket AF_NETLINK - NETLINK_GENERIC\n")
+}
+
+func (s *MicroOVNInterfaceSuite) TestStaticInfo(c *C) {
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Assert(si.ImplicitOnCore, Equals, false)
+	c.Assert(si.ImplicitOnClassic, Equals, false)
+	c.Assert(si.Summary, Equals, `allows access to the MicroOVN socket`)
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "microovn")
+}
+
+func (s *MicroOVNInterfaceSuite) TestAutoConnect(c *C) {
+	c.Check(s.iface.AutoConnect(nil, nil), Equals, true)
+}
+
+func (s *MicroOVNInterfaceSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -836,6 +836,7 @@ var (
 		"docker":          nil,
 		"lxd":             nil,
 		"microceph":       nil,
+		"microovn":        nil,
 		"pkcs11":          nil,
 		"posix-mq":        nil,
 		"shared-memory":   nil,
@@ -896,6 +897,12 @@ func (s *baseDeclSuite) TestSlotInstallation(c *C) {
 	err = ic.Check()
 	c.Assert(err, Not(IsNil))
 	c.Assert(err, ErrorMatches, "installation not allowed by \"microceph\" slot rule of interface \"microceph\"")
+
+	// test microovn specially
+	ic = s.installSlotCand(c, "microovn", snap.TypeApp, ``)
+	err = ic.Check()
+	c.Assert(err, Not(IsNil))
+	c.Assert(err, ErrorMatches, "installation not allowed by \"microovn\" slot rule of interface \"microovn\"")
 
 	// test shared-memory specially
 	ic = s.installSlotCand(c, "shared-memory", snap.TypeApp, ``)
@@ -1003,6 +1010,7 @@ func (s *baseDeclSuite) TestConnection(c *C) {
 		"lxd":                       true,
 		"maliit":                    true,
 		"microceph":                 true,
+		"microovn":                  true,
 		"mir":                       true,
 		"online-accounts-service":   true,
 		"posix-mq":                  true,

--- a/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
@@ -269,6 +269,9 @@ apps:
   microceph:
     command: bin/run
     plugs: [ microceph ]
+  microovn:
+    command: bin/run
+    plugs: [ microovn ]
   microstack-support:
     command: bin/run
     plugs: [ microstack-support ]

--- a/tests/main/interfaces-many-snap-provided/test-snapd-policy-app-provider-classic/meta/snap.yaml
+++ b/tests/main/interfaces-many-snap-provided/test-snapd-policy-app-provider-classic/meta/snap.yaml
@@ -24,6 +24,7 @@ slots:
   maliit: null
   media-hub: null
   microceph: null
+  microovn: null
   mir: null
   mpris:
     name: test-policy-app-provider-classic
@@ -69,6 +70,9 @@ apps:
   microceph:
     command: bin/run
     slots: [ microceph ]
+  microovn:
+    command: bin/run
+    slots: [ microovn ]
   mir:
     command: bin/run
     slots: [ mir ]

--- a/tests/main/interfaces-many-snap-provided/test-snapd-policy-app-provider-core/meta/snap.yaml
+++ b/tests/main/interfaces-many-snap-provided/test-snapd-policy-app-provider-core/meta/snap.yaml
@@ -33,6 +33,7 @@ slots:
   maliit: null
   media-hub: null
   microceph: null
+  microovn: null
   mir: null
   modem-manager: null
   network-manager: null
@@ -106,6 +107,9 @@ apps:
   microceph:
     command: bin/run
     slots: [ microceph ]
+  microovn:
+    command: bin/run
+    slots: [ microovn ]
   mir:
     command: bin/run
     slots: [ mir ]


### PR DESCRIPTION
This interface makes it possible to control MicroOVN.

It will be used by another snap, MicroCloud to bring up MicroOVN and LXD clusters automatically.
