### PR TITLE
i/b/fwupd.go: give access to USB character devices

### DIFF
--- a/interfaces/builtin/fwupd.go
+++ b/interfaces/builtin/fwupd.go
@@ -111,8 +111,10 @@ const fwupdPermanentSlotAppArmor = `
   # MTD plugin
   /dev/mtd[0-9]* rw,
   # Plugin for Logitech Whiteboard camera
-  /dev/bus/usb/[0-9][0-9][0-9]/[0-9][0-9][0-9] r,
   /dev/video[0-9]* r,
+  # Multiple plugins need to access to USB devices through character
+  # device nodes: DFU, FPC, logitech cameras
+  /dev/bus/usb/[0-9][0-9][0-9]/[0-9][0-9][0-9] rw,
   # Realtek MST plugin
   /dev/i2c-[0-9]* rw,
 


### PR DESCRIPTION
Multiple fwupd plugins require read/write access to USB character device nodes: fingerprint, FPU, cameras.

Upstream issue: https://github.com/fwupd/fwupd/issues/6141
