### PR TITLE
boot: only use variable snapd_full_cmdline_args

### DIFF
--- a/boot/boot.go
+++ b/boot/boot.go
@@ -523,9 +523,13 @@ func UpdateCommandLineForGadgetComponent(dev snap.Device, gadgetSnapOrDir, cmdli
 	if !cmdlineChange {
 		return false, nil
 	}
+	defaultCmdLine, err := tbl.DefaultCommandLine()
+	if err != nil {
+		return false, err
+	}
 	// update the bootloader environment, maybe clearing the relevant
 	// variables
-	cmdlineVars, err := bootVarsForTrustedCommandLineFromGadget(gadgetSnapOrDir, cmdlineAppend)
+	cmdlineVars, err := bootVarsForTrustedCommandLineFromGadget(gadgetSnapOrDir, cmdlineAppend, defaultCmdLine)
 	if err != nil {
 		return false, fmt.Errorf("cannot prepare bootloader variables for kernel command line: %v", err)
 	}

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -3839,8 +3839,8 @@ func (s *bootKernelCommandLineSuite) TestCommandLineUpdateUC20ArgsAdded(c *C) {
 	args, err := s.bootloader.GetBootVars("snapd_extra_cmdline_args", "snapd_full_cmdline_args")
 	c.Assert(err, IsNil)
 	c.Check(args, DeepEquals, map[string]string{
-		"snapd_extra_cmdline_args": "args from gadget",
-		"snapd_full_cmdline_args":  "",
+		"snapd_extra_cmdline_args": "",
+		"snapd_full_cmdline_args":  "static mocked panic=-1 args from gadget",
 	})
 }
 
@@ -3911,9 +3911,8 @@ func (s *bootKernelCommandLineSuite) TestCommandLineUpdateUC20ArgsSwitch(c *C) {
 	args, err = s.bootloader.GetBootVars("snapd_extra_cmdline_args", "snapd_full_cmdline_args")
 	c.Assert(err, IsNil)
 	c.Check(args, DeepEquals, map[string]string{
-		"snapd_extra_cmdline_args": "changed",
-		// canary has been cleared as bootenv was modified
-		"snapd_full_cmdline_args": "",
+		"snapd_extra_cmdline_args": "",
+		"snapd_full_cmdline_args":  "static mocked panic=-1 changed",
 	})
 }
 
@@ -3956,7 +3955,7 @@ func (s *bootKernelCommandLineSuite) TestCommandLineUpdateUC20UnencryptedArgsRem
 	c.Assert(err, IsNil)
 	c.Check(args, DeepEquals, map[string]string{
 		"snapd_extra_cmdline_args": "",
-		"snapd_full_cmdline_args":  "",
+		"snapd_full_cmdline_args":  "static mocked panic=-1",
 	})
 }
 
@@ -4065,9 +4064,8 @@ func (s *bootKernelCommandLineSuite) TestCommandLineUpdateUC20TransitionFullExtr
 	args, err := s.bootloader.GetBootVars("snapd_extra_cmdline_args", "snapd_full_cmdline_args")
 	c.Assert(err, IsNil)
 	c.Check(args, DeepEquals, map[string]string{
-		"snapd_extra_cmdline_args": "extra args",
-		// canary has been cleared
-		"snapd_full_cmdline_args": "",
+		"snapd_extra_cmdline_args": "",
+		"snapd_full_cmdline_args":  "static mocked panic=-1 extra args",
 	})
 	// this normally happens after booting
 	s.modeenvWithEncryption.CurrentKernelCommandLines = []string{"snapd_recovery_mode=run static mocked panic=-1 extra args"}
@@ -4131,9 +4129,8 @@ func (s *bootKernelCommandLineSuite) TestCommandLineUpdateUC20TransitionFullExtr
 	args, err = s.bootloader.GetBootVars("snapd_extra_cmdline_args", "snapd_full_cmdline_args")
 	c.Assert(err, IsNil)
 	c.Check(args, DeepEquals, map[string]string{
-		// both env variables have been cleared
 		"snapd_extra_cmdline_args": "",
-		"snapd_full_cmdline_args":  "",
+		"snapd_full_cmdline_args":  "static mocked panic=-1",
 	})
 }
 
@@ -4268,9 +4265,8 @@ func (s *bootKernelCommandLineSuite) TestCommandLineUpdateUC20OverSpuriousReboot
 	args, err := s.bootloader.GetBootVars("snapd_extra_cmdline_args", "snapd_full_cmdline_args")
 	c.Assert(err, IsNil)
 	c.Check(args, DeepEquals, map[string]string{
-		"snapd_extra_cmdline_args": "extra args",
-		// canary has been cleared
-		"snapd_full_cmdline_args": "",
+		"snapd_extra_cmdline_args": "",
+		"snapd_full_cmdline_args":  "static mocked panic=-1 extra args",
 	})
 }
 
@@ -4324,9 +4320,8 @@ func (s *bootKernelCommandLineSuite) TestCommandLineUpdateUC20OverSpuriousReboot
 	args, err := s.bootloader.GetBootVars("snapd_extra_cmdline_args", "snapd_full_cmdline_args")
 	c.Assert(err, IsNil)
 	c.Check(args, DeepEquals, map[string]string{
-		"snapd_extra_cmdline_args": "extra args",
-		// canary has been cleared
-		"snapd_full_cmdline_args": "",
+		"snapd_extra_cmdline_args": "",
+		"snapd_full_cmdline_args":  "static mocked panic=-1 extra args",
 	})
 
 	// REBOOT; since we rebooted after updating the bootenv, the kernel
@@ -4366,8 +4361,8 @@ func (s *bootKernelCommandLineSuite) TestCommandLineUpdateUC20OverSpuriousReboot
 	args, err = s.bootloader.GetBootVars("snapd_extra_cmdline_args", "snapd_full_cmdline_args")
 	c.Assert(err, IsNil)
 	c.Check(args, DeepEquals, map[string]string{
-		"snapd_extra_cmdline_args": "extra args",
-		"snapd_full_cmdline_args":  "",
+		"snapd_extra_cmdline_args": "",
+		"snapd_full_cmdline_args":  "static mocked panic=-1 extra args",
 	})
 }
 

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -3363,7 +3363,7 @@ func (s *bootConfigSuite) TestBootConfigUpdateHappyNoKeysNoReseal(c *C) {
 
 	updated, err := boot.UpdateManagedBootConfigs(coreDev, s.gadgetSnap, "")
 	c.Assert(err, IsNil)
-	c.Check(updated, Equals, false)
+	c.Check(updated, Equals, true)
 	c.Check(s.bootloader.UpdateCalls, Equals, 1)
 	c.Check(resealCalls, Equals, 0)
 }
@@ -3421,7 +3421,7 @@ func (s *bootConfigSuite) testBootConfigUpdateHappyWithReseal(c *C, cmdlineAppen
 
 	updated, err := boot.UpdateManagedBootConfigs(coreDev, s.gadgetSnap, cmdlineAppend)
 	c.Assert(err, IsNil)
-	c.Check(updated, Equals, false)
+	c.Check(updated, Equals, true)
 	c.Check(s.bootloader.UpdateCalls, Equals, 1)
 	c.Check(resealCalls, Equals, 1)
 
@@ -3633,7 +3633,7 @@ func (s *bootConfigSuite) TestBootConfigUpdateWithGadgetAndReseal(c *C) {
 
 	updated, err := boot.UpdateManagedBootConfigs(coreDev, gadgetSnap, "")
 	c.Assert(err, IsNil)
-	c.Check(updated, Equals, false)
+	c.Check(updated, Equals, true)
 	c.Check(s.bootloader.UpdateCalls, Equals, 1)
 	c.Check(resealCalls, Equals, 1)
 

--- a/boot/cmdline.go
+++ b/boot/cmdline.go
@@ -108,7 +108,7 @@ func getBootloaderManagingItsAssets(where string, opts *bootloader.Options) (boo
 // variables that carry the command line arguments defined by the
 // gadget and some system options (cmdlineApped). This is only useful
 // if snapd is managing the boot config.
-func bootVarsForTrustedCommandLineFromGadget(gadgetDirOrSnapPath, cmdlineAppend string) (map[string]string, error) {
+func bootVarsForTrustedCommandLineFromGadget(gadgetDirOrSnapPath, cmdlineAppend string, defaultCmdline string) (map[string]string, error) {
 	extraOrFull, full, err := gadget.KernelCommandLineFromGadget(gadgetDirOrSnapPath)
 	if err != nil {
 		return nil, fmt.Errorf("cannot use kernel command line from gadget: %v", err)
@@ -126,7 +126,7 @@ func bootVarsForTrustedCommandLineFromGadget(gadgetDirOrSnapPath, cmdlineAppend 
 	if full {
 		args["snapd_full_cmdline_args"] = extraOrFull
 	} else {
-		args["snapd_extra_cmdline_args"] = extraOrFull
+		args["snapd_full_cmdline_args"] = strutil.JoinNonEmpty([]string{defaultCmdline, extraOrFull}, " ")
 	}
 	return args, nil
 }

--- a/boot/cmdline_test.go
+++ b/boot/cmdline_test.go
@@ -378,16 +378,16 @@ func (s *kernelCommandLineSuite) TestBootVarsForGadgetCommandLine(c *C) {
 			{"cmdline.extra", "foo bar baz"},
 		},
 		expectedVars: map[string]string{
-			"snapd_extra_cmdline_args": "foo bar baz",
-			"snapd_full_cmdline_args":  "",
+			"snapd_extra_cmdline_args": "",
+			"snapd_full_cmdline_args":  "default foo bar baz",
 		},
 	}, {
 		files: [][]string{
 			{"cmdline.extra", "snapd.debug=1"},
 		},
 		expectedVars: map[string]string{
-			"snapd_extra_cmdline_args": "snapd.debug=1",
-			"snapd_full_cmdline_args":  "",
+			"snapd_extra_cmdline_args": "",
+			"snapd_full_cmdline_args":  "default snapd.debug=1",
 		},
 	}, {
 		files: [][]string{
@@ -405,8 +405,8 @@ func (s *kernelCommandLineSuite) TestBootVarsForGadgetCommandLine(c *C) {
 	}, {
 		cmdlineAppend: "foo bar baz",
 		expectedVars: map[string]string{
-			"snapd_extra_cmdline_args": "foo bar baz",
-			"snapd_full_cmdline_args":  "",
+			"snapd_extra_cmdline_args": "",
+			"snapd_full_cmdline_args":  "default foo bar baz",
 		},
 	}, {
 		files: [][]string{
@@ -414,8 +414,8 @@ func (s *kernelCommandLineSuite) TestBootVarsForGadgetCommandLine(c *C) {
 		},
 		cmdlineAppend: "x=y z",
 		expectedVars: map[string]string{
-			"snapd_extra_cmdline_args": "foo bar baz x=y z",
-			"snapd_full_cmdline_args":  "",
+			"snapd_extra_cmdline_args": "",
+			"snapd_full_cmdline_args":  "default foo bar baz x=y z",
 		},
 	}, {
 		files: [][]string{
@@ -431,13 +431,13 @@ func (s *kernelCommandLineSuite) TestBootVarsForGadgetCommandLine(c *C) {
 		files: [][]string{},
 		expectedVars: map[string]string{
 			"snapd_extra_cmdline_args": "",
-			"snapd_full_cmdline_args":  "",
+			"snapd_full_cmdline_args":  "default",
 		},
 	}} {
 		sf := snaptest.MakeTestSnapWithFiles(c, gadgetSnapYaml, append([][]string{
 			{"meta/snap.yaml", gadgetSnapYaml},
 		}, tc.files...))
-		vars, err := boot.BootVarsForTrustedCommandLineFromGadget(sf, tc.cmdlineAppend)
+		vars, err := boot.BootVarsForTrustedCommandLineFromGadget(sf, tc.cmdlineAppend, "default")
 		if tc.errMsg == "" {
 			c.Assert(err, IsNil)
 			c.Assert(vars, DeepEquals, tc.expectedVars)

--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -306,7 +306,8 @@ func MakeRecoverySystemBootable(model *asserts.Model, rootdir string, relativeRe
 		if err != nil {
 			return fmt.Errorf("while retrieving system.kernel.*cmdline-append defaults: %v", err)
 		}
-		defaultCmdLine, err := tbl.DefaultCommandLine()
+		candidate := false
+		defaultCmdLine, err := tbl.DefaultCommandLine(candidate)
 		if err != nil {
 			return err
 		}
@@ -509,7 +510,8 @@ func makeRunnableSystem(model *asserts.Model, bootWith *BootableSet, sealer *Tru
 			return fmt.Errorf("while retrieving system.kernel.*cmdline-append defaults: %v", err)
 		}
 
-		defaultCmdLine, err := tbl.DefaultCommandLine()
+		candidate := false
+		defaultCmdLine, err := tbl.DefaultCommandLine(candidate)
 		if err != nil {
 			return err
 		}

--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -300,14 +300,18 @@ func MakeRecoverySystemBootable(model *asserts.Model, rootdir string, relativeRe
 	recoveryBlVars := map[string]string{
 		"snapd_recovery_kernel": filepath.Join("/", kernelPath),
 	}
-	if _, ok := bl.(bootloader.TrustedAssetsBootloader); ok {
+	if tbl, ok := bl.(bootloader.TrustedAssetsBootloader); ok {
 		// Look at gadget default values for system.kernel.*cmdline-append options
 		cmdlineAppend, err := buildOptionalKernelCommandLine(model, bootWith.GadgetSnapOrDir)
 		if err != nil {
 			return fmt.Errorf("while retrieving system.kernel.*cmdline-append defaults: %v", err)
 		}
+		defaultCmdLine, err := tbl.DefaultCommandLine()
+		if err != nil {
+			return err
+		}
 		// to set cmdlineAppend.
-		recoveryCmdlineArgs, err := bootVarsForTrustedCommandLineFromGadget(bootWith.GadgetSnapOrDir, cmdlineAppend)
+		recoveryCmdlineArgs, err := bootVarsForTrustedCommandLineFromGadget(bootWith.GadgetSnapOrDir, cmdlineAppend, defaultCmdLine)
 		if err != nil {
 			return fmt.Errorf("cannot obtain recovery system command line: %v", err)
 		}
@@ -483,7 +487,7 @@ func makeRunnableSystem(model *asserts.Model, bootWith *BootableSet, sealer *Tru
 		return fmt.Errorf("cannot set run system environment: %v", err)
 	}
 
-	_, ok = bl.(bootloader.TrustedAssetsBootloader)
+	tbl, ok := bl.(bootloader.TrustedAssetsBootloader)
 	if ok {
 		// the bootloader can manage its boot config
 
@@ -504,7 +508,13 @@ func makeRunnableSystem(model *asserts.Model, bootWith *BootableSet, sealer *Tru
 		if err != nil {
 			return fmt.Errorf("while retrieving system.kernel.*cmdline-append defaults: %v", err)
 		}
-		cmdlineVars, err := bootVarsForTrustedCommandLineFromGadget(bootWith.UnpackedGadgetDir, cmdlineAppend)
+
+		defaultCmdLine, err := tbl.DefaultCommandLine()
+		if err != nil {
+			return err
+		}
+
+		cmdlineVars, err := bootVarsForTrustedCommandLineFromGadget(bootWith.UnpackedGadgetDir, cmdlineAppend, defaultCmdLine)
 		if err != nil {
 			return fmt.Errorf("cannot prepare bootloader variables for kernel command line: %v", err)
 		}

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -426,7 +426,8 @@ version: 5.0
 		c.Assert(err, IsNil)
 		tbl, ok := bl.(bootloader.TrustedAssetsBootloader)
 		if ok {
-			defaultCmdLine, err := tbl.DefaultCommandLine()
+			candidate := false
+			defaultCmdLine, err := tbl.DefaultCommandLine(candidate)
 			c.Assert(err, IsNil)
 			c.Check(systemGenv.Get("snapd_extra_cmdline_args"), Equals, "")
 			c.Check(systemGenv.Get("snapd_full_cmdline_args"), Equals, strutil.JoinNonEmpty([]string{defaultCmdLine, content}, " "))
@@ -1411,7 +1412,8 @@ version: 5.0
 		c.Assert(err, IsNil)
 		tbl, ok := bl.(bootloader.TrustedAssetsBootloader)
 		if ok {
-			defaultCmdLine, err := tbl.DefaultCommandLine()
+			candidate := false
+			defaultCmdLine, err := tbl.DefaultCommandLine(candidate)
 			c.Assert(err, IsNil)
 			c.Check(systemGenv.Get("snapd_extra_cmdline_args"), Equals, "")
 			c.Check(systemGenv.Get("snapd_full_cmdline_args"), Equals, strutil.JoinNonEmpty([]string{defaultCmdLine, content}, " "))
@@ -2340,7 +2342,8 @@ version: 5.0
 	c.Assert(err, IsNil)
 	tbl, ok := bl.(bootloader.TrustedAssetsBootloader)
 	if ok {
-		defaultCmdLine, err := tbl.DefaultCommandLine()
+		candidate := false
+		defaultCmdLine, err := tbl.DefaultCommandLine(candidate)
 		c.Assert(err, IsNil)
 		c.Check(systemGenv.Get("snapd_full_cmdline_args"), Equals, strutil.JoinNonEmpty([]string{defaultCmdLine, expectedCmdline}, " "))
 		c.Check(systemGenv.Get("snapd_extra_cmdline_args"), Equals, "")

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snapfile"
 	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/strutil"
 	"github.com/snapcore/snapd/testutil"
 	"github.com/snapcore/snapd/timings"
 )
@@ -418,8 +419,21 @@ version: 5.0
 	c.Check(systemGenv.Get("snapd_recovery_kernel"), Equals, "/snaps/pc-kernel_5.snap")
 	switch whichFile {
 	case "cmdline.extra":
-		c.Check(systemGenv.Get("snapd_extra_cmdline_args"), Equals, content)
-		c.Check(systemGenv.Get("snapd_full_cmdline_args"), Equals, "")
+		blopts := &bootloader.Options{
+			Role: bootloader.RoleRecovery,
+		}
+		bl, err := bootloader.Find(s.rootdir, blopts)
+		c.Assert(err, IsNil)
+		tbl, ok := bl.(bootloader.TrustedAssetsBootloader)
+		if ok {
+			defaultCmdLine, err := tbl.DefaultCommandLine()
+			c.Assert(err, IsNil)
+			c.Check(systemGenv.Get("snapd_extra_cmdline_args"), Equals, "")
+			c.Check(systemGenv.Get("snapd_full_cmdline_args"), Equals, strutil.JoinNonEmpty([]string{defaultCmdLine, content}, " "))
+		} else {
+			c.Check(systemGenv.Get("snapd_extra_cmdline_args"), Equals, content)
+			c.Check(systemGenv.Get("snapd_full_cmdline_args"), Equals, "")
+		}
 	case "cmdline.full":
 		c.Check(systemGenv.Get("snapd_extra_cmdline_args"), Equals, "")
 		c.Check(systemGenv.Get("snapd_full_cmdline_args"), Equals, content)
@@ -1386,10 +1400,25 @@ version: 5.0
 	c.Check(mockBootGrubenv, testutil.FilePresent)
 	systemGenv := grubenv.NewEnv(mockBootGrubenv)
 	c.Assert(systemGenv.Load(), IsNil)
+
 	switch whichFile {
 	case "cmdline.extra":
-		c.Check(systemGenv.Get("snapd_extra_cmdline_args"), Equals, content)
-		c.Check(systemGenv.Get("snapd_full_cmdline_args"), Equals, "")
+		blopts := &bootloader.Options{
+			Role:        bootloader.RoleRunMode,
+			NoSlashBoot: true,
+		}
+		bl, err := bootloader.Find(boot.InitramfsUbuntuBootDir, blopts)
+		c.Assert(err, IsNil)
+		tbl, ok := bl.(bootloader.TrustedAssetsBootloader)
+		if ok {
+			defaultCmdLine, err := tbl.DefaultCommandLine()
+			c.Assert(err, IsNil)
+			c.Check(systemGenv.Get("snapd_extra_cmdline_args"), Equals, "")
+			c.Check(systemGenv.Get("snapd_full_cmdline_args"), Equals, strutil.JoinNonEmpty([]string{defaultCmdLine, content}, " "))
+		} else {
+			c.Check(systemGenv.Get("snapd_extra_cmdline_args"), Equals, content)
+			c.Check(systemGenv.Get("snapd_full_cmdline_args"), Equals, "")
+		}
 	case "cmdline.full":
 		c.Check(systemGenv.Get("snapd_extra_cmdline_args"), Equals, "")
 		c.Check(systemGenv.Get("snapd_full_cmdline_args"), Equals, content)
@@ -2304,7 +2333,21 @@ version: 5.0
 	systemGenv := grubenv.NewEnv(filepath.Join(s.rootdir, recoverySystemDir, "grubenv"))
 	c.Assert(systemGenv.Load(), IsNil)
 	c.Check(systemGenv.Get("snapd_recovery_kernel"), Equals, "/snaps/pc-kernel_5.snap")
-	c.Check(systemGenv.Get("snapd_extra_cmdline_args"), Equals, expectedCmdline)
+	blopts := &bootloader.Options{
+		Role: bootloader.RoleRecovery,
+	}
+	bl, err := bootloader.Find(s.rootdir, blopts)
+	c.Assert(err, IsNil)
+	tbl, ok := bl.(bootloader.TrustedAssetsBootloader)
+	if ok {
+		defaultCmdLine, err := tbl.DefaultCommandLine()
+		c.Assert(err, IsNil)
+		c.Check(systemGenv.Get("snapd_full_cmdline_args"), Equals, strutil.JoinNonEmpty([]string{defaultCmdLine, expectedCmdline}, " "))
+		c.Check(systemGenv.Get("snapd_extra_cmdline_args"), Equals, "")
+	} else {
+		c.Check(systemGenv.Get("snapd_extra_cmdline_args"), Equals, expectedCmdline)
+		c.Check(systemGenv.Get("snapd_full_cmdline_args"), Equals, "")
+	}
 }
 
 func (s *makeBootable20Suite) TestMakeBootableImageOptionalKernelArgsHappy(c *C) {

--- a/bootloader/bootloader.go
+++ b/bootloader/bootloader.go
@@ -211,6 +211,11 @@ type TrustedAssetsBootloader interface {
 	// edition of managed built-in boot assets as reference.
 	CandidateCommandLine(pieces CommandLineComponents) (string, error)
 
+	// DefaultCommandLine returns the default kernel command-line
+	// used by the bootloader excluding the recovery mode and
+	// system parameters.
+	DefaultCommandLine() (string, error)
+
 	// TrustedAssets returns the list of relative paths to assets inside the
 	// bootloader's rootdir that are measured in the boot process in the
 	// order of loading during the boot. Does not require rootdir to be set.

--- a/bootloader/bootloader.go
+++ b/bootloader/bootloader.go
@@ -214,7 +214,7 @@ type TrustedAssetsBootloader interface {
 	// DefaultCommandLine returns the default kernel command-line
 	// used by the bootloader excluding the recovery mode and
 	// system parameters.
-	DefaultCommandLine() (string, error)
+	DefaultCommandLine(candidate bool) (string, error)
 
 	// TrustedAssets returns the list of relative paths to assets inside the
 	// bootloader's rootdir that are measured in the boot process in the

--- a/bootloader/bootloadertest/bootloadertest.go
+++ b/bootloader/bootloadertest/bootloadertest.go
@@ -491,9 +491,12 @@ func (b *MockTrustedAssetsMixin) CandidateCommandLine(pieces bootloader.CommandL
 	return glueCommandLine(pieces, b.CandidateStaticCommandLine)
 }
 
-func (b *MockTrustedAssetsMixin) DefaultCommandLine() (string, error) {
+func (b *MockTrustedAssetsMixin) DefaultCommandLine(candidate bool) (string, error) {
 	if b.CommandLineErr != nil {
 		return "", b.CommandLineErr
+	}
+	if candidate {
+		return b.CandidateStaticCommandLine, nil
 	}
 	return b.StaticCommandLine, nil
 }

--- a/bootloader/bootloadertest/bootloadertest.go
+++ b/bootloader/bootloadertest/bootloadertest.go
@@ -491,6 +491,13 @@ func (b *MockTrustedAssetsMixin) CandidateCommandLine(pieces bootloader.CommandL
 	return glueCommandLine(pieces, b.CandidateStaticCommandLine)
 }
 
+func (b *MockTrustedAssetsMixin) DefaultCommandLine() (string, error) {
+	if b.CommandLineErr != nil {
+		return "", b.CommandLineErr
+	}
+	return b.StaticCommandLine, nil
+}
+
 func (b *MockTrustedAssetsMixin) TrustedAssets() ([]string, error) {
 	b.TrustedAssetsCalls++
 	return b.TrustedAssetsList, b.TrustedAssetsErr

--- a/overlord/devicestate/devicestate_bootconfig_test.go
+++ b/overlord/devicestate/devicestate_bootconfig_test.go
@@ -496,6 +496,7 @@ func (s *deviceMgrBootconfigSuite) TestBootConfigUpdateRunButNotUpdated(c *C) {
 	s.setupUC20Model(c)
 	s.state.Unlock()
 
+	s.managedbl.CandidateStaticCommandLine = s.managedbl.StaticCommandLine
 	s.managedbl.Updated = false
 
 	opts := testBootConfigUpdateOpts{

--- a/overlord/devicestate/devicestate_gadget_test.go
+++ b/overlord/devicestate/devicestate_gadget_test.go
@@ -1306,11 +1306,12 @@ func (s *deviceMgrGadgetSuite) TestUpdateGadgetCommandlineWithExistingArgs(c *C)
 		"snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1 args from updated gadget",
 	})
 	c.Check(s.managedbl.SetBootVarsCalls, Equals, 1)
-	vars, err := s.managedbl.GetBootVars("snapd_extra_cmdline_args")
+	vars, err := s.managedbl.GetBootVars("snapd_extra_cmdline_args", "snapd_full_cmdline_args")
 	c.Assert(err, IsNil)
 	// bootenv was cleared
 	c.Assert(vars, DeepEquals, map[string]string{
-		"snapd_extra_cmdline_args": "args from updated gadget",
+		"snapd_extra_cmdline_args": "",
+		"snapd_full_cmdline_args":  "console=ttyS0 console=tty1 panic=-1 args from updated gadget",
 	})
 }
 
@@ -1363,11 +1364,12 @@ func (s *deviceMgrGadgetSuite) TestUpdateGadgetCommandlineClassicWithModesWithEx
 		"snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1 args from updated gadget",
 	})
 	c.Check(s.managedbl.SetBootVarsCalls, Equals, 1)
-	vars, err := s.managedbl.GetBootVars("snapd_extra_cmdline_args")
+	vars, err := s.managedbl.GetBootVars("snapd_extra_cmdline_args", "snapd_full_cmdline_args")
 	c.Assert(err, IsNil)
 	// bootenv was cleared
 	c.Assert(vars, DeepEquals, map[string]string{
-		"snapd_extra_cmdline_args": "args from updated gadget",
+		"snapd_extra_cmdline_args": "",
+		"snapd_full_cmdline_args":  "console=ttyS0 console=tty1 panic=-1 args from updated gadget",
 	})
 }
 
@@ -1419,11 +1421,12 @@ func (s *deviceMgrGadgetSuite) TestUpdateGadgetCommandlineWithNewArgs(c *C) {
 		"snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1 args from new gadget",
 	})
 	c.Check(s.managedbl.SetBootVarsCalls, Equals, 1)
-	vars, err := s.managedbl.GetBootVars("snapd_extra_cmdline_args")
+	vars, err := s.managedbl.GetBootVars("snapd_extra_cmdline_args", "snapd_full_cmdline_args")
 	c.Assert(err, IsNil)
 	// bootenv was cleared
 	c.Assert(vars, DeepEquals, map[string]string{
-		"snapd_extra_cmdline_args": "args from new gadget",
+		"snapd_extra_cmdline_args": "",
+		"snapd_full_cmdline_args":  "console=ttyS0 console=tty1 panic=-1 args from new gadget",
 	})
 }
 
@@ -1445,6 +1448,7 @@ func (s *deviceMgrGadgetSuite) testUpdateGadgetCommandlineWithNewAppendedArgs(c 
 	c.Assert(m.Write(), IsNil)
 	err = s.managedbl.SetBootVars(map[string]string{
 		"snapd_extra_cmdline_args": "",
+		"snapd_full_cmdline_args":  "console=ttyS0 console=tty1 panic=-1",
 	})
 	c.Assert(err, IsNil)
 	s.managedbl.SetBootVarsCalls = 0
@@ -1495,7 +1499,7 @@ kernel-cmdline:
 
 	c.Check([]string(m.CurrentKernelCommandLines), DeepEquals, expCmdlines)
 	c.Check(s.managedbl.SetBootVarsCalls, Equals, numSetBootVarsCalls)
-	vars, err := s.managedbl.GetBootVars("snapd_extra_cmdline_args")
+	vars, err := s.managedbl.GetBootVars("snapd_extra_cmdline_args", "snapd_full_cmdline_args")
 	c.Assert(err, IsNil)
 	// bootenv was cleared
 	extraArgs := opts.allowedCmdline
@@ -1503,7 +1507,8 @@ kernel-cmdline:
 		extraArgs = strutil.JoinNonEmpty([]string{extraArgs, opts.cmdlineAppendDanger}, " ")
 	}
 	c.Assert(vars, DeepEquals, map[string]string{
-		"snapd_extra_cmdline_args": extraArgs,
+		"snapd_extra_cmdline_args": "",
+		"snapd_full_cmdline_args":  strutil.JoinNonEmpty([]string{"console=ttyS0 console=tty1 panic=-1", extraArgs}, " "),
 	})
 }
 
@@ -1827,10 +1832,11 @@ func (s *deviceMgrGadgetSuite) TestGadgetCommandlineUpdateUndo(c *C) {
 	// update was applied and then undone
 	c.Check(s.restartRequests, DeepEquals, []restart.RestartType{restart.RestartSystemNow, restart.RestartSystemNow})
 	c.Check(restartCount, Equals, 2)
-	vars, err := s.managedbl.GetBootVars("snapd_extra_cmdline_args")
+	vars, err := s.managedbl.GetBootVars("snapd_extra_cmdline_args", "snapd_full_cmdline_args")
 	c.Assert(err, IsNil)
 	c.Assert(vars, DeepEquals, map[string]string{
-		"snapd_extra_cmdline_args": "args from old gadget",
+		"snapd_extra_cmdline_args": "",
+		"snapd_full_cmdline_args":  "console=ttyS0 console=tty1 panic=-1 args from old gadget",
 	})
 	// 2 calls, one to set the new arguments, and one to reset them back
 	c.Check(s.managedbl.SetBootVarsCalls, Equals, 2)
@@ -1933,10 +1939,11 @@ func (s *deviceMgrGadgetSuite) TestGadgetCommandlineClassicWithModesUpdateUndo(c
 	// update was applied and then undone, but no automatic restarts happened
 	c.Check(s.restartRequests, HasLen, 0)
 	c.Check(restartCount, Equals, 0)
-	vars, err := s.managedbl.GetBootVars("snapd_extra_cmdline_args")
+	vars, err := s.managedbl.GetBootVars("snapd_extra_cmdline_args", "snapd_full_cmdline_args")
 	c.Assert(err, IsNil)
 	c.Assert(vars, DeepEquals, map[string]string{
-		"snapd_extra_cmdline_args": "args from old gadget",
+		"snapd_extra_cmdline_args": "",
+		"snapd_full_cmdline_args":  "console=ttyS0 console=tty1 panic=-1 args from old gadget",
 	})
 	// 2 calls, one to set the new arguments, and one to reset them back
 	c.Check(s.managedbl.SetBootVarsCalls, Equals, 2)

--- a/overlord/devicestate/systems_test.go
+++ b/overlord/devicestate/systems_test.go
@@ -246,8 +246,8 @@ func (s *createSystemSuite) TestCreateSystemFromAssertedSnaps(c *C) {
 	// recovery system bootenv was set
 	c.Check(bl.RecoverySystemDir, Equals, "/systems/1234")
 	c.Check(bl.RecoverySystemBootVars, DeepEquals, map[string]string{
-		"snapd_full_cmdline_args":  "",
-		"snapd_extra_cmdline_args": "args from gadget",
+		"snapd_full_cmdline_args":  "mock static args from gadget",
+		"snapd_extra_cmdline_args": "",
 		"snapd_recovery_kernel":    "/snaps/pc-kernel_1.snap",
 	})
 	// load the seed
@@ -417,8 +417,8 @@ func (s *createSystemSuite) TestCreateSystemWithSomeSnapsAlreadyExisting(c *C) {
 	// recovery system bootenv was set
 	c.Check(bl.RecoverySystemDir, Equals, "/systems/1234")
 	c.Check(bl.RecoverySystemBootVars, DeepEquals, map[string]string{
-		"snapd_full_cmdline_args":  "",
-		"snapd_extra_cmdline_args": "args from gadget",
+		"snapd_full_cmdline_args":  "args from gadget",
+		"snapd_extra_cmdline_args": "",
 		"snapd_recovery_kernel":    "/snaps/pc-kernel_1.snap",
 	})
 	// load the seed

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -9496,7 +9496,8 @@ func (s *mgrsSuite) testUC20RunUpdateManagedBootConfig(c *C, snapPath string, si
 		RecoverySystem: "20191127",
 		Base:           "core20_1.snap",
 		CurrentKernelCommandLines: []string{
-			"snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1",
+			// We expect bl to be a mock bootloader with no default command line"
+			"snapd_recovery_mode=run",
 		},
 	}
 	err := m.WriteTo("")
@@ -9999,8 +10000,8 @@ func (s *mgrsSuiteCore) TestGadgetKernelCommandLineAddCmdline(c *C) {
 	vars, err := mabloader.GetBootVars("snapd_extra_cmdline_args", "snapd_full_cmdline_args")
 	c.Assert(err, IsNil)
 	c.Assert(vars, DeepEquals, map[string]string{
-		"snapd_extra_cmdline_args": "args from gadget",
-		"snapd_full_cmdline_args":  "",
+		"snapd_extra_cmdline_args": "",
+		"snapd_full_cmdline_args":  "mock static args from gadget",
 	})
 }
 
@@ -10041,7 +10042,7 @@ func (s *mgrsSuiteCore) TestGadgetKernelCommandLineRemoveCmdline(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(vars, DeepEquals, map[string]string{
 		"snapd_extra_cmdline_args": "",
-		"snapd_full_cmdline_args":  "",
+		"snapd_full_cmdline_args":  "mock static",
 	})
 }
 


### PR DESCRIPTION
We know what are the default the default command line so that we can compute measurement, so there is not much reason to use `snapd_extra_cmdline_args`. Always using `snapd_full_cmdline_args` will allow us to filter part of the default command line.

There is a potential bug when filtering all arguments, `grub.cfg` will just revert to the all the default. We will need to fix it when we introduce the filtering.

See #12987 for full feature branch