### PR TITLE
tests: update the ubuntu-image snap channel to avoid issue in uc16

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -42,7 +42,7 @@ environment:
     TRUST_TEST_KEYS: '$(HOST: echo "${SPREAD_TRUST_TEST_KEYS:-true}")'
     # a global setting for LXD channel to use in the tests
     LXD_SNAP_CHANNEL: "latest/candidate"
-    UBUNTU_IMAGE_SNAP_CHANNEL: "latest/stable"
+    UBUNTU_IMAGE_SNAP_CHANNEL: "2/stable"
     # controls whether ubuntu-image is built using the current snapd tree as a
     # dependency or the one listed in its go.mod
     UBUNTU_IMAGE_ALLOW_API_BREAK: '$(HOST: echo "${SPREAD_UBUNTU_IMAGE_ALLOW_API_BREAK:-true}")'


### PR DESCRIPTION
This is the error that I see in uc16 and also when using the snap in ubuntu classic:

UC16


    UBUNTU_IMAGE=/snap/bin/ubuntu-image
    /snap/bin/ubuntu-image snap -w /home/image /home/image/pc.model --channel edge --snap
    /home/image/core_16-2.59.1+git4490.46cba5af0_amd64.snap --output-dir /home/image
    /snap/ubuntu-image/460/bin/ubuntu-image:
    /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /snap/ubuntu-image/460/bin/ubuntu-image) 
    /snap/ubuntu-image/460/bin/ubuntu-image:
    /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /snap/ubuntu-image/460/bin/ubuntu-image)

Focal

    ubuntu-image snap --validation=enforce --image-size 8G  --snap snapd=beta -c stable -O output/pc-amd64-22-stable- 
    snapd_beta ./models/pc-amd64-22.model
    /snap/ubuntu-image/460/bin/ubuntu-image:
    /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /snap/ubuntu-image/460/bin/ubuntu-image) 
    /snap/ubuntu-image/460/bin/ubuntu-image:
    /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /snap/ubuntu-image/460/bin/ubuntu-image)
