### PR TITLE
i/b/physical_memory_observe: allow reading virt-phys page mappings

### DIFF
--- a/interfaces/builtin/physical_memory_observe.go
+++ b/interfaces/builtin/physical_memory_observe.go
@@ -35,6 +35,9 @@ const physicalMemoryObserveConnectedPlugAppArmor = `
 # access to architecture-specific subset of the physical address (eg, PCI,
 # space, BIOS code and data regions on x86, etc).
 /dev/mem r,
+
+# Allow reading info about the physical mapping of virtual pages
+@{PROC}/@{pids}/pagemap r,
 `
 
 var physicalMemoryObserveConnectedPlugUDev = []string{`KERNEL=="mem"`}

--- a/interfaces/builtin/physical_memory_observe_test.go
+++ b/interfaces/builtin/physical_memory_observe_test.go
@@ -81,6 +81,7 @@ func (s *PhysicalMemoryObserveInterfaceSuite) TestAppArmorSpec(c *C) {
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/dev/mem r,`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `@{PROC}/@{pids}/pagemap r,`)
 }
 
 func (s *PhysicalMemoryObserveInterfaceSuite) TestUDevSpec(c *C) {


### PR DESCRIPTION
I left this pretty permissive (`@{PROC}/@{pids}/pagemap` vs `owner @{PROC}/@{pid}/pagemap`) as I think that potentially fits more within the spirit of being able to observe all physical memory, but am happy to narrow it if that is seen as more appropriate.

John Johansen also noted that if we wanted to narrow it to "physical memory per process" as opposed to "all physical memory", we could probably use `ptrace r peer=snap...` or something. 