### PR TITLE
o/snapstate: use refresh hints to continue auto-refresh after monitoring

### DIFF
--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -113,7 +113,8 @@ func (rc *refreshCandidate) SnapSetupForUpdate(st *state.State, _ updateParamsFu
 
 	snapsup := &rc.SnapSetup
 	if globalFlags != nil {
-		snapsup.Flags = *globalFlags
+		snapsup.Flags.IsAutoRefresh = globalFlags.IsAutoRefresh
+		snapsup.Flags.IsContinuedAutoRefresh = globalFlags.IsContinuedAutoRefresh
 	}
 
 	return snapsup, &snapst, nil

--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -80,6 +80,9 @@ var refreshRetryDelay = 20 * time.Minute
 // of auto-refresh.
 type refreshCandidate struct {
 	SnapSetup
+	// Monitored signals whether this snap is currently being monitored for closure
+	// so its auto-refresh can be continued.
+	Monitored bool `json:"monitored,omitempty"`
 }
 
 func (rc *refreshCandidate) Type() snap.Type {
@@ -98,16 +101,22 @@ func (rc *refreshCandidate) InstanceName() string {
 	return rc.SnapSetup.InstanceName()
 }
 
-func (rc *refreshCandidate) Prereq(st *state.State) []string {
+func (rc *refreshCandidate) Prereq(*state.State) []string {
 	return rc.SnapSetup.Prereq
 }
 
-func (rc *refreshCandidate) SnapSetupForUpdate(st *state.State, params updateParamsFunc, userID int, globalFlags *Flags) (*SnapSetup, *SnapState, error) {
+func (rc *refreshCandidate) SnapSetupForUpdate(st *state.State, _ updateParamsFunc, _ int, globalFlags *Flags) (*SnapSetup, *SnapState, error) {
 	var snapst SnapState
 	if err := Get(st, rc.InstanceName(), &snapst); err != nil {
 		return nil, nil, err
 	}
-	return &rc.SnapSetup, &snapst, nil
+
+	snapsup := &rc.SnapSetup
+	if globalFlags != nil {
+		snapsup.Flags = *globalFlags
+	}
+
+	return snapsup, &snapst, nil
 }
 
 // soundness check
@@ -271,7 +280,9 @@ func (m *autoRefresh) Ensure() (err error) {
 	m.state.Lock()
 	defer m.state.Unlock()
 
-	m.restoreMonitoring()
+	if err := m.restoreMonitoring(); err != nil {
+		return fmt.Errorf("cannot restore monitoring: %v", err)
+	}
 
 	// see if it even makes sense to try to refresh
 	if CanAutoRefresh == nil {
@@ -279,27 +290,6 @@ func (m *autoRefresh) Ensure() (err error) {
 	}
 	if ok, err := CanAutoRefresh(m.state); err != nil || !ok {
 		return err
-	}
-
-	// is there a previously partially inhibited auto-refresh that can now be continued?
-	if attempt, ok := canContinueAutoRefresh(m.state); ok {
-		// override the auto-refresh delay if we're continuing an inhibited auto-refresh
-		// for the first time (because the snap just closed after we notified the user)
-		overrideDelay := attempt == 1
-		err := m.launchAutoRefresh(overrideDelay)
-		if err != nil {
-			if errors.Is(err, tooSoonError{}) {
-				// ignore error, retry the auto-refresh later
-				return nil
-			}
-
-			// we didn't auto-refresh, so keep flag but increase attempt counter
-			m.state.Cache("auto-refresh-continue-attempt", attempt+1)
-			return err
-		}
-		// clear the continue flag if the auto-refresh was scheduled successfully
-		m.state.Cache("auto-refresh-continue-attempt", nil)
-		return nil
 	}
 
 	// get lastRefresh and schedule
@@ -384,8 +374,7 @@ func (m *autoRefresh) Ensure() (err error) {
 				return nil
 			}
 
-			overrideDelay := false
-			err = m.launchAutoRefresh(overrideDelay)
+			err = m.launchAutoRefresh()
 			if _, ok := err.(*httputil.PersistentNetworkError); ok {
 				// refresh will be retried after refreshRetryDelay
 				return err
@@ -402,44 +391,48 @@ func (m *autoRefresh) Ensure() (err error) {
 	return err
 }
 
-func canContinueAutoRefresh(st *state.State) (int, bool) {
-	if cachedAttempt := st.Cached("auto-refresh-continue-attempt"); cachedAttempt != nil {
-		return cachedAttempt.(int), true
-	}
-
-	return 0, false
-}
-
-func (m *autoRefresh) restoreMonitoring() {
+func (m *autoRefresh) restoreMonitoring() error {
 	if m.restoredMonitoring {
-		return
+		return nil
 	}
 
-	var monitored []string
-	if err := m.state.Get("monitored-snaps", &monitored); err != nil && !errors.Is(err, state.ErrNoState) {
-		logger.Noticef("cannot restore monitoring: %v", err)
-		return
+	// clear the old monitoring state; remove in a later snapd version
+	m.state.Set("monitored-snaps", nil)
+
+	var refreshHints map[string]*refreshCandidate
+	if err := m.state.Get("refresh-candidates", &refreshHints); err != nil && !errors.Is(err, &state.NoStateError{}) {
+		return fmt.Errorf("cannot get refresh-candidates: %v", err)
 	}
 
 	defer func() { m.restoredMonitoring = true }()
-	if len(monitored) == 0 {
-		return
+
+	var monitored []*SnapSetup
+	for _, hint := range refreshHints {
+		if hint.Monitored {
+			monitored = append(monitored, &hint.SnapSetup)
+		}
 	}
 
-	monitoring := make(map[string]chan<- bool)
+	if len(monitored) == 0 {
+		return nil
+	}
+
+	abortChans := make(map[string]chan<- bool, len(monitored))
 	for _, snap := range monitored {
 		done := make(chan string, 1)
-		if err := cgroupMonitorSnapEnded(snap, done); err != nil {
-			logger.Noticef("cannot restore monitoring for snap %q closure: %v", snap, err)
+		snapName := snap.InstanceName()
+		if err := cgroupMonitorSnapEnded(snapName, done); err != nil {
+			logger.Noticef("cannot restore monitoring for snap %q closure: %v", snapName, err)
 			continue
 		}
 
 		abort := make(chan bool, 1)
-		monitoring[snap] = abort
-
+		abortChans[snapName] = abort
 		go continueRefreshOnSnapClose(m.state, snap, done, abort)
 	}
-	updateMonitoringState(m.state, monitoring)
+
+	m.state.Cache("monitored-snaps", abortChans)
+	return nil
 }
 
 // isRefreshHeld returns whether an auto-refresh is currently held back or not,
@@ -580,13 +573,13 @@ func (tooSoonError) Is(err error) bool {
 }
 
 // launchAutoRefresh creates the auto-refresh taskset and a change for it.
-func (m *autoRefresh) launchAutoRefresh(overrideDelay bool) error {
+func (m *autoRefresh) launchAutoRefresh() error {
 	// Check that we have reasonable delays between attempts.
 	// If the store is under stress we need to make sure we do not
 	// hammer it too often
 	now := timeNow()
 	minAttempt := m.lastRefreshAttempt.Add(refreshRetryDelay)
-	if !overrideDelay && !m.lastRefreshAttempt.IsZero() && minAttempt.After(now) {
+	if !m.lastRefreshAttempt.IsZero() && minAttempt.After(now) {
 		return tooSoonError{}
 	}
 	m.lastRefreshAttempt = now
@@ -599,7 +592,7 @@ func (m *autoRefresh) launchAutoRefresh(overrideDelay bool) error {
 	}()
 
 	// NOTE: this will unlock and re-lock state for network ops
-	updated, updateTss, err := AutoRefresh(auth.EnsureContextTODO(), m.state, &AutoRefreshOptions{IsContinuedAutoRefresh: overrideDelay})
+	updated, updateTss, err := AutoRefresh(auth.EnsureContextTODO(), m.state)
 
 	// TODO: we should have some way to lock just creating and starting changes,
 	//       as that would alleviate this race condition we are guarding against

--- a/overlord/snapstate/autorefresh_gating_test.go
+++ b/overlord/snapstate/autorefresh_gating_test.go
@@ -2034,8 +2034,7 @@ func (s *snapmgrTestSuite) TestAutoRefreshPhase2(c *C) {
 
 	// all snaps refreshed, all removed from refresh-candidates.
 	var candidates map[string]*snapstate.RefreshCandidate
-	c.Assert(s.state.Get("refresh-candidates", &candidates), IsNil)
-	c.Assert(candidates, HasLen, 0)
+	c.Assert(s.state.Get("refresh-candidates", &candidates), testutil.ErrorIs, &state.NoStateError{})
 }
 
 func (s *snapmgrTestSuite) TestAutoRefreshPhase2Held(c *C) {

--- a/overlord/snapstate/autorefresh_gating_test.go
+++ b/overlord/snapstate/autorefresh_gating_test.go
@@ -1417,7 +1417,7 @@ func (s *autorefreshGatingSuite) TestAutorefreshPhase1FeatureFlag(c *C) {
 	mockInstalledSnap(c, s.state, snapAyaml, useHook)
 
 	// gate-auto-refresh-hook feature not enabled, expect old-style refresh.
-	_, updateTss, err := snapstate.AutoRefresh(context.TODO(), st, nil)
+	_, updateTss, err := snapstate.AutoRefresh(context.TODO(), st)
 	c.Check(err, IsNil)
 	tss := updateTss.Refresh
 	c.Assert(tss, HasLen, 2)
@@ -1430,7 +1430,7 @@ func (s *autorefreshGatingSuite) TestAutorefreshPhase1FeatureFlag(c *C) {
 	tr.Set("core", "experimental.gate-auto-refresh-hook", true)
 	tr.Commit()
 
-	_, updateTss, err = snapstate.AutoRefresh(context.TODO(), st, nil)
+	_, updateTss, err = snapstate.AutoRefresh(context.TODO(), st)
 	c.Check(err, IsNil)
 	tss = updateTss.Refresh
 	c.Assert(tss, HasLen, 2)

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -706,7 +706,7 @@ func (f *fakeStore) Download(ctx context.Context, name, targetFn string, snapInf
 		macaroon = user.StoreMacaroon
 	}
 	// only add the options if they contain anything interesting
-	if *dlOpts == (store.DownloadOptions{}) {
+	if dlOpts != nil && *dlOpts == (store.DownloadOptions{}) {
 		dlOpts = nil
 	}
 	f.downloads = append(f.downloads, fakeDownload{

--- a/overlord/snapstate/flags.go
+++ b/overlord/snapstate/flags.go
@@ -75,7 +75,7 @@ type Flags struct {
 	// IsAutoRefresh is true if the snap is currently auto-refreshed
 	IsAutoRefresh bool `json:"is-auto-refresh,omitempty"`
 
-	// IsContinuedAutoRefresh is true if this is a continued auto-refresh
+	// IsContinuedAutoRefresh is true if this is a continued refresh
 	IsContinuedAutoRefresh bool `json:"is-continued-auto-refresh,omitempty"`
 
 	// NoReRefresh prevents refresh from adding epoch-hopping

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -834,16 +834,10 @@ func (m *SnapManager) doPreDownloadSnap(t *state.Task, tomb *tomb.Tomb) error {
 	}
 
 	targetFn := snapsup.MountFile()
-	dlOpts := &store.DownloadOptions{
-		// pre-downloads are only triggered in auto-refreshes
-		Scheduled: true,
-		RateLimit: autoRefreshRateLimited(st),
-	}
-
 	perfTimings := state.TimingsForTask(t)
 	st.Unlock()
 	timings.Run(perfTimings, "pre-download", fmt.Sprintf("pre-download snap %q", snapsup.SnapName()), func(timings.Measurer) {
-		err = theStore.Download(tomb.Context(nil), snapsup.SnapName(), targetFn, snapsup.DownloadInfo, nil, user, dlOpts)
+		err = theStore.Download(tomb.Context(nil), snapsup.SnapName(), targetFn, snapsup.DownloadInfo, nil, user, nil)
 	})
 	st.Lock()
 	if err != nil {
@@ -892,23 +886,18 @@ func (m *SnapManager) doPreDownloadSnap(t *state.Task, tomb *tomb.Tomb) error {
 			return err
 		}
 
-		return asyncRefreshOnSnapClose(m.state, refreshInfo)
+		return asyncRefreshOnSnapClose(m.state, snapsup, refreshInfo)
 	}
 
-	continueInhibitedAutoRefresh(st)
-	return nil
+	return continueInhibitedAutoRefresh(st, snapsup.InstanceName())
 }
 
 // asyncRefreshOnSnapClose asynchronously waits for the snap the close, notifies
 // the user and then triggers an auto-refresh.
-func asyncRefreshOnSnapClose(st *state.State, refreshInfo *userclient.PendingSnapRefreshInfo) error {
-	monitoredSnaps := snapMonitoring(st)
-	if monitoredSnaps == nil {
-		monitoredSnaps = make(map[string]chan<- bool)
-	}
-
+func asyncRefreshOnSnapClose(st *state.State, snapsup *SnapSetup, refreshInfo *userclient.PendingSnapRefreshInfo) error {
+	snapName := snapsup.InstanceName()
 	// there's already a goroutine waiting for this snap to close so just notify
-	if monitoredSnaps[refreshInfo.InstanceName] != nil {
+	if abortChan := getAbortMonitoringChan(st, snapName); abortChan != nil {
 		asyncPendingRefreshNotification(context.TODO(), userclient.New(), refreshInfo)
 		return nil
 	}
@@ -916,89 +905,177 @@ func asyncRefreshOnSnapClose(st *state.State, refreshInfo *userclient.PendingSna
 	// monitor the snap until it closes. Use buffered channel to prevent the sender
 	// from blocking if the receiver stops before reading from it
 	done := make(chan string, 1)
-	if err := cgroupMonitorSnapEnded(refreshInfo.InstanceName, done); err != nil {
+	if err := cgroupMonitorSnapEnded(snapName, done); err != nil {
 		return fmt.Errorf("cannot monitor for snap closure: %w", err)
 	}
 
 	// notify the user about the blocked refresh
 	asyncPendingRefreshNotification(context.TODO(), userclient.New(), refreshInfo)
 
-	abort := make(chan bool, 1)
-	monitoredSnaps[refreshInfo.InstanceName] = abort
-	updateMonitoringState(st, monitoredSnaps)
+	var refreshHints map[string]*refreshCandidate
+	if err := st.Get("refresh-candidates", &refreshHints); err != nil {
+		return fmt.Errorf("cannot get refresh-candidates: %v", err)
+	}
 
-	go continueRefreshOnSnapClose(st, refreshInfo.InstanceName, done, abort)
+	abort := make(chan bool, 1)
+	if err := addMonitoring(st, snapName, abort); err != nil {
+		return fmt.Errorf("cannot save monitoring state: %v", err)
+	}
+
+	go continueRefreshOnSnapClose(st, snapsup, done, abort)
+	return nil
+}
+
+// addMonitoring adds monitoring info to the persisted and in-memory states.
+func addMonitoring(st *state.State, snapName string, abort chan<- bool) error {
+	var refreshHints map[string]*refreshCandidate
+	if err := st.Get("refresh-candidates", &refreshHints); err != nil {
+		return fmt.Errorf("cannot get refresh-candidates: %v", err)
+	} else if _, ok := refreshHints[snapName]; !ok {
+		return fmt.Errorf("cannot get refresh candidate for %q: not found", snapName)
+	}
+
+	refreshHints[snapName].Monitored = true
+	st.Set("refresh-candidates", refreshHints)
+
+	storedChans := st.Cached("monitored-snaps")
+	if storedChans == nil {
+		storedChans = make(map[string]chan<- bool)
+	}
+
+	abortChans, ok := storedChans.(map[string]chan<- bool)
+	if !ok {
+		// should never happen save for programmer error
+		return fmt.Errorf(`"monitored-snaps" should be map[string]chan<- bool but got %T`, storedChans)
+	}
+
+	abortChans[snapName] = abort
+	st.Cache("monitored-snaps", abortChans)
 
 	return nil
 }
 
-func continueRefreshOnSnapClose(st *state.State, instanceName string, done <-chan string, abort <-chan bool) {
-	continueAutoRefresh := false
+// removeMonitoring removes monitoring state related to the specified snap.
+func removeMonitoring(st *state.State, snapName string) error {
+	var refreshHints map[string]*refreshCandidate
+	if err := st.Get("refresh-candidates", &refreshHints); err != nil {
+		return fmt.Errorf("cannot get refresh-candidates: %v", err)
+	} else if _, ok := refreshHints[snapName]; !ok {
+		return fmt.Errorf(`cannot reset the "monitored" field for %q in "refresh-candidates"`, snapName)
+	}
+
+	refreshHints[snapName].Monitored = false
+	st.Set("refresh-candidates", refreshHints)
+
+	storedChans := st.Cached("monitored-snaps")
+	if storedChans == nil {
+		return nil
+	}
+
+	abortChans, ok := storedChans.(map[string]chan<- bool)
+	if !ok {
+		// should never happen save for programmer error
+		return fmt.Errorf(`"monitored-snaps" should be map[string]chan<- bool but got %T`, storedChans)
+	}
+
+	delete(abortChans, snapName)
+	if len(abortChans) == 0 {
+		st.Cache("monitored-snaps", nil)
+	} else {
+		st.Cache("monitored-snaps", abortChans)
+	}
+
+	return nil
+}
+
+func continueRefreshOnSnapClose(st *state.State, snapsup *SnapSetup, done <-chan string, abort <-chan bool) {
+	snapName := snapsup.InstanceName()
+
+	var aborted bool
 	select {
 	case <-done:
-		continueAutoRefresh = true
 	case <-abort:
+		aborted = true
 	}
 
 	st.Lock()
 	defer st.Unlock()
 
-	monitoredSnaps := snapMonitoring(st)
-	if monitoredSnaps == nil {
-		// shouldn't happen except for programmer error
-		logger.Noticef("cannot find monitoring state for snap %q", instanceName)
-	} else {
-		delete(monitoredSnaps, instanceName)
-
-		if len(monitoredSnaps) == 0 {
-			// use nil to delete entry but must be nil type (can't be map var set to nil)
-			updateMonitoringState(st, nil)
-		} else {
-			updateMonitoringState(st, monitoredSnaps)
+	defer func() {
+		if err := removeMonitoring(st, snapName); err != nil {
+			logger.Noticef("cannot remove monitoring information: %v", err)
 		}
-	}
+	}()
 
-	if continueAutoRefresh {
-		continueInhibitedAutoRefresh(st)
-	}
-}
-
-// continueInhibitedAutoRefresh triggers an auto-refresh so it can be continued
-func continueInhibitedAutoRefresh(st *state.State) {
-	// signal that there's an auto-refresh to be continued (for auto-refresh code)
-	st.Cache("auto-refresh-continue-attempt", 1)
-	st.EnsureBefore(0)
-}
-
-func snapMonitoring(st *state.State) map[string]chan<- bool {
-	if cachedMonitored := st.Cached("monitored-snaps"); cachedMonitored != nil {
-		if monitoredSnaps, ok := cachedMonitored.(map[string]chan<- bool); ok {
-			return monitoredSnaps
-		}
-	}
-
-	return nil
-}
-
-func updateMonitoringState(st *state.State, monitored map[string]chan<- bool) {
-	if monitored == nil {
-		st.Cache("monitored-snaps", nil)
-		st.Set("monitored-snaps", nil)
+	if aborted {
+		logger.Debugf("monitoring for pre-downloaded snap %q was aborted", snapName)
 		return
 	}
 
-	var snaps []string
-	for snap := range monitored {
-		snaps = append(snaps, snap)
+	if err := continueInhibitedAutoRefresh(st, snapName); err != nil {
+		logger.Noticef("cannot continue inhibited auto-refresh for %q: %v", snapName, err)
+		return
+	}
+}
+
+// continueInhibitedAutoRefresh refreshes the snap to continue the inhibited auto-refresh
+func continueInhibitedAutoRefresh(st *state.State, snapName string) error {
+	var refreshHints map[string]*refreshCandidate
+	if err := st.Get("refresh-candidates", &refreshHints); err != nil {
+		return fmt.Errorf("cannot get refresh-candidates: %v", err)
 	}
 
-	st.Cache("monitored-snaps", monitored)
-	st.Set("monitored-snaps", snaps)
+	hint, ok := refreshHints[snapName]
+	if !ok {
+		return fmt.Errorf("cannot get refresh-candidates for %q: not found", snapName)
+	}
+
+	flags := &Flags{IsAutoRefresh: true, IsContinuedAutoRefresh: true}
+	tss, err := autoRefreshPhase2(context.TODO(), st, []*refreshCandidate{hint}, flags, "")
+	if err != nil {
+		return err
+	}
+
+	// TODO: do a check so this can't happen?
+	createdPreDl, err := createPreDownloadChange(st, tss)
+	if err != nil {
+		return err
+	}
+
+	if !createdPreDl {
+		snaps := []string{snapName}
+		msg := autoRefreshSummary(snaps)
+		chg := st.NewChange("auto-refresh", msg)
+		for _, ts := range tss.Refresh {
+			chg.AddAll(ts)
+		}
+		chg.Set("snap-names", snaps)
+		chg.Set("api-data", map[string]interface{}{"snap-names": snaps})
+	}
+
+	st.EnsureBefore(0)
+	return nil
+}
+
+func getAbortMonitoringChan(st *state.State, snapName string) chan<- bool {
+	storedChans := st.Cached("monitored-snaps")
+	if storedChans == nil {
+		return nil
+	}
+
+	abortChans, ok := storedChans.(map[string]chan<- bool)
+	if !ok {
+		// NOTE: should never happen save for programmer error
+		logger.Noticef(`internal error: "monitored-snap" should be map[string]chan<- bool but got %T: %v`, storedChans, storedChans)
+		return nil
+	}
+
+	return abortChans[snapName]
 }
 
 func abortMonitoring(st *state.State, snapName string) {
-	if monitored := snapMonitoring(st); monitored[snapName] != nil {
-		monitored[snapName] <- true
+	if abortChan := getAbortMonitoringChan(st, snapName); abortChan != nil {
+		abortChan <- true
 	}
 }
 
@@ -1271,7 +1348,7 @@ func (m *SnapManager) doUnlinkCurrentSnap(t *state.Task, _ *tomb.Tomb) (err erro
 			if errors.As(err, &busyErr) {
 				// notify user to close the snap and trigger the auto-refresh once it's closed
 				refreshInfo := busyErr.PendingSnapRefreshInfo()
-				if err := asyncRefreshOnSnapClose(m.state, refreshInfo); err != nil {
+				if err := asyncRefreshOnSnapClose(m.state, snapsup, refreshInfo); err != nil {
 					return err
 				}
 			}
@@ -4053,7 +4130,7 @@ func (m *SnapManager) doConditionalAutoRefresh(t *state.Task, tomb *tomb.Tomb) e
 		return nil
 	}
 
-	updateTss, err := autoRefreshPhase2(context.TODO(), st, snaps, t.Change().ID())
+	updateTss, err := autoRefreshPhase2(context.TODO(), st, snaps, nil, t.Change().ID())
 	if err != nil {
 		return err
 	}

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -915,7 +915,10 @@ func asyncRefreshOnSnapClose(st *state.State, snapsup *SnapSetup, refreshInfo *u
 		return fmt.Errorf("cannot monitor for snap closure: %w", err)
 	}
 
-	abort := make(chan bool, 1)
+	// use a buffer larger than 1 because there can be more than one writes to the channel.
+	// State locks make it unlikely but it's possible to have a second write before
+	// the reader can drain and remove the channel from the state
+	abort := make(chan bool, 16)
 	if ok, err := addMonitoring(st, snapName, abort); err != nil {
 		return fmt.Errorf("cannot save monitoring state for %q: %v", snapName, err)
 	} else if !ok {

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -736,7 +736,7 @@ func (m *SnapManager) doDownloadSnap(t *state.Task, tomb *tomb.Tomb) error {
 	st.Lock()
 	perfTimings := state.TimingsForTask(t)
 	snapsup, theStore, user, err := downloadSnapParams(st, t)
-	if snapsup != nil && snapsup.IsAutoRefresh {
+	if snapsup != nil && snapsup.IsAutoRefresh && !snapsup.IsContinuedAutoRefresh {
 		// NOTE rate is never negative
 		rate = autoRefreshRateLimited(st)
 	}
@@ -753,7 +753,7 @@ func (m *SnapManager) doDownloadSnap(t *state.Task, tomb *tomb.Tomb) error {
 	targetFn := snapsup.MountFile()
 
 	dlOpts := &store.DownloadOptions{
-		Scheduled: snapsup.IsAutoRefresh,
+		Scheduled: snapsup.IsAutoRefresh && !snapsup.IsContinuedAutoRefresh,
 		RateLimit: rate,
 	}
 	if snapsup.DownloadInfo == nil {

--- a/overlord/snapstate/refreshhints.go
+++ b/overlord/snapstate/refreshhints.go
@@ -123,7 +123,7 @@ func (r *refreshHints) Ensure() error {
 	defer r.state.Unlock()
 
 	// CanAutoRefresh is a hook that is set by the devicestate
-	// code to ensure that we only AutoRefersh if the device has
+	// code to ensure that we only AutoRefresh if the device has
 	// bootstraped itself enough. This is only nil when snapstate
 	// is used in isolation (like in tests).
 	if CanAutoRefresh == nil {
@@ -168,6 +168,7 @@ func refreshHintsFromCandidates(st *state.State, updates []*snap.Info, ignoreVal
 			continue
 		}
 
+		monitoring := getAbortMonitoringChan(st, update.InstanceName()) != nil
 		providerContentAttrs := defaultProviderContentAttrs(st, update)
 		snapsup := &refreshCandidate{
 			SnapSetup: SnapSetup{
@@ -191,6 +192,7 @@ func refreshHintsFromCandidates(st *state.State, updates []*snap.Info, ignoreVal
 					Website: update.Website(),
 				},
 			},
+			Monitored: monitoring,
 		}
 		hints[update.InstanceName()] = snapsup
 	}

--- a/overlord/snapstate/refreshhints.go
+++ b/overlord/snapstate/refreshhints.go
@@ -170,7 +170,7 @@ func refreshHintsFromCandidates(st *state.State, updates []*snap.Info, ignoreVal
 			continue
 		}
 
-		monitoring := getAbortMonitoringChan(st, update.InstanceName()) != nil
+		monitoring := isSnapMonitored(st, update.InstanceName())
 		providerContentAttrs := defaultProviderContentAttrs(st, update)
 		snapsup := &refreshCandidate{
 			SnapSetup: SnapSetup{

--- a/overlord/snapstate/refreshhints.go
+++ b/overlord/snapstate/refreshhints.go
@@ -99,7 +99,7 @@ func (r *refreshHints) refresh() error {
 		return fmt.Errorf("internal error: cannot get refresh-candidates: %v", err)
 	}
 
-	setNewRefreshCanditates(r.state, hints)
+	setNewRefreshCandidates(r.state, hints)
 	return nil
 }
 
@@ -252,14 +252,14 @@ func pruneRefreshCandidates(st *state.State, snaps ...string) error {
 		delete(candidates, snapName)
 	}
 
-	setNewRefreshCanditates(st, candidates)
+	setNewRefreshCandidates(st, candidates)
 	return nil
 }
 
-// setNewRefreshCanditates is used to set/replace "refresh-candidates" making
+// setNewRefreshCandidates is used to set/replace "refresh-candidates" making
 // sure that any snap that is no longer a candidate has its monitoring stopped.
-// Must be always used when replacing the full "refresh-candidates"
-func setNewRefreshCanditates(st *state.State, hints map[string]*refreshCandidate) {
+// Must always be used when replacing the full "refresh-candidates"
+func setNewRefreshCandidates(st *state.State, hints map[string]*refreshCandidate) {
 	stopMonitoringOutdatedCandidates(st, hints)
 	if len(hints) == 0 {
 		st.Set("refresh-candidates", nil)

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1721,7 +1721,7 @@ func updateManyFiltered(ctx context.Context, st *state.State, names []string, re
 			return nil, nil, err
 		}
 
-		st.Set("refresh-candidates", hints)
+		setNewRefreshCanditates(st, hints)
 	}
 
 	if filter != nil {
@@ -2594,7 +2594,7 @@ func autoRefreshPhase1(ctx context.Context, st *state.State, forGatingSnap strin
 	if err != nil {
 		return nil, nil, err
 	}
-	st.Set("refresh-candidates", hints)
+	setNewRefreshCanditates(st, hints)
 
 	// prune affecting snaps that are not in refresh candidates from hold state.
 	if err := pruneGating(st, hints); err != nil {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1721,7 +1721,7 @@ func updateManyFiltered(ctx context.Context, st *state.State, names []string, re
 			return nil, nil, err
 		}
 
-		setNewRefreshCanditates(st, hints)
+		setNewRefreshCandidates(st, hints)
 	}
 
 	if filter != nil {
@@ -2594,7 +2594,7 @@ func autoRefreshPhase1(ctx context.Context, st *state.State, forGatingSnap strin
 	if err != nil {
 		return nil, nil, err
 	}
-	setNewRefreshCanditates(st, hints)
+	setNewRefreshCandidates(st, hints)
 
 	// prune affecting snaps that are not in refresh candidates from hold state.
 	if err := pruneGating(st, hints); err != nil {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1707,7 +1707,7 @@ func updateManyFiltered(ctx context.Context, st *state.State, names []string, re
 
 	names = strutil.Deduplicate(names)
 
-	refreshOpts := &store.RefreshOptions{Scheduled: flags.IsAutoRefresh}
+	refreshOpts := &store.RefreshOptions{Scheduled: flags.IsAutoRefresh && !flags.IsContinuedAutoRefresh}
 	updates, stateByInstanceName, ignoreValidation, err := refreshCandidates(ctx, st, names, revOpts, user, refreshOpts)
 	if err != nil {
 		return nil, nil, err
@@ -2535,11 +2535,7 @@ type AutoRefreshOptions struct {
 // AutoRefresh is the wrapper that will do a refresh of all the installed
 // snaps on the system. In addition to that it will also refresh important
 // assertions.
-func AutoRefresh(ctx context.Context, st *state.State, opts *AutoRefreshOptions) ([]string, *UpdateTaskSets, error) {
-	if opts == nil {
-		opts = &AutoRefreshOptions{}
-	}
-
+func AutoRefresh(ctx context.Context, st *state.State) ([]string, *UpdateTaskSets, error) {
 	userID := 0
 
 	if AutoRefreshAssertions != nil {
@@ -2557,7 +2553,7 @@ func AutoRefresh(ctx context.Context, st *state.State, opts *AutoRefreshOptions)
 	}
 	if !gateAutoRefreshHook {
 		// old-style refresh (gate-auto-refresh-hook feature disabled)
-		return updateManyFiltered(ctx, st, nil, nil, userID, nil, &Flags{IsAutoRefresh: true, IsContinuedAutoRefresh: opts.IsContinuedAutoRefresh}, "")
+		return updateManyFiltered(ctx, st, nil, nil, userID, nil, &Flags{IsAutoRefresh: true}, "")
 	}
 
 	// TODO: rename to autoRefreshTasks when old auto refresh logic gets removed.
@@ -2723,8 +2719,10 @@ func autoRefreshPhase1(ctx context.Context, st *state.State, forGatingSnap strin
 }
 
 // autoRefreshPhase2 creates tasks for refreshing snaps from updates.
-func autoRefreshPhase2(ctx context.Context, st *state.State, updates []*refreshCandidate, fromChange string) (*UpdateTaskSets, error) {
-	flags := &Flags{IsAutoRefresh: true}
+func autoRefreshPhase2(ctx context.Context, st *state.State, updates []*refreshCandidate, flags *Flags, fromChange string) (*UpdateTaskSets, error) {
+	if flags == nil {
+		flags = &Flags{IsAutoRefresh: true}
+	}
 	userID := 0
 
 	deviceCtx, err := DeviceCtx(st, nil, nil)

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1707,7 +1707,7 @@ func updateManyFiltered(ctx context.Context, st *state.State, names []string, re
 
 	names = strutil.Deduplicate(names)
 
-	refreshOpts := &store.RefreshOptions{Scheduled: flags.IsAutoRefresh && !flags.IsContinuedAutoRefresh}
+	refreshOpts := &store.RefreshOptions{Scheduled: flags.IsAutoRefresh}
 	updates, stateByInstanceName, ignoreValidation, err := refreshCandidates(ctx, st, names, revOpts, user, refreshOpts)
 	if err != nil {
 		return nil, nil, err

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -8998,7 +8998,7 @@ func (s *snapmgrTestSuite) TestSaveRefreshCandidatesOnAutoRefresh(c *C) {
 	err := s.state.Get("refresh-candidates", &cands)
 	c.Assert(err, testutil.ErrorIs, &state.NoStateError{})
 
-	names, tss, err := snapstate.AutoRefresh(context.Background(), s.state, nil)
+	names, tss, err := snapstate.AutoRefresh(context.Background(), s.state)
 	c.Assert(err, IsNil)
 	c.Assert(tss, NotNil)
 	c.Check(names, DeepEquals, []string{"some-other-snap", "some-snap"})

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -9325,7 +9325,7 @@ func (s *snapmgrTestSuite) TestDownloadTaskWaitsForPreDownload(c *C) {
 	c.Check(monitored, Equals, false)
 }
 
-func (s *snapmgrTestSuite) TestPreDownloadTaskTriggersAutoRefreshIfSoftCheckOk(c *C) {
+func (s *snapmgrTestSuite) TestPreDownloadTaskContinuesAutoRefreshIfSoftCheckOk(c *C) {
 	var softChecked bool
 	restore := snapstate.MockRefreshAppsCheck(func(info *snap.Info) error {
 		c.Assert(info.InstanceName(), Equals, "foo")
@@ -9349,18 +9349,19 @@ func (s *snapmgrTestSuite) TestPreDownloadTaskTriggersAutoRefreshIfSoftCheckOk(c
 
 	s.state.Lock()
 	defer s.state.Unlock()
+
 	si := &snap.SideInfo{
 		RealName: "foo",
 		SnapID:   "foo-id",
 		Revision: snap.R(1),
 	}
-
 	snaptest.MockSnap(c, `name: foo`, si)
 	snapstate.Set(s.state, "foo", &snapstate.SnapState{
 		Active:   true,
 		Sequence: []*snap.SideInfo{si},
 		Current:  si.Revision,
 	})
+
 	snapsup := &snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: "foo",
@@ -9368,6 +9369,9 @@ func (s *snapmgrTestSuite) TestPreDownloadTaskTriggersAutoRefreshIfSoftCheckOk(c
 		},
 		Flags: snapstate.Flags{IsAutoRefresh: true},
 	}
+	s.state.Set("refresh-candidates", map[string]*snapstate.RefreshCandidate{
+		"foo": {SnapSetup: *snapsup},
+	})
 
 	preDlChg := s.state.NewChange("pre-download", "pre-download change")
 	preDlTask := s.state.NewTask("pre-download-snap", "pre-download task")
@@ -9379,13 +9383,23 @@ func (s *snapmgrTestSuite) TestPreDownloadTaskTriggersAutoRefreshIfSoftCheckOk(c
 	s.settle(c)
 
 	c.Assert(preDlTask.Status(), Equals, state.DoneStatus)
-	c.Assert(s.fakeStore.downloads, HasLen, 1)
-	c.Check(s.fakeStore.downloads[0].name, Equals, "foo")
+	c.Assert(s.fakeStore.downloads, HasLen, 2)
 
 	c.Check(softChecked, Equals, true)
 	c.Check(notified, Equals, false)
 	c.Check(monitored, Equals, false)
-	c.Check(s.state.Cached("auto-refresh-continue-attempt"), Equals, 1)
+
+	c.Assert(findChange(s.state, "auto-refresh"), NotNil)
+}
+
+func findChange(st *state.State, kind string) *state.Change {
+	for _, chg := range st.Changes() {
+		if chg.Kind() == kind {
+			return chg
+		}
+	}
+
+	return nil
 }
 
 func (s *snapmgrTestSuite) TestDownloadTaskMonitorsSnapStoppedAndNotifiesOnSoftCheckFail(c *C) {
@@ -9408,12 +9422,19 @@ func (s *snapmgrTestSuite) TestDownloadTaskMonitorsSnapStoppedAndNotifiesOnSoftC
 		},
 		Flags: snapstate.Flags{IsAutoRefresh: true},
 	}
+	s.state.Set("refresh-candidates", map[string]*snapstate.RefreshCandidate{
+		"foo": {SnapSetup: *snapsup},
+	})
 
 	var softChecked bool
+	inhibited := true
 	restore := snapstate.MockRefreshAppsCheck(func(info *snap.Info) error {
 		c.Assert(info.InstanceName(), Equals, "foo")
 		softChecked = true
-		return snapstate.NewBusySnapError(info, []int{123}, nil, nil)
+		if inhibited {
+			return snapstate.NewBusySnapError(info, []int{123}, nil, nil)
+		}
+		return nil
 	})
 	defer restore()
 
@@ -9449,22 +9470,31 @@ func (s *snapmgrTestSuite) TestDownloadTaskMonitorsSnapStoppedAndNotifiesOnSoftC
 	c.Check(notified, Equals, true)
 	c.Assert(monitorSignal, NotNil)
 
+	var hints map[string]*snapstate.RefreshCandidate
+	err := s.state.Get("refresh-candidates", &hints)
+	c.Assert(err, IsNil)
+	c.Assert(hints, HasLen, 1)
+	c.Assert(hints["foo"].Monitored, Equals, true)
+
 	monitored := s.state.Cached("monitored-snaps")
 	c.Assert(monitored, FitsTypeOf, map[string]chan<- bool{})
 	c.Assert(monitored.(map[string]chan<- bool)["foo"], NotNil)
-	c.Assert(s.state.Cached("auto-refresh-continue-attempt"), Equals, nil)
 
 	// signal snap has stopped and wait for pending goroutine to finish
 	s.state.Unlock()
+	inhibited = false
 	monitorSignal <- "foo"
 
 	waitForMonitoringEnd(s.state, c)
 
 	s.state.Lock()
 	defer s.state.Unlock()
+	s.settle(c)
 	c.Assert(s.state.Cached("monitored-snaps"), IsNil)
-	c.Check(s.state.Cached("auto-refresh-continue-attempt"), Equals, 1)
 
+	// the refresh-candidates are removed at the end of the change (see pruneRefreshCandidates)
+	err = s.state.Get("refresh-candidates", &hints)
+	c.Assert(err, testutil.ErrorIs, &state.NoStateError{})
 }
 
 func (s *snapmgrTestSuite) TestDownloadTaskMonitorsRepeated(c *C) {
@@ -9488,12 +9518,19 @@ func (s *snapmgrTestSuite) TestDownloadTaskMonitorsRepeated(c *C) {
 		},
 		Flags: snapstate.Flags{IsAutoRefresh: true},
 	}
+	s.state.Set("refresh-candidates", map[string]*snapstate.RefreshCandidate{
+		"foo": {SnapSetup: *snapsup},
+	})
 
 	var softChecked bool
+	inhibited := true
 	restore := snapstate.MockRefreshAppsCheck(func(info *snap.Info) error {
 		c.Assert(info.InstanceName(), Equals, "foo")
 		softChecked = true
-		return snapstate.NewBusySnapError(info, []int{123}, nil, nil)
+		if inhibited {
+			return snapstate.NewBusySnapError(info, []int{123}, nil, nil)
+		}
+		return nil
 	})
 	defer restore()
 
@@ -9526,9 +9563,10 @@ func (s *snapmgrTestSuite) TestDownloadTaskMonitorsRepeated(c *C) {
 	c.Assert(monitored, FitsTypeOf, map[string]chan<- bool{})
 	c.Assert(monitored.(map[string]chan<- bool)["foo"], NotNil)
 	c.Assert(notified, Equals, true)
+
 	// waiting for the monitoring to end
 	c.Check(s.state.Cached("monitored-snaps"), NotNil)
-	c.Check(s.state.Cached("auto-refresh-continue-attempt"), Equals, nil)
+	c.Assert(findChange(s.state, "auto-refresh"), IsNil)
 
 	// start a new pre-download which shouldn't start monitoring
 	preDlChg = s.state.NewChange("pre-download", "pre-download change")
@@ -9550,10 +9588,14 @@ func (s *snapmgrTestSuite) TestDownloadTaskMonitorsRepeated(c *C) {
 	// didn't wait for snap to stop because there's already a goroutine doing it
 	c.Check(monitorSignal, IsNil)
 
-	// unblock goroutine to finish
+	// make sure nothing is left running
 	s.state.Unlock()
-	defer s.state.Lock()
+	inhibited = false
 	firstMonitorSignal <- "foo"
+	waitForMonitoringEnd(s.state, c)
+	s.state.Lock()
+
+	s.settle(c)
 }
 
 func (s *snapmgrTestSuite) TestUnlinkMonitorSnapOnHardCheckFailure(c *C) {
@@ -9604,13 +9646,12 @@ func (s *snapmgrTestSuite) TestUnlinkMonitorSnapOnHardCheckFailure(c *C) {
 		case 2:
 			return snapstate.NewBusySnapError(info, []int{123}, nil, nil)
 		default:
-			c.Errorf("only expected 2 checks, now on %d", check)
-			return errors.New("unexpected refresh check")
+			return nil
 		}
 	})
 	defer restore()
 
-	updated, tss, err := snapstate.AutoRefresh(context.Background(), s.state, nil)
+	updated, tss, err := snapstate.AutoRefresh(context.Background(), s.state)
 	c.Assert(err, IsNil)
 	c.Check(updated, DeepEquals, []string{"some-snap"})
 	c.Assert(tss, NotNil)
@@ -9632,7 +9673,14 @@ func (s *snapmgrTestSuite) TestUnlinkMonitorSnapOnHardCheckFailure(c *C) {
 	monitored := s.state.Cached("monitored-snaps")
 	c.Assert(monitored, FitsTypeOf, map[string]chan<- bool{})
 	c.Assert(monitored.(map[string]chan<- bool)["some-snap"], NotNil)
-	close(monitorSignal)
+
+	// cleanup leftover routines
+	s.state.Unlock()
+	monitorSignal <- "some-snap"
+	waitForMonitoringEnd(s.state, c)
+
+	s.state.Lock()
+	s.settle(c)
 }
 
 func (s *snapmgrTestSuite) TestDeletedMonitoredMapIsCorrectlyDeleted(c *C) {
@@ -9655,10 +9703,16 @@ func (s *snapmgrTestSuite) TestDeletedMonitoredMapIsCorrectlyDeleted(c *C) {
 		},
 		Flags: snapstate.Flags{IsAutoRefresh: true},
 	}
+	s.state.Set("refresh-candidates", map[string]*snapstate.RefreshCandidate{
+		"foo": {SnapSetup: *snapsup},
+	})
 
+	inhibited := true
 	restore := snapstate.MockRefreshAppsCheck(func(info *snap.Info) error {
-		return snapstate.NewBusySnapError(info, []int{123}, nil, nil)
-
+		if inhibited {
+			return snapstate.NewBusySnapError(info, []int{123}, nil, nil)
+		}
+		return nil
 	})
 	defer restore()
 
@@ -9682,6 +9736,9 @@ func (s *snapmgrTestSuite) TestDeletedMonitoredMapIsCorrectlyDeleted(c *C) {
 
 	// unblock the monitoring routine which will delete the "monitored-snaps" map
 	s.state.Unlock()
+
+	// let the continuing logic create an auto-refresh change
+	inhibited = false
 	monitorSignal <- "foo"
 	waitForMonitoringEnd(s.state, c)
 
@@ -9695,34 +9752,43 @@ func (s *snapmgrTestSuite) TestDeletedMonitoredMapIsCorrectlyDeleted(c *C) {
 	preDlTask.Set("refresh-info", &userclient.PendingSnapRefreshInfo{InstanceName: "foo"})
 	preDlChg.AddTask(preDlTask)
 
+	// so we go into the monitoring
+	inhibited = true
+
 	s.settle(c)
 	c.Assert(preDlChg.Status(), Equals, state.DoneStatus)
 
+	// wait until the 2nd auto-refresh starts
 	s.state.Unlock()
+	inhibited = false
 	monitorSignal <- "foo"
-	waitForMonitoringEnd(s.state, c)
-
+	waitFor(s.state, c, func() bool { return s.state.Change("4") != nil })
 	s.state.Lock()
-	defer s.state.Unlock()
+	c.Assert(s.state.Change("4").Kind(), Equals, "auto-refresh")
+	s.settle(c)
+
 	c.Assert(s.state.Cached("monitored-snaps"), IsNil)
-	c.Check(s.state.Cached("auto-refresh-continue-attempt"), Equals, 1)
+}
+
+func waitFor(st *state.State, c *C, cond func() bool) {
+	for i := 0; i < 5; i++ {
+		st.Lock()
+		condMet := cond()
+		st.Unlock()
+		if condMet {
+			return
+		}
+
+		<-time.After(time.Second)
+	}
+
+	c.Fatal("condition wasn't met within 5 seconds")
 }
 
 func waitForMonitoringEnd(st *state.State, c *C) {
-	for i := 0; i < 5; i++ {
-		<-time.After(time.Second)
-		st.Lock()
-		finished := st.Cached("auto-refresh-continue-attempt")
-		if finished == nil {
-			st.Unlock()
-			continue
-		}
-
-		st.Unlock()
-		return
-	}
-
-	c.Fatal("couldn't check monitoring goroutine finished properly")
+	waitFor(st, c, func() bool {
+		return findChange(st, "auto-refresh") != nil
+	})
 }
 
 func (s *snapmgrTestSuite) TestPreDownloadWithIgnoreRunningRefresh(c *C) {
@@ -9746,6 +9812,9 @@ func (s *snapmgrTestSuite) TestPreDownloadWithIgnoreRunningRefresh(c *C) {
 		},
 		Flags: snapstate.Flags{IsAutoRefresh: true},
 	}
+	s.state.Set("refresh-candidates", map[string]*snapstate.RefreshCandidate{
+		"some-snap": {SnapSetup: *snapsup},
+	})
 
 	restore := snapstate.MockAsyncPendingRefreshNotification(func(ctx context.Context, client *userclient.Client, refreshInfo *userclient.PendingSnapRefreshInfo) {})
 	defer restore()
@@ -9867,13 +9936,17 @@ func (s *snapmgrTestSuite) TestMonitoringIsPersistedAndRestored(c *C) {
 		},
 		Flags: snapstate.Flags{IsAutoRefresh: true},
 	}
+	// simulate a restart with an in-progress monitoring
+	s.state.Set("refresh-candidates", map[string]*snapstate.RefreshCandidate{
+		"some-snap": {SnapSetup: *snapsup, Monitored: true},
+	})
 
+	var notified bool
 	restore := snapstate.MockAsyncPendingRefreshNotification(func(ctx context.Context, client *userclient.Client, refreshInfo *userclient.PendingSnapRefreshInfo) {})
 	defer restore()
 
 	restore = snapstate.MockRefreshAppsCheck(func(info *snap.Info) error {
-		c.Assert(info.InstanceName(), Equals, "some-snap")
-		return snapstate.NewBusySnapError(info, []int{123}, nil, nil)
+		return nil
 	})
 	defer restore()
 
@@ -9885,45 +9958,33 @@ func (s *snapmgrTestSuite) TestMonitoringIsPersistedAndRestored(c *C) {
 	})
 	defer restore()
 
-	preDlChg := s.state.NewChange("pre-download", "pre-download change")
-	preDlTask := s.state.NewTask("pre-download-snap", "pre-download task")
+	s.state.Unlock()
+	defer s.state.Lock()
+	af := snapstate.NewAutoRefresh(s.state)
+	err := af.Ensure()
+	c.Check(err, IsNil)
 
-	preDlTask.Set("snap-setup", snapsup)
-	preDlTask.Set("refresh-info", &userclient.PendingSnapRefreshInfo{InstanceName: "some-snap"})
-	preDlChg.AddTask(preDlTask)
+	// restores monitoring but doesn't notify again
+	c.Assert(stopMonitor, NotNil)
+	c.Assert(notified, Equals, false)
 
+	s.state.Lock()
+	abortChans := s.state.Cached("monitored-snaps").(map[string]chan<- bool)
+	abortChan := abortChans["some-snap"]
+	s.state.Unlock()
+	c.Assert(abortChan, NotNil)
+
+	stopMonitor <- "some-snap"
+	waitForMonitoringEnd(s.state, c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
 	s.settle(c)
 
-	c.Assert(preDlTask.Status(), Equals, state.DoneStatus)
-	// check there's still a goroutine monitoring the snap
-	monitoring := s.state.Cached("monitored-snaps")
-	c.Assert(monitoring, FitsTypeOf, map[string]chan<- bool{})
-	c.Assert(monitoring.(map[string]chan<- bool)["some-snap"], NotNil)
-
-	var monitored []string
-	c.Assert(s.state.Get("monitored-snaps", &monitored), IsNil)
-	c.Assert(monitored, DeepEquals, []string{"some-snap"})
-
-	// simulate a restart by stopping the monitoring but removing its effects
-	stopMonitor <- "some-snap"
-	s.state.Unlock()
-	waitForMonitoringEnd(s.state, c)
-
-	s.state.Lock()
-	s.state.Cache("monitored-snaps", nil)
-	s.state.Cache("auto-refresh-continue-attempt", nil)
-	s.state.Set("monitored-snaps", monitored)
-	snapstate.SetRestoredMonitoring(s.snapmgr, false)
-	s.state.Unlock()
-
-	// the first Ensure sets up the monitoring again
-	c.Assert(s.snapmgr.Ensure(), IsNil)
-	stopMonitor <- "some-snap"
-	waitForMonitoringEnd(s.state, c)
-	s.state.Lock()
-
-	c.Assert(s.state.Cached("monitored-snaps"), IsNil)
-	c.Check(s.state.Cached("auto-refresh-continue-attempt"), Equals, 1)
+	// the refresh-candidates are removed at the end of the change (see pruneRefreshCandidates)
+	var hints map[string]*snapstate.RefreshCandidate
+	err = s.state.Get("refresh-candidates", &hints)
+	c.Assert(err, testutil.ErrorIs, &state.NoStateError{})
 }
 
 func (s *snapmgrTestSuite) testUpdateDowngradeBlockedByOtherChanges(c *C, old, new string, revert bool) error {

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -9397,8 +9397,7 @@ func (s *snapmgrTestSuite) TestPreDownloadTaskContinuesAutoRefreshIfSoftCheckOk(
 
 	// check that the auto-refresh was completed without asking the store for refresh info
 	c.Assert(s.fakeBackend.ops.Count("storesvc-snap-action"), Equals, 0)
-	// the opts are nil because the fake store backend doesn't keep the opts if every field is empty
-	c.Assert(s.fakeStore.downloads[1].opts, IsNil)
+	c.Assert(s.fakeStore.downloads, HasLen, 2)
 }
 
 func findChange(st *state.State, kind string) *state.Change {
@@ -9514,8 +9513,7 @@ func (s *snapmgrTestSuite) TestDownloadTaskMonitorsSnapStoppedAndNotifiesOnSoftC
 
 	// check that the auto-refresh was completed without asking the store for refresh info
 	c.Assert(s.fakeBackend.ops.Count("storesvc-snap-action"), Equals, 0)
-	// the opts are nil because the fake store backend doesn't keep the opts if every field is empty
-	c.Assert(s.fakeStore.downloads[1].opts, IsNil)
+	c.Assert(s.fakeStore.downloads, HasLen, 2)
 }
 
 func (s *snapmgrTestSuite) TestDownloadTaskMonitorsRepeated(c *C) {


### PR DESCRIPTION
This addresses the [issue of Firefox auto-refreshes not being continued](https://bugs.launchpad.net/snapd/+bug/2019158) after the user stops the snap. The root cause is that the second auto-refresh doesn't always get a consistent response from the store. That is, the first auto-refresh might get a new revision but, if it's inhibited by a running snap, the next auto-refresh might not. This only happens for Firefox (to my knowledge) because the store only throttles Firefox, to reduce the load on its servers. This PR uses the refresh hints written during the auto-refresh (added [here](https://github.com/snapcore/snapd/pull/12946)) to continue the auto-refresh without relying on the store to return the same information.