### PR TITLE
i/b/fwupd.go: allow access to drm devices

### DIFF
--- a/interfaces/builtin/fwupd.go
+++ b/interfaces/builtin/fwupd.go
@@ -142,6 +142,10 @@ const fwupdPermanentSlotAppArmor = `
   # os-release from host is needed for UEFI
   /var/lib/snapd/hostfs/{etc,usr/lib}/os-release r,
 
+  # Allow access to drm devices for linux-display plugin
+  /sys/devices/**/drm r,
+  /sys/devices/**/drm/** r,
+
   # DBus accesses
   #include <abstractions/dbus-strict>
   dbus (send)


### PR DESCRIPTION
This access is needed by linux-display plugin.

Upstream PR: https://github.com/fwupd/fwupd/pull/6195
