### PR TITLE
many: stop using `-O no-expr-simplify` in apparmor_parser

### DIFF
--- a/cmd/snapd-apparmor/main_test.go
+++ b/cmd/snapd-apparmor/main_test.go
@@ -139,7 +139,6 @@ func (s *mainSuite) TestLoadAppArmorProfiles(c *C) {
 	// check arguments to the parser are as expected
 	c.Assert(parserCmd.Calls(), DeepEquals, [][]string{
 		{"apparmor_parser", "--replace", "--write-cache",
-			"-O", "no-expr-simplify",
 			fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", dirs.GlobalRootDir),
 			profile}})
 

--- a/sandbox/apparmor/profile.go
+++ b/sandbox/apparmor/profile.go
@@ -118,8 +118,7 @@ var LoadProfiles = func(fnames []string, cacheDir string, flags AaParserFlags) e
 		return nil
 	}
 
-	// Use no-expr-simplify since expr-simplify is actually slower on armhf (LP: #1383858)
-	args := []string{"--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s", cacheDir)}
+	args := []string{"--replace", "--write-cache", fmt.Sprintf("--cache-loc=%s", cacheDir)}
 	if flags&ConserveCPU != 0 {
 		args = append(args, numberOfJobsParam())
 	}

--- a/sandbox/apparmor/profile_test.go
+++ b/sandbox/apparmor/profile_test.go
@@ -63,7 +63,7 @@ func (s *appArmorSuite) TestLoadProfilesRunsAppArmorParserReplace(c *C) {
 	err := apparmor.LoadProfiles([]string{"/path/to/snap.samba.smbd"}, apparmor.CacheDir, 0)
 	c.Assert(err, IsNil)
 	c.Assert(cmd.Calls(), DeepEquals, [][]string{
-		{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", "--cache-loc=/var/cache/apparmor", "--quiet", "/path/to/snap.samba.smbd"},
+		{"apparmor_parser", "--replace", "--write-cache", "--cache-loc=/var/cache/apparmor", "--quiet", "/path/to/snap.samba.smbd"},
 	})
 }
 
@@ -75,7 +75,7 @@ func (s *appArmorSuite) TestLoadProfilesMany(c *C) {
 	err := apparmor.LoadProfiles([]string{"/path/to/snap.samba.smbd", "/path/to/another.profile"}, apparmor.CacheDir, 0)
 	c.Assert(err, IsNil)
 	c.Assert(cmd.Calls(), DeepEquals, [][]string{
-		{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", "--cache-loc=/var/cache/apparmor", "--quiet", "/path/to/snap.samba.smbd", "/path/to/another.profile"},
+		{"apparmor_parser", "--replace", "--write-cache", "--cache-loc=/var/cache/apparmor", "--quiet", "/path/to/snap.samba.smbd", "/path/to/another.profile"},
 	})
 }
 
@@ -99,7 +99,7 @@ func (s *appArmorSuite) TestLoadProfilesReportsErrors(c *C) {
 apparmor_parser output:
 `)
 	c.Assert(cmd.Calls(), DeepEquals, [][]string{
-		{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", "--cache-loc=/var/cache/apparmor", "--quiet", "/path/to/snap.samba.smbd"},
+		{"apparmor_parser", "--replace", "--write-cache", "--cache-loc=/var/cache/apparmor", "--quiet", "/path/to/snap.samba.smbd"},
 	})
 }
 
@@ -114,7 +114,7 @@ apparmor_parser output:
 parser error
 `)
 	c.Assert(cmd.Calls(), DeepEquals, [][]string{
-		{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", "--cache-loc=/var/cache/apparmor", "--quiet", "/path/to/snap.samba.smbd"},
+		{"apparmor_parser", "--replace", "--write-cache", "--cache-loc=/var/cache/apparmor", "--quiet", "/path/to/snap.samba.smbd"},
 	})
 }
 
@@ -128,7 +128,7 @@ func (s *appArmorSuite) TestLoadProfilesRunsAppArmorParserReplaceWithSnapdDebug(
 	err := apparmor.LoadProfiles([]string{"/path/to/snap.samba.smbd"}, apparmor.CacheDir, 0)
 	c.Assert(err, IsNil)
 	c.Assert(cmd.Calls(), DeepEquals, [][]string{
-		{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", "--cache-loc=/var/cache/apparmor", "/path/to/snap.samba.smbd"},
+		{"apparmor_parser", "--replace", "--write-cache", "--cache-loc=/var/cache/apparmor", "/path/to/snap.samba.smbd"},
 	})
 }
 

--- a/tests/regression/lp-1848567/task.yaml
+++ b/tests/regression/lp-1848567/task.yaml
@@ -27,7 +27,7 @@ execute: |
     # caches. Use memory-observe-do to record the maximum resident memory usage
     # and store it in a file.
     "$TESTSTOOLS"/memory-observe-do -o memory-kb.txt apparmor_parser \
-      --skip-read-cache --skip-cache --skip-kernel-load -Ono-expr-simplify \
+      --skip-read-cache --skip-cache --skip-kernel-load \
       /var/lib/snapd/apparmor/profiles/snap-update-ns.test-snapd-app
     # Without de-duplicating mount rules the compiler would take about 1.5GB on a
     # 64 bit system. With the de-duplication logic it took less than 38MB on an


### PR DESCRIPTION
We recently ran into a real world profile bug where the option `-O no-expr-simplify` causes a 10x increase in apparmor_parser runtime and memory usage [1] that breaks existing customers.

The decision to use `-O no-expr-simplify` was taken in 2014 [2] and the profiles back then where simpler. This commit will make some profile generation slower but it will avoid going into the exponential memory usage  when compiled with `apparmor_parser -O no-expr-simplify`.

[1] https://bugs.launchpad.net/snapd/+bug/2025030
[2] https://bugs.launchpad.net/ubuntu-rtm/+source/apparmor/+bug/1383858
