### PR TITLE
snapfile: show more context when a snap file header cannot be read

### DIFF
--- a/snap/snapfile/snapfile.go
+++ b/snap/snapfile/snapfile.go
@@ -71,11 +71,11 @@ func notSnapErrorDetails(path string) error {
 	}
 	// Arbitrary value but big enough to show some header
 	// information (the squashfs header is type u32)
-	var header [5]byte
+	var header [15]byte
 	if _, err := f.Read(header[:]); err != nil {
 		return fmt.Errorf("cannot read %q: %v", path, err)
 	}
-	return fmt.Errorf("file %q is invalid (header %v)", path, header)
+	return fmt.Errorf("file %q is invalid (header %v %q)", path, header, header)
 }
 
 // Open opens a given snap file with the right backend.

--- a/snap/snapfile/snapfile_test.go
+++ b/snap/snapfile/snapfile_test.go
@@ -132,7 +132,7 @@ func (s *snapFileTestSuite) TestOpenSnapdirUnsupportedFormat(c *C) {
 
 	_, err = snapfile.Open(fn)
 	c.Assert(err, FitsTypeOf, snap.NotSnapError{})
-	c.Check(err, ErrorMatches, `cannot process snap or snapdir: file ".*" is invalid \(header \[110 111 116 45 97\]\)`)
+	c.Check(err, ErrorMatches, `cannot process snap or snapdir: file ".*" is invalid \(header \[110 111 116 45 97 45 114 101 97 108 45 104 101 97 100\] "not-a-real-head"\)`)
 }
 
 func (s *snapFileTestSuite) TestOpenSnapdirFileNoExists(c *C) {


### PR DESCRIPTION
There was a recent salesforce case where a invalid snap was downloaded but because the error from the snapfile only contains the "bytes" representation it was not clear right away that the header was actually a json error like: `{"err...`.

This commit tweaks the error so that more context (15 bytes) are displayed and they are also displayed as quoted string not only as bytes.
