### PR TITLE
image,seed/seedwriter: fix corner cases of asserts fetching not triggered

### DIFF
--- a/image/image_test.go
+++ b/image/image_test.go
@@ -2213,6 +2213,12 @@ func (s *imageSuite) TestPrepareClassicModelNoModelAssertion(c *C) {
 		filepath.Join(seedsnapsdir, "core18_18.snap"),
 		filepath.Join(seedsnapsdir, "required-snap18_6.snap"),
 	})
+
+	// check assertions
+	seedassertsdir := filepath.Join(seeddir, "assertions")
+	l, err := ioutil.ReadDir(seedassertsdir)
+	c.Assert(err, IsNil)
+	c.Check(l, HasLen, 9)
 }
 
 func (s *imageSuite) TestSetupSeedWithKernelAndGadgetTrack(c *C) {

--- a/seed/seedwriter/seed16.go
+++ b/seed/seedwriter/seed16.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2020 Canonical Ltd
+ * Copyright (C) 2014-2023 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -43,6 +43,8 @@ type policy16 struct {
 
 	needsCore   []string
 	needsCore16 []string
+
+	snapdUsedOnClassic bool
 }
 
 func (pol *policy16) allowsDangerousFeatures() error {
@@ -147,7 +149,7 @@ func (pol *policy16) implicitSnaps(availableByMode map[string]*naming.SnapSet) [
 	if len(pol.needsCore) != 0 && !availableSnaps.Contains(naming.Snap("core")) {
 		return []*asserts.ModelSnap{makeSystemSnap("core")}
 	}
-	if pol.model.Classic() && !availableSnaps.Empty() {
+	if pol.model.Classic() && !availableSnaps.Empty() && !availableSnaps.Contains(naming.Snap("snapd")) {
 		return []*asserts.ModelSnap{makeSystemSnap("snapd")}
 	}
 	return nil
@@ -161,6 +163,14 @@ func (pol *policy16) implicitExtraSnaps(availableByMode map[string]*naming.SnapS
 	return nil
 }
 
+func (pol *policy16) recordSnapNameUsage(snapName string) {
+	if !pol.model.Classic() {
+		// nothing to record
+		return
+	}
+	pol.snapdUsedOnClassic = snapName == "snapd"
+}
+
 func (pol *policy16) isSystemSnapCandidate(sn *SeedSnap) bool {
 	if sn.modelSnap != nil {
 		sysSnap := pol.systemSnap()
@@ -171,7 +181,14 @@ func (pol *policy16) isSystemSnapCandidate(sn *SeedSnap) bool {
 			return true
 		}
 	}
-	return pol.model.Classic() && sn.SnapName() == "core"
+	if pol.model.Classic() {
+		if pol.snapdUsedOnClassic {
+			return sn.SnapName() == "snapd"
+		} else {
+			return sn.SnapName() == "core"
+		}
+	}
+	return false
 }
 
 func (pol *policy16) ignoreUndeterminedSystemSnap() bool {

--- a/seed/seedwriter/seed20.go
+++ b/seed/seedwriter/seed20.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2022 Canonical Ltd
+ * Copyright (C) 2014-2023 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -155,6 +155,8 @@ func (pol *policy20) implicitSnaps(map[string]*naming.SnapSet) []*asserts.ModelS
 func (pol *policy20) implicitExtraSnaps(map[string]*naming.SnapSet) []*OptionsSnap {
 	return nil
 }
+
+func (pol *policy20) recordSnapNameUsage(_ string) {}
 
 func (pol *policy20) isSystemSnapCandidate(sn *SeedSnap) bool {
 	if sn.modelSnap != nil {


### PR DESCRIPTION
with not extended classic models never seeing a system snap or seeing snapd outside the model would not trigger assertion fetching