### PR TITLE
many: switch to new restart logic

### DIFF
--- a/overlord/devicestate/devicestate_bootconfig_test.go
+++ b/overlord/devicestate/devicestate_bootconfig_test.go
@@ -197,6 +197,7 @@ kernel-cmdline:
 	s.state.Lock()
 	defer s.state.Unlock()
 
+	restarting, rt := restart.Pending(s.state)
 	c.Assert(chg.IsReady(), Equals, true)
 	if errMatch == "" {
 		c.Check(chg.Err(), IsNil)
@@ -212,9 +213,11 @@ kernel-cmdline:
 			log := tsk.Log()
 			c.Assert(log, HasLen, 2)
 			c.Check(log[0], Matches, ".* updated boot config assets")
-			c.Check(log[1], Matches, ".* Requested system restart")
+			c.Check(log[1], Matches, ".* INFO Task has requested a system restart")
 			// update was applied, thus a restart was requested
 			c.Check(s.restartRequests, DeepEquals, []restart.RestartType{restart.RestartSystemNow})
+			c.Check(restarting, Equals, true)
+			c.Check(rt, Equals, restart.RestartSystemNow)
 		} else {
 			// update was not applied or failed
 			c.Check(s.restartRequests, HasLen, 0)
@@ -265,12 +268,11 @@ kernel-cmdline:
 	s.state.Lock()
 	defer s.state.Unlock()
 
+	c.Assert(chg.IsReady(), Equals, true)
 	if errMatch == "" {
-		c.Assert(chg.IsReady(), Equals, false)
 		c.Check(chg.Err(), IsNil)
-		c.Check(tsk.Status(), Equals, state.WaitStatus)
+		c.Check(tsk.Status(), Equals, state.DoneStatus)
 	} else {
-		c.Assert(chg.IsReady(), Equals, true)
 		c.Check(chg.Err(), ErrorMatches, errMatch)
 		c.Check(tsk.Status(), Equals, state.ErrorStatus)
 	}
@@ -281,7 +283,7 @@ kernel-cmdline:
 			log := tsk.Log()
 			c.Assert(log, HasLen, 2)
 			c.Check(log[0], Matches, ".* updated boot config assets")
-			c.Check(log[1], Matches, ".* Task set to wait until a manual system restart allows to continue")
+			c.Check(log[1], Matches, ".* INFO Task has requested a system restart")
 		}
 		// There must be no restart request
 		c.Check(s.restartRequests, HasLen, 0)

--- a/overlord/devicestate/devicestate_remodel_test.go
+++ b/overlord/devicestate/devicestate_remodel_test.go
@@ -366,7 +366,7 @@ func (s *deviceMgrRemodelSuite) testRemodelTasksSwitchTrack(c *C, whatRefreshes 
 	}
 	new := s.brands.Model("canonical", "pc-model", headers)
 
-	testDeviceCtx = &snapstatetest.TrivialDeviceContext{Remodeling: true}
+	testDeviceCtx = &snapstatetest.TrivialDeviceContext{Remodeling: true, DeviceModel: new, OldDeviceModel: current}
 
 	tss, err := devicestate.RemodelTasks(context.Background(), s.state, current, new, nil, nil, testDeviceCtx, "99")
 	c.Assert(err, IsNil)
@@ -549,7 +549,7 @@ func (s *deviceMgrRemodelSuite) testRemodelSwitchTasks(c *C, whatNewTrack map[st
 	new.KernelSnap().SnapID = "pckernelidididididididididididid"
 	new.GadgetSnap().SnapID = "pcididididididididididididididid"
 
-	testDeviceCtx = &snapstatetest.TrivialDeviceContext{Remodeling: true}
+	testDeviceCtx = &snapstatetest.TrivialDeviceContext{Remodeling: true, DeviceModel: new, OldDeviceModel: current}
 
 	tss, err := devicestate.RemodelTasks(context.Background(), s.state, current, new, localSnaps, paths, testDeviceCtx, "99")
 	if expectedErr == "" {
@@ -1747,6 +1747,10 @@ volumes:
 
 	s.state.Lock()
 	defer s.state.Unlock()
+
+	// simulate restart
+	s.mockRestartAndSettle(c, s.state, chg)
+
 	c.Check(chg.IsReady(), Equals, true)
 	c.Check(chg.Err(), IsNil)
 	c.Check(gadgetUpdateCalled, Equals, true)
@@ -1886,7 +1890,7 @@ func (s *deviceMgrSuite) TestRemodelSwitchBase(c *C) {
 		"revision":     "1",
 	})
 
-	testDeviceCtx = &snapstatetest.TrivialDeviceContext{Remodeling: true}
+	testDeviceCtx = &snapstatetest.TrivialDeviceContext{Remodeling: true, DeviceModel: new, OldDeviceModel: current}
 
 	tss, err := devicestate.RemodelTasks(context.Background(), s.state, current, new, nil, nil, testDeviceCtx, "99")
 	c.Assert(err, IsNil)

--- a/overlord/devicestate/devicestate_systems_test.go
+++ b/overlord/devicestate/devicestate_systems_test.go
@@ -1442,8 +1442,8 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemHappy
 	s.state.Lock()
 
 	c.Assert(chg.Err(), IsNil)
-	c.Assert(tskCreate.Status(), Equals, state.DoneStatus)
-	c.Assert(tskFinalize.Status(), Equals, state.DoingStatus)
+	c.Assert(tskCreate.Status(), Equals, state.WaitStatus)
+	c.Assert(tskFinalize.Status(), Equals, state.DoStatus)
 	// a reboot is expected
 	c.Check(s.restartRequests, DeepEquals, []restart.RestartType{restart.RestartSystemNow})
 
@@ -1492,6 +1492,9 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemHappy
 	s.settle(c)
 	s.state.Lock()
 	defer s.state.Unlock()
+
+	// simulate a restart and run change to completion
+	s.mockRestartAndSettle(c, s.state, chg)
 
 	c.Assert(chg.Err(), IsNil)
 	c.Check(chg.IsReady(), Equals, true)
@@ -1617,8 +1620,8 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemRemod
 	defer s.state.Unlock()
 
 	c.Assert(chg.Err(), IsNil)
-	c.Assert(tskCreate.Status(), Equals, state.DoneStatus)
-	c.Assert(tskFinalize.Status(), Equals, state.DoingStatus)
+	c.Assert(tskCreate.Status(), Equals, state.WaitStatus)
+	c.Assert(tskFinalize.Status(), Equals, state.DoStatus)
 	// a reboot is expected
 	c.Check(s.restartRequests, DeepEquals, []restart.RestartType{restart.RestartSystemNow})
 
@@ -1668,6 +1671,9 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemRemod
 	s.state.Unlock()
 	s.settle(c)
 	s.state.Lock()
+
+	// simulate a restart and run change to completion
+	s.mockRestartAndSettle(c, s.state, chg)
 
 	c.Assert(chg.Err(), IsNil)
 	c.Check(chg.IsReady(), Equals, true)
@@ -1818,8 +1824,8 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemUndo(
 	s.state.Lock()
 
 	c.Assert(chg.Err(), IsNil)
-	c.Assert(tskCreate.Status(), Equals, state.DoneStatus)
-	c.Assert(tskFinalize.Status(), Equals, state.DoingStatus)
+	c.Assert(tskCreate.Status(), Equals, state.WaitStatus)
+	c.Assert(tskFinalize.Status(), Equals, state.DoStatus)
 	// a reboot is expected
 	c.Check(s.restartRequests, DeepEquals, []restart.RestartType{restart.RestartSystemNow})
 	// validity check asserted snaps location
@@ -1870,6 +1876,9 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemUndo(
 	s.settle(c)
 	s.state.Lock()
 	defer s.state.Unlock()
+
+	// simulate a restart and run change to completion
+	s.mockRestartAndSettle(c, s.state, chg)
 
 	c.Assert(chg.Err(), ErrorMatches, "(?s)cannot perform the following tasks.* provoking total undo.*")
 	c.Check(chg.IsReady(), Equals, true)
@@ -1929,8 +1938,8 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemFinal
 	s.state.Lock()
 
 	c.Assert(chg.Err(), IsNil)
-	c.Assert(tskCreate.Status(), Equals, state.DoneStatus)
-	c.Assert(tskFinalize.Status(), Equals, state.DoingStatus)
+	c.Assert(tskCreate.Status(), Equals, state.WaitStatus)
+	c.Assert(tskFinalize.Status(), Equals, state.DoStatus)
 	// a reboot is expected
 	c.Check(s.restartRequests, DeepEquals, []restart.RestartType{restart.RestartSystemNow})
 
@@ -1971,6 +1980,9 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemFinal
 	s.settle(c)
 	s.state.Lock()
 	defer s.state.Unlock()
+
+	// 'create-recovery-system' is pending a restart
+	s.mockRestartAndSettle(c, s.state, chg)
 
 	c.Assert(chg.Err(), ErrorMatches, `(?s)cannot perform the following tasks.* Finalize recovery system with label "1234" \(cannot promote recovery system "1234": system has not been successfully tried\)`)
 	c.Check(chg.IsReady(), Equals, true)
@@ -2112,8 +2124,8 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemReboo
 
 	// so far so good
 	c.Assert(chg.Err(), IsNil)
-	c.Assert(tskCreate.Status(), Equals, state.DoneStatus)
-	c.Assert(tskFinalize.Status(), Equals, state.DoingStatus)
+	c.Assert(tskCreate.Status(), Equals, state.WaitStatus)
+	c.Assert(tskFinalize.Status(), Equals, state.DoStatus)
 	// a reboot is expected
 	c.Check(s.restartRequests, DeepEquals, []restart.RestartType{restart.RestartSystemNow})
 	c.Check(s.bootloader.SetBootVarsCalls, Equals, 2)

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -110,6 +110,17 @@ type deviceMgrBaseSuite struct {
 	restoreProcessAutoImportAssertion func()
 }
 
+// mockRestartAndSettle expects the state to be locked
+func (s *deviceMgrBaseSuite) mockRestartAndSettle(c *C, st *state.State, chg *state.Change) {
+	restart.MockPending(st, restart.RestartUnset)
+	restart.MockAfterRestartForChange(chg)
+
+	st.Unlock()
+	defer st.Lock()
+	err := s.o.Settle(settleTimeout)
+	c.Check(err, IsNil)
+}
+
 type deviceMgrSuite struct {
 	deviceMgrBaseSuite
 }

--- a/overlord/devicestate/firstboot_preseed_test.go
+++ b/overlord/devicestate/firstboot_preseed_test.go
@@ -533,12 +533,14 @@ snaps:
 	c.Assert(err, IsNil)
 	c.Assert(chg.Err(), IsNil)
 	c.Check(chg.Status(), Equals, state.DoingStatus)
+	st.Unlock()
 
 	// we are done with this instance of the overlord, stop it here. Otherwise
 	// it will interfere with our second overlord instance
 	c.Assert(s.overlord.Stop(), IsNil)
 
 	// Verify state between the two change runs
+	st.Lock()
 	r, err := os.Open(dirs.SnapStateFile)
 	c.Assert(err, IsNil)
 	diskState, err := state.ReadState(nil, r)
@@ -588,10 +590,10 @@ snaps:
 	restart.MockPending(st, restart.RestartUnset)
 	st.Unlock()
 	err = s.overlord.Settle(settleTimeout)
-	st.Lock()
 	c.Assert(err, IsNil)
 	c.Assert(s.overlord.Stop(), IsNil)
 	c.Assert(err, IsNil)
+	st.Lock()
 
 	// Update the change pointer to the change in the new state
 	// otherwise we will be referring to the old one.

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -128,9 +128,16 @@ var (
 
 	AffectedByRefresh = affectedByRefresh
 
-	GetDirMigrationOpts = getDirMigrationOpts
-	WriteSeqFile        = writeSeqFile
-	TriggeredMigration  = triggeredMigration
+	GetDirMigrationOpts             = getDirMigrationOpts
+	WriteSeqFile                    = writeSeqFile
+	TriggeredMigration              = triggeredMigration
+	TaskSetsByTypeForEssentialSnaps = taskSetsByTypeForEssentialSnaps
+	SetDefaultRestartBoundaries     = setDefaultRestartBoundaries
+	DeviceModelBootBase             = deviceModelBootBase
+)
+
+const (
+	NoRestartBoundaries = noRestartBoundaries
 )
 
 func PreviousSideInfo(snapst *SnapState) *snap.SideInfo {

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -4046,6 +4046,14 @@ func (m *SnapManager) doCheckReRefresh(t *state.Task, tomb *tomb.Tomb) error {
 		logger.Panicf("Re-refresh task has %d tasks waiting for it.", numHaltTasks)
 	}
 
+	// Is there a restart pending for the current change? Then wait for
+	// restart to happen before proceeding, otherwise we will be blocking
+	// any restart that is waiting to occur. We handle this here as this
+	// task is dynamically added.
+	if restart.PendingForChange(st, t.Change()) {
+		return restart.TaskWaitForRestart(t)
+	}
+
 	if !changeReadyUpToTask(t) {
 		return &state.Retry{After: reRefreshRetryTimeout, Reason: "pending refreshes"}
 	}

--- a/overlord/snapstate/handlers_rerefresh_test.go
+++ b/overlord/snapstate/handlers_rerefresh_test.go
@@ -25,11 +25,14 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	. "gopkg.in/check.v1"
+	"gopkg.in/tomb.v2"
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/snapasserts"
+	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
@@ -60,6 +63,16 @@ func changeWithLanesAndSnapSetups(st *state.State, snapNames ...string) *state.C
 		tsk.SetStatus(state.DoneStatus)
 	}
 	return chg
+}
+
+func (s *reRefreshSuite) SetUpTest(c *C) {
+	s.baseHandlerSuite.SetUpTest(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	_, err := restart.Manager(s.state, "boot-id-1", nil)
+	c.Assert(err, IsNil)
 }
 
 func (s *reRefreshSuite) TestDoCheckReRefreshFailsWithoutReRefreshSetup(c *C) {
@@ -130,7 +143,7 @@ func (s *reRefreshSuite) TestDoCheckReRefreshPassesReRefreshSetupData(c *C) {
 	var chgID string
 	defer snapstate.MockReRefreshUpdateMany(func(_ context.Context, _ *state.State, snaps []string, _ []*snapstate.RevisionOptions, userID int, _ snapstate.UpdateFilter, flags *snapstate.Flags, changeID string) ([]string, *snapstate.UpdateTaskSets, error) {
 		c.Check(changeID, Equals, chgID)
-		expected := []string{"won", "too", "tree"}
+		expected := []string{"foo", "bar", "baz"}
 		sort.Strings(expected)
 		sort.Strings(snaps)
 		c.Check(snaps, DeepEquals, expected)
@@ -149,7 +162,7 @@ func (s *reRefreshSuite) TestDoCheckReRefreshPassesReRefreshSetupData(c *C) {
 		"devmode":  true,
 		"jailmode": true,
 	})
-	chg := changeWithLanesAndSnapSetups(s.state, "won", "too", "tree")
+	chg := changeWithLanesAndSnapSetups(s.state, "foo", "bar", "baz")
 	chg.AddTask(task)
 	chgID = chg.ID()
 	s.state.Unlock()
@@ -166,7 +179,7 @@ func (s *reRefreshSuite) TestDoCheckReRefreshPassesReRefreshSetupData(c *C) {
 
 func (s *reRefreshSuite) TestDoCheckReRefreshAddsNewTasks(c *C) {
 	defer snapstate.MockReRefreshUpdateMany(func(_ context.Context, st *state.State, snaps []string, _ []*snapstate.RevisionOptions, _ int, _ snapstate.UpdateFilter, _ *snapstate.Flags, _ string) ([]string, *snapstate.UpdateTaskSets, error) {
-		expected := []string{"won", "too", "tree"}
+		expected := []string{"foo", "bar", "baz"}
 		sort.Strings(expected)
 		sort.Strings(snaps)
 		c.Check(snaps, DeepEquals, expected)
@@ -174,11 +187,11 @@ func (s *reRefreshSuite) TestDoCheckReRefreshAddsNewTasks(c *C) {
 		task := st.NewTask("witness", "...")
 
 		tasksetGrp := &snapstate.UpdateTaskSets{Refresh: []*state.TaskSet{state.NewTaskSet(task)}}
-		return []string{"won"}, tasksetGrp, nil
+		return []string{"foo"}, tasksetGrp, nil
 	})()
 
 	s.state.Lock()
-	chg := changeWithLanesAndSnapSetups(s.state, "won", "too", "tree")
+	chg := changeWithLanesAndSnapSetups(s.state, "foo", "bar", "baz")
 	task := s.state.NewTask("check-rerefresh", "test")
 	task.Set("rerefresh-setup", map[string]interface{}{})
 	chg.AddTask(task)
@@ -191,16 +204,75 @@ func (s *reRefreshSuite) TestDoCheckReRefreshAddsNewTasks(c *C) {
 	defer s.state.Unlock()
 
 	c.Check(task.Status(), Equals, state.DoneStatus)
-	c.Check(logstr(task), Contains, `Found re-refresh for "won".`)
+	c.Check(logstr(task), Contains, `Found re-refresh for "foo".`)
 
 	tasks := chg.Tasks()
 	c.Assert(tasks, HasLen, 5)
 	for i, kind := range []string{
-		"a-task-for-snap-won-in-lane-1",
-		"a-task-for-snap-too-in-lane-2",
-		"a-task-for-snap-tree-in-lane-3",
+		"a-task-for-snap-foo-in-lane-1",
+		"a-task-for-snap-bar-in-lane-2",
+		"a-task-for-snap-baz-in-lane-3",
 		"check-rerefresh",
 		"witness",
+	} {
+		c.Check(tasks[i].Kind(), Equals, kind)
+	}
+}
+
+func (s *reRefreshSuite) TestDoCheckReRefreshWaitOnPendingRestart(c *C) {
+	s.runner.AddHandler("a-task-for-snap-foo", func(task *state.Task, tomb *tomb.Tomb) error {
+		st := task.State()
+		st.Lock()
+		defer st.Unlock()
+		return restart.FinishTaskWithRestart(task, state.DoneStatus, restart.RestartSystem, "foo", nil)
+	}, nil)
+
+	// setup the change for check-rerefresh, then we manually request for
+	// one of the tasks to reboot
+	s.state.Lock()
+
+	chg := s.state.NewChange("sample", "...")
+	lane := s.state.NewLane()
+	tsk := s.state.NewTask("a-task-for-snap-foo", "test")
+	tsk.Set("snap-setup", &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{RealName: "foo"},
+	})
+	// In order for the code to be tested we need a task to go into WaitStatus.
+	restart.MarkTaskAsRestartBoundary(tsk, restart.RestartBoundaryDirectionDo)
+	chg.AddTask(tsk)
+	tsk.JoinLane(lane)
+	task := s.state.NewTask("check-rerefresh", "test")
+	task.Set("rerefresh-setup", map[string]interface{}{})
+	chg.AddTask(task)
+	s.state.Unlock()
+
+	// retry will be hit, so we must ensure again
+	for i := 0; i < 3; i++ {
+		s.se.Ensure()
+		s.se.Wait()
+
+		s.state.Lock()
+		status := task.Status()
+		s.state.Unlock()
+		if status == state.WaitStatus {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	c.Check(task.Status(), Equals, state.WaitStatus)
+	c.Check(task.WaitedStatus(), Equals, state.DoStatus)
+	c.Check(chg.Status(), Equals, state.WaitStatus)
+	c.Check(logstr(task), Matches, `*. INFO Task set to wait until a system restart allows to continue`)
+
+	tasks := chg.Tasks()
+	c.Assert(tasks, HasLen, 2)
+	for i, kind := range []string{
+		"a-task-for-snap-foo",
+		"check-rerefresh",
 	} {
 		c.Check(tasks[i].Kind(), Equals, kind)
 	}

--- a/overlord/snapstate/reboot.go
+++ b/overlord/snapstate/reboot.go
@@ -1,0 +1,141 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate
+
+import (
+	"errors"
+
+	"github.com/snapcore/snapd/overlord/restart"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+)
+
+// Observed link order between essential snaps in doUpdate (snapstate.go)
+// base waits for snapd
+// gadget waits for base/os + snapd
+// kernel waits for base/os + snapd + gadget if present
+var essentialSnapsRestartOrder = []snap.Type{
+	snap.TypeOS,
+	// The base will only require restart if it's the base of the model.
+	snap.TypeBase,
+	snap.TypeGadget,
+	// Kernel must wait for gadget because the gadget may define
+	// new "$kernel:refs".
+	snap.TypeKernel,
+}
+
+func maybeTaskSetSnapSetup(ts *state.TaskSet) *SnapSetup {
+	for _, t := range ts.Tasks() {
+		snapsup, err := TaskSnapSetup(t)
+		if err == nil {
+			return snapsup
+		}
+	}
+	return nil
+}
+
+// taskSetsByTypeForEssentialSnaps returns a map of task-sets by their essential snap type, if
+// a task-set for any of the essential snap exists.
+func taskSetsByTypeForEssentialSnaps(tss []*state.TaskSet, bootBase string) (map[snap.Type]*state.TaskSet, error) {
+	avail := make(map[snap.Type]*state.TaskSet)
+	for _, ts := range tss {
+		snapsup := maybeTaskSetSnapSetup(ts)
+		if snapsup == nil {
+			continue
+		}
+
+		switch snapsup.Type {
+		case snap.TypeBase:
+			if snapsup.SnapName() == bootBase {
+				avail[snapsup.Type] = ts
+			}
+		case snap.TypeOS, snap.TypeGadget, snap.TypeKernel:
+			avail[snapsup.Type] = ts
+		}
+	}
+	return avail, nil
+}
+
+func findUnlinkTask(ts *state.TaskSet) *state.Task {
+	for _, t := range ts.Tasks() {
+		switch t.Kind() {
+		case "unlink-snap", "unlink-current-snap":
+			return t
+		}
+	}
+	return nil
+}
+
+// setDefaultRestartBoundaries marks edge MaybeRebootEdge (Do) and task "unlink-snap"/"unlink-current-snap" (Undo)
+// as restart boundaries to maintain the old restart logic. This means that a restart must be performed after
+// each of those tasks in order for the change to continue.
+func setDefaultRestartBoundaries(ts *state.TaskSet) {
+	linkSnap := ts.MaybeEdge(MaybeRebootEdge)
+	if linkSnap != nil {
+		restart.MarkTaskAsRestartBoundary(linkSnap, restart.RestartBoundaryDirectionDo)
+	}
+
+	unlinkSnap := findUnlinkTask(ts)
+	if unlinkSnap != nil {
+		restart.MarkTaskAsRestartBoundary(unlinkSnap, restart.RestartBoundaryDirectionUndo)
+	}
+}
+
+// deviceModelBootBase returns the base-snap name of the current model. For UC16
+// this will return "core".
+func deviceModelBootBase(st *state.State, providedDeviceCtx DeviceContext) (string, error) {
+	deviceCtx, err := DeviceCtx(st, nil, providedDeviceCtx)
+	if err != nil {
+		if !errors.Is(err, state.ErrNoState) {
+			return "", err
+		}
+		return "", nil
+	}
+	bootBase := deviceCtx.Model().Base()
+	if bootBase == "" {
+		return "core", nil
+	}
+	return bootBase, nil
+}
+
+// SetEssentialSnapsRestartBoundaries sets up default restart boundaries for a list of task-sets. If the
+// list of task-sets contain any updates/installs of essential snaps (base,gadget,kernel), then proper
+// restart boundaries will be set up for them.
+func SetEssentialSnapsRestartBoundaries(st *state.State, providedDeviceCtx DeviceContext, tss []*state.TaskSet) error {
+	bootBase, err := deviceModelBootBase(st, providedDeviceCtx)
+	if err != nil {
+		return err
+	}
+
+	mappedTss, err := taskSetsByTypeForEssentialSnaps(tss, bootBase)
+	if err != nil {
+		return err
+	}
+
+	// XXX: Currently we don't need to go through the correct order, but we do it
+	// just in preparation of when single-reboot functionality is added.
+	for _, o := range essentialSnapsRestartOrder {
+		if mappedTss[o] == nil {
+			continue
+		}
+		setDefaultRestartBoundaries(mappedTss[o])
+	}
+	return nil
+}

--- a/overlord/snapstate/reboot_test.go
+++ b/overlord/snapstate/reboot_test.go
@@ -1,0 +1,239 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/overlord/restart"
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type rebootSuite struct {
+	testutil.BaseTest
+	state *state.State
+}
+
+var _ = Suite(&rebootSuite{})
+
+func (s *rebootSuite) SetUpTest(c *C) {
+	dirs.SetRootDir(c.MkDir())
+	s.AddCleanup(func() { dirs.SetRootDir("") })
+	s.state = state.New(nil)
+}
+
+func (s *rebootSuite) taskSetForSnapSetup(snapName string, snapType snap.Type) *state.TaskSet {
+	snapsup := &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{
+			RealName: snapName,
+			SnapID:   snapName,
+			Revision: snap.R(1),
+		},
+		Type: snapType,
+	}
+	t1 := s.state.NewTask("snap-task", "...")
+	t1.Set("snap-setup", snapsup)
+	t2 := s.state.NewTask("link-snap", "...")
+	t3 := s.state.NewTask("unlink-snap", "...")
+	ts := state.NewTaskSet(t1, t2, t3)
+	ts.MarkEdge(t2, snapstate.MaybeRebootEdge)
+	return ts
+}
+
+func (s *rebootSuite) TestTaskSetsByTypeForEssentialSnapsNoBootBase(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	tss := []*state.TaskSet{
+		s.taskSetForSnapSetup("my-base", snap.TypeBase),
+		s.taskSetForSnapSetup("my-gadget", snap.TypeGadget),
+		s.taskSetForSnapSetup("my-kernel", snap.TypeKernel),
+		s.taskSetForSnapSetup("my-os", snap.TypeOS),
+		s.taskSetForSnapSetup("my-app", snap.TypeApp),
+	}
+
+	mappedTaskSets, err := snapstate.TaskSetsByTypeForEssentialSnaps(tss, "")
+	c.Assert(err, IsNil)
+	c.Check(mappedTaskSets, DeepEquals, map[snap.Type]*state.TaskSet{
+		snap.TypeGadget: tss[1],
+		snap.TypeKernel: tss[2],
+		snap.TypeOS:     tss[3],
+	})
+}
+
+func (s *rebootSuite) TestTaskSetsByTypeForEssentialSnapsBootBase(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	tss := []*state.TaskSet{
+		s.taskSetForSnapSetup("my-base", snap.TypeBase),
+		s.taskSetForSnapSetup("my-gadget", snap.TypeGadget),
+		s.taskSetForSnapSetup("my-kernel", snap.TypeKernel),
+		s.taskSetForSnapSetup("my-os", snap.TypeOS),
+		s.taskSetForSnapSetup("my-app", snap.TypeApp),
+	}
+
+	mappedTaskSets, err := snapstate.TaskSetsByTypeForEssentialSnaps(tss, "my-base")
+	c.Assert(err, IsNil)
+	c.Check(mappedTaskSets, DeepEquals, map[snap.Type]*state.TaskSet{
+		snap.TypeBase:   tss[0],
+		snap.TypeGadget: tss[1],
+		snap.TypeKernel: tss[2],
+		snap.TypeOS:     tss[3],
+	})
+}
+
+func (s *rebootSuite) TestSetDefaultRestartBoundariesLink(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	t1 := s.state.NewTask("first-thing", "...")
+	t2 := s.state.NewTask("other-thing", "...")
+	ts := state.NewTaskSet(t1, t2)
+	ts.MarkEdge(t1, snapstate.MaybeRebootEdge)
+
+	snapstate.SetDefaultRestartBoundaries(ts)
+
+	var boundary restart.RestartBoundaryDirection
+	c.Check(t1.Get("restart-boundary", &boundary), IsNil)
+	c.Check(t2.Get("restart-boundary", &boundary), ErrorMatches, `no state entry for key "restart-boundary"`)
+}
+
+func (s *rebootSuite) TestSetDefaultRestartBoundariesUnlink(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	t1 := s.state.NewTask("unlink-snap", "...")
+	t2 := s.state.NewTask("other-thing", "...")
+	ts := state.NewTaskSet(t1, t2)
+
+	snapstate.SetDefaultRestartBoundaries(ts)
+
+	var boundary restart.RestartBoundaryDirection
+	c.Check(t1.Get("restart-boundary", &boundary), IsNil)
+	c.Check(t2.Get("restart-boundary", &boundary), ErrorMatches, `no state entry for key "restart-boundary"`)
+}
+
+func (s *rebootSuite) TestSetDefaultRestartBoundariesUnlinkCurrent(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	t1 := s.state.NewTask("unlink-current-snap", "...")
+	t2 := s.state.NewTask("other-thing", "...")
+	ts := state.NewTaskSet(t1, t2)
+
+	snapstate.SetDefaultRestartBoundaries(ts)
+
+	var boundary restart.RestartBoundaryDirection
+	c.Check(t1.Get("restart-boundary", &boundary), IsNil)
+	c.Check(t2.Get("restart-boundary", &boundary), ErrorMatches, `no state entry for key "restart-boundary"`)
+}
+
+func (s *rebootSuite) TestDeviceModelBootBaseEmpty(c *C) {
+	defer snapstatetest.MockDeviceModel(nil)()
+	bootBase, err := snapstate.DeviceModelBootBase(s.state, nil)
+	c.Check(err, IsNil)
+	c.Check(bootBase, Equals, "")
+}
+
+func (s *rebootSuite) TestDeviceModelBootBaseUC16(c *C) {
+	defer snapstatetest.MockDeviceModel(DefaultModel())()
+	bootBase, err := snapstate.DeviceModelBootBase(s.state, nil)
+	c.Check(err, IsNil)
+	c.Check(bootBase, Equals, "core")
+}
+
+func (s *rebootSuite) TestDeviceModelBootBaseUC(c *C) {
+	defer snapstatetest.MockDeviceModel(MakeModel20("brand-gadget", nil))()
+	bootBase, err := snapstate.DeviceModelBootBase(s.state, nil)
+	c.Check(err, IsNil)
+	c.Check(bootBase, Equals, "core20")
+}
+
+func (s *rebootSuite) TestDeviceModelBootBaseClassic(c *C) {
+	defer snapstatetest.MockDeviceModel(ClassicModel())()
+	bootBase, err := snapstate.DeviceModelBootBase(s.state, nil)
+	c.Check(err, IsNil)
+	c.Check(bootBase, Equals, "core")
+}
+
+func (s *rebootSuite) TestDeviceModelBootBaseClassicModelProvided(c *C) {
+	// Mock the model to classic
+	defer snapstatetest.MockDeviceModel(ClassicModel())()
+
+	// then provide a UC18 model instead
+	deviceCtx := &snapstatetest.TrivialDeviceContext{DeviceModel: ModelWithBase("core18")}
+	bootBase, err := snapstate.DeviceModelBootBase(s.state, deviceCtx)
+	c.Check(err, IsNil)
+	c.Check(bootBase, Equals, "core18")
+}
+
+func (s *rebootSuite) findUnlinkTask(ts *state.TaskSet) *state.Task {
+	for _, t := range ts.Tasks() {
+		switch t.Kind() {
+		case "unlink-snap", "unlink-current-snap":
+			return t
+		}
+	}
+	return nil
+}
+
+func (s *rebootSuite) hasRestartBoundaries(c *C, ts *state.TaskSet) bool {
+	t1 := ts.MaybeEdge(snapstate.MaybeRebootEdge)
+	t2 := s.findUnlinkTask(ts)
+	c.Assert(t1, NotNil)
+	c.Assert(t2, NotNil)
+
+	var boundary restart.RestartBoundaryDirection
+	if err := t1.Get("restart-boundary", &boundary); err != nil {
+		return false
+	}
+	if err := t2.Get("restart-boundary", &boundary); err != nil {
+		return false
+	}
+	return true
+}
+
+func (s *rebootSuite) TestSetEssentialSnapsRestartBoundaries(c *C) {
+	defer snapstatetest.MockDeviceModel(DefaultModel())()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	tss := []*state.TaskSet{
+		s.taskSetForSnapSetup("core", snap.TypeBase),
+		s.taskSetForSnapSetup("my-gadget", snap.TypeGadget),
+		s.taskSetForSnapSetup("my-kernel", snap.TypeKernel),
+		s.taskSetForSnapSetup("my-os", snap.TypeOS),
+		s.taskSetForSnapSetup("my-app", snap.TypeApp),
+	}
+	err := snapstate.SetEssentialSnapsRestartBoundaries(s.state, nil, tss)
+	c.Assert(err, IsNil)
+	c.Check(s.hasRestartBoundaries(c, tss[0]), Equals, true)
+	c.Check(s.hasRestartBoundaries(c, tss[1]), Equals, true)
+	c.Check(s.hasRestartBoundaries(c, tss[2]), Equals, true)
+	c.Check(s.hasRestartBoundaries(c, tss[3]), Equals, true)
+	c.Check(s.hasRestartBoundaries(c, tss[4]), Equals, false)
+}

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/overlord/restart"
 
 	// So it registers Configure.
 	_ "github.com/snapcore/snapd/overlord/configstate"
@@ -749,6 +750,45 @@ func (s *snapmgrTestSuite) TestGadgetInstallConflict(c *C) {
 	_, err := snapstate.Install(context.Background(), s.state, "brand-gadget",
 		nil, 0, snapstate.Flags{})
 	c.Assert(err, ErrorMatches, "boot config is being updated, no change in kernel commnd line is allowed meanwhile")
+}
+
+func (s *snapmgrTestSuite) TestInstallNoRestartBoundaries(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	r := snapstatetest.MockDeviceModel(DefaultModel())
+	defer r()
+
+	snapsup := &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{
+			RealName: "brand-gadget",
+			SnapID:   "brand-gadget",
+			Revision: snap.R(2),
+		},
+		Type: snap.TypeGadget,
+	}
+
+	// Ensure that restart boundaries were set on 'link-snap' as a part of doInstall
+	// when the flag noRestartBoundaries is not set
+	ts1, err := snapstate.DoInstall(s.state, &snapstate.SnapState{}, snapsup, 0, "", inUseCheck)
+	c.Assert(err, IsNil)
+
+	linkSnap1 := ts1.MaybeEdge(snapstate.MaybeRebootEdge)
+	c.Assert(linkSnap1, NotNil)
+
+	var boundary restart.RestartBoundaryDirection
+	c.Check(linkSnap1.Get("restart-boundary", &boundary), IsNil)
+
+	// Ensure that restart boundaries are not set when we do provide the noRestartBoundaries flag
+	ts2, err := snapstate.DoInstall(s.state, &snapstate.SnapState{}, snapsup, snapstate.NoRestartBoundaries, "", inUseCheck)
+	c.Assert(err, IsNil)
+
+	linkSnap2 := ts2.MaybeEdge(snapstate.MaybeRebootEdge)
+	c.Assert(linkSnap2, NotNil)
+	c.Check(linkSnap2.Get("restart-boundary", &boundary), ErrorMatches, `no state entry for key "restart-boundary"`)
 }
 
 func (s *snapmgrTestSuite) TestInstallSnapdConflict(c *C) {
@@ -5842,4 +5882,32 @@ func (s *snapmgrTestSuite) TestInstallWithTransactionLaneForbidden(c *C) {
 	tss, err := snapstate.InstallWithDeviceContext(context.Background(), s.state, "some-snap", nil, 0, snapstate.Flags{Lane: 1}, nil, "")
 	c.Assert(err, ErrorMatches, "transaction lane is unsupported in InstallWithDeviceContext")
 	c.Check(tss, IsNil)
+}
+
+func (s *snapmgrTestSuite) TestInstallManyRestartBoundaries(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	r := snapstatetest.MockDeviceModel(DefaultModel())
+	defer r()
+
+	// install one we expect gets restart boundary set, and one that we don't expect
+	affected, tss, err := snapstate.InstallMany(s.state, []string{"brand-gadget", "some-snap"}, nil, s.user.ID, &snapstate.Flags{})
+	c.Assert(err, IsNil)
+	c.Check(affected, DeepEquals, []string{"brand-gadget", "some-snap"})
+	c.Check(tss, HasLen, 2)
+
+	// only ensure that SetEssentialSnapsRestartBoundaries was actually called, we don't
+	// test that all restart boundaries were set, one is enough
+	linkSnap1 := tss[0].MaybeEdge(snapstate.MaybeRebootEdge)
+	linkSnap2 := tss[1].MaybeEdge(snapstate.MaybeRebootEdge)
+	c.Assert(linkSnap1, NotNil)
+	c.Assert(linkSnap2, NotNil)
+
+	var boundary restart.RestartBoundaryDirection
+	c.Check(linkSnap1.Get("restart-boundary", &boundary), IsNil)
+	c.Check(linkSnap2.Get("restart-boundary", &boundary), ErrorMatches, `no state entry for key "restart-boundary"`)
 }

--- a/tests/core/kernel-and-base-single-reboot-failover/task.yaml
+++ b/tests/core/kernel-and-base-single-reboot-failover/task.yaml
@@ -60,10 +60,10 @@ execute: |
         # retrying auto-connect)
         snap debug state --change "$change_id" /var/lib/snapd/state.json > tasks.state
         # both link snaps are done
-        MATCH ' Done\s+.*Make snap "pc-kernel" .* available' < tasks.state
+        MATCH ' Wait\s+.*Make snap "pc-kernel" .* available' < tasks.state
         MATCH ' Done\s+.*Make snap "core18" .* available' < tasks.state
         # auto-connect of the base is in doing and waiting for reboot
-        MATCH ' Doing\s+.*Automatically connect eligible plugs and slots of snap "core18"' < tasks.state
+        MATCH ' Do\s+.*Automatically connect eligible plugs and slots of snap "core18"' < tasks.state
         # auto-connect of the kernel is still queued
         MATCH ' Do\s+.*Automatically connect eligible plugs and slots of snap "pc-kernel"' < tasks.state
 

--- a/tests/core/kernel-and-base-single-reboot/task.yaml
+++ b/tests/core/kernel-and-base-single-reboot/task.yaml
@@ -65,10 +65,10 @@ execute: |
         # retrying auto-connect)
         snap debug state --change "$change_id" /var/lib/snapd/state.json > tasks.state
         # both link snaps are done
-        MATCH ' Done\s+.*Make snap "pc-kernel" .* available' < tasks.state
+        MATCH ' Wait\s+.*Make snap "pc-kernel" .* available' < tasks.state
         MATCH " Done\s+.*Make snap \"$core_snap\" .* available" < tasks.state
         # auto-connect of the base is in doing and waiting for reboot
-        MATCH " Doing\s+.*Automatically connect eligible plugs and slots of snap \"$core_snap\"" < tasks.state
+        MATCH " Do\s+.*Automatically connect eligible plugs and slots of snap \"$core_snap\"" < tasks.state
         # auto-connect of the kernel is still queued
         MATCH ' Do\s+.*Automatically connect eligible plugs and slots of snap "pc-kernel"' < tasks.state
 

--- a/tests/core/system-snap-refresh/task.yaml
+++ b/tests/core/system-snap-refresh/task.yaml
@@ -3,7 +3,7 @@ summary: Check that the ubuntu-core system is rebooted after the core snap is re
 details: |
     This test checks that when invoking a manual refresh/revert for core or core18 snaps,
     a reboot is triggered and the command would exit after the first phase of the installation
-    reporting "snapd is about to reboot the system"
+    reporting "snapd is about to reboot the system" or "Change X waiting on external action to be completed"
 
 systems: [ubuntu-core-*]
 
@@ -72,7 +72,7 @@ execute: |
         [ "$(cat initialRev)" !=  "$currRev" ]
 
         # revert the target snap
-        snap revert "$TARGET_SNAP_NAME" 2>&1 | MATCH "snapd is about to reboot the system"
+        snap revert "$TARGET_SNAP_NAME" 2>&1 | MATCH "snapd is about to reboot the system|waiting on external action to be completed"
 
         # Detect in the logs when the reboot can been triggered
         "$TESTSTOOLS"/journal-state match-log -n 50 --wait 2 "Waiting for system reboot"


### PR DESCRIPTION
The PR switches to the new restart logic and changes a few neccessary things now that the semantics around restarting for changes is different. The whole process around restarting for tasks/changes is now more streamlined, and any deviances from the regular restarting must now explicitly be marked when creating a change. 

Currently two tasks are using deferred restarts ("update-gadget-assets" + "update-gadget-cmdline" for gadget/kernel snaps), to avoid incurring extra reboots during kernel/gadget installs, as they were implicitly allowed to be deferred before. 

Sadly a few changes were neccessary to the spread tests, as some reboots were actually skipped because it was allowed, even though they had been requested. The new restart code also provides full symmetry for do/undo paths, which also has required one spread test to handle an additional restart (these restarts **were** requested with the old code).

Whats left after this?

Moving single-reboot installs of base/kernel snaps to the new deferred restart API and removing "cannot-reboot" task variable.
Allowing single-reboot installs of base/gadget/kernel snaps with the new API.
