### PR TITLE
snap/sysparams: introduce system-params file for managing homedirs

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -283,6 +283,11 @@ func FeaturesDirUnder(rootdir string) string {
 	return filepath.Join(rootdir, snappyDir, "features")
 }
 
+// SnapSystemParamsUnder returns the path to the system-params file under rootdir
+func SnapSystemParamsUnder(rootdir string) string {
+	return filepath.Join(rootdir, snappyDir, "system-params")
+}
+
 // SnapSystemdConfDirUnder returns the path to the systemd conf dir under
 // rootdir.
 func SnapSystemdConfDirUnder(rootdir string) string {

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -283,7 +283,7 @@ func FeaturesDirUnder(rootdir string) string {
 	return filepath.Join(rootdir, snappyDir, "features")
 }
 
-// SnapSystemParamsUnder returns the path to the system-params file under rootdir
+// SnapSystemParamsUnder returns the path to the system-params file under rootdir.
 func SnapSystemParamsUnder(rootdir string) string {
 	return filepath.Join(rootdir, snappyDir, "system-params")
 }

--- a/snap/sysparams/export_test.go
+++ b/snap/sysparams/export_test.go
@@ -1,0 +1,33 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package sysparams
+
+import (
+	"os"
+
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/testutil"
+)
+
+func MockOsutilAtomicWriteFile(f func(filename string, data []byte, perm os.FileMode, flags osutil.AtomicWriteFlags) error) func() {
+	r := testutil.Backup(&osutilAtomicWriteFile)
+	osutilAtomicWriteFile = f
+	return r
+}

--- a/snap/sysparams/sysparams.go
+++ b/snap/sysparams/sysparams.go
@@ -1,0 +1,93 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package sysparams
+
+import (
+	"bufio"
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"github.com/snapcore/snapd/osutil"
+)
+
+// For mocking in tests
+var (
+	osutilAtomicWriteFile = osutil.AtomicWriteFile
+)
+
+// SystemParams manages certain system configuration parameters
+// aspects like the homedirs configuration that must be available
+// for other binaries, as snap-confine.
+type SystemParams struct {
+	// path stored to allow for updating the same path
+	path string
+	// Homedirs is the comma-delimited list of user specified home
+	// directories that should be mounted
+	Homedirs string
+}
+
+func parseSystemParams(contents string) (*SystemParams, error) {
+	params := &SystemParams{}
+	scanner := bufio.NewScanner(strings.NewReader(contents))
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// ignore empty lines and comments
+		if len(line) == 0 || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		if strings.HasPrefix(line, "homedirs=") {
+			params.Homedirs = strings.TrimPrefix(line, "homedirs=")
+		} else {
+			return params, fmt.Errorf("cannot parse invalid line: %s", line)
+		}
+	}
+	return params, nil
+}
+
+// Open either opens the existing file at the given path, and parses
+// the file, or in case the file does not exist, it will initialize
+// and return a new SnapdSystemParams structure.
+func Open(path string) (*SystemParams, error) {
+	if !osutil.FileExists(path) {
+		return &SystemParams{path: path}, nil
+	}
+
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	params, err := parseSystemParams(string(data))
+	if err != nil {
+		return params, err
+	}
+	params.path = path
+	return params, nil
+}
+
+// Write updates the system-params file with the values in the
+// SystemParams instance.
+func (ssp *SystemParams) Write() error {
+	contents := fmt.Sprintf("homedirs=%s\n", ssp.Homedirs)
+	return osutilAtomicWriteFile(ssp.path, []byte(contents), 0644, 0)
+}

--- a/snap/sysparams/sysparams.go
+++ b/snap/sysparams/sysparams.go
@@ -95,7 +95,7 @@ func Open(path string) (*SystemParams, error) {
 
 	params, err := parseSystemParams(string(data))
 	if err != nil {
-		return params, err
+		return nil, err
 	}
 	params.path = path
 	return params, nil

--- a/snap/sysparams/sysparams.go
+++ b/snap/sysparams/sysparams.go
@@ -37,10 +37,10 @@ var (
 // aspects like the homedirs configuration that must be available
 // for other binaries, as snap-confine.
 type SystemParams struct {
-	// path stored to allow for updating the same path
+	// path stored to allow for updating the same path.
 	path string
 	// Homedirs is the comma-delimited list of user specified home
-	// directories that should be mounted
+	// directories that should be mounted.
 	Homedirs string
 }
 

--- a/snap/sysparams/sysparams_test.go
+++ b/snap/sysparams/sysparams_test.go
@@ -88,7 +88,7 @@ func (s *sysParamsTestSuite) TestUpdateWriteFailure(c *C) {
 	defer r()
 
 	err = ssp.Write()
-	c.Assert(err, ErrorMatches, "some write error")
+	c.Assert(err, ErrorMatches, "cannot write system-params: some write error")
 }
 
 func (s *sysParamsTestSuite) TestOpenExisting(c *C) {
@@ -118,7 +118,7 @@ func (s *sysParamsTestSuite) TestOpenExistingWithInvalidContent(c *C) {
 	c.Assert(ioutil.WriteFile(sspPath, []byte("xuifu93\n"), 0644), IsNil)
 
 	ssp, err := sysparams.Open(sspPath)
-	c.Check(err, ErrorMatches, `cannot parse invalid line: "xuifu93"`)
+	c.Check(err, ErrorMatches, `cannot parse system-params: invalid line: "xuifu93"`)
 	c.Check(ssp, IsNil)
 }
 
@@ -152,6 +152,6 @@ homedirs=foo/baz
 	c.Assert(ioutil.WriteFile(sspPath, []byte(contents), 0644), IsNil)
 
 	ssp, err := sysparams.Open(sspPath)
-	c.Check(err, ErrorMatches, `cannot parse file, dublicate entry found: "homedirs"`)
+	c.Check(err, ErrorMatches, `cannot parse system-params: duplicate entry found: "homedirs"`)
 	c.Check(ssp, IsNil)
 }

--- a/snap/sysparams/sysparams_test.go
+++ b/snap/sysparams/sysparams_test.go
@@ -57,9 +57,6 @@ func (s *sysParamsTestSuite) TestOpenNewEmpty(c *C) {
 	c.Assert(ssp, NotNil)
 	c.Check(sspPath, testutil.FileAbsent)
 
-	// Set homedirs
-	ssp.Homedirs = "my-path/foo/bar,foo=bar"
-
 	// Save the file
 	err = ssp.Write()
 	c.Check(err, IsNil)
@@ -68,7 +65,7 @@ func (s *sysParamsTestSuite) TestOpenNewEmpty(c *C) {
 	// has the correct permissions
 	f, err := ioutil.ReadFile(sspPath)
 	c.Assert(err, IsNil)
-	c.Assert(string(f), Equals, "homedirs=my-path/foo/bar,foo=bar\n")
+	c.Assert(string(f), Equals, "homedirs=\n")
 
 	stat, err := os.Stat(sspPath)
 	c.Assert(err, IsNil)

--- a/snap/sysparams/sysparams_test.go
+++ b/snap/sysparams/sysparams_test.go
@@ -1,0 +1,128 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package sysparams_test
+
+import (
+	"errors"
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/snap/sysparams"
+	"github.com/snapcore/snapd/testutil"
+)
+
+func TestSysParamsTest(t *testing.T) { TestingT(t) }
+
+type sysParamsTestSuite struct {
+	testutil.BaseTest
+}
+
+var _ = Suite(&sysParamsTestSuite{})
+
+func (s *sysParamsTestSuite) SetUpTest(c *C) {
+	dirs.SetRootDir(c.MkDir())
+}
+
+func (s *sysParamsTestSuite) TestOpenNewEmpty(c *C) {
+	// Opening the file when it doesn't exist, should not create
+	// the file unless Update is called. And that an empty update
+	// provides empty members
+	sspPath := dirs.SnapSystemParamsUnder(dirs.GlobalRootDir)
+	ssp, err := sysparams.Open(sspPath)
+	c.Check(err, IsNil)
+	c.Assert(ssp, NotNil)
+	c.Check(sspPath, testutil.FileAbsent)
+
+	r := sysparams.MockOsutilAtomicWriteFile(func(filename string, data []byte, perm os.FileMode, flags osutil.AtomicWriteFlags) error {
+		c.Check(string(data), Equals, "homedirs=\n")
+		return nil
+	})
+	defer r()
+
+	// Save the file
+	err = ssp.Write()
+	c.Check(err, IsNil)
+}
+
+func (s *sysParamsTestSuite) TestUpdateWriteFailure(c *C) {
+	// Opening the file when it doesn't exist, should not create
+	// the file unless Update is called. And that an empty update
+	// provides empty members
+	sspPath := dirs.SnapSystemParamsUnder(dirs.GlobalRootDir)
+	ssp, err := sysparams.Open(sspPath)
+	c.Check(err, IsNil)
+	c.Assert(ssp, NotNil)
+	c.Check(sspPath, testutil.FileAbsent)
+
+	r := sysparams.MockOsutilAtomicWriteFile(func(filename string, data []byte, perm os.FileMode, flags osutil.AtomicWriteFlags) error {
+		return errors.New("some write error")
+	})
+	defer r()
+
+	err = ssp.Write()
+	c.Assert(err, ErrorMatches, "some write error")
+}
+
+func (s *sysParamsTestSuite) TestOpenExisting(c *C) {
+	sspPath := dirs.SnapSystemParamsUnder(dirs.GlobalRootDir)
+	c.Assert(os.MkdirAll(path.Dir(sspPath), 0755), IsNil)
+	c.Assert(ioutil.WriteFile(sspPath, []byte("homedirs=my-path/foo/bar,foo\n"), 0644), IsNil)
+
+	ssp, err := sysparams.Open(sspPath)
+	c.Check(err, IsNil)
+	c.Assert(ssp, NotNil)
+	c.Assert(ssp.Homedirs, Equals, "my-path/foo/bar,foo")
+}
+
+func (s *sysParamsTestSuite) TestOpenExistingEmpty(c *C) {
+	sspPath := dirs.SnapSystemParamsUnder(dirs.GlobalRootDir)
+	c.Assert(os.MkdirAll(path.Dir(sspPath), 0755), IsNil)
+	c.Assert(ioutil.WriteFile(sspPath, []byte("\n"), 0644), IsNil)
+
+	ssp, err := sysparams.Open(sspPath)
+	c.Check(err, IsNil)
+	c.Check(ssp, NotNil)
+}
+
+func (s *sysParamsTestSuite) TestOpenExistingWithInvalidContent(c *C) {
+	sspPath := dirs.SnapSystemParamsUnder(dirs.GlobalRootDir)
+	c.Assert(os.MkdirAll(path.Dir(sspPath), 0755), IsNil)
+	c.Assert(ioutil.WriteFile(sspPath, []byte("xuifu93\n"), 0644), IsNil)
+
+	ssp, err := sysparams.Open(sspPath)
+	c.Check(err, ErrorMatches, `cannot parse invalid line: xuifu93`)
+	c.Check(ssp, NotNil)
+}
+
+func (s *sysParamsTestSuite) TestOpenExistingWithComments(c *C) {
+	sspPath := dirs.SnapSystemParamsUnder(dirs.GlobalRootDir)
+	c.Assert(os.MkdirAll(path.Dir(sspPath), 0755), IsNil)
+	c.Assert(ioutil.WriteFile(sspPath, []byte("# this is a comment line\n"), 0644), IsNil)
+
+	ssp, err := sysparams.Open(sspPath)
+	c.Check(err, IsNil)
+	c.Check(ssp, NotNil)
+}


### PR DESCRIPTION
Sysparams package split out from the original PR https://github.com/snapcore/snapd/pull/12288. This is a small package that manages the system-params file under /var/lib/snapd/system-params, and is used to carry configuration data for homedirs to snap-confine.