### PR TITLE
arch: add new `arch.Endian()` helper and use it in seccomp

### DIFF
--- a/arch/endian.go
+++ b/arch/endian.go
@@ -27,7 +27,7 @@ import (
 
 var runtimeGOARCH = runtime.GOARCH
 
-// Endian will return the native endianes of the system
+// Endian will return the native endianness of the system
 func Endian() binary.ByteOrder {
 	switch runtimeGOARCH {
 	case "ppc", "ppc64", "s390x":
@@ -35,6 +35,6 @@ func Endian() binary.ByteOrder {
 	case "i386", "amd64", "arm", "arm64", "riscv64":
 		return binary.LittleEndian
 	default:
-		panic(fmt.Sprintf("unknown architecture %v", runtime.GOARCH))
+		panic(fmt.Sprintf("unknown architecture %s", runtimeGOARCH))
 	}
 }

--- a/arch/endian.go
+++ b/arch/endian.go
@@ -1,0 +1,40 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package arch
+
+import (
+	"encoding/binary"
+	"fmt"
+	"runtime"
+)
+
+var runtimeGOARCH = runtime.GOARCH
+
+// Endian will return the native endianes of the system
+func Endian() binary.ByteOrder {
+	switch runtimeGOARCH {
+	case "ppc", "ppc64", "s390x":
+		return binary.BigEndian
+	case "i386", "amd64", "arm", "arm64", "riscv64":
+		return binary.LittleEndian
+	default:
+		panic(fmt.Sprintf("unknown architecture %v", runtime.GOARCH))
+	}
+}

--- a/arch/endian_test.go
+++ b/arch/endian_test.go
@@ -56,5 +56,5 @@ func (s *endianTestSuite) TestEndianErrors(c *C) {
 	restore := arch.MockRuntimeGOARCH("unknown-arch")
 	defer restore()
 
-	c.Check(func() { arch.Endian() }, Panics, "unknown architecture amd64")
+	c.Check(func() { arch.Endian() }, Panics, "unknown architecture unknown-arch")
 }

--- a/arch/endian_test.go
+++ b/arch/endian_test.go
@@ -1,0 +1,60 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package arch_test
+
+import (
+	"encoding/binary"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/arch"
+)
+
+type endianTestSuite struct{}
+
+var _ = Suite(&endianTestSuite{})
+
+func (s *endianTestSuite) TestEndian(c *C) {
+	for _, t := range []struct {
+		arch   string
+		endian binary.ByteOrder
+	}{
+		{"ppc", binary.BigEndian},
+		{"ppc64", binary.BigEndian},
+		{"s390x", binary.BigEndian},
+		{"i386", binary.LittleEndian},
+		{"amd64", binary.LittleEndian},
+		{"arm", binary.LittleEndian},
+		{"arm64", binary.LittleEndian},
+		{"riscv64", binary.LittleEndian},
+	} {
+		restore := arch.MockRuntimeGOARCH(t.arch)
+		defer restore()
+
+		c.Check(arch.Endian(), Equals, t.endian)
+	}
+}
+
+func (s *endianTestSuite) TestEndianErrors(c *C) {
+	restore := arch.MockRuntimeGOARCH("unknown-arch")
+	defer restore()
+
+	c.Check(func() { arch.Endian() }, Panics, "unknown architecture amd64")
+}

--- a/arch/export_test.go
+++ b/arch/export_test.go
@@ -1,0 +1,30 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package arch
+
+import (
+	"github.com/snapcore/snapd/testutil"
+)
+
+func MockRuntimeGOARCH(arch string) (restore func()) {
+	restore = testutil.Backup(&runtimeGOARCH)
+	runtimeGOARCH = arch
+	return restore
+}

--- a/interfaces/seccomp/backend.go
+++ b/interfaces/seccomp/backend.go
@@ -34,6 +34,7 @@ package seccomp
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -120,7 +121,7 @@ func (b *Backend) Initialize(*interfaces.SecurityBackendOptions) error {
 	dir := dirs.SnapSeccompDir
 	fname := "global.bin"
 	var globalProfile []byte
-	if isBigEndian() {
+	if arch.Endian() == binary.BigEndian {
 		globalProfile = globalProfileBE
 	} else {
 		globalProfile = globalProfileLE

--- a/interfaces/seccomp/backend_test.go
+++ b/interfaces/seccomp/backend_test.go
@@ -21,6 +21,7 @@ package seccomp_test
 
 import (
 	"bytes"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -32,6 +33,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/arch"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/ifacetest"
@@ -111,7 +113,7 @@ func (s *backendSuite) TestInitialize(c *C) {
 	err := s.Backend.Initialize(nil)
 	c.Assert(err, IsNil)
 	fname := filepath.Join(dirs.SnapSeccompDir, "global.bin")
-	if seccomp.IsBigEndian() {
+	if arch.Endian() == binary.BigEndian {
 		c.Check(fname, testutil.FileEquals, seccomp.GlobalProfileBE)
 	} else {
 		c.Check(fname, testutil.FileEquals, seccomp.GlobalProfileLE)

--- a/interfaces/seccomp/export_test.go
+++ b/interfaces/seccomp/export_test.go
@@ -95,7 +95,6 @@ var (
 
 	GlobalProfileLE = globalProfileLE
 	GlobalProfileBE = globalProfileBE
-	IsBigEndian     = isBigEndian
 
 	ParallelCompile = parallelCompile
 )


### PR DESCRIPTION
Go has no good way to get the native endianness of a system. However for certain use-cases (like seccomp) this is quite important. We already have a (hackish) `isBigEndian()` helper in our code. However this will also be needed in snap-seccomp for PR#13014 this will also be needed so moving the helper to the `arch` package seems to be prudent.
