### PR TITLE
overlord/snapstate: remove unused snap downloads

### DIFF
--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -184,6 +184,36 @@ var (
 	HardEnsureNothingRunningDuringRefresh = hardEnsureNothingRunningDuringRefresh
 )
 
+// cleanup
+var (
+	CleanSnapDownloads = cleanSnapDownloads
+	CleanDownloads     = cleanDownloads
+)
+
+func MockMaxUnusedDownloadRetention(t time.Duration) func() {
+	old := maxUnusedDownloadRetention
+	maxUnusedDownloadRetention = t
+	return func() {
+		maxUnusedDownloadRetention = old
+	}
+}
+
+func MockCleanDownloads(mock func(st *state.State) error) func() {
+	old := cleanDownloads
+	cleanDownloads = mock
+	return func() {
+		cleanDownloads = old
+	}
+}
+
+func MockCleanSnapDownloads(mock func(st *state.State, snapName string) error) func() {
+	old := cleanSnapDownloads
+	cleanSnapDownloads = mock
+	return func() {
+		cleanSnapDownloads = old
+	}
+}
+
 // install
 var HasAllContentAttrs = hasAllContentAttrs
 
@@ -298,6 +328,14 @@ func MockEnsuredDesktopFilesUpdated(m *SnapManager, ensured bool) (restore func(
 	m.ensuredDesktopFilesUpdated = ensured
 	return func() {
 		m.ensuredDesktopFilesUpdated = old
+	}
+}
+
+func MockEnsuredDownloadsCleaned(m *SnapManager, ensured bool) (restore func()) {
+	old := m.ensuredDownloadsCleaned
+	m.ensuredDownloadsCleaned = ensured
+	return func() {
+		m.ensuredDownloadsCleaned = old
 	}
 }
 

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -856,6 +856,11 @@ func (m *SnapManager) doPreDownloadSnap(t *state.Task, tomb *tomb.Tomb) error {
 		return nil
 	}
 
+	// remove snap downloads that are no longer needed
+	if err := cleanSnapDownloads(st, snapsup.InstanceName()); err != nil {
+		return err
+	}
+
 	_, snapst, err := snapSetupAndState(t)
 	if err != nil {
 		return err

--- a/overlord/snapstate/snapstate_remove_test.go
+++ b/overlord/snapstate/snapstate_remove_test.go
@@ -1705,8 +1705,22 @@ func (s *snapmgrTestSuite) TestRemovePrunesRefreshGatingDataOnLastRevision(c *C)
 	}
 
 	rc := map[string]*snapstate.RefreshCandidate{
-		"some-snap": {},
-		"foo-snap":  {},
+		"some-snap": {
+			SnapSetup: snapstate.SnapSetup{
+				SideInfo: &snap.SideInfo{
+					RealName: "some-snap",
+					Revision: snap.R(7),
+				},
+			},
+		},
+		"foo-snap": {
+			SnapSetup: snapstate.SnapSetup{
+				SideInfo: &snap.SideInfo{
+					RealName: "foo-snap",
+					Revision: snap.R(7),
+				},
+			},
+		},
 	}
 	st.Set("refresh-candidates", rc)
 
@@ -1764,7 +1778,14 @@ func (s *snapmgrTestSuite) TestRemoveKeepsGatingDataIfNotLastRevision(c *C) {
 		LastRefreshTime: &t,
 	})
 
-	rc := map[string]*snapstate.RefreshCandidate{"some-snap": {}}
+	rc := map[string]*snapstate.RefreshCandidate{
+		"some-snap": {
+			SnapSetup: snapstate.SnapSetup{
+				SideInfo: &snap.SideInfo{
+					RealName: "some-snap",
+					Revision: snap.R(11),
+				},
+			}}}
 	st.Set("refresh-candidates", rc)
 
 	_, err := snapstate.HoldRefresh(st, snapstate.HoldAutoRefresh, "some-snap", 0, "some-snap")


### PR DESCRIPTION
This PR aims to clean up snap downloads that are not used anymore.
Clean up is run once for all snaps on startup, and run per-snap during pre-downloads.

relevant lp bug: https://bugs.launchpad.net/snapd/+bug/2033268 and https://bugs.launchpad.net/snapd/+bug/2043860