### PR TITLE
osutil: add support for symlinks to EnsureFileState

### DIFF
--- a/osutil/syncdir.go
+++ b/osutil/syncdir.go
@@ -34,7 +34,7 @@ type FileState interface {
 	State() (reader io.ReadCloser, size int64, mode os.FileMode, err error)
 }
 
-// SymlinkFileState describes the desired symlink by providing a target
+// SymlinkFileState describes the desired symlink by providing its target.
 type SymlinkFileState struct {
 	Target string
 }

--- a/osutil/syncdir.go
+++ b/osutil/syncdir.go
@@ -58,8 +58,8 @@ func (fref FileReference) State() (io.ReadCloser, int64, os.FileMode, error) {
 	if err != nil {
 		return nil, 0, os.FileMode(0), err
 	}
-	if err := checkFileType(fi.Mode()); err != nil {
-		return nil, 0, os.FileMode(0), err
+	if !fi.Mode().IsRegular() {
+		return nil, 0, os.FileMode(0), fmt.Errorf("internal error: only regular files are supported, got %q instead", fi.Mode().Type())
 	}
 	return file, fi.Size(), fi.Mode(), nil
 }
@@ -76,8 +76,8 @@ func (fcref FileReferencePlusMode) State() (io.ReadCloser, int64, os.FileMode, e
 	if err != nil {
 		return nil, 0, os.FileMode(0), err
 	}
-	if err := checkFileType(fcref.Mode); err != nil {
-		return nil, 0, os.FileMode(0), err
+	if !fcref.Mode.IsRegular() {
+		return nil, 0, os.FileMode(0), fmt.Errorf("internal error: only regular files are supported, got %q instead", fcref.Mode.Type())
 	}
 	return reader, size, fcref.Mode, nil
 }
@@ -90,8 +90,8 @@ type MemoryFileState struct {
 
 // State returns a reader of the in-memory contents of a file, along with other meta-data.
 func (blob *MemoryFileState) State() (io.ReadCloser, int64, os.FileMode, error) {
-	if err := checkFileType(blob.Mode); err != nil {
-		return nil, 0, os.FileMode(0), err
+	if !blob.Mode.IsRegular() {
+		return nil, 0, os.FileMode(0), fmt.Errorf("internal error: only regular files are supported, got %q instead", blob.Mode.Type())
 	}
 	return ioutil.NopCloser(bytes.NewReader(blob.Content)), int64(len(blob.Content)), blob.Mode, nil
 }

--- a/osutil/syncdir.go
+++ b/osutil/syncdir.go
@@ -34,6 +34,7 @@ type FileState interface {
 	State() (reader io.ReadCloser, size int64, mode os.FileMode, err error)
 }
 
+// SymlinkFileState describes the desired symlink by providing a target
 type SymlinkFileState struct {
 	Target string
 }

--- a/osutil/syncdir.go
+++ b/osutil/syncdir.go
@@ -308,11 +308,11 @@ func EnsureFileState(filePath string, state FileState) error {
 	if err != nil {
 		return err
 	}
-	switch mode.Type() {
-	case 0:
+	switch {
+	case mode.IsRegular():
 		return ensureRegularFileState(filePath, state)
-	case os.ModeSymlink:
+	case mode.Type() == os.ModeSymlink:
 		return ensureSymlinkFileState(filePath, state)
 	}
-	return fmt.Errorf("internal error: EnsureFileState does not support type: %q", mode.Type())
+	return fmt.Errorf("internal error: EnsureFileState does not support type %q", mode.Type())
 }

--- a/osutil/syncdir.go
+++ b/osutil/syncdir.go
@@ -96,13 +96,6 @@ func (blob *MemoryFileState) State() (io.ReadCloser, int64, os.FileMode, error) 
 	return ioutil.NopCloser(bytes.NewReader(blob.Content)), int64(len(blob.Content)), blob.Mode, nil
 }
 
-func checkFileType(mode os.FileMode) error {
-	if !mode.IsRegular() {
-		return fmt.Errorf("internal error: only regular files are supported, got %q instead", mode.Type())
-	}
-	return nil
-}
-
 // ErrSameState is returned when the state of a file has not changed.
 var ErrSameState = fmt.Errorf("file state has not changed")
 

--- a/osutil/syncdir.go
+++ b/osutil/syncdir.go
@@ -29,9 +29,29 @@ import (
 	"sort"
 )
 
+type FileStateType string
+
+const (
+	RegularFileStateType FileStateType = "regular"
+	SymlinkFileStateType FileStateType = "symlink"
+)
+
 // FileState is an interface for conveying the desired state of a some file.
 type FileState interface {
 	State() (reader io.ReadCloser, size int64, mode os.FileMode, err error)
+	Type() FileStateType
+}
+
+type SymlinkFileState struct {
+	Target string
+}
+
+func (sym SymlinkFileState) State() (io.ReadCloser, int64, os.FileMode, error) {
+	return ioutil.NopCloser(bytes.NewReader([]byte(sym.Target))), int64(len(sym.Target)), os.ModeSymlink, nil
+}
+
+func (sym SymlinkFileState) Type() FileStateType {
+	return SymlinkFileStateType
 }
 
 // FileReference describes the desired content by referencing an existing file.
@@ -52,6 +72,10 @@ func (fref FileReference) State() (io.ReadCloser, int64, os.FileMode, error) {
 	return file, fi.Size(), fi.Mode(), nil
 }
 
+func (fref FileReference) Type() FileStateType {
+	return RegularFileStateType
+}
+
 // FileReferencePlusMode describes the desired content by referencing an existing file and providing custom mode.
 type FileReferencePlusMode struct {
 	FileReference
@@ -67,6 +91,10 @@ func (fcref FileReferencePlusMode) State() (io.ReadCloser, int64, os.FileMode, e
 	return reader, size, fcref.Mode, nil
 }
 
+func (fcref FileReferencePlusMode) Type() FileStateType {
+	return RegularFileStateType
+}
+
 // MemoryFileState describes the desired content by providing an in-memory copy.
 type MemoryFileState struct {
 	Content []byte
@@ -76,6 +104,10 @@ type MemoryFileState struct {
 // State returns a reader of the in-memory contents of a file, along with other meta-data.
 func (blob *MemoryFileState) State() (io.ReadCloser, int64, os.FileMode, error) {
 	return ioutil.NopCloser(bytes.NewReader(blob.Content)), int64(len(blob.Content)), blob.Mode, nil
+}
+
+func (blob *MemoryFileState) Type() FileStateType {
+	return RegularFileStateType
 }
 
 // ErrSameState is returned when the state of a file has not changed.
@@ -108,6 +140,7 @@ var ErrSameState = fmt.Errorf("file state has not changed")
 //
 // In all cases, the function returns the first error it has encountered.
 func EnsureDirStateGlobs(dir string, globs []string, content map[string]FileState) (changed, removed []string, err error) {
+	// TODO: add tests for symlinks
 	// Check syntax before doing anything.
 	if _, index, err := matchAny(globs, "foo"); err != nil {
 		return nil, nil, fmt.Errorf("internal error: EnsureDirState got invalid pattern %q: %s", globs[index], err)
@@ -191,8 +224,8 @@ func EnsureDirState(dir string, glob string, content map[string]FileState) (chan
 	return EnsureDirStateGlobs(dir, []string{glob}, content)
 }
 
-// fileStateEqualTo returns whether the file exists in the expected state.
-func fileStateEqualTo(filePath string, state FileState) (bool, error) {
+// regularFileStateEqualTo returns whether the file exists in the expected state.
+func regularFileStateEqualTo(filePath string, state FileState) (bool, error) {
 	other := &FileReference{Path: filePath}
 
 	// Open views to both files so that we can compare them.
@@ -223,10 +256,8 @@ func fileStateEqualTo(filePath string, state FileState) (bool, error) {
 	return streamsEqualChunked(readerA, readerB, 0), nil
 }
 
-// EnsureFileState ensures that the file is in the expected state. It will not
-// attempt to remove the file if no content is provided.
-func EnsureFileState(filePath string, state FileState) error {
-	equal, err := fileStateEqualTo(filePath, state)
+func ensureRegularFileState(filePath string, state FileState) error {
+	equal, err := regularFileStateEqualTo(filePath, state)
 	if err != nil {
 		return err
 	}
@@ -239,4 +270,69 @@ func EnsureFileState(filePath string, state FileState) error {
 		return err
 	}
 	return AtomicWrite(filePath, reader, mode, 0)
+}
+
+// symlinkFileStateEqualTo returns whether the symlink exists in the expected state.
+func symlinkFileStateEqualTo(filePath string, state FileState) (bool, error) {
+	readerA, _, _, err := state.State()
+	if err != nil {
+		return false, err
+	}
+	defer readerA.Close()
+	buf, err := ioutil.ReadAll(readerA)
+	if err != nil {
+		return false, err
+	}
+	targetA := string(buf)
+
+	other, err := os.Lstat(filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Not existing is not an error
+			return false, nil
+		}
+		return false, err
+	}
+	if other.Mode().Type() != os.ModeSymlink {
+		return false, nil
+	}
+	targetB, err := os.Readlink(filePath)
+	if err != nil {
+		return false, err
+	}
+
+	return targetA == targetB, nil
+}
+
+func ensureSymlinkFileState(filePath string, state FileState) error {
+	equal, err := symlinkFileStateEqualTo(filePath, state)
+	if err != nil {
+		return err
+	}
+	if equal {
+		// Return a special error if the file doesn't need to be changed
+		return ErrSameState
+	}
+	reader, _, _, err := state.State()
+	if err != nil {
+		return err
+	}
+	buf, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return err
+	}
+	target := string(buf)
+	return AtomicSymlink(target, filePath)
+}
+
+// EnsureFileState ensures that the file is in the expected state. It will not
+// attempt to remove the file if no content is provided.
+func EnsureFileState(filePath string, state FileState) error {
+	switch state.Type() {
+	case RegularFileStateType:
+		return ensureRegularFileState(filePath, state)
+	case SymlinkFileStateType:
+		return ensureSymlinkFileState(filePath, state)
+	}
+	return fmt.Errorf("internal error: unknown FileStateType %q", state.Type())
 }

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -2428,5 +2428,5 @@ func (s *systemdErrorSuite) TestEnsureMountUnitFileEnsureFileStateErr(c *C) {
 	c.Assert(err, IsNil)
 
 	_, err = New(SystemMode, nil).EnsureMountUnitFile("foo", "42", mockSnapPath, "/snap/snapname/123", "squashfs")
-	c.Assert(err, ErrorMatches, `rename .*/etc/systemd/system/snap-snapname-123.mount.* .*/etc/systemd/system/snap-snapname-123.mount: file exists`)
+	c.Assert(err, ErrorMatches, fmt.Sprintf("internal error: only regular files are supported, got %q instead", os.ModeDir))
 }


### PR DESCRIPTION
This is part of the preparation for using `Ensure*` functions instead of `Add*` functions in `backend.LinkSnap` and `backend.UnlinkSnap`.

This is needed when replacing snap binaries as they are symlinks to `/usr/bin/snap`.
For more context: #13066

**Note: by adding support for symlinks to `EnsureFileSate` the other `Ensure*` functions also grow the feature.**