### PR TITLE
tests/main/uc20-create-partitions: do not check for shim on boot partition

### DIFF
--- a/tests/main/uc20-create-partitions/task.yaml
+++ b/tests/main/uc20-create-partitions/task.yaml
@@ -162,7 +162,6 @@ execute: |
     echo "Check that the filesystem content was deployed"
     mount "${LOOP}p3" ./mnt
     ls ./mnt/EFI/boot/grubx64.efi
-    ls ./mnt/EFI/boot/bootx64.efi
     # remove a file
     rm ./mnt/EFI/boot/grubx64.efi
     umount ./mnt


### PR DESCRIPTION
This was never used and then removed in
snapcore/pc-gadget@a6d5e0dabca77663f6a32eb3b089b244ea428978