### PR TITLE
osutil/epoll: make `e.Wait{,Timeout}()` return immediately when `e.Close()` is called

### DIFF
--- a/osutil/epoll/epoll.go
+++ b/osutil/epoll/epoll.go
@@ -37,7 +37,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-var ErrEpollClosed error = errors.New("the epoll instance has been closed")
+var ErrEpollClosed = errors.New("the epoll instance has been closed")
 
 // Readiness is the bit mask of aspects of readiness to monitor with epoll.
 type Readiness int

--- a/osutil/epoll/epoll.go
+++ b/osutil/epoll/epoll.go
@@ -70,6 +70,7 @@ func Open() (*Epoll, error) {
 	return e, nil
 }
 
+// IsClosed returns whether Close has been called on the epoll instance.
 func (e *Epoll) IsClosed() bool {
 	select {
 	case <-e.closed:

--- a/osutil/epoll/epoll.go
+++ b/osutil/epoll/epoll.go
@@ -91,11 +91,6 @@ func (e *Epoll) Close() error {
 	return unix.Close(e.fd)
 }
 
-// Fd returns the integer unix file descriptor referencing the open file.
-func (e *Epoll) Fd() int {
-	return e.fd
-}
-
 // RegisteredFdCount returns the number of file descriptors which are currently
 // registered to the epoll instance.
 func (e *Epoll) RegisteredFdCount() int {
@@ -118,7 +113,7 @@ func (e *Epoll) Register(fd int, mask Readiness) error {
 		return ErrEpollClosed
 	}
 	e.incrementRegisteredFdCount()
-	err := unix.EpollCtl(e.Fd(), unix.EPOLL_CTL_ADD, fd, &unix.EpollEvent{
+	err := unix.EpollCtl(e.fd, unix.EPOLL_CTL_ADD, fd, &unix.EpollEvent{
 		Events: uint32(mask),
 		Fd:     int32(fd),
 	})
@@ -137,7 +132,7 @@ func (e *Epoll) Deregister(fd int) error {
 	if e.IsClosed() {
 		return ErrEpollClosed
 	}
-	err := unix.EpollCtl(e.Fd(), unix.EPOLL_CTL_DEL, fd, &unix.EpollEvent{})
+	err := unix.EpollCtl(e.fd, unix.EPOLL_CTL_DEL, fd, &unix.EpollEvent{})
 	if err != nil {
 		return err
 	}
@@ -152,7 +147,7 @@ func (e *Epoll) Modify(fd int, mask Readiness) error {
 	if e.IsClosed() {
 		return ErrEpollClosed
 	}
-	err := unix.EpollCtl(e.Fd(), unix.EPOLL_CTL_MOD, fd, &unix.EpollEvent{
+	err := unix.EpollCtl(e.fd, unix.EPOLL_CTL_MOD, fd, &unix.EpollEvent{
 		Events: uint32(mask),
 		Fd:     int32(fd),
 	})
@@ -196,7 +191,7 @@ func (e *Epoll) waitTimeoutInternal(duration time.Duration, eventCh chan []Event
 			bufLen = 1
 		}
 		sysEvents = make([]unix.EpollEvent, bufLen)
-		n, err = unixEpollWait(e.Fd(), sysEvents, msec)
+		n, err = unixEpollWait(e.fd, sysEvents, msec)
 		runtime.KeepAlive(e)
 		// If the epoll fd was closed during epoll_wait
 		// then return ErrEpollClosed immediately.

--- a/osutil/epoll/epoll.go
+++ b/osutil/epoll/epoll.go
@@ -1,11 +1,30 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package epoll
+
 // Package epoll contains a thin wrapper around the epoll(7) facility.
 //
 // Using epoll from Go is unusual as the language provides facilities that
 // normally make using it directly pointless. Epoll is strictly required for
 // unusual kernel interfaces that use event notification but don't implement
 // file descriptors that provide usual read/write semantics.
-
-package epoll
 
 import (
 	"errors"

--- a/osutil/epoll/epoll.go
+++ b/osutil/epoll/epoll.go
@@ -71,7 +71,7 @@ func Open() (*Epoll, error) {
 }
 
 func (e *Epoll) IsClosed() bool {
-	return e.fd == -1
+	return e.Fd() == -1
 }
 
 // Close closes the event monitoring descriptor.

--- a/osutil/epoll/epoll.go
+++ b/osutil/epoll/epoll.go
@@ -137,6 +137,9 @@ func (e *Epoll) Register(fd int, mask Readiness) error {
 		Events: uint32(mask),
 		Fd:     int32(fd),
 	})
+	if e.IsClosed() {
+		return ErrEpollClosed
+	}
 	if err != nil {
 		e.decrementRegisteredFdCount()
 		return err
@@ -153,6 +156,9 @@ func (e *Epoll) Deregister(fd int) error {
 		return ErrEpollClosed
 	}
 	err := unix.EpollCtl(e.fd, unix.EPOLL_CTL_DEL, fd, &unix.EpollEvent{})
+	if e.IsClosed() {
+		return ErrEpollClosed
+	}
 	if err != nil {
 		return err
 	}
@@ -172,6 +178,9 @@ func (e *Epoll) Modify(fd int, mask Readiness) error {
 		Fd:     int32(fd),
 	})
 	runtime.KeepAlive(e)
+	if e.IsClosed() {
+		return ErrEpollClosed
+	}
 	return err
 }
 

--- a/osutil/epoll/epoll.go
+++ b/osutil/epoll/epoll.go
@@ -167,6 +167,7 @@ func (e *Epoll) waitTimeoutInternal(duration time.Duration, eventCh chan []Event
 		errCh <- ErrEpollClosed
 		return
 	}
+	startTs := time.Now()
 	noTimeout := false
 	msec := int(duration.Milliseconds())
 	if duration < 0 {
@@ -189,7 +190,6 @@ func (e *Epoll) waitTimeoutInternal(duration time.Duration, eventCh chan []Event
 			bufLen = 1
 		}
 		sysEvents = make([]unix.EpollEvent, bufLen)
-		startTs := time.Now()
 		n, err = unixEpollWait(e.fd, sysEvents, msec)
 		runtime.KeepAlive(e)
 		// If the epoll fd was closed (thus set to -1) during epoll_wait
@@ -214,7 +214,7 @@ func (e *Epoll) waitTimeoutInternal(duration time.Duration, eventCh chan []Event
 		}
 		// adjust the timeout and restart the syscall
 		elapsed := time.Since(startTs)
-		msec -= int(elapsed.Milliseconds())
+		msec = int((duration - elapsed).Milliseconds())
 		if msec <= 0 {
 			n = 0
 			break

--- a/osutil/epoll/epoll.go
+++ b/osutil/epoll/epoll.go
@@ -47,7 +47,7 @@ func (r Readiness) String() string {
 type Epoll struct {
 	fd                int32
 	registeredFdCount int32 // read/modify using helper functions
-	closed            chan interface{}
+	closed            chan struct{}
 	closingLock       sync.Mutex
 }
 
@@ -60,7 +60,7 @@ func Open() (*Epoll, error) {
 	e := &Epoll{
 		fd:                int32(fd),
 		registeredFdCount: 0,
-		closed:            make(chan interface{}),
+		closed:            make(chan struct{}),
 	}
 	runtime.SetFinalizer(e, func(e *Epoll) {
 		if e.fd != -1 {

--- a/osutil/epoll/epoll_test.go
+++ b/osutil/epoll/epoll_test.go
@@ -38,10 +38,11 @@ func (*epollSuite) TestOpenClose(c *C) {
 	c.Assert(e.Fd() == 1, Equals, false)
 	c.Assert(e.Fd() == 2, Equals, false)
 	c.Assert(e.RegisteredFdCount(), Equals, 0)
+	c.Assert(e.IsClosed(), Equals, false)
 
 	err = e.Close()
 	c.Assert(err, IsNil)
-	c.Assert(e.Fd(), Equals, -1)
+	c.Assert(e.IsClosed(), Equals, true)
 }
 
 func concurrentlyRegister(e *epoll.Epoll, fd int, errCh chan error) {

--- a/osutil/epoll/epoll_test.go
+++ b/osutil/epoll/epoll_test.go
@@ -33,10 +33,6 @@ func (*epollSuite) TestString(c *C) {
 func (*epollSuite) TestOpenClose(c *C) {
 	e, err := epoll.Open()
 	c.Assert(err, IsNil)
-	c.Assert(e.Fd() == -1, Equals, false)
-	c.Assert(e.Fd() == 0, Equals, false)
-	c.Assert(e.Fd() == 1, Equals, false)
-	c.Assert(e.Fd() == 2, Equals, false)
 	c.Assert(e.RegisteredFdCount(), Equals, 0)
 	c.Assert(e.IsClosed(), Equals, false)
 


### PR DESCRIPTION
For users of `osutil/epoll` (namely the AppArmor Prompting listener in #13148 ), we want to ensure that calls to `Wait()` and `WaitTimeout()` return immediately when the epoll instance on which they are called is closed. This PR adds that functionality.