### PR TITLE
interfaces/shutdown: fix reboot and shutdown in core desktop

### DIFF
--- a/interfaces/builtin/shutdown.go
+++ b/interfaces/builtin/shutdown.go
@@ -45,7 +45,7 @@ dbus (send)
     bus=system
     path=/org/freedesktop/login1
     interface=org.freedesktop.login1.Manager
-    member={PowerOff,Reboot,Suspend,Hibernate,HybridSleep,CanPowerOff,CanReboot,CanSuspend,CanHibernate,CanHybridSleep,ScheduleShutdown,CancelScheduledShutdown,SetWallMessage}
+    member={Inhibit,PowerOff,Reboot,Suspend,Hibernate,HybridSleep,CanPowerOff,CanReboot,CanSuspend,CanHibernate,CanHybridSleep,ScheduleShutdown,CancelScheduledShutdown,SetWallMessage}
     peer=(label=unconfined),
 
 # Allow clients to introspect


### PR DESCRIPTION
Core Desktop needs access to the Inhibit member to be able to reboot or shutdown the system from a Gnome Shell session.

This patch fixes this.
