### PR TITLE
packaging: update squashfuse to 0.2.0

### DIFF
--- a/c-vendor/vendor.sh
+++ b/c-vendor/vendor.sh
@@ -8,11 +8,12 @@ if [ ! -d ./squashfuse ]; then
     git clone https://github.com/vasi/squashfuse
 fi
 
-# This is just tip/master as of Aug 30th 2021, there is no other
-# specific reason to use this. It works with both "libfuse-dev" and
-# "libfuse3-dev" which is important as 16.04 only have libfuse-dev
-# and 21.10 only has libfuse3-dev
+# This is the commit that was tagged as 0.2.0, released on June 2023:
+# https://github.com/vasi/squashfuse/releases/tag/0.2.0
+# It contains bug fixes and adds multithreading support to squashfuse_ll.
+# It still should work with both "libfuse-dev" and "libfuse3-dev" which
+# is important as 16.04 only has libfuse-dev and 21.10 only has libfuse3-dev
 if [ -d ./squashfuse/.git ]; then
-    (cd squashfuse && git checkout 74f4fe86ebd47a2fb7df5cb60d452354f977c72e)
+    (cd squashfuse && git checkout 7ce9d15f4b0a7a76ddf08e662abde4a3e340bb41)
 fi
 


### PR DESCRIPTION
Hi! I've noticed that there is activity again in the [squashfuse repo](https://github.com/vasi/squashfuse) and that they just released [version 0.2.0](https://github.com/vasi/squashfuse/releases/tag/0.2.0) which, among bug fixes, adds multithreading support to squashfuse_ll.
This is not yet activated by default, [but will be in the next version](https://github.com/vasi/squashfuse/pull/100), but can be activated on a subsequent PR, as it should help with [performance of snaps running](https://github.com/nextcloud-snap/nextcloud-snap/issues/2453#issuecomment-1637381734) [inside of containers](https://github.com/apptainer/apptainer/issues/665#issuecomment-1249783592).