### PR TITLE
tests: spread test pre-download and delayed auto-refresh

### DIFF
--- a/tests/main/auto-refresh-pre-download/task.yaml
+++ b/tests/main/auto-refresh-pre-download/task.yaml
@@ -1,0 +1,112 @@
+summary: Check that an inhibited auto-refresh triggers a pre-download change and resumes on close
+
+# Ubuntu 14.04's special version of systemd doesn't have StartTransientUnit API.
+systems: [-ubuntu-14.04-*]
+
+kill-timeout: 5m
+
+environment:
+  REFRESH_TYPE/close: "close"
+  REFRESH_TYPE/ignore: "ignore-running"
+
+prepare: |
+  snap install --devmode jq
+  snap install test-snapd-sh
+
+restore: |
+  snap remove --purge jq || true
+  snap remove --purge test-snapd-sh || true
+
+debug: |
+  snap changes
+  cat /home/test/notif.log || true
+
+execute: |
+  changeAfterID() {
+    local OLD_CHANGE="$1"
+    local NEW_CHANGE
+
+    for _ in $(seq 5); do
+      NEW_CHANGE=$(snap changes | tail -n 2 | head -n 1 | awk '{print $1}')
+      if [ "$NEW_CHANGE" -gt "$OLD_CHANGE" ]; then
+        break
+      fi
+
+      snap debug ensure-state-soon
+      sleep 1s
+    done
+
+    if [ "$NEW_CHANGE" -le "$OLD_CHANGE" ]; then
+      echo "expected a change with an id greater than $OLD_CHANGE"
+      exit 1
+    fi
+  }
+
+  snap refresh --unhold
+  # make sure other snaps don't refresh later possibly interfering w/ the checks
+  snap refresh
+
+  test-snapd-sh.sh -c "while [ ! -e stamp ]; do sleep 1; done" &
+  APP_PID="$!"
+  tests.cleanup defer "kill \"$APP_PID\" || true"
+
+  # TODO: test notifications in other distros as well
+  if os.query is-ubuntu && os.query is-classic; then
+    tests.session -u test exec sh -c 'dbus-monitor > notif.log' &
+    tests.cleanup defer "systemctl kill user-12345.slice || true"
+  fi
+
+  # trigger an auto-refresh
+  OLD_CHANGE=$(snap changes | tail -n 2 | head -n 1 | awk '{print $1}')
+  systemctl stop snapd.{service,socket}
+  "$TESTSTOOLS"/snapd-state change-snap-channel test-snapd-sh edge
+  "$TESTSTOOLS"/snapd-state force-autorefresh
+  systemctl start snapd.{socket,service}
+
+  # check that a change was triggered and it's a pre-download
+  changeAfterID "$OLD_CHANGE"
+  if ! retry -n 15 sh -c 'snap changes | tail -n 2 | grep "Done.*Pre-download tasks for auto-refresh"'; then
+    echo "expected a completed pre-download change"
+    exit 1
+  fi
+
+  if os.query is-ubuntu && os.query is-classic; then
+    # stop all the dbus monitoring related processes
+    systemctl kill user-12345.slice 2>/dev/null || true
+
+    # check that the pre-download notified the user to close the snap
+    MATCH 'string "Pending update of "test-snapd-sh" snap"' < /home/test/notif.log
+    MATCH 'string "Close the app to avoid disruptions \(.* days left\)"' < /home/test/notif.log
+  fi
+
+  if [ "$REFRESH_TYPE" == "close" ]; then
+    CHANGE=$(snap changes | tail -n 2 | head -n 1 | awk '{print $1}')
+
+    # stop the snap and check that an auto-refresh is triggered
+    touch stamp
+    wait "$APP_PID"
+    "$TESTSTOOLS"/snapd-state wait-for-snap-autorefresh "test-snapd-sh" "$CHANGE"
+  elif [ "$REFRESH_TYPE" == "ignore-running" ]; then
+    # refresh the snap while running
+    OLD_CHANGE=$(snap changes | tail -n 2 | head -n 1 | awk '{print $1}')
+    snap refresh --ignore-running test-snapd-sh
+
+    # check the refresh was completed
+    changeAfterID "$OLD_CHANGE"
+    if ! retry -n 15 sh -c 'snap changes | tail -n 2 | grep "Done.*Refresh \"test-snapd-sh\" snap"'; then
+      echo "expected test-snapd-sh to be refreshed"
+      exit 1
+    fi
+
+    # stop the snap and check no auto-refresh was triggered
+    touch stamp
+    wait "$APP_PID"
+
+    if retry -n 5 sh -c 'snap changes | tail -n 2 | grep "Done.*Auto-refresh.*snap.*test-snapd-sh"'; then
+      echo "unexpected auto-refresh of test-snapd-sh"
+      exit 1
+    fi
+  else
+    echo "unrecognized test variant"
+    exit 1
+  fi


### PR DESCRIPTION
Check that an inhibited auto-refresh triggers a pre-download and notification for the snap. There are two tests variants, one for the case where the user closes the snap and that continues the inhibited auto-refresh and another for the case where the user runs `snap refresh --ignore-running ...`