### PR TITLE
cmd/snap-confine: read and mount homedirs in snap-confine

### DIFF
--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -203,11 +203,30 @@ struct sc_mount_config {
 	const char *rootfs_dir;
 	// The struct is terminated with an entry with NULL path.
 	const struct sc_mount *mounts;
+	// Same as the structure above, but this is malloc-allocated.
+	struct sc_mount *dynamic_mounts;
 	sc_distro distro;
 	bool normal_mode;
 	const char *base_snap_name;
 	const char *snap_instance;
 };
+
+/**
+ * Ensures all required mount points have been created
+ */
+static void sc_create_mount_points(const char *scratch_dir,
+                                   const struct sc_mount *mounts)
+{
+	char dst[PATH_MAX] = { 0 };
+	sc_identity old = sc_set_effective_identity(sc_root_group_identity());
+	for (const struct sc_mount * mnt = mounts; mnt->path != NULL; mnt++) {
+		sc_must_snprintf(dst, sizeof(dst), "%s/%s", scratch_dir, mnt->path);
+		if (sc_nonfatal_mkpath(dst, 0755) < 0) {
+			die("cannot create mount point %s", dst);
+		}
+	}
+	(void)sc_set_effective_identity(old);
+}
 
 /**
  * Perform all the given bind mounts
@@ -535,6 +554,12 @@ static void sc_bootstrap_mount_namespace(const struct sc_mount_config *config)
 	// below serves as the foundation of the mount sandbox.
 	sc_do_mount("none", scratch_dir, NULL, MS_REC | MS_SLAVE, NULL);
 	sc_do_mounts(scratch_dir, config->mounts);
+	
+	// Dynamic mounts handle things like user-specified home directories. These
+	// can change between runs, so they are stored separately. As we don't know
+	// these in advance, make sure paths also exist in the scratch dir.
+	sc_create_mount_points(scratch_dir, config->dynamic_mounts);
+	sc_do_mounts(scratch_dir, config->dynamic_mounts);
 
 	if (config->normal_mode) {
 		// Since we mounted /etc from the host filesystem to the scratch directory,
@@ -878,6 +903,41 @@ static bool __attribute__((used))
 	return false;
 }
 
+static struct sc_mount *sc_init_homedir_mounts(const struct sc_invocation *inv)
+{
+	if (inv->homedirs == NULL) {
+		// Return empty array, but never NULL as functions rely
+		// on the mounts array to be non-NULL
+		return calloc(1, sizeof(struct sc_mount));
+	}
+
+	int num_homedirs = 0;
+	for (char **path = inv->homedirs; *path != NULL; path++) {
+		num_homedirs++;
+	}
+
+	// We add one element for the end-of-array indicator.
+	struct sc_mount *mounts = calloc(num_homedirs + 1, sizeof(struct sc_mount));
+	if (mounts == NULL) {
+		die("cannot allocate mount data for homedirs");
+	}
+
+	struct sc_mount *current_mount = mounts;
+	for (char **path = inv->homedirs; *path != NULL; path++) {
+		debug("Adding homedir: %s", *path);
+		current_mount->path = *path;
+		current_mount++;
+	}
+	return mounts;
+}
+
+static void sc_free_dynamic_mounts(struct sc_mount *mounts)
+{
+	/* We don't free the paths, since they are borrowed by the sc_invocation
+	 * structure */
+	free(mounts);
+}
+
 void sc_populate_mount_ns(struct sc_apparmor *apparmor, int snap_update_ns_fd,
 			  const sc_invocation * inv, const gid_t real_gid,
 			  const gid_t saved_gid)
@@ -920,12 +980,18 @@ void sc_populate_mount_ns(struct sc_apparmor *apparmor, int snap_update_ns_fd,
 		struct sc_mount_config normal_config = {
 			.rootfs_dir = inv->rootfs_dir,
 			.mounts = mounts,
+			// Homedir mounts are user-specified paths that snaps are allowed
+			// to access, which don't reside in the regular home path. They can change
+			// between runs, so we must dynamically handle them.
+			.dynamic_mounts = sc_create_homedir_mounts(inv),
 			.distro = distro,
 			.normal_mode = true,
 			.base_snap_name = inv->base_snap_name,
 			.snap_instance = inv->snap_instance,
 		};
 		sc_bootstrap_mount_namespace(&normal_config);
+		sc_free_dynamic_mounts(normal_config.dynamic_mounts);
+		normal_config.dynamic_mounts = NULL;
 	} else {
 		// In legacy mode we don't pivot to a base snap's rootfs and instead
 		// just arrange bi-directional mount propagation for two directories.

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -273,20 +273,10 @@ static dev_t find_base_snap_device(const char *base_snap_name,
 	return base_snap_dev;
 }
 
-static bool should_discard_current_ns(dev_t base_snap_dev)
+static bool base_snap_device_changed(sc_mountinfo *mi, dev_t base_snap_dev)
 {
-	// Inspect the namespace and check if we should discard it.
-	//
-	// The namespace may become "stale" when the rootfs is not the same
-	// device we found above. This will happen whenever the base snap is
-	// refreshed since the namespace was first created.
 	sc_mountinfo_entry *mie;
-	sc_mountinfo *mi SC_CLEANUP(sc_cleanup_mountinfo) = NULL;
 
-	mi = sc_parse_mountinfo(NULL);
-	if (mi == NULL) {
-		die("cannot parse mountinfo of the current process");
-	}
 	/* We are looking for a mount entry matching the device ID of the base
 	 * snap. We need to take these cases into account:
 	 * 1) In the typical case, this will be mounted on the "/" directory.
@@ -317,6 +307,73 @@ static bool should_discard_current_ns(dev_t base_snap_dev)
 	debug("base snap device %d:%d not found in existing mount ns",
 	      major(base_snap_dev), minor(base_snap_dev));
 	return true;
+}
+
+static bool homedirs_are_mounted(sc_mountinfo *mi, char **homedirs)
+{
+	if (homedirs == NULL) {
+		return true;
+	}
+
+	int num_homedirs = 0;
+	for (char **path = homedirs; *path != NULL; path++) {
+		num_homedirs++;
+	}
+
+	/* We know that the number of homedirs is not going to be huge, so let's
+	 * just allocare this vector on the stack */
+	bool homedir_seen[num_homedirs];
+	for (int i = 0; i < num_homedirs; i++) {
+		homedir_seen[i] = false;
+	}
+
+	sc_mountinfo_entry *mie;
+	for (mie = sc_first_mountinfo_entry(mi); mie != NULL;
+	     mie = sc_next_mountinfo_entry(mie)) {
+		for (int i = 0; i < num_homedirs; i++) {
+			if (sc_streq(mie->mount_dir, homedirs[i])) {
+				homedir_seen[i] = true;
+			}
+		}
+	}
+
+	bool all_seen = true;
+	for (int i = 0; i < num_homedirs; i++) {
+		if (!homedir_seen[i]) {
+			debug("Homedir %s missing from namespace", homedirs[i]);
+			all_seen = false;
+			break;
+		}
+	}
+	return all_seen;
+}
+
+// Inspect the namespace and check if we should discard it.
+static bool should_discard_current_ns(const struct sc_invocation *inv,
+                                      dev_t base_snap_dev)
+{
+	sc_mountinfo *mi SC_CLEANUP(sc_cleanup_mountinfo) = NULL;
+
+	mi = sc_parse_mountinfo(NULL);
+	if (mi == NULL) {
+		die("cannot parse mountinfo of the current process");
+	}
+
+	// The namespace may become "stale" when the rootfs is not the same
+	// device we found above. This will happen whenever the base snap is
+	// refreshed since the namespace was first created.
+	if (base_snap_device_changed(mi, base_snap_dev)) {
+		return true;
+	}
+
+	// Another reason for becoming stale is if the homedirs configuration has
+	// changed: so this code will check that all homedirs are mounted in the
+	// namespace.
+	if (!homedirs_are_mounted(mi, inv->homedirs)) {
+		return true;
+	}
+
+	return false;
 }
 
 enum sc_discard_vote {
@@ -469,7 +526,7 @@ static int sc_inspect_and_maybe_discard_stale_ns(int mnt_fd,
 		// systemd. This makes us end up in a situation where the outer base
 		// snap will never match the rootfs inside the mount namespace.
 		if (inv->is_normal_mode
-		    && should_discard_current_ns(base_snap_dev)) {
+		    && should_discard_current_ns(inv, base_snap_dev)) {
 			value = SC_DISCARD_SHOULD;
 			value_str = "should";
 		}

--- a/cmd/snap-confine/snap-confine-invocation.c
+++ b/cmd/snap-confine/snap-confine-invocation.c
@@ -95,6 +95,7 @@ void sc_cleanup_invocation(sc_invocation *inv) {
         sc_cleanup_string(&inv->security_tag);
         sc_cleanup_string(&inv->executable);
         sc_cleanup_string(&inv->rootfs_dir);
+        sc_cleanup_deep_strv(&inv->homedirs);
     }
 }
 
@@ -143,4 +144,67 @@ void sc_check_rootfs_dir(sc_invocation *inv) {
     }
 
     die("cannot locate base snap %s", inv->base_snap_name);
+}
+
+static char* read_homedirs_from_system_params(void)
+{
+    FILE *f SC_CLEANUP(sc_cleanup_file) = NULL;
+    f = fopen("var/lib/snapd/system-params", "r");
+    if (f == NULL) {
+        return NULL;
+    }
+
+    char *line SC_CLEANUP(sc_cleanup_string) = NULL;
+    size_t line_size = 0;
+    while (getline(&line, &line_size, f) != -1) {
+        if (sc_startswith(line, "homedirs=")) {
+            return strdup(line + (sizeof("homedirs=") - 1));
+        }
+    }
+    return NULL;
+}
+
+void sc_invocation_check_homedirs(sc_invocation *inv)
+{
+    char *config_line SC_CLEANUP(sc_cleanup_string) = read_homedirs_from_system_params();
+    if (config_line == NULL) {
+        return;
+    }
+
+    /* The homedirs setting is a comma-separated list. In order to allocate the
+     * right number of strings, let's count how many commas we have.
+     */
+    int num_commas = 0;
+    for (char *c = config_line; *c != '\0'; c++) {
+        if (*c == ',') {
+            num_commas++;
+        }
+    }
+
+    /* We add *two* elements here: one is because of course the number of
+     * actual homedirs is the number of commas plus one, and the extra one is
+     * used as an end-of-array indicator. */
+    inv->homedirs = calloc(num_commas + 2, sizeof(char *));
+    if (inv->homedirs == NULL) {
+        die("cannot allocate memory for homedirs");
+    }
+
+    // strtok_r needs a pointer to keep track of where it is in the
+    // string.
+    char *buf_saveptr = NULL;
+
+    int current_index = 0;
+    char *homedir = strtok_r(config_line, ",\n", &buf_saveptr);
+    while (homedir != NULL) {
+        if (homedir[0] == '\0') {
+            /* The typical case where we'd get an empty string is
+             * if the config file just contains
+             *
+             * homedirs=
+             */
+            continue;
+        }
+        inv->homedirs[current_index++] = sc_strdup(homedir);
+        homedir = strtok_r(NULL, ",\n", &buf_saveptr);
+    }
 }

--- a/cmd/snap-confine/snap-confine-invocation.h
+++ b/cmd/snap-confine/snap-confine-invocation.h
@@ -38,6 +38,7 @@ typedef struct sc_invocation {
     /* Things derived at runtime. */
     char *base_snap_name;
     char *rootfs_dir;
+    char **homedirs;
     bool is_normal_mode;
 } sc_invocation;
 
@@ -76,5 +77,12 @@ void sc_cleanup_invocation(sc_invocation *inv);
  * of SNAP_MOUNT_DIR.
  **/
 void sc_check_rootfs_dir(sc_invocation *inv);
+
+/**
+ * sc_invocation_check_homedirs() reads the homedirs configuration
+ * file of snapd and fills the "homedirs" string vector in the
+ * sc_invocation structure.
+ */
+void sc_invocation_check_homedirs(sc_invocation *inv);
 
 #endif

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -680,6 +680,12 @@ static void enter_non_classic_execution_environment(sc_invocation * inv,
 	inv->is_normal_mode = distro != SC_DISTRO_CORE16 ||
 	    !sc_streq(inv->orig_base_snap_name, "core");
 
+	/* Read the homedirs configuration: this information is needed both by our
+	 * namespace helper (in order to detect if the homedirs are mounted) and by
+	 * snap-confine itself to mount the homedirs.
+	 */
+	sc_invocation_check_homedirs(inv);
+
 	/* Stale mount namespace discarded or no mount namespace to
 	   join. We need to construct a new mount namespace ourselves.
 	   To capture it we will need a helper process so make one. */

--- a/cmd/snap-confine/user-support.c
+++ b/cmd/snap-confine/user-support.c
@@ -41,7 +41,8 @@ void setup_user_data(void)
 		if ((errno == EROFS || errno == EACCES) && !sc_startswith(user_data, "/home/")) {
 			// clear errno or it will be displayed in die()
 			errno = 0;
-			die("Sorry, home directories outside of /home are not currently supported. \nSee https://forum.snapcraft.io/t/11209 for details.");
+			// XXX: may point to the right config option here?
+			die("Sorry, home directories outside of /home needs configuration.\nSee https://forum.snapcraft.io/t/11209 for details.");
 		}
 		die("cannot create user data directory: %s", user_data);
 	};


### PR DESCRIPTION
This PR contains the support for reading and mounting the home directories specified in the system-params file, in snap-confine. I've opened this early to just ensure things build correctly, and will move spread tests to this PR as this is the 'final' functionality required. This will need all other PRs related to https://github.com/snapcore/snapd/pull/12288 to land first.