### PR TITLE
sandbox/cgroup: change scope unit pattern to snap.<pkg>.<app>-<uuid>.scope

### DIFF
--- a/sandbox/cgroup/monitor_test.go
+++ b/sandbox/cgroup/monitor_test.go
@@ -252,7 +252,7 @@ func (s *monitorSuite) TestMonitorSnapEndedIntegration(c *C) {
 	s.AddCleanup(restore)
 
 	// make mock cgroups.procs file
-	mockProcsFile := filepath.Join(dirs.GlobalRootDir, "/sys/fs/cgroup/user.slice/user-1000.slice/user@1000.service/app.slice/snap.firefox.firefox.fa61f25b-92e1-4316-8acb-2b95af841855.scope/cgroup.procs")
+	mockProcsFile := filepath.Join(dirs.GlobalRootDir, "/sys/fs/cgroup/user.slice/user-1000.slice/user@1000.service/app.slice/snap.firefox.firefox-fa61f25b-92e1-4316-8acb-2b95af841855.scope/cgroup.procs")
 	err := os.MkdirAll(filepath.Dir(mockProcsFile), 0755)
 	c.Assert(err, IsNil)
 	err = ioutil.WriteFile(mockProcsFile, []byte("57003\n57004"), 0644)

--- a/sandbox/cgroup/scanning.go
+++ b/sandbox/cgroup/scanning.go
@@ -28,11 +28,18 @@ import (
 	"github.com/snapcore/snapd/snap/naming"
 )
 
+const (
+	uuidPattern = `[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}`
+)
+
 var (
+
 	// string that looks like a hook security tag
-	roughHookTagPattern = regexp.MustCompile(`snap\.[^.]+\.hook\.[^.]+`)
+	roughHookTagPattern         = regexp.MustCompile(`snap\.[^.]+\.hook\.[^.]+`)
+	roughHookTagPatternWithUUID = regexp.MustCompile(`(snap\.[^.]+\.hook\.[^.]+)(-` + uuidPattern + `)`)
 	// string that looks like an app security tag
-	roughAppTagPattern = regexp.MustCompile(`snap\.[^.]+\.[^.]+`)
+	roughAppTagPattern         = regexp.MustCompile(`snap\.[^.]+\.[^.]+`)
+	roughAppTagPatternWithUUID = regexp.MustCompile(`(snap\.[^.]+\.[^.]+)(-` + uuidPattern + `)`)
 )
 
 // securityTagFromCgroupPath returns a security tag from cgroup path.
@@ -50,13 +57,31 @@ func securityTagFromCgroupPath(path string) naming.SecurityTag {
 	// from a snap.
 	// Expected format of leaf name:
 	//   snap.<pkg>.<app>.service - assigned by systemd for services
-	//   snap.<pkg>.<app>.<uuid>.scope - transient scope for apps
-	//   snap.<pkg>.hook.<app>.<uuid>.scope - transient scope for hooks
+	//   snap.<pkg>.<app>-<uuid>.scope - transient scope for apps
+	//   snap.<pkg>.hook.<app>-<uuid>.scope - transient scope for hooks
 	if ext := filepath.Ext(leaf); ext != ".service" && ext != ".scope" {
 		return nil
 	}
 
-	// There are two broad forms expressed by the pair of regular expressions defined above.
+	// The original naming convention for scope transient units was
+	// snap.<pkg>.<app>.<uuid>.scope, but is now
+	// snap.<pkg>.<app>-<uuid>.scope.
+	//
+	// Check for the new patterns first, and then fall back to the original
+	// patterns if those fail. This ensures that we still match service
+	// units which do not specify a UUID, and also makes sure the
+	// transition between these two naming conventions is smooth.
+	for _, re := range []*regexp.Regexp{roughHookTagPatternWithUUID, roughAppTagPatternWithUUID} {
+		// If the string matches, we expect the whole match in the
+		// first position, the tag submatch in the second position, and
+		// the UUID submatch in the third position.
+		if matches := re.FindStringSubmatch(leaf); len(matches) == 3 {
+			if tag, err := naming.ParseSecurityTag(matches[1]); err == nil {
+				return tag
+			}
+		}
+	}
+
 	for _, re := range []*regexp.Regexp{roughHookTagPattern, roughAppTagPattern} {
 		if maybeTag := re.FindString(leaf); maybeTag != "" {
 			if tag, err := naming.ParseSecurityTag(maybeTag); err == nil {
@@ -64,6 +89,7 @@ func securityTagFromCgroupPath(path string) naming.SecurityTag {
 			}
 		}
 	}
+
 	return nil
 }
 

--- a/sandbox/cgroup/scanning_test.go
+++ b/sandbox/cgroup/scanning_test.go
@@ -59,15 +59,22 @@ func mustParseTag(tag string) naming.SecurityTag {
 func (s *scanningSuite) TestSecurityTagFromCgroupPath(c *C) {
 	c.Check(cgroup.SecurityTagFromCgroupPath("/a/b/snap.foo.foo.service"), DeepEquals, mustParseTag("snap.foo.foo"))
 	c.Check(cgroup.SecurityTagFromCgroupPath("/a/b/snap.foo.bar.service"), DeepEquals, mustParseTag("snap.foo.bar"))
-	c.Check(cgroup.SecurityTagFromCgroupPath("/a/b/snap.foo.bar.$RANDOM.scope"), DeepEquals, mustParseTag("snap.foo.bar"))
-	c.Check(cgroup.SecurityTagFromCgroupPath("/a/b/snap.foo.hook.bar.$RANDOM.scope"), DeepEquals, mustParseTag("snap.foo.hook.bar"))
+	// We should be able to match both the old and new naming convention for scope units.
+	c.Check(cgroup.SecurityTagFromCgroupPath("/a/b/snap.foo.bar-54b38acc-3ba2-4c6d-b284-7ac07e1159e5.scope"), DeepEquals, mustParseTag("snap.foo.bar"))
+	c.Check(cgroup.SecurityTagFromCgroupPath("/a/b/snap.foo.bar-baz-54b38acc-3ba2-4c6d-b284-7ac07e1159e5.scope"), DeepEquals, mustParseTag("snap.foo.bar-baz"))
+	c.Check(cgroup.SecurityTagFromCgroupPath("/a/b/snap.foo.hook.bar-54b38acc-3ba2-4c6d-b284-7ac07e1159e5.scope"), DeepEquals, mustParseTag("snap.foo.hook.bar"))
+	c.Check(cgroup.SecurityTagFromCgroupPath("/a/b/snap.foo.hook.bar-baz-54b38acc-3ba2-4c6d-b284-7ac07e1159e5.scope"), DeepEquals, mustParseTag("snap.foo.hook.bar-baz"))
+	c.Check(cgroup.SecurityTagFromCgroupPath("/a/b/snap.foo.bar.54b38acc-3ba2-4c6d-b284-7ac07e1159e5.scope"), DeepEquals, mustParseTag("snap.foo.bar"))
+	c.Check(cgroup.SecurityTagFromCgroupPath("/a/b/snap.foo.bar-baz.54b38acc-3ba2-4c6d-b284-7ac07e1159e5.scope"), DeepEquals, mustParseTag("snap.foo.bar-baz"))
+	c.Check(cgroup.SecurityTagFromCgroupPath("/a/b/snap.foo.hook.bar.54b38acc-3ba2-4c6d-b284-7ac07e1159e5.scope"), DeepEquals, mustParseTag("snap.foo.hook.bar"))
+	c.Check(cgroup.SecurityTagFromCgroupPath("/a/b/snap.foo.hook.bar-baz.54b38acc-3ba2-4c6d-b284-7ac07e1159e5.scope"), DeepEquals, mustParseTag("snap.foo.hook.bar-baz"))
 	// We are not confused by snapd things.
 	c.Check(cgroup.SecurityTagFromCgroupPath("/a/b/snap.service"), IsNil)
 	c.Check(cgroup.SecurityTagFromCgroupPath("/a/b/snapd.service"), IsNil)
 	c.Check(cgroup.SecurityTagFromCgroupPath("/a/b/snap.foo.mount"), IsNil)
 	// Real data looks like this.
-	c.Check(cgroup.SecurityTagFromCgroupPath("snap.test-snapd-refresh.sh.d854bd35-2457-4ac8-b494-06061d74df33.scope"), DeepEquals, mustParseTag("snap.test-snapd-refresh.sh"))
-	c.Check(cgroup.SecurityTagFromCgroupPath("snap.test-snapd-refresh.hook.configure.d854bd35-2457-4ac8-b494-06061d74df33.scope"), DeepEquals, mustParseTag("snap.test-snapd-refresh.hook.configure"))
+	c.Check(cgroup.SecurityTagFromCgroupPath("snap.test-snapd-refresh.sh-d854bd35-2457-4ac8-b494-06061d74df33.scope"), DeepEquals, mustParseTag("snap.test-snapd-refresh.sh"))
+	c.Check(cgroup.SecurityTagFromCgroupPath("snap.test-snapd-refresh.hook.configure-d854bd35-2457-4ac8-b494-06061d74df33.scope"), DeepEquals, mustParseTag("snap.test-snapd-refresh.hook.configure"))
 	// Trailing slashes are automatically handled.
 	c.Check(cgroup.SecurityTagFromCgroupPath("/a/b/snap.foo.foo.service/"), DeepEquals, mustParseTag("snap.foo.foo"))
 }
@@ -181,7 +188,7 @@ func (s *scanningSuite) TestPidsOfSnapSecurityTags(c *C) {
 		defer restore()
 
 		// Pids are collected and assigned to bins by security tag
-		s.writePids(c, "system.slice/snap.pkg.hook.configure.$RANDOM.scope", []int{1})
+		s.writePids(c, "system.slice/snap.pkg.hook.configure-54b38acc-3ba2-4c6d-b284-7ac07e1159e5.scope", []int{1})
 		s.writePids(c, "system.slice/snap.pkg.daemon.service", []int{2})
 
 		pids, err := cgroup.PidsOfSnap("pkg")
@@ -203,7 +210,7 @@ func (s *scanningSuite) TestPathsOfSnapWithSecurityTags(c *C) {
 		defer restore()
 
 		// Pids are collected and assigned to bins by security tag
-		path1 := s.writePids(c, "system.slice/snap.pkg.hook.configure.$RANDOM.scope", []int{1})
+		path1 := s.writePids(c, "system.slice/snap.pkg.hook.configure-54b38acc-3ba2-4c6d-b284-7ac07e1159e5.scope", []int{1})
 		path2 := s.writePids(c, "system.slice/snap.pkg.daemon.service", []int{2})
 
 		paths, err := cgroup.InstancePathsOfSnap("pkg", options)
@@ -290,10 +297,10 @@ func (s *scanningSuite) TestPidsOfAggregation(c *C) {
 
 		// A single snap may be invoked by multiple users in different sessions.
 		// All of their PIDs are collected though.
-		s.writePids(c, "user.slice/user-1000.slice/user@1000.service/gnome-shell-wayland.service/snap.pkg.app.$RANDOM1.scope", []int{1}) // mock 1st invocation
-		s.writePids(c, "user.slice/user-1000.slice/user@1000.service/gnome-shell-wayland.service/snap.pkg.app.$RANDOM2.scope", []int{2}) // mock fork() by pid 1
-		s.writePids(c, "user.slice/user-1001.slice/user@1001.service/gnome-shell-wayland.service/snap.pkg.app.$RANDOM3.scope", []int{3}) // mock 2nd invocation
-		s.writePids(c, "user.slice/user-1001.slice/user@1001.service/gnome-shell-wayland.service/snap.pkg.app.$RANDOM4.scope", []int{4}) // mock fork() by pid 3
+		s.writePids(c, "user.slice/user-1000.slice/user@1000.service/gnome-shell-wayland.service/snap.pkg.app-54b38acc-3ba2-4c6d-b284-7ac07e1159e1.scope", []int{1}) // mock 1st invocation
+		s.writePids(c, "user.slice/user-1000.slice/user@1000.service/gnome-shell-wayland.service/snap.pkg.app-54b38acc-3ba2-4c6d-b284-7ac07e1159e2.scope", []int{2}) // mock fork() by pid 1
+		s.writePids(c, "user.slice/user-1001.slice/user@1001.service/gnome-shell-wayland.service/snap.pkg.app-54b38acc-3ba2-4c6d-b284-7ac07e1159e3.scope", []int{3}) // mock 2nd invocation
+		s.writePids(c, "user.slice/user-1001.slice/user@1001.service/gnome-shell-wayland.service/snap.pkg.app-54b38acc-3ba2-4c6d-b284-7ac07e1159e4.scope", []int{4}) // mock fork() by pid 3
 
 		pids, err := cgroup.PidsOfSnap("pkg")
 		c.Assert(err, IsNil, comment)
@@ -314,10 +321,10 @@ func (s *scanningSuite) TestPathsOfAggregation(c *C) {
 
 		// A single snap may be invoked by multiple users in different sessions.
 		// All of their PIDs are collected though.
-		path1 := s.writePids(c, "user.slice/user-1000.slice/user@1000.service/gnome-shell-wayland.service/snap.pkg.app.$RANDOM1.scope", []int{1}) // mock 1st invocation
-		path2 := s.writePids(c, "user.slice/user-1000.slice/user@1000.service/gnome-shell-wayland.service/snap.pkg.app.$RANDOM2.scope", []int{2}) // mock fork() by pid 1
-		path3 := s.writePids(c, "user.slice/user-1001.slice/user@1001.service/gnome-shell-wayland.service/snap.pkg.app.$RANDOM3.scope", []int{3}) // mock 2nd invocation
-		path4 := s.writePids(c, "user.slice/user-1001.slice/user@1001.service/gnome-shell-wayland.service/snap.pkg.app.$RANDOM4.scope", []int{4}) // mock fork() by pid 3
+		path1 := s.writePids(c, "user.slice/user-1000.slice/user@1000.service/gnome-shell-wayland.service/snap.pkg.app-54b38acc-3ba2-4c6d-b284-7ac07e1159e1.scope", []int{1}) // mock 1st invocation
+		path2 := s.writePids(c, "user.slice/user-1000.slice/user@1000.service/gnome-shell-wayland.service/snap.pkg.app-54b38acc-3ba2-4c6d-b284-7ac07e1159e2.scope", []int{2}) // mock fork() by pid 1
+		path3 := s.writePids(c, "user.slice/user-1001.slice/user@1001.service/gnome-shell-wayland.service/snap.pkg.app-54b38acc-3ba2-4c6d-b284-7ac07e1159e3.scope", []int{3}) // mock 2nd invocation
+		path4 := s.writePids(c, "user.slice/user-1001.slice/user@1001.service/gnome-shell-wayland.service/snap.pkg.app-54b38acc-3ba2-4c6d-b284-7ac07e1159e4.scope", []int{4}) // mock fork() by pid 3
 
 		paths, err := cgroup.InstancePathsOfSnap("pkg", options)
 		c.Assert(err, IsNil, comment)
@@ -337,10 +344,10 @@ func (s *scanningSuite) TestPidsOfSnapUnrelated(c *C) {
 
 		// We are not confusing snaps with other snaps, instances of our snap, and
 		// with non-snap hierarchies.
-		s.writePids(c, "user.slice/.../snap.pkg.app.$RANDOM1.scope", []int{1})
-		s.writePids(c, "user.slice/.../snap.other.snap.$RANDOM2.scope", []int{2})
+		s.writePids(c, "user.slice/.../snap.pkg.app-54b38acc-3ba2-4c6d-b284-7ac07e1159e5.scope", []int{1})
+		s.writePids(c, "user.slice/.../snap.other.snap-54b38acc-3ba2-4c6d-b284-7ac07e1159e5.scope", []int{2})
 		s.writePids(c, "user.slice/.../pkg.service", []int{3})
-		s.writePids(c, "user.slice/.../snap.pkg_instance.app.$RANDOM3.scope", []int{4})
+		s.writePids(c, "user.slice/.../snap.pkg_instance.app-54b38acc-3ba2-4c6d-b284-7ac07e1159e5.scope", []int{4})
 
 		// Write a file which is not cgroup.procs with the number 666 inside.
 		// We want to ensure this is not read by accident.
@@ -367,10 +374,10 @@ func (s *scanningSuite) TestPathsOfSnapUnrelated(c *C) {
 
 		// We are not confusing snaps with other snaps, instances of our snap, and
 		// with non-snap hierarchies.
-		path1 := s.writePids(c, "user.slice/.../snap.pkg.app.$RANDOM1.scope", []int{1})
-		path2 := s.writePids(c, "user.slice/.../snap.other.snap.$RANDOM2.scope", []int{2})
+		path1 := s.writePids(c, "user.slice/.../snap.pkg.app-54b38acc-3ba2-4c6d-b284-7ac07e1159e5.scope", []int{1})
+		path2 := s.writePids(c, "user.slice/.../snap.other.snap-54b38acc-3ba2-4c6d-b284-7ac07e1159e5.scope", []int{2})
 		path3 := s.writePids(c, "user.slice/.../pkg.service", []int{3})
-		path4 := s.writePids(c, "user.slice/.../snap.pkg_instance.app.$RANDOM3.scope", []int{4})
+		path4 := s.writePids(c, "user.slice/.../snap.pkg_instance.app-54b38acc-3ba2-4c6d-b284-7ac07e1159e5.scope", []int{4})
 
 		// Write a file which is not cgroup.procs with the number 666 inside.
 		// We want to ensure this is not read by accident.

--- a/sandbox/cgroup/tracking.go
+++ b/sandbox/cgroup/tracking.go
@@ -86,7 +86,7 @@ func CreateTransientScopeForTracking(securityTag string, opts *TrackingOptions) 
 	// - the originally started scope must be marked as a delegate, with all
 	//   consequences.
 	// - the method AttachProcessesToUnit is unavailable on Ubuntu 16.04
-	unitName := fmt.Sprintf("%s.%s.scope", securityTag, uuid)
+	unitName := fmt.Sprintf("%s-%s.scope", securityTag, uuid)
 
 	pid := osGetpid()
 	start := time.Now()

--- a/sandbox/cgroup/tracking_test.go
+++ b/sandbox/cgroup/tracking_test.go
@@ -118,7 +118,7 @@ func (s *trackingSuite) TestCreateTransientScopeForTrackingFeatureEnabled(c *C) 
 			defer func() {
 				close(signalChan)
 			}()
-			return []*dbus.Message{checkAndRespondToStartTransientUnit(c, msg, "snap.pkg.app."+uuid+".scope", 312123)}, nil
+			return []*dbus.Message{checkAndRespondToStartTransientUnit(c, msg, "snap.pkg.app-"+uuid+".scope", 312123)}, nil
 		case 2:
 			return []*dbus.Message{checkSystemSignalUnsubscribe(c, msg)}, nil
 		}
@@ -127,7 +127,7 @@ func (s *trackingSuite) TestCreateTransientScopeForTrackingFeatureEnabled(c *C) 
 	go func() {
 		select {
 		case <-signalChan:
-			inject(mockJobRemovedSignal("snap.pkg.app."+uuid+".scope", "done"))
+			inject(mockJobRemovedSignal("snap.pkg.app-"+uuid+".scope", "done"))
 		}
 	}()
 	c.Assert(err, IsNil)
@@ -135,7 +135,7 @@ func (s *trackingSuite) TestCreateTransientScopeForTrackingFeatureEnabled(c *C) 
 	defer restore()
 	// Replace the cgroup analyzer function
 	restore = cgroup.MockCgroupProcessPathInTrackingCgroup(func(pid int) (string, error) {
-		return "/user.slice/user-12345.slice/user@12345.service/snap.pkg.app." + uuid + ".scope", nil
+		return "/user.slice/user-12345.slice/user@12345.service/snap.pkg.app-" + uuid + ".scope", nil
 	})
 	defer restore()
 
@@ -245,7 +245,7 @@ func (s *trackingSuite) TestCreateTransientScopeForTrackingUnhappyRootFallback(c
 	// Rig the cgroup analyzer to pretend that we got placed into the system slice.
 	restore = cgroup.MockCgroupProcessPathInTrackingCgroup(func(pid int) (string, error) {
 		c.Assert(pid, Equals, 312123)
-		return "/system.slice/snap.pkg.app." + uuid + ".scope", nil
+		return "/system.slice/snap.pkg.app-" + uuid + ".scope", nil
 	})
 	defer restore()
 
@@ -423,14 +423,14 @@ func (s *trackingSuite) TestCreateTransientScopeForRootOnSystemBus(c *C) {
 	// call was made on the system bus, as requested by TrackingOptions below.
 	restore = cgroup.MockDoCreateTransientScope(func(conn *dbus.Conn, unitName string, pid int) error {
 		c.Assert(conn, Equals, systemBus)
-		c.Assert(unitName, Equals, "snap.pkg.app."+uuid+".scope")
+		c.Assert(unitName, Equals, "snap.pkg.app-"+uuid+".scope")
 		return nil
 	})
 	defer restore()
 
 	// Rig the cgroup analyzer to indicate successful tracking.
 	restore = cgroup.MockCgroupProcessPathInTrackingCgroup(func(pid int) (string, error) {
-		return "snap.pkg.app." + uuid + ".scope", nil
+		return "snap.pkg.app-" + uuid + ".scope", nil
 	})
 	defer restore()
 
@@ -471,7 +471,7 @@ func (s *trackingSuite) testCreateTransientScopeConfirm(c *C, tc testTransientSc
 	defer restore()
 	restore = cgroup.MockDoCreateTransientScope(func(conn *dbus.Conn, unitName string, pid int) error {
 		c.Assert(conn, Equals, sessionBus)
-		c.Assert(unitName, Equals, "snap.pkg.app."+tc.uuid+".scope")
+		c.Assert(unitName, Equals, "snap.pkg.app-"+tc.uuid+".scope")
 		return nil
 	})
 	defer restore()
@@ -497,7 +497,7 @@ func (s *trackingSuite) TestCreateTransientScopeConfirmHappy(c *C) {
 	uuid := "cc98cd01-6a25-46bd-b71b-82069b71b770"
 	s.testCreateTransientScopeConfirm(c, testTransientScopeConfirm{
 		uuid:        uuid,
-		confirmUnit: "foo/bar/baz/snap.pkg.app." + uuid + ".scope",
+		confirmUnit: "foo/bar/baz/snap.pkg.app-" + uuid + ".scope",
 	})
 }
 
@@ -648,10 +648,10 @@ func (s *trackingSuite) TestCreateTransientScopeHappyWithRetriedCheckCgroupV1(c 
 		c.Logf("%v got msg: %v", n, msg)
 		switch n {
 		case 0:
-			return []*dbus.Message{checkAndRespondToStartTransientUnit(c, msg, "snap.pkg.app."+uuid+".scope", 312123)}, nil
+			return []*dbus.Message{checkAndRespondToStartTransientUnit(c, msg, "snap.pkg.app-"+uuid+".scope", 312123)}, nil
 			// CreateTransientScopeForTracking is called twice in the test
 		case 1:
-			return []*dbus.Message{checkAndRespondToStartTransientUnit(c, msg, "snap.pkg.app."+uuid+".scope", 312123)}, nil
+			return []*dbus.Message{checkAndRespondToStartTransientUnit(c, msg, "snap.pkg.app-"+uuid+".scope", 312123)}, nil
 		}
 		return nil, fmt.Errorf("unexpected message #%d: %s", n, msg)
 	})
@@ -667,7 +667,7 @@ func (s *trackingSuite) TestCreateTransientScopeHappyWithRetriedCheckCgroupV1(c 
 		if pathInTrackingCgroupCalls < pathInTrackingCgroupCallsToSuccess {
 			return "vte-spawn-1234-1234-1234.scope", nil
 		}
-		return "snap.pkg.app." + uuid + ".scope", nil
+		return "snap.pkg.app-" + uuid + ".scope", nil
 	})
 	defer restore()
 
@@ -709,7 +709,7 @@ func (s *trackingSuite) TestCreateTransientScopeUnhappyJobFailed(c *C) {
 			defer func() {
 				close(signalChan)
 			}()
-			return []*dbus.Message{checkAndRespondToStartTransientUnit(c, msg, "snap.pkg.app."+uuid+".scope", 312123)}, nil
+			return []*dbus.Message{checkAndRespondToStartTransientUnit(c, msg, "snap.pkg.app-"+uuid+".scope", 312123)}, nil
 		case 2:
 			return []*dbus.Message{checkSystemSignalUnsubscribe(c, msg)}, nil
 		}
@@ -718,7 +718,7 @@ func (s *trackingSuite) TestCreateTransientScopeUnhappyJobFailed(c *C) {
 	go func() {
 		select {
 		case <-signalChan:
-			inject(mockJobRemovedSignal("snap.pkg.app."+uuid+".scope", "failed"))
+			inject(mockJobRemovedSignal("snap.pkg.app-"+uuid+".scope", "failed"))
 		}
 	}()
 
@@ -758,7 +758,7 @@ func (s *trackingSuite) TestCreateTransientScopeUnhappyJobTimeout(c *C) {
 		case 0:
 			return []*dbus.Message{checkSystemdSignalSubscribe(c, msg)}, nil
 		case 1:
-			return []*dbus.Message{checkAndRespondToStartTransientUnit(c, msg, "snap.pkg.app."+uuid+".scope", 312123)}, nil
+			return []*dbus.Message{checkAndRespondToStartTransientUnit(c, msg, "snap.pkg.app-"+uuid+".scope", 312123)}, nil
 		case 2:
 			return []*dbus.Message{checkSystemSignalUnsubscribe(c, msg)}, nil
 		}

--- a/tests/main/cgroup-tracking/task.yaml
+++ b/tests/main/cgroup-tracking/task.yaml
@@ -62,7 +62,7 @@ execute: |
     # was attached to the system slice, as it is not associated with any user.
     test -f /var/snap/test-snapd-tracking/common/configure.cgroup
     hook_tracking_cg_path="$(grep -E "^$base_cg_id:" < /var/snap/test-snapd-tracking/common/configure.cgroup | cut -d : -f 3)"
-    echo "$hook_tracking_cg_path" | MATCH '/system\.slice/snap\.test-snapd-tracking\.hook\.configure\.[0-9a-f-]+\.scope'
+    echo "$hook_tracking_cg_path" | MATCH '/system\.slice/snap\.test-snapd-tracking\.hook\.configure-[0-9a-f-]+\.scope'
 
     # The nap service was executed and was tracked as a systemd service.
     test -f /var/snap/test-snapd-tracking/common/nap.cgroup
@@ -118,7 +118,7 @@ execute: |
     echo "new transient scope. The scope name is \"snap.\$random.test-snapd-tracking.sh\"."
     echo "Let's verify that."
     pid1_tracking_cg_path="$(grep -E "^$base_cg_id:" < "/proc/$pid1_sleep/cgroup" | cut -d : -f 3)"
-    echo "$pid1_tracking_cg_path" | MATCH '.*/snap\.test-snapd-tracking\.sh\.[0-9a-f-]+\.scope'
+    echo "$pid1_tracking_cg_path" | MATCH '.*/snap\.test-snapd-tracking\.sh-[0-9a-f-]+\.scope'
 
     echo "Sanity check, cgroup associated with the scope exists."
     test -d "${base_cg_path}${pid1_tracking_cg_path}"
@@ -133,7 +133,7 @@ execute: |
     retry -n 30 test -e /tmp/snap-private-tmp/snap.test-snapd-tracking/tmp/2.stamp
     pid2_sleep=$(cat /tmp/2.pid)
     pid2_tracking_cg_path="$(grep -E "^$base_cg_id:" < "/proc/$pid2_sleep/cgroup" | cut -d : -f 3)"
-    echo "$pid2_tracking_cg_path" | MATCH '.*/snap\.test-snapd-tracking\.sh\.[0-9a-f-]+\.scope'
+    echo "$pid2_tracking_cg_path" | MATCH '.*/snap\.test-snapd-tracking\.sh-[0-9a-f-]+\.scope'
     MATCH "$pid2_sleep" < "${base_cg_path}${pid2_tracking_cg_path}/cgroup.procs"
 
     echo "Each invocation uses a new transient scope and thus a new cgroup path."
@@ -187,6 +187,6 @@ execute: |
     retry -n 30 test -e /var/snap/test-snapd-tracking/common/nap.cgroup
     pid4=$(cat /tmp/4.pid)
     pid4_tracking_cg_path="$(grep -E "^$base_cg_id:" < "/proc/$pid4/cgroup" | cut -d : -f 3)"
-    echo "$pid4_tracking_cg_path" | MATCH '.*/snap\.test-snapd-tracking\.nap\.[0-9a-f-]+\.scope'
+    echo "$pid4_tracking_cg_path" | MATCH '.*/snap\.test-snapd-tracking\.nap-[0-9a-f-]+\.scope'
     kill "$pid4"
     wait "$session4_pid" || true


### PR DESCRIPTION
The current naming pattern for transient scope units does not yield a natural way to create systemd drop-in configurations that apply to all instances of a snap, regardless of the UUID. For example, systemd drop-in configurations for a unit named foo-bar-baz.scope could be made by placing .conf snippets in any of the following directories:

 /etc/systemd/user/foo-bar-baz.scope.d/
 /etc/systemd/user/foo-bar-.scope.d/
 /etc/systemd/user/foo-.scope.d/

In other words, successively truncating the unit name after '-' yields valid drop-in directory names. This feature is specifc to '-', and in particular does not work with '.'.

It is desirable to have the ability to write drop-in configurations that apply, for example, to all instances of firefox. To allow this functionality, modify the pattern used for transient scope units to `snap.<pkg>.<app>-<uuid>.scope` (i.e. separate the app name and UUID by a '-').

Both the old and the new patterns are supported in an attempt to make a smooth transition.
