### PR TITLE
daemon: add aspects endpoint to REST API

### DIFF
--- a/aspects/aspects.go
+++ b/aspects/aspects.go
@@ -87,6 +87,30 @@ func (e *FieldNotFoundError) Is(err error) bool {
 	return ok
 }
 
+// IsNotFound returns true if the error is some kind of aspect-related not
+// found error (e.g., aspect not found, field not found in aspect).
+func IsNotFound(err error) bool {
+	return errors.Is(err, &AspectNotFoundError{}) || errors.Is(err, &FieldNotFoundError{})
+}
+
+// InvalidAccessError represents a failure to perform a read or write due to the
+// aspect's access control.
+type InvalidAccessError struct {
+	RequestedAccess accessType
+	FieldAccess     accessType
+	Field           string
+}
+
+func (e *InvalidAccessError) Error() string {
+	return fmt.Sprintf("cannot %s field %q: only supports %s access",
+		accessTypeStrings[e.RequestedAccess], e.Field, accessTypeStrings[e.FieldAccess])
+}
+
+func (e *InvalidAccessError) Is(err error) bool {
+	_, ok := err.(*InvalidAccessError)
+	return ok
+}
+
 // DataBag controls access to the aspect data storage.
 type DataBag interface {
 	Get(path string, value interface{}) error
@@ -283,7 +307,7 @@ func (a *Aspect) Set(databag DataBag, name string, value interface{}) error {
 		}
 
 		if !accessPatt.isWriteable() {
-			return fmt.Errorf("cannot set field %q: path is not writeable", name)
+			return &InvalidAccessError{RequestedAccess: write, FieldAccess: accessPatt.access, Field: name}
 		}
 
 		if err := databag.Set(path, value); err != nil {
@@ -317,7 +341,7 @@ func (a *Aspect) Get(databag DataBag, name string, value interface{}) error {
 		}
 
 		if !accessPatt.isReadable() {
-			return fmt.Errorf("cannot get field %q: path is not readable", name)
+			return &InvalidAccessError{RequestedAccess: read, FieldAccess: accessPatt.access, Field: name}
 		}
 
 		if err := databag.Get(path, value); err != nil {

--- a/aspects/aspects_test.go
+++ b/aspects/aspects_test.go
@@ -249,11 +249,11 @@ func (s *aspectSuite) TestAspectsAccessControl(c *C) {
 			name: "read-only",
 			// unrelated error
 			getErr: `cannot get field "read-only": no value was found under "path"`,
-			setErr: `cannot set field "read-only": path is not writeable`,
+			setErr: `cannot write field "read-only": only supports read access`,
 		},
 		{
 			name:   "write-only",
-			getErr: `cannot get field "write-only": path is not readable`,
+			getErr: `cannot read field "write-only": only supports write access`,
 		},
 	} {
 		cmt := Commentf("sub-test %q failed", t.name)
@@ -587,4 +587,20 @@ func (s *aspectSuite) TestFieldNotFoundError(c *C) {
 	err := &aspects.FieldNotFoundError{Message: "expected error"}
 	c.Assert(err, testutil.ErrorIs, &aspects.FieldNotFoundError{})
 	c.Assert(err, ErrorMatches, `expected error`)
+}
+
+func (s *aspectSuite) TestInvalidAccessError(c *C) {
+	err := &aspects.InvalidAccessError{RequestedAccess: 1, FieldAccess: 2, Field: "foo"}
+	c.Assert(err, testutil.ErrorIs, &aspects.InvalidAccessError{})
+	c.Assert(err, ErrorMatches, `cannot read field "foo": only supports write access`)
+
+	err = &aspects.InvalidAccessError{RequestedAccess: 2, FieldAccess: 1, Field: "foo"}
+	c.Assert(err, testutil.ErrorIs, &aspects.InvalidAccessError{})
+	c.Assert(err, ErrorMatches, `cannot write field "foo": only supports read access`)
+}
+
+func (s *aspectSuite) TestIsNotFoundHelper(c *C) {
+	c.Assert(aspects.IsNotFound(&aspects.AspectNotFoundError{}), Equals, true)
+	c.Assert(aspects.IsNotFound(&aspects.FieldNotFoundError{}), Equals, true)
+	c.Assert(aspects.IsNotFound(&aspects.InvalidAccessError{}), Equals, false)
 }

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"github.com/snapcore/snapd/overlord/aspectstate"
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/configstate"
@@ -81,6 +82,7 @@ var api = []*Command{
 	systemRecoveryKeysCmd,
 	quotaGroupsCmd,
 	quotaGroupInfoCmd,
+	aspectsCmd,
 }
 
 const (
@@ -155,6 +157,9 @@ var (
 
 	assertstateRefreshSnapAssertions         = assertstate.RefreshSnapAssertions
 	assertstateRestoreValidationSetsTracking = assertstate.RestoreValidationSetsTracking
+
+	aspectstateGet = aspectstate.Get
+	aspectstateSet = aspectstate.Set
 )
 
 func ensureStateSoonImpl(st *state.State) {

--- a/daemon/api_aspects.go
+++ b/daemon/api_aspects.go
@@ -1,0 +1,122 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package daemon
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/snapcore/snapd/aspects"
+	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/strutil"
+)
+
+var (
+	aspectsCmd = &Command{
+		Path:        "/v2/aspects/{account}/{bundle}/{aspect}",
+		GET:         getAspect,
+		PUT:         setAspect,
+		ReadAccess:  authenticatedAccess{Polkit: polkitActionManage},
+		WriteAccess: authenticatedAccess{Polkit: polkitActionManage},
+	}
+)
+
+func getAspect(c *Command, r *http.Request, _ *auth.UserState) Response {
+	vars := muxVars(r)
+	account, bundleName, aspect := vars["account"], vars["bundle"], vars["aspect"]
+	fields := strutil.CommaSeparatedList(r.URL.Query().Get("fields"))
+
+	if len(fields) == 0 {
+		return BadRequest("missing aspect fields")
+	}
+	results := make(map[string]interface{})
+
+	st := c.d.state
+	st.Lock()
+	defer st.Unlock()
+
+	for _, field := range fields {
+		var value interface{}
+		err := aspectstateGet(c.d.state, account, bundleName, aspect, field, &value)
+		if err != nil {
+			if errors.Is(err, &aspects.FieldNotFoundError{}) {
+				// keep looking; return partial result, if only some fields are found
+				continue
+			} else {
+				return toAPIError(err)
+			}
+		}
+
+		results[field] = value
+	}
+
+	// no results were found, return 404
+	if len(results) == 0 {
+		return NotFound("no fields were found")
+	}
+
+	return SyncResponse(results)
+}
+
+func setAspect(c *Command, r *http.Request, _ *auth.UserState) Response {
+	vars := muxVars(r)
+	account, bundleName, aspect := vars["account"], vars["bundle"], vars["aspect"]
+
+	decoder := json.NewDecoder(r.Body)
+	var values map[string]interface{}
+	if err := decoder.Decode(&values); err != nil {
+		return BadRequest("cannot decode aspect request body: %v", err)
+	}
+
+	st := c.d.state
+	st.Lock()
+	defer st.Unlock()
+
+	for field, value := range values {
+		err := aspectstateSet(c.d.state, account, bundleName, aspect, field, value)
+		if err != nil {
+			return toAPIError(err)
+		}
+	}
+
+	// NOTE: could be sync but this is closer to the final version and the conf API
+	summary := fmt.Sprintf("Set aspect %s/%s/%s", account, bundleName, aspect)
+	chg := newChange(st, "set-aspect", summary, nil, nil)
+	ensureStateSoon(st)
+
+	return AsyncResponse(nil, chg.ID())
+}
+
+func toAPIError(err error) *apiError {
+	switch {
+	case aspects.IsNotFound(err):
+		return NotFound(err.Error())
+
+	case errors.Is(err, &aspects.InvalidAccessError{}):
+		return &apiError{
+			Status:  403,
+			Message: err.Error(),
+		}
+
+	default:
+		return InternalError(err.Error())
+	}
+}

--- a/daemon/api_aspects_test.go
+++ b/daemon/api_aspects_test.go
@@ -1,0 +1,442 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package daemon_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"reflect"
+
+	"gopkg.in/check.v1"
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/aspects"
+	"github.com/snapcore/snapd/client"
+	"github.com/snapcore/snapd/daemon"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type aspectsSuite struct {
+	apiBaseSuite
+}
+
+var _ = Suite(&aspectsSuite{})
+
+func (s *aspectsSuite) SetUpTest(c *C) {
+	s.apiBaseSuite.SetUpTest(c)
+
+	s.expectReadAccess(daemon.AuthenticatedAccess{Polkit: "io.snapcraft.snapd.manage"})
+	s.expectWriteAccess(daemon.AuthenticatedAccess{Polkit: "io.snapcraft.snapd.manage"})
+}
+
+func (s *aspectsSuite) TestGetAspect(c *C) {
+	s.daemon(c)
+
+	type test struct {
+		name  string
+		value interface{}
+	}
+
+	for _, t := range []test{
+		{name: "string", value: "foo"},
+		{name: "integer", value: 123},
+		{name: "list", value: []string{"foo", "bar"}},
+		{name: "map", value: map[string]int{"foo": 123}},
+	} {
+		cmt := Commentf("%s test", t.name)
+		restore := daemon.MockAspectstateGet(func(_ *state.State, acc, bundleName, aspect, field string, value interface{}) error {
+			c.Check(acc, Equals, "system", cmt)
+			c.Check(bundleName, Equals, "network", cmt)
+			c.Check(aspect, Equals, "wifi-setup", cmt)
+			c.Check(field, Equals, "ssid", cmt)
+
+			outputValue := reflect.ValueOf(value).Elem()
+			outputValue.Set(reflect.ValueOf(t.value))
+			return nil
+		})
+		req, err := http.NewRequest("GET", "/v2/aspects/system/network/wifi-setup?fields=ssid", nil)
+		c.Assert(err, IsNil, cmt)
+
+		rspe := s.syncReq(c, req, nil)
+		c.Check(rspe.Status, Equals, 200, cmt)
+		c.Check(rspe.Result, DeepEquals, map[string]interface{}{"ssid": t.value}, cmt)
+
+		restore()
+	}
+}
+
+func (s *aspectsSuite) TestAspectGetMany(c *C) {
+	s.daemon(c)
+
+	var calls int
+	restore := daemon.MockAspectstateGet(func(_ *state.State, _, _, _, _ string, value interface{}) error {
+		calls++
+		switch calls {
+		case 1:
+			*value.(*interface{}) = "foo"
+		case 2:
+			*value.(*interface{}) = "bar"
+		default:
+			err := fmt.Errorf("expected 2 calls, now on %d", calls)
+			c.Error(err)
+			return err
+		}
+
+		return nil
+	})
+	defer restore()
+
+	req, err := http.NewRequest("GET", "/v2/aspects/system/network/wifi-setup?fields=ssid,password", nil)
+	c.Assert(err, IsNil)
+
+	rspe := s.syncReq(c, req, nil)
+	c.Check(rspe.Status, Equals, 200)
+	c.Check(rspe.Result, DeepEquals, map[string]interface{}{"ssid": "foo", "password": "bar"})
+}
+
+func (s *aspectsSuite) TestAspectGetSomeFieldNotFound(c *C) {
+	s.daemon(c)
+
+	var calls int
+	restore := daemon.MockAspectstateGet(func(_ *state.State, acc, bundle, aspect, _ string, value interface{}) error {
+		calls++
+		switch calls {
+		case 1:
+			*value.(*interface{}) = "foo"
+		case 2:
+			return &aspects.FieldNotFoundError{}
+		default:
+			err := fmt.Errorf("expected 2 calls, now on %d", calls)
+			c.Error(err)
+			return err
+		}
+
+		return nil
+	})
+	defer restore()
+
+	req, err := http.NewRequest("GET", "/v2/aspects/system/network/wifi-setup?fields=ssid,password", nil)
+	c.Assert(err, IsNil)
+
+	rspe := s.syncReq(c, req, nil)
+	c.Check(rspe.Status, Equals, 200)
+	c.Check(rspe.Result, DeepEquals, map[string]interface{}{"ssid": "foo"})
+}
+
+func (s *aspectsSuite) TestGetAspectNoFieldsFound(c *C) {
+	s.daemon(c)
+
+	restore := daemon.MockAspectstateGet(func(_ *state.State, _, _, _, _ string, _ interface{}) error {
+		return &aspects.FieldNotFoundError{}
+	})
+	defer restore()
+
+	req, err := http.NewRequest("GET", "/v2/aspects/system/network/wifi-setup?fields=ssid", nil)
+	c.Assert(err, IsNil)
+
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, Equals, 404)
+	c.Check(rspe.Error(), Equals, "no fields were found (api 404)")
+}
+
+func (s *aspectsSuite) TestAspectSetMany(c *C) {
+	s.daemonWithOverlordMock()
+
+	var calls int
+	restore := daemon.MockAspectstateSet(func(_ *state.State, _, _, _, field string, value interface{}) error {
+		calls++
+		switch calls {
+		case 1, 2:
+			if field == "ssid" {
+				c.Assert(value, Equals, "foo")
+			} else if field == "password" {
+				c.Assert(value, IsNil)
+			} else {
+				c.Errorf("expected field to be \"ssid\" or \"password\" but got %q", field)
+			}
+
+		default:
+			err := fmt.Errorf("expected 2 calls, now on %d", calls)
+			c.Error(err)
+			return err
+		}
+
+		return nil
+	})
+	defer restore()
+
+	buf := bytes.NewBufferString(`{"ssid": "foo", "password": null}`)
+	req, err := http.NewRequest("PUT", "/v2/aspects/system/network/wifi-setup", buf)
+	c.Assert(err, IsNil)
+
+	rspe := s.asyncReq(c, req, nil)
+	c.Check(rspe.Status, Equals, 202)
+
+	st := s.d.Overlord().State()
+	st.Lock()
+	defer st.Unlock()
+
+	chg := st.Change(rspe.Change)
+	c.Check(chg.Kind(), check.Equals, "set-aspect")
+	c.Check(chg.Summary(), check.Equals, `Set aspect system/network/wifi-setup`)
+}
+
+func (s *aspectsSuite) TestGetAspectError(c *C) {
+	s.daemon(c)
+
+	type test struct {
+		name string
+		err  error
+		code int
+	}
+
+	for _, t := range []test{
+		{name: "aspect not found", err: &aspects.AspectNotFoundError{}, code: 404},
+		{name: "internal", err: errors.New("internal"), code: 500},
+		{name: "invalid access", err: &aspects.InvalidAccessError{RequestedAccess: 1, FieldAccess: 2, Field: "foo"}, code: 403},
+	} {
+		restore := daemon.MockAspectstateGet(func(_ *state.State, _, _, _, _ string, _ interface{}) error {
+			return t.err
+		})
+
+		req, err := http.NewRequest("GET", "/v2/aspects/system/network/wifi-setup?fields=ssid", nil)
+		c.Assert(err, IsNil, Commentf("%s test", t.name))
+
+		rspe := s.errorReq(c, req, nil)
+		c.Check(rspe.Status, Equals, t.code, Commentf("%s test", t.name))
+		restore()
+	}
+}
+
+func (s *aspectsSuite) TestGetAspectMissingField(c *C) {
+	s.daemon(c)
+
+	req, err := http.NewRequest("GET", "/v2/aspects/system/network/wifi-setup", nil)
+	c.Assert(err, IsNil)
+
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, Equals, 400)
+	c.Check(rspe.Error(), Equals, "missing aspect fields (api)")
+}
+
+func (s *aspectsSuite) TestGetAspectMisshapenQuery(c *C) {
+	s.daemon(c)
+
+	var calls int
+	restore := daemon.MockAspectstateGet(func(_ *state.State, _, _, _, field string, value interface{}) error {
+		calls++
+		switch calls {
+		case 1:
+			c.Check(field, Equals, "foo.bar")
+		case 2:
+			c.Check(field, Equals, "[1].foo")
+		case 3:
+			c.Check(field, Equals, "foo")
+		default:
+			c.Errorf("only expected 3 requests, now on %d", calls)
+		}
+
+		*value.(*interface{}) = calls
+		return nil
+	})
+	defer restore()
+
+	req, err := http.NewRequest("GET", "/v2/aspects/system/network/wifi-setup?fields=,foo.bar,,[1].foo,foo,", nil)
+	c.Assert(err, IsNil)
+
+	rsp := s.syncReq(c, req, nil)
+	c.Check(rsp.Status, Equals, 200)
+	c.Check(rsp.Result, DeepEquals, map[string]interface{}{"foo.bar": 1, "[1].foo": 2, "foo": 3})
+}
+
+func (s *aspectsSuite) TestSetAspect(c *C) {
+	s.daemonWithOverlordMock()
+
+	type test struct {
+		name  string
+		value interface{}
+	}
+
+	for _, t := range []test{
+		{name: "string", value: "foo"},
+		{name: "integer", value: float64(123)},
+		{name: "list", value: []interface{}{"foo", "bar"}},
+		{name: "map", value: map[string]interface{}{"foo": "bar"}},
+	} {
+		cmt := Commentf("%s test", t.name)
+		restore := daemon.MockAspectstateSet(func(_ *state.State, acc, bundleName, aspect, field string, value interface{}) error {
+			c.Check(acc, Equals, "system", cmt)
+			c.Check(bundleName, Equals, "network", cmt)
+			c.Check(aspect, Equals, "wifi-setup", cmt)
+			c.Check(field, Equals, "ssid", cmt)
+			c.Check(value, DeepEquals, t.value, cmt)
+			return nil
+		})
+		jsonVal, err := json.Marshal(t.value)
+		c.Check(err, IsNil, cmt)
+
+		buf := bytes.NewBufferString(fmt.Sprintf(`{"ssid": %s}`, jsonVal))
+		req, err := http.NewRequest("PUT", "/v2/aspects/system/network/wifi-setup", buf)
+		c.Check(err, IsNil, cmt)
+		req.Header.Set("Content-Type", "application/json")
+
+		rspe := s.asyncReq(c, req, nil)
+		c.Check(rspe.Status, Equals, 202, cmt)
+
+		st := s.d.Overlord().State()
+		st.Lock()
+		chg := st.Change(rspe.Change)
+		st.Unlock()
+
+		c.Check(chg.Kind(), check.Equals, "set-aspect", cmt)
+		c.Check(chg.Summary(), check.Equals, `Set aspect system/network/wifi-setup`, cmt)
+		restore()
+	}
+}
+
+func (s *aspectsSuite) TestUnsetAspect(c *C) {
+	s.daemonWithOverlordMock()
+
+	restore := daemon.MockAspectstateSet(func(_ *state.State, acc, bundleName, aspect, field string, value interface{}) error {
+		c.Check(acc, Equals, "system")
+		c.Check(bundleName, Equals, "network")
+		c.Check(aspect, Equals, "wifi-setup")
+		c.Check(field, Equals, "ssid")
+		c.Check(value, testutil.IsInterfaceNil)
+		return nil
+	})
+	defer restore()
+
+	buf := bytes.NewBufferString(`{"ssid": null}`)
+	req, err := http.NewRequest("PUT", "/v2/aspects/system/network/wifi-setup", buf)
+	c.Assert(err, IsNil)
+	req.Header.Set("Content-Type", "application/json")
+
+	rspe := s.asyncReq(c, req, nil)
+	c.Check(rspe.Status, Equals, 202)
+
+	st := s.d.Overlord().State()
+	st.Lock()
+	chg := st.Change(rspe.Change)
+	st.Unlock()
+
+	c.Check(chg.Kind(), check.Equals, "set-aspect")
+	c.Check(chg.Summary(), check.Equals, `Set aspect system/network/wifi-setup`)
+}
+
+func (s *aspectsSuite) TestSetAspectError(c *C) {
+	s.daemon(c)
+
+	type test struct {
+		name string
+		err  error
+		code int
+	}
+
+	for _, t := range []test{
+		{name: "aspect not found", err: &aspects.AspectNotFoundError{}, code: 404},
+		{name: "field not found", err: &aspects.FieldNotFoundError{}, code: 404},
+		{name: "internal", err: errors.New("internal"), code: 500},
+	} {
+		restore := daemon.MockAspectstateSet(func(*state.State, string, string, string, string, interface{}) error {
+			return t.err
+		})
+		cmt := Commentf("%s test", t.name)
+
+		buf := bytes.NewBufferString(`{"ssid": null}`)
+		req, err := http.NewRequest("PUT", "/v2/aspects/system/network/wifi-setup", buf)
+		c.Assert(err, IsNil, cmt)
+		req.Header.Set("Content-Type", "application/json")
+
+		rspe := s.errorReq(c, req, nil)
+		c.Check(rspe.Status, Equals, t.code, cmt)
+		restore()
+	}
+}
+
+func (s *aspectsSuite) TestSetAspectEmptyBody(c *C) {
+	s.daemon(c)
+
+	restore := daemon.MockAspectstateSet(func(*state.State, string, string, string, string, interface{}) error {
+		err := errors.New("unexpected call to aspectstate.Set")
+		c.Error(err)
+		return err
+	})
+	defer restore()
+
+	req, err := http.NewRequest("PUT", "/v2/aspects/system/network/wifi-setup", &bytes.Buffer{})
+	req.Header.Set("Content-Type", "application/json")
+	c.Assert(err, IsNil)
+
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, Equals, 400)
+}
+
+func (s *aspectsSuite) TestSetAspectBadRequest(c *C) {
+	s.daemon(c)
+
+	buf := bytes.NewBufferString(`{`)
+	req, err := http.NewRequest("PUT", "/v2/aspects/system/network/wifi-setup", buf)
+	c.Assert(err, IsNil)
+
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, Equals, 400)
+	c.Check(rspe.Message, Equals, "cannot decode aspect request body: unexpected EOF")
+}
+
+func (s *aspectsSuite) TestSetAspectNotAllowed(c *C) {
+	s.daemon(c)
+
+	restore := daemon.MockAspectstateSet(func(_ *state.State, acc, bundleName, aspect, field string, val interface{}) error {
+		return &aspects.InvalidAccessError{RequestedAccess: 2, FieldAccess: 1, Field: "foo"}
+	})
+	defer restore()
+
+	buf := bytes.NewBufferString(`{"foo": "bar"}`)
+	req, err := http.NewRequest("PUT", "/v2/aspects/system/network/wifi-setup", buf)
+	c.Assert(err, IsNil)
+	req.Header.Set("Content-Type", "application/json")
+
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, Equals, 403)
+	c.Check(rspe.Message, Equals, `cannot write field "foo": only supports read access`)
+	c.Check(rspe.Kind, Equals, client.ErrorKind(""))
+}
+
+func (s *aspectsSuite) TestGetAspectNotAllowed(c *C) {
+	s.daemon(c)
+
+	restore := daemon.MockAspectstateGet(func(_ *state.State, acc, bundleName, aspect, field string, val interface{}) error {
+		return &aspects.InvalidAccessError{RequestedAccess: 1, FieldAccess: 2, Field: "foo"}
+	})
+	defer restore()
+
+	req, err := http.NewRequest("GET", "/v2/aspects/system/network/wifi-setup?fields=foo", &bytes.Buffer{})
+	req.Header.Set("Content-Type", "application/json")
+	c.Assert(err, IsNil)
+
+	rspe := s.errorReq(c, req, nil)
+	c.Check(rspe.Status, Equals, 403)
+	c.Check(rspe.Message, Equals, `cannot read field "foo": only supports write access`)
+	c.Check(rspe.Kind, Equals, client.ErrorKind(""))
+}

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -312,3 +312,19 @@ var (
 
 	MaxReadBuflen = maxReadBuflen
 )
+
+func MockAspectstateGet(f func(st *state.State, account, bundleName, aspect, field string, value interface{}) error) (restore func()) {
+	old := aspectstateGet
+	aspectstateGet = f
+	return func() {
+		aspectstateGet = old
+	}
+}
+
+func MockAspectstateSet(f func(st *state.State, account, bundleName, aspect, field string, val interface{}) error) (restore func()) {
+	old := aspectstateSet
+	aspectstateSet = f
+	return func() {
+		aspectstateSet = old
+	}
+}

--- a/overlord/aspectstate/aspectstate.go
+++ b/overlord/aspectstate/aspectstate.go
@@ -29,9 +29,6 @@ import (
 // Set finds the aspect identified by the account, bundleName and aspect and sets
 // the specified field to the supplied value.
 func Set(st *state.State, account, bundleName, aspect, field string, value interface{}) error {
-	st.Lock()
-	defer st.Unlock()
-
 	databag, err := getDatabag(st, account, bundleName)
 	if err != nil {
 		if !errors.Is(err, state.ErrNoState) {
@@ -66,9 +63,6 @@ func Set(st *state.State, account, bundleName, aspect, field string, value inter
 // Get finds the aspect identified by the account, bundleName and aspect and
 // returns the specified field's value through the "value" output parameter.
 func Get(st *state.State, account, bundleName, aspect, field string, value interface{}) error {
-	st.Lock()
-	defer st.Unlock()
-
 	databag, err := getDatabag(st, account, bundleName)
 	if err != nil {
 		if errors.Is(err, state.ErrNoState) {

--- a/snap/revision.go
+++ b/snap/revision.go
@@ -85,7 +85,7 @@ func (r *Revision) UnmarshalJSON(data []byte) error {
 	return fmt.Errorf("invalid snap revision: %q", data)
 }
 
-// ParseRevisions returns the representation in r as a revision.
+// ParseRevision returns the representation in r as a revision.
 // See R for a function more suitable for hardcoded revisions.
 func ParseRevision(s string) (Revision, error) {
 	if s == "unset" {

--- a/strutil/strutil.go
+++ b/strutil/strutil.go
@@ -215,7 +215,7 @@ func ParseByteSize(inp string) (int64, error) {
 	return val * mul, nil
 }
 
-// CommaSeparatedList takes a comman-separated series of identifiers,
+// CommaSeparatedList takes a comma-separated series of identifiers,
 // and returns a slice of the space-trimmed identifiers, without empty
 // entries.
 // So " foo ,, bar,baz" -> {"foo", "bar", "baz"}

--- a/tests/main/aspects/task.yaml
+++ b/tests/main/aspects/task.yaml
@@ -1,0 +1,91 @@
+summary: Check the aspects API
+
+# ubuntu-14.04-64's curl doesn't support --unix-socket
+systems: [-ubuntu-14.04-*]
+
+prepare: |
+  snap install test-snapd-curl --edge --devmode
+  snap alias test-snapd-curl.curl curl
+  snap install --edge jq
+
+execute: |
+  calc_expected_change() {
+    local LAST_CHG
+    LAST_CHG=$(snap changes | tail -n 2 | awk '{print $1}')
+    EXPECTED_CHG="$((LAST_CHG + 1))"
+  }
+
+  # write a value
+  calc_expected_change
+  curl -sS --unix-socket /run/snapd.socket localhost/v2/aspects/system/network/wifi-setup -X PUT -d '{"ssid": "canonical"}' > response.txt
+  jq -r '."status-code"' < response.txt | MATCH 202
+  jq -r '."change"' < response.txt | MATCH "$EXPECTED_CHG"
+
+  # read the same value
+  curl -sS --unix-socket /run/snapd.socket localhost/v2/aspects/system/network/wifi-setup?fields=ssid -X GET > response.txt
+  jq -r '."status-code"' < response.txt | MATCH 200
+  jq -r '.result' < response.txt | MATCH "canonical"
+
+  # delete it
+  calc_expected_change
+  curl -sS --unix-socket /run/snapd.socket localhost/v2/aspects/system/network/wifi-setup -X PUT -d '{"ssid": null}' > response.txt
+  jq -r '."status-code"' < response.txt | MATCH 202
+  jq -r '."change"' < response.txt | MATCH "$EXPECTED_CHG"
+
+  # check it was deleted
+  curl -sS --unix-socket /run/snapd.socket localhost/v2/aspects/system/network/wifi-setup?fields=ssid -X GET > response.txt
+  jq -r '."status-code"' < response.txt | MATCH 404
+  jq -r '.result.message' < response.txt | MATCH 'no fields were found'
+
+  # write values using a placeholder access
+  curl -sS --unix-socket /run/snapd.socket localhost/v2/aspects/system/network/wifi-setup -X PUT -d '{"private.my-company": "my-config"}' > response.txt
+  curl -sS --unix-socket /run/snapd.socket localhost/v2/aspects/system/network/wifi-setup -X PUT -d '{"private.your-company": "your-config"}' > response.txt
+
+  # check first value
+  curl -sS --unix-socket /run/snapd.socket localhost/v2/aspects/system/network/wifi-setup?fields=private.my-company -X GET > response.txt
+  jq -r '."status-code"' < response.txt | MATCH 200
+  jq -r '.result' < response.txt | MATCH "my-config"
+
+  # delete it
+  calc_expected_change
+  curl -sS --unix-socket /run/snapd.socket localhost/v2/aspects/system/network/wifi-setup -X PUT -d '{"private.my-company": null}' > response.txt
+  jq -r '."status-code"' < response.txt | MATCH 202
+  jq -r '."change"' < response.txt | MATCH "$EXPECTED_CHG"
+
+  # check it was deleted
+  curl -sS --unix-socket /run/snapd.socket localhost/v2/aspects/system/network/wifi-setup?fields=private.my-company -X GET > response.txt
+  jq -r '."status-code"' < response.txt | MATCH 404
+  jq -r '.result.message' < response.txt | MATCH 'no fields were found'
+
+  # check second value remains
+  curl -sS --unix-socket /run/snapd.socket localhost/v2/aspects/system/network/wifi-setup?fields=private.your-company -X GET > response.txt
+  jq -r '."status-code"' < response.txt | MATCH 200
+  jq -r '.result' < response.txt | MATCH "your-config"
+  curl -sS --unix-socket /run/snapd.socket localhost/v2/aspects/system/network/wifi-setup -X PUT -d '{"private.your-company": null}' > response.txt
+
+  # write a list
+  calc_expected_change
+  curl -sS --unix-socket /run/snapd.socket localhost/v2/aspects/system/network/wifi-setup -X PUT -d '{"ssids": ["one", 2]}' > response.txt
+  jq -r '."status-code"' < response.txt | MATCH 202
+  jq -r '."change"' < response.txt | MATCH "$EXPECTED_CHG"
+
+  # read the same value
+  curl -sS --unix-socket /run/snapd.socket localhost/v2/aspects/system/network/wifi-setup?fields=ssids -X GET > response.txt
+  jq -r '."status-code"' < response.txt | MATCH 200
+  jq -r '.result' < response.txt | MATCH '["one", 2]'
+
+  # check read-only access control works
+  calc_expected_change
+  curl -sS --unix-socket /run/snapd.socket localhost/v2/aspects/system/network/wifi-setup -X PUT -d '{"status": "foo"}' > response.txt
+  jq -r '."status-code"' < response.txt | MATCH 403
+  jq -r '.result.message' < response.txt | MATCH 'cannot write field "status": only supports read access'
+
+  # check write-only access control works
+  calc_expected_change
+  curl -sS --unix-socket /run/snapd.socket localhost/v2/aspects/system/network/wifi-setup -X PUT -d '{"password": "foo"}' > response.txt
+  jq -r '."status-code"' < response.txt | MATCH 202
+  jq -r '."change"' < response.txt | MATCH "$EXPECTED_CHG"
+
+  curl -sS --unix-socket /run/snapd.socket localhost/v2/aspects/system/network/wifi-setup?fields=password -X GET > response.txt
+  jq -r '."status-code"' < response.txt | MATCH 403
+  jq -r '.result.message' < response.txt | MATCH 'cannot read field "password": only supports write access'


### PR DESCRIPTION
Adds a `/v2/aspects` endpoint to the REST API with set, get and unset capabilities. Also adds a spread test (which will probably be re-written at some point, once more of the aspects work has been done).