### PR TITLE
snap-bootstrap: print version information at startup

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -45,6 +45,7 @@ import (
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/disks"
+	"github.com/snapcore/snapd/snapdtool"
 
 	// to set sysconfig.ApplyFilesystemOnlyDefaultsImpl
 	_ "github.com/snapcore/snapd/overlord/configstate/configcore"
@@ -78,6 +79,8 @@ type cmdInitramfsMounts struct{}
 func (c *cmdInitramfsMounts) Execute([]string) error {
 	boot.HasFDESetupHook = hasFDESetupHook
 	boot.RunFDESetupHook = runFDESetupHook
+
+	logger.Noticef("snap-bootstrap version %v starting", snapdtool.Version)
 
 	return generateInitramfsMounts()
 }


### PR DESCRIPTION
We got asked to print the version information of snap-bootstrap during the boot to help the enablement/field team to know if they are using the right version of snap-bootstrap.

This is a small commit that archives this. It uses the logger so quiet boot will also be honored.
