### PR TITLE
cmd/snap/cmd_changes: make "change-id" arg in 'snap tasks --help' required

### DIFF
--- a/cmd/snap/last.go
+++ b/cmd/snap/last.go
@@ -33,7 +33,7 @@ type changeIDMixin struct {
 	LastChangeType string `long:"last"`
 	Positional     struct {
 		ID changeID `positional-arg-name:"<id>"`
-	} `positional-args:"yes"`
+	} `positional-args:"yes" required:"true"`
 }
 
 var changeIDMixinOptDesc = mixinDescs{


### PR DESCRIPTION
Make `change-id` arg mentioned in `snap tasks --help` required
currently `snap tasks --help` suggests that the `change-id` argument is optional, when it must be provided.

This fixes https://bugs.launchpad.net/snapd/+bug/2017647.
The bug report mentions `snap change --help` showing help for `tasks` command, this is intentional since `change` is just an [alias for `tasks` command](https://github.com/snapcore/snapd/blob/master/cmd/snap/cmd_changes.go#L62).
