### PR TITLE
gadget: fix TestMatchDisksToGadgetVolumes on systems with /dev/vda2

### DIFF
--- a/gadget/install/install_test.go
+++ b/gadget/install/install_test.go
@@ -1434,7 +1434,7 @@ func (s *installSuite) TestMountVolumesLazyUnmountError(c *C) {
 	c.Check(log.String(), testutil.Contains, fmt.Sprintf("cannot lazy unmount %q: lazy unmount failed", seedMntPt))
 }
 
-func (s *installSuite) makeMockGadgetParitionDiskAsinstallerSetsThem(c *C, deviceFmt string) *gadget.Info {
+func (s *installSuite) makeMockGadgetPartitionDiskAsInstallerSetsThem(c *C, deviceFmt string) *gadget.Info {
 	gadgetRoot := filepath.Join(c.MkDir(), "gadget")
 	ginfo, _, _, restore, err := gadgettest.MockGadgetPartitionedDisk(gadgettest.SingleVolumeClassicWithModesGadgetYaml, gadgetRoot)
 	c.Assert(err, IsNil)
@@ -1454,9 +1454,9 @@ func (s *installSuite) makeMockGadgetParitionDiskAsinstallerSetsThem(c *C, devic
 
 func (s *installSuite) TestMatchDisksToGadgetVolumesNotFound(c *C) {
 	// SysfsPathForBlockDevice() is not mocked here and by using
-	// the obsolte /dev/xda%d path we can be sure no system that
+	// the obsolete /dev/xda%d path we can be sure no system that
 	// runs this test has it and can match this disk.
-	ginfo := s.makeMockGadgetParitionDiskAsinstallerSetsThem(c, "/dev/xda%d")
+	ginfo := s.makeMockGadgetPartitionDiskAsInstallerSetsThem(c, "/dev/xda%d")
 
 	volCompatOpts := &gadget.VolumeCompatibilityOptions{
 		// at this point all partitions should be created
@@ -1471,7 +1471,7 @@ func (s *installSuite) TestMatchDisksToGadgetVolumesNotFound(c *C) {
 }
 
 func (s *installSuite) TestMatchDisksToGadgetVolumesHappy(c *C) {
-	ginfo := s.makeMockGadgetParitionDiskAsinstallerSetsThem(c, "/dev/vda%d")
+	ginfo := s.makeMockGadgetPartitionDiskAsInstallerSetsThem(c, "/dev/vda%d")
 
 	volCompatOpts := &gadget.VolumeCompatibilityOptions{
 		// at this point all partitions should be created
@@ -1513,7 +1513,7 @@ func (s *installSuite) TestMatchDisksToGadgetVolumesHappy(c *C) {
 }
 
 func (s *installSuite) TestMatchDisksToGadgetVolumesIncompatibleGadget(c *C) {
-	ginfo := s.makeMockGadgetParitionDiskAsinstallerSetsThem(c, "/dev/vda%d")
+	ginfo := s.makeMockGadgetPartitionDiskAsInstallerSetsThem(c, "/dev/vda%d")
 
 	volCompatOpts := &gadget.VolumeCompatibilityOptions{
 		// at this point all partitions should be created

--- a/gadget/install/install_test.go
+++ b/gadget/install/install_test.go
@@ -1434,20 +1434,29 @@ func (s *installSuite) TestMountVolumesLazyUnmountError(c *C) {
 	c.Check(log.String(), testutil.Contains, fmt.Sprintf("cannot lazy unmount %q: lazy unmount failed", seedMntPt))
 }
 
-func (s *installSuite) TestMatchDisksToGadgetVolumes(c *C) {
+func (s *installSuite) makeMockGadgetParitionDiskAsinstallerSetsThem(c *C, deviceFmt string) *gadget.Info {
 	gadgetRoot := filepath.Join(c.MkDir(), "gadget")
 	ginfo, _, _, restore, err := gadgettest.MockGadgetPartitionedDisk(gadgettest.SingleVolumeClassicWithModesGadgetYaml, gadgetRoot)
 	c.Assert(err, IsNil)
-	defer restore()
+	s.AddCleanup(restore)
+
 	// Set devices as an installer would
 	for _, vol := range ginfo.Volumes {
 		for sIdx := range vol.Structure {
 			if vol.Structure[sIdx].Type == "mbr" {
 				continue
 			}
-			vol.Structure[sIdx].Device = fmt.Sprintf("/dev/vda%d", sIdx+1)
+			vol.Structure[sIdx].Device = fmt.Sprintf(deviceFmt, sIdx+1)
 		}
 	}
+	return ginfo
+}
+
+func (s *installSuite) TestMatchDisksToGadgetVolumesNotFound(c *C) {
+	// SysfsPathForBlockDevice() is not mocked here and by using
+	// the obsolte /dev/xda%d path we can be sure no system that
+	// runs this test has it and can match this disk.
+	ginfo := s.makeMockGadgetParitionDiskAsinstallerSetsThem(c, "/dev/xda%d")
 
 	volCompatOpts := &gadget.VolumeCompatibilityOptions{
 		// at this point all partitions should be created
@@ -1457,10 +1466,20 @@ func (s *installSuite) TestMatchDisksToGadgetVolumes(c *C) {
 	// No disk found
 	mapStructToDisk, err := install.MatchDisksToGadgetVolumes(ginfo.Volumes, volCompatOpts)
 	c.Assert(mapStructToDisk, IsNil)
-	c.Assert(err.Error(), Equals, `cannot read link "/sys/class/block/vda2": readlink /sys/class/block/vda2: no such file or directory`)
+	c.Assert(err.Error(), Equals, `cannot read link "/sys/class/block/xda2": readlink /sys/class/block/xda2: no such file or directory`)
+
+}
+
+func (s *installSuite) TestMatchDisksToGadgetVolumesHappy(c *C) {
+	ginfo := s.makeMockGadgetParitionDiskAsinstallerSetsThem(c, "/dev/vda%d")
+
+	volCompatOpts := &gadget.VolumeCompatibilityOptions{
+		// at this point all partitions should be created
+		AssumeCreatablePartitionsCreated: true,
+	}
 
 	vdaSysPath := "/sys/devices/pci0000:00/0000:00:03.0/virtio1/block/vda"
-	restore = gadget.MockSysfsPathForBlockDevice(func(device string) (string, error) {
+	restore := gadget.MockSysfsPathForBlockDevice(func(device string) (string, error) {
 		if strings.HasPrefix(device, "/dev/vda") == true {
 			return filepath.Join(vdaSysPath, filepath.Base(device)), nil
 		}
@@ -1469,7 +1488,7 @@ func (s *installSuite) TestMatchDisksToGadgetVolumes(c *C) {
 	defer restore()
 
 	// Happy case
-	mapStructToDisk, err = install.MatchDisksToGadgetVolumes(ginfo.Volumes, volCompatOpts)
+	mapStructToDisk, err := install.MatchDisksToGadgetVolumes(ginfo.Volumes, volCompatOpts)
 	c.Assert(err, IsNil)
 	expectedMap := map[string]map[int]*gadget.OnDiskStructure{
 		"pc": {
@@ -1491,10 +1510,28 @@ func (s *installSuite) TestMatchDisksToGadgetVolumes(c *C) {
 		},
 	}
 	c.Check(mapStructToDisk, DeepEquals, expectedMap)
+}
 
-	// Now use an incompatible gadget
+func (s *installSuite) TestMatchDisksToGadgetVolumesIncompatibleGadget(c *C) {
+	ginfo := s.makeMockGadgetParitionDiskAsinstallerSetsThem(c, "/dev/vda%d")
+
+	volCompatOpts := &gadget.VolumeCompatibilityOptions{
+		// at this point all partitions should be created
+		AssumeCreatablePartitionsCreated: true,
+	}
+
+	vdaSysPath := "/sys/devices/pci0000:00/0000:00:03.0/virtio1/block/vda"
+	restore := gadget.MockSysfsPathForBlockDevice(func(device string) (string, error) {
+		if strings.HasPrefix(device, "/dev/vda") == true {
+			return filepath.Join(vdaSysPath, filepath.Base(device)), nil
+		}
+		return "", fmt.Errorf("bad disk")
+	})
+	defer restore()
+
+	// Use an incompatible gadget
 	ginfo.Volumes["pc"].Structure[1].Size = quantity.SizeKiB
-	mapStructToDisk, err = install.MatchDisksToGadgetVolumes(ginfo.Volumes, volCompatOpts)
+	mapStructToDisk, err := install.MatchDisksToGadgetVolumes(ginfo.Volumes, volCompatOpts)
 	c.Assert(mapStructToDisk, IsNil)
 	c.Assert(err.Error(), Equals, `cannot find disk partition /dev/vda1 (starting at 1048576) in gadget: on disk size 1048576 (1 MiB) is larger than gadget size 1024 (1 KiB) (and the role should not be expanded)`)
 }


### PR DESCRIPTION
The `TestMatchDisksToGadgetVolumes` is using insufficient mocking and therefor the test will fail on any system that has a /dev/vda2 device (like our ppc64el sbuild environment).

This commit fixes this by splitting the test into three tests that check different aspects of the `MatchDisksToGadgetVolumes()`.

With that the "not-found" base can be tested easily by ensuring that a device that is no longer supported by the kernel is used (/dev/xda which got deleted in v3.9 [0]. There is now a little bit more duplication but it seems an acceptable trade-off.

[0] https://docs.kernel.org/admin-guide/devices.html
