### PR TITLE
interfaces/builtin: qipc-router: allow abstract sockets with seqpacket

### DIFF
--- a/interfaces/builtin/qualcomm_ipc_router.go
+++ b/interfaces/builtin/qualcomm_ipc_router.go
@@ -51,6 +51,12 @@ network qipcrtr,
 
 # CAP_NET_ADMIN required for port number smaller QRTR_MIN_EPH_SOCKET per 'https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/net/qrtr/qrtr.c'
 capability net_admin,
+
+# Socket for diag-router which is using Linux abstract socket address (@0000...)
+# the server side
+unix (bind, listen, connect, accept, send, receive) type=seqpacket addr="@**",
+# the client side
+unix (connect, send, receive) type=seqpacket addr=none peer=(addr="@**"),
 `
 
 const qipcrtrConnectedPlugSecComp = `

--- a/interfaces/builtin/qualcomm_ipc_router_test.go
+++ b/interfaces/builtin/qualcomm_ipc_router_test.go
@@ -102,6 +102,8 @@ func (s *QrtrInterfaceSuite) TestAppArmorSpec(c *C) {
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "network qipcrtr,\n")
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "capability net_admin,\n")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "unix (bind, listen, connect, accept, send, receive) type=seqpacket addr=\"@**\",\n")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "unix (connect, send, receive) type=seqpacket addr=none peer=(addr=\"@**\"),\n")
 }
 
 func (s *QrtrInterfaceSuite) TestSecCompSpec(c *C) {


### PR DESCRIPTION
The userspace applications are using `@00000...` as address, so we have to allow the address.