### PR TITLE
run-checks: use nakedret@1.0.1 compatible w/ go1.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ go 1.13
 replace maze.io/x/crypto => github.com/snapcore/maze.io-x-crypto v0.0.0-20190131090603-9b94c9afe066
 
 require (
+	github.com/alexkohler/nakedret v1.0.1 // indirect
 	github.com/canonical/go-efilib v0.3.1-0.20220815143333-7e5151412e93 // indirect
 	github.com/canonical/go-sp800.90a-drbg v0.0.0-20210314144037-6eeb1040d6c3 // indirect
 	github.com/canonical/go-tpm2 v0.0.0-20210827151749-f80ff5afff61

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/alexkohler/nakedret v1.0.1 h1:cYUUKLoQ//kuZ3ww60tGjniwOOZW0cfnClt6SGX5qr0=
+github.com/alexkohler/nakedret v1.0.1/go.mod h1:FIP5ubTIqmK2D35Xct6bjnYc4O027gqCYLqXLQM4xuY=
 github.com/canonical/go-efilib v0.0.0-20210909101908-41435fa545d4 h1:rSWREoNHHbcIC1iQeKKraBlsDm7cmKg8eS+N48jMVKA=
 github.com/canonical/go-efilib v0.0.0-20210909101908-41435fa545d4/go.mod h1:9Sr9kd7IhQPYqaU5nut8Ky97/CtlhHDzQncQnrULgDM=
 github.com/canonical/go-efilib v0.3.1-0.20220815143333-7e5151412e93 h1:F0bRDzPy/j2IX/iIWqCEA23S1nal+f7A+/vLyj6Ye+4=

--- a/run-checks
+++ b/run-checks
@@ -74,14 +74,15 @@ addtrap() {
 
 goinstall() {
     pkg="$1"
+    version="${2:-}"
     # go1.18+ will no longer build/install packages. Here "go install"
     # must be used but it will only fetch remote packages if the @latest
     # (or similar syntax is used). Instead of checking the version we
     # check if the "go install" help mentions this new feature.
     if go help install | grep -q @latest; then
-        go install "${pkg}"@latest
+        go install "${pkg}"@"${version:=latest}"
     else
-        go get -u "${pkg}"
+        go get -u "${pkg}"@"${version:=latest}"
     fi
 }
 
@@ -282,7 +283,7 @@ if [ "$STATIC" = 1 ]; then
 
     echo "Checking for naked returns"
     if ! command -v nakedret >/dev/null; then
-        goinstall github.com/alexkohler/nakedret
+        goinstall github.com/alexkohler/nakedret v1.0.1
     fi
     got=$(go list ./... | grep -v '/osutil/udev/' | grep -v '/vendor/' | xargs nakedret 2>&1)
     if [ -n "$got" ]; then


### PR DESCRIPTION
nakedret was updated to require go version 1.18. This PR changes our static checks script so we use version 1.0.1 of nakedret which doesn't have this incompatibility.