### PR TITLE
interfaces/u2f-devices: add Swissbit iShield Key

### DIFF
--- a/interfaces/builtin/u2f_devices.go
+++ b/interfaces/builtin/u2f_devices.go
@@ -167,6 +167,11 @@ var u2fDevices = []u2fDevice{
 		VendorIDPattern:  "16d0",
 		ProductIDPattern: "0e90",
 	},
+	{
+		Name:             "Swissbit iShield Key",
+		VendorIDPattern:  "1370",
+		ProductIDPattern: "0911",
+	},
 }
 
 const u2fDevicesConnectedPlugAppArmor = `

--- a/interfaces/builtin/u2f_devices_test.go
+++ b/interfaces/builtin/u2f_devices_test.go
@@ -89,7 +89,7 @@ func (s *u2fDevicesInterfaceSuite) TestAppArmorSpec(c *C) {
 func (s *u2fDevicesInterfaceSuite) TestUDevSpec(c *C) {
 	spec := &udev.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 26)
+	c.Assert(spec.Snippets(), HasLen, 27)
 	c.Assert(spec.Snippets(), testutil.Contains, `# u2f-devices
 # Yubico YubiKey
 SUBSYSTEM=="hidraw", KERNEL=="hidraw*", ATTRS{idVendor}=="1050", ATTRS{idProduct}=="0113|0114|0115|0116|0120|0121|0200|0402|0403|0406|0407|0410", TAG+="snap_consumer_app"`)


### PR DESCRIPTION
This PR adds support for the Swissbit iShield Key series which supports FIDO2 (U2F/CTAP).

dmesg output:
```
[ 2300.560476] usb 1-1: USB disconnect, device number 22
[ 2301.471451] usb 1-1: new full-speed USB device number 23 using xhci_hcd
[ 2301.629671] usb 1-1: New USB device found, idVendor=1370, idProduct=0911, bcdDevice= 0.01
[ 2301.629699] usb 1-1: New USB device strings: Mfr=1, Product=2, SerialNumber=0
[ 2301.629706] usb 1-1: Product: iShield Key Pro
[ 2301.629712] usb 1-1: Manufacturer: Swissbit
```

Reference: https://www.swissbit.com/en/products/ishield-key
