### PR TITLE
tests: ensure `interfaces-account-control` does not trigger denials

### DIFF
--- a/tests/main/interfaces-account-control/task.yaml
+++ b/tests/main/interfaces-account-control/task.yaml
@@ -10,6 +10,9 @@ environment:
     TSNAP: account-control-consumer
 
 prepare: |
+    # capture apparmor denials before
+    dmesg | grep DENIED > denied.before || true
+
     #shellcheck source=tests/lib/core-config.sh
     . "$TESTSLIB"/core-config.sh
 
@@ -44,3 +47,10 @@ execute: |
 
     # User deletion is unsupported yet on Core: https://bugs.launchpad.net/ubuntu/+source/shadow/+bug/1659534
     # snap run "${TSNAP}${SUFFIX}".userdel --extrausers alice
+
+    # ensure no new deials appeared
+    dmesg |grep DENIED > denied.after
+    if ! diff -u denied.before denied.after; then
+        echo "error new apparmor denials after running the test"
+        exit 1
+    fi


### PR DESCRIPTION
During the review of PR#12860 we found that there are apparmor denials after "pam-lockout" was added. However the test for interfaces-account-control did not catch that.

This commit adds a check to ensure that apparmor denials are captured.
