### PR TITLE
tests: retry the notification matching in racy check

### DIFF
--- a/tests/main/auto-refresh-pre-download/task.yaml
+++ b/tests/main/auto-refresh-pre-download/task.yaml
@@ -79,12 +79,12 @@ execute: |
   fi
 
   if os.query is-ubuntu && os.query is-classic; then
+    # check that the pre-download notified the user to close the snap
+    retry -n 20 MATCH 'string "Pending update of "test-snapd-sh" snap"' < /home/test/notif.log
+    MATCH 'string "Close the app to update now \(.* days left\)"' < /home/test/notif.log
+
     # stop all the dbus monitoring related processes
     systemctl kill user-12345.slice 2>/dev/null || true
-
-    # check that the pre-download notified the user to close the snap
-    MATCH 'string "Pending update of "test-snapd-sh" snap"' < /home/test/notif.log
-    MATCH 'string "Close the app to update now \(.* days left\)"' < /home/test/notif.log
   fi
 
   OLD_CHANGE=$(snap changes | tail -n 2 | head -n 1 | awk '{print $1}')


### PR DESCRIPTION
I've seen some test failures of `tests/main/auto-refresh-pre-download` on the notification checks. I suspect it's a timing issue because there's a race condition between the notification and the task finishing (since the notification happens on a different thread). So this PR adds some retrying.

```
+ MATCH 'string "Pending update of "test-snapd-sh" snap"'
grep error: pattern not found, got:
signal time=1682252401.117375 sender=org.freedesktop.DBus -> destination=:1.1 serial=2 path=/org/freedesktop/DBus; interface=org.freedesktop.DBus; member=NameAcquired
   string ":1.1"
signal time=1682252401.117438 sender=org.freedesktop.DBus -> destination=:1.1 serial=4 path=/org/freedesktop/DBus; interface=org.freedesktop.DBus; member=NameLost
   string ":1.1"
```