### PR TITLE
usersession/agent: only close session bus if non-nil

### DIFF
--- a/usersession/agent/session_agent.go
+++ b/usersession/agent/session_agent.go
@@ -276,7 +276,10 @@ func (s *SessionAgent) shutdownServerOnKill() error {
 	// Historically We do something similar in the main daemon
 	// logic as well.
 	s.listener.Close()
-	s.bus.Close()
+	// Note that session bus may be nil, see the comment in tryConnectSessionBus.
+	if s.bus != nil {
+		s.bus.Close()
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 	defer cancel()
 	return s.serve.Shutdown(ctx)


### PR DESCRIPTION
On Ubuntu 16.04, ssh sessions may not have a D-Bus session bus, resulting in the `bus` field of the session agent being nil.  If this is the case, calling `s.bus.Close()` results in a nil pointer exception. This commit adds a check of `s.bus` (like those found elsewhere in session_agent.go) before calling `s.bus.Close()` during a session shutdown.

Thanks to @andrewphelpsj for discovering and discussing this bug.