### PR TITLE
i/builtin/block-devices: loop* is actually included now

### DIFF
--- a/interfaces/builtin/block_devices.go
+++ b/interfaces/builtin/block_devices.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2019 Canonical Ltd
+ * Copyright (C) 2019-2023 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -19,7 +19,7 @@
 
 package builtin
 
-// Only allow raw disk devices; not loop, ram, CDROM, generic SCSI, network,
+// Only allow raw disk devices; not ram, CDROM, generic SCSI, network,
 // tape, raid, etc devices or disk partitions. For some devices, allow controller
 // character devices since they are used to configure the corresponding block
 // device.


### PR DESCRIPTION
update the comment to match current reality
