### PR TITLE
i/b/shared-memory: handle "private" plug attribute in shared-memory interface correctly

### DIFF
--- a/interfaces/builtin/shared_memory.go
+++ b/interfaces/builtin/shared_memory.go
@@ -286,8 +286,19 @@ func (iface *sharedMemoryInterface) BeforePreparePlug(plug *snap.PlugInfo) error
 }
 
 func (iface *sharedMemoryInterface) isPrivate(plug *interfaces.ConnectedPlug) (bool, error) {
+	// Note that private may not be set even if
+	// "SanitizePlugsSlots()" is called (which in turn calls
+	// BeforePreparePlug() which will set this).
+	//
+	// The code-path is an upgrade from snapd 2.54.4 where
+	// shared-memory did not have the "private" attribute
+	// yet. Then the ConnectedPlug data is written into the
+	// interface repo without this attribute and on regeneration
+	// of security profiles the connectedPlug is loaded from the
+	// interface repository in the state and not from the
+	// snap.yaml so this attribute is missing.
 	var private bool
-	if err := plug.Attr("private", &private); err != nil {
+	if err := plug.Attr("private", &private); err != nil && !errors.Is(err, snap.AttributeNotFoundError{}) {
 		return false, err
 	}
 	return private, nil

--- a/interfaces/builtin/shared_memory.go
+++ b/interfaces/builtin/shared_memory.go
@@ -329,7 +329,9 @@ func (iface *sharedMemoryInterface) MountConnectedPlug(spec *mount.Specification
 	private, err := iface.isPrivate(plug)
 	if err != nil {
 		return err
-	} else if !private {
+	}
+
+	if !private {
 		return nil
 	}
 

--- a/interfaces/builtin/shared_memory_test.go
+++ b/interfaces/builtin/shared_memory_test.go
@@ -470,3 +470,18 @@ func (s *SharedMemoryInterfaceSuite) TestAutoConnect(c *C) {
 func (s *SharedMemoryInterfaceSuite) TestInterfaces(c *C) {
 	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
 }
+
+func (s *SharedMemoryInterfaceSuite) TestErrorOnBadPlug(c *C) {
+	consumerYaml := `name: consumer
+version: 0
+plugs:
+ shmem-missing:
+  interface: shared-memory
+  shared-memory: foo
+`
+	plug, _ := MockConnectedPlug(c, consumerYaml, nil, "shmem-missing")
+
+	spec := &mount.Specification{}
+	err := spec.AddConnectedPlug(s.iface, plug, nil)
+	c.Assert(err, ErrorMatches, `snap "consumer" does not have attribute "private" for interface "shared-memory"`)
+}

--- a/interfaces/builtin/shared_memory_test.go
+++ b/interfaces/builtin/shared_memory_test.go
@@ -471,7 +471,7 @@ func (s *SharedMemoryInterfaceSuite) TestInterfaces(c *C) {
 	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
 }
 
-func (s *SharedMemoryInterfaceSuite) TestErrorOnBadPlug(c *C) {
+func (s *SharedMemoryInterfaceSuite) TestNoErrorOnMissingPrivate(c *C) {
 	consumerYaml := `name: consumer
 version: 0
 plugs:
@@ -483,5 +483,21 @@ plugs:
 
 	spec := &mount.Specification{}
 	err := spec.AddConnectedPlug(s.iface, plug, nil)
-	c.Assert(err, ErrorMatches, `snap "consumer" does not have attribute "private" for interface "shared-memory"`)
+	c.Assert(err, IsNil)
+}
+
+func (s *SharedMemoryInterfaceSuite) TestErrorOnBadPlug(c *C) {
+	consumerYaml := `name: consumer
+version: 0
+plugs:
+ shmem-missing:
+  interface: shared-memory
+  shared-memory: foo
+  private: xxx
+`
+	plug, _ := MockConnectedPlug(c, consumerYaml, nil, "shmem-missing")
+
+	spec := &mount.Specification{}
+	err := spec.AddConnectedPlug(s.iface, plug, nil)
+	c.Assert(err, ErrorMatches, `snap "consumer" has interface "shared-memory" with invalid value type string for "private" attribute: \*bool`)
 }


### PR DESCRIPTION
The isPrivate() method assumes that a plug has been sanitised by BeforePreparePlug and panics if there's no "private" attribute. There's been a customer report of this happening and even though it's unclear how the attribute is missing/wrong, we should handle it as gracefully as we can instead of panicking.