### PR TITLE
data: update content of the preseeded blob

### DIFF
--- a/data/preseed.json
+++ b/data/preseed.json
@@ -3,6 +3,8 @@
         "etc/udev/rules.d",
         "etc/systemd",
         "etc/dbus-1",
+        "etc/modprobe.d",
+        "etc/modules-load.d",
         "snap",
         "var/lib/extrausers",
         "var/lib/snapd/state.json",


### PR DESCRIPTION
Generated preseed.targ.z should contain content of the
`/etc/modprobe.d` and `/etc/modules-load.d`
Those directories can be populated as a result of the auto-connecting of `kernel-module-load` interface