### PR TITLE
interfaces: update comments about `no-expr-simplify`

### DIFF
--- a/interfaces/apparmor/spec.go
+++ b/interfaces/apparmor/spec.go
@@ -172,8 +172,8 @@ func (spec *Specification) AddDeduplicatedSnippet(snippet string) {
 // This function should be used whenever the apparmor template features more
 // than one use of "**" syntax (which represent arbitrary many directories or
 // files) and a variable component, like a device name or similar. Repeated
-// instances of this pattern require exponential memory when compiled with
-// apparmor_parser -O no-expr-simplify.
+// instances of this pattern slow down the apparmor parser in the default
+// "expr-simplify" mode (see PR#12943 for measurements).
 func (spec *Specification) AddParametricSnippet(templateFragment []string, value string) {
 	if len(spec.securityTags) == 0 {
 		return

--- a/interfaces/builtin/i2c.go
+++ b/interfaces/builtin/i2c.go
@@ -129,7 +129,7 @@ func (iface *i2cInterface) AppArmorConnectedPlug(spec *apparmor.Specification, p
 
 	cleanedPath := filepath.Clean(path)
 	spec.AddSnippet(fmt.Sprintf(i2cConnectedPlugAppArmorPath, cleanedPath))
-	// Use parametric snippets to avoid no-expr-simplify side-effects.
+	// Use parametric snippets to avoid parser slowdown.
 	spec.AddParametricSnippet([]string{
 		"/sys/devices/platform/{*,**.i2c}/i2c-" /* ###PARAM### */, "/** rw,  # Add any condensed parametric rules",
 	}, strings.TrimPrefix(path, "/dev/i2c-"))

--- a/interfaces/builtin/iio.go
+++ b/interfaces/builtin/iio.go
@@ -120,7 +120,7 @@ func (iface *iioInterface) AppArmorConnectedPlug(spec *apparmor.Specification, p
 	// shorter expansion expression.
 	deviceNum := strings.TrimPrefix(deviceName, "iio:device")
 
-	// Use parametric snippets to avoid no-expr-simplify side-effects.
+	// Use parametric snippets to avoid parser slowdown.
 	spec.AddParametricSnippet([]string{
 		"/sys/devices/**/iio:device" /* ###PARAM### */, "/** rwk,  # Add any condensed parametric rules",
 	}, deviceNum)

--- a/interfaces/builtin/spi.go
+++ b/interfaces/builtin/spi.go
@@ -84,7 +84,7 @@ func (iface *spiInterface) AppArmorConnectedPlug(spec *apparmor.Specification, p
 		return nil
 	}
 	spec.AddSnippet(fmt.Sprintf("%s rw,", path))
-	// Use parametric snippets to avoid no-expr-simplify side-effects.
+	// Use parametric snippets to avoid parser slowdown.
 	spec.AddParametricSnippet([]string{
 		"/sys/devices/platform/**/**.spi/**/spidev" /* ###PARAM### */, "/** rw,  # Add any condensed parametric rules",
 	}, strings.TrimPrefix(path, "/dev/spidev"))


### PR DESCRIPTION
This commit is a followup for the comments in the review for PR#12918 [1]. As snapd is no longer using `no-expr-simplify` all reference in the code got updated.

The `AddParametricSnippet()` that was originally introduced to avoid exponential memory growth with the parser is still useful and needed because the measurements in PR#12943 show that multiple lines with overlaping patterns will slow down the apparmor_parser when running with default `expr-simplify`.

The comments are updated accordingly in this commit.

[1] https://github.com/snapcore/snapd/pull/12918#pullrequestreview-1499831667
