### PR TITLE
wrappers: use `Ensure` in snap linking operations for snap binaries/icons/desktop files

### DIFF
--- a/overlord/snapstate/backend/link.go
+++ b/overlord/snapstate/backend/link.go
@@ -232,7 +232,7 @@ func (b Backend) generateWrappers(s *snap.Info, linkCtx LinkContext) error {
 	cleanupFuncs = append(cleanupFuncs, wrappers.RemoveSnapDesktopFiles)
 
 	// add the desktop icons
-	if err = wrappers.AddSnapIcons(s); err != nil {
+	if err = wrappers.EnsureSnapIcons(s); err != nil {
 		return err
 	}
 	cleanupFuncs = append(cleanupFuncs, wrappers.RemoveSnapIcons)

--- a/overlord/snapstate/backend/link.go
+++ b/overlord/snapstate/backend/link.go
@@ -226,7 +226,7 @@ func (b Backend) generateWrappers(s *snap.Info, linkCtx LinkContext) error {
 	cleanupFuncs = append(cleanupFuncs, wrappers.RemoveSnapDBusActivationFiles)
 
 	// add the desktop files
-	if err = wrappers.AddSnapDesktopFiles(s); err != nil {
+	if err = wrappers.EnsureSnapDesktopFiles(s); err != nil {
 		return err
 	}
 	cleanupFuncs = append(cleanupFuncs, wrappers.RemoveSnapDesktopFiles)

--- a/overlord/snapstate/backend/link.go
+++ b/overlord/snapstate/backend/link.go
@@ -200,7 +200,7 @@ func (b Backend) generateWrappers(s *snap.Info, linkCtx LinkContext) error {
 	}
 
 	// add the CLI apps from the snap.yaml
-	if err = wrappers.AddSnapBinaries(s); err != nil {
+	if err = wrappers.EnsureSnapBinaries(nil, s); err != nil {
 		return err
 	}
 	cleanupFuncs = append(cleanupFuncs, wrappers.RemoveSnapBinaries)

--- a/overlord/snapstate/backend/link.go
+++ b/overlord/snapstate/backend/link.go
@@ -200,7 +200,7 @@ func (b Backend) generateWrappers(s *snap.Info, linkCtx LinkContext) error {
 	}
 
 	// add the CLI apps from the snap.yaml
-	if err = wrappers.EnsureSnapBinaries(nil, s); err != nil {
+	if err = wrappers.EnsureSnapBinaries(s); err != nil {
 		return err
 	}
 	cleanupFuncs = append(cleanupFuncs, wrappers.RemoveSnapBinaries)

--- a/snap/info.go
+++ b/snap/info.go
@@ -103,6 +103,9 @@ type PlaceInfo interface {
 
 	// UserExposedHomeDir returns the snap's new home directory under ~/Snap.
 	UserExposedHomeDir(home string) string
+
+	// BinaryGlobs returns globs that matches all snap binaries.
+	BinaryGlobs() []string
 }
 
 // MinimalPlaceInfo returns a PlaceInfo with just the location information for a
@@ -677,6 +680,10 @@ func (s *Info) UserXdgRuntimeDir(euid sys.UserID) string {
 // snap.
 func (s *Info) XdgRuntimeDirs() string {
 	return filepath.Join(dirs.XdgRuntimeDirGlob, fmt.Sprintf("snap.%s", s.InstanceName()))
+}
+
+func (s *Info) BinaryGlobs() []string {
+	return []string{s.InstanceName(), fmt.Sprintf("%s.*", s.InstanceName())}
 }
 
 // NeedsDevMode returns whether the snap needs devmode.

--- a/snap/info.go
+++ b/snap/info.go
@@ -104,8 +104,8 @@ type PlaceInfo interface {
 	// UserExposedHomeDir returns the snap's new home directory under ~/Snap.
 	UserExposedHomeDir(home string) string
 
-	// BinaryGlobs returns globs that matches all snap binaries.
-	BinaryGlobs() []string
+	// BinaryNameGlobs returns base name globs that matches all snap binaries.
+	BinaryNameGlobs() []string
 }
 
 // MinimalPlaceInfo returns a PlaceInfo with just the location information for a
@@ -682,7 +682,7 @@ func (s *Info) XdgRuntimeDirs() string {
 	return filepath.Join(dirs.XdgRuntimeDirGlob, fmt.Sprintf("snap.%s", s.InstanceName()))
 }
 
-func (s *Info) BinaryGlobs() []string {
+func (s *Info) BinaryNameGlobs() []string {
 	return []string{s.InstanceName(), fmt.Sprintf("%s.*", s.InstanceName())}
 }
 

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -1180,6 +1180,7 @@ func (s *infoSuite) testDirAndFileMethods(c *C, info snap.PlaceInfo) {
 	c.Check(info.DataHomeDir(nil), Equals, "/home/*/snap/name/1")
 	c.Check(info.CommonDataHomeDir(nil), Equals, "/home/*/snap/name/common")
 	c.Check(info.XdgRuntimeDirs(), Equals, "/run/user/*/snap.name")
+	c.Check(info.BinaryGlobs(), DeepEquals, []string{"name", "name.*"})
 }
 
 func (s *infoSuite) TestMinimalInfoDirAndFileMethodsParallelInstall(c *C) {
@@ -1209,6 +1210,7 @@ func (s *infoSuite) testInstanceDirAndFileMethods(c *C, info snap.PlaceInfo) {
 	c.Check(info.DataHomeDir(nil), Equals, "/home/*/snap/name_instance/1")
 	c.Check(info.CommonDataHomeDir(nil), Equals, "/home/*/snap/name_instance/common")
 	c.Check(info.XdgRuntimeDirs(), Equals, "/run/user/*/snap.name_instance")
+	c.Check(info.BinaryGlobs(), DeepEquals, []string{"name_instance", "name_instance.*"})
 }
 
 func BenchmarkTestParsePlaceInfoFromSnapFileName(b *testing.B) {

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -1180,7 +1180,7 @@ func (s *infoSuite) testDirAndFileMethods(c *C, info snap.PlaceInfo) {
 	c.Check(info.DataHomeDir(nil), Equals, "/home/*/snap/name/1")
 	c.Check(info.CommonDataHomeDir(nil), Equals, "/home/*/snap/name/common")
 	c.Check(info.XdgRuntimeDirs(), Equals, "/run/user/*/snap.name")
-	c.Check(info.BinaryGlobs(), DeepEquals, []string{"name", "name.*"})
+	c.Check(info.BinaryNameGlobs(), DeepEquals, []string{"name", "name.*"})
 }
 
 func (s *infoSuite) TestMinimalInfoDirAndFileMethodsParallelInstall(c *C) {
@@ -1210,7 +1210,7 @@ func (s *infoSuite) testInstanceDirAndFileMethods(c *C, info snap.PlaceInfo) {
 	c.Check(info.DataHomeDir(nil), Equals, "/home/*/snap/name_instance/1")
 	c.Check(info.CommonDataHomeDir(nil), Equals, "/home/*/snap/name_instance/common")
 	c.Check(info.XdgRuntimeDirs(), Equals, "/run/user/*/snap.name_instance")
-	c.Check(info.BinaryGlobs(), DeepEquals, []string{"name_instance", "name_instance.*"})
+	c.Check(info.BinaryNameGlobs(), DeepEquals, []string{"name_instance", "name_instance.*"})
 }
 
 func BenchmarkTestParsePlaceInfoFromSnapFileName(b *testing.B) {

--- a/wrappers/binaries.go
+++ b/wrappers/binaries.go
@@ -108,7 +108,7 @@ func detectCompletion(base string) (string, completionMode) {
 //
 // Note: Only base names are returned and not the full paths of the completers.
 func findExistingCompleters(s *snap.Info, dir string) (existingCompleters []string, err error) {
-	for _, glob := range s.BinaryGlobs() {
+	for _, glob := range s.BinaryNameGlobs() {
 		completers, err := filepath.Glob(filepath.Join(dir, glob))
 		if err != nil {
 			return nil, err
@@ -156,7 +156,7 @@ func ensureSnapBinariesWithContent(s *snap.Info, binariesContent, completersCont
 	}
 
 	// Ensure binaries
-	_, _, err := osutil.EnsureDirStateGlobs(dirs.SnapBinariesDir, s.BinaryGlobs(), binariesContent)
+	_, _, err := osutil.EnsureDirStateGlobs(dirs.SnapBinariesDir, s.BinaryNameGlobs(), binariesContent)
 	if err != nil {
 		return err
 	}
@@ -188,11 +188,11 @@ func ensureSnapBinariesWithContent(s *snap.Info, binariesContent, completersCont
 		legacyCompletersContent = nil
 	}
 	// Finally add/remove completers
-	_, _, err = ensureDirStateGlobsWithKeep(dirs.CompletersDir, s.BinaryGlobs(), normalCompletersContent, existingCompleters)
+	_, _, err = ensureDirStateGlobsWithKeep(dirs.CompletersDir, s.BinaryNameGlobs(), normalCompletersContent, existingCompleters)
 	if err != nil {
 		return err
 	}
-	_, _, err = ensureDirStateGlobsWithKeep(dirs.LegacyCompletersDir, s.BinaryGlobs(), legacyCompletersContent, existingLegacyCompleters)
+	_, _, err = ensureDirStateGlobsWithKeep(dirs.LegacyCompletersDir, s.BinaryNameGlobs(), legacyCompletersContent, existingLegacyCompleters)
 	if err != nil {
 		return err
 	}

--- a/wrappers/binaries.go
+++ b/wrappers/binaries.go
@@ -22,6 +22,7 @@ package wrappers
 
 import (
 	"bufio"
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -205,6 +206,9 @@ func ensureSnapBinariesWithContent(s *snap.Info, binariesContent, completersCont
 // It also removes wrapper binaries from the applications of the old snap revision if it exists ensuring that
 // only new snap binaries exist.
 func EnsureSnapBinaries(s *snap.Info) (err error) {
+	if s == nil {
+		return fmt.Errorf("internal error: snap info cannot be nil")
+	}
 	binariesContent := map[string]osutil.FileState{}
 	completersContent := map[string]osutil.FileState{}
 

--- a/wrappers/binaries.go
+++ b/wrappers/binaries.go
@@ -162,7 +162,7 @@ func ensureSnapBinariesWithContent(s *snap.Info, binariesContent, completersCont
 	}
 
 	// Ensure completers
-	// First find exsiting completers that were not created by us
+	// First find existing completers that were not created by us
 	existingCompleters, err := findExistingCompleters(s, dirs.CompletersDir)
 	if err != nil {
 		return err

--- a/wrappers/binaries.go
+++ b/wrappers/binaries.go
@@ -23,6 +23,7 @@ package wrappers
 import (
 	"bufio"
 	"os"
+	"path/filepath"
 	"regexp"
 
 	"github.com/snapcore/snapd/dirs"
@@ -103,42 +104,73 @@ func detectCompletion(base string) (string, completionMode) {
 	}
 }
 
-// AddSnapBinaries writes the wrapper binaries for the applications from the snap which aren't services.
-func AddSnapBinaries(s *snap.Info) (err error) {
-	var created []string
-	defer func() {
-		if err == nil {
-			return
+func findSnapBinaryGlobs(s *snap.Info) (dirToGlobs map[string][]string) {
+	dirToGlobs = make(map[string][]string)
+	if s == nil {
+		return dirToGlobs
+	}
+	for _, app := range s.Apps {
+		binDir := filepath.Dir(app.WrapperPath())
+		binBase := filepath.Base(app.WrapperPath())
+		dirToGlobs[binDir] = append(dirToGlobs[binDir], binBase)
+		if app.Completer == "" {
+			continue
 		}
-		for _, fn := range created {
-			os.Remove(fn)
-		}
-	}()
 
+		compDir := filepath.Dir(app.CompleterPath())
+		compBase := filepath.Base(app.CompleterPath())
+		if dirs.IsCompleteShSymlink(app.CompleterPath()) {
+			dirToGlobs[compDir] = append(dirToGlobs[compDir], compBase)
+		}
+
+		legacyCompDir := filepath.Dir(app.LegacyCompleterPath())
+		legacyCompBase := filepath.Base(app.LegacyCompleterPath())
+		if dirs.IsCompleteShSymlink(app.LegacyCompleterPath()) {
+			dirToGlobs[legacyCompDir] = append(dirToGlobs[legacyCompDir], legacyCompBase)
+		}
+	}
+	return dirToGlobs
+}
+
+// EnsureSnapBinaries writes the wrapper binaries for the applications from the snap which aren't services.
+//
+// It also removes wrapper binaries from the applications of the old snap revision (oldInfo) if it is
+// passed to ensure that only new snap binaries exist.
+func EnsureSnapBinaries(oldInfo, newInfo *snap.Info) (err error) {
+	dirToContent := make(map[string]map[string]osutil.FileState)
+	// Initialize globs with old binaries to mark for removal
+	// Removal => Present in glob set without a content entry
+	dirToGlobs := findSnapBinaryGlobs(oldInfo)
+	addEntry := func(dir, base string, state osutil.FileState) {
+		if dirToContent[dir] == nil {
+			dirToContent[dir] = make(map[string]osutil.FileState)
+		}
+		dirToGlobs[dir] = append(dirToGlobs[dir], base)
+		if state != nil {
+			dirToContent[dir][base] = state
+		}
+	}
 	if err := os.MkdirAll(dirs.SnapBinariesDir, 0755); err != nil {
 		return err
 	}
+	completeSh, completion := detectCompletion(newInfo.Base)
 
-	completeSh, completion := detectCompletion(s.Base)
-
-	for _, app := range s.Apps {
+	for _, app := range newInfo.Apps {
 		if app.IsService() {
 			continue
 		}
 
-		wrapperPath := app.WrapperPath()
-		if err := os.Remove(wrapperPath); err != nil && !os.IsNotExist(err) {
-			return err
-		}
-		if err := os.Symlink("/usr/bin/snap", wrapperPath); err != nil {
-			return err
-		}
-		created = append(created, wrapperPath)
+		binDir := filepath.Dir(app.WrapperPath())
+		binBase := filepath.Base(app.WrapperPath())
+		addEntry(binDir, binBase, &osutil.SymlinkFileState{Target: "/usr/bin/snap"})
 
 		if completion == normalCompletion {
 			legacyCompPath := app.LegacyCompleterPath()
+			legacyCompDir := filepath.Dir(legacyCompPath)
+			legacyCompBase := filepath.Base(legacyCompPath)
 			if dirs.IsCompleteShSymlink(legacyCompPath) {
-				os.Remove(legacyCompPath)
+				// Mark legacy completion for removal
+				addEntry(legacyCompDir, legacyCompBase, nil)
 			}
 		}
 
@@ -157,32 +189,33 @@ func AddSnapBinaries(s *snap.Info) (err error) {
 		if completion == legacyCompletion {
 			compPath = app.LegacyCompleterPath()
 		}
-		if err := os.Symlink(completeSh, compPath); err == nil {
-			created = append(created, compPath)
-		} else if !os.IsExist(err) {
+		if osutil.FileExists(compPath) && !dirs.IsCompleteShSymlink(compPath) {
+			// Don't remove existing completer
+			continue
+		}
+		compBase := filepath.Base(compPath)
+		addEntry(compDir, compBase, &osutil.SymlinkFileState{Target: completeSh})
+	}
+	for dir, content := range dirToContent {
+		globs := dirToGlobs[dir]
+		_, _, err := osutil.EnsureDirStateGlobs(dir, globs, content)
+		if err != nil {
 			return err
 		}
 	}
-
 	return nil
 }
 
 // RemoveSnapBinaries removes the wrapper binaries for the applications from the snap which aren't services from.
 func RemoveSnapBinaries(s *snap.Info) error {
-	for _, app := range s.Apps {
-		os.Remove(app.WrapperPath())
-		if app.Completer == "" {
-			continue
-		}
-		compPath := app.CompleterPath()
-		if dirs.IsCompleteShSymlink(compPath) {
-			os.Remove(compPath)
-		}
-		legacyCompPath := app.LegacyCompleterPath()
-		if dirs.IsCompleteShSymlink(legacyCompPath) {
-			os.Remove(legacyCompPath)
+	// Initialize globs with old binaries to mark for removal
+	// Removal => Present in glob set without a content entry
+	dirToGlobs := findSnapBinaryGlobs(s)
+	for dir, globs := range dirToGlobs {
+		_, _, err := osutil.EnsureDirStateGlobs(dir, globs, nil)
+		if err != nil {
+			return err
 		}
 	}
-
 	return nil
 }

--- a/wrappers/binaries_test.go
+++ b/wrappers/binaries_test.go
@@ -84,6 +84,26 @@ const packageHello = packageHelloNoSrv + `
   daemon: forking
 `
 
+const packageHelloNoSrvV2 = `name: hello-snap
+version: 1.11
+summary: hello
+description: Hello...
+apps:
+ hello:
+   command: bin/hello
+ universe:
+   command: bin/universe
+   completer: universe-completer.sh
+`
+
+const packageHelloV2 = packageHelloNoSrvV2 + `
+ svc1:
+  command: bin/hello
+  stop-command: bin/goodbye
+  post-stop-command: bin/missya
+  daemon: forking
+`
+
 func (s *binariesTestSuite) TestAddSnapBinariesAndRemove(c *C) {
 	// no completers support -> no problem \o/
 	c.Assert(osutil.FileExists(dirs.CompletersDir), Equals, false)
@@ -91,7 +111,14 @@ func (s *binariesTestSuite) TestAddSnapBinariesAndRemove(c *C) {
 	s.testAddSnapBinariesAndRemove(c, false, false)
 }
 
-func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveUseLegacy(c *C) {
+func (s *binariesTestSuite) TestEnsureSnapBinariesAndRemove(c *C) {
+	// no completers support -> no problem \o/
+	c.Assert(osutil.FileExists(dirs.CompletersDir), Equals, false)
+
+	s.testEnsureSnapBinariesAndRemove(c, false, false)
+}
+
+func (s *binariesTestSuite) prepareUseLegacy(c *C) {
 	c.Assert(os.MkdirAll(dirs.CompletersDir, 0755), IsNil)
 	if s.base == "core-with-snapd" {
 		c.Check(os.MkdirAll(filepath.Join(dirs.SnapMountDir, "snapd/current/usr/lib/snapd"), 0755), IsNil)
@@ -101,11 +128,19 @@ func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveUseLegacy(c *C) {
 	c.Assert(err, IsNil)
 	f.Write([]byte("#\n#   RELEASE: 2.1\n"))
 	f.Close()
+}
 
+func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveUseLegacy(c *C) {
+	s.prepareUseLegacy(c)
 	s.testAddSnapBinariesAndRemove(c, true, false)
 }
 
-func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveOldButNotThatOld(c *C) {
+func (s *binariesTestSuite) TestEnsureSnapBinariesAndRemoveUseLegacy(c *C) {
+	s.prepareUseLegacy(c)
+	s.testEnsureSnapBinariesAndRemove(c, true, false)
+}
+
+func (s *binariesTestSuite) prepareOldButNotThatOld(c *C) {
 	c.Assert(os.MkdirAll(dirs.CompletersDir, 0755), IsNil)
 	if s.base == "core-with-snapd" {
 		c.Check(os.MkdirAll(filepath.Join(dirs.SnapMountDir, "snapd/current/usr/lib/snapd"), 0755), IsNil)
@@ -115,11 +150,19 @@ func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveOldButNotThatOld(c *C) {
 	c.Assert(err, IsNil)
 	f.Write([]byte("#\n#   RELEASE: 2.2\n"))
 	f.Close()
+}
 
+func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveOldButNotThatOld(c *C) {
+	s.prepareOldButNotThatOld(c)
 	s.testAddSnapBinariesAndRemove(c, false, false)
 }
 
-func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveUnknownVersion(c *C) {
+func (s *binariesTestSuite) TestEnsureSnapBinariesAndRemoveOldButNotThatOld(c *C) {
+	s.prepareOldButNotThatOld(c)
+	s.testEnsureSnapBinariesAndRemove(c, false, false)
+}
+
+func (s *binariesTestSuite) prepareUnknownVersion(c *C) {
 	c.Assert(os.MkdirAll(dirs.CompletersDir, 0755), IsNil)
 	if s.base == "core-with-snapd" {
 		c.Check(os.MkdirAll(filepath.Join(dirs.SnapMountDir, "snapd/current/usr/lib/snapd"), 0755), IsNil)
@@ -128,31 +171,56 @@ func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveUnknownVersion(c *C) {
 	f, err := os.OpenFile(dirs.BashCompletionScript, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0644)
 	c.Assert(err, IsNil)
 	f.Close()
+}
 
+func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveUnknownVersion(c *C) {
+	s.prepareUnknownVersion(c)
 	s.testAddSnapBinariesAndRemove(c, false, true)
 }
 
-func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveNotInstalled(c *C) {
+func (s *binariesTestSuite) TestEnsureSnapBinariesAndRemoveUnknownVersion(c *C) {
+	s.prepareUnknownVersion(c)
+	s.testEnsureSnapBinariesAndRemove(c, false, true)
+}
+
+func (s *binariesTestSuite) prepareNotInstalled(c *C) {
 	c.Assert(os.MkdirAll(dirs.CompletersDir, 0755), IsNil)
 	if s.base == "core-with-snapd" {
 		c.Check(os.MkdirAll(filepath.Join(dirs.SnapMountDir, "snapd/current/usr/lib/snapd"), 0755), IsNil)
 	}
 
 	c.Assert(os.Remove(dirs.BashCompletionScript), IsNil)
+}
 
+func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveNotInstalled(c *C) {
+	s.prepareNotInstalled(c)
 	s.testAddSnapBinariesAndRemove(c, false, true)
 }
 
-func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveWithCompleters(c *C) {
+func (s *binariesTestSuite) TestEnsureSnapBinariesAndRemoveNotInstalled(c *C) {
+	s.prepareNotInstalled(c)
+	s.testEnsureSnapBinariesAndRemove(c, false, true)
+}
+
+func (s *binariesTestSuite) prepareWithCompleters(c *C) {
 	c.Assert(os.MkdirAll(dirs.CompletersDir, 0755), IsNil)
 	if s.base == "core-with-snapd" {
 		c.Check(os.MkdirAll(filepath.Join(dirs.SnapMountDir, "snapd/current/usr/lib/snapd"), 0755), IsNil)
 	}
 	c.Assert(os.MkdirAll(filepath.Dir(dirs.CompleteShPath(s.base)), 0755), IsNil)
 	c.Assert(ioutil.WriteFile(dirs.CompleteShPath(s.base), nil, 0644), IsNil)
-	// full completers support -> we get completers \o/
+}
 
+func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveWithCompleters(c *C) {
+	s.prepareWithCompleters(c)
+	// full completers support -> we get completers \o/
 	s.testAddSnapBinariesAndRemove(c, false, false)
+}
+
+func (s *binariesTestSuite) TestEnsureSnapBinariesAndRemoveWithCompleters(c *C) {
+	s.prepareWithCompleters(c)
+	// full completers support -> we get completers \o/
+	s.testEnsureSnapBinariesAndRemove(c, false, false)
 }
 
 func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveWithLegacyCompleters(c *C) {
@@ -170,7 +238,7 @@ func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveWithLegacyCompleters(c *
 
 func (s *binariesTestSuite) TestRemoveWithLegacyCompleters(c *C) {
 	info := snaptest.MockSnap(c, packageHello+"base: "+s.base+"\n", &snap.SideInfo{Revision: snap.R(11)})
-	err := wrappers.AddSnapBinaries(info)
+	err := s.addSnapBinaries(info)
 	c.Assert(err, IsNil)
 
 	// Simulate legacy installation
@@ -188,7 +256,7 @@ func (s *binariesTestSuite) TestRemoveWithLegacyCompleters(c *C) {
 	c.Assert(osutil.IsSymlink(legacyCompleter), Equals, false)
 }
 
-func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveWithExistingCompleters(c *C) {
+func (s *binariesTestSuite) prepareWithExistingCompleters(c *C) {
 	c.Assert(os.MkdirAll(dirs.CompletersDir, 0755), IsNil)
 	if s.base == "core-with-snapd" {
 		c.Check(os.MkdirAll(filepath.Join(dirs.SnapMountDir, "snapd/current/usr/lib/snapd"), 0755), IsNil)
@@ -197,8 +265,21 @@ func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveWithExistingCompleters(c
 	c.Assert(ioutil.WriteFile(dirs.CompleteShPath(s.base), nil, 0644), IsNil)
 	// existing completers -> they're left alone \o/
 	c.Assert(ioutil.WriteFile(filepath.Join(dirs.CompletersDir, "hello-snap.world"), nil, 0644), IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(dirs.CompletersDir, "hello-snap.universe"), nil, 0644), IsNil)
+}
 
+func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveWithExistingCompleters(c *C) {
+	s.prepareWithExistingCompleters(c)
 	s.testAddSnapBinariesAndRemove(c, false, false)
+}
+
+func (s *binariesTestSuite) TestEnsureSnapBinariesAndRemoveWithExistingCompleters(c *C) {
+	s.prepareWithExistingCompleters(c)
+	s.testEnsureSnapBinariesAndRemove(c, false, false)
+}
+
+func (s *binariesTestSuite) addSnapBinaries(info *snap.Info) error {
+	return wrappers.EnsureSnapBinaries(nil, info)
 }
 
 func (s *binariesTestSuite) testAddSnapBinariesAndRemove(c *C, useLegacy bool, disabledCompletion bool) {
@@ -209,7 +290,7 @@ func (s *binariesTestSuite) testAddSnapBinariesAndRemove(c *C, useLegacy bool, d
 	}
 	completerExisted := osutil.FileExists(completer)
 
-	err := wrappers.AddSnapBinaries(info)
+	err := s.addSnapBinaries(info)
 	c.Assert(err, IsNil)
 
 	bins := []string{"hello-snap.hello", "hello-snap.world"}
@@ -234,6 +315,7 @@ func (s *binariesTestSuite) testAddSnapBinariesAndRemove(c *C, useLegacy bool, d
 
 		if completerExisted {
 			// there was a completer there before, so it should _not_ be a symlink to our complete.sh
+			c.Check(osutil.FileExists(completer), Equals, true)
 			c.Assert(osutil.IsSymlink(completer), Equals, false)
 		} else {
 			target, err := os.Readlink(completer)
@@ -259,6 +341,89 @@ func (s *binariesTestSuite) testAddSnapBinariesAndRemove(c *C, useLegacy bool, d
 	c.Check(osutil.FileExists(completer), Equals, completerExisted)
 }
 
+func (s *binariesTestSuite) testEnsureSnapBinariesAndRemove(c *C, useLegacy bool, disabledCompletion bool) {
+	oldInfo := snaptest.MockSnap(c, packageHello+"base: "+s.base+"\n", &snap.SideInfo{Revision: snap.R(11)})
+	oldCompleter := filepath.Join(dirs.CompletersDir, "hello-snap.world")
+	if useLegacy {
+		oldCompleter = filepath.Join(dirs.LegacyCompletersDir, "hello-snap.world")
+	}
+	oldCompleterExisted := osutil.FileExists(oldCompleter)
+	err := s.addSnapBinaries(oldInfo)
+	c.Assert(err, IsNil)
+
+	newInfo := snaptest.MockSnap(c, packageHelloV2+"base: "+s.base+"\n", &snap.SideInfo{Revision: snap.R(12)})
+	newCompleter := filepath.Join(dirs.CompletersDir, "hello-snap.universe")
+	if useLegacy {
+		newCompleter = filepath.Join(dirs.LegacyCompletersDir, "hello-snap.universe")
+	}
+	newCompleterExisted := osutil.FileExists(newCompleter)
+	err = wrappers.EnsureSnapBinaries(oldInfo, newInfo)
+	c.Assert(err, IsNil)
+
+	binsAdded := []string{"hello-snap.hello", "hello-snap.universe"}
+	binsRemoved := []string{"hello-snap.world"}
+
+	for _, bin := range binsAdded {
+		link := filepath.Join(dirs.SnapBinariesDir, bin)
+		target, err := os.Readlink(link)
+		c.Assert(err, IsNil, Commentf(bin))
+		c.Check(target, Equals, "/usr/bin/snap", Commentf(bin))
+	}
+
+	for _, bin := range binsRemoved {
+		link := filepath.Join(dirs.SnapBinariesDir, bin)
+		c.Check(osutil.FileExists(link), Equals, false, Commentf(bin))
+	}
+
+	compDir := dirs.CompletersDir
+	if useLegacy {
+		compDir = dirs.LegacyCompletersDir
+	}
+
+	if oldCompleterExisted {
+		// there was a completer there before, so it should _not_ be removed or be a symlink to our complete.sh
+		c.Check(osutil.FileExists(oldCompleter), Equals, true)
+		c.Check(osutil.IsSymlink(oldCompleter), Equals, false)
+	} else {
+		// we created this completer, old revision completer should be removed
+		c.Check(osutil.FileExists(oldCompleter), Equals, false)
+	}
+
+	if disabledCompletion {
+		c.Assert(osutil.FileExists(dirs.CompleteShPath(s.base)), Equals, false)
+		c.Assert(osutil.IsSymlink(filepath.Join(dirs.CompletersDir, "hello-snap.universe")), Equals, false)
+		c.Assert(osutil.IsSymlink(filepath.Join(dirs.LegacyCompletersDir, "hello-snap.universe")), Equals, false)
+	} else if osutil.FileExists(dirs.CompleteShPath(s.base)) {
+		c.Assert(osutil.IsDirectory(compDir), Equals, true)
+
+		if newCompleterExisted {
+			// there was a completer there before, so it should _not_ be a symlink to our complete.sh
+			c.Check(osutil.FileExists(newCompleter), Equals, true)
+			c.Assert(osutil.IsSymlink(newCompleter), Equals, false)
+		} else {
+			target, err := os.Readlink(newCompleter)
+			c.Assert(err, IsNil)
+			c.Check(target, Equals, dirs.CompleteShPath(s.base))
+		}
+	}
+
+	if !disabledCompletion && !useLegacy {
+		legacyCompleter := filepath.Join(dirs.LegacyCompletersDir, "hello-snap.universe")
+		c.Assert(osutil.IsSymlink(legacyCompleter), Equals, false)
+	}
+
+	err = wrappers.RemoveSnapBinaries(newInfo)
+	c.Assert(err, IsNil)
+
+	for _, bin := range binsAdded {
+		link := filepath.Join(dirs.SnapBinariesDir, bin)
+		c.Check(osutil.FileExists(link), Equals, false, Commentf(bin))
+	}
+
+	// we left the existing completer alone, but removed it otherwise
+	c.Check(osutil.FileExists(newCompleter), Equals, newCompleterExisted)
+}
+
 func (s *binariesTestSuite) TestAddSnapBinariesCleansUpOnFailure(c *C) {
 	link := filepath.Join(dirs.SnapBinariesDir, "hello-snap.hello")
 	c.Assert(osutil.FileExists(link), Equals, false)
@@ -269,7 +434,7 @@ func (s *binariesTestSuite) TestAddSnapBinariesCleansUpOnFailure(c *C) {
   command: bin/bye
 `, &snap.SideInfo{Revision: snap.R(11)})
 
-	err := wrappers.AddSnapBinaries(info)
+	err := s.addSnapBinaries(info)
 	c.Assert(err, NotNil)
 
 	c.Check(osutil.FileExists(link), Equals, false)

--- a/wrappers/binaries_test.go
+++ b/wrappers/binaries_test.go
@@ -267,7 +267,7 @@ func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveWithLegacyCompleters(c *
 
 func (s *binariesTestSuite) TestRemoveWithLegacyCompleters(c *C) {
 	info := snaptest.MockSnap(c, packageHello+"base: "+s.base+"\n", &snap.SideInfo{Revision: snap.R(11)})
-	err := s.addSnapBinaries(info)
+	err := wrappers.EnsureSnapBinaries(info)
 	c.Assert(err, IsNil)
 
 	// Simulate legacy installation
@@ -329,10 +329,6 @@ func (s *binariesTestSuite) TestEnsureSnapBinariesAndRemoveWithExistingLegacyCom
 	s.testEnsureSnapBinariesAndRemove(c, true, false)
 }
 
-func (s *binariesTestSuite) addSnapBinaries(info *snap.Info) error {
-	return wrappers.EnsureSnapBinaries(nil, info)
-}
-
 func (s *binariesTestSuite) testAddSnapBinariesAndRemove(c *C, useLegacy bool, disabledCompletionOnHost bool) {
 	info := snaptest.MockSnap(c, packageHello+"base: "+s.base+"\n", &snap.SideInfo{Revision: snap.R(11)})
 	completer := filepath.Join(dirs.CompletersDir, "hello-snap.world")
@@ -341,7 +337,7 @@ func (s *binariesTestSuite) testAddSnapBinariesAndRemove(c *C, useLegacy bool, d
 	}
 	completerExisted := osutil.FileExists(completer) && !osutil.IsSymlink(completer)
 
-	err := s.addSnapBinaries(info)
+	err := wrappers.EnsureSnapBinaries(info)
 	c.Assert(err, IsNil)
 
 	bins := []string{"hello-snap.hello", "hello-snap.world"}
@@ -399,7 +395,7 @@ func (s *binariesTestSuite) testEnsureSnapBinariesAndRemove(c *C, useLegacy bool
 		oldCompleter = filepath.Join(dirs.LegacyCompletersDir, "hello-snap.world")
 	}
 	oldCompleterExisted := osutil.FileExists(oldCompleter) && !osutil.IsSymlink(oldCompleter)
-	err := s.addSnapBinaries(oldInfo)
+	err := wrappers.EnsureSnapBinaries(oldInfo)
 	c.Assert(err, IsNil)
 
 	newInfo := snaptest.MockSnap(c, packageHelloV2+"base: "+s.base+"\n", &snap.SideInfo{Revision: snap.R(12)})
@@ -408,7 +404,7 @@ func (s *binariesTestSuite) testEnsureSnapBinariesAndRemove(c *C, useLegacy bool
 		newCompleter = filepath.Join(dirs.LegacyCompletersDir, "hello-snap.universe")
 	}
 	newCompleterExisted := osutil.FileExists(newCompleter) && !osutil.IsSymlink(newCompleter)
-	err = wrappers.EnsureSnapBinaries(oldInfo, newInfo)
+	err = wrappers.EnsureSnapBinaries(newInfo)
 	c.Assert(err, IsNil)
 
 	binsAdded := []string{"hello-snap.hello", "hello-snap.universe"}
@@ -485,7 +481,7 @@ func (s *binariesTestSuite) TestAddSnapBinariesCleansUpOnFailure(c *C) {
   command: bin/bye
 `, &snap.SideInfo{Revision: snap.R(11)})
 
-	err := s.addSnapBinaries(info)
+	err := wrappers.EnsureSnapBinaries(info)
 	c.Assert(err, NotNil)
 
 	c.Check(osutil.FileExists(link), Equals, false)

--- a/wrappers/binaries_test.go
+++ b/wrappers/binaries_test.go
@@ -108,21 +108,49 @@ func (s *binariesTestSuite) TestAddSnapBinariesAndRemove(c *C) {
 	// no completers support -> no problem \o/
 	c.Assert(osutil.FileExists(dirs.CompletersDir), Equals, false)
 
-	s.testAddSnapBinariesAndRemove(c, false, false)
+	s.testAddSnapBinariesAndRemove(c, false, true)
 }
 
 func (s *binariesTestSuite) TestEnsureSnapBinariesAndRemove(c *C) {
 	// no completers support -> no problem \o/
 	c.Assert(osutil.FileExists(dirs.CompletersDir), Equals, false)
 
-	s.testEnsureSnapBinariesAndRemove(c, false, false)
+	s.testEnsureSnapBinariesAndRemove(c, false, true)
 }
 
-func (s *binariesTestSuite) prepareUseLegacy(c *C) {
-	c.Assert(os.MkdirAll(dirs.CompletersDir, 0755), IsNil)
+func (s *binariesTestSuite) prepareReadOnlyLegacyDir(c *C) {
+	c.Assert(os.MkdirAll(dirs.LegacyCompletersDir, 0400), IsNil)
 	if s.base == "core-with-snapd" {
 		c.Check(os.MkdirAll(filepath.Join(dirs.SnapMountDir, "snapd/current/usr/lib/snapd"), 0755), IsNil)
 	}
+
+	c.Assert(os.MkdirAll(filepath.Dir(dirs.CompleteShPath(s.base)), 0755), IsNil)
+	c.Assert(ioutil.WriteFile(dirs.CompleteShPath(s.base), nil, 0644), IsNil)
+
+	f, err := os.OpenFile(dirs.BashCompletionScript, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0644)
+	c.Assert(err, IsNil)
+	f.Write([]byte("#\n#   RELEASE: 2.1\n"))
+	f.Close()
+}
+
+func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveReadOnlyLegacyDir(c *C) {
+	s.prepareReadOnlyLegacyDir(c)
+	s.testAddSnapBinariesAndRemove(c, true, true)
+}
+
+func (s *binariesTestSuite) TestEnsureSnapBinariesAndRemoveReadOnlyLegacyDir(c *C) {
+	s.prepareReadOnlyLegacyDir(c)
+	s.testEnsureSnapBinariesAndRemove(c, true, true)
+}
+
+func (s *binariesTestSuite) prepareUseLegacy(c *C) {
+	c.Assert(os.MkdirAll(dirs.LegacyCompletersDir, 0755), IsNil)
+	if s.base == "core-with-snapd" {
+		c.Check(os.MkdirAll(filepath.Join(dirs.SnapMountDir, "snapd/current/usr/lib/snapd"), 0755), IsNil)
+	}
+
+	c.Assert(os.MkdirAll(filepath.Dir(dirs.CompleteShPath(s.base)), 0755), IsNil)
+	c.Assert(ioutil.WriteFile(dirs.CompleteShPath(s.base), nil, 0644), IsNil)
 
 	f, err := os.OpenFile(dirs.BashCompletionScript, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0644)
 	c.Assert(err, IsNil)
@@ -141,10 +169,12 @@ func (s *binariesTestSuite) TestEnsureSnapBinariesAndRemoveUseLegacy(c *C) {
 }
 
 func (s *binariesTestSuite) prepareOldButNotThatOld(c *C) {
-	c.Assert(os.MkdirAll(dirs.CompletersDir, 0755), IsNil)
 	if s.base == "core-with-snapd" {
 		c.Check(os.MkdirAll(filepath.Join(dirs.SnapMountDir, "snapd/current/usr/lib/snapd"), 0755), IsNil)
 	}
+
+	c.Assert(os.MkdirAll(filepath.Dir(dirs.CompleteShPath(s.base)), 0755), IsNil)
+	c.Assert(ioutil.WriteFile(dirs.CompleteShPath(s.base), nil, 0644), IsNil)
 
 	f, err := os.OpenFile(dirs.BashCompletionScript, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0644)
 	c.Assert(err, IsNil)
@@ -163,10 +193,12 @@ func (s *binariesTestSuite) TestEnsureSnapBinariesAndRemoveOldButNotThatOld(c *C
 }
 
 func (s *binariesTestSuite) prepareUnknownVersion(c *C) {
-	c.Assert(os.MkdirAll(dirs.CompletersDir, 0755), IsNil)
 	if s.base == "core-with-snapd" {
 		c.Check(os.MkdirAll(filepath.Join(dirs.SnapMountDir, "snapd/current/usr/lib/snapd"), 0755), IsNil)
 	}
+
+	c.Assert(os.MkdirAll(filepath.Dir(dirs.CompleteShPath(s.base)), 0755), IsNil)
+	c.Assert(ioutil.WriteFile(dirs.CompleteShPath(s.base), nil, 0644), IsNil)
 
 	f, err := os.OpenFile(dirs.BashCompletionScript, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0644)
 	c.Assert(err, IsNil)
@@ -184,7 +216,6 @@ func (s *binariesTestSuite) TestEnsureSnapBinariesAndRemoveUnknownVersion(c *C) 
 }
 
 func (s *binariesTestSuite) prepareNotInstalled(c *C) {
-	c.Assert(os.MkdirAll(dirs.CompletersDir, 0755), IsNil)
 	if s.base == "core-with-snapd" {
 		c.Check(os.MkdirAll(filepath.Join(dirs.SnapMountDir, "snapd/current/usr/lib/snapd"), 0755), IsNil)
 	}
@@ -203,7 +234,6 @@ func (s *binariesTestSuite) TestEnsureSnapBinariesAndRemoveNotInstalled(c *C) {
 }
 
 func (s *binariesTestSuite) prepareWithCompleters(c *C) {
-	c.Assert(os.MkdirAll(dirs.CompletersDir, 0755), IsNil)
 	if s.base == "core-with-snapd" {
 		c.Check(os.MkdirAll(filepath.Join(dirs.SnapMountDir, "snapd/current/usr/lib/snapd"), 0755), IsNil)
 	}
@@ -224,13 +254,12 @@ func (s *binariesTestSuite) TestEnsureSnapBinariesAndRemoveWithCompleters(c *C) 
 }
 
 func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveWithLegacyCompleters(c *C) {
-	c.Assert(os.MkdirAll(dirs.CompletersDir, 0755), IsNil)
+	c.Assert(os.MkdirAll(dirs.LegacyCompletersDir, 0755), IsNil)
 	if s.base == "core-with-snapd" {
 		c.Check(os.MkdirAll(filepath.Join(dirs.SnapMountDir, "snapd/current/usr/lib/snapd"), 0755), IsNil)
 	}
 	c.Assert(os.MkdirAll(filepath.Dir(dirs.CompleteShPath(s.base)), 0755), IsNil)
 	c.Assert(ioutil.WriteFile(dirs.CompleteShPath(s.base), nil, 0644), IsNil)
-	c.Assert(os.MkdirAll(dirs.LegacyCompletersDir, 0755), IsNil)
 	c.Assert(os.Symlink(dirs.CompleteShPath(s.base), filepath.Join(dirs.LegacyCompletersDir, "hello-snap.world")), IsNil)
 
 	s.testAddSnapBinariesAndRemove(c, false, false)
@@ -278,6 +307,28 @@ func (s *binariesTestSuite) TestEnsureSnapBinariesAndRemoveWithExistingCompleter
 	s.testEnsureSnapBinariesAndRemove(c, false, false)
 }
 
+func (s *binariesTestSuite) prepareWithExistingLegacyCompleters(c *C) {
+	c.Assert(os.MkdirAll(dirs.LegacyCompletersDir, 0755), IsNil)
+	if s.base == "core-with-snapd" {
+		c.Check(os.MkdirAll(filepath.Join(dirs.SnapMountDir, "snapd/current/usr/lib/snapd"), 0755), IsNil)
+	}
+	c.Assert(os.MkdirAll(filepath.Dir(dirs.CompleteShPath(s.base)), 0755), IsNil)
+	c.Assert(ioutil.WriteFile(dirs.CompleteShPath(s.base), nil, 0644), IsNil)
+	// existing completers -> they're left alone \o/
+	c.Assert(ioutil.WriteFile(filepath.Join(dirs.LegacyCompletersDir, "hello-snap.world"), nil, 0644), IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(dirs.LegacyCompletersDir, "hello-snap.universe"), nil, 0644), IsNil)
+}
+
+func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveWithExistingLegacyCompleters(c *C) {
+	s.prepareWithExistingLegacyCompleters(c)
+	s.testAddSnapBinariesAndRemove(c, true, false)
+}
+
+func (s *binariesTestSuite) TestEnsureSnapBinariesAndRemoveWithExistingLegacyCompleters(c *C) {
+	s.prepareWithExistingLegacyCompleters(c)
+	s.testEnsureSnapBinariesAndRemove(c, true, false)
+}
+
 func (s *binariesTestSuite) addSnapBinaries(info *snap.Info) error {
 	return wrappers.EnsureSnapBinaries(nil, info)
 }
@@ -307,10 +358,10 @@ func (s *binariesTestSuite) testAddSnapBinariesAndRemove(c *C, useLegacy bool, d
 		compDir = dirs.LegacyCompletersDir
 	}
 	if disabledCompletion {
-		c.Assert(osutil.FileExists(dirs.CompleteShPath(s.base)), Equals, false)
 		c.Assert(osutil.IsSymlink(filepath.Join(dirs.CompletersDir, "hello-snap.world")), Equals, false)
 		c.Assert(osutil.IsSymlink(filepath.Join(dirs.LegacyCompletersDir, "hello-snap.world")), Equals, false)
-	} else if osutil.FileExists(dirs.CompleteShPath(s.base)) {
+	} else {
+		c.Assert(osutil.FileExists(dirs.CompleteShPath(s.base)), Equals, true)
 		c.Assert(osutil.IsDirectory(compDir), Equals, true)
 
 		if completerExisted {
@@ -390,10 +441,10 @@ func (s *binariesTestSuite) testEnsureSnapBinariesAndRemove(c *C, useLegacy bool
 	}
 
 	if disabledCompletion {
-		c.Assert(osutil.FileExists(dirs.CompleteShPath(s.base)), Equals, false)
 		c.Assert(osutil.IsSymlink(filepath.Join(dirs.CompletersDir, "hello-snap.universe")), Equals, false)
 		c.Assert(osutil.IsSymlink(filepath.Join(dirs.LegacyCompletersDir, "hello-snap.universe")), Equals, false)
-	} else if osutil.FileExists(dirs.CompleteShPath(s.base)) {
+	} else {
+		c.Assert(osutil.FileExists(dirs.CompleteShPath(s.base)), Equals, true)
 		c.Assert(osutil.IsDirectory(compDir), Equals, true)
 
 		if newCompleterExisted {

--- a/wrappers/binaries_test.go
+++ b/wrappers/binaries_test.go
@@ -486,3 +486,7 @@ func (s *binariesTestSuite) TestAddSnapBinariesCleansUpOnFailure(c *C) {
 
 	c.Check(osutil.FileExists(link), Equals, false)
 }
+
+func (s *iconsTestSuite) TestEnsureSnapBinariesNilSnapInfo(c *C) {
+	c.Assert(wrappers.EnsureSnapBinaries(nil), ErrorMatches, "internal error: snap info cannot be nil")
+}

--- a/wrappers/desktop.go
+++ b/wrappers/desktop.go
@@ -263,7 +263,7 @@ func deriveDesktopFilesContent(s *snap.Info, desktopFiles []string) (map[string]
 		fileContent = sanitizeDesktopFile(s, installedDesktopFileName, fileContent)
 		content[base] = &osutil.MemoryFileState{
 			Content: fileContent,
-			Mode:    0755,
+			Mode:    0644,
 		}
 	}
 	return content, nil

--- a/wrappers/desktop.go
+++ b/wrappers/desktop.go
@@ -281,7 +281,7 @@ func deriveDesktopFilesContent(s *snap.Info) (map[string]osutil.FileState, error
 // that only new snap desktop files exist.
 func EnsureSnapDesktopFiles(s *snap.Info) error {
 	if s == nil {
-		panic("internal error: snap info cannot be nil")
+		return fmt.Errorf("internal error: snap info cannot be nil")
 	}
 	if err := os.MkdirAll(dirs.SnapDesktopFilesDir, 0755); err != nil {
 		return err

--- a/wrappers/desktop.go
+++ b/wrappers/desktop.go
@@ -246,7 +246,13 @@ func findDesktopFiles(rootDir string) ([]string, error) {
 	return desktopFiles, nil
 }
 
-func deriveDesktopFilesContent(s *snap.Info, desktopFiles []string) (map[string]osutil.FileState, error) {
+func deriveDesktopFilesContent(s *snap.Info) (map[string]osutil.FileState, error) {
+	rootDir := filepath.Join(s.MountDir(), "meta", "gui")
+	desktopFiles, err := findDesktopFiles(rootDir)
+	if err != nil {
+		return nil, err
+	}
+
 	content := make(map[string]osutil.FileState)
 	for _, df := range desktopFiles {
 		base := filepath.Base(df)
@@ -281,13 +287,7 @@ func EnsureSnapDesktopFiles(s *snap.Info) error {
 		return err
 	}
 
-	rootDir := filepath.Join(s.MountDir(), "meta", "gui")
-	desktopFiles, err := findDesktopFiles(rootDir)
-	if err != nil {
-		return err
-	}
-
-	content, err := deriveDesktopFilesContent(s, desktopFiles)
+	content, err := deriveDesktopFilesContent(s)
 	if err != nil {
 		return err
 	}

--- a/wrappers/desktop_test.go
+++ b/wrappers/desktop_test.go
@@ -105,9 +105,7 @@ func (s *desktopSuite) TestEnsurePackageDesktopFiles(c *C) {
 }
 
 func (s *iconsTestSuite) TestEnsurePackageDesktopFilesNilSnapInfo(c *C) {
-	c.Assert(func() {
-		wrappers.EnsureSnapDesktopFiles(nil)
-	}, PanicMatches, "internal error: snap info cannot be nil")
+	c.Assert(wrappers.EnsureSnapDesktopFiles(nil), ErrorMatches, "internal error: snap info cannot be nil")
 }
 
 func (s *desktopSuite) TestRemovePackageDesktopFiles(c *C) {

--- a/wrappers/desktop_test.go
+++ b/wrappers/desktop_test.go
@@ -91,6 +91,9 @@ func (s *desktopSuite) TestEnsurePackageDesktopFiles(c *C) {
 	err := wrappers.EnsureSnapDesktopFiles(info)
 	c.Assert(err, IsNil)
 	c.Assert(osutil.FileExists(expectedDesktopFilePath), Equals, true)
+	stat, err := os.Stat(expectedDesktopFilePath)
+	c.Assert(err, IsNil)
+	c.Assert(stat.Mode().Perm(), Equals, os.FileMode(0644))
 	c.Assert(s.mockUpdateDesktopDatabase.Calls(), DeepEquals, [][]string{
 		{"update-desktop-database", dirs.SnapDesktopFilesDir},
 	})

--- a/wrappers/desktop_test.go
+++ b/wrappers/desktop_test.go
@@ -72,26 +72,39 @@ var mockDesktopFile = []byte(`
 Name=foo
 Icon=${SNAP}/foo.png`)
 
-func (s *desktopSuite) TestAddPackageDesktopFiles(c *C) {
+func (s *desktopSuite) TestEnsurePackageDesktopFiles(c *C) {
 	expectedDesktopFilePath := filepath.Join(dirs.SnapDesktopFilesDir, "foo_foobar.desktop")
 	c.Assert(osutil.FileExists(expectedDesktopFilePath), Equals, false)
+
+	oldDesktopFilePath := filepath.Join(dirs.SnapDesktopFilesDir, "foo_foobar2.desktop")
+	c.Assert(os.MkdirAll(dirs.SnapDesktopFilesDir, 0755), IsNil)
+	c.Assert(ioutil.WriteFile(oldDesktopFilePath, mockDesktopFile, 0644), IsNil)
+	c.Assert(osutil.FileExists(oldDesktopFilePath), Equals, true)
 
 	info := snaptest.MockSnap(c, desktopAppYaml, &snap.SideInfo{Revision: snap.R(11)})
 
 	// generate .desktop file in the package baseDir
 	baseDir := info.MountDir()
-	err := os.MkdirAll(filepath.Join(baseDir, "meta", "gui"), 0755)
-	c.Assert(err, IsNil)
+	c.Assert(os.MkdirAll(filepath.Join(baseDir, "meta", "gui"), 0755), IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(baseDir, "meta", "gui", "foobar.desktop"), mockDesktopFile, 0644), IsNil)
 
-	err = ioutil.WriteFile(filepath.Join(baseDir, "meta", "gui", "foobar.desktop"), mockDesktopFile, 0644)
-	c.Assert(err, IsNil)
-
-	err = wrappers.AddSnapDesktopFiles(info)
+	err := wrappers.EnsureSnapDesktopFiles(info)
 	c.Assert(err, IsNil)
 	c.Assert(osutil.FileExists(expectedDesktopFilePath), Equals, true)
 	c.Assert(s.mockUpdateDesktopDatabase.Calls(), DeepEquals, [][]string{
 		{"update-desktop-database", dirs.SnapDesktopFilesDir},
 	})
+	sanitizedDesktopFileContent := wrappers.SanitizeDesktopFile(info, expectedDesktopFilePath, mockDesktopFile)
+	c.Check(expectedDesktopFilePath, testutil.FileContains, sanitizedDesktopFileContent)
+
+	// Old desktop file should be removed
+	c.Assert(osutil.FileExists(oldDesktopFilePath), Equals, false)
+}
+
+func (s *iconsTestSuite) TestEnsurePackageDesktopFilesNilSnapInfo(c *C) {
+	c.Assert(func() {
+		wrappers.EnsureSnapDesktopFiles(nil)
+	}, PanicMatches, "internal error: snap info cannot be nil")
 }
 
 func (s *desktopSuite) TestRemovePackageDesktopFiles(c *C) {
@@ -151,7 +164,7 @@ func (s *desktopSuite) TestParallelInstancesRemovePackageDesktopFiles(c *C) {
 	c.Assert(osutil.FileExists(mockDesktopFilePath), Equals, true)
 }
 
-func (s *desktopSuite) TestAddPackageDesktopFilesCleanup(c *C) {
+func (s *desktopSuite) TestEnsurePackageDesktopFilesCleanup(c *C) {
 	mockDesktopFilePath := filepath.Join(dirs.SnapDesktopFilesDir, "foo_foobar1.desktop")
 	c.Assert(osutil.FileExists(mockDesktopFilePath), Equals, false)
 
@@ -177,7 +190,7 @@ func (s *desktopSuite) TestAddPackageDesktopFilesCleanup(c *C) {
 	err = ioutil.WriteFile(filepath.Join(baseDir, "meta", "gui", "foobar2.desktop"), mockDesktopFile, 0644)
 	c.Assert(err, IsNil)
 
-	err = wrappers.AddSnapDesktopFiles(info)
+	err = wrappers.EnsureSnapDesktopFiles(info)
 	c.Check(err, NotNil)
 	c.Check(osutil.FileExists(mockDesktopFilePath), Equals, false)
 	c.Check(s.mockUpdateDesktopDatabase.Calls(), HasLen, 0)
@@ -574,7 +587,7 @@ func (s *desktopSuite) TestAddRemoveDesktopFiles(c *C) {
 		err = ioutil.WriteFile(filepath.Join(baseDir, "meta", "gui", t.upstreamDesktopFileName), mockDesktopFile, 0644)
 		c.Assert(err, IsNil)
 
-		err = wrappers.AddSnapDesktopFiles(info)
+		err = wrappers.EnsureSnapDesktopFiles(info)
 		c.Assert(err, IsNil)
 		c.Assert(osutil.FileExists(expectedDesktopFilePath), Equals, true)
 

--- a/wrappers/icons.go
+++ b/wrappers/icons.go
@@ -91,7 +91,14 @@ func deriveIconContent(instanceName string, rootDir string, icons []string) (con
 	return content, nil
 }
 
-func AddSnapIcons(s *snap.Info) error {
+// EnsureSnapIcons puts in place the icon files for the applications from the snap.
+//
+// It also removes icon files from the applications of the old snap revision to ensure
+// that only new snap icon files exist.
+func EnsureSnapIcons(s *snap.Info) error {
+	if s == nil {
+		panic("internal error: snap info cannot be nil")
+	}
 	if err := os.MkdirAll(dirs.SnapDesktopIconsDir, 0755); err != nil {
 		return err
 	}
@@ -111,6 +118,7 @@ func AddSnapIcons(s *snap.Info) error {
 	return err
 }
 
+// RemoveSnapIcons removes the added icons for the applications in the snap.
 func RemoveSnapIcons(s *snap.Info) error {
 	if !osutil.IsDirectory(dirs.SnapDesktopIconsDir) {
 		return nil

--- a/wrappers/icons.go
+++ b/wrappers/icons.go
@@ -97,7 +97,7 @@ func deriveIconContent(instanceName string, rootDir string, icons []string) (con
 // that only new snap icon files exist.
 func EnsureSnapIcons(s *snap.Info) error {
 	if s == nil {
-		panic("internal error: snap info cannot be nil")
+		return fmt.Errorf("internal error: snap info cannot be nil")
 	}
 	if err := os.MkdirAll(dirs.SnapDesktopIconsDir, 0755); err != nil {
 		return err

--- a/wrappers/icons_test.go
+++ b/wrappers/icons_test.go
@@ -99,9 +99,7 @@ func (s *iconsTestSuite) TestEnsureSnapIcons(c *C) {
 }
 
 func (s *iconsTestSuite) TestEnsureSnapIconsNilSnapInfo(c *C) {
-	c.Assert(func() {
-		wrappers.EnsureSnapIcons(nil)
-	}, PanicMatches, "internal error: snap info cannot be nil")
+	c.Assert(wrappers.EnsureSnapIcons(nil), ErrorMatches, "internal error: snap info cannot be nil")
 }
 
 func (s *iconsTestSuite) TestRemoveSnapIcons(c *C) {

--- a/wrappers/icons_test.go
+++ b/wrappers/icons_test.go
@@ -78,7 +78,7 @@ func (s *iconsTestSuite) TestFindIconFiles(c *C) {
 	})
 }
 
-func (s *iconsTestSuite) TestAddSnapIcons(c *C) {
+func (s *iconsTestSuite) TestEnsureSnapIcons(c *C) {
 	info := snaptest.MockSnap(c, packageHello, &snap.SideInfo{Revision: snap.R(11)})
 
 	baseDir := info.MountDir()
@@ -86,9 +86,22 @@ func (s *iconsTestSuite) TestAddSnapIcons(c *C) {
 	c.Assert(os.MkdirAll(filepath.Join(iconsDir, "hicolor", "scalable", "apps"), 0755), IsNil)
 	c.Assert(ioutil.WriteFile(filepath.Join(iconsDir, "hicolor", "scalable", "apps", "snap.hello-snap.foo.svg"), []byte("scalable"), 0644), IsNil)
 
-	c.Assert(wrappers.AddSnapIcons(info), IsNil)
+	c.Assert(os.MkdirAll(filepath.Join(dirs.SnapDesktopIconsDir, "hicolor", "scalable", "apps"), 0755), IsNil)
+	oldIconFile := filepath.Join(dirs.SnapDesktopIconsDir, "hicolor", "scalable", "apps", "snap.hello-snap.bar.svg")
+	c.Assert(ioutil.WriteFile(oldIconFile, []byte("scalable"), 0644), IsNil)
+
+	c.Assert(wrappers.EnsureSnapIcons(info), IsNil)
 	iconFile := filepath.Join(dirs.SnapDesktopIconsDir, "hicolor", "scalable", "apps", "snap.hello-snap.foo.svg")
 	c.Check(iconFile, testutil.FileEquals, "scalable")
+
+	// Old icon should be removed
+	c.Check(oldIconFile, testutil.FileAbsent)
+}
+
+func (s *iconsTestSuite) TestEnsureSnapIconsNilSnapInfo(c *C) {
+	c.Assert(func() {
+		wrappers.EnsureSnapIcons(nil)
+	}, PanicMatches, "internal error: snap info cannot be nil")
 }
 
 func (s *iconsTestSuite) TestRemoveSnapIcons(c *C) {
@@ -102,7 +115,7 @@ func (s *iconsTestSuite) TestRemoveSnapIcons(c *C) {
 	c.Check(iconFile, testutil.FileAbsent)
 }
 
-func (s *iconsTestSuite) TestParallelInstanceAddIcons(c *C) {
+func (s *iconsTestSuite) TestParallelInstanceEnsureIcons(c *C) {
 	info := snaptest.MockSnap(c, packageHello, &snap.SideInfo{Revision: snap.R(11)})
 	info.InstanceKey = "instance"
 
@@ -111,7 +124,7 @@ func (s *iconsTestSuite) TestParallelInstanceAddIcons(c *C) {
 	c.Assert(os.MkdirAll(filepath.Join(iconsDir, "hicolor", "scalable", "apps"), 0755), IsNil)
 	c.Assert(ioutil.WriteFile(filepath.Join(iconsDir, "hicolor", "scalable", "apps", "snap.hello-snap.foo.svg"), []byte("scalable"), 0644), IsNil)
 
-	c.Assert(wrappers.AddSnapIcons(info), IsNil)
+	c.Assert(wrappers.EnsureSnapIcons(info), IsNil)
 	iconFile := filepath.Join(dirs.SnapDesktopIconsDir, "hicolor", "scalable", "apps", "snap.hello-snap_instance.foo.svg")
 	c.Check(iconFile, testutil.FileEquals, "scalable")
 


### PR DESCRIPTION
This is part of the preparation for using Ensure* functions instead of Add* functions in backend.LinkSnap and backend.UnlinkSnap.

For more context: https://github.com/snapcore/snapd/pull/13066