### PR TITLE
tests: fix selinux-clean denials after removing snap

### DIFF
--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -458,6 +458,8 @@ gen_require(`
 ')
 allow snappy_t devicekit_power_exec_t:file { getattr };
 
+
+
 ########################################
 #
 # snap-update-ns, snap-dicsard-ns local policy
@@ -806,6 +808,8 @@ allow snappy_cli_t snappy_snap_t:lnk_file { read_lnk_file_perms };
 allow snappy_cli_t snappy_var_lib_t:dir { list_dir_perms };
 allow snappy_cli_t snappy_var_lib_t:file { read_file_perms };
 allow snappy_cli_t snappy_var_lib_t:lnk_file { read_lnk_file_perms };
+
+allow snappy_cli_t snappy_var_t:dir { search getattr };
 
 # the release package calls stat() on /proc/sys/fs/binfmt_misc/WSLInterop to
 # detect WSL


### PR DESCRIPTION
After pr #13019 the selinux-clean test started failing after removing the snap test-snapd-service.

type=AVC msg=audit(08/21/23 14:42:23.030:1354) : avc:  denied  { search } for  pid=38749 comm=snap name=x1 dev="sda5" ino=196452 scontext=system_u:system_r:snappy_cli_t:s0
tcontext=system_u:object_r:snappy_var_t:s0 tclass=dir permissive=1 ----
type=AVC msg=audit(08/21/23 14:42:23.030:1355) : avc:  denied  { getattr } for  pid=38749 comm=snap path=/var/snap/test-snapd-service/x1 dev="sda5" ino=196452 scontext=system_u:system_r:snappy_cli_t:s0 tcontext=system_u:object_r:snappy_var_t:s0 tclass=dir permissive=1 ----
type=AVC msg=audit(08/21/23 14:42:38.846:1412) : avc:  denied  { search } for  pid=39200 comm=snap name=x1 dev="sda5" ino=196452 scontext=system_u:system_r:snappy_cli_t:s0
tcontext=system_u:object_r:snappy_var_t:s0 tclass=dir permissive=1 ----
type=AVC msg=audit(08/21/23 14:42:38.846:1413) : avc:  denied  { getattr } for  pid=39200 comm=snap path=/var/snap/test-snapd-service/x1 dev="sda5" ino=196452 scontext=system_u:system_r:snappy_cli_t:s0 tcontext=system_u:object_r:snappy_var_t:s0 tclass=dir permissive=1

