### PR TITLE
docs: updates to CONTRIBUTING.md and HACKING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ Before merging any changes into the snapd codebase, we need to verify that the
 proposed functionality and code quality does not degrade the functionality and
 quality requirement we've set for the project.
 
-For each PR, we run checks in three different groups: static, unit and spread:
+For each PR, we run checks in three different groups: static, unit and spread.
 
 Static tests use several code analysis tools present in the GoLang ecosystem
 (go vet, go lint and go fmt) to make sure that the code always aligns with
@@ -90,7 +90,7 @@ The following labels are commonly used:
   documentation changes, either internally (to this repository) or externally.
 - `Needs documentation`: not to be confused with the above. This label needs to
   be added when a PR introduces new features which need to be documented for
-  our users, or if the PR changes the behaviour of an already documented
+  our users, or if the PR changes the behaviour of already documented
   features (though this should almost never happen).
   * Our user-facing documentation can be found here: https://snapcraft.io/docs
   * The PR description must explain any required documentation changes.
@@ -102,7 +102,7 @@ The following labels are commonly used:
   a [draft PR][github-draft] to avoid the risk of other reviewers wasting time
   on something that has not been agreed upon.
 - `Needs Samuele review`: Samuele (@pedronis) is our architect, and this label
-  will summon his attention. Do not use unless you want @pedronis to review
+  will summon his attention. Do not use it unless you want @pedronis to review
   your branch. If making big or deep changes, then ping Samuele in advance. The
   tag will then be added if necessary.
 - `Needs security review`: similar to above, but with a security focus. If your
@@ -122,7 +122,7 @@ The following labels are commonly used:
 Feel free to [rebase][github-rebase], rework commits, and [force
 push][git-force] to your branch while a PR is waiting for its first review.
 
-However, iff you are still making significant changes during this waiting
+However, if you are still making significant changes during this waiting
 phase, it's a good idea to keep the PR as a [draft][github-draft]. This stops
 reviewers from looking at code you may not be confident about. Set the PR as
 "Ready for review" when you do feel confident.
@@ -143,7 +143,7 @@ process, for example. A [force push][git-force] will be required if you do
 this.
 
 Start a [rebase][github-rebase] from the original parent commit of your first
-commit. Ensure you do not  rebase on-top of the current "main" as this means
+commit. Ensure you do not rebase on-top of the current "main" as this means
 changes from the _main_ branch will be shown in the GitHub UI as part of your
 changes, making the verification more confusing.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ which ensures we're building on the solid base of a tested and working system.
 If any tests need to be added for a PR to be merged it will be denoted
 during the review process.
 
-See [Testing](HACKING.md#user-content-testing) for further details on running
+See [Testing](./HACKING.md#user-content-testing) for further details on running
 tests.
 
 ## Pull request guidelines

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,7 +135,7 @@ and submit any requested changes as additional commits. This helps reviewers to
 see exactly what has changed since the last review without requesting them to
 review all the changes.
 
-Two approvals are required for a PR to be merged. A PR can then be merged into the "master" branch.
+Two approvals are required for a PR to be merged. A PR can then be merged into the "main" branch.
 
 On merging, you can rework the branch history as you see fit. Consider
 squashing commits from the original PR with those made during the review
@@ -143,12 +143,12 @@ process, for example. A [force push][git-force] will be required if you do
 this.
 
 Start a [rebase][github-rebase] from the original parent commit of your first
-commit. Ensure you do not  rebase on-top of the current "master" as this means
-changes from the _master_ branch will be shown in the GitHub UI as part of your
+commit. Ensure you do not  rebase on-top of the current "main" as this means
+changes from the _main_ branch will be shown in the GitHub UI as part of your
 changes, making the verification more confusing.
 
 Merging using GitHub's [Rebase and merge][github-rebase-merge] command will
-replay your commits on top of the current master. This ensures a linear git
+replay your commits on top of the current main. This ensures a linear git
 history.
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,8 +21,6 @@ Contributors can help us by observing the following guidelines:
 
 - Commit messages should be well structured.
 - Commit emails should not include non-ASCII characters.
-- PR titles should start with a prefix denoting the scope affected by the changes
-(e.g. `<feature name>`,`<package name>`) followed by a semicolon. 
 - Try to open several smaller PRs, rather than one large PR.
 - Try not to mix potentially controversial and trivial changes together.
   (Proposing trivial changes separately makes landing them easier and 
@@ -30,6 +28,9 @@ Contributors can help us by observing the following guidelines:
 - Try not to [force push][git-force] to a PR after it has received reviews. It is
   acceptable to force push when a PR is ready to merge, however.
 - Try to write tests to cover the contributed changes (see below)
+
+For further details on our coding conventions, including how to format a PR,
+see [CODING.md](CODING.md).
 
 ## Pull requests and tests
 
@@ -39,7 +40,7 @@ quality requirement we've set for the project.
 
 For each PR, we run checks in three different groups: static, unit and spread.
 
-Static tests use several code analysis tools present in the GoLang ecosystem
+Static tests use several code analysis tools present in the golang ecosystem
 (go vet, go lint and go fmt) to make sure that the code always aligns with
 the standards. They also check the markdown format of documentation files.
 
@@ -51,10 +52,14 @@ integrity of the product, exercising it as a whole, both from an end user
 standpoint (eg. all kinds of interactions with the snap tool from the command
 line) and from a more systemic approach (testing upgrades, for instance).
 
-We do not set the addition of spread and unit tests as a requirement for a PR
-to be merged. We do, however, encourage contributors to add them. This helps us
-understand expected behaviour, verified through the tests and review process,
-which ensures we're building on the solid base of a tested and working system.
+Spread and unit tests are not strictly a requirement for a PR to be submitted,
+but we do strongly encourage contributors to include them. We rarely merge code
+without tests although we may occasionally write them ourselves on behalf to
+a contributor.
+
+Unit tests help us understand expected behaviour, verified through the tests
+and review process, which ensures we're building on the solid base of a tested
+and working system.
 
 If any tests need to be added for a PR to be merged it will be denoted
 during the review process.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,7 +114,7 @@ The following labels are commonly used:
   but they're useful to test a PR  against certain operating system traits that
   might otherwise be missed.
 - `Skip spread`: instructs our CI system to not run any spread tests. Only unit
-  tests will be executed. Use this only when a PR changes code in the unit tests.
+  tests will be executed. Use this when a PR only changes code in the unit tests.
   Do not use this flag if any production code changes.
 
 ### Pull request updates
@@ -135,7 +135,7 @@ and submit any requested changes as additional commits. This helps reviewers to
 see exactly what has changed since the last review without requesting them to
 review all the changes.
 
-Two approvals are required for a PR to be merged. A PR can then be merged into the "main" branch.
+Two approvals are required for a PR to be merged. A PR can then be merged into the main branch.
 
 On merging, you can rework the branch history as you see fit. Consider
 squashing commits from the original PR with those made during the review
@@ -143,7 +143,7 @@ process, for example. A [force push][git-force] will be required if you do
 this.
 
 Start a [rebase][github-rebase] from the original parent commit of your first
-commit. Ensure you do not rebase on-top of the current "main" as this means
+commit. Ensure you do not rebase on top of the current main as this means
 changes from the _main_ branch will be shown in the GitHub UI as part of your
 changes, making the verification more confusing.
 
@@ -154,7 +154,7 @@ history.
 
 [1]: http://www.ubuntu.com/legal/contributors
 [pull-request]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork
-[fork]: https://git-scm.com/docs/git-bisect
+[fork]: https://docs.github.com/en/get-started/quickstart/fork-a-repo#forking-a-repository
 [github-pr]: https://docs.github.com/en/github/collaborating-with-pull-requests
 [pr-gist]: https://gist.github.com/Chaser324/ce0505fbed06b947d962
 [linear-git]: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#require-linear-history

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ line) and from a more systemic approach (testing upgrades, for instance).
 
 Spread and unit tests are not strictly a requirement for a PR to be submitted,
 but we do strongly encourage contributors to include them. We rarely merge code
-without tests although we may occasionally write them ourselves on behalf to
+without tests although we may occasionally write them ourselves on behalf of
 a contributor.
 
 Unit tests help us understand expected behaviour, verified through the tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,27 +1,167 @@
-Before contributing you should sign [Canonical's contributor agreement][1],
-it’s the easiest way for you to give us permission to use your contributions.
+# Contributing to snapd
 
-## Pull Requests and tests
+We are an open source project and welcome community contributions, suggestions,
+fixes and constructive feedback.
 
-We need to verify that the code functionality and quality is not degraded
-by additions before merging any changes to snapd's codebase. For each PR
-we run checks in three different groups: static, unit and spread.
+If you'd like to contribute, you will first need to sign the Canonical
+contributor agreement. This is the easiest way for you to give us permission to
+use your contributions. In effect, you’re giving us a licence, but you still
+own the copyright — so you retain the right to modify your code and use it in
+other projects.
 
-Static test use several code analysis tools present in the GoLang ecosystem
+The agreement can be found, and signed, here:
+https://ubuntu.com/legal/contributors
+
+If you have any questions, please reach out to us on our forum:
+https://forum.snapcraft.io/c/snapd/5
+
+## Contributor guidelines
+
+Contributors can help us by observing the following guidelines:
+
+- Commit messages should be well structured.
+- Commit emails should not include non-ASCII characters.
+- PR titles should start with a prefix denoting the scope affected by the changes
+(e.g. `<feature name>`,`<package name>`) followed by a semicolon. 
+- Try to open several smaller PRs, rather than one large PR.
+- Try not to mix potentially controversial and trivial changes together.
+  (Proposing trivial changes separately makes landing them easier and 
+  makes reviewing controversial changes simpler)
+- Try not to [force push][git-force] to a PR after it has received reviews. It is
+  acceptable to force push when a PR is ready to merge, however.
+- Try to write tests to cover the contributed changes (see below)
+
+## Pull requests and tests
+
+Before merging any changes into the snapd codebase, we need to verify that the
+proposed functionality and code quality does not degrade the functionality and
+quality requirement we've set for the project.
+
+For each PR, we run checks in three different groups: static, unit and spread:
+
+Static tests use several code analysis tools present in the GoLang ecosystem
 (go vet, go lint and go fmt) to make sure that the code always aligns with
 the standards. They also check the markdown format of documentation files.
-All the existing unit tests are also executed, and the coverage info is
-reported to coveralls. Regarding [spread](https://github.com/snapcore/spread),
-we use it to verify the integrity of the product exercising it as a whole,
-both from an end user standpoint (eg. all kind of interactions with the
-snap tool from the command line) and from a more systemic approach (testing
-upgrades, for instance).
 
-We do not set as a requirement the addition of spread and unit tests for a PR
-to be merged, but encourage the contributors to add them so that the expected
-behaviour is explained and verified through the tests and the review process
-can be made on the solid base of a working system after the addition of the
-changes. If any tests need to be added for a PR to be merged it will be denoted
+All the existing unit tests are also executed, and the coverage info is
+reported to coveralls.
+
+We use [spread](https://github.com/snapcore/spread) to verify the
+integrity of the product, exercising it as a whole, both from an end user
+standpoint (eg. all kinds of interactions with the snap tool from the command
+line) and from a more systemic approach (testing upgrades, for instance).
+
+We do not set the addition of spread and unit tests as a requirement for a PR
+to be merged. We do, however, encourage contributors to add them. This helps us
+understand expected behaviour, verified through the tests and review process,
+which ensures we're building on the solid base of a tested and working system.
+
+If any tests need to be added for a PR to be merged it will be denoted
 during the review process.
 
+See [Testing](HACKING.md#user-content-testing) for further details on running
+tests.
+
+## Pull request guidelines
+
+Contributions are submitted through a [pull request][pull-request] created from
+a [fork][fork] of the `snapd` repository (under your GitHub account).
+
+GitHub's documentation outlines the [process][github-pr], but for a more
+concise and informative version try [this GitHub gist][pr-gist]. 
+
+### Linear git history
+
+We strive to keep a [linear git history][linear-git]. This makes it easier to
+inspect the history, keep related commits next to each other, and make tools
+like [git bisect][git-bisect] work intuitively.
+
+### Labels
+
+We add [GitHub labels][github-labels] to a PR for both organisational purposes
+and to alter specific CI behaviour.
+
+The following labels are commonly used:
+
+- `Simple 🙂`: informs potential reviewers the PR can be reviewed quickly.
+- `Test robustness`: either fixes tests, adds tests, or otherwise improves our
+  test suite.
+- `Documentation`: is used to denote a PR that requires typically small
+  documentation changes, either internally (to this repository) or externally.
+- `Needs documentation`: not to be confused with the above. This label needs to
+  be added when a PR introduces new features which need to be documented for
+  our users, or if the PR changes the behaviour of an already documented
+  features (though this should almost never happen).
+  * Our user-facing documentation can be found here: https://snapcraft.io/docs
+  * The PR description must explain any required documentation changes.
+  * For internal documentation in this repository, it's expected that 
+    documentation changes are delivered in the same branch.
+    Please don't abuse this tag.
+- `need-architecture-review`: is added to request a quick high-level green
+  light about a chosen approach before continuing the implementation. Also, use
+  a [draft PR][github-draft] to avoid the risk of other reviewers wasting time
+  on something that has not been agreed upon.
+- `Needs Samuele review`: Samuele (@pedronis) is our architect, and this label
+  will summon his attention. Do not use unless you want @pedronis to review
+  your branch. If making big or deep changes, then ping Samuele in advance. The
+  tag will then be added if necessary.
+- `Needs security review`: similar to above, but with a security focus. If your
+  changes touch code in snap-confine or code related to AppArmor, Seccomp,
+  Cgroup management, then someone from the security team will be alerted and
+  will review your code.
+- `Run nested`: instructs our CI system to run our container-based
+  [nested tests][nested-tests]. These tests are usually skipped to save time,
+  but they're useful to test a PR  against certain operating system traits that
+  might otherwise be missed.
+- `Skip spread`: instructs our CI system to not run any spread tests. Only unit
+  tests will be executed. Use this only when a PR changes code in the unit tests.
+  Do not use this flag if any production code changes.
+
+### Pull request updates
+
+Feel free to [rebase][github-rebase], rework commits, and [force
+push][git-force] to your branch while a PR is waiting for its first review.
+
+However, iff you are still making significant changes during this waiting
+phase, it's a good idea to keep the PR as a [draft][github-draft]. This stops
+reviewers from looking at code you may not be confident about. Set the PR as
+"Ready for review" when you do feel confident.
+
+During the review process, reviewers will point out defects or suggest
+alternative implementations.
+
+After the first review, please treat your already pushed commits as immutable
+and submit any requested changes as additional commits. This helps reviewers to
+see exactly what has changed since the last review without requesting them to
+review all the changes.
+
+Two approvals are required for a PR to be merged. A PR can then be merged into the "master" branch.
+
+On merging, you can rework the branch history as you see fit. Consider
+squashing commits from the original PR with those made during the review
+process, for example. A [force push][git-force] will be required if you do
+this.
+
+Start a [rebase][github-rebase] from the original parent commit of your first
+commit. Ensure you do not  rebase on-top of the current "master" as this means
+changes from the _master_ branch will be shown in the GitHub UI as part of your
+changes, making the verification more confusing.
+
+Merging using GitHub's [Rebase and merge][github-rebase-merge] command will
+replay your commits on top of the current master. This ensures a linear git
+history.
+
+
 [1]: http://www.ubuntu.com/legal/contributors
+[pull-request]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork
+[fork]: https://git-scm.com/docs/git-bisect
+[github-pr]: https://docs.github.com/en/github/collaborating-with-pull-requests
+[pr-gist]: https://gist.github.com/Chaser324/ce0505fbed06b947d962
+[linear-git]: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#require-linear-history
+[git-bisect]: https://git-scm.com/docs/git-bisect
+[github-draft]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests 
+[github-labels]: https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels
+[nested-tests]: https://github.com/snapcore/snapd/tree/master/tests/nested
+[github-rebase]: https://docs.github.com/en/get-started/using-git/about-git-rebase
+[git-force]: https://git-scm.com/docs/git-push#Documentation/git-push.txt---force
+[github-rebase-merge]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#rebase-and-merge-your-commits

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ like [git bisect][git-bisect] work intuitively.
 ### Labels
 
 We add [GitHub labels][github-labels] to a PR for both organisational purposes
-and to alter specific CI behaviour.
+and to alter specific CI behaviour. Only project maintainers can add labels.
 
 The following labels are commonly used:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ which ensures we're building on the solid base of a tested and working system.
 If any tests need to be added for a PR to be merged it will be denoted
 during the review process.
 
-See [Testing](./HACKING.md#user-content-testing) for further details on running
+See [Testing](HACKING.md#user-content-testing) for further details on running
 tests.
 
 ## Pull request guidelines

--- a/HACKING.md
+++ b/HACKING.md
@@ -4,6 +4,9 @@ Hacking on `snapd` is fun and straightforward. The code is extensively unit
 tested and we use the [spread](https://github.com/snapcore/spread)
 integration test framework for the integration/system level tests.
 
+For non-technical details on contributing to the project, including how to
+approach a pull request, see [Contributing to snapd](./CONTRIBUTING.md).
+
 ## Setting up
 
 ### Supported Ubuntu distributions
@@ -33,7 +36,7 @@ directory.
     cd snapd
 
 This will allow you to build and test `snapd`. If you wish to contribute to
-the `snapd` project, please see the [Contributing section](#contributing).
+the `snapd` project, please see [Contributing to snapd](./CONTRIBUTING.md).
 
 > For more details about source-code structure of `snapd` please read about
 [Managing module source](https://go.dev/doc/modules/managing-source) in Go.
@@ -283,49 +286,6 @@ File Attributes
   Tag_CPU_arch: v7
   Tag_FP_arch: VFPv3-D16
 ```
-
-## Contributing
-
-Contributions are always welcome!
-
-Please make sure that you sign the Canonical contributor agreement [here](
-http://www.ubuntu.com/legal/contributors).
-
-Complete requirements can be found in [CONTRIBUTING.md](./CONTRIBUTING.md).
-
-### Guidelines for contributors
-
-There are few guidelines that contributors should follow:
-
-- Commit messages should be well structured.
-- Commit emails should not have non-ASCII characters.  
-- PR title should start with a prefix denoting the scope affected by the changes
-(e.g. `<feature name>`,`<package name>`) followed by a semicolon.    
-- Try to open several smaller PRs, rather than one large PR.
-- Try not to mix controversial and trivial changes together.  
-  (_Proposing trivial changes separately makes landing them easier and 
-  makes reviewing the controversial changes simpler_)
-- Try not to force push to PRs after they have gotten reviews.
-- Try to write tests to cover the contributed changes.
-- Write idiomatic Go (refer to [Effective Go](https://go.dev/doc/effective_go) etc).
-- Exported names should have documentation comments.
-- [CODING.md](CODING.md) contains a more extensive checklist of points
-  to take into account when coding or reviewing code for the project.
-
->If you need any help with any of these guidelines, please reach out to the team.
-
-### Creating Pull Requests
-
-Contributions are submitted through a 
-[Pull Request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork) 
-created from a 
-[fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo#forking-a-repository) 
-of the `snapd` repository (under your GitHub account).
-
->This complete process is outlined in details in the [GitHub documentation](
-https://docs.github.com/en/github/collaborating-with-pull-requests). 
-However, for a more concise and yet very informative version try 
-[this GitHub gist](https://gist.github.com/Chaser324/ce0505fbed06b947d962). 
 
 ## Testing
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -345,7 +345,7 @@ To run the various tests that we have to ensure a high quality source just run:
     ./run-checks
 
 This will check if the source format is consistent, that it builds, all tests
-work as expected and that "go vet" has nothing to complain.
+work as expected and that "go vet" has nothing to complain about.
 
 The source format follows the `gofmt -s` formating. Please run this on your 
 source files if `run-checks` complains about the format.
@@ -401,7 +401,7 @@ Assuming you are building on Ubuntu 18.04 LTS ([Bionic Beaver](https://releases.
     $ autopkgtest-buildvm-ubuntu-cloud -r <release-short-name>
     $ mv autopkgtest-<release-short-name>-amd64.img ubuntu-<release-version>-64.img  
 
-For the correct values of `<release-short-name>` and `<release-version>`, pleaser refer
+For the correct values of `<release-short-name>` and `<release-version>`, please refer
 to the official list of [Ubuntu releases](https://wiki.ubuntu.com/Releases). 
 
 > `<release-short-name>` is the first word in the release's full name, 
@@ -477,10 +477,11 @@ the testing one. Don't forget to roll back to the original, after you finish tes
 
 Nested tests are used to validate features that cannot be tested with the regular tests.
 
-The nested test suites work different from the other test suites in snapd. In this case each test runs in a new image
-which is created following the rules defined for the test.
+The nested test suites work differently from the other test suites in snapd. In
+this case each test runs in a new image which is created following the rules
+defined for the test.
 
-The nested tests are executed using [spread framework](#downloading-spread-framework). 
+The nested tests are executed using the [spread framework](#downloading-spread-framework). 
 See the following examples using the QEMU and Google backends.
 
 - _QEMU_: `spread qemu-nested:ubuntu-20.04-64:tests/nested/core20/tpm`  
@@ -506,7 +507,7 @@ Nested test suite is composed by the following 4 suites:
 - _manual_: tests on this suite create a non generic image with specific conditions
 
 The nested suites use some environment variables to configure the suite 
-and the tests inside it. The most important ones are described bellow:
+and the tests inside it. The most important ones are described below:
 
 - `NESTED_WORK_DIR`: path to the directory where all the nested assets and images are stored
 - `NESTED_TYPE`: use core for Ubuntu Core nested systems or classic instead.


### PR DESCRIPTION
- integrated @mardy's contribution improvements (with thanks to @mardy)
- renamed tags to labels to avoid confusion with git tags
- to keep the technical focus in HACKING.md, moved the contributing parts to the pre-existing CONTRIBUTING.md
- typo pass