### PR TITLE
boot: fix redundant error check in markSuccessful()

### DIFF
--- a/boot/bootstate20.go
+++ b/boot/bootstate20.go
@@ -880,9 +880,6 @@ func (brs20 *bootState20Model) markSuccessful(update bootStateUpdate) (bootState
 	// sign key ID was not being populated in earlier versions of snapd, try
 	// to remedy that
 	if u20.modeenv.ModelSignKeyID == "" {
-		if err != nil {
-			return nil, err
-		}
 		u20.writeModeenv.ModelSignKeyID = brs20.dev.Model().SignKeyID()
 	}
 	return u20, nil


### PR DESCRIPTION
This commit removes an error check that is unnecessary. No new error is created here and err is already checked 4 lines above.

