### PR TITLE
t/n/m/fde-on-classic: do not check for default EFI boot loader (shim)

### DIFF
--- a/tests/nested/manual/fde-on-classic/task.yaml
+++ b/tests/nested/manual/fde-on-classic/task.yaml
@@ -136,7 +136,7 @@ execute: |
 
   echo "Refresh pc gadget and assert assets got updated"
   refresh_rebooting_snap pc-new.snap pc reboot
-  for f in /boot/grub/kernel.efi /run/mnt/ubuntu-boot/EFI/boot/bootx64.efi /run/mnt/ubuntu-boot/EFI/boot/grubx64.efi; do
+  for f in /boot/grub/kernel.efi /run/mnt/ubuntu-boot/EFI/boot/grubx64.efi; do
       remote.exec sudo grep -q -a '"This program cannot be run in XXX mode"' "$f"
   done
 


### PR DESCRIPTION
The EFI boot loader is for the ESP, not the boot partition. This was removed in pc-gadget recently.
