### PR TITLE
build: add test and build scripts

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -100,6 +100,18 @@ installed (since it will not get updates as it was installed dangerously), you
 can either use `snap revert snapd`, or you can refresh directly with 
 `snap refresh snapd --stable --amend`.
 
+A simpler way of building it without touching your system is by using the
+*local_build.py* script. Launching it with *./local_build.py init* the first
+time, it will use *multipass* to create a virtual machine with Ubuntu 16.04,
+install inside snapcraft from the 4.x channel, set the building environment
+to LXD, and launch a shell, where you can just execute *snapcraft* to build
+the snap. The next time, you only need to use the *init* parameter if you
+want to fully re-create the virtual machine; if not, just use *./local_build.py*
+to enter into it.
+
+At the beginning of the *local_build.py* script you can adjust things like
+how much memory, disk space or CPU cores to assign to the VM.
+
 #### Building for other architectures with snapcraft
 
 It is also sometimes useful to use snapcraft to build the snapd snap for
@@ -210,6 +222,15 @@ cd ~/snapd
 mkdir -p /tmp/build
 go build -o /tmp/build ./...
 ```
+
+You can also use the *launch* script to build and test the daemon.
+Just doing *./launch launch* will compile the code locally, stop the
+current daemon, and launch the daemon compiled. It will run in the
+current terminal until *Ctrl+C* is pressed. Then, the script will
+relaunch the system's snapd daemon and exit, thus ensuring that
+everything in the system will continue working as expected.
+
+If you only want to build but not launch it, just run *./launch build*.
 
 ### Building with cross-compilation (_example: ARM v7 target_)
 

--- a/launch
+++ b/launch
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+build() {
+    mkdir -p build
+    go build -o build ./...
+}
+
+stop() {
+    sudo systemctl stop snapd.service snapd.socket
+}
+
+launch() {
+    sudo SNAPD_DEBUG=1 SNAPD_DEBUG_HTTP=3 ./build/snapd
+}
+
+start() {
+    sudo systemctl start snapd.service snapd.socket
+}
+
+if [[ $1 == "launch" ]]
+then
+    build
+    stop
+    launch
+    start
+fi
+
+if [[ $1 == "build" ]]
+then
+    build
+fi

--- a/local_build.py
+++ b/local_build.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import time
+
+vm_name = "build-snapd"
+# Memory in GB
+vm_memory = 16
+# number of cores assigned to the VM
+vm_cpu_cores = 16
+# disk space for the VM in GB
+vm_disk_space = 10
+
+def run_command(command):
+    print(f"Running {command}")
+    os.system(f"multipass exec {vm_name} -- {command}")
+
+def create_vm():
+    print("Creating VM")
+    # first, delete any old VM
+    os.system(f"multipass delete {vm_name}")
+    os.system(f"multipass purge")
+    time.sleep(2)
+    os.system(f"multipass launch xenial -n {vm_name} -m {vm_memory}G -c {vm_cpu_cores} -d {vm_disk_space}G")
+
+if (len(sys.argv) > 1):
+    if (sys.argv[1] != "init"):
+        print("Unknown command. Use:")
+        print("    build-snapd [init]")
+        sys.exit(-1)
+    create_vm()
+    run_command("sudo apt update")
+    run_command("sudo apt dist-upgrade -y")
+    run_command("sudo snap install lxd")
+    run_command("sudo lxd.migrate -yes")
+    run_command("lxd init --auto")
+    run_command("sudo snap install snapcraft --classic --channel=4.x")
+    run_command('bash -c "echo export SNAPCRAFT_BUILD_ENVIRONMENT=lxd >> /home/ubuntu/.bashrc"')
+    run_command("mkdir -p /home/ubuntu/basedir")
+    os.system(f"multipass stop {vm_name}")
+    os.system(f"multipass mount -t native . {vm_name}:/home/ubuntu/basedir/")
+    os.system(f"multipass start {vm_name}")
+
+run_command('bash')


### PR DESCRIPTION
This MR adds two little scripts that I use to build locally the snap, and to compile and launch the daemon to do quick tests. They have nothing "new", just saves the time of doing the steps specified in the HACKING.md files manually.
