### PR TITLE
tests: increase retry in pre-download test

### DIFF
--- a/tests/main/auto-refresh-pre-download/task.yaml
+++ b/tests/main/auto-refresh-pre-download/task.yaml
@@ -34,7 +34,7 @@ execute: |
     local OLD_CHANGE="$1"
     local NEW_CHANGE
 
-    for _ in $(seq 5); do
+    for _ in $(seq 30); do
       NEW_CHANGE=$(snap changes | tail -n 2 | head -n 1 | awk '{print $1}')
       if [ "$NEW_CHANGE" -gt "$OLD_CHANGE" ]; then
         break


### PR DESCRIPTION
Increase a retry in a function used to determined whether a new change has been created. Since it's used after a snapd restart (when forcing an auto-refresh), the timeout wasn't enough to ensure that snapd had started, auto-refreshed and triggered the pre-download flow. This is meant to address the recent flakiness in this test.