### PR TITLE
tests/core/custom-device: added system ubuntu-core-20-*

### DIFF
--- a/tests/core/custom-device-reg/task.yaml
+++ b/tests/core/custom-device-reg/task.yaml
@@ -2,9 +2,7 @@ summary: |
     Test that device initialisation and registration can be customized
     with the prepare-device gadget hook
 
-# TODO:UC20: enable for UC20, it assumes /var/lib/snapd/seed/assertions/model
-#            which we don't have currently
-systems: [ubuntu-core-1*]
+systems: [ubuntu-core-1*, ubuntu-core-20-*]
 
 prepare: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then


### PR DESCRIPTION
This PR is currently only meant for testing spread changes on full infrastructure.

First step: Added system `ubuntu-core-20-*` to one of the tests `tests/core/custom-device-reg/task.yaml`. This enables the following new permutations for testing: 
 - `external:ubuntu-core-20-64:tests/core/custom-device-reg`
 - `external:ubuntu-core-20-arm-32:tests/core/custom-device-reg`
 - `external:ubuntu-core-20-arm-64:tests/core/custom-device-reg`
 - `google:ubuntu-core-20-64:tests/core/custom-device-reg`
 - `qemu:ubuntu-core-20-64:tests/core/custom-device-reg`
