### PR TITLE
daemon: make tests pass with race detector

### DIFF
--- a/daemon/api_base_test.go
+++ b/daemon/api_base_test.go
@@ -239,8 +239,11 @@ func (s *apiBaseSuite) TearDownTest(c *check.C) {
 	s.d = nil
 	s.ctx = nil
 
-	dirs.SetRootDir("")
+	// this must come before dirs.SetRootDir because tearing down the base test
+	// waits for a goroutine to exit that happens to read from dirs.GlobalRootDir,
+	// causing 'go test -race' to fail
 	s.BaseTest.TearDownTest(c)
+	dirs.SetRootDir("")
 }
 
 func (s *apiBaseSuite) mockModel(st *state.State, model *asserts.Model) {

--- a/daemon/api_base_test.go
+++ b/daemon/api_base_test.go
@@ -201,6 +201,7 @@ func (s *apiBaseSuite) SetUpTest(c *check.C) {
 	s.SysctlBufs = nil
 
 	dirs.SetRootDir(c.MkDir())
+	s.AddCleanup(func() { dirs.SetRootDir("") })
 	err := os.MkdirAll(filepath.Dir(dirs.SnapStateFile), 0755)
 	restore := osutil.MockMountInfo("")
 	s.AddCleanup(restore)
@@ -216,6 +217,7 @@ func (s *apiBaseSuite) SetUpTest(c *check.C) {
 	s.vars = nil
 	s.user = nil
 	s.d = nil
+	s.ctx = nil
 	s.currentSnaps = nil
 	s.actions = nil
 	s.authUser = nil
@@ -233,17 +235,6 @@ func (s *apiBaseSuite) SetUpTest(c *check.C) {
 
 	s.Brands = assertstest.NewSigningAccounts(s.StoreSigning)
 	s.Brands.Register("my-brand", brandPrivKey, nil)
-}
-
-func (s *apiBaseSuite) TearDownTest(c *check.C) {
-	s.d = nil
-	s.ctx = nil
-
-	// this must come before dirs.SetRootDir because tearing down the base test
-	// waits for a goroutine to exit that happens to read from dirs.GlobalRootDir,
-	// causing 'go test -race' to fail
-	s.BaseTest.TearDownTest(c)
-	dirs.SetRootDir("")
 }
 
 func (s *apiBaseSuite) mockModel(st *state.State, model *asserts.Model) {


### PR DESCRIPTION
Race that was detected:
```
phelps@ubuntu ~/r/s/daemon> go test -race .                                                                                                                             
==================                                                                                                                                                      
WARNING: DATA RACE                                                                                                                                                      
Read at 0x00000234f880 by goroutine 433:                                                                                                                                
  github.com/snapcore/snapd/bootloader.Find()                                                                                                                           
      /home/phelps/repos/snapd/bootloader/bootloader.go:343 +0x13d                                                                                                      
  github.com/snapcore/snapd/boot.newBootStateUpdate16()                                                                                                                 
      /home/phelps/repos/snapd/boot/bootstate16.go:106 +0x144                                                                                                           
  github.com/snapcore/snapd/boot.(*bootState16).markSuccessful()                                                                                                        
      /home/phelps/repos/snapd/boot/bootstate16.go:132 +0x152                                                                                                           
  github.com/snapcore/snapd/boot.MarkBootSuccessful()                                                                                                                   
      /home/phelps/repos/snapd/boot/boot.go:368 +0x18c                                                                                                                  
  github.com/snapcore/snapd/overlord/devicestate.(*DeviceManager).ensureBootOk()                                                                                        
      /home/phelps/repos/snapd/overlord/devicestate/devicemgr.go:1059 +0x265                                                                                            
  github.com/snapcore/snapd/overlord/devicestate.(*DeviceManager).Ensure()                                                                                              
      /home/phelps/repos/snapd/overlord/devicestate/devicemgr.go:1727 +0x63a                                                                                            
  github.com/snapcore/snapd/overlord.(*StateEngine).Ensure()                                                                                                            
      /home/phelps/repos/snapd/overlord/stateengine.go:147 +0x279                                                                                                       
  github.com/snapcore/snapd/overlord.(*Overlord).Loop.func1()                                                                                                           
      /home/phelps/repos/snapd/overlord/overlord.go:466 +0x85                                                                                                           
  gopkg.in/tomb%2ev2.(*Tomb).run()                                                                                                                                      
      /home/phelps/repos/snapd/vendor/gopkg.in/tomb.v2/tomb.go:163 +0x51                                                                                                
  gopkg.in/tomb%2ev2.(*Tomb).Go.func2()                                                                                                                                 
      /home/phelps/repos/snapd/vendor/gopkg.in/tomb.v2/tomb.go:159 +0x47                                                                                                
                                                                                                                                                                        
Previous write at 0x00000234f880 by goroutine 434:                                                                                                                      
  github.com/snapcore/snapd/dirs.SetRootDir()                                                                                                                           
      /home/phelps/repos/snapd/dirs/dirs.go:343 +0x78                                                                                                                   
  github.com/snapcore/snapd/daemon_test.(*apiBaseSuite).TearDownTest()                                                                                                  
      /home/phelps/repos/snapd/daemon/api_base_test.go:242 +0xc4                                                                                                        
  github.com/snapcore/snapd/daemon_test.(*appsSuite).TearDownTest()
...
```

A goroutine that is spawned during some of the tests in `daemon` reads from `dirs.GlobalRootDir` while `apiBaseSuite.TearDownTest` simultaneously calls `dirs.SetRootDir`. Calling `s.BaseTest.TearDownTest` waits for the goroutine to exit, so we can safely mutate `dirs.GlobalRootDir` via `dirs.SetRootDir`.