### PR TITLE
o/snapstate: fix test race condition

### DIFF
--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/auth"
+	userclient "github.com/snapcore/snapd/usersession/client"
 
 	// So it registers Configure.
 	_ "github.com/snapcore/snapd/overlord/configstate"
@@ -327,6 +328,10 @@ SNAPD_APPARMOR_REEXEC=1
 
 	s.reloadOrRestarts = make(map[string]int)
 	s.AddCleanup(s.mockSystemctlCallsUpdateMounts(c))
+
+	// mock so the actual notification code isn't called. It races with the SetRootDir
+	// call in the TearDown function. It's harmless but triggers go test -race
+	s.AddCleanup(snapstate.MockAsyncPendingRefreshNotification(func(context.Context, *userclient.Client, *userclient.PendingSnapRefreshInfo) {}))
 }
 
 func (s *snapmgrBaseTest) TearDownTest(c *C) {

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -9173,7 +9173,6 @@ func (s *snapmgrTestSuite) TestAutoRefreshBusySnapButOngoingPreDownload(c *C) {
 }
 
 func (s *snapmgrTestSuite) TestReRefreshCreatesPreDownloadChange(c *C) {
-
 	s.o.TaskRunner().AddHandler("pre-download-snap", func(*state.Task, *tomb.Tomb) error { return nil }, nil)
 
 	s.state.Lock()


### PR DESCRIPTION
`go test -race` flagged a race condition between two tests' TearDown() functions and the notification code that runs in a goroutine. This can only happen in tests where we mock the root dir, so it's not a problem in production code. This simply mocks the notification function so notification code can't race with the restoring of the root dir.