### PR TITLE
interfaces/builtin: allow mount-control functionfs specific options

### DIFF
--- a/interfaces/builtin/mount_control.go
+++ b/interfaces/builtin/mount_control.go
@@ -201,6 +201,14 @@ type MountInfo struct {
 	options    []string
 }
 
+func (mi *MountInfo) isType(typ string) bool {
+	return len(mi.types) == 1 && mi.types[0] == typ
+}
+
+func (mi *MountInfo) hasType() bool {
+	return len(mi.types) > 0
+}
+
 func parseStringList(mountEntry map[string]interface{}, fieldName string) ([]string, error) {
 	var list []string
 	value, ok := mountEntry[fieldName]
@@ -272,16 +280,22 @@ func enumerateMounts(plug interfaces.Attrer, fn func(mountInfo *MountInfo) error
 	return nil
 }
 
+func validateNoAppArmorRegexpWithError(errPrefix string, strList ...string) error {
+	for _, str := range strList {
+		if err := apparmor_sandbox.ValidateNoAppArmorRegexp(str); err != nil {
+			return fmt.Errorf(errPrefix+`: %w`, err)
+		}
+	}
+	return nil
+}
+
 func validateWhatAttr(mountInfo *MountInfo) error {
 	what := mountInfo.what
 
 	// with "functionfs" the "what" can essentially be anything, see
 	// https://www.kernel.org/doc/html/latest/usb/functionfs.html
-	if len(mountInfo.types) == 1 && mountInfo.types[0] == "functionfs" {
-		if err := apparmor_sandbox.ValidateNoAppArmorRegexp(what); err != nil {
-			return fmt.Errorf(`cannot use mount-control "what" attribute: %w`, err)
-		}
-		return nil
+	if mountInfo.isType("functionfs") {
+		return validateNoAppArmorRegexpWithError(`cannot use mount-control "what" attribute`, what)
 	}
 
 	if !whatRegexp.MatchString(what) {
@@ -296,8 +310,8 @@ func validateWhatAttr(mountInfo *MountInfo) error {
 		return fmt.Errorf(`mount-control "what" setting cannot be used: %v`, err)
 	}
 
-	// "what" must be set to "none" if the type is "tmpfs"
-	isTmpfs := len(mountInfo.types) == 1 && mountInfo.types[0] == "tmpfs"
+	// "what" must be set to "none" iff the type is "tmpfs"
+	isTmpfs := mountInfo.isType("tmpfs")
 	if mountInfo.what == "none" {
 		if !isTmpfs {
 			return errors.New(`mount-control "what" attribute can be "none" only with "tmpfs"`)
@@ -349,7 +363,12 @@ func validateMountOptions(mountInfo *MountInfo) error {
 	if len(mountInfo.options) == 0 {
 		return errors.New(`mount-control "options" cannot be empty`)
 	}
-	if !(len(mountInfo.types) == 1 && mountInfo.types[0] == "functionfs") {
+	// With "functionfs" none of the valid "options" can be harmful so no need to check against allowedMountOptions
+	if mountInfo.isType("functionfs") {
+		if err := validateNoAppArmorRegexpWithError(`cannot use mount-control "option" attribute`, mountInfo.options...); err != nil {
+			return err
+		}
+	} else {
 		for _, o := range mountInfo.options {
 			if !strutil.ListContains(allowedMountOptions, o) {
 				return fmt.Errorf(`mount-control option unrecognized or forbidden: %q`, o)
@@ -357,7 +376,7 @@ func validateMountOptions(mountInfo *MountInfo) error {
 		}
 	}
 	fsExclusiveOption := optionIncompatibleWithFsType(mountInfo.options)
-	if fsExclusiveOption != "" && len(mountInfo.types) > 0 {
+	if fsExclusiveOption != "" && mountInfo.hasType() {
 		return fmt.Errorf(`mount-control option %q is incompatible with specifying filesystem type`, fsExclusiveOption)
 	}
 	return nil
@@ -471,7 +490,7 @@ func (iface *mountControlInterface) AppArmorConnectedPlug(spec *apparmor.Specifi
 			typeRule = ""
 		} else {
 			var types []string
-			if len(mountInfo.types) > 0 {
+			if mountInfo.hasType() {
 				types = mountInfo.types
 			} else {
 				types = defaultFSTypes

--- a/interfaces/builtin/mount_control.go
+++ b/interfaces/builtin/mount_control.go
@@ -97,14 +97,19 @@ var allowedMountOptions = []string{
 // options.
 var optionsWithoutFsType = []string{
 	"bind",
-	// Note: the following flags should also fall into this list, but we are
-	// not currently allowing them (and don't plan to):
-	// - "make-private"
-	// - "make-shared"
-	// - "make-slave"
-	// - "make-unbindable"
-	// - "move"
-	// - "remount"
+	// The following flags are only relevant to filesystem type "functionfs", in which case options
+	// are not validated against allowedMountOptions.
+	"rbind",
+	"move",
+	"remount",
+	"make-private",
+	"make-shared",
+	"make-slave",
+	"make-unbindable",
+	"make-rshared",
+	"make-rslave",
+	"make-rprivate",
+	"make-runbindable",
 }
 
 // List of filesystem types to allow if the plug declaration does not

--- a/interfaces/builtin/mount_control_test.go
+++ b/interfaces/builtin/mount_control_test.go
@@ -233,8 +233,8 @@ func (s *MountControlInterfaceSuite) TestSanitizePlugUnhappy(c *C) {
 			`mount-control option "bind" is incompatible with specifying filesystem type`,
 		},
 		{
-			"mount:\n  - what: diag\n    where: /dev/ffs-diag\n    type: [functionfs]\n    options: [rw,bind]",
-			`mount-control option "bind" is incompatible with specifying filesystem type`,
+			"mount:\n  - what: diag\n    where: /dev/ffs-diag\n    type: [functionfs]\n    options: [rw,make-private]",
+			`mount-control option "make-private" is incompatible with specifying filesystem type`,
 		},
 		{
 			"mount:\n  - what: /tmp/..\n    where: /media/*",

--- a/interfaces/builtin/mount_control_test.go
+++ b/interfaces/builtin/mount_control_test.go
@@ -233,6 +233,10 @@ func (s *MountControlInterfaceSuite) TestSanitizePlugUnhappy(c *C) {
 			`mount-control option "bind" is incompatible with specifying filesystem type`,
 		},
 		{
+			"mount:\n  - what: diag\n    where: /dev/ffs-diag\n    type: [functionfs]\n    options: [rw,bind]",
+			`mount-control option "bind" is incompatible with specifying filesystem type`,
+		},
+		{
 			"mount:\n  - what: /tmp/..\n    where: /media/*",
 			`mount-control "what" pattern is not clean:.*`,
 		},
@@ -263,6 +267,10 @@ func (s *MountControlInterfaceSuite) TestSanitizePlugUnhappy(c *C) {
 		{
 			"mount:\n  - what: a?\n    where: /dev/ffs-diag\n    type: [functionfs]\n    options: [rw]",
 			`cannot use mount-control "what" attribute: "a\?" contains a reserved apparmor char from.*`,
+		},
+		{
+			"mount:\n  - what: diag\n    where: /dev/ffs-diag\n    type: [functionfs]\n    options: [rw,uid=*]",
+			`cannot use mount-control "option" attribute: "uid=\*" contains a reserved apparmor char from.*`,
 		},
 	}
 

--- a/interfaces/builtin/mount_control_test.go
+++ b/interfaces/builtin/mount_control_test.go
@@ -233,6 +233,10 @@ func (s *MountControlInterfaceSuite) TestSanitizePlugUnhappy(c *C) {
 			`mount-control option "bind" is incompatible with specifying filesystem type`,
 		},
 		{
+			"mount:\n  - what: diag\n    where: /dev/ffs-diag\n    type: [functionfs]\n    options: [rw,bind]",
+			`mount-control option "bind" is incompatible with specifying filesystem type`,
+		},
+		{
 			"mount:\n  - what: diag\n    where: /dev/ffs-diag\n    type: [functionfs]\n    options: [rw,make-private]",
 			`mount-control option "make-private" is incompatible with specifying filesystem type`,
 		},

--- a/interfaces/builtin/mount_control_test.go
+++ b/interfaces/builtin/mount_control_test.go
@@ -334,7 +334,7 @@ func (s *MountControlInterfaceSuite) TestFunctionfsValidates(c *C) {
     what: diag
     where: /dev/ffs-diag
     type: [functionfs]
-    options: [rw]
+    options: [rw, uid=2000, gid=2000, rmode=0550, fmode=0660, no_disconnect=1]
 `
 	snapYaml := fmt.Sprintf(mountControlYaml, plugYaml)
 	plug, _ := MockConnectedPlug(c, snapYaml, nil, "mntctl")


### PR DESCRIPTION
These changes builds on [PR-12559](https://github.com/snapcore/snapd/pull/12559) to enable using functionfs with the mount-control interface.

Currently a mount-control functionfs use case requires functionfs to be used with options such as:
```what: diag
where: /dev/ffs-diag
type: [functionfs]
options: [uid=2000, gid=2000, rmode=0550, fmode=0660, no_disconnect=1]
```
results in error message `... mount-control option unrecognized or forbidden: "uid=2000"`

This change allows the use of all functionfs specific options when the filesystem type is functionfs only.