### PR TITLE
i/builtin: adds new JaCarta U2F usb token product id

### DIFF
--- a/interfaces/builtin/u2f_devices.go
+++ b/interfaces/builtin/u2f_devices.go
@@ -75,7 +75,7 @@ var u2fDevices = []u2fDevice{
 	{
 		Name:             "JaCarta U2F",
 		VendorIDPattern:  "24dc",
-		ProductIDPattern: "0101",
+		ProductIDPattern: "0101|0501",
 	},
 	{
 		Name:             "U2F Zero",


### PR DESCRIPTION
I have a real device - [JaCarta U2F token (usb)](https://www.aladdin-rd.ru/catalog/jacarta_u2f/) - and can confirm, that it has the following characteristics:
idVendor=24dc, idProduct=0501