### PR TITLE
o/snapstate: fix race condition in test

### DIFF
--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -9285,25 +9285,23 @@ func (s *snapmgrTestSuite) TestDownloadTaskWaitsForPreDownload(c *C) {
 			c.Assert(s.o.TaskRunner().Ensure(), IsNil)
 
 			for i := 0; i < 5; i++ {
-				select {
-				case <-time.After(time.Second):
-					s.state.Lock()
-					atTime := dlTask.AtTime()
-					s.state.Unlock()
-					if atTime.IsZero() {
-						continue
-					}
-
-					s.state.Lock()
-					defer s.state.Unlock()
-
-					// the download task registers itself w/ the pre-download and retries
-					c.Assert(atTime.Equal(now.Add(2*time.Minute)), Equals, true)
-					var taskIDs []string
-					c.Assert(preDlTask.Get("waiting-tasks", &taskIDs), IsNil)
-					c.Assert(taskIDs, DeepEquals, []string{dlTask.ID()})
-					return
+				<-time.After(time.Second)
+				s.state.Lock()
+				atTime := dlTask.AtTime()
+				s.state.Unlock()
+				if atTime.IsZero() {
+					continue
 				}
+
+				s.state.Lock()
+				defer s.state.Unlock()
+
+				// the download task registers itself w/ the pre-download and retries
+				c.Assert(atTime.Equal(now.Add(2*time.Minute)), Equals, true)
+				var taskIDs []string
+				c.Assert(preDlTask.Get("waiting-tasks", &taskIDs), IsNil)
+				c.Assert(taskIDs, DeepEquals, []string{dlTask.ID()})
+				return
 			}
 
 			c.Fatal("download task hasn't run")
@@ -9708,18 +9706,16 @@ func (s *snapmgrTestSuite) TestDeletedMonitoredMapIsCorrectlyDeleted(c *C) {
 
 func waitForMonitoringEnd(st *state.State, c *C) {
 	for i := 0; i < 5; i++ {
-		select {
-		case <-time.After(time.Second):
-			st.Lock()
-			finished := st.Cached("auto-refresh-continue-attempt")
-			if finished == nil {
-				st.Unlock()
-				continue
-			}
-
+		<-time.After(time.Second)
+		st.Lock()
+		finished := st.Cached("auto-refresh-continue-attempt")
+		if finished == nil {
 			st.Unlock()
-			return
+			continue
 		}
+
+		st.Unlock()
+		return
 	}
 
 	c.Fatal("couldn't check monitoring goroutine finished properly")

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -9790,6 +9790,23 @@ func (s *snapmgrTestSuite) TestPreDownloadWithIgnoreRunningRefresh(c *C) {
 	}
 	s.settle(c)
 
+	c.Assert(chg.Status(), Equals, state.DoneStatus)
+	c.Assert(chg.Err(), IsNil)
+
+	// wait for the monitoring to be cleared
+	s.state.Unlock()
+	for i := 0; i < 5; i++ {
+		<-time.After(time.Second)
+		s.state.Lock()
+		// the monitoring has stopped but no auto-refresh was or will be attempted
+		monitoredSnaps := s.state.Cached("monitored-snaps")
+		if monitoredSnaps != nil {
+			s.state.Unlock()
+			continue
+		}
+		break
+	}
+
 	// the monitoring has stopped but no auto-refresh was or will be attempted
 	c.Check(s.state.Cached("monitored-snaps"), IsNil)
 	c.Check(s.state.Cached("auto-refresh-continue-attempt"), IsNil)


### PR DESCRIPTION
The first commit fixes a race condition that I think (I couldn't reproduce) was causing a test to be flaky. The second commit simplifies a check in a few tests.