### PR TITLE
interfaces/builtin: alphabetized kernel mount options

### DIFF
--- a/interfaces/builtin/mount_control.go
+++ b/interfaces/builtin/mount_control.go
@@ -72,22 +72,22 @@ var allowedKernelMountOptions = []string{
 	"dirsync",
 	"iversion",
 	"lazytime",
-	"noiversion",
-	"nomand",
 	"noatime",
 	"nodev",
 	"nodiratime",
 	"noexec",
+	"noiversion",
 	"nolazytime",
+	"nomand",
 	"norelatime",
-	"nosuid",
 	"nostrictatime",
+	"nosuid",
 	"nouser",
 	"relatime",
-	"strictatime",
-	"sync",
 	"ro",
 	"rw",
+	"strictatime",
+	"sync",
 }
 
 // These mount options are evaluated by mount(8) only and never reach the kernel
@@ -190,8 +190,8 @@ var defaultFSTypes = []string{
 	"udf",
 	"ufs",
 	"vfat",
-	"zfs",
 	"xfs",
+	"zfs",
 }
 
 // The filesystems in the following list were considered either dangerous or

--- a/interfaces/builtin/mount_control_test.go
+++ b/interfaces/builtin/mount_control_test.go
@@ -341,7 +341,7 @@ func (s *MountControlInterfaceSuite) TestAppArmorSpec(c *C) {
 
 	expectedMountLine3 := `mount fstype=(` +
 		`aufs,autofs,btrfs,ext2,ext3,ext4,hfs,iso9660,jfs,msdos,ntfs,ramfs,` +
-		`reiserfs,squashfs,tmpfs,ubifs,udf,ufs,vfat,zfs,xfs` +
+		`reiserfs,squashfs,tmpfs,ubifs,udf,ufs,vfat,xfs,zfs` +
 		`) options=(ro) "/dev/sda{0,1}" -> "/var/snap/consumer/common/**{,/}",`
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, expectedMountLine3)
 	expectedUmountLine3 := `umount "/var/snap/consumer/common/**{,/}",`
@@ -355,7 +355,7 @@ func (s *MountControlInterfaceSuite) TestAppArmorSpec(c *C) {
 
 	expectedMountLine5 := `mount fstype=(` +
 		`aufs,autofs,btrfs,ext2,ext3,ext4,hfs,iso9660,jfs,msdos,ntfs,ramfs,` +
-		`reiserfs,squashfs,tmpfs,ubifs,udf,ufs,vfat,zfs,xfs` +
+		`reiserfs,squashfs,tmpfs,ubifs,udf,ufs,vfat,xfs,zfs` +
 		`) options=(rw) "/dev/sd[abc]" -> "/media/someuser/**{,/}",`
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, expectedMountLine5)
 	expectedUmountLine5 := `umount "/media/someuser/**{,/}",`


### PR DESCRIPTION
This change alphabetizes the supported kernel mount options, as well as moves `zfs` after `xfs` in the list of default filesystems.

Filesystem-specific mount options are not alphabetized, and are instead left in the order they are defined in their documentation or source code in order to ease visual verification of their correctness.
