### PR TITLE
tests: increase memory limit for snapd during the tests to 200M

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -262,7 +262,7 @@ prepare_memory_limit_override() {
         # systemd is backwards compatible so the limit is still set.
         cat <<EOF > /etc/systemd/system/snapd.service.d/memory-max.conf
 [Service]
-MemoryLimit=150M
+MemoryLimit=200M
 EOF
     fi
     # the service setting may have changed in the service so we need


### PR DESCRIPTION
Tests are flaky with the MemoryMax=150M, we saw recently failures around e.g.the `tests/main/microk8s-smoke:edge` test, e.g.:
```
2023-09-06T07:36:43.0524017Z [  560.495582] snapd invoked oom-killer: gfp_mask=0x101cca(GFP_HIGHUSER_MOVABLE|__GFP_WRITE), order=0, oom_score_adj=-900
```
Lets increase the memory limit to make things less flaky.
