### PR TITLE
tests: fix how snapd is restored in snapd-homedirs-vendored

### DIFF
--- a/tests/main/snapd-homedirs-vendored/task.yaml
+++ b/tests/main/snapd-homedirs-vendored/task.yaml
@@ -25,6 +25,12 @@ restore: |
     userdel -f --remove "$USERNAME"
     rm -rf /remote/users
 
+    # Reinstall the original snap
+    #shellcheck source=tests/lib/pkgdb.sh
+    . "$TESTSLIB/pkgdb.sh"
+    distro_purge_package snapd
+    distro_install_build_snapd
+
 debug: |
     # output custom snap-confine snippets
     ls -l /var/lib/snapd/apparmor/snap-confine/


### PR DESCRIPTION
This fix is needed because the system is not remaining in the original state after the test is executed. For example if the test classic-prepare-image is executed after that one it fails with the following error

    + echo 'Wait for seeding to be done' Wait for seeding to be done
    + snap wait system seed.loaded -----

run this command line to reproduce the error: 
> spread-debug -debug -order -workers 1 google:ubuntu-22.04-64:tests/main/snapd-homedirs-vendored google:ubuntu-22.04-64:tests/main/classic-prepare-image