### PR TITLE
o/state: fix comment formatting

### DIFF
--- a/overlord/state/task.go
+++ b/overlord/state/task.go
@@ -203,38 +203,37 @@ func (t *Task) Summary() string {
 //
 // Possible state transitions:
 //
-//     /----aborting lane--Do
-//     |                   |
-//     V                   V
-//    Hold               Doing-->Wait
-//     ^                /  |  \
-//     |         abort /   V   V
-//   no undo          /  Done  Error
-//     |             V     |
-//     \----------Abort   aborting lane
-//     /          |        |
-//     |       finished or |
-//  running    not running |
-//     V          \------->|
-//  kill goroutine         |
-//     |                   V
-//    / \           ----->Undo
-//   /   no error  /       |
-//   |   from goroutine    |
-//  error                  |
-//  from goroutine         |
-//   |                     V
-//   |                  Undoing-->Wait
-//   V                     |   \
-//  Error                  V    V
-//                       Undone Error
+//	   /----aborting lane--Do
+//	   |                   |
+//	   V                   V
+//	  Hold               Doing-->Wait
+//	   ^                /  |  \
+//	   |         abort /   V   V
+//	 no undo          /  Done  Error
+//	   |             V     |
+//	   \----------Abort   aborting lane
+//	   /          |        |
+//	   |       finished or |
+//	running    not running |
+//	   V          \------->|
+//	kill goroutine         |
+//	   |                   V
+//	  / \           ----->Undo
+//	 /   no error  /       |
+//	 |   from goroutine    |
+//	error                  |
+//	from goroutine         |
+//	 |                     V
+//	 |                  Undoing-->Wait
+//	 V                     |   \
+//	Error                  V    V
+//	                     Undone Error
 //
 // Do -> Doing -> Done is the direct succcess scenario.
 //
 // Wait can transition to its waited status,
 // usually Done|Undone or back to Doing.
 // See Wait struct, SetToWait and WaitedStatus.
-//
 func (t *Task) Status() Status {
 	t.state.reading()
 	if t.status == DefaultStatus {


### PR DESCRIPTION
Our static checks were failing when running with go1.20 because of a gofmt difference.
