### PR TITLE
[1/X] Integrity data for snaps: assertion changes

### DIFF
--- a/asserts/header_checks.go
+++ b/asserts/header_checks.go
@@ -197,34 +197,42 @@ func checkRFC3339DateWithDefaultWhat(m map[string]interface{}, name, what string
 }
 
 func checkUint(headers map[string]interface{}, name string, bitSize int) (uint64, error) {
-	valueStr, err := checkNotEmptyString(headers, name)
+	return checkUintWhat(headers, name, bitSize, "header")
+}
+
+func checkUintWhat(headers map[string]interface{}, name string, bitSize int, what string) (uint64, error) {
+	valueStr, err := checkNotEmptyStringWhat(headers, name, what)
 	if err != nil {
 		return 0, err
 	}
 	value, err := strconv.ParseUint(valueStr, 10, bitSize)
 	if err != nil {
 		if ne, ok := err.(*strconv.NumError); ok && ne.Err == strconv.ErrRange {
-			return 0, fmt.Errorf("%q header is out of range: %v", name, valueStr)
+			return 0, fmt.Errorf("%q %s is out of range: %v", name, what, valueStr)
 		}
-		return 0, fmt.Errorf("%q header is not an unsigned integer: %v", name, valueStr)
+		return 0, fmt.Errorf("%q %s is not an unsigned integer: %v", name, what, valueStr)
 	}
 	if prefixZeros(valueStr) {
-		return 0, fmt.Errorf("%q header has invalid prefix zeros: %s", name, valueStr)
+		return 0, fmt.Errorf("%q %s has invalid prefix zeros: %s", name, what, valueStr)
 	}
 	return value, nil
 }
 
 func checkDigest(headers map[string]interface{}, name string, h crypto.Hash) ([]byte, error) {
-	digestStr, err := checkNotEmptyString(headers, name)
+	return checkDigestWhat(headers, name, h, "header")
+}
+
+func checkDigestWhat(headers map[string]interface{}, name string, h crypto.Hash, what string) ([]byte, error) {
+	digestStr, err := checkNotEmptyStringWhat(headers, name, what)
 	if err != nil {
 		return nil, err
 	}
 	b, err := base64.RawURLEncoding.DecodeString(digestStr)
 	if err != nil {
-		return nil, fmt.Errorf("%q header cannot be decoded: %v", name, err)
+		return nil, fmt.Errorf("%q %s cannot be decoded: %v", name, what, err)
 	}
 	if len(b) != h.Size() {
-		return nil, fmt.Errorf("%q header does not have the expected bit length: %d", name, len(b)*8)
+		return nil, fmt.Errorf("%q %s does not have the expected bit length: %d", name, what, len(b)*8)
 	}
 
 	return b, nil

--- a/asserts/snap_asserts.go
+++ b/asserts/snap_asserts.go
@@ -445,6 +445,13 @@ func (ra *RevisionAuthority) Check(rev *SnapRevision, model *Model, store *Store
 	return nil
 }
 
+// SnapIntegrity holds information about integrity data included in a revision
+// for a given snap.
+type SnapIntegrity struct {
+	SHA3_384 string
+	Size     uint64
+}
+
 // SnapFileSHA3_384 computes the SHA3-384 digest of the given snap file.
 // It also returns its size.
 func SnapFileSHA3_384(snapPath string) (digest string, size uint64, err error) {
@@ -534,6 +541,8 @@ type SnapRevision struct {
 	snapSize     uint64
 	snapRevision int
 	timestamp    time.Time
+
+	snapIntegrity *SnapIntegrity
 }
 
 // SnapSHA3_384 returns the SHA3-384 digest of the snap.
@@ -571,6 +580,11 @@ func (snaprev *SnapRevision) DeveloperID() string {
 // Timestamp returns the time when the snap-revision was issued.
 func (snaprev *SnapRevision) Timestamp() time.Time {
 	return snaprev.timestamp
+}
+
+// SnapIntegrity returns the snap integrity data associated with the snap revision if any.
+func (snaprev *SnapRevision) SnapIntegrity() *SnapIntegrity {
+	return snaprev.snapIntegrity
 }
 
 // Implement further consistency checks.
@@ -679,11 +693,36 @@ func assembleSnapRevision(assert assertionBase) (Assertion, error) {
 		return nil, err
 	}
 
+	integrityMap, err := checkMap(assert.headers, "integrity")
+	if err != nil {
+		return nil, err
+	}
+
+	var snapIntegrity *SnapIntegrity
+
+	if integrityMap != nil {
+		_, err := checkDigestWhat(integrityMap, "sha3-384", crypto.SHA3_384, "of integrity header")
+		if err != nil {
+			return nil, err
+		}
+
+		size, err := checkUintWhat(integrityMap, "size", 64, "of integrity header")
+		if err != nil {
+			return nil, err
+		}
+
+		snapIntegrity = &SnapIntegrity{
+			SHA3_384: integrityMap["sha3-384"].(string),
+			Size:     size,
+		}
+	}
+
 	return &SnapRevision{
 		assertionBase: assert,
 		snapSize:      snapSize,
 		snapRevision:  snapRevision,
 		timestamp:     timestamp,
+		snapIntegrity: snapIntegrity,
 	}, nil
 }
 

--- a/asserts/snap_asserts_test.go
+++ b/asserts/snap_asserts_test.go
@@ -1002,6 +1002,25 @@ func (srs *snapRevSuite) makeValidEncoded() string {
 		"AXNpZw=="
 }
 
+func (srs *snapRevSuite) makeValidEncodedWithIntegrity() string {
+	return "type: snap-revision\n" +
+		"authority-id: store-id1\n" +
+		"snap-sha3-384: " + blobSHA3_384 + "\n" +
+		"snap-id: snap-id-1\n" +
+		"snap-size: 123\n" +
+		"snap-revision: 1\n" +
+		"integrity:\n" +
+		"  sha3-384: " + blobSHA3_384 + "\n" +
+		"  size: 128\n" +
+		"developer-id: dev-id1\n" +
+		"revision: 1\n" +
+		srs.tsLine +
+		"body-length: 0\n" +
+		"sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij" +
+		"\n\n" +
+		"AXNpZw=="
+}
+
 func makeSnapRevisionHeaders(overrides map[string]interface{}) map[string]interface{} {
 	headers := map[string]interface{}{
 		"authority-id":  "canonical",
@@ -1058,6 +1077,25 @@ func (srs *snapRevSuite) TestDecodeOKWithProvenance(c *C) {
 	c.Check(snapRev.Provenance(), Equals, "foo")
 }
 
+func (srs *snapRevSuite) TestDecodeOKWithIntegrity(c *C) {
+	encoded := srs.makeValidEncodedWithIntegrity()
+	a, err := asserts.Decode([]byte(encoded))
+	c.Assert(err, IsNil)
+	c.Check(a.Type(), Equals, asserts.SnapRevisionType)
+	snapRev := a.(*asserts.SnapRevision)
+	c.Check(snapRev.AuthorityID(), Equals, "store-id1")
+	c.Check(snapRev.Timestamp(), Equals, srs.ts)
+	c.Check(snapRev.SnapID(), Equals, "snap-id-1")
+	c.Check(snapRev.SnapSHA3_384(), Equals, blobSHA3_384)
+	c.Check(snapRev.SnapSize(), Equals, uint64(123))
+	c.Check(snapRev.SnapRevision(), Equals, 1)
+	c.Check(snapRev.DeveloperID(), Equals, "dev-id1")
+	c.Check(snapRev.Revision(), Equals, 1)
+	c.Check(snapRev.Provenance(), Equals, "global-upload")
+	c.Check(snapRev.SnapIntegrity().SHA3_384, Equals, blobSHA3_384)
+	c.Check(snapRev.SnapIntegrity().Size, Equals, uint64(128))
+}
+
 const (
 	snapRevErrPrefix = "assertion snap-revision: "
 )
@@ -1089,6 +1127,35 @@ func (srs *snapRevSuite) TestDecodeInvalid(c *C) {
 		{srs.tsLine, "", `"timestamp" header is mandatory`},
 		{srs.tsLine, "timestamp: \n", `"timestamp" header should not be empty`},
 		{srs.tsLine, "timestamp: 12:30\n", `"timestamp" header is not a RFC3339 date: .*`},
+	}
+
+	for _, test := range invalidTests {
+		invalid := strings.Replace(encoded, test.original, test.invalid, 1)
+		_, err := asserts.Decode([]byte(invalid))
+		c.Check(err, ErrorMatches, snapRevErrPrefix+test.expectedErr)
+	}
+}
+
+func (srs *snapRevSuite) TestDecodeInvalidWithIntegrity(c *C) {
+	encoded := srs.makeValidEncodedWithIntegrity()
+
+	integrityHdr := "integrity:\n" +
+		"  sha3-384: " + blobSHA3_384 + "\n" +
+		"  size: 128\n"
+
+	integrityShaHdr := "  sha3-384: " + blobSHA3_384 + "\n"
+
+	integritySizeHdr := "  size: 128\n"
+
+	invalidTests := []struct{ original, invalid, expectedErr string }{
+		{integrityHdr, "integrity: \n", `"integrity" header must be a map`},
+		{integrityShaHdr, "  sha3-384: \n", `"sha3-384" of integrity header should not be empty`},
+		{integrityShaHdr, "  sha3-384: #\n", `"sha3-384" of integrity header cannot be decoded:.*`},
+		{integrityShaHdr, "  sha3-384: eHl6\n", `"sha3-384" of integrity header does not have the expected bit length: 24`},
+		{integritySizeHdr, "", `"size" of integrity header is mandatory`},
+		{integritySizeHdr, "  size: \n", `"size" of integrity header should not be empty`},
+		{integritySizeHdr, "  size: -1\n", `"size" of integrity header is not an unsigned integer: -1`},
+		{integritySizeHdr, "  size: zzz\n", `"size" of integrity header is not an unsigned integer: zzz`},
 	}
 
 	for _, test := range invalidTests {


### PR DESCRIPTION
This depends on https://github.com/snapcore/snapd/pull/12460.

New commits start at https://github.com/snapcore/snapd/pull/12686/commits/adfba3b26ed0e3154a3f6604bb1849de70489a1c