### PR TITLE
cmd/snap-device-helper: do not read sysfs directly

### DIFF
--- a/cmd/snap-device-helper/main.c
+++ b/cmd/snap-device-helper/main.c
@@ -20,14 +20,19 @@
 #include "snap-device-helper.h"
 
 int main(int argc, char *argv[]) {
-    if (argc < 5) {
+    int old_invocation_detected = (argc >= 5);
+
+    if ((argc != 2) && !old_invocation_detected)  {
         die("incorrect number of arguments");
     }
+
     struct sdh_invocation inv = {
-        .action = argv[1],
-        .tagname = argv[2],
-        .devpath = argv[3],
-        .majmin = argv[4],
+        .action = getenv("ACTION"),
+        .tagname = old_invocation_detected?argv[2]:argv[1],
+        .major = getenv("MAJOR"),
+        .minor = getenv("MINOR"),
+        .subsystem = getenv("SUBSYSTEM"),
     };
+
     return snap_device_helper_run(&inv);
 }

--- a/cmd/snap-device-helper/snap-device-helper-test.c
+++ b/cmd/snap-device-helper/snap-device-helper-test.c
@@ -31,52 +31,15 @@
 #include "../libsnap-confine-private/device-cgroup-support.h"
 
 typedef struct _sdh_test_fixture {
-    char *sysroot;
 } sdh_test_fixture;
 
-static void mkdir_in_sysroot(sdh_test_fixture *fixture, const char *path) {
-    char *p = g_build_filename(fixture->sysroot, path, NULL);
-    g_assert(g_mkdir_with_parents(p, 0755) == 0);
-    g_free(p);
-}
-
-static void symlink_in_sysroot(sdh_test_fixture *fixture, const char *from, const char *to) {
-    g_debug("mock symlink from %s to %s", from, to);
-    char *pfrom = g_build_filename(fixture->sysroot, from, NULL);
-    g_assert(g_path_is_absolute(to) == FALSE);
-    g_assert_cmpint(symlink(to, pfrom), ==, 0);
-    g_free(pfrom);
-}
-
 static void sdh_test_set_up(sdh_test_fixture *fixture, gconstpointer user_data) {
-    gchar *mock_dir = g_dir_make_tmp(NULL, NULL);
-    g_assert_nonnull(mock_dir);
-
-    fixture->sysroot = mock_dir;
-    sysroot = mock_dir;
-
-    char *sys_devices = g_build_filename(fixture->sysroot, "sys", "devices", NULL);
-    g_assert(g_mkdir_with_parents(sys_devices, 0755) == 0);
-    g_free(sys_devices);
-    char *sys_class_block = g_build_filename(fixture->sysroot, "sys", "class", "block", NULL);
-    g_assert(g_mkdir_with_parents(sys_class_block, 0755) == 0);
-    g_free(sys_class_block);
-    char *sys_class_other = g_build_filename(fixture->sysroot, "sys", "class", "other", NULL);
-    g_assert(g_mkdir_with_parents(sys_class_other, 0755) == 0);
-    g_free(sys_class_other);
-
-    g_debug("mock sysroot dir: %s", mock_dir);
 }
 
 static void mocks_reset(void);
 
 static void sdh_test_tear_down(sdh_test_fixture *fixture, gconstpointer user_data) {
-    sysroot = "";
-    if (!g_strcmp0(sysroot, "/")) {
-        rm_rf_tmp(fixture->sysroot);
-    }
     mocks_reset();
-    g_free(fixture->sysroot);
 }
 
 static struct mocks {
@@ -140,12 +103,10 @@ static void test_sdh_action(sdh_test_fixture *fixture, gconstpointer test_data) 
     struct sdh_invocation inv_block = {
         .action = td->action,
         .tagname = td->mangled_appname,
-        .devpath = "/devices/foo/block/sda/sda4",
-        .majmin = "8:4",
+        .major = "8",
+        .minor = "4",
+        .subsystem = "block",
     };
-
-    mkdir_in_sysroot(fixture, "/sys/devices/foo/block/sda/sda4");
-    symlink_in_sysroot(fixture, "/sys/devices/foo/block/sda/sda4/subsystem", "../../../../../class/block");
 
     int bogus = 0;
     /* make cgroup_device_new return a non-NULL */
@@ -184,11 +145,10 @@ static void test_sdh_action(sdh_test_fixture *fixture, gconstpointer test_data) 
     struct sdh_invocation inv_serial = {
         .action = td->action,
         .tagname = td->mangled_appname,
-        .devpath = "/devices/foo/tty/ttyS0",
-        .majmin = "6:64",
+        .major = "6",
+        .minor = "64",
+        .subsystem = "other",
     };
-    mkdir_in_sysroot(fixture, "/sys/devices/foo/tty/ttyS0");
-    symlink_in_sysroot(fixture, "/sys/devices/foo/tty/ttyS0/subsystem", "../../../../class/other");
     ret = snap_device_helper_run(&inv_serial);
     g_assert_cmpint(ret, ==, 0);
     if (g_strcmp0(td->action, "add") == 0 || g_strcmp0(td->action, "change") == 0 || g_strcmp0(td->action, "bind") == 0) {
@@ -217,53 +177,42 @@ static void test_sdh_action(sdh_test_fixture *fixture, gconstpointer test_data) 
 }
 
 static void test_sdh_action_nvme(sdh_test_fixture *fixture, gconstpointer test_data) {
-    /* hierarchy from an actual system with a nvme disk */
-    mkdir_in_sysroot(fixture, "/sys/devices/pci0000:00/0000:00:01.1/0000:01:00.0/nvme/nvme0/nvme0n1");
-    mkdir_in_sysroot(fixture, "/sys/devices/pci0000:00/0000:00:01.1/0000:01:00.0/nvme/nvme0/nvme0n1p1");
-    mkdir_in_sysroot(fixture, "/sys/devices/pci0000:00/0000:00:01.1/0000:01:00.0/nvme/nvme0/ng0n1");
-    mkdir_in_sysroot(fixture, "/sys/devices/pci0000:00/0000:00:01.1/0000:01:00.0/nvme/nvme0/hwmon0");
-    symlink_in_sysroot(fixture, "/sys//devices/pci0000:00/0000:00:01.1/0000:01:00.0/nvme/nvme0/nvme0n1/subsystem",
-                       "../../../../../../../class/block");
-    symlink_in_sysroot(fixture, "/sys//devices/pci0000:00/0000:00:01.1/0000:01:00.0/nvme/nvme0/nvme0n1p1/subsystem",
-                       "../../../../../../../class/block");
-    symlink_in_sysroot(fixture, "/sys//devices/pci0000:00/0000:00:01.1/0000:01:00.0/nvme/nvme0/subsystem",
-                       "../../../../../../class/nvme");
-    symlink_in_sysroot(fixture, "/sys//devices/pci0000:00/0000:00:01.1/0000:01:00.0/nvme/nvme0/ng0n1/subsystem",
-                       "../../../../../../class/nvme-generic");
-    symlink_in_sysroot(fixture, "/sys//devices/pci0000:00/0000:00:01.1/0000:01:00.0/nvme/nvme0/hwmon0/subsystem",
-                       "../../../../../../class/hwmon");
-
     struct {
-        const char *dev;
-        const char *majmin;
+        const char *major;
+        const char *minor;
+        const char *subsystem;
         int expected_maj;
         int expected_min;
         int expected_type;
     } tcs[] = {
         {
-            .dev = "/devices/pci0000:00/0000:00:01.1/0000:01:00.0/nvme/nvme0/nvme0n1",
-            .majmin = "259:0",
+            .major = "259",
+            .minor = "0",
+            .subsystem = "block",
             .expected_maj = 259,
             .expected_min = 0,
             .expected_type = S_IFBLK,
         },
         {
-            .dev = "/devices/pci0000:00/0000:00:01.1/0000:01:00.0/nvme/nvme0/nvme0n1p1",
-            .majmin = "259:1",
+            .major = "259",
+            .minor = "1",
+            .subsystem = "block",
             .expected_maj = 259,
             .expected_min = 1,
             .expected_type = S_IFBLK,
         },
         {
-            .dev = "/devices/pci0000:00/0000:00:01.1/0000:01:00.0/nvme/nvme0",
-            .majmin = "242:0",
+            .major = "242",
+            .minor = "0",
+            .subsystem = "nvme",
             .expected_maj = 242,
             .expected_min = 0,
             .expected_type = S_IFCHR,
         },
         {
-            .dev = "/devices/pci0000:00/0000:00:01.1/0000:01:00.0/nvme/nvme0/hwmon0",
-            .majmin = "241:0",
+            .major = "241",
+            .minor = "0",
+            .subsystem = "hwmon",
             .expected_maj = 241,
             .expected_min = 0,
             .expected_type = S_IFCHR,
@@ -280,8 +229,9 @@ static void test_sdh_action_nvme(sdh_test_fixture *fixture, gconstpointer test_d
         struct sdh_invocation inv_block = {
             .action = "add",
             .tagname = "snap_foo_bar",
-            .devpath = tcs[i].dev,
-            .majmin = tcs[i].majmin,
+            .major = tcs[i].major,
+            .minor = tcs[i].minor,
+            .subsystem = tcs[i].subsystem,
         };
         int ret = snap_device_helper_run(&inv_block);
         g_assert_cmpint(ret, ==, 0);
@@ -297,61 +247,60 @@ static void test_sdh_action_nvme(sdh_test_fixture *fixture, gconstpointer test_d
 }
 
 static void test_sdh_action_remove_fallback_devtype(sdh_test_fixture *fixture, gconstpointer test_data) {
-    /* check that fallback guessing of device type if applied during remove action */
-    mkdir_in_sysroot(fixture, "/sys/devices/pci0000:00/0000:00:01.1/0000:01:00.0/nvme/nvme0/nvme0n1");
-    mkdir_in_sysroot(fixture, "/sys/devices/pci0000:00/0000:00:01.1/0000:01:00.0/nvme/nvme0/nvme0n1p1");
-    mkdir_in_sysroot(fixture, "/sys/devices/pci0000:00/0000:00:01.1/0000:01:00.0/nvme/nvme0/ng0n1");
-    mkdir_in_sysroot(fixture, "/sys/devices/pci0000:00/0000:00:01.1/0000:01:00.0/nvme/nvme0/hwmon0");
-    mkdir_in_sysroot(fixture, "/sys/devices/foo/block/sda/sda4");
-    mkdir_in_sysroot(fixture, "/sys//devices/pnp0/00:04/tty/ttyS0");
-
     struct {
-        const char *dev;
-        const char *majmin;
+        const char *major;
+        const char *minor;
+        const char *subsystem;
         int expected_maj;
         int expected_min;
         int expected_type;
     } tcs[] = {
         /* these device paths match the fallback pattern of block devices */
         {
-            .dev = "/devices/pci0000:00/0000:00:01.1/0000:01:00.0/nvme/nvme0/nvme0n1",
-            .majmin = "259:0",
+            .major = "259",
+            .minor = "0",
+            .subsystem = "block",
             .expected_maj = 259,
             .expected_min = 0,
             .expected_type = S_IFBLK,
         },
         {
-            .dev = "/devices/pci0000:00/0000:00:01.1/0000:01:00.0/nvme/nvme0/nvme0n1p1",
-            .majmin = "259:1",
+            .major = "259",
+            .minor = "1",
+            .subsystem = "block",
             .expected_maj = 259,
             .expected_min = 1,
             .expected_type = S_IFBLK,
         },
         {
-            .dev = "/devices/foo/block/sda/sda4",
-            .majmin = "8:0",
+            .major = "8",
+            .minor = "0",
+            .subsystem = "block",
             .expected_maj = 8,
             .expected_min = 0,
             .expected_type = S_IFBLK,
         },
         /* these are treated as char devices */
         {
-            .dev = "/devices/pci0000:00/0000:00:01.1/0000:01:00.0/nvme/nvme0",
-            .majmin = "242:0",
+            .major = "242",
+            .minor = "0",
+            .subsystem = "nvme",
             .expected_maj = 242,
             .expected_min = 0,
             .expected_type = S_IFCHR,
         },
         {
-            .dev = "/devices/pci0000:00/0000:00:01.1/0000:01:00.0/nvme/nvme0/hwmon0",
-            .majmin = "241:0",
+            .major = "241",
+            .minor = "0",
+            .subsystem = "hwmon",
             .expected_maj = 241,
             .expected_min = 0,
             .expected_type = S_IFCHR,
         },
         {
-            .dev = "/devices/pnp0/00:04/tty/ttyS0",
-            .majmin = "4:64",
+            .major = "4",
+            .minor = "64",
+            .subsystem = "tty",
             .expected_maj = 4,
             .expected_min = 64,
             .expected_type = S_IFCHR,
@@ -368,8 +317,9 @@ static void test_sdh_action_remove_fallback_devtype(sdh_test_fixture *fixture, g
         struct sdh_invocation inv_block = {
             .action = "remove",
             .tagname = "snap_foo_bar",
-            .devpath = tcs[i].dev,
-            .majmin = tcs[i].majmin,
+            .major = tcs[i].major,
+            .minor = tcs[i].minor,
+            .subsystem = tcs[i].subsystem,
         };
         int ret = snap_device_helper_run(&inv_block);
         g_assert_cmpint(ret, ==, 0);
@@ -384,13 +334,14 @@ static void test_sdh_action_remove_fallback_devtype(sdh_test_fixture *fixture, g
     }
 }
 
-static void run_sdh_die(const char *action, const char *tagname, const char *devpath, const char *majmin,
-                        const char *msg) {
+static void run_sdh_die(const char *action, const char *tagname, const char *major,
+                        const char *minor, const char *subsystem, const char *msg) {
     struct sdh_invocation inv = {
         .action = action,
         .tagname = tagname,
-        .devpath = devpath,
-        .majmin = majmin,
+        .major = major,
+        .minor = minor,
+        .subsystem = subsystem,
     };
     if (g_test_subprocess()) {
         errno = 0;
@@ -403,109 +354,73 @@ static void run_sdh_die(const char *action, const char *tagname, const char *dev
 
 static void test_sdh_err_noappname(sdh_test_fixture *fixture, gconstpointer test_data) {
     // missing appname
-    run_sdh_die("add", "", "/devices/foo/block/sda/sda4", "8:4", "malformed tag \"\"\n");
+    run_sdh_die("add", "", "8", "4", "block", "malformed tag \"\"\n");
 }
 
 static void test_sdh_err_badappname(sdh_test_fixture *fixture, gconstpointer test_data) {
     // malformed appname
-    run_sdh_die("add", "foo_bar", "/devices/foo/block/sda/sda4", "8:4", "malformed tag \"foo_bar\"\n");
-}
-static void test_sdh_err_nodevpath(sdh_test_fixture *fixture, gconstpointer test_data) {
-    // missing devpath
-    run_sdh_die("add", "snap_foo_bar", "", "8:4", "no or malformed devpath \"\"\n");
+    run_sdh_die("add", "foo_bar", "8", "4", "block", "malformed tag \"foo_bar\"\n");
 }
 
 static void test_sdh_err_wrongdevmajorminor1(sdh_test_fixture *fixture, gconstpointer test_data) {
     // missing device major:minor numbers
-    run_sdh_die("add", "snap_foo_bar", "/devices/foo/block/sda/sda4", "", "no or malformed major/minor \"\"\n");
+    run_sdh_die("add", "snap_foo_bar", "8", NULL, "block", "incomplete major/minor\n");
 }
 
 static void test_sdh_err_wrongdevmajorminor2(sdh_test_fixture *fixture, gconstpointer test_data) {
-    // too short major:minor numbers
-    run_sdh_die("add", "snap_foo_bar", "/devices/foo/block/sda/sda4", "8", "no or malformed major/minor \"8\"\n");
-}
-
-static void test_sdh_err_wrongdevmajorminor_late1(sdh_test_fixture *fixture, gconstpointer test_data) {
-    // mock enough to the major:minor extraction in the code
-    mkdir_in_sysroot(fixture, "/sys/devices/foo/block/sda/sda4");
-    symlink_in_sysroot(fixture, "/sys/devices/foo/block/sda/sda4/subsystem", "../../../../../class/block");
-
-    // ensure mocked sc_device_cgroup_new() returns non-NULL
-    int bogus = 0;
-    mocks.new_ret = &bogus;
-
-    // missing ":"
-    run_sdh_die("add", "snap_foo_bar", "/devices/foo/block/sda/sda4", "100", "malformed major:minor string: 100\n");
-}
-
-static void test_sdh_err_wrongdevmajorminor_late2(sdh_test_fixture *fixture, gconstpointer test_data) {
-    // mock enough to the major:minor extraction in the code
-    mkdir_in_sysroot(fixture, "/sys/devices/foo/block/sda/sda4");
-    symlink_in_sysroot(fixture, "/sys/devices/foo/block/sda/sda4/subsystem", "../../../../../class/block");
-
-    // ensure mocked sc_device_cgroup_new() returns non-NULL
-    int bogus = 0;
-    mocks.new_ret = &bogus;
-
-    // missing part after ":"
-    run_sdh_die("add", "snap_foo_bar", "/devices/foo/block/sda/sda4", "88:", "malformed major:minor string: 88:\n");
+    // missing device major:minor numbers
+    run_sdh_die("add", "snap_foo_bar", NULL, "4", "block", "incomplete major/minor\n");
 }
 
 static void test_sdh_err_badaction(sdh_test_fixture *fixture, gconstpointer test_data) {
     // bogus action
-    run_sdh_die("badaction", "snap_foo_bar", "/devices/foo/block/sda/sda4", "8:4",
+    run_sdh_die("badaction", "snap_foo_bar", "8", "4", "block",
                 "ERROR: unknown action \"badaction\"\n");
 }
 
-static void test_sdh_err_nosymlink_block(sdh_test_fixture *fixture, gconstpointer test_data) {
-    // missing symlink
-    run_sdh_die("add", "snap_foo_bar", "/devices/foo/block/sda/sda4", "8:4",
-                "cannot read symlink */sys//devices/foo/block/sda/sda4/subsystem*\n");
-}
-
-static void test_sdh_err_nosymlink_char(sdh_test_fixture *fixture, gconstpointer test_data) {
-    // missing symlink
-    run_sdh_die("add", "snap_foo_bar", "/devices/pnp0/00:04/tty/ttyS0", "4:64",
-                "cannot read symlink */sys//devices/pnp0/00:04/tty/ttyS0/subsystem*\n");
+static void test_sdh_err_noaction(sdh_test_fixture *fixture, gconstpointer test_data) {
+    // bogus action
+    run_sdh_die(NULL, "snap_foo_bar", "8", "4", "block",
+                "ERROR: no action given\n");
 }
 
 static void test_sdh_err_funtag1(sdh_test_fixture *fixture, gconstpointer test_data) {
-    run_sdh_die("add", "snap___bar", "/devices/foo/block/sda/sda4", "8:4",
+    run_sdh_die("add", "snap___bar", "8", "4", "block",
                 "security tag \"snap._.bar\" for snap \"_\" is not valid\n");
 }
 
 static void test_sdh_err_funtag2(sdh_test_fixture *fixture, gconstpointer test_data) {
-    run_sdh_die("add", "snap_foobar", "/devices/foo/block/sda/sda4", "8:4",
+    run_sdh_die("add", "snap_foobar", "8", "4", "block",
                 "missing app name in tag \"snap_foobar\"\n");
 }
 
 static void test_sdh_err_funtag3(sdh_test_fixture *fixture, gconstpointer test_data) {
-    run_sdh_die("add", "snap_", "/devices/foo/block/sda/sda4", "8:4", "tag \"snap_\" length 5 is incorrect\n");
+    run_sdh_die("add", "snap_", "8", "4", "block", "tag \"snap_\" length 5 is incorrect\n");
 }
 
 static void test_sdh_err_funtag4(sdh_test_fixture *fixture, gconstpointer test_data) {
-    run_sdh_die("add", "snap_foo_", "/devices/foo/block/sda/sda4", "8:4",
+    run_sdh_die("add", "snap_foo_", "8", "4", "block",
                 "security tag \"snap.foo.\" for snap \"foo\" is not valid\n");
 }
 
 static void test_sdh_err_funtag5(sdh_test_fixture *fixture, gconstpointer test_data) {
     run_sdh_die(
-        "add", "snap_thisisverylonginstancenameabovelengthlimit_instancekey_bar", "/devices/foo/block/sda/sda4", "8:4",
+        "add", "snap_thisisverylonginstancenameabovelengthlimit_instancekey_bar", "8", "4", "block",
         "snap instance of tag \"snap_thisisverylonginstancenameabovelengthlimit_instancekey_bar\" is too long\n");
 }
 
 static void test_sdh_err_funtag6(sdh_test_fixture *fixture, gconstpointer test_data) {
-    run_sdh_die("add", "snap__barbar", "/devices/foo/block/sda/sda4", "8:4",
+    run_sdh_die("add", "snap__barbar", "8", "4", "block",
                 "missing snap name in tag \"snap__barbar\"\n");
 }
 
 static void test_sdh_err_funtag7(sdh_test_fixture *fixture, gconstpointer test_data) {
-    run_sdh_die("add", "snap_barbarbarbar", "/devices/foo/block/sda/sda4", "8:4",
+    run_sdh_die("add", "snap_barbarbarbar", "8", "4", "block",
                 "missing app name in tag \"snap_barbarbarbar\"\n");
 }
 
 static void test_sdh_err_funtag8(sdh_test_fixture *fixture, gconstpointer test_data) {
-    run_sdh_die("add", "snap_#_barbar", "/devices/foo/block/sda/sda4", "8:4",
+    run_sdh_die("add", "snap_#_barbar", "8", "4", "block",
                 "security tag \"snap.#.barbar\" for snap \"#\" is not valid\n");
 }
 
@@ -547,14 +462,10 @@ static void __attribute__((constructor)) init(void) {
 
     _test_add("/snap-device-helper/err/no-appname", NULL, test_sdh_err_noappname);
     _test_add("/snap-device-helper/err/bad-appname", NULL, test_sdh_err_badappname);
-    _test_add("/snap-device-helper/err/no-devpath", NULL, test_sdh_err_nodevpath);
     _test_add("/snap-device-helper/err/wrong-devmajorminor1", NULL, test_sdh_err_wrongdevmajorminor1);
     _test_add("/snap-device-helper/err/wrong-devmajorminor2", NULL, test_sdh_err_wrongdevmajorminor2);
-    _test_add("/snap-device-helper/err/wrong-devmajorminor_late1", NULL, test_sdh_err_wrongdevmajorminor_late1);
-    _test_add("/snap-device-helper/err/wrong-devmajorminor_late2", NULL, test_sdh_err_wrongdevmajorminor_late2);
     _test_add("/snap-device-helper/err/bad-action", NULL, test_sdh_err_badaction);
-    _test_add("/snap-device-helper/err/no-symlink-block", NULL, test_sdh_err_nosymlink_block);
-    _test_add("/snap-device-helper/err/no-symlink-char", NULL, test_sdh_err_nosymlink_char);
+    _test_add("/snap-device-helper/err/no-action", NULL, test_sdh_err_noaction);
     _test_add("/snap-device-helper/err/funtag1", NULL, test_sdh_err_funtag1);
     _test_add("/snap-device-helper/err/funtag2", NULL, test_sdh_err_funtag2);
     _test_add("/snap-device-helper/err/funtag3", NULL, test_sdh_err_funtag3);

--- a/cmd/snap-device-helper/snap-device-helper.h
+++ b/cmd/snap-device-helper/snap-device-helper.h
@@ -21,8 +21,9 @@
 struct sdh_invocation {
     const char *action;
     const char *tagname;
-    const char *devpath;
-    const char *majmin;
+    const char *major;
+    const char *minor;
+    const char *subsystem;
 };
 
 int snap_device_helper_run(const struct sdh_invocation *inv);

--- a/interfaces/builtin/acrn_support_test.go
+++ b/interfaces/builtin/acrn_support_test.go
@@ -99,7 +99,7 @@ func (s *acrnSupportInterfaceSuite) TestUDevSpec(c *C) {
 	c.Assert(spec.Snippets(), HasLen, 2)
 	c.Assert(spec.Snippets()[0], Equals, `# acrn-support
 KERNEL=="acrn_hsm", TAG+="snap_consumer_app"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%s/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%s/snap-device-helper snap_consumer_app"`, dirs.DistroLibExecDir))
 }
 
 func (s *acrnSupportInterfaceSuite) TestStaticInfo(c *C) {

--- a/interfaces/builtin/allegro_vcu_test.go
+++ b/interfaces/builtin/allegro_vcu_test.go
@@ -96,7 +96,7 @@ SUBSYSTEM=="allegro_encode_class", KERNEL=="allegroIP", TAG+="snap_consumer_app"
 	c.Assert(spec.Snippets(), testutil.Contains, `# allegro-vcu
 SUBSYSTEM=="char", KERNEL=="dmaproxy", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(
-		`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+		`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_consumer_app"`, dirs.DistroLibExecDir))
 }
 
 func (s *AllegroVcuInterfaceSuite) TestStaticInfo(c *C) {

--- a/interfaces/builtin/alsa_test.go
+++ b/interfaces/builtin/alsa_test.go
@@ -89,7 +89,7 @@ func (s *AlsaInterfaceSuite) TestUDevpec(c *C) {
 	c.Assert(spec.Snippets(), HasLen, 8)
 	c.Assert(spec.Snippets(), testutil.Contains, `# alsa
 KERNEL=="pcmC[0-9]*D[0-9]*[cp]", TAG+="snap_consumer_app"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_consumer_app"`, dirs.DistroLibExecDir))
 }
 
 func (s *AlsaInterfaceSuite) TestStaticInfo(c *C) {

--- a/interfaces/builtin/audio_playback_test.go
+++ b/interfaces/builtin/audio_playback_test.go
@@ -215,7 +215,7 @@ KERNEL=="controlC[0-9]*", TAG+="snap_audio-playback_app1"`)
 KERNEL=="pcmC[0-9]*D[0-9]*[cp]", TAG+="snap_audio-playback_app1"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `# audio-playback
 KERNEL=="timer", TAG+="snap_audio-playback_app1"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_audio-playback_app1", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_audio-playback_app1 $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_audio-playback_app1", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_audio-playback_app1"`, dirs.DistroLibExecDir))
 }
 
 func (s *AudioPlaybackInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/builtin/block_devices_test.go
+++ b/interfaces/builtin/block_devices_test.go
@@ -94,7 +94,7 @@ func (s *blockDevicesInterfaceSuite) TestUDevSpec(c *C) {
 	c.Assert(spec.Snippets(), HasLen, 5)
 	c.Assert(spec.Snippets()[0], Equals, `# block-devices
 KERNEL=="megaraid_sas_ioctl_node", TAG+="snap_consumer_app"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_consumer_app"`, dirs.DistroLibExecDir))
 }
 
 func (s *blockDevicesInterfaceSuite) TestStaticInfo(c *C) {

--- a/interfaces/builtin/bluetooth_control_test.go
+++ b/interfaces/builtin/bluetooth_control_test.go
@@ -107,7 +107,7 @@ func (s *BluetoothControlInterfaceSuite) TestUDevSpec(c *C) {
 SUBSYSTEM=="bluetooth", TAG+="snap_other_app2"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `# bluetooth-control
 SUBSYSTEM=="BT_chrdev", TAG+="snap_other_app2"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_other_app2", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_other_app2 $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_other_app2", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_other_app2"`, dirs.DistroLibExecDir))
 }
 
 func (s *BluetoothControlInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/builtin/bluez_test.go
+++ b/interfaces/builtin/bluez_test.go
@@ -247,7 +247,7 @@ func (s *BluezInterfaceSuite) TestUDevSpec(c *C) {
 	c.Assert(spec.Snippets(), HasLen, 2)
 	c.Assert(spec.Snippets(), testutil.Contains, `# bluez
 KERNEL=="rfkill", TAG+="snap_consumer_app"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_consumer_app"`, dirs.DistroLibExecDir))
 
 	// on a classic system with bluez slot coming from the core snap.
 	restore = release.MockOnClassic(true)
@@ -257,7 +257,7 @@ KERNEL=="rfkill", TAG+="snap_consumer_app"`)
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.coreSlot), IsNil)
 	c.Assert(spec.Snippets(), HasLen, 2)
 	c.Assert(spec.Snippets()[0], testutil.Contains, `KERNEL=="rfkill", TAG+="snap_consumer_app"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_consumer_app"`, dirs.DistroLibExecDir))
 
 }
 

--- a/interfaces/builtin/broadcom_asic_control_test.go
+++ b/interfaces/builtin/broadcom_asic_control_test.go
@@ -94,7 +94,7 @@ func (s *BroadcomAsicControlSuite) TestUDevSpec(c *C) {
 	c.Assert(spec.Snippets(), HasLen, 3)
 	c.Assert(spec.Snippets(), testutil.Contains, `# broadcom-asic-control
 SUBSYSTEM=="net", KERNEL=="bcm[0-9]*", TAG+="snap_consumer_app"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_consumer_app"`, dirs.DistroLibExecDir))
 }
 
 func (s *BroadcomAsicControlSuite) TestKModSpec(c *C) {

--- a/interfaces/builtin/camera_test.go
+++ b/interfaces/builtin/camera_test.go
@@ -91,7 +91,7 @@ func (s *CameraInterfaceSuite) TestUDevSpec(c *C) {
 KERNEL=="video[0-9]*", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `# camera
 KERNEL=="vchiq", TAG+="snap_consumer_app"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_consumer_app"`, dirs.DistroLibExecDir))
 }
 
 func (s *CameraInterfaceSuite) TestStaticInfo(c *C) {

--- a/interfaces/builtin/common_test.go
+++ b/interfaces/builtin/common_test.go
@@ -63,11 +63,11 @@ slots:
 	c.Assert(spec.Snippets(), DeepEquals, []string{
 		`# common
 KERNEL=="foo", TAG+="snap_consumer_app-a"`,
-		fmt.Sprintf(`TAG=="snap_consumer_app-a", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app-a $devpath $major:$minor"`, dirs.DistroLibExecDir),
+		fmt.Sprintf(`TAG=="snap_consumer_app-a", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_consumer_app-a"`, dirs.DistroLibExecDir),
 		// NOTE: app-b is unaffected as it doesn't have a plug reference.
 		`# common
 KERNEL=="foo", TAG+="snap_consumer_app-c"`,
-		fmt.Sprintf(`TAG=="snap_consumer_app-c", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app-c $devpath $major:$minor"`, dirs.DistroLibExecDir),
+		fmt.Sprintf(`TAG=="snap_consumer_app-c", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_consumer_app-c"`, dirs.DistroLibExecDir),
 	})
 
 	// connected plug udev rules are optional

--- a/interfaces/builtin/device_buttons_test.go
+++ b/interfaces/builtin/device_buttons_test.go
@@ -92,7 +92,7 @@ func (s *DeviceButtonsInterfaceSuite) TestUDevSpec(c *C) {
 KERNEL=="event[0-9]*", SUBSYSTEM=="input", ENV{ID_INPUT_KEY}=="1", ENV{ID_INPUT_KEYBOARD}!="1", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `# device-buttons
 KERNEL=="full", SUBSYSTEM=="mem", TAG+="snap_consumer_app"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_consumer_app"`, dirs.DistroLibExecDir))
 	c.Assert(spec.TriggeredSubsystems(), DeepEquals, []string{"input/key"})
 }
 

--- a/interfaces/builtin/dm_crypt_test.go
+++ b/interfaces/builtin/dm_crypt_test.go
@@ -107,7 +107,7 @@ KERNEL=="dm-[0-9]", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `# dm-crypt
 SUBSYSTEM=="block", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains,
-		fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+		fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_consumer_app"`, dirs.DistroLibExecDir))
 }
 
 func (s *DmCryptInterfaceSuite) TestSeccompSpec(c *C) {

--- a/interfaces/builtin/dsp_test.go
+++ b/interfaces/builtin/dsp_test.go
@@ -107,7 +107,7 @@ func (s *dspSuite) TestUDevConnectedPlugAmbarella(c *C) {
 	c.Assert(spec.Snippets(), HasLen, 6)
 	c.Assert(spec.Snippets(), testutil.Contains, `# dsp
 KERNEL=="iav", TAG+="snap_my-device_svc"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_my-device_svc", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_my-device_svc $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_my-device_svc", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_my-device_svc"`, dirs.DistroLibExecDir))
 }
 
 func (s *dspSuite) TestUDevConnectedPlugNoFlavor(c *C) {

--- a/interfaces/builtin/dvb_test.go
+++ b/interfaces/builtin/dvb_test.go
@@ -90,7 +90,7 @@ func (s *DvbInterfaceSuite) TestUDevSpec(c *C) {
 	c.Assert(spec.Snippets(), HasLen, 2)
 	c.Assert(spec.Snippets(), testutil.Contains, `# dvb
 SUBSYSTEM=="dvb", TAG+="snap_consumer_app"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_consumer_app"`, dirs.DistroLibExecDir))
 }
 
 func (s *DvbInterfaceSuite) TestStaticInfo(c *C) {

--- a/interfaces/builtin/fpga_test.go
+++ b/interfaces/builtin/fpga_test.go
@@ -92,7 +92,7 @@ func (s *FpgaInterfaceSuite) TestUDevSpec(c *C) {
 	c.Assert(spec.Snippets(), HasLen, 2)
 	c.Assert(spec.Snippets(), testutil.Contains, `# fpga
 SUBSYSTEM=="misc", KERNEL=="fpga[0-9]*", TAG+="snap_consumer_app"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_consumer_app"`, dirs.DistroLibExecDir))
 }
 
 func (s *FpgaInterfaceSuite) TestStaticInfo(c *C) {

--- a/interfaces/builtin/framebuffer_test.go
+++ b/interfaces/builtin/framebuffer_test.go
@@ -91,7 +91,7 @@ func (s *FramebufferInterfaceSuite) TestUDevSpec(c *C) {
 	c.Assert(spec.Snippets(), HasLen, 2)
 	c.Assert(spec.Snippets()[0], Equals, `# framebuffer
 KERNEL=="fb[0-9]*", TAG+="snap_consumer_app"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_consumer_app"`, dirs.DistroLibExecDir))
 }
 
 func (s *FramebufferInterfaceSuite) TestStaticInfo(c *C) {

--- a/interfaces/builtin/fuse_support_test.go
+++ b/interfaces/builtin/fuse_support_test.go
@@ -98,7 +98,7 @@ func (s *FuseSupportInterfaceSuite) TestUDevSpec(c *C) {
 	c.Assert(spec.Snippets(), HasLen, 2)
 	c.Assert(spec.Snippets(), testutil.Contains, `# fuse-support
 KERNEL=="fuse", TAG+="snap_consumer_app"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_consumer_app"`, dirs.DistroLibExecDir))
 }
 
 func (s *FuseSupportInterfaceSuite) TestStaticInfo(c *C) {

--- a/interfaces/builtin/fwupd_test.go
+++ b/interfaces/builtin/fwupd_test.go
@@ -268,7 +268,7 @@ KERNEL=="wmi/dell-smbios", TAG+="snap_uefi-fw-tools_app2"`)
 	c.Assert(snippets[11], Equals, `# fwupd
 SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", TAG+="snap_uefi-fw-tools_app2"`)
 
-	expected := fmt.Sprintf(`TAG=="snap_uefi-fw-tools_app2", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_uefi-fw-tools_app2 $devpath $major:$minor"`, dirs.DistroLibExecDir)
+	expected := fmt.Sprintf(`TAG=="snap_uefi-fw-tools_app2", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_uefi-fw-tools_app2"`, dirs.DistroLibExecDir)
 	c.Assert(snippets[12], Equals, expected)
 
 	// The implicit slot found on classic systems does not generate any rules

--- a/interfaces/builtin/hardware_random_control_test.go
+++ b/interfaces/builtin/hardware_random_control_test.go
@@ -89,7 +89,7 @@ func (s *HardwareRandomControlInterfaceSuite) TestUDevSpec(c *C) {
 	c.Assert(spec.Snippets(), HasLen, 2)
 	c.Assert(spec.Snippets(), testutil.Contains, `# hardware-random-control
 KERNEL=="hwrng", TAG+="snap_consumer_app"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_consumer_app"`, dirs.DistroLibExecDir))
 }
 
 func (s *HardwareRandomControlInterfaceSuite) TestStaticInfo(c *C) {

--- a/interfaces/builtin/hardware_random_observe_test.go
+++ b/interfaces/builtin/hardware_random_observe_test.go
@@ -89,7 +89,7 @@ func (s *HardwareRandomObserveInterfaceSuite) TestUDevSpec(c *C) {
 	c.Assert(spec.Snippets(), HasLen, 2)
 	c.Assert(spec.Snippets(), testutil.Contains, `# hardware-random-observe
 KERNEL=="hwrng", TAG+="snap_consumer_app"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_consumer_app"`, dirs.DistroLibExecDir))
 }
 
 func (s *HardwareRandomObserveInterfaceSuite) TestStaticInfo(c *C) {

--- a/interfaces/builtin/hidraw_test.go
+++ b/interfaces/builtin/hidraw_test.go
@@ -266,7 +266,7 @@ func (s *HidrawInterfaceSuite) TestConnectedPlugUDevSnippets(c *C) {
 SUBSYSTEM=="hidraw", KERNEL=="hidraw0", TAG+="snap_client-snap_app-accessing-2-devices"`
 	c.Assert(snippet, Equals, expectedSnippet1)
 	extraSnippet := spec.Snippets()[1]
-	expectedExtraSnippet1 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-2-devices", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_client-snap_app-accessing-2-devices $devpath $major:$minor"`, dirs.DistroLibExecDir)
+	expectedExtraSnippet1 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-2-devices", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_client-snap_app-accessing-2-devices"`, dirs.DistroLibExecDir)
 	c.Assert(extraSnippet, Equals, expectedExtraSnippet1)
 
 	// add the plug for the first slot with vendor and product ids
@@ -279,7 +279,7 @@ IMPORT{builtin}="usb_id"
 SUBSYSTEM=="hidraw", SUBSYSTEMS=="usb", ATTRS{idVendor}=="0001", ATTRS{idProduct}=="0001", TAG+="snap_client-snap_app-accessing-2-devices"`
 	c.Assert(snippet, Equals, expectedSnippet2)
 	extraSnippet = spec.Snippets()[1]
-	expectedExtraSnippet2 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-2-devices", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_client-snap_app-accessing-2-devices $devpath $major:$minor"`, dirs.DistroLibExecDir)
+	expectedExtraSnippet2 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-2-devices", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_client-snap_app-accessing-2-devices"`, dirs.DistroLibExecDir)
 	c.Assert(extraSnippet, Equals, expectedExtraSnippet2)
 
 	// add the plug for the second slot with vendor and product ids
@@ -292,7 +292,7 @@ IMPORT{builtin}="usb_id"
 SUBSYSTEM=="hidraw", SUBSYSTEMS=="usb", ATTRS{idVendor}=="ffff", ATTRS{idProduct}=="ffff", TAG+="snap_client-snap_app-accessing-2-devices"`
 	c.Assert(snippet, Equals, expectedSnippet3)
 	extraSnippet = spec.Snippets()[1]
-	expectedExtraSnippet3 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-2-devices", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_client-snap_app-accessing-2-devices $devpath $major:$minor"`, dirs.DistroLibExecDir)
+	expectedExtraSnippet3 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-2-devices", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_client-snap_app-accessing-2-devices"`, dirs.DistroLibExecDir)
 	c.Assert(extraSnippet, Equals, expectedExtraSnippet3)
 }
 
@@ -325,7 +325,7 @@ func (s *HidrawInterfaceSuite) TestConnectedPlugAppArmorSnippets(c *C) {
 func (s *HidrawInterfaceSuite) TestConnectedPlugUDevSnippetsForPath(c *C) {
 	expectedSnippet1 := `# hidraw
 SUBSYSTEM=="hidraw", KERNEL=="hidraw0", TAG+="snap_client-snap_app-accessing-2-devices"`
-	expectedExtraSnippet1 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-2-devices", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_client-snap_app-accessing-2-devices $devpath $major:$minor"`, dirs.DistroLibExecDir)
+	expectedExtraSnippet1 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-2-devices", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_client-snap_app-accessing-2-devices"`, dirs.DistroLibExecDir)
 	udevSpec := &udev.Specification{}
 	err := udevSpec.AddConnectedPlug(s.iface, s.testPlugPort1, s.testSlot1)
 	c.Assert(err, IsNil)
@@ -338,7 +338,7 @@ SUBSYSTEM=="hidraw", KERNEL=="hidraw0", TAG+="snap_client-snap_app-accessing-2-d
 	expectedSnippet2 := `# hidraw
 IMPORT{builtin}="usb_id"
 SUBSYSTEM=="hidraw", SUBSYSTEMS=="usb", ATTRS{idVendor}=="0001", ATTRS{idProduct}=="0001", TAG+="snap_client-snap_app-accessing-2-devices"`
-	expectedExtraSnippet2 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-2-devices", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_client-snap_app-accessing-2-devices $devpath $major:$minor"`, dirs.DistroLibExecDir)
+	expectedExtraSnippet2 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-2-devices", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_client-snap_app-accessing-2-devices"`, dirs.DistroLibExecDir)
 	udevSpec = &udev.Specification{}
 	err = udevSpec.AddConnectedPlug(s.iface, s.testPlugPort1, s.testUDev1)
 	c.Assert(err, IsNil)
@@ -351,7 +351,7 @@ SUBSYSTEM=="hidraw", SUBSYSTEMS=="usb", ATTRS{idVendor}=="0001", ATTRS{idProduct
 	expectedSnippet3 := `# hidraw
 IMPORT{builtin}="usb_id"
 SUBSYSTEM=="hidraw", SUBSYSTEMS=="usb", ATTRS{idVendor}=="ffff", ATTRS{idProduct}=="ffff", TAG+="snap_client-snap_app-accessing-2-devices"`
-	expectedExtraSnippet3 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-2-devices", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_client-snap_app-accessing-2-devices $devpath $major:$minor"`, dirs.DistroLibExecDir)
+	expectedExtraSnippet3 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-2-devices", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_client-snap_app-accessing-2-devices"`, dirs.DistroLibExecDir)
 	udevSpec = &udev.Specification{}
 	err = udevSpec.AddConnectedPlug(s.iface, s.testPlugPort2, s.testUDev2)
 	c.Assert(err, IsNil)

--- a/interfaces/builtin/i2c_test.go
+++ b/interfaces/builtin/i2c_test.go
@@ -232,7 +232,7 @@ func (s *I2cInterfaceSuite) TestUDevSpec(c *C) {
 	c.Assert(spec.Snippets(), HasLen, 2)
 	c.Assert(spec.Snippets(), testutil.Contains, `# i2c
 KERNEL=="i2c-1", TAG+="snap_client-snap_app-accessing-1-port"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-1-port", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_client-snap_app-accessing-1-port $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-1-port", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_client-snap_app-accessing-1-port"`, dirs.DistroLibExecDir))
 }
 
 func (s *I2cInterfaceSuite) TestUDevSpecSysfsName(c *C) {

--- a/interfaces/builtin/iio_test.go
+++ b/interfaces/builtin/iio_test.go
@@ -203,7 +203,7 @@ func (s *IioInterfaceSuite) TestConnectedPlugUDevSnippets(c *C) {
 	c.Assert(spec.Snippets(), HasLen, 2)
 	c.Assert(spec.Snippets(), testutil.Contains, `# iio
 KERNEL=="iio:device1", TAG+="snap_client-snap_app-accessing-1-port"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-1-port", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_client-snap_app-accessing-1-port $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-1-port", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_client-snap_app-accessing-1-port"`, dirs.DistroLibExecDir))
 }
 
 func (s *IioInterfaceSuite) TestConnectedPlugAppArmorSingleSnippet(c *C) {

--- a/interfaces/builtin/intel_mei_test.go
+++ b/interfaces/builtin/intel_mei_test.go
@@ -89,7 +89,7 @@ func (s *IntelMEISuite) TestUDevSpec(c *C) {
 	c.Assert(spec.Snippets(), HasLen, 2)
 	c.Assert(spec.Snippets(), testutil.Contains, `# intel-mei
 SUBSYSTEM=="mei", TAG+="snap_consumer_app"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_consumer_app"`, dirs.DistroLibExecDir))
 }
 
 func (s *IntelMEISuite) TestStaticInfo(c *C) {

--- a/interfaces/builtin/io_ports_control_test.go
+++ b/interfaces/builtin/io_ports_control_test.go
@@ -97,7 +97,7 @@ func (s *ioPortsControlInterfaceSuite) TestUDevSpec(c *C) {
 	c.Assert(udevSpec.Snippets(), HasLen, 2)
 	c.Assert(udevSpec.Snippets(), testutil.Contains, `# io-ports-control
 KERNEL=="port", TAG+="snap_consumer_app"`)
-	c.Assert(udevSpec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(udevSpec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_consumer_app"`, dirs.DistroLibExecDir))
 }
 
 func (s *ioPortsControlInterfaceSuite) TestStaticInfo(c *C) {

--- a/interfaces/builtin/ion_memory_control_test.go
+++ b/interfaces/builtin/ion_memory_control_test.go
@@ -90,7 +90,7 @@ func (s *IonMemoryControlInterfaceSuite) TestUDevSpec(c *C) {
 	c.Assert(spec.Snippets(), testutil.Contains, `# ion-memory-control
 KERNEL=="ion", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains,
-		fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+		fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_consumer_app"`, dirs.DistroLibExecDir))
 }
 
 func (s *IonMemoryControlInterfaceSuite) TestStaticInfo(c *C) {

--- a/interfaces/builtin/joystick_test.go
+++ b/interfaces/builtin/joystick_test.go
@@ -94,7 +94,7 @@ KERNEL=="js[0-9]*", TAG+="snap_consumer_app"`)
 KERNEL=="event[0-9]*", SUBSYSTEM=="input", ENV{ID_INPUT_JOYSTICK}=="1", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `# joystick
 KERNEL=="full", SUBSYSTEM=="mem", TAG+="snap_consumer_app"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_consumer_app"`, dirs.DistroLibExecDir))
 	c.Assert(spec.TriggeredSubsystems(), DeepEquals, []string{"input/joystick"})
 }
 

--- a/interfaces/builtin/kernel_module_control_test.go
+++ b/interfaces/builtin/kernel_module_control_test.go
@@ -99,7 +99,7 @@ func (s *KernelModuleControlInterfaceSuite) TestUDevSpec(c *C) {
 	c.Assert(spec.Snippets(), HasLen, 2)
 	c.Assert(spec.Snippets(), testutil.Contains, `# kernel-module-control
 KERNEL=="mem", TAG+="snap_consumer_app"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_consumer_app"`, dirs.DistroLibExecDir))
 }
 
 func (s *KernelModuleControlInterfaceSuite) TestStaticInfo(c *C) {

--- a/interfaces/builtin/kubernetes_support_test.go
+++ b/interfaces/builtin/kubernetes_support_test.go
@@ -254,7 +254,7 @@ func (s *KubernetesSupportInterfaceSuite) TestUDevConnectedPlug(c *C) {
 	c.Assert(spec.Snippets(), HasLen, 2)
 	c.Assert(spec.Snippets(), testutil.Contains, `# kubernetes-support
 KERNEL=="kmsg", TAG+="snap_kubernetes-support_default"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_kubernetes-support_default", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_kubernetes-support_default $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_kubernetes-support_default", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_kubernetes-support_default"`, dirs.DistroLibExecDir))
 
 	// kubeproxy should not have any rules
 	spec = &udev.Specification{}
@@ -269,7 +269,7 @@ KERNEL=="kmsg", TAG+="snap_kubernetes-support_default"`)
 	c.Assert(spec.Snippets(), HasLen, 2)
 	c.Assert(spec.Snippets(), testutil.Contains, `# kubernetes-support
 KERNEL=="kmsg", TAG+="snap_kubernetes-support_kubelet"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_kubernetes-support_kubelet", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_kubernetes-support_kubelet $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_kubernetes-support_kubelet", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_kubernetes-support_kubelet"`, dirs.DistroLibExecDir))
 }
 
 func (s *KubernetesSupportInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/builtin/kvm_test.go
+++ b/interfaces/builtin/kvm_test.go
@@ -127,7 +127,7 @@ func (s *kvmInterfaceSuite) TestUDevSpec(c *C) {
 	c.Assert(spec.Snippets(), HasLen, 2)
 	c.Assert(spec.Snippets()[0], Equals, `# kvm
 KERNEL=="kvm", TAG+="snap_consumer_app"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%s/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%s/snap-device-helper snap_consumer_app"`, dirs.DistroLibExecDir))
 }
 
 func (s *kvmInterfaceSuite) TestStaticInfo(c *C) {

--- a/interfaces/builtin/media_control_test.go
+++ b/interfaces/builtin/media_control_test.go
@@ -93,7 +93,7 @@ SUBSYSTEM=="media", KERNEL=="media[0-9]*", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `# media-control
 SUBSYSTEM=="video4linux", KERNEL=="v4l-subdev[0-9]*", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains,
-		fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+		fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_consumer_app"`, dirs.DistroLibExecDir))
 }
 
 func (s *MediacontrolInterfaceSuite) TestStaticInfo(c *C) {

--- a/interfaces/builtin/mir_test.go
+++ b/interfaces/builtin/mir_test.go
@@ -149,7 +149,7 @@ KERNEL=="mouse[0-9]*", TAG+="snap_mir-server_mir"`)
 KERNEL=="event[0-9]*", TAG+="snap_mir-server_mir"`)
 	c.Assert(udevSpec.Snippets(), testutil.Contains, `# mir
 KERNEL=="ts[0-9]*", TAG+="snap_mir-server_mir"`)
-	c.Assert(udevSpec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_mir-server_mir", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_mir-server_mir $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(udevSpec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_mir-server_mir", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_mir-server_mir"`, dirs.DistroLibExecDir))
 	c.Assert(udevSpec.TriggeredSubsystems(), DeepEquals, []string{"input"})
 }
 

--- a/interfaces/builtin/modem_manager_test.go
+++ b/interfaces/builtin/modem_manager_test.go
@@ -213,7 +213,7 @@ func (s *ModemManagerInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(udevSpec.Snippets()[0], testutil.Contains, `SUBSYSTEMS=="usb"`)
 	c.Assert(udevSpec.Snippets(), testutil.Contains, `# modem-manager
 KERNEL=="rfcomm*|tty[a-zA-Z]*[0-9]*|cdc-wdm[0-9]*|*MBIM|*QMI|*AT|*QCDM", TAG+="snap_modem-manager_mm"`)
-	c.Assert(udevSpec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_modem-manager_mm", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_modem-manager_mm $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(udevSpec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_modem-manager_mm", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_modem-manager_mm"`, dirs.DistroLibExecDir))
 }
 
 func (s *ModemManagerInterfaceSuite) TestPermanentSlotDBus(c *C) {

--- a/interfaces/builtin/network_control_test.go
+++ b/interfaces/builtin/network_control_test.go
@@ -145,7 +145,7 @@ func (s *NetworkControlInterfaceSuite) TestUDevSpec(c *C) {
 	c.Assert(spec.Snippets(), HasLen, 3)
 	c.Assert(spec.Snippets(), testutil.Contains, `# network-control
 KERNEL=="tun", TAG+="snap_consumer_app"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_consumer_app"`, dirs.DistroLibExecDir))
 }
 
 func (s *NetworkControlInterfaceSuite) TestMountSpec(c *C) {

--- a/interfaces/builtin/network_manager_test.go
+++ b/interfaces/builtin/network_manager_test.go
@@ -238,7 +238,7 @@ func (s *NetworkManagerInterfaceSuite) TestUDevPermanentSlot(c *C) {
 	c.Assert(spec.Snippets(), HasLen, 2)
 	c.Assert(spec.Snippets(), testutil.Contains, `# network-manager
 KERNEL=="rfkill", TAG+="snap_network-manager_nm"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_network-manager_nm", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_network-manager_nm $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_network-manager_nm", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_network-manager_nm"`, dirs.DistroLibExecDir))
 }
 
 func (s *NetworkManagerInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/builtin/ofono_test.go
+++ b/interfaces/builtin/ofono_test.go
@@ -212,7 +212,7 @@ KERNEL=="tty[a-zA-Z]*[0-9]*|cdc-wdm[0-9]*", TAG+="snap_ofono_app"`)
 KERNEL=="tun", TAG+="snap_ofono_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `# ofono
 KERNEL=="dsp", TAG+="snap_ofono_app"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_ofono_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_ofono_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_ofono_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_ofono_app"`, dirs.DistroLibExecDir))
 }
 
 func (s *OfonoInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/builtin/opengl_test.go
+++ b/interfaces/builtin/opengl_test.go
@@ -117,7 +117,7 @@ KERNEL=="mali[0-9]*", TAG+="snap_consumer_app"`)
 KERNEL=="dma_buf_te", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `# opengl
 KERNEL=="galcore", TAG+="snap_consumer_app"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_consumer_app"`, dirs.DistroLibExecDir))
 }
 
 func (s *OpenglInterfaceSuite) TestStaticInfo(c *C) {

--- a/interfaces/builtin/optical_drive_test.go
+++ b/interfaces/builtin/optical_drive_test.go
@@ -151,7 +151,7 @@ func (s *OpticalDriveInterfaceSuite) TestUDevSpec(c *C) {
 	c.Assert(spec.Snippets(), HasLen, 12) // four rules multiplied by three apps
 	c.Assert(spec.Snippets(), testutil.Contains, `# optical-drive
 KERNEL=="sr[0-9]*", TAG+="snap_consumer_app"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_consumer_app"`, dirs.DistroLibExecDir))
 }
 
 func (s *OpticalDriveInterfaceSuite) TestStaticInfo(c *C) {

--- a/interfaces/builtin/physical_memory_control_test.go
+++ b/interfaces/builtin/physical_memory_control_test.go
@@ -89,7 +89,7 @@ func (s *PhysicalMemoryControlInterfaceSuite) TestUDevSpec(c *C) {
 	c.Assert(spec.Snippets(), HasLen, 2)
 	c.Assert(spec.Snippets(), testutil.Contains, `# physical-memory-control
 KERNEL=="mem", TAG+="snap_consumer_app"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_consumer_app"`, dirs.DistroLibExecDir))
 }
 
 func (s *PhysicalMemoryControlInterfaceSuite) TestStaticInfo(c *C) {

--- a/interfaces/builtin/physical_memory_observe_test.go
+++ b/interfaces/builtin/physical_memory_observe_test.go
@@ -90,7 +90,7 @@ func (s *PhysicalMemoryObserveInterfaceSuite) TestUDevSpec(c *C) {
 	c.Assert(spec.Snippets(), HasLen, 2)
 	c.Assert(spec.Snippets(), testutil.Contains, `# physical-memory-observe
 KERNEL=="mem", TAG+="snap_consumer_app"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_consumer_app"`, dirs.DistroLibExecDir))
 }
 
 func (s *PhysicalMemoryObserveInterfaceSuite) TestStaticInfo(c *C) {

--- a/interfaces/builtin/ppp_test.go
+++ b/interfaces/builtin/ppp_test.go
@@ -98,7 +98,7 @@ func (s *PppInterfaceSuite) TestUDevSpec(c *C) {
 	c.Assert(spec.Snippets(), HasLen, 3)
 	c.Assert(spec.Snippets(), testutil.Contains, `# ppp
 KERNEL=="ppp", TAG+="snap_consumer_app"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_consumer_app"`, dirs.DistroLibExecDir))
 }
 
 func (s *PppInterfaceSuite) TestStaticInfo(c *C) {

--- a/interfaces/builtin/ptp_test.go
+++ b/interfaces/builtin/ptp_test.go
@@ -89,7 +89,7 @@ func (s *PTPInterfaceSuite) TestUDevSpec(c *C) {
 	c.Assert(spec.Snippets(), HasLen, 2)
 	c.Assert(spec.Snippets(), testutil.Contains, `# ptp
 SUBSYSTEM=="ptp", KERNEL=="ptp[0-9]*", TAG+="snap_consumer_app"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_consumer_app"`, dirs.DistroLibExecDir))
 }
 
 func (s *PTPInterfaceSuite) TestStaticInfo(c *C) {

--- a/interfaces/builtin/pulseaudio_test.go
+++ b/interfaces/builtin/pulseaudio_test.go
@@ -160,7 +160,7 @@ KERNEL=="controlC[0-9]*", TAG+="snap_pulseaudio_app1"`)
 KERNEL=="pcmC[0-9]*D[0-9]*[cp]", TAG+="snap_pulseaudio_app1"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `# pulseaudio
 KERNEL=="timer", TAG+="snap_pulseaudio_app1"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_pulseaudio_app1", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_pulseaudio_app1 $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_pulseaudio_app1", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_pulseaudio_app1"`, dirs.DistroLibExecDir))
 }
 
 func (s *PulseAudioInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/builtin/raw_input_test.go
+++ b/interfaces/builtin/raw_input_test.go
@@ -107,7 +107,7 @@ KERNEL=="mice", TAG+="snap_consumer_app"`)
 KERNEL=="mouse[0-9]*", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `# raw-input
 KERNEL=="ts[0-9]*", TAG+="snap_consumer_app"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_consumer_app"`, dirs.DistroLibExecDir))
 	c.Assert(spec.TriggeredSubsystems(), DeepEquals, []string{"input"})
 }
 

--- a/interfaces/builtin/raw_usb_test.go
+++ b/interfaces/builtin/raw_usb_test.go
@@ -101,7 +101,7 @@ SUBSYSTEM=="usb", TAG+="snap_consumer_app"`)
 SUBSYSTEM=="usbmisc", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `# raw-usb
 SUBSYSTEM=="tty", ENV{ID_BUS}=="usb", TAG+="snap_consumer_app"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_consumer_app"`, dirs.DistroLibExecDir))
 }
 
 func (s *RawUsbInterfaceSuite) TestStaticInfo(c *C) {

--- a/interfaces/builtin/raw_volume_test.go
+++ b/interfaces/builtin/raw_volume_test.go
@@ -298,7 +298,7 @@ func (s *rawVolumeInterfaceSuite) TestUDevSpec(c *C) {
 	c.Assert(spec.Snippets(), HasLen, 2)
 	c.Assert(spec.Snippets()[0], Equals, `# raw-volume
 KERNEL=="vda1", TAG+="snap_client-snap_app-accessing-1-part"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-1-part", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_client-snap_app-accessing-1-part $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-1-part", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_client-snap_app-accessing-1-part"`, dirs.DistroLibExecDir))
 
 	spec = &udev.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.testPlugPart2, s.testUDev2), IsNil)

--- a/interfaces/builtin/scsi_generic_test.go
+++ b/interfaces/builtin/scsi_generic_test.go
@@ -92,7 +92,7 @@ func (s *ScsiGenericInterfaceSuite) TestUDevSpec(c *C) {
 	c.Assert(udevSpec.Snippets(), HasLen, 2)
 	c.Assert(udevSpec.Snippets(), testutil.Contains, `# scsi-generic
 KERNEL=="sg[0-9]*", TAG+="snap_other_app"`)
-	c.Assert(udevSpec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_other_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_other_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(udevSpec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_other_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_other_app"`, dirs.DistroLibExecDir))
 }
 
 func (s *ScsiGenericInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/builtin/sd_control_test.go
+++ b/interfaces/builtin/sd_control_test.go
@@ -106,7 +106,7 @@ func (s *sdControlSuite) TestUDevConnectedPlugDualSD(c *C) {
 	c.Assert(spec.Snippets(), HasLen, 2)
 	c.Assert(spec.Snippets(), testutil.Contains, `# sd-control
 KERNEL=="DualSD", TAG+="snap_my-device_svc"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_my-device_svc", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_my-device_svc $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_my-device_svc", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_my-device_svc"`, dirs.DistroLibExecDir))
 }
 
 func (s *sdControlSuite) TestUDevConnectedPlugNoFlavor(c *C) {

--- a/interfaces/builtin/serial_port_test.go
+++ b/interfaces/builtin/serial_port_test.go
@@ -487,7 +487,7 @@ func (s *SerialPortInterfaceSuite) TestConnectedPlugUDevSnippets(c *C) {
 SUBSYSTEM=="tty", KERNEL=="ttyS0", TAG+="snap_client-snap_app-accessing-2-ports"`
 	c.Assert(snippet, Equals, expectedSnippet1)
 	extraSnippet := spec.Snippets()[1]
-	expectedExtraSnippet1 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-2-ports", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_client-snap_app-accessing-2-ports $devpath $major:$minor"`, dirs.DistroLibExecDir)
+	expectedExtraSnippet1 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-2-ports", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_client-snap_app-accessing-2-ports"`, dirs.DistroLibExecDir)
 	c.Assert(extraSnippet, Equals, expectedExtraSnippet1)
 
 	// add plug for the first slot with product and vendor ids
@@ -501,7 +501,7 @@ IMPORT{builtin}="usb_id"
 SUBSYSTEM=="tty", SUBSYSTEMS=="usb", ATTRS{idVendor}=="0001", ATTRS{idProduct}=="0001", TAG+="snap_client-snap_app-accessing-2-ports"`
 	c.Assert(snippet, Equals, expectedSnippet2)
 	extraSnippet = spec.Snippets()[1]
-	expectedExtraSnippet2 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-2-ports", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_client-snap_app-accessing-2-ports $devpath $major:$minor"`, dirs.DistroLibExecDir)
+	expectedExtraSnippet2 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-2-ports", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_client-snap_app-accessing-2-ports"`, dirs.DistroLibExecDir)
 	c.Assert(extraSnippet, Equals, expectedExtraSnippet2)
 
 	// add plug for the first slot with product and vendor ids
@@ -515,7 +515,7 @@ IMPORT{builtin}="usb_id"
 SUBSYSTEM=="tty", SUBSYSTEMS=="usb", ATTRS{idVendor}=="ffff", ATTRS{idProduct}=="ffff", TAG+="snap_client-snap_app-accessing-2-ports"`
 	c.Assert(snippet, Equals, expectedSnippet3)
 	extraSnippet = spec.Snippets()[1]
-	expectedExtraSnippet3 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-2-ports", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_client-snap_app-accessing-2-ports $devpath $major:$minor"`, dirs.DistroLibExecDir)
+	expectedExtraSnippet3 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-2-ports", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_client-snap_app-accessing-2-ports"`, dirs.DistroLibExecDir)
 	c.Assert(extraSnippet, Equals, expectedExtraSnippet3)
 
 	// add plug for the first slot with product and vendor ids and usb interface number
@@ -529,7 +529,7 @@ IMPORT{builtin}="usb_id"
 SUBSYSTEM=="tty", SUBSYSTEMS=="usb", ATTRS{idVendor}=="abcd", ATTRS{idProduct}=="1234", ENV{ID_USB_INTERFACE_NUM}=="00", TAG+="snap_client-snap_app-accessing-2-ports"`
 	c.Assert(snippet, Equals, expectedSnippet4)
 	extraSnippet = spec.Snippets()[1]
-	expectedExtraSnippet4 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-2-ports", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_client-snap_app-accessing-2-ports $devpath $major:$minor"`, dirs.DistroLibExecDir)
+	expectedExtraSnippet4 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-2-ports", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_client-snap_app-accessing-2-ports"`, dirs.DistroLibExecDir)
 	c.Assert(extraSnippet, Equals, expectedExtraSnippet4)
 }
 
@@ -605,75 +605,75 @@ func (s *SerialPortInterfaceSuite) TestConnectedPlugUDevSnippetsForPath(c *C) {
 	// these have only path
 	expectedSnippet1 := `# serial-port
 SUBSYSTEM=="tty", KERNEL=="ttyS0", TAG+="snap_client-snap_app-accessing-3rd-port"`
-	expectedExtraSnippet1 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-3rd-port", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_client-snap_app-accessing-3rd-port $devpath $major:$minor"`, dirs.DistroLibExecDir)
+	expectedExtraSnippet1 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-3rd-port", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_client-snap_app-accessing-3rd-port"`, dirs.DistroLibExecDir)
 	checkConnectedPlugSnippet(s.testPlugPort3, s.testSlot1, expectedSnippet1, expectedExtraSnippet1)
 
 	expectedSnippet2 := `# serial-port
 SUBSYSTEM=="tty", KERNEL=="ttyUSB927", TAG+="snap_client-snap_app-accessing-3rd-port"`
-	expectedExtraSnippet2 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-3rd-port", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_client-snap_app-accessing-3rd-port $devpath $major:$minor"`, dirs.DistroLibExecDir)
+	expectedExtraSnippet2 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-3rd-port", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_client-snap_app-accessing-3rd-port"`, dirs.DistroLibExecDir)
 	checkConnectedPlugSnippet(s.testPlugPort3, s.testSlot2, expectedSnippet2, expectedExtraSnippet2)
 
 	expectedSnippet3 := `# serial-port
 SUBSYSTEM=="tty", KERNEL=="ttyS42", TAG+="snap_client-snap_app-accessing-3rd-port"`
-	expectedExtraSnippet3 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-3rd-port", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_client-snap_app-accessing-3rd-port $devpath $major:$minor"`, dirs.DistroLibExecDir)
+	expectedExtraSnippet3 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-3rd-port", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_client-snap_app-accessing-3rd-port"`, dirs.DistroLibExecDir)
 	checkConnectedPlugSnippet(s.testPlugPort3, s.testSlot3, expectedSnippet3, expectedExtraSnippet3)
 
 	expectedSnippet4 := `# serial-port
 SUBSYSTEM=="tty", KERNEL=="ttyO0", TAG+="snap_client-snap_app-accessing-3rd-port"`
-	expectedExtraSnippet4 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-3rd-port", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_client-snap_app-accessing-3rd-port $devpath $major:$minor"`, dirs.DistroLibExecDir)
+	expectedExtraSnippet4 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-3rd-port", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_client-snap_app-accessing-3rd-port"`, dirs.DistroLibExecDir)
 	checkConnectedPlugSnippet(s.testPlugPort3, s.testSlot4, expectedSnippet4, expectedExtraSnippet4)
 
 	expectedSnippet5 := `# serial-port
 SUBSYSTEM=="tty", KERNEL=="ttyACM0", TAG+="snap_client-snap_app-accessing-3rd-port"`
-	expectedExtraSnippet5 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-3rd-port", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_client-snap_app-accessing-3rd-port $devpath $major:$minor"`, dirs.DistroLibExecDir)
+	expectedExtraSnippet5 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-3rd-port", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_client-snap_app-accessing-3rd-port"`, dirs.DistroLibExecDir)
 	checkConnectedPlugSnippet(s.testPlugPort3, s.testSlot5, expectedSnippet5, expectedExtraSnippet5)
 
 	expectedSnippet6 := `# serial-port
 SUBSYSTEM=="tty", KERNEL=="ttyAMA0", TAG+="snap_client-snap_app-accessing-3rd-port"`
-	expectedExtraSnippet6 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-3rd-port", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_client-snap_app-accessing-3rd-port $devpath $major:$minor"`, dirs.DistroLibExecDir)
+	expectedExtraSnippet6 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-3rd-port", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_client-snap_app-accessing-3rd-port"`, dirs.DistroLibExecDir)
 	checkConnectedPlugSnippet(s.testPlugPort3, s.testSlot6, expectedSnippet6, expectedExtraSnippet6)
 
 	expectedSnippet7 := `# serial-port
 SUBSYSTEM=="tty", KERNEL=="ttyXRUSB0", TAG+="snap_client-snap_app-accessing-3rd-port"`
-	expectedExtraSnippet7 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-3rd-port", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_client-snap_app-accessing-3rd-port $devpath $major:$minor"`, dirs.DistroLibExecDir)
+	expectedExtraSnippet7 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-3rd-port", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_client-snap_app-accessing-3rd-port"`, dirs.DistroLibExecDir)
 	checkConnectedPlugSnippet(s.testPlugPort3, s.testSlot7, expectedSnippet7, expectedExtraSnippet7)
 
 	expectedSnippet8 := `# serial-port
 SUBSYSTEM=="tty", KERNEL=="ttymxc2", TAG+="snap_client-snap_app-accessing-3rd-port"`
-	expectedExtraSnippet8 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-3rd-port", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_client-snap_app-accessing-3rd-port $devpath $major:$minor"`, dirs.DistroLibExecDir)
+	expectedExtraSnippet8 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-3rd-port", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_client-snap_app-accessing-3rd-port"`, dirs.DistroLibExecDir)
 	checkConnectedPlugSnippet(s.testPlugPort3, s.testSlot8, expectedSnippet8, expectedExtraSnippet8)
 
 	expectedSnippet9 := `# serial-port
 SUBSYSTEM=="tty", KERNEL=="ttySC0", TAG+="snap_client-snap_app-accessing-3rd-port"`
-	expectedExtraSnippet9 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-3rd-port", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_client-snap_app-accessing-3rd-port $devpath $major:$minor"`, dirs.DistroLibExecDir)
+	expectedExtraSnippet9 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-3rd-port", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_client-snap_app-accessing-3rd-port"`, dirs.DistroLibExecDir)
 	checkConnectedPlugSnippet(s.testPlugPort3, s.testSlot9, expectedSnippet9, expectedExtraSnippet9)
 
 	expectedSnippet10 := `# serial-port
 SUBSYSTEM=="tty", KERNEL=="ttyMSM0", TAG+="snap_client-snap_app-accessing-3rd-port"`
-	expectedExtraSnippet10 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-3rd-port", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_client-snap_app-accessing-3rd-port $devpath $major:$minor"`, dirs.DistroLibExecDir)
+	expectedExtraSnippet10 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-3rd-port", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_client-snap_app-accessing-3rd-port"`, dirs.DistroLibExecDir)
 	checkConnectedPlugSnippet(s.testPlugPort3, s.testSlot10, expectedSnippet10, expectedExtraSnippet10)
 
 	expectedSnippet11 := `# serial-port
 SUBSYSTEM=="tty", KERNEL=="ttyHS0", TAG+="snap_client-snap_app-accessing-3rd-port"`
-	expectedExtraSnippet11 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-3rd-port", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_client-snap_app-accessing-3rd-port $devpath $major:$minor"`, dirs.DistroLibExecDir)
+	expectedExtraSnippet11 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-3rd-port", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_client-snap_app-accessing-3rd-port"`, dirs.DistroLibExecDir)
 	checkConnectedPlugSnippet(s.testPlugPort3, s.testSlot11, expectedSnippet11, expectedExtraSnippet11)
 
 	expectedSnippet12 := `# serial-port
 SUBSYSTEM=="tty", KERNEL=="ttyGS0", TAG+="snap_client-snap_app-accessing-3rd-port"`
-	expectedExtraSnippet12 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-3rd-port", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_client-snap_app-accessing-3rd-port $devpath $major:$minor"`, dirs.DistroLibExecDir)
+	expectedExtraSnippet12 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-3rd-port", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_client-snap_app-accessing-3rd-port"`, dirs.DistroLibExecDir)
 	checkConnectedPlugSnippet(s.testPlugPort3, s.testSlot12, expectedSnippet12, expectedExtraSnippet12)
 
 	// these have product and vendor ids
 	expectedSnippet100 := `# serial-port
 IMPORT{builtin}="usb_id"
 SUBSYSTEM=="tty", SUBSYSTEMS=="usb", ATTRS{idVendor}=="0001", ATTRS{idProduct}=="0001", TAG+="snap_client-snap_app-accessing-3rd-port"`
-	expectedExtraSnippet100 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-3rd-port", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_client-snap_app-accessing-3rd-port $devpath $major:$minor"`, dirs.DistroLibExecDir)
+	expectedExtraSnippet100 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-3rd-port", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_client-snap_app-accessing-3rd-port"`, dirs.DistroLibExecDir)
 	checkConnectedPlugSnippet(s.testPlugPort3, s.testUDev1, expectedSnippet100, expectedExtraSnippet100)
 
 	expectedSnippet101 := `# serial-port
 IMPORT{builtin}="usb_id"
 SUBSYSTEM=="tty", SUBSYSTEMS=="usb", ATTRS{idVendor}=="ffff", ATTRS{idProduct}=="ffff", TAG+="snap_client-snap_app-accessing-3rd-port"`
-	expectedExtraSnippet101 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-3rd-port", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_client-snap_app-accessing-3rd-port $devpath $major:$minor"`, dirs.DistroLibExecDir)
+	expectedExtraSnippet101 := fmt.Sprintf(`TAG=="snap_client-snap_app-accessing-3rd-port", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_client-snap_app-accessing-3rd-port"`, dirs.DistroLibExecDir)
 	checkConnectedPlugSnippet(s.testPlugPort3, s.testUDev2, expectedSnippet101, expectedExtraSnippet101)
 }
 

--- a/interfaces/builtin/spi_test.go
+++ b/interfaces/builtin/spi_test.go
@@ -216,7 +216,7 @@ func (s *spiInterfaceSuite) TestUDevSpec(c *C) {
 	c.Assert(spec.Snippets(), HasLen, 2)
 	c.Assert(spec.Snippets(), testutil.Contains, `# spi
 KERNEL=="spidev0.0", TAG+="snap_consumer_app"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_consumer_app"`, dirs.DistroLibExecDir))
 }
 
 func (s *spiInterfaceSuite) TestAppArmorSpec(c *C) {

--- a/interfaces/builtin/tee_test.go
+++ b/interfaces/builtin/tee_test.go
@@ -95,7 +95,7 @@ KERNEL=="teepriv[0-9]*", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `# tee
 KERNEL=="qseecom", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains,
-		fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+		fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_consumer_app"`, dirs.DistroLibExecDir))
 }
 
 func (s *TeeInterfaceSuite) TestStaticInfo(c *C) {

--- a/interfaces/builtin/time_control_test.go
+++ b/interfaces/builtin/time_control_test.go
@@ -111,7 +111,7 @@ func (s *TimeControlInterfaceSuite) TestUDevSpec(c *C) {
 SUBSYSTEM=="rtc", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `# time-control
 KERNEL=="pps[0-9]*", TAG+="snap_consumer_app"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_consumer_app"`, dirs.DistroLibExecDir))
 }
 
 func (s *TimeControlInterfaceSuite) TestStaticInfo(c *C) {

--- a/interfaces/builtin/tpm_test.go
+++ b/interfaces/builtin/tpm_test.go
@@ -91,7 +91,7 @@ func (s *TpmInterfaceSuite) TestUDevSpec(c *C) {
 KERNEL=="tpm[0-9]*", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `# tpm
 KERNEL=="tpmrm[0-9]*", TAG+="snap_consumer_app"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_consumer_app"`, dirs.DistroLibExecDir))
 }
 
 func (s *TpmInterfaceSuite) TestStaticInfo(c *C) {

--- a/interfaces/builtin/u2f_devices_test.go
+++ b/interfaces/builtin/u2f_devices_test.go
@@ -93,7 +93,7 @@ func (s *u2fDevicesInterfaceSuite) TestUDevSpec(c *C) {
 	c.Assert(spec.Snippets(), testutil.Contains, `# u2f-devices
 # Yubico YubiKey
 SUBSYSTEM=="hidraw", KERNEL=="hidraw*", ATTRS{idVendor}=="1050", ATTRS{idProduct}=="0113|0114|0115|0116|0120|0121|0200|0402|0403|0406|0407|0410", TAG+="snap_consumer_app"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_consumer_app"`, dirs.DistroLibExecDir))
 }
 
 func (s *u2fDevicesInterfaceSuite) TestStaticInfo(c *C) {

--- a/interfaces/builtin/udisks2_test.go
+++ b/interfaces/builtin/udisks2_test.go
@@ -257,7 +257,7 @@ func (s *UDisks2InterfaceSuite) TestUDevSpec(c *C) {
 SUBSYSTEM=="block", TAG+="snap_producer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `# udisks2
 SUBSYSTEM=="usb", TAG+="snap_producer_app"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_producer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_producer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_producer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_producer_app"`, dirs.DistroLibExecDir))
 }
 
 func (s *UDisks2InterfaceSuite) TestUDevSpecFile(c *C) {

--- a/interfaces/builtin/uinput_test.go
+++ b/interfaces/builtin/uinput_test.go
@@ -94,7 +94,7 @@ func (s *uinputInterfaceSuite) TestUDevSpec(c *C) {
 	c.Assert(spec.Snippets(), HasLen, 2)
 	c.Assert(spec.Snippets()[0], Equals, `# uinput
 KERNEL=="uinput", TAG+="snap_consumer_app"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_consumer_app"`, dirs.DistroLibExecDir))
 }
 
 func (s *uinputInterfaceSuite) TestStaticInfo(c *C) {

--- a/interfaces/builtin/uio_test.go
+++ b/interfaces/builtin/uio_test.go
@@ -107,7 +107,7 @@ func (s *uioInterfaceSuite) TestUDevSpec(c *C) {
 	c.Assert(spec.Snippets(), HasLen, 2)
 	c.Assert(spec.Snippets(), testutil.Contains, `# uio
 SUBSYSTEM=="uio", KERNEL=="uio0", TAG+="snap_consumer_app"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_consumer_app"`, dirs.DistroLibExecDir))
 }
 
 func (s *uioInterfaceSuite) TestAppArmorConnectedPlugIgnoresMissingConfigFile(c *C) {

--- a/interfaces/builtin/vcio_test.go
+++ b/interfaces/builtin/vcio_test.go
@@ -89,7 +89,7 @@ func (s *VcioInterfaceSuite) TestUDevSpec(c *C) {
 	c.Assert(spec.Snippets(), HasLen, 2)
 	c.Assert(spec.Snippets(), testutil.Contains, `# vcio
 SUBSYSTEM=="bcm2708_vcio", KERNEL=="vcio", TAG+="snap_consumer_app"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_consumer_app"`, dirs.DistroLibExecDir))
 }
 
 func (s *VcioInterfaceSuite) TestStaticInfo(c *C) {

--- a/interfaces/builtin/wayland_test.go
+++ b/interfaces/builtin/wayland_test.go
@@ -184,7 +184,7 @@ KERNEL=="mouse[0-9]*", TAG+="snap_wayland_app1"`)
 KERNEL=="ts[0-9]*", TAG+="snap_wayland_app1"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `# wayland
 KERNEL=="tty[0-9]*", TAG+="snap_wayland_app1"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_wayland_app1", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_wayland_app1 $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_wayland_app1", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_wayland_app1"`, dirs.DistroLibExecDir))
 	c.Assert(spec.TriggeredSubsystems(), DeepEquals, []string{"input"})
 }
 

--- a/interfaces/builtin/x11_test.go
+++ b/interfaces/builtin/x11_test.go
@@ -253,7 +253,7 @@ KERNEL=="mouse[0-9]*", TAG+="snap_x11_app"`)
 KERNEL=="ts[0-9]*", TAG+="snap_x11_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `# x11
 KERNEL=="tty[0-9]*", TAG+="snap_x11_app"`)
-	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_x11_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_x11_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_x11_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_x11_app"`, dirs.DistroLibExecDir))
 	c.Assert(spec.TriggeredSubsystems(), DeepEquals, []string{"input"})
 
 	// on a classic system with x11 slot coming from the core snap.

--- a/interfaces/builtin/xilinx_dma_test.go
+++ b/interfaces/builtin/xilinx_dma_test.go
@@ -93,7 +93,7 @@ func (s *XilinxDmaInterfaceSuite) TestUDevSpec(c *C) {
 	c.Assert(spec.Snippets(), testutil.Contains, `# xilinx-dma
 SUBSYSTEM=="xdma", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(
-		`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+		`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper snap_consumer_app"`, dirs.DistroLibExecDir))
 }
 
 func (s *XilinxDmaInterfaceSuite) TestStaticInfo(c *C) {

--- a/interfaces/udev/spec.go
+++ b/interfaces/udev/spec.go
@@ -98,7 +98,7 @@ func (spec *Specification) TagDevice(snippet string) {
 		// SUBSYSTEM=="subsystem" is for subsystems (the top directories in /sys/class). Not for devices.
 		// When loaded, they send an ADD event
 		// snap-device-helper expects devices only, not modules nor subsystems
-		spec.addEntry(fmt.Sprintf("TAG==\"%s\", SUBSYSTEM!=\"module\", SUBSYSTEM!=\"subsystem\", RUN+=\"%s/snap-device-helper $env{ACTION} %s $devpath $major:$minor\"",
+		spec.addEntry(fmt.Sprintf("TAG==\"%s\", SUBSYSTEM!=\"module\", SUBSYSTEM!=\"subsystem\", RUN+=\"%s/snap-device-helper %s\"",
 			tag, dirs.DistroLibExecDir, tag), tag)
 	}
 }

--- a/interfaces/udev/spec_test.go
+++ b/interfaces/udev/spec_test.go
@@ -124,12 +124,12 @@ func (s *specSuite) testTagDevice(c *C, helperDir string) {
 kernel="voodoo", TAG+="snap_snap1_foo"`,
 		`# iface-2
 kernel="hoodoo", TAG+="snap_snap1_foo"`,
-		fmt.Sprintf(`TAG=="snap_snap1_foo", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%s/snap-device-helper $env{ACTION} snap_snap1_foo $devpath $major:$minor"`, helperDir),
+		fmt.Sprintf(`TAG=="snap_snap1_foo", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%s/snap-device-helper snap_snap1_foo"`, helperDir),
 		`# iface-1
 kernel="voodoo", TAG+="snap_snap1_hook_configure"`,
 		`# iface-2
 kernel="hoodoo", TAG+="snap_snap1_hook_configure"`,
-		fmt.Sprintf(`TAG=="snap_snap1_hook_configure", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%[1]s/snap-device-helper $env{ACTION} snap_snap1_hook_configure $devpath $major:$minor"`, helperDir),
+		fmt.Sprintf(`TAG=="snap_snap1_hook_configure", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%[1]s/snap-device-helper snap_snap1_hook_configure"`, helperDir),
 	})
 }
 

--- a/tests/main/security-device-cgroups-helper/task.yaml
+++ b/tests/main/security-device-cgroups-helper/task.yaml
@@ -77,10 +77,10 @@ execute: |
     snap run test-strict-cgroup-helper.sh -c 'head -1 /dev/kmsg' 2>&1 | MATCH "Operation not permitted"
 
     # snap-device-helper is invoked by udev as:
-    # RUN+="$libexecdir/snapd/snap-device-helper $env{ACTION} snap_test-strict-cgroup-helper_sh $devpath $major:$minor"
+    # RUN+="$libexecdir/snapd/snap-device-helper snap_test-strict-cgroup-helper_sh"
 
-    "$libexecdir"/snapd/snap-device-helper add snap_test-strict-cgroup-helper_sh "$DEVICES_PATH_MEM_FULL" 1:7
-    "$libexecdir"/snapd/snap-device-helper change snap_test-strict-cgroup-helper_sh "$DEVICES_PATH_MEM_FULL" 1:7
+    ACTION=add MAJOR=1 MINOR=7 SUBSYSTEM=mem "$libexecdir"/snapd/snap-device-helper snap_test-strict-cgroup-helper_sh
+    ACTION=change MAJOR=1 MINOR=7 SUBSYSTEM=mem "$libexecdir"/snapd/snap-device-helper snap_test-strict-cgroup-helper_sh
     # still present
     tests.device-cgroup test-strict-cgroup-helper.sh dump | MATCH 'c 1:7 rwm'
 
@@ -91,13 +91,13 @@ execute: |
     retry -n 5 test -e /var/snap/test-strict-cgroup-helper/common/started
 
     # device got added
-    "$libexecdir"/snapd/snap-device-helper add snap_test-strict-cgroup-helper_sh "$DEVICES_PATH_MEM_KMSG" 1:11
+    ACTION=add MAJOR=1 MINOR=11 SUBSYSTEM=mem "$libexecdir"/snapd/snap-device-helper snap_test-strict-cgroup-helper_sh
     tests.device-cgroup test-strict-cgroup-helper.sh dump | MATCH 'c 1:11 rwm'
     # or changed
-    "$libexecdir"/snapd/snap-device-helper change snap_test-strict-cgroup-helper_sh "$DEVICES_PATH_MEM_KMSG" 1:11
+    ACTION=change MAJOR=1 MINOR=11 SUBSYSTEM=mem "$libexecdir"/snapd/snap-device-helper snap_test-strict-cgroup-helper_sh
     tests.device-cgroup test-strict-cgroup-helper.sh dump | MATCH 'c 1:11 rwm'
     # or bound to driver
-    "$libexecdir"/snapd/snap-device-helper bind snap_test-strict-cgroup-helper_sh "$DEVICES_PATH_MEM_KMSG" 1:11
+    ACTION=bind MAJOR=1 MINOR=11 SUBSYSTEM=mem "$libexecdir"/snapd/snap-device-helper snap_test-strict-cgroup-helper_sh
     tests.device-cgroup test-strict-cgroup-helper.sh dump | MATCH 'c 1:11 rwm'
     # and it should be possible to read a line now
     touch /var/snap/test-strict-cgroup-helper/common/ready
@@ -108,11 +108,11 @@ execute: |
     test -n "$(cat run.log)"
 
     # unbind does not remove the device
-    "$libexecdir"/snapd/snap-device-helper unbind snap_test-strict-cgroup-helper_sh "$DEVICES_PATH_MEM_KMSG" 1:11
+    ACTION=unbind MAJOR=1 MINOR=11 SUBSYSTEM=mem "$libexecdir"/snapd/snap-device-helper snap_test-strict-cgroup-helper_sh
     tests.device-cgroup test-strict-cgroup-helper.sh dump | MATCH 'c 1:11 rwm'
 
     # remove action removes the device from the cgroup
-    "$libexecdir"/snapd/snap-device-helper remove snap_test-strict-cgroup-helper_sh "$DEVICES_PATH_MEM_KMSG" 1:11
+    ACTION=remove MAJOR=1 MINOR=11 SUBSYSTEM=mem "$libexecdir"/snapd/snap-device-helper snap_test-strict-cgroup-helper_sh
     # /dev/kmsg is not present anymore
     tests.device-cgroup test-strict-cgroup-helper.sh dump | NOMATCH 'c 1:11 rwm'
     # and it's not possible to read /dev/kmsg again
@@ -126,10 +126,10 @@ execute: |
     fi
 
     # running the helper does not fail for either device and action
-    "$libexecdir"/snapd/snap-device-helper add snap_test-strict-cgroup-helper_sh "$DEVICES_PATH_MEM_FULL" 1:7
-    "$libexecdir"/snapd/snap-device-helper change snap_test-strict-cgroup-helper_sh "$DEVICES_PATH_MEM_FULL" 1:7
-    "$libexecdir"/snapd/snap-device-helper add snap_test-strict-cgroup-helper_sh "$DEVICES_PATH_MEM_KMSG" 1:11
-    "$libexecdir"/snapd/snap-device-helper change snap_test-strict-cgroup-helper_sh "$DEVICES_PATH_MEM_KMSG" 1:11
+    ACTION=add MAJOR=1 MINOR=7 SUBSYSTEM=mem "$libexecdir"/snapd/snap-device-helper snap_test-strict-cgroup-helper_sh
+    ACTION=change MAJOR=1 MINOR=7 SUBSYSTEM=mem "$libexecdir"/snapd/snap-device-helper snap_test-strict-cgroup-helper_sh
+    ACTION=add MAJOR=1 MINOR=11 SUBSYSTEM=mem "$libexecdir"/snapd/snap-device-helper snap_test-strict-cgroup-helper_sh
+    ACTION=change MAJOR=1 MINOR=11 SUBSYSTEM=mem "$libexecdir"/snapd/snap-device-helper snap_test-strict-cgroup-helper_sh
 
     # and the device cgroup map/directory is still gone
     if is_cgroupv2; then

--- a/tests/main/security-device-cgroups-strict-enforced/task.yaml
+++ b/tests/main/security-device-cgroups-strict-enforced/task.yaml
@@ -25,7 +25,7 @@ execute: |
     echo "$content" > /etc/udev/rules.d/70-snap.test-strict-cgroup.rules
     libexecdir=$(os.paths libexec-dir)
     # populate a RUN rule like the one snapd adds for snap apps
-    content="TAG==\"snap_test-strict-cgroup_sh\" RUN+=\"$libexecdir/snapd/snap-device-helper \$env{ACTION} snap_test-strict-cgroup_sh \$devpath \$major:\$minor\""
+    content="TAG==\"snap_test-strict-cgroup_sh\" RUN+=\"$libexecdir/snapd/snap-device-helper snap_test-strict-cgroup_sh\""
     echo "$content" >> /etc/udev/rules.d/70-snap.test-strict-cgroup.rules
     udevadm control --reload-rules
     udevadm settle


### PR DESCRIPTION
udev does that for us and provides all the information we need even
for a delete event. So we can know if a device is a block without
guessing.

Depends on:
 * [x] #12874 (because of conflicts)