### PR TITLE
configcore: allow to run core configuration on classic via env

### DIFF
--- a/overlord/configstate/configcore/handlers.go
+++ b/overlord/configstate/configcore/handlers.go
@@ -115,6 +115,14 @@ func init() {
 	sysconfig.ApplyFilesystemOnlyDefaultsImpl = filesystemOnlyApply
 }
 
+func isClassic(dev sysconfig.Device) bool {
+	if osutil.GetenvBool("SNAPD_BREAK_SYSTEM_BY_RUNNING_CORE_ONLY_CONFIG") {
+		return true
+	}
+
+	return dev.Classic()
+}
+
 // addFSOnlyHandler registers functions to validate and handle a subset of
 // system config options that do not require to manipulate state but only
 // the file system.
@@ -183,7 +191,7 @@ func filesystemOnlyRun(dev sysconfig.Device, cfg ConfGetter, ctx *fsOnlyContext)
 		if h.needsState() {
 			continue
 		}
-		if h.flags().coreOnlyConfig && dev.Classic() {
+		if h.flags().coreOnlyConfig && isClassic(dev) {
 			continue
 		}
 		if err := h.handle(dev, cfg, ctx); err != nil {

--- a/overlord/configstate/configcore/runwithstate.go
+++ b/overlord/configstate/configcore/runwithstate.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
@@ -174,7 +175,7 @@ func applyHandlers(dev sysconfig.Device, cfg RunTransaction, handlers []configHa
 	}
 
 	for _, h := range handlers {
-		if h.flags().coreOnlyConfig && dev.Classic() {
+		if h.flags().coreOnlyConfig && isClassic(dev) {
 			continue
 		}
 		if err := h.handle(dev, cfg, nil); err != nil {


### PR DESCRIPTION
This commit adds a new environment called
`SNAPD_BREAK_SYSTEM_BY_RUNNING_CORE_ONLY_CONFIG`
that allows to run core configuration options on classic.

The goal is to be able to test netplan integration on classic systems. Nothing in netplan is core specific, we just did not enable it on classic for conistency but it should be great for netplan based integration testing inside the netplan repo.

