### PR TITLE
tests: skip snap-advice-command test on exernal backend

### DIFF
--- a/tests/main/snap-advise-command/task.yaml
+++ b/tests/main/snap-advise-command/task.yaml
@@ -1,5 +1,9 @@
 summary: Ensure that `snap advise-snap` works
 
+# On some slow external devices the test fails to restart snapd on restore
+backends:
+    - -external
+
 # advise-snap / command-not-found only works on ubuntu classic, and on uc16
 # on uc18+ we don't have the /usr/lib/command-not-found symlink so it's not
 # useful


### PR DESCRIPTION
On some slow external devices the test fails to restart snapd on restore

As the test fails during restore, it means the whole execution fails forcing re-execution.

The idea is to run this for classic and uc16 in google.


