### PR TITLE
interfaces: add some tests for the mount backend ns update case

### DIFF
--- a/interfaces/ifacetest/backendtest.go
+++ b/interfaces/ifacetest/backendtest.go
@@ -211,6 +211,13 @@ func (s *BackendSuite) InstallSnap(c *C, opts interfaces.ConfinementOptions, ins
 
 // UpdateSnap "updates" an existing snap from YAML.
 func (s *BackendSuite) UpdateSnap(c *C, oldSnapInfo *snap.Info, opts interfaces.ConfinementOptions, snapYaml string, revision int) *snap.Info {
+	newSnapInfo, err := s.UpdateSnapMaybeErr(c, oldSnapInfo, opts, snapYaml, revision)
+	c.Assert(err, IsNil)
+	return newSnapInfo
+}
+
+// UpdateSnapMaybeErr "updates" an existing snap from YAML, this might error.
+func (s *BackendSuite) UpdateSnapMaybeErr(c *C, oldSnapInfo *snap.Info, opts interfaces.ConfinementOptions, snapYaml string, revision int) (*snap.Info, error) {
 	newSnapInfo := snaptest.MockInfo(c, snapYaml, &snap.SideInfo{
 		Revision: snap.R(revision),
 	})
@@ -218,8 +225,7 @@ func (s *BackendSuite) UpdateSnap(c *C, oldSnapInfo *snap.Info, opts interfaces.
 	s.removePlugsSlots(c, oldSnapInfo)
 	s.addPlugsSlots(c, newSnapInfo)
 	err := s.Backend.Setup(newSnapInfo, opts, s.Repo, s.meas)
-	c.Assert(err, IsNil)
-	return newSnapInfo
+	return newSnapInfo, err
 }
 
 // RemoveSnap "removes" an "installed" snap.

--- a/interfaces/mount/backend_test.go
+++ b/interfaces/mount/backend_test.go
@@ -349,4 +349,15 @@ func (s *backendSuite) TestSetupUpdatesError(c *C) {
 
 	// snap-update-ns was invoked
 	c.Check(cmd.Calls(), DeepEquals, [][]string{{"snap-update-ns", "snap-name"}})
+
+	// no undo at this level
+	expected := strings.Split(fmt.Sprintf("%s\n%s\n%s\n", fsEntry1, fsEntry2, fsEntry3), "\n")
+	sort.Strings(expected)
+	// and that we have the modern fstab file (global for snap)
+	fn := filepath.Join(dirs.SnapMountPolicyDir, "snap.snap-name.fstab")
+	content, err := ioutil.ReadFile(fn)
+	c.Assert(err, IsNil, Commentf("Expected mount profile for the whole snap"))
+	got := strings.Split(string(content), "\n")
+	sort.Strings(got)
+	c.Check(got, DeepEquals, expected)
 }


### PR DESCRIPTION
This is also helpful as baseline to add unit tests in #12541
