### PR TITLE
Add "jetbrains" to the whitelist of URL schemes handled by xdg-open

### DIFF
--- a/tests/main/xdg-open/task.yaml
+++ b/tests/main/xdg-open/task.yaml
@@ -90,6 +90,7 @@ execute: |
     ensure_xdg_open_output "slack://5NAPPY111/magic-login/bcaf81ee-07b1-4362-9c09-ff46bd6e1bb9"
     ensure_xdg_open_output "msteams://snapcraft.io"
     ensure_xdg_open_output "randomurl://foo.bar"
+    ensure_xdg_open_output "jetbrains://foo/bar.baz=/!@*&-=="
 
     # Ensure other schemes are not passed through
     rm /tmp/xdg-open-output

--- a/usersession/userd/launcher.go
+++ b/usersession/userd/launcher.go
@@ -96,9 +96,9 @@ var (
 		"https",
 		// jetbrains: the scheme allows specifying a link for Jetbrains Toolbox
 		//   for e.g. installing a plugin from a webpage or joining a remote IDE session
-        //   - scheme: jetbrains:...
-        //   - https://github.com/snapcore/snapd/pull/13070
-        "jetbrains",
+        	//   - scheme: jetbrains:...
+        	//   - https://github.com/snapcore/snapd/pull/13070
+        	"jetbrains",
 		// mailto: the scheme allows for specifying an email address
 		//   - scheme: mailto:foo@example.com
 		"mailto",

--- a/usersession/userd/launcher.go
+++ b/usersession/userd/launcher.go
@@ -94,6 +94,11 @@ var (
 		//   - scheme: http(s)://example.com
 		"http",
 		"https",
+		// jetbrains: the scheme allows specifying a link for Jetbrains Toolbox
+		//   for e.g. installing a plugin from a webpage or joining a remote IDE session
+        //   - scheme: jetbrains:...
+        //   - https://github.com/snapcore/snapd/pull/13070
+        "jetbrains",
 		// mailto: the scheme allows for specifying an email address
 		//   - scheme: mailto:foo@example.com
 		"mailto",

--- a/usersession/userd/launcher_test.go
+++ b/usersession/userd/launcher_test.go
@@ -87,7 +87,7 @@ func (s *launcherSuite) TestOpenURLWithNotAllowedScheme(c *C) {
 }
 
 func (s *launcherSuite) TestOpenURLWithAllowedSchemeHappy(c *C) {
-	for _, schema := range []string{"http", "https", "mailto", "snap", "help", "apt", "zoommtg", "zoomus", "zoomphonecall", "slack", "msteams"} {
+	for _, schema := range []string{"http", "https", "mailto", "snap", "help", "apt", "zoommtg", "zoomus", "zoomphonecall", "slack", "msteams", "jetbrains"} {
 		err := s.launcher.OpenURL(schema+"://snapcraft.io", ":some-dbus-sender")
 		c.Assert(err, IsNil)
 		c.Assert(s.mockXdgOpen.Calls(), DeepEquals, [][]string{


### PR DESCRIPTION
I based this PR on https://github.com/snapcore/snapd/pull/8254 to add Jetbrains Toolbox support