### PR TITLE
data: fix snapd.aa-prompt-ui.service to actually get started

### DIFF
--- a/data/systemd-user/Makefile
+++ b/data/systemd-user/Makefile
@@ -15,6 +15,7 @@
 
 SNAPD_ENVIRONMENT_FILE := /etc/environment
 BINDIR := /usr/bin
+LIBEXECDIR := /usr/lib
 SYSTEMDUSERUNITDIR := /usr/lib/systemd/user
 
 SYSTEMD_UNITS_GENERATED := $(wildcard *.in)
@@ -37,4 +38,5 @@ clean:
 %: %.in
 	cat $< | \
 		sed s:@bindir@:$(BINDIR):g | \
+		sed s:@libexecdir@:$(LIBEXECDIR):g | \
 		cat > $@

--- a/data/systemd-user/snapd.aa-prompt-ui.service.in
+++ b/data/systemd-user/snapd.aa-prompt-ui.service.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=snapd UI prompt
+ConditionPathExists=/sys/kernel/security/apparmor/.notify
 
 [Service]
-Type=dbus
-BusName=io.snapcraft.Prompt
-ExecStart=@bindir@/snapd-aa-prompt-ui
+Type=simple
+ExecStart=@libexecdir@/snapd/snapd-aa-prompt-ui

--- a/packaging/ubuntu-16.04/snapd.links
+++ b/packaging/ubuntu-16.04/snapd.links
@@ -4,3 +4,4 @@ usr/lib/snapd/snapctl usr/bin/snapctl
 # This should be removed once we can rely on debhelper >= 11.5:
 #     https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=764678
 /usr/lib/systemd/user/snapd.session-agent.socket /usr/lib/systemd/user/sockets.target.wants/snapd.session-agent.socket
+/usr/lib/systemd/user/snapd.aa-prompt-ui.service /usr/lib/systemd/user/default.target.wants/snapd.aa-prompt-ui.service


### PR DESCRIPTION
The current snapd.aa-prompt-ui.service user service is dbus activated. However this does not work with the latest prompt design.
