### PR TITLE
wrappers: tell user systemd instances to reload after updating snapd's user units

### DIFF
--- a/wrappers/core18.go
+++ b/wrappers/core18.go
@@ -324,7 +324,7 @@ func AddSnapdSnapServices(s *snap.Info, opts *AddSnapdSnapServicesOptions, inter
 	}
 
 	// Handle the user services
-	if err := writeSnapdUserServicesOnCore(s, inter); err != nil {
+	if err := writeSnapdUserServicesOnCore(s, opts, inter); err != nil {
 		return err
 	}
 
@@ -431,7 +431,7 @@ func undoSnapdServicesOnCore(s *snap.Info, sysd systemd.Systemd) error {
 	return nil
 }
 
-func writeSnapdUserServicesOnCore(s *snap.Info, inter Interacter) error {
+func writeSnapdUserServicesOnCore(s *snap.Info, opts *AddSnapdSnapServicesOptions, inter Interacter) error {
 	// Ensure /etc/systemd/user exists
 	if err := os.MkdirAll(dirs.SnapUserServicesDir, 0755); err != nil {
 		return err
@@ -497,6 +497,12 @@ func writeSnapdUserServicesOnCore(s *snap.Info, inter Interacter) error {
 		}
 		if err := sysd.EnableNoReload(units); err != nil {
 			return err
+		}
+	}
+
+	if !opts.Preseeding {
+		if err := userDaemonReload(); err != nil {
+			logger.Noticef("failed to reload user systemd instances: %v", err)
 		}
 	}
 

--- a/wrappers/core18_test.go
+++ b/wrappers/core18_test.go
@@ -217,6 +217,7 @@ WantedBy=snapd.service
 		{"--user", "--global", "--no-reload", "enable", "snapd.session-agent.service"},
 		{"--user", "--global", "--no-reload", "disable", "snapd.session-agent.socket"},
 		{"--user", "--global", "--no-reload", "enable", "snapd.session-agent.socket"},
+		{"--user", "daemon-reload"},
 	})
 }
 


### PR DESCRIPTION
The snapd.session-agent.service unit written out on Core devices includes a line like:

    ExecStart=/snap/snapd/NNNN/usr/bin/snap userd --agent

Running user session systemd instances will cache the unit, and should that snapd revision be removed, the unit can no longer be started. This can then break future operations that rely on the session agent.

To fix this, we ask all available session agents to do a deamon-reload after the new versions of the units have been written out. The exec path in the cached version of the unit should work for this call, since the old snapd revision is still available while upgrading to the new one.