### PR TITLE
overlord,tests: use always 00-snapd-config.yaml to store netplan config

### DIFF
--- a/overlord/configstate/configcore/netplan.go
+++ b/overlord/configstate/configcore/netplan.go
@@ -190,11 +190,14 @@ func handleNetplanConfiguration(tr RunTransaction, opts *fsOnlyContext) (err err
 
 	originHint := "90-snapd-config"
 	if !seeded {
-		// Use a different origin hint when seeding that sorts
-		// before the console-conf "00-snapd-config.yaml" so
-		// that console-conf can override our settings when it
-		// runs.
-		originHint = "0-snapd-defaults"
+		// This is the origin used by the defaults settings established from
+		// the base, and it is also modified by console-conf if it runs. We
+		// really want to clean it if console-conf is disabled, as we want to
+		// override the base defaults. If console conf is enabled, it will
+		// rewrite the file anyway setting its own thing, which is fine, as it
+		// is a manual configuration and the defaults might even conflict with
+		// it.
+		originHint = "00-snapd-config"
 	}
 
 	// Always starts with a clean config to avoid merging of keys

--- a/overlord/configstate/configcore/netplan_test.go
+++ b/overlord/configstate/configcore/netplan_test.go
@@ -365,7 +365,7 @@ func (s *netplanSuite) TestNetplanWriteConfigHappyAfterSeeding(c *C) {
 }
 
 func (s *netplanSuite) TestNetplanWriteConfigHappyDuringSeeding(c *C) {
-	s.testNetplanWriteConfigHappy(c, false, "0-snapd-defaults")
+	s.testNetplanWriteConfigHappy(c, false, "00-snapd-config")
 }
 
 func (s *netplanSuite) testNetplanWriteConfigHappy(c *C, seeded bool, expectedOriginHint string) {

--- a/tests/core/netplan-cfg/task.yaml
+++ b/tests/core/netplan-cfg/task.yaml
@@ -6,9 +6,6 @@ systems:
   - ubuntu-core-20-*
   - ubuntu-core-22-*
 
-# TODO: re-enable the test once https://bugs.launchpad.net/ubuntu/+source/netplan.io/+bug/1967084 is fixed
-manual: true
-
 prepare: |
     snap install jq
     snap install yq

--- a/tests/nested/manual/core20-early-config/defaults.yaml
+++ b/tests/nested/manual/core20-early-config/defaults.yaml
@@ -21,12 +21,10 @@ defaults:
           bridges:
             br54:
               dhcp4: true
-          # ensure that default behavor can be overridden
+          # ensure that default behavior can be overridden
           ethernets:
-            ens3:
-              dhcp4: false
-              addresses:
-                - 10.0.2.15/24
-              routes:
-                - to: default
-                  via: 10.0.2.2
+            any:
+              match:
+                name: e*
+              dhcp4: true
+              dhcp6: true

--- a/tests/nested/manual/core20-early-config/task.yaml
+++ b/tests/nested/manual/core20-early-config/task.yaml
@@ -36,7 +36,7 @@ prepare: |
     tests.nested create-vm core
 
 restore: |
-    remote.exec "sudo rm -f /etc/netplan/90-snapd-config.yaml" || true
+    remote.exec "sudo rm -f /etc/netplan/00-snapd-config.yaml" || true
 
 debug: |
     # show if anything went wrong during seeding
@@ -80,8 +80,12 @@ execute: |
         remote.exec "cat /etc/hostname" | MATCH "foo"
         remote.exec "hostname" | MATCH "foo"
 
+        # Should not have all-* snippets from the base
+        not remote.exec "sudo snap get system system.network.netplan.network.ethernets.all-en"
+        not remote.exec "sudo snap get system system.network.netplan.network.ethernets.all-eth"
+
         # netplan config defaults are applied
-        remote.exec "sudo cat /etc/netplan/0-snapd-defaults.yaml" | MATCH br54
+        remote.exec "sudo cat /etc/netplan/00-snapd-config.yaml" | MATCH br54
         remote.exec "sudo netplan get bridges.br54.dhcp4" | MATCH true
         remote.exec "sudo snap get system system.network.netplan.network.bridges.br54.dhcp4" | MATCH true
         remote.exec "sudo netplan get ethernets.ens3.dhcp4" | MATCH false

--- a/tests/nested/manual/core20-early-config/task.yaml
+++ b/tests/nested/manual/core20-early-config/task.yaml
@@ -88,7 +88,7 @@ execute: |
         remote.exec "sudo cat /etc/netplan/00-snapd-config.yaml" | MATCH br54
         remote.exec "sudo netplan get bridges.br54.dhcp4" | MATCH true
         remote.exec "sudo snap get system system.network.netplan.network.bridges.br54.dhcp4" | MATCH true
-        remote.exec "sudo netplan get ethernets.ens3.dhcp4" | MATCH false
+        remote.exec "sudo netplan get ethernets.any.dhcp6" | MATCH true
         # and updating netplan works
         remote.exec "sudo snap set system system.network.netplan.network.bridges.br54.dhcp4=false"
         remote.exec "sudo netplan get bridges.br54.dhcp4" | MATCH false


### PR DESCRIPTION
If using other files we might keep the default configuration from the
base, thing that we do not really want. Fixes LP: #2025737.
