### PR TITLE
many: fix running unit tests on fedora

### DIFF
--- a/cmd/snap/cmd_quota_test.go
+++ b/cmd/snap/cmd_quota_test.go
@@ -260,6 +260,13 @@ func (s *quotaSuite) TestParseQuotas(c *check.C) {
 }
 
 func (s *quotaSuite) TestSetQuotaInvalidArgs(c *check.C) {
+	const json = `{
+		"type": "sync",
+		"status-code": 200,
+		"result": {}
+	}`
+	s.RedirectClientToTestServer(s.makeFakeGetQuotaGroupHandler(c, json))
+
 	for _, args := range []struct {
 		args []string
 		err  string

--- a/overlord/devicestate/firstboot20_test.go
+++ b/overlord/devicestate/firstboot20_test.go
@@ -933,6 +933,9 @@ func (s *firstBoot20Suite) TestPopulateFromSeedClassicWithModesRunModeNoKernelAn
 
 func (s *firstBoot20Suite) testPopulateFromSeedClassicWithModesRunModeNoKernelAndGadgetClassicSnap(c *C, modelGrade asserts.ModelGrade, modelUpdater func(*C, map[string]interface{}), expectedErr string) {
 	defer release.MockReleaseInfo(&release.OS{ID: "ubuntu", VersionID: "20.04"})()
+	// re-init rootdirs required after MockReleaseInfo to ensure
+	// dirs.SnapMountDir is set to /snap on e.g. fedora
+	dirs.SetRootDir(dirs.GlobalRootDir)
 	// XXX this shouldn't be needed
 	defer release.MockOnClassic(true)()
 	c.Assert(release.OnClassic, Equals, true)

--- a/overlord/install/install_test.go
+++ b/overlord/install/install_test.go
@@ -1310,7 +1310,7 @@ func (s *installSuite) TestApplyPreseededData(c *C) {
 		{"pc/1", "pc_1.snap"},
 		{"optional20-a/x1", "optional20-a_x1.snap"},
 	} {
-		c.Assert(osutil.FileExists(filepath.Join(writableDir, "/snap", seedSnap.name)), Equals, true, &dumpDirContents{c, writableDir})
+		c.Assert(osutil.FileExists(filepath.Join(writableDir, dirs.StripRootDir(dirs.SnapMountDir), seedSnap.name)), Equals, true, &dumpDirContents{c, writableDir})
 		c.Assert(osutil.FileExists(filepath.Join(writableDir, dirs.SnapBlobDir, seedSnap.blob)), Equals, true, &dumpDirContents{c, writableDir})
 	}
 

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -8804,7 +8804,7 @@ apps:
 	s.state.Unlock()
 
 	what := fmt.Sprintf("%s/%s_%s.snap", "/var/lib/snapd/snaps", "test-snap", "42")
-	unitName := systemd.EscapeUnitNamePath(filepath.Join("/snap", "test-snap", fmt.Sprintf("%s.mount", "42")))
+	unitName := systemd.EscapeUnitNamePath(dirs.StripRootDir(filepath.Join(dirs.SnapMountDir, "test-snap", fmt.Sprintf("%s.mount", "42"))))
 	mountFile := filepath.Join(dirs.SnapServicesDir, unitName)
 	mountContent := fmt.Sprintf(`
 [Unit]
@@ -8815,7 +8815,7 @@ Before=local-fs.target
 
 [Mount]
 What=%s
-Where=/snap/test-snap/42
+Where=%s/test-snap/42
 Type=squashfs
 Options=nodev,ro,x-gdu.hide,x-gvfs-hide,otheroptions
 LazyUnmount=yes
@@ -8823,7 +8823,7 @@ LazyUnmount=yes
 [Install]
 WantedBy=snapd.mounts.target
 WantedBy=multi-user.target
-`[1:], what)
+`[1:], what, dirs.SnapMountDir)
 	os.MkdirAll(dirs.SnapServicesDir, 0755)
 	err := ioutil.WriteFile(mountFile, []byte(mountContent), 0644)
 	c.Assert(err, IsNil)
@@ -8844,7 +8844,7 @@ Before=local-fs.target
 
 [Mount]
 What=%s
-Where=/snap/test-snap/42
+Where=%s/test-snap/42
 Type=squashfs
 Options=nodev,ro,x-gdu.hide,x-gvfs-hide
 LazyUnmount=yes
@@ -8852,7 +8852,7 @@ LazyUnmount=yes
 [Install]
 WantedBy=snapd.mounts.target
 WantedBy=multi-user.target
-`[1:], what)
+`[1:], what, dirs.StripRootDir(dirs.SnapMountDir))
 
 	c.Assert(mountFile, testutil.FileEquals, expectedContent)
 }
@@ -8881,7 +8881,7 @@ apps:
 	s.state.Unlock()
 
 	what := fmt.Sprintf("%s/%s_%s.snap", "/var/lib/snapd/snaps", "test-snap", "42")
-	unitName := systemd.EscapeUnitNamePath(filepath.Join("/snap", "test-snap", fmt.Sprintf("%s.mount", "42")))
+	unitName := systemd.EscapeUnitNamePath(dirs.StripRootDir(filepath.Join(dirs.SnapMountDir, "test-snap", fmt.Sprintf("%s.mount", "42"))))
 	mountFile := filepath.Join(dirs.SnapServicesDir, unitName)
 	mountContent := fmt.Sprintf(`
 [Unit]
@@ -8892,7 +8892,7 @@ Before=local-fs.target
 
 [Mount]
 What=%s
-Where=/snap/test-snap/42
+Where=%s/test-snap/42
 Type=squashfs
 Options=nodev,ro,x-gdu.hide,x-gvfs-hide
 LazyUnmount=yes
@@ -8900,7 +8900,7 @@ LazyUnmount=yes
 [Install]
 WantedBy=snapd.mounts.target
 WantedBy=multi-user.target
-`[1:], what)
+`[1:], what, dirs.StripRootDir(dirs.SnapMountDir))
 	os.MkdirAll(dirs.SnapServicesDir, 0755)
 	err := ioutil.WriteFile(mountFile, []byte(mountContent), 0644)
 	c.Assert(err, IsNil)
@@ -8936,7 +8936,7 @@ apps:
 	s.state.Unlock()
 
 	what := fmt.Sprintf("%s/%s_%s.snap", "/var/lib/snapd/snaps", "test-snap", "42")
-	unitName := systemd.EscapeUnitNamePath(filepath.Join("/snap", "test-snap", fmt.Sprintf("%s.mount", "42")))
+	unitName := systemd.EscapeUnitNamePath(dirs.StripRootDir(filepath.Join(dirs.SnapMountDir, "test-snap", fmt.Sprintf("%s.mount", "42"))))
 	mountFile := filepath.Join(dirs.SnapServicesDir, unitName)
 	if osutil.FileExists(mountFile) {
 		c.Assert(os.Remove(mountFile), IsNil)
@@ -8961,7 +8961,7 @@ Before=local-fs.target
 
 [Mount]
 What=%s
-Where=/snap/test-snap/42
+Where=%s/test-snap/42
 Type=squashfs
 Options=nodev,ro,x-gdu.hide,x-gvfs-hide
 LazyUnmount=yes
@@ -8969,7 +8969,7 @@ LazyUnmount=yes
 [Install]
 WantedBy=snapd.mounts.target
 WantedBy=multi-user.target
-`[1:], what)
+`[1:], what, dirs.StripRootDir(dirs.SnapMountDir))
 
 	c.Assert(mountFile, testutil.FileEquals, expectedContent)
 }


### PR DESCRIPTION
While looking into 2.60.3 for fedora (we are two version behind right now) I ran the unit tests on a pristine fedora 38 system and noticed that we have a bunch of failures, mostly easy enough to fix. This PR contains the "easy" ones (i.e. differenes lke that on fedora/RH/some-others /snap is there /var/lib/snapd/snaps).

What is missing is:
* a PR to include  `glibc-static.i686 glibc-devel.i686 fakeroot python3-yamlordereddictloader` as BuildRequires
* a PR that deals with -xatts/-no-xattrs during the tests. when test snaps are build during the unit tests they cannot be unpacked to to selinux xattrs that get included when running snap pack
