### PR TITLE
o/snapstate: pass name instead of SnapSetup in pre-dl funcs

### DIFF
--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -433,7 +433,7 @@ func (m *autoRefresh) restoreMonitoring() error {
 
 		refreshCtx, abort := context.WithCancel(context.Background())
 		aborts[snapName] = abort
-		go continueRefreshOnSnapClose(m.state, snap, done, refreshCtx)
+		go continueRefreshOnSnapClose(m.state, snap.InstanceName(), done, refreshCtx)
 	}
 
 	m.state.Cache("monitored-snaps", aborts)


### PR DESCRIPTION
Use the snap name instead of a SnapSetup to make it clear that the monitoring process is not revision specific (since we use only the name to get the latest refresh candidate) and it doesn't need to be updated if a new revision is pre-downloaded.