### PR TITLE
HACKING: add notes about launching user agent

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -435,7 +435,7 @@ the testing one. Don't forget to roll back to the original, after you finish tes
 
 ### Testing the snap userd agent
 
-To test the `snap userd --agent` command, you must first to stop the current process if it is
+To test the `snap userd --agent` command, you must first stop the current process, if it is
 running, and then stop the dbus activation part. To do so, just run:
 
     systemctl --user disable snapd.session-agent.socket

--- a/HACKING.md
+++ b/HACKING.md
@@ -433,6 +433,20 @@ maybe you need to replace system installed snap-seccomp with the one aligned to 
 you are testing. To do this, simply backup `/usr/lib/snapd/snap-seccomp` and overwrite it with 
 the testing one. Don't forget to roll back to the original, after you finish testing.
 
+### Testing the snap userd agent
+
+To test the `snap userd --agent` command, you must first kill the current process if it is
+running, and then stop the dbus activation part. To do so, just run:
+
+    systemctl --user disable snapd.session-agent.socket
+    systemctl --user stop snapd.session-agent.socket
+
+After that, it's now possible to launch the program from a command line.
+
+To re-enable the dbus activation, kill that process and run:
+
+    systemctl --user enable snapd.session-agent.socket
+
 ### Running nested tests
 
 Nested tests are used to validate features that cannot be tested with the regular tests.

--- a/HACKING.md
+++ b/HACKING.md
@@ -435,13 +435,14 @@ the testing one. Don't forget to roll back to the original, after you finish tes
 
 ### Testing the snap userd agent
 
-To test the `snap userd --agent` command, you must first kill the current process if it is
+To test the `snap userd --agent` command, you must first to stop the current process if it is
 running, and then stop the dbus activation part. To do so, just run:
 
     systemctl --user disable snapd.session-agent.socket
     systemctl --user stop snapd.session-agent.socket
 
-After that, it's now possible to launch the program from a command line.
+After that, it's now possible to launch the daemon with `snapd userd --agent` from a command
+line.
 
 To re-enable the dbus activation, kill that process and run:
 


### PR DESCRIPTION
Launching a locally compiled `snap userd --agent` command requires to disable first its dbus activation service.

This MR adds some notes to the HACKING.md file explaining this.
