### PR TITLE
interfaces/microstack-support: read access to /proc/task/sched{,stat}

### DIFF
--- a/interfaces/builtin/microstack_support.go
+++ b/interfaces/builtin/microstack_support.go
@@ -119,6 +119,8 @@ const microStackSupportConnectedPlugAppArmor = `
 @{PROC}/mtrr w,
 @{PROC}/@{pids}/environ r,
 @{PROC}/@{pids}/sched r,
+@{PROC}/@{pids}/task/@{tid}/sched r,
+@{PROC}/@{pids}/task/@{tid}/schedstat r,
 
 @{PROC}/*/status r,
 


### PR DESCRIPTION
microstack requires read access to ``@{PROC}/*/{,task/*/}sched`` and ``@{PROC}/*/{,task/*/}schedstat`` to allow virsh to read cpu statistics of the instances.

Without this rule, ``openstack-hypervisor.virsh domstats <id>`` does not print cpu statistics, to be specific ``vcpu.<id>.time``, ``vcpu.<id>.wait``.

Apparmor deny rule in dmesg:
```
[98847.604617] audit: type=1400 audit(1693470840.357:1499):  apparmor="DENIED" operation="open" profile="snap.openstack-hypervisor.libvirtd" name="/proc/2014588/task/2014595/sched" pid=3668724 comm="rpc-libvirtd" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
```
This rule is also required by ceilometer service running on the openstack-hypervisor snap which queries libvirt for the cpu/memory/disk statistics of the instances running on hypervisor [1].

[1] https://opendev.org/openstack/ceilometer/src/commit/d31d4ed3574a5d19fe4b09ab2c227dba64da170a/ceilometer/compute/virt/libvirt/inspector.py#L222-L234

