### PR TITLE
tests: fix upgrade-from-release for ubuntu mantic and fix it for lunar

### DIFF
--- a/tests/main/upgrade-from-release/task.yaml
+++ b/tests/main/upgrade-from-release/task.yaml
@@ -13,8 +13,8 @@ restore: |
     distro_install_build_snapd
 
 execute: |
-    if os.query is-ubuntu 23.04; then
-        echo "Ubuntu lunar is skipped until it is released."
+    if os.query is-ubuntu 23.10; then
+        echo "Ubuntu mantic is skipped until it is released."
         exit
     fi
 
@@ -44,6 +44,7 @@ execute: |
     fi
 
     declare -A EXPECTED_SNAPD_VERSIONS=(
+        ["23.04"]='2.59.1\+23.04'
         ["22.10"]='2.57.4\+22.10'
         ["22.04"]='2.55.3\+22.04'
         ["20.04"]='2.44.3\+20.04'


### PR DESCRIPTION
make the test work for ubuntu lunar
