### PR TITLE
interfaces/upower-observe: allow it in core-desktop

### DIFF
--- a/interfaces/builtin/upower_observe.go
+++ b/interfaces/builtin/upower_observe.go
@@ -38,8 +38,6 @@ const upowerObserveBaseDeclarationSlots = `
       slot-snap-type:
         - app
         - core
-    deny-connection:
-      on-classic: false
 `
 
 const upowerObservePermanentSlotAppArmor = `

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -1076,7 +1076,6 @@ func (s *baseDeclSuite) TestConnectionOnClassic(c *C) {
 		"network-manager": true,
 		"ofono":           true,
 		"pulseaudio":      true,
-		"upower-observe":  true,
 	}
 
 	for _, onClassic := range []bool{true, false} {


### PR DESCRIPTION
This change is required to allow ubuntu-desktop-session and other snaps to connect to upower-observe in core-desktop.

