### PR TITLE
preseed: remove unneeded error check after sd.EssentialSnaps()

### DIFF
--- a/image/preseed/preseed.go
+++ b/image/preseed/preseed.go
@@ -158,11 +158,7 @@ func writePreseedAssertion(artifactDigest []byte, opts *preseedCoreOptions) erro
 	if err != nil {
 		return err
 	}
-	essSnaps := sd.EssentialSnaps()
-	if err != nil {
-		return err
-	}
-	for _, ess := range essSnaps {
+	for _, ess := range sd.EssentialSnaps() {
 		addSnap(ess)
 	}
 	for _, msnap := range modeSnaps {


### PR DESCRIPTION
There is no need to check `sd.EssentialSnaps()` as it does not return an error.

