### PR TITLE
tests: validate the snaps with homedirs work well after refresh snapd to stable

### DIFF
--- a/tests/regression/lp-2032679/task.yaml
+++ b/tests/regression/lp-2032679/task.yaml
@@ -1,0 +1,34 @@
+summary: Refresh snap from 2.59 to stable having homedirs set
+
+systems: [ ubuntu-18*, ubuntu-2* ]
+
+prepare: |
+    apt remove -y snapd --purge
+    apt install -y snapd
+
+    mkdir -p /home/mydir/
+    useradd -m -d /home/mydir/mytest mytest
+    usermod -aG sudo mytest
+
+    tests.session -u mytest prepare
+
+restore: |
+    tests.session -u mytest restore
+    userdel mytest
+    rm -rf /home/mydir
+
+    # Restore the original snapd
+    apt remove -y snapd --purge
+    #shellcheck source=tests/lib/pkgdb.sh
+    . "$TESTSLIB/pkgdb.sh"
+    distro_install_build_snapd
+
+execute: |
+    snap install snapd --revision 19122
+    snap set system homedirs=/home/mydir/
+
+    snap install kubectl --classic
+    tests.session -u mytest exec sh -c "kubectl version" 2>&1 | NOMATCH "Permission denied"
+
+    snap refresh snapd --stable
+    tests.session -u mytest exec sh -c "kubectl version" 2>&1 | NOMATCH "Permission denied"

--- a/tests/regression/lp-2032679/task.yaml
+++ b/tests/regression/lp-2032679/task.yaml
@@ -3,6 +3,10 @@ summary: Refresh snap from 2.59 to stable having homedirs set
 systems: [ ubuntu-18*, ubuntu-2* ]
 
 prepare: |
+    if not os.query is-amd64; then
+        exit 0
+    fi
+
     apt remove -y snapd --purge
     apt install -y snapd
 
@@ -13,6 +17,10 @@ prepare: |
     tests.session -u mytest prepare
 
 restore: |
+    if not os.query is-amd64; then
+        exit 0
+    fi
+
     tests.session -u mytest restore
     userdel mytest
     rm -rf /home/mydir
@@ -24,11 +32,19 @@ restore: |
     distro_install_build_snapd
 
 execute: |
+    if not os.query is-amd64; then
+        exit 0
+    fi
+
     snap install snapd --revision 19122
     snap set system homedirs=/home/mydir/
 
     snap install kubectl --classic
     tests.session -u mytest exec sh -c "kubectl version" 2>&1 | NOMATCH "Permission denied"
+
+    # 2.60.2 regression
+    snap refresh snapd --revision 19993
+    tests.session -u mytest exec sh -c "kubectl version" 2>&1 | MATCH "Permission denied"
 
     snap refresh snapd --stable
     tests.session -u mytest exec sh -c "kubectl version" 2>&1 | NOMATCH "Permission denied"

--- a/tests/regression/lp-2032679/task.yaml
+++ b/tests/regression/lp-2032679/task.yaml
@@ -3,7 +3,7 @@ summary: Refresh snap from 2.59 to stable having homedirs set
 systems: [ ubuntu-18*, ubuntu-2* ]
 
 prepare: |
-    if not os.query is-amd64; then
+    if not os.query is-pc-amd64; then
         exit 0
     fi
 
@@ -17,7 +17,7 @@ prepare: |
     tests.session -u mytest prepare
 
 restore: |
-    if not os.query is-amd64; then
+    if not os.query is-pc-amd64; then
         exit 0
     fi
 
@@ -32,7 +32,7 @@ restore: |
     distro_install_build_snapd
 
 execute: |
-    if not os.query is-amd64; then
+    if not os.query is-pc-amd64; then
         exit 0
     fi
 


### PR DESCRIPTION
This test is used to reproduce the error described in https://bugs.launchpad.net/snapd/+bug/2032679
