### PR TITLE
fde: export runFDEinitramfsHelper for reuse from initramfs

### DIFF
--- a/kernel/fde/cmd_helper.go
+++ b/kernel/fde/cmd_helper.go
@@ -49,7 +49,7 @@ var fdeInitramfsHelperPollWaitParanoiaFactor = 2
 // overridden in tests
 var fdeInitramfsHelperCommandExtra []string
 
-func runFDEinitramfsHelper(name string, stdin []byte) (output []byte, err error) {
+func RunFDEinitramfsHelper(name string, stdin []byte) (output []byte, err error) {
 	runDir := filepath.Join(dirs.GlobalRootDir, "/run", name)
 	if err := os.MkdirAll(runDir, 0700); err != nil {
 		return nil, fmt.Errorf("cannot create tmp dir for %s: %v", name, err)

--- a/kernel/fde/reveal_key.go
+++ b/kernel/fde/reveal_key.go
@@ -53,7 +53,7 @@ func runFDERevealKeyCommand(req *RevealKeyRequest) (output []byte, err error) {
 		return nil, fmt.Errorf(`cannot build request %v for fde-reveal-key: %v`, req, err)
 	}
 
-	return runFDEinitramfsHelper("fde-reveal-key", stdin)
+	return RunFDEinitramfsHelper("fde-reveal-key", stdin)
 }
 
 var runFDERevealKey = runFDERevealKeyCommand


### PR DESCRIPTION
Export runFDEinitramfsHelper for use from snap-bootstrap