### PR TITLE
snap-{seccomp,confine}: rework seccomp denylist

### DIFF
--- a/cmd/snap-confine/seccomp-support.c
+++ b/cmd/snap-confine/seccomp-support.c
@@ -115,14 +115,14 @@ bool sc_apply_seccomp_profile_for_security_tag(const char *security_tag) {
 	char profile_path[PATH_MAX] = { 0 };
 
 	struct sock_fprog SC_CLEANUP(sc_cleanup_seccomp_profile) prog_allow = { 0 };
-	sc_must_snprintf(profile_path, sizeof(profile_path), "%s/%s.bin.allow",
+	sc_must_snprintf(profile_path, sizeof(profile_path), "%s/%s/filter.allow",
 			 filter_profile_dir, security_tag);
 	if (!sc_load_seccomp_profile_path(profile_path, &prog_allow)) {
 	   return false;
 	}
 
 	struct sock_fprog SC_CLEANUP(sc_cleanup_seccomp_profile) prog_deny  = { 0 };
-	sc_must_snprintf(profile_path, sizeof(profile_path), "%s/%s.bin.deny",
+	sc_must_snprintf(profile_path, sizeof(profile_path), "%s/%s/filter.deny",
 			 filter_profile_dir, security_tag);
 	if (!sc_load_seccomp_profile_path(profile_path, &prog_deny)) {
 	   return false;

--- a/cmd/snap-confine/seccomp-support.c
+++ b/cmd/snap-confine/seccomp-support.c
@@ -114,28 +114,29 @@ bool sc_apply_seccomp_profile_for_security_tag(const char *security_tag) {
 
 	char profile_path[PATH_MAX] = { 0 };
 
-        struct sock_fprog prog_allow = { 0 };
+	struct sock_fprog SC_CLEANUP(sc_cleanup_seccomp_profile) prog_allow = { 0 };
 	sc_must_snprintf(profile_path, sizeof(profile_path), "%s/%s.bin.allow",
 			 filter_profile_dir, security_tag);
-        if (!sc_load_seccomp_profile_path(profile_path, &prog_allow)) {
-           return false;
-        }
+	if (!sc_load_seccomp_profile_path(profile_path, &prog_allow)) {
+	   return false;
+	}
 
-        struct sock_fprog prog_deny  = { 0 };
+	struct sock_fprog SC_CLEANUP(sc_cleanup_seccomp_profile) prog_deny  = { 0 };
 	sc_must_snprintf(profile_path, sizeof(profile_path), "%s/%s.bin.deny",
 			 filter_profile_dir, security_tag);
-        if (!sc_load_seccomp_profile_path(profile_path, &prog_deny)) {
-           return false;
-        }
+	if (!sc_load_seccomp_profile_path(profile_path, &prog_deny)) {
+	   return false;
+	}
 
-        sc_apply_seccomp_filter(&prog_deny);
-        sc_apply_seccomp_filter(&prog_allow);
+	sc_apply_seccomp_filter(&prog_deny);
+	sc_apply_seccomp_filter(&prog_allow);
 
-        // XXX: this is not ideal, allocation happens in
-        // sc_load_seccomp_profile but free here :(
-        free(prog_allow.filter);
-        free(prog_deny.filter);
-        return true;
+	return true;
+}
+
+void sc_cleanup_seccomp_profile(struct sock_fprog *prog) {
+	free(prog->filter);
+	prog->filter = NULL;
 }
 
 bool sc_load_seccomp_profile_path(const char *profile_path, struct sock_fprog *prog)

--- a/cmd/snap-confine/seccomp-support.h
+++ b/cmd/snap-confine/seccomp-support.h
@@ -19,6 +19,10 @@
 
 #include <stdbool.h>
 
+#include <linux/filter.h>
+
+bool sc_load_seccomp_profile_path(const char *profile_path, struct sock_fprog *prog);
+
 /** 
  * sc_apply_seccomp_profile_for_security_tag applies a seccomp profile to the
  * current process. The filter is loaded from a pre-compiled bpf bytecode

--- a/cmd/snap-confine/seccomp-support.h
+++ b/cmd/snap-confine/seccomp-support.h
@@ -21,8 +21,6 @@
 
 #include <linux/filter.h>
 
-bool sc_load_seccomp_profile_path(const char *profile_path, struct sock_fprog *prog);
-
 /** 
  * sc_apply_seccomp_profile_for_security_tag applies a seccomp profile to the
  * current process. The filter is loaded from a pre-compiled bpf bytecode
@@ -49,6 +47,22 @@ bool sc_load_seccomp_profile_path(const char *profile_path, struct sock_fprog *p
  **/
 bool sc_apply_seccomp_profile_for_security_tag(const char *security_tag);
 
+/** sc_apply_global_seccomp_profile applies the global seccomp profile
+ **/
 void sc_apply_global_seccomp_profile(void);
+
+/**
+ * sc_load_seccomp_profile_path loads the seccomp profile from the given
+ * profile_path into the given sock_fprog. The sock_fprog needs to be
+ * freed with sc_cleanup_seccomp_profile() later.
+ *
+ * The return value indicates if the loading was successful.
+ **/
+bool sc_load_seccomp_profile_path(const char *profile_path, struct sock_fprog *prog);
+
+/**
+ * sc_cleanup_seccomp_profile frees the dynamic memory from sock_fprog.
+ **/
+void sc_cleanup_seccomp_profile(struct sock_fprog *prog);
 
 #endif

--- a/cmd/snap-seccomp/main_test.go
+++ b/cmd/snap-seccomp/main_test.go
@@ -366,7 +366,9 @@ mprotect
 		}
 	}
 
-	cmd := exec.Command(s.seccompBpfLoader, bpfPath+".allow", bpfPath+".deny", syscallRunner, syscallRunnerArgs[0], syscallRunnerArgs[1], syscallRunnerArgs[2], syscallRunnerArgs[3], syscallRunnerArgs[4], syscallRunnerArgs[5], syscallRunnerArgs[6])
+	pathAllow := filepath.Join(bpfPath, "filter.allow")
+	pathDeny := filepath.Join(bpfPath, "filter.deny")
+	cmd := exec.Command(s.seccompBpfLoader, pathAllow, pathDeny, syscallRunner, syscallRunnerArgs[0], syscallRunnerArgs[1], syscallRunnerArgs[2], syscallRunnerArgs[3], syscallRunnerArgs[4], syscallRunnerArgs[5], syscallRunnerArgs[6])
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -396,8 +398,8 @@ func (s *snapSeccompSuite) TestUnrestricted(c *C) {
 	err := main.Compile([]byte(inp), outPath)
 	c.Assert(err, IsNil)
 
-	c.Check(outPath+".allow", testutil.FileEquals, inp)
-	c.Check(outPath+".deny", testutil.FileEquals, inp)
+	c.Check(filepath.Join(outPath, "filter.allow"), testutil.FileEquals, inp)
+	c.Check(filepath.Join(outPath, "filter.deny"), testutil.FileEquals, inp)
 }
 
 // TestCompile iterates over a range of textual seccomp whitelist rules and

--- a/interfaces/seccomp/backend.go
+++ b/interfaces/seccomp/backend.go
@@ -159,7 +159,7 @@ func bpfSrcPath(srcName string) string {
 }
 
 func bpfBinPath(srcName string) string {
-	return filepath.Join(dirs.SnapSeccompDir, strings.TrimSuffix(srcName, ".src")+".bin")
+	return filepath.Join(dirs.SnapSeccompDir, strings.TrimSuffix(srcName, ".src"))
 }
 
 func parallelCompile(compiler Compiler, profiles []string) error {
@@ -195,7 +195,7 @@ func parallelCompile(compiler Compiler, profiles []string) error {
 				// remove the old profile first so that we are
 				// not loading it accidentally should the
 				// compilation fail
-				if err := os.Remove(out); err != nil && !os.IsNotExist(err) {
+				if err := os.RemoveAll(out); err != nil && !os.IsNotExist(err) {
 					res <- err
 					continue
 				}

--- a/interfaces/seccomp/backend.go
+++ b/interfaces/seccomp/backend.go
@@ -280,7 +280,7 @@ func (b *Backend) Setup(snapInfo *snap.Info, opts interfaces.ConfinementOptions,
 		return fmt.Errorf("cannot synchronize security files for snap %q: %s", snapName, err)
 	}
 	for _, c := range removed {
-		err := os.Remove(bpfBinPath(c))
+		err := os.RemoveAll(bpfBinPath(c))
 		if err != nil && !os.IsNotExist(err) {
 			return err
 		}

--- a/interfaces/seccomp/backend.go
+++ b/interfaces/seccomp/backend.go
@@ -291,10 +291,13 @@ func (b *Backend) Setup(snapInfo *snap.Info, opts interfaces.ConfinementOptions,
 
 // Remove removes seccomp profiles of a given snap.
 func (b *Backend) Remove(snapName string) error {
+	if err := os.RemoveAll(bpfBinPath(snapName)); err != nil {
+		return fmt.Errorf("cannot remove bpf security files for snap %q: %s", snapName, err)
+	}
 	glob := interfaces.SecurityTagGlob(snapName)
 	_, _, err := osutil.EnsureDirState(dirs.SnapSeccompDir, glob, nil)
 	if err != nil {
-		return fmt.Errorf("cannot synchronize security files for snap %q: %s", snapName, err)
+		return fmt.Errorf("cannot remove bpf security files for snap %q: %s", snapName, err)
 	}
 	return nil
 }

--- a/interfaces/seccomp/template.go
+++ b/interfaces/seccomp/template.go
@@ -205,14 +205,7 @@ inotify_rm_watch
 # TODO: this should be scaled back even more
 ~ioctl - TIOCSTI
 ~ioctl - TIOCLINUX
-# restrict argument otherwise will match all uses of ioctl() and allow the rules
-# that were disallowed above
-# TODO: Fix the need to keep TIOCLINUX here - the issue is a unrestricted
-#       allow for "ioctl" here makes libseccomp "optimize" the deny rules
-#       above away and the generated bpf becomes just "allow ioctl".
-#       We should fix this by creating a way to make "AND" rules, so
-#       this becomes "ioctl - !TIOCSTI&&!TIOCLINUX" and remove the "~" again.
-ioctl - !TIOCSTI
+ioctl
 
 io_cancel
 io_destroy

--- a/osutil/syncdir.go
+++ b/osutil/syncdir.go
@@ -161,7 +161,8 @@ func EnsureDirStateGlobs(dir string, globs []string, content map[string]FileStat
 		if content[baseName] != nil {
 			continue
 		}
-		err := os.Remove(path)
+		// XXX: option?
+		err := os.RemoveAll(path)
 		if err != nil {
 			if firstErr == nil {
 				firstErr = err

--- a/tests/main/security-seccomp/task.yaml
+++ b/tests/main/security-seccomp/task.yaml
@@ -93,10 +93,14 @@ execute: |
     echo "and check that negative nice fails"
     test-snapd-setpriority -10 | MATCH 'Operation not permitted \(EPERM\)'
 
+    # TODO: filtering on setpriority is a bit confusing as it is not part
+    # of the "negative args" filter added in ec7c9f27c97 so the fact that
+    # negative args are denied is a bit magic
     echo "Explicitly deny arg filtered setpriority rule"
-    sed 's/^\(setpriority.*\)/~\1/g' "$SRC".orig > "$SRC"
+    cp -a "$SRC".orig "$SRC"
+    echo '~setpriority PRIO_PROCESS 0 >10' >> "$SRC"
     snapd.tool exec snap-seccomp compile "$SRC" "$BIN"
-    echo "and check that positive nice fails with explicit denial"
-    test-snapd-setpriority 10  | MATCH 'Insufficient privileges \(EACCES\)'
+    echo "and check that explicit requested fails with explicit denial"
+    test-snapd-setpriority 11  | MATCH 'Insufficient privileges \(EACCES\)'
     echo "and check that negative nice still fails with implicit denial"
     test-snapd-setpriority -10 | MATCH 'Operation not permitted \(EPERM\)'

--- a/tests/main/security-seccomp/task.yaml
+++ b/tests/main/security-seccomp/task.yaml
@@ -25,7 +25,7 @@ details: |
 
 environment:
     SRC: /var/lib/snapd/seccomp/bpf/snap.test-snapd-setpriority.test-snapd-setpriority.src
-    BIN: /var/lib/snapd/seccomp/bpf/snap.test-snapd-setpriority.test-snapd-setpriority.bin
+    BIN: /var/lib/snapd/seccomp/bpf/snap.test-snapd-setpriority.test-snapd-setpriority
     AAP: /var/lib/snapd/apparmor/profiles/snap.test-snapd-setpriority.test-snapd-setpriority
 
 prepare: |

--- a/tests/main/snap-seccomp/task.yaml
+++ b/tests/main/snap-seccomp/task.yaml
@@ -86,7 +86,7 @@ execute: |
     fi
 
     echo "Break snapd.test-snapd-sh filters to ensure (kernel) validation works"
-    for ext in filter.allow filter.deny; do
+    for f in filter.allow filter.deny; do
         dd if=/dev/urandom of="${PROFILE}/$f" count=1 bs=1024
         if output=$(test-snapd-sh.sh -c 'echo hello' 2>&1 ); then
             echo "test-snapd-sh.sh should fail with invalid seccomp profile"

--- a/tests/main/snap-seccomp/task.yaml
+++ b/tests/main/snap-seccomp/task.yaml
@@ -1,8 +1,6 @@
 summary: Ensure that the snap-seccomp bpf handling works
 
-# FIXME: once $(snap debug confinment) can be used (in 2.27+) remove
-#        the systems line
-systems: [ubuntu-16*, ubuntu-18*]
+systems: [ubuntu-*]
 
 # Start early as it takes a long time.
 priority: 100
@@ -25,7 +23,7 @@ execute: |
 
     # from the old test_complain
     echo "Test that the @complain keyword works"
-    rm -f "${PROFILE}.bin"
+    rm -f "${PROFILE}.bin"*
     cat >"${PROFILE}.src" <<EOF
     # some comment
     @complain
@@ -35,7 +33,7 @@ execute: |
     test-snapd-sh.sh -c 'echo hello' | MATCH hello
 
     # from the old test_complain_missed
-    rm -f "${PROFILE}.bin"
+    rm -f "${PROFILE}.bin"*
     cat >"${PROFILE}.src" <<EOF
     # super strict filter
     @complai
@@ -53,7 +51,7 @@ execute: |
     
     # from the old test_unrestricted
     echo "Test that the @unrestricted keyword works"
-    rm -f "${PROFILE}.bin"
+    rm -f "${PROFILE}.bin"*
     cat >"${PROFILE}.src" <<EOF
     # some comment
     @unrestricted
@@ -63,7 +61,7 @@ execute: |
     test-snapd-sh.sh -c 'echo hello' | MATCH hello
 
     # from the old test_unrestricted_missed
-    rm -f "${PROFILE}.bin"
+    rm -f "${PROFILE}.bin"*
     cat >"${PROFILE}.src" <<EOF
     # super strict filter
     @unrestricte
@@ -80,7 +78,7 @@ execute: |
     fi
 
     # from the old test_noprofile
-    rm -f "${PROFILE}.bin"
+    rm -f "${PROFILE}.bin"*
     echo "Ensure the code cannot not run due to missing filter"
     if SNAP_CONFINE_MAX_PROFILE_WAIT=3 test-snapd-sh.sh -c 'echo hello'; then
         echo "filtering broken: program should have failed to run"
@@ -88,31 +86,35 @@ execute: |
     fi
 
     echo "Break snapd.test-snapd-sh.bin to ensure (kernel) validation works"
-    dd if=/dev/urandom of="${PROFILE}.bin" count=1 bs=1024
-    if output=$(test-snapd-sh.sh -c 'echo hello' 2>&1 ); then
-        echo "test-snapd-sh.sh should fail with invalid seccomp profile"
-        exit 1
-    fi
+    for ext in allow deny; do
+        dd if=/dev/urandom of="${PROFILE}.bin.$ext" count=1 bs=1024
+        if output=$(test-snapd-sh.sh -c 'echo hello' 2>&1 ); then
+            echo "test-snapd-sh.sh should fail with invalid seccomp profile"
+            exit 1
+        fi
+    done
     echo "$output" | MATCH "cannot apply seccomp profile: Invalid argument"
 
     echo "Add huge snapd.test-snapd-sh.bin to ensure size limit works"
-    dd if=/dev/zero of="${PROFILE}.bin" count=50 bs=1M
-    if output=$(test-snapd-sh.sh -c 'echo hello' 2>&1 ); then
-        echo "test-snapd-sh.sh should fail with big seccomp profile"
-        exit 1
-    fi
+    for ext in allow deny; do
+        dd if=/dev/zero of="${PROFILE}.bin.$ext" count=50 bs=1M
+        if output=$(test-snapd-sh.sh -c 'echo hello' 2>&1 ); then
+            echo "test-snapd-sh.sh should fail with big seccomp profile"
+            exit 1
+        fi
+    done
     echo "$output" | MATCH "cannot fit .* to memory buffer"
 
     
     echo "Ensure the code cannot not run with a missing .bin profile"
-    rm -f "${PROFILE}.bin"
+    rm -f "${PROFILE}.bin"*
     if test-snapd-sh.sh -c 'echo hello'; then
         echo "filtering broken: program should have failed to run"
         exit 1
     fi
 
     echo "Ensure the code cannot not run with an empty seccomp profile"
-    rm -f "${PROFILE}.bin"
+    rm -f "${PROFILE}.bin"*
     echo "" > "${PROFILE}.src"
     $SNAP_SECCOMP compile "${PROFILE}.src" "${PROFILE}.bin"
     if test-snapd-sh.sh -c 'echo hello'; then
@@ -121,7 +123,7 @@ execute: |
     fi
 
     echo "Ensure snap-confine waits for security profiles to appear"
-    rm -f "${PROFILE}.bin"
+    rm -f "${PROFILE}.bin"*
     cat >"${PROFILE}.src" <<EOF
     @unrestricted
     EOF

--- a/tests/main/snap-seccomp/task.yaml
+++ b/tests/main/snap-seccomp/task.yaml
@@ -23,17 +23,17 @@ execute: |
 
     # from the old test_complain
     echo "Test that the @complain keyword works"
-    rm -f "${PROFILE}.bin"*
+    rm -rf "${PROFILE}"
     cat >"${PROFILE}.src" <<EOF
     # some comment
     @complain
     EOF
-    $SNAP_SECCOMP compile "${PROFILE}.src" "${PROFILE}.bin"
+    $SNAP_SECCOMP compile "${PROFILE}.src" "${PROFILE}"
     echo "Ensure the code still runs"
     test-snapd-sh.sh -c 'echo hello' | MATCH hello
 
     # from the old test_complain_missed
-    rm -f "${PROFILE}.bin"*
+    rm -rf "${PROFILE}"
     cat >"${PROFILE}.src" <<EOF
     # super strict filter
     @complai
@@ -42,7 +42,7 @@ execute: |
     @COMPLAIN
     complain
     EOF
-    $SNAP_SECCOMP compile "${PROFILE}.src" "${PROFILE}.bin"
+    $SNAP_SECCOMP compile "${PROFILE}.src" "${PROFILE}"
     echo "Ensure the code cannot not run due to impossible filtering"
     if test-snapd-sh.sh -c 'echo hello'; then
         echo "filtering broken: program should have failed to run"
@@ -51,17 +51,17 @@ execute: |
     
     # from the old test_unrestricted
     echo "Test that the @unrestricted keyword works"
-    rm -f "${PROFILE}.bin"*
+    rm -rf "${PROFILE}"
     cat >"${PROFILE}.src" <<EOF
     # some comment
     @unrestricted
     EOF
-    $SNAP_SECCOMP compile "${PROFILE}.src" "${PROFILE}.bin"
+    $SNAP_SECCOMP compile "${PROFILE}.src" "${PROFILE}"
     echo "Ensure the code still runs"
     test-snapd-sh.sh -c 'echo hello' | MATCH hello
 
     # from the old test_unrestricted_missed
-    rm -f "${PROFILE}.bin"*
+    rm -rf "${PROFILE}"
     cat >"${PROFILE}.src" <<EOF
     # super strict filter
     @unrestricte
@@ -70,7 +70,7 @@ execute: |
     @UNRESTRICTED
     unrestricted
     EOF
-    $SNAP_SECCOMP compile "${PROFILE}.src" "${PROFILE}.bin"
+    $SNAP_SECCOMP compile "${PROFILE}.src" "${PROFILE}"
     echo "Ensure the code cannot not run due to impossible filtering"
     if test-snapd-sh.sh -c 'echo hello'; then
         echo "filtering broken: program should have failed to run"
@@ -78,16 +78,16 @@ execute: |
     fi
 
     # from the old test_noprofile
-    rm -f "${PROFILE}.bin"*
+    rm -rf "${PROFILE}"
     echo "Ensure the code cannot not run due to missing filter"
     if SNAP_CONFINE_MAX_PROFILE_WAIT=3 test-snapd-sh.sh -c 'echo hello'; then
         echo "filtering broken: program should have failed to run"
         exit 1
     fi
 
-    echo "Break snapd.test-snapd-sh.bin to ensure (kernel) validation works"
-    for ext in allow deny; do
-        dd if=/dev/urandom of="${PROFILE}.bin.$ext" count=1 bs=1024
+    echo "Break snapd.test-snapd-sh filters to ensure (kernel) validation works"
+    for ext in filter.allow filter.deny; do
+        dd if=/dev/urandom of="${PROFILE}/$f" count=1 bs=1024
         if output=$(test-snapd-sh.sh -c 'echo hello' 2>&1 ); then
             echo "test-snapd-sh.sh should fail with invalid seccomp profile"
             exit 1
@@ -95,9 +95,9 @@ execute: |
     done
     echo "$output" | MATCH "cannot apply seccomp profile: Invalid argument"
 
-    echo "Add huge snapd.test-snapd-sh.bin to ensure size limit works"
-    for ext in allow deny; do
-        dd if=/dev/zero of="${PROFILE}.bin.$ext" count=50 bs=1M
+    echo "Add huge snapd.test-snapd-sh filters to ensure size limit works"
+    for f in filter.allow filter.deny; do
+        dd if=/dev/zero of="${PROFILE}/$f" count=50 bs=1M
         if output=$(test-snapd-sh.sh -c 'echo hello' 2>&1 ); then
             echo "test-snapd-sh.sh should fail with big seccomp profile"
             exit 1
@@ -106,28 +106,28 @@ execute: |
     echo "$output" | MATCH "cannot fit .* to memory buffer"
 
     
-    echo "Ensure the code cannot not run with a missing .bin profile"
-    rm -f "${PROFILE}.bin"*
+    echo "Ensure the code cannot not run with a missing filter profile"
+    rm -rf "${PROFILE}"
     if test-snapd-sh.sh -c 'echo hello'; then
         echo "filtering broken: program should have failed to run"
         exit 1
     fi
 
     echo "Ensure the code cannot not run with an empty seccomp profile"
-    rm -f "${PROFILE}.bin"*
+    rm -rf "${PROFILE}"
     echo "" > "${PROFILE}.src"
-    $SNAP_SECCOMP compile "${PROFILE}.src" "${PROFILE}.bin"
+    $SNAP_SECCOMP compile "${PROFILE}.src" "${PROFILE}"
     if test-snapd-sh.sh -c 'echo hello'; then
         echo "filtering broken: program should have failed to run"
         exit 1
     fi
 
     echo "Ensure snap-confine waits for security profiles to appear"
-    rm -f "${PROFILE}.bin"*
+    rm -rf "${PROFILE}"
     cat >"${PROFILE}.src" <<EOF
     @unrestricted
     EOF
-    ( (sleep 3; $SNAP_SECCOMP compile "${PROFILE}.src" "${PROFILE}.bin") &)
+    ( (sleep 3; $SNAP_SECCOMP compile "${PROFILE}.src" "${PROFILE}") &)
     echo "Ensure the code still runs"
     test-snapd-sh.sh -c 'echo hello' | MATCH hello
 


### PR DESCRIPTION
[DRAFT FOR NOW BECAUSE CODE NEEDS CLEANUP AND I WANT TO SEE THE SPREAD OUTPUT]
[but concept should be sound]

When a denylist was introduced in PR#12849 we reached the limits of the API of libseccomp and some things are now hard to reason about [1]. This is mostly because what we try to do does not match the libseccomp API very well and a slightly different approach is probably more aligned with it's design (see also this libseccomp issue [2] that is related to our issue).

So this commit changes the approach and instead of trying to use a single filter the work is split into two filters:
1. explicit allow list
2. explicit deny list

and then load both filters into the kernel. The way the kernel works is that it selects the most restrictive action.

So in the case of PR#12849:
```
~ioctl - TIOCSTI
~ioctl - TIOCLINUX
ioctl
```
For `ioctl(TIOCLINUX)` the first allow filter would pass `ioctl` but the second deny filter would correctly deny the TIOCLINUX.

[1] https://github.com/snapcore/snapd/pull/12849#discussion_r1206855700
[2] https://github.com/seccomp/libseccomp/issues/44
