### PR TITLE
i/b/network-control: allow configuring some specific network component device via sysfs

### DIFF
--- a/interfaces/builtin/network_control.go
+++ b/interfaces/builtin/network_control.go
@@ -209,6 +209,9 @@ network sna,
 # For reading the address of a particular ethernet interface
 /sys/devices/{pci[0-9a-f]*,platform,virtual}/**/net/*/address r,
 
+# Some specific drivers are configured via config file
+/sys/devices/{pci[0-9a-f]*,platform,virtual}/**/config rw,
+
 # arp
 network netlink dgram,
 


### PR DESCRIPTION
The customer has a specific network component chip for industrial automation whose driver provides a way to configure the device via sysfs. 

```
May 04 15:48:33 mydevice audit[754]: AVC apparmor="DENIED" operation="open" profile="snap.my-snap.control" name="/sys/devices/pci0000:00/0000:00:01.1/0000:02:00.0/0000:03:00.0/config" pid=754 comm="my-snap" requested_mask="w" denied_mask="w" fsuid=0 ouid=0
May 04 15:48:33 mydevice kernel: audit: type=1400 audit(1683229713.151:85): apparmor="DENIED" operation="open" profile="snap.my-snap.control" name="/sys/devices/pci0000:00/0000:00:01.1/0000:02:00.0/0000:03:00.0/config" pid=754 comm="my-snap" requested_mask="w" denied_mask="w" fsuid=0 ouid=0
```

This PR expands the AppArmor profile to allow developers/customers to configure specific network drivers via sysfs. 
