### PR TITLE
tests/main/interfaces-mount-control: use auditd to match apparmor errors

### DIFF
--- a/tests/main/interfaces-mount-control/task.yaml
+++ b/tests/main/interfaces-mount-control/task.yaml
@@ -12,11 +12,16 @@ environment:
     MOUNT_DEST3: $SNAP_COMMON/target3/path/subpath
 
 prepare: |
+    if ! [ -f /etc/audit/auditd.conf ] && os.query is-ubuntu && os.query is-classic; then
+        #shellcheck source=tests/lib/pkgdb.sh
+        . "$TESTSLIB/pkgdb.sh"
+        distro_install_package auditd
+    fi
     mkdir -p "$MOUNT_SRC/dir1"
     echo "Something" > "$MOUNT_SRC/file1"
 
 restore: |
-    rm connect_error.log
+    rm -f connect_error.log
     rm -rf "$MOUNT_SRC"
 
 execute: |
@@ -105,7 +110,9 @@ execute: |
             echo "Mount succeeded despite not matching the allowed FS type"
             exit 1
         fi
-        journalctl -t audit | grep 'fstype="debugfs"' | MATCH 'info="failed type match"'
+        if os.query is-ubuntu && os.query is-classic; then
+            grep 'fstype="debugfs"' /var/log/audit/audit.log | MATCH 'info="failed type match"'
+        fi
         rmdir /media/somedir
 
         echo "Verify that a maliciously crafted path cannot bypass the allowed pattern"


### PR DESCRIPTION
The test was expecting audit logs to go to kmsg. But this is a buggy behavior from the kernel. It seems to have been fixed. Now auditd needs to be used.