### PR TITLE
o/state: support for task+change status events

### DIFF
--- a/overlord/state/state.go
+++ b/overlord/state/state.go
@@ -87,6 +87,9 @@ type State struct {
 	lastTaskId   int
 	lastChangeId int
 	lastLaneId   int
+	// lastHandlerId is not serialized, it's only used during runtime
+	// for registering runtime callbacks
+	lastHandlerId int
 
 	backend  Backend
 	data     customData
@@ -99,6 +102,10 @@ type State struct {
 	cache map[interface{}]interface{}
 
 	pendingChangeByAttr map[string]func(*Change) bool
+
+	// task/changes observing
+	taskHandlers   map[int]func(t *Task, old, new Status)
+	changeHandlers map[int]func(chg *Change, old, new Status)
 }
 
 // New returns a new empty state.
@@ -112,6 +119,8 @@ func New(backend Backend) *State {
 		modified:            true,
 		cache:               make(map[interface{}]interface{}),
 		pendingChangeByAttr: make(map[string]func(*Change) bool),
+		taskHandlers:        make(map[int]func(t *Task, old Status, new Status)),
+		changeHandlers:      make(map[int]func(chg *Change, old Status, new Status)),
 	}
 }
 
@@ -480,6 +489,58 @@ func (s *State) GetMaybeTimings(timings interface{}) error {
 		return err
 	}
 	return nil
+}
+
+// AddTaskStatusChangedHandler adds a callback function that will be invoked
+// whenever tasks change status.
+// NOTE: Callbacks registered this way may be invoked in the context
+// of the taskrunner, so the callbacks should be as simple as possible, and return
+// as quickly as possible, and should avoid the use of i/o code or blocking, as this
+// will stop the entire task system.
+func (s *State) AddTaskStatusChangedHandler(f func(t *Task, old, new Status)) (id int) {
+	s.reading()
+	id = s.lastHandlerId
+	s.lastHandlerId++
+	s.taskHandlers[id] = f
+	return id
+}
+
+func (s *State) RemoveTaskStatusChangedHandler(id int) {
+	s.reading()
+	delete(s.taskHandlers, id)
+}
+
+func (s *State) notifyTaskStatusChangedHandlers(t *Task, old, new Status) {
+	s.reading()
+	for _, f := range s.taskHandlers {
+		f(t, old, new)
+	}
+}
+
+// AddChangeStatusChangedHandler adds a callback function that will be invoked
+// whenever a Change changes status.
+// NOTE: Callbacks registered this way may be invoked in the context
+// of the taskrunner, so the callbacks should be as simple as possible, and return
+// as quickly as possible, and should avoid the use of i/o code or blocking, as this
+// will stop the entire task system.
+func (s *State) AddChangeStatusChangedHandler(f func(chg *Change, old, new Status)) (id int) {
+	s.reading()
+	id = s.lastHandlerId
+	s.lastHandlerId++
+	s.changeHandlers[id] = f
+	return id
+}
+
+func (s *State) RemoveChangeStatusChangedHandler(id int) {
+	s.reading()
+	delete(s.changeHandlers, id)
+}
+
+func (s *State) notifyChangeStatusChangedHandlers(chg *Change, old, new Status) {
+	s.reading()
+	for _, f := range s.changeHandlers {
+		f(chg, old, new)
+	}
 }
 
 // SaveTimings implements timings.GetSaver

--- a/overlord/state/state.go
+++ b/overlord/state/state.go
@@ -498,6 +498,8 @@ func (s *State) GetMaybeTimings(timings interface{}) error {
 // as quickly as possible, and should avoid the use of i/o code or blocking, as this
 // will stop the entire task system.
 func (s *State) AddTaskStatusChangedHandler(f func(t *Task, old, new Status)) (id int) {
+	// We are reading here as we want to ensure access to the state is serialized,
+	// and not writing as we are not changing the part of state that goes on the disk.
 	s.reading()
 	id = s.lastHandlerId
 	s.lastHandlerId++
@@ -524,6 +526,8 @@ func (s *State) notifyTaskStatusChangedHandlers(t *Task, old, new Status) {
 // as quickly as possible, and should avoid the use of i/o code or blocking, as this
 // will stop the entire task system.
 func (s *State) AddChangeStatusChangedHandler(f func(chg *Change, old, new Status)) (id int) {
+	// We are reading here as we want to ensure access to the state is serialized,
+	// and not writing as we are not changing the part of state that goes on the disk.
 	s.reading()
 	id = s.lastHandlerId
 	s.lastHandlerId++

--- a/overlord/state/state_test.go
+++ b/overlord/state/state_test.go
@@ -1081,3 +1081,161 @@ func (ss *stateSuite) TestNoStateErrorString(c *C) {
 	err.Key = "foo"
 	c.Assert(err.Error(), Equals, `no state entry for key "foo"`)
 }
+
+type taskAndStatus struct {
+	t        *state.Task
+	old, new state.Status
+}
+
+func (ss *stateSuite) TestTaskChangedHandler(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	var taskObservedChanges []taskAndStatus
+	oId := st.AddTaskStatusChangedHandler(func(t *state.Task, old, new state.Status) {
+		taskObservedChanges = append(taskObservedChanges, taskAndStatus{
+			t:   t,
+			old: old,
+			new: new,
+		})
+	})
+
+	t1 := st.NewTask("foo", "...")
+
+	t1.SetStatus(state.DoingStatus)
+
+	// Set task status to identical status, we don't want
+	// task events when task don't actually change status.
+	t1.SetStatus(state.DoingStatus)
+
+	// Set task to done.
+	t1.SetStatus(state.DoneStatus)
+
+	// Unregister us, and make sure we do not receive more events.
+	st.RemoveTaskStatusChangedHandler(oId)
+
+	// must not appear in list.
+	t1.SetStatus(state.DoingStatus)
+
+	c.Check(taskObservedChanges, DeepEquals, []taskAndStatus{
+		{
+			t:   t1,
+			old: state.DefaultStatus,
+			new: state.DoingStatus,
+		},
+		{
+			t:   t1,
+			old: state.DoingStatus,
+			new: state.DoneStatus,
+		},
+	})
+}
+
+type changeAndStatus struct {
+	chg      *state.Change
+	old, new state.Status
+}
+
+func (ss *stateSuite) TestChangeChangedHandler(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	var observedChanges []changeAndStatus
+	oId := st.AddChangeStatusChangedHandler(func(chg *state.Change, old, new state.Status) {
+		observedChanges = append(observedChanges, changeAndStatus{
+			chg: chg,
+			old: old,
+			new: new,
+		})
+	})
+
+	chg := st.NewChange("test-chg", "...")
+	t1 := st.NewTask("foo", "...")
+	chg.AddTask(t1)
+
+	t1.SetStatus(state.DoingStatus)
+
+	// Set task status to identical status, we don't want
+	// change events when changes don't actually change status.
+	t1.SetStatus(state.DoingStatus)
+
+	// Set task to waiting
+	t1.SetToWait(state.DoneStatus)
+
+	// Unregister us, and make sure we do not receive more events.
+	st.RemoveChangeStatusChangedHandler(oId)
+
+	// must not appear in list.
+	t1.SetStatus(state.DoneStatus)
+
+	c.Check(observedChanges, DeepEquals, []changeAndStatus{
+		{
+			chg: chg,
+			old: state.DefaultStatus,
+			new: state.DoingStatus,
+		},
+		{
+			chg: chg,
+			old: state.DoingStatus,
+			new: state.WaitStatus,
+		},
+	})
+}
+
+func (ss *stateSuite) TestChangeSetStatusChangedHandler(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	var observedChanges []changeAndStatus
+	oId := st.AddChangeStatusChangedHandler(func(chg *state.Change, old, new state.Status) {
+		observedChanges = append(observedChanges, changeAndStatus{
+			chg: chg,
+			old: old,
+			new: new,
+		})
+	})
+
+	chg := st.NewChange("test-chg", "...")
+	t1 := st.NewTask("foo", "...")
+	chg.AddTask(t1)
+
+	t1.SetStatus(state.DoingStatus)
+
+	// We have a single task in Doing, now we manipulate the status
+	// of the change to ensure we are receiving correct events
+	chg.SetStatus(state.WaitStatus)
+
+	// Change to a new status
+	chg.SetStatus(state.ErrorStatus)
+
+	// Now return the status back to Default, which should result
+	// in the change reporting Doing
+	chg.SetStatus(state.DefaultStatus)
+	st.RemoveChangeStatusChangedHandler(oId)
+
+	c.Check(observedChanges, DeepEquals, []changeAndStatus{
+		{
+			chg: chg,
+			old: state.DefaultStatus,
+			new: state.DoingStatus,
+		},
+		{
+			chg: chg,
+			old: state.DoingStatus,
+			new: state.WaitStatus,
+		},
+		{
+			chg: chg,
+			old: state.WaitStatus,
+			new: state.ErrorStatus,
+		},
+		{
+			chg: chg,
+			old: state.ErrorStatus,
+			new: state.DoingStatus,
+		},
+	})
+}

--- a/overlord/state/task.go
+++ b/overlord/state/task.go
@@ -243,6 +243,9 @@ func (t *Task) Status() Status {
 }
 
 func (t *Task) changeStatus(old, new Status) {
+	if old == new {
+		return
+	}
 	t.status = new
 	if !old.Ready() && new.Ready() {
 		t.readyTime = timeNow()
@@ -251,6 +254,7 @@ func (t *Task) changeStatus(old, new Status) {
 	if chg != nil {
 		chg.taskStatusChanged(t, old, new)
 	}
+	t.state.notifyTaskStatusChangedHandlers(t, old, new)
 }
 
 // SetStatus sets the task status, overriding the default behavior (see Status method).


### PR DESCRIPTION
This PR adds support for subscribing to task and change status events. It's extrapolated from this PR https://github.com/snapcore/snapd/pull/12898 and aims to replace this PR https://github.com/snapcore/snapd/pull/12720