### PR TITLE
agent: Add DBus interface for changes monitoring

### DIFF
--- a/client/change.go
+++ b/client/change.go
@@ -56,12 +56,15 @@ func (c *Change) Get(key string, value interface{}) error {
 
 // A Task is an operation done to change the system's state.
 type Task struct {
-	ID       string       `json:"id"`
-	Kind     string       `json:"kind"`
-	Summary  string       `json:"summary"`
-	Status   string       `json:"status"`
-	Log      []string     `json:"log,omitempty"`
-	Progress TaskProgress `json:"progress"`
+	ID           string       `json:"id"`
+	Kind         string       `json:"kind"`
+	Summary      string       `json:"summary"`
+	SnapName     string       `json:"snap-name,omitempty"`
+	InstanceName string       `json:"instance-name,omitempty"`
+	Revision     string       `json:"revision,omitempty"`
+	Status       string       `json:"status"`
+	Log          []string     `json:"log,omitempty"`
+	Progress     TaskProgress `json:"progress"`
 
 	SpawnTime time.Time `json:"spawn-time,omitempty"`
 	ReadyTime time.Time `json:"ready-time,omitempty"`

--- a/daemon/api_general.go
+++ b/daemon/api_general.go
@@ -36,6 +36,7 @@ import (
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/devicestate"
+	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/sandbox"
@@ -324,12 +325,15 @@ type changeInfo struct {
 }
 
 type taskInfo struct {
-	ID       string           `json:"id"`
-	Kind     string           `json:"kind"`
-	Summary  string           `json:"summary"`
-	Status   string           `json:"status"`
-	Log      []string         `json:"log,omitempty"`
-	Progress taskInfoProgress `json:"progress"`
+	ID           string           `json:"id"`
+	Kind         string           `json:"kind"`
+	SnapName     string           `json:"snap-name,omitempty"`
+	InstanceName string           `json:"instance-name,omitempty"`
+	Revision     string           `json:"revision,omitempty"`
+	Summary      string           `json:"summary"`
+	Status       string           `json:"status"`
+	Log          []string         `json:"log,omitempty"`
+	Progress     taskInfoProgress `json:"progress"`
 
 	SpawnTime time.Time  `json:"spawn-time,omitempty"`
 	ReadyTime *time.Time `json:"ready-time,omitempty"`
@@ -377,6 +381,12 @@ func change2changeInfo(chg *state.Change) *changeInfo {
 				Total: total,
 			},
 			SpawnTime: t.SpawnTime(),
+		}
+		snapsup, err := snapstate.TaskSnapSetup(t)
+		if err == nil {
+			taskInfo.SnapName = snapsup.SnapName()
+			taskInfo.InstanceName = snapsup.InstanceName()
+			taskInfo.Revision = snapsup.Revision().String()
 		}
 		readyTime := t.ReadyTime()
 		if !readyTime.IsZero() {

--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -652,6 +652,17 @@ func (m *autoRefresh) launchAutoRefresh(overrideDelay bool) error {
 	chg.Set("snap-names", updated)
 	chg.Set("api-data", map[string]interface{}{"snap-names": updated})
 	state.TagTimingsWithChange(perfTimings, chg)
+	if overrideDelay {
+		go func() {
+			clientT := userclient.New()
+			changeInfo := userclient.ChangeNotifyInfo{
+				ChangeId:   chg.ID(),
+				ChangeType: "delayed-auto-refresh",
+				ChangeKind: chg.Kind(),
+			}
+			clientT.ChangeNotification(context.TODO(), changeInfo)
+		}()
+	}
 
 	return nil
 }

--- a/usersession/agent/changes.go
+++ b/usersession/agent/changes.go
@@ -1,0 +1,103 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package agent
+
+import (
+	"errors"
+
+	"github.com/godbus/dbus"
+	"github.com/snapcore/snapd/client"
+)
+
+const snapChangesIntrospectionXML = `
+<interface name='io.snapcraft.SnapChanges'>
+	<method name="GetTasks">
+		<arg type="s" name="change_id" direction="in" />
+		<arg type="a{sv}" name="extra_data" direction="in" />
+		<arg type="a{sa{sv}}" name="tasks_data" direction="out" />
+	</method>
+	<signal name="Change">
+		<arg type="s" name="change_id" />
+		<arg type="s" name="change_type" />
+		<arg type="s" name="change_kind" />
+		<arg type="a{sv}" name="metadata" />
+	</signal>
+
+</interface>`
+
+// SnapChanges implements the 'io.snapcraft.SnapChanges' DBus interface.
+type SnapChanges struct {
+	conn *dbus.Conn
+}
+
+// Interface returns the name of the interface this object implements
+func (s *SnapChanges) Interface() string {
+	return "io.snapcraft.SnapChanges"
+}
+
+// ObjectPath returns the path that the object is exported as
+func (s *SnapChanges) ObjectPath() dbus.ObjectPath {
+	return "/io/snapcraft/SnapChanges"
+}
+
+// IntrospectionData gives the XML formatted introspection description
+// of the DBus service.
+func (s *SnapChanges) IntrospectionData() string {
+	return snapChangesIntrospectionXML
+}
+
+func (s *SnapChanges) GetTasks(changeId string, extraData map[string]dbus.Variant) (*map[string]map[string]dbus.Variant, *dbus.Error) {
+	var cliConfig client.Config
+
+	result := make(map[string]map[string]dbus.Variant)
+
+	cli := client.New(&cliConfig)
+	if cli == nil {
+		return &result, dbus.NewError("Failed to connect to the daemon", nil)
+	}
+
+	changeData, err := cli.Change(changeId)
+	if err != nil {
+		return &result, dbus.NewError(err.Error(), nil)
+	}
+	for _, task := range changeData.Tasks {
+		val := make(map[string]dbus.Variant)
+		val["ID"] = dbus.MakeVariant(task.ID)
+		val["Kind"] = dbus.MakeVariant(task.Kind)
+		val["Summary"] = dbus.MakeVariant(task.Summary)
+		val["SnapName"] = dbus.MakeVariant(task.SnapName)
+		val["InstanceName"] = dbus.MakeVariant(task.InstanceName)
+		val["Revision"] = dbus.MakeVariant(task.Revision)
+		val["Status"] = dbus.MakeVariant(task.Status)
+		val["ProgressLabel"] = dbus.MakeVariant(task.Progress.Label)
+		val["ProgressTotal"] = dbus.MakeVariant(task.Progress.Total)
+		val["ProgressDone"] = dbus.MakeVariant(task.Progress.Done)
+		result[task.ID] = val
+	}
+	return &result, nil
+}
+
+func (s *SnapChanges) EmitChange(change_id string, change_type string, change_kind string, extraData map[string]dbus.Variant) error {
+	if s.conn != nil {
+		s.conn.Emit(s.ObjectPath(), "io.snapcraft.SnapChanges.Change", change_id, change_type, change_kind, extraData)
+		return nil
+	}
+	return errors.New("No session bus connection.")
+}

--- a/usersession/agent/changes.go
+++ b/usersession/agent/changes.go
@@ -36,7 +36,6 @@ const snapChangesIntrospectionXML = `
 	<signal name="Change">
 		<arg type="s" name="change_id" />
 		<arg type="s" name="change_type" />
-		<arg type="s" name="change_kind" />
 		<arg type="a{sv}" name="metadata" />
 	</signal>
 
@@ -96,7 +95,9 @@ func (s *SnapChanges) GetTasks(changeId string, extraData map[string]dbus.Varian
 
 func (s *SnapChanges) EmitChange(change_id string, change_type string, change_kind string, extraData map[string]dbus.Variant) error {
 	if s.conn != nil {
-		s.conn.Emit(s.ObjectPath(), "io.snapcraft.SnapChanges.Change", change_id, change_type, change_kind, extraData)
+		extraData := make(map[string]dbus.Variant)
+		extraData["Kind"] = dbus.MakeVariant(change_kind)
+		s.conn.Emit(s.ObjectPath(), "io.snapcraft.SnapChanges.Change", change_id, change_type, extraData)
 		return nil
 	}
 	return errors.New("No session bus connection.")

--- a/usersession/client/client.go
+++ b/usersession/client/client.go
@@ -34,6 +34,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/godbus/dbus"
 	"github.com/snapcore/snapd/dirs"
 )
 
@@ -339,5 +340,24 @@ func (client *Client) FinishRefreshNotification(ctx context.Context, closeInfo *
 		return err
 	}
 	_, err = client.doMany(ctx, "POST", "/v1/notifications/finish-refresh", nil, headers, reqBody)
+	return err
+}
+
+// ChangeNotifyInfo holds information about a refresh notification
+type ChangeNotifyInfo struct {
+	ChangeId   string                  `json:"change-id"`
+	ChangeType string                  `json:"change-type"`
+	ChangeKind string                  `json:"change-kind"`
+	ExtraData  map[string]dbus.Variant `json:"extra-data"`
+}
+
+// ChangeNotification notifies that a new change has been added
+func (client *Client) ChangeNotification(ctx context.Context, changeInfo ChangeNotifyInfo) error {
+	headers := map[string]string{"Content-Type": "application/json"}
+	reqBody, err := json.Marshal(changeInfo)
+	if err != nil {
+		return err
+	}
+	_, err = client.doMany(ctx, "POST", "/v1/notifications/notify-change", nil, headers, reqBody)
 	return err
 }


### PR DESCRIPTION
This DBus interface allows an user-session program to know when a delayed autorefresh has begun and ask for the current status of the tasks, thus moving outside snapd all the code to update the current refresh status.

The DBus interface is added to the user agent, at the well-known name `io.snapcraft.SessionAgent`, object `/io/snapcraft/SessionAgent`, interface `io.snapcraft.SessionAgent`, described at https://docs.google.com/document/d/1RLbTPKyPb_u47xgndPut_IC2L1WxHXUxzAx2As0Q-Vo

This MR requires changes in snapd-desktop-integration.

This MR also adds some extra info in the internal query from the user agent to the snapd daemon when asking data about a change. The new data, added only when it is available, is the snap name, instance name and snap revision of the snap being modified by an specific task.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
