### PR TITLE
interfaces/builtin: allow ZFS vols as a block-device

### DIFF
--- a/interfaces/builtin/block_devices.go
+++ b/interfaces/builtin/block_devices.go
@@ -68,6 +68,9 @@ const blockDevicesConnectedPlugAppArmor = `
 /dev/vd[a-z] rwk,                                          # virtio
 /dev/loop[0-9]{,[0-9],[0-9][0-9]} rwk,                     # loopback (up to 1000 devices)
 /dev/loop-control rw,                                      # loopback control
+/dev/zd[0-9]{,[0-9],[0-9][0-9]} rwk,                       # ZFS volumes (up to 1000 devices)
+/dev/zd[0-9]{,[0-9],[0-9][0-9]}{,p[0-9]{,[0-9]}} rwk,      # ZFS volumes (up to 1000 devices, 100 partitions)
+/dev/zfs rw,                                               # ZFS control
 
 # Allow /dev/nvmeXnY namespace block devices. Please note this grants access to all
 # NVMe namespace block devices and that the numeric suffix on the character device

--- a/interfaces/builtin/block_devices.go
+++ b/interfaces/builtin/block_devices.go
@@ -69,7 +69,6 @@ const blockDevicesConnectedPlugAppArmor = `
 /dev/loop[0-9]{,[0-9],[0-9][0-9]} rwk,                     # loopback (up to 1000 devices)
 /dev/loop-control rw,                                      # loopback control
 /dev/zd[0-9]{,[0-9],[0-9][0-9]} rwk,                       # ZFS volumes (up to 1000 devices)
-/dev/zd[0-9]{,[0-9],[0-9][0-9]}{,p[0-9]{,[0-9]}} rwk,      # ZFS volumes (up to 1000 devices, 100 partitions)
 /dev/zfs rw,                                               # ZFS control
 
 # Allow /dev/nvmeXnY namespace block devices. Please note this grants access to all


### PR DESCRIPTION
ZFS is a versatile tool in managing block storage. Allowing ZFS vols as block-devices would enable additional scenarios for snaps (like MicroCeph) that need to deal with block storage. Specifically for MicroCeph it could be useful for testing and development scenarios where OSD block devices are expected without requiring actual physical disks.

Adding the /dev/zfs ioctrl device would enable snaps to automatically manage these volumes.