### PR TITLE
many: minor test cleanups 

### DIFF
--- a/bootloader/lkenv/lkenv_test.go
+++ b/bootloader/lkenv/lkenv_test.go
@@ -67,17 +67,17 @@ func (l *lkenvTestSuite) SetUpTest(c *C) {
 }
 
 // unpack test data packed with gzip
-func unpackTestData(data []byte) (resData []byte, err error) {
+func unpackTestData(data []byte) ([]byte, error) {
 	b := bytes.NewBuffer(data)
-	var r io.Reader
-	r, err = gzip.NewReader(b)
+	r, err := gzip.NewReader(b)
 	if err != nil {
-		return
+		return nil, err
 	}
+
 	var env bytes.Buffer
 	_, err = env.ReadFrom(r)
 	if err != nil {
-		return
+		return nil, err
 	}
 	return env.Bytes(), nil
 }
@@ -94,7 +94,7 @@ func (l *lkenvTestSuite) TestCtoGoString(c *C) {
 		{[]byte{'a', 'b', 'c', 'd', 0}, "abcd"},
 		// no trailing \0 - assume corrupted "" ?
 		{[]byte{'a', 'b', 'c', 'd', 'e'}, ""},
-		// first \0 is the cutof
+		// first \0 is the cutoff
 		{[]byte{'a', 'b', 0, 'z', 0}, "ab"},
 	} {
 		c.Check(lkenv.CToGoString(t.input), Equals, t.expected)

--- a/timeutil/schedule_test.go
+++ b/timeutil/schedule_test.go
@@ -26,6 +26,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/testutil"
 	"github.com/snapcore/snapd/timeutil"
 )
 
@@ -513,12 +514,11 @@ func (ts *timeutilSuite) TestScheduleNext(c *C) {
 	// transition across one of the intervals (ie in Australia in
 	// 2019 DST started on 6th October) then the result will be
 	// different and the test will fail
-	oldLocal := time.Local
-	local, _ := time.LoadLocation("UTC")
+	restore := testutil.Backup(&time.Local)
+	defer restore()
+	local, err := time.LoadLocation("UTC")
+	c.Assert(err, IsNil)
 	time.Local = local
-	defer func() {
-		time.Local = oldLocal
-	}()
 
 	for _, t := range []struct {
 		schedule   string


### PR DESCRIPTION
Removes a naked return that the latest version of golangci complains about. Also adds an assertion and a `testutil.Backup` as a follow-up to a PR that I merged too early.