### PR TITLE
opengl: add /usr/share/nvidia

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -115,8 +115,6 @@ var (
 	SnapDeviceSaveDir string
 	SnapDataSaveDir   string
 
-	NvidiaProfilesDir string
-
 	CloudMetaDataFile     string
 	CloudInstanceDataFile string
 
@@ -510,8 +508,6 @@ func SetRootDir(rootdir string) {
 
 	ErrtrackerDbDir = filepath.Join(rootdir, snappyDir, "errtracker.db")
 	SysfsDir = filepath.Join(rootdir, "/sys")
-
-	NvidiaProfilesDir = filepath.Join(rootdir, "/usr/share/nvidia")
 
 	FeaturesDir = FeaturesDirUnder(rootdir)
 

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -115,6 +115,8 @@ var (
 	SnapDeviceSaveDir string
 	SnapDataSaveDir   string
 
+	NvidiaProfilesDir string
+
 	CloudMetaDataFile     string
 	CloudInstanceDataFile string
 
@@ -508,6 +510,8 @@ func SetRootDir(rootdir string) {
 
 	ErrtrackerDbDir = filepath.Join(rootdir, snappyDir, "errtracker.db")
 	SysfsDir = filepath.Join(rootdir, "/sys")
+
+	NvidiaProfilesDir = filepath.Join(rootdir, "/usr/share/nvidia")
 
 	FeaturesDir = FeaturesDirUnder(rootdir)
 

--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -185,7 +185,7 @@ unix (bind,listen) type=seqpacket addr="@cuda-uvmfd-[0-9a-f]*",
 unix (send, receive) type=dgram peer=(addr="@var/run/nvidia-xdriver-*"),
 `
 
-type openGlInterface struct {
+type openglInterface struct {
 	commonInterface
 }
 
@@ -217,7 +217,7 @@ const (
 	nvProfilesDirInMountNs = "/usr/share/nvidia"
 )
 
-func (iface *openGlInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+func (iface *openglInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	spec.AddSnippet(openglConnectedPlugAppArmor)
 
 	// Allow mounting the Nvidia driver profiles directory
@@ -241,7 +241,7 @@ func (iface *openGlInterface) AppArmorConnectedPlug(spec *apparmor.Specification
 	return nil
 }
 
-func (iface *openGlInterface) MountConnectedPlug(spec *mount.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+func (iface *openglInterface) MountConnectedPlug(spec *mount.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// Do nothing if this doesn't exist on the host
 	hostNvProfilesDir := filepath.Join(dirs.GlobalRootDir, nvProfilesDirInHostNs)
 	if !osutil.IsDirectory(hostNvProfilesDir) {
@@ -258,7 +258,7 @@ func (iface *openGlInterface) MountConnectedPlug(spec *mount.Specification, plug
 }
 
 func init() {
-	registerIface(&openGlInterface{
+	registerIface(&openglInterface{
 		commonInterface: commonInterface{
 			name:                 "opengl",
 			summary:              openglSummary,

--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -221,6 +221,12 @@ func (iface *openGlInterface) AppArmorConnectedPlug(spec *apparmor.Specification
   
   `, dirs.NvidiaProfilesDir, dirs.StripRootDir(dirs.NvidiaProfilesDir))
 
+	apparmor.GenWritableProfile(
+		spec.AddUpdateNSf,
+		dirs.StripRootDir(dirs.NvidiaProfilesDir),
+		3,
+	)
+
 	return nil
 }
 

--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -214,7 +214,7 @@ func (iface *openGlInterface) AppArmorConnectedPlug(spec *apparmor.Specification
 		return nil
 	}
 
-	spec.AddUpdateNSf(`  # Read-only access to Nvidia driver profiles in %[2]s
+	spec.AddUpdateNSf(`	# Read-only access to Nvidia driver profiles in %[2]s
 	mount options=(bind) /var/lib/snapd/hostfs%[1]s/ -> %[2]s/,
 	remount options=(bind, ro) %[2]s/,
 	umount %[2]s/,

--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -218,8 +218,7 @@ func (iface *openGlInterface) AppArmorConnectedPlug(spec *apparmor.Specification
 	mount options=(bind) /var/lib/snapd/hostfs%[1]s/ -> %[2]s/,
 	remount options=(bind, ro) %[2]s/,
 	umount %[2]s/,
-  
-  `, dirs.NvidiaProfilesDir, dirs.StripRootDir(dirs.NvidiaProfilesDir))
+`, dirs.NvidiaProfilesDir, dirs.StripRootDir(dirs.NvidiaProfilesDir))
 
 	apparmor.GenWritableProfile(
 		spec.AddUpdateNSf,

--- a/interfaces/builtin/opengl_test.go
+++ b/interfaces/builtin/opengl_test.go
@@ -79,6 +79,10 @@ func (s *OpenglInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
 }
 
+func (s *OpenglInterfaceSuite) TearDownTest(c *C) {
+	dirs.SetRootDir("/")
+}
+
 func (s *OpenglInterfaceSuite) TestAppArmorSpec(c *C) {
 	spec := &apparmor.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)

--- a/interfaces/builtin/opengl_test.go
+++ b/interfaces/builtin/opengl_test.go
@@ -104,12 +104,11 @@ func (s *OpenglInterfaceSuite) TestAppArmorSpec(c *C) {
 	updateNS := spec.UpdateNS()
 
 	// This all gets added as one giant snippet so just testing for the comment fails
-	// We also can't use a multiline raw string for `Sprintf` if we want to use %s,
-	// so easier to concat regular strings
-	c.Check(updateNS, testutil.Contains, fmt.Sprintf("\t# Read-only access to Nvidia driver profiles in /usr/share/nvidia\n"+
-		"\tmount options=(bind) /var/lib/snapd/hostfs%s/usr/share/nvidia/ -> /usr/share/nvidia/,\n"+
-		"\tremount options=(bind, ro) /usr/share/nvidia/,\n"+
-		"\tumount /usr/share/nvidia/,\n", tmpdir))
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf(`	# Read-only access to Nvidia driver profiles in /usr/share/nvidia
+	mount options=(bind) /var/lib/snapd/hostfs%s/usr/share/nvidia/ -> /usr/share/nvidia/,\n"+
+	remount options=(bind, ro) /usr/share/nvidia/,\n"
+	umount /usr/share/nvidia/,
+`, tmpdir))
 }
 
 func (s *OpenglInterfaceSuite) TestUDevSpec(c *C) {

--- a/interfaces/builtin/opengl_test.go
+++ b/interfaces/builtin/opengl_test.go
@@ -170,7 +170,7 @@ func (s *OpenglInterfaceSuite) TestMountSpec(c *C) {
 	c.Assert(entries, HasLen, 1)
 
 	const hostfs = "/var/lib/snapd/hostfs"
-	c.Check(entries[0].Name, Equals, hostfs+dirs.NvidiaProfilesDir)
+	c.Check(entries[0].Name, Equals, filepath.Join(hostfs, tmpdir, "/usr/share/nvidia"))
 	c.Check(entries[0].Dir, Equals, "/usr/share/nvidia")
 	c.Check(entries[0].Options, DeepEquals, []string{"bind", "ro"})
 }

--- a/interfaces/builtin/opengl_test.go
+++ b/interfaces/builtin/opengl_test.go
@@ -93,6 +93,9 @@ func (s *OpenglInterfaceSuite) TestAppArmorSpec(c *C) {
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/usr/share/nvidia/ r,`)
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/usr/share/nvidia/** r,`)
 
+	tmpdir := c.MkDir()
+	dirs.SetRootDir(tmpdir)
+	c.Assert(os.MkdirAll(filepath.Join(tmpdir, "/usr/share/nvidia"), 0777), IsNil)
 	updateNS := spec.UpdateNS()
 
 	// This all gets added as one giant snippet so just testing for the comment fails

--- a/interfaces/builtin/opengl_test.go
+++ b/interfaces/builtin/opengl_test.go
@@ -105,8 +105,8 @@ func (s *OpenglInterfaceSuite) TestAppArmorSpec(c *C) {
 
 	// This all gets added as one giant snippet so just testing for the comment fails
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf(`	# Read-only access to Nvidia driver profiles in /usr/share/nvidia
-	mount options=(bind) /var/lib/snapd/hostfs%s/usr/share/nvidia/ -> /usr/share/nvidia/,\n"+
-	remount options=(bind, ro) /usr/share/nvidia/,\n"
+	mount options=(bind) /var/lib/snapd/hostfs%s/usr/share/nvidia/ -> /usr/share/nvidia/,
+	remount options=(bind, ro) /usr/share/nvidia/,
 	umount /usr/share/nvidia/,
 `, tmpdir))
 }

--- a/tests/main/interfaces-opengl-nvidia/task.yaml
+++ b/tests/main/interfaces-opengl-nvidia/task.yaml
@@ -75,6 +75,11 @@ prepare: |
         echo "canary-32-legacy" >> /usr/lib32/nvidia-123/vdpau/libvdpau_nvidia.so."$NV_VERSION"
     fi
 
+    mkdir -p /usr/share/nvidia/
+    touch /usr/share/nvidia/nvoptix.bin
+    touch /usr/share/nvidia/nvidia-application-profiles-535.54.03-rc
+    touch /usr/share/nvidia/nvidia-application-profiles-535.54.03-key-documentation
+
 restore: |
     umount /sys/module
     rm -rf /usr/share/vulkan
@@ -98,6 +103,7 @@ restore: |
     fi
     rm -rf /usr/lib/nvidia-123
     rm -rf /usr/lib32/nvidia-123
+    rm -rf /usr/share/nvidia
 
 execute: |
     "$TESTSTOOLS"/snaps-state install-local gl-core16
@@ -152,3 +158,8 @@ execute: |
             gl-core20 cat /var/lib/snapd/lib/gl32/libGLX_nvidia.so.0.0.1 | MATCH canary-32-triplet
         fi
     fi
+
+    echo "Can we access nvidia driver profiles in /usr/share/nvidia?"
+    test -r /usr/share/nvidia/nvidia-application-profiles-535.54.03-rc 
+    test -r /usr/share/nvidia/nvidia-application-profiles-535.54.03-documentation
+    test -r /usr/share/nvidia/nvoptix.bin

--- a/tests/main/interfaces-opengl-nvidia/task.yaml
+++ b/tests/main/interfaces-opengl-nvidia/task.yaml
@@ -161,5 +161,5 @@ execute: |
 
     echo "Can we access nvidia driver profiles in /usr/share/nvidia?"
     gl-core16 cat /usr/share/nvidia/nvidia-application-profiles-535.54.03-rc | MATCH rc
-    gl-core16 cat /usr/share/nvidia/nvidia-application-profiles-535.54.03-documentation | MATCH documentation
+    gl-core16 cat /usr/share/nvidia/nvidia-application-profiles-535.54.03-key-documentation | MATCH documentation
     gl-core16 cat /usr/share/nvidia/nvoptix.bin | MATCH nvoptix

--- a/tests/main/interfaces-opengl-nvidia/task.yaml
+++ b/tests/main/interfaces-opengl-nvidia/task.yaml
@@ -76,9 +76,9 @@ prepare: |
     fi
 
     mkdir -p /usr/share/nvidia/
-    touch /usr/share/nvidia/nvoptix.bin
-    touch /usr/share/nvidia/nvidia-application-profiles-535.54.03-rc
-    touch /usr/share/nvidia/nvidia-application-profiles-535.54.03-key-documentation
+    echo "nvoptix" > /usr/share/nvidia/nvoptix.bin
+    echo "rc" > /usr/share/nvidia/nvidia-application-profiles-535.54.03-rc
+    echo "documentation" > /usr/share/nvidia/nvidia-application-profiles-535.54.03-key-documentation
 
 restore: |
     umount /sys/module
@@ -160,6 +160,6 @@ execute: |
     fi
 
     echo "Can we access nvidia driver profiles in /usr/share/nvidia?"
-    test -r /usr/share/nvidia/nvidia-application-profiles-535.54.03-rc 
-    test -r /usr/share/nvidia/nvidia-application-profiles-535.54.03-documentation
-    test -r /usr/share/nvidia/nvoptix.bin
+    gl-core16 cat /usr/share/nvidia/nvidia-application-profiles-535.54.03-rc | MATCH rc
+    gl-core16 cat /usr/share/nvidia/nvidia-application-profiles-535.54.03-documentation | MATCH documentation
+    gl-core16 cat /usr/share/nvidia/nvoptix.bin | MATCH nvoptix

--- a/tests/main/interfaces-opengl-nvidia/task.yaml
+++ b/tests/main/interfaces-opengl-nvidia/task.yaml
@@ -1,5 +1,11 @@
 summary: Ensure that basic opengl works with faked nvidia
 
+details: |
+    The opengl interface provides access to specific device nodes and libraries.
+    Some of the libraries are exposed from the classic host. There is
+    considerable complexity in providing access to nvidia user-space libraries.
+    Depending on the host operating system version the location of the
+    libraries differs.
 systems: [ubuntu-16.04-*, ubuntu-18.04-*, ubuntu-2*]
 
 environment:


### PR DESCRIPTION
This allows access to `/usr/share/nvidia` in the `opengl` plug. Nvidia apparently requests this be available in containers as per discussion in #12794 