### PR TITLE
tests: fix lxd-mount-units test in ubuntu-22.10

### DIFF
--- a/tests/main/lxd-mount-units/task.yaml
+++ b/tests/main/lxd-mount-units/task.yaml
@@ -18,7 +18,7 @@ execute: |
 
     # Define the core snap for the current system
     core_snap=core20
-    if os.query is-ubuntu 23.04; then
+    if os.query is-ubuntu-gt 22.04; then
         core_snap=core22
     fi
 


### PR DESCRIPTION
Same issue fixed in preseed test now needs to be fixed in lxd-mount-units test

