### PR TITLE
.github: ignore launchpad translations commit in CLA check

### DIFF
--- a/.github/workflows/cla-check.yaml
+++ b/.github/workflows/cla-check.yaml
@@ -12,3 +12,4 @@ jobs:
         uses: canonical/has-signed-canonical-cla@v1
         with:
           accept-existing-contributors: true
+          exempted-bots: 'Launchpad Translations on behalf of snappy-dev [bot],dependabot'


### PR DESCRIPTION
Make the CLA check action ignore launchpad translations.