### PR TITLE
Allow overriding the Chronical API URL

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -231,7 +231,7 @@ func endpointURL(base *url.URL, path string, query url.Values) *url.URL {
 // apiURL returns the system default base API URL.
 func apiURL() *url.URL {
 	if s := os.Getenv("SNAPPY_FORCE_API_URL"); s == "" {
-		s := "https://api.snapcraft.io/"
+		s = "https://api.snapcraft.io/"
 		if snapdenv.UseStagingStore() {
 			s = "https://api.staging.snapcraft.io/"
 		}

--- a/store/store.go
+++ b/store/store.go
@@ -230,9 +230,11 @@ func endpointURL(base *url.URL, path string, query url.Values) *url.URL {
 
 // apiURL returns the system default base API URL.
 func apiURL() *url.URL {
-	s := "https://api.snapcraft.io/"
-	if snapdenv.UseStagingStore() {
-		s = "https://api.staging.snapcraft.io/"
+	if s := os.Getenv("SNAPPY_FORCE_API_URL"); s == "" {
+		s := "https://api.snapcraft.io/"
+		if snapdenv.UseStagingStore() {
+			s = "https://api.staging.snapcraft.io/"
+		}
 	}
 	u, _ := url.Parse(s)
 	return u


### PR DESCRIPTION
One of the main reasons for criticism of Snap is that you cannot fully change the client to point to a self-hosted version without recompiling.  This simple PR will fix that.