### PR TITLE
interfaces/hardware-observe: allow readin /proc/tty/driver/*

### DIFF
--- a/interfaces/builtin/hardware_observe.go
+++ b/interfaces/builtin/hardware_observe.go
@@ -95,7 +95,7 @@ network netlink raw,
 # hwinfo --short
 @{PROC}/ioports r,
 @{PROC}/dma r,
-@{PROC}/tty/driver/serial r,
+@{PROC}/tty/driver/{,*} r,
 @{PROC}/sys/dev/cdrom/info r,
 
 # status of hugepages and transparent_hugepage, but not the pages themselves


### PR DESCRIPTION
Each serial driver can leave its own file specifying harware information in /proc/tty/driver/, in the same format as "serial" driver, so we should allow reading any of them. Example of files created there are usbserial, max310x or IMX-uart.