### PR TITLE
github: run arm/arm64 tests on github action too

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -279,6 +279,23 @@ jobs:
         cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
         ./run-checks --unit
 
+    - name: Test Go (arm, arm64)
+      if: ${{ matrix.unit-scenario == 'normal' }}
+      run: |
+        echo "Install qemu arm run support"
+        sudo apt install -y qemu-user-static jq
+
+        cd ${{ github.workspace }}/src/github.com/snapcore/snapd || exit 1
+        for arch in arm arm64; do
+          GOARCH="$arch" go test $(go list -json ./...| \
+            jq -r -c "select(.Imports | \
+               . != null and \
+               (index([\"C\"]) | not) and \
+               (index([\"github.com/snapcore/snapd/cmd/snap-bootstrap/triggerwatch\"]) | not) and \
+               (index([\"github.com/gvalkov/golang-evdev\"]) | not)   \
+             ) | .Dir  | ltrimstr(\"${PWD}\") | \".\" + . + \"/\" ")
+        done
+
     - name: Test Go (SNAPD_DEBUG=1)
       if: ${{ matrix.unit-scenario == 'snapd_debug' }}
       run: |

--- a/osutil/uname_linux_test.go
+++ b/osutil/uname_linux_test.go
@@ -22,6 +22,7 @@ package osutil_test
 import (
 	"bytes"
 	"errors"
+	"os"
 	"os/exec"
 	"syscall"
 
@@ -41,6 +42,10 @@ func ucmd1(c *check.C, arg string) string {
 }
 
 func (unameSuite) TestUname(c *check.C) {
+	if os.Getenv("GOARCH") != "" {
+		c.Skip("cannot test uname when GOARCH is set")
+	}
+
 	c.Check(osutil.KernelVersion(), check.Equals, ucmd1(c, "-r"))
 	c.Check(osutil.MachineName(), check.Equals, ucmd1(c, "-m"))
 }


### PR DESCRIPTION
There was a recent build failure because we do not test arm/arm64 automatically for each PR. This commit adds running the arm/arm64 unit tests by default using qemu-static-user.

Opening to see how long it takes to run the extra tests on GH.

This test would have caught https://github.com/snapcore/snapd/pull/12941