### PR TITLE
gadget: warn instead of returning error if overlapping with GPT header

### DIFF
--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -986,7 +986,7 @@ func validateVolume(vol *Volume) error {
 			start := *s.Offset
 			end := start + quantity.Offset(s.Size)
 			if start < 512*34 && end > 4096 {
-				return fmt.Errorf("invalid structure: GPT header or GPT partition table overlapped with structure %q\n", s.Name)
+				logger.Noticef("WARNING: invalid structure: GPT header or GPT partition table overlapped with structure %q\n", s.Name)
 			} else if start < 4096*6 && end > 512 {
 				logger.Noticef("WARNING: GPT header or GPT partition table might be overlapped with structure %q", s.Name)
 			}

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -1349,17 +1349,16 @@ func (s *gadgetYamlTestSuite) TestValidateVolumeSchemaNotOverlapWithGPT(c *C) {
 				{Name: "name", Type: "bare", Size: tc.sz, Offset: &tc.o},
 			},
 		})
-		if tc.err != "" {
-			c.Check(err, ErrorMatches, tc.err)
-		} else {
-			c.Check(err, IsNil)
+		c.Check(err, IsNil)
 
-			start := tc.o
-			end := start + quantity.Offset(tc.sz)
-			if start < 4096*34 && end > 512 {
-				c.Assert(loggerBuf.String(), testutil.Contains,
-					fmt.Sprintf("WARNING: GPT header or GPT partition table might be overlapped with structure \"name\""))
-			}
+		start := tc.o
+		end := start + quantity.Offset(tc.sz)
+		if start < 512*34 && end > 4096 {
+			c.Assert(loggerBuf.String(), testutil.Contains,
+				fmt.Sprintf("WARNING: invalid structure: GPT header or GPT partition table overlapped with structure \"name\""))
+		} else if start < 4096*6 && end > 512 {
+			c.Assert(loggerBuf.String(), testutil.Contains,
+				fmt.Sprintf("WARNING: GPT header or GPT partition table might be overlapped with structure \"name\""))
 		}
 	}
 }


### PR DESCRIPTION
Warn instead of returning error if a structure overlaps with the GPT header. The previous check was introduced by [1], but unfortunately there are legacy gadgets that rely on the old behavior.

[1] https://github.com/snapcore/snapd/pull/12454/files
