### PR TITLE
run-checks: allow default GOPATH for local checks

### DIFF
--- a/run-checks
+++ b/run-checks
@@ -27,8 +27,13 @@ if [ "$(uname -m)" = "s390x" ]; then
     fi
 fi
 
-export GOPATH="${GOPATH:-$(realpath "$(dirname "$0")"/../../../../)}"
-export PATH="$PATH:${GOPATH%%:*}/bin"
+# If GOPATH is set in the shell environment, the path will be reflected
+# in $(go env GOPATH). If no shell path was set, Go will default the internal
+# GOPATH to $HOME/go. Note that GOPATH may contain a colon delimited set
+# of paths, so in order to run any binary from any of the installed GOPATHs
+# we must add all the possible bin locations.
+GOBINS=$(go env GOPATH | sed 's|:|/bin:|g' | sed 's|.*|\0/bin|g')
+export PATH="$PATH:$GOBINS"
 
 short=
 


### PR DESCRIPTION
In the past HACKING.md instructed developers to setup GOPATH explicitly.

This was removed some time ago:
github.com/snapcore/snapd/commit/5b9864a203e9ea26d743436a424699ec07a52ac7

The run-checks script will not work on a clean developer machine, even if someone follows the HACKING.md instructions.

The problem is that run-checks does not support Go's default GOPATH

For example:

/home/foo> go env GOPATH
/home/foo/go

However, the internal GOPATH still respects externally set variables:

/home/foo> GOPATH="/home/foo/go:/home/foo/go2" go env GOPATH /home/foo/go:/home/foo/go2

The run-checks script supported falling back to a hardcoded GOPATH location, based on assumptions of where automated tests check out the repository.

For example:

The github actions repo location:

 ${{ github.workspace }}/src/github.com/snapcore/snapd

resulted in the fallback GOPATH to be:

GOPATH="${GOPATH:-$(realpath "$(dirname "$0")"/../../../../)}"

This was because the GOPATH was placed at the root of the github action workspace.

However, the location is explicitly set in the environment variable GOPATH before any call is made to run-checks as part of the job setup and therefore not needed.

Other references of run-checks always set GOPATH before calling the script.

Changes:

- Use the Go provided "go env GOPATH" command to obtain GOPATH

- Remove the fallback logic for run-checks when determining GOPATH

- Add all possible bin paths from GOPATH to PATH

