### PR TITLE
i/b/uio: allow configuring UIO drivers from userspace app/libraries

### DIFF
--- a/interfaces/builtin/uio.go
+++ b/interfaces/builtin/uio.go
@@ -22,6 +22,7 @@ package builtin
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -104,7 +105,7 @@ func (iface *uioInterface) AppArmorConnectedPlug(spec *apparmor.Specification, p
 	spec.AddDeduplicatedSnippet("/sys/devices/platform/**/uio/uio[0-9]** r,  # common rule for all uio connections")
 
 	// Allow uio configuration
-	uioConfigPath := "/sys/class/uio/" + strings.TrimPrefix(path, "/dev/") + "/device/config"
+	uioConfigPath := filepath.Join("/sys/class/uio/", strings.TrimPrefix(path, "/dev/"), "/device/config")
 	dereferencedPath, err := evalSymlinks(uioConfigPath)
 	if err != nil && os.IsNotExist(err) {
 		// This should not block the interface connection operation

--- a/interfaces/builtin/uio_test.go
+++ b/interfaces/builtin/uio_test.go
@@ -21,6 +21,8 @@ package builtin_test
 
 import (
 	"fmt"
+	"os"
+	"strings"
 
 	. "gopkg.in/check.v1"
 
@@ -29,6 +31,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/udev"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
@@ -107,7 +110,15 @@ SUBSYSTEM=="uio", KERNEL=="uio0", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
 }
 
-func (s *uioInterfaceSuite) TestAppArmorSpec(c *C) {
+func (s *uioInterfaceSuite) TestAppArmorConnectedPlugIgnoresMissingConfigFile(c *C) {
+	log, restore := logger.MockLogger()
+	defer restore()
+
+	builtin.MockEvalSymlinks(&s.BaseTest, func(path string) (string, error) {
+		c.Assert(path, Matches, "/sys/class/uio/uio[0-1]+/device/config")
+		return "", os.ErrNotExist
+	})
+
 	spec := &apparmor.Specification{}
 	// Simulate two UIO connections.
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slotGadget0), IsNil)
@@ -116,6 +127,34 @@ func (s *uioInterfaceSuite) TestAppArmorSpec(c *C) {
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), Equals, ""+
 		"/dev/uio0 rw,\n"+
 		"/dev/uio1 rw,\n"+
+		"/sys/devices/platform/**/uio/uio[0-9]** r,  # common rule for all uio connections")
+
+	c.Assert(log.String(), testutil.Contains, "cannot configure not existing uio device config file /sys/class/uio/uio0/device/config")
+	c.Assert(log.String(), testutil.Contains, "cannot configure not existing uio device config file /sys/class/uio/uio1/device/config")
+}
+
+func (s *uioInterfaceSuite) TestAppArmorConnectedPlug(c *C) {
+	builtin.MockEvalSymlinks(&s.BaseTest, func(path string) (string, error) {
+		c.Assert(path, Matches, "/sys/class/uio/uio[0-1]+/device/config")
+		device := "uio0"
+		if !strings.Contains(path, device) {
+			device = "uio1"
+		}
+		// Not representative of actual resolved symlink
+		target := fmt.Sprint("/sys/devices/", device, "/config")
+		return target, nil
+	})
+
+	spec := &apparmor.Specification{}
+	// Simulate two UIO connections.
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slotGadget0), IsNil)
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slotGadget1), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), Equals, ""+
+		"/dev/uio0 rw,\n"+
+		"/dev/uio1 rw,\n"+
+		"/sys/devices/uio0/config rwk,\n"+
+		"/sys/devices/uio1/config rwk,\n"+
 		"/sys/devices/platform/**/uio/uio[0-9]** r,  # common rule for all uio connections")
 }
 


### PR DESCRIPTION
The customer has a specific network component chip for industrial automation whose driver provides a way to configure the device via sysfs. 

```
May 04 15:48:33 mydevice audit[754]: AVC apparmor="DENIED" operation="open" profile="snap.my-snap.control" name="/sys/devices/pci0000:00/0000:00:01.1/0000:02:00.0/0000:03:00.0/config" pid=754 comm="my-snap" requested_mask="w" denied_mask="w" fsuid=0 ouid=0
May 04 15:48:33 mydevice kernel: audit: type=1400 audit(1683229713.151:85): apparmor="DENIED" operation="open" profile="snap.my-snap.control" name="/sys/devices/pci0000:00/0000:00:01.1/0000:02:00.0/0000:03:00.0/config" pid=754 comm="my-snap" requested_mask="w" denied_mask="w" fsuid=0 ouid=0
```

This PR expands the AppArmor profile to allow developers/customers to configure industrial I/O cards UIO drivers from userspace app/libraries. 