### PR TITLE
tests/core20-auto-remove-user: do retries for set-ntp

### DIFF
--- a/tests/nested/manual/core20-auto-remove-user/task.yaml
+++ b/tests/nested/manual/core20-auto-remove-user/task.yaml
@@ -178,7 +178,7 @@ execute: |
   teardown_ramdisk
 
   # lets put the system time ahead by 1h
-  remote.exec "sudo timedatectl set-ntp false"
+  retry -n 3 --wait 5 remote.exec "sudo timedatectl set-ntp false"
   remote.exec "sudo date -s 'next hour'"
 
   # run ensure state to have the user removed


### PR DESCRIPTION
The "sudo timedatectl set-ntp false" command some times fails with message:

Failed to set ntp: Connection timed out

Apparently because it takes a bit of time to start org.freedesktop.timedate1 and then stop systemd-timedated, as trying again fixes the issue. Do some retries to prevent random failures of this spread test.