### PR TITLE
snap: show log information from Wait tasks in the CLI

### DIFF
--- a/cmd/snap/wait.go
+++ b/cmd/snap/wait.go
@@ -127,7 +127,7 @@ func (wmx waitMixin) wait(id string) (*client.Change, error) {
 		// via the log mechanism. So make sure the log is
 		// visible even if the normal progress reporting
 		// has tasks in "Doing" state (like "check-refresh")
-		// that would supress displaying the log. This will
+		// that would suppress displaying the log. This will
 		// ensure on a classic+modes system the user sees
 		// the messages: "Task set to wait until a manual system restart allows to continue"
 		for _, t := range chg.Tasks {

--- a/cmd/snap/wait.go
+++ b/cmd/snap/wait.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"sync"
 	"time"
 
 	"github.com/snapcore/snapd/client"
@@ -83,6 +84,7 @@ func (wmx waitMixin) wait(id string) (*client.Change, error) {
 
 	var lastID string
 	lastLog := map[string]string{}
+	var waitCtrlcMsg sync.Once
 	for {
 		var rebootingErr error
 		chg, err := cli.Change(id)
@@ -133,6 +135,9 @@ func (wmx waitMixin) wait(id string) (*client.Change, error) {
 		for _, t := range chg.Tasks {
 			if t.Status == "Wait" {
 				maybeShowLog(t)
+				waitCtrlcMsg.Do(func() {
+					fmt.Fprintf(Stdout, i18n.G("Warning: pressing ctrl-c will abort the running change\n"))
+				})
 			}
 		}
 

--- a/cmd/snap/wait.go
+++ b/cmd/snap/wait.go
@@ -136,7 +136,7 @@ func (wmx waitMixin) wait(id string) (*client.Change, error) {
 			if t.Status == "Wait" {
 				maybeShowLog(t)
 				waitCtrlcMsg.Do(func() {
-					fmt.Fprintf(Stdout, i18n.G("Warning: pressing ctrl-c will abort the running change\n"))
+					fmt.Fprintf(Stderr, i18n.G("WARNING: pressing ctrl-c will abort the running change.\n"))
 				})
 			}
 		}

--- a/cmd/snap/wait.go
+++ b/cmd/snap/wait.go
@@ -115,17 +115,35 @@ func (wmx waitMixin) wait(id string) (*client.Change, error) {
 			tMax = time.Time{}
 		}
 
+		maybeShowLog := func(t *client.Task) {
+			nowLog := lastLogStr(t.Log)
+			if lastLog[t.ID] != nowLog {
+				pb.Notify(nowLog)
+				lastLog[t.ID] = nowLog
+			}
+		}
+
+		// Tasks in "wait" state communicate the wait reason
+		// via the log mechanism. So make sure the log is
+		// visible even if the normal progress reporting
+		// has tasks in "Doing" state (like "check-refresh")
+		// that would supress displaying the log. This will
+		// ensure on a classic+modes system the user sees
+		// the messages: "Task set to wait until a manual system restart allows to continue"
+		for _, t := range chg.Tasks {
+			if t.Status == "Wait" {
+				maybeShowLog(t)
+			}
+		}
+
+		// progress reporting
 		for _, t := range chg.Tasks {
 			switch {
 			case t.Status != "Doing":
 				continue
 			case t.Progress.Total == 1:
 				pb.Spin(t.Summary)
-				nowLog := lastLogStr(t.Log)
-				if lastLog[t.ID] != nowLog {
-					pb.Notify(nowLog)
-					lastLog[t.ID] = nowLog
-				}
+				maybeShowLog(t)
 			case t.ID == lastID:
 				pb.Set(float64(t.Progress.Done))
 			default:


### PR DESCRIPTION
This is a tiny patch to make the UX on classic+modes systems more user friendly. Right now when running e.g.
`snap refresh pc-kernel` there is no indication that a system reboot is required to continue, the only visible output is that a re-refresh is attempted.

To fix this properly a bigger change is required and various attempts in PR#12417 are all having problems. However as a very minimal improvement this commit shows log messages from tasks in `Wait` state without changing anything else.

This means that the UX is more like:
```
$ snap refresh pc-kernel
2023-02-24T11:2315Z INFO Task set to wait until a manual system restart allows to continue
Handling re-refresh of "pc-kernel" as needed
```
while not ideal UX it feels like a worthwhile improvement until we find the time to fix this properly.
