### PR TITLE
tests: restart ssh service through systemd interface in google machines

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -748,6 +748,12 @@ prepare: |
             ;;
     esac
 
+    # Make sure ssh service is restarted after it is killed by spread (pkill -o -HUP sshd)
+    # during the machine setup in google systems. For more details see lp:2011458
+    if [ "$SPREAD_BACKEND" = "google" ] && command -v systemctl > /dev/null && ! systemctl is-active ssh; then
+        systemctl restart ssh
+    fi
+
     # Unpack delta, or move content out of the prefixed directory (see rename and repack above).
     # (needs to be in spread.yaml directly because there's nothing else on the filesystem yet)
     if [ -f current.delta ]; then


### PR DESCRIPTION
Make sure ssh service is restarted after it is killed by spread (pkill -o -HUP sshd) during the machine setup in google systems.

For more details see lp:2011458

This change prevents the ssh service is degraded and the test suite fails because of the tests/main/degraded test
