### PR TITLE
[beta-riscv64] Bring in missing snapcraft.yaml changes

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -37,6 +37,12 @@ parts:
     build-snaps:
       - on riscv64: [go/1.16/stable]
       - else: [go/1.13/stable]
+    # these packages are needed to call mkversion.sh in override-pull, all other
+    # dependencies are installed using apt-get build-dep
+    build-packages:
+      - git
+      - dpkg-dev
+    after: [apparmor]
     override-pull: |
       snapcraftctl pull
       [ -e packaging/ubuntu-20.04 ] || ln -s ubuntu-16.04 packaging/ubuntu-20.04
@@ -52,17 +58,6 @@ parts:
       sudo -E apt-get build-dep -y ./
       ./get-deps.sh --skip-unused-check
     override-build: |
-      # TODO: when something like "craftctl get-version" is ready, then we can
-      # use that, but until then, we have to re-run mkversion.sh to check if the
-      # version number was set as "dirty" from the override-pull step
-      if sh -x ./mkversion.sh --output-only | grep "dirty"; then
-        mkdir -p $SNAPCRAFT_PART_INSTALL/usr/lib/snapd
-        ( 
-          echo "dirty git tree during build detected:"
-          git status
-          git diff
-        ) > $SNAPCRAFT_PART_INSTALL/usr/lib/snapd/dirty-git-tree-info.txt
-      fi
       # unset the LD_FLAGS and LD_LIBRARY_PATH vars that snapcraft sets for us
       # as those will point to the $SNAPCRAFT_STAGE which on re-builds will 
       # contain things like libc and friends that confuse the debian package
@@ -82,6 +77,21 @@ parts:
       dpkg-deb -x $(pwd)/../snapd_*.deb $SNAPCRAFT_PART_INSTALL
       # not included in the deb as it's only used with UC20 preseeding.
       cp -a data/preseed.json $SNAPCRAFT_PART_INSTALL/usr/lib/snapd/
+      # Note that this check should run *after* dpkg-buildpackage was run
+      # as this will re-run "go generate" which may cause a dirty tree
+      #
+      # TODO: when something like "craftctl get-version" is ready, then we can
+      # use that, but until then, we have to re-run mkversion.sh to check if the
+      # version number was set as "dirty" from the override-pull step or during
+      # the build step
+      if sh -x ./mkversion.sh --output-only | grep "dirty"; then
+        mkdir -p $SNAPCRAFT_PART_INSTALL/usr/lib/snapd
+        (
+          echo "dirty git tree during build detected:"
+          git status
+          git diff
+        ) > $SNAPCRAFT_PART_INSTALL/usr/lib/snapd/dirty-git-tree-info.txt
+      fi
 
   # xdelta is used to enable delta downloads (even if the host does not have it)
   xdelta3:
@@ -160,3 +170,37 @@ parts:
       cp -a fc-cache-bionic $SNAPCRAFT_PART_INSTALL/bin/fc-cache-v7
     prime:
       - bin/fc-cache-v7
+  apparmor:
+    plugin: autotools
+    build-packages: [bison, flex, gettext, g++, pkg-config]
+    source: https://launchpad.net/apparmor/3.0/3.0.7/+download/apparmor-3.0.7.tar.gz
+    override-build: |
+      cd $SNAPCRAFT_PART_BUILD/libraries/libapparmor
+      ./autogen.sh
+      ./configure --prefix=/usr --disable-man-pages --disable-perl --disable-python --disable-ruby
+      make -j$(nproc)
+      # place libapparmor into staging area for use by snap-confine
+      make -C src install DESTDIR=$SNAPCRAFT_STAGE
+      cd $SNAPCRAFT_PART_BUILD/parser
+      # copy in a pregenerated list of network address families so that the
+      # parser gets built to support as many as possible even if glibc in
+      # the current build environment does not support them
+      # For some reason, some snapcraft version remove the "build-aux" folder
+      # and move the contents up when the data is uploaded; this conditional
+      # manages it.
+      if [ -d "$SNAPCRAFT_PROJECT_DIR/build-aux" ]; then
+        cp $SNAPCRAFT_PROJECT_DIR/build-aux/snap/local/apparmor/af_names.h .
+      else
+        cp $SNAPCRAFT_PROJECT_DIR/snap/local/apparmor/af_names.h .
+      fi
+      make -j$(nproc)
+      mkdir -p $SNAPCRAFT_PART_INSTALL/usr/lib/snapd
+      cp -a apparmor_parser $SNAPCRAFT_PART_INSTALL/usr/lib/snapd/
+      mkdir -p $SNAPCRAFT_PART_INSTALL/usr/lib/snapd/apparmor
+      cp -a parser.conf $SNAPCRAFT_PART_INSTALL/usr/lib/snapd/apparmor/
+      cd $SNAPCRAFT_PART_BUILD/profiles
+      make -j$(nproc)
+      mkdir -p $SNAPCRAFT_PART_INSTALL/usr/lib/snapd/apparmor.d
+      cp -a apparmor.d/abi $SNAPCRAFT_PART_INSTALL/usr/lib/snapd/apparmor.d/
+      cp -a apparmor.d/abstractions $SNAPCRAFT_PART_INSTALL/usr/lib/snapd/apparmor.d/
+      cp -a apparmor.d/tunables $SNAPCRAFT_PART_INSTALL/usr/lib/snapd/apparmor.d/


### PR DESCRIPTION
somehow beta-riscv64 branch is still missing many packaging changes to snapcraft.yaml which are present in the `release/2.59` branch and in the `master-riscv64` branch.

With this merge the difference between `beta-riscv64` and `master-riscv64` is just the branch name used for the snapd part (which is the current expected snapcraft.ymal delta between master & release/2.59)