### PR TITLE
many: move TaskRunner to its own package

### DIFF
--- a/daemon/api_base_test.go
+++ b/daemon/api_base_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/devicestate/devicestatetest"
 	"github.com/snapcore/snapd/overlord/ifacestate"
+	"github.com/snapcore/snapd/overlord/runner"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/sandbox"
@@ -362,11 +363,11 @@ func (s *apiBaseSuite) asUserAuth(c *check.C, req *http.Request) {
 
 type fakeSnapManager struct{}
 
-func newFakeSnapManager(st *state.State, runner *state.TaskRunner) *fakeSnapManager {
-	runner.AddHandler("fake-install-snap", func(t *state.Task, _ *tomb.Tomb) error {
+func newFakeSnapManager(st *state.State, r *runner.TaskRunner) *fakeSnapManager {
+	r.AddHandler("fake-install-snap", func(t *state.Task, _ *tomb.Tomb) error {
 		return nil
 	}, nil)
-	runner.AddHandler("fake-install-snap-error", func(t *state.Task, _ *tomb.Tomb) error {
+	r.AddHandler("fake-install-snap-error", func(t *state.Task, _ *tomb.Tomb) error {
 		return fmt.Errorf("fake-install-snap-error errored")
 	}, nil)
 

--- a/overlord/assertstate/assertmgr.go
+++ b/overlord/assertstate/assertmgr.go
@@ -27,6 +27,7 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/asserts/sysdb"
+	"github.com/snapcore/snapd/overlord/runner"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 )
@@ -38,10 +39,10 @@ import (
 type AssertManager struct{}
 
 // Manager returns a new assertion manager.
-func Manager(s *state.State, runner *state.TaskRunner) (*AssertManager, error) {
+func Manager(s *state.State, r *runner.TaskRunner) (*AssertManager, error) {
 	delayedCrossMgrInit()
 
-	runner.AddHandler("validate-snap", doValidateSnap, nil)
+	r.AddHandler("validate-snap", doValidateSnap, nil)
 
 	db, err := sysdb.Open()
 	if err != nil {

--- a/overlord/cmdstate/cmdmgr.go
+++ b/overlord/cmdstate/cmdmgr.go
@@ -27,6 +27,7 @@ import (
 	"gopkg.in/tomb.v2"
 
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/overlord/runner"
 	"github.com/snapcore/snapd/overlord/state"
 )
 
@@ -34,8 +35,8 @@ import (
 type CommandManager struct{}
 
 // Manager returns a new CommandManager.
-func Manager(st *state.State, runner *state.TaskRunner) *CommandManager {
-	runner.AddHandler("exec-command", doExec, nil)
+func Manager(st *state.State, r *runner.TaskRunner) *CommandManager {
+	r.AddHandler("exec-command", doExec, nil)
 	return &CommandManager{}
 }
 

--- a/overlord/cmdstate/cmdstate_test.go
+++ b/overlord/cmdstate/cmdstate_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/cmdstate"
+	"github.com/snapcore/snapd/overlord/runner"
 	"github.com/snapcore/snapd/overlord/state"
 )
 
@@ -71,7 +72,7 @@ func (s *cmdSuite) SetUpTest(c *check.C) {
 	s.rootdir = d
 	s.state = state.New(nil)
 	s.se = overlord.NewStateEngine(s.state)
-	runner := state.NewTaskRunner(s.state)
+	runner := runner.NewTaskRunner(s.state)
 	s.manager = cmdstate.Manager(s.state, runner)
 	s.se.AddManager(s.manager)
 	s.se.AddManager(runner)

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -55,6 +55,7 @@ import (
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
 	"github.com/snapcore/snapd/overlord/restart"
+	"github.com/snapcore/snapd/overlord/runner"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
@@ -1222,7 +1223,7 @@ func (s *deviceMgrSuite) TestResetSession(c *C) {
 func (s *deviceMgrSuite) TestReloadRegistered(c *C) {
 	st := state.New(nil)
 
-	runner1 := state.NewTaskRunner(st)
+	runner1 := runner.NewTaskRunner(st)
 	hookMgr1, err := hookstate.Manager(st, runner1)
 	c.Assert(err, IsNil)
 	mgr1, err := devicestate.Manager(st, hookMgr1, runner1, nil)
@@ -1244,7 +1245,7 @@ func (s *deviceMgrSuite) TestReloadRegistered(c *C) {
 	})
 	st.Unlock()
 
-	runner2 := state.NewTaskRunner(st)
+	runner2 := runner.NewTaskRunner(st)
 	hookMgr2, err := hookstate.Manager(st, runner2)
 	c.Assert(err, IsNil)
 	mgr2, err := devicestate.Manager(st, hookMgr2, runner2, nil)
@@ -1303,7 +1304,7 @@ func (s *deviceMgrSuite) TestMarkSeededInConfig(c *C) {
 func (s *deviceMgrSuite) TestDevicemgrCanStandby(c *C) {
 	st := state.New(nil)
 
-	runner := state.NewTaskRunner(st)
+	runner := runner.NewTaskRunner(st)
 	hookMgr, err := hookstate.Manager(st, runner)
 	c.Assert(err, IsNil)
 	mgr, err := devicestate.Manager(st, hookMgr, runner, nil)
@@ -1899,7 +1900,7 @@ func (s *deviceMgrSuite) TestRunFDESetupHookErrorResult(c *C) {
 type startOfOperationTimeSuite struct {
 	state  *state.State
 	mgr    *devicestate.DeviceManager
-	runner *state.TaskRunner
+	runner *runner.TaskRunner
 }
 
 var _ = Suite(&startOfOperationTimeSuite{})
@@ -1909,7 +1910,7 @@ func (s *startOfOperationTimeSuite) SetUpTest(c *C) {
 	os.MkdirAll(dirs.SnapRunDir, 0755)
 
 	s.state = state.New(nil)
-	s.runner = state.NewTaskRunner(s.state)
+	s.runner = runner.NewTaskRunner(s.state)
 	s.mgr = nil
 }
 

--- a/overlord/devicestate/handlers_test.go
+++ b/overlord/devicestate/handlers_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/devicestate/devicestatetest"
 	"github.com/snapcore/snapd/overlord/restart"
+	"github.com/snapcore/snapd/overlord/runner"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/overlord/storecontext"
@@ -769,7 +770,7 @@ func (s *preseedingUC20Suite) TestSysModeIsRunWhenPreseeding(c *C) {
 
 	c.Assert(os.MkdirAll(filepath.Join(dirs.SnapSeedDir, "systems", "20220105"), 0755), IsNil)
 
-	runner := state.NewTaskRunner(s.state)
+	runner := runner.NewTaskRunner(s.state)
 	mgr, err := devicestate.Manager(s.state, s.hookMgr, runner, nil)
 	c.Assert(err, IsNil)
 	c.Check(devicestate.GetSystemMode(mgr), Equals, "run")

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/snapcore/snapd/overlord/ifacestate"
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
 	"github.com/snapcore/snapd/overlord/ifacestate/udevmonitor"
+	"github.com/snapcore/snapd/overlord/runner"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
@@ -293,12 +294,12 @@ func (s *interfaceManagerSuite) TearDownTest(c *C) {
 	dirs.SetRootDir("")
 }
 
-func addForeignTaskHandlers(runner *state.TaskRunner) {
+func addForeignTaskHandlers(r *runner.TaskRunner) {
 	// Add handler to test full aborting of changes
 	erroringHandler := func(task *state.Task, _ *tomb.Tomb) error {
 		return errors.New("error out")
 	}
-	runner.AddHandler("error-trigger", erroringHandler, nil)
+	r.AddHandler("error-trigger", erroringHandler, nil)
 }
 
 func (s *interfaceManagerSuite) manager(c *C) *ifacestate.InterfaceManager {

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -48,6 +48,7 @@ import (
 	"github.com/snapcore/snapd/overlord/ifacestate"
 	"github.com/snapcore/snapd/overlord/patch"
 	"github.com/snapcore/snapd/overlord/restart"
+	"github.com/snapcore/snapd/overlord/runner"
 	"github.com/snapcore/snapd/overlord/servicestate"
 	"github.com/snapcore/snapd/overlord/snapshotstate"
 	"github.com/snapcore/snapd/overlord/snapstate"
@@ -100,7 +101,7 @@ type Overlord struct {
 	// managers
 	inited     bool
 	startedUp  bool
-	runner     *state.TaskRunner
+	runner     *runner.TaskRunner
 	restartMgr *restart.RestartManager
 	snapMgr    *snapstate.SnapManager
 	serviceMgr *servicestate.ServiceManager
@@ -133,7 +134,7 @@ func New(restartHandler restart.Handler) (*Overlord, error) {
 	}
 
 	o.stateEng = NewStateEngine(s)
-	o.runner = state.NewTaskRunner(s)
+	o.runner = runner.NewTaskRunner(s)
 
 	// any unknown task should be ignored and succeed
 	matchAnyUnknownTask := func(_ *state.Task) bool {
@@ -619,7 +620,7 @@ func (o *Overlord) StateEngine() *StateEngine {
 
 // TaskRunner returns the shared task runner responsible for running
 // tasks for all managers under the overlord.
-func (o *Overlord) TaskRunner() *state.TaskRunner {
+func (o *Overlord) TaskRunner() *runner.TaskRunner {
 	return o.runner
 }
 
@@ -692,7 +693,7 @@ func MockWithState(s *state.State) *Overlord {
 		s = state.New(mockBackend{o: o})
 	}
 	o.stateEng = NewStateEngine(s)
-	o.runner = state.NewTaskRunner(s)
+	o.runner = runner.NewTaskRunner(s)
 
 	return o
 }

--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/snapcore/snapd/overlord/ifacestate"
 	"github.com/snapcore/snapd/overlord/patch"
 	"github.com/snapcore/snapd/overlord/restart"
+	"github.com/snapcore/snapd/overlord/runner"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
@@ -866,45 +867,45 @@ type sampleManager struct {
 	ensureCallback func()
 }
 
-func newSampleManager(runner *state.TaskRunner) *sampleManager {
+func newSampleManager(r *runner.TaskRunner) *sampleManager {
 	sm := &sampleManager{}
 
-	runner.AddHandler("runMgr1", func(t *state.Task, _ *tomb.Tomb) error {
+	r.AddHandler("runMgr1", func(t *state.Task, _ *tomb.Tomb) error {
 		s := t.State()
 		s.Lock()
 		defer s.Unlock()
 		s.Set("runMgr1Mark", 1)
 		return nil
 	}, nil)
-	runner.AddHandler("runMgr2", func(t *state.Task, _ *tomb.Tomb) error {
+	r.AddHandler("runMgr2", func(t *state.Task, _ *tomb.Tomb) error {
 		s := t.State()
 		s.Lock()
 		defer s.Unlock()
 		s.Set("runMgr2Mark", 1)
 		return nil
 	}, nil)
-	runner.AddHandler("runMgrEnsureBefore", func(t *state.Task, _ *tomb.Tomb) error {
+	r.AddHandler("runMgrEnsureBefore", func(t *state.Task, _ *tomb.Tomb) error {
 		s := t.State()
 		s.Lock()
 		defer s.Unlock()
 		s.EnsureBefore(20 * time.Millisecond)
 		return nil
 	}, nil)
-	runner.AddHandler("runMgrForever", func(t *state.Task, _ *tomb.Tomb) error {
+	r.AddHandler("runMgrForever", func(t *state.Task, _ *tomb.Tomb) error {
 		s := t.State()
 		s.Lock()
 		defer s.Unlock()
 		s.EnsureBefore(20 * time.Millisecond)
 		return &state.Retry{}
 	}, nil)
-	runner.AddHandler("runMgrWCleanup", func(t *state.Task, _ *tomb.Tomb) error {
+	r.AddHandler("runMgrWCleanup", func(t *state.Task, _ *tomb.Tomb) error {
 		s := t.State()
 		s.Lock()
 		defer s.Unlock()
 		s.Set("runMgrWCleanupMark", 1)
 		return nil
 	}, nil)
-	runner.AddCleanup("runMgrWCleanup", func(t *state.Task, _ *tomb.Tomb) error {
+	r.AddCleanup("runMgrWCleanup", func(t *state.Task, _ *tomb.Tomb) error {
 		s := t.State()
 		s.Lock()
 		defer s.Unlock()

--- a/overlord/runner/taskrunner.go
+++ b/overlord/runner/taskrunner.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2022 Canonical Ltd
+ * Copyright (C) 2023 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -17,7 +17,7 @@
  *
  */
 
-package state
+package runner
 
 import (
 	"sync"
@@ -26,43 +26,17 @@ import (
 	"gopkg.in/tomb.v2"
 
 	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/overlord/state"
 )
 
 // HandlerFunc is the type of function for the handlers
-type HandlerFunc func(task *Task, tomb *tomb.Tomb) error
+type HandlerFunc func(task *state.Task, tomb *tomb.Tomb) error
 
-// Retry is returned from a handler to signal that is ok to rerun the
-// task at a later point. It's to be used also when a task goroutine
-// is asked to stop through its tomb. After can be used to indicate
-// how much to postpone the retry, 0 (the default) means at the next
-// ensure pass and is what should be used if stopped through its tomb.
-// Reason is an optional explanation of the conflict.
-type Retry struct {
-	After  time.Duration
-	Reason string
-}
-
-func (r *Retry) Error() string {
-	return "task should be retried"
-}
-
-// Wait is returned from a handler to signal that the task cannot
-// proceed at the moment maybe because some manual action from the
-// user required at this point or because of errors. The task
-// will be set to WaitStatus.
-type Wait struct {
-	Reason string
-}
-
-func (r *Wait) Error() string {
-	return "task set to wait, manual action required"
-}
-
-type blockedFunc func(t *Task, running []*Task) bool
+type blockedFunc func(t *state.Task, running []*state.Task) bool
 
 // TaskRunner controls the running of goroutines to execute known task kinds.
 type TaskRunner struct {
-	state *State
+	state *state.State
 
 	// locking
 	mu       sync.Mutex
@@ -86,12 +60,19 @@ type handlerPair struct {
 }
 
 type optionalHandler struct {
-	match func(t *Task) bool
+	match func(t *state.Task) bool
 	handlerPair
 }
 
+var timeNow = time.Now
+
+func MockTime(now time.Time) (restore func()) {
+	timeNow = func() time.Time { return now }
+	return func() { timeNow = time.Now }
+}
+
 // NewTaskRunner creates a new TaskRunner
-func NewTaskRunner(s *State) *TaskRunner {
+func NewTaskRunner(s *state.State) *TaskRunner {
 	return &TaskRunner{
 		state:    s,
 		handlers: make(map[string]handlerPair),
@@ -116,11 +97,11 @@ func (r *TaskRunner) AddHandler(kind string, do, undo HandlerFunc) {
 
 // AddOptionalHandler register functions for doing and undoing tasks that match
 // the given predicate if no explicit handler was registered for the task kind.
-func (r *TaskRunner) AddOptionalHandler(match func(t *Task) bool, do, undo HandlerFunc) {
+func (r *TaskRunner) AddOptionalHandler(match func(t *state.Task) bool, do, undo HandlerFunc) {
 	r.optional = append(r.optional, optionalHandler{match, handlerPair{do, undo}})
 }
 
-func (r *TaskRunner) handlerPair(t *Task) handlerPair {
+func (r *TaskRunner) handlerPair(t *state.Task) handlerPair {
 	if handler, ok := r.handlers[t.Kind()]; ok {
 		return handler
 	}
@@ -163,7 +144,7 @@ func (r *TaskRunner) AddCleanup(kind string, cleanup HandlerFunc) {
 }
 
 // SetBlocked sets a predicate function to decide whether to block a task from running based on the current running tasks. It can be used to control task serialisation.
-func (r *TaskRunner) SetBlocked(pred func(t *Task, running []*Task) bool) {
+func (r *TaskRunner) SetBlocked(pred func(t *state.Task, running []*state.Task) bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -171,7 +152,7 @@ func (r *TaskRunner) SetBlocked(pred func(t *Task, running []*Task) bool) {
 }
 
 // AddBlocked adds a predicate function to decide whether to block a task from running based on the current running tasks. It can be used to control task serialisation. All added predicates are considered in turn until one returns true, or none.
-func (r *TaskRunner) AddBlocked(pred func(t *Task, running []*Task) bool) {
+func (r *TaskRunner) AddBlocked(pred func(t *state.Task, running []*state.Task) bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -179,23 +160,23 @@ func (r *TaskRunner) AddBlocked(pred func(t *Task, running []*Task) bool) {
 }
 
 // run must be called with the state lock in place
-func (r *TaskRunner) run(t *Task) {
+func (r *TaskRunner) run(t *state.Task) {
 	var handler HandlerFunc
 	var accuRuntime func(dur time.Duration)
 	switch t.Status() {
-	case DoStatus:
-		t.SetStatus(DoingStatus)
+	case state.DoStatus:
+		t.SetStatus(state.DoingStatus)
 		fallthrough
-	case DoingStatus:
+	case state.DoingStatus:
 		handler = r.handlerPair(t).do
-		accuRuntime = t.accumulateDoingTime
+		accuRuntime = t.AccumulateDoingTime
 
-	case UndoStatus:
-		t.SetStatus(UndoingStatus)
+	case state.UndoStatus:
+		t.SetStatus(state.UndoingStatus)
 		fallthrough
-	case UndoingStatus:
+	case state.UndoingStatus:
 		handler = r.handlerPair(t).undo
-		accuRuntime = t.accumulateUndoingTime
+		accuRuntime = t.AccumulateUndoingTime
 
 	default:
 		panic("internal error: attempted to run task in status " + t.Status().String())
@@ -234,48 +215,48 @@ func (r *TaskRunner) run(t *Task) {
 		switch err.(type) {
 		case nil:
 			// we are ok
-		case *Retry, *Wait:
+		case *state.Retry, *state.Wait:
 			// preserve
 		default:
 			if r.stopped {
 				// we are shutting down, errors might be due
 				// to cancellations, to be safe retry
-				err = &Retry{}
+				err = &state.Retry{}
 			}
 		}
 
 		switch x := err.(type) {
-		case *Retry:
+		case *state.Retry:
 			// Handler asked to be called again later.
-			if t.Status() == AbortStatus {
+			if t.Status() == state.AbortStatus {
 				// Would work without it but might take two ensures.
 				r.tryUndo(t)
 			} else if x.After != 0 {
 				t.At(timeNow().Add(x.After))
 			}
-		case *Wait:
-			if t.Status() == AbortStatus {
+		case *state.Wait:
+			if t.Status() == state.AbortStatus {
 				// Would work without it but might take two ensures.
 				r.tryUndo(t)
 			} else {
-				t.SetStatus(WaitStatus)
+				t.SetStatus(state.WaitStatus)
 			}
 		case nil:
-			var next []*Task
+			var next []*state.Task
 			switch t.Status() {
-			case DoingStatus:
-				t.SetStatus(DoneStatus)
+			case state.DoingStatus:
+				t.SetStatus(state.DoneStatus)
 				fallthrough
-			case DoneStatus:
+			case state.DoneStatus:
 				next = t.HaltTasks()
-			case AbortStatus:
+			case state.AbortStatus:
 				// It was actually Done if it got here.
-				t.SetStatus(UndoStatus)
+				t.SetStatus(state.UndoStatus)
 				r.state.EnsureBefore(0)
-			case UndoingStatus:
-				t.SetStatus(UndoneStatus)
+			case state.UndoingStatus:
+				t.SetStatus(state.UndoneStatus)
 				fallthrough
-			case UndoneStatus:
+			case state.UndoneStatus:
 				next = t.WaitTasks()
 			}
 			if len(next) > 0 {
@@ -283,7 +264,7 @@ func (r *TaskRunner) run(t *Task) {
 			}
 		default:
 			r.abortLanes(t.Change(), t.Lanes())
-			t.SetStatus(ErrorStatus)
+			t.SetStatus(state.ErrorStatus)
 			t.Errorf("%s", err)
 			// ensure the error is available in the global log too
 			logger.Noticef("[change %s %q task] failed: %v", t.Change().ID(), t.Summary(), err)
@@ -296,7 +277,7 @@ func (r *TaskRunner) run(t *Task) {
 	})
 }
 
-func (r *TaskRunner) clean(t *Task) {
+func (r *TaskRunner) clean(t *state.Task) {
 	if !t.Change().IsReady() {
 		// Whole Change is not ready so don't run cleanups yet.
 		return
@@ -330,12 +311,12 @@ func (r *TaskRunner) clean(t *Task) {
 	})
 }
 
-func (r *TaskRunner) abortLanes(chg *Change, lanes []int) {
+func (r *TaskRunner) abortLanes(chg *state.Change, lanes []int) {
 	chg.AbortLanes(lanes)
 	ensureScheduled := false
 	for _, t := range chg.Tasks() {
 		status := t.Status()
-		if status == AbortStatus {
+		if status == state.AbortStatus {
 			if tb, ok := r.tombs[t.ID()]; ok {
 				tb.Kill(nil)
 			}
@@ -348,16 +329,16 @@ func (r *TaskRunner) abortLanes(chg *Change, lanes []int) {
 }
 
 // tryUndo replaces the status of a knowingly aborted task.
-func (r *TaskRunner) tryUndo(t *Task) {
-	if t.Status() == AbortStatus && r.handlerPair(t).undo == nil {
+func (r *TaskRunner) tryUndo(t *state.Task) {
+	if t.Status() == state.AbortStatus && r.handlerPair(t).undo == nil {
 		// Cannot undo but it was stopped in flight.
 		// Hold so it doesn't look like it finished.
-		t.SetStatus(HoldStatus)
+		t.SetStatus(state.HoldStatus)
 		if len(t.WaitTasks()) > 0 {
 			r.state.EnsureBefore(0)
 		}
 	} else {
-		t.SetStatus(UndoStatus)
+		t.SetStatus(state.UndoStatus)
 		r.state.EnsureBefore(0)
 	}
 }
@@ -379,7 +360,7 @@ func (r *TaskRunner) Ensure() error {
 	defer r.state.Unlock()
 
 	r.someBlocked = false
-	running := make([]*Task, 0, len(r.tombs))
+	running := make([]*state.Task, 0, len(r.tombs))
 	for tid := range r.tombs {
 		t := r.state.Task(tid)
 		if t != nil {
@@ -399,7 +380,7 @@ ConsiderTasks:
 
 		tb := r.tombs[t.ID()]
 
-		if t.Status() == AbortStatus {
+		if t.Status() == state.AbortStatus {
 			if tb != nil {
 				tb.Kill(nil)
 				continue
@@ -419,7 +400,7 @@ ConsiderTasks:
 			}
 			continue
 		}
-		if status == WaitStatus {
+		if status == state.WaitStatus {
 			// nothing more to run
 			continue
 		}
@@ -429,11 +410,11 @@ ConsiderTasks:
 			continue
 		}
 
-		if status == UndoStatus && handlers.undo == nil {
+		if status == state.UndoStatus && handlers.undo == nil {
 			// Although this has no dependencies itself, it must have waited
 			// above too since follow up tasks may have handlers again.
 			// Cannot undo. Revert to done status.
-			t.SetStatus(DoneStatus)
+			t.SetStatus(state.DoneStatus)
 			if len(t.WaitTasks()) > 0 {
 				r.state.EnsureBefore(0)
 			}
@@ -473,15 +454,15 @@ ConsiderTasks:
 }
 
 // mustWait returns whether task t must wait for other tasks to be done.
-func mustWait(t *Task) bool {
+func mustWait(t *state.Task) bool {
 	switch t.Status() {
-	case DoStatus:
+	case state.DoStatus:
 		for _, wt := range t.WaitTasks() {
-			if wt.Status() != DoneStatus {
+			if wt.Status() != state.DoneStatus {
 				return true
 			}
 		}
-	case UndoStatus:
+	case state.UndoStatus:
 		for _, ht := range t.HaltTasks() {
 			if !ht.Status().Ready() {
 				return true

--- a/overlord/runner/taskrunner_test.go
+++ b/overlord/runner/taskrunner_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2022 Canonical Ltd
+ * Copyright (C) 2023 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -17,7 +17,7 @@
  *
  */
 
-package state_test
+package runner_test
 
 import (
 	"errors"
@@ -32,6 +32,7 @@ import (
 	"gopkg.in/tomb.v2"
 
 	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/overlord/runner"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -61,7 +62,7 @@ func (b *stateBackend) EnsureBefore(d time.Duration) {
 	}
 }
 
-func ensureChange(c *C, r *state.TaskRunner, sb *stateBackend, chg *state.Change) {
+func ensureChange(c *C, r *runner.TaskRunner, sb *stateBackend, chg *state.Change) {
 	for i := 0; i < 20; i++ {
 		sb.ensureBefore = time.Hour
 		r.Ensure()
@@ -150,11 +151,11 @@ func (ts *taskRunnerSuite) SetUpTest(c *C) {
 func (ts *taskRunnerSuite) TestSequenceTests(c *C) {
 	sb := &stateBackend{}
 	st := state.New(sb)
-	r := state.NewTaskRunner(st)
+	r := runner.NewTaskRunner(st)
 	defer r.Stop()
 
 	ch := make(chan string, 256)
-	fn := func(label string) state.HandlerFunc {
+	fn := func(label string) runner.HandlerFunc {
 		return func(task *state.Task, tomb *tomb.Tomb) error {
 			st.Lock()
 			defer st.Unlock()
@@ -361,7 +362,7 @@ func (ts *taskRunnerSuite) TestAbortAcrossLanesDescendantTask(c *C) {
 
 	sb := &stateBackend{}
 	st := state.New(sb)
-	r := state.NewTaskRunner(st)
+	r := runner.NewTaskRunner(st)
 	defer r.Stop()
 
 	st.Lock()
@@ -466,7 +467,7 @@ func (ts *taskRunnerSuite) TestAbortAcrossLanesStriclyOrderedTasks(c *C) {
 
 	sb := &stateBackend{}
 	st := state.New(sb)
-	r := state.NewTaskRunner(st)
+	r := runner.NewTaskRunner(st)
 	defer r.Stop()
 
 	st.Lock()
@@ -551,7 +552,7 @@ func (ts *taskRunnerSuite) TestAbortAcrossLanesStriclyOrderedTasks(c *C) {
 func (ts *taskRunnerSuite) TestExternalAbort(c *C) {
 	sb := &stateBackend{}
 	st := state.New(sb)
-	r := state.NewTaskRunner(st)
+	r := runner.NewTaskRunner(st)
 	defer r.Stop()
 
 	ch := make(chan bool)
@@ -581,7 +582,7 @@ func (ts *taskRunnerSuite) TestExternalAbort(c *C) {
 func (ts *taskRunnerSuite) TestUndoSingleLane(c *C) {
 	sb := &stateBackend{}
 	st := state.New(sb)
-	r := state.NewTaskRunner(st)
+	r := runner.NewTaskRunner(st)
 	defer r.Stop()
 
 	r.AddHandler("noop", func(t *state.Task, tb *tomb.Tomb) error {
@@ -676,7 +677,7 @@ func (ts *taskRunnerSuite) TestUndoSingleLane(c *C) {
 func (ts *taskRunnerSuite) TestStopHandlerJustFinishing(c *C) {
 	sb := &stateBackend{}
 	st := state.New(sb)
-	r := state.NewTaskRunner(st)
+	r := runner.NewTaskRunner(st)
 	defer r.Stop()
 
 	ch := make(chan bool)
@@ -707,7 +708,7 @@ func (ts *taskRunnerSuite) TestStopHandlerJustFinishing(c *C) {
 func (ts *taskRunnerSuite) TestStopKinds(c *C) {
 	sb := &stateBackend{}
 	st := state.New(sb)
-	r := state.NewTaskRunner(st)
+	r := runner.NewTaskRunner(st)
 	defer r.Stop()
 
 	ch1 := make(chan bool)
@@ -752,7 +753,7 @@ func (ts *taskRunnerSuite) TestStopKinds(c *C) {
 func (ts *taskRunnerSuite) TestErrorsOnStopAreRetried(c *C) {
 	sb := &stateBackend{}
 	st := state.New(sb)
-	r := state.NewTaskRunner(st)
+	r := runner.NewTaskRunner(st)
 	defer r.Stop()
 
 	ch := make(chan bool)
@@ -782,7 +783,7 @@ func (ts *taskRunnerSuite) TestErrorsOnStopAreRetried(c *C) {
 func (ts *taskRunnerSuite) TestStopAskForRetry(c *C) {
 	sb := &stateBackend{}
 	st := state.New(sb)
-	r := state.NewTaskRunner(st)
+	r := runner.NewTaskRunner(st)
 	defer r.Stop()
 
 	ch := make(chan bool)
@@ -812,7 +813,7 @@ func (ts *taskRunnerSuite) TestStopAskForRetry(c *C) {
 func (ts *taskRunnerSuite) TestTaskReturningWait(c *C) {
 	sb := &stateBackend{}
 	st := state.New(sb)
-	r := state.NewTaskRunner(st)
+	r := runner.NewTaskRunner(st)
 	defer r.Stop()
 
 	r.AddHandler("ask-for-wait", func(t *state.Task, tb *tomb.Tomb) error {
@@ -854,7 +855,7 @@ func (ts *taskRunnerSuite) TestRetryAfterDuration(c *C) {
 		ensureBeforeSeen: ensureBeforeTick,
 	}
 	st := state.New(sb)
-	r := state.NewTaskRunner(st)
+	r := runner.NewTaskRunner(st)
 	defer r.Stop()
 
 	ch := make(chan bool)
@@ -924,14 +925,14 @@ func (ts *taskRunnerSuite) TestRetryAfterDuration(c *C) {
 	c.Check(t.AtTime().IsZero(), Equals, true)
 }
 
-func (ts *taskRunnerSuite) testTaskSerialization(c *C, setupBlocked func(r *state.TaskRunner)) {
+func (ts *taskRunnerSuite) testTaskSerialization(c *C, setupBlocked func(r *runner.TaskRunner)) {
 	ensureBeforeTick := make(chan bool, 1)
 	sb := &stateBackend{
 		ensureBefore:     time.Hour,
 		ensureBeforeSeen: ensureBeforeTick,
 	}
 	st := state.New(sb)
-	r := state.NewTaskRunner(st)
+	r := runner.NewTaskRunner(st)
 	defer r.Stop()
 
 	ch1 := make(chan bool)
@@ -1003,7 +1004,7 @@ func (ts *taskRunnerSuite) testTaskSerialization(c *C, setupBlocked func(r *stat
 func (ts *taskRunnerSuite) TestTaskSerializationSetBlocked(c *C) {
 	// start first do1, and then do2 when nothing else is running
 	startedDo1 := false
-	ts.testTaskSerialization(c, func(r *state.TaskRunner) {
+	ts.testTaskSerialization(c, func(r *runner.TaskRunner) {
 		r.SetBlocked(func(t *state.Task, running []*state.Task) bool {
 			if t.Kind() == "do2" && (len(running) != 0 || !startedDo1) {
 				return true
@@ -1019,7 +1020,7 @@ func (ts *taskRunnerSuite) TestTaskSerializationSetBlocked(c *C) {
 func (ts *taskRunnerSuite) TestTaskSerializationAddBlocked(c *C) {
 	// start first do1, and then do2 when nothing else is running
 	startedDo1 := false
-	ts.testTaskSerialization(c, func(r *state.TaskRunner) {
+	ts.testTaskSerialization(c, func(r *runner.TaskRunner) {
 		r.AddBlocked(func(t *state.Task, running []*state.Task) bool {
 			if t.Kind() == "do2" && (len(running) != 0 || !startedDo1) {
 				return true
@@ -1038,7 +1039,7 @@ func (ts *taskRunnerSuite) TestTaskSerializationAddBlocked(c *C) {
 func (ts *taskRunnerSuite) TestPrematureChangeReady(c *C) {
 	sb := &stateBackend{}
 	st := state.New(sb)
-	r := state.NewTaskRunner(st)
+	r := runner.NewTaskRunner(st)
 	defer r.Stop()
 
 	ch := make(chan bool)
@@ -1083,7 +1084,7 @@ func (ts *taskRunnerSuite) TestPrematureChangeReady(c *C) {
 func (ts *taskRunnerSuite) TestOptionalHandler(c *C) {
 	sb := &stateBackend{}
 	st := state.New(sb)
-	r := state.NewTaskRunner(st)
+	r := runner.NewTaskRunner(st)
 
 	r.AddOptionalHandler(func(t *state.Task) bool { return true },
 		func(t *state.Task, tomb *tomb.Tomb) error {
@@ -1109,7 +1110,7 @@ func (ts *taskRunnerSuite) TestOptionalHandler(c *C) {
 func (ts *taskRunnerSuite) TestUndoSequence(c *C) {
 	sb := &stateBackend{}
 	st := state.New(sb)
-	r := state.NewTaskRunner(st)
+	r := runner.NewTaskRunner(st)
 
 	var events []string
 
@@ -1189,7 +1190,7 @@ func (ts *taskRunnerSuite) TestUndoSequence(c *C) {
 
 func (ts *taskRunnerSuite) TestKnownTaskKinds(c *C) {
 	st := state.New(nil)
-	r := state.NewTaskRunner(st)
+	r := runner.NewTaskRunner(st)
 	r.AddHandler("task-kind-1", func(t *state.Task, tb *tomb.Tomb) error { return nil }, nil)
 	r.AddHandler("task-kind-2", func(t *state.Task, tb *tomb.Tomb) error { return nil }, nil)
 
@@ -1201,7 +1202,7 @@ func (ts *taskRunnerSuite) TestKnownTaskKinds(c *C) {
 func (ts *taskRunnerSuite) TestCleanup(c *C) {
 	sb := &stateBackend{}
 	st := state.New(sb)
-	r := state.NewTaskRunner(st)
+	r := runner.NewTaskRunner(st)
 	defer r.Stop()
 
 	r.AddHandler("clean-it", func(t *state.Task, tb *tomb.Tomb) error { return nil }, nil)
@@ -1256,7 +1257,7 @@ func (ts *taskRunnerSuite) TestErrorCallbackCalledOnError(c *C) {
 
 	sb := &stateBackend{}
 	st := state.New(sb)
-	r := state.NewTaskRunner(st)
+	r := runner.NewTaskRunner(st)
 
 	var called bool
 	r.OnTaskError(func(err error) {
@@ -1290,7 +1291,7 @@ func (ts *taskRunnerSuite) TestErrorCallbackCalledOnError(c *C) {
 func (ts *taskRunnerSuite) TestErrorCallbackNotCalled(c *C) {
 	sb := &stateBackend{}
 	st := state.New(sb)
-	r := state.NewTaskRunner(st)
+	r := runner.NewTaskRunner(st)
 
 	var called bool
 	r.OnTaskError(func(err error) {

--- a/overlord/servicestate/servicemgr.go
+++ b/overlord/servicestate/servicemgr.go
@@ -32,6 +32,7 @@ import (
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/restart"
+	"github.com/snapcore/snapd/overlord/runner"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/progress"
@@ -51,16 +52,16 @@ type ServiceManager struct {
 }
 
 // Manager returns a new service manager.
-func Manager(st *state.State, runner *state.TaskRunner) *ServiceManager {
+func Manager(st *state.State, r *runner.TaskRunner) *ServiceManager {
 	delayedCrossMgrInit()
 	m := &ServiceManager{
 		state: st,
 	}
 	// TODO: undo handler
-	runner.AddHandler("service-control", m.doServiceControl, nil)
+	r.AddHandler("service-control", m.doServiceControl, nil)
 
 	// TODO: undo handler
-	runner.AddHandler("quota-control", m.doQuotaControl, nil)
+	r.AddHandler("quota-control", m.doQuotaControl, nil)
 	RegisterAffectedQuotasByKind("quota-control", affectedQuotasForQuotaControl)
 	snapstate.RegisterAffectedSnapsByKind("quota-control", affectedSnapsForQuotaControl)
 
@@ -68,7 +69,7 @@ func Manager(st *state.State, runner *state.TaskRunner) *ServiceManager {
 	// so this task encapsulate taking care of calling quotaUpdate
 	// with the correct setup. This task also supports proper handling of
 	// failure during install and correctly removes the snap again.
-	runner.AddHandler("quota-add-snap", m.doQuotaAddSnap, m.undoQuotaAddSnap)
+	r.AddHandler("quota-add-snap", m.doQuotaAddSnap, m.undoQuotaAddSnap)
 	RegisterAffectedQuotasByKind("quota-add-snap", affectedQuotasForQuotaAddSnap)
 	// quota-add-snap uses snap-setup and because of this retrieving the snap
 	// that is being added is implicitly already supported by snapstate/conflict.go

--- a/overlord/snapshotstate/snapshotmgr.go
+++ b/overlord/snapshotstate/snapshotmgr.go
@@ -32,6 +32,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/configstate/config"
+	"github.com/snapcore/snapd/overlord/runner"
 	"github.com/snapcore/snapd/overlord/snapshotstate/backend"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
@@ -66,14 +67,14 @@ type SnapshotManager struct {
 }
 
 // Manager returns a new SnapshotManager
-func Manager(st *state.State, runner *state.TaskRunner) *SnapshotManager {
+func Manager(st *state.State, r *runner.TaskRunner) *SnapshotManager {
 	delayedCrossMgrInit()
 
-	runner.AddHandler("save-snapshot", doSave, doForget)
-	runner.AddHandler("forget-snapshot", doForget, nil)
-	runner.AddHandler("check-snapshot", doCheck, nil)
-	runner.AddHandler("restore-snapshot", doRestore, undoRestore)
-	runner.AddHandler("cleanup-after-restore", doCleanupAfterRestore, nil)
+	r.AddHandler("save-snapshot", doSave, doForget)
+	r.AddHandler("forget-snapshot", doForget, nil)
+	r.AddHandler("check-snapshot", doCheck, nil)
+	r.AddHandler("restore-snapshot", doRestore, undoRestore)
+	r.AddHandler("cleanup-after-restore", doCleanupAfterRestore, nil)
 
 	manager := &SnapshotManager{
 		state: st,

--- a/overlord/snapshotstate/snapshotmgr_test.go
+++ b/overlord/snapshotstate/snapshotmgr_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord"
+	"github.com/snapcore/snapd/overlord/runner"
 	"github.com/snapcore/snapd/overlord/snapshotstate"
 	"github.com/snapcore/snapd/overlord/snapshotstate/backend"
 	"github.com/snapcore/snapd/overlord/state"
@@ -46,7 +47,7 @@ func (snapshotSuite) TestManager(c *check.C) {
 	st := state.New(nil)
 	st.Lock()
 	defer st.Unlock()
-	runner := state.NewTaskRunner(st)
+	runner := runner.NewTaskRunner(st)
 	mgr := snapshotstate.Manager(st, runner)
 	c.Assert(mgr, check.NotNil)
 	kinds := runner.KnownTaskKinds()
@@ -92,7 +93,7 @@ func (snapshotSuite) TestEnsureForgetsSnapshots(c *check.C) {
 	defer restore()
 
 	st := state.New(nil)
-	runner := state.NewTaskRunner(st)
+	runner := runner.NewTaskRunner(st)
 	mgr := snapshotstate.Manager(st, runner)
 	c.Assert(mgr, check.NotNil)
 
@@ -137,7 +138,7 @@ func (snapshotSuite) TestEnsureForgetsSnapshotsRunsRegularly(c *check.C) {
 	defer restoreOsRemove()
 
 	st := state.New(nil)
-	runner := state.NewTaskRunner(st)
+	runner := runner.NewTaskRunner(st)
 	mgr := snapshotstate.Manager(st, runner)
 	c.Assert(mgr, check.NotNil)
 
@@ -180,7 +181,7 @@ func (snapshotSuite) testEnsureForgetSnapshotsConflict(c *check.C, snapshotOp st
 	defer restore()
 
 	st := state.New(nil)
-	runner := state.NewTaskRunner(st)
+	runner := runner.NewTaskRunner(st)
 	mgr := snapshotstate.Manager(st, runner)
 	c.Assert(mgr, check.NotNil)
 
@@ -896,7 +897,7 @@ func (snapshotSuite) TestManagerRunCleanupAbandondedImportsAtStartup(c *check.C)
 
 	o := overlord.Mock()
 	st := o.State()
-	mgr := snapshotstate.Manager(st, state.NewTaskRunner(st))
+	mgr := snapshotstate.Manager(st, runner.NewTaskRunner(st))
 	c.Assert(mgr, check.NotNil)
 	o.AddManager(mgr)
 	err := o.Settle(100 * time.Millisecond)
@@ -918,7 +919,7 @@ func (snapshotSuite) TestManagerRunCleanupAbandondedImportsAtStartupErrorLogged(
 
 	o := overlord.Mock()
 	st := o.State()
-	mgr := snapshotstate.Manager(st, state.NewTaskRunner(st))
+	mgr := snapshotstate.Manager(st, runner.NewTaskRunner(st))
 	c.Assert(mgr, check.NotNil)
 	o.AddManager(mgr)
 	err := o.Settle(100 * time.Millisecond)

--- a/overlord/snapstate/cookies_test.go
+++ b/overlord/snapstate/cookies_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/overlord/runner"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -46,7 +47,7 @@ func (s *cookiesSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
 	dirs.SetRootDir(c.MkDir())
 	s.st = state.New(nil)
-	s.snapmgr, _ = Manager(s.st, state.NewTaskRunner(s.st))
+	s.snapmgr, _ = Manager(s.st, runner.NewTaskRunner(s.st))
 }
 
 func (s *cookiesSuite) TearDownTest(c *C) {

--- a/overlord/snapstate/handlers_prepare_test.go
+++ b/overlord/snapstate/handlers_prepare_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord"
+	"github.com/snapcore/snapd/overlord/runner"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
@@ -37,7 +38,7 @@ type baseHandlerSuite struct {
 	testutil.BaseTest
 
 	state   *state.State
-	runner  *state.TaskRunner
+	runner  *runner.TaskRunner
 	se      *overlord.StateEngine
 	snapmgr *snapstate.SnapManager
 
@@ -51,7 +52,7 @@ func (s *baseHandlerSuite) SetUpTest(c *C) {
 
 	s.fakeBackend = &fakeSnappyBackend{}
 	s.state = state.New(nil)
-	s.runner = state.NewTaskRunner(s.state)
+	s.runner = runner.NewTaskRunner(s.state)
 
 	var err error
 	s.snapmgr, err = snapstate.Manager(s.state, s.runner)

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/overlord/runner"
 	userclient "github.com/snapcore/snapd/usersession/client"
 
 	// So it registers Configure.
@@ -345,7 +346,7 @@ type ForeignTaskTracker interface {
 	ForeignTask(kind string, status state.Status, snapsup *snapstate.SnapSetup) error
 }
 
-func AddForeignTaskHandlers(runner *state.TaskRunner, tracker ForeignTaskTracker) {
+func AddForeignTaskHandlers(r *runner.TaskRunner, tracker ForeignTaskTracker) {
 	// Add fake handlers for tasks handled by interfaces manager
 	fakeHandler := func(task *state.Task, _ *tomb.Tomb) error {
 		task.State().Lock()
@@ -359,30 +360,30 @@ func AddForeignTaskHandlers(runner *state.TaskRunner, tracker ForeignTaskTracker
 
 		return tracker.ForeignTask(kind, status, snapsup)
 	}
-	runner.AddHandler("setup-profiles", fakeHandler, fakeHandler)
-	runner.AddHandler("auto-connect", fakeHandler, fakeHandler)
-	runner.AddHandler("auto-disconnect", fakeHandler, nil)
-	runner.AddHandler("remove-profiles", fakeHandler, fakeHandler)
-	runner.AddHandler("discard-conns", fakeHandler, fakeHandler)
-	runner.AddHandler("validate-snap", fakeHandler, nil)
-	runner.AddHandler("transition-ubuntu-core", fakeHandler, nil)
-	runner.AddHandler("transition-to-snapd-snap", fakeHandler, nil)
-	runner.AddHandler("update-gadget-assets", fakeHandler, nil)
-	runner.AddHandler("update-managed-boot-config", fakeHandler, nil)
+	r.AddHandler("setup-profiles", fakeHandler, fakeHandler)
+	r.AddHandler("auto-connect", fakeHandler, fakeHandler)
+	r.AddHandler("auto-disconnect", fakeHandler, nil)
+	r.AddHandler("remove-profiles", fakeHandler, fakeHandler)
+	r.AddHandler("discard-conns", fakeHandler, fakeHandler)
+	r.AddHandler("validate-snap", fakeHandler, nil)
+	r.AddHandler("transition-ubuntu-core", fakeHandler, nil)
+	r.AddHandler("transition-to-snapd-snap", fakeHandler, nil)
+	r.AddHandler("update-gadget-assets", fakeHandler, nil)
+	r.AddHandler("update-managed-boot-config", fakeHandler, nil)
 
 	// Add handler to test full aborting of changes
 	erroringHandler := func(task *state.Task, _ *tomb.Tomb) error {
 		return errors.New("error out")
 	}
-	runner.AddHandler("error-trigger", erroringHandler, nil)
+	r.AddHandler("error-trigger", erroringHandler, nil)
 
-	runner.AddHandler("save-snapshot", func(task *state.Task, _ *tomb.Tomb) error {
+	r.AddHandler("save-snapshot", func(task *state.Task, _ *tomb.Tomb) error {
 		return nil
 	}, nil)
-	runner.AddHandler("run-hook", func(task *state.Task, _ *tomb.Tomb) error {
+	r.AddHandler("run-hook", func(task *state.Task, _ *tomb.Tomb) error {
 		return nil
 	}, nil)
-	runner.AddHandler("configure-snapd", func(t *state.Task, _ *tomb.Tomb) error {
+	r.AddHandler("configure-snapd", func(t *state.Task, _ *tomb.Tomb) error {
 		return nil
 	}, nil)
 }

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/overlord/runner"
 	userclient "github.com/snapcore/snapd/usersession/client"
 
 	// So it registers Configure.
@@ -9233,7 +9234,7 @@ func (s *snapmgrTestSuite) TestReRefreshCreatesPreDownloadChange(c *C) {
 
 func (s *snapmgrTestSuite) TestDownloadTaskWaitsForPreDownload(c *C) {
 	now := time.Now()
-	restore := state.MockTime(now)
+	restore := runner.MockTime(now)
 	defer restore()
 
 	var notified bool
@@ -9295,13 +9296,12 @@ func (s *snapmgrTestSuite) TestDownloadTaskWaitsForPreDownload(c *C) {
 					}
 
 					s.state.Lock()
-					defer s.state.Unlock()
-
 					// the download task registers itself w/ the pre-download and retries
-					c.Assert(atTime.Equal(now.Add(2*time.Minute)), Equals, true)
+					c.Check(atTime.Equal(now.Add(2*time.Minute)), Equals, true)
 					var taskIDs []string
-					c.Assert(preDlTask.Get("waiting-tasks", &taskIDs), IsNil)
-					c.Assert(taskIDs, DeepEquals, []string{dlTask.ID()})
+					c.Check(preDlTask.Get("waiting-tasks", &taskIDs), IsNil)
+					c.Check(taskIDs, DeepEquals, []string{dlTask.ID()})
+					s.state.Unlock()
 					return
 				}
 			}

--- a/overlord/state/export_test.go
+++ b/overlord/state/export_test.go
@@ -58,14 +58,6 @@ func (w Warning) LastAdded() time.Time {
 	return w.lastAdded
 }
 
-func (t *Task) AccumulateDoingTime(duration time.Duration) {
-	t.accumulateDoingTime(duration)
-}
-
-func (t *Task) AccumulateUndoingTime(duration time.Duration) {
-	t.accumulateUndoingTime(duration)
-}
-
 var (
 	ErrNoWarningMessage     = errNoWarningMessage
 	ErrBadWarningMessage    = errBadWarningMessage


### PR DESCRIPTION
As I want to integrate restart awareness for changes into the TaskRunner, I see a reason to move TaskRunner to its own package to be separated from the state package. This makes it a lot easier to avoid cyclic dependencies for functionality in the TaskRunner due to *everything* relying on the state package.