### PR TITLE
tests/nested/manual/core20-preseed: run on uc22

### DIFF
--- a/tests/nested/manual/core20-preseed/task.yaml
+++ b/tests/nested/manual/core20-preseed/task.yaml
@@ -4,14 +4,16 @@ details: |
   This test checks that preseeding of UC20 image with ubuntu-image works
   and that the resulting image boots.
 
-systems: [ubuntu-20.04-64]
+systems:
+  - ubuntu-20.04-64
+  - ubuntu-22.04-64
 
 environment:
   NESTED_UBUNTU_IMAGE_PRESEED_KEY: "\" (test)\""
   NESTED_ENABLE_TPM: false
   NESTED_ENABLE_SECURE_BOOT: true
   NESTED_BUILD_SNAPD_FROM_CURRENT: true
-  NESTED_CUSTOM_MODEL: $TESTSLIB/assertions/developer1-20-dangerous.model
+  NESTED_CUSTOM_MODEL: $TESTSLIB/assertions/developer1-{VERSION}-dangerous.model
   # for the fake store
   STORE_ADDR: localhost:11028
   NESTED_FAKESTORE_BLOB_DIR: $(pwd)/fake-store-blobdir
@@ -60,5 +62,6 @@ execute: |
 
   echo "Check that no snaps are broken"
   remote.exec "snap list" | NOMATCH "broken"
-  remote.exec "snap list" | MATCH "core20"
+  VERSION="$(tests.nested show version)"
+  remote.exec "snap list" | MATCH "core${VERSION}"
   remote.exec "snap list" | MATCH "snapd"


### PR DESCRIPTION
This depends on ubuntu-image to update its `go.mod`.