### PR TITLE
locale_control: add locale1 dbus support

### DIFF
--- a/interfaces/builtin/account_control.go
+++ b/interfaces/builtin/account_control.go
@@ -72,31 +72,6 @@ dbus (receive)
     member=PropertiesChanged
     peer=(label=unconfined),
 
-# Introspection of org.freedesktop.locale1
-dbus (send)
-	bus=system
-	path=/org/freedesktop/locale1
-	interface=org.freedesktop.DBus.Introspectable
-	member=Introspect,
-# Properties of org.freedesktop.locale1
-dbus (send)
-	bus=system
-	path=/org/freedesktop/locale1
-	interface=org.freedesktop.DBus.Properties
-	member=Get{,All},
-# do not use peer=(label=unconfined) here since this is DBus activated
-dbus (send)
-	bus=system
-	path=/org/freedesktop/locale1
-	interface=org.freedesktop.locale1
-	member={SetLocale,SetX11Keyboard,SetVConsoleKeyboard},
-# Receive Accounts property changed events
-dbus (receive)
-	bus=system
-	path=/org/freedesktop/locale1
-	interface=org.freedesktop.DBus.Properties
-	member=PropertiesChanged,
-
 /{,usr/}sbin/chpasswd ixr,
 /{,usr/}sbin/user{add,del} ixr,
 

--- a/interfaces/builtin/account_control.go
+++ b/interfaces/builtin/account_control.go
@@ -72,6 +72,31 @@ dbus (receive)
     member=PropertiesChanged
     peer=(label=unconfined),
 
+# Introspection of org.freedesktop.locale1
+dbus (send)
+	bus=system
+	path=/org/freedesktop/locale1
+	interface=org.freedesktop.DBus.Introspectable
+	member=Introspect,
+# Properties of org.freedesktop.locale1
+dbus (send)
+	bus=system
+	path=/org/freedesktop/locale1
+	interface=org.freedesktop.DBus.Properties
+	member=Get{,All},
+# do not use peer=(label=unconfined) here since this is DBus activated
+dbus (send)
+	bus=system
+	path=/org/freedesktop/locale1
+	interface=org.freedesktop.locale1
+	member={SetLocale,SetX11Keyboard,SetVConsoleKeyboard},
+# Receive Accounts property changed events
+dbus (receive)
+	bus=system
+	path=/org/freedesktop/locale1
+	interface=org.freedesktop.DBus.Properties
+	member=PropertiesChanged,
+
 /{,usr/}sbin/chpasswd ixr,
 /{,usr/}sbin/user{add,del} ixr,
 

--- a/interfaces/builtin/locale_control.go
+++ b/interfaces/builtin/locale_control.go
@@ -53,12 +53,6 @@ dbus (send)
 	path=/org/freedesktop/locale1
 	interface=org.freedesktop.locale1
 	member={SetLocale,SetX11Keyboard,SetVConsoleKeyboard}
-	peer=(label=unconfined),
-dbus (send)
-	bus=system
-	path=/org/freedesktop/locale1
-	interface=org.freedesktop.locale1
-	member={SetLocale,SetX11Keyboard,SetVConsoleKeyboard}
 	peer=(name=org.freedesktop.locale1),
 # Receive Accounts property changed events
 dbus (receive)

--- a/interfaces/builtin/locale_control.go
+++ b/interfaces/builtin/locale_control.go
@@ -33,6 +33,31 @@ const localeControlBaseDeclarationSlots = `
 const localeControlConnectedPlugAppArmor = `
 # Description: Can manage locales directly separate from 'config ubuntu-core'.
 
+# Introspection of org.freedesktop.locale1
+dbus (send)
+	bus=system
+	path=/org/freedesktop/locale1
+	interface=org.freedesktop.DBus.Introspectable
+	member=Introspect,
+# Properties of org.freedesktop.locale1
+dbus (send)
+	bus=system
+	path=/org/freedesktop/locale1
+	interface=org.freedesktop.DBus.Properties
+	member=Get{,All},
+# do not use peer=(label=unconfined) here since this is DBus activated
+dbus (send)
+	bus=system
+	path=/org/freedesktop/locale1
+	interface=org.freedesktop.locale1
+	member={SetLocale,SetX11Keyboard,SetVConsoleKeyboard},
+# Receive Accounts property changed events
+dbus (receive)
+	bus=system
+	path=/org/freedesktop/locale1
+	interface=org.freedesktop.DBus.Properties
+	member=PropertiesChanged,
+
 # TODO: this won't work until snappy exposes this configurability
 /etc/default/locale rw,
 `

--- a/interfaces/builtin/locale_control.go
+++ b/interfaces/builtin/locale_control.go
@@ -33,6 +33,8 @@ const localeControlBaseDeclarationSlots = `
 const localeControlConnectedPlugAppArmor = `
 # Description: Can manage locales directly separate from 'config ubuntu-core'.
 
+#include <abstractions/dbus-strict>
+
 # Introspection of org.freedesktop.locale1
 dbus (send)
 	bus=system
@@ -50,7 +52,14 @@ dbus (send)
 	bus=system
 	path=/org/freedesktop/locale1
 	interface=org.freedesktop.locale1
-	member={SetLocale,SetX11Keyboard,SetVConsoleKeyboard},
+	member={SetLocale,SetX11Keyboard,SetVConsoleKeyboard}
+	peer=(label=unconfined),
+dbus (send)
+	bus=system
+	path=/org/freedesktop/locale1
+	interface=org.freedesktop.locale1
+	member={SetLocale,SetX11Keyboard,SetVConsoleKeyboard}
+	peer=(name=org.freedesktop.locale1),
 # Receive Accounts property changed events
 dbus (receive)
 	bus=system


### PR DESCRIPTION
This PR adds support for the org.freedesktop.locale1 DBus interface. It is required for Ubuntu Core Desktop and for the installer.

Fix git checkout -b UDENG-1110-add-locale-1-dbus-interface-support-in-snapd

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
