### PR TITLE
interfaces: make network-status implicit on core - it is required for using the network portal

### DIFF
--- a/interfaces/builtin/network_status.go
+++ b/interfaces/builtin/network_status.go
@@ -50,6 +50,7 @@ func init() {
 		commonInterface: commonInterface{
 			name:                  "network-status",
 			summary:               networkStatusSummary,
+			implicitOnCore:        true,
 			implicitOnClassic:     true,
 			baseDeclarationSlots:  networkStatusBaseDeclarationSlots,
 			connectedPlugAppArmor: networkStatusConnectedPlugAppArmor,


### PR DESCRIPTION
This is a patch we've been using in the Core Desktop snapd tree for a while but had forgotten to upstream.

The `network-status` interface is used as a marker interface by `xdg-desktop-portal` to decide whether to provide access network connectivity portal API. We are using `xdg-desktop-portal` on Core Desktop, so needed to make this implicit slot available on core too.

We currently have one spread test for the interface in `tests/main/interfaces-network-status-classic`, but it is hard to get this running with any of the `ubuntu-core-*` backends since none of them currently include xdg-desktop-portal.