### PR TITLE
tests: update selinux policy to allow snapd to read upowerd binary

### DIFF
--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -452,6 +452,12 @@ allow snappy_t unconfined_service_t:process { getpgid sigkill };
 # not transition to a separate type and has no interface policy
 kernel_read_xen_state(snappy_t)
 
+# Allow snapd to read upowerd binary requiered by upower-observe interface
+gen_require(`
+    type devicekit_power_exec_t;
+')
+allow snappy_t devicekit_power_exec_t:file { getattr };
+
 ########################################
 #
 # snap-update-ns, snap-dicsard-ns local policy


### PR DESCRIPTION
This is required by upower-observe interface.

Some tests are failing in centos and fedora after the upowerObserveInterface was update in this way.

func (iface *upowerObserveInterface) StaticInfo() interfaces.StaticInfo {
...
		ImplicitOnCore:
osutil.IsExecutable("/usr/libexec/upowerd"),
...
}

This is to avoid this denial:

type=SYSCALL msg=audit(1679948376.046:1319): arch=c000003e syscall=262 success=yes exit=0 a0=ffffffffffffff9c a1=c0001e47b0 a2=c0001246b8 a3=0 items=0 ppid=1 pid=40320 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="snapd" exe="/usr/libexec/snapd/snapd" subj=system_u:system_r:snappy_t:s0 key=(null)
type=AVC msg=audit(1679948376.046:1319): avc:  denied  { getattr } for pid=40320 comm="snapd" path="/usr/libexec/upowerd" dev="sda2" ino=2180887 scontext=system_u:system_r:snappy_t:s0 tcontext=system_u:object_r:devicekit_power_exec_t:s0 tclass=file permissive=1
