### PR TITLE
interfaces/audio: remove write permissions in pulse folder

### DIFF
--- a/interfaces/builtin/audio_playback.go
+++ b/interfaces/builtin/audio_playback.go
@@ -73,7 +73,7 @@ const audioPlaybackConnectedPlugAppArmorDesktop = `
 /etc/pulse/** r,
 owner @{HOME}/.pulse-cookie rk,
 owner @{HOME}/.config/pulse/cookie rk,
-owner /{,var/}run/user/*/pulse/ rk,
+owner /{,var/}run/user/*/pulse/ r,
 owner /{,var/}run/user/*/pulse/native rwk,
 owner /{,var/}run/user/*/pulse/pid r,
 `
@@ -106,7 +106,6 @@ owner /{,var/}run/pulse/** rwk,
 # Shared memory based communication with clients
 /{run,dev}/shm/pulse-shm-* mrwk,
 
-owner /run/pulse/native/ rk,
 owner /run/user/[0-9]*/ r,
 owner /run/user/[0-9]*/pulse/ rw,
 `

--- a/interfaces/builtin/audio_playback.go
+++ b/interfaces/builtin/audio_playback.go
@@ -58,7 +58,7 @@ owner /{,var/}run/pulse/ r,
 owner /{,var/}run/pulse/native rwk,
 owner /{,var/}run/pulse/pid r,
 owner /{,var/}run/user/[0-9]*/ r,
-owner /{,var/}run/user/[0-9]*/pulse/ rw,
+owner /{,var/}run/user/[0-9]*/pulse/ r,
 
 /run/udev/data/c116:[0-9]* r,
 /run/udev/data/+sound:card[0-9]* r,
@@ -73,7 +73,7 @@ const audioPlaybackConnectedPlugAppArmorDesktop = `
 /etc/pulse/** r,
 owner @{HOME}/.pulse-cookie rk,
 owner @{HOME}/.config/pulse/cookie rk,
-owner /{,var/}run/user/*/pulse/ rwk,
+owner /{,var/}run/user/*/pulse/ rk,
 owner /{,var/}run/user/*/pulse/native rwk,
 owner /{,var/}run/user/*/pulse/pid r,
 `
@@ -106,7 +106,7 @@ owner /{,var/}run/pulse/** rwk,
 # Shared memory based communication with clients
 /{run,dev}/shm/pulse-shm-* mrwk,
 
-owner /run/pulse/native/ rwk,
+owner /run/pulse/native/ rk,
 owner /run/user/[0-9]*/ r,
 owner /run/user/[0-9]*/pulse/ rw,
 `

--- a/interfaces/builtin/pulseaudio.go
+++ b/interfaces/builtin/pulseaudio.go
@@ -64,7 +64,7 @@ const pulseaudioConnectedPlugAppArmorDesktop = `
 /etc/pulse/** r,
 owner @{HOME}/.pulse-cookie rk,
 owner @{HOME}/.config/pulse/cookie rk,
-owner /{,var/}run/user/*/pulse/ rk,
+owner /{,var/}run/user/*/pulse/ r,
 owner /{,var/}run/user/*/pulse/native rwk,
 owner /{,var/}run/user/*/pulse/pid r,
 `
@@ -111,7 +111,6 @@ owner /{,var/}run/pulse/** rwk,
 
 /usr/share/applications/ r,
 
-owner /run/pulse/native/ rwk,
 owner /run/user/[0-9]*/ r,
 owner /run/user/[0-9]*/pulse/ rw,
 `

--- a/interfaces/builtin/pulseaudio.go
+++ b/interfaces/builtin/pulseaudio.go
@@ -50,7 +50,7 @@ owner /{,var/}run/pulse/ r,
 owner /{,var/}run/pulse/native rwk,
 owner /{,var/}run/pulse/pid r,
 owner /{,var/}run/user/[0-9]*/ r,
-owner /{,var/}run/user/[0-9]*/pulse/ rw,
+owner /{,var/}run/user/[0-9]*/pulse/ r,
 
 /run/udev/data/c116:[0-9]* r,
 /run/udev/data/+sound:card[0-9]* r,
@@ -64,7 +64,7 @@ const pulseaudioConnectedPlugAppArmorDesktop = `
 /etc/pulse/** r,
 owner @{HOME}/.pulse-cookie rk,
 owner @{HOME}/.config/pulse/cookie rk,
-owner /{,var/}run/user/*/pulse/ rwk,
+owner /{,var/}run/user/*/pulse/ rk,
 owner /{,var/}run/user/*/pulse/native rwk,
 owner /{,var/}run/user/*/pulse/pid r,
 `


### PR DESCRIPTION
Currently, any application that connects to the audio-playback or the pulseaudio interfaces, have write permissions to the pulse/ folder. This means that a snapped malicious application would be able to delete the socket and put its own, being able to read the audio of any other snapped application.

This patch removes those permissions.

