### PR TITLE
interfaces/account-control: grant access to files needed by pam

### DIFF
--- a/interfaces/builtin/account_control.go
+++ b/interfaces/builtin/account_control.go
@@ -67,8 +67,13 @@ capability chown,
 capability fsetid,
 
 # useradd writes the result in the log
+# faillog tracks failed events, lastlog maintain records of the last
+# time a user successfully logged in, tallylog maintains records of
+# failures.
 #include <abstractions/wutmp>
 /var/log/faillog rwk,
+/var/log/lastlog rwk,
+/var/log/tallylog rwk,
 `
 
 // Needed because useradd uses a netlink socket, {{group}} is used as a


### PR DESCRIPTION
pam uses /var/log/lastlog for successful log attempts, and /var/log/tallylog for failures.