### PR TITLE
gadget,osutil: add support for fat16 partitions

### DIFF
--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -350,6 +350,15 @@ func isFatFilesystem(filesystem string) bool {
 	return strutil.ListContains([]string{"vfat", "fat16"}, filesystem)
 }
 
+// MatchesLinuxFilesystem checks if the filesystem specified in the
+// gadget matches the filesystem as specified in Linux.
+func (vs *VolumeStructure) MatchesLinuxFilesystem(linuxFsystem string) bool {
+	if isFatFilesystem(vs.Filesystem) && linuxFsystem == "vfat" {
+		return true
+	}
+	return vs.Filesystem == linuxFsystem
+}
+
 // HasLabel checks if label matches the VolumeStructure label. It ignores
 // capitals if the structure has a fat filesystem.
 func (vs *VolumeStructure) HasLabel(label string) bool {

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -359,6 +359,17 @@ func (vs *VolumeStructure) MatchesLinuxFilesystem(linuxFsystem string) bool {
 	return vs.Filesystem == linuxFsystem
 }
 
+// GadgetToLinuxFilesystem returns the linux filesystem that corresponds to the
+// one specified in the gadget.
+func (vs *VolumeStructure) GadgetToLinuxFilesystem() string {
+	switch vs.Filesystem {
+	case "vfat-16", "vfat-32":
+		return "vfat"
+	default:
+		return vs.Filesystem
+	}
+}
+
 // HasLabel checks if label matches the VolumeStructure label. It ignores
 // capitals if the structure has a fat filesystem.
 func (vs *VolumeStructure) HasLabel(label string) bool {

--- a/gadget/gadget.go
+++ b/gadget/gadget.go
@@ -293,8 +293,8 @@ type VolumeStructure struct {
 	// ID is the GPT partition ID, this should always be made upper case for
 	// comparison purposes.
 	ID string `yaml:"id" json:"id"`
-	// Filesystem used for the partition, 'fat16', 'vfat', 'ext4' or 'none' for
-	// structures of type 'bare'
+	// Filesystem used for the partition, 'vfat', 'vfat-{16,32}', 'ext4' or 'none' for
+	// structures of type 'bare'. 'vfat' is a synonymous for 'vfat-32'.
 	Filesystem string `yaml:"filesystem" json:"filesystem"`
 	// Content of the structure
 	Content []VolumeContent `yaml:"content" json:"content"`
@@ -347,7 +347,7 @@ func (vs *VolumeStructure) IsPartition() bool {
 }
 
 func isFatFilesystem(filesystem string) bool {
-	return strutil.ListContains([]string{"vfat", "fat16"}, filesystem)
+	return strutil.ListContains([]string{"vfat", "vfat-16", "vfat-32"}, filesystem)
 }
 
 // MatchesLinuxFilesystem checks if the filesystem specified in the
@@ -1397,7 +1397,7 @@ func validateVolumeStructure(vs *VolumeStructure, vol *Volume) error {
 		}
 		return fmt.Errorf("invalid %s: %v", what, err)
 	}
-	if vs.Filesystem != "" && !strutil.ListContains([]string{"ext4", "vfat", "fat16", "none"}, vs.Filesystem) {
+	if vs.Filesystem != "" && !strutil.ListContains([]string{"ext4", "vfat", "vfat-16", "vfat-32", "none"}, vs.Filesystem) {
 		return fmt.Errorf("invalid filesystem %q", vs.Filesystem)
 	}
 

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -5199,3 +5199,19 @@ func (s *gadgetYamlTestSuite) TestLayoutCompatibilityVfatPartitions(c *C) {
 	_, err = gadget.EnsureVolumeCompatibility(gadgetVolumeWithExtras, &deviceLayout, opts)
 	c.Assert(err, IsNil)
 }
+
+func (s *gadgetYamlTestSuite) TestGadgetToLinuxFilesystem(c *C) {
+
+	for i, tc := range []struct {
+		vs    *gadget.VolumeStructure
+		linFs string
+	}{
+		{&gadget.VolumeStructure{Filesystem: "ext4"}, "ext4"},
+		{&gadget.VolumeStructure{Filesystem: "vfat"}, "vfat"},
+		{&gadget.VolumeStructure{Filesystem: "vfat-16"}, "vfat"},
+		{&gadget.VolumeStructure{Filesystem: "vfat-32"}, "vfat"},
+	} {
+		c.Logf("case %d: %s", i, tc.linFs)
+		c.Check(tc.vs.GadgetToLinuxFilesystem(), Equals, tc.linFs)
+	}
+}

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -260,7 +260,7 @@ volumes:
           - image: pc-core.img
       - name: ubuntu-seed
         role: system-seed
-        filesystem: vfat
+        filesystem: vfat-32
         # UEFI will boot the ESP partition by default first
         type: EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B
         size: 1200M
@@ -1368,7 +1368,8 @@ func (s *gadgetYamlTestSuite) TestValidateFilesystem(c *C) {
 		err string
 	}{
 		{"vfat", ""},
-		{"fat16", ""},
+		{"vfat-16", ""},
+		{"vfat-32", ""},
 		{"ext4", ""},
 		{"none", ""},
 		{"btrfs", `invalid filesystem "btrfs"`},
@@ -1556,8 +1557,9 @@ volumes:
 		err              string
 	}{
 		{"foo", "FOO", "vfat", "vfat", `invalid volume "minimal": filesystem label "FOO" is not unique`},
-		{"foo", "FOO", "vfat", "fat16", `invalid volume "minimal": filesystem label "FOO" is not unique`},
-		{"foo", "FOO", "fat16", "fat16", `invalid volume "minimal": filesystem label "FOO" is not unique`},
+		{"foo", "FOO", "vfat", "vfat-16", `invalid volume "minimal": filesystem label "FOO" is not unique`},
+		{"foo", "FOO", "vfat-16", "vfat-16", `invalid volume "minimal": filesystem label "FOO" is not unique`},
+		{"foo", "FOO", "vfat-16", "vfat-32", `invalid volume "minimal": filesystem label "FOO" is not unique`},
 		{"foo", "FOO", "ext4", "ext4", ""},
 		{"foo", "FOO", "vfat", "ext4", `invalid volume "minimal": filesystem label "FOO" is not unique`},
 		{"FOO", "foo", "vfat", "ext4", `invalid volume "minimal": filesystem label "foo" is not unique`},
@@ -5170,7 +5172,7 @@ func (s *gadgetYamlTestSuite) TestLayoutCompatibilityVfatPartitions(c *C) {
       - name: Writable
         role: system-data
         filesystem-label: writable
-        filesystem: fat16
+        filesystem: vfat-16
         type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
         size: 64M
 `

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -1368,6 +1368,7 @@ func (s *gadgetYamlTestSuite) TestValidateFilesystem(c *C) {
 		err string
 	}{
 		{"vfat", ""},
+		{"fat16", ""},
 		{"ext4", ""},
 		{"none", ""},
 		{"btrfs", `invalid filesystem "btrfs"`},
@@ -1555,6 +1556,8 @@ volumes:
 		err              string
 	}{
 		{"foo", "FOO", "vfat", "vfat", `invalid volume "minimal": filesystem label "FOO" is not unique`},
+		{"foo", "FOO", "vfat", "fat16", `invalid volume "minimal": filesystem label "FOO" is not unique`},
+		{"foo", "FOO", "fat16", "fat16", `invalid volume "minimal": filesystem label "FOO" is not unique`},
 		{"foo", "FOO", "ext4", "ext4", ""},
 		{"foo", "FOO", "vfat", "ext4", `invalid volume "minimal": filesystem label "FOO" is not unique`},
 		{"FOO", "foo", "vfat", "ext4", `invalid volume "minimal": filesystem label "foo" is not unique`},

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -5212,6 +5212,6 @@ func (s *gadgetYamlTestSuite) TestGadgetToLinuxFilesystem(c *C) {
 		{&gadget.VolumeStructure{Filesystem: "vfat-32"}, "vfat"},
 	} {
 		c.Logf("case %d: %s", i, tc.linFs)
-		c.Check(tc.vs.GadgetToLinuxFilesystem(), Equals, tc.linFs)
+		c.Check(tc.vs.LinuxFilesystem(), Equals, tc.linFs)
 	}
 }

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -396,7 +396,7 @@ func Run(model gadget.Model, gadgetRoot, kernelRoot, bootDevice string, options 
 		if options.Mount && vs.Label != "" && vs.HasFilesystem() {
 			// fs is taken from gadget, as on disk one might be displayed as
 			// crypto_LUKS, which is not useful for formatting.
-			if err := mountFilesystem(fsDevice, vs.Filesystem, getMntPointForPart(vs)); err != nil {
+			if err := mountFilesystem(fsDevice, vs.GadgetToLinuxFilesystem(), getMntPointForPart(vs)); err != nil {
 				return nil, err
 			}
 		}
@@ -588,7 +588,7 @@ func MountVolumes(onVolumes map[string]*gadget.Volume, encSetupData *EncryptionS
 			// Device might have been encrypted
 			device := deviceForMaybeEncryptedVolume(&part, encSetupData)
 
-			if err := mountFilesystem(device, part.Filesystem, mntPt); err != nil {
+			if err := mountFilesystem(device, part.GadgetToLinuxFilesystem(), mntPt); err != nil {
 				defer unmount()
 				return "", nil, fmt.Errorf("cannot mount %q at %q: %v", device, mntPt, err)
 			}
@@ -784,7 +784,7 @@ func FactoryReset(model gadget.Model, gadgetRoot, kernelRoot, bootDevice string,
 		if options.Mount && vs.Label != "" && vs.HasFilesystem() {
 			// fs is taken from gadget, as on disk one might be displayed as
 			// crypto_LUKS, which is not useful for formatting.
-			if err := mountFilesystem(fsDevice, vs.Filesystem, getMntPointForPart(vs)); err != nil {
+			if err := mountFilesystem(fsDevice, vs.GadgetToLinuxFilesystem(), getMntPointForPart(vs)); err != nil {
 				return nil, err
 			}
 		}

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -396,7 +396,7 @@ func Run(model gadget.Model, gadgetRoot, kernelRoot, bootDevice string, options 
 		if options.Mount && vs.Label != "" && vs.HasFilesystem() {
 			// fs is taken from gadget, as on disk one might be displayed as
 			// crypto_LUKS, which is not useful for formatting.
-			if err := mountFilesystem(fsDevice, vs.GadgetToLinuxFilesystem(), getMntPointForPart(vs)); err != nil {
+			if err := mountFilesystem(fsDevice, vs.LinuxFilesystem(), getMntPointForPart(vs)); err != nil {
 				return nil, err
 			}
 		}
@@ -588,7 +588,7 @@ func MountVolumes(onVolumes map[string]*gadget.Volume, encSetupData *EncryptionS
 			// Device might have been encrypted
 			device := deviceForMaybeEncryptedVolume(&part, encSetupData)
 
-			if err := mountFilesystem(device, part.GadgetToLinuxFilesystem(), mntPt); err != nil {
+			if err := mountFilesystem(device, part.LinuxFilesystem(), mntPt); err != nil {
 				defer unmount()
 				return "", nil, fmt.Errorf("cannot mount %q at %q: %v", device, mntPt, err)
 			}
@@ -784,7 +784,7 @@ func FactoryReset(model gadget.Model, gadgetRoot, kernelRoot, bootDevice string,
 		if options.Mount && vs.Label != "" && vs.HasFilesystem() {
 			// fs is taken from gadget, as on disk one might be displayed as
 			// crypto_LUKS, which is not useful for formatting.
-			if err := mountFilesystem(fsDevice, vs.GadgetToLinuxFilesystem(), getMntPointForPart(vs)); err != nil {
+			if err := mountFilesystem(fsDevice, vs.LinuxFilesystem(), getMntPointForPart(vs)); err != nil {
 				return nil, err
 			}
 		}

--- a/gadget/install/partition.go
+++ b/gadget/install/partition.go
@@ -226,7 +226,7 @@ func buildPartitionList(dl *gadget.OnDiskVolume, vol *gadget.Volume, opts *Creat
 			Name:             vs.Name,
 			PartitionFSLabel: vs.Label,
 			Type:             vs.Type,
-			PartitionFSType:  vs.Filesystem,
+			PartitionFSType:  vs.GadgetToLinuxFilesystem(),
 			StartOffset:      offset,
 			Node:             node,
 			DiskIndex:        pIndex,

--- a/gadget/install/partition.go
+++ b/gadget/install/partition.go
@@ -226,7 +226,7 @@ func buildPartitionList(dl *gadget.OnDiskVolume, vol *gadget.Volume, opts *Creat
 			Name:             vs.Name,
 			PartitionFSLabel: vs.Label,
 			Type:             vs.Type,
-			PartitionFSType:  vs.GadgetToLinuxFilesystem(),
+			PartitionFSType:  vs.LinuxFilesystem(),
 			StartOffset:      offset,
 			Node:             node,
 			DiskIndex:        pIndex,

--- a/gadget/layout.go
+++ b/gadget/layout.go
@@ -121,7 +121,7 @@ func (l LaidOutStructure) Label() string {
 
 // Filesystem for formatting the structure.
 func (l LaidOutStructure) Filesystem() string {
-	return l.VolumeStructure.GadgetToLinuxFilesystem()
+	return l.VolumeStructure.LinuxFilesystem()
 }
 
 // Role for the structure as specified in the gadget.

--- a/gadget/layout.go
+++ b/gadget/layout.go
@@ -121,7 +121,7 @@ func (l LaidOutStructure) Label() string {
 
 // Filesystem for formatting the structure.
 func (l LaidOutStructure) Filesystem() string {
-	return l.VolumeStructure.Filesystem
+	return l.VolumeStructure.GadgetToLinuxFilesystem()
 }
 
 // Role for the structure as specified in the gadget.

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -426,7 +426,7 @@ func EnsureVolumeCompatibility(gadgetVolume *Volume, diskVolume *OnDiskVolume, o
 			// not touch it, unless a gadget asset update says to update that
 			// image file with a new binary image file. This also covers the
 			// partial filesystem case.
-			if gs.Filesystem != "" && gs.Filesystem != ds.PartitionFSType {
+			if gs.Filesystem != "" && !gs.MatchesLinuxFilesystem(ds.PartitionFSType) {
 				// use more specific error message for structures that are
 				// not creatable at install when we are not being strict
 				if !IsCreatableAtInstall(gs) && !opts.AssumeCreatablePartitionsCreated {

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -426,7 +426,7 @@ func EnsureVolumeCompatibility(gadgetVolume *Volume, diskVolume *OnDiskVolume, o
 			// not touch it, unless a gadget asset update says to update that
 			// image file with a new binary image file. This also covers the
 			// partial filesystem case.
-			if gs.Filesystem != "" && !gs.MatchesLinuxFilesystem(ds.PartitionFSType) {
+			if gs.Filesystem != "" && gs.LinuxFilesystem() != ds.PartitionFSType {
 				// use more specific error message for structures that are
 				// not creatable at install when we are not being strict
 				if !IsCreatableAtInstall(gs) && !opts.AssumeCreatablePartitionsCreated {

--- a/osutil/mkfs/mkfs.go
+++ b/osutil/mkfs/mkfs.go
@@ -38,8 +38,9 @@ type MakeFunc func(imgFile, label, contentsRootDir string, deviceSize, sectorSiz
 
 var (
 	mkfsHandlers = map[string]MakeFunc{
-		"vfat": mkfsVfat,
-		"ext4": mkfsExt4,
+		"fat16": mkfsVfat16,
+		"vfat":  mkfsVfat32,
+		"ext4":  mkfsExt4,
 	}
 )
 
@@ -132,10 +133,18 @@ func mkfsExt4(img, label, contentsRootDir string, deviceSize, sectorSize quantit
 	return nil
 }
 
+func mkfsVfat16(img, label, contentsRootDir string, deviceSize, sectorSize quantity.Size) error {
+	return mkfsVfat(img, label, contentsRootDir, deviceSize, sectorSize, "16")
+}
+
+func mkfsVfat32(img, label, contentsRootDir string, deviceSize, sectorSize quantity.Size) error {
+	return mkfsVfat(img, label, contentsRootDir, deviceSize, sectorSize, "32")
+}
+
 // mkfsVfat creates a VFAT filesystem in given image file, with an optional
 // filesystem label, and populates it with the contents of provided root
 // directory.
-func mkfsVfat(img, label, contentsRootDir string, deviceSize, sectorSize quantity.Size) error {
+func mkfsVfat(img, label, contentsRootDir string, deviceSize, sectorSize quantity.Size, fatBits string) error {
 	// 512B logical sector size by default, unless the specified sector size is
 	// larger than 512, in which case use the sector size
 	// mkfs.vfat will automatically increase the block size to the internal
@@ -154,7 +163,7 @@ func mkfsVfat(img, label, contentsRootDir string, deviceSize, sectorSize quantit
 		// 1 sector per cluster
 		"-s", "1",
 		// 32b FAT size
-		"-F", "32",
+		"-F", fatBits,
 	}
 	if label != "" {
 		mkfsArgs = append(mkfsArgs, "-n", label)

--- a/osutil/mkfs/mkfs.go
+++ b/osutil/mkfs/mkfs.go
@@ -38,9 +38,10 @@ type MakeFunc func(imgFile, label, contentsRootDir string, deviceSize, sectorSiz
 
 var (
 	mkfsHandlers = map[string]MakeFunc{
-		"fat16": mkfsVfat16,
-		"vfat":  mkfsVfat32,
-		"ext4":  mkfsExt4,
+		"vfat-16": mkfsVfat16,
+		"vfat":    mkfsVfat32,
+		"vfat-32": mkfsVfat32,
+		"ext4":    mkfsExt4,
 	}
 )
 

--- a/osutil/mkfs/mkfs_test.go
+++ b/osutil/mkfs/mkfs_test.go
@@ -179,11 +179,12 @@ func (m *mkfsSuite) TestMkfsExt4Error(c *C) {
 }
 
 func (m *mkfsSuite) TestMkfsFat16HappySimple(c *C) {
-	m.testMkfsVfatHappySimple(c, "fat16", "16")
+	m.testMkfsVfatHappySimple(c, "vfat-16", "16")
 }
 
 func (m *mkfsSuite) TestMkfsFat32HappySimple(c *C) {
 	m.testMkfsVfatHappySimple(c, "vfat", "32")
+	m.testMkfsVfatHappySimple(c, "vfat-32", "32")
 }
 
 func (m *mkfsSuite) testMkfsVfatHappySimple(c *C, fatType, fatBits string) {

--- a/osutil/mkfs/mkfs_test.go
+++ b/osutil/mkfs/mkfs_test.go
@@ -178,21 +178,29 @@ func (m *mkfsSuite) TestMkfsExt4Error(c *C) {
 	c.Assert(err, ErrorMatches, "command failed")
 }
 
-func (m *mkfsSuite) TestMkfsVfatHappySimple(c *C) {
+func (m *mkfsSuite) TestMkfsFat16HappySimple(c *C) {
+	m.testMkfsVfatHappySimple(c, "fat16", "16")
+}
+
+func (m *mkfsSuite) TestMkfsFat32HappySimple(c *C) {
+	m.testMkfsVfatHappySimple(c, "vfat", "32")
+}
+
+func (m *mkfsSuite) testMkfsVfatHappySimple(c *C, fatType, fatBits string) {
 	// no contents, should not fail
 	d := c.MkDir()
 
 	cmd := testutil.MockCommand(c, "mkfs.vfat", "")
 	defer cmd.Restore()
 
-	err := mkfs.MakeWithContent("vfat", "foo.img", "my-label", d, 0, 0)
+	err := mkfs.MakeWithContent(fatType, "foo.img", "my-label", d, 0, 0)
 	c.Assert(err, IsNil)
 	c.Check(cmd.Calls(), DeepEquals, [][]string{
 		{
 			"mkfs.vfat",
 			"-S", "512",
 			"-s", "1",
-			"-F", "32",
+			"-F", fatBits,
 			"-n", "my-label",
 			"foo.img",
 		},
@@ -201,14 +209,14 @@ func (m *mkfsSuite) TestMkfsVfatHappySimple(c *C) {
 	cmd.ForgetCalls()
 
 	// empty label
-	err = mkfs.MakeWithContent("vfat", "foo.img", "", d, 0, 0)
+	err = mkfs.MakeWithContent(fatType, "foo.img", "", d, 0, 0)
 	c.Assert(err, IsNil)
 	c.Check(cmd.Calls(), DeepEquals, [][]string{
 		{
 			"mkfs.vfat",
 			"-S", "512",
 			"-s", "1",
-			"-F", "32",
+			"-F", fatBits,
 			"foo.img",
 		},
 	})
@@ -216,14 +224,14 @@ func (m *mkfsSuite) TestMkfsVfatHappySimple(c *C) {
 	cmd.ForgetCalls()
 
 	// no content
-	err = mkfs.Make("vfat", "foo.img", "my-label", 0, 0)
+	err = mkfs.Make(fatType, "foo.img", "my-label", 0, 0)
 	c.Assert(err, IsNil)
 	c.Check(cmd.Calls(), DeepEquals, [][]string{
 		{
 			"mkfs.vfat",
 			"-S", "512",
 			"-s", "1",
-			"-F", "32",
+			"-F", fatBits,
 			"-n", "my-label",
 			"foo.img",
 		},


### PR DESCRIPTION
Add support to FAT16 by adding it as a valid filesystem in the gadget.yaml `filesystem` label. An alternative would be a fat specific field `fat-bits`, as in the end both FAT16 and FAT32 are seen as vfat type by Linux.

This change will require a recompilation of `ubuntu-image` and also new `snap-bootstrap` in pc-kernel for all pieces to work.