### PR TITLE
testutil: add checker for nil typed and valued vars

### DIFF
--- a/testutil/errorischecker_test.go
+++ b/testutil/errorischecker_test.go
@@ -69,5 +69,4 @@ func (*errorIsCheckerSuite) TestErrorIsWithInvalidArguments(c *C) {
 	res, errMsg = ErrorIs.Check([]interface{}{errors.New(""), ""}, []string{"error", "target"})
 	c.Assert(res, Equals, false)
 	c.Assert(errMsg, Equals, "second argument must be an error")
-
 }

--- a/testutil/interfacenilchecker.go
+++ b/testutil/interfacenilchecker.go
@@ -1,0 +1,44 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package testutil
+
+import (
+	"fmt"
+	"reflect"
+
+	"gopkg.in/check.v1"
+)
+
+// IsInterfaceNil checks that the value is a nil interface value (<nil>).
+var IsInterfaceNil = &interfaceNilChecker{
+	&check.CheckerInfo{Name: "IsInterfaceNil", Params: []string{"value"}},
+}
+
+type interfaceNilChecker struct {
+	*check.CheckerInfo
+}
+
+func (*interfaceNilChecker) Check(params []interface{}, names []string) (result bool, errMsg string) {
+	if reflect.ValueOf(params[0]).IsValid() {
+		return false, fmt.Sprintf("expected <nil> but got %T type", params[0])
+	}
+
+	return true, ""
+}

--- a/testutil/interfacenilchecker_test.go
+++ b/testutil/interfacenilchecker_test.go
@@ -1,0 +1,67 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package testutil_test
+
+import (
+	. "github.com/snapcore/snapd/testutil"
+
+	. "gopkg.in/check.v1"
+)
+
+type interfaceNilCheckerSuite struct{}
+
+var _ = Suite(&interfaceNilCheckerSuite{})
+
+type someError struct{}
+
+func (*someError) Error() string { return "" }
+
+func (*interfaceNilCheckerSuite) TestIsInterfaceNilMatchesIntendedNilComparison(c *C) {
+	testInfo(c, IsInterfaceNil, "IsInterfaceNil", []string{"value"})
+
+	err1 := func() error {
+		return nil
+	}()
+	c.Assert(err1 == nil, Equals, true)
+	c.Assert(err1, IsInterfaceNil)
+
+	err2 := func() error {
+		var err error
+		return err
+	}()
+	c.Assert(err2 == nil, Equals, true)
+	c.Assert(err2, IsInterfaceNil)
+
+	// assigning nil to a typed variable and then returning it fails the '== nil' check
+	err3 := typedErrWithNilValue()
+	c.Assert(err3 == nil, Equals, false)
+	res, errMsg := IsInterfaceNil.Check([]interface{}{err3}, []string{"value"})
+	c.Assert(res, Equals, false)
+	c.Assert(errMsg, Equals, "expected <nil> but got *testutil_test.someError type")
+}
+
+// returns an error with a *someError type but nil value
+func typedErrWithNilValue() error {
+	err := &someError{}
+	// prevent inefassign from complaining
+	_ = err
+	err = nil
+	return err
+}


### PR DESCRIPTION
Add an IsStrictNil checker that ensures that both a variable's type and value are nil. This is useful to prevent returned errors with non-nil types from being compared to a nil value with a nil type (since the compiler can't tell that the other variable is not nil typed), resulting in the check failing.