### PR TITLE
overlord: move install helpers

### DIFF
--- a/daemon/api_systems.go
+++ b/daemon/api_systems.go
@@ -29,6 +29,7 @@ import (
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/devicestate"
+	"github.com/snapcore/snapd/overlord/install"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -105,11 +106,11 @@ func getAllSystems(c *Command, r *http.Request, user *auth.UserState) Response {
 }
 
 // wrapped for unit tests
-var deviceManagerSystemAndGadgetAndEncryptionInfo = func(dm *devicestate.DeviceManager, systemLabel string) (*devicestate.System, *gadget.Info, *devicestate.EncryptionSupportInfo, error) {
+var deviceManagerSystemAndGadgetAndEncryptionInfo = func(dm *devicestate.DeviceManager, systemLabel string) (*install.System, *gadget.Info, *install.EncryptionSupportInfo, error) {
 	return dm.SystemAndGadgetAndEncryptionInfo(systemLabel)
 }
 
-func storageEncryption(encInfo *devicestate.EncryptionSupportInfo) *client.StorageEncryption {
+func storageEncryption(encInfo *install.EncryptionSupportInfo) *client.StorageEncryption {
 	if encInfo.Disabled {
 		return &client.StorageEncryption{
 			Support: client.StorageEncryptionSupportDisabled,
@@ -236,7 +237,7 @@ func postSystemActionDo(c *Command, systemLabel string, req *systemActionRequest
 		return BadRequest("system action requires the mode to be provided")
 	}
 
-	sa := devicestate.SystemAction{
+	sa := install.SystemAction{
 		Title: req.Title,
 		Mode:  req.Mode,
 	}

--- a/daemon/api_systems_test.go
+++ b/daemon/api_systems_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/snapcore/snapd/overlord/assertstate/assertstatetest"
 	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/hookstate"
+	"github.com/snapcore/snapd/overlord/install"
 	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
@@ -836,7 +837,7 @@ func (s *systemsSuite) TestSystemsGetSystemDetailsForLabel(c *check.C) {
 			client.StorageEncryptionSupportAvailable, "encrypted", "",
 		},
 	} {
-		mockEncryptionSupportInfo := &devicestate.EncryptionSupportInfo{
+		mockEncryptionSupportInfo := &install.EncryptionSupportInfo{
 			Available:          tc.available,
 			Disabled:           tc.disabled,
 			StorageSafety:      tc.storageSafety,
@@ -844,9 +845,9 @@ func (s *systemsSuite) TestSystemsGetSystemDetailsForLabel(c *check.C) {
 			UnavailableWarning: tc.unavailableWarning,
 		}
 
-		r := daemon.MockDeviceManagerSystemAndGadgetAndEncryptionInfo(func(mgr *devicestate.DeviceManager, label string) (*devicestate.System, *gadget.Info, *devicestate.EncryptionSupportInfo, error) {
+		r := daemon.MockDeviceManagerSystemAndGadgetAndEncryptionInfo(func(mgr *devicestate.DeviceManager, label string) (*install.System, *gadget.Info, *install.EncryptionSupportInfo, error) {
 			c.Check(label, check.Equals, "20191119")
-			sys := &devicestate.System{
+			sys := &install.System{
 				Model: s.seedModelForLabel20191119,
 				Label: "20191119",
 				Brand: s.Brands.Account("my-brand"),
@@ -884,7 +885,7 @@ func (s *systemsSuite) TestSystemsGetSpecificLabelError(c *check.C) {
 	s.daemon(c)
 	s.expectRootAccess()
 
-	r := daemon.MockDeviceManagerSystemAndGadgetAndEncryptionInfo(func(mgr *devicestate.DeviceManager, label string) (*devicestate.System, *gadget.Info, *devicestate.EncryptionSupportInfo, error) {
+	r := daemon.MockDeviceManagerSystemAndGadgetAndEncryptionInfo(func(mgr *devicestate.DeviceManager, label string) (*install.System, *gadget.Info, *install.EncryptionSupportInfo, error) {
 		return nil, nil, nil, fmt.Errorf("boom")
 	})
 	defer r()
@@ -922,7 +923,7 @@ func (s *systemsSuite) TestSystemsGetSpecificLabelIntegration(c *check.C) {
 	restore = s.mockSystemSeeds(c)
 	defer restore()
 
-	r := daemon.MockDeviceManagerSystemAndGadgetAndEncryptionInfo(func(mgr *devicestate.DeviceManager, label string) (*devicestate.System, *gadget.Info, *devicestate.EncryptionSupportInfo, error) {
+	r := daemon.MockDeviceManagerSystemAndGadgetAndEncryptionInfo(func(mgr *devicestate.DeviceManager, label string) (*install.System, *gadget.Info, *install.EncryptionSupportInfo, error) {
 		// mockSystemSeed will ensure everything here is coming from
 		// the mocked seed except the encryptionInfo
 		sys, gadgetInfo, encInfo, err := deviceMgr.SystemAndGadgetAndEncryptionInfo(label)

--- a/daemon/export_api_systems_test.go
+++ b/daemon/export_api_systems_test.go
@@ -22,6 +22,7 @@ package daemon
 import (
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/overlord/devicestate"
+	"github.com/snapcore/snapd/overlord/install"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -38,7 +39,7 @@ type (
 	SystemsResponse = systemsResponse
 )
 
-func MockDeviceManagerSystemAndGadgetAndEncryptionInfo(f func(*devicestate.DeviceManager, string) (*devicestate.System, *gadget.Info, *devicestate.EncryptionSupportInfo, error)) (restore func()) {
+func MockDeviceManagerSystemAndGadgetAndEncryptionInfo(f func(*devicestate.DeviceManager, string) (*install.System, *gadget.Info, *install.EncryptionSupportInfo, error)) (restore func()) {
 	restore = testutil.Backup(&deviceManagerSystemAndGadgetAndEncryptionInfo)
 	deviceManagerSystemAndGadgetAndEncryptionInfo = f
 	return restore

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -1466,7 +1466,11 @@ func (m *DeviceManager) ensureTriedRecoverySystem() error {
 	return nil
 }
 
-var bootMarkFactoryResetComplete = boot.MarkFactoryResetComplete
+var (
+	bootMarkFactoryResetComplete = boot.MarkFactoryResetComplete
+	checkEncryptionType          = installHandler.CheckEncryptionType
+	rotateEncryptionKeys         = installHandler.RotateEncryptionKeys
+)
 
 func (m *DeviceManager) ensurePostFactoryReset() error {
 	m.state.Lock()
@@ -1519,7 +1523,7 @@ func (m *DeviceManager) ensurePostFactoryReset() error {
 	}
 
 	if encrypted {
-		if err := installHandler.RotateEncryptionKeys(); err != nil {
+		if err := rotateEncryptionKeys(); err != nil {
 			return fmt.Errorf("cannot transition encryption keys: %v", err)
 		}
 	}
@@ -2444,5 +2448,5 @@ func (m *DeviceManager) checkEncryption(st *state.State, deviceCtx snapstate.Dev
 		return "", err
 	}
 
-	return installHandler.CheckEncryptionType(model, tpmMode, kernelInfo, gadgetInfo, m.runFDESetupHook)
+	return checkEncryptionType(model, tpmMode, kernelInfo, gadgetInfo, m.runFDESetupHook)
 }

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -46,6 +46,7 @@ import (
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/devicestate/internal"
 	"github.com/snapcore/snapd/overlord/hookstate"
+	installHandler "github.com/snapcore/snapd/overlord/install"
 	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
@@ -144,7 +145,7 @@ func Manager(s *state.State, hookManager *hookstate.HookManager, runner *state.T
 	m.populateStateFromSeed = m.populateStateFromSeedImpl
 
 	if !m.preseed {
-		modeenv, err := maybeReadModeenv()
+		modeenv, err := installHandler.MaybeReadModeenv()
 		if err != nil {
 			return nil, err
 		}
@@ -246,18 +247,10 @@ func newBasicHookStateHandler(context *hookstate.Context) hookstate.Handler {
 	return genericHook{}
 }
 
-func maybeReadModeenv() (*boot.Modeenv, error) {
-	modeenv, err := boot.ReadModeenv("")
-	if err != nil && !os.IsNotExist(err) {
-		return nil, fmt.Errorf("cannot read modeenv: %v", err)
-	}
-	return modeenv, nil
-}
-
 // ReloadModeenv is only useful for integration testing
 func (m *DeviceManager) ReloadModeenv() error {
 	osutil.MustBeTestBinary("ReloadModeenv can only be called from tests")
-	modeenv, err := maybeReadModeenv()
+	modeenv, err := installHandler.MaybeReadModeenv()
 	if err != nil {
 		return err
 	}
@@ -827,7 +820,7 @@ func (m *DeviceManager) seedLabelAndMode() (seedLabel, seedMode string, err erro
 			seedLabel = m.systemForPreseeding()
 		}
 	} else {
-		modeenv, err := maybeReadModeenv()
+		modeenv, err := installHandler.MaybeReadModeenv()
 		if err != nil {
 			return "", "", err
 		}

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -1935,7 +1935,7 @@ var ErrNoSystems = errors.New("no systems seeds")
 func (m *DeviceManager) Systems() ([]*installHandler.System, error) {
 	// it's tough luck when we cannot determine the current system seed
 	systemMode := m.SystemMode(SysAny)
-	currentSys, _ := currentSystemForMode(m.state, systemMode)
+	currentSys, _ := installHandler.CurrentSystemForMode(m.state, systemMode)
 
 	systemLabels, err := filepath.Glob(filepath.Join(dirs.SnapSeedDir, "systems", "*"))
 	if err != nil && !os.IsNotExist(err) {
@@ -1949,7 +1949,7 @@ func (m *DeviceManager) Systems() ([]*installHandler.System, error) {
 	var systems []*installHandler.System
 	for _, fpLabel := range systemLabels {
 		label := filepath.Base(fpLabel)
-		system, err := systemFromSeed(label, currentSys)
+		system, err := installHandler.SystemFromSeed(label, currentSys)
 		if err != nil {
 			// TODO:UC20 add a Broken field to the seed system like
 			// we do for snap.Info
@@ -2009,9 +2009,9 @@ func (m *DeviceManager) loadSystemAndEssentialSnaps(wantedSystemLabel string, ty
 
 	// get current system as input for loadSeedAndSystem()
 	systemMode := m.SystemMode(SysAny)
-	currentSys, _ := currentSystemForMode(m.state, systemMode)
+	currentSys, _ := installHandler.CurrentSystemForMode(m.state, systemMode)
 
-	s, sys, err := loadSeedAndSystem(wantedSystemLabel, currentSys)
+	s, sys, err := installHandler.LoadSeedAndSystem(wantedSystemLabel, currentSys)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -2083,7 +2083,7 @@ func (m *DeviceManager) Reboot(systemLabel, mode string) error {
 	// no systemLabel means "current" so get the current system label
 	if systemLabel == "" {
 		systemMode := m.SystemMode(SysAny)
-		currentSys, err := currentSystemForMode(m.state, systemMode)
+		currentSys, err := installHandler.CurrentSystemForMode(m.state, systemMode)
 		if err != nil {
 			return fmt.Errorf("cannot get current system: %v", err)
 		}
@@ -2132,14 +2132,14 @@ func (m *DeviceManager) switchToSystemAndMode(systemLabel, mode string, sameSyst
 	// make sure that currentSys == nil does not break
 	// the code below!
 	// TODO: should we log the error?
-	currentSys, _ := currentSystemForMode(m.state, systemMode)
+	currentSys, _ := installHandler.CurrentSystemForMode(m.state, systemMode)
 
 	systemSeedDir := filepath.Join(dirs.SnapSeedDir, "systems", systemLabel)
 	if _, err := os.Stat(systemSeedDir); err != nil {
 		// XXX: should we wrap this instead return a naked stat error?
 		return err
 	}
-	system, err := systemFromSeed(systemLabel, currentSys)
+	system, err := installHandler.SystemFromSeed(systemLabel, currentSys)
 	if err != nil {
 		return fmt.Errorf("cannot load seed system: %v", err)
 	}

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -1509,7 +1509,7 @@ func (m *DeviceManager) ensurePostFactoryReset() error {
 	}
 
 	// verify the marker
-	if err := verifyFactoryResetMarkerInRun(factoryResetMarker, encrypted); err != nil {
+	if err := installHandler.VerifyFactoryResetMarkerInRun(factoryResetMarker, encrypted); err != nil {
 		return fmt.Errorf("cannot verify factory reset marker: %v", err)
 	}
 
@@ -1519,7 +1519,7 @@ func (m *DeviceManager) ensurePostFactoryReset() error {
 	}
 
 	if encrypted {
-		if err := rotateEncryptionKeys(); err != nil {
+		if err := installHandler.RotateEncryptionKeys(); err != nil {
 			return fmt.Errorf("cannot transition encryption keys: %v", err)
 		}
 	}
@@ -1914,7 +1914,7 @@ func (m *DeviceManager) Systems() ([]*installHandler.System, error) {
 // SystemAndGadgetAndEncryptionInfo return the system details
 // including the model assertion, gadget details and encryption info
 // for the given system label.
-func (m *DeviceManager) SystemAndGadgetAndEncryptionInfo(wantedSystemLabel string) (*installHandler.System, *gadget.Info, *EncryptionSupportInfo, error) {
+func (m *DeviceManager) SystemAndGadgetAndEncryptionInfo(wantedSystemLabel string) (*installHandler.System, *gadget.Info, *installHandler.EncryptionSupportInfo, error) {
 	// TODO check that the system is not a classic boot one when the
 	// installer is not anymore.
 
@@ -1935,7 +1935,7 @@ func (m *DeviceManager) SystemAndGadgetAndEncryptionInfo(wantedSystemLabel strin
 	}
 
 	// Encryption details
-	encInfo, err := m.encryptionSupportInfo(sys.Model, secboot.TPMProvisionFull, snapInfos[snap.TypeKernel], gadgetInfo)
+	encInfo, err := installHandler.GetEncryptionSupportInfo(sys.Model, secboot.TPMProvisionFull, snapInfos[snap.TypeKernel], gadgetInfo, m.runFDESetupHook)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -2241,7 +2241,7 @@ func (m *DeviceManager) hasFDESetupHook(kernelInfo *snap.Info) (bool, error) {
 			return false, fmt.Errorf("cannot get kernel info: %v", err)
 		}
 	}
-	return hasFDESetupHookInKernel(kernelInfo), nil
+	return installHandler.HasFDESetupHookInKernel(kernelInfo), nil
 }
 
 func (m *DeviceManager) runFDESetupHook(req *fde.SetupRequest) ([]byte, error) {
@@ -2286,33 +2286,6 @@ func (m *DeviceManager) runFDESetupHook(req *fde.SetupRequest) ([]byte, error) {
 		return nil, fmt.Errorf("cannot get result from fde-setup hook %q: %v", req.Op, err)
 	}
 	return hookOutput, nil
-}
-
-func (m *DeviceManager) checkFDEFeatures() (et secboot.EncryptionType, err error) {
-	// Run fde-setup hook with "op":"features". If the hook
-	// returns any {"features":[...]} reply we consider the
-	// hardware supported. If the hook errors or if it returns
-	// {"error":"hardware-unsupported"} we don't.
-	features, err := fde.CheckFeatures(m.runFDESetupHook)
-	if err != nil {
-		return et, err
-	}
-	switch {
-	case strutil.ListContains(features, "inline-crypto-engine"):
-		et = secboot.EncryptionTypeLUKSWithICE
-		// TODO:ICE: remove this
-	case strutil.ListContains(features, "device-setup"):
-		et = secboot.EncryptionTypeDeviceSetupHook
-	default:
-		et = secboot.EncryptionTypeLUKS
-	}
-
-	return et, nil
-}
-
-func hasFDESetupHookInKernel(kernelInfo *snap.Info) bool {
-	_, ok := kernelInfo.Hooks["fde-setup"]
-	return ok
 }
 
 type fdeSetupHandler struct {
@@ -2452,36 +2425,6 @@ func (m *DeviceManager) RemoveRecoveryKeys() error {
 	return secbootRemoveRecoveryKeys(recoveryKeyDevices)
 }
 
-// EncryptionSupportInfo describes what encryption is available and needed
-// for the current device.
-type EncryptionSupportInfo struct {
-	// Disabled is set if to true encryption was forcefully
-	// disabled (e.g. via the seed partition), if set the rest
-	// of the struct content is not relevant.
-	Disabled bool
-
-	// StorageSafety describes the level safety properties
-	// requested by the model
-	StorageSafety asserts.StorageSafety
-	// Available is set to true if encryption is available on this device
-	// with the used gadget.
-	Available bool
-
-	// Type is set to the EncryptionType that can be used if
-	// Available is true.
-	Type secboot.EncryptionType
-
-	// UnvailableErr is set if the encryption support availability of
-	// the this device and used gadget do not match the
-	// storage safety requirements.
-	UnavailableErr error
-	// UnavailbleWarning describes why encryption support is not
-	// available in case it is optional.
-	UnavailableWarning string
-}
-
-var secbootCheckTPMKeySealingSupported = secboot.CheckTPMKeySealingSupported
-
 // checkEncryption verifies whether encryption should be used based on the
 // model grade and the availability of a TPM device or a fde-setup hook
 // in the kernel.
@@ -2501,88 +2444,5 @@ func (m *DeviceManager) checkEncryption(st *state.State, deviceCtx snapstate.Dev
 		return "", err
 	}
 
-	res, err := m.encryptionSupportInfo(model, tpmMode, kernelInfo, gadgetInfo)
-	if err != nil {
-		return "", err
-	}
-	if res.UnavailableWarning != "" {
-		logger.Noticef("%s", res.UnavailableWarning)
-	}
-	// encryption disabled or preferred unencrypted: follow the model preferences here even if encryption would be available
-	if res.Disabled || res.StorageSafety == asserts.StorageSafetyPreferUnencrypted {
-		res.Type = secboot.EncryptionTypeNone
-	}
-
-	return res.Type, res.UnavailableErr
-}
-
-func (m *DeviceManager) encryptionSupportInfo(model *asserts.Model, tpmMode secboot.TPMProvisionMode, kernelInfo *snap.Info, gadgetInfo *gadget.Info) (EncryptionSupportInfo, error) {
-	secured := model.Grade() == asserts.ModelSecured
-	dangerous := model.Grade() == asserts.ModelDangerous
-	encrypted := model.StorageSafety() == asserts.StorageSafetyEncrypted
-
-	res := EncryptionSupportInfo{
-		StorageSafety: model.StorageSafety(),
-	}
-
-	// check if we should disable encryption non-secured devices
-	// TODO:UC20: this is not the final mechanism to bypass encryption
-	if dangerous && osutil.FileExists(filepath.Join(boot.InitramfsUbuntuSeedDir, ".force-unencrypted")) {
-		res.Disabled = true
-		return res, nil
-	}
-
-	// check encryption: this can either be provided by the fde-setup
-	// hook mechanism or by the built-in secboot based encryption
-	checkFDESetupHookEncryption := hasFDESetupHookInKernel(kernelInfo)
-	// Note that having a fde-setup hook will disable the internal
-	// secboot based encryption
-	checkSecbootEncryption := !checkFDESetupHookEncryption
-	var checkEncryptionErr error
-	switch {
-	case checkFDESetupHookEncryption:
-		res.Type, checkEncryptionErr = m.checkFDEFeatures()
-	case checkSecbootEncryption:
-		checkEncryptionErr = secbootCheckTPMKeySealingSupported(tpmMode)
-		if checkEncryptionErr == nil {
-			res.Type = secboot.EncryptionTypeLUKS
-		}
-	default:
-		return res, fmt.Errorf("internal error: no encryption checked in encryptionSupportInfo")
-	}
-	res.Available = (checkEncryptionErr == nil)
-
-	if checkEncryptionErr != nil {
-		switch {
-		case secured:
-			res.UnavailableErr = fmt.Errorf("cannot encrypt device storage as mandated by model grade secured: %v", checkEncryptionErr)
-		case encrypted:
-			res.UnavailableErr = fmt.Errorf("cannot encrypt device storage as mandated by encrypted storage-safety model option: %v", checkEncryptionErr)
-		case checkFDESetupHookEncryption:
-			res.UnavailableWarning = fmt.Sprintf("not encrypting device storage as querying kernel fde-setup hook did not succeed: %v", checkEncryptionErr)
-		case checkSecbootEncryption:
-			res.UnavailableWarning = fmt.Sprintf("not encrypting device storage as checking TPM gave: %v", checkEncryptionErr)
-		default:
-			return res, fmt.Errorf("internal error: checkEncryptionErr is set but not handled by the code")
-		}
-	}
-
-	// If encryption is available check if the gadget is
-	// compatible with encryption.
-	if res.Available {
-		opts := &gadget.ValidationConstraints{
-			EncryptedData: true,
-		}
-		if err := gadget.Validate(gadgetInfo, model, opts); err != nil {
-			if secured || encrypted {
-				res.UnavailableErr = fmt.Errorf("cannot use encryption with the gadget: %v", err)
-			} else {
-				res.UnavailableWarning = fmt.Sprintf("cannot use encryption with the gadget, disabling encryption: %v", err)
-			}
-			res.Available = false
-			res.Type = secboot.EncryptionTypeNone
-		}
-	}
-
-	return res, nil
+	return installHandler.CheckEncryptionType(model, tpmMode, kernelInfo, gadgetInfo, m.runFDESetupHook)
 }

--- a/overlord/devicestate/firstboot.go
+++ b/overlord/devicestate/firstboot.go
@@ -31,6 +31,7 @@ import (
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/devicestate/internal"
+	"github.com/snapcore/snapd/overlord/install"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
@@ -319,7 +320,7 @@ func (m *DeviceManager) populateStateFromSeedImpl(tm timings.Measurer) ([]*state
 		endTs.AddTask(preseedDoneTask)
 		markSeeded.WaitFor(preseedDoneTask)
 	}
-	whatSeeds := &seededSystem{
+	whatSeeds := &install.SeededSystem{
 		System:    sysLabel,
 		Model:     model.Model(),
 		BrandID:   model.BrandID(),

--- a/overlord/devicestate/handlers.go
+++ b/overlord/devicestate/handlers.go
@@ -154,7 +154,7 @@ func (m *DeviceManager) doMarkSeeded(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	if deviceCtx.HasModeenv() && deviceCtx.RunMode() {
-		modeEnv, err := maybeReadModeenv()
+		modeEnv, err := install.MaybeReadModeenv()
 		if err != nil {
 			return err
 		}

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -1261,7 +1261,7 @@ func mountSeedSnap(seedSn *seed.Snap) (mountpoint string, unmount func() error, 
 }
 
 func (m *DeviceManager) loadAndMountSystemLabelSnaps(systemLabel string) (
-	*System, map[snap.Type]*snap.Info, map[snap.Type]*seed.Snap, map[snap.Type]string, func(), error) {
+	*installHandler.System, map[snap.Type]*snap.Info, map[snap.Type]*seed.Snap, map[snap.Type]string, func(), error) {
 
 	essentialTypes := []snap.Type{snap.TypeKernel, snap.TypeBase, snap.TypeGadget}
 	sys, snapInfos, snapSeeds, err := m.loadSystemAndEssentialSnaps(systemLabel, essentialTypes)

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -322,7 +322,7 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 	}
 	kernelDir := kernelInfo.MountDir()
 
-	modeEnv, err := maybeReadModeenv()
+	modeEnv, err := installHandler.MaybeReadModeenv()
 	if err != nil {
 		return err
 	}
@@ -563,7 +563,7 @@ func (m *DeviceManager) doRestartSystemToRunMode(t *state.Task, _ *tomb.Tomb) er
 	perfTimings := state.TimingsForTask(t)
 	defer perfTimings.Save(st)
 
-	modeEnv, err := maybeReadModeenv()
+	modeEnv, err := installHandler.MaybeReadModeenv()
 	if err != nil {
 		return err
 	}
@@ -881,7 +881,7 @@ func (m *DeviceManager) doFactoryResetRunSystem(t *state.Task, _ *tomb.Tomb) err
 	}
 	kernelDir := kernelInfo.MountDir()
 
-	modeEnv, err := maybeReadModeenv()
+	modeEnv, err := installHandler.MaybeReadModeenv()
 	if err != nil {
 		return err
 	}

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -20,16 +20,9 @@
 package devicestate
 
 import (
-	"bytes"
 	"compress/gzip"
-	"crypto"
-	"encoding/base64"
-	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -38,7 +31,6 @@ import (
 	"gopkg.in/tomb.v2"
 
 	"github.com/snapcore/snapd/asserts"
-	"github.com/snapcore/snapd/asserts/sysdb"
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/dirs"
@@ -48,17 +40,16 @@ import (
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/assertstate"
+	installHandler "github.com/snapcore/snapd/overlord/install"
 	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/progress"
-	"github.com/snapcore/snapd/randutil"
 	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/secboot/keys"
 	"github.com/snapcore/snapd/seed"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snapfile"
-	"github.com/snapcore/snapd/snap/squashfs"
 	"github.com/snapcore/snapd/sysconfig"
 	"github.com/snapcore/snapd/systemd"
 	"github.com/snapcore/snapd/timings"
@@ -81,45 +72,6 @@ var (
 
 	sysconfigConfigureTargetSystem = sysconfig.ConfigureTargetSystem
 )
-
-func setSysconfigCloudOptions(opts *sysconfig.Options, gadgetDir string, model *asserts.Model) {
-	ubuntuSeedCloudCfg := filepath.Join(boot.InitramfsUbuntuSeedDir, "data/etc/cloud/cloud.cfg.d")
-
-	grade := model.Grade()
-
-	// we always set the cloud-init src directory if it exists, it is
-	// automatically ignored by sysconfig in the case it shouldn't be used
-	if osutil.IsDirectory(ubuntuSeedCloudCfg) {
-		opts.CloudInitSrcDir = ubuntuSeedCloudCfg
-	}
-
-	switch {
-	// if the gadget has a cloud.conf file, always use that regardless of grade
-	case sysconfig.HasGadgetCloudConf(gadgetDir):
-		opts.AllowCloudInit = true
-
-	// next thing is if are in secured grade and didn't have gadget config, we
-	// disable cloud-init always, clouds should have their own config via
-	// gadgets for grade secured
-	case grade == asserts.ModelSecured:
-		opts.AllowCloudInit = false
-
-	// all other cases we allow cloud-init to run, either through config that is
-	// available at runtime via a CI-DATA USB drive, or via config on
-	// ubuntu-seed if that is allowed by the model grade, etc.
-	default:
-		opts.AllowCloudInit = true
-	}
-}
-
-func writeModel(model *asserts.Model, where string) error {
-	f, err := os.OpenFile(where, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0644)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-	return asserts.NewEncoder(f).Encode(model)
-}
 
 func writeLogs(rootdir string, fromMode string) error {
 	// XXX: would be great to use native journal format but it's tied
@@ -153,31 +105,6 @@ func writeLogs(rootdir string, fromMode string) error {
 		return fmt.Errorf("cannot flush compressed log output: %v", err)
 	}
 
-	return nil
-}
-
-func writeTimesyncdClock(srcRootDir, dstRootDir string) error {
-	// keep track of the time
-	const timesyncClockInRoot = "/var/lib/systemd/timesync/clock"
-	clockSrc := filepath.Join(srcRootDir, timesyncClockInRoot)
-	clockDst := filepath.Join(dstRootDir, timesyncClockInRoot)
-	if err := os.MkdirAll(filepath.Dir(clockDst), 0755); err != nil {
-		return fmt.Errorf("cannot store the clock: %v", err)
-	}
-	if !osutil.FileExists(clockSrc) {
-		logger.Noticef("timesyncd clock timestamp %v does not exist", clockSrc)
-		return nil
-	}
-	// clock file is owned by a specific user/group, thus preserve
-	// attributes of the source
-	if err := osutil.CopyFile(clockSrc, clockDst, osutil.CopyFlagPreserveAll); err != nil {
-		return fmt.Errorf("cannot copy clock: %v", err)
-	}
-	// the file is empty however, its modification timestamp is used to set
-	// up the current time
-	if err := os.Chtimes(clockDst, timeNow(), timeNow()); err != nil {
-		return fmt.Errorf("cannot update clock timestamp: %v", err)
-	}
 	return nil
 }
 
@@ -260,30 +187,6 @@ func writeTimings(st *state.State, rootdir, fromMode string) error {
 	return nil
 }
 
-// buildInstallObserver creates an observer for gadget assets if
-// applicable, otherwise the returned gadget.ContentObserver is nil.
-// The observer if any is also returned as non-nil trustedObserver if
-// encryption is in use.
-func buildInstallObserver(model *asserts.Model, gadgetDir string, useEncryption bool) (
-	observer gadget.ContentObserver, trustedObserver *boot.TrustedAssetsInstallObserver, err error) {
-
-	// observer will be a nil interface by default
-	trustedObserver, err = boot.TrustedAssetsInstallObserverForModel(model, gadgetDir, useEncryption)
-	if err != nil && err != boot.ErrObserverNotApplicable {
-		return nil, nil, fmt.Errorf("cannot setup asset install observer: %v", err)
-	}
-	if err == nil {
-		observer = trustedObserver
-		if !useEncryption {
-			// there will be no key sealing, so past the
-			// installation pass no other methods need to be called
-			trustedObserver = nil
-		}
-	}
-
-	return observer, trustedObserver, nil
-}
-
 func (m *DeviceManager) doSetupUbuntuSave(t *state.Task, _ *tomb.Tomb) error {
 	st := t.State()
 	st.Lock()
@@ -358,7 +261,7 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 		return fmt.Errorf("cannot use gadget: %v", err)
 	}
 
-	installObserver, trustedInstallObserver, err := buildInstallObserver(model, gadgetDir, useEncryption)
+	installObserver, trustedInstallObserver, err := installHandler.BuildInstallObserver(model, gadgetDir, useEncryption)
 	if err != nil {
 		return err
 	}
@@ -376,12 +279,12 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	if trustedInstallObserver != nil {
-		if err := prepareEncryptedSystemData(model, installedSystem.KeyForRole, trustedInstallObserver); err != nil {
+		if err := installHandler.PrepareEncryptedSystemData(model, installedSystem.KeyForRole, trustedInstallObserver); err != nil {
 			return err
 		}
 	}
 
-	if err := prepareRunSystemData(model, gadgetDir, perfTimings); err != nil {
+	if err := installHandler.PrepareRunSystemData(model, gadgetDir, perfTimings); err != nil {
 		return err
 	}
 
@@ -410,137 +313,6 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 		return fmt.Errorf("cannot make system runnable: %v", err)
 	}
 
-	return nil
-}
-
-func prepareEncryptedSystemData(model *asserts.Model, keyForRole map[string]keys.EncryptionKey, trustedInstallObserver *boot.TrustedAssetsInstallObserver) error {
-	// validity check
-	if len(keyForRole) == 0 || keyForRole[gadget.SystemData] == nil || keyForRole[gadget.SystemSave] == nil {
-		return fmt.Errorf("internal error: system encryption keys are unset")
-	}
-	dataEncryptionKey := keyForRole[gadget.SystemData]
-	saveEncryptionKey := keyForRole[gadget.SystemSave]
-
-	// make note of the encryption keys
-	trustedInstallObserver.ChosenEncryptionKeys(dataEncryptionKey, saveEncryptionKey)
-
-	// keep track of recovery assets
-	if err := trustedInstallObserver.ObserveExistingTrustedRecoveryAssets(boot.InitramfsUbuntuSeedDir); err != nil {
-		return fmt.Errorf("cannot observe existing trusted recovery assets: %v", err)
-	}
-	if err := saveKeys(model, keyForRole); err != nil {
-		return err
-	}
-	// write markers containing a secret to pair data and save
-	if err := writeMarkers(model); err != nil {
-		return err
-	}
-	return nil
-}
-
-func prepareRunSystemData(model *asserts.Model, gadgetDir string, perfTimings timings.Measurer) error {
-	// keep track of the model we installed
-	err := os.MkdirAll(filepath.Join(boot.InitramfsUbuntuBootDir, "device"), 0755)
-	if err != nil {
-		return fmt.Errorf("cannot store the model: %v", err)
-	}
-	err = writeModel(model, filepath.Join(boot.InitramfsUbuntuBootDir, "device/model"))
-	if err != nil {
-		return fmt.Errorf("cannot store the model: %v", err)
-	}
-
-	// preserve systemd-timesyncd clock timestamp, so that RTC-less devices
-	// can start with a more recent time on the next boot
-	if err := writeTimesyncdClock(dirs.GlobalRootDir, boot.InstallHostWritableDir(model)); err != nil {
-		return fmt.Errorf("cannot seed timesyncd clock: %v", err)
-	}
-
-	// configure the run system
-	opts := &sysconfig.Options{TargetRootDir: boot.InstallHostWritableDir(model), GadgetDir: gadgetDir}
-	// configure cloud init
-	setSysconfigCloudOptions(opts, gadgetDir, model)
-	timings.Run(perfTimings, "sysconfig-configure-target-system", "Configure target system", func(timings.Measurer) {
-		err = sysconfigConfigureTargetSystem(model, opts)
-	})
-	if err != nil {
-		return err
-	}
-
-	// TODO: FIXME: this should go away after we have time to design a proper
-	//              solution
-
-	if !model.Classic() {
-		// on some specific devices, we need to create these directories in
-		// _writable_defaults in order to allow the install-device hook to install
-		// some files there, this eventually will go away when we introduce a proper
-		// mechanism not using system-files to install files onto the root
-		// filesystem from the install-device hook
-		if err := fixupWritableDefaultDirs(boot.InstallHostWritableDir(model)); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func fixupWritableDefaultDirs(systemDataDir string) error {
-	// the _writable_default directory is used to put files in place on
-	// ubuntu-data from install mode, so we abuse it here for a specific device
-	// to let that device install files with system-files and the install-device
-	// hook
-
-	// eventually this will be a proper, supported, designed mechanism instead
-	// of just this hack, but this hack is just creating the directories, since
-	// the system-files interface only allows creating the file, not creating
-	// the directories leading up to that file, and since the file is deeply
-	// nested we would effectively have to give all permission to the device
-	// to create any file on ubuntu-data which we don't want to do, so we keep
-	// this restriction to let the device create one specific file, and then
-	// we behind the scenes just create the directories for the device
-
-	for _, subDirToCreate := range []string{"/etc/udev/rules.d", "/etc/modprobe.d", "/etc/modules-load.d/", "/etc/systemd/network"} {
-		dirToCreate := sysconfig.WritableDefaultsDir(systemDataDir, subDirToCreate)
-
-		if err := os.MkdirAll(dirToCreate, 0755); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// writeMarkers writes markers containing the same secret to pair data and save.
-func writeMarkers(model *asserts.Model) error {
-	// ensure directory for markers exists
-	if err := os.MkdirAll(boot.InstallHostFDEDataDir(model), 0755); err != nil {
-		return err
-	}
-	if err := os.MkdirAll(boot.InstallHostFDESaveDir, 0755); err != nil {
-		return err
-	}
-
-	// generate a secret random marker
-	markerSecret, err := randutil.CryptoTokenBytes(32)
-	if err != nil {
-		return fmt.Errorf("cannot create ubuntu-data/save marker secret: %v", err)
-	}
-
-	return device.WriteEncryptionMarkers(boot.InstallHostFDEDataDir(model), boot.InstallHostFDESaveDir, markerSecret)
-}
-
-func saveKeys(model *asserts.Model, keyForRole map[string]keys.EncryptionKey) error {
-	saveEncryptionKey := keyForRole[gadget.SystemSave]
-	if saveEncryptionKey == nil {
-		// no system-save support
-		return nil
-	}
-	// ensure directory for keys exists
-	if err := os.MkdirAll(boot.InstallHostFDEDataDir(model), 0755); err != nil {
-		return err
-	}
-	if err := saveEncryptionKey.Save(device.SaveKeyUnder(boot.InstallHostFDEDataDir(model))); err != nil {
-		return fmt.Errorf("cannot store system save key: %v", err)
-	}
 	return nil
 }
 
@@ -578,7 +350,7 @@ func (m *DeviceManager) doRestartSystemToRunMode(t *state.Task, _ *tomb.Tomb) er
 	}
 	model := deviceCtx.Model()
 
-	preseeded, err := maybeApplyPreseededData(st, boot.InitramfsUbuntuSeedDir, modeEnv.RecoverySystem, boot.InstallHostWritableDir(model))
+	preseeded, err := maybeApplyPreseededData(st, model, boot.InitramfsUbuntuSeedDir, modeEnv.RecoverySystem, boot.InstallHostWritableDir(model))
 	if err != nil {
 		logger.Noticef("failed to apply preseed data: %v", err)
 		return err
@@ -642,219 +414,22 @@ func (m *DeviceManager) doRestartSystemToRunMode(t *state.Task, _ *tomb.Tomb) er
 	return nil
 }
 
-func readPreseedAssertion(st *state.State, model *asserts.Model, ubuntuSeedDir, sysLabel string) (*asserts.Preseed, error) {
-	f, err := os.Open(filepath.Join(ubuntuSeedDir, "systems", sysLabel, "preseed"))
-	if err != nil {
-		return nil, fmt.Errorf("cannot read preseed assertion: %v", err)
-	}
-
-	// main seed assertions are loaded in the assertion db of install mode; add preseed assertion from
-	// systems/<label>/preseed file on top of it via a temporary db.
-	tmpDb := assertstate.TemporaryDB(st)
-	batch := asserts.NewBatch(nil)
-	_, err = batch.AddStream(f)
-	if err != nil {
-		return nil, err
-	}
-
-	var preseedAs *asserts.Preseed
-	err = batch.CommitToAndObserve(tmpDb, func(as asserts.Assertion) {
-		if as.Type() == asserts.PreseedType {
-			preseedAs = as.(*asserts.Preseed)
-		}
-	}, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	switch {
-	case preseedAs == nil:
-		return nil, fmt.Errorf("internal error: preseed assertion file is present but preseed assertion not found")
-	case preseedAs.SystemLabel() != sysLabel:
-		return nil, fmt.Errorf("preseed assertion system label %q doesn't match system label %q", preseedAs.SystemLabel(), sysLabel)
-	case preseedAs.Model() != model.Model():
-		return nil, fmt.Errorf("preseed assertion model %q doesn't match the model %q", preseedAs.Model(), model.Model())
-	case preseedAs.BrandID() != model.BrandID():
-		return nil, fmt.Errorf("preseed assertion brand %q doesn't match model brand %q", preseedAs.BrandID(), model.BrandID())
-	case preseedAs.Series() != model.Series():
-		return nil, fmt.Errorf("preseed assertion series %q doesn't match model series %q", preseedAs.Series(), model.Series())
-	}
-
-	return preseedAs, nil
-}
-
-var seedOpen = seed.Open
-
-// TODO: consider reusing this kind of handler for UC20 seeding
-type preseedSnapHandler struct {
-	writableDir string
-}
-
-func (p *preseedSnapHandler) HandleUnassertedSnap(name, path string, _ timings.Measurer) (string, error) {
-	pinfo := snap.MinimalPlaceInfo(name, snap.Revision{N: -1})
-	targetPath := filepath.Join(p.writableDir, pinfo.MountFile())
-	mountDir := filepath.Join(p.writableDir, pinfo.MountDir())
-
-	sq := squashfs.New(path)
-	opts := &snap.InstallOptions{MustNotCrossDevices: true}
-	if _, err := sq.Install(targetPath, mountDir, opts); err != nil {
-		return "", fmt.Errorf("cannot install snap %q: %v", name, err)
-	}
-
-	return targetPath, nil
-}
-
-func (p *preseedSnapHandler) HandleAndDigestAssertedSnap(name, path string, essType snap.Type, snapRev *asserts.SnapRevision, _ func(string, uint64) (snap.Revision, error), _ timings.Measurer) (string, string, uint64, error) {
-	pinfo := snap.MinimalPlaceInfo(name, snap.Revision{N: snapRev.SnapRevision()})
-	targetPath := filepath.Join(p.writableDir, pinfo.MountFile())
-	mountDir := filepath.Join(p.writableDir, pinfo.MountDir())
-
-	logger.Debugf("copying: %q to %q; mount dir=%q", path, targetPath, mountDir)
-
-	srcFile, err := os.Open(path)
-	if err != nil {
-		return "", "", 0, err
-	}
-	defer srcFile.Close()
-
-	destFile, err := osutil.NewAtomicFile(targetPath, 0644, 0, osutil.NoChown, osutil.NoChown)
-	if err != nil {
-		return "", "", 0, fmt.Errorf("cannot create atomic file: %v", err)
-	}
-	defer destFile.Cancel()
-
-	finfo, err := srcFile.Stat()
-	if err != nil {
-		return "", "", 0, err
-	}
-
-	destFile.SetModTime(finfo.ModTime())
-
-	h := crypto.SHA3_384.New()
-	w := io.MultiWriter(h, destFile)
-
-	size, err := io.CopyBuffer(w, srcFile, make([]byte, 2*1024*1024))
-	if err != nil {
-		return "", "", 0, err
-	}
-	if err := destFile.Commit(); err != nil {
-		return "", "", 0, fmt.Errorf("cannot copy snap %q: %v", name, err)
-	}
-
-	sq := squashfs.New(targetPath)
-	opts := &snap.InstallOptions{MustNotCrossDevices: true}
-	// since Install target path is the same as source path passed to squashfs.New,
-	// Install isn't going to copy the blob, but we call it to set up mount directory etc.
-	if _, err := sq.Install(targetPath, mountDir, opts); err != nil {
-		return "", "", 0, fmt.Errorf("cannot install snap %q: %v", name, err)
-	}
-
-	sha3_384, err := asserts.EncodeDigest(crypto.SHA3_384, h.Sum(nil))
-	if err != nil {
-		return "", "", 0, fmt.Errorf("cannot encode snap %q digest: %v", path, err)
-	}
-	return targetPath, sha3_384, uint64(size), nil
-}
-
-var maybeApplyPreseededData = func(st *state.State, ubuntuSeedDir, sysLabel, writableDir string) (preseeded bool, err error) {
+var maybeApplyPreseededData = func(st *state.State, model *asserts.Model, ubuntuSeedDir, sysLabel, writableDir string) (preseeded bool, err error) {
 	preseedArtifact := filepath.Join(ubuntuSeedDir, "systems", sysLabel, "preseed.tgz")
 	if !osutil.FileExists(preseedArtifact) {
 		return false, nil
 	}
-
-	model, err := findModel(st)
-	if err != nil {
-		return false, fmt.Errorf("preseed error: cannot find model: %v", err)
-	}
-
-	preseedAs, err := readPreseedAssertion(st, model, ubuntuSeedDir, sysLabel)
+	// main seed assertions are loaded in the assertion db of install mode; add preseed assertion from
+	// systems/<label>/preseed file on top of it via a temporary db.
+	preseedAs, err := installHandler.ReadPreseedAssertion(assertstate.TemporaryDB(st), model, ubuntuSeedDir, sysLabel)
 	if err != nil {
 		return false, err
 	}
-
-	// TODO: consider a writer that feeds the file to stdin of tar and calculates the digest at the same time.
-	sha3_384, _, err := osutil.FileDigest(preseedArtifact, crypto.SHA3_384)
-	if err != nil {
-		return false, fmt.Errorf("cannot calculate preseed artifact digest: %v", err)
-	}
-
-	digest, err := base64.RawURLEncoding.DecodeString(preseedAs.ArtifactSHA3_384())
-	if err != nil {
-		return false, fmt.Errorf("cannot decode preseed artifact digest")
-	}
-	if !bytes.Equal(sha3_384, digest) {
-		return false, fmt.Errorf("invalid preseed artifact digest")
-	}
-
-	logger.Noticef("apply preseed data: %q, %q", writableDir, preseedArtifact)
-	cmd := exec.Command("tar", "--extract", "--preserve-permissions", "--preserve-order", "--gunzip", "--directory", writableDir, "-f", preseedArtifact)
-	if err := cmd.Run(); err != nil {
+	if err = installHandler.MaybeApplyPreseededData(model, preseedAs, preseedArtifact, ubuntuSeedDir, sysLabel, writableDir); err != nil {
 		return false, err
+	} else {
+		return true, nil
 	}
-
-	logger.Noticef("copying snaps")
-
-	deviceSeed, err := seedOpen(ubuntuSeedDir, sysLabel)
-	if err != nil {
-		return false, err
-	}
-	tm := timings.New(nil)
-
-	if err := deviceSeed.LoadAssertions(nil, nil); err != nil {
-		return false, err
-	}
-
-	if err := os.MkdirAll(filepath.Join(writableDir, "var/lib/snapd/snaps"), 0755); err != nil {
-		return false, err
-	}
-
-	snapHandler := &preseedSnapHandler{writableDir: writableDir}
-	if err := deviceSeed.LoadMeta("run", snapHandler, tm); err != nil {
-		return false, err
-	}
-
-	preseedSnaps := make(map[string]*asserts.PreseedSnap)
-	for _, ps := range preseedAs.Snaps() {
-		preseedSnaps[ps.Name] = ps
-	}
-
-	checkSnap := func(ssnap *seed.Snap) error {
-		ps, ok := preseedSnaps[ssnap.SnapName()]
-		if !ok {
-			return fmt.Errorf("snap %q not present in the preseed assertion", ssnap.SnapName())
-		}
-		if ps.Revision != ssnap.SideInfo.Revision.N {
-			rev := snap.Revision{N: ps.Revision}
-			return fmt.Errorf("snap %q has wrong revision %s (expected: %s)", ssnap.SnapName(), ssnap.SideInfo.Revision, rev)
-		}
-		if ps.SnapID != ssnap.SideInfo.SnapID {
-			return fmt.Errorf("snap %q has wrong snap id %q (expected: %q)", ssnap.SnapName(), ssnap.SideInfo.SnapID, ps.SnapID)
-		}
-		return nil
-	}
-
-	esnaps := deviceSeed.EssentialSnaps()
-	msnaps, err := deviceSeed.ModeSnaps("run")
-	if err != nil {
-		return false, err
-	}
-	if len(msnaps)+len(esnaps) != len(preseedSnaps) {
-		return false, fmt.Errorf("seed has %d snaps but %d snaps are required by preseed assertion", len(msnaps)+len(esnaps), len(preseedSnaps))
-	}
-
-	for _, esnap := range esnaps {
-		if err := checkSnap(esnap); err != nil {
-			return false, err
-		}
-	}
-
-	for _, ssnap := range msnaps {
-		if err := checkSnap(ssnap); err != nil {
-			return false, err
-		}
-	}
-
-	return true, nil
 }
 
 func (m *DeviceManager) doFactoryResetRunSystem(t *state.Task, _ *tomb.Tomb) error {
@@ -997,16 +572,16 @@ func (m *DeviceManager) doFactoryResetRunSystem(t *state.Task, _ *tomb.Tomb) err
 		// keep track of the new ubuntu-save encryption key
 		installedSystem.KeyForRole[gadget.SystemSave] = saveEncryptionKey
 
-		if err := prepareEncryptedSystemData(model, installedSystem.KeyForRole, trustedInstallObserver); err != nil {
+		if err := installHandler.PrepareEncryptedSystemData(model, installedSystem.KeyForRole, trustedInstallObserver); err != nil {
 			return err
 		}
 	}
 
-	if err := prepareRunSystemData(model, gadgetDir, perfTimings); err != nil {
+	if err := installHandler.PrepareRunSystemData(model, gadgetDir, perfTimings); err != nil {
 		return err
 	}
 
-	if err := restoreDeviceFromSave(model); err != nil {
+	if err := installHandler.RestoreDeviceFromSave(model); err != nil {
 		return fmt.Errorf("cannot restore data from save: %v", err)
 	}
 
@@ -1036,202 +611,8 @@ func (m *DeviceManager) doFactoryResetRunSystem(t *state.Task, _ *tomb.Tomb) err
 
 	// leave a marker that factory reset was performed
 	factoryResetMarker := filepath.Join(dirs.SnapDeviceDirUnder(boot.InstallHostWritableDir(model)), "factory-reset")
-	if err := writeFactoryResetMarker(factoryResetMarker, useEncryption); err != nil {
+	if err := installHandler.WriteFactoryResetMarker(factoryResetMarker, useEncryption); err != nil {
 		return fmt.Errorf("cannot write the marker file: %v", err)
-	}
-	return nil
-}
-
-func restoreDeviceFromSave(model *asserts.Model) error {
-	// we could also look at factory-reset-bootstrap.json left by
-	// snap-bootstrap, but the mount was already verified during boot
-	mounted, err := osutil.IsMounted(boot.InitramfsUbuntuSaveDir)
-	if err != nil {
-		return fmt.Errorf("cannot determine ubuntu-save mount state: %v", err)
-	}
-	if !mounted {
-		logger.Noticef("not restoring from save, ubuntu-save not mounted")
-		return nil
-	}
-	// TODO anything else we want to restore?
-	return restoreDeviceSerialFromSave(model)
-}
-
-func restoreDeviceSerialFromSave(model *asserts.Model) error {
-	fromDevice := filepath.Join(boot.InstallHostDeviceSaveDir)
-	logger.Debugf("looking for serial assertion and device key under %v", fromDevice)
-	fromDB, err := sysdb.OpenAt(fromDevice)
-	if err != nil {
-		return err
-	}
-	// key pair manager always uses ubuntu-save whenever it's available
-	kp, err := asserts.OpenFSKeypairManager(fromDevice)
-	if err != nil {
-		return err
-	}
-	// there should be a serial assertion for the current model
-	serials, err := fromDB.FindMany(asserts.SerialType, map[string]string{
-		"brand-id": model.BrandID(),
-		"model":    model.Model(),
-	})
-	if (err != nil && errors.Is(err, &asserts.NotFoundError{})) || len(serials) == 0 {
-		// there is no serial assertion in the old system that matches
-		// our model, it is still possible that the old system could
-		// have generated device keys and sent out a serial request, but
-		// for simplicity we ignore this scenario and a new set of keys
-		// will be generated after booting into the run system
-		logger.Debugf("no serial assertion for %v/%v", model.BrandID(), model.Model())
-		return nil
-	}
-	if err != nil {
-		return err
-	}
-	logger.Noticef("found %v serial assertions for %v/%v", len(serials), model.BrandID(), model.Model())
-
-	var serialAs *asserts.Serial
-	for _, serial := range serials {
-		maybeCurrentSerialAs := serial.(*asserts.Serial)
-		// serial assertion is signed with the device key, its ID is in the
-		// header
-		deviceKeyID := maybeCurrentSerialAs.DeviceKey().ID()
-		logger.Debugf("serial assertion device key ID: %v", deviceKeyID)
-
-		// there can be multiple serial assertions, as the device could
-		// have exercised the registration a number of times, but each
-		// time it unregisters, the old key is removed and a new one is
-		// generated
-		_, err = kp.Get(deviceKeyID)
-		if err != nil {
-			if asserts.IsKeyNotFound(err) {
-				logger.Debugf("no key with ID %v", deviceKeyID)
-				continue
-			}
-			return fmt.Errorf("cannot obtain device key: %v", err)
-		} else {
-			serialAs = maybeCurrentSerialAs
-			break
-		}
-	}
-
-	if serialAs == nil {
-		// no serial assertion that matches the model, brand and is
-		// signed with a device key that is present in the filesystem
-		logger.Debugf("no valid serial assertions")
-		return nil
-	}
-
-	logger.Debugf("found a serial assertion for %v/%v, with serial %v",
-		model.BrandID(), model.Model(), serialAs.Serial())
-
-	toDB, err := sysdb.OpenAt(filepath.Join(boot.InstallHostWritableDir(model), "var/lib/snapd/assertions"))
-	if err != nil {
-		return err
-	}
-
-	logger.Debugf("importing serial and model assertions")
-	b := asserts.NewBatch(nil)
-	err = b.Fetch(toDB,
-		func(ref *asserts.Ref) (asserts.Assertion, error) { return ref.Resolve(fromDB.Find) },
-		func(f asserts.Fetcher) error {
-			if err := f.Save(model); err != nil {
-				return err
-			}
-			return f.Save(serialAs)
-		})
-	if err != nil {
-		return fmt.Errorf("cannot fetch assertions: %v", err)
-	}
-	if err := b.CommitTo(toDB, nil); err != nil {
-		return fmt.Errorf("cannot commit assertions: %v", err)
-	}
-	return nil
-}
-
-type factoryResetMarker struct {
-	FallbackSaveKeyHash string `json:"fallback-save-key-sha3-384,omitempty"`
-}
-
-func fileDigest(p string) (string, error) {
-	digest, _, err := osutil.FileDigest(p, crypto.SHA3_384)
-	if err != nil {
-		return "", err
-	}
-	return hex.EncodeToString(digest), nil
-}
-
-func writeFactoryResetMarker(marker string, hasEncryption bool) error {
-	keyDigest := ""
-	if hasEncryption {
-		d, err := fileDigest(device.FactoryResetFallbackSaveSealedKeyUnder(boot.InitramfsSeedEncryptionKeyDir))
-		if err != nil {
-			return err
-		}
-		keyDigest = d
-	}
-	var buf bytes.Buffer
-	err := json.NewEncoder(&buf).Encode(factoryResetMarker{
-		FallbackSaveKeyHash: keyDigest,
-	})
-	if err != nil {
-		return err
-	}
-
-	if hasEncryption {
-		logger.Noticef("writing factory-reset marker at %v with key digest %q", marker, keyDigest)
-	} else {
-		logger.Noticef("writing factory-reset marker at %v", marker)
-	}
-	return osutil.AtomicWriteFile(marker, buf.Bytes(), 0644, 0)
-}
-
-func verifyFactoryResetMarkerInRun(marker string, hasEncryption bool) error {
-	f, err := os.Open(marker)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-	var frm factoryResetMarker
-	if err := json.NewDecoder(f).Decode(&frm); err != nil {
-		return err
-	}
-	if hasEncryption {
-		saveFallbackKeyFactory := device.FactoryResetFallbackSaveSealedKeyUnder(boot.InitramfsSeedEncryptionKeyDir)
-		d, err := fileDigest(saveFallbackKeyFactory)
-		if err != nil {
-			// possible that there was unexpected reboot
-			// before, after the key was moved, but before
-			// the marker was removed, in which case the
-			// actual fallback key should have the right
-			// digest
-			if !os.IsNotExist(err) {
-				// unless it's a different error
-				return err
-			}
-			saveFallbackKeyFactory := device.FallbackSaveSealedKeyUnder(boot.InitramfsSeedEncryptionKeyDir)
-			d, err = fileDigest(saveFallbackKeyFactory)
-			if err != nil {
-				return err
-			}
-		}
-		if d != frm.FallbackSaveKeyHash {
-			return fmt.Errorf("fallback sealed key digest mismatch, got %v expected %v", d, frm.FallbackSaveKeyHash)
-		}
-	} else {
-		if frm.FallbackSaveKeyHash != "" {
-			return fmt.Errorf("unexpected non-empty fallback key digest")
-		}
-	}
-	return nil
-}
-
-func rotateEncryptionKeys() error {
-	kd, err := ioutil.ReadFile(filepath.Join(dirs.SnapFDEDir, "ubuntu-save.key"))
-	if err != nil {
-		return fmt.Errorf("cannot open encryption key file: %v", err)
-	}
-	// does the right thing if the key has already been transitioned
-	if err := secbootTransitionEncryptionKeyChange(boot.InitramfsUbuntuSaveDir, keys.EncryptionKey(kd)); err != nil {
-		return fmt.Errorf("cannot transition the encryption key: %v", err)
 	}
 	return nil
 }
@@ -1352,7 +733,7 @@ func (m *DeviceManager) doInstallFinish(t *state.Task, _ *tomb.Tomb) error {
 	logger.Debugf("starting install-finish for %q (using encryption: %t) on %v", systemLabel, useEncryption, onVolumes)
 
 	// TODO we probably want to pass a different location for the assets cache
-	installObserver, trustedInstallObserver, err := buildInstallObserver(sys.Model, mntPtForType[snap.TypeGadget], useEncryption)
+	installObserver, trustedInstallObserver, err := installHandler.BuildInstallObserver(sys.Model, mntPtForType[snap.TypeGadget], useEncryption)
 	if err != nil {
 		return err
 	}
@@ -1392,7 +773,7 @@ func (m *DeviceManager) doInstallFinish(t *state.Task, _ *tomb.Tomb) error {
 
 	if useEncryption {
 		if trustedInstallObserver != nil {
-			if err := prepareEncryptedSystemData(sys.Model, install.KeysForRole(encryptSetupData), trustedInstallObserver); err != nil {
+			if err := installHandler.PrepareEncryptedSystemData(sys.Model, install.KeysForRole(encryptSetupData), trustedInstallObserver); err != nil {
 				return err
 			}
 		}
@@ -1423,7 +804,7 @@ func (m *DeviceManager) doInstallFinish(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	// writes the model
-	if err := prepareRunSystemData(sys.Model, bootWith.UnpackedGadgetDir, perfTimings); err != nil {
+	if err := installHandler.PrepareRunSystemData(sys.Model, bootWith.UnpackedGadgetDir, perfTimings); err != nil {
 		return err
 	}
 
@@ -1471,7 +852,7 @@ func (m *DeviceManager) doInstallSetupStorageEncryption(t *state.Task, _ *tomb.T
 		return fmt.Errorf("reading gadget information: %v", err)
 	}
 
-	encryptInfo, err := m.encryptionSupportInfo(sys.Model, secboot.TPMProvisionFull, snapInfos[snap.TypeKernel], gadgetInfo)
+	encryptInfo, err := installHandler.GetEncryptionSupportInfo(sys.Model, secboot.TPMProvisionFull, snapInfos[snap.TypeKernel], gadgetInfo, m.runFDESetupHook)
 	if err != nil {
 		return err
 	}

--- a/overlord/devicestate/remodel.go
+++ b/overlord/devicestate/remodel.go
@@ -26,6 +26,7 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/overlord/install"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/overlord/storecontext"
@@ -276,7 +277,7 @@ func (rc *baseRemodelContext) updateRunModeSystem() error {
 	if err := boot.DeviceChange(oldDeviceContext, newDeviceContext); err != nil {
 		return fmt.Errorf("cannot switch device: %v", err)
 	}
-	if err := rc.deviceMgr.recordSeededSystem(rc.st, &seededSystem{
+	if err := rc.deviceMgr.recordSeededSystem(rc.st, &install.SeededSystem{
 		System:    rc.recoverySystemLabel,
 		Model:     rc.model.Model(),
 		BrandID:   rc.model.BrandID(),

--- a/overlord/devicestate/systems.go
+++ b/overlord/devicestate/systems.go
@@ -30,6 +30,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/overlord/install"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/seed"
@@ -55,7 +56,7 @@ func checkSystemRequestConflict(st *state.State, systemLabel string) error {
 	// holding the state lock so there is no race against mark-seeded
 	// clearing recovery system; recovery system is not cleared when seeding
 	// fails
-	modeEnv, err := maybeReadModeenv()
+	modeEnv, err := install.MaybeReadModeenv()
 	if err != nil {
 		return err
 	}
@@ -168,7 +169,7 @@ func currentSeededSystem(st *state.State) (*seededSystem, error) {
 }
 
 func seededSystemFromModeenv() (*seededSystem, error) {
-	modeEnv, err := maybeReadModeenv()
+	modeEnv, err := install.maybeReadModeenv()
 	if err != nil {
 		return nil, err
 	}

--- a/overlord/install/export_test.go
+++ b/overlord/install/export_test.go
@@ -1,0 +1,177 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package install
+
+import (
+	"fmt"
+
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/gadget"
+	"github.com/snapcore/snapd/gadget/install"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/secboot"
+	"github.com/snapcore/snapd/secboot/keys"
+	"github.com/snapcore/snapd/seed"
+	"github.com/snapcore/snapd/sysconfig"
+	"github.com/snapcore/snapd/testutil"
+	"github.com/snapcore/snapd/timings"
+)
+
+// // var (
+// // 	MaybeApplyPreseededData = maybeApplyPreseededData
+// // )
+
+// func MockMaybeApplyPreseededData(f func(st *state.State, model *asserts.Model, ubuntuSeedDir, sysLabel, writableDir string) (bool, error)) (restore func()) {
+// 	r := testutil.Backup(&maybeApplyPreseededData)
+// 	maybeApplyPreseededData = f
+// 	return r
+// }
+
+func MockSeedOpen(f func(seedDir, label string) (seed.Seed, error)) (restore func()) {
+	r := testutil.Backup(&seedOpen)
+	seedOpen = f
+	return r
+}
+
+func MockBootMakeSystemRunnable(f func(model *asserts.Model, bootWith *boot.BootableSet, seal *boot.TrustedAssetsInstallObserver) error) (restore func()) {
+	restore = testutil.Backup(&bootMakeRunnable)
+	bootMakeRunnable = f
+	return restore
+}
+
+func MockBootMakeSystemRunnableAfterDataReset(f func(model *asserts.Model, bootWith *boot.BootableSet, seal *boot.TrustedAssetsInstallObserver) error) (restore func()) {
+	restore = testutil.Backup(&bootMakeRunnableAfterDataReset)
+	bootMakeRunnableAfterDataReset = f
+	return restore
+}
+
+func MockBootEnsureNextBootToRunMode(f func(systemLabel string) error) (restore func()) {
+	old := bootEnsureNextBootToRunMode
+	bootEnsureNextBootToRunMode = f
+	return func() {
+		bootEnsureNextBootToRunMode = old
+	}
+}
+
+func MockSecbootCheckTPMKeySealingSupported(f func() error) (restore func()) {
+	old := secbootCheckTPMKeySealingSupported
+	secbootCheckTPMKeySealingSupported = f
+	return func() {
+		secbootCheckTPMKeySealingSupported = old
+	}
+}
+
+func MockSysconfigConfigureTargetSystem(f func(mod *asserts.Model, opts *sysconfig.Options) error) (restore func()) {
+	old := sysconfigConfigureTargetSystem
+	sysconfigConfigureTargetSystem = f
+	return func() {
+		sysconfigConfigureTargetSystem = old
+	}
+}
+
+func MockInstallRun(f func(model gadget.Model, gadgetRoot, kernelRoot, device string, options install.Options, observer gadget.ContentObserver, perfTimings timings.Measurer) (*install.InstalledSystemSideData, error)) (restore func()) {
+	old := installRun
+	installRun = f
+	return func() {
+		installRun = old
+	}
+}
+
+func MockInstallFactoryReset(f func(model gadget.Model, gadgetRoot, kernelRoot, device string, options install.Options, observer gadget.ContentObserver, perfTimings timings.Measurer) (*install.InstalledSystemSideData, error)) (restore func()) {
+	restore = testutil.Backup(&installFactoryReset)
+	installFactoryReset = f
+	return restore
+}
+
+func MockInstallWriteContent(f func(onVolumes map[string]*gadget.Volume, allLaidOutVols map[string]*gadget.LaidOutVolume, encSetupData *install.EncryptionSetupData, observer gadget.ContentObserver, perfTimings timings.Measurer) ([]*gadget.OnDiskVolume, error)) (restore func()) {
+	old := installWriteContent
+	installWriteContent = f
+	return func() {
+		installWriteContent = old
+	}
+}
+
+func MockInstallMountVolumes(f func(onVolumes map[string]*gadget.Volume, encSetupData *install.EncryptionSetupData) (espMntDir string, unmount func() error, err error)) (restore func()) {
+	old := installMountVolumes
+	installMountVolumes = f
+	return func() {
+		installMountVolumes = old
+	}
+}
+
+func MockInstallEncryptPartitions(f func(onVolumes map[string]*gadget.Volume, encryptionType secboot.EncryptionType, model *asserts.Model, gadgetRoot, kernelRoot string, perfTimings timings.Measurer) (*install.EncryptionSetupData, error)) (restore func()) {
+	old := installEncryptPartitions
+	installEncryptPartitions = f
+	return func() {
+		installEncryptPartitions = old
+	}
+}
+
+func MockInstallSaveStorageTraits(f func(model gadget.Model, allLaidOutVols map[string]*gadget.LaidOutVolume, encryptSetupData *install.EncryptionSetupData) error) (restore func()) {
+	old := installSaveStorageTraits
+	installSaveStorageTraits = f
+	return func() {
+		installSaveStorageTraits = old
+	}
+}
+
+func MockSecbootStageEncryptionKeyChange(f func(node string, key keys.EncryptionKey) error) (restore func()) {
+	restore = testutil.Backup(&secbootStageEncryptionKeyChange)
+	secbootStageEncryptionKeyChange = f
+	return restore
+}
+
+func MockEncryptionSetupDataInCache(st *state.State, label string) (restore func()) {
+	st.Lock()
+	defer st.Unlock()
+	var esd *install.EncryptionSetupData
+	labelToEncData := map[string]*install.MockEncryptedDeviceAndRole{
+		"ubuntu-save": {
+			Role:            "system-save",
+			EncryptedDevice: "/dev/mapper/ubuntu-save",
+		},
+		"ubuntu-data": {
+			Role:            "system-data",
+			EncryptedDevice: "/dev/mapper/ubuntu-data",
+		},
+	}
+	esd = install.MockEncryptionSetupData(labelToEncData)
+	st.Cache(encryptionSetupDataKey{label}, esd)
+	return func() { CleanUpEncryptionSetupDataInCache(st, label) }
+}
+
+func CheckEncryptionSetupDataFromCache(st *state.State, label string) error {
+	cached := st.Cached(encryptionSetupDataKey{label})
+	if cached == nil {
+		return fmt.Errorf("no EncryptionSetupData found in cache")
+	}
+	if _, ok := cached.(*install.EncryptionSetupData); !ok {
+		return fmt.Errorf("wrong data type under encryptionSetupDataKey")
+	}
+	return nil
+}
+
+func CleanUpEncryptionSetupDataInCache(st *state.State, label string) {
+	st.Lock()
+	defer st.Unlock()
+	key := encryptionSetupDataKey{label}
+	st.Cache(key, nil)
+}

--- a/overlord/install/install.go
+++ b/overlord/install/install.go
@@ -696,9 +696,13 @@ func checkFDEFeatures(runSetupHook fde.RunSetupHookFunc) (et secboot.EncryptionT
 	if err != nil {
 		return et, err
 	}
-	if strutil.ListContains(features, "device-setup") {
+	switch {
+	case strutil.ListContains(features, "inline-crypto-engine"):
+		et = secboot.EncryptionTypeLUKSWithICE
+		// TODO:ICE: remove this
+	case strutil.ListContains(features, "device-setup"):
 		et = secboot.EncryptionTypeDeviceSetupHook
-	} else {
+	default:
 		et = secboot.EncryptionTypeLUKS
 	}
 
@@ -756,4 +760,121 @@ func EnsureUbuntuSaveIsMounted() error {
 		return fmt.Errorf("cannot bind mount %v under %v: %v", boot.InitramfsUbuntuSaveDir, dirs.SnapSaveDir, err)
 	}
 	return nil
+}
+
+// EncryptionSupportInfo describes what encryption is available and needed
+// for the current device.
+type EncryptionSupportInfo struct {
+	// Disabled is set if to true encryption was forcefully
+	// disabled (e.g. via the seed partition), if set the rest
+	// of the struct content is not relevant.
+	Disabled bool
+
+	// StorageSafety describes the level safety properties
+	// requested by the model
+	StorageSafety asserts.StorageSafety
+	// Available is set to true if encryption is available on this device
+	// with the used gadget.
+	Available bool
+
+	// Type is set to the EncryptionType that can be used if
+	// Available is true.
+	Type secboot.EncryptionType
+
+	// UnvailableErr is set if the encryption support availability of
+	// the this device and used gadget do not match the
+	// storage safety requirements.
+	UnavailableErr error
+	// UnavailbleWarning describes why encryption support is not
+	// available in case it is optional.
+	UnavailableWarning string
+}
+
+var secbootCheckTPMKeySealingSupported = secboot.CheckTPMKeySealingSupported
+
+func CheckEncryptionType(model *asserts.Model, tpmMode secboot.TPMProvisionMode, kernelInfo *snap.Info, gadgetInfo *gadget.Info, runSetupHook fde.RunSetupHookFunc) (secboot.EncryptionType, error) {
+	res, err := GetEncryptionSupportInfo(model, tpmMode, kernelInfo, gadgetInfo, runSetupHook)
+	if err != nil {
+		return "", err
+	}
+	if res.UnavailableWarning != "" {
+		logger.Noticef("%s", res.UnavailableWarning)
+	}
+	// encryption disabled or preferred unencrypted: follow the model preferences here even if encryption would be available
+	if res.Disabled || res.StorageSafety == asserts.StorageSafetyPreferUnencrypted {
+		res.Type = secboot.EncryptionTypeNone
+	}
+
+	return res.Type, res.UnavailableErr
+}
+
+func GetEncryptionSupportInfo(model *asserts.Model, tpmMode secboot.TPMProvisionMode, kernelInfo *snap.Info, gadgetInfo *gadget.Info, runSetupHook fde.RunSetupHookFunc) (EncryptionSupportInfo, error) {
+	secured := model.Grade() == asserts.ModelSecured
+	dangerous := model.Grade() == asserts.ModelDangerous
+	encrypted := model.StorageSafety() == asserts.StorageSafetyEncrypted
+
+	res := EncryptionSupportInfo{
+		StorageSafety: model.StorageSafety(),
+	}
+
+	// check if we should disable encryption non-secured devices
+	// TODO:UC20: this is not the final mechanism to bypass encryption
+	if dangerous && osutil.FileExists(filepath.Join(boot.InitramfsUbuntuSeedDir, ".force-unencrypted")) {
+		res.Disabled = true
+		return res, nil
+	}
+
+	// check encryption: this can either be provided by the fde-setup
+	// hook mechanism or by the built-in secboot based encryption
+	checkFDESetupHookEncryption := HasFDESetupHookInKernel(kernelInfo)
+	// Note that having a fde-setup hook will disable the internal
+	// secboot based encryption
+	checkSecbootEncryption := !checkFDESetupHookEncryption
+	var checkEncryptionErr error
+	switch {
+	case checkFDESetupHookEncryption:
+		res.Type, checkEncryptionErr = checkFDEFeatures(runSetupHook)
+	case checkSecbootEncryption:
+		checkEncryptionErr = secbootCheckTPMKeySealingSupported(tpmMode)
+		if checkEncryptionErr == nil {
+			res.Type = secboot.EncryptionTypeLUKS
+		}
+	default:
+		return res, fmt.Errorf("internal error: no encryption checked in encryptionSupportInfo")
+	}
+	res.Available = (checkEncryptionErr == nil)
+
+	if checkEncryptionErr != nil {
+		switch {
+		case secured:
+			res.UnavailableErr = fmt.Errorf("cannot encrypt device storage as mandated by model grade secured: %v", checkEncryptionErr)
+		case encrypted:
+			res.UnavailableErr = fmt.Errorf("cannot encrypt device storage as mandated by encrypted storage-safety model option: %v", checkEncryptionErr)
+		case checkFDESetupHookEncryption:
+			res.UnavailableWarning = fmt.Sprintf("not encrypting device storage as querying kernel fde-setup hook did not succeed: %v", checkEncryptionErr)
+		case checkSecbootEncryption:
+			res.UnavailableWarning = fmt.Sprintf("not encrypting device storage as checking TPM gave: %v", checkEncryptionErr)
+		default:
+			return res, fmt.Errorf("internal error: checkEncryptionErr is set but not handled by the code")
+		}
+	}
+
+	// If encryption is available check if the gadget is
+	// compatible with encryption.
+	if res.Available {
+		opts := &gadget.ValidationConstraints{
+			EncryptedData: true,
+		}
+		if err := gadget.Validate(gadgetInfo, model, opts); err != nil {
+			if secured || encrypted {
+				res.UnavailableErr = fmt.Errorf("cannot use encryption with the gadget: %v", err)
+			} else {
+				res.UnavailableWarning = fmt.Sprintf("cannot use encryption with the gadget, disabling encryption: %v", err)
+			}
+			res.Available = false
+			res.Type = secboot.EncryptionTypeNone
+		}
+	}
+
+	return res, nil
 }

--- a/overlord/install/install.go
+++ b/overlord/install/install.go
@@ -1,0 +1,708 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package install
+
+import (
+	"bytes"
+	"crypto"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	_ "golang.org/x/crypto/sha3"
+
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/asserts/sysdb"
+	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/gadget"
+	"github.com/snapcore/snapd/gadget/device"
+	"github.com/snapcore/snapd/kernel/fde"
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/randutil"
+	"github.com/snapcore/snapd/secboot"
+	"github.com/snapcore/snapd/secboot/keys"
+	"github.com/snapcore/snapd/seed"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/squashfs"
+	"github.com/snapcore/snapd/strutil"
+	"github.com/snapcore/snapd/sysconfig"
+	"github.com/snapcore/snapd/timings"
+)
+
+var (
+	secbootTransitionEncryptionKeyChange = secboot.TransitionEncryptionKeyChange
+	sysconfigConfigureTargetSystem       = sysconfig.ConfigureTargetSystem
+)
+
+var timeNow = time.Now
+
+func setSysconfigCloudOptions(opts *sysconfig.Options, gadgetDir string, model *asserts.Model) {
+	ubuntuSeedCloudCfg := filepath.Join(boot.InitramfsUbuntuSeedDir, "data/etc/cloud/cloud.cfg.d")
+
+	grade := model.Grade()
+
+	// we always set the cloud-init src directory if it exists, it is
+	// automatically ignored by sysconfig in the case it shouldn't be used
+	if osutil.IsDirectory(ubuntuSeedCloudCfg) {
+		opts.CloudInitSrcDir = ubuntuSeedCloudCfg
+	}
+
+	switch {
+	// if the gadget has a cloud.conf file, always use that regardless of grade
+	case sysconfig.HasGadgetCloudConf(gadgetDir):
+		opts.AllowCloudInit = true
+
+	// next thing is if are in secured grade and didn't have gadget config, we
+	// disable cloud-init always, clouds should have their own config via
+	// gadgets for grade secured
+	case grade == asserts.ModelSecured:
+		opts.AllowCloudInit = false
+
+	// all other cases we allow cloud-init to run, either through config that is
+	// available at runtime via a CI-DATA USB drive, or via config on
+	// ubuntu-seed if that is allowed by the model grade, etc.
+	default:
+		opts.AllowCloudInit = true
+	}
+}
+
+func writeModel(model *asserts.Model, where string) error {
+	f, err := os.OpenFile(where, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return asserts.NewEncoder(f).Encode(model)
+}
+
+func writeTimesyncdClock(srcRootDir, dstRootDir string) error {
+	// keep track of the time
+	const timesyncClockInRoot = "/var/lib/systemd/timesync/clock"
+	clockSrc := filepath.Join(srcRootDir, timesyncClockInRoot)
+	clockDst := filepath.Join(dstRootDir, timesyncClockInRoot)
+	if err := os.MkdirAll(filepath.Dir(clockDst), 0755); err != nil {
+		return fmt.Errorf("cannot store the clock: %v", err)
+	}
+	if !osutil.FileExists(clockSrc) {
+		logger.Noticef("timesyncd clock timestamp %v does not exist", clockSrc)
+		return nil
+	}
+	// clock file is owned by a specific user/group, thus preserve
+	// attributes of the source
+	if err := osutil.CopyFile(clockSrc, clockDst, osutil.CopyFlagPreserveAll); err != nil {
+		return fmt.Errorf("cannot copy clock: %v", err)
+	}
+	// the file is empty however, its modification timestamp is used to set
+	// up the current time
+	if err := os.Chtimes(clockDst, timeNow(), timeNow()); err != nil {
+		return fmt.Errorf("cannot update clock timestamp: %v", err)
+	}
+	return nil
+}
+
+// BuildInstallObserver creates an observer for gadget assets if
+// applicable, otherwise the returned gadget.ContentObserver is nil.
+// The observer if any is also returned as non-nil trustedObserver if
+// encryption is in use.
+func BuildInstallObserver(model *asserts.Model, gadgetDir string, useEncryption bool) (
+	observer gadget.ContentObserver, trustedObserver *boot.TrustedAssetsInstallObserver, err error) {
+
+	// observer will be a nil interface by default
+	trustedObserver, err = boot.TrustedAssetsInstallObserverForModel(model, gadgetDir, useEncryption)
+	if err != nil && err != boot.ErrObserverNotApplicable {
+		return nil, nil, fmt.Errorf("cannot setup asset install observer: %v", err)
+	}
+	if err == nil {
+		observer = trustedObserver
+		if !useEncryption {
+			// there will be no key sealing, so past the
+			// installation pass no other methods need to be called
+			trustedObserver = nil
+		}
+	}
+
+	return observer, trustedObserver, nil
+}
+
+func PrepareEncryptedSystemData(model *asserts.Model, keyForRole map[string]keys.EncryptionKey, trustedInstallObserver *boot.TrustedAssetsInstallObserver) error {
+	// validity check
+	if len(keyForRole) == 0 || keyForRole[gadget.SystemData] == nil || keyForRole[gadget.SystemSave] == nil {
+		return fmt.Errorf("internal error: system encryption keys are unset")
+	}
+	dataEncryptionKey := keyForRole[gadget.SystemData]
+	saveEncryptionKey := keyForRole[gadget.SystemSave]
+
+	// make note of the encryption keys
+	trustedInstallObserver.ChosenEncryptionKeys(dataEncryptionKey, saveEncryptionKey)
+
+	// keep track of recovery assets
+	if err := trustedInstallObserver.ObserveExistingTrustedRecoveryAssets(boot.InitramfsUbuntuSeedDir); err != nil {
+		return fmt.Errorf("cannot observe existing trusted recovery assets: %v", err)
+	}
+	if err := saveKeys(model, keyForRole); err != nil {
+		return err
+	}
+	// write markers containing a secret to pair data and save
+	if err := writeMarkers(model); err != nil {
+		return err
+	}
+	return nil
+}
+
+func PrepareRunSystemData(model *asserts.Model, gadgetDir string, perfTimings timings.Measurer) error {
+	// keep track of the model we installed
+	err := os.MkdirAll(filepath.Join(boot.InitramfsUbuntuBootDir, "device"), 0755)
+	if err != nil {
+		return fmt.Errorf("cannot store the model: %v", err)
+	}
+	err = writeModel(model, filepath.Join(boot.InitramfsUbuntuBootDir, "device/model"))
+	if err != nil {
+		return fmt.Errorf("cannot store the model: %v", err)
+	}
+
+	// preserve systemd-timesyncd clock timestamp, so that RTC-less devices
+	// can start with a more recent time on the next boot
+	if err := writeTimesyncdClock(dirs.GlobalRootDir, boot.InstallHostWritableDir(model)); err != nil {
+		return fmt.Errorf("cannot seed timesyncd clock: %v", err)
+	}
+
+	// configure the run system
+	opts := &sysconfig.Options{TargetRootDir: boot.InstallHostWritableDir(model), GadgetDir: gadgetDir}
+	// configure cloud init
+	setSysconfigCloudOptions(opts, gadgetDir, model)
+	// allow running this helper without perfTimings
+	if perfTimings == nil {
+		err = sysconfigConfigureTargetSystem(model, opts)
+	} else {
+		timings.Run(perfTimings, "sysconfig-configure-target-system", "Configure target system", func(timings.Measurer) {
+			err = sysconfigConfigureTargetSystem(model, opts)
+		})
+	}
+	if err != nil {
+		return err
+	}
+
+	// TODO: FIXME: this should go away after we have time to design a proper
+	//              solution
+
+	if !model.Classic() {
+		// on some specific devices, we need to create these directories in
+		// _writable_defaults in order to allow the install-device hook to install
+		// some files there, this eventually will go away when we introduce a proper
+		// mechanism not using system-files to install files onto the root
+		// filesystem from the install-device hook
+		if err := fixupWritableDefaultDirs(boot.InstallHostWritableDir(model)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func fixupWritableDefaultDirs(systemDataDir string) error {
+	// the _writable_default directory is used to put files in place on
+	// ubuntu-data from install mode, so we abuse it here for a specific device
+	// to let that device install files with system-files and the install-device
+	// hook
+
+	// eventually this will be a proper, supported, designed mechanism instead
+	// of just this hack, but this hack is just creating the directories, since
+	// the system-files interface only allows creating the file, not creating
+	// the directories leading up to that file, and since the file is deeply
+	// nested we would effectively have to give all permission to the device
+	// to create any file on ubuntu-data which we don't want to do, so we keep
+	// this restriction to let the device create one specific file, and then
+	// we behind the scenes just create the directories for the device
+
+	for _, subDirToCreate := range []string{"/etc/udev/rules.d", "/etc/modprobe.d", "/etc/modules-load.d/", "/etc/systemd/network"} {
+		dirToCreate := sysconfig.WritableDefaultsDir(systemDataDir, subDirToCreate)
+
+		if err := os.MkdirAll(dirToCreate, 0755); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// writeMarkers writes markers containing the same secret to pair data and save.
+func writeMarkers(model *asserts.Model) error {
+	// ensure directory for markers exists
+	if err := os.MkdirAll(boot.InstallHostFDEDataDir(model), 0755); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(boot.InstallHostFDESaveDir, 0755); err != nil {
+		return err
+	}
+
+	// generate a secret random marker
+	markerSecret, err := randutil.CryptoTokenBytes(32)
+	if err != nil {
+		return fmt.Errorf("cannot create ubuntu-data/save marker secret: %v", err)
+	}
+
+	return device.WriteEncryptionMarkers(boot.InstallHostFDEDataDir(model), boot.InstallHostFDESaveDir, markerSecret)
+}
+
+func saveKeys(model *asserts.Model, keyForRole map[string]keys.EncryptionKey) error {
+	saveEncryptionKey := keyForRole[gadget.SystemSave]
+	if saveEncryptionKey == nil {
+		// no system-save support
+		return nil
+	}
+	// ensure directory for keys exists
+	if err := os.MkdirAll(boot.InstallHostFDEDataDir(model), 0755); err != nil {
+		return err
+	}
+	if err := saveEncryptionKey.Save(device.SaveKeyUnder(boot.InstallHostFDEDataDir(model))); err != nil {
+		return fmt.Errorf("cannot store system save key: %v", err)
+	}
+	return nil
+}
+
+func ReadPreseedAssertion(assertDb *asserts.Database, model *asserts.Model, ubuntuSeedDir, sysLabel string) (*asserts.Preseed, error) {
+	f, err := os.Open(filepath.Join(ubuntuSeedDir, "systems", sysLabel, "preseed"))
+	if err != nil {
+		return nil, fmt.Errorf("cannot read preseed assertion: %v", err)
+	}
+
+	batch := asserts.NewBatch(nil)
+	_, err = batch.AddStream(f)
+	if err != nil {
+		return nil, err
+	}
+
+	var preseedAs *asserts.Preseed
+	err = batch.CommitToAndObserve(assertDb, func(as asserts.Assertion) {
+		if as.Type() == asserts.PreseedType {
+			preseedAs = as.(*asserts.Preseed)
+		}
+	}, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	switch {
+	case preseedAs == nil:
+		return nil, fmt.Errorf("internal error: preseed assertion file is present but preseed assertion not found")
+	case preseedAs.SystemLabel() != sysLabel:
+		return nil, fmt.Errorf("preseed assertion system label %q doesn't match system label %q", preseedAs.SystemLabel(), sysLabel)
+	case preseedAs.Model() != model.Model():
+		return nil, fmt.Errorf("preseed assertion model %q doesn't match the model %q", preseedAs.Model(), model.Model())
+	case preseedAs.BrandID() != model.BrandID():
+		return nil, fmt.Errorf("preseed assertion brand %q doesn't match model brand %q", preseedAs.BrandID(), model.BrandID())
+	case preseedAs.Series() != model.Series():
+		return nil, fmt.Errorf("preseed assertion series %q doesn't match model series %q", preseedAs.Series(), model.Series())
+	}
+
+	return preseedAs, nil
+}
+
+var seedOpen = seed.Open
+
+// TODO: consider reusing this kind of handler for UC20 seeding
+type preseedSnapHandler struct {
+	writableDir string
+}
+
+func (p *preseedSnapHandler) HandleUnassertedSnap(name, path string, _ timings.Measurer) (string, error) {
+	pinfo := snap.MinimalPlaceInfo(name, snap.Revision{N: -1})
+	targetPath := filepath.Join(p.writableDir, pinfo.MountFile())
+	mountDir := filepath.Join(p.writableDir, pinfo.MountDir())
+
+	sq := squashfs.New(path)
+	opts := &snap.InstallOptions{MustNotCrossDevices: true}
+	if _, err := sq.Install(targetPath, mountDir, opts); err != nil {
+		return "", fmt.Errorf("cannot install snap %q: %v", name, err)
+	}
+
+	return targetPath, nil
+}
+
+func (p *preseedSnapHandler) HandleAndDigestAssertedSnap(name, path string, essType snap.Type, snapRev *asserts.SnapRevision, _ func(string, uint64) (snap.Revision, error), _ timings.Measurer) (string, string, uint64, error) {
+	pinfo := snap.MinimalPlaceInfo(name, snap.Revision{N: snapRev.SnapRevision()})
+	targetPath := filepath.Join(p.writableDir, pinfo.MountFile())
+	mountDir := filepath.Join(p.writableDir, pinfo.MountDir())
+
+	logger.Debugf("copying: %q to %q; mount dir=%q", path, targetPath, mountDir)
+
+	srcFile, err := os.Open(path)
+	if err != nil {
+		return "", "", 0, err
+	}
+	defer srcFile.Close()
+
+	destFile, err := osutil.NewAtomicFile(targetPath, 0644, 0, osutil.NoChown, osutil.NoChown)
+	if err != nil {
+		return "", "", 0, fmt.Errorf("cannot create atomic file: %v", err)
+	}
+	defer destFile.Cancel()
+
+	finfo, err := srcFile.Stat()
+	if err != nil {
+		return "", "", 0, err
+	}
+
+	destFile.SetModTime(finfo.ModTime())
+
+	h := crypto.SHA3_384.New()
+	w := io.MultiWriter(h, destFile)
+
+	size, err := io.CopyBuffer(w, srcFile, make([]byte, 2*1024*1024))
+	if err != nil {
+		return "", "", 0, err
+	}
+	if err := destFile.Commit(); err != nil {
+		return "", "", 0, fmt.Errorf("cannot copy snap %q: %v", name, err)
+	}
+
+	sq := squashfs.New(targetPath)
+	opts := &snap.InstallOptions{MustNotCrossDevices: true}
+	// since Install target path is the same as source path passed to squashfs.New,
+	// Install isn't going to copy the blob, but we call it to set up mount directory etc.
+	if _, err := sq.Install(targetPath, mountDir, opts); err != nil {
+		return "", "", 0, fmt.Errorf("cannot install snap %q: %v", name, err)
+	}
+
+	sha3_384, err := asserts.EncodeDigest(crypto.SHA3_384, h.Sum(nil))
+	if err != nil {
+		return "", "", 0, fmt.Errorf("cannot encode snap %q digest: %v", path, err)
+	}
+	return targetPath, sha3_384, uint64(size), nil
+}
+
+func MaybeApplyPreseededData(model *asserts.Model, preseedAs *asserts.Preseed, preseedArtifact, ubuntuSeedDir, sysLabel, writableDir string) error {
+
+	// TODO: consider a writer that feeds the file to stdin of tar and calculates the digest at the same time.
+	sha3_384, _, err := osutil.FileDigest(preseedArtifact, crypto.SHA3_384)
+	if err != nil {
+		return fmt.Errorf("cannot calculate preseed artifact digest: %v", err)
+	}
+
+	digest, err := base64.RawURLEncoding.DecodeString(preseedAs.ArtifactSHA3_384())
+	if err != nil {
+		return fmt.Errorf("cannot decode preseed artifact digest")
+	}
+	if !bytes.Equal(sha3_384, digest) {
+		return fmt.Errorf("invalid preseed artifact digest")
+	}
+
+	logger.Noticef("apply preseed data: %q, %q", writableDir, preseedArtifact)
+	cmd := exec.Command("tar", "--extract", "--preserve-permissions", "--preserve-order", "--gunzip", "--directory", writableDir, "-f", preseedArtifact)
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	logger.Noticef("copying snaps")
+
+	deviceSeed, err := seedOpen(ubuntuSeedDir, sysLabel)
+	if err != nil {
+		return err
+	}
+	tm := timings.New(nil)
+
+	if err := deviceSeed.LoadAssertions(nil, nil); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Join(writableDir, "var/lib/snapd/snaps"), 0755); err != nil {
+		return err
+	}
+
+	n := runtime.NumCPU()
+	if n > 1 {
+		deviceSeed.SetParallelism(n)
+	}
+	snapHandler := &preseedSnapHandler{writableDir: writableDir}
+	if err := deviceSeed.LoadMeta("run", snapHandler, tm); err != nil {
+		return err
+	}
+
+	preseedSnaps := make(map[string]*asserts.PreseedSnap)
+	for _, ps := range preseedAs.Snaps() {
+		preseedSnaps[ps.Name] = ps
+	}
+
+	checkSnap := func(ssnap *seed.Snap) error {
+		ps, ok := preseedSnaps[ssnap.SnapName()]
+		if !ok {
+			return fmt.Errorf("snap %q not present in the preseed assertion", ssnap.SnapName())
+		}
+		if ps.Revision != ssnap.SideInfo.Revision.N {
+			rev := snap.Revision{N: ps.Revision}
+			return fmt.Errorf("snap %q has wrong revision %s (expected: %s)", ssnap.SnapName(), ssnap.SideInfo.Revision, rev)
+		}
+		if ps.SnapID != ssnap.SideInfo.SnapID {
+			return fmt.Errorf("snap %q has wrong snap id %q (expected: %q)", ssnap.SnapName(), ssnap.SideInfo.SnapID, ps.SnapID)
+		}
+		return nil
+	}
+
+	esnaps := deviceSeed.EssentialSnaps()
+	msnaps, err := deviceSeed.ModeSnaps("run")
+	if err != nil {
+		return err
+	}
+	if len(msnaps)+len(esnaps) != len(preseedSnaps) {
+		return fmt.Errorf("seed has %d snaps but %d snaps are required by preseed assertion", len(msnaps)+len(esnaps), len(preseedSnaps))
+	}
+
+	for _, esnap := range esnaps {
+		if err := checkSnap(esnap); err != nil {
+			return err
+		}
+	}
+
+	for _, ssnap := range msnaps {
+		if err := checkSnap(ssnap); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func RestoreDeviceFromSave(model *asserts.Model) error {
+	// we could also look at factory-reset-bootstrap.json left by
+	// snap-bootstrap, but the mount was already verified during boot
+	mounted, err := osutil.IsMounted(boot.InitramfsUbuntuSaveDir)
+	if err != nil {
+		return fmt.Errorf("cannot determine ubuntu-save mount state: %v", err)
+	}
+	if !mounted {
+		logger.Noticef("not restoring from save, ubuntu-save not mounted")
+		return nil
+	}
+	// TODO anything else we want to restore?
+	return RestoreDeviceSerialFromSave(model)
+}
+
+func RestoreDeviceSerialFromSave(model *asserts.Model) error {
+	fromDevice := filepath.Join(boot.InstallHostDeviceSaveDir)
+	logger.Debugf("looking for serial assertion and device key under %v", fromDevice)
+	fromDB, err := sysdb.OpenAt(fromDevice)
+	if err != nil {
+		return err
+	}
+	// key pair manager always uses ubuntu-save whenever it's available
+	kp, err := asserts.OpenFSKeypairManager(fromDevice)
+	if err != nil {
+		return err
+	}
+	// there should be a serial assertion for the current model
+	serials, err := fromDB.FindMany(asserts.SerialType, map[string]string{
+		"brand-id": model.BrandID(),
+		"model":    model.Model(),
+	})
+	if (err != nil && errors.Is(err, &asserts.NotFoundError{})) || len(serials) == 0 {
+		// there is no serial assertion in the old system that matches
+		// our model, it is still possible that the old system could
+		// have generated device keys and sent out a serial request, but
+		// for simplicity we ignore this scenario and a new set of keys
+		// will be generated after booting into the run system
+		logger.Debugf("no serial assertion for %v/%v", model.BrandID(), model.Model())
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	logger.Noticef("found %v serial assertions for %v/%v", len(serials), model.BrandID(), model.Model())
+
+	var serialAs *asserts.Serial
+	for _, serial := range serials {
+		maybeCurrentSerialAs := serial.(*asserts.Serial)
+		// serial assertion is signed with the device key, its ID is in the
+		// header
+		deviceKeyID := maybeCurrentSerialAs.DeviceKey().ID()
+		logger.Debugf("serial assertion device key ID: %v", deviceKeyID)
+
+		// there can be multiple serial assertions, as the device could
+		// have exercised the registration a number of times, but each
+		// time it unregisters, the old key is removed and a new one is
+		// generated
+		_, err = kp.Get(deviceKeyID)
+		if err != nil {
+			if asserts.IsKeyNotFound(err) {
+				logger.Debugf("no key with ID %v", deviceKeyID)
+				continue
+			}
+			return fmt.Errorf("cannot obtain device key: %v", err)
+		} else {
+			serialAs = maybeCurrentSerialAs
+			break
+		}
+	}
+
+	if serialAs == nil {
+		// no serial assertion that matches the model, brand and is
+		// signed with a device key that is present in the filesystem
+		logger.Debugf("no valid serial assertions")
+		return nil
+	}
+
+	logger.Debugf("found a serial assertion for %v/%v, with serial %v",
+		model.BrandID(), model.Model(), serialAs.Serial())
+
+	toDB, err := sysdb.OpenAt(filepath.Join(boot.InstallHostWritableDir(model), "var/lib/snapd/assertions"))
+	if err != nil {
+		return err
+	}
+
+	logger.Debugf("importing serial and model assertions")
+	b := asserts.NewBatch(nil)
+	err = b.Fetch(toDB,
+		func(ref *asserts.Ref) (asserts.Assertion, error) { return ref.Resolve(fromDB.Find) },
+		func(f asserts.Fetcher) error {
+			if err := f.Save(model); err != nil {
+				return err
+			}
+			return f.Save(serialAs)
+		})
+	if err != nil {
+		return fmt.Errorf("cannot fetch assertions: %v", err)
+	}
+	if err := b.CommitTo(toDB, nil); err != nil {
+		return fmt.Errorf("cannot commit assertions: %v", err)
+	}
+	return nil
+}
+
+type factoryResetMarker struct {
+	FallbackSaveKeyHash string `json:"fallback-save-key-sha3-384,omitempty"`
+}
+
+func fileDigest(p string) (string, error) {
+	digest, _, err := osutil.FileDigest(p, crypto.SHA3_384)
+	if err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(digest), nil
+}
+
+func WriteFactoryResetMarker(marker string, hasEncryption bool) error {
+	keyDigest := ""
+	if hasEncryption {
+		d, err := fileDigest(device.FactoryResetFallbackSaveSealedKeyUnder(boot.InitramfsSeedEncryptionKeyDir))
+		if err != nil {
+			return err
+		}
+		keyDigest = d
+	}
+	var buf bytes.Buffer
+	err := json.NewEncoder(&buf).Encode(factoryResetMarker{
+		FallbackSaveKeyHash: keyDigest,
+	})
+	if err != nil {
+		return err
+	}
+
+	if hasEncryption {
+		logger.Noticef("writing factory-reset marker at %v with key digest %q", marker, keyDigest)
+	} else {
+		logger.Noticef("writing factory-reset marker at %v", marker)
+	}
+	return osutil.AtomicWriteFile(marker, buf.Bytes(), 0644, 0)
+}
+
+func VerifyFactoryResetMarkerInRun(marker string, hasEncryption bool) error {
+	f, err := os.Open(marker)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	var frm factoryResetMarker
+	if err := json.NewDecoder(f).Decode(&frm); err != nil {
+		return err
+	}
+	if hasEncryption {
+		saveFallbackKeyFactory := device.FactoryResetFallbackSaveSealedKeyUnder(boot.InitramfsSeedEncryptionKeyDir)
+		d, err := fileDigest(saveFallbackKeyFactory)
+		if err != nil {
+			// possible that there was unexpected reboot
+			// before, after the key was moved, but before
+			// the marker was removed, in which case the
+			// actual fallback key should have the right
+			// digest
+			if !os.IsNotExist(err) {
+				// unless it's a different error
+				return err
+			}
+			saveFallbackKeyFactory := device.FallbackSaveSealedKeyUnder(boot.InitramfsSeedEncryptionKeyDir)
+			d, err = fileDigest(saveFallbackKeyFactory)
+			if err != nil {
+				return err
+			}
+		}
+		if d != frm.FallbackSaveKeyHash {
+			return fmt.Errorf("fallback sealed key digest mismatch, got %v expected %v", d, frm.FallbackSaveKeyHash)
+		}
+	} else {
+		if frm.FallbackSaveKeyHash != "" {
+			return fmt.Errorf("unexpected non-empty fallback key digest")
+		}
+	}
+	return nil
+}
+
+func RotateEncryptionKeys() error {
+	kd, err := ioutil.ReadFile(filepath.Join(dirs.SnapFDEDir, "ubuntu-save.key"))
+	if err != nil {
+		return fmt.Errorf("cannot open encryption key file: %v", err)
+	}
+	// does the right thing if the key has already been transitioned
+	if err := secbootTransitionEncryptionKeyChange(boot.InitramfsUbuntuSaveDir, keys.EncryptionKey(kd)); err != nil {
+		return fmt.Errorf("cannot transition the encryption key: %v", err)
+	}
+	return nil
+}
+
+func checkFDEFeatures(runSetupHook fde.RunSetupHookFunc) (et secboot.EncryptionType, err error) {
+	// Run fde-setup hook with "op":"features". If the hook
+	// returns any {"features":[...]} reply we consider the
+	// hardware supported. If the hook errors or if it returns
+	// {"error":"hardware-unsupported"} we don't.
+	features, err := fde.CheckFeatures(runSetupHook)
+	if err != nil {
+		return et, err
+	}
+	if strutil.ListContains(features, "device-setup") {
+		et = secboot.EncryptionTypeDeviceSetupHook
+	} else {
+		et = secboot.EncryptionTypeLUKS
+	}
+
+	return et, nil
+}
+
+func HasFDESetupHookInKernel(kernelInfo *snap.Info) bool {
+	_, ok := kernelInfo.Hooks["fde-setup"]
+	return ok
+}

--- a/overlord/install/systems.go
+++ b/overlord/install/systems.go
@@ -68,3 +68,27 @@ var recoverSystemActions = []SystemAction{
 	{Title: "Run normally", Mode: "run"},
 }
 
+type SeededSystem struct {
+	// System carries the recovery system label that was used to seed the
+	// current system
+	System string `json:"system"`
+	Model  string `json:"model"`
+	// BrandID is the brand account ID
+	BrandID string `json:"brand-id"`
+	// Revision of the model assertion
+	Revision int `json:"revision"`
+	// Timestamp of model assertion
+	Timestamp time.Time `json:"timestamp"`
+	// SeedTime holds the timestamp when the system was seeded
+	SeedTime time.Time `json:"seed-time"`
+}
+
+func (s *SeededSystem) SameAs(other *SeededSystem) bool {
+	// in theory the system labels are unique, however be extra paranoid and
+	// check all model related fields too
+	return s.System == other.System &&
+		s.Model == other.Model &&
+		s.BrandID == other.BrandID &&
+		s.Revision == other.Revision
+}
+

--- a/overlord/install/systems.go
+++ b/overlord/install/systems.go
@@ -34,3 +34,37 @@ func MaybeReadModeenv() (*boot.Modeenv, error) {
 	return modeenv, nil
 }
 
+type SystemAction struct {
+	Title string
+	Mode  string
+}
+
+type System struct {
+	// Current is true when the system running now was installed from that
+	// seed
+	Current bool
+	// Label of the seed system
+	Label string
+	// Model assertion of the system
+	Model *asserts.Model
+	// Brand information
+	Brand *asserts.Account
+	// Actions available for this system
+	Actions []SystemAction
+}
+
+var defaultSystemActions = []SystemAction{
+	{Title: "Install", Mode: "install"},
+}
+var currentSystemActions = []SystemAction{
+	{Title: "Reinstall", Mode: "install"},
+	{Title: "Recover", Mode: "recover"},
+	{Title: "Factory reset", Mode: "factory-reset"},
+	{Title: "Run normally", Mode: "run"},
+}
+var recoverSystemActions = []SystemAction{
+	{Title: "Reinstall", Mode: "install"},
+	{Title: "Factory reset", Mode: "factory-reset"},
+	{Title: "Run normally", Mode: "run"},
+}
+

--- a/overlord/install/systems.go
+++ b/overlord/install/systems.go
@@ -1,0 +1,36 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package install
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/snapcore/snapd/boot"
+)
+
+func MaybeReadModeenv() (*boot.Modeenv, error) {
+	modeenv, err := boot.ReadModeenv("")
+	if err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("cannot read modeenv: %v", err)
+	}
+	return modeenv, nil
+}
+

--- a/overlord/install/systems.go
+++ b/overlord/install/systems.go
@@ -22,8 +22,13 @@ package install
 import (
 	"fmt"
 	"os"
+	"time"
 
+	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/seed"
 )
 
 func MaybeReadModeenv() (*boot.Modeenv, error) {
@@ -92,3 +97,120 @@ func (s *SeededSystem) SameAs(other *SeededSystem) bool {
 		s.Revision == other.Revision
 }
 
+func SystemFromSeed(label string, current *CurrentSystem) (*System, error) {
+	_, sys, err := LoadSeedAndSystem(label, current)
+	return sys, err
+}
+
+func LoadSeedAndSystem(label string, current *CurrentSystem) (seed.Seed, *System, error) {
+	s, err := seedOpen(dirs.SnapSeedDir, label)
+	if err != nil {
+		return nil, nil, fmt.Errorf("cannot open: %v", err)
+	}
+	if err := s.LoadAssertions(nil, nil); err != nil {
+		return nil, nil, fmt.Errorf("cannot load assertions for label %q: %v", label, err)
+	}
+	// get the model
+	model := s.Model()
+	brand, err := s.Brand()
+	if err != nil {
+		return nil, nil, fmt.Errorf("cannot obtain brand: %v", err)
+	}
+	system := &System{
+		Current: false,
+		Label:   label,
+		Model:   model,
+		Brand:   brand,
+		Actions: defaultSystemActions,
+	}
+	if current.SameAs(system) {
+		system.Current = true
+		system.Actions = current.actions
+	}
+	return s, system, nil
+}
+
+type CurrentSystem struct {
+	*SeededSystem
+	actions []SystemAction
+}
+
+func (c *CurrentSystem) SameAs(other *System) bool {
+	return c != nil &&
+		c.System == other.Label &&
+		c.Model == other.Model.Model() &&
+		c.BrandID == other.Brand.AccountID()
+}
+
+func CurrentSystemForMode(st *state.State, mode string) (*CurrentSystem, error) {
+	var system *SeededSystem
+	var actions []SystemAction
+	var err error
+
+	switch mode {
+	case "run":
+		actions = currentSystemActions
+		system, err = currentSeededSystem(st)
+	case "install":
+		// there is no current system for install mode
+		return nil, nil
+	case "recover":
+		actions = recoverSystemActions
+		// recover mode uses modeenv for reference
+		system, err = seededSystemFromModeenv()
+	default:
+		return nil, fmt.Errorf("internal error: cannot identify current system for unsupported mode %q", mode)
+	}
+	if err != nil {
+		return nil, err
+	}
+	currentSys := &CurrentSystem{
+		SeededSystem: system,
+		actions:      actions,
+	}
+	return currentSys, nil
+}
+
+func currentSeededSystem(st *state.State) (*SeededSystem, error) {
+	st.Lock()
+	defer st.Unlock()
+
+	var whatseeded []SeededSystem
+	if err := st.Get("seeded-systems", &whatseeded); err != nil {
+		return nil, err
+	}
+	if len(whatseeded) == 0 {
+		// unexpected
+		return nil, state.ErrNoState
+	}
+	// seeded systems are prepended to the list, so the most recently seeded
+	// one comes first
+	return &whatseeded[0], nil
+}
+
+func seededSystemFromModeenv() (*SeededSystem, error) {
+	modeEnv, err := MaybeReadModeenv()
+	if err != nil {
+		return nil, err
+	}
+	if modeEnv == nil {
+		return nil, fmt.Errorf("internal error: modeenv does not exist")
+	}
+	if modeEnv.RecoverySystem == "" {
+		return nil, fmt.Errorf("internal error: recovery system is unset")
+	}
+
+	system, err := SystemFromSeed(modeEnv.RecoverySystem, nil)
+	if err != nil {
+		return nil, err
+	}
+	seededSys := &SeededSystem{
+		System:    modeEnv.RecoverySystem,
+		Model:     system.Model.Model(),
+		BrandID:   system.Model.BrandID(),
+		Revision:  system.Model.Revision(),
+		Timestamp: system.Model.Timestamp(),
+		// SeedTime is intentionally left unset
+	}
+	return seededSys, nil
+}


### PR DESCRIPTION
Move install related helpers from `overlord/devicestate` to the new package `overlord/install`

This will allow the future use of the install helpers from other components (e.g. `snap-bootstrap`) without need to include entire `overlord/devicestate`