### PR TITLE
many: move SnapConfineAppArmorDir from dirs to sandbox/apparmor

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -41,26 +41,25 @@ var (
 
 	HiddenSnapDataHomeGlob string
 
-	SnapBlobDir            string
-	SnapDataDir            string
-	SnapDataHomeGlob       string
-	SnapDownloadCacheDir   string
-	SnapAppArmorDir        string
-	SnapConfineAppArmorDir string
-	SnapSeccompBase        string
-	SnapSeccompDir         string
-	SnapMountPolicyDir     string
-	SnapUdevRulesDir       string
-	SnapKModModulesDir     string
-	SnapKModModprobeDir    string
-	LocaleDir              string
-	SnapdSocket            string
-	SnapSocket             string
-	SnapRunDir             string
-	SnapRunNsDir           string
-	SnapRunLockDir         string
-	SnapBootstrapRunDir    string
-	SnapVoidDir            string
+	SnapBlobDir          string
+	SnapDataDir          string
+	SnapDataHomeGlob     string
+	SnapDownloadCacheDir string
+	SnapAppArmorDir      string
+	SnapSeccompBase      string
+	SnapSeccompDir       string
+	SnapMountPolicyDir   string
+	SnapUdevRulesDir     string
+	SnapKModModulesDir   string
+	SnapKModModprobeDir  string
+	LocaleDir            string
+	SnapdSocket          string
+	SnapSocket           string
+	SnapRunDir           string
+	SnapRunNsDir         string
+	SnapRunLockDir       string
+	SnapBootstrapRunDir  string
+	SnapVoidDir          string
 
 	SnapdMaintenanceFile string
 
@@ -365,7 +364,6 @@ func SetRootDir(rootdir string) {
 	SnapDataHomeGlob = filepath.Join(rootdir, "/home/*/", UserHomeSnapDir)
 	HiddenSnapDataHomeGlob = filepath.Join(rootdir, "/home/*/", HiddenSnapDataHomeDir)
 	SnapAppArmorDir = filepath.Join(rootdir, snappyDir, "apparmor", "profiles")
-	SnapConfineAppArmorDir = filepath.Join(rootdir, snappyDir, "apparmor", "snap-confine")
 	SnapDownloadCacheDir = filepath.Join(rootdir, snappyDir, "cache")
 	SnapSeccompBase = filepath.Join(rootdir, snappyDir, "seccomp")
 	SnapSeccompDir = filepath.Join(SnapSeccompBase, "bpf")

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -176,6 +176,10 @@ func snapConfineFromSnapProfile(info *snap.Info) (dir, glob string, content map[
 	patchedProfileText := bytes.Replace(
 		vanillaProfileText, []byte("/usr/lib/snapd/snap-confine"), []byte(snapConfineInCore), -1)
 
+	// Replace the path to the vanilla snap-confine apparmor snippets
+	patchedProfileText = bytes.Replace(
+		patchedProfileText, []byte("/var/lib/snapd/apparmor/snap-confine"), []byte(apparmor_sandbox.SnapConfineAppArmorDir), -1)
+
 	// Also replace the test providing access to verbatim
 	// /usr/lib/snapd/snap-confine, which is necessary because to execute snaps
 	// from strict snaps, we need to be able read and map
@@ -232,7 +236,7 @@ func snapConfineProfileName(snapName string, rev snap.Revision) string {
 //
 // Additionally it will cleanup stale apparmor profiles it created.
 func (b *Backend) setupSnapConfineReexec(info *snap.Info) error {
-	if err := os.MkdirAll(dirs.SnapConfineAppArmorDir, 0755); err != nil {
+	if err := os.MkdirAll(apparmor_sandbox.SnapConfineAppArmorDir, 0755); err != nil {
 		return fmt.Errorf("cannot create snap-confine policy directory: %s", err)
 	}
 	dir, glob, content, err := snapConfineFromSnapProfile(info)

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -1252,6 +1252,8 @@ func (s *backendSuite) writeVanillaSnapConfineProfile(c *C, coreOrSnapdInfo *sna
 	vanillaProfilePath := filepath.Join(coreOrSnapdInfo.MountDir(), "/etc/apparmor.d/usr.lib.snapd.snap-confine.real")
 	vanillaProfileText := []byte(`#include <tunables/global>
 /usr/lib/snapd/snap-confine (attach_disconnected) {
+    #include "/var/lib/snapd/apparmor/snap-confine"
+
     # We run privileged, so be fanatical about what we include and don't use
     # any abstractions
     /etc/ld.so.cache r,
@@ -1271,11 +1273,13 @@ func (s *backendSuite) TestSnapConfineProfile(c *C) {
 	expectedProfileGlob := "snap-confine.core.*"
 	expectedProfileText := fmt.Sprintf(`#include <tunables/global>
 %s/usr/lib/snapd/snap-confine (attach_disconnected) {
+    #include "%s/var/lib/snapd/apparmor/snap-confine"
+
     # We run privileged, so be fanatical about what we include and don't use
     # any abstractions
     /etc/ld.so.cache r,
 }
-`, coreInfo.MountDir())
+`, coreInfo.MountDir(), dirs.GlobalRootDir)
 
 	c.Assert(expectedProfileName, testutil.Contains, coreInfo.Revision.String())
 
@@ -1306,11 +1310,13 @@ func (s *backendSuite) TestSnapConfineProfileFromSnapdSnap(c *C) {
 	expectedProfileGlob := "snap-confine.snapd.222"
 	expectedProfileText := fmt.Sprintf(`#include <tunables/global>
 %s/usr/lib/snapd/snap-confine (attach_disconnected) {
+    #include "%s/var/lib/snapd/apparmor/snap-confine"
+
     # We run privileged, so be fanatical about what we include and don't use
     # any abstractions
     /etc/ld.so.cache r,
 }
-`, snapdInfo.MountDir())
+`, snapdInfo.MountDir(), dirs.GlobalRootDir)
 
 	c.Assert(expectedProfileName, testutil.Contains, snapdInfo.Revision.String())
 
@@ -1325,6 +1331,21 @@ func (s *backendSuite) TestSnapConfineProfileFromSnapdSnap(c *C) {
 			Mode:    0644,
 		},
 	})
+}
+
+func (s *backendSuite) TestSnapConfineProfileUsesSandboxSnapConfineDir(c *C) {
+	snapdInfo := snaptest.MockInfo(c, snapdYaml, &snap.SideInfo{Revision: snap.R(222)})
+	s.writeVanillaSnapConfineProfile(c, snapdInfo)
+	expectedProfileName := "snap-confine.snapd.222"
+
+	// Compute the profile and see that it replaces
+	// "/var/lib/snapd/apparmor/snap-confine" with the
+	// apparmor_sandbox.SnapConfineAppArmorDir dir
+	apparmor_sandbox.SnapConfineAppArmorDir = "/apparmor/sandbox/dir"
+	_, _, content, err := apparmor.SnapConfineFromSnapProfile(snapdInfo)
+	c.Assert(err, IsNil)
+	contentStr := string(content[expectedProfileName].(*osutil.MemoryFileState).Content)
+	c.Check(contentStr, testutil.Contains, `   #include "/apparmor/sandbox/dir"`)
 }
 
 func (s *backendSuite) TestSnapConfineFromSnapProfileCreatesAllDirs(c *C) {
@@ -1384,11 +1405,13 @@ func (s *backendSuite) TestSetupHostSnapConfineApparmorForReexecWritesNew(c *C) 
 	// No other changes other than that to the input
 	c.Check(newAA[0], testutil.FileEquals, fmt.Sprintf(`#include <tunables/global>
 %s/core/111/usr/lib/snapd/snap-confine (attach_disconnected) {
+    #include "%s/var/lib/snapd/apparmor/snap-confine"
+
     # We run privileged, so be fanatical about what we include and don't use
     # any abstractions
     /etc/ld.so.cache r,
 }
-`, dirs.SnapMountDir))
+`, dirs.SnapMountDir, dirs.GlobalRootDir))
 
 	c.Check(s.loadProfilesCalls, DeepEquals, []loadProfilesParams{
 		{[]string{newAA[0]}, fmt.Sprintf("%s/var/cache/apparmor", s.RootDir), 0},

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -1395,7 +1395,7 @@ func (s *backendSuite) TestSetupHostSnapConfineApparmorForReexecWritesNew(c *C) 
 	})
 
 	// snap-confine directory was created
-	_, err = os.Stat(dirs.SnapConfineAppArmorDir)
+	_, err = os.Stat(apparmor_sandbox.SnapConfineAppArmorDir)
 	c.Check(err, IsNil)
 }
 
@@ -1557,7 +1557,7 @@ func (s *backendSuite) testSetupSnapConfineGeneratedPolicyWithNFS(c *C, profileF
 	c.Assert(err, IsNil)
 
 	// Because NFS is being used, we have the extra policy file.
-	files, err := ioutil.ReadDir(dirs.SnapConfineAppArmorDir)
+	files, err := ioutil.ReadDir(apparmor_sandbox.SnapConfineAppArmorDir)
 	c.Assert(err, IsNil)
 	c.Assert(files, HasLen, 1)
 	c.Assert(files[0].Name(), Equals, "nfs-support")
@@ -1565,7 +1565,7 @@ func (s *backendSuite) testSetupSnapConfineGeneratedPolicyWithNFS(c *C, profileF
 	c.Assert(files[0].IsDir(), Equals, false)
 
 	// The policy allows network access.
-	fn := filepath.Join(dirs.SnapConfineAppArmorDir, files[0].Name())
+	fn := filepath.Join(apparmor_sandbox.SnapConfineAppArmorDir, files[0].Name())
 	c.Assert(fn, testutil.FileContains, "network inet,")
 	c.Assert(fn, testutil.FileContains, "network inet6,")
 
@@ -1605,7 +1605,7 @@ func (s *backendSuite) TestSetupSnapConfineGeneratedPolicyWithNFSAndReExec(c *C)
 	c.Assert(err, IsNil)
 
 	// Because NFS is being used, we have the extra policy file.
-	files, err := ioutil.ReadDir(dirs.SnapConfineAppArmorDir)
+	files, err := ioutil.ReadDir(apparmor_sandbox.SnapConfineAppArmorDir)
 	c.Assert(err, IsNil)
 	c.Assert(files, HasLen, 1)
 	c.Assert(files[0].Name(), Equals, "nfs-support")
@@ -1613,7 +1613,7 @@ func (s *backendSuite) TestSetupSnapConfineGeneratedPolicyWithNFSAndReExec(c *C)
 	c.Assert(files[0].IsDir(), Equals, false)
 
 	// The policy allows network access.
-	fn := filepath.Join(dirs.SnapConfineAppArmorDir, files[0].Name())
+	fn := filepath.Join(apparmor_sandbox.SnapConfineAppArmorDir, files[0].Name())
 	c.Assert(fn, testutil.FileContains, "network inet,")
 	c.Assert(fn, testutil.FileContains, "network inet6,")
 
@@ -1647,7 +1647,7 @@ func (s *backendSuite) TestSetupSnapConfineGeneratedPolicyError1(c *C) {
 	c.Assert(err, ErrorMatches, "cannot read .*corrupt-proc-self-exe: .*")
 
 	// We didn't create the policy file.
-	files, err := ioutil.ReadDir(dirs.SnapConfineAppArmorDir)
+	files, err := ioutil.ReadDir(apparmor_sandbox.SnapConfineAppArmorDir)
 	c.Assert(err, IsNil)
 	c.Assert(files, HasLen, 0)
 
@@ -1686,7 +1686,7 @@ func (s *backendSuite) TestSetupSnapConfineGeneratedPolicyError2(c *C) {
 
 	// While created the policy file initially we also removed it so that
 	// no side-effects remain.
-	files, err := ioutil.ReadDir(dirs.SnapConfineAppArmorDir)
+	files, err := ioutil.ReadDir(apparmor_sandbox.SnapConfineAppArmorDir)
 	c.Assert(err, IsNil)
 	c.Assert(files, HasLen, 0)
 
@@ -1755,7 +1755,7 @@ func (s *backendSuite) testSetupSnapConfineGeneratedPolicyWithOverlay(c *C, prof
 	c.Assert(err, IsNil)
 
 	// Because overlay is being used, we have the extra policy file.
-	files, err := ioutil.ReadDir(dirs.SnapConfineAppArmorDir)
+	files, err := ioutil.ReadDir(apparmor_sandbox.SnapConfineAppArmorDir)
 	c.Assert(err, IsNil)
 	c.Assert(files, HasLen, 1)
 	c.Assert(files[0].Name(), Equals, "overlay-root")
@@ -1763,7 +1763,7 @@ func (s *backendSuite) testSetupSnapConfineGeneratedPolicyWithOverlay(c *C, prof
 	c.Assert(files[0].IsDir(), Equals, false)
 
 	// The policy allows upperdir access.
-	data, err := ioutil.ReadFile(filepath.Join(dirs.SnapConfineAppArmorDir, files[0].Name()))
+	data, err := ioutil.ReadFile(filepath.Join(apparmor_sandbox.SnapConfineAppArmorDir, files[0].Name()))
 	c.Assert(err, IsNil)
 	c.Assert(string(data), testutil.Contains, "\"/upper/{,**/}\" r,")
 
@@ -1802,7 +1802,7 @@ func (s *backendSuite) TestSetupSnapConfineGeneratedPolicyWithOverlayAndReExec(c
 	c.Assert(err, IsNil)
 
 	// Because overlay is being used, we have the extra policy file.
-	files, err := ioutil.ReadDir(dirs.SnapConfineAppArmorDir)
+	files, err := ioutil.ReadDir(apparmor_sandbox.SnapConfineAppArmorDir)
 	c.Assert(err, IsNil)
 	c.Assert(files, HasLen, 1)
 	c.Assert(files[0].Name(), Equals, "overlay-root")
@@ -1810,7 +1810,7 @@ func (s *backendSuite) TestSetupSnapConfineGeneratedPolicyWithOverlayAndReExec(c
 	c.Assert(files[0].IsDir(), Equals, false)
 
 	// The policy allows upperdir access
-	data, err := ioutil.ReadFile(filepath.Join(dirs.SnapConfineAppArmorDir, files[0].Name()))
+	data, err := ioutil.ReadFile(filepath.Join(apparmor_sandbox.SnapConfineAppArmorDir, files[0].Name()))
 	c.Assert(err, IsNil)
 	c.Assert(string(data), testutil.Contains, "\"/upper/{,**/}\" r,")
 
@@ -1856,14 +1856,14 @@ func (s *backendSuite) testSetupSnapConfineGeneratedPolicyWithBPFCapability(c *C
 
 	// Capability bpf is supported by the parser, so an extra policy file
 	// for snap-confine is present
-	files, err := ioutil.ReadDir(dirs.SnapConfineAppArmorDir)
+	files, err := ioutil.ReadDir(apparmor_sandbox.SnapConfineAppArmorDir)
 	c.Assert(err, IsNil)
 	c.Assert(files, HasLen, 1)
 	c.Assert(files[0].Name(), Equals, "cap-bpf")
 	c.Assert(files[0].Mode(), Equals, os.FileMode(0644))
 	c.Assert(files[0].IsDir(), Equals, false)
 
-	c.Assert(filepath.Join(dirs.SnapConfineAppArmorDir, files[0].Name()),
+	c.Assert(filepath.Join(apparmor_sandbox.SnapConfineAppArmorDir, files[0].Name()),
 		testutil.FileContains, "capability bpf,")
 
 	if reexec {
@@ -1924,7 +1924,7 @@ func (s *backendSuite) TestSetupSnapConfineGeneratedPolicyWithBPFProbeError(c *C
 
 	// Probing apparmor_parser capabilities failed, so nothing gets written
 	// to the snap-confine policy directory
-	files, err := ioutil.ReadDir(dirs.SnapConfineAppArmorDir)
+	files, err := ioutil.ReadDir(apparmor_sandbox.SnapConfineAppArmorDir)
 	c.Assert(err, IsNil)
 	c.Assert(files, HasLen, 0)
 

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -1070,6 +1070,9 @@ profile snap-update-ns.###SNAP_INSTANCE_NAME### (attach_disconnected) {
   # snapd logger.go checks /proc/cmdline
   @{PROC}/cmdline r,
 
+  # snap checks if vendored apparmor parser should be used at startup
+  /usr/lib/snapd/info r,
+
 ###SNIPPETS###
 }
 `

--- a/sandbox/apparmor/apparmor.go
+++ b/sandbox/apparmor/apparmor.go
@@ -85,6 +85,14 @@ func setupConfCacheDirs(newrootdir string) {
 		// TODO: it seems Solus has a different setup too, investigate this
 		SystemCacheDir = CacheDir
 	}
+
+	snapConfineDir := "snap-confine"
+	if _, internal, err := AppArmorParser(); err == nil {
+		if internal {
+			snapConfineDir = "snap-confine.internal"
+		}
+	}
+	SnapConfineAppArmorDir = filepath.Join(dirs.SnapdStateDir(newrootdir), "apparmor", snapConfineDir)
 }
 
 func init() {
@@ -93,9 +101,10 @@ func init() {
 }
 
 var (
-	ConfDir        string
-	CacheDir       string
-	SystemCacheDir string
+	ConfDir                string
+	CacheDir               string
+	SystemCacheDir         string
+	SnapConfineAppArmorDir string
 )
 
 func (level LevelType) String() string {

--- a/sandbox/apparmor/apparmor_test.go
+++ b/sandbox/apparmor/apparmor_test.go
@@ -514,3 +514,28 @@ func (s *apparmorSuite) TestSnapdAppArmorSupportsReexecImpl(c *C) {
 	c.Assert(ioutil.WriteFile(infoFile, []byte("VERSION=foo\nSNAPD_APPARMOR_REEXEC=1"), 0644), IsNil)
 	c.Check(apparmor.SnapdAppArmorSupportsRexecImpl(), Equals, true)
 }
+
+func (s *apparmorSuite) TestSetupConfCacheDirs(c *C) {
+	apparmor.SetupConfCacheDirs("/newdir")
+	c.Check(apparmor.SnapConfineAppArmorDir, Equals, "/newdir/var/lib/snapd/apparmor/snap-confine")
+}
+
+func (s *apparmorSuite) TestSetupConfCacheDirsWithInternalApparmor(c *C) {
+	fakeroot := c.MkDir()
+	dirs.SetRootDir(fakeroot)
+
+	d := filepath.Join(dirs.SnapMountDir, "/snapd/42", "/usr/lib/snapd")
+	c.Assert(os.MkdirAll(d, 0755), IsNil)
+	p := filepath.Join(d, "apparmor_parser")
+	c.Assert(ioutil.WriteFile(p, nil, 0755), IsNil)
+	restore := snapdtool.MockOsReadlink(func(path string) (string, error) {
+		c.Assert(path, Equals, "/proc/self/exe")
+		return filepath.Join(d, "snapd"), nil
+	})
+	defer restore()
+	restore = apparmor.MockSnapdAppArmorSupportsReexec(func() bool { return true })
+	defer restore()
+
+	apparmor.SetupConfCacheDirs("/newdir")
+	c.Check(apparmor.SnapConfineAppArmorDir, Equals, "/newdir/var/lib/snapd/apparmor/snap-confine.internal")
+}

--- a/sandbox/apparmor/export_test.go
+++ b/sandbox/apparmor/export_test.go
@@ -28,7 +28,8 @@ import (
 )
 
 var (
-	NumberOfJobsParam = numberOfJobsParam
+	NumberOfJobsParam  = numberOfJobsParam
+	SetupConfCacheDirs = setupConfCacheDirs
 )
 
 func MockRuntimeNumCPU(new func() int) (restore func()) {

--- a/sandbox/apparmor/profile.go
+++ b/sandbox/apparmor/profile.go
@@ -295,7 +295,7 @@ var loadHomedirs = func() ([]string, error) {
 // Returns whether any modifications was made to the snap-confine snippets.
 func SetupSnapConfineSnippets() (wasChanged bool, err error) {
 	// Create the local policy directory if it is not there.
-	if err := os.MkdirAll(dirs.SnapConfineAppArmorDir, 0755); err != nil {
+	if err := os.MkdirAll(SnapConfineAppArmorDir, 0755); err != nil {
 		return false, fmt.Errorf("cannot create snap-confine policy directory: %s", err)
 	}
 
@@ -349,7 +349,7 @@ func SetupSnapConfineSnippets() (wasChanged bool, err error) {
 	}
 
 	// Ensure that generated policy is what we computed above.
-	created, removed, err := osutil.EnsureDirState(dirs.SnapConfineAppArmorDir, "*", policy)
+	created, removed, err := osutil.EnsureDirState(SnapConfineAppArmorDir, "*", policy)
 	if err != nil {
 		return false, fmt.Errorf("cannot synchronize snap-confine policy: %s", err)
 	}
@@ -359,6 +359,6 @@ func SetupSnapConfineSnippets() (wasChanged bool, err error) {
 // RemoveSnapConfineSnippets clears out any previously written apparmor snippets
 // for snap-confine.
 func RemoveSnapConfineSnippets() error {
-	_, _, err := osutil.EnsureDirState(dirs.SnapConfineAppArmorDir, "*", nil)
+	_, _, err := osutil.EnsureDirState(SnapConfineAppArmorDir, "*", nil)
 	return err
 }

--- a/sandbox/apparmor/profile_test.go
+++ b/sandbox/apparmor/profile_test.go
@@ -395,7 +395,7 @@ func (s *appArmorSuite) TestSetupSnapConfineSnippetsNoSnippets(c *C) {
 
 	// Because overlay/nfs is not used there are no local policy files but the
 	// directory was created.
-	files, err := ioutil.ReadDir(dirs.SnapConfineAppArmorDir)
+	files, err := ioutil.ReadDir(apparmor.SnapConfineAppArmorDir)
 	c.Assert(err, IsNil)
 	c.Assert(files, HasLen, 0)
 }
@@ -427,16 +427,16 @@ func (s *appArmorSuite) TestSetupSnapConfineSnippetsHomedirs(c *C) {
 
 	// Homedirs was specified, so we expect an entry for each homedir in a
 	// snippet 'homedirs'
-	files, err := ioutil.ReadDir(dirs.SnapConfineAppArmorDir)
+	files, err := ioutil.ReadDir(apparmor.SnapConfineAppArmorDir)
 	c.Assert(err, IsNil)
 	c.Assert(files, HasLen, 1)
 	c.Assert(files[0].Name(), Equals, "homedirs")
 	c.Assert(files[0].Mode(), Equals, os.FileMode(0644))
 	c.Assert(files[0].IsDir(), Equals, false)
 
-	c.Assert(filepath.Join(dirs.SnapConfineAppArmorDir, files[0].Name()),
+	c.Assert(filepath.Join(apparmor.SnapConfineAppArmorDir, files[0].Name()),
 		testutil.FileContains, `"/mnt/foo/" -> "/tmp/snap.rootfs_*/mnt/foo/",`)
-	c.Assert(filepath.Join(dirs.SnapConfineAppArmorDir, files[0].Name()),
+	c.Assert(filepath.Join(apparmor.SnapConfineAppArmorDir, files[0].Name()),
 		testutil.FileContains, `"/mnt/bar/" -> "/tmp/snap.rootfs_*/mnt/bar/",`)
 }
 
@@ -459,7 +459,7 @@ func (s *appArmorSuite) TestSetupSnapConfineGeneratedPolicyWithHomedirsLoadError
 
 	// Probing apparmor_parser capabilities failed, so nothing gets written
 	// to the snap-confine policy directory
-	files, err := ioutil.ReadDir(dirs.SnapConfineAppArmorDir)
+	files, err := ioutil.ReadDir(apparmor.SnapConfineAppArmorDir)
 	c.Assert(err, IsNil)
 	c.Assert(files, HasLen, 0)
 
@@ -488,14 +488,14 @@ func (s *appArmorSuite) TestSetupSnapConfineSnippetsBPF(c *C) {
 
 	// Capability bpf is supported by the parser, so an extra policy file
 	// for snap-confine is present
-	files, err := ioutil.ReadDir(dirs.SnapConfineAppArmorDir)
+	files, err := ioutil.ReadDir(apparmor.SnapConfineAppArmorDir)
 	c.Assert(err, IsNil)
 	c.Assert(files, HasLen, 1)
 	c.Assert(files[0].Name(), Equals, "cap-bpf")
 	c.Assert(files[0].Mode(), Equals, os.FileMode(0644))
 	c.Assert(files[0].IsDir(), Equals, false)
 
-	c.Assert(filepath.Join(dirs.SnapConfineAppArmorDir, files[0].Name()),
+	c.Assert(filepath.Join(apparmor.SnapConfineAppArmorDir, files[0].Name()),
 		testutil.FileContains, "capability bpf,")
 }
 
@@ -522,7 +522,7 @@ func (s *appArmorSuite) TestSetupSnapConfineGeneratedPolicyWithBPFProbeError(c *
 
 	// Probing apparmor_parser capabilities failed, so nothing gets written
 	// to the snap-confine policy directory
-	files, err := ioutil.ReadDir(dirs.SnapConfineAppArmorDir)
+	files, err := ioutil.ReadDir(apparmor.SnapConfineAppArmorDir)
 	c.Assert(err, IsNil)
 	c.Assert(files, HasLen, 0)
 
@@ -547,7 +547,7 @@ func (s *appArmorSuite) TestSetupSnapConfineSnippetsOverlay(c *C) {
 	c.Check(wasChanged, Equals, true)
 
 	// Because overlay is being used, we have the extra policy file.
-	files, err := ioutil.ReadDir(dirs.SnapConfineAppArmorDir)
+	files, err := ioutil.ReadDir(apparmor.SnapConfineAppArmorDir)
 	c.Assert(err, IsNil)
 	c.Assert(files, HasLen, 1)
 	c.Assert(files[0].Name(), Equals, "overlay-root")
@@ -555,7 +555,7 @@ func (s *appArmorSuite) TestSetupSnapConfineSnippetsOverlay(c *C) {
 	c.Assert(files[0].IsDir(), Equals, false)
 
 	// The policy allows upperdir access.
-	data, err := ioutil.ReadFile(filepath.Join(dirs.SnapConfineAppArmorDir, files[0].Name()))
+	data, err := ioutil.ReadFile(filepath.Join(apparmor.SnapConfineAppArmorDir, files[0].Name()))
 	c.Assert(err, IsNil)
 	c.Assert(string(data), testutil.Contains, "\"/upper/{,**/}\" r,")
 }
@@ -577,7 +577,7 @@ func (s *appArmorSuite) TestSetupSnapConfineSnippetsNFS(c *C) {
 	c.Check(wasChanged, Equals, true)
 
 	// Because NFS is being used, we have the extra policy file.
-	files, err := ioutil.ReadDir(dirs.SnapConfineAppArmorDir)
+	files, err := ioutil.ReadDir(apparmor.SnapConfineAppArmorDir)
 	c.Assert(err, IsNil)
 	c.Assert(files, HasLen, 1)
 	c.Assert(files[0].Name(), Equals, "nfs-support")
@@ -585,7 +585,7 @@ func (s *appArmorSuite) TestSetupSnapConfineSnippetsNFS(c *C) {
 	c.Assert(files[0].IsDir(), Equals, false)
 
 	// The policy allows network access.
-	fn := filepath.Join(dirs.SnapConfineAppArmorDir, files[0].Name())
+	fn := filepath.Join(apparmor.SnapConfineAppArmorDir, files[0].Name())
 	c.Assert(fn, testutil.FileContains, "network inet,")
 	c.Assert(fn, testutil.FileContains, "network inet6,")
 }
@@ -619,7 +619,7 @@ func (s *appArmorSuite) TestSetupSnapConfineGeneratedPolicyError1(c *C) {
 
 	// While other stuff failed we created the policy directory and didn't
 	// write any files to it.
-	files, err := ioutil.ReadDir(dirs.SnapConfineAppArmorDir)
+	files, err := ioutil.ReadDir(apparmor.SnapConfineAppArmorDir)
 	c.Check(err, IsNil)
 	c.Check(files, HasLen, 0)
 
@@ -633,16 +633,16 @@ func (s *appArmorSuite) TestSetupSnapConfineGeneratedPolicyError2(c *C) {
 	defer dirs.SetRootDir("")
 
 	// Create a file where we would expect to find the local policy.
-	err := os.RemoveAll(filepath.Dir(dirs.SnapConfineAppArmorDir))
+	err := os.RemoveAll(filepath.Dir(apparmor.SnapConfineAppArmorDir))
 	c.Assert(err, IsNil)
-	err = os.MkdirAll(filepath.Dir(dirs.SnapConfineAppArmorDir), 0755)
+	err = os.MkdirAll(filepath.Dir(apparmor.SnapConfineAppArmorDir), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(dirs.SnapConfineAppArmorDir, []byte(""), 0644)
+	err = ioutil.WriteFile(apparmor.SnapConfineAppArmorDir, []byte(""), 0644)
 	c.Assert(err, IsNil)
 
 	wasChanged, err := apparmor.SetupSnapConfineSnippets()
 	c.Check(err, ErrorMatches, fmt.Sprintf(`cannot create snap-confine policy directory: mkdir %s: not a directory`,
-		dirs.SnapConfineAppArmorDir))
+		apparmor.SnapConfineAppArmorDir))
 	c.Check(wasChanged, Equals, false)
 }
 
@@ -666,23 +666,23 @@ func (s *appArmorSuite) TestSetupSnapConfineGeneratedPolicyError3(c *C) {
 	// Create the snap-confine directory and put a file. Because the file name
 	// matches the glob generated-* snapd will attempt to remove it but because
 	// the directory is not writable, that operation will fail.
-	err := os.MkdirAll(dirs.SnapConfineAppArmorDir, 0755)
+	err := os.MkdirAll(apparmor.SnapConfineAppArmorDir, 0755)
 	c.Assert(err, IsNil)
-	f := filepath.Join(dirs.SnapConfineAppArmorDir, "generated-test")
+	f := filepath.Join(apparmor.SnapConfineAppArmorDir, "generated-test")
 	err = ioutil.WriteFile(f, []byte("spurious content"), 0644)
 	c.Assert(err, IsNil)
-	err = os.Chmod(dirs.SnapConfineAppArmorDir, 0555)
+	err = os.Chmod(apparmor.SnapConfineAppArmorDir, 0555)
 	c.Assert(err, IsNil)
 
 	// Make the directory writable for cleanup.
-	defer os.Chmod(dirs.SnapConfineAppArmorDir, 0755)
+	defer os.Chmod(apparmor.SnapConfineAppArmorDir, 0755)
 
 	wasChanged, err := apparmor.SetupSnapConfineSnippets()
 	c.Check(err.Error(), testutil.Contains, "cannot synchronize snap-confine policy")
 	c.Check(wasChanged, Equals, false)
 
 	// The policy directory was unchanged.
-	files, err := ioutil.ReadDir(dirs.SnapConfineAppArmorDir)
+	files, err := ioutil.ReadDir(apparmor.SnapConfineAppArmorDir)
 	c.Assert(err, IsNil)
 	c.Assert(files, HasLen, 1)
 }
@@ -692,16 +692,16 @@ func (s *appArmorSuite) TestRemoveSnapConfineSnippets(c *C) {
 	defer dirs.SetRootDir("")
 
 	// Create the snap-confine directory and put a few files.
-	err := os.MkdirAll(dirs.SnapConfineAppArmorDir, 0755)
+	err := os.MkdirAll(apparmor.SnapConfineAppArmorDir, 0755)
 	c.Assert(err, IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(dirs.SnapConfineAppArmorDir, "cap-test"), []byte("foo"), 0644), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(dirs.SnapConfineAppArmorDir, "my-file"), []byte("foo"), 0644), IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(apparmor.SnapConfineAppArmorDir, "cap-test"), []byte("foo"), 0644), IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(apparmor.SnapConfineAppArmorDir, "my-file"), []byte("foo"), 0644), IsNil)
 
 	err = apparmor.RemoveSnapConfineSnippets()
 	c.Check(err, IsNil)
 
 	// The files were removed
-	files, err := ioutil.ReadDir(dirs.SnapConfineAppArmorDir)
+	files, err := ioutil.ReadDir(apparmor.SnapConfineAppArmorDir)
 	c.Assert(err, IsNil)
 	c.Assert(files, HasLen, 0)
 }
@@ -711,14 +711,14 @@ func (s *appArmorSuite) TestRemoveSnapConfineSnippetsNoSnippets(c *C) {
 	defer dirs.SetRootDir("")
 
 	// Create the snap-confine directory and let it do nothing.
-	err := os.MkdirAll(dirs.SnapConfineAppArmorDir, 0755)
+	err := os.MkdirAll(apparmor.SnapConfineAppArmorDir, 0755)
 	c.Assert(err, IsNil)
 
 	err = apparmor.RemoveSnapConfineSnippets()
 	c.Check(err, IsNil)
 
 	// Nothing happens
-	files, err := ioutil.ReadDir(dirs.SnapConfineAppArmorDir)
+	files, err := ioutil.ReadDir(apparmor.SnapConfineAppArmorDir)
 	c.Assert(err, IsNil)
 	c.Assert(files, HasLen, 0)
 }

--- a/tests/main/snapd-snap/task.yaml
+++ b/tests/main/snapd-snap/task.yaml
@@ -239,7 +239,9 @@ execute: |
     snap debug sandbox-features --required apparmor:parser:snapd-internal
 
     echo "Ensure snap-confine apparmor profile points to snap-confine.internal"
-    MATCH '#include "/var/lib/snapd/apparmor/snap-confine.internal"' < /etc/apparmor.d/usr.lib.snapd.snap-confine.real
+    for profile in /var/lib/snapd/apparmor/profiles/snap-confine.*; do
+        MATCH '#include "/var/lib/snapd/apparmor/snap-confine.internal"' < "$profile"
+    done
 
     echo "Ensure we support posix mqueue and userns in the internal apparmor_parser"
     snap debug sandbox-features --required apparmor:parser:mqueue

--- a/tests/main/snapd-snap/task.yaml
+++ b/tests/main/snapd-snap/task.yaml
@@ -238,6 +238,9 @@ execute: |
     echo "Ensure sandbox-features shows the internal apparmor_parser"
     snap debug sandbox-features --required apparmor:parser:snapd-internal
 
+    echo "Ensure snap-confine apparmor profile points to snap-confine.internal"
+    MATCH '#include "/var/lib/snapd/apparmor/snap-confine.internal"' < /etc/apparmor.d/usr.lib.snapd.snap-confine.real
+
     echo "Ensure we support posix mqueue and userns in the internal apparmor_parser"
     snap debug sandbox-features --required apparmor:parser:mqueue
     snap debug sandbox-features --required apparmor:parser:userns


### PR DESCRIPTION
Then when using the internal vendored AppArmor, use a different location for SnapConfineAppArmorDir so that we don't interfere with the system installed AppArmor.

In Ubuntu, the snapd deb includes an AppArmor profile for /usr/lib/snapd/snap-confine that includes any profile snippets from the hard-coded directory of /var/lib/snapd/apparmor/snap-confine. When we use the snapd snap with the vendored AppArmor, this may contain newer features and so would create snippets under /var/lib/snapd/apparmor/snap-confine that then may not be supported by the system installed AppArmor. When the system installed apparmor.service would run on boot, it would try and load the snap-confine AppArmor profile shipped in the snapd deb, which would then try and include these snippets generated by the newer vendored AppArmor and could fail to load them as they would use new features not supported by the system AppArmor.

So instead, when using the vendored AppArmor, have snapd use a different directory for the snap-confine profile snippets and then have the snapd-generated AppArmor profiles for snap-confine reference this location instead. This should allow to support both use-cases simultaneously.
