### PR TITLE
packagekit: allow dbus activation from snapped apps

### DIFF
--- a/interfaces/builtin/packagekit_control.go
+++ b/interfaces/builtin/packagekit_control.go
@@ -19,6 +19,14 @@
 
 package builtin
 
+import (
+	"strings"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/snap"
+)
+
 const packageKitControlSummary = `allows control of the PackageKit service`
 
 const packageKitControlBaseDeclarationPlugs = `
@@ -46,30 +54,34 @@ dbus (receive, send)
         bus=system
         path=/org/freedesktop/PackageKit
         interface=org.freedesktop.PackageKit
-        peer=(label=unconfined),
+        peer=(label=###SLOT_SECURITY_TAGS###),
 dbus (receive, send)
         bus=system
         path=/org/freedesktop/PackageKit
         interface=org.freedesktop.PackageKit.Offline
-        peer=(label=unconfined),
+        peer=(label=###SLOT_SECURITY_TAGS###),
+
+# Read all properties from PackageKit
+# do not use peer=(label=unconfined) here since this is DBus activated
 dbus (send)
         bus=system
         path=/org/freedesktop/PackageKit
         interface=org.freedesktop.DBus.Properties
-        member=Get{,All}
-        peer=(label=unconfined),
+        member=Get{,All},
 dbus (receive)
         bus=system
         path=/org/freedesktop/PackageKit
         interface=org.freedesktop.DBus.Properties
         member=PropertiesChanged
-        peer=(label=unconfined),
+        peer=(label=###SLOT_SECURITY_TAGS###),
+
+# Allow clients to introspect the service
+# do not use peer=(label=unconfined) here since this is DBus activated
 dbus (send)
 	bus=system
 	path=/org/freedesktop/PackageKit
 	interface=org.freedesktop.DBus.Introspectable
-	member=Introspect
-	peer=(label=unconfined),
+	member=Introspect,
 
 # Allow communication with PackageKit transactions.  Transactions are
 # exported with random object paths that currently take the form
@@ -100,13 +112,39 @@ dbus (send)
 	peer=(label=unconfined),
 `
 
+type packageKitInterface struct{}
+
+func (iface *packageKitInterface) Name() string {
+	return "packagekit-control"
+}
+
+func (iface *packageKitInterface) StaticInfo() interfaces.StaticInfo {
+	return interfaces.StaticInfo{
+		Summary:              packageKitControlSummary,
+		ImplicitOnCore:       false, // Maybe... osutil.IsExecutable("/usr/libexec/packagekitd"), ?
+		ImplicitOnClassic:    true,
+		BaseDeclarationPlugs: packageKitControlBaseDeclarationPlugs,
+		BaseDeclarationSlots: packageKitControlBaseDeclarationSlots,
+	}
+}
+
+func (iface *packageKitInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	old := "###SLOT_SECURITY_TAGS###"
+	new := slotAppLabelExpr(slot)
+	if implicitSystemConnectedSlot(slot) {
+		// Let confined apps access unconfined packagekit on classic
+		new = "unconfined"
+	}
+	snippet := strings.Replace(packageKitControlConnectedPlugAppArmor, old, new, -1)
+	spec.AddSnippet(snippet)
+	return nil
+}
+
+func (iface *packageKitInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
+	// allow what declarations allowed
+	return true
+}
+
 func init() {
-	registerIface(&commonInterface{
-		name:                  "packagekit-control",
-		summary:               packageKitControlSummary,
-		implicitOnClassic:     true,
-		baseDeclarationPlugs:  packageKitControlBaseDeclarationPlugs,
-		baseDeclarationSlots:  packageKitControlBaseDeclarationSlots,
-		connectedPlugAppArmor: packageKitControlConnectedPlugAppArmor,
-	})
+	registerIface(&packageKitInterface{})
 }


### PR DESCRIPTION
Currently, a snapped application with the "packagekit-control" plug connected (like snap-store/ubuntu-software), can access the packagekit daemon through DBus without problem... as long as the daemon is already running. If it isn't running, DBus activation won't work for a snapped application.

A way of checking this is by launching a shell inside the snap- store snap

    snap run --shell snap-store

and do a DBus call, like

    dbus-send --system --print-reply --dest=org.freedesktop.PackageKit /org/freedesktop/PackageKit org.freedesktop.DBus.Properties.GetAll string:"org.freedesktop.PackageKit"

If packagekitd is running, this call will succeed, but if it's not running, it will fail.

This problem was detected by the people of the new snap-store. Currently they use a trick to ensure that packagekitd is launched, that consists on:

    dbus-send --system --print-reply --dest=org.freedesktop.DBus /org/freedesktop/DBus org.freedesktop.DBus.StartServiceByName string:org.freedesktop.PackageKit uint32:0

This PR fixes this, although it needs security review.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
