### PR TITLE
tests: reapply work-around when hooks running at restart

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -306,7 +306,12 @@ prepare_reexec_override() {
         # the re-exec setting may have changed in the service so we need
         # to ensure snapd is reloaded
         systemctl daemon-reload
+        # Leave some time for snapd to finish processing hooks
+        flush_changes
         systemctl restart snapd
+        # Snapd might need to run some hooks (prepare-device) which
+        # triggers `tests.invariant cgroup-scopes` false positives
+        flush_changes
     fi
 }
 


### PR DESCRIPTION
This was introduced #12625 but since has been lost. Latest pc gadget fails test without this, because scopes are actually running around restart of snapd and `tests.invariant` identifies valid scopes as invalid.

This is blocking snapcore/core-base.