### PR TITLE
fde: let systemd-run finish cleaning up service

### DIFF
--- a/kernel/fde/export_test.go
+++ b/kernel/fde/export_test.go
@@ -39,6 +39,14 @@ func MockFdeRevealKeyRuntimeMax(d time.Duration) (restore func()) {
 	}
 }
 
+func MockFdeRevealKeyCleanupMax(d time.Duration) (restore func()) {
+	oldFdeRevealKeyCleanupMax := fdeInitramfsHelperCleanupMax
+	fdeInitramfsHelperCleanupMax = d
+	return func() {
+		fdeInitramfsHelperCleanupMax = oldFdeRevealKeyCleanupMax
+	}
+}
+
 func MockFdeRevealKeyPollWaitParanoiaFactor(n int) (restore func()) {
 	oldFdeRevealKeyPollWaitParanoiaFactor := fdeInitramfsHelperPollWaitParanoiaFactor
 	fdeInitramfsHelperPollWaitParanoiaFactor = n


### PR DESCRIPTION
In Ubuntu Core 20, systemd sometimes hangs if we remove directory containing files for `StandardInput=`, `StandardOutput=`, `StandardError=` before the service created by systemd-run is finished. So we need to query systemd for the service to not be active before we can remove the directory.
