### PR TITLE
tests: avoid reboot in snap-confine-tmp-mount test

### DIFF
--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -50,7 +50,7 @@ reset_classic() {
         ls -lR "$SNAP_MOUNT_DIR"/ /var/snap/
         exit 1
     fi
-    rm -rf /tmp/snap-private-tmp
+    rm -rf /tmp/snap-private-tmp/*
 
     case "$SPREAD_SYSTEM" in
         fedora-*|centos-*)

--- a/tests/main/snap-confine-tmp-mount/task.yaml
+++ b/tests/main/snap-confine-tmp-mount/task.yaml
@@ -24,22 +24,6 @@ debug: |
     cat /tmp/snap-confine-stderr.log || true
 
 execute: |
-    # in general our systemd-tmpfiles configuration should have created
-    # /tmp/snap-private-tmp already, BUT if this is the first time a snapd deb
-    # has been installed which contains this configuration then it will not have
-    # been created yet so always reboot to ensure that our systemd-tmpfiles
-    # configuration gets run
-    if [ "$SPREAD_REBOOT" = "0" ]; then
-      # currently the systemd-tmpfiles config is not installed on UC so it will
-      # not get executed on reboot
-      if ! os.query is-core; then
-        echo "Rebooting to ensure systemd-tmpfiles gets triggered to create /tmp/snap-private-tmp"
-        REBOOT
-      fi
-    else
-      stat -c "%U %G %a" /tmp/snap-private-tmp | MATCH "root root 700"
-    fi
-
     SNAP_CONFINE=$(os.paths libexec-dir)/snapd/snap-confine
 
     # on Ubuntu Core we need to use the correct path to ensure it is
@@ -59,7 +43,8 @@ execute: |
     # /tmp/snap-private-tmp/snap.test-snapd-sh/ - snap-confine outputs to
     # stderr and id will output to stdout so capture each separately
     tests.session -u test exec sh -c "env -i SNAPD_DEBUG=1 SNAP_INSTANCE_NAME=test-snapd-sh $SNAP_CONFINE --base core snap.test-snapd-sh.sh /bin/bash -c id 1>/tmp/snap-confine-stdout.log 2>/tmp/snap-confine-stderr.log"
-    
+
+    stat -c "%U %G %a" /tmp/snap-private-tmp | MATCH "root root 700"
     stat -c "%U %G %a" /tmp/snap-private-tmp/snap.test-snapd-sh | MATCH "root root 700"
     stat -c "%U %G %a" /tmp/snap-private-tmp/snap.test-snapd-sh/tmp | MATCH "root root 1777"
     # and snap-confine should ensure the target binary is executed as the test user


### PR DESCRIPTION
The reboot can be avoided in the test snap-confine-tmp-mount. 

Also the reboot was causing the test auto-refresh-gating-from-snap to fail because the refresh was being delayed about 5 minutes.

+ echo 'Trigger auto-refresh of test-snapd-refresh-control-provider but hold it via test-snapd-refresh-control'\''s hook'
Trigger auto-refresh of test-snapd-refresh-control-provider but hold it via test-snapd-refresh-control's hook
+ /home/gopath/src/github.com/snapcore/snapd/tests/lib/tools/snapd-state force-autorefresh
+ systemctl start snapd.service snapd.socket ++
/home/gopath/src/github.com/snapcore/snapd/tests/lib/tools/snapd-state wait-for-autorefresh 1
+ LAST_REFRESH_CHANGE_ID='snapd-state: expected a new auto-refresh change with id greater than 1, but it didn'\''t happen'

these are the tests affected by the reboot:
    - google:ubuntu-16.04-64:tests/main/auto-refresh-gating-from-snap
    - google:ubuntu-16.04-64:tests/main/auto-refresh-pre-download:restart
 