### PR TITLE
cmd/snap-device-helper: handle bind and unbind commands

### DIFF
--- a/cmd/snap-device-helper/snap-device-helper-test.c
+++ b/cmd/snap-device-helper/snap-device-helper-test.c
@@ -153,22 +153,29 @@ static void test_sdh_action(sdh_test_fixture *fixture, gconstpointer test_data) 
 
     int ret = snap_device_helper_run(&inv_block);
     g_assert_cmpint(ret, ==, 0);
-    g_assert_cmpint(mocks.cgroup_new_calls, ==, 1);
-    if (g_strcmp0(td->action, "add") == 0 || g_strcmp0(td->action, "change") == 0) {
+    if (g_strcmp0(td->action, "add") == 0 || g_strcmp0(td->action, "change") == 0 || g_strcmp0(td->action, "bind") == 0) {
+        g_assert_cmpint(mocks.cgroup_new_calls, ==, 1);
         g_assert_cmpint(mocks.cgroup_allow_calls, ==, 1);
         g_assert_cmpint(mocks.cgroup_deny_calls, ==, 0);
     } else if (g_strcmp0(td->action, "remove") == 0) {
+        g_assert_cmpint(mocks.cgroup_new_calls, ==, 1);
         g_assert_cmpint(mocks.cgroup_allow_calls, ==, 0);
         g_assert_cmpint(mocks.cgroup_deny_calls, ==, 1);
+    } else if (g_strcmp0(td->action, "unbind") == 0) {
+        g_assert_cmpint(mocks.cgroup_new_calls, ==, 0);
+        g_assert_cmpint(mocks.cgroup_allow_calls, ==, 0);
+        g_assert_cmpint(mocks.cgroup_deny_calls, ==, 0);
     }
-    g_assert_cmpint(mocks.device_major, ==, 8);
-    g_assert_cmpint(mocks.device_minor, ==, 4);
-    g_assert_cmpint(mocks.device_type, ==, S_IFBLK);
-    g_assert_nonnull(mocks.new_tag);
-    g_assert_nonnull(td->app);
-    g_assert_cmpstr(mocks.new_tag, ==, td->app);
-    g_assert_cmpint(mocks.new_flags, !=, 0);
-    g_assert_cmpint(mocks.new_flags, ==, SC_DEVICE_CGROUP_FROM_EXISTING);
+    if (g_strcmp0(td->action, "unbind") != 0) {
+        g_assert_cmpint(mocks.device_major, ==, 8);
+        g_assert_cmpint(mocks.device_minor, ==, 4);
+        g_assert_cmpint(mocks.device_type, ==, S_IFBLK);
+        g_assert_nonnull(mocks.new_tag);
+        g_assert_nonnull(td->app);
+        g_assert_cmpstr(mocks.new_tag, ==, td->app);
+        g_assert_cmpint(mocks.new_flags, !=, 0);
+        g_assert_cmpint(mocks.new_flags, ==, SC_DEVICE_CGROUP_FROM_EXISTING);
+    }
 
     g_debug("reset");
     mocks_reset();
@@ -184,22 +191,29 @@ static void test_sdh_action(sdh_test_fixture *fixture, gconstpointer test_data) 
     symlink_in_sysroot(fixture, "/sys/devices/foo/tty/ttyS0/subsystem", "../../../../class/other");
     ret = snap_device_helper_run(&inv_serial);
     g_assert_cmpint(ret, ==, 0);
-    g_assert_cmpint(mocks.cgroup_new_calls, ==, 1);
-    if (g_strcmp0(td->action, "add") == 0 || g_strcmp0(td->action, "change") == 0) {
+    if (g_strcmp0(td->action, "add") == 0 || g_strcmp0(td->action, "change") == 0 || g_strcmp0(td->action, "bind") == 0) {
+        g_assert_cmpint(mocks.cgroup_new_calls, ==, 1);
         g_assert_cmpint(mocks.cgroup_allow_calls, ==, 1);
         g_assert_cmpint(mocks.cgroup_deny_calls, ==, 0);
     } else if (g_strcmp0(td->action, "remove") == 0) {
+        g_assert_cmpint(mocks.cgroup_new_calls, ==, 1);
         g_assert_cmpint(mocks.cgroup_allow_calls, ==, 0);
         g_assert_cmpint(mocks.cgroup_deny_calls, ==, 1);
+    } else if (g_strcmp0(td->action, "unbind") == 0) {
+        g_assert_cmpint(mocks.cgroup_new_calls, ==, 0);
+        g_assert_cmpint(mocks.cgroup_allow_calls, ==, 0);
+        g_assert_cmpint(mocks.cgroup_deny_calls, ==, 0);
     }
-    g_assert_cmpint(mocks.device_major, ==, 6);
-    g_assert_cmpint(mocks.device_minor, ==, 64);
-    g_assert_cmpint(mocks.device_type, ==, S_IFCHR);
-    g_assert_nonnull(mocks.new_tag);
-    g_assert_nonnull(td->app);
-    g_assert_cmpstr(mocks.new_tag, ==, td->app);
-    g_assert_cmpint(mocks.new_flags, !=, 0);
-    g_assert_cmpint(mocks.new_flags, ==, SC_DEVICE_CGROUP_FROM_EXISTING);
+    if (g_strcmp0(td->action, "unbind") != 0) {
+        g_assert_cmpint(mocks.device_major, ==, 6);
+        g_assert_cmpint(mocks.device_minor, ==, 64);
+        g_assert_cmpint(mocks.device_type, ==, S_IFCHR);
+        g_assert_nonnull(mocks.new_tag);
+        g_assert_nonnull(td->app);
+        g_assert_cmpstr(mocks.new_tag, ==, td->app);
+        g_assert_cmpint(mocks.new_flags, !=, 0);
+        g_assert_cmpint(mocks.new_flags, ==, SC_DEVICE_CGROUP_FROM_EXISTING);
+    }
 }
 
 static void test_sdh_action_nvme(sdh_test_fixture *fixture, gconstpointer test_data) {
@@ -498,11 +512,17 @@ static void test_sdh_err_funtag8(sdh_test_fixture *fixture, gconstpointer test_d
 static struct sdh_test_data add_data = {"add", "snap.foo.bar", "snap_foo_bar"};
 static struct sdh_test_data change_data = {"change", "snap.foo.bar", "snap_foo_bar"};
 
+static struct sdh_test_data bind_data = {"bind", "snap.foo.bar", "snap_foo_bar"};
+static struct sdh_test_data unbind_data = {"unbind", "snap.foo.bar", "snap_foo_bar"};
+
 static struct sdh_test_data remove_data = {"remove", "snap.foo.bar", "snap_foo_bar"};
 
 static struct sdh_test_data instance_add_data = {"add", "snap.foo_bar.baz", "snap_foo_bar_baz"};
 
 static struct sdh_test_data instance_change_data = {"change", "snap.foo_bar.baz", "snap_foo_bar_baz"};
+
+static struct sdh_test_data instance_bind_data = {"bind", "snap.foo_bar.baz", "snap_foo_bar_baz"};
+static struct sdh_test_data instance_unbind_data = {"unbind", "snap.foo_bar.baz", "snap_foo_bar_baz"};
 
 static struct sdh_test_data instance_remove_data = {"remove", "snap.foo_bar.baz", "snap_foo_bar_baz"};
 
@@ -520,6 +540,8 @@ static void __attribute__((constructor)) init(void) {
 
     _test_add("/snap-device-helper/add", &add_data, test_sdh_action);
     _test_add("/snap-device-helper/change", &change_data, test_sdh_action);
+    _test_add("/snap-device-helper/bind", &bind_data, test_sdh_action);
+    _test_add("/snap-device-helper/unbind", &unbind_data, test_sdh_action);
     _test_add("/snap-device-helper/remove", &remove_data, test_sdh_action);
     _test_add("/snap-device-helper/remove_fallback", NULL, test_sdh_action_remove_fallback_devtype);
 
@@ -544,6 +566,8 @@ static void __attribute__((constructor)) init(void) {
     // parallel instances
     _test_add("/snap-device-helper/parallel/add", &instance_add_data, test_sdh_action);
     _test_add("/snap-device-helper/parallel/change", &instance_change_data, test_sdh_action);
+    _test_add("/snap-device-helper/parallel/bind", &instance_bind_data, test_sdh_action);
+    _test_add("/snap-device-helper/parallel/unbind", &instance_unbind_data, test_sdh_action);
     _test_add("/snap-device-helper/parallel/remove", &instance_remove_data, test_sdh_action);
     // hooks
     _test_add("/snap-device-helper/hook/add", &add_hook_data, test_sdh_action);

--- a/cmd/snap-device-helper/snap-device-helper.c
+++ b/cmd/snap-device-helper/snap-device-helper.c
@@ -160,10 +160,17 @@ int snap_device_helper_run(const struct sdh_invocation *inv) {
     if (strlen(devpath) <= strlen("/devices/")) {
         die("no or malformed devpath \"%s\"", devpath);
     }
-    if (sc_streq(action, "add") || sc_streq(action, "change")) {
+    if (sc_streq(action, "bind") || sc_streq(action, "add") || sc_streq(action, "change")) {
         allow = true;
     } else if (sc_streq(action, "remove")) {
         allow = false;
+    } else if (sc_streq(action, "unbind")) {
+        /* "unbind" does not mean removal of the device, the device node can still exist.
+         * Usually "unbind" will happen before a "remove" if a removed device is bound to a driver.
+         * We will disable access to the device once we get "remove". For "unbind", we
+         * simply ignore it.
+         */
+        return 0;
     } else {
         die("ERROR: unknown action \"%s\"", action);
     }

--- a/tests/main/security-device-cgroups-helper/task.yaml
+++ b/tests/main/security-device-cgroups-helper/task.yaml
@@ -96,6 +96,9 @@ execute: |
     # or changed
     "$libexecdir"/snapd/snap-device-helper change snap_test-strict-cgroup-helper_sh "$DEVICES_PATH_MEM_KMSG" 1:11
     tests.device-cgroup test-strict-cgroup-helper.sh dump | MATCH 'c 1:11 rwm'
+    # or bound to driver
+    "$libexecdir"/snapd/snap-device-helper bind snap_test-strict-cgroup-helper_sh "$DEVICES_PATH_MEM_KMSG" 1:11
+    tests.device-cgroup test-strict-cgroup-helper.sh dump | MATCH 'c 1:11 rwm'
     # and it should be possible to read a line now
     touch /var/snap/test-strict-cgroup-helper/common/ready
     # wait for the snap application we started in the background earlier to
@@ -103,6 +106,10 @@ execute: |
     wait
     NOMATCH 'Operation not permitted' < run.log
     test -n "$(cat run.log)"
+
+    # unbind does not remove the device
+    "$libexecdir"/snapd/snap-device-helper unbind snap_test-strict-cgroup-helper_sh "$DEVICES_PATH_MEM_KMSG" 1:11
+    tests.device-cgroup test-strict-cgroup-helper.sh dump | MATCH 'c 1:11 rwm'
 
     # remove action removes the device from the cgroup
     "$libexecdir"/snapd/snap-device-helper remove snap_test-strict-cgroup-helper_sh "$DEVICES_PATH_MEM_KMSG" 1:11


### PR DESCRIPTION
At some point the kernel added two events "bind" and "unbind" for uevent.

https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=1455cf8dbfd0

Those actions were hidden by udev. But they seemed to have been added now. They were not handle by snap-device-helper. Instead it would generate an error.

Here we ignore `unbind`, since `remove` should take care of cleaning up. And it should happen after.

We treat `bind` like `change` (which is like `add`).