### PR TITLE
desktop: fix fonts access

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -131,6 +131,7 @@ var (
 
 	SystemFontsDir            string
 	SystemLocalFontsDir       string
+	SystemFontconfigDir       string
 	SystemFontconfigCacheDirs []string
 
 	SnapshotsDir string
@@ -489,6 +490,7 @@ func SetRootDir(rootdir string) {
 	// These paths agree across all supported distros
 	SystemFontsDir = filepath.Join(rootdir, "/usr/share/fonts")
 	SystemLocalFontsDir = filepath.Join(rootdir, "/usr/local/share/fonts")
+	SystemFontconfigDir = filepath.Join(rootdir, "/usr/share/fontconfig")
 	// The cache path is true for Ubuntu, Debian, openSUSE, Arch
 	SystemFontconfigCacheDirs = []string{filepath.Join(rootdir, "/var/cache/fontconfig")}
 	if release.DistroLike("fedora") && !release.DistroLike("amzn") {

--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -331,6 +331,7 @@ func (iface *desktopInterface) fontconfigDirs(plug *interfaces.ConnectedPlug) ([
 	fontDirs := []string{
 		dirs.SystemFontsDir,
 		dirs.SystemLocalFontsDir,
+		dirs.SystemFontconfigDir,
 	}
 
 	shouldMountHostFontCache, err := iface.shouldMountHostFontCache(plug)


### PR DESCRIPTION
Inside /etc/fonts/conf.avail are several soft links to files at /usr/share/fontconfig. Although AppArmour rules are in place to allow access to that folder to snaps that have the desktop plug connected, the folder itself isn't being mounted inside the container, thus it isn't accessible from inside.

This patch adds that folder to the list of font folders, to ensure that it is available from inside a container.

Fix https://bugs.launchpad.net/snapd/+bug/2017313