### PR TITLE
o/assertstate: take the model assertion into account when manipulating validation-sets

### DIFF
--- a/daemon/api_validate.go
+++ b/daemon/api_validate.go
@@ -287,7 +287,7 @@ func updateValidationSet(st *state.State, accountID, name string, reqMode string
 
 	tr, err := assertstateMonitorValidationSet(st, accountID, name, sequence, userID)
 	if err != nil {
-		return BadRequest("cannot get validation set assertion for %v: %v", assertstate.ValidationSetKey(accountID, name), err)
+		return BadRequest("cannot monitor validation set %v: %v", assertstate.ValidationSetKey(accountID, name), err)
 	}
 
 	res, err := validationSetResultFromTracking(st, tr)
@@ -310,7 +310,7 @@ func forgetValidationSet(st *state.State, accountID, name string, sequence int) 
 		return InternalError("accessing validation sets failed: %v", err)
 	}
 	if err := assertstate.ForgetValidationSet(st, accountID, name); err != nil {
-		return BadRequest("cannot forget validation set for %v: %v", assertstate.ValidationSetKey(accountID, name), err)
+		return BadRequest("cannot forget validation set %v: %v", assertstate.ValidationSetKey(accountID, name), err)
 	}
 	return SyncResponse(nil)
 }

--- a/daemon/api_validate_test.go
+++ b/daemon/api_validate_test.go
@@ -656,7 +656,7 @@ func (s *apiValidationSetsSuite) TestApplyValidationSetMonitorModeError(c *check
 
 	rspe := s.errorReq(c, req, nil)
 	c.Assert(rspe.Status, check.Equals, 400)
-	c.Check(rspe.Message, check.Equals, fmt.Sprintf(`cannot get validation set assertion for %s/bar: boom`, s.dev1acct.AccountID()))
+	c.Check(rspe.Message, check.Equals, fmt.Sprintf(`cannot monitor validation set %s/bar: boom`, s.dev1acct.AccountID()))
 }
 
 func (s *apiValidationSetsSuite) TestForgetValidationSet(c *check.C) {

--- a/overlord/assertstate/assertstate.go
+++ b/overlord/assertstate/assertstate.go
@@ -1012,11 +1012,66 @@ func ApplyEnforcedValidationSets(st *state.State, valsets map[string]*asserts.Va
 	return addCurrentTrackingToValidationSetsHistory(st)
 }
 
+func validationSetFromModel(st *state.State, accountID, name string) (*asserts.ModelValidationSet, error) {
+	deviceCtx, err := snapstate.DevicePastSeeding(st, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	model := deviceCtx.Model()
+	for _, vs := range model.ValidationSets() {
+		if vs.AccountID == accountID && vs.Name == name {
+			return vs, nil
+		}
+	}
+	return nil, nil
+}
+
+func sequenceSetByModelAssertion(st *state.State, accountID, name string) (int, error) {
+	vs, err := validationSetFromModel(st, accountID, name)
+	if err != nil {
+		return 0, err
+	}
+	if vs == nil {
+		return 0, nil
+	}
+	return vs.Sequence, nil
+}
+
+func validateSequenceAgainstModel(st *state.State, accountID, name string, sequence int) (int, error) {
+	modelSeq, err := sequenceSetByModelAssertion(st, accountID, name)
+	if err != nil {
+		return 0, err
+	}
+
+	// Verify the sequence requested does not differ from the one specified by the model
+	// in case one is set.
+	if sequence > 0 {
+		// Sequence was set, it must match any requirements set by model.
+		if modelSeq > 0 && modelSeq != sequence {
+			return 0, fmt.Errorf("only sequence %d allowed by model", modelSeq)
+		}
+	} else if modelSeq > 0 {
+		// Sequence was set by model, use that specifically.
+		sequence = modelSeq
+	}
+	return sequence, nil
+}
+
 // FetchAndApplyEnforcedValidationSet tries to fetch the given validation set and enforce it.
 // If all validation sets constrains are satisfied, the current validation sets
 // tracking state is saved in validation sets history.
 func FetchAndApplyEnforcedValidationSet(st *state.State, accountID, name string, sequence, userID int, snaps []*snapasserts.InstalledSnap, ignoreValidation map[string]bool) (*ValidationSetTracking, error) {
-	vs, err := validationSetAssertionForEnforce(st, accountID, name, sequence, userID, snaps, ignoreValidation)
+	// If the model has a specific sequence specified, then either we may
+	// need to use the correct sequence (if no specific is requested)
+	// or we may need to throw a validation error if the user is requesting a
+	// different sequence than is allowed by the model.
+	modelSeq, err := validateSequenceAgainstModel(st, accountID, name, sequence)
+	if err != nil {
+		return nil, fmt.Errorf("cannot enforce sequence %d of validation set %v: %v", sequence, ValidationSetKey(accountID, name), err)
+	}
+
+	vs, err := validationSetAssertionForEnforce(st, accountID, name, modelSeq, userID, snaps, ignoreValidation)
 	if err != nil {
 		return nil, err
 	}
@@ -1025,8 +1080,8 @@ func FetchAndApplyEnforcedValidationSet(st *state.State, accountID, name string,
 		AccountID: accountID,
 		Name:      name,
 		Mode:      Enforce,
-		// note, sequence may be 0, meaning not pinned.
-		PinnedAt: sequence,
+		// note, modelSeq may be 0, meaning not pinned.
+		PinnedAt: modelSeq,
 		Current:  vs.Sequence(),
 	}
 
@@ -1038,9 +1093,18 @@ func FetchAndApplyEnforcedValidationSet(st *state.State, accountID, name string,
 // MonitorValidationSet tries to fetch the given validation set and monitor it.
 // The current validation sets tracking state is saved in validation sets history.
 func MonitorValidationSet(st *state.State, accountID, name string, sequence int, userID int) (*ValidationSetTracking, error) {
-	pinned := sequence > 0
+	// If the model has a specific sequence specified, then either we may
+	// need to use the correct sequence (if no specific is requested)
+	// or we may need to throw a validation error if the user is requesting a
+	// different sequence than is allowed by the model.
+	modelSeq, err := validateSequenceAgainstModel(st, accountID, name, sequence)
+	if err != nil {
+		return nil, fmt.Errorf("cannot monitor sequence %d of validation set %v: %v", sequence, ValidationSetKey(accountID, name), err)
+	}
+
+	pinned := modelSeq > 0
 	opts := ResolveOptions{AllowLocalFallback: true}
-	as, local, err := validationSetAssertionForMonitor(st, accountID, name, sequence, pinned, userID, &opts)
+	as, local, err := validationSetAssertionForMonitor(st, accountID, name, modelSeq, pinned, userID, &opts)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get validation set assertion for %v: %v", ValidationSetKey(accountID, name), err)
 	}
@@ -1049,8 +1113,8 @@ func MonitorValidationSet(st *state.State, accountID, name string, sequence int,
 		AccountID: accountID,
 		Name:      name,
 		Mode:      Monitor,
-		// note, Sequence may be 0, meaning not pinned.
-		PinnedAt:  sequence,
+		// note, modelSeq may be 0, meaning not pinned.
+		PinnedAt:  modelSeq,
 		Current:   as.Sequence(),
 		LocalOnly: local,
 	}

--- a/overlord/assertstate/validation_set_tracking_test.go
+++ b/overlord/assertstate/validation_set_tracking_test.go
@@ -26,11 +26,13 @@ import (
 	"github.com/snapcore/snapd/asserts/assertstest"
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/assertstate/assertstatetest"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/testutil"
 )
 
 type validationSetTrackingSuite struct {
+	testutil.BaseTest
 	st          *state.State
 	dev1Signing *assertstest.SigningDB
 	dev1acct    *asserts.Account
@@ -134,10 +136,33 @@ func (s *validationSetTrackingSuite) TestUpdate(c *C) {
 	c.Check(gotSecond, Equals, true)
 }
 
+func (s *validationSetTrackingSuite) mockModel() {
+	a := assertstest.FakeAssertion(map[string]interface{}{
+		"type":         "model",
+		"authority-id": "my-brand",
+		"series":       "16",
+		"brand-id":     "my-brand",
+		"model":        "my-model",
+		"architecture": "amd64",
+		"store":        "my-brand-store",
+		"gadget":       "gadget",
+		"kernel":       "krnl",
+	})
+	deviceCtx := &snapstatetest.TrivialDeviceContext{
+		DeviceModel: a.(*asserts.Model),
+	}
+	s.AddCleanup(snapstatetest.MockDeviceContext(deviceCtx))
+	s.st.Set("seeded", true)
+}
+
 // there is a more extensive test for forget in assertstate_test.go.
 func (s *validationSetTrackingSuite) TestForget(c *C) {
 	s.st.Lock()
 	defer s.st.Unlock()
+
+	// mock a minimal model to get past the check against validation
+	// sets specified in the model
+	s.mockModel()
 
 	// delete non-existing one is fine
 	assertstate.ForgetValidationSet(s.st, "foo", "bar")


### PR DESCRIPTION
During spread testing I found these constraints missing when manipulating validation-sets post seeding.

- Do not allow forgetting validation-sets that have the mode `enforce` set in the model assertion
- When enforcing validation-sets, take any sequence constraint set by the model assertion into account.
- Improve/fix some existing error messages.
