### PR TITLE
t/regression/mount-order-regression: set no mem limit

### DIFF
--- a/tests/regression/mount-order-regression/task.yaml
+++ b/tests/regression/mount-order-regression/task.yaml
@@ -11,6 +11,10 @@ systems:
   - -ubuntu-core-16-32
   - -ubuntu-core-18-32
 
+environment:
+    # we unfortunately (sometimes) run out of memory while setting up test-content-layout-consumer snap
+    SNAPD_NO_MEMORY_LIMIT: 1
+
 prepare: |
     if os.query is-arm64; then
         SNAP_NAME=test-content-layout-consumer-arm64


### PR DESCRIPTION
Unfortunately it happens that we hit the memory limit while setting up security profiles for the snap. Set no memory limit for this test
