### PR TITLE
tests: skip microk8s-smoke test in external devices

### DIFF
--- a/tests/main/microk8s-smoke/task.yaml
+++ b/tests/main/microk8s-smoke/task.yaml
@@ -1,5 +1,8 @@
 summary: Smoke test for microk8s
 
+backends:
+  - -external
+
 systems:
   - -amazon-linux-2-* # fails to start service daemon-containerd
   - -centos-7-*       # doesn't have libseccomp >= 2.4


### PR DESCRIPTION
The test fails with timeouts caused for lack of resources on those instances/vms.

The idea is to run this test in google backend where the machines have 4GB of RAM and 2 cores.
