### PR TITLE
many: implement workaround for veritysetup usage on older distros

### DIFF
--- a/cmd/snap/cmd_pack_test.go
+++ b/cmd/snap/cmd_pack_test.go
@@ -4,12 +4,14 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 
 	"gopkg.in/check.v1"
 
 	snaprun "github.com/snapcore/snapd/cmd/snap"
 	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/testutil"
 )
 
 const packSnapYaml = `name: hello
@@ -144,8 +146,29 @@ func (s *SnapSuite) TestPackPacksASnapWithCompressionUnhappy(c *check.C) {
 func (s *SnapSuite) TestPackPacksASnapWithIntegrityHappy(c *check.C) {
 	snapDir := makeSnapDirForPack(c, "name: hello\nversion: 1.0")
 
+	// mock the verity-setup command, what it does is make of a copy of the snap
+	// and then returns pre-calculated output
+	vscmd := testutil.MockCommand(c, "veritysetup", fmt.Sprintf(`
+cp %[1]s/hello_1.0_all.snap %[1]s/hello_1.0_all.snap.verity
+echo "VERITY header information for %[1]s/hello_1.0_all.snap.verity"
+echo "UUID:            	8f6dcdd2-9426-49d8-9879-a5c87fc78c15"
+echo "Hash type:       	1"
+echo "Data blocks:     	1"
+echo "Data block size: 	4096"
+echo "Hash block size: 	4096"
+echo "Hash algorithm:  	sha256"
+echo "Salt:            	06d01a87b298b6855b6a3a1b32450deba4550417cbec2bb21a38d6dda24a1b53"
+echo "Root hash:      	306398e250a950ea1cbfceda608ee4585f053323251b08b7ed3f004740e91ba5"
+`, snapDir))
+	defer vscmd.Restore()
+
 	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"pack", "--append-integrity-data", snapDir, snapDir})
 	c.Assert(err, check.IsNil)
+
+	snapOriginal := path.Join(snapDir, "hello_1.0_all.snap")
+	snapVerity := snapOriginal + ".verity"
+	c.Assert(vscmd.Calls(), check.HasLen, 1)
+	c.Check(vscmd.Calls()[0], check.DeepEquals, []string{"veritysetup", "format", snapOriginal, snapVerity})
 
 	matches, err := filepath.Glob(snapDir + "/hello*.snap")
 	c.Assert(err, check.IsNil)

--- a/cmd/snap/cmd_pack_test.go
+++ b/cmd/snap/cmd_pack_test.go
@@ -146,23 +146,27 @@ func (s *SnapSuite) TestPackPacksASnapWithCompressionUnhappy(c *check.C) {
 func (s *SnapSuite) TestPackPacksASnapWithIntegrityHappy(c *check.C) {
 	snapDir := makeSnapDirForPack(c, "name: hello\nversion: 1.0")
 
-	// mock the verity-setup command, what it does is make of a copy of the snap
+	// mock the verity-setup command, what it does is make a copy of the snap
 	// and then returns pre-calculated output
 	vscmd := testutil.MockCommand(c, "veritysetup", fmt.Sprintf(`
-if "$1" == "--version"; then
-	echo "veritysetup 2.2.6"
-	exit 0
-fi
-cp %[1]s/hello_1.0_all.snap %[1]s/hello_1.0_all.snap.verity
-echo "VERITY header information for %[1]s/hello_1.0_all.snap.verity"
-echo "UUID:            	8f6dcdd2-9426-49d8-9879-a5c87fc78c15"
-echo "Hash type:       	1"
-echo "Data blocks:     	1"
-echo "Data block size: 	4096"
-echo "Hash block size: 	4096"
-echo "Hash algorithm:  	sha256"
-echo "Salt:            	06d01a87b298b6855b6a3a1b32450deba4550417cbec2bb21a38d6dda24a1b53"
-echo "Root hash:      	306398e250a950ea1cbfceda608ee4585f053323251b08b7ed3f004740e91ba5"
+case "$1" in
+	--version)
+		echo "veritysetup 2.2.6"
+		exit 0
+		;;
+	format)
+		cp %[1]s/hello_1.0_all.snap %[1]s/hello_1.0_all.snap.verity
+		echo "VERITY header information for %[1]s/hello_1.0_all.snap.verity"
+		echo "UUID:            	8f6dcdd2-9426-49d8-9879-a5c87fc78c15"
+		echo "Hash type:       	1"
+		echo "Data blocks:     	1"
+		echo "Data block size: 	4096"
+		echo "Hash block size: 	4096"
+		echo "Hash algorithm:  	sha256"
+		echo "Salt:            	06d01a87b298b6855b6a3a1b32450deba4550417cbec2bb21a38d6dda24a1b53"
+		echo "Root hash:      	306398e250a950ea1cbfceda608ee4585f053323251b08b7ed3f004740e91ba5"
+		;;
+esac
 `, snapDir))
 	defer vscmd.Restore()
 

--- a/cmd/snap/cmd_pack_test.go
+++ b/cmd/snap/cmd_pack_test.go
@@ -149,6 +149,10 @@ func (s *SnapSuite) TestPackPacksASnapWithIntegrityHappy(c *check.C) {
 	// mock the verity-setup command, what it does is make of a copy of the snap
 	// and then returns pre-calculated output
 	vscmd := testutil.MockCommand(c, "veritysetup", fmt.Sprintf(`
+if "$1" == "--version"; then
+	echo "veritysetup 2.2.6"
+	exit 0
+fi
 cp %[1]s/hello_1.0_all.snap %[1]s/hello_1.0_all.snap.verity
 echo "VERITY header information for %[1]s/hello_1.0_all.snap.verity"
 echo "UUID:            	8f6dcdd2-9426-49d8-9879-a5c87fc78c15"
@@ -167,8 +171,9 @@ echo "Root hash:      	306398e250a950ea1cbfceda608ee4585f053323251b08b7ed3f00474
 
 	snapOriginal := path.Join(snapDir, "hello_1.0_all.snap")
 	snapVerity := snapOriginal + ".verity"
-	c.Assert(vscmd.Calls(), check.HasLen, 1)
-	c.Check(vscmd.Calls()[0], check.DeepEquals, []string{"veritysetup", "format", snapOriginal, snapVerity})
+	c.Assert(vscmd.Calls(), check.HasLen, 2)
+	c.Check(vscmd.Calls()[0], check.DeepEquals, []string{"veritysetup", "--version"})
+	c.Check(vscmd.Calls()[1], check.DeepEquals, []string{"veritysetup", "format", snapOriginal, snapVerity})
 
 	matches, err := filepath.Glob(snapDir + "/hello*.snap")
 	c.Assert(err, check.IsNil)

--- a/snap/integrity/dmverity/export_test.go
+++ b/snap/integrity/dmverity/export_test.go
@@ -21,4 +21,5 @@ package dmverity
 
 var (
 	GetRootHashFromOutput = getRootHashFromOutput
+	ShouldApplyWorkaround = shouldApplyNewFileWorkaroundForOlderThan204
 )

--- a/snap/integrity/dmverity/veritysetup_test.go
+++ b/snap/integrity/dmverity/veritysetup_test.go
@@ -92,23 +92,27 @@ func (s *VerityTestSuite) TestGetRootHashFromOutputInvalid(c *C) {
 func (s *VerityTestSuite) TestFormatSuccess(c *C) {
 	snapPath, _ := snaptest.MakeTestSnapInfoWithFiles(c, "name: foo\nversion: 1.0", nil, nil)
 
-	// mock the verity-setup command, what it does is make of a copy of the snap
+	// mock the verity-setup command, what it does is make a copy of the snap
 	// and then returns pre-calculated output
 	vscmd := testutil.MockCommand(c, "veritysetup", fmt.Sprintf(`
-if "$1" == "--version"; then
-	echo "veritysetup 2.2.6"
-	exit 0
-fi
-cp %[1]s %[1]s.verity
-echo VERITY header information for %[1]s.verity
-echo "UUID:            	97d80536-aad9-4f25-a528-5319c038c0c4"
-echo "Hash type:       	1"
-echo "Data blocks:     	1"
-echo "Data block size: 	4096"
-echo "Hash block size: 	4096"
-echo "Hash algorithm:  	sha256"
-echo "Salt:            	c0234a906cfde0d5ffcba25038c240a98199cbc1d8fbd388a41e8faa02239c08"
-echo "Root hash:      	e48cfc4df6df0f323bcf67f17b659a5074bec3afffe28f0b3b4db981d78d2e3e"
+case "$1" in
+	--version)
+		echo "veritysetup 2.2.6"
+		exit 0
+		;;
+	format)
+		cp %[1]s %[1]s.verity
+		echo VERITY header information for %[1]s.verity
+		echo "UUID:            	97d80536-aad9-4f25-a528-5319c038c0c4"
+		echo "Hash type:       	1"
+		echo "Data blocks:     	1"
+		echo "Data block size: 	4096"
+		echo "Hash block size: 	4096"
+		echo "Hash algorithm:  	sha256"
+		echo "Salt:            	c0234a906cfde0d5ffcba25038c240a98199cbc1d8fbd388a41e8faa02239c08"
+		echo "Root hash:      	e48cfc4df6df0f323bcf67f17b659a5074bec3afffe28f0b3b4db981d78d2e3e"
+		;;
+esac
 `, snapPath))
 	defer vscmd.Restore()
 
@@ -125,22 +129,26 @@ func (s *VerityTestSuite) TestFormatSuccessWithWorkaround(c *C) {
 	// use a version that forces the deployment of the workaround to run. Any version
 	// before 2.0.4 should automatically create a file we can verify
 	vscmd := testutil.MockCommand(c, "veritysetup", fmt.Sprintf(`
-if "$1" == "--version"; then
-	echo "veritysetup 1.6.4"
-	exit 0
-fi
-if ![ -e %[1]s.verity ]; then
-    exit 1
-fi
-echo VERITY header information for %[1]s.verity
-echo "UUID:            	97d80536-aad9-4f25-a528-5319c038c0c4"
-echo "Hash type:       	1"
-echo "Data blocks:     	1"
-echo "Data block size: 	4096"
-echo "Hash block size: 	4096"
-echo "Hash algorithm:  	sha256"
-echo "Salt:            	c0234a906cfde0d5ffcba25038c240a98199cbc1d8fbd388a41e8faa02239c08"
-echo "Root hash:      	e48cfc4df6df0f323bcf67f17b659a5074bec3afffe28f0b3b4db981d78d2e3e"
+case "$1" in
+	--version)
+		echo "veritysetup 1.6.4"
+		exit 0
+		;;
+	format)
+		if ! [ -e %[1]s.verity ]; then
+			exit 1
+		fi
+		echo VERITY header information for %[1]s.verity
+		echo "UUID:            	97d80536-aad9-4f25-a528-5319c038c0c4"
+		echo "Hash type:       	1"
+		echo "Data blocks:     	1"
+		echo "Data block size: 	4096"
+		echo "Hash block size: 	4096"
+		echo "Hash algorithm:  	sha256"
+		echo "Salt:            	c0234a906cfde0d5ffcba25038c240a98199cbc1d8fbd388a41e8faa02239c08"
+		echo "Root hash:      	e48cfc4df6df0f323bcf67f17b659a5074bec3afffe28f0b3b4db981d78d2e3e"
+		;;
+esac
 `, snapPath))
 	defer vscmd.Restore()
 
@@ -169,4 +177,31 @@ esac
 
 	_, err := dmverity.Format(snapPath, "")
 	c.Check(err, ErrorMatches, "Cannot create hash image  for writing.")
+}
+
+func (s *VerityTestSuite) TestVerityVersionDetect(c *C) {
+	tests := []struct {
+		ver    string
+		deploy bool
+		err    string
+	}{
+		{"", false, `cannot detect veritysetup version from: veritysetup\n`},
+		{"1", false, `cannot detect veritysetup version from: veritysetup 1\n`},
+		{"1.6", false, `cannot detect veritysetup version from: veritysetup 1.6\n`},
+		{"1.6.4", true, ``},
+		{"2.0.0", true, ``},
+		{"2.0.4", false, ``},
+		{"2.1.0", false, ``},
+	}
+
+	for _, t := range tests {
+		vscmd := testutil.MockCommand(c, "veritysetup", fmt.Sprintf(`echo veritysetup %s`, t.ver))
+		defer vscmd.Restore()
+
+		deploy, err := dmverity.ShouldApplyWorkaround()
+		if err != nil {
+			c.Check(err, ErrorMatches, t.err, Commentf("test failed for version: %s", t.ver))
+		}
+		c.Check(deploy, Equals, t.deploy, Commentf("test failed for version: %s", t.ver))
+	}
 }

--- a/snap/integrity/integrity_test.go
+++ b/snap/integrity/integrity_test.go
@@ -221,6 +221,10 @@ func (s *IntegrityTestSuite) TestGenerateAndAppendSuccess(c *C) {
 	// mock the verity-setup command, what it does is make of a copy of the snap
 	// and then returns pre-calculated output
 	vscmd := testutil.MockCommand(c, "veritysetup", fmt.Sprintf(`
+if "$1" == "--version"; then
+	echo "veritysetup 2.2.6"
+	exit 0
+fi
 cp %[1]s %[1]s.verity
 echo "VERITY header information for %[1]s.verity"
 echo "UUID:            	f8b4f201-fe4e-41a2-9f1d-4908d3c76632"
@@ -261,6 +265,7 @@ echo "Root hash:      	e2926364a8b1242d92fb1b56081e1ddb86eba35411961252a103a1c08
 	c.Check(integrityDataHeader.Size, Equals, uint64(2*4096))
 	c.Check(integrityDataHeader.DmVerity.RootHash, HasLen, 64)
 
-	c.Assert(vscmd.Calls(), HasLen, 1)
-	c.Check(vscmd.Calls()[0], DeepEquals, []string{"veritysetup", "format", snapPath, snapPath + ".verity"})
+	c.Assert(vscmd.Calls(), HasLen, 2)
+	c.Check(vscmd.Calls()[0], DeepEquals, []string{"veritysetup", "--version"})
+	c.Check(vscmd.Calls()[1], DeepEquals, []string{"veritysetup", "format", snapPath, snapPath + ".verity"})
 }

--- a/snap/integrity/integrity_test.go
+++ b/snap/integrity/integrity_test.go
@@ -218,23 +218,27 @@ func (s *IntegrityTestSuite) TestGenerateAndAppendSuccess(c *C) {
 
 	snapPath, _ := snaptest.MakeTestSnapInfoWithFiles(c, "name: foo\nversion: 1.0", nil, nil)
 
-	// mock the verity-setup command, what it does is make of a copy of the snap
+	// mock the verity-setup command, what it does is make a copy of the snap
 	// and then returns pre-calculated output
 	vscmd := testutil.MockCommand(c, "veritysetup", fmt.Sprintf(`
-if "$1" == "--version"; then
-	echo "veritysetup 2.2.6"
-	exit 0
-fi
-cp %[1]s %[1]s.verity
-echo "VERITY header information for %[1]s.verity"
-echo "UUID:            	f8b4f201-fe4e-41a2-9f1d-4908d3c76632"
-echo "Hash type:       	1"
-echo "Data blocks:     	1"
-echo "Data block size: 	4096"
-echo "Hash block size: 	4096"
-echo "Hash algorithm:  	sha256"
-echo "Salt:            	f1a7f87b88692b388f47dbda4a3bdf790f5adc3104b325f8772aee593488bf15"
-echo "Root hash:      	e2926364a8b1242d92fb1b56081e1ddb86eba35411961252a103a1c083c2be6d"
+case "$1" in
+	--version)
+		echo "veritysetup 2.2.6"
+		exit 0
+		;;
+	format)
+		cp %[1]s %[1]s.verity
+		echo "VERITY header information for %[1]s.verity"
+		echo "UUID:            	f8b4f201-fe4e-41a2-9f1d-4908d3c76632"
+		echo "Hash type:       	1"
+		echo "Data blocks:     	1"
+		echo "Data block size: 	4096"
+		echo "Hash block size: 	4096"
+		echo "Hash algorithm:  	sha256"
+		echo "Salt:            	f1a7f87b88692b388f47dbda4a3bdf790f5adc3104b325f8772aee593488bf15"
+		echo "Root hash:      	e2926364a8b1242d92fb1b56081e1ddb86eba35411961252a103a1c083c2be6d"
+		;;
+esac
 `, snapPath))
 	defer vscmd.Restore()
 

--- a/snap/pack/pack_test.go
+++ b/snap/pack/pack_test.go
@@ -361,23 +361,27 @@ func (s *packSuite) TestPackWithIntegrity(c *C) {
 	sourceDir := makeExampleSnapSourceDir(c, "{name: hello, version: 0}")
 	targetDir := c.MkDir()
 
-	// mock the verity-setup command, what it does is make of a copy of the snap
+	// mock the verity-setup command, what it does is make a copy of the snap
 	// and then returns pre-calculated output
 	vscmd := testutil.MockCommand(c, "veritysetup", fmt.Sprintf(`
-if "$1" == "--version"; then
-	echo "veritysetup 2.2.6"
-	exit 0
-fi
-cp %[1]s/hello_0_all.snap %[1]s/hello_0_all.snap.verity
-echo "VERITY header information for %[1]s/hello_0_all.snap.verity"
-echo "UUID:            	606d10a2-24d8-4c6b-90cf-68207aa7c850"
-echo "Hash type:       	1"
-echo "Data blocks:     	1"
-echo "Data block size: 	4096"
-echo "Hash block size: 	4096"
-echo "Hash algorithm:  	sha256"
-echo "Salt:            	eba61f2091bb6122226aef83b0d6c1623f095fc1fda5712d652a8b34a02024ea"
-echo "Root hash:      	3fbfef5f1f0214d727d03eebc4723b8ef5a34740fd8f1359783cff1ef9c3f334"
+case "$1" in
+	--version)
+		echo "veritysetup 2.2.6"
+		exit 0
+		;;
+	format)
+		cp %[1]s/hello_0_all.snap %[1]s/hello_0_all.snap.verity
+		echo "VERITY header information for %[1]s/hello_0_all.snap.verity"
+		echo "UUID:            	606d10a2-24d8-4c6b-90cf-68207aa7c850"
+		echo "Hash type:       	1"
+		echo "Data blocks:     	1"
+		echo "Data block size: 	4096"
+		echo "Hash block size: 	4096"
+		echo "Hash algorithm:  	sha256"
+		echo "Salt:            	eba61f2091bb6122226aef83b0d6c1623f095fc1fda5712d652a8b34a02024ea"
+		echo "Root hash:      	3fbfef5f1f0214d727d03eebc4723b8ef5a34740fd8f1359783cff1ef9c3f334"
+		;;
+esac
 `, targetDir))
 	defer vscmd.Restore()
 

--- a/snap/pack/pack_test.go
+++ b/snap/pack/pack_test.go
@@ -364,6 +364,10 @@ func (s *packSuite) TestPackWithIntegrity(c *C) {
 	// mock the verity-setup command, what it does is make of a copy of the snap
 	// and then returns pre-calculated output
 	vscmd := testutil.MockCommand(c, "veritysetup", fmt.Sprintf(`
+if "$1" == "--version"; then
+	echo "veritysetup 2.2.6"
+	exit 0
+fi
 cp %[1]s/hello_0_all.snap %[1]s/hello_0_all.snap.verity
 echo "VERITY header information for %[1]s/hello_0_all.snap.verity"
 echo "UUID:            	606d10a2-24d8-4c6b-90cf-68207aa7c850"
@@ -383,8 +387,9 @@ echo "Root hash:      	3fbfef5f1f0214d727d03eebc4723b8ef5a34740fd8f1359783cff1ef
 	})
 	c.Assert(err, IsNil)
 	c.Check(snapPath, testutil.FilePresent)
-	c.Assert(vscmd.Calls(), HasLen, 1)
-	c.Check(vscmd.Calls()[0], DeepEquals, []string{"veritysetup", "format", snapPath, snapPath + ".verity"})
+	c.Assert(vscmd.Calls(), HasLen, 2)
+	c.Check(vscmd.Calls()[0], DeepEquals, []string{"veritysetup", "--version"})
+	c.Check(vscmd.Calls()[1], DeepEquals, []string{"veritysetup", "format", snapPath, snapPath + ".verity"})
 
 	magic := []byte{'s', 'n', 'a', 'p', 'e', 'x', 't'}
 

--- a/tests/main/snap-pack-integrity/task.yaml
+++ b/tests/main/snap-pack-integrity/task.yaml
@@ -1,0 +1,40 @@
+summary: Verify that snap pack works with integrity data appended
+
+# TODO: add systems we know have veritysetup package available
+# so far a lot of distributions don't have veritysetup in path
+systems:
+  - debian-*
+  - ubuntu-1*
+  - ubuntu-2*
+
+prepare: |
+    snap install jq
+
+execute: |
+    # Manually pack the test snap instead of using the snaps-state tool here
+    # as we want to append some command line arguments. We also make sure to test
+    # with a small snap which is known to cause issues on older veritysetup
+    SNAP_DIR="$TESTSLIB"/snaps/test-snapd-sh
+    snap pack --append-integrity-data "$SNAP_DIR"
+
+    # Rename for description purposes
+    mv ./test-snapd-sh_1.0_all.snap ./snap.combined
+
+    # Build it without any integrity data appended to get the original
+    # file-size
+    snap pack "$SNAP_DIR"
+
+    # Split the normal data from the hashed data, and add 4K to the
+    # offset to account for the header which is written immediately after.
+    HDROFFSET=$(wc -c <./test-snapd-sh_1.0_all.snap)
+    HASHOFFSET=$((HDROFFSET+4096))
+    COMBSIZE=$(wc -c <./snap.combined)
+    DIFFSIZE=$((COMBSIZE-HDROFFSET))
+    dd if=./snap.combined of=./snap.data bs=4K count="$HDROFFSET" iflag=count_bytes
+    dd if=./snap.combined of=./snap.header bs=4K skip="$HDROFFSET" count=4K iflag=skip_bytes,count_bytes
+    dd if=./snap.combined of=./snap.hashed bs=4K skip="$HASHOFFSET" count="$DIFFSIZE" iflag=skip_bytes,count_bytes
+    ROOT_HASH=$(cut -c 8- < snap.header | jq -n 'input | ."dm-verity"."root-hash"' | tr -d '"')
+
+    # Use veritysetup verify to verify the hashed data
+    veritysetup verify ./snap.data ./snap.hashed "$ROOT_HASH"
+


### PR DESCRIPTION
This PR introduces the following things:

- The veritysetup calls were not always mocked in our unit test, and this unfortunately causes a lot of instability in our spread tests, with some platforms failing on the veritysetup calls.
- Adds a spread test instead to verify that `veritysetup` works as expected
- Implements a workaround for older `veritysetup` installations, veritysetup fails on short files (or files that don't already exists, see https://gitlab.com/cryptsetup/cryptsetup/-/commit/dc852a100f8e640dfdf4f6aeb86e129100653673)

