### PR TITLE
overlord: implement support for delayed restarts in the restart logic

### DIFF
--- a/overlord/devicestate/devicestate_remodel_test.go
+++ b/overlord/devicestate/devicestate_remodel_test.go
@@ -1597,6 +1597,10 @@ volumes:
 
 	s.state.Lock()
 	defer s.state.Unlock()
+
+	// simulate restart
+	s.mockRestartAndRun(c, s.state, chg)
+
 	c.Check(chg.IsReady(), Equals, true)
 	c.Check(chg.Err(), IsNil)
 	c.Check(gadgetUpdateCalled, Equals, true)

--- a/overlord/devicestate/devicestate_systems_test.go
+++ b/overlord/devicestate/devicestate_systems_test.go
@@ -1443,7 +1443,7 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemHappy
 
 	c.Assert(chg.Err(), IsNil)
 	c.Assert(tskCreate.Status(), Equals, state.DoneStatus)
-	c.Assert(tskFinalize.Status(), Equals, state.DoingStatus)
+	c.Assert(tskFinalize.Status(), Equals, state.WaitStatus)
 	// a reboot is expected
 	c.Check(s.restartRequests, DeepEquals, []restart.RestartType{restart.RestartSystemNow})
 
@@ -1492,6 +1492,9 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemHappy
 	s.settle(c)
 	s.state.Lock()
 	defer s.state.Unlock()
+
+	// simulate a restart and run change to completion
+	s.mockRestartAndRun(c, s.state, chg)
 
 	c.Assert(chg.Err(), IsNil)
 	c.Check(chg.IsReady(), Equals, true)
@@ -1618,7 +1621,7 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemRemod
 
 	c.Assert(chg.Err(), IsNil)
 	c.Assert(tskCreate.Status(), Equals, state.DoneStatus)
-	c.Assert(tskFinalize.Status(), Equals, state.DoingStatus)
+	c.Assert(tskFinalize.Status(), Equals, state.WaitStatus)
 	// a reboot is expected
 	c.Check(s.restartRequests, DeepEquals, []restart.RestartType{restart.RestartSystemNow})
 
@@ -1668,6 +1671,9 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemRemod
 	s.state.Unlock()
 	s.settle(c)
 	s.state.Lock()
+
+	// simulate a restart and run change to completion
+	s.mockRestartAndRun(c, s.state, chg)
 
 	c.Assert(chg.Err(), IsNil)
 	c.Check(chg.IsReady(), Equals, true)
@@ -1819,7 +1825,7 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemUndo(
 
 	c.Assert(chg.Err(), IsNil)
 	c.Assert(tskCreate.Status(), Equals, state.DoneStatus)
-	c.Assert(tskFinalize.Status(), Equals, state.DoingStatus)
+	c.Assert(tskFinalize.Status(), Equals, state.WaitStatus)
 	// a reboot is expected
 	c.Check(s.restartRequests, DeepEquals, []restart.RestartType{restart.RestartSystemNow})
 	// validity check asserted snaps location
@@ -1870,6 +1876,9 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemUndo(
 	s.settle(c)
 	s.state.Lock()
 	defer s.state.Unlock()
+
+	// simulate a restart and run change to completion
+	s.mockRestartAndRun(c, s.state, chg)
 
 	c.Assert(chg.Err(), ErrorMatches, "(?s)cannot perform the following tasks.* provoking total undo.*")
 	c.Check(chg.IsReady(), Equals, true)
@@ -1930,7 +1939,7 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemFinal
 
 	c.Assert(chg.Err(), IsNil)
 	c.Assert(tskCreate.Status(), Equals, state.DoneStatus)
-	c.Assert(tskFinalize.Status(), Equals, state.DoingStatus)
+	c.Assert(tskFinalize.Status(), Equals, state.WaitStatus)
 	// a reboot is expected
 	c.Check(s.restartRequests, DeepEquals, []restart.RestartType{restart.RestartSystemNow})
 
@@ -1971,6 +1980,9 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemFinal
 	s.settle(c)
 	s.state.Lock()
 	defer s.state.Unlock()
+
+	// simulate a restart and run change to completion
+	s.mockRestartAndRun(c, s.state, chg)
 
 	c.Assert(chg.Err(), ErrorMatches, `(?s)cannot perform the following tasks.* Finalize recovery system with label "1234" \(cannot promote recovery system "1234": system has not been successfully tried\)`)
 	c.Check(chg.IsReady(), Equals, true)
@@ -2113,7 +2125,7 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemReboo
 	// so far so good
 	c.Assert(chg.Err(), IsNil)
 	c.Assert(tskCreate.Status(), Equals, state.DoneStatus)
-	c.Assert(tskFinalize.Status(), Equals, state.DoingStatus)
+	c.Assert(tskFinalize.Status(), Equals, state.WaitStatus)
 	// a reboot is expected
 	c.Check(s.restartRequests, DeepEquals, []restart.RestartType{restart.RestartSystemNow})
 	c.Check(s.bootloader.SetBootVarsCalls, Equals, 2)

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -170,7 +170,7 @@ func (s *deviceMgrBaseSuite) setupBaseTest(c *C, classic bool) {
 	s.o = overlord.Mock()
 	s.state = s.o.State()
 	s.state.Lock()
-	_, err = restart.Manager(s.state, "boot-id-0", snapstatetest.MockRestartHandler(func(req restart.RestartType) {
+	_, err = restart.Manager(s.state, s.o.TaskRunner(), "boot-id-0", snapstatetest.MockRestartHandler(func(req restart.RestartType) {
 		s.restartRequests = append(s.restartRequests, req)
 		if s.restartObserve != nil {
 			s.restartObserve()

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -116,9 +116,9 @@ func (s *deviceMgrBaseSuite) mockRestartAndRun(c *C, st *state.State, chg *state
 	restart.MockRestartForChange(chg)
 
 	st.Unlock()
+	defer st.Lock()
 	err := s.o.Settle(settleTimeout)
-	st.Lock()
-	c.Assert(err, IsNil)
+	c.Check(err, IsNil)
 }
 
 type deviceMgrSuite struct {

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -110,6 +110,17 @@ type deviceMgrBaseSuite struct {
 	restoreProcessAutoImportAssertion func()
 }
 
+// mockRestartAndRun expects the state to be locked
+func (s *deviceMgrBaseSuite) mockRestartAndRun(c *C, st *state.State, chg *state.Change) {
+	restart.MockPending(st, restart.RestartUnset)
+	restart.MockRestartForChange(chg)
+
+	st.Unlock()
+	err := s.o.Settle(settleTimeout)
+	st.Lock()
+	c.Assert(err, IsNil)
+}
+
 type deviceMgrSuite struct {
 	deviceMgrBaseSuite
 }

--- a/overlord/hookstate/hookstate_test.go
+++ b/overlord/hookstate/hookstate_test.go
@@ -76,7 +76,7 @@ func (s *baseHookManagerSuite) commonSetUpTest(c *C) {
 	s.o = overlord.Mock()
 	s.state = s.o.State()
 	s.state.Lock()
-	_, err := restart.Manager(s.state, "boot-id-0", nil)
+	_, err := restart.Manager(s.state, s.o.TaskRunner(), "boot-id-0", nil)
 	s.state.Unlock()
 	c.Assert(err, IsNil)
 	manager, err := hookstate.Manager(s.state, s.o.TaskRunner())

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -517,9 +517,9 @@ func (s *baseMgrsSuite) mockRestartAndRun(c *C, st *state.State, chg *state.Chan
 	restart.MockRestartForChange(chg)
 
 	st.Unlock()
+	defer st.Lock()
 	err := s.o.Settle(settleTimeout)
-	st.Lock()
-	c.Assert(err, IsNil)
+	c.Check(err, IsNil)
 }
 
 // XXX: We have some very similar code in hookstate/ctlcmd/is_connected_test.go

--- a/overlord/restart/export_test.go
+++ b/overlord/restart/export_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2021-2023 Canonical Ltd
+ * Copyright (C) 2023 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/overlord/restart/export_test.go
+++ b/overlord/restart/export_test.go
@@ -19,6 +19,13 @@
 
 package restart
 
+import "github.com/snapcore/snapd/overlord/state"
+
 var (
+	ChangeRestartInfo       = changeRestartInfo
 	RequestRestartForChange = requestRestartForChange
 )
+
+func RestartInfoMarkTaskForRestart(rt *RestartInfo, task *state.Task, snapName string, status state.Status) {
+	rt.markTaskForRestart(task, snapName, status)
+}

--- a/overlord/restart/export_test.go
+++ b/overlord/restart/export_test.go
@@ -23,7 +23,7 @@ import "github.com/snapcore/snapd/overlord/state"
 
 var (
 	ChangeRestartInfo       = changeRestartInfo
-	RequestRestartForChange = requestRestartForChange
+	ProcessRestartForChange = processRestartForChange
 )
 
 func RestartInfoMarkTaskForRestart(rt *RestartContext, task *state.Task, snapName string, status state.Status) {

--- a/overlord/restart/export_test.go
+++ b/overlord/restart/export_test.go
@@ -26,6 +26,6 @@ var (
 	RequestRestartForChange = requestRestartForChange
 )
 
-func RestartInfoMarkTaskForRestart(rt *RestartInfo, task *state.Task, snapName string, status state.Status) {
+func RestartInfoMarkTaskForRestart(rt *RestartContext, task *state.Task, snapName string, status state.Status) {
 	rt.markTaskForRestart(task, snapName, status)
 }

--- a/overlord/restart/export_test.go
+++ b/overlord/restart/export_test.go
@@ -1,0 +1,24 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021-2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package restart
+
+var (
+	RequestRestartForChange = requestRestartForChange
+)

--- a/overlord/restart/restart.go
+++ b/overlord/restart/restart.go
@@ -380,7 +380,7 @@ func TaskWaitForRestart(t *state.Task) error {
 // does an immediate restart of the snapd daemon, depending on the type of restart
 // provided.
 // For SystemRestart and friends, the restart is scheduled and postponed until the
-// change has run out of tasks to do, and is then performed in RequestRestartForChange.
+// change has run out of tasks to do, and is then performed in processRestartForChange.
 // For tasks that request restarts as a part of their undo, any tasks that previously scheduled
 // restarts as a part of their 'do' will be unscheduled.
 func FinishTaskWithRestart(t *state.Task, snapName string, status state.Status, restartType RestartType, rebootInfo *boot.RebootInfo) error {
@@ -444,7 +444,7 @@ func changeRestartInfo(chg *state.Change) (*RestartContext, error) {
 	return &rt, nil
 }
 
-func requestRestartForChange(chg *state.Change) error {
+func processRestartForChange(chg *state.Change) error {
 	var rt RestartContext
 	if err := chg.Get("restart-info", &rt); err != nil {
 		if errors.Is(err, &state.NoStateError{}) {
@@ -466,7 +466,7 @@ func checkRestartRequiredForChange(chg *state.Change) {
 	if chg.Status() != state.WaitStatus {
 		return
 	}
-	if err := requestRestartForChange(chg); err != nil {
+	if err := processRestartForChange(chg); err != nil {
 		logger.Noticef("failed to request restart: %v", err)
 	}
 }

--- a/overlord/restart/restart.go
+++ b/overlord/restart/restart.go
@@ -343,168 +343,6 @@ func ReplaceBootID(st *state.State, bootID string) {
 	rm.bootID = bootID
 }
 
-type RestartWaiter struct {
-	TaskID string
-	Status state.Status
-}
-
-// XXX: How should we handle bootinfo and multiple requesters
-// when passing to restart package. Right now we just pass the last one.
-type RestartInfo struct {
-	Waiters        []*RestartWaiter
-	RestoreWaiters bool
-	SnapName       string
-	RestartType    RestartType
-	RebootInfo     *boot.RebootInfo
-	Requested      bool
-}
-
-func (rt *RestartInfo) needsReboot() bool {
-	return len(rt.Waiters) > 0 && !rt.Requested
-}
-
-func (rt *RestartInfo) setParameters(snapName string, restartType RestartType, rebootInfo *boot.RebootInfo) {
-	rt.Requested = false
-	rt.SnapName = snapName
-	rt.RestartType = restartType
-	rt.RebootInfo = rebootInfo
-}
-
-func (rt *RestartInfo) Reboot(st *state.State) {
-	rt.Requested = true
-	rt.Waiters = nil
-	rt.RestoreWaiters = false
-
-	if release.OnClassic {
-		// Notify the system that a reboot is required.
-		if err := notifyRebootRequiredClassic(rt.SnapName); err != nil {
-			logger.Noticef("cannot notify about pending reboot: %v", err)
-		}
-		logger.Noticef("Postponing restart until a manual system restart allows to continue")
-		return
-	}
-	Request(st, rt.RestartType, rt.RebootInfo)
-}
-
-func (rt *RestartInfo) taskFromID(chg *state.Change, id string) *state.Task {
-	for _, t := range chg.Tasks() {
-		if t.ID() == id {
-			return t
-		}
-	}
-	return nil
-}
-
-func (rt *RestartInfo) restoreWaiters(chg *state.Change) {
-	for _, w := range rt.Waiters {
-		if t := rt.taskFromID(chg, w.TaskID); t != nil {
-			t.SetStatus(w.Status)
-		}
-	}
-	rt.Waiters = nil
-	rt.RestoreWaiters = false
-}
-
-func (rt *RestartInfo) doUndoReboot(t *state.Task, status state.Status) error {
-	// Immediately, on the first undo, we clear all the waiters that previously
-	// has requested a reboot, that are now in WaitStatus. We put those back into
-	// their original requested state.
-	if rt.RestoreWaiters {
-		rt.restoreWaiters(t.Change())
-	}
-	return rt.doReboot(t, status)
-}
-
-func (rt *RestartInfo) taskInSlice(t *state.Task, ts []*state.Task) bool {
-	for _, tt := range ts {
-		if tt == t {
-			return true
-		}
-	}
-	return false
-}
-
-// markTaskForRestart sets certain properties on a task to mark it for restart.
-func (rt *RestartInfo) markTaskForRestart(task *state.Task, snapName string, status state.Status) {
-	rm := restartManager(task.State(), "internal error: cannot request a restart before RestartManager initialization")
-
-	// store current boot id to be able to check later if we have rebooted or not
-	task.Set("wait-for-system-restart-from-boot-id", rm.bootID)
-	task.SetToWait(status)
-	setWaitForSystemRestart(task.Change())
-
-	rt.Waiters = append(rt.Waiters, &RestartWaiter{
-		TaskID: task.ID(),
-		Status: status,
-	})
-}
-
-func (rt *RestartInfo) doReboot(t *state.Task, status state.Status) error {
-	switch status {
-	case state.DoneStatus:
-		// A bit of a edge-case scenario, if the task has no halt
-		// tasks (tasks waiting for this one), then we can put this
-		// task into WaitStatus.
-		if len(t.HaltTasks()) == 0 {
-			rt.markTaskForRestart(t, rt.SnapName, status)
-			return nil
-		}
-
-		// If the task does have halt tasks, we cannot do this as this would block
-		// execution of tasks that need this task to be completed to run, i.e. think
-		// changes with multiple lanes where each lane depends on a part of a different lane
-		// to have finished executing. We do this for instance to allow multiple snaps to partly
-		// install, and then handle their required restart as one, instead of restarting once per
-		// snap in each lane.
-		// To properly fix this we would need to account for the resulting status
-		// after the wait when determining when a tasks pre-conditions have completed.
-		// This would require support in the taskrunner. Instead handle this here, by moving
-		// the wait to the halt-tasks in same lane (and only same lane).
-		chg := t.Change()
-		laneTasks := chg.LaneTasks(t.Lanes()...)
-		for _, wt := range t.HaltTasks() {
-			if rt.taskInSlice(wt, laneTasks) {
-				originalStatus := wt.Status()
-				rt.markTaskForRestart(wt, rt.SnapName, originalStatus)
-			}
-		}
-	case state.UndoneStatus:
-		// XXX: This is logic kept from the previous restart logic. What is the reasoning here?
-		if release.OnClassic {
-			t.SetStatus(status)
-			t.Logf("Skipped automatic system restart on classic system when undoing changes back to previous state")
-			return nil
-		}
-
-		// Same goes for undoing, if there are no wait tasks, then
-		// put this into wait.
-		if len(t.WaitTasks()) == 0 {
-			rt.markTaskForRestart(t, rt.SnapName, status)
-			return nil
-		}
-
-		chg := t.Change()
-		laneTasks := chg.LaneTasks(t.Lanes()...)
-		for _, wt := range t.WaitTasks() {
-			if rt.taskInSlice(wt, laneTasks) {
-				rt.markTaskForRestart(wt, rt.SnapName, wt.Status())
-			}
-		}
-	case state.UndoStatus:
-		if release.OnClassic {
-			t.SetStatus(status)
-			t.Logf("Skipped automatic system restart on classic system when undoing changes back to previous state")
-			return nil
-		}
-		fallthrough
-	case state.DoStatus:
-		rt.markTaskForRestart(t, rt.SnapName, status)
-		return &state.Wait{Reason: "Postponing reboot as long as there are tasks to run"}
-	}
-	t.SetStatus(status)
-	return nil
-}
-
 // TaskWaitForRestart can be used for tasks that need to wait for a pending
 // restart to occur. The task will then be restored to the provided status
 // after the reboot, and then re-run.
@@ -566,22 +404,6 @@ func RequestRestartForTask(t *state.Task, snapName string, status state.Status, 
 		return err
 	}
 
-	// If system restart is requested, consider how the change the
-	// task belongs to is configured (system-restart-immediate) to
-	// choose whether request an immediate restart or not.
-	var immediate bool
-	chg := t.Change()
-	if chg != nil {
-		// Ignore errors intentionally, to follow
-		// RequestRestart itself which does not
-		// return errors. If the state is corrupt
-		// something else will error.
-		chg.Get("system-restart-immediate", &immediate)
-		if restartType == RestartSystem && immediate {
-			restartType = RestartSystemNow
-		}
-	}
-
 	// Update restart params.
 	rt.setParameters(snapName, restartType, rebootInfo)
 
@@ -601,19 +423,20 @@ func RequestRestartForTask(t *state.Task, snapName string, status state.Status, 
 	}
 
 	// Store updated copy of restart-info.
+	chg := t.Change()
 	chg.Set("restart-info", rt)
 	return err
 }
 
-func changeRestartInfo(chg *state.Change) (*RestartInfo, error) {
-	var rt RestartInfo
+func changeRestartInfo(chg *state.Change) (*RestartContext, error) {
+	var rt RestartContext
 	if chg == nil {
 		return nil, fmt.Errorf("task is not bound to any change")
 	}
 
 	if err := chg.Get("restart-info", &rt); err != nil {
 		if errors.Is(err, &state.NoStateError{}) {
-			rt := &RestartInfo{}
+			rt := &RestartContext{}
 			chg.Set("restart-info", rt)
 			return rt, nil
 		}
@@ -623,7 +446,7 @@ func changeRestartInfo(chg *state.Change) (*RestartInfo, error) {
 }
 
 func requestRestartForChange(chg *state.Change) error {
-	var rt RestartInfo
+	var rt RestartContext
 	if err := chg.Get("restart-info", &rt); err != nil {
 		if errors.Is(err, &state.NoStateError{}) {
 			return fmt.Errorf("change %s is waiting to continue but has not requested any reboots", chg.ID())

--- a/overlord/restart/restart.go
+++ b/overlord/restart/restart.go
@@ -114,7 +114,10 @@ func (rm *RestartManager) init(fromBootID, curBootID string) error {
 	}
 	// we rebooted alright
 	ClearReboot(rm.state)
-	return rm.rebootAsExpected()
+	if err := rm.rebootAsExpected(); err != nil {
+		return err
+	}
+	return nil
 }
 
 // ClearReboot clears state information about tracking requested reboots.
@@ -223,17 +226,30 @@ func (rm *RestartManager) PendingForSystemRestart(chg *state.Change) bool {
 			// but if it happens fair game for aborting
 			continue
 		}
-		// no boot intervened yet
 
-		if len(t.HaltTasks()) == 0 {
-			// no successive tasks, take the WaitStatus at face value
-			return true
-		}
-		// check if there are tasks which need doing (DoStatus)
+		// no boot intervened yet
+		// check if there are tasks which need doing
 		// that depend on the task that is waiting for reboot
-		for _, dep := range t.HaltTasks() {
-			if dep.Status() == state.DoStatus {
+		switch t.WaitedStatus() {
+		case state.DoStatus, state.DoneStatus:
+			if len(t.HaltTasks()) == 0 {
+				// no successive tasks, take the WaitStatus at face value
 				return true
+			}
+			for _, dep := range t.HaltTasks() {
+				if dep.Status() == state.DoStatus {
+					return true
+				}
+			}
+		case state.UndoStatus, state.UndoneStatus:
+			if len(t.WaitTasks()) == 0 {
+				// no successive tasks, take the WaitStatus at face value
+				return true
+			}
+			for _, dep := range t.WaitTasks() {
+				if dep.Status() == state.UndoStatus {
+					return true
+				}
 			}
 		}
 	}
@@ -341,6 +357,12 @@ func FinishTaskWithRestart(task *state.Task, status state.Status, rt RestartType
 	return nil
 }
 
+// RestartIsPending checks if a restart is pending for a task using the restart manager.
+func RestartIsPending(st *state.State, chg *state.Change) bool {
+	rm := restartManager(st, "internal error: cannot request a restart before RestartManager initialization")
+	return rm.PendingForSystemRestart(chg)
+}
+
 // Pending returns whether a restart was requested with Request and of which type.
 func Pending(st *state.State) (bool, RestartType) {
 	cached := st.Cached(restartManagerKey{})
@@ -361,4 +383,285 @@ func MockPending(st *state.State, restarting RestartType) RestartType {
 func ReplaceBootID(st *state.State, bootID string) {
 	rm := restartManager(st, "internal error: cannot mock a restart request before RestartManager initialization")
 	rm.bootID = bootID
+}
+
+type RestartWaiter struct {
+	TaskID string
+	Status state.Status
+}
+
+// XXX: How should we handle bootinfo and multiple requesters
+// when passing to restart package. Right now we just pass the last one.
+type RestartInfo struct {
+	Waiters        []*RestartWaiter
+	RestoreWaiters bool
+	SnapName       string
+	RestartType    RestartType
+	RebootInfo     *boot.RebootInfo
+	Requested      bool
+}
+
+func newRestartInfo() *RestartInfo {
+	return &RestartInfo{}
+}
+
+func (rt *RestartInfo) needsReboot() bool {
+	return len(rt.Waiters) > 0 && !rt.Requested
+}
+
+func (rt *RestartInfo) setParameters(snapName string, restartType RestartType, rebootInfo *boot.RebootInfo) {
+	rt.Requested = false
+	rt.SnapName = snapName
+	rt.RestartType = restartType
+	rt.RebootInfo = rebootInfo
+}
+
+func (rt *RestartInfo) Reboot(st *state.State) {
+	rt.Requested = true
+	rt.Waiters = nil
+	rt.RestoreWaiters = false
+
+	if release.OnClassic {
+		// notify the system that a reboot is required
+		if err := notifyRebootRequiredClassic(rt.SnapName); err != nil {
+			logger.Noticef("cannot notify about pending reboot: %v", err)
+		}
+		logger.Debugf("Postponing restart until a manual system restart allows to continue")
+		return
+	}
+	Request(st, rt.RestartType, rt.RebootInfo)
+}
+
+func (rt *RestartInfo) taskFromID(chg *state.Change, id string) *state.Task {
+	for _, t := range chg.Tasks() {
+		if t.ID() == id {
+			return t
+		}
+	}
+	return nil
+}
+
+func (rt *RestartInfo) restoreWaiters(chg *state.Change) {
+	for _, w := range rt.Waiters {
+		if t := rt.taskFromID(chg, w.TaskID); t != nil {
+			t.SetStatus(w.Status)
+		}
+	}
+	rt.Waiters = nil
+	rt.RestoreWaiters = false
+}
+
+func (rt *RestartInfo) doUndoReboot(t *state.Task, status state.Status) error {
+	// Immediately, on the first undo, we clear all the waiters that previously
+	// has requested a reboot, that are now in WaitStatus. We put those back into
+	// their original requested state.
+	if rt.RestoreWaiters {
+		rt.restoreWaiters(t.Change())
+	}
+	return rt.doReboot(t, status)
+}
+
+func (rt *RestartInfo) taskInSlice(t *state.Task, ts []*state.Task) bool {
+	for _, tt := range ts {
+		if tt == t {
+			return true
+		}
+	}
+	return false
+}
+
+// markTaskForRestart sets certain properties on a task to mark it for restart.
+func (rt *RestartInfo) markTaskForRestart(task *state.Task, snapName string, status state.Status) {
+	rm := restartManager(task.State(), "internal error: cannot request a restart before RestartManager initialization")
+
+	// store current boot id to be able to check later if we have rebooted or not
+	task.Set("wait-for-system-restart-from-boot-id", rm.bootID)
+	task.SetToWait(status)
+	setWaitForSystemRestart(task.Change())
+
+	rt.Waiters = append(rt.Waiters, &RestartWaiter{
+		TaskID: task.ID(),
+		Status: status,
+	})
+}
+
+func (rt *RestartInfo) doReboot(t *state.Task, status state.Status) error {
+	switch status {
+	case state.DoneStatus:
+		// A bit of a edge-case scenario, if the task has no halt
+		// tasks (tasks waiting for this one), then we can put this
+		// task into WaitStatus. *BUT* if it does have halt tasks, we
+		// cannot do this as this would block execution of tasks that need
+		// this task as completed to run.
+		// To properly fix this we would need to account for the resulting status
+		// after the wait when determining when a tasks pre-conditions have completed.
+		// This would require support in the taskrunner. Instead handle this here, by moving
+		// the wait to the halt-tasks in same lane.
+		if len(t.HaltTasks()) == 0 {
+			rt.markTaskForRestart(t, rt.SnapName, status)
+			return nil
+		}
+
+		chg := t.Change()
+		laneTasks := chg.LaneTasks(t.Lanes()...)
+		for _, wt := range t.HaltTasks() {
+			if rt.taskInSlice(wt, laneTasks) {
+				originalStatus := wt.Status()
+				rt.markTaskForRestart(wt, rt.SnapName, originalStatus)
+			}
+		}
+	case state.UndoneStatus:
+		// Same goes for undoing, if there are no wait tasks, then
+		// put this into wait
+		if len(t.WaitTasks()) == 0 {
+			rt.markTaskForRestart(t, rt.SnapName, status)
+			return nil
+		}
+
+		chg := t.Change()
+		laneTasks := chg.LaneTasks(t.Lanes()...)
+		for _, wt := range t.WaitTasks() {
+			if rt.taskInSlice(wt, laneTasks) {
+				rt.markTaskForRestart(wt, rt.SnapName, wt.Status())
+			}
+		}
+	case state.DoStatus, state.UndoStatus:
+		rt.markTaskForRestart(t, rt.SnapName, status)
+		return &state.Wait{Reason: "Postponing reboot as long as there are tasks to run"}
+	}
+	t.SetStatus(status)
+	return nil
+}
+
+// TaskWaitForRestart can be used for tasks that need to wait for a pending
+// restart to occur. The task will then be restored to the provided status
+// after the reboot, and then re-run.
+func TaskWaitForRestart(t *state.Task) error {
+	// If a task requests a reboot, then we make that task wait for the
+	// current reboot task. We must support multiple tasks waiting for this
+	// task.
+	rt, err := changeRestartInfo(t.Change())
+	if err != nil {
+		return err
+	}
+	if rt == nil {
+		return nil
+	}
+
+	t.Logf("task %q pending reboot", t.Kind())
+
+	switch t.Status() {
+	case state.UndoingStatus:
+		return rt.doUndoReboot(t, state.UndoStatus)
+	case state.DoingStatus:
+		return rt.doReboot(t, state.DoStatus)
+	}
+	return nil
+}
+
+// FinishTaskWithRestart will finish a task that needs a restart, by
+// setting its status and requesting a restart.
+// It should usually be invoked returning its result immediately
+// from the caller.
+// It delegates the work to restart.FinishTaskWithRestart which can decide
+// to set the task to wait returning state.Wait.
+func RequestRestartForTask(t *state.Task, snapName string, status state.Status, restartType RestartType, rebootInfo *boot.RebootInfo) error {
+	// The reboot-tracker only handles system reboots
+	switch restartType {
+	case RestartSystem, RestartSystemNow, RestartSystemHaltNow, RestartSystemPoweroffNow:
+		break
+	default:
+		t.SetStatus(status)
+		Request(t.State(), restartType, rebootInfo)
+		return nil
+	}
+	t.Logf("reboot requested by snap %q", snapName)
+
+	rt, err := changeRestartInfo(t.Change())
+	if err != nil {
+		return err
+	}
+
+	// If system restart is requested, consider how the change the
+	// task belongs to is configured (system-restart-immediate) to
+	// choose whether request an immediate restart or not.
+	var immediate bool
+	chg := t.Change()
+	if chg != nil {
+		// ignore errors intentionally, to follow
+		// RequestRestart itself which does not
+		// return errors. If the state is corrupt
+		// something else will error
+		chg.Get("system-restart-immediate", &immediate)
+		if restartType == RestartSystem && immediate {
+			restartType = RestartSystemNow
+		}
+	}
+
+	// Update restart params
+	rt.setParameters(snapName, restartType, rebootInfo)
+
+	// Either invoked with undone or done as the final status
+	switch status {
+	case state.UndoneStatus:
+		err = rt.doUndoReboot(t, state.UndoneStatus)
+	case state.DoneStatus:
+		// When registering waiters for the 'Do' path in
+		// changes, we must restore waiters once the change
+		// goes into 'Undo'. This is not necessary when undoing
+		// as we cannot go from undo => do.
+		err = rt.doReboot(t, state.DoneStatus)
+		if err != nil {
+			rt.RestoreWaiters = true
+		}
+	}
+
+	// Store updated copy of restart-info
+	chg.Set("restart-info", rt)
+	return err
+}
+
+func changeRestartInfo(chg *state.Change) (*RestartInfo, error) {
+	var rt RestartInfo
+	if chg == nil {
+		return nil, fmt.Errorf("no change for task")
+	}
+
+	if err := chg.Get("restart-info", &rt); err != nil {
+		if errors.Is(err, &state.NoStateError{}) {
+			rt := newRestartInfo()
+			chg.Set("restart-info", rt)
+			return rt, nil
+		}
+		return nil, err
+	}
+	return &rt, nil
+}
+
+func RequestRestartForChange(chg *state.Change) error {
+	var rt RestartInfo
+	if err := chg.Get("restart-info", &rt); err != nil {
+		if errors.Is(err, &state.NoStateError{}) {
+			return fmt.Errorf("change %s needs a reboot to continue but has no info set", chg.ID())
+		}
+		return err
+	}
+	if !rt.needsReboot() {
+		return nil
+	}
+
+	rt.Reboot(chg.State())
+	chg.Set("restart-info", rt)
+	return nil
+}
+
+func RestartTypePendingForChange(chg *state.Change) (RestartType, error) {
+	var rt RestartInfo
+	if err := chg.Get("restart-info", &rt); err != nil {
+		if errors.Is(err, &state.NoStateError{}) {
+			return 0, fmt.Errorf("cannot retrieve restart information for change %s", chg.ID())
+		}
+		return 0, err
+	}
+	return rt.RestartType, nil
 }

--- a/overlord/restart/restart_context.go
+++ b/overlord/restart/restart_context.go
@@ -56,7 +56,7 @@ func (rt *RestartContext) setParameters(snapName string, restartType RestartType
 	rt.RebootInfo = rebootInfo
 }
 
-func (rt *RestartContext) Reboot(st *state.State) {
+func (rt *RestartContext) reboot(st *state.State) {
 	rt.Requested = true
 	rt.Waiters = nil
 	rt.RestoreWaiters = false

--- a/overlord/restart/restart_context.go
+++ b/overlord/restart/restart_context.go
@@ -1,0 +1,192 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// Package restart implements requesting restarts from any part of the
+// code that has access to state. It also implements a mimimal manager
+// to take care of restart state.
+package restart
+
+import (
+	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/release"
+)
+
+type RestartWaiter struct {
+	TaskID string
+	Status state.Status
+}
+
+// XXX: How should we handle bootinfo and multiple requesters
+// when passing to restart package. Right now we just pass the last one.
+type RestartContext struct {
+	Waiters        []*RestartWaiter
+	RestoreWaiters bool
+	SnapName       string
+	RestartType    RestartType
+	RebootInfo     *boot.RebootInfo
+	Requested      bool
+}
+
+func (rt *RestartContext) needsReboot() bool {
+	return len(rt.Waiters) > 0 && !rt.Requested
+}
+
+func (rt *RestartContext) setParameters(snapName string, restartType RestartType, rebootInfo *boot.RebootInfo) {
+	rt.Requested = false
+	rt.SnapName = snapName
+	rt.RestartType = restartType
+	rt.RebootInfo = rebootInfo
+}
+
+func (rt *RestartContext) Reboot(st *state.State) {
+	rt.Requested = true
+	rt.Waiters = nil
+	rt.RestoreWaiters = false
+
+	if release.OnClassic {
+		// Notify the system that a reboot is required.
+		if err := notifyRebootRequiredClassic(rt.SnapName); err != nil {
+			logger.Noticef("cannot notify about pending reboot: %v", err)
+		}
+		logger.Noticef("Postponing restart until a manual system restart allows to continue")
+		return
+	}
+	Request(st, rt.RestartType, rt.RebootInfo)
+}
+
+func (rt *RestartContext) taskFromID(chg *state.Change, id string) *state.Task {
+	for _, t := range chg.Tasks() {
+		if t.ID() == id {
+			return t
+		}
+	}
+	return nil
+}
+
+func (rt *RestartContext) restoreWaiters(chg *state.Change) {
+	for _, w := range rt.Waiters {
+		if t := rt.taskFromID(chg, w.TaskID); t != nil {
+			t.SetStatus(w.Status)
+		}
+	}
+	rt.Waiters = nil
+	rt.RestoreWaiters = false
+}
+
+func (rt *RestartContext) doUndoReboot(t *state.Task, status state.Status) error {
+	// Immediately, on the first undo, we clear all the waiters that previously
+	// has requested a reboot, that are now in WaitStatus. We put those back into
+	// their original requested state.
+	if rt.RestoreWaiters {
+		rt.restoreWaiters(t.Change())
+	}
+	return rt.doReboot(t, status)
+}
+
+func (rt *RestartContext) taskInSlice(t *state.Task, ts []*state.Task) bool {
+	for _, tt := range ts {
+		if tt == t {
+			return true
+		}
+	}
+	return false
+}
+
+// markTaskForRestart sets certain properties on a task to mark it for restart.
+func (rt *RestartContext) markTaskForRestart(task *state.Task, snapName string, status state.Status) {
+	rm := restartManager(task.State(), "internal error: cannot request a restart before RestartManager initialization")
+
+	// store current boot id to be able to check later if we have rebooted or not
+	task.Set("wait-for-system-restart-from-boot-id", rm.bootID)
+	task.SetToWait(status)
+	setWaitForSystemRestart(task.Change())
+
+	rt.Waiters = append(rt.Waiters, &RestartWaiter{
+		TaskID: task.ID(),
+		Status: status,
+	})
+}
+
+func (rt *RestartContext) doReboot(t *state.Task, status state.Status) error {
+	switch status {
+	case state.DoneStatus:
+		// A bit of a edge-case scenario, if the task has no halt
+		// tasks (tasks waiting for this one), then we can put this
+		// task into WaitStatus.
+		if len(t.HaltTasks()) == 0 {
+			rt.markTaskForRestart(t, rt.SnapName, status)
+			return nil
+		}
+
+		// If the task does have halt tasks, we cannot do this as this would block
+		// execution of tasks that need this task to be completed to run, i.e. think
+		// changes with multiple lanes where each lane depends on a part of a different lane
+		// to have finished executing. We do this for instance to allow multiple snaps to partly
+		// install, and then handle their required restart as one, instead of restarting once per
+		// snap in each lane.
+		// To properly fix this we would need to account for the resulting status
+		// after the wait when determining when a tasks pre-conditions have completed.
+		// This would require support in the taskrunner. Instead handle this here, by moving
+		// the wait to the halt-tasks in same lane (and only same lane).
+		chg := t.Change()
+		laneTasks := chg.LaneTasks(t.Lanes()...)
+		for _, wt := range t.HaltTasks() {
+			if rt.taskInSlice(wt, laneTasks) {
+				originalStatus := wt.Status()
+				rt.markTaskForRestart(wt, rt.SnapName, originalStatus)
+			}
+		}
+	case state.UndoneStatus:
+		// XXX: This is logic kept from the previous restart logic. What is the reasoning here?
+		if release.OnClassic {
+			t.SetStatus(status)
+			t.Logf("Skipped automatic system restart on classic system when undoing changes back to previous state")
+			return nil
+		}
+
+		// Same goes for undoing, if there are no wait tasks, then
+		// put this into wait.
+		if len(t.WaitTasks()) == 0 {
+			rt.markTaskForRestart(t, rt.SnapName, status)
+			return nil
+		}
+
+		chg := t.Change()
+		laneTasks := chg.LaneTasks(t.Lanes()...)
+		for _, wt := range t.WaitTasks() {
+			if rt.taskInSlice(wt, laneTasks) {
+				rt.markTaskForRestart(wt, rt.SnapName, wt.Status())
+			}
+		}
+	case state.UndoStatus:
+		if release.OnClassic {
+			t.SetStatus(status)
+			t.Logf("Skipped automatic system restart on classic system when undoing changes back to previous state")
+			return nil
+		}
+		fallthrough
+	case state.DoStatus:
+		rt.markTaskForRestart(t, rt.SnapName, status)
+		return &state.Wait{Reason: "Postponing reboot as long as there are tasks to run"}
+	}
+	t.SetStatus(status)
+	return nil
+}

--- a/overlord/restart/restart_context_test.go
+++ b/overlord/restart/restart_context_test.go
@@ -1,0 +1,189 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package restart_test
+
+import (
+	"errors"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/overlord"
+	"github.com/snapcore/snapd/overlord/restart"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type restartContextSuite struct {
+	testutil.BaseTest
+	o     *overlord.Overlord
+	state *state.State
+}
+
+var _ = Suite(&restartContextSuite{})
+
+func (s *restartContextSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	s.o = overlord.Mock()
+	s.state = s.o.State()
+
+	s.state.Lock()
+	_, err := restart.Manager(s.state, s.o.TaskRunner(), "boot-id-1", nil)
+	s.state.Unlock()
+	c.Assert(err, IsNil)
+}
+
+func (s *restartContextSuite) TestMarkTaskForRestart(c *C) {
+	rt := &restart.RestartContext{}
+
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	chg := st.NewChange("test", "...")
+	t1 := st.NewTask("foo", "...")
+	chg.AddTask(t1)
+
+	restart.RestartInfoMarkTaskForRestart(rt, t1, "", state.DoneStatus)
+
+	var waitBootID string
+	if err := t1.Get("wait-for-system-restart-from-boot-id", &waitBootID); !errors.Is(err, state.ErrNoState) {
+		c.Check(err, IsNil)
+	}
+	c.Check(waitBootID, Equals, "boot-id-1")
+	c.Check(t1.Status(), Equals, state.WaitStatus)
+	c.Check(t1.WaitedStatus(), Equals, state.DoneStatus)
+	c.Check(rt.Waiters, DeepEquals, []*restart.RestartWaiter{
+		{
+			TaskID: t1.ID(),
+			Status: state.DoneStatus,
+		},
+	})
+}
+
+func (s *restartContextSuite) TestTaskWaitForRestartDo(c *C) {
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	chg := st.NewChange("test", "...")
+	t1 := st.NewTask("foo", "...")
+	chg.AddTask(t1)
+
+	t1.SetStatus(state.DoingStatus)
+
+	err := restart.TaskWaitForRestart(t1)
+	c.Assert(err, FitsTypeOf, &state.Wait{Reason: "Postponing reboot as long as there are tasks to run"})
+
+	c.Check(t1.Log(), HasLen, 1)
+	c.Check(t1.Log()[0], Matches, ".* Task \"foo\" is pending reboot to continue")
+
+	var waitBootID string
+	if err := t1.Get("wait-for-system-restart-from-boot-id", &waitBootID); !errors.Is(err, state.ErrNoState) {
+		c.Check(err, IsNil)
+	}
+	c.Check(waitBootID, Equals, "boot-id-1")
+	c.Check(t1.Status(), Equals, state.WaitStatus)
+	c.Check(t1.WaitedStatus(), Equals, state.DoStatus)
+
+	rt, err := restart.ChangeRestartInfo(chg)
+	c.Check(err, IsNil)
+	c.Check(rt.Waiters, DeepEquals, []*restart.RestartWaiter{
+		{
+			TaskID: t1.ID(),
+			Status: state.DoStatus,
+		},
+	})
+
+	c.Check(t1.Log(), HasLen, 1)
+	c.Check(t1.Log()[0], Matches, ".* Task \"foo\" is pending reboot to continue")
+}
+
+func (s *restartContextSuite) TestTaskWaitForRestartUndoClassic(c *C) {
+	release.MockOnClassic(true)
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	chg := st.NewChange("test", "...")
+	t1 := st.NewTask("foo", "...")
+	chg.AddTask(t1)
+
+	t1.SetStatus(state.UndoingStatus)
+
+	err := restart.TaskWaitForRestart(t1)
+	c.Assert(err, IsNil)
+
+	c.Check(t1.Log(), HasLen, 1)
+	c.Check(t1.Log()[0], Matches, ".* Skipped automatic system restart on classic system when undoing changes back to previous state")
+}
+
+func (s *restartContextSuite) TestTaskWaitForRestartUndoCore(c *C) {
+	release.MockOnClassic(false)
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	chg := st.NewChange("test", "...")
+	t1 := st.NewTask("foo", "...")
+	chg.AddTask(t1)
+
+	t1.SetStatus(state.UndoingStatus)
+
+	err := restart.TaskWaitForRestart(t1)
+	c.Assert(err, FitsTypeOf, &state.Wait{Reason: "Postponing reboot as long as there are tasks to run"})
+
+	c.Check(t1.Log(), HasLen, 1)
+	c.Check(t1.Log()[0], Matches, ".* Task \"foo\" is pending reboot to continue")
+
+	var waitBootID string
+	if err := t1.Get("wait-for-system-restart-from-boot-id", &waitBootID); !errors.Is(err, state.ErrNoState) {
+		c.Check(err, IsNil)
+	}
+	c.Check(waitBootID, Equals, "boot-id-1")
+	c.Check(t1.Status(), Equals, state.WaitStatus)
+	c.Check(t1.WaitedStatus(), Equals, state.UndoStatus)
+
+	var rt restart.RestartContext
+	err = chg.Get("restart-info", &rt)
+	c.Check(err, IsNil)
+	c.Check(rt.Waiters, DeepEquals, []*restart.RestartWaiter{
+		{
+			TaskID: t1.ID(),
+			Status: state.UndoStatus,
+		},
+	})
+
+	c.Check(t1.Log(), HasLen, 1)
+	c.Check(t1.Log()[0], Matches, ".* Task \"foo\" is pending reboot to continue")
+}
+
+func (s *restartContextSuite) TestTaskWaitForRestartInvalid(c *C) {
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	chg := st.NewChange("test", "...")
+	t1 := st.NewTask("foo", "...")
+	chg.AddTask(t1)
+
+	err := restart.TaskWaitForRestart(t1)
+	c.Assert(err, ErrorMatches, `only tasks currently in progress \(doing/undoing\) are supported`)
+}

--- a/overlord/restart/restart_test.go
+++ b/overlord/restart/restart_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2022 Canonical Ltd
+ * Copyright (C) 2016-2023 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/overlord/restart/restart_test.go
+++ b/overlord/restart/restart_test.go
@@ -68,7 +68,7 @@ func (h *testHandler) RebootDidNotHappen(*state.State) error {
 
 func newRestartManager(c *C, st *state.State, bootID string, h restart.Handler) *restart.RestartManager {
 	o := overlord.Mock()
-	mgr, err := restart.Manager(st, o.TaskRunner(), "boot-id-1", h)
+	mgr, err := restart.Manager(st, o.TaskRunner(), bootID, h)
 	c.Assert(err, IsNil)
 	return mgr
 }
@@ -333,16 +333,14 @@ func (s *restartSuite) TestStartUpWaitTasks(c *C) {
 	t2 := st.NewTask("wait-for-reboot", "...")
 	chg.AddTask(t2)
 	err := restart.RequestRestartForTask(t2, "some-snap", state.DoneStatus, restart.RestartSystem, nil)
-	c.Assert(err, FitsTypeOf, &state.Wait{WaitedStatus: state.DoneStatus})
-	t2.SetToWait(state.DoneStatus)
+	c.Assert(err, IsNil)
 
 	restart.ReplaceBootID(st, "boot-id-2")
 
 	t3 := st.NewTask("wait-for-reboot-same-boot", "...")
 	chg.AddTask(t3)
 	err = restart.RequestRestartForTask(t3, "some-snap", state.DoneStatus, restart.RestartSystem, nil)
-	c.Assert(err, FitsTypeOf, &state.Wait{WaitedStatus: state.DoneStatus})
-	t3.SetToWait(state.DoneStatus)
+	c.Assert(err, IsNil)
 
 	t4 := st.NewTask("do-after-wait", "...")
 	t4.SetToWait(state.DoStatus)

--- a/overlord/restart/restart_test.go
+++ b/overlord/restart/restart_test.go
@@ -264,7 +264,7 @@ func (s *restartSuite) TestFinishTaskWithRestart(c *C) {
 			continue
 		}
 
-		// For system restarts, we also call the RequestRestartForChange to
+		// For system restarts, we also call the ProcessRestartForChange to
 		// make it trigger the restart.Request
 		if t.classic && t.final == state.UndoneStatus {
 			c.Check(task.Status(), Equals, state.UndoneStatus)
@@ -272,7 +272,7 @@ func (s *restartSuite) TestFinishTaskWithRestart(c *C) {
 			c.Check(task.Status(), Equals, state.WaitStatus)
 			c.Check(task.WaitedStatus(), Equals, t.final)
 		}
-		err = restart.RequestRestartForChange(chg)
+		err = restart.ProcessRestartForChange(chg)
 		c.Check(err, IsNil)
 
 		var waitBootID string
@@ -311,7 +311,7 @@ func (s *restartSuite) TestFinishTaskWithRestart(c *C) {
 	}
 }
 
-func (s *restartSuite) TestRequestRestartForChangeNoRebootInfo(c *C) {
+func (s *restartSuite) TestProcessRestartForChangeMissingRebootContext(c *C) {
 	st := state.New(nil)
 
 	st.Lock()
@@ -323,7 +323,7 @@ func (s *restartSuite) TestRequestRestartForChangeNoRebootInfo(c *C) {
 	chg.AddTask(t)
 	t.SetToWait(state.DoneStatus)
 
-	err := restart.RequestRestartForChange(chg)
+	err := restart.ProcessRestartForChange(chg)
 	c.Assert(err, ErrorMatches, `change 1 is waiting to continue but has not requested any reboots`)
 }
 
@@ -708,7 +708,7 @@ test "$DPKG_MAINTSCRIPT_NAME" = "postinst"
 	err := restart.FinishTaskWithRestart(s.t1, "some-snap", state.DoneStatus, restart.RestartSystem, nil)
 	c.Assert(err, IsNil)
 
-	err = restart.RequestRestartForChange(s.chg)
+	err = restart.ProcessRestartForChange(s.chg)
 	c.Assert(err, IsNil)
 
 	c.Check(mockNrr.Calls(), DeepEquals, [][]string{
@@ -727,7 +727,7 @@ func (s *notifyRebootRequiredSuite) TestFinishTaskWithRestartNotifiesRebootRequi
 	err := restart.FinishTaskWithRestart(s.t1, "some-snap", state.DoneStatus, restart.RestartSystem, nil)
 	c.Assert(err, IsNil)
 
-	err = restart.RequestRestartForChange(s.chg)
+	err = restart.ProcessRestartForChange(s.chg)
 	c.Assert(err, IsNil)
 
 	c.Check(mockNrr.Calls(), DeepEquals, [][]string{

--- a/overlord/servicestate/servicemgr_test.go
+++ b/overlord/servicestate/servicemgr_test.go
@@ -78,7 +78,7 @@ func (s *baseServiceMgrTestSuite) SetUpTest(c *C) {
 	s.o = overlord.Mock()
 	s.state = s.o.State()
 	s.state.Lock()
-	_, err := restart.Manager(s.state, "boot-id-0", snapstatetest.MockRestartHandler(func(req restart.RestartType) {
+	_, err := restart.Manager(s.state, s.o.TaskRunner(), "boot-id-0", snapstatetest.MockRestartHandler(func(req restart.RestartType) {
 		s.restartRequests = append(s.restartRequests, req)
 		if s.restartObserve != nil {
 			s.restartObserve()

--- a/overlord/snapstate/booted_test.go
+++ b/overlord/snapstate/booted_test.go
@@ -84,7 +84,7 @@ func (bs *bootedSuite) SetUpTest(c *C) {
 	bs.o = overlord.Mock()
 	bs.state = bs.o.State()
 	bs.state.Lock()
-	_, err = restart.Manager(bs.state, "boot-id-0", nil)
+	_, err = restart.Manager(bs.state, bs.o.TaskRunner(), "boot-id-0", nil)
 	bs.state.Unlock()
 	c.Assert(err, IsNil)
 	bs.snapmgr, err = snapstate.Manager(bs.state, bs.o.TaskRunner())

--- a/overlord/snapstate/handlers_link_test.go
+++ b/overlord/snapstate/handlers_link_test.go
@@ -62,7 +62,7 @@ func (s *linkSnapSuite) SetUpTest(c *C) {
 	s.baseHandlerSuite.SetUpTest(c)
 
 	s.state.Lock()
-	_, err := restart.Manager(s.state, "boot-id-0", snapstatetest.MockRestartHandler(func(t restart.RestartType) {
+	_, err := restart.Manager(s.state, s.runner, "boot-id-0", snapstatetest.MockRestartHandler(func(t restart.RestartType) {
 		s.restartRequested = append(s.restartRequested, t)
 	}))
 	s.state.Unlock()

--- a/overlord/snapstate/handlers_rerefresh_test.go
+++ b/overlord/snapstate/handlers_rerefresh_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/snapasserts"
+	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
@@ -42,6 +43,15 @@ type reRefreshSuite struct {
 }
 
 var _ = Suite(&reRefreshSuite{})
+
+func (s *reRefreshSuite) SetUpTest(c *C) {
+	s.baseHandlerSuite.SetUpTest(c)
+
+	s.state.Lock()
+	_, err := restart.Manager(s.state, s.runner, "boot-id-0", nil)
+	s.state.Unlock()
+	c.Assert(err, IsNil)
+}
 
 func logstr(task *state.Task) string {
 	return strings.Join(task.Log(), "\n")

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -898,33 +898,15 @@ func FinishRestart(task *state.Task, snapsup *SnapSetup) (err error) {
 // from the caller.
 // It delegates the work to restart.FinishTaskWithRestart which can decide
 // to set the task to wait returning state.Wait.
-func FinishTaskWithRestart(task *state.Task, status state.Status, rt restart.RestartType, rebootInfo *boot.RebootInfo) error {
-	var rebootRequiredSnap string
-	// If system restart is requested, consider how the change the
-	// task belongs to is configured (system-restart-immediate) to
-	// choose whether request an immediate restart or not.
-	if rt == restart.RestartSystem {
-		snapsup, err := TaskSnapSetup(task)
-		if err != nil {
-			return fmt.Errorf("cannot get snap that triggered a reboot: %v", err)
-		}
-		rebootRequiredSnap = snapsup.InstanceName()
-
-		chg := task.Change()
-		var immediate bool
-		if chg != nil {
-			// ignore errors intentionally, to follow
-			// RequestRestart itself which does not
-			// return errors. If the state is corrupt
-			// something else will error
-			chg.Get("system-restart-immediate", &immediate)
-		}
-		if immediate {
-			rt = restart.RestartSystemNow
-		}
+func FinishTaskWithRestart(t *state.Task, status state.Status, restartType restart.RestartType, rebootInfo *boot.RebootInfo) error {
+	// If a task requests a reboot, then we make that task wait for the
+	// current reboot task. We must support multiple tasks waiting for this
+	// task.
+	snapsup, err := TaskSnapSetup(t)
+	if err != nil {
+		return fmt.Errorf("cannot get snap that requested a reboot: %v", err)
 	}
-
-	return restart.FinishTaskWithRestart(task, status, rt, rebootRequiredSnap, rebootInfo)
+	return restart.RequestRestartForTask(t, snapsup.InstanceName(), status, restartType, rebootInfo)
 }
 
 // IsErrAndNotWait returns true if err is not nil and neither state.Wait, it is

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -896,7 +896,7 @@ func FinishRestart(task *state.Task, snapsup *SnapSetup) (err error) {
 // setting its status and requesting a restart.
 // It should usually be invoked returning its result immediately
 // from the caller.
-// It delegates the work to restart.RequestRestartForTask which decides
+// It delegates the work to restart.FinishTaskWithRestart which decides
 // on how the restart will be scheduled.
 func FinishTaskWithRestart(task *state.Task, status state.Status, rt restart.RestartType, rebootInfo *boot.RebootInfo) error {
 	var rebootRequiredSnap string
@@ -923,7 +923,7 @@ func FinishTaskWithRestart(task *state.Task, status state.Status, rt restart.Res
 			rt = restart.RestartSystemNow
 		}
 	}
-	return restart.RequestRestartForTask(task, rebootRequiredSnap, status, rt, rebootInfo)
+	return restart.FinishTaskWithRestart(task, rebootRequiredSnap, status, rt, rebootInfo)
 }
 
 // IsErrAndNotWait returns true if err is not nil and neither state.Wait, it is

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -902,11 +902,15 @@ func FinishTaskWithRestart(t *state.Task, status state.Status, restartType resta
 	// If a task requests a reboot, then we make that task wait for the
 	// current reboot task. We must support multiple tasks waiting for this
 	// task.
-	snapsup, err := TaskSnapSetup(t)
-	if err != nil {
-		return fmt.Errorf("cannot get snap that requested a reboot: %v", err)
+	var snapName string
+	if restartType == restart.RestartSystem {
+		snapsup, err := TaskSnapSetup(t)
+		if err != nil {
+			return fmt.Errorf("cannot get snap that requested a reboot: %v", err)
+		}
+		snapName = snapsup.InstanceName()
 	}
-	return restart.RequestRestartForTask(t, snapsup.InstanceName(), status, restartType, rebootInfo)
+	return restart.RequestRestartForTask(t, snapName, status, restartType, rebootInfo)
 }
 
 // IsErrAndNotWait returns true if err is not nil and neither state.Wait, it is

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -152,7 +152,7 @@ func (s *snapmgrBaseTest) SetUpTest(c *C) {
 	s.o = overlord.Mock()
 	s.state = s.o.State()
 	s.state.Lock()
-	_, err := restart.Manager(s.state, "boot-id-0", nil)
+	_, err := restart.Manager(s.state, s.o.TaskRunner(), "boot-id-0", nil)
 	s.state.Unlock()
 	c.Assert(err, IsNil)
 

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -8178,7 +8178,7 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootHappy(c *C) {
 	defer s.state.Unlock()
 
 	var restartRequested []restart.RestartType
-	_, err := restart.Manager(s.state, "boot-id-0", snapstatetest.MockRestartHandler(func(t restart.RestartType) {
+	_, err := restart.Manager(s.state, s.o.TaskRunner(), "boot-id-0", snapstatetest.MockRestartHandler(func(t restart.RestartType) {
 		restartRequested = append(restartRequested, t)
 	}))
 	c.Assert(err, IsNil)
@@ -8367,7 +8367,7 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootUnsupportedWithCoreHa
 	defer s.state.Unlock()
 
 	var restartRequested []restart.RestartType
-	_, err := restart.Manager(s.state, "boot-id-0", snapstatetest.MockRestartHandler(func(t restart.RestartType) {
+	_, err := restart.Manager(s.state, s.o.TaskRunner(), "boot-id-0", snapstatetest.MockRestartHandler(func(t restart.RestartType) {
 		restartRequested = append(restartRequested, t)
 	}))
 	c.Assert(err, IsNil)
@@ -8508,7 +8508,7 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootUnsupportedWithGadget
 	defer s.state.Unlock()
 
 	var restartRequested []restart.RestartType
-	_, err := restart.Manager(s.state, "boot-id-0", snapstatetest.MockRestartHandler(func(t restart.RestartType) {
+	_, err := restart.Manager(s.state, s.o.TaskRunner(), "boot-id-0", snapstatetest.MockRestartHandler(func(t restart.RestartType) {
 		restartRequested = append(restartRequested, t)
 	}))
 	c.Assert(err, IsNil)
@@ -8601,7 +8601,7 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootUndone(c *C) {
 	defer s.state.Unlock()
 
 	var restartRequested []restart.RestartType
-	_, err := restart.Manager(s.state, "boot-id-0", snapstatetest.MockRestartHandler(func(t restart.RestartType) {
+	_, err := restart.Manager(s.state, s.o.TaskRunner(), "boot-id-0", snapstatetest.MockRestartHandler(func(t restart.RestartType) {
 		restartRequested = append(restartRequested, t)
 	}))
 	c.Assert(err, IsNil)
@@ -8748,7 +8748,7 @@ func (s *snapmgrTestSuite) TestUpdateBaseAndSnapdOrder(c *C) {
 	defer s.state.Unlock()
 
 	var restartRequested []restart.RestartType
-	_, err := restart.Manager(s.state, "boot-id-0", snapstatetest.MockRestartHandler(func(t restart.RestartType) {
+	_, err := restart.Manager(s.state, s.o.TaskRunner(), "boot-id-0", snapstatetest.MockRestartHandler(func(t restart.RestartType) {
 		restartRequested = append(restartRequested, t)
 	}))
 	c.Assert(err, IsNil)

--- a/overlord/state/task.go
+++ b/overlord/state/task.go
@@ -203,38 +203,37 @@ func (t *Task) Summary() string {
 //
 // Possible state transitions:
 //
-//     /----aborting lane--Do
-//     |                   |
-//     V                   V
-//    Hold               Doing-->Wait
-//     ^                /  |  \
-//     |         abort /   V   V
-//   no undo          /  Done  Error
-//     |             V     |
-//     \----------Abort   aborting lane
-//     /          |        |
-//     |       finished or |
-//  running    not running |
-//     V          \------->|
-//  kill goroutine         |
-//     |                   V
-//    / \           ----->Undo
-//   /   no error  /       |
-//   |   from goroutine    |
-//  error                  |
-//  from goroutine         |
-//   |                     V
-//   |                  Undoing-->Wait
-//   V                     |   \
-//  Error                  V    V
-//                       Undone Error
+//	   /----aborting lane--Do
+//	   |                   |
+//	   V                   V
+//	  Hold               Doing-->Wait
+//	   ^                /  |  \
+//	   |         abort /   V   V
+//	 no undo          /  Done  Error
+//	   |             V     |
+//	   \----------Abort   aborting lane
+//	   /          |        |
+//	   |       finished or |
+//	running    not running |
+//	   V          \------->|
+//	kill goroutine         |
+//	   |                   V
+//	  / \           ----->Undo
+//	 /   no error  /       |
+//	 |   from goroutine    |
+//	error                  |
+//	from goroutine         |
+//	 |                     V
+//	 |                  Undoing-->Wait
+//	 V                     |   \
+//	Error                  V    V
+//	                     Undone Error
 //
 // Do -> Doing -> Done is the direct succcess scenario.
 //
 // Wait can transition to its waited status,
 // usually Done|Undone or back to Doing.
 // See Wait struct, SetToWait and WaitedStatus.
-//
 func (t *Task) Status() Status {
 	t.state.reading()
 	if t.status == DefaultStatus {

--- a/overlord/state/taskrunner.go
+++ b/overlord/state/taskrunner.go
@@ -35,8 +35,8 @@ type HookFunc func()
 type HookEvent int
 
 const (
-	// TaskExhaustionHook is executed when there are no more tasks to be run.
-	TaskExhaustionHook HookEvent = iota
+	// TaskExhaustion is executed when there are no more tasks to be run.
+	TaskExhaustion HookEvent = iota
 )
 
 // HandlerFunc is the type of function for the handlers
@@ -501,15 +501,12 @@ ConsiderTasks:
 		r.state.EnsureBefore(nextTaskTime.Sub(ensureTime))
 	}
 
-	// run hooks registered for task exhaustion
+	// run hooks registered for task exhaustion for each change
 	if len(running) == 0 {
-		for _, hooks := range r.hooks {
-			for _, h := range hooks {
-				h()
-			}
+		for _, h := range r.hooks[TaskExhaustion] {
+			h()
 		}
 	}
-
 	return nil
 }
 

--- a/overlord/state/taskrunner.go
+++ b/overlord/state/taskrunner.go
@@ -517,7 +517,7 @@ ConsiderTasks:
 	for _, chg := range r.state.changes {
 		// if there are no running tasks for this change, report
 		// task exhaustion for that change.
-		if readyChanges[chg.ID()] {
+		if !readyChanges[chg.ID()] {
 			// have we already reported exhaustion for that change?
 			if r.exhausted[chg.ID()] {
 				continue

--- a/overlord/state/taskrunner.go
+++ b/overlord/state/taskrunner.go
@@ -422,7 +422,7 @@ func (r *TaskRunner) Ensure() error {
 		}
 	}
 
-	changes := make(map[string]bool)
+	readyChanges := make(map[string]bool)
 	ensureTime := timeNow()
 	nextTaskTime := time.Time{}
 ConsiderTasks:
@@ -501,10 +501,9 @@ ConsiderTasks:
 
 		// Keep track of changes that have jobs ready to run.
 		chg := t.Change()
-		changes[chg.ID()] = true
+		readyChanges[chg.ID()] = true
 
-		// If a change had jobs ready to run, then reset the exhaustion
-		// status for that change.
+		// If a change had jobs ready to run, reset its exhaustion status.
 		r.exhausted[chg.ID()] = false
 	}
 
@@ -518,9 +517,9 @@ ConsiderTasks:
 	for _, chg := range r.state.changes {
 		// if there are no running tasks for this change, report
 		// task exhaustion for that change.
-		if seen := changes[chg.ID()]; seen {
+		if readyChanges[chg.ID()] {
 			// have we already reported exhaustion for that change?
-			if reported := r.exhausted[chg.ID()]; reported {
+			if r.exhausted[chg.ID()] {
 				continue
 			}
 			r.exhausted[chg.ID()] = true

--- a/overlord/state/taskrunner_test.go
+++ b/overlord/state/taskrunner_test.go
@@ -1357,6 +1357,8 @@ func (ts *taskRunnerSuite) TestTaskExhaustionHook(c *C) {
 	// Ensure that 'ensure' is run one more time
 	// to report exhaustion
 	r.Ensure()
+	// make sure that hook was called at the end of 'Ensure'
+	c.Check(hookCalls, Equals, 1)
 
 	// Make sure we run 'ensure' once more, that we don't
 	// get a second exhaustion hook
@@ -1368,7 +1370,8 @@ func (ts *taskRunnerSuite) TestTaskExhaustionHook(c *C) {
 
 	c.Check(t1.Status(), Equals, state.DoneStatus)
 
-	// make sure that hook was called at the end of 'Ensure'
+	// make sure that hook wasn't invoked again during the last
+	// ensure call
 	c.Check(hookCalls, Equals, 1)
 	c.Check(hookChange, Equals, chg)
 }

--- a/overlord/state/taskrunner_test.go
+++ b/overlord/state/taskrunner_test.go
@@ -1341,7 +1341,7 @@ func (ts *taskRunnerSuite) TestTaskExhaustionHook(c *C) {
 	var hookCalled bool
 	r.AddHook(func() {
 		hookCalled = true
-	}, state.TaskExhaustionHook)
+	}, state.TaskExhaustion)
 
 	st.Lock()
 	chg := st.NewChange("install", "...")


### PR DESCRIPTION
This PR contains the restart logic from the primary PR (https://github.com/snapcore/snapd/pull/12718). This PR also builds on top of https://github.com/snapcore/snapd/pull/12720 to get the taskrunner hooks functionality which is needed to get informed about when a change has no more tasks to run.

The PR is in draft until I can confirm any test failures is not related to this PR and I've had a chance to go through my unit test code changes with some fresh eyes

A small overview:

### Changes to unit tests
- A lot of unit tests now need to do different checks, and some unit tests need additional explicit restart logic to simulate restarts which before was implicit. This has caused a large number of unit tests to be updated as the semantics around how restarts are now done has changed.
- If a unit test suddenly has added additional restarts, this is because the restart is no longer happening directly. This only means that the restart is now more visible in the unit test instead of having been done implicitly before.

### overlord/restart/restart.go
- The restart logic is now split into two phases. The scheduling of restart and the execution of the restarts. Before this was one single code-path, but now this happens seperately. Tasks can now request reboots, which either puts that task into WaitStatus or it puts the dependencies of that task into WaitStatus based on the context of the change.
- When a change runs out of tasks to run, the restart logic is notified, and the restart logic will check if any restarts are scheduled for that change, if it is, then it reuses the same restart logic as before and performs the reboot.

### overlord/overlord.go
- Seperated some of the logic to allow instantiation of the RestartManager after creating the taskrunner, so we can supply that as a parameter to RestartManager.Manager(), which is needed to register the hook.

### overlord/snapstate/handlers.go
- Delay/schedule the re-refresh task to wait for any pending reboot

### overlord/state/taskrunner.go
- Imported changes from PR https://github.com/snapcore/snapd/pull/12720 to support the hooks used in the restart logic
