### PR TITLE
many: add new snapd-observe API interface via /run/snapd-ro.socket

### DIFF
--- a/daemon/access.go
+++ b/daemon/access.go
@@ -84,8 +84,31 @@ func requireSnapdSocket(ucred *ucrednet) *apiError {
 	return nil
 }
 
-// openAccess allows requests without authentication, provided they
+// XXX: find a better name
+// observeAccess allows requests without authentication, provided they
 // have peer credentials and were not received on snapd-snap.socket
+type observeAccess struct{}
+
+func (ac observeAccess) CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError {
+	return requireAtLeastSnapdReadOnlySocket(ucred)
+}
+
+// requireSnapdRoSocket ensures the request was received via snapd{,-ro}.socket.
+func requireAtLeastSnapdReadOnlySocket(ucred *ucrednet) *apiError {
+	if ucred == nil {
+		return Forbidden("access denied")
+	}
+
+	if ucred.Socket != dirs.SnapdSocket && ucred.Socket != dirs.SnapdRoSocket {
+		return Forbidden("access denied")
+	}
+
+	return nil
+}
+
+// XXX: rename to something more descriptive
+// openAccess allows requests without authentication, provided they
+// have peer credentials and were received on snapd.socket
 type openAccess struct{}
 
 func (ac openAccess) CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError {

--- a/daemon/api_base_test.go
+++ b/daemon/api_base_test.go
@@ -561,6 +561,10 @@ func (s *apiBaseSuite) checkGetOnly(c *check.C, req *http.Request) {
 	c.Check(cmd.GET, check.NotNil)
 }
 
+func (s *apiBaseSuite) expectObserveAccess() {
+	s.expectedReadAccess = daemon.ObserveAccess{}
+}
+
 func (s *apiBaseSuite) expectOpenAccess() {
 	s.expectedReadAccess = daemon.OpenAccess{}
 }

--- a/daemon/api_general.go
+++ b/daemon/api_general.go
@@ -60,14 +60,14 @@ var (
 		Path:        "/v2/changes/{id}",
 		GET:         getChange,
 		POST:        abortChange,
-		ReadAccess:  openAccess{},
+		ReadAccess:  observeAccess{},
 		WriteAccess: authenticatedAccess{Polkit: polkitActionManage},
 	}
 
 	stateChangesCmd = &Command{
 		Path:       "/v2/changes",
 		GET:        getChanges,
-		ReadAccess: openAccess{},
+		ReadAccess: observeAccess{},
 	}
 
 	warningsCmd = &Command{

--- a/daemon/api_general_test.go
+++ b/daemon/api_general_test.go
@@ -373,6 +373,8 @@ func (s *generalSuite) TestStateChangesDefaultToInProgress(c *check.C) {
 	setupChanges(st)
 	st.Unlock()
 
+	s.expectObserveAccess()
+
 	// Execute
 	req, err := http.NewRequest("GET", "/v2/changes", nil)
 	c.Assert(err, check.IsNil)
@@ -401,6 +403,8 @@ func (s *generalSuite) TestStateChangesInProgress(c *check.C) {
 	setupChanges(st)
 	st.Unlock()
 
+	s.expectObserveAccess()
+
 	// Execute
 	req, err := http.NewRequest("GET", "/v2/changes?select=in-progress", nil)
 	c.Assert(err, check.IsNil)
@@ -428,6 +432,8 @@ func (s *generalSuite) TestStateChangesAll(c *check.C) {
 	st.Lock()
 	setupChanges(st)
 	st.Unlock()
+
+	s.expectObserveAccess()
 
 	// Execute
 	req, err := http.NewRequest("GET", "/v2/changes?select=all", nil)
@@ -458,6 +464,8 @@ func (s *generalSuite) TestStateChangesReady(c *check.C) {
 	setupChanges(st)
 	st.Unlock()
 
+	s.expectObserveAccess()
+
 	// Execute
 	req, err := http.NewRequest("GET", "/v2/changes?select=ready", nil)
 	c.Assert(err, check.IsNil)
@@ -485,6 +493,8 @@ func (s *generalSuite) TestStateChangesForSnapName(c *check.C) {
 	st.Lock()
 	setupChanges(st)
 	st.Unlock()
+
+	s.expectObserveAccess()
 
 	// Execute
 	req, err := http.NewRequest("GET", "/v2/changes?for=funky-snap-name&select=all", nil)
@@ -521,6 +531,8 @@ func (s *generalSuite) TestStateChangesForSnapNameWithApp(c *check.C) {
 
 	st.Unlock()
 
+	s.expectObserveAccess()
+
 	// Execute
 	req, err := http.NewRequest("GET", "/v2/changes?for=lxd&select=all", nil)
 	c.Assert(err, check.IsNil)
@@ -551,6 +563,8 @@ func (s *generalSuite) TestStateChange(c *check.C) {
 	chg := st.Change(ids[0])
 	chg.Set("api-data", map[string]int{"n": 42})
 	st.Unlock()
+
+	s.expectObserveAccess()
 
 	// Execute
 	req, err := http.NewRequest("GET", "/v2/changes/"+ids[0], nil)

--- a/daemon/export_access_test.go
+++ b/daemon/export_access_test.go
@@ -29,6 +29,7 @@ type (
 	AccessChecker = accessChecker
 
 	OpenAccess                = openAccess
+	ObserveAccess             = observeAccess
 	AuthenticatedAccess       = authenticatedAccess
 	RootAccess                = rootAccess
 	SnapAccess                = snapAccess

--- a/data/systemd/snapd.socket
+++ b/data/systemd/snapd.socket
@@ -3,6 +3,7 @@ Description=Socket activation for snappy daemon
 
 [Socket]
 ListenStream=/run/snapd.socket
+ListenStream=/run/snapd-ro.socket
 ListenStream=/run/snapd-snap.socket
 SocketMode=0666
 # these are the defaults, but can't hurt to specify them anyway:

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -55,6 +55,7 @@ var (
 	SnapKModModprobeDir    string
 	LocaleDir              string
 	SnapdSocket            string
+	SnapdRoSocket          string // SnapdObserveSocket?
 	SnapSocket             string
 	SnapRunDir             string
 	SnapRunNsDir           string
@@ -389,6 +390,7 @@ func SetRootDir(rootdir string) {
 
 	// keep in sync with the debian/snapd.socket file:
 	SnapdSocket = filepath.Join(rootdir, "/run/snapd.socket")
+	SnapdRoSocket = filepath.Join(rootdir, "/run/snapd-ro.socket")
 	SnapSocket = filepath.Join(rootdir, "/run/snapd-snap.socket")
 
 	SnapAssertsDBDir = filepath.Join(rootdir, snappyDir, "assertions")

--- a/interfaces/builtin/snapd_observe.go
+++ b/interfaces/builtin/snapd_observe.go
@@ -1,0 +1,58 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+const snapdObserveSummary = `allows observing snapd`
+
+const snapdObserveBaseDeclarationPlugs = `
+  snapd-observe:
+    allow-installation: false
+    deny-auto-connection: true
+`
+
+const snapdObserveBaseDeclarationSlots = `
+  snapd-observe:
+    allow-installation:
+      slot-snap-type:
+        - core
+    deny-auto-connection: true
+`
+
+const snapdObserveConnectedPlugAppArmor = `
+# Description: Can observe snaps via snapd.
+
+/run/snapd-ro.socket rw,
+`
+
+type snapObserveInterface struct {
+	commonInterface
+}
+
+func init() {
+	registerIface(&snapObserveInterface{commonInterface{
+		name:                  "snapd-observe",
+		summary:               snapdObserveSummary,
+		implicitOnCore:        true,
+		implicitOnClassic:     true,
+		baseDeclarationPlugs:  snapdObserveBaseDeclarationPlugs,
+		baseDeclarationSlots:  snapdObserveBaseDeclarationSlots,
+		connectedPlugAppArmor: snapdObserveConnectedPlugAppArmor,
+	}})
+}

--- a/interfaces/builtin/snapd_observe_test.go
+++ b/interfaces/builtin/snapd_observe_test.go
@@ -1,0 +1,79 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type SnapdObserveInterfaceSuite struct {
+	iface    interfaces.Interface
+	slotInfo *snap.SlotInfo
+	slot     *interfaces.ConnectedSlot
+	plugInfo *snap.PlugInfo
+	plug     *interfaces.ConnectedPlug
+}
+
+var _ = Suite(&SnapdObserveInterfaceSuite{
+	iface: builtin.MustInterface("snapd-observe"),
+})
+
+func (s *SnapdObserveInterfaceSuite) SetUpTest(c *C) {
+	consumingSnapInfo := snaptest.MockInfo(c, `
+name: other
+version: 0
+apps:
+ app:
+    command: foo
+    plugs: [snapd-observe]
+`, nil)
+	s.slotInfo = &snap.SlotInfo{
+		Snap:      &snap.Info{SuggestedName: "core", SnapType: snap.TypeOS},
+		Name:      "snapd-observe",
+		Interface: "snapd-observe",
+	}
+	s.slot = interfaces.NewConnectedSlot(s.slotInfo, nil, nil)
+	s.plugInfo = consumingSnapInfo.Plugs["snapd-observe"]
+	s.plug = interfaces.NewConnectedPlug(s.plugInfo, nil, nil)
+}
+
+func (s *SnapdObserveInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "snapd-observe")
+}
+
+func (s *SnapdObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
+	// connected plugs have a non-nil security snippet for apparmor
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
+	c.Assert(err, IsNil)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, `/run/snapd-ro.socket rw,`)
+}
+
+func (s *SnapdObserveInterfaceSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}

--- a/tests/main/snapd-ro/task.yaml
+++ b/tests/main/snapd-ro/task.yaml
@@ -1,0 +1,29 @@
+summary: Ensure the snapd read-only socket is really read-only
+
+execute: |
+  # ensure no install can happen via the snapd-ro socket
+  SOCKET=/run/snapd-ro.socket
+  curl -v --data '{"action":"install","name":"test-snapd-sh"}' \
+     --unix-socket "$SOCKET" \
+     http://localhost/v2/snaps/test-snapd-sh > output.txt
+  MATCH '"type":"error"' < output.txt
+  MATCH '"status-code":403' < output.txt
+  MATCH '"status":"Forbidden"' < output.txt
+
+  # but using the normal socket works fine
+  SOCKET=/run/snapd.socket
+  curl -v --data '{"action":"install","name":"test-snapd-sh"}' \
+     --unix-socket "$SOCKET" \
+     http://localhost/v2/snaps/test-snapd-sh > output.txt
+  MATCH '"type":"async"' < output.txt
+  MATCH '"status-code":202' < output.txt
+  MATCH '"status":"Accepted"' < output.txt
+
+  # access to the /v2/changes endpoint on snapd-ro is granted
+  SOCKET=/run/snapd-ro.socket
+  curl -v --unix-socket "$SOCKET" \
+     http://localhost/v2/changes?select=all > output.txt
+  MATCH '"status-code":200' < output.txt
+  MATCH '"status":"OK"' < output.txt
+  # TODO: add jq checks
+  


### PR DESCRIPTION
This is draft/RFC of a potentially alternative way how the gnome-desktop-integration could keep track of changes and calculate progress for snap that get refreshed via refresh-app-awareness. Fine to close if it's deemed unfit for the purpose.

This commit adds a new /run/snapd-ro.socket that and a new access daemon API access checker called `observeAccess` that can be used to make API functions available on the read-only socket.

In addition there is a new `snapd-observe` interface that allows access to the new `/run/snapd-ro.socket` that will allow access to this new socket (at this point still super privileged until it's clear how freely we want to give it away).

Initially the snapd-ro socket will only grant access to the `/v2/changes` API. Alternatively we could make everything under the current `openAccess` available on the observe socket but that needs a closer audit.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
