### PR TITLE
osutil: fix broken {old,new}Dir.Sync() in AtomicRename()

### DIFF
--- a/osutil/io.go
+++ b/osutil/io.go
@@ -262,7 +262,7 @@ func AtomicWriteChown(filename string, reader io.Reader, perm os.FileMode, flags
 }
 
 // AtomicRename attempts to rename a path from oldName to newName atomically.
-func AtomicRename(oldName, newName string) error {
+func AtomicRename(oldName, newName string) (err error) {
 	var oldDir, newDir *os.File
 
 	// snapdUnsafeIO controls the ability to ignore expensive disk
@@ -276,13 +276,13 @@ func AtomicRename(oldName, newName string) error {
 		oldDirPath := filepath.Dir(oldName)
 		newDirPath := filepath.Dir(newName)
 
-		oldDir, err := os.Open(oldDirPath)
+		oldDir, err = os.Open(oldDirPath)
 		if err != nil {
 			return err
 		}
 		defer oldDir.Close()
 
-		newDir, err := os.Open(newDirPath)
+		newDir, err = os.Open(newDirPath)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The AtomicRename() code was assigning {old,new}Dir only inside the `if !snapdUnsafeIO{}` block which means that the `{old,new}Dir.Sync()` calls never happend.
