### PR TITLE
o/snapstate: make monitoring survive across restarts

### DIFF
--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -471,3 +471,7 @@ func MockCgroupMonitorSnapEnded(f func(string, chan<- string) error) func() {
 		cgroupMonitorSnapEnded = old
 	}
 }
+
+func SetRestoredMonitoring(snapmgr *SnapManager, value bool) {
+	snapmgr.autoRefresh.restoredMonitoring = value
+}

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -9828,3 +9828,83 @@ func (s *snapmgrTestSuite) TestRefreshNoRelatedMonitoring(c *C) {
 
 	c.Assert(chg.Status(), Equals, state.DoneStatus)
 }
+
+func (s *snapmgrTestSuite) TestMonitoringIsPersistedAndRestored(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+	si := &snap.SideInfo{
+		RealName: "some-snap",
+		SnapID:   "some-snap-id",
+		Revision: snap.R(1),
+	}
+	snaptest.MockSnap(c, `name: some-snap`, si)
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active:   true,
+		Sequence: []*snap.SideInfo{si},
+		Current:  si.Revision,
+	})
+	snapsup := &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{
+			RealName: "some-snap",
+			Revision: snap.R(2),
+		},
+		Flags: snapstate.Flags{IsAutoRefresh: true},
+	}
+
+	restore := snapstate.MockAsyncPendingRefreshNotification(func(ctx context.Context, client *userclient.Client, refreshInfo *userclient.PendingSnapRefreshInfo) {})
+	defer restore()
+
+	restore = snapstate.MockRefreshAppsCheck(func(info *snap.Info) error {
+		c.Assert(info.InstanceName(), Equals, "some-snap")
+		return snapstate.NewBusySnapError(info, []int{123}, nil, nil)
+	})
+	defer restore()
+
+	var stopMonitor chan<- string
+	restore = snapstate.MockCgroupMonitorSnapEnded(func(name string, done chan<- string) error {
+		stopMonitor = done
+		c.Check(name, Equals, "some-snap")
+		return nil
+	})
+	defer restore()
+
+	preDlChg := s.state.NewChange("pre-download", "pre-download change")
+	preDlTask := s.state.NewTask("pre-download-snap", "pre-download task")
+
+	preDlTask.Set("snap-setup", snapsup)
+	preDlTask.Set("refresh-info", &userclient.PendingSnapRefreshInfo{InstanceName: "some-snap"})
+	preDlChg.AddTask(preDlTask)
+
+	s.settle(c)
+
+	c.Assert(preDlTask.Status(), Equals, state.DoneStatus)
+	// check there's still a goroutine monitoring the snap
+	monitoring := s.state.Cached("monitored-snaps")
+	c.Assert(monitoring, FitsTypeOf, map[string]chan<- bool{})
+	c.Assert(monitoring.(map[string]chan<- bool)["some-snap"], NotNil)
+
+	var monitored []string
+	c.Assert(s.state.Get("monitored-snaps", &monitored), IsNil)
+	c.Assert(monitored, DeepEquals, []string{"some-snap"})
+
+	// simulate a restart by stopping the monitoring but removing its effects
+	stopMonitor <- "some-snap"
+	s.state.Unlock()
+	waitForMonitoringEnd(s.state, c)
+
+	s.state.Lock()
+	s.state.Cache("monitored-snaps", nil)
+	s.state.Cache("auto-refresh-continue-attempt", nil)
+	s.state.Set("monitored-snaps", monitored)
+	snapstate.SetRestoredMonitoring(s.snapmgr, false)
+	s.state.Unlock()
+
+	// the first Ensure sets up the monitoring again
+	c.Assert(s.snapmgr.Ensure(), IsNil)
+	stopMonitor <- "some-snap"
+	waitForMonitoringEnd(s.state, c)
+	s.state.Lock()
+
+	c.Assert(s.state.Cached("monitored-snaps"), IsNil)
+	c.Check(s.state.Cached("auto-refresh-continue-attempt"), Equals, 1)
+}

--- a/tests/main/auto-refresh-pre-download/task.yaml
+++ b/tests/main/auto-refresh-pre-download/task.yaml
@@ -6,10 +6,18 @@ systems: [-ubuntu-14.04-*]
 kill-timeout: 5m
 
 environment:
-  REFRESH_TYPE/close: "close"
-  REFRESH_TYPE/ignore: "ignore-running"
+  # trigger the auto-refresh continuation by closing the snap
+  VARIANT/close: "close"
+  # explicitly tell snapd to do the auto-refresh
+  VARIANT/ignore: "ignore-running"
+  # snapd restarts while the snap is being monitored but the auto-refresh is still triggered
+  VARIANT/restart: "restart"
+  # the snap closes in the middle of a restart
+  VARIANT/close_mid_restart: "close-mid-restart"
 
 prepare: |
+  # ensure no other refreshes interfere with the test
+  snap refresh
   snap install --devmode jq
   snap install test-snapd-sh
 
@@ -79,16 +87,14 @@ execute: |
     MATCH 'string "Close the app to avoid disruptions \(.* days left\)"' < /home/test/notif.log
   fi
 
-  if [ "$REFRESH_TYPE" == "close" ]; then
-    CHANGE=$(snap changes | tail -n 2 | head -n 1 | awk '{print $1}')
-
+  OLD_CHANGE=$(snap changes | tail -n 2 | head -n 1 | awk '{print $1}')
+  if [ "$VARIANT" == "close" ]; then
     # stop the snap and check that an auto-refresh is triggered
     touch stamp
     wait "$APP_PID"
-    "$TESTSTOOLS"/snapd-state wait-for-snap-autorefresh "test-snapd-sh" "$CHANGE"
-  elif [ "$REFRESH_TYPE" == "ignore-running" ]; then
+    "$TESTSTOOLS"/snapd-state wait-for-snap-autorefresh "test-snapd-sh" "$OLD_CHANGE"
+  elif [ "$VARIANT" == "ignore-running" ]; then
     # refresh the snap while running
-    OLD_CHANGE=$(snap changes | tail -n 2 | head -n 1 | awk '{print $1}')
     snap refresh --ignore-running test-snapd-sh
 
     # check the refresh was completed
@@ -106,6 +112,20 @@ execute: |
       echo "unexpected auto-refresh of test-snapd-sh"
       exit 1
     fi
+  elif [ "$VARIANT" == "restart" ]; then
+    systemctl stop snapd.{service,socket}
+    systemctl start snapd.{socket,service}
+
+    touch stamp
+    wait "$APP_PID"
+    "$TESTSTOOLS"/snapd-state wait-for-snap-autorefresh "test-snapd-sh" "$OLD_CHANGE"
+  elif [ "$VARIANT" == "close-mid-restart" ]; then
+    systemctl stop snapd.{service,socket}
+    touch stamp
+    wait "$APP_PID"
+    systemctl start snapd.{socket,service}
+
+    "$TESTSTOOLS"/snapd-state wait-for-snap-autorefresh "test-snapd-sh" "$OLD_CHANGE"
   else
     echo "unrecognized test variant"
     exit 1


### PR DESCRIPTION
Persist some monitoring-related information and use them to create new monitoring goroutines when snapd starts. This logic ensures that the pre-download/continue auto-refresh UX flow survives restarts. This is important because if snapd is part of the auto-refresh, it will trigger a restart once it refreshes which would then wipe the monitoring state.