### PR TITLE
seed/seedwriter: produce validation-sets in the manifest

### DIFF
--- a/seed/seedwriter/writer.go
+++ b/seed/seedwriter/writer.go
@@ -1441,7 +1441,7 @@ func (w *Writer) WriteMeta() error {
 	}
 
 	if w.opts.ManifestPath != "" {
-		// Mark validation sets seeded in the manifest if we the options
+		// Mark validation sets seeded in the manifest if the options
 		// are set to produce a manifest.
 		if err := w.markValidationSetsSeeded(); err != nil {
 			return err

--- a/seed/seedwriter/writer.go
+++ b/seed/seedwriter/writer.go
@@ -1423,6 +1423,17 @@ func (w *Writer) SeedSnaps(copySnap func(name, src, dst string) error) error {
 	return nil
 }
 
+func (w *Writer) markValidationSetsSeeded() error {
+	vsm, err := w.validationSetAsserts()
+	if err != nil {
+		return err
+	}
+	for seq, vs := range vsm {
+		w.manifest.MarkValidationSetSeeded(vs, seq.Pinned)
+	}
+	return nil
+}
+
 // WriteMeta writes seed metadata and assertions into the seed.
 func (w *Writer) WriteMeta() error {
 	if err := w.checkStep(writeMetaStep); err != nil {
@@ -1430,6 +1441,11 @@ func (w *Writer) WriteMeta() error {
 	}
 
 	if w.opts.ManifestPath != "" {
+		// Mark validation sets seeded in the manifest if we the options
+		// are set to produce a manifest.
+		if err := w.markValidationSetsSeeded(); err != nil {
+			return err
+		}
 		if err := w.manifest.Write(w.opts.ManifestPath); err != nil {
 			return err
 		}

--- a/seed/seedwriter/writer.go
+++ b/seed/seedwriter/writer.go
@@ -1429,7 +1429,9 @@ func (w *Writer) markValidationSetsSeeded() error {
 		return err
 	}
 	for seq, vs := range vsm {
-		w.manifest.MarkValidationSetSeeded(vs, seq.Pinned)
+		if err := w.manifest.MarkValidationSetSeeded(vs, seq.Pinned); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/seed/seedwriter/writer_test.go
+++ b/seed/seedwriter/writer_test.go
@@ -4590,4 +4590,15 @@ series: 16
 account-id: canonical
 name: base-set
 sequence: 1`)
+
+	// verify that the manifest was correctly produced, now that
+	// the manifest is tracking validation-sets, then we should not
+	// see pc/pc-kernel in the manifest, instead it should just show
+	// the validation-set tracking those.
+	m, err := ioutil.ReadFile(s.opts.ManifestPath)
+	c.Assert(err, IsNil)
+	c.Check(string(m), Equals, `canonical/base-set 1
+core20 1
+snapd 1
+`)
 }


### PR DESCRIPTION
Mark validation-sets seeded when producing the seed manifest. After adding manifest checks to the spread test I discovered this was missing from one of my earlier closed PRs