### PR TITLE
tests/main/microk8s-smoke: set no memory limit

### DIFF
--- a/tests/main/microk8s-smoke/task.yaml
+++ b/tests/main/microk8s-smoke/task.yaml
@@ -17,6 +17,8 @@ systems:
 
 environment:
     CHANNEL/edge: 1.25-strict/edge
+    # apparmor profile of microk8s can make snapd exceed its spread memory limit
+    SNAPD_NO_MEMORY_LIMIT: 1
 
 prepare: |
     # ensure curl is available (needed for Ubuntu Core)


### PR DESCRIPTION
Observed in spread tests failing due to microk8s security profile causing snapd to run out of memory and getting killed.
Example run: https://github.com/snapcore/snapd/actions/runs/5737693862/job/15553535179?pr=12922

