### PR TITLE
i/b/microceph: allow more access for microceph-support

### DIFF
--- a/interfaces/builtin/microceph.go
+++ b/interfaces/builtin/microceph.go
@@ -37,9 +37,8 @@ const microcephConnectedPlugAppArmor = `
 /dev/bcache[0-9]{,[0-9],[0-9][0-9]} rwk,                   # bcache (up to 1000 devices)
 # Access to individual partitions
 /dev/hd[a-t][0-9]{,[0-9],[0-9][0-9]} rwk,                  # IDE, MFM, RLL
-/dev/sd{,[a-h]}[a-z][0-9]{,[0-9],[0-9][0-9]} rwk,          # SCSI
-/dev/sdi[a-v][0-9]{,[0-9],[0-9][0-9]} rwk,                 # SCSI continued
-/dev/vd[a-z][0-9]{,[0-9],[0-9][0-9]} rwk,                  # virtio
+/dev/sd{,[a-z]}[a-z][0-9]{,[0-9],[0-9][0-9]} rwk,          # SCSI
+/dev/vd{,[a-z]}[a-z][0-9]{,[0-9],[0-9][0-9]} rwk,          # virtio
 /dev/nvme{[0-9],[1-9][0-9]}n{[1-9],[1-5][0-9],6[0-3]}p[0-9]{,[0-9],[0-9][0-9]} rwk, # NVMe
 # Allow managing of rbd-backed block devices
 /sys/bus/rbd/add rwk,                                      # add block dev

--- a/interfaces/builtin/microceph.go
+++ b/interfaces/builtin/microceph.go
@@ -32,6 +32,21 @@ const microcephConnectedPlugAppArmor = `
 # Description: allow access to the MicroCeph control socket.
 
 /var/snap/microceph/common/state/control.socket rw,
+
+# Allow bcache devices to be accessed since DM devices may be set up on top of those.
+/dev/bcache[0-9]{,[0-9],[0-9][0-9]} rwk,                   # bcache (up to 1000 devices)
+# Access to individual partitions
+/dev/hd[a-t][0-9]{,[0-9],[0-9][0-9]} rwk,                  # IDE, MFM, RLL
+/dev/sd{,[a-h]}[a-z][0-9]{,[0-9],[0-9][0-9]} rwk,          # SCSI
+/dev/sdi[a-v][0-9]{,[0-9],[0-9][0-9]} rwk,                 # SCSI continued
+/dev/vd[a-z][0-9]{,[0-9],[0-9][0-9]} rwk,                  # virtio
+# Allow managing of rbd-backed block devices
+/sys/bus/rbd/add rwk,                                      # add block dev
+/sys/bus/rbd/remove rwk,                                   # remove block dev
+/sys/bus/rbd/add_single_major rwk,                         # add single major dev
+/sys/bus/rbd/remove_single_major rwk,                      # remove single major dev
+/sys/bus/rbd/supported_features r,                         # display enabled features
+/sys/bus/rbd/devices/** rwk,                               # manage individual block devs
 `
 
 const microcephConnectedPlugSecComp = `

--- a/interfaces/builtin/microceph.go
+++ b/interfaces/builtin/microceph.go
@@ -40,6 +40,7 @@ const microcephConnectedPlugAppArmor = `
 /dev/sd{,[a-h]}[a-z][0-9]{,[0-9],[0-9][0-9]} rwk,          # SCSI
 /dev/sdi[a-v][0-9]{,[0-9],[0-9][0-9]} rwk,                 # SCSI continued
 /dev/vd[a-z][0-9]{,[0-9],[0-9][0-9]} rwk,                  # virtio
+/dev/nvme{[0-9],[1-9][0-9]}n{[1-9],[1-5][0-9],6[0-3]}p[0-9]{,[0-9],[0-9][0-9]} rwk, # NVMe
 # Allow managing of rbd-backed block devices
 /sys/bus/rbd/add rwk,                                      # add block dev
 /sys/bus/rbd/remove rwk,                                   # remove block dev


### PR DESCRIPTION
Allow more types of block devices to be added as an OSD (bcache, indiv. partitions)

Allow access to the rbd sysfs controls for managing rbd-backed block devices (cf.
https://docs.kernel.org/admin-guide/abi-testing.html#abi-file-testing-sysfs-bus-rbd)
