### PR TITLE
o/snapstate: remove snap data home directories

### DIFF
--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -95,7 +95,7 @@ type managerBackend interface {
 	RemoveSnapData(info *snap.Info, opts *dirs.SnapDirOptions) error
 	RemoveSnapCommonData(info *snap.Info, opts *dirs.SnapDirOptions) error
 	RemoveSnapSaveData(info *snap.Info, dev snap.Device) error
-	RemoveSnapDataDir(info *snap.Info, hasOtherInstances bool) error
+	RemoveSnapDataDir(info *snap.Info, hasOtherInstances bool, opts *dirs.SnapDirOptions) error
 	RemoveSnapMountUnits(s snap.PlaceInfo, meter progress.Meter) error
 	DiscardSnapNamespace(snapName string) error
 	RemoveSnapInhibitLock(snapName string) error

--- a/overlord/snapstate/backend/snapdata_test.go
+++ b/overlord/snapstate/backend/snapdata_test.go
@@ -20,6 +20,7 @@
 package backend_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -30,6 +31,7 @@ import (
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/snap/sysparams"
 )
 
 type snapdataSuite struct {
@@ -126,7 +128,7 @@ func mockSnapDir(baseDir string) error {
 	return nil
 }
 
-func (s *snapdataSuite) testRemoveSnapDataDir(c *C, opts *dirs.SnapDirOptions) {
+func (s *snapdataSuite) testRemoveSnapDataDir(c *C, opts *dirs.SnapDirOptions, withNonStandardHome bool) {
 	// create system data dirs
 	dataDir := filepath.Join(dirs.SnapDataDir, "hello")
 	c.Assert(mockSnapDir(dataDir), IsNil)
@@ -150,6 +152,37 @@ func (s *snapdataSuite) testRemoveSnapDataDir(c *C, opts *dirs.SnapDirOptions) {
 	instanceRootDataDir := filepath.Join(s.tempdir, "root", snapHomeDir, "hello_instance")
 	c.Assert(mockSnapDir(instanceRootDataDir), IsNil)
 
+	var systemDataDir1, instanceSystemDataDir1 string
+	var systemDataDir2, instanceSystemDataDir2 string
+	if withNonStandardHome {
+		sspPath := dirs.SnapSystemParamsUnder(s.tempdir)
+		c.Assert(os.MkdirAll(filepath.Dir(sspPath), 0755), IsNil)
+
+		ssp, err := sysparams.Open(s.tempdir)
+		c.Assert(err, IsNil)
+		systemHomeDir1 := filepath.Join(s.tempdir, "non-standard-home-1")
+		systemHomeDir2 := filepath.Join(s.tempdir, "non-standard-home-2")
+		ssp.Homedirs = fmt.Sprintf("%s,%s", systemHomeDir1, systemHomeDir2)
+		c.Assert(ssp.Write(), IsNil)
+
+		snapHomeDir := "snap"
+		if opts.HiddenSnapDataDir {
+			snapHomeDir = ".snap/data"
+		}
+
+		// create data dirs in non-standard-home-1
+		systemDataDir1 = filepath.Join(systemHomeDir1, "user2", snapHomeDir, "hello")
+		c.Assert(mockSnapDir(systemDataDir1), IsNil)
+		instanceSystemDataDir1 = filepath.Join(systemHomeDir1, "user2", snapHomeDir, "hello_instance")
+		c.Assert(mockSnapDir(instanceSystemDataDir1), IsNil)
+
+		// create data dirs in non-standard-home-2
+		systemDataDir2 = filepath.Join(systemHomeDir2, "user2", snapHomeDir, "hello")
+		c.Assert(mockSnapDir(systemDataDir2), IsNil)
+		instanceSystemDataDir2 = filepath.Join(systemHomeDir2, "user2", snapHomeDir, "hello_instance")
+		c.Assert(mockSnapDir(instanceSystemDataDir2), IsNil)
+	}
+
 	info := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
 
 	err := s.be.RemoveSnapDataDir(info, true, opts)
@@ -160,6 +193,12 @@ func (s *snapdataSuite) testRemoveSnapDataDir(c *C, opts *dirs.SnapDirOptions) {
 	c.Assert(osutil.FileExists(instanceHomeDataDir), Equals, true)
 	c.Assert(osutil.FileExists(rootDataDir), Equals, true)
 	c.Assert(osutil.FileExists(instanceRootDataDir), Equals, true)
+	if withNonStandardHome {
+		c.Assert(osutil.FileExists(systemDataDir1), Equals, true)
+		c.Assert(osutil.FileExists(instanceSystemDataDir1), Equals, true)
+		c.Assert(osutil.FileExists(systemDataDir2), Equals, true)
+		c.Assert(osutil.FileExists(instanceSystemDataDir2), Equals, true)
+	}
 
 	// now with instance key
 	info.InstanceKey = "instance"
@@ -169,10 +208,18 @@ func (s *snapdataSuite) testRemoveSnapDataDir(c *C, opts *dirs.SnapDirOptions) {
 	c.Assert(osutil.FileExists(instanceDataDir), Equals, false)
 	c.Assert(osutil.FileExists(instanceHomeDataDir), Equals, false)
 	c.Assert(osutil.FileExists(instanceRootDataDir), Equals, false)
+	if withNonStandardHome {
+		c.Assert(osutil.FileExists(instanceSystemDataDir1), Equals, false)
+		c.Assert(osutil.FileExists(instanceSystemDataDir2), Equals, false)
+	}
 	// but the snap-name ones are still around
 	c.Assert(osutil.FileExists(dataDir), Equals, true)
 	c.Assert(osutil.FileExists(homeDataDir), Equals, true)
 	c.Assert(osutil.FileExists(rootDataDir), Equals, true)
+	if withNonStandardHome {
+		c.Assert(osutil.FileExists(systemDataDir1), Equals, true)
+		c.Assert(osutil.FileExists(systemDataDir2), Equals, true)
+	}
 
 	// back to no instance key
 	info.InstanceKey = ""
@@ -182,14 +229,61 @@ func (s *snapdataSuite) testRemoveSnapDataDir(c *C, opts *dirs.SnapDirOptions) {
 	c.Assert(osutil.FileExists(dataDir), Equals, false)
 	c.Assert(osutil.FileExists(homeDataDir), Equals, false)
 	c.Assert(osutil.FileExists(rootDataDir), Equals, false)
+	if withNonStandardHome {
+		c.Assert(osutil.FileExists(systemDataDir1), Equals, false)
+		c.Assert(osutil.FileExists(systemDataDir2), Equals, false)
+	}
 }
 
 func (s *snapdataSuite) TestRemoveSnapDataDir(c *C) {
 	opts := &dirs.SnapDirOptions{HiddenSnapDataDir: false}
-	s.testRemoveSnapDataDir(c, opts)
+	s.testRemoveSnapDataDir(c, opts, false)
 }
 
 func (s *snapdataSuite) TestRemoveSnapDataDirWithHiddenDataDir(c *C) {
 	opts := &dirs.SnapDirOptions{HiddenSnapDataDir: true}
-	s.testRemoveSnapDataDir(c, opts)
+	s.testRemoveSnapDataDir(c, opts, false)
+}
+
+func (s *snapdataSuite) TestRemoveSnapDataDirSystemHomeDirs(c *C) {
+	opts := &dirs.SnapDirOptions{HiddenSnapDataDir: false}
+	s.testRemoveSnapDataDir(c, opts, true)
+}
+
+func (s *snapdataSuite) TestRemoveSnapDataDirSystemHomeDirsWithHiddenDataDir(c *C) {
+	opts := &dirs.SnapDirOptions{HiddenSnapDataDir: true}
+	s.testRemoveSnapDataDir(c, opts, true)
+}
+
+func (s *snapdataSuite) TestRemoveSnapDataDirBadDir(c *C) {
+	// we should try to cleanup as much as we can here (even if there is an error)
+	// avoid one bad dir breaking the cleanup of the others
+
+	// create system data dirs
+	instanceDataDir := filepath.Join(dirs.SnapDataDir, "hello_instance")
+	c.Assert(mockSnapDir(instanceDataDir), IsNil)
+
+	// create root home data dirs
+	instanceRootDataDir := filepath.Join(s.tempdir, "root", "snap", "hello_instance")
+	c.Assert(mockSnapDir(instanceRootDataDir), IsNil)
+
+	// create user home data dirs
+	instanceHomeDataDir := filepath.Join(s.tempdir, "home", "user1", "snap", "hello_instance")
+	c.Assert(mockSnapDir(instanceHomeDataDir), IsNil)
+	// make dir read-only
+	os.Chmod(instanceHomeDataDir, 0555)
+	defer func() {
+		// fix dir permissions to cleanup test
+		os.Chmod(instanceHomeDataDir, 0755)
+	}()
+
+	info := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
+	info.InstanceKey = "instance"
+	err := s.be.RemoveSnapDataDir(info, true, &dirs.SnapDirOptions{})
+	// home directory removal fails
+	c.Assert(err, ErrorMatches, `failed to remove snap "hello_instance" base directory:.*permission denied`)
+	c.Assert(osutil.FileExists(instanceHomeDataDir), Equals, true)
+	// other dirs are removed
+	c.Assert(osutil.FileExists(instanceDataDir), Equals, false)
+	c.Assert(osutil.FileExists(instanceRootDataDir), Equals, false)
 }

--- a/overlord/snapstate/backend/snapdata_test.go
+++ b/overlord/snapstate/backend/snapdata_test.go
@@ -126,7 +126,7 @@ func mockSnapDir(baseDir string) error {
 	return nil
 }
 
-func (s *snapdataSuite) testRemoveSnapDataDir(c *C, hiddenSnapDataDir bool) {
+func (s *snapdataSuite) testRemoveSnapDataDir(c *C, opts *dirs.SnapDirOptions) {
 	// create system data dirs
 	dataDir := filepath.Join(dirs.SnapDataDir, "hello")
 	c.Assert(mockSnapDir(dataDir), IsNil)
@@ -134,10 +134,9 @@ func (s *snapdataSuite) testRemoveSnapDataDir(c *C, hiddenSnapDataDir bool) {
 	c.Assert(mockSnapDir(instanceDataDir), IsNil)
 
 	snapHomeDir := "snap"
-	if hiddenSnapDataDir {
+	if opts.HiddenSnapDataDir {
 		snapHomeDir = ".snap/data"
 	}
-	opts := &dirs.SnapDirOptions{HiddenSnapDataDir: hiddenSnapDataDir}
 
 	// create user home data dirs
 	homeDataDir := filepath.Join(s.tempdir, "home", "user1", snapHomeDir, "hello")
@@ -186,9 +185,11 @@ func (s *snapdataSuite) testRemoveSnapDataDir(c *C, hiddenSnapDataDir bool) {
 }
 
 func (s *snapdataSuite) TestRemoveSnapDataDir(c *C) {
-	s.testRemoveSnapDataDir(c, false)
+	opts := &dirs.SnapDirOptions{HiddenSnapDataDir: false}
+	s.testRemoveSnapDataDir(c, opts)
 }
 
 func (s *snapdataSuite) TestRemoveSnapDataDirWithHiddenDataDir(c *C) {
-	s.testRemoveSnapDataDir(c, true)
+	opts := &dirs.SnapDirOptions{HiddenSnapDataDir: true}
+	s.testRemoveSnapDataDir(c, opts)
 }

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -1221,7 +1221,7 @@ func (f *fakeSnappyBackend) RemoveSnapSaveData(info *snap.Info, _ snap.Device) e
 	return f.maybeErrForLastOp()
 }
 
-func (f *fakeSnappyBackend) RemoveSnapDataDir(info *snap.Info, otherInstances bool) error {
+func (f *fakeSnappyBackend) RemoveSnapDataDir(info *snap.Info, otherInstances bool, opts *dirs.SnapDirOptions) error {
 	f.ops = append(f.ops, fakeOp{
 		op:             "remove-snap-data-dir",
 		name:           info.InstanceName(),

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1595,7 +1595,7 @@ func (m *SnapManager) doCopySnapData(t *state.Task, _ *tomb.Tomb) (err error) {
 		}
 		// no other instances of this snap, shared data directory can be
 		// removed now too
-		if err := m.backend.RemoveSnapDataDir(newInfo, otherInstances); err != nil {
+		if err := m.backend.RemoveSnapDataDir(newInfo, otherInstances, dirOpts); err != nil {
 			t.Errorf("cannot undo partial snap %q data copy, failed removing shared directory: %v", snapsup.InstanceName(), err)
 		}
 		return copyDataErr
@@ -1788,7 +1788,7 @@ func (m *SnapManager) undoCopySnapData(t *state.Task, _ *tomb.Tomb) error {
 	}
 	// no other instances of this snap and no other revisions, shared data
 	// directory can be removed
-	if err := m.backend.RemoveSnapDataDir(newInfo, otherInstances); err != nil {
+	if err := m.backend.RemoveSnapDataDir(newInfo, otherInstances, dirOpts); err != nil {
 		return err
 	}
 	return nil
@@ -3268,7 +3268,7 @@ func (m *SnapManager) doClearSnapData(t *state.Task, _ *tomb.Tomb) error {
 			return err
 		}
 		// Snap data directory can be removed now too
-		if err := m.backend.RemoveSnapDataDir(info, otherInstances); err != nil {
+		if err := m.backend.RemoveSnapDataDir(info, otherInstances, dirOpts); err != nil {
 			return err
 		}
 	}

--- a/snap/info.go
+++ b/snap/info.go
@@ -188,6 +188,11 @@ func BaseDataDir(name string) string {
 	return filepath.Join(dirs.SnapDataDir, name)
 }
 
+// BaseDataHomeDir returns the per user base directory for snap data locations.
+func BaseDataHomeDir(name string, opts *dirs.SnapDirOptions) string {
+	return filepath.Join(DataHomeGlob(opts), name)
+}
+
 // DataDir returns the data directory for given snap name and revision. The name
 // can be
 // either a snap name or snap instance name.
@@ -225,10 +230,15 @@ func snapDataDir(opts *dirs.SnapDirOptions) string {
 	return dirs.UserHomeSnapDir
 }
 
+// BaseUserDataDir returns the user-specific base data directory for given snap name.
+func BaseUserDataDir(home string, name string, opts *dirs.SnapDirOptions) string {
+	return filepath.Join(home, snapDataDir(opts), name)
+}
+
 // UserDataDir returns the user-specific data directory for given snap name. The
 // name can be either a snap name or snap instance name.
 func UserDataDir(home string, name string, revision Revision, opts *dirs.SnapDirOptions) string {
-	return filepath.Join(home, snapDataDir(opts), name, revision.String())
+	return filepath.Join(BaseUserDataDir(home, name, opts), revision.String())
 }
 
 // UserCommonDataDir returns the user-specific common data directory for given
@@ -654,9 +664,9 @@ func DataHomeGlob(opts *dirs.SnapDirOptions) string {
 	return dirs.SnapDataHomeGlob
 }
 
-// DataHomeDir returns the per user data directory of the snap.
+// DataHomeDir returns the per user data directory of the snap revision.
 func (s *Info) DataHomeDir(opts *dirs.SnapDirOptions) string {
-	return filepath.Join(DataHomeGlob(opts), s.InstanceName(), s.Revision.String())
+	return filepath.Join(BaseDataHomeDir(s.InstanceName(), opts), s.Revision.String())
 }
 
 // CommonDataHomeDir returns the per user data directory common across revisions

--- a/tests/main/user-data-handling/task.yaml
+++ b/tests/main/user-data-handling/task.yaml
@@ -1,26 +1,11 @@
 summary: Check that the refresh data copy works.
 
-environment:
-    USERNAME: home-sweet-home
-
-prepare: |
-    # Create a new user in a non-standard location
-    mkdir -p /remote/users
-    useradd -b /remote/users -m -U "$USERNAME"
-
-restore: |
-    userdel -f --remove "$USERNAME"
-    rm -rf /remote/users
-
 execute: |
-    echo "Enable the home directories under /remote/users"
-    snap set system homedirs=/remote/users
-
     echo "For an installed snap"
     snap install test-snapd-sh
     rev=$(snap list test-snapd-sh|tail -n1|tr -s ' '|cut -f3 -d' ')
 
-    homes=(/root/ /home/test/ "/remote/users/$USERNAME/")
+    homes=(/root/ /home/test/)
     echo "That has some user data"
     for h in "${homes[@]}"; do
         test -d "$h"
@@ -36,10 +21,6 @@ execute: |
 
     echo "Then the user data gets copied"
     for h in "${homes[@]}"; do
-        # TODO: fix data copy not working for non-standard home dirs
-        if [[ ${h} == "/remote/users/$USERNAME/" ]]; then
-            continue
-        fi
         test -e "${h}snap/test-snapd-sh/$new_rev/mock-data"
         test -e "${h}snap/test-snapd-sh/$rev/mock-data"
     done

--- a/tests/main/user-data-handling/task.yaml
+++ b/tests/main/user-data-handling/task.yaml
@@ -1,11 +1,26 @@
 summary: Check that the refresh data copy works.
 
+environment:
+    USERNAME: home-sweet-home
+
+prepare: |
+    # Create a new user in a non-standard location
+    mkdir -p /remote/users
+    useradd -b /remote/users -m -U "$USERNAME"
+
+restore: |
+    userdel -f --remove "$USERNAME"
+    rm -rf /remote/users
+
 execute: |
+    echo "Enable the home directories under /remote/users"
+    snap set system homedirs=/remote/users
+
     echo "For an installed snap"
     snap install test-snapd-sh
     rev=$(snap list test-snapd-sh|tail -n1|tr -s ' '|cut -f3 -d' ')
 
-    homes=(/root/ /home/test/)
+    homes=(/root/ /home/test/ "/remote/users/$USERNAME/")
     echo "That has some user data"
     for h in "${homes[@]}"; do
         test -d "$h"
@@ -21,6 +36,10 @@ execute: |
 
     echo "Then the user data gets copied"
     for h in "${homes[@]}"; do
+        # TODO: fix data copy not working for non-standard home dirs
+        if [[ ${h} == "/remote/users/$USERNAME/" ]]; then
+            continue
+        fi
         test -e "${h}snap/test-snapd-sh/$new_rev/mock-data"
         test -e "${h}snap/test-snapd-sh/$rev/mock-data"
     done

--- a/tests/main/user-data-handling/task.yaml
+++ b/tests/main/user-data-handling/task.yaml
@@ -30,6 +30,5 @@ execute: |
 
     echo "Then all user data and root data is gone"
     for h in "${homes[@]}"; do
-        test ! -e "${h}snap/test-snapd-sh/$new_rev/mock-data"
-        test ! -e "${h}snap/test-snapd-sh/$rev/mock-data"
+        test ! -e "${h}snap/test-snapd-sh"
     done


### PR DESCRIPTION
RemoveSnapDataDir was only removing snap data under `/var/snap/$SNAP`, it was extended to also remove snap users (including root) data home directories.

I intentionally avoided removing current data symlinks for home directories in `backend.UnlinkSnap` because their life cycle is already handled by `snap run` specifically `createOrUpdateUserDataSymlink` to avoid conflicts and confusion.

Fixes: https://bugs.launchpad.net/snapd/+bug/2009617