### PR TITLE
o/state: Reduce number of days refresh is inhibited from 14 days to 4

### DIFF
--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -51,9 +51,9 @@ const maxPostponementBuffer = 5 * 24 * time.Hour
 
 // cannot inhibit refreshes for more than maxInhibition;
 // deduct 1s so it doesn't look confusing initially when two notifications
-// get displayed in short period of time and it immediately goes from "14 days"
-// to "13 days" left.
-const maxInhibition = 14*24*time.Hour - time.Second
+// get displayed in short period of time and it immediately goes from "4 days"
+// to "3 days" left.
+const maxInhibition = 4*24*time.Hour - time.Second
 
 // maxDuration is used to represent "forever" internally (it's 290 years).
 const maxDuration = time.Duration(1<<63 - 1)

--- a/overlord/snapstate/autorefresh_test.go
+++ b/overlord/snapstate/autorefresh_test.go
@@ -963,7 +963,7 @@ func (s *autoRefreshTestSuite) TestInitialInhibitRefreshWithinInhibitWindow(c *C
 	refreshInfo := timedErr.PendingSnapRefreshInfo()
 	c.Assert(refreshInfo, NotNil)
 	c.Check(refreshInfo.InstanceName, Equals, "pkg")
-	c.Check(refreshInfo.TimeRemaining, Equals, time.Hour*14*24-time.Second)
+	c.Check(refreshInfo.TimeRemaining, Equals, time.Hour*4*24-time.Second)
 }
 
 func (s *autoRefreshTestSuite) TestSubsequentInhibitRefreshWithinInhibitWindow(c *C) {
@@ -1003,7 +1003,7 @@ func (s *autoRefreshTestSuite) TestSubsequentInhibitRefreshWithinInhibitWindow(c
 	c.Check(refreshInfo.InstanceName, Equals, "pkg")
 	// XXX: This test measures real time, with second granularity.
 	// It takes non-zero (hence the subtracted second) to execute the test.
-	c.Check(refreshInfo.TimeRemaining, Equals, time.Hour*14*24/2-time.Second)
+	c.Check(refreshInfo.TimeRemaining, Equals, time.Hour*4*24/2-time.Second)
 }
 
 func (s *autoRefreshTestSuite) TestInhibitRefreshRefreshesWhenOverdue(c *C) {


### PR DESCRIPTION
As shown in updated design:
![image-20230712-103620](https://github.com/snapcore/snapd/assets/126560/0613a0aa-136e-4d8e-9634-53149cf5d3b4)
