### PR TITLE
daemon.go: fix typo

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -340,7 +340,7 @@ func (d *Daemon) Start() error {
 		logger.Noticef("adjusting startup timeout by %v (%s)", to, reasoning)
 		systemdSdNotify(fmt.Sprintf("EXTEND_TIMEOUT_USEC=%d", us))
 	}
-	// now perform expensive overlord/manages initiliazation
+	// now perform expensive overlord/manages initialization
 	if err := d.overlord.StartUp(); err != nil {
 		return err
 	}


### PR DESCRIPTION
I feel bad for even spending the minute to file this as it couldn't be more trivial.
But it is wrong and I could not unsee it while debugging the `systemdSdNotify` just above it.
So while being trivial, it was also trivial to submit this :-)

I haven't gone deeper, but seeing this maybe a mid term suggestion could be to sit down someone for 2h with a spell checker  for non-code, to fix what is broken now. And then afterwards add automatic PR spellchecks?