### PR TITLE
cmd/snaplock/runinhibit: add snap revision to inhibit lock file

### DIFF
--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -2159,7 +2159,7 @@ func makeDBusMethodAvailableMessage(c *check.C, msg *dbus.Message) *dbus.Message
 	})
 	c.Check(msg.Body[0], check.Equals, "SnapTest")
 	param2 := fmt.Sprintf("%s", msg.Body[1])
-	c.Check(strings.HasSuffix(param2, "/var/lib/snapd/inhibit/SnapTest.lock"), check.Equals, true)
+	c.Check(strings.HasSuffix(param2, "/var/lib/snapd/inhibit/SnapTest_v2.lock"), check.Equals, true)
 	return &dbus.Message{
 		Type: dbus.TypeMethodReply,
 		Headers: map[dbus.HeaderField]dbus.Variant{

--- a/cmd/snap/inhibit.go
+++ b/cmd/snap/inhibit.go
@@ -110,7 +110,7 @@ var tryNotifyRefreshViaSnapDesktopIntegrationFlow = func(snapName string) (bool,
 	}
 	obj := conn.Object("io.snapcraft.SnapDesktopIntegration", "/io/snapcraft/SnapDesktopIntegration")
 	extraParams := make(map[string]dbus.Variant)
-	err = obj.Call("io.snapcraft.SnapDesktopIntegration.ApplicationIsBeingRefreshed", 0, snapName, runinhibit.HintFile(snapName), extraParams).Store()
+	err = obj.Call("io.snapcraft.SnapDesktopIntegration.ApplicationIsBeingRefreshed", 0, snapName, runinhibit.LockFile(snapName), extraParams).Store()
 	if err != nil {
 		logger.Noticef("unable to successfully call io.snapcraft.SnapDesktopIntegration.ApplicationIsBeingRefreshed: %v", err)
 		return false, nil

--- a/image/preseed/preseed_classic_test.go
+++ b/image/preseed/preseed_classic_test.go
@@ -372,7 +372,7 @@ func (s *preseedSuite) TestReset(c *C) {
 			{filepath.Join(dirs.SnapSeqDir, "foo.json"), ""},
 			{filepath.Join(dirs.SnapMountDir, "foo", "bin"), ""},
 			{filepath.Join(dirs.SnapSeccompDir, "foo.bin"), ""},
-			{filepath.Join(runinhibit.InhibitDir, "foo.lock"), ""},
+			{runinhibit.LockFile("foo"), ""},
 			// bash-completion symlinks
 			{filepath.Join(dirs.CompletersDir, "foo.bar"), "/a/snapd/complete.sh"},
 			{filepath.Join(dirs.CompletersDir, "foo"), "foo.bar"},

--- a/image/preseed/reset.go
+++ b/image/preseed/reset.go
@@ -115,7 +115,7 @@ var ResetPreseededChroot = func(preseedChroot string) error {
 		filepath.Join(dirs.SnapUserServicesDir, "default.target.wants", "snap.*.service"),
 		filepath.Join(dirs.SnapUserServicesDir, "sockets.target.wants", "snap.*.socket"),
 		filepath.Join(dirs.SnapUserServicesDir, "timers.target.wants", "snap.*.timer"),
-		filepath.Join(runinhibit.InhibitDir, "*.lock"),
+		filepath.Join(runinhibit.InhibitDir, "*_v2.lock"),
 	}
 
 	for _, gl := range globs {

--- a/overlord/snapstate/backend/link_test.go
+++ b/overlord/snapstate/backend/link_test.go
@@ -293,7 +293,7 @@ apps:
 	c.Assert(err, IsNil)
 	c.Assert(currentDataDir, Equals, dataDir)
 
-	c.Check(filepath.Join(runinhibit.InhibitDir, "hello.lock"), testutil.FileAbsent)
+	c.Check(runinhibit.LockFile("hello"), testutil.FileAbsent)
 }
 
 func (s *linkSuite) TestLinkUndoIdempotent(c *C) {
@@ -334,7 +334,7 @@ apps:
 	c.Check(osutil.FileExists(currentDataSymlink), Equals, false)
 
 	// no inhibition lock
-	c.Check(filepath.Join(runinhibit.InhibitDir, "hello.lock"), testutil.FileAbsent)
+	c.Check(runinhibit.LockFile("hello"), testutil.FileAbsent)
 }
 
 func (s *linkSuite) TestLinkFailsForUnsetRevision(c *C) {
@@ -676,7 +676,7 @@ func (s *linkCleanupSuite) testLinkCleanupFailedSnapdSnapOnCorePastWrappers(c *C
 	c.Check(filepath.Join(dirs.SnapUserServicesDir, "snapd.session-agent.service"), checker)
 	c.Check(filepath.Join(dirs.SnapUserServicesDir, "snapd.session-agent.socket"), checker)
 	c.Check(filepath.Join(dirs.SnapServicesDir, "usr-lib-snapd.mount"), checker)
-	c.Check(filepath.Join(runinhibit.InhibitDir, "snapd.lock"), testutil.FileAbsent)
+	c.Check(runinhibit.LockFile("hello"), testutil.FileAbsent)
 
 	// D-Bus service activation
 	c.Check(filepath.Join(dirs.SnapDBusSessionServicesDir, "io.snapcraft.Launcher.service"), checker)
@@ -744,7 +744,7 @@ func (s *snapdOnCoreUnlinkSuite) TestUndoGeneratedWrappers(c *C) {
 		c.Check(toEtcUnitPath(entry[0]), testutil.FilePresent)
 	}
 	// linked snaps do not have a run inhibition lock
-	c.Check(filepath.Join(runinhibit.InhibitDir, "snapd.lock"), testutil.FileAbsent)
+	c.Check(runinhibit.LockFile("hello"), testutil.FileAbsent)
 
 	linkCtx := backend.LinkContext{
 		FirstInstall:   true,
@@ -758,12 +758,12 @@ func (s *snapdOnCoreUnlinkSuite) TestUndoGeneratedWrappers(c *C) {
 		c.Check(toEtcUnitPath(entry[0]), testutil.FileAbsent)
 	}
 	// unlinked snaps have a run inhibition lock
-	c.Check(filepath.Join(runinhibit.InhibitDir, "snapd.lock"), testutil.FilePresent)
+	c.Check(runinhibit.LockFile("snapd"), testutil.FilePresent)
 
 	// unlink is idempotent
 	err = s.be.UnlinkSnap(info, linkCtx, nil)
 	c.Assert(err, IsNil)
-	c.Check(filepath.Join(runinhibit.InhibitDir, "snapd.lock"), testutil.FilePresent)
+	c.Check(runinhibit.LockFile("snapd"), testutil.FilePresent)
 }
 
 func (s *snapdOnCoreUnlinkSuite) TestUnlinkNonFirstSnapdOnCoreDoesNothing(c *C) {
@@ -798,8 +798,8 @@ func (s *snapdOnCoreUnlinkSuite) TestUnlinkNonFirstSnapdOnCoreDoesNothing(c *C) 
 	}
 
 	// unlinked snaps have a run inhibition lock. XXX: the specific inhibition hint can change.
-	c.Check(filepath.Join(runinhibit.InhibitDir, "snapd.lock"), testutil.FilePresent)
-	c.Check(filepath.Join(runinhibit.InhibitDir, "snapd.lock"), testutil.FileEquals, "refresh")
+	c.Check(runinhibit.LockFile("snapd"), testutil.FilePresent)
+	c.Check(runinhibit.LockFile("snapd"), testutil.FileEquals, `{"hint":"refresh","revision":"unset"}`)
 }
 
 func (s *linkSuite) TestLinkOptRequiresTooling(c *C) {

--- a/tests/main/refresh/task.yaml
+++ b/tests/main/refresh/task.yaml
@@ -129,9 +129,9 @@ execute: |
 
     if [ -f /tmp/inhibit.events ]; then
       echo "During the refresh process, the inhibition lock was established and released"
-      MATCH "/var/lib/snapd/inhibit/ OPEN $SNAP_NAME.lock" /tmp/inhibit.events
-      MATCH "/var/lib/snapd/inhibit/ MODIFY $SNAP_NAME.lock" /tmp/inhibit.events
-      MATCH "/var/lib/snapd/inhibit/ CLOSE_WRITE,CLOSE $SNAP_NAME.lock" /tmp/inhibit.events
+      MATCH "/var/lib/snapd/inhibit/ OPEN ${SNAP_NAME}_v2.lock" /tmp/inhibit.events
+      MATCH "/var/lib/snapd/inhibit/ MODIFY ${SNAP_NAME}_v2.lock" /tmp/inhibit.events
+      MATCH "/var/lib/snapd/inhibit/ CLOSE_WRITE,CLOSE ${SNAP_NAME}_v2.lock" /tmp/inhibit.events
       tests.cleanup pop  # stop the inotifywait unit
       tests.cleanup pop  # remove inotify-tools
     fi


### PR DESCRIPTION
This is handy to be used by `snap run` **in a later PR** to [get snap info](https://github.com/snapcore/snapd/blob/661258f683ebb9fa6589672fac33fe26bc3653ce/cmd/snap/cmd_run.go#L491) when the `current` symlink is not available (i.e. during a refresh after the snap is unlinked).

Inhibit file (v2) is now JSON instead of a flat file with the hint string. This is needed to carry more information that is needed by `snap run` while the snap is inhibited. It can be expanded to add more data as needed later.

`runinhibit.SetRevision` and `runinhibit.GetRevision` are not used currently, they will be used in a later PR.

This is needed as a part of the work for improving refresh-app-awareness UX.
For context: https://github.com/snapcore/snapd/pull/13066

**Note: [snapd-desktop-integration](https://github.com/snapcore/snapd-desktop-integration) snap will need to be updated to handle v2 lock files when this is merged**