### PR TITLE
snap: tighten up layout path checking for usrmerge'd systems

### DIFF
--- a/snap/validate.go
+++ b/snap/validate.go
@@ -924,6 +924,7 @@ var layoutRejectionList = []string{
 	// snap applications to be integrated with the rest of the system and
 	// therefore snaps should not be allowed to replace it.
 	"/run",
+	"/var/run",
 	// The /tmp directory contains a private, per-snap, view of /tmp and
 	// there's no valid reason to allow snaps to replace it.
 	"/tmp",
@@ -939,9 +940,11 @@ var layoutRejectionList = []string{
 	// firmware. Therefore firmware must not be replaceable to prevent
 	// malicious firmware from attacking the host.
 	"/lib/firmware",
+	"/usr/lib/firmware",
 	// Similarly the kernel will load modules and the modules should not be
 	// something that snaps can tamper with.
 	"/lib/modules",
+	"/usr/lib/modules",
 
 	// Locations that store essential data:
 

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -977,6 +977,12 @@ func (s *ValidateSuite) TestValidateLayout(c *C) {
 		ErrorMatches, `layout "/run/foo" in an off-limits area`)
 	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/run/systemd", Type: "tmpfs"}, nil),
 		ErrorMatches, `layout "/run/systemd" in an off-limits area`)
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/var/run", Type: "tmpfs"}, nil),
+		ErrorMatches, `layout "/var/run" in an off-limits area`)
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/var/run/foo", Type: "tmpfs"}, nil),
+		ErrorMatches, `layout "/var/run/foo" in an off-limits area`)
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/var/run/systemd", Type: "tmpfs"}, nil),
+		ErrorMatches, `layout "/var/run/systemd" in an off-limits area`)
 	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/boot", Type: "tmpfs"}, nil),
 		ErrorMatches, `layout "/boot" in an off-limits area`)
 	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/lost+found", Type: "tmpfs"}, nil),
@@ -993,6 +999,10 @@ func (s *ValidateSuite) TestValidateLayout(c *C) {
 		ErrorMatches, `layout "/lib/firmware" in an off-limits area`)
 	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/lib/modules", Type: "tmpfs"}, nil),
 		ErrorMatches, `layout "/lib/modules" in an off-limits area`)
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/usr/lib/firmware", Type: "tmpfs"}, nil),
+		ErrorMatches, `layout "/usr/lib/firmware" in an off-limits area`)
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/usr/lib/modules", Type: "tmpfs"}, nil),
+		ErrorMatches, `layout "/usr/lib/modules" in an off-limits area`)
 	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/tmp", Type: "tmpfs"}, nil),
 		ErrorMatches, `layout "/tmp" in an off-limits area`)
 


### PR DESCRIPTION
On a usrmerge'd system, /lib is a symlink to /usr/lib and /var/run is a symlink to /run - ensure these are also tested for when validating a snap layout.

Noticed in https://forum.snapcraft.io/t/snap-layouts/7207/50
