### PR TITLE
tests: fix retry-network test in ubuntu lunar

### DIFF
--- a/tests/main/retry-network/task.yaml
+++ b/tests/main/retry-network/task.yaml
@@ -19,12 +19,6 @@ execute: |
     echo "Add totally unconnected network namespace"
     ip netns add testns
 
-    # Without having "lo" up the ipv6 test will retrun EADDRNOTAVAIL which
-    # is misleading, it just means that there is no ipv6 addresses in the
-    # namespace, adding localhost fixes this.
-    echo "but make sure we have localhost available so that ipv6 works"
-    ip netns exec testns ip link set dev lo up
-
     SNAPD_DEBUG=1 nsenter --net=/var/run/netns/testns ./detect-retry http://www.ubuntu.com > output.txt 2>stderr
     # XXX: ShouldRetryError is slightly misbehaving, if we know we don't have
     #      a network connection we should not retry. However we keep it as
@@ -42,6 +36,12 @@ execute: |
     MATCH "NoNetwork: true" < output.txt
     # be paranoid and look at the low-level go error as well
     MATCH "network is unreachable" < stderr
+
+    # Without having "lo" up the ipv6 test will retrun EADDRNOTAVAIL which
+    # is misleading, it just means that there is no ipv6 addresses in the
+    # namespace, adding localhost fixes this.
+    echo "but make sure we have localhost available so that ipv6 works"
+    ip netns exec testns ip link set dev lo up
 
     echo "Now without DNS resolver for ipv6"
     UBUNTU_IP="$(getent ahostsv6 www.ubuntu.com|awk '{print $1 }' | head -n1)"


### PR DESCRIPTION
Set dev lo up just before ipv6 test is executed. This is making fail the test in ubuntu lunar when ipv4 is tested.

In ubuntu lunar we get "connection refused" instead of "network is unreachable" in ipv4.

