### PR TITLE
golang: remove deadcode linter and bump version

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -154,7 +154,7 @@ jobs:
       with:
         # version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest`
         # to use the latest version
-        version: v1.50.1
+        version: v1.51.2
         working-directory: ./src/github.com/snapcore/snapd
         # show only new issues
         # use empty path prefix to make annotations work

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -175,7 +175,6 @@ linters:
   enable:
     - govet
     - misspell
-    - deadcode
     - unused
     # gosimple may suggest patterns that work only with more recent Go versions
     # - gosimple

--- a/asserts/fetcher.go
+++ b/asserts/fetcher.go
@@ -27,7 +27,6 @@ import (
 type fetchProgress int
 
 const (
-	//nolint:deadcode
 	fetchNotSeen fetchProgress = iota
 	fetchRetrieved
 	fetchSaved

--- a/cmd/snap-update-ns/utils.go
+++ b/cmd/snap-update-ns/utils.go
@@ -41,7 +41,6 @@ const (
 	// SquashfsMagic is the equivalent of SQUASHFS_MAGIC
 	SquashfsMagic = 0x73717368
 	// Ext4Magic is the equivalent of EXT4_SUPER_MAGIC
-	//nolint:deadcode
 	Ext4Magic = 0xef53
 	// TmpfsMagic is the equivalent of TMPFS_MAGIC
 	TmpfsMagic = 0x01021994

--- a/spdx/licenses.go
+++ b/spdx/licenses.go
@@ -25,7 +25,7 @@ package spdx
 //
 // jq < json/licenses.json '.licenses | .[] | select(.isOsiApproved == true) | .licenseId' | sort | sed -e 's/$/,/'
 //
-//nolint:deadcode,unused
+//nolint:unused
 var osi = []string{
 	"0BSD",
 	"AAL",

--- a/store/store.go
+++ b/store/store.go
@@ -563,7 +563,6 @@ var (
 type deviceAuthNeed int
 
 const (
-	//nolint:deadcode
 	deviceAuthPreferred deviceAuthNeed = iota
 	deviceAuthCustomStoreOnly
 )

--- a/strutil/shlex/shlex.go
+++ b/strutil/shlex/shlex.go
@@ -84,7 +84,6 @@ const (
 
 // Classes of rune token
 const (
-	//nolint:deadcode
 	unknownRuneClass runeTokenClass = iota
 	spaceRuneClass
 	escapingQuoteRuneClass


### PR DESCRIPTION
It seems the 'deadcode' linter is marked deprecated, and is replaced by unused (we already have that). This caused our static checks to fail

`The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.`