### PR TITLE
osutil/kcmdline.go: create separate pattern type for cmdline

### DIFF
--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -36,7 +36,7 @@ import (
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/bootloader/bootloadertest"
 	"github.com/snapcore/snapd/dirs"
-	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/osutil/kcmdline"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/seed"
@@ -72,7 +72,7 @@ func (s *baseBootenvSuite) SetUpTest(c *C) {
 	s.bootdir = filepath.Join(s.rootdir, "boot")
 
 	s.cmdlineFile = filepath.Join(c.MkDir(), "cmdline")
-	restore = osutil.MockProcCmdline(s.cmdlineFile)
+	restore = kcmdline.MockProcCmdline(s.cmdlineFile)
 	s.AddCleanup(restore)
 }
 
@@ -4163,7 +4163,7 @@ func (s *bootKernelCommandLineSuite) TestCommandLineUpdateUC20OverSpuriousReboot
 	cmdlineFile := filepath.Join(c.MkDir(), "cmdline")
 	err := ioutil.WriteFile(cmdlineFile, []byte("snapd_recovery_mode=run static mocked panic=-1"), 0644)
 	c.Assert(err, IsNil)
-	restore = osutil.MockProcCmdline(cmdlineFile)
+	restore = kcmdline.MockProcCmdline(cmdlineFile)
 	s.AddCleanup(restore)
 
 	err = s.bootloader.SetBootVars(map[string]string{
@@ -4284,7 +4284,7 @@ func (s *bootKernelCommandLineSuite) TestCommandLineUpdateUC20OverSpuriousReboot
 	c.Assert(s.modeenvWithEncryption.WriteTo(""), IsNil)
 
 	cmdlineFile := filepath.Join(c.MkDir(), "cmdline")
-	restore := osutil.MockProcCmdline(cmdlineFile)
+	restore := kcmdline.MockProcCmdline(cmdlineFile)
 	s.AddCleanup(restore)
 
 	err := s.bootloader.SetBootVars(map[string]string{

--- a/boot/cmdline.go
+++ b/boot/cmdline.go
@@ -28,7 +28,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/logger"
-	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/osutil/kcmdline"
 	"github.com/snapcore/snapd/strutil"
 )
 
@@ -56,7 +56,7 @@ var (
 // and the recovery system label as passed in the kernel command line by the
 // bootloader.
 func ModeAndRecoverySystemFromKernelCommandLine() (mode, sysLabel string, err error) {
-	m, err := osutil.KernelCommandLineKeyValues("snapd_recovery_mode", "snapd_recovery_system")
+	m, err := kcmdline.KernelCommandLineKeyValues("snapd_recovery_mode", "snapd_recovery_system")
 	if err != nil {
 		return "", "", err
 	}
@@ -265,7 +265,7 @@ func observeSuccessfulCommandLineUpdate(m *Modeenv) (*Modeenv, error) {
 	}
 
 	// get the current command line
-	cmdlineBootedWith, err := osutil.KernelCommandLine()
+	cmdlineBootedWith, err := kcmdline.KernelCommandLine()
 	if err != nil {
 		return nil, err
 	}
@@ -297,7 +297,7 @@ func observeSuccessfulCommandLineCompatBoot(model *asserts.Model, m *Modeenv) (*
 		// not being tracked
 		return m, nil
 	}
-	cmdlineBootedWith, err := osutil.KernelCommandLine()
+	cmdlineBootedWith, err := kcmdline.KernelCommandLine()
 	if err != nil {
 		return nil, err
 	}

--- a/boot/cmdline.go
+++ b/boot/cmdline.go
@@ -56,7 +56,7 @@ var (
 // and the recovery system label as passed in the kernel command line by the
 // bootloader.
 func ModeAndRecoverySystemFromKernelCommandLine() (mode, sysLabel string, err error) {
-	m, err := kcmdline.KernelCommandLineKeyValues("snapd_recovery_mode", "snapd_recovery_system")
+	m, err := kcmdline.KeyValues("snapd_recovery_mode", "snapd_recovery_system")
 	if err != nil {
 		return "", "", err
 	}

--- a/boot/cmdline_test.go
+++ b/boot/cmdline_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/snapcore/snapd/boot/boottest"
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/bootloader/bootloadertest"
-	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/osutil/kcmdline"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -49,7 +49,7 @@ func (s *kernelCommandLineSuite) SetUpTest(c *C) {
 
 	err := os.MkdirAll(filepath.Join(s.rootDir, "proc"), 0755)
 	c.Assert(err, IsNil)
-	restore := osutil.MockProcCmdline(filepath.Join(s.rootDir, "proc/cmdline"))
+	restore := kcmdline.MockProcCmdline(filepath.Join(s.rootDir, "proc/cmdline"))
 	s.AddCleanup(restore)
 }
 

--- a/boot/initramfs.go
+++ b/boot/initramfs.go
@@ -149,7 +149,7 @@ func updateNotScriptableBootloaderStatus(bl bootloader.NotScriptableBootloader) 
 		return nil
 	}
 
-	kVals, err := kcmdline.KernelCommandLineKeyValues("kernel_status")
+	kVals, err := kcmdline.KeyValues("kernel_status")
 	if err != nil {
 		return err
 	}

--- a/boot/initramfs.go
+++ b/boot/initramfs.go
@@ -26,6 +26,7 @@ import (
 	"github.com/snapcore/snapd/bootloader"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/osutil/kcmdline"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -148,7 +149,7 @@ func updateNotScriptableBootloaderStatus(bl bootloader.NotScriptableBootloader) 
 		return nil
 	}
 
-	kVals, err := osutil.KernelCommandLineKeyValues("kernel_status")
+	kVals, err := kcmdline.KernelCommandLineKeyValues("kernel_status")
 	if err != nil {
 		return err
 	}

--- a/boot/initramfs_test.go
+++ b/boot/initramfs_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/gadget/gadgettest"
-	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/osutil/kcmdline"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -781,7 +781,7 @@ func (s *initramfsSuite) TestInitramfsRunModeUpdateBootloaderVars(c *C) {
 		cmdlineFile := filepath.Join(c.MkDir(), "cmdline")
 		err := ioutil.WriteFile(cmdlineFile, []byte(t.cmdline), 0644)
 		c.Assert(err, IsNil)
-		r := osutil.MockProcCmdline(cmdlineFile)
+		r := kcmdline.MockProcCmdline(cmdlineFile)
 		defer r()
 
 		err = boot.InitramfsRunModeUpdateBootloaderVars()
@@ -805,7 +805,7 @@ func (s *initramfsSuite) TestInitramfsRunModeUpdateBootloaderVarsNotNotScriptabl
 	cmdlineFile := filepath.Join(c.MkDir(), "cmdline")
 	err := ioutil.WriteFile(cmdlineFile, []byte("kernel_status=trying"), 0644)
 	c.Assert(err, IsNil)
-	r := osutil.MockProcCmdline(cmdlineFile)
+	r := kcmdline.MockProcCmdline(cmdlineFile)
 	defer r()
 
 	err = boot.InitramfsRunModeUpdateBootloaderVars()
@@ -826,7 +826,7 @@ func (s *initramfsSuite) TestInitramfsRunModeUpdateBootloaderVarsErrOnGetBootVar
 	cmdlineFile := filepath.Join(c.MkDir(), "cmdline")
 	err := ioutil.WriteFile(cmdlineFile, []byte("kernel_status=trying"), 0644)
 	c.Assert(err, IsNil)
-	r := osutil.MockProcCmdline(cmdlineFile)
+	r := kcmdline.MockProcCmdline(cmdlineFile)
 	defer r()
 
 	err = boot.InitramfsRunModeUpdateBootloaderVars()

--- a/bootloader/export_test.go
+++ b/bootloader/export_test.go
@@ -28,8 +28,8 @@ import (
 
 	"github.com/snapcore/snapd/bootloader/lkenv"
 	"github.com/snapcore/snapd/bootloader/ubootenv"
-	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/disks"
+	"github.com/snapcore/snapd/osutil/kcmdline"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -175,7 +175,7 @@ func MockLkFiles(c *C, rootdir string, opts *Options) (restore func()) {
 		// now mock the kernel command line
 		cmdLine := filepath.Join(c.MkDir(), "cmdline")
 		ioutil.WriteFile(cmdLine, []byte("snapd_lk_boot_disk=lk-boot-disk"), 0644)
-		r = osutil.MockProcCmdline(cmdLine)
+		r = kcmdline.MockProcCmdline(cmdLine)
 		cleanups = append(cleanups, r)
 	}
 

--- a/bootloader/grub.go
+++ b/bootloader/grub.go
@@ -381,7 +381,7 @@ func (g *grub) commandLineForEdition(edition uint, pieces CommandLineComponents)
 	} else {
 		nonSnapdCmdline = pieces.FullArgs
 	}
-	args, err := kcmdline.KernelCommandLineSplit(nonSnapdCmdline)
+	args, err := kcmdline.Split(nonSnapdCmdline)
 	if err != nil {
 		return "", fmt.Errorf("cannot use badly formatted kernel command line: %v", err)
 	}

--- a/bootloader/grub.go
+++ b/bootloader/grub.go
@@ -29,6 +29,7 @@ import (
 	"github.com/snapcore/snapd/bootloader/assets"
 	"github.com/snapcore/snapd/bootloader/grubenv"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/osutil/kcmdline"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -380,7 +381,7 @@ func (g *grub) commandLineForEdition(edition uint, pieces CommandLineComponents)
 	} else {
 		nonSnapdCmdline = pieces.FullArgs
 	}
-	args, err := osutil.KernelCommandLineSplit(nonSnapdCmdline)
+	args, err := kcmdline.KernelCommandLineSplit(nonSnapdCmdline)
 	if err != nil {
 		return "", fmt.Errorf("cannot use badly formatted kernel command line: %v", err)
 	}

--- a/bootloader/lk.go
+++ b/bootloader/lk.go
@@ -33,6 +33,7 @@ import (
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/disks"
+	"github.com/snapcore/snapd/osutil/kcmdline"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -230,7 +231,7 @@ func (l *lk) devPathForPartName(partName string) (string, bool, error) {
 		// parameter "snapd_lk_boot_disk" to indicated which disk we should look
 		// for partitions on. In typical boot scenario this will be something like
 		// "snapd_lk_boot_disk=mmcblk0".
-		m, err := osutil.KernelCommandLineKeyValues("snapd_lk_boot_disk")
+		m, err := kcmdline.KernelCommandLineKeyValues("snapd_lk_boot_disk")
 		if err != nil {
 			// return false, since we don't have enough info to conclude there
 			// is likely a lk bootloader here or not

--- a/bootloader/lk.go
+++ b/bootloader/lk.go
@@ -231,7 +231,7 @@ func (l *lk) devPathForPartName(partName string) (string, bool, error) {
 		// parameter "snapd_lk_boot_disk" to indicated which disk we should look
 		// for partitions on. In typical boot scenario this will be something like
 		// "snapd_lk_boot_disk=mmcblk0".
-		m, err := kcmdline.KernelCommandLineKeyValues("snapd_lk_boot_disk")
+		m, err := kcmdline.KeyValues("snapd_lk_boot_disk")
 		if err != nil {
 			// return false, since we don't have enough info to conclude there
 			// is likely a lk bootloader here or not

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -1573,7 +1573,7 @@ func waitForCandidateByLabelPath(label string) (string, error) {
 }
 
 func getNonUEFISystemDisk(fallbacklabel string) (string, error) {
-	values, err := kcmdline.KernelCommandLineKeyValues("snapd_system_disk")
+	values, err := kcmdline.KeyValues("snapd_system_disk")
 	if err != nil {
 		return "", err
 	}

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -45,6 +45,7 @@ import (
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/disks"
+	"github.com/snapcore/snapd/osutil/kcmdline"
 	"github.com/snapcore/snapd/snapdtool"
 
 	// to set sysconfig.ApplyFilesystemOnlyDefaultsImpl
@@ -1572,7 +1573,7 @@ func waitForCandidateByLabelPath(label string) (string, error) {
 }
 
 func getNonUEFISystemDisk(fallbacklabel string) (string, error) {
-	values, err := osutil.KernelCommandLineKeyValues("snapd_system_disk")
+	values, err := kcmdline.KernelCommandLineKeyValues("snapd_system_disk")
 	if err != nil {
 		return "", err
 	}

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/disks"
+	"github.com/snapcore/snapd/osutil/kcmdline"
 	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/secboot/keys"
 	"github.com/snapcore/snapd/seed"
@@ -521,7 +522,7 @@ func (s *baseInitramfsMountsSuite) mockProcCmdlineContent(c *C, newContent strin
 	mockProcCmdline := filepath.Join(c.MkDir(), "proc-cmdline")
 	err := ioutil.WriteFile(mockProcCmdline, []byte(newContent), 0644)
 	c.Assert(err, IsNil)
-	restore := osutil.MockProcCmdline(mockProcCmdline)
+	restore := kcmdline.MockProcCmdline(mockProcCmdline)
 	s.AddCleanup(restore)
 }
 

--- a/cmd/snap/main_test.go
+++ b/cmd/snap/main_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/osutil/kcmdline"
 	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/snapdtool"
 	"github.com/snapcore/snapd/testutil"
@@ -101,7 +102,7 @@ func (s *BaseSnapSuite) SetUpTest(c *C) {
 
 	// mock an empty cmdline since we check the cmdline to check whether we are
 	// in install mode or not and we don't want to use the host's proc/cmdline
-	s.AddCleanup(osutil.MockProcCmdline(filepath.Join(c.MkDir(), "proc/cmdline")))
+	s.AddCleanup(kcmdline.MockProcCmdline(filepath.Join(c.MkDir(), "proc/cmdline")))
 }
 
 func (s *BaseSnapSuite) TearDownTest(c *C) {

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -42,6 +42,7 @@ import (
 	"github.com/snapcore/snapd/metautil"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/disks"
+	"github.com/snapcore/snapd/osutil/kcmdline"
 	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/naming"
@@ -111,7 +112,7 @@ type KernelCmdline struct {
 	// files that can be included nowadays in the gadget.
 	// Allow is the list of allowed parameters for the system.kernel.cmdline-append
 	// system option
-	Allow []osutil.KernelArgumentPattern `yaml:"allow"`
+	Allow []kcmdline.KernelArgumentPattern `yaml:"allow"`
 }
 
 type Info struct {
@@ -1795,7 +1796,7 @@ func parseCommandLineFromGadget(content []byte) (string, error) {
 	if err := s.Err(); err != nil {
 		return "", err
 	}
-	kargs, err := osutil.KernelCommandLineSplit(filtered.String())
+	kargs, err := kcmdline.KernelCommandLineSplit(filtered.String())
 	if err != nil {
 		return "", err
 	}

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -112,7 +112,7 @@ type KernelCmdline struct {
 	// files that can be included nowadays in the gadget.
 	// Allow is the list of allowed parameters for the system.kernel.cmdline-append
 	// system option
-	Allow []kcmdline.KernelArgumentPattern `yaml:"allow"`
+	Allow []kcmdline.ArgumentPattern `yaml:"allow"`
 }
 
 type Info struct {
@@ -1796,7 +1796,7 @@ func parseCommandLineFromGadget(content []byte) (string, error) {
 	if err := s.Err(); err != nil {
 		return "", err
 	}
-	kargs, err := kcmdline.KernelCommandLineSplit(filtered.String())
+	kargs, err := kcmdline.Split(filtered.String())
 	if err != nil {
 		return "", err
 	}

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -111,7 +111,7 @@ type KernelCmdline struct {
 	// files that can be included nowadays in the gadget.
 	// Allow is the list of allowed parameters for the system.kernel.cmdline-append
 	// system option
-	Allow []osutil.KernelArgument `yaml:"allow"`
+	Allow []osutil.KernelArgumentPattern `yaml:"allow"`
 }
 
 type Info struct {

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -4232,11 +4232,12 @@ kernel-cmdline:
 			c.Assert(err, ErrorMatches, t.err)
 			c.Assert(gi, IsNil)
 		} else {
-			allowed := []osutil.KernelArgument{}
+			allowed := []osutil.KernelArgumentPattern{}
 			for _, arg := range t.allowList {
 				parsed := osutil.ParseKernelCommandline(arg)
 				c.Assert(len(parsed), Equals, 1)
-				allowed = append(allowed, parsed[0])
+				pattern := osutil.NewConstantKernelArgumentPattern(parsed[0].Param, parsed[0].Value)
+				allowed = append(allowed, pattern)
 			}
 
 			c.Assert(gi.KernelCmdline.Allow, DeepEquals, allowed)

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -4232,11 +4232,11 @@ kernel-cmdline:
 			c.Assert(err, ErrorMatches, t.err)
 			c.Assert(gi, IsNil)
 		} else {
-			allowed := []kcmdline.KernelArgumentPattern{}
+			allowed := []kcmdline.ArgumentPattern{}
 			for _, arg := range t.allowList {
-				parsed := kcmdline.ParseKernelCommandline(arg)
+				parsed := kcmdline.Parse(arg)
 				c.Assert(len(parsed), Equals, 1)
-				pattern := kcmdline.NewConstantKernelArgumentPattern(parsed[0].Param, parsed[0].Value)
+				pattern := kcmdline.NewConstantPattern(parsed[0].Param, parsed[0].Value)
 				allowed = append(allowed, pattern)
 			}
 

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -38,8 +38,8 @@ import (
 	"github.com/snapcore/snapd/gadget/gadgettest"
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/logger"
-	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/disks"
+	"github.com/snapcore/snapd/osutil/kcmdline"
 	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snapfile"
@@ -4232,11 +4232,11 @@ kernel-cmdline:
 			c.Assert(err, ErrorMatches, t.err)
 			c.Assert(gi, IsNil)
 		} else {
-			allowed := []osutil.KernelArgumentPattern{}
+			allowed := []kcmdline.KernelArgumentPattern{}
 			for _, arg := range t.allowList {
-				parsed := osutil.ParseKernelCommandline(arg)
+				parsed := kcmdline.ParseKernelCommandline(arg)
 				c.Assert(len(parsed), Equals, 1)
-				pattern := osutil.NewConstantKernelArgumentPattern(parsed[0].Param, parsed[0].Value)
+				pattern := kcmdline.NewConstantKernelArgumentPattern(parsed[0].Param, parsed[0].Value)
 				allowed = append(allowed, pattern)
 			}
 

--- a/gadget/kcmdline.go
+++ b/gadget/kcmdline.go
@@ -32,10 +32,10 @@ type kernelArgsSet map[kargKey]bool
 // wild card ('*') can be used in the allow list for the
 // values. Additionally, a string with the arguments that have been
 // filtered out is also returned.
-func FilterKernelCmdline(cmdline string, allowedSl []kcmdline.KernelArgumentPattern) (argsAllowed, argsDenied string) {
-	matcher := kcmdline.NewKernelArgumentMatcher(allowedSl)
+func FilterKernelCmdline(cmdline string, allowedSl []kcmdline.ArgumentPattern) (argsAllowed, argsDenied string) {
+	matcher := kcmdline.NewMatcher(allowedSl)
 
-	proposed := kcmdline.ParseKernelCommandline(cmdline)
+	proposed := kcmdline.Parse(cmdline)
 
 	in := []string{}
 	out := []string{}

--- a/gadget/kcmdline.go
+++ b/gadget/kcmdline.go
@@ -20,8 +20,6 @@
 package gadget
 
 import (
-	"fmt"
-
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/strutil"
 )
@@ -39,25 +37,13 @@ func FilterKernelCmdline(cmdline string, allowedSl []osutil.KernelArgumentPatter
 
 	proposed := osutil.ParseKernelCommandline(cmdline)
 
-	buildArg := func(arg osutil.KernelArgument) string {
-		if arg.Value == "" {
-			return arg.Param
-		} else {
-			val := arg.Value
-			if arg.Quoted {
-				val = "\"" + arg.Value + "\""
-			}
-			return fmt.Sprintf("%s=%s", arg.Param, val)
-		}
-	}
-
 	in := []string{}
 	out := []string{}
 	for _, p := range proposed {
 		if matcher.Match(p) {
-			in = append(in, buildArg(p))
+			in = append(in, p.String())
 		} else {
-			out = append(out, buildArg(p))
+			out = append(out, p.String())
 		}
 	}
 

--- a/gadget/kcmdline.go
+++ b/gadget/kcmdline.go
@@ -20,7 +20,7 @@
 package gadget
 
 import (
-	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/osutil/kcmdline"
 	"github.com/snapcore/snapd/strutil"
 )
 
@@ -32,10 +32,10 @@ type kernelArgsSet map[kargKey]bool
 // wild card ('*') can be used in the allow list for the
 // values. Additionally, a string with the arguments that have been
 // filtered out is also returned.
-func FilterKernelCmdline(cmdline string, allowedSl []osutil.KernelArgumentPattern) (argsAllowed, argsDenied string) {
-	matcher := osutil.NewKernelArgumentMatcher(allowedSl)
+func FilterKernelCmdline(cmdline string, allowedSl []kcmdline.KernelArgumentPattern) (argsAllowed, argsDenied string) {
+	matcher := kcmdline.NewKernelArgumentMatcher(allowedSl)
 
-	proposed := osutil.ParseKernelCommandline(cmdline)
+	proposed := kcmdline.ParseKernelCommandline(cmdline)
 
 	in := []string{}
 	out := []string{}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -198,7 +198,7 @@ func SimpleSetup() error {
 // initramfs, where we want to consider the quiet kernel option.
 func BootSetup() error {
 	flags := buildFlags()
-	m, _ := kcmdline.KernelCommandLineKeyValues("quiet")
+	m, _ := kcmdline.KeyValues("quiet")
 	_, quiet := m["quiet"]
 	logger := &Log{
 		log:   log.New(os.Stderr, "", flags),
@@ -221,7 +221,7 @@ func debugEnabledOnKernelCmdline() bool {
 	if osutil.IsTestBinary() && procCmdlineUseDefaultMockInTests {
 		return false
 	}
-	m, _ := kcmdline.KernelCommandLineKeyValues("snapd.debug")
+	m, _ := kcmdline.KeyValues("snapd.debug")
 	return m["snapd.debug"] == "1"
 }
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/osutil/kcmdline"
 )
 
 // A Logger is a fairly minimal logging tool.
@@ -197,7 +198,7 @@ func SimpleSetup() error {
 // initramfs, where we want to consider the quiet kernel option.
 func BootSetup() error {
 	flags := buildFlags()
-	m, _ := osutil.KernelCommandLineKeyValues("quiet")
+	m, _ := kcmdline.KernelCommandLineKeyValues("quiet")
 	_, quiet := m["quiet"]
 	logger := &Log{
 		log:   log.New(os.Stderr, "", flags),
@@ -220,7 +221,7 @@ func debugEnabledOnKernelCmdline() bool {
 	if osutil.IsTestBinary() && procCmdlineUseDefaultMockInTests {
 		return false
 	}
-	m, _ := osutil.KernelCommandLineKeyValues("snapd.debug")
+	m, _ := kcmdline.KernelCommandLineKeyValues("snapd.debug")
 	return m["snapd.debug"] == "1"
 }
 

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -34,7 +34,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/logger"
-	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/osutil/kcmdline"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -112,7 +112,7 @@ func (s *LogSuite) TestBootSetup(c *C) {
 	cmdlineFile := filepath.Join(c.MkDir(), "cmdline")
 	err := ioutil.WriteFile(cmdlineFile, []byte("mocked panic=-1"), 0644)
 	c.Assert(err, IsNil)
-	restore := osutil.MockProcCmdline(cmdlineFile)
+	restore := kcmdline.MockProcCmdline(cmdlineFile)
 	defer restore()
 	os.Setenv("TERM", "dumb")
 	err = logger.BootSetup()
@@ -124,7 +124,7 @@ func (s *LogSuite) TestBootSetup(c *C) {
 	cmdlineFile = filepath.Join(c.MkDir(), "cmdline")
 	err = ioutil.WriteFile(cmdlineFile, []byte("mocked panic=-1 quiet"), 0644)
 	c.Assert(err, IsNil)
-	restore = osutil.MockProcCmdline(cmdlineFile)
+	restore = kcmdline.MockProcCmdline(cmdlineFile)
 	defer restore()
 	os.Unsetenv("TERM")
 	err = logger.BootSetup()
@@ -199,7 +199,7 @@ func (s *LogSuite) TestIntegrationDebugFromKernelCmdline(c *C) {
 	mockProcCmdline := filepath.Join(c.MkDir(), "proc-cmdline")
 	err := ioutil.WriteFile(mockProcCmdline, []byte("console=tty panic=-1 snapd.debug=1\n"), 0644)
 	c.Assert(err, IsNil)
-	restore = osutil.MockProcCmdline(mockProcCmdline)
+	restore = kcmdline.MockProcCmdline(mockProcCmdline)
 	defer restore()
 
 	var buf bytes.Buffer

--- a/osutil/kcmdline.go
+++ b/osutil/kcmdline.go
@@ -218,14 +218,6 @@ func (ka *KernelArgument) UnmarshalYAML(unmarshal func(interface{}) error) error
 	if len(parsed) != 1 {
 		return fmt.Errorf("%q is not a unique kernel argument", arg)
 	}
-	// To make parsing future proof in case we support full
-	// globbing in the future, do not allow unquoted globbing
-	// characters, except the currently only supported case ('*').
-	if !parsed[0].Quoted && parsed[0].Value != "*" &&
-		strings.ContainsAny(parsed[0].Value, `*?[]\{}`) {
-		return fmt.Errorf("%q contains globbing characters and is not quoted",
-			parsed[0].Value)
-	}
 	*ka = parsed[0]
 
 	return nil
@@ -344,4 +336,90 @@ func KernelCommandLine() (string, error) {
 		return "", err
 	}
 	return strings.TrimSpace(string(buf)), nil
+}
+
+type valuePattern interface {
+	Match(value string) bool
+}
+
+type valuePatternAny struct {}
+
+func (any valuePatternAny) Match(value string) bool {
+	return true
+}
+
+type valuePatternConstant struct {
+	constantValue string
+}
+
+func (constant valuePatternConstant) Match(value string) bool {
+	return constant.constantValue == value
+}
+
+// KernelArgumentPattern represents a pattern which can match a KernelArgument
+// This is intended to be used with KernelArgumentMatcher
+type KernelArgumentPattern struct {
+	param string
+	value valuePattern
+}
+
+// KernelArgumentMatcher matches a KernelArgument with multiple KernelArgumentPatterns
+type KernelArgumentMatcher struct {
+	patterns map[string]valuePattern
+}
+
+func (m *KernelArgumentMatcher) Match(arg KernelArgument) bool {
+	pattern, ok := m.patterns[arg.Param]
+	if !ok {
+		return false
+	}
+	return pattern.Match(arg.Value)
+}
+
+func NewKernelArgumentMatcher(allowed []KernelArgumentPattern) KernelArgumentMatcher {
+	patterns := map[string]valuePattern{}
+
+	for _, p := range allowed {
+		patterns[p.param] = p.value
+	}
+
+	return KernelArgumentMatcher{patterns}
+}
+
+// This constructor is needed mainly for test instead of unmarshaling from yaml
+func NewConstantKernelArgumentPattern(param string, value string) KernelArgumentPattern {
+	return KernelArgumentPattern{param, valuePatternConstant{value}}
+}
+
+// This constructor is needed mainly for test instead of unmarshaling from yaml
+func NewAnyKernelArgumentPattern(param string) KernelArgumentPattern {
+	return KernelArgumentPattern{param, valuePatternAny{}}
+}
+
+func (kap *KernelArgumentPattern) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var arg string
+	if err := unmarshal(&arg); err != nil {
+		return errors.New("cannot unmarshal kernel argument")
+	}
+
+	parsed := ParseKernelCommandline(arg)
+	if len(parsed) != 1 {
+		return fmt.Errorf("%q is not a unique kernel argument", arg)
+	}
+	// To make parsing future proof in case we support full
+	// globbing in the future, do not allow unquoted globbing
+	// characters, except the currently only supported case ('*').
+	if !parsed[0].Quoted && parsed[0].Value != "*" &&
+		strings.ContainsAny(parsed[0].Value, `*?[]\{}`) {
+		return fmt.Errorf("%q contains globbing characters and is not quoted",
+			parsed[0].Value)
+	}
+	kap.param = parsed[0].Param
+	if parsed[0].Quoted || parsed[0].Value != "*" {
+		kap.value = valuePatternConstant{parsed[0].Value}
+	} else {
+		kap.value = valuePatternAny{}
+	}
+
+	return nil
 }

--- a/osutil/kcmdline.go
+++ b/osutil/kcmdline.go
@@ -223,6 +223,22 @@ func (ka *KernelArgument) UnmarshalYAML(unmarshal func(interface{}) error) error
 	return nil
 }
 
+func quoteIfNeeded(input string, force bool) string {
+	if force || strings.Contains(input, " ") {
+		return "\"" + input + "\""
+	} else {
+		return input
+	}
+}
+
+func (ka *KernelArgument) String() string {
+	if ka.Value == "" {
+		return quoteIfNeeded(ka.Param, false)
+	} else {
+		return fmt.Sprintf("%s=%s", quoteIfNeeded(ka.Param, false), quoteIfNeeded(ka.Value, ka.Quoted))
+	}
+}
+
 // ParseKernelCommandline parses a kernel command line, returning a
 // slice with the arguments in the same order as in cmdline. Note that
 // kernel arguments can be repeated. We follow the same algorithm as in

--- a/osutil/kcmdline/kcmdline.go
+++ b/osutil/kcmdline/kcmdline.go
@@ -17,7 +17,7 @@
  *
  */
 
-package osutil
+package kcmdline
 
 import (
 	"bytes"
@@ -25,6 +25,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"strings"
+
+	"github.com/snapcore/snapd/osutil"
 )
 
 var (
@@ -33,7 +35,7 @@ var (
 
 // MockProcCmdline overrides the path to /proc/cmdline. For use in tests.
 func MockProcCmdline(newPath string) (restore func()) {
-	MustBeTestBinary("mocking can only be done from tests")
+	osutil.MustBeTestBinary("mocking can only be done from tests")
 	oldProcCmdline := procCmdline
 	procCmdline = newPath
 	return func() {
@@ -358,7 +360,7 @@ type valuePattern interface {
 	Match(value string) bool
 }
 
-type valuePatternAny struct {}
+type valuePatternAny struct{}
 
 func (any valuePatternAny) Match(value string) bool {
 	return true

--- a/osutil/kcmdline/kcmdline_test.go
+++ b/osutil/kcmdline/kcmdline_test.go
@@ -17,18 +17,21 @@
  *
  */
 
-package osutil_test
+package kcmdline_test
 
 import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
+	"testing"
 
 	. "gopkg.in/check.v1"
 	"gopkg.in/yaml.v2"
 
-	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/osutil/kcmdline"
 )
+
+func Test(t *testing.T) { TestingT(t) }
 
 type kcmdlineTestSuite struct{}
 
@@ -84,7 +87,7 @@ func (s *kcmdlineTestSuite) TestSplitKernelCommandLine(c *C) {
 		{cmd: `foo ==a`, errStr: "unexpected assignment"},
 	} {
 		c.Logf("%v: cmd: %q", idx, tc.cmd)
-		out, err := osutil.KernelCommandLineSplit(tc.cmd)
+		out, err := kcmdline.KernelCommandLineSplit(tc.cmd)
 		if tc.errStr != "" {
 			c.Assert(err, ErrorMatches, tc.errStr)
 			c.Check(out, IsNil)
@@ -182,9 +185,9 @@ func (s *kcmdlineTestSuite) TestGetKernelCommandLineKeyValue(c *C) {
 		cmdlineFile := filepath.Join(c.MkDir(), "cmdline")
 		err := ioutil.WriteFile(cmdlineFile, []byte(t.cmdline), 0644)
 		c.Assert(err, IsNil)
-		r := osutil.MockProcCmdline(cmdlineFile)
+		r := kcmdline.MockProcCmdline(cmdlineFile)
 		defer r()
-		res, err := osutil.KernelCommandLineKeyValues(t.keys...)
+		res, err := kcmdline.KernelCommandLineKeyValues(t.keys...)
 		if t.err != "" {
 			c.Assert(err, ErrorMatches, t.err, Commentf(t.comment))
 		} else {
@@ -201,16 +204,16 @@ func (s *kcmdlineTestSuite) TestGetKernelCommandLineKeyValue(c *C) {
 func (s *kcmdlineTestSuite) TestKernelCommandLine(c *C) {
 	d := c.MkDir()
 	newProcCmdline := filepath.Join(d, "cmdline")
-	restore := osutil.MockProcCmdline(newProcCmdline)
+	restore := kcmdline.MockProcCmdline(newProcCmdline)
 	defer restore()
 
-	cmd, err := osutil.KernelCommandLine()
+	cmd, err := kcmdline.KernelCommandLine()
 	c.Assert(err, ErrorMatches, `.*/cmdline: no such file or directory`)
 	c.Check(cmd, Equals, "")
 
 	err = ioutil.WriteFile(newProcCmdline, []byte("foo bar baz panic=-1\n"), 0644)
 	c.Assert(err, IsNil)
-	cmd, err = osutil.KernelCommandLine()
+	cmd, err = kcmdline.KernelCommandLine()
 	c.Assert(err, IsNil)
 	c.Check(cmd, Equals, "foo bar baz panic=-1")
 }
@@ -222,33 +225,33 @@ func (s *kcmdlineTestSuite) TestKernelCommandLine(c *C) {
 func (s *kcmdlineTestSuite) TestKernelParseCommandLine(c *C) {
 	for idx, tc := range []struct {
 		cmd string
-		exp []osutil.KernelArgument
+		exp []kcmdline.KernelArgument
 	}{
-		{cmd: ``, exp: []osutil.KernelArgument{}},
-		{cmd: `foo bar baz`, exp: []osutil.KernelArgument{
+		{cmd: ``, exp: []kcmdline.KernelArgument{}},
+		{cmd: `foo bar baz`, exp: []kcmdline.KernelArgument{
 			{"foo", "", false}, {"bar", "", false}, {"baz", "", false}}},
-		{cmd: `"foo"=" many   spaces  " bar`, exp: []osutil.KernelArgument{
+		{cmd: `"foo"=" many   spaces  " bar`, exp: []kcmdline.KernelArgument{
 			{`foo"`, " many   spaces  ", true}, {"bar", "", false}}},
-		{cmd: `"foo=bar" foo="bar"`, exp: []osutil.KernelArgument{
+		{cmd: `"foo=bar" foo="bar"`, exp: []kcmdline.KernelArgument{
 			{"foo", "bar", true}, {"foo", "bar", true}}},
-		{cmd: `foo=* baz=bar`, exp: []osutil.KernelArgument{
+		{cmd: `foo=* baz=bar`, exp: []kcmdline.KernelArgument{
 			{"foo", "*", false}, {"baz", "bar", false}}},
-		{cmd: `foo-dev-mode`, exp: []osutil.KernelArgument{
+		{cmd: `foo-dev-mode`, exp: []kcmdline.KernelArgument{
 			{"foo-dev-mode", "", false}}},
-		{cmd: `foo_bar-tee=bar_aa-bb`, exp: []osutil.KernelArgument{
+		{cmd: `foo_bar-tee=bar_aa-bb`, exp: []kcmdline.KernelArgument{
 			{"foo_bar-tee", "bar_aa-bb", false}}},
-		{cmd: `foo="1$2"`, exp: []osutil.KernelArgument{{"foo", "1$2", true}}},
-		{cmd: `foo=1$2`, exp: []osutil.KernelArgument{{"foo", "1$2", false}}},
-		{cmd: `foo= bar`, exp: []osutil.KernelArgument{{"foo", "", false}, {"bar", "", false}}},
-		{cmd: `foo=""`, exp: []osutil.KernelArgument{{"foo", "", true}}},
+		{cmd: `foo="1$2"`, exp: []kcmdline.KernelArgument{{"foo", "1$2", true}}},
+		{cmd: `foo=1$2`, exp: []kcmdline.KernelArgument{{"foo", "1$2", false}}},
+		{cmd: `foo= bar`, exp: []kcmdline.KernelArgument{{"foo", "", false}, {"bar", "", false}}},
+		{cmd: `foo=""`, exp: []kcmdline.KernelArgument{{"foo", "", true}}},
 		{cmd: `   cpu=1,2,3   mem=0x2000;0x4000:$2  `,
-			exp: []osutil.KernelArgument{{"cpu", "1,2,3", false}, {"mem", "0x2000;0x4000:$2", false}}},
+			exp: []kcmdline.KernelArgument{{"cpu", "1,2,3", false}, {"mem", "0x2000;0x4000:$2", false}}},
 		{cmd: "isolcpus=1,2,10-20,100-2000:2/25",
-			exp: []osutil.KernelArgument{{"isolcpus", "1,2,10-20,100-2000:2/25", false}}},
+			exp: []kcmdline.KernelArgument{{"isolcpus", "1,2,10-20,100-2000:2/25", false}}},
 		// something more realistic
 		{
 			cmd: `BOOT_IMAGE=/vmlinuz-linux root=/dev/mapper/linux-root rw quiet loglevel=3 rd.udev.log_priority=3 vt.global_cursor_default=0 rd.luks.uuid=1a273f76-3118-434b-8597-a3b12a59e017 rd.luks.uuid=775e4582-33c1-423b-ac19-f734e0d5e21c rd.luks.options=discard,timeout=0 root=/dev/mapper/linux-root apparmor=1 security=apparmor`,
-			exp: []osutil.KernelArgument{
+			exp: []kcmdline.KernelArgument{
 				{"BOOT_IMAGE", "/vmlinuz-linux", false},
 				{"root", "/dev/mapper/linux-root", false},
 				{"rw", "", false},
@@ -265,31 +268,31 @@ func (s *kcmdlineTestSuite) TestKernelParseCommandLine(c *C) {
 			},
 		},
 		// this is actually ok, eg. rd.luks.options=discard,timeout=0
-		{cmd: `a=b=`, exp: []osutil.KernelArgument{{"a", "b=", false}}},
+		{cmd: `a=b=`, exp: []kcmdline.KernelArgument{{"a", "b=", false}}},
 		// bad quoting, or otherwise malformed command line
-		{cmd: `foo="1$2`, exp: []osutil.KernelArgument{{"foo", "1$2", true}}},
-		{cmd: `"foo"`, exp: []osutil.KernelArgument{{"foo", "", true}}},
-		{cmd: `foo"foo"`, exp: []osutil.KernelArgument{{`foo"foo"`, "", false}}},
-		{cmd: `foo=foo"`, exp: []osutil.KernelArgument{{"foo", `foo"`, false}}},
-		{cmd: `foo=bar=baz`, exp: []osutil.KernelArgument{{"foo", `bar=baz`, false}}},
-		{cmd: `"f"o"o"="b"a"r"`, exp: []osutil.KernelArgument{{`f"o"o"`, `b"a"r`, true}}},
-		{cmd: `foo="a""b"`, exp: []osutil.KernelArgument{{"foo", `a""b`, true}}},
-		{cmd: `foo="a foo="b`, exp: []osutil.KernelArgument{{"foo", `a foo="b`, true}}},
-		{cmd: `foo="a"="b"`, exp: []osutil.KernelArgument{{"foo", `a"="b`, true}}},
-		{cmd: `=`, exp: []osutil.KernelArgument{{"=", "", false}}},
-		{cmd: `a =`, exp: []osutil.KernelArgument{{"a", "", false}, {"=", "", false}}},
-		{cmd: `="foo"`, exp: []osutil.KernelArgument{{`="foo"`, "", false}}},
-		{cmd: `a==`, exp: []osutil.KernelArgument{{"a", "=", false}}},
-		{cmd: `foo ==a`, exp: []osutil.KernelArgument{{"foo", "", false}, {"=", "a", false}}},
+		{cmd: `foo="1$2`, exp: []kcmdline.KernelArgument{{"foo", "1$2", true}}},
+		{cmd: `"foo"`, exp: []kcmdline.KernelArgument{{"foo", "", true}}},
+		{cmd: `foo"foo"`, exp: []kcmdline.KernelArgument{{`foo"foo"`, "", false}}},
+		{cmd: `foo=foo"`, exp: []kcmdline.KernelArgument{{"foo", `foo"`, false}}},
+		{cmd: `foo=bar=baz`, exp: []kcmdline.KernelArgument{{"foo", `bar=baz`, false}}},
+		{cmd: `"f"o"o"="b"a"r"`, exp: []kcmdline.KernelArgument{{`f"o"o"`, `b"a"r`, true}}},
+		{cmd: `foo="a""b"`, exp: []kcmdline.KernelArgument{{"foo", `a""b`, true}}},
+		{cmd: `foo="a foo="b`, exp: []kcmdline.KernelArgument{{"foo", `a foo="b`, true}}},
+		{cmd: `foo="a"="b"`, exp: []kcmdline.KernelArgument{{"foo", `a"="b`, true}}},
+		{cmd: `=`, exp: []kcmdline.KernelArgument{{"=", "", false}}},
+		{cmd: `a =`, exp: []kcmdline.KernelArgument{{"a", "", false}, {"=", "", false}}},
+		{cmd: `="foo"`, exp: []kcmdline.KernelArgument{{`="foo"`, "", false}}},
+		{cmd: `a==`, exp: []kcmdline.KernelArgument{{"a", "=", false}}},
+		{cmd: `foo ==a`, exp: []kcmdline.KernelArgument{{"foo", "", false}, {"=", "a", false}}},
 	} {
 		c.Logf("%v, cmd: %q", idx, tc.cmd)
-		out := osutil.ParseKernelCommandline(tc.cmd)
+		out := kcmdline.ParseKernelCommandline(tc.cmd)
 		c.Check(out, DeepEquals, tc.exp)
 	}
 }
 
 type argsList struct {
-	Args []osutil.KernelArgument `yaml:"args"`
+	Args []kcmdline.KernelArgument `yaml:"args"`
 }
 
 func buildYamlArgsList(list []string) string {
@@ -308,42 +311,42 @@ func (s *kcmdlineTestSuite) TestUnmarshalKernelArgument(c *C) {
 	}{
 		{
 			[]string{`par1=val1`, `par2="val2"`},
-			argsList{[]osutil.KernelArgument{{"par1", "val1", false}, {"par2", "val2", true}}},
+			argsList{[]kcmdline.KernelArgument{{"par1", "val1", false}, {"par2", "val2", true}}},
 			"",
 		},
 		{
 			[]string{`par1="*"`, `par2`},
-			argsList{[]osutil.KernelArgument{{"par1", "*", true}, {"par2", "", false}}},
+			argsList{[]kcmdline.KernelArgument{{"par1", "*", true}, {"par2", "", false}}},
 			"",
 		},
 		{
 			[]string{`par1=*`, `par2`},
-			argsList{[]osutil.KernelArgument{{"par1", "*", false}, {"par2", "", false}}},
+			argsList{[]kcmdline.KernelArgument{{"par1", "*", false}, {"par2", "", false}}},
 			"",
 		},
 		{
 			[]string{`par1=val`, `par2=3[a-b]`, `par3=val`},
-			argsList{[]osutil.KernelArgument{{"par1", "val", false}, {"par2", "3[a-b]", false}, {"par3", "val", false}}},
+			argsList{[]kcmdline.KernelArgument{{"par1", "val", false}, {"par2", "3[a-b]", false}, {"par3", "val", false}}},
 			"",
 		},
 		{
 			[]string{`par=ab*`},
-			argsList{[]osutil.KernelArgument{{"par", "ab*", false}}},
+			argsList{[]kcmdline.KernelArgument{{"par", "ab*", false}}},
 			"",
 		},
 		{
 			[]string{`par=ab?`},
-			argsList{[]osutil.KernelArgument{{"par", "ab?", false}}},
+			argsList{[]kcmdline.KernelArgument{{"par", "ab?", false}}},
 			"",
 		},
 		{
 			[]string{`par=\a`},
-			argsList{[]osutil.KernelArgument{{"par", `\a`, false}}},
+			argsList{[]kcmdline.KernelArgument{{"par", `\a`, false}}},
 			"",
 		},
 		{
 			[]string{`par="ab?g*[s-d]\q"`},
-			argsList{[]osutil.KernelArgument{{"par", `ab?g*[s-d]\q`, true}}},
+			argsList{[]kcmdline.KernelArgument{{"par", `ab?g*[s-d]\q`, true}}},
 			"",
 		},
 	} {
@@ -361,23 +364,23 @@ func (s *kcmdlineTestSuite) TestUnmarshalKernelArgument(c *C) {
 
 func (s *kcmdlineTestSuite) TestKernelArgumentToString(c *C) {
 	for _, t := range []struct {
-		input     osutil.KernelArgument
-		expected  string
+		input    kcmdline.KernelArgument
+		expected string
 	}{
 		{
-			osutil.KernelArgument{"has space", "", false},
+			kcmdline.KernelArgument{"has space", "", false},
 			`"has space"`,
 		},
 		{
-			osutil.KernelArgument{"param", "has space", false},
+			kcmdline.KernelArgument{"param", "has space", false},
 			`param="has space"`,
 		},
 		{
-			osutil.KernelArgument{"param", "hasnospace", false},
+			kcmdline.KernelArgument{"param", "hasnospace", false},
 			`param=hasnospace`,
 		},
 		{
-			osutil.KernelArgument{"param", "forcequotes", true},
+			kcmdline.KernelArgument{"param", "forcequotes", true},
 			`param="forcequotes"`,
 		},
 	} {
@@ -385,9 +388,8 @@ func (s *kcmdlineTestSuite) TestKernelArgumentToString(c *C) {
 	}
 }
 
-
 type patternsList struct {
-	Args []osutil.KernelArgumentPattern `yaml:"args"`
+	Args []kcmdline.KernelArgumentPattern `yaml:"args"`
 }
 
 func (s *kcmdlineTestSuite) TestUnmarshalKernelArgumentPattern(c *C) {
@@ -398,25 +400,25 @@ func (s *kcmdlineTestSuite) TestUnmarshalKernelArgumentPattern(c *C) {
 	}{
 		{
 			[]string{`par1=val1`, `par2="val2"`},
-			patternsList{[]osutil.KernelArgumentPattern{
-				osutil.NewConstantKernelArgumentPattern("par1", "val1"),
-				osutil.NewConstantKernelArgumentPattern("par2", "val2"),
+			patternsList{[]kcmdline.KernelArgumentPattern{
+				kcmdline.NewConstantKernelArgumentPattern("par1", "val1"),
+				kcmdline.NewConstantKernelArgumentPattern("par2", "val2"),
 			}},
 			"",
 		},
 		{
 			[]string{`par1="*"`, `par2`},
-			patternsList{[]osutil.KernelArgumentPattern{
-				osutil.NewConstantKernelArgumentPattern("par1", "*"),
-				osutil.NewConstantKernelArgumentPattern("par2", ""),
+			patternsList{[]kcmdline.KernelArgumentPattern{
+				kcmdline.NewConstantKernelArgumentPattern("par1", "*"),
+				kcmdline.NewConstantKernelArgumentPattern("par2", ""),
 			}},
 			"",
 		},
 		{
 			[]string{`par1=*`, `par2`},
-			patternsList{[]osutil.KernelArgumentPattern{
-				osutil.NewAnyKernelArgumentPattern("par1"),
-				osutil.NewConstantKernelArgumentPattern("par2", ""),
+			patternsList{[]kcmdline.KernelArgumentPattern{
+				kcmdline.NewAnyKernelArgumentPattern("par1"),
+				kcmdline.NewConstantKernelArgumentPattern("par2", ""),
 			}},
 			"",
 		},
@@ -442,8 +444,8 @@ func (s *kcmdlineTestSuite) TestUnmarshalKernelArgumentPattern(c *C) {
 		},
 		{
 			[]string{`par="ab?g*[s-d]\q"`},
-			patternsList{[]osutil.KernelArgumentPattern{
-				osutil.NewConstantKernelArgumentPattern("par", `ab?g*[s-d]\q`),
+			patternsList{[]kcmdline.KernelArgumentPattern{
+				kcmdline.NewConstantKernelArgumentPattern("par", `ab?g*[s-d]\q`),
 			}},
 			"",
 		},

--- a/osutil/kcmdline_test.go
+++ b/osutil/kcmdline_test.go
@@ -359,6 +359,33 @@ func (s *kcmdlineTestSuite) TestUnmarshalKernelArgument(c *C) {
 	}
 }
 
+func (s *kcmdlineTestSuite) TestKernelArgumentToString(c *C) {
+	for _, t := range []struct {
+		input     osutil.KernelArgument
+		expected  string
+	}{
+		{
+			osutil.KernelArgument{"has space", "", false},
+			`"has space"`,
+		},
+		{
+			osutil.KernelArgument{"param", "has space", false},
+			`param="has space"`,
+		},
+		{
+			osutil.KernelArgument{"param", "hasnospace", false},
+			`param=hasnospace`,
+		},
+		{
+			osutil.KernelArgument{"param", "forcequotes", true},
+			`param="forcequotes"`,
+		},
+	} {
+		c.Check(t.input.String(), Equals, t.expected)
+	}
+}
+
+
 type patternsList struct {
 	Args []osutil.KernelArgumentPattern `yaml:"args"`
 }

--- a/overlord/configstate/configcore/corecfg_test.go
+++ b/overlord/configstate/configcore/corecfg_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/osutil/kcmdline"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/configstate/configcore"
 	"github.com/snapcore/snapd/overlord/state"
@@ -173,7 +174,7 @@ func (s *configcoreSuite) SetUpTest(c *C) {
 	mockCmdline := filepath.Join(dirs.GlobalRootDir, "cmdline")
 	err := ioutil.WriteFile(mockCmdline, nil, 0644)
 	c.Assert(err, IsNil)
-	restore = osutil.MockProcCmdline(mockCmdline)
+	restore = kcmdline.MockProcCmdline(mockCmdline)
 	s.AddCleanup(restore)
 }
 

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -62,6 +62,7 @@ import (
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/disks"
+	"github.com/snapcore/snapd/osutil/kcmdline"
 	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/assertstate/assertstatetest"
@@ -7015,7 +7016,7 @@ func (s *mgrsSuiteCore) testRemodelUC20WithRecoverySystem(c *C, encrypted bool) 
 	c.Assert(os.Symlink(boot.InitramfsUbuntuSeedDir, dirs.SnapSeedDir), IsNil)
 
 	c.Assert(os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "proc"), 0755), IsNil)
-	restore = osutil.MockProcCmdline(filepath.Join(dirs.GlobalRootDir, "proc/cmdline"))
+	restore = kcmdline.MockProcCmdline(filepath.Join(dirs.GlobalRootDir, "proc/cmdline"))
 	defer restore()
 
 	// mock state related to boot assets
@@ -7451,7 +7452,7 @@ func (s *mgrsSuiteCore) testRemodelUC20WithRecoverySystemSimpleSetUp(c *C) {
 	c.Assert(os.Symlink(boot.InitramfsUbuntuSeedDir, dirs.SnapSeedDir), IsNil)
 
 	c.Assert(os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "proc"), 0755), IsNil)
-	restore = osutil.MockProcCmdline(filepath.Join(dirs.GlobalRootDir, "proc/cmdline"))
+	restore = kcmdline.MockProcCmdline(filepath.Join(dirs.GlobalRootDir, "proc/cmdline"))
 	s.AddCleanup(restore)
 
 	// mock state related to boot assets
@@ -7977,7 +7978,7 @@ func (s *mgrsSuiteCore) TestRemodelUC20DifferentBaseChannel(c *C) {
 func (s *mgrsSuiteCore) TestRemodelUC20BackToPreviousGadget(c *C) {
 	s.testRemodelUC20WithRecoverySystemSimpleSetUp(c)
 	c.Assert(os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "proc"), 0755), IsNil)
-	restore := osutil.MockProcCmdline(filepath.Join(dirs.GlobalRootDir, "proc/cmdline"))
+	restore := kcmdline.MockProcCmdline(filepath.Join(dirs.GlobalRootDir, "proc/cmdline"))
 	defer restore()
 	newModel := s.brands.Model("can0nical", "my-model", uc20ModelDefaults, map[string]interface{}{
 		"snaps": []interface{}{
@@ -8155,7 +8156,7 @@ func (s *mgrsSuiteCore) TestRemodelUC20ExistingGadgetSnapDifferentChannel(c *C) 
 	// but tracks a different channel than what the new model ordains
 	s.testRemodelUC20WithRecoverySystemSimpleSetUp(c)
 	c.Assert(os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "proc"), 0755), IsNil)
-	restore := osutil.MockProcCmdline(filepath.Join(dirs.GlobalRootDir, "proc/cmdline"))
+	restore := kcmdline.MockProcCmdline(filepath.Join(dirs.GlobalRootDir, "proc/cmdline"))
 	defer restore()
 	newModel := s.brands.Model("can0nical", "my-model", uc20ModelDefaults, map[string]interface{}{
 		"snaps": []interface{}{
@@ -8345,7 +8346,7 @@ func (s *mgrsSuiteCore) TestRemodelUC20SnapWithPrereqsMissingDeps(c *C) {
 	s.testRemodelUC20WithRecoverySystemSimpleSetUp(c)
 
 	c.Assert(os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "proc"), 0755), IsNil)
-	restore := osutil.MockProcCmdline(filepath.Join(dirs.GlobalRootDir, "proc/cmdline"))
+	restore := kcmdline.MockProcCmdline(filepath.Join(dirs.GlobalRootDir, "proc/cmdline"))
 	defer restore()
 	newModel := s.brands.Model("can0nical", "my-model", uc20ModelDefaults, map[string]interface{}{
 		"snaps": []interface{}{
@@ -8501,7 +8502,7 @@ func dumpTasks(c *C, when string, tasks []*state.Task) {
 
 func (s *mgrsSuiteCore) TestRemodelUC20ToUC22(c *C) {
 	s.testRemodelUC20WithRecoverySystemSimpleSetUp(c)
-	restore := osutil.MockProcCmdline(filepath.Join(dirs.GlobalRootDir, "proc/cmdline"))
+	restore := kcmdline.MockProcCmdline(filepath.Join(dirs.GlobalRootDir, "proc/cmdline"))
 	defer restore()
 
 	restore = backend.MockAllUsers(func(*dirs.SnapDirOptions) ([]*user.User, error) {
@@ -9851,7 +9852,7 @@ func (s *mgrsSuiteCore) testGadgetKernelCommandLine(c *C, gadgetPath string, gad
 		// old and pending command line
 		c.Assert(m.CurrentKernelCommandLines, HasLen, 2)
 
-		restore := osutil.MockProcCmdline(cmdlineAfterRebootPath)
+		restore := kcmdline.MockProcCmdline(cmdlineAfterRebootPath)
 		defer restore()
 
 		// reset bootstate, so that after-reboot command line is


### PR DESCRIPTION
The matching code is now with the pattern type rather than where we interpret the pattern.  Also glob characters can be now used where we do not expect a pattern.

Also, add command line to string conversion and fix quotation when a space is in a parameter part of the argument.