### PR TITLE
interfaces/bool-file: do not fail if path cannot be dereferenced

### DIFF
--- a/interfaces/builtin/bool_file.go
+++ b/interfaces/builtin/bool_file.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -109,7 +110,8 @@ func (iface *boolFileInterface) AppArmorConnectedPlug(spec *apparmor.Specificati
 	// filtering.
 	path, err := iface.dereferencedPath(slot)
 	if err != nil {
-		return fmt.Errorf("cannot compute plug security snippet: %v", err)
+		logger.Noticef("cannot compute plug security snippet: %v", err)
+		return nil
 	}
 	spec.AddSnippet(fmt.Sprintf("%s rwk,", path))
 	return nil

--- a/interfaces/builtin/bool_file_test.go
+++ b/interfaces/builtin/bool_file_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/dbus"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/interfaces/udev"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
@@ -154,10 +155,13 @@ func (s *BoolFileInterfaceSuite) TestPlugSnippetHandlesSymlinkErrors(c *C) {
 	builtin.MockEvalSymlinks(&s.BaseTest, func(path string) (string, error) {
 		return "", fmt.Errorf("broken symbolic link")
 	})
+	loggerBuf, restore := logger.MockLogger()
+	defer restore()
 
 	apparmorSpec := &apparmor.Specification{}
 	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.gpioSlot)
-	c.Assert(err, ErrorMatches, "cannot compute plug security snippet: broken symbolic link")
+	c.Assert(err, IsNil)
+	c.Assert(loggerBuf.String(), testutil.Contains, "cannot compute plug security snippet: broken symbolic link")
 	c.Assert(apparmorSpec.SecurityTags(), HasLen, 0)
 }
 


### PR DESCRIPTION
Do not fail if the path defined for a bool-file slot cannot be dereferenced. The intent is to allow for more flexibility on gadgets that define bool-file slots that might not be in all the devices that are supported by said gadget.