### PR TITLE
release: 2.60.3 (#13124)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# New in snapd 2.60.3:
+* Fix bug in the "private" plug attribute of the shared-memory
+  interface that can result in a crash when upgrading from an
+  old version of snapd.
+* Fix missing integration of the /etc/apparmor.d/tunables/home.d/
+  apparmor to support non-standard home directories
+
 # New in snapd 2.60.2:
 * Performance improvements for apparmor_parser to compensate for
   the slower `-O expr-simplify` default used. This should bring

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -11,7 +11,7 @@ pkgdesc="Service and tools for management of snap packages."
 depends=('squashfs-tools' 'libseccomp' 'libsystemd' 'apparmor')
 optdepends=('bash-completion: bash completion support'
             'xdg-desktop-portal: desktop integration')
-pkgver=2.60.2
+pkgver=2.60.3
 pkgrel=1
 arch=('x86_64' 'i686' 'armv7h' 'aarch64')
 url="https://github.com/snapcore/snapd"

--- a/packaging/debian-sid/changelog
+++ b/packaging/debian-sid/changelog
@@ -1,3 +1,12 @@
+snapd (2.60.3-1) unstable; urgency=medium
+
+  * New upstream release, LP: #2024007
+    - i/b/shared-memory: handle "private" plug attribute in shared-
+      memory interface correctly
+    - i/apparmor: support for home.d tunables from /etc/
+
+ -- Michael Vogt <michael.vogt@ubuntu.com>  Fri, 25 Aug 2023 18:36:50 +0200
+
 snapd (2.60.2-1) unstable; urgency=medium
 
   * New upstream release, LP: #2024007

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -102,7 +102,7 @@
 %endif
 
 Name:           snapd
-Version:        2.60.2
+Version:        2.60.3
 Release:        0%{?dist}
 Summary:        A transactional software package manager
 License:        GPLv3
@@ -996,6 +996,12 @@ fi
 
 
 %changelog
+* Fri Aug 25 2023 Michael Vogt <michael.vogt@ubuntu.com>
+- New upstream release 2.60.3
+ - i/b/shared-memory: handle "private" plug attribute in shared-
+   memory interface correctly
+ - i/apparmor: support for home.d tunables from /etc/
+
 * Fri Aug 04 2023 Michael Vogt <michael.vogt@ubuntu.com>
 - New upstream release 2.60.2
  - i/builtin: allow directories in private /dev/shm

--- a/packaging/opensuse/snapd.changes
+++ b/packaging/opensuse/snapd.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Aug 25 16:36:50 UTC 2023 - michael.vogt@ubuntu.com
+
+- Update to upstream release 2.60.3
+
+-------------------------------------------------------------------
 Fri Aug 04 10:14:04 UTC 2023 - michael.vogt@ubuntu.com
 
 - Update to upstream release 2.60.2

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -82,7 +82,7 @@
 
 
 Name:           snapd
-Version:        2.60.2
+Version:        2.60.3
 Release:        0
 Summary:        Tools enabling systems to work with .snap files
 License:        GPL-3.0

--- a/packaging/ubuntu-14.04/changelog
+++ b/packaging/ubuntu-14.04/changelog
@@ -1,3 +1,12 @@
+snapd (2.60.3~14.04) trusty; urgency=medium
+
+  * New upstream release, LP: #2024007
+    - i/b/shared-memory: handle "private" plug attribute in shared-
+      memory interface correctly
+    - i/apparmor: support for home.d tunables from /etc/
+
+ -- Michael Vogt <michael.vogt@ubuntu.com>  Fri, 25 Aug 2023 18:36:50 +0200
+
 snapd (2.60.2~14.04) trusty; urgency=medium
 
   * New upstream release, LP: #2024007

--- a/packaging/ubuntu-16.04/changelog
+++ b/packaging/ubuntu-16.04/changelog
@@ -1,3 +1,12 @@
+snapd (2.60.3) xenial; urgency=medium
+
+  * New upstream release, LP: #2024007
+    - i/b/shared-memory: handle "private" plug attribute in shared-
+      memory interface correctly
+    - i/apparmor: support for home.d tunables from /etc/
+
+ -- Michael Vogt <michael.vogt@ubuntu.com>  Fri, 25 Aug 2023 18:36:50 +0200
+
 snapd (2.60.2) xenial; urgency=medium
 
   * New upstream release, LP: #2024007


### PR DESCRIPTION
Merge the changelog of 2.60.3 back into master. 

This needs to be merged via a merge-commit.