### PR TITLE
tests: remove docker tests in ubuntu trusty and update livepatch

### DIFF
--- a/tests/main/canonical-livepatch/task.yaml
+++ b/tests/main/canonical-livepatch/task.yaml
@@ -1,7 +1,7 @@
 summary: Ensure canonical-livepatch snap works
 
 # livepatch works only on LTS amd64 systems
-systems: [ubuntu-14.04-64, ubuntu-16.04-64, ubuntu-18.04-64]
+systems: [ubuntu-14.04-64, ubuntu-16.04-64, ubuntu-18.04-64, ubuntu-20.04-64, ubuntu-22.04-64]
 
 execute: |
     echo "Ensure canonical-livepatch can be installed"

--- a/tests/main/docker-smoke/task.yaml
+++ b/tests/main/docker-smoke/task.yaml
@@ -10,6 +10,11 @@ debug: |
   "$TESTSTOOLS"/journal-state get-log -u snap.docker.dockerd
 
 execute: |
+  # ubuntu trusty is not supported anymore
+  if os.query is-trusty; then
+      exit
+  fi
+
   CHANNEL=latest/stable
   if os.query is-pc-i386; then
       # on i386 only the "base: core18" version is available

--- a/tests/regression/lp-1910456/task.yaml
+++ b/tests/regression/lp-1910456/task.yaml
@@ -1,8 +1,12 @@
 summary: container management snaps should have special systemd unit directives
+
 details: |
     Some special interfaces have additional systemd unit directives added to 
     their systemd units, specifically container management interfaces have the
     Delegate=true snippet added to prevent CVE-2020-27352.
+
+# Docker is not supported anymore in ubuntu 14.04
+systems: [-ubuntu-14.04-64]
 
 prepare: |
     # build and install the strict test snap


### PR DESCRIPTION
Docker is failing frequently in ubuntu 14.04.

trusty is not supported any more for snapd, just livepacth is supported.
