### PR TITLE
aspects: support user-defined types in schemas

### DIFF
--- a/aspects/aspects.go
+++ b/aspects/aspects.go
@@ -220,6 +220,8 @@ var (
 	subkeyRegex      = "(?:[a-z0-9]+-?)*[a-z](?:-?[a-z0-9])*"
 	validSubkey      = regexp.MustCompile(fmt.Sprintf("^%s$", subkeyRegex))
 	validPlaceholder = regexp.MustCompile(fmt.Sprintf("^{%s}$", subkeyRegex))
+	// TODO: decide on what the format should be for user-defined types in schemas
+	validUserType = validSubkey
 )
 
 // validateAspectDottedPath validates that names/paths in an aspect definition are:

--- a/aspects/schema.go
+++ b/aspects/schema.go
@@ -52,7 +52,7 @@ func ParseSchema(raw []byte) (*StorageSchema, error) {
 		}
 
 		if typ != "map" {
-			return nil, fmt.Errorf(`cannot parse top level schema: expected map but got %s`, typ)
+			return nil, fmt.Errorf(`cannot parse top level schema: unexpected declared type %q, should be "map" or omitted`, typ)
 		}
 	}
 

--- a/aspects/schema.go
+++ b/aspects/schema.go
@@ -69,6 +69,10 @@ func ParseSchema(raw []byte) (*StorageSchema, error) {
 
 		schema.userTypes = make(map[string]parser, len(userTypes))
 		for userTypeName, typeDef := range userTypes {
+			if !validUserType.Match([]byte(userTypeName)) {
+				return nil, fmt.Errorf(`cannot parse user-defined type name %q: must match %s`, userTypeName, validUserType)
+			}
+
 			userTypeSchema, err := schema.parse(typeDef)
 			if err != nil {
 				return nil, fmt.Errorf(`cannot parse user-defined type %q: %w`, userTypeName, err)

--- a/aspects/schema_test.go
+++ b/aspects/schema_test.go
@@ -668,20 +668,20 @@ func (*schemaSuite) TestStringBasedUserType(c *C) {
 func (*schemaSuite) TestMapKeyMustBeStringUserType(c *C) {
 	schemaStr := []byte(`{
   "types": {
-    "keyType": {
+    "key-type": {
       "type": "map",
 			"schema": {}
     }
   },
   "schema": {
     "snaps": {
-      "keys": "$keyType"
+      "keys": "$key-type"
     }
   }
 }`)
 
 	_, err := aspects.ParseSchema(schemaStr)
-	c.Assert(err, ErrorMatches, `cannot parse "keys" constraint: key type "keyType" must be based on string`)
+	c.Assert(err, ErrorMatches, `cannot parse "keys" constraint: key type "key-type" must be based on string`)
 }
 
 func (*schemaSuite) TestUserDefinedTypesWrongFormat(c *C) {
@@ -803,4 +803,26 @@ func (*schemaSuite) TestMapBasedUserDefinedTypeFail(c *C) {
 
 	err = schema.Validate(input)
 	c.Assert(err, ErrorMatches, `cannot validate string: json: .*`)
+}
+
+func (*schemaSuite) TestBadUserDefinedTypeName(c *C) {
+	schemaStr := []byte(`{
+	"types": {
+		"-foo": {
+			"schema": {
+				"name": "string",
+				"version": "string"
+			}
+		}
+	},
+	"schema": {
+		"snaps": {
+			"values": "$-foo"
+		}
+	}
+}`)
+
+	_, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, `cannot parse user-defined type name "-foo": must match ^(?:[a-z0-9]+-?)*[a-z](?:-?[a-z0-9])*$`)
 }

--- a/aspects/schema_test.go
+++ b/aspects/schema_test.go
@@ -52,7 +52,7 @@ func (*schemaSuite) TestTopLevelMustBeMapType(c *C) {
 }`)
 
 	_, err := aspects.ParseSchema(schemaStr)
-	c.Assert(err, ErrorMatches, `cannot parse top level schema: expected map but got string`)
+	c.Assert(err, ErrorMatches, `cannot parse top level schema: unexpected declared type "string", should be "map" or omitted`)
 
 	schemaStr = []byte(`{
 		"type": "map",

--- a/aspects/schema_test.go
+++ b/aspects/schema_test.go
@@ -619,43 +619,43 @@ func (*schemaSuite) TestStringChoicesWrongFormat(c *C) {
 
 func (*schemaSuite) TestStringBasedUserType(c *C) {
 	schemaStr := []byte(`{
-  "types": {
-    "snap-name": {
-      "type": "string",
+	"types": {
+		"snap-name": {
+			"type": "string",
 			"pattern": "^[a-z0-9-]*[a-z][a-z0-9-]*$"
-    },
+		},
 		"status": {
 			"type": "string",
 			"choices": ["active", "inactive"]
 		}
-  },
-  "schema": {
-    "snaps": {
-      "keys": "$snap-name",
-      "values": {
-        "schema": {
-          "name": "$snap-name",
-          "version": "string",
-          "status": "$status"
-        }
-      }
-    }
-  }
+	},
+	"schema": {
+		"snaps": {
+			"keys": "$snap-name",
+			"values": {
+				"schema": {
+					"name": "$snap-name",
+					"version": "string",
+					"status": "$status"
+				}
+			}
+		}
+	}
 }`)
 
 	input := []byte(`{
-  "snaps": {
-    "core20": {
-      "name": "core20",
-      "version": "20230503",
-      "status": "active"
-    },
-    "snapd": {
-      "name": "snapd",
-      "version": "2.59.5+git948.gb447044",
-      "status": "inactive"
-    }
-  }
+	"snaps": {
+		"core20": {
+			"name": "core20",
+			"version": "20230503",
+			"status": "active"
+		},
+		"snapd": {
+			"name": "snapd",
+			"version": "2.59.5+git948.gb447044",
+			"status": "inactive"
+		}
+	}
 }`)
 
 	schema, err := aspects.ParseSchema(schemaStr)
@@ -667,17 +667,17 @@ func (*schemaSuite) TestStringBasedUserType(c *C) {
 
 func (*schemaSuite) TestMapKeyMustBeStringUserType(c *C) {
 	schemaStr := []byte(`{
-  "types": {
-    "key-type": {
-      "type": "map",
+	"types": {
+		"key-type": {
+			"type": "map",
 			"schema": {}
-    }
-  },
-  "schema": {
-    "snaps": {
-      "keys": "$key-type"
-    }
-  }
+		}
+	},
+	"schema": {
+		"snaps": {
+			"keys": "$key-type"
+		}
+	}
 }`)
 
 	_, err := aspects.ParseSchema(schemaStr)
@@ -686,7 +686,7 @@ func (*schemaSuite) TestMapKeyMustBeStringUserType(c *C) {
 
 func (*schemaSuite) TestUserDefinedTypesWrongFormat(c *C) {
 	schemaStr := []byte(`{
-  "types": ["foo"],
+	"types": ["foo"],
 	"schema": {}
 }`)
 
@@ -696,11 +696,11 @@ func (*schemaSuite) TestUserDefinedTypesWrongFormat(c *C) {
 
 func (*schemaSuite) TestBadUserDefinedType(c *C) {
 	schemaStr := []byte(`{
-  "types": {
-    "mytype": {
-      "type": "bad-type"
-    }
-  },
+	"types": {
+		"mytype": {
+			"type": "bad-type"
+		}
+	},
 	"schema": {}
 }`)
 
@@ -710,11 +710,11 @@ func (*schemaSuite) TestBadUserDefinedType(c *C) {
 
 func (*schemaSuite) TestUnknownUserDefinedType(c *C) {
 	schemaStr := []byte(`{
-  "schema": {
-    "snaps": {
-      "values": "$foo"
-    }
-  }
+	"schema": {
+		"snaps": {
+			"values": "$foo"
+		}
+	}
 }`)
 
 	_, err := aspects.ParseSchema(schemaStr)
@@ -723,11 +723,11 @@ func (*schemaSuite) TestUnknownUserDefinedType(c *C) {
 
 func (*schemaSuite) TestUnknownUserDefinedTypeInKeys(c *C) {
 	schemaStr := []byte(`{
-  "schema": {
-    "snaps": {
-      "keys": "$foo"
-    }
-  }
+	"schema": {
+		"snaps": {
+			"keys": "$foo"
+		}
+	}
 }`)
 
 	_, err := aspects.ParseSchema(schemaStr)
@@ -736,33 +736,33 @@ func (*schemaSuite) TestUnknownUserDefinedTypeInKeys(c *C) {
 
 func (*schemaSuite) TestMapBasedUserDefinedTypeHappy(c *C) {
 	schemaStr := []byte(`{
-  "types": {
-    "snap": {
+	"types": {
+		"snap": {
 			"schema": {
 				"name": "string",
 				"status": "string"
 			}
-    }
-  },
-  "schema": {
-    "snaps": {
-      "values": "$snap"
-    }
-  }
+		}
+	},
+	"schema": {
+		"snaps": {
+			"values": "$snap"
+		}
+	}
 }`)
 
 	input := []byte(`{
-  "snaps": {
-    "core20": {
-      "name": "core20",
-      "version": "20230503",
-      "status": "active"
-    },
-    "snapd": {
-      "name": "snapd",
-      "status": "inactive"
-    }
-  }
+	"snaps": {
+		"core20": {
+			"name": "core20",
+			"version": "20230503",
+			"status": "active"
+		},
+		"snapd": {
+			"name": "snapd",
+			"status": "inactive"
+		}
+	}
 }`)
 
 	schema, err := aspects.ParseSchema(schemaStr)
@@ -774,28 +774,28 @@ func (*schemaSuite) TestMapBasedUserDefinedTypeHappy(c *C) {
 
 func (*schemaSuite) TestMapBasedUserDefinedTypeFail(c *C) {
 	schemaStr := []byte(`{
-  "types": {
-    "snap": {
+	"types": {
+		"snap": {
 			"schema": {
 				"name": "string",
 				"version": "string"
 			}
-    }
-  },
-  "schema": {
-    "snaps": {
-      "values": "$snap"
-    }
-  }
+		}
+	},
+	"schema": {
+		"snaps": {
+			"values": "$snap"
+		}
+	}
 }`)
 
 	input := []byte(`{
-  "snaps": {
-    "core20": {
-      "name": "core20",
-      "version": 123
-    }
-  }
+	"snaps": {
+		"core20": {
+			"name": "core20",
+			"version": 123
+		}
+	}
 }`)
 
 	schema, err := aspects.ParseSchema(schemaStr)


### PR DESCRIPTION
Adds support for user-defined types that can be based on any of the other built-in types and referred to in the schema definition with a '$' prefix.