### PR TITLE
o/state: add missing initializers and a unit test to cover this

### DIFF
--- a/overlord/state/state.go
+++ b/overlord/state/state.go
@@ -566,5 +566,7 @@ func ReadState(backend Backend, r io.Reader) (*State, error) {
 	s.modified = false
 	s.cache = make(map[interface{}]interface{})
 	s.pendingChangeByAttr = make(map[string]func(*Change) bool)
+	s.changeHandlers = make(map[int]func(chg *Change, old Status, new Status))
+	s.taskHandlers = make(map[int]func(t *Task, old Status, new Status))
 	return s, err
 }

--- a/overlord/state/state_test.go
+++ b/overlord/state/state_test.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
@@ -546,6 +547,29 @@ func (ss *stateSuite) TestEmptyStateDataAndCheckpointReadAndSet(c *C) {
 
 	// no crash
 	st2.Set("a", 1)
+
+	// ensure all maps of state are correctly initialized by ReadState
+	val := reflect.ValueOf(st2)
+	typ := val.Elem().Type()
+	var maps []string
+	for i := 0; i < typ.NumField(); i++ {
+		f := typ.Field(i)
+		if f.Type.Kind() == reflect.Map {
+			maps = append(maps, f.Name)
+			fv := val.Elem().Field(i)
+			c.Check(fv.IsNil(), Equals, false, Commentf("Map field %s of state was not initialized by ReadState", f.Name))
+		}
+	}
+	c.Check(maps, DeepEquals, []string{
+		"data",
+		"changes",
+		"tasks",
+		"warnings",
+		"cache",
+		"pendingChangeByAttr",
+		"taskHandlers",
+		"changeHandlers",
+	})
 }
 
 func (ss *stateSuite) TestEmptyTaskAndChangeDataAndCheckpointReadAndSet(c *C) {


### PR DESCRIPTION
This PR separates a bugfix from the single-reboot PR (https://github.com/snapcore/snapd/pull/13044).

It adds a couple of missing initializers for an empty state, and a unit test to cover this doesn't happen in the future.