### PR TITLE
tests: add test that explores `apparmor_parser {,no-}expr-simplify`

### DIFF
--- a/tests/main/interfaces-no-expr-simplify-bad/task.yaml
+++ b/tests/main/interfaces-no-expr-simplify-bad/task.yaml
@@ -1,0 +1,29 @@
+summary: Ensure that interfaces bad for -O no-expr-simplify work
+
+systems: [ubuntu-*]
+
+prepare: |
+    snap install yq
+
+execute: |
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-expensive-interfaces
+
+    for con in $(yq -r '.apps.cmd.plugs | join(" ")' < test-snapd-expensive-interfaces/meta/snap.yaml); do
+        snap connect test-snapd-expensive-interfaces:"$con"
+    done
+
+    # validate profile can *not* be compiled with "no-expr-simplify"
+    LIMIT=800M
+    OPT="no-expr-simplify"
+    not systemd-run -P --unit aa-compile --wait \
+      -pMemorySwapMax=0 -p MemoryMax="$LIMIT" -p MemoryLimit="$LIMIT" \
+       /usr/bin/time -f 'mem-kilobyte: %M' apparmor_parser -O "$OPT" \
+          -S /var/lib/snapd/apparmor/profiles/snap.test-snapd-expensive-interfaces.cmd >/dev/null
+    journalctl -u aa-compile | MATCH "OOM killer"
+
+    # but it can be without (with a much smaller limit)
+    LIMIT=400M
+    systemd-run -P --unit aa-compile-defaults --wait \
+      -pMemorySwapMax=0 -p MemoryMax="$LIMIT" -p MemoryLimit="$LIMIT" \
+       /usr/bin/time -f 'mem-kilobyte: %M' apparmor_parser \
+          -S /var/lib/snapd/apparmor/profiles/snap.test-snapd-expensive-interfaces.cmd >/dev/null

--- a/tests/main/interfaces-no-expr-simplify-bad/test-snapd-expensive-interfaces/bin/sh
+++ b/tests/main/interfaces-no-expr-simplify-bad/test-snapd-expensive-interfaces/bin/sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec /bin/sh "$@"

--- a/tests/main/interfaces-no-expr-simplify-bad/test-snapd-expensive-interfaces/meta/snap.yaml
+++ b/tests/main/interfaces-no-expr-simplify-bad/test-snapd-expensive-interfaces/meta/snap.yaml
@@ -1,0 +1,28 @@
+name: test-snapd-expensive-interfaces
+summary: A snap that uses interfaces that are unfriendly to -O no-expr-simplify
+version: 1.0
+
+apps:
+ cmd:
+  command: bin/sh
+  plugs:
+    # interfaces with /sys/devices/**/../** really behave badly with
+    # -O no-expr-simplify
+    - block-devices
+    - bluetooth-control
+    - bluez
+    - browser-support
+    - camera
+    - cpu-control
+    - framebuffer
+    - device-buttons
+    - display-control
+    - joystick
+    - modem-manager
+    - network-manager
+    - opengl
+    - power-control
+    - raw-input
+    - udisks2
+    - wayland
+    - x11


### PR DESCRIPTION
When apparmor_parser is used with `-O no-expr-simplify` it can go into a expoential memory/cpu usage pattern when there are lines with `/**/`. We dealt with that in the past by adding special helpers like `AddParametricSnippet`, see 9c74887908b.

But it seems we have reached the limits for this now as we have various interfaces that e.g. contain `/sys/devices/**/.../**` like patterns which when combined seems to cause issues that make the parser easily consume more than 1G of memory.

This commit has an example snap that combines some of the problematic interfaces and demonstrates that it cannot be compiled with less than 750M (the real number is probably closer to 1G) when `no-expr-simplify` is used. It then shows that it does work with the default apparmor options.
