### PR TITLE
timeutil: fix tests to run in non-UTC timezones

### DIFF
--- a/timeutil/schedule_test.go
+++ b/timeutil/schedule_test.go
@@ -517,7 +517,7 @@ func (ts *timeutilSuite) TestScheduleNext(c *C) {
 	local, _ := time.LoadLocation("UTC")
 	time.Local = local
 	defer func() {
-	    time.Local = oldLocal
+		time.Local = oldLocal
 	}()
 
 	for _, t := range []struct {

--- a/timeutil/schedule_test.go
+++ b/timeutil/schedule_test.go
@@ -508,6 +508,15 @@ func (ts *timeutilSuite) TestParseSchedule(c *C) {
 func (ts *timeutilSuite) TestScheduleNext(c *C) {
 	const shortForm = "2006-01-02 15:04"
 
+	// force timezone for tests to UTC otherwise if run in a
+	// different timezone where there was a daylight savings
+	// transition across one of the intervals (ie in Australia in
+	// 2019 DST started on 6th October) then the result will be
+	// different and the test will fail
+	oldlocal := time.Local
+	local, _ := time.LoadLocation("UTC")
+	time.Local = local
+
 	for _, t := range []struct {
 		schedule   string
 		last       string
@@ -827,6 +836,7 @@ func (ts *timeutilSuite) TestScheduleNext(c *C) {
 			previous = next
 		}
 	}
+	time.Local = oldlocal
 }
 
 func (ts *timeutilSuite) TestScheduleIncludes(c *C) {

--- a/timeutil/schedule_test.go
+++ b/timeutil/schedule_test.go
@@ -513,9 +513,12 @@ func (ts *timeutilSuite) TestScheduleNext(c *C) {
 	// transition across one of the intervals (ie in Australia in
 	// 2019 DST started on 6th October) then the result will be
 	// different and the test will fail
-	oldlocal := time.Local
+	oldLocal := time.Local
 	local, _ := time.LoadLocation("UTC")
 	time.Local = local
+	defer func() {
+	    time.Local = oldLocal
+	}()
 
 	for _, t := range []struct {
 		schedule   string
@@ -836,7 +839,6 @@ func (ts *timeutilSuite) TestScheduleNext(c *C) {
 			previous = next
 		}
 	}
-	time.Local = oldlocal
 }
 
 func (ts *timeutilSuite) TestScheduleIncludes(c *C) {


### PR DESCRIPTION
TestParseSchedule() has always failed for me - unless I set TZ=UTC before running go test, since one of the tested time intervals encompasses a daylight savings time transition here in my local timezone and so the result is different in this case. Consequently, since this test always fails, building the snapd deb or snap also fails for me locally. Fix this by forcing golang to use the UTC timezone when running these tests, regardless of how they were invoked.
