### PR TITLE
o/snapstate: fix deletion of monitored snaps map

### DIFF
--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -929,11 +929,15 @@ func asyncRefreshOnSnapClose(st *state.State, refreshInfo *userclient.PendingSna
 		st.Lock()
 		defer st.Unlock()
 
+		monitoredSnaps := st.Cached("monitored-snaps").(map[string]bool)
 		delete(monitoredSnaps, refreshInfo.InstanceName)
+
 		if len(monitoredSnaps) == 0 {
-			monitoredSnaps = nil
+			// use nil to delete entry but must be nil type (can't be map var set to nil)
+			st.Cache("monitored-snaps", nil)
+		} else {
+			st.Cache("monitored-snaps", monitoredSnaps)
 		}
-		st.Cache("monitored-snaps", monitoredSnaps)
 		continueInhibitedAutoRefresh(st)
 	}()
 


### PR DESCRIPTION
The deletion of the empty "monitored-snaps" was wrong since it assigned nil to a variable with a map type and passed that into Cache(). This variable isn't equal to nil due to its type so Cache() would store it instead of deleting the state entry.