### PR TITLE
interfaces: add pcscd interface

### DIFF
--- a/interfaces/builtin/pcscd.go
+++ b/interfaces/builtin/pcscd.go
@@ -1,0 +1,46 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+const pcscdSummary = `allows interacting with PCSD daemon
+(e.g. for the PS/SC API library).`
+
+const pcscdBaseDeclarationSlots = `
+  pcscd:
+    allow-installation:
+      slot-snap-type:
+        - core
+    deny-auto-connection: true
+`
+
+const pcscdConnectedPlugAppArmor = `
+# Socket for communication between PCSCD and PS/SC API library
+/{var/,}run/pcscd/pcscd.comm rw,
+`
+
+func init() {
+	registerIface(&commonInterface{
+		name:                  "pcscd",
+		summary:               pcscdSummary,
+		implicitOnClassic:     true,
+		baseDeclarationSlots:  pcscdBaseDeclarationSlots,
+		connectedPlugAppArmor: pcscdConnectedPlugAppArmor,
+	})
+}

--- a/interfaces/builtin/pcscd_test.go
+++ b/interfaces/builtin/pcscd_test.go
@@ -1,0 +1,94 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type pcscdInterfaceSuite struct {
+	iface    interfaces.Interface
+	slotInfo *snap.SlotInfo
+	slot     *interfaces.ConnectedSlot
+	plugInfo *snap.PlugInfo
+	plug     *interfaces.ConnectedPlug
+}
+
+var _ = Suite(&pcscdInterfaceSuite{
+	iface: builtin.MustInterface("pcscd"),
+})
+
+func (s *pcscdInterfaceSuite) SetUpTest(c *C) {
+	var mockPlugSnapInfoYaml = `name: other
+version: 1.0
+apps:
+ app:
+  command: foo
+  plugs: [pcscd]
+`
+	s.slotInfo = &snap.SlotInfo{
+		Snap:      &snap.Info{SuggestedName: "core", SnapType: snap.TypeOS},
+		Name:      "pcscd",
+		Interface: "pcscd",
+	}
+	s.slot = interfaces.NewConnectedSlot(s.slotInfo, nil, nil)
+	snapInfo := snaptest.MockInfo(c, mockPlugSnapInfoYaml, nil)
+	s.plugInfo = snapInfo.Plugs["pcscd"]
+	s.plug = interfaces.NewConnectedPlug(s.plugInfo, nil, nil)
+}
+
+func (s *pcscdInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "pcscd")
+}
+
+func (s *pcscdInterfaceSuite) TestSanitizeSlot(c *C) {
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.slotInfo), IsNil)
+}
+
+func (s *pcscdInterfaceSuite) TestSanitizePlug(c *C) {
+	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
+}
+
+func (s *pcscdInterfaceSuite) TestAppArmorSpec(c *C) {
+	spec := &apparmor.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
+	c.Assert(spec.SnippetForTag("snap.other.app"), testutil.Contains, "/{var/,}run/pcscd/pcscd.comm rw")
+}
+
+func (s *pcscdInterfaceSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}
+
+func (s *pcscdInterfaceSuite) TestStaticInfo(c *C) {
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Assert(si.ImplicitOnCore, Equals, false)
+	c.Assert(si.ImplicitOnClassic, Equals, true)
+	c.Assert(si.Summary, Equals, `allows interacting with PCSD daemon
+(e.g. for the PS/SC API library).`)
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "pcscd")
+}

--- a/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
@@ -353,6 +353,9 @@ apps:
   password-manager-service:
     command: bin/run
     plugs: [ password-manager-service ]
+  pcscd:
+    command: bin/run
+    plugs: [ pcscd ]
   physical-memory-control:
     command: bin/run
     plugs: [ physical-memory-control ]


### PR DESCRIPTION
To access smart cards under a snapped program ([bug 1843392][1]), we need to allow it to communicate with the reader drivers via the pcscd socket.

This has already been discussed with the security team as the comment #1 in the linked bug report describes.

To create this interface I simply copied jack1.go and changed the appropriate parts.

[1]: https://bugs.launchpad.net/ubuntu/+source/firefox/+bug/1843392