### PR TITLE
o/d/remodel.go: release lock when resealing

### DIFF
--- a/overlord/devicestate/remodel.go
+++ b/overlord/devicestate/remodel.go
@@ -273,7 +273,10 @@ func (rc *baseRemodelContext) updateRunModeSystem() error {
 	// booting and consider a new recovery system as as seeded
 	oldDeviceContext := rc.GroundContext()
 	newDeviceContext := &rc.groundDeviceContext
-	if err := boot.DeviceChange(oldDeviceContext, newDeviceContext); err != nil {
+	rc.st.Unlock()
+	err := boot.DeviceChange(oldDeviceContext, newDeviceContext)
+	rc.st.Lock()
+	if err != nil {
 		return fmt.Errorf("cannot switch device: %v", err)
 	}
 	if err := rc.deviceMgr.recordSeededSystem(rc.st, &seededSystem{

--- a/overlord/devicestate/remodel_test.go
+++ b/overlord/devicestate/remodel_test.go
@@ -1109,6 +1109,8 @@ func (s *uc20RemodelLogicSuite) TestReregRemodelContextUC20(c *C) {
 		}
 		// this is running as part of post finish step, so the state has
 		// already been updated
+		s.state.Lock()
+		defer s.state.Unlock()
 		serial, err = s.mgr.Serial()
 		c.Assert(err, IsNil)
 		c.Check(serial.Model(), Equals, "other-model")


### PR DESCRIPTION
Resealing can take more than a minute since it must hash a lot of files that it might need to unpack from snaps. It also needs to interact with the TPM and parse the event log, which might be slow. If we keep the lock, then snapd will not respond for a long time.

This fixes failures for `tests/nested/manual/core20-remodel`