### PR TITLE
[beta-riscv64] build-aux: Use dpkg-buildpackage options to not attempt signing anything

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -73,7 +73,7 @@ parts:
       fi
       # run the real build (but just build the binary package, and don't
       # bother compressing it too much)
-      dpkg-buildpackage -b -Zgzip -zfast
+      dpkg-buildpackage -b -Zgzip -zfast -uc -us
       dpkg-deb -x $(pwd)/../snapd_*.deb $SNAPCRAFT_PART_INSTALL
       # not included in the deb as it's only used with UC20 preseeding.
       cp -a data/preseed.json $SNAPCRAFT_PART_INSTALL/usr/lib/snapd/

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -76,7 +76,7 @@ build_deb(){
     fi
 
     unshare -n -- \
-            su -l -c "cd $PWD && DEB_BUILD_OPTIONS='nocheck testkeys' dpkg-buildpackage -tc -b -Zgzip" test
+            su -l -c "cd $PWD && DEB_BUILD_OPTIONS='nocheck testkeys' dpkg-buildpackage -tc -b -Zgzip -uc -us" test
     # put our debs to a safe place
     cp ../*.deb "$GOHOME"
 }
@@ -361,7 +361,7 @@ prepare_project() {
         tar -c -z -f ../snapd_"$(dpkg-parsechangelog --show-field Version|cut -d- -f1)".orig.tar.gz --exclude=./debian --exclude=./.git .
 
         # and build a source package - this will be used during the sbuild test
-        dpkg-buildpackage -S --no-sign
+        dpkg-buildpackage -S -uc -us
     fi
 
     # so is ubuntu-14.04


### PR DESCRIPTION
NB! target branch is beta-riscv64.

Currently riscv64 builds are failing, because dpkg-buildpackage attempts signing. Use the historic `-uc -us` (unsigned changes, unsigned sources) options that are available in xenial and up, to prevent attempts to sign with mvo's gpg key inside launchpad snap builds.

(cherry picked from commit 2204c2fd8e78443041de6e39ee935077d49af055)

(cherry pick packaging fix that unbreaks riscv64 builds into the beta-riscv64 branch to build 2.59 release)
