### PR TITLE
install: lazy unmount() in writeFilesystemContent() if needed

### DIFF
--- a/gadget/install/content.go
+++ b/gadget/install/content.go
@@ -85,6 +85,7 @@ func writeFilesystemContent(laidOut *gadget.LaidOutStructure, fsDevice string, o
 	defer func() {
 		var errUnmount error
 		if errUnmount = sysUnmount(mountpoint, 0); errUnmount != nil {
+			logger.Noticef("cannot unmount %v after writing filesystem content, trying lazy unmount next: %v", mountpoint, errUnmount)
 			// lazy umount on error, see LP:2025402
 			errUnmount = sysUnmount(mountpoint, syscall.MNT_DETACH)
 		}

--- a/gadget/install/content_test.go
+++ b/gadget/install/content_test.go
@@ -273,7 +273,7 @@ func (s *contentTestSuite) TestWriteFilesystemContentUnmountErrHandling(c *C) {
 		}, {
 			errors.New("umount error"),
 			nil,
-			"", // no error as lazy unmount succedded
+			"", // no error as lazy unmount succeeded
 		}, {
 			errors.New("umount error"),
 			errors.New("lazy umount err"),

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -570,9 +570,10 @@ func MountVolumes(onVolumes map[string]*gadget.Volume, encSetupData *EncryptionS
 		for _, mntPt := range mountPoints {
 			errUnmount := sysUnmount(mntPt, 0)
 			if errUnmount != nil {
-				logger.Noticef("cannot unmount %q: %v", mntPt, errUnmount)
+				logger.Noticef("cannot unmount %q: %v (trying lazy unmount next)", mntPt, errUnmount)
 				// lazy umount on error, see LP:2025402
 				errUnmount = sysUnmount(mntPt, syscall.MNT_DETACH)
+				logger.Noticef("cannot lazy unmount %q: %v", mntPt, errUnmount)
 			}
 			// Make sure we do not set err to nil if it had already an error
 			if errUnmount != nil {

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"syscall"
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/boot"
@@ -570,6 +571,8 @@ func MountVolumes(onVolumes map[string]*gadget.Volume, encSetupData *EncryptionS
 			errUnmount := sysUnmount(mntPt, 0)
 			if errUnmount != nil {
 				logger.Noticef("cannot unmount %q: %v", mntPt, errUnmount)
+				// lazy umount on error, see LP:2025402
+				errUnmount = sysUnmount(mntPt, syscall.MNT_DETACH)
 			}
 			// Make sure we do not set err to nil if it had already an error
 			if errUnmount != nil {


### PR DESCRIPTION
The existing code in writeFilesystemContent() will error when the filesystem cannot be unmounted. However in practise this is problematic as the live-system can keep the mount point busy: https://bugs.launchpad.net/snapd/+bug/2025402

As a pragmatic solution this commit unmounts the filesystem with the `--lazy` option if a normal unmount does not work.

This is what live-editor is doing:
https://github.com/mwhudson/livefs-editor/pull/26

Alternatively we could do a bunch of retries and wait for the process that keep the filesystem busy to go away.

