### PR TITLE
many: enforce quiet boot when requested

### DIFF
--- a/cmd/snap-bootstrap/main.go
+++ b/cmd/snap-bootstrap/main.go
@@ -39,13 +39,6 @@ such as initramfs.
 	commandBuilders []func(*flags.Parser)
 )
 
-func init() {
-	err := logger.SimpleSetup()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "WARNING: failed to activate logging: %s\n", err)
-	}
-}
-
 func main() {
 	err := run(os.Args[1:])
 	if err != nil {
@@ -58,7 +51,7 @@ func run(args []string) error {
 	if os.Getuid() != 0 {
 		return fmt.Errorf("please run as root")
 	}
-	logger.SimpleSetup()
+	logger.BootSetup()
 	return parseArgs(args)
 }
 

--- a/logger/export_test.go
+++ b/logger/export_test.go
@@ -41,6 +41,12 @@ func GetLoggerFlags() int {
 	return log.log.Flags()
 }
 
+func GetQuiet() bool {
+	log := GetLogger().(*Log)
+
+	return log.quiet
+}
+
 func ProcCmdlineMustMock(new bool) (restore func()) {
 	old := procCmdlineUseDefaultMockInTests
 	procCmdlineUseDefaultMockInTests = new

--- a/osutil/kcmdline.go
+++ b/osutil/kcmdline.go
@@ -176,30 +176,25 @@ func KernelCommandLineSplit(s string) (out []string, err error) {
 }
 
 // KernelCommandLineKeyValues returns a map of the specified keys to the values
-// set for them in the kernel command line (eg. panic=-1). If the value is
-// missing from the kernel command line or it has no value (eg. quiet), the key
-// is omitted from the returned map.
+// set for them in the kernel command line (eg. panic=-1). If the key is missing
+// from the kernel command line, it is omitted from the returned map, but it is
+// added if present even if it has no value.
 func KernelCommandLineKeyValues(keys ...string) (map[string]string, error) {
 	cmdline, err := KernelCommandLine()
 	if err != nil {
 		return nil, err
 	}
-	params, err := KernelCommandLineSplit(cmdline)
-	if err != nil {
-		return nil, err
-	}
 
+	parsed := ParseKernelCommandline(cmdline)
 	m := make(map[string]string, len(keys))
 
-	for _, param := range params {
+	for _, arg := range parsed {
 		for _, key := range keys {
-			if strings.HasPrefix(param, fmt.Sprintf("%s=", key)) {
-				res := strings.SplitN(param, "=", 2)
-				// we have confirmed key= prefix, thus len(res)
-				// is always 2
-				m[key] = res[1]
-				break
+			if arg.Param != key {
+				continue
 			}
+			m[key] = arg.Value
+			break
 		}
 	}
 	return m, nil

--- a/osutil/kcmdline_test.go
+++ b/osutil/kcmdline_test.go
@@ -112,6 +112,9 @@ func (s *kcmdlineTestSuite) TestGetKernelCommandLineKeyValue(c *C) {
 			cmdline: "foo",
 			comment: "cmdline non-key-value",
 			keys:    []string{"foo"},
+			exp: map[string]string{
+				"foo": "",
+			},
 		},
 		{
 			cmdline: "foo=1",
@@ -151,7 +154,7 @@ func (s *kcmdlineTestSuite) TestGetKernelCommandLineKeyValue(c *C) {
 			comment: "cmdline key-value pair and non-key-value",
 			keys:    []string{"foo"},
 			exp: map[string]string{
-				"foo": "1",
+				"foo": "",
 			},
 		},
 		{
@@ -166,13 +169,14 @@ func (s *kcmdlineTestSuite) TestGetKernelCommandLineKeyValue(c *C) {
 			cmdline: "=foo",
 			comment: "missing key",
 			keys:    []string{"foo"},
-			err:     "unexpected assignment",
 		},
 		{
 			cmdline: `"foo`,
 			comment: "invalid kernel cmdline",
 			keys:    []string{"foo"},
-			err:     "unexpected quoting",
+			exp: map[string]string{
+				"foo": "",
+			},
 		},
 	} {
 		cmdlineFile := filepath.Join(c.MkDir(), "cmdline")


### PR DESCRIPTION
Avoid printing anything from snap-bootstrap if "quiet" is present in the kernel command line. This prevents flickering that might happen otherwise in the splash screen.