### PR TITLE
go: go fix with 1.18

### DIFF
--- a/asserts/sysdb/staging.go
+++ b/asserts/sysdb/staging.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build withtestkeys || withstagingkeys
-// +build withtestkeys withstagingkeys
 
 /*
  * Copyright (C) 2016 Canonical Ltd

--- a/asserts/sysdb/testkeys.go
+++ b/asserts/sysdb/testkeys.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build withtestkeys
-// +build withtestkeys
 
 /*
  * Copyright (C) 2016 Canonical Ltd

--- a/bootloader/assets/assetstesting.go
+++ b/bootloader/assets/assetstesting.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build withbootassetstesting
-// +build withbootassetstesting
 
 /*
  * Copyright (C) 2021 Canonical Ltd

--- a/bootloader/withbootassettesting.go
+++ b/bootloader/withbootassettesting.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build withbootassetstesting
-// +build withbootassetstesting
 
 /*
  * Copyright (C) 2021 Canonical Ltd

--- a/bootloader/withbootassettesting_test.go
+++ b/bootloader/withbootassettesting_test.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build withbootassetstesting
-// +build withbootassetstesting
 
 /*
  * Copyright (C) 2021 Canonical Ltd

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_nosecboot.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_nosecboot.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build nosecboot
-// +build nosecboot
 
 /*
  * Copyright (C) 2019-2020 Canonical Ltd

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_secboot.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_secboot.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !nosecboot
-// +build !nosecboot
 
 /*
  * Copyright (C) 2019-2020 Canonical Ltd

--- a/cmd/snap-repair/staging.go
+++ b/cmd/snap-repair/staging.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build withtestkeys || withstagingkeys
-// +build withtestkeys withstagingkeys
 
 /*
  * Copyright (C) 2017-2020 Canonical Ltd

--- a/cmd/snap-repair/testkeys.go
+++ b/cmd/snap-repair/testkeys.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build withtestkeys
-// +build withtestkeys
 
 /*
  * Copyright (C) 2021 Canonical Ltd

--- a/cmd/snap-seccomp/main_nonriscv64.go
+++ b/cmd/snap-seccomp/main_nonriscv64.go
@@ -1,7 +1,6 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
 //go:build !riscv64
-// +build !riscv64
 
 /*
  * Copyright (C) 2021 Canonical Ltd

--- a/cmd/snap-seccomp/main_ppc64le.go
+++ b/cmd/snap-seccomp/main_ppc64le.go
@@ -1,7 +1,6 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
 //go:build ppc64le && go1.7 && !go1.8
-// +build ppc64le,go1.7,!go1.8
 
 /*
  * Copyright (C) 2017 Canonical Ltd

--- a/cmd/snap-seccomp/main_riscv64.go
+++ b/cmd/snap-seccomp/main_riscv64.go
@@ -1,7 +1,6 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
 //go:build riscv64
-// +build riscv64
 
 /*
  * Copyright (C) 2021 Canonical Ltd

--- a/cmd/snap-seccomp/old_seccomp.go
+++ b/cmd/snap-seccomp/old_seccomp.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build oldseccomp
-// +build oldseccomp
 
 /*
  * Copyright (C) 2021 Canonical Ltd

--- a/cmd/snap-update-ns/bootstrap_ppc64le.go
+++ b/cmd/snap-update-ns/bootstrap_ppc64le.go
@@ -1,7 +1,6 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
 //go:build ppc64le && go1.7 && !go1.8
-// +build ppc64le,go1.7,!go1.8
 
 /*
  * Copyright (C) 2017 Canonical Ltd

--- a/cmd/snap/cmd_userd.go
+++ b/cmd/snap/cmd_userd.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !darwin
-// +build !darwin
 
 /*
  * Copyright (C) 2017-2022 Canonical Ltd

--- a/cmd/snap/cmd_userd_test.go
+++ b/cmd/snap/cmd_userd_test.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !darwin
-// +build !darwin
 
 /*
  * Copyright (C) 2016-2022 Canonical Ltd

--- a/cmd/snap/cmd_version_other.go
+++ b/cmd/snap/cmd_version_other.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !linux
-// +build !linux
 
 /*
  * Copyright (C) 2016 Canonical Ltd

--- a/gadget/install/encrypt.go
+++ b/gadget/install/encrypt.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !nosecboot
-// +build !nosecboot
 
 /*
  * Copyright (C) 2020 Canonical Ltd

--- a/gadget/install/encrypt_test.go
+++ b/gadget/install/encrypt_test.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !nosecboot
-// +build !nosecboot
 
 /*
  * Copyright (C) 2020 Canonical Ltd

--- a/gadget/install/export_secboot_test.go
+++ b/gadget/install/export_secboot_test.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !nosecboot
-// +build !nosecboot
 
 /*
  * Copyright (C) 2020 Canonical Ltd

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !nosecboot
-// +build !nosecboot
 
 /*
  * Copyright (C) 2019-2020 Canonical Ltd

--- a/gadget/install/install_dummy.go
+++ b/gadget/install/install_dummy.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build nosecboot
-// +build nosecboot
 
 /*
  * Copyright (C) 2019-2020 Canonical Ltd

--- a/gadget/install/install_test.go
+++ b/gadget/install/install_test.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !nosecboot
-// +build !nosecboot
 
 /*
  * Copyright (C) 2019-2022 Canonical Ltd

--- a/gadget/install/mount_other.go
+++ b/gadget/install/mount_other.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !linux
-// +build !linux
 
 /*
  * Copyright (C) 2020 Canonical Ltd

--- a/image/preseed/preseed_other.go
+++ b/image/preseed/preseed_other.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !linux
-// +build !linux
 
 /*
  * Copyright (C) 2019-2022 Canonical Ltd

--- a/osutil/chattr_32.go
+++ b/osutil/chattr_32.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build arm || 386 || ppc
-// +build arm 386 ppc
 
 /*
  * Copyright (C) 2016 Canonical Ltd

--- a/osutil/chattr_64.go
+++ b/osutil/chattr_64.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build amd64 || arm64 || ppc64le || riscv64 || s390x
-// +build amd64 arm64 ppc64le riscv64 s390x
 
 /*
  * Copyright (C) 2016 Canonical Ltd

--- a/osutil/cp_other.go
+++ b/osutil/cp_other.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !linux
-// +build !linux
 
 /*
  * Copyright (C) 2014-2015 Canonical Ltd

--- a/osutil/export_fault_test.go
+++ b/osutil/export_fault_test.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build faultinject
-// +build faultinject
 
 /*
  * Copyright (C) 2016 Canonical Ltd

--- a/osutil/faultinject.go
+++ b/osutil/faultinject.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build faultinject
-// +build faultinject
 
 /*
  * Copyright (C) 2021 Canonical Ltd

--- a/osutil/faultinject_fake.go
+++ b/osutil/faultinject_fake.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !faultinject
-// +build !faultinject
 
 /*
  * Copyright (C) 2021 Canonical Ltd

--- a/osutil/faultinject_fake_test.go
+++ b/osutil/faultinject_fake_test.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !faultinject
-// +build !faultinject
 
 /*
  * Copyright (C) 2021 Canonical Ltd

--- a/osutil/faultinject_test.go
+++ b/osutil/faultinject_test.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build faultinject
-// +build faultinject
 
 /*
  * Copyright (C) 2021 Canonical Ltd

--- a/osutil/group_cgo.go
+++ b/osutil/group_cgo.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build cgo
-// +build cgo
 
 /*
  * Copyright (C) 2017-2019 Canonical Ltd

--- a/osutil/group_no_cgo.go
+++ b/osutil/group_no_cgo.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !cgo
-// +build !cgo
 
 package osutil
 

--- a/osutil/inotify/inotify_linux.go
+++ b/osutil/inotify/inotify_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright 2010 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/osutil/inotify/inotify_linux_test.go
+++ b/osutil/inotify/inotify_linux_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright 2010 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/osutil/inotify/inotify_others.go
+++ b/osutil/inotify/inotify_others.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 /*
 Copyright 2020 The Kubernetes Authors.

--- a/osutil/settime_32bit.go
+++ b/osutil/settime_32bit.go
@@ -1,8 +1,6 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 //go:build (386 || arm) && linux
-// +build 386 arm
-// +build linux
 
 /*
  * Copyright (C) 2021 Canonical Ltd

--- a/osutil/settime_64bit.go
+++ b/osutil/settime_64bit.go
@@ -1,7 +1,6 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 //go:build !386 && !arm && linux
-// +build !386,!arm,linux
 
 /*
  * Copyright (C) 2021 Canonical Ltd

--- a/osutil/sys/sysnum_16_linux.go
+++ b/osutil/sys/sysnum_16_linux.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build arm || 386
-// +build arm 386
 
 /*
  * Copyright (C) 2017 Canonical Ltd

--- a/osutil/sys/sysnum_32_linux.go
+++ b/osutil/sys/sysnum_32_linux.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build amd64 || arm64 || ppc || ppc64le || riscv64 || s390x
-// +build amd64 arm64 ppc ppc64le riscv64 s390x
 
 /*
  * Copyright (C) 2017 Canonical Ltd

--- a/osutil/udev/netlink/rawsockstop_other.go
+++ b/osutil/udev/netlink/rawsockstop_other.go
@@ -1,5 +1,4 @@
 //go:build !arm64
-// +build !arm64
 
 // don't remove the newline between the above statement and the package statement
 // or else the build constraint will be ignored and assumed to be part of the package comment!

--- a/overlord/configstate/configcore/certs.go
+++ b/overlord/configstate/configcore/certs.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !nomanagers
-// +build !nomanagers
 
 /*
  * Copyright (C) 2020 Canonical Ltd

--- a/overlord/configstate/configcore/certs_test.go
+++ b/overlord/configstate/configcore/certs_test.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !nomanagers
-// +build !nomanagers
 
 /*
  * Copyright (C) 2020 Canonical Ltd

--- a/overlord/configstate/configcore/cloud.go
+++ b/overlord/configstate/configcore/cloud.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !nomanagers
-// +build !nomanagers
 
 /*
  * Copyright (C) 2018 Canonical Ltd

--- a/overlord/configstate/configcore/cloud_test.go
+++ b/overlord/configstate/configcore/cloud_test.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !nomanagers
-// +build !nomanagers
 
 /*
  * Copyright (C) 2018 Canonical Ltd

--- a/overlord/configstate/configcore/early_test.go
+++ b/overlord/configstate/configcore/early_test.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !nomanagers
-// +build !nomanagers
 
 /*
  * Copyright (C) 2021 Canonical Ltd

--- a/overlord/configstate/configcore/export_runwithstate_test.go
+++ b/overlord/configstate/configcore/export_runwithstate_test.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !nomanagers
-// +build !nomanagers
 
 /*
  * Copyright (C) 2023 Canonical Ltd

--- a/overlord/configstate/configcore/kernel.go
+++ b/overlord/configstate/configcore/kernel.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !nomanagers
-// +build !nomanagers
 
 /*
  * Copyright (C) 2023 Canonical Ltd

--- a/overlord/configstate/configcore/netplan.go
+++ b/overlord/configstate/configcore/netplan.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !nomanagers
-// +build !nomanagers
 
 /*
  * Copyright (C) 2021 Canonical Ltd

--- a/overlord/configstate/configcore/netplan_test.go
+++ b/overlord/configstate/configcore/netplan_test.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !nomanagers
-// +build !nomanagers
 
 /*
  * Copyright (C) 2021 Canonical Ltd

--- a/overlord/configstate/configcore/proxy.go
+++ b/overlord/configstate/configcore/proxy.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !nomanagers
-// +build !nomanagers
 
 /*
  * Copyright (C) 2017-2022 Canonical Ltd

--- a/overlord/configstate/configcore/proxy_test.go
+++ b/overlord/configstate/configcore/proxy_test.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !nomanagers
-// +build !nomanagers
 
 /*
  * Copyright (C) 2017-2022 Canonical Ltd

--- a/overlord/configstate/configcore/refresh.go
+++ b/overlord/configstate/configcore/refresh.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !nomanagers
-// +build !nomanagers
 
 /*
  * Copyright (C) 2017-2022 Canonical Ltd

--- a/overlord/configstate/configcore/refresh_test.go
+++ b/overlord/configstate/configcore/refresh_test.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !nomanagers
-// +build !nomanagers
 
 /*
  * Copyright (C) 2017-2018 Canonical Ltd

--- a/overlord/configstate/configcore/runwithstate.go
+++ b/overlord/configstate/configcore/runwithstate.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !nomanagers
-// +build !nomanagers
 
 /*
  * Copyright (C) 2020-2022 Canonical Ltd

--- a/overlord/configstate/configcore/runwithstate_test.go
+++ b/overlord/configstate/configcore/runwithstate_test.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !nomanagers
-// +build !nomanagers
 
 /*
  * Copyright (C) 2023 Canonical Ltd

--- a/overlord/configstate/configcore/snapshots.go
+++ b/overlord/configstate/configcore/snapshots.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !nomanagers
-// +build !nomanagers
 
 /*
  * Copyright (C) 2019 Canonical Ltd

--- a/overlord/configstate/configcore/snapshots_test.go
+++ b/overlord/configstate/configcore/snapshots_test.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !nomanagers
-// +build !nomanagers
 
 /*
  * Copyright (C) 2019 Canonical Ltd

--- a/overlord/configstate/configcore/users.go
+++ b/overlord/configstate/configcore/users.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !nomanagers
-// +build !nomanagers
 
 /*
  * Copyright (C) 2021 Canonical Ltd

--- a/overlord/configstate/configcore/users_test.go
+++ b/overlord/configstate/configcore/users_test.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !nomanagers
-// +build !nomanagers
 
 /*
  * Copyright (C) 2021 Canonical Ltd

--- a/overlord/configstate/configcore/vitality.go
+++ b/overlord/configstate/configcore/vitality.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !nomanagers
-// +build !nomanagers
 
 /*
  * Copyright (C) 2020 Canonical Ltd

--- a/overlord/configstate/configcore/vitality_test.go
+++ b/overlord/configstate/configcore/vitality_test.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !nomanagers
-// +build !nomanagers
 
 /*
  * Copyright (C) 2020 Canonical Ltd

--- a/overlord/configstate/configmgr.go
+++ b/overlord/configstate/configmgr.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !nomanagers
-// +build !nomanagers
 
 /*
  * Copyright (C) 2016-2017 Canonical Ltd

--- a/overlord/configstate/configstate.go
+++ b/overlord/configstate/configstate.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !nomanagers
-// +build !nomanagers
 
 /*
  * Copyright (C) 2016 Canonical Ltd

--- a/overlord/configstate/configstate_test.go
+++ b/overlord/configstate/configstate_test.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !nomanagers
-// +build !nomanagers
 
 /*
  * Copyright (C) 2016 Canonical Ltd

--- a/overlord/configstate/export_test.go
+++ b/overlord/configstate/export_test.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !nomanagers
-// +build !nomanagers
 
 /*
  * Copyright (C) 2016 Canonical Ltd

--- a/overlord/configstate/handler_test.go
+++ b/overlord/configstate/handler_test.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !nomanagers
-// +build !nomanagers
 
 /*
  * Copyright (C) 2016 Canonical Ltd

--- a/overlord/devicestate/devicestate_install_api_test.go
+++ b/overlord/devicestate/devicestate_install_api_test.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !nosecboot
-// +build !nosecboot
 
 /*
  * Copyright (C) 2022 Canonical Ltd

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !nomanagers
-// +build !nomanagers
 
 /*
  * Copyright (C) 2016-2022 Canonical Ltd

--- a/polkit/pid_start_time.go
+++ b/polkit/pid_start_time.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build linux
-// +build linux
 
 /*
  * Copyright (C) 2017 Canonical Ltd

--- a/polkit/pid_start_time_test.go
+++ b/polkit/pid_start_time_test.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build linux
-// +build linux
 
 /*
  * Copyright (C) 2017 Canonical Ltd

--- a/secboot/encrypt_dummy.go
+++ b/secboot/encrypt_dummy.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build nosecboot
-// +build nosecboot
 
 /*
  * Copyright (C) 2022 Canonical Ltd

--- a/secboot/encrypt_sb.go
+++ b/secboot/encrypt_sb.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !nosecboot
-// +build !nosecboot
 
 /*
  * Copyright (C) 2022 Canonical Ltd

--- a/secboot/encrypt_sb_test.go
+++ b/secboot/encrypt_sb_test.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !nosecboot
-// +build !nosecboot
 
 /*
  * Copyright (C) 2022 Canonical Ltd

--- a/secboot/export_sb_test.go
+++ b/secboot/export_sb_test.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !nosecboot
-// +build !nosecboot
 
 /*
  * Copyright (C) 2021 Canonical Ltd

--- a/secboot/keys/keys_dummy.go
+++ b/secboot/keys/keys_dummy.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build nosecboot
-// +build nosecboot
 
 /*
  * Copyright (C) 2022 Canonical Ltd

--- a/secboot/keys/keys_sb.go
+++ b/secboot/keys/keys_sb.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !nosecboot
-// +build !nosecboot
 
 /*
  * Copyright (C) 2022 Canonical Ltd

--- a/secboot/secboot_dummy.go
+++ b/secboot/secboot_dummy.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build nosecboot
-// +build nosecboot
 
 /*
  * Copyright (C) 2021 Canonical Ltd

--- a/secboot/secboot_hooks.go
+++ b/secboot/secboot_hooks.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !nosecboot
-// +build !nosecboot
 
 /*
  * Copyright (C) 2021 Canonical Ltd

--- a/secboot/secboot_sb.go
+++ b/secboot/secboot_sb.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !nosecboot
-// +build !nosecboot
 
 /*
  * Copyright (C) 2021 Canonical Ltd

--- a/secboot/secboot_sb_test.go
+++ b/secboot/secboot_sb_test.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !nosecboot
-// +build !nosecboot
 
 /*
  * Copyright (C) 2021 Canonical Ltd

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !nosecboot
-// +build !nosecboot
 
 /*
  * Copyright (C) 2021 Canonical Ltd

--- a/snapdenv/withtestkeys.go
+++ b/snapdenv/withtestkeys.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build withtestkeys
-// +build withtestkeys
 
 /*
  * Copyright (C) 2016-2020 Canonical Ltd

--- a/snapdtool/tool_other.go
+++ b/snapdtool/tool_other.go
@@ -1,6 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //go:build !linux
-// +build !linux
 
 /*
  * Copyright (C) 2018 Canonical Ltd

--- a/strutil/ctrl16.go
+++ b/strutil/ctrl16.go
@@ -1,5 +1,4 @@
 //go:build !go1.7
-// +build !go1.7
 
 package strutil
 

--- a/strutil/ctrl17.go
+++ b/strutil/ctrl17.go
@@ -1,5 +1,4 @@
 //go:build go1.7
-// +build go1.7
 
 package strutil
 

--- a/tests/nested/manual/core20-da-lockout/getdalockout.go
+++ b/tests/nested/manual/core20-da-lockout/getdalockout.go
@@ -1,5 +1,4 @@
 //go:build !nosecboot
-// +build !nosecboot
 
 package main
 

--- a/tests/nested/manual/core20-da-lockout/getdalockout_nosecboot.go
+++ b/tests/nested/manual/core20-da-lockout/getdalockout_nosecboot.go
@@ -1,5 +1,4 @@
 //go:build nosecboot
-// +build nosecboot
 
 // Note: This file is needed to ensure that debian does not pick it up when building,
 // otherwise it produces the error: cannot find package "github.com/canonical/go-tpm2"


### PR DESCRIPTION
Apply `go fix ./...` to the whole code base using go-1.18 to remove old build tags.
