### PR TITLE
image,seed: refactor RefAssertsFetcher

### DIFF
--- a/asserts/fetcher.go
+++ b/asserts/fetcher.go
@@ -175,6 +175,9 @@ func (f *fetcher) fetchSequence(seq *AtSequence) error {
 
 // FetchSequence retrieves the assertion as indicated by its sequence reference.
 func (f *fetcher) FetchSequence(seq *AtSequence) error {
+	if f.retrieveSeq == nil {
+		return fmt.Errorf("cannot fetch assertion sequence point, fetcher must be created using NewSequenceFormingFetcher")
+	}
 	return f.fetchSequence(seq)
 }
 

--- a/image/preseed/preseed.go
+++ b/image/preseed/preseed.go
@@ -200,7 +200,7 @@ func writePreseedAssertion(artifactDigest []byte, opts *preseedCoreOptions) erro
 		return tsto.AssertionFetcher(adb, save)
 	}
 
-	f := seedwriter.MakeRefAssertsFetcher(newFetcher)
+	f := seedwriter.MakeSeedAssertionFetcher(newFetcher)
 	if err := f.Save(signedAssert); err != nil {
 		return fmt.Errorf("cannot fetch assertion: %v", err)
 	}

--- a/overlord/devicestate/systems.go
+++ b/overlord/devicestate/systems.go
@@ -303,8 +303,9 @@ func createSystemForModelFromValidatedSnaps(model *asserts.Model, label string, 
 		}
 		return asserts.NewFetcher(db, fromDB, save)
 	}
-	f, err := w.Start(db, newFetcher)
-	if err != nil {
+
+	sf := seedwriter.MakeSeedAssertionFetcher(newFetcher)
+	if err := w.Start(db, sf); err != nil {
 		return "", err
 	}
 	// past this point the system directory is present
@@ -324,7 +325,7 @@ func createSystemForModelFromValidatedSnaps(model *asserts.Model, label string, 
 		// we have in snap.Info, but getting it this way can be
 		// expensive as we need to compute the hash, try to find a
 		// better way
-		_, aRefs, err := seedwriter.DeriveSideInfo(sn.Path, model, f, db)
+		_, aRefs, err := seedwriter.DeriveSideInfo(sn.Path, model, sf, db)
 		if err != nil {
 			if !errors.Is(err, &asserts.NotFoundError{}) {
 				return recoverySystemDir, err

--- a/seed/seedtest/seedtest.go
+++ b/seed/seedtest/seedtest.go
@@ -287,6 +287,7 @@ func (s *TestingSeed20) MakeSeedWithModel(c *C, label string, model *asserts.Mod
 		}
 		return asserts.NewFetcher(db, retrieve, save2)
 	}
+	sf := seedwriter.MakeSeedAssertionFetcher(newFetcher)
 
 	opts := seedwriter.Options{
 		SeedDir: s.SeedDir,
@@ -298,7 +299,7 @@ func (s *TestingSeed20) MakeSeedWithModel(c *C, label string, model *asserts.Mod
 	err = w.SetOptionsSnaps(optSnaps)
 	c.Assert(err, IsNil)
 
-	rf, err := w.Start(db, newFetcher)
+	err = w.Start(db, sf)
 	c.Assert(err, IsNil)
 
 	localSnaps, err := w.LocalSnaps()
@@ -307,7 +308,7 @@ func (s *TestingSeed20) MakeSeedWithModel(c *C, label string, model *asserts.Mod
 	localARefs := make(map[*seedwriter.SeedSnap][]*asserts.Ref)
 
 	for _, sn := range localSnaps {
-		si, aRefs, err := seedwriter.DeriveSideInfo(sn.Path, model, rf, db)
+		si, aRefs, err := seedwriter.DeriveSideInfo(sn.Path, model, sf, db)
 		if !errors.Is(err, &asserts.NotFoundError{}) {
 			c.Assert(err, IsNil)
 		}
@@ -328,11 +329,11 @@ func (s *TestingSeed20) MakeSeedWithModel(c *C, label string, model *asserts.Mod
 		if aRefs, ok := localARefs[sn]; ok {
 			return aRefs, nil
 		}
-		prev := len(rf.Refs())
-		if err = rf.Save(s.snapRevs[sn.SnapName()]); err != nil {
+		prev := len(sf.Refs())
+		if err = sf.Save(s.snapRevs[sn.SnapName()]); err != nil {
 			return nil, err
 		}
-		return rf.Refs()[prev:], nil
+		return sf.Refs()[prev:], nil
 	}
 
 	for {

--- a/seed/seedwriter/fetcher.go
+++ b/seed/seedwriter/fetcher.go
@@ -32,7 +32,6 @@ import (
 // retrieval of assertions.
 // Optimally we would gather all retrieval logic here related to the fetching of
 // assertions during seeding.
-// TODO: See how much of the logic for fetching of assertions in image_linux and writer.go we can move here.
 type SeedAssertionFetcher interface {
 	Fetch(ref *asserts.Ref) error
 	FetchSequence(seq *asserts.AtSequence) error

--- a/seed/seedwriter/fetcher.go
+++ b/seed/seedwriter/fetcher.go
@@ -30,8 +30,6 @@ import (
 // for retrieving them at any point in time during seeding. It wraps around the
 // asserts.{SequenceFormingFetcher,Fetcher} interfaces to allow for flexible
 // retrieval of assertions.
-// Optimally we would gather all retrieval logic here related to the fetching of
-// assertions during seeding.
 type SeedAssertionFetcher interface {
 	Fetch(ref *asserts.Ref) error
 	FetchSequence(seq *asserts.AtSequence) error

--- a/seed/seedwriter/fetcher.go
+++ b/seed/seedwriter/fetcher.go
@@ -1,0 +1,90 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package seedwriter
+
+import (
+	"fmt"
+
+	"github.com/snapcore/snapd/asserts"
+)
+
+// SeedAssertionFetcher is a Fetcher which is designed to help with the fetching
+// of assertions during seeding. It keeps track of assertions fetched, and allows
+// for retrieving them at any point in time during seeding. It wraps around the
+// asserts.{SequenceFormingFetcher,Fetcher} interfaces to allow for flexible
+// retrieval of assertions.
+// Optimally we would gather all retrieval logic here related to the fetching of
+// assertions during seeding.
+// TODO: See how much of the logic for fetching of assertions in image_linux and writer.go we can move here.
+type SeedAssertionFetcher interface {
+	Fetch(ref *asserts.Ref) error
+	FetchSequence(seq *asserts.AtSequence) error
+	Save(asserts.Assertion) error
+	Refs() []*asserts.Ref
+	ResetRefs()
+}
+
+type assertionFetcher struct {
+	fetcher asserts.Fetcher
+	refs    []*asserts.Ref
+}
+
+func (af *assertionFetcher) Fetch(ref *asserts.Ref) error {
+	return af.fetcher.Fetch(ref)
+}
+
+// FetchSequence attempts to cast the provided fetcher to a SequenceFormingFetcher
+// to allow the use of FetchSequence.
+func (af *assertionFetcher) FetchSequence(seq *asserts.AtSequence) error {
+	sf, ok := af.fetcher.(asserts.SequenceFormingFetcher)
+	if !ok {
+		return fmt.Errorf("cannot fetch assertion sequence point, fetcher must be a SequenceFormingFetcher")
+	}
+	return sf.FetchSequence(seq)
+}
+
+func (af *assertionFetcher) Save(a asserts.Assertion) error {
+	return af.fetcher.Save(a)
+}
+
+func (af *assertionFetcher) Refs() []*asserts.Ref {
+	return af.refs
+}
+
+func (af *assertionFetcher) ResetRefs() {
+	af.refs = nil
+}
+
+// A NewFetcherFunc can build a Fetcher saving to an (implicit)
+// database and also calling the given additional save function.
+type NewFetcherFunc func(save func(asserts.Assertion) error) asserts.Fetcher
+
+// MakeSeedAssertionFetcher makes a SeedAssertionFetcher using newFetcher which can
+// build a base Fetcher with an additional save function, to capture assertion
+// references.
+func MakeSeedAssertionFetcher(newFetcher NewFetcherFunc) SeedAssertionFetcher {
+	var af assertionFetcher
+	save := func(a asserts.Assertion) error {
+		af.refs = append(af.refs, a.Ref())
+		return nil
+	}
+	af.fetcher = newFetcher(save)
+	return &af
+}

--- a/seed/seedwriter/fetcher_test.go
+++ b/seed/seedwriter/fetcher_test.go
@@ -1,0 +1,156 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package seedwriter_test
+
+import (
+	"time"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/asserts/assertstest"
+	"github.com/snapcore/snapd/seed/seedwriter"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type fetcherSuite struct {
+	testutil.BaseTest
+	storeSigning *assertstest.StoreStack
+}
+
+var _ = Suite(&fetcherSuite{})
+
+func (s *fetcherSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	s.storeSigning = assertstest.NewStoreStack("can0nical", nil)
+}
+
+func (s *fetcherSuite) setupTestAssertion(c *C) asserts.Assertion {
+	modelAs, err := s.storeSigning.Sign(asserts.ModelType, map[string]interface{}{
+		"series":       "16",
+		"brand-id":     "can0nical",
+		"model":        "my-model-2",
+		"architecture": "amd64",
+		"gadget":       "gadget",
+		"kernel":       "kernel",
+		"timestamp":    time.Now().UTC().Format(time.RFC3339),
+	}, nil, "")
+	c.Assert(err, IsNil)
+	err = s.storeSigning.Add(modelAs)
+	c.Assert(err, IsNil)
+	return modelAs
+}
+
+func (s *fetcherSuite) TestAssertFetcher(c *C) {
+	// Verify the basic use-case of the SeedAssertionFetcher. This
+	// sets up a model assertion, and we then fetch this. Then we verify
+	// that the as was added accordingly to the as-tracking.
+	as := s.setupTestAssertion(c)
+
+	db, err := asserts.OpenDatabase(&asserts.DatabaseConfig{
+		Backstore: asserts.NewMemoryBackstore(),
+		Trusted:   s.storeSigning.Trusted,
+	})
+	c.Assert(err, IsNil)
+
+	retrieve := func(ref *asserts.Ref) (asserts.Assertion, error) {
+		return ref.Resolve(s.storeSigning.Find)
+	}
+	var newFetcherCalled int
+	newFetcher := func(save func(asserts.Assertion) error) asserts.Fetcher {
+		newFetcherCalled++
+		return asserts.NewFetcher(db, retrieve, save)
+	}
+
+	af := seedwriter.MakeSeedAssertionFetcher(newFetcher)
+	c.Assert(af, NotNil)
+	c.Check(newFetcherCalled, Equals, 1)
+
+	// Fetch the model assertion, then let's verify the refs was added.
+	// We expect the model, and it's account key to be added.
+	err = af.Fetch(as.Ref())
+	c.Check(err, IsNil)
+	c.Assert(af.Refs(), HasLen, 2)
+	c.Check(af.Refs()[0].Type, Equals, asserts.AccountKeyType)
+	c.Check(af.Refs()[1].String(), Equals, "model (my-model-2; series:16 brand-id:can0nical)")
+
+	// Clear the Refs using ResetRefs
+	af.ResetRefs()
+	c.Check(af.Refs(), HasLen, 0)
+}
+
+func (s *fetcherSuite) TestAssertFetcherSave(c *C) {
+	// Verify that we also track references added directly via
+	// SeedAssertionFetcher.Save.
+	as := s.setupTestAssertion(c)
+
+	db, err := asserts.OpenDatabase(&asserts.DatabaseConfig{
+		Backstore: asserts.NewMemoryBackstore(),
+		Trusted:   s.storeSigning.Trusted,
+	})
+	c.Assert(err, IsNil)
+
+	retrieve := func(ref *asserts.Ref) (asserts.Assertion, error) {
+		return ref.Resolve(s.storeSigning.Find)
+	}
+	var newFetcherCalled int
+	newFetcher := func(save func(asserts.Assertion) error) asserts.Fetcher {
+		newFetcherCalled++
+		return asserts.NewFetcher(db, retrieve, save)
+	}
+
+	af := seedwriter.MakeSeedAssertionFetcher(newFetcher)
+	c.Assert(af, NotNil)
+	c.Check(newFetcherCalled, Equals, 1)
+
+	// Fetch the model assertion, then let's verify the refs was added.
+	err = af.Save(as)
+	c.Check(err, IsNil)
+	c.Assert(af.Refs(), HasLen, 2)
+	c.Check(af.Refs()[0].Type, Equals, asserts.AccountKeyType)
+	c.Check(af.Refs()[1].String(), Equals, "model (my-model-2; series:16 brand-id:can0nical)")
+}
+
+type testFetcher struct{}
+
+func (t *testFetcher) Fetch(ref *asserts.Ref) error {
+	return nil
+}
+
+func (t *testFetcher) Save(a asserts.Assertion) error {
+	return nil
+}
+
+func (s *fetcherSuite) TestAssertFetcherInvalidSequenceFormingFetcher(c *C) {
+	// Verify that trying to use FetchSequence will produce an error if
+	// a non-sequence forming assertion fetcher was created using the newFetcherFunc.
+	var newFetcherCalled int
+	newFetcher := func(save func(asserts.Assertion) error) asserts.Fetcher {
+		newFetcherCalled++
+		return &testFetcher{}
+	}
+
+	af := seedwriter.MakeSeedAssertionFetcher(newFetcher)
+	c.Assert(af, NotNil)
+	c.Check(newFetcherCalled, Equals, 1)
+
+	err := af.FetchSequence(nil)
+	c.Check(err, ErrorMatches, `cannot fetch assertion sequence point, fetcher must be a SequenceFormingFetcher`)
+}

--- a/seed/seedwriter/fetcher_test.go
+++ b/seed/seedwriter/fetcher_test.go
@@ -91,6 +91,11 @@ func (s *fetcherSuite) TestAssertFetcher(c *C) {
 	c.Check(af.Refs()[0].Type, Equals, asserts.AccountKeyType)
 	c.Check(af.Refs()[1].String(), Equals, "model (my-model-2; series:16 brand-id:can0nical)")
 
+	// Using the default fetcher, which was not created using NewSequenceFormingFetcher,
+	// FetchSequence must return us an error.
+	err = af.FetchSequence(nil)
+	c.Check(err, ErrorMatches, `cannot fetch assertion sequence point, fetcher must be created using NewSequenceFormingFetcher`)
+
 	// Clear the Refs using ResetRefs
 	af.ResetRefs()
 	c.Check(af.Refs(), HasLen, 0)

--- a/seed/seedwriter/writer.go
+++ b/seed/seedwriter/writer.go
@@ -443,11 +443,9 @@ func IsSytemDirectoryExistsError(err error) bool {
 	return ok
 }
 
-// Start starts the seed writing. It creates a RefAssertsFetcher using
-// newFetcher and uses it to fetch model related assertions. For convenience it
-// returns the fetcher possibly for use to fetch seed snap assertions, a task
-// that the writer delegates as well as snap downloading. The writer assumes
-// that the snap assertions will end up in the given db (writing assertion
+// Start starts the seed writing, and fetches the necessary model assertions using
+// the provided SeedAssertionFetcher (See MakeSeedAssertionFetcher). The seed-writer
+// assumes that the snap assertions will end up in the given db (writing assertion
 // database). When the system seed directory is already present,
 // SystemAlreadyExistsError is returned.
 func (w *Writer) Start(db asserts.RODatabase, f SeedAssertionFetcher) error {

--- a/seed/seedwriter/writer_test.go
+++ b/seed/seedwriter/writer_test.go
@@ -56,7 +56,7 @@ type writerSuite struct {
 
 	db         *asserts.Database
 	newFetcher seedwriter.NewFetcherFunc
-	rf         seedwriter.RefAssertsFetcher
+	rf         seedwriter.SeedAssertionFetcher
 
 	devAcct *asserts.Account
 
@@ -122,7 +122,7 @@ func (s *writerSuite) SetUpTest(c *C) {
 		}
 		return asserts.NewFetcher(db, retrieve, save2)
 	}
-	s.rf = seedwriter.MakeRefAssertsFetcher(s.newFetcher)
+	s.rf = seedwriter.MakeSeedAssertionFetcher(s.newFetcher)
 
 	s.aRefs = make(map[string][]*asserts.Ref)
 	// default expected system and kernel snaps
@@ -297,7 +297,7 @@ func (s *writerSuite) TestSnapsToDownloadCore16(c *C) {
 	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Name: "pc", Channel: "edge"}})
 	c.Assert(err, IsNil)
 
-	_, err = w.Start(s.db, s.newFetcher)
+	err = w.Start(s.db, s.rf)
 	c.Assert(err, IsNil)
 
 	snaps, err := w.SnapsToDownload()
@@ -327,7 +327,7 @@ func (s *writerSuite) TestSnapsToDownloadOptionTrack(c *C) {
 	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Name: "pc", Channel: "track/edge"}})
 	c.Assert(err, IsNil)
 
-	_, err = w.Start(s.db, s.newFetcher)
+	err = w.Start(s.db, s.rf)
 	c.Assert(err, IsNil)
 
 	snaps, err := w.SnapsToDownload()
@@ -358,7 +358,7 @@ func (s *writerSuite) TestDownloadedCore16(c *C) {
 	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Name: "pc", Channel: "edge"}})
 	c.Assert(err, IsNil)
 
-	_, err = w.Start(s.db, s.newFetcher)
+	err = w.Start(s.db, s.rf)
 	c.Assert(err, IsNil)
 
 	snaps, err := w.SnapsToDownload()
@@ -405,7 +405,7 @@ func (s *writerSuite) TestDownloadedCore18(c *C) {
 	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Name: "pc", Channel: "edge"}})
 	c.Assert(err, IsNil)
 
-	_, err = w.Start(s.db, s.newFetcher)
+	err = w.Start(s.db, s.rf)
 	c.Assert(err, IsNil)
 
 	snaps, err := w.SnapsToDownload()
@@ -455,7 +455,7 @@ func (s *writerSuite) TestSnapsToDownloadCore18IncompatibleTrack(c *C) {
 	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Name: "pc-kernel", Channel: "18.1"}})
 	c.Assert(err, IsNil)
 
-	_, err = w.Start(s.db, s.newFetcher)
+	err = w.Start(s.db, s.rf)
 	c.Assert(err, IsNil)
 
 	_, err = w.SnapsToDownload()
@@ -486,7 +486,7 @@ func (s *writerSuite) TestSnapsToDownloadDefaultChannel(c *C) {
 	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Name: "pc", Channel: "edge"}})
 	c.Assert(err, IsNil)
 
-	_, err = w.Start(s.db, s.newFetcher)
+	err = w.Start(s.db, s.rf)
 	c.Assert(err, IsNil)
 
 	snaps, err := w.SnapsToDownload()
@@ -515,7 +515,7 @@ func (s *writerSuite) upToDownloaded(c *C, model *asserts.Model, fill func(c *C,
 		c.Assert(err, IsNil)
 	}
 
-	_, err = w.Start(s.db, s.newFetcher)
+	err = w.Start(s.db, s.rf)
 	c.Assert(err, IsNil)
 
 	snaps, err := w.SnapsToDownload()
@@ -584,7 +584,7 @@ func (s *writerSuite) TestOutOfOrder(c *C) {
 	c.Check(w.WriteMeta(), ErrorMatches, "internal error: seedwriter.Writer expected Start|SetOptionsSnaps to be invoked on it at this point, not WriteMeta")
 	c.Check(w.SeedSnaps(nil), ErrorMatches, "internal error: seedwriter.Writer expected Start|SetOptionsSnaps to be invoked on it at this point, not SeedSnaps")
 
-	_, err = w.Start(s.db, s.newFetcher)
+	err = w.Start(s.db, s.rf)
 	c.Assert(err, IsNil)
 	_, err = w.Downloaded(nil)
 	c.Check(err, ErrorMatches, "internal error: seedwriter.Writer expected SnapToDownload|LocalSnaps to be invoked on it at this point, not Downloaded")
@@ -614,7 +614,7 @@ func (s *writerSuite) TestOutOfOrderWithLocalSnaps(c *C) {
 	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Path: requiredFn}})
 	c.Assert(err, IsNil)
 
-	_, err = w.Start(s.db, s.newFetcher)
+	err = w.Start(s.db, s.rf)
 	c.Assert(err, IsNil)
 
 	_, err = w.SnapsToDownload()
@@ -821,7 +821,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore16(c *C) {
 	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Name: "pc", Channel: "edge"}})
 	c.Assert(err, IsNil)
 
-	_, err = w.Start(s.db, s.newFetcher)
+	err = w.Start(s.db, s.rf)
 	c.Assert(err, IsNil)
 
 	snaps, err := w.SnapsToDownload()
@@ -936,7 +936,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore18(c *C) {
 	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Name: "pc", Channel: "edge"}})
 	c.Assert(err, IsNil)
 
-	_, err = w.Start(s.db, s.newFetcher)
+	err = w.Start(s.db, s.rf)
 	c.Assert(err, IsNil)
 
 	snaps, err := w.SnapsToDownload()
@@ -1100,7 +1100,7 @@ func (s *writerSuite) TestLocalSnaps(c *C) {
 	})
 	c.Assert(err, IsNil)
 
-	_, err = w.Start(s.db, s.newFetcher)
+	err = w.Start(s.db, s.rf)
 	c.Assert(err, IsNil)
 
 	localSnaps, err := w.LocalSnaps()
@@ -1143,7 +1143,7 @@ func (s *writerSuite) TestLocalSnapsCore18FullUse(c *C) {
 	})
 	c.Assert(err, IsNil)
 
-	tf, err := w.Start(s.db, s.newFetcher)
+	err = w.Start(s.db, s.rf)
 	c.Assert(err, IsNil)
 
 	localSnaps, err := w.LocalSnaps()
@@ -1151,7 +1151,7 @@ func (s *writerSuite) TestLocalSnapsCore18FullUse(c *C) {
 	c.Assert(localSnaps, HasLen, 5)
 
 	for _, sn := range localSnaps {
-		si, aRefs, err := seedwriter.DeriveSideInfo(sn.Path, model, tf, s.db)
+		si, aRefs, err := seedwriter.DeriveSideInfo(sn.Path, model, s.rf, s.db)
 		if !errors.Is(err, &asserts.NotFoundError{}) {
 			c.Assert(err, IsNil)
 		}
@@ -1279,7 +1279,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaDefaultTrackCore18(c *C) {
 	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Name: "required18", Channel: "candidate"}})
 	c.Assert(err, IsNil)
 
-	_, err = w.Start(s.db, s.newFetcher)
+	err = w.Start(s.db, s.rf)
 	c.Assert(err, IsNil)
 
 	snaps, err := w.SnapsToDownload()
@@ -1341,7 +1341,7 @@ func (s *writerSuite) TestSetRedirectChannelErrors(c *C) {
 	w, err := seedwriter.New(model, s.opts)
 	c.Assert(err, IsNil)
 
-	_, err = w.Start(s.db, s.newFetcher)
+	err = w.Start(s.db, s.rf)
 	c.Assert(err, IsNil)
 
 	snaps, err := w.SnapsToDownload()
@@ -1382,7 +1382,7 @@ func (s *writerSuite) TestInfoDerivedInfosNotSet(c *C) {
 	})
 	c.Assert(err, IsNil)
 
-	_, err = w.Start(s.db, s.newFetcher)
+	err = w.Start(s.db, s.rf)
 	c.Assert(err, IsNil)
 
 	_, err = w.LocalSnaps()
@@ -1417,7 +1417,7 @@ func (s *writerSuite) TestInfoDerivedRepeatedLocalSnap(c *C) {
 	})
 	c.Assert(err, IsNil)
 
-	_, err = w.Start(s.db, s.newFetcher)
+	err = w.Start(s.db, s.rf)
 	c.Assert(err, IsNil)
 
 	localSnaps, err := w.LocalSnaps()
@@ -1461,7 +1461,7 @@ func (s *writerSuite) TestInfoDerivedInconsistentChannel(c *C) {
 	})
 	c.Assert(err, IsNil)
 
-	_, err = w.Start(s.db, s.newFetcher)
+	err = w.Start(s.db, s.rf)
 	c.Assert(err, IsNil)
 
 	localSnaps, err := w.LocalSnaps()
@@ -1499,7 +1499,7 @@ func (s *writerSuite) TestSetRedirectChannelLocalError(c *C) {
 	})
 	c.Assert(err, IsNil)
 
-	_, err = w.Start(s.db, s.newFetcher)
+	err = w.Start(s.db, s.rf)
 	c.Assert(err, IsNil)
 
 	localSnaps, err := w.LocalSnaps()
@@ -1960,7 +1960,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaExtraSnaps(c *C) {
 	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Name: "required", Channel: "beta"}})
 	c.Assert(err, IsNil)
 
-	_, err = w.Start(s.db, s.newFetcher)
+	err = w.Start(s.db, s.rf)
 	c.Assert(err, IsNil)
 
 	snaps, err := w.SnapsToDownload()
@@ -2085,7 +2085,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaLocalExtraSnaps(c *C) {
 	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Path: requiredFn}})
 	c.Assert(err, IsNil)
 
-	tf, err := w.Start(s.db, s.newFetcher)
+	err = w.Start(s.db, s.rf)
 	c.Assert(err, IsNil)
 
 	localSnaps, err := w.LocalSnaps()
@@ -2093,7 +2093,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaLocalExtraSnaps(c *C) {
 	c.Assert(localSnaps, HasLen, 1)
 
 	for _, sn := range localSnaps {
-		si, aRefs, err := seedwriter.DeriveSideInfo(sn.Path, model, tf, s.db)
+		si, aRefs, err := seedwriter.DeriveSideInfo(sn.Path, model, s.rf, s.db)
 		if !errors.Is(err, &asserts.NotFoundError{}) {
 			c.Assert(err, IsNil)
 		}
@@ -2263,7 +2263,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20(c *C) {
 	w, err := seedwriter.New(model, s.opts)
 	c.Assert(err, IsNil)
 
-	_, err = w.Start(s.db, s.newFetcher)
+	err = w.Start(s.db, s.rf)
 	c.Assert(err, IsNil)
 
 	snaps, err := w.SnapsToDownload()
@@ -2739,7 +2739,7 @@ func (s *writerSuite) TestCore20NonDangerousDisallowedDevmodeSnaps(c *C) {
 	w, err := seedwriter.New(model, s.opts)
 	c.Assert(err, IsNil)
 
-	_, err = w.Start(s.db, s.newFetcher)
+	err = w.Start(s.db, s.rf)
 	c.Assert(err, IsNil)
 
 	localSnaps, err := w.LocalSnaps()
@@ -2807,7 +2807,7 @@ func (s *writerSuite) TestCore20NonDangerousDisallowedOptionsSnaps(c *C) {
 			continue
 		}
 
-		tf, err := w.Start(s.db, s.newFetcher)
+		err = w.Start(s.db, s.rf)
 		c.Assert(err, IsNil)
 
 		if t.optSnap.Path != "" {
@@ -2816,7 +2816,7 @@ func (s *writerSuite) TestCore20NonDangerousDisallowedOptionsSnaps(c *C) {
 			c.Assert(localSnaps, HasLen, 1)
 
 			for _, sn := range localSnaps {
-				si, _, err := seedwriter.DeriveSideInfo(sn.Path, model, tf, s.db)
+				si, _, err := seedwriter.DeriveSideInfo(sn.Path, model, s.rf, s.db)
 				if !errors.Is(err, &asserts.NotFoundError{}) {
 					c.Assert(err, IsNil)
 				}
@@ -2919,7 +2919,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20LocalSnaps(c *C) {
 	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Path: requiredFn}})
 	c.Assert(err, IsNil)
 
-	tf, err := w.Start(s.db, s.newFetcher)
+	err = w.Start(s.db, s.rf)
 	c.Assert(err, IsNil)
 
 	localSnaps, err := w.LocalSnaps()
@@ -2927,7 +2927,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20LocalSnaps(c *C) {
 	c.Assert(localSnaps, HasLen, 1)
 
 	for _, sn := range localSnaps {
-		_, _, err := seedwriter.DeriveSideInfo(sn.Path, model, tf, s.db)
+		_, _, err := seedwriter.DeriveSideInfo(sn.Path, model, s.rf, s.db)
 		c.Assert(errors.Is(err, &asserts.NotFoundError{}), Equals, true)
 		f, err := snapfile.Open(sn.Path)
 		c.Assert(err, IsNil)
@@ -3047,7 +3047,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20ChannelOverrides(c *C) {
 	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Name: "pc", Channel: "edge"}})
 	c.Assert(err, IsNil)
 
-	_, err = w.Start(s.db, s.newFetcher)
+	err = w.Start(s.db, s.rf)
 	c.Assert(err, IsNil)
 
 	snaps, err := w.SnapsToDownload()
@@ -3146,7 +3146,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20ModelOverrideSnapd(c *C) {
 	w, err := seedwriter.New(model, s.opts)
 	c.Assert(err, IsNil)
 
-	_, err = w.Start(s.db, s.newFetcher)
+	err = w.Start(s.db, s.rf)
 	c.Assert(err, IsNil)
 
 	snaps, err := w.SnapsToDownload()
@@ -3252,7 +3252,7 @@ func (s *writerSuite) TestSnapsToDownloadCore20OptionalSnaps(c *C) {
 	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Name: "optional20-b"}})
 	c.Assert(err, IsNil)
 
-	_, err = w.Start(s.db, s.newFetcher)
+	err = w.Start(s.db, s.rf)
 	c.Assert(err, IsNil)
 
 	snaps, err := w.SnapsToDownload()
@@ -3300,7 +3300,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20ExtraSnaps(c *C) {
 	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Name: "cont-producer", Channel: "edge"}, {Name: "core18"}, {Path: contConsumerFn}})
 	c.Assert(err, IsNil)
 
-	tf, err := w.Start(s.db, s.newFetcher)
+	err = w.Start(s.db, s.rf)
 	c.Assert(err, IsNil)
 
 	localSnaps, err := w.LocalSnaps()
@@ -3308,7 +3308,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20ExtraSnaps(c *C) {
 	c.Assert(localSnaps, HasLen, 1)
 
 	for _, sn := range localSnaps {
-		_, _, err := seedwriter.DeriveSideInfo(sn.Path, model, tf, s.db)
+		_, _, err := seedwriter.DeriveSideInfo(sn.Path, model, s.rf, s.db)
 		c.Assert(errors.Is(err, &asserts.NotFoundError{}), Equals, true)
 		f, err := snapfile.Open(sn.Path)
 		c.Assert(err, IsNil)
@@ -3472,7 +3472,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20LocalAssertedSnaps(c *C) {
 	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Path: s.AssertedSnap("pc"), Channel: "edge"}, {Path: s.AssertedSnap("required20")}})
 	c.Assert(err, IsNil)
 
-	tf, err := w.Start(s.db, s.newFetcher)
+	err = w.Start(s.db, s.rf)
 	c.Assert(err, IsNil)
 
 	localSnaps, err := w.LocalSnaps()
@@ -3480,7 +3480,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20LocalAssertedSnaps(c *C) {
 	c.Assert(localSnaps, HasLen, 2)
 
 	for _, sn := range localSnaps {
-		si, aRefs, err := seedwriter.DeriveSideInfo(sn.Path, model, tf, s.db)
+		si, aRefs, err := seedwriter.DeriveSideInfo(sn.Path, model, s.rf, s.db)
 		c.Assert(err, IsNil)
 		f, err := snapfile.Open(sn.Path)
 		c.Assert(err, IsNil)
@@ -3596,7 +3596,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20SignedLocalAssertedSnaps(c *C)
 	err = w.SetOptionsSnaps([]*seedwriter.OptionsSnap{{Path: s.AssertedSnap("pc")}})
 	c.Assert(err, IsNil)
 
-	tf, err := w.Start(s.db, s.newFetcher)
+	err = w.Start(s.db, s.rf)
 	c.Assert(err, IsNil)
 
 	localSnaps, err := w.LocalSnaps()
@@ -3604,7 +3604,7 @@ func (s *writerSuite) TestSeedSnapsWriteMetaCore20SignedLocalAssertedSnaps(c *C)
 	c.Assert(localSnaps, HasLen, 1)
 
 	for _, sn := range localSnaps {
-		si, aRefs, err := seedwriter.DeriveSideInfo(sn.Path, model, tf, s.db)
+		si, aRefs, err := seedwriter.DeriveSideInfo(sn.Path, model, s.rf, s.db)
 		c.Assert(err, IsNil)
 		f, err := snapfile.Open(sn.Path)
 		c.Assert(err, IsNil)
@@ -3688,7 +3688,7 @@ func (s *writerSuite) TestSeedSnapsWriteCore20ErrWhenDirExists(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(w, NotNil)
 
-	_, err = w.Start(s.db, s.newFetcher)
+	err = w.Start(s.db, s.rf)
 	c.Assert(err, ErrorMatches, `system "1234" already exists`)
 	c.Assert(seedwriter.IsSytemDirectoryExistsError(err), Equals, true)
 }


### PR DESCRIPTION
As a part of supporting sequence forming assertions during seeding, I'd like to take the opportunity to do some cleanup around how we fetch assertions during seeding. Instead of how weaved the RefAssertsFetcher was in/out of the seedwriter, I've isolated how it's used, so it's strictly provided as a parameter to writer.Start, and otherwise controlled by the caller.

I've also taken the liberty of renaming it and moving it to it's own file, to encourage us to use it more in terms of isolating logic related to how we fetch assertions.