### PR TITLE
tests/prepare-image-validation-sets: disable for all arm images

### DIFF
--- a/tests/main/prepare-image-validation-sets/task.yaml
+++ b/tests/main/prepare-image-validation-sets/task.yaml
@@ -11,7 +11,9 @@ backends: [-autopkgtest]
 systems:
 - -ubuntu-14.04-*
 - -ubuntu-18.04-32
-- -ubuntu-20.04-arm-*
+# The test downloads pc from track 20, which is not available for arm
+# TODO run the test also for a UC22 model
+- -ubuntu-*-arm-*
 
 environment:
     ROOT: /home/test/tmp/


### PR DESCRIPTION
The prepare-image-validation-sets test downloads pc-kernel and pc snaps from track 20, which is not available for arm64.