### PR TITLE
install: extract unmount helper function

### DIFF
--- a/gadget/install/content_test.go
+++ b/gadget/install/content_test.go
@@ -309,7 +309,7 @@ func (s *contentTestSuite) TestWriteFilesystemContentUnmountErrHandling(c *C) {
 			c.Check(unmountCalls, HasLen, 2)
 			c.Check(unmountCalls[0].flags, Equals, 0)
 			c.Check(unmountCalls[1].flags, Equals, syscall.MNT_DETACH)
-			c.Check(log.String(), Matches, `(?sm).* cannot unmount /.*/run/snapd/gadget-install/dev-node2 after writing filesystem content, trying lazy unmount next: umount error`)
+			c.Check(log.String(), Matches, `(?sm).* cannot unmount /.*/run/snapd/gadget-install/dev-node2 after writing filesystem content: umount error \(trying lazy unmount next\)`)
 		}
 	}
 }

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"syscall"
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/boot"
@@ -568,13 +567,7 @@ func MountVolumes(onVolumes map[string]*gadget.Volume, encSetupData *EncryptionS
 	numSeedPart := 0
 	unmount = func() (err error) {
 		for _, mntPt := range mountPoints {
-			errUnmount := sysUnmount(mntPt, 0)
-			if errUnmount != nil {
-				logger.Noticef("cannot unmount %q: %v (trying lazy unmount next)", mntPt, errUnmount)
-				// lazy umount on error, see LP:2025402
-				errUnmount = sysUnmount(mntPt, syscall.MNT_DETACH)
-				logger.Noticef("cannot lazy unmount %q: %v", mntPt, errUnmount)
-			}
+			errUnmount := unmountWithFallbackToLazy(mntPt, "mounting volumes")
 			// Make sure we do not set err to nil if it had already an error
 			if errUnmount != nil {
 				err = errUnmount


### PR DESCRIPTION
In the review of PR#12939 extracting a common helper for unmounting was suggested. This commit extracts a new `unmountWithFallbackToLazy` helper that first tries to do a normal unmount and then falls back to `syscall.MNT_DETACH` which is the same as `umount --lazy`. It will ensure the mountpoint will be released in the kernel once there are no longer any processes keeping it busy.

Followup for https://github.com/snapcore/snapd/pull/12939#discussion_r1251886974