### PR TITLE
interfaces/account-control: grant access to the files and executables…

### DIFF
--- a/interfaces/builtin/account_control.go
+++ b/interfaces/builtin/account_control.go
@@ -58,6 +58,13 @@ const accountControlConnectedPlugAppArmor = `
 # Needed by chpasswd
 /{,usr/}lib/@{multiarch}/security/* ixr,
 
+# Needed by Linux PAM
+/{,usr/}sbin/pam_extrausers_chkpwd ixr,
+/{,usr/}sbin/unix_chkpwd ixr,
+/{,usr/}lib/core/lockout-not-enabled.sh ixr,
+/etc/security/faillock.conf r,
+/etc/shadow r,
+
 # Useradd needs netlink
 network netlink raw,
 


### PR DESCRIPTION
Hi,

core22 snap enables `pam_faillock` by default and therefore while using it, the developers face the following denials;

```
audit: type=1400 audit(1683639151.460:3331): apparmor="DENIED" operation="exec" profile="snap-name" name="/usr/lib/core/lockout-not-enabled.sh" pid=52701 comm="wasp" requested_mask="x" denied_mask="x" fsuid=0 ouid=0
audit: type=1400 audit(1683639151.460:3332): apparmor="DENIED" operation="open" profile="snap-name" name="/etc/security/faillock.conf" pid=25489 comm="wasp" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
audit: type=1400 audit(1683639151.460:3333): apparmor="DENIED" operation="exec" profile="snap-name" name="/usr/sbin/pam_extrausers_chkpwd" pid=52701 comm="wasp" requested_mask="x" denied_mask="x" fsuid=0 ouid=0
audit: type=1400 audit(1683639151.460:3334): apparmor="DENIED" operation="exec" profile="snap-name" name="/usr/sbin/unix_chkpwd" pid=52701 comm="wasp" requested_mask="x" denied_mask="x" fsuid=0 ouid=0
audit: type=1400 audit(1683639151.460:3335): apparmor="DENIED" operation="open" profile="snap-name" name="/etc/shadow" pid=25489 comm="wasp" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
```
The proposed changes address these denials.

Thanks,
Bugra
