### PR TITLE
account_control: allow local user account management

### DIFF
--- a/interfaces/builtin/account_control.go
+++ b/interfaces/builtin/account_control.go
@@ -39,6 +39,39 @@ const accountControlBaseDeclarationSlots = `
 `
 
 const accountControlConnectedPlugAppArmor = `
+#include <abstractions/dbus-strict>
+# Introspection of org.freedesktop.Accounts
+# do not use peer=(label=unconfined) here since this is DBus activated
+dbus (send)
+    bus=system
+    path=/org/freedesktop/Accounts{,/User[0-9]*}
+    interface=org.freedesktop.DBus.Introspectable
+    member=Introspect,
+dbus (send)
+    bus=system
+    path=/org/freedesktop/Accounts
+    interface=org.freedesktop.Accounts
+    peer=(label=unconfined),
+dbus (send)
+    bus=system
+    path=/org/freedesktop/Accounts/User[0-9]*
+    interface=org.freedesktop.Accounts.User
+    peer=(label=unconfined),
+# Read all properties from Accounts
+# do not use peer=(label=unconfined) here since this is DBus activated
+dbus (send)
+    bus=system
+    path=/org/freedesktop/Accounts{,/User[0-9]*}
+    interface=org.freedesktop.DBus.Properties
+    member=Get{,All},
+# Receive Accounts property changed events
+dbus (receive)
+    bus=system
+    path=/org/freedesktop/Accounts{,/User[0-9]*}
+    interface=org.freedesktop.DBus.Properties
+    member=PropertiesChanged
+    peer=(label=unconfined),
+
 /{,usr/}sbin/chpasswd ixr,
 /{,usr/}sbin/user{add,del} ixr,
 

--- a/interfaces/builtin/account_control.go
+++ b/interfaces/builtin/account_control.go
@@ -50,11 +50,13 @@ dbus (send)
 dbus (send)
     bus=system
     path=/org/freedesktop/Accounts
-    interface=org.freedesktop.Accounts,
+    interface=org.freedesktop.Accounts
+    peer=(label=unconfined),
 dbus (send)
     bus=system
     path=/org/freedesktop/Accounts/User[0-9]*
-    interface=org.freedesktop.Accounts.User,
+    interface=org.freedesktop.Accounts.User
+    peer=(label=unconfined),
 # Read all properties from Accounts
 dbus (send)
     bus=system
@@ -67,7 +69,8 @@ dbus (receive)
     bus=system
     path=/org/freedesktop/Accounts{,/User[0-9]*}
     interface=org.freedesktop.DBus.Properties
-    member=PropertiesChanged,
+    member=PropertiesChanged
+    peer=(label=unconfined),
 
 /{,usr/}sbin/chpasswd ixr,
 /{,usr/}sbin/user{add,del} ixr,

--- a/interfaces/builtin/account_control.go
+++ b/interfaces/builtin/account_control.go
@@ -41,12 +41,12 @@ const accountControlBaseDeclarationSlots = `
 const accountControlConnectedPlugAppArmor = `
 #include <abstractions/dbus-strict>
 # Introspection of org.freedesktop.Accounts
-# do not use peer=(label=unconfined) here since this is DBus activated
 dbus (send)
     bus=system
     path=/org/freedesktop/Accounts{,/User[0-9]*}
     interface=org.freedesktop.DBus.Introspectable
-    member=Introspect,
+    member=Introspect
+    peer=(label=unconfined),
 dbus (send)
     bus=system
     path=/org/freedesktop/Accounts
@@ -56,12 +56,12 @@ dbus (send)
     path=/org/freedesktop/Accounts/User[0-9]*
     interface=org.freedesktop.Accounts.User,
 # Read all properties from Accounts
-# do not use peer=(label=unconfined) here since this is DBus activated
 dbus (send)
     bus=system
     path=/org/freedesktop/Accounts{,/User[0-9]*}
     interface=org.freedesktop.DBus.Properties
-    member=Get{,All},
+    member=Get{,All}
+    peer=(label=unconfined),
 # Receive Accounts property changed events
 dbus (receive)
     bus=system

--- a/interfaces/builtin/account_control.go
+++ b/interfaces/builtin/account_control.go
@@ -50,13 +50,11 @@ dbus (send)
 dbus (send)
     bus=system
     path=/org/freedesktop/Accounts
-    interface=org.freedesktop.Accounts
-    peer=(label=unconfined),
+    interface=org.freedesktop.Accounts,
 dbus (send)
     bus=system
     path=/org/freedesktop/Accounts/User[0-9]*
-    interface=org.freedesktop.Accounts.User
-    peer=(label=unconfined),
+    interface=org.freedesktop.Accounts.User,
 # Read all properties from Accounts
 # do not use peer=(label=unconfined) here since this is DBus activated
 dbus (send)
@@ -69,8 +67,7 @@ dbus (receive)
     bus=system
     path=/org/freedesktop/Accounts{,/User[0-9]*}
     interface=org.freedesktop.DBus.Properties
-    member=PropertiesChanged
-    peer=(label=unconfined),
+    member=PropertiesChanged,
 
 /{,usr/}sbin/chpasswd ixr,
 /{,usr/}sbin/user{add,del} ixr,


### PR DESCRIPTION
This MR adds support for adding, removing and modifying the users. It is required for Core Desktop, to allow to add, remove and manage users from gnome-control-center.

