### PR TITLE
daemon: allow snaps to get snap metadata

### DIFF
--- a/daemon/access.go
+++ b/daemon/access.go
@@ -156,11 +156,11 @@ func (ac snapAccess) CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet, us
 }
 
 var (
-	cgroupSnapNameFromPid = cgroup.SnapNameFromPid
-	requireThemeApiAccess = requireThemeApiAccessImpl
+	cgroupSnapNameFromPid     = cgroup.SnapNameFromPid
+	requireInterfaceApiAccess = requireInterfaceApiAccessImpl
 )
 
-func requireThemeApiAccessImpl(d *Daemon, ucred *ucrednet) *apiError {
+func requireInterfaceApiAccessImpl(d *Daemon, ucred *ucrednet, interfaceName string) *apiError {
 	if ucred == nil {
 		return Forbidden("access denied")
 	}
@@ -176,8 +176,7 @@ func requireThemeApiAccessImpl(d *Daemon, ucred *ucrednet) *apiError {
 		return Forbidden("access denied")
 	}
 
-	// Access on snapd-snap.socket requires a connected
-	// snap-themes-control plug.
+	// Access on snapd-snap.socket requires a connected plug.
 	snapName, err := cgroupSnapNameFromPid(int(ucred.Pid))
 	if err != nil {
 		return Forbidden("could not determine snap name for pid: %s", err)
@@ -191,7 +190,7 @@ func requireThemeApiAccessImpl(d *Daemon, ucred *ucrednet) *apiError {
 		return Forbidden("internal error: cannot get connections: %s", err)
 	}
 	for refStr, connState := range conns {
-		if !connState.Active() || connState.Interface != "snap-themes-control" {
+		if !connState.Active() || connState.Interface != interfaceName {
 			continue
 		}
 		connRef, err := interfaces.ParseConnRef(refStr)
@@ -205,28 +204,31 @@ func requireThemeApiAccessImpl(d *Daemon, ucred *ucrednet) *apiError {
 	return Forbidden("access denied")
 }
 
-// themesOpenAccess behaves like openAccess, but allows requests from
-// snapd-snap.socket for snaps that plug snap-themes-control.
-type themesOpenAccess struct{}
-
-func (ac themesOpenAccess) CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError {
-	return requireThemeApiAccess(d, ucred)
+// interfaceOpenAccess behaves like openAccess, but allows requests from
+// snapd-snap.socket for snaps that plug the provided interface.
+type interfaceOpenAccess struct {
+	Interface string
 }
 
-// themesAuthenticatedAccess behaves like authenticatedAccess, but
-// allows requests from snapd-snap.socket for snaps that plug
-// snap-themes-control.
-type themesAuthenticatedAccess struct {
-	Polkit string
+func (ac interfaceOpenAccess) CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError {
+	return requireInterfaceApiAccess(d, ucred, ac.Interface)
 }
 
-func (ac themesAuthenticatedAccess) CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError {
-	if rspe := requireThemeApiAccess(d, ucred); rspe != nil {
+// interfaceAuthenticatedAccess behaves like authenticatedAccess, but
+// allows requests from snapd-snap.socket that plug the provided
+// interface.
+type interfaceAuthenticatedAccess struct {
+	Interface string
+	Polkit    string
+}
+
+func (ac interfaceAuthenticatedAccess) CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError {
+	if rspe := requireInterfaceApiAccess(d, ucred, ac.Interface); rspe != nil {
 		return rspe
 	}
 
 	// check as well that we have admin permission to proceed with
-	// the theme operation
+	// the operation
 	if user != nil {
 		return nil
 	}

--- a/daemon/access_test.go
+++ b/daemon/access_test.go
@@ -227,7 +227,7 @@ func (s *accessSuite) TestSnapAccess(c *C) {
 	c.Check(ac.CheckAccess(nil, nil, nil, nil), DeepEquals, errForbidden)
 }
 
-func (s *accessSuite) TestRequireThemeApiAccessImpl(c *C) {
+func (s *accessSuite) TestRequireInterfaceApiAccessImpl(c *C) {
 	d := s.daemon(c)
 	s.mockSnap(c, `
 name: core
@@ -251,7 +251,7 @@ plugs:
 	})
 	defer restore()
 
-	var ac daemon.AccessChecker = daemon.ThemesOpenAccess{}
+	var ac daemon.AccessChecker = daemon.InterfaceOpenAccess{Interface: "snap-themes-control"}
 
 	// Access with no ucred data is forbidden
 	c.Check(ac.CheckAccess(d, nil, nil, nil), DeepEquals, errForbidden)
@@ -298,13 +298,13 @@ plugs:
 	c.Check(ac.CheckAccess(d, nil, ucred, nil), DeepEquals, errForbidden)
 }
 
-func (s *accessSuite) TestThemesOpenAccess(c *C) {
-	var ac daemon.AccessChecker = daemon.ThemesOpenAccess{}
+func (s *accessSuite) TestInterfaceOpenAccess(c *C) {
+	var ac daemon.AccessChecker = daemon.InterfaceOpenAccess{Interface: "snap-themes-control"}
 
 	s.daemon(c)
-	// themesOpenAccess allows access if requireThemeApiAccess() succeeds
+	// interfaceOpenAccess allows access if requireInterfaceApiAccess() succeeds
 	ucred := &daemon.Ucrednet{Uid: 42, Pid: 100, Socket: dirs.SnapSocket}
-	restore := daemon.MockRequireThemeApiAccess(func(d *daemon.Daemon, u *daemon.Ucrednet) *daemon.APIError {
+	restore := daemon.MockRequireInterfaceApiAccess(func(d *daemon.Daemon, u *daemon.Ucrednet, interfaceName string) *daemon.APIError {
 		c.Check(d, Equals, s.d)
 		c.Check(u, Equals, ucred)
 		return nil
@@ -312,15 +312,15 @@ func (s *accessSuite) TestThemesOpenAccess(c *C) {
 	defer restore()
 	c.Check(ac.CheckAccess(s.d, nil, ucred, nil), IsNil)
 
-	// Access is forbidden if requireThemeApiAccess() fails
-	restore = daemon.MockRequireThemeApiAccess(func(d *daemon.Daemon, u *daemon.Ucrednet) *daemon.APIError {
+	// Access is forbidden if requireInterfaceApiAccess() fails
+	restore = daemon.MockRequireInterfaceApiAccess(func(d *daemon.Daemon, u *daemon.Ucrednet, interfaceName string) *daemon.APIError {
 		return errForbidden
 	})
 	defer restore()
 	c.Check(ac.CheckAccess(s.d, nil, ucred, nil), DeepEquals, errForbidden)
 }
 
-func (s *accessSuite) TestThemesAuthenticatedAccess(c *C) {
+func (s *accessSuite) TestInterfaceAuthenticatedAccess(c *C) {
 	restore := daemon.MockCheckPolkitAction(func(r *http.Request, ucred *daemon.Ucrednet, action string) *daemon.APIError {
 		// Polkit is not consulted if no action is specified
 		c.Fail()
@@ -328,15 +328,15 @@ func (s *accessSuite) TestThemesAuthenticatedAccess(c *C) {
 	})
 	defer restore()
 
-	var ac daemon.AccessChecker = daemon.ThemesAuthenticatedAccess{}
+	var ac daemon.AccessChecker = daemon.InterfaceAuthenticatedAccess{}
 
 	req := httptest.NewRequest("GET", "/", nil)
 	user := &auth.UserState{}
 	s.daemon(c)
 
-	// themesAuthenticatedAccess denies access if requireThemesApiAccess fails
+	// themesAuthenticatedAccess denies access if requireInterfaceApiAccess fails
 	ucred := &daemon.Ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapSocket}
-	restore = daemon.MockRequireThemeApiAccess(func(d *daemon.Daemon, u *daemon.Ucrednet) *daemon.APIError {
+	restore = daemon.MockRequireInterfaceApiAccess(func(d *daemon.Daemon, u *daemon.Ucrednet, interfaceName string) *daemon.APIError {
 		c.Check(d, Equals, s.d)
 		c.Check(u, Equals, ucred)
 		return errForbidden
@@ -345,8 +345,8 @@ func (s *accessSuite) TestThemesAuthenticatedAccess(c *C) {
 	c.Check(ac.CheckAccess(s.d, req, ucred, nil), DeepEquals, errForbidden)
 	c.Check(ac.CheckAccess(s.d, req, ucred, user), DeepEquals, errForbidden)
 
-	// If requireThemeApiAccess succeeds, root is granted access
-	restore = daemon.MockRequireThemeApiAccess(func(d *daemon.Daemon, u *daemon.Ucrednet) *daemon.APIError {
+	// If requireInterfaceApiAccess succeeds, root is granted access
+	restore = daemon.MockRequireInterfaceApiAccess(func(d *daemon.Daemon, u *daemon.Ucrednet, interfaceName string) *daemon.APIError {
 		return nil
 	})
 	defer restore()
@@ -360,15 +360,15 @@ func (s *accessSuite) TestThemesAuthenticatedAccess(c *C) {
 	c.Check(ac.CheckAccess(s.d, req, ucred, nil), DeepEquals, errUnauthorized)
 }
 
-func (s *accessSuite) TestThemesAuthenticatedAccessPolkit(c *C) {
-	var ac daemon.AccessChecker = daemon.ThemesAuthenticatedAccess{Polkit: "action-id"}
+func (s *accessSuite) TestInterfaceAuthenticatedAccessPolkit(c *C) {
+	var ac daemon.AccessChecker = daemon.InterfaceAuthenticatedAccess{Polkit: "action-id"}
 
 	req := httptest.NewRequest("GET", "/", nil)
 	user := &auth.UserState{}
 	ucred := &daemon.Ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapSocket}
 
 	s.daemon(c)
-	restore := daemon.MockRequireThemeApiAccess(func(d *daemon.Daemon, u *daemon.Ucrednet) *daemon.APIError {
+	restore := daemon.MockRequireInterfaceApiAccess(func(d *daemon.Daemon, u *daemon.Ucrednet, interfaceName string) *daemon.APIError {
 		c.Check(d, Equals, s.d)
 		c.Check(u, Equals, ucred)
 		return nil

--- a/daemon/api_accessories.go
+++ b/daemon/api_accessories.go
@@ -30,7 +30,7 @@ var (
 		Path: "/v2/accessories/changes/{id}",
 		GET:  getAccessoriesChange,
 		// TODO: expand this to other accessories APIs as they appear
-		ReadAccess: themesOpenAccess{},
+		ReadAccess: interfaceOpenAccess{Interface: "snap-themes-control"},
 	}
 )
 

--- a/daemon/api_accessories_test.go
+++ b/daemon/api_accessories_test.go
@@ -35,7 +35,7 @@ type accessoriesSuite struct {
 }
 
 func (s *accessoriesSuite) expectThemesAccess() {
-	s.expectReadAccess(daemon.ThemesOpenAccess{})
+	s.expectReadAccess(daemon.InterfaceOpenAccess{Interface: "snap-themes-control"})
 }
 
 func (s *accessoriesSuite) TestChangeInfo(c *C) {

--- a/daemon/api_find.go
+++ b/daemon/api_find.go
@@ -40,7 +40,7 @@ var (
 	findCmd = &Command{
 		Path:       "/v2/find",
 		GET:        searchStore,
-		ReadAccess: openAccess{},
+		ReadAccess: interfaceOpenAccess{Interface: "snap-find"},
 	}
 )
 

--- a/daemon/api_find_test.go
+++ b/daemon/api_find_test.go
@@ -29,6 +29,7 @@ import (
 	"gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/client"
+	"github.com/snapcore/snapd/daemon"
 	"github.com/snapcore/snapd/httputil"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/snapstate"
@@ -40,6 +41,12 @@ var _ = check.Suite(&findSuite{})
 
 type findSuite struct {
 	apiBaseSuite
+}
+
+func (s *findSuite) SetUpTest(c *check.C) {
+	s.apiBaseSuite.SetUpTest(c)
+
+	s.expectReadAccess(daemon.InterfaceOpenAccess{Interface: "snap-find"})
 }
 
 func (s *findSuite) TestFind(c *check.C) {

--- a/daemon/api_snaps.go
+++ b/daemon/api_snaps.go
@@ -51,7 +51,7 @@ var (
 		Path:        "/v2/snaps/{name}",
 		GET:         getSnapInfo,
 		POST:        postSnap,
-		ReadAccess:  openAccess{},
+		ReadAccess:  interfaceOpenAccess{Interface: "snap-snaps"},
 		WriteAccess: authenticatedAccess{Polkit: polkitActionManage},
 	}
 
@@ -59,7 +59,7 @@ var (
 		Path:        "/v2/snaps",
 		GET:         getSnapsInfo,
 		POST:        postSnaps,
-		ReadAccess:  openAccess{},
+		ReadAccess:  interfaceOpenAccess{Interface: "snap-snaps"},
 		WriteAccess: authenticatedAccess{Polkit: polkitActionManage},
 	}
 )

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -65,6 +65,7 @@ var _ = check.Suite(&snapsSuite{})
 func (s *snapsSuite) SetUpTest(c *check.C) {
 	s.apiBaseSuite.SetUpTest(c)
 
+	s.expectReadAccess(daemon.InterfaceOpenAccess{Interface: "snap-snaps"})
 	s.expectWriteAccess(daemon.AuthenticatedAccess{Polkit: "io.snapcraft.snapd.manage"})
 }
 

--- a/daemon/api_themes.go
+++ b/daemon/api_themes.go
@@ -45,8 +45,8 @@ var (
 		Path:        "/v2/accessories/themes",
 		GET:         checkThemes,
 		POST:        installThemes,
-		ReadAccess:  themesOpenAccess{},
-		WriteAccess: themesAuthenticatedAccess{Polkit: polkitActionManage},
+		ReadAccess:  interfaceOpenAccess{Interface: "snap-themes-control"},
+		WriteAccess: interfaceAuthenticatedAccess{Interface: "snap-themes-control", Polkit: polkitActionManage},
 	}
 )
 

--- a/daemon/api_themes_test.go
+++ b/daemon/api_themes_test.go
@@ -72,8 +72,8 @@ func (s *themesSuite) daemon(c *C) *daemon.Daemon {
 }
 
 func (s *themesSuite) expectThemesAccess() {
-	s.expectReadAccess(daemon.ThemesOpenAccess{})
-	s.expectWriteAccess(daemon.ThemesAuthenticatedAccess{Polkit: "io.snapcraft.snapd.manage"})
+	s.expectReadAccess(daemon.InterfaceOpenAccess{Interface: "snap-themes-control"})
+	s.expectWriteAccess(daemon.InterfaceAuthenticatedAccess{Interface: "snap-themes-control", Polkit: "io.snapcraft.snapd.manage"})
 }
 
 func (s *themesSuite) TestInstalledThemes(c *C) {

--- a/daemon/export_access_test.go
+++ b/daemon/export_access_test.go
@@ -28,12 +28,12 @@ import (
 type (
 	AccessChecker = accessChecker
 
-	OpenAccess                = openAccess
-	AuthenticatedAccess       = authenticatedAccess
-	RootAccess                = rootAccess
-	SnapAccess                = snapAccess
-	ThemesOpenAccess          = themesOpenAccess
-	ThemesAuthenticatedAccess = themesAuthenticatedAccess
+	OpenAccess                   = openAccess
+	AuthenticatedAccess          = authenticatedAccess
+	RootAccess                   = rootAccess
+	SnapAccess                   = snapAccess
+	InterfaceOpenAccess          = interfaceOpenAccess
+	InterfaceAuthenticatedAccess = interfaceAuthenticatedAccess
 )
 
 var CheckPolkitActionImpl = checkPolkitActionImpl
@@ -62,12 +62,12 @@ func MockCgroupSnapNameFromPid(new func(pid int) (string, error)) (restore func(
 	}
 }
 
-var RequireThemeApiAccessImpl = requireThemeApiAccessImpl
+var RequireInterfaceApiAccessImpl = requireInterfaceApiAccessImpl
 
-func MockRequireThemeApiAccess(new func(d *Daemon, ucred *ucrednet) *apiError) (restore func()) {
-	old := requireThemeApiAccess
-	requireThemeApiAccess = new
+func MockRequireInterfaceApiAccess(new func(d *Daemon, ucred *ucrednet, interfaceName string) *apiError) (restore func()) {
+	old := requireInterfaceApiAccess
+	requireInterfaceApiAccess = new
 	return func() {
-		requireThemeApiAccess = old
+		requireInterfaceApiAccess = old
 	}
 }

--- a/interfaces/builtin/snap_find.go
+++ b/interfaces/builtin/snap_find.go
@@ -1,0 +1,47 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+const snapFindSummary = `allows use of snapd's snap store find API`
+
+const snapFindBaseDeclarationPlugs = `
+  snap-find:
+    allow-installation: false
+    deny-auto-connection: true
+`
+
+const snapFindBaseDeclarationSlots = `
+  snap-find:
+    allow-installation:
+      slot-snap-type:
+        - core
+    deny-auto-connection: true
+`
+
+func init() {
+	registerIface(&commonInterface{
+		name:                 "snap-find",
+		summary:              snapFindSummary,
+		implicitOnCore:       true,
+		implicitOnClassic:    true,
+		baseDeclarationPlugs: snapFindBaseDeclarationPlugs,
+		baseDeclarationSlots: snapFindBaseDeclarationSlots,
+	})
+}

--- a/interfaces/builtin/snap_find_test.go
+++ b/interfaces/builtin/snap_find_test.go
@@ -1,0 +1,98 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type SnapFindInterfaceSuite struct {
+	iface    interfaces.Interface
+	slotInfo *snap.SlotInfo
+	slot     *interfaces.ConnectedSlot
+	plugInfo *snap.PlugInfo
+	plug     *interfaces.ConnectedPlug
+}
+
+var _ = Suite(&SnapFindInterfaceSuite{
+	iface: builtin.MustInterface("snap-find"),
+})
+
+func (s *SnapFindInterfaceSuite) SetUpTest(c *C) {
+	const coreSlotYaml = `
+name: core
+type: os
+version: 1.0
+slots:
+  snap-find:
+`
+	s.slot, s.slotInfo = MockConnectedSlot(c, coreSlotYaml, nil, "snap-find")
+
+	const appPlugYaml = `
+name: other
+version: 0
+apps:
+ app:
+    command: foo
+    plugs: [snap-find]
+`
+	s.plug, s.plugInfo = MockConnectedPlug(c, appPlugYaml, nil, "snap-find")
+}
+
+func (s *SnapFindInterfaceSuite) TestName(c *C) {
+	c.Check(s.iface.Name(), Equals, "snap-find")
+}
+
+func (s *SnapFindInterfaceSuite) TestSanitizeSlot(c *C) {
+	c.Check(interfaces.BeforePrepareSlot(s.iface, s.slotInfo), IsNil)
+}
+
+func (s *SnapFindInterfaceSuite) TestSanitizePlug(c *C) {
+	c.Check(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
+}
+
+func (s *SnapFindInterfaceSuite) TestAppArmor(c *C) {
+	// The interface generates no AppArmor rules
+	spec := &apparmor.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Check(spec.SecurityTags(), HasLen, 0)
+
+	spec = &apparmor.Specification{}
+	c.Assert(spec.AddConnectedSlot(s.iface, s.plug, s.slot), IsNil)
+	c.Check(spec.SecurityTags(), HasLen, 0)
+
+	spec = &apparmor.Specification{}
+	c.Assert(spec.AddPermanentPlug(s.iface, s.plugInfo), IsNil)
+	c.Check(spec.SecurityTags(), HasLen, 0)
+
+	spec = &apparmor.Specification{}
+	c.Assert(spec.AddPermanentSlot(s.iface, s.slotInfo), IsNil)
+	c.Check(spec.SecurityTags(), HasLen, 0)
+}
+
+func (s *SnapFindInterfaceSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}

--- a/interfaces/builtin/snap_snaps.go
+++ b/interfaces/builtin/snap_snaps.go
@@ -1,0 +1,47 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+const snapSnapsSummary = `allows use of snapd's snap metadata API`
+
+const snapSnapsBaseDeclarationPlugs = `
+  snap-snaps:
+    allow-installation: false
+    deny-auto-connection: true
+`
+
+const snapSnapsBaseDeclarationSlots = `
+  snap-snaps:
+    allow-installation:
+      slot-snap-type:
+        - core
+    deny-auto-connection: true
+`
+
+func init() {
+	registerIface(&commonInterface{
+		name:                 "snap-snaps",
+		summary:              snapSnapsSummary,
+		implicitOnCore:       true,
+		implicitOnClassic:    true,
+		baseDeclarationPlugs: snapSnapsBaseDeclarationPlugs,
+		baseDeclarationSlots: snapSnapsBaseDeclarationSlots,
+	})
+}

--- a/interfaces/builtin/snap_snaps_test.go
+++ b/interfaces/builtin/snap_snaps_test.go
@@ -1,0 +1,98 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type SnapSnapsInterfaceSuite struct {
+	iface    interfaces.Interface
+	slotInfo *snap.SlotInfo
+	slot     *interfaces.ConnectedSlot
+	plugInfo *snap.PlugInfo
+	plug     *interfaces.ConnectedPlug
+}
+
+var _ = Suite(&SnapSnapsInterfaceSuite{
+	iface: builtin.MustInterface("snap-snaps"),
+})
+
+func (s *SnapSnapsInterfaceSuite) SetUpTest(c *C) {
+	const coreSlotYaml = `
+name: core
+type: os
+version: 1.0
+slots:
+  snap-snaps:
+`
+	s.slot, s.slotInfo = MockConnectedSlot(c, coreSlotYaml, nil, "snap-snaps")
+
+	const appPlugYaml = `
+name: other
+version: 0
+apps:
+ app:
+    command: foo
+    plugs: [snap-snaps]
+`
+	s.plug, s.plugInfo = MockConnectedPlug(c, appPlugYaml, nil, "snap-snaps")
+}
+
+func (s *SnapSnapsInterfaceSuite) TestName(c *C) {
+	c.Check(s.iface.Name(), Equals, "snap-snaps")
+}
+
+func (s *SnapSnapsInterfaceSuite) TestSanitizeSlot(c *C) {
+	c.Check(interfaces.BeforePrepareSlot(s.iface, s.slotInfo), IsNil)
+}
+
+func (s *SnapSnapsInterfaceSuite) TestSanitizePlug(c *C) {
+	c.Check(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
+}
+
+func (s *SnapSnapsInterfaceSuite) TestAppArmor(c *C) {
+	// The interface generates no AppArmor rules
+	spec := &apparmor.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Check(spec.SecurityTags(), HasLen, 0)
+
+	spec = &apparmor.Specification{}
+	c.Assert(spec.AddConnectedSlot(s.iface, s.plug, s.slot), IsNil)
+	c.Check(spec.SecurityTags(), HasLen, 0)
+
+	spec = &apparmor.Specification{}
+	c.Assert(spec.AddPermanentPlug(s.iface, s.plugInfo), IsNil)
+	c.Check(spec.SecurityTags(), HasLen, 0)
+
+	spec = &apparmor.Specification{}
+	c.Assert(spec.AddPermanentSlot(s.iface, s.slotInfo), IsNil)
+	c.Check(spec.SecurityTags(), HasLen, 0)
+}
+
+func (s *SnapSnapsInterfaceSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}

--- a/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
@@ -416,9 +416,15 @@ apps:
   snapd-control:
     command: bin/run
     plugs: [ snapd-control ]
+  snap-find:
+    command: bin/run
+    plugs: [ snap-find ]
   snap-refresh-control:
     command: bin/run
     plugs: [ snap-refresh-control ]
+  snap-snaps:
+    command: bin/run
+    plugs: [ snap-snaps ]
   snap-themes-control:
     command: bin/run
     plugs: [ snap-themes-control ]


### PR DESCRIPTION
This is needed for snapd-desktop-integration to show appropriate information (icon, title, publisher etc) on UI elements. Depends on https://github.com/snapcore/snapd/pull/13120

I would expect the snap-find interface to be easily accessible for many snaps, as this information can be accessed easily by contacting the store directly. The snap-snaps interface needs a bit more care, as this allows your system to be scanned for what snaps are installed.