### PR TITLE
store: remove auth headers from being sent in CDN redirects

### DIFF
--- a/httputil/client_test.go
+++ b/httputil/client_test.go
@@ -100,6 +100,12 @@ func (s *clientSuite) TestClientProxyTakesUserAgent(c *check.C) {
 	c.Assert(called, check.Equals, true)
 }
 
+func (s *clientSuite) TestClientCheckRedirect(c *check.C) {
+	cli := httputil.NewHTTPClient(&httputil.ClientOptions{})
+	c.Assert(cli, check.NotNil)
+	c.Assert(cli.CheckRedirect, check.NotNil)
+}
+
 var privKey, _ = rsa.GenerateKey(rand.Reader, 768)
 
 // see crypto/tls/generate_cert.go

--- a/store/auth.go
+++ b/store/auth.go
@@ -104,6 +104,13 @@ func (a *deviceAuthorizer) Authorize(r *http.Request, dauthCtx DeviceAndAuthCont
 	return firstError
 }
 
+func dropAuthorization(r *http.Request, opts *AuthorizeOptions) {
+	if opts.deviceAuth {
+		r.Header.Del(hdrSnapDeviceAuthorization[opts.apiLevel])
+	}
+	r.Header.Del("Authorization")
+}
+
 func (a *deviceAuthorizer) EnsureDeviceSession(dauthCtx DeviceAndAuthContext, client *http.Client) error {
 	if dauthCtx == nil {
 		return fmt.Errorf("internal error: no authContext")

--- a/store/export_test.go
+++ b/store/export_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/juju/ratelimit"
 	"gopkg.in/retry.v1"
 
+	"github.com/snapcore/snapd/httputil"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/snap"
@@ -167,6 +168,14 @@ func (sto *Store) MockCacher(obs downloadCache) (restore func()) {
 	sto.cacher = obs
 	return func() {
 		sto.cacher = oldCacher
+	}
+}
+
+func MockHttputilNewHTTPClient(f func(opts *httputil.ClientOptions) *http.Client) (restore func()) {
+	old := httputilNewHTTPClient
+	httputilNewHTTPClient = f
+	return func() {
+		httputilNewHTTPClient = old
 	}
 }
 

--- a/store/store.go
+++ b/store/store.go
@@ -464,6 +464,8 @@ const (
 	assertionsPath = "v2/assertions"
 )
 
+var httputilNewHTTPClient = httputil.NewHTTPClient
+
 func (s *Store) newHTTPClient(opts *httputil.ClientOptions) *http.Client {
 	if opts == nil {
 		opts = &httputil.ClientOptions{}
@@ -473,7 +475,7 @@ func (s *Store) newHTTPClient(opts *httputil.ClientOptions) *http.Client {
 	opts.ExtraSSLCerts = &httputil.ExtraSSLCertsFromDir{
 		Dir: dirs.SnapdStoreSSLCertsDir,
 	}
-	return httputil.NewHTTPClient(opts)
+	return httputilNewHTTPClient(opts)
 }
 
 func (s *Store) defaultSnapQuery() url.Values {

--- a/store/store_download.go
+++ b/store/store_download.go
@@ -474,7 +474,7 @@ func downloadImpl(ctx context.Context, name, sha3_384, downloadURL string, user 
 		cli := s.newHTTPClient(nil)
 		oldCheckRedirect := cli.CheckRedirect
 		if oldCheckRedirect == nil {
-			panic("internal error: CheckRedirect cannot be nil")
+			panic("internal error: the httputil.NewHTTPClient-produced http.Client must have CheckRedirect defined")
 		}
 		cli.CheckRedirect = func(req *http.Request, via []*http.Request) error {
 			// remove user/device auth headers from being sent in "CDN" redirects

--- a/store/store_download_test.go
+++ b/store/store_download_test.go
@@ -994,6 +994,21 @@ func (s *storeDownloadSuite) TestDownloadRedirectHideAuthHeaders(c *C) {
 	c.Assert(targetFn, testutil.FileEquals, "test-download")
 }
 
+func (s *storeDownloadSuite) TestDownloadNoCheckRedirectPanic(c *C) {
+	restore := store.MockHttputilNewHTTPClient(func(opts *httputil.ClientOptions) *http.Client {
+		client := httputil.NewHTTPClient(opts)
+		client.CheckRedirect = nil
+		return client
+	})
+	defer restore()
+
+	targetFn := filepath.Join(c.MkDir(), "foo_1.0_all.snap")
+	downloadFunc := func() {
+		s.store.Download(s.ctx, "foo", targetFn, &snap.DownloadInfo{}, nil, nil, nil)
+	}
+	c.Assert(downloadFunc, PanicMatches, "internal error: CheckRedirect cannot be nil")
+}
+
 func (s *storeDownloadSuite) TestDownloadInfiniteRedirect(c *C) {
 	n := 0
 	var mockServer *httptest.Server

--- a/store/store_download_test.go
+++ b/store/store_download_test.go
@@ -1006,7 +1006,7 @@ func (s *storeDownloadSuite) TestDownloadNoCheckRedirectPanic(c *C) {
 	downloadFunc := func() {
 		s.store.Download(s.ctx, "foo", targetFn, &snap.DownloadInfo{}, nil, nil, nil)
 	}
-	c.Assert(downloadFunc, PanicMatches, "internal error: CheckRedirect cannot be nil")
+	c.Assert(downloadFunc, PanicMatches, "internal error: the httputil.NewHTTPClient-produced http.Client must have CheckRedirect defined")
 }
 
 func (s *storeDownloadSuite) TestDownloadInfiniteRedirect(c *C) {


### PR DESCRIPTION
LP bug: https://bugs.launchpad.net/snapd/+bug/2027993

I removed `Authorization` and `X-Device-Authorization` headers only, should we remove any other identifying headers?