### PR TITLE
github: fix/simplify `go fmt` check

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -181,14 +181,9 @@ jobs:
       run: |
           cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
           # run gofmt checks only with Go 1.18
-          if ! echo "${{ matrix.gochannel }}" | grep -E '1\.13' ; then
-              # and skip with other versions
+          if [ "${{ matrix.gochannel }}" != "1.18" ]; then
               export SKIP_GOFMT=1
               echo "Formatting checks will be skipped due to the use of Go version ${{ matrix.gochannel }}"
-          else
-              # misspell and infessassign do not build with Go 1.18
-              export SKIP_MISSPELL=1
-              export SKIP_INEFFASSIGN=1
           fi
           sudo apt-get install -y python3-yamlordereddictloader
           ./run-checks --static


### PR DESCRIPTION
It looks like the format check in the static tests got broken when
we moved to go 1.18. It was most likely missed because the code
does not check for `1.13` but uses a regexp `1\.13`.

This commit fixes this and also simplifies the code around this
so that on the next move to a newer go-version we have an easier
time finding the version.
