### PR TITLE
interfaces: allow loopback as a block-device

### DIFF
--- a/interfaces/builtin/block_devices.go
+++ b/interfaces/builtin/block_devices.go
@@ -66,6 +66,8 @@ const blockDevicesConnectedPlugAppArmor = `
 /dev/i2o/hdd[a-x] rwk,                                     # I2O hard disk continued
 /dev/mmcblk[0-9]{,[0-9],[0-9][0-9]} rwk,                   # MMC (up to 1000 devices)
 /dev/vd[a-z] rwk,                                          # virtio
+/dev/loop[0-9]{,[0-9],[0-9][0-9]} rwk,                     # loopback (up to 1000 devices)
+/dev/loop-control rw,                                      # loopback control
 
 # Allow /dev/nvmeXnY namespace block devices. Please note this grants access to all
 # NVMe namespace block devices and that the numeric suffix on the character device


### PR DESCRIPTION
Allowing loopback devices in the block-devices interface would be convenient for testing and proof-of-concept setups for users of snaps that consume block devices such as MicroCeph

Use case 1: allow a snap to utilize a preconfigured loopback bdev, for
instance allow MicroCeph to use a loopback device as an OSD for
testing or other non-performance critical work

Use case 2: allow a snap to create a loopback device automatically;
e.g. for the above scenario MicroCeph could automatically set up a
loop bdev for use as an OSD