### PR TITLE
tests: fix test failure for `tests/main/docker-smoke` on i386

### DIFF
--- a/tests/main/docker-smoke/task.yaml
+++ b/tests/main/docker-smoke/task.yaml
@@ -10,7 +10,13 @@ debug: |
   "$TESTSTOOLS"/journal-state get-log -u snap.docker.dockerd
 
 execute: |
-  if ! snap install docker; then
+  CHANNEL=latest/stable
+  if os.query is-pc-i386; then
+      # on i386 only the "base: core18" version is available
+      CHANNEL=core18/stable
+  fi
+
+  if ! snap install --channel="$CHANNEL" docker; then
     echo "failed to install the docker snap!"
     exit 1
   fi
@@ -22,4 +28,4 @@ execute: |
   # also check that the docker snap can be installed in devmode for some 
   # specific customer use cases related to microk8s
   snap remove docker --purge
-  snap install docker --devmode
+  snap install --channel="$CHANNEL" docker --devmode


### PR DESCRIPTION
For i386 there is no "base: core20" or later so the docker smoke test fails. This commit fixes the test by using the older track for docker on i386.

