### PR TITLE
many: add default-configure hook

### DIFF
--- a/overlord/configstate/configmgr.go
+++ b/overlord/configstate/configmgr.go
@@ -44,6 +44,9 @@ func MockConfigcoreRun(f func(sysconfig.Device, configcore.RunTransaction) error
 func Init(st *state.State, hookManager *hookstate.HookManager) error {
 	delayedCrossMgrInit()
 
+	// Default configuration is handled via the "default-configure" hook
+	hookManager.Register(regexp.MustCompile("^default-configure$"), newDefaultConfigureHandler)
+
 	// Most configuration is handled via the "configure" hook of the
 	// snaps. However some configuration is internally handled
 	hookManager.Register(regexp.MustCompile("^configure$"), newConfigureHandler)

--- a/overlord/configstate/configstate.go
+++ b/overlord/configstate/configstate.go
@@ -43,6 +43,7 @@ import (
 
 func init() {
 	snapstate.Configure = Configure
+	snapstate.DefaultConfigure = DefaultConfigure
 }
 
 func ConfigureHookTimeout() time.Duration {
@@ -130,6 +131,22 @@ func Configure(st *state.State, snapName string, patch map[string]interface{}, f
 	}
 
 	task := hookstate.HookTask(st, summary, hooksup, contextData)
+	return state.NewTaskSet(task)
+}
+
+// DefaultConfigure returns a taskset to apply the given default-configuration patch.
+func DefaultConfigure(st *state.State, snapName string) *state.TaskSet {
+	summary := fmt.Sprintf(i18n.G("Run default-configure hook of %q snap if present"), snapName)
+	hooksup := &hookstate.HookSetup{
+		Snap:     snapName,
+		Hook:     "default-configure",
+		Optional: true,
+		// all configure hooks must finish within this timeout
+		Timeout: ConfigureHookTimeout(),
+	}
+	// the default-configure hook always uses defaults, no need to indicate this
+	// by setting use-defaults flag in context data
+	task := hookstate.HookTask(st, summary, hooksup, nil)
 	return state.NewTaskSet(task)
 }
 

--- a/overlord/configstate/export_test.go
+++ b/overlord/configstate/export_test.go
@@ -27,6 +27,7 @@ import (
 )
 
 var NewConfigureHandler = newConfigureHandler
+var NewDefaultConfigureHandler = newDefaultConfigureHandler
 
 func MockConfigcoreExportExperimentalFlags(mock func(tr configcore.ConfGetter) error) (restore func()) {
 	old := configcoreExportExperimentalFlags

--- a/overlord/configstate/handler_test.go
+++ b/overlord/configstate/handler_test.go
@@ -22,6 +22,7 @@
 package configstate_test
 
 import (
+	"errors"
 	"io/ioutil"
 	"path/filepath"
 	"testing"
@@ -261,6 +262,169 @@ volumes:
 
 	err = s.handler.Before()
 	c.Check(err, ErrorMatches, `cannot apply gadget config defaults for snap "test-snap", no configure hook`)
+}
+
+type defaultConfigureHandlerSuite struct {
+	testutil.BaseTest
+
+	state                   *state.State
+	defaultConfigureContext *hookstate.Context
+	configureContext        *hookstate.Context
+	defaultConfigureHandler hookstate.Handler
+	configureHandler        hookstate.Handler
+}
+
+var _ = Suite(&defaultConfigureHandlerSuite{})
+
+func (s *defaultConfigureHandlerSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	dirs.SetRootDir(c.MkDir())
+	s.AddCleanup(func() { dirs.SetRootDir("/") })
+
+	s.state = state.New(nil)
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	var err error
+	task := s.state.NewTask("run-hook", "Run default-configure hook")
+	setup := &hookstate.HookSetup{Snap: "test-snap", Revision: snap.R(1), Hook: "default-configure"}
+	s.defaultConfigureContext, err = hookstate.NewContext(task, task.State(), setup, hooktest.NewMockHandler(), "")
+	c.Assert(err, IsNil)
+
+	task = s.state.NewTask("run-hook", "Run configure hook")
+	setup = &hookstate.HookSetup{Snap: "test-snap", Revision: snap.R(1), Hook: "configure"}
+	s.configureContext, err = hookstate.NewContext(task, task.State(), setup, hooktest.NewMockHandler(), "")
+	c.Assert(err, IsNil)
+
+	s.defaultConfigureHandler = configstate.NewDefaultConfigureHandler(s.defaultConfigureContext)
+	s.configureHandler = configstate.NewConfigureHandler(s.configureContext)
+}
+
+func (s *defaultConfigureHandlerSuite) TestBeforeNotInstalledError(c *C) {
+	err := s.defaultConfigureHandler.Before()
+	var notInstalledError *snap.NotInstalledError
+	c.Assert(errors.As(err, &notInstalledError), Equals, true)
+
+	s.defaultConfigureContext.Lock()
+	tr := configstate.ContextTransaction(s.defaultConfigureContext)
+	s.defaultConfigureContext.Unlock()
+	c.Check(len(tr.Changes()), Equals, 0)
+}
+
+func (s *defaultConfigureHandlerSuite) TestBeforeMissingConfigureHookError(c *C) {
+	const mockTestSnapYaml = `
+name: test-snap
+hooks:
+    default-configure:
+`
+	snaptest.MockSnap(c, mockTestSnapYaml, &snap.SideInfo{Revision: snap.R(11)})
+	s.state.Lock()
+	snapstate.Set(s.state, "test-snap", &snapstate.SnapState{
+		Active: true,
+		Sequence: []*snap.SideInfo{
+			{RealName: "test-snap", Revision: snap.R(11), SnapID: "testsnapidididididididididididid"},
+		},
+		Current:  snap.R(11),
+		SnapType: "app",
+	})
+	s.state.Unlock()
+
+	err := s.defaultConfigureHandler.Before()
+	c.Check(err, ErrorMatches, `cannot use default-configure hook for snap "test-snap", no configure hook`)
+
+	s.defaultConfigureContext.Lock()
+	tr := configstate.ContextTransaction(s.defaultConfigureContext)
+	s.defaultConfigureContext.Unlock()
+	c.Check(len(tr.Changes()), Equals, 0)
+}
+
+func (s *defaultConfigureHandlerSuite) TestBeforeUseDefaults(c *C) {
+	r := release.MockOnClassic(false)
+	defer r()
+
+	const mockGadgetSnapYaml = `
+name: canonical-pc
+type: gadget
+`
+	var mockGadgetYaml = []byte(`
+defaults:
+  testsnapidididididididididididid:
+      bar: baz
+      num: 1.305
+
+volumes:
+    volume-id:
+        bootloader: grub
+`)
+
+	info := snaptest.MockSnap(c, mockGadgetSnapYaml, &snap.SideInfo{Revision: snap.R(1)})
+	err := ioutil.WriteFile(filepath.Join(info.MountDir(), "meta", "gadget.yaml"), mockGadgetYaml, 0644)
+	c.Assert(err, IsNil)
+
+	s.state.Lock()
+	snapstate.Set(s.state, "canonical-pc", &snapstate.SnapState{
+		Active: true,
+		Sequence: []*snap.SideInfo{
+			{RealName: "canonical-pc", Revision: snap.R(1)},
+		},
+		Current:  snap.R(1),
+		SnapType: "gadget",
+	})
+
+	r = snapstatetest.MockDeviceModel(makeModel(map[string]interface{}{
+		"gadget": "canonical-pc",
+	}))
+	defer r()
+
+	const mockTestSnapYaml = `
+name: test-snap
+hooks:
+    default-configure:
+    configure:
+`
+
+	snaptest.MockSnap(c, mockTestSnapYaml, &snap.SideInfo{Revision: snap.R(11)})
+	snapstate.Set(s.state, "test-snap", &snapstate.SnapState{
+		Active: true,
+		Sequence: []*snap.SideInfo{
+			{RealName: "test-snap", Revision: snap.R(11), SnapID: "testsnapidididididididididididid"},
+		},
+		Current:  snap.R(11),
+		SnapType: "app",
+	})
+	s.state.Unlock()
+
+	s.defaultConfigureContext.Lock()
+	s.defaultConfigureContext.Set("use-defaults", true)
+	s.defaultConfigureContext.Unlock()
+
+	c.Assert(s.defaultConfigureHandler.Before(), IsNil)
+	s.defaultConfigureContext.Lock()
+	tr := configstate.ContextTransaction(s.defaultConfigureContext)
+	s.defaultConfigureContext.Unlock()
+	c.Check(tr.Changes(), DeepEquals, []string{"test-snap.bar", "test-snap.num"})
+	var value string
+	c.Check(tr.Get("test-snap", "bar", &value), IsNil)
+	c.Check(value, Equals, "baz")
+	var fl float64
+	c.Check(tr.Get("test-snap", "num", &fl), IsNil)
+	c.Check(fl, Equals, 1.305)
+
+	s.defaultConfigureContext.Lock()
+	c.Assert(s.defaultConfigureContext.Done(), IsNil)
+	tr = configstate.ContextTransaction(s.defaultConfigureContext)
+	s.defaultConfigureContext.Unlock()
+	c.Check(len(tr.Changes()), Equals, 0)
+
+	s.configureContext.Lock()
+	s.configureContext.Set("use-defaults", true)
+	s.configureContext.Unlock()
+
+	c.Assert(s.configureHandler.Before(), IsNil)
+	s.configureContext.Lock()
+	tr = configstate.ContextTransaction(s.configureContext)
+	s.configureContext.Unlock()
+	c.Check(len(tr.Changes()), Equals, 0)
 }
 
 type configcoreHandlerSuite struct {

--- a/overlord/hookstate/ctlcmd/services_test.go
+++ b/overlord/hookstate/ctlcmd/services_test.go
@@ -336,6 +336,7 @@ var (
 		"set-auto-aliases",
 		"setup-aliases",
 		"run-hook[install]",
+		"run-hook[default-configure]",
 		"start-snap-services",
 		"run-hook[configure]",
 		"run-hook[check-health]",
@@ -403,10 +404,10 @@ func (s *servicectlSuite) TestQueuedCommands(c *C) {
 	checkLaneTasks := func(lane int) {
 		laneTasks := chg.LaneTasks(lane)
 		c.Assert(taskKinds(laneTasks), DeepEquals, expectedTaskKinds)
-		c.Check(laneTasks[12].Summary(), Matches, `Run configure hook of .* snap if present`)
-		c.Check(laneTasks[14].Summary(), Equals, "stop of [test-snap.test-service]")
-		c.Check(laneTasks[16].Summary(), Equals, "start of [test-snap.test-service]")
-		c.Check(laneTasks[18].Summary(), Equals, "restart of [test-snap.test-service]")
+		c.Check(laneTasks[13].Summary(), Matches, `Run configure hook of .* snap if present`)
+		c.Check(laneTasks[15].Summary(), Equals, "stop of [test-snap.test-service]")
+		c.Check(laneTasks[17].Summary(), Equals, "start of [test-snap.test-service]")
+		c.Check(laneTasks[19].Summary(), Equals, "restart of [test-snap.test-service]")
 	}
 	checkLaneTasks(1)
 	checkLaneTasks(2)
@@ -591,10 +592,10 @@ func (s *servicectlSuite) TestQueuedCommandsSingleLane(c *C) {
 
 	laneTasks := chg.LaneTasks(0)
 	c.Assert(taskKinds(laneTasks), DeepEquals, append(installTaskKinds, "exec-command", "service-control", "exec-command", "service-control", "exec-command", "service-control"))
-	c.Check(laneTasks[12].Summary(), Matches, `Run configure hook of .* snap if present`)
-	c.Check(laneTasks[14].Summary(), Equals, "stop of [test-snap.test-service]")
-	c.Check(laneTasks[16].Summary(), Equals, "start of [test-snap.test-service]")
-	c.Check(laneTasks[18].Summary(), Equals, "restart of [test-snap.test-service]")
+	c.Check(laneTasks[13].Summary(), Matches, `Run configure hook of .* snap if present`)
+	c.Check(laneTasks[15].Summary(), Equals, "stop of [test-snap.test-service]")
+	c.Check(laneTasks[17].Summary(), Equals, "start of [test-snap.test-service]")
+	c.Check(laneTasks[19].Summary(), Equals, "restart of [test-snap.test-service]")
 }
 
 func (s *servicectlSuite) TestTwoServices(c *C) {

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -4808,6 +4808,10 @@ func validateInstallTasks(c *C, tasks []*state.Task, name, revno string, flags i
 	i++
 	c.Assert(tasks[i].Summary(), Equals, fmt.Sprintf(`Run install hook of "%s" snap if present`, name))
 	i++
+	if flags&noConfigure == 0 {
+		c.Assert(tasks[i].Summary(), Equals, fmt.Sprintf(`Run default-configure hook of "%s" snap if present`, name))
+		i++
+	}
 	c.Assert(tasks[i].Summary(), Equals, fmt.Sprintf(`Start snap "%s" (%s) services`, name, revno))
 	i++
 	if flags&noConfigure == 0 {

--- a/overlord/snapstate/check_snap.go
+++ b/overlord/snapstate/check_snap.go
@@ -566,10 +566,21 @@ func checkAndCreateSystemUsernames(si *snap.Info) error {
 	return nil
 }
 
+func checkConfigureHooks(_ *state.State, snapInfo, curInfo *snap.Info, _ snap.Container, _ Flags, deviceCtx DeviceContext) error {
+	hasDefaultConfigureHook := snapInfo.Hooks["default-configure"] != nil
+	hasConfigureHook := snapInfo.Hooks["configure"] != nil
+
+	if hasDefaultConfigureHook && !hasConfigureHook {
+		return fmt.Errorf(`cannot specify "default-configure" hook without "configure" hook`)
+	}
+	return nil
+}
+
 func init() {
 	AddCheckSnapCallback(checkCoreName)
 	AddCheckSnapCallback(checkSnapdName)
 	AddCheckSnapCallback(checkGadgetOrKernel)
 	AddCheckSnapCallback(checkBases)
 	AddCheckSnapCallback(checkEpochs)
+	AddCheckSnapCallback(checkConfigureHooks)
 }

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -311,6 +311,32 @@ var excludeFromRefreshAppAwareness = func(t snap.Type) bool {
 	return t == snap.TypeSnapd || t == snap.TypeOS
 }
 
+func isDefaultConfigureAllowed(snapsup *SnapSetup) bool {
+	return isConfigureAllowed(snapsup) && !isCoreSnap(snapsup.InstanceName())
+}
+
+func isConfigureAllowed(snapsup *SnapSetup) bool {
+	// we do not support configuration for bases or the "snapd" snap yet
+	return snapsup.Type != snap.TypeBase && snapsup.Type != snap.TypeSnapd
+}
+
+func configureSnapFlags(snapst *SnapState, snapsup *SnapSetup) int {
+	confFlags := 0
+	// config defaults cannot be retrieved without a snap ID
+	hasSnapID := snapsup.SideInfo != nil && snapsup.SideInfo.SnapID != ""
+
+	if !snapst.IsInstalled() && hasSnapID && !isCoreSnap(snapsup.InstanceName()) {
+		// installation, run configure using the gadget defaults if available, system config defaults (attached to
+		// "core") are consumed only during seeding, via an explicit configure step separate from installing
+		confFlags |= UseConfigDefaults
+	}
+	return confFlags
+}
+
+func isCoreSnap(snapName string) bool {
+	return snapName == defaultCoreSnapName
+}
+
 func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int, fromChange string, inUseCheck func(snap.Type) (boot.InUseFunc, error)) (*state.TaskSet, error) {
 	// NB: we should strive not to need or propagate deviceCtx
 	// here, the resulting effects/changes were not pleasant at
@@ -431,12 +457,18 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 	prepare.WaitFor(prereq)
 
 	tasks := []*state.Task{prereq, prepare}
+	prev = prepare
+
 	addTask := func(t *state.Task) {
 		t.Set("snap-setup-task", prepare.ID())
 		t.WaitFor(prev)
 		tasks = append(tasks, t)
 	}
-	prev = prepare
+	addTasksFromTaskSet := func(ts *state.TaskSet) {
+		ts.WaitFor(prev)
+		tasks = append(tasks, ts.Tasks()...)
+		prev = tasks[len(tasks)-1]
+	}
 
 	var checkAsserts *state.Task
 	if fromStore {
@@ -577,6 +609,13 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 		prev = quotaAddSnapTask
 	}
 
+	// only run default-configure hook if installing the snap for the first time and
+	// default-configure is allowed
+	if !snapst.IsInstalled() && isDefaultConfigureAllowed(snapsup) {
+		defaultConfigureSet := DefaultConfigure(st, snapsup.InstanceName())
+		addTasksFromTaskSet(defaultConfigureSet)
+	}
+
 	// run new services
 	startSnapServices := st.NewTask("start-snap-services", fmt.Sprintf(i18n.G("Start snap %q%s services"), snapsup.InstanceName(), revisionStr))
 	addTask(startSnapServices)
@@ -603,9 +642,7 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 				continue
 			}
 			ts := removeInactiveRevision(st, snapsup.InstanceName(), si.SnapID, si.Revision, snapsup.Type)
-			ts.WaitFor(prev)
-			tasks = append(tasks, ts.Tasks()...)
-			prev = tasks[len(tasks)-1]
+			addTasksFromTaskSet(ts)
 		}
 
 		// make sure we're not scheduling the removal of the target
@@ -637,9 +674,7 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 				continue
 			}
 			ts := removeInactiveRevision(st, snapsup.InstanceName(), si.SnapID, si.Revision, snapsup.Type)
-			ts.WaitFor(prev)
-			tasks = append(tasks, ts.Tasks()...)
-			prev = tasks[len(tasks)-1]
+			addTasksFromTaskSet(ts)
 		}
 
 		addTask(st.NewTask("cleanup", fmt.Sprintf("Clean up %q%s install", snapsup.InstanceName(), revisionStr)))
@@ -670,18 +705,8 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 
 	ts.AddAllWithEdges(installSet)
 
-	// we do not support configuration for bases or the "snapd" snap yet
-	if snapsup.Type != snap.TypeBase && snapsup.Type != snap.TypeSnapd {
-		confFlags := 0
-		notCore := snapsup.InstanceName() != "core"
-		hasSnapID := snapsup.SideInfo != nil && snapsup.SideInfo.SnapID != ""
-		if !snapst.IsInstalled() && hasSnapID && notCore {
-			// installation, run configure using the gadget defaults
-			// if available, system config defaults (attached to
-			// "core") are consumed only during seeding, via an
-			// explicit configure step separate from installing
-			confFlags |= UseConfigDefaults
-		}
+	if isConfigureAllowed(snapsup) {
+		confFlags := configureSnapFlags(snapst, snapsup)
 		configSet := ConfigureSnap(st, snapsup.InstanceName(), confFlags)
 		configSet.WaitAll(ts)
 		ts.AddAll(configSet)
@@ -719,7 +744,7 @@ func ConfigureSnap(st *state.State, snapName string, confFlags int) *state.TaskS
 	// This is slightly ugly, ideally we would check the type instead
 	// of hardcoding the name here. Unfortunately we do not have the
 	// type until we actually run the change.
-	if snapName == defaultCoreSnapName {
+	if isCoreSnap(snapName) {
 		confFlags |= IgnoreHookError
 		confFlags |= TrackHookError
 	}
@@ -728,6 +753,10 @@ func ConfigureSnap(st *state.State, snapName string, confFlags int) *state.TaskS
 
 var Configure = func(st *state.State, snapName string, patch map[string]interface{}, flags int) *state.TaskSet {
 	panic("internal error: snapstate.Configure is unset")
+}
+
+var DefaultConfigure = func(st *state.State, snapName string) *state.TaskSet {
+	panic("internal error: snapstate.DefaultConfigure is unset")
 }
 
 var SetupInstallHook = func(st *state.State, snapName string) *state.Task {

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -110,6 +110,9 @@ func expectedDoInstallTasks(typ snap.Type, opts, discards int, startTasks []stri
 		expected = append(expected, "run-hook[post-refresh]")
 	} else {
 		expected = append(expected, "run-hook[install]")
+		if opts&(noConfigure|runCoreConfigure) == 0 {
+			expected = append(expected, "run-hook[default-configure]")
+		}
 	}
 	expected = append(expected, "start-snap-services")
 	for i := 0; i < discards; i++ {
@@ -1106,14 +1109,14 @@ func (s *snapmgrTestSuite) TestInstallRunThrough(c *C) {
 	c.Check(task.Summary(), Equals, `Download snap "some-snap" (11) from channel "some-channel"`)
 
 	// check install-record present
-	mountTask := ta[len(ta)-11]
+	mountTask := ta[len(ta)-12]
 	c.Check(mountTask.Kind(), Equals, "mount-snap")
 	var installRecord backend.InstallRecord
 	c.Assert(mountTask.Get("install-record", &installRecord), IsNil)
 	c.Check(installRecord.TargetSnapExisted, Equals, false)
 
 	// check link/start snap summary
-	linkTask := ta[len(ta)-8]
+	linkTask := ta[len(ta)-9]
 	c.Check(linkTask.Summary(), Equals, `Make snap "some-snap" (11) available to the system`)
 	startTask := ta[len(ta)-3]
 	c.Check(startTask.Summary(), Equals, `Start snap "some-snap" (11) services`)
@@ -1286,7 +1289,7 @@ func (s *snapmgrTestSuite) TestParallelInstanceInstallRunThrough(c *C) {
 	c.Check(task.Summary(), Equals, `Download snap "some-snap_instance" (11) from channel "some-channel"`)
 
 	// check link/start snap summary
-	linkTask := ta[len(ta)-8]
+	linkTask := ta[len(ta)-9]
 	c.Check(linkTask.Summary(), Equals, `Make snap "some-snap_instance" (11) available to the system`)
 	startTask := ta[len(ta)-3]
 	c.Check(startTask.Summary(), Equals, `Start snap "some-snap_instance" (11) services`)
@@ -1334,7 +1337,7 @@ func (s *snapmgrTestSuite) TestParallelInstanceInstallRunThrough(c *C) {
 	c.Assert(snapst.InstanceKey, Equals, "instance")
 
 	runHooks := tasksWithKind(ts, "run-hook")
-	c.Assert(taskKinds(runHooks), DeepEquals, []string{"run-hook[install]", "run-hook[configure]", "run-hook[check-health]"})
+	c.Assert(taskKinds(runHooks), DeepEquals, []string{"run-hook[install]", "run-hook[default-configure]", "run-hook[configure]", "run-hook[check-health]"})
 	for _, hookTask := range runHooks {
 		c.Assert(hookTask.Kind(), Equals, "run-hook")
 		var hooksup hookstate.HookSetup
@@ -1366,7 +1369,7 @@ func (s *snapmgrTestSuite) TestInstallUndoRunThroughJustOneSnap(c *C) {
 	defer s.se.Stop()
 	s.settle(c)
 
-	mountTask := tasks[len(tasks)-11]
+	mountTask := tasks[len(tasks)-12]
 	c.Assert(mountTask.Kind(), Equals, "mount-snap")
 	var installRecord backend.InstallRecord
 	c.Assert(mountTask.Get("install-record", &installRecord), IsNil)
@@ -1634,7 +1637,7 @@ func (s *snapmgrTestSuite) TestInstallWithCohortRunThrough(c *C) {
 	c.Check(task.Summary(), Equals, `Download snap "some-snap" (666) from channel "some-channel"`)
 
 	// check link/start snap summary
-	linkTask := ta[len(ta)-8]
+	linkTask := ta[len(ta)-9]
 	c.Check(linkTask.Summary(), Equals, `Make snap "some-snap" (666) available to the system`)
 	startTask := ta[len(ta)-3]
 	c.Check(startTask.Summary(), Equals, `Start snap "some-snap" (666) services`)
@@ -1800,7 +1803,7 @@ func (s *snapmgrTestSuite) TestInstallWithRevisionRunThrough(c *C) {
 	c.Check(task.Summary(), Equals, `Download snap "some-snap" (42) from channel "some-channel"`)
 
 	// check link/start snap summary
-	linkTask := ta[len(ta)-8]
+	linkTask := ta[len(ta)-9]
 	c.Check(linkTask.Summary(), Equals, `Make snap "some-snap" (42) available to the system`)
 	startTask := ta[len(ta)-3]
 	c.Check(startTask.Summary(), Equals, `Start snap "some-snap" (42) services`)
@@ -2593,8 +2596,8 @@ func (s *snapmgrTestSuite) TestInstallWithoutCoreTwoSnapsRunThrough(c *C) {
 	if len(chg1.Tasks()) < len(chg2.Tasks()) {
 		chg1, chg2 = chg2, chg1
 	}
-	c.Assert(taskKinds(chg1.Tasks()), HasLen, 28)
-	c.Assert(taskKinds(chg2.Tasks()), HasLen, 14)
+	c.Assert(taskKinds(chg1.Tasks()), HasLen, 29)
+	c.Assert(taskKinds(chg2.Tasks()), HasLen, 15)
 
 	// FIXME: add helpers and do a DeepEquals here for the operations
 }
@@ -3369,7 +3372,7 @@ func (s *snapmgrTestSuite) TestInstallUndoRunThroughUndoContextOptional(c *C) {
 	defer s.se.Stop()
 	s.settle(c)
 
-	mountTask := tasks[len(tasks)-11]
+	mountTask := tasks[len(tasks)-12]
 	c.Assert(mountTask.Kind(), Equals, "mount-snap")
 	var installRecord backend.InstallRecord
 	c.Assert(mountTask.Get("install-record", &installRecord), testutil.ErrorIs, state.ErrNoState)
@@ -3869,10 +3872,15 @@ func (s *snapmgrTestSuite) TestGadgetDefaults(c *C) {
 
 	c.Assert(taskKinds(runHooks), DeepEquals, []string{
 		"run-hook[install]",
+		"run-hook[default-configure]",
 		"run-hook[configure]",
 		"run-hook[check-health]",
 	})
+	// default-configure always uses defaults, not required to explicitly indicate this within the hook context data
 	err = runHooks[1].Get("hook-context", &m)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
+
+	err = runHooks[2].Get("hook-context", &m)
 	c.Assert(err, IsNil)
 	c.Assert(m, DeepEquals, map[string]interface{}{"use-defaults": true})
 }

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -7984,6 +7984,7 @@ var nonReLinkKinds = []string{
 	"set-auto-aliases",
 	"setup-aliases",
 	"run-hook[install]",
+	"run-hook[default-configure]",
 	"start-snap-services",
 	"run-hook[configure]",
 	"run-hook[check-health]",

--- a/overlord/snapstate/snapstate_try_test.go
+++ b/overlord/snapstate/snapstate_try_test.go
@@ -98,6 +98,7 @@ func (s *snapmgrTestSuite) testTrySetsTryMode(flags snapstate.Flags, c *C, extra
 		"set-auto-aliases",
 		"setup-aliases",
 		"run-hook[install]",
+		"run-hook[default-configure]",
 		"start-snap-services",
 		"run-hook[configure]",
 		"run-hook[check-health]",

--- a/snap/hooktypes.go
+++ b/snap/hooktypes.go
@@ -26,6 +26,7 @@ import (
 var supportedHooks = []*HookType{
 	NewHookType(regexp.MustCompile("^prepare-device$")),
 	NewHookType(regexp.MustCompile("^install-device$")),
+	NewHookType(regexp.MustCompile("^default-configure$")),
 	NewHookType(regexp.MustCompile("^configure$")),
 	NewHookType(regexp.MustCompile("^install$")),
 	NewHookType(regexp.MustCompile("^pre-refresh$")),


### PR DESCRIPTION
Spec: https://docs.google.com/document/d/1QDlVmTCtRAe0SxyvMZ97NlcosEtf1-MCmGcsRixDbek

Two parts:
(1) Implementation and unit tests: https://github.com/snapcore/snapd/pull/12701   <- this is part 1
(2) Spread test: https://github.com/snapcore/snapd/pull/12747

**snap/hooktypes.go:**
- Added support for default-configure hook type

**overlord/configstate/configmgr.go:**
 - Register the new default configuration handler

**overlord/configstate/configstate.go:**
 - Added `DefaultConfigure` that provides the task set for the default configure hook. It is significantly simplified compared to the configure hook due to simpler mandate to configure snap with gadget defaults on first install for non-core snaps. 
 
**overlord/configstate/hooks.go**:
 - Created new type `defaultConfigureHandler` with functions that satisfy the same interface as `ConfigureHandler` with Before, Error and Done.
 - Modified configure hook `Before` to only apply defaults if default-configure is not available, otherwise "
configuration empty change" as per specification.
 - Default Configure hook `Before` returns with error if there is not a configure hook so that "default-configure will be taken into account only if there is also a configure hook" as per specification.

**overlord/snapstate/check_snap.go:**
- New check to flag default-configure without configure

**overlord/snapstate/snapstate.go:**
 - Added `DefaultConfigure` after installation and right before service starting task.

