### PR TITLE
image, store/tooling: correct how validation-sets were sent to store

### DIFF
--- a/image/image_linux.go
+++ b/image/image_linux.go
@@ -507,15 +507,13 @@ func (s *imageSeeder) validationSetsAndRevisionForSnap(snapName string) ([]snapa
 
 func (s *imageSeeder) downloadSnaps(snapsToDownload []*seedwriter.SeedSnap, curSnaps []*tooling.CurrentSnap) (downloadedSnaps map[string]*tooling.DownloadedSnap, err error) {
 	byName := make(map[string]*seedwriter.SeedSnap, len(snapsToDownload))
+	revisions := make(map[string]snap.Revision)
 	beforeDownload := func(info *snap.Info) (string, error) {
 		sn := byName[info.SnapName()]
 		if sn == nil {
 			return "", fmt.Errorf("internal error: downloading unexpected snap %q", info.SnapName())
 		}
-		_, rev, err := s.validationSetsAndRevisionForSnap(sn.SnapName())
-		if err != nil {
-			return "", err
-		}
+		rev := revisions[info.SnapName()]
 		if rev.Unset() {
 			rev = info.Revision
 		}
@@ -536,6 +534,7 @@ func (s *imageSeeder) downloadSnaps(snapsToDownload []*seedwriter.SeedSnap, curS
 		}
 
 		byName[sn.SnapName()] = sn
+		revisions[sn.SnapName()] = rev
 		snapToDownloadOptions[i].Snap = sn
 		snapToDownloadOptions[i].Channel = sn.Channel
 		snapToDownloadOptions[i].Revision = rev

--- a/image/image_linux.go
+++ b/image/image_linux.go
@@ -482,7 +482,7 @@ func (s *imageSeeder) deriveInfoForLocalSnaps(f seedwriter.SeedAssertionFetcher,
 	return snaps, s.w.InfoDerived()
 }
 
-func (s *imageSeeder) validationSetsAndRevisionForSnap(snapName string) ([]snapasserts.ValidationSetKey, snap.Revision, error) {
+func (s *imageSeeder) validationSetKeysAndRevisionForSnap(snapName string) ([]snapasserts.ValidationSetKey, snap.Revision, error) {
 	vsas, err := s.db.FindMany(asserts.ValidationSetType, nil)
 	if err != nil && !errors.Is(err, &asserts.NotFoundError{}) {
 		return nil, snap.Revision{}, err
@@ -505,12 +505,12 @@ func (s *imageSeeder) validationSetsAndRevisionForSnap(snapName string) ([]snapa
 	// may miss logic for optional snaps which have required revisions. This
 	// is not covered by the below check, and we may or may not have multiple places
 	// with a similar issue.
-	snapVss, snapRev, err := allVss.CheckPresenceRequired(naming.Snap(snapName))
+	snapVsKeys, snapRev, err := allVss.CheckPresenceRequired(naming.Snap(snapName))
 	if err != nil {
 		return nil, snap.Revision{}, err
 	}
-	if len(snapVss) > 0 {
-		return snapVss, snapRev, nil
+	if len(snapVsKeys) > 0 {
+		return snapVsKeys, snapRev, nil
 	}
 	return nil, s.w.Manifest().AllowedSnapRevision(snapName), nil
 }
@@ -538,7 +538,7 @@ func (s *imageSeeder) downloadSnaps(snapsToDownload []*seedwriter.SeedSnap, curS
 	}
 	snapToDownloadOptions := make([]tooling.SnapToDownload, len(snapsToDownload))
 	for i, sn := range snapsToDownload {
-		vss, rev, err := s.validationSetsAndRevisionForSnap(sn.SnapName())
+		vss, rev, err := s.validationSetKeysAndRevisionForSnap(sn.SnapName())
 		if err != nil {
 			return nil, err
 		}

--- a/image/image_linux.go
+++ b/image/image_linux.go
@@ -495,6 +495,16 @@ func (s *imageSeeder) validationSetsAndRevisionForSnap(snapName string) ([]snapa
 		}
 	}
 
+	// Just for a good measure, perform a conflict check once we have the
+	// list of all validation-sets for the image seed.
+	if err := allVss.Conflict(); err != nil {
+		return nil, snap.Revision{}, err
+	}
+
+	// TODO: It's pointed out that here and some of the others uses of this
+	// may miss logic for optional snaps which have required revisions. This
+	// is not covered by the below check, and we may or may not have multiple places
+	// with a similar issue.
 	snapVss, snapRev, err := allVss.CheckPresenceRequired(naming.Snap(snapName))
 	if err != nil {
 		return nil, snap.Revision{}, err

--- a/image/image_linux.go
+++ b/image/image_linux.go
@@ -48,6 +48,7 @@ import (
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/seed/seedwriter"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/naming"
 	"github.com/snapcore/snapd/snap/snapfile"
 	"github.com/snapcore/snapd/snap/squashfs"
 	"github.com/snapcore/snapd/sysconfig"
@@ -481,28 +482,40 @@ func (s *imageSeeder) deriveInfoForLocalSnaps(f seedwriter.SeedAssertionFetcher,
 	return snaps, s.w.InfoDerived()
 }
 
-func (s *imageSeeder) validationSetKeys() ([]snapasserts.ValidationSetKey, error) {
+func (s *imageSeeder) validationSetsAndRevisionForSnap(snapName string) ([]snapasserts.ValidationSetKey, snap.Revision, error) {
 	vsas, err := s.db.FindMany(asserts.ValidationSetType, nil)
 	if err != nil && !errors.Is(err, &asserts.NotFoundError{}) {
-		return nil, err
+		return nil, snap.Revision{}, err
 	}
 
-	var vsKeys []snapasserts.ValidationSetKey
+	allVss := snapasserts.NewValidationSets()
 	for _, a := range vsas {
-		vsa := a.(*asserts.ValidationSet)
-		vsKeys = append(vsKeys, snapasserts.NewValidationSetKey(vsa))
+		if err := allVss.Add(a.(*asserts.ValidationSet)); err != nil {
+			return nil, snap.Revision{}, err
+		}
 	}
-	return vsKeys, nil
+
+	snapVss, snapRev, err := allVss.CheckPresenceRequired(naming.Snap(snapName))
+	if err != nil {
+		return nil, snap.Revision{}, err
+	}
+	if len(snapVss) > 0 {
+		return snapVss, snapRev, nil
+	}
+	return nil, s.w.Manifest().AllowedSnapRevision(snapName), nil
 }
 
-func (s *imageSeeder) downloadSnaps(snapsToDownload []*seedwriter.SeedSnap, curSnaps []*tooling.CurrentSnap, vsKeys []snapasserts.ValidationSetKey) (downloadedSnaps map[string]*tooling.DownloadedSnap, err error) {
+func (s *imageSeeder) downloadSnaps(snapsToDownload []*seedwriter.SeedSnap, curSnaps []*tooling.CurrentSnap) (downloadedSnaps map[string]*tooling.DownloadedSnap, err error) {
 	byName := make(map[string]*seedwriter.SeedSnap, len(snapsToDownload))
 	beforeDownload := func(info *snap.Info) (string, error) {
 		sn := byName[info.SnapName()]
 		if sn == nil {
 			return "", fmt.Errorf("internal error: downloading unexpected snap %q", info.SnapName())
 		}
-		rev := s.w.Manifest().AllowedSnapRevision(sn.SnapName())
+		_, rev, err := s.validationSetsAndRevisionForSnap(sn.SnapName())
+		if err != nil {
+			return "", err
+		}
 		if rev.Unset() {
 			rev = info.Revision
 		}
@@ -517,11 +530,17 @@ func (s *imageSeeder) downloadSnaps(snapsToDownload []*seedwriter.SeedSnap, curS
 	}
 	snapToDownloadOptions := make([]tooling.SnapToDownload, len(snapsToDownload))
 	for i, sn := range snapsToDownload {
+		vss, rev, err := s.validationSetsAndRevisionForSnap(sn.SnapName())
+		if err != nil {
+			return nil, err
+		}
+
 		byName[sn.SnapName()] = sn
 		snapToDownloadOptions[i].Snap = sn
 		snapToDownloadOptions[i].Channel = sn.Channel
-		snapToDownloadOptions[i].Revision = s.w.Manifest().AllowedSnapRevision(sn.SnapName())
+		snapToDownloadOptions[i].Revision = rev
 		snapToDownloadOptions[i].CohortKey = s.wideCohortKey
+		snapToDownloadOptions[i].ValidationSets = vss
 	}
 
 	// sort the curSnaps slice for test consistency
@@ -531,7 +550,6 @@ func (s *imageSeeder) downloadSnaps(snapsToDownload []*seedwriter.SeedSnap, curS
 	downloadedSnaps, err = s.tsto.DownloadMany(snapToDownloadOptions, curSnaps, tooling.DownloadManyOptions{
 		BeforeDownloadFunc: beforeDownload,
 		EnforceValidation:  s.customizations.Validation == "enforce",
-		ValidationSets:     vsKeys,
 	})
 	if err != nil {
 		return nil, err
@@ -556,13 +574,6 @@ func localSnapsWithID(snaps localSnapRefs) []*tooling.CurrentSnap {
 }
 
 func (s *imageSeeder) downloadAllSnaps(localSnaps localSnapRefs, fetchAsserts seedwriter.AssertsFetchFunc) error {
-	// Get validation set keys from database, it will contain all
-	// resolved validation-sets needed for the seeded snaps (if any).
-	vsKeys, err := s.validationSetKeys()
-	if err != nil {
-		return err
-	}
-
 	curSnaps := localSnapsWithID(localSnaps)
 	for {
 		toDownload, err := s.w.SnapsToDownload()
@@ -570,7 +581,7 @@ func (s *imageSeeder) downloadAllSnaps(localSnaps localSnapRefs, fetchAsserts se
 			return err
 		}
 
-		downloadedSnaps, err := s.downloadSnaps(toDownload, curSnaps, vsKeys)
+		downloadedSnaps, err := s.downloadSnaps(toDownload, curSnaps)
 		if err != nil {
 			return err
 		}
@@ -731,6 +742,14 @@ func (s *imageSeeder) finish() error {
 	// print warnings on unasserted snaps
 	if err := s.warnOnUnassertedSnaps(); err != nil {
 		return err
+	}
+
+	// run validation-set checks, this is also done by store but
+	// we double-check for the seed.
+	if s.customizations.Validation != "ignore" {
+		if err := s.w.CheckValidationSets(); err != nil {
+			return err
+		}
 	}
 
 	copySnap := func(name, src, dst string) error {

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -4313,7 +4313,7 @@ func (s *imageSuite) TestLocalSnapRevisionMatchingStoreRevision(c *C) {
 	})
 }
 
-func (s *imageSuite) setupValidationSets(c *C) *asserts.ValidationSet {
+func (s *imageSuite) setupValidationSets(c *C, snaps []interface{}) *asserts.ValidationSet {
 	vs, err := s.StoreSigning.Sign(asserts.ValidationSetType, map[string]interface{}{
 		"type":         "validation-set",
 		"authority-id": "canonical",
@@ -4321,26 +4321,171 @@ func (s *imageSuite) setupValidationSets(c *C) *asserts.ValidationSet {
 		"account-id":   "canonical",
 		"name":         "base-set",
 		"sequence":     "1",
-		"snaps": []interface{}{
-			map[string]interface{}{
-				"name":     "pc-kernel",
-				"id":       s.AssertedSnapID("pc-kernel"),
-				"presence": "required",
-				"revision": "1",
-			},
-			map[string]interface{}{
-				"name":     "pc",
-				"id":       s.AssertedSnapID("pc"),
-				"presence": "required",
-				"revision": "1",
-			},
-		},
-		"timestamp": time.Now().UTC().Format(time.RFC3339),
+		"snaps":        snaps,
+		"timestamp":    time.Now().UTC().Format(time.RFC3339),
 	}, nil, "")
 	c.Assert(err, IsNil)
 	err = s.StoreSigning.Add(vs)
 	c.Check(err, IsNil)
 	return vs.(*asserts.ValidationSet)
+}
+
+func (s *imageSuite) TestSetupSeedValidationSetsUnmetCriteria(c *C) {
+	restore := image.MockTrusted(s.StoreSigning.Trusted)
+	defer restore()
+
+	// a model that uses validation-sets
+	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+		"display-name":   "my display name",
+		"architecture":   "amd64",
+		"gadget":         "pc",
+		"kernel":         "pc-kernel",
+		"required-snaps": []interface{}{"required-snap1"},
+		"validation-sets": []interface{}{
+			map[string]interface{}{
+				"account-id": "canonical",
+				"name":       "base-set",
+				"mode":       "enforce",
+			},
+		},
+	})
+
+	// setup validation-sets that will fail the check
+	vsa := s.setupValidationSets(c, []interface{}{
+		map[string]interface{}{
+			"name":     "pc-kernel",
+			"id":       s.AssertedSnapID("pc-kernel"),
+			"presence": "required",
+			"revision": "6",
+		},
+	})
+
+	rootdir := filepath.Join(c.MkDir(), "image")
+	s.setupSnaps(c, map[string]string{
+		"pc":        "canonical",
+		"pc-kernel": "my-brand",
+	}, "")
+
+	opts := &image.Options{
+		Snaps: []string{
+			s.AssertedSnap("core"),
+		},
+		PrepareDir: filepath.Dir(rootdir),
+		Customizations: image.Customizations{
+			Validation: "enforce",
+		},
+	}
+
+	err := image.SetupSeed(s.tsto, model, opts)
+	c.Assert(err.Error(), testutil.Contains, `pc-kernel (required at revision 6 by sets canonical/base-set)`)
+
+	// ensure download actions were invoked with the validation-sets
+	// described in the model.
+	c.Check(s.storeActionsBunchSizes, DeepEquals, []int{3})
+	c.Check(s.storeActions[0], DeepEquals, &store.SnapAction{
+		Action:       "download",
+		InstanceName: "pc-kernel",
+		// For pc snap we must have both correct revision (6) and
+		// the validation-set applied
+		Revision: snap.R(6),
+		Flags:    store.SnapActionEnforceValidation,
+		ValidationSets: []snapasserts.ValidationSetKey{
+			snapasserts.NewValidationSetKey(vsa),
+		},
+	})
+	c.Check(s.storeActions[1], DeepEquals, &store.SnapAction{
+		Action:       "download",
+		InstanceName: "pc",
+		Channel:      stableChannel,
+		Flags:        store.SnapActionEnforceValidation,
+		// Empty validation-sets for this one as no validation-set applies here
+	})
+	c.Check(s.storeActions[2], DeepEquals, &store.SnapAction{
+		Action:       "download",
+		InstanceName: "required-snap1",
+		Channel:      stableChannel,
+		Flags:        store.SnapActionEnforceValidation,
+		// Empty validation-sets for this one as no validation-set applies here
+	})
+}
+
+func (s *imageSuite) TestSetupSeedValidationSetsUnmetCriteriaButIgnoredValidation(c *C) {
+	restore := image.MockTrusted(s.StoreSigning.Trusted)
+	defer restore()
+
+	// a model that uses validation-sets
+	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
+		"display-name":   "my display name",
+		"architecture":   "amd64",
+		"gadget":         "pc",
+		"kernel":         "pc-kernel",
+		"required-snaps": []interface{}{"required-snap1"},
+		"validation-sets": []interface{}{
+			map[string]interface{}{
+				"account-id": "canonical",
+				"name":       "base-set",
+				"mode":       "enforce",
+			},
+		},
+	})
+
+	// setup validation-sets that will fail the check
+	vsa := s.setupValidationSets(c, []interface{}{
+		map[string]interface{}{
+			"name":     "pc-kernel",
+			"id":       s.AssertedSnapID("pc-kernel"),
+			"presence": "required",
+			"revision": "6",
+		},
+	})
+
+	rootdir := filepath.Join(c.MkDir(), "image")
+	s.setupSnaps(c, map[string]string{
+		"pc":        "canonical",
+		"pc-kernel": "my-brand",
+	}, "")
+
+	opts := &image.Options{
+		Snaps: []string{
+			s.AssertedSnap("core"),
+		},
+		PrepareDir: filepath.Dir(rootdir),
+		Customizations: image.Customizations{
+			Validation: "ignore",
+		},
+	}
+
+	err := image.SetupSeed(s.tsto, model, opts)
+	c.Assert(err, IsNil)
+
+	// ensure download actions were invoked with the validation-sets
+	// described in the model.
+	c.Check(s.storeActionsBunchSizes, DeepEquals, []int{3})
+	c.Check(s.storeActions[0], DeepEquals, &store.SnapAction{
+		Action:       "download",
+		InstanceName: "pc-kernel",
+		// For pc snap we must have both correct revision (6) and
+		// the validation-set applied
+		Revision: snap.R(6),
+		Flags:    store.SnapActionIgnoreValidation,
+		ValidationSets: []snapasserts.ValidationSetKey{
+			snapasserts.NewValidationSetKey(vsa),
+		},
+	})
+	c.Check(s.storeActions[1], DeepEquals, &store.SnapAction{
+		Action:       "download",
+		InstanceName: "pc",
+		Channel:      stableChannel,
+		Flags:        store.SnapActionIgnoreValidation,
+		// Empty validation-sets for this one as no validation-set applies here
+	})
+	c.Check(s.storeActions[2], DeepEquals, &store.SnapAction{
+		Action:       "download",
+		InstanceName: "required-snap1",
+		Channel:      stableChannel,
+		Flags:        store.SnapActionIgnoreValidation,
+		// Empty validation-sets for this one as no validation-set applies here
+	})
 }
 
 func (s *imageSuite) TestDownloadSnapsModelValidationSets(c *C) {
@@ -4364,7 +4509,20 @@ func (s *imageSuite) TestDownloadSnapsModelValidationSets(c *C) {
 	})
 
 	// setup validation-sets
-	vsa := s.setupValidationSets(c)
+	vsa := s.setupValidationSets(c, []interface{}{
+		map[string]interface{}{
+			"name":     "pc-kernel",
+			"id":       s.AssertedSnapID("pc-kernel"),
+			"presence": "required",
+			"revision": "1",
+		},
+		map[string]interface{}{
+			"name":     "pc",
+			"id":       s.AssertedSnapID("pc"),
+			"presence": "required",
+			"revision": "1",
+		},
+	})
 
 	rootdir := filepath.Join(c.MkDir(), "image")
 	s.setupSnaps(c, map[string]string{
@@ -4391,8 +4549,10 @@ func (s *imageSuite) TestDownloadSnapsModelValidationSets(c *C) {
 	c.Check(s.storeActions[0], DeepEquals, &store.SnapAction{
 		Action:       "download",
 		InstanceName: "pc-kernel",
-		Channel:      stableChannel,
-		Flags:        store.SnapActionEnforceValidation,
+		// For pc snap we must have both correct revision (1) and
+		// the validation-set applied
+		Revision: snap.R(1),
+		Flags:    store.SnapActionEnforceValidation,
 		ValidationSets: []snapasserts.ValidationSetKey{
 			snapasserts.NewValidationSetKey(vsa),
 		},
@@ -4400,8 +4560,10 @@ func (s *imageSuite) TestDownloadSnapsModelValidationSets(c *C) {
 	c.Check(s.storeActions[1], DeepEquals, &store.SnapAction{
 		Action:       "download",
 		InstanceName: "pc",
-		Channel:      stableChannel,
-		Flags:        store.SnapActionEnforceValidation,
+		// For pc snap we must have both correct revision (1) and
+		// the validation-set applied
+		Revision: snap.R(1),
+		Flags:    store.SnapActionEnforceValidation,
 		ValidationSets: []snapasserts.ValidationSetKey{
 			snapasserts.NewValidationSetKey(vsa),
 		},
@@ -4411,9 +4573,7 @@ func (s *imageSuite) TestDownloadSnapsModelValidationSets(c *C) {
 		InstanceName: "required-snap1",
 		Channel:      stableChannel,
 		Flags:        store.SnapActionEnforceValidation,
-		ValidationSets: []snapasserts.ValidationSetKey{
-			snapasserts.NewValidationSetKey(vsa),
-		},
+		// Empty validation-sets for this one as no validation-set applies here
 	})
 }
 
@@ -4438,7 +4598,20 @@ func (s *imageSuite) TestDownloadSnapsManifestValidationSets(c *C) {
 	})
 
 	// setup validation-sets
-	vsa := s.setupValidationSets(c)
+	vsa := s.setupValidationSets(c, []interface{}{
+		map[string]interface{}{
+			"name":     "pc-kernel",
+			"id":       s.AssertedSnapID("pc-kernel"),
+			"presence": "required",
+			"revision": "1",
+		},
+		map[string]interface{}{
+			"name":     "pc",
+			"id":       s.AssertedSnapID("pc"),
+			"presence": "required",
+			"revision": "1",
+		},
+	})
 
 	rootDir := c.MkDir()
 	imageDir := filepath.Join(rootDir, "image")
@@ -4484,8 +4657,10 @@ func (s *imageSuite) TestDownloadSnapsManifestValidationSets(c *C) {
 	c.Check(s.storeActions[0], DeepEquals, &store.SnapAction{
 		Action:       "download",
 		InstanceName: "pc-kernel",
-		Channel:      stableChannel,
-		Flags:        store.SnapActionEnforceValidation,
+		// For pc-kernel snap we must have both correct revision (1) and
+		// the validation-set applied
+		Revision: snap.R(1),
+		Flags:    store.SnapActionEnforceValidation,
 		ValidationSets: []snapasserts.ValidationSetKey{
 			snapasserts.NewValidationSetKey(vsa),
 		},
@@ -4493,8 +4668,10 @@ func (s *imageSuite) TestDownloadSnapsManifestValidationSets(c *C) {
 	c.Check(s.storeActions[1], DeepEquals, &store.SnapAction{
 		Action:       "download",
 		InstanceName: "pc",
-		Channel:      stableChannel,
-		Flags:        store.SnapActionEnforceValidation,
+		// For pc snap we must have both correct revision (1) and
+		// the validation-set applied
+		Revision: snap.R(1),
+		Flags:    store.SnapActionEnforceValidation,
 		ValidationSets: []snapasserts.ValidationSetKey{
 			snapasserts.NewValidationSetKey(vsa),
 		},
@@ -4504,9 +4681,7 @@ func (s *imageSuite) TestDownloadSnapsManifestValidationSets(c *C) {
 		InstanceName: "required-snap1",
 		Channel:      stableChannel,
 		Flags:        store.SnapActionEnforceValidation,
-		ValidationSets: []snapasserts.ValidationSetKey{
-			snapasserts.NewValidationSetKey(vsa),
-		},
+		// Empty validation-sets for this one as no validation-set applies here
 	})
 }
 

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -4514,7 +4514,8 @@ func (s *imageSuite) TestDownloadSnapsModelValidationSets(c *C) {
 			"name":     "pc-kernel",
 			"id":       s.AssertedSnapID("pc-kernel"),
 			"presence": "required",
-			"revision": "1",
+			// setupSnaps sets pc-kernel to snap.R(2)
+			"revision": "2",
 		},
 		map[string]interface{}{
 			"name":     "pc",
@@ -4549,9 +4550,9 @@ func (s *imageSuite) TestDownloadSnapsModelValidationSets(c *C) {
 	c.Check(s.storeActions[0], DeepEquals, &store.SnapAction{
 		Action:       "download",
 		InstanceName: "pc-kernel",
-		// For pc snap we must have both correct revision (1) and
+		// For pc snap we must have both correct revision (2) and
 		// the validation-set applied
-		Revision: snap.R(1),
+		Revision: snap.R(2),
 		Flags:    store.SnapActionEnforceValidation,
 		ValidationSets: []snapasserts.ValidationSetKey{
 			snapasserts.NewValidationSetKey(vsa),
@@ -4603,7 +4604,8 @@ func (s *imageSuite) TestDownloadSnapsManifestValidationSets(c *C) {
 			"name":     "pc-kernel",
 			"id":       s.AssertedSnapID("pc-kernel"),
 			"presence": "required",
-			"revision": "1",
+			// setupSnaps sets pc-kernel to snap.R(2)
+			"revision": "2",
 		},
 		map[string]interface{}{
 			"name":     "pc",
@@ -4659,7 +4661,7 @@ func (s *imageSuite) TestDownloadSnapsManifestValidationSets(c *C) {
 		InstanceName: "pc-kernel",
 		// For pc-kernel snap we must have both correct revision (1) and
 		// the validation-set applied
-		Revision: snap.R(1),
+		Revision: snap.R(2),
 		Flags:    store.SnapActionEnforceValidation,
 		ValidationSets: []snapasserts.ValidationSetKey{
 			snapasserts.NewValidationSetKey(vsa),

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -4659,7 +4659,7 @@ func (s *imageSuite) TestDownloadSnapsManifestValidationSets(c *C) {
 	c.Check(s.storeActions[0], DeepEquals, &store.SnapAction{
 		Action:       "download",
 		InstanceName: "pc-kernel",
-		// For pc-kernel snap we must have both correct revision (1) and
+		// For pc-kernel snap we must have both correct revision (2) and
 		// the validation-set applied
 		Revision: snap.R(2),
 		Flags:    store.SnapActionEnforceValidation,

--- a/store/tooling/tooling.go
+++ b/store/tooling/tooling.go
@@ -273,6 +273,8 @@ type SnapToDownload struct {
 	Channel   string
 	Revision  snap.Revision
 	CohortKey string
+	// ValidationSets is an optional array of validation set primary keys.
+	ValidationSets []snapasserts.ValidationSetKey
 }
 
 type CurrentSnap struct {
@@ -286,8 +288,6 @@ type CurrentSnap struct {
 type DownloadManyOptions struct {
 	BeforeDownloadFunc func(*snap.Info) (targetPath string, err error)
 	EnforceValidation  bool
-	// ValidationSets is an optional array of validation set primary keys.
-	ValidationSets []snapasserts.ValidationSetKey
 }
 
 // DownloadMany downloads the specified snaps.
@@ -323,7 +323,6 @@ func (tsto *ToolingStore) DownloadMany(toDownload []SnapToDownload, curSnaps []*
 			TrackingChannel:  ch,
 			Epoch:            csnap.Epoch,
 			IgnoreValidation: !opts.EnforceValidation,
-			ValidationSets:   opts.ValidationSets,
 		})
 	}
 
@@ -343,7 +342,7 @@ func (tsto *ToolingStore) DownloadMany(toDownload []SnapToDownload, curSnaps []*
 			Revision:       sn.Revision,
 			CohortKey:      sn.CohortKey,
 			Flags:          actionFlag,
-			ValidationSets: opts.ValidationSets,
+			ValidationSets: sn.ValidationSets,
 		})
 	}
 


### PR DESCRIPTION
Fix how validation-sets and required revision was set for snaps that were controlled by validation-sets. Mirror how it's done for the snap validate --refresh. I missed in the first iteration that it needed to be done on a per-snap basis, and I also missed that the required revision for the snap should also be sent.

This was discovered while creating the spread test.