### PR TITLE
tests: fix basic20plus test for uc22 on rpi

### DIFF
--- a/tests/core/basic20plus/task.yaml
+++ b/tests/core/basic20plus/task.yaml
@@ -41,7 +41,7 @@ execute: |
     "test-snapd-sh-${base_snap}.sh" -c 'cat /var/lib/extrausers/passwd' | MATCH test
 
     case "$SPREAD_SYSTEM" in
-      ubuntu-core-20-64|ubuntu-core-22-64|ubuntu-core-22-arm-64)
+      ubuntu-core-20-64|ubuntu-core-22-64)
         echo "Ensure extracted kernel.efi exists"
         kernel_name="$(snaps.name kernel)"
         test -e /boot/grub/"$kernel_name"*/kernel.efi

--- a/tests/core/basic20plus/task.yaml
+++ b/tests/core/basic20plus/task.yaml
@@ -40,8 +40,8 @@ execute: |
     echo "Ensure passwd/group is available for snaps"
     "test-snapd-sh-${base_snap}.sh" -c 'cat /var/lib/extrausers/passwd' | MATCH test
 
-    case "$SPREAD_SYSTEM" in
-      ubuntu-core-20-64|ubuntu-core-22-64)
+    # rpi devices don't use grub
+    if ( os.query is-core20 || os.query is-core22 ) && not snap list pi-kernel &>/dev/null; then
         echo "Ensure extracted kernel.efi exists"
         kernel_name="$(snaps.name kernel)"
         test -e /boot/grub/"$kernel_name"*/kernel.efi
@@ -52,13 +52,11 @@ execute: |
         echo "Ensure we are using managed boot assets"
         MATCH '# Snapd-Boot-Config-Edition: [0-9]+' < /boot/grub/grub.cfg
         MATCH '# Snapd-Boot-Config-Edition: [0-9]+' < /run/mnt/ubuntu-seed/EFI/ubuntu/grub.cfg
-        ;;
-      *)
+    else
         echo "Ensure extracted {kernel,initrd}.img exists"
         test -e /run/mnt/ubuntu-seed/systems/*/kernel/kernel.img
         test -e /run/mnt/ubuntu-seed/systems/*/kernel/initrd.img
-        ;;
-    esac
+    fi
 
     echo "Ensure that model was written to ubuntu-boot"
     test -e /run/mnt/ubuntu-boot/device/model

--- a/tests/core/basic20plus/task.yaml
+++ b/tests/core/basic20plus/task.yaml
@@ -1,5 +1,12 @@
 summary: Check basic core20 and later system functionality
 
+details: |
+    Verify some basic functionalities in ubuntu core (>=20): system
+    snaps are present, the system is fully seeded, install a simple
+    snap, check boot configuration, symlinks in /var/lib/snapd/snaps,
+    snap recovery, loop devices and apparmor after a reboot works
+    properly
+
 systems:
   - ubuntu-core-20-*
   - ubuntu-core-22-*


### PR DESCRIPTION
This test is failing because uc22 on rpi is not using grub, it uses piboot instead. 

The test is failing to find the kernel.efi
