### PR TITLE
cmd/libsnap-confine-private: add sc_cleanup_deep_strv

### DIFF
--- a/cmd/libsnap-confine-private/cleanup-funcs-test.c
+++ b/cmd/libsnap-confine-private/cleanup-funcs-test.c
@@ -196,5 +196,6 @@ static void __attribute__((constructor)) init(void)
 	g_test_add_func("/cleanup/endmntent", test_cleanup_endmntent);
 	g_test_add_func("/cleanup/closedir", test_cleanup_closedir);
 	g_test_add_func("/cleanup/close", test_cleanup_close);
+	g_test_add_func("/cleanup/deep_strv", test_cleanup_deep_strv);
 	g_test_add_func("/cleanup/shallow_strv", test_cleanup_shallow_strv);
 }

--- a/cmd/libsnap-confine-private/cleanup-funcs-test.c
+++ b/cmd/libsnap-confine-private/cleanup-funcs-test.c
@@ -142,6 +142,31 @@ static void test_cleanup_close(void)
 	g_assert_cmpint(fd, ==, -1);
 }
 
+static void test_cleanup_deep_strv(void)
+{
+	/* It is safe to use with a NULL pointer */
+	sc_cleanup_deep_strv(NULL);
+
+	char **argses = NULL;
+	/* It is OK if the pointer value is NULL */
+	sc_cleanup_deep_strv(&argses);
+	g_assert_null(argses);
+
+	/* It is safe to call with an empty array */
+	argses = calloc(10, sizeof(char *));
+	g_assert_nonnull(argses);
+	sc_cleanup_deep_strv(&argses);
+
+	/* And of course the typical case works as well */
+	argses = calloc(10, sizeof(char *));
+	g_assert_nonnull(argses);
+	for (int i = 0; i < 9; i++) {
+		argses[i] = strdup("hello");
+	}
+	sc_cleanup_deep_strv(&argses);
+	g_assert_null(argses);
+}
+
 static void test_cleanup_shallow_strv(void)
 {
 	/* It is safe to use with a NULL pointer */

--- a/cmd/libsnap-confine-private/cleanup-funcs-test.c
+++ b/cmd/libsnap-confine-private/cleanup-funcs-test.c
@@ -25,6 +25,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/timerfd.h>
+#include <string.h>
 
 static int called = 0;
 

--- a/cmd/libsnap-confine-private/cleanup-funcs.c
+++ b/cmd/libsnap-confine-private/cleanup-funcs.c
@@ -28,6 +28,17 @@ void sc_cleanup_string(char **ptr)
 	}
 }
 
+void sc_cleanup_deep_strv(char ***ptr)
+{
+	if (ptr != NULL && *ptr != NULL) {
+		for (char **str = *ptr; *str != NULL; str++) {
+			free(*str);
+		}
+		free(*ptr);
+		*ptr = NULL;
+	}
+}
+
 void sc_cleanup_shallow_strv(const char ***ptr)
 {
 	if (ptr != NULL && *ptr != NULL) {

--- a/cmd/libsnap-confine-private/cleanup-funcs.h
+++ b/cmd/libsnap-confine-private/cleanup-funcs.h
@@ -41,6 +41,17 @@
 void sc_cleanup_string(char **ptr);
 
 /**
+ * Free a dynamically allocated string vector.
+ *
+ * Both the vector itself and all the strings contained inside it will be
+ * freed. It's assumed that the strings have been allocated with malloc().
+ * This function is designed to be used with SC_CLEANUP() macro.
+ * The variable MUST be initialized for correct operation.
+ * The safe initialisation value is NULL.
+ */
+void sc_cleanup_deep_strv(char ***ptr);
+
+/**
  * Shallow free a dynamically allocated string vector.
  *
  * The strings in the vector will not be freed.


### PR DESCRIPTION
Deep cleanup of string arrays. Utility function needed for PR https://github.com/snapcore/snapd/pull/12288. 