### PR TITLE
store: use as much from snap-yaml as possible if available

### DIFF
--- a/store/details_v2.go
+++ b/store/details_v2.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2021-2022 Canonical Ltd
+ * Copyright (C) 2021-2023 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -269,6 +269,13 @@ func copyNonZeroFrom(src, dst *storeSnap) {
 
 func infoFromStoreSnap(d *storeSnap) (*snap.Info, error) {
 	info := &snap.Info{}
+	// if snap-yaml is available fill in as much as possible from there
+	if len(d.SnapYAML) != 0 {
+		if parsedYamlInfo, err := snap.InfoFromSnapYaml([]byte(d.SnapYAML)); err == nil {
+			info = parsedYamlInfo
+		}
+	}
+
 	info.RealName = d.Name
 	info.Revision = snap.R(d.Revision)
 	info.SnapID = d.SnapID
@@ -319,28 +326,6 @@ func infoFromStoreSnap(d *storeSnap) (*snap.Info, error) {
 		info.LegacyWebsite = d.Website
 	}
 	info.StoreURL = d.StoreURL
-
-	// fill in the plug/slot data etc
-	if rawYamlInfo, err := snap.InfoFromSnapYaml([]byte(d.SnapYAML)); err == nil {
-		if info.Plugs == nil {
-			info.Plugs = make(map[string]*snap.PlugInfo)
-		}
-		for k, v := range rawYamlInfo.Plugs {
-			info.Plugs[k] = v
-			info.Plugs[k].Snap = info
-		}
-		if info.Slots == nil {
-			info.Slots = make(map[string]*snap.SlotInfo)
-		}
-		for k, v := range rawYamlInfo.Slots {
-			info.Slots[k] = v
-			info.Slots[k].Snap = info
-		}
-		for _, s := range rawYamlInfo.Assumes {
-			info.Assumes = append(info.Assumes, s)
-		}
-		info.SnapProvenance = rawYamlInfo.SnapProvenance
-	}
 
 	// convert prices
 	if len(d.Prices) > 0 {

--- a/store/details_v2_test.go
+++ b/store/details_v2_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2018-2022 Canonical Ltd
+ * Copyright (C) 2018-2023 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -130,7 +130,7 @@ const (
   },
   "revision": 21,
   "snap-id": "XYZEfjn4WJYnm0FzDKwqqRZZI77awQEV",
-  "snap-yaml": "name: test-snapd-content-plug\nversion: 1.0\nassumes: [snapd2.49]\napps:\n    content-plug:\n        command: bin/content-plug\n        plugs: [shared-content-plug]\nplugs:\n    shared-content-plug:\n        interface: content\n        target: import\n        content: mylib\n        default-provider: test-snapd-content-slot\nslots:\n    shared-content-slot:\n        interface: content\n        content: mylib\n        read:\n            - /\nprovenance: prov\n",
+  "snap-yaml": "name: test-snapd-content-plug\nversion: 1.0\nassumes: [snapd2.49]\napps:\n    user-svc:\n        command: bin/user-svc\n        daemon-scope: user\n        daemon: simple\n    content-plug:\n        command: bin/content-plug\n        plugs: [shared-content-plug]\nplugs:\n    shared-content-plug:\n        interface: content\n        target: import\n        content: mylib\n        default-provider: test-snapd-content-slot\nslots:\n    shared-content-slot:\n        interface: content\n        content: mylib\n        read:\n            - /\nprovenance: prov\n",
   "store-url": "https://snapcraft.io/thingy",
   "summary": "useful thingy",
   "title": "This Is The Most Fantastical Snap of Thingy",
@@ -191,8 +191,6 @@ func (s *detailsV2Suite) TestInfoFromStoreSnapSimpleAndLegacy(c *C) {
 			Sha3_384:    "b691f6dde3d8022e4db563840f0ef82320cb824b6292ffd027dbc838535214dac31c3512c619beaf73f1aeaf35ac62d5",
 			Size:        85291008,
 		},
-		Plugs:         make(map[string]*snap.PlugInfo),
-		Slots:         make(map[string]*snap.SlotInfo),
 		LegacyWebsite: "http://example.com/core",
 		StoreURL:      "https://snapcraft.io/core",
 	})
@@ -213,7 +211,10 @@ func (s *detailsV2Suite) TestInfoFromStoreSnap(c *C) {
 	// clear recursive bits
 	info2.Plugs = nil
 	info2.Slots = nil
+	info2.Apps = nil
+	info2.Hooks = nil
 	c.Check(&info2, DeepEquals, &snap.Info{
+		SuggestedName: "test-snapd-content-plug",
 		Architectures: []string{"amd64"},
 		Assumes:       []string{"snapd2.49"},
 		Base:          "base-18",
@@ -277,6 +278,11 @@ func (s *detailsV2Suite) TestInfoFromStoreSnap(c *C) {
 		},
 		StoreURL:       "https://snapcraft.io/thingy",
 		SnapProvenance: "prov",
+		// empty
+		BadInterfaces:   map[string]string{},
+		SystemUsernames: map[string]*snap.SystemUsernameInfo{},
+		OriginalLinks:   map[string][]string{},
+		LegacyAliases:   map[string]*snap.AppInfo{},
 	})
 
 	// validate the plugs/slots
@@ -291,8 +297,13 @@ func (s *detailsV2Suite) TestInfoFromStoreSnap(c *C) {
 	slot := info.Slots["shared-content-slot"]
 	c.Check(slot.Name, Equals, "shared-content-slot")
 	c.Check(slot.Snap, Equals, info)
-	c.Check(slot.Apps, HasLen, 1)
+	c.Check(slot.Apps, HasLen, 2)
 	c.Check(slot.Apps["content-plug"].Command, Equals, "bin/content-plug")
+
+	// validate apps
+	c.Check(info.Apps["user-svc"].Command, Equals, "bin/user-svc")
+	c.Check(info.Apps["user-svc"].Daemon, Equals, "simple")
+	c.Check(info.Apps["user-svc"].DaemonScope, Equals, snap.UserDaemon)
 
 	// private
 	err = json.Unmarshal([]byte(strings.Replace(thingyStoreJSON, `"private": false`, `"private": true`, 1)), &snp)
@@ -306,26 +317,19 @@ func (s *detailsV2Suite) TestInfoFromStoreSnap(c *C) {
 
 	// check that up to few exceptions info is filled
 	expectedZeroFields := []string{
-		"SuggestedName",
 		"InstanceKey",
 		"OriginalTitle",
 		"OriginalSummary",
 		"OriginalDescription",
-		"OriginalLinks",
 		"Environment",
 		"LicenseAgreement", // XXX go away?
 		"LicenseVersion",   // XXX go away?
-		"Apps",
-		"LegacyAliases",
-		"Hooks",
-		"BadInterfaces",
 		"Broken",
 		"MustBuy",
 		"Channels", // handled at a different level (see TestInfo)
 		"Tracks",   // handled at a different level (see TestInfo)
 		"Layout",
 		"SideInfo.Channel",
-		"SystemUsernames",
 		"LegacyWebsite",
 		"Components",
 	}


### PR DESCRIPTION
then applies any store only/store override data

this should help make any pre-download checks/validations work correctly
