### PR TITLE
gadget: remove unused private types after refactor

### DIFF
--- a/gadget/kcmdline.go
+++ b/gadget/kcmdline.go
@@ -24,9 +24,6 @@ import (
 	"github.com/snapcore/snapd/strutil"
 )
 
-type kargKey struct{ par, val string }
-type kernelArgsSet map[kargKey]bool
-
 // FilterKernelCmdline returns a filtered command line, removing
 // arguments that are not on a list of allowed kernel arguments. A
 // wild card ('*') can be used in the allow list for the


### PR DESCRIPTION
After refactors in b27425ab99c47cf8fc1b3bb8b0df96d143ea6fa3, the `kargKey` and `kernelArgsSet` types are now unused. This was caught by the `golangci-lint` workflow, but not previously by `./run-checks [--static]`.

The compiler usually catches unused variables, but I guess unused types are not caught in the same way?

I'm going to investigate adding `golangci-lint` to the static checks of `./run-checks` as well, so linting commits without a PR can be more easily caught in the future.