### PR TITLE
aspects: support constraints in string schemas

### DIFF
--- a/aspects/schema.go
+++ b/aspects/schema.go
@@ -23,6 +23,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
+
+	"github.com/snapcore/snapd/strutil"
 )
 
 type parser interface {
@@ -329,31 +332,68 @@ func (v *mapSchema) parseMapKeyType(raw json.RawMessage) (Schema, error) {
 		return schema, nil
 	}
 
-	if typ == "string" {
-		return &stringSchema{}, nil
-	}
 	// TODO: if type starts with $, check against user-defined types
+	if typ != "string" {
+		return nil, fmt.Errorf(`must be based on string but got %q`, typ)
+	}
 
-	return nil, fmt.Errorf(`must be based on string but got %q`, typ)
+	return &stringSchema{}, nil
 }
 
-type stringSchema struct{}
+type stringSchema struct {
+	// pattern is a regex pattern that the string must match.
+	pattern *regexp.Regexp
+	// choices holds the possible values the string can take, if non-empty.
+	choices []string
+}
 
-// Validate that raw is a valid aspect string.
+// Validate that raw is a valid aspect string and meets the schema's constraints.
 func (v *stringSchema) Validate(raw []byte) error {
 	var value string
 	if err := json.Unmarshal(raw, &value); err != nil {
-		var typeErr *json.UnmarshalTypeError
-		if !errors.As(err, &typeErr) {
-			return err
-		}
+		return fmt.Errorf("cannot validate string: %w", err)
+	}
 
-		return fmt.Errorf("cannot validate string: unexpected %s type", typeErr.Value)
+	if len(v.choices) != 0 && !strutil.ListContains(v.choices, value) {
+		return fmt.Errorf(`string %q is not one of the allowed choices`, value)
+	}
+
+	if v.pattern != nil && !v.pattern.Match([]byte(value)) {
+		return fmt.Errorf(`string %q doesn't match schema pattern %s`, value, v.pattern.String())
 	}
 
 	return nil
 }
 
 func (v *stringSchema) parseConstraints(constraints map[string]json.RawMessage) error {
+	if rawChoices, ok := constraints["choices"]; ok {
+		var choices []string
+		if err := json.Unmarshal(rawChoices, &choices); err != nil {
+			return fmt.Errorf(`cannot parse "choices" constraint: %w`, err)
+		}
+
+		if len(choices) == 0 {
+			return fmt.Errorf(`cannot have "choices" constraint with empty list`)
+		}
+
+		v.choices = choices
+	}
+
+	if rawPattern, ok := constraints["pattern"]; ok {
+		if v.choices != nil {
+			return fmt.Errorf(`cannot use "choices" and "pattern" constraints in same schema`)
+		}
+
+		var patt string
+		err := json.Unmarshal(rawPattern, &patt)
+		if err != nil {
+			return fmt.Errorf(`cannot parse "pattern" constraint: %w`, err)
+		}
+
+		if v.pattern, err = regexp.Compile(patt); err != nil {
+			return fmt.Errorf(`cannot parse "pattern" constraint: %w`, err)
+		}
+	}
+
 	return nil
 }

--- a/aspects/schema.go
+++ b/aspects/schema.go
@@ -222,7 +222,7 @@ func (v *mapSchema) parseConstraints(constraints map[string]json.RawMessage) err
 		return fmt.Errorf(`cannot parse map: %w`, err)
 	}
 
-	// maps can "schemas" with types for specific entries and optional "required" constraints
+	// maps can be "schemas" with types for specific entries and optional "required" constraints
 	if rawEntries, ok := constraints["schema"]; ok {
 		var entries map[string]json.RawMessage
 		if err := json.Unmarshal(rawEntries, &entries); err != nil {
@@ -373,7 +373,7 @@ func (v *stringSchema) parseConstraints(constraints map[string]json.RawMessage) 
 		}
 
 		if len(choices) == 0 {
-			return fmt.Errorf(`cannot have "choices" constraint with empty list`)
+			return fmt.Errorf(`cannot have a "choices" constraint with an empty list`)
 		}
 
 		v.choices = choices

--- a/aspects/schema_test.go
+++ b/aspects/schema_test.go
@@ -175,8 +175,58 @@ func (*schemaSuite) TestMapKeysConstraintMustBeStringBased(c *C) {
 	c.Assert(err, ErrorMatches, `cannot parse "keys" constraint: must be based on string but got "int"`)
 }
 
-// TODO: once string constraints are supported, test that keys with unmet constraints
-// fail during validation (can't test now because we can't express constraints)
+func (*schemaSuite) TestMapKeysStringBased(c *C) {
+	schemaStr := []byte(`{
+	"schema": {
+		"pattern": {
+			"keys": {
+				"type": "string",
+				"pattern": "[fb]oo"
+			}
+		}
+	}
+}`)
+
+	input := []byte(`{
+	"pattern": {
+		"foo": "a"
+	},
+	"userType": {
+		"boo": "a"
+	}
+}`)
+
+	schema, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, IsNil)
+
+	err = schema.Validate(input)
+	c.Assert(err, IsNil)
+}
+
+func (*schemaSuite) TestMapKeysFail(c *C) {
+	schemaStr := []byte(`{
+	"schema": {
+		"snaps": {
+			"keys": {
+				"type": "string",
+				"choices": ["foo"]
+			}
+		}
+	}
+}`)
+
+	input := []byte(`{
+	"snaps": {
+		"bar": "a"
+		}
+}`)
+
+	schema, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, IsNil)
+
+	err = schema.Validate(input)
+	c.Assert(err, ErrorMatches, `string "bar" is not one of the allowed choices`)
+}
 
 func (*schemaSuite) TestMapWithValuesStringConstraintHappy(c *C) {
 	schemaStr := []byte(`{
@@ -232,7 +282,7 @@ func (*schemaSuite) TestMapWithUnmetValuesConstraint(c *C) {
 	c.Assert(err, IsNil)
 
 	err = schema.Validate(input)
-	c.Assert(err, ErrorMatches, "cannot validate string: unexpected object type")
+	c.Assert(err, ErrorMatches, "cannot validate string: json: cannot unmarshal object into Go value of type string")
 }
 
 func (*schemaSuite) TestMapSchemaMetConstraintsWithMissingEntry(c *C) {
@@ -278,7 +328,7 @@ func (*schemaSuite) TestMapSchemaUnmetConstraint(c *C) {
 	c.Assert(err, IsNil)
 
 	err = schema.Validate(input)
-	c.Assert(err, ErrorMatches, `cannot validate string: unexpected object type`)
+	c.Assert(err, ErrorMatches, `cannot validate string: json: cannot unmarshal object into Go value of type string`)
 }
 
 func (*schemaSuite) TestMapSchemaWithMetRequiredConstraint(c *C) {
@@ -443,4 +493,151 @@ func (*schemaSuite) TestSchemaWithUnknownType(c *C) {
 
 	_, err := aspects.ParseSchema(schemaStr)
 	c.Assert(err, ErrorMatches, `cannot parse unknown type "blarg"`)
+}
+
+func (*schemaSuite) TestStringsWithEmptyChoices(c *C) {
+	schemaStr := []byte(`{
+	"schema": {
+		"snaps": {
+			"keys": {
+				"type": "string",
+				"choices": []
+			}
+		}
+	}
+}`)
+
+	_, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, ErrorMatches, `cannot parse "keys" constraint: cannot have "choices" constraint with empty list`)
+}
+
+func (*schemaSuite) TestStringsWithChoicesHappy(c *C) {
+	schemaStr := []byte(`{
+	"schema": {
+		"snaps": {
+			"keys": {
+				"type": "string",
+				"choices": ["foo", "bar"]
+			}
+		}
+	}
+}`)
+
+	input := []byte(`{
+	"snaps": {
+		"foo": "a",
+		"bar": "a"
+		}
+}`)
+
+	schema, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, IsNil)
+
+	err = schema.Validate(input)
+	c.Assert(err, IsNil)
+}
+
+func (*schemaSuite) TestStringsWithChoicesFail(c *C) {
+	schemaStr := []byte(`{
+	"schema": {
+		"snaps": {
+			"keys": {
+				"type": "string",
+				"choices": ["foo", "bar"]
+			}
+		}
+	}
+}`)
+
+	input := []byte(`{
+	"snaps": {
+		"foo": "a",
+		"bar": "a",
+		"baz": "a"
+		}
+}`)
+
+	schema, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, IsNil)
+
+	err = schema.Validate(input)
+	c.Assert(err, ErrorMatches, `string "baz" is not one of the allowed choices`)
+}
+
+func (*schemaSuite) TestStringChoicesAndPatternsFail(c *C) {
+	schemaStr := []byte(`{
+	"schema": {
+		"snaps": {
+			"keys": {
+				"type": "string",
+				"pattern": "foo",
+				"choices": ["foo"]
+			}
+		}
+	}
+}`)
+
+	_, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, ErrorMatches, `.*cannot use "choices" and "pattern" constraints in same schema`)
+}
+
+func (*schemaSuite) TestStringPatternNoMatch(c *C) {
+	schemaStr := []byte(`{
+	"schema": {
+		"foo": {
+			"type": "string",
+			"pattern": "[fb]00"
+		}
+	}
+}`)
+
+	input := []byte(`{
+	"foo": "F00"
+}`)
+
+	schema, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, IsNil)
+
+	err = schema.Validate(input)
+	c.Assert(err, ErrorMatches, `string "F00" doesn't match schema pattern \[fb\]00`)
+}
+
+func (*schemaSuite) TestStringPatternWrongFormat(c *C) {
+	schemaStr := []byte(`{
+	"schema": {
+		"foo": {
+			"type": "string",
+			"pattern": "[fb00"
+		}
+	}
+}`)
+
+	_, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, ErrorMatches, `cannot parse "pattern" constraint: error parsing regexp.*`)
+
+	schemaStr = []byte(`{
+	"schema": {
+		"foo": {
+			"type": "string",
+			"pattern": 1
+		}
+	}
+}`)
+
+	_, err = aspects.ParseSchema(schemaStr)
+	c.Assert(err, ErrorMatches, `cannot parse "pattern" constraint:.*`)
+}
+
+func (*schemaSuite) TestStringChoicesWrongFormat(c *C) {
+	schemaStr := []byte(`{
+	"schema": {
+		"foo": {
+			"type": "string",
+			"choices": "one-choice"
+		}
+	}
+}`)
+
+	_, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, ErrorMatches, `cannot parse "choices" constraint:.*`)
 }

--- a/aspects/schema_test.go
+++ b/aspects/schema_test.go
@@ -508,7 +508,7 @@ func (*schemaSuite) TestStringsWithEmptyChoices(c *C) {
 }`)
 
 	_, err := aspects.ParseSchema(schemaStr)
-	c.Assert(err, ErrorMatches, `cannot parse "keys" constraint: cannot have "choices" constraint with empty list`)
+	c.Assert(err, ErrorMatches, `cannot parse "keys" constraint: cannot have a "choices" constraint with an empty list`)
 }
 
 func (*schemaSuite) TestStringsWithChoicesHappy(c *C) {

--- a/aspects/schema_test.go
+++ b/aspects/schema_test.go
@@ -175,59 +175,6 @@ func (*schemaSuite) TestMapKeysConstraintMustBeStringBased(c *C) {
 	c.Assert(err, ErrorMatches, `cannot parse "keys" constraint: must be based on string but got "int"`)
 }
 
-func (*schemaSuite) TestMapKeysStringBased(c *C) {
-	schemaStr := []byte(`{
-	"schema": {
-		"pattern": {
-			"keys": {
-				"type": "string",
-				"pattern": "[fb]oo"
-			}
-		}
-	}
-}`)
-
-	input := []byte(`{
-	"pattern": {
-		"foo": "a"
-	},
-	"userType": {
-		"boo": "a"
-	}
-}`)
-
-	schema, err := aspects.ParseSchema(schemaStr)
-	c.Assert(err, IsNil)
-
-	err = schema.Validate(input)
-	c.Assert(err, IsNil)
-}
-
-func (*schemaSuite) TestMapKeysFail(c *C) {
-	schemaStr := []byte(`{
-	"schema": {
-		"snaps": {
-			"keys": {
-				"type": "string",
-				"choices": ["foo"]
-			}
-		}
-	}
-}`)
-
-	input := []byte(`{
-	"snaps": {
-		"bar": "a"
-		}
-}`)
-
-	schema, err := aspects.ParseSchema(schemaStr)
-	c.Assert(err, IsNil)
-
-	err = schema.Validate(input)
-	c.Assert(err, ErrorMatches, `string "bar" is not one of the allowed choices`)
-}
-
 func (*schemaSuite) TestMapWithValuesStringConstraintHappy(c *C) {
 	schemaStr := []byte(`{
 	"schema": {
@@ -511,6 +458,7 @@ func (*schemaSuite) TestStringsWithEmptyChoices(c *C) {
 	c.Assert(err, ErrorMatches, `cannot parse "keys" constraint: cannot have a "choices" constraint with an empty list`)
 }
 
+// NOTE: this also serves as a test for the success case of checking map keys
 func (*schemaSuite) TestStringsWithChoicesHappy(c *C) {
 	schemaStr := []byte(`{
 	"schema": {
@@ -537,6 +485,7 @@ func (*schemaSuite) TestStringsWithChoicesHappy(c *C) {
 	c.Assert(err, IsNil)
 }
 
+// NOTE: this also serves as a test for the failure case of checking map keys
 func (*schemaSuite) TestStringsWithChoicesFail(c *C) {
 	schemaStr := []byte(`{
 	"schema": {
@@ -579,6 +528,32 @@ func (*schemaSuite) TestStringChoicesAndPatternsFail(c *C) {
 
 	_, err := aspects.ParseSchema(schemaStr)
 	c.Assert(err, ErrorMatches, `.*cannot use "choices" and "pattern" constraints in same schema`)
+}
+
+func (*schemaSuite) TestStringPatternHappy(c *C) {
+	schemaStr := []byte(`{
+	"schema": {
+		"pattern": {
+			"keys": {
+				"type": "string",
+				"pattern": "[fb]oo"
+			}
+		}
+	}
+}`)
+
+	input := []byte(`{
+	"pattern": {
+		"foo": "a",
+		"boo": "a"
+	}
+}`)
+
+	schema, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, IsNil)
+
+	err = schema.Validate(input)
+	c.Assert(err, IsNil)
 }
 
 func (*schemaSuite) TestStringPatternNoMatch(c *C) {


### PR DESCRIPTION
Adds support for "pattern" and "choices" constraints in string schemas which constrain values to regular expressions or sets of alternatives, respectively.