### PR TITLE
many: add pointer to volume in gadget.VolumeStructure.

### DIFF
--- a/daemon/api_systems_test.go
+++ b/daemon/api_systems_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/snapcore/snapd/daemon"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget"
+	"github.com/snapcore/snapd/gadget/gadgettest"
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/overlord/assertstate/assertstatetest"
 	"github.com/snapcore/snapd/overlord/devicestate"
@@ -943,7 +944,7 @@ func (s *systemsSuite) TestSystemsGetSpecificLabelIntegration(c *check.C) {
 	c.Assert(rsp.Status, check.Equals, 200)
 	sys := rsp.Result.(client.SystemDetails)
 
-	c.Assert(sys, check.DeepEquals, client.SystemDetails{
+	sd := client.SystemDetails{
 		Label: "20191119",
 		Model: s.seedModelForLabel20191119.Headers(),
 		Actions: []client.SystemAction{
@@ -1061,7 +1062,9 @@ func (s *systemsSuite) TestSystemsGetSpecificLabelIntegration(c *check.C) {
 				},
 			},
 		},
-	})
+	}
+	gadgettest.SetEnclosingVolumeInStructs(sd.Volumes)
+	c.Assert(sys, check.DeepEquals, sd)
 }
 
 func (s *systemsSuite) TestSystemInstallActionSetupStorageEncryptionCallsDevicestate(c *check.C) {

--- a/gadget/gadgettest/gadgettest.go
+++ b/gadget/gadgettest/gadgettest.go
@@ -229,3 +229,13 @@ func MockGadgetPartitionedDisk(gadgetYaml, gadgetRoot string) (ginfo *gadget.Inf
 
 	return ginfo, laidVols, model, restore, nil
 }
+
+// SetEnclosingVolumeInStructs is a helper that sets the pointer to
+// the Volume in all VolumeStructure objects it contains.
+func SetEnclosingVolumeInStructs(vv map[string]*gadget.Volume) {
+	for _, v := range vv {
+		for sidx := range v.Structure {
+			v.Structure[sidx].EnclosingVolume = v
+		}
+	}
+}

--- a/gadget/install/partition_test.go
+++ b/gadget/install/partition_test.go
@@ -280,6 +280,8 @@ func (s *partitionTestSuite) TestBuildPartitionList(c *C) {
 /dev/node4 : start=     2723840, size=     5664735, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4, name="Writable"
 `)
 	c.Check(create, NotNil)
+	mockLaidoutStructureSave.VolumeStructure.EnclosingVolume = pv.Volume
+	mockLaidoutStructureWritableAfterSave.VolumeStructure.EnclosingVolume = pv.Volume
 	c.Assert(create, DeepEquals, []gadget.LaidOutStructure{
 		mockLaidoutStructureSave,
 		mockLaidoutStructureWritableAfterSave,
@@ -347,6 +349,7 @@ func (s *partitionTestSuite) TestCreatePartitions(c *C) {
 	}
 	created, err := install.TestCreateMissingPartitions(dl, pv, opts)
 	c.Assert(err, IsNil)
+	mockLaidoutStructureWritable.VolumeStructure.EnclosingVolume = pv.Volume
 	c.Assert(created, DeepEquals, []gadget.LaidOutStructure{mockLaidoutStructureWritable})
 	c.Assert(calls, Equals, 1)
 

--- a/gadget/layout_test.go
+++ b/gadget/layout_test.go
@@ -49,7 +49,7 @@ func (p *layoutTestSuite) SetUpTest(c *C) {
 func (p *layoutTestSuite) TestVolumeSize(c *C) {
 	vol := gadget.Volume{
 		Structure: []gadget.VolumeStructure{
-			{Offset: asOffsetPtr(quantity.OffsetMiB), Size: 2 * quantity.SizeMiB},
+			{Offset: asOffsetPtr(quantity.OffsetMiB), Size: 2 * quantity.SizeMiB, EnclosingVolume: &gadget.Volume{}},
 		},
 	}
 	opts := &gadget.LayoutOptions{GadgetRootDir: p.dir}
@@ -59,7 +59,7 @@ func (p *layoutTestSuite) TestVolumeSize(c *C) {
 	c.Assert(v, DeepEquals, &gadget.LaidOutVolume{
 		Volume: &gadget.Volume{
 			Structure: []gadget.VolumeStructure{
-				{Offset: asOffsetPtr(quantity.OffsetMiB), Size: 2 * quantity.SizeMiB},
+				{Offset: asOffsetPtr(quantity.OffsetMiB), Size: 2 * quantity.SizeMiB, EnclosingVolume: &gadget.Volume{}},
 			},
 		},
 		LaidOutStructure: []gadget.LaidOutStructure{{
@@ -68,8 +68,9 @@ func (p *layoutTestSuite) TestVolumeSize(c *C) {
 				StartOffset: 1 * quantity.OffsetMiB,
 			},
 			VolumeStructure: &gadget.VolumeStructure{
-				Offset: asOffsetPtr(quantity.OffsetMiB),
-				Size:   2 * quantity.SizeMiB,
+				Offset:          asOffsetPtr(quantity.OffsetMiB),
+				Size:            2 * quantity.SizeMiB,
+				EnclosingVolume: &gadget.Volume{},
 			},
 		}},
 	})
@@ -1382,13 +1383,15 @@ func (p *layoutTestSuite) TestLayoutWithMinSize(c *C) {
 	vol := gadget.Volume{
 		Structure: []gadget.VolumeStructure{
 			{
-				Offset:  asOffsetPtr(quantity.OffsetMiB),
-				MinSize: quantity.SizeMiB,
-				Size:    2 * quantity.SizeMiB,
+				Offset:          asOffsetPtr(quantity.OffsetMiB),
+				MinSize:         quantity.SizeMiB,
+				Size:            2 * quantity.SizeMiB,
+				EnclosingVolume: &gadget.Volume{},
 			},
 			{
-				MinSize: quantity.SizeMiB,
-				Size:    2 * quantity.SizeMiB,
+				MinSize:         quantity.SizeMiB,
+				Size:            2 * quantity.SizeMiB,
+				EnclosingVolume: &gadget.Volume{},
 			},
 		},
 	}

--- a/gadget/mountedfilesystem_test.go
+++ b/gadget/mountedfilesystem_test.go
@@ -823,6 +823,7 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterNoFs(c *C) {
 					Target:           "/foo-dir/",
 				},
 			},
+			EnclosingVolume: &gadget.Volume{},
 		},
 	}
 
@@ -846,6 +847,7 @@ func (s *mountedfilesystemTestSuite) TestMountedWriterTrivialValidation(c *C) {
 					Target:           "/",
 				},
 			},
+			EnclosingVolume: &gadget.Volume{},
 		},
 	}
 	s.mustResolveVolumeContent(c, ps)
@@ -2939,7 +2941,8 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterTrivialValidation(c *C) {
 		VolumeStructure: &gadget.VolumeStructure{
 			Size: 2048,
 			// no filesystem
-			Content: []gadget.VolumeContent{},
+			Content:         []gadget.VolumeContent{},
+			EnclosingVolume: &gadget.Volume{},
 		},
 	}
 	s.mustResolveVolumeContent(c, psNoFs)
@@ -2955,9 +2958,10 @@ func (s *mountedfilesystemTestSuite) TestMountedUpdaterTrivialValidation(c *C) {
 
 	ps := &gadget.LaidOutStructure{
 		VolumeStructure: &gadget.VolumeStructure{
-			Size:       2048,
-			Filesystem: "ext4",
-			Content:    []gadget.VolumeContent{},
+			Size:            2048,
+			Filesystem:      "ext4",
+			Content:         []gadget.VolumeContent{},
+			EnclosingVolume: &gadget.Volume{},
 		},
 	}
 	s.mustResolveVolumeContent(c, ps)

--- a/gadget/raw_test.go
+++ b/gadget/raw_test.go
@@ -80,7 +80,8 @@ func (r *rawTestSuite) TestRawWriterHappy(c *C) {
 
 	ps := &gadget.LaidOutStructure{
 		VolumeStructure: &gadget.VolumeStructure{
-			Size: 2048,
+			Size:            2048,
+			EnclosingVolume: &gadget.Volume{},
 		},
 		LaidOutContent: []gadget.LaidOutContent{
 			{
@@ -129,7 +130,8 @@ func (r *rawTestSuite) TestRawWriterNoFile(c *C) {
 
 	ps := &gadget.LaidOutStructure{
 		VolumeStructure: &gadget.VolumeStructure{
-			Size: 2048,
+			Size:            2048,
+			EnclosingVolume: &gadget.Volume{},
 		},
 		LaidOutContent: []gadget.LaidOutContent{
 			{
@@ -181,7 +183,8 @@ func (r *rawTestSuite) TestRawWriterFailInWriteSeeker(c *C) {
 
 	ps := &gadget.LaidOutStructure{
 		VolumeStructure: &gadget.VolumeStructure{
-			Size: 2048,
+			Size:            2048,
+			EnclosingVolume: &gadget.Volume{},
 		},
 		LaidOutContent: []gadget.LaidOutContent{
 			{
@@ -213,7 +216,8 @@ func (r *rawTestSuite) TestRawWriterNoImage(c *C) {
 	out := &mockWriteSeeker{}
 	ps := &gadget.LaidOutStructure{
 		VolumeStructure: &gadget.VolumeStructure{
-			Size: 2048,
+			Size:            2048,
+			EnclosingVolume: &gadget.Volume{},
 		},
 		LaidOutContent: []gadget.LaidOutContent{
 			{
@@ -251,7 +255,8 @@ func (r *rawTestSuite) TestRawWriterFailWithNonBare(c *C) {
 func (r *rawTestSuite) TestRawWriterInternalErrors(c *C) {
 	ps := &gadget.LaidOutStructure{
 		VolumeStructure: &gadget.VolumeStructure{
-			Size: 2048,
+			Size:            2048,
+			EnclosingVolume: &gadget.Volume{},
 		},
 	}
 
@@ -302,7 +307,8 @@ func (r *rawTestSuite) TestRawUpdaterBackupUpdateRestoreSame(c *C) {
 			StartOffset: 1 * quantity.OffsetMiB,
 		},
 		VolumeStructure: &gadget.VolumeStructure{
-			Size: 2048,
+			Size:            2048,
+			EnclosingVolume: &gadget.Volume{},
 		},
 		LaidOutContent: []gadget.LaidOutContent{
 			{
@@ -384,7 +390,8 @@ func (r *rawTestSuite) TestRawUpdaterBackupUpdateRestoreDifferent(c *C) {
 			StartOffset: 1 * quantity.OffsetMiB,
 		},
 		VolumeStructure: &gadget.VolumeStructure{
-			Size: 4096,
+			Size:            4096,
+			EnclosingVolume: &gadget.Volume{},
 		},
 		LaidOutContent: []gadget.LaidOutContent{
 			{
@@ -544,7 +551,8 @@ func (r *rawTestSuite) TestRawUpdaterBackupErrors(c *C) {
 			StartOffset: 0,
 		},
 		VolumeStructure: &gadget.VolumeStructure{
-			Size: 2048,
+			Size:            2048,
+			EnclosingVolume: &gadget.Volume{},
 		},
 		LaidOutContent: []gadget.LaidOutContent{
 			{
@@ -595,7 +603,8 @@ func (r *rawTestSuite) TestRawUpdaterBackupIdempotent(c *C) {
 			StartOffset: 0,
 		},
 		VolumeStructure: &gadget.VolumeStructure{
-			Size: 2048,
+			Size:            2048,
+			EnclosingVolume: &gadget.Volume{},
 		},
 		LaidOutContent: []gadget.LaidOutContent{
 			{
@@ -639,7 +648,8 @@ func (r *rawTestSuite) TestRawUpdaterFindDeviceFailed(c *C) {
 			StartOffset: 0,
 		},
 		VolumeStructure: &gadget.VolumeStructure{
-			Size: 2048,
+			Size:            2048,
+			EnclosingVolume: &gadget.Volume{},
 		},
 		LaidOutContent: []gadget.LaidOutContent{
 			{
@@ -687,7 +697,8 @@ func (r *rawTestSuite) TestRawUpdaterRollbackErrors(c *C) {
 			StartOffset: 0,
 		},
 		VolumeStructure: &gadget.VolumeStructure{
-			Size: 2048,
+			Size:            2048,
+			EnclosingVolume: &gadget.Volume{},
 		},
 		LaidOutContent: []gadget.LaidOutContent{
 			{
@@ -739,7 +750,8 @@ func (r *rawTestSuite) TestRawUpdaterUpdateErrors(c *C) {
 			StartOffset: 0,
 		},
 		VolumeStructure: &gadget.VolumeStructure{
-			Size: 2048,
+			Size:            2048,
+			EnclosingVolume: &gadget.Volume{},
 		},
 		LaidOutContent: []gadget.LaidOutContent{
 			{
@@ -807,7 +819,8 @@ func (r *rawTestSuite) TestRawUpdaterContentBackupPath(c *C) {
 func (r *rawTestSuite) TestRawUpdaterInternalErrors(c *C) {
 	ps := &gadget.LaidOutStructure{
 		VolumeStructure: &gadget.VolumeStructure{
-			Size: 2048,
+			Size:            2048,
+			EnclosingVolume: &gadget.Volume{},
 		},
 	}
 

--- a/gadget/update_test.go
+++ b/gadget/update_test.go
@@ -150,43 +150,43 @@ func (u *updateTestSuite) TestCanUpdateSize(c *C) {
 	cases := []canUpdateTestCase{
 		{
 			// size change
-			from: gadget.VolumeStructure{MinSize: quantity.SizeMiB, Size: quantity.SizeMiB},
-			to:   gadget.VolumeStructure{MinSize: quantity.SizeMiB + quantity.SizeKiB, Size: quantity.SizeMiB + quantity.SizeKiB},
+			from: gadget.VolumeStructure{MinSize: quantity.SizeMiB, Size: quantity.SizeMiB, EnclosingVolume: &gadget.Volume{}},
+			to:   gadget.VolumeStructure{MinSize: quantity.SizeMiB + quantity.SizeKiB, Size: quantity.SizeMiB + quantity.SizeKiB, EnclosingVolume: &gadget.Volume{}},
 			err:  `new valid structure size range \[1049600, 1049600\] is not compatible with current \(\[1048576, 1048576\]\)`,
 		}, {
 			// no size change
-			from: gadget.VolumeStructure{MinSize: quantity.SizeMiB, Size: quantity.SizeMiB},
-			to:   gadget.VolumeStructure{MinSize: quantity.SizeMiB, Size: quantity.SizeMiB},
+			from: gadget.VolumeStructure{MinSize: quantity.SizeMiB, Size: quantity.SizeMiB, EnclosingVolume: &gadget.Volume{}},
+			to:   gadget.VolumeStructure{MinSize: quantity.SizeMiB, Size: quantity.SizeMiB, EnclosingVolume: &gadget.Volume{}},
 			err:  "",
 		}, {
 			// range ok
-			from: gadget.VolumeStructure{MinSize: 10, Size: 20},
-			to:   gadget.VolumeStructure{MinSize: 0, Size: 10},
+			from: gadget.VolumeStructure{MinSize: 10, Size: 20, EnclosingVolume: &gadget.Volume{}},
+			to:   gadget.VolumeStructure{MinSize: 0, Size: 10, EnclosingVolume: &gadget.Volume{}},
 			err:  "",
 		}, {
 			// range ok
-			from: gadget.VolumeStructure{MinSize: 10, Size: 20},
-			to:   gadget.VolumeStructure{MinSize: 0, Size: 15},
+			from: gadget.VolumeStructure{MinSize: 10, Size: 20, EnclosingVolume: &gadget.Volume{}},
+			to:   gadget.VolumeStructure{MinSize: 0, Size: 15, EnclosingVolume: &gadget.Volume{}},
 			err:  "",
 		}, {
 			// range ok
-			from: gadget.VolumeStructure{MinSize: 10, Size: 20},
-			to:   gadget.VolumeStructure{MinSize: 15, Size: 18},
+			from: gadget.VolumeStructure{MinSize: 10, Size: 20, EnclosingVolume: &gadget.Volume{}},
+			to:   gadget.VolumeStructure{MinSize: 15, Size: 18, EnclosingVolume: &gadget.Volume{}},
 			err:  "",
 		}, {
 			// range ok
-			from: gadget.VolumeStructure{MinSize: 10, Size: 20},
-			to:   gadget.VolumeStructure{MinSize: 15, Size: 25},
+			from: gadget.VolumeStructure{MinSize: 10, Size: 20, EnclosingVolume: &gadget.Volume{}},
+			to:   gadget.VolumeStructure{MinSize: 15, Size: 25, EnclosingVolume: &gadget.Volume{}},
 			err:  "",
 		}, {
 			// range out
-			from: gadget.VolumeStructure{MinSize: 10, Size: 20},
-			to:   gadget.VolumeStructure{MinSize: 1, Size: 9},
+			from: gadget.VolumeStructure{MinSize: 10, Size: 20, EnclosingVolume: &gadget.Volume{}},
+			to:   gadget.VolumeStructure{MinSize: 1, Size: 9, EnclosingVolume: &gadget.Volume{}},
 			err:  `new valid structure size range \[1, 9\] is not compatible with current \(\[10, 20\]\)`,
 		}, {
 			// range out
-			from: gadget.VolumeStructure{MinSize: 10, Size: 20},
-			to:   gadget.VolumeStructure{MinSize: 21, Size: 25},
+			from: gadget.VolumeStructure{MinSize: 10, Size: 20, EnclosingVolume: &gadget.Volume{}},
+			to:   gadget.VolumeStructure{MinSize: 21, Size: 25, EnclosingVolume: &gadget.Volume{}},
 			err:  `new valid structure size range \[21, 25\] is not compatible with current \(\[10, 20\]\)`,
 		},
 	}
@@ -200,60 +200,69 @@ func (u *updateTestSuite) TestCanUpdateOffsetWrite(c *C) {
 		{
 			// offset-write change
 			from: gadget.VolumeStructure{
-				OffsetWrite: &gadget.RelativeOffset{Offset: 1024}},
+				OffsetWrite: &gadget.RelativeOffset{Offset: 1024}, EnclosingVolume: &gadget.Volume{}},
 			to: gadget.VolumeStructure{
-				OffsetWrite: &gadget.RelativeOffset{Offset: 2048}},
+				OffsetWrite: &gadget.RelativeOffset{Offset: 2048}, EnclosingVolume: &gadget.Volume{}},
 			err: "cannot change structure offset-write from [0-9]+ to [0-9]+",
 		}, {
 			// offset-write, change in relative-to structure name
 			from: gadget.VolumeStructure{
-				OffsetWrite: &gadget.RelativeOffset{RelativeTo: "foo", Offset: 1024}},
+				OffsetWrite: &gadget.RelativeOffset{RelativeTo: "foo", Offset: 1024}, EnclosingVolume: &gadget.Volume{}},
 			to: gadget.VolumeStructure{
-				OffsetWrite: &gadget.RelativeOffset{RelativeTo: "bar", Offset: 1024}},
+				OffsetWrite: &gadget.RelativeOffset{RelativeTo: "bar", Offset: 1024}, EnclosingVolume: &gadget.Volume{}},
 			err: `cannot change structure offset-write from foo\+[0-9]+ to bar\+[0-9]+`,
 		}, {
 			// offset-write, unspecified in old
 			from: gadget.VolumeStructure{
-				OffsetWrite: nil,
+				OffsetWrite: nil, EnclosingVolume: &gadget.Volume{},
 			},
 			to: gadget.VolumeStructure{
-				OffsetWrite: &gadget.RelativeOffset{RelativeTo: "bar", Offset: 1024},
+				OffsetWrite:     &gadget.RelativeOffset{RelativeTo: "bar", Offset: 1024},
+				EnclosingVolume: &gadget.Volume{},
 			},
 			err: `cannot change structure offset-write from unspecified to bar\+[0-9]+`,
 		}, {
 			// offset-write, unspecified in new
 			from: gadget.VolumeStructure{
-				OffsetWrite: &gadget.RelativeOffset{RelativeTo: "foo", Offset: 1024},
+				OffsetWrite:     &gadget.RelativeOffset{RelativeTo: "foo", Offset: 1024},
+				EnclosingVolume: &gadget.Volume{},
 			},
 			to: gadget.VolumeStructure{
-				OffsetWrite: nil,
+				OffsetWrite:     nil,
+				EnclosingVolume: &gadget.Volume{},
 			},
 			err: `cannot change structure offset-write from foo\+[0-9]+ to unspecified`,
 		}, {
 			// all ok, both nils
 			from: gadget.VolumeStructure{
-				OffsetWrite: nil,
+				OffsetWrite:     nil,
+				EnclosingVolume: &gadget.Volume{},
 			},
 			to: gadget.VolumeStructure{
-				OffsetWrite: nil,
+				OffsetWrite:     nil,
+				EnclosingVolume: &gadget.Volume{},
 			},
 			err: ``,
 		}, {
 			// all ok, both fully specified
 			from: gadget.VolumeStructure{
-				OffsetWrite: &gadget.RelativeOffset{RelativeTo: "foo", Offset: 1024},
+				OffsetWrite:     &gadget.RelativeOffset{RelativeTo: "foo", Offset: 1024},
+				EnclosingVolume: &gadget.Volume{},
 			},
 			to: gadget.VolumeStructure{
-				OffsetWrite: &gadget.RelativeOffset{RelativeTo: "foo", Offset: 1024},
+				OffsetWrite:     &gadget.RelativeOffset{RelativeTo: "foo", Offset: 1024},
+				EnclosingVolume: &gadget.Volume{},
 			},
 			err: ``,
 		}, {
 			// all ok, both fully specified
 			from: gadget.VolumeStructure{
-				OffsetWrite: &gadget.RelativeOffset{Offset: 1024},
+				OffsetWrite:     &gadget.RelativeOffset{Offset: 1024},
+				EnclosingVolume: &gadget.Volume{},
 			},
 			to: gadget.VolumeStructure{
-				OffsetWrite: &gadget.RelativeOffset{Offset: 1024},
+				OffsetWrite:     &gadget.RelativeOffset{Offset: 1024},
+				EnclosingVolume: &gadget.Volume{},
 			},
 			err: ``,
 		},
@@ -295,28 +304,28 @@ func (u *updateTestSuite) TestCanUpdateRole(c *C) {
 	cases := []canUpdateTestCase{
 		{
 			// new role
-			from: gadget.VolumeStructure{Role: ""},
-			to:   gadget.VolumeStructure{Role: "system-data"},
+			from: gadget.VolumeStructure{Role: "", EnclosingVolume: &gadget.Volume{}},
+			to:   gadget.VolumeStructure{Role: "system-data", EnclosingVolume: &gadget.Volume{}},
 			err:  `cannot change structure role from "" to "system-data"`,
 		}, {
 			// explicitly set tole
-			from: gadget.VolumeStructure{Role: "mbr"},
-			to:   gadget.VolumeStructure{Role: "system-data"},
+			from: gadget.VolumeStructure{Role: "mbr", EnclosingVolume: &gadget.Volume{}},
+			to:   gadget.VolumeStructure{Role: "system-data", EnclosingVolume: &gadget.Volume{}},
 			err:  `cannot change structure role from "mbr" to "system-data"`,
 		}, {
 			// implicit legacy role to proper explicit role
-			from: gadget.VolumeStructure{Type: "mbr", Role: "mbr"},
-			to:   gadget.VolumeStructure{Type: "bare", Role: "mbr"},
+			from: gadget.VolumeStructure{Type: "mbr", Role: "mbr", EnclosingVolume: &gadget.Volume{}},
+			to:   gadget.VolumeStructure{Type: "bare", Role: "mbr", EnclosingVolume: &gadget.Volume{}},
 			err:  "",
 		}, {
 			// but not in the opposite direction
-			from: gadget.VolumeStructure{Type: "bare", Role: "mbr"},
-			to:   gadget.VolumeStructure{Type: "mbr", Role: "mbr"},
+			from: gadget.VolumeStructure{Type: "bare", Role: "mbr", EnclosingVolume: &gadget.Volume{}},
+			to:   gadget.VolumeStructure{Type: "mbr", Role: "mbr", EnclosingVolume: &gadget.Volume{}},
 			err:  `cannot change structure type from "bare" to "mbr"`,
 		}, {
 			// start offset changed due to layout
-			from: gadget.VolumeStructure{Role: ""},
-			to:   gadget.VolumeStructure{Role: ""},
+			from: gadget.VolumeStructure{Role: "", EnclosingVolume: &gadget.Volume{}},
+			to:   gadget.VolumeStructure{Role: "", EnclosingVolume: &gadget.Volume{}},
 			err:  "",
 		},
 	}
@@ -328,41 +337,41 @@ func (u *updateTestSuite) TestCanUpdateType(c *C) {
 	cases := []canUpdateTestCase{
 		{
 			// from hybrid type to GUID
-			from: gadget.VolumeStructure{Type: "0C,00000000-0000-0000-0000-dd00deadbeef"},
-			to:   gadget.VolumeStructure{Type: "00000000-0000-0000-0000-dd00deadbeef"},
+			from: gadget.VolumeStructure{Type: "0C,00000000-0000-0000-0000-dd00deadbeef", EnclosingVolume: &gadget.Volume{}},
+			to:   gadget.VolumeStructure{Type: "00000000-0000-0000-0000-dd00deadbeef", EnclosingVolume: &gadget.Volume{}},
 			err:  `cannot change structure type from "0C,00000000-0000-0000-0000-dd00deadbeef" to "00000000-0000-0000-0000-dd00deadbeef"`,
 		}, {
 			// from MBR type to GUID (would be stopped at volume update checks)
-			from: gadget.VolumeStructure{Type: "0C"},
-			to:   gadget.VolumeStructure{Type: "00000000-0000-0000-0000-dd00deadbeef"},
+			from: gadget.VolumeStructure{Type: "0C", EnclosingVolume: &gadget.Volume{}},
+			to:   gadget.VolumeStructure{Type: "00000000-0000-0000-0000-dd00deadbeef", EnclosingVolume: &gadget.Volume{}},
 			err:  `cannot change structure type from "0C" to "00000000-0000-0000-0000-dd00deadbeef"`,
 		}, {
 			// from one MBR type to another
-			from: gadget.VolumeStructure{Type: "0C"},
-			to:   gadget.VolumeStructure{Type: "0A"},
+			from: gadget.VolumeStructure{Type: "0C", EnclosingVolume: &gadget.Volume{}},
+			to:   gadget.VolumeStructure{Type: "0A", EnclosingVolume: &gadget.Volume{}},
 			err:  `cannot change structure type from "0C" to "0A"`,
 		}, {
 			// from one MBR type to another
-			from: gadget.VolumeStructure{Type: "0C"},
-			to:   gadget.VolumeStructure{Type: "bare"},
+			from: gadget.VolumeStructure{Type: "0C", EnclosingVolume: &gadget.Volume{}},
+			to:   gadget.VolumeStructure{Type: "bare", EnclosingVolume: &gadget.Volume{}},
 			err:  `cannot change structure type from "0C" to "bare"`,
 		}, {
 			// from one GUID to another
-			from: gadget.VolumeStructure{Type: "00000000-0000-0000-0000-dd00deadcafe"},
-			to:   gadget.VolumeStructure{Type: "00000000-0000-0000-0000-dd00deadbeef"},
+			from: gadget.VolumeStructure{Type: "00000000-0000-0000-0000-dd00deadcafe", EnclosingVolume: &gadget.Volume{}},
+			to:   gadget.VolumeStructure{Type: "00000000-0000-0000-0000-dd00deadbeef", EnclosingVolume: &gadget.Volume{}},
 			err:  `cannot change structure type from "00000000-0000-0000-0000-dd00deadcafe" to "00000000-0000-0000-0000-dd00deadbeef"`,
 		}, {
-			from: gadget.VolumeStructure{Type: "bare"},
-			to:   gadget.VolumeStructure{Type: "bare"},
+			from: gadget.VolumeStructure{Type: "bare", EnclosingVolume: &gadget.Volume{}},
+			to:   gadget.VolumeStructure{Type: "bare", EnclosingVolume: &gadget.Volume{}},
 		}, {
-			from: gadget.VolumeStructure{Type: "0C"},
-			to:   gadget.VolumeStructure{Type: "0C"},
+			from: gadget.VolumeStructure{Type: "0C", EnclosingVolume: &gadget.Volume{}},
+			to:   gadget.VolumeStructure{Type: "0C", EnclosingVolume: &gadget.Volume{}},
 		}, {
-			from: gadget.VolumeStructure{Type: "00000000-0000-0000-0000-dd00deadbeef"},
-			to:   gadget.VolumeStructure{Type: "00000000-0000-0000-0000-dd00deadbeef"},
+			from: gadget.VolumeStructure{Type: "00000000-0000-0000-0000-dd00deadbeef", EnclosingVolume: &gadget.Volume{}},
+			to:   gadget.VolumeStructure{Type: "00000000-0000-0000-0000-dd00deadbeef", EnclosingVolume: &gadget.Volume{}},
 		}, {
-			from: gadget.VolumeStructure{Type: "0C,00000000-0000-0000-0000-dd00deadbeef"},
-			to:   gadget.VolumeStructure{Type: "0C,00000000-0000-0000-0000-dd00deadbeef"},
+			from: gadget.VolumeStructure{Type: "0C,00000000-0000-0000-0000-dd00deadbeef", EnclosingVolume: &gadget.Volume{}},
+			to:   gadget.VolumeStructure{Type: "0C,00000000-0000-0000-0000-dd00deadbeef", EnclosingVolume: &gadget.Volume{}},
 		},
 	}
 	u.testCanUpdate(c, cases)
@@ -384,25 +393,25 @@ func (u *updateTestSuite) TestCanUpdateBareOrFilesystem(c *C) {
 
 	cases := []canUpdateTestCase{
 		{
-			from: gadget.VolumeStructure{Type: "0C", Filesystem: "ext4", Offset: asOffsetPtr(0)},
-			to:   gadget.VolumeStructure{Type: "0C", Filesystem: "", Offset: asOffsetPtr(0)},
+			from: gadget.VolumeStructure{Type: "0C", Filesystem: "ext4", Offset: asOffsetPtr(0), EnclosingVolume: &gadget.Volume{}},
+			to:   gadget.VolumeStructure{Type: "0C", Filesystem: "", Offset: asOffsetPtr(0), EnclosingVolume: &gadget.Volume{}},
 			err:  `cannot change a filesystem structure to a bare one`,
 		}, {
-			from: gadget.VolumeStructure{Type: "0C", Filesystem: "", Offset: asOffsetPtr(0)},
-			to:   gadget.VolumeStructure{Type: "0C", Filesystem: "ext4", Offset: asOffsetPtr(0)},
+			from: gadget.VolumeStructure{Type: "0C", Filesystem: "", Offset: asOffsetPtr(0), EnclosingVolume: &gadget.Volume{}},
+			to:   gadget.VolumeStructure{Type: "0C", Filesystem: "ext4", Offset: asOffsetPtr(0), EnclosingVolume: &gadget.Volume{}},
 			err:  `cannot change a bare structure to filesystem one`,
 		}, {
-			from: gadget.VolumeStructure{Type: "0C", Filesystem: "ext4", Offset: asOffsetPtr(0)},
-			to:   gadget.VolumeStructure{Type: "0C", Filesystem: "vfat", Offset: asOffsetPtr(0)},
+			from: gadget.VolumeStructure{Type: "0C", Filesystem: "ext4", Offset: asOffsetPtr(0), EnclosingVolume: &gadget.Volume{}},
+			to:   gadget.VolumeStructure{Type: "0C", Filesystem: "vfat", Offset: asOffsetPtr(0), EnclosingVolume: &gadget.Volume{}},
 			err:  `cannot change filesystem from "ext4" to "vfat"`,
 		}, {
-			from: gadget.VolumeStructure{Type: "0C", Filesystem: "ext4", Label: "writable", Offset: asOffsetPtr(0)},
-			to:   gadget.VolumeStructure{Type: "0C", Filesystem: "ext4", Offset: asOffsetPtr(0)},
+			from: gadget.VolumeStructure{Type: "0C", Filesystem: "ext4", Label: "writable", Offset: asOffsetPtr(0), EnclosingVolume: &gadget.Volume{}},
+			to:   gadget.VolumeStructure{Type: "0C", Filesystem: "ext4", Offset: asOffsetPtr(0), EnclosingVolume: &gadget.Volume{}},
 			err:  `cannot change filesystem label from "writable" to ""`,
 		}, {
 			// all ok
-			from: gadget.VolumeStructure{Type: "0C", Filesystem: "ext4", Label: "do-not-touch", Offset: asOffsetPtr(0)},
-			to:   gadget.VolumeStructure{Type: "0C", Filesystem: "ext4", Label: "do-not-touch", Offset: asOffsetPtr(0)},
+			from: gadget.VolumeStructure{Type: "0C", Filesystem: "ext4", Label: "do-not-touch", Offset: asOffsetPtr(0), EnclosingVolume: &gadget.Volume{}},
+			to:   gadget.VolumeStructure{Type: "0C", Filesystem: "ext4", Label: "do-not-touch", Offset: asOffsetPtr(0), EnclosingVolume: &gadget.Volume{}},
 			err:  ``,
 		},
 	}
@@ -413,13 +422,13 @@ func (u *updateTestSuite) TestCanUpdateName(c *C) {
 
 	cases := []canUpdateTestCase{
 		{
-			from:   gadget.VolumeStructure{Name: "foo", Type: "0C"},
-			to:     gadget.VolumeStructure{Name: "mbr-ok", Type: "0C"},
+			from:   gadget.VolumeStructure{Name: "foo", Type: "0C", EnclosingVolume: &gadget.Volume{}},
+			to:     gadget.VolumeStructure{Name: "mbr-ok", Type: "0C", EnclosingVolume: &gadget.Volume{}},
 			err:    ``,
 			schema: "mbr",
 		}, {
-			from:   gadget.VolumeStructure{Name: "foo", Type: "00000000-0000-0000-0000-dd00deadbeef"},
-			to:     gadget.VolumeStructure{Name: "gpt-unhappy", Type: "00000000-0000-0000-0000-dd00deadbeef"},
+			from:   gadget.VolumeStructure{Name: "foo", Type: "00000000-0000-0000-0000-dd00deadbeef", EnclosingVolume: &gadget.Volume{}},
+			to:     gadget.VolumeStructure{Name: "gpt-unhappy", Type: "00000000-0000-0000-0000-dd00deadbeef", EnclosingVolume: &gadget.Volume{}},
 			err:    `cannot change structure name from "foo" to "gpt-unhappy"`,
 			schema: "gpt",
 		},
@@ -429,29 +438,29 @@ func (u *updateTestSuite) TestCanUpdateName(c *C) {
 
 func (u *updateTestSuite) TestCanUpdateOffsetRange(c *C) {
 	fromVss := []gadget.VolumeStructure{
-		{Offset: asOffsetPtr(0), MinSize: 10, Size: 20},
+		{Offset: asOffsetPtr(0), MinSize: 10, Size: 20, EnclosingVolume: &gadget.Volume{}},
 		// Valid offset range for second structure is [10, 20]
-		{MinSize: 10, Size: 10},
+		{MinSize: 10, Size: 10, EnclosingVolume: &gadget.Volume{}},
 	}
 	toVss := []gadget.VolumeStructure{
-		{Offset: asOffsetPtr(0), MinSize: 10, Size: 10},
-		{MinSize: 10, Size: 10},
+		{Offset: asOffsetPtr(0), MinSize: 10, Size: 10, EnclosingVolume: &gadget.Volume{}},
+		{MinSize: 10, Size: 10, EnclosingVolume: &gadget.Volume{}},
 	}
 
 	err := gadget.CanUpdateStructure(fromVss, 1, toVss, 1, "")
 	c.Check(err, IsNil)
 
 	toVss = []gadget.VolumeStructure{
-		{Offset: asOffsetPtr(0), MinSize: 15, Size: 21},
-		{MinSize: 10, Size: 10},
+		{Offset: asOffsetPtr(0), MinSize: 15, Size: 21, EnclosingVolume: &gadget.Volume{}},
+		{MinSize: 10, Size: 10, EnclosingVolume: &gadget.Volume{}},
 	}
 
 	err = gadget.CanUpdateStructure(fromVss, 1, toVss, 1, "")
 	c.Check(err, IsNil)
 
 	toVss = []gadget.VolumeStructure{
-		{Offset: asOffsetPtr(0), MinSize: 21, Size: 30},
-		{MinSize: 10, Size: 10},
+		{Offset: asOffsetPtr(0), MinSize: 21, Size: 30, EnclosingVolume: &gadget.Volume{}},
+		{MinSize: 10, Size: 10, EnclosingVolume: &gadget.Volume{}},
 	}
 
 	err = gadget.CanUpdateStructure(fromVss, 1, toVss, 1, "")
@@ -640,6 +649,8 @@ func (u *updateTestSuite) updateDataSet(c *C) (oldData gadget.GadgetData, newDat
 	makeSizedFile(c, filepath.Join(newRootDir, "/second-content/foo"), quantity.SizeKiB, nil)
 	makeSizedFile(c, filepath.Join(newRootDir, "/third-content/bar"), quantity.SizeKiB, nil)
 	newData = gadget.GadgetData{Info: newInfo, RootDir: newRootDir}
+	gadgettest.SetEnclosingVolumeInStructs(oldData.Info.Volumes)
+	gadgettest.SetEnclosingVolumeInStructs(newData.Info.Volumes)
 
 	rollbackDir = c.MkDir()
 	return oldData, newData, rollbackDir
@@ -2749,9 +2760,11 @@ func (u *updateTestSuite) TestUpdateApplyErrorLayout(c *C) {
 
 	newRootDir := c.MkDir()
 	newData := gadget.GadgetData{Info: newInfo, RootDir: newRootDir}
+	gadgettest.SetEnclosingVolumeInStructs(newData.Info.Volumes)
 
 	oldRootDir := c.MkDir()
 	oldData := gadget.GadgetData{Info: oldInfo, RootDir: oldRootDir}
+	gadgettest.SetEnclosingVolumeInStructs(oldData.Info.Volumes)
 
 	rollbackDir := c.MkDir()
 
@@ -2805,9 +2818,11 @@ func (u *updateTestSuite) TestUpdateApplyErrorIllegalVolumeUpdate(c *C) {
 
 	newRootDir := c.MkDir()
 	newData := gadget.GadgetData{Info: newInfo, RootDir: newRootDir}
+	gadgettest.SetEnclosingVolumeInStructs(newData.Info.Volumes)
 
 	oldRootDir := c.MkDir()
 	oldData := gadget.GadgetData{Info: oldInfo, RootDir: oldRootDir}
+	gadgettest.SetEnclosingVolumeInStructs(oldData.Info.Volumes)
 
 	rollbackDir := c.MkDir()
 
@@ -2859,9 +2874,11 @@ func (u *updateTestSuite) TestUpdateApplyErrorIllegalStructureUpdate(c *C) {
 
 	newRootDir := c.MkDir()
 	newData := gadget.GadgetData{Info: newInfo, RootDir: newRootDir}
+	gadgettest.SetEnclosingVolumeInStructs(newData.Info.Volumes)
 
 	oldRootDir := c.MkDir()
 	oldData := gadget.GadgetData{Info: oldInfo, RootDir: oldRootDir}
+	gadgettest.SetEnclosingVolumeInStructs(oldData.Info.Volumes)
 
 	rollbackDir := c.MkDir()
 
@@ -2937,12 +2954,14 @@ func (u *updateTestSuite) TestUpdateApplyUpdatesAreOptInWithDefaultPolicy(c *C) 
 	oldRootDir := c.MkDir()
 	oldData := gadget.GadgetData{Info: oldInfo, RootDir: oldRootDir}
 	makeSizedFile(c, filepath.Join(oldRootDir, "first.img"), quantity.SizeMiB, nil)
+	gadgettest.SetEnclosingVolumeInStructs(oldData.Info.Volumes)
 
 	newRootDir := c.MkDir()
 	// same volume description
 	newData := gadget.GadgetData{Info: oldInfo, RootDir: newRootDir}
 	// different content, but updates are opt in
 	makeSizedFile(c, filepath.Join(newRootDir, "first.img"), 900*quantity.SizeKiB, nil)
+	gadgettest.SetEnclosingVolumeInStructs(newData.Info.Volumes)
 
 	rollbackDir := c.MkDir()
 
@@ -3015,6 +3034,7 @@ func (u *updateTestSuite) policyDataSet(c *C) (oldData gadget.GadgetData, newDat
 	oldVol.Structure = append(oldVol.Structure, oldStructs...)
 	oldVol.Structure = append(oldVol.Structure, noPartitionStruct)
 	oldData.Info.Volumes["foo"] = oldVol
+	gadgettest.SetEnclosingVolumeInStructs(oldData.Info.Volumes)
 
 	newVol := newData.Info.Volumes["foo"]
 	newStructs := newVol.Structure
@@ -3022,6 +3042,7 @@ func (u *updateTestSuite) policyDataSet(c *C) (oldData gadget.GadgetData, newDat
 	newVol.Structure = append(newVol.Structure, newStructs...)
 	newVol.Structure = append(newVol.Structure, noPartitionStruct)
 	newData.Info.Volumes["foo"] = newVol
+	gadgettest.SetEnclosingVolumeInStructs(newData.Info.Volumes)
 
 	c.Assert(oldData.Info.Volumes["foo"].Structure, HasLen, 5)
 	c.Assert(newData.Info.Volumes["foo"].Structure, HasLen, 5)
@@ -3350,8 +3371,9 @@ func (u *updateTestSuite) TestUpdaterForStructure(c *C) {
 	psBare := &gadget.LaidOutStructure{
 		OnDiskStructure: gadget.OnDiskStructure{StartOffset: 1 * quantity.OffsetMiB},
 		VolumeStructure: &gadget.VolumeStructure{
-			Filesystem: "none",
-			Size:       10 * quantity.SizeMiB,
+			Filesystem:      "none",
+			Size:            10 * quantity.SizeMiB,
+			EnclosingVolume: &gadget.Volume{},
 		},
 	}
 	updater, err := gadget.UpdaterForStructure(gadget.StructureLocation{}, psBare, gadgetRootDir, rollbackDir, nil)
@@ -3361,17 +3383,18 @@ func (u *updateTestSuite) TestUpdaterForStructure(c *C) {
 	psFs := &gadget.LaidOutStructure{
 		OnDiskStructure: gadget.OnDiskStructure{StartOffset: 1 * quantity.OffsetMiB},
 		VolumeStructure: &gadget.VolumeStructure{
-			Filesystem: "ext4",
-			Size:       10 * quantity.SizeMiB,
-			Label:      "writable",
+			Filesystem:      "ext4",
+			Size:            10 * quantity.SizeMiB,
+			Label:           "writable",
+			EnclosingVolume: &gadget.Volume{},
 		},
 	}
-	updater, err = gadget.UpdaterForStructure(gadget.StructureLocation{}, psFs, gadgetRootDir, rollbackDir, nil)
+	updater, err = gadget.UpdaterForStructure(gadget.StructureLocation{RootMountPoint: "/"}, psFs, gadgetRootDir, rollbackDir, nil)
 	c.Assert(err, IsNil)
 	c.Assert(updater, FitsTypeOf, &gadget.MountedFilesystemUpdater{})
 
 	// trigger errors
-	updater, err = gadget.UpdaterForStructure(gadget.StructureLocation{}, psBare, gadgetRootDir, "", nil)
+	updater, err = gadget.UpdaterForStructure(gadget.StructureLocation{Device: "/dev/vda"}, psBare, gadgetRootDir, "", nil)
 	c.Assert(err, ErrorMatches, "internal error: backup directory cannot be unset")
 	c.Assert(updater, IsNil)
 }

--- a/overlord/devicestate/devicestate_remodel_test.go
+++ b/overlord/devicestate/devicestate_remodel_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/snapcore/snapd/asserts/assertstest"
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/gadget"
+	"github.com/snapcore/snapd/gadget/gadgettest"
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/assertstate"
@@ -1506,7 +1507,7 @@ volumes:
 		gadgetUpdateCalled = true
 		c.Check(policy, NotNil)
 		c.Check(reflect.ValueOf(policy).Pointer(), Equals, reflect.ValueOf(gadget.RemodelUpdatePolicy).Pointer())
-		c.Check(current, DeepEquals, gadget.GadgetData{
+		gd := gadget.GadgetData{
 			Info: &gadget.Info{
 				Volumes: map[string]*gadget.Volume{
 					"pc": {
@@ -1524,7 +1525,8 @@ volumes:
 							Content: []gadget.VolumeContent{
 								{UnresolvedSource: "foo-content", Target: "/"},
 							},
-							YamlIndex: 0,
+							YamlIndex:       0,
+							EnclosingVolume: &gadget.Volume{},
 						}, {
 							VolumeName: "pc",
 							Name:       "bare-one",
@@ -1535,14 +1537,17 @@ volumes:
 							Content: []gadget.VolumeContent{
 								{Image: "bare.img"},
 							},
-							YamlIndex: 1,
+							YamlIndex:       1,
+							EnclosingVolume: &gadget.Volume{},
 						}},
 					},
 				},
 			},
 			RootDir: currentGadgetInfo.MountDir(),
-		})
-		c.Check(update, DeepEquals, gadget.GadgetData{
+		}
+		gadgettest.SetEnclosingVolumeInStructs(gd.Info.Volumes)
+		c.Check(current, DeepEquals, gd)
+		gd = gadget.GadgetData{
 			Info: &gadget.Info{
 				Volumes: map[string]*gadget.Volume{
 					"pc": {
@@ -1577,7 +1582,9 @@ volumes:
 				},
 			},
 			RootDir: newGadgetInfo.MountDir(),
-		})
+		}
+		gadgettest.SetEnclosingVolumeInStructs(gd.Info.Volumes)
+		c.Check(update, DeepEquals, gd)
 		return nil
 	})
 	defer restore()


### PR DESCRIPTION
With this pointer we can access to "partial" options from the Volume, with information that we need to check if the structure needs a filesystem or if it has a partially defined size.

Additionally, rename willHaveFilesystem() to HasFilesystem() and use it everywhere, as in the end they mean the same: the structure definition in the gadget expects a filesystem to be there.
