### PR TITLE
i/builtin: add read access to /proc/task/schedstat in system-observe

### DIFF
--- a/interfaces/builtin/system_observe.go
+++ b/interfaces/builtin/system_observe.go
@@ -98,6 +98,7 @@ ptrace (read),
 # but not smaps which contains a detailed mappings breakdown like
 # /proc/self/maps, which we do not allow access to for other processes
 @{PROC}/*/{,task/*/}smaps_rollup r,
+@{PROC}/*/{,task/*/}schedstat r,
 @{PROC}/*/{,task/*/}stat r,
 @{PROC}/*/{,task/*/}statm r,
 @{PROC}/*/{,task/*/}status r,


### PR DESCRIPTION
Hello - this PR is a proposal to patch the `system_observe` interface to allow read access to `@{PROC}/*/{,task/*/}schedstat` which is a file needed by OpenSearch's performance analyzer. 
For context - [forum discussion](https://forum.snapcraft.io/t/interface-auto-connect-request-for-opensearch-snap/34772/13)
Do you think it makes sense to add it to `system-observe`? 