### PR TITLE
systemd: fix incorrect err handling in ensureMountUnitFile()

### DIFF
--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -1429,8 +1429,8 @@ func ensureMountUnitFile(u *MountUnitOptions) (mountUnitName string, modified mo
 
 	if stateErr == osutil.ErrSameState {
 		modified = mountUnchanged
-	} else if err != nil {
-		return "", mountUnchanged, err
+	} else if stateErr != nil {
+		return "", mountUnchanged, stateErr
 	}
 
 	return filepath.Base(mu), modified, nil


### PR DESCRIPTION
The ensureMountUnitFile() was not handling errors from osutil.EnsureFileState() correctly. This commit fixes this and adds a unit test.

