### PR TITLE
sandbox/apparmor: don't let vendored apparmor conflict with system

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -1072,6 +1072,7 @@ profile snap-update-ns.###SNAP_INSTANCE_NAME### (attach_disconnected) {
 
   # snap checks if vendored apparmor parser should be used at startup
   /usr/lib/snapd/info r,
+  /lib/apparmor/functions r,
 
 ###SNIPPETS###
 }

--- a/sandbox/apparmor/apparmor.go
+++ b/sandbox/apparmor/apparmor.go
@@ -403,7 +403,9 @@ func systemAppArmorLoadsSnapPolicy() bool {
 	// load snapd generated apparmor policy (LP: #2024637)
 	f, err := os.Open(filepath.Join(dirs.GlobalRootDir, "/lib/apparmor/functions"))
 	if err != nil {
-		logger.Debugf("cannot open apparmor functions file: %v", err)
+		if !os.IsNotExist(err) {
+			logger.Debugf("cannot open apparmor functions file: %v", err)
+		}
 		return false
 	}
 	defer f.Close()

--- a/sandbox/apparmor/apparmor.go
+++ b/sandbox/apparmor/apparmor.go
@@ -32,6 +32,7 @@ import (
 	"sync"
 
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snapdtool"
 	"github.com/snapcore/snapd/strutil"
@@ -400,11 +401,13 @@ func probeParserFeatures() ([]string, error) {
 func systemAppArmorLoadsSnapPolicy() bool {
 	// on older Ubuntu systems the system installed apparmor may try and
 	// load snapd generated apparmor policy (LP: #2024637)
-	f, err := os.Open("/lib/apparmor/functions")
+	f, err := os.Open(filepath.Join(dirs.GlobalRootDir, "/lib/apparmor/functions"))
 	if err != nil {
+		logger.Debugf("cannot open apparmor functions file: %v", err)
 		return false
 	}
 	defer f.Close()
+
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -412,6 +415,10 @@ func systemAppArmorLoadsSnapPolicy() bool {
 			return true
 		}
 	}
+	if scanner.Err() != nil {
+		logger.Debugf("cannot scan apparmor functions file: %v", scanner.Err())
+	}
+
 	return false
 }
 

--- a/sandbox/apparmor/apparmor_test.go
+++ b/sandbox/apparmor/apparmor_test.go
@@ -33,6 +33,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/sandbox/apparmor"
 	"github.com/snapcore/snapd/snapdtool"
@@ -513,4 +514,49 @@ func (s *apparmorSuite) TestSnapdAppArmorSupportsReexecImpl(c *C) {
 	c.Check(apparmor.SnapdAppArmorSupportsRexecImpl(), Equals, false)
 	c.Assert(ioutil.WriteFile(infoFile, []byte("VERSION=foo\nSNAPD_APPARMOR_REEXEC=1"), 0644), IsNil)
 	c.Check(apparmor.SnapdAppArmorSupportsRexecImpl(), Equals, true)
+}
+
+func (s *apparmorSuite) TestSystemAppArmorLoadsSnapPolicyErr(c *C) {
+	os.Setenv("SNAPD_DEBUG", "1")
+	defer os.Unsetenv("SNAPD_DEBUG")
+
+	log, restore := logger.MockLogger()
+	defer restore()
+
+	fakeroot := c.MkDir()
+	dirs.SetRootDir(fakeroot)
+
+	c.Check(apparmor.SystemAppArmorLoadsSnapPolicy(), Equals, false)
+	c.Check(log.String(), Matches, `(?ms).* DEBUG: cannot open apparmor functions file: open .*/lib/apparmor/functions: no such file or directory`)
+}
+
+func (s *apparmorSuite) TestSystemAppArmorLoadsSnapPolicy(c *C) {
+	fakeroot := c.MkDir()
+	dirs.SetRootDir(fakeroot)
+
+	// systemAppArmorLoadsSnapPolicy() will look at this path so it
+	// needs to be the real path, not a faked one
+	dirs.SnapAppArmorDir = dirs.SnapAppArmorDir[len(fakeroot):]
+
+	fakeApparmorFunctionsPath := filepath.Join(fakeroot, "/lib/apparmor/functions")
+	err := os.MkdirAll(filepath.Dir(fakeApparmorFunctionsPath), 0755)
+	c.Assert(err, IsNil)
+
+	for _, tc := range []struct {
+		apparmorFunctionsContent string
+		expectedResult           bool
+	}{
+		{"", false},
+		{"unrelated content", false},
+		// 16.04
+		{`PROFILES_SNAPPY="/var/lib/snapd/apparmor/profiles"`, true},
+		// 18.04
+		{`PROFILES_VAR="/var/lib/snapd/apparmor/profiles"`, true},
+	} {
+		err := ioutil.WriteFile(fakeApparmorFunctionsPath, []byte(tc.apparmorFunctionsContent), 0644)
+		c.Assert(err, IsNil)
+
+		loadsPolicy := apparmor.SystemAppArmorLoadsSnapPolicy()
+		c.Check(loadsPolicy, Equals, tc.expectedResult, Commentf("%v", tc))
+	}
 }

--- a/sandbox/apparmor/export_test.go
+++ b/sandbox/apparmor/export_test.go
@@ -101,6 +101,7 @@ var (
 	PreferredParserFeatures = preferredParserFeatures
 
 	SnapdAppArmorSupportsRexecImpl = snapdAppArmorSupportsReexecImpl
+	SystemAppArmorLoadsSnapPolicy  = systemAppArmorLoadsSnapPolicy
 )
 
 func FreshAppArmorAssessment() {

--- a/tests/core/basic18/task.yaml
+++ b/tests/core/basic18/task.yaml
@@ -25,3 +25,12 @@ execute: |
 
     echo "Ensure passwd/group is available for snaps"
     test-snapd-sh-core18.sh -c 'cat /var/lib/extrausers/passwd' | MATCH test
+
+    # ensure apparmor works, see LP: 2024637
+    systemctl status apparmor.service
+    
+    # reboot to double check that apparmor still works after the reboot
+    # (LP: 2024637)
+    if [ "$SPREAD_REBOOT" = 0 ]; then
+        REBOOT
+    fi

--- a/tests/core/basic20plus/task.yaml
+++ b/tests/core/basic20plus/task.yaml
@@ -111,3 +111,12 @@ execute: |
         echo "${loop}" | MATCH "/dev/loop[0-9]+"
         losetup -O ro -n --raw "${loop}" | MATCH "1"
     done
+
+    # ensure apparmor works, see LP: 2024637
+    systemctl status apparmor.service
+
+    # reboot to double check that apparmor still works after the reboot
+    # (LP: 2024637)
+    if [ "$SPREAD_REBOOT" = 0 ]; then
+        REBOOT
+    fi

--- a/tests/main/snapd-snap/task.yaml
+++ b/tests/main/snapd-snap/task.yaml
@@ -235,6 +235,12 @@ execute: |
     echo "Ensure we restarted into the snapd snap"
     "$TESTSTOOLS"/journal-state match-log  'restarting into "/snap/snapd/'
 
+    # see LP:2024637
+    if grep -q /var/lib/snapd/apparmor/ /lib/apparmor/functions; then
+       echo "SKIP: cannot test buildin apparmor parser until /lib/apparmor/functions stops loading the snapd profiles"
+       exit 0
+    fi
+
     echo "Ensure sandbox-features shows the internal apparmor_parser"
     snap debug sandbox-features --required apparmor:parser:snapd-internal
 

--- a/tests/main/snapd-snap/task.yaml
+++ b/tests/main/snapd-snap/task.yaml
@@ -237,7 +237,7 @@ execute: |
 
     # see LP:2024637
     if grep -q /var/lib/snapd/apparmor/ /lib/apparmor/functions; then
-       echo "SKIP: cannot test buildin apparmor parser until /lib/apparmor/functions stops loading the snapd profiles"
+       echo "SKIP: cannot test builtin apparmor parser until /lib/apparmor/functions stops loading the snapd profiles"
        exit 0
     fi
 


### PR DESCRIPTION
Don't enable the vendored apparmor if the system installed apparmor will try and load policy that would be generated by the vendored apparmor and hence may conflict with that by using newer features not supported by the system installed apparmor (LP: 2024637)
