### PR TITLE
boot,o/devicestate: protect with a mutex modifying modeeenv and sealing/releasing

### DIFF
--- a/boot/assets.go
+++ b/boot/assets.go
@@ -692,7 +692,7 @@ func (o *TrustedAssetsUpdateObserver) BeforeWrite() error {
 		return nil
 	}
 	const expectReseal = true
-	if err := resealKeyToModeenv(dirs.GlobalRootDir, o.modeenv, expectReseal); err != nil {
+	if err := resealKeyToModeenv(dirs.GlobalRootDir, o.modeenv, expectReseal, nil); err != nil {
 		return err
 	}
 	return nil
@@ -758,7 +758,7 @@ func (o *TrustedAssetsUpdateObserver) Canceled() error {
 	}
 
 	const expectReseal = true
-	if err := resealKeyToModeenv(dirs.GlobalRootDir, o.modeenv, expectReseal); err != nil {
+	if err := resealKeyToModeenv(dirs.GlobalRootDir, o.modeenv, expectReseal, nil); err != nil {
 		return fmt.Errorf("while canceling gadget update: %v", err)
 	}
 	return nil

--- a/boot/assets.go
+++ b/boot/assets.go
@@ -513,6 +513,7 @@ func (o *TrustedAssetsUpdateObserver) Observe(op gadget.ContentOperation, partRo
 	}
 	if o.modeenv == nil {
 		// we've hit a trusted asset, so a modeenv is needed now too
+		// XXX take the lock
 		o.modeenv, err = ReadModeenv("")
 		if err != nil {
 			return gadget.ChangeAbort, fmt.Errorf("cannot load modeenv: %v", err)

--- a/boot/assets_test.go
+++ b/boot/assets_test.go
@@ -80,6 +80,7 @@ func (s *assetsSuite) uc20UpdateObserver(c *C, gadgetDir string) (*boot.TrustedA
 	obs, err := boot.TrustedAssetsUpdateObserverForModel(uc20Model, gadgetDir)
 	c.Assert(obs, NotNil)
 	c.Assert(err, IsNil)
+	s.AddCleanup(obs.Done)
 	return obs, uc20Model
 }
 
@@ -1010,6 +1011,7 @@ func (s *assetsSuite) TestUpdateObserverUpdateTrivialErr(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(obs, NotNil)
 	c.Check(bl.TrustedAssetsCalls, Equals, 2)
+	defer obs.Done()
 
 	// no modeenv
 	res, err := obs.Observe(gadget.ContentUpdate, gadget.SystemBoot, root, "asset",
@@ -1324,6 +1326,7 @@ func (s *assetsSuite) TestUpdateObserverRollbackFileValidity(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(newM.CurrentTrustedBootAssets, HasLen, 0)
 	c.Check(newM.CurrentTrustedRecoveryBootAssets, HasLen, 0)
+	obs.Done()
 
 	// new observer
 	obs, _ = s.uc20UpdateObserverEncryptedSystemMockedBootloader(c)
@@ -1858,6 +1861,7 @@ func (s *assetsSuite) TestUpdateObserverCanceledEmptyModeenvAssets(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(afterCancelM.CurrentTrustedBootAssets, HasLen, 0)
 	c.Check(afterCancelM.CurrentTrustedRecoveryBootAssets, HasLen, 0)
+	obs.Done()
 
 	// get a new observer, and observe an update for run bootloader asset only
 	obs, _ = s.uc20UpdateObserverEncryptedSystemMockedBootloader(c)

--- a/boot/boot.go
+++ b/boot/boot.go
@@ -310,6 +310,9 @@ var (
 // type of snap, which can be snap.TypeBase (or snap.TypeOS), or snap.TypeKernel.
 // Returns ErrBootNameAndRevisionNotReady if the values are temporarily not established.
 func GetCurrentBoot(t snap.Type, dev snap.Device) (snap.PlaceInfo, error) {
+	modeenvLock()
+	defer modeenvUnlock()
+
 	s, err := bootStateFor(t, dev)
 	if err != nil {
 		return nil, err
@@ -354,6 +357,9 @@ type bootStateUpdate interface {
 //     will set snap_mode="" and the system will boot with the known good
 //     values from snap_{core,kernel}
 func MarkBootSuccessful(dev snap.Device) error {
+	modeenvLock()
+	defer modeenvUnlock()
+
 	const errPrefix = "cannot mark boot successful: %s"
 
 	var u bootStateUpdate
@@ -443,6 +449,9 @@ func UpdateManagedBootConfigs(dev snap.Device, gadgetSnapOrDir, cmdlineAppend st
 	if !dev.RunMode() {
 		return false, fmt.Errorf("internal error: boot config can only be updated in run mode")
 	}
+	modeenvLock()
+	defer modeenvUnlock()
+
 	return updateManagedBootConfigForBootloader(dev, ModeRun, gadgetSnapOrDir, cmdlineAppend)
 }
 
@@ -482,6 +491,9 @@ func UpdateCommandLineForGadgetComponent(dev snap.Device, gadgetSnapOrDir, cmdli
 		// only UC20 devices are supported
 		return false, fmt.Errorf("internal error: command line component cannot be updated on pre-UC20 devices")
 	}
+	modeenvLock()
+	defer modeenvUnlock()
+
 	opts := &bootloader.Options{
 		Role: bootloader.RoleRunMode,
 	}

--- a/boot/boot.go
+++ b/boot/boot.go
@@ -28,6 +28,13 @@ import (
 	"github.com/snapcore/snapd/snap"
 )
 
+// Unlocker functions are passed from code using boot to indicate that global
+// state should be unlocked during slow operations, e.g sealing/unsealing.
+// Boot code is then expected to call the unlocker around the slow section and
+// relock using the returned function. Unlocker being nil indicates not to do
+// this.
+type Unlocker func() (relock func())
+
 const (
 	// DefaultStatus is the value of a status boot variable when nothing is
 	// being tried

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -4422,7 +4422,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameGadgetSnap(c *C) {
 		s.normalDefaultState,
 	)
 	defer r()
-	r = boot.MockResealKeyToModeenv(func(_ string, _ *boot.Modeenv, expectReseal bool) error {
+	r = boot.MockResealKeyToModeenv(func(_ string, _ *boot.Modeenv, expectReseal bool, _ boot.Unlocker) error {
 		c.Assert(expectReseal, Equals, false)
 		return nil
 	})
@@ -4457,7 +4457,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewGadgetSnap(c *C) {
 		s.normalDefaultState,
 	)
 	defer r()
-	r = boot.MockResealKeyToModeenv(func(_ string, _ *boot.Modeenv, expectReseal bool) error {
+	r = boot.MockResealKeyToModeenv(func(_ string, _ *boot.Modeenv, expectReseal bool, _ boot.Unlocker) error {
 		c.Assert(expectReseal, Equals, false)
 		return nil
 	})

--- a/boot/bootstate20.go
+++ b/boot/bootstate20.go
@@ -215,7 +215,7 @@ func (u20 *bootStateUpdate20) commit() error {
 	// changed because of unasserted kernels, then pass a
 	// flag as hint whether to reseal based on whether we
 	// wrote the modeenv
-	if err := resealKeyToModeenv(dirs.GlobalRootDir, u20.writeModeenv, expectReseal); err != nil {
+	if err := resealKeyToModeenv(dirs.GlobalRootDir, u20.writeModeenv, expectReseal, nil); err != nil {
 		return err
 	}
 

--- a/boot/bootstate20.go
+++ b/boot/bootstate20.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2019-2022 Canonical Ltd
+ * Copyright (C) 2019-2023 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -183,6 +183,10 @@ func newBootStateUpdate20(m *Modeenv) (*bootStateUpdate20, error) {
 
 // commit will write out boot state persistently to disk.
 func (u20 *bootStateUpdate20) commit() error {
+	if !isModeeenvLocked() {
+		return fmt.Errorf("internal error: cannot commit modeenv without the lock")
+	}
+
 	// The actual actions taken here will depend on what things were called
 	// before commit(), either setNextBoot for a single type of kernel snap, or
 	// markSuccessful for kernel and/or base snaps.

--- a/boot/bootstate20.go
+++ b/boot/bootstate20.go
@@ -49,7 +49,7 @@ func newBootState20(typ snap.Type, dev snap.Device) bootState {
 func loadModeenv() (*Modeenv, error) {
 	modeenv, err := ReadModeenv("")
 	if err != nil {
-		return nil, fmt.Errorf("cannot get snap revision: unable to read modeenv: %v", err)
+		return nil, fmt.Errorf("cannot read modeenv: %v", err)
 	}
 	return modeenv, nil
 }
@@ -464,7 +464,7 @@ type bootState20Base struct{}
 func (bs20 *bootState20Base) revisions() (curSnap, trySnap snap.PlaceInfo, tryingStatus string, err error) {
 	modeenv, err := loadModeenv()
 	if err != nil {
-		return nil, nil, "", err
+		return nil, nil, "", fmt.Errorf("cannot get snap revision: %v", err)
 	}
 	return bs20.revisionsFromModeenv(modeenv)
 }

--- a/boot/bootstate20.go
+++ b/boot/bootstate20.go
@@ -48,6 +48,11 @@ func newBootState20(typ snap.Type, dev snap.Device) bootState {
 	}
 }
 
+// modeenvMu is used to protect sections doing:
+//  * read moddeenv/modify it(/reseal from it)
+//  * write modeenv/seal from it
+// while we might want to release the global state lock as seal/reseal are slow
+// (see Unlocker for that)
 var (
 	modeenvMu     sync.Mutex
 	modeenvLocked int32

--- a/boot/cmdline.go
+++ b/boot/cmdline.go
@@ -366,7 +366,7 @@ func observeCommandLineUpdate(model *asserts.Model, reason commandLineUpdateReas
 	}
 
 	expectReseal := true
-	if err := resealKeyToModeenv(dirs.GlobalRootDir, m, expectReseal); err != nil {
+	if err := resealKeyToModeenv(dirs.GlobalRootDir, m, expectReseal, nil); err != nil {
 		return false, err
 	}
 	return true, nil

--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -21,6 +21,7 @@ package boot
 
 import (
 	"fmt"
+	"sync/atomic"
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/bootloader"
@@ -250,6 +251,13 @@ func MockResealKeyToModeenvUsingFDESetupHook(f func(string, *Modeenv, bool) erro
 	resealKeyToModeenvUsingFDESetupHook = f
 	return func() {
 		resealKeyToModeenvUsingFDESetupHook = old
+	}
+}
+
+func MockModeenvLocked() (restore func()) {
+	atomic.AddInt32(&modeenvLocked, 1)
+	return func() {
+		atomic.AddInt32(&modeenvLocked, -1)
 	}
 }
 

--- a/boot/flags.go
+++ b/boot/flags.go
@@ -269,6 +269,8 @@ func setNextBootFlags(dev snap.Device, rootDir string, flags []string) error {
 		return errNotUC20
 	}
 
+	// XXX take the lock?
+
 	m, err := ReadModeenv(rootDir)
 	if err != nil {
 		return err

--- a/boot/flags.go
+++ b/boot/flags.go
@@ -269,7 +269,7 @@ func setNextBootFlags(dev snap.Device, rootDir string, flags []string) error {
 		return errNotUC20
 	}
 
-	// XXX take the lock?
+	// XXX take the modeenv lock?
 
 	m, err := ReadModeenv(rootDir)
 	if err != nil {

--- a/boot/kernel_os.go
+++ b/boot/kernel_os.go
@@ -37,6 +37,9 @@ var _ BootParticipant = (*coreBootParticipant)(nil)
 func (*coreBootParticipant) IsTrivial() bool { return false }
 
 func (bp *coreBootParticipant) SetNextBoot(bootCtx NextBootContext) (rebootInfo RebootInfo, err error) {
+	modeenvLock()
+	defer modeenvUnlock()
+
 	const errPrefix = "cannot set next boot: %s"
 
 	rebootInfo, u, err := bp.bs.setNext(bp.s, bootCtx)

--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -358,6 +358,8 @@ func makeRunnableSystem(model *asserts.Model, bootWith *BootableSet, sealer *Tru
 	if bootWith.RecoverySystemDir != "" {
 		return fmt.Errorf("internal error: RecoverySystemDir unexpectedly set for MakeRunnableSystem")
 	}
+	modeenvLock()
+	defer modeenvUnlock()
 
 	// TODO:UC20:
 	// - figure out what to do for uboot gadgets, currently we require them to

--- a/boot/model.go
+++ b/boot/model.go
@@ -39,6 +39,8 @@ func DeviceChange(from snap.Device, to snap.Device) error {
 		// nothing useful happens on a non-UC20 system here
 		return nil
 	}
+	modeenvLock()
+	defer modeenvUnlock()
 
 	m, err := loadModeenv()
 	if err != nil {

--- a/boot/model.go
+++ b/boot/model.go
@@ -34,7 +34,7 @@ import (
 // encryption keys will be resealed for both models. The device model file which
 // is measured during boot will be updated. The recovery systems that belong to
 // the old model will no longer be usable.
-func DeviceChange(from snap.Device, to snap.Device) error {
+func DeviceChange(from snap.Device, to snap.Device, unlocker Unlocker) error {
 	if !to.HasModeenv() {
 		// nothing useful happens on a non-UC20 system here
 		return nil
@@ -73,7 +73,7 @@ func DeviceChange(from snap.Device, to snap.Device) error {
 	// even if there is a reboot before the device/model file is updated, or
 	// before the final reseal with one model
 	const expectReseal = true
-	if err := resealKeyToModeenv(dirs.GlobalRootDir, m, expectReseal); err != nil {
+	if err := resealKeyToModeenv(dirs.GlobalRootDir, m, expectReseal, unlocker); err != nil {
 		// best effort clear the modeenv's try model
 		m.clearTryModel()
 		if mErr := m.Write(); mErr != nil {
@@ -114,7 +114,7 @@ func DeviceChange(from snap.Device, to snap.Device) error {
 
 	// past a successful reseal, the old recovery systems become unusable and will
 	// not be able to access the data anymore
-	if err := resealKeyToModeenv(dirs.GlobalRootDir, m, expectReseal); err != nil {
+	if err := resealKeyToModeenv(dirs.GlobalRootDir, m, expectReseal, unlocker); err != nil {
 		// resealing failed, but modeenv and the file have been modified
 
 		// first restore the modeenv in case we reboot, such that if the

--- a/boot/model_test.go
+++ b/boot/model_test.go
@@ -255,9 +255,12 @@ func (s *modelSuite) TestDeviceChangeHappy(c *C) {
 	})
 	defer restore()
 
-	err = boot.DeviceChange(s.oldUc20dev, s.newUc20dev)
+	u := mockUnlocker{}
+
+	err = boot.DeviceChange(s.oldUc20dev, s.newUc20dev, u.unlocker)
 	c.Assert(err, IsNil)
 	c.Assert(resealKeysCalls, Equals, 4)
+	c.Check(u.unlocked, Equals, 2)
 
 	c.Check(filepath.Join(boot.InitramfsUbuntuBootDir, "device/model"), testutil.FileContains,
 		"model: my-new-model-uc20\n")
@@ -313,7 +316,7 @@ func (s *modelSuite) TestDeviceChangeUnhappyFirstReseal(c *C) {
 	})
 	defer restore()
 
-	err = boot.DeviceChange(s.oldUc20dev, s.newUc20dev)
+	err = boot.DeviceChange(s.oldUc20dev, s.newUc20dev, nil)
 	c.Assert(err, ErrorMatches, "cannot reseal the encryption key: fail on first try")
 	c.Assert(resealKeysCalls, Equals, 1)
 	// still the old model file
@@ -382,7 +385,7 @@ func (s *modelSuite) TestDeviceChangeUnhappyFirstSwapModelFile(c *C) {
 	})
 	defer restore()
 
-	err = boot.DeviceChange(s.oldUc20dev, s.newUc20dev)
+	err = boot.DeviceChange(s.oldUc20dev, s.newUc20dev, nil)
 	c.Assert(err, ErrorMatches, `cannot write new model file: open .*/run/mnt/ubuntu-boot/device/model\..*: no such file or directory`)
 	c.Assert(resealKeysCalls, Equals, 2)
 
@@ -473,7 +476,7 @@ func (s *modelSuite) TestDeviceChangeUnhappySecondReseal(c *C) {
 	})
 	defer restore()
 
-	err = boot.DeviceChange(s.oldUc20dev, s.newUc20dev)
+	err = boot.DeviceChange(s.oldUc20dev, s.newUc20dev, nil)
 	c.Assert(err, ErrorMatches, `cannot reseal the encryption key: fail on second try`)
 	c.Assert(resealKeysCalls, Equals, 3)
 	// old model file was restored
@@ -580,7 +583,7 @@ func (s *modelSuite) TestDeviceChangeRebootBeforeNewModel(c *C) {
 	})
 	defer restore()
 
-	c.Assert(func() { boot.DeviceChange(s.oldUc20dev, s.newUc20dev) }, PanicMatches,
+	c.Assert(func() { boot.DeviceChange(s.oldUc20dev, s.newUc20dev, nil) }, PanicMatches,
 		`mock reboot after first complete reseal`)
 	c.Assert(resealKeysCalls, Equals, 2)
 	// still old model in place
@@ -596,7 +599,7 @@ func (s *modelSuite) TestDeviceChangeRebootBeforeNewModel(c *C) {
 	c.Assert(tryForSealing, Equals, "canonical/my-new-model-uc20,secured,"+s.keyID)
 
 	// let's try again
-	err = boot.DeviceChange(s.oldUc20dev, s.newUc20dev)
+	err = boot.DeviceChange(s.oldUc20dev, s.newUc20dev, nil)
 	c.Assert(err, IsNil)
 	c.Assert(resealKeysCalls, Equals, 5)
 	// got new model now
@@ -703,7 +706,7 @@ func (s *modelSuite) TestDeviceChangeRebootAfterNewModelFileWrite(c *C) {
 	})
 	defer restore()
 
-	c.Assert(func() { boot.DeviceChange(s.oldUc20dev, s.newUc20dev) }, PanicMatches,
+	c.Assert(func() { boot.DeviceChange(s.oldUc20dev, s.newUc20dev, nil) }, PanicMatches,
 		`mock reboot before second complete reseal`)
 	c.Assert(resealKeysCalls, Equals, 3)
 	// model file has already been replaced
@@ -719,7 +722,7 @@ func (s *modelSuite) TestDeviceChangeRebootAfterNewModelFileWrite(c *C) {
 	c.Assert(tryForSealing, Equals, "/,,")
 
 	// let's try again (post reboot)
-	err = boot.DeviceChange(s.oldUc20dev, s.newUc20dev)
+	err = boot.DeviceChange(s.oldUc20dev, s.newUc20dev, nil)
 	c.Assert(err, IsNil)
 	c.Assert(resealKeysCalls, Equals, 5)
 	// got new model now
@@ -833,7 +836,7 @@ func (s *modelSuite) TestDeviceChangeRebootPostSameModel(c *C) {
 	defer restore()
 
 	// as if called by device manager in task handler
-	c.Assert(func() { boot.DeviceChange(s.oldUc20dev, s.newUc20dev) }, PanicMatches,
+	c.Assert(func() { boot.DeviceChange(s.oldUc20dev, s.newUc20dev, nil) }, PanicMatches,
 		`mock reboot before second complete reseal`)
 	c.Assert(resealKeysCalls, Equals, 4)
 	// model file has already been replaced
@@ -842,7 +845,7 @@ func (s *modelSuite) TestDeviceChangeRebootPostSameModel(c *C) {
 
 	// as if called by device manager, after the model has been changed, but
 	// the set-model task isn't marked as done
-	err = boot.DeviceChange(s.newUc20dev, s.newUc20dev)
+	err = boot.DeviceChange(s.newUc20dev, s.newUc20dev, nil)
 	c.Assert(err, IsNil)
 	c.Assert(resealKeysCalls, Equals, 7)
 
@@ -942,7 +945,7 @@ func (s *modelSuite) testDeviceChangeUnhappyMockedWriteModelToBoot(c *C, tc unha
 	})
 	defer restore()
 
-	err = boot.DeviceChange(s.oldUc20dev, s.newUc20dev)
+	err = boot.DeviceChange(s.oldUc20dev, s.newUc20dev, nil)
 	c.Assert(err, ErrorMatches, tc.expectedErr)
 	c.Assert(resealKeysCalls, Equals, 2)
 	if tc.breakModeenvAfterFirstWrite {
@@ -1067,7 +1070,7 @@ func (s *modelSuite) TestDeviceChangeUnhappyFailReseaWithSwappedModelMockedWrite
 	})
 	defer restore()
 
-	err = boot.DeviceChange(s.oldUc20dev, s.newUc20dev)
+	err = boot.DeviceChange(s.oldUc20dev, s.newUc20dev, nil)
 	c.Assert(err, ErrorMatches, `cannot reseal the encryption key: mock reseal failure`)
 	c.Assert(resealKeysCalls, Equals, 3)
 	c.Assert(writeModelToBootCalls, Equals, 2)
@@ -1210,12 +1213,12 @@ func (s *modelSuite) TestDeviceChangeRebootRestoreModelKeyChangeMockedWriteModel
 	defer restore()
 
 	// as if called by device manager in task handler
-	c.Assert(func() { boot.DeviceChange(s.oldUc20dev, s.newUc20dev) }, PanicMatches,
+	c.Assert(func() { boot.DeviceChange(s.oldUc20dev, s.newUc20dev, nil) }, PanicMatches,
 		`mock reboot before second complete reseal`)
 	c.Assert(resealKeysCalls, Equals, 4)
 	c.Assert(writeModelToBootCalls, Equals, 1)
 
-	err := boot.DeviceChange(s.oldUc20dev, s.newUc20dev)
+	err := boot.DeviceChange(s.oldUc20dev, s.newUc20dev, nil)
 	c.Assert(err, IsNil)
 	c.Assert(resealKeysCalls, Equals, 7)
 	c.Assert(writeModelToBootCalls, Equals, 2)

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -416,9 +416,9 @@ var resealKeyToModeenv = resealKeyToModeenvImpl
 // transient/in-memory information with the risk that successive
 // reseals during in-progress operations produce diverging outcomes.
 func resealKeyToModeenvImpl(rootdir string, modeenv *Modeenv, expectReseal bool) error {
-	/*if !isModeeenvLocked() {
+	if !isModeeenvLocked() {
 		return fmt.Errorf("internal error: cannot reseal without the modeenv lock")
-	}*/
+	}
 
 	method, err := device.SealedKeysMethod(rootdir)
 	if err == device.ErrNoSealedKeys {

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2020-2022 Canonical Ltd
+ * Copyright (C) 2020-2023 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -128,6 +128,10 @@ type sealKeyToModeenvFlags struct {
 // in modeenv.
 // It assumes to be invoked in install mode.
 func sealKeyToModeenvImpl(key, saveKey keys.EncryptionKey, model *asserts.Model, modeenv *Modeenv, flags sealKeyToModeenvFlags) error {
+	if !isModeeenvLocked() {
+		return fmt.Errorf("internal error: cannot seal without the modeenv lock")
+	}
+
 	// make sure relevant locations exist
 	for _, p := range []string{
 		InitramfsSeedEncryptionKeyDir,
@@ -412,6 +416,10 @@ var resealKeyToModeenv = resealKeyToModeenvImpl
 // transient/in-memory information with the risk that successive
 // reseals during in-progress operations produce diverging outcomes.
 func resealKeyToModeenvImpl(rootdir string, modeenv *Modeenv, expectReseal bool) error {
+	/*if !isModeeenvLocked() {
+		return fmt.Errorf("internal error: cannot reseal without the modeenv lock")
+	}*/
+
 	method, err := device.SealedKeysMethod(rootdir)
 	if err == device.ErrNoSealedKeys {
 		// nothing to do

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -433,6 +433,8 @@ func (s *sealSuite) TestResealKeyToModeenvWithSystemFallback(c *C) {
 	var prevPbc boot.PredictableBootChains
 	var prevRecoveryPbc boot.PredictableBootChains
 
+	defer boot.MockModeenvLocked()()
+
 	for idx, tc := range []struct {
 		sealedKeys       bool
 		reuseRunPbc      bool
@@ -832,6 +834,8 @@ func (s *sealSuite) TestResealKeyToModeenvRecoveryKeysForGoodSystemsOnly(c *C) {
 	})
 	defer restore()
 
+	defer boot.MockModeenvLocked()()
+
 	// set mock key resealing
 	resealKeysCalls := 0
 	restore = boot.MockSecbootResealKeys(func(params *secboot.ResealKeysParams) error {
@@ -1105,6 +1109,8 @@ func (s *sealSuite) TestResealKeyToModeenvFallbackCmdline(c *C) {
 		return model, []*seed.Snap{mockKernelSeedSnap(snap.R(1)), mockGadgetSeedSnap(c, nil)}, nil
 	})
 	defer restore()
+
+	defer boot.MockModeenvLocked()()
 
 	// set mock key resealing
 	resealKeysCalls := 0
@@ -1743,6 +1749,8 @@ func (s *sealSuite) TestResealKeyToModeenvWithFdeHookCalled(c *C) {
 	err = ioutil.WriteFile(marker, []byte("fde-setup-hook"), 0644)
 	c.Assert(err, IsNil)
 
+	defer boot.MockModeenvLocked()()
+
 	model := boottest.MakeMockUC20Model()
 	modeenv := &boot.Modeenv{
 		RecoverySystem: "20200825",
@@ -1774,6 +1782,8 @@ func (s *sealSuite) TestResealKeyToModeenvWithFdeHookVerySad(c *C) {
 	c.Assert(err, IsNil)
 	err = ioutil.WriteFile(marker, []byte("fde-setup-hook"), 0644)
 	c.Assert(err, IsNil)
+
+	defer boot.MockModeenvLocked()()
 
 	model := boottest.MakeMockUC20Model()
 	modeenv := &boot.Modeenv{
@@ -1872,6 +1882,8 @@ func (s *sealSuite) TestResealKeyToModeenvWithTryModel(c *C) {
 		return systemModel, []*seed.Snap{mockKernelSeedSnap(snap.R(kernelRev)), mockGadgetSeedSnap(c, nil)}, nil
 	})
 	defer restore()
+
+	defer boot.MockModeenvLocked()()
 
 	// set mock key resealing
 	resealKeysCalls := 0

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -100,6 +100,8 @@ func mockGadgetSeedSnap(c *C, files [][]string) *seed.Snap {
 }
 
 func (s *sealSuite) TestSealKeyToModeenv(c *C) {
+	defer boot.MockModeenvLocked()()
+
 	for idx, tc := range []struct {
 		sealErr                  error
 		provisionErr             error
@@ -1665,6 +1667,8 @@ func (s *sealSuite) TestSealToModeenvWithFdeHookHappy(c *C) {
 	key := keys.EncryptionKey{1, 2, 3, 4}
 	saveKey := keys.EncryptionKey{5, 6, 7, 8}
 
+	defer boot.MockModeenvLocked()()
+
 	err := boot.SealKeyToModeenv(key, saveKey, model, modeenv, boot.MockSealKeyToModeenvFlags{HasFDESetupHook: true})
 	c.Assert(err, IsNil)
 	// check that runFDESetupHook was called the expected way
@@ -1703,6 +1707,8 @@ func (s *sealSuite) TestSealToModeenvWithFdeHookSad(c *C) {
 	}
 	key := keys.EncryptionKey{1, 2, 3, 4}
 	saveKey := keys.EncryptionKey{5, 6, 7, 8}
+
+	defer boot.MockModeenvLocked()()
 
 	model := boottest.MakeMockUC20Model()
 	err := boot.SealKeyToModeenv(key, saveKey, model, modeenv, boot.MockSealKeyToModeenvFlags{HasFDESetupHook: true})

--- a/boot/systems.go
+++ b/boot/systems.go
@@ -95,7 +95,7 @@ func clearTryRecoverySystem(dev snap.Device, systemLabel string) error {
 	// but we still want to reseal, in case the cleanup did not reach this
 	// point before
 	const expectReseal = true
-	resealErr := resealKeyToModeenv(dirs.GlobalRootDir, m, expectReseal)
+	resealErr := resealKeyToModeenv(dirs.GlobalRootDir, m, expectReseal, nil)
 
 	if resealErr != nil {
 		return resealErr
@@ -177,7 +177,7 @@ func SetTryRecoverySystem(dev snap.Device, systemLabel string) (err error) {
 	// tried system, data will still be inaccessible and the system will be
 	// considered as nonoperational
 	const expectReseal = true
-	return resealKeyToModeenv(dirs.GlobalRootDir, m, expectReseal)
+	return resealKeyToModeenv(dirs.GlobalRootDir, m, expectReseal, nil)
 }
 
 type errInconsistentRecoverySystemState struct {
@@ -421,7 +421,7 @@ func PromoteTriedRecoverySystem(dev snap.Device, systemLabel string, triedSystem
 	}
 
 	const expectReseal = true
-	if err := resealKeyToModeenv(dirs.GlobalRootDir, m, expectReseal); err != nil {
+	if err := resealKeyToModeenv(dirs.GlobalRootDir, m, expectReseal, nil); err != nil {
 		if cleanupErr := dropRecoverySystem(dev, systemLabel); cleanupErr != nil {
 			err = fmt.Errorf("%v (cleanup failed: %v)", err, cleanupErr)
 		}
@@ -464,7 +464,7 @@ func dropRecoverySystem(dev snap.Device, systemLabel string) error {
 	}
 
 	const expectReseal = true
-	return resealKeyToModeenv(dirs.GlobalRootDir, m, expectReseal)
+	return resealKeyToModeenv(dirs.GlobalRootDir, m, expectReseal, nil)
 }
 
 // MarkRecoveryCapableSystem records a given system as one that we can recover

--- a/boot/systems.go
+++ b/boot/systems.go
@@ -349,7 +349,7 @@ func InspectTryRecoverySystemOutcome(dev snap.Device) (outcome TryRecoverySystem
 	case status == "tried":
 		// check that try_recovery_system ended up in the modeenv's
 		// CurrentRecoverySystems
-		m, err := ReadModeenv("")
+		m, err := loadModeenv()
 		if err != nil {
 			return TryRecoverySystemOutcomeFailure, trySystem, err
 		}

--- a/overlord/devicestate/devicestate_remodel_test.go
+++ b/overlord/devicestate/devicestate_remodel_test.go
@@ -4110,7 +4110,7 @@ func (s *deviceMgrRemodelSuite) testUC20RemodelSetModel(c *C, tc uc20RemodelSetM
 	s.state.Set("tried-systems", []string{expectedLabel})
 
 	resealKeyCalls := 0
-	restore = boot.MockResealKeyToModeenv(func(rootdir string, modeenv *boot.Modeenv, expectReseal bool) error {
+	restore = boot.MockResealKeyToModeenv(func(rootdir string, modeenv *boot.Modeenv, expectReseal bool, u boot.Unlocker) error {
 		resealKeyCalls++
 		c.Assert(len(tc.resealErr) >= resealKeyCalls, Equals, true)
 		c.Check(modeenv.GoodRecoverySystems, DeepEquals, []string{"0000", expectedLabel})
@@ -4417,7 +4417,7 @@ func (s *deviceMgrRemodelSuite) testUC20RemodelLocalNonEssential(c *C, tc *uc20R
 	s.state.Set("tried-systems", []string{expectedLabel})
 
 	resealKeyCalls := 0
-	restore = boot.MockResealKeyToModeenv(func(rootdir string, modeenv *boot.Modeenv, expectReseal bool) error {
+	restore = boot.MockResealKeyToModeenv(func(rootdir string, modeenv *boot.Modeenv, expectReseal bool, u boot.Unlocker) error {
 		resealKeyCalls++
 		c.Check(modeenv.GoodRecoverySystems, DeepEquals, []string{"0000", expectedLabel})
 		c.Check(modeenv.CurrentRecoverySystems, DeepEquals, []string{"0000", expectedLabel})
@@ -4682,7 +4682,7 @@ func (s *deviceMgrRemodelSuite) TestUC20RemodelSetModelWithReboot(c *C) {
 	s.state.Set("tried-systems", []string{expectedLabel})
 
 	resealKeyCalls := 0
-	restore = boot.MockResealKeyToModeenv(func(rootdir string, modeenv *boot.Modeenv, expectReseal bool) error {
+	restore = boot.MockResealKeyToModeenv(func(rootdir string, modeenv *boot.Modeenv, expectReseal bool, u boot.Unlocker) error {
 		resealKeyCalls++
 		// calls:
 		// 1 - promote recovery system
@@ -4722,6 +4722,8 @@ func (s *deviceMgrRemodelSuite) TestUC20RemodelSetModelWithReboot(c *C) {
 				testutil.FileContains, fmt.Sprintf("model: %s\n", new.Model()))
 			c.Check(filepath.Join(boot.InitramfsUbuntuBootDir, "device/model"),
 				testutil.FileContains, fmt.Sprintf("revision: %v\n", new.Revision()))
+			// check unlocker
+			u()()
 		case 6:
 			c.Check(modeenv.Model, Equals, new.Model())
 			c.Check(modeenv.TryModel, Equals, "")
@@ -4729,6 +4731,8 @@ func (s *deviceMgrRemodelSuite) TestUC20RemodelSetModelWithReboot(c *C) {
 				testutil.FileContains, fmt.Sprintf("model: %s\n", new.Model()))
 			c.Check(filepath.Join(boot.InitramfsUbuntuBootDir, "device/model"),
 				testutil.FileContains, fmt.Sprintf("revision: %v\n", new.Revision()))
+			// check unlocker
+			u()()
 		}
 		if resealKeyCalls > 6 {
 			c.Fatalf("unexpected #%v call to reseal key to modeenv", resealKeyCalls)

--- a/overlord/devicestate/handlers.go
+++ b/overlord/devicestate/handlers.go
@@ -154,6 +154,7 @@ func (m *DeviceManager) doMarkSeeded(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	if deviceCtx.HasModeenv() && deviceCtx.RunMode() {
+		// XXX make this a boot method
 		modeEnv, err := maybeReadModeenv()
 		if err != nil {
 			return err

--- a/overlord/devicestate/remodel.go
+++ b/overlord/devicestate/remodel.go
@@ -273,14 +273,7 @@ func (rc *baseRemodelContext) updateRunModeSystem() error {
 	// booting and consider a new recovery system as as seeded
 	oldDeviceContext := rc.GroundContext()
 	newDeviceContext := &rc.groundDeviceContext
-	// XXX => State method
-	unlocker := func() func() {
-		rc.st.Unlock()
-		return func() {
-			rc.st.Lock()
-		}
-	}
-	err := boot.DeviceChange(oldDeviceContext, newDeviceContext, unlocker)
+	err := boot.DeviceChange(oldDeviceContext, newDeviceContext, rc.st.Unlocker())
 	if err != nil {
 		return fmt.Errorf("cannot switch device: %v", err)
 	}

--- a/overlord/devicestate/remodel.go
+++ b/overlord/devicestate/remodel.go
@@ -273,9 +273,14 @@ func (rc *baseRemodelContext) updateRunModeSystem() error {
 	// booting and consider a new recovery system as as seeded
 	oldDeviceContext := rc.GroundContext()
 	newDeviceContext := &rc.groundDeviceContext
-	rc.st.Unlock()
-	err := boot.DeviceChange(oldDeviceContext, newDeviceContext)
-	rc.st.Lock()
+	// XXX => State method
+	unlocker := func() func() {
+		rc.st.Unlock()
+		return func() {
+			rc.st.Lock()
+		}
+	}
+	err := boot.DeviceChange(oldDeviceContext, newDeviceContext, unlocker)
 	if err != nil {
 		return fmt.Errorf("cannot switch device: %v", err)
 	}

--- a/overlord/devicestate/remodel_test.go
+++ b/overlord/devicestate/remodel_test.go
@@ -988,7 +988,7 @@ func (s *uc20RemodelLogicSuite) SetUpTest(c *C) {
 	err := m.WriteTo("")
 	c.Assert(err, IsNil)
 
-	restore := boot.MockResealKeyToModeenv(func(_ string, m *boot.Modeenv, expectReseal bool) error {
+	restore := boot.MockResealKeyToModeenv(func(_ string, m *boot.Modeenv, expectReseal bool, _ boot.Unlocker) error {
 		return fmt.Errorf("not expected to be called")
 	})
 	s.AddCleanup(restore)
@@ -1089,7 +1089,7 @@ func (s *uc20RemodelLogicSuite) TestReregRemodelContextUC20(c *C) {
 	c.Assert(err, IsNil)
 
 	resealKeysCalls := 0
-	restore := boot.MockResealKeyToModeenv(func(_ string, m *boot.Modeenv, expectReseal bool) error {
+	restore := boot.MockResealKeyToModeenv(func(_ string, m *boot.Modeenv, expectReseal bool, u boot.Unlocker) error {
 		resealKeysCalls++
 		c.Check(m.CurrentRecoverySystems, DeepEquals, []string{"0000", "1234"})
 		c.Check(m.GoodRecoverySystems, DeepEquals, []string{"0000", "1234"})
@@ -1107,10 +1107,10 @@ func (s *uc20RemodelLogicSuite) TestReregRemodelContextUC20(c *C) {
 		default:
 			c.Fatalf("unexpected call #%v to reseal key to modeenv", resealKeysCalls)
 		}
+		// check unlocker
+		u()()
 		// this is running as part of post finish step, so the state has
 		// already been updated
-		s.state.Lock()
-		defer s.state.Unlock()
 		serial, err = s.mgr.Serial()
 		c.Assert(err, IsNil)
 		c.Check(serial.Model(), Equals, "other-model")
@@ -1199,7 +1199,7 @@ func (s *uc20RemodelLogicSuite) TestUpdateRemodelContext(c *C) {
 	c.Assert(chg.Get("new-model", &encNewModel), IsNil)
 
 	resealKeysCalls := 0
-	restore := boot.MockResealKeyToModeenv(func(_ string, m *boot.Modeenv, expectReseal bool) error {
+	restore := boot.MockResealKeyToModeenv(func(_ string, m *boot.Modeenv, expectReseal bool, u boot.Unlocker) error {
 		resealKeysCalls++
 		c.Check(m.CurrentRecoverySystems, DeepEquals, []string{"0000", "1234"})
 		c.Check(m.GoodRecoverySystems, DeepEquals, []string{"0000", "1234"})
@@ -1219,6 +1219,8 @@ func (s *uc20RemodelLogicSuite) TestUpdateRemodelContext(c *C) {
 		default:
 			c.Fatalf("unexpected call #%v to reseal key to modeenv", resealKeysCalls)
 		}
+		// check unlocker
+		u()()
 		return nil
 	})
 	s.AddCleanup(restore)
@@ -1298,7 +1300,7 @@ func (s *uc20RemodelLogicSuite) TestSimpleRemodelErr(c *C) {
 	c.Assert(chg.Get("new-model", &encNewModel), IsNil)
 
 	resealKeysCalls := 0
-	restore := boot.MockResealKeyToModeenv(func(_ string, m *boot.Modeenv, expectReseal bool) error {
+	restore := boot.MockResealKeyToModeenv(func(_ string, m *boot.Modeenv, expectReseal bool, u boot.Unlocker) error {
 		resealKeysCalls++
 		c.Check(m.CurrentRecoverySystems, DeepEquals, []string{"0000", "1234"})
 		c.Check(m.GoodRecoverySystems, DeepEquals, []string{"0000", "1234"})
@@ -1313,6 +1315,8 @@ func (s *uc20RemodelLogicSuite) TestSimpleRemodelErr(c *C) {
 		default:
 			c.Fatalf("unexpected call #%v to reseal key to modeenv", resealKeysCalls)
 		}
+		// check unlocker
+		u()()
 		return nil
 	})
 	s.AddCleanup(restore)

--- a/overlord/state/state.go
+++ b/overlord/state/state.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2022 Canonical Ltd
+ * Copyright (C) 2016-2023 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -219,6 +219,15 @@ var (
 	unlockCheckpointRetryMaxTime  = 5 * time.Minute
 	unlockCheckpointRetryInterval = 3 * time.Second
 )
+
+// Unlocker returns a closure that will unlock and checkpoint the state and
+// in turn return a function to relock it.
+func (s *State) Unlocker() (unlock func() (relock func())) {
+	return func() func() {
+		s.Unlock()
+		return s.Lock
+	}
+}
 
 // Unlock releases the state lock and checkpoints the state.
 // It does not return until the state is correctly checkpointed.

--- a/overlord/state/state_test.go
+++ b/overlord/state/state_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2022 Canonical Ltd
+ * Copyright (C) 2016-2023 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -54,6 +54,17 @@ func (ss *stateSuite) TestLockUnlock(c *C) {
 	st := state.New(nil)
 	st.Lock()
 	st.Unlock()
+}
+
+func (ss *stateSuite) TestUnlocker(c *C) {
+	st := state.New(nil)
+	unlocker := st.Unlocker()
+	st.Lock()
+	defer st.Unlock()
+	relock := unlocker()
+	st.Lock()
+	st.Unlock()
+	relock()
 }
 
 func (ss *stateSuite) TestGetAndSet(c *C) {


### PR DESCRIPTION
this should allow to release the global state lock while doing resealing/sealing proper as those are slow operations in fact