### PR TITLE
arch: fix incorrect architecture name in `arch.Endian()`

### DIFF
--- a/arch/endian.go
+++ b/arch/endian.go
@@ -32,7 +32,7 @@ func Endian() binary.ByteOrder {
 	switch runtimeGOARCH {
 	case "ppc", "ppc64", "s390x":
 		return binary.BigEndian
-	case "i386", "amd64", "arm", "arm64", "ppc64le", "riscv64":
+	case "386", "amd64", "arm", "arm64", "ppc64le", "riscv64":
 		return binary.LittleEndian
 	default:
 		panic(fmt.Sprintf("unknown architecture %s", runtimeGOARCH))


### PR DESCRIPTION
The go and Debian/Ubuntu architecture names are extremly close and there was a typo in one of them (i386->386). In addition to fixing the typo this commit also includes a list of known architectures from the go source directly to ensure this change is correct.

There is no exported list of available architectures so it had to be copied. There is `go tool dist list` which will list all supported combinations of os/arch but the downside of using this is that when architecture support gets dropped in the future the test would start failing for no good reason.
