### PR TITLE
interfaces: allow docker-support access to apparmor.d/abi/

### DIFF
--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2018 Canonical Ltd
+ * Copyright (C) 2016-2023 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -154,6 +154,7 @@ pivot_root,
 /etc/apparmor.d/tunables/{,**} r,
 /etc/apparmor.d/abstractions/{,**} r,
 /etc/apparmor/parser.conf r,
+/etc/apparmor.d/abi/{,*} r,
 /etc/apparmor/subdomain.conf r,
 /sys/kernel/security/apparmor/.replace rw,
 /sys/kernel/security/apparmor/{,**} r,

--- a/tests/regression/lp-2011485/task.yaml
+++ b/tests/regression/lp-2011485/task.yaml
@@ -1,0 +1,39 @@
+summary: docker-support should have access to /etc/apparmor.d/abi/
+
+# This test case is only interesting on modern classic systems with
+# apparmor in enforcing mode by default
+systems: [ubuntu-2*]
+
+prepare: |
+    snap pack test-snapd-docker-support-core22-app
+    snap install --dangerous ./test-snapd-docker-support-core22-app_1_all.snap
+
+    # XXX: Not a super-realistic test but it lets us see what we are after.
+    # Real snaps in real environment must cope with lack of apparmor anyway.
+    if [ ! -d /etc/apparmor ]; then
+        mkdir /etc/apparmor
+        tests.cleanup defer rmdir /etc/apparmor
+    fi
+    if [ ! -d /etc/apparmor.d ]; then
+        mkdir /etc/apparmor.d
+        tests.cleanup defer rmdir /etc/apparmor.d
+    fi
+    if [ ! -d /etc/apparmor.d/abi ]; then
+        mkdir /etc/apparmor.d/abi
+        tests.cleanup defer rmdir /etc/apparmor.d/abi
+    fi
+    if [ ! -e /etc/apparmor.d/abi/kernel-5.4-outoftree-network ]; then
+        touch /etc/apparmor.d/abi/kernel-5.4-outoftree-network
+        tests.cleanup defer rm /etc/apparmor.d/abi/kernel-5.4-outoftree-network
+    fi
+    if [ ! -e /etc/apparmor/parser.conf ]; then
+        echo policy-features=/etc/apparmor.d/abi/kernel-5.4-outoftree-network > /etc/apparmor/parser.conf
+        tests.cleanup defer rm /etc/apparmor/parser.conf
+    fi
+
+    snap connect test-snapd-docker-support-core22-app:docker-support
+
+execute: |
+    # now connect it and verify apparmor_parser --version can load
+    # policy features file
+    test-snapd-docker-support-core22-app.test-snapd-docker-support

--- a/tests/regression/lp-2011485/test-snapd-docker-support-core22-app/bin/test-snapd-docker-support
+++ b/tests/regression/lp-2011485/test-snapd-docker-support-core22-app/bin/test-snapd-docker-support
@@ -1,0 +1,2 @@
+#!/bin/sh
+apparmor_parser --version

--- a/tests/regression/lp-2011485/test-snapd-docker-support-core22-app/meta/snap.yaml
+++ b/tests/regression/lp-2011485/test-snapd-docker-support-core22-app/meta/snap.yaml
@@ -1,0 +1,9 @@
+name: test-snapd-docker-support-core22-app
+base: core22
+version: 1
+
+apps:
+    test-snapd-docker-support:
+        command: bin/test-snapd-docker-support
+        plugs:
+            - docker-support


### PR DESCRIPTION
Allow access to apparmor.d/abi/ files, as referenced by apparmor/parser.conf on base:core20+ to allow apparmor_parser to continue to work as used by docker.
    
LP: #2011485