### PR TITLE
interfaces: fix `network-control` rule for apparmor 3.1.4

### DIFF
--- a/interfaces/builtin/network_control.go
+++ b/interfaces/builtin/network_control.go
@@ -298,8 +298,9 @@ umount /,
 capability sys_ptrace,
 
 # 'ip netns exec foo /bin/sh'
-mount options=(rw, rslave) /,
+#mount options=(rw, rslave) /, # commented out because of LP: #2023025
 mount options=(rw, rslave), # LP: #1648245
+mount fstype=sysfs,
 umount /sys/,
 
 # Eg, nsenter --net=/run/netns/... <command>


### PR DESCRIPTION
It looks like some changes in apparmor 3.1.4 cause issues with the existing network-control rules. It appears the rules are stricter now.

Thie commit updates the rules to match the new behavior, see also https://bugs.launchpad.net/apparmor/+bug/2023025

