### PR TITLE
gadget: remove testutil import in non-test code

### DIFF
--- a/gadget/ondisk.go
+++ b/gadget/ondisk.go
@@ -27,7 +27,6 @@ import (
 	"github.com/snapcore/snapd/gadget/quantity"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil/disks"
-	"github.com/snapcore/snapd/testutil"
 )
 
 // TODO: consider looking into merging LaidOutVolume/Structure OnDiskVolume/Structure
@@ -257,7 +256,9 @@ func onDiskVolumeFromPartitionSysfsPath(partPath string) (*OnDiskVolume, error) 
 }
 
 func MockSysfsPathForBlockDevice(f func(device string) (string, error)) (restore func()) {
-	restore = testutil.Backup(&sysfsPathForBlockDevice)
+	old := sysfsPathForBlockDevice
 	sysfsPathForBlockDevice = f
-	return restore
+	return func() {
+		sysfsPathForBlockDevice = old
+	}
 }


### PR DESCRIPTION
The previous commit 85812c58a74d8efaef4734a8f0e28bacedfb6f77 introduced a testutil import in non-test code. This broke MacOS quick checks. Thanks @mvo5 for finding the bug and offering a solution!