### PR TITLE
tests: make sure there is not neither stopping nor abandoned user sessions

### DIFF
--- a/tests/lib/tools/tests.session
+++ b/tests/lib/tools/tests.session
@@ -181,6 +181,9 @@ main() {
 				umount -l /var/lib/systemd
 			fi
 
+			# Make sure there is not neither stopping nor abandoned user sessions
+			systemctl restart systemd-logind.service
+
 			exit 0
 			;;
 		dump)

--- a/tests/main/cgroup-tracking-failure/task.yaml
+++ b/tests/main/cgroup-tracking-failure/task.yaml
@@ -9,7 +9,6 @@ details: |
     transitions that the kernel normally does not allow.
 
 systems:
-    - ubuntu-14.04-*
     - ubuntu-16.04-*  # tracking works correctly, caveats apply
     - ubuntu-18.04-*
     - ubuntu-2*       # tracking works correctly, for completeness


### PR DESCRIPTION
This is to avoid abandoned user sessions in systemd v253
