### PR TITLE
tests: make sure there are not any snapd service listed after removing snapd

### DIFF
--- a/cmd/snap-mgmt/snap-mgmt.sh.in
+++ b/cmd/snap-mgmt/snap-mgmt.sh.in
@@ -147,6 +147,11 @@ purge() {
         fi
     done
 
+    # stop snapd services
+    for serv in snapd.autoimport.service snapd.seeded.service snapd.apparmor.service snapd.mounts.target snapd.mounts-pre.target; do
+        systemctl_stop "$serv"
+    done
+
     # snapd session-agent
     rm -f /etc/systemd/user/snapd.session-agent.socket
     rm -f /etc/systemd/user/snapd.session-agent.service

--- a/tests/main/postrm-purge/task.yaml
+++ b/tests/main/postrm-purge/task.yaml
@@ -130,4 +130,3 @@ execute: |
         test "$(find /etc/systemd/user -name 'snap.*.socket' | wc -l)" -eq 0
     fi
     test "$(find /etc/systemd -name 'snap.*.slice' | wc -l)" -eq 0
-

--- a/tests/main/postrm-purge/task.yaml
+++ b/tests/main/postrm-purge/task.yaml
@@ -101,7 +101,7 @@ execute: |
         exit 1
     fi
 
-    # Check there are not snapd services listed
+    # Check no snapd services are listed
     systemctl -l | NOMATCH "snapd\."
 
     echo "No dangling service symlinks are left behind"

--- a/tests/main/postrm-purge/task.yaml
+++ b/tests/main/postrm-purge/task.yaml
@@ -101,6 +101,9 @@ execute: |
         exit 1
     fi
 
+    # Check there are not snapd services listed
+    systemctl -l | NOMATCH "snapd\."
+
     echo "No dangling service symlinks are left behind"
     test -z "$(find /etc/systemd/system/multi-user.target.wants/ -name 'snap.test-snapd-service.*')"
     # shellcheck disable=SC2251
@@ -127,3 +130,4 @@ execute: |
         test "$(find /etc/systemd/user -name 'snap.*.socket' | wc -l)" -eq 0
     fi
     test "$(find /etc/systemd -name 'snap.*.slice' | wc -l)" -eq 0
+


### PR DESCRIPTION
This is to avoid snapd.apparmor.service snapd.mounts.target snapd.mounts-pre.target are listed after snapd is purged in arch linux.

