### PR TITLE
tests: fix snapd16 test

### DIFF
--- a/tests/core/snapd16/task.yaml
+++ b/tests/core/snapd16/task.yaml
@@ -69,7 +69,7 @@ execute: |
         systemctl status snapd|MATCH " /usr/lib/snapd/snapd"
         snap wait system seed.loaded
 
-        umount /snap/snapd/x2
+        retry -n 3 --wait 1 umount /snap/snapd/x2
         rm /etc/systemd/system/snap-snapd-x2.mount
         systemctl daemon-reload
         snap list


### PR DESCRIPTION
The umount could fail sporadically with the following error

+ umount /snap/snapd/x2 umount: /snap/snapd/x2: not mounted

The idea is to retry 3 times to make sure the umount is done
