### PR TITLE
o/configcore: add flag that will determine if a system option can be

### DIFF
--- a/overlord/configstate/configcore/handlers.go
+++ b/overlord/configstate/configcore/handlers.go
@@ -37,6 +37,9 @@ type flags struct {
 	// coreOnlyConfig tells Run/FilesystemOnlyApply to apply the config on core
 	// systems only.
 	coreOnlyConfig bool
+	// modeenvOnlyConfig is set if the option can be applied only
+	// to systems with core-like booting.
+	modeenvOnlyConfig bool
 	// validatedOnlyStateConfig tells that the config requires only validation,
 	// its options are applied dynamically elsewhere.
 	validatedOnlyStateConfig bool
@@ -184,6 +187,9 @@ func filesystemOnlyRun(dev sysconfig.Device, cfg ConfGetter, ctx *fsOnlyContext)
 			continue
 		}
 		if h.flags().coreOnlyConfig && dev.Classic() {
+			continue
+		}
+		if h.flags().modeenvOnlyConfig && !dev.HasModeenv() {
 			continue
 		}
 		if err := h.handle(dev, cfg, ctx); err != nil {

--- a/overlord/configstate/configcore/runwithstate.go
+++ b/overlord/configstate/configcore/runwithstate.go
@@ -63,11 +63,10 @@ func init() {
 	addWithStateHandler(validateAutomaticSnapshotsExpiration, nil, validateOnly)
 
 	// netplan.*
-	addWithStateHandler(validateNetplanSettings, handleNetplanConfiguration, &flags{coreOnlyConfig: true})
+	addWithStateHandler(validateNetplanSettings, handleNetplanConfiguration, coreOnly)
 
 	// kernel.{,dangerous-}cmdline-append
-	// TODO we actually want this on classic with modes too
-	addWithStateHandler(validateCmdlineAppend, handleCmdlineAppend, coreOnly)
+	addWithStateHandler(validateCmdlineAppend, handleCmdlineAppend, &flags{modeenvOnlyConfig: true})
 }
 
 // RunTransaction is an interface describing how to access
@@ -175,6 +174,9 @@ func applyHandlers(dev sysconfig.Device, cfg RunTransaction, handlers []configHa
 
 	for _, h := range handlers {
 		if h.flags().coreOnlyConfig && dev.Classic() {
+			continue
+		}
+		if h.flags().modeenvOnlyConfig && !dev.HasModeenv() {
 			continue
 		}
 		if err := h.handle(dev, cfg, nil); err != nil {

--- a/tests/nested/manual/fde-on-classic/task.yaml
+++ b/tests/nested/manual/fde-on-classic/task.yaml
@@ -20,6 +20,14 @@ prepare: |
   unsquashfs -d pc-gadget pc.snap
   # gadget.yaml needs a different structure than for Ubuntu Core
   python3 tweak-gadget.py pc-gadget/meta/gadget.yaml
+  # Append kernel-cmdline section
+  cat << 'EOF' >> pc-gadget/meta/gadget.yaml
+  kernel-cmdline:
+    allow:
+      - append.val=*
+      - append.flag
+      - other.val=foo
+  EOF
   snap pack --filename=pc_x1.snap pc-gadget
 
   # create an image that looks like a classic image
@@ -94,6 +102,23 @@ execute: |
       fi
   }
 
+  # Sets a system option to append arguments to the kernel command line.
+  # $1: option
+  # $2: value
+  append_kernel_cmdline()
+  {
+      local option=$1
+      local value=$2
+
+      remote.exec "sudo snap set system $option=\"$value\""
+      boot_id="$(tests.nested boot-id)"
+      remote.exec snap changes | MATCH "Done .*Update kernel command line due to change in system configuration"
+      echo "Rebooting after setting $option=\"$value\""
+      remote.exec "sudo reboot" || true
+      tests.nested wait-for reboot "$boot_id"
+      remote.exec "sudo cat /proc/cmdline" | MATCH "$value"
+  }
+
   current_kernel_file=$(remote.exec readlink /run/mnt/ubuntu-boot/EFI/ubuntu/kernel.efi)
   current_kernel_file=${current_kernel_file%/*}
 
@@ -114,6 +139,18 @@ execute: |
       remote.exec sudo grep -q -a '"This program cannot be run in XXX mode"' "$f"
   done
 
+  # Test appending values to the kernel command line
+  append_kernel_cmdline system.kernel.cmdline-append "append.val=1 append.flag other.val=foo"
+  append_kernel_cmdline system.kernel.cmdline-append ""
+  append_kernel_cmdline system.kernel.dangerous-cmdline-append "dang.val=1 dang.flag"
+  append_kernel_cmdline system.kernel.dangerous-cmdline-append ""
+
+  # Test append values, but do not reboot immediately and refresh kernel
+  optCmdline="dang.val=1 dang.flag"
+  remote.exec "sudo snap set system system.kernel.dangerous-cmdline-append=\"$optCmdline\""
+  refresh_rebooting_snap pc-kernel-new.snap pc-kernel reboot
+  remote.exec "sudo cat /proc/cmdline" | MATCH "$optCmdline"
+
   # Test that installing a different base and a reboot cause no reverts
   # (regression test for SNAPDENG-4975)
 
@@ -124,7 +161,7 @@ execute: |
   touch core22/empty-file
   snap pack --filename=core22-new.snap core22
   remote.push "core22-new.snap"
-  # install and validate its now a local version
+  # install and validate it is now a local version
   remote.exec sudo snap install --dangerous "core22-new.snap"
   remote.exec sudo snap list core22 | MATCH " x1 "
   # wait for reboot


### PR DESCRIPTION
used on a system with modes. Use it for the kernel command line
options.