### PR TITLE
tests/lib: uc20 drop unnecessary kernel modules

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -783,7 +783,7 @@ EOF
 
         # Add additional modules required by tests. The list includes modules required for
         # snapd interfaces, ramdisk creation, networking and more.
-        echo "arc4 arp_tables bfq bochs brd bridge br_netfilter cec dm_bio_prison dm_bufio dm_persistent_data dm_snapshot dm_thin_pool drm_kms_helper drm_vram_helper ip6table_filter ip6table_mangle ip6table_nat ip6table_raw ip6_tables ip6table_security iptable_filter iptable_mangle iptable_nat iptable_raw ip_tables iptable_security ip_vs ip_vs_rr ip_vs_sh ip_vs_wrr iscsi_tcp kvm libarc4 libcrc32c libiscsi libiscsi_tcp llc md4 nbd nf_conntrack nf_defrag_ipv4 nf_defrag_ipv6 nls_iso8859_1 overlay pci-stub rc-core scsi_transport_iscsi stp tap target_core_mod veth vhost vhost_iotlb vhost_net vhost_scsi vhost_vsock vmac vmw_vsock_virtio_transport_common vsock xcbc x_tables" | tr ' ' '\n' >> /tmp/mods
+        echo "arc4 arp_tables bfq bochs brd bridge br_netfilter cec dm_bio_prison dm_bufio dm_persistent_data dm_snapshot dm_thin_pool drm_kms_helper drm_vram_helper ip6table_filter ip6table_mangle ip6table_nat ip6table_raw ip6_tables ip6table_security iptable_filter iptable_mangle iptable_nat iptable_raw ip_tables iptable_security ip_vs ip_vs_rr ip_vs_sh ip_vs_wrr iscsi_tcp kvm libarc4 libcrc32c libiscsi libiscsi_tcp llc md4 nbd nf_conntrack nf_defrag_ipv4 nf_defrag_ipv6 nf_tables nft_compat nft_masq nft_chain_nat nf_nat nfnetlink nls_iso8859_1 overlay pci-stub rc-core scsi_transport_iscsi stp tap target_core_mod veth vhost vhost_iotlb vhost_net vhost_scsi vhost_vsock vmac vmw_vsock_virtio_transport_common vsock xcbc x_tables" | tr ' ' '\n' >> /tmp/mods
 
         #shellcheck disable=SC2044
         for m in $(find modules/ -name '*.ko'); do

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -783,7 +783,7 @@ EOF
 
         # Add additional modules required by tests. Module brd provides /dev/ram*
         # used to create ramdisks and the others are used by interfaces.
-        echo "brd br_netfilter bridge stp llc ip6table_filter iptable_filter ip_tables ip6_tables x_tables arp_tables veth ip_vs_rr ip_vs_sh ip_vs_wrr ip_vs nf_conntrack nf_defrag_ipv4 nf_defrag_ipv6 libcrc32c overlay xcbc arc4 libarc4 bfq md4 kvm vmac dm_snapshot dm_bufio dm_thin_pool dm_persistent_data dm_bio_prison iscsi_tcp libiscsi_tcp libiscsi scsi_transport_iscsi nbd pci_stub target_core_mod vhost vhost_net vhost_scsi vhost_vsock vmw_vsock_virtio_transport_common vhost_iotlb vsock tap rc-core cec drm_kms_helper drm_vram_helper nls_iso8859_1 bochs" | tr ' ' '\n' >> /tmp/mods
+        echo "brd br_netfilter bridge stp llc ip6table_filter iptable_filter ip_tables ip6_tables x_tables arp_tables veth ip_vs_rr ip_vs_sh ip_vs_wrr ip_vs nf_conntrack nf_defrag_ipv4 nf_defrag_ipv6 libcrc32c overlay xcbc arc4 libarc4 bfq md4 kvm vmac dm_snapshot dm_bufio dm_thin_pool dm_persistent_data dm_bio_prison iscsi_tcp libiscsi_tcp libiscsi scsi_transport_iscsi nbd pci-stub target_core_mod vhost vhost_net vhost_scsi vhost_vsock vmw_vsock_virtio_transport_common vhost_iotlb vsock tap rc-core cec drm_kms_helper drm_vram_helper nls_iso8859_1 bochs ip6_gre ip6_vti ip6_tunnel ip6_udp_tunnel ip6table_mangle ip6table_raw ip6table_security ip6table_nat iptable_mangle iptable_raw iptable_nat iptable_security ip_tunnel ip_vti tcp_yeah nf_tables nf_tables_set arptable_filter vkms hv_sock virtio-gpu pci-pf-stub virtio_net ipvlan" | tr ' ' '\n' >> /tmp/mods
 
         #shellcheck disable=SC2044
         for m in $(find modules/ -name '*.ko'); do

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -789,7 +789,8 @@ EOF
         for m in $(find modules/ -name '*.ko'); do
             noko=$(basename "$m"); noko="${noko%.ko}"
             if echo "$noko" | grep -f /tmp/mods -vq; then
-                rm -f "$m"
+                #echo "$m" >> /tmp/dropped_mods
+                #rm -f "$m"
             fi
         done
 

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -780,10 +780,12 @@ EOF
 
         # Get list of loaded modules from current host
         awk '{print $1}' < /proc/modules | sort > /tmp/mods
+	echo ">>> LIST OF HOST MODULES:"
+	cat /tmp/mods
 
         # Add additional modules required by tests. The list includes modules required for
         # snapd interfaces, ramdisk creation, networking and more.
-        echo "arc4 arp_tables bfq bochs brd bridge br_netfilter cec dm_bio_prison dm_bufio dm_persistent_data dm_snapshot dm_thin_pool drm_kms_helper drm_vram_helper ip6table_filter ip6table_mangle ip6table_nat ip6table_raw ip6_tables ip6table_security iptable_filter iptable_mangle iptable_nat iptable_raw ip_tables iptable_security ip_vs ip_vs_rr ip_vs_sh ip_vs_wrr iscsi_tcp kvm libarc4 libcrc32c libiscsi libiscsi_tcp llc md4 nbd nf_conntrack nf_defrag_ipv4 nf_defrag_ipv6 nf_tables nft_compat nft_masq nft_chain_nat nf_nat nfnetlink nls_iso8859_1 overlay pci-stub rc-core scsi_transport_iscsi stp tap target_core_mod veth vhost vhost_iotlb vhost_net vhost_scsi vhost_vsock vmac vmw_vsock_virtio_transport_common vsock xcbc x_tables" | tr ' ' '\n' >> /tmp/mods
+        # echo "arc4 arp_tables bfq bochs brd bridge br_netfilter cec dm_bio_prison dm_bufio dm_persistent_data dm_snapshot dm_thin_pool drm_kms_helper drm_vram_helper ip6table_filter ip6table_mangle ip6table_nat ip6table_raw ip6_tables ip6table_security iptable_filter iptable_mangle iptable_nat iptable_raw ip_tables iptable_security ip_vs ip_vs_rr ip_vs_sh ip_vs_wrr iscsi_tcp kvm libarc4 libcrc32c libiscsi libiscsi_tcp llc md4 nbd nf_conntrack nf_defrag_ipv4 nf_defrag_ipv6 nf_tables nft_compat nft_masq nft_chain_nat nf_nat nfnetlink nls_iso8859_1 overlay pci-stub rc-core scsi_transport_iscsi stp tap target_core_mod veth vhost vhost_iotlb vhost_net vhost_scsi vhost_vsock vmac vmw_vsock_virtio_transport_common vsock xcbc x_tables" | tr ' ' '\n' >> /tmp/mods
 
         #shellcheck disable=SC2044
         for m in $(find modules/ -name '*.ko'); do

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -789,7 +789,7 @@ EOF
         for m in $(find modules/ -name '*.ko'); do
             noko=$(basename "$m"); noko="${noko%.ko}"
             if echo "$noko" | grep -f /tmp/mods -vq; then
-                #echo "$m" >> /tmp/dropped_mods
+                echo "$m" >> /tmp/dropped_mods
                 #rm -f "$m"
             fi
         done

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -781,16 +781,15 @@ EOF
         # Get list of loaded modules from current host
         awk '{print $1}' < /proc/modules | sort > /tmp/mods
 
-        # Add additional modules required by tests. Module brd provides /dev/ram*
-        # used to create ramdisks and the others are used by interfaces.
-        echo "brd br_netfilter bridge stp llc ip6table_filter iptable_filter ip_tables ip6_tables x_tables arp_tables veth ip_vs_rr ip_vs_sh ip_vs_wrr ip_vs nf_conntrack nf_defrag_ipv4 nf_defrag_ipv6 libcrc32c overlay xcbc arc4 libarc4 bfq md4 kvm vmac dm_snapshot dm_bufio dm_thin_pool dm_persistent_data dm_bio_prison iscsi_tcp libiscsi_tcp libiscsi scsi_transport_iscsi nbd pci-stub target_core_mod vhost vhost_net vhost_scsi vhost_vsock vmw_vsock_virtio_transport_common vhost_iotlb vsock tap rc-core cec drm_kms_helper drm_vram_helper nls_iso8859_1 bochs ip6_gre ip6_vti ip6_tunnel ip6_udp_tunnel ip6table_mangle ip6table_raw ip6table_security ip6table_nat iptable_mangle iptable_raw iptable_nat iptable_security ip_tunnel ip_vti tcp_yeah nf_tables nf_tables_set arptable_filter vkms hv_sock virtio-gpu pci-pf-stub virtio_net ipvlan" | tr ' ' '\n' >> /tmp/mods
+        # Add additional modules required by tests. The list includes modules required for
+        # snapd interfaces, ramdisk creation, networking and more.
+        echo "arc4 arp_tables bfq bochs brd bridge br_netfilter cec dm_bio_prison dm_bufio dm_persistent_data dm_snapshot dm_thin_pool drm_kms_helper drm_vram_helper ip6table_filter ip6table_mangle ip6table_nat ip6table_raw ip6_tables ip6table_security iptable_filter iptable_mangle iptable_nat iptable_raw ip_tables iptable_security ip_vs ip_vs_rr ip_vs_sh ip_vs_wrr iscsi_tcp kvm libarc4 libcrc32c libiscsi libiscsi_tcp llc md4 nbd nf_conntrack nf_defrag_ipv4 nf_defrag_ipv6 nls_iso8859_1 overlay pci-stub rc-core scsi_transport_iscsi stp tap target_core_mod veth vhost vhost_iotlb vhost_net vhost_scsi vhost_vsock vmac vmw_vsock_virtio_transport_common vsock xcbc x_tables" | tr ' ' '\n' >> /tmp/mods
 
         #shellcheck disable=SC2044
         for m in $(find modules/ -name '*.ko'); do
             noko=$(basename "$m"); noko="${noko%.ko}"
             if echo "$noko" | grep -f /tmp/mods -vq; then
-                echo "$m" >> /tmp/dropped_mods
-                #rm -f "$m"
+                rm -f "$m"
             fi
         done
 

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -789,7 +789,8 @@ EOF
         for m in $(find modules/ -name '*.ko'); do
             noko=$(basename "$m"); noko="${noko%.ko}"
             if echo "$noko" | grep -f /tmp/mods -vq; then
-                rm -f "$m"
+                #rm -f "$m"
+		:
             fi
         done
 

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -780,8 +780,15 @@ EOF
 
         # Get list of loaded modules from current host
         awk '{print $1}' < /proc/modules | sort > /tmp/mods
-	echo ">>> LIST OF HOST MODULES:"
-	cat /tmp/mods
+        echo ">>> LIST OF HOST MODULES:"
+        cat /tmp/mods
+
+        # Trigger error
+        MUST_EXIT="YES"
+        if [ "$MUST_EXIT" = "YES" ]; then
+            echo "Faking error..."
+            exit 1
+        fi
 
         # Add additional modules required by tests. The list includes modules required for
         # snapd interfaces, ramdisk creation, networking and more.

--- a/tests/main/interfaces-firewall-control/task.yaml
+++ b/tests/main/interfaces-firewall-control/task.yaml
@@ -44,6 +44,11 @@ restore: |
     fi
     rm -f "$REQUEST_FILE"
 
+debug: |
+    echo ">>> Dumping used modules:"
+    awk '{print $1}' < /proc/modules | sort > /tmp/mods
+    cat /tmp/mods
+
 execute: |
     echo "Then the plug is disconnected by default"
     snap interfaces -i firewall-control | MATCH '^- +firewall-control-consumer:firewall-control'
@@ -56,6 +61,13 @@ execute: |
 
     echo "Then the service listening on localhost is accessible through the destination IP in the rule"
     nc -w 2 "$DESTINATION_IP" "$PORT" < "$REQUEST_FILE" | MATCH 'ok$'
+
+    # Trigger error
+    MUST_EXIT="YES"
+    if [ "$MUST_EXIT" = "YES" ]; then
+        echo "Faking error..."
+        exit 1
+    fi
 
     echo "When the snap deletes the firewall rule"
     firewall-control-consumer.delete

--- a/tests/main/interfaces-firewall-control/task.yaml
+++ b/tests/main/interfaces-firewall-control/task.yaml
@@ -63,7 +63,7 @@ execute: |
     nc -w 2 "$DESTINATION_IP" "$PORT" < "$REQUEST_FILE" | MATCH 'ok$'
 
     # Trigger error
-    MUST_EXIT="YES"
+    MUST_EXIT="NO"
     if [ "$MUST_EXIT" = "YES" ]; then
         echo "Faking error..."
         exit 1

--- a/tests/main/microk8s-smoke/task.yaml
+++ b/tests/main/microk8s-smoke/task.yaml
@@ -49,7 +49,19 @@ restore: |
         groupdel "$user" || groupdel --extrausers "$user" || true
     done
 
+debug: |
+    echo ">>> Dumping used modules:"
+    awk '{print $1}' < /proc/modules | sort > /tmp/mods
+    cat /tmp/mods
+
 execute: |
+    # Trigger error
+    MUST_EXIT="YES"
+    if [ "$MUST_EXIT" = "YES" ]; then
+        echo "Faking error..."
+        exit 1
+    fi
+    
     snap install --channel="$CHANNEL" microk8s
     microk8s status --wait-ready
     # XXX: enable dashboard etc? doing this is slow :/

--- a/tests/main/microk8s-smoke/task.yaml
+++ b/tests/main/microk8s-smoke/task.yaml
@@ -56,7 +56,7 @@ debug: |
 
 execute: |
     # Trigger error
-    MUST_EXIT="YES"
+    MUST_EXIT="NO"
     if [ "$MUST_EXIT" = "YES" ]; then
         echo "Faking error..."
         exit 1


### PR DESCRIPTION
Testing confirmed that enabling this code that drops unused kernel modules saves approx 23 min of prepare time.

The basic assumption/principle is that only modules that is loaded by the host is required which is not completely the case, therefore a list of 8 additional modules are specified and loaded before the dropping logic is kicked off. A total of 5424 modules are dropped.


**UPDATE:**
Retrieved definitive list of additional drivers for select tests for UC20 and UC22 (that still failed after fixing basic interface driver needs). See notes [here](https://warthogs.atlassian.net/browse/SNAPDENG-5917?focusedCommentId=256719).

My conclusion is that it will take significant effort to manually find (or create automated way) a definitive generic list of additional drivers that caters for all the potential hosts/kernels (e.g. google and local PCs etc) for the different tests. Failures will not directly point to obvious explicit issue which can affect maintenance negatively. I do not feel the benefit here outweigh the effort and potential pain.