### PR TITLE
i/apparmor: support for home.d tunables from /etc/

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -65,6 +65,7 @@ var templateCommon = `
 
 #include <tunables/global>
 
+###INCLUDE_SYSTEM_TUNABLES_HOME_D_WITH_VENDORED_APPARMOR###
 ###INCLUDE_IF_EXISTS_SNAP_TUNING###
 
 # snapd supports the concept of 'parallel installs' where snaps with the same
@@ -842,6 +843,8 @@ var coreSnippet = `
 var classicTemplate = `
 #include <tunables/global>
 
+###INCLUDE_SYSTEM_TUNABLES_HOME_D_WITH_VENDORED_APPARMOR###
+
 ###VAR###
 
 ###PROFILEATTACH### (attach_disconnected,mediate_deleted) {
@@ -935,6 +938,8 @@ var updateNSTemplate = `
 # vim:syntax=apparmor
 
 #include <tunables/global>
+
+###INCLUDE_SYSTEM_TUNABLES_HOME_D_WITH_VENDORED_APPARMOR###
 
 profile snap-update-ns.###SNAP_INSTANCE_NAME### (attach_disconnected) {
   # The next four rules mirror those above. We want to be able to read

--- a/tests/main/snapd-homedirs-vendored/task.yaml
+++ b/tests/main/snapd-homedirs-vendored/task.yaml
@@ -1,7 +1,7 @@
 summary: Test that vendored apparmor does not break any system tunables
 
 # specific for now because of some hardcoded apt versions
-systems: [ubuntu-20.04-64]
+systems: [ubuntu-*]
 
 environment:
     USERNAME: home-sweet-home
@@ -34,8 +34,11 @@ debug: |
     done
 
 execute: |
-    echo "Downgrading the snapd deb to pre-vendored apparmor times"
-    apt install -yqq --allow-downgrades snapd=2.58+20.04.1
+    if ! os.query is-core; then
+        echo "Downgrading the snapd deb to pre-vendored apparmor times"
+        TARGET_VER="$(apt list -a snapd|grep -- -updates|cut -f2 -d' ')"
+        apt install -yqq --allow-downgrades snapd="$TARGET_VER"
+    fi
     echo "But installing the vendored apparmor snapd with our changes"
     snap install --dangerous snapd_modified.snap
 

--- a/tests/main/snapd-homedirs-vendored/task.yaml
+++ b/tests/main/snapd-homedirs-vendored/task.yaml
@@ -1,7 +1,7 @@
 summary: Test that vendored apparmor does not break any system tunables
 
-# specific for now because of some hardcoded apt versions
-systems: [ubuntu-*]
+# On ubuntu 18 and below snapd-internal is not available
+systems: [ubuntu-18*, ubuntu-2*]
 
 environment:
     USERNAME: home-sweet-home
@@ -34,11 +34,10 @@ debug: |
     done
 
 execute: |
-    if ! os.query is-core; then
-        echo "Downgrading the snapd deb to pre-vendored apparmor times"
-        TARGET_VER="$(apt list -a snapd|grep -- -updates|cut -f2 -d' ')"
-        apt install -yqq --allow-downgrades snapd="$TARGET_VER"
-    fi
+    echo "Downgrading the snapd deb to pre-vendored apparmor times"
+    TARGET_VER="$(apt list -a snapd|grep -- -updates|cut -f2 -d' ')"
+    apt install -yqq --allow-downgrades snapd="$TARGET_VER"
+    
     echo "But installing the vendored apparmor snapd with our changes"
     snap install --dangerous snapd_modified.snap
 

--- a/tests/main/snapd-homedirs-vendored/task.yaml
+++ b/tests/main/snapd-homedirs-vendored/task.yaml
@@ -1,0 +1,68 @@
+summary: Test that vendored apparmor does not break any system tunables
+
+# specific for now because of some hardcoded apt versions
+systems: [ubuntu-20.04-64]
+
+environment:
+    USERNAME: home-sweet-home
+
+prepare: |
+    # Create a new user in a non-standard location
+    mkdir -p /remote/users
+    useradd -b /remote/users -m -U "$USERNAME"
+
+    # Download current snapd edge
+    snap download --edge snapd --basename=snapd_edge
+
+    # Repack it with currently built snapd
+    unpackdir=/tmp/snapd-current-snap
+    unsquashfs -no-progress -d "${unpackdir}" snapd_edge.snap
+    dpkg-deb -x "${GOHOME}"/snapd_*.deb "${unpackdir}"
+    snap pack "${unpackdir}" --filename snapd_modified.snap
+    rm -rf "${unpackdir}"
+
+restore: |
+    userdel -f --remove "$USERNAME"
+    rm -rf /remote/users
+
+debug: |
+    # output custom snap-confine snippets
+    ls -l /var/lib/snapd/apparmor/snap-confine/
+    for f in /var/lib/snapd/apparmor/snap-confine/*; do
+        echo "$f"
+        cat "$f"
+    done
+
+execute: |
+    echo "Downgrading the snapd deb to pre-vendored apparmor times"
+    apt install -yqq --allow-downgrades snapd=2.58+20.04.1
+    echo "But installing the vendored apparmor snapd with our changes"
+    snap install --dangerous snapd_modified.snap
+
+    # Verify supported features
+    snap debug sandbox-features --required apparmor:parser:snapd-internal
+    snap debug sandbox-features --required apparmor:parser:include-if-exists
+    
+    # Install our test snap
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
+
+    echo "Invoke the test app without setting up homedir support"
+    if sudo -u "$USERNAME" -i test-snapd-sh.cmd echo "Hello world" 2> stderr.log; then
+        echo "The command succeeded; this is unexpected where AppArmor is fully working"
+        test "$(snap debug confinement)" = partial
+    else
+        MATCH "Sorry, home directories outside of /home needs configuration" < stderr.log
+    fi
+    rm -f stderr.log
+
+    echo "Enable the home directories under /remote/users"
+    snap set system homedirs=/remote/users
+
+    echo "Verify that the system-params file has been created"
+    MATCH "^homedirs=/remote/users$" < /var/lib/snapd/system-params
+
+    echo "And that the AppArmor tunable file is proper"
+    MATCH "^@{HOMEDIRS}\\+=\"/remote/users\"$" < /etc/apparmor.d/tunables/home.d/snapd
+
+    echo "Invoke the test app again (should now work)"
+    sudo -u "$USERNAME" -i test-snapd-sh.cmd echo "Hello world" | MATCH "Hello world"

--- a/tests/main/snapd-homedirs-vendored/test-snapd-sh/bin/sh
+++ b/tests/main/snapd-homedirs-vendored/test-snapd-sh/bin/sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec "$@"

--- a/tests/main/snapd-homedirs-vendored/test-snapd-sh/meta/snap.yaml
+++ b/tests/main/snapd-homedirs-vendored/test-snapd-sh/meta/snap.yaml
@@ -1,0 +1,7 @@
+name: test-snapd-sh
+summary: A no-strings-attached, no-fuss shell for writing tests
+version: 1.0
+
+apps:
+    cmd:
+        command: bin/sh


### PR DESCRIPTION
The release of snapd 2.60.2 surfaced a bug in the new vendored apparmor integration code. For users with customized /home dirs there is a regression that prevents snaps from working. This is reported in https://forum.snapcraft.io/t/upgrade-snapd-from-2-59-5-to-2-60-2-gives-apparmor-denied-on-app-launch-for-every-app/36492 and also in various LP bugreports.

The issue is that the vendored apparmor does not seem to use the system /etc because of the "--base" keyword we use in the apparmor_parser code. This branch fixes this by ensuring that at least /etc/apparmor.d/tunabables/home.d is included.

More work is needed to include the other tunables, I suspect the easiest fix for this is to add a new option to apparmor_parser to have a commandline option for a tunables search path but this requires more work and short term this branch should help the affected users.
