### PR TITLE
o/snapstate: use refresh hints to continue auto-refresh after monitoring (2.60)

### DIFF
--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -1212,7 +1212,7 @@ func (s *assertMgrSuite) TestRefreshAssertionsRefreshSnapDeclarationsAndValidati
 	c.Check(a.Revision(), Equals, 3)
 
 	c.Assert(err, IsNil)
-	c.Check(s.fakeStore.(*fakeStore).opts.IsAutoRefresh, Equals, false)
+	c.Check(s.fakeStore.(*fakeStore).opts.Scheduled, Equals, false)
 
 	// changed validation set assertion again
 	vsetAs3 := s.validationSetAssert(c, "bar", "4", "5", "required", "1")
@@ -1251,7 +1251,7 @@ func (s *assertMgrSuite) TestRefreshSnapDeclarationsNop(c *C) {
 
 	err := assertstate.RefreshSnapDeclarations(s.state, 0, &assertstate.RefreshAssertionsOptions{IsAutoRefresh: true})
 	c.Assert(err, IsNil)
-	c.Check(s.fakeStore.(*fakeStore).opts.IsAutoRefresh, Equals, true)
+	c.Check(s.fakeStore.(*fakeStore).opts.Scheduled, Equals, true)
 }
 
 func (s *assertMgrSuite) TestRefreshSnapDeclarationsNoStore(c *C) {
@@ -2504,7 +2504,7 @@ func (s *assertMgrSuite) TestValidationSetAssertionsAutoRefresh(c *C) {
 	assertstate.UpdateValidationSet(s.state, &tr)
 
 	c.Assert(assertstate.AutoRefreshAssertions(s.state, 0), IsNil)
-	c.Check(s.fakeStore.(*fakeStore).opts.IsAutoRefresh, Equals, true)
+	c.Check(s.fakeStore.(*fakeStore).opts.Scheduled, Equals, true)
 
 	a, err := assertstate.DB(s.state).Find(asserts.ValidationSetType, map[string]string{
 		"series":     "16",
@@ -2607,7 +2607,7 @@ func (s *assertMgrSuite) TestRefreshValidationSetAssertions(c *C) {
 	c.Check(s.fakeStore.(*fakeStore).requestedTypes, DeepEquals, [][]string{
 		{"account", "account-key", "validation-set"},
 	})
-	c.Check(s.fakeStore.(*fakeStore).opts.IsAutoRefresh, Equals, true)
+	c.Check(s.fakeStore.(*fakeStore).opts.Scheduled, Equals, true)
 
 	// sequence changed in the store to 4
 	vsetAs3 := s.validationSetAssert(c, "bar", "4", "3", "required", "1")
@@ -3307,7 +3307,7 @@ func (s *assertMgrSuite) TestValidationSetAssertionForEnforcePinnedHappy(c *C) {
 		"sequence":   "2",
 	})
 	c.Assert(err, IsNil)
-	c.Check(s.fakeStore.(*fakeStore).opts.IsAutoRefresh, Equals, false)
+	c.Check(s.fakeStore.(*fakeStore).opts.Scheduled, Equals, false)
 }
 
 func (s *assertMgrSuite) TestValidationSetAssertionForEnforceNotPinnedUnhappyMissingSnap(c *C) {
@@ -3601,7 +3601,7 @@ func (s *assertMgrSuite) TestEnforceValidationSetAssertion(c *C) {
 		"sequence":   "2",
 	})
 	c.Assert(err, IsNil)
-	c.Check(s.fakeStore.(*fakeStore).opts.IsAutoRefresh, Equals, false)
+	c.Check(s.fakeStore.(*fakeStore).opts.Scheduled, Equals, false)
 
 	var tr assertstate.ValidationSetTracking
 	c.Assert(assertstate.GetValidationSet(s.state, s.dev1Acct.AccountID(), "bar", &tr), IsNil)
@@ -3662,7 +3662,7 @@ func (s *assertMgrSuite) TestEnforceValidationSetAssertionUpdate(c *C) {
 		"sequence":   "2",
 	})
 	c.Assert(err, IsNil)
-	c.Check(s.fakeStore.(*fakeStore).opts.IsAutoRefresh, Equals, false)
+	c.Check(s.fakeStore.(*fakeStore).opts.Scheduled, Equals, false)
 
 	var tr assertstate.ValidationSetTracking
 	c.Assert(assertstate.GetValidationSet(s.state, s.dev1Acct.AccountID(), "bar", &tr), IsNil)
@@ -3739,7 +3739,7 @@ func (s *assertMgrSuite) TestEnforceValidationSetAssertionPinToOlderSequence(c *
 		"sequence":   "2",
 	})
 	c.Assert(err, IsNil)
-	c.Check(s.fakeStore.(*fakeStore).opts.IsAutoRefresh, Equals, false)
+	c.Check(s.fakeStore.(*fakeStore).opts.Scheduled, Equals, false)
 
 	var tr assertstate.ValidationSetTracking
 	c.Assert(assertstate.GetValidationSet(s.state, s.dev1Acct.AccountID(), "bar", &tr), IsNil)
@@ -3814,7 +3814,7 @@ func (s *assertMgrSuite) TestEnforceValidationSetAssertionAfterMonitor(c *C) {
 		"sequence":   "2",
 	})
 	c.Assert(err, IsNil)
-	c.Check(s.fakeStore.(*fakeStore).opts.IsAutoRefresh, Equals, false)
+	c.Check(s.fakeStore.(*fakeStore).opts.Scheduled, Equals, false)
 
 	var tr assertstate.ValidationSetTracking
 	c.Assert(assertstate.GetValidationSet(s.state, s.dev1Acct.AccountID(), "bar", &tr), IsNil)
@@ -3869,7 +3869,7 @@ func (s *assertMgrSuite) TestEnforceValidationSetAssertionIgnoreValidation(c *C)
 		"sequence":   "2",
 	})
 	c.Assert(err, IsNil)
-	c.Check(s.fakeStore.(*fakeStore).opts.IsAutoRefresh, Equals, false)
+	c.Check(s.fakeStore.(*fakeStore).opts.Scheduled, Equals, false)
 
 	var tr assertstate.ValidationSetTracking
 	c.Assert(assertstate.GetValidationSet(s.state, s.dev1Acct.AccountID(), "bar", &tr), IsNil)
@@ -3972,7 +3972,7 @@ func (s *assertMgrSuite) TestTryEnforceValidationSetsAssertionsValidationError(c
 		"sequence":   "1",
 	})
 	c.Assert(errors.Is(err, &asserts.NotFoundError{}), Equals, true)
-	c.Check(s.fakeStore.(*fakeStore).opts.IsAutoRefresh, Equals, false)
+	c.Check(s.fakeStore.(*fakeStore).opts.Scheduled, Equals, false)
 }
 
 func (s *assertMgrSuite) TestTryEnforceValidationSetsAssertionsOK(c *C) {
@@ -4044,7 +4044,7 @@ func (s *assertMgrSuite) TestTryEnforceValidationSetsAssertionsOK(c *C) {
 		"sequence":   "1",
 	})
 	c.Assert(err, IsNil)
-	c.Check(s.fakeStore.(*fakeStore).opts.IsAutoRefresh, Equals, false)
+	c.Check(s.fakeStore.(*fakeStore).opts.Scheduled, Equals, false)
 
 	// tracking was updated
 	var tr assertstate.ValidationSetTracking
@@ -4145,7 +4145,7 @@ func (s *assertMgrSuite) TestTryEnforceValidationSetsAssertionsAlreadyTrackedUpd
 		"sequence":   "2",
 	})
 	c.Assert(err, IsNil)
-	c.Check(s.fakeStore.(*fakeStore).opts.IsAutoRefresh, Equals, false)
+	c.Check(s.fakeStore.(*fakeStore).opts.Scheduled, Equals, false)
 
 	// tracking was updated
 	var tr assertstate.ValidationSetTracking
@@ -4228,7 +4228,7 @@ func (s *assertMgrSuite) TestTryEnforceValidationSetsAssertionsConflictError(c *
 		"sequence":   "2",
 	})
 	c.Assert(errors.Is(err, &asserts.NotFoundError{}), Equals, true)
-	c.Check(s.fakeStore.(*fakeStore).opts.IsAutoRefresh, Equals, false)
+	c.Check(s.fakeStore.(*fakeStore).opts.Scheduled, Equals, false)
 }
 
 func (s *assertMgrSuite) TestMonitorValidationSet(c *C) {
@@ -4267,7 +4267,7 @@ func (s *assertMgrSuite) TestMonitorValidationSet(c *C) {
 		"sequence":   "2",
 	})
 	c.Assert(err, IsNil)
-	c.Check(s.fakeStore.(*fakeStore).opts.IsAutoRefresh, Equals, false)
+	c.Check(s.fakeStore.(*fakeStore).opts.Scheduled, Equals, false)
 
 	var tr assertstate.ValidationSetTracking
 	c.Assert(assertstate.GetValidationSet(s.state, s.dev1Acct.AccountID(), "bar", &tr), IsNil)

--- a/overlord/assertstate/bulk.go
+++ b/overlord/assertstate/bulk.go
@@ -256,7 +256,7 @@ func resolvePool(s *state.State, pool *asserts.Pool, checkBeforeCommit func(*ass
 	unsupported := handleUnsupported(db)
 
 	for {
-		storeOpts := &store.RefreshOptions{IsAutoRefresh: opts.IsAutoRefresh}
+		storeOpts := &store.RefreshOptions{Scheduled: opts.IsAutoRefresh}
 		s.Unlock()
 		_, aresults, err := sto.SnapAction(context.TODO(), nil, nil, pool, user, storeOpts)
 		s.Lock()

--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -80,7 +80,9 @@ var refreshRetryDelay = 20 * time.Minute
 // of auto-refresh.
 type refreshCandidate struct {
 	SnapSetup
-	Version string `json:"version,omitempty"`
+	// Monitored signals whether this snap is currently being monitored for closure
+	// so its auto-refresh can be continued.
+	Monitored bool `json:"monitored,omitempty"`
 }
 
 func (rc *refreshCandidate) Type() snap.Type {
@@ -99,16 +101,23 @@ func (rc *refreshCandidate) InstanceName() string {
 	return rc.SnapSetup.InstanceName()
 }
 
-func (rc *refreshCandidate) Prereq(st *state.State) []string {
+func (rc *refreshCandidate) Prereq(*state.State) []string {
 	return rc.SnapSetup.Prereq
 }
 
-func (rc *refreshCandidate) SnapSetupForUpdate(st *state.State, params updateParamsFunc, userID int, globalFlags *Flags) (*SnapSetup, *SnapState, error) {
+func (rc *refreshCandidate) SnapSetupForUpdate(st *state.State, _ updateParamsFunc, _ int, globalFlags *Flags) (*SnapSetup, *SnapState, error) {
 	var snapst SnapState
 	if err := Get(st, rc.InstanceName(), &snapst); err != nil {
 		return nil, nil, err
 	}
-	return &rc.SnapSetup, &snapst, nil
+
+	snapsup := &rc.SnapSetup
+	if globalFlags != nil {
+		snapsup.Flags.IsAutoRefresh = globalFlags.IsAutoRefresh
+		snapsup.Flags.IsContinuedAutoRefresh = globalFlags.IsContinuedAutoRefresh
+	}
+
+	return snapsup, &snapst, nil
 }
 
 // soundness check
@@ -272,7 +281,9 @@ func (m *autoRefresh) Ensure() (err error) {
 	m.state.Lock()
 	defer m.state.Unlock()
 
-	m.restoreMonitoring()
+	if err := m.restoreMonitoring(); err != nil {
+		return fmt.Errorf("cannot restore monitoring: %v", err)
+	}
 
 	// see if it even makes sense to try to refresh
 	if CanAutoRefresh == nil {
@@ -280,27 +291,6 @@ func (m *autoRefresh) Ensure() (err error) {
 	}
 	if ok, err := CanAutoRefresh(m.state); err != nil || !ok {
 		return err
-	}
-
-	// is there a previously partially inhibited auto-refresh that can now be continued?
-	if attempt, ok := canContinueAutoRefresh(m.state); ok {
-		// override the auto-refresh delay if we're continuing an inhibited auto-refresh
-		// for the first time (because the snap just closed after we notified the user)
-		overrideDelay := attempt == 1
-		err := m.launchAutoRefresh(overrideDelay)
-		if err != nil {
-			if errors.Is(err, tooSoonError{}) {
-				// ignore error, retry the auto-refresh later
-				return nil
-			}
-
-			// we didn't auto-refresh, so keep flag but increase attempt counter
-			m.state.Cache("auto-refresh-continue-attempt", attempt+1)
-			return err
-		}
-		// clear the continue flag if the auto-refresh was scheduled successfully
-		m.state.Cache("auto-refresh-continue-attempt", nil)
-		return nil
 	}
 
 	// get lastRefresh and schedule
@@ -385,8 +375,7 @@ func (m *autoRefresh) Ensure() (err error) {
 				return nil
 			}
 
-			overrideDelay := false
-			err = m.launchAutoRefresh(overrideDelay)
+			err = m.launchAutoRefresh()
 			if _, ok := err.(*httputil.PersistentNetworkError); ok {
 				// refresh will be retried after refreshRetryDelay
 				return err
@@ -403,44 +392,48 @@ func (m *autoRefresh) Ensure() (err error) {
 	return err
 }
 
-func canContinueAutoRefresh(st *state.State) (int, bool) {
-	if cachedAttempt := st.Cached("auto-refresh-continue-attempt"); cachedAttempt != nil {
-		return cachedAttempt.(int), true
-	}
-
-	return 0, false
-}
-
-func (m *autoRefresh) restoreMonitoring() {
+func (m *autoRefresh) restoreMonitoring() error {
 	if m.restoredMonitoring {
-		return
+		return nil
 	}
 
-	var monitored []string
-	if err := m.state.Get("monitored-snaps", &monitored); err != nil && !errors.Is(err, state.ErrNoState) {
-		logger.Noticef("cannot restore monitoring: %v", err)
-		return
+	// clear the old monitoring state; remove in a later snapd version
+	m.state.Set("monitored-snaps", nil)
+
+	var refreshHints map[string]*refreshCandidate
+	if err := m.state.Get("refresh-candidates", &refreshHints); err != nil && !errors.Is(err, &state.NoStateError{}) {
+		return fmt.Errorf("cannot get refresh-candidates: %v", err)
 	}
 
 	defer func() { m.restoredMonitoring = true }()
-	if len(monitored) == 0 {
-		return
+
+	var monitored []*SnapSetup
+	for _, hint := range refreshHints {
+		if hint.Monitored {
+			monitored = append(monitored, &hint.SnapSetup)
+		}
 	}
 
-	monitoring := make(map[string]chan<- bool)
+	if len(monitored) == 0 {
+		return nil
+	}
+
+	aborts := make(map[string]context.CancelFunc, len(monitored))
 	for _, snap := range monitored {
 		done := make(chan string, 1)
-		if err := cgroupMonitorSnapEnded(snap, done); err != nil {
-			logger.Noticef("cannot restore monitoring for snap %q closure: %v", snap, err)
+		snapName := snap.InstanceName()
+		if err := cgroupMonitorSnapEnded(snapName, done); err != nil {
+			logger.Noticef("cannot restore monitoring for snap %q closure: %v", snapName, err)
 			continue
 		}
 
-		abort := make(chan bool, 1)
-		monitoring[snap] = abort
-
-		go continueRefreshOnSnapClose(m.state, snap, done, abort)
+		refreshCtx, abort := context.WithCancel(context.Background())
+		aborts[snapName] = abort
+		go continueRefreshOnSnapClose(m.state, snap, done, refreshCtx)
 	}
-	updateMonitoringState(m.state, monitoring)
+
+	m.state.Cache("monitored-snaps", aborts)
+	return nil
 }
 
 // isRefreshHeld returns whether an auto-refresh is currently held back or not,
@@ -581,13 +574,13 @@ func (tooSoonError) Is(err error) bool {
 }
 
 // launchAutoRefresh creates the auto-refresh taskset and a change for it.
-func (m *autoRefresh) launchAutoRefresh(overrideDelay bool) error {
+func (m *autoRefresh) launchAutoRefresh() error {
 	// Check that we have reasonable delays between attempts.
 	// If the store is under stress we need to make sure we do not
 	// hammer it too often
 	now := timeNow()
 	minAttempt := m.lastRefreshAttempt.Add(refreshRetryDelay)
-	if !overrideDelay && !m.lastRefreshAttempt.IsZero() && minAttempt.After(now) {
+	if !m.lastRefreshAttempt.IsZero() && minAttempt.After(now) {
 		return tooSoonError{}
 	}
 	m.lastRefreshAttempt = now
@@ -600,7 +593,7 @@ func (m *autoRefresh) launchAutoRefresh(overrideDelay bool) error {
 	}()
 
 	// NOTE: this will unlock and re-lock state for network ops
-	updated, updateTss, err := AutoRefresh(auth.EnsureContextTODO(), m.state, &AutoRefreshOptions{IsContinuedAutoRefresh: overrideDelay})
+	updated, updateTss, err := AutoRefresh(auth.EnsureContextTODO(), m.state)
 
 	// TODO: we should have some way to lock just creating and starting changes,
 	//       as that would alleviate this race condition we are guarding against

--- a/overlord/snapstate/autorefresh_gating_test.go
+++ b/overlord/snapstate/autorefresh_gating_test.go
@@ -1417,7 +1417,7 @@ func (s *autorefreshGatingSuite) TestAutorefreshPhase1FeatureFlag(c *C) {
 	mockInstalledSnap(c, s.state, snapAyaml, useHook)
 
 	// gate-auto-refresh-hook feature not enabled, expect old-style refresh.
-	_, updateTss, err := snapstate.AutoRefresh(context.TODO(), st, nil)
+	_, updateTss, err := snapstate.AutoRefresh(context.TODO(), st)
 	c.Check(err, IsNil)
 	tss := updateTss.Refresh
 	c.Assert(tss, HasLen, 2)
@@ -1430,7 +1430,7 @@ func (s *autorefreshGatingSuite) TestAutorefreshPhase1FeatureFlag(c *C) {
 	tr.Set("core", "experimental.gate-auto-refresh-hook", true)
 	tr.Commit()
 
-	_, updateTss, err = snapstate.AutoRefresh(context.TODO(), st, nil)
+	_, updateTss, err = snapstate.AutoRefresh(context.TODO(), st)
 	c.Check(err, IsNil)
 	tss = updateTss.Refresh
 	c.Assert(tss, HasLen, 2)
@@ -2034,8 +2034,7 @@ func (s *snapmgrTestSuite) TestAutoRefreshPhase2(c *C) {
 
 	// all snaps refreshed, all removed from refresh-candidates.
 	var candidates map[string]*snapstate.RefreshCandidate
-	c.Assert(s.state.Get("refresh-candidates", &candidates), IsNil)
-	c.Assert(candidates, HasLen, 0)
+	c.Assert(s.state.Get("refresh-candidates", &candidates), testutil.ErrorIs, &state.NoStateError{})
 }
 
 func (s *snapmgrTestSuite) TestAutoRefreshPhase2Held(c *C) {

--- a/overlord/snapstate/autorefresh_test.go
+++ b/overlord/snapstate/autorefresh_test.go
@@ -73,7 +73,7 @@ func (r *autoRefreshStore) SnapAction(ctx context.Context, currentSnaps []*store
 	if assertQuery != nil {
 		panic("no assertion query support")
 	}
-	if !opts.IsAutoRefresh {
+	if !opts.Scheduled {
 		panic("AutoRefresh snap action did not set IsAutoRefresh flag")
 	}
 

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -706,7 +706,7 @@ func (f *fakeStore) Download(ctx context.Context, name, targetFn string, snapInf
 		macaroon = user.StoreMacaroon
 	}
 	// only add the options if they contain anything interesting
-	if *dlOpts == (store.DownloadOptions{}) {
+	if dlOpts != nil && *dlOpts == (store.DownloadOptions{}) {
 		dlOpts = nil
 	}
 	f.downloads = append(f.downloads, fakeDownload{

--- a/overlord/snapstate/flags.go
+++ b/overlord/snapstate/flags.go
@@ -75,7 +75,7 @@ type Flags struct {
 	// IsAutoRefresh is true if the snap is currently auto-refreshed
 	IsAutoRefresh bool `json:"is-auto-refresh,omitempty"`
 
-	// IsContinuedAutoRefresh is true if this is a continued auto-refresh
+	// IsContinuedAutoRefresh is true if this is a continued refresh
 	IsContinuedAutoRefresh bool `json:"is-continued-auto-refresh,omitempty"`
 
 	// NoReRefresh prevents refresh from adding epoch-hopping

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -892,23 +892,18 @@ func (m *SnapManager) doPreDownloadSnap(t *state.Task, tomb *tomb.Tomb) error {
 			return err
 		}
 
-		return asyncRefreshOnSnapClose(m.state, refreshInfo)
+		return asyncRefreshOnSnapClose(m.state, snapsup, refreshInfo)
 	}
 
-	continueInhibitedAutoRefresh(st)
-	return nil
+	return continueInhibitedAutoRefresh(st, snapsup.InstanceName())
 }
 
 // asyncRefreshOnSnapClose asynchronously waits for the snap the close, notifies
 // the user and then triggers an auto-refresh.
-func asyncRefreshOnSnapClose(st *state.State, refreshInfo *userclient.PendingSnapRefreshInfo) error {
-	monitoredSnaps := snapMonitoring(st)
-	if monitoredSnaps == nil {
-		monitoredSnaps = make(map[string]chan<- bool)
-	}
-
+func asyncRefreshOnSnapClose(st *state.State, snapsup *SnapSetup, refreshInfo *userclient.PendingSnapRefreshInfo) error {
+	snapName := snapsup.InstanceName()
 	// there's already a goroutine waiting for this snap to close so just notify
-	if monitoredSnaps[refreshInfo.InstanceName] != nil {
+	if isSnapMonitored(st, snapName) {
 		asyncPendingRefreshNotification(context.TODO(), userclient.New(), refreshInfo)
 		return nil
 	}
@@ -916,89 +911,190 @@ func asyncRefreshOnSnapClose(st *state.State, refreshInfo *userclient.PendingSna
 	// monitor the snap until it closes. Use buffered channel to prevent the sender
 	// from blocking if the receiver stops before reading from it
 	done := make(chan string, 1)
-	if err := cgroupMonitorSnapEnded(refreshInfo.InstanceName, done); err != nil {
+	if err := cgroupMonitorSnapEnded(snapName, done); err != nil {
 		return fmt.Errorf("cannot monitor for snap closure: %w", err)
+	}
+
+	refreshCtx, abort := context.WithCancel(context.Background())
+	if ok, err := addMonitoring(st, snapName, abort); err != nil {
+		return fmt.Errorf("cannot save monitoring state for %q: %v", snapName, err)
+	} else if !ok {
+		// refresh candidate missing, no need to monitor
+		return nil
 	}
 
 	// notify the user about the blocked refresh
 	asyncPendingRefreshNotification(context.TODO(), userclient.New(), refreshInfo)
 
-	abort := make(chan bool, 1)
-	monitoredSnaps[refreshInfo.InstanceName] = abort
-	updateMonitoringState(st, monitoredSnaps)
+	go continueRefreshOnSnapClose(st, snapsup, done, refreshCtx)
+	return nil
+}
 
-	go continueRefreshOnSnapClose(st, refreshInfo.InstanceName, done, abort)
+// addMonitoring adds monitoring info to the persisted and in-memory states.
+// Returns true if the monitoring state was saved or false if it wasn't because
+// the monitoring shouldn't proceed.
+func addMonitoring(st *state.State, snapName string, abort context.CancelFunc) (bool, error) {
+	var refreshHints map[string]*refreshCandidate
+	if err := st.Get("refresh-candidates", &refreshHints); err != nil {
+		if errors.Is(err, &state.NoStateError{}) {
+			// the candidate may have been reverted from the channel after the
+			// auto-refresh, so it's missing here and there's nothing to refresh to
+			logger.Noticef("cannot get refresh candidate for %q (possibly reverted): nothing to refresh", snapName)
+			return false, nil
+		}
+
+		return false, fmt.Errorf("cannot get refresh-candidates: %v", err)
+	} else if _, ok := refreshHints[snapName]; !ok {
+		// the candidate may have been reverted from the channel after the
+		// auto-refresh, so it's missing here and there's nothing to refresh to
+		logger.Noticef("cannot get refresh candidate for %q (possibly reverted): nothing to refresh", snapName)
+		return false, nil
+	}
+
+	abortChans, err := getMonitoringAborts(st)
+	if err != nil {
+		return false, err
+	}
+	if abortChans == nil {
+		abortChans = make(map[string]context.CancelFunc)
+	}
+
+	refreshHints[snapName].Monitored = true
+	st.Set("refresh-candidates", refreshHints)
+
+	abortChans[snapName] = abort
+	st.Cache("monitored-snaps", abortChans)
+
+	return true, nil
+}
+
+// removeMonitoring removes monitoring state related to the specified snap.
+func removeMonitoring(st *state.State, snapName string) error {
+	var refreshHints map[string]*refreshCandidate
+	if err := st.Get("refresh-candidates", &refreshHints); err != nil {
+		return fmt.Errorf("cannot get refresh-candidates: %v", err)
+	} else if _, ok := refreshHints[snapName]; !ok {
+		return fmt.Errorf(`cannot reset the "monitored" field for %q in "refresh-candidates"`, snapName)
+	}
+
+	refreshHints[snapName].Monitored = false
+	st.Set("refresh-candidates", refreshHints)
+
+	abortChans, err := getMonitoringAborts(st)
+	if err != nil {
+		return nil
+	}
+	if abortChans == nil {
+		return nil
+	}
+
+	delete(abortChans, snapName)
+	if len(abortChans) == 0 {
+		st.Cache("monitored-snaps", nil)
+	} else {
+		st.Cache("monitored-snaps", abortChans)
+	}
 
 	return nil
 }
 
-func continueRefreshOnSnapClose(st *state.State, instanceName string, done <-chan string, abort <-chan bool) {
-	continueAutoRefresh := false
+func continueRefreshOnSnapClose(st *state.State, snapsup *SnapSetup, done <-chan string, refreshCtx context.Context) {
+	snapName := snapsup.InstanceName()
+
+	var aborted bool
 	select {
 	case <-done:
-		continueAutoRefresh = true
-	case <-abort:
+	case <-refreshCtx.Done():
+		aborted = true
 	}
 
 	st.Lock()
 	defer st.Unlock()
 
-	monitoredSnaps := snapMonitoring(st)
-	if monitoredSnaps == nil {
-		// shouldn't happen except for programmer error
-		logger.Noticef("cannot find monitoring state for snap %q", instanceName)
-	} else {
-		delete(monitoredSnaps, instanceName)
-
-		if len(monitoredSnaps) == 0 {
-			// use nil to delete entry but must be nil type (can't be map var set to nil)
-			updateMonitoringState(st, nil)
-		} else {
-			updateMonitoringState(st, monitoredSnaps)
+	defer func() {
+		if err := removeMonitoring(st, snapName); err != nil {
+			logger.Noticef("cannot remove monitoring information: %v", err)
 		}
-	}
+	}()
 
-	if continueAutoRefresh {
-		continueInhibitedAutoRefresh(st)
-	}
-}
-
-// continueInhibitedAutoRefresh triggers an auto-refresh so it can be continued
-func continueInhibitedAutoRefresh(st *state.State) {
-	// signal that there's an auto-refresh to be continued (for auto-refresh code)
-	st.Cache("auto-refresh-continue-attempt", 1)
-	st.EnsureBefore(0)
-}
-
-func snapMonitoring(st *state.State) map[string]chan<- bool {
-	if cachedMonitored := st.Cached("monitored-snaps"); cachedMonitored != nil {
-		if monitoredSnaps, ok := cachedMonitored.(map[string]chan<- bool); ok {
-			return monitoredSnaps
-		}
-	}
-
-	return nil
-}
-
-func updateMonitoringState(st *state.State, monitored map[string]chan<- bool) {
-	if monitored == nil {
-		st.Cache("monitored-snaps", nil)
-		st.Set("monitored-snaps", nil)
+	if aborted {
+		logger.Debugf("monitoring for pre-downloaded snap %q was aborted", snapName)
 		return
 	}
 
-	var snaps []string
-	for snap := range monitored {
-		snaps = append(snaps, snap)
+	if err := continueInhibitedAutoRefresh(st, snapName); err != nil {
+		logger.Noticef("cannot continue inhibited auto-refresh for %q: %v", snapName, err)
+		return
+	}
+}
+
+// continueInhibitedAutoRefresh refreshes the snap to continue the inhibited auto-refresh
+func continueInhibitedAutoRefresh(st *state.State, snapName string) error {
+	var refreshHints map[string]*refreshCandidate
+	if err := st.Get("refresh-candidates", &refreshHints); err != nil {
+		return fmt.Errorf("cannot get refresh-candidates: %v", err)
 	}
 
-	st.Cache("monitored-snaps", monitored)
-	st.Set("monitored-snaps", snaps)
+	hint, ok := refreshHints[snapName]
+	if !ok {
+		return fmt.Errorf("cannot get refresh-candidates for %q: not found", snapName)
+	}
+
+	flags := &Flags{IsAutoRefresh: true, IsContinuedAutoRefresh: true}
+	tss, err := autoRefreshPhase2(context.TODO(), st, []*refreshCandidate{hint}, flags, "")
+	if err != nil {
+		return err
+	}
+
+	// TODO: do a check so this can't happen?
+	createdPreDl, err := createPreDownloadChange(st, tss)
+	if err != nil {
+		return err
+	}
+
+	if !createdPreDl {
+		snaps := []string{snapName}
+		msg := autoRefreshSummary(snaps)
+		chg := st.NewChange("auto-refresh", msg)
+		for _, ts := range tss.Refresh {
+			chg.AddAll(ts)
+		}
+		chg.Set("snap-names", snaps)
+		chg.Set("api-data", map[string]interface{}{"snap-names": snaps})
+	}
+
+	st.EnsureBefore(0)
+	return nil
+}
+
+func getMonitoringAborts(st *state.State) (map[string]context.CancelFunc, error) {
+	stored := st.Cached("monitored-snaps")
+	if stored == nil {
+		return nil, nil
+	}
+	aborts, ok := stored.(map[string]context.CancelFunc)
+	if !ok {
+		// NOTE: should never happen save for programmer error
+		return nil, fmt.Errorf(`internal error: "monitored-snaps" should be map[string]context.CancelFunc but got %T`, stored)
+	}
+	return aborts, nil
+}
+
+func monitoringAbort(st *state.State, snapName string) context.CancelFunc {
+	aborts, err := getMonitoringAborts(st)
+	if err != nil {
+		logger.Noticef("%v", err)
+	}
+	return aborts[snapName]
+}
+
+func isSnapMonitored(st *state.State, snapName string) bool {
+	return monitoringAbort(st, snapName) != nil
 }
 
 func abortMonitoring(st *state.State, snapName string) {
-	if monitored := snapMonitoring(st); monitored[snapName] != nil {
-		monitored[snapName] <- true
+	if abort := monitoringAbort(st, snapName); abort != nil {
+		abort()
 	}
 }
 
@@ -1271,7 +1367,7 @@ func (m *SnapManager) doUnlinkCurrentSnap(t *state.Task, _ *tomb.Tomb) (err erro
 			if errors.As(err, &busyErr) {
 				// notify user to close the snap and trigger the auto-refresh once it's closed
 				refreshInfo := busyErr.PendingSnapRefreshInfo()
-				if err := asyncRefreshOnSnapClose(m.state, refreshInfo); err != nil {
+				if err := asyncRefreshOnSnapClose(m.state, snapsup, refreshInfo); err != nil {
 					return err
 				}
 			}
@@ -4053,7 +4149,7 @@ func (m *SnapManager) doConditionalAutoRefresh(t *state.Task, tomb *tomb.Tomb) e
 		return nil
 	}
 
-	updateTss, err := autoRefreshPhase2(context.TODO(), st, snaps, t.Change().ID())
+	updateTss, err := autoRefreshPhase2(context.TODO(), st, snaps, nil, t.Change().ID())
 	if err != nil {
 		return err
 	}

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -753,8 +753,8 @@ func (m *SnapManager) doDownloadSnap(t *state.Task, tomb *tomb.Tomb) error {
 	targetFn := snapsup.MountFile()
 
 	dlOpts := &store.DownloadOptions{
-		IsAutoRefresh: snapsup.IsAutoRefresh,
-		RateLimit:     rate,
+		Scheduled: snapsup.IsAutoRefresh,
+		RateLimit: rate,
 	}
 	if snapsup.DownloadInfo == nil {
 		var storeInfo store.SnapActionResult
@@ -836,8 +836,8 @@ func (m *SnapManager) doPreDownloadSnap(t *state.Task, tomb *tomb.Tomb) error {
 	targetFn := snapsup.MountFile()
 	dlOpts := &store.DownloadOptions{
 		// pre-downloads are only triggered in auto-refreshes
-		IsAutoRefresh: true,
-		RateLimit:     autoRefreshRateLimited(st),
+		Scheduled: true,
+		RateLimit: autoRefreshRateLimited(st),
 	}
 
 	perfTimings := state.TimingsForTask(t)

--- a/overlord/snapstate/handlers_download_test.go
+++ b/overlord/snapstate/handlers_download_test.go
@@ -296,8 +296,8 @@ func (s *downloadSnapSuite) TestDoDownloadRateLimitedIntegration(c *C) {
 			name:   "foo",
 			target: filepath.Join(dirs.SnapBlobDir, "foo_11.snap"),
 			opts: &store.DownloadOptions{
-				RateLimit:     1234,
-				IsAutoRefresh: true,
+				RateLimit: 1234,
+				Scheduled: true,
 			},
 		},
 	})

--- a/overlord/snapstate/refreshhints.go
+++ b/overlord/snapstate/refreshhints.go
@@ -22,6 +22,7 @@ package snapstate
 import (
 	"errors"
 	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/snapcore/snapd/features"
@@ -97,7 +98,8 @@ func (r *refreshHints) refresh() error {
 	if err != nil {
 		return fmt.Errorf("internal error: cannot get refresh-candidates: %v", err)
 	}
-	r.state.Set("refresh-candidates", hints)
+
+	setNewRefreshCandidates(r.state, hints)
 	return nil
 }
 
@@ -123,7 +125,7 @@ func (r *refreshHints) Ensure() error {
 	defer r.state.Unlock()
 
 	// CanAutoRefresh is a hook that is set by the devicestate
-	// code to ensure that we only AutoRefersh if the device has
+	// code to ensure that we only AutoRefresh if the device has
 	// bootstraped itself enough. This is only nil when snapstate
 	// is used in isolation (like in tests).
 	if CanAutoRefresh == nil {
@@ -168,6 +170,7 @@ func refreshHintsFromCandidates(st *state.State, updates []*snap.Info, ignoreVal
 			continue
 		}
 
+		monitoring := isSnapMonitored(st, update.InstanceName())
 		providerContentAttrs := defaultProviderContentAttrs(st, update)
 		snapsup := &refreshCandidate{
 			SnapSetup: SnapSetup{
@@ -190,7 +193,7 @@ func refreshHintsFromCandidates(st *state.State, updates []*snap.Info, ignoreVal
 					Website: update.Website(),
 				},
 			},
-			Version: update.Version,
+			Monitored: monitoring,
 		}
 		hints[update.InstanceName()] = snapsup
 	}
@@ -206,7 +209,7 @@ func pruneRefreshCandidates(st *state.State, snaps ...string) error {
 		return err
 	}
 	// Remove refresh-candidates from state if gate-auto-refresh-hook feature is
-	// not enabled. This acts as a workaround for the case where a snapd from
+	// not enabled and it is not a map. This acts as a workaround for the case where a snapd from
 	// edge was used and created refresh-candidates in the old format (an array)
 	// with the feature enabled, but the feature was then disabled so the new
 	// map format will never make it into the state.
@@ -214,8 +217,24 @@ func pruneRefreshCandidates(st *state.State, snaps ...string) error {
 	// refresh-candidates in the correct format expected here.
 	// See https://forum.snapcraft.io/t/cannot-r-emove-snap-json-cannot-unmarshal-array-into-go-value-of-type-map-string-snapstate-refreshcandidate/27276
 	if !gateAutoRefreshHook {
-		st.Set("refresh-candidates", nil)
-		return nil
+		var rc interface{}
+		err = st.Get("refresh-candidates", &rc)
+		if err != nil {
+			if errors.Is(err, state.ErrNoState) {
+				// nothing to do
+				return nil
+			}
+		}
+		v := reflect.ValueOf(rc)
+		if !v.IsValid() {
+			// nothing to do
+			return nil
+		}
+		if v.Kind() != reflect.Map {
+			// just remove
+			st.Set("refresh-candidates", nil)
+			return nil
+		}
 	}
 
 	var candidates map[string]*refreshCandidate
@@ -232,6 +251,40 @@ func pruneRefreshCandidates(st *state.State, snaps ...string) error {
 		delete(candidates, snapName)
 	}
 
-	st.Set("refresh-candidates", candidates)
+	setNewRefreshCandidates(st, candidates)
 	return nil
+}
+
+// setNewRefreshCandidates is used to set/replace "refresh-candidates" making
+// sure that any snap that is no longer a candidate has its monitoring stopped.
+// Must always be used when replacing the full "refresh-candidates"
+func setNewRefreshCandidates(st *state.State, hints map[string]*refreshCandidate) {
+	stopMonitoringOutdatedCandidates(st, hints)
+	if len(hints) == 0 {
+		st.Set("refresh-candidates", nil)
+		return
+	}
+	st.Set("refresh-candidates", hints)
+}
+
+// stopMonitoringOutdatedCandidates aborts the monitoring for snaps for which a
+// refresh candidate has been removed (possibly because the channel was reverted
+// to an older version)
+func stopMonitoringOutdatedCandidates(st *state.State, hints map[string]*refreshCandidate) {
+	var oldHints map[string]*refreshCandidate
+	if err := st.Get("refresh-candidates", &oldHints); err != nil {
+		if errors.Is(err, &state.NoStateError{}) {
+			// nothing to abort
+			return
+		}
+
+		logger.Noticef("cannot abort removed refresh candidates: %v", err)
+		return
+	}
+
+	for oldCand := range oldHints {
+		if _, ok := hints[oldCand]; !ok {
+			abortMonitoring(st, oldCand)
+		}
+	}
 }

--- a/overlord/snapstate/refreshhints_test.go
+++ b/overlord/snapstate/refreshhints_test.go
@@ -461,6 +461,57 @@ epoch: 1
 type: app
 `
 
+func (s *refreshHintsTestSuite) TestRefreshHintsAbortsMonitoringForRemovedCandidates(c *C) {
+	s.state.Lock()
+	snapstate.Set(s.state, "other-snap", &snapstate.SnapState{
+		Active: true,
+		Sequence: []*snap.SideInfo{
+			{RealName: "other-snap", Revision: snap.R(1), SnapID: "other-snap-id"},
+		},
+		Current: snap.R(1),
+	})
+	s.state.Unlock()
+
+	s.store.refreshedSnaps = []*snap.Info{{
+		SideInfo: snap.SideInfo{
+			RealName: "some-snap",
+			Revision: snap.R(1),
+		}},
+		{
+			SideInfo: snap.SideInfo{
+				RealName: "other-snap",
+				Revision: snap.R(2),
+			},
+		}}
+
+	s.state.Lock()
+	s.state.Set("refresh-candidates", map[string]*snapstate.RefreshCandidate{
+		"some-snap":      {SnapSetup: snapstate.SnapSetup{SideInfo: &snap.SideInfo{RealName: "some-snap"}}},
+		"monitored-snap": {SnapSetup: snapstate.SnapSetup{SideInfo: &snap.SideInfo{RealName: "second-snap"}}},
+	})
+
+	// mock a monitoring routine for "second-snap" for which the refresh-candidate
+	// will be removed
+	refreshCtx, abort := context.WithCancel(context.TODO())
+	monitored := map[string]context.CancelFunc{
+		"monitored-snap": abort,
+		"something-else": nil,
+	}
+	s.state.Cache("monitored-snaps", monitored)
+	s.state.Unlock()
+
+	rh := snapstate.NewRefreshHints(s.state)
+	err := rh.Ensure()
+	c.Check(err, IsNil)
+	c.Check(s.store.ops, DeepEquals, []string{"list-refresh"})
+
+	select {
+	case <-refreshCtx.Done():
+	case <-time.After(5 * time.Second):
+		c.Fatal("test timed out before mocked monitoring was aborted")
+	}
+}
+
 func (s *refreshHintsTestSuite) TestRefreshHintsNotApplicableWrongEpoch(c *C) {
 	s.state.Lock()
 

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1694,6 +1694,17 @@ func updateManyFiltered(ctx context.Context, st *state.State, names []string, re
 		return nil, nil, err
 	}
 
+	// save the candidates so the auto-refresh can be continued if it's inhibited
+	// by a running snap.
+	if flags.IsAutoRefresh {
+		hints, err := refreshHintsFromCandidates(st, updates, ignoreValidation, deviceCtx)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		st.Set("refresh-candidates", hints)
+	}
+
 	if filter != nil {
 		actual := updates[:0]
 		for _, update := range updates {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1688,7 +1688,7 @@ func updateManyFiltered(ctx context.Context, st *state.State, names []string, re
 
 	names = strutil.Deduplicate(names)
 
-	refreshOpts := &store.RefreshOptions{IsAutoRefresh: flags.IsAutoRefresh}
+	refreshOpts := &store.RefreshOptions{Scheduled: flags.IsAutoRefresh}
 	updates, stateByInstanceName, ignoreValidation, err := refreshCandidates(ctx, st, names, revOpts, user, refreshOpts)
 	if err != nil {
 		return nil, nil, err
@@ -2562,7 +2562,7 @@ func autoRefreshPhase1(ctx context.Context, st *state.State, forGatingSnap strin
 		return nil, nil, err
 	}
 
-	refreshOpts := &store.RefreshOptions{IsAutoRefresh: true}
+	refreshOpts := &store.RefreshOptions{Scheduled: true}
 	// XXX: should we skip refreshCandidates if forGatingSnap isn't empty (meaning we're handling proceed from a snap)?
 	candidates, snapstateByInstance, ignoreValidationByInstanceName, err := refreshCandidates(ctx, st, nil, nil, user, refreshOpts)
 	if err != nil {

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -8995,7 +8995,7 @@ func (s *snapmgrTestSuite) TestSaveRefreshCandidatesOnAutoRefresh(c *C) {
 	err := s.state.Get("refresh-candidates", &cands)
 	c.Assert(err, testutil.ErrorIs, &state.NoStateError{})
 
-	names, tss, err := snapstate.AutoRefresh(context.Background(), s.state, nil)
+	names, tss, err := snapstate.AutoRefresh(context.Background(), s.state)
 	c.Assert(err, IsNil)
 	c.Assert(tss, NotNil)
 	c.Check(names, DeepEquals, []string{"some-other-snap", "some-snap"})
@@ -9007,4 +9007,37 @@ func (s *snapmgrTestSuite) TestSaveRefreshCandidatesOnAutoRefresh(c *C) {
 	c.Assert(cands, HasLen, 2)
 	c.Check(cands["some-snap"], NotNil)
 	c.Check(cands["some-other-snap"], NotNil)
+}
+
+func (s *snapmgrTestSuite) TestRefreshCandidatesMergeFlags(c *C) {
+	si := &snap.SideInfo{
+		RealName: "some-snap",
+	}
+	cand := &snapstate.RefreshCandidate{
+		SnapSetup: snapstate.SnapSetup{
+			SideInfo: si,
+			Flags: snapstate.Flags{
+				Classic:     true,
+				NoReRefresh: true,
+			},
+		},
+	}
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{Sequence: []*snap.SideInfo{si}})
+
+	globalFlags := &snapstate.Flags{IsAutoRefresh: true, IsContinuedAutoRefresh: true}
+	snapsup, _, err := cand.SnapSetupForUpdate(s.state, nil, 0, globalFlags)
+	c.Assert(err, IsNil)
+	c.Assert(snapsup, NotNil)
+	c.Assert(*snapsup, DeepEquals, snapstate.SnapSetup{
+		SideInfo: si,
+		Flags: snapstate.Flags{
+			Classic:                true,
+			NoReRefresh:            true,
+			IsAutoRefresh:          true,
+			IsContinuedAutoRefresh: true,
+		},
+	})
 }

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -8968,3 +8968,43 @@ WantedBy=multi-user.target
 
 	c.Assert(mountFile, testutil.FileEquals, expectedContent)
 }
+
+func (s *snapmgrTestSuite) TestSaveRefreshCandidatesOnAutoRefresh(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active: true,
+		Sequence: []*snap.SideInfo{
+			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
+		},
+		Current:  snap.R(1),
+		SnapType: "app",
+	})
+	snapstate.Set(s.state, "some-other-snap", &snapstate.SnapState{
+		Active: true,
+		Sequence: []*snap.SideInfo{
+			{RealName: "some-other-snap", SnapID: "some-other-snap-id", Revision: snap.R(1)},
+		},
+		Current:  snap.R(1),
+		SnapType: "app",
+	})
+
+	// precondition check
+	var cands map[string]*snapstate.RefreshCandidate
+	err := s.state.Get("refresh-candidates", &cands)
+	c.Assert(err, testutil.ErrorIs, &state.NoStateError{})
+
+	names, tss, err := snapstate.AutoRefresh(context.Background(), s.state, nil)
+	c.Assert(err, IsNil)
+	c.Assert(tss, NotNil)
+	c.Check(names, DeepEquals, []string{"some-other-snap", "some-snap"})
+
+	// check that refresh-candidates in the state were updated
+	err = s.state.Get("refresh-candidates", &cands)
+	c.Assert(err, IsNil)
+
+	c.Assert(cands, HasLen, 2)
+	c.Check(cands["some-snap"], NotNil)
+	c.Check(cands["some-other-snap"], NotNil)
+}

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -9321,7 +9321,7 @@ func (s *snapmgrTestSuite) TestDownloadTaskWaitsForPreDownload(c *C) {
 	c.Check(monitored, Equals, false)
 }
 
-func (s *snapmgrTestSuite) TestPreDownloadTaskTriggersAutoRefreshIfSoftCheckOk(c *C) {
+func (s *snapmgrTestSuite) TestPreDownloadTaskContinuesAutoRefreshIfSoftCheckOk(c *C) {
 	var softChecked bool
 	restore := snapstate.MockRefreshAppsCheck(func(info *snap.Info) error {
 		c.Assert(info.InstanceName(), Equals, "foo")
@@ -9345,25 +9345,32 @@ func (s *snapmgrTestSuite) TestPreDownloadTaskTriggersAutoRefreshIfSoftCheckOk(c
 
 	s.state.Lock()
 	defer s.state.Unlock()
+
 	si := &snap.SideInfo{
 		RealName: "foo",
 		SnapID:   "foo-id",
 		Revision: snap.R(1),
 	}
-
 	snaptest.MockSnap(c, `name: foo`, si)
 	snapstate.Set(s.state, "foo", &snapstate.SnapState{
 		Active:   true,
 		Sequence: []*snap.SideInfo{si},
 		Current:  si.Revision,
 	})
+
 	snapsup := &snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: "foo",
 			Revision: snap.R(2),
 		},
 		Flags: snapstate.Flags{IsAutoRefresh: true},
+		// if there's no downloadInfo, the download goes into a fallback behaviour of requesting it from the store and
+		// makes it harder to check that we don't request refresh info form the store
+		DownloadInfo: &snap.DownloadInfo{DownloadURL: "my-url"},
 	}
+	s.state.Set("refresh-candidates", map[string]*snapstate.RefreshCandidate{
+		"foo": {SnapSetup: *snapsup},
+	})
 
 	preDlChg := s.state.NewChange("pre-download", "pre-download change")
 	preDlTask := s.state.NewTask("pre-download-snap", "pre-download task")
@@ -9375,13 +9382,28 @@ func (s *snapmgrTestSuite) TestPreDownloadTaskTriggersAutoRefreshIfSoftCheckOk(c
 	s.settle(c)
 
 	c.Assert(preDlTask.Status(), Equals, state.DoneStatus)
-	c.Assert(s.fakeStore.downloads, HasLen, 1)
-	c.Check(s.fakeStore.downloads[0].name, Equals, "foo")
 
 	c.Check(softChecked, Equals, true)
 	c.Check(notified, Equals, false)
 	c.Check(monitored, Equals, false)
-	c.Check(s.state.Cached("auto-refresh-continue-attempt"), Equals, 1)
+
+	autoRefreshChg := findChange(s.state, "auto-refresh")
+	c.Assert(autoRefreshChg, NotNil)
+	c.Assert(autoRefreshChg.Status(), Equals, state.DoneStatus)
+
+	// check that the auto-refresh was completed without asking the store for refresh info
+	c.Assert(s.fakeBackend.ops.Count("storesvc-snap-action"), Equals, 0)
+	c.Assert(s.fakeStore.downloads, HasLen, 2)
+}
+
+func findChange(st *state.State, kind string) *state.Change {
+	for _, chg := range st.Changes() {
+		if chg.Kind() == kind {
+			return chg
+		}
+	}
+
+	return nil
 }
 
 func (s *snapmgrTestSuite) TestDownloadTaskMonitorsSnapStoppedAndNotifiesOnSoftCheckFail(c *C) {
@@ -9403,13 +9425,23 @@ func (s *snapmgrTestSuite) TestDownloadTaskMonitorsSnapStoppedAndNotifiesOnSoftC
 			Revision: snap.R(2),
 		},
 		Flags: snapstate.Flags{IsAutoRefresh: true},
+		// if there's no downloadInfo, the download goes into a fallback behaviour of requesting it from the store and
+		// makes it harder to check that we don't request refresh info form the store
+		DownloadInfo: &snap.DownloadInfo{DownloadURL: "my-url"},
 	}
+	s.state.Set("refresh-candidates", map[string]*snapstate.RefreshCandidate{
+		"foo": {SnapSetup: *snapsup},
+	})
 
 	var softChecked bool
+	inhibited := true
 	restore := snapstate.MockRefreshAppsCheck(func(info *snap.Info) error {
 		c.Assert(info.InstanceName(), Equals, "foo")
 		softChecked = true
-		return snapstate.NewBusySnapError(info, []int{123}, nil, nil)
+		if inhibited {
+			return snapstate.NewBusySnapError(info, []int{123}, nil, nil)
+		}
+		return nil
 	})
 	defer restore()
 
@@ -9445,22 +9477,39 @@ func (s *snapmgrTestSuite) TestDownloadTaskMonitorsSnapStoppedAndNotifiesOnSoftC
 	c.Check(notified, Equals, true)
 	c.Assert(monitorSignal, NotNil)
 
+	var hints map[string]*snapstate.RefreshCandidate
+	err := s.state.Get("refresh-candidates", &hints)
+	c.Assert(err, IsNil)
+	c.Assert(hints, HasLen, 1)
+	c.Assert(hints["foo"].Monitored, Equals, true)
+
 	monitored := s.state.Cached("monitored-snaps")
-	c.Assert(monitored, FitsTypeOf, map[string]chan<- bool{})
-	c.Assert(monitored.(map[string]chan<- bool)["foo"], NotNil)
-	c.Assert(s.state.Cached("auto-refresh-continue-attempt"), Equals, nil)
+	c.Assert(monitored, FitsTypeOf, map[string]context.CancelFunc{})
+	c.Assert(monitored.(map[string]context.CancelFunc)["foo"], NotNil)
 
 	// signal snap has stopped and wait for pending goroutine to finish
 	s.state.Unlock()
+	inhibited = false
 	monitorSignal <- "foo"
 
 	waitForMonitoringEnd(s.state, c)
 
 	s.state.Lock()
 	defer s.state.Unlock()
-	c.Assert(s.state.Cached("monitored-snaps"), IsNil)
-	c.Check(s.state.Cached("auto-refresh-continue-attempt"), Equals, 1)
+	s.settle(c)
 
+	autoRefreshChg := findChange(s.state, "auto-refresh")
+	c.Assert(autoRefreshChg, NotNil)
+	c.Assert(autoRefreshChg.Status(), Equals, state.DoneStatus)
+	c.Assert(s.state.Cached("monitored-snaps"), IsNil)
+
+	// the refresh-candidates are removed at the end of the change (see pruneRefreshCandidates)
+	err = s.state.Get("refresh-candidates", &hints)
+	c.Assert(err, testutil.ErrorIs, &state.NoStateError{})
+
+	// check that the auto-refresh was completed without asking the store for refresh info
+	c.Assert(s.fakeBackend.ops.Count("storesvc-snap-action"), Equals, 0)
+	c.Assert(s.fakeStore.downloads, HasLen, 2)
 }
 
 func (s *snapmgrTestSuite) TestDownloadTaskMonitorsRepeated(c *C) {
@@ -9484,12 +9533,19 @@ func (s *snapmgrTestSuite) TestDownloadTaskMonitorsRepeated(c *C) {
 		},
 		Flags: snapstate.Flags{IsAutoRefresh: true},
 	}
+	s.state.Set("refresh-candidates", map[string]*snapstate.RefreshCandidate{
+		"foo": {SnapSetup: *snapsup},
+	})
 
 	var softChecked bool
+	inhibited := true
 	restore := snapstate.MockRefreshAppsCheck(func(info *snap.Info) error {
 		c.Assert(info.InstanceName(), Equals, "foo")
 		softChecked = true
-		return snapstate.NewBusySnapError(info, []int{123}, nil, nil)
+		if inhibited {
+			return snapstate.NewBusySnapError(info, []int{123}, nil, nil)
+		}
+		return nil
 	})
 	defer restore()
 
@@ -9519,12 +9575,13 @@ func (s *snapmgrTestSuite) TestDownloadTaskMonitorsRepeated(c *C) {
 	c.Assert(preDlTask.Status(), Equals, state.DoneStatus)
 	// monitoring snap
 	monitored := s.state.Cached("monitored-snaps")
-	c.Assert(monitored, FitsTypeOf, map[string]chan<- bool{})
-	c.Assert(monitored.(map[string]chan<- bool)["foo"], NotNil)
+	c.Assert(monitored, FitsTypeOf, map[string]context.CancelFunc{})
+	c.Assert(monitored.(map[string]context.CancelFunc)["foo"], NotNil)
 	c.Assert(notified, Equals, true)
+
 	// waiting for the monitoring to end
 	c.Check(s.state.Cached("monitored-snaps"), NotNil)
-	c.Check(s.state.Cached("auto-refresh-continue-attempt"), Equals, nil)
+	c.Assert(findChange(s.state, "auto-refresh"), IsNil)
 
 	// start a new pre-download which shouldn't start monitoring
 	preDlChg = s.state.NewChange("pre-download", "pre-download change")
@@ -9546,10 +9603,14 @@ func (s *snapmgrTestSuite) TestDownloadTaskMonitorsRepeated(c *C) {
 	// didn't wait for snap to stop because there's already a goroutine doing it
 	c.Check(monitorSignal, IsNil)
 
-	// unblock goroutine to finish
+	// make sure nothing is left running
 	s.state.Unlock()
-	defer s.state.Lock()
+	inhibited = false
 	firstMonitorSignal <- "foo"
+	waitForMonitoringEnd(s.state, c)
+	s.state.Lock()
+
+	s.settle(c)
 }
 
 func (s *snapmgrTestSuite) TestUnlinkMonitorSnapOnHardCheckFailure(c *C) {
@@ -9600,13 +9661,12 @@ func (s *snapmgrTestSuite) TestUnlinkMonitorSnapOnHardCheckFailure(c *C) {
 		case 2:
 			return snapstate.NewBusySnapError(info, []int{123}, nil, nil)
 		default:
-			c.Errorf("only expected 2 checks, now on %d", check)
-			return errors.New("unexpected refresh check")
+			return nil
 		}
 	})
 	defer restore()
 
-	updated, tss, err := snapstate.AutoRefresh(context.Background(), s.state, nil)
+	updated, tss, err := snapstate.AutoRefresh(context.Background(), s.state)
 	c.Assert(err, IsNil)
 	c.Check(updated, DeepEquals, []string{"some-snap"})
 	c.Assert(tss, NotNil)
@@ -9626,9 +9686,16 @@ func (s *snapmgrTestSuite) TestUnlinkMonitorSnapOnHardCheckFailure(c *C) {
 	c.Check(monitorSignal, NotNil)
 
 	monitored := s.state.Cached("monitored-snaps")
-	c.Assert(monitored, FitsTypeOf, map[string]chan<- bool{})
-	c.Assert(monitored.(map[string]chan<- bool)["some-snap"], NotNil)
-	close(monitorSignal)
+	c.Assert(monitored, FitsTypeOf, map[string]context.CancelFunc{})
+	c.Assert(monitored.(map[string]context.CancelFunc)["some-snap"], NotNil)
+
+	// cleanup leftover routines
+	s.state.Unlock()
+	monitorSignal <- "some-snap"
+	waitForMonitoringEnd(s.state, c)
+
+	s.state.Lock()
+	s.settle(c)
 }
 
 func (s *snapmgrTestSuite) TestDeletedMonitoredMapIsCorrectlyDeleted(c *C) {
@@ -9651,10 +9718,16 @@ func (s *snapmgrTestSuite) TestDeletedMonitoredMapIsCorrectlyDeleted(c *C) {
 		},
 		Flags: snapstate.Flags{IsAutoRefresh: true},
 	}
+	s.state.Set("refresh-candidates", map[string]*snapstate.RefreshCandidate{
+		"foo": {SnapSetup: *snapsup},
+	})
 
+	inhibited := true
 	restore := snapstate.MockRefreshAppsCheck(func(info *snap.Info) error {
-		return snapstate.NewBusySnapError(info, []int{123}, nil, nil)
-
+		if inhibited {
+			return snapstate.NewBusySnapError(info, []int{123}, nil, nil)
+		}
+		return nil
 	})
 	defer restore()
 
@@ -9678,6 +9751,9 @@ func (s *snapmgrTestSuite) TestDeletedMonitoredMapIsCorrectlyDeleted(c *C) {
 
 	// unblock the monitoring routine which will delete the "monitored-snaps" map
 	s.state.Unlock()
+
+	// let the continuing logic create an auto-refresh change
+	inhibited = false
 	monitorSignal <- "foo"
 	waitForMonitoringEnd(s.state, c)
 
@@ -9691,34 +9767,43 @@ func (s *snapmgrTestSuite) TestDeletedMonitoredMapIsCorrectlyDeleted(c *C) {
 	preDlTask.Set("refresh-info", &userclient.PendingSnapRefreshInfo{InstanceName: "foo"})
 	preDlChg.AddTask(preDlTask)
 
+	// so we go into the monitoring
+	inhibited = true
+
 	s.settle(c)
 	c.Assert(preDlChg.Status(), Equals, state.DoneStatus)
 
+	// wait until the 2nd auto-refresh starts
 	s.state.Unlock()
+	inhibited = false
 	monitorSignal <- "foo"
-	waitForMonitoringEnd(s.state, c)
-
+	waitFor(s.state, c, func() bool { return s.state.Change("4") != nil })
 	s.state.Lock()
-	defer s.state.Unlock()
+	c.Assert(s.state.Change("4").Kind(), Equals, "auto-refresh")
+	s.settle(c)
+
 	c.Assert(s.state.Cached("monitored-snaps"), IsNil)
-	c.Check(s.state.Cached("auto-refresh-continue-attempt"), Equals, 1)
+}
+
+func waitFor(st *state.State, c *C, cond func() bool) {
+	for i := 0; i < 5; i++ {
+		st.Lock()
+		condMet := cond()
+		st.Unlock()
+		if condMet {
+			return
+		}
+
+		<-time.After(time.Second)
+	}
+
+	c.Fatal("condition wasn't met within 5 seconds")
 }
 
 func waitForMonitoringEnd(st *state.State, c *C) {
-	for i := 0; i < 5; i++ {
-		<-time.After(time.Second)
-		st.Lock()
-		finished := st.Cached("auto-refresh-continue-attempt")
-		if finished == nil {
-			st.Unlock()
-			continue
-		}
-
-		st.Unlock()
-		return
-	}
-
-	c.Fatal("couldn't check monitoring goroutine finished properly")
+	waitFor(st, c, func() bool {
+		return findChange(st, "auto-refresh") != nil
+	})
 }
 
 func (s *snapmgrTestSuite) TestPreDownloadWithIgnoreRunningRefresh(c *C) {
@@ -9742,6 +9827,9 @@ func (s *snapmgrTestSuite) TestPreDownloadWithIgnoreRunningRefresh(c *C) {
 		},
 		Flags: snapstate.Flags{IsAutoRefresh: true},
 	}
+	s.state.Set("refresh-candidates", map[string]*snapstate.RefreshCandidate{
+		"some-snap": {SnapSetup: *snapsup},
+	})
 
 	restore := snapstate.MockAsyncPendingRefreshNotification(func(ctx context.Context, client *userclient.Client, refreshInfo *userclient.PendingSnapRefreshInfo) {})
 	defer restore()
@@ -9772,8 +9860,8 @@ func (s *snapmgrTestSuite) TestPreDownloadWithIgnoreRunningRefresh(c *C) {
 	c.Assert(preDlTask.Status(), Equals, state.DoneStatus)
 	// check there's still a goroutine monitoring the snap
 	monitored := s.state.Cached("monitored-snaps")
-	c.Assert(monitored, FitsTypeOf, map[string]chan<- bool{})
-	c.Assert(monitored.(map[string]chan<- bool)["some-snap"], NotNil)
+	c.Assert(monitored, FitsTypeOf, map[string]context.CancelFunc{})
+	c.Assert(monitored.(map[string]context.CancelFunc)["some-snap"], NotNil)
 
 	updated, tss, err := snapstate.UpdateMany(context.Background(), s.state, []string{"some-snap"}, nil, 0, &snapstate.Flags{IgnoreRunning: true})
 	c.Assert(err, IsNil)
@@ -9828,7 +9916,7 @@ func (s *snapmgrTestSuite) TestRefreshNoRelatedMonitoring(c *C) {
 		Sequence: []*snap.SideInfo{si},
 		Current:  si.Revision,
 	})
-	s.state.Cache("monitored-snaps", map[string]chan<- bool{"other-snap": make(chan bool, 1)})
+	s.state.Cache("monitored-snaps", map[string]context.CancelFunc{"other-snap": func() {}})
 
 	_, tss, err := snapstate.UpdateMany(context.Background(), s.state, []string{"some-snap"}, nil, 0, &snapstate.Flags{IgnoreRunning: true})
 	c.Assert(err, IsNil)
@@ -9863,13 +9951,17 @@ func (s *snapmgrTestSuite) TestMonitoringIsPersistedAndRestored(c *C) {
 		},
 		Flags: snapstate.Flags{IsAutoRefresh: true},
 	}
+	// simulate a restart with an in-progress monitoring
+	s.state.Set("refresh-candidates", map[string]*snapstate.RefreshCandidate{
+		"some-snap": {SnapSetup: *snapsup, Monitored: true},
+	})
 
+	var notified bool
 	restore := snapstate.MockAsyncPendingRefreshNotification(func(ctx context.Context, client *userclient.Client, refreshInfo *userclient.PendingSnapRefreshInfo) {})
 	defer restore()
 
 	restore = snapstate.MockRefreshAppsCheck(func(info *snap.Info) error {
-		c.Assert(info.InstanceName(), Equals, "some-snap")
-		return snapstate.NewBusySnapError(info, []int{123}, nil, nil)
+		return nil
 	})
 	defer restore()
 
@@ -9881,6 +9973,92 @@ func (s *snapmgrTestSuite) TestMonitoringIsPersistedAndRestored(c *C) {
 	})
 	defer restore()
 
+	s.state.Unlock()
+	defer s.state.Lock()
+	af := snapstate.NewAutoRefresh(s.state)
+	err := af.Ensure()
+	c.Check(err, IsNil)
+
+	// restores monitoring but doesn't notify again
+	c.Assert(stopMonitor, NotNil)
+	c.Assert(notified, Equals, false)
+
+	s.state.Lock()
+	aborts := s.state.Cached("monitored-snaps").(map[string]context.CancelFunc)
+	abort := aborts["some-snap"]
+	s.state.Unlock()
+	c.Assert(abort, NotNil)
+
+	stopMonitor <- "some-snap"
+	waitForMonitoringEnd(s.state, c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	s.settle(c)
+
+	// the refresh-candidates are removed at the end of the change (see pruneRefreshCandidates)
+	var hints map[string]*snapstate.RefreshCandidate
+	err = s.state.Get("refresh-candidates", &hints)
+	c.Assert(err, testutil.ErrorIs, &state.NoStateError{})
+}
+
+func (s *snapmgrTestSuite) TestNoMonitoringIfOnlyOtherRefreshCandidates(c *C) {
+	s.testNoMonitoringWithCands(c, map[string]*snapstate.RefreshCandidate{
+		"other-snap": {},
+	})
+}
+
+func (s *snapmgrTestSuite) TestNoMonitoringIfNoRefreshCandidates(c *C) {
+	s.testNoMonitoringWithCands(c, nil)
+}
+
+func (s *snapmgrTestSuite) testNoMonitoringWithCands(c *C, cands map[string]*snapstate.RefreshCandidate) {
+	s.state.Lock()
+	defer s.state.Unlock()
+	si := &snap.SideInfo{
+		RealName: "some-snap",
+		SnapID:   "some-snap-id",
+		Revision: snap.R(1),
+	}
+	snaptest.MockSnap(c, `name: some-snap`, si)
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active:   true,
+		Sequence: []*snap.SideInfo{si},
+		Current:  si.Revision,
+	})
+	snapsup := &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{
+			RealName: "some-snap",
+			Revision: snap.R(2),
+		},
+		Flags: snapstate.Flags{IsAutoRefresh: true},
+	}
+
+	// cands shouldn't include a refresh candidate for this snap so we can simulate
+	// that the candidate was reverted before the pre-download task runs
+	s.state.Set("refresh-candidates", cands)
+
+	var notified bool
+	restore := snapstate.MockAsyncPendingRefreshNotification(func(ctx context.Context, client *userclient.Client, refreshInfo *userclient.PendingSnapRefreshInfo) {
+		notified = true
+	})
+	defer restore()
+
+	var inhibited bool
+	restore = snapstate.MockRefreshAppsCheck(func(info *snap.Info) error {
+		inhibited = true
+		return snapstate.NewBusySnapError(info, []int{123}, nil, nil)
+	})
+	defer restore()
+
+	restore = snapstate.MockCgroupMonitorSnapEnded(func(name string, done chan<- string) error {
+		return nil
+	})
+	defer restore()
+
+	buf, restore := logger.MockLogger()
+	defer restore()
+
 	preDlChg := s.state.NewChange("pre-download", "pre-download change")
 	preDlTask := s.state.NewTask("pre-download-snap", "pre-download task")
 
@@ -9890,34 +10068,12 @@ func (s *snapmgrTestSuite) TestMonitoringIsPersistedAndRestored(c *C) {
 
 	s.settle(c)
 
+	// task finished without waiting for monitoring
 	c.Assert(preDlTask.Status(), Equals, state.DoneStatus)
-	// check there's still a goroutine monitoring the snap
-	monitoring := s.state.Cached("monitored-snaps")
-	c.Assert(monitoring, FitsTypeOf, map[string]chan<- bool{})
-	c.Assert(monitoring.(map[string]chan<- bool)["some-snap"], NotNil)
+	c.Assert(s.state.Cached("monitored-snap"), IsNil)
+	c.Assert(buf.String(), testutil.Contains, `cannot get refresh candidate for "some-snap" (possibly reverted): nothing to refresh`)
 
-	var monitored []string
-	c.Assert(s.state.Get("monitored-snaps", &monitored), IsNil)
-	c.Assert(monitored, DeepEquals, []string{"some-snap"})
-
-	// simulate a restart by stopping the monitoring but removing its effects
-	stopMonitor <- "some-snap"
-	s.state.Unlock()
-	waitForMonitoringEnd(s.state, c)
-
-	s.state.Lock()
-	s.state.Cache("monitored-snaps", nil)
-	s.state.Cache("auto-refresh-continue-attempt", nil)
-	s.state.Set("monitored-snaps", monitored)
-	snapstate.SetRestoredMonitoring(s.snapmgr, false)
-	s.state.Unlock()
-
-	// the first Ensure sets up the monitoring again
-	c.Assert(s.snapmgr.Ensure(), IsNil)
-	stopMonitor <- "some-snap"
-	waitForMonitoringEnd(s.state, c)
-	s.state.Lock()
-
-	c.Assert(s.state.Cached("monitored-snaps"), IsNil)
-	c.Check(s.state.Cached("auto-refresh-continue-attempt"), Equals, 1)
+	// we didn't notify since there's no candidate to refresh to
+	c.Assert(notified, Equals, false)
+	c.Assert(inhibited, Equals, true)
 }

--- a/store/download_test.go
+++ b/store/download_test.go
@@ -103,7 +103,7 @@ func (s *downloadSuite) TestActualDownloadAutoRefresh(c *C) {
 	var buf SillyBuffer
 	// keep tests happy
 	sha3 := ""
-	err := store.Download(context.TODO(), "foo", sha3, mockServer.URL, nil, theStore, &buf, 0, nil, &store.DownloadOptions{IsAutoRefresh: true})
+	err := store.Download(context.TODO(), "foo", sha3, mockServer.URL, nil, theStore, &buf, 0, nil, &store.DownloadOptions{Scheduled: true})
 	c.Assert(err, IsNil)
 	c.Check(buf.String(), Equals, "response-data")
 	c.Check(n, Equals, 1)

--- a/store/store_action.go
+++ b/store/store_action.go
@@ -40,7 +40,7 @@ type RefreshOptions struct {
 	// RefreshManaged indicates to the store that the refresh is
 	// managed via snapd-control.
 	RefreshManaged bool
-	IsAutoRefresh  bool
+	Scheduled      bool
 
 	PrivacyKey string
 }
@@ -536,7 +536,7 @@ func (s *Store) snapAction(ctx context.Context, currentSnaps []*CurrentSnap, act
 		APILevel:    apiV2Endps,
 	}
 
-	if opts.IsAutoRefresh {
+	if opts.Scheduled {
 		logger.Debugf("Auto-refresh; adding header Snap-Refresh-Reason: scheduled")
 		reqOptions.addHeader("Snap-Refresh-Reason", "scheduled")
 	}

--- a/store/store_action_test.go
+++ b/store/store_action_test.go
@@ -817,7 +817,7 @@ func (s *storeActionSuite) TestSnapActionAutoRefresh(c *C) {
 			SnapID:       helloWorldSnapID,
 			InstanceName: "hello-world",
 		},
-	}, nil, nil, &store.RefreshOptions{IsAutoRefresh: true})
+	}, nil, nil, &store.RefreshOptions{Scheduled: true})
 	c.Assert(err, IsNil)
 	c.Assert(results, HasLen, 1)
 }

--- a/store/store_download.go
+++ b/store/store_download.go
@@ -183,7 +183,7 @@ func (e HashError) Error() string {
 
 type DownloadOptions struct {
 	RateLimit           int64
-	IsAutoRefresh       bool
+	Scheduled           bool
 	LeavePartialOnError bool
 }
 
@@ -305,7 +305,7 @@ func downloadReqOpts(storeURL *url.URL, cdnHeader string, opts *DownloadOptions)
 	if cdnHeader != "" {
 		reqOptions.ExtraHeaders["Snap-CDN"] = cdnHeader
 	}
-	if opts != nil && opts.IsAutoRefresh {
+	if opts != nil && opts.Scheduled {
 		reqOptions.ExtraHeaders["Snap-Refresh-Reason"] = "scheduled"
 	}
 

--- a/store/store_download_test.go
+++ b/store/store_download_test.go
@@ -587,7 +587,7 @@ func (s *storeDownloadSuite) TestDownloadDelta(c *C) {
 	for _, testCase := range downloadDeltaTests {
 		sto.SetDeltaFormat(testCase.format)
 		restore := store.MockDownload(func(ctx context.Context, name, sha3, url string, user *auth.UserState, _ *store.Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter, dlOpts *store.DownloadOptions) error {
-			c.Check(dlOpts, DeepEquals, &store.DownloadOptions{IsAutoRefresh: true})
+			c.Check(dlOpts, DeepEquals, &store.DownloadOptions{Scheduled: true})
 			expectedUser := s.user
 			if !testCase.withUser {
 				expectedUser = nil
@@ -608,7 +608,7 @@ func (s *storeDownloadSuite) TestDownloadDelta(c *C) {
 			authedUser = nil
 		}
 
-		err = sto.DownloadDelta("snapname", &testCase.info, w, nil, authedUser, &store.DownloadOptions{IsAutoRefresh: true})
+		err = sto.DownloadDelta("snapname", &testCase.info, w, nil, authedUser, &store.DownloadOptions{Scheduled: true})
 
 		if testCase.expectError {
 			c.Assert(err, NotNil)


### PR DESCRIPTION
Backport of https://github.com/snapcore/snapd/pull/12970