### PR TITLE
osutil: do not change "-" and "_" in kcmdline parseArgument()

### DIFF
--- a/gadget/kcmdline_test.go
+++ b/gadget/kcmdline_test.go
@@ -34,7 +34,7 @@ kernel-cmdline:
     - par1
     - par2=val
     - par3=*
-    - par-4=val_1-2
+    - par_4=val_1-2
     - par5="foo bar"
 `
 	tests := []struct {

--- a/osutil/kcmdline.go
+++ b/osutil/kcmdline.go
@@ -338,10 +338,6 @@ func parseArgument(args []byte) (argument KernelArgument, end int) {
 	}
 
 	param = string(args[startArg : endParam-subsParam])
-
-	// Hyphens (dashes) and underscores are equivalent in parameter names,
-	// so we standardize in "_".
-	param = strings.ReplaceAll(param, "-", "_")
 	argument = KernelArgument{Param: param, Value: val, Quoted: quoted}
 	return argument, end
 }

--- a/osutil/kcmdline_test.go
+++ b/osutil/kcmdline_test.go
@@ -229,8 +229,10 @@ func (s *kcmdlineTestSuite) TestKernelParseCommandLine(c *C) {
 			{"foo", "bar", true}, {"foo", "bar", true}}},
 		{cmd: `foo=* baz=bar`, exp: []osutil.KernelArgument{
 			{"foo", "*", false}, {"baz", "bar", false}}},
+		{cmd: `foo-dev-mode`, exp: []osutil.KernelArgument{
+			{"foo-dev-mode", "", false}}},
 		{cmd: `foo_bar-tee=bar_aa-bb`, exp: []osutil.KernelArgument{
-			{"foo_bar_tee", "bar_aa-bb", false}}},
+			{"foo_bar-tee", "bar_aa-bb", false}}},
 		{cmd: `foo="1$2"`, exp: []osutil.KernelArgument{{"foo", "1$2", true}}},
 		{cmd: `foo=1$2`, exp: []osutil.KernelArgument{{"foo", "1$2", false}}},
 		{cmd: `foo= bar`, exp: []osutil.KernelArgument{{"foo", "", false}, {"bar", "", false}}},

--- a/tests/nested/manual/fde-on-classic/task.yaml
+++ b/tests/nested/manual/fde-on-classic/task.yaml
@@ -27,6 +27,7 @@ prepare: |
       - append.val=*
       - append.flag
       - other.val=foo
+      - some-value
   EOF
   snap pack --filename=pc_x1.snap pc-gadget
 
@@ -140,7 +141,7 @@ execute: |
   done
 
   # Test appending values to the kernel command line
-  append_kernel_cmdline system.kernel.cmdline-append "append.val=1 append.flag other.val=foo"
+  append_kernel_cmdline system.kernel.cmdline-append "append.val=1 append.flag other.val=foo some-value"
   append_kernel_cmdline system.kernel.cmdline-append ""
   append_kernel_cmdline system.kernel.dangerous-cmdline-append "dang.val=1 dang.flag"
   append_kernel_cmdline system.kernel.dangerous-cmdline-append ""


### PR DESCRIPTION
The current code in kcmdline.go:parseArgumen() will "stanardize" parameters that have "-" to "_". While this is fine for kernel parameters it's breaking use-cases where the kernel commandline is used to transmit information to user-space. One example is the "dhc-dev-mode" option that is used by some systems.

It also means that the allow rules in the gadget must be explicit, i.e. "foo_bar" and "foo-bar" but I think that is reaonable.