### PR TITLE
apparmor: simplify IoctlRequestBuffer

### DIFF
--- a/sandbox/apparmor/notify/ioctl_test.go
+++ b/sandbox/apparmor/notify/ioctl_test.go
@@ -32,7 +32,7 @@ func (*ioctlSuite) TestIoctlRequestBuffer(c *C) {
 
 func (*ioctlSuite) TestBytesToIoctlRequestBuffer(c *C) {
 	buf := []byte("foo")
-	ioctlBuf := notify.BytesToIoctlRequestBuffer(buf)
+	ioctlBuf := notify.IoctlRequestBuffer(buf)
 	c.Assert(ioctlBuf.Bytes(), DeepEquals, buf)
 }
 


### PR DESCRIPTION
The `IoctlRequestBuffer` is currently a struct with a single `[]byte`. This means it might equally be just an alias type with the needed methods.

A minimal draft mostly to get early feedback, this feels cleaner to me but maybe it's just personal. Once we agree about this direction we can trivially also remove `func (b IoctlRequestBuffer) Bytes() []byte` and Len() (if we want).