### PR TITLE
luks2: add missing unit tests, fix hang when cryptsetup fails

### DIFF
--- a/secboot/luks2/cryptsetup.go
+++ b/secboot/luks2/cryptsetup.go
@@ -206,7 +206,7 @@ func AddKey(devicePath string, existingKey, key []byte, options *AddKeyOptions) 
 	case cmdErr != nil && (fifoErr == nil || errors.Is(fifoErr, syscall.EPIPE)):
 		// cmdErr and EPIPE means the problem is with cmd, no
 		// need to display the EPIPE error
-		return fmt.Errorf("cryptsetup failed with: %v", osutil.OutputErr(output, err))
+		return fmt.Errorf("cryptsetup failed with: %v", osutil.OutputErr(output, cmdErr))
 	case cmdErr != nil || fifoErr != nil:
 		// For all other cases show a generic error message
 		return fmt.Errorf("cryptsetup failed with: %v (fifo failed with: %v)", osutil.OutputErr(output, err), fifoErr)

--- a/secboot/luks2/cryptsetup.go
+++ b/secboot/luks2/cryptsetup.go
@@ -203,7 +203,7 @@ func AddKey(devicePath string, existingKey, key []byte, options *AddKeyOptions) 
 	fifoErr := <-fifoErrCh
 
 	switch {
-	case cmdErr != nil && errors.Is(fifoErr, syscall.EPIPE):
+	case cmdErr != nil && (fifoErr == nil || errors.Is(fifoErr, syscall.EPIPE)):
 		// cmdErr and EPIPE means the problem is with cmd, no
 		// need to display the EPIPE error
 		return fmt.Errorf("cryptsetup failed with: %v", osutil.OutputErr(output, err))

--- a/secboot/luks2/cryptsetup_test.go
+++ b/secboot/luks2/cryptsetup_test.go
@@ -1,0 +1,98 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package luks2_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/secboot/luks2"
+	"github.com/snapcore/snapd/testutil"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type luks2Suite struct {
+	testutil.BaseTest
+
+	tmpdir         string
+	mockCryptsetup *testutil.MockCmd
+}
+
+var _ = Suite(&luks2Suite{})
+
+func (s *luks2Suite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+
+	dirs.SetRootDir(c.MkDir())
+	s.tmpdir = dirs.GlobalRootDir
+
+	s.mockCryptsetup = testutil.MockCommand(c, "cryptsetup", fmt.Sprintf("cat - > %[1]s/stdout 2>%[1]s/stderr", s.tmpdir))
+	s.AddCleanup(s.mockCryptsetup.Restore)
+}
+
+func (s *luks2Suite) TestKillSlot(c *C) {
+	err := luks2.KillSlot("/my/device", 123, []byte("some-key"))
+	c.Check(err, IsNil)
+	c.Check(s.mockCryptsetup.Calls(), DeepEquals, [][]string{
+		{"cryptsetup", "luksKillSlot", "--type", "luks2", "--key-file", "-", "/my/device", "123"},
+	})
+	c.Check(filepath.Join(s.tmpdir, "stdout"), testutil.FileEquals, "some-key")
+	c.Check(filepath.Join(s.tmpdir, "stderr"), testutil.FileEquals, "")
+}
+
+func (s *luks2Suite) TestAddKeyHappy(c *C) {
+	err := os.MkdirAll(filepath.Join(s.tmpdir, "run"), 0755)
+	c.Assert(err, IsNil)
+
+	mockCryptsetup := testutil.MockCommand(c, "cryptsetup", fmt.Sprintf(`
+FIFO="$5"
+cat "$FIFO" > %[1]s/fifo
+cat - > %[1]s/stdout 2>%[1]s/stderr
+`, s.tmpdir))
+	defer mockCryptsetup.Restore()
+
+	err = luks2.AddKey("/my/device", []byte("old-key"), []byte("new-key"), nil)
+	c.Check(err, IsNil)
+	c.Check(mockCryptsetup.Calls(), HasLen, 1)
+	fifoPath := mockCryptsetup.Calls()[0][5]
+	c.Check(mockCryptsetup.Calls(), DeepEquals, [][]string{
+		{"cryptsetup", "luksAddKey", "--type", "luks2", "--key-file", fifoPath, "--pbkdf", "argon2i", "/my/device", "-"},
+	})
+	c.Check(filepath.Join(s.tmpdir, "stdout"), testutil.FileEquals, "new-key")
+	c.Check(filepath.Join(s.tmpdir, "stderr"), testutil.FileEquals, "")
+	c.Check(filepath.Join(s.tmpdir, "fifo"), testutil.FileEquals, "old-key")
+}
+
+func (s *luks2Suite) TestAddKeyBadCryptsetup(c *C) {
+	err := os.MkdirAll(filepath.Join(s.tmpdir, "run"), 0755)
+	c.Assert(err, IsNil)
+
+	mockCryptsetup := testutil.MockCommand(c, "cryptsetup", "echo some-error; exit  1")
+	defer mockCryptsetup.Restore()
+
+	err = luks2.AddKey("/my/device", []byte("old-key"), []byte("new-key"), nil)
+	c.Check(err, ErrorMatches, "cryptsetup failed with: some-error")
+}

--- a/secboot/luks2/export_test.go
+++ b/secboot/luks2/export_test.go
@@ -1,0 +1,31 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package luks2
+
+import (
+	"github.com/snapcore/snapd/testutil"
+)
+
+func MockWriteExistingKeyToFifo(f func(string, []byte) error) (restore func()) {
+	restore = testutil.Backup(&writeExistingKeyToFifo)
+	writeExistingKeyToFifo = f
+	return restore
+
+}


### PR DESCRIPTION
I looked a bit at the spread failure on 23.04 for tests/main/uc20-create-partitions-encrypt and it turns out the error is real:
```
...
+ systemd-run --pipe --wait --collect -p KeyringMode=inherit -- /usr/lib/snapd/snap-fde-keymgr add-recovery-key --key-file /home/gopath/src/github.com/snapcore/snapd/tests/main/uc20-create-partitions-encrypt/recovery-key --devices /dev/loop1p5 --authorizations file:/home/gopath/src/github.com/snapcore/snapd/tests/main/uc20-create-partitions-encrypt/unsealed-key --devices /dev/loop1p4 --authorizations file:/home/gopath/src/github.com/snapcore/snapd/tests/main/uc20-create-partitions-encrypt/save-key
Running as unit: run-u58.service
error: cannot add recovery key to LUKS device using authorization key: cannot add key: cryptsetup failed with: 
-----
Key slot 1 is full, please select another one.
WARNING: The --key-slot parameter is used for new keyslot number.
-----
Finished with result: exit-code
Main processes terminated with: code=exited/status=1
Service runtime: 32ms
CPU time consumed: 22ms
```

The issue is essentially that if cryptsetup dies the writeExistingKeyToFifo() never returns and the process hangs forever.
