### PR TITLE
cmd/snap/cmd_aliases: update stale aliases cmd help text

### DIFF
--- a/cmd/snap/cmd_aliases.go
+++ b/cmd/snap/cmd_aliases.go
@@ -44,10 +44,6 @@ The aliases command lists all aliases available in the system and their status.
 $ snap aliases <snap>
 
 Lists only the aliases defined by the specified snap.
-
-An alias noted as undefined means it was explicitly enabled or disabled but is
-not defined in the current revision of the snap, possibly temporarily (e.g.
-because of a revert). This can cleared with 'snap alias --reset'.
 `)
 
 func init() {

--- a/cmd/snap/cmd_aliases_test.go
+++ b/cmd/snap/cmd_aliases_test.go
@@ -38,10 +38,6 @@ The aliases command lists all aliases available in the system and their status.
 $ snap aliases <snap>
 
 Lists only the aliases defined by the specified snap.
-
-An alias noted as undefined means it was explicitly enabled or disabled but is
-not defined in the current revision of the snap, possibly temporarily (e.g.
-because of a revert). This can cleared with 'snap alias --reset'.
 `
 	s.testSubCommandHelp(c, "aliases", msg)
 }


### PR DESCRIPTION
Remove section mentioning 'snap alias --reset' from aliases cmd which is now out of date as it was removed by commit e2d7e0ebd8d.