### PR TITLE
tests: skip uc20-create-partitions-encrypt in ubuntu-23.*

### DIFF
--- a/tests/main/uc20-create-partitions-encrypt/task.yaml
+++ b/tests/main/uc20-create-partitions-encrypt/task.yaml
@@ -1,7 +1,8 @@
 summary: Integration tests for the snap-bootstrap binary
 
 # use the same system and tooling as uc20
-systems: [ubuntu-2*]
+# TODO: revert skip for ubuntu-23*
+systems: [ubuntu-20.*,ubuntu-22.*]
 
 environment:
     SNAPD_DEBUG: "1"


### PR DESCRIPTION
This skip is required because the test is getting stuck

/usr/lib/snapd/snap-fde-keymgr add-recovery-key --key-file /home/gopath/src/github.com/snapcore/snapd/tests/main/uc20-create-partitions-encrypt/recovery-key --devices /dev/loop1p5 --authorizations
file:/home/gopath/src/github.com/snapcore/snapd/tests/main/uc20-create-partitions-encrypt/unsealed-key --devices /dev/loop1p4 --authorizations
file:/home/gopath/src/github.com/snapcore/snapd/tests/main/uc20-create-partitions-encrypt/save-key

Getting stuck in keymgr_luks3.go
if err := luks2.AddKey(dev, currKey, recoveryKey[:], &options); err != nil {
	return fmt.Errorf("cannot add key: %v", err)
}

dev: /dev/loop1p5
currKey: [147 82 161 187 119 61 54 50 164 67 214 97 112 65 122 24 186 176 1 239 110 94 3 108 52 204 252 215 105 68 53 245] recoveryKey: [135 240 162 165 227 144 234 164 196 133 220 32 104 174 169 112]
options: {{0s 1048576 4 0} 1}
