### PR TITLE
aspects: add map and string schema parsing and validation

### DIFF
--- a/aspects/aspects.go
+++ b/aspects/aspects.go
@@ -102,6 +102,7 @@ type DataBag interface {
 // be committed.
 type Schema interface {
 	Validate(data []byte) error
+	Parse(raw json.RawMessage) error
 }
 
 // Bundle holds a series of related aspects.
@@ -694,4 +695,9 @@ func (s JSONSchema) Validate(jsonData []byte) error {
 	// the top-level is always an object
 	var data map[string]json.RawMessage
 	return json.Unmarshal(jsonData, &data)
+}
+
+func (s JSONSchema) Parse(json.RawMessage) error {
+	// TODO: JSONSchema will be removed; this is just to re-use the Schema interface
+	return fmt.Errorf(`not implemented`)
 }

--- a/aspects/aspects.go
+++ b/aspects/aspects.go
@@ -102,6 +102,8 @@ type DataBag interface {
 // be committed.
 type Schema interface {
 	Validate(data []byte) error
+	// Parse parses type constraints for a type, defined as a JSON object. It shouldn't
+	// be used if the type schema isn't defined as a JSON object (e.g., a string or list).
 	Parse(raw json.RawMessage) error
 }
 

--- a/aspects/schema.go
+++ b/aspects/schema.go
@@ -259,6 +259,8 @@ func (v *mapSchema) Validate(raw []byte) error {
 				if err := validator.Validate(val); err != nil {
 					return err
 				}
+			} else {
+				return fmt.Errorf(`unexpected field %q in map`, key)
 			}
 		}
 	}

--- a/aspects/schema.go
+++ b/aspects/schema.go
@@ -318,19 +318,19 @@ func (v *mapSchema) Parse(raw json.RawMessage) error {
 	}
 
 	// alternatively, it can constrain the type of its keys and/or values
-	keyDescription, ok := schemaDef["keys"]
+	rawKeyDef, ok := schemaDef["keys"]
 	if ok {
-		if keyType, err := v.parseMapKeyType(keyDescription); err != nil {
+		if keyType, err := v.parseMapKeyType(rawKeyDef); err != nil {
 			return err
 		} else {
 			v.keyType = keyType
 		}
 	}
 
-	valuesDescriptor, ok := schemaDef["values"]
+	rawValuesDef, ok := schemaDef["values"]
 	if ok {
 		var err error
-		v.valueType, err = v.topSchema.Parse(valuesDescriptor)
+		v.valueType, err = v.topSchema.Parse(rawValuesDef)
 		if err != nil {
 			return fmt.Errorf(`cannot parse "values" constraint in map schema: %w`, err)
 		}

--- a/aspects/schema.go
+++ b/aspects/schema.go
@@ -1,0 +1,277 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package aspects
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+)
+
+type validator interface {
+	Validate(json.RawMessage) error
+}
+
+type stringValidator struct {
+	// pattern is a regex pattern that the string must match.
+	pattern *regexp.Regexp
+	// choices holds the possible values the string can take, if non-empty.
+	choices []string
+
+	// TODO: JSON schema formats? which ones and how will they be defined?
+}
+
+func (*stringValidator) Validate(json.RawMessage) error {
+	// TODO: implement validation
+	return nil
+}
+
+func (v *stringValidator) parse(raw json.RawMessage) error {
+	var constraints map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &constraints); err != nil {
+		var typeErr *json.UnmarshalTypeError
+		if !errors.As(err, &typeErr) {
+			return err
+		}
+
+		var typ string
+		if err := json.Unmarshal(raw, &typ); err != nil {
+			return err
+		}
+
+		if typ != "string" {
+			// NOTE: shouldn't happen save for a bug in parseValidator
+			return fmt.Errorf(`cannot parse type %q as string`, typ)
+		}
+
+		// a simple "string" type with no constraints
+		return nil
+	}
+
+	if rawPattern, ok := constraints["pattern"]; ok {
+		var patt string
+		err := json.Unmarshal(rawPattern, &patt)
+		if err != nil {
+			return err
+		}
+
+		if v.pattern, err = regexp.Compile(patt); err != nil {
+			return err
+		}
+	}
+
+	if rawChoices, ok := constraints["choices"]; ok {
+		var choices []string
+		err := json.Unmarshal(rawChoices, &choices)
+		if err != nil {
+			return err
+		}
+
+		if len(choices) == 0 {
+			return fmt.Errorf(`cannot have "choices" constraint with empty list: field must be populated or not exist`)
+		}
+
+		v.choices = choices
+	}
+
+	return nil
+}
+
+type mapValidator struct {
+	schema *CustomSchema
+
+	// entries map keys that can the map can contain to their expected types.
+	// Alternatively, the schema can instead key and/or value types.
+	entryTypes map[string]validator
+
+	// valueType validates that the map's values match a certain type.
+	valueType validator
+
+	// keyType validates that the map's key match a certain type.
+	keyType validator
+
+	// required holds combinations of keys that an instance of the map is allowed
+	// to have.
+	required [][]string
+}
+
+func (v *mapValidator) Validate(json.RawMessage) error {
+	// TODO: implement validation
+	return nil
+}
+
+func (v *mapValidator) parse(level map[string]json.RawMessage) error {
+	requiredRaw, ok := level["required"]
+	if ok {
+		if err := json.Unmarshal(requiredRaw, &v.required); err != nil {
+			return fmt.Errorf(`cannot unmarshal map's "required" field: %v`, err)
+		}
+	}
+
+	// a map can have a "schema" constrain with specific values
+	if schema, ok := level["schema"]; ok {
+		var nextLevel map[string]json.RawMessage
+		if err := json.Unmarshal(schema, &nextLevel); err != nil {
+			return fmt.Errorf(`cannot unmarshal map's "schema" field: %v`, err)
+		}
+
+		v.entryTypes = make(map[string]validator, len(nextLevel))
+		for key, value := range nextLevel {
+			validator, err := v.schema.parseValidator(value)
+			if err != nil {
+				return fmt.Errorf(`cannot parse constraint for key %q: %w`, key, err)
+			}
+
+			v.entryTypes[key] = validator
+		}
+
+		return nil
+	}
+
+	// alternatively, it can constrain the type of its keys and/or values
+	keyDescription, ok := level["keys"]
+	if ok {
+		var err error
+		v.keyType, err = v.schema.parseValidator(keyDescription)
+		if err != nil {
+			return fmt.Errorf(`cannot parse "keys" constraint in map schema: %w`, err)
+		}
+	}
+
+	valuesDescriptor, ok := level["values"]
+	if ok {
+		var err error
+		v.valueType, err = v.schema.parseValidator(valuesDescriptor)
+		if err != nil {
+			return fmt.Errorf(`cannot parse "values" constraint in map schema: %w`, err)
+		}
+	}
+
+	return nil
+}
+
+type CustomSchema struct {
+	userTypes map[string]validator
+	validator validator
+}
+
+func (s *CustomSchema) Validate(raw json.RawMessage) error {
+	return s.validator.Validate(raw)
+}
+
+func (s *CustomSchema) userTypeValidator(typeName string) validator {
+	return s.userTypes[typeName]
+}
+
+func ParseSchema(raw []byte) (*CustomSchema, error) {
+	var level map[string]json.RawMessage
+	err := json.Unmarshal(raw, &level)
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse top level schema: top level must be a map")
+	}
+
+	schema := &CustomSchema{}
+	if val, ok := level["types"]; ok {
+		var userTypes map[string]json.RawMessage
+		if err := json.Unmarshal(val, &userTypes); err != nil {
+			return nil, fmt.Errorf(`cannot parse user-defined types at top level (must be a map): %w`, err)
+		}
+
+		schema.userTypes = make(map[string]validator, len(userTypes))
+		for userTypeName, typeDef := range userTypes {
+			validator, err := schema.parseValidator(typeDef)
+			if err != nil {
+				return nil, fmt.Errorf(`cannot parse user-defined type %q: %w`, userTypeName, err)
+			}
+
+			schema.userTypes[userTypeName] = validator
+		}
+	}
+
+	schema.validator, err = schema.parseValidator(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	return schema, nil
+}
+
+func (s *CustomSchema) parseValidator(raw json.RawMessage) (validator, error) {
+	var typ string
+	var level map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &level); err != nil {
+		var typeErr *json.UnmarshalTypeError
+		if !errors.As(err, &typeErr) {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(raw, &typ); err != nil {
+			return nil, err
+		}
+	} else {
+		rawType, ok := level["type"]
+		if !ok {
+			typ = "map"
+		} else {
+			if err := json.Unmarshal(rawType, &typ); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	var val validator
+	switch typ {
+	case "map":
+		mapVal := &mapValidator{
+			schema: s,
+		}
+
+		if err := mapVal.parse(level); err != nil {
+			return nil, err
+		}
+		val = mapVal
+	case "int":
+		return nil, nil
+	case "string":
+		strVal := &stringValidator{}
+		if err := strVal.parse(raw); err != nil {
+			return nil, err
+		}
+		val = strVal
+	case "number":
+		return nil, nil
+	case "bool":
+		return nil, nil
+	case "array":
+		return nil, nil
+	default:
+		if typ[0] != '$' {
+			return nil, fmt.Errorf("cannot parse type %q: unknown", typ)
+		}
+		userType, ok := s.userTypes[typ[1:]]
+		if !ok {
+			return nil, fmt.Errorf(`cannot find referenced user-defined type %q`, typ)
+		}
+		val = userType
+	}
+
+	return val, nil
+}

--- a/aspects/schema.go
+++ b/aspects/schema.go
@@ -164,8 +164,7 @@ func (v *stringSchema) Parse(raw json.RawMessage) error {
 
 	if rawChoices, ok := constraints["choices"]; ok {
 		var choices []string
-		err := json.Unmarshal(rawChoices, &choices)
-		if err != nil {
+		if err := json.Unmarshal(rawChoices, &choices); err != nil {
 			return err
 		}
 
@@ -178,7 +177,7 @@ func (v *stringSchema) Parse(raw json.RawMessage) error {
 
 	if rawPattern, ok := constraints["pattern"]; ok {
 		if v.choices != nil {
-			return fmt.Errorf(`cannot have "choices" and "pattern" constraints`)
+			return fmt.Errorf(`cannot use "choices" and "pattern" constraints in same schema`)
 		}
 
 		var patt string

--- a/aspects/schema.go
+++ b/aspects/schema.go
@@ -247,10 +247,6 @@ func (s *CustomSchema) Validate(raw json.RawMessage) error {
 	return s.validator.Validate(raw)
 }
 
-func (s *CustomSchema) userTypeValidator(typeName string) validator {
-	return s.userTypes[typeName]
-}
-
 func ParseSchema(raw []byte) (*CustomSchema, error) {
 	var level map[string]json.RawMessage
 	err := json.Unmarshal(raw, &level)

--- a/aspects/schema.go
+++ b/aspects/schema.go
@@ -53,6 +53,10 @@ func ParseSchema(raw []byte) (*CustomSchema, error) {
 		}
 	}
 
+	if _, ok := schemaDef["schema"]; !ok {
+		return nil, fmt.Errorf(`cannot parse top level schema: must have a "schema" constraint`)
+	}
+
 	schema.topLevel, err = schema.Parse(raw)
 	if err != nil {
 		return nil, err

--- a/aspects/schema_test.go
+++ b/aspects/schema_test.go
@@ -50,8 +50,7 @@ func (*schemaSuite) TestParseSchema(c *C) {
   }
 }`
 
-	_ = `
-{
+	input := `{
   "snaps": {
     "core20": {
       "name": "core20",
@@ -69,4 +68,7 @@ func (*schemaSuite) TestParseSchema(c *C) {
 	schema, err := aspects.ParseSchema([]byte(schemaStr))
 	c.Assert(err, IsNil)
 	c.Assert(schema, NotNil)
+
+	err = schema.Validate([]byte(input))
+	c.Assert(err, IsNil)
 }

--- a/aspects/schema_test.go
+++ b/aspects/schema_test.go
@@ -74,6 +74,24 @@ func (*schemaSuite) TestParseSchemaExample(c *C) {
 	c.Assert(err, IsNil)
 }
 
+func (*schemaSuite) TestTopLevelMustHaveSchema(c *C) {
+	schemaStr := []byte(`{
+  "schema": {
+    "foo": "string"
+  }
+}`)
+
+	_, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, IsNil)
+
+	schemaStr = []byte(`{
+  "keys": "string"
+}`)
+
+	_, err = aspects.ParseSchema(schemaStr)
+	c.Assert(err, ErrorMatches, `cannot parse top level schema: must have a "schema" constraint`)
+}
+
 func (*schemaSuite) TestParseAndValidateSchemaWithStringsHappy(c *C) {
 	schemaStr := []byte(`{
   "schema": {

--- a/aspects/schema_test.go
+++ b/aspects/schema_test.go
@@ -20,6 +20,8 @@
 package aspects_test
 
 import (
+	"fmt"
+
 	"github.com/snapcore/snapd/aspects"
 	. "gopkg.in/check.v1"
 )
@@ -28,8 +30,8 @@ type schemaSuite struct{}
 
 var _ = Suite(&schemaSuite{})
 
-func (*schemaSuite) TestParseSchema(c *C) {
-	schemaStr := `{
+func (*schemaSuite) TestParseSchemaExample(c *C) {
+	schemaStr := []byte(`{
   "types": {
     "snap-name": {
       "type": "string",
@@ -48,9 +50,9 @@ func (*schemaSuite) TestParseSchema(c *C) {
       }
     }
   }
-}`
+}`)
 
-	input := `{
+	input := []byte(`{
   "snaps": {
     "core20": {
       "name": "core20",
@@ -63,12 +65,162 @@ func (*schemaSuite) TestParseSchema(c *C) {
       "status": "active"
     }
   }
-}`
+}`)
 
-	schema, err := aspects.ParseSchema([]byte(schemaStr))
+	schema, err := aspects.ParseSchema(schemaStr)
 	c.Assert(err, IsNil)
 	c.Assert(schema, NotNil)
 
-	err = schema.Validate([]byte(input))
+	err = schema.Validate(input)
 	c.Assert(err, IsNil)
+}
+
+func (*schemaSuite) TestParseAndValidateSchemaWithStringsHappy(c *C) {
+	schemaStr := []byte(`{
+  "schema": {
+    "snaps": {
+      "keys": "string",
+      "values": {
+        "schema": {
+          "name": "string"
+        }
+      }
+    }
+  }
+}`)
+
+	input := []byte(`{
+  "snaps": {
+    "core20": {
+      "name": "core20"
+    },
+    "snapd": {
+      "name": "snapd"
+    }
+  }
+}`)
+
+	schema, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, IsNil)
+	c.Assert(schema, NotNil)
+
+	err = schema.Validate(input)
+	c.Assert(err, IsNil)
+}
+
+func (*schemaSuite) TestUnknownFieldInMap(c *C) {
+	schemaStr := []byte(`{
+  "schema": {
+    "foo": "string"
+  }
+}`)
+
+	input := []byte(`{
+  "foo": "bar",
+	"oof": "baz"
+}`)
+
+	schema, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, IsNil)
+	c.Assert(schema, NotNil)
+
+	err = schema.Validate(input)
+	c.Assert(err, ErrorMatches, `unexpected field "oof" in map`)
+}
+
+func (*schemaSuite) TestFieldNoMatch(c *C) {
+	schemaStr := []byte(`{
+  "schema": {
+    "foo": {
+			"type": "string",
+			"pattern": "[fb]00"
+		}
+  }
+}`)
+
+	input := []byte(`{
+  "foo": "F00"
+}`)
+
+	schema, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, IsNil)
+	c.Assert(schema, NotNil)
+
+	err = schema.Validate(input)
+	c.Assert(err, ErrorMatches, `string "F00" doesn't match schema pattern \[fb\]00`)
+}
+
+func (*schemaSuite) TestParseAndValidateSchemaWithInts(c *C) {
+	schemaStr := []byte(`{
+  "schema": {
+    "foo": "int",
+		"bar": {
+			"type": "int",
+			"min": 0,
+			"max": 100,
+			"choices": [1, 2, 3]
+		}
+  }
+}`)
+
+	input := []byte(`{
+  "foo": 5,
+	"bar": 3
+}`)
+
+	schema, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, IsNil)
+	c.Assert(schema, NotNil)
+
+	err = schema.Validate(input)
+	c.Assert(err, IsNil)
+}
+
+func (*schemaSuite) TestIntegerMustMatchConstraints(c *C) {
+	schemaStr := []byte(`{
+  "schema": {
+		"foo": {
+			"type": "int",
+			"min": 0,
+			"max": 100,
+			"choices": [1, 2, 3]
+		}
+  }
+}`)
+
+	schema, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, IsNil)
+	c.Assert(schema, NotNil)
+
+	type testcase struct {
+		name string
+		num  int
+		err  string
+	}
+	tcs := []testcase{
+		{
+			name: "less than min",
+			num:  -1,
+			err:  `integer -1 is less than allowed minimum 0`,
+		},
+		{
+			name: "greater than max",
+			num:  101,
+			err:  `integer 101 is greater than allowed maximum 100`,
+		},
+		{
+			name: "not one of allowed choices",
+			num:  4,
+			err:  `integer 4 is not one of the allowed choices`,
+		},
+	}
+	for _, tc := range tcs {
+		input := []byte(fmt.Sprintf(`{
+  "foo": %d
+}`, tc.num))
+
+		cmt := Commentf("subtest: %s", tc.name)
+		err = schema.Validate(input)
+		c.Assert(err, ErrorMatches, tc.err, cmt)
+	}
 }

--- a/aspects/schema_test.go
+++ b/aspects/schema_test.go
@@ -108,6 +108,43 @@ func (*schemaSuite) TestParseAndValidateSchemaWithStringsHappy(c *C) {
 	c.Assert(err, IsNil)
 }
 
+func (*schemaSuite) TestMapKeysStringBased(c *C) {
+	schemaStr := []byte(`{
+  "types": {
+    "patt": {
+      "type": "string",
+      "pattern": "[fb]oo"
+    }
+  },
+  "schema": {
+    "pattern": {
+      "keys": {
+        "pattern": "[fb]oo"
+      }
+    },
+    "userType": {
+      "keys": "$patt"
+    }
+  }
+}`)
+
+	input := []byte(`{
+  "pattern": {
+    "foo": 1
+  },
+  "userType": {
+    "boo": 2
+  }
+}`)
+
+	schema, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, IsNil)
+	c.Assert(schema, NotNil)
+
+	err = schema.Validate(input)
+	c.Assert(err, IsNil)
+}
+
 func (*schemaSuite) TestUnknownFieldInMap(c *C) {
 	schemaStr := []byte(`{
   "schema": {
@@ -117,7 +154,7 @@ func (*schemaSuite) TestUnknownFieldInMap(c *C) {
 
 	input := []byte(`{
   "foo": "bar",
-	"oof": "baz"
+  "oof": "baz"
 }`)
 
 	schema, err := aspects.ParseSchema(schemaStr)
@@ -132,9 +169,9 @@ func (*schemaSuite) TestFieldNoMatch(c *C) {
 	schemaStr := []byte(`{
   "schema": {
     "foo": {
-			"type": "string",
-			"pattern": "[fb]00"
-		}
+      "type": "string",
+      "pattern": "[fb]00"
+    }
   }
 }`)
 
@@ -154,18 +191,18 @@ func (*schemaSuite) TestParseAndValidateSchemaWithInts(c *C) {
 	schemaStr := []byte(`{
   "schema": {
     "foo": "int",
-		"bar": {
-			"type": "int",
-			"min": 0,
-			"max": 100,
-			"choices": [1, 2, 3]
-		}
+    "bar": {
+      "type": "int",
+      "min": 0,
+      "max": 100,
+      "choices": [1, 2, 3]
+    }
   }
 }`)
 
 	input := []byte(`{
   "foo": 5,
-	"bar": 3
+  "bar": 3
 }`)
 
 	schema, err := aspects.ParseSchema(schemaStr)
@@ -179,12 +216,12 @@ func (*schemaSuite) TestParseAndValidateSchemaWithInts(c *C) {
 func (*schemaSuite) TestIntegerMustMatchConstraints(c *C) {
 	schemaStr := []byte(`{
   "schema": {
-		"foo": {
-			"type": "int",
-			"min": 0,
-			"max": 100,
-			"choices": [1, 2, 3]
-		}
+    "foo": {
+      "type": "int",
+      "min": 0,
+      "max": 100,
+      "choices": [1, 2, 3]
+    }
   }
 }`)
 

--- a/aspects/schema_test.go
+++ b/aspects/schema_test.go
@@ -1,0 +1,72 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package aspects_test
+
+import (
+	"github.com/snapcore/snapd/aspects"
+	. "gopkg.in/check.v1"
+)
+
+type schemaSuite struct{}
+
+var _ = Suite(&schemaSuite{})
+
+func (*schemaSuite) TestParseSchema(c *C) {
+	schemaStr := `{
+  "types": {
+    "snap-name": {
+      "type": "string",
+      "pattern": "^[a-z0-9-]*[a-z][a-z0-9-]*$"
+    }
+  },
+  "schema": {
+    "snaps": {
+      "keys": "$snap-name",
+      "values": {
+        "schema": {
+          "name": "$snap-name",
+          "version": "string",
+          "status": "string"
+        }
+      }
+    }
+  }
+}`
+
+	_ = `
+{
+  "snaps": {
+    "core20": {
+      "name": "core20",
+      "version": "20230503",
+      "status": "active"
+    },
+    "snapd": {
+      "name": "snapd",
+      "version": "2.59.5+git948.gb447044",
+      "status": "active"
+    }
+  }
+}`
+
+	schema, err := aspects.ParseSchema([]byte(schemaStr))
+	c.Assert(err, IsNil)
+	c.Assert(schema, NotNil)
+}

--- a/aspects/transaction_test.go
+++ b/aspects/transaction_test.go
@@ -19,7 +19,9 @@
 package aspects_test
 
 import (
+	"encoding/json"
 	"errors"
+	"fmt"
 
 	. "gopkg.in/check.v1"
 
@@ -117,6 +119,11 @@ type failingSchema struct {
 
 func (f *failingSchema) Validate([]byte) error {
 	return f.err
+}
+
+func (f *failingSchema) Parse(json.RawMessage) error {
+	// TODO: JSONSchema will be removed; this is just to re-use the Schema interface
+	return fmt.Errorf(`not implemented`)
 }
 
 func (s *transactionTestSuite) TestRollBackOnCommitError(c *C) {


### PR DESCRIPTION
Spike for aspect schemas. Currently only supports maps, string and user-defined types based on those.