### PR TITLE
tests: update interfaces-account-control test to use snapd with the UC base

### DIFF
--- a/tests/main/interfaces-account-control/account-control-consumer-core22/bin/chpasswd
+++ b/tests/main/interfaces-account-control/account-control-consumer-core22/bin/chpasswd
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /usr/sbin/chpasswd "$@"

--- a/tests/main/interfaces-account-control/account-control-consumer-core22/bin/deluser
+++ b/tests/main/interfaces-account-control/account-control-consumer-core22/bin/deluser
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /usr/sbin/deluser "$@"

--- a/tests/main/interfaces-account-control/account-control-consumer-core22/bin/useradd
+++ b/tests/main/interfaces-account-control/account-control-consumer-core22/bin/useradd
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /usr/sbin/useradd "$@"

--- a/tests/main/interfaces-account-control/account-control-consumer-core22/meta/snap.yaml
+++ b/tests/main/interfaces-account-control/account-control-consumer-core22/meta/snap.yaml
@@ -1,0 +1,16 @@
+name: account-control-consumer-core22
+version: 1.0
+summary: Basic account-control consumer snap
+description: A basic snap declaring a plug on a account-control slot
+base: core22
+
+apps:
+  useradd:
+    command: bin/useradd
+    plugs: [account-control]
+  deluser:
+    command: bin/deluser
+    plugs: [account-control]
+  chpasswd:
+    command: bin/chpasswd
+    plugs: [account-control]

--- a/tests/main/interfaces-account-control/task.yaml
+++ b/tests/main/interfaces-account-control/task.yaml
@@ -4,30 +4,43 @@ details: |
     This test makes sure that a snap using the account-control interface
     can handle the user accounts properly.
 
-systems: [ubuntu-core-16-64, ubuntu-core-18-64, ubuntu-core-20-64]
+systems: [ubuntu-core-16-64, ubuntu-core-18-64, ubuntu-core-20-64, ubuntu-core-22-64]
 
 environment:
-    TSNAP/ac: account-control-consumer
-    TSNAP/accore18: account-control-consumer-core18
-    TSNAP/accore20: account-control-consumer-core20
+    TSNAP: account-control-consumer
 
 prepare: |
+    #shellcheck source=tests/lib/core-config.sh
+    . "$TESTSLIB"/core-config.sh
+
     echo "Given a snap declaring a plug on account-control is installed"
-    "$TESTSTOOLS"/snaps-state install-local "$TSNAP"
+    SUFFIX="$(get_test_snap_suffix)"
+    "$TESTSTOOLS"/snaps-state install-local "${TSNAP}${SUFFIX}"
 
     echo "And the account-control plug is connected"
-    snap connect "$TSNAP":account-control
+    snap connect "${TSNAP}${SUFFIX}":account-control
 
 restore: |
+    #shellcheck source=tests/lib/core-config.sh
+    . "$TESTSLIB"/core-config.sh
+    SUFFIX="$(get_test_snap_suffix)"
+
     echo "Ensure alice is gone from the system"
     for f in /var/lib/extrausers/*; do
         sed -i '/^alice:/d' "$f"
     done
-    snap remove --purge "$TSNAP"
+    snap remove --purge "${TSNAP}${SUFFIX}"
 
 execute: |
-    snap run "$TSNAP".useradd --extrausers alice
-    echo alice:password | snap run "$TSNAP".chpasswd
+    #shellcheck source=tests/lib/core-config.sh
+    . "$TESTSLIB"/core-config.sh
+    SUFFIX="$(get_test_snap_suffix)"
+
+    # It is added a user using a snap with the same base than UC
+    # because pam is configured to load a binary module and when
+    # the snap is a different base, UC fails to load the module
+    snap run "${TSNAP}${SUFFIX}".useradd --extrausers alice
+    echo alice:password | snap run "${TSNAP}${SUFFIX}".chpasswd
 
     # User deletion is unsupported yet on Core: https://bugs.launchpad.net/ubuntu/+source/shadow/+bug/1659534
-    # snap run $TSNAP".userdel --extrausers alice
+    # snap run "${TSNAP}${SUFFIX}".userdel --extrausers alice


### PR DESCRIPTION
The test is updated because pam is now configured to load a binary module and when the snap is a different base, UC fails to load the module

Also, uc22 is added to the systems supported.
