### PR TITLE
tests: increate the watchdog-timeout to 5 seconds to avoid failed service

### DIFF
--- a/tests/main/services-watchdog/task.yaml
+++ b/tests/main/services-watchdog/task.yaml
@@ -10,7 +10,7 @@ debug: |
     done
 
 execute: |
-    echo "When the service snap  is installed"
+    echo "When the service snap is installed"
     "$TESTSTOOLS"/snaps-state install-local test-snapd-service-watchdog
 
     # the interface is disconnected by default

--- a/tests/main/services-watchdog/test-snapd-service-watchdog/meta/snap.yaml
+++ b/tests/main/services-watchdog/test-snapd-service-watchdog/meta/snap.yaml
@@ -4,7 +4,7 @@ apps:
   direct-watchdog-ok:
     command: bin/direct
     daemon: simple
-    watchdog-timeout: 2s
+    watchdog-timeout: 5s
     restart-condition: never
     plugs: [daemon-notify]
   direct-watchdog-bad:


### PR DESCRIPTION

It happens that in some rpi devices the 2s timeout is not enough and the service is failing like this:

snap.test-snapd-service-watchdog.direct-watchdog-ok.service × snap.test-snapd-service-watchdog.direct-watchdog-ok.service - Service for snap application test-snapd-service-watchdog.direct-watchdog-ok Loaded: loaded
(/etc/systemd/system/snap.test-snapd-service-watchdog.direct-watchdog-ok.service; enabled; vendor preset: enabled)
Active: failed (Result: watchdog) since Tue 2023-04-25 17:23:14 UTC; 2min 14s ago
Process: 6221 ExecStart=/usr/bin/snap run
test-snapd-service-watchdog.direct-watchdog-ok (code=killed, signal=ABRT)
   Main PID: 6221 (code=killed, signal=ABRT)
        CPU: 1.549s

Apr 25 17:23:12 ubuntu systemd[1]: Started Service for snap application test-snapd-service-watchdog.direct-watchdog-ok.
Apr 25 17:23:14 ubuntu systemd[1]:
snap.test-snapd-service-watchdog.direct-watchdog-ok.service: Watchdog timeout (limit 2s)!
Apr 25 17:23:14 ubuntu systemd[1]:
snap.test-snapd-service-watchdog.direct-watchdog-ok.service: Killing process 6221 (snap-exec) with signal SIGABRT.
Apr 25 17:23:14 ubuntu systemd[1]:
snap.test-snapd-service-watchdog.direct-watchdog-ok.service: Main process exited, code=killed, status=6/ABRT
Apr 25 17:23:14 ubuntu systemd[1]:
snap.test-snapd-service-watchdog.direct-watchdog-ok.service: Failed with result 'watchdog'.
Apr 25 17:23:14 ubuntu systemd[1]:
snap.test-snapd-service-watchdog.direct-watchdog-ok.service: Consumed 1.549s CPU time.

external:ubuntu-core-22-arm-32 .../tests/main/services-watchdog# systemctl show -p SubState
snap.test-snapd-service-watchdog.direct-watchdog-ok.service SubState=failed

