### PR TITLE
interfaces/apparmor: address feedback from @mvo5 in #12543

### DIFF
--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -539,10 +539,16 @@ func RemoveAllSnapAppArmorProfiles() error {
 	cache := apparmor_sandbox.CacheDir
 	_, removed, errEnsure := osutil.EnsureDirStateGlobs(dir, globs, nil)
 	errRemoveCached := removeCachedProfiles(removed, cache)
-	if errEnsure != nil {
+	switch {
+	case errEnsure != nil && errRemoveCached != nil:
+		return fmt.Errorf("cannot remove apparmor profiles: %s (and also %s)", errEnsure, errRemoveCached)
+	case errEnsure != nil:
 		return fmt.Errorf("cannot remove apparmor profiles: %s", errEnsure)
+	case errRemoveCached != nil:
+		return errRemoveCached
+	default:
+		return nil
 	}
-	return errRemoveCached
 }
 
 // Remove removes the apparmor profiles of a given snap from disk and the cache.

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -2498,6 +2498,7 @@ func (s *backendSuite) TestRemoveAllSnapAppArmorProfiles(c *C) {
 		c.Check(os.IsNotExist(err), Equals, true)
 	}
 
+	// remove snaps to restore the test environment back to the original state
 	s.RemoveSnap(c, snapInfo2)
 	s.RemoveSnap(c, snapInfo1)
 }

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -2479,7 +2479,10 @@ func (s *backendSuite) TestRemoveAllSnapAppArmorProfiles(c *C) {
 
 	opts := interfaces.ConfinementOptions{}
 	snapInfo1 := s.InstallSnap(c, opts, "", ifacetest.SambaYamlV1, 1)
+	s.AddCleanup(func() { s.RemoveSnap(c, snapInfo1) })
 	snapInfo2 := s.InstallSnap(c, opts, "", ifacetest.SomeSnapYamlV1, 1)
+	s.AddCleanup(func() { s.RemoveSnap(c, snapInfo2) })
+
 	snap1nsProfile := filepath.Join(dirs.SnapAppArmorDir, "snap-update-ns.samba")
 	snap1AAprofile := filepath.Join(dirs.SnapAppArmorDir, "snap.samba.smbd")
 	snap2nsProfile := filepath.Join(dirs.SnapAppArmorDir, "snap-update-ns.some-snap")
@@ -2497,8 +2500,4 @@ func (s *backendSuite) TestRemoveAllSnapAppArmorProfiles(c *C) {
 		_, err := os.Stat(p)
 		c.Check(os.IsNotExist(err), Equals, true)
 	}
-
-	// remove snaps to restore the test environment back to the original state
-	s.RemoveSnap(c, snapInfo2)
-	s.RemoveSnap(c, snapInfo1)
 }

--- a/overlord/snapstate/backend/apparmor.go
+++ b/overlord/snapstate/backend/apparmor.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2017 Canonical Ltd
+ * Copyright (C) 2023 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as


### PR DESCRIPTION
Rewrite the code in RemoveAllSnapAppArmorProfiles() to be more readable and to
allow to surface more errors, plus add a comment to clarify the backend test and
update a copyright date. Original review was given in:

https://github.com/snapcore/snapd/pull/12543#pullrequestreview-1394183004

Signed-off-by: Alex Murray <alex.murray@canonical.com>
