### PR TITLE
o/state: add support for taskrunner hooks

### DIFF
--- a/overlord/state/taskrunner.go
+++ b/overlord/state/taskrunner.go
@@ -35,8 +35,8 @@ type HookFunc func()
 type HookEvent int
 
 const (
-	// TaskExhaustionHook is executed when there are no more tasks to be run.
-	TaskExhaustionHook HookEvent = iota
+	// TaskExhaustion is executed when there are no more tasks to be run.
+	TaskExhaustion HookEvent = iota
 )
 
 // HandlerFunc is the type of function for the handlers
@@ -501,15 +501,12 @@ ConsiderTasks:
 		r.state.EnsureBefore(nextTaskTime.Sub(ensureTime))
 	}
 
-	// run hooks registered for task exhaustion
+	// run hooks registered for task exhaustion for each change
 	if len(running) == 0 {
-		for _, hooks := range r.hooks {
-			for _, h := range hooks {
-				h()
-			}
+		for _, h := range r.hooks[TaskExhaustion] {
+			h()
 		}
 	}
-
 	return nil
 }
 

--- a/overlord/state/taskrunner.go
+++ b/overlord/state/taskrunner.go
@@ -517,7 +517,7 @@ ConsiderTasks:
 	for _, chg := range r.state.changes {
 		// if there are no running tasks for this change, report
 		// task exhaustion for that change.
-		if readyChanges[chg.ID()] {
+		if !readyChanges[chg.ID()] {
 			// have we already reported exhaustion for that change?
 			if r.exhausted[chg.ID()] {
 				continue

--- a/overlord/state/taskrunner.go
+++ b/overlord/state/taskrunner.go
@@ -28,16 +28,17 @@ import (
 	"github.com/snapcore/snapd/logger"
 )
 
-// HookFunc is the type of function that can be registered as a hook.
-type HookFunc func(chg *Change)
+// ChangeHookFunc is the type of function that can be registered as a hook, to
+// listen for change events
+type ChangeHookFunc func(chg *Change)
 
-// HookEvent are types of different hooks that can be registered handlers for.
-type HookEvent int
+// ChangeHookEvent are types of change hooks that can be registered handlers for.
+type ChangeHookEvent int
 
 const (
 	// TaskExhaustion is executed when there are no more tasks to be run for
 	// a given change.
-	TaskExhaustion HookEvent = iota
+	TaskExhaustion ChangeHookEvent = iota
 )
 
 // HandlerFunc is the type of function for the handlers
@@ -91,7 +92,7 @@ type TaskRunner struct {
 	blocked     []blockedFunc
 	someBlocked bool
 
-	hooks     map[HookEvent][]HookFunc
+	hooks     map[ChangeHookEvent][]ChangeHookFunc
 	exhausted map[string]bool
 
 	// optional callback executed on task errors
@@ -116,7 +117,7 @@ func NewTaskRunner(s *State) *TaskRunner {
 		state:     s,
 		handlers:  make(map[string]handlerPair),
 		cleanups:  make(map[string]HandlerFunc),
-		hooks:     make(map[HookEvent][]HookFunc),
+		hooks:     make(map[ChangeHookEvent][]ChangeHookFunc),
 		exhausted: make(map[string]bool),
 		tombs:     make(map[string]*tomb.Tomb),
 	}
@@ -200,8 +201,8 @@ func (r *TaskRunner) AddBlocked(pred func(t *Task, running []*Task) bool) {
 	r.blocked = append(r.blocked, pred)
 }
 
-// AddHook registers a hook function for the given hook event type.
-func (r *TaskRunner) AddHook(hook HookFunc, evt HookEvent) {
+// AddChangeHook registers a hook function for the given change hook event.
+func (r *TaskRunner) AddChangeHook(hook ChangeHookFunc, evt ChangeHookEvent) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 

--- a/overlord/state/taskrunner.go
+++ b/overlord/state/taskrunner.go
@@ -422,7 +422,7 @@ func (r *TaskRunner) Ensure() error {
 		}
 	}
 
-	changes := make(map[string]bool)
+	readyChanges := make(map[string]bool)
 	ensureTime := timeNow()
 	nextTaskTime := time.Time{}
 ConsiderTasks:
@@ -501,10 +501,9 @@ ConsiderTasks:
 
 		// Keep track of changes that have jobs ready to run.
 		chg := t.Change()
-		changes[chg.ID()] = true
+		readyChanges[chg.ID()] = true
 
-		// If a change had jobs ready to run, then reset the exhaustion
-		// status for that change.
+		// If a change had jobs ready to run, reset its exhaustion status.
 		r.exhausted[chg.ID()] = false
 	}
 
@@ -518,9 +517,9 @@ ConsiderTasks:
 	for _, chg := range r.state.changes {
 		// if there are no running tasks for this change, report
 		// task exhaustion for that change.
-		if seen := changes[chg.ID()]; seen {
+		if readyChanges[chg.ID()] {
 			// have we already reported exhaustion for that change?
-			if reported := r.exhausted[chg.ID()]; reported {
+			if r.exhausted[chg.ID()] {
 				continue
 			}
 			r.exhausted[chg.ID()] = true

--- a/overlord/state/taskrunner_test.go
+++ b/overlord/state/taskrunner_test.go
@@ -1340,7 +1340,7 @@ func (ts *taskRunnerSuite) TestTaskExhaustionHook(c *C) {
 
 	var hookCalls int
 	var hookChange *state.Change
-	r.AddHook(func(chg *state.Change) {
+	r.AddChangeHook(func(chg *state.Change) {
 		hookCalls++
 		hookChange = chg
 	}, state.TaskExhaustion)
@@ -1383,7 +1383,7 @@ func (ts *taskRunnerSuite) TestTaskExhaustionHookResetsTracking(c *C) {
 	}, nil)
 
 	var hookCalls int
-	r.AddHook(func(chg *state.Change) {
+	r.AddChangeHook(func(chg *state.Change) {
 		hookCalls++
 	}, state.TaskExhaustion)
 

--- a/overlord/state/taskrunner_test.go
+++ b/overlord/state/taskrunner_test.go
@@ -1357,6 +1357,8 @@ func (ts *taskRunnerSuite) TestTaskExhaustionHook(c *C) {
 	// Ensure that 'ensure' is run one more time
 	// to report exhaustion
 	r.Ensure()
+	// make sure that hook was called at the end of 'Ensure'
+	c.Check(hookCalls, Equals, 1)
 
 	// Make sure we run 'ensure' once more, that we don't
 	// get a second exhaustion hook
@@ -1368,7 +1370,8 @@ func (ts *taskRunnerSuite) TestTaskExhaustionHook(c *C) {
 
 	c.Check(t1.Status(), Equals, state.DoneStatus)
 
-	// make sure that hook was called at the end of 'Ensure'
+	// make sure that hook wasn't invoked again during the last
+	// ensure call
 	c.Check(hookCalls, Equals, 1)
 	c.Check(hookChange, Equals, chg)
 }

--- a/overlord/state/taskrunner_test.go
+++ b/overlord/state/taskrunner_test.go
@@ -1341,7 +1341,7 @@ func (ts *taskRunnerSuite) TestTaskExhaustionHook(c *C) {
 	var hookCalled bool
 	r.AddHook(func() {
 		hookCalled = true
-	}, state.TaskExhaustionHook)
+	}, state.TaskExhaustion)
 
 	st.Lock()
 	chg := st.NewChange("install", "...")

--- a/overlord/state/taskrunner_test.go
+++ b/overlord/state/taskrunner_test.go
@@ -1354,9 +1354,6 @@ func (ts *taskRunnerSuite) TestTaskExhaustionHook(c *C) {
 	// Mark tasks as done.
 	ensureChange(c, r, sb, chg)
 
-	// Ensure that 'ensure' is run one more time
-	// to report exhaustion
-	r.Ensure()
 	// make sure that hook was called at the end of 'Ensure'
 	c.Check(hookCalls, Equals, 1)
 
@@ -1401,10 +1398,6 @@ func (ts *taskRunnerSuite) TestTaskExhaustionHookResetsTracking(c *C) {
 	r.Ensure()
 	r.Wait()
 
-	// Ensure that 'ensure' is run one more time
-	// to report exhaustion
-	r.Ensure()
-
 	// Reset the foo handler to instead finish
 	r.AddHandler("foo", func(t *state.Task, tomb *tomb.Tomb) error {
 		return nil
@@ -1417,9 +1410,6 @@ func (ts *taskRunnerSuite) TestTaskExhaustionHookResetsTracking(c *C) {
 
 	// Mark tasks as done.
 	ensureChange(c, r, sb, chg)
-
-	// Run again to ensure hook is called again
-	r.Ensure()
 	r.Stop()
 
 	st.Lock()


### PR DESCRIPTION
This is an alternative solution to https://github.com/snapcore/snapd/pull/12716, which instead implements the concept of hooks for the TaskRunner.