### PR TITLE
wrappers: use `Ensure` in snap linking operations for snap binaries/icons/desktop files

### DIFF
--- a/osutil/syncdir.go
+++ b/osutil/syncdir.go
@@ -29,9 +29,29 @@ import (
 	"sort"
 )
 
+type FileStateType string
+
+const (
+	RegularFileStateType FileStateType = "regular"
+	SymlinkFileStateType FileStateType = "symlink"
+)
+
 // FileState is an interface for conveying the desired state of a some file.
 type FileState interface {
 	State() (reader io.ReadCloser, size int64, mode os.FileMode, err error)
+	Type() FileStateType
+}
+
+type SymlinkFileState struct {
+	Target string
+}
+
+func (sym SymlinkFileState) State() (io.ReadCloser, int64, os.FileMode, error) {
+	return ioutil.NopCloser(bytes.NewReader([]byte(sym.Target))), int64(len(sym.Target)), os.ModeSymlink, nil
+}
+
+func (sym SymlinkFileState) Type() FileStateType {
+	return SymlinkFileStateType
 }
 
 // FileReference describes the desired content by referencing an existing file.
@@ -52,6 +72,10 @@ func (fref FileReference) State() (io.ReadCloser, int64, os.FileMode, error) {
 	return file, fi.Size(), fi.Mode(), nil
 }
 
+func (fref FileReference) Type() FileStateType {
+	return RegularFileStateType
+}
+
 // FileReferencePlusMode describes the desired content by referencing an existing file and providing custom mode.
 type FileReferencePlusMode struct {
 	FileReference
@@ -67,6 +91,10 @@ func (fcref FileReferencePlusMode) State() (io.ReadCloser, int64, os.FileMode, e
 	return reader, size, fcref.Mode, nil
 }
 
+func (fcref FileReferencePlusMode) Type() FileStateType {
+	return RegularFileStateType
+}
+
 // MemoryFileState describes the desired content by providing an in-memory copy.
 type MemoryFileState struct {
 	Content []byte
@@ -76,6 +104,10 @@ type MemoryFileState struct {
 // State returns a reader of the in-memory contents of a file, along with other meta-data.
 func (blob *MemoryFileState) State() (io.ReadCloser, int64, os.FileMode, error) {
 	return ioutil.NopCloser(bytes.NewReader(blob.Content)), int64(len(blob.Content)), blob.Mode, nil
+}
+
+func (blob *MemoryFileState) Type() FileStateType {
+	return RegularFileStateType
 }
 
 // ErrSameState is returned when the state of a file has not changed.
@@ -108,6 +140,7 @@ var ErrSameState = fmt.Errorf("file state has not changed")
 //
 // In all cases, the function returns the first error it has encountered.
 func EnsureDirStateGlobs(dir string, globs []string, content map[string]FileState) (changed, removed []string, err error) {
+	// TODO: add tests for symlinks
 	// Check syntax before doing anything.
 	if _, index, err := matchAny(globs, "foo"); err != nil {
 		return nil, nil, fmt.Errorf("internal error: EnsureDirState got invalid pattern %q: %s", globs[index], err)
@@ -191,8 +224,8 @@ func EnsureDirState(dir string, glob string, content map[string]FileState) (chan
 	return EnsureDirStateGlobs(dir, []string{glob}, content)
 }
 
-// fileStateEqualTo returns whether the file exists in the expected state.
-func fileStateEqualTo(filePath string, state FileState) (bool, error) {
+// regularFileStateEqualTo returns whether the file exists in the expected state.
+func regularFileStateEqualTo(filePath string, state FileState) (bool, error) {
 	other := &FileReference{Path: filePath}
 
 	// Open views to both files so that we can compare them.
@@ -223,10 +256,8 @@ func fileStateEqualTo(filePath string, state FileState) (bool, error) {
 	return streamsEqualChunked(readerA, readerB, 0), nil
 }
 
-// EnsureFileState ensures that the file is in the expected state. It will not
-// attempt to remove the file if no content is provided.
-func EnsureFileState(filePath string, state FileState) error {
-	equal, err := fileStateEqualTo(filePath, state)
+func ensureRegularFileState(filePath string, state FileState) error {
+	equal, err := regularFileStateEqualTo(filePath, state)
 	if err != nil {
 		return err
 	}
@@ -239,4 +270,69 @@ func EnsureFileState(filePath string, state FileState) error {
 		return err
 	}
 	return AtomicWrite(filePath, reader, mode, 0)
+}
+
+// symlinkFileStateEqualTo returns whether the symlink exists in the expected state.
+func symlinkFileStateEqualTo(filePath string, state FileState) (bool, error) {
+	readerA, _, _, err := state.State()
+	if err != nil {
+		return false, err
+	}
+	defer readerA.Close()
+	buf, err := ioutil.ReadAll(readerA)
+	if err != nil {
+		return false, err
+	}
+	targetA := string(buf)
+
+	other, err := os.Lstat(filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Not existing is not an error
+			return false, nil
+		}
+		return false, err
+	}
+	if other.Mode().Type() != os.ModeSymlink {
+		return false, nil
+	}
+	targetB, err := os.Readlink(filePath)
+	if err != nil {
+		return false, err
+	}
+
+	return targetA == targetB, nil
+}
+
+func ensureSymlinkFileState(filePath string, state FileState) error {
+	equal, err := symlinkFileStateEqualTo(filePath, state)
+	if err != nil {
+		return err
+	}
+	if equal {
+		// Return a special error if the file doesn't need to be changed
+		return ErrSameState
+	}
+	reader, _, _, err := state.State()
+	if err != nil {
+		return err
+	}
+	buf, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return err
+	}
+	target := string(buf)
+	return AtomicSymlink(target, filePath)
+}
+
+// EnsureFileState ensures that the file is in the expected state. It will not
+// attempt to remove the file if no content is provided.
+func EnsureFileState(filePath string, state FileState) error {
+	switch state.Type() {
+	case RegularFileStateType:
+		return ensureRegularFileState(filePath, state)
+	case SymlinkFileStateType:
+		return ensureSymlinkFileState(filePath, state)
+	}
+	return fmt.Errorf("internal error: unknown FileStateType %q", state.Type())
 }

--- a/overlord/snapstate/backend/link.go
+++ b/overlord/snapstate/backend/link.go
@@ -232,7 +232,7 @@ func (b Backend) generateWrappers(s *snap.Info, linkCtx LinkContext) error {
 	cleanupFuncs = append(cleanupFuncs, wrappers.RemoveSnapDesktopFiles)
 
 	// add the desktop icons
-	if err = wrappers.AddSnapIcons(s); err != nil {
+	if err = wrappers.EnsureSnapIcons(s); err != nil {
 		return err
 	}
 	cleanupFuncs = append(cleanupFuncs, wrappers.RemoveSnapIcons)

--- a/overlord/snapstate/backend/link.go
+++ b/overlord/snapstate/backend/link.go
@@ -226,7 +226,7 @@ func (b Backend) generateWrappers(s *snap.Info, linkCtx LinkContext) error {
 	cleanupFuncs = append(cleanupFuncs, wrappers.RemoveSnapDBusActivationFiles)
 
 	// add the desktop files
-	if err = wrappers.AddSnapDesktopFiles(s); err != nil {
+	if err = wrappers.EnsureSnapDesktopFiles(s); err != nil {
 		return err
 	}
 	cleanupFuncs = append(cleanupFuncs, wrappers.RemoveSnapDesktopFiles)

--- a/overlord/snapstate/backend/link.go
+++ b/overlord/snapstate/backend/link.go
@@ -200,7 +200,7 @@ func (b Backend) generateWrappers(s *snap.Info, linkCtx LinkContext) error {
 	}
 
 	// add the CLI apps from the snap.yaml
-	if err = wrappers.AddSnapBinaries(s); err != nil {
+	if err = wrappers.EnsureSnapBinaries(nil, s); err != nil {
 		return err
 	}
 	cleanupFuncs = append(cleanupFuncs, wrappers.RemoveSnapBinaries)

--- a/wrappers/binaries_test.go
+++ b/wrappers/binaries_test.go
@@ -84,6 +84,26 @@ const packageHello = packageHelloNoSrv + `
   daemon: forking
 `
 
+const packageHelloNoSrvV2 = `name: hello-snap
+version: 1.11
+summary: hello
+description: Hello...
+apps:
+ hello:
+   command: bin/hello
+ universe:
+   command: bin/universe
+   completer: universe-completer.sh
+`
+
+const packageHelloV2 = packageHelloNoSrvV2 + `
+ svc1:
+  command: bin/hello
+  stop-command: bin/goodbye
+  post-stop-command: bin/missya
+  daemon: forking
+`
+
 func (s *binariesTestSuite) TestAddSnapBinariesAndRemove(c *C) {
 	// no completers support -> no problem \o/
 	c.Assert(osutil.FileExists(dirs.CompletersDir), Equals, false)
@@ -91,7 +111,14 @@ func (s *binariesTestSuite) TestAddSnapBinariesAndRemove(c *C) {
 	s.testAddSnapBinariesAndRemove(c, false, false)
 }
 
-func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveUseLegacy(c *C) {
+func (s *binariesTestSuite) TestEnsureSnapBinariesAndRemove(c *C) {
+	// no completers support -> no problem \o/
+	c.Assert(osutil.FileExists(dirs.CompletersDir), Equals, false)
+
+	s.testEnsureSnapBinariesAndRemove(c, false, false)
+}
+
+func (s *binariesTestSuite) prepareUseLegacy(c *C) {
 	c.Assert(os.MkdirAll(dirs.CompletersDir, 0755), IsNil)
 	if s.base == "core-with-snapd" {
 		c.Check(os.MkdirAll(filepath.Join(dirs.SnapMountDir, "snapd/current/usr/lib/snapd"), 0755), IsNil)
@@ -101,11 +128,19 @@ func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveUseLegacy(c *C) {
 	c.Assert(err, IsNil)
 	f.Write([]byte("#\n#   RELEASE: 2.1\n"))
 	f.Close()
+}
 
+func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveUseLegacy(c *C) {
+	s.prepareUseLegacy(c)
 	s.testAddSnapBinariesAndRemove(c, true, false)
 }
 
-func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveOldButNotThatOld(c *C) {
+func (s *binariesTestSuite) TestEnsureSnapBinariesAndRemoveUseLegacy(c *C) {
+	s.prepareUseLegacy(c)
+	s.testEnsureSnapBinariesAndRemove(c, true, false)
+}
+
+func (s *binariesTestSuite) prepareOldButNotThatOld(c *C) {
 	c.Assert(os.MkdirAll(dirs.CompletersDir, 0755), IsNil)
 	if s.base == "core-with-snapd" {
 		c.Check(os.MkdirAll(filepath.Join(dirs.SnapMountDir, "snapd/current/usr/lib/snapd"), 0755), IsNil)
@@ -115,11 +150,19 @@ func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveOldButNotThatOld(c *C) {
 	c.Assert(err, IsNil)
 	f.Write([]byte("#\n#   RELEASE: 2.2\n"))
 	f.Close()
+}
 
+func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveOldButNotThatOld(c *C) {
+	s.prepareOldButNotThatOld(c)
 	s.testAddSnapBinariesAndRemove(c, false, false)
 }
 
-func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveUnknownVersion(c *C) {
+func (s *binariesTestSuite) TestEnsureSnapBinariesAndRemoveOldButNotThatOld(c *C) {
+	s.prepareOldButNotThatOld(c)
+	s.testEnsureSnapBinariesAndRemove(c, false, false)
+}
+
+func (s *binariesTestSuite) prepareUnknownVersion(c *C) {
 	c.Assert(os.MkdirAll(dirs.CompletersDir, 0755), IsNil)
 	if s.base == "core-with-snapd" {
 		c.Check(os.MkdirAll(filepath.Join(dirs.SnapMountDir, "snapd/current/usr/lib/snapd"), 0755), IsNil)
@@ -128,31 +171,56 @@ func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveUnknownVersion(c *C) {
 	f, err := os.OpenFile(dirs.BashCompletionScript, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0644)
 	c.Assert(err, IsNil)
 	f.Close()
+}
 
+func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveUnknownVersion(c *C) {
+	s.prepareUnknownVersion(c)
 	s.testAddSnapBinariesAndRemove(c, false, true)
 }
 
-func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveNotInstalled(c *C) {
+func (s *binariesTestSuite) TestEnsureSnapBinariesAndRemoveUnknownVersion(c *C) {
+	s.prepareUnknownVersion(c)
+	s.testEnsureSnapBinariesAndRemove(c, false, true)
+}
+
+func (s *binariesTestSuite) prepareNotInstalled(c *C) {
 	c.Assert(os.MkdirAll(dirs.CompletersDir, 0755), IsNil)
 	if s.base == "core-with-snapd" {
 		c.Check(os.MkdirAll(filepath.Join(dirs.SnapMountDir, "snapd/current/usr/lib/snapd"), 0755), IsNil)
 	}
 
 	c.Assert(os.Remove(dirs.BashCompletionScript), IsNil)
+}
 
+func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveNotInstalled(c *C) {
+	s.prepareNotInstalled(c)
 	s.testAddSnapBinariesAndRemove(c, false, true)
 }
 
-func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveWithCompleters(c *C) {
+func (s *binariesTestSuite) TestEnsureSnapBinariesAndRemoveNotInstalled(c *C) {
+	s.prepareNotInstalled(c)
+	s.testEnsureSnapBinariesAndRemove(c, false, true)
+}
+
+func (s *binariesTestSuite) prepareWithCompleters(c *C) {
 	c.Assert(os.MkdirAll(dirs.CompletersDir, 0755), IsNil)
 	if s.base == "core-with-snapd" {
 		c.Check(os.MkdirAll(filepath.Join(dirs.SnapMountDir, "snapd/current/usr/lib/snapd"), 0755), IsNil)
 	}
 	c.Assert(os.MkdirAll(filepath.Dir(dirs.CompleteShPath(s.base)), 0755), IsNil)
 	c.Assert(ioutil.WriteFile(dirs.CompleteShPath(s.base), nil, 0644), IsNil)
-	// full completers support -> we get completers \o/
+}
 
+func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveWithCompleters(c *C) {
+	s.prepareWithCompleters(c)
+	// full completers support -> we get completers \o/
 	s.testAddSnapBinariesAndRemove(c, false, false)
+}
+
+func (s *binariesTestSuite) TestEnsureSnapBinariesAndRemoveWithCompleters(c *C) {
+	s.prepareWithCompleters(c)
+	// full completers support -> we get completers \o/
+	s.testEnsureSnapBinariesAndRemove(c, false, false)
 }
 
 func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveWithLegacyCompleters(c *C) {
@@ -170,7 +238,7 @@ func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveWithLegacyCompleters(c *
 
 func (s *binariesTestSuite) TestRemoveWithLegacyCompleters(c *C) {
 	info := snaptest.MockSnap(c, packageHello+"base: "+s.base+"\n", &snap.SideInfo{Revision: snap.R(11)})
-	err := wrappers.AddSnapBinaries(info)
+	err := s.addSnapBinaries(info)
 	c.Assert(err, IsNil)
 
 	// Simulate legacy installation
@@ -188,7 +256,7 @@ func (s *binariesTestSuite) TestRemoveWithLegacyCompleters(c *C) {
 	c.Assert(osutil.IsSymlink(legacyCompleter), Equals, false)
 }
 
-func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveWithExistingCompleters(c *C) {
+func (s *binariesTestSuite) prepareWithExistingCompleters(c *C) {
 	c.Assert(os.MkdirAll(dirs.CompletersDir, 0755), IsNil)
 	if s.base == "core-with-snapd" {
 		c.Check(os.MkdirAll(filepath.Join(dirs.SnapMountDir, "snapd/current/usr/lib/snapd"), 0755), IsNil)
@@ -197,8 +265,21 @@ func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveWithExistingCompleters(c
 	c.Assert(ioutil.WriteFile(dirs.CompleteShPath(s.base), nil, 0644), IsNil)
 	// existing completers -> they're left alone \o/
 	c.Assert(ioutil.WriteFile(filepath.Join(dirs.CompletersDir, "hello-snap.world"), nil, 0644), IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(dirs.CompletersDir, "hello-snap.universe"), nil, 0644), IsNil)
+}
 
+func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveWithExistingCompleters(c *C) {
+	s.prepareWithExistingCompleters(c)
 	s.testAddSnapBinariesAndRemove(c, false, false)
+}
+
+func (s *binariesTestSuite) TestEnsureSnapBinariesAndRemoveWithExistingCompleters(c *C) {
+	s.prepareWithExistingCompleters(c)
+	s.testEnsureSnapBinariesAndRemove(c, false, false)
+}
+
+func (s *binariesTestSuite) addSnapBinaries(info *snap.Info) error {
+	return wrappers.EnsureSnapBinaries(nil, info)
 }
 
 func (s *binariesTestSuite) testAddSnapBinariesAndRemove(c *C, useLegacy bool, disabledCompletion bool) {
@@ -209,7 +290,7 @@ func (s *binariesTestSuite) testAddSnapBinariesAndRemove(c *C, useLegacy bool, d
 	}
 	completerExisted := osutil.FileExists(completer)
 
-	err := wrappers.AddSnapBinaries(info)
+	err := s.addSnapBinaries(info)
 	c.Assert(err, IsNil)
 
 	bins := []string{"hello-snap.hello", "hello-snap.world"}
@@ -234,6 +315,7 @@ func (s *binariesTestSuite) testAddSnapBinariesAndRemove(c *C, useLegacy bool, d
 
 		if completerExisted {
 			// there was a completer there before, so it should _not_ be a symlink to our complete.sh
+			c.Check(osutil.FileExists(completer), Equals, true)
 			c.Assert(osutil.IsSymlink(completer), Equals, false)
 		} else {
 			target, err := os.Readlink(completer)
@@ -259,6 +341,89 @@ func (s *binariesTestSuite) testAddSnapBinariesAndRemove(c *C, useLegacy bool, d
 	c.Check(osutil.FileExists(completer), Equals, completerExisted)
 }
 
+func (s *binariesTestSuite) testEnsureSnapBinariesAndRemove(c *C, useLegacy bool, disabledCompletion bool) {
+	oldInfo := snaptest.MockSnap(c, packageHello+"base: "+s.base+"\n", &snap.SideInfo{Revision: snap.R(11)})
+	oldCompleter := filepath.Join(dirs.CompletersDir, "hello-snap.world")
+	if useLegacy {
+		oldCompleter = filepath.Join(dirs.LegacyCompletersDir, "hello-snap.world")
+	}
+	oldCompleterExisted := osutil.FileExists(oldCompleter)
+	err := s.addSnapBinaries(oldInfo)
+	c.Assert(err, IsNil)
+
+	newInfo := snaptest.MockSnap(c, packageHelloV2+"base: "+s.base+"\n", &snap.SideInfo{Revision: snap.R(12)})
+	newCompleter := filepath.Join(dirs.CompletersDir, "hello-snap.universe")
+	if useLegacy {
+		newCompleter = filepath.Join(dirs.LegacyCompletersDir, "hello-snap.universe")
+	}
+	newCompleterExisted := osutil.FileExists(newCompleter)
+	err = wrappers.EnsureSnapBinaries(oldInfo, newInfo)
+	c.Assert(err, IsNil)
+
+	binsAdded := []string{"hello-snap.hello", "hello-snap.universe"}
+	binsRemoved := []string{"hello-snap.world"}
+
+	for _, bin := range binsAdded {
+		link := filepath.Join(dirs.SnapBinariesDir, bin)
+		target, err := os.Readlink(link)
+		c.Assert(err, IsNil, Commentf(bin))
+		c.Check(target, Equals, "/usr/bin/snap", Commentf(bin))
+	}
+
+	for _, bin := range binsRemoved {
+		link := filepath.Join(dirs.SnapBinariesDir, bin)
+		c.Check(osutil.FileExists(link), Equals, false, Commentf(bin))
+	}
+
+	compDir := dirs.CompletersDir
+	if useLegacy {
+		compDir = dirs.LegacyCompletersDir
+	}
+
+	if oldCompleterExisted {
+		// there was a completer there before, so it should _not_ be removed or be a symlink to our complete.sh
+		c.Check(osutil.FileExists(oldCompleter), Equals, true)
+		c.Check(osutil.IsSymlink(oldCompleter), Equals, false)
+	} else {
+		// we created this completer, old revision completer should be removed
+		c.Check(osutil.FileExists(oldCompleter), Equals, false)
+	}
+
+	if disabledCompletion {
+		c.Assert(osutil.FileExists(dirs.CompleteShPath(s.base)), Equals, false)
+		c.Assert(osutil.IsSymlink(filepath.Join(dirs.CompletersDir, "hello-snap.universe")), Equals, false)
+		c.Assert(osutil.IsSymlink(filepath.Join(dirs.LegacyCompletersDir, "hello-snap.universe")), Equals, false)
+	} else if osutil.FileExists(dirs.CompleteShPath(s.base)) {
+		c.Assert(osutil.IsDirectory(compDir), Equals, true)
+
+		if newCompleterExisted {
+			// there was a completer there before, so it should _not_ be a symlink to our complete.sh
+			c.Check(osutil.FileExists(newCompleter), Equals, true)
+			c.Assert(osutil.IsSymlink(newCompleter), Equals, false)
+		} else {
+			target, err := os.Readlink(newCompleter)
+			c.Assert(err, IsNil)
+			c.Check(target, Equals, dirs.CompleteShPath(s.base))
+		}
+	}
+
+	if !disabledCompletion && !useLegacy {
+		legacyCompleter := filepath.Join(dirs.LegacyCompletersDir, "hello-snap.universe")
+		c.Assert(osutil.IsSymlink(legacyCompleter), Equals, false)
+	}
+
+	err = wrappers.RemoveSnapBinaries(newInfo)
+	c.Assert(err, IsNil)
+
+	for _, bin := range binsAdded {
+		link := filepath.Join(dirs.SnapBinariesDir, bin)
+		c.Check(osutil.FileExists(link), Equals, false, Commentf(bin))
+	}
+
+	// we left the existing completer alone, but removed it otherwise
+	c.Check(osutil.FileExists(newCompleter), Equals, newCompleterExisted)
+}
+
 func (s *binariesTestSuite) TestAddSnapBinariesCleansUpOnFailure(c *C) {
 	link := filepath.Join(dirs.SnapBinariesDir, "hello-snap.hello")
 	c.Assert(osutil.FileExists(link), Equals, false)
@@ -269,7 +434,7 @@ func (s *binariesTestSuite) TestAddSnapBinariesCleansUpOnFailure(c *C) {
   command: bin/bye
 `, &snap.SideInfo{Revision: snap.R(11)})
 
-	err := wrappers.AddSnapBinaries(info)
+	err := s.addSnapBinaries(info)
 	c.Assert(err, NotNil)
 
 	c.Check(osutil.FileExists(link), Equals, false)

--- a/wrappers/desktop.go
+++ b/wrappers/desktop.go
@@ -235,50 +235,65 @@ func updateDesktopDatabase(desktopFiles []string) error {
 	return nil
 }
 
-// AddSnapDesktopFiles puts in place the desktop files for the applications from the snap.
-func AddSnapDesktopFiles(s *snap.Info) (err error) {
-	var created []string
-	defer func() {
-		if err == nil {
-			return
-		}
-
-		for _, fn := range created {
-			os.Remove(fn)
-		}
-	}()
-
-	if err := os.MkdirAll(dirs.SnapDesktopFilesDir, 0755); err != nil {
-		return err
+func findDesktopFiles(rootDir string) ([]string, error) {
+	if !osutil.IsDirectory(rootDir) {
+		return nil, nil
 	}
-
-	baseDir := s.MountDir()
-
-	desktopFiles, err := filepath.Glob(filepath.Join(baseDir, "meta", "gui", "*.desktop"))
+	desktopFiles, err := filepath.Glob(filepath.Join(rootDir, "*.desktop"))
 	if err != nil {
-		return fmt.Errorf("cannot get desktop files for %v: %s", baseDir, err)
+		return nil, fmt.Errorf("cannot get desktop files from %v: %s", rootDir, err)
 	}
+	return desktopFiles, nil
+}
 
+func deriveDesktopFilesContent(s *snap.Info, desktopFiles []string) (map[string]osutil.FileState, error) {
+	content := make(map[string]osutil.FileState)
 	for _, df := range desktopFiles {
-		content, err := ioutil.ReadFile(df)
+		base := filepath.Base(df)
+		fileContent, err := ioutil.ReadFile(df)
 		if err != nil {
-			return err
+			return nil, err
 		}
-
 		// FIXME: don't blindly use the snap desktop filename, mangle it
 		// but we can't just use the app name because a desktop file
 		// may call the same app with multiple parameters, e.g.
 		// --create-new, --open-existing etc
-		installedDesktopFileName := filepath.Join(dirs.SnapDesktopFilesDir, fmt.Sprintf("%s_%s", s.DesktopPrefix(), filepath.Base(df)))
-		content = sanitizeDesktopFile(s, installedDesktopFileName, content)
-		if err := osutil.AtomicWriteFile(installedDesktopFileName, content, 0755, 0); err != nil {
-			return err
+		base = fmt.Sprintf("%s_%s", s.DesktopPrefix(), base)
+		installedDesktopFileName := filepath.Join(dirs.SnapDesktopFilesDir, base)
+		fileContent = sanitizeDesktopFile(s, installedDesktopFileName, fileContent)
+		content[base] = &osutil.MemoryFileState{
+			Content: fileContent,
+			Mode:    0755,
 		}
-		created = append(created, installedDesktopFileName)
+	}
+	return content, nil
+}
+
+func EnsureSnapDesktopFiles(s *snap.Info) error {
+	// TODO: Add nil check?
+	if err := os.MkdirAll(dirs.SnapDesktopFilesDir, 0755); err != nil {
+		return err
+	}
+
+	rootDir := filepath.Join(s.MountDir(), "meta", "gui")
+	desktopFiles, err := findDesktopFiles(rootDir)
+	if err != nil {
+		return err
+	}
+
+	content, err := deriveDesktopFilesContent(s, desktopFiles)
+	if err != nil {
+		return err
+	}
+
+	desktopFilesGlob := fmt.Sprintf("%s_*.desktop", s.DesktopPrefix())
+	changed, removed, err := osutil.EnsureDirState(dirs.SnapDesktopFilesDir, desktopFilesGlob, content)
+	if err != nil {
+		return err
 	}
 
 	// updates mime info etc
-	if err := updateDesktopDatabase(desktopFiles); err != nil {
+	if err := updateDesktopDatabase(append(changed, removed...)); err != nil {
 		return err
 	}
 
@@ -287,24 +302,18 @@ func AddSnapDesktopFiles(s *snap.Info) (err error) {
 
 // RemoveSnapDesktopFiles removes the added desktop files for the applications in the snap.
 func RemoveSnapDesktopFiles(s *snap.Info) error {
-	removedDesktopFiles := make([]string, 0, len(s.Apps))
-
-	desktopFiles, err := filepath.Glob(filepath.Join(dirs.SnapDesktopFilesDir, fmt.Sprintf("%s_*.desktop", s.DesktopPrefix())))
-	if err != nil {
+	if !osutil.IsDirectory(dirs.SnapDesktopFilesDir) {
 		return nil
 	}
-	for _, df := range desktopFiles {
-		if err := os.Remove(df); err != nil {
-			if !os.IsNotExist(err) {
-				return err
-			}
-		} else {
-			removedDesktopFiles = append(removedDesktopFiles, df)
-		}
+
+	desktopFilesGlob := fmt.Sprintf("%s_*.desktop", s.DesktopPrefix())
+	_, removed, err := osutil.EnsureDirState(dirs.SnapDesktopFilesDir, desktopFilesGlob, nil)
+	if err != nil {
+		return err
 	}
 
 	// updates mime info etc
-	if err := updateDesktopDatabase(removedDesktopFiles); err != nil {
+	if err := updateDesktopDatabase(removed); err != nil {
 		return err
 	}
 

--- a/wrappers/desktop_test.go
+++ b/wrappers/desktop_test.go
@@ -72,26 +72,32 @@ var mockDesktopFile = []byte(`
 Name=foo
 Icon=${SNAP}/foo.png`)
 
-func (s *desktopSuite) TestAddPackageDesktopFiles(c *C) {
+func (s *desktopSuite) TestEnsurePackageDesktopFiles(c *C) {
 	expectedDesktopFilePath := filepath.Join(dirs.SnapDesktopFilesDir, "foo_foobar.desktop")
 	c.Assert(osutil.FileExists(expectedDesktopFilePath), Equals, false)
+
+	oldDesktopFilePath := filepath.Join(dirs.SnapDesktopFilesDir, "foo_foobar2.desktop")
+	c.Assert(os.MkdirAll(dirs.SnapDesktopFilesDir, 0755), IsNil)
+	c.Assert(ioutil.WriteFile(oldDesktopFilePath, mockDesktopFile, 0644), IsNil)
+	c.Assert(osutil.FileExists(oldDesktopFilePath), Equals, true)
 
 	info := snaptest.MockSnap(c, desktopAppYaml, &snap.SideInfo{Revision: snap.R(11)})
 
 	// generate .desktop file in the package baseDir
 	baseDir := info.MountDir()
-	err := os.MkdirAll(filepath.Join(baseDir, "meta", "gui"), 0755)
-	c.Assert(err, IsNil)
+	c.Assert(os.MkdirAll(filepath.Join(baseDir, "meta", "gui"), 0755), IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(baseDir, "meta", "gui", "foobar.desktop"), mockDesktopFile, 0644), IsNil)
 
-	err = ioutil.WriteFile(filepath.Join(baseDir, "meta", "gui", "foobar.desktop"), mockDesktopFile, 0644)
-	c.Assert(err, IsNil)
-
-	err = wrappers.AddSnapDesktopFiles(info)
+	err := wrappers.EnsureSnapDesktopFiles(info)
 	c.Assert(err, IsNil)
 	c.Assert(osutil.FileExists(expectedDesktopFilePath), Equals, true)
 	c.Assert(s.mockUpdateDesktopDatabase.Calls(), DeepEquals, [][]string{
 		{"update-desktop-database", dirs.SnapDesktopFilesDir},
 	})
+	sanitizedDesktopFileContent := wrappers.SanitizeDesktopFile(info, expectedDesktopFilePath, mockDesktopFile)
+	c.Check(expectedDesktopFilePath, testutil.FileContains, sanitizedDesktopFileContent)
+	// Old desktop file should be removed
+	c.Assert(osutil.FileExists(oldDesktopFilePath), Equals, false)
 }
 
 func (s *desktopSuite) TestRemovePackageDesktopFiles(c *C) {
@@ -151,7 +157,7 @@ func (s *desktopSuite) TestParallelInstancesRemovePackageDesktopFiles(c *C) {
 	c.Assert(osutil.FileExists(mockDesktopFilePath), Equals, true)
 }
 
-func (s *desktopSuite) TestAddPackageDesktopFilesCleanup(c *C) {
+func (s *desktopSuite) TestEnsurePackageDesktopFilesCleanup(c *C) {
 	mockDesktopFilePath := filepath.Join(dirs.SnapDesktopFilesDir, "foo_foobar1.desktop")
 	c.Assert(osutil.FileExists(mockDesktopFilePath), Equals, false)
 
@@ -177,7 +183,7 @@ func (s *desktopSuite) TestAddPackageDesktopFilesCleanup(c *C) {
 	err = ioutil.WriteFile(filepath.Join(baseDir, "meta", "gui", "foobar2.desktop"), mockDesktopFile, 0644)
 	c.Assert(err, IsNil)
 
-	err = wrappers.AddSnapDesktopFiles(info)
+	err = wrappers.EnsureSnapDesktopFiles(info)
 	c.Check(err, NotNil)
 	c.Check(osutil.FileExists(mockDesktopFilePath), Equals, false)
 	c.Check(s.mockUpdateDesktopDatabase.Calls(), HasLen, 0)
@@ -574,7 +580,7 @@ func (s *desktopSuite) TestAddRemoveDesktopFiles(c *C) {
 		err = ioutil.WriteFile(filepath.Join(baseDir, "meta", "gui", t.upstreamDesktopFileName), mockDesktopFile, 0644)
 		c.Assert(err, IsNil)
 
-		err = wrappers.AddSnapDesktopFiles(info)
+		err = wrappers.EnsureSnapDesktopFiles(info)
 		c.Assert(err, IsNil)
 		c.Assert(osutil.FileExists(expectedDesktopFilePath), Equals, true)
 

--- a/wrappers/icons.go
+++ b/wrappers/icons.go
@@ -91,7 +91,8 @@ func deriveIconContent(instanceName string, rootDir string, icons []string) (con
 	return content, nil
 }
 
-func AddSnapIcons(s *snap.Info) error {
+func EnsureSnapIcons(s *snap.Info) error {
+	// TODO: Add nil check?
 	if err := os.MkdirAll(dirs.SnapDesktopIconsDir, 0755); err != nil {
 		return err
 	}

--- a/wrappers/icons_test.go
+++ b/wrappers/icons_test.go
@@ -78,7 +78,7 @@ func (s *iconsTestSuite) TestFindIconFiles(c *C) {
 	})
 }
 
-func (s *iconsTestSuite) TestAddSnapIcons(c *C) {
+func (s *iconsTestSuite) TestEnsureSnapIcons(c *C) {
 	info := snaptest.MockSnap(c, packageHello, &snap.SideInfo{Revision: snap.R(11)})
 
 	baseDir := info.MountDir()
@@ -86,9 +86,16 @@ func (s *iconsTestSuite) TestAddSnapIcons(c *C) {
 	c.Assert(os.MkdirAll(filepath.Join(iconsDir, "hicolor", "scalable", "apps"), 0755), IsNil)
 	c.Assert(ioutil.WriteFile(filepath.Join(iconsDir, "hicolor", "scalable", "apps", "snap.hello-snap.foo.svg"), []byte("scalable"), 0644), IsNil)
 
-	c.Assert(wrappers.AddSnapIcons(info), IsNil)
+	c.Assert(os.MkdirAll(filepath.Join(dirs.SnapDesktopIconsDir, "hicolor", "scalable", "apps"), 0755), IsNil)
+	oldIconFile := filepath.Join(dirs.SnapDesktopIconsDir, "hicolor", "scalable", "apps", "snap.hello-snap.bar.svg")
+	c.Assert(ioutil.WriteFile(oldIconFile, []byte("scalable"), 0644), IsNil)
+
+	c.Assert(wrappers.EnsureSnapIcons(info), IsNil)
 	iconFile := filepath.Join(dirs.SnapDesktopIconsDir, "hicolor", "scalable", "apps", "snap.hello-snap.foo.svg")
 	c.Check(iconFile, testutil.FileEquals, "scalable")
+
+	// Old icon should be removed
+	c.Check(oldIconFile, testutil.FileAbsent)
 }
 
 func (s *iconsTestSuite) TestRemoveSnapIcons(c *C) {
@@ -102,7 +109,7 @@ func (s *iconsTestSuite) TestRemoveSnapIcons(c *C) {
 	c.Check(iconFile, testutil.FileAbsent)
 }
 
-func (s *iconsTestSuite) TestParallelInstanceAddIcons(c *C) {
+func (s *iconsTestSuite) TestParallelInstanceEnsureIcons(c *C) {
 	info := snaptest.MockSnap(c, packageHello, &snap.SideInfo{Revision: snap.R(11)})
 	info.InstanceKey = "instance"
 
@@ -111,7 +118,7 @@ func (s *iconsTestSuite) TestParallelInstanceAddIcons(c *C) {
 	c.Assert(os.MkdirAll(filepath.Join(iconsDir, "hicolor", "scalable", "apps"), 0755), IsNil)
 	c.Assert(ioutil.WriteFile(filepath.Join(iconsDir, "hicolor", "scalable", "apps", "snap.hello-snap.foo.svg"), []byte("scalable"), 0644), IsNil)
 
-	c.Assert(wrappers.AddSnapIcons(info), IsNil)
+	c.Assert(wrappers.EnsureSnapIcons(info), IsNil)
 	iconFile := filepath.Join(dirs.SnapDesktopIconsDir, "hicolor", "scalable", "apps", "snap.hello-snap_instance.foo.svg")
 	c.Check(iconFile, testutil.FileEquals, "scalable")
 


### PR DESCRIPTION
This is part of the preparation for using Ensure* functions instead of Add* functions in backend.LinkSnap and backend.UnlinkSnap.

For more context: https://github.com/snapcore/snapd/pull/13066