### PR TITLE
tests: skip snapd-reexec-prompt on arm devices as it is excluded in amd64

### DIFF
--- a/tests/main/snapd-reexec-prompt/task.yaml
+++ b/tests/main/snapd-reexec-prompt/task.yaml
@@ -3,7 +3,7 @@ summary: Test that snapd prompt services reexec into the snapd snap
 # Disable for Fedora, openSUSE and Arch as re-exec is not supported there yet
 # Disable on Ubuntu 14.04 and UC16 as this feature will not land there, and
 # there are limitations that render backporting hard.
-systems: [-fedora-*, -opensuse-*, -arch-*, -amazon-*, -centos-*, -ubuntu-14.04-*, -ubuntu-core-16-64]
+systems: [-fedora-*, -opensuse-*, -arch-*, -amazon-*, -centos-*, -ubuntu-14.04-*, -ubuntu-core-16-*64]
 
 execute: |
     if [ "${SNAP_REEXEC:-}" = "0" ]; then


### PR DESCRIPTION
Include ubuntu-core-16-arm-64 in the excluded systems, this is failing as it fails in amd64

This test is failing in beta validation on arm devices