### PR TITLE
snapstate: fix crash in doInstall() when doing the soft checks

### DIFF
--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -725,7 +725,10 @@ func inhibitRefresh(st *state.State, snapst *SnapState, snapsup *SnapSetup, info
 		// refresh is happening now and ignore the error
 		refreshInfo := busyErr.PendingSnapRefreshInfo()
 		asyncPendingRefreshNotification(context.TODO(), userclient.New(), refreshInfo)
-		busyErr = nil
+		// important to return "nil" type here instead of
+		// setting busyErr to nil as otherwise we return a nil
+		// interface which is not the nil type
+		return nil
 	}
 
 	return busyErr

--- a/overlord/snapstate/autorefresh_test.go
+++ b/overlord/snapstate/autorefresh_test.go
@@ -1036,7 +1036,7 @@ func (s *autoRefreshTestSuite) TestInhibitRefreshRefreshesWhenOverdue(c *C) {
 	defer restore()
 
 	err := snapstate.InhibitRefresh(s.state, snapst, snapsup, info)
-	c.Assert(err, IsNil)
+	c.Assert(err == nil, Equals, true)
 	c.Check(notificationCount, Equals, 1)
 }
 


### PR DESCRIPTION
The current code will crash in doInstall() after
softCheckNothingRunningForRefresh() because the returned error if not the nil type but instead it's generated via:
```go
busyErr := &timedBusySnapError{}
...
busyErr = nil
return busyErr
```
when the application is running.

This leads to a confusing crash because the line:
```go
if err := softCheckNothingRunningForRefresh(st, snapst, snapsup, info); err != nil {
```
will execute as if `err != nil` but when accessing `err` it will crash because the err is a nil error interface type so it's like accessing the a nil pointer.

This is similar to https://github.com/snapcore/snapd/pull/12614

Fwiw, the full crash backtrace is:
```
Mär 14 10:09:37 top snapd[64660]: panic: runtime error: invalid memory address or nil pointer dereference
Mär 14 10:09:37 top snapd[64660]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x556e787d23cf]
Mär 14 10:09:37 top snapd[64660]: goroutine 42 [running]:
Mär 14 10:09:37 top snapd[64660]: github.com/snapcore/snapd/overlord/snapstate.(*timedBusySnapError).PendingSnapRefreshInfo(...)
Mär 14 10:09:37 top snapd[64660]:         /build/snapd/parts/snapd-deb/build/overlord/snapstate/autorefresh.go:671
Mär 14 10:09:37 top snapd[64660]: github.com/snapcore/snapd/overlord/snapstate.doInstall(0xc00014a0e0, 0xc002183040, 0xc007847180, 0x0, 0x0, 0x0, 0xc0029dbce0, 0x0, 0x0, 0x0)
Mär 14 10:09:37 top snapd[64660]:         /build/snapd/parts/snapd-deb/build/overlord/snapstate/snapstate.go:396 +0x39af
Mär 14 10:09:37 top snapd[64660]: github.com/snapcore/snapd/overlord/snapstate.doUpdate(0x556e7944ac40, 0xc001cca930, 0xc00014a0e0, 0x556e79bd2c20, 0x0, 0x0, 0xc0042ff640, 0x4, 0x4, 0xc006293d60, ...)
Mär 14 10:09:37 top snapd[64660]:         /build/snapd/parts/snapd-deb/build/overlord/snapstate/snapstate.go:1842 +0xd7a
Mär 14 10:09:37 top snapd[64660]: github.com/snapcore/snapd/overlord/snapstate.updateManyFiltered(0x556e7944ac40, 0xc001cca930, 0xc00014a0e0, 0x556e79bd2c20, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
Mär 14 10:09:37 top snapd[64660]:         /build/snapd/parts/snapd-deb/build/overlord/snapstate/snapstate.go:1716 +0x644
Mär 14 10:09:37 top snapd[64660]: github.com/snapcore/snapd/overlord/snapstate.AutoRefresh(0x556e7944ac40, 0xc001cca930, 0xc00014a0e0, 0x556e79bd2c20, 0x556e79285580, 0x556e79bd2c20, 0x556e7944ac40, 0xc001cca930, 0xc0000d2110)
Mär 14 10:09:37 top snapd[64660]:         /build/snapd/parts/snapd-deb/build/overlord/snapstate/snapstate.go:2490 +0x296
Mär 14 10:09:37 top snapd[64660]: github.com/snapcore/snapd/overlord/snapstate.(*autoRefresh).launchAutoRefresh(0xc0001f91d0, 0xc0fc2c5408199100, 0x0, 0x0)
Mär 14 10:09:37 top snapd[64660]:         /build/snapd/parts/snapd-deb/build/overlord/snapstate/autorefresh.go:567 +0x2a3
Mär 14 10:09:37 top snapd[64660]: github.com/snapcore/snapd/overlord/snapstate.(*autoRefresh).Ensure(0xc0001f91d0, 0x0, 0x0)
Mär 14 10:09:37 top snapd[64660]:         /build/snapd/parts/snapd-deb/build/overlord/snapstate/autorefresh.go:385 +0x91f
Mär 14 10:09:37 top snapd[64660]: github.com/snapcore/snapd/overlord/snapstate.(*SnapManager).Ensure(0xc001636140, 0x0, 0x0)
Mär 14 10:09:37 top snapd[64660]:         /build/snapd/parts/snapd-deb/build/overlord/snapstate/snapmgr.go:1151 +0x11b
Mär 14 10:09:37 top snapd[64660]: github.com/snapcore/snapd/overlord.(*StateEngine).Ensure(0xc0016230e0, 0x0, 0x0)
Mär 14 10:09:37 top snapd[64660]:         /build/snapd/parts/snapd-deb/build/overlord/stateengine.go:147 +0x11e
Mär 14 10:09:37 top snapd[64660]: github.com/snapcore/snapd/overlord.(*Overlord).Loop.func1(0x556e77fee725, 0xc0016492c0)
Mär 14 10:09:37 top snapd[64660]:         /build/snapd/parts/snapd-deb/build/overlord/overlord.go:464 +0x64
Mär 14 10:09:37 top snapd[64660]: gopkg.in/tomb%2ev2.(*Tomb).run(0xc0005ec4b0, 0xc0009a5940)
Mär 14 10:09:37 top snapd[64660]:         /build/snapd/parts/snapd-deb/build/vendor/gopkg.in/tomb.v2/tomb.go:163 +0x2d
Mär 14 10:09:37 top snapd[64660]: created by gopkg.in/tomb%2ev2.(*Tomb).Go
Mär 14 10:09:37 top snapd[64660]:         /build/snapd/parts/snapd-deb/build/vendor/gopkg.in/tomb.v2/tomb.go:159 +0xc9
```
