### PR TITLE
interfaces: fix missing error return in kvm

### DIFF
--- a/interfaces/builtin/kvm.go
+++ b/interfaces/builtin/kvm.go
@@ -104,7 +104,7 @@ func (iface *kvmInterface) KModConnectedPlug(spec *kmod.Specification, plug *int
 	}
 
 	if err := spec.AddModule(m); err != nil {
-		return nil
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
Everywhere else we check/return err if spec.AddModule() fails so this looks like an oversight.