### PR TITLE
steam_support: add unshare CLONE_NEWNS to steam_support interface

### DIFF
--- a/interfaces/builtin/steam_support.go
+++ b/interfaces/builtin/steam_support.go
@@ -215,6 +215,10 @@ const steamSupportConnectedPlugSecComp = `
 mount
 umount2
 pivot_root
+
+# Native games using QtWebEngineProcess -
+# https://forum.snapcraft.io/t/autoconnect-request-steam-network-control/34267
+unshare CLONE_NEWNS
 `
 
 const steamSupportSteamInputUDevRules = `


### PR DESCRIPTION
As per the discussion [in the Snapcraft forum](https://forum.snapcraft.io/t/autoconnect-request-steam-network-control/34267/7), this PR adds `unshare CLONE_NEWNS` to the steam_support builtin interface.

This change is essentially exactly @alexmurray's [suggestion](https://forum.snapcraft.io/t/autoconnect-request-steam-network-control/34267/8).