### PR TITLE
o/snapstate: implicitly set --unaliased flag for parallel installs

### DIFF
--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -368,7 +368,6 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 	// Implicitly set --unaliased flag for parallel installs to avoid
 	// alias conflicts with the main snap
 	if snapsup.InstanceKey != "" {
-		logger.Noticef("implicitly setting --unaliased flag for parallel install %q", snapsup.InstanceName())
 		snapsup.Unaliased = true
 	}
 

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -365,12 +365,6 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 		}
 	}
 
-	// Implicitly set --unaliased flag for parallel installs to avoid
-	// alias conflicts with the main snap
-	if snapsup.InstanceKey != "" {
-		snapsup.Unaliased = true
-	}
-
 	if snapsup.Flags.Classic {
 		if !release.OnClassic {
 			return nil, fmt.Errorf("classic confinement is only supported on classic systems")
@@ -1094,6 +1088,12 @@ func ensureInstallPreconditions(st *state.State, info *snap.Info, flags Flags, s
 	if flags.Classic && !info.NeedsClassic() {
 		// snap does not require classic confinement, silently drop the flag
 		flags.Classic = false
+	}
+
+	// Implicitly set --unaliased flag for parallel installs to avoid
+	// alias conflicts with the main snap
+	if !snapst.IsInstalled() && info.InstanceKey != "" {
+		flags.Unaliased = true
 	}
 
 	if err := validateInfoAndFlags(info, snapst, flags); err != nil {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -365,6 +365,13 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 		}
 	}
 
+	// Implicitly set --unaliased flag for parallel installs to avoid
+	// alias conflicts with the main snap
+	if snapsup.InstanceKey != "" {
+		logger.Noticef("implicitly setting --unaliased flag for parallel install %q", snapsup.InstanceName())
+		snapsup.Unaliased = true
+	}
+
 	if snapsup.Flags.Classic {
 		if !release.OnClassic {
 			return nil, fmt.Errorf("classic confinement is only supported on classic systems")

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -1360,6 +1360,8 @@ func (s *snapmgrTestSuite) TestParallelInstanceInstallRunThrough(c *C) {
 		Version:     "some-snapVer",
 		PlugsOnly:   true,
 		InstanceKey: "instance",
+		// parallel installs should implicitly pass --unaliased
+		Flags: snapstate.Flags{Unaliased: true},
 	})
 	c.Assert(snapsup.SideInfo, DeepEquals, &snap.SideInfo{
 		RealName: "some-snap",

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -1408,6 +1408,8 @@ func (s *snapmgrTestSuite) TestParallelInstanceUpdateRunThrough(c *C) {
 		Version:     "services-snapVer",
 		PlugsOnly:   true,
 		InstanceKey: "instance",
+		// parallel installs should implicitly pass --unaliased
+		Flags: snapstate.Flags{Unaliased: true},
 	})
 	c.Assert(snapsup.SideInfo, DeepEquals, &snap.SideInfo{
 		RealName: "services-snap",

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -1408,8 +1408,6 @@ func (s *snapmgrTestSuite) TestParallelInstanceUpdateRunThrough(c *C) {
 		Version:     "services-snapVer",
 		PlugsOnly:   true,
 		InstanceKey: "instance",
-		// parallel installs should implicitly pass --unaliased
-		Flags: snapstate.Flags{Unaliased: true},
 	})
 	c.Assert(snapsup.SideInfo, DeepEquals, &snap.SideInfo{
 		RealName: "services-snap",

--- a/tests/main/parallel-install-auto-aliases/task.yaml
+++ b/tests/main/parallel-install-auto-aliases/task.yaml
@@ -74,7 +74,7 @@ execute: |
     snap install test-snapd-auto-aliases_foo
 
     echo "Installing test-snapd-auto-aliases after test-snapd-auto-aliases_foo"
-    echo "shouldn't conflict and it's aliases should be enabled"
+    echo "shouldn't conflict and its aliases should be enabled"
     snap install test-snapd-auto-aliases
 
     echo "Aliases should belong to test-snapd-auto-aliases"

--- a/tests/main/parallel-install-auto-aliases/task.yaml
+++ b/tests/main/parallel-install-auto-aliases/task.yaml
@@ -17,20 +17,16 @@ execute: |
     test_snapd_wellknown1|MATCH "ok wellknown 1"
     test_snapd_wellknown2|MATCH "ok wellknown 2"
 
-    # TODO parallel-install: due to store not supporting actions when more than
-    # one snap with given snap ID is sent in the request, use a workaround and
-    # install the snap directly from the file, but still let snapd fetch the
-    # assertions from the store, leave a canary to catch when the store starts
-    # supporting parallel installations
-    not snap install test-snapd-auto-aliases_foo
+    # parallel-install should implicitly pass --unaliased
+    # test-snapd-auto-aliases_foo should install normally with aliases disabled
+    snap install test-snapd-auto-aliases_foo
 
-    fname=$(find /var/lib/snapd/snaps -name 'test-snapd-auto-aliases*.snap')
-    test "$(echo "$fname" | wc -l)" = "1"
-    # make a copy, we'll remove the snap later on
-    cp "$fname" .
-    name="$(basename "$fname")"
-
-    snap install --unaliased --name test-snapd-auto-aliases_foo "$name"
+    echo "Check list of aliases"
+    snap aliases > aliases.out
+    MATCH "test-snapd-auto-aliases_foo.wellknown1 +test_snapd_wellknown1 +disabled" < aliases.out
+    MATCH "test-snapd-auto-aliases_foo.wellknown2 +test_snapd_wellknown2 +disabled" < aliases.out
+    MATCH "test-snapd-auto-aliases.wellknown1 +test_snapd_wellknown1 +-"    < aliases.out
+    MATCH "test-snapd-auto-aliases.wellknown2 +test_snapd_wellknown2 +-"    < aliases.out
 
     # aliases are unchanged
     test "$(readlink "$SNAP_MOUNT_DIR"/bin/test_snapd_wellknown1)" = "test-snapd-auto-aliases.wellknown1"
@@ -73,14 +69,21 @@ execute: |
     # clean slate
     snap remove --purge test-snapd-auto-aliases
 
-    echo "When test-snapd-auto-aliases_foo is installed"
+    echo "Even when test-snapd-auto-aliases_foo is installed first"
+    echo "it should be installed with --unaliased"
     snap install test-snapd-auto-aliases_foo
 
-    echo "Installing test-snapd-auto-aliases will conflict"
-    # TODO parallel-install: need to install using file
-    not snap install "$name"
-    snap change --last=install | MATCH 'cannot enable aliases .* for "test-snapd-auto-aliases", already enabled for "test-snapd-auto-aliases_foo"'
+    echo "Installing test-snapd-auto-aliases after test-snapd-auto-aliases_foo"
+    echo "shouldn't conflict and it's aliases should be enabled"
+    snap install test-snapd-auto-aliases
 
-    # make sure that symlinks are in place
-    test "$(readlink "$SNAP_MOUNT_DIR"/bin/test_snapd_wellknown1)" = "test-snapd-auto-aliases_foo.wellknown1"
-    test "$(readlink "$SNAP_MOUNT_DIR"/bin/test_snapd_wellknown2)" = "test-snapd-auto-aliases_foo.wellknown2"
+    echo "Aliases should belong to test-snapd-auto-aliases"
+    snap aliases > aliases.out
+    MATCH "test-snapd-auto-aliases_foo.wellknown1 +test_snapd_wellknown1 +disabled" < aliases.out
+    MATCH "test-snapd-auto-aliases_foo.wellknown2 +test_snapd_wellknown2 +disabled" < aliases.out
+    MATCH "test-snapd-auto-aliases.wellknown1 +test_snapd_wellknown1 +-"    < aliases.out
+    MATCH "test-snapd-auto-aliases.wellknown2 +test_snapd_wellknown2 +-"    < aliases.out
+
+    # aliases are unchanged
+    test "$(readlink "$SNAP_MOUNT_DIR"/bin/test_snapd_wellknown1)" = "test-snapd-auto-aliases.wellknown1"
+    test "$(readlink "$SNAP_MOUNT_DIR"/bin/test_snapd_wellknown2)" = "test-snapd-auto-aliases.wellknown2"


### PR DESCRIPTION
Implicitly set `--unaliased` flag for parallel installs to avoid alias conflicts with the main snap.

Some potential improvement points:
- Extracting parallel install detection into a function to make it more explicit instead of doing `InstanceKey != ""` implicitly
- Adding a unit test for installing many snaps at once with parallel installs included

They seemed a bit out of scope for this PR, if they seem sensible, maybe they can be implemented in their own PRs?