### PR TITLE
asserts: add ResolveUnknown method to asserts.AtSequence

### DIFF
--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -498,6 +498,15 @@ func (at *AtSequence) Resolve(find func(assertType *AssertionType, headers map[s
 	return find(at.Type, headers)
 }
 
+// ResolveLatest resolves the latest sequence for sequence forming assertion reference
+func (at *AtSequence) ResolveLatest(find func(assertType *AssertionType, sequenceHeaders map[string]string, after, maxFormat int) (SequenceMember, error)) (Assertion, error) {
+	headers, err := HeadersFromSequenceKey(at.Type, at.SequenceKey)
+	if err != nil {
+		return nil, fmt.Errorf("%q assertion reference sequence key %v is invalid: %v", at.Type.Name, at.SequenceKey, err)
+	}
+	return find(at.Type, headers, -1, at.Type.MaxSupportedFormat())
+}
+
 // Assertion represents an assertion through its general elements.
 type Assertion interface {
 	// Type returns the type of this assertion

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -498,8 +498,9 @@ func (at *AtSequence) Resolve(find func(assertType *AssertionType, headers map[s
 	return find(at.Type, headers)
 }
 
-// ResolveLatest resolves the latest sequence for sequence forming assertion reference
-func (at *AtSequence) ResolveLatest(find func(assertType *AssertionType, sequenceHeaders map[string]string, after, maxFormat int) (SequenceMember, error)) (Assertion, error) {
+// ResolveUnknown resolves the assertion at an unknown sequence point. This will return the highest
+// sequence point of the assertion.
+func (at *AtSequence) ResolveUnknown(find func(assertType *AssertionType, sequenceHeaders map[string]string, after, maxFormat int) (SequenceMember, error)) (Assertion, error) {
 	headers, err := HeadersFromSequenceKey(at.Type, at.SequenceKey)
 	if err != nil {
 		return nil, fmt.Errorf("%q assertion reference sequence key %v is invalid: %v", at.Type.Name, at.SequenceKey, err)

--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -1340,23 +1340,23 @@ func (as *assertsSuite) TestAtSequenceResolve(c *C) {
 	c.Check(a.Type().Name, Equals, "test-only-seq")
 }
 
-func (as *assertsSuite) TestAtSequenceResolveLatestKeyError(c *C) {
+func (as *assertsSuite) TestAtSequenceResolveUnknownKeyError(c *C) {
 	atSeq := asserts.AtSequence{
 		Type:        asserts.ValidationSetType,
 		SequenceKey: []string{"abc"},
 		Sequence:    1,
 	}
-	_, err := atSeq.ResolveLatest(nil)
+	_, err := atSeq.ResolveUnknown(nil)
 	c.Check(err, ErrorMatches, `"validation-set" assertion reference sequence key \[abc\] is invalid: sequence key has wrong length for "validation-set" assertion`)
 }
 
-func (as *assertsSuite) TestAtSequenceResolveLatest(c *C) {
+func (as *assertsSuite) TestAtSequenceResolveUnknown(c *C) {
 	atSeq := asserts.AtSequence{
 		Type:        asserts.TestOnlySeqType,
 		SequenceKey: []string{"foo"},
 		Sequence:    -1,
 	}
-	a, err := atSeq.ResolveLatest(func(atype *asserts.AssertionType, hdrs map[string]string, after, maxFormat int) (asserts.SequenceMember, error) {
+	a, err := atSeq.ResolveUnknown(func(atype *asserts.AssertionType, hdrs map[string]string, after, maxFormat int) (asserts.SequenceMember, error) {
 		c.Assert(atype, Equals, asserts.TestOnlySeqType)
 		c.Assert(hdrs, DeepEquals, map[string]string{
 			"n": "foo",


### PR DESCRIPTION
*WIP*


This PR helps support the use-case of fetching assertions at an unknown sequence. Currently AtSeq already has one `Resolve` method, however this can only be used for resolving assertions at a known sequence point.

It's needed to fetch validation-sets using the assertions fetcher.