### PR TITLE
wrappers: install session files

### DIFF
--- a/data/desktop/Makefile
+++ b/data/desktop/Makefile
@@ -26,6 +26,8 @@ AUTOSTART_FILES = $(AUTOSTART_SOURCES:.in=)
 ICON_FILES = snapcraft-logo-bird.svg
 ICON_FOLDER = /usr/share/snapd
 
+CORE_DESKTOP_WRAPPER_FILES = ubuntu-core-desktop-session-wrapper
+
 .PHONY: all
 all: $(DESKTOP_FILES) $(AUTOSTART_FILES)
 
@@ -42,6 +44,10 @@ install:: $(AUTOSTART_FILES)
 install:: $(ICON_FILES)
 	install -d -m 0755 $(DESTDIR)/$(ICON_FOLDER)
 	install -m 0644 -t $(DESTDIR)/$(ICON_FOLDER) $^
+
+install:: $(CORE_DESKTOP_WRAPPER_FILES)
+	install -d -m 0755 $(DESTDIR)/$(BINDIR)
+	install -m 0644 -t $(DESTDIR)/$(BINDDIR) $^
 
 .PHONY: clean
 clean:

--- a/data/desktop/ubuntu-core-desktop-session-wrapper
+++ b/data/desktop/ubuntu-core-desktop-session-wrapper
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# This script runs outside of snap confinement as a wrapper around the
+# confined desktop session.
+snap_cmd="$1"
+snap_name="$(echo "$snap_cmd" | cut -d . -f 1)"
+
+# Set up PATH and XDG_DATA_DIRS to allow calling snaps
+if [ -f /snap/snapd/current/etc/profile.d/apps-bin-path.sh ]; then
+    source /snap/snapd/current/etc/profile.d/apps-bin-path.sh
+fi
+
+export XDG_CURRENT_DESKTOP=ubuntu:GNOME
+export GSETTINGS_BACKEND=keyfile
+
+dbus-update-activation-environment --systemd --all
+
+# Don't set this in our own environment, since it will make
+# gnome-session believe it is running in X mode
+dbus-update-activation-environment --systemd DISPLAY=:0 WAYLAND_DISPLAY=wayland-0
+
+# Set up a background task to wait for gnome-session to create its
+# Xauthority file, and copy it to a location snaps will be able to
+# see.
+function fixup_xauthority() {
+    while :; do
+        sleep 1s
+        xauth_file="$(find "$XDG_RUNTIME_DIR"/snap."$snap_name" -maxdepth 1 -name ".mutter-Xwaylandauth.*" | head -n1)"
+        if [ -f "$xauth_file" ]; then
+            cp "$xauth_file" "$XDG_RUNTIME_DIR"/.Xauthority
+            return
+        fi
+    done
+}
+fixup_xauthority &
+
+# Symlink the Wayland socket from the snap's private directory
+ln -sf "snap.$snap_name/wayland-0" "$XDG_RUNTIME_DIR"/wayland-0
+# Symlink sockets for pipewire and pipewire-pulse
+ln -sf "snap.$snap_name/pipewire-0" "$XDG_RUNTIME_DIR"/pipewire-0
+ln -sf "snap.$snap_name/pulse" "$XDG_RUNTIME_DIR"/pulse
+
+exec "/snap/bin/$snap_cmd"

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -102,6 +102,7 @@ var (
 	SnapSystemdConfDir     string
 	SnapDesktopFilesDir    string
 	SnapDesktopIconsDir    string
+	SnapWaylandSessionsDir string
 	SnapPolkitPolicyDir    string
 	SnapSystemdDir         string
 	SnapSystemdRunDir      string
@@ -460,6 +461,7 @@ func SetRootDir(rootdir string) {
 	// freedesktop.org specifications
 	SnapDesktopFilesDir = filepath.Join(rootdir, snappyDir, "desktop", "applications")
 	SnapDesktopIconsDir = filepath.Join(rootdir, snappyDir, "desktop", "icons")
+	SnapWaylandSessionsDir = filepath.Join(rootdir, "/usr/share/wayland-sessions")
 	RunDir = filepath.Join(rootdir, "/run")
 	SnapRunDir = filepath.Join(rootdir, "/run/snapd")
 	SnapRunNsDir = filepath.Join(SnapRunDir, "/ns")

--- a/overlord/snapstate/backend/link.go
+++ b/overlord/snapstate/backend/link.go
@@ -199,6 +199,12 @@ func (b Backend) generateWrappers(s *snap.Info, linkCtx LinkContext) error {
 	}
 	cleanupFuncs = append(cleanupFuncs, wrappers.RemoveSnapDBusActivationFiles)
 
+	// add the sessions.
+	if err = wrappers.EnsureSnapSessionFiles(s); err != nil {
+		return err
+	}
+	cleanupFuncs = append(cleanupFuncs, wrappers.RemoveSnapSessionFiles)
+
 	// add the desktop files
 	if err = wrappers.EnsureSnapDesktopFiles([]*snap.Info{s}); err != nil {
 		return err

--- a/wrappers/export_test.go
+++ b/wrappers/export_test.go
@@ -42,6 +42,9 @@ var (
 	UsersToUids               = usersToUids
 	NewUserServiceClientNames = newUserServiceClientNames
 
+	SanitizeSessionFile    = sanitizeSessionFile
+	IsValidSessionFileLine = isValidSessionFileLine
+
 	// icons
 	FindIconFiles = findIconFiles
 )

--- a/wrappers/session.go
+++ b/wrappers/session.go
@@ -1,0 +1,218 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package wrappers
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/snap"
+)
+
+var isValidSessionFileLine = regexp.MustCompile(strings.Join([]string{
+	// NOTE (mostly to self): as much as possible keep the
+	// individual regexp simple, optimize for legibility
+	//
+	// empty lines and comments
+	`^\s*$`,
+	`^\s*#`,
+	// headers
+	`^\[Desktop Entry\]$`,
+	// https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s05.html
+	"^Type=",
+	"^Version=",
+	"^Name" + localizedSuffix,
+	"^Comment" + localizedSuffix,
+	"^DesktopNames=",
+	"^Exec=",
+	// Note that we do not support TryExec, it does not make sense
+	// in the snap context
+	"^X-GDM-BypassXsession=",
+	// Ubuntu extension
+	"^X-GDM-SessionRegisters=",
+}, "|")).Match
+
+func findCommand(s *snap.Info, cmd string) (string, error) {
+	// Disallow anything that might try and get out of the snap path.
+	if strings.Contains(filepath.Clean(cmd), "..") {
+		return "", fmt.Errorf("exec command has non-local path: %q", cmd)
+	}
+	if filepath.IsAbs(cmd) {
+		return "", fmt.Errorf("exec command has absolute path: %q", cmd)
+	}
+
+	// Check if is in the snap directory.
+	baseDir := s.MountDir()
+	path := filepath.Join(baseDir, cmd)
+	_, err := os.Stat(path)
+	if err == nil {
+		return path, nil
+	}
+
+	// Check if in one of the standard directories that are in the path.
+	for _, dir := range []string{"bin", "usr/bin"} {
+		path := filepath.Join(baseDir, dir, cmd)
+		_, err := os.Stat(path)
+		if err == nil {
+			return path, nil
+		}
+	}
+
+	return "", fmt.Errorf("invalid exec command: %q", cmd)
+}
+
+// rewriteExecLine rewrites a "Exec=" line to use the session wrapper.
+func rewriteSessionExecLine(s *snap.Info, sessionFile, line string) (string, error) {
+	cmd := strings.SplitN(line, "=", 2)[1]
+
+	// The executable must be provided by this snap
+	var err error
+	absCmd, err := findCommand(s, cmd)
+	if err != nil {
+		return "", err
+	}
+
+	newExec := fmt.Sprintf("Exec=ubuntu-core-desktop-session-wrapper %s", absCmd)
+	logger.Noticef("rewriting desktop file %q to %q", sessionFile, newExec)
+
+	return newExec, nil
+}
+
+func sanitizeSessionFile(s *snap.Info, sessionFile string, rawcontent []byte) []byte {
+	var newContent bytes.Buffer
+	scanner := bufio.NewScanner(bytes.NewReader(rawcontent))
+	for i := 0; scanner.Scan(); i++ {
+		bline := scanner.Bytes()
+
+		if !isValidSessionFileLine(bline) {
+			logger.Debugf("ignoring line %d (%q) in source of session file %q", i, bline, filepath.Base(sessionFile))
+			continue
+		}
+
+		// rewrite exec lines to use the session wrapper.
+		if bytes.HasPrefix(bline, []byte("Exec=")) {
+			var err error
+			line, err := rewriteSessionExecLine(s, sessionFile, string(bline))
+			if err != nil {
+				// something went wrong, ignore the line
+				continue
+			}
+			bline = []byte(line)
+		}
+
+		newContent.Grow(len(bline) + 1)
+		newContent.Write(bline)
+		newContent.WriteByte('\n')
+
+		// insert snap name
+		if bytes.Equal(bline, []byte("[Desktop Entry]")) {
+			newContent.Write([]byte("X-SnapInstanceName=" + s.InstanceName() + "\n"))
+		}
+	}
+
+	return newContent.Bytes()
+}
+
+func deriveSessionFilesContent(s *snap.Info) (map[string]osutil.FileState, error) {
+	baseDir := s.MountDir()
+	sessionFiles, err := filepath.Glob(filepath.Join(baseDir, "usr/share/wayland-sessions", "*.desktop"))
+	if err != nil {
+		return nil, fmt.Errorf("cannot get wayland sessions for %v: %s", baseDir, err)
+	}
+
+	content := make(map[string]osutil.FileState)
+	for _, df := range sessionFiles {
+		base := filepath.Base(df)
+		fileContent, err := ioutil.ReadFile(df)
+		if err != nil {
+			return nil, err
+		}
+		// FIXME: don't blindly use the snap desktop filename, mangle it
+		// but we can't just use the app name because a desktop file
+		// may call the same app with multiple parameters, e.g.
+		// --create-new, --open-existing etc
+		base = fmt.Sprintf("%s_%s", s.DesktopPrefix(), base)
+		installedDesktopFileName := filepath.Join(dirs.SnapDesktopFilesDir, base)
+		fileContent = sanitizeDesktopFile(s, installedDesktopFileName, fileContent)
+		content[base] = &osutil.MemoryFileState{
+			Content: fileContent,
+			Mode:    0644,
+		}
+	}
+	return content, nil
+}
+
+// EnsureSnapSessionFiles puts in place the session files from the snap.
+//
+// It also removes session files from the applications of the old snap revision to ensure
+// that only new snap session files exist.
+func EnsureSnapSessionFiles(s *snap.Info) (err error) {
+	// Session files only supported on core desktop.
+	if !release.OnCoreDesktop {
+		return nil
+	}
+
+	// Desktop slot required to be allowed to provide sessions.
+	if s.Slots["desktop"] == nil {
+		return nil
+	}
+
+	if err := os.MkdirAll(dirs.SnapWaylandSessionsDir, 0755); err != nil {
+		return err
+	}
+
+	content, err := deriveSessionFilesContent(s)
+	if err != nil {
+		return err
+	}
+
+	sessionFilesGlob := fmt.Sprintf("%s_*.desktop", s.DesktopPrefix())
+	_, _, err = osutil.EnsureDirState(dirs.SnapWaylandSessionsDir, sessionFilesGlob, content)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// RemoveSnapSessionFiles removes the added session files for the snap.
+func RemoveSnapSessionFiles(s *snap.Info) error {
+	if !osutil.IsDirectory(dirs.SnapWaylandSessionsDir) {
+		return nil
+	}
+
+	sessionFilesGlob := fmt.Sprintf("%s_*.desktop", s.DesktopPrefix())
+	_, _, err := osutil.EnsureDirState(dirs.SnapWaylandSessionsDir, sessionFilesGlob, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/wrappers/session_test.go
+++ b/wrappers/session_test.go
@@ -1,0 +1,533 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package wrappers_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
+	"github.com/snapcore/snapd/wrappers"
+)
+
+type sessionSuite struct {
+	testutil.BaseTest
+	tempdir string
+}
+
+var _ = Suite(&sessionSuite{})
+
+func (s *sessionSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	s.BaseTest.AddCleanup(snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {}))
+	s.tempdir = c.MkDir()
+	dirs.SetRootDir(s.tempdir)
+}
+
+func (s *sessionSuite) TearDownTest(c *C) {
+	s.BaseTest.TearDownTest(c)
+	dirs.SetRootDir("")
+}
+
+var sessionSnapYaml = `
+name: foo
+version: 1.0
+slots:
+  desktop:
+    iface: desktop
+`
+
+var mockSessionFile = []byte(`
+[Desktop Entry]
+Name=foo
+Exec=snap-session
+`)
+
+var mockSessionBinary = []byte(`
+#!/bin/sh
+
+echo "Hello World"
+`)
+
+func (s *sessionSuite) TestEnsurePackageSessionFiles(c *C) {
+	reset := release.MockOnCoreDesktop(true)
+	defer reset()
+
+	expectedSessionFilePath := filepath.Join(dirs.SnapWaylandSessionsDir, "foo_foobar.desktop")
+	c.Assert(osutil.FileExists(expectedSessionFilePath), Equals, false)
+
+	info := snaptest.MockSnap(c, sessionSnapYaml, &snap.SideInfo{Revision: snap.R(11)})
+
+	// generate .desktop file in the package baseDir
+	baseDir := info.MountDir()
+	err := os.MkdirAll(filepath.Join(baseDir, "usr/share/wayland-sessions"), 0755)
+	c.Assert(err, IsNil)
+
+	err = ioutil.WriteFile(filepath.Join(baseDir, "usr/share/wayland-sessions", "foobar.desktop"), mockSessionFile, 0644)
+	c.Assert(err, IsNil)
+
+	err = wrappers.EnsureSnapSessionFiles(info)
+	c.Assert(err, IsNil)
+	c.Assert(osutil.FileExists(expectedSessionFilePath), Equals, true)
+}
+
+func (s *sessionSuite) TestRemovePackageSessionFiles(c *C) {
+	reset := release.MockOnCoreDesktop(true)
+	defer reset()
+
+	mockSessionFilePath := filepath.Join(dirs.SnapWaylandSessionsDir, "foo_foobar.desktop")
+
+	err := os.MkdirAll(dirs.SnapWaylandSessionsDir, 0755)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(mockSessionFilePath, mockSessionFile, 0644)
+	c.Assert(err, IsNil)
+	info, err := snap.InfoFromSnapYaml([]byte(sessionSnapYaml))
+	c.Assert(err, IsNil)
+
+	err = wrappers.RemoveSnapSessionFiles(info)
+	c.Assert(err, IsNil)
+	c.Assert(osutil.FileExists(mockSessionFilePath), Equals, false)
+}
+
+func (s *sessionSuite) TestParallelInstancesRemovePackageSessionFiles(c *C) {
+	reset := release.MockOnCoreDesktop(true)
+	defer reset()
+
+	mockSessionFilePath := filepath.Join(dirs.SnapWaylandSessionsDir, "foo_foobar.desktop")
+	mockSessionInstanceFilePath := filepath.Join(dirs.SnapWaylandSessionsDir, "foo+instance_foobar.desktop")
+
+	err := os.MkdirAll(dirs.SnapWaylandSessionsDir, 0755)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(mockSessionFilePath, mockSessionFile, 0644)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(mockSessionInstanceFilePath, mockSessionFile, 0644)
+	c.Assert(err, IsNil)
+	info, err := snap.InfoFromSnapYaml([]byte(sessionSnapYaml))
+	c.Assert(err, IsNil)
+
+	err = wrappers.RemoveSnapSessionFiles(info)
+	c.Assert(err, IsNil)
+	c.Assert(osutil.FileExists(mockSessionFilePath), Equals, false)
+	// foo+instance file is still there
+	c.Assert(osutil.FileExists(mockSessionInstanceFilePath), Equals, true)
+
+	// restore the non-instance file
+	err = ioutil.WriteFile(mockSessionFilePath, mockSessionFile, 0644)
+	c.Assert(err, IsNil)
+
+	info.InstanceKey = "instance"
+	err = wrappers.RemoveSnapSessionFiles(info)
+	c.Assert(err, IsNil)
+	c.Assert(osutil.FileExists(mockSessionInstanceFilePath), Equals, false)
+	// foo file is still there
+	c.Assert(osutil.FileExists(mockSessionFilePath), Equals, true)
+}
+
+func (s *sessionSuite) TestEnsurePackageSessionFilesCleanup(c *C) {
+	reset := release.MockOnCoreDesktop(true)
+	defer reset()
+
+	mockSessionFilePath := filepath.Join(dirs.SnapWaylandSessionsDir, "foo_foobar1.desktop")
+	c.Assert(osutil.FileExists(mockSessionFilePath), Equals, false)
+
+	err := os.MkdirAll(dirs.SnapWaylandSessionsDir, 0755)
+	c.Assert(err, IsNil)
+
+	mockSessionInstanceFilePath := filepath.Join(dirs.SnapWaylandSessionsDir, "foo+instance_foobar.desktop")
+	err = ioutil.WriteFile(mockSessionInstanceFilePath, mockSessionFile, 0644)
+	c.Assert(err, IsNil)
+
+	err = os.MkdirAll(filepath.Join(dirs.SnapWaylandSessionsDir, "foo_foobar2.desktop", "potato"), 0755)
+	c.Assert(err, IsNil)
+
+	info := snaptest.MockSnap(c, sessionSnapYaml, &snap.SideInfo{Revision: snap.R(11)})
+
+	// generate .desktop file in the package baseDir
+	baseDir := info.MountDir()
+	err = os.MkdirAll(filepath.Join(baseDir, "usr/share/wayland-sessions"), 0755)
+	c.Assert(err, IsNil)
+
+	err = ioutil.WriteFile(filepath.Join(baseDir, "usr/share/wayland-sessions", "foobar1.desktop"), mockSessionFile, 0644)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(filepath.Join(baseDir, "usr/share/wayland-sessions", "foobar2.desktop"), mockSessionFile, 0644)
+	c.Assert(err, IsNil)
+
+	err = wrappers.EnsureSnapSessionFiles(info)
+	c.Check(err, NotNil)
+	c.Check(osutil.FileExists(mockSessionFilePath), Equals, false)
+	// foo+instance file was not removed by cleanup
+	c.Check(osutil.FileExists(mockSessionInstanceFilePath), Equals, true)
+}
+
+func (s *sessionSuite) TestRewriteExec(c *C) {
+	reset := release.MockOnCoreDesktop(true)
+	defer reset()
+
+	expectedSessionFilePath := filepath.Join(dirs.SnapWaylandSessionsDir, "foo_foobar.desktop")
+	c.Assert(osutil.FileExists(expectedSessionFilePath), Equals, false)
+
+	info := snaptest.MockSnap(c, sessionSnapYaml, &snap.SideInfo{Revision: snap.R(11)})
+
+	// generate .desktop file in the package baseDir
+	baseDir := info.MountDir()
+	err := os.MkdirAll(filepath.Join(baseDir, "usr/share/wayland-sessions"), 0755)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(filepath.Join(baseDir, "usr/share/wayland-sessions", "foobar.desktop"), []byte(`
+[Desktop Entry]
+Name=foo
+Exec=snap-session
+`), 0644)
+	c.Assert(err, IsNil)
+
+	err = os.MkdirAll(filepath.Join(baseDir, "usr/bin"), 0755)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(filepath.Join(baseDir, "usr/bin", "snap-session"), mockSessionBinary, 0644)
+	c.Assert(err, IsNil)
+
+	err = wrappers.EnsureSnapSessionFiles(info)
+	c.Assert(err, IsNil)
+
+	content, err := ioutil.ReadFile(expectedSessionFilePath)
+	c.Assert(err, IsNil)
+	c.Assert(string(content), Equals, fmt.Sprintf(`
+[Desktop Entry]
+X-SnapInstanceName=foo
+Name=foo
+Exec=ubuntu-core-desktop-session-wrapper %s/usr/bin/snap-session
+`, baseDir))
+}
+
+func (s *sessionSuite) TestNonExistantExec(c *C) {
+	reset := release.MockOnCoreDesktop(true)
+	defer reset()
+
+	expectedSessionFilePath := filepath.Join(dirs.SnapWaylandSessionsDir, "foo_foobar.desktop")
+	info := snaptest.MockSnap(c, sessionSnapYaml, &snap.SideInfo{Revision: snap.R(11)})
+
+	// generate .desktop file in the package baseDir
+	baseDir := info.MountDir()
+	err := os.MkdirAll(filepath.Join(baseDir, "usr/share/wayland-sessions"), 0755)
+	c.Assert(err, IsNil)
+
+	err = ioutil.WriteFile(filepath.Join(baseDir, "usr/share/wayland-sessions", "foobar.desktop"), []byte(`
+[Desktop Entry]
+Name=foo
+Exec=snap-session
+`), 0644)
+	c.Assert(err, IsNil)
+
+	err = wrappers.EnsureSnapSessionFiles(info)
+	c.Assert(err, IsNil)
+
+	content, err := ioutil.ReadFile(expectedSessionFilePath)
+	c.Assert(err, IsNil)
+	c.Assert(string(content), Equals, `
+[Desktop Entry]
+X-SnapInstanceName=foo
+Name=foo
+`)
+}
+
+func (s *sessionSuite) TestAbsoluteExec(c *C) {
+	reset := release.MockOnCoreDesktop(true)
+	defer reset()
+
+	expectedSessionFilePath := filepath.Join(dirs.SnapWaylandSessionsDir, "foo_foobar.desktop")
+	info := snaptest.MockSnap(c, sessionSnapYaml, &snap.SideInfo{Revision: snap.R(11)})
+
+	// generate .desktop file in the package baseDir
+	baseDir := info.MountDir()
+	err := os.MkdirAll(filepath.Join(baseDir, "usr/share/wayland-sessions"), 0755)
+	c.Assert(err, IsNil)
+
+	err = ioutil.WriteFile(filepath.Join(baseDir, "usr/share/wayland-sessions", "foobar.desktop"), []byte(`
+[Desktop Entry]
+Name=foo
+Exec=/bin/rm
+`), 0644)
+	c.Assert(err, IsNil)
+
+	err = wrappers.EnsureSnapSessionFiles(info)
+	c.Assert(err, IsNil)
+
+	content, err := ioutil.ReadFile(expectedSessionFilePath)
+	c.Assert(err, IsNil)
+	c.Assert(string(content), Equals, `
+[Desktop Entry]
+X-SnapInstanceName=foo
+Name=foo
+`)
+}
+
+func (s *sessionSuite) TestRelativeExec(c *C) {
+	reset := release.MockOnCoreDesktop(true)
+	defer reset()
+
+	expectedSessionFilePath := filepath.Join(dirs.SnapWaylandSessionsDir, "foo_foobar.desktop")
+	info := snaptest.MockSnap(c, sessionSnapYaml, &snap.SideInfo{Revision: snap.R(11)})
+
+	// generate .desktop file in the package baseDir
+	baseDir := info.MountDir()
+	err := os.MkdirAll(filepath.Join(baseDir, "usr/share/wayland-sessions"), 0755)
+	c.Assert(err, IsNil)
+
+	err = ioutil.WriteFile(filepath.Join(baseDir, "usr/share/wayland-sessions", "foobar.desktop"), []byte(`
+[Desktop Entry]
+Name=foo
+Exec=../../../../../../bin/rm
+`), 0644)
+	c.Assert(err, IsNil)
+
+	err = wrappers.EnsureSnapSessionFiles(info)
+	c.Assert(err, IsNil)
+
+	content, err := ioutil.ReadFile(expectedSessionFilePath)
+	c.Assert(err, IsNil)
+	c.Assert(string(content), Equals, `
+[Desktop Entry]
+X-SnapInstanceName=foo
+Name=foo
+`)
+}
+
+func (s *sessionSuite) TestNotCoreDesktop(c *C) {
+	reset := release.MockOnCoreDesktop(false)
+	defer reset()
+
+	expectedSessionFilePath := filepath.Join(dirs.SnapWaylandSessionsDir, "foo_foobar.desktop")
+	info := snaptest.MockSnap(c, sessionSnapYaml, &snap.SideInfo{Revision: snap.R(11)})
+
+	// generate .desktop file in the package baseDir
+	baseDir := info.MountDir()
+	err := os.MkdirAll(filepath.Join(baseDir, "usr/share/wayland-sessions"), 0755)
+	c.Assert(err, IsNil)
+
+	err = ioutil.WriteFile(filepath.Join(baseDir, "usr/share/wayland-sessions", "foobar.desktop"), []byte(`
+[Desktop Entry]
+Name=foo
+Exec=snap-session
+`), 0644)
+	c.Assert(err, IsNil)
+
+	err = wrappers.EnsureSnapSessionFiles(info)
+	c.Assert(err, IsNil)
+
+	_, err = os.Stat(expectedSessionFilePath)
+	c.Assert(os.IsNotExist(err), Equals, true)
+}
+
+func (s *sessionSuite) TestNoDesktopSlot(c *C) {
+	reset := release.MockOnCoreDesktop(true)
+	defer reset()
+
+	expectedSessionFilePath := filepath.Join(dirs.SnapWaylandSessionsDir, "foo_foobar.desktop")
+	info := snaptest.MockSnap(c, `
+name: foo
+version: 1.0
+`, &snap.SideInfo{Revision: snap.R(11)})
+
+	// generate .desktop file in the package baseDir
+	baseDir := info.MountDir()
+	err := os.MkdirAll(filepath.Join(baseDir, "usr/share/wayland-sessions"), 0755)
+	c.Assert(err, IsNil)
+
+	err = ioutil.WriteFile(filepath.Join(baseDir, "usr/share/wayland-sessions", "foobar.desktop"), []byte(`
+[Desktop Entry]
+Name=foo
+Exec=snap-session
+`), 0644)
+	c.Assert(err, IsNil)
+
+	err = wrappers.EnsureSnapSessionFiles(info)
+	c.Assert(err, IsNil)
+
+	_, err = os.Stat(expectedSessionFilePath)
+	c.Assert(os.IsNotExist(err), Equals, true)
+}
+
+// sanitize
+
+type sanitizeSessionFileSuite struct {
+	testutil.BaseTest
+}
+
+var _ = Suite(&sanitizeSessionFileSuite{})
+
+func (s *sanitizeSessionFileSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	s.BaseTest.AddCleanup(snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {}))
+}
+
+func (s *sanitizeSessionFileSuite) TearDownTest(c *C) {
+	s.BaseTest.TearDownTest(c)
+}
+
+func (s *sanitizeSessionFileSuite) TestSanitizeIgnoreUnknownKey(c *C) {
+	snap := &snap.Info{SideInfo: snap.SideInfo{RealName: "foo", Revision: snap.R(12)}}
+	desktopContent := []byte(`[Desktop Entry]
+Name=foo
+UnknownKey=baz
+nonsense
+
+# the empty line above is fine`)
+
+	e := wrappers.SanitizeSessionFile(snap, "foo.desktop", desktopContent)
+	c.Assert(string(e), Equals, `[Desktop Entry]
+X-SnapInstanceName=foo
+Name=foo
+
+# the empty line above is fine
+`)
+}
+
+// we do not support TryExec (even if its a valid line), this test ensures
+// we do not accidentally enable it
+func (s *sanitizeSessionFileSuite) TestSanitizeFiltersTryExecIgnored(c *C) {
+	snap, err := snap.InfoFromSnapYaml([]byte(`
+name: snap
+version: 1.0
+`))
+	c.Assert(err, IsNil)
+	desktopContent := []byte(`[Desktop Entry]
+Name=foo
+TryExec=snap-session-test
+`)
+
+	e := wrappers.SanitizeSessionFile(snap, "foo.desktop", desktopContent)
+	c.Assert(string(e), Equals, `[Desktop Entry]
+X-SnapInstanceName=snap
+Name=foo
+`)
+}
+
+func (s *sanitizeSessionFileSuite) TestSanitizeWorthWithI18n(c *C) {
+	snap := &snap.Info{SideInfo: snap.SideInfo{RealName: "snap"}}
+	desktopContent := []byte(`[Desktop Entry]
+Name=foo
+Invalid=key
+Invalid[i18n]=key
+`)
+
+	e := wrappers.SanitizeSessionFile(snap, "foo.desktop", desktopContent)
+	c.Assert(string(e), Equals, `[Desktop Entry]
+X-SnapInstanceName=snap
+Name=foo
+`)
+}
+
+func (s *sanitizeSessionFileSuite) TestSanitizeParallelInstancesPlain(c *C) {
+	snap, err := snap.InfoFromSnapYaml([]byte(`
+name: snap
+version: 1.0
+`))
+	snap.InstanceKey = "bar"
+	c.Assert(err, IsNil)
+	desktopContent := []byte(`[Desktop Entry]
+Name=foo
+`)
+	e := wrappers.SanitizeSessionFile(snap, "", desktopContent)
+	c.Assert(string(e), Equals, `[Desktop Entry]
+X-SnapInstanceName=snap_bar
+Name=foo
+`)
+}
+func (s *sanitizeSessionFileSuite) TestLangLang(c *C) {
+	langs := []struct {
+		line    string
+		isValid bool
+	}{
+		// langCodes
+		{"Name[lang]=lang-alone", true},
+		{"Name[_COUNTRY]=country-alone", false},
+		{"Name[.ENC-0DING]=encoding-alone", false},
+		{"Name[@modifier]=modifier-alone", false},
+		{"Name[lang_COUNTRY]=lang+country", true},
+		{"Name[lang.ENC-0DING]=lang+encoding", true},
+		{"Name[lang@modifier]=lang+modifier", true},
+		// could also test all bad combos of 2, and all combos of 3...
+		{"Name[lang_COUNTRY.ENC-0DING@modifier]=all", true},
+		// bad ones
+		{"Name[foo=bar", false},
+	}
+	for _, t := range langs {
+		c.Assert(wrappers.IsValidSessionFileLine([]byte(t.line)), Equals, t.isValid)
+	}
+}
+
+func (s *sessionSuite) TestAddRemoveSessionFiles(c *C) {
+	reset := release.MockOnCoreDesktop(true)
+	defer reset()
+
+	var tests = []struct {
+		instance                string
+		upstreamSessionFileName string
+
+		expectedSessionFileName string
+	}{
+		// normal cases
+		{"", "upstream.desktop", "foo_upstream.desktop"},
+		{"instance", "upstream.desktop", "foo+instance_upstream.desktop"},
+		// pathological cases are handled
+		{"", "instance.desktop", "foo_instance.desktop"},
+		{"instance", "instance.desktop", "foo+instance_instance.desktop"},
+	}
+
+	for _, t := range tests {
+		expectedSessionFilePath := filepath.Join(dirs.SnapWaylandSessionsDir, t.expectedSessionFileName)
+		c.Assert(osutil.FileExists(expectedSessionFilePath), Equals, false)
+
+		info := snaptest.MockSnap(c, sessionSnapYaml, &snap.SideInfo{Revision: snap.R(11)})
+		info.InstanceKey = t.instance
+
+		// generate .desktop file in the package baseDir
+		baseDir := info.MountDir()
+		err := os.MkdirAll(filepath.Join(baseDir, "usr/share/wayland-sessions"), 0755)
+		c.Assert(err, IsNil)
+
+		err = ioutil.WriteFile(filepath.Join(baseDir, "usr/share/wayland-sessions", t.upstreamSessionFileName), mockSessionFile, 0644)
+		c.Assert(err, IsNil)
+
+		err = wrappers.EnsureSnapSessionFiles(info)
+		c.Assert(err, IsNil)
+		c.Assert(osutil.FileExists(expectedSessionFilePath), Equals, true)
+
+		// Ensure that the old-style parallel install desktop file was
+		// not created.
+		if t.instance != "" {
+			unexpectedOldStyleSessionFilePath := strings.Replace(expectedSessionFilePath, "+", "_", 1)
+			c.Assert(osutil.FileExists(unexpectedOldStyleSessionFilePath), Equals, false)
+		}
+
+		// remove it again
+		err = wrappers.RemoveSnapSessionFiles(info)
+		c.Assert(err, IsNil)
+		c.Assert(osutil.FileExists(expectedSessionFilePath), Equals, false)
+	}
+}


### PR DESCRIPTION
Allow snaps to install Wayland sessions to /usr/share/wayland-sessions so we can allow sessions to be distributed via snaps. This is limited by only allowing this on core desktop (other systems use their packaging systems to control /usr/share/wayland-sessions) and the snap to have a desktop slot (required for Wayland socket access, and means only manually approved snaps can be uploaded to the store).
