### PR TITLE
interfaces: upower-observe base policy considers whether the slot is implicit

### DIFF
--- a/asserts/ifacedecls.go
+++ b/asserts/ifacedecls.go
@@ -1011,6 +1011,12 @@ func compileSlotInstallationConstraints(context *subruleContext, cDef constraint
 // interface slot for a snap relevant to its connection or
 // auto-connection.
 type SlotConnectionConstraints struct {
+	// SlotSnapTypes constraints on the slot side for connections
+	// are only useful in the base-declaration,
+	// as the snap-declaration is for one given snap with its type.
+	// So there is no (new) format iteration to cover this.
+	SlotSnapTypes []string
+
 	PlugSnapTypes    []string
 	PlugSnapIDs      []string
 	PlugPublisherIDs []string
@@ -1065,6 +1071,8 @@ func (c *SlotConnectionConstraints) setAttributeConstraints(field string, cstrs 
 
 func (c *SlotConnectionConstraints) setIDConstraints(field string, cstrs []string) {
 	switch field {
+	case "slot-snap-type":
+		c.SlotSnapTypes = cstrs
 	case "plug-snap-type":
 		c.PlugSnapTypes = cstrs
 	case "plug-snap-id":
@@ -1077,7 +1085,7 @@ func (c *SlotConnectionConstraints) setIDConstraints(field string, cstrs []strin
 }
 
 var (
-	slotIDConstraints = []string{"plug-snap-type", "plug-publisher-id", "plug-snap-id"}
+	slotIDConstraints = []string{"slot-snap-type", "plug-snap-type", "plug-publisher-id", "plug-snap-id"}
 )
 
 func (c *SlotConnectionConstraints) setSlotsPerPlug(a SideArityConstraint) {

--- a/asserts/ifacedecls_test.go
+++ b/asserts/ifacedecls_test.go
@@ -1686,6 +1686,7 @@ func (s *plugSlotRulesSuite) TestCompileSlotRuleInstallationConstraintsSlotNames
 func (s *plugSlotRulesSuite) TestCompileSlotRuleConnectionConstraintsIDConstraints(c *C) {
 	rule, err := asserts.CompileSlotRule("iface", map[string]interface{}{
 		"allow-connection": map[string]interface{}{
+			"slot-snap-type":    []interface{}{"core"},
 			"plug-snap-type":    []interface{}{"core", "kernel", "gadget", "app"},
 			"plug-snap-id":      []interface{}{"snapidsnapidsnapidsnapidsnapid01", "snapidsnapidsnapidsnapidsnapid02"},
 			"plug-publisher-id": []interface{}{"pubidpubidpubidpubidpubidpubid09", "canonical", "$SAME"},
@@ -1695,6 +1696,7 @@ func (s *plugSlotRulesSuite) TestCompileSlotRuleConnectionConstraintsIDConstrain
 
 	c.Assert(rule.AllowConnection, HasLen, 1)
 	cstrs := rule.AllowConnection[0]
+	c.Check(cstrs.SlotSnapTypes, DeepEquals, []string{"core"})
 	c.Check(cstrs.PlugSnapTypes, DeepEquals, []string{"core", "kernel", "gadget", "app"})
 	c.Check(cstrs.PlugSnapIDs, DeepEquals, []string{"snapidsnapidsnapidsnapidsnapid01", "snapidsnapidsnapidsnapidsnapid02"})
 	c.Check(cstrs.PlugPublisherIDs, DeepEquals, []string{"pubidpubidpubidpubidpubidpubid09", "canonical", "$SAME"})
@@ -1979,6 +1981,10 @@ func (s *plugSlotRulesSuite) TestCompileSlotRuleErrors(c *C) {
       - foo`, `plug-snap-id in allow-connection in slot rule for interface "iface" contains an invalid element: "foo"`},
 		{`iface:
   allow-connection:
+    slot-snap-type:
+      - foo`, `slot-snap-type in allow-connection in slot rule for interface "iface" contains an invalid element: "foo"`},
+		{`iface:
+  allow-connection:
     plug-snap-type:
       - foo`, `plug-snap-type in allow-connection in slot rule for interface "iface" contains an invalid element: "foo"`},
 		{`iface:
@@ -1996,19 +2002,19 @@ func (s *plugSlotRulesSuite) TestCompileSlotRuleErrors(c *C) {
 		{`iface:
   allow-connection:
     plug-snap-ids:
-      - foo`, `allow-connection in slot rule for interface "iface" must specify at least one of plug-names, slot-names, plug-attributes, slot-attributes, plug-snap-type, plug-publisher-id, plug-snap-id, slots-per-plug, plugs-per-slot, on-classic, on-store, on-brand, on-model`},
+      - foo`, `allow-connection in slot rule for interface "iface" must specify at least one of plug-names, slot-names, plug-attributes, slot-attributes, slot-snap-type, plug-snap-type, plug-publisher-id, plug-snap-id, slots-per-plug, plugs-per-slot, on-classic, on-store, on-brand, on-model`},
 		{`iface:
   deny-connection:
     plug-snap-ids:
-      - foo`, `deny-connection in slot rule for interface "iface" must specify at least one of plug-names, slot-names, plug-attributes, slot-attributes, plug-snap-type, plug-publisher-id, plug-snap-id, slots-per-plug, plugs-per-slot, on-classic, on-store, on-brand, on-model`},
+      - foo`, `deny-connection in slot rule for interface "iface" must specify at least one of plug-names, slot-names, plug-attributes, slot-attributes, slot-snap-type, plug-snap-type, plug-publisher-id, plug-snap-id, slots-per-plug, plugs-per-slot, on-classic, on-store, on-brand, on-model`},
 		{`iface:
   allow-auto-connection:
     plug-snap-ids:
-      - foo`, `allow-auto-connection in slot rule for interface "iface" must specify at least one of plug-names, slot-names, plug-attributes, slot-attributes, plug-snap-type, plug-publisher-id, plug-snap-id, slots-per-plug, plugs-per-slot, on-classic, on-store, on-brand, on-model`},
+      - foo`, `allow-auto-connection in slot rule for interface "iface" must specify at least one of plug-names, slot-names, plug-attributes, slot-attributes, slot-snap-type, plug-snap-type, plug-publisher-id, plug-snap-id, slots-per-plug, plugs-per-slot, on-classic, on-store, on-brand, on-model`},
 		{`iface:
   deny-auto-connection:
     plug-snap-ids:
-      - foo`, `deny-auto-connection in slot rule for interface "iface" must specify at least one of plug-names, slot-names, plug-attributes, slot-attributes, plug-snap-type, plug-publisher-id, plug-snap-id, slots-per-plug, plugs-per-slot, on-classic, on-store, on-brand, on-model`},
+      - foo`, `deny-auto-connection in slot rule for interface "iface" must specify at least one of plug-names, slot-names, plug-attributes, slot-attributes, slot-snap-type, plug-snap-type, plug-publisher-id, plug-snap-id, slots-per-plug, plugs-per-slot, on-classic, on-store, on-brand, on-model`},
 		{`iface:
   allow-connect: true`, `slot rule for interface "iface" must specify at least one of allow-installation, deny-installation, allow-connection, deny-connection, allow-auto-connection, deny-auto-connection`},
 		{`iface:

--- a/interfaces/builtin/upower_observe.go
+++ b/interfaces/builtin/upower_observe.go
@@ -38,8 +38,12 @@ const upowerObserveBaseDeclarationSlots = `
       slot-snap-type:
         - app
         - core
+    deny-auto-connection:
+      slot-snap-type:
+        - app
     deny-connection:
-      on-classic: false
+      slot-snap-type:
+        - app
 `
 
 const upowerObservePermanentSlotAppArmor = `

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -171,7 +171,6 @@ func (s *baseDeclSuite) TestAutoConnection(c *C) {
 		"ubuntu-download-manager": true,
 		"unity7":                  true,
 		"unity8":                  true,
-		"upower-observe":          true,
 		"wayland":                 true,
 		"x11":                     true,
 	}
@@ -192,6 +191,33 @@ func (s *baseDeclSuite) TestAutoConnection(c *C) {
 		} else {
 			c.Check(err, NotNil, comm)
 		}
+	}
+}
+
+func (s *baseDeclSuite) TestAutoConnectionImplicitSlotOnly(c *C) {
+	all := builtin.Interfaces()
+
+	// these auto-connect only with an implicit slot
+	autoconnect := map[string]bool{
+		"upower-observe": true,
+	}
+
+	for _, iface := range all {
+		if !autoconnect[iface.Name()] {
+			continue
+		}
+		comm := Commentf(iface.Name())
+
+		// check base declaration
+		cand := s.connectCand(c, iface.Name(), fmt.Sprintf(`name: snapd
+type: snapd
+version: 0
+slots:
+  %s:
+`, iface.Name()), "")
+		arity, err := cand.CheckAutoConnect()
+		c.Check(err, IsNil, comm)
+		c.Check(arity.SlotsPerPlugAny(), Equals, false)
 	}
 }
 
@@ -1044,6 +1070,7 @@ func (s *baseDeclSuite) TestConnection(c *C) {
 		"ubuntu-download-manager":   true,
 		"unity8-calendar":           true,
 		"unity8-contacts":           true,
+		"upower-observe":            true,
 	}
 
 	for _, iface := range all {
@@ -1062,6 +1089,32 @@ func (s *baseDeclSuite) TestConnection(c *C) {
 	}
 }
 
+func (s *baseDeclSuite) TestConnectionImplicitSlotOnly(c *C) {
+	all := builtin.Interfaces()
+
+	// these allow connect only with an implicit slot
+	autoconnect := map[string]bool{
+		"upower-observe": true,
+	}
+
+	for _, iface := range all {
+		if !autoconnect[iface.Name()] {
+			continue
+		}
+		comm := Commentf(iface.Name())
+
+		// check base declaration
+		cand := s.connectCand(c, iface.Name(), fmt.Sprintf(`name: snapd
+type: snapd
+version: 0
+slots:
+  %s:
+`, iface.Name()), "")
+		err := cand.Check()
+		c.Check(err, IsNil, comm)
+	}
+}
+
 func (s *baseDeclSuite) TestConnectionOnClassic(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
@@ -1076,7 +1129,6 @@ func (s *baseDeclSuite) TestConnectionOnClassic(c *C) {
 		"network-manager": true,
 		"ofono":           true,
 		"pulseaudio":      true,
-		"upower-observe":  true,
 	}
 
 	for _, onClassic := range []bool{true, false} {

--- a/interfaces/policy/helpers.go
+++ b/interfaces/policy/helpers.go
@@ -167,6 +167,9 @@ func checkSlotConnectionConstraints1(connc *ConnectCandidate, constraints *asser
 	if err := constraints.SlotAttributes.Check(connc.Slot, connc); err != nil {
 		return err
 	}
+	if err := checkSnapType(connc.Slot.Snap(), constraints.SlotSnapTypes); err != nil {
+		return err
+	}
 	if err := checkSnapType(connc.Plug.Snap(), constraints.PlugSnapTypes); err != nil {
 		return err
 	}

--- a/interfaces/policy/policy_test.go
+++ b/interfaces/policy/policy_test.go
@@ -193,6 +193,10 @@ slots:
     allow-connection:
       plug-snap-type:
         - gadget
+  fromcore:
+    allow-connection:
+      slot-snap-type:
+        - core
   same-slot-publisher-id:
     allow-connection:
       plug-publisher-id:
@@ -393,6 +397,7 @@ plugs:
 
    gadgethelp:
    trustedhelp:
+   fromcore:
 
    precise-plug-snap-id:
    precise-slot-snap-id:
@@ -1094,6 +1099,7 @@ plugs:
    gadgethelp:
 slots:
    trustedhelp:
+   fromcore:
 `, nil)
 
 	coreSnap := snaptest.MockInfo(c, `
@@ -1103,6 +1109,7 @@ type: os
 slots:
    gadgethelp:
    trustedhelp:
+   fromcore:
 `, nil)
 
 	cand := policy.ConnectCandidate{
@@ -1134,6 +1141,20 @@ slots:
 		PlugSnapDeclaration: s.plugDecl,
 		Slot:                interfaces.NewConnectedSlot(s.slotSnap.Slots["trustedhelp"], nil, nil),
 		BaseDeclaration:     s.baseDecl,
+	}
+	c.Check(cand.Check(), ErrorMatches, "connection not allowed.*")
+
+	cand = policy.ConnectCandidate{
+		Plug:            interfaces.NewConnectedPlug(s.plugSnap.Plugs["fromcore"], nil, nil),
+		Slot:            interfaces.NewConnectedSlot(coreSnap.Slots["fromcore"], nil, nil),
+		BaseDeclaration: s.baseDecl,
+	}
+	c.Check(cand.Check(), IsNil)
+
+	cand = policy.ConnectCandidate{
+		Plug:            interfaces.NewConnectedPlug(s.plugSnap.Plugs["fromcore"], nil, nil),
+		Slot:            interfaces.NewConnectedSlot(gadgetSnap.Slots["fromcore"], nil, nil),
+		BaseDeclaration: s.baseDecl,
 	}
 	c.Check(cand.Check(), ErrorMatches, "connection not allowed.*")
 }


### PR DESCRIPTION
let connect/auto-connect only to an upower-observe implicit slot by default,
this will require changes to review-tools to detect that for an app slot
dedicated rules in snap-declaration are needed

to allow for this, first introduce new rule syntax in the form of slot-snap-type slot-side connection constraints