### PR TITLE
tests: add extra space to the arch linux image

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -159,6 +159,7 @@ backends:
 
             - arch-linux-64:
                   workers: 6
+                  storage: 12G
             - amazon-linux-2-64:
                   workers: 6
                   storage: preserve-size


### PR DESCRIPTION
This is to avoid some errors like this one:
 Write on output file failed because No space left on device
