### PR TITLE
devicestate: do not use the proxy for device-service on proxy errors

### DIFF
--- a/overlord/devicestate/devicestatetest/devicesvc.go
+++ b/overlord/devicestate/devicestatetest/devicesvc.go
@@ -94,8 +94,9 @@ func MockDeviceService(c *C, bhv *DeviceServiceBehavior) (mockServer *httptest.S
 			}
 			if bhv.Head != nil {
 				bhv.Head(c, bhv, w, r)
+			} else {
+				w.WriteHeader(200)
 			}
-			w.WriteHeader(200)
 			return
 		case "POST":
 			// carry on

--- a/overlord/devicestate/handlers_serial.go
+++ b/overlord/devicestate/handlers_serial.go
@@ -657,7 +657,16 @@ func getSerialRequestConfig(t *state.Task, regCtx registrationContext, client *h
 	if proxyURL != nil && svcURL != nil {
 		newEnough, err := newEnoughProxy(st, proxyURL, client)
 		if err != nil {
-			return nil, err
+			// Ignore the proxy on any error for
+			// compatibility with previous versions of
+			// snapd.
+			//
+			// TODO: provide a way for the users to specify
+			// if they want to use the proxy store for their
+			// device-service.url or not. This needs design.
+			// (see LP:#2023166)
+			logger.Noticef("cannot reach proxy store: %v; ignore the proxy", err)
+			proxyURL = nil
 		}
 		if !newEnough {
 			logger.Noticef("Proxy store does not support custom serial vault; ignoring the proxy")


### PR DESCRIPTION
When a `proxy.store` is used together with a `device-service.url` snapd will try to acquire the serial assertion via the proxy store.

If there was any error from the proxy store snapd would historically just ignore the proxy store and use the `device-service.url` directly.

However this behavior is not neccessarily correct as the proxy may just be down or configured incorrectly. So this was changed [1] but existing customers depend on the old behavior.

For a real fix we need a way to express that a proxy store should be used in general but that it should not be used for the `device-service.url`. This is not possible to express right now and needs design.

So as a short term fix this commit restores the old behavior.

[1] https://github.com/snapcore/snapd/pull/12593/files#diff-def3111c6efb66814e58452672900286c18087b637548fcee28c321ada4a2b6c
