### PR TITLE
asserts: add support for account-key constraints

### DIFF
--- a/asserts/account_key.go
+++ b/asserts/account_key.go
@@ -298,8 +298,7 @@ func checkAKConstraints(cs interface{}) ([]attrMatcher, error) {
 
 func accountKeyFormatAnalyze(headers map[string]interface{}, body []byte) (formatnum int, err error) {
 	formatnum = 0
-	_, ok := headers["constraints"]
-	if ok {
+	if _, ok := headers["constraints"]; ok {
 		formatnum = 1
 	}
 	return formatnum, nil

--- a/asserts/account_key_test.go
+++ b/asserts/account_key_test.go
@@ -83,6 +83,9 @@ func (aks *accountKeySuite) TestDecodeOK(c *C) {
 	c.Check(accKey.Name(), Equals, "default")
 	c.Check(accKey.PublicKeyID(), Equals, aks.keyID)
 	c.Check(accKey.Since(), Equals, aks.since)
+
+	// no constraints, anything goes
+	c.Check(accKey.CanSign(nil), Equals, true)
 }
 
 func (aks *accountKeySuite) TestDecodeNoName(c *C) {
@@ -987,4 +990,147 @@ func (aks *accountKeySuite) TestAccountKeyRequestNoAccount(c *C) {
 
 	err = db.Check(akr)
 	c.Assert(err, ErrorMatches, `account-key-request assertion for "acc-id1" does not have a matching account assertion`)
+}
+
+func (aks *accountKeySuite) TestDecodeConstraints(c *C) {
+	encoded := "type: account-key\n" +
+		"format: 1\n" +
+		"authority-id: canonical\n" +
+		"account-id: acc-id1\n" +
+		"name: default\n" +
+		"constraints:\n" +
+		"  -\n" +
+		"    headers:\n" +
+		"      type: model\n" +
+		"      model: foo-.*\n" +
+		"  -\n" +
+		"    headers:\n" +
+		"      type: preseed\n" +
+		"public-key-sha3-384: " + aks.keyID + "\n" +
+		aks.sinceLine +
+		fmt.Sprintf("body-length: %v", len(aks.pubKeyBody)) + "\n" +
+		"sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij" + "\n\n" +
+		aks.pubKeyBody + "\n\n" +
+		"AXNpZw=="
+	a, err := asserts.Decode([]byte(encoded))
+	c.Assert(err, IsNil)
+	c.Check(a.Type(), Equals, asserts.AccountKeyType)
+	accKey := a.(*asserts.AccountKey)
+	c.Check(accKey.AccountID(), Equals, "acc-id1")
+	c.Check(accKey.Name(), Equals, "default")
+	c.Check(accKey.PublicKeyID(), Equals, aks.keyID)
+	c.Check(accKey.Since(), Equals, aks.since)
+}
+
+func (aks *accountKeySuite) TestDecodeConstraintsInvalid(c *C) {
+	const constr = "\n" +
+		"  -\n" +
+		"    headers:\n" +
+		"      type: model\n" +
+		"      model: foo-.*\n"
+	encoded := "type: account-key\n" +
+		"format: 1\n" +
+		"authority-id: canonical\n" +
+		"account-id: acc-id1\n" +
+		"name: default\n" +
+		"constraints:" +
+		constr +
+		"public-key-sha3-384: " + aks.keyID + "\n" +
+		aks.sinceLine +
+		fmt.Sprintf("body-length: %v", len(aks.pubKeyBody)) + "\n" +
+		"sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij" + "\n\n" +
+		aks.pubKeyBody + "\n\n" +
+		"AXNpZw=="
+
+	invalidHeaderTests := []struct{ original, invalid, expectedErr string }{
+		{constr, " x\n", "assertions constraints must be a list of maps"}, {constr, "\n  - foo\n", "assertions constraints must be a list of maps"},
+		{constr, "\n  -\n    headers: x\n", `"headers" constraint must be a map`},
+		{constr, "\n  -\n    header:\n      t: x\n", `"headers" constraint mandatory in asserions constraints`},
+		{constr, "\n  -\n    headers:\n      t: x\n", "type header constraint mandatory in asserions constraints"},
+		{constr, "\n  -\n    headers:\n      type:\n        - foo\n", "type header constraint must be a string"},
+		{constr, "\n  -\n    headers:\n      type: preseed|model\n", "type header constraint must be a precise string and not a regexp"},
+		{constr, "\n  -\n    headers:\n      type: foo\n      model: $X\n", `cannot compile headers constraint: cannot compile "model" constraint "\$X": no \$OP\(\) constraints supported`},
+	}
+	for _, test := range invalidHeaderTests {
+		invalid := strings.Replace(encoded, test.original, test.invalid, 1)
+		_, err := asserts.Decode([]byte(invalid))
+		c.Check(err, ErrorMatches, accKeyErrPrefix+test.expectedErr)
+	}
+}
+
+func (s *accountKeySuite) TestSuggestedFormat(c *C) {
+	fmtnum, err := asserts.SuggestFormat(asserts.AccountKeyType, nil, nil)
+	c.Assert(err, IsNil)
+	c.Check(fmtnum, Equals, 0)
+
+	headers := map[string]interface{}{
+		"constraints": []interface{}{map[string]interface{}{"headers": nil}},
+	}
+	fmtnum, err = asserts.SuggestFormat(asserts.AccountKeyType, headers, nil)
+	c.Assert(err, IsNil)
+	c.Check(fmtnum, Equals, 1)
+}
+
+func (aks *accountKeySuite) TestCanSign(c *C) {
+	encoded := "type: account-key\n" +
+		"format: 1\n" +
+		"authority-id: canonical\n" +
+		"account-id: acc-id1\n" +
+		"name: default\n" +
+		"constraints:\n" +
+		"  -\n" +
+		"    headers:\n" +
+		"      type: model\n" +
+		"      model: foo-.*\n" +
+		"  -\n" +
+		"    headers:\n" +
+		"      type: preseed\n" +
+		"public-key-sha3-384: " + aks.keyID + "\n" +
+		aks.sinceLine +
+		fmt.Sprintf("body-length: %v", len(aks.pubKeyBody)) + "\n" +
+		"sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij" + "\n\n" +
+		aks.pubKeyBody + "\n\n" +
+		"AXNpZw=="
+	a, err := asserts.Decode([]byte(encoded))
+	c.Assert(err, IsNil)
+	c.Check(a.Type(), Equals, asserts.AccountKeyType)
+	accKey := a.(*asserts.AccountKey)
+	mfoo := assertstest.FakeAssertion(map[string]interface{}{
+		"type":         "model",
+		"authority-id": "my-brand",
+		"brand-id":     "my-brand",
+		"series":       "16",
+		"model":        "foo-200",
+		"classic":      "true",
+	})
+	c.Check(accKey.CanSign(mfoo), Equals, true)
+	mnotfoo := assertstest.FakeAssertion(map[string]interface{}{
+		"type":         "model",
+		"authority-id": "my-brand",
+		"brand-id":     "my-brand",
+		"series":       "16",
+		"model":        "goo-200",
+		"classic":      "true",
+	})
+	c.Check(accKey.CanSign(mnotfoo), Equals, false)
+	pr := assertstest.FakeAssertion(map[string]interface{}{
+		"type":              "preseed",
+		"authority-id":      "my-brand",
+		"series":            "16",
+		"brand-id":          "my-brand",
+		"model":             "goo-200",
+		"system-label":      "2023-07-17",
+		"snaps":             []interface{}{},
+		"artifact-sha3-384": "KPIl7M4vQ9d4AUjkoU41TGAwtOMLc_bWUCeW8AvdRWD4_xcP60Oo4ABs1No7BtXj",
+	})
+	c.Check(accKey.CanSign(pr), Equals, true)
+	snapDecl := assertstest.FakeAssertion(map[string]interface{}{
+		"type":         "snap-declaration",
+		"authority-id": "my-brand",
+		"series":       "16",
+		"snap-id":      "snapid",
+		"snap-name":    "foo",
+		"publisher-id": "my-brand",
+	})
+	c.Check(accKey.CanSign(snapDecl), Equals, false)
 }

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -204,6 +204,9 @@ func init() {
 	// 2: support for user-presence constraint
 	maxSupportedFormat[SystemUserType.Name] = 2
 
+	// 1: support for constraints
+	maxSupportedFormat[AccountKeyType.Name] = 1
+
 	for _, at := range typeRegistry {
 		at.validate()
 	}
@@ -235,6 +238,7 @@ func MockOptionalPrimaryKey(assertType *AssertionType, key, defaultValue string)
 }
 
 var formatAnalyzer = map[*AssertionType]func(headers map[string]interface{}, body []byte) (formatnum int, err error){
+	AccountKeyType:      accountKeyFormatAnalyze,
 	SnapDeclarationType: snapDeclarationFormatAnalyze,
 	SystemUserType:      systemUserFormatAnalyze,
 }

--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -78,12 +78,15 @@ func (as *assertsSuite) TestTypeNames(c *C) {
 }
 
 func (as *assertsSuite) TestMaxSupportedFormats(c *C) {
+	accountKeyMaxFormat := asserts.AccountKeyType.MaxSupportedFormat()
 	snapDeclMaxFormat := asserts.SnapDeclarationType.MaxSupportedFormat()
 	systemUserMaxFormat := asserts.SystemUserType.MaxSupportedFormat()
 	// validity
+	c.Check(accountKeyMaxFormat >= 1, Equals, true)
 	c.Check(snapDeclMaxFormat >= 4, Equals, true)
 	c.Check(systemUserMaxFormat >= 2, Equals, true)
 	c.Check(asserts.MaxSupportedFormats(1), DeepEquals, map[string]int{
+		"account-key":      accountKeyMaxFormat,
 		"snap-declaration": snapDeclMaxFormat,
 		"system-user":      systemUserMaxFormat,
 		"test-only":        1,

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -775,6 +775,9 @@ func CheckSignature(assert Assertion, signingKey *AccountKey, roDB RODatabase, c
 		if assert.AuthorityID() != signingKey.AccountID() {
 			return fmt.Errorf("assertion authority %q does not match public key from %q", assert.AuthorityID(), signingKey.AccountID())
 		}
+		if !signingKey.canSign(assert) {
+			return fmt.Errorf("assertion does not match signing constraints for public key %q from %q", assert.SignKeyID(), assert.AuthorityID())
+		}
 	} else {
 		custom, ok := assert.(customSigner)
 		if !ok {

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -1576,6 +1576,80 @@ func (safs *signAddFindSuite) TestFindSequence(c *C) {
 
 }
 
+func (safs *signAddFindSuite) TestCheckConstraints(c *C) {
+	headers := map[string]interface{}{
+		"type":         "account",
+		"authority-id": "canonical",
+		"account-id":   "my-brand",
+		"display-name": "My Brand",
+		"validation":   "verified",
+		"timestamp":    time.Now().Format(time.RFC3339),
+	}
+	acct, err := safs.signingDB.Sign(asserts.AccountType, headers, nil, safs.signingKeyID)
+	c.Assert(err, IsNil)
+
+	err = safs.db.Add(acct)
+	c.Check(err, IsNil)
+
+	pubKey1 := testPrivKey1.PublicKey()
+	pubKey1Encoded, err := asserts.EncodePublicKey(pubKey1)
+	c.Assert(err, IsNil)
+
+	now := time.Now().UTC()
+	headers = map[string]interface{}{
+		"authority-id":        "canonical",
+		"format":              "1",
+		"account-id":          "my-brand",
+		"public-key-sha3-384": pubKey1.ID(),
+		"name":                "default",
+		"since":               now.Format(time.RFC3339),
+		"until":               now.AddDate(1, 0, 0).Format(time.RFC3339),
+		"constraints": []interface{}{
+			map[string]interface{}{
+				"headers": map[string]interface{}{
+					"type":  "model",
+					"model": "foo-.*",
+				},
+			},
+		},
+	}
+	accKey, err := safs.signingDB.Sign(asserts.AccountKeyType, headers, []byte(pubKey1Encoded), safs.signingKeyID)
+	c.Assert(err, IsNil)
+
+	err = safs.db.Add(accKey)
+	c.Check(err, IsNil)
+
+	headers = map[string]interface{}{
+		"type":         "model",
+		"authority-id": "my-brand",
+		"brand-id":     "my-brand",
+		"series":       "16",
+		"model":        "foo-200",
+		"classic":      "true",
+		"timestamp":    now.Format(time.RFC3339),
+	}
+	mfoo, err := asserts.AssembleAndSignInTest(asserts.ModelType, headers, nil, testPrivKey1)
+	c.Assert(err, IsNil)
+
+	headers = map[string]interface{}{
+		"type":         "model",
+		"authority-id": "my-brand",
+		"brand-id":     "my-brand",
+		"series":       "16",
+		"model":        "goo-200",
+		"classic":      "true",
+		"timestamp":    now.Format(time.RFC3339),
+	}
+	mnotfoo, err := asserts.AssembleAndSignInTest(asserts.ModelType, headers, nil, testPrivKey1)
+	c.Assert(err, IsNil)
+
+	err = safs.db.Add(mfoo)
+	c.Check(err, IsNil)
+
+	err = safs.db.Add(mnotfoo)
+	c.Check(err, ErrorMatches, `assertion does not match signing constraints for public key ".*" from "my-brand"`)
+}
+
 type revisionErrorSuite struct{}
 
 func (res *revisionErrorSuite) TestErrorText(c *C) {

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -1631,6 +1631,9 @@ func (safs *signAddFindSuite) TestCheckConstraints(c *C) {
 	mfoo, err := asserts.AssembleAndSignInTest(asserts.ModelType, headers, nil, testPrivKey1)
 	c.Assert(err, IsNil)
 
+	err = safs.db.Add(mfoo)
+	c.Check(err, IsNil)
+
 	headers = map[string]interface{}{
 		"type":         "model",
 		"authority-id": "my-brand",
@@ -1642,9 +1645,6 @@ func (safs *signAddFindSuite) TestCheckConstraints(c *C) {
 	}
 	mnotfoo, err := asserts.AssembleAndSignInTest(asserts.ModelType, headers, nil, testPrivKey1)
 	c.Assert(err, IsNil)
-
-	err = safs.db.Add(mfoo)
-	c.Check(err, IsNil)
 
 	err = safs.db.Add(mnotfoo)
 	c.Check(err, ErrorMatches, `assertion does not match signing constraints for public key ".*" from "my-brand"`)

--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -260,6 +260,10 @@ func init() {
 	maxSupportedFormat[TestOnlySeqType.Name] = 2
 }
 
+func (ak *AccountKey) CanSign(a Assertion) bool {
+	return ak.canSign(a)
+}
+
 // AccountKeyIsKeyValidAt exposes isKeyValidAt on AccountKey for tests
 func AccountKeyIsKeyValidAt(ak *AccountKey, when time.Time) bool {
 	return ak.isValidAt(when)


### PR DESCRIPTION
and take them into account when verifying assertion signatures
