### PR TITLE
snap, snap/pack: add pack validation for default-configure hook

### DIFF
--- a/snap/implicit.go
+++ b/snap/implicit.go
@@ -49,11 +49,11 @@ func addImplicitHooks(snapInfo *Info, hooksDir string) error {
 	return nil
 }
 
-// addImplicitHooksFromContainer adds hooks from the snap file's hookdir to the snap info.
+// AddImplicitHooksFromContainer adds hooks from the snap file's hookdir to the snap info.
 //
 // Existing hooks (i.e. ones defined in the YAML) are not changed; only missing
 // hooks are added.
-func addImplicitHooksFromContainer(snapInfo *Info, snapf Container) {
+func AddImplicitHooksFromContainer(snapInfo *Info, snapf Container) {
 	// Read the hooks directory. If this fails we assume the hooks directory
 	// doesn't exist, which means there are no implicit hooks to load (not an
 	// error).

--- a/snap/info.go
+++ b/snap/info.go
@@ -1413,7 +1413,7 @@ func ReadInfoFromSnapFile(snapf Container, si *SideInfo) (*Info, error) {
 		return nil, err
 	}
 
-	addImplicitHooksFromContainer(info, snapf)
+	AddImplicitHooksFromContainer(info, snapf)
 
 	bindImplicitHooks(info, strk)
 

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -837,6 +837,22 @@ version: 1.0`
 	c.Assert(err, ErrorMatches, ".*invalid hook name.*")
 }
 
+func (s *infoSuite) TestReadInfoFromSnapFileCatchesImplicitHookDefaultConfigureOnly(c *C) {
+	yaml := `name: foo
+version: 1.0`
+
+	contents := [][]string{
+		{"meta/hooks/default-configure", ""},
+	}
+	sideInfo := &snap.SideInfo{}
+	snapInfo := snaptest.MockSnapWithFiles(c, yaml, sideInfo, contents)
+	snapf, err := snapfile.Open(snapInfo.MountDir())
+	c.Assert(err, IsNil)
+
+	_, err = snap.ReadInfoFromSnapFile(snapf, nil)
+	c.Assert(err, ErrorMatches, "cannot specify \"default-configure\" hook without \"configure\" hook")
+}
+
 func (s *infoSuite) checkInstalledSnapAndSnapFile(c *C, instanceName, yaml string, contents string, hooks []string, checker func(c *C, info *snap.Info)) {
 	// First check installed snap
 	sideInfo := &snap.SideInfo{Revision: snap.R(42)}

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -824,9 +824,13 @@ hooks:
 func (s *infoSuite) TestReadInfoFromSnapFileCatchesInvalidImplicitHook(c *C) {
 	yaml := `name: foo
 version: 1.0`
-	snapPath := snaptest.MakeTestSnapWithFiles(c, yaml, emptyHooks("123abc"))
 
-	snapf, err := snapfile.Open(snapPath)
+	contents := [][]string{
+		{"meta/hooks/123abc", ""},
+	}
+	sideInfo := &snap.SideInfo{}
+	snapInfo := snaptest.MockSnapWithFiles(c, yaml, sideInfo, contents)
+	snapf, err := snapfile.Open(snapInfo.MountDir())
 	c.Assert(err, IsNil)
 
 	_, err = snap.ReadInfoFromSnapFile(snapf, nil)

--- a/snap/pack/pack.go
+++ b/snap/pack/pack.go
@@ -107,8 +107,8 @@ func CheckSkeleton(w io.Writer, sourceDir string) error {
 }
 
 func loadAndValidate(sourceDir string) (*snap.Info, error) {
-	// Extraction of snap info is duplicated in ReadInfoFromSnapFile, this is done
-	// only to extract the snap instance name, if available, to use in case of
+	// Parsing of snap info is duplicated in ReadInfoFromSnapFile. It is done
+	// here to retrieve the snap instance name, if available, to use in case of
 	// ReadInfoFromSnapFile error
 	yaml, err := ioutil.ReadFile(filepath.Join(sourceDir, "meta", "snap.yaml"))
 	if err != nil {
@@ -122,9 +122,10 @@ func loadAndValidate(sourceDir string) (*snap.Info, error) {
 
 	// ReadInfoFromSnapFile covers the following required steps:
 	// 	- Read snap metadata from meta/snap.yaml
-	//      - Extract snap info from meta/snap.yaml, without populating side info
-	//      - Add implicit hooks from meta/hooks, and validate hooks individually
+	//      - Parse snap info from meta/snap.yaml without side info
+	//      - Add and bind implicit hooks from meta/hooks
 	//      - Validate available snap information
+	//      - Validate snapshot metadata from opional meta/snapshot.yaml
 	info, err = snap.ReadInfoFromSnapFile(snapdir.New(sourceDir), nil)
 	if err != nil {
 		return nil, fmt.Errorf("cannot validate snap %q: %v", instanceName, err)

--- a/snap/pack/pack_test.go
+++ b/snap/pack/pack_test.go
@@ -202,7 +202,7 @@ apps:
 `
 	c.Assert(ioutil.WriteFile(filepath.Join(sourceDir, "meta", "snapshots.yaml"), []byte(invalidSnapshotYaml), 0444), IsNil)
 	_, err := pack.Snap(sourceDir, pack.Defaults)
-	c.Assert(err, ErrorMatches, "cannot validate snap \"hello\": snapshot exclude path must start with one of.*")
+	c.Assert(err, ErrorMatches, "snapshot exclude path must start with one of.*")
 }
 
 func (s *packSuite) TestPackSnapshotYamlPermissionsError(c *C) {

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -162,6 +162,22 @@ func ValidateLicense(license string) error {
 	return nil
 }
 
+func validateHooks(info *Info) error {
+	for _, hook := range info.Hooks {
+		if err := ValidateHook(hook); err != nil {
+			return err
+		}
+	}
+
+	hasDefaultConfigureHook := info.Hooks["default-configure"] != nil
+	hasConfigureHook := info.Hooks["configure"] != nil
+	if hasDefaultConfigureHook && !hasConfigureHook {
+		return fmt.Errorf(`cannot specify "default-configure" hook without "configure" hook`)
+	}
+
+	return nil
+}
+
 // ValidateHook validates the content of the given HookInfo
 func ValidateHook(hook *HookInfo) error {
 	if err := naming.ValidateHook(hook.Name); err != nil {
@@ -368,11 +384,9 @@ func Validate(info *Info) error {
 		}
 	}
 
-	// validate hook entries
-	for _, hook := range info.Hooks {
-		if err := ValidateHook(hook); err != nil {
-			return err
-		}
+	// Validate hook entries
+	if err := validateHooks(info); err != nil {
+		return err
 	}
 
 	// Ensure that plugs and slots have appropriate names and interface names.

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -793,6 +793,18 @@ hooks:
 	c.Check(err, ErrorMatches, `invalid hook name: "123abc"`)
 }
 
+func (s *ValidateSuite) TestIllegalHookDefaultConfigureWithoutConfigure(c *C) {
+	info, err := InfoFromSnapYaml([]byte(`name: foo
+version: 1.0
+hooks:
+  default-configure:
+`))
+	c.Assert(err, IsNil)
+
+	err = Validate(info)
+	c.Check(err, ErrorMatches, "cannot specify \"default-configure\" hook without \"configure\" hook")
+}
+
 func (s *ValidateSuite) TestPlugSlotNamesUnique(c *C) {
 	info, err := InfoFromSnapYaml([]byte(`name: snap
 version: 0


### PR DESCRIPTION
Additional to [PR-12701](https://github.com/snapcore/snapd/pull/12701), to address [this comment](https://github.com/snapcore/snapd/pull/12701#discussion_r1172686765). 

As a temporary measure [checkConfigureHooks](https://github.com/snapcore/snapd/blob/master/overlord/snapstate/check_snap.go#L569) was added which extends [checkSnap](https://github.com/snapcore/snapd/blob/master/overlord/snapstate/check_snap.go#L242) that is called from [doMountSnap](https://github.com/snapcore/snapd/blob/master/overlord/snapstate/handlers.go#L1182)

The requirement is to have a similar check in place in:
   - snap.Validate (with this in place, arguably the temporary measure can fall away)
   - snap pack loadAndValidate

This PR proposes to achieve this by:
1. Export `addImplicitHooksFromContainer` and use in `loadAndValidate` to populate missing implicit hooks to enable validation.
2. Extend snap.Validate hook validation to check for the invalid combination of default-configure without configure.

**Further consideration:**
- Arguably we can remove the temporary measure, but the `doMountSnap` handler [checkSnap](https://github.com/ernestl/snapd/blob/2dbc1b6dfbd8218c57291c3d2d97c00c9d3ff655/overlord/snapstate/handlers.go#L1182) uses [snap.ReadInfoFromMountPoint](https://github.com/ernestl/snapd/blob/2dbc1b6dfbd8218c57291c3d2d97c00c9d3ff655/snap/info.go#L1330) which unlike its counterpart `snap.ReadInfoFromSnapFile` does not have a snap.Validation step included. This means without the temporary measure in place, we would loose the check at that stage.
- It seems as if direct snap pack testing is limited to a fairly [simple case](https://github.com/ernestl/snapd/blob/2dbc1b6dfbd8218c57291c3d2d97c00c9d3ff655/tests/main/snap-pack/task.yaml):
Propose to extend test to include repack of some of the most complicated snaps we have, including essential snaps.