### PR TITLE
tests: refresh before the refresh-hold test

### DIFF
--- a/tests/main/snap-refresh-hold/task.yaml
+++ b/tests/main/snap-refresh-hold/task.yaml
@@ -1,6 +1,8 @@
 summary: Check snap refresh hold and unhold
 
 prepare: |
+  # ensure no other pending refreshes can interfere with the test
+  snap refresh
   snap install test-snapd-tools
   snap set system experimental.parallel-instances=true
   snap install test-snapd-tools_instance


### PR DESCRIPTION
The snap-refresh-hold test was failing occasionally because the test would sometimes refresh a core snap which resulted in a system reboot when running on a Ubuntu Core system. This runs a refresh when preparing for the test so that it can't interfere with the test's checks.
