### PR TITLE
early_test.go: correct typo, "services.ssh..." -> "service.ssh..."

### DIFF
--- a/overlord/configstate/configcore/early_test.go
+++ b/overlord/configstate/configcore/early_test.go
@@ -38,7 +38,7 @@ func (s *earlySuite) TestEarly(c *C) {
 	patch := map[string]interface{}{
 		"experimental.parallel-instances": true,
 		"experimental.user-daemons":       true,
-		"services.ssh.disable":            true,
+		"service.ssh.disable":             true,
 	}
 	tr := &mockConf{state: s.state}
 	err := configcore.Early(coreDev, tr, patch)


### PR DESCRIPTION
The correct name for the system config setting is "service", not "services".
