### PR TITLE
image,store: introduce AssertionSequenceFormingFetcher in ToolingStore

### DIFF
--- a/image/image_test.go
+++ b/image/image_test.go
@@ -222,6 +222,12 @@ func (s *imageSuite) Assertion(assertType *asserts.AssertionType, primaryKey []s
 
 }
 
+// TODO: Implement this once we add support in writer for validation sets,
+// until then it should not be called.
+func (s *imageSuite) SeqFormingAssertion(assertType *asserts.AssertionType, sequenceKey []string, sequence int, user *auth.UserState) (asserts.Assertion, error) {
+	panic("not expected")
+}
+
 // TODO: use seedtest.SampleSnapYaml for some of these
 const packageGadget = `
 name: pc

--- a/image/preseed/preseed_uc20_test.go
+++ b/image/preseed/preseed_uc20_test.go
@@ -78,6 +78,10 @@ func (s *toolingStore) Assertion(assertType *asserts.AssertionType, primaryKey [
 	return as, nil
 }
 
+func (s *toolingStore) SeqFormingAssertion(assertType *asserts.AssertionType, sequenceKey []string, sequence int, user *auth.UserState) (asserts.Assertion, error) {
+	panic("not expected")
+}
+
 func (s *toolingStore) SetAssertionMaxFormats(maxFormats map[string]int) {
 	panic("not implemented")
 }

--- a/store/tooling/tooling.go
+++ b/store/tooling/tooling.go
@@ -363,8 +363,8 @@ func (tsto *ToolingStore) DownloadMany(toDownload []SnapToDownload, curSnaps []*
 	return downloadedSnaps, nil
 }
 
-// AssertionFetcher creates an asserts.Fetcher for assertions using dlOpts for authorization,
-// the fetcher will add assertions in the given database and after that also call save for each of them.
+// AssertionFetcher creates an asserts.Fetcher for assertions, the fetcher will
+// add assertions in the given database and after that also call save for each of them.
 func (tsto *ToolingStore) AssertionFetcher(db *asserts.Database, save func(asserts.Assertion) error) asserts.Fetcher {
 	retrieve := func(ref *asserts.Ref) (asserts.Assertion, error) {
 		return tsto.sto.Assertion(ref.Type, ref.PrimaryKey, nil)
@@ -384,8 +384,8 @@ func (tsto *ToolingStore) AssertionFetcher(db *asserts.Database, save func(asser
 }
 
 // AssertionSequenceFormingFetcher creates an asserts.SequenceFormingFetcher for
-// fetching assertions using dlOpts for authorization. The fetcher will then store
-// the fetched assertions in the given db and call save for each of them.
+// fetching assertions. The fetcher will then store the fetched assertions in the
+// given db and call save for each of them.
 func (tsto *ToolingStore) AssertionSequenceFormingFetcher(db *asserts.Database, save func(asserts.Assertion) error) asserts.SequenceFormingFetcher {
 	retrieve := func(ref *asserts.Ref) (asserts.Assertion, error) {
 		return tsto.sto.Assertion(ref.Type, ref.PrimaryKey, nil)

--- a/store/tooling/tooling.go
+++ b/store/tooling/tooling.go
@@ -67,6 +67,12 @@ type StoreImpl interface {
 	// Assertion retrieves the assertion for the given type and primary key.
 	Assertion(assertType *asserts.AssertionType, primaryKey []string, user *auth.UserState) (asserts.Assertion, error)
 
+	// SeqFormingAssertion retrieves the sequence-forming assertion for the given
+	// type (currently validation-set only). For sequence <= 0 we query for the
+	// latest sequence, otherwise the latest revision of the given sequence is
+	// requested.
+	SeqFormingAssertion(assertType *asserts.AssertionType, sequenceKey []string, sequence int, user *auth.UserState) (asserts.Assertion, error)
+
 	// SetAssertionMaxFormats sets the assertion max formats to send.
 	SetAssertionMaxFormats(maxFormats map[string]int)
 }
@@ -357,10 +363,14 @@ func (tsto *ToolingStore) DownloadMany(toDownload []SnapToDownload, curSnaps []*
 	return downloadedSnaps, nil
 }
 
-// AssertionFetcher creates an asserts.Fetcher for assertions using dlOpts for authorization, the fetcher will add assertions in the given database and after that also call save for each of them.
-func (tsto *ToolingStore) AssertionFetcher(db *asserts.Database, save func(asserts.Assertion) error) asserts.Fetcher {
+// AssertionFetcher creates an asserts.Fetcher for assertions using dlOpts for authorization,
+// the fetcher will add assertions in the given database and after that also call save for each of them.
+func (tsto *ToolingStore) AssertionFetcher(db *asserts.Database, save func(asserts.Assertion) error) asserts.SequenceFormingFetcher {
 	retrieve := func(ref *asserts.Ref) (asserts.Assertion, error) {
 		return tsto.sto.Assertion(ref.Type, ref.PrimaryKey, nil)
+	}
+	retrieveSeq := func(seq *asserts.AtSequence) (asserts.Assertion, error) {
+		return tsto.sto.SeqFormingAssertion(seq.Type, seq.SequenceKey, seq.Sequence, nil)
 	}
 	save2 := func(a asserts.Assertion) error {
 		// for checking
@@ -373,7 +383,7 @@ func (tsto *ToolingStore) AssertionFetcher(db *asserts.Database, save func(asser
 		}
 		return save(a)
 	}
-	return asserts.NewFetcher(db, retrieve, save2)
+	return asserts.NewSequenceFormingFetcher(db, retrieve, retrieveSeq, save2)
 }
 
 // Find provides the snapsserts.Finder interface for snapasserts.DerviceSideInfo

--- a/store/tooling/tooling_test.go
+++ b/store/tooling/tooling_test.go
@@ -462,6 +462,16 @@ func (s *toolingSuite) Assertion(assertType *asserts.AssertionType, primaryKey [
 	return ref.Resolve(s.StoreSigning.Find)
 }
 
+func (s *toolingSuite) SeqFormingAssertion(assertType *asserts.AssertionType, sequenceKey []string, sequence int, user *auth.UserState) (asserts.Assertion, error) {
+	seq := &asserts.AtSequence{
+		Type:        assertType,
+		SequenceKey: sequenceKey,
+		Sequence:    sequence,
+		Revision:    asserts.RevisionNotKnown,
+	}
+	return seq.Resolve(s.StoreSigning.Find)
+}
+
 func (s *toolingSuite) TestUpdateUserAuth(c *C) {
 	u := auth.UserState{
 		StoreMacaroon:   "macaroon",

--- a/store/tooling/tooling_test.go
+++ b/store/tooling/tooling_test.go
@@ -465,7 +465,7 @@ func (s *toolingSuite) Assertion(assertType *asserts.AssertionType, primaryKey [
 
 func (s *toolingSuite) SeqFormingAssertion(assertType *asserts.AssertionType, sequenceKey []string, sequence int, user *auth.UserState) (asserts.Assertion, error) {
 	if sequence <= 0 {
-		panic("unexpected call to SeqFormingAssertion with unknown sequence")
+		panic("unexpected call to SeqFormingAssertion with unspecified sequence")
 	}
 
 	seq := &asserts.AtSequence{


### PR DESCRIPTION
Needed as as part of introducing support for validation-sets in seedwriter. This exposes `SeqFormingAssertion` in ToolingStore to retrieve sequence forming assertions, and we then introduce `AssertionSequenceFormingFetcher` to use this.