### PR TITLE
tests/lib/nested.sh: fix unbound variable access error

### DIFF
--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -5,6 +5,7 @@
 : "${NESTED_RUNTIME_DIR:=${NESTED_WORK_DIR}/runtime}"
 : "${NESTED_ASSETS_DIR:=${NESTED_WORK_DIR}/assets}"
 : "${NESTED_LOGS_DIR:=${NESTED_WORK_DIR}/logs}"
+: "${NESTED_ARCHITECTURE:=amd64}"
 
 : "${NESTED_VM:=nested-vm}"
 : "${NESTED_SSH_PORT:=8022}"
@@ -251,7 +252,7 @@ nested_get_snap_rev_for_channel() {
     local CHANNEL=$2
 
     curl -s \
-         -H "Snap-Device-Architecture: ${NESTED_ARCHITECTURE:-amd64}" \
+         -H "Snap-Device-Architecture: $NESTED_ARCHITECTURE" \
          -H "Snap-Device-Series: 16" \
          -X POST \
          -H "Content-Type: application/json" \


### PR DESCRIPTION
This was causing these tests to fail:
google-nested:ubuntu-22.04-64:tests/nested/manual/core20-install-mode-shutdown-via-hook
google-nested:ubuntu-22.04-64:tests/nested/manual/core20-install-mode-shutdown-via-hook