### PR TITLE
o/h/ctlcmd/mount.go: remove a useless start

### DIFF
--- a/overlord/hookstate/ctlcmd/mount.go
+++ b/overlord/hookstate/ctlcmd/mount.go
@@ -26,7 +26,6 @@ import (
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/utils"
-	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/ifacestate"
 	"github.com/snapcore/snapd/overlord/snapstate"
@@ -181,14 +180,14 @@ func (m *mountCommand) checkConnections(context *hookstate.Context) error {
 	return fmt.Errorf("no matching mount-control connection found")
 }
 
-func (m *mountCommand) createMountUnit(sysd systemd.Systemd) (string, error) {
+func (m *mountCommand) ensureMount(sysd systemd.Systemd) (string, error) {
 	snapName := m.snapInfo.InstanceName()
 	revision := m.snapInfo.SnapRevision().String()
 	lifetime := systemd.Transient
 	if m.Persistent {
 		lifetime = systemd.Persistent
 	}
-	return sysd.EnsureMountUnitFileWithOptions(&systemd.MountUnitOptions{
+	unitName, err := sysd.EnsureMountUnitFileWithOptions(&systemd.MountUnitOptions{
 		Lifetime: lifetime,
 		SnapName: snapName,
 		Revision: revision,
@@ -198,6 +197,10 @@ func (m *mountCommand) createMountUnit(sysd systemd.Systemd) (string, error) {
 		Options:  m.optionsList,
 		Origin:   "mount-control",
 	})
+	if err != nil {
+		_ = sysd.RemoveMountUnitFile(m.Positional.Where)
+	}
+	return unitName, err
 }
 
 func (m *mountCommand) Execute([]string) error {
@@ -219,20 +222,10 @@ func (m *mountCommand) Execute([]string) error {
 	}
 
 	sysd := systemd.New(systemd.SystemMode, nil)
-	name, err := m.createMountUnit(sysd)
+	_, err = m.ensureMount(sysd)
 	if err != nil {
-		return fmt.Errorf("cannot create mount unit: %v", err)
+		return fmt.Errorf("cannot ensure mount unit: %v", err)
 	}
 
-	if err := sysd.Start([]string{name}); err != nil {
-		// There's no point in keeping the mount unit if it doesn't work. Even
-		// if the problem is transient, the next invocation of "snapctl mount"
-		// will create a new unit anyway.
-		if err := sysd.RemoveMountUnitFile(m.Positional.Where); err != nil {
-			// Not much we can do about it, other than logging.
-			logger.Noticef("cannot remove mount unit on %q which failed to start: %v", m.Positional.Where, err)
-		}
-		return fmt.Errorf("cannot start mount unit: %v", err)
-	}
 	return nil
 }

--- a/overlord/hookstate/ctlcmd/mount_test.go
+++ b/overlord/hookstate/ctlcmd/mount_test.go
@@ -43,19 +43,11 @@ type ResultForEnsureMountUnitFileWithOptions struct {
 type FakeSystemdForMount struct {
 	systemd.Systemd
 
-	StartCalls  [][]string
-	StartResult error
-
 	RemoveMountUnitFileCalls  []string
 	RemoveMountUnitFileResult error
 
 	EnsureMountUnitFileWithOptionsCalls  []*systemd.MountUnitOptions
 	EnsureMountUnitFileWithOptionsResult ResultForEnsureMountUnitFileWithOptions
-}
-
-func (s *FakeSystemdForMount) Start(serviceNames []string) error {
-	s.StartCalls = append(s.StartCalls, serviceNames)
-	return s.StartResult
 }
 
 func (s *FakeSystemdForMount) RemoveMountUnitFile(baseDir string) error {
@@ -286,7 +278,7 @@ func (s *mountSuite) TestUnitCreationFailure(c *C) {
 	s.sysd.EnsureMountUnitFileWithOptionsResult = ResultForEnsureMountUnitFileWithOptions{"", errors.New("creation error")}
 
 	_, _, err := ctlcmd.Run(s.mockContext, []string{"mount", "-t", "ext4", "/src", "/dest"}, 0)
-	c.Check(err, ErrorMatches, `cannot create mount unit: creation error`)
+	c.Check(err, ErrorMatches, `cannot ensure mount unit: creation error`)
 	c.Check(s.sysd.EnsureMountUnitFileWithOptionsCalls, DeepEquals, []*systemd.MountUnitOptions{
 		{
 			Lifetime: systemd.Transient,
@@ -297,32 +289,6 @@ func (s *mountSuite) TestUnitCreationFailure(c *C) {
 			Fstype:   "ext4",
 			Origin:   "mount-control",
 		},
-	})
-	c.Check(s.sysd.StartCalls, HasLen, 0)
-}
-
-func (s *mountSuite) TestUnitStartFailure(c *C) {
-	s.injectSnapWithProperPlug(c)
-
-	s.sysd.EnsureMountUnitFileWithOptionsResult = ResultForEnsureMountUnitFileWithOptions{"/path/unit.mount", nil}
-	s.sysd.StartResult = errors.New("some start error")
-	s.sysd.RemoveMountUnitFileResult = errors.New("some removal error")
-
-	_, _, err := ctlcmd.Run(s.mockContext, []string{"mount", "-t", "ext4", "/src", "/dest"}, 0)
-	c.Check(err, ErrorMatches, `cannot start mount unit: some start error`)
-	c.Check(s.sysd.EnsureMountUnitFileWithOptionsCalls, DeepEquals, []*systemd.MountUnitOptions{
-		{
-			Lifetime: systemd.Transient,
-			SnapName: "snap1",
-			Revision: "1",
-			What:     "/src",
-			Where:    "/dest",
-			Fstype:   "ext4",
-			Origin:   "mount-control",
-		},
-	})
-	c.Check(s.sysd.StartCalls, DeepEquals, [][]string{
-		{"/path/unit.mount"},
 	})
 }
 
@@ -344,9 +310,6 @@ func (s *mountSuite) TestHappy(c *C) {
 			Options:  []string{"sync", "rw"},
 			Origin:   "mount-control",
 		},
-	})
-	c.Check(s.sysd.StartCalls, DeepEquals, [][]string{
-		{"/path/unit.mount"},
 	})
 }
 
@@ -371,9 +334,6 @@ func (s *mountSuite) TestHappyWithVariableExpansion(c *C) {
 			Origin:   "mount-control",
 		},
 	})
-	c.Check(s.sysd.StartCalls, DeepEquals, [][]string{
-		{"/path/unit.mount"},
-	})
 }
 
 func (s *mountSuite) TestHappyWithCommasInPath(c *C) {
@@ -395,7 +355,51 @@ func (s *mountSuite) TestHappyWithCommasInPath(c *C) {
 			Origin:   "mount-control",
 		},
 	})
-	c.Check(s.sysd.StartCalls, DeepEquals, [][]string{
-		{"/path/unit.mount"},
+}
+
+func (s *mountSuite) TestEnsureMountUnitFailed(c *C) {
+	s.injectSnapWithProperPlug(c)
+
+	s.sysd.EnsureMountUnitFileWithOptionsResult = ResultForEnsureMountUnitFileWithOptions{"", errors.New("some error")}
+
+	_, _, err := ctlcmd.Run(s.mockContext, []string{"mount", "--persistent", "-t", "ext4", "-o", "sync,rw", "/src", "/dest"}, 0)
+	c.Check(err, ErrorMatches, `cannot ensure mount unit: some error`)
+	c.Check(s.sysd.EnsureMountUnitFileWithOptionsCalls, DeepEquals, []*systemd.MountUnitOptions{
+		{
+			Lifetime: systemd.Persistent,
+			SnapName: "snap1",
+			Revision: "1",
+			What:     "/src",
+			Where:    "/dest",
+			Fstype:   "ext4",
+			Options:  []string{"sync", "rw"},
+			Origin:   "mount-control",
+		},
 	})
+
+	c.Check(s.sysd.RemoveMountUnitFileCalls, DeepEquals, []string{"/dest"})
+}
+
+func (s *mountSuite) TestEnsureMountUnitFailedRemoveFailed(c *C) {
+	s.injectSnapWithProperPlug(c)
+
+	s.sysd.EnsureMountUnitFileWithOptionsResult = ResultForEnsureMountUnitFileWithOptions{"", errors.New("some error")}
+	s.sysd.RemoveMountUnitFileResult = errors.New("some other error")
+
+	_, _, err := ctlcmd.Run(s.mockContext, []string{"mount", "--persistent", "-t", "ext4", "-o", "sync,rw", "/src", "/dest"}, 0)
+	c.Check(err, ErrorMatches, `cannot ensure mount unit: some error`)
+	c.Check(s.sysd.EnsureMountUnitFileWithOptionsCalls, DeepEquals, []*systemd.MountUnitOptions{
+		{
+			Lifetime: systemd.Persistent,
+			SnapName: "snap1",
+			Revision: "1",
+			What:     "/src",
+			Where:    "/dest",
+			Fstype:   "ext4",
+			Options:  []string{"sync", "rw"},
+			Origin:   "mount-control",
+		},
+	})
+
+	c.Check(s.sysd.RemoveMountUnitFileCalls, DeepEquals, []string{"/dest"})
 }


### PR DESCRIPTION
In combination with broken dev-mapper devices in UC20, it makes `snapctl mount` hang and then timeout.