### PR TITLE
aspects: parse and validate maps and simple strings

### DIFF
--- a/aspects/schema.go
+++ b/aspects/schema.go
@@ -337,7 +337,7 @@ func (v *stringSchema) Validate(raw []byte) error {
 			return err
 		}
 
-		return fmt.Errorf("cannot parse string: unexpected %s type", typeErr.Value)
+		return fmt.Errorf("cannot validate string: unexpected %s type", typeErr.Value)
 	}
 
 	return nil

--- a/aspects/schema.go
+++ b/aspects/schema.go
@@ -42,13 +42,21 @@ func ParseSchema(raw []byte) (*StorageSchema, error) {
 		return nil, fmt.Errorf("cannot parse top level schema: must be a map")
 	}
 
-	schema := &StorageSchema{}
-	// TODO: check "types" here and parse the user-defined types
+	if rawType, ok := schemaDef["type"]; ok {
+		var typ string
+		if err := json.Unmarshal(rawType, &typ); err != nil {
+			return nil, fmt.Errorf(`cannot parse top level schema's "type" entry: %w`, err)
+		}
+
+		return nil, fmt.Errorf(`cannot parse top level schema: expected map but got %s`, typ)
+	}
 
 	if _, ok := schemaDef["schema"]; !ok {
 		return nil, fmt.Errorf(`cannot parse top level schema: must have a "schema" constraint`)
 	}
 
+	// TODO: check "types" here and parse the user-defined types
+	schema := &StorageSchema{}
 	schema.topLevel, err = schema.parse(raw)
 	if err != nil {
 		return nil, err

--- a/aspects/schema.go
+++ b/aspects/schema.go
@@ -67,12 +67,14 @@ func ParseSchema(raw []byte) (*StorageSchema, error) {
 	return schema, nil
 }
 
+// StorageSchema represents an aspect schema and can be used to validate JSON
+// aspects against it.
 type StorageSchema struct {
 	// topLevel is the schema for the top level map.
 	topLevel Schema
 }
 
-// Validate validates the provided JSON object
+// Validate validates the provided JSON object.
 func (s *StorageSchema) Validate(raw []byte) error {
 	return s.topLevel.Validate(raw)
 }
@@ -123,7 +125,7 @@ func (s *StorageSchema) newTypeSchema(typ string) (parser, error) {
 	case "string":
 		return &stringSchema{}, nil
 	default:
-		return nil, fmt.Errorf("cannot parse type %q: unknown", typ)
+		return nil, fmt.Errorf("cannot parse unknown type %q", typ)
 	}
 }
 
@@ -197,7 +199,6 @@ func (v *mapSchema) Validate(raw []byte) error {
 			if err := v.keySchema.Validate(rawKey); err != nil {
 				return err
 			}
-
 		}
 	}
 
@@ -213,7 +214,7 @@ func (v *mapSchema) Validate(raw []byte) error {
 }
 
 func (v *mapSchema) parseConstraints(constraints map[string]json.RawMessage) error {
-	err := checkExclusiveConstraints(constraints)
+	err := checkExclusiveMapConstraints(constraints)
 	if err != nil {
 		return fmt.Errorf(`cannot parse map: %w`, err)
 	}
@@ -277,8 +278,8 @@ func (v *mapSchema) parseConstraints(constraints map[string]json.RawMessage) err
 	return nil
 }
 
-// checkExclusiveConstraints checks if the map contains mutually exclusive constraints.
-func checkExclusiveConstraints(obj map[string]json.RawMessage) error {
+// checkExclusiveMapConstraints checks if the map contains mutually exclusive constraints.
+func checkExclusiveMapConstraints(obj map[string]json.RawMessage) error {
 	has := func(k string) bool {
 		_, ok := obj[k]
 		return ok

--- a/aspects/schema.go
+++ b/aspects/schema.go
@@ -48,7 +48,9 @@ func ParseSchema(raw []byte) (*StorageSchema, error) {
 			return nil, fmt.Errorf(`cannot parse top level schema's "type" entry: %w`, err)
 		}
 
-		return nil, fmt.Errorf(`cannot parse top level schema: expected map but got %s`, typ)
+		if typ != "map" {
+			return nil, fmt.Errorf(`cannot parse top level schema: expected map but got %s`, typ)
+		}
 	}
 
 	if _, ok := schemaDef["schema"]; !ok {

--- a/aspects/schema.go
+++ b/aspects/schema.go
@@ -85,11 +85,11 @@ func (s *StorageSchema) parse(raw json.RawMessage) (parser, error) {
 	if err := json.Unmarshal(raw, &schemaDef); err != nil {
 		var typeErr *json.UnmarshalTypeError
 		if !errors.As(err, &typeErr) {
-			return nil, err
+			return nil, fmt.Errorf(`cannot parse aspect schema: %w`, err)
 		}
 
 		if err := json.Unmarshal(raw, &typ); err != nil {
-			return nil, err
+			return nil, fmt.Errorf(`cannot parse aspect schema: types constraint must be expressed as maps or strings: %w`, err)
 		}
 	} else {
 		rawType, ok := schemaDef["type"]
@@ -97,7 +97,7 @@ func (s *StorageSchema) parse(raw json.RawMessage) (parser, error) {
 			typ = "map"
 		} else {
 			if err := json.Unmarshal(rawType, &typ); err != nil {
-				return nil, err
+				return nil, fmt.Errorf(`cannot parse "type" constraint in type definition: %w`, err)
 			}
 		}
 	}

--- a/aspects/schema.go
+++ b/aspects/schema.go
@@ -121,8 +121,8 @@ type mapSchema struct {
 	// topSchema is the schema for the top-level schema which contains the user types.
 	topSchema *StorageSchema
 
-	// entrySchemas map keys that can the map can contain to their expected types.
-	// Alternatively, the schema can instead key and/or value types.
+	// entrySchemas maps keys to their expected types. Alternatively, the schema
+	// can constrain key and/or value types.
 	entrySchemas map[string]Schema
 
 	// valueSchema validates that the map's values match a certain type.

--- a/aspects/schema_test.go
+++ b/aspects/schema_test.go
@@ -189,7 +189,7 @@ func (*schemaSuite) TestMapWithUnmetValuesConstraint(c *C) {
 	c.Assert(err, IsNil)
 
 	err = schema.Validate(input)
-	c.Assert(err, ErrorMatches, "cannot parse string: unexpected object type")
+	c.Assert(err, ErrorMatches, "cannot validate string: unexpected object type")
 }
 
 func (*schemaSuite) TestMapSchemaMetConstraintsWithMissingEntry(c *C) {
@@ -235,7 +235,7 @@ func (*schemaSuite) TestMapSchemaUnmetConstraint(c *C) {
 	c.Assert(err, IsNil)
 
 	err = schema.Validate(input)
-	c.Assert(err, ErrorMatches, `cannot parse string: unexpected object type`)
+	c.Assert(err, ErrorMatches, `cannot validate string: unexpected object type`)
 }
 
 func (*schemaSuite) TestMapSchemaWithMetRequiredConstraint(c *C) {

--- a/aspects/schema_test.go
+++ b/aspects/schema_test.go
@@ -1,0 +1,355 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package aspects_test
+
+import (
+	"github.com/snapcore/snapd/aspects"
+	. "gopkg.in/check.v1"
+)
+
+type schemaSuite struct{}
+
+var _ = Suite(&schemaSuite{})
+
+func (*schemaSuite) TestTopLevelFailsWithoutSchema(c *C) {
+	schemaStr := []byte(`{
+  "keys": "string"
+}`)
+
+	_, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, ErrorMatches, `cannot parse top level schema: must have a "schema" constraint`)
+}
+
+func (*schemaSuite) TestSchemaMustBeMap(c *C) {
+	schemaStr := []byte(`["foo"]`)
+
+	_, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, ErrorMatches, `cannot parse top level schema: must be a map`)
+}
+
+func (*schemaSuite) TestMapWithSchemaConstraint(c *C) {
+	schemaStr := []byte(`{
+  "schema": {
+    "snaps": {
+			"type": "map",
+			"schema": {
+				"foo": "string",
+				"bar": "string"
+			}
+    }
+  }
+}`)
+
+	input := []byte(`{
+  "snaps": {
+    "foo": "abc",
+		"bar": "cba"
+  }
+}`)
+
+	schema, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, IsNil)
+
+	err = schema.Validate(input)
+	c.Assert(err, IsNil)
+}
+
+func (*schemaSuite) TestMapWithKeysStringConstraintHappy(c *C) {
+	schemaStr := []byte(`{
+  "schema": {
+    "snaps": {
+      "keys": "string"
+    }
+  }
+}`)
+
+	input := []byte(`{
+  "snaps": {
+    "foo": "bar"
+  }
+}`)
+
+	schema, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, IsNil)
+
+	err = schema.Validate(input)
+	c.Assert(err, IsNil)
+}
+
+func (*schemaSuite) TestMapWithKeysConstraintAsMap(c *C) {
+	// the map constraining "keys" is assumed to be based on type string
+	schemaStr := []byte(`{
+  "schema": {
+    "snaps": {
+      "keys": {
+			}
+    }
+  }
+}`)
+
+	input := []byte(`{
+  "snaps": {
+    "foo": "bar"
+  }
+}`)
+
+	schema, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, IsNil)
+
+	err = schema.Validate(input)
+	c.Assert(err, IsNil)
+}
+
+func (*schemaSuite) TestMapKeysConstraintMustBeStringBased(c *C) {
+	schemaStr := []byte(`{
+  "schema": {
+    "snaps": {
+      "keys": {
+				"type": "map"
+			}
+    }
+  }
+}`)
+
+	_, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, ErrorMatches, `cannot parse "keys" constraint: must be based on string but got "map"`)
+
+	schemaStr = []byte(`{
+  "schema": {
+    "snaps": {
+      "keys": "int"
+		}
+  }
+}`)
+
+	_, err = aspects.ParseSchema(schemaStr)
+	c.Assert(err, ErrorMatches, `cannot parse "keys" constraint: must be based on string but got "int"`)
+}
+
+// TODO: once string constraints are supported, test that keys with unmet constraints
+// fail during validation (can't test now because we can't express constraints)
+
+func (*schemaSuite) TestMapWithValuesStringConstraintHappy(c *C) {
+	schemaStr := []byte(`{
+  "schema": {
+    "snaps": {
+      "values": "string"
+    }
+  }
+}`)
+
+	input := []byte(`{
+  "snaps": {
+    "foo": "bar"
+  }
+}`)
+
+	schema, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, IsNil)
+
+	err = schema.Validate(input)
+	c.Assert(err, IsNil)
+}
+
+func (*schemaSuite) TestMapWithUnmetValuesConstraint(c *C) {
+	schemaStr := []byte(`{
+  "schema": {
+    "snaps": {
+      "values": "string"
+    }
+  }
+}`)
+
+	input := []byte(`{
+  "snaps": {
+    "foo": {}
+  }
+}`)
+
+	schema, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, IsNil)
+
+	err = schema.Validate(input)
+	c.Assert(err, ErrorMatches, "cannot parse string: unexpected object type")
+}
+
+func (*schemaSuite) TestMapSchemaMetConstraintsWithMissingEntry(c *C) {
+	schemaStr := []byte(`{
+  "schema": {
+    "foo": "string",
+		"bar": "string"
+  }
+}`)
+
+	// bar is in the schema but not the input and baz is the opposite (both aren't errors)
+	input := []byte(`{
+  "foo": "oof",
+	"baz": {
+		"a": "b"
+	}
+}`)
+
+	schema, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, IsNil)
+
+	err = schema.Validate(input)
+	c.Assert(err, IsNil)
+}
+
+func (*schemaSuite) TestMapSchemaUnmetConstraint(c *C) {
+	schemaStr := []byte(`{
+  "schema": {
+    "foo": "string",
+		"bar": "string"
+  }
+}`)
+
+	input := []byte(`{
+  "foo": "oof",
+	"bar": {
+		"a": "b"
+	},
+	"baz": "zab"
+}`)
+
+	schema, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, IsNil)
+
+	err = schema.Validate(input)
+	c.Assert(err, ErrorMatches, `cannot parse string: unexpected object type`)
+}
+
+func (*schemaSuite) TestMapSchemaWithMetRequiredConstraint(c *C) {
+	// single list of required entries
+	schemaStr := []byte(`{
+  "schema": {
+    "foo": "string",
+		"bar": "string",
+		"baz": "map"
+  },
+	"required": ["foo", "baz"]
+}`)
+
+	input := []byte(`{
+  "foo": "oof",
+	"baz": {
+		"a": "b"
+	}
+}`)
+
+	schema, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, IsNil)
+
+	err = schema.Validate(input)
+	c.Assert(err, IsNil)
+}
+
+func (*schemaSuite) TestMapSchemaWithUnmetRequiredConstraint(c *C) {
+	// single list of required entries
+	schemaStr := []byte(`{
+  "schema": {
+    "foo": "string",
+		"bar": "string",
+		"baz": "map"
+  },
+	"required": ["foo", "baz"]
+}`)
+
+	input := []byte(`{
+  "foo": "oof",
+	"bar": "rab"
+}`)
+
+	schema, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, IsNil)
+
+	err = schema.Validate(input)
+	c.Assert(err, ErrorMatches, "cannot find required combinations of keys")
+}
+
+func (*schemaSuite) TestMapSchemaWithAlternativeOfRequiredEntries(c *C) {
+	// multiple alternative lists of required entries
+	schemaStr := []byte(`{
+  "schema": {
+    "foo": "string",
+		"bar": "string",
+		"baz": "map"
+  },
+	"required": [["foo"], ["bar"]]
+}`)
+
+	// accepts the 1st allowed combination "foo"
+	input := []byte(`{
+  "foo": "oof"
+}`)
+
+	schema, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, IsNil)
+
+	err = schema.Validate(input)
+	c.Assert(err, IsNil)
+
+	// accepts the 2nd allowed combination "bar"
+	input = []byte(`{
+	"bar": "rab"
+}`)
+
+	schema, err = aspects.ParseSchema(schemaStr)
+	c.Assert(err, IsNil)
+
+	err = schema.Validate(input)
+	c.Assert(err, IsNil)
+}
+
+func (*schemaSuite) TestMapSchemaWithUnmetAlternativeOfRequiredEntries(c *C) {
+	// multiple alternative lists of required entries
+	schemaStr := []byte(`{
+  "schema": {
+    "foo": "string",
+		"bar": "string",
+		"baz": "map"
+  },
+	"required": [["foo"], ["bar"]]
+}`)
+
+	// accepts the 1st allowed combination "foo"
+	input := []byte(`{
+  "baz": {
+		"a": "b"
+	}
+}`)
+
+	schema, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, IsNil)
+
+	err = schema.Validate(input)
+	c.Assert(err, ErrorMatches, "cannot find required combinations of keys")
+}
+
+func (*schemaSuite) TestSchemaWithUnknownType(c *C) {
+	schemaStr := []byte(`{
+  "schema": {
+    "foo": "blarg"
+  }
+}`)
+
+	_, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, ErrorMatches, `cannot parse type "blarg": unknown`)
+}

--- a/aspects/schema_test.go
+++ b/aspects/schema_test.go
@@ -200,6 +200,19 @@ func (*schemaSuite) TestMapWithValuesStringConstraintHappy(c *C) {
 	c.Assert(err, IsNil)
 }
 
+func (*schemaSuite) TestMapWithBadValuesConstraint(c *C) {
+	schemaStr := []byte(`{
+	"schema": {
+		"snaps": {
+			"values": "int"
+		}
+	}
+}`)
+
+	_, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, ErrorMatches, `cannot parse unknown type "int"`)
+}
+
 func (*schemaSuite) TestMapWithUnmetValuesConstraint(c *C) {
 	schemaStr := []byte(`{
 	"schema": {
@@ -429,5 +442,5 @@ func (*schemaSuite) TestSchemaWithUnknownType(c *C) {
 }`)
 
 	_, err := aspects.ParseSchema(schemaStr)
-	c.Assert(err, ErrorMatches, `cannot parse type "blarg": unknown`)
+	c.Assert(err, ErrorMatches, `cannot parse unknown type "blarg"`)
 }

--- a/aspects/schema_test.go
+++ b/aspects/schema_test.go
@@ -46,6 +46,26 @@ func (*schemaSuite) TestSchemaMustBeMap(c *C) {
 	c.Assert(err, ErrorMatches, `cannot parse top level schema: must be a map`)
 }
 
+func (*schemaSuite) TestTopLevelMustBeMapType(c *C) {
+	schemaStr := []byte(`{
+	"type": "string"
+}`)
+
+	_, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, ErrorMatches, `cannot parse top level schema: expected map but got string`)
+}
+
+func (*schemaSuite) TestTopLevelTypeWrongFormat(c *C) {
+	schemaStr := []byte(`{
+	"type": {
+		"type": "string"
+	}
+}`)
+
+	_, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, ErrorMatches, `cannot parse top level schema's "type" entry: .*`)
+}
+
 func (*schemaSuite) TestMapWithSchemaConstraint(c *C) {
 	schemaStr := []byte(`{
 	"schema": {

--- a/aspects/schema_test.go
+++ b/aspects/schema_test.go
@@ -32,7 +32,7 @@ var _ = Suite(&schemaSuite{})
 
 func (*schemaSuite) TestTopLevelFailsWithoutSchema(c *C) {
 	schemaStr := []byte(`{
-  "keys": "string"
+	"keys": "string"
 }`)
 
 	_, err := aspects.ParseSchema(schemaStr)
@@ -48,22 +48,22 @@ func (*schemaSuite) TestSchemaMustBeMap(c *C) {
 
 func (*schemaSuite) TestMapWithSchemaConstraint(c *C) {
 	schemaStr := []byte(`{
-  "schema": {
-    "snaps": {
+	"schema": {
+		"snaps": {
 			"type": "map",
 			"schema": {
 				"foo": "string",
 				"bar": "string"
 			}
-    }
-  }
+		}
+	}
 }`)
 
 	input := []byte(`{
-  "snaps": {
-    "foo": "abc",
+	"snaps": {
+		"foo": "abc",
 		"bar": "cba"
-  }
+	}
 }`)
 
 	schema, err := aspects.ParseSchema(schemaStr)
@@ -75,17 +75,17 @@ func (*schemaSuite) TestMapWithSchemaConstraint(c *C) {
 
 func (*schemaSuite) TestMapWithKeysStringConstraintHappy(c *C) {
 	schemaStr := []byte(`{
-  "schema": {
-    "snaps": {
-      "keys": "string"
-    }
-  }
+	"schema": {
+		"snaps": {
+			"keys": "string"
+		}
+	}
 }`)
 
 	input := []byte(`{
-  "snaps": {
-    "foo": "bar"
-  }
+	"snaps": {
+		"foo": "bar"
+	}
 }`)
 
 	schema, err := aspects.ParseSchema(schemaStr)
@@ -98,18 +98,18 @@ func (*schemaSuite) TestMapWithKeysStringConstraintHappy(c *C) {
 func (*schemaSuite) TestMapWithKeysConstraintAsMap(c *C) {
 	// the map constraining "keys" is assumed to be based on type string
 	schemaStr := []byte(`{
-  "schema": {
-    "snaps": {
-      "keys": {
+	"schema": {
+		"snaps": {
+			"keys": {
 			}
-    }
-  }
+		}
+	}
 }`)
 
 	input := []byte(`{
-  "snaps": {
-    "foo": "bar"
-  }
+	"snaps": {
+		"foo": "bar"
+	}
 }`)
 
 	schema, err := aspects.ParseSchema(schemaStr)
@@ -121,24 +121,24 @@ func (*schemaSuite) TestMapWithKeysConstraintAsMap(c *C) {
 
 func (*schemaSuite) TestMapKeysConstraintMustBeStringBased(c *C) {
 	schemaStr := []byte(`{
-  "schema": {
-    "snaps": {
-      "keys": {
+	"schema": {
+		"snaps": {
+			"keys": {
 				"type": "map"
 			}
-    }
-  }
+		}
+	}
 }`)
 
 	_, err := aspects.ParseSchema(schemaStr)
 	c.Assert(err, ErrorMatches, `cannot parse "keys" constraint: must be based on string but got "map"`)
 
 	schemaStr = []byte(`{
-  "schema": {
-    "snaps": {
-      "keys": "int"
+	"schema": {
+		"snaps": {
+			"keys": "int"
 		}
-  }
+	}
 }`)
 
 	_, err = aspects.ParseSchema(schemaStr)
@@ -150,17 +150,17 @@ func (*schemaSuite) TestMapKeysConstraintMustBeStringBased(c *C) {
 
 func (*schemaSuite) TestMapWithValuesStringConstraintHappy(c *C) {
 	schemaStr := []byte(`{
-  "schema": {
-    "snaps": {
-      "values": "string"
-    }
-  }
+	"schema": {
+		"snaps": {
+			"values": "string"
+		}
+	}
 }`)
 
 	input := []byte(`{
-  "snaps": {
-    "foo": "bar"
-  }
+	"snaps": {
+		"foo": "bar"
+	}
 }`)
 
 	schema, err := aspects.ParseSchema(schemaStr)
@@ -172,17 +172,17 @@ func (*schemaSuite) TestMapWithValuesStringConstraintHappy(c *C) {
 
 func (*schemaSuite) TestMapWithUnmetValuesConstraint(c *C) {
 	schemaStr := []byte(`{
-  "schema": {
-    "snaps": {
-      "values": "string"
-    }
-  }
+	"schema": {
+		"snaps": {
+			"values": "string"
+		}
+	}
 }`)
 
 	input := []byte(`{
-  "snaps": {
-    "foo": {}
-  }
+	"snaps": {
+		"foo": {}
+	}
 }`)
 
 	schema, err := aspects.ParseSchema(schemaStr)
@@ -194,15 +194,15 @@ func (*schemaSuite) TestMapWithUnmetValuesConstraint(c *C) {
 
 func (*schemaSuite) TestMapSchemaMetConstraintsWithMissingEntry(c *C) {
 	schemaStr := []byte(`{
-  "schema": {
-    "foo": "string",
+	"schema": {
+		"foo": "string",
 		"bar": "string"
-  }
+	}
 }`)
 
 	// bar is in the schema but not the input and baz is the opposite (both aren't errors)
 	input := []byte(`{
-  "foo": "oof",
+	"foo": "oof",
 	"baz": {
 		"a": "b"
 	}
@@ -217,14 +217,14 @@ func (*schemaSuite) TestMapSchemaMetConstraintsWithMissingEntry(c *C) {
 
 func (*schemaSuite) TestMapSchemaUnmetConstraint(c *C) {
 	schemaStr := []byte(`{
-  "schema": {
-    "foo": "string",
+	"schema": {
+		"foo": "string",
 		"bar": "string"
-  }
+	}
 }`)
 
 	input := []byte(`{
-  "foo": "oof",
+	"foo": "oof",
 	"bar": {
 		"a": "b"
 	},
@@ -241,16 +241,16 @@ func (*schemaSuite) TestMapSchemaUnmetConstraint(c *C) {
 func (*schemaSuite) TestMapSchemaWithMetRequiredConstraint(c *C) {
 	// single list of required entries
 	schemaStr := []byte(`{
-  "schema": {
-    "foo": "string",
+	"schema": {
+		"foo": "string",
 		"bar": "string",
 		"baz": "map"
-  },
+	},
 	"required": ["foo", "baz"]
 }`)
 
 	input := []byte(`{
-  "foo": "oof",
+	"foo": "oof",
 	"baz": {
 		"a": "b"
 	}
@@ -266,16 +266,16 @@ func (*schemaSuite) TestMapSchemaWithMetRequiredConstraint(c *C) {
 func (*schemaSuite) TestMapSchemaWithUnmetRequiredConstraint(c *C) {
 	// single list of required entries
 	schemaStr := []byte(`{
-  "schema": {
-    "foo": "string",
+	"schema": {
+		"foo": "string",
 		"bar": "string",
 		"baz": "map"
-  },
+	},
 	"required": ["foo", "baz"]
 }`)
 
 	input := []byte(`{
-  "foo": "oof",
+	"foo": "oof",
 	"bar": "rab"
 }`)
 
@@ -289,17 +289,17 @@ func (*schemaSuite) TestMapSchemaWithUnmetRequiredConstraint(c *C) {
 func (*schemaSuite) TestMapSchemaWithAlternativeOfRequiredEntries(c *C) {
 	// multiple alternative lists of required entries
 	schemaStr := []byte(`{
-  "schema": {
-    "foo": "string",
+	"schema": {
+		"foo": "string",
 		"bar": "string",
 		"baz": "map"
-  },
+	},
 	"required": [["foo"], ["bar"]]
 }`)
 
 	// accepts the 1st allowed combination "foo"
 	input := []byte(`{
-  "foo": "oof"
+	"foo": "oof"
 }`)
 
 	schema, err := aspects.ParseSchema(schemaStr)
@@ -323,17 +323,17 @@ func (*schemaSuite) TestMapSchemaWithAlternativeOfRequiredEntries(c *C) {
 func (*schemaSuite) TestMapSchemaWithUnmetAlternativeOfRequiredEntries(c *C) {
 	// multiple alternative lists of required entries
 	schemaStr := []byte(`{
-  "schema": {
-    "foo": "string",
+	"schema": {
+		"foo": "string",
 		"bar": "string",
 		"baz": "map"
-  },
+	},
 	"required": [["foo"], ["bar"]]
 }`)
 
 	// accepts the 1st allowed combination "foo"
 	input := []byte(`{
-  "baz": {
+	"baz": {
 		"a": "b"
 	}
 }`)
@@ -355,8 +355,7 @@ func (*schemaSuite) TestMapInvalidConstraintCombos(c *C) {
 	tcs := []testcase{
 		{
 			name: "schema and keys",
-			snippet: `
-{
+			snippet: `{
 	"schema": { "foo": "bar" },
 	"keys": "string"
 }`,
@@ -364,8 +363,7 @@ func (*schemaSuite) TestMapInvalidConstraintCombos(c *C) {
 		},
 		{
 			name: "schema and values",
-			snippet: `
-{
+			snippet: `{
 	"schema": { "foo": "bar" },
 	"values": "string"
 }`,
@@ -373,8 +371,7 @@ func (*schemaSuite) TestMapInvalidConstraintCombos(c *C) {
 		},
 		{
 			name: "required w/o schema",
-			snippet: `
-{
+			snippet: `{
 	"required": ["foo"]
 }`,
 			err: `cannot parse map: cannot use "required" without "schema" constraint`,
@@ -383,9 +380,9 @@ func (*schemaSuite) TestMapInvalidConstraintCombos(c *C) {
 
 	for _, tc := range tcs {
 		schemaStr := []byte(fmt.Sprintf(`{
-  "schema": {
-    "top": %s
-  }
+	"schema": {
+		"top": %s
+	}
 }`, tc.snippet))
 
 		_, err := aspects.ParseSchema(schemaStr)
@@ -396,9 +393,9 @@ func (*schemaSuite) TestMapInvalidConstraintCombos(c *C) {
 
 func (*schemaSuite) TestSchemaWithUnknownType(c *C) {
 	schemaStr := []byte(`{
-  "schema": {
-    "foo": "blarg"
-  }
+	"schema": {
+		"foo": "blarg"
+	}
 }`)
 
 	_, err := aspects.ParseSchema(schemaStr)

--- a/aspects/schema_test.go
+++ b/aspects/schema_test.go
@@ -53,6 +53,16 @@ func (*schemaSuite) TestTopLevelMustBeMapType(c *C) {
 
 	_, err := aspects.ParseSchema(schemaStr)
 	c.Assert(err, ErrorMatches, `cannot parse top level schema: expected map but got string`)
+
+	schemaStr = []byte(`{
+		"type": "map",
+		"schema": {
+
+		}
+}`)
+
+	_, err = aspects.ParseSchema(schemaStr)
+	c.Assert(err, IsNil)
 }
 
 func (*schemaSuite) TestTopLevelTypeWrongFormat(c *C) {


### PR DESCRIPTION
Adds support for parsing and validating maps with "schema", "required", "keys" and "values" constraints. Also adds support for simple strings (without any of the constraints defined in the spec) because it simplifies testing of the maps (and, in the case of "keys", it's even required because they must be string-based). 
The spike that this was split from is https://github.com/snapcore/snapd/pull/13059. This PR is nearly as large as the draft even though the scope is much smaller (no ints, no string constraints, no user-defined types) because of all the tests. They're not verbose but they're many. The code's spec is SD133.