### PR TITLE
snapd: show pulsebar while refreshing

### DIFF
--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -438,7 +438,7 @@ func (m *autoRefresh) restoreMonitoring() {
 		abort := make(chan bool, 1)
 		monitoring[snap] = abort
 
-		go continueRefreshOnSnapClose(m.state, snap, done, abort)
+		go continueRefreshOnSnapClose(m.state, snap, "", done, abort)
 	}
 	updateMonitoringState(m.state, monitoring)
 }

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -34,7 +34,6 @@ import (
 
 	"gopkg.in/tomb.v2"
 
-	"github.com/mvo5/goconfigparser"
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/boot"
@@ -970,19 +969,11 @@ func continueRefreshOnSnapClose(st *state.State, instanceName string, desktopEnt
 	if continueAutoRefresh {
 		continueInhibitedAutoRefresh(st)
 
-		var icon string
-		if desktopEntry != "" {
-			parser := goconfigparser.New()
-			desktopFilePath := filepath.Join(dirs.SnapDesktopFilesDir, desktopEntry+".desktop")
-			if err := parser.ReadFile(desktopFilePath); err == nil {
-				icon, _ = parser.Get("Desktop Entry", "Icon")
-
-			}
-		}
 		data := userclient.DelayedRefreshNotifyInfo{
-			SnapName: instanceName,
-			Icon:     icon,
+			SnapName:    instanceName,
+			DesktopFile: filepath.Join(dirs.SnapDesktopFilesDir, desktopEntry+".desktop"),
 		}
+
 		asyncDelayedRefreshNotification(userclient.New(), context.TODO(), data)
 	}
 }

--- a/usersession/agent/rest_api.go
+++ b/usersession/agent/rest_api.go
@@ -361,7 +361,7 @@ func postRefreshFinishedNotification(c *Command, r *http.Request) Response {
 	return SyncResponse(nil)
 }
 
-var tryNotifyRefreshViaSnapDesktopIntegrationFlow = func(snapName string, icon string, create bool) error {
+var tryNotifyRefreshViaSnapDesktopIntegrationFlow = func(snapName string, desktopFile string, create bool) error {
 	// Check if Snapd-Desktop-Integration is available
 	conn, err := dbusutil.SessionBus()
 	if err != nil {
@@ -370,8 +370,8 @@ var tryNotifyRefreshViaSnapDesktopIntegrationFlow = func(snapName string, icon s
 	}
 	obj := conn.Object("io.snapcraft.SnapDesktopIntegration", "/io/snapcraft/SnapDesktopIntegration")
 	extraParams := make(map[string]dbus.Variant)
-	if icon != "" {
-		extraParams["icon_image"] = dbus.MakeVariant(icon)
+	if desktopFile != "" {
+		extraParams["desktop_file"] = dbus.MakeVariant(desktopFile)
 	}
 	if create {
 		err = obj.Call("io.snapcraft.SnapDesktopIntegration.ApplicationIsBeingRefreshed", 0, snapName, "", extraParams).Store()
@@ -397,7 +397,7 @@ func postNotifyDelayedRefresh(c *Command, r *http.Request) Response {
 		return BadRequest("cannot decode request body into delayed refresh notification info: %v", err)
 	}
 
-	if err := tryNotifyRefreshViaSnapDesktopIntegrationFlow(delayedRefreshNotify.SnapName, delayedRefreshNotify.Icon, true); err == nil {
+	if err := tryNotifyRefreshViaSnapDesktopIntegrationFlow(delayedRefreshNotify.SnapName, delayedRefreshNotify.DesktopFile, true); err == nil {
 		return SyncResponse(nil)
 	}
 	// Notification through snapd-desktop-integration failed; use a standard notification

--- a/usersession/client/client.go
+++ b/usersession/client/client.go
@@ -341,3 +341,20 @@ func (client *Client) FinishRefreshNotification(ctx context.Context, closeInfo *
 	_, err = client.doMany(ctx, "POST", "/v1/notifications/finish-refresh", nil, headers, reqBody)
 	return err
 }
+
+// DelayedRefreshNotifyInfo holds information about a refresh notification
+type DelayedRefreshNotifyInfo struct {
+	SnapName string `json:"snap-name"`
+	Icon     string `json:"icon,omitempty"`
+}
+
+// ChangeNotification notifies that a new change has been added
+func (client *Client) DelayedRefreshNotification(ctx context.Context, delayedRefreshInfo DelayedRefreshNotifyInfo) error {
+	headers := map[string]string{"Content-Type": "application/json"}
+	reqBody, err := json.Marshal(delayedRefreshInfo)
+	if err != nil {
+		return err
+	}
+	_, err = client.doMany(ctx, "POST", "/v1/notifications/begin-delayed-refresh", nil, headers, reqBody)
+	return err
+}

--- a/usersession/client/client.go
+++ b/usersession/client/client.go
@@ -344,8 +344,8 @@ func (client *Client) FinishRefreshNotification(ctx context.Context, closeInfo *
 
 // DelayedRefreshNotifyInfo holds information about a refresh notification
 type DelayedRefreshNotifyInfo struct {
-	SnapName string `json:"snap-name"`
-	Icon     string `json:"icon,omitempty"`
+	SnapName    string `json:"snap-name"`
+	DesktopFile string `json:"desktop-file,omitempty"`
 }
 
 // ChangeNotification notifies that a new change has been added


### PR DESCRIPTION
This MR uses snapd-desktop-integration to show a pulsed bar while a snap is being refreshed after the user closed it. It's a stop-gap until the complete version, showing a true progress bar with the number of tasks to do and done, and the task summary being executed in each moment, can be merged. Also, if snapd-desktop-integration isn't installed, it shows a normal notification to inform the user that the snap is being refreshed.

It works with the current snapd-desktop-integration snap, although to show the snap icon it requires the `candidate` version.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
