### PR TITLE
aspects: add transactions to aspects

### DIFF
--- a/aspects/aspects.go
+++ b/aspects/aspects.go
@@ -513,8 +513,7 @@ type JSONDataBag map[string]json.RawMessage
 // NewJSONDataBag returns a DataBag implementation that stores data in JSON.
 // The top-level of the JSON structure is always a map.
 func NewJSONDataBag() JSONDataBag {
-	storage := make(map[string]json.RawMessage)
-	return storage
+	return JSONDataBag(make(map[string]json.RawMessage))
 }
 
 // Get takes a path and a pointer to a variable into which the value referenced
@@ -656,6 +655,18 @@ func unset(subKeys []string, index int, node map[string]json.RawMessage) (json.R
 // Data returns all of the bag's data encoded in JSON.
 func (s JSONDataBag) Data() ([]byte, error) {
 	return json.Marshal(s)
+}
+
+// Copy returns a copy of the databag.
+func (s JSONDataBag) Copy() JSONDataBag {
+	toplevel := map[string]json.RawMessage(s)
+	copy := make(map[string]json.RawMessage, len(toplevel))
+
+	for k, v := range toplevel {
+		copy[k] = v
+	}
+
+	return JSONDataBag(copy)
 }
 
 // JSONSchema is the Schema implementation corresponding to JSONDataBag and it's

--- a/aspects/aspects_test.go
+++ b/aspects/aspects_test.go
@@ -281,7 +281,7 @@ type witnessDataBag struct {
 	getPath, setPath string
 }
 
-func newSpyDataBag(bag aspects.DataBag) *witnessDataBag {
+func newWitnessDataBag(bag aspects.DataBag) *witnessDataBag {
 	return &witnessDataBag{bag: bag}
 }
 
@@ -359,7 +359,7 @@ func (s *aspectSuite) TestAspectAssertionWithPlaceholder(c *C) {
 	} {
 		cmt := Commentf("sub-test %q failed", t.testName)
 
-		databag := newSpyDataBag(aspects.NewJSONDataBag())
+		databag := newWitnessDataBag(aspects.NewJSONDataBag())
 		err := aspect.Set(databag, t.name, "expectedValue")
 		c.Assert(err, IsNil, cmt)
 
@@ -603,4 +603,36 @@ func (s *aspectSuite) TestIsNotFoundHelper(c *C) {
 	c.Assert(aspects.IsNotFound(&aspects.AspectNotFoundError{}), Equals, true)
 	c.Assert(aspects.IsNotFound(&aspects.FieldNotFoundError{}), Equals, true)
 	c.Assert(aspects.IsNotFound(&aspects.InvalidAccessError{}), Equals, false)
+}
+
+func (s *aspectSuite) TestJSONDataBagCopy(c *C) {
+	bag := aspects.NewJSONDataBag()
+	err := bag.Set("foo", "bar")
+	c.Assert(err, IsNil)
+
+	// precondition check
+	data, err := bag.Data()
+	c.Assert(err, IsNil)
+	c.Assert(string(data), Equals, `{"foo":"bar"}`)
+
+	bagCopy := bag.Copy()
+	data, err = bagCopy.Data()
+	c.Assert(err, IsNil)
+	c.Assert(string(data), Equals, `{"foo":"bar"}`)
+
+	// changes in the copied bag don't affect the original
+	err = bagCopy.Set("foo", "baz")
+	c.Assert(err, IsNil)
+
+	data, err = bag.Data()
+	c.Assert(err, IsNil)
+	c.Assert(string(data), Equals, `{"foo":"bar"}`)
+
+	// and vice-versa
+	err = bag.Set("foo", "zab")
+	c.Assert(err, IsNil)
+
+	data, err = bagCopy.Data()
+	c.Assert(err, IsNil)
+	c.Assert(string(data), Equals, `{"foo":"baz"}`)
 }

--- a/aspects/transaction.go
+++ b/aspects/transaction.go
@@ -1,0 +1,136 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package aspects
+
+import (
+	"sync"
+)
+
+type DatabagRead func() (JSONDataBag, error)
+type DatabagWrite func(JSONDataBag) error
+
+// Transaction performs read and writes to a databag in an atomic way.
+type Transaction struct {
+	pristine JSONDataBag
+	deltas   []map[string]interface{}
+	schema   Schema
+
+	readDatabag  DatabagRead
+	writeDatabag DatabagWrite
+	mu           sync.RWMutex
+}
+
+// NewTransaction takes a getter and setter to read and write the databag.
+func NewTransaction(readDatabag DatabagRead, writeDatabag DatabagWrite, schema Schema) (*Transaction, error) {
+	databag, err := readDatabag()
+	if err != nil {
+		return nil, err
+	}
+
+	return &Transaction{
+		pristine:     databag.Copy(),
+		schema:       schema,
+		readDatabag:  readDatabag,
+		writeDatabag: writeDatabag,
+	}, nil
+}
+
+// Set sets a value in the transaction's databag. The change isn't persisted
+// until Commit returns without errors.
+func (t *Transaction) Set(path string, value interface{}) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.deltas = append(t.deltas, map[string]interface{}{path: value})
+	return nil
+}
+
+// Get reads a value from the transaction's databag including uncommitted changes.
+func (t *Transaction) Get(path string, value interface{}) error {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	// if there are changes, create a copy before applying (for isolation)
+	bag := t.pristine
+	if len(t.deltas) != 0 {
+		bag = t.pristine.Copy()
+
+		if err := applyDeltas(bag, t.deltas); err != nil {
+			return err
+		}
+	}
+
+	return bag.Get(path, value)
+}
+
+// Commit applies the previous writes and validates the final databag. If any
+// error occurs, the original databag is kept.
+func (t *Transaction) Commit() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	pristine, err := t.readDatabag()
+	if err != nil {
+		return err
+	}
+
+	// ensure we're using a different databag, so outside changes can't affect
+	// the transaction
+	pristine = pristine.Copy()
+
+	if err := applyDeltas(pristine, t.deltas); err != nil {
+		return err
+	}
+
+	data, err := pristine.Data()
+	if err != nil {
+		return err
+	}
+
+	if err := t.schema.Validate(data); err != nil {
+		return err
+	}
+
+	// copy the databag before writing to make sure the writer can't modify into
+	// and introduce changes in the transaction
+	if err := t.writeDatabag(pristine.Copy()); err != nil {
+		return err
+	}
+
+	t.pristine = pristine
+	t.deltas = nil
+	return nil
+}
+
+func applyDeltas(bag JSONDataBag, deltas []map[string]interface{}) error {
+	// changes must be applied in the order they were written
+	for _, delta := range deltas {
+		for k, v := range delta {
+			if err := bag.Set(k, v); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// Data returns the transaction's committed data.
+func (t *Transaction) Data() ([]byte, error) {
+	return t.pristine.Data()
+}

--- a/aspects/transaction_test.go
+++ b/aspects/transaction_test.go
@@ -1,0 +1,350 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package aspects_test
+
+import (
+	"errors"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/aspects"
+)
+
+type transactionTestSuite struct{}
+
+var _ = Suite(&transactionTestSuite{})
+
+type witnessReadWriter struct {
+	readCalled     int
+	writeCalled    int
+	bag            aspects.JSONDataBag
+	writtenDatabag aspects.JSONDataBag
+}
+
+func (w *witnessReadWriter) read() (aspects.JSONDataBag, error) {
+	w.readCalled++
+	return w.bag, nil
+}
+
+func (w *witnessReadWriter) write(bag aspects.JSONDataBag) error {
+	w.writeCalled++
+	w.writtenDatabag = bag
+	return nil
+}
+
+func (s *transactionTestSuite) TestSet(c *C) {
+	bag := aspects.NewJSONDataBag()
+	witness := &witnessReadWriter{bag: bag}
+	schema := aspects.NewJSONSchema()
+	tx, err := aspects.NewTransaction(witness.read, witness.write, schema)
+	c.Assert(err, IsNil)
+	c.Assert(witness.readCalled, Equals, 1)
+
+	err = tx.Set("foo", "bar")
+	c.Assert(err, IsNil)
+	c.Assert(witness.writeCalled, Equals, 0)
+
+	var value interface{}
+	err = witness.writtenDatabag.Get("foo", &value)
+	c.Assert(err, FitsTypeOf, &aspects.FieldNotFoundError{})
+}
+
+func (s *transactionTestSuite) TestCommit(c *C) {
+	witness := &witnessReadWriter{bag: aspects.NewJSONDataBag()}
+	schema := aspects.NewJSONSchema()
+	tx, err := aspects.NewTransaction(witness.read, witness.write, schema)
+	c.Assert(err, IsNil)
+	c.Assert(witness.readCalled, Equals, 1)
+
+	err = tx.Set("foo", "bar")
+	c.Assert(err, IsNil)
+	c.Assert(witness.readCalled, Equals, 1)
+	c.Assert(witness.writeCalled, Equals, 0)
+	c.Assert(witness.writtenDatabag, IsNil)
+
+	err = tx.Commit()
+	c.Assert(err, IsNil)
+
+	var value interface{}
+	err = witness.writtenDatabag.Get("foo", &value)
+	c.Assert(err, IsNil)
+
+	c.Assert(value, Equals, "bar")
+	c.Assert(witness.writeCalled, Equals, 1)
+}
+
+func (s *transactionTestSuite) TestGetReadsUncommitted(c *C) {
+	databag := aspects.NewJSONDataBag()
+	witness := &witnessReadWriter{bag: databag}
+	schema := aspects.NewJSONSchema()
+	tx, err := aspects.NewTransaction(witness.read, witness.write, schema)
+	c.Assert(err, IsNil)
+
+	err = databag.Set("foo", "bar")
+	c.Assert(err, IsNil)
+
+	err = tx.Set("foo", "baz")
+	c.Assert(err, IsNil)
+	// nothing was committed
+	c.Assert(witness.writeCalled, Equals, 0)
+	c.Assert(txData(c, tx), Equals, "{}")
+
+	var val string
+	err = tx.Get("foo", &val)
+	c.Assert(err, IsNil)
+	c.Assert(val, Equals, "baz")
+}
+
+type failingSchema struct {
+	err error
+}
+
+func (f *failingSchema) Validate([]byte) error {
+	return f.err
+}
+
+func (s *transactionTestSuite) TestRollBackOnCommitError(c *C) {
+	databag := aspects.NewJSONDataBag()
+	witness := &witnessReadWriter{bag: databag}
+	schema := &failingSchema{err: errors.New("expected error")}
+	tx, err := aspects.NewTransaction(witness.read, witness.write, schema)
+	c.Assert(err, IsNil)
+
+	err = tx.Set("foo", "bar")
+	c.Assert(err, IsNil)
+
+	err = tx.Commit()
+	c.Assert(err, ErrorMatches, "expected error")
+
+	// nothing was committed
+	c.Assert(witness.writeCalled, Equals, 0)
+	c.Assert(txData(c, tx), Equals, "{}")
+
+	// but subsequent Gets still read the uncommitted values
+	var val string
+	err = tx.Get("foo", &val)
+	c.Assert(err, IsNil)
+	c.Assert(val, Equals, "bar")
+}
+
+func (s *transactionTestSuite) TestManyWrites(c *C) {
+	databag := aspects.NewJSONDataBag()
+	witness := &witnessReadWriter{bag: databag}
+	schema := aspects.NewJSONSchema()
+	tx, err := aspects.NewTransaction(witness.read, witness.write, schema)
+	c.Assert(err, IsNil)
+
+	err = tx.Set("foo", "bar")
+	c.Assert(err, IsNil)
+	err = tx.Set("foo", "baz")
+	c.Assert(err, IsNil)
+
+	err = tx.Commit()
+	c.Assert(err, IsNil)
+	c.Assert(witness.writeCalled, Equals, 1)
+
+	// writes are applied in chronological order
+	c.Assert(txData(c, tx), Equals, `{"foo":"baz"}`)
+
+	var value interface{}
+	err = witness.writtenDatabag.Get("foo", &value)
+	c.Assert(err, IsNil)
+	c.Assert(value, Equals, "baz")
+}
+
+func (s *transactionTestSuite) TestCommittedIncludesRecentWrites(c *C) {
+	databag := aspects.NewJSONDataBag()
+	witness := &witnessReadWriter{bag: databag}
+	schema := aspects.NewJSONSchema()
+	tx, err := aspects.NewTransaction(witness.read, witness.write, schema)
+	c.Assert(err, IsNil)
+	c.Assert(witness.readCalled, Equals, 1)
+
+	err = tx.Set("foo", "bar")
+	c.Assert(err, IsNil)
+
+	err = databag.Set("bar", "baz")
+	c.Assert(err, IsNil)
+
+	err = tx.Commit()
+	c.Assert(err, IsNil)
+	// databag was read from state before writing
+	c.Assert(witness.readCalled, Equals, 2)
+	c.Assert(witness.writeCalled, Equals, 1)
+
+	// writes are applied in chronological order
+	var value interface{}
+	err = witness.writtenDatabag.Get("foo", &value)
+	c.Assert(err, IsNil)
+	c.Assert(value, Equals, "bar")
+
+	// contains recent values not written by the transaction
+	err = witness.writtenDatabag.Get("bar", &value)
+	c.Assert(err, IsNil)
+	c.Assert(value, Equals, "baz")
+}
+
+func (s *transactionTestSuite) TestCommittedIncludesPreviousCommit(c *C) {
+	var databag aspects.JSONDataBag
+	readBag := func() (aspects.JSONDataBag, error) {
+		if databag == nil {
+			return aspects.NewJSONDataBag(), nil
+		}
+		return databag, nil
+	}
+
+	writeBag := func(bag aspects.JSONDataBag) error {
+		databag = bag
+		return nil
+	}
+
+	schema := aspects.NewJSONSchema()
+	txOne, err := aspects.NewTransaction(readBag, writeBag, schema)
+	c.Assert(err, IsNil)
+
+	txTwo, err := aspects.NewTransaction(readBag, writeBag, schema)
+	c.Assert(err, IsNil)
+
+	err = txOne.Set("foo", "bar")
+	c.Assert(err, IsNil)
+
+	err = txTwo.Set("bar", "baz")
+	c.Assert(err, IsNil)
+
+	err = txOne.Commit()
+	c.Assert(err, IsNil)
+
+	var value interface{}
+	err = databag.Get("foo", &value)
+	c.Assert(err, IsNil)
+	c.Assert(value, Equals, "bar")
+
+	err = databag.Get("bar", &value)
+	c.Assert(err, FitsTypeOf, &aspects.FieldNotFoundError{})
+
+	err = txTwo.Commit()
+	c.Assert(err, IsNil)
+
+	value = nil
+	err = databag.Get("foo", &value)
+	c.Assert(err, IsNil)
+	c.Assert(value, Equals, "bar")
+
+	err = databag.Get("bar", &value)
+	c.Assert(err, IsNil)
+	c.Assert(value, Equals, "baz")
+}
+
+func (s *transactionTestSuite) TestTransactionBagReadError(c *C) {
+	var readErr error
+	readBag := func() (aspects.JSONDataBag, error) {
+		return nil, readErr
+	}
+	writeBag := func(_ aspects.JSONDataBag) error {
+		return nil
+	}
+
+	schema := aspects.NewJSONSchema()
+	txOne, err := aspects.NewTransaction(readBag, writeBag, schema)
+	c.Assert(err, IsNil)
+
+	readErr = errors.New("expected")
+	// Commit()'s databag read fails
+	err = txOne.Commit()
+	c.Assert(err, ErrorMatches, "expected")
+
+	// NewTransaction()'s databag read fails
+	txOne, err = aspects.NewTransaction(readBag, writeBag, schema)
+	c.Assert(err, ErrorMatches, "expected")
+}
+
+func (s *transactionTestSuite) TestTransactionBagWriteError(c *C) {
+	readBag := func() (aspects.JSONDataBag, error) {
+		return nil, nil
+	}
+	var writeErr error
+	writeBag := func(_ aspects.JSONDataBag) error {
+		return writeErr
+	}
+
+	schema := aspects.NewJSONSchema()
+	txOne, err := aspects.NewTransaction(readBag, writeBag, schema)
+	c.Assert(err, IsNil)
+
+	writeErr = errors.New("expected")
+	// Commit()'s databag write fails
+	err = txOne.Commit()
+	c.Assert(err, ErrorMatches, "expected")
+}
+
+func (s *transactionTestSuite) TestTransactionReadsIsolated(c *C) {
+	databag := aspects.NewJSONDataBag()
+	readBag := func() (aspects.JSONDataBag, error) {
+		return databag, nil
+	}
+	writeBag := func(aspects.JSONDataBag) error {
+		return nil
+	}
+
+	schema := aspects.NewJSONSchema()
+	tx, err := aspects.NewTransaction(readBag, writeBag, schema)
+	c.Assert(err, IsNil)
+
+	err = databag.Set("foo", "bar")
+	c.Assert(err, IsNil)
+
+	var value interface{}
+	err = tx.Get("foo", &value)
+	c.Assert(err, FitsTypeOf, &aspects.FieldNotFoundError{})
+}
+
+func (s *transactionTestSuite) TestReadDatabagsAreCopiedForIsolation(c *C) {
+	witness := &witnessReadWriter{bag: aspects.NewJSONDataBag()}
+	schema := &failingSchema{}
+	tx, err := aspects.NewTransaction(witness.read, witness.write, schema)
+	c.Assert(err, IsNil)
+
+	err = tx.Set("foo", "bar")
+	c.Assert(err, IsNil)
+
+	err = tx.Commit()
+	c.Assert(err, IsNil)
+
+	err = tx.Set("foo", "baz")
+	c.Assert(err, IsNil)
+
+	var value interface{}
+	err = witness.writtenDatabag.Get("foo", &value)
+	c.Assert(err, IsNil)
+	c.Assert(value, Equals, "bar")
+
+	schema.err = errors.New("expected error")
+	err = tx.Commit()
+	c.Assert(err, ErrorMatches, "expected error")
+
+	err = witness.writtenDatabag.Get("foo", &value)
+	c.Assert(err, IsNil)
+	c.Assert(value, Equals, "bar")
+}
+
+func txData(c *C, tx *aspects.Transaction) string {
+	data, err := tx.Data()
+	c.Assert(err, IsNil)
+	return string(data)
+}

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -158,8 +158,8 @@ var (
 	assertstateRefreshSnapAssertions         = assertstate.RefreshSnapAssertions
 	assertstateRestoreValidationSetsTracking = assertstate.RestoreValidationSetsTracking
 
-	aspectstateGet = aspectstate.Get
-	aspectstateSet = aspectstate.Set
+	aspectstateGetAspect = aspectstate.GetAspect
+	aspectstateSetAspect = aspectstate.SetAspect
 )
 
 func ensureStateSoonImpl(st *state.State) {

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"github.com/snapcore/snapd/aspects"
 	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/overlord"
@@ -313,18 +314,18 @@ var (
 	MaxReadBuflen = maxReadBuflen
 )
 
-func MockAspectstateGet(f func(st *state.State, account, bundleName, aspect, field string, value interface{}) error) (restore func()) {
-	old := aspectstateGet
-	aspectstateGet = f
+func MockAspectstateGet(f func(databag aspects.DataBag, account, bundleName, aspect, field string, value interface{}) error) (restore func()) {
+	old := aspectstateGetAspect
+	aspectstateGetAspect = f
 	return func() {
-		aspectstateGet = old
+		aspectstateGetAspect = old
 	}
 }
 
-func MockAspectstateSet(f func(st *state.State, account, bundleName, aspect, field string, val interface{}) error) (restore func()) {
-	old := aspectstateSet
-	aspectstateSet = f
+func MockAspectstateSet(f func(databag aspects.DataBag, account, bundleName, aspect, field string, val interface{}) error) (restore func()) {
+	old := aspectstateSetAspect
+	aspectstateSetAspect = f
 	return func() {
-		aspectstateSet = old
+		aspectstateSetAspect = old
 	}
 }

--- a/overlord/aspectstate/aspectstate.go
+++ b/overlord/aspectstate/aspectstate.go
@@ -26,20 +26,13 @@ import (
 	"github.com/snapcore/snapd/overlord/state"
 )
 
-// Set finds the aspect identified by the account, bundleName and aspect and sets
-// the specified field to the supplied value.
-func Set(st *state.State, account, bundleName, aspect, field string, value interface{}) error {
-	databag, err := getDatabag(st, account, bundleName)
-	if err != nil {
-		if !errors.Is(err, state.ErrNoState) {
-			return err
-		}
-
-		databag = aspects.NewJSONDataBag()
-	}
-
+// SetAspect finds the aspect identified by the account, bundleName and aspect
+// and sets the specified field to the supplied value in the provided matching databag.
+func SetAspect(databag aspects.DataBag, account, bundleName, aspect, field string, value interface{}) error {
 	accPatterns := aspecttest.MockWifiSetupAspect()
-	aspectBundle, err := aspects.NewAspectBundle(bundleName, accPatterns, aspects.NewJSONSchema())
+	schema := aspects.NewJSONSchema()
+
+	aspectBundle, err := aspects.NewAspectBundle(bundleName, accPatterns, schema)
 	if err != nil {
 		return err
 	}
@@ -53,27 +46,17 @@ func Set(st *state.State, account, bundleName, aspect, field string, value inter
 		return err
 	}
 
-	if err := updateDatabags(st, account, bundleName, databag); err != nil {
-		return err
-	}
-
 	return nil
 }
 
-// Get finds the aspect identified by the account, bundleName and aspect and
-// returns the specified field's value through the "value" output parameter.
-func Get(st *state.State, account, bundleName, aspect, field string, value interface{}) error {
-	databag, err := getDatabag(st, account, bundleName)
-	if err != nil {
-		if errors.Is(err, state.ErrNoState) {
-			return &aspects.AspectNotFoundError{Account: account, BundleName: bundleName, Aspect: aspect}
-		}
-
-		return err
-	}
-
+// GetAspect finds the aspect identified by the account, bundleName and aspect
+// and returns the specified field value from the provided matching databag
+// through the value output parameter.
+func GetAspect(databag aspects.DataBag, account, bundleName, aspect, field string, value interface{}) error {
 	accPatterns := aspecttest.MockWifiSetupAspect()
-	aspectBundle, err := aspects.NewAspectBundle(bundleName, accPatterns, aspects.NewJSONSchema())
+	schema := aspects.NewJSONSchema()
+
+	aspectBundle, err := aspects.NewAspectBundle(bundleName, accPatterns, schema)
 	if err != nil {
 		return err
 	}
@@ -90,13 +73,55 @@ func Get(st *state.State, account, bundleName, aspect, field string, value inter
 	return nil
 }
 
-func updateDatabags(st *state.State, account, bundleName string, databag aspects.JSONDataBag) error {
+// NewTransaction returns a transaction configured to read and write databags
+// from state as needed.
+func NewTransaction(st *state.State, account, bundleName string) (*aspects.Transaction, error) {
+	schema := aspects.NewJSONSchema()
+	getter := bagGetter(st, account, bundleName)
+	setter := func(bag aspects.JSONDataBag) error {
+		return updateDatabags(st, account, bundleName, bag)
+	}
+
+	tx, err := aspects.NewTransaction(getter, setter, schema)
+	if err != nil {
+		return nil, err
+	}
+
+	return tx, nil
+}
+
+func bagGetter(st *state.State, account, bundleName string) aspects.DatabagRead {
+	return func() (aspects.JSONDataBag, error) {
+		databag, err := getDatabag(st, account, bundleName)
+		if err != nil {
+			if !errors.Is(err, state.ErrNoState) {
+				return nil, err
+			}
+
+			databag = aspects.NewJSONDataBag()
+		}
+		return databag, nil
+	}
+}
+
+func getDatabag(st *state.State, account, bundleName string) (aspects.JSONDataBag, error) {
 	var databags map[string]map[string]aspects.JSONDataBag
 	if err := st.Get("aspect-databags", &databags); err != nil {
-		if !errors.Is(err, state.ErrNoState) {
-			return err
-		}
+		return nil, err
+	}
 
+	if databags[account] == nil || databags[account][bundleName] == nil {
+		return nil, state.ErrNoState
+	}
+	return databags[account][bundleName], nil
+}
+
+func updateDatabags(st *state.State, account, bundleName string, databag aspects.JSONDataBag) error {
+	var databags map[string]map[string]aspects.JSONDataBag
+	err := st.Get("aspect-databags", &databags)
+	if err != nil && !errors.Is(err, state.ErrNoState) {
+		return err
+	} else if errors.Is(err, &state.NoStateError{}) || databags[account] == nil || databags[account][bundleName] == nil {
 		databags = map[string]map[string]aspects.JSONDataBag{
 			account: {bundleName: aspects.NewJSONDataBag()},
 		}
@@ -105,12 +130,4 @@ func updateDatabags(st *state.State, account, bundleName string, databag aspects
 	databags[account][bundleName] = databag
 	st.Set("aspect-databags", databags)
 	return nil
-}
-
-func getDatabag(st *state.State, account, bundleName string) (aspects.JSONDataBag, error) {
-	var databags map[string]map[string]aspects.JSONDataBag
-	if err := st.Get("aspect-databags", &databags); err != nil {
-		return nil, err
-	}
-	return databags[account][bundleName], nil
 }

--- a/overlord/aspectstate/aspectstate_test.go
+++ b/overlord/aspectstate/aspectstate_test.go
@@ -46,56 +46,31 @@ func (s *aspectTestSuite) TestGetAspect(c *C) {
 	err := databag.Set("wifi.ssid", "foo")
 	c.Assert(err, IsNil)
 
-	s.state.Lock()
-	defer s.state.Unlock()
-	s.state.Set("aspect-databags", map[string]map[string]aspects.JSONDataBag{
-		"system": {"network": databag},
-	})
-
 	var res interface{}
-	err = aspectstate.Get(s.state, "system", "network", "wifi-setup", "ssid", &res)
+	err = aspectstate.GetAspect(databag, "system", "network", "wifi-setup", "ssid", &res)
 	c.Assert(err, IsNil)
 	c.Assert(res, Equals, "foo")
 }
 
 func (s *aspectTestSuite) TestGetNotFound(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
+	databag := aspects.NewJSONDataBag()
 
 	var res interface{}
-	err := aspectstate.Get(s.state, "system", "network", "wifi-setup", "ssid", &res)
-	c.Assert(err, FitsTypeOf, &aspects.AspectNotFoundError{})
-	c.Assert(err, ErrorMatches, `aspect system/network/wifi-setup not found`)
-	c.Check(res, IsNil)
-
-	s.state.Set("aspect-databags", map[string]map[string]aspects.JSONDataBag{
-		"system": {"network": aspects.NewJSONDataBag()},
-	})
-
-	err = aspectstate.Get(s.state, "system", "network", "other-aspect", "ssid", &res)
+	err := aspectstate.GetAspect(databag, "system", "network", "other-aspect", "ssid", &res)
 	c.Assert(err, FitsTypeOf, &aspects.AspectNotFoundError{})
 	c.Assert(err, ErrorMatches, `aspect system/network/other-aspect not found`)
 	c.Check(res, IsNil)
 
-	err = aspectstate.Get(s.state, "system", "network", "wifi-setup", "ssid", &res)
+	err = aspectstate.GetAspect(databag, "system", "network", "wifi-setup", "ssid", &res)
 	c.Assert(err, FitsTypeOf, &aspects.FieldNotFoundError{})
 	c.Assert(err, ErrorMatches, `cannot get field "ssid": no value was found under "wifi"`)
 	c.Check(res, IsNil)
 }
 
 func (s *aspectTestSuite) TestSetAspect(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	err := aspectstate.Set(s.state, "system", "network", "wifi-setup", "ssid", "foo")
+	databag := aspects.NewJSONDataBag()
+	err := aspectstate.SetAspect(databag, "system", "network", "wifi-setup", "ssid", "foo")
 	c.Assert(err, IsNil)
-
-	var databags map[string]map[string]aspects.JSONDataBag
-	err = s.state.Get("aspect-databags", &databags)
-	c.Assert(err, IsNil)
-
-	databag := databags["system"]["network"]
-	c.Assert(databag, NotNil)
 
 	var val string
 	err = databag.Get("wifi.ssid", &val)
@@ -104,43 +79,112 @@ func (s *aspectTestSuite) TestSetAspect(c *C) {
 }
 
 func (s *aspectTestSuite) TestSetNotFound(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	err := aspectstate.Set(s.state, "system", "other-bundle", "other-aspect", "foo", "bar")
+	databag := aspects.NewJSONDataBag()
+	err := aspectstate.SetAspect(databag, "system", "other-bundle", "other-aspect", "foo", "bar")
 	c.Assert(err, FitsTypeOf, &aspects.AspectNotFoundError{})
 
-	err = aspectstate.Set(s.state, "system", "network", "other-aspect", "foo", "bar")
+	err = aspectstate.SetAspect(databag, "system", "network", "other-aspect", "foo", "bar")
 	c.Assert(err, FitsTypeOf, &aspects.AspectNotFoundError{})
 }
 
 func (s *aspectTestSuite) TestSetAccessError(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	err := aspectstate.Set(s.state, "system", "network", "wifi-setup", "status", "foo")
+	databag := aspects.NewJSONDataBag()
+	err := aspectstate.SetAspect(databag, "system", "network", "wifi-setup", "status", "foo")
 	c.Assert(err, ErrorMatches, `cannot write field "status": only supports read access`)
 }
 
 func (s *aspectTestSuite) TestUnsetAspect(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	err := aspectstate.Set(s.state, "system", "network", "wifi-setup", "ssid", "foo")
+	databag := aspects.NewJSONDataBag()
+	err := aspectstate.SetAspect(databag, "system", "network", "wifi-setup", "ssid", "foo")
 	c.Assert(err, IsNil)
 
-	err = aspectstate.Set(s.state, "system", "network", "wifi-setup", "ssid", nil)
+	err = aspectstate.SetAspect(databag, "system", "network", "wifi-setup", "ssid", nil)
 	c.Assert(err, IsNil)
-
-	var databags map[string]map[string]aspects.JSONDataBag
-	err = s.state.Get("aspect-databags", &databags)
-	c.Assert(err, IsNil)
-
-	databag := databags["system"]["network"]
-	c.Assert(databag, NotNil)
 
 	var val string
 	err = databag.Get("wifi.ssid", &val)
 	c.Assert(err, FitsTypeOf, &aspects.FieldNotFoundError{})
 	c.Assert(val, Equals, "")
+}
+
+func (s *aspectTestSuite) TestNewTransactionExistingState(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	bag := aspects.NewJSONDataBag()
+	err := bag.Set("foo", "bar")
+	c.Assert(err, IsNil)
+	databags := map[string]map[string]aspects.JSONDataBag{
+		"system": {"network": bag},
+	}
+	s.state.Set("aspect-databags", databags)
+
+	tx, err := aspectstate.NewTransaction(s.state, "system", "network")
+	c.Assert(err, IsNil)
+
+	var value interface{}
+	err = tx.Get("foo", &value)
+	c.Assert(err, IsNil)
+	c.Assert(value, Equals, "bar")
+
+	err = tx.Set("foo", "baz")
+	c.Assert(err, IsNil)
+
+	err = tx.Commit()
+	c.Assert(err, IsNil)
+
+	err = s.state.Get("aspect-databags", &databags)
+	c.Assert(err, IsNil)
+	err = databags["system"]["network"].Get("foo", &value)
+	c.Assert(err, IsNil)
+	c.Assert(value, Equals, "baz")
+}
+
+func (s *aspectTestSuite) TestNewTransactionNoState(c *C) {
+	type testcase struct {
+		state map[string]map[string]aspects.JSONDataBag
+	}
+
+	testcases := []testcase{
+		{
+			state: map[string]map[string]aspects.JSONDataBag{
+				"system": {"network": nil},
+			},
+		},
+		{
+			state: map[string]map[string]aspects.JSONDataBag{
+				"system": nil,
+			},
+		},
+		{
+			state: map[string]map[string]aspects.JSONDataBag{},
+		},
+		{
+			state: nil,
+		},
+	}
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	for _, tc := range testcases {
+		s.state.Set("aspect-databags", tc.state)
+
+		tx, err := aspectstate.NewTransaction(s.state, "system", "network")
+		c.Assert(err, IsNil)
+
+		err = tx.Set("foo", "bar")
+		c.Assert(err, IsNil)
+
+		err = tx.Commit()
+		c.Assert(err, IsNil)
+
+		var databags map[string]map[string]aspects.JSONDataBag
+		err = s.state.Get("aspect-databags", &databags)
+		c.Assert(err, IsNil)
+
+		var value interface{}
+		err = databags["system"]["network"].Get("foo", &value)
+		c.Assert(err, IsNil)
+		c.Assert(value, Equals, "bar")
+	}
 }


### PR DESCRIPTION
Add a Transaction object that can be used to perform multiple get/set on a databag atomically. Transactions implement the DataBag interface so they can be used with the Aspects transparently.