### PR TITLE
cmd/snap: prevent passing --prefer in multi-snap installs

### DIFF
--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -681,6 +681,9 @@ func (x *cmdInstall) Execute([]string) error {
 	if x.IgnoreValidation {
 		return errors.New(i18n.G("a single snap name must be specified when ignoring validation"))
 	}
+	if x.Prefer {
+		return errors.New(i18n.G("a single snap name is needed to specify the prefer flag"))
+	}
 
 	if x.Name != "" {
 		return errors.New(i18n.G("cannot use instance name when installing multiple snaps"))

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -1243,6 +1243,12 @@ func (s *SnapOpSuite) TestInstallPathManyChannel(c *check.C) {
 	c.Assert(err, check.ErrorMatches, `a single snap name is needed to specify channel flags`)
 }
 
+func (s *SnapOpSuite) TestInstallPathManyPrefer(c *check.C) {
+	s.RedirectClientToTestServer(nil)
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "--prefer", "one.snap", "two.snap"})
+	c.Assert(err, check.ErrorMatches, `a single snap name is needed to specify the prefer flag`)
+}
+
 func (s *SnapOpSuite) TestInstallPathManyMode(c *check.C) {
 	s.RedirectClientToTestServer(nil)
 	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "--classic", "foo.snap", "bar.snap"})
@@ -2657,6 +2663,12 @@ func (s *SnapOpSuite) TestInstallManyChannel(c *check.C) {
 	s.RedirectClientToTestServer(nil)
 	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "--beta", "one", "two"})
 	c.Assert(err, check.ErrorMatches, `a single snap name is needed to specify channel flags`)
+}
+
+func (s *SnapOpSuite) TestInstallManyPrefer(c *check.C) {
+	s.RedirectClientToTestServer(nil)
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "--prefer", "one", "two"})
+	c.Assert(err, check.ErrorMatches, `a single snap name is needed to specify the prefer flag`)
 }
 
 func (s *SnapOpSuite) TestInstallManyMode(c *check.C) {

--- a/tests/main/parallel-install-auto-aliases/task.yaml
+++ b/tests/main/parallel-install-auto-aliases/task.yaml
@@ -127,3 +127,7 @@ execute: |
     # aliases belong to test-snapd-auto-aliases
     test "$(readlink "$SNAP_MOUNT_DIR"/bin/test_snapd_wellknown1)" = "test-snapd-auto-aliases.wellknown1"
     test "$(readlink "$SNAP_MOUNT_DIR"/bin/test_snapd_wellknown2)" = "test-snapd-auto-aliases.wellknown2"
+
+    echo "Check that --prefer doesn't support multi-snap installs"
+    not snap install --prefer test-snapd-auto-aliases test-snapd-auto-aliases_bar 2> stderr.out
+    MATCH 'a single snap name is needed to specify the prefer flag' < stderr.out


### PR DESCRIPTION
I noticed that when passing `--prefer` when installing multiple snaps works and `--prefer` is ignored silently, this is because it is not being passed in the [client](https://github.com/snapcore/snapd/blob/d9e4ab8c5eeafda96bdf01df9e38dce0b684ec54/client/snap_op.go#L262) unlike for single [snap ops](https://github.com/snapcore/snapd/blob/d9e4ab8c5eeafda96bdf01df9e38dce0b684ec54/client/snap_op.go#L228).

This PR prevents `snap install --prefer snap1 snap2`, which was ignored silently before.