### PR TITLE
apparmor: disable vendoring again

### DIFF
--- a/sandbox/apparmor/apparmor_test.go
+++ b/sandbox/apparmor/apparmor_test.go
@@ -79,31 +79,34 @@ func (*apparmorSuite) TestAppArmorParser(c *C) {
 }
 
 func (*apparmorSuite) TestAppArmorInternalAppArmorParser(c *C) {
-	fakeroot := c.MkDir()
-	dirs.SetRootDir(fakeroot)
+	// TODO:apparmor-vendoring
+	/*
+		fakeroot := c.MkDir()
+		dirs.SetRootDir(fakeroot)
 
-	d := filepath.Join(dirs.SnapMountDir, "/snapd/42", "/usr/lib/snapd")
-	c.Assert(os.MkdirAll(d, 0755), IsNil)
-	p := filepath.Join(d, "apparmor_parser")
-	c.Assert(ioutil.WriteFile(p, nil, 0755), IsNil)
-	restore := snapdtool.MockOsReadlink(func(path string) (string, error) {
-		c.Assert(path, Equals, "/proc/self/exe")
-		return filepath.Join(d, "snapd"), nil
-	})
-	defer restore()
-	restore = apparmor.MockSnapdAppArmorSupportsReexec(func() bool { return true })
-	defer restore()
+		d := filepath.Join(dirs.SnapMountDir, "/snapd/42", "/usr/lib/snapd")
+		c.Assert(os.MkdirAll(d, 0755), IsNil)
+		p := filepath.Join(d, "apparmor_parser")
+		c.Assert(ioutil.WriteFile(p, nil, 0755), IsNil)
+		restore := snapdtool.MockOsReadlink(func(path string) (string, error) {
+			c.Assert(path, Equals, "/proc/self/exe")
+			return filepath.Join(d, "snapd"), nil
+		})
+		defer restore()
+		restore = apparmor.MockSnapdAppArmorSupportsReexec(func() bool { return true })
+		defer restore()
 
-	cmd, internal, err := apparmor.AppArmorParser()
-	c.Check(err, IsNil)
-	c.Check(cmd.Path, Equals, p)
-	c.Check(cmd.Args, DeepEquals, []string{
-		p,
-		"--config-file", filepath.Join(d, "/apparmor/parser.conf"),
-		"--base", filepath.Join(d, "/apparmor.d"),
-		"--policy-features", filepath.Join(d, "/apparmor.d/abi/3.0"),
-	})
-	c.Check(internal, Equals, true)
+		cmd, internal, err := apparmor.AppArmorParser()
+		c.Check(err, IsNil)
+		c.Check(cmd.Path, Equals, p)
+		c.Check(cmd.Args, DeepEquals, []string{
+			p,
+			"--config-file", filepath.Join(d, "/apparmor/parser.conf"),
+			"--base", filepath.Join(d, "/apparmor.d"),
+			"--policy-features", filepath.Join(d, "/apparmor.d/abi/3.0"),
+		})
+		c.Check(internal, Equals, true)
+	*/
 }
 
 func (*apparmorSuite) TestAppArmorLevelTypeStringer(c *C) {
@@ -352,9 +355,14 @@ profile snap-test {
 	defer restore()
 	restore = apparmor.MockSnapdAppArmorSupportsReexec(func() bool { return true })
 	defer restore()
-	features, err = apparmor.ProbeParserFeatures()
-	c.Check(err, Equals, nil)
-	c.Check(features, DeepEquals, []string{"snapd-internal"})
+
+	// TODO:apparmor-vendoring
+	// disabled until the spread test failures are fixed
+	/*
+		features, err = apparmor.ProbeParserFeatures()
+		c.Check(err, Equals, nil)
+		c.Check(features, DeepEquals, []string{"snapd-internal"})
+	*/
 }
 
 func (s *apparmorSuite) TestInterfaceSystemKey(c *C) {

--- a/tests/main/snapd-snap/task.yaml
+++ b/tests/main/snapd-snap/task.yaml
@@ -221,6 +221,10 @@ execute: |
 
     unsquashfs -ll snapd_spread-test.snap | MATCH libc.so
 
+    # TODO:apparmor-vendoring
+    # remove this "exit 0" once apparmor-vendoring is ready
+    exit 0
+
     echo "Ensure we have apparmor_parser"
     unsquashfs -ll snapd_spread-test.snap | MATCH usr/lib/snapd/apparmor_parser
 


### PR DESCRIPTION
This is similar to 9ad372eae0, apparmor vendoring is disabled again because it breaks user with non-home homedirs or users that require tunables from /etc.

See also:
https://forum.snapcraft.io/t/upgrade-snapd-from-2-59-5-to-2-60-2-gives-apparmor-denied-on-app-launch-for-every-app/36492 https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/2032668
