### PR TITLE
tests: speed up the prepare phase through a new tool to manage initial snapd env

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -15,6 +15,7 @@ environment:
     TESTSLIB: $PROJECT_PATH/tests/lib
     TESTSTOOLS: $PROJECT_PATH/tests/lib/tools
     TESTSTMP: /var/tmp/snapd-tools
+    RUNTIME_STATE_PATH: $TESTSTMP/runtime-state
     # turn debug off so that we don't get errant debug messages while running
     # tests, and in some cases like on UC20 we have the kernel command line
     # parameter, snapd.debug=1 turned on to enable early boot debugging before
@@ -73,6 +74,8 @@ environment:
     # Use the installed snapd and reset the systems without removing snapd
     REUSE_SNAPD: '$(HOST: echo "${SPREAD_REUSE_SNAPD:-0}")'
     EXPERIMENTAL_FEATURES: '$(HOST: echo "${SPREAD_EXPERIMENTAL_FEATURES:-}")'
+    # set to 1 when the snapd memory limit has to be removed
+    SNAPD_NO_MEMORY_LIMIT: '$(HOST: echo "${SPREAD_SNAPD_NO_MEMORY_LIMIT:-}")'
 
     SNAPD_PUBLISHED_VERSION: '$(HOST: echo "$SPREAD_SNAPD_PUBLISHED_VERSION")'
     # Build and use snapd from current branch

--- a/tests/bin/tests.env
+++ b/tests/bin/tests.env
@@ -1,0 +1,1 @@
+../lib/tools/tests.env

--- a/tests/lib/state.sh
+++ b/tests/lib/state.sh
@@ -2,9 +2,7 @@
 
 SNAPD_STATE_PATH="$TESTSTMP/snapd-state"
 SNAPD_STATE_FILE="$TESTSTMP/snapd-state/snapd-state.tar"
-RUNTIME_STATE_PATH="$TESTSTMP/runtime-state"
 SNAPD_ACTIVE_UNITS="$RUNTIME_STATE_PATH/snapd-active-units"
-
 
 delete_snapd_state() {
     rm -rf "$SNAPD_STATE_PATH"

--- a/tests/lib/tools/suite/tests.env/task.yaml
+++ b/tests/lib/tools/suite/tests.env/task.yaml
@@ -1,0 +1,59 @@
+summary: tests for tests.env
+
+restore: |
+    rm -f "$RUNTIME_STATE_PATH"/test1.env "$RUNTIME_STATE_PATH"/test2.env
+
+execute: |
+    # Both -h and --help are also recognized.
+    tests.env --help | MATCH "usage: tests.env start <ENV_NAME>"
+    tests.env -h | MATCH "usage: tests.env start <ENV_NAME>"
+
+    # check start env file
+    tests.env start test1
+    test -f "$RUNTIME_STATE_PATH"/test1.env
+
+    # check commands is-set and set
+    not tests.env is-set test1 var1
+    tests.env set test1 var1 val1
+    tests.env is-set test1 var1
+    tests.env is-set test1 var3
+    tests.env is-set test1 var4 ""
+
+    # check command get
+    test "$(tests.env get test1 var1)" = "val1"
+    test "$(tests.env get test1 var3)" = ""
+    test "$(tests.env get test1 var4)" = ""
+
+    # check set another value
+    not tests.env is-set test1 var2
+    tests.env set test1 var2 val2
+    tests.env is-set test1 var2
+    test "$(tests.env get test1 var2)" = "val2"
+    test "$(tests.env get test1 var1)" = "val1"
+
+    # check update the value
+    tests.env set test1 var1 val3
+    test "$(tests.env get test1 var1)" = "val3"
+
+    # create another env
+    tests.env start test2
+    tests.env set test2 var1 val1
+    test "$(tests.env get test1 var1)" = "val3"
+    test "$(tests.env get test2 var1)" = "val1"
+
+    # check errors
+    tests.env test 2>&1 | MATCH "tests.env: no such command: test"
+
+    tests.env start 2>&1 | MATCH "tests.env: name for the env file is required"
+
+    tests.env is-set 2>&1 | MATCH "tests.env: name for the env file is required"
+    tests.env is-set test1 2>&1 | MATCH "tests.env: variable to check in env file is required"
+    tests.env is-set test10 2>&1 | MATCH "tests.env: env file $RUNTIME_STATE_PATH/test10.env does not exist"
+
+    tests.env get 2>&1 | MATCH "tests.env: name for the env file is required"
+    tests.env get test1 2>&1 | MATCH "tests.env: variable to check in env file is required"
+    tests.env get test10 var1 2>&1 | MATCH "tests.env: env file $RUNTIME_STATE_PATH/test10.env does not exist"
+
+    tests.env set 2>&1 | MATCH "tests.env: name for the env file is required"
+    tests.env set test1 2>&1 | MATCH "tests.env: variable to set in env file is required"
+    tests.env set test10 var1 val1 2>&1 | MATCH "tests.env: env file $RUNTIME_STATE_PATH/test10.env does not exist"

--- a/tests/lib/tools/suite/tests.env/task.yaml
+++ b/tests/lib/tools/suite/tests.env/task.yaml
@@ -16,8 +16,8 @@ execute: |
     not tests.env is-set test1 var1
     tests.env set test1 var1 val1
     tests.env is-set test1 var1
-    tests.env is-set test1 var3
-    tests.env is-set test1 var4 ""
+    tests.env set test1 var3
+    tests.env set test1 var4 ""
 
     # check command get
     test "$(tests.env get test1 var1)" = "val1"
@@ -48,7 +48,7 @@ execute: |
 
     tests.env is-set 2>&1 | MATCH "tests.env: name for the env file is required"
     tests.env is-set test1 2>&1 | MATCH "tests.env: variable to check in env file is required"
-    tests.env is-set test10 2>&1 | MATCH "tests.env: env file $RUNTIME_STATE_PATH/test10.env does not exist"
+    tests.env is-set test10 var1 2>&1 | MATCH "tests.env: env file $RUNTIME_STATE_PATH/test10.env does not exist"
 
     tests.env get 2>&1 | MATCH "tests.env: name for the env file is required"
     tests.env get test1 2>&1 | MATCH "tests.env: variable to check in env file is required"

--- a/tests/lib/tools/tests.env
+++ b/tests/lib/tools/tests.env
@@ -1,0 +1,126 @@
+#!/bin/bash
+
+show_help() {
+    echo "usage: tests.env start <ENV_NAME>"
+    echo "       tests.env is-set <ENV_NAME> <VAR>"
+    echo "       tests.env get <ENV_NAME> <VAR>"
+    echo "       tests.env set <ENV_NAME> <VAR> <VAL>"
+}
+
+start() {
+    local NAME=$1
+    if [ -z "$NAME" ]; then
+        echo "tests.env: name for the env file is required"
+        exit 1
+    fi
+
+    if [ -f "$RUNTIME_STATE_PATH/$NAME.env" ]; then
+        echo "tests.env: env file $RUNTIME_STATE_PATH/$NAME.env already exists, deleting..."
+        rm -f "$RUNTIME_STATE_PATH/$NAME.env"
+    fi
+    mkdir -p "$RUNTIME_STATE_PATH"
+    touch "$RUNTIME_STATE_PATH/$NAME.env"
+}
+
+is_set() {
+    local NAME=$1
+    local VAR=$2
+
+    if [ -z "$NAME" ]; then
+        echo "tests.env: name for the env file is required"
+        exit 1
+    fi
+    if [ -z "$VAR" ]; then
+        echo "tests.env: variable to check in env file is required"
+        exit 1
+    fi
+
+    if [ ! -f "$RUNTIME_STATE_PATH/$NAME.env" ]; then
+        echo "tests.env: env file $RUNTIME_STATE_PATH/$NAME.env does not exist"
+        exit 1
+    fi
+
+    grep -E "^${VAR}=" "$RUNTIME_STATE_PATH/$NAME.env"
+}
+
+get() {
+    local NAME=$1
+    local VAR=$2
+
+    if [ -z "$NAME" ]; then
+        echo "tests.env: name for the env file is required"
+        exit 1
+    fi
+    if [ -z "$VAR" ]; then
+        echo "tests.env: variable to check in env file is required"
+        exit 1
+    fi
+
+    if [ ! -f "$RUNTIME_STATE_PATH/$NAME.env" ]; then
+        echo "tests.env: env file $RUNTIME_STATE_PATH/$NAME.env does not exist"
+        exit 1
+    fi
+
+    if is_set "$NAME" "$VAR"; then
+        grep -E "^${VAR}=" "$RUNTIME_STATE_PATH/$NAME.env" | cut -d "=" -f2-
+    fi
+}
+
+set() {
+    local NAME=$1
+    local VAR=$2
+    local VAL=$3
+
+    if [ -z "$NAME" ]; then
+        echo "tests.env: name for the env file is required"
+        exit 1
+    fi
+    if [ -z "$VAR" ]; then
+        echo "tests.env: variable to set in env file is required"
+        exit 1
+    fi
+
+    if [ ! -f "$RUNTIME_STATE_PATH/$NAME.env" ]; then
+        echo "tests.env: env file $RUNTIME_STATE_PATH/$NAME.env does not exist"
+        exit 1
+    fi
+
+    if is_set "$NAME" "$VAR"; then
+        sed -i "/^${VAR}=/d" "$RUNTIME_STATE_PATH/$NAME.env"
+    fi
+    echo "${VAR}=${VAL}" >> "$RUNTIME_STATE_PATH/$NAME.env"
+
+}
+
+main() {
+    if [ $# -eq 0 ]; then
+        show_help
+        exit 0
+    fi
+
+    local subcommand="$1"
+    local action=
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            -h|--help)
+                show_help
+                exit 0
+                ;;
+            *)
+                action=$(echo "$subcommand" | tr '-' '_')
+                shift
+                break
+                ;;
+        esac
+    done
+
+    if [ -z "$(declare -f "$action")" ]; then
+        echo "tests.env: no such command: $subcommand"
+        show_help
+        exit 1
+    fi
+
+    "$action" "$@"
+}
+
+main "$@"

--- a/tests/lib/tools/tests.env
+++ b/tests/lib/tools/tests.env
@@ -6,7 +6,7 @@ show_help() {
     echo "       tests.env get <ENV_NAME> <VAR>"
     echo "       tests.env set <ENV_NAME> <VAR> <VAL>"
     echo ""
-    echo "The tool is used to create and/or an environment file"
+    echo "The tool is used to create an environment file"
     echo " which can be shared across different tests and suites"
 }
 
@@ -89,9 +89,10 @@ set() {
     fi
 
     if is_set "$NAME" "$VAR"; then
-        sed -i "/^${VAR}=/d" "$RUNTIME_STATE_PATH/$NAME.env"
+        sed -i -E "s/^${VAR}=.*/${VAR}=${VAL}/" "$RUNTIME_STATE_PATH/$NAME.env"
+    else
+        echo "${VAR}=${VAL}" >> "$RUNTIME_STATE_PATH/$NAME.env"
     fi
-    echo "${VAR}=${VAL}" >> "$RUNTIME_STATE_PATH/$NAME.env"
 
 }
 

--- a/tests/lib/tools/tests.env
+++ b/tests/lib/tools/tests.env
@@ -5,6 +5,9 @@ show_help() {
     echo "       tests.env is-set <ENV_NAME> <VAR>"
     echo "       tests.env get <ENV_NAME> <VAR>"
     echo "       tests.env set <ENV_NAME> <VAR> <VAL>"
+    echo ""
+    echo "The tool is used to create and/or an environment file"
+    echo " which can be shared across different tests and suites"
 }
 
 start() {
@@ -101,7 +104,7 @@ main() {
     local subcommand="$1"
     local action=
     while [ $# -gt 0 ]; do
-        case "$1" in
+        case "$subcommand" in
             -h|--help)
                 show_help
                 exit 0

--- a/tests/lib/tools/tests.env
+++ b/tests/lib/tools/tests.env
@@ -40,7 +40,7 @@ is_set() {
         exit 1
     fi
 
-    grep -E "^${VAR}=" "$RUNTIME_STATE_PATH/$NAME.env"
+    grep -Eq "^${VAR}=" "$RUNTIME_STATE_PATH/$NAME.env"
 }
 
 get() {

--- a/tests/main/abort/task.yaml
+++ b/tests/main/abort/task.yaml
@@ -2,7 +2,6 @@ summary: Check change abort
 
 environment:
     SNAP_NAME: test-snapd-tools
-    SNAPD_NO_MEMORY_LIMIT: 1
 
 execute: |
     echo "Abort with invalid id"

--- a/tests/main/abort/task.yaml
+++ b/tests/main/abort/task.yaml
@@ -2,6 +2,7 @@ summary: Check change abort
 
 environment:
     SNAP_NAME: test-snapd-tools
+    SNAPD_NO_MEMORY_LIMIT: 1
 
 execute: |
     echo "Abort with invalid id"


### PR DESCRIPTION
The new tool is used to know in spread tests the initial value for the vars and be able to repeat not needed steps

With this change, an environment file with the values for SNAPD_NO_MEMORY_LIMIT and SNAPD_REEXEC is written at the beginning of the tests execution and then updated (and snapd restarted) just when the test changes the value through its environment section. This is done to speed up the prepare-each phase of the tests (a lot of snapd restarts are avoided).

Also the memory limit is re-introduced with 150M instead of the previous 100M which caused issues in tests

