### PR TITLE
snap/squashfs: enforce a minimum snap size to eliminate some kernel log noise

### DIFF
--- a/snap/integrity/integrity_test.go
+++ b/snap/integrity/integrity_test.go
@@ -218,6 +218,9 @@ func (s *IntegrityTestSuite) TestGenerateAndAppendSuccess(c *C) {
 
 	snapPath, _ := snaptest.MakeTestSnapInfoWithFiles(c, "name: foo\nversion: 1.0", nil, nil)
 
+	// 8192 is the hash size that is created when running 'veritysetup format'
+	// on a minimally sized snap. there is not an easy way to calculate this
+	// value dynamically.
 	const verityHashSize = 8192
 
 	// mock the verity-setup command, what it does is make a copy of the snap

--- a/snap/integrity/integrity_test.go
+++ b/snap/integrity/integrity_test.go
@@ -218,6 +218,8 @@ func (s *IntegrityTestSuite) TestGenerateAndAppendSuccess(c *C) {
 
 	snapPath, _ := snaptest.MakeTestSnapInfoWithFiles(c, "name: foo\nversion: 1.0", nil, nil)
 
+	const verityHashSize = 8192
+
 	// mock the verity-setup command, what it does is make a copy of the snap
 	// and then returns pre-calculated output
 	vscmd := testutil.MockCommand(c, "veritysetup", fmt.Sprintf(`
@@ -227,11 +229,11 @@ case "$1" in
 		exit 0
 		;;
 	format)
-		cp %[1]s %[1]s.verity
-		echo "VERITY header information for %[1]s.verity"
+		truncate -s %[1]d %[2]s.verity
+		echo "VERITY header information for %[2]s.verity"
 		echo "UUID:            	f8b4f201-fe4e-41a2-9f1d-4908d3c76632"
 		echo "Hash type:       	1"
-		echo "Data blocks:     	1"
+		echo "Data blocks:     	4"
 		echo "Data block size: 	4096"
 		echo "Hash block size: 	4096"
 		echo "Hash algorithm:  	sha256"
@@ -239,7 +241,7 @@ case "$1" in
 		echo "Root hash:      	e2926364a8b1242d92fb1b56081e1ddb86eba35411961252a103a1c083c2be6d"
 		;;
 esac
-`, snapPath))
+`, verityHashSize, snapPath))
 	defer vscmd.Restore()
 
 	snapFileInfo, err := os.Stat(snapPath)
@@ -266,7 +268,7 @@ esac
 	err = integrityDataHeader.Decode(header)
 	c.Check(err, IsNil)
 	c.Check(integrityDataHeader.Type, Equals, "integrity")
-	c.Check(integrityDataHeader.Size, Equals, uint64(2*4096))
+	c.Check(integrityDataHeader.Size, Equals, uint64(verityHashSize+integrity.HeaderSize))
 	c.Check(integrityDataHeader.DmVerity.RootHash, HasLen, 64)
 
 	c.Assert(vscmd.Calls(), HasLen, 2)

--- a/snap/pack/pack_test.go
+++ b/snap/pack/pack_test.go
@@ -482,7 +482,7 @@ case "$1" in
 		echo "VERITY header information for %[2]s/hello_0_all.snap.verity"
 		echo "UUID:            	606d10a2-24d8-4c6b-90cf-68207aa7c850"
 		echo "Hash type:       	1"
-		echo "Data blocks:     	1"
+		echo "Data blocks:     	4"
 		echo "Data block size: 	4096"
 		echo "Hash block size: 	4096"
 		echo "Hash algorithm:  	sha256"

--- a/snap/pack/pack_test.go
+++ b/snap/pack/pack_test.go
@@ -467,6 +467,9 @@ func (s *packSuite) TestPackWithIntegrity(c *C) {
 	sourceDir := makeExampleSnapSourceDir(c, "{name: hello, version: 0}")
 	targetDir := c.MkDir()
 
+	// 8192 is the hash size that is created when running 'veritysetup format'
+	// on a minimally sized snap. there is not an easy way to calculate this
+	// value dynamically.
 	const verityHashSize = 8192
 
 	// mock the verity-setup command, what it does is make a copy of the snap

--- a/snap/pack/pack_test.go
+++ b/snap/pack/pack_test.go
@@ -509,7 +509,7 @@ esac
 	c.Assert(err, IsNil)
 	defer snapFile.Close()
 
-	// example snap has a size of 4096 (1 block)
+	// example snap has a size of 16384 (4 blocks)
 	_, err = snapFile.Seek(squashfs.MinimumSnapSize, io.SeekStart)
 	c.Assert(err, IsNil)
 

--- a/snap/squashfs/export_test.go
+++ b/snap/squashfs/export_test.go
@@ -88,3 +88,11 @@ func MockIsRootWritableOverlay(new func() (string, error)) (restore func()) {
 		isRootWritableOverlay = old
 	}
 }
+
+func MockTruncateSnapToMinSize(newTruncate func(string, int64) error) (restore func()) {
+	oldTruncate := truncateSnapToMinSize
+	truncateSnapToMinSize = newTruncate
+	return func() {
+		truncateSnapToMinSize = oldTruncate
+	}
+}

--- a/snap/squashfs/export_test.go
+++ b/snap/squashfs/export_test.go
@@ -88,11 +88,3 @@ func MockIsRootWritableOverlay(new func() (string, error)) (restore func()) {
 		isRootWritableOverlay = old
 	}
 }
-
-func MockGrowSnapToMinSize(newGrow func(string, int64) error) (restore func()) {
-	oldGrow := growSnapToMinSize
-	growSnapToMinSize = newGrow
-	return func() {
-		growSnapToMinSize = oldGrow
-	}
-}

--- a/snap/squashfs/export_test.go
+++ b/snap/squashfs/export_test.go
@@ -89,10 +89,10 @@ func MockIsRootWritableOverlay(new func() (string, error)) (restore func()) {
 	}
 }
 
-func MockTruncateSnapToMinSize(newTruncate func(string, int64) error) (restore func()) {
-	oldTruncate := truncateSnapToMinSize
-	truncateSnapToMinSize = newTruncate
+func MockGrowSnapToMinSize(newGrow func(string, int64) error) (restore func()) {
+	oldGrow := growSnapToMinSize
+	growSnapToMinSize = newGrow
 	return func() {
-		truncateSnapToMinSize = oldTruncate
+		growSnapToMinSize = oldGrow
 	}
 }

--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -554,14 +554,15 @@ func (s *Snap) Build(sourceDir string, opts *BuildOpts) error {
 		cmd.Args = append(cmd.Args, "-all-root", "-no-xattrs")
 	}
 
-	if err := osutil.ChDir(sourceDir, func() error {
+	err = osutil.ChDir(sourceDir, func() error {
 		output, err := cmd.CombinedOutput()
 		if err != nil {
 			return MksquashfsError{fmt.Sprintf("mksquashfs call failed: %s", osutil.OutputErr(output, err))}
 		}
 
 		return nil
-	}); err != nil {
+	})
+	if err != nil {
 		return err
 	}
 

--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -611,7 +611,7 @@ var growSnapToMinSize = func(snapPath string, minSize int64) error {
 	}
 
 	if err := os.Truncate(snapPath, minSize); err != nil {
-		return fmt.Errorf("cannot truncate snap: %w", err)
+		return fmt.Errorf("cannot grow snap to minimum size: %w", err)
 	}
 
 	return nil

--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -565,9 +565,9 @@ func (s *Snap) Build(sourceDir string, opts *BuildOpts) error {
 		return err
 	}
 
-	// grow the snap larger if it is smaller than the minimum snap size. see
-	// MinimumSnapSize for more details
-	return truncateSnapToMinSize(fullSnapPath, MinimumSnapSize)
+	// Grow the snap larger if it is smaller than the minimum snap size. See
+	// MinimumSnapSize for more details.
+	return growSnapToMinSize(fullSnapPath, MinimumSnapSize)
 }
 
 // BuildDate returns the "Creation or last append time" as reported by unsquashfs.
@@ -600,7 +600,7 @@ func BuildDate(path string) time.Time {
 	return t0
 }
 
-var truncateSnapToMinSize = func(snapPath string, minSize int64) error {
+var growSnapToMinSize = func(snapPath string, minSize int64) error {
 	info, err := os.Stat(snapPath)
 	if err != nil {
 		return fmt.Errorf("cannot get size of snap: %w", err)

--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -565,7 +565,7 @@ func (s *Snap) Build(sourceDir string, opts *BuildOpts) error {
 		return err
 	}
 
-	// Grow the snap larger if it is smaller than the minimum snap size. See
+	// Grow the snap if it is smaller than the minimum snap size. See
 	// MinimumSnapSize for more details.
 	return growSnapToMinSize(fullSnapPath, MinimumSnapSize)
 }

--- a/snap/squashfs/squashfs_test.go
+++ b/snap/squashfs/squashfs_test.go
@@ -997,5 +997,5 @@ func (s *SquashfsTestSuite) TestBuildAboveMinimumSize(c *C) {
 	size, err := sn.Size()
 	c.Assert(err, IsNil)
 
-	c.Assert(int(size), testutil.IntGreaterThan, int(squashfs.MinimumSnapSize))
+	c.Assert(int(size), testutil.IntGreaterThan, int(squashfs.MinimumSnapSize), Commentf("random snap data: %s", randomData))
 }

--- a/snap/squashfs/squashfs_test.go
+++ b/snap/squashfs/squashfs_test.go
@@ -671,7 +671,7 @@ func (s *SquashfsTestSuite) TestBuildSupportsMultipleExcludesWithOnlyOneWildcard
 	})()
 	mksq := testutil.MockCommand(c, "mksquashfs", "")
 	defer mksq.Restore()
-	defer squashfs.MockTruncateSnapToMinSize(func(string, int64) error {
+	defer squashfs.MockGrowSnapToMinSize(func(string, int64) error {
 		return nil
 	})()
 
@@ -701,7 +701,7 @@ func (s *SquashfsTestSuite) TestBuildUsesMksquashfsFromCoreIfAvailable(c *C) {
 	})()
 	mksq := testutil.MockCommand(c, "mksquashfs", "exit 1")
 	defer mksq.Restore()
-	defer squashfs.MockTruncateSnapToMinSize(func(string, int64) error {
+	defer squashfs.MockGrowSnapToMinSize(func(string, int64) error {
 		return nil
 	})()
 
@@ -723,7 +723,7 @@ func (s *SquashfsTestSuite) TestBuildUsesMksquashfsFromClassicIfCoreUnavailable(
 	})()
 	mksq := testutil.MockCommand(c, "mksquashfs", "")
 	defer mksq.Restore()
-	defer squashfs.MockTruncateSnapToMinSize(func(string, int64) error {
+	defer squashfs.MockGrowSnapToMinSize(func(string, int64) error {
 		return nil
 	})()
 
@@ -761,7 +761,7 @@ func (s *SquashfsTestSuite) TestBuildVariesArgsByType(c *C) {
 	})()
 	mksq := testutil.MockCommand(c, "mksquashfs", "")
 	defer mksq.Restore()
-	defer squashfs.MockTruncateSnapToMinSize(func(string, int64) error {
+	defer squashfs.MockGrowSnapToMinSize(func(string, int64) error {
 		return nil
 	})()
 

--- a/snap/squashfs/squashfs_test.go
+++ b/snap/squashfs/squashfs_test.go
@@ -985,7 +985,7 @@ func (s *SquashfsTestSuite) TestBuildBelowMinimumSize(c *C) {
 	size, err := sn.Size()
 	c.Assert(err, IsNil)
 
-	c.Assert(int(size), testutil.IntEqual, int(squashfs.MinimumSnapSize))
+	c.Assert(size, Equals, squashfs.MinimumSnapSize)
 }
 
 func (s *SquashfsTestSuite) TestBuildAboveMinimumSize(c *C) {


### PR DESCRIPTION
Some kernel versions will log messages such as
```
[13026.677193] Dev loop12: unable to read RDB block 8
[13026.678051] loop12: unable to read partition table
[13026.678093] loop12: partition table beyond EOD, truncated
```
when creating a loopback device for squashfs files that are smaller than 16KB. To eliminate this log noise, we can enforce a minimum snap size of 16KB. This should only impact really small snaps, such as the `bare` snap.

Note that `losetup` prints a warning when creating a loopback device for truncated snaps:
```
# truncate -s 16KB bare_5.snap 
# losetup -f bare_5.snap
losetup: bare_5.snap: Warning: file does not fit into a 512-byte sector; the end of the file will be ignored.
```

See https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1979633 for more relevant details.