### PR TITLE
prompting: add listener package

### DIFF
--- a/sandbox/apparmor/notify/listener/export_test.go
+++ b/sandbox/apparmor/notify/listener/export_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2022 Canonical Ltd
+ * Copyright (C) 2023 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -24,9 +24,17 @@ import (
 
 	"golang.org/x/sys/unix"
 
+	"github.com/snapcore/snapd/osutil/epoll"
 	"github.com/snapcore/snapd/sandbox/apparmor/notify"
 	"github.com/snapcore/snapd/testutil"
 )
+
+func FakeRequestWithClassAndReplyChan(class notify.MediationClass, replyChan chan interface{}) *Request {
+	return &Request{
+		class:     class,
+		replyChan: replyChan,
+	}
+}
 
 func MockOsOpen(f func(name string) (*os.File, error)) (restore func()) {
 	restore = testutil.Backup(&osOpen)
@@ -54,30 +62,71 @@ func MockOsOpenWithSockets() (sockFdChan chan int, restore func()) {
 	return sockFdChan, restore
 }
 
+func MockEpollWait(f func(l *Listener) ([]epoll.Event, error)) (restore func()) {
+	restore = testutil.Backup(&listenerEpollWait)
+	listenerEpollWait = f
+	return restore
+}
+
 func MockNotifyIoctl(f func(fd uintptr, req notify.IoctlRequest, buf notify.IoctlRequestBuffer) ([]byte, error)) (restore func()) {
 	restore = testutil.Backup(&notifyIoctl)
 	notifyIoctl = f
 	return restore
 }
 
-// Mocks notify.Ioctl calls by performing Read in place of RECV and Write in
-// place of SEND, and ignoring other IoctlRequest types.
-func MockNotifyIoctlWithReadWrite() (restore func()) {
-	f := func(fd uintptr, req notify.IoctlRequest, buf notify.IoctlRequestBuffer) ([]byte, error) {
-		size := 0
-		var err error = nil
+// Mocks epoll.Wait and notify.Ioctl calls by sending data over channels.
+// When data is sent over the recv channel (to be consumed by a mocked ioctl
+// call), it triggers an epoll event with the listener's notify socket fd, and
+// then passes the data on to the next ioctl RECV call. When the listener makes
+// a SEND call via ioctl, the data is instead written to the send channel.
+func MockEpollWaitNotifyIoctl() (recvChan chan<- []byte, sendChan <-chan []byte, restore func()) {
+	recvChanRW := make(chan []byte)
+	sendChanRW := make(chan []byte)
+	internalRecvChan := make(chan []byte, 1)
+	ef := func(l *Listener) ([]epoll.Event, error) {
+		select {
+		case request := <-recvChanRW:
+			internalRecvChan <- request
+		case <-l.tomb.Dying():
+			return nil, l.tomb.Err()
+		}
+		events := []epoll.Event{
+			{
+				Fd:        int(l.notifyFile.Fd()),
+				Readiness: epoll.Readable,
+			},
+		}
+		return events, nil
+	}
+	nf := func(fd uintptr, req notify.IoctlRequest, buf notify.IoctlRequestBuffer) ([]byte, error) {
 		switch req {
 		case notify.APPARMOR_NOTIF_RECV:
-			size, err = unix.Read(int(fd), buf)
+			request := <-internalRecvChan
+			return request, nil
 		case notify.APPARMOR_NOTIF_SEND:
-			size, err = unix.Write(int(fd), buf)
+			sendChanRW <- buf
 		default:
 			// ignore other IoctlRequest types
 		}
-		if size >= 0 && size <= len(buf) {
-			buf = buf[:size]
-		}
-		return buf, err
+		return buf, nil
 	}
-	return MockNotifyIoctl(f)
+	restoreEpoll := testutil.Backup(&listenerEpollWait)
+	listenerEpollWait = ef
+	restoreIoctl := testutil.Backup(&notifyIoctl)
+	notifyIoctl = nf
+	restore = func() {
+		restoreEpoll()
+		restoreIoctl()
+		close(recvChanRW)
+		close(sendChanRW)
+	}
+	return recvChanRW, sendChanRW, restore
+}
+
+func (l *Listener) Dying() <-chan struct{} {
+	return l.tomb.Dying()
+}
+
+func (l *Listener) Err() error {
+	return l.tomb.Err()
 }

--- a/sandbox/apparmor/notify/listener/export_test.go
+++ b/sandbox/apparmor/notify/listener/export_test.go
@@ -1,0 +1,83 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package listener
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/snapcore/snapd/sandbox/apparmor/notify"
+	"github.com/snapcore/snapd/testutil"
+)
+
+func MockOsOpen(f func(name string) (*os.File, error)) (restore func()) {
+	restore = testutil.Backup(&osOpen)
+	osOpen = f
+	return restore
+}
+
+// Mocks os.Open to instead create a socket pair, return one wrapped in a
+// os.File (in place of the opened file), and send the other along the
+// sockFdChan which is returned by this function.
+func MockOsOpenWithSockets() (sockFdChan chan int, restore func()) {
+	sockFdChan = make(chan int, 1)
+	f := func(name string) (*os.File, error) {
+		sockets, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM, 0)
+		if err != nil {
+			return nil, err
+		}
+		senderSocket := sockets[0]
+		receiverSocket := sockets[1]
+		notifyFile := os.NewFile(uintptr(receiverSocket), notify.SysPath)
+		sockFdChan <- senderSocket
+		return notifyFile, nil
+	}
+	restore = MockOsOpen(f)
+	return sockFdChan, restore
+}
+
+func MockNotifyIoctl(f func(fd uintptr, req notify.IoctlRequest, buf notify.IoctlRequestBuffer) ([]byte, error)) (restore func()) {
+	restore = testutil.Backup(&notifyIoctl)
+	notifyIoctl = f
+	return restore
+}
+
+// Mocks notify.Ioctl calls by performing Read in place of RECV and Write in
+// place of SEND, and ignoring other IoctlRequest types.
+func MockNotifyIoctlWithReadWrite() (restore func()) {
+	f := func(fd uintptr, req notify.IoctlRequest, buf notify.IoctlRequestBuffer) ([]byte, error) {
+		size := 0
+		var err error = nil
+		switch req {
+		case notify.APPARMOR_NOTIF_RECV:
+			size, err = unix.Read(int(fd), buf)
+		case notify.APPARMOR_NOTIF_SEND:
+			size, err = unix.Write(int(fd), buf)
+		default:
+			// ignore other IoctlRequest types
+		}
+		if size >= 0 && size <= len(buf) {
+			buf = buf[:size]
+		}
+		return buf, err
+	}
+	return MockNotifyIoctl(f)
+}

--- a/sandbox/apparmor/notify/listener/listener.go
+++ b/sandbox/apparmor/notify/listener/listener.go
@@ -186,7 +186,7 @@ func (l *Listener) waitAndRespondAaClassFile(req *Request, msg *notify.MsgNotifi
 		resp.Deny = 0
 		resp.Error = 0
 	} else {
-		resp.Allow = 0
+		resp.Allow = msg.Allow
 		resp.Deny = msg.Deny
 		resp.Error = msg.Error
 		// msg.Error is field from MsgNotificationResponse, and is unused.

--- a/sandbox/apparmor/notify/listener/listener.go
+++ b/sandbox/apparmor/notify/listener/listener.go
@@ -33,8 +33,6 @@ type Listener struct {
 //
 // Each request must be replied to by writing a boolean to the YesNo channel.
 type Request struct {
-	l *Listener
-
 	// Pid is the identifier of the process triggering the request.
 	Pid uint32
 	// Label is the apparmor label on the process triggering the request.
@@ -60,8 +58,6 @@ func newRequest(l *Listener, msg *notify.MsgNotificationFile) (*Request, error) 
 		perm = missingPerms
 	}
 	return &Request{
-		l: l, // why is this needed?
-
 		Pid:        msg.Pid,
 		Label:      msg.Label,
 		Path:       msg.Name,

--- a/sandbox/apparmor/notify/listener/listener.go
+++ b/sandbox/apparmor/notify/listener/listener.go
@@ -1,0 +1,265 @@
+// Package listener implements a high-level interface to the apparmor
+// notification mechanism. It can be used to build userspace applications
+// which respond to apparmor prompting profiles.
+package listener
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"gopkg.in/tomb.v2"
+
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/osutil/epoll"
+	"github.com/snapcore/snapd/sandbox/apparmor/notify"
+)
+
+// Listener contains low-level components for receiving notification requests
+// and responding with notification responses.
+type Listener struct {
+	// R is a channel with incoming requests. Each request is asynchronous
+	// and needs to be replied to.
+	R chan *Request
+	// E is a channel for receiving asynchronous error messages from
+	// concurrently running parts of the listener system.
+	E chan error
+
+	notifyFile *os.File
+	poll       *epoll.Epoll
+}
+
+// Request is a high-level representation of an apparmor prompting message.
+//
+// Each request must be replied to by writing a boolean to the YesNo channel.
+type Request struct {
+	l *Listener
+
+	// Pid is the identifier of the process triggering the request.
+	Pid uint32
+	// Label is the apparmor label on the process triggering the request.
+	Label string
+	// SubjectUID is the UID of the subject that triggered the prompt
+	SubjectUid uint32
+
+	// Path is the path of the file, as seen by the process triggering the request.
+	Path string
+	// Permission is the opaque permission that is being requested.
+	Permission interface{}
+	// YesNo is a channel for writing the response.
+	YesNo chan bool
+}
+
+func newRequest(l *Listener, msg *notify.MsgNotificationFile) (*Request, error) {
+	var perm interface{}
+	if msg.Class == notify.AA_CLASS_FILE {
+		_, missingPerms, err := msg.DecodeFilePermissions()
+		if err != nil {
+			return nil, err
+		}
+		perm = missingPerms
+	}
+	return &Request{
+		l: l, // why is this needed?
+
+		Pid:        msg.Pid,
+		Label:      msg.Label,
+		Path:       msg.Name,
+		SubjectUid: msg.SUID,
+
+		Permission: perm,
+
+		YesNo: make(chan bool, 1),
+	}, nil
+}
+
+var (
+	// ErrListenerNotSupported indicates that the kernel does not support apparmor prompting
+	ErrListenerNotSupported = errors.New("kernel does not support apparmor notifications")
+
+	osOpen      = os.Open
+	notifyIoctl = notify.Ioctl
+)
+
+// Register opens and configures the apparmor notification interface.
+//
+// If the kernel does not support the notification mechanism the error is ErrNotSupported.
+func Register() (*Listener, error) {
+	path := notify.SysPath
+	if override := os.Getenv("PROMPT_NOTIFY_PATH"); override != "" {
+		path = override
+	}
+
+	notifyFile, err := osOpen(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, ErrListenerNotSupported
+		}
+		return nil, fmt.Errorf("cannot open %q: %v", path, err)
+	}
+	defer func() {
+		if err != nil {
+			notifyFile.Close()
+		}
+	}()
+
+	msg := notify.MsgNotificationFilter{ModeSet: notify.APPARMOR_MODESET_USER}
+	data, err := msg.MarshalBinary()
+	if err != nil {
+		return nil, err
+	}
+	ioctlBuf := notify.IoctlRequestBuffer(data)
+	_, err = notifyIoctl(notifyFile.Fd(), notify.APPARMOR_NOTIF_SET_FILTER, ioctlBuf)
+	if err != nil {
+		return nil, fmt.Errorf("cannot notify ioctl to modeset user on %q: %v", path, err)
+	}
+
+	poll, err := epoll.Open()
+	if err != nil {
+		return nil, fmt.Errorf("cannot open epoll file descriptor: %v", err)
+	}
+	defer func() {
+		if err != nil {
+			poll.Close()
+		}
+	}()
+	// XXX: Do we need a notification for Writable, to send responses back?
+	if err = poll.Register(int(notifyFile.Fd()), epoll.Readable); err != nil {
+		return nil, fmt.Errorf("cannot register epoll on %q: %v", path, err)
+	}
+
+	listener := &Listener{
+		R: make(chan *Request),
+		E: make(chan error),
+
+		notifyFile: notifyFile,
+		poll:       poll,
+	}
+	return listener, nil
+}
+
+func (l *Listener) decodeAndDispatchRequest(buf []byte, tomb *tomb.Tomb) error {
+	var nmsg notify.MsgNotification
+	if err := nmsg.UnmarshalBinary(buf); err != nil {
+		return err
+	}
+	// What kind of notification message did we get?
+	if nmsg.NotificationType != notify.APPARMOR_NOTIF_OP {
+		return fmt.Errorf("unsupported notification type: %v", nmsg.NotificationType)
+	}
+	var omsg notify.MsgNotificationOp
+	if err := omsg.UnmarshalBinary(buf); err != nil {
+		return err
+	}
+	// What kind of operation notification did we get?
+	switch omsg.Class {
+	case notify.AA_CLASS_FILE:
+		return l.handleRequestAaClassFile(buf, tomb)
+	}
+	return fmt.Errorf("unsupported mediation class: %v", omsg.Class)
+}
+
+func (l *Listener) handleRequestAaClassFile(buf []byte, tomb *tomb.Tomb) error {
+	var fmsg notify.MsgNotificationFile
+	if err := fmsg.UnmarshalBinary(buf); err != nil {
+		return err
+	}
+	logger.Debugf("notification request: %#v", fmsg)
+	req, err := newRequest(l, &fmsg)
+	if err != nil {
+		return err
+	}
+	l.R <- req
+	tomb.Go(func() error {
+		l.waitAndRespondAaClassFile(req, &fmsg)
+		return nil
+	})
+	return nil
+}
+
+func (l *Listener) waitAndRespondAaClassFile(req *Request, msg *notify.MsgNotificationFile) {
+	resp := notify.ResponseForRequest(&msg.MsgNotification)
+	resp.MsgNotification.Error = 0 // ignored in responses
+	resp.MsgNotification.NoCache = 1
+	if allow := <-req.YesNo; allow {
+		resp.Allow = msg.Allow | msg.Deny
+		resp.Deny = 0
+		resp.Error = 0
+	} else {
+		resp.Allow = 0
+		resp.Deny = msg.Deny
+		resp.Error = msg.Error
+		// msg.Error is field from MsgNotificationResponse, and is unused.
+		// msg.MsgNotification.Error is also ignored in responses.
+	}
+	logger.Debugf("notification response: %#v\n", resp)
+	if err := l.encodeAndSendResponse(&resp); err != nil {
+		l.fail(err)
+	}
+}
+
+func (l *Listener) encodeAndSendResponse(resp *notify.MsgNotificationResponse) error {
+	buf, err := resp.MarshalBinary()
+	if err != nil {
+		return err
+	}
+	ioctlBuf := notify.IoctlRequestBuffer(buf)
+	_, err = notifyIoctl(l.notifyFile.Fd(), notify.APPARMOR_NOTIF_SEND, ioctlBuf)
+	return err
+}
+
+func (l *Listener) runOnce(tomb *tomb.Tomb) error {
+	events, err := l.poll.Wait()
+	if err != nil {
+		return err
+	}
+	for _, event := range events {
+		if event.Fd != int(l.notifyFile.Fd()) {
+			logger.Debugf("unexpected event from fd %v (%v)", event.Fd, event.Readiness)
+			continue
+		}
+		if event.Readiness&epoll.Readable == 0 {
+			continue
+		}
+		// Prepare a receive buffer for incoming request. The buffer is of the
+		// maximum allowed size and will contain one kernel request upon return.
+		// Note that the actually occupied buffer is indicated by the Length field
+		// in the header.
+		ioctlBuf := notify.NewIoctlRequestBuffer()
+		buf, err := notifyIoctl(l.notifyFile.Fd(), notify.APPARMOR_NOTIF_RECV, ioctlBuf)
+		if err != nil {
+			return err
+		}
+		if err := l.decodeAndDispatchRequest(buf, tomb); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Run reads and dispatches kernel requests until stopped.
+func (l *Listener) Run(tomb *tomb.Tomb) {
+	// TODO: allow the run to stop
+	for {
+		if err := l.runOnce(tomb); err != nil {
+			l.fail(err)
+			break
+		}
+	}
+}
+
+func (l *Listener) fail(err error) {
+	l.E <- err
+	close(l.E)
+	close(l.R)
+}
+
+// Close closes the kernel communication file.
+func (l *Listener) Close() error {
+	err1 := l.notifyFile.Close()
+	err2 := l.poll.Close()
+	if err1 != nil {
+		return err1
+	}
+	return err2
+}

--- a/sandbox/apparmor/notify/listener/listener_test.go
+++ b/sandbox/apparmor/notify/listener/listener_test.go
@@ -1,0 +1,324 @@
+package listener_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	. "gopkg.in/check.v1"
+
+	"gopkg.in/tomb.v2"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/snapcore/snapd/arch"
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/sandbox/apparmor/notify"
+	"github.com/snapcore/snapd/sandbox/apparmor/notify/listener"
+	"github.com/snapcore/snapd/testutil"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type listenerSuite struct {
+	testutil.BaseTest
+}
+
+var _ = Suite(&listenerSuite{})
+
+func (s *listenerSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+
+	dirs.SetRootDir(c.MkDir())
+	s.AddCleanup(func() { dirs.SetRootDir("") })
+}
+
+func (*listenerSuite) TestRegisterClose(c *C) {
+	sockFdChan, restoreOpen := listener.MockOsOpenWithSockets()
+	defer restoreOpen()
+
+	restoreIoctl := listener.MockNotifyIoctlWithReadWrite()
+	defer restoreIoctl()
+
+	l, err := listener.Register()
+	c.Assert(err, IsNil)
+
+	<-sockFdChan
+
+	err = l.Close()
+	c.Assert(err, IsNil)
+}
+
+func (*listenerSuite) TestRegisterOverridePath(c *C) {
+	var outputOverridePath string
+	restoreOpen := listener.MockOsOpen(func(name string) (*os.File, error) {
+		outputOverridePath = name
+		placeholderSocket, err := unix.Socket(unix.AF_UNIX, unix.SOCK_STREAM, 0)
+		c.Assert(err, IsNil)
+		placeholderFile := os.NewFile(uintptr(placeholderSocket), name)
+		return placeholderFile, nil
+	})
+	defer restoreOpen()
+
+	restoreIoctl := listener.MockNotifyIoctl(func(fd uintptr, req notify.IoctlRequest, buf notify.IoctlRequestBuffer) ([]byte, error) {
+		return make([]byte, 0), nil
+	})
+	defer restoreIoctl()
+
+	l, err := listener.Register()
+	c.Assert(err, IsNil)
+
+	c.Assert(outputOverridePath, Equals, notify.SysPath)
+
+	err = l.Close()
+	c.Assert(err, IsNil)
+
+	fakePath := "/a/new/path"
+	os.Setenv("PROMPT_NOTIFY_PATH", fakePath)
+
+	l, err = listener.Register()
+	c.Assert(err, IsNil)
+
+	c.Assert(outputOverridePath, Equals, fakePath)
+
+	err = l.Close()
+	c.Assert(err, IsNil)
+}
+
+func (*listenerSuite) TestRegisterErrors(c *C) {
+	restoreOpen := listener.MockOsOpen(func(name string) (*os.File, error) {
+		return nil, os.ErrNotExist
+	})
+	defer restoreOpen()
+
+	l, err := listener.Register()
+	c.Assert(l, IsNil)
+	c.Assert(err, Equals, listener.ErrListenerNotSupported)
+
+	customError := errors.New("custom error")
+
+	restoreOpen = listener.MockOsOpen(func(name string) (*os.File, error) {
+		return nil, customError
+	})
+	defer restoreOpen()
+
+	l, err = listener.Register()
+	c.Assert(l, IsNil)
+	c.Assert(err, ErrorMatches, fmt.Sprintf("cannot open %q: %v", notify.SysPath, customError))
+
+	restoreOpen = listener.MockOsOpen(func(name string) (*os.File, error) {
+		placeholderSocket, err := unix.Socket(unix.AF_UNIX, unix.SOCK_STREAM, 0)
+		c.Assert(err, IsNil)
+		placeholderFile := os.NewFile(uintptr(placeholderSocket), name)
+		return placeholderFile, nil
+	})
+	defer restoreOpen()
+
+	restoreIoctl := listener.MockNotifyIoctl(func(fd uintptr, req notify.IoctlRequest, buf notify.IoctlRequestBuffer) ([]byte, error) {
+		return nil, customError
+	})
+	defer restoreIoctl()
+
+	l, err = listener.Register()
+	c.Assert(l, IsNil)
+	c.Assert(err, ErrorMatches, fmt.Sprintf("cannot notify ioctl to modeset user on %q: %v", notify.SysPath, customError))
+
+	restoreOpen = listener.MockOsOpen(func(name string) (*os.File, error) {
+		badFd := ^uintptr(0)
+		fakeFile := os.NewFile(badFd, name)
+		return fakeFile, nil
+	})
+	defer restoreOpen()
+
+	restoreIoctl = listener.MockNotifyIoctl(func(fd uintptr, req notify.IoctlRequest, buf notify.IoctlRequestBuffer) ([]byte, error) {
+		return nil, nil
+	})
+	defer restoreIoctl()
+
+	l, err = listener.Register()
+	c.Assert(l, IsNil)
+	c.Assert(err, ErrorMatches, fmt.Sprintf("cannot register epoll on %q: bad file descriptor", notify.SysPath))
+}
+
+type msgNotificationFile struct {
+	// MsgHeader
+	Length  uint16
+	Version uint16
+	// MsgNotification
+	NotificationType notify.NotificationType
+	Signalled        uint8
+	NoCache          uint8
+	ID               uint64
+	Error            int32
+	// msgNotificationOpKernel
+	Allow uint32
+	Deny  uint32
+	Pid   uint32
+	Label uint32
+	Class uint32
+	Op    uint32
+	// msgNotificationFileKernel
+	SUID uint32
+	OUID uint32
+	Name uint32
+}
+
+func (*listenerSuite) TestRun(c *C) {
+	sockFdChan, restoreOpen := listener.MockOsOpenWithSockets()
+	defer restoreOpen()
+
+	restoreIoctl := listener.MockNotifyIoctlWithReadWrite()
+	defer restoreIoctl()
+
+	l, err := listener.Register()
+	c.Assert(err, IsNil)
+	notifySocket := <-sockFdChan
+
+	var lt tomb.Tomb
+	lt.Go(func() error {
+		l.Run(&lt)
+		return nil
+	})
+	defer lt.Kill(errors.New("exiting"))
+
+	label := "snap.foo.bar"
+	path := "/home/Documents/foo"
+
+	ids := []uint64{0xdead, 0xbeef}
+	requests := make([]*listener.Request, 0, len(ids))
+
+	for _, id := range ids {
+		msg := notify.MsgNotificationFile{}
+		msg.Version = 3
+		msg.NotificationType = notify.APPARMOR_NOTIF_OP
+		msg.NoCache = 1
+		msg.ID = id
+		msg.Allow = 0b1010
+		msg.Deny = 0b0101
+		msg.Pid = 1234
+		msg.Label = label
+		msg.Class = notify.AA_CLASS_FILE
+		msg.SUID = 1000
+		msg.Name = path
+		buf, err := msg.MarshalBinary()
+		c.Assert(err, IsNil)
+		unix.Write(notifySocket, buf)
+
+		select {
+		case req := <-l.R:
+			c.Assert(req.Pid, Equals, msg.Pid)
+			c.Assert(req.Label, Equals, label)
+			c.Assert(req.Path, Equals, path)
+			c.Assert(req.SubjectUid, Equals, msg.SUID)
+			requests = append(requests, req)
+		case err := <-l.E:
+			c.Assert(err, IsNil)
+		case reason := <-lt.Dying():
+			c.Assert(reason, Equals, nil)
+		}
+	}
+
+	for i, id := range ids {
+		switch i % 2 {
+		case 0:
+			requests[i].YesNo <- false
+		case 1:
+			requests[i].YesNo <- true
+		}
+
+		time.Sleep(25 * time.Millisecond)
+
+		msgNotification := notify.MsgNotification{
+			NotificationType: notify.APPARMOR_NOTIF_RESP,
+			NoCache:          1,
+			ID:               id,
+			Error:            0,
+		}
+		resp := notify.MsgNotificationResponse{
+			MsgNotification: msgNotification,
+			Error:           0,
+			Allow:           uint32(0b1111 * i),
+			Deny:            uint32(0b0101 * (1 - i)),
+		}
+		respBuf, err := resp.MarshalBinary()
+		c.Assert(err, IsNil)
+
+		receivedBuf := make([]byte, 0xFFFF)
+		size, err := unix.Read(notifySocket, receivedBuf)
+		c.Assert(err, IsNil)
+		c.Assert(size, Equals, len(respBuf))
+		c.Assert(receivedBuf[:size], DeepEquals, respBuf)
+	}
+
+	err = l.Close()
+	c.Assert(err, IsNil)
+}
+
+func (*listenerSuite) TestRunErrors(c *C) {
+	sockFdChan, restoreOpen := listener.MockOsOpenWithSockets()
+	defer restoreOpen()
+
+	restoreIoctl := listener.MockNotifyIoctlWithReadWrite()
+	defer restoreIoctl()
+
+	order := arch.Endian()
+
+	for _, testCase := range []struct {
+		msg msgNotificationFile
+		err string
+	}{
+		{
+			msgNotificationFile{},
+			`cannot unmarshal apparmor message header: unsupported version: 0`,
+		},
+		{
+			msgNotificationFile{
+				Version: 3,
+			},
+			`cannot unmarshal apparmor message header: length mismatch 0 != 56`,
+		},
+		{
+			msgNotificationFile{
+				Length:           56,
+				Version:          3,
+				NotificationType: notify.APPARMOR_NOTIF_CANCEL,
+			},
+			`unsupported notification type: APPARMOR_NOTIF_CANCEL`,
+		},
+		{
+			msgNotificationFile{
+				Length:           56,
+				Version:          3,
+				NotificationType: notify.APPARMOR_NOTIF_OP,
+				Class:            uint32(notify.AA_CLASS_DBUS),
+			},
+			`unsupported mediation class: AA_CLASS_DBUS`,
+		},
+	} {
+		l, err := listener.Register()
+		c.Assert(err, IsNil)
+		notifySocket := <-sockFdChan
+
+		var lt tomb.Tomb
+		lt.Go(func() error {
+			l.Run(&lt)
+			return nil
+		})
+
+		buf := bytes.NewBuffer(make([]byte, 0, testCase.msg.Length))
+		err = binary.Write(buf, order, testCase.msg)
+		c.Check(err, IsNil)
+		unix.Write(notifySocket, buf.Bytes())
+
+		eChanResult := <-l.E
+		c.Assert(eChanResult, ErrorMatches, testCase.err)
+
+		err = l.Close()
+		c.Assert(err, IsNil)
+		unix.Close(notifySocket)
+	}
+}

--- a/sandbox/apparmor/notify/listener/listener_test.go
+++ b/sandbox/apparmor/notify/listener/listener_test.go
@@ -191,14 +191,17 @@ func (*listenerSuite) TestRun(c *C) {
 	ids := []uint64{0xdead, 0xbeef}
 	requests := make([]*listener.Request, 0, len(ids))
 
+	aBits := uint32(0b1010)
+	dBits := uint32(0b0101)
+
 	for _, id := range ids {
 		msg := notify.MsgNotificationFile{}
 		msg.Version = 3
 		msg.NotificationType = notify.APPARMOR_NOTIF_OP
 		msg.NoCache = 1
 		msg.ID = id
-		msg.Allow = 0b1010
-		msg.Deny = 0b0101
+		msg.Allow = aBits
+		msg.Deny = dBits
 		msg.Pid = 1234
 		msg.Label = label
 		msg.Class = notify.AA_CLASS_FILE
@@ -241,8 +244,8 @@ func (*listenerSuite) TestRun(c *C) {
 		resp := notify.MsgNotificationResponse{
 			MsgNotification: msgNotification,
 			Error:           0,
-			Allow:           uint32(0b1111 * i),
-			Deny:            uint32(0b0101 * (1 - i)),
+			Allow:           uint32(aBits | (dBits * uint32(i))),
+			Deny:            uint32(dBits * uint32((1 - i))),
 		}
 		respBuf, err := resp.MarshalBinary()
 		c.Assert(err, IsNil)

--- a/sandbox/apparmor/notify/listener/listener_test.go
+++ b/sandbox/apparmor/notify/listener/listener_test.go
@@ -1,3 +1,22 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 package listener_test
 
 import (
@@ -17,6 +36,7 @@ import (
 
 	"github.com/snapcore/snapd/arch"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil/epoll"
 	"github.com/snapcore/snapd/sandbox/apparmor/notify"
 	"github.com/snapcore/snapd/sandbox/apparmor/notify/listener"
 	"github.com/snapcore/snapd/testutil"
@@ -37,20 +57,60 @@ func (s *listenerSuite) SetUpTest(c *C) {
 	s.AddCleanup(func() { dirs.SetRootDir("") })
 }
 
+func (*listenerSuite) TestReply(c *C) {
+	rc := make(chan interface{}, 1)
+	req := listener.FakeRequestWithClassAndReplyChan(notify.AA_CLASS_FILE, rc)
+	reply := true
+	req.Reply(reply)
+	resp := <-rc
+	c.Assert(resp, Equals, reply)
+}
+
+func (*listenerSuite) TestBadReply(c *C) {
+	rc := make(chan interface{}, 1)
+	req := listener.FakeRequestWithClassAndReplyChan(notify.AA_CLASS_FILE, rc)
+	reply := 1
+	err := req.Reply(reply)
+	c.Assert(err, ErrorMatches, "invalid reply: response must be of type bool")
+}
+
+func (*listenerSuite) TestReplyTwice(c *C) {
+	rc := make(chan interface{}, 1)
+	req := listener.FakeRequestWithClassAndReplyChan(notify.AA_CLASS_FILE, rc)
+	reply := false
+	err := req.Reply(reply)
+	c.Assert(err, IsNil)
+	resp := <-rc
+	c.Assert(resp, Equals, reply)
+
+	reply = true
+	err = req.Reply(reply)
+	c.Assert(err, Equals, listener.ErrAlreadyReplied)
+}
+
 func (*listenerSuite) TestRegisterClose(c *C) {
 	sockFdChan, restoreOpen := listener.MockOsOpenWithSockets()
 	defer restoreOpen()
 
-	restoreIoctl := listener.MockNotifyIoctlWithReadWrite()
+	restoreIoctl := listener.MockNotifyIoctl(func(fd uintptr, req notify.IoctlRequest, buf notify.IoctlRequestBuffer) ([]byte, error) {
+		expected := notify.MsgNotificationFilter{ModeSet: notify.APPARMOR_MODESET_USER}
+		expectedBytes, err := expected.MarshalBinary()
+		c.Assert(err, IsNil)
+		expectedBuf := notify.IoctlRequestBuffer(expectedBytes)
+		c.Assert(req, Equals, notify.APPARMOR_NOTIF_SET_FILTER)
+		c.Assert(buf, DeepEquals, expectedBuf)
+		return make([]byte, 0), nil
+	})
 	defer restoreIoctl()
 
 	l, err := listener.Register()
 	c.Assert(err, IsNil)
+	defer func() {
+		err = l.Close()
+		c.Assert(err, IsNil)
+	}()
 
 	<-sockFdChan
-
-	err = l.Close()
-	c.Assert(err, IsNil)
 }
 
 func (*listenerSuite) TestRegisterOverridePath(c *C) {
@@ -65,6 +125,7 @@ func (*listenerSuite) TestRegisterOverridePath(c *C) {
 	defer restoreOpen()
 
 	restoreIoctl := listener.MockNotifyIoctl(func(fd uintptr, req notify.IoctlRequest, buf notify.IoctlRequestBuffer) ([]byte, error) {
+		c.Assert(req, Equals, notify.APPARMOR_NOTIF_SET_FILTER)
 		return make([]byte, 0), nil
 	})
 	defer restoreIoctl()
@@ -78,7 +139,12 @@ func (*listenerSuite) TestRegisterOverridePath(c *C) {
 	c.Assert(err, IsNil)
 
 	fakePath := "/a/new/path"
-	os.Setenv("PROMPT_NOTIFY_PATH", fakePath)
+	err = os.Setenv("PROMPT_NOTIFY_PATH", fakePath)
+	c.Assert(err, IsNil)
+	defer func() {
+		err := os.Unsetenv("PROMPT_NOTIFY_PATH")
+		c.Assert(err, IsNil)
+	}()
 
 	l, err = listener.Register()
 	c.Assert(err, IsNil)
@@ -97,7 +163,7 @@ func (*listenerSuite) TestRegisterErrors(c *C) {
 
 	l, err := listener.Register()
 	c.Assert(l, IsNil)
-	c.Assert(err, Equals, listener.ErrListenerNotSupported)
+	c.Assert(err, Equals, listener.ErrNotSupported)
 
 	customError := errors.New("custom error")
 
@@ -119,6 +185,7 @@ func (*listenerSuite) TestRegisterErrors(c *C) {
 	defer restoreOpen()
 
 	restoreIoctl := listener.MockNotifyIoctl(func(fd uintptr, req notify.IoctlRequest, buf notify.IoctlRequestBuffer) ([]byte, error) {
+		c.Assert(req, Equals, notify.APPARMOR_NOTIF_SET_FILTER)
 		return nil, customError
 	})
 	defer restoreIoctl()
@@ -135,6 +202,7 @@ func (*listenerSuite) TestRegisterErrors(c *C) {
 	defer restoreOpen()
 
 	restoreIoctl = listener.MockNotifyIoctl(func(fd uintptr, req notify.IoctlRequest, buf notify.IoctlRequestBuffer) ([]byte, error) {
+		c.Assert(req, Equals, notify.APPARMOR_NOTIF_SET_FILTER)
 		return nil, nil
 	})
 	defer restoreIoctl()
@@ -144,6 +212,8 @@ func (*listenerSuite) TestRegisterErrors(c *C) {
 	c.Assert(err, ErrorMatches, fmt.Sprintf("cannot register epoll on %q: bad file descriptor", notify.SysPath))
 }
 
+// An expedient abstraction over notify.MsgNotificationFile to allow defining
+// MsgNotificationFile structs using value literals.
 type msgNotificationFile struct {
 	// MsgHeader
 	Length  uint16
@@ -167,108 +237,186 @@ type msgNotificationFile struct {
 	Name uint32
 }
 
-func (*listenerSuite) TestRun(c *C) {
+func (msg *msgNotificationFile) MarshalBinary(c *C) []byte {
+	msgBuf := bytes.NewBuffer(make([]byte, 0, msg.Length))
+	order := arch.Endian()
+	c.Assert(binary.Write(msgBuf, order, msg), IsNil)
+	return msgBuf.Bytes()
+}
+
+func (*listenerSuite) TestRunSimple(c *C) {
 	sockFdChan, restoreOpen := listener.MockOsOpenWithSockets()
 	defer restoreOpen()
 
-	restoreIoctl := listener.MockNotifyIoctlWithReadWrite()
-	defer restoreIoctl()
+	recvChan, sendChan, restoreEpollIoctl := listener.MockEpollWaitNotifyIoctl()
+	defer restoreEpollIoctl()
 
+	var t tomb.Tomb
 	l, err := listener.Register()
 	c.Assert(err, IsNil)
+	defer func() {
+		c.Check(l.Close(), IsNil)
+		c.Check(t.Wait(), Equals, listener.ErrClosed)
+	}()
 	notifySocket := <-sockFdChan
+	defer unix.Close(notifySocket)
 
-	var lt tomb.Tomb
-	lt.Go(func() error {
-		l.Run(&lt)
-		return nil
-	})
-	defer lt.Kill(errors.New("exiting"))
-
-	label := "snap.foo.bar"
-	path := "/home/Documents/foo"
+	t.Go(l.Run)
 
 	ids := []uint64{0xdead, 0xbeef}
 	requests := make([]*listener.Request, 0, len(ids))
 
+	label := "snap.foo.bar"
+	path := "/home/Documents/foo"
 	aBits := uint32(0b1010)
 	dBits := uint32(0b0101)
 
 	for _, id := range ids {
-		msg := notify.MsgNotificationFile{}
-		msg.Version = 3
-		msg.NotificationType = notify.APPARMOR_NOTIF_OP
-		msg.NoCache = 1
-		msg.ID = id
-		msg.Allow = aBits
-		msg.Deny = dBits
-		msg.Pid = 1234
-		msg.Label = label
-		msg.Class = notify.AA_CLASS_FILE
-		msg.SUID = 1000
-		msg.Name = path
+		msg := newMsgNotificationFile(id, label, path, aBits, dBits)
 		buf, err := msg.MarshalBinary()
 		c.Assert(err, IsNil)
-		unix.Write(notifySocket, buf)
+		recvChan <- buf
 
 		select {
-		case req := <-l.R:
-			c.Assert(req.Pid, Equals, msg.Pid)
-			c.Assert(req.Label, Equals, label)
-			c.Assert(req.Path, Equals, path)
-			c.Assert(req.SubjectUid, Equals, msg.SUID)
+		case req := <-l.Reqs():
+			c.Assert(req.PID(), Equals, msg.Pid)
+			c.Assert(req.Label(), Equals, label)
+			c.Assert(req.SubjectUID(), Equals, msg.SUID)
+			c.Assert(req.Path(), Equals, path)
+			c.Assert(req.Class(), Equals, notify.AA_CLASS_FILE)
+			perm, ok := req.Permission().(notify.FilePermission)
+			c.Assert(ok, Equals, true)
+			c.Assert(perm, Equals, notify.FilePermission(dBits))
 			requests = append(requests, req)
-		case err := <-l.E:
-			c.Assert(err, IsNil)
-		case reason := <-lt.Dying():
-			c.Assert(reason, Equals, nil)
+		case <-l.Dying():
+			c.Fatalf("listener encountered unexpected error: %v", l.Err())
 		}
 	}
 
 	for i, id := range ids {
 		switch i % 2 {
 		case 0:
-			requests[i].YesNo <- false
+			err = requests[i].Reply(false)
 		case 1:
-			requests[i].YesNo <- true
+			err = requests[i].Reply(true)
 		}
-
-		time.Sleep(25 * time.Millisecond)
-
-		msgNotification := notify.MsgNotification{
-			NotificationType: notify.APPARMOR_NOTIF_RESP,
-			NoCache:          1,
-			ID:               id,
-			Error:            0,
-		}
-		resp := notify.MsgNotificationResponse{
-			MsgNotification: msgNotification,
-			Error:           0,
-			Allow:           uint32(aBits | (dBits * uint32(i))),
-			Deny:            uint32(dBits * uint32((1 - i))),
-		}
-		respBuf, err := resp.MarshalBinary()
 		c.Assert(err, IsNil)
 
-		receivedBuf := make([]byte, 0xFFFF)
-		size, err := unix.Read(notifySocket, receivedBuf)
+		allow := aBits | (dBits * uint32(i))
+		deny := dBits * uint32(1-i)
+		resp := newMsgNotificationResponse(id, allow, deny)
+		desiredBuf, err := resp.MarshalBinary()
 		c.Assert(err, IsNil)
-		c.Assert(size, Equals, len(respBuf))
-		c.Assert(receivedBuf[:size], DeepEquals, respBuf)
+
+		received := <-sendChan
+		c.Assert(received, DeepEquals, desiredBuf)
+	}
+}
+
+// Check that if a request is written between when the listener is registered
+// and when Run() is called, that request will still be handled correctly.
+func (*listenerSuite) TestRegisterWriteRun(c *C) {
+	sockFdChan, restoreOpen := listener.MockOsOpenWithSockets()
+	defer restoreOpen()
+
+	recvChan, sendChan, restoreEpollIoctl := listener.MockEpollWaitNotifyIoctl()
+	defer restoreEpollIoctl()
+
+	var t tomb.Tomb
+	l, err := listener.Register()
+	c.Assert(err, IsNil)
+	defer func() {
+		c.Check(l.Close(), IsNil)
+		c.Check(t.Wait(), Equals, listener.ErrClosed)
+	}()
+	notifySocket := <-sockFdChan
+	defer unix.Close(notifySocket)
+
+	id := uint64(1234)
+	label := "snap.foo.bar"
+	path := "/home/Documents/foo"
+	aBits := uint32(0b1010)
+	dBits := uint32(0b0101)
+
+	msg := newMsgNotificationFile(id, label, path, aBits, dBits)
+	buf, err := msg.MarshalBinary()
+	c.Assert(err, IsNil)
+
+	go func() {
+		giveUp := time.NewTimer(100 * time.Millisecond)
+		select {
+		case recvChan <- buf:
+			// all good
+		case <-giveUp.C:
+			c.Fatalf("failed to receive buffer")
+		}
+	}()
+
+	timer := time.NewTimer(10 * time.Millisecond)
+	select {
+	case <-l.Reqs():
+		c.Fatalf("should not have received request before Run() called")
+	case <-l.Dying():
+		c.Fatalf("listener encountered an error before Run() called: %v", l.Err())
+	case <-timer.C:
 	}
 
-	err = l.Close()
-	c.Assert(err, IsNil)
+	t.Go(l.Run)
+
+	timer.Reset(100 * time.Millisecond)
+	select {
+	case req, ok := <-l.Reqs():
+		c.Assert(ok, Equals, true)
+		c.Assert(req.Path(), Equals, path)
+	case <-l.Dying():
+		c.Fatalf("listener encountered unexpected error: %v", l.Err())
+	case <-timer.C:
+		c.Fatalf("failed to receive request before timer expired")
+	}
+
+	go func() {
+		<-sendChan
+	}()
+}
+
+func newMsgNotificationFile(id uint64, label, name string, allow, deny uint32) *notify.MsgNotificationFile {
+	msg := notify.MsgNotificationFile{}
+	msg.Version = 3
+	msg.NotificationType = notify.APPARMOR_NOTIF_OP
+	msg.NoCache = 1
+	msg.ID = id
+	msg.Allow = allow
+	msg.Deny = deny
+	msg.Pid = 1234
+	msg.Label = label
+	msg.Class = notify.AA_CLASS_FILE
+	msg.SUID = 1000
+	msg.Name = name
+	return &msg
+}
+
+func newMsgNotificationResponse(id uint64, allow, deny uint32) *notify.MsgNotificationResponse {
+	msgNotification := notify.MsgNotification{
+		NotificationType: notify.APPARMOR_NOTIF_RESP,
+		NoCache:          1,
+		ID:               id,
+		Error:            0,
+	}
+	resp := notify.MsgNotificationResponse{
+		MsgNotification: msgNotification,
+		Error:           0,
+		Allow:           allow,
+		Deny:            deny,
+	}
+	return &resp
 }
 
 func (*listenerSuite) TestRunErrors(c *C) {
 	sockFdChan, restoreOpen := listener.MockOsOpenWithSockets()
 	defer restoreOpen()
 
-	restoreIoctl := listener.MockNotifyIoctlWithReadWrite()
-	defer restoreIoctl()
-
-	order := arch.Endian()
+	recvChan, _, restoreEpollIoctl := listener.MockEpollWaitNotifyIoctl()
+	defer restoreEpollIoctl()
 
 	for _, testCase := range []struct {
 		msg msgNotificationFile
@@ -306,22 +454,309 @@ func (*listenerSuite) TestRunErrors(c *C) {
 		c.Assert(err, IsNil)
 		notifySocket := <-sockFdChan
 
-		var lt tomb.Tomb
-		lt.Go(func() error {
-			l.Run(&lt)
-			return nil
-		})
+		var t tomb.Tomb
+		t.Go(l.Run)
 
-		buf := bytes.NewBuffer(make([]byte, 0, testCase.msg.Length))
-		err = binary.Write(buf, order, testCase.msg)
-		c.Check(err, IsNil)
-		unix.Write(notifySocket, buf.Bytes())
+		buf := testCase.msg.MarshalBinary(c)
+		recvChan <- buf
 
-		eChanResult := <-l.E
-		c.Assert(eChanResult, ErrorMatches, testCase.err)
+		select {
+		case r := <-l.Reqs():
+			c.Check(r, IsNil, Commentf("should not have received non-nil request; expected error: %v", testCase.err))
+		case <-t.Dying():
+		}
+		err = t.Wait()
+		c.Check(err, ErrorMatches, testCase.err)
 
 		err = l.Close()
-		c.Assert(err, IsNil)
+		c.Check(err, Equals, listener.ErrAlreadyClosed)
+
 		unix.Close(notifySocket)
 	}
+}
+
+func (*listenerSuite) TestRunMultipleTimes(c *C) {
+	sockFdChan, restoreOpen := listener.MockOsOpenWithSockets()
+	defer restoreOpen()
+
+	restoreEpoll := listener.MockEpollWait(func(l *listener.Listener) ([]epoll.Event, error) {
+		<-l.Dying()
+		return nil, l.Err()
+	})
+	defer restoreEpoll()
+
+	restoreIoctl := listener.MockNotifyIoctl(func(fd uintptr, req notify.IoctlRequest, buf notify.IoctlRequestBuffer) ([]byte, error) {
+		c.Assert(req, Equals, notify.APPARMOR_NOTIF_SET_FILTER)
+		return make([]byte, 0), nil
+	})
+	defer restoreIoctl()
+
+	var t tomb.Tomb
+	l, err := listener.Register()
+	c.Assert(err, IsNil)
+	defer func() {
+		c.Check(l.Close(), IsNil)
+		c.Check(t.Wait(), Equals, listener.ErrClosed)
+	}()
+	<-sockFdChan
+
+	t.Go(l.Run)
+
+	// Make sure the spawned goroutine starts Run() first
+	time.Sleep(10 * time.Millisecond)
+
+	err = l.Run()
+	c.Assert(err, Equals, listener.ErrAlreadyRun)
+}
+
+// Test that calling Run() after Close() does not cause a panic, as Close()
+// kills the internal tomb
+func (*listenerSuite) TestCloseThenRun(c *C) {
+	sockFdChan, restoreOpen := listener.MockOsOpenWithSockets()
+	defer restoreOpen()
+
+	restoreIoctl := listener.MockNotifyIoctl(func(fd uintptr, req notify.IoctlRequest, buf notify.IoctlRequestBuffer) ([]byte, error) {
+		c.Assert(req, Equals, notify.APPARMOR_NOTIF_SET_FILTER)
+		return make([]byte, 0), nil
+	})
+	defer restoreIoctl()
+
+	l, err := listener.Register()
+	c.Assert(err, IsNil)
+	defer func() {
+		c.Assert(l.Close(), Equals, listener.ErrAlreadyClosed)
+	}()
+	<-sockFdChan
+
+	err = l.Close()
+	c.Assert(err, IsNil)
+
+	err = l.Run()
+	c.Assert(err, Equals, listener.ErrAlreadyClosed)
+}
+
+// Test that waiters send back a deny message if the tomb dies as a result of
+// an error, and that that message makes it through the notify socket before it
+// is closed.
+func (*listenerSuite) TestRunTombDying(c *C) {
+	sockFdChan, restoreOpen := listener.MockOsOpenWithSockets()
+	defer restoreOpen()
+
+	// Using many sockets can be flakey in this test, so use channels instead
+	recvChan, sendChan, restoreEpollIoctl := listener.MockEpollWaitNotifyIoctl()
+	defer restoreEpollIoctl()
+
+	var t tomb.Tomb
+	l, err := listener.Register()
+	c.Assert(err, IsNil)
+	notifySocket := <-sockFdChan
+	defer unix.Close(notifySocket)
+
+	t.Go(l.Run)
+
+	id := uint64(0x1234)
+	label := "snap.foo.bar"
+	path := "/home/Documents/foo"
+	aBits := uint32(0b1010)
+	dBits := uint32(0b0101)
+
+	msg := newMsgNotificationFile(id, label, path, aBits, dBits)
+	buf, err := msg.MarshalBinary()
+	c.Assert(err, IsNil)
+	recvChan <- buf
+
+	select {
+	case <-l.Reqs():
+	case <-l.Dying():
+		c.Fatalf("listener encountered unexpected error: %v", l.Err())
+	}
+
+	// Build desired message (denial)
+	resp := newMsgNotificationResponse(id, aBits, dBits)
+	desiredBuf, err := resp.MarshalBinary()
+	c.Assert(err, IsNil)
+
+	// Cause an internal error by sending a bad message
+	badBuf := []byte("foo")
+	select {
+	case <-l.Dying():
+		c.Fatalf("listener should not have encountered an error yet: %v", l.Err())
+	case received := <-sendChan:
+		c.Check(received, DeepEquals, desiredBuf, Commentf("prematurely received response that doesn't matched the desired denial response"))
+		c.Check(received, Not(DeepEquals), desiredBuf, Commentf("prematurely received the desired denial response"))
+		c.Fatalf("should not receive response from send channel until after bad message is sent: %v", received)
+	case recvChan <- badBuf:
+		// sent bad message, should now trigger failure
+	}
+
+	received := <-sendChan
+	c.Assert(received, DeepEquals, desiredBuf)
+
+	err = t.Wait()
+	c.Assert(err, ErrorMatches, "cannot unmarshal apparmor message header: unexpected EOF")
+}
+
+func (*listenerSuite) TestRunListenerClosed(c *C) {
+	sockFdChan, restoreOpen := listener.MockOsOpenWithSockets()
+	defer restoreOpen()
+
+	recvChan, sendChan, restoreEpollIoctl := listener.MockEpollWaitNotifyIoctl()
+	defer restoreEpollIoctl()
+
+	l, err := listener.Register()
+	c.Assert(err, IsNil)
+	defer func() {
+		err = l.Close()
+		c.Assert(err, Equals, listener.ErrAlreadyClosed)
+	}()
+
+	notifySocket := <-sockFdChan
+	defer unix.Close(notifySocket)
+
+	var t tomb.Tomb
+	t.Go(l.Run)
+
+	id := uint64(1234)
+	label := "snap.foo.bar"
+	path := "/home/Documents/foo"
+
+	aBits := uint32(0b1010)
+	dBits := uint32(0b0101)
+
+	msg := newMsgNotificationFile(id, label, path, aBits, dBits)
+	buf, err := msg.MarshalBinary()
+	c.Assert(err, IsNil)
+	recvChan <- buf
+
+	var req *listener.Request
+	select {
+	case req = <-l.Reqs():
+		c.Assert(req.PID(), Equals, msg.Pid)
+		c.Assert(req.Label(), Equals, label)
+		c.Assert(req.SubjectUID(), Equals, msg.SUID)
+		c.Assert(req.Path(), Equals, path)
+		c.Assert(req.Class(), Equals, notify.AA_CLASS_FILE)
+		perm, ok := req.Permission().(notify.FilePermission)
+		c.Assert(ok, Equals, true)
+		c.Assert(perm, Equals, notify.FilePermission(dBits))
+	case <-l.Dying():
+		c.Fatalf("listener encountered unexpected error: %v", l.Err())
+	}
+
+	go func() {
+		// Check that listener sends deny response as a result of being closed
+		resp := newMsgNotificationResponse(id, aBits, dBits)
+		desiredBuf, err := resp.MarshalBinary()
+		c.Assert(err, IsNil)
+
+		received := <-sendChan
+		c.Assert(received, DeepEquals, desiredBuf)
+	}()
+
+	// Close listener before sending back allow response
+	err = l.Close()
+	c.Assert(err, IsNil)
+
+	err = req.Reply(true)
+	c.Assert(err, IsNil)
+
+	err = t.Wait()
+	c.Assert(err, Equals, listener.ErrClosed)
+}
+
+func (*listenerSuite) TestRunConcurrency(c *C) {
+	sockFdChan, restoreOpen := listener.MockOsOpenWithSockets()
+	defer restoreOpen()
+
+	recvChan, sendChan, restoreEpollIoctl := listener.MockEpollWaitNotifyIoctl()
+	defer restoreEpollIoctl()
+
+	l, err := listener.Register()
+	c.Assert(err, IsNil)
+	defer func() {
+		err = l.Close()
+		c.Check(err, Equals, listener.ErrAlreadyClosed)
+	}()
+	notifySocket := <-sockFdChan
+	defer unix.Close(notifySocket)
+
+	var t tomb.Tomb
+	t.Go(l.Run)
+
+	label := "snap.foo.bar"
+	path := "/home/Documents/foo"
+	reqAllow := uint32(0b1010)
+	reqDeny := uint32(0b0101)
+
+	msg := newMsgNotificationFile(0, label, path, reqAllow, reqDeny)
+
+	respAllow := uint32(0b1111)
+	respDeny := uint32(0b0000)
+	resp := newMsgNotificationResponse(0, respAllow, respDeny)
+
+	templateBuf, err := resp.MarshalBinary()
+	c.Assert(err, IsNil)
+	expectedLen := len(templateBuf)
+
+	closeTimeout := 50 * time.Millisecond
+	closeTimer := time.NewTimer(closeTimeout)
+	createTimer := time.NewTimer(2 * closeTimeout)
+
+	safeToReturn := make(chan interface{})
+	go func() {
+		// create requests until createTimer expires
+		id := uint64(0)
+		for {
+			id += 1
+			msg.ID = id
+			buf, err := msg.MarshalBinary()
+			c.Assert(err, IsNil)
+			select {
+			case <-createTimer.C:
+			case recvChan <- buf:
+				continue
+			}
+			break
+		}
+		close(safeToReturn)
+		c.Logf("total requests sent: %d", id)
+	}()
+
+	go func() {
+		// reply to all requests as they are received, until l.Reqs() closes
+		replyCount := 0
+		for req := range l.Reqs() {
+			err := req.Reply(true)
+			c.Check(err, IsNil)
+			replyCount += 1
+		}
+		c.Logf("total replies sent: %d", replyCount)
+	}()
+
+	go func() {
+		// Consume responses from the sendChan (in place of reading from the
+		// actual FD). No guarantee of order, so just check that the length is
+		// correct, rather than picking apart the buffer to throw out the ID and
+		// compare the rest.
+		responseCount := 0
+		for response := range sendChan {
+			c.Check(response, HasLen, expectedLen)
+			responseCount += 1
+		}
+		c.Logf("total responses received: %d", responseCount)
+	}()
+
+	<-closeTimer.C
+
+	// Check that no error has yet occurred
+	c.Check(l.Err(), Equals, tomb.ErrStillAlive)
+
+	// Check that closing the listener while creating and replying to requests
+	// does not cause a panic (e.g. by writing to a closed channel)
+	c.Check(l.Close(), IsNil)
+	c.Check(t.Wait(), Equals, listener.ErrClosed)
+
+	// Restoring functions closes channels, so make sure to wait until done
+	// creating requests before closing the channels.
+	<-safeToReturn
 }


### PR DESCRIPTION
This PR backports the listener package from the [WIP prompting branch](https://github.com/olivercalder/snapd/tree/prompting). The listener listens for and responds to access request messages from apparmor.