### PR TITLE
aspects: merge and improve not found errors

### DIFF
--- a/aspects/aspects.go
+++ b/aspects/aspects.go
@@ -56,41 +56,21 @@ func newAccessType(access string) (accessType, error) {
 	return readWrite, fmt.Errorf("expected 'access' to be one of %s but was %q", strutil.Quoted(accessTypeStrings), access)
 }
 
-// AspectNotFoundError represents a failure to find an aspect.
-type AspectNotFoundError struct {
+type NotFoundError struct {
 	Account    string
 	BundleName string
 	Aspect     string
+	Field      string
+	Cause      string
 }
 
-func (e *AspectNotFoundError) Error() string {
-	return fmt.Sprintf("aspect %s/%s/%s not found", e.Account, e.BundleName, e.Aspect)
+func (e *NotFoundError) Error() string {
+	return fmt.Sprintf("cannot find field %q of aspect %s/%s/%s: %s", e.Field, e.Account, e.BundleName, e.Aspect, e.Cause)
 }
 
-func (e *AspectNotFoundError) Is(err error) bool {
-	_, ok := err.(*AspectNotFoundError)
+func (e *NotFoundError) Is(err error) bool {
+	_, ok := err.(*NotFoundError)
 	return ok
-}
-
-// FieldNotFoundError represents a failure to find a field carrying a value in
-// an aspect databag.
-type FieldNotFoundError struct {
-	Message string
-}
-
-func (e *FieldNotFoundError) Error() string {
-	return e.Message
-}
-
-func (e *FieldNotFoundError) Is(err error) bool {
-	_, ok := err.(*FieldNotFoundError)
-	return ok
-}
-
-// IsNotFound returns true if the error is some kind of aspect-related not
-// found error (e.g., aspect not found, field not found in aspect).
-func IsNotFound(err error) bool {
-	return errors.Is(err, &AspectNotFoundError{}) || errors.Is(err, &FieldNotFoundError{})
 }
 
 // InvalidAccessError represents a failure to perform a read or write due to the
@@ -126,6 +106,7 @@ type Schema interface {
 
 // Bundle holds a series of related aspects.
 type Bundle struct {
+	Account string
 	Name    string
 	schema  Schema
 	aspects map[string]*Aspect
@@ -133,13 +114,14 @@ type Bundle struct {
 
 // NewAspectBundle returns a new aspect bundle for the specified aspects
 // and access patterns.
-func NewAspectBundle(name string, aspects map[string]interface{}, schema Schema) (*Bundle, error) {
+func NewAspectBundle(account string, bundleName string, aspects map[string]interface{}, schema Schema) (*Bundle, error) {
 	if len(aspects) == 0 {
 		return nil, errors.New(`cannot define aspects bundle: no aspects`)
 	}
 
 	aspectBundle := &Bundle{
-		Name:    name,
+		Account: account,
+		Name:    bundleName,
 		schema:  schema,
 		aspects: make(map[string]*Aspect, len(aspects)),
 	}
@@ -322,7 +304,13 @@ func (a *Aspect) Set(databag DataBag, name string, value interface{}) error {
 		return a.bundle.schema.Validate(data)
 	}
 
-	return &FieldNotFoundError{fmt.Sprintf("cannot set field %q: not found", name)}
+	return &NotFoundError{
+		Account:    a.bundle.Account,
+		BundleName: a.bundle.Name,
+		Aspect:     a.Name,
+		Field:      name,
+		Cause:      "field not found",
+	}
 }
 
 // Get returns the aspect value identified by the name. If either the named aspect
@@ -345,16 +333,28 @@ func (a *Aspect) Get(databag DataBag, name string, value interface{}) error {
 		}
 
 		if err := databag.Get(path, value); err != nil {
-			if errors.Is(err, &FieldNotFoundError{}) {
-				return &FieldNotFoundError{fmt.Sprintf("cannot get field %q: %v", name, err)}
+			var pathErr PathNotFoundError
+			if errors.As(err, &pathErr) {
+				return &NotFoundError{
+					Account:    a.bundle.Account,
+					BundleName: a.bundle.Name,
+					Aspect:     a.Name,
+					Field:      name,
+					Cause:      string(pathErr),
+				}
 			}
-
 			return err
 		}
 		return nil
 	}
 
-	return &FieldNotFoundError{fmt.Sprintf("cannot get field %q: not found", name)}
+	return &NotFoundError{
+		Account:    a.bundle.Account,
+		BundleName: a.bundle.Name,
+		Aspect:     a.Name,
+		Field:      name,
+		Cause:      "field not found",
+	}
 }
 
 func newAccessPattern(name, path, accesstype string) (*accessPattern, error) {
@@ -507,6 +507,17 @@ func (p literal) write(sb *strings.Builder, _ map[string]string) error {
 	return err
 }
 
+type PathNotFoundError string
+
+func (e PathNotFoundError) Error() string {
+	return string(e)
+}
+
+func (e PathNotFoundError) Is(err error) bool {
+	_, ok := err.(PathNotFoundError)
+	return ok
+}
+
 // JSONDataBag is a simple DataBag implementation that keeps JSON in-memory.
 type JSONDataBag map[string]json.RawMessage
 
@@ -529,7 +540,7 @@ func get(subKeys []string, index int, node map[string]json.RawMessage, result in
 	rawLevel, ok := node[key]
 	if !ok {
 		pathPrefix := strings.Join(subKeys[:index+1], ".")
-		return &FieldNotFoundError{fmt.Sprintf("no value was found under %q", pathPrefix)}
+		return PathNotFoundError(fmt.Sprintf("no value was found under path %q", pathPrefix))
 	}
 
 	// read the final value

--- a/aspects/aspects_test.go
+++ b/aspects/aspects_test.go
@@ -36,34 +36,34 @@ func Test(t *testing.T) { TestingT(t) }
 var _ = Suite(&aspectSuite{})
 
 func (*aspectSuite) TestNewAspectBundle(c *C) {
-	_, err := aspects.NewAspectBundle("foo", nil, aspects.NewJSONSchema())
+	_, err := aspects.NewAspectBundle("acc", "foo", nil, aspects.NewJSONSchema())
 	c.Assert(err, ErrorMatches, `cannot define aspects bundle: no aspects`)
 
-	_, err = aspects.NewAspectBundle("foo", map[string]interface{}{
+	_, err = aspects.NewAspectBundle("acc", "foo", map[string]interface{}{
 		"bar": "baz",
 	}, aspects.NewJSONSchema())
 	c.Assert(err, ErrorMatches, `cannot define aspect "bar": access patterns should be a list of maps`)
 
-	_, err = aspects.NewAspectBundle("foo", map[string]interface{}{
+	_, err = aspects.NewAspectBundle("acc", "foo", map[string]interface{}{
 		"bar": []map[string]string{},
 	}, aspects.NewJSONSchema())
 	c.Assert(err, ErrorMatches, `cannot define aspect "bar": no access patterns found`)
 
-	_, err = aspects.NewAspectBundle("foo", map[string]interface{}{
+	_, err = aspects.NewAspectBundle("acc", "foo", map[string]interface{}{
 		"bar": []map[string]string{
 			{"path": "foo"},
 		},
 	}, aspects.NewJSONSchema())
 	c.Assert(err, ErrorMatches, `cannot define aspect "bar": access patterns must have a "name" field`)
 
-	_, err = aspects.NewAspectBundle("foo", map[string]interface{}{
+	_, err = aspects.NewAspectBundle("acc", "foo", map[string]interface{}{
 		"bar": []map[string]string{
 			{"name": "foo"},
 		},
 	}, aspects.NewJSONSchema())
 	c.Assert(err, ErrorMatches, `cannot define aspect "bar": access patterns must have a "path" field`)
 
-	aspectBundle, err := aspects.NewAspectBundle("foo", map[string]interface{}{
+	aspectBundle, err := aspects.NewAspectBundle("acc", "foo", map[string]interface{}{
 		"bar": []map[string]string{
 			{"name": "a", "path": "b"},
 		},
@@ -96,7 +96,7 @@ func (s *aspectSuite) TestAccessTypes(c *C) {
 			err:    true,
 		},
 	} {
-		aspectBundle, err := aspects.NewAspectBundle("foo", map[string]interface{}{
+		aspectBundle, err := aspects.NewAspectBundle("acc", "foo", map[string]interface{}{
 			"bar": []map[string]string{
 				{"name": "a", "path": "b", "access": t.access},
 			}}, aspects.NewJSONSchema())
@@ -114,7 +114,7 @@ func (s *aspectSuite) TestAccessTypes(c *C) {
 
 func (*aspectSuite) TestGetAndSetAspects(c *C) {
 	databag := aspects.NewJSONDataBag()
-	aspectBundle, err := aspects.NewAspectBundle("system/network", map[string]interface{}{
+	aspectBundle, err := aspects.NewAspectBundle("system", "network", map[string]interface{}{
 		"wifi-setup": []map[string]string{
 			{"name": "ssids", "path": "wifi.ssids"},
 			{"name": "ssid", "path": "wifi.ssid"},
@@ -165,7 +165,7 @@ func (*aspectSuite) TestGetAndSetAspects(c *C) {
 
 func (s *aspectSuite) TestAspectNotFound(c *C) {
 	databag := aspects.NewJSONDataBag()
-	aspectBundle, err := aspects.NewAspectBundle("foo", map[string]interface{}{
+	aspectBundle, err := aspects.NewAspectBundle("acc", "foo", map[string]interface{}{
 		"bar": []map[string]string{
 			{"name": "top-level", "path": "top-level"},
 			{"name": "nested", "path": "top.nested-one"},
@@ -178,28 +178,28 @@ func (s *aspectSuite) TestAspectNotFound(c *C) {
 
 	var value string
 	err = aspect.Get(databag, "missing", &value)
-	c.Assert(err, testutil.ErrorIs, &aspects.FieldNotFoundError{})
-	c.Assert(err, ErrorMatches, `cannot get field "missing": not found`)
+	c.Assert(err, testutil.ErrorIs, &aspects.NotFoundError{})
+	c.Assert(err, ErrorMatches, `cannot find field "missing" of aspect acc/foo/bar: field not found`)
 
 	err = aspect.Set(databag, "missing", "thing")
-	c.Assert(err, testutil.ErrorIs, &aspects.FieldNotFoundError{})
-	c.Assert(err, ErrorMatches, `cannot set field "missing": not found`)
+	c.Assert(err, testutil.ErrorIs, &aspects.NotFoundError{})
+	c.Assert(err, ErrorMatches, `cannot find field "missing" of aspect acc/foo/bar: field not found`)
 
 	err = aspect.Get(databag, "top-level", &value)
-	c.Assert(err, testutil.ErrorIs, &aspects.FieldNotFoundError{})
-	c.Assert(err, ErrorMatches, `cannot get field "top-level": no value was found under "top-level"`)
+	c.Assert(err, testutil.ErrorIs, &aspects.NotFoundError{})
+	c.Assert(err, ErrorMatches, `cannot find field "top-level" of aspect acc/foo/bar: no value was found under path "top-level"`)
 
 	err = aspect.Set(databag, "nested", "thing")
 	c.Assert(err, IsNil)
 
 	err = aspect.Get(databag, "other-nested", &value)
-	c.Assert(err, testutil.ErrorIs, &aspects.FieldNotFoundError{})
-	c.Assert(err, ErrorMatches, `cannot get field "other-nested": no value was found under "top.nested-two"`)
+	c.Assert(err, testutil.ErrorIs, &aspects.NotFoundError{})
+	c.Assert(err, ErrorMatches, `cannot find field "other-nested" of aspect acc/foo/bar: no value was found under path "top.nested-two"`)
 }
 
 func (s *aspectSuite) TestAspectBadRead(c *C) {
 	databag := aspects.NewJSONDataBag()
-	aspectBundle, err := aspects.NewAspectBundle("foo", map[string]interface{}{
+	aspectBundle, err := aspects.NewAspectBundle("acc", "foo", map[string]interface{}{
 		"bar": []map[string]string{
 			{"name": "one", "path": "one"},
 			{"name": "onetwo", "path": "one.two"},
@@ -221,7 +221,7 @@ func (s *aspectSuite) TestAspectBadRead(c *C) {
 }
 
 func (s *aspectSuite) TestAspectsAccessControl(c *C) {
-	aspectBundle, err := aspects.NewAspectBundle("bundle", map[string]interface{}{
+	aspectBundle, err := aspects.NewAspectBundle("acc", "bundle", map[string]interface{}{
 		"foo": []map[string]string{
 			{"name": "default", "path": "path.default"},
 			{"name": "read-write", "path": "path.read-write", "access": "read-write"},
@@ -248,7 +248,7 @@ func (s *aspectSuite) TestAspectsAccessControl(c *C) {
 		{
 			name: "read-only",
 			// unrelated error
-			getErr: `cannot get field "read-only": no value was found under "path"`,
+			getErr: `cannot find field "read-only" of aspect acc/bundle/foo: no value was found under path "path"`,
 			setErr: `cannot write field "read-only": only supports read access`,
 		},
 		{
@@ -307,7 +307,7 @@ func (s *witnessDataBag) getLastPaths() (get, set string) {
 }
 
 func (s *aspectSuite) TestAspectAssertionWithPlaceholder(c *C) {
-	aspectBundle, err := aspects.NewAspectBundle("bundle", map[string]interface{}{
+	aspectBundle, err := aspects.NewAspectBundle("acc", "bundle", map[string]interface{}{
 		"foo": []map[string]string{
 			{"name": "defaults.{foo}", "path": "first.{foo}.last"},
 			{"name": "{bar}.name", "path": "first.{bar}"},
@@ -437,7 +437,7 @@ func (s *aspectSuite) TestAspectNameAndPathValidation(c *C) {
 			name:     "a. .c", path: "a.b", err: `invalid access name "a. .c": invalid subkey " "`,
 		},
 	} {
-		_, err := aspects.NewAspectBundle("foo", map[string]interface{}{
+		_, err := aspects.NewAspectBundle("acc", "foo", map[string]interface{}{
 			"foo": []map[string]string{
 				{"name": tc.name, "path": tc.path},
 			},
@@ -451,7 +451,7 @@ func (s *aspectSuite) TestAspectNameAndPathValidation(c *C) {
 
 func (s *aspectSuite) TestAspectUnsetTopLevelEntry(c *C) {
 	databag := aspects.NewJSONDataBag()
-	aspectBundle, err := aspects.NewAspectBundle("foo", map[string]interface{}{
+	aspectBundle, err := aspects.NewAspectBundle("acc", "foo", map[string]interface{}{
 		"my-aspect": []map[string]string{
 			{"name": "foo", "path": "foo"},
 			{"name": "bar", "path": "bar"},
@@ -471,7 +471,7 @@ func (s *aspectSuite) TestAspectUnsetTopLevelEntry(c *C) {
 
 	var value string
 	err = aspect.Get(databag, "foo", &value)
-	c.Assert(err, testutil.ErrorIs, &aspects.FieldNotFoundError{})
+	c.Assert(err, testutil.ErrorIs, &aspects.NotFoundError{})
 
 	err = aspect.Get(databag, "bar", &value)
 	c.Assert(err, IsNil)
@@ -480,7 +480,7 @@ func (s *aspectSuite) TestAspectUnsetTopLevelEntry(c *C) {
 
 func (s *aspectSuite) TestAspectUnsetLeafWithSiblings(c *C) {
 	databag := aspects.NewJSONDataBag()
-	aspectBundle, err := aspects.NewAspectBundle("foo", map[string]interface{}{
+	aspectBundle, err := aspects.NewAspectBundle("acc", "foo", map[string]interface{}{
 		"my-aspect": []map[string]string{
 			{"name": "bar", "path": "foo.bar"},
 			{"name": "baz", "path": "foo.baz"},
@@ -500,7 +500,7 @@ func (s *aspectSuite) TestAspectUnsetLeafWithSiblings(c *C) {
 
 	var value string
 	err = aspect.Get(databag, "bar", &value)
-	c.Assert(err, testutil.ErrorIs, &aspects.FieldNotFoundError{})
+	c.Assert(err, testutil.ErrorIs, &aspects.NotFoundError{})
 
 	// doesn't affect the other leaf entry under "foo"
 	err = aspect.Get(databag, "baz", &value)
@@ -510,7 +510,7 @@ func (s *aspectSuite) TestAspectUnsetLeafWithSiblings(c *C) {
 
 func (s *aspectSuite) TestAspectUnsetWithNestedEntry(c *C) {
 	databag := aspects.NewJSONDataBag()
-	aspectBundle, err := aspects.NewAspectBundle("foo", map[string]interface{}{
+	aspectBundle, err := aspects.NewAspectBundle("acc", "foo", map[string]interface{}{
 		"my-aspect": []map[string]string{
 			{"name": "foo", "path": "foo"},
 			{"name": "bar", "path": "foo.bar"},
@@ -527,15 +527,15 @@ func (s *aspectSuite) TestAspectUnsetWithNestedEntry(c *C) {
 
 	var value interface{}
 	err = aspect.Get(databag, "foo", &value)
-	c.Assert(err, testutil.ErrorIs, &aspects.FieldNotFoundError{})
+	c.Assert(err, testutil.ErrorIs, &aspects.NotFoundError{})
 
 	err = aspect.Get(databag, "bar", &value)
-	c.Assert(err, testutil.ErrorIs, &aspects.FieldNotFoundError{})
+	c.Assert(err, testutil.ErrorIs, &aspects.NotFoundError{})
 }
 
 func (s *aspectSuite) TestAspectUnsetLeafUnsetsParent(c *C) {
 	databag := aspects.NewJSONDataBag()
-	aspectBundle, err := aspects.NewAspectBundle("foo", map[string]interface{}{
+	aspectBundle, err := aspects.NewAspectBundle("acc", "foo", map[string]interface{}{
 		"my-aspect": []map[string]string{
 			{"name": "foo", "path": "foo"},
 			{"name": "bar", "path": "foo.bar"},
@@ -556,12 +556,12 @@ func (s *aspectSuite) TestAspectUnsetLeafUnsetsParent(c *C) {
 	c.Assert(err, IsNil)
 
 	err = aspect.Get(databag, "foo", &value)
-	c.Assert(err, testutil.ErrorIs, &aspects.FieldNotFoundError{})
+	c.Assert(err, testutil.ErrorIs, &aspects.NotFoundError{})
 }
 
 func (s *aspectSuite) TestAspectUnsetAlreadyUnsetEntry(c *C) {
 	databag := aspects.NewJSONDataBag()
-	aspectBundle, err := aspects.NewAspectBundle("foo", map[string]interface{}{
+	aspectBundle, err := aspects.NewAspectBundle("acc", "foo", map[string]interface{}{
 		"my-aspect": []map[string]string{
 			{"name": "foo", "path": "foo"},
 			{"name": "bar", "path": "one.bar"},
@@ -577,18 +577,6 @@ func (s *aspectSuite) TestAspectUnsetAlreadyUnsetEntry(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *aspectSuite) TestAspectNotFoundError(c *C) {
-	err := &aspects.AspectNotFoundError{Account: "foo", BundleName: "bar", Aspect: "baz"}
-	c.Assert(err, testutil.ErrorIs, &aspects.AspectNotFoundError{})
-	c.Assert(err, ErrorMatches, `aspect foo/bar/baz not found`)
-}
-
-func (s *aspectSuite) TestFieldNotFoundError(c *C) {
-	err := &aspects.FieldNotFoundError{Message: "expected error"}
-	c.Assert(err, testutil.ErrorIs, &aspects.FieldNotFoundError{})
-	c.Assert(err, ErrorMatches, `expected error`)
-}
-
 func (s *aspectSuite) TestInvalidAccessError(c *C) {
 	err := &aspects.InvalidAccessError{RequestedAccess: 1, FieldAccess: 2, Field: "foo"}
 	c.Assert(err, testutil.ErrorIs, &aspects.InvalidAccessError{})
@@ -597,12 +585,6 @@ func (s *aspectSuite) TestInvalidAccessError(c *C) {
 	err = &aspects.InvalidAccessError{RequestedAccess: 2, FieldAccess: 1, Field: "foo"}
 	c.Assert(err, testutil.ErrorIs, &aspects.InvalidAccessError{})
 	c.Assert(err, ErrorMatches, `cannot write field "foo": only supports read access`)
-}
-
-func (s *aspectSuite) TestIsNotFoundHelper(c *C) {
-	c.Assert(aspects.IsNotFound(&aspects.AspectNotFoundError{}), Equals, true)
-	c.Assert(aspects.IsNotFound(&aspects.FieldNotFoundError{}), Equals, true)
-	c.Assert(aspects.IsNotFound(&aspects.InvalidAccessError{}), Equals, false)
 }
 
 func (s *aspectSuite) TestJSONDataBagCopy(c *C) {

--- a/aspects/transaction_test.go
+++ b/aspects/transaction_test.go
@@ -62,7 +62,7 @@ func (s *transactionTestSuite) TestSet(c *C) {
 
 	var value interface{}
 	err = witness.writtenDatabag.Get("foo", &value)
-	c.Assert(err, FitsTypeOf, &aspects.FieldNotFoundError{})
+	c.Assert(err, FitsTypeOf, aspects.PathNotFoundError(""))
 }
 
 func (s *transactionTestSuite) TestCommit(c *C) {
@@ -236,7 +236,7 @@ func (s *transactionTestSuite) TestCommittedIncludesPreviousCommit(c *C) {
 	c.Assert(value, Equals, "bar")
 
 	err = databag.Get("bar", &value)
-	c.Assert(err, FitsTypeOf, &aspects.FieldNotFoundError{})
+	c.Assert(err, FitsTypeOf, aspects.PathNotFoundError(""))
 
 	err = txTwo.Commit()
 	c.Assert(err, IsNil)
@@ -311,7 +311,7 @@ func (s *transactionTestSuite) TestTransactionReadsIsolated(c *C) {
 
 	var value interface{}
 	err = tx.Get("foo", &value)
-	c.Assert(err, FitsTypeOf, &aspects.FieldNotFoundError{})
+	c.Assert(err, FitsTypeOf, aspects.PathNotFoundError(""))
 }
 
 func (s *transactionTestSuite) TestReadDatabagsAreCopiedForIsolation(c *C) {

--- a/overlord/aspectstate/aspectstate.go
+++ b/overlord/aspectstate/aspectstate.go
@@ -32,14 +32,20 @@ func SetAspect(databag aspects.DataBag, account, bundleName, aspect, field strin
 	accPatterns := aspecttest.MockWifiSetupAspect()
 	schema := aspects.NewJSONSchema()
 
-	aspectBundle, err := aspects.NewAspectBundle(bundleName, accPatterns, schema)
+	aspectBundle, err := aspects.NewAspectBundle(account, bundleName, accPatterns, schema)
 	if err != nil {
 		return err
 	}
 
 	asp := aspectBundle.Aspect(aspect)
 	if asp == nil {
-		return &aspects.AspectNotFoundError{Account: account, BundleName: bundleName, Aspect: aspect}
+		return &aspects.NotFoundError{
+			Account:    account,
+			BundleName: bundleName,
+			Aspect:     aspect,
+			Field:      field,
+			Cause:      "aspect not found",
+		}
 	}
 
 	if err := asp.Set(databag, field, value); err != nil {
@@ -56,14 +62,20 @@ func GetAspect(databag aspects.DataBag, account, bundleName, aspect, field strin
 	accPatterns := aspecttest.MockWifiSetupAspect()
 	schema := aspects.NewJSONSchema()
 
-	aspectBundle, err := aspects.NewAspectBundle(bundleName, accPatterns, schema)
+	aspectBundle, err := aspects.NewAspectBundle(account, bundleName, accPatterns, schema)
 	if err != nil {
 		return err
 	}
 
 	asp := aspectBundle.Aspect(aspect)
 	if asp == nil {
-		return &aspects.AspectNotFoundError{Account: account, BundleName: bundleName, Aspect: aspect}
+		return &aspects.NotFoundError{
+			Account:    account,
+			BundleName: bundleName,
+			Aspect:     aspect,
+			Field:      field,
+			Cause:      "aspect not found",
+		}
 	}
 
 	if err := asp.Get(databag, field, value); err != nil {

--- a/tests/main/aspects/task.yaml
+++ b/tests/main/aspects/task.yaml
@@ -35,7 +35,7 @@ execute: |
   # check it was deleted
   curl -sS --unix-socket /run/snapd.socket localhost/v2/aspects/system/network/wifi-setup?fields=ssid -X GET > response.txt
   jq -r '."status-code"' < response.txt | MATCH 404
-  jq -r '.result.message' < response.txt | MATCH 'no fields were found'
+  jq -r '.result.message' < response.txt | MATCH 'cannot find field "ssid" of aspect system/network/wifi-setup: no value was found under path "wifi"'
 
   # write values using a placeholder access
   curl -sS --unix-socket /run/snapd.socket localhost/v2/aspects/system/network/wifi-setup -X PUT -d '{"private.my-company": "my-config"}' > response.txt
@@ -55,7 +55,7 @@ execute: |
   # check it was deleted
   curl -sS --unix-socket /run/snapd.socket localhost/v2/aspects/system/network/wifi-setup?fields=private.my-company -X GET > response.txt
   jq -r '."status-code"' < response.txt | MATCH 404
-  jq -r '.result.message' < response.txt | MATCH 'no fields were found'
+  jq -r '.result.message' < response.txt | MATCH 'cannot find field "private.my-company" of aspect system/network/wifi-setup: no value was found under path "wifi.my-company"'
 
   # check second value remains
   curl -sS --unix-socket /run/snapd.socket localhost/v2/aspects/system/network/wifi-setup?fields=private.your-company -X GET > response.txt


### PR DESCRIPTION
Merge the FieldNotFound and AspectNotFound errors so the user-facing error messages returned by the API are consistent in wording and in the information they provide. Incomplete errors returned by `aspects/` are filled with additional information in `aspectstate/`.