### PR TITLE
snap-confine: add `tmpfs` mount rule to apparmor profile

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -172,6 +172,7 @@
 
     # boostrapping the mount namespace
     /tmp/snap.rootfs_*/ rw,
+    mount fstype=tmpfs none -> /tmp/snap.rootfs_*/,
     mount options=(rw rshared) -> /,
     mount options=(rw bind) /tmp/snap.rootfs_*/ -> /tmp/snap.rootfs_*/,
     mount options=(rw unbindable) -> /tmp/snap.rootfs_*/,


### PR DESCRIPTION
There is a bugfix to make the mount rules more strict/explicit in apparmor 3.0.10, seehttps://gitlab.com/apparmor/apparmor/-/wikis/Release_Notes_3.0.10 - this affects snapd as it's current profile relies on the implicit behavior. With this commit the missing mount rule is added explicitly. 



--- old description ----

After a fresh boot with the lunar proposed kernel 6.2.0-23.23 with the snapd from `edge/prompting` revision 19342 and 19399 (and the apparmor userspace build from https://gitlab.com/jjohansen/apparmor.git and the "prompt" branch). I cannot produce this with the snapd from "edge" that vendors a slightly older version of apparmor userspace.

I got an error starting snaps:
```
$ firefox
cannot perform operation: mount -t tmpfs /tmp/snap.rootfs_9ftEd8: Permission denied
$ sudo dmesg|tail -n1
[   43.588251] audit: type=1400 audit(1684915677.455:329): apparmor="DENIED" operation="mount" class="mount" info="failed perms check" error=-13 profile="/snap/snapd/19342/usr/lib/snapd/snap-confine" name="/tmp/snap.rootfs_9ftEd8/" pid=4741 comm="snap-confine" fstype="tmpfs" srcname="none"
```

Looking at the apparmor profiles we generate for `snap-confine` I could indeed not find a rule that allows snap-confine to mount the scratch dir that should be needed in `mount-support.c:sc_bootstrap_mount_namespace()`.

The relevant code looks like this:
```
	sc_do_mount("none", scratch_dir, NULL, MS_UNBINDABLE, NULL);
	if (config->normal_mode) {
		sc_initialize_ns_fstab(config->snap_instance);
		// Create a tmpfs on scratch_dir; we'll them mount all the root
		// directories of the base snap onto it.
		sc_do_mount("none", scratch_dir, "tmpfs", 0, NULL);
		sc_replicate_base_rootfs(scratch_dir, config->rootfs_dir, config->mounts);
```
and indeed `strace` confirms this mount is taking place:
```
[pid 15281] mount("none", "/tmp/snap.rootfs_w5Tw1R", "tmpfs", 0, NULL) = -1 EACCES (Permission denied)
```

Manually adding the following rule to the `snap-confine` profile:
```
    mount fstype=tmpfs none -> /tmp/snap.rootfs_*/,
```
and
```
$ sudo apparmor_parser -r /var/lib/snapd/apparmor/profiles/snap-confine.snapd.19342
```
made snaps work again.

This is puzzling because AFAICT the rule is really missing and the mount should be denied but it's only denied with the vendored userapce from the `edge/prompting` snap (and also not always!).
