### PR TITLE
interfaces/audio: allow to provide pipewire/pulse slots from a containerized pipewire/desktop

### DIFF
--- a/interfaces/builtin/audio_playback.go
+++ b/interfaces/builtin/audio_playback.go
@@ -123,8 +123,8 @@ const audioPlaybackPermanentSlotAppArmorCore = `
 # This allows to share screen in Core Desktop
 owner /run/user/[0-9]*/pipewire-[0-9] rwk,
 
-# This allows to read the wireplumber configuration if
-# pipewire runs inside the container
+# This allows wireplumber to read the pulseaudio
+# configuration if pipewire runs inside a container
 /etc/pulse/ r,
 /etc/pulse/** r,
 `

--- a/interfaces/builtin/audio_playback.go
+++ b/interfaces/builtin/audio_playback.go
@@ -117,9 +117,7 @@ owner /{,var/}run/pulse/** rwk,
 owner /run/pulse/native/ rwk,
 owner /run/user/[0-9]*/ r,
 owner /run/user/[0-9]*/pulse/ rw,
-`
 
-const audioPlaybackPermanentSlotAppArmorCore = `
 # This allows to share screen in Core Desktop
 owner /run/user/[0-9]*/pipewire-[0-9] rwk,
 
@@ -183,10 +181,6 @@ func (iface *audioPlaybackInterface) UDevPermanentSlot(spec *udev.Specification,
 
 func (iface *audioPlaybackInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *snap.SlotInfo) error {
 	spec.AddSnippet(audioPlaybackPermanentSlotAppArmor)
-	if !implicitSystemPermanentSlot(slot) {
-		// This allows to share screen in Core Desktop
-		spec.AddSnippet(audioPlaybackPermanentSlotAppArmorCore)
-	}
 	return nil
 }
 

--- a/interfaces/builtin/audio_playback.go
+++ b/interfaces/builtin/audio_playback.go
@@ -156,7 +156,6 @@ func (iface *audioPlaybackInterface) StaticInfo() interfaces.StaticInfo {
 	return interfaces.StaticInfo{
 		Summary:              audioPlaybackSummary,
 		ImplicitOnClassic:    true,
-		ImplicitOnCore:       false,
 		BaseDeclarationSlots: audioPlaybackBaseDeclarationSlots,
 	}
 }

--- a/interfaces/builtin/audio_playback.go
+++ b/interfaces/builtin/audio_playback.go
@@ -81,9 +81,9 @@ owner /{,var/}run/user/*/pulse/pid r,
 `
 
 const audioPlaybackConnectedPlugAppArmorCore = `
-owner /run/user/[0-9]*/###PLUG_SECURITY_TAGS###/pulse/ r,
-owner /run/user/[0-9]*/###PLUG_SECURITY_TAGS###/pulse/native rwk,
-owner /run/user/[0-9]*/###PLUG_SECURITY_TAGS###/pulse/pid r,
+owner /run/user/[0-9]*/###SLOT_SECURITY_TAGS###/pulse/ r,
+owner /run/user/[0-9]*/###SLOT_SECURITY_TAGS###/pulse/native rwk,
+owner /run/user/[0-9]*/###SLOT_SECURITY_TAGS###/pulse/pid r,
 `
 
 const audioPlaybackConnectedPlugSecComp = `
@@ -167,7 +167,7 @@ func (iface *audioPlaybackInterface) AppArmorConnectedPlug(spec *apparmor.Specif
 		spec.AddSnippet(audioPlaybackConnectedPlugAppArmorDesktop)
 	}
 	if !implicitSystemConnectedSlot(slot) {
-		old := "###PLUG_SECURITY_TAGS###"
+		old := "###SLOT_SECURITY_TAGS###"
 		new := "snap." + slot.Snap().InstanceName() // forms the snap-instance-specific subdirectory name of /run/user/*/ used for XDG_RUNTIME_DIR
 		snippet := strings.Replace(audioPlaybackConnectedPlugAppArmorCore, old, new, -1)
 		spec.AddSnippet(snippet)

--- a/interfaces/builtin/audio_playback_test.go
+++ b/interfaces/builtin/audio_playback_test.go
@@ -136,6 +136,10 @@ func (s *AudioPlaybackInterfaceSuite) TestSecCompOnClassic(c *C) {
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "shmctl\n")
 
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), Not(testutil.Contains), "owner /run/user/[0-9]*/snap.audio-playback/pulse/ r,\n")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), Not(testutil.Contains), "owner /run/user/[0-9]*/snap.audio-playback/pulse/native rwk,\n")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), Not(testutil.Contains), "owner /run/user/[0-9]*/snap.audio-playback/pulse/pid r,\n")
+
 	// connected classic slot to plug
 	spec = &seccomp.Specification{}
 	c.Assert(spec.AddConnectedSlot(s.iface, s.plug, s.classicSlot), IsNil)
@@ -145,6 +149,10 @@ func (s *AudioPlaybackInterfaceSuite) TestSecCompOnClassic(c *C) {
 	spec = &seccomp.Specification{}
 	c.Assert(spec.AddPermanentSlot(s.iface, s.classicSlotInfo), IsNil)
 	c.Assert(spec.SecurityTags(), HasLen, 0)
+
+	c.Assert(spec.SnippetForTag("snap.audio-playback.app1"), Not(testutil.Contains), "owner /run/user/[0-9]*/pipewire-[0-9] rwk,\n")
+	c.Check(spec.SnippetForTag("snap.audio-playback.app1"), Not(testutil.Contains), "/etc/pulse/ r,\n")
+	c.Check(spec.SnippetForTag("snap.audio-playback.app1"), Not(testutil.Contains), "/etc/pulse/** r,\n")
 }
 
 func (s *AudioPlaybackInterfaceSuite) TestAppArmor(c *C) {
@@ -156,6 +164,9 @@ func (s *AudioPlaybackInterfaceSuite) TestAppArmor(c *C) {
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.coreSlot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/{run,dev}/shm/pulse-shm-* mrwk,\n")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "owner /run/user/[0-9]*/snap.audio-playback/pulse/ r,\n")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "owner /run/user/[0-9]*/snap.audio-playback/pulse/native rwk,\n")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "owner /run/user/[0-9]*/snap.audio-playback/pulse/pid r,\n")
 
 	// connected core slot to plug
 	spec = &apparmor.Specification{}
@@ -167,6 +178,9 @@ func (s *AudioPlaybackInterfaceSuite) TestAppArmor(c *C) {
 	c.Assert(spec.AddPermanentSlot(s.iface, s.coreSlotInfo), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.audio-playback.app1"})
 	c.Check(spec.SnippetForTag("snap.audio-playback.app1"), testutil.Contains, "capability setuid,\n")
+	c.Assert(spec.SnippetForTag("snap.audio-playback.app1"), testutil.Contains, "owner /run/user/[0-9]*/pipewire-[0-9] rwk,\n")
+	c.Check(spec.SnippetForTag("snap.audio-playback.app1"), testutil.Contains, "/etc/pulse/ r,\n")
+	c.Check(spec.SnippetForTag("snap.audio-playback.app1"), testutil.Contains, "/etc/pulse/** r,\n")
 }
 
 func (s *AudioPlaybackInterfaceSuite) TestAppArmorOnClassic(c *C) {

--- a/interfaces/builtin/audio_record.go
+++ b/interfaces/builtin/audio_record.go
@@ -64,6 +64,7 @@ func (iface *audioRecordInterface) StaticInfo() interfaces.StaticInfo {
 	return interfaces.StaticInfo{
 		Summary:              audioRecordSummary,
 		ImplicitOnClassic:    true,
+		ImplicitOnCore:       false,
 		BaseDeclarationSlots: audioRecordBaseDeclarationSlots,
 	}
 }

--- a/interfaces/builtin/audio_record.go
+++ b/interfaces/builtin/audio_record.go
@@ -64,7 +64,6 @@ func (iface *audioRecordInterface) StaticInfo() interfaces.StaticInfo {
 	return interfaces.StaticInfo{
 		Summary:              audioRecordSummary,
 		ImplicitOnClassic:    true,
-		ImplicitOnCore:       false,
 		BaseDeclarationSlots: audioRecordBaseDeclarationSlots,
 	}
 }

--- a/interfaces/builtin/pulseaudio.go
+++ b/interfaces/builtin/pulseaudio.go
@@ -20,6 +20,8 @@
 package builtin
 
 import (
+	"strings"
+
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/seccomp"
@@ -67,6 +69,12 @@ owner @{HOME}/.config/pulse/cookie rk,
 owner /{,var/}run/user/*/pulse/ rwk,
 owner /{,var/}run/user/*/pulse/native rwk,
 owner /{,var/}run/user/*/pulse/pid r,
+`
+
+const pulseaudioConnectedPlugAppArmorCore = `
+owner /run/user/[0-9]*/###PLUG_SECURITY_TAGS###/pulse/ r,
+owner /run/user/[0-9]*/###PLUG_SECURITY_TAGS###/pulse/native rwk,
+owner /run/user/[0-9]*/###PLUG_SECURITY_TAGS###/pulse/pid r,
 `
 
 const pulseaudioConnectedPlugSecComp = `
@@ -151,6 +159,12 @@ func (iface *pulseAudioInterface) AppArmorConnectedPlug(spec *apparmor.Specifica
 	spec.AddSnippet(pulseaudioConnectedPlugAppArmor)
 	if release.OnClassic {
 		spec.AddSnippet(pulseaudioConnectedPlugAppArmorDesktop)
+	}
+	if !implicitSystemConnectedSlot(slot) {
+		old := "###PLUG_SECURITY_TAGS###"
+		new := "snap." + slot.Snap().InstanceName() // forms the snap-instance-specific subdirectory name of /run/user/*/ used for XDG_RUNTIME_DIR
+		snippet := strings.Replace(pulseaudioConnectedPlugAppArmorCore, old, new, -1)
+		spec.AddSnippet(snippet)
 	}
 	return nil
 }


### PR DESCRIPTION
This PR ports UDENG-418 to upstream. It enables audio and screen sharing in core Desktop. To do so, it allows access to pulse sockets provided by an app and it allows access to the pipewire socket from snapped applications that implement the _audio_playback_ slot, and allows to have pipewire running inside a snap container. To avoid security issues, it only allows to access the sockets located at the folder belonging to the snap that owns the slot.

With this patch, audio works fine in Core Desktop, and also screen sharing.
