### PR TITLE
interfaces/builtin: fix custom-device default udev kernel rules

### DIFF
--- a/interfaces/builtin/custom_device.go
+++ b/interfaces/builtin/custom_device.go
@@ -157,11 +157,11 @@ func (iface *customDeviceInterface) validateUDevDevicesUniqueBasenames(devices [
 	if len(duplicateBasenames) == 0 {
 		return nil
 	}
-	duplicatesMap := make(map[string][]string, len(duplicateBasenames))
+	var duplicatesOutput []string
 	for _, deviceName := range duplicateBasenames {
-		duplicatesMap[deviceName] = basenames[deviceName]
+		duplicatesOutput = append(duplicatesOutput, fmt.Sprintf(`"%s": ["%s"]`, deviceName, strings.Join(basenames[deviceName], `", "`)))
 	}
-	return fmt.Errorf(`custom-device specified devices have duplicate basenames: %v`, duplicatesMap)
+	return fmt.Errorf(`custom-device specified devices have duplicate basenames: {%s}`, strings.Join(duplicatesOutput, ", "))
 }
 
 func (iface *customDeviceInterface) validateKernelDeviceNameIsBasename(deviceName string) error {

--- a/interfaces/builtin/custom_device.go
+++ b/interfaces/builtin/custom_device.go
@@ -144,7 +144,37 @@ func (iface *customDeviceInterface) validateUDevValueMap(value interface{}) erro
 	return nil
 }
 
+func (iface *customDeviceInterface) validateUDevDevicesUniqueBasenames(devices []string) error {
+	basenames := make(map[string][]string, len(devices))
+	var duplicateBasenames []string
+	for _, devicePath := range devices {
+		deviceName := filepath.Base(devicePath)
+		if len(basenames[deviceName]) == 1 {
+			append(duplicateBasenames, devicePath)
+		}
+		append(basenames[deviceName], devicePath)
+	}
+	if len(duplicateBasenames) == 0 {
+		return nil
+	}
+	duplicatesMap := make(map[string][]string, len(duplicateBasenames))
+	for _, deviceName := range duplicateBasenames {
+		duplicatesMap[deviceName] = basenames[deviceName]
+	}
+	return fmt.Errorf(`custom-device specified devices have duplicate basenames: %v`, duplicatesMap)
+}
+
+func (iface *customDeviceInterface) validateKernelDeviceNameIsBasename(deviceName string) error {
+	if deviceName != filepath.Base(deviceName) {
+		return fmt.Errorf(`kernel device name "%s" must be a basename`, deviceName)
+	}
+	return nil
+}
+
 func (iface *customDeviceInterface) validateUDevTaggingRule(rule map[string]interface{}, devices []string) error {
+	if err := iface.validateUDevDevicesUniqueBasenames(devices); err != nil {
+		return err
+	}
 	hasKernelTag := false
 	for key, value := range rule {
 		var err error
@@ -154,24 +184,25 @@ func (iface *customDeviceInterface) validateUDevTaggingRule(rule map[string]inte
 		case "kernel":
 			hasKernelTag = true
 			err = iface.validateUDevValue(value)
-			if err == nil {
-				deviceName := value.(string)
-				// furthermore, the kernel name must match the basename of one
-				// of the given devices
-				var matches []string
-				for _, devicePath := range devices {
-					if "/dev/"+deviceName == devicePath || deviceName == filepath.Base(devicePath) {
-						matches = append(matches, devicePath)
-					}
+			if err != nil {
+				break
+			}
+			deviceName := value.(string)
+			err = iface.validateKernelDeviceNameIsBasename(deviceName)
+			if err != nil {
+				break
+			}
+			// furthermore, the kernel name must match the basename of one
+			// of the given devices
+			foundMatch := false
+			for _, devicePath := range devices {
+				if deviceName == filepath.Base(devicePath) {
+					foundMatch = true
+					break
 				}
-				switch len(matches) {
-				case 0:
-					err = fmt.Errorf(`%q does not match a specified device`, deviceName)
-				case 1:
-					err = nil
-				default:
-					err = fmt.Errorf(`%q matches more than one specified device: %v`, deviceName, matches)
-				}
+			}
+			if !foundMatch {
+				err = fmt.Errorf(`%q does not match a specified device`, deviceName)
 			}
 		case "attributes", "environment":
 			err = iface.validateUDevValueMap(value)
@@ -375,7 +406,18 @@ func (iface *customDeviceInterface) UDevConnectedPlug(spec *udev.Specification, 
 	// Create a map in which will store udev rules indexed by device name
 	deviceRules := make(map[string]string, len(allDevicePaths))
 
-	// Generate udev rules from the "udev-tagging" attribute
+	// Generate a basic udev rule for each device; we put them into a map
+	// indexed by the device name, so tat we can overwrite the entry later
+	for _, devicePath := range allDevicePaths {
+		if strings.HasPrefix(devicePath, "/dev/") {
+			deviceName := filepath.Base(devicePath)
+			deviceRules[deviceName] = fmt.Sprintf(`KERNEL=="%s"`, deviceName)
+		}
+	}
+
+	// Generate udev rules from the "udev-tagging" attribute; note that these
+	// rules might override the simpler KERNEL=="<device>" rules we computed
+	// above -- that's fine
 	var udevTaggingRules []map[string]interface{}
 	_ = slot.Attr("udev-tagging", &udevTaggingRules)
 	for _, udevTaggingRule := range udevTaggingRules {
@@ -403,29 +445,6 @@ func (iface *customDeviceInterface) UDevConnectedPlug(spec *udev.Specification, 
 		}
 
 		deviceRules[deviceName] = rule.String()
-	}
-
-	// Generate a basic udev rule for each device which was not explicitly
-	// matched by a kernel device name in the "udev-tagging" attribute.
-	// Since each kernel device name matches exactly one device in
-	// allDevicePaths (see: validateUDevTaggingRule), then any device which is
-	// not matched by any kernel device should get a basic KERNEL="<device>"
-	// rule.
-	for _, devicePath := range allDevicePaths {
-		if !strings.HasPrefix(devicePath, "/dev/") {
-			continue
-		}
-		foundMatch := false
-		for deviceName := range deviceRules {
-			if strings.HasSuffix(devicePath, deviceName) {
-				foundMatch = true
-				break
-			}
-		}
-		if !foundMatch {
-			deviceName := devicePath[len("/dev/"):]
-			deviceRules[deviceName] = fmt.Sprintf(`KERNEL=="%s"`, deviceName)
-		}
 	}
 
 	// Now write all the rules

--- a/interfaces/builtin/custom_device.go
+++ b/interfaces/builtin/custom_device.go
@@ -203,7 +203,7 @@ func (iface *customDeviceInterface) validateUDevTaggingRule(rule map[string]inte
 				}
 			}
 			if !foundMatch {
-				err = fmt.Errorf(`%q does not match a specified device`, deviceName)
+				err = fmt.Errorf(`%q does not match any specified device`, deviceName)
 			}
 		case "attributes", "environment":
 			err = iface.validateUDevValueMap(value)

--- a/interfaces/builtin/custom_device.go
+++ b/interfaces/builtin/custom_device.go
@@ -150,9 +150,9 @@ func (iface *customDeviceInterface) validateUDevDevicesUniqueBasenames(devices [
 	for _, devicePath := range devices {
 		deviceName := filepath.Base(devicePath)
 		if len(basenames[deviceName]) == 1 {
-			append(duplicateBasenames, devicePath)
+			duplicateBasenames = append(duplicateBasenames, deviceName)
 		}
-		append(basenames[deviceName], devicePath)
+		basenames[deviceName] = append(basenames[deviceName], devicePath)
 	}
 	if len(duplicateBasenames) == 0 {
 		return nil

--- a/interfaces/builtin/custom_device_test.go
+++ b/interfaces/builtin/custom_device_test.go
@@ -433,7 +433,7 @@ apps:
 				{`KERNEL`: `"event[0-9]"`},
 				{`KERNEL`: `"mice"`},
 				{`KERNEL`: `"js*"`},
-				{`KERNEL`: `"dma_heap/qcom,qseecom"`},
+				{`KERNEL`: `"qcom,qseecom"`},
 			},
 		},
 		{
@@ -442,7 +442,7 @@ apps:
 				{`KERNEL`: `"event[0-9]"`},
 				{`KERNEL`: `"mice"`, `SUBSYSTEM`: `"input"`},
 				{`KERNEL`: `"js*"`},
-				{`KERNEL`: `"dma_heap/qcom,qseecom"`},
+				{`KERNEL`: `"qcom,qseecom"`},
 			},
 		},
 		{
@@ -457,7 +457,7 @@ apps:
 				{`KERNEL`: `"event[0-9]"`},
 				{`KERNEL`: `"mice"`, `SUBSYSTEM`: `"input"`},
 				{`KERNEL`: `"js*"`, `ATTR{attr1}`: `"one"`, `ATTR{attr2}`: `"two"`},
-				{`KERNEL`: `"dma_heap/qcom,qseecom"`},
+				{`KERNEL`: `"qcom,qseecom"`},
 			},
 		},
 		{
@@ -479,23 +479,14 @@ apps:
 				},
 				{`KERNEL`: `"mice"`, `ATTR{wheel}`: `"true"`},
 				{`KERNEL`: `"js*"`},
-				{`KERNEL`: `"dma_heap/qcom,qseecom"`},
-			},
-		},
-		{
-			"udev-tagging:\n   - kernel: dma_heap/qcom,qseecom",
-			[]map[string]string{
-				{`KERNEL`: `"input/event[0-9]"`},
-				{`KERNEL`: `"input/mice"`},
-				{`KERNEL`: `"js*"`},
-				{`KERNEL`: `"dma_heap/qcom,qseecom"`},
+				{`KERNEL`: `"qcom,qseecom"`},
 			},
 		},
 		{
 			"udev-tagging:\n   - kernel: qcom,qseecom",
 			[]map[string]string{
-				{`KERNEL`: `"input/event[0-9]"`},
-				{`KERNEL`: `"input/mice"`},
+				{`KERNEL`: `"event[0-9]"`},
+				{`KERNEL`: `"mice"`},
 				{`KERNEL`: `"js*"`},
 				{`KERNEL`: `"qcom,qseecom"`},
 			},

--- a/interfaces/builtin/custom_device_test.go
+++ b/interfaces/builtin/custom_device_test.go
@@ -75,7 +75,7 @@ slots:
     read:
       - /dev/input/by-id/*
   udev-tagging:
-    - kernel: input/mice
+    - kernel: mice
       subsystem: input
       attributes:
         attr1: one
@@ -309,12 +309,16 @@ apps:
 			`custom-device "udev-tagging" invalid "kernel" tag: "bar" does not match a specified device`,
 		},
 		{
+			"devices: [/dev/subdir/foo]\n  udev-tagging:\n    - kernel: subdir/foo",
+			`custom-device "udev-tagging" invalid "kernel" tag: kernel device name "subdir/foo" must be a basename`,
+		},
+		{
 			"devices: [/dev/subdir/foo]\n  udev-tagging:\n    - kernel: foo\n      subsystem: 12",
 			`custom-device "udev-tagging" invalid "subsystem" tag: value "12" is not a string`,
 		},
 		{
 			"devices: [/dev/dir1/foo, /dev/dir2/foo]\n  udev-tagging:\n    - kernel: foo",
-			`custom-device "udev-tagging" invalid "kernel" tag: "foo" matches more than one specified device: \[/dev/dir1/foo /dev/dir2/foo\]`,
+			`custom-device specified devices have duplicate basenames: {foo:[/dev/dir1/foo /dev/dir2/foo]}`,
 		},
 		{
 			"devices: [/dev/null]\n  udev-tagging:\n    - attributes: foo",
@@ -425,51 +429,51 @@ apps:
 			"", // missing "udev-tagging" attribute
 			[]map[string]string{
 				// all rules are automatically-generated
-				{`KERNEL`: `"input/event[0-9]"`},
-				{`KERNEL`: `"input/mice"`},
+				{`KERNEL`: `"event[0-9]"`},
+				{`KERNEL`: `"mice"`},
 				{`KERNEL`: `"js*"`},
 			},
 		},
 		{
-			"udev-tagging:\n   - kernel: input/mice\n     subsystem: input",
+			"udev-tagging:\n   - kernel: mice\n     subsystem: input",
 			[]map[string]string{
-				{`KERNEL`: `"input/event[0-9]"`},
-				{`KERNEL`: `"input/mice"`, `SUBSYSTEM`: `"input"`},
+				{`KERNEL`: `"event[0-9]"`},
+				{`KERNEL`: `"mice"`, `SUBSYSTEM`: `"input"`},
 				{`KERNEL`: `"js*"`},
 			},
 		},
 		{
 			`udev-tagging:
-   - kernel: input/mice
+   - kernel: mice
      subsystem: input
    - kernel: js*
      attributes:
       attr1: one
       attr2: two`,
 			[]map[string]string{
-				{`KERNEL`: `"input/event[0-9]"`},
-				{`KERNEL`: `"input/mice"`, `SUBSYSTEM`: `"input"`},
+				{`KERNEL`: `"event[0-9]"`},
+				{`KERNEL`: `"mice"`, `SUBSYSTEM`: `"input"`},
 				{`KERNEL`: `"js*"`, `ATTR{attr1}`: `"one"`, `ATTR{attr2}`: `"two"`},
 			},
 		},
 		{
 			`udev-tagging:
-   - kernel: input/mice
+   - kernel: mice
      attributes:
       wheel: "true"
-   - kernel: input/event[0-9]
+   - kernel: event[0-9]
      subsystem: input
      environment:
       env1: first
       env2: second|other`,
 			[]map[string]string{
 				{
-					`KERNEL`:    `"input/event[0-9]"`,
+					`KERNEL`:    `"event[0-9]"`,
 					`SUBSYSTEM`: `"input"`,
 					`ENV{env1}`: `"first"`,
 					`ENV{env2}`: `"second|other"`,
 				},
-				{`KERNEL`: `"input/mice"`, `ATTR{wheel}`: `"true"`},
+				{`KERNEL`: `"mice"`, `ATTR{wheel}`: `"true"`},
 				{`KERNEL`: `"js*"`},
 			},
 		},

--- a/interfaces/builtin/custom_device_test.go
+++ b/interfaces/builtin/custom_device_test.go
@@ -306,7 +306,7 @@ apps:
 		},
 		{
 			"devices: [/dev/null]\n  udev-tagging:\n    - kernel: bar",
-			`custom-device "udev-tagging" invalid "kernel" tag: "bar" does not match a specified device`,
+			`custom-device "udev-tagging" invalid "kernel" tag: "bar" does not match any specified device`,
 		},
 		{
 			"devices: [/dev/subdir/foo]\n  udev-tagging:\n    - kernel: subdir/foo",

--- a/interfaces/builtin/custom_device_test.go
+++ b/interfaces/builtin/custom_device_test.go
@@ -318,7 +318,7 @@ apps:
 		},
 		{
 			"devices: [/dev/dir1/foo, /dev/dir2/foo]\n  udev-tagging:\n    - kernel: foo",
-			`custom-device specified devices have duplicate basenames: {foo:[/dev/dir1/foo /dev/dir2/foo]}`,
+			`custom-device specified devices have duplicate basenames: \{"foo": \["/dev/dir1/foo", "/dev/dir2/foo"\]\}`,
 		},
 		{
 			"devices: [/dev/null]\n  udev-tagging:\n    - attributes: foo",


### PR DESCRIPTION
The KERNEL value in udev rules must be the basename of the device path. For devices for which there is not a matching kernel value specified in the custom-device `udev-tagging` section, a default udev kernel rule is generated.  Previously, https://github.com/snapcore/snapd/pull/12734 (and prior) generated these default rules by using the complete device path relative to `/dev/`.  However, for device paths which are in subdirectories of `/dev/`, this means that the kernel values were not basenames, which violates the udev spec.

This commit changes this behavior to instead generate udev kernel rules using the basename of each specified device.

Since ambiguity would arise if multiple devices had the same basename, this change introduces a check to ensure that all the specified devices have unique basenames.

Additionally, this commit introduces a check to ensure that all specified kernel values in the `udev-tagging` section are basenames.

It is still the case that each specified kernel value must match one of the specified devices.

There are currently problems with `vet` where it is claimed that several of the `[]string` variables in `validateUDevDevicesUniqueBasenames()` are unused.  These variables are used in a several ways, so further investigation is required as to why this is the case.
