### PR TITLE
tests: call prepare_memory_limit_override before the snapd state is saved

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -665,12 +665,11 @@ prepare_suite_each() {
     fi
 
     if [[ "$variant" = full ]]; then
-        # shellcheck source=tests/lib/prepare.sh
-        . "$TESTSLIB"/prepare.sh
         if os.query is-classic; then
+            # shellcheck source=tests/lib/prepare.sh
+            . "$TESTSLIB"/prepare.sh
             prepare_each_classic
         fi
-        prepare_memory_limit_override
     fi
 
     case "$SPREAD_SYSTEM" in

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -289,13 +289,7 @@ EOF
     # the re-exec setting may have changed in the service so we need
     # to ensure snapd is reloaded
     systemctl daemon-reload
-
-    # Leave some time for snapd to finish processing hooks
-    flush_changes
     systemctl restart snapd
-    # Snapd might need to run some hooks (prepare-device) which
-    # triggers `tests.invariant cgroup-scopes` false positives
-    flush_changes
 
     if [ ! -f /etc/systemd/system/snapd.service.d/local.conf ]; then
         echo "/etc/systemd/system/snapd.service.d/local.conf vanished!"
@@ -383,6 +377,7 @@ prepare_classic() {
         update_core_snap_for_classic_reexec
         systemctl start snapd.{service,socket}
 
+        prepare_memory_limit_override
         disable_refreshes
 
         # Check bootloader environment output in architectures different to s390x which uses zIPL
@@ -398,6 +393,7 @@ prepare_classic() {
         fi
 
         setup_experimental_features
+
         systemctl stop snapd.{service,socket}
         save_snapd_state
         systemctl start snapd.socket

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -276,25 +276,46 @@ EOF
     flush_changes
 }
 
-prepare_each_classic() {
-    mkdir -p /etc/systemd/system/snapd.service.d
-    if [ -z "${SNAP_REEXEC:-}" ]; then
-        rm -f /etc/systemd/system/snapd.service.d/reexec.conf
-    else
-        cat <<EOF > /etc/systemd/system/snapd.service.d/reexec.conf
+create_reexec_file(){
+    local reexec_file=$1
+    cat <<EOF > "$reexec_file"
 [Service]
 Environment=SNAP_REEXEC=$SNAP_REEXEC
 EOF
-    fi
-    # the re-exec setting may have changed in the service so we need
-    # to ensure snapd is reloaded
-    systemctl daemon-reload
-    systemctl restart snapd
+}
 
+prepare_reexec_override() {
+    local reexec_file=/etc/systemd/system/snapd.service.d/reexec.conf
+    local updated=false
+
+    # Just update reexec configuration when the SNAP_REEXEC var has been updated
+    # Otherwise it is used the configuration set during project preparation
+    mkdir -p /etc/systemd/system/snapd.service.d
+    if [ -z "${SNAP_REEXEC:-}" ] && [ -f "$reexec_file" ] ; then
+        rm -f "$reexec_file"
+        updated=true
+    elif [ -n "${SNAP_REEXEC:-}" ] && [ ! -f "$reexec_file" ]; then
+        create_reexec_file "$reexec_file"
+        updated=true
+    elif [ -n "${SNAP_REEXEC:-}" ] && NOMATCH "Environment=SNAP_REEXEC=$SNAP_REEXEC" < "$reexec_file"; then
+        create_reexec_file "$reexec_file"
+        updated=true
+    fi
+
+    if [ "$updated" = true ]; then
+        # the re-exec setting may have changed in the service so we need
+        # to ensure snapd is reloaded
+        systemctl daemon-reload
+        systemctl restart snapd
+    fi
+}
+
+prepare_each_classic() {
     if [ ! -f /etc/systemd/system/snapd.service.d/local.conf ]; then
         echo "/etc/systemd/system/snapd.service.d/local.conf vanished!"
         exit 1
     fi
+    prepare_reexec_override
 }
 
 prepare_classic() {
@@ -377,6 +398,7 @@ prepare_classic() {
         update_core_snap_for_classic_reexec
         systemctl start snapd.{service,socket}
 
+        prepare_reexec_override
         prepare_memory_limit_override
         disable_refreshes
 
@@ -1412,10 +1434,10 @@ prepare_ubuntu_core() {
 
     # Snapshot the fresh state (including boot/bootenv)
     if ! is_snapd_state_saved; then
-
         # important to remove disabled snaps before calling save_snapd_state
         # or restore will break
         remove_disabled_snaps
+        prepare_memory_limit_override
         setup_experimental_features
         systemctl stop snapd.service snapd.socket
         save_snapd_state

--- a/tests/main/snap-confine-from-core/task.yaml
+++ b/tests/main/snap-confine-from-core/task.yaml
@@ -23,9 +23,10 @@ execute: |
     fi
 
     echo "Ensure we re-exec by default"
-    snap list
-
-    "$TESTSTOOLS"/journal-state match-log "DEBUG: restarting into"
+    # It is not possible to check by using journal-state tools because the
+    # reexec "DEBUG: restarting into" line appears before the snapd state is
+    # saved, which is outside the scope of this test
+    /usr/bin/env SNAPD_DEBUG=1 snap list 2>&1 | MATCH "DEBUG: restarting into"
 
     echo "Ensure snap-confine from the core snap is run"
     test-snapd-sh.sh -c 'echo hello'


### PR DESCRIPTION
Avoid calling this function on every prepare because it is taking several seconds and it is delaying the whole test execution by more than 1 hour.
Currently, the tests are taking more than 2 hours instead of 70 minutes.

prepare_memory_limit_override is saving a configuration in /etc/systemd/system/snapd.service.d/. This directory is being restored during the prepare-each, so the change is to save the desired config before the snapd state is saved, so we make sure the config is applied for every test.

Also, reexec configuration is just updated when there is a change in SNAP_REEXEC var. By doing that, snapd is not needed to be restarted on every prepare-each.