### PR TITLE
interfaces/seccomp/template: Adding kcmp to allow Mesa usecases

### DIFF
--- a/interfaces/seccomp/template.go
+++ b/interfaces/seccomp/template.go
@@ -217,6 +217,7 @@ ioprio_get
 
 ipc
 kill
+kcmp - - KCMP_FILE
 link
 linkat
 


### PR DESCRIPTION
For fixing https://bugs.launchpad.net/snapd/+bug/1998980 implement the suggested fix of allowing kcmp in the base template.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
