### PR TITLE
wrappers: enable activated services only if flag is set

### DIFF
--- a/tests/main/services-socket-activation/task.yaml
+++ b/tests/main/services-socket-activation/task.yaml
@@ -18,16 +18,18 @@ execute: |
     snap services | cat -n > svcs.txt
     MATCH "     1\s+Service\s+Startup\s+Current\s+Notes$" < svcs.txt
     MATCH "     2\s+socket-activation.sleep-daemon\s+enabled\s+inactive\s+socket-activated$" < svcs.txt
-    
+
     echo "Checking that the service is reported as static"
     systemctl show --property=UnitFileState snap.socket-activation.sleep-daemon.service | grep "static"
 
-    echo "Checking that service activation unit is reported as enabled"
+    echo "Checking that service activation unit is reported as enabled and running"
     systemctl show --property=UnitFileState snap.socket-activation.sleep-daemon.sock.socket | grep "enabled"
+    systemctl show --property=ActiveState snap.socket-activation.sleep-daemon.sock.socket | grep "ActiveState=active"
 
     echo "Testing that we can stop will not disable the service"
     snap stop socket-activation.sleep-daemon
     systemctl show --property=UnitFileState snap.socket-activation.sleep-daemon.sock.socket | grep "enabled"
+    systemctl show --property=ActiveState snap.socket-activation.sleep-daemon.sock.socket | grep "ActiveState=inactive"
 
     echo "Testing that we can correctly disable activations"
     snap stop --disable socket-activation.sleep-daemon
@@ -37,10 +39,23 @@ execute: |
     MATCH "     1\s+Service\s+Startup\s+Current\s+Notes$" < svcs.txt
     MATCH "     2\s+socket-activation.sleep-daemon\s+disabled\s+inactive\s+socket-activated$" < svcs.txt
     
-    echo "Checking that service activation unit is reported as disabled"
+    echo "Checking that service activation unit is reported as disabled and inactive"
     systemctl show --property=UnitFileState snap.socket-activation.sleep-daemon.sock.socket | grep "disabled"
+    systemctl show --property=ActiveState snap.socket-activation.sleep-daemon.sock.socket | grep "ActiveState=inactive"
 
-    echo "Enable service again and verify its listed as enabled, but inactive"
+    echo "Starting the service will start the socket unit, but not enable"
+    snap start socket-activation.sleep-daemon
+
+    echo "Checking that services are listed as expected"
+    snap services | cat -n > svcs.txt
+    MATCH "     1\s+Service\s+Startup\s+Current\s+Notes$" < svcs.txt
+    MATCH "     2\s+socket-activation.sleep-daemon\s+disabled\s+inactive\s+socket-activated$" < svcs.txt
+
+    echo "Checking that service activation unit is reported as disabled and active"
+    systemctl show --property=UnitFileState snap.socket-activation.sleep-daemon.sock.socket | grep "disabled"
+    systemctl show --property=ActiveState snap.socket-activation.sleep-daemon.sock.socket | grep "ActiveState=active"
+
+    echo "Enable service and verify its listed as enabled"
     snap start --enable socket-activation.sleep-daemon
 
     echo "Checking that services are listed correctly"
@@ -48,5 +63,6 @@ execute: |
     MATCH "     1\s+Service\s+Startup\s+Current\s+Notes$" < svcs.txt
     MATCH "     2\s+socket-activation.sleep-daemon\s+enabled\s+inactive\s+socket-activated$" < svcs.txt
 
-    echo "Checking that service activation unit is reported as enabled again"
+    echo "Checking that service activation unit is reported as enabled and active again"
     systemctl show --property=UnitFileState snap.socket-activation.sleep-daemon.sock.socket | grep "enabled"
+    systemctl show --property=ActiveState snap.socket-activation.sleep-daemon.sock.socket | grep "ActiveState=active"

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -348,8 +348,9 @@ func StartServices(apps []*snap.AppInfo, disabledSvcs []string, flags *StartServ
 			continue
 		}
 		markServicesForStart(activators, app.DaemonScope)
-		// TODO: only if flags.Enable is set
-		markServicesForEnable(activators, app.DaemonScope)
+		if flags.Enable {
+			markServicesForEnable(activators, app.DaemonScope)
+		}
 	}
 
 	// now collect all services

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -3827,9 +3827,7 @@ func (s *servicesTestSuite) TestStartSnapMultiServicesFailStartCleanupWithSocket
 
 func (s *servicesTestSuite) TestStartSnapMultiServicesFailStartNoEnableNoDisable(c *C) {
 	// start services is called without the enable flag (eg. as during snap
-	// start foo), in which case, the cleanup does not call disable (unless
-	// there are timers and socket, in which the buggy behavior kicks in,
-	// but only for those units)
+	// start foo), in which case, the cleanup does not call disable.
 	var sysdLog [][]string
 	svc1Name := "snap.hello-snap.svc1.service"
 	svc2Name := "snap.hello-snap.svc2.service"
@@ -3873,10 +3871,8 @@ func (s *servicesTestSuite) TestStartSnapMultiServicesFailStartNoEnableNoDisable
 	err := wrappers.StartServices(apps, nil, flags, &progress.Null, s.perfTimings)
 	c.Assert(err, ErrorMatches, "failed")
 	c.Logf("sysdlog: %v", sysdLog)
-	c.Assert(sysdLog, HasLen, 15, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
+	c.Assert(sysdLog, HasLen, 11, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
 	c.Check(sysdLog, DeepEquals, [][]string{
-		{"--no-reload", "enable", svc2SocketName, svc3SocketName},
-		{"daemon-reload"},
 		{"start", svc2SocketName},
 		{"start", svc3SocketName},
 		{"start", svc1Name}, // start failed, what follows is the cleanup
@@ -3888,8 +3884,6 @@ func (s *servicesTestSuite) TestStartSnapMultiServicesFailStartNoEnableNoDisable
 		{"show", "--property=ActiveState", svc2Name},
 		{"stop", svc1Name},
 		{"show", "--property=ActiveState", svc1Name},
-		{"--no-reload", "disable", svc2SocketName, svc3SocketName},
-		{"daemon-reload"},
 	}, Commentf("calls: %v", sysdLog))
 }
 


### PR DESCRIPTION
This PR fixes the current `snap start` and `snap start --enable` behaviour which today do exactly the same thing for services that are activated by other units. With this PR these commands now behave as you would expect.

`snap start` now starts the activation units, but does not enable them on startup
`snap start --enable` now starts the activation units, and enables them for startup.

For some history:
- Original PR that preserved this behaviour: https://github.com/snapcore/snapd/pull/11314
- The commit https://github.com/snapcore/snapd/pull/11314/commits/d275bda87153e4418a0eee496ffe6adc89c3fc69