### PR TITLE
secboot: use experimental mvo5/secboot:uc22-sbat-workaround branch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 // maze.io/x/crypto/afis imported by github.com/snapcore/secboot/tpm2
 replace maze.io/x/crypto => github.com/snapcore/maze.io-x-crypto v0.0.0-20190131090603-9b94c9afe066
 
-replace github.com/snapcore/secboot => github.com/mvo5/secboot v0.0.0-20230322150747-be05cfb11b02
+replace github.com/snapcore/secboot => github.com/mvo5/secboot v0.0.0-20230323100326-6c7289eea31f
 
 require (
 	github.com/canonical/go-efilib v0.3.1-0.20220815143333-7e5151412e93 // indirect

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,8 @@ github.com/mvo5/goconfigparser v0.0.0-20200803085309-72e476556adb h1:1I/JqsB+Fff
 github.com/mvo5/goconfigparser v0.0.0-20200803085309-72e476556adb/go.mod h1:xmt4k1xLDl8Tdan+0S/jmMK2uSUBSzTc18+5GN5Vea8=
 github.com/mvo5/libseccomp-golang v0.9.1-0.20180308152521-f4de83b52afb h1:+u5VeqU0Lm7ESN1mS0WONqKRScw7WpPYYtr3zmqEFQ0=
 github.com/mvo5/libseccomp-golang v0.9.1-0.20180308152521-f4de83b52afb/go.mod h1:RduRpSkQHOCvZTbGgT/NJUGjFBFkYlVedimxssQ64ag=
-github.com/mvo5/secboot v0.0.0-20230322150747-be05cfb11b02 h1:zl7ihuO01+lJik8C9ovTdXPLtjPqnCTW+B0agvBVCQI=
-github.com/mvo5/secboot v0.0.0-20230322150747-be05cfb11b02/go.mod h1:HwwnP8X2E5jNQ+rXnd7J+HPCA7b8doUtFR6LAooUpsQ=
+github.com/mvo5/secboot v0.0.0-20230323100326-6c7289eea31f h1:BDHtDCv+eiBqSqyd3kxv+avXpbC0qxvKvBCY5H52crc=
+github.com/mvo5/secboot v0.0.0-20230323100326-6c7289eea31f/go.mod h1:HwwnP8X2E5jNQ+rXnd7J+HPCA7b8doUtFR6LAooUpsQ=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/rogpeppe/clock v0.0.0-20190514195947-2896927a307a h1:3QH7VyOaaiUHNrA9Se4YQIRkDTCw1EJls9xTUCaCeRM=
 github.com/rogpeppe/clock v0.0.0-20190514195947-2896927a307a/go.mod h1:4r5QyqhjIWCcK8DO4KMclc5Iknq5qVBAlbYYzAbUScQ=


### PR DESCRIPTION
Experimental build to include the sbat workaround from Chris from https://github.com/snapcore/secboot/pull/242