### PR TITLE
tests: skip snap-quota-services in external devices

### DIFF
--- a/tests/main/snap-quota-services/task.yaml
+++ b/tests/main/snap-quota-services/task.yaml
@@ -1,5 +1,9 @@
 summary: Test for per-service quota-related snap functionality.
 
+# memory cgroup is disabled on external devices like rpi3
+backends:
+  - -external
+
 # these systems do not support journal quota groups due to their old systemd versions.
 # requires systemd v245+
 systems:
@@ -14,22 +18,12 @@ systems:
   - -ubuntu-core-18-*
 
 prepare: |
-  # memory cgroup is disabled on external devices like rpi3
-  if [ "$SPREAD_BACKEND" = "external" ]; then
-      exit 0
-  fi
-
   snap install test-snapd-stressd --edge --devmode
   tests.cleanup defer snap remove --purge test-snapd-stressd
   snap set system experimental.quota-groups=true
   tests.cleanup defer snap unset system experimental.quota-groups
 
 execute: |
-  # memory cgroup is disabled on external devices like rpi3
-  if [ "$SPREAD_BACKEND" = "external" ]; then
-      exit 0
-  fi
-
   # Create the top level snap group with a memory limit. test-snapd-stressd
   # contains 4 services, which makes it perfect for our testing as we only need
   # this one snap to test isolating services.

--- a/tests/main/snap-quota-services/task.yaml
+++ b/tests/main/snap-quota-services/task.yaml
@@ -14,12 +14,22 @@ systems:
   - -ubuntu-core-18-*
 
 prepare: |
+  # memory cgroup is disabled on external devices like rpi3
+  if [ "$SPREAD_BACKEND" = "external" ]; then
+      exit 0
+  fi
+
   snap install test-snapd-stressd --edge --devmode
   tests.cleanup defer snap remove --purge test-snapd-stressd
   snap set system experimental.quota-groups=true
   tests.cleanup defer snap unset system experimental.quota-groups
 
 execute: |
+  # memory cgroup is disabled on external devices like rpi3
+  if [ "$SPREAD_BACKEND" = "external" ]; then
+      exit 0
+  fi
+
   # Create the top level snap group with a memory limit. test-snapd-stressd
   # contains 4 services, which makes it perfect for our testing as we only need
   # this one snap to test isolating services.


### PR DESCRIPTION
As with the other quota tests, we need to disable snap-quota-services too for external devices.

This is the error in the test

+ snap set-quota test-top --memory=400MB test-snapd-stressd error: cannot create quota group: cannot create quota group "test-top": cannot
       use memory quota: memory cgroup is disabled on this system
