### PR TITLE
asserts,seed: preseed authority delegation

### DIFF
--- a/asserts/model.go
+++ b/asserts/model.go
@@ -674,7 +674,7 @@ func checkAuthorityMatchesBrand(a Assertion) error {
 	return nil
 }
 
-func checkOptionalAuthority(name string, acceptsAny bool, headers map[string]interface{}, brandID string) ([]string, error) {
+func checkOptionalAuthority(headers map[string]interface{}, name string, brandID string, acceptsAny bool) ([]string, error) {
 	ids := []string{brandID}
 	v, ok := headers[name]
 	if !ok {
@@ -703,15 +703,18 @@ func checkOptionalAuthority(name string, acceptsAny bool, headers map[string]int
 }
 
 func checkOptionalSerialAuthority(headers map[string]interface{}, brandID string) ([]string, error) {
-	return checkOptionalAuthority("serial-authority", false, headers, brandID)
+	const acceptsAny = false
+	return checkOptionalAuthority(headers, "serial-authority", brandID, acceptsAny)
 }
 
 func checkOptionalSystemUserAuthority(headers map[string]interface{}, brandID string) ([]string, error) {
-	return checkOptionalAuthority("system-user-authority", true, headers, brandID)
+	const acceptsAny = true
+	return checkOptionalAuthority(headers, "system-user-authority", brandID, acceptsAny)
 }
 
 func checkOptionalPreseedAuthority(headers map[string]interface{}, brandID string) ([]string, error) {
-	return checkOptionalAuthority("preseed-authority", false, headers, brandID)
+	const acceptsAny = false
+	return checkOptionalAuthority(headers, "preseed-authority", brandID, acceptsAny)
 }
 
 func checkModelValidationSetAccountID(headers map[string]interface{}, what, brandID string) (string, error) {

--- a/asserts/model.go
+++ b/asserts/model.go
@@ -674,7 +674,7 @@ func checkAuthorityMatchesBrand(a Assertion) error {
 	return nil
 }
 
-func checkOptionalAuthority(headers map[string]interface{}, name string, brandID string, acceptsAny bool) ([]string, error) {
+func checkOptionalAuthority(headers map[string]interface{}, name string, brandID string, acceptsWildcard bool) ([]string, error) {
 	ids := []string{brandID}
 	v, ok := headers[name]
 	if !ok {
@@ -682,7 +682,7 @@ func checkOptionalAuthority(headers map[string]interface{}, name string, brandID
 	}
 	switch x := v.(type) {
 	case string:
-		if acceptsAny && x == "*" {
+		if acceptsWildcard && x == "*" {
 			return nil, nil
 		}
 	case []interface{}:
@@ -695,7 +695,7 @@ func checkOptionalAuthority(headers map[string]interface{}, name string, brandID
 		}
 	}
 
-	if acceptsAny {
+	if acceptsWildcard {
 		return nil, fmt.Errorf("%q header must be '*' or a list of account ids", name)
 	} else {
 		return nil, fmt.Errorf("%q header must be a list of account ids", name)
@@ -703,18 +703,18 @@ func checkOptionalAuthority(headers map[string]interface{}, name string, brandID
 }
 
 func checkOptionalSerialAuthority(headers map[string]interface{}, brandID string) ([]string, error) {
-	const acceptsAny = false
-	return checkOptionalAuthority(headers, "serial-authority", brandID, acceptsAny)
+	const acceptsWildcard = false
+	return checkOptionalAuthority(headers, "serial-authority", brandID, acceptsWildcard)
 }
 
 func checkOptionalSystemUserAuthority(headers map[string]interface{}, brandID string) ([]string, error) {
-	const acceptsAny = true
-	return checkOptionalAuthority(headers, "system-user-authority", brandID, acceptsAny)
+	const acceptsWildcard = true
+	return checkOptionalAuthority(headers, "system-user-authority", brandID, acceptsWildcard)
 }
 
 func checkOptionalPreseedAuthority(headers map[string]interface{}, brandID string) ([]string, error) {
-	const acceptsAny = false
-	return checkOptionalAuthority(headers, "preseed-authority", brandID, acceptsAny)
+	const acceptsWildcard = false
+	return checkOptionalAuthority(headers, "preseed-authority", brandID, acceptsWildcard)
 }
 
 func checkModelValidationSetAccountID(headers map[string]interface{}, what, brandID string) (string, error) {

--- a/asserts/model.go
+++ b/asserts/model.go
@@ -627,7 +627,7 @@ func (mod *Model) SystemUserAuthority() []string {
 	return mod.sysUserAuthority
 }
 
-// SystemUserAuthority returns the authority ids that are accepted as
+// PreseedAuthority returns the authority ids that are accepted as
 // signers of the preseed binary blob for this model. It always includes the
 // brand of the model.
 func (mod *Model) PreseedAuthority() []string {

--- a/asserts/model.go
+++ b/asserts/model.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2022 Canonical Ltd
+ * Copyright (C) 2016-2023 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/asserts/model_test.go
+++ b/asserts/model_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2020 Canonical Ltd
+ * Copyright (C) 2016-2023 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/asserts/preseed.go
+++ b/asserts/preseed.go
@@ -74,7 +74,7 @@ func (p *Preseed) Series() string {
 	return p.HeaderString("series")
 }
 
-// BrandID returns the brand identifier. Same as the authority id.
+// BrandID returns the brand identifier.
 func (p *Preseed) BrandID() string {
 	return p.HeaderString("brand-id")
 }
@@ -186,13 +186,11 @@ func checkPreseedSnaps(snapList interface{}) ([]*PreseedSnap, error) {
 }
 
 func assemblePreseed(assert assertionBase) (Assertion, error) {
-	// authority must match the brand (signer is the brand)
-	err := checkAuthorityMatchesBrand(&assert)
-	if err != nil {
-		return nil, err
-	}
+	// because the authority-id and model-id can differ (as per the model),
+	// authority-id should be validated against allowed IDs when the preseed
+	// blob is being checked
 
-	_, err = checkModel(assert.headers)
+	_, err := checkModel(assert.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/asserts/preseed.go
+++ b/asserts/preseed.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2022 Canonical Ltd
+ * Copyright (C) 2023 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/asserts/preseed_test.go
+++ b/asserts/preseed_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2022 Canonical Ltd
+ * Copyright (C) 2023 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/asserts/preseed_test.go
+++ b/asserts/preseed_test.go
@@ -138,7 +138,6 @@ func (ps *preseedSuite) TestDecodeInvalid(c *C) {
 		{"model: baz-3000\n", "model: -\n", `"model" header contains invalid characters: "-"`},
 		{"brand-id: brand-id1\n", "", `"brand-id" header is mandatory`},
 		{"brand-id: brand-id1\n", "brand-id: \n", `"brand-id" header should not be empty`},
-		{"brand-id: brand-id1\n", "brand-id: brand-id2\n", `authority-id and brand-id must match, preseed assertions are expected to be signed by the brand: "brand-id1" != "brand-id2"`},
 		{"system-label: 20220210\n", "system-label: \n", `"system-label" header should not be empty`},
 		{"system-label: 20220210\n", "system-label: -x\n", `"system-label" header contains invalid characters: "-x"`},
 		{ps.tsLine, "timestamp: 12:30\n", `"timestamp" header is not a RFC3339 date: .*`},

--- a/seed/seed20.go
+++ b/seed/seed20.go
@@ -839,7 +839,7 @@ func (s *seed20) LoadPreseedAssertion() (*asserts.Preseed, error) {
 	preseedAs := a.(*asserts.Preseed)
 
 	if !strutil.ListContains(model.PreseedAuthority(), preseedAs.AuthorityID()) {
-		return nil, fmt.Errorf("authority id %q is not allowed by the model", preseedAs.AuthorityID())
+		return nil, fmt.Errorf("preseed authority-id %q is not allowed by the model", preseedAs.AuthorityID())
 	}
 
 	switch {

--- a/seed/seed20.go
+++ b/seed/seed20.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2022 Canonical Ltd
+ * Copyright (C) 2014-2023 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/seed/seed20.go
+++ b/seed/seed20.go
@@ -837,6 +837,11 @@ func (s *seed20) LoadPreseedAssertion() (*asserts.Preseed, error) {
 		return nil, err
 	}
 	preseedAs := a.(*asserts.Preseed)
+
+	if !strutil.ListContains(model.PreseedAuthority(), preseedAs.AuthorityID()) {
+		return nil, fmt.Errorf("authority id %q is not allowed by the model", preseedAs.AuthorityID())
+	}
+
 	switch {
 	case preseedAs.SystemLabel() != sysLabel:
 		return nil, fmt.Errorf("preseed assertion system label %q doesn't match system label %q", preseedAs.SystemLabel(), sysLabel)

--- a/seed/seed20_test.go
+++ b/seed/seed20_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2019-2022 Canonical Ltd
+ * Copyright (C) 2019-2023 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/seed/seed20_test.go
+++ b/seed/seed20_test.go
@@ -3322,7 +3322,7 @@ func (s *seed20Suite) TestPreseedCapableSeedErrors(c *C) {
 		{overrides: map[string]interface{}{"system-label": "other-label"}, err: `preseed assertion system label "other-label" doesn't match system label "20230406"`},
 		{overrides: map[string]interface{}{"model": "other-model"}, err: `preseed assertion model "other-model" doesn't match the model "my-model"`},
 		{overrides: map[string]interface{}{"series": "other-series"}, err: `preseed assertion series "other-series" doesn't match model series "16"`},
-		{overrides: map[string]interface{}{"authority-id": "other-brand"}, asserts: s.Brands.AccountsAndKeys("other-brand"), err: `authority id "other-brand" is not allowed by the model`},
+		{overrides: map[string]interface{}{"authority-id": "other-brand"}, asserts: s.Brands.AccountsAndKeys("other-brand"), err: `preseed authority-id "other-brand" is not allowed by the model`},
 		{overrides: map[string]interface{}{"brand-id": "other-brand", "authority-id": "other-brand"}, err: `cannot resolve prerequisite assertion:.*`},
 	}
 

--- a/seed/seed20_test.go
+++ b/seed/seed20_test.go
@@ -3322,8 +3322,8 @@ func (s *seed20Suite) TestPreseedCapableSeedErrors(c *C) {
 		{overrides: map[string]interface{}{"system-label": "other-label"}, err: `preseed assertion system label "other-label" doesn't match system label "20230406"`},
 		{overrides: map[string]interface{}{"model": "other-model"}, err: `preseed assertion model "other-model" doesn't match the model "my-model"`},
 		{overrides: map[string]interface{}{"series": "other-series"}, err: `preseed assertion series "other-series" doesn't match model series "16"`},
-		{overrides: map[string]interface{}{"brand-id": "other-brand"}, asserts: s.Brands.AccountsAndKeys("other-brand"), err: `preseed assertion brand "other-brand" doesn't match model brand "my-brand"`},
-		{overrides: map[string]interface{}{"brand-id": "other-brand"}, err: `cannot resolve prerequisite assertion:.*`},
+		{overrides: map[string]interface{}{"authority-id": "other-brand"}, asserts: s.Brands.AccountsAndKeys("other-brand"), err: `authority id "other-brand" is not allowed by the model`},
+		{overrides: map[string]interface{}{"brand-id": "other-brand", "authority-id": "other-brand"}, err: `cannot resolve prerequisite assertion:.*`},
 	}
 
 	for _, tc := range tests {
@@ -3331,6 +3331,7 @@ func (s *seed20Suite) TestPreseedCapableSeedErrors(c *C) {
 			"type":              "preseed",
 			"series":            "16",
 			"brand-id":          "my-brand",
+			"authority-id":      "my-brand",
 			"model":             "my-model",
 			"system-label":      sysLabel,
 			"artifact-sha3-384": digest,
@@ -3342,14 +3343,14 @@ func (s *seed20Suite) TestPreseedCapableSeedErrors(c *C) {
 			for h, v := range tc.overrides {
 				headers[h] = v
 			}
-			signer := s.Brands.Signing(headers["brand-id"].(string))
+			signer := s.Brands.Signing(headers["authority-id"].(string))
 			preseedAs, err := signer.Sign(asserts.PreseedType, headers, nil, "")
 			c.Assert(err, IsNil)
 			as = append(as, preseedAs)
 		}
 		if tc.dupPreseedAssert {
 			headers["system-label"] = "other-label"
-			signer := s.Brands.Signing(headers["brand-id"].(string))
+			signer := s.Brands.Signing(headers["authority-id"].(string))
 			preseedAs, err := signer.Sign(asserts.PreseedType, headers, nil, "")
 			c.Assert(err, IsNil)
 			as = append(as, preseedAs)
@@ -3416,4 +3417,96 @@ func (s *seed20Suite) TestPreseedCapableSeedNoPreseedAssertion(c *C) {
 
 	_, err = preseedSeed.LoadPreseedAssertion()
 	c.Assert(err, Equals, seed.ErrNoPreseedAssertion)
+}
+
+func (s *seed20Suite) TestPreseedCapableSeedAlternateAuthority(c *C) {
+	r := seed.MockTrusted(s.StoreSigning.Trusted)
+	defer r()
+
+	s.makeSnap(c, "snapd", "")
+	s.makeSnap(c, "core20", "")
+	s.makeSnap(c, "pc-kernel=20", "")
+	s.makeSnap(c, "pc=20", "")
+
+	sysLabel := "20230406"
+	s.MakeSeed(c, sysLabel, "my-brand", "my-model", map[string]interface{}{
+		"display-name": "my model",
+		"architecture": "amd64",
+		"base":         "core20",
+		"preseed-authority": []interface{}{
+			"my-brand",
+			"my-signer",
+		},
+		"snaps": []interface{}{
+			map[string]interface{}{
+				"name":            "pc-kernel",
+				"id":              s.AssertedSnapID("pc-kernel"),
+				"type":            "kernel",
+				"default-channel": "20",
+			},
+			map[string]interface{}{
+				"name":            "pc",
+				"id":              s.AssertedSnapID("pc"),
+				"type":            "gadget",
+				"default-channel": "20",
+			}},
+	}, nil)
+
+	preseedArtifact := filepath.Join(s.SeedDir, "systems", sysLabel, "preseed.tgz")
+	c.Assert(ioutil.WriteFile(preseedArtifact, nil, 0644), IsNil)
+	sha3_384, _, err := osutil.FileDigest(preseedArtifact, crypto.SHA3_384)
+	c.Assert(err, IsNil)
+	digest, err := asserts.EncodeDigest(crypto.SHA3_384, sha3_384)
+	c.Assert(err, IsNil)
+
+	snaps := []interface{}{
+		map[string]interface{}{"name": "snapd", "id": s.AssertedSnapID("snapd"), "revision": "1"},
+		map[string]interface{}{"name": "core20", "id": s.AssertedSnapID("core20"), "revision": "1"},
+		map[string]interface{}{"name": "pc-kernel", "id": s.AssertedSnapID("pc-kernel"), "revision": "1"},
+		map[string]interface{}{"name": "pc", "id": s.AssertedSnapID("pc"), "revision": "1"},
+	}
+	headers := map[string]interface{}{
+		"type":              "preseed",
+		"series":            "16",
+		"brand-id":          "my-brand",
+		"authority-id":      "my-signer",
+		"model":             "my-model",
+		"system-label":      sysLabel,
+		"artifact-sha3-384": digest,
+		"timestamp":         time.Now().UTC().Format(time.RFC3339),
+		"snaps":             snaps,
+	}
+
+	signerKey, _ := assertstest.GenerateKey(752)
+	s.Brands.Register("my-signer", signerKey, nil)
+
+	signer := s.Brands.Signing("my-signer")
+	preseedAs, err := signer.Sign(asserts.PreseedType, headers, nil, "")
+	c.Assert(err, IsNil)
+
+	systemDir := filepath.Join(s.SeedDir, "systems", sysLabel)
+	seedtest.WriteAssertions(
+		filepath.Join(systemDir, "assertions", "my-signer"),
+		s.Brands.AccountsAndKeys("my-signer")...,
+	)
+	seedtest.WriteAssertions(filepath.Join(systemDir, "preseed"), preseedAs)
+
+	seed20, err := seed.Open(s.SeedDir, sysLabel)
+	c.Assert(err, IsNil)
+
+	preseedSeed := seed20.(seed.PreseedCapable)
+
+	c.Check(preseedSeed.HasArtifact("preseed.tgz"), Equals, true)
+
+	err = preseedSeed.LoadAssertions(nil, nil)
+	c.Assert(err, IsNil)
+
+	err = preseedSeed.LoadEssentialMeta(nil, s.perfTimings)
+	c.Assert(err, IsNil)
+
+	preseedAs2, err := preseedSeed.LoadPreseedAssertion()
+	c.Assert(err, IsNil)
+	c.Check(preseedAs2, DeepEquals, preseedAs)
+
+	preseedAs2 = nil
 }

--- a/seed/seed20_test.go
+++ b/seed/seed20_test.go
@@ -3507,6 +3507,4 @@ func (s *seed20Suite) TestPreseedCapableSeedAlternateAuthority(c *C) {
 	preseedAs2, err := preseedSeed.LoadPreseedAssertion()
 	c.Assert(err, IsNil)
 	c.Check(preseedAs2, DeepEquals, preseedAs)
-
-	preseedAs2 = nil
 }


### PR DESCRIPTION
Allow preseed authority delegation in the model assertion, and check that either the brand or a delegated authority has signed a preseed assertion when importing.
