### PR TITLE
tests: use 8 workers for ubuntu lunar

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -142,7 +142,7 @@ backends:
                   workers: 8
             - ubuntu-23.04-64:
                   storage: 12G
-                  workers: 6
+                  workers: 8
 
             - debian-10-64:
                   workers: 6


### PR DESCRIPTION
Use the same number of workers than the other ubuntu systems.
