### PR TITLE
cmd/configure.ac: rework

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -7,18 +7,6 @@ dist_man_MANS =
 noinst_PROGRAMS =
 noinst_LIBRARIES =
 
-CHECK_CFLAGS = -Wall -Wextra -Wmissing-prototypes -Wstrict-prototypes \
-	-Wno-unused-parameter
-
-if NO_MISSING_FIELD_INITIALIZERS
-CHECK_CFLAGS += -Wno-missing-field-initializers
-endif
-
-# Make all warnings errors when building for unit tests
-if WITH_UNIT_TESTS
-CHECK_CFLAGS += -Werror
-endif
-
 if USE_INTERNAL_BPF_HEADERS
 VENDOR_BPF_HEADERS_CFLAGS = -I$(srcdir)/libsnap-confine-private/bpf/vendor
 endif

--- a/cmd/configure.ac
+++ b/cmd/configure.ac
@@ -241,21 +241,27 @@ esac],
 [enable_bpf=yes])
 AM_CONDITIONAL([ENABLE_BPF], [test "x$enable_bpf" = "xyes"])
 
-if test "x$enable_bpf" = "xyes"; then
-AC_DEFINE([ENABLE_BPF], [1], [Enable BPF support])
-AC_MSG_CHECKING([whether host BPF headers are usable])
-AC_COMPILE_IFELSE([
+AS_IF([test "x$enable_bpf" = "xyes"], [
+  AC_DEFINE([ENABLE_BPF], [1], [Enable BPF support])
+
+  AC_CACHE_CHECK([whether host BPF headers are usable], [snapd_cv_bpf_header_works], [
+      AC_COMPILE_IFELSE(
+        [AC_LANG_SOURCE([[
 #include <linux/bpf.h>
 void foo(enum bpf_attach_type type) {}
 void bar() { struct bpf_cgroup_dev_ctx ctx = {0}; }
-], [host_bpf_headers_usable=yes], [host_bpf_headers_usable=no])
-if test "x$host_bpf_headers_usable" = "xyes"; then
-   AC_MSG_RESULT([yes])
-else
-  AC_MSG_RESULT([no, using vendored BPF headers])
-fi
-fi
-AM_CONDITIONAL([USE_INTERNAL_BPF_HEADERS], [test "x$host_bpf_headers_usable" = "xno"])
+]])],
+          [snapd_cv_bpf_header_works=yes],
+          [snapd_cv_bpf_header_works=no])
+  ])
+
+  AS_IF([test "x$snapd_cv_bpf_header_works" = "xno"], [
+    use_internal_pbf_headers=yes
+  ])
+], [
+  use_internal_pbf_headers=no
+])
+AM_CONDITIONAL([USE_INTERNAL_BPF_HEADERS], [test "x$use_internal_pbf_headers" = "xyes"])
 
 AC_DEFINE([MISSING_FIELD_INITIALIZERS_USABLE], [1], [-Wmissing-field-initializers are usable])
 AC_MSG_CHECKING([whether MISSING_FIELD_INITIALIZER warnings are usable])

--- a/cmd/configure.ac
+++ b/cmd/configure.ac
@@ -278,7 +278,21 @@ struct { const char* a; int b; } b[] = { {.a = ""}, {} };
   CFLAGS="${save_CFLAGS}"
 ])
 
-AM_CONDITIONAL([NO_MISSING_FIELD_INITIALIZERS], [test "x$snapd_cv_missing_field_initializers_works" = "xno"])
+AX_APPEND_COMPILE_FLAGS([ dnl
+  -Wall dnl
+  -Wextra dnl
+  -Wmissing-prototypes dnl
+  -Wstrict-prototypes dnl
+  -Wno-unused-parameter dnl
+ ], [CHECK_CFLAGS])
+
+AS_IF([test "x$snapd_cv_missing_field_initializers_works" = "xno"], [
+  AX_APPEND_COMPILE_FLAGS([-Wno-missing-field-initializers], [CHECK_CFLAGS])
+])
+
+AS_IF([test "x$with_unit_tests" = "xyes"], [
+  AX_APPEND_COMPILE_FLAGS([-Werror], [CHECK_CFLAGS])
+])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/cmd/configure.ac
+++ b/cmd/configure.ac
@@ -263,22 +263,22 @@ void bar() { struct bpf_cgroup_dev_ctx ctx = {0}; }
 ])
 AM_CONDITIONAL([USE_INTERNAL_BPF_HEADERS], [test "x$use_internal_pbf_headers" = "xyes"])
 
-AC_DEFINE([MISSING_FIELD_INITIALIZERS_USABLE], [1], [-Wmissing-field-initializers are usable])
-AC_MSG_CHECKING([whether MISSING_FIELD_INITIALIZER warnings are usable])
-AC_COMPILE_IFELSE([
-#include <linux/resource.h>
-#pragma GCC diagnostic error "-Wmissing-field-initializers"
-struct sc_mount{const char *path;int foo;};
-void foo() { struct sc_mount mounts[[]] = { {.path = "x"}, {}, }; }
-void bar() { struct rlimit limit = {0}; }
-], [w_missing_field_initializers_usable=yes], [w_missing_field_initializers_usable=no])
-if test "x$w_missing_field_initializers_usable" = "xyes"; then
-   AC_MSG_RESULT([yes])
-else
-  AC_MSG_RESULT([no, running with -Wno-missing-field-initializers])
-fi
-AM_CONDITIONAL([NO_MISSING_FIELD_INITIALIZERS], [test "x$w_missing_field_initializers_usable" = "xno"])
+AC_CACHE_CHECK([whether -Wmissing-field-initializers is correct], [snapd_cv_missing_field_initializers_works], [
+  save_CFLAGS="${CFLAGS}"
+  CFLAGS="${CFLAGS} -Wmissing-field-initializers -Werror"
+  AC_COMPILE_IFELSE(
+    [AC_LANG_SOURCE([[
+struct { int a; int b; } a = { 0 };
+struct { const char* a; int b; } b[] = { {.a = ""}, {} };
+]])], [
+    snapd_cv_missing_field_initializers_works=yes
+  ], [
+    snapd_cv_missing_field_initializers_works=no
+  ])
+  CFLAGS="${save_CFLAGS}"
+])
 
+AM_CONDITIONAL([NO_MISSING_FIELD_INITIALIZERS], [test "x$snapd_cv_missing_field_initializers_works" = "xno"])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/cmd/configure.ac
+++ b/cmd/configure.ac
@@ -22,11 +22,7 @@ AC_SYS_LARGEFILE
 # Checks for header files.
 AC_CHECK_HEADERS([fcntl.h limits.h stdlib.h string.h sys/mount.h unistd.h])
 AC_CHECK_HEADERS([sys/quota.h], [], [AC_MSG_ERROR(sys/quota.h unavailable)])
-AC_CHECK_HEADERS([xfs/xqm.h], [], [AC_MSG_ERROR(xfs/xqm.h unavailable)],
-[[#define _GNU_SOURCE
-#define _FILE_OFFSET_BITS 64
-#include <xfs/xqm.h>
-]])
+AC_CHECK_HEADERS([xfs/xqm.h], [], [AC_MSG_ERROR(xfs/xqm.h unavailable)])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_CHECK_HEADER_STDBOOL

--- a/packaging/debian-sid/control
+++ b/packaging/debian-sid/control
@@ -7,6 +7,7 @@ Uploaders: Steve Langasek <vorlon@debian.org>,
 	Luke Faraone <lfaraone@debian.org>,
         Michael Vogt <mvo@debian.org>
 Build-Depends: autoconf,
+               autoconf-archive,
                automake,
                autotools-dev,
                bash-completion,

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -192,6 +192,7 @@ designed for working with self-contained, immutable packages.
 Summary:        Confinement system for snap applications
 License:        GPLv3
 BuildRequires:  autoconf
+BuildRequires:  autoconf-archive
 BuildRequires:  automake
 BuildRequires:  libtool
 BuildRequires:  gcc

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -91,6 +91,7 @@ Url:            https://%{import_path}
 Source0:        https://github.com/snapcore/snapd/releases/download/%{version}/%{name}_%{version}.vendor.tar.xz
 Source1:        snapd-rpmlintrc
 BuildRequires:  autoconf
+BuildRequires:  autoconf-archive
 BuildRequires:  automake
 BuildRequires:  fakeroot
 BuildRequires:  glib2-devel

--- a/packaging/ubuntu-14.04/control
+++ b/packaging/ubuntu-14.04/control
@@ -3,6 +3,7 @@ Section: devel
 Priority: optional
 Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
 Build-Depends: autoconf,
+               autoconf-archive,
                automake,
                autotools-dev,
                bash-completion,

--- a/packaging/ubuntu-16.04/control
+++ b/packaging/ubuntu-16.04/control
@@ -3,6 +3,7 @@ Section: devel
 Priority: optional
 Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
 Build-Depends: autoconf,
+               autoconf-archive,
                automake,
                autotools-dev,
                bash-completion,

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -800,6 +800,7 @@ pkg_dependencies_opensuse(){
 pkg_dependencies_arch(){
     echo "
     apparmor
+    autoconf-archive
     base-devel
     bash-completion
     bpf


### PR DESCRIPTION
This is a cleanup of `cmd/configure.ac`.
 * Cache results from running compiler.
 * Use `AX_APPEND_COMPILE_FLAGS` to make sure warning flags exist
 * Wrap test code in `AC_LANG_SOURCE`/`AC_LANG_PROGRAM` and simplify test code.