### PR TITLE
o/devicestate: track included validation-sets in seed on first boot 

### DIFF
--- a/overlord/assertstate/assertstate.go
+++ b/overlord/assertstate/assertstate.go
@@ -880,7 +880,7 @@ func TryEnforcedValidationSets(st *state.State, validationSets []string, userID 
 // of validation set keys to validation sets, pinned sequence numbers (if any),
 // installed snaps and ignored snaps. It fetches any pre-requisites necessary.
 func ApplyEnforcedValidationSets(st *state.State, valsets map[string]*asserts.ValidationSet, pinnedSeqs map[string]int, snaps []*snapasserts.InstalledSnap, ignoreValidation map[string]bool, userID int) error {
-	deviceCtx, err := snapstate.DevicePastSeeding(st, nil)
+	deviceCtx, err := snapstate.DeviceCtxFromState(st, nil)
 	if err != nil {
 		return err
 	}

--- a/overlord/devicestate/firstboot.go
+++ b/overlord/devicestate/firstboot.go
@@ -108,8 +108,9 @@ func maybeEnforceValidationSetsTask(st *state.State, model *asserts.Model, db as
 	}
 
 	t := st.NewTask("enforce-validation-sets", i18n.G("Track validation sets"))
-	// Set local to true to indicate that we are providing all the neccessary assertions
-	// locally from our assertion database.
+	// Set local to true to indicate that we do only use assertions from the
+	// local assertion database, and that we should not contact the store
+	// for any additional assertions.
 	t.Set("local", true)
 	t.Set("validation-set-keys", vsKeys)
 	t.Set("pinned-sequence-numbers", pins)

--- a/overlord/devicestate/firstboot.go
+++ b/overlord/devicestate/firstboot.go
@@ -386,9 +386,11 @@ func (m *DeviceManager) populateStateFromSeedImpl(tm timings.Measurer) ([]*state
 
 	// mark-seeded waits for the taskset of last snap, and
 	// for all the tasks in the endTs as well.
-	markSeeded.WaitAll(ts)
 	markSeeded.WaitAll(endTs)
 	endTs.AddTask(markSeeded)
+
+	// the last task-set waits for the taskset of the last snap
+	endTs.WaitAll(ts)
 	tsAll = append(tsAll, endTs)
 
 	return tsAll, nil

--- a/overlord/devicestate/firstboot.go
+++ b/overlord/devicestate/firstboot.go
@@ -111,8 +111,7 @@ func maybeEnforceValidationSetsTask(st *state.State, model *asserts.Model, db as
 	}
 
 	t := st.NewTask("enforce-validation-sets", i18n.G("Track validation sets"))
-	userID := 0
-	t.Set("userID", userID)
+	t.Set("local", true)
 	t.Set("validation-sets", vsas)
 	t.Set("pinned-sequence-numbers", pins)
 	return t, nil
@@ -361,14 +360,11 @@ func (m *DeviceManager) populateStateFromSeedImpl(tm timings.Measurer) ([]*state
 
 	// Start tracking any validation sets included in the seed after
 	// installing the included snaps.
-	// XXX: For both preseed and seed or *just* seed?
-	if !preseed {
-		if trackVss, err := maybeEnforceValidationSetsTask(st, model, db); err != nil {
-			return nil, err
-		} else if trackVss != nil {
-			trackVss.WaitAll(ts)
-			endTs.AddTask(trackVss)
-		}
+	if trackVss, err := maybeEnforceValidationSetsTask(st, model, db); err != nil {
+		return nil, err
+	} else if trackVss != nil {
+		trackVss.WaitAll(ts)
+		endTs.AddTask(trackVss)
 	}
 
 	markSeeded := markSeededTask(st)

--- a/overlord/devicestate/firstboot.go
+++ b/overlord/devicestate/firstboot.go
@@ -366,13 +366,13 @@ func (m *DeviceManager) populateStateFromSeedImpl(tm timings.Measurer) ([]*state
 		if trackVss, err := maybeEnforceValidationSetsTask(st, model, db); err != nil {
 			return nil, err
 		} else if trackVss != nil {
+			trackVss.WaitAll(ts)
 			endTs.AddTask(trackVss)
 		}
 	}
 
 	markSeeded := markSeededTask(st)
 	if preseed {
-		preseedDoneTask.WaitAll(endTs)
 		endTs.AddTask(preseedDoneTask)
 	}
 	whatSeeds := &seededSystem{
@@ -386,11 +386,11 @@ func (m *DeviceManager) populateStateFromSeedImpl(tm timings.Measurer) ([]*state
 
 	// mark-seeded waits for the taskset of last snap, and
 	// for all the tasks in the endTs as well.
+	markSeeded.WaitAll(ts)
 	markSeeded.WaitAll(endTs)
 	endTs.AddTask(markSeeded)
 
 	// the last task-set waits for the taskset of the last snap
-	endTs.WaitAll(ts)
 	tsAll = append(tsAll, endTs)
 
 	return tsAll, nil

--- a/overlord/devicestate/firstboot.go
+++ b/overlord/devicestate/firstboot.go
@@ -385,8 +385,6 @@ func (m *DeviceManager) populateStateFromSeedImpl(tm timings.Measurer) ([]*state
 	markSeeded.WaitAll(ts)
 	markSeeded.WaitAll(endTs)
 	endTs.AddTask(markSeeded)
-
-	// the last task-set waits for the taskset of the last snap
 	tsAll = append(tsAll, endTs)
 
 	return tsAll, nil

--- a/overlord/devicestate/firstboot.go
+++ b/overlord/devicestate/firstboot.go
@@ -111,6 +111,8 @@ func maybeEnforceValidationSetsTask(st *state.State, model *asserts.Model, db as
 	}
 
 	t := st.NewTask("enforce-validation-sets", i18n.G("Track validation sets"))
+	// Set local to true to indicate that we are providing all the neccessary assertions
+	// locally from our assertion database.
 	t.Set("local", true)
 	t.Set("validation-sets", vsas)
 	t.Set("pinned-sequence-numbers", pins)

--- a/overlord/devicestate/firstboot20_test.go
+++ b/overlord/devicestate/firstboot20_test.go
@@ -106,7 +106,7 @@ type core20SeedOptions struct {
 	valsets         []string
 }
 
-func (s *firstBoot20Suite) setupCore20LikeSeed(c *C, opts *core20SeedOptions, extraSnaps ...string) *asserts.Model {
+func (s *firstBoot20Suite) setupCore20LikeSeed(c *C, opts core20SeedOptions, extraSnaps ...string) *asserts.Model {
 	var gadgetYaml string
 	if opts.kernelAndGadget {
 		gadgetYaml = `
@@ -301,7 +301,7 @@ func (s *firstBoot20Suite) earlySetup(c *C, m *boot.Modeenv, modelGrade asserts.
 	err := m.WriteTo("")
 	c.Assert(err, IsNil)
 
-	model = s.setupCore20LikeSeed(c, &core20SeedOptions{
+	model = s.setupCore20LikeSeed(c, core20SeedOptions{
 		sysLabel:        m.RecoverySystem,
 		modelGrade:      modelGrade,
 		kernelAndGadget: true,
@@ -804,7 +804,7 @@ func (s *firstBoot20Suite) TestPopulateFromSeedClassicWithModesRunModeNoKernelAn
 	err := m.WriteTo("")
 	c.Assert(err, IsNil)
 
-	model := s.setupCore20LikeSeed(c, &core20SeedOptions{
+	model := s.setupCore20LikeSeed(c, core20SeedOptions{
 		sysLabel:        m.RecoverySystem,
 		modelGrade:      modelGrade,
 		kernelAndGadget: false,
@@ -970,7 +970,7 @@ apps:
 `
 
 	sysLabel := m.RecoverySystem
-	model := s.setupCore20LikeSeed(c, &core20SeedOptions{
+	model := s.setupCore20LikeSeed(c, core20SeedOptions{
 		sysLabel:        sysLabel,
 		modelGrade:      modelGrade,
 		kernelAndGadget: false,
@@ -1155,7 +1155,7 @@ func (s *firstBoot20Suite) testPopulateFromSeedCore20ValidationSetTracking(c *C,
 	err := m.WriteTo("")
 	c.Assert(err, IsNil)
 
-	model := s.setupCore20LikeSeed(c, &core20SeedOptions{
+	model := s.setupCore20LikeSeed(c, core20SeedOptions{
 		sysLabel:        m.RecoverySystem,
 		modelGrade:      "signed",
 		kernelAndGadget: true,

--- a/overlord/devicestate/firstboot20_test.go
+++ b/overlord/devicestate/firstboot20_test.go
@@ -38,7 +38,6 @@ import (
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/assertstate"
-	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/ifacestate"
@@ -48,7 +47,6 @@ import (
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/seed/seedtest"
 	"github.com/snapcore/snapd/snap"
-	"github.com/snapcore/snapd/store/storetest"
 	"github.com/snapcore/snapd/strutil"
 	"github.com/snapcore/snapd/systemd"
 	"github.com/snapcore/snapd/testutil"
@@ -1198,19 +1196,6 @@ func (s *firstBoot20Suite) setupTestValidationSets(c *C) {
 	c.Assert(err, IsNil)
 }
 
-type mockedStore struct {
-	storetest.Store
-	db asserts.RODatabase
-}
-
-func (s *mockedStore) Assertion(assertType *asserts.AssertionType, primaryKey []string, user *auth.UserState) (asserts.Assertion, error) {
-	hdrs, err := asserts.HeadersFromPrimaryKey(assertType, primaryKey)
-	if err != nil {
-		return nil, err
-	}
-	return s.db.Find(assertType, hdrs)
-}
-
 func (s *firstBoot20Suite) testPopulateFromSeedCore20ValidationSetTracking(c *C, valSets []string) *state.Change {
 	s.setupTestValidationSets(c)
 
@@ -1236,9 +1221,6 @@ func (s *firstBoot20Suite) testPopulateFromSeedCore20ValidationSetTracking(c *C,
 	st := s.overlord.State()
 	st.Lock()
 	defer st.Unlock()
-	snapstate.ReplaceStore(st, &mockedStore{
-		db: s.StoreSigning.Database,
-	})
 
 	// run the firstboot code
 	tsAll, err := devicestate.PopulateStateFromSeedImpl(s.overlord.DeviceManager(), s.perfTimings)

--- a/overlord/devicestate/firstboot20_test.go
+++ b/overlord/devicestate/firstboot20_test.go
@@ -1174,6 +1174,7 @@ func (s *firstBoot20Suite) testPopulateFromSeedCore20ValidationSetTracking(c *C,
 	tsAll, err := devicestate.PopulateStateFromSeedImpl(s.overlord.DeviceManager(), s.perfTimings)
 	c.Assert(err, IsNil)
 
+	// ensure the validation-set tracking task is present
 	tsEnd := tsAll[len(tsAll)-1]
 	c.Assert(tsEnd.Tasks(), HasLen, 2)
 	c.Check(tsEnd.Tasks()[0].Kind(), Equals, "enforce-validation-sets")
@@ -1242,6 +1243,18 @@ func (s *firstBoot20Suite) TestPopulateFromSeedCore20ValidationSetTrackingHappy(
 	s.overlord.State().Lock()
 	defer s.overlord.State().Unlock()
 	c.Assert(chg.Status(), Equals, state.DoneStatus, Commentf("%s", chg.Err()))
+
+	// Ensure that we are now tracking the validation-set
+	var tr assertstate.ValidationSetTracking
+	err = assertstate.GetValidationSet(s.overlord.State(), "canonical", "base-set", &tr)
+	c.Assert(err, IsNil)
+	c.Check(tr, DeepEquals, assertstate.ValidationSetTracking{
+		AccountID: "canonical",
+		Name:      "base-set",
+		Mode:      assertstate.Enforce,
+		Current:   1,
+		PinnedAt:  1,
+	})
 }
 
 func (s *firstBoot20Suite) TestPopulateFromSeedCore20ValidationSetTrackingFailsUnmetCriterias(c *C) {

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -2247,6 +2247,12 @@ snaps:
 
 	tsAll, err := devicestate.PopulateStateFromSeedImpl(s.overlord.DeviceManager(), s.perfTimings)
 	c.Assert(err, IsNil)
+
+	// ensure the validation-set tracking task is present
+	tsEnd := tsAll[len(tsAll)-1]
+	c.Assert(tsEnd.Tasks(), HasLen, 2)
+	c.Check(tsEnd.Tasks()[0].Kind(), Equals, "enforce-validation-sets")
+
 	// use the expected kind otherwise settle with start another one
 	chg := st.NewChange("seed", "run the populate from seed changes")
 	for _, ts := range tsAll {
@@ -2310,6 +2316,18 @@ func (s *firstBoot16Suite) TestPopulateFromSeedCore18ValidationSetTrackingHappy(
 	s.overlord.State().Lock()
 	defer s.overlord.State().Unlock()
 	c.Assert(chg.Status(), Equals, state.DoneStatus, Commentf("%s", chg.Err()))
+
+	// Ensure that we are now tracking the validation-set
+	var tr assertstate.ValidationSetTracking
+	err = assertstate.GetValidationSet(s.overlord.State(), "canonical", "base-set", &tr)
+	c.Assert(err, IsNil)
+	c.Check(tr, DeepEquals, assertstate.ValidationSetTracking{
+		AccountID: "canonical",
+		Name:      "base-set",
+		Mode:      assertstate.Enforce,
+		Current:   1,
+		PinnedAt:  1,
+	})
 }
 
 func (s *firstBoot16Suite) TestPopulateFromSeedCore18ValidationSetTrackingUnmetCriteria(c *C) {

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -464,6 +464,14 @@ func MockEnforceValidationSets(f func(*state.State, map[string]*asserts.Validati
 	}
 }
 
+func MockEnforceLocalValidationSets(f func(*state.State, map[string][]string, map[string]int, []*snapasserts.InstalledSnap, map[string]bool) error) func() {
+	old := EnforceLocalValidationSets
+	EnforceLocalValidationSets = f
+	return func() {
+		EnforceLocalValidationSets = old
+	}
+}
+
 func MockCgroupMonitorSnapEnded(f func(string, chan<- string) error) func() {
 	old := cgroupMonitorSnapEnded
 	cgroupMonitorSnapEnded = f

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -4105,7 +4105,7 @@ func (m *SnapManager) doEnforceValidationSets(t *state.Task, _ *tomb.Tomb) error
 	st.Lock()
 	defer st.Unlock()
 
-	var pinnedSeqs map[string]int
+	pinnedSeqs := make(map[string]int)
 	if err := t.Get("pinned-sequence-numbers", &pinnedSeqs); err != nil {
 		return err
 	}

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -4083,8 +4083,8 @@ func (m *SnapManager) doEnforceValidationSets(t *state.Task, _ *tomb.Tomb) error
 	st.Lock()
 	defer st.Unlock()
 
-	var userID int
-	if err := t.Get("userID", &userID); err != nil {
+	var local bool
+	if err := t.Get("local", &local); err != nil {
 		return err
 	}
 
@@ -4117,10 +4117,20 @@ func (m *SnapManager) doEnforceValidationSets(t *state.Task, _ *tomb.Tomb) error
 		return err
 	}
 
-	if err := EnforceValidationSets(st, decodedAsserts, pinnedSeqs, snaps, ignoreValidation, userID); err != nil {
-		return fmt.Errorf("cannot enforce validation sets: %v", err)
-	}
+	if local {
+		if err := EnforceLocalValidationSets(st, decodedAsserts, pinnedSeqs, snaps, ignoreValidation); err != nil {
+			return fmt.Errorf("cannot enforce validation sets: %v", err)
+		}
+	} else {
+		var userID int
+		if err := t.Get("userID", &userID); err != nil {
+			return err
+		}
 
+		if err := EnforceValidationSets(st, decodedAsserts, pinnedSeqs, snaps, ignoreValidation, userID); err != nil {
+			return fmt.Errorf("cannot enforce validation sets: %v", err)
+		}
+	}
 	return nil
 }
 

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -4083,6 +4083,11 @@ func (m *SnapManager) doEnforceValidationSets(t *state.Task, _ *tomb.Tomb) error
 	st.Lock()
 	defer st.Unlock()
 
+	// 'local' determines which enforcement function to invoke. If local is set
+	// to true, then we should call EnforceLocalValidationSets, which does not
+	// fetch any assertions or their pre-requisites. If local is set to false, then
+	// we can call EnforceValidationSets, which may contact the store for any additional
+	// assertions.
 	var local bool
 	if err := t.Get("local", &local); err != nil {
 		return err

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1551,9 +1551,6 @@ func ResolveValidationSetsEnforcementError(ctx context.Context, st *state.State,
 	enforceTask := st.NewTask("enforce-validation-sets", "Enforce validation sets")
 	enforceTask.Set("validation-sets", encodedAsserts)
 	enforceTask.Set("pinned-sequence-numbers", pinnedSeqs)
-	// Set 'local' to false to indicate that we may fetch any necessary assertions. When
-	// setting local to false, we also need to provide the userID.
-	enforceTask.Set("local", false)
 	enforceTask.Set("userID", userID)
 
 	for _, ts := range tasksets {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1551,6 +1551,8 @@ func ResolveValidationSetsEnforcementError(ctx context.Context, st *state.State,
 	enforceTask := st.NewTask("enforce-validation-sets", "Enforce validation sets")
 	enforceTask.Set("validation-sets", encodedAsserts)
 	enforceTask.Set("pinned-sequence-numbers", pinnedSeqs)
+	// Set 'local' to false to indicate that we may fetch any necessary assertions. When
+	// setting local to false, we also need to provide the userID.
 	enforceTask.Set("local", false)
 	enforceTask.Set("userID", userID)
 

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1551,6 +1551,7 @@ func ResolveValidationSetsEnforcementError(ctx context.Context, st *state.State,
 	enforceTask := st.NewTask("enforce-validation-sets", "Enforce validation sets")
 	enforceTask.Set("validation-sets", encodedAsserts)
 	enforceTask.Set("pinned-sequence-numbers", pinnedSeqs)
+	enforceTask.Set("local", false)
 	enforceTask.Set("userID", userID)
 
 	for _, ts := range tasksets {

--- a/overlord/snapstate/storehelpers.go
+++ b/overlord/snapstate/storehelpers.go
@@ -45,7 +45,7 @@ var EnforcedValidationSets func(st *state.State, extraVss ...*asserts.Validation
 
 // EnforceLocalValidationSets allows to hook enforcing validation sets without
 // fetching them or their dependencies. It's hooked from assertstate.
-var EnforceLocalValidationSets func(*state.State, map[string]*asserts.ValidationSet, map[string]int, []*snapasserts.InstalledSnap, map[string]bool) error
+var EnforceLocalValidationSets func(*state.State, map[string][]string, map[string]int, []*snapasserts.InstalledSnap, map[string]bool) error
 
 // EnforceValidationSets allows to hook enforcing validation sets without
 // fetching them. It's hooked from assertstate.

--- a/overlord/snapstate/storehelpers.go
+++ b/overlord/snapstate/storehelpers.go
@@ -43,6 +43,10 @@ var currentSnaps = currentSnapsImpl
 // assertstate.
 var EnforcedValidationSets func(st *state.State, extraVss ...*asserts.ValidationSet) (*snapasserts.ValidationSets, error)
 
+// EnforceLocalValidationSets allows to hook enforcing validation sets without
+// fetching them or their dependencies. It's hooked from assertstate.
+var EnforceLocalValidationSets func(*state.State, map[string]*asserts.ValidationSet, map[string]int, []*snapasserts.InstalledSnap, map[string]bool) error
+
 // EnforceValidationSets allows to hook enforcing validation sets without
 // fetching them. It's hooked from assertstate.
 var EnforceValidationSets func(*state.State, map[string]*asserts.ValidationSet, map[string]int, []*snapasserts.InstalledSnap, map[string]bool, int) error

--- a/seed/seedtest/seedtest.go
+++ b/seed/seedtest/seedtest.go
@@ -273,6 +273,9 @@ func (s *TestingSeed20) MakeSeedWithModel(c *C, label string, model *asserts.Mod
 	retrieve := func(ref *asserts.Ref) (asserts.Assertion, error) {
 		return ref.Resolve(s.StoreSigning.Find)
 	}
+	retrieveSeq := func(seq *asserts.AtSequence) (asserts.Assertion, error) {
+		return seq.Resolve(s.StoreSigning.Find)
+	}
 	newFetcher := func(save func(asserts.Assertion) error) asserts.Fetcher {
 		save2 := func(a asserts.Assertion) error {
 			// for checking
@@ -285,7 +288,7 @@ func (s *TestingSeed20) MakeSeedWithModel(c *C, label string, model *asserts.Mod
 			}
 			return save(a)
 		}
-		return asserts.NewFetcher(db, retrieve, save2)
+		return asserts.NewSequenceFormingFetcher(db, retrieve, retrieveSeq, save2)
 	}
 	sf := seedwriter.MakeSeedAssertionFetcher(newFetcher)
 


### PR DESCRIPTION
This is the final functionality for reproducible images. This adds the neccessary handling of automatically setting up tracking of included validation-sets in the seed.

