### PR TITLE
o/aspectstate: get/set aspects in state databags

### DIFF
--- a/aspects/aspects_test.go
+++ b/aspects/aspects_test.go
@@ -185,14 +185,14 @@ func (s *aspectSuite) TestAspectNotFoundError(c *C) {
 
 	err = aspect.Get("top-level", &value)
 	c.Assert(err, testutil.ErrorIs, &aspects.NotFoundError{})
-	c.Assert(err, ErrorMatches, `cannot get "top-level": value of key path "top-level" not found`)
+	c.Assert(err, ErrorMatches, `cannot get "top-level": no value was found under "top-level"`)
 
 	err = aspect.Set("nested", "thing")
 	c.Assert(err, IsNil)
 
 	err = aspect.Get("other-nested", &value)
 	c.Assert(err, testutil.ErrorIs, &aspects.NotFoundError{})
-	c.Assert(err, ErrorMatches, `cannot get "other-nested": value of key path "top.nested-two" not found`)
+	c.Assert(err, ErrorMatches, `cannot get "other-nested": no value was found under "top.nested-two"`)
 }
 
 func (s *aspectSuite) TestAspectBadRead(c *C) {
@@ -245,7 +245,7 @@ func (s *aspectSuite) TestAspectsAccessControl(c *C) {
 		{
 			name: "read-only",
 			// unrelated error
-			getErr: `cannot get "read-only": value of key path "path.read-only" not found`,
+			getErr: `cannot get "read-only": no value was found under "path.read-only"`,
 			setErr: `cannot set "read-only": path is not writeable`,
 		},
 		{

--- a/overlord/aspectstate/aspectstate.go
+++ b/overlord/aspectstate/aspectstate.go
@@ -1,0 +1,132 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package aspectstate
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/snapcore/snapd/aspects"
+	"github.com/snapcore/snapd/overlord/aspectstate/aspecttest"
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+func Set(st *state.State, account, bundleName, aspect, field string, value interface{}) error {
+	st.Lock()
+	defer st.Unlock()
+
+	databag, err := getDatabag(st, account, bundleName)
+	if err != nil {
+		if !errors.Is(err, state.ErrNoState) && !errors.Is(err, &aspects.NotFoundError{}) {
+			return err
+		}
+
+		databag = aspects.NewJSONDataBag()
+	}
+
+	accPatterns, err := aspecttest.MockAspect(account, bundleName)
+	if err != nil {
+		return err
+	}
+
+	aspectBundle, err := aspects.NewAspectBundle(bundleName, accPatterns, databag, aspects.NewJSONSchema())
+	if err != nil {
+		return err
+	}
+
+	asp := aspectBundle.Aspect(aspect)
+	if asp == nil {
+		return notFound("aspect %q was not found", aspect)
+	}
+
+	if err := asp.Set(field, value); err != nil {
+		return err
+	}
+
+	if err := updateDatabags(st, account, bundleName, databag); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func Get(st *state.State, account, bundleName, aspect, field string) (interface{}, error) {
+	st.Lock()
+	defer st.Unlock()
+
+	databag, err := getDatabag(st, account, bundleName)
+	if err != nil {
+		if errors.Is(err, state.ErrNoState) {
+			return nil, notFound("aspect %s/%s/%s was not found", account, bundleName, aspect)
+		}
+
+		return nil, err
+	}
+
+	accPatterns, err := aspecttest.MockAspect(account, bundleName)
+	if err != nil {
+		return nil, err
+	}
+
+	aspectBundle, err := aspects.NewAspectBundle(bundleName, accPatterns, databag, aspects.NewJSONSchema())
+	if err != nil {
+		return nil, err
+	}
+
+	asp := aspectBundle.Aspect(aspect)
+	if asp == nil {
+		return nil, notFound("aspect %s/%s/%s was not found", account, bundleName, aspect)
+	}
+
+	var value interface{}
+	if err := asp.Get(field, &value); err != nil {
+		return nil, err
+	}
+
+	return value, nil
+}
+
+func updateDatabags(st *state.State, account, bundleName string, databag aspects.JSONDataBag) error {
+	var databags map[string]map[string]aspects.JSONDataBag
+	if err := st.Get("aspect-databags", &databags); err != nil {
+		if !errors.Is(err, state.ErrNoState) {
+			return err
+		}
+
+		databags = map[string]map[string]aspects.JSONDataBag{
+			account: {bundleName: aspects.NewJSONDataBag()},
+		}
+	}
+
+	databags[account][bundleName] = databag
+	st.Set("aspect-databags", databags)
+	return nil
+}
+
+func getDatabag(st *state.State, account, bundleName string) (aspects.JSONDataBag, error) {
+	var databags map[string]map[string]aspects.JSONDataBag
+	if err := st.Get("aspect-databags", &databags); err != nil {
+		return nil, err
+	}
+	return databags[account][bundleName], nil
+}
+
+func notFound(msg string, v ...interface{}) *aspects.NotFoundError {
+	return &aspects.NotFoundError{Message: fmt.Sprintf(msg, v...)}
+}

--- a/overlord/aspectstate/aspectstate_test.go
+++ b/overlord/aspectstate/aspectstate_test.go
@@ -1,0 +1,130 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package aspectstate_test
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/aspects"
+	"github.com/snapcore/snapd/overlord"
+	"github.com/snapcore/snapd/overlord/aspectstate"
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+type aspectTestSuite struct {
+	state *state.State
+}
+
+var _ = Suite(&aspectTestSuite{})
+
+func Test(t *testing.T) { TestingT(t) }
+
+func (s *aspectTestSuite) SetUpTest(_ *C) {
+	s.state = overlord.Mock().State()
+}
+
+func (s *aspectTestSuite) TestGetAspect(c *C) {
+	databag := aspects.NewJSONDataBag()
+	err := databag.Set("wifi.ssid", "foo")
+	c.Assert(err, IsNil)
+
+	s.state.Lock()
+	s.state.Set("aspect-databags", map[string]map[string]aspects.JSONDataBag{
+		"system": {"network": databag},
+	})
+	s.state.Unlock()
+
+	val, err := aspectstate.Get(s.state, "system", "network", "wifi-setup", "ssid")
+	c.Assert(err, IsNil)
+	c.Assert(val, Equals, "foo")
+}
+
+func (s *aspectTestSuite) TestGetNotFound(c *C) {
+	val, err := aspectstate.Get(s.state, "system", "network", "wifi-setup", "ssid")
+	c.Assert(err, FitsTypeOf, &aspects.NotFoundError{})
+	c.Assert(err, ErrorMatches, `aspect system/network/wifi-setup was not found`)
+	c.Check(val, IsNil)
+
+	s.state.Lock()
+	s.state.Set("aspect-databags", map[string]map[string]aspects.JSONDataBag{
+		"system": {"network": aspects.NewJSONDataBag()},
+	})
+	s.state.Unlock()
+
+	val, err = aspectstate.Get(s.state, "system", "network", "other-aspect", "ssid")
+	c.Assert(err, FitsTypeOf, &aspects.NotFoundError{})
+	c.Assert(err, ErrorMatches, `aspect system/network/other-aspect was not found`)
+	c.Check(val, IsNil)
+
+	val, err = aspectstate.Get(s.state, "system", "network", "wifi-setup", "ssid")
+	c.Assert(err, FitsTypeOf, &aspects.NotFoundError{})
+	c.Assert(err, ErrorMatches, `cannot get "ssid": no value was found under "wifi"`)
+	c.Check(val, IsNil)
+}
+
+func (s *aspectTestSuite) TestSetAspect(c *C) {
+	err := aspectstate.Set(s.state, "system", "network", "wifi-setup", "ssid", "foo")
+	c.Assert(err, IsNil)
+
+	var databags map[string]map[string]aspects.JSONDataBag
+	s.state.Lock()
+	err = s.state.Get("aspect-databags", &databags)
+	s.state.Unlock()
+	c.Assert(err, IsNil)
+
+	databag := databags["system"]["network"]
+	c.Assert(databag, NotNil)
+
+	var val string
+	err = databag.Get("wifi.ssid", &val)
+	c.Assert(err, IsNil)
+	c.Assert(val, Equals, "foo")
+}
+
+func (s *aspectTestSuite) TestSetNotFound(c *C) {
+	err := aspectstate.Set(s.state, "system", "other-bundle", "other-aspect", "foo", "bar")
+	c.Assert(err, FitsTypeOf, &aspects.NotFoundError{})
+
+	err = aspectstate.Set(s.state, "system", "network", "other-aspect", "foo", "bar")
+	c.Assert(err, FitsTypeOf, &aspects.NotFoundError{})
+}
+
+func (s *aspectTestSuite) TestUnsetAspect(c *C) {
+	err := aspectstate.Set(s.state, "system", "network", "wifi-setup", "ssid", "foo")
+	c.Assert(err, IsNil)
+
+	err = aspectstate.Set(s.state, "system", "network", "wifi-setup", "ssid", nil)
+	c.Assert(err, IsNil)
+
+	var databags map[string]map[string]aspects.JSONDataBag
+	s.state.Lock()
+	err = s.state.Get("aspect-databags", &databags)
+	s.state.Unlock()
+	c.Assert(err, IsNil)
+
+	databag := databags["system"]["network"]
+	c.Assert(databag, NotNil)
+
+	var val string
+	err = databag.Get("wifi.ssid", &val)
+	c.Assert(err, FitsTypeOf, &aspects.NotFoundError{})
+	c.Assert(val, Equals, "")
+}

--- a/overlord/aspectstate/aspecttest/mock_aspect.go
+++ b/overlord/aspectstate/aspecttest/mock_aspect.go
@@ -1,0 +1,44 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package aspecttest
+
+import (
+	"fmt"
+
+	"github.com/snapcore/snapd/aspects"
+)
+
+// MockAspect returns some mocked aspect access patterns for the "system:network"
+// account and bundle combination. This will eventually be replaced by proper
+// aspect assertions.
+func MockAspect(account, bundle string) (map[string]interface{}, error) {
+	if account != "system" || bundle != "network" {
+		return nil, &aspects.NotFoundError{Message: fmt.Sprintf("aspect assertions for %s:%s not found", account, bundle)}
+	}
+
+	return map[string]interface{}{
+		"wifi-setup": []map[string]string{
+			{"name": "ssids", "path": "wifi.ssids"},
+			{"name": "ssid", "path": "wifi.ssid", "access": "read-write"},
+			{"name": "password", "path": "wifi.psk", "access": "write"},
+			{"name": "status", "path": "wifi.status", "access": "read"},
+			{"name": "private.{placeholder}", "path": "wifi.{placeholder}"},
+		},
+	}, nil
+}


### PR DESCRIPTION
Add a new aspectstate package that stores aspect data in the state. Includes a temporary mocked aspect assertion to facilitate testing and experimentation.