### PR TITLE
Allow directories in private /dev/shm

### DIFF
--- a/interfaces/builtin/shared_memory.go
+++ b/interfaces/builtin/shared_memory.go
@@ -100,7 +100,7 @@ const sharedMemoryBaseDeclarationSlots = `
 
 const sharedMemoryPrivateConnectedPlugAppArmor = `
 # Description: Allow access to everything in private /dev/shm
-"/dev/shm/*" mrwlkix,
+"/dev/shm/**" mrwlkix,
 `
 
 func validateSharedMemoryPath(path string) error {


### PR DESCRIPTION
Hello - This small PR is about allowing directories creation in private `/dev/shm`. 
This is needed for applications that rely/advise on a directory structure under `/dev/shm` such the OpenSearch's performance analyzer. [Original discussion](https://forum.snapcraft.io/t/interface-auto-connect-request-for-opensearch-snap/34772)
