### PR TITLE
tests: fix system-usernames-missing-user multiline MATCH

### DIFF
--- a/tests/main/system-usernames-missing-user/task.yaml
+++ b/tests/main/system-usernames-missing-user/task.yaml
@@ -25,4 +25,4 @@ execute: |
     getent group snap_daemon || exit 1
 
     echo "Then the snap cannot be installed"
-    snap install --edge test-snapd-daemon-user 2>&1 | MATCH 'cannot add user/group "snap_daemon": group exists and user does not'
+    snap install --edge test-snapd-daemon-user 2>&1 | tr '\n' ' ' | tr -s ' ' | MATCH 'cannot add user/group "snap_daemon": group exists and user does not'


### PR DESCRIPTION
This test failed with:
```
2023-09-05T12:51:25.0650751Z + echo 'Then the snap cannot be installed'
2023-09-05T12:51:25.0651128Z Then the snap cannot be installed
2023-09-05T12:51:25.0651591Z + MATCH 'cannot add user/group "snap_daemon": group exists and user does not'
2023-09-05T12:51:25.0652024Z + snap install --edge test-snapd-daemon-user
2023-09-05T12:51:25.0652503Z grep error: pattern not found, got:
2023-09-05T12:51:25.0653135Z error: cannot install "test-snapd-daemon-user": cannot ensure users for snap
2023-09-05T12:51:25.0653797Z        "test-snapd-daemon-user" required system username "snap_daemon": cannot
2023-09-05T12:51:25.0654381Z        add user/group "snap_daemon": group exists and user does not
```
This is because of the line breaks that are added in the error and that MATCH only matces a single line. This commit fixes it by changing the \n to normal spaces in the error message before doing the match.
