### PR TITLE
tests.invariant: wait for system scopes to finish

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -214,12 +214,6 @@ update_core_snap_for_classic_reexec() {
     done
 }
 
-flush_changes() {
-    # Leave some time for the tasks to show up in snap changes
-    sleep 1
-    retry -n 20 sh -c 'snap changes | grep -q Doing' || true
-}
-
 prepare_memory_limit_override() {
     # set up memory limits for snapd bu default unless explicit requested not to
     # or the system is known to be problematic
@@ -267,13 +261,7 @@ EOF
     # the service setting may have changed in the service so we need
     # to ensure snapd is reloaded
     systemctl daemon-reload
-
-    # Leave some time for snapd to finish processing hooks
-    flush_changes
     systemctl restart snapd
-    # Snapd might need to run some hooks (prepare-device) which
-    # triggers `tests.invariant cgroup-scopes` false positives
-    flush_changes
 }
 
 create_reexec_file(){
@@ -306,12 +294,7 @@ prepare_reexec_override() {
         # the re-exec setting may have changed in the service so we need
         # to ensure snapd is reloaded
         systemctl daemon-reload
-        # Leave some time for snapd to finish processing hooks
-        flush_changes
         systemctl restart snapd
-        # Snapd might need to run some hooks (prepare-device) which
-        # triggers `tests.invariant cgroup-scopes` false positives
-        flush_changes
     fi
 }
 

--- a/tests/lib/tools/tests.invariant
+++ b/tests/lib/tools/tests.invariant
@@ -150,6 +150,22 @@ check_cgroup_scopes() {
 		return 0
 	fi
 
+	wait_for_system_scopes=5
+	while [ "${wait_for_system_scopes}" -gt 0 ]; do
+		has_active_scope=0
+		while read -r -d '' scope; do
+			if systemctl is-active "$(basename "${scope}")"; then
+				has_active_scope=1
+				break
+			fi
+		done < <(find /sys/fs/cgroup/system.slice -name 'snap.*.scope' -print0)
+		if [ "${has_active_scope}" -eq 0 ]; then
+			break
+		fi
+		: $((wait_for_system_scopes--))
+		sleep 1
+	done
+
 	n="$1" # invariant name
 	find /sys/fs/cgroup -name 'snap.*.scope' > "$TESTSTMP/tests.invariant.$n"
 	if [ -s "$TESTSTMP/tests.invariant.$n" ]; then


### PR DESCRIPTION
This is required for core-base CI to pass. Also removes the previous work-around that did not fully work.

Tested in https://github.com/snapcore/core-base/pull/118