### PR TITLE
steam_support: allow /usr access

### DIFF
--- a/interfaces/builtin/steam_support.go
+++ b/interfaces/builtin/steam_support.go
@@ -194,11 +194,8 @@ pivot_root oldroot=/newroot/ /newroot/,
 umount /,
 
 # Permissions needed within sandbox root
+/usr/** ixr,
 deny /usr/bin/{chfn,chsh,gpasswd,mount,newgrp,passwd,su,sudo,umount} x,
-/usr/bin/** ixr,
-/usr/sbin/** ixr,
-/usr/libexec/** ixr,
-/usr/lib/** ixr,
 /run/host/** mr,
 /run/pressure-vessel/** mrw,
 /run/host/usr/sbin/ldconfig* ixr,


### PR DESCRIPTION
Expanding on the conversation in https://github.com/snapcore/snapd/pull/12794 and https://github.com/canonical/steam-snap/issues/227, this PR allows Steam access to everything in `/usr` to better facilitate Steam changes in the future