### PR TITLE
interfaces/opengl: add support for ARM Mali

### DIFF
--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -127,6 +127,8 @@ unix (bind,listen) type=seqpacket addr="@cuda-uvmfd-[0-9a-f]*",
 # ARM Mali driver
 /dev/mali[0-9]* rw,
 /dev/dma_buf_te rw,
+/dev/dma_heap/linux,cma rw,
+/dev/dma_heap/system rw,
 
 # NXP i.MX driver
 # https://github.com/Freescale/kernel-module-imx-gpu-viv
@@ -174,6 +176,8 @@ unix (send, receive) type=dgram peer=(addr="@var/run/nvidia-xdriver-*"),
 // will be added by snap-confine.
 var openglConnectedPlugUDev = []string{
 	`SUBSYSTEM=="drm", KERNEL=="card[0-9]*"`,
+	`SUBSYSTEM=="dma_heap", KERNEL=="linux,cma"`,
+	`SUBSYSTEM=="dma_heap", KERNEL=="system"`,
 	`KERNEL=="vchiq"`,
 	`KERNEL=="vcsm-cma"`,
 	`KERNEL=="renderD[0-9]*"`,

--- a/interfaces/builtin/opengl_test.go
+++ b/interfaces/builtin/opengl_test.go
@@ -83,6 +83,8 @@ func (s *OpenglInterfaceSuite) TestAppArmorSpec(c *C) {
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/dev/nvidia* rw,`)
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/dev/dri/renderD[0-9]* rw,`)
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/dev/mali[0-9]* rw,`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/dev/dma_heap/linux,cma rw,`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/dev/dma_heap/system rw,`)
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/dev/galcore rw,`)
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/usr/share/libdrm/amdgpu.ids r,`)
 }
@@ -90,9 +92,13 @@ func (s *OpenglInterfaceSuite) TestAppArmorSpec(c *C) {
 func (s *OpenglInterfaceSuite) TestUDevSpec(c *C) {
 	spec := &udev.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 13)
+	c.Assert(spec.Snippets(), HasLen, 15)
 	c.Assert(spec.Snippets(), testutil.Contains, `# opengl
 SUBSYSTEM=="drm", KERNEL=="card[0-9]*", TAG+="snap_consumer_app"`)
+	c.Assert(spec.Snippets(), testutil.Contains, `# opengl
+SUBSYSTEM=="dma_heap", KERNEL=="linux,cma", TAG+="snap_consumer_app"`)
+	c.Assert(spec.Snippets(), testutil.Contains, `# opengl
+SUBSYSTEM=="dma_heap", KERNEL=="system", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `# opengl
 KERNEL=="renderD[0-9]*", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `# opengl


### PR DESCRIPTION
Different version of ARM Mali drivers and libraries might access different path to do memory allocate, so I added 2 entries to resolve the issue

```
ubuntu@mtk-genio:~$ udevadm info --query property /dev/mali0
DEVPATH=/devices/platform/soc/13000000.mali/misc/mali0
DEVNAME=/dev/mali0
DEVMODE=0666
MAJOR=10
MINOR=123
SUBSYSTEM=misc
USEC_INITIALIZED=233197373
TAGS=:snap_ubuntu-frame_ubuntu-frame:snap_ubuntu-frame_screenshot:snap_ubuntu-frame_daemon:
CURRENT_TAGS=:snap_ubuntu-frame_ubuntu-frame:snap_ubuntu-frame_screenshot:snap_ubuntu-frame_daemon:

ubuntu@mtk-genio:~$ udevadm info --query property /dev/dma_heap/system
DEVPATH=/devices/virtual/dma_heap/system
DEVNAME=/dev/dma_heap/system
MAJOR=248
MINOR=0
SUBSYSTEM=dma_heap
USEC_INITIALIZED=2125565932
TAGS=:snap_ubuntu-frame_screenshot:snap_ubuntu-frame_ubuntu-frame:snap_ubuntu-frame_daemon:
CURRENT_TAGS=:snap_ubuntu-frame_screenshot:snap_ubuntu-frame_daemon:snap_ubuntu-frame_ubuntu-frame:

ubuntu@mtk-genio:~$ udevadm info --query property /dev/dma_heap/linux,cma
DEVPATH=/devices/virtual/dma_heap/linux,cma
DEVNAME=/dev/dma_heap/linux,cma
MAJOR=248
MINOR=1
SUBSYSTEM=dma_heap
USEC_INITIALIZED=1772032427
TAGS=:snap_ubuntu-frame_screenshot:snap_ubuntu-frame_daemon:snap_ubuntu-frame_ubuntu-frame:
CURRENT_TAGS=:snap_ubuntu-frame_screenshot:snap_ubuntu-frame_daemon:snap_ubuntu-frame_ubuntu-frame:
```