### PR TITLE
interfaces/builtin: fix custom-device udev KERNEL values

### DIFF
--- a/interfaces/builtin/custom_device.go
+++ b/interfaces/builtin/custom_device.go
@@ -31,6 +31,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/udev"
 	"github.com/snapcore/snapd/interfaces/utils"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/strutil"
 )
@@ -467,6 +468,7 @@ func (iface *customDeviceInterface) UDevConnectedPlug(spec *udev.Specification, 
 			// emit a default rule for this device name.
 			// validateUDevTaggingRule() already checked that the
 			// basename rule only applies to only one device.
+			logger.Noticef(`custom-device: applying "udev-tagging" rule with kernel "%s" to device "/dev/%s", since no device with path "/dev/%s"`, baseName, deviceName, baseName)
 			continue
 		}
 

--- a/interfaces/builtin/custom_device.go
+++ b/interfaces/builtin/custom_device.go
@@ -145,33 +145,6 @@ func (iface *customDeviceInterface) validateUDevValueMap(value interface{}) erro
 	return nil
 }
 
-func (iface *customDeviceInterface) validateUDevDevicesUniqueBasenames(devices []string) error {
-	basenames := make(map[string][]string, len(devices))
-	var duplicateBasenames []string
-	for _, devicePath := range devices {
-		deviceName := filepath.Base(devicePath)
-		if len(basenames[deviceName]) == 1 {
-			duplicateBasenames = append(duplicateBasenames, deviceName)
-		}
-		basenames[deviceName] = append(basenames[deviceName], devicePath)
-	}
-	if len(duplicateBasenames) == 0 {
-		return nil
-	}
-	var duplicatesOutput []string
-	for _, deviceName := range duplicateBasenames {
-		duplicatesOutput = append(duplicatesOutput, fmt.Sprintf(`"%s": ["%s"]`, deviceName, strings.Join(basenames[deviceName], `", "`)))
-	}
-	return fmt.Errorf(`custom-device specified devices have duplicate basenames: {%s}`, strings.Join(duplicatesOutput, ", "))
-}
-
-func (iface *customDeviceInterface) validateKernelDeviceNameIsBasename(deviceName string) error {
-	if deviceName != filepath.Base(deviceName) {
-		return fmt.Errorf(`kernel device name "%s" must be a basename`, deviceName)
-	}
-	return nil
-}
-
 func (iface *customDeviceInterface) validateUDevTaggingRule(rule map[string]interface{}, devices []string) error {
 	hasKernelTag := false
 	for key, value := range rule {

--- a/interfaces/builtin/custom_device_test.go
+++ b/interfaces/builtin/custom_device_test.go
@@ -314,7 +314,7 @@ apps:
 		},
 		{
 			"devices: [/dev/dir1/foo, /dev/dir2/foo]\n  udev-tagging:\n    - kernel: foo",
-			`custom-device "udev-tagging" invalid "kernel" tag: "foo" matches more than one specified device`,
+			`custom-device "udev-tagging" invalid "kernel" tag: "foo" matches more than one specified device: \["/dev/dir1/foo" "/dev/dir2/foo"\]`,
 		},
 		{
 			"devices: [/dev/null]\n  udev-tagging:\n    - attributes: foo",

--- a/interfaces/builtin/custom_device_test.go
+++ b/interfaces/builtin/custom_device_test.go
@@ -412,6 +412,8 @@ slots:
     - /dev/dma_heap/qcom,qseecom
     - /dev/bar
     - /dev/foo/bar
+    - /dev/dir1/baz
+    - /dev/dir2/baz
   read-devices:
     - /dev/js*
   %s
@@ -437,6 +439,9 @@ apps:
 				{`KERNEL`: `"qcom,qseecom"`},
 				{`KERNEL`: `"bar"`},
 				{`KERNEL`: `"foo/bar"`},
+				{`KERNEL`: `"dir1/baz"`},
+				{`KERNEL`: `"dir2/baz"`},
+				{`KERNEL`: `"baz"`},
 			},
 		},
 		{
@@ -450,6 +455,9 @@ apps:
 				{`KERNEL`: `"qcom,qseecom"`},
 				{`KERNEL`: `"bar"`},
 				{`KERNEL`: `"foo/bar"`},
+				{`KERNEL`: `"dir1/baz"`},
+				{`KERNEL`: `"dir2/baz"`},
+				{`KERNEL`: `"baz"`},
 			},
 		},
 		{
@@ -469,6 +477,9 @@ apps:
 				{`KERNEL`: `"qcom,qseecom"`},
 				{`KERNEL`: `"bar"`},
 				{`KERNEL`: `"foo/bar"`},
+				{`KERNEL`: `"dir1/baz"`},
+				{`KERNEL`: `"dir2/baz"`},
+				{`KERNEL`: `"baz"`},
 			},
 		},
 		{
@@ -494,6 +505,9 @@ apps:
 				{`KERNEL`: `"qcom,qseecom"`},
 				{`KERNEL`: `"bar"`},
 				{`KERNEL`: `"foo/bar"`},
+				{`KERNEL`: `"dir1/baz"`},
+				{`KERNEL`: `"dir2/baz"`},
+				{`KERNEL`: `"baz"`},
 			},
 		},
 		{
@@ -507,6 +521,9 @@ apps:
 				{`KERNEL`: `"dma_heap/qcom,qseecom"`},
 				{`KERNEL`: `"bar"`},
 				{`KERNEL`: `"foo/bar"`},
+				{`KERNEL`: `"dir1/baz"`},
+				{`KERNEL`: `"dir2/baz"`},
+				{`KERNEL`: `"baz"`},
 			},
 		},
 		{
@@ -520,6 +537,9 @@ apps:
 				{`KERNEL`: `"qcom,qseecom"`},
 				{`KERNEL`: `"bar"`},
 				{`KERNEL`: `"foo/bar"`},
+				{`KERNEL`: `"dir1/baz"`},
+				{`KERNEL`: `"dir2/baz"`},
+				{`KERNEL`: `"baz"`},
 			},
 		},
 		// if there happens to be a full device path which matches the
@@ -537,6 +557,9 @@ apps:
 				{`KERNEL`: `"qcom,qseecom"`},
 				{`KERNEL`: `"bar"`},
 				{`KERNEL`: `"foo/bar"`},
+				{`KERNEL`: `"dir1/baz"`},
+				{`KERNEL`: `"dir2/baz"`},
+				{`KERNEL`: `"baz"`},
 			},
 		},
 		{
@@ -551,6 +574,50 @@ apps:
 				{`KERNEL`: `"qcom,qseecom"`},
 				{`KERNEL`: `"bar"`},
 				{`KERNEL`: `"foo/bar"`},
+				{`KERNEL`: `"dir1/baz"`},
+				{`KERNEL`: `"dir2/baz"`},
+				{`KERNEL`: `"baz"`},
+			},
+		},
+		// if there happen to be two device paths with the same
+		// basenames, create default rules for both full paths, and one
+		// default rule with the shared basename.  If there is a rule
+		// for one of the full paths, the other still gets both default
+		// rules.  If there is are rules for both full paths, don't
+		// generate the basename default rule.
+		{
+			"udev-tagging:\n   - kernel: dir1/baz",
+			[]map[string]string{
+				{`KERNEL`: `"input/event[0-9]"`},
+				{`KERNEL`: `"event[0-9]"`},
+				{`KERNEL`: `"input/mice"`},
+				{`KERNEL`: `"mice"`},
+				{`KERNEL`: `"js*"`},
+				{`KERNEL`: `"dma_heap/qcom,qseecom"`},
+				{`KERNEL`: `"qcom,qseecom"`},
+				{`KERNEL`: `"bar"`},
+				{`KERNEL`: `"foo/bar"`},
+				{`KERNEL`: `"dir1/baz"`},
+				{`KERNEL`: `"dir2/baz"`},
+				{`KERNEL`: `"baz"`},
+			},
+		},
+		{
+			`udev-tagging:
+   - kernel: dir1/baz
+   - kernel: dir2/baz`,
+			[]map[string]string{
+				{`KERNEL`: `"input/event[0-9]"`},
+				{`KERNEL`: `"event[0-9]"`},
+				{`KERNEL`: `"input/mice"`},
+				{`KERNEL`: `"mice"`},
+				{`KERNEL`: `"js*"`},
+				{`KERNEL`: `"dma_heap/qcom,qseecom"`},
+				{`KERNEL`: `"qcom,qseecom"`},
+				{`KERNEL`: `"bar"`},
+				{`KERNEL`: `"foo/bar"`},
+				{`KERNEL`: `"dir1/baz"`},
+				{`KERNEL`: `"dir2/baz"`},
 			},
 		},
 	}


### PR DESCRIPTION
Previously, the handling of udev tagging rules was modified to allow device paths in subdirectories of `/dev/`.  As part of this work, checks were put in place to ensure that all KERNEL values, including default rules, must be basenames of a device path.

That work can be found in two previous commits:

- b1df21de4719da0644ce7528d9bc9cd46dbf99c1
- 12ca6af3a000b30552abb33377724379faf4aab8

The former allows either full paths (stripped of leading `/dev/`) or basenames, while the latter switches this requirement so that all values must be basenames.  The commit message of the latter indicates that KERNEL values which are not basenames violate the udev spec -- this is incorrect.

For some devices, the udev KERNEL value must be the full path of the device, stripped of leading `/dev/`, while for other devices, the udev KERNEL value must be the basename of the device path.  If an explicit udev tagging rule is not given, it is unclear which of these is the case.

This commit changes udev tagging handling to emit two rules for each device path in a subdirectory of `/dev/` which is not given as the kernel value of an explicit udev rule in the "udev-tagging" section: one using the full device path following `/dev/`, and one using the basename of the device path.

If there are device paths of the form /dev/bar and /dev/foo/bar, then default rules will be generated for both KERNEL=="bar" and KERNEL=="foo/bar".  If there are explicit rules for either, the default rule for the other (if it has no explicit rule) will still be emitted.
