### PR TITLE
t/n/c/connected-after-reboot-revert: expect one more reboot on UC16

### DIFF
--- a/tests/nested/core/connected-after-reboot-revert/task.yaml
+++ b/tests/nested/core/connected-after-reboot-revert/task.yaml
@@ -31,8 +31,6 @@ execute: |
   echo "Wait for the system to be seeded first"
   remote.exec "sudo snap wait system seed.loaded"
 
-  boot_id="$(tests.nested boot-id)"
-
   echo "Install kernel with failing post-refresh hook"
   remote.push pc-kernel_badhook.snap
 
@@ -51,6 +49,8 @@ execute: |
       snapd_snap=$(remote.exec find /var/lib/snapd/snaps/ -name 'snapd_*.snap')
   fi
 
+  boot_id="$(tests.nested boot-id)"
+
   chg_id=$(remote.exec "sudo snap install \
                              --dangerous --transaction=all-snaps --no-wait \
                              ./pc-kernel_badhook.snap \"$snapd_snap\"")
@@ -62,6 +62,9 @@ execute: |
   if [ "$VERSION" -eq 16 ]; then
       boot_id="$(tests.nested boot-id)"
       echo "Wait for second reboot for UC16"
+      remote.wait-for reboot "$boot_id"
+      boot_id="$(tests.nested boot-id)"
+      echo "Wait for third reboot for UC16"
       remote.wait-for reboot "$boot_id"
   fi
 


### PR DESCRIPTION
Here are the expected reboot causes:
 * Make current revision for snap "core" unavailable
 * Make snap "core" (unset) available to the system
 * Make current revision for snap "pc-kernel" unavailable
 * Make snap "pc-kernel" (unset) available to the system