### PR TITLE
snap-confine: build with `-Wmissing-field-initializers`

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -8,7 +8,8 @@ noinst_PROGRAMS =
 noinst_LIBRARIES =
 
 CHECK_CFLAGS = -Wall -Wextra -Wmissing-prototypes -Wstrict-prototypes \
-	-Wno-missing-field-initializers -Wno-unused-parameter
+	-Wno-missing-field-initializers -Wno-unused-parameter \
+	-Wmissing-field-initializers
 
 # Make all warnings errors when building for unit tests
 if WITH_UNIT_TESTS

--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -8,8 +8,7 @@ noinst_PROGRAMS =
 noinst_LIBRARIES =
 
 CHECK_CFLAGS = -Wall -Wextra -Wmissing-prototypes -Wstrict-prototypes \
-	-Wno-missing-field-initializers -Wno-unused-parameter \
-	-Wmissing-field-initializers
+	-Wno-unused-parameter
 
 # Make all warnings errors when building for unit tests
 if WITH_UNIT_TESTS

--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -951,32 +951,32 @@ void sc_populate_mount_ns(struct sc_apparmor *apparmor, int snap_update_ns_fd,
 	if (inv->is_normal_mode) {
 		// In normal mode we use the base snap as / and set up several bind mounts.
 		static const struct sc_mount mounts[] = {
-			{"/dev"},	// because it contains devices on host OS
-			{"/etc"},	// because that's where /etc/resolv.conf lives, perhaps a bad idea
-			{"/home"},	// to support /home/*/snap and home interface
-			{"/root"},	// because that is $HOME for services
-			{"/proc"},	// fundamental filesystem
-			{"/sys"},	// fundamental filesystem
-			{"/tmp"},	// to get writable tmp
-			{"/var/snap"},	// to get access to global snap data
-			{"/var/lib/snapd"},	// to get access to snapd state and seccomp profiles
-			{"/var/tmp"},	// to get access to the other temporary directory
-			{"/run"},	// to get /run with sockets and what not
-			{"/lib/modules",.is_optional = true},	// access to the modules of the running kernel
-			{"/lib/firmware",.is_optional = true},	// access to the firmware of the running kernel
-			{"/usr/src"},	// FIXME: move to SecurityMounts in system-trace interface
-			{"/var/log"},	// FIXME: move to SecurityMounts in log-observe interface
+			{.path = "/dev"},	// because it contains devices on host OS
+			{.path = "/etc"},	// because that's where /etc/resolv.conf lives, perhaps a bad idea
+			{.path = "/home"},	// to support /home/*/snap and home interface
+			{.path = "/root"},	// because that is $HOME for services
+			{.path = "/proc"},	// fundamental filesystem
+			{.path = "/sys"},	// fundamental filesystem
+			{.path = "/tmp"},	// to get writable tmp
+			{.path = "/var/snap"},	// to get access to global snap data
+			{.path = "/var/lib/snapd"},	// to get access to snapd state and seccomp profiles
+			{.path = "/var/tmp"},	// to get access to the other temporary directory
+			{.path = "/run"},	// to get /run with sockets and what not
+			{.path = "/lib/modules",.is_optional = true},	// access to the modules of the running kernel
+			{.path = "/lib/firmware",.is_optional = true},	// access to the firmware of the running kernel
+			{.path = "/usr/src"},	// FIXME: move to SecurityMounts in system-trace interface
+			{.path = "/var/log"},	// FIXME: move to SecurityMounts in log-observe interface
 #ifdef MERGED_USR
-			{"/run/media", true, "/media"},	// access to the users removable devices
+			{.path = "/run/media", .is_bidirectional = true, .altpath = "/media"},	// access to the users removable devices
 #else
-			{"/media", true},	// access to the users removable devices
+			{.path = "/media", .is_bidirectional = true},	// access to the users removable devices
 #endif				// MERGED_USR
-			{"/run/netns", true},	// access to the 'ip netns' network namespaces
+			{.path = "/run/netns", .is_bidirectional = true},	// access to the 'ip netns' network namespaces
 			// The /mnt directory is optional in base snaps to ensure backwards
 			// compatibility with the first version of base snaps that was
 			// released.
-			{"/mnt",.is_optional = true},	// to support the removable-media interface
-			{"/var/lib/extrausers",.is_optional = true},	// access to UID/GID of extrausers (if available)
+			{.path = "/mnt",.is_optional = true},	// to support the removable-media interface
+			{.path = "/var/lib/extrausers",.is_optional = true},	// access to UID/GID of extrausers (if available)
 			{},
 		};
 		struct sc_mount_config normal_config = {
@@ -998,8 +998,8 @@ void sc_populate_mount_ns(struct sc_apparmor *apparmor, int snap_update_ns_fd,
 		// In legacy mode we don't pivot to a base snap's rootfs and instead
 		// just arrange bi-directional mount propagation for two directories.
 		static const struct sc_mount mounts[] = {
-			{"/media", true},
-			{"/run/netns", true},
+			{.path = "/media", .is_bidirectional = true},
+			{.path = "/run/netns", .is_bidirectional = true},
 			{},
 		};
 		struct sc_mount_config legacy_config = {


### PR DESCRIPTION
The tiobe software quality checker flaged this and while it's a bit debatable it adds some clarity around the booleans in the `sc_mount` struct so I think it's overall worth it.
