### PR TITLE
daemon: move the closing of snapdListener til after the rebootNoticeWait period

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -504,9 +504,10 @@ func (d *Daemon) Stop(sigCh chan<- os.Signal) error {
 		logger.Noticef("error writing maintenance file: %v", err)
 	}
 
-	d.snapdListener.Close()
-	d.standbyOpinions.Stop()
-
+	// take a timestamp before shutting down the snap listener, and
+	// use the time we may spend on waiting for hooks against the shutdown
+	// delay.
+	ts := time.Now()
 	if d.snapListener != nil {
 		// stop running hooks first
 		// and do it more gracefully if we are restarting
@@ -522,11 +523,18 @@ func (d *Daemon) Stop(sigCh chan<- os.Signal) error {
 		hookMgr.StopHooks()
 		d.snapListener.Close()
 	}
+	timeSpent := time.Since(ts)
 
-	if needsFullShutdown {
-		// give time to polling clients to notice restart
-		time.Sleep(rebootNoticeWait)
+	// When shutting down the snapd listener wait until the rebootNoticeWait
+	// period has passed before snapdListener is closed to allow polling
+	// clients to access the daemon. For testing we disable this unless SNAPD_SHUTDOWN_DELAY
+	// has been set, to avoid incurring this wait for every daemon restart which happens
+	// quite often in testing.
+	if !snapdenv.Testing() || osutil.GetenvBool("SNAPD_SHUTDOWN_DELAY") {
+		time.Sleep(rebootNoticeWait - timeSpent)
 	}
+	d.snapdListener.Close()
+	d.standbyOpinions.Stop()
 
 	// We're using the background context here because the tomb's
 	// context will likely already have been cancelled when we are

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -83,6 +83,7 @@ func (s *daemonSuite) SetUpTest(c *check.C) {
 	}
 	s.notified = nil
 	s.AddCleanup(ifacestate.MockSecurityBackends(nil))
+	s.AddCleanup(MockRebootNoticeWait(0))
 }
 
 func (s *daemonSuite) TearDownTest(c *check.C) {
@@ -664,6 +665,7 @@ version: 1`, si)
 
 func (s *daemonSuite) TestRestartWiring(c *check.C) {
 	d := s.newTestDaemon(c)
+
 	// mark as already seeded
 	s.markSeeded(d)
 
@@ -1015,6 +1017,9 @@ func (s *daemonSuite) testRestartSystemWiring(c *check.C, prep func(d *Daemon), 
 
 	err = d.Stop(nil)
 
+	// ensure Stop waited for at least rebootWaitTimeout
+	timeToStop := time.Since(now)
+	c.Check(timeToStop > rebootWaitTimeout+rebootNoticeWait, check.Equals, true)
 	c.Check(err, check.ErrorMatches, fmt.Sprintf("expected %s did not happen", expectedAction))
 
 	c.Check(delays, check.HasLen, 2)

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -329,3 +329,9 @@ func MockAspectstateSet(f func(databag aspects.DataBag, account, bundleName, asp
 		aspectstateSetAspect = old
 	}
 }
+
+func MockRebootNoticeWait(d time.Duration) (restore func()) {
+	restore = testutil.Backup(&rebootNoticeWait)
+	rebootNoticeWait = d
+	return restore
+}

--- a/tests/core/gadget-kernel-refs-update-pc/task.yaml
+++ b/tests/core/gadget-kernel-refs-update-pc/task.yaml
@@ -85,6 +85,12 @@ prepare: |
     p=$(fakestore new-snap-revision --dir "$BLOB_DIR" pc_x1.snap --snap-rev-json rev-headers.json)
     snap ack "$p"
     cp -av pc_x1.snap "$BLOB_DIR/"
+
+    # make sure that the snapd daemon gives us time for comms before
+    # closing the socket
+    sed -i '/^Environment=/ s/$/ SNAPD_SHUTDOWN_DELAY=1/' /etc/systemd/system/snapd.service.d/local.conf
+    systemctl restart snapd
+    
 restore: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then
         echo "This test needs test keys to be trusted"
@@ -97,6 +103,10 @@ restore: |
     "$TESTSTOOLS"/store-state teardown-fake-store "$BLOB_DIR"
     # XXX: ideally we would restore the kernel/gadget here but the kernel
     #      restore requires a reboot :/
+
+    # remove SNAPD_SHUTDOWN_DELAY again
+    sed -i 's/SNAPD_SHUTDOWN_DELAY=1//g' /etc/systemd/system/snapd.service.d/local.conf
+    systemctl restart snapd
     
 execute: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then

--- a/tests/core/mem-cgroup-disabled/task.yaml
+++ b/tests/core/mem-cgroup-disabled/task.yaml
@@ -36,6 +36,16 @@ prepare: |
   fi
 
   snap pack pc-gadget-no-cgroup --filename=pc-cgroup-disabled.snap
+  
+  # make sure that the snapd daemon gives us time for comms before
+  # closing the socket
+  sed -i '/^Environment=/ s/$/ SNAPD_SHUTDOWN_DELAY=1/' /etc/systemd/system/snapd.service.d/local.conf
+  systemctl restart snapd
+
+restore: |
+  # remove SNAPD_SHUTDOWN_DELAY again
+  sed -i 's/SNAPD_SHUTDOWN_DELAY=1//g' /etc/systemd/system/snapd.service.d/local.conf
+  systemctl restart snapd
 
 execute: |
   if not os.query is-pc-amd64; then

--- a/tests/core/remodel-gadget/task.yaml
+++ b/tests/core/remodel-gadget/task.yaml
@@ -12,6 +12,10 @@ prepare: |
     . "$TESTSLIB"/core-config.sh
 
     if [ "$SPREAD_REBOOT" = 0 ]; then
+        # enable the shutdown delay for this test in /etc/environment to properly persist it
+        # in this test
+        echo "SNAPD_SHUTDOWN_DELAY=1" >> /etc/environment
+
         REBOOT_NEEDED=false
         if os.query is-core18 && snap list snapd | NOMATCH ' x1 '; then
             REBOOT_NEEDED=true
@@ -81,6 +85,10 @@ restore: |
         find /var/snap
         exit 1
     fi
+
+    # remove SNAPD_SHUTDOWN_DELAY from /etc/environment again
+    #shellcheck disable=SC2005
+    echo "$(grep -v 'SNAPD_SHUTDOWN_DELAY=1' /etc/environment)" > /etc/environment
 
 execute: |
     #shellcheck source=tests/lib/core-config.sh

--- a/tests/core/snapd-maintenance-msg/task.yaml
+++ b/tests/core/snapd-maintenance-msg/task.yaml
@@ -1,0 +1,59 @@
+summary: Verify that the maintenance message is included in the daemon API responses when available
+
+# kinda slow test, probably enough to keep on one system
+systems: [ubuntu-core-20-64]
+
+prepare: |
+    # devmode as the snap does not have snapd-control
+    snap install test-snapd-curl --devmode --edge
+    snap install jq
+
+    # make sure that the snapd daemon gives us time for comms before
+    # closing the socket
+    echo "SNAPD_SHUTDOWN_DELAY=1" >> /etc/environment
+    systemctl restart snapd
+
+restore: |
+    snap remove test-snapd-curl jq
+
+    # remove SNAPD_SHUTDOWN_DELAY from /etc/environment again
+    #shellcheck disable=SC2005
+    echo "$(grep -v 'SNAPD_SHUTDOWN_DELAY=1' /etc/environment)" > /etc/environment
+    systemctl restart snapd
+
+execute: |
+    if [ "$SPREAD_REBOOT" = 0 ]; then
+        current=$(readlink /snap/snapd/current)
+        SNAPD_SNAP=$(ls /var/lib/snapd/snaps/snapd_"$current".snap)
+        
+        # we have three seconds between the maintenance json being written and the snapd listener being
+        # closed so we need to catch it in that timeframe.
+        echo "Testing maintenance message for daemon restarts"
+        snap install --dangerous "$SNAPD_SNAP" &
+        retry -n 20 --wait 0.5 sh -c 'test-snapd-curl.curl -sS --unix-socket /run/snapd.socket http://localhost/v2/changes?select=all | jq ".maintenance" | MATCH "daemon is restarting"'
+        wait
+
+        echo "Restoring the snapd snap"
+        snap revert snapd
+
+        echo "Testing maintenance message for system reboots"
+        snap refresh core20 --channel=stable &
+        retry -n 20 --wait 0.5 sh -c 'test-snapd-curl.curl -sS --unix-socket /run/snapd.socket http://localhost/v2/changes?select=all | jq ".maintenance" | MATCH "system is restarting"'
+        wait
+
+        REBOOT
+    fi
+
+    if [ "$SPREAD_REBOOT" = 1 ]; then
+        echo "Waiting for the core20 to finish refresh"
+        CHANGE_ID=$(snap changes | tr -s '\n' | awk 'END{ print $1 }')
+        snap watch "$CHANGE_ID"
+
+        echo "Restoring the core20 snap"
+        snap revert core20
+        REBOOT
+    fi
+    
+    echo "Waiting for the core20 to finish revert"
+    CHANGE_ID=$(snap changes | tr -s '\n' | awk 'END{ print $1 }')
+    snap watch "$CHANGE_ID"


### PR DESCRIPTION
Do not close snapdListener before the rebootNoticeWait, as the comment correctly says we want to give a notice period to polling clients to allow them to get informed of the pending reboot. Extend this also to be true for daemon restarts.

This fixes polling clients through the snapd API not getting notified of pending reboots, as the listener was closed immediately when rebooting. 