### PR TITLE
disks: fix copy/paste error in mockdisks.go

### DIFF
--- a/osutil/disks/disks_linux_test.go
+++ b/osutil/disks/disks_linux_test.go
@@ -2035,3 +2035,17 @@ func (s *diskSuite) TestFindMatchingPartitionWithFsLabel(c *C) {
 		}
 	}
 }
+
+func (s *diskSuite) TestMockDisksChecking(c *C) {
+	f := func() {
+		disks.MockDeviceNameToDiskMapping(map[string]*disks.MockDiskMapping{
+			"/dev/vda": {
+				Structure: []disks.Partition{
+					{KernelDeviceNode: "/dev/vda1"},
+					{KernelDeviceNode: "/dev/vda1"},
+				},
+			},
+		})
+	}
+	c.Check(f, Panics, "mock error: duplicated kernel device nodes for partitions in disk mapping")
+}

--- a/osutil/disks/mockdisk.go
+++ b/osutil/disks/mockdisk.go
@@ -261,7 +261,7 @@ func checkMockDiskMappingsForDuplicates(mockedDisks map[string]*MockDiskMapping)
 	for _, disk := range mockedDisks {
 		sendDevNodes := map[string]bool{}
 		for _, p := range disk.Structure {
-			if p.KernelDevicePath == "" {
+			if p.KernelDeviceNode == "" {
 				continue
 			}
 


### PR DESCRIPTION
The loop is about `KernelDeviceNode` but the code checks for `KernelDevicePath`. This looks like a copy/paste error from the previous looe` but the code checks
for `KernelDevicePath`. This is a copy/paste error from the previous loop. Includes a unit test.

