### PR TITLE
gadget: relax gadget update checks

### DIFF
--- a/tests/nested/manual/remodel-offline/task.yaml
+++ b/tests/nested/manual/remodel-offline/task.yaml
@@ -36,9 +36,9 @@ execute: |
   remodel_options="--no-wait"
   # Get specific revision to grab pc 22 with compatible gadget with the one
   # in 20/stable.
-  # TODO update this code to use pc from 22/stable when it is compatible
-  # (min-size, part ids...) -> for sn_name in pc pc-kernel; do ...
-  remote.exec "snap download --revision=149 --basename=pc pc"
+  # TODO update this code to use pc from 22/stable when it has min-size
+  # for the ubuntu-save partition -> for sn_name in pc pc-kernel; do ...
+  remote.exec "snap download --revision=148 --basename=pc pc"
   remodel_options="$remodel_options --snap pc.snap --assertion pc.assert"
   #shellcheck disable=SC2043
   for sn_name in pc-kernel; do


### PR DESCRIPTION
Don't care anymore if there is a change in offset-write, as that does
not imply that the partitions layout is incompatible. Also, allow
changes in the partition type as long as there is an intersection in
the list of supported types. This will make easier UC20 to UC 22
updates for images using pc gadget.
