### PR TITLE
.github: fix exempted bot name

### DIFF
--- a/.github/workflows/cla-check.yaml
+++ b/.github/workflows/cla-check.yaml
@@ -12,4 +12,4 @@ jobs:
         uses: canonical/has-signed-canonical-cla@v1
         with:
           accept-existing-contributors: true
-          exempted-bots: 'Launchpad Translations on behalf of snappy-dev [bot],dependabot'
+          exempted-bots: 'Launchpad Translations on behalf of snappy-dev,dependabot'


### PR DESCRIPTION
I messed up the name in the exempted bots. I'm not sure why this wasn't caught when I pushed a test commit to the original PR 