### PR TITLE
tests: update lxd base snap for ubuntu gt 22.04 in preseed test

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -42,7 +42,7 @@ environment:
     TRUST_TEST_KEYS: '$(HOST: echo "${SPREAD_TRUST_TEST_KEYS:-true}")'
     # a global setting for LXD channel to use in the tests
     LXD_SNAP_CHANNEL: "latest/candidate"
-    UBUNTU_IMAGE_SNAP_CHANNEL: "latest/candidate"
+    UBUNTU_IMAGE_SNAP_CHANNEL: "latest/stable"
     # controls whether ubuntu-image is built using the current snapd tree as a
     # dependency or the one listed in its go.mod
     UBUNTU_IMAGE_ALLOW_API_BREAK: '$(HOST: echo "${SPREAD_UBUNTU_IMAGE_ALLOW_API_BREAK:-true}")'

--- a/tests/main/preseed/task.yaml
+++ b/tests/main/preseed/task.yaml
@@ -9,7 +9,6 @@ systems: [ubuntu-2*]
 
 environment:
   IMAGE_MOUNTPOINT: /mnt/cloudimg
-  LXD_BASE_SNAP: core20
 
 prepare: |
   # shellcheck source=tests/lib/image.sh
@@ -39,6 +38,11 @@ restore: |
   umount_ubuntu_image "$IMAGE_MOUNTPOINT" || true
 
 execute: |
+  LXD_BASE_SNAP=core20
+  if os.query is-ubuntu-gt 22.04; then
+      LXD_BASE_SNAP=core22
+  fi
+
   echo "Checking missing chroot path arg error"
   /usr/lib/snapd/snap-preseed 2>&1 | MATCH "error: need chroot path as argument"
 


### PR DESCRIPTION
This is needed because the lxd snap had changed the base snap

Also, the ubuntu-image snap channel is updated to stable. With candidate snap the following error is happening:

[15948](https://github.com/snapcore/snapd/actions/runs/4682589568/jobs/8309300825?pr=12725#step:8:15949)/snap/ubuntu-image/460/bin/ubuntu-image:
/lib/x86\_64-linux-gnu/libc.so.6: version \`GLIBC\_2.32' not found
(required by /snap/ubuntu-image/460/bin/ubuntu-image)