### PR TITLE
t/m/snapd-homedirs-vendored: disable on 23+, snapd is too new

### DIFF
--- a/tests/main/snapd-homedirs-vendored/task.yaml
+++ b/tests/main/snapd-homedirs-vendored/task.yaml
@@ -1,7 +1,8 @@
 summary: Test that vendored apparmor does not break any system tunables
 
 # On ubuntu 18 and below snapd-internal is not available
-systems: [ubuntu-18*, ubuntu-2*]
+# On ubuntu 23+ the earliest snapd contains the vendored apparmor
+systems: [ubuntu-18*, ubuntu-20-*, ubuntu-22-*]
 
 environment:
     USERNAME: home-sweet-home

--- a/tests/main/snapd-homedirs-vendored/task.yaml
+++ b/tests/main/snapd-homedirs-vendored/task.yaml
@@ -1,6 +1,6 @@
 summary: Test that vendored apparmor does not break any system tunables
 
-# On ubuntu 18 and below snapd-internal is not available
+# On ubuntu systems below 18 snapd-internal is not available
 # On ubuntu 23+ the earliest snapd contains the vendored apparmor
 systems: [ubuntu-18*, ubuntu-20-*, ubuntu-22-*]
 


### PR DESCRIPTION
On mantic, the snapd deb is version 2.60.3 which is post-vendored apparmor. The test, which is actually a regression test, verifies that on systems where we have an older snapd (pre vendored apparmor) deb package, and the snap itself is upgraded to vendored apparmor, apparmor snippets continue to work.

Thus there is no reason to test the upgrade path from non-vendored to vendored on mantic.