### PR TITLE
tests: fix security-seccomp test by skip using the apparmor parser with cache

### DIFF
--- a/tests/main/security-seccomp/task.yaml
+++ b/tests/main/security-seccomp/task.yaml
@@ -44,7 +44,7 @@ prepare: |
         if snap debug sandbox-features --required apparmor:parser:snapd-internal; then
           APPARMOR_PARSER="/snap/snapd/current/usr/lib/snapd/apparmor_parser --config-file /snap/snapd/current/usr/lib/snapd/apparmor/parser.conf -b /snap/snapd/current/usr/lib/snapd/apparmor.d --policy-features /snap/snapd/current/usr/lib/snapd/apparmor.d/abi/3.0"
         fi
-        $APPARMOR_PARSER -r "$AAP"
+        $APPARMOR_PARSER -K -r "$AAP"
     fi
 
 restore: |
@@ -59,7 +59,7 @@ restore: |
         if snap debug sandbox-features --required apparmor:parser:snapd-internal; then
           APPARMOR_PARSER="/snap/snapd/current/usr/lib/snapd/apparmor_parser --config-file /snap/snapd/current/usr/lib/snapd/apparmor/parser.conf -b /snap/snapd/current/usr/lib/snapd/apparmor.d --policy-features /snap/snapd/current/usr/lib/snapd/apparmor.d/abi/3.0"
         fi
-        $APPARMOR_PARSER -r "$AAP"
+        $APPARMOR_PARSER -K -r "$AAP"
     fi
 
 execute: |


### PR DESCRIPTION
The test is failing sporadically in uc18. The error seems to be related to the apparmor_parser which is generating incorrect definitions. This error seems to be caused because of cached profiles.
