### PR TITLE
interface: partly revert network-control apparmor change (ee7e554)

### DIFF
--- a/interfaces/builtin/network_control.go
+++ b/interfaces/builtin/network_control.go
@@ -298,7 +298,7 @@ umount /,
 capability sys_ptrace,
 
 # 'ip netns exec foo /bin/sh'
-#mount options=(rw, rslave) /, # commented out because of LP: #2023025
+mount options=(rw, rslave) /,
 mount options=(rw, rslave), # LP: #1648245
 mount fstype=sysfs,
 umount /sys/,


### PR DESCRIPTION
This commit reverts the commenting out of the rule:
```
mount options=(rw, rslave) /,
```
This was broken in apparmor 3.1.4 but got fixed in 3.1.6.

