### PR TITLE
o/snapstate: continue inhibitted refresh manually

### DIFF
--- a/overlord/snapstate/agentnotify/agentnotify.go
+++ b/overlord/snapstate/agentnotify/agentnotify.go
@@ -57,7 +57,7 @@ func notifyLinkSnap(snapsup *snapstate.SnapSetup) error {
 	// Note that we only show a notification here if the refresh was
 	// triggered by a "continued-auto-refresh", i.e. when the user
 	// closed an application that had a auto-refresh ready.
-	if snapsup.Flags.IsContinuedAutoRefresh {
+	if snapsup.Flags.IsContinuedRefresh {
 		logger.Debugf("notifying user client about continued refresh for %q", snapsup.InstanceName())
 		sendClientFinishRefreshNotification(snapsup)
 	}

--- a/overlord/snapstate/agentnotify/agentnotify_test.go
+++ b/overlord/snapstate/agentnotify/agentnotify_test.go
@@ -72,7 +72,7 @@ func (s *agentNotifySuite) TestNotifyAgentOnLinkChange(c *C) {
 			Current: snap.R(1),
 		})
 		snapsup := &snapstate.SnapSetup{
-			Flags: snapstate.Flags{IsContinuedAutoRefresh: tc.isContinuedAutoRefresh},
+			Flags: snapstate.Flags{IsContinuedRefresh: tc.isContinuedAutoRefresh},
 			SideInfo: &snap.SideInfo{
 				RealName: "some-snap",
 			},

--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -80,6 +80,8 @@ var refreshRetryDelay = 20 * time.Minute
 // of auto-refresh.
 type refreshCandidate struct {
 	SnapSetup
+	Version    string `json:"version,omitempty"`
+	Monitoring bool   `json:"monitoring,omitempty"`
 }
 
 func (rc *refreshCandidate) Type() snap.Type {
@@ -271,7 +273,9 @@ func (m *autoRefresh) Ensure() (err error) {
 	m.state.Lock()
 	defer m.state.Unlock()
 
-	m.restoreMonitoring()
+	if err := m.restoreMonitoring(); err != nil {
+		return fmt.Errorf("cannot restore monitoring: %v", err)
+	}
 
 	// see if it even makes sense to try to refresh
 	if CanAutoRefresh == nil {
@@ -279,27 +283,6 @@ func (m *autoRefresh) Ensure() (err error) {
 	}
 	if ok, err := CanAutoRefresh(m.state); err != nil || !ok {
 		return err
-	}
-
-	// is there a previously partially inhibited auto-refresh that can now be continued?
-	if attempt, ok := canContinueAutoRefresh(m.state); ok {
-		// override the auto-refresh delay if we're continuing an inhibited auto-refresh
-		// for the first time (because the snap just closed after we notified the user)
-		overrideDelay := attempt == 1
-		err := m.launchAutoRefresh(overrideDelay)
-		if err != nil {
-			if errors.Is(err, tooSoonError{}) {
-				// ignore error, retry the auto-refresh later
-				return nil
-			}
-
-			// we didn't auto-refresh, so keep flag but increase attempt counter
-			m.state.Cache("auto-refresh-continue-attempt", attempt+1)
-			return err
-		}
-		// clear the continue flag if the auto-refresh was scheduled successfully
-		m.state.Cache("auto-refresh-continue-attempt", nil)
-		return nil
 	}
 
 	// get lastRefresh and schedule
@@ -384,8 +367,7 @@ func (m *autoRefresh) Ensure() (err error) {
 				return nil
 			}
 
-			overrideDelay := false
-			err = m.launchAutoRefresh(overrideDelay)
+			err = m.launchAutoRefresh()
 			if _, ok := err.(*httputil.PersistentNetworkError); ok {
 				// refresh will be retried after refreshRetryDelay
 				return err
@@ -402,44 +384,48 @@ func (m *autoRefresh) Ensure() (err error) {
 	return err
 }
 
-func canContinueAutoRefresh(st *state.State) (int, bool) {
-	if cachedAttempt := st.Cached("auto-refresh-continue-attempt"); cachedAttempt != nil {
-		return cachedAttempt.(int), true
-	}
-
-	return 0, false
-}
-
-func (m *autoRefresh) restoreMonitoring() {
+func (m *autoRefresh) restoreMonitoring() error {
 	if m.restoredMonitoring {
-		return
+		return nil
 	}
 
-	var monitored []string
-	if err := m.state.Get("monitored-snaps", &monitored); err != nil && !errors.Is(err, state.ErrNoState) {
-		logger.Noticef("cannot restore monitoring: %v", err)
-		return
+	// clear the old monitoring state; remove in a later snapd version
+	m.state.Set("monitored-snaps", nil)
+
+	var refreshHints map[string]*refreshCandidate
+	if err := m.state.Get("refresh-candidates", &refreshHints); err != nil && !errors.Is(err, &state.NoStateError{}) {
+		return fmt.Errorf("cannot get refresh-candidates: %v", err)
 	}
 
 	defer func() { m.restoredMonitoring = true }()
-	if len(monitored) == 0 {
-		return
+
+	var monitored []*SnapSetup
+	for _, hint := range refreshHints {
+		if hint.Monitoring {
+			monitored = append(monitored, &hint.SnapSetup)
+		}
 	}
 
-	monitoring := make(map[string]chan<- bool)
+	if len(monitored) == 0 {
+		return nil
+	}
+
+	abortChans := make(map[string]chan<- bool, len(monitored))
 	for _, snap := range monitored {
 		done := make(chan string, 1)
-		if err := cgroupMonitorSnapEnded(snap, done); err != nil {
-			logger.Noticef("cannot restore monitoring for snap %q closure: %v", snap, err)
+		snapName := snap.InstanceName()
+		if err := cgroupMonitorSnapEnded(snapName, done); err != nil {
+			logger.Noticef("cannot restore monitoring for snap %q closure: %v", snapName, err)
 			continue
 		}
 
 		abort := make(chan bool, 1)
-		monitoring[snap] = abort
-
+		abortChans[snapName] = abort
 		go continueRefreshOnSnapClose(m.state, snap, done, abort)
 	}
-	updateMonitoringState(m.state, monitoring)
+
+	m.state.Cache("monitored-snaps", abortChans)
+	return nil
 }
 
 // isRefreshHeld returns whether an auto-refresh is currently held back or not,
@@ -580,13 +566,13 @@ func (tooSoonError) Is(err error) bool {
 }
 
 // launchAutoRefresh creates the auto-refresh taskset and a change for it.
-func (m *autoRefresh) launchAutoRefresh(overrideDelay bool) error {
+func (m *autoRefresh) launchAutoRefresh() error {
 	// Check that we have reasonable delays between attempts.
 	// If the store is under stress we need to make sure we do not
 	// hammer it too often
 	now := timeNow()
 	minAttempt := m.lastRefreshAttempt.Add(refreshRetryDelay)
-	if !overrideDelay && !m.lastRefreshAttempt.IsZero() && minAttempt.After(now) {
+	if !m.lastRefreshAttempt.IsZero() && minAttempt.After(now) {
 		return tooSoonError{}
 	}
 	m.lastRefreshAttempt = now
@@ -599,7 +585,7 @@ func (m *autoRefresh) launchAutoRefresh(overrideDelay bool) error {
 	}()
 
 	// NOTE: this will unlock and re-lock state for network ops
-	updated, updateTss, err := AutoRefresh(auth.EnsureContextTODO(), m.state, &AutoRefreshOptions{IsContinuedAutoRefresh: overrideDelay})
+	updated, updateTss, err := AutoRefresh(auth.EnsureContextTODO(), m.state)
 
 	// TODO: we should have some way to lock just creating and starting changes,
 	//       as that would alleviate this race condition we are guarding against

--- a/overlord/snapstate/autorefresh_gating_test.go
+++ b/overlord/snapstate/autorefresh_gating_test.go
@@ -1417,7 +1417,7 @@ func (s *autorefreshGatingSuite) TestAutorefreshPhase1FeatureFlag(c *C) {
 	mockInstalledSnap(c, s.state, snapAyaml, useHook)
 
 	// gate-auto-refresh-hook feature not enabled, expect old-style refresh.
-	_, updateTss, err := snapstate.AutoRefresh(context.TODO(), st, nil)
+	_, updateTss, err := snapstate.AutoRefresh(context.TODO(), st)
 	c.Check(err, IsNil)
 	tss := updateTss.Refresh
 	c.Assert(tss, HasLen, 2)
@@ -1430,7 +1430,7 @@ func (s *autorefreshGatingSuite) TestAutorefreshPhase1FeatureFlag(c *C) {
 	tr.Set("core", "experimental.gate-auto-refresh-hook", true)
 	tr.Commit()
 
-	_, updateTss, err = snapstate.AutoRefresh(context.TODO(), st, nil)
+	_, updateTss, err = snapstate.AutoRefresh(context.TODO(), st)
 	c.Check(err, IsNil)
 	tss = updateTss.Refresh
 	c.Assert(tss, HasLen, 2)

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -706,7 +706,7 @@ func (f *fakeStore) Download(ctx context.Context, name, targetFn string, snapInf
 		macaroon = user.StoreMacaroon
 	}
 	// only add the options if they contain anything interesting
-	if *dlOpts == (store.DownloadOptions{}) {
+	if dlOpts != nil && *dlOpts == (store.DownloadOptions{}) {
 		dlOpts = nil
 	}
 	f.downloads = append(f.downloads, fakeDownload{

--- a/overlord/snapstate/flags.go
+++ b/overlord/snapstate/flags.go
@@ -75,8 +75,8 @@ type Flags struct {
 	// IsAutoRefresh is true if the snap is currently auto-refreshed
 	IsAutoRefresh bool `json:"is-auto-refresh,omitempty"`
 
-	// IsContinuedAutoRefresh is true if this is a continued auto-refresh
-	IsContinuedAutoRefresh bool `json:"is-continued-auto-refresh,omitempty"`
+	// IsContinuedRefresh is true if this is a continued refresh
+	IsContinuedRefresh bool `json:"is-continued-auto-refresh,omitempty"`
 
 	// NoReRefresh prevents refresh from adding epoch-hopping
 	// re-refresh tasks. This allows refresh to work offline, as

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -834,16 +834,10 @@ func (m *SnapManager) doPreDownloadSnap(t *state.Task, tomb *tomb.Tomb) error {
 	}
 
 	targetFn := snapsup.MountFile()
-	dlOpts := &store.DownloadOptions{
-		// pre-downloads are only triggered in auto-refreshes
-		IsAutoRefresh: true,
-		RateLimit:     autoRefreshRateLimited(st),
-	}
-
 	perfTimings := state.TimingsForTask(t)
 	st.Unlock()
 	timings.Run(perfTimings, "pre-download", fmt.Sprintf("pre-download snap %q", snapsup.SnapName()), func(timings.Measurer) {
-		err = theStore.Download(tomb.Context(nil), snapsup.SnapName(), targetFn, snapsup.DownloadInfo, nil, user, dlOpts)
+		err = theStore.Download(tomb.Context(nil), snapsup.SnapName(), targetFn, snapsup.DownloadInfo, nil, user, nil)
 	})
 	st.Lock()
 	if err != nil {
@@ -892,23 +886,19 @@ func (m *SnapManager) doPreDownloadSnap(t *state.Task, tomb *tomb.Tomb) error {
 			return err
 		}
 
-		return asyncRefreshOnSnapClose(m.state, refreshInfo)
+		return asyncRefreshOnSnapClose(m.state, snapsup, refreshInfo)
 	}
 
-	continueInhibitedAutoRefresh(st)
+	refreshInhibitedSnap(st, snapsup.InstanceName())
 	return nil
 }
 
 // asyncRefreshOnSnapClose asynchronously waits for the snap the close, notifies
 // the user and then triggers an auto-refresh.
-func asyncRefreshOnSnapClose(st *state.State, refreshInfo *userclient.PendingSnapRefreshInfo) error {
-	monitoredSnaps := snapMonitoring(st)
-	if monitoredSnaps == nil {
-		monitoredSnaps = make(map[string]chan<- bool)
-	}
-
+func asyncRefreshOnSnapClose(st *state.State, snapsup *SnapSetup, refreshInfo *userclient.PendingSnapRefreshInfo) error {
+	snapName := snapsup.InstanceName()
 	// there's already a goroutine waiting for this snap to close so just notify
-	if monitoredSnaps[refreshInfo.InstanceName] != nil {
+	if abortChan := getAbortMonitoringChan(st, snapName); abortChan != nil {
 		asyncPendingRefreshNotification(context.TODO(), userclient.New(), refreshInfo)
 		return nil
 	}
@@ -916,89 +906,173 @@ func asyncRefreshOnSnapClose(st *state.State, refreshInfo *userclient.PendingSna
 	// monitor the snap until it closes. Use buffered channel to prevent the sender
 	// from blocking if the receiver stops before reading from it
 	done := make(chan string, 1)
-	if err := cgroupMonitorSnapEnded(refreshInfo.InstanceName, done); err != nil {
+	if err := cgroupMonitorSnapEnded(snapName, done); err != nil {
 		return fmt.Errorf("cannot monitor for snap closure: %w", err)
 	}
 
 	// notify the user about the blocked refresh
 	asyncPendingRefreshNotification(context.TODO(), userclient.New(), refreshInfo)
 
-	abort := make(chan bool, 1)
-	monitoredSnaps[refreshInfo.InstanceName] = abort
-	updateMonitoringState(st, monitoredSnaps)
+	// TODO: since we're assuming that the gated auto-refresh is on by default, the
+	// hints should be set. Use the task's snapSetup as fallback anyway?
+	var refreshHints map[string]*refreshCandidate
+	if err := st.Get("refresh-candidates", &refreshHints); err != nil {
+		return fmt.Errorf("cannot get refresh-candidates: %v", err)
+	}
 
-	go continueRefreshOnSnapClose(st, refreshInfo.InstanceName, done, abort)
+	abort := make(chan bool, 1)
+	if err := addMonitoring(st, snapName, abort); err != nil {
+		return fmt.Errorf("cannot save monitoring state: %v", err)
+	}
+
+	go continueRefreshOnSnapClose(st, snapsup, done, abort)
+	return nil
+}
+
+// addMonitoring adds monitoring info to the persisted and in-memory states.
+func addMonitoring(st *state.State, snapName string, abort chan<- bool) error {
+	var refreshHints map[string]*refreshCandidate
+	if err := st.Get("refresh-candidates", &refreshHints); err != nil {
+		return fmt.Errorf("cannot get refresh-candidates: %v", err)
+	} else if _, ok := refreshHints[snapName]; !ok {
+		return fmt.Errorf("cannot get refresh candidate for %q: not found", snapName)
+	}
+
+	refreshHints[snapName].Monitoring = true
+	st.Set("refresh-candidates", refreshHints)
+
+	storedChans := st.Cached("monitored-snap")
+	if storedChans == nil {
+		storedChans = make(map[string]chan<- bool)
+	}
+
+	abortChans, ok := storedChans.(map[string]chan<- bool)
+	if !ok {
+		// should never happen save for programmer error
+		return fmt.Errorf(`"monitored-snap" should be map[string]chan<- bool but got %T`, storedChans)
+	}
+
+	abortChans[snapName] = abort
+	st.Cache("monitored-snaps", abortChans)
 
 	return nil
 }
 
-func continueRefreshOnSnapClose(st *state.State, instanceName string, done <-chan string, abort <-chan bool) {
-	continueAutoRefresh := false
+// removeMonitoring removes monitoring state related to the specified snap.
+func removeMonitoring(st *state.State, snapName string) error {
+	storedChans := st.Cached("monitored-snap")
+	if storedChans == nil {
+		storedChans = make(map[string]chan<- bool)
+	}
+
+	abortChans, ok := storedChans.(map[string]chan<- bool)
+	if !ok {
+		// should never happen save for programmer error
+		return fmt.Errorf(`"monitored-snap" should be map[string]chan<- bool but got %T`, storedChans)
+	}
+
+	delete(abortChans, snapName)
+	if len(abortChans) == 0 {
+		st.Cache("monitored-snaps", nil)
+	} else {
+		st.Cache("monitored-snaps", abortChans)
+	}
+
+	var refreshHints map[string]*refreshCandidate
+	if err := st.Get("refresh-candidates", &refreshHints); err != nil {
+		return fmt.Errorf("cannot get refresh-candidates: %v", err)
+	}
+
+	if _, ok := refreshHints[snapName]; !ok {
+		return fmt.Errorf("cannot reset the monitoring field for %q in \"refresh-candidates\"", snapName)
+	}
+
+	refreshHints[snapName].Monitoring = false
+	st.Set("refresh-candidates", refreshHints)
+	return nil
+}
+
+func continueRefreshOnSnapClose(st *state.State, snapsup *SnapSetup, done <-chan string, abort <-chan bool) {
+	snapName := snapsup.InstanceName()
+
+	var aborted bool
 	select {
 	case <-done:
-		continueAutoRefresh = true
 	case <-abort:
+		aborted = true
 	}
 
 	st.Lock()
 	defer st.Unlock()
 
-	monitoredSnaps := snapMonitoring(st)
-	if monitoredSnaps == nil {
-		// shouldn't happen except for programmer error
-		logger.Noticef("cannot find monitoring state for snap %q", instanceName)
-	} else {
-		delete(monitoredSnaps, instanceName)
-
-		if len(monitoredSnaps) == 0 {
-			// use nil to delete entry but must be nil type (can't be map var set to nil)
-			updateMonitoringState(st, nil)
-		} else {
-			updateMonitoringState(st, monitoredSnaps)
+	defer func() {
+		if err := removeMonitoring(st, snapName); err != nil {
+			logger.Noticef("cannot remove monitoring information: %v", err)
 		}
-	}
+	}()
 
-	if continueAutoRefresh {
-		continueInhibitedAutoRefresh(st)
-	}
-}
-
-// continueInhibitedAutoRefresh triggers an auto-refresh so it can be continued
-func continueInhibitedAutoRefresh(st *state.State) {
-	// signal that there's an auto-refresh to be continued (for auto-refresh code)
-	st.Cache("auto-refresh-continue-attempt", 1)
-	st.EnsureBefore(0)
-}
-
-func snapMonitoring(st *state.State) map[string]chan<- bool {
-	if cachedMonitored := st.Cached("monitored-snaps"); cachedMonitored != nil {
-		if monitoredSnaps, ok := cachedMonitored.(map[string]chan<- bool); ok {
-			return monitoredSnaps
-		}
-	}
-
-	return nil
-}
-
-func updateMonitoringState(st *state.State, monitored map[string]chan<- bool) {
-	if monitored == nil {
-		st.Cache("monitored-snaps", nil)
-		st.Set("monitored-snaps", nil)
+	if aborted {
+		logger.Debugf("monitoring for pre-downloaded snap %q was aborted", snapName)
 		return
 	}
 
-	var snaps []string
-	for snap := range monitored {
-		snaps = append(snaps, snap)
+	// TODO: notify the user that the auto-refresh can't be continued? since this
+	// is a very user-centric flow
+	if err := refreshInhibitedSnap(st, snapName); err != nil {
+		logger.Noticef("cannot continue inhibitted auto-refresh for %q: %v", snapName, err)
+		return
+	}
+}
+
+// refreshInhibitedSnap refreshes the snap to continue the inhibited auto-refresh
+func refreshInhibitedSnap(st *state.State, snapName string) error {
+	// TODO: set the continued flag so we can emit the notification at the end of the flow
+	var refreshHints map[string]*refreshCandidate
+	if err := st.Get("refresh-candidates", &refreshHints); err != nil {
+		return fmt.Errorf("cannot get refresh-candidates: %v", err)
 	}
 
-	st.Cache("monitored-snaps", monitored)
-	st.Set("monitored-snaps", snaps)
+	hint, ok := refreshHints[snapName]
+	if !ok {
+		return fmt.Errorf("cannot get refresh-candidates for %q: not found", snapName)
+	}
+
+	tss, err := autoRefreshPhase2(context.TODO(), st, []*refreshCandidate{hint}, "")
+	if err != nil {
+		return err
+	}
+
+	msg := fmt.Sprintf(i18n.G("Continue the inhibited refresh of %q"), snapName)
+	chg := st.NewChange("continue-refresh-snap", msg)
+	// TODO: deal with the possibility that this has pre-download tasks
+	for _, ts := range tss.Refresh {
+		chg.AddAll(ts)
+	}
+	chg.Set("snap-names", []string{snapName})
+
+	st.EnsureBefore(0)
+	return nil
+}
+
+func getAbortMonitoringChan(st *state.State, snapName string) chan<- bool {
+	storedChans := st.Cached("monitored-snap")
+	if storedChans == nil {
+		return nil
+	}
+
+	abortChans, ok := storedChans.(map[string]chan<- bool)
+	if !ok {
+		// NOTE: should never happen save for programmer error
+		logger.Noticef(`internal error: "monitored-snap" should be map[string]chan<- bool but got %T: %v`, storedChans, storedChans)
+		return nil
+	}
+
+	return abortChans[snapName]
 }
 
 func abortMonitoring(st *state.State, snapName string) {
-	if monitored := snapMonitoring(st); monitored[snapName] != nil {
-		monitored[snapName] <- true
+	if abortChan := getAbortMonitoringChan(st, snapName); abortChan != nil {
+		abortChan <- true
 	}
 }
 
@@ -1271,7 +1345,7 @@ func (m *SnapManager) doUnlinkCurrentSnap(t *state.Task, _ *tomb.Tomb) (err erro
 			if errors.As(err, &busyErr) {
 				// notify user to close the snap and trigger the auto-refresh once it's closed
 				refreshInfo := busyErr.PendingSnapRefreshInfo()
-				if err := asyncRefreshOnSnapClose(m.state, refreshInfo); err != nil {
+				if err := asyncRefreshOnSnapClose(m.state, snapsup, refreshInfo); err != nil {
 					return err
 				}
 			}

--- a/overlord/snapstate/refreshhints.go
+++ b/overlord/snapstate/refreshhints.go
@@ -123,7 +123,7 @@ func (r *refreshHints) Ensure() error {
 	defer r.state.Unlock()
 
 	// CanAutoRefresh is a hook that is set by the devicestate
-	// code to ensure that we only AutoRefersh if the device has
+	// code to ensure that we only AutoRefresh if the device has
 	// bootstraped itself enough. This is only nil when snapstate
 	// is used in isolation (like in tests).
 	if CanAutoRefresh == nil {
@@ -168,6 +168,7 @@ func refreshHintsFromCandidates(st *state.State, updates []*snap.Info, ignoreVal
 			continue
 		}
 
+		monitoring := getAbortMonitoringChan(st, update.InstanceName()) != nil
 		providerContentAttrs := defaultProviderContentAttrs(st, update)
 		snapsup := &refreshCandidate{
 			SnapSetup: SnapSetup{
@@ -191,6 +192,8 @@ func refreshHintsFromCandidates(st *state.State, updates []*snap.Info, ignoreVal
 					Website: update.Website(),
 				},
 			},
+			Version:    update.Version,
+			Monitoring: monitoring,
 		}
 		hints[update.InstanceName()] = snapsup
 	}

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -137,7 +137,7 @@ func (ins installSnapInfo) SnapSetupForUpdate(st *state.State, params updatePara
 
 	revnoOpts, flags, snapst := params(update)
 	flags.IsAutoRefresh = globalFlags.IsAutoRefresh
-	flags.IsContinuedAutoRefresh = globalFlags.IsContinuedAutoRefresh
+	flags.IsContinuedRefresh = globalFlags.IsContinuedRefresh
 
 	flags, err := earlyChecks(st, snapst, update, flags)
 	if err != nil {
@@ -2510,11 +2510,7 @@ type AutoRefreshOptions struct {
 // AutoRefresh is the wrapper that will do a refresh of all the installed
 // snaps on the system. In addition to that it will also refresh important
 // assertions.
-func AutoRefresh(ctx context.Context, st *state.State, opts *AutoRefreshOptions) ([]string, *UpdateTaskSets, error) {
-	if opts == nil {
-		opts = &AutoRefreshOptions{}
-	}
-
+func AutoRefresh(ctx context.Context, st *state.State) ([]string, *UpdateTaskSets, error) {
 	userID := 0
 
 	if AutoRefreshAssertions != nil {
@@ -2532,7 +2528,7 @@ func AutoRefresh(ctx context.Context, st *state.State, opts *AutoRefreshOptions)
 	}
 	if !gateAutoRefreshHook {
 		// old-style refresh (gate-auto-refresh-hook feature disabled)
-		return updateManyFiltered(ctx, st, nil, nil, userID, nil, &Flags{IsAutoRefresh: true, IsContinuedAutoRefresh: opts.IsContinuedAutoRefresh}, "")
+		return updateManyFiltered(ctx, st, nil, nil, userID, nil, &Flags{IsAutoRefresh: true}, "")
 	}
 
 	// TODO: rename to autoRefreshTasks when old auto refresh logic gets removed.

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -577,7 +577,7 @@ func checkIsContinuedAutoRefresh(c *C, tasks []*state.Task, expected bool) {
 			var snapsup snapstate.SnapSetup
 			err := t.Get("snap-setup", &snapsup)
 			c.Assert(err, IsNil)
-			c.Check(snapsup.IsContinuedAutoRefresh, Equals, expected)
+			c.Check(snapsup.IsContinuedRefresh, Equals, expected)
 			return
 		}
 	}

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -9610,7 +9610,7 @@ func (s *snapmgrTestSuite) TestUnlinkMonitorSnapOnHardCheckFailure(c *C) {
 	})
 	defer restore()
 
-	updated, tss, err := snapstate.AutoRefresh(context.Background(), s.state, nil)
+	updated, tss, err := snapstate.AutoRefresh(context.Background(), s.state)
 	c.Assert(err, IsNil)
 	c.Check(updated, DeepEquals, []string{"some-snap"})
 	c.Assert(tss, NotNil)


### PR DESCRIPTION
This is a proposal to address the issues between the pre-download flow and inconsistent store returns for specific snaps. At the moment, this triggers a manual refresh per snap. Previously, an auto-refresh would try to refresh all of the inhibited snaps. In theory it's more verbose in `snap changes` output but, in practice, when the user closed multiple snaps in sequence only the first would get in the first auto-refresh (because it would be triggered faster than a person could close all the snaps) so the rest would go into the pre-download flow again and get their own auto-refresh change. So in practice there may not be much of a difference in terms of UX. One open question is how to write a spread test that simulates the store throttling with the Firefox snap so we can be sure this solves the problem.