### PR TITLE
o/restart: add first part of the new restart logic

### DIFF
--- a/bootloader/bootloader.go
+++ b/bootloader/bootloader.go
@@ -57,17 +57,17 @@ type Options struct {
 	// PrepareImageTime indicates whether the booloader is being
 	// used at prepare-image time, that means not on a runtime
 	// system.
-	PrepareImageTime bool
+	PrepareImageTime bool `json:"prepare-image-time,omitempty"`
 
 	// Role specifies to use the bootloader for the given role.
-	Role Role
+	Role Role `json:"role,omitempty"`
 
 	// NoSlashBoot indicates to use the native layout of the
 	// bootloader partition and not the /boot mount.
 	// It applies only for RoleRunMode.
 	// It is implied and ignored for RoleRecovery.
 	// It is an error to set it for RoleSole.
-	NoSlashBoot bool
+	NoSlashBoot bool `json:"no-slash-boot,omitempty"`
 }
 
 func (o *Options) validate() error {

--- a/overlord/restart/export_test.go
+++ b/overlord/restart/export_test.go
@@ -1,0 +1,34 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package restart
+
+import (
+	"github.com/snapcore/snapd/boot"
+)
+
+var (
+	MarkTaskForRestart          = markTaskForRestart
+	RestartParametersFromChange = restartParametersFromChange
+	ProcessRestartForChange     = processRestartForChange
+)
+
+func RestartParametersInit(rt *RestartParameters, snapName string, restartType RestartType, rebootInfo *boot.RebootInfo) {
+	rt.init(snapName, restartType, rebootInfo)
+}

--- a/overlord/restart/restart.go
+++ b/overlord/restart/restart.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2022 Canonical Ltd
+ * Copyright (C) 2016-2023 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -98,7 +98,7 @@ func Manager(st *state.State, curBootID string, h Handler) (*RestartManager, err
 		return nil, err
 	}
 
-	st.RegisterPendingChangeByAttr("wait-for-system-restart", rm.PendingForSystemRestart)
+	st.RegisterPendingChangeByAttr("wait-for-system-restart", rm.pendingForSystemRestart)
 
 	return rm, nil
 }
@@ -194,9 +194,9 @@ func (rm *RestartManager) rebootDidNotHappen() error {
 	return nil
 }
 
-// PendingForSystemRestart returns true if the change has tasks that are set to
+// pendingForSystemRestart returns true if the change has tasks that are set to
 // wait pending a manual system restart. It is registered with the prune logic.
-func (rm *RestartManager) PendingForSystemRestart(chg *state.Change) bool {
+func (rm *RestartManager) pendingForSystemRestart(chg *state.Change) bool {
 	if chg.IsReady() {
 		return false
 	}
@@ -361,4 +361,140 @@ func MockPending(st *state.State, restarting RestartType) RestartType {
 func ReplaceBootID(st *state.State, bootID string) {
 	rm := restartManager(st, "internal error: cannot mock a restart request before RestartManager initialization")
 	rm.bootID = bootID
+}
+
+// markTaskForRestart sets certain properties on a task to mark it for system restart.
+// The status argument is the status that the task will have after the system restart.
+func markTaskForRestart(t *state.Task, status state.Status) {
+	// XXX: Preserve previous restart behaviour for classic in the undo cases, is this still
+	// necessary?
+	if release.OnClassic && (status == state.UndoStatus || status == state.UndoneStatus) {
+		t.SetStatus(status)
+		t.Logf("Skipped automatic system restart on classic system when undoing changes back to previous state")
+		return
+	}
+
+	rm := restartManager(t.State(), "internal error: cannot request a restart before RestartManager initialization")
+
+	// store current boot id to be able to check later if we have rebooted or not
+	t.Set("wait-for-system-restart-from-boot-id", rm.bootID)
+	t.SetToWait(status)
+	setWaitForSystemRestart(t.Change())
+
+	t.Logf("Task set to wait until a system restart allows to continue")
+}
+
+// restartParametersFromChange returns either existing restart parameters from a
+// previous reboot request, or a new empty instance of RestartParameters which
+// needs to be init().
+func restartParametersFromChange(chg *state.Change) (*RestartParameters, error) {
+	if chg == nil {
+		return nil, fmt.Errorf("task is not bound to any change")
+	}
+
+	var rp RestartParameters
+	if err := chg.Get("pending-system-restart", &rp); err != nil {
+		if errors.Is(err, &state.NoStateError{}) {
+			return &RestartParameters{}, nil
+		}
+		return nil, err
+	}
+	return &rp, nil
+}
+
+// FinishTaskWithRestart2 either schedules a restart for the given task or it
+// does an immediate restart of the snapd daemon, depending on the type of restart
+// provided.
+// For SystemRestart and friends, the restart is scheduled and postponed until the
+// change has run out of tasks to run.
+// For tasks that request restarts as a part of their undo, any tasks that previously scheduled
+// restarts as a part of their 'do' will be unscheduled.
+// XXX: will replace FinishTaskWithRestart
+func FinishTaskWithRestart2(t *state.Task, snapName string, status state.Status, restartType RestartType, rebootInfo *boot.RebootInfo) error {
+	switch restartType {
+	case RestartSystem, RestartSystemNow, RestartSystemHaltNow, RestartSystemPoweroffNow:
+		break
+	default:
+		t.SetStatus(status)
+		Request(t.State(), restartType, rebootInfo)
+		return nil
+	}
+
+	chg := t.Change()
+	rp, err := restartParametersFromChange(chg)
+	if err != nil {
+		return err
+	}
+
+	// always re-init restart parameters
+	if snapName == "" {
+		snapName = "snapd"
+	}
+	rp.init(snapName, restartType, rebootInfo)
+
+	// Either invoked with undone or done as the final status. We don't expect
+	// other uses than tasks that end their Doing/Undoing to call this. Let's
+	// only allow these for now as nothing tests with anything else.
+	switch status {
+	case state.DoneStatus, state.UndoneStatus:
+		markTaskForRestart(t, status)
+	default:
+		return fmt.Errorf("internal error: unexpected task status when requesting system restart for task: %s", status)
+	}
+
+	chg.Set("pending-system-restart", rp)
+	return nil
+}
+
+// PendingForChange checks if a system restart is pending for a change.
+func PendingForChange(st *state.State, chg *state.Change) bool {
+	rm := restartManager(st, "internal error: cannot request a restart before RestartManager initialization")
+	return rm.pendingForSystemRestart(chg)
+}
+
+// TaskWaitForRestart can be used for tasks that need to wait for a pending
+// restart to occur, meant to be used in conjunction with PendingForChange.
+// The task will then be re-run after the restart has occurred.
+// This is only supported for tasks that are currently in Doing/Undoing and is only
+// safe to call from the task itself. After calling this, the task should immediately
+// return.
+func TaskWaitForRestart(t *state.Task) error {
+	// We catch them in Undoing/Doing and restore them to
+	// Do/Undo so they are re-run as we cannot save progress mid-task.
+	switch t.Status() {
+	case state.UndoingStatus:
+		markTaskForRestart(t, state.UndoStatus)
+	case state.DoingStatus:
+		markTaskForRestart(t, state.DoStatus)
+	default:
+		return fmt.Errorf("internal error: only tasks currently in progress (doing/undoing) are supported")
+	}
+	return nil
+}
+
+// processRestartForChange must only be called from the change status changed event
+// hook.
+func processRestartForChange(chg *state.Change) error {
+	var rp RestartParameters
+	if err := chg.Get("pending-system-restart", &rp); err != nil {
+		if errors.Is(err, &state.NoStateError{}) {
+			return fmt.Errorf("change %s is waiting to continue but has not requested any reboots", chg.ID())
+		}
+		return err
+	}
+
+	// clear out the restart context for this change before restarting
+	chg.Set("pending-system-restart", nil)
+
+	// perform the restart
+	if release.OnClassic {
+		// Notify the system that a reboot is required.
+		if err := notifyRebootRequiredClassic(rp.SnapName); err != nil {
+			logger.Noticef("cannot notify about pending reboot: %v", err)
+		}
+		logger.Noticef("Postponing restart until a manual system restart allows to continue")
+		return nil
+	}
+	Request(chg.State(), rp.RestartType, &boot.RebootInfo{RebootRequired: true, BootloaderOptions: rp.BootloaderOptions})
+	return nil
 }

--- a/overlord/restart/restart_parameters.go
+++ b/overlord/restart/restart_parameters.go
@@ -1,0 +1,63 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package restart
+
+import (
+	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/bootloader"
+)
+
+type RestartParameters struct {
+	SnapName          string              `json:"snap-name,omitempty"`
+	RestartType       RestartType         `json:"restart-type,omitempty"`
+	BootloaderOptions *bootloader.Options `json:"bootloader-options,omitempty"`
+}
+
+// These are the restart-types that are relevant for the restart parameters. They
+// are ordered by priority.
+// Restart types of type *Now takes precedence.
+var restartTypeOrder = []RestartType{
+	// PowerOff takes precedence above Halt as it we perceive it as being the
+	// stronger of those two requests.
+	RestartSystemPoweroffNow,
+	RestartSystemHaltNow,
+	RestartSystemNow,
+	RestartSystem,
+}
+
+func (rt *RestartParameters) init(snapName string, restartType RestartType, rebootInfo *boot.RebootInfo) {
+	for _, r := range restartTypeOrder {
+		// Only set if the one stored isn't already same priority
+		// or higher.
+		if rt.RestartType == r {
+			break
+		}
+		if restartType == r {
+			rt.SnapName = snapName
+			rt.RestartType = restartType
+			break
+		}
+	}
+
+	// only override if the one we have stored is nil
+	if rebootInfo != nil && rebootInfo.BootloaderOptions != nil && rt.BootloaderOptions == nil {
+		rt.BootloaderOptions = rebootInfo.BootloaderOptions
+	}
+}

--- a/overlord/restart/restart_parameters_test.go
+++ b/overlord/restart/restart_parameters_test.go
@@ -1,0 +1,109 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package restart_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/bootloader"
+	"github.com/snapcore/snapd/overlord/restart"
+)
+
+type restartParametersSuite struct{}
+
+var _ = Suite(&restartParametersSuite{})
+
+func (s *restartParametersSuite) TestSetParameters(c *C) {
+	rt := &restart.RestartParameters{}
+
+	restart.RestartParametersInit(rt, "some-snap", restart.RestartSystem, &boot.RebootInfo{
+		BootloaderOptions: &bootloader.Options{
+			Role:        bootloader.RoleRunMode,
+			NoSlashBoot: true,
+		},
+	})
+	c.Check(rt.SnapName, Equals, "some-snap")
+	c.Check(rt.RestartType, Equals, restart.RestartSystem)
+	c.Check(rt.BootloaderOptions, DeepEquals, &bootloader.Options{
+		Role:        bootloader.RoleRunMode,
+		NoSlashBoot: true,
+	})
+}
+
+func (s *restartParametersSuite) TestSetParametersPrecedences(c *C) {
+	rt := &restart.RestartParameters{}
+
+	restart.RestartParametersInit(rt, "restart", restart.RestartSystem, nil)
+	c.Check(rt.SnapName, Equals, "restart")
+	c.Check(rt.RestartType, Equals, restart.RestartSystem)
+	c.Check(rt.BootloaderOptions, IsNil)
+
+	restart.RestartParametersInit(rt, "restart-now", restart.RestartSystemNow, nil)
+	c.Check(rt.SnapName, Equals, "restart-now")
+	c.Check(rt.RestartType, Equals, restart.RestartSystemNow)
+	c.Check(rt.BootloaderOptions, IsNil)
+
+	restart.RestartParametersInit(rt, "halt-now", restart.RestartSystemHaltNow, nil)
+	c.Check(rt.SnapName, Equals, "halt-now")
+	c.Check(rt.RestartType, Equals, restart.RestartSystemHaltNow)
+	c.Check(rt.BootloaderOptions, IsNil)
+
+	restart.RestartParametersInit(rt, "poweroff-now", restart.RestartSystemPoweroffNow, nil)
+	c.Check(rt.SnapName, Equals, "poweroff-now")
+	c.Check(rt.RestartType, Equals, restart.RestartSystemPoweroffNow)
+	c.Check(rt.BootloaderOptions, IsNil)
+
+	// verify it's not changed after setting with *Now
+	restart.RestartParametersInit(rt, "restart", restart.RestartSystem, nil)
+	c.Check(rt.SnapName, Equals, "poweroff-now")
+	c.Check(rt.RestartType, Equals, restart.RestartSystemPoweroffNow)
+	c.Check(rt.BootloaderOptions, IsNil)
+}
+
+func (s *restartParametersSuite) TestSetParametersBootloaderOptionsSetOnce(c *C) {
+	rt := &restart.RestartParameters{}
+
+	restart.RestartParametersInit(rt, "some-snap", restart.RestartSystem, &boot.RebootInfo{
+		BootloaderOptions: &bootloader.Options{
+			PrepareImageTime: true,
+			Role:             bootloader.RoleRunMode,
+		},
+	})
+	c.Check(rt.SnapName, Equals, "some-snap")
+	c.Check(rt.RestartType, Equals, restart.RestartSystem)
+	c.Check(rt.BootloaderOptions, DeepEquals, &bootloader.Options{
+		PrepareImageTime: true,
+		Role:             bootloader.RoleRunMode,
+	})
+
+	// should essentially be a no-op right now
+	restart.RestartParametersInit(rt, "other-snap", restart.RestartSystem, &boot.RebootInfo{
+		BootloaderOptions: &bootloader.Options{
+			Role: bootloader.RoleRunMode,
+		},
+	})
+	c.Check(rt.SnapName, Equals, "some-snap")
+	c.Check(rt.RestartType, Equals, restart.RestartSystem)
+	c.Check(rt.BootloaderOptions, DeepEquals, &bootloader.Options{
+		PrepareImageTime: true,
+		Role:             bootloader.RoleRunMode,
+	})
+}


### PR DESCRIPTION
Implement a RestartContext system that keeps track of tasks that needs to restart and why for a change. This PR is the first part of https://github.com/snapcore/snapd/pull/12913 and contains most of the new logic. It does not integrate this code into the current system, that is postponed for when https://github.com/snapcore/snapd/pull/12921 lands as well.

