### PR TITLE
interfaces: make steam-support implicit on core

### DIFF
--- a/interfaces/builtin/steam_support.go
+++ b/interfaces/builtin/steam_support.go
@@ -399,7 +399,7 @@ func init() {
 	registerIface(&steamSupportInterface{commonInterface{
 		name:                  "steam-support",
 		summary:               steamSupportSummary,
-		implicitOnCore:        false,
+		implicitOnCore:        true,
 		implicitOnClassic:     true,
 		baseDeclarationSlots:  steamSupportBaseDeclarationSlots,
 		baseDeclarationPlugs:  steamSupportBaseDeclarationPlugs,

--- a/interfaces/builtin/steam_support.go
+++ b/interfaces/builtin/steam_support.go
@@ -22,6 +22,7 @@ package builtin
 import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/udev"
+	"github.com/snapcore/snapd/release"
 )
 
 const steamSupportSummary = `allow Steam to configure pressure-vessel containers`
@@ -399,7 +400,7 @@ func init() {
 	registerIface(&steamSupportInterface{commonInterface{
 		name:                  "steam-support",
 		summary:               steamSupportSummary,
-		implicitOnCore:        true,
+		implicitOnCore:        release.OnCoreDesktop,
 		implicitOnClassic:     true,
 		baseDeclarationSlots:  steamSupportBaseDeclarationSlots,
 		baseDeclarationPlugs:  steamSupportBaseDeclarationPlugs,

--- a/interfaces/builtin/steam_support_test.go
+++ b/interfaces/builtin/steam_support_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/interfaces/udev"
+	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -98,4 +99,12 @@ func (s *SteamSupportInterfaceSuite) TestUDevSpec(c *C) {
 	c.Assert(spec.Snippets(), HasLen, 2)
 	c.Assert(spec.Snippets()[0], testutil.Contains, `SUBSYSTEM=="usb", ATTRS{idVendor}=="28de", MODE="0660", TAG+="uaccess"`)
 	c.Assert(spec.Snippets()[1], testutil.Contains, `KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="114d", ATTRS{idProduct}=="8a12", MODE="0660", TAG+="uaccess"`)
+}
+
+func (s *SteamSupportInterfaceSuite) TestStaticInfo(c *C) {
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Assert(si.ImplicitOnCore, Equals, release.OnCoreDesktop)
+	c.Assert(si.ImplicitOnClassic, Equals, true)
+	c.Assert(si.Summary, Equals, `allow Steam to configure pressure-vessel containers`)
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "steam-support")
 }


### PR DESCRIPTION
This is a commit we've had in the Core Desktop snapd tree for a while that had not been proposed upstream.

We would like to be able to run the Steam snap on Core Desktop. We've got everything else working, so providing an implicit `steam-support` slot on core was the last piece of the puzzle. Everything else is similar enough not to be a problem.

Currently there are no Spread tests for steam-support, so there's nothing obvious to update on that side.