### PR TITLE
i/b/desktop: allow desktop slots to provide notifications

### DIFF
--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -310,6 +310,35 @@ dbus (send, receive)
       peer=(label=unconfined),
 `
 
+var desktopPermanentSlotAppArmor = `
+# Description: Can provide various desktop services
+
+#include <abstractions/dbus-session-strict>
+
+# Able to provide notifications
+dbus (receive)
+    bus=session
+    path=/org/freedesktop/Notifications
+    interface=org.freedesktop.Notifications
+    member="{GetCapabilities,GetServerInformation,Notify,CloseNotification}"
+    peer=(label=unconfined),
+
+dbus (send)
+    bus=session
+    path=/org/freedesktop/Notifications
+    interface=org.freedesktop.Notifications
+    member={ActionInvoked,NotificationClosed,NotificationReplied}
+    peer=(label=unconfined),
+
+# Able to provide GTK notifications
+dbus (receive)
+    bus=session
+    path=/org/gtk/Notifications
+    interface=org.gtk.Notifications
+    member="{AddNotification,RemoveNotification}"
+    peer=(label=unconfined),
+`
+
 type desktopInterface struct {
 	commonInterface
 }


### PR DESCRIPTION
This is used in core desktop as the shell needs to expose these interfaces.
