### PR TITLE
spread: add apparmor version as part of the debug output

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -543,6 +543,9 @@ debug-each: |
     echo '# Kernel information'
     uname -a
 
+    echo '# Apparmor information'
+    apparmor_parser --version || true
+
     echo '# Go information'
     go version || true
 


### PR DESCRIPTION
It looks like aparmor and arch are not in a happy place right now, the various logs (e.g. https://github.com/snapcore/snapd/actions/runs/5179085285/jobs/9345943979?pr=12694 and https://github.com/snapcore/snapd/actions/runs/5178270014 and /jobs/9345790086?pr=12842 and https://github.com/snapcore/snapd/actions/runs/5178273702/jobs/9345887057 show failures.

Some failure output is apparmor related, e.g.
```
...
error: cannot perform the following tasks:
2023-06-06T07:28:34.1885484Z - Connect test-snapd-with-configure-nc:network-control to core:network-control (cannot setup profiles for snap "test-snapd-with-configure-nc": cannot load apparmor profiles: exit status 1
2023-06-06T07:28:34.1886088Z apparmor_parser output:
2023-06-06T07:28:34.1886430Z Encoding of mount rule failed
2023-06-06T07:28:34.1887832Z ERROR processing policydb rules for profile snap.test-snapd-with-configure-nc.hook.configure, failed to load
```
it's unclear what apparmor version arch is using so this PR starts by adding this information to the debug logs.