### PR TITLE
cmd,snap: add support to pack snap components

### DIFF
--- a/cmd/snap/cmd_pack.go
+++ b/cmd/snap/cmd_pack.go
@@ -115,7 +115,7 @@ func (x *packCmd) Execute([]string) error {
 		return err
 	}
 
-	snapPath, err := pack.Snap(x.Positional.SnapDir, &pack.Options{
+	snapPath, err := pack.Pack(x.Positional.SnapDir, &pack.Options{
 		TargetDir:   x.Positional.TargetDir,
 		SnapName:    x.Filename,
 		Compression: x.Compression,

--- a/overlord/snapstate/check_snap.go
+++ b/overlord/snapstate/check_snap.go
@@ -231,7 +231,7 @@ func validateInfoAndFlags(info *snap.Info, snapst *SnapState, flags Flags) error
 var openSnapFile = backend.OpenSnapFile
 
 func validateContainer(c snap.Container, s *snap.Info, logf func(format string, v ...interface{})) error {
-	err := snap.ValidateContainer(c, s, logf)
+	err := snap.ValidateSnapContainer(c, s, logf)
 	if err == nil {
 		return nil
 	}

--- a/snap/component.go
+++ b/snap/component.go
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snap
+
+import (
+	"fmt"
+
+	"github.com/snapcore/snapd/snap/naming"
+	"gopkg.in/yaml.v2"
+)
+
+// ComponentInfo is the content of a component.yaml file.
+type ComponentInfo struct {
+	Component   naming.ComponentRef `yaml:"component"`
+	Type        ComponentType       `yaml:"type"`
+	Version     string              `yaml:"version"`
+	Summary     string              `yaml:"summary"`
+	Description string              `yaml:"description"`
+}
+
+// ReadComponentInfoFromContainer reads ComponentInfo from a snap component container.
+func ReadComponentInfoFromContainer(compf Container) (*ComponentInfo, error) {
+	yamlData, err := compf.ReadFile("meta/component.yaml")
+	if err != nil {
+		return nil, err
+	}
+
+	var ci ComponentInfo
+
+	if err := yaml.UnmarshalStrict(yamlData, &ci); err != nil {
+		return nil, fmt.Errorf("cannot parse component.yaml: %s", err)
+	}
+
+	if err := ci.validate(); err != nil {
+		return nil, err
+	}
+
+	return &ci, nil
+}
+
+// FullName returns the full name of the component, which is composed
+// by snap name and component name.
+func (ci *ComponentInfo) FullName() string {
+	return ci.Component.String()
+}
+
+// Validate performs some basic validations on component.yaml values.
+func (ci *ComponentInfo) validate() error {
+	if ci.Component.SnapName == "" {
+		return fmt.Errorf("snap name for component cannot be empty")
+	}
+	if ci.Component.ComponentName == "" {
+		return fmt.Errorf("component name cannot be empty")
+	}
+	if err := ci.Component.Validate(); err != nil {
+		return err
+	}
+	if ci.Type == "" {
+		return fmt.Errorf("component type cannot be empty")
+	}
+	// version is optional
+	if ci.Version != "" {
+		if err := ValidateVersion(ci.Version); err != nil {
+			return err
+		}
+	}
+	if err := ValidateSummary(ci.Summary); err != nil {
+		return err
+	}
+	if err := ValidateDescription(ci.Description); err != nil {
+		return err
+	}
+	return nil
+}

--- a/snap/component_test.go
+++ b/snap/component_test.go
@@ -1,0 +1,277 @@
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snap_test
+
+import (
+	"fmt"
+	"strings"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/naming"
+	"github.com/snapcore/snapd/snap/snapfile"
+	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type componentSuite struct {
+	testutil.BaseTest
+}
+
+var _ = Suite(&componentSuite{})
+
+func (s *componentSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	dirs.SetRootDir(c.MkDir())
+}
+
+func (s *componentSuite) TearDownTest(c *C) {
+	s.BaseTest.TearDownTest(c)
+	dirs.SetRootDir("")
+}
+
+func (s *componentSuite) TestReadComponentInfoFromFile(c *C) {
+	const componentYaml = `component: mysnap+test-info
+type: test
+version: 1.0
+summary: short description
+description: long description
+`
+	compName := "mysnap+test-info"
+	testComp := snaptest.MakeTestComponentWithFiles(c, compName+".comp", componentYaml, nil)
+
+	compf, err := snapfile.Open(testComp)
+	c.Assert(err, IsNil)
+
+	ci, err := snap.ReadComponentInfoFromContainer(compf)
+	c.Assert(err, IsNil)
+	c.Assert(ci, DeepEquals, &snap.ComponentInfo{
+		Component:   naming.NewComponentRef("mysnap", "test-info"),
+		Type:        "test",
+		Version:     "1.0",
+		Summary:     "short description",
+		Description: "long description",
+	})
+	c.Assert(ci.FullName(), Equals, compName)
+}
+
+func (s *componentSuite) TestReadComponentInfoMinimal(c *C) {
+	const componentYaml = `component: mysnap+test-info
+type: test
+version: 1.0.2
+`
+	compName := "mysnap+test-info"
+	testComp := snaptest.MakeTestComponentWithFiles(c, compName+".comp", componentYaml, nil)
+
+	compf, err := snapfile.Open(testComp)
+	c.Assert(err, IsNil)
+
+	ci, err := snap.ReadComponentInfoFromContainer(compf)
+	c.Assert(err, IsNil)
+	c.Assert(ci, DeepEquals, &snap.ComponentInfo{
+		Component: naming.NewComponentRef("mysnap", "test-info"),
+		Type:      "test",
+		Version:   "1.0.2",
+	})
+	c.Assert(ci.FullName(), Equals, compName)
+}
+
+func (s *componentSuite) TestReadComponentInfoFromFileBadName(c *C) {
+	const componentYaml = `component: mysnap-test-info
+type: test
+version: 1.0
+summary: short description
+description: long description
+`
+	testComp := snaptest.MakeTestComponentWithFiles(c, "mysnap-test-info.comp", componentYaml, nil)
+
+	compf, err := snapfile.Open(testComp)
+	c.Assert(err, IsNil)
+
+	ci, err := snap.ReadComponentInfoFromContainer(compf)
+	c.Assert(err.Error(), Equals, `cannot parse component.yaml: incorrect component name "mysnap-test-info"`)
+	c.Assert(ci, IsNil)
+}
+
+func (s *componentSuite) TestReadComponentUnexpectedField(c *C) {
+	const componentYaml = `component: mysnap+extra
+type: test
+version: 1.0
+foo: bar
+`
+	testComp := snaptest.MakeTestComponentWithFiles(c, "mysnap+extra.comp", componentYaml, nil)
+
+	compf, err := snapfile.Open(testComp)
+	c.Assert(err, IsNil)
+
+	ci, err := snap.ReadComponentInfoFromContainer(compf)
+	c.Assert(err, ErrorMatches, `.*\n.*: field foo not found in type snap.ComponentInfo`)
+	c.Assert(ci, IsNil)
+}
+
+func (s *componentSuite) TestReadComponentEmptyNames(c *C) {
+	const componentYamlTmpl = `component: %s
+type: test
+version: 1.0
+`
+
+	for _, tc := range []struct {
+		name, error string
+	}{
+		{name: "snapname+", error: "component name cannot be empty"},
+		{name: "+compname", error: "snap name for component cannot be empty"},
+		{name: "+", error: "snap name for component cannot be empty"},
+		{name: "", error: "snap name for component cannot be empty"},
+	} {
+		componentYaml := fmt.Sprintf(componentYamlTmpl, tc.name)
+		testComp := snaptest.MakeTestComponentWithFiles(c, "mysnap+extra.comp", componentYaml, nil)
+
+		compf, err := snapfile.Open(testComp)
+		c.Assert(err, IsNil)
+
+		ci, err := snap.ReadComponentInfoFromContainer(compf)
+		c.Assert(err, ErrorMatches, tc.error)
+		c.Assert(ci, IsNil)
+	}
+}
+
+func (s *componentSuite) TestReadComponentEmptyType(c *C) {
+	const componentYaml = `component: mysnap+extra
+version: 1.0
+`
+	testComp := snaptest.MakeTestComponentWithFiles(c, "mysnap+extra.comp", componentYaml, nil)
+
+	compf, err := snapfile.Open(testComp)
+	c.Assert(err, IsNil)
+
+	ci, err := snap.ReadComponentInfoFromContainer(compf)
+	c.Assert(err.Error(), Equals, `component type cannot be empty`)
+	c.Assert(ci, IsNil)
+}
+
+func (s *componentSuite) TestReadComponentBadType(c *C) {
+	const componentYaml = `component: mysnap+extra
+type: unknowntype
+version: 1.0
+`
+	testComp := snaptest.MakeTestComponentWithFiles(c, "mysnap+extra.comp", componentYaml, nil)
+
+	compf, err := snapfile.Open(testComp)
+	c.Assert(err, IsNil)
+
+	ci, err := snap.ReadComponentInfoFromContainer(compf)
+	c.Assert(err.Error(), Equals, `cannot parse component.yaml: unknown component type "unknowntype"`)
+	c.Assert(ci, IsNil)
+}
+
+func (s *componentSuite) TestReadComponentVersion(c *C) {
+	const componentYamlTmpl = `component: snap+comp
+type: test
+version: %s
+`
+
+	for _, tc := range []struct {
+		version, error string
+	}{
+		{version: "1.0a", error: ""},
+		{version: "1.2.3.4", error: ""},
+		{version: "1.2_", error: ".*must end with an ASCII alphanumeric.*"},
+		{version: "0123456789012345678901234567890123456789",
+			error: ".*cannot be longer than 32 characters.*"},
+		// version is optional
+		{version: "", error: ""},
+	} {
+		componentYaml := fmt.Sprintf(componentYamlTmpl, tc.version)
+		testComp := snaptest.MakeTestComponentWithFiles(c, "snap+comp.comp", componentYaml, nil)
+
+		compf, err := snapfile.Open(testComp)
+		c.Assert(err, IsNil)
+
+		ci, err := snap.ReadComponentInfoFromContainer(compf)
+		if tc.error != "" {
+			c.Check(err, ErrorMatches, tc.error)
+			c.Check(ci, IsNil)
+		} else {
+			c.Check(err, IsNil)
+			c.Check(ci.Version, Equals, tc.version)
+		}
+	}
+}
+
+func (s *componentSuite) TestReadComponentBadName(c *C) {
+	const componentYamlTmpl = `component: %s
+type: test
+version: 1.0
+`
+
+	for _, tc := range []struct {
+		name, error string
+	}{
+		{name: "name_+comp", error: `invalid snap name: "name_"`},
+		{name: "name+comp_", error: `invalid snap name: "comp_"`},
+	} {
+		componentYaml := fmt.Sprintf(componentYamlTmpl, tc.name)
+		testComp := snaptest.MakeTestComponentWithFiles(c, "snap+comp.comp", componentYaml, nil)
+
+		compf, err := snapfile.Open(testComp)
+		c.Assert(err, IsNil)
+
+		ci, err := snap.ReadComponentInfoFromContainer(compf)
+		c.Check(err, ErrorMatches, tc.error)
+		c.Assert(ci, IsNil)
+	}
+}
+
+func (s *componentSuite) TestReadComponentTooLongSummary(c *C) {
+	const componentYamlTmpl = `component: snap+comp
+type: test
+version: 2s.0b
+summary: %s
+description: 👹👺👻👽👾🤖
+`
+
+	componentYaml := fmt.Sprintf(componentYamlTmpl, strings.Repeat("👾🤖", 65))
+	testComp := snaptest.MakeTestComponentWithFiles(c, "snap+comp.comp", componentYaml, nil)
+
+	compf, err := snapfile.Open(testComp)
+	c.Assert(err, IsNil)
+
+	ci, err := snap.ReadComponentInfoFromContainer(compf)
+	c.Assert(err, ErrorMatches, "summary can have up to 128 codepoints, got 130")
+	c.Assert(ci, IsNil)
+}
+
+func (s *componentSuite) TestReadComponentTooLongDescription(c *C) {
+	const componentYamlTmpl = `component: snap+comp
+type: test
+version: 2s.0b
+description: %s
+`
+
+	componentYaml := fmt.Sprintf(componentYamlTmpl, strings.Repeat("👾🤖", 2049))
+	testComp := snaptest.MakeTestComponentWithFiles(c, "snap+comp.comp", componentYaml, nil)
+
+	compf, err := snapfile.Open(testComp)
+	c.Assert(err, IsNil)
+
+	ci, err := snap.ReadComponentInfoFromContainer(compf)
+	c.Assert(err, ErrorMatches, "description can have up to 4096 codepoints, got 4098")
+	c.Assert(ci, IsNil)
+}

--- a/snap/export_test.go
+++ b/snap/export_test.go
@@ -21,7 +21,6 @@ package snap
 
 var (
 	ValidateSocketName           = validateSocketName
-	ValidateDescription          = validateDescription
 	ValidateTitle                = validateTitle
 	InfoFromSnapYamlWithSideInfo = infoFromSnapYamlWithSideInfo
 	GetAttribute                 = getAttribute

--- a/snap/naming/componentref.go
+++ b/snap/naming/componentref.go
@@ -1,0 +1,67 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package naming
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ComponentRef contains the component name and the owner snap name.
+type ComponentRef struct {
+	SnapName      string
+	ComponentName string
+}
+
+// NewComponentRef returns a reference to a snap component.
+func NewComponentRef(snapName, componentName string) ComponentRef {
+	return ComponentRef{SnapName: snapName, ComponentName: componentName}
+}
+
+func (cr ComponentRef) String() string {
+	return fmt.Sprintf("%s+%s", cr.SnapName, cr.ComponentName)
+}
+
+// Validate validates the component.
+func (cr ComponentRef) Validate() error {
+	for _, name := range []string{cr.SnapName, cr.ComponentName} {
+		// Same restrictions as snap names
+		if err := ValidateSnap(name); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (cid *ComponentRef) UnmarshalYAML(unmarshall func(interface{}) error) error {
+	idStr := ""
+	if err := unmarshall(&idStr); err != nil {
+		return err
+	}
+
+	names := strings.Split(idStr, "+")
+	if len(names) != 2 {
+		return fmt.Errorf("incorrect component name %q", idStr)
+	}
+
+	*cid = ComponentRef{SnapName: names[0], ComponentName: names[1]}
+
+	return nil
+}

--- a/snap/naming/componentref_test.go
+++ b/snap/naming/componentref_test.go
@@ -1,0 +1,56 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package naming_test
+
+import (
+	. "gopkg.in/check.v1"
+	"gopkg.in/yaml.v2"
+
+	"github.com/snapcore/snapd/snap/naming"
+)
+
+type componentRefSuite struct{}
+
+var _ = Suite(&componentRefSuite{})
+
+func (s *componentRefSuite) TestNewComponentRefAndString(c *C) {
+	fooRef := naming.NewComponentRef("foo", "foo-comp")
+	c.Check(fooRef.SnapName, Equals, "foo")
+	c.Check(fooRef.ComponentName, Equals, "foo-comp")
+	c.Check(fooRef.String(), Equals, "foo+foo-comp")
+}
+
+func (s *componentRefSuite) TestValidate(c *C) {
+	fooRef := naming.NewComponentRef("foo", "foo-comp")
+	c.Check(fooRef.Validate(), IsNil)
+
+	fooRef = naming.NewComponentRef("foo_", "foo-comp")
+	c.Check(fooRef.Validate().Error(), Equals, `invalid snap name: "foo_"`)
+}
+
+func (s *componentRefSuite) TestUnmarshal(c *C) {
+	var cr naming.ComponentRef
+
+	yamlData := []byte(`mysnap+test-info`)
+	c.Check(yaml.UnmarshalStrict(yamlData, &cr), IsNil)
+
+	yamlData = []byte(`mysnap`)
+	c.Check(yaml.UnmarshalStrict(yamlData, &cr).Error(), Equals, `incorrect component name "mysnap"`)
+}

--- a/snap/pack/pack.go
+++ b/snap/pack/pack.go
@@ -96,7 +96,11 @@ func debArchitecture(info *snap.Info) string {
 
 // CheckSkeleton attempts to validate snap data in source directory
 func CheckSkeleton(w io.Writer, sourceDir string) error {
-	info, err := loadAndValidate(sourceDir)
+	yaml, err := os.ReadFile(filepath.Join(sourceDir, "meta", "snap.yaml"))
+	if err != nil {
+		return err
+	}
+	info, err := loadAndValidate(sourceDir, yaml)
 	if err == nil {
 		snap.SanitizePlugsSlots(info)
 		if len(info.BadInterfaces) > 0 {
@@ -106,12 +110,8 @@ func CheckSkeleton(w io.Writer, sourceDir string) error {
 	return err
 }
 
-func loadAndValidate(sourceDir string) (*snap.Info, error) {
+func loadAndValidate(sourceDir string, yaml []byte) (*snap.Info, error) {
 	container := snapdir.New(sourceDir)
-	yaml, err := container.ReadFile("meta/snap.yaml")
-	if err != nil {
-		return nil, err
-	}
 
 	info, err := snap.InfoFromSnapYaml(yaml)
 	if err != nil {
@@ -123,7 +123,7 @@ func loadAndValidate(sourceDir string) (*snap.Info, error) {
 		return nil, fmt.Errorf("cannot validate snap %q: %v", info.InstanceName(), err)
 	}
 
-	if err := snap.ValidateContainer(container, info, logger.Noticef); err != nil {
+	if err := snap.ValidateSnapContainer(container, info, logger.Noticef); err != nil {
 		return nil, err
 	}
 	if _, err := snap.ReadSnapshotYamlFromSnapFile(container); err != nil {
@@ -159,21 +159,6 @@ func snapPath(info *snap.Info, targetDir, snapName string) string {
 		snapName = filepath.Join(targetDir, snapName)
 	}
 	return snapName
-}
-
-func prepare(sourceDir, targetDir string) (*snap.Info, error) {
-	info, err := loadAndValidate(sourceDir)
-	if err != nil {
-		return nil, err
-	}
-
-	if targetDir != "" {
-		if err := os.MkdirAll(targetDir, 0755); err != nil {
-			return nil, err
-		}
-	}
-
-	return info, nil
 }
 
 func excludesFile() (filename string, err error) {
@@ -214,9 +199,9 @@ type Options struct {
 
 var Defaults *Options = nil
 
-// Snap the given sourceDirectory and return the generated
-// snap file
-func Snap(sourceDir string, opts *Options) (string, error) {
+// Pack the given sourceDirectory and return the generated
+// snap or component file.
+func Pack(sourceDir string, opts *Options) (string, error) {
 	if opts == nil {
 		opts = &Options{}
 	}
@@ -227,33 +212,95 @@ func Snap(sourceDir string, opts *Options) (string, error) {
 		return "", fmt.Errorf("cannot use compression %q", opts.Compression)
 	}
 
-	info, err := prepare(sourceDir, opts.TargetDir)
+	// ensure we have valid content
+	packFunc := packSnap
+	yaml, err := os.ReadFile(filepath.Join(sourceDir, "meta", "snap.yaml"))
 	if err != nil {
-		return "", err
+		if !os.IsNotExist(err) {
+			return "", err
+		}
+		// Maybe a component?
+		var errComp error
+		if yaml, errComp = os.ReadFile(filepath.Join(sourceDir, "meta", "component.yaml")); errComp != nil {
+			return "", err
+		}
+		packFunc = packComponent
 	}
 
-	excludes, err := excludesFile()
-	if err != nil {
-		return "", err
-	}
-	defer os.Remove(excludes)
-
-	snapName := snapPath(info, opts.TargetDir, opts.SnapName)
-	d := squashfs.New(snapName)
-	if err = d.Build(sourceDir, &squashfs.BuildOpts{
-		SnapType:     string(info.Type()),
-		Compression:  opts.Compression,
-		ExcludeFiles: []string{excludes},
-	}); err != nil {
-		return "", err
-	}
-
-	if opts.Integrity {
-		err := integrity.GenerateAndAppend(snapName)
-		if err != nil {
+	if opts.TargetDir != "" {
+		if err := os.MkdirAll(opts.TargetDir, 0755); err != nil {
 			return "", err
 		}
 	}
 
+	return packFunc(sourceDir, yaml, opts)
+}
+
+func packSnap(sourceDir string, yaml []byte, opts *Options) (string, error) {
+	info, err := loadAndValidate(sourceDir, yaml)
+	if err != nil {
+		return "", err
+	}
+
+	snapName := snapPath(info, opts.TargetDir, opts.SnapName)
+	if err := mksquashfs(sourceDir, snapName, string(info.Type()), opts); err != nil {
+		return "", err
+	}
+
 	return snapName, nil
+}
+
+func packComponent(sourceDir string, yaml []byte, opts *Options) (string, error) {
+	cont := snapdir.New(sourceDir)
+	ci, err := snap.ReadComponentInfoFromContainer(cont)
+	if err != nil {
+		return "", err
+	}
+	compPath := componentPath(ci, opts.TargetDir, opts.SnapName)
+	if err := snap.ValidateComponentContainer(cont, compPath, logger.Noticef); err != nil {
+		return "", err
+	}
+
+	if err := mksquashfs(sourceDir, compPath, "", opts); err != nil {
+		return "", err
+	}
+
+	return compPath, nil
+}
+
+func mksquashfs(sourceDir, fName, snapType string, opts *Options) error {
+	excludes, err := excludesFile()
+	if err != nil {
+		return err
+	}
+	defer os.Remove(excludes)
+
+	d := squashfs.New(fName)
+	if err := d.Build(sourceDir, &squashfs.BuildOpts{
+		SnapType:     snapType,
+		Compression:  opts.Compression,
+		ExcludeFiles: []string{excludes},
+	}); err != nil {
+		return err
+	}
+
+	if opts.Integrity {
+		err := integrity.GenerateAndAppend(fName)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func componentPath(ci *snap.ComponentInfo, targetDir, compName string) string {
+	if compName == "" {
+		// TODO should we consider architecture as with snaps?
+		compName = fmt.Sprintf("%s_%s.comp", ci.FullName(), ci.Version)
+	}
+	if targetDir != "" && !filepath.IsAbs(compName) {
+		compName = filepath.Join(targetDir, compName)
+	}
+	return compName
 }

--- a/snap/pack/pack_test.go
+++ b/snap/pack/pack_test.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -115,10 +116,23 @@ printf "hello world"
 	return tempdir
 }
 
+func makeExampleComponentSourceDir(c *C, componentYaml string) string {
+	tempdir := c.MkDir()
+	c.Assert(os.Chmod(tempdir, 0755), IsNil)
+
+	// use meta/snap.yaml
+	metaDir := filepath.Join(tempdir, "meta")
+	err := os.Mkdir(metaDir, 0755)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(filepath.Join(metaDir, "component.yaml"), []byte(componentYaml), 0644)
+	c.Assert(err, IsNil)
+	return tempdir
+}
+
 func (s *packSuite) TestPackNoManifestFails(c *C) {
 	sourceDir := makeExampleSnapSourceDir(c, "{name: hello, version: 0}")
 	c.Assert(os.Remove(filepath.Join(sourceDir, "meta", "snap.yaml")), IsNil)
-	_, err := pack.Snap(sourceDir, pack.Defaults)
+	_, err := pack.Pack(sourceDir, pack.Defaults)
 	c.Assert(err, ErrorMatches, `.*/meta/snap\.yaml: no such file or directory`)
 }
 
@@ -127,8 +141,22 @@ func (s *packSuite) TestPackInfoFromSnapYamlFails(c *C) {
 version: 0
 no-colon
 `)
-	_, err := pack.Snap(sourceDir, pack.Defaults)
+	_, err := pack.Pack(sourceDir, pack.Defaults)
 	c.Assert(err, ErrorMatches, `cannot parse snap.yaml: yaml: line 4: could not find expected ':'`)
+}
+
+func (s *packSuite) TestPackComponentBadName(c *C) {
+	sourceDir := makeExampleComponentSourceDir(c, "{component: hello, version: 0}")
+	pathName, err := pack.Pack(sourceDir, pack.Defaults)
+	c.Assert(pathName, Equals, "")
+	c.Assert(err.Error(), Equals, `cannot parse component.yaml: incorrect component name "hello"`)
+}
+
+func (s *packSuite) TestPackComponentBadYaml(c *C) {
+	sourceDir := makeExampleComponentSourceDir(c, "...")
+	pathName, err := pack.Pack(sourceDir, pack.Defaults)
+	c.Assert(pathName, Equals, "")
+	c.Assert(err.Error(), Equals, `cannot parse component.yaml: yaml: did not find expected node content`)
 }
 
 func (s *packSuite) TestPackMissingAppFails(c *C) {
@@ -139,7 +167,7 @@ apps:
   command: bin/hello-world
 `)
 	c.Assert(os.Remove(filepath.Join(sourceDir, "bin", "hello-world")), IsNil)
-	_, err := pack.Snap(sourceDir, pack.Defaults)
+	_, err := pack.Pack(sourceDir, pack.Defaults)
 	c.Assert(err, Equals, snap.ErrMissingPaths)
 }
 
@@ -152,7 +180,7 @@ apps:
 `)
 	c.Assert(os.Mkdir(filepath.Join(sourceDir, "meta", "hooks"), 0755), IsNil)
 	c.Assert(os.WriteFile(filepath.Join(sourceDir, "meta", "hooks", "default-configure"), []byte("#!/bin/sh"), 0755), IsNil)
-	_, err := pack.Snap(sourceDir, pack.Defaults)
+	_, err := pack.Pack(sourceDir, pack.Defaults)
 	c.Check(err, ErrorMatches, "cannot validate snap \"hello\": cannot specify \"default-configure\" hook without \"configure\" hook")
 }
 
@@ -167,7 +195,7 @@ apps:
 	configureHooks := []string{"configure", "default-configure"}
 	for _, hook := range configureHooks {
 		c.Assert(os.WriteFile(filepath.Join(sourceDir, "meta", "hooks", hook), []byte("#!/bin/sh"), 0666), IsNil)
-		_, err := pack.Snap(sourceDir, pack.Defaults)
+		_, err := pack.Pack(sourceDir, pack.Defaults)
 		c.Check(err, ErrorMatches, "snap is unusable due to bad permissions")
 	}
 }
@@ -183,7 +211,7 @@ apps:
 	configureHooks := []string{"configure", "default-configure"}
 	for _, hook := range configureHooks {
 		c.Assert(os.WriteFile(filepath.Join(sourceDir, "meta", "hooks", hook), []byte("#!/bin/sh"), 0755), IsNil)
-		_, err := pack.Snap(sourceDir, pack.Defaults)
+		_, err := pack.Pack(sourceDir, pack.Defaults)
 		c.Assert(err, IsNil)
 	}
 }
@@ -201,7 +229,7 @@ apps:
     - $SNAP_UNKNOWN_DIR/two
 `
 	c.Assert(os.WriteFile(filepath.Join(sourceDir, "meta", "snapshots.yaml"), []byte(invalidSnapshotYaml), 0444), IsNil)
-	_, err := pack.Snap(sourceDir, pack.Defaults)
+	_, err := pack.Pack(sourceDir, pack.Defaults)
 	c.Assert(err, ErrorMatches, "snapshot exclude path must start with one of.*")
 }
 
@@ -218,7 +246,7 @@ apps:
     - $SNAP_COMMON/two
 `
 	c.Assert(os.WriteFile(filepath.Join(sourceDir, "meta", "snapshots.yaml"), []byte(invalidSnapshotYaml), 0411), IsNil)
-	_, err := pack.Snap(sourceDir, pack.Defaults)
+	_, err := pack.Pack(sourceDir, pack.Defaults)
 	c.Assert(err, ErrorMatches, "snap is unusable due to bad permissions")
 }
 
@@ -235,7 +263,7 @@ apps:
     - $SNAP_COMMON/two
 `
 	c.Assert(os.WriteFile(filepath.Join(sourceDir, "meta", "snapshots.yaml"), []byte(invalidSnapshotYaml), 0444), IsNil)
-	_, err := pack.Snap(sourceDir, pack.Defaults)
+	_, err := pack.Pack(sourceDir, pack.Defaults)
 	c.Assert(err, IsNil)
 }
 
@@ -265,7 +293,7 @@ func (s *packSuite) TestPackExcludesBackups(c *C) {
 	target := c.MkDir()
 	// add a backup file
 	c.Assert(os.WriteFile(filepath.Join(sourceDir, "foo~"), []byte("hi"), 0755), IsNil)
-	snapfile, err := pack.Snap(sourceDir, &pack.Options{TargetDir: c.MkDir()})
+	snapfile, err := pack.Pack(sourceDir, &pack.Options{TargetDir: c.MkDir()})
 	c.Assert(err, IsNil)
 	c.Assert(squashfs.New(snapfile).Unpack("*", target), IsNil)
 
@@ -283,7 +311,7 @@ func (s *packSuite) TestPackExcludesTopLevelDEBIAN(c *C) {
 	c.Assert(os.MkdirAll(filepath.Join(sourceDir, "DEBIAN", "foo"), 0755), IsNil)
 	// and a non-toplevel DEBIAN
 	c.Assert(os.MkdirAll(filepath.Join(sourceDir, "bar", "DEBIAN", "baz"), 0755), IsNil)
-	snapfile, err := pack.Snap(sourceDir, &pack.Options{TargetDir: c.MkDir()})
+	snapfile, err := pack.Pack(sourceDir, &pack.Options{TargetDir: c.MkDir()})
 	c.Assert(err, IsNil)
 	c.Assert(squashfs.New(snapfile).Unpack("*", target), IsNil)
 	cmd := exec.Command("diff", "-qr", sourceDir, target)
@@ -301,7 +329,7 @@ func (s *packSuite) TestPackExcludesWholeDirs(c *C) {
 	// add a file inside a skipped dir
 	c.Assert(os.Mkdir(filepath.Join(sourceDir, ".bzr"), 0755), IsNil)
 	c.Assert(os.WriteFile(filepath.Join(sourceDir, ".bzr", "foo"), []byte("hi"), 0755), IsNil)
-	snapfile, err := pack.Snap(sourceDir, &pack.Options{TargetDir: c.MkDir()})
+	snapfile, err := pack.Pack(sourceDir, &pack.Options{TargetDir: c.MkDir()})
 	c.Assert(err, IsNil)
 	c.Assert(squashfs.New(snapfile).Unpack("*", target), IsNil)
 	out, _ := exec.Command("find", sourceDir).Output()
@@ -320,6 +348,55 @@ func (s *packSuite) TestDebArchitecture(c *C) {
 }
 
 func (s *packSuite) TestPackSimple(c *C) {
+	sourceDir := makeExampleComponentSourceDir(c, `component: hello+test
+type: test
+version: 1.0.1
+`)
+
+	outputDir := filepath.Join(c.MkDir(), "output")
+	absSnapFile := filepath.Join(c.MkDir(), "foo.comp")
+
+	type T struct {
+		outputDir, filename, expected string
+	}
+
+	table := []T{
+		// no output dir, no filename -> default in .
+		{"", "", "hello+test_1.0.1.comp"},
+		// no output dir, relative filename -> filename in .
+		{"", "foo.comp", "foo.comp"},
+		// no putput dir, absolute filename -> absolute filename
+		{"", absSnapFile, absSnapFile},
+		// output dir, no filename -> default in outputdir
+		{outputDir, "", filepath.Join(outputDir, "hello+test_1.0.1.comp")},
+		// output dir, relative filename -> filename in outputDir
+		{filepath.Join(outputDir, "inner"), "../foo.comp", filepath.Join(outputDir, "foo.comp")},
+		// output dir, absolute filename -> absolute filename
+		{outputDir, absSnapFile, absSnapFile},
+	}
+
+	for i, t := range table {
+		comm := Commentf("%d", i)
+		resultSnap, err := pack.Pack(sourceDir, &pack.Options{
+			TargetDir: t.outputDir,
+			SnapName:  t.filename,
+		})
+		c.Assert(err, IsNil, comm)
+
+		// check that there is result
+		_, err = os.Stat(resultSnap)
+		c.Assert(err, IsNil, comm)
+		c.Assert(resultSnap, Equals, t.expected, comm)
+
+		// check that the content looks sane
+		output, err := exec.Command("unsquashfs", "-ll", resultSnap).CombinedOutput()
+		c.Assert(err, IsNil, comm)
+		expr := fmt.Sprintf(`(?ms).*%s.*`, regexp.QuoteMeta("meta/component.yaml"))
+		c.Assert(string(output), Matches, expr, comm)
+	}
+}
+
+func (s *packSuite) TestPackComponentSimple(c *C) {
 	sourceDir := makeExampleSnapSourceDir(c, `name: hello
 version: 1.0.1
 architectures: ["i386", "amd64"]
@@ -352,7 +429,7 @@ integration:
 
 	for i, t := range table {
 		comm := Commentf("%d", i)
-		resultSnap, err := pack.Snap(sourceDir, &pack.Options{
+		resultSnap, err := pack.Pack(sourceDir, &pack.Options{
 			TargetDir: t.outputDir,
 			SnapName:  t.filename,
 		})
@@ -410,7 +487,7 @@ volumes:
 	absSnapFile := filepath.Join(c.MkDir(), "foo.snap")
 
 	// gadget validation fails during layout
-	_, err = pack.Snap(sourceDir, &pack.Options{
+	_, err = pack.Pack(sourceDir, &pack.Options{
 		TargetDir: outputDir,
 		SnapName:  absSnapFile,
 	})
@@ -420,7 +497,7 @@ volumes:
 	c.Assert(err, IsNil)
 
 	// gadget validation fails during content presence checks
-	_, err = pack.Snap(sourceDir, &pack.Options{
+	_, err = pack.Pack(sourceDir, &pack.Options{
 		TargetDir: outputDir,
 		SnapName:  absSnapFile,
 	})
@@ -429,7 +506,7 @@ volumes:
 	err = os.Mkdir(filepath.Join(sourceDir, "foo"), 0644)
 	c.Assert(err, IsNil)
 	// all good now
-	_, err = pack.Snap(sourceDir, &pack.Options{
+	_, err = pack.Pack(sourceDir, &pack.Options{
 		TargetDir: outputDir,
 		SnapName:  absSnapFile,
 	})
@@ -440,7 +517,7 @@ func (s *packSuite) TestPackWithCompressionHappy(c *C) {
 	sourceDir := makeExampleSnapSourceDir(c, "{name: hello, version: 0}")
 
 	for _, comp := range []string{"", "xz", "lzo"} {
-		snapfile, err := pack.Snap(sourceDir, &pack.Options{
+		snapfile, err := pack.Pack(sourceDir, &pack.Options{
 			TargetDir:   c.MkDir(),
 			Compression: comp,
 		})
@@ -453,7 +530,7 @@ func (s *packSuite) TestPackWithCompressionUnhappy(c *C) {
 	sourceDir := makeExampleSnapSourceDir(c, "{name: hello, version: 0}")
 
 	for _, comp := range []string{"gzip", "zstd", "silly"} {
-		snapfile, err := pack.Snap(sourceDir, &pack.Options{
+		snapfile, err := pack.Pack(sourceDir, &pack.Options{
 			TargetDir:   c.MkDir(),
 			Compression: comp,
 		})
@@ -495,7 +572,7 @@ esac
 `, verityHashSize, targetDir))
 	defer vscmd.Restore()
 
-	snapPath, err := pack.Snap(sourceDir, &pack.Options{
+	snapPath, err := pack.Pack(sourceDir, &pack.Options{
 		TargetDir: targetDir,
 		Integrity: true,
 	})

--- a/snap/snaptest/snaptest.go
+++ b/snap/snaptest/snaptest.go
@@ -250,7 +250,7 @@ func MakeTestSnapInfoWithFiles(c *check.C, snapYamlContent string, files [][]str
 	}
 	err = osutil.ChDir(snapSource, func() error {
 		var err error
-		snapFilePath, err = pack.Snap(snapSource, nil)
+		snapFilePath, err = pack.Pack(snapSource, nil)
 		return err
 	})
 	c.Assert(err, check.IsNil)
@@ -267,7 +267,7 @@ func MakeSnapFileAndDir(c *check.C, snapYamlContent string, files [][]string, si
 	defer restoreSanitize()
 
 	err := osutil.ChDir(info.MountDir(), func() error {
-		snapName, err := pack.Snap(info.MountDir(), &pack.Options{
+		snapName, err := pack.Pack(info.MountDir(), &pack.Options{
 			SnapName: info.MountFile(),
 		})
 		c.Check(snapName, check.Equals, info.MountFile())

--- a/snap/snaptest/snaptest.go
+++ b/snap/snaptest/snaptest.go
@@ -33,6 +33,7 @@ import (
 	"github.com/snapcore/snapd/snap/channel"
 	"github.com/snapcore/snapd/snap/pack"
 	"github.com/snapcore/snapd/snap/snapdir"
+	"github.com/snapcore/snapd/snap/squashfs"
 )
 
 func mockSnap(c *check.C, instanceName, yamlText string, sideInfo *snap.SideInfo) *snap.Info {
@@ -205,19 +206,39 @@ func MakeTestSnapWithFiles(c *check.C, snapYamlContent string, files [][]string)
 	return path
 }
 
+// MakeTestComponentWithFiles builds a snap component container with a
+// given name and content for component.yaml, populating additionally
+// the squashfs with files if required.
+func MakeTestComponentWithFiles(c *check.C, componentName, componentYaml string, files [][]string) (snapFilePath string) {
+	compSource := populateContainer(c, "component.yaml", componentYaml, files)
+	err := osutil.ChDir(compSource, func() error {
+		d := squashfs.New(componentName)
+		err := d.Build(compSource, nil)
+		return err
+	})
+	c.Assert(err, check.IsNil)
+	return filepath.Join(compSource, componentName)
+}
+
+func populateContainer(c *check.C, yamlFile, yamlContent string, files [][]string) string {
+	tmpdir := c.MkDir()
+	snapSource := filepath.Join(tmpdir, "snapsrc")
+	err := os.MkdirAll(filepath.Join(snapSource, "meta"), 0755)
+	c.Assert(err, check.IsNil)
+	snapYamlFn := filepath.Join(snapSource, "meta", yamlFile)
+	err = os.WriteFile(snapYamlFn, []byte(yamlContent), 0644)
+	c.Assert(err, check.IsNil)
+	PopulateDir(snapSource, files)
+	return snapSource
+}
+
 // MakeTestSnapInfoWithFiles makes a squashfs snap file with the given snap.yaml
 // content and optional extra files specified as pairs of relative file path and
 // it's contents, and returns the path to the snap file and a suitable snap.Info
 // for the snap
 func MakeTestSnapInfoWithFiles(c *check.C, snapYamlContent string, files [][]string, si *snap.SideInfo) (snapFilePath string, info *snap.Info) {
-	tmpdir := c.MkDir()
-	snapSource := filepath.Join(tmpdir, "snapsrc")
-	err := os.MkdirAll(filepath.Join(snapSource, "meta"), 0755)
-	c.Assert(err, check.IsNil)
-	snapYamlFn := filepath.Join(snapSource, "meta", "snap.yaml")
-	err = os.WriteFile(snapYamlFn, []byte(snapYamlContent), 0644)
-	c.Assert(err, check.IsNil)
-	PopulateDir(snapSource, files)
+	snapSource := populateContainer(c, "snap.yaml", snapYamlContent, files)
+
 	restoreSanitize := snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {})
 	defer restoreSanitize()
 
@@ -234,7 +255,6 @@ func MakeTestSnapInfoWithFiles(c *check.C, snapYamlContent string, files [][]str
 	})
 	c.Assert(err, check.IsNil)
 	return filepath.Join(snapSource, snapFilePath), snapInfo
-
 }
 
 // MakeSnapFileAndDir makes a squashfs snap file and a directory under

--- a/snap/snaptest/snaptest_test.go
+++ b/snap/snaptest/snaptest_test.go
@@ -219,7 +219,7 @@ func (s *snapTestSuite) TestMockSnapWithFiles(c *C) {
 
 func (s *snapTestSuite) TestMockContainerMinimal(c *C) {
 	cont := snaptest.MockContainer(c, nil)
-	err := snap.ValidateContainer(cont, &snap.Info{}, nil)
+	err := snap.ValidateSnapContainer(cont, &snap.Info{}, nil)
 	c.Check(err, IsNil)
 }
 
@@ -239,7 +239,7 @@ version: 1.0`
 	info, err := snap.ReadInfoFromSnapFile(cont, nil)
 	c.Assert(err, IsNil)
 	c.Check(info.SnapName(), Equals, "gadget")
-	err = snap.ValidateContainer(cont, info, nil)
+	err = snap.ValidateSnapContainer(cont, info, nil)
 	c.Assert(err, IsNil)
 	readGadgetYaml, err := cont.ReadFile("meta/gadget.yaml")
 	c.Assert(err, IsNil)

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -343,6 +343,13 @@ func Validate(info *Info) error {
 		return err
 	}
 
+	// validate component names, which follow the same rules as snap names
+	for cname := range info.Components {
+		if err := ValidateName(cname); err != nil {
+			return err
+		}
+	}
+
 	if err := validateTitle(info.Title()); err != nil {
 		return err
 	}

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -300,6 +300,14 @@ func validateSocketAddrNetPort(fieldName string, port string) error {
 	return nil
 }
 
+func ValidateSummary(summary string) error {
+	// 128 is the maximum allowed by review-tools
+	if count := utf8.RuneCountInString(summary); count > 128 {
+		return fmt.Errorf("summary can have up to 128 codepoints, got %d", count)
+	}
+	return nil
+}
+
 func ValidateDescription(descr string) error {
 	if count := utf8.RuneCountInString(descr); count > 4096 {
 		return fmt.Errorf("description can have up to 4096 codepoints, got %d", count)
@@ -344,8 +352,15 @@ func Validate(info *Info) error {
 	}
 
 	// validate component names, which follow the same rules as snap names
-	for cname := range info.Components {
+	for cname, comp := range info.Components {
+		// component Type is validated when unmarshaling
 		if err := ValidateName(cname); err != nil {
+			return err
+		}
+		if err := ValidateSummary(comp.Summary); err != nil {
+			return err
+		}
+		if err := ValidateDescription(comp.Description); err != nil {
 			return err
 		}
 	}

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -300,7 +300,7 @@ func validateSocketAddrNetPort(fieldName string, port string) error {
 	return nil
 }
 
-func validateDescription(descr string) error {
+func ValidateDescription(descr string) error {
 	if count := utf8.RuneCountInString(descr); count > 4096 {
 		return fmt.Errorf("description can have up to 4096 codepoints, got %d", count)
 	}
@@ -354,7 +354,10 @@ func Validate(info *Info) error {
 		return err
 	}
 
-	if err := validateDescription(info.Description()); err != nil {
+	// TODO for some reason we are not validating the summary for
+	// snap.yaml. What is the store checking?
+
+	if err := ValidateDescription(info.Description()); err != nil {
 		return err
 	}
 

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -2301,3 +2301,31 @@ func (s *ValidateSuite) TestSimplePrereqTracker(c *C) {
 	c.Check(providerContentAttrs["common-themes"], DeepEquals, []string{"bar", "foo"})
 	c.Check(providerContentAttrs["some-snap"], DeepEquals, []string{"baz"})
 }
+
+func (s *ValidateSuite) TestValidateComponentNames(c *C) {
+	info, err := InfoFromSnapYaml([]byte(`name: foo
+version: 1.0
+components:
+  comp-1:
+    type: test
+  comp-long123-1-name:
+    type: test
+`))
+	c.Assert(err, IsNil)
+
+	err = Validate(info)
+	c.Check(err, IsNil)
+}
+
+func (s *ValidateSuite) TestDetectInvalidComponentName(c *C) {
+	info, err := InfoFromSnapYaml([]byte(`name: foo
+version: 1.0
+components:
+  comp_1:
+    type: test
+`))
+	c.Assert(err, IsNil)
+
+	err = Validate(info)
+	c.Check(err, ErrorMatches, `invalid snap name: "comp_1"`)
+}

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -25,6 +25,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	. "gopkg.in/check.v1"
 
@@ -2308,6 +2309,8 @@ version: 1.0
 components:
   comp-1:
     type: test
+    summary: short summary
+    description: some loooong description
   comp-long123-1-name:
     type: test
 `))
@@ -2328,4 +2331,26 @@ components:
 
 	err = Validate(info)
 	c.Check(err, ErrorMatches, `invalid snap name: "comp_1"`)
+}
+
+func (s *ValidateSuite) TestDetectInvalidComponentTextFields(c *C) {
+	yamlTmpl := `name: foo
+version: 1.0
+components:
+  comp1:
+    type: test
+    %s: %s
+`
+
+	for _, tc := range []struct {
+		field         string
+		maxCodePoints int
+	}{{"summary", 128}, {"description", 4096}} {
+		text := strings.Repeat("xx", 2049)
+		info, err := InfoFromSnapYaml([]byte(fmt.Sprintf(yamlTmpl, tc.field, text)))
+		c.Assert(err, IsNil)
+
+		err = Validate(info)
+		c.Check(err, ErrorMatches, fmt.Sprintf("%s can have up to %d codepoints, got %d", tc.field, tc.maxCodePoints, utf8.RuneCountInString(text)))
+	}
 }


### PR DESCRIPTION
With this change we will be able to pack directories containing file `meta/component.yaml` with `snap pack <dir>`.