### PR TITLE
interfaces: grant access to new ibus socket location in desktop-legacy

### DIFF
--- a/interfaces/builtin/desktop_legacy.go
+++ b/interfaces/builtin/desktop_legacy.go
@@ -148,6 +148,9 @@ unix (connect, receive, send)
      type=stream
      peer=(addr="@/home/*/.cache/ibus/dbus-*"),
 
+# when running with glib >= 2.75.0, ibus uses a regular socket
+owner @{HOME}/.cache/ibus/dbus-* rw,
+
 
 # mozc
 # allow communicating with mozc server


### PR DESCRIPTION
The ibus input method communicates via a private D-Bus message bus implemented with glib's D-Bus implementation. With glib >= 2.75.0, this switched from an abstract namespace unix socket to a regular unix socket. This commit grants access to the regular unix socket path.

More details can be found in [Launchpad bug #2008279](https://launchpad.net/bugs/2008279). The problem is triggered by the glib currently in lunar-proposed, so I think this is a candidate to cherry-pick into the snapd that ships with Ubuntu 23.04.