### PR TITLE
client: fix specificErr handling in SnapshotExport()

### DIFF
--- a/client/snapshot.go
+++ b/client/snapshot.go
@@ -243,9 +243,12 @@ func (client *Client) SnapshotExport(setID uint64) (stream io.ReadCloser, conten
 		defer rsp.Body.Close()
 
 		var r response
-		specificErr := r.err(client, rsp.StatusCode)
-		if err != nil {
-			return nil, 0, specificErr
+		dec := json.NewDecoder(rsp.Body)
+		if err := dec.Decode(&r); err == nil {
+			specificErr := r.err(client, rsp.StatusCode)
+			if specificErr != nil {
+				return nil, 0, specificErr
+			}
 		}
 		return nil, 0, fmt.Errorf("unexpected status code: %v", rsp.Status)
 	}

--- a/client/snapshot_test.go
+++ b/client/snapshot_test.go
@@ -142,6 +142,7 @@ func (cs *clientSuite) TestClientCheckSnapshots(c *check.C) {
 func (cs *clientSuite) TestClientRestoreSnapshots(c *check.C) {
 	cs.testClientSnapshotAction(c, "restore", cs.cli.RestoreSnapshots)
 }
+
 func (cs *clientSuite) TestClientExportSnapshotSpecificErr(c *check.C) {
 	content := `{"type":"error","status-code":400,"result":{"message":"boom","kind":"err-kind","value":"err-value"}}`
 	cs.contentLength = int64(len(content))

--- a/client/snapshot_test.go
+++ b/client/snapshot_test.go
@@ -142,6 +142,15 @@ func (cs *clientSuite) TestClientCheckSnapshots(c *check.C) {
 func (cs *clientSuite) TestClientRestoreSnapshots(c *check.C) {
 	cs.testClientSnapshotAction(c, "restore", cs.cli.RestoreSnapshots)
 }
+func (cs *clientSuite) TestClientExportSnapshotSpecificErr(c *check.C) {
+	content := `{"type":"error","status-code":400,"result":{"message":"boom","kind":"err-kind","value":"err-value"}}`
+	cs.contentLength = int64(len(content))
+	cs.rsp = content
+	cs.status = 400
+	cs.header = http.Header{"Content-Type": []string{"application/json"}}
+	_, _, err := cs.cli.SnapshotExport(42)
+	c.Check(err, check.ErrorMatches, "boom")
+}
 
 func (cs *clientSuite) TestClientExportSnapshot(c *check.C) {
 	type tableT struct {


### PR DESCRIPTION
The code was checking generating a `specificErr` but then checked `if err != nil {` (and not check for specificErr) and also lacked a unit test.

When adding the code test it became clear that the other issue there is that the response body was never read so r.err() would always return nil.

This commit fixes both issues.
