### PR TITLE
github: remove use of `covertool merge` to fix codecov reporting

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -339,15 +339,6 @@ jobs:
         name: coverage-files
         path: .coverage/
 
-    - name: Merge coverage results
-      run: |
-        echo "List the coverage files downloaded"
-        ls -l .coverage/
-
-        echo "Install covertool and merge the results"
-        go install github.com/makholm/covertool@latest
-        covertool merge -o .coverage/all.cov .coverage/coverage*.cov
-
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       # uploading to codecov occasionally fails, so continue running the test
@@ -357,7 +348,7 @@ jobs:
         fail_ci_if_error: true
         flags: unittests
         name: codecov-umbrella
-        files: .coverage/all.cov
+        files: .coverage/coverage-*.cov
         verbose: true
 
   spread:


### PR DESCRIPTION
The codecov reporting was broken for a while and after some slightly painful debugging in PR#12834 it turns out that the use of `covertool merge` seems to break codecov. Using this is not needed as codecov can merge reports natively.

This commit removes the use of `covertool merge` and instead just send the various generated coverage reports to codecov.
