### PR TITLE
boot,bootloader: add support for shim fallback and setting EFI boot variables on install

### DIFF
--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2019 Canonical Ltd
+ * Copyright (C) 2014-2023 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -22,6 +22,9 @@ package boot
 import (
 	"fmt"
 	"sync/atomic"
+
+	"github.com/canonical/go-efilib"
+	"github.com/canonical/go-efilib/linux"
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/bootloader"
@@ -280,4 +283,34 @@ func MockWriteModelToUbuntuBoot(mock func(*asserts.Model) error) (restore func()
 func EnableTestingRebootFunction() (restore func()) {
 	testingRebootItself = true
 	return func() { testingRebootItself = false }
+}
+
+var (
+	ConstructLoadOption      = constructLoadOption
+	SetEfiBootOptionVariable = setEfiBootOptionVariable
+	SetEfiBootOrderVariable  = setEfiBootOrderVariable
+)
+
+func MockEfiListVariables(f func() ([]efi.VariableDescriptor, error)) (restore func()) {
+	restore = testutil.Backup(&efiListVariables)
+	efiListVariables = f
+	return restore
+}
+
+func MockEfiReadVariable(f func(name string, guid efi.GUID) ([]byte, efi.VariableAttributes, error)) (restore func()) {
+	restore = testutil.Backup(&efiReadVariable)
+	efiReadVariable = f
+	return restore
+}
+
+func MockEfiWriteVariable(f func(name string, guid efi.GUID, attrs efi.VariableAttributes, data []byte) error) (restore func()) {
+	restore = testutil.Backup(&efiWriteVariable)
+	efiWriteVariable = f
+	return restore
+}
+
+func MockLinuxFilePathToDevicePath(f func(path string, mode linux.FilePathToDevicePathMode) (out efi.DevicePath, err error)) (restore func()) {
+	restore = testutil.Backup(&linuxFilePathToDevicePath)
+	linuxFilePathToDevicePath = f
+	return restore
 }

--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2022 Canonical Ltd
+ * Copyright (C) 2014-2023 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -558,6 +558,14 @@ func makeRunnableSystem(model *asserts.Model, bootWith *BootableSet, sealer *Tru
 	if err := MarkRecoveryCapableSystem(recoverySystemLabel); err != nil {
 		return fmt.Errorf("cannot record %q as a recovery capable system: %v", recoverySystemLabel, err)
 	}
+
+	err = setUbuntuSeedEfiBootVariables()
+	if err == errUnsupportedBootloader {
+		logger.Debugf("%v", err)
+	} else if err != nil {
+		logger.Debugf("WARNING: %v", err)
+	}
+
 	return nil
 }
 

--- a/boot/setefibootvars.go
+++ b/boot/setefibootvars.go
@@ -1,0 +1,24 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package boot
+
+import "errors"
+
+var errUnsupportedBootloader = errors.New("bootloader does not support setting EFI boot variables")

--- a/boot/setefibootvars_darwin.go
+++ b/boot/setefibootvars_darwin.go
@@ -1,0 +1,30 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package boot
+
+import "github.com/snapcore/snapd/osutil"
+
+func SetEfiBootVariables(description string, assetPath string, optionalData []byte) error {
+	return osutil.ErrDarwin
+}
+
+func setUbuntuSeedEfiBootVariables() error {
+	return osutil.ErrDarwin
+}

--- a/boot/setefibootvars_linux.go
+++ b/boot/setefibootvars_linux.go
@@ -1,0 +1,224 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package boot
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+
+	"github.com/canonical/go-efilib"
+	"github.com/canonical/go-efilib/linux"
+
+	"github.com/snapcore/snapd/bootloader"
+)
+
+var (
+	ErrAllBootNumsUsed    = errors.New("all Boot#### variable numbers are already in use")
+	ErrNoMatchingVariable = errors.New("no variable matches the given boot option")
+	ErrInvalidBootOrder   = errors.New("BootOrder variable data must have even length")
+
+	defaultVarAttrs = efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess
+
+	efiListVariables = efi.ListVariables
+	efiReadVariable  = efi.ReadVariable
+	efiWriteVariable = efi.WriteVariable
+
+	linuxFilePathToDevicePath = linux.FilePathToDevicePath
+
+	bootOptionRegexp = regexp.MustCompile("^Boot[0-9A-F]{4}$")
+)
+
+// constructLoadOption returns a serialized EFI load option with the device
+// path corresponding to the given asset path, along with the given description
+// and optional data.
+func constructLoadOption(description string, assetPath string, optionalData []byte) ([]byte, error) {
+	devicePath, err := linuxFilePathToDevicePath(assetPath, linux.ShortFormPathHD)
+	if err != nil {
+		return nil, err
+	}
+	loadOption := &efi.LoadOption{
+		Attributes:   efi.LoadOptionActive | efi.LoadOptionCategoryBoot,
+		Description:  description,
+		FilePath:     devicePath,
+		OptionalData: optionalData,
+	}
+	loadOptionSerialized, err := loadOption.Bytes()
+	if err != nil {
+		return nil, err
+	}
+	return loadOptionSerialized, nil
+}
+
+// Searches existing Boot#### variables for one which matches the given data.
+//
+// If there is a match, returns the boot number of the existing variable.
+// Otherwise, finds the first available boot number and returns it, along with
+// ErrNoMatchingVariable, indicating that a new boot option with that boot
+// number should be written. If a different error occurs, returns that error,
+// and the returned boot number should be ignored.
+func findMatchingBootOption(optionData []byte) (uint16, error) {
+	variables, err := efiListVariables()
+	if err != nil {
+		return 0, err
+	}
+	usedBootNums := make(map[uint64]bool)
+	for _, varDesc := range variables {
+		varName := varDesc.Name
+		varGUID := varDesc.GUID
+		if !bootOptionRegexp.MatchString(varName) {
+			// Not a Boot#### variable, so skip it
+			continue
+		}
+		if varGUID != efi.GlobalVariable {
+			// Not an EFI global variable, so skip it
+			continue
+		}
+		varNumber, err := strconv.ParseUint(varName[4:], 16, 16)
+		if err != nil {
+			// Should not occur, since variable matched bootOptionRegexp
+			return 0, err
+		}
+		// Since we never overwrite an existing variable, we can ignore
+		// variable attributes when reading the variable
+		varData, _, err := efiReadVariable(varName, varGUID)
+		if err != nil {
+			return 0, err
+		}
+		if bytes.Compare(optionData, varData) == 0 {
+			// existing variable already identical, use it
+			return uint16(varNumber), nil
+		}
+		usedBootNums[varNumber] = true
+	}
+	for bootNum := uint64(0); bootNum <= 0xFFFF; bootNum++ {
+		if !usedBootNums[bootNum] {
+			return uint16(bootNum), ErrNoMatchingVariable
+		}
+	}
+	return 0, ErrAllBootNumsUsed
+}
+
+// Ensures that a Boot#### variable contains the given EFI load option.
+//
+// It may be the case that an existing boot variable already contains the
+// given load option, in which case that boot variable is reused. Otherwise,
+// finds the first unused boot variable number and uses it. Writes the load
+// option to that variable, and returns the number of the variable that was
+// used.
+func setEfiBootOptionVariable(loadOptionData []byte) (uint16, error) {
+	bootNum, err := findMatchingBootOption(loadOptionData)
+	if err == nil {
+		return bootNum, nil
+	} else if err != ErrNoMatchingVariable {
+		return 0, err
+	}
+	varName := fmt.Sprintf("Boot%04X", bootNum)
+	err = efiWriteVariable(varName, efi.GlobalVariable, defaultVarAttrs, loadOptionData)
+	return bootNum, err
+}
+
+// Reads the current BootOrder variable, inserts the given newBootNum at the
+// beginning of the number list (and removes it from later in the list if
+// it occurs) and writes the list as the new BootOrder variable.
+func setEfiBootOrderVariable(newBootNum uint16) error {
+	origData, attrs, err := efiReadVariable("BootOrder", efi.GlobalVariable)
+	if err == efi.ErrVarNotExist {
+		attrs = defaultVarAttrs
+		origData = make([]byte, 0)
+	} else if err != nil {
+		return err
+	}
+	if len(origData)%2 != 0 {
+		return ErrInvalidBootOrder
+	}
+	var optionOffset = -1
+	for i := 0; i < len(origData); i += 2 {
+		bootNum := binary.LittleEndian.Uint16(origData[i : i+2])
+		if newBootNum == bootNum {
+			optionOffset = i
+			break
+		}
+	}
+	var newData []byte
+	if optionOffset == 0 {
+		// newBootNum already at start, no need to re-write variable
+		return nil
+	} else if optionOffset == -1 {
+		// newBootNum not in original boot order
+		newData = make([]byte, len(origData)+2)
+		binary.LittleEndian.PutUint16(newData, newBootNum)
+		copy(newData[2:], origData)
+	} else {
+		newData = make([]byte, len(origData))
+		binary.LittleEndian.PutUint16(newData, newBootNum)
+		copy(newData[2:], origData[:optionOffset])
+		copy(newData[optionOffset+2:], origData[optionOffset+2:])
+	}
+	return efiWriteVariable("BootOrder", efi.GlobalVariable, attrs, newData)
+}
+
+// SetEfiBootVariables sets the Boot#### and BootOrder variables for the given
+// load option information.
+//
+// Constructs an EFI load option with the given description, the device path
+// corresponding to the given asset path, and the given optional data. Writes
+// the EFI boot variable Boot#### to contain the resulting load option. Then,
+// sets the BootOrder variable so that the #### number from the chosen Boot####
+// is first, removing it from elsewhere in the BootOrder if it occurs.
+func SetEfiBootVariables(description string, assetPath string, optionalData []byte) error {
+	loadOptionData, err := constructLoadOption(description, assetPath, optionalData)
+	if err != nil {
+		return err
+	}
+	bootNum, err := setEfiBootOptionVariable(loadOptionData)
+	if err != nil {
+		return err
+	}
+	return setEfiBootOrderVariable(bootNum)
+}
+
+// setUbuntuSeedEfiBootVariables sets EFI variables according to the bootloader
+// found on ubuntu seed if it is a UefiBootloader.
+func setUbuntuSeedEfiBootVariables() error {
+	opts := &bootloader.Options{
+		Role: bootloader.RoleRecovery,
+	}
+	// Set EFI boot variables according to bootloader on ubuntu-seed
+	seedBl, err := bootloader.Find(InitramfsUbuntuSeedDir, opts)
+	if err != nil {
+		return fmt.Errorf("cannot find bootloader in seed directory: %v; skipping setting EFI variables", err)
+	}
+	ubl, ok := seedBl.(bootloader.UefiBootloader)
+	if !ok {
+		return errUnsupportedBootloader
+	}
+	description, assetPath, optionalData, err := ubl.EfiLoadOptionParameters()
+	if err != nil {
+		return fmt.Errorf("cannot get EFI load option parameter: %v", err)
+	}
+	if err = SetEfiBootVariables(description, assetPath, optionalData); err != nil {
+		return fmt.Errorf("failed to set EFI boot variables: %v", err)
+	}
+	return nil
+}

--- a/boot/setefibootvars_linux_test.go
+++ b/boot/setefibootvars_linux_test.go
@@ -1,0 +1,750 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package boot_test
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	. "gopkg.in/check.v1"
+
+	"golang.org/x/text/encoding/unicode"
+
+	"github.com/canonical/go-efilib"
+	"github.com/canonical/go-efilib/linux"
+
+	"github.com/snapcore/snapd/boot"
+)
+
+type setEfiBootVarsSuite struct {
+	baseBootenvSuite
+}
+
+var _ = Suite(&setEfiBootVarsSuite{})
+
+func (s *setEfiBootVarsSuite) SetUpTest(c *C) {
+	s.baseBootenvSuite.SetUpTest(c)
+}
+
+var (
+	errShouldNotOverwrite = errors.New("should not overwrite an existing Boot#### variable")
+)
+
+type fakeDevicePathNode struct {
+	buf []byte
+}
+
+func (n *fakeDevicePathNode) String() string {
+	return string(n.buf[:])
+}
+
+func (n *fakeDevicePathNode) ToString(flags efi.DevicePathToStringFlags) string {
+	return n.String()
+}
+
+func (n *fakeDevicePathNode) Write(w io.Writer) error {
+	_, err := w.Write(n.buf)
+	return err
+}
+
+func stringToNode(path string) efi.DevicePathNode {
+	return efi.DevicePathNode(&fakeDevicePathNode{
+		buf: []byte(path),
+	})
+}
+
+func stringToDevicePath(str string) efi.DevicePath {
+	pathComponents := strings.Split(str, "/")
+	pathNodes := make([]efi.DevicePathNode, 0, len(pathComponents))
+	for _, comp := range pathComponents {
+		pathNodes = append(pathNodes, stringToNode(comp))
+	}
+	return pathNodes
+}
+
+func (s *setEfiBootVarsSuite) TestStringToDevicePath(c *C) {
+	path := "path/to/dir/with/file.efi"
+	devicePath := stringToDevicePath(path)
+	c.Assert(devicePath, HasLen, 5)
+	pathWithBackslashes := "\\" + strings.ReplaceAll(path, "/", "\\")
+	c.Assert(devicePath.String(), Equals, pathWithBackslashes)
+}
+
+func stringToUtf16Bytes(c *C, str string) []byte {
+	encoder := unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM).NewEncoder()
+	arr, err := encoder.Bytes([]byte(str))
+	c.Assert(err, IsNil)
+	return append(arr, []byte{0x00, 0x00}...)
+}
+
+func (s *setEfiBootVarsSuite) TestStringToUtf16Bytes(c *C) {
+	str := "ubuntu"
+	expected := []byte{0x75, 0x00, 0x62, 0x00, 0x75, 0x00, 0x6e, 0x00, 0x74, 0x00, 0x75, 0x00, 0x00, 0x00}
+	result := stringToUtf16Bytes(c, str)
+	c.Assert(result, DeepEquals, expected)
+}
+
+func (s *setEfiBootVarsSuite) TestConstructLoadOption(c *C) {
+	restore := boot.MockLinuxFilePathToDevicePath(func(path string, mode linux.FilePathToDevicePathMode) (out efi.DevicePath, err error) {
+		return stringToDevicePath(path), nil
+	})
+	defer restore()
+
+	expectedAttributes := []byte{0x01, 0x00, 0x00, 0x00}
+
+	for _, tc := range []struct {
+		description  string
+		assetPath    string
+		optionalData []byte
+	}{
+		{
+			"default",
+			"EFI/boot/bootx64.efi",
+			nil,
+		},
+		{
+			"ubuntu",
+			"EFI/ubuntu/shimx64.efi",
+			[]byte("This is the boot entry for ubuntu"),
+		},
+		{
+			"fallback",
+			"EFI/boot/fallback.efi",
+			make([]byte, 0),
+		},
+	} {
+		expectedDescription := stringToUtf16Bytes(c, tc.description)
+		expectedPath := []byte(strings.ReplaceAll(tc.assetPath, "/", ""))
+		expectedRest := append(expectedPath, append([]byte{0x7f, 0xff, 0x04, 0x00}, tc.optionalData...)...)
+		result, err := boot.ConstructLoadOption(tc.description, tc.assetPath, tc.optionalData)
+		c.Assert(err, IsNil)
+		c.Assert(result[:4], DeepEquals, expectedAttributes)
+		c.Assert(result[6:6+len(expectedDescription)], DeepEquals, expectedDescription)
+		c.Assert(result[len(result)-len(expectedRest):], DeepEquals, expectedRest)
+	}
+}
+
+func (s *setEfiBootVarsSuite) TestConstructLoadOptionNullOptionalData(c *C) {
+	restore := boot.MockLinuxFilePathToDevicePath(func(path string, mode linux.FilePathToDevicePathMode) (out efi.DevicePath, err error) {
+		return stringToDevicePath(path), nil
+	})
+	defer restore()
+
+	desc := "ubuntu"
+	path := "EFI/ubuntu/shimx64.efi"
+
+	option1, err := boot.ConstructLoadOption(desc, path, nil)
+	c.Assert(err, IsNil)
+	option2, err := boot.ConstructLoadOption(desc, path, make([]byte, 0))
+	c.Assert(err, IsNil)
+	c.Assert(option1, DeepEquals, option2)
+}
+
+type varDataAttrs struct {
+	data  []byte
+	attrs efi.VariableAttributes
+}
+
+var defaultVarAttrs = efi.AttributeNonVolatile | efi.AttributeBootserviceAccess | efi.AttributeRuntimeAccess
+
+func (s *setEfiBootVarsSuite) TestSetEfiBootOptionVariable(c *C) {
+	boot0Option := efi.LoadOption{
+		Attributes:  efi.LoadOptionActive | efi.LoadOptionCategoryBoot,
+		Description: "ubuntu",
+		FilePath:    stringToDevicePath("/run/mnt/ubuntu-seed/EFI/ubuntu/grubx64.efi"),
+	}
+	boot0OptionBytes, err := boot0Option.Bytes()
+	c.Assert(err, IsNil)
+
+	boot1Option := efi.LoadOption{
+		Attributes:  efi.LoadOptionActive | efi.LoadOptionCategoryBoot,
+		Description: "ubuntu",
+		FilePath:    stringToDevicePath("/run/mnt/ubuntu-seed/EFI/BOOT/BOOTX64.efi"),
+	}
+	boot1OptionBytes, err := boot1Option.Bytes()
+	c.Assert(err, IsNil)
+
+	boot3Option := efi.LoadOption{
+		Attributes:  efi.LoadOptionActive | efi.LoadOptionCategoryBoot,
+		Description: "ubuntu",
+		FilePath:    stringToDevicePath("/run/mnt/ubuntu-seed/EFI/fakedir/shimx64.efi"),
+	}
+	boot3OptionBytes, err := boot3Option.Bytes()
+	c.Assert(err, IsNil)
+
+	fakeVariableData := map[efi.VariableDescriptor]*varDataAttrs{
+		{
+			Name: "foo",
+			GUID: efi.GlobalVariable,
+		}: {
+			[]byte("foo"),
+			defaultVarAttrs,
+		},
+		{
+			Name: "Boot0000",
+			GUID: efi.GlobalVariable,
+		}: {
+			boot0OptionBytes,
+			defaultVarAttrs,
+		},
+		{
+			Name: "BootOrder",
+			GUID: efi.GlobalVariable,
+		}: {
+			[]byte{0x02, 0x00, 0x34, 0x12, 0x03, 0x00, 0x01, 0x00},
+			defaultVarAttrs,
+		},
+		{
+			Name: "Boot0003",
+			GUID: efi.GlobalVariable,
+		}: {
+			boot3OptionBytes,
+			defaultVarAttrs,
+		},
+		{
+			Name: "Boot0001",
+			GUID: efi.GlobalVariable,
+		}: {
+			boot1OptionBytes,
+			defaultVarAttrs,
+		},
+	}
+	restore := boot.MockEfiListVariables(func() ([]efi.VariableDescriptor, error) {
+		varDescriptorList := make([]efi.VariableDescriptor, 0, len(fakeVariableData))
+		for key := range fakeVariableData {
+			varDescriptorList = append(varDescriptorList, key)
+		}
+		return varDescriptorList, nil
+	})
+	defer restore()
+	restore = boot.MockEfiReadVariable(func(name string, guid efi.GUID) ([]byte, efi.VariableAttributes, error) {
+		descriptor := efi.VariableDescriptor{
+			Name: name,
+			GUID: guid,
+		}
+		if varDA, exists := fakeVariableData[descriptor]; exists {
+			return varDA.data, varDA.attrs, nil
+		}
+		return nil, 0, efi.ErrVarNotExist
+	})
+	defer restore()
+	writeChan := make(chan []byte, 1)
+	restore = boot.MockEfiWriteVariable(func(name string, guid efi.GUID, attrs efi.VariableAttributes, data []byte) error {
+		for varDesc := range fakeVariableData {
+			if varDesc.Name == name && varDesc.GUID == guid {
+				return errShouldNotOverwrite
+			}
+		}
+		writeChan <- data
+		return nil
+	})
+	defer restore()
+
+	// Check that existing variables are matched
+
+	initialVarCount := len(fakeVariableData)
+
+	bootNum, err := boot.SetEfiBootOptionVariable(boot1OptionBytes)
+	c.Assert(err, IsNil)
+	c.Assert(bootNum, Equals, uint16(1))
+	c.Assert(len(fakeVariableData), Equals, initialVarCount)
+
+	bootNum, err = boot.SetEfiBootOptionVariable(boot3OptionBytes)
+	c.Assert(err, IsNil)
+	c.Assert(bootNum, Equals, uint16(3))
+	c.Assert(len(fakeVariableData), Equals, initialVarCount)
+
+	// Check that non-matching path adds a new variable at Boot0002
+
+	newOption := efi.LoadOption{
+		Attributes:  efi.LoadOptionActive | efi.LoadOptionCategoryBoot,
+		Description: "ubuntu",
+		FilePath:    stringToDevicePath("/run/mnt/ubuntu-seed/EFI/fedora/shimx64.efi"),
+	}
+	newOptionBytes, err := newOption.Bytes()
+	c.Assert(err, IsNil)
+	bootNum, err = boot.SetEfiBootOptionVariable(newOptionBytes)
+	c.Assert(err, IsNil)
+	c.Assert(bootNum, Equals, uint16(2))
+	c.Assert(<-writeChan, DeepEquals, newOptionBytes)
+	newPathDesc := efi.VariableDescriptor{
+		Name: "Boot0002",
+		GUID: efi.GlobalVariable,
+	}
+	fakeVariableData[newPathDesc] = &varDataAttrs{
+		data:  newOptionBytes,
+		attrs: defaultVarAttrs,
+	}
+	c.Assert(len(fakeVariableData), Equals, initialVarCount+1)
+
+	// Check that re-running on the same path chooses the newly-existing variable again
+	bootNum, err = boot.SetEfiBootOptionVariable(newOptionBytes)
+	c.Assert(err, IsNil)
+	c.Assert(bootNum, Equals, uint16(2))
+}
+
+func (s *setEfiBootVarsSuite) TestMismatchedGuid(c *C) {
+	bootOption := efi.LoadOption{
+		Attributes:  efi.LoadOptionActive | efi.LoadOptionCategoryBoot,
+		Description: "ubuntu",
+		FilePath:    stringToDevicePath("/run/mnt/ubuntu-seed/EFI/BOOT/BOOTX64.efi"),
+	}
+	bootOptionBytes, err := bootOption.Bytes()
+	c.Assert(err, IsNil)
+
+	shimOption := efi.LoadOption{
+		Attributes:  efi.LoadOptionActive | efi.LoadOptionCategoryBoot,
+		Description: "ubuntu",
+		FilePath:    stringToDevicePath("/run/mnt/ubuntu-seed/EFI/ubuntu/shimx64.efi"),
+	}
+	shimOptionBytes, err := shimOption.Bytes()
+	c.Assert(err, IsNil)
+
+	grubOption := efi.LoadOption{
+		Attributes:  efi.LoadOptionActive | efi.LoadOptionCategoryBoot,
+		Description: "ubuntu",
+		FilePath:    stringToDevicePath("/run/mnt/ubuntu-seed/EFI/ubuntu/grubx64.efi"),
+	}
+	grubOptionBytes, err := grubOption.Bytes()
+	c.Assert(err, IsNil)
+
+	fakeVariableData := map[efi.VariableDescriptor]*varDataAttrs{
+		{
+			Name: "Boot0000",
+			GUID: efi.ImageSecurityDatabaseGuid,
+		}: {
+			bootOptionBytes,
+			defaultVarAttrs,
+		},
+		{
+			Name: "Boot0001",
+			GUID: efi.GlobalVariable,
+		}: {
+			shimOptionBytes,
+			defaultVarAttrs,
+		},
+		{
+			Name: "Boot0002",
+			GUID: efi.GlobalVariable,
+		}: {
+			bootOptionBytes,
+			defaultVarAttrs,
+		},
+		{
+			Name: "Boot0003",
+			GUID: efi.ImageSecurityDatabaseGuid,
+		}: {
+			grubOptionBytes,
+			defaultVarAttrs,
+		},
+	}
+	restore := boot.MockEfiListVariables(func() ([]efi.VariableDescriptor, error) {
+		varDescriptorList := make([]efi.VariableDescriptor, 0, len(fakeVariableData))
+		for key := range fakeVariableData {
+			varDescriptorList = append(varDescriptorList, key)
+		}
+		return varDescriptorList, nil
+	})
+	defer restore()
+	restore = boot.MockEfiReadVariable(func(name string, guid efi.GUID) ([]byte, efi.VariableAttributes, error) {
+		descriptor := efi.VariableDescriptor{
+			Name: name,
+			GUID: guid,
+		}
+		if varDA, exists := fakeVariableData[descriptor]; exists {
+			return varDA.data, varDA.attrs, nil
+		}
+		return nil, 0, efi.ErrVarNotExist
+	})
+	defer restore()
+	writeChan := make(chan []byte, 1)
+	restore = boot.MockEfiWriteVariable(func(name string, guid efi.GUID, attrs efi.VariableAttributes, data []byte) error {
+		for varDesc := range fakeVariableData {
+			if varDesc.Name == name && varDesc.GUID == guid {
+				return errShouldNotOverwrite
+			}
+		}
+		writeChan <- data
+		return nil
+	})
+	defer restore()
+
+	bootNum, err := boot.SetEfiBootOptionVariable(shimOptionBytes)
+	c.Assert(err, IsNil)
+	c.Assert(bootNum, Equals, uint16(1))
+
+	bootNum, err = boot.SetEfiBootOptionVariable(bootOptionBytes)
+	c.Assert(err, IsNil)
+	c.Assert(bootNum, Equals, uint16(2))
+
+	bootNum, err = boot.SetEfiBootOptionVariable(grubOptionBytes)
+	c.Assert(err, IsNil)
+	c.Assert(bootNum, Equals, uint16(0))
+	c.Assert(<-writeChan, DeepEquals, grubOptionBytes)
+}
+
+func (s *setEfiBootVarsSuite) TestSetEfiBootOptionVarAttrs(c *C) {
+	bootOption := efi.LoadOption{
+		Attributes:  efi.LoadOptionActive | efi.LoadOptionCategoryBoot,
+		Description: "ubuntu",
+		FilePath:    stringToDevicePath("/run/mnt/ubuntu-seed/EFI/BOOT/BOOTX64.efi"),
+	}
+	bootOptionBytes, err := bootOption.Bytes()
+	c.Assert(err, IsNil)
+	bootAttrs := efi.AttributeNonVolatile | efi.AttributeBootserviceAccess
+
+	shimOption := efi.LoadOption{
+		Attributes:  efi.LoadOptionActive | efi.LoadOptionCategoryBoot,
+		Description: "ubuntu",
+		FilePath:    stringToDevicePath("/run/mnt/ubuntu-seed/EFI/ubuntu/shimx64.efi"),
+	}
+	shimOptionBytes, err := shimOption.Bytes()
+	c.Assert(err, IsNil)
+	shimAttrs := defaultVarAttrs | efi.AttributeAuthenticatedWriteAccess
+
+	grubOption := efi.LoadOption{
+		Attributes:  efi.LoadOptionActive | efi.LoadOptionCategoryBoot,
+		Description: "ubuntu",
+		FilePath:    stringToDevicePath("/run/mnt/ubuntu-seed/EFI/ubuntu/grubx64.efi"),
+	}
+	grubOptionBytes, err := grubOption.Bytes()
+	c.Assert(err, IsNil)
+	grubAttrs := defaultVarAttrs
+
+	fakeVariableData := map[efi.VariableDescriptor]*varDataAttrs{
+		{
+			Name: "Boot0000",
+			GUID: efi.GlobalVariable,
+		}: {
+			bootOptionBytes,
+			bootAttrs,
+		},
+		{
+			Name: "Boot0001",
+			GUID: efi.GlobalVariable,
+		}: {
+			shimOptionBytes,
+			shimAttrs,
+		},
+		{
+			Name: "Boot0002",
+			GUID: efi.GlobalVariable,
+		}: {
+			grubOptionBytes,
+			grubAttrs,
+		},
+	}
+	restore := boot.MockEfiListVariables(func() ([]efi.VariableDescriptor, error) {
+		varDescriptorList := make([]efi.VariableDescriptor, 0, len(fakeVariableData))
+		for key := range fakeVariableData {
+			varDescriptorList = append(varDescriptorList, key)
+		}
+		return varDescriptorList, nil
+	})
+	defer restore()
+	restore = boot.MockEfiReadVariable(func(name string, guid efi.GUID) ([]byte, efi.VariableAttributes, error) {
+		descriptor := efi.VariableDescriptor{
+			Name: name,
+			GUID: guid,
+		}
+		if varDA, exists := fakeVariableData[descriptor]; exists {
+			return varDA.data, varDA.attrs, nil
+		}
+		return nil, 0, efi.ErrVarNotExist
+	})
+	defer restore()
+	restore = boot.MockEfiWriteVariable(func(name string, guid efi.GUID, attrs efi.VariableAttributes, data []byte) error {
+		for varDesc := range fakeVariableData {
+			if varDesc.Name == name && varDesc.GUID == guid {
+				return errShouldNotOverwrite
+			}
+		}
+		c.Assert(attrs, Equals, defaultVarAttrs)
+		return nil
+	})
+	defer restore()
+
+	bootNum, err := boot.SetEfiBootOptionVariable(bootOptionBytes)
+	c.Assert(err, IsNil)
+	c.Assert(bootNum, Equals, uint16(0))
+
+	bootNum, err = boot.SetEfiBootOptionVariable(shimOptionBytes)
+	c.Assert(err, IsNil)
+	c.Assert(bootNum, Equals, uint16(1))
+
+	bootNum, err = boot.SetEfiBootOptionVariable(grubOptionBytes)
+	c.Assert(err, IsNil)
+	c.Assert(bootNum, Equals, uint16(2))
+
+	newOption := efi.LoadOption{
+		Attributes:  efi.LoadOptionActive | efi.LoadOptionCategoryBoot,
+		Description: "ubuntu",
+		FilePath:    stringToDevicePath("/run/mnt/ubuntu-seed/EFI/foo/bar.efi"),
+	}
+	newOptionBytes, err := newOption.Bytes()
+	c.Assert(err, IsNil)
+	bootNum, err = boot.SetEfiBootOptionVariable(newOptionBytes)
+	c.Assert(err, IsNil)
+	c.Assert(bootNum, Equals, uint16(3))
+}
+
+func (s *setEfiBootVarsSuite) TestOutOfBootNumbers(c *C) {
+	bootOption := efi.LoadOption{
+		Attributes:  efi.LoadOptionActive | efi.LoadOptionCategoryBoot,
+		Description: "ubuntu",
+		FilePath:    stringToDevicePath("/run/mnt/ubuntu-seed/EFI/BOOT/BOOTX64.efi"),
+	}
+	bootOptionBytes, err := bootOption.Bytes()
+	c.Assert(err, IsNil)
+
+	shimOption := efi.LoadOption{
+		Attributes:  efi.LoadOptionActive | efi.LoadOptionCategoryBoot,
+		Description: "ubuntu",
+		FilePath:    stringToDevicePath("/run/mnt/ubuntu-seed/EFI/newdir/shimx64.efi"),
+	}
+	shimOptionBytes, err := shimOption.Bytes()
+	c.Assert(err, IsNil)
+
+	fakeVariableData := make(map[efi.VariableDescriptor]*varDataAttrs)
+
+	restore := boot.MockEfiListVariables(func() ([]efi.VariableDescriptor, error) {
+		varDescriptorList := make([]efi.VariableDescriptor, 0, len(fakeVariableData))
+		for key := range fakeVariableData {
+			varDescriptorList = append(varDescriptorList, key)
+		}
+		return varDescriptorList, nil
+	})
+	defer restore()
+	restore = boot.MockEfiReadVariable(func(name string, guid efi.GUID) ([]byte, efi.VariableAttributes, error) {
+		descriptor := efi.VariableDescriptor{
+			Name: name,
+			GUID: guid,
+		}
+		if varDA, exists := fakeVariableData[descriptor]; exists {
+			return varDA.data, varDA.attrs, nil
+		}
+		return nil, 0, efi.ErrVarNotExist
+	})
+	defer restore()
+	writeChan := make(chan []byte, 1)
+	restore = boot.MockEfiWriteVariable(func(name string, guid efi.GUID, attrs efi.VariableAttributes, data []byte) error {
+		for varDesc := range fakeVariableData {
+			if varDesc.Name == name && varDesc.GUID == guid {
+				return errShouldNotOverwrite
+			}
+		}
+		writeChan <- data
+		return nil
+	})
+	defer restore()
+
+	// Set all boot variables <= BootFFFE
+	var bootName string
+	var descriptor efi.VariableDescriptor
+	var dataAttrs *varDataAttrs
+	for i := 0; i <= 0xFFFE; i++ {
+		bootName = fmt.Sprintf("Boot%04X", i)
+		descriptor = efi.VariableDescriptor{
+			Name: bootName,
+			GUID: efi.GlobalVariable,
+		}
+		dataAttrs = &varDataAttrs{
+			data:  bootOptionBytes,
+			attrs: defaultVarAttrs,
+		}
+		fakeVariableData[descriptor] = dataAttrs
+	}
+
+	// Check that it is possible to select BootFFFF if unused
+	bootNum, err := boot.SetEfiBootOptionVariable(shimOptionBytes)
+	c.Assert(err, IsNil)
+	c.Assert(bootNum, Equals, uint16(0xFFFF))
+	c.Assert(<-writeChan, DeepEquals, shimOptionBytes)
+
+	bootNum, err = boot.SetEfiBootOptionVariable(bootOptionBytes)
+	c.Assert(err, IsNil)
+	// If multiple variables match, undefined which one will be returned
+	// since map is converted to list in test code.
+	c.Assert(bootNum >= uint16(0) && bootNum < uint16(0xFFFF), Equals, true)
+
+	// Add final BootFFFF variable to make all used
+	descriptor = efi.VariableDescriptor{
+		Name: "BootFFFF",
+		GUID: efi.GlobalVariable,
+	}
+	dataAttrs = &varDataAttrs{
+		data:  bootOptionBytes,
+		attrs: defaultVarAttrs,
+	}
+	fakeVariableData[descriptor] = dataAttrs
+
+	// Check that if there's no match and no numbers left, throws error
+	_, err = boot.SetEfiBootOptionVariable(shimOptionBytes)
+	c.Assert(err, Equals, boot.ErrAllBootNumsUsed)
+
+	// Check that even if all boot nums are used, correct match still occurs
+	bootNum, err = boot.SetEfiBootOptionVariable(bootOptionBytes)
+	c.Assert(err, IsNil)
+	// If multiple variables match, undefined which one will be returned since
+	// map is converted to list in test code.
+	c.Assert(bootNum >= uint16(0) && bootNum <= uint16(0xFFFF), Equals, true)
+}
+
+func (s *setEfiBootVarsSuite) TestSetEfiBootOrderVariable(c *C) {
+	allBootNumbers := make([]byte, 0x20000-2) // all but BootFFFF
+	for n := 0; n < 0xFFFF; n++ {
+		allBootNumbers[n*2] = byte(n & 0xFF)
+		allBootNumbers[n*2+1] = byte((n >> 8) & 0xFF)
+	}
+	allBootNumbersFffeFirst := make([]byte, 0x20000-2)
+	allBootNumbersFffeFirst[0] = 0xFE
+	allBootNumbersFffeFirst[1] = 0xFF
+	copy(allBootNumbersFffeFirst[2:], allBootNumbers[:0x20000-4])
+	allBootNumbersFfffFirst := make([]byte, 0x20000)
+	allBootNumbersFfffFirst[0] = 0xFF
+	allBootNumbersFfffFirst[1] = 0xFF
+	copy(allBootNumbersFfffFirst[2:], allBootNumbers)
+	testCases := []struct {
+		bootNum          uint16
+		initialBootOrder []byte
+		finalBootOrder   []byte
+	}{
+		{
+			uint16(0),
+			[]byte{0, 0, 1, 0, 2, 0, 3, 0},
+			[]byte{0, 0, 1, 0, 2, 0, 3, 0},
+		},
+		{
+			uint16(1),
+			[]byte{0, 0, 1, 0, 2, 0, 3, 0},
+			[]byte{1, 0, 0, 0, 2, 0, 3, 0},
+		},
+		{
+			uint16(2),
+			[]byte{0, 0, 1, 0, 2, 0, 3, 0},
+			[]byte{2, 0, 0, 0, 1, 0, 3, 0},
+		},
+		{
+			uint16(3),
+			[]byte{0, 0, 1, 0, 2, 0, 3, 0},
+			[]byte{3, 0, 0, 0, 1, 0, 2, 0},
+		},
+		{
+			uint16(4),
+			[]byte{0, 0, 1, 0, 2, 0, 3, 0},
+			[]byte{4, 0, 0, 0, 1, 0, 2, 0, 3, 0},
+		},
+		{
+			uint16(2),
+			[]byte{0, 0, 1, 0, 3, 0, 4, 0},
+			[]byte{2, 0, 0, 0, 1, 0, 3, 0, 4, 0},
+		},
+		{
+			uint16(2),
+			[]byte{1, 0, 0, 0, 3, 0},
+			[]byte{2, 0, 1, 0, 0, 0, 3, 0},
+		},
+		{
+			uint16(0xFFFE),
+			allBootNumbers,
+			allBootNumbersFffeFirst,
+		},
+		{
+			uint16(7),
+			[]byte{},
+			[]byte{7, 0},
+		},
+		{
+			uint16(43),
+			nil,
+			[]byte{43, 0},
+		},
+	}
+	readChan := make(chan []byte, 1)
+	restore := boot.MockEfiReadVariable(func(name string, guid efi.GUID) ([]byte, efi.VariableAttributes, error) {
+		return <-readChan, defaultVarAttrs, nil
+	})
+	defer restore()
+	writeChan := make(chan []byte, 1)
+	restore = boot.MockEfiWriteVariable(func(name string, guid efi.GUID, attrs efi.VariableAttributes, data []byte) error {
+		c.Assert(name, Equals, "BootOrder")
+		c.Assert(guid, Equals, efi.GlobalVariable)
+		c.Assert(attrs, Equals, defaultVarAttrs)
+		writeChan <- data
+		return nil
+	})
+	defer restore()
+	for _, tc := range testCases {
+		readChan <- tc.initialBootOrder
+		err := boot.SetEfiBootOrderVariable(tc.bootNum)
+		c.Assert(err, IsNil)
+		select {
+		case written := <-writeChan:
+			if bytes.Compare(tc.initialBootOrder, tc.finalBootOrder) == 0 {
+				c.Fatalf("should not have written BootOrder: %+v", tc)
+			}
+			c.Assert(written, DeepEquals, tc.finalBootOrder)
+		default:
+			if bytes.Compare(tc.initialBootOrder, tc.finalBootOrder) == 0 {
+				continue // BootOrder unchanged, so there should be no write
+			}
+			c.Fatalf("BootOrder was not written: %+v", tc)
+		}
+	}
+}
+
+func (s *setEfiBootVarsSuite) TestSetEfiBootOrderVarAttrs(c *C) {
+	bootNum := uint16(2)
+	initialBootOrder := []byte{0, 0, 1, 0, 2, 0, 3, 0}
+	finalBootOrder := []byte{2, 0, 0, 0, 1, 0, 3, 0}
+	testAttrs := []efi.VariableAttributes{
+		efi.AttributeNonVolatile | efi.AttributeBootserviceAccess,
+		defaultVarAttrs,
+		defaultVarAttrs | efi.AttributeAuthenticatedWriteAccess,
+	}
+	attrReadChan := make(chan efi.VariableAttributes, 1)
+	restore := boot.MockEfiReadVariable(func(name string, guid efi.GUID) ([]byte, efi.VariableAttributes, error) {
+		return initialBootOrder, <-attrReadChan, nil
+	})
+	defer restore()
+	attrWriteChan := make(chan efi.VariableAttributes, 1)
+	restore = boot.MockEfiWriteVariable(func(name string, guid efi.GUID, attrs efi.VariableAttributes, data []byte) error {
+		c.Assert(name, Equals, "BootOrder")
+		c.Assert(guid, Equals, efi.GlobalVariable)
+		c.Assert(data, DeepEquals, finalBootOrder)
+		attrWriteChan <- attrs
+		return nil
+	})
+	defer restore()
+	for _, attrs := range testAttrs {
+		attrReadChan <- attrs
+		err := boot.SetEfiBootOrderVariable(bootNum)
+		c.Assert(err, IsNil)
+		select {
+		case a := <-attrWriteChan:
+			c.Assert(a, Equals, attrs)
+		default:
+			c.Fatalf("BootOrder was not written with attrs: %+v", attrs)
+		}
+	}
+}

--- a/bootloader/bootloader.go
+++ b/bootloader/bootloader.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2021 Canonical Ltd
+ * Copyright (C) 2014-2023 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -253,6 +253,15 @@ type RebootBootloader interface {
 
 	// GetRebootArguments returns the needed reboot arguments
 	GetRebootArguments() (string, error)
+}
+
+// UefiBootloader provides data for setting EFI boot variables.
+type UefiBootloader interface {
+	Bootloader
+
+	// EfiLoadOptionParameters returns the data which may be used to construct
+	// an EFI load option.
+	EfiLoadOptionParameters() (description string, assetPath string, optionalData []byte, err error)
 }
 
 func genericInstallBootConfig(gadgetFile, systemFile string) error {

--- a/bootloader/export_test.go
+++ b/bootloader/export_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2017 Canonical Ltd
+ * Copyright (C) 2017-2023 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/bootloader/grub.go
+++ b/bootloader/grub.go
@@ -498,19 +498,28 @@ func staticCommandLineForGrubAssetEdition(asset string, edition uint) string {
 
 // grubBootAssetPath contains the paths for assets in the boot chain.
 type grubBootAssetPath struct {
-	shimBinary string
-	grubBinary string
+	shimBinary         string
+	grubBinary         string
+	fallbackBinary     string
+	shimFallbackBinary string
+	grubFallbackBinary string
 }
 
 // grubBootAssetsForArch contains the paths for assets for different
 // architectures in a map
 var grubBootAssetsForArch = map[string]grubBootAssetPath{
 	"amd64": {
-		shimBinary: filepath.Join("EFI/boot/", "bootx64.efi"),
-		grubBinary: filepath.Join("EFI/boot/", "grubx64.efi")},
+		shimBinary:         filepath.Join("EFI/boot/", "bootx64.efi"),
+		grubBinary:         filepath.Join("EFI/boot/", "grubx64.efi"),
+		fallbackBinary:     filepath.Join("EFI/boot/", "fbx64.efi"),
+		shimFallbackBinary: filepath.Join("EFI/ubuntu/", "shimx64.efi"),
+		grubFallbackBinary: filepath.Join("EFI/ubuntu/", "grubx64.efi")},
 	"arm64": {
-		shimBinary: filepath.Join("EFI/boot/", "bootaa64.efi"),
-		grubBinary: filepath.Join("EFI/boot/", "grubaa64.efi")},
+		shimBinary:         filepath.Join("EFI/boot/", "bootaa64.efi"),
+		grubBinary:         filepath.Join("EFI/boot/", "grubaa64.efi"),
+		fallbackBinary:     filepath.Join("EFI/boot/", "fbaa64.efi"),
+		shimFallbackBinary: filepath.Join("EFI/ubuntu/", "shimaa64.efi"),
+		grubFallbackBinary: filepath.Join("EFI/ubuntu/", "grubaa64.efi")},
 }
 
 func (g *grub) getGrubBootAssetsForArch() (*grubBootAssetPath, error) {
@@ -531,6 +540,9 @@ func (g *grub) getGrubRecoveryModeTrustedAssets() ([]string, error) {
 	assets, err := g.getGrubBootAssetsForArch()
 	if err != nil {
 		return nil, err
+	}
+	if osutil.FileExists(filepath.Join(g.rootdir, assets.fallbackBinary)) {
+		return []string{assets.shimFallbackBinary, assets.grubFallbackBinary}, nil
 	}
 	return []string{assets.shimBinary, assets.grubBinary}, nil
 }

--- a/bootloader/grub.go
+++ b/bootloader/grub.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2021 Canonical Ltd
+ * Copyright (C) 2014-2023 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -498,28 +498,28 @@ func staticCommandLineForGrubAssetEdition(asset string, edition uint) string {
 
 // grubBootAssetPath contains the paths for assets in the boot chain.
 type grubBootAssetPath struct {
-	shimBinary         string
-	grubBinary         string
-	fallbackBinary     string
-	shimFallbackBinary string
-	grubFallbackBinary string
+	defaultShimBinary string
+	defaultGrubBinary string
+	fallbackBinary    string
+	shimBinary        string
+	grubBinary        string
 }
 
 // grubBootAssetsForArch contains the paths for assets for different
 // architectures in a map
 var grubBootAssetsForArch = map[string]grubBootAssetPath{
 	"amd64": {
-		shimBinary:         filepath.Join("EFI/boot/", "bootx64.efi"),
-		grubBinary:         filepath.Join("EFI/boot/", "grubx64.efi"),
-		fallbackBinary:     filepath.Join("EFI/boot/", "fbx64.efi"),
-		shimFallbackBinary: filepath.Join("EFI/ubuntu/", "shimx64.efi"),
-		grubFallbackBinary: filepath.Join("EFI/ubuntu/", "grubx64.efi")},
+		defaultShimBinary: filepath.Join("EFI/boot/", "bootx64.efi"),
+		defaultGrubBinary: filepath.Join("EFI/boot/", "grubx64.efi"),
+		fallbackBinary:    filepath.Join("EFI/boot/", "fbx64.efi"),
+		shimBinary:        filepath.Join("EFI/ubuntu/", "shimx64.efi"),
+		grubBinary:        filepath.Join("EFI/ubuntu/", "grubx64.efi")},
 	"arm64": {
-		shimBinary:         filepath.Join("EFI/boot/", "bootaa64.efi"),
-		grubBinary:         filepath.Join("EFI/boot/", "grubaa64.efi"),
-		fallbackBinary:     filepath.Join("EFI/boot/", "fbaa64.efi"),
-		shimFallbackBinary: filepath.Join("EFI/ubuntu/", "shimaa64.efi"),
-		grubFallbackBinary: filepath.Join("EFI/ubuntu/", "grubaa64.efi")},
+		defaultShimBinary: filepath.Join("EFI/boot/", "bootaa64.efi"),
+		defaultGrubBinary: filepath.Join("EFI/boot/", "grubaa64.efi"),
+		fallbackBinary:    filepath.Join("EFI/boot/", "fbaa64.efi"),
+		shimBinary:        filepath.Join("EFI/ubuntu/", "shimaa64.efi"),
+		grubBinary:        filepath.Join("EFI/ubuntu/", "grubaa64.efi")},
 }
 
 func (g *grub) getGrubBootAssetsForArch() (*grubBootAssetPath, error) {
@@ -542,9 +542,9 @@ func (g *grub) getGrubRecoveryModeTrustedAssets() ([]string, error) {
 		return nil, err
 	}
 	if osutil.FileExists(filepath.Join(g.rootdir, assets.fallbackBinary)) {
-		return []string{assets.shimFallbackBinary, assets.grubFallbackBinary}, nil
+		return []string{assets.shimBinary, assets.grubBinary}, nil
 	}
-	return []string{assets.shimBinary, assets.grubBinary}, nil
+	return []string{assets.defaultShimBinary, assets.defaultGrubBinary}, nil
 }
 
 // getGrubRunModeTrustedAssets returns the assets for run mode, which is
@@ -554,7 +554,19 @@ func (g *grub) getGrubRunModeTrustedAssets() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	return []string{assets.grubBinary}, nil
+	return []string{assets.defaultGrubBinary}, nil
+}
+
+// getGrubShimBinaryFullPath returns the full filepath of the shim binary.
+func (g *grub) getGrubShimBinaryFullPath() (string, error) {
+	assets, err := g.getGrubBootAssetsForArch()
+	if err != nil {
+		return "", err
+	}
+	if osutil.FileExists(filepath.Join(g.rootdir, assets.fallbackBinary)) {
+		return filepath.Join(g.rootdir, assets.shimBinary), nil
+	}
+	return filepath.Join(g.rootdir, assets.defaultShimBinary), nil
 }
 
 // TrustedAssets returns the list of relative paths to assets inside
@@ -623,4 +635,16 @@ func (g *grub) BootChain(runBl Bootloader, kernelPath string) ([]BootFile, error
 	chain = append(chain, NewBootFile(kernelPath, "kernel.efi", RoleRunMode))
 
 	return chain, nil
+}
+
+// ConstructShimEfiLoadOption returns a serialized load option for the shim
+// binary. It should be called on a UefiBootloader.
+func (g *grub) EfiLoadOptionParameters() (description string, assetPath string, optionalData []byte, err error) {
+	assetPath, err = g.getGrubShimBinaryFullPath()
+	if err != nil {
+		return "", "", nil, err
+	}
+	description = "ubuntu"
+	optionalData = nil
+	return description, assetPath, optionalData, nil
 }

--- a/bootloader/grub_test.go
+++ b/bootloader/grub_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2021 Canonical Ltd
+ * Copyright (C) 2014-2023 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -1376,4 +1376,25 @@ func (s *grubTestSuite) TestBootChainsNotRecoveryBootloader(c *C) {
 
 	_, err := tab.BootChain(g2, "kernel.snap")
 	c.Assert(err, ErrorMatches, "not a recovery bootloader")
+}
+
+func (s *grubTestSuite) TestConstructShimEfiLoadOption(c *C) {
+	s.makeFakeGrubEFINativeEnv(c, nil)
+	g := bootloader.NewGrub(s.rootdir, nil)
+	ubl, ok := g.(bootloader.UefiBootloader)
+	c.Assert(ok, Equals, true)
+
+	description, assetPath, optionalData, err := ubl.EfiLoadOptionParameters()
+	c.Assert(err, IsNil)
+	c.Assert(description, Equals, "ubuntu")
+	c.Assert(assetPath, Equals, fmt.Sprintf("%s/EFI/boot/bootx64.efi", s.rootdir))
+	c.Assert(optionalData, HasLen, 0)
+
+	s.makeFakeShimFallback(c)
+
+	description, assetPath, optionalData, err = ubl.EfiLoadOptionParameters()
+	c.Assert(err, IsNil)
+	c.Assert(description, Equals, "ubuntu")
+	c.Assert(assetPath, Equals, fmt.Sprintf("%s/EFI/ubuntu/shimx64.efi", s.rootdir))
+	c.Assert(optionalData, HasLen, 0)
 }

--- a/gadget/update.go
+++ b/gadget/update.go
@@ -1421,6 +1421,8 @@ func Update(model Model, old, new GadgetData, rollbackDirPath string, updatePoli
 		return err
 	}
 
+	// TODO: set EFI bootvariables when gadget updates
+
 	return nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ go 1.18
 replace maze.io/x/crypto => github.com/snapcore/maze.io-x-crypto v0.0.0-20190131090603-9b94c9afe066
 
 require (
-	github.com/canonical/go-efilib v0.3.1-0.20220815143333-7e5151412e93 // indirect
+	github.com/canonical/go-efilib v0.4.0
 	github.com/canonical/go-sp800.90a-drbg v0.0.0-20210314144037-6eeb1040d6c3 // indirect
 	github.com/canonical/go-tpm2 v0.0.0-20210827151749-f80ff5afff61
 	github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7
@@ -25,10 +25,10 @@ require (
 	golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90
 	golang.org/x/net v0.9.0 // indirect
 	golang.org/x/sys v0.7.0
+	golang.org/x/text v0.9.0
 	golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
 	gopkg.in/macaroon.v1 v1.0.0-20150121114231-ab3940c6c165
-	gopkg.in/mgo.v2 v2.0.0-20180704144907-a7e2c1d573e1
 	gopkg.in/retry.v1 v1.0.3
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637
 	gopkg.in/tylerb/graceful.v1 v1.2.15

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/canonical/go-efilib v0.3.1-0.20220815143333-7e5151412e93 h1:F0bRDzPy/j2IX/iIWqCEA23S1nal+f7A+/vLyj6Ye+4=
-github.com/canonical/go-efilib v0.3.1-0.20220815143333-7e5151412e93/go.mod h1:9b2PNAuPcZsB76x75/uwH99D8CyH/A2y4rq1/+bvplg=
+github.com/canonical/go-efilib v0.4.0 h1:2ee5pvhIZ+g1EO4HxFE/owBgs5Up2g7dw1+Ls9/fiSs=
+github.com/canonical/go-efilib v0.4.0/go.mod h1:9b2PNAuPcZsB76x75/uwH99D8CyH/A2y4rq1/+bvplg=
 github.com/canonical/go-sp800.108-kdf v0.0.0-20210314145419-a3359f2d21b9 h1:USzKjrfWo/ESzozv2i3OMM7XDgxrZRvaHFrKkIKRtwU=
 github.com/canonical/go-sp800.108-kdf v0.0.0-20210314145419-a3359f2d21b9/go.mod h1:Zrs3YjJr+w51u0R/dyLh/oWt/EcBVdLPCVFYC4daW5s=
 github.com/canonical/go-sp800.90a-drbg v0.0.0-20210314144037-6eeb1040d6c3 h1:oe6fCvaEpkhyW3qAicT0TnGtyht/UrgvOwMcEgLb7Aw=
@@ -71,6 +71,7 @@ golang.org/x/term v0.7.0 h1:BEvjmm5fURWqcfbSKTdpkDXYBrUS1c0m8agp14W48vQ=
 golang.org/x/term v0.7.0/go.mod h1:P32HKFT3hSsZrRxla30E9HqToFYAQPCMs/zFMBUFqPY=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.9.0 h1:2sjJmO8cDvYveuX97RDLsxlyUxLl+GHoLxBiRdHllBE=
+golang.org/x/text v0.9.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f h1:uF6paiQQebLeSXkrTqHqz0MXhXXS1KgF41eUdBNvxK0=
@@ -80,8 +81,6 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/macaroon.v1 v1.0.0-20150121114231-ab3940c6c165 h1:85xqOSyTpSzplW7fyO9bOZpSsemJc9UKzEQR2L4k32k=
 gopkg.in/macaroon.v1 v1.0.0-20150121114231-ab3940c6c165/go.mod h1:PABpHZvxAbIuSYTPWJdQsNu0mtx+HX/1NIm3IT95IX0=
-gopkg.in/mgo.v2 v2.0.0-20180704144907-a7e2c1d573e1 h1:pZKliRm58MUzYBqgNxAAGvnLp27Oy76J6Il8oSsaSrI=
-gopkg.in/mgo.v2 v2.0.0-20180704144907-a7e2c1d573e1/go.mod h1:yeKp02qBN3iKW1OzL3MGk2IdtZzaj7SFntXj72NppTA=
 gopkg.in/retry.v1 v1.0.3 h1:a9CArYczAVv6Qs6VGoLMio99GEs7kY9UzSF9+LD+iGs=
 gopkg.in/retry.v1 v1.0.3/go.mod h1:FJkXmWiMaAo7xB+xhvDF59zhfjDWyzmyAxiT4dB688g=
 gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637 h1:yiW+nvdHb9LVqSHQBXfZCieqV4fzYhNBql77zY0ykqs=

--- a/tests/nested/core/core20-set-efi-boot-variables/setefivars.go
+++ b/tests/nested/core/core20-set-efi-boot-variables/setefivars.go
@@ -8,18 +8,20 @@ import (
 	"github.com/snapcore/snapd/osutil"
 )
 
-const shimPath string = "/boot/efi/EFI/ubuntu/shimx64.efi"
-const bootPath string = "/boot/efi/EFI/BOOT/BOOTX64.efi"
+var possibleAssets = []string{
+	"/boot/efi/EFI/ubuntu/shimx64.efi",
+	"/boot/efi/EFI/BOOT/BOOTX64.efi",
+	"/boot/efi/EFI/ubuntu/shimaa64.efi",
+	"/boot/efi/EFI/BOOT/BOOTAA64.efi",
+}
 
 func uefiLoadOptionParameters() (description string, assetPath string, optionalData []byte, err error) {
-	if osutil.FileExists(shimPath) {
-		assetPath = shimPath
-	} else if osutil.FileExists(bootPath) {
-		assetPath = bootPath
-	} else {
-		return "", "", nil, fmt.Errorf("cannot find boot or shim EFI binary")
+	for _, assetPath = range possibleAssets {
+		if osutil.FileExists(assetPath) {
+			return "spread-test-var", assetPath, make([]byte, 0), nil
+		}
 	}
-	return "spread-test-var", assetPath, make([]byte, 0), nil
+	return "", "", nil, fmt.Errorf("cannot find boot or shim EFI binary")
 }
 
 func main() {
@@ -30,6 +32,6 @@ func main() {
 
 	err = boot.SetEfiBootVariables(description, assetPath, optionalData)
 	if err != nil {
-		log.Fatalf("cannot set EFI boot variables: %q", err)
+		log.Fatalf("cannot set EFI boot variables for asset path '%s': %q", assetPath, err)
 	}
 }

--- a/tests/nested/core/core20-set-efi-boot-variables/setefivars.go
+++ b/tests/nested/core/core20-set-efi-boot-variables/setefivars.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/osutil"
+)
+
+const shimPath string = "/boot/efi/EFI/ubuntu/shimx64.efi"
+const bootPath string = "/boot/efi/EFI/BOOT/BOOTX64.efi"
+
+func uefiLoadOptionParameters() (description string, assetPath string, optionalData []byte, err error) {
+	if osutil.FileExists(shimPath) {
+		assetPath = shimPath
+	} else if osutil.FileExists(bootPath) {
+		assetPath = bootPath
+	} else {
+		return "", "", nil, fmt.Errorf("cannot find boot or shim EFI binary")
+	}
+	return "spread-test-var", assetPath, make([]byte, 0), nil
+}
+
+func main() {
+	description, assetPath, optionalData, err := uefiLoadOptionParameters()
+	if err != nil {
+		log.Fatalf("%v", err)
+	}
+
+	err = boot.SetEfiBootVariables(description, assetPath, optionalData)
+	if err != nil {
+		log.Fatalf("cannot set EFI boot variables: %q", err)
+	}
+}

--- a/tests/nested/core/core20-set-efi-boot-variables/task.yaml
+++ b/tests/nested/core/core20-set-efi-boot-variables/task.yaml
@@ -1,30 +1,9 @@
-summary: Integration tests for the setting EFI boot variables
+summary: Tests for the code that sets EFI boot variables, as if it were a library separate from snapd
 
 systems: [ubuntu-2*]
 
 prepare: |
     "$(command -v go)" build -o setefivars setefivars.go
-
-debug: |
-    remote_exec_efibootmgr() {
-        remote_path="$(remote.exec "echo ${PATH}")"
-        augmented_path="/snap/toolbox/current/bin:/snap/toolbox/current/sbin:/snap/toolbox/current/usr/bin:/snap/toolbox/current/usr/sbin:${remote_path}"
-        remote.exec "PATH=${augmented_path} LD_LIBRARY_PATH='/lib:/usr/lib:/lib/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnu:/snap/toolbox/current/lib:/snap/toolbox/current/usr/lib:/snap/toolbox/current/lib/x86_64-linux-gnu:/snap/toolbox/current/usr/lib/x86_64-linux-gnu' sh -c 'efibootmgr -v'"
-    }
-    if [ -f orig_vars.txt ]; then
-        echo "Original EFI boot variables:"
-        cat orig_vars.txt
-        echo "Current EFI boot variables:"
-        remote_exec_efibootmgr
-    else
-        echo "Original EFI variables were never recorded"
-    fi
-
-execute: |
-    if not os.query is-pc-amd64; then
-        echo "test designed for amd64 architecture, exiting..."
-        exit
-    fi
 
     VERSION=$(tests.nested show version)
 
@@ -36,12 +15,31 @@ execute: |
 
     echo "Install toolbox (to get efibootmgr)"
     remote.exec "sudo snap install --channel=$VERSION toolbox" || true
+
+debug: |
     # The usual toolbox setup assumes bash, so just set PATH and LD_LIBRARY_PATH
     # manually when executing efibootmgr.
     remote_exec_efibootmgr() {
-        remote_path=$(remote.exec "echo ${PATH}")
-        augmented_path="/snap/toolbox/current/bin:/snap/toolbox/current/sbin:/snap/toolbox/current/usr/bin:/snap/toolbox/current/usr/sbin:${remote_path}"
-        remote.exec "PATH=${augmented_path} LD_LIBRARY_PATH='/lib:/usr/lib:/lib/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnu:/snap/toolbox/current/lib:/snap/toolbox/current/usr/lib:/snap/toolbox/current/lib/x86_64-linux-gnu:/snap/toolbox/current/usr/lib/x86_64-linux-gnu' sh -c 'efibootmgr -v'"
+        augmented_path="/snap/toolbox/current/bin:/snap/toolbox/current/sbin:/snap/toolbox/current/usr/bin:/snap/toolbox/current/usr/sbin:${PATH}" # Host path is fine as base
+        augmented_ld_path="/lib:/usr/lib:/lib/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnu:/snap/toolbox/current/lib:/snap/toolbox/current/usr/lib:/snap/toolbox/current/lib/x86_64-linux-gnu:/snap/toolbox/current/usr/lib/x86_64-linux-gnu"
+        remote.exec "PATH=${augmented_path} LD_LIBRARY_PATH=${augmented_ld_path} sh -c 'efibootmgr -v'"
+    }
+    if [ -f orig_vars.txt ]; then
+        echo "Original EFI boot variables:"
+        cat orig_vars.txt
+        echo "Current EFI boot variables:"
+        remote_exec_efibootmgr
+    else
+        echo "Original EFI variables were never recorded"
+    fi
+
+execute: |
+    # The usual toolbox setup assumes bash, so just set PATH and LD_LIBRARY_PATH
+    # manually when executing efibootmgr.
+    remote_exec_efibootmgr() {
+        augmented_path="/snap/toolbox/current/bin:/snap/toolbox/current/sbin:/snap/toolbox/current/usr/bin:/snap/toolbox/current/usr/sbin:${PATH}" # Host path is fine as base
+        augmented_ld_path="/lib:/usr/lib:/lib/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnu:/snap/toolbox/current/lib:/snap/toolbox/current/usr/lib:/snap/toolbox/current/lib/x86_64-linux-gnu:/snap/toolbox/current/usr/lib/x86_64-linux-gnu"
+        remote.exec "PATH=${augmented_path} LD_LIBRARY_PATH=${augmented_ld_path} sh -c 'efibootmgr -v'"
     }
 
     echo "Store original variables"

--- a/tests/nested/core/core20-set-efi-boot-variables/task.yaml
+++ b/tests/nested/core/core20-set-efi-boot-variables/task.yaml
@@ -1,0 +1,74 @@
+summary: Integration tests for the setting EFI boot variables
+
+systems: [ubuntu-2*]
+
+prepare: |
+    "$(command -v go)" build -o setefivars setefivars.go
+
+debug: |
+    remote_exec_efibootmgr() {
+        remote_path="$(remote.exec "echo ${PATH}")"
+        augmented_path="/snap/toolbox/current/bin:/snap/toolbox/current/sbin:/snap/toolbox/current/usr/bin:/snap/toolbox/current/usr/sbin:${remote_path}"
+        remote.exec "PATH=${augmented_path} LD_LIBRARY_PATH='/lib:/usr/lib:/lib/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnu:/snap/toolbox/current/lib:/snap/toolbox/current/usr/lib:/snap/toolbox/current/lib/x86_64-linux-gnu:/snap/toolbox/current/usr/lib/x86_64-linux-gnu' sh -c 'efibootmgr -v'"
+    }
+    if [ -f orig_vars.txt ]; then
+        echo "Original EFI boot variables:"
+        cat orig_vars.txt
+        echo "Current EFI boot variables:"
+        remote_exec_efibootmgr
+    else
+        echo "Original EFI variables were never recorded"
+    fi
+
+execute: |
+    if not os.query is-pc-amd64; then
+        echo "test designed for amd64 architecture, exiting..."
+        exit
+    fi
+
+    VERSION=$(tests.nested show version)
+
+    echo "Wait for the system to be seeded"
+    remote.exec "sudo snap wait system seed.loaded"
+
+    echo "Wait for device initialization to be done"
+    remote.exec "retry --wait 5 -n 10 sh -c 'snap changes | MATCH \"Done.*Initialize device\"'"
+
+    echo "Install toolbox (to get efibootmgr)"
+    remote.exec "sudo snap install --channel=$VERSION toolbox" || true
+    # The usual toolbox setup assumes bash, so just set PATH and LD_LIBRARY_PATH
+    # manually when executing efibootmgr.
+    remote_exec_efibootmgr() {
+        remote_path=$(remote.exec "echo ${PATH}")
+        augmented_path="/snap/toolbox/current/bin:/snap/toolbox/current/sbin:/snap/toolbox/current/usr/bin:/snap/toolbox/current/usr/sbin:${remote_path}"
+        remote.exec "PATH=${augmented_path} LD_LIBRARY_PATH='/lib:/usr/lib:/lib/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnu:/snap/toolbox/current/lib:/snap/toolbox/current/usr/lib:/snap/toolbox/current/lib/x86_64-linux-gnu:/snap/toolbox/current/usr/lib/x86_64-linux-gnu' sh -c 'efibootmgr -v'"
+    }
+
+    echo "Store original variables"
+    remote_exec_efibootmgr > orig_vars.txt
+    echo "Store original boot order"
+    remote_exec_efibootmgr | grep BootOrder | cut -d ' ' -f 2 > orig_bootorder.txt
+
+    echo "Push locally-built setefivars binary"
+    remote.push setefivars
+
+    echo "Execute setefivars binary"
+    remote.exec "sudo ./setefivars"
+
+    echo "Check that new boot order differs from original"
+    new_bootorder="$(remote_exec_efibootmgr | grep 'BootOrder' | cut -d ' ' -f 2)"
+    new_first="$(echo "$new_bootorder" | cut -d ',' -f 1)"
+    orig_bootorder="$(cat orig_bootorder.txt)"
+
+    remote_exec_efibootmgr -v | grep 'spread-test-var' | MATCH "^Boot${new_first}"
+
+    if [ "$new_bootorder" != "${new_first},${orig_bootorder}" ]; then
+        ERROR "New BootOrder variable is not set correctly"
+    fi
+
+    echo "Check that running the code again results does not modify boot vars again"
+    remote_exec_efibootmgr -v > new_vars.txt
+    remote.exec "sudo ./setefivars"
+    remote_exec_efibootmgr -v > newest_vars.txt
+    diff new_vars.txt newest_vars.txt
+

--- a/tests/nested/manual/core20-set-efi-boot-vars/modify-gadget.sh
+++ b/tests/nested/manual/core20-set-efi-boot-vars/modify-gadget.sh
@@ -1,0 +1,98 @@
+#!/bin/sh
+
+USAGE='USAGE: sh modify-gadget.sh GADGET_DIR ARCH {fallback | no-fallback}'
+
+GADGET_DIR="$1"
+ARCH="$2"
+ARCH_UPPER="$(echo "$ARCH" | tr '[:lower:]' '[:upper:]')"
+FALLBACK="$3"
+
+file_exists() {
+	filepath="$1"
+	if [ -f "$filepath" ]; then
+		return 0
+	fi
+	echo "ERROR: file does not exist: $filepath"
+	echo "$USAGE"
+	exit 1
+}
+
+prepare_boot_csv() {
+	if [ -f "${GADGET_DIR}/BOOT${ARCH_UPPER}.CSV" ]; then
+		return 0
+	elif [ -f "/usr/lib/shim/BOOT${ARCH_UPPER}.CSV" ]; then
+		cp "/usr/lib/shim/BOOT${ARCH_UPPER}.CSV" "${GADGET_DIR}/"
+		return 0
+	fi
+	echo "ERROR: neither gadget nor host has boot CSV: BOOT${ARCH_UPPER}.CSV"
+	exit 1
+}
+
+prepare_fallback() {
+	if [ -f "${GADGET_DIR}/fb${ARCH}.efi" ]; then
+		return 0
+	elif [ -f "${GADGET_DIR}/fb${ARCH}.efi.bak" ]; then
+		mv "${GADGET_DIR}/fb${ARCH}.efi.bak" "${GADGET_DIR}/fb${ARCH}.efi"
+		return 0
+	elif [ -f "/usr/lib/shim/fb${ARCH}.efi" ]; then
+		cp "/usr/lib/shim/fb${ARCH}.efi" "${GADGET_DIR}/"
+		return 0
+	fi
+	echo "ERROR: neither gadget nor host has fallback binary: fb${ARCH}.efi"
+	exit 1
+}
+
+prepare_no_fallback() {
+	if [ -f "${GADGET_DIR}/fb${ARCH}.efi" ]; then
+		mv "${GADGET_DIR}/fb${ARCH}.efi" "${GADGET_DIR}/fb${ARCH}.efi.bak"
+	fi
+}
+
+if ! [ -d "$GADGET_DIR" ]; then
+	echo "ERROR: unpacked gadget directory not found: $GADGET_DIR"
+	echo "$USAGE"
+	exit 1
+fi
+
+file_exists "${GADGET_DIR}/shim.efi.signed" || exit 1
+file_exists "${GADGET_DIR}/grub${ARCH}.efi" || exit 1
+file_exists "${GADGET_DIR}/meta/gadget.yaml" || exit 1
+
+command -v yq > /dev/null || sudo snap install yq || snap install yq
+
+if ! [ -f "${GADGET_DIR}/meta/gadget.yaml.bak" ]; then
+	cp "${GADGET_DIR}/meta/gadget.yaml" "${GADGET_DIR}/meta/gadget.yaml.bak" || exit 1
+fi
+
+case "$FALLBACK" in
+	"fallback")
+		prepare_boot_csv || exit 1
+		prepare_fallback || exit 1
+		yq -i '(.volumes.pc.structure[] | select(.role == "system-seed") | .content) |= [
+			{"source": "BOOT'"$ARCH_UPPER"'.CSV", "target": "EFI/ubuntu/BOOT'"$ARCH_UPPER"'.CSV"},
+			{"source": "grub'"$ARCH"'.efi",       "target": "EFI/ubuntu/grub'"$ARCH"'.efi"},
+			{"source": "shim.efi.signed",         "target": "EFI/ubuntu/shim'"$ARCH"'.efi"},
+			{"source": "shim.efi.signed",         "target": "EFI/boot/boot'"$ARCH"'.efi"},
+			{"source": "fb'"$ARCH"'.efi",         "target": "EFI/boot/fb'"$ARCH"'.efi"}
+		]' "${GADGET_DIR}/meta/gadget.yaml"
+		;;
+	"no-fallback")
+		prepare_no_fallback || exit 1
+		yq -i '(.volumes.pc.structure[] | select(.role == "system-seed") | .content) |= [
+			{"source": "grub'"$ARCH"'.efi", "target": "EFI/boot/grub'"$ARCH"'.efi"},
+			{"source": "shim.efi.signed",   "target": "EFI/boot/boot'"$ARCH"'.efi"}
+		]' "${GADGET_DIR}/meta/gadget.yaml"
+		;;
+	*)
+		echo 'ERROR: must specify "fallback" or "no-fallback"'
+		echo "$USAGE"
+		exit 1
+		;;
+esac
+
+# Increment edition. If the gadget was previously modified, make sure it is not
+# reset to its original state, as this incremented edition must be greater than
+# the previous for the new gadget to be installed.
+yq -i '(.volumes.pc.structure[] | select(.role == "system-seed") | .update.edition) |= . + 1' \
+	pc-gadget/meta/gadget.yaml
+

--- a/tests/nested/manual/core20-set-efi-boot-vars/task.yaml
+++ b/tests/nested/manual/core20-set-efi-boot-vars/task.yaml
@@ -153,48 +153,51 @@ execute: |
 
     echo "All good!"
 
-    echo "Set up gadget with EFI assets in EFI/${FINAL_ASSET_DIR}"
-    case "${FINAL_ASSET_DIR}" in
-        boot )
-            sh modify-gadget.sh pc-gadget "$ARCH" no-fallback
-            ;;
-        ubuntu )
-            sh modify-gadget.sh pc-gadget "$ARCH" fallback
-            ;;
-        * )
-            ERROR "Invalid initial asset dir: ${FINAL_ASSET_DIR}"
-            ;;
-    esac
+    # At the moment, setting EFI boot vars does not happen during gadget update.
+    # When this is fixed, include the rest of this test.
 
-    echo "Get snakeoil key"
-    KEY_NAME=$(tests.nested download snakeoil-key)
-    SNAKEOIL_KEY="$PWD/$KEY_NAME.key"
-    SNAKEOIL_CERT="$PWD/$KEY_NAME.pem"
+    # echo "Set up gadget with EFI assets in EFI/${FINAL_ASSET_DIR}"
+    # case "${FINAL_ASSET_DIR}" in
+    #     boot )
+    #         sh modify-gadget.sh pc-gadget "$ARCH" no-fallback
+    #         ;;
+    #     ubuntu )
+    #         sh modify-gadget.sh pc-gadget "$ARCH" fallback
+    #         ;;
+    #     * )
+    #         ERROR "Invalid initial asset dir: ${FINAL_ASSET_DIR}"
+    #         ;;
+    # esac
 
-    echo "Sign the modified pc-gadget"
-    tests.nested secboot-sign gadget pc-gadget "${SNAKEOIL_KEY}" "${SNAKEOIL_CERT}"
+    # echo "Get snakeoil key"
+    # KEY_NAME=$(tests.nested download snakeoil-key)
+    # SNAKEOIL_KEY="$PWD/$KEY_NAME.key"
+    # SNAKEOIL_CERT="$PWD/$KEY_NAME.pem"
 
-    snap pack --filename=pc.snap pc-gadget
-    remote.push pc.snap
+    # echo "Sign the modified pc-gadget"
+    # tests.nested secboot-sign gadget pc-gadget "${SNAKEOIL_KEY}" "${SNAKEOIL_CERT}"
 
-    boot_id=$(tests.nested boot-id)
+    # snap pack --filename=pc.snap pc-gadget
+    # remote.push pc.snap
 
-    echo "Install new gadget"
-    REMOTE_CHG_ID=$(remote.exec "sudo snap install --dangerous --no-wait pc.snap")
-    # VM should reboot now
-    echo "Wait for reboot"
-    remote.wait-for reboot "${boot_id}"
-    # Wait for previous change to finish before continuing
-    remote.exec sudo snap watch "$REMOTE_CHG_ID"
+    # boot_id=$(tests.nested boot-id)
 
-    echo "#### Updated gadget: ####"
+    # echo "Install new gadget"
+    # REMOTE_CHG_ID=$(remote.exec "sudo snap install --dangerous --no-wait pc.snap")
+    # # VM should reboot now
+    # echo "Wait for reboot"
+    # remote.wait-for reboot "${boot_id}"
+    # # Wait for previous change to finish before continuing
+    # remote.exec sudo snap watch "$REMOTE_CHG_ID"
 
-    echo "Check that EFI assets in EFI/${INITIAL_ASSET_DIR} and variables are set correctly"
-    check_efi_assets "$FINAL_ASSET_DIR"
-    if [ "${FINAL_ASSET_DIR}" = "boot" ]; then
-        check_efi_variables "/EFI/boot/boot${ARCH}.efi"
-    elif [ "${FINAL_ASSET_DIR}" = "ubuntu" ]; then
-        check_efi_variables "/EFI/ubuntu/shim${ARCH}.efi"
-    fi
+    # echo "#### Updated gadget: ####"
 
-    echo "All good!"
+    # echo "Check that EFI assets in EFI/${INITIAL_ASSET_DIR} and variables are set correctly"
+    # check_efi_assets "$FINAL_ASSET_DIR"
+    # if [ "${FINAL_ASSET_DIR}" = "boot" ]; then
+    #     check_efi_variables "/EFI/boot/boot${ARCH}.efi"
+    # elif [ "${FINAL_ASSET_DIR}" = "ubuntu" ]; then
+    #     check_efi_variables "/EFI/ubuntu/shim${ARCH}.efi"
+    # fi
+
+    # echo "All good!"

--- a/tests/nested/manual/core20-set-efi-boot-vars/task.yaml
+++ b/tests/nested/manual/core20-set-efi-boot-vars/task.yaml
@@ -1,0 +1,200 @@
+summary: Check that EFI boot variables are successfully on UC20+
+
+details: >
+    This test checks that EFI boot variables are correctly set during
+    installation.  In particular, there should be a Boot#### variable with
+    data pointing to either \EFI\ubuntu\shimx64.efi or \EFI\boot\bootx64.efi,
+    depending on the version of the pc-gadget snap, and the first number in the
+    BootOrder variable should be the corresponding number.
+
+systems: [ubuntu-2*]
+
+environment:
+    DESCRIPTION/BOOTDIR: "Install with assets in EFI/boot/, then update to gadget with assets in EFI/ubuntu/"
+    DESCRIPTION/UBUNTUDIR: "Install with assets in EFI/ubuntu/, then update to gadget with assets in EFI/boot/"
+
+    INITIAL_ASSET_DIR/BOOTDIR: "boot"
+    INITIAL_ASSET_DIR/UBUNTUDIR: "ubuntu"
+
+    FINAL_ASSET_DIR/BOOTDIR: "ubuntu"
+    FINAL_ASSET_DIR/UBUNTUDIR: "boot"
+
+prepare: |
+    snap install yq
+
+    VERSION=$(tests.nested show version)
+    echo "Download pc-gadget to use in initial image"
+    snap download --basename=pc --channel="$VERSION/edge" pc
+    unsquashfs -d pc-gadget pc.snap
+
+    ARCH=$(find pc-gadget -name 'grub*.efi' -printf '%f\n' | sed 's/grub//;s/\.efi//')
+
+    case "${ARCH}" in
+        x64  ) ;;
+        aa64 ) ;;
+        *    ) ERROR "Invalid architecture '${ARCH}': must be 'x64' or 'aa64'" ;;
+    esac
+
+    echo "Set up gadget with EFI assets in EFI/${INITIAL_ASSET_DIR}"
+    case "${INITIAL_ASSET_DIR}" in
+        boot )
+            sh modify-gadget.sh pc-gadget "$ARCH" no-fallback
+            ;;
+        ubuntu )
+            sh modify-gadget.sh pc-gadget "$ARCH" fallback
+            ;;
+        * )
+            ERROR "Invalid initial asset dir: ${INITIAL_ASSET_DIR}"
+            ;;
+    esac
+
+    echo "Get snakeoil key"
+    KEY_NAME=$(tests.nested download snakeoil-key)
+    SNAKEOIL_KEY="$PWD/$KEY_NAME.key"
+    SNAKEOIL_CERT="$PWD/$KEY_NAME.pem"
+
+    echo "Sign the modified pc-gadget"
+    tests.nested secboot-sign gadget pc-gadget "${SNAKEOIL_KEY}" "${SNAKEOIL_CERT}"
+
+    echo "Repack the modified pc-gadget"
+    snap pack pc-gadget/ "$(tests.nested get extra-snaps-path)"
+    # No need to re-sign again after repacking
+    echo "Build core image around modified pc-gadget"
+    tests.nested build-image core
+    echo "Create VM around custom image"
+    tests.nested create-vm core
+
+debug: |
+    VERSION=$(tests.nested show version)
+    echo "Current state of the remote EFI variables:"
+    remote.exec "sudo snap install --channel=${VERSION}/edge toolbox"
+    # The usual toolbox setup assumes bash, so just set PATH and LD_LIBRARY_PATH
+    # manually when executing efibootmgr.
+    augmented_path="/snap/toolbox/current/bin:/snap/toolbox/current/sbin:/snap/toolbox/current/usr/bin:/snap/toolbox/current/usr/sbin:${PATH}" # Host path is fine as base
+    augmented_ld_path="/lib:/usr/lib:/lib/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnu:/snap/toolbox/current/lib:/snap/toolbox/current/usr/lib:/snap/toolbox/current/lib/x86_64-linux-gnu:/snap/toolbox/current/usr/lib/x86_64-linux-gnu"
+    remote.exec "PATH=${augmented_path} LD_LIBRARY_PATH=${augmented_ld_path} sh -c 'efibootmgr -v'"
+
+    echo "Current state of the gadget.yaml"
+    if [ -f pc-gadget/meta/gadget.yaml ]; then
+        cat pc-gadget/meta/gadget.yaml
+    fi
+
+execute: |
+    VERSION=$(tests.nested show version)
+    ARCH="$(find pc-gadget -name 'grub*.efi' -printf '%f\n' | sed 's/grub//;s/\.efi//')"
+    ARCH_UPPER="$(echo "$ARCH" | tr '[:lower:]' '[:upper:]')"
+
+    case "${ARCH}" in
+        x64  ) ;;
+        aa64 ) ;;
+        *    ) ERROR "Invalid architecture '${ARCH}': must be 'x64' or 'aa64'" ;;
+    esac
+
+    echo "${DESCRIPTION}"
+
+    echo "#### Initial gadget: ####"
+
+    echo "Wait for device to be initialized"
+    remote.wait-for device-initialized
+
+    echo "Wait for the system to be seeded"
+    remote.exec "sudo snap wait system seed.loaded"
+
+    echo "Install and set up toolbox on nested VM"
+    remote.exec "sudo snap install --channel=${VERSION}/edge toolbox"
+    # The usual toolbox setup assumes bash, so just set PATH and LD_LIBRARY_PATH
+    # manually when executing efibootmgr.
+    remote_exec_efibootmgr() {
+        augmented_path="/snap/toolbox/current/bin:/snap/toolbox/current/sbin:/snap/toolbox/current/usr/bin:/snap/toolbox/current/usr/sbin:${PATH}" # Host path is fine as base
+        augmented_ld_path="/lib:/usr/lib:/lib/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnu:/snap/toolbox/current/lib:/snap/toolbox/current/usr/lib:/snap/toolbox/current/lib/x86_64-linux-gnu:/snap/toolbox/current/usr/lib/x86_64-linux-gnu"
+        remote.exec "PATH=${augmented_path} LD_LIBRARY_PATH=${augmented_ld_path} sh -c 'efibootmgr -v'"
+    }
+
+    # Check that the EFI assets are correctly situated
+    check_efi_assets() {
+        if [ "$1" = "boot" ]; then
+            remote.exec "ls /run/mnt/ubuntu-seed/EFI/boot/boot${ARCH}.efi"
+            remote.exec "ls /run/mnt/ubuntu-seed/EFI/boot/grub${ARCH}.efi"
+        elif [ "$1" = "ubuntu" ]; then
+            remote.exec "ls /run/mnt/ubuntu-seed/EFI/ubuntu/BOOT${ARCH_UPPER}.CSV"
+            remote.exec "ls /run/mnt/ubuntu-seed/EFI/ubuntu/grub${ARCH}.efi"
+            remote.exec "ls /run/mnt/ubuntu-seed/EFI/ubuntu/shim${ARCH}.efi"
+            remote.exec "ls /run/mnt/ubuntu-seed/EFI/boot/boot${ARCH}.efi"
+            remote.exec "ls /run/mnt/ubuntu-seed/EFI/boot/fb${ARCH}.efi"
+        fi
+    }
+
+    # Print the number of the first boot option in BootOrder.
+    get_bootorder_first_number() {
+        remote_exec_efibootmgr | MATCH "^BootOrder: "
+        remote_exec_efibootmgr | grep  "^BootOrder: " | cut -d ' ' -f 2 | cut -d ',' -f 1
+    }
+    # Check that a boot option variable exists for the given shim path, and
+    # that it is the first option in the BootOrder variable.
+    check_efi_variables() {
+        shim_path="$(echo "$1" | sed 's/\//\\\\/g')"
+        boot_var_pattern="^Boot[0-9A-F][0-9A-F][0-9A-F][0-9A-F]. ubuntu.*/File.${shim_path}.$"
+        echo "Check that there exists one EFI boot variable for ${shim_path}"
+        remote_exec_efibootmgr | MATCH "${boot_var_pattern}"
+        remote_exec_efibootmgr | grep -c "${boot_var_pattern}" | MATCH "^1$"
+        echo "Get boot number associated with that boot variable"
+        boot_num=$(remote_exec_efibootmgr | grep "${boot_var_pattern}" | grep -o '^Boot....' | sed 's/Boot//')
+        echo "Check that first boot option in BootOrder matches ${boot_num}"
+        get_bootorder_first_number | MATCH "^${boot_num}$"
+    }
+
+    echo "Check that EFI assets in EFI/${INITIAL_ASSET_DIR} and variables are set correctly"
+    check_efi_assets "$INITIAL_ASSET_DIR"
+    if [ "${INITIAL_ASSET_DIR}" = "boot" ]; then
+        check_efi_variables "/EFI/boot/boot${ARCH}.efi"
+    elif [ "${INITIAL_ASSET_DIR}" = "ubuntu" ]; then
+        check_efi_variables "/EFI/ubuntu/shim${ARCH}.efi"
+    fi
+
+    echo "All good!"
+
+    echo "Set up gadget with EFI assets in EFI/${FINAL_ASSET_DIR}"
+    case "${FINAL_ASSET_DIR}" in
+        boot )
+            sh modify-gadget.sh pc-gadget "$ARCH" no-fallback
+            ;;
+        ubuntu )
+            sh modify-gadget.sh pc-gadget "$ARCH" fallback
+            ;;
+        * )
+            ERROR "Invalid initial asset dir: ${FINAL_ASSET_DIR}"
+            ;;
+    esac
+
+    echo "Get snakeoil key"
+    KEY_NAME=$(tests.nested download snakeoil-key)
+    SNAKEOIL_KEY="$PWD/$KEY_NAME.key"
+    SNAKEOIL_CERT="$PWD/$KEY_NAME.pem"
+
+    echo "Sign the modified pc-gadget"
+    tests.nested secboot-sign gadget pc-gadget "${SNAKEOIL_KEY}" "${SNAKEOIL_CERT}"
+
+    snap pack --filename=pc.snap pc-gadget
+    remote.push pc.snap
+
+    boot_id=$(tests.nested boot-id)
+
+    echo "Install new gadget"
+    REMOTE_CHG_ID=$(remote.exec "sudo snap install --dangerous --no-wait pc.snap")
+    # VM should reboot now
+    echo "Wait for reboot"
+    remote.wait-for reboot "${boot_id}"
+    # Wait for previous change to finish before continuing
+    remote.exec sudo snap watch "$REMOTE_CHG_ID"
+
+    echo "#### Updated gadget: ####"
+
+    echo "Check that EFI assets in EFI/${INITIAL_ASSET_DIR} and variables are set correctly"
+    check_efi_assets "$FINAL_ASSET_DIR"
+    if [ "${FINAL_ASSET_DIR}" = "boot" ]; then
+        check_efi_variables "/EFI/boot/boot${ARCH}.efi"
+    elif [ "${FINAL_ASSET_DIR}" = "ubuntu" ]; then
+        check_efi_variables "/EFI/ubuntu/shim${ARCH}.efi"
+    fi
+
+    echo "All good!"


### PR DESCRIPTION
We want to boot Ubuntu Core from `EFI/ubuntu/shim*.efi`, setup fallback boot properly, and manually set EFI boot variables on install so that the correct efi asset is used without going through a long multi-fallback boot process.

This relates to the following changes in the pc-gadget snap:
- https://github.com/snapcore/pc-gadget/pull/106

This is meant to be a revival/replacement of the following existing snapd PRs:
- https://github.com/snapcore/snapd/pull/13025 (my naïve first attempt)
- https://github.com/snapcore/snapd/pull/11437
- https://github.com/snapcore/snapd/pull/11448