### PR TITLE
overlord,wrappers: restart always enabled units

### DIFF
--- a/overlord/servicestate/quota_handlers.go
+++ b/overlord/servicestate/quota_handlers.go
@@ -218,9 +218,10 @@ func addRestartServicesTasks(st *state.State, queueTask func(task *state.Task), 
 	for _, info := range sortedInfos {
 		restartTask := st.NewTask("service-control", fmt.Sprintf("Restarting services for snap %q", info.InstanceName()))
 		restartTask.Set("service-action", ServiceAction{
-			Action:   "restart",
-			SnapName: info.InstanceName(),
-			Services: getServiceNames(servicesAffected[info]),
+			Action:                  "restart",
+			SnapName:                info.InstanceName(),
+			Services:                getServiceNames(servicesAffected[info]),
+			RestartEnabledNonActive: false,
 		})
 		queueTask(restartTask)
 	}
@@ -844,7 +845,9 @@ func restartSnapServices(st *state.State, appsToRestartBySnap map[*snap.Info][]*
 			return err
 		}
 
-		err = wrappers.RestartServices(startupOrdered, nil, nil, progress.Null, &timings.Timings{})
+		err = wrappers.RestartServices(startupOrdered, nil,
+			&wrappers.RestartServicesFlags{Reload: false},
+			progress.Null, &timings.Timings{})
 		if err != nil {
 			return err
 		}

--- a/overlord/servicestate/service_control_test.go
+++ b/overlord/servicestate/service_control_test.go
@@ -821,6 +821,119 @@ func (s *serviceControlSuite) TestRestartServices(c *C) {
 	})
 }
 
+func (s *serviceControlSuite) TestRestartOnlyActiveServices(c *C) {
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	s.mockTestSnap(c)
+
+	srvFoo := "snap.test-snap.foo.service"
+	srvBar := "snap.test-snap.bar.service"
+
+	systemctlRestorer := systemd.MockSystemctl(func(cmd ...string) (buf []byte, err error) {
+		states := map[string]systemdtest.ServiceState{
+			srvFoo: {ActiveState: "inactive", UnitFileState: "enabled"},
+			srvBar: {ActiveState: "active", UnitFileState: "enabled"},
+		}
+		if out := systemdtest.HandleMockAllUnitsActiveOutput(cmd, states); out != nil {
+			return out, nil
+		}
+
+		s.sysctlArgs = append(s.sysctlArgs, cmd)
+		if cmd[0] == "show" {
+			return []byte("ActiveState=inactive\n"), nil
+		}
+		return nil, nil
+	})
+	s.AddCleanup(systemctlRestorer)
+
+	chg := st.NewChange("service-control", "...")
+	t := st.NewTask("service-control", "...")
+	cmd := &servicestate.ServiceAction{
+		SnapName:                "test-snap",
+		Action:                  "restart",
+		Services:                []string{"foo", "bar"},
+		RestartEnabledNonActive: false,
+	}
+	t.Set("service-action", cmd)
+	chg.AddTask(t)
+
+	st.Unlock()
+	defer s.se.Stop()
+	err := s.o.Settle(5 * time.Second)
+	st.Lock()
+	c.Assert(err, IsNil)
+
+	c.Assert(t.Status(), Equals, state.DoneStatus)
+
+	expectedInvocations := [][]string{
+		{"stop", srvBar},
+		{"show", "--property=ActiveState", srvBar},
+		{"start", srvBar},
+	}
+	// We expect to get only bar restarted, as foo is inactive
+	c.Check(s.sysctlArgs, DeepEquals, expectedInvocations)
+}
+
+func (s *serviceControlSuite) TestRestartAllEnabledServices(c *C) {
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	s.mockTestSnap(c)
+
+	srvFoo := "snap.test-snap.foo.service"
+	srvBar := "snap.test-snap.bar.service"
+
+	systemctlRestorer := systemd.MockSystemctl(func(cmd ...string) (buf []byte, err error) {
+		states := map[string]systemdtest.ServiceState{
+			srvFoo: {ActiveState: "inactive", UnitFileState: "enabled"},
+			srvBar: {ActiveState: "active", UnitFileState: "enabled"},
+		}
+		if out := systemdtest.HandleMockAllUnitsActiveOutput(cmd, states); out != nil {
+			return out, nil
+		}
+
+		s.sysctlArgs = append(s.sysctlArgs, cmd)
+		if cmd[0] == "show" {
+			return []byte("ActiveState=inactive\n"), nil
+		}
+		return nil, nil
+	})
+	s.AddCleanup(systemctlRestorer)
+
+	chg := st.NewChange("service-control", "...")
+	t := st.NewTask("service-control", "...")
+	cmd := &servicestate.ServiceAction{
+		SnapName:                "test-snap",
+		Action:                  "restart",
+		Services:                []string{"foo", "bar"},
+		RestartEnabledNonActive: true,
+	}
+	t.Set("service-action", cmd)
+	chg.AddTask(t)
+
+	st.Unlock()
+	defer s.se.Stop()
+	err := s.o.Settle(5 * time.Second)
+	st.Lock()
+	c.Assert(err, IsNil)
+
+	c.Assert(t.Status(), Equals, state.DoneStatus)
+
+	expectedInvocations := [][]string{
+		{"stop", srvFoo},
+		{"show", "--property=ActiveState", srvFoo},
+		{"start", srvFoo},
+		{"stop", srvBar},
+		{"show", "--property=ActiveState", srvBar},
+		{"start", srvBar},
+	}
+	// We expect both foo and bar restarted
+	c.Check(s.sysctlArgs, DeepEquals, expectedInvocations)
+}
+
 func (s *serviceControlSuite) testRestartWithExplicitServicesCommon(c *C,
 	explicitServices []string, expectedInvocations [][]string) {
 	st := s.state

--- a/overlord/servicestate/servicestate.go
+++ b/overlord/servicestate/servicestate.go
@@ -114,6 +114,7 @@ func serviceControlTs(st *state.State, appInfos []*snap.AppInfo, inst *Instructi
 				cmd.ActionModifier = "disable"
 			}
 		case inst.Action == "restart":
+			cmd.RestartEnabledNonActive = true
 			if inst.Reload {
 				cmd.Action = "reload-or-restart"
 			} else {

--- a/tests/main/services-restart/task.yaml
+++ b/tests/main/services-restart/task.yaml
@@ -43,15 +43,13 @@ execute: |
     echo "Restarting services via restart"
     snap restart $EXTRA_FLAGS test-snapd-service-restart
 
-    echo "Check that services 1 and 2 are running"
-    for id in 1 2; do
+    echo "Check that services 1, 2 and 4 are running"
+    for id in 1 2 4; do
         systemctl status snap.test-snapd-service-restart.svc${id}.service | MATCH "running"
     done
 
-    echo "Check that services 3 and 4 are not running"
-    for id in 3 4; do
-        systemctl status snap.test-snapd-service-restart.svc${id}.service | MATCH "inactive"
-    done
+    echo "Check that service 3 is not running"
+    systemctl status snap.test-snapd-service-restart.svc3.service | MATCH "inactive"
 
     echo "Fetching execution timestamps after restart"
     for id in 1 2 3 4; do
@@ -60,14 +58,14 @@ execute: |
     done
 
     echo "Verify expectations in execution timestamps"
+    # When a service has been restarted, time after is later (=greater) than
+    # time before. Otherwise both times are equal.
     test "$TIMESTAMP1_AFTER" -gt "$TIMESTAMP1_BEFORE"
     test "$TIMESTAMP2_AFTER" -gt "$TIMESTAMP2_BEFORE"
     test "$TIMESTAMP3_AFTER" -eq "$TIMESTAMP3_BEFORE"
-    test "$TIMESTAMP4_AFTER" -eq "$TIMESTAMP4_BEFORE"
+    test "$TIMESTAMP4_AFTER" -gt "$TIMESTAMP4_BEFORE"
 
     # Now verify that services explicitly mentioned on the command line always
     # get restarted, regardless of their current state
-    for id in 3 4; do
-        snap restart $EXTRA_FLAGS test-snapd-service-restart.svc${id}
-        systemctl status snap.test-snapd-service-restart.svc${id}.service | MATCH "running"
-    done
+    snap restart $EXTRA_FLAGS test-snapd-service-restart.svc3
+    systemctl status snap.test-snapd-service-restart.svc3.service | MATCH "running"

--- a/tests/main/services-snapctl/task.yaml
+++ b/tests/main/services-snapctl/task.yaml
@@ -50,22 +50,10 @@ execute: |
     echo "It's stopped"
     _wait_for_service "test-snapd-service.test-snapd-service" " inactive"
 
-    echo "And then attempt restart"
-    snap set test-snapd-service service-option-source=foo command=restart
-
-    echo "It's still not running, since restart ignores stopped units"
-    _wait_for_service "test-snapd-service.test-snapd-service" " inactive"
-
-    echo "So we start it again"
-    snap set test-snapd-service command=start
-
-    echo "It's running"
-    _wait_for_service "test-snapd-service.test-snapd-service" " active"
-
     echo "And then restart"
     snap set test-snapd-service service-option-source=foo command=restart
 
-    echo "It's still running"
+    echo "It's running"
     _wait_for_service "test-snapd-service.test-snapd-service" " active"
 
     echo "And restart command was executed as part of configure hook change"


### PR DESCRIPTION
Due to a previous decision [1] we were not restarting any non-running
unit, this commit changes that back so non-running units are not
restarted only if the unit is also disabled. This way, stopping and
restarting works more similarly to how it is usually expected. Fixes
LP#2012630.

Merged in master by https://github.com/snapcore/snapd/pull/12670

[1] https://forum.snapcraft.io/t/command-line-interface-to-manipulate-services/262/46
