### PR TITLE
daemon: fix /v2/snaps "Internal Server Error" error when installing unknown snaps

### DIFF
--- a/daemon/errors.go
+++ b/daemon/errors.go
@@ -339,10 +339,10 @@ func errToResponse(err error, snaps []string, fallback errorResponder, format st
 			}
 		case *store.SnapActionError:
 			// we only handle a few specific cases
-			_, _, e := err.SingleOpError()
+			_, name, e := err.SingleOpError()
 			if e != nil {
 				// 👉😎👉
-				return errToResponse(e, snaps, fallback, format)
+				return errToResponse(e, []string{name}, fallback, format)
 			}
 			handled = false
 		default:

--- a/daemon/errors_test.go
+++ b/daemon/errors_test.go
@@ -154,33 +154,41 @@ func (s *errorsSuite) TestErrToResponse(c *C) {
 	tests := []struct {
 		err         error
 		expectedRsp daemon.Response
+		isMany      bool
 	}{
-		{store.ErrSnapNotFound, daemon.SnapNotFound("foo", store.ErrSnapNotFound)},
-		{store.ErrNoUpdateAvailable, makeErrorRsp(client.ErrorKindSnapNoUpdateAvailable, store.ErrNoUpdateAvailable, "")},
-		{store.ErrLocalSnap, makeErrorRsp(client.ErrorKindSnapLocal, store.ErrLocalSnap, "")},
-		{aie, makeErrorRsp(client.ErrorKindSnapAlreadyInstalled, aie, "foo")},
-		{nie, makeErrorRsp(client.ErrorKindSnapNotInstalled, nie, "foo")},
-		{ndme, makeErrorRsp(client.ErrorKindSnapNeedsDevMode, ndme, "foo")},
-		{nc, makeErrorRsp(client.ErrorKindSnapNotClassic, nc, "foo")},
-		{nce, makeErrorRsp(client.ErrorKindSnapNeedsClassic, nce, "foo")},
-		{ncse, makeErrorRsp(client.ErrorKindSnapNeedsClassicSystem, ncse, "foo")},
-		{cce, daemon.SnapChangeConflict(cce)},
-		{nettoute, makeErrorRsp(client.ErrorKindNetworkTimeout, nettoute, "")},
-		{netoe, daemon.BadRequest("ERR: %v", netoe)},
-		{nettmpe, daemon.BadRequest("ERR: %v", nettmpe)},
-		{e, daemon.BadRequest("ERR: %v", e)},
+		{store.ErrSnapNotFound, daemon.SnapNotFound("foo", store.ErrSnapNotFound), false},
+		{store.ErrNoUpdateAvailable, makeErrorRsp(client.ErrorKindSnapNoUpdateAvailable, store.ErrNoUpdateAvailable, ""), false},
+		{store.ErrLocalSnap, makeErrorRsp(client.ErrorKindSnapLocal, store.ErrLocalSnap, ""), false},
+		{aie, makeErrorRsp(client.ErrorKindSnapAlreadyInstalled, aie, "foo"), false},
+		{nie, makeErrorRsp(client.ErrorKindSnapNotInstalled, nie, "foo"), false},
+		{ndme, makeErrorRsp(client.ErrorKindSnapNeedsDevMode, ndme, "foo"), false},
+		{nc, makeErrorRsp(client.ErrorKindSnapNotClassic, nc, "foo"), false},
+		{nce, makeErrorRsp(client.ErrorKindSnapNeedsClassic, nce, "foo"), false},
+		{ncse, makeErrorRsp(client.ErrorKindSnapNeedsClassicSystem, ncse, "foo"), false},
+		{cce, daemon.SnapChangeConflict(cce), false},
+		{nettoute, makeErrorRsp(client.ErrorKindNetworkTimeout, nettoute, ""), false},
+		{netoe, daemon.BadRequest("ERR: %v", netoe), false},
+		{nettmpe, daemon.BadRequest("ERR: %v", nettmpe), false},
+		{e, daemon.BadRequest("ERR: %v", e), false},
 
 		// action error unwrapping:
-		{sa1e, daemon.SnapNotFound("foo", store.ErrSnapNotFound)},
-		{saXe, daemon.SnapNotFound("foo", store.ErrSnapNotFound)},
+		{sa1e, daemon.SnapNotFound("foo", store.ErrSnapNotFound), false},
+		// simulates one snap not found (foo) and another one found (bar)
+		// for context see: https://bugs.launchpad.net/snapd/+bug/2024858
+		{sa1e, daemon.SnapNotFound("foo", store.ErrSnapNotFound), true},
+		{saXe, daemon.SnapNotFound("foo", store.ErrSnapNotFound), false},
 		// action errors, unwrapped:
-		{sa2e, daemon.BadRequest(`ERR: cannot refresh: snap not found: "bar", "foo"`)},
-		{saOe, daemon.BadRequest("ERR: cannot refresh, install, or download: other error")},
+		{sa2e, daemon.BadRequest(`ERR: cannot refresh: snap not found: "bar", "foo"`), true},
+		{saOe, daemon.BadRequest("ERR: cannot refresh, install, or download: other error"), false},
 	}
 
 	for _, t := range tests {
 		com := Commentf("%v", t.err)
-		rspe := daemon.ErrToResponse(t.err, []string{"foo"}, daemon.BadRequest, "%s: %v", "ERR")
+		snaps := []string{"foo"}
+		if t.isMany {
+			snaps = append(snaps, "bar")
+		}
+		rspe := daemon.ErrToResponse(t.err, snaps, daemon.BadRequest, "%s: %v", "ERR")
 		c.Check(rspe, DeepEquals, t.expectedRsp, com)
 	}
 }


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/snapd/+bug/2024858

Internal Server Error response was returned when only one of many snaps is not found. The problem was passing all snap names (including successful ones) to [errToResponse](https://github.com/snapcore/snapd/blob/b0c8a48341dd29e82f16f5220bd766f7d1d9b88a/daemon/errors.go#L292) instead of the unknown snap only.

**How to reproduce:**
In the following example only "spamandeggs" is not found, 404 status code is expected, 500 is returned instead:
```
curl -sS --unix-socket /run/snapd.socket http://localhost/v2/snaps -X POST \
-d '{"action": "install", "snaps": ["spamandeggs", "hello"]}' -H "Content-Type: application/json" \
| jq
```
```
{
  "type": "error",
  "status-code": 500,
  "status": "Internal Server Error",
  "result": {
    "message": "store.SnapNotFound with 2 snaps"
  }
}
```

**Side note:**
When multiple snaps are unknown, generic BadRequest 400 is returned (where 404 would be preferable). This is due to the implementation of [`func (e SnapActionError) SingleOpError()`](https://github.com/snapcore/snapd/blob/b0c8a48341dd29e82f16f5220bd766f7d1d9b88a/store/errors.go#L148) checking that only a single error exists and not single error **type** exists (e.g. `ErrSnapNotFound`).
The logic for grouping single type errors already exists [here](https://github.com/snapcore/snapd/blob/b0c8a48341dd29e82f16f5220bd766f7d1d9b88a/store/errors.go#L220) and can be extracted into a reusable function.
```
curl -sS --unix-socket /run/snapd.socket http://localhost/v2/snaps -X POST \
-d '{"action": "install", "snaps": ["spamandeggs", "spamandeggs2"]}' -H "Content-Type: application/json" \
| jq
```
```
{
  "type": "error",
  "status-code": 400,
  "status": "Bad Request",
  "result": {
    "message": "cannot install \"snapandeggs\", \"spamandeggs2\": cannot install: snap not found: \"snapandeggs\", \"spamandeggs2\""
  }
}
```