### PR TITLE
data/systemd: make snapd.seed wait for snapd.socket only

### DIFF
--- a/data/systemd/snapd.seeded.service.in
+++ b/data/systemd/snapd.seeded.service.in
@@ -1,6 +1,6 @@
 [Unit]
 Description=Wait until snapd is fully seeded
-After=snapd.service snapd.socket
+After=snapd.socket
 Requires=snapd.socket
 
 [Service]


### PR DESCRIPTION
snapd.service should not need to be started from snapd.seed.service to start. Only snapd.socket needs to be started.
