### PR TITLE
boot/cmdline.go: remove ErrNoKernelCommandline

### DIFF
--- a/boot/cmdline.go
+++ b/boot/cmdline.go
@@ -111,11 +111,7 @@ func getBootloaderManagingItsAssets(where string, opts *bootloader.Options) (boo
 func bootVarsForTrustedCommandLineFromGadget(gadgetDirOrSnapPath, cmdlineAppend string) (map[string]string, error) {
 	extraOrFull, full, err := gadget.KernelCommandLineFromGadget(gadgetDirOrSnapPath)
 	if err != nil {
-		if err != gadget.ErrNoKernelCommandline {
-			return nil, fmt.Errorf("cannot use kernel command line from gadget: %v", err)
-		}
-		extraOrFull = ""
-		full = false
+		return nil, fmt.Errorf("cannot use kernel command line from gadget: %v", err)
 	}
 	logger.Debugf("trusted command line: from gadget: %q, from options: %q",
 		extraOrFull, cmdlineAppend)
@@ -179,16 +175,14 @@ func composeCommandLine(currentOrCandidate int, mode, system, gadgetDirOrSnapPat
 	}
 	if gadgetDirOrSnapPath != "" {
 		extraOrFull, full, err := gadget.KernelCommandLineFromGadget(gadgetDirOrSnapPath)
-		if err != nil && err != gadget.ErrNoKernelCommandline {
+		if err != nil {
 			return "", fmt.Errorf("cannot use kernel command line from gadget: %v", err)
 		}
-		if err == nil {
-			// gadget provides some part of the kernel command line
-			if full {
-				components.FullArgs = extraOrFull
-			} else {
-				components.ExtraArgs = extraOrFull
-			}
+		// gadget provides some part of the kernel command line
+		if full {
+			components.FullArgs = extraOrFull
+		} else {
+			components.ExtraArgs = extraOrFull
 		}
 	}
 	if currentOrCandidate == currentEdition {

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -1729,13 +1729,9 @@ func isKernelArgumentAllowed(arg string) bool {
 	return true
 }
 
-var ErrNoKernelCommandline = errors.New("no kernel command line in the gadget")
-
 // KernelCommandLineFromGadget returns the desired kernel command line provided by the
 // gadget. The full flag indicates whether the gadget provides a full command
 // line or just the extra parameters that will be appended to the static ones.
-// An ErrNoKernelCommandline is returned when thea gadget does not set any
-// kernel command line.
 func KernelCommandLineFromGadget(gadgetDirOrSnapPath string) (cmdline string, full bool, err error) {
 	sf, err := snapfile.Open(gadgetDirOrSnapPath)
 	if err != nil {
@@ -1756,7 +1752,7 @@ func KernelCommandLineFromGadget(gadgetDirOrSnapPath string) (cmdline string, fu
 	case contentExtra != nil && contentFull != nil:
 		return "", false, fmt.Errorf("cannot support both extra and full kernel command lines")
 	case contentExtra == nil && contentFull == nil:
-		return "", false, ErrNoKernelCommandline
+		return "", false, nil
 	case contentFull != nil:
 		content = contentFull
 		whichFile = "cmdline.full"

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -2784,14 +2784,16 @@ func (s *gadgetYamlTestSuite) TestKernelCommandLineBasic(c *C) {
 		full:    true,
 	}, {
 		// no cmdline
-		files: nil,
-		err:   "no kernel command line in the gadget",
+		files:   nil,
+		full:    false,
+		cmdline: "",
 	}, {
 		// not what we are looking for
 		files: [][]string{
 			{"cmdline.other", `ignored`},
 		},
-		err: "no kernel command line in the gadget",
+		full:    false,
+		cmdline: "",
 	}, {
 		files: [][]string{{"cmdline.full", " # error"}},
 		full:  true, err: `invalid kernel command line in cmdline\.full: unexpected or invalid use of # in argument "#"`,


### PR DESCRIPTION
This error does not seem to need to be an error.