### PR TITLE
o/snapstate: include snap names in pre-dl change summary

### DIFF
--- a/overlord/snapstate/autorefresh_test.go
+++ b/overlord/snapstate/autorefresh_test.go
@@ -1127,7 +1127,7 @@ func (s *autoRefreshTestSuite) TestAutoRefreshCreatesBothRefreshAndPreDownload(c
 
 func checkPreDownloadChange(c *C, chg *state.Change, name string, rev snap.Revision) {
 	c.Assert(chg.Kind(), Equals, "pre-download")
-	c.Assert(chg.Summary(), Equals, "Pre-download tasks for auto-refresh")
+	c.Assert(chg.Summary(), Equals, fmt.Sprintf(`Pre-download "%s" for auto-refresh`, name))
 	c.Assert(chg.Tasks(), HasLen, 1)
 	task := chg.Tasks()[0]
 	c.Assert(task.Kind(), Equals, "pre-download-snap")

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -3939,7 +3939,9 @@ func (m *SnapManager) doCheckReRefresh(t *state.Task, tomb *tomb.Tomb) error {
 		}
 	}
 
-	if createPreDownloadChange(st, updateTss) {
+	if created, err := createPreDownloadChange(st, updateTss); err != nil {
+		return err
+	} else if created {
 		newTasks = true
 	}
 
@@ -3971,7 +3973,9 @@ func (m *SnapManager) doConditionalAutoRefresh(t *state.Task, tomb *tomb.Tomb) e
 		return err
 	}
 
-	createPreDownloadChange(st, updateTss)
+	if _, err := createPreDownloadChange(st, updateTss); err != nil {
+		return err
+	}
 
 	if updateTss.Refresh != nil {
 		// update the map of refreshed snaps on the task, this affects

--- a/tests/main/auto-refresh-pre-download/task.yaml
+++ b/tests/main/auto-refresh-pre-download/task.yaml
@@ -65,7 +65,7 @@ execute: |
 
   # check that a change was triggered and it's a pre-download
   changeAfterID "$OLD_CHANGE"
-  if ! retry -n 15 sh -c 'snap changes | tail -n 2 | grep "Done.*Pre-download tasks for auto-refresh"'; then
+  if ! retry -n 15 sh -c 'snap changes | tail -n 2 | grep "Done.*Pre-download \"test-snapd-sh\" for auto-refresh"'; then
     echo "expected a completed pre-download change"
     exit 1
   fi


### PR DESCRIPTION
Include the names of the snaps being pre-downloaded in the summary of the pre-download change (e.g.,`Pre-download "foo" for auto-refresh`)