### PR TITLE
wrappers: allow PrefersNonDefaultGPU and SingleMainWindow keys in desktop files

### DIFF
--- a/wrappers/desktop.go
+++ b/wrappers/desktop.go
@@ -97,6 +97,8 @@ var isValidDesktopFileLine = regexp.MustCompile(strings.Join([]string{
 	"^Keywords" + localizedSuffix,
 	"^StartupNotify=",
 	"^StartupWMClass=",
+	"^PrefersNonDefaultGPU=",
+	"^SingleMainWindow=",
 	// unity extension
 	"^X-Ayatana-Desktop-Shortcuts=",
 	"^TargetEnvironment=",


### PR DESCRIPTION
These are new additions in versions 1.4 and 1.5 of the [Desktop Entry Specification](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html) respectively, so are new since April 2020. Both are boolean keys, and seem safe to pass through from their description.

I filed this in response to this post in a thread on the forum:

  https://forum.snapcraft.io/t/snaps-dont-detect-nvidia-driver-in-wayland/35065/14?u=jamesh