### PR TITLE
tests: fix the invalid signatures error in special-home-can-run-classic-snaps

### DIFF
--- a/tests/main/special-home-can-run-classic-snaps/task.yaml
+++ b/tests/main/special-home-can-run-classic-snaps/task.yaml
@@ -16,8 +16,8 @@ prepare: |
         jenkins)
             # Jenkins depends on java but not in the Debian sense.
             apt-get install -y default-jre-headless
-            wget -q -O - https://pkg.jenkins.io/debian-stable/jenkins.io.key | apt-key add -
-            echo 'deb http://pkg.jenkins.io/debian-stable binary/' > /etc/apt/sources.list.d/jenkins.list
+            curl -fsSL https://pkg.jenkins.io/debian/jenkins.io-2023.key | sudo tee /usr/share/keyrings/jenkins-keyring.asc > /dev/null
+            echo 'deb [signed-by=/usr/share/keyrings/jenkins-keyring.asc] https://pkg.jenkins.io/debian binary/' | sudo tee /etc/apt/sources.list.d/jenkins.list > /dev/null
             apt update
             apt install -y jenkins
             ;;


### PR DESCRIPTION
This is needed to fix the invalid signatures error:

W: GPG error: https://pkg.jenkins.io/debian-stable binary/ Release: The following signatures were invalid: EXPKEYSIG FCEF32E745F2C3D5 Jenkins Project <jenkinsci-board@googlegroups.com>
E: The repository 'http://pkg.jenkins.io/debian-stable binary/ Release' is not signed.
