### PR TITLE
o/d/handlers_install.go: unlock state when sealing keys

### DIFF
--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -528,13 +528,12 @@ func makeRunnableSystem(model *asserts.Model, bootWith *BootableSet, sealer *Tru
 			HasFDESetupHook: hasHook,
 			FactoryReset:    makeOpts.AfterDataReset,
 			SeedDir:         makeOpts.SeedDir,
+			Unlocker:        makeOpts.Unlocker,
 		}
 		if makeOpts.Standalone {
 			flags.SnapsDir = snapBlobDir
 		}
 
-		locker := makeOpts.Unlocker()
-		defer locker()
 		// seal the encryption key to the parameters specified in modeenv
 		if err := sealKeyToModeenv(sealer.dataEncryptionKey, sealer.saveEncryptionKey, model, modeenv, flags); err != nil {
 			return err

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -122,6 +122,9 @@ type sealKeyToModeenvFlags struct {
 	// SeedDir is the path where to find mounted seed with
 	// essential snaps.
 	SeedDir string
+	// Unlocker is a function that is called before sealing keys
+	// on TPM. And it should return a function to be called after.
+	Unlocker func() func()
 }
 
 // sealKeyToModeenvImpl seals the supplied keys to the parameters specified
@@ -145,6 +148,8 @@ func sealKeyToModeenvImpl(key, saveKey keys.EncryptionKey, model *asserts.Model,
 		return sealKeyToModeenvUsingFDESetupHook(key, saveKey, model, modeenv, flags)
 	}
 
+	locker := flags.Unlocker()
+	defer locker()
 	return sealKeyToModeenvUsingSecboot(key, saveKey, model, modeenv, flags)
 }
 

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -318,6 +318,7 @@ func (s *sealSuite) TestSealKeyToModeenv(c *C) {
 
 		err = boot.SealKeyToModeenv(myKey, myKey2, model, modeenv, boot.MockSealKeyToModeenvFlags{
 			FactoryReset: tc.factoryReset,
+			Unlocker:     func() func() { return func() {} },
 		})
 		c.Check(pcrHandleOfKeyCalls, Equals, tc.expPCRHandleOfKeyCalls)
 		c.Check(provisionCalls, Equals, tc.expProvisionCalls)

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -62,7 +62,7 @@ import (
 var (
 	bootMakeBootablePartition            = boot.MakeBootablePartition
 	bootMakeRunnable                     = boot.MakeRunnableSystem
-	bootMakeRunnableStandalone           = boot.MakeRunnableStandaloneSystem
+	bootMakeRunnableStandalone           = boot.MakeRunnableStandaloneSystemUnlocker
 	bootMakeRunnableAfterDataReset       = boot.MakeRunnableSystemAfterDataReset
 	bootEnsureNextBootToRunMode          = boot.EnsureNextBootToRunMode
 	installRun                           = install.Run
@@ -1051,8 +1051,14 @@ func (m *DeviceManager) doInstallFinish(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
+	unlocker := func() func() {
+		st.Unlock()
+		return func() {
+			st.Lock()
+		}
+	}
 	logger.Debugf("making the installed system runnable for system label %s", systemLabel)
-	if err := bootMakeRunnableStandalone(sys.Model, bootWith, trustedInstallObserver); err != nil {
+	if err := bootMakeRunnableStandalone(sys.Model, bootWith, trustedInstallObserver, unlocker); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Alternative to #13146

This should in theory fix fix `tests/nested/manual/muinstaller-real:encrypted`

Unfortunately, this is blocked by https://github.com/snapcore/snapd/pull/13144 and https://github.com/canonical/ubuntu-image/pull/136