### PR TITLE
tests: add dependency needed in debian to run the sbuild tests

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -637,6 +637,7 @@ pkg_dependencies_ubuntu_classic(){
         debian-*)
             echo "
                 autopkgtest
+                cryptsetup-bin
                 debootstrap
                 eatmydata
                 evolution-data-server


### PR DESCRIPTION
Install dependencies to make sure veritysetup is installed in debian. Currently the unit tests are failing with the following error:

cmd_pack_test.go:148:
    c.Assert(err, check.IsNil)
... value *xerrors.wrapError = cannot pack
"/tmp/check-7666987206516866937/651": exec: "veritysetup": executable file not found in $PATH ("cannot pack
\"/tmp/check-7666987206516866937/651\": exec: \"veritysetup\": executable file not found in $PATH")

