### PR TITLE
many: replace deprecated ioutil.WriteFile with os.WriteFile

### DIFF
--- a/asserts/extkeypairmgr_test.go
+++ b/asserts/extkeypairmgr_test.go
@@ -24,7 +24,6 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -55,16 +54,16 @@ func (s *extKeypairMgrSuite) SetUpSuite(c *C) {
 
 	derPub1, err := x509.MarshalPKIXPublicKey(&k1.PublicKey)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(tmpdir, "default.pub"), derPub1, 0644)
+	err = os.WriteFile(filepath.Join(tmpdir, "default.pub"), derPub1, 0644)
 	c.Assert(err, IsNil)
 	derPub2, err := x509.MarshalPKIXPublicKey(&k2.PublicKey)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(tmpdir, "models.pub"), derPub2, 0644)
+	err = os.WriteFile(filepath.Join(tmpdir, "models.pub"), derPub2, 0644)
 	c.Assert(err, IsNil)
 
-	err = ioutil.WriteFile(filepath.Join(tmpdir, "default.key"), x509.MarshalPKCS1PrivateKey(k1), 0600)
+	err = os.WriteFile(filepath.Join(tmpdir, "default.key"), x509.MarshalPKCS1PrivateKey(k1), 0600)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(tmpdir, "models.key"), x509.MarshalPKCS1PrivateKey(k2), 0600)
+	err = os.WriteFile(filepath.Join(tmpdir, "models.key"), x509.MarshalPKCS1PrivateKey(k2), 0600)
 	c.Assert(err, IsNil)
 
 	s.defaultPub = &k1.PublicKey

--- a/asserts/findwildcard_test.go
+++ b/asserts/findwildcard_test.go
@@ -21,7 +21,6 @@ package asserts
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -49,13 +48,13 @@ func (fs *findWildcardSuite) TestFindWildcard(c *check.C) {
 	err = os.MkdirAll(filepath.Join(top, "acc-id2", "f444"), os.ModePerm)
 	c.Assert(err, check.IsNil)
 
-	err = ioutil.WriteFile(filepath.Join(top, "acc-id1", "abcd", "active"), nil, os.ModePerm)
+	err = os.WriteFile(filepath.Join(top, "acc-id1", "abcd", "active"), nil, os.ModePerm)
 	c.Assert(err, check.IsNil)
-	err = ioutil.WriteFile(filepath.Join(top, "acc-id1", "abcd", "active.1"), nil, os.ModePerm)
+	err = os.WriteFile(filepath.Join(top, "acc-id1", "abcd", "active.1"), nil, os.ModePerm)
 	c.Assert(err, check.IsNil)
-	err = ioutil.WriteFile(filepath.Join(top, "acc-id1", "e5cd", "active"), nil, os.ModePerm)
+	err = os.WriteFile(filepath.Join(top, "acc-id1", "e5cd", "active"), nil, os.ModePerm)
 	c.Assert(err, check.IsNil)
-	err = ioutil.WriteFile(filepath.Join(top, "acc-id2", "f444", "active"), nil, os.ModePerm)
+	err = os.WriteFile(filepath.Join(top, "acc-id2", "f444", "active"), nil, os.ModePerm)
 	c.Assert(err, check.IsNil)
 
 	var res []string
@@ -114,7 +113,7 @@ func (fs *findWildcardSuite) TestFindWildcardSomeErrors(c *check.C) {
 	err = os.MkdirAll(filepath.Join(top, "acc-id2"), os.ModePerm)
 	c.Assert(err, check.IsNil)
 
-	err = ioutil.WriteFile(filepath.Join(top, "acc-id1", "abcd"), nil, os.ModePerm)
+	err = os.WriteFile(filepath.Join(top, "acc-id1", "abcd"), nil, os.ModePerm)
 	c.Assert(err, check.IsNil)
 
 	err = os.MkdirAll(filepath.Join(top, "acc-id2", "dddd"), os.ModePerm)
@@ -154,7 +153,7 @@ func (fs *findWildcardSuite) TestFindWildcardSequence(c *check.C) {
 	for _, fn := range files {
 		err := os.MkdirAll(filepath.Dir(filepath.Join(top, fn)), os.ModePerm)
 		c.Assert(err, check.IsNil)
-		err = ioutil.WriteFile(filepath.Join(top, fn), nil, os.ModePerm)
+		err = os.WriteFile(filepath.Join(top, fn), nil, os.ModePerm)
 		c.Assert(err, check.IsNil)
 	}
 
@@ -259,7 +258,7 @@ func (fs *findWildcardSuite) TestFindWildcardSequenceSomeErrors(c *check.C) {
 	for _, fn := range files {
 		err := os.MkdirAll(filepath.Dir(filepath.Join(top, fn)), os.ModePerm)
 		c.Assert(err, check.IsNil)
-		err = ioutil.WriteFile(filepath.Join(top, fn), nil, os.ModePerm)
+		err = os.WriteFile(filepath.Join(top, fn), nil, os.ModePerm)
 		c.Assert(err, check.IsNil)
 	}
 

--- a/asserts/repair_test.go
+++ b/asserts/repair_test.go
@@ -21,7 +21,7 @@ package asserts_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -356,7 +356,7 @@ func (s *repairSuite) TestRepairCanEmbedScripts(c *C) {
 
 	tmpdir := c.MkDir()
 	repairScript := filepath.Join(tmpdir, "repair")
-	err = ioutil.WriteFile(repairScript, []byte(repair.Body()), 0755)
+	err = os.WriteFile(repairScript, []byte(repair.Body()), 0755)
 	c.Assert(err, IsNil)
 	cmd := exec.Command(repairScript)
 	cmd.Dir = tmpdir

--- a/asserts/snap_asserts_test.go
+++ b/asserts/snap_asserts_test.go
@@ -21,7 +21,7 @@ package asserts_test
 
 import (
 	"encoding/base64"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -786,7 +786,7 @@ func (s *snapFileDigestSuite) TestSnapFileSHA3_384(c *C) {
 
 	tempdir := c.MkDir()
 	snapFn := filepath.Join(tempdir, "ex.snap")
-	err := ioutil.WriteFile(snapFn, exData, 0644)
+	err := os.WriteFile(snapFn, exData, 0644)
 	c.Assert(err, IsNil)
 
 	encDgst, size, err := asserts.SnapFileSHA3_384(snapFn)

--- a/asserts/snapasserts/snapasserts_test.go
+++ b/asserts/snapasserts/snapasserts_test.go
@@ -23,7 +23,7 @@ import (
 	"crypto"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -275,7 +275,7 @@ version: 1`, nil)
 func (s *snapassertsSuite) TestDeriveSideInfoNoSignatures(c *C) {
 	tempdir := c.MkDir()
 	snapPath := filepath.Join(tempdir, "anon.snap")
-	err := ioutil.WriteFile(snapPath, fakeSnap(42), 0644)
+	err := os.WriteFile(snapPath, fakeSnap(42), 0644)
 	c.Assert(err, IsNil)
 
 	_, err = snapasserts.DeriveSideInfo(snapPath, nil, s.localDB)
@@ -301,7 +301,7 @@ func (s *snapassertsSuite) TestDeriveSideInfoSizeMismatch(c *C) {
 
 	tempdir := c.MkDir()
 	snapPath := filepath.Join(tempdir, "anon.snap")
-	err = ioutil.WriteFile(snapPath, fakeSnap(42), 0644)
+	err = os.WriteFile(snapPath, fakeSnap(42), 0644)
 	c.Assert(err, IsNil)
 
 	_, err = snapasserts.DeriveSideInfo(snapPath, nil, s.localDB)
@@ -340,7 +340,7 @@ func (s *snapassertsSuite) TestDeriveSideInfoRevokedSnapDecl(c *C) {
 
 	tempdir := c.MkDir()
 	snapPath := filepath.Join(tempdir, "anon.snap")
-	err = ioutil.WriteFile(snapPath, fakeSnap(42), 0644)
+	err = os.WriteFile(snapPath, fakeSnap(42), 0644)
 	c.Assert(err, IsNil)
 
 	_, err = snapasserts.DeriveSideInfo(snapPath, nil, s.localDB)

--- a/boot/assets_test.go
+++ b/boot/assets_test.go
@@ -21,7 +21,6 @@ package boot_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -101,7 +100,7 @@ func (s *assetsSuite) TestAssetsCacheAddRemove(c *C) {
 	data := []byte("foobar")
 	// SHA3-384
 	hash := "0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"
-	err := ioutil.WriteFile(filepath.Join(d, "foobar"), data, 0644)
+	err := os.WriteFile(filepath.Join(d, "foobar"), data, 0644)
 	c.Assert(err, IsNil)
 
 	// add a new file
@@ -137,7 +136,7 @@ func (s *assetsSuite) TestAssetsCacheAddRemove(c *C) {
 	// same source, data (new hash), existing asset name
 	newData := []byte("new foobar")
 	newHash := "5aa87615f6613a37d63c9a29746ef57457286c37148a4ae78493b0face5976c1fea940a19486e6bef65d43aec6b8f5a2"
-	err = ioutil.WriteFile(filepath.Join(d, "foobar"), newData, 0644)
+	err = os.WriteFile(filepath.Join(d, "foobar"), newData, 0644)
 	c.Assert(err, IsNil)
 
 	taExistingAssetName, err := cache.Add(filepath.Join(d, "foobar"), "grub", "bootx64.efi")
@@ -182,7 +181,7 @@ func (s *assetsSuite) TestAssetsCacheAddErr(c *C) {
 	c.Assert(err, IsNil)
 
 	if os.Geteuid() != 0 {
-		err = ioutil.WriteFile(filepath.Join(d, "foobar"), []byte("foo"), 0644)
+		err = os.WriteFile(filepath.Join(d, "foobar"), []byte("foo"), 0644)
 		c.Assert(err, IsNil)
 		// cannot create bootloader subdirectory
 		ta, err := cache.Add(filepath.Join(d, "foobar"), "grub", "grubx64.efi")
@@ -215,7 +214,7 @@ func (s *assetsSuite) TestAssetsCacheRemoveErr(c *C) {
 
 	data := []byte("foobar")
 	dataHash := "0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"
-	err := ioutil.WriteFile(filepath.Join(d, "foobar"), data, 0644)
+	err := os.WriteFile(filepath.Join(d, "foobar"), data, 0644)
 	c.Assert(err, IsNil)
 	// cannot create bootloader subdirectory
 	_, err = cache.Add(filepath.Join(d, "foobar"), "grub", "grubx64.efi")
@@ -243,7 +242,7 @@ func (s *assetsSuite) TestInstallObserverNew(c *C) {
 	}
 
 	// pretend grub is used
-	c.Assert(ioutil.WriteFile(filepath.Join(d, "grub.conf"), nil, 0755), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(d, "grub.conf"), nil, 0755), IsNil)
 
 	for _, encryption := range []bool{true, false} {
 		obs, err := boot.TrustedAssetsInstallObserverForModel(uc20Model, d, encryption)
@@ -279,7 +278,7 @@ func (s *assetsSuite) TestInstallObserverObserveSystemBootRealGrub(c *C) {
 	d := c.MkDir()
 
 	// mock a bootloader that uses trusted assets
-	err := ioutil.WriteFile(filepath.Join(d, "grub.conf"), nil, 0644)
+	err := os.WriteFile(filepath.Join(d, "grub.conf"), nil, 0644)
 	c.Assert(err, IsNil)
 
 	// we get an observer for UC20
@@ -292,11 +291,11 @@ func (s *assetsSuite) TestInstallObserverObserveSystemBootRealGrub(c *C) {
 	data := []byte("foobar")
 	// SHA3-384
 	dataHash := "0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"
-	err = ioutil.WriteFile(filepath.Join(d, "foobar"), data, 0644)
+	err = os.WriteFile(filepath.Join(d, "foobar"), data, 0644)
 	c.Assert(err, IsNil)
 
 	otherData := []byte("other foobar")
-	err = ioutil.WriteFile(filepath.Join(d, "other-foobar"), otherData, 0644)
+	err = os.WriteFile(filepath.Join(d, "other-foobar"), otherData, 0644)
 	c.Assert(err, IsNil)
 
 	writeChange := &gadget.ContentChange{
@@ -374,7 +373,7 @@ func (s *assetsSuite) TestInstallObserverObserveSystemBootMocked(c *C) {
 	data := []byte("foobar")
 	// SHA3-384
 	dataHash := "0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"
-	err = ioutil.WriteFile(filepath.Join(d, "foobar"), data, 0644)
+	err = os.WriteFile(filepath.Join(d, "foobar"), data, 0644)
 	c.Assert(err, IsNil)
 
 	writeChange := &gadget.ContentChange{
@@ -435,7 +434,7 @@ func (s *assetsSuite) TestInstallObserverObserveSystemBootMockedUnencryptedWithM
 	c.Assert(err, IsNil)
 	c.Assert(obs, NotNil)
 
-	c.Assert(ioutil.WriteFile(filepath.Join(d, "foobar"), nil, 0755), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(d, "foobar"), nil, 0755), IsNil)
 	writeChange := &gadget.ContentChange{
 		// file that contains the data of the installed file
 		After: filepath.Join(d, "foobar"),
@@ -507,9 +506,9 @@ func (s *assetsSuite) TestInstallObserverTrustedReuseNameErr(c *C) {
 	// the list of trusted assets was asked for run and recovery bootloaders
 	c.Check(tab.TrustedAssetsCalls, Equals, 2)
 
-	err = ioutil.WriteFile(filepath.Join(d, "foobar"), []byte("foobar"), 0644)
+	err = os.WriteFile(filepath.Join(d, "foobar"), []byte("foobar"), 0644)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(d, "other"), []byte("other"), 0644)
+	err = os.WriteFile(filepath.Join(d, "other"), []byte("other"), 0644)
 	c.Assert(err, IsNil)
 	res, err := obs.Observe(gadget.ContentWrite, gadget.SystemBoot, boot.InitramfsUbuntuBootDir, "asset",
 		&gadget.ContentChange{After: filepath.Join(d, "foobar")})
@@ -543,15 +542,15 @@ func (s *assetsSuite) TestInstallObserverObserveExistingRecoveryMocked(c *C) {
 	data := []byte("foobar")
 	// SHA3-384
 	dataHash := "0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"
-	err = ioutil.WriteFile(filepath.Join(d, "asset"), data, 0644)
+	err = os.WriteFile(filepath.Join(d, "asset"), data, 0644)
 	c.Assert(err, IsNil)
 	err = os.Mkdir(filepath.Join(d, "nested"), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(d, "nested/other-asset"), data, 0644)
+	err = os.WriteFile(filepath.Join(d, "nested/other-asset"), data, 0644)
 	c.Assert(err, IsNil)
 	shim := []byte("shim")
 	shimHash := "dac0063e831d4b2e7a330426720512fc50fa315042f0bb30f9d1db73e4898dcb89119cac41fdfa62137c8931a50f9d7b"
-	err = ioutil.WriteFile(filepath.Join(d, "shim"), shim, 0644)
+	err = os.WriteFile(filepath.Join(d, "shim"), shim, 0644)
 	c.Assert(err, IsNil)
 
 	err = obs.ObserveExistingTrustedRecoveryAssets(d)
@@ -588,12 +587,12 @@ func (s *assetsSuite) TestInstallObserverObserveExistingRecoveryReuseNameErr(c *
 	// got the list of trusted assets for run and recovery bootloaders
 	c.Check(tab.TrustedAssetsCalls, Equals, 2)
 
-	err = ioutil.WriteFile(filepath.Join(d, "asset"), []byte("foobar"), 0644)
+	err = os.WriteFile(filepath.Join(d, "asset"), []byte("foobar"), 0644)
 	c.Assert(err, IsNil)
 	err = os.MkdirAll(filepath.Join(d, "nested"), 0755)
 	c.Assert(err, IsNil)
 	// same asset name but different content
-	err = ioutil.WriteFile(filepath.Join(d, "nested/asset"), []byte("other"), 0644)
+	err = os.WriteFile(filepath.Join(d, "nested/asset"), []byte("other"), 0644)
 	c.Assert(err, IsNil)
 	err = obs.ObserveExistingTrustedRecoveryAssets(d)
 	// same asset name but different content
@@ -680,17 +679,17 @@ func (s *assetsSuite) testUpdateObserverUpdateMockedWithReseal(c *C, seedRole st
 	// try to arrange the backups like the updater would do it
 	before := []byte("before")
 	beforeHash := "2df0976fd45ba2392dc7985cdfb7c2d096c1ea4917929dd7a0e9bffae90a443271e702663fc6a4189c1f4ab3ce7daee3"
-	err := ioutil.WriteFile(filepath.Join(backups, "asset.backup"), before, 0644)
+	err := os.WriteFile(filepath.Join(backups, "asset.backup"), before, 0644)
 	c.Assert(err, IsNil)
 
 	data := []byte("foobar")
 	// SHA3-384
 	dataHash := "0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"
-	err = ioutil.WriteFile(filepath.Join(d, "foobar"), data, 0644)
+	err = os.WriteFile(filepath.Join(d, "foobar"), data, 0644)
 	c.Assert(err, IsNil)
 	shim := []byte("shim")
 	shimHash := "dac0063e831d4b2e7a330426720512fc50fa315042f0bb30f9d1db73e4898dcb89119cac41fdfa62137c8931a50f9d7b"
-	err = ioutil.WriteFile(filepath.Join(d, "shim"), shim, 0644)
+	err = os.WriteFile(filepath.Join(d, "shim"), shim, 0644)
 	c.Assert(err, IsNil)
 
 	m := boot.Modeenv{
@@ -804,11 +803,11 @@ func (s *assetsSuite) TestUpdateObserverUpdateExistingAssetMocked(c *C) {
 	data := []byte("foobar")
 	// SHA3-384
 	dataHash := "0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"
-	err := ioutil.WriteFile(filepath.Join(d, "foobar"), data, 0644)
+	err := os.WriteFile(filepath.Join(d, "foobar"), data, 0644)
 	c.Assert(err, IsNil)
 	shim := []byte("shim")
 	shimHash := "dac0063e831d4b2e7a330426720512fc50fa315042f0bb30f9d1db73e4898dcb89119cac41fdfa62137c8931a50f9d7b"
-	err = ioutil.WriteFile(filepath.Join(d, "shim"), shim, 0644)
+	err = os.WriteFile(filepath.Join(d, "shim"), shim, 0644)
 	c.Assert(err, IsNil)
 
 	// add one file to the cache, as if the system got rebooted before
@@ -905,7 +904,7 @@ func (s *assetsSuite) TestUpdateObserverUpdateNothingTrackedMocked(c *C) {
 	data := []byte("foobar")
 	// SHA3-384
 	dataHash := "0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"
-	err := ioutil.WriteFile(filepath.Join(d, "foobar"), data, 0644)
+	err := os.WriteFile(filepath.Join(d, "foobar"), data, 0644)
 	c.Assert(err, IsNil)
 
 	m := boot.Modeenv{
@@ -1069,7 +1068,7 @@ func (s *assetsSuite) TestUpdateObserverUpdateRepeatedAssetErr(c *C) {
 	c.Assert(err, IsNil)
 
 	// and the source file
-	err = ioutil.WriteFile(filepath.Join(d, "foobar"), nil, 0644)
+	err = os.WriteFile(filepath.Join(d, "foobar"), nil, 0644)
 	c.Assert(err, IsNil)
 
 	res, err := obs.Observe(gadget.ContentUpdate, gadget.SystemBoot, root, "asset",
@@ -1094,13 +1093,13 @@ func (s *assetsSuite) TestUpdateObserverUpdateAfterSuccessfulBootMocked(c *C) {
 	// try to arrange the backups like the updater would do it
 	before := []byte("before")
 	beforeHash := "2df0976fd45ba2392dc7985cdfb7c2d096c1ea4917929dd7a0e9bffae90a443271e702663fc6a4189c1f4ab3ce7daee3"
-	err := ioutil.WriteFile(filepath.Join(backups, "asset.backup"), before, 0644)
+	err := os.WriteFile(filepath.Join(backups, "asset.backup"), before, 0644)
 	c.Assert(err, IsNil)
 
 	data := []byte("foobar")
 	// SHA3-384
 	dataHash := "0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"
-	err = ioutil.WriteFile(filepath.Join(d, "foobar"), data, 0644)
+	err = os.WriteFile(filepath.Join(d, "foobar"), data, 0644)
 	c.Assert(err, IsNil)
 
 	// pretend we rebooted mid update and have successfully booted with the
@@ -1183,21 +1182,21 @@ func (s *assetsSuite) TestUpdateObserverRollbackModeenvManipulationMocked(c *C) 
 	// SHA3-384
 	dataHash := "0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"
 	// file exists in both run and seed bootloader rootdirs
-	c.Assert(ioutil.WriteFile(filepath.Join(root, "asset"), data, 0644), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(rootSeed, "asset"), data, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(root, "asset"), data, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(rootSeed, "asset"), data, 0644), IsNil)
 	// and in the gadget
-	c.Assert(ioutil.WriteFile(filepath.Join(d, "asset"), data, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(d, "asset"), data, 0644), IsNil)
 	// would be listed as Before
-	c.Assert(ioutil.WriteFile(filepath.Join(backups, "asset.backup"), data, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(backups, "asset.backup"), data, 0644), IsNil)
 
 	shim := []byte("shim")
 	shimHash := "dac0063e831d4b2e7a330426720512fc50fa315042f0bb30f9d1db73e4898dcb89119cac41fdfa62137c8931a50f9d7b"
 	// only exists in seed bootloader rootdir
-	c.Assert(ioutil.WriteFile(filepath.Join(rootSeed, "shim"), shim, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(rootSeed, "shim"), shim, 0644), IsNil)
 	// and in the gadget
-	c.Assert(ioutil.WriteFile(filepath.Join(d, "shim"), shim, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(d, "shim"), shim, 0644), IsNil)
 	// would be listed as Before
-	c.Assert(ioutil.WriteFile(filepath.Join(backups, "shim.backup"), data, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(backups, "shim.backup"), data, 0644), IsNil)
 
 	c.Assert(os.MkdirAll(filepath.Join(dirs.SnapBootAssetsDir, "trusted"), 0755), IsNil)
 	// mock some files in cache
@@ -1208,7 +1207,7 @@ func (s *assetsSuite) TestUpdateObserverRollbackModeenvManipulationMocked(c *C) 
 		"asset-newhash",
 		"other-asset-newotherhash",
 	} {
-		err := ioutil.WriteFile(filepath.Join(dirs.SnapBootAssetsDir, "trusted", name), nil, 0644)
+		err := os.WriteFile(filepath.Join(dirs.SnapBootAssetsDir, "trusted", name), nil, 0644)
 		c.Assert(err, IsNil)
 	}
 
@@ -1354,7 +1353,7 @@ func (s *assetsSuite) TestUpdateObserverRollbackFileValidity(c *C) {
 	c.Check(res, Equals, gadget.ChangeAbort)
 
 	// create the file which will fail checksum check
-	err = ioutil.WriteFile(filepath.Join(root, "asset"), nil, 0644)
+	err = os.WriteFile(filepath.Join(root, "asset"), nil, 0644)
 	c.Assert(err, IsNil)
 	// once more, the file exists on disk, but has unexpected checksum
 	res, err = obs.Observe(gadget.ContentRollback, gadget.SystemBoot, root, "asset",
@@ -1375,7 +1374,7 @@ func (s *assetsSuite) TestUpdateObserverUpdateRollbackGrub(c *C) {
 	seedDir := c.MkDir()
 
 	// prepare a marker for grub bootloader
-	c.Assert(ioutil.WriteFile(filepath.Join(gadgetDir, "grub.conf"), nil, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(gadgetDir, "grub.conf"), nil, 0644), IsNil)
 
 	// we get an observer for UC20
 	s.stampSealedKeys(c, dirs.GlobalRootDir)
@@ -1434,7 +1433,7 @@ func (s *assetsSuite) TestUpdateObserverUpdateRollbackGrub(c *C) {
 			p := filepath.Join(dir.root, f[0])
 			err := os.MkdirAll(filepath.Dir(p), 0755)
 			c.Assert(err, IsNil)
-			err = ioutil.WriteFile(p, []byte(f[1]), 0644)
+			err = os.WriteFile(p, []byte(f[1]), 0644)
 			c.Assert(err, IsNil)
 			if dir.addContentToCache {
 				_, err = cache.Add(p, "grub", filepath.Base(p))
@@ -1577,7 +1576,7 @@ func (s *assetsSuite) TestUpdateObserverCanceledSimpleAfterBackupMocked(c *C) {
 		"asset-assethash",
 		"asset-recoveryhash",
 	} {
-		err = ioutil.WriteFile(filepath.Join(dirs.SnapBootAssetsDir, "trusted", name), nil, 0644)
+		err = os.WriteFile(filepath.Join(dirs.SnapBootAssetsDir, "trusted", name), nil, 0644)
 		c.Assert(err, IsNil)
 	}
 
@@ -1589,11 +1588,11 @@ func (s *assetsSuite) TestUpdateObserverCanceledSimpleAfterBackupMocked(c *C) {
 	data := []byte("foobar")
 	// SHA3-384
 	dataHash := "0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"
-	err = ioutil.WriteFile(filepath.Join(d, "foobar"), data, 0644)
+	err = os.WriteFile(filepath.Join(d, "foobar"), data, 0644)
 	c.Assert(err, IsNil)
 	shim := []byte("shim")
 	shimHash := "dac0063e831d4b2e7a330426720512fc50fa315042f0bb30f9d1db73e4898dcb89119cac41fdfa62137c8931a50f9d7b"
-	err = ioutil.WriteFile(filepath.Join(d, "shim"), shim, 0644)
+	err = os.WriteFile(filepath.Join(d, "shim"), shim, 0644)
 	c.Assert(err, IsNil)
 
 	res, err := obs.Observe(gadget.ContentUpdate, gadget.SystemBoot, root, "asset",
@@ -1668,11 +1667,11 @@ func (s *assetsSuite) TestUpdateObserverCanceledPartiallyUsedMocked(c *C) {
 	data := []byte("foobar")
 	// SHA3-384
 	dataHash := "0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"
-	err := ioutil.WriteFile(filepath.Join(d, "foobar"), data, 0644)
+	err := os.WriteFile(filepath.Join(d, "foobar"), data, 0644)
 	c.Assert(err, IsNil)
 	shim := []byte("shim")
 	shimHash := "dac0063e831d4b2e7a330426720512fc50fa315042f0bb30f9d1db73e4898dcb89119cac41fdfa62137c8931a50f9d7b"
-	err = ioutil.WriteFile(filepath.Join(d, "shim"), shim, 0644)
+	err = os.WriteFile(filepath.Join(d, "shim"), shim, 0644)
 	c.Assert(err, IsNil)
 
 	// mock some files in cache
@@ -1682,7 +1681,7 @@ func (s *assetsSuite) TestUpdateObserverCanceledPartiallyUsedMocked(c *C) {
 		"asset-assethash",
 		fmt.Sprintf("shim-%s", shimHash),
 	} {
-		err = ioutil.WriteFile(filepath.Join(dirs.SnapBootAssetsDir, "trusted", name), nil, 0644)
+		err = os.WriteFile(filepath.Join(dirs.SnapBootAssetsDir, "trusted", name), nil, 0644)
 		c.Assert(err, IsNil)
 	}
 
@@ -1778,7 +1777,7 @@ func (s *assetsSuite) TestUpdateObserverCanceledNoActionsMocked(c *C) {
 		"asset-assethash",
 		"asset-recoveryhash",
 	} {
-		err = ioutil.WriteFile(filepath.Join(dirs.SnapBootAssetsDir, "trusted", name), nil, 0644)
+		err = os.WriteFile(filepath.Join(dirs.SnapBootAssetsDir, "trusted", name), nil, 0644)
 		c.Assert(err, IsNil)
 	}
 
@@ -1810,7 +1809,7 @@ func (s *assetsSuite) TestUpdateObserverCanceledNoActionsMocked(c *C) {
 
 	c.Check(resealCalls, Equals, 0)
 
-	err = ioutil.WriteFile(filepath.Join(d, "shim"), []byte("shim"), 0644)
+	err = os.WriteFile(filepath.Join(d, "shim"), []byte("shim"), 0644)
 	c.Assert(err, IsNil)
 	// observe only recovery bootloader update, no action for run bootloader
 	res, err := obs.Observe(gadget.ContentUpdate, gadget.SystemSeed, root, "shim",
@@ -1846,7 +1845,7 @@ func (s *assetsSuite) TestUpdateObserverCanceledEmptyModeenvAssets(c *C) {
 	obs, _ := s.uc20UpdateObserverEncryptedSystemMockedBootloader(c)
 
 	// trigger loading modeenv and bootloader information
-	err = ioutil.WriteFile(filepath.Join(d, "shim"), []byte("shim"), 0644)
+	err = os.WriteFile(filepath.Join(d, "shim"), []byte("shim"), 0644)
 	c.Assert(err, IsNil)
 	// observe an update only for the recovery bootloader, the run bootloader trusted assets remain empty
 	res, err := obs.Observe(gadget.ContentUpdate, gadget.SystemSeed, root, "shim",
@@ -1901,7 +1900,7 @@ func (s *assetsSuite) TestUpdateObserverCanceledAfterRollback(c *C) {
 	obs, _ := s.uc20UpdateObserverEncryptedSystemMockedBootloader(c)
 
 	// trigger loading modeenv and bootloader information
-	err = ioutil.WriteFile(filepath.Join(d, "shim"), []byte("shim"), 0644)
+	err = os.WriteFile(filepath.Join(d, "shim"), []byte("shim"), 0644)
 	c.Assert(err, IsNil)
 	res, err := obs.Observe(gadget.ContentUpdate, gadget.SystemSeed, root, "shim",
 		&gadget.ContentChange{After: filepath.Join(d, "shim")})
@@ -1962,7 +1961,7 @@ func (s *assetsSuite) TestUpdateObserverCanceledUnhappyCacheStillProceeds(c *C) 
 		"asset-assethash",
 		"asset-recoveryhash",
 	} {
-		err = ioutil.WriteFile(filepath.Join(dirs.SnapBootAssetsDir, "trusted", name), nil, 0644)
+		err = os.WriteFile(filepath.Join(dirs.SnapBootAssetsDir, "trusted", name), nil, 0644)
 		c.Assert(err, IsNil)
 	}
 
@@ -1972,7 +1971,7 @@ func (s *assetsSuite) TestUpdateObserverCanceledUnhappyCacheStillProceeds(c *C) 
 
 	shim := []byte("shim")
 	shimHash := "dac0063e831d4b2e7a330426720512fc50fa315042f0bb30f9d1db73e4898dcb89119cac41fdfa62137c8931a50f9d7b"
-	err = ioutil.WriteFile(filepath.Join(d, "shim"), shim, 0644)
+	err = os.WriteFile(filepath.Join(d, "shim"), shim, 0644)
 	c.Assert(err, IsNil)
 	res, err := obs.Observe(gadget.ContentUpdate, gadget.SystemSeed, root, "shim",
 		&gadget.ContentChange{After: filepath.Join(d, "shim")})
@@ -2067,10 +2066,10 @@ func (s *assetsSuite) TestObserveSuccessfulBootAfterUpdate(c *C) {
 	shimHash := "dac0063e831d4b2e7a330426720512fc50fa315042f0bb30f9d1db73e4898dcb89119cac41fdfa62137c8931a50f9d7b"
 
 	// only asset for ubuntu-boot
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), data, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), data, 0644), IsNil)
 	// shim and asset for ubuntu-seed
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "shim"), shim, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "shim"), shim, 0644), IsNil)
 
 	m := &boot.Modeenv{
 		Mode: "run",
@@ -2116,9 +2115,9 @@ func (s *assetsSuite) TestObserveSuccessfulBootWithUnexpected(c *C) {
 	unexpectedHash := "2c823b62c52e614e48faac7e8b1fbb8ff3aee4d06b6f7fe5bd7d64953162b6e9879ead4827fa19c8c9a514585ddac94c"
 
 	// asset for ubuntu-boot
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), unexpected, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), unexpected, 0644), IsNil)
 	// and for ubuntu-seed
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), unexpected, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), unexpected, 0644), IsNil)
 
 	m := &boot.Modeenv{
 		Mode: "run",
@@ -2137,7 +2136,7 @@ func (s *assetsSuite) TestObserveSuccessfulBootWithUnexpected(c *C) {
 
 	// make the run bootloader asset an expected one, we should still fail
 	// on the recovery bootloader asset
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), data, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), data, 0644), IsNil)
 
 	newM, drop, err = boot.ObserveSuccessfulBootWithAssets(m)
 	c.Assert(err, ErrorMatches, fmt.Sprintf(`system booted with unexpected recovery bootloader asset "asset" hash %v`, unexpectedHash))
@@ -2157,10 +2156,10 @@ func (s *assetsSuite) TestObserveSuccessfulBootSingleEntries(c *C) {
 	shimHash := "dac0063e831d4b2e7a330426720512fc50fa315042f0bb30f9d1db73e4898dcb89119cac41fdfa62137c8931a50f9d7b"
 
 	// only asset for ubuntu-boot
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), data, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), data, 0644), IsNil)
 	// shim and asset for ubuntu-seed
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "shim"), shim, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "shim"), shim, 0644), IsNil)
 
 	m := &boot.Modeenv{
 		Mode: "run",
@@ -2194,9 +2193,9 @@ func (s *assetsSuite) TestObserveSuccessfulBootDropCandidateUsedByOtherBootloade
 	dataHash := "0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"
 
 	// ubuntu-boot booted with maybe-drop asset
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), maybeDrop, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), maybeDrop, 0644), IsNil)
 
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
 
 	m := &boot.Modeenv{
 		Mode: "run",
@@ -2235,10 +2234,10 @@ func (s *assetsSuite) TestObserveSuccessfulBootParallelUpdate(c *C) {
 	shimHash := "dac0063e831d4b2e7a330426720512fc50fa315042f0bb30f9d1db73e4898dcb89119cac41fdfa62137c8931a50f9d7b"
 
 	// only asset for ubuntu-boot
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), data, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), data, 0644), IsNil)
 	// shim and asset for ubuntu-seed
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "shim"), shim, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "shim"), shim, 0644), IsNil)
 
 	m := &boot.Modeenv{
 		Mode: "run",
@@ -2279,8 +2278,8 @@ func (s *assetsSuite) TestObserveSuccessfulBootHashErr(c *C) {
 	data := []byte("foobar")
 	dataHash := "0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"
 
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), data, 0000), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0000), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), data, 0000), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0000), IsNil)
 
 	m := &boot.Modeenv{
 		Mode: "run",
@@ -2342,7 +2341,7 @@ func (s *assetsSuite) TestCopyBootAssetsCacheHappy(c *C) {
 		p := filepath.Join(dirs.SnapBootAssetsDir, entry.name)
 		err = os.MkdirAll(filepath.Dir(p), 0755)
 		c.Assert(err, IsNil)
-		err = ioutil.WriteFile(p, []byte(entry.content), os.FileMode(entry.mode))
+		err = os.WriteFile(p, []byte(entry.content), os.FileMode(entry.mode))
 		c.Assert(err, IsNil)
 	}
 
@@ -2378,7 +2377,7 @@ func (s *assetsSuite) TestCopyBootAssetsCacheUnhappy(c *C) {
 	err = os.MkdirAll(nonWritableRoot, 0000)
 	c.Assert(err, IsNil)
 	dirs.SnapBootAssetsDir = c.MkDir()
-	err = ioutil.WriteFile(filepath.Join(dirs.SnapBootAssetsDir, "file"), nil, 0644)
+	err = os.WriteFile(filepath.Join(dirs.SnapBootAssetsDir, "file"), nil, 0644)
 	c.Assert(err, IsNil)
 	err = boot.CopyBootAssetsCacheToRoot(nonWritableRoot)
 	c.Assert(err, ErrorMatches, `cannot create cache directory under new root: mkdir .*: permission denied`)
@@ -2386,7 +2385,7 @@ func (s *assetsSuite) TestCopyBootAssetsCacheUnhappy(c *C) {
 	// file cannot be read
 	newRoot = c.MkDir()
 	dirs.SnapBootAssetsDir = c.MkDir()
-	err = ioutil.WriteFile(filepath.Join(dirs.SnapBootAssetsDir, "file"), nil, 0000)
+	err = os.WriteFile(filepath.Join(dirs.SnapBootAssetsDir, "file"), nil, 0000)
 	c.Assert(err, IsNil)
 	err = boot.CopyBootAssetsCacheToRoot(newRoot)
 	c.Assert(err, ErrorMatches, `cannot copy boot asset cache file "file": failed to copy all: .*`)
@@ -2401,7 +2400,7 @@ func (s *assetsSuite) TestCopyBootAssetsCacheUnhappy(c *C) {
 	c.Assert(err, IsNil)
 	err = os.MkdirAll(filepath.Join(dirs.SnapBootAssetsDir, "dir"), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(dirs.SnapBootAssetsDir, "dir", "file"), nil, 0000)
+	err = os.WriteFile(filepath.Join(dirs.SnapBootAssetsDir, "dir", "file"), nil, 0000)
 	c.Assert(err, IsNil)
 	err = boot.CopyBootAssetsCacheToRoot(newRoot)
 	c.Assert(err, ErrorMatches, `cannot recreate cache directory "dir": .*: permission denied`)
@@ -2418,17 +2417,17 @@ func (s *assetsSuite) TestUpdateObserverReseal(c *C) {
 	// try to arrange the backups like the updater would do it
 	before := []byte("before")
 	beforeHash := "2df0976fd45ba2392dc7985cdfb7c2d096c1ea4917929dd7a0e9bffae90a443271e702663fc6a4189c1f4ab3ce7daee3"
-	err := ioutil.WriteFile(filepath.Join(backups, "asset.backup"), before, 0644)
+	err := os.WriteFile(filepath.Join(backups, "asset.backup"), before, 0644)
 	c.Assert(err, IsNil)
 
 	data := []byte("foobar")
 	// SHA3-384
 	dataHash := "0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"
-	err = ioutil.WriteFile(filepath.Join(d, "foobar"), data, 0644)
+	err = os.WriteFile(filepath.Join(d, "foobar"), data, 0644)
 	c.Assert(err, IsNil)
 	shim := []byte("shim")
 	shimHash := "dac0063e831d4b2e7a330426720512fc50fa315042f0bb30f9d1db73e4898dcb89119cac41fdfa62137c8931a50f9d7b"
-	err = ioutil.WriteFile(filepath.Join(d, "shim"), shim, 0644)
+	err = os.WriteFile(filepath.Join(d, "shim"), shim, 0644)
 	c.Assert(err, IsNil)
 
 	tab := s.bootloaderWithTrustedAssets([]string{
@@ -2570,7 +2569,7 @@ func (s *assetsSuite) TestUpdateObserverCanceledReseal(c *C) {
 		"asset-assethash",
 		"asset-recoveryhash",
 	} {
-		err := ioutil.WriteFile(filepath.Join(dirs.SnapBootAssetsDir, "trusted", name), nil, 0644)
+		err := os.WriteFile(filepath.Join(dirs.SnapBootAssetsDir, "trusted", name), nil, 0644)
 		c.Assert(err, IsNil)
 	}
 
@@ -2602,10 +2601,10 @@ func (s *assetsSuite) TestUpdateObserverCanceledReseal(c *C) {
 	c.Assert(err, IsNil)
 
 	data := []byte("foobar")
-	err = ioutil.WriteFile(filepath.Join(d, "foobar"), data, 0644)
+	err = os.WriteFile(filepath.Join(d, "foobar"), data, 0644)
 	c.Assert(err, IsNil)
 	shim := []byte("shim")
-	err = ioutil.WriteFile(filepath.Join(d, "shim"), shim, 0644)
+	err = os.WriteFile(filepath.Join(d, "shim"), shim, 0644)
 	c.Assert(err, IsNil)
 
 	// trigger a bunch of updates, so that we have things to cancel
@@ -2706,7 +2705,7 @@ func (s *assetsSuite) TestUpdateObserverUpdateMockedNonEncryption(c *C) {
 
 	// try to arrange the backups like the updater would do it
 	data := []byte("foobar")
-	err := ioutil.WriteFile(filepath.Join(d, "foobar"), data, 0644)
+	err := os.WriteFile(filepath.Join(d, "foobar"), data, 0644)
 	c.Assert(err, IsNil)
 
 	m := boot.Modeenv{

--- a/boot/boot_test.go
+++ b/boot/boot_test.go
@@ -22,7 +22,6 @@ package boot_test
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -84,12 +83,12 @@ func (s *baseBootenvSuite) forceBootloader(bloader bootloader.Bootloader) {
 func (s *baseBootenvSuite) stampSealedKeys(c *C, rootdir string) {
 	stamp := filepath.Join(dirs.SnapFDEDirUnder(rootdir), "sealed-keys")
 	c.Assert(os.MkdirAll(filepath.Dir(stamp), 0755), IsNil)
-	err := ioutil.WriteFile(stamp, nil, 0644)
+	err := os.WriteFile(stamp, nil, 0644)
 	c.Assert(err, IsNil)
 }
 
 func (s *baseBootenvSuite) mockCmdline(c *C, cmdline string) {
-	c.Assert(ioutil.WriteFile(s.cmdlineFile, []byte(cmdline), 0644), IsNil)
+	c.Assert(os.WriteFile(s.cmdlineFile, []byte(cmdline), 0644), IsNil)
 }
 
 // mockAssetsCache mocks the listed assets in the boot assets cache by creating
@@ -99,7 +98,7 @@ func mockAssetsCache(c *C, rootdir, bootloaderName string, cachedAssets []string
 	err := os.MkdirAll(p, 0755)
 	c.Assert(err, IsNil)
 	for _, cachedAsset := range cachedAssets {
-		err = ioutil.WriteFile(filepath.Join(p, cachedAsset), nil, 0644)
+		err = os.WriteFile(filepath.Join(p, cachedAsset), nil, 0644)
 		c.Assert(err, IsNil)
 	}
 }
@@ -1029,8 +1028,8 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewKernelSnapWithReseal(c *
 
 	c.Assert(os.MkdirAll(filepath.Join(boot.InitramfsUbuntuBootDir), 0755), IsNil)
 	c.Assert(os.MkdirAll(filepath.Join(boot.InitramfsUbuntuSeedDir), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), data, 0644), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), data, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
 
 	// mock the files in cache
 	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
@@ -1147,8 +1146,8 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewUnassertedKernelSnapWith
 
 	c.Assert(os.MkdirAll(filepath.Join(boot.InitramfsUbuntuBootDir), 0755), IsNil)
 	c.Assert(os.MkdirAll(filepath.Join(boot.InitramfsUbuntuSeedDir), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), data, 0644), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), data, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
 
 	// mock the files in cache
 	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
@@ -1264,8 +1263,8 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameKernelSnapNoReseal(c *C
 
 	c.Assert(os.MkdirAll(filepath.Join(boot.InitramfsUbuntuBootDir), 0755), IsNil)
 	c.Assert(os.MkdirAll(filepath.Join(boot.InitramfsUbuntuSeedDir), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), data, 0644), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), data, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
 
 	// mock the files in cache
 	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
@@ -1382,8 +1381,8 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextSameUnassertedKernelSnapNoR
 
 	c.Assert(os.MkdirAll(filepath.Join(boot.InitramfsUbuntuBootDir), 0755), IsNil)
 	c.Assert(os.MkdirAll(filepath.Join(boot.InitramfsUbuntuSeedDir), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), data, 0644), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), data, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
 
 	// mock the files in cache
 	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
@@ -1759,7 +1758,7 @@ func (s *bootenv20Suite) TestCoreParticipant20SetNextNewBaseSnapNoReseal(c *C) {
 	// SHA3-384
 	dataHash := "0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"
 	c.Assert(os.MkdirAll(filepath.Join(boot.InitramfsUbuntuBootDir), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), data, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), data, 0644), IsNil)
 	// mock the files in cache
 	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
 		"asset-" + dataHash,
@@ -2100,7 +2099,7 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20KernelUpdateWithReseal(c *C) {
 	dataHash := "0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"
 
 	c.Assert(os.MkdirAll(filepath.Join(boot.InitramfsUbuntuBootDir), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), data, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), data, 0644), IsNil)
 
 	// mock the files in cache
 	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
@@ -2333,10 +2332,10 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootAssetsUpdateHappy(c *C) {
 	c.Assert(os.MkdirAll(boot.InitramfsUbuntuBootDir, 0755), IsNil)
 	c.Assert(os.MkdirAll(boot.InitramfsUbuntuSeedDir, 0755), IsNil)
 	// only asset for ubuntu
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), data, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), data, 0644), IsNil)
 	// shim and asset for seed
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "shim"), shim, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "shim"), shim, 0644), IsNil)
 
 	// mock the files in cache
 	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
@@ -2474,10 +2473,10 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootAssetsStableStateHappy(c *C
 	c.Assert(os.MkdirAll(filepath.Join(boot.InitramfsUbuntuBootDir, "nested"), 0755), IsNil)
 	c.Assert(os.MkdirAll(filepath.Join(boot.InitramfsUbuntuSeedDir, "nested"), 0755), IsNil)
 	// only asset for ubuntu-boot
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "nested/asset"), data, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "nested/asset"), data, 0644), IsNil)
 	// shim and asset for ubuntu-seed
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "nested/asset"), data, 0644), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "shim"), shim, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "nested/asset"), data, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "shim"), shim, 0644), IsNil)
 
 	// mock the files in cache
 	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
@@ -2635,10 +2634,10 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootUnassertedKernelAssetsStabl
 	c.Assert(os.MkdirAll(filepath.Join(boot.InitramfsUbuntuBootDir, "nested"), 0755), IsNil)
 	c.Assert(os.MkdirAll(filepath.Join(boot.InitramfsUbuntuSeedDir, "nested"), 0755), IsNil)
 	// only asset for ubuntu-boot
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "nested/asset"), data, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "nested/asset"), data, 0644), IsNil)
 	// shim and asset for ubuntu-seed
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "nested/asset"), data, 0644), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "shim"), shim, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "nested/asset"), data, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "shim"), shim, 0644), IsNil)
 
 	// mock the files in cache
 	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
@@ -2792,8 +2791,8 @@ func (s *bootenv20Suite) TestMarkBootSuccessful20BootAssetsUpdateUnexpectedAsset
 
 	c.Assert(os.MkdirAll(filepath.Join(boot.InitramfsUbuntuBootDir, "EFI"), 0755), IsNil)
 	c.Assert(os.MkdirAll(filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI"), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "EFI/asset"), data, 0644), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/asset"), data, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "EFI/asset"), data, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/asset"), data, 0644), IsNil)
 	// mock some state in the cache
 	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
 		"asset-one",
@@ -3301,7 +3300,7 @@ func (s *recoveryBootenv20Suite) TestSetRecoveryBootSystemAndModeRealHappy(c *C)
 	mockSeedGrubDir := filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI", "ubuntu")
 	err := os.MkdirAll(mockSeedGrubDir, 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(mockSeedGrubDir, "grub.cfg"), nil, 0644)
+	err = os.WriteFile(filepath.Join(mockSeedGrubDir, "grub.cfg"), nil, 0644)
 	c.Assert(err, IsNil)
 
 	err = boot.SetRecoveryBootSystemAndMode(s.dev, "1234", "install")
@@ -3340,7 +3339,7 @@ func (s *bootConfigSuite) SetUpTest(c *C) {
 }
 
 func (s *bootConfigSuite) mockCmdline(c *C, cmdline string) {
-	c.Assert(ioutil.WriteFile(s.cmdlineFile, []byte(cmdline), 0644), IsNil)
+	c.Assert(os.WriteFile(s.cmdlineFile, []byte(cmdline), 0644), IsNil)
 }
 
 func (s *bootConfigSuite) TestBootConfigUpdateHappyNoKeysNoReseal(c *C) {
@@ -3716,8 +3715,8 @@ func (s *bootKernelCommandLineSuite) SetUpTest(c *C) {
 	dataHash := "0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"
 	c.Assert(os.MkdirAll(filepath.Join(boot.InitramfsUbuntuBootDir), 0755), IsNil)
 	c.Assert(os.MkdirAll(filepath.Join(boot.InitramfsUbuntuSeedDir), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), data, 0644), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), data, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
 
 	s.bootloader = bootloadertest.Mock("trusted", c.MkDir()).WithTrustedAssets()
 	s.bootloader.TrustedAssetsList = []string{"asset"}
@@ -4161,7 +4160,7 @@ func (s *bootKernelCommandLineSuite) TestCommandLineUpdateUC20OverSpuriousReboot
 	c.Assert(s.modeenvWithEncryption.WriteTo(""), IsNil)
 
 	cmdlineFile := filepath.Join(c.MkDir(), "cmdline")
-	err := ioutil.WriteFile(cmdlineFile, []byte("snapd_recovery_mode=run static mocked panic=-1"), 0644)
+	err := os.WriteFile(cmdlineFile, []byte("snapd_recovery_mode=run static mocked panic=-1"), 0644)
 	c.Assert(err, IsNil)
 	restore = kcmdline.MockProcCmdline(cmdlineFile)
 	s.AddCleanup(restore)
@@ -4334,7 +4333,7 @@ func (s *bootKernelCommandLineSuite) TestCommandLineUpdateUC20OverSpuriousReboot
 	// command line will include arguments that came from gadget snap
 	s.bootloader.SetBootVarsCalls = 0
 	s.resealCalls = 0
-	err = ioutil.WriteFile(cmdlineFile, []byte("snapd_recovery_mode=run static mocked panic=-1 extra args"), 0644)
+	err = os.WriteFile(cmdlineFile, []byte("snapd_recovery_mode=run static mocked panic=-1 extra args"), 0644)
 	c.Assert(err, IsNil)
 	err = boot.MarkBootSuccessful(s.uc20dev)
 	c.Assert(err, IsNil)
@@ -4663,8 +4662,8 @@ func (s *bootenv20Suite) TestCoreParticipant20UndoKernelSnapInstallNewWithReseal
 
 	c.Assert(os.MkdirAll(filepath.Join(boot.InitramfsUbuntuBootDir), 0755), IsNil)
 	c.Assert(os.MkdirAll(filepath.Join(boot.InitramfsUbuntuSeedDir), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), data, 0644), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), data, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
 
 	// mock the files in cache
 	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
@@ -4777,8 +4776,8 @@ func (s *bootenv20Suite) TestCoreParticipant20UndoUnassertedKernelSnapInstallNew
 
 	c.Assert(os.MkdirAll(filepath.Join(boot.InitramfsUbuntuBootDir), 0755), IsNil)
 	c.Assert(os.MkdirAll(filepath.Join(boot.InitramfsUbuntuSeedDir), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), data, 0644), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), data, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
 
 	// mock the files in cache
 	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
@@ -4888,8 +4887,8 @@ func (s *bootenv20Suite) TestCoreParticipant20UndoKernelSnapInstallSameNoReseal(
 
 	c.Assert(os.MkdirAll(filepath.Join(boot.InitramfsUbuntuBootDir), 0755), IsNil)
 	c.Assert(os.MkdirAll(filepath.Join(boot.InitramfsUbuntuSeedDir), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), data, 0644), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), data, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
 
 	// mock the files in cache
 	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
@@ -5006,8 +5005,8 @@ func (s *bootenv20Suite) TestCoreParticipant20UndoUnassertedKernelSnapInstallSam
 
 	c.Assert(os.MkdirAll(filepath.Join(boot.InitramfsUbuntuBootDir), 0755), IsNil)
 	c.Assert(os.MkdirAll(filepath.Join(boot.InitramfsUbuntuSeedDir), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), data, 0644), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), data, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "asset"), data, 0644), IsNil)
 
 	// mock the files in cache
 	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
@@ -5197,7 +5196,7 @@ func (s *bootenv20Suite) TestCoreParticipant20UndoBaseSnapInstallNewNoReseal(c *
 	// SHA3-384
 	dataHash := "0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8"
 	c.Assert(os.MkdirAll(filepath.Join(boot.InitramfsUbuntuBootDir), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), data, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "asset"), data, 0644), IsNil)
 	// mock the files in cache
 	mockAssetsCache(c, dirs.GlobalRootDir, "trusted", []string{
 		"asset-" + dataHash,

--- a/boot/bootchain_test.go
+++ b/boot/bootchain_test.go
@@ -21,7 +21,6 @@ package boot_test
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -1022,7 +1021,7 @@ func (s *bootchainSuite) TestBootAssetsToLoadChainErr(c *C) {
 	c.Check(chains, IsNil)
 	// make it work now
 	c.Assert(os.MkdirAll(filepath.Dir(cPath("recovery-bl/shim-hash0")), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(cPath("recovery-bl/shim-hash0"), nil, 0644), IsNil)
+	c.Assert(os.WriteFile(cPath("recovery-bl/shim-hash0"), nil, 0644), IsNil)
 
 	// nested error bubbled up
 	chains, err = boot.BootAssetsToLoadChains(assets, kbl, blNames)
@@ -1030,7 +1029,7 @@ func (s *bootchainSuite) TestBootAssetsToLoadChainErr(c *C) {
 	c.Check(chains, IsNil)
 	// again, make it work
 	c.Assert(os.MkdirAll(filepath.Dir(cPath("recovery-bl/loader-recovery-hash0")), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(cPath("recovery-bl/loader-recovery-hash0"), nil, 0644), IsNil)
+	c.Assert(os.WriteFile(cPath("recovery-bl/loader-recovery-hash0"), nil, 0644), IsNil)
 
 	// fails on missing bootloader name for role "run-mode"
 	chains, err = boot.BootAssetsToLoadChains(assets, kbl, blNames)
@@ -1055,7 +1054,7 @@ func (s *bootchainSuite) TestBootAssetsToLoadChainSimpleChain(c *C) {
 	} {
 		p := filepath.Join(dirs.SnapBootAssetsDir, name)
 		c.Assert(os.MkdirAll(filepath.Dir(p), 0755), IsNil)
-		c.Assert(ioutil.WriteFile(p, nil, 0644), IsNil)
+		c.Assert(os.WriteFile(p, nil, 0644), IsNil)
 	}
 
 	blNames := map[bootloader.Role]string{

--- a/boot/bootstate20.go
+++ b/boot/bootstate20.go
@@ -49,8 +49,9 @@ func newBootState20(typ snap.Type, dev snap.Device) bootState {
 }
 
 // modeenvMu is used to protect sections doing:
-//  * read moddeenv/modify it(/reseal from it)
-//  * write modeenv/seal from it
+//   - read moddeenv/modify it(/reseal from it)
+//   - write modeenv/seal from it
+//
 // while we might want to release the global state lock as seal/reseal are slow
 // (see Unlocker for that)
 var (

--- a/boot/cmdline_test.go
+++ b/boot/cmdline_test.go
@@ -20,7 +20,6 @@
 package boot_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -55,7 +54,7 @@ func (s *kernelCommandLineSuite) SetUpTest(c *C) {
 
 func (s *kernelCommandLineSuite) mockProcCmdlineContent(c *C, newContent string) {
 	mockProcCmdline := filepath.Join(s.rootDir, "proc/cmdline")
-	err := ioutil.WriteFile(mockProcCmdline, []byte(newContent), 0644)
+	err := os.WriteFile(mockProcCmdline, []byte(newContent), 0644)
 	c.Assert(err, IsNil)
 }
 

--- a/boot/flags.go
+++ b/boot/flags.go
@@ -204,7 +204,7 @@ func InitramfsExposeBootFlagsForSystem(flags []string) error {
 		return err
 	}
 
-	return ioutil.WriteFile(snapBootFlagsFile, []byte(s), 0644)
+	return os.WriteFile(snapBootFlagsFile, []byte(s), 0644)
 }
 
 // BootFlags returns the current set of boot flags active for this boot. It uses

--- a/boot/flags_test.go
+++ b/boot/flags_test.go
@@ -21,7 +21,6 @@ package boot_test
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -84,7 +83,7 @@ func setupRealGrub(c *C, rootDir, baseDir string, opts *bootloader.Options) boot
 	err := os.MkdirAll(filepath.Dir(grubCfg), 0755)
 	c.Assert(err, IsNil)
 
-	err = ioutil.WriteFile(grubCfg, nil, 0644)
+	err = os.WriteFile(grubCfg, nil, 0644)
 	c.Assert(err, IsNil)
 
 	genv := grubenv.NewEnv(filepath.Join(rootDir, baseDir, "grubenv"))
@@ -535,7 +534,7 @@ func (s *bootFlagsSuite) TestRunModeRootfs(c *C) {
 			err := os.MkdirAll(dirs.SnapBootstrapRunDir, 0755)
 			c.Assert(err, IsNil, comment)
 
-			err = ioutil.WriteFile(degradedJSON, []byte(t.degradedJSON), 0644)
+			err = os.WriteFile(degradedJSON, []byte(t.degradedJSON), 0644)
 			c.Assert(err, IsNil, comment)
 		}
 

--- a/boot/initramfs_test.go
+++ b/boot/initramfs_test.go
@@ -21,7 +21,6 @@ package boot_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -75,7 +74,7 @@ func (s *initramfsSuite) TestEnsureNextBootToRunModeRealBootloader(c *C) {
 	err := os.MkdirAll(filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/ubuntu"), 0755)
 	c.Assert(err, IsNil)
 
-	err = ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/ubuntu", "grub.cfg"), nil, 0644)
+	err = os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/ubuntu", "grub.cfg"), nil, 0644)
 	c.Assert(err, IsNil)
 
 	err = boot.EnsureNextBootToRunMode("somelabel")
@@ -107,7 +106,7 @@ func makeSnapFilesOnInitramfsUbuntuData(c *C, rootfsDir string, comment CommentI
 	for _, sn := range snaps {
 		snPath := filepath.Join(snapDir, sn.Filename())
 		paths = append(paths, snPath)
-		err = ioutil.WriteFile(snPath, nil, 0644)
+		err = os.WriteFile(snPath, nil, 0644)
 		c.Assert(err, IsNil, comment)
 	}
 	return func() {
@@ -779,7 +778,7 @@ func (s *initramfsSuite) TestInitramfsRunModeUpdateBootloaderVars(c *C) {
 		bloader.SetBootVars(map[string]string{"kernel_status": t.initialStatus})
 
 		cmdlineFile := filepath.Join(c.MkDir(), "cmdline")
-		err := ioutil.WriteFile(cmdlineFile, []byte(t.cmdline), 0644)
+		err := os.WriteFile(cmdlineFile, []byte(t.cmdline), 0644)
 		c.Assert(err, IsNil)
 		r := kcmdline.MockProcCmdline(cmdlineFile)
 		defer r()
@@ -803,7 +802,7 @@ func (s *initramfsSuite) TestInitramfsRunModeUpdateBootloaderVarsNotNotScriptabl
 	bloader.SetBootVars(map[string]string{"kernel_status": "try"})
 
 	cmdlineFile := filepath.Join(c.MkDir(), "cmdline")
-	err := ioutil.WriteFile(cmdlineFile, []byte("kernel_status=trying"), 0644)
+	err := os.WriteFile(cmdlineFile, []byte("kernel_status=trying"), 0644)
 	c.Assert(err, IsNil)
 	r := kcmdline.MockProcCmdline(cmdlineFile)
 	defer r()
@@ -824,7 +823,7 @@ func (s *initramfsSuite) TestInitramfsRunModeUpdateBootloaderVarsErrOnGetBootVar
 	bloader.GetErr = fmt.Errorf(errMsg)
 
 	cmdlineFile := filepath.Join(c.MkDir(), "cmdline")
-	err := ioutil.WriteFile(cmdlineFile, []byte("kernel_status=trying"), 0644)
+	err := os.WriteFile(cmdlineFile, []byte("kernel_status=trying"), 0644)
 	c.Assert(err, IsNil)
 	r := kcmdline.MockProcCmdline(cmdlineFile)
 	defer r()

--- a/boot/kernel_os_test.go
+++ b/boot/kernel_os_test.go
@@ -21,7 +21,6 @@ package boot_test
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -468,7 +467,7 @@ func (s *ubootSuite) forceUbootBootloader(c *C) {
 	mockGadgetDir := c.MkDir()
 	// this is testing the uc16/uc18 style uboot bootloader layout, the file
 	// must be non-empty for uc16/uc18 gadget config install behavior
-	err := ioutil.WriteFile(filepath.Join(mockGadgetDir, "uboot.conf"), []byte{1}, 0644)
+	err := os.WriteFile(filepath.Join(mockGadgetDir, "uboot.conf"), []byte{1}, 0644)
 	c.Assert(err, IsNil)
 	err = bootloader.InstallBootConfig(mockGadgetDir, dirs.GlobalRootDir, nil)
 	c.Assert(err, IsNil)
@@ -498,7 +497,7 @@ func (s *ubootSuite) forceUC20UbootBootloader(c *C) {
 	mockGadgetDir := c.MkDir()
 	// this must be empty for uc20 behavior
 	// TODO:UC20: update this test for the new behavior when that is implemented
-	err := ioutil.WriteFile(filepath.Join(mockGadgetDir, "uboot.conf"), nil, 0644)
+	err := os.WriteFile(filepath.Join(mockGadgetDir, "uboot.conf"), nil, 0644)
 	c.Assert(err, IsNil)
 	err = bootloader.InstallBootConfig(mockGadgetDir, dirs.GlobalRootDir, installOpts)
 	c.Assert(err, IsNil)
@@ -608,7 +607,7 @@ func (s *grubSuite) forceGrubBootloader(c *C) bootloader.Bootloader {
 
 	// make mock grub bootenv dir
 	mockGadgetDir := c.MkDir()
-	err := ioutil.WriteFile(filepath.Join(mockGadgetDir, "grub.conf"), nil, 0644)
+	err := os.WriteFile(filepath.Join(mockGadgetDir, "grub.conf"), nil, 0644)
 	c.Assert(err, IsNil)
 	err = bootloader.InstallBootConfig(mockGadgetDir, dirs.GlobalRootDir, nil)
 	c.Assert(err, IsNil)

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -21,7 +21,6 @@ package boot_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -95,7 +94,7 @@ func (s *makeBootableSuite) TestMakeBootableImage(c *C) {
 
 	grubCfg := []byte("#grub cfg")
 	unpackedGadgetDir := c.MkDir()
-	err := ioutil.WriteFile(filepath.Join(unpackedGadgetDir, "grub.conf"), grubCfg, 0644)
+	err := os.WriteFile(filepath.Join(unpackedGadgetDir, "grub.conf"), grubCfg, 0644)
 	c.Assert(err, IsNil)
 
 	seedSnapsDirs := filepath.Join(s.rootdir, "/var/lib/snapd/seed", "snaps")
@@ -445,10 +444,10 @@ func (s *makeBootable20Suite) TestMakeBootableImage20UnsetRecoverySystemLabelErr
 
 	unpackedGadgetDir := c.MkDir()
 	grubRecoveryCfg := []byte("#grub-recovery cfg")
-	err := ioutil.WriteFile(filepath.Join(unpackedGadgetDir, "grub-recovery.conf"), grubRecoveryCfg, 0644)
+	err := os.WriteFile(filepath.Join(unpackedGadgetDir, "grub-recovery.conf"), grubRecoveryCfg, 0644)
 	c.Assert(err, IsNil)
 	grubCfg := []byte("#grub cfg")
-	err = ioutil.WriteFile(filepath.Join(unpackedGadgetDir, "grub.conf"), grubCfg, 0644)
+	err = os.WriteFile(filepath.Join(unpackedGadgetDir, "grub.conf"), grubCfg, 0644)
 	c.Assert(err, IsNil)
 
 	label := "20191209"
@@ -508,7 +507,7 @@ func (s *makeBootable20Suite) testMakeSystemRunnable20(c *C, standalone, factory
 	mockSeedGrubCfg := filepath.Join(mockSeedGrubDir, "grub.cfg")
 	err = os.MkdirAll(filepath.Dir(mockSeedGrubCfg), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(mockSeedGrubCfg, []byte("# Snapd-Boot-Config-Edition: 1\n"), 0644)
+	err = os.WriteFile(mockSeedGrubCfg, []byte("# Snapd-Boot-Config-Edition: 1\n"), 0644)
 	c.Assert(err, IsNil)
 	genv := grubenv.NewEnv(filepath.Join(mockSeedGrubDir, "grubenv"))
 	c.Assert(genv.Save(), IsNil)
@@ -517,11 +516,11 @@ func (s *makeBootable20Suite) testMakeSystemRunnable20(c *C, standalone, factory
 	err = os.MkdirAll(filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/boot"), 0755)
 	c.Assert(err, IsNil)
 	// SHA3-384: 39efae6545f16e39633fbfbef0d5e9fdd45a25d7df8764978ce4d81f255b038046a38d9855e42e5c7c4024e153fd2e37
-	err = ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/boot/bootx64.efi"),
+	err = os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/boot/bootx64.efi"),
 		[]byte("recovery shim content"), 0644)
 	c.Assert(err, IsNil)
 	// SHA3-384: aa3c1a83e74bf6dd40dd64e5c5bd1971d75cdf55515b23b9eb379f66bf43d4661d22c4b8cf7d7a982d2013ab65c1c4c5
-	err = ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/boot/grubx64.efi"),
+	err = os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/boot/grubx64.efi"),
 		[]byte("recovery grub content"), 0644)
 	c.Assert(err, IsNil)
 
@@ -530,7 +529,7 @@ func (s *makeBootable20Suite) testMakeSystemRunnable20(c *C, standalone, factory
 	mockBootGrubCfg := filepath.Join(mockBootGrubDir, "grub.cfg")
 	err = os.MkdirAll(filepath.Dir(mockBootGrubCfg), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(mockBootGrubCfg, nil, 0644)
+	err = os.WriteFile(mockBootGrubCfg, nil, 0644)
 	c.Assert(err, IsNil)
 
 	unpackedGadgetDir := c.MkDir()
@@ -957,7 +956,7 @@ func (s *makeBootable20Suite) TestMakeRunnableSystem20ModeInstallBootConfigErr(c
 	mockBootGrubCfg := filepath.Join(mockBootGrubDir, "grub.cfg")
 	err = os.MkdirAll(filepath.Dir(mockBootGrubCfg), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(mockBootGrubCfg, nil, 0644)
+	err = os.WriteFile(mockBootGrubCfg, nil, 0644)
 	c.Assert(err, IsNil)
 
 	unpackedGadgetDir := c.MkDir()
@@ -1008,7 +1007,7 @@ version: 5.0
 
 	// set up grub.cfg in gadget
 	grubCfg := []byte("#grub cfg")
-	err = ioutil.WriteFile(filepath.Join(unpackedGadgetDir, "grub.conf"), grubCfg, 0644)
+	err = os.WriteFile(filepath.Join(unpackedGadgetDir, "grub.conf"), grubCfg, 0644)
 	c.Assert(err, IsNil)
 
 	// no write access to destination directory
@@ -1031,18 +1030,18 @@ func (s *makeBootable20Suite) TestMakeRunnableSystem20RunModeSealKeyErr(c *C) {
 	mockSeedGrubCfg := filepath.Join(mockSeedGrubDir, "grub.cfg")
 	err = os.MkdirAll(filepath.Dir(mockSeedGrubCfg), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(mockSeedGrubCfg, []byte("# Snapd-Boot-Config-Edition: 1\n"), 0644)
+	err = os.WriteFile(mockSeedGrubCfg, []byte("# Snapd-Boot-Config-Edition: 1\n"), 0644)
 	c.Assert(err, IsNil)
 
 	// setup recovery boot assets
 	err = os.MkdirAll(filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/boot"), 0755)
 	c.Assert(err, IsNil)
 	// SHA3-384: 39efae6545f16e39633fbfbef0d5e9fdd45a25d7df8764978ce4d81f255b038046a38d9855e42e5c7c4024e153fd2e37
-	err = ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/boot/bootx64.efi"),
+	err = os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/boot/bootx64.efi"),
 		[]byte("recovery shim content"), 0644)
 	c.Assert(err, IsNil)
 	// SHA3-384: aa3c1a83e74bf6dd40dd64e5c5bd1971d75cdf55515b23b9eb379f66bf43d4661d22c4b8cf7d7a982d2013ab65c1c4c5
-	err = ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/boot/grubx64.efi"),
+	err = os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/boot/grubx64.efi"),
 		[]byte("recovery grub content"), 0644)
 	c.Assert(err, IsNil)
 
@@ -1051,7 +1050,7 @@ func (s *makeBootable20Suite) TestMakeRunnableSystem20RunModeSealKeyErr(c *C) {
 	mockBootGrubCfg := filepath.Join(mockBootGrubDir, "grub.cfg")
 	err = os.MkdirAll(filepath.Dir(mockBootGrubCfg), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(mockBootGrubCfg, nil, 0644)
+	err = os.WriteFile(mockBootGrubCfg, nil, 0644)
 	c.Assert(err, IsNil)
 
 	unpackedGadgetDir := c.MkDir()
@@ -1218,7 +1217,7 @@ func (s *makeBootable20Suite) testMakeSystemRunnable20WithCustomKernelArgs(c *C,
 	mockSeedGrubCfg := filepath.Join(mockSeedGrubDir, "grub.cfg")
 	err = os.MkdirAll(filepath.Dir(mockSeedGrubCfg), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(mockSeedGrubCfg, []byte("# Snapd-Boot-Config-Edition: 1\n"), 0644)
+	err = os.WriteFile(mockSeedGrubCfg, []byte("# Snapd-Boot-Config-Edition: 1\n"), 0644)
 	c.Assert(err, IsNil)
 	genv := grubenv.NewEnv(filepath.Join(mockSeedGrubDir, "grubenv"))
 	c.Assert(genv.Save(), IsNil)
@@ -1227,11 +1226,11 @@ func (s *makeBootable20Suite) testMakeSystemRunnable20WithCustomKernelArgs(c *C,
 	err = os.MkdirAll(filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/boot"), 0755)
 	c.Assert(err, IsNil)
 	// SHA3-384: 39efae6545f16e39633fbfbef0d5e9fdd45a25d7df8764978ce4d81f255b038046a38d9855e42e5c7c4024e153fd2e37
-	err = ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/boot/bootx64.efi"),
+	err = os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/boot/bootx64.efi"),
 		[]byte("recovery shim content"), 0644)
 	c.Assert(err, IsNil)
 	// SHA3-384: aa3c1a83e74bf6dd40dd64e5c5bd1971d75cdf55515b23b9eb379f66bf43d4661d22c4b8cf7d7a982d2013ab65c1c4c5
-	err = ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/boot/grubx64.efi"),
+	err = os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/boot/grubx64.efi"),
 		[]byte("recovery grub content"), 0644)
 	c.Assert(err, IsNil)
 
@@ -1240,7 +1239,7 @@ func (s *makeBootable20Suite) testMakeSystemRunnable20WithCustomKernelArgs(c *C,
 	mockBootGrubCfg := filepath.Join(mockBootGrubDir, "grub.cfg")
 	err = os.MkdirAll(filepath.Dir(mockBootGrubCfg), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(mockBootGrubCfg, nil, 0644)
+	err = os.WriteFile(mockBootGrubCfg, nil, 0644)
 	c.Assert(err, IsNil)
 
 	unpackedGadgetDir := c.MkDir()
@@ -1460,17 +1459,17 @@ func (s *makeBootable20Suite) TestMakeSystemRunnable20UnhappyMarkRecoveryCapable
 	mockSeedGrubCfg := filepath.Join(mockSeedGrubDir, "grub.cfg")
 	err = os.MkdirAll(filepath.Dir(mockSeedGrubCfg), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(mockSeedGrubCfg, []byte("# Snapd-Boot-Config-Edition: 1\n"), 0644)
+	err = os.WriteFile(mockSeedGrubCfg, []byte("# Snapd-Boot-Config-Edition: 1\n"), 0644)
 	c.Assert(err, IsNil)
 	// there is no grubenv in ubuntu-seed so loading from it will fail
 
 	// setup recovery boot assets
 	err = os.MkdirAll(filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/boot"), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/boot/bootx64.efi"),
+	err = os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/boot/bootx64.efi"),
 		[]byte("recovery shim content"), 0644)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/boot/grubx64.efi"),
+	err = os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "EFI/boot/grubx64.efi"),
 		[]byte("recovery grub content"), 0644)
 	c.Assert(err, IsNil)
 
@@ -1479,7 +1478,7 @@ func (s *makeBootable20Suite) TestMakeSystemRunnable20UnhappyMarkRecoveryCapable
 	mockBootGrubCfg := filepath.Join(mockBootGrubDir, "grub.cfg")
 	err = os.MkdirAll(filepath.Dir(mockBootGrubCfg), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(mockBootGrubCfg, nil, 0644)
+	err = os.WriteFile(mockBootGrubCfg, nil, 0644)
 	c.Assert(err, IsNil)
 
 	unpackedGadgetDir := c.MkDir()
@@ -1559,7 +1558,7 @@ func (s *makeBootable20UbootSuite) TestUbootMakeBootableImage20TraditionalUboote
 
 	unpackedGadgetDir := c.MkDir()
 	ubootEnv := []byte("#uboot env")
-	err := ioutil.WriteFile(filepath.Join(unpackedGadgetDir, "uboot.conf"), ubootEnv, 0644)
+	err := os.WriteFile(filepath.Join(unpackedGadgetDir, "uboot.conf"), ubootEnv, 0644)
 	c.Assert(err, IsNil)
 
 	// on uc20 the seed layout if different
@@ -1610,7 +1609,7 @@ func (s *makeBootable20UbootSuite) TestUbootMakeBootableImage20BootScr(c *C) {
 
 	unpackedGadgetDir := c.MkDir()
 	// the uboot.conf must be empty for this to work/do the right thing
-	err := ioutil.WriteFile(filepath.Join(unpackedGadgetDir, "uboot.conf"), nil, 0644)
+	err := os.WriteFile(filepath.Join(unpackedGadgetDir, "uboot.conf"), nil, 0644)
 	c.Assert(err, IsNil)
 
 	// on uc20 the seed layout if different
@@ -1681,7 +1680,7 @@ func (s *makeBootable20UbootSuite) TestUbootMakeBootableImage20BootSelNoHeaderFl
 
 	unpackedGadgetDir := c.MkDir()
 	// the uboot.conf must be empty for this to work/do the right thing
-	err := ioutil.WriteFile(filepath.Join(unpackedGadgetDir, "uboot.conf"), nil, 0644)
+	err := os.WriteFile(filepath.Join(unpackedGadgetDir, "uboot.conf"), nil, 0644)
 	c.Assert(err, IsNil)
 
 	sampleEnv, err := ubootenv.Create(filepath.Join(unpackedGadgetDir, "boot.sel"), 4096, ubootenv.CreateOptions{HeaderFlagByte: false})
@@ -1768,7 +1767,7 @@ func (s *makeBootable20UbootSuite) TestUbootMakeRunnableSystem20RunModeBootSel(c
 	c.Assert(env.Save(), IsNil)
 
 	unpackedGadgetDir := c.MkDir()
-	c.Assert(ioutil.WriteFile(filepath.Join(unpackedGadgetDir, "uboot.conf"), nil, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(unpackedGadgetDir, "uboot.conf"), nil, 0644), IsNil)
 
 	baseFn, baseInfo := makeSnap(c, "core20", `name: core20
 type: base
@@ -2041,7 +2040,7 @@ func (s *makeBootable20Suite) TestMakeRunnableSystemNoGoodRecoverySystems(c *C) 
 	mockSeedGrubCfg := filepath.Join(mockSeedGrubDir, "grub.cfg")
 	err = os.MkdirAll(filepath.Dir(mockSeedGrubCfg), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(mockSeedGrubCfg, []byte("# Snapd-Boot-Config-Edition: 1\n"), 0644)
+	err = os.WriteFile(mockSeedGrubCfg, []byte("# Snapd-Boot-Config-Edition: 1\n"), 0644)
 	c.Assert(err, IsNil)
 	genv := grubenv.NewEnv(filepath.Join(mockSeedGrubDir, "grubenv"))
 	c.Assert(genv.Save(), IsNil)
@@ -2127,7 +2126,7 @@ func (s *makeBootable20Suite) TestMakeRunnableSystemStandaloneSnapsCopy(c *C) {
 	mockSeedGrubCfg := filepath.Join(mockSeedGrubDir, "grub.cfg")
 	err = os.MkdirAll(filepath.Dir(mockSeedGrubCfg), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(mockSeedGrubCfg, []byte("# Snapd-Boot-Config-Edition: 1\n"), 0644)
+	err = os.WriteFile(mockSeedGrubCfg, []byte("# Snapd-Boot-Config-Edition: 1\n"), 0644)
 	c.Assert(err, IsNil)
 	genv := grubenv.NewEnv(filepath.Join(mockSeedGrubDir, "grubenv"))
 	c.Assert(genv.Save(), IsNil)

--- a/boot/modeenv_test.go
+++ b/boot/modeenv_test.go
@@ -90,7 +90,7 @@ func (s *modeenvSuite) TestReadEmptyErrors(c *C) {
 func (s *modeenvSuite) makeMockModeenvFile(c *C, content string) {
 	err := os.MkdirAll(filepath.Dir(s.mockModeenvPath), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(s.mockModeenvPath, []byte(content), 0644)
+	err = os.WriteFile(s.mockModeenvPath, []byte(content), 0644)
 	c.Assert(err, IsNil)
 }
 

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -22,7 +22,6 @@ package boot_test
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -468,7 +467,7 @@ func (s *sealSuite) TestResealKeyToModeenvWithSystemFallback(c *C) {
 
 		if tc.sealedKeys {
 			c.Assert(os.MkdirAll(dirs.SnapFDEDir, 0755), IsNil)
-			err := ioutil.WriteFile(filepath.Join(dirs.SnapFDEDir, "sealed-keys"), nil, 0644)
+			err := os.WriteFile(filepath.Join(dirs.SnapFDEDir, "sealed-keys"), nil, 0644)
 			c.Assert(err, IsNil)
 
 		}
@@ -792,7 +791,7 @@ func (s *sealSuite) TestResealKeyToModeenvRecoveryKeysForGoodSystemsOnly(c *C) {
 	defer dirs.SetRootDir("")
 
 	c.Assert(os.MkdirAll(dirs.SnapFDEDir, 0755), IsNil)
-	err := ioutil.WriteFile(filepath.Join(dirs.SnapFDEDir, "sealed-keys"), nil, 0644)
+	err := os.WriteFile(filepath.Join(dirs.SnapFDEDir, "sealed-keys"), nil, 0644)
 	c.Assert(err, IsNil)
 
 	err = createMockGrubCfg(filepath.Join(rootdir, "run/mnt/ubuntu-seed"))
@@ -1064,7 +1063,7 @@ func (s *sealSuite) TestResealKeyToModeenvFallbackCmdline(c *C) {
 	model := boottest.MakeMockUC20Model()
 
 	c.Assert(os.MkdirAll(dirs.SnapFDEDir, 0755), IsNil)
-	err := ioutil.WriteFile(filepath.Join(dirs.SnapFDEDir, "sealed-keys"), nil, 0644)
+	err := os.WriteFile(filepath.Join(dirs.SnapFDEDir, "sealed-keys"), nil, 0644)
 	c.Assert(err, IsNil)
 
 	modeenv := &boot.Modeenv{
@@ -1449,7 +1448,7 @@ func createMockGrubCfg(baseDir string) error {
 	if err := os.MkdirAll(filepath.Dir(cfg), 0755); err != nil {
 		return err
 	}
-	return ioutil.WriteFile(cfg, []byte("# Snapd-Boot-Config-Edition: 1\n"), 0644)
+	return os.WriteFile(cfg, []byte("# Snapd-Boot-Config-Edition: 1\n"), 0644)
 }
 
 func (s *sealSuite) TestSealKeyModelParams(c *C) {
@@ -1759,7 +1758,7 @@ func (s *sealSuite) TestResealKeyToModeenvWithFdeHookCalled(c *C) {
 	marker := filepath.Join(dirs.SnapFDEDirUnder(rootdir), "sealed-keys")
 	err := os.MkdirAll(filepath.Dir(marker), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(marker, []byte("fde-setup-hook"), 0644)
+	err = os.WriteFile(marker, []byte("fde-setup-hook"), 0644)
 	c.Assert(err, IsNil)
 
 	defer boot.MockModeenvLocked()()
@@ -1793,7 +1792,7 @@ func (s *sealSuite) TestResealKeyToModeenvWithFdeHookVerySad(c *C) {
 	marker := filepath.Join(dirs.SnapFDEDirUnder(rootdir), "sealed-keys")
 	err := os.MkdirAll(filepath.Dir(marker), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(marker, []byte("fde-setup-hook"), 0644)
+	err = os.WriteFile(marker, []byte("fde-setup-hook"), 0644)
 	c.Assert(err, IsNil)
 
 	defer boot.MockModeenvLocked()()
@@ -1818,7 +1817,7 @@ func (s *sealSuite) TestResealKeyToModeenvWithTryModel(c *C) {
 	defer dirs.SetRootDir("")
 
 	c.Assert(os.MkdirAll(dirs.SnapFDEDir, 0755), IsNil)
-	err := ioutil.WriteFile(filepath.Join(dirs.SnapFDEDir, "sealed-keys"), nil, 0644)
+	err := os.WriteFile(filepath.Join(dirs.SnapFDEDir, "sealed-keys"), nil, 0644)
 	c.Assert(err, IsNil)
 
 	err = createMockGrubCfg(filepath.Join(rootdir, "run/mnt/ubuntu-seed"))
@@ -2181,10 +2180,10 @@ func (s *sealSuite) TestMarkFactoryResetComplete(c *C) {
 		if tc.encrypted {
 			c.Assert(os.MkdirAll(boot.InitramfsSeedEncryptionKeyDir, 0755), IsNil)
 			if tc.factoryKeyAlreadyMigrated {
-				c.Assert(ioutil.WriteFile(saveSealedKey, []byte{'o', 'l', 'd'}, 0644), IsNil)
-				c.Assert(ioutil.WriteFile(saveSealedKeyByFactoryReset, []byte{'n', 'e', 'w'}, 0644), IsNil)
+				c.Assert(os.WriteFile(saveSealedKey, []byte{'o', 'l', 'd'}, 0644), IsNil)
+				c.Assert(os.WriteFile(saveSealedKeyByFactoryReset, []byte{'n', 'e', 'w'}, 0644), IsNil)
 			} else {
-				c.Assert(ioutil.WriteFile(saveSealedKey, []byte{'n', 'e', 'w'}, 0644), IsNil)
+				c.Assert(os.WriteFile(saveSealedKey, []byte{'n', 'e', 'w'}, 0644), IsNil)
 			}
 		}
 

--- a/bootloader/asset_test.go
+++ b/bootloader/asset_test.go
@@ -21,7 +21,6 @@ package bootloader_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -61,7 +60,7 @@ one after that
 func (s *configAssetTestSuite) TestTrivialFromFile(c *C) {
 	d := c.MkDir()
 	p := filepath.Join(d, "foo")
-	ioutil.WriteFile(p, []byte(`# Snapd-Boot-Config-Edition: 123
+	os.WriteFile(p, []byte(`# Snapd-Boot-Config-Edition: 123
 this is some
 this too`), 0644)
 	e, err := bootloader.EditionFromDiskConfigAsset(p)
@@ -105,7 +104,7 @@ func (s *configAssetTestSuite) TestUnreadableFile(c *C) {
 	}
 	d := c.MkDir()
 	p := filepath.Join(d, "foo")
-	err := ioutil.WriteFile(p, []byte("foo"), 0000)
+	err := os.WriteFile(p, []byte("foo"), 0000)
 	c.Assert(err, IsNil)
 	_, err = bootloader.EditionFromDiskConfigAsset(p)
 	c.Assert(err, ErrorMatches, "cannot load existing config asset: .*/foo: permission denied")

--- a/bootloader/assets/genasset/main_test.go
+++ b/bootloader/assets/genasset/main_test.go
@@ -79,7 +79,7 @@ func (s *generateAssetsTestSuite) TestArgs(c *C) {
 
 func (s *generateAssetsTestSuite) TestSimpleAsset(c *C) {
 	d := c.MkDir()
-	err := ioutil.WriteFile(filepath.Join(d, "in"), []byte("this is a\n"+
+	err := os.WriteFile(filepath.Join(d, "in"), []byte("this is a\n"+
 		"multiline asset \"'``\nwith chars\n"), 0644)
 	c.Assert(err, IsNil)
 	err = generate.Run("asset-name", filepath.Join(d, "in"), filepath.Join(d, "out"))
@@ -128,7 +128,7 @@ func (s *generateAssetsTestSuite) TestGoFmtClean(c *C) {
 	}
 
 	d := c.MkDir()
-	err = ioutil.WriteFile(filepath.Join(d, "in"), []byte("this is a\n"+
+	err = os.WriteFile(filepath.Join(d, "in"), []byte("this is a\n"+
 		"multiline asset \"'``\nuneven chars\n"), 0644)
 	c.Assert(err, IsNil)
 	err = generate.Run("asset-name", filepath.Join(d, "in"), filepath.Join(d, "out"))
@@ -145,7 +145,7 @@ func (s *generateAssetsTestSuite) TestRunErrors(c *C) {
 	err := generate.Run("asset-name", filepath.Join(d, "missing"), filepath.Join(d, "out"))
 	c.Assert(err, ErrorMatches, "cannot open input file: open .*/missing: no such file or directory")
 
-	err = ioutil.WriteFile(filepath.Join(d, "in"), []byte("this is a\n"+
+	err = os.WriteFile(filepath.Join(d, "in"), []byte("this is a\n"+
 		"multiline asset \"'``\nuneven chars\n"), 0644)
 	c.Assert(err, IsNil)
 

--- a/bootloader/bootloader_test.go
+++ b/bootloader/bootloader_test.go
@@ -22,7 +22,6 @@ package bootloader_test
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -126,7 +125,7 @@ func (s *bootenvTestSuite) TestInstallBootloaderConfigFromGadget(c *C) {
 	} {
 		mockGadgetDir := c.MkDir()
 		rootDir := c.MkDir()
-		err := ioutil.WriteFile(filepath.Join(mockGadgetDir, t.gadgetFile), t.gadgetFileContent, 0644)
+		err := os.WriteFile(filepath.Join(mockGadgetDir, t.gadgetFile), t.gadgetFileContent, 0644)
 		c.Assert(err, IsNil)
 		err = bootloader.InstallBootConfig(mockGadgetDir, rootDir, t.opts)
 		c.Assert(err, IsNil, Commentf("installing boot config for %s", t.name))
@@ -219,7 +218,7 @@ func (s *bootenvTestSuite) TestInstallBootloaderConfigFromAssets(c *C) {
 		mockGadgetDir := c.MkDir()
 		rootDir := c.MkDir()
 		fn := filepath.Join(rootDir, t.sysFile)
-		err := ioutil.WriteFile(filepath.Join(mockGadgetDir, t.gadgetFile), t.gadgetFileContent, 0644)
+		err := os.WriteFile(filepath.Join(mockGadgetDir, t.gadgetFile), t.gadgetFileContent, 0644)
 		c.Assert(err, IsNil)
 		var restoreAsset func()
 		if t.assetName != "" {
@@ -322,7 +321,7 @@ func (s *bootenvTestSuite) TestBootloaderFind(c *C) {
 		rootDir := c.MkDir()
 		err := os.MkdirAll(filepath.Join(rootDir, filepath.Dir(tc.sysFile)), 0755)
 		c.Assert(err, IsNil)
-		err = ioutil.WriteFile(filepath.Join(rootDir, tc.sysFile), nil, 0644)
+		err = os.WriteFile(filepath.Join(rootDir, tc.sysFile), nil, 0644)
 		c.Assert(err, IsNil)
 		bl, err := bootloader.Find(rootDir, tc.opts)
 		c.Assert(err, IsNil)
@@ -350,7 +349,7 @@ func (s *bootenvTestSuite) TestBootloaderForGadget(c *C) {
 		rootDir := c.MkDir()
 		err := os.MkdirAll(filepath.Join(rootDir, filepath.Dir(tc.gadgetFile)), 0755)
 		c.Assert(err, IsNil)
-		err = ioutil.WriteFile(filepath.Join(gadgetDir, tc.gadgetFile), nil, 0644)
+		err = os.WriteFile(filepath.Join(gadgetDir, tc.gadgetFile), nil, 0644)
 		c.Assert(err, IsNil)
 		bl, err := bootloader.ForGadget(gadgetDir, rootDir, tc.opts)
 		c.Assert(err, IsNil)

--- a/bootloader/efi/efi_test.go
+++ b/bootloader/efi/efi_test.go
@@ -20,7 +20,6 @@
 package efi_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -76,7 +75,7 @@ func (s *efiVarsSuite) TestNoEFISystem(c *C) {
 func (s *efiVarsSuite) TestSizeError(c *C) {
 	// mock the efi var file
 	varPath := filepath.Join(s.rootdir, "/sys/firmware/efi/efivars", "my-cool-efi-var")
-	err := ioutil.WriteFile(varPath, []byte("\x06"), 0644)
+	err := os.WriteFile(varPath, []byte("\x06"), 0644)
 	c.Assert(err, IsNil)
 
 	_, _, err = efi.ReadVarBytes("my-cool-efi-var")
@@ -86,7 +85,7 @@ func (s *efiVarsSuite) TestSizeError(c *C) {
 func (s *efiVarsSuite) TestReadVarBytes(c *C) {
 	// mock the efi var file
 	varPath := filepath.Join(s.rootdir, "/sys/firmware/efi/efivars", "my-cool-efi-var")
-	err := ioutil.WriteFile(varPath, []byte("\x06\x00\x00\x00\x01"), 0644)
+	err := os.WriteFile(varPath, []byte("\x06\x00\x00\x00\x01"), 0644)
 	c.Assert(err, IsNil)
 
 	data, attr, err := efi.ReadVarBytes("my-cool-efi-var")
@@ -98,7 +97,7 @@ func (s *efiVarsSuite) TestReadVarBytes(c *C) {
 func (s *efiVarsSuite) TestReadVarString(c *C) {
 	// mock the efi var file
 	varPath := filepath.Join(s.rootdir, "/sys/firmware/efi/efivars", "my-cool-efi-var")
-	err := ioutil.WriteFile(varPath, []byte("\x06\x00\x00\x00A\x009\x00F\x005\x00C\x009\x004\x009\x00-\x00A\x00B\x008\x009\x00-\x005\x00B\x004\x007\x00-\x00A\x007\x00B\x00F\x00-\x005\x006\x00D\x00D\x002\x008\x00F\x009\x006\x00E\x006\x005\x00\x00\x00"), 0644)
+	err := os.WriteFile(varPath, []byte("\x06\x00\x00\x00A\x009\x00F\x005\x00C\x009\x004\x009\x00-\x00A\x00B\x008\x009\x00-\x005\x00B\x004\x007\x00-\x00A\x007\x00B\x00F\x00-\x005\x006\x00D\x00D\x002\x008\x00F\x009\x006\x00E\x006\x005\x00\x00\x00"), 0644)
 	c.Assert(err, IsNil)
 
 	data, attr, err := efi.ReadVarString("my-cool-efi-var")
@@ -110,7 +109,7 @@ func (s *efiVarsSuite) TestReadVarString(c *C) {
 func (s *efiVarsSuite) TestEmpty(c *C) {
 	// mock the efi var file
 	varPath := filepath.Join(s.rootdir, "/sys/firmware/efi/efivars", "my-cool-efi-var")
-	err := ioutil.WriteFile(varPath, []byte("\x06\x00\x00\x00"), 0644)
+	err := os.WriteFile(varPath, []byte("\x06\x00\x00\x00"), 0644)
 	c.Assert(err, IsNil)
 
 	b, _, err := efi.ReadVarBytes("my-cool-efi-var")

--- a/bootloader/export_test.go
+++ b/bootloader/export_test.go
@@ -20,7 +20,6 @@
 package bootloader
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -42,7 +41,7 @@ func MockAndroidBootFile(c *C, rootdir string, mode os.FileMode) {
 	f := &androidboot{rootdir: rootdir}
 	err := os.MkdirAll(f.dir(), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(f.configFile(), nil, mode)
+	err = os.WriteFile(f.configFile(), nil, mode)
 	c.Assert(err, IsNil)
 }
 
@@ -71,7 +70,7 @@ func NewGrub(rootdir string, opts *Options) RecoveryAwareBootloader {
 func MockGrubFiles(c *C, rootdir string) {
 	err := os.MkdirAll(filepath.Join(rootdir, "/boot/grub"), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(rootdir, "/boot/grub/grub.cfg"), nil, 0644)
+	err = os.WriteFile(filepath.Join(rootdir, "/boot/grub/grub.cfg"), nil, 0644)
 	c.Assert(err, IsNil)
 }
 
@@ -174,7 +173,7 @@ func MockLkFiles(c *C, rootdir string, opts *Options) (restore func()) {
 
 		// now mock the kernel command line
 		cmdLine := filepath.Join(c.MkDir(), "cmdline")
-		ioutil.WriteFile(cmdLine, []byte("snapd_lk_boot_disk=lk-boot-disk"), 0644)
+		os.WriteFile(cmdLine, []byte("snapd_lk_boot_disk=lk-boot-disk"), 0644)
 		r = kcmdline.MockProcCmdline(cmdLine)
 		cleanups = append(cleanups, r)
 	}
@@ -185,7 +184,7 @@ func MockLkFiles(c *C, rootdir string, opts *Options) (restore func()) {
 	c.Assert(err, IsNil)
 
 	c.Assert(os.MkdirAll(filepath.Dir(f), 0755), IsNil)
-	err = ioutil.WriteFile(f, buf, 0660)
+	err = os.WriteFile(f, buf, 0660)
 	c.Assert(err, IsNil)
 
 	// now write env in it with correct crc
@@ -211,7 +210,7 @@ func MockLkFiles(c *C, rootdir string, opts *Options) (restore func()) {
 			c.Assert(err, IsNil)
 			bootFile := filepath.Join(rootdir, "/dev/disk/by-partuuid", partUUID)
 			c.Assert(os.MkdirAll(filepath.Dir(bootFile), 0755), IsNil)
-			c.Assert(ioutil.WriteFile(bootFile, nil, 0755), IsNil)
+			c.Assert(os.WriteFile(bootFile, nil, 0755), IsNil)
 		}
 	} else {
 		// for non-uc20 roles just mock the files in /dev/disk/by-partlabel
@@ -219,7 +218,7 @@ func MockLkFiles(c *C, rootdir string, opts *Options) (restore func()) {
 			mockPart := filepath.Join(rootdir, "/dev/disk/by-partlabel/", partName)
 			err := os.MkdirAll(filepath.Dir(mockPart), 0755)
 			c.Assert(err, IsNil)
-			err = ioutil.WriteFile(mockPart, nil, 0600)
+			err = os.WriteFile(mockPart, nil, 0600)
 			c.Assert(err, IsNil)
 		}
 	}

--- a/bootloader/grub_test.go
+++ b/bootloader/grub_test.go
@@ -21,7 +21,6 @@ package bootloader_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -253,7 +252,7 @@ func (s *grubTestSuite) grubEFINativeDir() string {
 func (s *grubTestSuite) makeFakeGrubEFINativeEnv(c *C, content []byte) {
 	err := os.MkdirAll(s.grubEFINativeDir(), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(s.grubEFINativeDir(), "grub.cfg"), content, 0644)
+	err = os.WriteFile(filepath.Join(s.grubEFINativeDir(), "grub.cfg"), content, 0644)
 	c.Assert(err, IsNil)
 }
 
@@ -357,7 +356,7 @@ func (s *grubTestSuite) makeKernelAssetSnap(c *C, snapFileName string) snap.Plac
 	err = os.MkdirAll(kernelSnapExtractedAssetsDir, 0755)
 	c.Assert(err, IsNil)
 
-	err = ioutil.WriteFile(filepath.Join(kernelSnapExtractedAssetsDir, "kernel.efi"), nil, 0644)
+	err = os.WriteFile(filepath.Join(kernelSnapExtractedAssetsDir, "kernel.efi"), nil, 0644)
 	c.Assert(err, IsNil)
 
 	return kernelSnap
@@ -408,7 +407,7 @@ func (s *grubTestSuite) TestGrubExtractedRunKernelImageTryKernel(c *C) {
 	err = os.MkdirAll(kernelSnapExtractedAssetsDir, 0755)
 	c.Assert(err, IsNil)
 
-	err = ioutil.WriteFile(badKernelSnapPath, nil, 0644)
+	err = os.WriteFile(badKernelSnapPath, nil, 0644)
 	c.Assert(err, IsNil)
 
 	err = os.Symlink("bad_snap_rev_name/kernel.efi", tryKernelSymlink)

--- a/bootloader/lk_test.go
+++ b/bootloader/lk_test.go
@@ -89,7 +89,7 @@ func (s *lkTestSuite) TestNewLkPresentChecksBackupStorageToo(c *C) {
 	err = os.MkdirAll(filepath.Dir(f), 0755)
 	c.Assert(err, IsNil)
 
-	err = ioutil.WriteFile(f+"bak", nil, 0644)
+	err = os.WriteFile(f+"bak", nil, 0644)
 	c.Assert(err, IsNil)
 
 	// now the bootloader is present because the backup exists

--- a/bootloader/lkenv/lkenv_test.go
+++ b/bootloader/lkenv/lkenv_test.go
@@ -26,7 +26,6 @@ import (
 	"fmt"
 	"hash/crc32"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -246,12 +245,12 @@ func (l *lkenvTestSuite) TestSave(c *C) {
 			if makeBackup {
 				// create the backup file too
 				buf := make([]byte, 4096)
-				err := ioutil.WriteFile(testFileBackup, buf, 0644)
+				err := os.WriteFile(testFileBackup, buf, 0644)
 				c.Assert(err, IsNil, comment)
 			}
 
 			buf := make([]byte, 4096)
-			err := ioutil.WriteFile(testFile, buf, 0644)
+			err := os.WriteFile(testFile, buf, 0644)
 			c.Assert(err, IsNil, comment)
 
 			env := lkenv.NewEnv(testFile, "", t.version)
@@ -342,7 +341,7 @@ func (l *lkenvTestSuite) TestLoadValidatesCRC32(c *C) {
 		// we write it out so that the checksum is invalid
 		expCrc32 := crc32.ChecksumIEEE(buf.Bytes()[:ss-4])
 
-		err = ioutil.WriteFile(testFile, buf.Bytes(), 0644)
+		err = os.WriteFile(testFile, buf.Bytes(), 0644)
 		c.Assert(err, IsNil)
 
 		// now try importing the file with LoadEnv()
@@ -366,9 +365,9 @@ func (l *lkenvTestSuite) TestNewBackupFileLocation(c *C) {
 		c.Assert(testFile, testutil.FileAbsent)
 		c.Assert(testFile+"bak", testutil.FileAbsent)
 		// make empty files for Save() to overwrite
-		err := ioutil.WriteFile(testFile, nil, 0644)
+		err := os.WriteFile(testFile, nil, 0644)
 		c.Assert(err, IsNil)
-		err = ioutil.WriteFile(testFile+"bak", nil, 0644)
+		err = os.WriteFile(testFile+"bak", nil, 0644)
 		c.Assert(err, IsNil)
 		env := lkenv.NewEnv(testFile, "", version)
 		c.Assert(env, NotNil)
@@ -395,9 +394,9 @@ func (l *lkenvTestSuite) TestNewBackupFileLocation(c *C) {
 		defer restore()
 		testFile := filepath.Join(c.MkDir(), "lk.bin")
 		testFileBackup := filepath.Join(c.MkDir(), "lkbackup.bin")
-		err := ioutil.WriteFile(testFile, nil, 0644)
+		err := os.WriteFile(testFile, nil, 0644)
 		c.Assert(err, IsNil)
-		err = ioutil.WriteFile(testFileBackup, nil, 0644)
+		err = os.WriteFile(testFileBackup, nil, 0644)
 		c.Assert(err, IsNil)
 
 		env := lkenv.NewEnv(testFile, testFileBackup, version)
@@ -507,7 +506,7 @@ func (l *lkenvTestSuite) TestLoadValidatesVersionSignatureConsistency(c *C) {
 		buf.Truncate(ss - 4)
 		binary.Write(buf, binary.LittleEndian, &newCrc32)
 
-		err = ioutil.WriteFile(testFile, buf.Bytes(), 0644)
+		err = os.WriteFile(testFile, buf.Bytes(), 0644)
 		c.Assert(err, IsNil)
 
 		// now try importing the file with LoadEnv()
@@ -557,12 +556,12 @@ func (l *lkenvTestSuite) TestLoad(c *C) {
 			testFileBackup := testFile + "bak"
 			if makeBackup {
 				buf := make([]byte, 100000)
-				err := ioutil.WriteFile(testFileBackup, buf, 0644)
+				err := os.WriteFile(testFileBackup, buf, 0644)
 				c.Assert(err, IsNil)
 			}
 
 			buf := make([]byte, 100000)
-			err := ioutil.WriteFile(testFile, buf, 0644)
+			err := os.WriteFile(testFile, buf, 0644)
 			c.Assert(err, IsNil)
 
 			// create an env for this file and try to load it
@@ -700,7 +699,7 @@ func (l *lkenvTestSuite) TestGetAndSetAndFindBootPartition(c *C) {
 		c.Assert(t.bootMatrixKeys, HasLen, len(t.bootMatrixValues), comment)
 
 		buf := make([]byte, 4096)
-		err := ioutil.WriteFile(l.envPath, buf, 0644)
+		err := os.WriteFile(l.envPath, buf, 0644)
 		c.Assert(err, IsNil, comment)
 
 		env := lkenv.NewEnv(l.envPath, "", t.version)
@@ -889,9 +888,9 @@ func (l *lkenvTestSuite) TestZippedDataSample(c *C) {
 	// uncompress test data to sample env file
 	rawData, err := unpackTestData(gzipedData)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(l.envPath, rawData, 0644)
+	err = os.WriteFile(l.envPath, rawData, 0644)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(l.envPathbak, rawData, 0644)
+	err = os.WriteFile(l.envPathbak, rawData, 0644)
 	c.Assert(err, IsNil)
 
 	env := lkenv.NewEnv(l.envPath, "", lkenv.V1)

--- a/bootloader/piboot_test.go
+++ b/bootloader/piboot_test.go
@@ -389,11 +389,11 @@ func (s *pibootTestSuite) TestCreateConfigCurrentNotEmpty(c *C) {
 	defer r()
 
 	// Get some extra kernel command line parameters
-	err := ioutil.WriteFile(filepath.Join(s.rootdir, "cmdline.txt"),
+	err := os.WriteFile(filepath.Join(s.rootdir, "cmdline.txt"),
 		[]byte("opt1=foo bar\n"), 0644)
 	c.Assert(err, IsNil)
 	// Add some options to already existing config.txt
-	err = ioutil.WriteFile(filepath.Join(s.rootdir, "config.txt"),
+	err = os.WriteFile(filepath.Join(s.rootdir, "config.txt"),
 		[]byte("rpi.option1=val\nos_prefix=1\nrpi.option2=val\n"), 0644)
 	c.Assert(err, IsNil)
 	p := bootloader.NewPiboot(s.rootdir, &opts)
@@ -462,7 +462,7 @@ func (s *pibootTestSuite) TestOnlyOneOsPrefix(c *C) {
 	defer r()
 
 	// Introuce two os_prefix lines
-	err := ioutil.WriteFile(filepath.Join(s.rootdir, "config.txt"),
+	err := os.WriteFile(filepath.Join(s.rootdir, "config.txt"),
 		[]byte("os_prefix=1\nos_prefix=2\n"), 0644)
 	c.Assert(err, IsNil)
 	p := bootloader.NewPiboot(s.rootdir, &opts)

--- a/bootloader/ubootenv/env_test.go
+++ b/bootloader/ubootenv/env_test.go
@@ -83,7 +83,7 @@ func (u *uenvTestSuite) TestOpenEnvNoHeaderFlagByte(c *C) {
 func (u *uenvTestSuite) TestOpenEnvBadEmpty(c *C) {
 	empty := filepath.Join(c.MkDir(), "empty.env")
 
-	err := ioutil.WriteFile(empty, nil, 0644)
+	err := os.WriteFile(empty, nil, 0644)
 	c.Assert(err, IsNil)
 
 	_, err = ubootenv.Open(empty)
@@ -94,7 +94,7 @@ func (u *uenvTestSuite) TestOpenEnvBadCRC(c *C) {
 	corrupted := filepath.Join(c.MkDir(), "corrupted.env")
 
 	buf := make([]byte, 4096)
-	err := ioutil.WriteFile(corrupted, buf, 0644)
+	err := os.WriteFile(corrupted, buf, 0644)
 	c.Assert(err, IsNil)
 
 	_, err = ubootenv.Open(corrupted)

--- a/bootloader/withbootassettesting_test.go
+++ b/bootloader/withbootassettesting_test.go
@@ -22,7 +22,7 @@
 package bootloader_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	. "gopkg.in/check.v1"
@@ -40,7 +40,7 @@ var _ = Suite(&withbootasetstestingTestSuite{})
 
 func (s *withbootasetstestingTestSuite) TestInjects(c *C) {
 	d := c.MkDir()
-	c.Assert(ioutil.WriteFile(filepath.Join(d, "bootassetstesting"), []byte("with-bootassetstesting\n"), 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(d, "bootassetstesting"), []byte("with-bootassetstesting\n"), 0644), IsNil)
 	restore := bootloader.MockMaybeInjectOsReadlink(func(_ string) (string, error) {
 		return filepath.Join(d, "foo"), nil
 	})

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -150,7 +150,7 @@ func (cs *clientSuite) TestClientWorks(c *C) {
 
 func makeMaintenanceFile(c *C, b []byte) {
 	c.Assert(os.MkdirAll(filepath.Dir(dirs.SnapdMaintenanceFile), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(dirs.SnapdMaintenanceFile, b, 0644), IsNil)
+	c.Assert(os.WriteFile(dirs.SnapdMaintenanceFile, b, 0644), IsNil)
 }
 
 func (cs *clientSuite) TestClientSetMaintenanceForMaintenanceJSON(c *C) {
@@ -332,7 +332,7 @@ func (cs *clientSuite) TestClientWhoAmINobody(c *C) {
 }
 
 func (cs *clientSuite) TestClientWhoAmIRubbish(c *C) {
-	c.Assert(ioutil.WriteFile(client.TestStoreAuthFilename(os.Getenv("HOME")), []byte("rubbish"), 0644), IsNil)
+	c.Assert(os.WriteFile(client.TestStoreAuthFilename(os.Getenv("HOME")), []byte("rubbish"), 0644), IsNil)
 
 	email, err := cs.cli.WhoAmI()
 	c.Check(err, NotNil)

--- a/client/clientutil/snapinfo_test.go
+++ b/client/clientutil/snapinfo_test.go
@@ -20,7 +20,6 @@
 package clientutil_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -200,7 +199,7 @@ func (*cmdSuite) TestClientSnapFromSnapInfoAppsInactive(c *C) {
 	df := si.Apps["app"].DesktopFile()
 	err := os.MkdirAll(filepath.Dir(df), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(df, nil, 0644)
+	err = os.WriteFile(df, nil, 0644)
 	c.Assert(err, IsNil)
 
 	sd := &testStatusDecorator{}

--- a/client/login_test.go
+++ b/client/login_test.go
@@ -20,7 +20,6 @@
 package client_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -67,7 +66,7 @@ func (cs *clientSuite) TestClientLoginWhenLoggedIn(c *check.C) {
 	os.Setenv(client.TestAuthFileEnvKey, outfile)
 	defer os.Unsetenv(client.TestAuthFileEnvKey)
 
-	err := ioutil.WriteFile(outfile, []byte(`{"email":"foo@bar.com","macaroon":"macaroon"}`), 0600)
+	err := os.WriteFile(outfile, []byte(`{"email":"foo@bar.com","macaroon":"macaroon"}`), 0600)
 	c.Assert(err, check.IsNil)
 	c.Assert(cs.cli.LoggedInUser(), check.DeepEquals, &client.User{
 		Email:    "foo@bar.com",
@@ -118,7 +117,7 @@ func (cs *clientSuite) TestClientLogout(c *check.C) {
 	os.Setenv(client.TestAuthFileEnvKey, outfile)
 	defer os.Unsetenv(client.TestAuthFileEnvKey)
 
-	err := ioutil.WriteFile(outfile, []byte(`{"macaroon":"macaroon","discharges":["discharged"]}`), 0600)
+	err := os.WriteFile(outfile, []byte(`{"macaroon":"macaroon","discharges":["discharged"]}`), 0600)
 	c.Assert(err, check.IsNil)
 
 	err = cs.cli.Logout()

--- a/client/model_test.go
+++ b/client/model_test.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -190,10 +191,10 @@ func (cs *clientSuite) TestClientOfflineRemodel(c *C) {
 
 	var err error
 	snapPaths := []string{filepath.Join(dirs.GlobalRootDir, "snap1.snap")}
-	err = ioutil.WriteFile(snapPaths[0], []byte("snap1"), 0644)
+	err = os.WriteFile(snapPaths[0], []byte("snap1"), 0644)
 	c.Assert(err, IsNil)
 	assertsPaths := []string{filepath.Join(dirs.GlobalRootDir, "f1.asserts")}
-	err = ioutil.WriteFile(assertsPaths[0], []byte("asserts1"), 0644)
+	err = os.WriteFile(assertsPaths[0], []byte("asserts1"), 0644)
 	c.Assert(err, IsNil)
 
 	id, err := cs.cli.RemodelOffline(rawModel, snapPaths, assertsPaths)
@@ -237,10 +238,10 @@ func (cs *clientSuite) TestClientOfflineRemodelServerError(c *C) {
 
 	var err error
 	snapPaths := []string{filepath.Join(dirs.GlobalRootDir, "snap1.snap")}
-	err = ioutil.WriteFile(snapPaths[0], []byte("snap1"), 0644)
+	err = os.WriteFile(snapPaths[0], []byte("snap1"), 0644)
 	c.Assert(err, IsNil)
 	assertsPaths := []string{filepath.Join(dirs.GlobalRootDir, "f1.asserts")}
-	err = ioutil.WriteFile(assertsPaths[0], []byte("asserts1"), 0644)
+	err = os.WriteFile(assertsPaths[0], []byte("asserts1"), 0644)
 	c.Assert(err, IsNil)
 
 	id, err := cs.cli.RemodelOffline(rawModel, snapPaths, assertsPaths)

--- a/client/packages_test.go
+++ b/client/packages_test.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"time"
@@ -430,7 +429,7 @@ func (cs *clientSuite) TestClientFindFromPathErrIsWrapped(c *check.C) {
 	var e client.AuthorizationError
 
 	// this will trigger a "client.AuthorizationError"
-	err := ioutil.WriteFile(client.TestStoreAuthFilename(os.Getenv("HOME")), []byte("rubbish"), 0644)
+	err := os.WriteFile(client.TestStoreAuthFilename(os.Getenv("HOME")), []byte("rubbish"), 0644)
 	c.Assert(err, check.IsNil)
 
 	// check that all the functions that use snapsFromPath() get a

--- a/client/snap_op_test.go
+++ b/client/snap_op_test.go
@@ -28,6 +28,7 @@ import (
 	"mime"
 	"mime/multipart"
 	"net/http"
+	"os"
 	"path/filepath"
 
 	"gopkg.in/check.v1"
@@ -289,7 +290,7 @@ func (cs *clientSuite) TestClientOpInstallPath(c *check.C) {
 	bodyData := []byte("snap-data")
 
 	snap := filepath.Join(c.MkDir(), "foo.snap")
-	err := ioutil.WriteFile(snap, bodyData, 0644)
+	err := os.WriteFile(snap, bodyData, 0644)
 	c.Assert(err, check.IsNil)
 
 	id, err := cs.cli.InstallPath(snap, "", nil)
@@ -319,7 +320,7 @@ func (cs *clientSuite) TestClientOpInstallPathIgnoreRunning(c *check.C) {
 	bodyData := []byte("snap-data")
 
 	snap := filepath.Join(c.MkDir(), "foo.snap")
-	err := ioutil.WriteFile(snap, bodyData, 0644)
+	err := os.WriteFile(snap, bodyData, 0644)
 	c.Assert(err, check.IsNil)
 
 	id, err := cs.cli.InstallPath(snap, "", &client.SnapOptions{IgnoreRunning: true})
@@ -350,7 +351,7 @@ func (cs *clientSuite) TestClientOpInstallPathInstance(c *check.C) {
 	bodyData := []byte("snap-data")
 
 	snap := filepath.Join(c.MkDir(), "foo.snap")
-	err := ioutil.WriteFile(snap, bodyData, 0644)
+	err := os.WriteFile(snap, bodyData, 0644)
 	c.Assert(err, check.IsNil)
 
 	id, err := cs.cli.InstallPath(snap, "foo_bar", nil)
@@ -382,7 +383,7 @@ func (cs *clientSuite) TestClientOpInstallPathMany(c *check.C) {
 	for _, name := range names {
 		path := filepath.Join(c.MkDir(), name)
 		paths = append(paths, path)
-		c.Assert(ioutil.WriteFile(path, []byte("snap-data"), 0644), check.IsNil)
+		c.Assert(os.WriteFile(path, []byte("snap-data"), 0644), check.IsNil)
 	}
 
 	id, err := cs.cli.InstallPathMany(paths, nil)
@@ -419,7 +420,7 @@ func (cs *clientSuite) TestClientOpInstallPathManyTransactionally(c *check.C) {
 	for _, name := range names {
 		path := filepath.Join(c.MkDir(), name)
 		paths = append(paths, path)
-		c.Assert(ioutil.WriteFile(path, []byte("snap-data"), 0644), check.IsNil)
+		c.Assert(os.WriteFile(path, []byte("snap-data"), 0644), check.IsNil)
 	}
 
 	id, err := cs.cli.InstallPathMany(paths, &client.SnapOptions{Transaction: client.TransactionAllSnaps})
@@ -456,7 +457,7 @@ func (cs *clientSuite) TestClientOpInstallPathManyWithOptions(c *check.C) {
 	for _, name := range []string{"foo.snap", "bar.snap"} {
 		path := filepath.Join(c.MkDir(), name)
 		paths = append(paths, path)
-		c.Assert(ioutil.WriteFile(path, []byte("snap-data"), 0644), check.IsNil)
+		c.Assert(os.WriteFile(path, []byte("snap-data"), 0644), check.IsNil)
 	}
 
 	// InstallPathMany supports opts
@@ -488,7 +489,7 @@ func (cs *clientSuite) TestClientOpInstallPathManyWithQuotaGroup(c *check.C) {
 	for _, name := range []string{"foo.snap", "bar.snap"} {
 		path := filepath.Join(c.MkDir(), name)
 		paths = append(paths, path)
-		c.Assert(ioutil.WriteFile(path, []byte("snap-data"), 0644), check.IsNil)
+		c.Assert(os.WriteFile(path, []byte("snap-data"), 0644), check.IsNil)
 	}
 
 	// Verify that the quota group option is serialized as a part of multipart form.
@@ -516,7 +517,7 @@ func (cs *clientSuite) TestClientOpInstallDangerous(c *check.C) {
 	bodyData := []byte("snap-data")
 
 	snap := filepath.Join(c.MkDir(), "foo.snap")
-	err := ioutil.WriteFile(snap, bodyData, 0644)
+	err := os.WriteFile(snap, bodyData, 0644)
 	c.Assert(err, check.IsNil)
 
 	opts := client.SnapOptions{
@@ -551,7 +552,7 @@ func (cs *clientSuite) TestClientOpInstallUnaliased(c *check.C) {
 	bodyData := []byte("snap-data")
 
 	snap := filepath.Join(c.MkDir(), "foo.snap")
-	err := ioutil.WriteFile(snap, bodyData, 0644)
+	err := os.WriteFile(snap, bodyData, 0644)
 	c.Assert(err, check.IsNil)
 
 	opts := client.SnapOptions{
@@ -587,7 +588,7 @@ func (cs *clientSuite) TestClientOpInstallTransactional(c *check.C) {
 	bodyData := []byte("snap-data")
 
 	snap := filepath.Join(c.MkDir(), "foo.snap")
-	err := ioutil.WriteFile(snap, bodyData, 0644)
+	err := os.WriteFile(snap, bodyData, 0644)
 	c.Assert(err, check.IsNil)
 
 	opts := client.SnapOptions{
@@ -625,7 +626,7 @@ func (cs *clientSuite) TestClientOpInstallPrefer(c *check.C) {
 	bodyData := []byte("snap-data")
 
 	snap := filepath.Join(c.MkDir(), "foo.snap")
-	err := ioutil.WriteFile(snap, bodyData, 0644)
+	err := os.WriteFile(snap, bodyData, 0644)
 	c.Assert(err, check.IsNil)
 
 	opts := client.SnapOptions{

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -128,7 +128,7 @@ func stampedAction(stamp string, action func() error) error {
 	if err := action(); err != nil {
 		return err
 	}
-	return ioutil.WriteFile(stampFile, nil, 0644)
+	return os.WriteFile(stampFile, nil, 0644)
 }
 
 func generateInitramfsMounts() (err error) {
@@ -525,7 +525,7 @@ func disableConsoleConf(dst string) error {
 	if err := os.MkdirAll(filepath.Dir(consoleConfCompleteFile), 0755); err != nil {
 		return err
 	}
-	return ioutil.WriteFile(consoleConfCompleteFile, nil, 0644)
+	return os.WriteFile(consoleConfCompleteFile, nil, 0644)
 }
 
 // copySafeDefaultData will copy to the destination a "safe" set of data for
@@ -670,7 +670,7 @@ func (r *recoverDegradedState) serializeTo(name string) error {
 	}
 
 	// leave the information about degraded state at an ephemeral location
-	return ioutil.WriteFile(filepath.Join(dirs.SnapBootstrapRunDir, name), b, 0644)
+	return os.WriteFile(filepath.Join(dirs.SnapBootstrapRunDir, name), b, 0644)
 }
 
 // stateFunc is a function which executes a state action, returns the next

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -343,17 +343,17 @@ func (s *baseInitramfsMountsSuite) SetUpTest(c *C) {
 	s.byLabelDir = filepath.Join(s.tmpDir, "dev/disk/by-label")
 	err = os.MkdirAll(s.byLabelDir, 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(s.tmpDir, "dev/sda1"), nil, 0644)
+	err = os.WriteFile(filepath.Join(s.tmpDir, "dev/sda1"), nil, 0644)
 	c.Assert(err, IsNil)
 	err = os.Symlink("../../sda1", filepath.Join(s.byLabelDir, "ubuntu-seed"))
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(s.tmpDir, "dev/sda2"), nil, 0644)
+	err = os.WriteFile(filepath.Join(s.tmpDir, "dev/sda2"), nil, 0644)
 	c.Assert(err, IsNil)
 	err = os.Symlink("../../sda2", filepath.Join(s.byLabelDir, "ubuntu-boot"))
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(s.byLabelDir, "ubuntu-boot"), nil, 0644)
+	err = os.WriteFile(filepath.Join(s.byLabelDir, "ubuntu-boot"), nil, 0644)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(s.tmpDir, "dev/sda"), nil, 0644)
+	err = os.WriteFile(filepath.Join(s.tmpDir, "dev/sda"), nil, 0644)
 	c.Assert(err, IsNil)
 
 	// make test snap PlaceInfo's for various boot functionality
@@ -513,14 +513,14 @@ func (s *baseInitramfsMountsSuite) makeSnapFilesOnEarlyBootUbuntuData(c *C, snap
 	c.Assert(err, IsNil)
 	for _, sn := range snaps {
 		snFilename := sn.Filename()
-		err = ioutil.WriteFile(filepath.Join(snapDir, snFilename), nil, 0644)
+		err = os.WriteFile(filepath.Join(snapDir, snFilename), nil, 0644)
 		c.Assert(err, IsNil)
 	}
 }
 
 func (s *baseInitramfsMountsSuite) mockProcCmdlineContent(c *C, newContent string) {
 	mockProcCmdline := filepath.Join(c.MkDir(), "proc-cmdline")
-	err := ioutil.WriteFile(mockProcCmdline, []byte(newContent), 0644)
+	err := os.WriteFile(mockProcCmdline, []byte(newContent), 0644)
 	c.Assert(err, IsNil)
 	restore := kcmdline.MockProcCmdline(mockProcCmdline)
 	s.AddCleanup(restore)
@@ -529,18 +529,18 @@ func (s *baseInitramfsMountsSuite) mockProcCmdlineContent(c *C, newContent strin
 func (s *baseInitramfsMountsSuite) mockUbuntuSaveKeyAndMarker(c *C, rootDir, key, marker string) {
 	keyPath := filepath.Join(dirs.SnapFDEDirUnder(rootDir), "ubuntu-save.key")
 	c.Assert(os.MkdirAll(filepath.Dir(keyPath), 0700), IsNil)
-	c.Assert(ioutil.WriteFile(keyPath, []byte(key), 0600), IsNil)
+	c.Assert(os.WriteFile(keyPath, []byte(key), 0600), IsNil)
 
 	if marker != "" {
 		markerPath := filepath.Join(dirs.SnapFDEDirUnder(rootDir), "marker")
-		c.Assert(ioutil.WriteFile(markerPath, []byte(marker), 0600), IsNil)
+		c.Assert(os.WriteFile(markerPath, []byte(marker), 0600), IsNil)
 	}
 }
 
 func (s *baseInitramfsMountsSuite) mockUbuntuSaveMarker(c *C, rootDir, marker string) {
 	markerPath := filepath.Join(rootDir, "device/fde", "marker")
 	c.Assert(os.MkdirAll(filepath.Dir(markerPath), 0700), IsNil)
-	c.Assert(ioutil.WriteFile(markerPath, []byte(marker), 0600), IsNil)
+	c.Assert(os.WriteFile(markerPath, []byte(marker), 0600), IsNil)
 }
 
 func (s *initramfsMountsSuite) TestInitramfsMountsNoModeError(c *C) {
@@ -3061,9 +3061,9 @@ func (s *initramfsMountsSuite) TestInitramfsMountsRunModeUpgradeScenarios(c *C) 
 		var err error
 		err = os.MkdirAll(s.byLabelDir, 0755)
 		c.Assert(err, IsNil)
-		err = ioutil.WriteFile(filepath.Join(s.byLabelDir, "ubuntu-seed"), nil, 0644)
+		err = os.WriteFile(filepath.Join(s.byLabelDir, "ubuntu-seed"), nil, 0644)
 		c.Assert(err, IsNil)
-		err = ioutil.WriteFile(filepath.Join(s.byLabelDir, "ubuntu-boot"), nil, 0644)
+		err = os.WriteFile(filepath.Join(s.byLabelDir, "ubuntu-boot"), nil, 0644)
 		c.Assert(err, IsNil)
 
 		restore := disks.MockMountPointDisksToPartitionMapping(
@@ -3272,14 +3272,14 @@ func (s *initramfsMountsSuite) testRecoverModeHappy(c *C) {
 		err = os.MkdirAll(filepath.Dir(p), 0750)
 		c.Assert(err, IsNil)
 		mockContent := fmt.Sprintf("content of %s", filepath.Base(mockFile))
-		err = ioutil.WriteFile(p, []byte(mockContent), 0640)
+		err = os.WriteFile(p, []byte(mockContent), 0640)
 		c.Assert(err, IsNil)
 	}
 	// create a mock state
 	mockedState := filepath.Join(hostUbuntuData, "system-data/var/lib/snapd/state.json")
 	err = os.MkdirAll(filepath.Dir(mockedState), 0750)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(mockedState, []byte(mockStateContent), 0640)
+	err = os.WriteFile(mockedState, []byte(mockStateContent), 0640)
 	c.Assert(err, IsNil)
 
 	_, err = main.Parser().ParseArgs([]string{"initramfs-mounts"})
@@ -6198,7 +6198,7 @@ func (s *baseInitramfsMountsSuite) testInitramfsMountsTryRecoveryHappy(c *C, hap
 		mockedState = filepath.Join(hostUbuntuData, "system-data/var/lib/snapd/state.json")
 	}
 	c.Assert(os.MkdirAll(filepath.Dir(mockedState), 0750), IsNil)
-	c.Assert(ioutil.WriteFile(mockedState, []byte(mockStateContent), 0640), IsNil)
+	c.Assert(os.WriteFile(mockedState, []byte(mockStateContent), 0640), IsNil)
 
 	const triedSystem = true
 	err := s.runInitramfsMountsUnencryptedTryRecovery(c, triedSystem)
@@ -6348,7 +6348,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsTryRecoveryDifferentSystem(c *
 	hostUbuntuData := filepath.Join(boot.InitramfsRunMntDir, "host/ubuntu-data/")
 	mockedState := filepath.Join(hostUbuntuData, "system-data/var/lib/snapd/state.json")
 	c.Assert(os.MkdirAll(filepath.Dir(mockedState), 0750), IsNil)
-	c.Assert(ioutil.WriteFile(mockedState, []byte(mockStateContent), 0640), IsNil)
+	c.Assert(os.WriteFile(mockedState, []byte(mockStateContent), 0640), IsNil)
 
 	const triedSystem = false
 	err := s.runInitramfsMountsUnencryptedTryRecovery(c, triedSystem)
@@ -6607,7 +6607,7 @@ func (s *initramfsMountsSuite) TestInitramfsMountsTryRecoveryHealthCheckFails(c 
 	hostUbuntuData := filepath.Join(boot.InitramfsRunMntDir, "host/ubuntu-data/")
 	mockedState := filepath.Join(hostUbuntuData, "system-data/var/lib/snapd/state.json")
 	c.Assert(os.MkdirAll(filepath.Dir(mockedState), 0750), IsNil)
-	c.Assert(ioutil.WriteFile(mockedState, []byte(mockStateContent), 0640), IsNil)
+	c.Assert(os.WriteFile(mockedState, []byte(mockStateContent), 0640), IsNil)
 
 	restore = main.MockTryRecoverySystemHealthCheck(func(gadget.Model) error {
 		return fmt.Errorf("mock failure")
@@ -6683,7 +6683,7 @@ func (s *initramfsMountsSuite) TestMountNonDataPartitionNoPollNoLogMsg(c *C) {
 	fakedPartSrc := filepath.Join(dirs.GlobalRootDir, "/dev/disk/by-partuuid/some-uuid")
 	err := os.MkdirAll(filepath.Dir(fakedPartSrc), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(fakedPartSrc, nil, 0644)
+	err = os.WriteFile(fakedPartSrc, nil, 0644)
 	c.Assert(err, IsNil)
 
 	err = main.MountNonDataPartitionMatchingKernelDisk("some-target", "")
@@ -6699,7 +6699,7 @@ func (s *initramfsMountsSuite) TestWaitFileErr(c *C) {
 
 func (s *initramfsMountsSuite) TestWaitFile(c *C) {
 	existingPartSrc := filepath.Join(c.MkDir(), "does-exist")
-	err := ioutil.WriteFile(existingPartSrc, nil, 0644)
+	err := os.WriteFile(existingPartSrc, nil, 0644)
 	c.Assert(err, IsNil)
 
 	err = main.WaitFile(existingPartSrc, 5000*time.Second, 1)
@@ -6713,7 +6713,7 @@ func (s *initramfsMountsSuite) TestWaitFileWorksWithFilesAppearingLate(c *C) {
 	eventuallyExists := filepath.Join(c.MkDir(), "eventually-exists")
 	go func() {
 		time.Sleep(40 * time.Millisecond)
-		err := ioutil.WriteFile(eventuallyExists, nil, 0644)
+		err := os.WriteFile(eventuallyExists, nil, 0644)
 		c.Assert(err, IsNil)
 	}()
 
@@ -7906,9 +7906,9 @@ func (s *initramfsMountsSuite) TestGetDiskNotUEFINotKernelCmdlineFail(c *C) {
 	c.Assert(err.Error(), Equals, `no candidate found for label "ubuntu-seed"`)
 	c.Assert(path, Equals, "")
 
-	err = ioutil.WriteFile(filepath.Join(s.byLabelDir, "UBUNTU-SEED"), nil, 0644)
+	err = os.WriteFile(filepath.Join(s.byLabelDir, "UBUNTU-SEED"), nil, 0644)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(s.byLabelDir, "UBUNTU-FOO"), nil, 0644)
+	err = os.WriteFile(filepath.Join(s.byLabelDir, "UBUNTU-FOO"), nil, 0644)
 	c.Assert(err, IsNil)
 
 	// Mock udevadm calls
@@ -7933,7 +7933,7 @@ exit 0
 	c.Assert(path, Equals, "")
 
 	// More than one candidate
-	err = ioutil.WriteFile(filepath.Join(s.byLabelDir, "UBUNTU-seed"), nil, 0644)
+	err = os.WriteFile(filepath.Join(s.byLabelDir, "UBUNTU-seed"), nil, 0644)
 	path, err = main.GetNonUEFISystemDisk("ubuntu-seed")
 	c.Assert(err.Error(), Equals, `more than one candidate for label "ubuntu-seed"`)
 	c.Assert(path, Equals, "")
@@ -7954,7 +7954,7 @@ func (s *initramfsMountsSuite) TestGetDiskNotUEFINotKernelCmdlineOk(c *C) {
 
 	err := os.Remove(filepath.Join(s.byLabelDir, "ubuntu-seed"))
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(s.byLabelDir, "UBUNTU-SEED"), nil, 0644)
+	err = os.WriteFile(filepath.Join(s.byLabelDir, "UBUNTU-SEED"), nil, 0644)
 	c.Assert(err, IsNil)
 
 	path, err := main.GetNonUEFISystemDisk("ubuntu-seed")
@@ -7988,7 +7988,7 @@ func (s *initramfsMountsSuite) TestGetDiskNotUEFINotKernelCmdlineSomeItersOk(c *
 	// Wait a bit so we get at least an iteration
 	time.Sleep(50 * time.Millisecond)
 	// Now create a file that matches the label
-	err = ioutil.WriteFile(filepath.Join(s.byLabelDir, "UBUNTU-SEED"), nil, 0644)
+	err = os.WriteFile(filepath.Join(s.byLabelDir, "UBUNTU-SEED"), nil, 0644)
 	c.Assert(err, IsNil)
 
 	<-ch
@@ -8006,7 +8006,7 @@ func (s *initramfsMountsSuite) TestGetDiskNotUEFINotKernelCmdlineFailNoFs(c *C) 
 
 	err := os.Remove(filepath.Join(s.byLabelDir, "ubuntu-seed"))
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(s.byLabelDir, "UBUNTU-SEED"), nil, 0644)
+	err = os.WriteFile(filepath.Join(s.byLabelDir, "UBUNTU-SEED"), nil, 0644)
 	c.Assert(err, IsNil)
 
 	path, err := main.GetNonUEFISystemDisk("ubuntu-seed")
@@ -8052,11 +8052,11 @@ func (s *initramfsMountsSuite) TestInitramfsMountsInstallAndRunMissingFdeSetup(c
 
 	systemDir := filepath.Join(boot.InitramfsUbuntuSeedDir, "systems", s.sysLabel)
 	c.Assert(os.MkdirAll(filepath.Join(boot.InitramfsUbuntuSeedDir, "systems", s.sysLabel), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(systemDir, "preseed.tgz"), []byte{}, 0640), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(systemDir, "preseed.tgz"), []byte{}, 0640), IsNil)
 
 	fdeSetupHook := filepath.Join(boot.InitramfsRunMntDir, "kernel", "meta", "hooks", "fde-setup")
 	c.Assert(os.MkdirAll(filepath.Dir(fdeSetupHook), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(fdeSetupHook, []byte{}, 0555), IsNil)
+	c.Assert(os.WriteFile(fdeSetupHook, []byte{}, 0555), IsNil)
 
 	// ensure that we check that access to sealed keys were locked
 	sealedKeysLocked := false
@@ -8100,14 +8100,14 @@ func (s *initramfsMountsSuite) TestInitramfsMountsInstallAndRunFdeSetupPresent(c
 
 	systemDir := filepath.Join(boot.InitramfsUbuntuSeedDir, "systems", s.sysLabel)
 	c.Assert(os.MkdirAll(filepath.Join(boot.InitramfsUbuntuSeedDir, "systems", s.sysLabel), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(systemDir, "preseed.tgz"), []byte{}, 0640), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(systemDir, "preseed.tgz"), []byte{}, 0640), IsNil)
 
 	fdeSetupHook := filepath.Join(boot.InitramfsRunMntDir, "kernel", "meta", "hooks", "fde-setup")
 	c.Assert(os.MkdirAll(filepath.Dir(fdeSetupHook), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(fdeSetupHook, []byte{}, 0555), IsNil)
+	c.Assert(os.WriteFile(fdeSetupHook, []byte{}, 0555), IsNil)
 	fdeRevealKeyHook := filepath.Join(boot.InitramfsRunMntDir, "kernel", "meta", "hooks", "fde-reveal-key")
 	c.Assert(os.MkdirAll(filepath.Dir(fdeRevealKeyHook), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(fdeRevealKeyHook, []byte{}, 0555), IsNil)
+	c.Assert(os.WriteFile(fdeRevealKeyHook, []byte{}, 0555), IsNil)
 
 	fdeSetupMock := testutil.MockCommand(c, "fde-setup", fmt.Sprintf(`
 tmpdir='%s'
@@ -8122,28 +8122,28 @@ echo '{"features":[]}'
 	kernelSnapYaml := filepath.Join(boot.InitramfsRunMntDir, "kernel", "meta", "snap.yaml")
 	c.Assert(os.MkdirAll(filepath.Dir(kernelSnapYaml), 0755), IsNil)
 	kernelSnapYamlContent := `{}`
-	c.Assert(ioutil.WriteFile(kernelSnapYaml, []byte(kernelSnapYamlContent), 0555), IsNil)
+	c.Assert(os.WriteFile(kernelSnapYaml, []byte(kernelSnapYamlContent), 0555), IsNil)
 
 	baseSnapYaml := filepath.Join(boot.InitramfsRunMntDir, "base", "meta", "snap.yaml")
 	c.Assert(os.MkdirAll(filepath.Dir(baseSnapYaml), 0755), IsNil)
 	baseSnapYamlContent := `{}`
-	c.Assert(ioutil.WriteFile(baseSnapYaml, []byte(baseSnapYamlContent), 0555), IsNil)
+	c.Assert(os.WriteFile(baseSnapYaml, []byte(baseSnapYamlContent), 0555), IsNil)
 
 	gadgetSnapYaml := filepath.Join(boot.InitramfsRunMntDir, "gadget", "meta", "snap.yaml")
 	c.Assert(os.MkdirAll(filepath.Dir(gadgetSnapYaml), 0755), IsNil)
 	gadgetSnapYamlContent := `{}`
-	c.Assert(ioutil.WriteFile(gadgetSnapYaml, []byte(gadgetSnapYamlContent), 0555), IsNil)
+	c.Assert(os.WriteFile(gadgetSnapYaml, []byte(gadgetSnapYamlContent), 0555), IsNil)
 
 	grubConf := filepath.Join(boot.InitramfsRunMntDir, "gadget", "grub.conf")
 	c.Assert(os.MkdirAll(filepath.Dir(grubConf), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(grubConf, nil, 0555), IsNil)
+	c.Assert(os.WriteFile(grubConf, nil, 0555), IsNil)
 
 	bootloader := filepath.Join(boot.InitramfsRunMntDir, "ubuntu-seed", "EFI", "boot", fmt.Sprintf("boot%s.efi", efiArch))
 	c.Assert(os.MkdirAll(filepath.Dir(bootloader), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(bootloader, nil, 0555), IsNil)
+	c.Assert(os.WriteFile(bootloader, nil, 0555), IsNil)
 	grub := filepath.Join(boot.InitramfsRunMntDir, "ubuntu-seed", "EFI", "boot", fmt.Sprintf("grub%s.efi", efiArch))
 	c.Assert(os.MkdirAll(filepath.Dir(grub), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(grub, nil, 0555), IsNil)
+	c.Assert(os.WriteFile(grub, nil, 0555), IsNil)
 
 	writeGadget(c, "ubuntu-seed", "system-seed", "")
 
@@ -8244,15 +8244,15 @@ func (s *initramfsMountsSuite) TestInitramfsMountsInstallAndRunInstallDeviceHook
 
 	systemDir := filepath.Join(boot.InitramfsUbuntuSeedDir, "systems", s.sysLabel)
 	c.Assert(os.MkdirAll(filepath.Join(boot.InitramfsUbuntuSeedDir, "systems", s.sysLabel), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(systemDir, "preseed.tgz"), []byte{}, 0640), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(systemDir, "preseed.tgz"), []byte{}, 0640), IsNil)
 
 	installDeviceHook := filepath.Join(boot.InitramfsRunMntDir, "gadget", "meta", "hooks", "install-device")
 	c.Assert(os.MkdirAll(filepath.Dir(installDeviceHook), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(installDeviceHook, []byte{}, 0555), IsNil)
+	c.Assert(os.WriteFile(installDeviceHook, []byte{}, 0555), IsNil)
 
 	fdeSetupHook := filepath.Join(boot.InitramfsRunMntDir, "kernel", "meta", "hooks", "fde-setup")
 	c.Assert(os.MkdirAll(filepath.Dir(fdeSetupHook), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(fdeSetupHook, []byte{}, 0555), IsNil)
+	c.Assert(os.WriteFile(fdeSetupHook, []byte{}, 0555), IsNil)
 
 	cmd := testutil.MockCommand(c, "fde-setup", ``)
 	defer cmd.Restore()

--- a/cmd/snap-bootstrap/cmd_recovery_chooser_trigger_test.go
+++ b/cmd/snap-bootstrap/cmd_recovery_chooser_trigger_test.go
@@ -21,7 +21,7 @@ package main_test
 
 import (
 	"errors"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -115,7 +115,7 @@ func (s *cmdSuite) TestRecoveryChooserTriggerDoesNothingWhenMarkerPresent(c *C) 
 	})
 	defer restore()
 
-	err := ioutil.WriteFile(marker, nil, 0644)
+	err := os.WriteFile(marker, nil, 0644)
 	c.Assert(err, IsNil)
 
 	rest, err := main.Parser().ParseArgs([]string{

--- a/cmd/snap-bootstrap/initramfs_systemd_mount.go
+++ b/cmd/snap-bootstrap/initramfs_systemd_mount.go
@@ -21,7 +21,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -177,7 +176,7 @@ func doSystemdMountImpl(what, where string, opts *systemdMountOptions) error {
 			// unit so that when we isolate to the initrd unit, it does not get
 			// unmounted
 			fname := fmt.Sprintf("snap_bootstrap_%s.conf", whereEscaped)
-			err = ioutil.WriteFile(filepath.Join(targetDir, fname), overrideContent, 0644)
+			err = os.WriteFile(filepath.Join(targetDir, fname), overrideContent, 0644)
 			if err != nil {
 				return err
 			}

--- a/cmd/snap-exec/main_test.go
+++ b/cmd/snap-exec/main_test.go
@@ -21,7 +21,6 @@ package main_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -364,7 +363,7 @@ func (s *snapExecSuite) TestSnapExecAppRealIntegration(c *C) {
 
 	canaryFile := filepath.Join(c.MkDir(), "canary.txt")
 	script := fmt.Sprintf("%s/snapname/42/run-app", dirs.SnapMountDir)
-	err := ioutil.WriteFile(script, []byte(fmt.Sprintf(binaryTemplate, canaryFile)), 0755)
+	err := os.WriteFile(script, []byte(fmt.Sprintf(binaryTemplate, canaryFile)), 0755)
 	c.Assert(err, IsNil)
 
 	// we can not use the real syscall.execv here because it would

--- a/cmd/snap-failure/cmd_snapd_test.go
+++ b/cmd/snap-failure/cmd_snapd_test.go
@@ -21,7 +21,6 @@ package main_test
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -59,7 +58,7 @@ func writeSeqFile(c *C, name string, current snap.Revision, seq []*snap.SideInfo
 	})
 	c.Assert(err, IsNil)
 
-	err = ioutil.WriteFile(seqPath, b, 0644)
+	err = os.WriteFile(seqPath, b, 0644)
 	c.Assert(err, IsNil)
 }
 
@@ -165,9 +164,9 @@ fi
 	// mock the sockets re-appearing
 	err := os.MkdirAll(filepath.Dir(dirs.SnapdSocket), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(dirs.SnapdSocket, nil, 0755)
+	err = os.WriteFile(dirs.SnapdSocket, nil, 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(dirs.SnapSocket, nil, 0755)
+	err = os.WriteFile(dirs.SnapSocket, nil, 0755)
 	c.Assert(err, IsNil)
 
 	os.Args = []string{"snap-failure", "snapd"}
@@ -338,7 +337,7 @@ func (r *failureSuite) TestGarbageSeq(c *C) {
 	err := os.MkdirAll(dirs.SnapSeqDir, 0755)
 	c.Assert(err, IsNil)
 
-	err = ioutil.WriteFile(seqPath, []byte("this is garbage"), 0644)
+	err = os.WriteFile(seqPath, []byte("this is garbage"), 0644)
 	c.Assert(err, IsNil)
 
 	snapdCmd := testutil.MockCommand(c, filepath.Join(dirs.SnapMountDir, "snapd", "100", "/usr/lib/snapd/snapd"),
@@ -421,7 +420,7 @@ func (r *failureSuite) TestStickySnapdSocket(c *C) {
 
 	err := os.MkdirAll(filepath.Dir(dirs.SnapdSocket), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(dirs.SnapdSocket, []byte{}, 0755)
+	err = os.WriteFile(dirs.SnapdSocket, []byte{}, 0755)
 	c.Assert(err, IsNil)
 
 	// mock snapd in the core snap

--- a/cmd/snap-fde-keymgr/main_test.go
+++ b/cmd/snap-fde-keymgr/main_test.go
@@ -22,7 +22,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -67,7 +67,7 @@ func (s *mainSuite) TestAddKey(c *C) {
 		return nil
 	})
 	defer restore()
-	c.Assert(ioutil.WriteFile(filepath.Join(d, "authz.key"), []byte{1, 1, 1}, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(d, "authz.key"), []byte{1, 1, 1}, 0644), IsNil)
 	err := main.Run([]string{
 		"add-recovery-key",
 		"--devices", "/dev/vda4",
@@ -159,9 +159,9 @@ type addKeyTestCase struct {
 
 func (s *mainSuite) testAddKeyIdempotent(c *C, tc addKeyTestCase) {
 	d := c.MkDir()
-	c.Assert(ioutil.WriteFile(filepath.Join(d, "authz.key"), []byte{1, 1, 1}, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(d, "authz.key"), []byte{1, 1, 1}, 0644), IsNil)
 	rkey := keys.RecoveryKey{'r', 'e', 'c', 'o', 'v', 'e', 'r', 'y'}
-	c.Assert(ioutil.WriteFile(filepath.Join(d, "recovery.key"), rkey[:], 0600), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(d, "recovery.key"), rkey[:], 0600), IsNil)
 
 	addCalls := 0
 	restore := main.MockAddRecoveryKeyToLUKS(func(recoveryKey keys.RecoveryKey, luksDev string) error {
@@ -261,9 +261,9 @@ func (s *mainSuite) TestRemoveKey(c *C) {
 	defer restore()
 	d := c.MkDir()
 	// key which will be removed
-	c.Assert(ioutil.WriteFile(filepath.Join(d, "recovery.key"), []byte{0, 0, 0}, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(d, "recovery.key"), []byte{0, 0, 0}, 0644), IsNil)
 
-	c.Assert(ioutil.WriteFile(filepath.Join(d, "authz.key"), []byte{1, 1, 1}, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(d, "authz.key"), []byte{1, 1, 1}, 0644), IsNil)
 	err := main.Run([]string{
 		"remove-recovery-key",
 		"--devices", "/dev/vda4",

--- a/cmd/snap-preseed/preseed_uc20_test.go
+++ b/cmd/snap-preseed/preseed_uc20_test.go
@@ -20,7 +20,6 @@
 package main_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -43,7 +42,7 @@ func (s *startPreseedSuite) TestRunPreseedUC20Happy(c *C) {
 	// for UC20 probing
 	c.Assert(os.MkdirAll(filepath.Join(tmpDir, "system-seed/systems/20220203"), 0755), IsNil)
 	// we don't run tar, so create a fake artifact to make FileDigest happy
-	c.Assert(ioutil.WriteFile(filepath.Join(tmpDir, "system-seed/systems/20220203/preseed.tgz"), nil, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(tmpDir, "system-seed/systems/20220203/preseed.tgz"), nil, 0644), IsNil)
 
 	var called bool
 	restorePreseed := main.MockPreseedCore20(func(opts *preseed.CoreOptions) error {
@@ -72,7 +71,7 @@ func (s *startPreseedSuite) TestRunPreseedUC20HappyNoArgs(c *C) {
 
 	// for UC20 probing
 	c.Assert(os.MkdirAll(filepath.Join(tmpDir, "system-seed/systems/20220203"), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(tmpDir, "system-seed/systems/20220203/preseed.tgz"), nil, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(tmpDir, "system-seed/systems/20220203/preseed.tgz"), nil, 0644), IsNil)
 
 	var called bool
 	restorePreseed := main.MockPreseedCore20(func(opts *preseed.CoreOptions) error {
@@ -102,7 +101,7 @@ func (s *startPreseedSuite) TestResetUC20(c *C) {
 	// for UC20 probing
 	c.Assert(os.MkdirAll(filepath.Join(tmpDir, "system-seed/systems/20220203"), 0755), IsNil)
 	// we don't run tar, so create a fake artifact to make FileDigest happy
-	c.Assert(ioutil.WriteFile(filepath.Join(tmpDir, "system-seed/systems/20220203/preseed.tgz"), nil, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(tmpDir, "system-seed/systems/20220203/preseed.tgz"), nil, 0644), IsNil)
 
 	var called bool
 	restorePreseed := main.MockPreseedCore20(func(opts *preseed.CoreOptions) error {

--- a/cmd/snap-recovery-chooser/main_test.go
+++ b/cmd/snap-recovery-chooser/main_test.go
@@ -61,7 +61,7 @@ func (s *baseCmdSuite) SetUpTest(c *C) {
 
 	d := c.MkDir()
 	s.markerFile = filepath.Join(d, "marker")
-	err := ioutil.WriteFile(s.markerFile, nil, 0644)
+	err := os.WriteFile(s.markerFile, nil, 0644)
 	c.Assert(err, IsNil)
 }
 

--- a/cmd/snap-repair/runner_test.go
+++ b/cmd/snap-repair/runner_test.go
@@ -181,7 +181,7 @@ func (s *baseRunnerSuite) freshStateWithBaseAndMode(c *C, base, mode string) {
 	b, err := json.Marshal(stateJSON)
 	c.Assert(err, IsNil)
 
-	err = ioutil.WriteFile(dirs.SnapRepairStateFile, b, 0600)
+	err = os.WriteFile(dirs.SnapRepairStateFile, b, 0600)
 	c.Assert(err, IsNil)
 }
 
@@ -2223,7 +2223,7 @@ func (s *runner16Suite) SetUpTest(c *C) {
 	err := os.MkdirAll(s.seedAssertsDir, 0755)
 	c.Assert(err, IsNil)
 	seedYamlFn := filepath.Join(dirs.SnapSeedDir, "seed.yaml")
-	err = ioutil.WriteFile(seedYamlFn, nil, 0644)
+	err = os.WriteFile(seedYamlFn, nil, 0644)
 	c.Assert(err, IsNil)
 	seedTime, err := time.Parse(time.RFC3339, "2017-08-11T15:49:49Z")
 	c.Assert(err, IsNil)
@@ -2237,7 +2237,7 @@ func (s *runner16Suite) SetUpTest(c *C) {
 }
 
 func (s *runner16Suite) writeSeedAssert16(c *C, fname string, a asserts.Assertion) {
-	err := ioutil.WriteFile(filepath.Join(s.seedAssertsDir, fname), asserts.Encode(a), 0644)
+	err := os.WriteFile(filepath.Join(s.seedAssertsDir, fname), asserts.Encode(a), 0644)
 	c.Assert(err, IsNil)
 }
 
@@ -2265,7 +2265,7 @@ func (s *runner16Suite) TestLoadStateInitDeviceInfoFail(c *C) {
 		{func() {
 			// broken signature
 			blob := asserts.Encode(s.brandAcct)
-			err := ioutil.WriteFile(filepath.Join(s.seedAssertsDir, "brand.account"), blob[:len(blob)-3], 0644)
+			err := os.WriteFile(filepath.Join(s.seedAssertsDir, "brand.account"), blob[:len(blob)-3], 0644)
 			c.Assert(err, IsNil)
 		}, errPrefix + "cannot decode signature:.*"},
 		{func() { s.writeSeedAssert(c, "model2", s.modelAs) }, errPrefix + "multiple models in seed assertions"},
@@ -2310,7 +2310,7 @@ func (s *runner20Suite) SetUpTest(c *C) {
 	// write sample modeenv
 	err = os.MkdirAll(filepath.Dir(dirs.SnapModeenvFile), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(dirs.SnapModeenvFile, mockModeenv, 0644)
+	err = os.WriteFile(dirs.SnapModeenvFile, mockModeenv, 0644)
 	c.Assert(err, IsNil)
 	// validate that modeenv is actually valid
 	_, err = boot.ReadModeenv("")
@@ -2333,7 +2333,7 @@ func (s *runner20Suite) writeSeedAssert20(c *C, fname string, a asserts.Assertio
 	} else {
 		fn = filepath.Join(s.seedAssertsDir, fname)
 	}
-	err := ioutil.WriteFile(fn, asserts.Encode(a), 0644)
+	err := os.WriteFile(fn, asserts.Encode(a), 0644)
 	c.Assert(err, IsNil)
 
 	// ensure model assertion file has the correct seed time
@@ -2361,7 +2361,7 @@ func (s *runner20Suite) TestLoadStateInitDeviceInfoModeenvInvalidContent(c *C) {
 			`cannot set device information: cannot find brand/model in modeenv model string "brand-but-no-model"`,
 		},
 	} {
-		err := ioutil.WriteFile(dirs.SnapModeenvFile, []byte(tc.modelStr), 0644)
+		err := os.WriteFile(dirs.SnapModeenvFile, []byte(tc.modelStr), 0644)
 		c.Assert(err, IsNil)
 		err = runner.LoadState()
 		c.Check(err, ErrorMatches, tc.expectedErr)

--- a/cmd/snap-repair/trace_test.go
+++ b/cmd/snap-repair/trace_test.go
@@ -20,7 +20,6 @@
 package main_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -34,33 +33,33 @@ func makeMockRepairState(c *C) {
 	basedir := filepath.Join(dirs.SnapRepairRunDir, "canonical/1")
 	err := os.MkdirAll(basedir, 0700)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(basedir, "r3.retry"), []byte("repair: canonical-1\nsummary: repair one\noutput:\nretry output"), 0600)
+	err = os.WriteFile(filepath.Join(basedir, "r3.retry"), []byte("repair: canonical-1\nsummary: repair one\noutput:\nretry output"), 0600)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(basedir, "r3.script"), []byte("#!/bin/sh\necho retry output"), 0700)
+	err = os.WriteFile(filepath.Join(basedir, "r3.script"), []byte("#!/bin/sh\necho retry output"), 0700)
 	c.Assert(err, IsNil)
 
 	// my-brand
 	basedir = filepath.Join(dirs.SnapRepairRunDir, "my-brand/1")
 	err = os.MkdirAll(basedir, 0700)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(basedir, "r1.done"), []byte("repair: my-brand-1\nsummary: my-brand repair one\noutput:\ndone output"), 0600)
+	err = os.WriteFile(filepath.Join(basedir, "r1.done"), []byte("repair: my-brand-1\nsummary: my-brand repair one\noutput:\ndone output"), 0600)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(basedir, "r1.script"), []byte("#!/bin/sh\necho done output"), 0700)
+	err = os.WriteFile(filepath.Join(basedir, "r1.script"), []byte("#!/bin/sh\necho done output"), 0700)
 	c.Assert(err, IsNil)
 
 	basedir = filepath.Join(dirs.SnapRepairRunDir, "my-brand/2")
 	err = os.MkdirAll(basedir, 0700)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(basedir, "r2.skip"), []byte("repair: my-brand-2\nsummary: my-brand repair two\noutput:\nskip output"), 0600)
+	err = os.WriteFile(filepath.Join(basedir, "r2.skip"), []byte("repair: my-brand-2\nsummary: my-brand repair two\noutput:\nskip output"), 0600)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(basedir, "r2.script"), []byte("#!/bin/sh\necho skip output"), 0700)
+	err = os.WriteFile(filepath.Join(basedir, "r2.script"), []byte("#!/bin/sh\necho skip output"), 0700)
 	c.Assert(err, IsNil)
 
 	basedir = filepath.Join(dirs.SnapRepairRunDir, "my-brand/3")
 	err = os.MkdirAll(basedir, 0700)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(basedir, "r0.running"), []byte("repair: my-brand-3\nsummary: my-brand repair three\noutput:\nrunning output"), 0600)
+	err = os.WriteFile(filepath.Join(basedir, "r0.running"), []byte("repair: my-brand-3\nsummary: my-brand repair three\noutput:\nrunning output"), 0600)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(basedir, "r0.script"), []byte("#!/bin/sh\necho running output"), 0700)
+	err = os.WriteFile(filepath.Join(basedir, "r0.script"), []byte("#!/bin/sh\necho running output"), 0700)
 	c.Assert(err, IsNil)
 }

--- a/cmd/snap-seccomp/main_test.go
+++ b/cmd/snap-seccomp/main_test.go
@@ -21,7 +21,6 @@ package main_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -167,7 +166,7 @@ func (s *snapSeccompSuite) SetUpSuite(c *C) {
 
 	// build seccomp-load helper
 	s.seccompBpfLoader = filepath.Join(c.MkDir(), "seccomp_bpf_loader")
-	err := ioutil.WriteFile(s.seccompBpfLoader+".c", seccompBpfLoaderContent, 0644)
+	err := os.WriteFile(s.seccompBpfLoader+".c", seccompBpfLoaderContent, 0644)
 	c.Assert(err, IsNil)
 	cmd := exec.Command("gcc", "-Werror", "-Wall", s.seccompBpfLoader+".c", "-o", s.seccompBpfLoader)
 	cmd.Stdout = os.Stdout
@@ -177,7 +176,7 @@ func (s *snapSeccompSuite) SetUpSuite(c *C) {
 
 	// build syscall-runner helper
 	s.seccompSyscallRunner = filepath.Join(c.MkDir(), "seccomp_syscall_runner")
-	err = ioutil.WriteFile(s.seccompSyscallRunner+".c", seccompSyscallRunnerContent, 0644)
+	err = os.WriteFile(s.seccompSyscallRunner+".c", seccompSyscallRunnerContent, 0644)
 	c.Assert(err, IsNil)
 
 	cmd = exec.Command("gcc", "-std=c99", "-Werror", "-Wall", "-static", s.seccompSyscallRunner+".c", "-o", s.seccompSyscallRunner, "-Wl,-static", "-static-libgcc")

--- a/cmd/snap-update-ns/common_test.go
+++ b/cmd/snap-update-ns/common_test.go
@@ -21,7 +21,6 @@ package main_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -120,7 +119,7 @@ func (s *commonSuite) TestLoadDesiredProfile(c *C) {
 	// Write a desired user mount profile for snap "foo".
 	path := upCtx.DesiredProfilePath()
 	c.Assert(os.MkdirAll(filepath.Dir(path), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(path, []byte(text), 0644), IsNil)
+	c.Assert(os.WriteFile(path, []byte(text), 0644), IsNil)
 
 	// Ask the common profile update helper to read the desired profile.
 	profile, err = upCtx.LoadDesiredProfile()
@@ -146,7 +145,7 @@ func (s *commonSuite) TestLoadCurrentProfile(c *C) {
 	// Write a current user mount profile for snap "foo".
 	path := upCtx.CurrentProfilePath()
 	c.Assert(os.MkdirAll(filepath.Dir(path), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(path, []byte(text), 0644), IsNil)
+	c.Assert(os.WriteFile(path, []byte(text), 0644), IsNil)
 
 	// Ask the common profile update helper to read the current profile.
 	profile, err = upCtx.LoadCurrentProfile()

--- a/cmd/snap-update-ns/main_test.go
+++ b/cmd/snap-update-ns/main_test.go
@@ -22,7 +22,6 @@ package main_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -78,13 +77,13 @@ func (s *mainSuite) TestExecuteMountProfileUpdate(c *C) {
 	desiredProfilePath := fmt.Sprintf("%s/snap.%s.fstab", dirs.SnapMountPolicyDir, snapName)
 	err := os.MkdirAll(filepath.Dir(desiredProfilePath), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(desiredProfilePath, []byte(desiredProfileContent), 0644)
+	err = os.WriteFile(desiredProfilePath, []byte(desiredProfileContent), 0644)
 	c.Assert(err, IsNil)
 
 	currentProfilePath := fmt.Sprintf("%s/snap.%s.fstab", dirs.SnapRunNsDir, snapName)
 	err = os.MkdirAll(filepath.Dir(currentProfilePath), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(currentProfilePath, nil, 0644)
+	err = os.WriteFile(currentProfilePath, nil, 0644)
 	c.Assert(err, IsNil)
 
 	upCtx := update.NewSystemProfileUpdateContext(snapName, false)
@@ -111,8 +110,8 @@ func (s *mainSuite) TestAddingSyntheticChanges(c *C) {
 
 	c.Assert(os.MkdirAll(filepath.Dir(currentProfilePath), 0755), IsNil)
 	c.Assert(os.MkdirAll(filepath.Dir(desiredProfilePath), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(currentProfilePath, []byte(currentProfileContent), 0644), IsNil)
-	c.Assert(ioutil.WriteFile(desiredProfilePath, []byte(desiredProfileContent), 0644), IsNil)
+	c.Assert(os.WriteFile(currentProfilePath, []byte(currentProfileContent), 0644), IsNil)
+	c.Assert(os.WriteFile(desiredProfilePath, []byte(desiredProfileContent), 0644), IsNil)
 
 	// In order to make that work, /usr/share had to be converted to a writable
 	// mimic. Some actions were performed under the hood and now we see a
@@ -171,7 +170,7 @@ func (s *mainSuite) TestRemovingSyntheticChanges(c *C) {
 	defer dirs.SetRootDir("/")
 
 	c.Assert(os.MkdirAll(dirs.FeaturesDir, 0755), IsNil)
-	c.Assert(ioutil.WriteFile(features.RobustMountNamespaceUpdates.ControlFile(), []byte(nil), 0644), IsNil)
+	c.Assert(os.WriteFile(features.RobustMountNamespaceUpdates.ControlFile(), []byte(nil), 0644), IsNil)
 
 	// The snap `mysnap` no longer wishes to export it's usr/share/mysnap
 	// directory. All the synthetic changes that were associated with that mount
@@ -189,8 +188,8 @@ func (s *mainSuite) TestRemovingSyntheticChanges(c *C) {
 
 	c.Assert(os.MkdirAll(filepath.Dir(currentProfilePath), 0755), IsNil)
 	c.Assert(os.MkdirAll(filepath.Dir(desiredProfilePath), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(currentProfilePath, []byte(currentProfileContent), 0644), IsNil)
-	c.Assert(ioutil.WriteFile(desiredProfilePath, []byte(desiredProfileContent), 0644), IsNil)
+	c.Assert(os.WriteFile(currentProfilePath, []byte(currentProfileContent), 0644), IsNil)
+	c.Assert(os.WriteFile(desiredProfilePath, []byte(desiredProfileContent), 0644), IsNil)
 
 	n := -1
 	restore := update.MockChangePerform(func(chg *update.Change, as *update.Assumptions) ([]*update.Change, error) {
@@ -255,8 +254,8 @@ func (s *mainSuite) TestApplyingLayoutChanges(c *C) {
 
 	c.Assert(os.MkdirAll(filepath.Dir(currentProfilePath), 0755), IsNil)
 	c.Assert(os.MkdirAll(filepath.Dir(desiredProfilePath), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(currentProfilePath, []byte(currentProfileContent), 0644), IsNil)
-	c.Assert(ioutil.WriteFile(desiredProfilePath, []byte(desiredProfileContent), 0644), IsNil)
+	c.Assert(os.WriteFile(currentProfilePath, []byte(currentProfileContent), 0644), IsNil)
+	c.Assert(os.WriteFile(desiredProfilePath, []byte(desiredProfileContent), 0644), IsNil)
 
 	n := -1
 	restore := update.MockChangePerform(func(chg *update.Change, as *update.Assumptions) ([]*update.Change, error) {
@@ -298,8 +297,8 @@ func (s *mainSuite) TestApplyingParallelInstanceChanges(c *C) {
 
 	c.Assert(os.MkdirAll(filepath.Dir(currentProfilePath), 0755), IsNil)
 	c.Assert(os.MkdirAll(filepath.Dir(desiredProfilePath), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(currentProfilePath, []byte(currentProfileContent), 0644), IsNil)
-	c.Assert(ioutil.WriteFile(desiredProfilePath, []byte(desiredProfileContent), 0644), IsNil)
+	c.Assert(os.WriteFile(currentProfilePath, []byte(currentProfileContent), 0644), IsNil)
+	c.Assert(os.WriteFile(desiredProfilePath, []byte(desiredProfileContent), 0644), IsNil)
 
 	n := -1
 	restore := update.MockChangePerform(func(chg *update.Change, as *update.Assumptions) ([]*update.Change, error) {
@@ -341,8 +340,8 @@ func (s *mainSuite) TestApplyIgnoredMissingMount(c *C) {
 
 	c.Assert(os.MkdirAll(filepath.Dir(currentProfilePath), 0755), IsNil)
 	c.Assert(os.MkdirAll(filepath.Dir(desiredProfilePath), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(currentProfilePath, []byte(currentProfileContent), 0644), IsNil)
-	c.Assert(ioutil.WriteFile(desiredProfilePath, []byte(desiredProfileContent), 0644), IsNil)
+	c.Assert(os.WriteFile(currentProfilePath, []byte(currentProfileContent), 0644), IsNil)
+	c.Assert(os.WriteFile(desiredProfilePath, []byte(desiredProfileContent), 0644), IsNil)
 
 	n := -1
 	restore := update.MockChangePerform(func(chg *update.Change, as *update.Assumptions) ([]*update.Change, error) {
@@ -389,7 +388,7 @@ func (s *mainSuite) TestApplyUserFstab(c *C) {
 	desiredProfilePath := fmt.Sprintf("%s/snap.%s.user-fstab", dirs.SnapMountPolicyDir, snapName)
 	err := os.MkdirAll(filepath.Dir(desiredProfilePath), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(desiredProfilePath, []byte(desiredProfileContent), 0644)
+	err = os.WriteFile(desiredProfilePath, []byte(desiredProfileContent), 0644)
 	c.Assert(err, IsNil)
 
 	upCtx := update.NewUserProfileUpdateContext(snapName, true, 1000)

--- a/cmd/snap-update-ns/system_test.go
+++ b/cmd/snap-update-ns/system_test.go
@@ -21,7 +21,6 @@ package main_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -101,7 +100,7 @@ func (s *systemSuite) TestLoadDesiredProfile(c *C) {
 	// Write a desired system mount profile for snap "foo".
 	path := update.DesiredSystemProfilePath(upCtx.InstanceName())
 	c.Assert(os.MkdirAll(filepath.Dir(path), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(path, []byte(text), 0644), IsNil)
+	c.Assert(os.WriteFile(path, []byte(text), 0644), IsNil)
 
 	// Ask the system profile update helper to read the desired profile.
 	profile, err := upCtx.LoadDesiredProfile()
@@ -123,7 +122,7 @@ func (s *systemSuite) TestLoadCurrentProfile(c *C) {
 	// Write a current system mount profile for snap "foo".
 	path := update.CurrentSystemProfilePath(upCtx.InstanceName())
 	c.Assert(os.MkdirAll(filepath.Dir(path), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(path, []byte(text), 0644), IsNil)
+	c.Assert(os.WriteFile(path, []byte(text), 0644), IsNil)
 
 	// Ask the system profile update helper to read the current profile.
 	profile, err := upCtx.LoadCurrentProfile()

--- a/cmd/snap-update-ns/user_test.go
+++ b/cmd/snap-update-ns/user_test.go
@@ -21,7 +21,6 @@ package main_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -71,7 +70,7 @@ func (s *userSuite) TestLoadDesiredProfile(c *C) {
 	// Write a desired user mount profile for snap "foo".
 	path := update.DesiredUserProfilePath("foo")
 	c.Assert(os.MkdirAll(filepath.Dir(path), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(path, []byte(input), 0644), IsNil)
+	c.Assert(os.WriteFile(path, []byte(input), 0644), IsNil)
 
 	// Ask the user profile update helper to read the desired profile.
 	profile, err := upCtx.LoadDesiredProfile()
@@ -94,7 +93,7 @@ func (s *userSuite) TestLoadCurrentProfile(c *C) {
 	text := "/run/user/1234/doc/by-app/snap.foo /run/user/1234/doc none bind,rw 0 0\n"
 	path := update.CurrentUserProfilePath(upCtx.InstanceName(), upCtx.UID())
 	c.Assert(os.MkdirAll(filepath.Dir(path), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(path, []byte(text), 0644), IsNil)
+	c.Assert(os.WriteFile(path, []byte(text), 0644), IsNil)
 
 	// Ask the user profile update helper to read the current profile.
 	profile, err := upCtx.LoadCurrentProfile()
@@ -123,7 +122,7 @@ func (s *userSuite) TestSaveCurrentProfile(c *C) {
 	// Write a fake current user mount profile for snap "foo".
 	path := update.CurrentUserProfilePath("foo", 1234)
 	c.Assert(os.MkdirAll(filepath.Dir(path), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(path, []byte("banana"), 0644), IsNil)
+	c.Assert(os.WriteFile(path, []byte("banana"), 0644), IsNil)
 
 	// Ask the user profile update helper to write the current profile.
 	err = upCtx.SaveCurrentProfile(profile)

--- a/cmd/snap-update-ns/utils_test.go
+++ b/cmd/snap-update-ns/utils_test.go
@@ -22,7 +22,6 @@ package main_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -1147,7 +1146,7 @@ func (s *realSystemSuite) TestSecureOpenPathUncleanPath(c *C) {
 
 func (s *realSystemSuite) TestSecureOpenPathFile(c *C) {
 	path := filepath.Join(c.MkDir(), "file.txt")
-	c.Assert(ioutil.WriteFile(path, []byte("hello"), 0644), IsNil)
+	c.Assert(os.WriteFile(path, []byte("hello"), 0644), IsNil)
 
 	fd, err := update.OpenPath(path)
 	c.Assert(err, IsNil)

--- a/cmd/snap/cmd_auto_import_test.go
+++ b/cmd/snap/cmd_auto_import_test.go
@@ -72,7 +72,7 @@ func (s *SnapSuite) TestAutoImportAssertsHappy(c *C) {
 
 	testDir := c.MkDir()
 	fakeAssertsFn := filepath.Join(testDir, "auto-import.assert")
-	err := ioutil.WriteFile(fakeAssertsFn, fakeAssertData, 0644)
+	err := os.WriteFile(fakeAssertsFn, fakeAssertData, 0644)
 	c.Assert(err, IsNil)
 
 	mockMountInfoFmt := fmt.Sprintf(`24 0 8:18 / %s rw,relatime shared:1 - ext4 /dev/sdb2 rw,errors=remount-ro,data=ordered
@@ -107,7 +107,7 @@ func (s *SnapSuite) TestAutoImportAssertsNotImportedFromLoop(c *C) {
 
 	testDir := c.MkDir()
 	fakeAssertsFn := filepath.Join(testDir, "auto-import.assert")
-	err := ioutil.WriteFile(fakeAssertsFn, fakeAssertData, 0644)
+	err := os.WriteFile(fakeAssertsFn, fakeAssertData, 0644)
 	c.Assert(err, IsNil)
 
 	mockMountInfoFmtWithLoop := `24 0 8:18 / %s rw,relatime shared:1 - squashfs /dev/loop1 rw,errors=remount-ro,data=ordered`
@@ -132,7 +132,7 @@ func (s *SnapSuite) TestAutoImportAssertsHappyNotOnClassic(c *C) {
 	})
 
 	fakeAssertsFn := filepath.Join(c.MkDir(), "auto-import.assert")
-	err := ioutil.WriteFile(fakeAssertsFn, fakeAssertData, 0644)
+	err := os.WriteFile(fakeAssertsFn, fakeAssertData, 0644)
 	c.Assert(err, IsNil)
 
 	mockMountInfoFmt := `
@@ -160,7 +160,7 @@ func (s *SnapSuite) TestAutoImportIntoSpool(c *C) {
 	snap.ClientConfig.BaseURL = "can-not-connect-to-this-url"
 
 	fakeAssertsFn := filepath.Join(c.MkDir(), "auto-import.assert")
-	err := ioutil.WriteFile(fakeAssertsFn, fakeAssertData, 0644)
+	err := os.WriteFile(fakeAssertsFn, fakeAssertData, 0644)
 	c.Assert(err, IsNil)
 
 	mockMountInfoFmt := fmt.Sprintf(`24 0 8:18 / %s rw,relatime shared:1 - squashfs /dev/sc1 rw,errors=remount-ro,data=ordered`, filepath.Dir(fakeAssertsFn))
@@ -221,7 +221,7 @@ func (s *SnapSuite) TestAutoImportFromSpoolHappy(c *C) {
 	fakeAssertsFn := filepath.Join(dirs.SnapAssertsSpoolDir, "1234343")
 	err := os.MkdirAll(filepath.Dir(fakeAssertsFn), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(fakeAssertsFn, fakeAssertData, 0644)
+	err = os.WriteFile(fakeAssertsFn, fakeAssertData, 0644)
 	c.Assert(err, IsNil)
 
 	logbuf, restore := logger.MockLogger()
@@ -254,7 +254,7 @@ func (s *SnapSuite) TestAutoImportIntoSpoolUnhappyTooBig(c *C) {
 	snap.ClientConfig.BaseURL = "can-not-connect-to-this-url"
 
 	fakeAssertsFn := filepath.Join(c.MkDir(), "auto-import.assert")
-	err := ioutil.WriteFile(fakeAssertsFn, fakeAssertData, 0644)
+	err := os.WriteFile(fakeAssertsFn, fakeAssertData, 0644)
 	c.Assert(err, IsNil)
 
 	mockMountInfoFmt := fmt.Sprintf(`24 0 8:18 / %s rw,relatime shared:1 - squashfs /dev/sc1 rw,errors=remount-ro,data=ordered`, filepath.Dir(fakeAssertsFn))
@@ -279,7 +279,7 @@ func (s *SnapSuite) TestAutoImportUnhappyInInstallMode(c *C) {
 recovery_system=20200202
 `
 	c.Assert(os.MkdirAll(filepath.Dir(dirs.SnapModeenvFile), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(dirs.SnapModeenvFile, []byte(modeenvContent), 0644), IsNil)
+	c.Assert(os.WriteFile(dirs.SnapModeenvFile, []byte(modeenvContent), 0644), IsNil)
 
 	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"auto-import"})
 	c.Assert(err, IsNil)
@@ -301,7 +301,7 @@ func (s *SnapSuite) TestAutoImportUnhappyInInstallInInitrdMode(c *C) {
 recovery_system=20200202
 `
 	c.Assert(os.MkdirAll(filepath.Dir(dirs.SnapModeenvFile), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(dirs.SnapModeenvFile, []byte(modeenvContent), 0644), IsNil)
+	c.Assert(os.WriteFile(dirs.SnapModeenvFile, []byte(modeenvContent), 0644), IsNil)
 
 	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"auto-import"})
 	c.Assert(err, IsNil)
@@ -480,7 +480,7 @@ func (s *SnapSuite) TestAutoImportUC20CandidatesIgnoresSystemPartitions(c *C) {
 		args = append(args, dir)
 		file := filepath.Join(rootDir, dir, "auto-import.assert")
 		c.Assert(os.MkdirAll(filepath.Dir(file), 0755), IsNil)
-		c.Assert(ioutil.WriteFile(file, nil, 0644), IsNil)
+		c.Assert(os.WriteFile(file, nil, 0644), IsNil)
 	}
 
 	mockMountInfoFmtWithLoop := `24 0 8:18 / %[1]s%[2]s rw,relatime foo - ext3 /dev/meep2 rw,errors=remount-ro,data=ordered
@@ -537,7 +537,7 @@ func (s *SnapSuite) TestAutoImportAssertsManagedEmptyReply(c *C) {
 	})
 
 	fakeAssertsFn := filepath.Join(c.MkDir(), "auto-import.assert")
-	err := ioutil.WriteFile(fakeAssertsFn, fakeAssertData, 0644)
+	err := os.WriteFile(fakeAssertsFn, fakeAssertData, 0644)
 	c.Assert(err, IsNil)
 
 	mockMountInfoFmt := `24 0 8:18 / %s rw,relatime shared:1 - ext4 /dev/sdb2 rw,errors=remount-ro,data=ordered`

--- a/cmd/snap/cmd_debug_state_test.go
+++ b/cmd/snap/cmd_debug_state_test.go
@@ -21,7 +21,7 @@ package main_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -224,7 +224,7 @@ var stateCyclesJSON = []byte(`
 func (s *SnapSuite) TestDebugChanges(c *C) {
 	dir := c.MkDir()
 	stateFile := filepath.Join(dir, "test-state.json")
-	c.Assert(ioutil.WriteFile(stateFile, stateJSON, 0644), IsNil)
+	c.Assert(os.WriteFile(stateFile, stateJSON, 0644), IsNil)
 
 	rest, err := main.Parser(main.Client()).ParseArgs([]string{"debug", "state", "--abs-time", "--changes", stateFile})
 	c.Assert(err, IsNil)
@@ -244,7 +244,7 @@ func (s *SnapSuite) TestDebugChangesMissingState(c *C) {
 func (s *SnapSuite) TestDebugTask(c *C) {
 	dir := c.MkDir()
 	stateFile := filepath.Join(dir, "test-state.json")
-	c.Assert(ioutil.WriteFile(stateFile, stateJSON, 0644), IsNil)
+	c.Assert(os.WriteFile(stateFile, stateJSON, 0644), IsNil)
 
 	rest, err := main.Parser(main.Client()).ParseArgs([]string{"debug", "state", "--task=31", stateFile})
 	c.Assert(err, IsNil)
@@ -265,7 +265,7 @@ func (s *SnapSuite) TestDebugTask(c *C) {
 func (s *SnapSuite) TestDebugTaskEmptyLists(c *C) {
 	dir := c.MkDir()
 	stateFile := filepath.Join(dir, "test-state.json")
-	c.Assert(ioutil.WriteFile(stateFile, stateJSON, 0644), IsNil)
+	c.Assert(os.WriteFile(stateFile, stateJSON, 0644), IsNil)
 
 	rest, err := main.Parser(main.Client()).ParseArgs([]string{"debug", "state", "--task=12", stateFile})
 	c.Assert(err, IsNil)
@@ -286,7 +286,7 @@ func (s *SnapSuite) TestDebugTaskMissingState(c *C) {
 func (s *SnapSuite) TestDebugTaskNoSuchTaskError(c *C) {
 	dir := c.MkDir()
 	stateFile := filepath.Join(dir, "test-state.json")
-	c.Assert(ioutil.WriteFile(stateFile, stateJSON, 0644), IsNil)
+	c.Assert(os.WriteFile(stateFile, stateJSON, 0644), IsNil)
 
 	_, err := main.Parser(main.Client()).ParseArgs([]string{"debug", "state", "--task=99", stateFile})
 	c.Check(err, ErrorMatches, "no such task: 99")
@@ -295,7 +295,7 @@ func (s *SnapSuite) TestDebugTaskNoSuchTaskError(c *C) {
 func (s *SnapSuite) TestDebugTaskMutuallyExclusiveCommands(c *C) {
 	dir := c.MkDir()
 	stateFile := filepath.Join(dir, "test-state.json")
-	c.Assert(ioutil.WriteFile(stateFile, stateJSON, 0644), IsNil)
+	c.Assert(os.WriteFile(stateFile, stateJSON, 0644), IsNil)
 
 	_, err := main.Parser(main.Client()).ParseArgs([]string{"debug", "state", "--task=99", "--changes", stateFile})
 	c.Check(err, ErrorMatches, "cannot use --changes and --task= together")
@@ -313,7 +313,7 @@ func (s *SnapSuite) TestDebugTaskMutuallyExclusiveCommands(c *C) {
 func (s *SnapSuite) TestDebugTasks(c *C) {
 	dir := c.MkDir()
 	stateFile := filepath.Join(dir, "test-state.json")
-	c.Assert(ioutil.WriteFile(stateFile, stateJSON, 0644), IsNil)
+	c.Assert(os.WriteFile(stateFile, stateJSON, 0644), IsNil)
 
 	rest, err := main.Parser(main.Client()).ParseArgs([]string{"debug", "state", "--abs-time", "--change=9", stateFile})
 	c.Assert(err, IsNil)
@@ -328,7 +328,7 @@ func (s *SnapSuite) TestDebugTasks(c *C) {
 func (s *SnapSuite) TestDebugTasksWithCycles(c *C) {
 	dir := c.MkDir()
 	stateFile := filepath.Join(dir, "test-state.json")
-	c.Assert(ioutil.WriteFile(stateFile, stateCyclesJSON, 0644), IsNil)
+	c.Assert(os.WriteFile(stateFile, stateCyclesJSON, 0644), IsNil)
 
 	rest, err := main.Parser(main.Client()).ParseArgs([]string{"debug", "state", "--abs-time", "--change=1", stateFile})
 	c.Assert(err, IsNil)
@@ -353,7 +353,7 @@ func (s *SnapSuite) TestDebugCheckForCycles(c *C) {
 
 	dir := c.MkDir()
 	stateFile := filepath.Join(dir, "test-state.json")
-	c.Assert(ioutil.WriteFile(stateFile, stateCyclesJSON, 0644), IsNil)
+	c.Assert(os.WriteFile(stateFile, stateCyclesJSON, 0644), IsNil)
 
 	rest, err := main.Parser(main.Client()).ParseArgs([]string{"debug", "state", "--check", "--change=1", stateFile})
 	c.Assert(err, IsNil)
@@ -376,7 +376,7 @@ func (s *SnapSuite) TestDebugTasksMissingState(c *C) {
 func (s *SnapSuite) TestDebugIsSeededHappy(c *C) {
 	dir := c.MkDir()
 	stateFile := filepath.Join(dir, "test-state.json")
-	c.Assert(ioutil.WriteFile(stateFile, stateJSON, 0644), IsNil)
+	c.Assert(os.WriteFile(stateFile, stateJSON, 0644), IsNil)
 
 	rest, err := main.Parser(main.Client()).ParseArgs([]string{"debug", "state", "--is-seeded", stateFile})
 	c.Assert(err, IsNil)
@@ -388,7 +388,7 @@ func (s *SnapSuite) TestDebugIsSeededHappy(c *C) {
 func (s *SnapSuite) TestDebugIsSeededNo(c *C) {
 	dir := c.MkDir()
 	stateFile := filepath.Join(dir, "test-state.json")
-	c.Assert(ioutil.WriteFile(stateFile, []byte("{}"), 0644), IsNil)
+	c.Assert(os.WriteFile(stateFile, []byte("{}"), 0644), IsNil)
 
 	rest, err := main.Parser(main.Client()).ParseArgs([]string{"debug", "state", "--is-seeded", stateFile})
 	c.Assert(err, IsNil)
@@ -400,7 +400,7 @@ func (s *SnapSuite) TestDebugIsSeededNo(c *C) {
 func (s *SnapSuite) TestDebugConnections(c *C) {
 	dir := c.MkDir()
 	stateFile := filepath.Join(dir, "test-state.json")
-	c.Assert(ioutil.WriteFile(stateFile, stateConnsJSON, 0644), IsNil)
+	c.Assert(os.WriteFile(stateFile, stateConnsJSON, 0644), IsNil)
 
 	rest, err := main.Parser(main.Client()).ParseArgs([]string{"debug", "state", "--connections", stateFile})
 	c.Assert(err, IsNil)
@@ -421,7 +421,7 @@ func (s *SnapSuite) TestDebugConnections(c *C) {
 func (s *SnapSuite) TestDebugConnectionDetails(c *C) {
 	dir := c.MkDir()
 	stateFile := filepath.Join(dir, "test-state.json")
-	c.Assert(ioutil.WriteFile(stateFile, stateConnsJSON, 0644), IsNil)
+	c.Assert(os.WriteFile(stateFile, stateConnsJSON, 0644), IsNil)
 
 	for i, connArg := range []string{"gnome-calculator:gtk-3-themes", ",gtk-common-themes:gtk-3-themes"} {
 		s.ResetStdStreams()
@@ -452,7 +452,7 @@ func (s *SnapSuite) TestDebugConnectionDetails(c *C) {
 func (s *SnapSuite) TestDebugConnectionPlugAndSlot(c *C) {
 	dir := c.MkDir()
 	stateFile := filepath.Join(dir, "test-state.json")
-	c.Assert(ioutil.WriteFile(stateFile, stateConnsJSON, 0644), IsNil)
+	c.Assert(os.WriteFile(stateFile, stateConnsJSON, 0644), IsNil)
 
 	connArg := "gnome-calculator:network,core:network"
 	rest, err := main.Parser(main.Client()).ParseArgs([]string{"debug", "state", fmt.Sprintf("--connection=%s", connArg), stateFile})
@@ -471,7 +471,7 @@ func (s *SnapSuite) TestDebugConnectionPlugAndSlot(c *C) {
 func (s *SnapSuite) TestDebugConnectionInvalidCombination(c *C) {
 	dir := c.MkDir()
 	stateFile := filepath.Join(dir, "test-state.json")
-	c.Assert(ioutil.WriteFile(stateFile, stateConnsJSON, 0644), IsNil)
+	c.Assert(os.WriteFile(stateFile, stateConnsJSON, 0644), IsNil)
 
 	connArg := "gnome-calculator,core:network"
 	_, err := main.Parser(main.Client()).ParseArgs([]string{"debug", "state", fmt.Sprintf("--connection=%s", connArg), stateFile})
@@ -482,7 +482,7 @@ func (s *SnapSuite) TestDebugConnectionInvalidCombination(c *C) {
 func (s *SnapSuite) TestDebugConnectionDetailsMany(c *C) {
 	dir := c.MkDir()
 	stateFile := filepath.Join(dir, "test-state.json")
-	c.Assert(ioutil.WriteFile(stateFile, stateConnsJSON, 0644), IsNil)
+	c.Assert(os.WriteFile(stateFile, stateConnsJSON, 0644), IsNil)
 
 	rest, err := main.Parser(main.Client()).ParseArgs([]string{"debug", "state", "--connection=core", stateFile})
 	c.Assert(err, IsNil)
@@ -531,7 +531,7 @@ func (s *SnapSuite) TestDebugConnectionDetailsMany(c *C) {
 func (s *SnapSuite) TestDebugConnectionDetailsManySlotSide(c *C) {
 	dir := c.MkDir()
 	stateFile := filepath.Join(dir, "test-state.json")
-	c.Assert(ioutil.WriteFile(stateFile, stateConnsJSON, 0644), IsNil)
+	c.Assert(os.WriteFile(stateFile, stateConnsJSON, 0644), IsNil)
 
 	rest, err := main.Parser(main.Client()).ParseArgs([]string{"debug", "state", "--connection=core:x11", stateFile})
 	c.Assert(err, IsNil)

--- a/cmd/snap/cmd_debug_validate_seed_test.go
+++ b/cmd/snap/cmd_debug_validate_seed_test.go
@@ -20,7 +20,7 @@
 package main_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	. "gopkg.in/check.v1"
@@ -30,7 +30,7 @@ import (
 
 func (s *SnapSuite) TestDebugValidateCannotValidate(c *C) {
 	tmpf := filepath.Join(c.MkDir(), "seed.yaml")
-	err := ioutil.WriteFile(tmpf, []byte(`
+	err := os.WriteFile(tmpf, []byte(`
 snaps:
  -
    name: core

--- a/cmd/snap/cmd_find_test.go
+++ b/cmd/snap/cmd_find_test.go
@@ -21,7 +21,6 @@ package main_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -676,7 +675,7 @@ func (s *SnapSuite) TestFindSnapCachedSection(c *check.C) {
 	})
 
 	os.MkdirAll(path.Dir(dirs.SnapSectionsFile), 0755)
-	ioutil.WriteFile(dirs.SnapSectionsFile, []byte("sec1\nsec2\nsec3"), 0644)
+	os.WriteFile(dirs.SnapSectionsFile, []byte("sec1\nsec2\nsec3"), 0644)
 
 	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"find", "--section=foobar", "hello"})
 	c.Logf("stdout: %s", s.Stdout())

--- a/cmd/snap/cmd_info_test.go
+++ b/cmd/snap/cmd_info_test.go
@@ -22,8 +22,8 @@ package main_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -277,7 +277,7 @@ func (s *infoSuite) TestMaybePrintBuildDate(c *check.C) {
 	// some prep
 	dir := c.MkDir()
 	arbfile := filepath.Join(dir, "arb")
-	c.Assert(ioutil.WriteFile(arbfile, nil, 0600), check.IsNil)
+	c.Assert(os.WriteFile(arbfile, nil, 0600), check.IsNil)
 	filename := filepath.Join(c.MkDir(), "foo.snap")
 	diskSnap := squashfs.New(filename)
 	c.Assert(diskSnap.Build(dir, nil), check.IsNil)

--- a/cmd/snap/cmd_keys_test.go
+++ b/cmd/snap/cmd_keys_test.go
@@ -72,14 +72,14 @@ func (s *SnapKeysSuite) SetUpTest(c *C) {
 	for _, fileName := range []string{"pubring.gpg", "secring.gpg", "trustdb.gpg"} {
 		data, err := ioutil.ReadFile(filepath.Join("test-data", fileName))
 		c.Assert(err, IsNil)
-		err = ioutil.WriteFile(filepath.Join(s.tempdir, fileName), data, 0644)
+		err = os.WriteFile(filepath.Join(s.tempdir, fileName), data, 0644)
 		c.Assert(err, IsNil)
 	}
 	fakePinentryFn := filepath.Join(s.tempdir, "pinentry-fake")
-	err := ioutil.WriteFile(fakePinentryFn, fakePinentryData, 0755)
+	err := os.WriteFile(fakePinentryFn, fakePinentryData, 0755)
 	c.Assert(err, IsNil)
 	gpgAgentConfFn := filepath.Join(s.tempdir, "gpg-agent.conf")
-	err = ioutil.WriteFile(gpgAgentConfFn, []byte(fmt.Sprintf(`pinentry-program %s`, fakePinentryFn)), 0644)
+	err = os.WriteFile(gpgAgentConfFn, []byte(fmt.Sprintf(`pinentry-program %s`, fakePinentryFn)), 0644)
 	c.Assert(err, IsNil)
 
 	os.Setenv("SNAP_GNUPG_HOME", s.tempdir)

--- a/cmd/snap/cmd_pack_test.go
+++ b/cmd/snap/cmd_pack_test.go
@@ -2,7 +2,6 @@ package main_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -29,7 +28,7 @@ func makeSnapDirForPack(c *check.C, snapYaml string) string {
 	metaDir := filepath.Join(tempdir, "meta")
 	err := os.Mkdir(metaDir, 0755)
 	c.Assert(err, check.IsNil)
-	err = ioutil.WriteFile(filepath.Join(metaDir, "snap.yaml"), []byte(snapYaml), 0644)
+	err = os.WriteFile(filepath.Join(metaDir, "snap.yaml"), []byte(snapYaml), 0644)
 	c.Assert(err, check.IsNil)
 
 	return tempdir
@@ -108,7 +107,7 @@ printf "hello world"
 	binDir := filepath.Join(snapDir, "bin")
 	err := os.Mkdir(binDir, 0755)
 	c.Assert(err, check.IsNil)
-	err = ioutil.WriteFile(filepath.Join(binDir, "hello"), []byte(helloBinContent), 0755)
+	err = os.WriteFile(filepath.Join(binDir, "hello"), []byte(helloBinContent), 0755)
 	c.Assert(err, check.IsNil)
 
 	_, err = snaprun.Parser(snaprun.Client()).ParseArgs([]string{"pack", snapDir, snapDir})

--- a/cmd/snap/cmd_prepare_image_test.go
+++ b/cmd/snap/cmd_prepare_image_test.go
@@ -20,7 +20,6 @@
 package main_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -156,7 +155,7 @@ func (s *SnapPrepareImageSuite) TestPrepareImageCustomize(c *C) {
 
 	tmpdir := c.MkDir()
 	customizeFile := filepath.Join(tmpdir, "custo.json")
-	err := ioutil.WriteFile(customizeFile, []byte(`{
+	err := os.WriteFile(customizeFile, []byte(`{
   "console-conf": "disabled",
   "cloud-init-user-data": "cloud-init-user-data"
 }`), 0644)

--- a/cmd/snap/cmd_routine_console_conf_test.go
+++ b/cmd/snap/cmd_routine_console_conf_test.go
@@ -22,7 +22,6 @@ package main_test
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -257,7 +256,7 @@ func (s *SnapSuite) TestRoutineConsoleConfStartSnapdRefreshMaintenanceJSON(c *C)
 	c.Assert(err, IsNil)
 	err = os.MkdirAll(filepath.Dir(dirs.SnapdMaintenanceFile), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(dirs.SnapdMaintenanceFile, b, 0644)
+	err = os.WriteFile(dirs.SnapdMaintenanceFile, b, 0644)
 	c.Assert(err, IsNil)
 
 	n := 0
@@ -323,7 +322,7 @@ func (s *SnapSuite) TestRoutineConsoleConfStartSystemRebootMaintenanceJSON(c *C)
 	c.Assert(err, IsNil)
 	err = os.MkdirAll(filepath.Dir(dirs.SnapdMaintenanceFile), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(dirs.SnapdMaintenanceFile, b, 0644)
+	err = os.WriteFile(dirs.SnapdMaintenanceFile, b, 0644)
 	c.Assert(err, IsNil)
 
 	n := 0

--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -779,7 +779,7 @@ func activateXdgDocumentPortal(info *snap.Info, snapApp, hook string) error {
 			// We ignore errors here: if writing the file
 			// fails, we'll just try connecting to D-Bus
 			// again next time.
-			if err = ioutil.WriteFile(portalsUnavailableFile, []byte(""), 0644); err != nil {
+			if err = os.WriteFile(portalsUnavailableFile, []byte(""), 0644); err != nil {
 				logger.Noticef("WARNING: cannot write file at %s: %s", portalsUnavailableFile, err)
 			}
 			return nil

--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/user"
@@ -235,7 +234,7 @@ func (s *RunSuite) TestSnapRunAppRunsChecksInhibitionLock(c *check.C) {
 
 	c.Assert(runinhibit.LockWithHint("snapname", runinhibit.HintInhibitedForRefresh), check.IsNil)
 	c.Assert(os.MkdirAll(dirs.FeaturesDir, 0755), check.IsNil)
-	c.Assert(ioutil.WriteFile(features.RefreshAppAwareness.ControlFile(), []byte(nil), 0644), check.IsNil)
+	c.Assert(os.WriteFile(features.RefreshAppAwareness.ControlFile(), []byte(nil), 0644), check.IsNil)
 
 	var called int
 	restore := snaprun.MockWaitInhibitUnlock(func(snapName string, waitFor runinhibit.Hint) (bool, error) {
@@ -286,7 +285,7 @@ func (s *RunSuite) TestSnapRunHookNoRuninhibit(c *check.C) {
 
 	c.Assert(runinhibit.LockWithHint("snapname", runinhibit.HintInhibitedForRefresh), check.IsNil)
 	c.Assert(os.MkdirAll(dirs.FeaturesDir, 0755), check.IsNil)
-	c.Assert(ioutil.WriteFile(features.RefreshAppAwareness.ControlFile(), []byte(nil), 0644), check.IsNil)
+	c.Assert(os.WriteFile(features.RefreshAppAwareness.ControlFile(), []byte(nil), 0644), check.IsNil)
 
 	// Run a hook from the active revision
 	_, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--hook=configure", "--", "snapname"})
@@ -318,7 +317,7 @@ func (s *RunSuite) TestSnapRunAppRuninhibitSkipsServices(c *check.C) {
 
 	c.Assert(runinhibit.LockWithHint("snapname", runinhibit.HintInhibitedForRefresh), check.IsNil)
 	c.Assert(os.MkdirAll(dirs.FeaturesDir, 0755), check.IsNil)
-	c.Assert(ioutil.WriteFile(features.RefreshAppAwareness.ControlFile(), []byte(nil), 0644), check.IsNil)
+	c.Assert(os.WriteFile(features.RefreshAppAwareness.ControlFile(), []byte(nil), 0644), check.IsNil)
 
 	var called bool
 	restore := snaprun.MockWaitInhibitUnlock(func(snapName string, waitFor runinhibit.Hint) (bool, error) {
@@ -2049,10 +2048,10 @@ func (s *RunSuite) TestGetSnapDirOptions(c *check.C) {
 	}
 	data, err := json.Marshal(&str)
 	c.Assert(err, check.IsNil)
-	c.Assert(ioutil.WriteFile(seqFile, data, 0660), check.IsNil)
+	c.Assert(os.WriteFile(seqFile, data, 0660), check.IsNil)
 
 	// write control file for hidden dir feature
-	c.Assert(ioutil.WriteFile(features.HiddenSnapDataHomeDir.ControlFile(), []byte{}, 0660), check.IsNil)
+	c.Assert(os.WriteFile(features.HiddenSnapDataHomeDir.ControlFile(), []byte{}, 0660), check.IsNil)
 
 	opts, err := snaprun.GetSnapDirOptions("somesnap")
 	c.Assert(err, check.IsNil)

--- a/cmd/snap/cmd_sign_build_test.go
+++ b/cmd/snap/cmd_sign_build_test.go
@@ -55,7 +55,7 @@ func (s *SnapSignBuildSuite) TestSignBuildMissingSnap(c *C) {
 
 func (s *SnapSignBuildSuite) TestSignBuildMissingKey(c *C) {
 	snapFilename := "foo_1_amd64.snap"
-	_err := ioutil.WriteFile(snapFilename, []byte("sample"), 0644)
+	_err := os.WriteFile(snapFilename, []byte("sample"), 0644)
 	c.Assert(_err, IsNil)
 	defer os.Remove(snapFilename)
 
@@ -73,7 +73,7 @@ func (s *SnapSignBuildSuite) TestSignBuildMissingKey(c *C) {
 func (s *SnapSignBuildSuite) TestSignBuildWorks(c *C) {
 	snapFilename := "foo_1_amd64.snap"
 	snapContent := []byte("sample")
-	_err := ioutil.WriteFile(snapFilename, snapContent, 0644)
+	_err := os.WriteFile(snapFilename, snapContent, 0644)
 	c.Assert(_err, IsNil)
 	defer os.Remove(snapFilename)
 
@@ -81,7 +81,7 @@ func (s *SnapSignBuildSuite) TestSignBuildWorks(c *C) {
 	for _, fileName := range []string{"pubring.gpg", "secring.gpg", "trustdb.gpg"} {
 		data, err := ioutil.ReadFile(filepath.Join("test-data", fileName))
 		c.Assert(err, IsNil)
-		err = ioutil.WriteFile(filepath.Join(tempdir, fileName), data, 0644)
+		err = os.WriteFile(filepath.Join(tempdir, fileName), data, 0644)
 		c.Assert(err, IsNil)
 	}
 	os.Setenv("SNAP_GNUPG_HOME", tempdir)
@@ -108,7 +108,7 @@ func (s *SnapSignBuildSuite) TestSignBuildWorks(c *C) {
 func (s *SnapSignBuildSuite) TestSignBuildWorksDevelGrade(c *C) {
 	snapFilename := "foo_1_amd64.snap"
 	snapContent := []byte("sample")
-	_err := ioutil.WriteFile(snapFilename, snapContent, 0644)
+	_err := os.WriteFile(snapFilename, snapContent, 0644)
 	c.Assert(_err, IsNil)
 	defer os.Remove(snapFilename)
 
@@ -116,7 +116,7 @@ func (s *SnapSignBuildSuite) TestSignBuildWorksDevelGrade(c *C) {
 	for _, fileName := range []string{"pubring.gpg", "secring.gpg", "trustdb.gpg"} {
 		data, err := ioutil.ReadFile(filepath.Join("test-data", fileName))
 		c.Assert(err, IsNil)
-		err = ioutil.WriteFile(filepath.Join(tempdir, fileName), data, 0644)
+		err = os.WriteFile(filepath.Join(tempdir, fileName), data, 0644)
 		c.Assert(err, IsNil)
 	}
 	os.Setenv("SNAP_GNUPG_HOME", tempdir)

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -978,7 +978,7 @@ func (s *SnapOpSuite) TestInstallPath(c *check.C) {
 	snapBody := []byte("snap-data")
 	s.RedirectClientToTestServer(s.srv.handle)
 	snapPath := filepath.Join(c.MkDir(), "foo.snap")
-	err := ioutil.WriteFile(snapPath, snapBody, 0644)
+	err := os.WriteFile(snapPath, snapBody, 0644)
 	c.Assert(err, check.IsNil)
 
 	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", snapPath})
@@ -1010,7 +1010,7 @@ func (s *SnapOpSuite) TestInstallPathDevMode(c *check.C) {
 	snapBody := []byte("snap-data")
 	s.RedirectClientToTestServer(s.srv.handle)
 	snapPath := filepath.Join(c.MkDir(), "foo.snap")
-	err := ioutil.WriteFile(snapPath, snapBody, 0644)
+	err := os.WriteFile(snapPath, snapBody, 0644)
 	c.Assert(err, check.IsNil)
 
 	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "--devmode", snapPath})
@@ -1044,7 +1044,7 @@ func (s *SnapOpSuite) TestInstallPathClassic(c *check.C) {
 	snapBody := []byte("snap-data")
 	s.RedirectClientToTestServer(s.srv.handle)
 	snapPath := filepath.Join(c.MkDir(), "foo.snap")
-	err := ioutil.WriteFile(snapPath, snapBody, 0644)
+	err := os.WriteFile(snapPath, snapBody, 0644)
 	c.Assert(err, check.IsNil)
 
 	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "--classic", snapPath})
@@ -1076,7 +1076,7 @@ func (s *SnapOpSuite) TestInstallPathDangerous(c *check.C) {
 	snapBody := []byte("snap-data")
 	s.RedirectClientToTestServer(s.srv.handle)
 	snapPath := filepath.Join(c.MkDir(), "foo.snap")
-	err := ioutil.WriteFile(snapPath, snapBody, 0644)
+	err := os.WriteFile(snapPath, snapBody, 0644)
 	c.Assert(err, check.IsNil)
 
 	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "--dangerous", snapPath})
@@ -1108,7 +1108,7 @@ func (s *SnapOpSuite) TestInstallPathQuotaGroup(c *check.C) {
 	snapBody := []byte("snap-data")
 	s.RedirectClientToTestServer(s.srv.handle)
 	snapPath := filepath.Join(c.MkDir(), "foo.snap")
-	err := ioutil.WriteFile(snapPath, snapBody, 0644)
+	err := os.WriteFile(snapPath, snapBody, 0644)
 	c.Assert(err, check.IsNil)
 
 	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", "--quota-group", "foo", snapPath})
@@ -1167,7 +1167,7 @@ func (s *SnapOpSuite) TestInstallPathManyTransactional(c *check.C) {
 	for _, snap := range snaps {
 		path := filepath.Join(c.MkDir(), snap)
 		args = append(args, path)
-		err := ioutil.WriteFile(path, []byte("snap-data"), 0644)
+		err := os.WriteFile(path, []byte("snap-data"), 0644)
 		c.Assert(err, check.IsNil)
 	}
 
@@ -1206,7 +1206,7 @@ func (s *SnapOpSuite) TestInstallPathInstance(c *check.C) {
 	// instance is named foo_bar
 	s.srv.snap = "foo_bar"
 	snapPath := filepath.Join(c.MkDir(), "foo.snap")
-	err := ioutil.WriteFile(snapPath, snapBody, 0644)
+	err := os.WriteFile(snapPath, snapBody, 0644)
 	c.Assert(err, check.IsNil)
 
 	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"install", snapPath, "--name", "foo_bar"})
@@ -1265,7 +1265,7 @@ func (s *SnapOpSuite) TestInstallPathMany(c *check.C) {
 	for _, snap := range snaps {
 		path := filepath.Join(c.MkDir(), snap)
 		args = append(args, path)
-		err := ioutil.WriteFile(path, []byte("snap-data"), 0644)
+		err := os.WriteFile(path, []byte("snap-data"), 0644)
 		c.Assert(err, check.IsNil)
 	}
 

--- a/cmd/snap/cmd_snapshot_test.go
+++ b/cmd/snap/cmd_snapshot_test.go
@@ -21,8 +21,8 @@ package main_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -157,7 +157,7 @@ func (s *SnapSuite) TestSnapshotImportHappy(c *C) {
 	ageStr := quantity.FormatDuration(expectedAge.Seconds())
 
 	exportedSnapshotPath := filepath.Join(c.MkDir(), "mocked-snapshot.snapshot")
-	ioutil.WriteFile(exportedSnapshotPath, []byte("this is really snapshot zip file data"), 0644)
+	os.WriteFile(exportedSnapshotPath, []byte("this is really snapshot zip file data"), 0644)
 
 	_, err := main.Parser(main.Client()).ParseArgs([]string{"import-snapshot", exportedSnapshotPath})
 	c.Check(err, IsNil)

--- a/cmd/snap/main_test.go
+++ b/cmd/snap/main_test.go
@@ -23,7 +23,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -184,7 +183,7 @@ func mockSnapConfine(libExecDir string) func() {
 	if err := os.MkdirAll(libExecDir, 0755); err != nil {
 		panic(err)
 	}
-	if err := ioutil.WriteFile(snapConfine, nil, 0644); err != nil {
+	if err := os.WriteFile(snapConfine, nil, 0644); err != nil {
 		panic(err)
 	}
 	return func() {

--- a/cmd/snapctl/main_test.go
+++ b/cmd/snapctl/main_test.go
@@ -23,7 +23,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -81,7 +80,7 @@ func (s *snapctlSuite) SetUpTest(c *C) {
 
 	fakeAuthPath := filepath.Join(c.MkDir(), "auth.json")
 	os.Setenv("SNAPD_AUTH_DATA_FILENAME", fakeAuthPath)
-	err := ioutil.WriteFile(fakeAuthPath, []byte(`{"macaroon":"user-macaroon"}`), 0644)
+	err := os.WriteFile(fakeAuthPath, []byte(`{"macaroon":"user-macaroon"}`), 0644)
 	c.Assert(err, IsNil)
 }
 

--- a/cmd/snapd-apparmor/main_test.go
+++ b/cmd/snapd-apparmor/main_test.go
@@ -22,7 +22,6 @@ package main_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -94,19 +93,19 @@ func (s *mainSuite) TestIsContainerWithInternalPolicy(c *C) {
 	testutil.MockCommand(c, "systemd-detect-virt", "echo lxc")
 	c.Assert(snapd_apparmor.IsContainerWithInternalPolicy(), Equals, false)
 
-	err = ioutil.WriteFile(filepath.Join(appArmorSecurityFSPath, ".ns_stacked"), []byte("yes"), 0644)
+	err = os.WriteFile(filepath.Join(appArmorSecurityFSPath, ".ns_stacked"), []byte("yes"), 0644)
 	c.Assert(err, IsNil)
 	c.Assert(snapd_apparmor.IsContainerWithInternalPolicy(), Equals, false)
 
-	err = ioutil.WriteFile(filepath.Join(appArmorSecurityFSPath, ".ns_name"), nil, 0644)
+	err = os.WriteFile(filepath.Join(appArmorSecurityFSPath, ".ns_name"), nil, 0644)
 	c.Assert(err, IsNil)
 	c.Assert(snapd_apparmor.IsContainerWithInternalPolicy(), Equals, false)
 
-	err = ioutil.WriteFile(filepath.Join(appArmorSecurityFSPath, ".ns_name"), []byte("foo"), 0644)
+	err = os.WriteFile(filepath.Join(appArmorSecurityFSPath, ".ns_name"), []byte("foo"), 0644)
 	c.Assert(err, IsNil)
 	c.Assert(snapd_apparmor.IsContainerWithInternalPolicy(), Equals, false)
 	// lxc/lxd name should result in a container with internal policy
-	err = ioutil.WriteFile(filepath.Join(appArmorSecurityFSPath, ".ns_name"), []byte("lxc-foo"), 0644)
+	err = os.WriteFile(filepath.Join(appArmorSecurityFSPath, ".ns_name"), []byte("lxc-foo"), 0644)
 	c.Assert(err, IsNil)
 	c.Assert(snapd_apparmor.IsContainerWithInternalPolicy(), Equals, true)
 }
@@ -126,7 +125,7 @@ func (s *mainSuite) TestLoadAppArmorProfiles(c *C) {
 	c.Assert(err, IsNil)
 
 	profile := filepath.Join(dirs.SnapAppArmorDir, "foo")
-	err = ioutil.WriteFile(profile, nil, 0644)
+	err = os.WriteFile(profile, nil, 0644)
 	c.Assert(err, IsNil)
 
 	// ensure SNAPD_DEBUG is set in the environment so then --quiet
@@ -241,7 +240,7 @@ func (s *integrationSuite) SetUpTest(c *C) {
 	err := os.MkdirAll(dirs.SnapAppArmorDir, 0755)
 	c.Assert(err, IsNil)
 	profile := filepath.Join(dirs.SnapAppArmorDir, "foo")
-	err = ioutil.WriteFile(profile, nil, 0644)
+	err = os.WriteFile(profile, nil, 0644)
 	c.Assert(err, IsNil)
 
 	os.Args = []string{"snapd-apparmor", "start"}

--- a/daemon/api_base_test.go
+++ b/daemon/api_base_test.go
@@ -394,7 +394,7 @@ func (s *apiBaseSuite) mkInstalledDesktopFile(c *check.C, name, content string) 
 	df := filepath.Join(dirs.SnapDesktopFilesDir, name)
 	err := os.MkdirAll(filepath.Dir(df), 0755)
 	c.Assert(err, check.IsNil)
-	err = ioutil.WriteFile(df, []byte(content), 0644)
+	err = os.WriteFile(df, []byte(content), 0644)
 	c.Assert(err, check.IsNil)
 	return df
 }
@@ -469,7 +469,7 @@ version: %s
 	metadir := filepath.Join(snapInfo.MountDir(), "meta")
 	guidir := filepath.Join(metadir, "gui")
 	c.Assert(os.MkdirAll(guidir, 0755), check.IsNil)
-	c.Check(ioutil.WriteFile(filepath.Join(guidir, "icon.svg"), []byte("yadda icon"), 0644), check.IsNil)
+	c.Check(os.WriteFile(filepath.Join(guidir, "icon.svg"), []byte("yadda icon"), 0644), check.IsNil)
 
 	if d == nil {
 		return snapInfo

--- a/daemon/api_icons_test.go
+++ b/daemon/api_icons_test.go
@@ -20,7 +20,6 @@
 package daemon_test
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -47,7 +46,7 @@ func (s *iconsSuite) TestAppIconGet(c *check.C) {
 	// have an icon for it in the package itself
 	iconfile := filepath.Join(info.MountDir(), "meta", "gui", "icon.ick")
 	c.Assert(os.MkdirAll(filepath.Dir(iconfile), 0755), check.IsNil)
-	c.Check(ioutil.WriteFile(iconfile, []byte("ick"), 0644), check.IsNil)
+	c.Check(os.WriteFile(iconfile, []byte("ick"), 0644), check.IsNil)
 
 	req, err := http.NewRequest("GET", "/v2/icons/foo/icon", nil)
 	c.Assert(err, check.IsNil)
@@ -68,7 +67,7 @@ func (s *iconsSuite) TestAppIconGetInactive(c *check.C) {
 	// have an icon for it in the package itself
 	iconfile := filepath.Join(info.MountDir(), "meta", "gui", "icon.ick")
 	c.Assert(os.MkdirAll(filepath.Dir(iconfile), 0755), check.IsNil)
-	c.Check(ioutil.WriteFile(iconfile, []byte("ick"), 0644), check.IsNil)
+	c.Check(os.WriteFile(iconfile, []byte("ick"), 0644), check.IsNil)
 
 	req, err := http.NewRequest("GET", "/v2/icons/foo/icon", nil)
 	c.Assert(err, check.IsNil)

--- a/daemon/api_sideload_n_try_test.go
+++ b/daemon/api_sideload_n_try_test.go
@@ -1006,7 +1006,7 @@ func (s *trySuite) TestTrySnap(c *check.C) {
 	snapYaml := filepath.Join(tryDir, "meta", "snap.yaml")
 	err = os.MkdirAll(filepath.Dir(snapYaml), 0755)
 	c.Assert(err, check.IsNil)
-	err = ioutil.WriteFile(snapYaml, []byte("name: foo\nversion: 1.0\n"), 0644)
+	err = os.WriteFile(snapYaml, []byte("name: foo\nversion: 1.0\n"), 0644)
 	c.Assert(err, check.IsNil)
 
 	reqForFlags := func(f snapstate.Flags) *http.Request {

--- a/daemon/api_snap_conf_test.go
+++ b/daemon/api_snap_conf_test.go
@@ -22,7 +22,6 @@ package daemon_test
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -191,7 +190,7 @@ version: 1
 
 	err := os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "/etc/"), 0755)
 	c.Assert(err, check.IsNil)
-	err = ioutil.WriteFile(filepath.Join(dirs.GlobalRootDir, "/etc/environment"), nil, 0644)
+	err = os.WriteFile(filepath.Join(dirs.GlobalRootDir, "/etc/environment"), nil, 0644)
 	c.Assert(err, check.IsNil)
 
 	d.Overlord().Loop()

--- a/daemon/api_system_recovery_keys_test.go
+++ b/daemon/api_system_recovery_keys_test.go
@@ -23,7 +23,6 @@ import (
 	"bytes"
 	"encoding/hex"
 	"errors"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -56,13 +55,13 @@ func mockSystemRecoveryKeys(c *C) {
 	rkeyPath := filepath.Join(dirs.SnapFDEDir, "recovery.key")
 	err = os.MkdirAll(filepath.Dir(rkeyPath), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(rkeyPath, []byte(rkeystr), 0644)
+	err = os.WriteFile(rkeyPath, []byte(rkeystr), 0644)
 	c.Assert(err, IsNil)
 
 	skeystr := "1234567890123456"
 	c.Assert(err, IsNil)
 	skeyPath := filepath.Join(dirs.SnapFDEDir, "reinstall.key")
-	err = ioutil.WriteFile(skeyPath, []byte(skeystr), 0644)
+	err = os.WriteFile(skeyPath, []byte(skeystr), 0644)
 	c.Assert(err, IsNil)
 }
 

--- a/daemon/command_counter_test.go
+++ b/daemon/command_counter_test.go
@@ -24,7 +24,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -213,7 +213,7 @@ func (cmdCounterSuite) TestCommandDeclCounter(c *check.C) {
 	for i, t := range commandDeclCounterTable {
 		fn := filepath.Join(d, fmt.Sprintf("a_%02d.go", i))
 		comm := check.Commentf(t.desc)
-		c.Assert(ioutil.WriteFile(fn, []byte("package huh"+t.content), 0644), check.IsNil, comm)
+		c.Assert(os.WriteFile(fn, []byte("package huh"+t.content), 0644), check.IsNil, comm)
 		n := countCommandDeclsIn(c, fn, comm)
 		c.Check(n, check.Equals, t.count, comm)
 	}

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -318,7 +318,7 @@ func (s *daemonSuite) TestMaintenanceJsonDeletedOnStart(c *check.C) {
 	b, err := json.Marshal(maintErr)
 	c.Assert(err, check.IsNil)
 	c.Assert(os.MkdirAll(filepath.Dir(dirs.SnapdMaintenanceFile), 0755), check.IsNil)
-	c.Assert(ioutil.WriteFile(dirs.SnapdMaintenanceFile, b, 0644), check.IsNil)
+	c.Assert(os.WriteFile(dirs.SnapdMaintenanceFile, b, 0644), check.IsNil)
 
 	d := s.newTestDaemon(c)
 	makeDaemonListeners(c, d)
@@ -1242,7 +1242,7 @@ func (s *daemonSuite) TestRestartExpectedRebootDidNotHappen(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	fakeState := []byte(fmt.Sprintf(`{"data":{"patch-level":%d,"patch-sublevel":%d,"some":"data","refresh-privacy-key":"0123456789ABCDEF","system-restart-from-boot-id":%q,"daemon-system-restart-at":"%s"},"changes":null,"tasks":null,"last-change-id":0,"last-task-id":0,"last-lane-id":0}`, patch.Level, patch.Sublevel, curBootID, time.Now().UTC().Format(time.RFC3339)))
-	err = ioutil.WriteFile(dirs.SnapStateFile, fakeState, 0600)
+	err = os.WriteFile(dirs.SnapStateFile, fakeState, 0600)
 	c.Assert(err, check.IsNil)
 
 	oldRebootNoticeWait := rebootNoticeWait
@@ -1297,7 +1297,7 @@ func (s *daemonSuite) TestRestartExpectedRebootDidNotHappen(c *check.C) {
 
 func (s *daemonSuite) TestRestartExpectedRebootOK(c *check.C) {
 	fakeState := []byte(fmt.Sprintf(`{"data":{"patch-level":%d,"patch-sublevel":%d,"some":"data","refresh-privacy-key":"0123456789ABCDEF","system-restart-from-boot-id":%q,"daemon-system-restart-at":"%s"},"changes":null,"tasks":null,"last-change-id":0,"last-task-id":0,"last-lane-id":0}`, patch.Level, patch.Sublevel, "boot-id-0", time.Now().UTC().Format(time.RFC3339)))
-	err := ioutil.WriteFile(dirs.SnapStateFile, fakeState, 0600)
+	err := os.WriteFile(dirs.SnapStateFile, fakeState, 0600)
 	c.Assert(err, check.IsNil)
 
 	cmd := testutil.MockCommand(c, "shutdown", "")
@@ -1321,7 +1321,7 @@ func (s *daemonSuite) TestRestartExpectedRebootGiveUp(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	fakeState := []byte(fmt.Sprintf(`{"data":{"patch-level":%d,"patch-sublevel":%d,"some":"data","refresh-privacy-key":"0123456789ABCDEF","system-restart-from-boot-id":%q,"daemon-system-restart-at":"%s","daemon-system-restart-tentative":3},"changes":null,"tasks":null,"last-change-id":0,"last-task-id":0,"last-lane-id":0}`, patch.Level, patch.Sublevel, curBootID, time.Now().UTC().Format(time.RFC3339)))
-	err = ioutil.WriteFile(dirs.SnapStateFile, fakeState, 0600)
+	err = os.WriteFile(dirs.SnapStateFile, fakeState, 0600)
 	c.Assert(err, check.IsNil)
 
 	cmd := testutil.MockCommand(c, "shutdown", "")

--- a/daemon/response_test.go
+++ b/daemon/response_test.go
@@ -22,7 +22,6 @@ package daemon_test
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -86,7 +85,7 @@ func (s *responseSuite) TestFileResponseSetsContentDisposition(c *check.C) {
 	const filename = "icon.png"
 
 	path := filepath.Join(c.MkDir(), filename)
-	err := ioutil.WriteFile(path, nil, os.ModePerm)
+	err := os.WriteFile(path, nil, os.ModePerm)
 	c.Check(err, check.IsNil)
 
 	rec := httptest.NewRecorder()

--- a/dbusutil/dbusutil_test.go
+++ b/dbusutil/dbusutil_test.go
@@ -21,7 +21,6 @@ package dbusutil_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -74,7 +73,7 @@ func (*dbusutilSuite) TestIsSessionBusLikelyPresentEnvVar(c *C) {
 func (*dbusutilSuite) TestIsSessionBusLikelyPresentAddrFile(c *C) {
 	f := fmt.Sprintf("%s/%d/dbus-session", dirs.XdgRuntimeDirBase, os.Getuid())
 	c.Assert(os.MkdirAll(filepath.Dir(f), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(f, []byte("address"), 0644), IsNil)
+	c.Assert(os.WriteFile(f, []byte("address"), 0644), IsNil)
 
 	c.Assert(dbusutil.IsSessionBusLikelyPresent(), Equals, true)
 }

--- a/desktop/desktopentry/desktopentry_test.go
+++ b/desktop/desktopentry/desktopentry_test.go
@@ -21,7 +21,7 @@ package desktopentry_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -125,7 +125,7 @@ NoEqualsSign
 
 func (s *desktopentrySuite) TestRead(c *C) {
 	path := filepath.Join(c.MkDir(), "foo.desktop")
-	err := ioutil.WriteFile(path, []byte(browserDesktopEntry), 0o644)
+	err := os.WriteFile(path, []byte(browserDesktopEntry), 0o644)
 	c.Assert(err, IsNil)
 
 	de, err := desktopentry.Read(path)

--- a/desktop/portal/launcher_test.go
+++ b/desktop/portal/launcher_test.go
@@ -21,7 +21,6 @@ package portal_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -88,7 +87,7 @@ func (s *portalSuite) SetUpTest(c *C) {
 
 func (s *portalSuite) TestOpenFile(c *C) {
 	path := filepath.Join(c.MkDir(), "test.txt")
-	c.Assert(ioutil.WriteFile(path, []byte("hello world"), 0644), IsNil)
+	c.Assert(os.WriteFile(path, []byte("hello world"), 0644), IsNil)
 
 	err := portal.OpenFile(s.SessionBus, path)
 	c.Check(err, IsNil)
@@ -101,7 +100,7 @@ func (s *portalSuite) TestOpenFileCallError(c *C) {
 	s.openError = dbus.MakeFailedError(fmt.Errorf("failure"))
 
 	path := filepath.Join(c.MkDir(), "test.txt")
-	c.Assert(ioutil.WriteFile(path, []byte("hello world"), 0644), IsNil)
+	c.Assert(os.WriteFile(path, []byte("hello world"), 0644), IsNil)
 
 	err := portal.OpenFile(s.SessionBus, path)
 	c.Check(err, FitsTypeOf, dbus.Error{})
@@ -115,7 +114,7 @@ func (s *portalSuite) TestOpenFileResponseError(c *C) {
 	s.openResponse = 2
 
 	path := filepath.Join(c.MkDir(), "test.txt")
-	c.Assert(ioutil.WriteFile(path, []byte("hello world"), 0644), IsNil)
+	c.Assert(os.WriteFile(path, []byte("hello world"), 0644), IsNil)
 
 	err := portal.OpenFile(s.SessionBus, path)
 	c.Check(err, FitsTypeOf, (*portal.ResponseError)(nil))
@@ -131,7 +130,7 @@ func (s *portalSuite) TestOpenFileTimeout(c *C) {
 	defer restore()
 
 	file := filepath.Join(c.MkDir(), "test.txt")
-	c.Assert(ioutil.WriteFile(file, []byte("hello world"), 0644), IsNil)
+	c.Assert(os.WriteFile(file, []byte("hello world"), 0644), IsNil)
 
 	err := portal.OpenFile(s.SessionBus, file)
 	c.Check(err, FitsTypeOf, (*portal.ResponseError)(nil))
@@ -160,7 +159,7 @@ func (s *portalSuite) TestOpenMissingFile(c *C) {
 
 func (s *portalSuite) TestOpenUnreadableFile(c *C) {
 	path := filepath.Join(c.MkDir(), "test.txt")
-	c.Assert(ioutil.WriteFile(path, []byte("hello world"), 0644), IsNil)
+	c.Assert(os.WriteFile(path, []byte("hello world"), 0644), IsNil)
 	c.Assert(os.Chmod(path, 0), IsNil)
 
 	err := portal.OpenFile(s.SessionBus, path)

--- a/dirs/dirs_test.go
+++ b/dirs/dirs_test.go
@@ -20,7 +20,6 @@
 package dirs_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -120,7 +119,7 @@ func (s *DirsTestSuite) TestInsideBaseSnap(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(inside, Equals, false)
 
-	err = ioutil.WriteFile(snapYaml, []byte{}, 0755)
+	err = os.WriteFile(snapYaml, []byte{}, 0755)
 	c.Assert(err, IsNil)
 
 	inside, err = dirs.IsInsideBaseSnap()

--- a/errtracker/errtracker_test.go
+++ b/errtracker/errtracker_test.go
@@ -71,7 +71,7 @@ func (s *ErrtrackerTestSuite) SetUpTest(c *C) {
 	dirs.SetRootDir(s.tmpdir)
 
 	p := filepath.Join(s.tmpdir, "machine-id")
-	err := ioutil.WriteFile(p, []byte("bbb1a6a5bcdb418380056a2d759c3f7c"), 0644)
+	err := os.WriteFile(p, []byte("bbb1a6a5bcdb418380056a2d759c3f7c"), 0644)
 	c.Assert(err, IsNil)
 	s.AddCleanup(errtracker.MockMachineIDPaths([]string{p}))
 	s.AddCleanup(errtracker.MockHostSnapd(truePath))
@@ -97,7 +97,7 @@ func (s *ErrtrackerTestSuite) SetUpTest(c *C) {
 	mockSelfExe := filepath.Join(s.tmpdir, "self.exe")
 	mockSelfCwd := filepath.Join(s.tmpdir, "self.cwd")
 
-	c.Assert(ioutil.WriteFile(mockCpuinfo, []byte(`
+	c.Assert(os.WriteFile(mockCpuinfo, []byte(`
 processor	: 0
 bugs		: very yes
 etc		: ...
@@ -105,7 +105,7 @@ etc		: ...
 processor	: 42
 bugs		: very yes
 `[1:]), 0644), IsNil)
-	c.Assert(ioutil.WriteFile(mockSelfCmdline, []byte("foo\x00bar\x00baz"), 0644), IsNil)
+	c.Assert(os.WriteFile(mockSelfCmdline, []byte("foo\x00bar\x00baz"), 0644), IsNil)
 	c.Assert(os.Symlink("target of /proc/self/exe", mockSelfExe), IsNil)
 	c.Assert(os.Symlink("target of /proc/self/cwd", mockSelfCwd), IsNil)
 
@@ -135,14 +135,14 @@ func (s *ErrtrackerTestSuite) TestReport(c *C) {
 	snapConfineProfile := filepath.Join(s.tmpdir, "/etc/apparmor.d/usr.lib.snapd.snap-confine")
 	err := os.MkdirAll(filepath.Dir(snapConfineProfile), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(snapConfineProfile, []byte("# fake profile of snap-confine"), 0644)
+	err = os.WriteFile(snapConfineProfile, []byte("# fake profile of snap-confine"), 0644)
 	c.Assert(err, IsNil)
 
-	err = ioutil.WriteFile(snapConfineProfile+".dpkg-new", []byte{0}, 0644)
+	err = os.WriteFile(snapConfineProfile+".dpkg-new", []byte{0}, 0644)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(snapConfineProfile+".real", []byte{0}, 0644)
+	err = os.WriteFile(snapConfineProfile+".real", []byte{0}, 0644)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(snapConfineProfile+".real.dpkg-new", []byte{0}, 0644)
+	err = os.WriteFile(snapConfineProfile+".real.dpkg-new", []byte{0}, 0644)
 	c.Assert(err, IsNil)
 
 	prev := errtracker.SnapdVersion
@@ -264,7 +264,7 @@ func (s *ErrtrackerTestSuite) TestReportUnderTesting(c *C) {
 func (s *ErrtrackerTestSuite) TestTriesAllKnownMachineIDs(c *C) {
 	p := filepath.Join(c.MkDir(), "machine-id")
 	machineID := []byte("bbb1a6a5bcdb418380056a2d759c3f7c")
-	err := ioutil.WriteFile(p, machineID, 0644)
+	err := os.WriteFile(p, machineID, 0644)
 	c.Assert(err, IsNil)
 	s.AddCleanup(errtracker.MockMachineIDPaths([]string{"/does/not/exist", p}))
 
@@ -414,7 +414,7 @@ bugs		: very yes
 `[1:])
 
 	// if no processor line, just return the whole thing
-	c.Assert(ioutil.WriteFile(fn, []byte("yadda yadda\n"), 0644), IsNil)
+	c.Assert(os.WriteFile(fn, []byte("yadda yadda\n"), 0644), IsNil)
 	c.Check(errtracker.ProcCpuinfoMinimal(), Equals, "yadda yadda\n")
 
 	c.Assert(os.Remove(fn), IsNil)

--- a/features/features_test.go
+++ b/features/features_test.go
@@ -19,7 +19,6 @@
 package features_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -98,7 +97,7 @@ func (*featureSuite) TestIsEnabled(c *C) {
 	// If the feature file is a regular file then the feature is enabled.
 	err := os.MkdirAll(dirs.FeaturesDir, 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(dirs.FeaturesDir, f.String()), nil, 0644)
+	err = os.WriteFile(filepath.Join(dirs.FeaturesDir, f.String()), nil, 0644)
 	c.Assert(err, IsNil)
 	c.Check(f.IsEnabled(), Equals, true)
 

--- a/gadget/device/encrypt_test.go
+++ b/gadget/device/encrypt_test.go
@@ -74,13 +74,13 @@ func (s *deviceSuite) TestReadEncryptionMarkers(c *C) {
 	p1 := filepath.Join(tmpdir, filepath.Join(dirs.GlobalRootDir, "/run/mnt/ubuntu-data/system-data/var/lib/snapd/device/fde"), "marker")
 	err := os.MkdirAll(filepath.Dir(p1), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(p1, []byte("marker-p1"), 0600)
+	err = os.WriteFile(p1, []byte("marker-p1"), 0600)
 	c.Assert(err, IsNil)
 
 	p2 := filepath.Join(tmpdir, boot.InstallHostFDESaveDir, "marker")
 	err = os.MkdirAll(filepath.Dir(p2), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(p2, []byte("marker-p2"), 0600)
+	err = os.WriteFile(p2, []byte("marker-p2"), 0600)
 	c.Assert(err, IsNil)
 
 	// reading them returns the two different values
@@ -143,7 +143,7 @@ func (s *deviceSuite) TestSealedKeysMethodWithWrongContentHappy(c *C) {
 	mockSealedKeyPath := filepath.Join(root, "/var/lib/snapd/device/fde/sealed-keys")
 	err := os.MkdirAll(filepath.Dir(mockSealedKeyPath), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(mockSealedKeyPath, []byte("invalid-sealing-method"), 0600)
+	err = os.WriteFile(mockSealedKeyPath, []byte("invalid-sealing-method"), 0600)
 	c.Assert(err, IsNil)
 
 	// invalid/unknown sealing methods do not error

--- a/gadget/device_test.go
+++ b/gadget/device_test.go
@@ -21,7 +21,6 @@ package gadget_test
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -47,7 +46,7 @@ func (d *deviceSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 	err = os.MkdirAll(filepath.Join(d.dir, "/dev/mapper"), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(d.dir, "/dev/fakedevice"), []byte(""), 0644)
+	err = os.WriteFile(filepath.Join(d.dir, "/dev/fakedevice"), []byte(""), 0644)
 	c.Assert(err, IsNil)
 }
 
@@ -155,7 +154,7 @@ func (d *deviceSuite) TestDeviceFindChecksPartlabelAndFilesystemLabelMismatch(c 
 
 	// partlabel of the structure points to a different device
 	fakedeviceOther := filepath.Join(d.dir, "/dev/fakedevice-other")
-	err = ioutil.WriteFile(fakedeviceOther, []byte(""), 0644)
+	err = os.WriteFile(fakedeviceOther, []byte(""), 0644)
 	c.Assert(err, IsNil)
 	err = os.Symlink(fakedeviceOther, filepath.Join(d.dir, "/dev/disk/by-partlabel/bar"))
 	c.Assert(err, IsNil)
@@ -215,7 +214,7 @@ func (d *deviceSuite) TestDeviceFindNotFoundSymlinkPointsNowhere(c *C) {
 }
 
 func (d *deviceSuite) TestDeviceFindNotFoundNotASymlink(c *C) {
-	err := ioutil.WriteFile(filepath.Join(d.dir, "/dev/disk/by-label/foo"), nil, 0644)
+	err := os.WriteFile(filepath.Join(d.dir, "/dev/disk/by-label/foo"), nil, 0644)
 	c.Assert(err, IsNil)
 
 	found, err := gadget.FindDeviceForStructure(&gadget.VolumeStructure{

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -23,7 +23,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -684,7 +683,7 @@ func (s *gadgetYamlTestSuite) TestReadGadgetYamlOnClassicOptional(c *C) {
 }
 
 func (s *gadgetYamlTestSuite) TestReadGadgetYamlOnClassicEmptyIsValid(c *C) {
-	err := ioutil.WriteFile(s.gadgetYamlPath, nil, 0644)
+	err := os.WriteFile(s.gadgetYamlPath, nil, 0644)
 	c.Assert(err, IsNil)
 
 	ginfo, err := gadget.ReadInfo(s.dir, &gadgettest.ModelCharacteristics{IsClassic: true})
@@ -693,7 +692,7 @@ func (s *gadgetYamlTestSuite) TestReadGadgetYamlOnClassicEmptyIsValid(c *C) {
 }
 
 func (s *gadgetYamlTestSuite) TestReadGadgetYamlOnClassicOnylDefaultsIsValid(c *C) {
-	err := ioutil.WriteFile(s.gadgetYamlPath, mockClassicGadgetYaml, 0644)
+	err := os.WriteFile(s.gadgetYamlPath, mockClassicGadgetYaml, 0644)
 	c.Assert(err, IsNil)
 
 	ginfo, err := gadget.ReadInfo(s.dir, &gadgettest.ModelCharacteristics{IsClassic: true})
@@ -730,7 +729,7 @@ func (s *gadgetYamlTestSuite) TestFlatten(c *C) {
 }
 
 func (s *gadgetYamlTestSuite) TestCoreConfigDefaults(c *C) {
-	err := ioutil.WriteFile(s.gadgetYamlPath, mockClassicGadgetCoreDefaultsYaml, 0644)
+	err := os.WriteFile(s.gadgetYamlPath, mockClassicGadgetCoreDefaultsYaml, 0644)
 	c.Assert(err, IsNil)
 
 	ginfo, err := gadget.ReadInfo(s.dir, &gadgettest.ModelCharacteristics{IsClassic: true})
@@ -745,7 +744,7 @@ func (s *gadgetYamlTestSuite) TestCoreConfigDefaults(c *C) {
     something: true
 `
 
-	err = ioutil.WriteFile(s.gadgetYamlPath, []byte(yaml), 0644)
+	err = os.WriteFile(s.gadgetYamlPath, []byte(yaml), 0644)
 	c.Assert(err, IsNil)
 	ginfo, err = gadget.ReadInfo(s.dir, &gadgettest.ModelCharacteristics{IsClassic: true})
 	c.Assert(err, IsNil)
@@ -762,7 +761,7 @@ volumes:
 `
 
 func (s *gadgetYamlTestSuite) TestRegressionGadgetWithEmptyVolume(c *C) {
-	err := ioutil.WriteFile(s.gadgetYamlPath, []byte(mockGadgetWithEmptyVolumes), 0644)
+	err := os.WriteFile(s.gadgetYamlPath, []byte(mockGadgetWithEmptyVolumes), 0644)
 	c.Assert(err, IsNil)
 
 	_, err = gadget.ReadInfo(s.dir, nil)
@@ -770,7 +769,7 @@ func (s *gadgetYamlTestSuite) TestRegressionGadgetWithEmptyVolume(c *C) {
 }
 
 func (s *gadgetYamlTestSuite) TestReadGadgetDefaultsMultiline(c *C) {
-	err := ioutil.WriteFile(s.gadgetYamlPath, mockClassicGadgetMultilineDefaultsYaml, 0644)
+	err := os.WriteFile(s.gadgetYamlPath, mockClassicGadgetMultilineDefaultsYaml, 0644)
 	c.Assert(err, IsNil)
 
 	ginfo, err := gadget.ReadInfo(s.dir, &gadgettest.ModelCharacteristics{IsClassic: true})
@@ -817,7 +816,7 @@ func checkEnclosingPointsToVolume(c *C, vols map[string]*gadget.Volume) {
 }
 
 func (s *gadgetYamlTestSuite) TestReadGadgetYamlValid(c *C) {
-	err := ioutil.WriteFile(s.gadgetYamlPath, mockGadgetYaml, 0644)
+	err := os.WriteFile(s.gadgetYamlPath, mockGadgetYaml, 0644)
 	c.Assert(err, IsNil)
 
 	ginfo, err := gadget.ReadInfo(s.dir, coreMod)
@@ -871,7 +870,7 @@ func (s *gadgetYamlTestSuite) TestReadGadgetYamlValid(c *C) {
 }
 
 func (s *gadgetYamlTestSuite) TestReadMultiVolumeGadgetYamlValid(c *C) {
-	err := ioutil.WriteFile(s.gadgetYamlPath, mockMultiVolumeGadgetYaml, 0644)
+	err := os.WriteFile(s.gadgetYamlPath, mockMultiVolumeGadgetYaml, 0644)
 	c.Assert(err, IsNil)
 
 	ginfo, err := gadget.ReadInfo(s.dir, nil)
@@ -949,7 +948,7 @@ volumes:
   bootloader: silo
 `)
 
-	err := ioutil.WriteFile(s.gadgetYamlPath, mockGadgetYamlBroken, 0644)
+	err := os.WriteFile(s.gadgetYamlPath, mockGadgetYamlBroken, 0644)
 	c.Assert(err, IsNil)
 
 	_, err = gadget.ReadInfo(s.dir, nil)
@@ -963,7 +962,7 @@ volumes:
   bootloader:
 `)
 
-	err := ioutil.WriteFile(s.gadgetYamlPath, mockGadgetYamlBroken, 0644)
+	err := os.WriteFile(s.gadgetYamlPath, mockGadgetYamlBroken, 0644)
 	c.Assert(err, IsNil)
 
 	_, err = gadget.ReadInfo(s.dir, &gadgettest.ModelCharacteristics{IsClassic: false})
@@ -971,7 +970,7 @@ volumes:
 }
 
 func (s *gadgetYamlTestSuite) TestReadGadgetYamlMissingBootloader(c *C) {
-	err := ioutil.WriteFile(s.gadgetYamlPath, nil, 0644)
+	err := os.WriteFile(s.gadgetYamlPath, nil, 0644)
 	c.Assert(err, IsNil)
 
 	_, err = gadget.ReadInfo(s.dir, &gadgettest.ModelCharacteristics{IsClassic: false})
@@ -985,7 +984,7 @@ defaults:
   x: 1
 `)
 
-	err := ioutil.WriteFile(s.gadgetYamlPath, mockGadgetYamlBroken, 0644)
+	err := os.WriteFile(s.gadgetYamlPath, mockGadgetYamlBroken, 0644)
 	c.Assert(err, IsNil)
 
 	_, err = gadget.ReadInfo(s.dir, nil)
@@ -1012,7 +1011,7 @@ connections:
 	for _, t := range tests {
 		mockGadgetYamlBroken := strings.Replace(mockGadgetYamlBroken, "@INVALID@", t.invalidConn, 1)
 
-		err := ioutil.WriteFile(s.gadgetYamlPath, []byte(mockGadgetYamlBroken), 0644)
+		err := os.WriteFile(s.gadgetYamlPath, []byte(mockGadgetYamlBroken), 0644)
 		c.Assert(err, IsNil)
 
 		_, err = gadget.ReadInfo(s.dir, nil)
@@ -1021,7 +1020,7 @@ connections:
 }
 
 func (s *gadgetYamlTestSuite) TestReadGadgetYamlVolumeUpdate(c *C) {
-	err := ioutil.WriteFile(s.gadgetYamlPath, mockVolumeUpdateGadgetYaml, 0644)
+	err := os.WriteFile(s.gadgetYamlPath, mockVolumeUpdateGadgetYaml, 0644)
 	c.Assert(err, IsNil)
 
 	ginfo, err := gadget.ReadInfo(s.dir, coreMod)
@@ -1068,14 +1067,14 @@ func (s *gadgetYamlTestSuite) TestReadGadgetYamlVolumeUpdate(c *C) {
 
 func (s *gadgetYamlTestSuite) TestReadGadgetYamlVolumeUpdateUnhappy(c *C) {
 	broken := bytes.Replace(mockVolumeUpdateGadgetYaml, []byte("edition: 5"), []byte("edition: borked"), 1)
-	err := ioutil.WriteFile(s.gadgetYamlPath, broken, 0644)
+	err := os.WriteFile(s.gadgetYamlPath, broken, 0644)
 	c.Assert(err, IsNil)
 
 	_, err = gadget.ReadInfo(s.dir, nil)
 	c.Check(err, ErrorMatches, `cannot parse gadget metadata: "edition" must be a positive number, not "borked"`)
 
 	broken = bytes.Replace(mockVolumeUpdateGadgetYaml, []byte("edition: 5"), []byte("edition: -5"), 1)
-	err = ioutil.WriteFile(s.gadgetYamlPath, broken, 0644)
+	err = os.WriteFile(s.gadgetYamlPath, broken, 0644)
 	c.Assert(err, IsNil)
 
 	_, err = gadget.ReadInfo(s.dir, nil)
@@ -1129,7 +1128,7 @@ var classicModelCharacteristics = []gadget.Model{
 }
 
 func (s *gadgetYamlTestSuite) TestReadGadgetYamlPCHappy(c *C) {
-	err := ioutil.WriteFile(s.gadgetYamlPath, gadgetYamlPC, 0644)
+	err := os.WriteFile(s.gadgetYamlPath, gadgetYamlPC, 0644)
 	c.Assert(err, IsNil)
 
 	for _, mod := range classicModelCharacteristics {
@@ -1139,7 +1138,7 @@ func (s *gadgetYamlTestSuite) TestReadGadgetYamlPCHappy(c *C) {
 }
 
 func (s *gadgetYamlTestSuite) TestReadGadgetYamlRPiHappy(c *C) {
-	err := ioutil.WriteFile(s.gadgetYamlPath, gadgetYamlRPi, 0644)
+	err := os.WriteFile(s.gadgetYamlPath, gadgetYamlRPi, 0644)
 	c.Assert(err, IsNil)
 
 	for _, mod := range classicModelCharacteristics {
@@ -1149,7 +1148,7 @@ func (s *gadgetYamlTestSuite) TestReadGadgetYamlRPiHappy(c *C) {
 }
 
 func (s *gadgetYamlTestSuite) TestReadGadgetYamlLkHappy(c *C) {
-	err := ioutil.WriteFile(s.gadgetYamlPath, gadgetYamlLk, 0644)
+	err := os.WriteFile(s.gadgetYamlPath, gadgetYamlLk, 0644)
 	c.Assert(err, IsNil)
 
 	for _, mod := range classicModelCharacteristics {
@@ -1159,7 +1158,7 @@ func (s *gadgetYamlTestSuite) TestReadGadgetYamlLkHappy(c *C) {
 }
 
 func (s *gadgetYamlTestSuite) TestReadGadgetYamlLkUC20Happy(c *C) {
-	err := ioutil.WriteFile(s.gadgetYamlPath, gadgetYamlLkUC20, 0644)
+	err := os.WriteFile(s.gadgetYamlPath, gadgetYamlLkUC20, 0644)
 	c.Assert(err, IsNil)
 
 	uc20Model := &gadgettest.ModelCharacteristics{
@@ -1172,7 +1171,7 @@ func (s *gadgetYamlTestSuite) TestReadGadgetYamlLkUC20Happy(c *C) {
 }
 
 func (s *gadgetYamlTestSuite) TestReadGadgetYamlLkLegacyHappy(c *C) {
-	err := ioutil.WriteFile(s.gadgetYamlPath, gadgetYamlLkLegacy, 0644)
+	err := os.WriteFile(s.gadgetYamlPath, gadgetYamlLkLegacy, 0644)
 	c.Assert(err, IsNil)
 
 	for _, mod := range classicModelCharacteristics {
@@ -1708,7 +1707,7 @@ volumes:
           - image: pc-core.img
 `
 
-	err := ioutil.WriteFile(s.gadgetYamlPath, []byte(gadgetYamlBadStructureName), 0644)
+	err := os.WriteFile(s.gadgetYamlPath, []byte(gadgetYamlBadStructureName), 0644)
 	c.Assert(err, IsNil)
 
 	_, err = gadget.ReadInfo(s.dir, nil)
@@ -1823,7 +1822,7 @@ volumes:
         content:
           - image: pc-core.img
 `
-	err := ioutil.WriteFile(s.gadgetYamlPath, []byte(overlappingGadgetYaml), 0644)
+	err := os.WriteFile(s.gadgetYamlPath, []byte(overlappingGadgetYaml), 0644)
 	c.Assert(err, IsNil)
 
 	_, err = gadget.ReadInfo(s.dir, nil)
@@ -1848,7 +1847,7 @@ volumes:
         offset: 100
         filesystem: vfat
 `
-	err := ioutil.WriteFile(s.gadgetYamlPath, []byte(outOfOrderGadgetYaml), 0644)
+	err := os.WriteFile(s.gadgetYamlPath, []byte(outOfOrderGadgetYaml), 0644)
 	c.Assert(err, IsNil)
 
 	_, err = gadget.ReadInfo(s.dir, nil)
@@ -1874,7 +1873,7 @@ volumes:
         size: 1M
         offset: 3M
 `
-	err := ioutil.WriteFile(s.gadgetYamlPath, []byte(overlappingGadgetYaml), 0644)
+	err := os.WriteFile(s.gadgetYamlPath, []byte(overlappingGadgetYaml), 0644)
 	c.Assert(err, IsNil)
 
 	_, err = gadget.ReadInfo(s.dir, nil)
@@ -1900,7 +1899,7 @@ volumes:
         content:
           - image: pc-boot.img
 `
-	err := ioutil.WriteFile(s.gadgetYamlPath, []byte(gadgetYaml), 0644)
+	err := os.WriteFile(s.gadgetYamlPath, []byte(gadgetYaml), 0644)
 	c.Assert(err, IsNil)
 
 	_, err = gadget.ReadInfo(s.dir, nil)
@@ -1925,7 +1924,7 @@ volumes:
         content:
           - image: pc-boot.img
 `
-	err := ioutil.WriteFile(s.gadgetYamlPath, []byte(gadgetYaml), 0644)
+	err := os.WriteFile(s.gadgetYamlPath, []byte(gadgetYaml), 0644)
 	c.Assert(err, IsNil)
 
 	_, err = gadget.ReadInfo(s.dir, nil)
@@ -1968,7 +1967,7 @@ volumes:
         role: system-data
         filesystem-label: %s`, tc.label)
 
-		err := ioutil.WriteFile(s.gadgetYamlPath, b.Bytes(), 0644)
+		err := os.WriteFile(s.gadgetYamlPath, b.Bytes(), 0644)
 		c.Assert(err, IsNil)
 
 		_, err = gadget.ReadInfoAndValidate(s.dir, nil, nil)
@@ -1984,7 +1983,7 @@ volumes:
     schema: mbr
     structure:`
 
-	err := ioutil.WriteFile(s.gadgetYamlPath, []byte(bloader), 0644)
+	err := os.WriteFile(s.gadgetYamlPath, []byte(bloader), 0644)
 	c.Assert(err, IsNil)
 	mod := &gadgettest.ModelCharacteristics{
 		HasModes: true,
@@ -1995,7 +1994,7 @@ volumes:
 }
 
 func (s *gadgetYamlTestSuite) TestGadgetReadInfoVsFromMeta(c *C) {
-	err := ioutil.WriteFile(s.gadgetYamlPath, gadgetYamlPC, 0644)
+	err := os.WriteFile(s.gadgetYamlPath, gadgetYamlPC, 0644)
 	c.Assert(err, IsNil)
 
 	mod := &gadgettest.ModelCharacteristics{
@@ -2342,10 +2341,10 @@ func (s *gadgetYamlTestSuite) TestGadgetFromMetaEmpty(c *C) {
 }
 
 func (s *gadgetYamlTestSuite) TestLaidOutVolumesFromGadgetMultiVolume(c *C) {
-	err := ioutil.WriteFile(s.gadgetYamlPath, mockMultiVolumeUC20GadgetYaml, 0644)
+	err := os.WriteFile(s.gadgetYamlPath, mockMultiVolumeUC20GadgetYaml, 0644)
 	c.Assert(err, IsNil)
 
-	err = ioutil.WriteFile(filepath.Join(s.dir, "u-boot.imz"), nil, 0644)
+	err = os.WriteFile(filepath.Join(s.dir, "u-boot.imz"), nil, 0644)
 	c.Assert(err, IsNil)
 
 	systemLv, all, err := gadgettest.LaidOutVolumesFromGadget(s.dir, "", uc20Mod, secboot.EncryptionTypeNone, nil)
@@ -2390,10 +2389,10 @@ func (s *gadgetYamlTestSuite) TestLaidOutVolumesFromGadgetMultiVolume(c *C) {
 }
 
 func (s *gadgetYamlTestSuite) TestLaidOutVolumesFromGadgetHappy(c *C) {
-	err := ioutil.WriteFile(s.gadgetYamlPath, gadgetYamlPC, 0644)
+	err := os.WriteFile(s.gadgetYamlPath, gadgetYamlPC, 0644)
 	c.Assert(err, IsNil)
 	for _, fn := range []string{"pc-boot.img", "pc-core.img"} {
-		err = ioutil.WriteFile(filepath.Join(s.dir, fn), nil, 0644)
+		err = os.WriteFile(filepath.Join(s.dir, fn), nil, 0644)
 		c.Assert(err, IsNil)
 	}
 
@@ -2407,10 +2406,10 @@ func (s *gadgetYamlTestSuite) TestLaidOutVolumesFromGadgetHappy(c *C) {
 }
 
 func (s *gadgetYamlTestSuite) TestLaidOutVolumesFromGadgetAndDiskHappy(c *C) {
-	err := ioutil.WriteFile(s.gadgetYamlPath, gadgetYamlUC20PC, 0644)
+	err := os.WriteFile(s.gadgetYamlPath, gadgetYamlUC20PC, 0644)
 	c.Assert(err, IsNil)
 	for _, fn := range []string{"pc-boot.img", "pc-core.img"} {
-		err = ioutil.WriteFile(filepath.Join(s.dir, fn), nil, 0644)
+		err = os.WriteFile(filepath.Join(s.dir, fn), nil, 0644)
 		c.Assert(err, IsNil)
 	}
 
@@ -2439,10 +2438,10 @@ func (s *gadgetYamlTestSuite) TestLaidOutVolumesFromGadgetAndDiskHappy(c *C) {
 }
 
 func (s *gadgetYamlTestSuite) TestLaidOutVolumesFromGadgetAndDiskFail(c *C) {
-	err := ioutil.WriteFile(s.gadgetYamlPath, gadgetYamlUC20PC, 0644)
+	err := os.WriteFile(s.gadgetYamlPath, gadgetYamlUC20PC, 0644)
 	c.Assert(err, IsNil)
 	for _, fn := range []string{"pc-boot.img", "pc-core.img"} {
-		err = ioutil.WriteFile(filepath.Join(s.dir, fn), nil, 0644)
+		err = os.WriteFile(filepath.Join(s.dir, fn), nil, 0644)
 		c.Assert(err, IsNil)
 	}
 
@@ -2460,10 +2459,10 @@ func (s *gadgetYamlTestSuite) TestLaidOutVolumesFromGadgetAndDiskFail(c *C) {
 }
 
 func (s *gadgetYamlTestSuite) TestLaidOutVolumesFromGadgetNeedsModel(c *C) {
-	err := ioutil.WriteFile(s.gadgetYamlPath, gadgetYamlPC, 0644)
+	err := os.WriteFile(s.gadgetYamlPath, gadgetYamlPC, 0644)
 	c.Assert(err, IsNil)
 	for _, fn := range []string{"pc-boot.img", "pc-core.img"} {
-		err = ioutil.WriteFile(filepath.Join(s.dir, fn), nil, 0644)
+		err = os.WriteFile(filepath.Join(s.dir, fn), nil, 0644)
 		c.Assert(err, IsNil)
 	}
 
@@ -2474,10 +2473,10 @@ func (s *gadgetYamlTestSuite) TestLaidOutVolumesFromGadgetNeedsModel(c *C) {
 }
 
 func (s *gadgetYamlTestSuite) testLaidOutVolumesFromGadgetUCHappy(c *C, gadgetYaml []byte) {
-	err := ioutil.WriteFile(s.gadgetYamlPath, gadgetYaml, 0644)
+	err := os.WriteFile(s.gadgetYamlPath, gadgetYaml, 0644)
 	c.Assert(err, IsNil)
 	for _, fn := range []string{"pc-boot.img", "pc-core.img"} {
-		err = ioutil.WriteFile(filepath.Join(s.dir, fn), nil, 0644)
+		err = os.WriteFile(filepath.Join(s.dir, fn), nil, 0644)
 		c.Assert(err, IsNil)
 	}
 
@@ -2903,7 +2902,7 @@ func (s *gadgetYamlTestSuite) testKernelCommandLineArgs(c *C, whichCmdline strin
 
 	for _, arg := range allowedArgs {
 		c.Logf("trying allowed arg: %q", arg)
-		err := ioutil.WriteFile(filepath.Join(info.MountDir(), whichCmdline), []byte(arg), 0644)
+		err := os.WriteFile(filepath.Join(info.MountDir(), whichCmdline), []byte(arg), 0644)
 		c.Assert(err, IsNil)
 
 		cmdline, _, err := gadget.KernelCommandLineFromGadget(info.MountDir())
@@ -2922,7 +2921,7 @@ func (s *gadgetYamlTestSuite) testKernelCommandLineArgs(c *C, whichCmdline strin
 
 	for _, arg := range disallowedArgs {
 		c.Logf("trying disallowed arg: %q", arg)
-		err := ioutil.WriteFile(filepath.Join(info.MountDir(), whichCmdline), []byte(arg), 0644)
+		err := os.WriteFile(filepath.Join(info.MountDir(), whichCmdline), []byte(arg), 0644)
 		c.Assert(err, IsNil)
 
 		cmdline, _, err := gadget.KernelCommandLineFromGadget(info.MountDir())
@@ -3885,7 +3884,7 @@ func (s *gadgetYamlTestSuite) TestSaveLoadDiskVolumeDeviceTraits(c *C) {
 		"pi": gadgettest.ExpectedRaspiDiskVolumeDeviceTraits,
 	}
 
-	err = ioutil.WriteFile(
+	err = os.WriteFile(
 		filepath.Join(dirs.SnapDeviceDir, "disk-mapping.json"),
 		[]byte(gadgettest.ExpectedRaspiDiskVolumeDeviceTraitsJSON),
 		0644,
@@ -3902,7 +3901,7 @@ func (s *gadgetYamlTestSuite) TestSaveLoadDiskVolumeDeviceTraits(c *C) {
 		"pi": gadgettest.ExpectedLUKSEncryptedRaspiDiskVolumeDeviceTraits,
 	}
 
-	err = ioutil.WriteFile(
+	err = os.WriteFile(
 		filepath.Join(dirs.SnapDeviceDir, "disk-mapping.json"),
 		[]byte(gadgettest.ExpectedLUKSEncryptedRaspiDiskVolumeDeviceTraitsJSON),
 		0644,
@@ -4019,7 +4018,7 @@ func (s *gadgetYamlTestSuite) TestAllDiskVolumeDeviceTraitsHappy(c *C) {
 	fakedevicepart := filepath.Join(dirs.GlobalRootDir, "/dev/foo1")
 	err = os.Symlink(fakedevicepart, filepath.Join(dirs.GlobalRootDir, "/dev/disk/by-partlabel/nofspart"))
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(fakedevicepart, nil, 0644)
+	err = os.WriteFile(fakedevicepart, nil, 0644)
 	c.Assert(err, IsNil)
 
 	// mock the device name
@@ -4061,7 +4060,7 @@ func (s *gadgetYamlTestSuite) TestAllDiskVolumeDeviceTraitsTriesAllStructures(c 
 	fakedevicepart := filepath.Join(dirs.GlobalRootDir, "/dev/foo2")
 	err = os.Symlink(fakedevicepart, filepath.Join(dirs.GlobalRootDir, "/dev/disk/by-label/some-filesystem"))
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(fakedevicepart, nil, 0644)
+	err = os.WriteFile(fakedevicepart, nil, 0644)
 	c.Assert(err, IsNil)
 
 	// mock the device name
@@ -4099,14 +4098,14 @@ func (s *gadgetYamlTestSuite) TestAllDiskVolumeDeviceTraitsMultipleGPTVolumes(c 
 	fooVolDevicePart := filepath.Join(dirs.GlobalRootDir, "/dev/vdb1")
 	err = os.Symlink(fooVolDevicePart, filepath.Join(dirs.GlobalRootDir, "/dev/disk/by-partlabel/nofspart"))
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(fooVolDevicePart, nil, 0644)
+	err = os.WriteFile(fooVolDevicePart, nil, 0644)
 	c.Assert(err, IsNil)
 
 	// make a symlink for the partition label for "BIOS Boot" to /dev/vda1
 	fakepcdevicepart := filepath.Join(dirs.GlobalRootDir, "/dev/vda1")
 	err = os.Symlink(fakepcdevicepart, filepath.Join(dirs.GlobalRootDir, "/dev/disk/by-partlabel/BIOS\\x20Boot"))
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(fakepcdevicepart, nil, 0644)
+	err = os.WriteFile(fakepcdevicepart, nil, 0644)
 	c.Assert(err, IsNil)
 
 	// mock the device name
@@ -4147,7 +4146,7 @@ func (s *gadgetYamlTestSuite) TestAllDiskVolumeDeviceTraitsMultipleGPTVolumes(c 
 	// constructed
 	err = os.MkdirAll(dirs.SnapDeviceDir, 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(
+	err = os.WriteFile(
 		filepath.Join(dirs.SnapDeviceDir, "disk-mapping.json"),
 		[]byte(gadgettest.VMMultiVolumeUC20DiskTraitsJSON),
 		0644,
@@ -4168,7 +4167,7 @@ func (s *gadgetYamlTestSuite) TestAllDiskVolumeDeviceTraitsImplicitSystemDataHap
 	biosBootPart := filepath.Join(dirs.GlobalRootDir, "/dev/sda1")
 	err = os.Symlink(biosBootPart, filepath.Join(dirs.GlobalRootDir, "/dev/disk/by-partlabel/BIOS\\x20Boot"))
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(biosBootPart, nil, 0644)
+	err = os.WriteFile(biosBootPart, nil, 0644)
 	c.Assert(err, IsNil)
 
 	// mock the device name
@@ -4313,10 +4312,10 @@ func (s *gadgetYamlTestSuite) TestGadgetInfoVolumeStructureInternalFieldsNoJSON(
 }
 
 func (s *gadgetYamlTestSuite) TestLaidOutVolumesFromClassicWithModesGadgetHappy(c *C) {
-	err := ioutil.WriteFile(s.gadgetYamlPath, gadgetYamlClassicWithModes, 0644)
+	err := os.WriteFile(s.gadgetYamlPath, gadgetYamlClassicWithModes, 0644)
 	c.Assert(err, IsNil)
 	for _, fn := range []string{"pc-boot.img", "pc-core.img"} {
-		err = ioutil.WriteFile(filepath.Join(s.dir, fn), nil, 0644)
+		err = os.WriteFile(filepath.Join(s.dir, fn), nil, 0644)
 		c.Assert(err, IsNil)
 	}
 
@@ -4343,7 +4342,7 @@ func (s *gadgetYamlTestSuite) TestHasRole(c *C) {
 	}
 
 	for _, t := range tests {
-		err := ioutil.WriteFile(s.gadgetYamlPath, t.yaml, 0644)
+		err := os.WriteFile(s.gadgetYamlPath, t.yaml, 0644)
 		c.Assert(err, IsNil)
 
 		found, err := gadget.HasRole(s.dir, t.roles)
@@ -4356,7 +4355,7 @@ func (s *gadgetYamlTestSuite) TestHasRoleUnhappy(c *C) {
 	_, err := gadget.HasRole("bogus-path", []string{gadget.SystemData})
 	c.Check(err, ErrorMatches, `.*meta/gadget.yaml: no such file or directory`)
 
-	err = ioutil.WriteFile(s.gadgetYamlPath, []byte(`{`), 0644)
+	err = os.WriteFile(s.gadgetYamlPath, []byte(`{`), 0644)
 	c.Assert(err, IsNil)
 	_, err = gadget.HasRole(s.dir, []string{gadget.SystemData})
 	c.Check(err, ErrorMatches, `cannot minimally parse gadget metadata: yaml:.*`)

--- a/gadget/gadgettest/gadgettest.go
+++ b/gadget/gadgettest/gadgettest.go
@@ -21,7 +21,6 @@ package gadgettest
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -67,7 +66,7 @@ func WriteGadgetYaml(newDir, gadgetYaml string) (string, error) {
 		return "", err
 	}
 
-	if err := ioutil.WriteFile(filepath.Join(gadgetRoot, "meta", "gadget.yaml"), []byte(gadgetYaml), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(gadgetRoot, "meta", "gadget.yaml"), []byte(gadgetYaml), 0644); err != nil {
 		return "", err
 	}
 
@@ -155,19 +154,19 @@ func MakeMockGadget(gadgetRoot, gadgetContent string) error {
 	if err := os.MkdirAll(filepath.Join(gadgetRoot, "meta"), 0755); err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(filepath.Join(gadgetRoot, "meta", "gadget.yaml"), []byte(gadgetContent), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(gadgetRoot, "meta", "gadget.yaml"), []byte(gadgetContent), 0644); err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(filepath.Join(gadgetRoot, "pc-boot.img"), []byte("pc-boot.img content"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(gadgetRoot, "pc-boot.img"), []byte("pc-boot.img content"), 0644); err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(filepath.Join(gadgetRoot, "pc-core.img"), []byte("pc-core.img content"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(gadgetRoot, "pc-core.img"), []byte("pc-core.img content"), 0644); err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(filepath.Join(gadgetRoot, "grubx64.efi"), []byte("grubx64.efi content"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(gadgetRoot, "grubx64.efi"), []byte("grubx64.efi content"), 0644); err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(filepath.Join(gadgetRoot, "shim.efi.signed"), []byte("shim.efi.signed content"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(gadgetRoot, "shim.efi.signed"), []byte("shim.efi.signed content"), 0644); err != nil {
 		return err
 	}
 

--- a/gadget/install/install_test.go
+++ b/gadget/install/install_test.go
@@ -474,7 +474,7 @@ fi
 		jsonBytes = []byte(gadgettest.ExpectedLUKSEncryptedRaspiDiskVolumeDeviceTraitsJSON)
 	}
 
-	err = ioutil.WriteFile(dataFile, jsonBytes, 0644)
+	err = os.WriteFile(dataFile, jsonBytes, 0644)
 	c.Assert(err, IsNil)
 
 	mapping2, err := gadget.LoadDiskVolumesDeviceTraits(dirs.SnapDeviceDirUnder(filepath.Join(dirs.GlobalRootDir, "/run/mnt/ubuntu-data/system-data")))
@@ -531,7 +531,7 @@ func (s *installSuite) setupMockUdevSymlinks(c *C, devName string) {
 	err := os.MkdirAll(filepath.Join(s.dir, "/dev/disk/by-partlabel"), 0755)
 	c.Assert(err, IsNil)
 
-	err = ioutil.WriteFile(filepath.Join(s.dir, "/dev/"+devName), nil, 0644)
+	err = os.WriteFile(filepath.Join(s.dir, "/dev/"+devName), nil, 0644)
 	c.Assert(err, IsNil)
 	err = os.Symlink("../../"+devName, filepath.Join(s.dir, "/dev/disk/by-partlabel/ubuntu-seed"))
 	c.Assert(err, IsNil)
@@ -845,7 +845,7 @@ fi
 	// the static JSON to make sure they compare the same, this ensures that
 	// the JSON that is written always stays compatible
 	jsonBytes := []byte(opts.traitsJSON)
-	err = ioutil.WriteFile(dataFile, jsonBytes, 0644)
+	err = os.WriteFile(dataFile, jsonBytes, 0644)
 	c.Assert(err, IsNil)
 
 	mapping2, err := gadget.LoadDiskVolumesDeviceTraits(dirs.SnapDeviceDirUnder(filepath.Join(dirs.GlobalRootDir, "/run/mnt/ubuntu-data/system-data")))

--- a/gadget/install/partition_test.go
+++ b/gadget/install/partition_test.go
@@ -21,7 +21,6 @@ package install_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -587,7 +586,7 @@ func (s *partitionTestSuite) TestRemovePartitionsWithDeviceRescan(c *C) {
 	err := os.MkdirAll(filepath.Join(devPath, "device"), 0755)
 	c.Assert(err, IsNil)
 
-	err = ioutil.WriteFile(filepath.Join(devPath, "device", "rescan"), nil, 0755)
+	err = os.WriteFile(filepath.Join(devPath, "device", "rescan"), nil, 0755)
 	c.Assert(err, IsNil)
 
 	fmt.Println("wrote", devPath)
@@ -608,7 +607,7 @@ func (s *partitionTestSuite) TestRemovePartitionsWithDeviceRescan(c *C) {
 	c.Assert(err, IsNil)
 
 	// add the file to indicate we should do the device/rescan trick
-	err = ioutil.WriteFile(filepath.Join(s.gadgetRoot, "meta", "force-partition-table-reload-via-device-rescan"), nil, 0755)
+	err = os.WriteFile(filepath.Join(s.gadgetRoot, "meta", "force-partition-table-reload-via-device-rescan"), nil, 0755)
 	c.Assert(err, IsNil)
 
 	gInfo, err := gadget.ReadInfoAndValidate(s.gadgetRoot, uc20Mod, nil)
@@ -797,7 +796,7 @@ func (s *partitionTestSuite) TestEnsureNodesExist(c *C) {
 		c.Logf("utErr:%q err:%q", tc.utErr, tc.err)
 
 		node := filepath.Join(c.MkDir(), "node")
-		err := ioutil.WriteFile(node, nil, 0644)
+		err := os.WriteFile(node, nil, 0644)
 		c.Assert(err, IsNil)
 
 		cmdUdevadm := testutil.MockCommand(c, "udevadm", fmt.Sprintf(mockUdevadmScript, tc.utErr))

--- a/gadget/layout_test.go
+++ b/gadget/layout_test.go
@@ -23,7 +23,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1096,14 +1095,14 @@ func mockKernel(c *C, kernelYaml string, filesWithContent map[string]string) str
 	kernelRootDir := c.MkDir()
 	err = os.MkdirAll(filepath.Join(kernelRootDir, "meta"), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(kernelRootDir, "meta/kernel.yaml"), []byte(kernelYaml), 0644)
+	err = os.WriteFile(filepath.Join(kernelRootDir, "meta/kernel.yaml"), []byte(kernelYaml), 0644)
 	c.Assert(err, IsNil)
 
 	for fname, content := range filesWithContent {
 		p := filepath.Join(kernelRootDir, fname)
 		err = os.MkdirAll(filepath.Dir(p), 0755)
 		c.Assert(err, IsNil)
-		err = ioutil.WriteFile(p, []byte(content), 0644)
+		err = os.WriteFile(p, []byte(content), 0644)
 		c.Assert(err, IsNil)
 	}
 

--- a/gadget/ondisk_test.go
+++ b/gadget/ondisk_test.go
@@ -21,7 +21,6 @@ package gadget_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -59,16 +58,16 @@ func makeMockGadget(gadgetRoot, gadgetContent string) error {
 	if err := os.MkdirAll(filepath.Join(gadgetRoot, "meta"), 0755); err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(filepath.Join(gadgetRoot, "meta", "gadget.yaml"), []byte(gadgetContent), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(gadgetRoot, "meta", "gadget.yaml"), []byte(gadgetContent), 0644); err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(filepath.Join(gadgetRoot, "pc-boot.img"), []byte("pc-boot.img content"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(gadgetRoot, "pc-boot.img"), []byte("pc-boot.img content"), 0644); err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(filepath.Join(gadgetRoot, "pc-core.img"), []byte("pc-core.img content"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(gadgetRoot, "pc-core.img"), []byte("pc-core.img content"), 0644); err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(filepath.Join(gadgetRoot, "grubx64.efi"), []byte("grubx64.efi content"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(gadgetRoot, "grubx64.efi"), []byte("grubx64.efi content"), 0644); err != nil {
 		return err
 	}
 

--- a/gadget/partial_test.go
+++ b/gadget/partial_test.go
@@ -21,7 +21,7 @@ package gadget_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/gadget/quantity"
@@ -60,7 +60,7 @@ volumes:
         type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
         role: system-data
 `)
-	err := ioutil.WriteFile(s.gadgetYamlPath, yaml, 0644)
+	err := os.WriteFile(s.gadgetYamlPath, yaml, 0644)
 	c.Assert(err, IsNil)
 
 	installerVols := map[string]*gadget.Volume{
@@ -136,7 +136,7 @@ volumes:
         type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
         role: system-data
 `)
-	err := ioutil.WriteFile(s.gadgetYamlPath, yaml, 0644)
+	err := os.WriteFile(s.gadgetYamlPath, yaml, 0644)
 	c.Assert(err, IsNil)
 
 	installerVols := map[string]*gadget.Volume{
@@ -209,7 +209,7 @@ volumes:
         type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
         role: system-data
 `)
-	err := ioutil.WriteFile(s.gadgetYamlPath, yaml, 0644)
+	err := os.WriteFile(s.gadgetYamlPath, yaml, 0644)
 	c.Assert(err, IsNil)
 
 	installerVols := map[string]*gadget.Volume{
@@ -287,7 +287,7 @@ volumes:
         type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
         role: system-data
 `)
-	err := ioutil.WriteFile(s.gadgetYamlPath, yaml, 0644)
+	err := os.WriteFile(s.gadgetYamlPath, yaml, 0644)
 	c.Assert(err, IsNil)
 
 	installerVols := map[string]*gadget.Volume{

--- a/gadget/update_test.go
+++ b/gadget/update_test.go
@@ -22,7 +22,6 @@ package gadget_test
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -823,7 +822,7 @@ func (u *updateTestSuite) TestUpdateApplyUC16FullLogic(c *C) {
 	fakedevicepart := filepath.Join(dirs.GlobalRootDir, "/dev/sda1")
 	err = os.Symlink(fakedevicepart, filepath.Join(dirs.GlobalRootDir, "/dev/disk/by-partlabel", disks.BlkIDEncodeLabel("EFI System")))
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(fakedevicepart, nil, 0644)
+	err = os.WriteFile(fakedevicepart, nil, 0644)
 	c.Assert(err, IsNil)
 
 	// mock the partition device node to mock disk
@@ -998,7 +997,7 @@ func (u *updateTestSuite) TestUpdateApplyUC20MissingInitialMapFullLogicOnlySyste
 	fakedevicepart := filepath.Join(dirs.GlobalRootDir, "/dev/vda1")
 	err = os.Symlink(fakedevicepart, filepath.Join(dirs.GlobalRootDir, "/dev/disk/by-partlabel", disks.BlkIDEncodeLabel("BIOS Boot")))
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(fakedevicepart, nil, 0644)
+	err = os.WriteFile(fakedevicepart, nil, 0644)
 	c.Assert(err, IsNil)
 
 	// mock the partition device node to mock disk
@@ -1241,7 +1240,7 @@ func (u *updateTestSuite) TestUpdateApplyUC20MissingInitialMapFullLogicOnlySyste
 	fakedevicepart := filepath.Join(dirs.GlobalRootDir, "/dev/vda1")
 	err = os.Symlink(fakedevicepart, filepath.Join(dirs.GlobalRootDir, "/dev/disk/by-label", disks.BlkIDEncodeLabel("UBUNTU-SEED")))
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(fakedevicepart, nil, 0644)
+	err = os.WriteFile(fakedevicepart, nil, 0644)
 	c.Assert(err, IsNil)
 
 	// mock the partition device node to mock disk
@@ -1484,7 +1483,7 @@ func (u *updateTestSuite) TestUpdateApplyUC20MissingInitialMapFullLogicOnlySyste
 	fakedevicepart := filepath.Join(dirs.GlobalRootDir, "/dev/vda1")
 	err = os.Symlink(fakedevicepart, filepath.Join(dirs.GlobalRootDir, "/dev/disk/by-partlabel", disks.BlkIDEncodeLabel("BIOS Boot")))
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(fakedevicepart, nil, 0644)
+	err = os.WriteFile(fakedevicepart, nil, 0644)
 	c.Assert(err, IsNil)
 
 	// mock the partition device node to mock disk
@@ -1708,7 +1707,7 @@ func (u *updateTestSuite) TestUpdateApplyUC20WithInitialMapAllVolumesUpdatedFull
 	c.Assert(err, IsNil)
 	// write out the provided traits JSON so we can at least load the traits for
 	// mocking via setupForVolumeStructureToLocation
-	err = ioutil.WriteFile(
+	err = os.WriteFile(
 		filepath.Join(dirs.SnapDeviceDir, "disk-mapping.json"),
 		[]byte(gadgettest.VMMultiVolumeUC20DiskTraitsJSON),
 		0644,
@@ -1746,7 +1745,7 @@ func (u *updateTestSuite) TestUpdateApplyUC20WithInitialMapAllVolumesUpdatedFull
 	fakedevicepart := filepath.Join(dirs.GlobalRootDir, "/dev/vda1")
 	err = os.Symlink(fakedevicepart, filepath.Join(dirs.GlobalRootDir, "/dev/disk/by-partlabel", disks.BlkIDEncodeLabel("BIOS Boot")))
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(fakedevicepart, nil, 0644)
+	err = os.WriteFile(fakedevicepart, nil, 0644)
 	c.Assert(err, IsNil)
 
 	// mock the partition device node to mock disk
@@ -2045,7 +2044,7 @@ func (u *updateTestSuite) TestUpdateApplyUC20WithInitialMapIncompatibleStructure
 	c.Assert(err, IsNil)
 	// write out the provided traits JSON so we can at least load the traits for
 	// mocking via setupForVolumeStructureToLocation
-	err = ioutil.WriteFile(
+	err = os.WriteFile(
 		filepath.Join(dirs.SnapDeviceDir, "disk-mapping.json"),
 		[]byte(gadgettest.VMMultiVolumeUC20DiskTraitsJSON),
 		0644,
@@ -2208,7 +2207,7 @@ volumes:
 	c.Assert(err, IsNil)
 	// write out the provided traits JSON so we can at least load the traits for
 	// mocking via setupForVolumeStructureToLocation
-	err = ioutil.WriteFile(
+	err = os.WriteFile(
 		filepath.Join(dirs.SnapDeviceDir, "disk-mapping.json"),
 		[]byte(gadgettest.VMMultiVolumeUC20DiskTraitsJSON),
 		0644,
@@ -2246,7 +2245,7 @@ volumes:
 	fakedevicepart := filepath.Join(dirs.GlobalRootDir, "/dev/vda1")
 	err = os.Symlink(fakedevicepart, filepath.Join(dirs.GlobalRootDir, "/dev/disk/by-partlabel", disks.BlkIDEncodeLabel("BIOS Boot")))
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(fakedevicepart, nil, 0644)
+	err = os.WriteFile(fakedevicepart, nil, 0644)
 	c.Assert(err, IsNil)
 
 	// mock the partition device node to mock disk
@@ -2508,7 +2507,7 @@ volumes:
 	c.Assert(err, IsNil)
 	// write out the provided traits JSON so we can at least load the traits for
 	// mocking via setupForVolumeStructureToLocation
-	err = ioutil.WriteFile(
+	err = os.WriteFile(
 		filepath.Join(dirs.SnapDeviceDir, "disk-mapping.json"),
 		[]byte(gadgettest.VMMultiVolumeUC20DiskTraitsJSON),
 		0644,
@@ -2546,7 +2545,7 @@ volumes:
 	fakedevicepart := filepath.Join(dirs.GlobalRootDir, "/dev/vda1")
 	err = os.Symlink(fakedevicepart, filepath.Join(dirs.GlobalRootDir, "/dev/disk/by-partlabel", disks.BlkIDEncodeLabel("BIOS Boot")))
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(fakedevicepart, nil, 0644)
+	err = os.WriteFile(fakedevicepart, nil, 0644)
 	c.Assert(err, IsNil)
 
 	// mock the partition device node to mock disk
@@ -3397,7 +3396,7 @@ func (u *updateTestSuite) TestUpdaterForStructure(c *C) {
 	err = os.MkdirAll(filepath.Join(rootDir, "/dev/disk/by-label"), 0755)
 	c.Assert(err, IsNil)
 	fakedevice := filepath.Join(rootDir, "/dev/sdxxx2")
-	err = ioutil.WriteFile(fakedevice, []byte(""), 0644)
+	err = os.WriteFile(fakedevice, []byte(""), 0644)
 	c.Assert(err, IsNil)
 	err = os.Symlink(fakedevice, filepath.Join(rootDir, "/dev/disk/by-label/writable"))
 	c.Assert(err, IsNil)
@@ -4526,7 +4525,7 @@ func (u *updateTestSuite) TestBuildNewVolumeToDeviceMappingImplicitSystemDataUC1
 	fakedevicepart := filepath.Join(dirs.GlobalRootDir, "/dev/sda1")
 	err = os.Symlink(fakedevicepart, filepath.Join(dirs.GlobalRootDir, "/dev/disk/by-partlabel", disks.BlkIDEncodeLabel("EFI System")))
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(fakedevicepart, nil, 0644)
+	err = os.WriteFile(fakedevicepart, nil, 0644)
 	c.Assert(err, IsNil)
 
 	// mock the partition device node to mock disk
@@ -4593,7 +4592,7 @@ func (u *updateTestSuite) TestBuildNewVolumeToDeviceMappingImplicitSystemBootSin
 	fakedevicepart := filepath.Join(dirs.GlobalRootDir, "/dev/sda1")
 	err = os.Symlink(fakedevicepart, filepath.Join(dirs.GlobalRootDir, "/dev/disk/by-partlabel", disks.BlkIDEncodeLabel("EFI System")))
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(fakedevicepart, nil, 0644)
+	err = os.WriteFile(fakedevicepart, nil, 0644)
 	c.Assert(err, IsNil)
 
 	// mock the partition device node to mock disk
@@ -4734,7 +4733,7 @@ func (u *updateTestSuite) TestBuildNewVolumeToDeviceMappingUC20MultiVolume(c *C)
 	fakedevicepart := filepath.Join(dirs.GlobalRootDir, "/dev/vda1")
 	err = os.Symlink(fakedevicepart, filepath.Join(dirs.GlobalRootDir, "/dev/disk/by-partlabel", disks.BlkIDEncodeLabel("ubuntu-seed")))
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(fakedevicepart, nil, 0644)
+	err = os.WriteFile(fakedevicepart, nil, 0644)
 	c.Assert(err, IsNil)
 
 	// mock the partition device node to mock disk
@@ -4781,7 +4780,7 @@ func (u *updateTestSuite) TestBuildNewVolumeToDeviceMappingUC20Encryption(c *C) 
 	fakedevicepart := filepath.Join(dirs.GlobalRootDir, "/dev/mmcblk0p1")
 	err = os.Symlink(fakedevicepart, filepath.Join(dirs.GlobalRootDir, "/dev/disk/by-partlabel", disks.BlkIDEncodeLabel("ubuntu-seed")))
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(fakedevicepart, nil, 0644)
+	err = os.WriteFile(fakedevicepart, nil, 0644)
 	c.Assert(err, IsNil)
 
 	// mock the partition device node to mock disk
@@ -4801,7 +4800,7 @@ func (u *updateTestSuite) TestBuildNewVolumeToDeviceMappingUC20Encryption(c *C) 
 	err = os.MkdirAll(filepath.Dir(markerFile), 0755)
 	c.Assert(err, IsNil)
 
-	err = ioutil.WriteFile(markerFile, nil, 0644)
+	err = os.WriteFile(markerFile, nil, 0644)
 	c.Assert(err, IsNil)
 
 	vols := map[string]*gadget.Volume{}
@@ -5176,13 +5175,13 @@ func (s *updateTestSuite) setupForVolumeStructureToLocation(c *C,
 			fakedevicepart := filepath.Join(dirs.GlobalRootDir, firstPartDev)
 			err = os.Symlink(fakedevicepart, filepath.Join(dirs.GlobalRootDir, "/dev/disk/by-partlabel", partlabel))
 			c.Assert(err, IsNil)
-			err = ioutil.WriteFile(fakedevicepart, nil, 0644)
+			err = os.WriteFile(fakedevicepart, nil, 0644)
 			c.Assert(err, IsNil)
 		case "dos":
 			fakedevicepart := filepath.Join(dirs.GlobalRootDir, firstPartDev)
 			err = os.Symlink(fakedevicepart, filepath.Join(dirs.GlobalRootDir, "/dev/disk/by-label", fslabel))
 			c.Assert(err, IsNil)
-			err = ioutil.WriteFile(fakedevicepart, nil, 0644)
+			err = os.WriteFile(fakedevicepart, nil, 0644)
 			c.Assert(err, IsNil)
 		default:
 			panic(fmt.Sprintf("unexpected schema %s", traits[volName].Schema))
@@ -5216,7 +5215,7 @@ func (s *updateTestSuite) testVolumeStructureToLocationMap(c *C,
 	c.Assert(err, IsNil)
 	// write out the provided traits JSON so we can at least load the traits for
 	// mocking via setupForVolumeStructureToLocation
-	err = ioutil.WriteFile(
+	err = os.WriteFile(
 		filepath.Join(dirs.SnapDeviceDir, "disk-mapping.json"),
 		[]byte(traitsJSON),
 		0644,

--- a/httputil/client_test.go
+++ b/httputil/client_test.go
@@ -28,7 +28,6 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"io"
-	"io/ioutil"
 	"math/big"
 	"net"
 	"net/http"
@@ -211,7 +210,7 @@ func (s *tlsSuite) TestClientEmptyExtraSSLCertsDirWorks(c *check.C) {
 }
 
 func (s *tlsSuite) TestClientExtraSSLCertInvalidCertWarnsAndRefuses(c *check.C) {
-	err := ioutil.WriteFile(filepath.Join(dirs.SnapdStoreSSLCertsDir, "garbage.pem"), []byte("garbage"), 0644)
+	err := os.WriteFile(filepath.Join(dirs.SnapdStoreSSLCertsDir, "garbage.pem"), []byte("garbage"), 0644)
 	c.Assert(err, check.IsNil)
 
 	cli := httputil.NewHTTPClient(&httputil.ClientOptions{

--- a/i18n/i18n_test.go
+++ b/i18n/i18n_test.go
@@ -20,7 +20,6 @@
 package i18n
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -62,7 +61,7 @@ func makeMockTranslations(c *C, localeDir string) {
 
 	po := filepath.Join(fullLocaleDir, "snappy-test.po")
 	mo := filepath.Join(fullLocaleDir, "snappy-test.mo")
-	err = ioutil.WriteFile(po, mockLocalePo, 0644)
+	err = os.WriteFile(po, mockLocalePo, 0644)
 	c.Assert(err, IsNil)
 
 	cmd := exec.Command("msgfmt", po, "--output-file", mo)

--- a/i18n/xgettext-go/main_test.go
+++ b/i18n/xgettext-go/main_test.go
@@ -22,7 +22,6 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -43,7 +42,7 @@ var _ = Suite(&xgettextTestSuite{})
 // test helper
 func makeGoSourceFile(c *C, content []byte) string {
 	fname := filepath.Join(c.MkDir(), "foo.go")
-	err := ioutil.WriteFile(fname, []byte(content), 0644)
+	err := os.WriteFile(fname, []byte(content), 0644)
 	c.Assert(err, IsNil)
 
 	return fname

--- a/image/image_linux.go
+++ b/image/image_linux.go
@@ -244,7 +244,7 @@ func customizeImage(rootDir, defaultsDir string, custo *Customizations) error {
 		if err := os.MkdirAll(varCloudDir, 0755); err != nil {
 			return err
 		}
-		if err := ioutil.WriteFile(filepath.Join(varCloudDir, "meta-data"), []byte("instance-id: nocloud-static\n"), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(varCloudDir, "meta-data"), []byte("instance-id: nocloud-static\n"), 0644); err != nil {
 			return err
 		}
 		dst := filepath.Join(varCloudDir, "user-data")
@@ -259,7 +259,7 @@ func customizeImage(rootDir, defaultsDir string, custo *Customizations) error {
 		if err := os.MkdirAll(filepath.Dir(consoleConfDisabled), 0755); err != nil {
 			return err
 		}
-		if err := ioutil.WriteFile(consoleConfDisabled, []byte("console-conf has been disabled by image customization\n"), 0644); err != nil {
+		if err := os.WriteFile(consoleConfDisabled, []byte("console-conf has been disabled by image customization\n"), 0644); err != nil {
 			return err
 		}
 	}

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -382,7 +382,7 @@ func (s *imageSuite) TestMissingModelAssertions(c *C) {
 
 func (s *imageSuite) TestIncorrectModelAssertions(c *C) {
 	fn := filepath.Join(c.MkDir(), "broken-model.assertion")
-	err := ioutil.WriteFile(fn, nil, 0644)
+	err := os.WriteFile(fn, nil, 0644)
 	c.Assert(err, IsNil)
 	_, err = image.DecodeModelAssertion(&image.Options{
 		ModelFile: fn,
@@ -404,7 +404,7 @@ AXNpZw==
 `)
 
 	fn := filepath.Join(c.MkDir(), "different.assertion")
-	err := ioutil.WriteFile(fn, differentAssertion, 0644)
+	err := os.WriteFile(fn, differentAssertion, 0644)
 	c.Assert(err, IsNil)
 
 	_, err = image.DecodeModelAssertion(&image.Options{
@@ -438,7 +438,7 @@ AXNpZw==
 	for _, rsvd := range reserved {
 		tweaked := strings.Replace(mod, "kernel: kernel\n", fmt.Sprintf("kernel: kernel\n%s: stuff\n", rsvd), 1)
 		fn := filepath.Join(c.MkDir(), "model.assertion")
-		err := ioutil.WriteFile(fn, []byte(tweaked), 0644)
+		err := os.WriteFile(fn, []byte(tweaked), 0644)
 		c.Assert(err, IsNil)
 		_, err = image.DecodeModelAssertion(&image.Options{
 			ModelFile: fn,
@@ -465,7 +465,7 @@ AXNpZw==
 `
 
 	fn := filepath.Join(c.MkDir(), "model.assertion")
-	err := ioutil.WriteFile(fn, []byte(mod), 0644)
+	err := os.WriteFile(fn, []byte(mod), 0644)
 	c.Assert(err, IsNil)
 	_, err = image.DecodeModelAssertion(&image.Options{
 		ModelFile: fn,
@@ -489,7 +489,7 @@ AXNpZw==
 `
 
 	fn := filepath.Join(c.MkDir(), "model.assertion")
-	err := ioutil.WriteFile(fn, []byte(mod), 0644)
+	err := os.WriteFile(fn, []byte(mod), 0644)
 	c.Assert(err, IsNil)
 	_, err = image.DecodeModelAssertion(&image.Options{
 		ModelFile: fn,
@@ -513,7 +513,7 @@ AXNpZw==
 `
 
 	fn := filepath.Join(c.MkDir(), "model.assertion")
-	err := ioutil.WriteFile(fn, []byte(mod), 0644)
+	err := os.WriteFile(fn, []byte(mod), 0644)
 	c.Assert(err, IsNil)
 	_, err = image.DecodeModelAssertion(&image.Options{
 		ModelFile: fn,
@@ -538,7 +538,7 @@ AXNpZw==
 `
 
 	fn := filepath.Join(c.MkDir(), "model.assertion")
-	err := ioutil.WriteFile(fn, []byte(mod), 0644)
+	err := os.WriteFile(fn, []byte(mod), 0644)
 	c.Assert(err, IsNil)
 	_, err = image.DecodeModelAssertion(&image.Options{
 		ModelFile: fn,
@@ -548,7 +548,7 @@ AXNpZw==
 
 func (s *imageSuite) TestHappyDecodeModelAssertion(c *C) {
 	fn := filepath.Join(c.MkDir(), "model.assertion")
-	err := ioutil.WriteFile(fn, asserts.Encode(s.model), 0644)
+	err := os.WriteFile(fn, asserts.Encode(s.model), 0644)
 	c.Assert(err, IsNil)
 
 	a, err := image.DecodeModelAssertion(&image.Options{
@@ -1319,7 +1319,7 @@ func (s *imageSuite) testSetupSeedWithBaseWithCustomizationsAndDefaults(c *C, wi
 	tmpdir := c.MkDir()
 	rootdir := filepath.Join(tmpdir, "image")
 	cloudInitUserData := filepath.Join(tmpdir, "cloudstuff")
-	err := ioutil.WriteFile(cloudInitUserData, []byte(`# user cloud data`), 0644)
+	err := os.WriteFile(cloudInitUserData, []byte(`# user cloud data`), 0644)
 	c.Assert(err, IsNil)
 	s.setupSnaps(c, map[string]string{
 		"core18":    "canonical",
@@ -1371,7 +1371,7 @@ func (s *imageSuite) TestPrepareUC20CustomizationsUnsupported(c *C) {
 
 	model := s.makeUC20Model(nil)
 	fn := filepath.Join(c.MkDir(), "model.assertion")
-	err := ioutil.WriteFile(fn, asserts.Encode(model), 0644)
+	err := os.WriteFile(fn, asserts.Encode(model), 0644)
 	c.Assert(err, IsNil)
 
 	err = image.Prepare(&image.Options{
@@ -1392,7 +1392,7 @@ func (s *imageSuite) TestPrepareClassicCustomizationsUnsupported(c *C) {
 		"classic": "true",
 	})
 	fn := filepath.Join(c.MkDir(), "model.assertion")
-	err := ioutil.WriteFile(fn, asserts.Encode(model), 0644)
+	err := os.WriteFile(fn, asserts.Encode(model), 0644)
 	c.Assert(err, IsNil)
 
 	err = image.Prepare(&image.Options{
@@ -1418,7 +1418,7 @@ func (s *imageSuite) TestPrepareUC18CustomizationsUnsupported(c *C) {
 		"base":         "core18",
 	})
 	fn := filepath.Join(c.MkDir(), "model.assertion")
-	err := ioutil.WriteFile(fn, asserts.Encode(model), 0644)
+	err := os.WriteFile(fn, asserts.Encode(model), 0644)
 	c.Assert(err, IsNil)
 
 	err = image.Prepare(&image.Options{
@@ -1693,7 +1693,7 @@ func (s *imageSuite) TestInstallCloudConfigWithCloudConfig(c *C) {
 
 	targetDir := c.MkDir()
 	gadgetDir := c.MkDir()
-	err := ioutil.WriteFile(filepath.Join(gadgetDir, "cloud.conf"), canary, 0644)
+	err := os.WriteFile(filepath.Join(gadgetDir, "cloud.conf"), canary, 0644)
 	c.Assert(err, IsNil)
 
 	err = image.InstallCloudConfig(targetDir, gadgetDir)
@@ -2078,7 +2078,7 @@ func (s *imageSuite) TestSetupSeedLocalSnapsWithStoreAssertsValidationEnforce(c 
 
 func (s *imageSuite) TestCannotCreateGadgetUnpackDir(c *C) {
 	fn := filepath.Join(c.MkDir(), "model.assertion")
-	err := ioutil.WriteFile(fn, asserts.Encode(s.model), 0644)
+	err := os.WriteFile(fn, asserts.Encode(s.model), 0644)
 	c.Assert(err, IsNil)
 
 	err = image.Prepare(&image.Options{
@@ -2091,7 +2091,7 @@ func (s *imageSuite) TestCannotCreateGadgetUnpackDir(c *C) {
 
 func (s *imageSuite) TestNoLocalParallelSnapInstances(c *C) {
 	fn := filepath.Join(c.MkDir(), "model.assertion")
-	err := ioutil.WriteFile(fn, asserts.Encode(s.model), 0644)
+	err := os.WriteFile(fn, asserts.Encode(s.model), 0644)
 	c.Assert(err, IsNil)
 
 	err = image.Prepare(&image.Options{
@@ -2103,7 +2103,7 @@ func (s *imageSuite) TestNoLocalParallelSnapInstances(c *C) {
 
 func (s *imageSuite) TestNoInvalidSnapNames(c *C) {
 	fn := filepath.Join(c.MkDir(), "model.assertion")
-	err := ioutil.WriteFile(fn, asserts.Encode(s.model), 0644)
+	err := os.WriteFile(fn, asserts.Encode(s.model), 0644)
 	c.Assert(err, IsNil)
 
 	err = image.Prepare(&image.Options{
@@ -2115,7 +2115,7 @@ func (s *imageSuite) TestNoInvalidSnapNames(c *C) {
 
 func (s *imageSuite) TestPrepareInvalidChannel(c *C) {
 	fn := filepath.Join(c.MkDir(), "model.assertion")
-	err := ioutil.WriteFile(fn, asserts.Encode(s.model), 0644)
+	err := os.WriteFile(fn, asserts.Encode(s.model), 0644)
 	c.Assert(err, IsNil)
 
 	err = image.Prepare(&image.Options{
@@ -2127,7 +2127,7 @@ func (s *imageSuite) TestPrepareInvalidChannel(c *C) {
 
 func (s *imageSuite) TestPrepareClassicModeNoClassicModel(c *C) {
 	fn := filepath.Join(c.MkDir(), "model.assertion")
-	err := ioutil.WriteFile(fn, asserts.Encode(s.model), 0644)
+	err := os.WriteFile(fn, asserts.Encode(s.model), 0644)
 	c.Assert(err, IsNil)
 
 	err = image.Prepare(&image.Options{
@@ -2146,7 +2146,7 @@ func (s *imageSuite) TestPrepareClassicModelNoClassicMode(c *C) {
 	})
 
 	fn := filepath.Join(c.MkDir(), "model.assertion")
-	err := ioutil.WriteFile(fn, asserts.Encode(model), 0644)
+	err := os.WriteFile(fn, asserts.Encode(model), 0644)
 	c.Assert(err, IsNil)
 
 	err = image.Prepare(&image.Options{
@@ -2165,7 +2165,7 @@ func (s *imageSuite) TestPrepareClassicModelArchOverrideFails(c *C) {
 	})
 
 	fn := filepath.Join(c.MkDir(), "model.assertion")
-	err := ioutil.WriteFile(fn, asserts.Encode(model), 0644)
+	err := os.WriteFile(fn, asserts.Encode(model), 0644)
 	c.Assert(err, IsNil)
 
 	err = image.Prepare(&image.Options{
@@ -2186,7 +2186,7 @@ func (s *imageSuite) TestPrepareClassicModelSnapsButNoArchFails(c *C) {
 	})
 
 	fn := filepath.Join(c.MkDir(), "model.assertion")
-	err := ioutil.WriteFile(fn, asserts.Encode(model), 0644)
+	err := os.WriteFile(fn, asserts.Encode(model), 0644)
 	c.Assert(err, IsNil)
 
 	err = image.Prepare(&image.Options{
@@ -3644,7 +3644,7 @@ func (s *imageSuite) TestPrepareWithUC20Preseed(c *C) {
 
 	model := s.makeUC20Model(nil)
 	fn := filepath.Join(c.MkDir(), "model.assertion")
-	c.Assert(ioutil.WriteFile(fn, asserts.Encode(model), 0644), IsNil)
+	c.Assert(os.WriteFile(fn, asserts.Encode(model), 0644), IsNil)
 
 	err := image.Prepare(&image.Options{
 		ModelFile:      fn,
@@ -4624,7 +4624,7 @@ func (s *imageSuite) TestDownloadSnapsManifestValidationSets(c *C) {
 
 	// write a seed.manifest we will provide to image
 	manifestFile := filepath.Join(rootDir, "seed.manifest")
-	err := ioutil.WriteFile(manifestFile, []byte("canonical/base-set 1"), 0644)
+	err := os.WriteFile(manifestFile, []byte("canonical/base-set 1"), 0644)
 	c.Assert(err, IsNil)
 
 	manifest, err := seedwriter.ReadManifest(manifestFile)

--- a/image/preseed/preseed_classic_test.go
+++ b/image/preseed/preseed_classic_test.go
@@ -21,7 +21,6 @@ package preseed_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -40,7 +39,7 @@ func mockVersionFiles(c *C, rootDir1, version1, rootDir2, version2 string) {
 	for i, root := range []string{rootDir1, rootDir2} {
 		c.Assert(os.MkdirAll(filepath.Join(root, dirs.CoreLibExecDir), 0755), IsNil)
 		infoFile := filepath.Join(root, dirs.CoreLibExecDir, "info")
-		c.Assert(ioutil.WriteFile(infoFile, []byte(fmt.Sprintf("VERSION=%s", versions[i])), 0644), IsNil)
+		c.Assert(os.WriteFile(infoFile, []byte(fmt.Sprintf("VERSION=%s", versions[i])), 0644), IsNil)
 	}
 }
 
@@ -92,7 +91,7 @@ func (s *preseedSuite) TestChrootValidationAlreadyPreseeded(c *C) {
 	tmpDir := c.MkDir()
 	snapdDir := filepath.Dir(dirs.SnapStateFile)
 	c.Assert(os.MkdirAll(filepath.Join(tmpDir, snapdDir), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(tmpDir, dirs.SnapStateFile), nil, os.ModePerm), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(tmpDir, dirs.SnapStateFile), nil, os.ModePerm), IsNil)
 
 	c.Check(preseed.Classic(tmpDir), ErrorMatches, fmt.Sprintf("the system at %q appears to be preseeded, pass --reset flag to clean it up", tmpDir))
 }
@@ -182,11 +181,11 @@ func (s *preseedSuite) TestRunPreseedHappyPremounted(c *C) {
 
 	// Faking that /proc is mounted
 	c.Assert(os.MkdirAll(filepath.Join(tmpDir, "/proc/self"), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(tmpDir, "/proc/self/cmdline"), []byte{}, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(tmpDir, "/proc/self/cmdline"), []byte{}, 0644), IsNil)
 
 	// Faking that /dev is mounted
 	c.Assert(os.MkdirAll(filepath.Join(tmpDir, "/dev"), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(tmpDir, "/dev/loop-control"), []byte{}, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(tmpDir, "/dev/loop-control"), []byte{}, 0644), IsNil)
 
 	restoreSyscallChroot := preseed.MockSyscallChroot(func(path string) error { return nil })
 	defer restoreSyscallChroot()
@@ -310,11 +309,11 @@ func (s *preseedSuite) TestRunPreseedUnsupportedVersion(c *C) {
 	defer mockTargetSnapd.Restore()
 
 	infoFile := filepath.Join(targetSnapdRoot, dirs.CoreLibExecDir, "info")
-	c.Assert(ioutil.WriteFile(infoFile, []byte("VERSION=2.43.0"), 0644), IsNil)
+	c.Assert(os.WriteFile(infoFile, []byte("VERSION=2.43.0"), 0644), IsNil)
 
 	// simulate snapd version from the deb
 	infoFile = filepath.Join(filepath.Join(tmpDir, dirs.CoreLibExecDir, "info"))
-	c.Assert(ioutil.WriteFile(infoFile, []byte("VERSION=2.41.0"), 0644), IsNil)
+	c.Assert(os.WriteFile(infoFile, []byte("VERSION=2.41.0"), 0644), IsNil)
 
 	c.Check(preseed.Classic(tmpDir), ErrorMatches,
 		`snapd 2.43.0 from the target system does not support preseeding, the minimum required version is 2.43.3\+`)
@@ -388,7 +387,7 @@ func (s *preseedSuite) TestReset(c *C) {
 				// note, symlinkTarget is not relative to tmpDir
 				c.Assert(os.Symlink(art.symlinkTarget, fullPath), IsNil)
 			} else {
-				c.Assert(ioutil.WriteFile(fullPath, nil, os.ModePerm), IsNil)
+				c.Assert(os.WriteFile(fullPath, nil, os.ModePerm), IsNil)
 			}
 		}
 
@@ -408,7 +407,7 @@ func (s *preseedSuite) TestReset(c *C) {
 
 		snapdDir := filepath.Dir(dirs.SnapStateFile)
 		c.Assert(os.MkdirAll(filepath.Join(tmpDir, snapdDir), 0755), IsNil)
-		c.Assert(ioutil.WriteFile(filepath.Join(tmpDir, dirs.SnapStateFile), nil, os.ModePerm), IsNil)
+		c.Assert(os.WriteFile(filepath.Join(tmpDir, dirs.SnapStateFile), nil, os.ModePerm), IsNil)
 
 		c.Assert(preseed.ResetPreseededChroot(resetDirArg), IsNil)
 
@@ -422,7 +421,7 @@ func (s *preseedSuite) TestReset(c *C) {
 
 		// reset complains if target is not a directory
 		fooFile := filepath.Join(resetDirArg, "foo")
-		c.Assert(ioutil.WriteFile(fooFile, nil, os.ModePerm), IsNil)
+		c.Assert(os.WriteFile(fooFile, nil, os.ModePerm), IsNil)
 		err = preseed.ResetPreseededChroot(fooFile)
 		// the error message is always with an absolute file, so make the path
 		// absolute if we are running the relative test to properly match
@@ -467,15 +466,15 @@ func (s *preseedSuite) TestResetRexec(c *C) {
 	// Before chroot
 	c.Assert(os.MkdirAll(filepath.Join(tmpDir, targetSnapdRoot, dirs.CoreLibExecDir), 0755), IsNil)
 	infoFile := filepath.Join(tmpDir, targetSnapdRoot, dirs.CoreLibExecDir, "info")
-	c.Assert(ioutil.WriteFile(infoFile, []byte("VERSION=2.59"), 0644), IsNil)
+	c.Assert(os.WriteFile(infoFile, []byte("VERSION=2.59"), 0644), IsNil)
 
 	// After chroot
 	c.Assert(os.MkdirAll(filepath.Join(targetSnapdRoot, dirs.CoreLibExecDir), 0755), IsNil)
 	infoFile = filepath.Join(targetSnapdRoot, dirs.CoreLibExecDir, "info")
-	c.Assert(ioutil.WriteFile(infoFile, []byte("VERSION=2.59"), 0644), IsNil)
+	c.Assert(os.WriteFile(infoFile, []byte("VERSION=2.59"), 0644), IsNil)
 
 	infoFile = filepath.Join(filepath.Join(tmpDir, dirs.CoreLibExecDir, "info"))
-	c.Assert(ioutil.WriteFile(infoFile, []byte("VERSION=2.58"), 0644), IsNil)
+	c.Assert(os.WriteFile(infoFile, []byte("VERSION=2.58"), 0644), IsNil)
 
 	c.Assert(preseed.ClassicReset(tmpDir), IsNil)
 
@@ -514,10 +513,10 @@ func (s *preseedSuite) TestResetRexecTooOld(c *C) {
 
 	c.Assert(os.MkdirAll(filepath.Join(tmpDir, targetSnapdRoot, dirs.CoreLibExecDir), 0755), IsNil)
 	infoFile := filepath.Join(tmpDir, targetSnapdRoot, dirs.CoreLibExecDir, "info")
-	c.Assert(ioutil.WriteFile(infoFile, []byte("VERSION=2.58"), 0644), IsNil)
+	c.Assert(os.WriteFile(infoFile, []byte("VERSION=2.58"), 0644), IsNil)
 
 	infoFile = filepath.Join(filepath.Join(tmpDir, dirs.CoreLibExecDir, "info"))
-	c.Assert(ioutil.WriteFile(infoFile, []byte("VERSION=2.58"), 0644), IsNil)
+	c.Assert(os.WriteFile(infoFile, []byte("VERSION=2.58"), 0644), IsNil)
 
 	c.Assert(preseed.ClassicReset(tmpDir), IsNil)
 

--- a/image/preseed/preseed_test.go
+++ b/image/preseed/preseed_test.go
@@ -21,7 +21,6 @@ package preseed_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -281,12 +280,12 @@ func (s *preseedSuite) TestChooseTargetSnapdVersion(c *C) {
 		infoFile := filepath.Join(tmpDir, "usr/lib/snapd/info")
 		os.Remove(infoFile)
 		if test.fromDeb != "" {
-			c.Assert(ioutil.WriteFile(infoFile, []byte(fmt.Sprintf("VERSION=%s", test.fromDeb)), 0644), IsNil)
+			c.Assert(os.WriteFile(infoFile, []byte(fmt.Sprintf("VERSION=%s", test.fromDeb)), 0644), IsNil)
 		}
 		infoFile = filepath.Join(targetSnapdRoot, "usr/lib/snapd/info")
 		os.Remove(infoFile)
 		if test.fromSnap != "" {
-			c.Assert(ioutil.WriteFile(infoFile, []byte(fmt.Sprintf("VERSION=%s", test.fromSnap)), 0644), IsNil)
+			c.Assert(os.WriteFile(infoFile, []byte(fmt.Sprintf("VERSION=%s", test.fromSnap)), 0644), IsNil)
 		}
 
 		targetSnapd, err := preseed.ChooseTargetSnapdVersion()
@@ -317,17 +316,17 @@ func (s *preseedSuite) TestCreatePreseedArtifact(c *C) {
 
 	c.Assert(os.MkdirAll(filepath.Join(writableDir, "system-data/etc/bar"), 0755), IsNil)
 	c.Assert(os.MkdirAll(filepath.Join(writableDir, "system-data/baz"), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(writableDir, "system-data/etc/bar/a"), nil, 0644), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(writableDir, "system-data/etc/bar/x"), nil, 0644), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(writableDir, "system-data/baz/b"), nil, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(writableDir, "system-data/etc/bar/a"), nil, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(writableDir, "system-data/etc/bar/x"), nil, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(writableDir, "system-data/baz/b"), nil, 0644), IsNil)
 
 	const exportFileContents = `{
 "exclude": ["/etc/bar/x*"],
 "include": ["/etc/bar/a", "/baz/*"]
 }`
 	c.Assert(os.MkdirAll(filepath.Join(tmpDir, "/usr/lib/snapd"), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(tmpDir, "/usr/lib/snapd/preseed.json"), []byte(exportFileContents), 0644), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(prepareDir, "system-seed/systems/20220203/preseed.tgz"), nil, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(tmpDir, "/usr/lib/snapd/preseed.json"), []byte(exportFileContents), 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(prepareDir, "system-seed/systems/20220203/preseed.tgz"), nil, 0644), IsNil)
 
 	opts := &preseed.CoreOptions{
 		PrepareImageDir: prepareDir,

--- a/image/preseed/preseed_uc20_test.go
+++ b/image/preseed/preseed_uc20_test.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -191,8 +190,8 @@ func (s *preseedSuite) testRunPreseedUC20Happy(c *C, customAppArmorFeaturesDir, 
 	defer restoreMakeWritableTempDir()
 
 	c.Assert(os.MkdirAll(filepath.Join(writableTmpDir, "system-data/etc/bar"), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(writableTmpDir, "system-data/etc/bar/a"), nil, 0644), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(writableTmpDir, "system-data/etc/bar/b"), nil, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(writableTmpDir, "system-data/etc/bar/a"), nil, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(writableTmpDir, "system-data/etc/bar/b"), nil, 0644), IsNil)
 
 	mockTar := testutil.MockCommand(c, "tar", "")
 	defer mockTar.Restore()
@@ -203,7 +202,7 @@ func (s *preseedSuite) testRunPreseedUC20Happy(c *C, customAppArmorFeaturesDir, 
 }`
 
 	c.Assert(os.MkdirAll(filepath.Join(preseedTmpDir, "usr/lib/snapd"), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(preseedTmpDir, "usr/lib/snapd/preseed.json"), []byte(exportFileContents), 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(preseedTmpDir, "usr/lib/snapd/preseed.json"), []byte(exportFileContents), 0644), IsNil)
 
 	mockWritablePaths := testutil.MockCommand(c, filepath.Join(preseedTmpDir, "/usr/lib/core/handle-writable-paths"), "")
 	defer mockWritablePaths.Restore()
@@ -220,7 +219,7 @@ func (s *preseedSuite) testRunPreseedUC20Happy(c *C, customAppArmorFeaturesDir, 
 	defer restoreSystemSnapFromSeed()
 
 	c.Assert(os.MkdirAll(filepath.Join(tmpDir, "system-seed/systems/20220203"), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(tmpDir, "system-seed/systems/20220203/preseed.tgz"), []byte(`hello world`), 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(tmpDir, "system-seed/systems/20220203/preseed.tgz"), []byte(`hello world`), 0644), IsNil)
 
 	opts := &preseed.CoreOptions{
 		PrepareImageDir:           tmpDir,
@@ -424,7 +423,7 @@ func (s *preseedSuite) TestRunPreseedUC20ExecFormatError(c *C) {
 	// not the image target architecture.
 	mockChrootCmd := testutil.MockCommand(c, "chroot", "")
 	defer mockChrootCmd.Restore()
-	err := ioutil.WriteFile(mockChrootCmd.Exe(), []byte("invalid-exe"), 0755)
+	err := os.WriteFile(mockChrootCmd.Exe(), []byte("invalid-exe"), 0755)
 	c.Check(err, IsNil)
 
 	popts := &preseed.PreseedCoreOptions{

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -572,8 +572,8 @@ func (s *backendSuite) TestSetupManyProfilesWithChanged(c *C) {
 		snap2AAprofile := filepath.Join(dirs.SnapAppArmorDir, "snap.some-snap.someapp")
 
 		// simulate outdated profiles by changing their data on the disk
-		c.Assert(ioutil.WriteFile(snap1AAprofile, []byte("# an outdated profile"), 0644), IsNil)
-		c.Assert(ioutil.WriteFile(snap2AAprofile, []byte("# an outdated profile"), 0644), IsNil)
+		c.Assert(os.WriteFile(snap1AAprofile, []byte("# an outdated profile"), 0644), IsNil)
+		c.Assert(os.WriteFile(snap2AAprofile, []byte("# an outdated profile"), 0644), IsNil)
 
 		setupManyInterface, ok := s.Backend.(interfaces.SecurityBackendSetupMany)
 		c.Assert(ok, Equals, true)
@@ -1294,7 +1294,7 @@ func (s *backendSuite) writeVanillaSnapConfineProfile(c *C, coreOrSnapdInfo *sna
 }
 `)
 	c.Assert(os.MkdirAll(filepath.Dir(vanillaProfilePath), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(vanillaProfilePath, vanillaProfileText, 0644), IsNil)
+	c.Assert(os.WriteFile(vanillaProfilePath, vanillaProfileText, 0644), IsNil)
 }
 
 func (s *backendSuite) TestSnapConfineProfile(c *C) {
@@ -1441,7 +1441,7 @@ func (s *backendSuite) TestSetupHostSnapConfineApparmorForReexecCleans(c *C) {
 	canary := filepath.Join(dirs.SnapAppArmorDir, canaryName)
 	err := os.MkdirAll(filepath.Dir(canary), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(canary, nil, 0644)
+	err = os.WriteFile(canary, nil, 0644)
 	c.Assert(err, IsNil)
 
 	// install the new core snap on classic triggers cleanup
@@ -1503,7 +1503,7 @@ func (s *backendSuite) TestSnapConfineProfileDiscardedLateSnapd(c *C) {
 	// precondition
 	c.Assert(filepath.Join(dirs.SnapAppArmorDir, "snap-confine.snapd.222"), testutil.FilePresent)
 	// place a canary
-	c.Assert(ioutil.WriteFile(filepath.Join(dirs.SnapAppArmorDir, "snap-confine.snapd.111"), nil, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dirs.SnapAppArmorDir, "snap-confine.snapd.111"), nil, 0644), IsNil)
 
 	// backed implements the right interface
 	late, ok := s.Backend.(interfaces.SecurityBackendDiscardingLate)
@@ -1535,26 +1535,26 @@ func (s *backendSuite) testCoreOrSnapdOnCoreCleansApparmorCache(c *C, coreOrSnap
 	c.Assert(err, IsNil)
 	// the canary file in the cache will be removed
 	canaryPath := filepath.Join(apparmor_sandbox.SystemCacheDir, "meep")
-	err = ioutil.WriteFile(canaryPath, nil, 0644)
+	err = os.WriteFile(canaryPath, nil, 0644)
 	c.Assert(err, IsNil)
 	// and the snap-confine profiles are removed
 	scCanaryPath := filepath.Join(apparmor_sandbox.SystemCacheDir, "usr.lib.snapd.snap-confine.real")
-	err = ioutil.WriteFile(scCanaryPath, nil, 0644)
+	err = os.WriteFile(scCanaryPath, nil, 0644)
 	c.Assert(err, IsNil)
 	scCanaryPath = filepath.Join(apparmor_sandbox.SystemCacheDir, "usr.lib.snapd.snap-confine")
-	err = ioutil.WriteFile(scCanaryPath, nil, 0644)
+	err = os.WriteFile(scCanaryPath, nil, 0644)
 	c.Assert(err, IsNil)
 	scCanaryPath = filepath.Join(apparmor_sandbox.SystemCacheDir, "snap-confine.core.6405")
-	err = ioutil.WriteFile(scCanaryPath, nil, 0644)
+	err = os.WriteFile(scCanaryPath, nil, 0644)
 	c.Assert(err, IsNil)
 	scCanaryPath = filepath.Join(apparmor_sandbox.SystemCacheDir, "snap-confine.snapd.6405")
-	err = ioutil.WriteFile(scCanaryPath, nil, 0644)
+	err = os.WriteFile(scCanaryPath, nil, 0644)
 	c.Assert(err, IsNil)
 	scCanaryPath = filepath.Join(apparmor_sandbox.SystemCacheDir, "snap.core.4938.usr.lib.snapd.snap-confine")
-	err = ioutil.WriteFile(scCanaryPath, nil, 0644)
+	err = os.WriteFile(scCanaryPath, nil, 0644)
 	c.Assert(err, IsNil)
 	scCanaryPath = filepath.Join(apparmor_sandbox.SystemCacheDir, "var.lib.snapd.snap.core.1234.usr.lib.snapd.snap-confine")
-	err = ioutil.WriteFile(scCanaryPath, nil, 0644)
+	err = os.WriteFile(scCanaryPath, nil, 0644)
 	c.Assert(err, IsNil)
 	// but non-regular entries in the cache dir are kept
 	dirsAreKept := filepath.Join(apparmor_sandbox.SystemCacheDir, "dir")
@@ -1565,14 +1565,14 @@ func (s *backendSuite) testCoreOrSnapdOnCoreCleansApparmorCache(c *C, coreOrSnap
 	c.Assert(err, IsNil)
 	// and the snap profiles are kept
 	snapCanaryKept := filepath.Join(apparmor_sandbox.SystemCacheDir, "snap.canary.meep")
-	err = ioutil.WriteFile(snapCanaryKept, nil, 0644)
+	err = os.WriteFile(snapCanaryKept, nil, 0644)
 	c.Assert(err, IsNil)
 	sunCanaryKept := filepath.Join(apparmor_sandbox.SystemCacheDir, "snap-update-ns.canary")
-	err = ioutil.WriteFile(sunCanaryKept, nil, 0644)
+	err = os.WriteFile(sunCanaryKept, nil, 0644)
 	c.Assert(err, IsNil)
 	// and the .features file is kept
 	dotKept := filepath.Join(apparmor_sandbox.SystemCacheDir, ".features")
-	err = ioutil.WriteFile(dotKept, nil, 0644)
+	err = os.WriteFile(dotKept, nil, 0644)
 	c.Assert(err, IsNil)
 
 	// install the new core snap on classic triggers a new snap-confine
@@ -1641,7 +1641,7 @@ func (s *backendSuite) testSetupSnapConfineGeneratedPolicyWithNFS(c *C, profileF
 	// Create the directory where system apparmor profiles are stored and write
 	// the system apparmor profile of snap-confine.
 	c.Assert(os.MkdirAll(apparmor_sandbox.ConfDir, 0755), IsNil)
-	c.Assert(ioutil.WriteFile(profilePath, []byte(""), 0644), IsNil)
+	c.Assert(os.WriteFile(profilePath, []byte(""), 0644), IsNil)
 
 	// Setup generated policy for snap-confine.
 	err = (&apparmor.Backend{}).Initialize(ifacetest.DefaultInitializeOpts)
@@ -1769,7 +1769,7 @@ func (s *backendSuite) TestSetupSnapConfineGeneratedPolicyError2(c *C) {
 	// Create the directory where system apparmor profiles are stored and Write
 	// the system apparmor profile of snap-confine.
 	c.Assert(os.MkdirAll(apparmor_sandbox.ConfDir, 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(apparmor_sandbox.ConfDir, "usr.lib.snapd.snap-confine"), []byte(""), 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(apparmor_sandbox.ConfDir, "usr.lib.snapd.snap-confine"), []byte(""), 0644), IsNil)
 
 	// Setup generated policy for snap-confine.
 	err = (&apparmor.Backend{}).Initialize(ifacetest.DefaultInitializeOpts)
@@ -1839,7 +1839,7 @@ func (s *backendSuite) testSetupSnapConfineGeneratedPolicyWithOverlay(c *C, prof
 	// Create the directory where system apparmor profiles are stored and write
 	// the system apparmor profile of snap-confine.
 	c.Assert(os.MkdirAll(apparmor_sandbox.ConfDir, 0755), IsNil)
-	c.Assert(ioutil.WriteFile(profilePath, []byte(""), 0644), IsNil)
+	c.Assert(os.WriteFile(profilePath, []byte(""), 0644), IsNil)
 
 	// Setup generated policy for snap-confine.
 	err = (&apparmor.Backend{}).Initialize(ifacetest.DefaultInitializeOpts)
@@ -1939,7 +1939,7 @@ func (s *backendSuite) testSetupSnapConfineGeneratedPolicyWithBPFCapability(c *C
 	// Create the directory where system apparmor profiles are stored and write
 	// the system apparmor profile of snap-confine.
 	c.Assert(os.MkdirAll(apparmor_sandbox.ConfDir, 0755), IsNil)
-	c.Assert(ioutil.WriteFile(profilePath, []byte(""), 0644), IsNil)
+	c.Assert(os.WriteFile(profilePath, []byte(""), 0644), IsNil)
 
 	// Setup generated policy for snap-confine.
 	err := (&apparmor.Backend{}).Initialize(ifacetest.DefaultInitializeOpts)
@@ -2007,7 +2007,7 @@ func (s *backendSuite) TestSetupSnapConfineGeneratedPolicyWithBPFProbeError(c *C
 	// Create the directory where system apparmor profiles are stored and write
 	// the system apparmor profile of snap-confine.
 	c.Assert(os.MkdirAll(apparmor_sandbox.ConfDir, 0755), IsNil)
-	c.Assert(ioutil.WriteFile(profilePath, []byte(""), 0644), IsNil)
+	c.Assert(os.WriteFile(profilePath, []byte(""), 0644), IsNil)
 
 	// Setup generated policy for snap-confine.
 	err = (&apparmor.Backend{}).Initialize(ifacetest.DefaultInitializeOpts)
@@ -2524,8 +2524,8 @@ func (s *backendSuite) TestSetupManyInPreseedMode(c *C) {
 		snap2AAprofile := filepath.Join(dirs.SnapAppArmorDir, "snap.some-snap.someapp")
 
 		// simulate outdated profiles by changing their data on the disk
-		c.Assert(ioutil.WriteFile(snap1AAprofile, []byte("# an outdated profile"), 0644), IsNil)
-		c.Assert(ioutil.WriteFile(snap2AAprofile, []byte("# an outdated profile"), 0644), IsNil)
+		c.Assert(os.WriteFile(snap1AAprofile, []byte("# an outdated profile"), 0644), IsNil)
+		c.Assert(os.WriteFile(snap2AAprofile, []byte("# an outdated profile"), 0644), IsNil)
 
 		setupManyInterface, ok := s.Backend.(interfaces.SecurityBackendSetupMany)
 		c.Assert(ok, Equals, true)

--- a/interfaces/builtin/kvm_test.go
+++ b/interfaces/builtin/kvm_test.go
@@ -21,7 +21,7 @@ package builtin_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	. "gopkg.in/check.v1"
@@ -78,7 +78,7 @@ func (s *kvmInterfaceSuite) SetUpTest(c *C) {
 	s.AddCleanup(func() { dirs.SetRootDir("/") })
 
 	mockCpuinfo := filepath.Join(s.tmpdir, "cpuinfo")
-	c.Assert(ioutil.WriteFile(mockCpuinfo, []byte(`
+	c.Assert(os.WriteFile(mockCpuinfo, []byte(`
 processor       : 0
 flags		: cpuflags without kvm support
 
@@ -156,7 +156,7 @@ func (s *kvmInterfaceSuite) TestKModSpecWithUnknownCpu(c *C) {
 
 func (s *kvmInterfaceSuite) TestKModSpecWithIntel(c *C) {
 	mockCpuinfo := filepath.Join(s.tmpdir, "cpuinfo")
-	c.Assert(ioutil.WriteFile(mockCpuinfo, []byte(`
+	c.Assert(os.WriteFile(mockCpuinfo, []byte(`
 processor       : 0
 flags           : stuff vmx other
 `[1:]), 0644), IsNil)
@@ -170,7 +170,7 @@ flags           : stuff vmx other
 
 func (s *kvmInterfaceSuite) TestKModSpecWithAMD(c *C) {
 	mockCpuinfo := filepath.Join(s.tmpdir, "cpuinfo")
-	c.Assert(ioutil.WriteFile(mockCpuinfo, []byte(`
+	c.Assert(os.WriteFile(mockCpuinfo, []byte(`
 processor       : 0
 flags           : stuff svm other
 `[1:]), 0644), IsNil)
@@ -186,7 +186,7 @@ flags           : stuff svm other
 
 func (s *kvmInterfaceSuite) TestKModSpecWithEmptyCpuinfo(c *C) {
 	mockCpuinfo := filepath.Join(s.tmpdir, "cpuinfo")
-	c.Assert(ioutil.WriteFile(mockCpuinfo, []byte(`
+	c.Assert(os.WriteFile(mockCpuinfo, []byte(`
 `[1:]), 0644), IsNil)
 
 	s.AddCleanup(builtin.MockProcCpuinfo(mockCpuinfo))

--- a/interfaces/builtin/polkit_test.go
+++ b/interfaces/builtin/polkit_test.go
@@ -20,7 +20,6 @@
 package builtin_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -112,9 +111,9 @@ func (s *polkitInterfaceSuite) TestConnectedPlugPolkit(c *C) {
 
 	c.Assert(os.MkdirAll(filepath.Join(s.plugInfo.Snap.MountDir(), "meta/polkit"), 0755), IsNil)
 	policyPath := filepath.Join(s.plugInfo.Snap.MountDir(), "meta/polkit/polkit.foo.policy")
-	c.Assert(ioutil.WriteFile(policyPath, []byte(samplePolicy1), 0644), IsNil)
+	c.Assert(os.WriteFile(policyPath, []byte(samplePolicy1), 0644), IsNil)
 	policyPath = filepath.Join(s.plugInfo.Snap.MountDir(), "meta/polkit/polkit.bar.policy")
-	c.Assert(ioutil.WriteFile(policyPath, []byte(samplePolicy2), 0644), IsNil)
+	c.Assert(os.WriteFile(policyPath, []byte(samplePolicy2), 0644), IsNil)
 
 	polkitSpec := &polkit.Specification{}
 	err := polkitSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
@@ -146,7 +145,7 @@ func (s *polkitInterfaceSuite) TestConnectedPlugPolkitBadXML(c *C) {
 	const samplePolicy = `<malformed`
 	c.Assert(os.MkdirAll(filepath.Join(s.plugInfo.Snap.MountDir(), "meta/polkit"), 0755), IsNil)
 	policyPath := filepath.Join(s.plugInfo.Snap.MountDir(), "meta/polkit/polkit.foo.policy")
-	c.Assert(ioutil.WriteFile(policyPath, []byte(samplePolicy), 0644), IsNil)
+	c.Assert(os.WriteFile(policyPath, []byte(samplePolicy), 0644), IsNil)
 
 	polkitSpec := &polkit.Specification{}
 	err := polkitSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
@@ -165,7 +164,7 @@ func (s *polkitInterfaceSuite) TestConnectedPlugPolkitBadAction(c *C) {
 </policyconfig>`
 	c.Assert(os.MkdirAll(filepath.Join(s.plugInfo.Snap.MountDir(), "meta/polkit"), 0755), IsNil)
 	policyPath := filepath.Join(s.plugInfo.Snap.MountDir(), "meta/polkit/polkit.foo.policy")
-	c.Assert(ioutil.WriteFile(policyPath, []byte(samplePolicy), 0644), IsNil)
+	c.Assert(os.WriteFile(policyPath, []byte(samplePolicy), 0644), IsNil)
 
 	polkitSpec := &polkit.Specification{}
 	err := polkitSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
@@ -185,7 +184,7 @@ func (s *polkitInterfaceSuite) TestConnectedPlugPolkitBadImplies(c *C) {
 </policyconfig>`
 	c.Assert(os.MkdirAll(filepath.Join(s.plugInfo.Snap.MountDir(), "meta/polkit"), 0755), IsNil)
 	policyPath := filepath.Join(s.plugInfo.Snap.MountDir(), "meta/polkit/polkit.foo.policy")
-	c.Assert(ioutil.WriteFile(policyPath, []byte(samplePolicy), 0644), IsNil)
+	c.Assert(os.WriteFile(policyPath, []byte(samplePolicy), 0644), IsNil)
 
 	polkitSpec := &polkit.Specification{}
 	err := polkitSpec.AddConnectedPlug(s.iface, s.plug, s.slot)

--- a/interfaces/builtin/udisks2_test.go
+++ b/interfaces/builtin/udisks2_test.go
@@ -21,7 +21,6 @@ package builtin_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -152,7 +151,7 @@ func (s *UDisks2InterfaceSuite) SetUpTest(c *C) {
 	producerDir := s.slotInfoWithUdevFile.Snap.MountDir()
 	ruleFile := filepath.Join(producerDir, "lib/udev/rules.d/99-udisks.rules")
 	os.MkdirAll(filepath.Dir(ruleFile), 0777)
-	err := ioutil.WriteFile(ruleFile, []byte("# Test UDev file\n"), 0777)
+	err := os.WriteFile(ruleFile, []byte("# Test UDev file\n"), 0777)
 	c.Assert(err, IsNil)
 }
 
@@ -270,7 +269,7 @@ func (s *UDisks2InterfaceSuite) TestUDevSpecFile(c *C) {
 
 func (s *UDisks2InterfaceSuite) TestUDevSpecFileEvilPathRel(c *C) {
 	outsideFile := filepath.Join(dirs.GlobalRootDir, "outside")
-	c.Assert(ioutil.WriteFile(outsideFile, []byte(""), 0777), IsNil)
+	c.Assert(os.WriteFile(outsideFile, []byte(""), 0777), IsNil)
 	producerDir := s.slotInfoWithUdevFile.Snap.MountDir()
 	outsideFileRel, err := filepath.Rel(producerDir, outsideFile)
 	c.Assert(err, IsNil)
@@ -284,7 +283,7 @@ func (s *UDisks2InterfaceSuite) TestUDevSpecFileEvilPathRel(c *C) {
 
 func (s *UDisks2InterfaceSuite) TestUDevSpecFileEvilAbsSymlink(c *C) {
 	outsideFile := filepath.Join(dirs.GlobalRootDir, "outside")
-	c.Assert(ioutil.WriteFile(outsideFile, []byte(""), 0777), IsNil)
+	c.Assert(os.WriteFile(outsideFile, []byte(""), 0777), IsNil)
 	producerDir := s.slotInfoWithUdevFile.Snap.MountDir()
 	c.Assert(os.Symlink(outsideFile, filepath.Join(producerDir, "link")), IsNil)
 
@@ -297,7 +296,7 @@ func (s *UDisks2InterfaceSuite) TestUDevSpecFileEvilAbsSymlink(c *C) {
 
 func (s *UDisks2InterfaceSuite) TestUDevSpecFileEvilRelSymlink(c *C) {
 	outsideFile := filepath.Join(dirs.GlobalRootDir, "outside")
-	c.Assert(ioutil.WriteFile(outsideFile, []byte(""), 0777), IsNil)
+	c.Assert(os.WriteFile(outsideFile, []byte(""), 0777), IsNil)
 	producerDir := s.slotInfoWithUdevFile.Snap.MountDir()
 	outsideFileRel, err := filepath.Rel(producerDir, outsideFile)
 	c.Assert(err, IsNil)
@@ -320,7 +319,7 @@ func (s *UDisks2InterfaceSuite) TestUDevSpecFileDoesNotExist(c *C) {
 
 func (s *UDisks2InterfaceSuite) TestUDevSpecFileCannotOpen(c *C) {
 	producerDir := s.slotInfoWithUdevFile.Snap.MountDir()
-	c.Assert(ioutil.WriteFile(filepath.Join(producerDir, "non-readable"), []byte(""), 0222), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(producerDir, "non-readable"), []byte(""), 0222), IsNil)
 	yaml := fmt.Sprintf(udisks2WithUdevFileProducerYamlTemplate, "non-readable")
 	_, slotInfo := MockConnectedSlot(c, yaml, nil, "udisks2")
 

--- a/interfaces/dbus/backend_test.go
+++ b/interfaces/dbus/backend_test.go
@@ -21,7 +21,6 @@ package dbus_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -287,13 +286,13 @@ func makeFakeDbusConfigAndUserdServiceFiles(c *C, coreOrSnapdSnap *snap.Info) {
 	err := os.MkdirAll(filepath.Join(coreOrSnapdSnap.MountDir(), "/usr/share/dbus-1/session.d"), 0755)
 	c.Assert(err, IsNil)
 	content := fmt.Sprintf("content of snapd.session-services.conf for snap %s", coreOrSnapdSnap.InstanceName())
-	err = ioutil.WriteFile(filepath.Join(coreOrSnapdSnap.MountDir(), "/usr/share/dbus-1/session.d/snapd.session-services.conf"), []byte(content), 0644)
+	err = os.WriteFile(filepath.Join(coreOrSnapdSnap.MountDir(), "/usr/share/dbus-1/session.d/snapd.session-services.conf"), []byte(content), 0644)
 	c.Assert(err, IsNil)
 
 	err = os.MkdirAll(filepath.Join(coreOrSnapdSnap.MountDir(), "/usr/share/dbus-1/system.d"), 0755)
 	c.Assert(err, IsNil)
 	content = fmt.Sprintf("content of snapd.system-services.conf for snap %s", coreOrSnapdSnap.InstanceName())
-	err = ioutil.WriteFile(filepath.Join(coreOrSnapdSnap.MountDir(), "/usr/share/dbus-1/system.d/snapd.system-services.conf"), []byte(content), 0644)
+	err = os.WriteFile(filepath.Join(coreOrSnapdSnap.MountDir(), "/usr/share/dbus-1/system.d/snapd.system-services.conf"), []byte(content), 0644)
 	c.Assert(err, IsNil)
 
 	err = os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "/usr/share/dbus-1/services"), 0755)
@@ -309,7 +308,7 @@ func makeFakeDbusConfigAndUserdServiceFiles(c *C, coreOrSnapdSnap *snap.Info) {
 		"io.snapcraft.Settings.service",
 	} {
 		content := fmt.Sprintf("content of %s for snap %s", fn, coreOrSnapdSnap.InstanceName())
-		err = ioutil.WriteFile(filepath.Join(servicesPath, fn), []byte(content), 0644)
+		err = os.WriteFile(filepath.Join(servicesPath, fn), []byte(content), 0644)
 		c.Assert(err, IsNil)
 	}
 }

--- a/interfaces/mount/backend_test.go
+++ b/interfaces/mount/backend_test.go
@@ -75,30 +75,30 @@ func (s *backendSuite) TestName(c *C) {
 
 func (s *backendSuite) TestRemove(c *C) {
 	appCanaryToGo := filepath.Join(dirs.SnapMountPolicyDir, "snap.hello-world.hello-world.fstab")
-	err := ioutil.WriteFile(appCanaryToGo, []byte("ni! ni! ni!"), 0644)
+	err := os.WriteFile(appCanaryToGo, []byte("ni! ni! ni!"), 0644)
 	c.Assert(err, IsNil)
 
 	hookCanaryToGo := filepath.Join(dirs.SnapMountPolicyDir, "snap.hello-world.hook.configure.fstab")
-	err = ioutil.WriteFile(hookCanaryToGo, []byte("ni! ni! ni!"), 0644)
+	err = os.WriteFile(hookCanaryToGo, []byte("ni! ni! ni!"), 0644)
 	c.Assert(err, IsNil)
 
 	snapCanaryToGo := filepath.Join(dirs.SnapMountPolicyDir, "snap.hello-world.fstab")
-	err = ioutil.WriteFile(snapCanaryToGo, []byte("ni! ni! ni!"), 0644)
+	err = os.WriteFile(snapCanaryToGo, []byte("ni! ni! ni!"), 0644)
 	c.Assert(err, IsNil)
 
 	appCanaryToStay := filepath.Join(dirs.SnapMountPolicyDir, "snap.i-stay.really.fstab")
-	err = ioutil.WriteFile(appCanaryToStay, []byte("stay!"), 0644)
+	err = os.WriteFile(appCanaryToStay, []byte("stay!"), 0644)
 	c.Assert(err, IsNil)
 
 	snapCanaryToStay := filepath.Join(dirs.SnapMountPolicyDir, "snap.i-stay.fstab")
-	err = ioutil.WriteFile(snapCanaryToStay, []byte("stay!"), 0644)
+	err = os.WriteFile(snapCanaryToStay, []byte("stay!"), 0644)
 	c.Assert(err, IsNil)
 
 	// Write the .mnt file, the logic for discarding mount namespaces uses it
 	// as a canary file to look for to even attempt to run the mount discard
 	// tool.
 	mntFile := filepath.Join(dirs.SnapRunNsDir, "hello-world.mnt")
-	err = ioutil.WriteFile(mntFile, []byte(""), 0644)
+	err = os.WriteFile(mntFile, []byte(""), 0644)
 	c.Assert(err, IsNil)
 
 	// Mock snap-discard-ns and allow tweak distro libexec dir so that it is used.
@@ -284,7 +284,7 @@ func (s *backendSuite) TestSetupUpdates(c *C) {
 	update = true
 	// ensure .mnt file
 	mntFile := filepath.Join(dirs.SnapRunNsDir, "snap-name.mnt")
-	err = ioutil.WriteFile(mntFile, []byte(""), 0644)
+	err = os.WriteFile(mntFile, []byte(""), 0644)
 	c.Assert(err, IsNil)
 
 	// confinement options are irrelevant to this security backend
@@ -334,7 +334,7 @@ func (s *backendSuite) TestSetupEndureUpdatesError(c *C) {
 	update = true
 	// ensure .mnt file
 	mntFile := filepath.Join(dirs.SnapRunNsDir, "snap-name.mnt")
-	err := ioutil.WriteFile(mntFile, []byte(""), 0644)
+	err := os.WriteFile(mntFile, []byte(""), 0644)
 	c.Assert(err, IsNil)
 
 	// confinement options are irrelevant to this security backend
@@ -405,7 +405,7 @@ func (s *backendSuite) TestSetupUpdatesErrorDiscardsNs(c *C) {
 	update = true
 	// ensure .mnt file
 	mntFile := filepath.Join(dirs.SnapRunNsDir, "snap-name.mnt")
-	err := ioutil.WriteFile(mntFile, []byte(""), 0644)
+	err := os.WriteFile(mntFile, []byte(""), 0644)
 	c.Assert(err, IsNil)
 
 	// confinement options are irrelevant to this security backend

--- a/interfaces/mount/ns_test.go
+++ b/interfaces/mount/ns_test.go
@@ -20,7 +20,6 @@
 package mount_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -80,7 +79,7 @@ func (s *nsSuite) TestDiscardNamespaceMnt(c *C) {
 
 		if t.mnt {
 			c.Assert(os.MkdirAll(dirs.SnapRunNsDir, 0755), IsNil)
-			c.Assert(ioutil.WriteFile(filepath.Join(dirs.SnapRunNsDir, "snap-name.mnt"), nil, 0644), IsNil)
+			c.Assert(os.WriteFile(filepath.Join(dirs.SnapRunNsDir, "snap-name.mnt"), nil, 0644), IsNil)
 		} else {
 			c.Assert(os.RemoveAll(dirs.SnapRunNsDir), IsNil)
 		}
@@ -128,7 +127,7 @@ func (s *nsSuite) TestUpdateNamespaceMnt(c *C) {
 
 		if t.mnt {
 			c.Assert(os.MkdirAll(dirs.SnapRunNsDir, 0755), IsNil)
-			c.Assert(ioutil.WriteFile(filepath.Join(dirs.SnapRunNsDir, "snap-name.mnt"), nil, 0644), IsNil)
+			c.Assert(os.WriteFile(filepath.Join(dirs.SnapRunNsDir, "snap-name.mnt"), nil, 0644), IsNil)
 		} else {
 			c.Assert(os.RemoveAll(dirs.SnapRunNsDir), IsNil)
 		}

--- a/interfaces/polkit/backend_test.go
+++ b/interfaces/polkit/backend_test.go
@@ -20,7 +20,6 @@
 package polkit_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -112,12 +111,12 @@ func (s *backendSuite) TestUnexpectedPolicyFilesremoved(c *C) {
 	policyFile := filepath.Join(dirs.SnapPolkitPolicyDir, "snap.samba.interface.something.policy")
 
 	for _, opts := range testedConfinementOpts {
-		c.Assert(ioutil.WriteFile(policyFile, []byte("<policyconfig/>"), 0644), IsNil)
+		c.Assert(os.WriteFile(policyFile, []byte("<policyconfig/>"), 0644), IsNil)
 		// Installing snap removes unexpected policy files
 		snapInfo := s.InstallSnap(c, opts, "", ifacetest.SambaYamlV1, 0)
 		c.Check(policyFile, testutil.FileAbsent)
 
-		c.Assert(ioutil.WriteFile(policyFile, []byte("<policyconfig/>"), 0644), IsNil)
+		c.Assert(os.WriteFile(policyFile, []byte("<policyconfig/>"), 0644), IsNil)
 		// Removing snap also removes unexpected policy files
 		s.RemoveSnap(c, snapInfo)
 		c.Check(policyFile, testutil.FileAbsent)

--- a/interfaces/seccomp/backend_test.go
+++ b/interfaces/seccomp/backend_test.go
@@ -957,7 +957,7 @@ func (s *backendSuite) TestParallelCompileError(c *C) {
 func (s *backendSuite) TestParallelCompileRemovesFirst(c *C) {
 	err := os.MkdirAll(dirs.SnapSeccompDir, 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(dirs.SnapSeccompDir, "profile-001.bin"), nil, 0755)
+	err = os.WriteFile(filepath.Join(dirs.SnapSeccompDir, "profile-001.bin"), nil, 0755)
 	c.Assert(err, IsNil)
 
 	// make profiles directory non-accessible

--- a/interfaces/system_key_test.go
+++ b/interfaces/system_key_test.go
@@ -246,7 +246,7 @@ func (s *systemKeySuite) TestInterfaceSystemKeyMismatchVersions(c *C) {
 "build-id": "7a94e9736c091b3984bd63f5aebfc883c4d859e0"
 }`))
 	// and the on-disk version is v2
-	err := ioutil.WriteFile(dirs.SnapSystemKeyFile, []byte(`
+	err := os.WriteFile(dirs.SnapSystemKeyFile, []byte(`
 {
 "version":2,
 "build-id": "7a94e9736c091b3984bd63f5aebfc883c4d859e0"

--- a/kernel/fde/cmd_helper.go
+++ b/kernel/fde/cmd_helper.go
@@ -70,9 +70,9 @@ func runFDEinitramfsHelper(name string, stdin []byte) (output []byte, err error)
 		// permissions, so deleting first is the right thing to do
 		os.Remove(streamFile)
 		if stream == "stdin" {
-			err = ioutil.WriteFile(streamFile, stdin, 0600)
+			err = os.WriteFile(streamFile, stdin, 0600)
 		} else {
-			err = ioutil.WriteFile(streamFile, nil, 0600)
+			err = os.WriteFile(streamFile, nil, 0600)
 		}
 		if err != nil {
 			return nil, fmt.Errorf("cannot create %s for %s: %v", name, stream, err)

--- a/kernel/fde/fde_test.go
+++ b/kernel/fde/fde_test.go
@@ -24,7 +24,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -67,7 +66,7 @@ func (s *fdeSuite) TestHasRevealKey(c *C) {
 	c.Check(fde.HasRevealKey(), Equals, false)
 
 	// fde-reveal-key without +x
-	err = ioutil.WriteFile(mockBin+"fde-reveal-key", nil, 0644)
+	err = os.WriteFile(mockBin+"fde-reveal-key", nil, 0644)
 	c.Assert(err, IsNil)
 	c.Check(fde.HasRevealKey(), Equals, false)
 
@@ -420,7 +419,7 @@ func (s *fdeSuite) TestedRevealTruncatesStreamFiles(c *C) {
 		c.Assert(err, IsNil)
 		// but make the file world-readable as it should be reset to 0600 before
 		// the hook is run
-		err = ioutil.WriteFile(streamFile, []byte("blah blah blah blah blah blah blah blah blah blah"), 0755)
+		err = os.WriteFile(streamFile, []byte("blah blah blah blah blah blah blah blah blah blah"), 0755)
 		c.Assert(err, IsNil)
 	}
 

--- a/kernel/kernel_test.go
+++ b/kernel/kernel_test.go
@@ -20,7 +20,6 @@
 package kernel_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -34,14 +33,14 @@ func makeMockKernel(c *C, kernelYaml string, filesWithContent map[string]string)
 	kernelRootDir := c.MkDir()
 	err := os.MkdirAll(filepath.Join(kernelRootDir, "meta"), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(kernelRootDir, "meta/kernel.yaml"), []byte(kernelYaml), 0644)
+	err = os.WriteFile(filepath.Join(kernelRootDir, "meta/kernel.yaml"), []byte(kernelYaml), 0644)
 	c.Assert(err, IsNil)
 
 	for fname, content := range filesWithContent {
 		p := filepath.Join(kernelRootDir, fname)
 		err = os.MkdirAll(filepath.Dir(p), 0755)
 		c.Assert(err, IsNil)
-		err = ioutil.WriteFile(p, []byte(content), 0644)
+		err = os.WriteFile(p, []byte(content), 0644)
 		c.Assert(err, IsNil)
 	}
 
@@ -107,7 +106,7 @@ func (s *kernelYamlTestSuite) TestReadKernelYamlSad(c *C) {
 	kernelYamlPath := filepath.Join(mockKernelSnapRoot, "meta/kernel.yaml")
 	err := os.MkdirAll(filepath.Dir(kernelYamlPath), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(kernelYamlPath, []byte(`invalid-kernel-yaml`), 0644)
+	err = os.WriteFile(kernelYamlPath, []byte(`invalid-kernel-yaml`), 0644)
 	c.Assert(err, IsNil)
 
 	ki, err := kernel.ReadInfo(mockKernelSnapRoot)
@@ -120,7 +119,7 @@ func (s *kernelYamlTestSuite) TestReadKernelYamlHappy(c *C) {
 	kernelYamlPath := filepath.Join(mockKernelSnapRoot, "meta/kernel.yaml")
 	err := os.MkdirAll(filepath.Dir(kernelYamlPath), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(kernelYamlPath, mockKernelYaml, 0644)
+	err = os.WriteFile(kernelYamlPath, mockKernelYaml, 0644)
 	c.Assert(err, IsNil)
 
 	ki, err := kernel.ReadInfo(mockKernelSnapRoot)

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -22,7 +22,6 @@ package logger_test
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -110,7 +109,7 @@ func (s *LogSuite) TestBootSetup(c *C) {
 	c.Check(logger.GetLogger(), IsNil)
 
 	cmdlineFile := filepath.Join(c.MkDir(), "cmdline")
-	err := ioutil.WriteFile(cmdlineFile, []byte("mocked panic=-1"), 0644)
+	err := os.WriteFile(cmdlineFile, []byte("mocked panic=-1"), 0644)
 	c.Assert(err, IsNil)
 	restore := kcmdline.MockProcCmdline(cmdlineFile)
 	defer restore()
@@ -122,7 +121,7 @@ func (s *LogSuite) TestBootSetup(c *C) {
 	c.Check(logger.GetQuiet(), Equals, false)
 
 	cmdlineFile = filepath.Join(c.MkDir(), "cmdline")
-	err = ioutil.WriteFile(cmdlineFile, []byte("mocked panic=-1 quiet"), 0644)
+	err = os.WriteFile(cmdlineFile, []byte("mocked panic=-1 quiet"), 0644)
 	c.Assert(err, IsNil)
 	restore = kcmdline.MockProcCmdline(cmdlineFile)
 	defer restore()
@@ -197,7 +196,7 @@ func (s *LogSuite) TestIntegrationDebugFromKernelCmdline(c *C) {
 	defer restore()
 
 	mockProcCmdline := filepath.Join(c.MkDir(), "proc-cmdline")
-	err := ioutil.WriteFile(mockProcCmdline, []byte("console=tty panic=-1 snapd.debug=1\n"), 0644)
+	err := os.WriteFile(mockProcCmdline, []byte("console=tty panic=-1 snapd.debug=1\n"), 0644)
 	c.Assert(err, IsNil)
 	restore = kcmdline.MockProcCmdline(mockProcCmdline)
 	defer restore()

--- a/osutil/buildid_test.go
+++ b/osutil/buildid_test.go
@@ -21,7 +21,6 @@ package osutil_test
 
 import (
 	"encoding/hex"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -94,7 +93,7 @@ func (s *buildIDSuite) TestReadBuildIDmd5(c *C) {
 	}
 
 	md5Truth := filepath.Join(c.MkDir(), "true")
-	err := ioutil.WriteFile(md5Truth+".c", []byte(`int main(){return 0;}`), 0644)
+	err := os.WriteFile(md5Truth+".c", []byte(`int main(){return 0;}`), 0644)
 	c.Assert(err, IsNil)
 	output, err := exec.Command(gccPath, "-Wl,--build-id=md5", "-xc", md5Truth+".c", "-o", md5Truth).CombinedOutput()
 	c.Assert(string(output), Equals, "")
@@ -111,7 +110,7 @@ func (s *buildIDSuite) TestReadBuildIDFixedELF(c *C) {
 	}
 
 	md5Truth := filepath.Join(c.MkDir(), "true")
-	err := ioutil.WriteFile(md5Truth+".c", []byte(`int main(){return 0;}`), 0644)
+	err := os.WriteFile(md5Truth+".c", []byte(`int main(){return 0;}`), 0644)
 	c.Assert(err, IsNil)
 	output, err := exec.Command(gccPath, "-Wl,--build-id=0xdeadcafe", "-xc", md5Truth+".c", "-o", md5Truth).CombinedOutput()
 	c.Assert(string(output), Equals, "")
@@ -147,7 +146,7 @@ func (s *buildIDSuite) TestReadBuildGo(c *C) {
 
 	tmpdir := c.MkDir()
 	goTruth := filepath.Join(tmpdir, "true")
-	err := ioutil.WriteFile(goTruth+".go", []byte(`package main; func main(){}`), 0644)
+	err := os.WriteFile(goTruth+".go", []byte(`package main; func main(){}`), 0644)
 	c.Assert(err, IsNil)
 	// force specific Go BuildID
 	cmd := exec.Command("go", "build", "-o", goTruth, "-ldflags=-buildid=foobar", goTruth+".go")

--- a/osutil/cmp_test.go
+++ b/osutil/cmp_test.go
@@ -21,7 +21,6 @@ package osutil_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -79,7 +78,7 @@ func (ts *CmpTestSuite) TestCmpEmptyNeqNonEmpty(c *C) {
 	f, err := os.Create(foo)
 	c.Assert(err, IsNil)
 	defer f.Close()
-	c.Assert(ioutil.WriteFile(bar, []byte("x"), 0644), IsNil)
+	c.Assert(os.WriteFile(bar, []byte("x"), 0644), IsNil)
 	c.Assert(osutil.FilesAreEqual(foo, bar), Equals, false)
 	c.Assert(osutil.FilesAreEqual(bar, foo), Equals, false)
 }

--- a/osutil/cp_linux_test.go
+++ b/osutil/cp_linux_test.go
@@ -20,7 +20,6 @@
 package osutil_test
 
 import (
-	"io/ioutil"
 	"os"
 
 	. "gopkg.in/check.v1"
@@ -38,7 +37,7 @@ func (s *cpSuite) TestCpMulti(c *C) {
 }
 
 func (s *cpSuite) TestDoCpErr(c *C) {
-	c.Assert(ioutil.WriteFile(s.f2, nil, 0444), IsNil)
+	c.Assert(os.WriteFile(s.f2, nil, 0444), IsNil)
 
 	src, err := os.Open(s.f1)
 	c.Assert(err, IsNil)

--- a/osutil/cp_test.go
+++ b/osutil/cp_test.go
@@ -21,7 +21,6 @@ package osutil_test
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -75,7 +74,7 @@ func (s *cpSuite) SetUpTest(c *C) {
 	s.f1 = filepath.Join(s.dir, "f1")
 	s.f2 = filepath.Join(s.dir, "f2")
 	s.data = []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
-	c.Assert(ioutil.WriteFile(s.f1, s.data, 0644), IsNil)
+	c.Assert(os.WriteFile(s.f1, s.data, 0644), IsNil)
 }
 
 func (s *cpSuite) mock() {
@@ -102,7 +101,7 @@ func (s *cpSuite) TestCpOverwrite(c *C) {
 }
 
 func (s *cpSuite) TestCpOverwriteTruncates(c *C) {
-	c.Assert(ioutil.WriteFile(s.f2, []byte("xxxxxxxxxxxxxxxx"), 0644), IsNil)
+	c.Assert(os.WriteFile(s.f2, []byte("xxxxxxxxxxxxxxxx"), 0644), IsNil)
 	c.Check(osutil.CopyFile(s.f1, s.f2, osutil.CopyFlagOverwrite), IsNil)
 	c.Check(s.f2, testutil.FileEquals, s.data)
 }
@@ -216,7 +215,7 @@ func (s *cpSuite) TestCopyPreserveAll(c *C) {
 	src := filepath.Join(c.MkDir(), "meep")
 	dst := filepath.Join(c.MkDir(), "copied-meep")
 
-	err := ioutil.WriteFile(src, []byte(nil), 0644)
+	err := os.WriteFile(src, []byte(nil), 0644)
 	c.Assert(err, IsNil)
 
 	// Give the file a different mtime to ensure CopyFlagPreserveAll
@@ -248,7 +247,7 @@ func (s *cpSuite) TestCopyPreserveAllSync(c *C) {
 	src := filepath.Join(dir, "meep")
 	dst := filepath.Join(dir, "copied-meep")
 
-	err := ioutil.WriteFile(src, []byte(nil), 0644)
+	err := os.WriteFile(src, []byte(nil), 0644)
 	c.Assert(err, IsNil)
 
 	err = osutil.CopyFile(src, dst, osutil.CopyFlagPreserveAll|osutil.CopyFlagSync)
@@ -268,7 +267,7 @@ func (s *cpSuite) TestCopyPreserveAllSyncCpFailure(c *C) {
 	src := filepath.Join(dir, "meep")
 	dst := filepath.Join(dir, "copied-meep")
 
-	err := ioutil.WriteFile(src, []byte(nil), 0644)
+	err := os.WriteFile(src, []byte(nil), 0644)
 	c.Assert(err, IsNil)
 
 	err = osutil.CopyFile(src, dst, osutil.CopyFlagPreserveAll|osutil.CopyFlagSync)
@@ -286,7 +285,7 @@ func (s *cpSuite) TestCopyPreserveAllSyncSyncFailure(c *C) {
 	src := filepath.Join(dir, "meep")
 	dst := filepath.Join(dir, "copied-meep")
 
-	err := ioutil.WriteFile(src, []byte(nil), 0644)
+	err := os.WriteFile(src, []byte(nil), 0644)
 	c.Assert(err, IsNil)
 
 	err = osutil.CopyFile(src, dst, osutil.CopyFlagPreserveAll|osutil.CopyFlagSync)
@@ -323,7 +322,7 @@ func (s *cpSuite) TestAtomicWriteFileCopyPreservesModTime(c *C) {
 }
 
 func (s *cpSuite) TestAtomicWriteFileCopyOverwrites(c *C) {
-	err := ioutil.WriteFile(s.f2, []byte("this is f2 content"), 0644)
+	err := os.WriteFile(s.f2, []byte("this is f2 content"), 0644)
 	c.Assert(err, IsNil)
 
 	err = osutil.AtomicWriteFileCopy(s.f2, s.f1, 0)

--- a/osutil/digest_test.go
+++ b/osutil/digest_test.go
@@ -22,7 +22,7 @@ package osutil_test
 import (
 	"crypto"
 	"crypto/sha512"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	. "gopkg.in/check.v1"
@@ -39,7 +39,7 @@ func (ts *FileDigestSuite) TestFileDigest(c *C) {
 
 	tempdir := c.MkDir()
 	fn := filepath.Join(tempdir, "ex.file")
-	err := ioutil.WriteFile(fn, exData, 0644)
+	err := os.WriteFile(fn, exData, 0644)
 	c.Assert(err, IsNil)
 
 	digest, size, err := osutil.FileDigest(fn, crypto.SHA512)

--- a/osutil/disks/disks_linux_test.go
+++ b/osutil/disks/disks_linux_test.go
@@ -22,7 +22,6 @@ package disks_test
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -122,7 +121,7 @@ func createVirtioDevicesInSysfs(c *C, path string, devsToPartition map[string]bo
 		err := os.MkdirAll(filepath.Join(diskDir, dev), 0755)
 		c.Assert(err, IsNil)
 		if isPartition {
-			err = ioutil.WriteFile(filepath.Join(diskDir, dev, "partition"), []byte("1"), 0644)
+			err = os.WriteFile(filepath.Join(diskDir, dev, "partition"), []byte("1"), 0644)
 			c.Assert(err, IsNil)
 		}
 	}
@@ -744,11 +743,11 @@ func (s *diskSuite) TestDiskFromMountPointIsDecryptedLUKSDeviceVolumeHappy(c *C)
 	c.Assert(err, IsNil)
 
 	b := []byte("something")
-	err = ioutil.WriteFile(filepath.Join(dmDir, "name"), b, 0644)
+	err = os.WriteFile(filepath.Join(dmDir, "name"), b, 0644)
 	c.Assert(err, IsNil)
 
 	b = []byte("CRYPT-LUKS2-5a522809c87e4dfa81a88dc5667d1304-something")
-	err = ioutil.WriteFile(filepath.Join(dmDir, "uuid"), b, 0644)
+	err = os.WriteFile(filepath.Join(dmDir, "uuid"), b, 0644)
 	c.Assert(err, IsNil)
 
 	opts := &disks.Options{IsDecryptedDevice: true}
@@ -1201,11 +1200,11 @@ func (s *diskSuite) TestDiskFromMountPointDecryptedDevicePartitionsHappy(c *C) {
 	c.Assert(err, IsNil)
 
 	b := []byte("ubuntu-data-3776bab4-8bcc-46b7-9da2-6a84ce7f93b4")
-	err = ioutil.WriteFile(filepath.Join(dmDir, "name"), b, 0644)
+	err = os.WriteFile(filepath.Join(dmDir, "name"), b, 0644)
 	c.Assert(err, IsNil)
 
 	b = []byte("CRYPT-LUKS2-5a522809c87e4dfa81a88dc5667d1304-ubuntu-data-3776bab4-8bcc-46b7-9da2-6a84ce7f93b4")
-	err = ioutil.WriteFile(filepath.Join(dmDir, "uuid"), b, 0644)
+	err = os.WriteFile(filepath.Join(dmDir, "uuid"), b, 0644)
 	c.Assert(err, IsNil)
 
 	// mock the dev nodes in sysfs for the partitions
@@ -1781,7 +1780,7 @@ func (s *diskSuite) TestAllPhysicalDisks(c *C) {
 	c.Assert(err, IsNil)
 	devsToCreate := []string{"sda", "loop1", "loop2", "sdb", "nvme0n1", "mmcblk0"}
 	for _, dev := range devsToCreate {
-		err := ioutil.WriteFile(filepath.Join(blockDir, dev), nil, 0644)
+		err := os.WriteFile(filepath.Join(blockDir, dev), nil, 0644)
 		c.Assert(err, IsNil)
 	}
 
@@ -1924,11 +1923,11 @@ func (s *diskSuite) TestPartitionUUIDFromMopuntPointDecrypted(c *C) {
 	c.Assert(err, IsNil)
 
 	b := []byte("something")
-	err = ioutil.WriteFile(filepath.Join(dmDir, "name"), b, 0644)
+	err = os.WriteFile(filepath.Join(dmDir, "name"), b, 0644)
 	c.Assert(err, IsNil)
 
 	b = []byte("CRYPT-LUKS2-5a522809c87e4dfa81a88dc5667d1304-something")
-	err = ioutil.WriteFile(filepath.Join(dmDir, "uuid"), b, 0644)
+	err = os.WriteFile(filepath.Join(dmDir, "uuid"), b, 0644)
 	c.Assert(err, IsNil)
 
 	uuid, err := disks.PartitionUUIDFromMountPoint("/run/mnt/point", &disks.Options{

--- a/osutil/export_test.go
+++ b/osutil/export_test.go
@@ -180,7 +180,7 @@ func MockEtcFstab(text string) (restore func()) {
 	if err != nil {
 		panic(fmt.Errorf("cannot open temporary file: %s", err))
 	}
-	if err := ioutil.WriteFile(f.Name(), []byte(text), 0644); err != nil {
+	if err := os.WriteFile(f.Name(), []byte(text), 0644); err != nil {
 		panic(fmt.Errorf("cannot write mock fstab file: %s", err))
 	}
 	etcFstab = f.Name()

--- a/osutil/faultinject_test.go
+++ b/osutil/faultinject_test.go
@@ -23,7 +23,6 @@ package osutil_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -68,14 +67,14 @@ func (s *testhelperFaultInjectionSuite) TestFaultInject(c *C) {
 
 	os.Setenv("SNAPD_FAULT_INJECT", "tag:reboot,othertag:panic,funtag:reboot")
 
-	c.Assert(ioutil.WriteFile(sysrqFile, nil, 0644), IsNil)
+	c.Assert(os.WriteFile(sysrqFile, nil, 0644), IsNil)
 	osutil.MaybeInjectFault("tag")
 	c.Assert(filepath.Join(s.sysroot, "/proc/sysrq-trigger"), testutil.FileEquals, "b\n")
 	c.Check(foreverLoopCalls, Equals, 1)
 	c.Check(filepath.Join(s.sysroot, "/var/lib/snapd/faults/tag:reboot"), testutil.FilePresent)
 	c.Check(stderrBuf.String(), Equals, "injecting \"reboot\" fault for tag \"tag\"\n")
 	// trying to inject a tag again does nothing as long as the stamp file is present
-	c.Assert(ioutil.WriteFile(sysrqFile, nil, 0644), IsNil)
+	c.Assert(os.WriteFile(sysrqFile, nil, 0644), IsNil)
 	stderrBuf.Reset()
 	osutil.MaybeInjectFault("tag")
 	c.Check(foreverLoopCalls, Equals, 1)
@@ -90,7 +89,7 @@ func (s *testhelperFaultInjectionSuite) TestFaultInject(c *C) {
 	c.Check(stderrBuf.String(), Equals, "injecting \"reboot\" fault for tag \"tag\"\n")
 
 	// try another tag that triggers reboot
-	c.Assert(ioutil.WriteFile(sysrqFile, nil, 0644), IsNil)
+	c.Assert(os.WriteFile(sysrqFile, nil, 0644), IsNil)
 	stderrBuf.Reset()
 	osutil.MaybeInjectFault("funtag")
 	c.Assert(filepath.Join(s.sysroot, "/proc/sysrq-trigger"), testutil.FileEquals, "b\n")
@@ -99,7 +98,7 @@ func (s *testhelperFaultInjectionSuite) TestFaultInject(c *C) {
 	c.Check(filepath.Join(s.sysroot, "/var/lib/snapd/faults/funtag:reboot"), testutil.FilePresent)
 
 	// clear sysrq-trigger file
-	c.Assert(ioutil.WriteFile(sysrqFile, nil, 0644), IsNil)
+	c.Assert(os.WriteFile(sysrqFile, nil, 0644), IsNil)
 	stderrBuf.Reset()
 	c.Assert(func() {
 		osutil.MaybeInjectFault("othertag")

--- a/osutil/fshelpers_test.go
+++ b/osutil/fshelpers_test.go
@@ -20,7 +20,6 @@
 package osutil_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -36,7 +35,7 @@ var _ = Suite(&groupFindGidOwningSuite{})
 
 func (s *groupFindGidOwningSuite) TestSelfOwnedFile(c *C) {
 	name := filepath.Join(c.MkDir(), "testownedfile")
-	err := ioutil.WriteFile(name, nil, 0644)
+	err := os.WriteFile(name, nil, 0644)
 	c.Assert(err, IsNil)
 
 	gid, err := osutil.FindGidOwning(name)

--- a/osutil/io.go
+++ b/osutil/io.go
@@ -221,7 +221,7 @@ func (aw *AtomicFile) CommitAs(filename string) error {
 	return aw.commit()
 }
 
-// The AtomicWrite* family of functions work like ioutil.WriteFile(), but the
+// The AtomicWrite* family of functions work like os.WriteFile(), but the
 // file created is an AtomicWriter, which is Committed before returning.
 //
 // AtomicWriteChown and AtomicWriteFileChown take an uid and a gid that can be

--- a/osutil/io_test.go
+++ b/osutil/io_test.go
@@ -70,7 +70,7 @@ func (ts *AtomicWriteTestSuite) TestAtomicWriteFilePermissions(c *C) {
 func (ts *AtomicWriteTestSuite) TestAtomicWriteFileOverwrite(c *C) {
 	tmpdir := c.MkDir()
 	p := filepath.Join(tmpdir, "foo")
-	c.Assert(ioutil.WriteFile(p, []byte("hello"), 0644), IsNil)
+	c.Assert(os.WriteFile(p, []byte("hello"), 0644), IsNil)
 	c.Assert(osutil.AtomicWriteFile(p, []byte("hi"), 0600, 0), IsNil)
 
 	c.Assert(p, testutil.FileEquals, "hi")
@@ -116,7 +116,7 @@ func (ts *AtomicWriteTestSuite) TestAtomicWriteFileOverwriteAbsoluteSymlink(c *C
 	c.Assert(os.Chmod(rodir, 0500), IsNil)
 	defer os.Chmod(rodir, 0700)
 
-	c.Assert(ioutil.WriteFile(s, []byte("hello"), 0644), IsNil)
+	c.Assert(os.WriteFile(s, []byte("hello"), 0644), IsNil)
 	c.Assert(osutil.AtomicWriteFile(p, []byte("hi"), 0600, osutil.AtomicWriteFollow), IsNil)
 
 	c.Assert(p, testutil.FileEquals, "hi")
@@ -147,7 +147,7 @@ func (ts *AtomicWriteTestSuite) TestAtomicWriteFileOverwriteRelativeSymlink(c *C
 	c.Assert(os.Chmod(rodir, 0500), IsNil)
 	defer os.Chmod(rodir, 0700)
 
-	c.Assert(ioutil.WriteFile(s, []byte("hello"), 0644), IsNil)
+	c.Assert(os.WriteFile(s, []byte("hello"), 0644), IsNil)
 	c.Assert(osutil.AtomicWriteFile(p, []byte("hi"), 0600, osutil.AtomicWriteFollow), IsNil)
 
 	c.Assert(p, testutil.FileEquals, "hi")
@@ -162,7 +162,7 @@ func (ts *AtomicWriteTestSuite) TestAtomicWriteFileNoOverwriteTmpExisting(c *C) 
 	rand.Seed(1)
 
 	p := filepath.Join(tmpdir, "foo")
-	err := ioutil.WriteFile(p+"."+expectedRandomness, []byte(""), 0644)
+	err := os.WriteFile(p+"."+expectedRandomness, []byte(""), 0644)
 	c.Assert(err, IsNil)
 
 	err = osutil.AtomicWriteFile(p, []byte(""), 0600, 0)
@@ -285,7 +285,7 @@ func (ts *AtomicWriteTestSuite) TestAtomicFileCommitAs(c *C) {
 
 	// overwrites any existing file on CommitAs (same as Commit)
 	overwrittenTarget := filepath.Join(d, "will-overwrite")
-	err = ioutil.WriteFile(overwrittenTarget, []byte("overwritten"), 0644)
+	err = os.WriteFile(overwrittenTarget, []byte("overwritten"), 0644)
 	c.Assert(err, IsNil)
 	aw, err = osutil.NewAtomicFile(filepath.Join(d, "temp-name"), 0644, 0, osutil.NoChown, osutil.NoChown)
 	c.Assert(err, IsNil)
@@ -382,7 +382,7 @@ func (ts *AtomicSymlinkTestSuite) createCollisionSequence(c *C, baseName string,
 	for i := 0; i < many; i++ {
 		expectedRandomness := randutil.RandomString(12) + "~"
 		// ensure we always get the same result
-		err := ioutil.WriteFile(baseName+"."+expectedRandomness, []byte(""), 0644)
+		err := os.WriteFile(baseName+"."+expectedRandomness, []byte(""), 0644)
 		c.Assert(err, IsNil)
 	}
 }
@@ -420,7 +420,7 @@ var _ = Suite(&AtomicRenameTestSuite{})
 func (ts *AtomicRenameTestSuite) TestAtomicRenameFile(c *C) {
 	d := c.MkDir()
 
-	err := ioutil.WriteFile(filepath.Join(d, "foo"), []byte("foobar"), 0644)
+	err := os.WriteFile(filepath.Join(d, "foo"), []byte("foobar"), 0644)
 	c.Assert(err, IsNil)
 
 	err = osutil.AtomicRename(filepath.Join(d, "foo"), filepath.Join(d, "bar"))
@@ -454,7 +454,7 @@ func (ts *AtomicRenameTestSuite) TestAtomicRenameFile(c *C) {
 	err = osutil.AtomicRename(filepath.Join(d, "bar"), filepath.Join(nested, "bar"))
 	c.Assert(err, IsNil)
 
-	err = ioutil.WriteFile(filepath.Join(nested, "new-bar"), []byte("barbar"), 0644)
+	err = os.WriteFile(filepath.Join(nested, "new-bar"), []byte("barbar"), 0644)
 	c.Assert(err, IsNil)
 
 	// target is overwritten

--- a/osutil/kcmdline/kcmdline_test.go
+++ b/osutil/kcmdline/kcmdline_test.go
@@ -22,7 +22,7 @@ package kcmdline_test
 import (
 	"encoding"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -184,7 +184,7 @@ func (s *kcmdlineTestSuite) TestGetKernelCommandLineKeyValue(c *C) {
 		},
 	} {
 		cmdlineFile := filepath.Join(c.MkDir(), "cmdline")
-		err := ioutil.WriteFile(cmdlineFile, []byte(t.cmdline), 0644)
+		err := os.WriteFile(cmdlineFile, []byte(t.cmdline), 0644)
 		c.Assert(err, IsNil)
 		r := kcmdline.MockProcCmdline(cmdlineFile)
 		defer r()
@@ -212,7 +212,7 @@ func (s *kcmdlineTestSuite) TestKernelCommandLine(c *C) {
 	c.Assert(err, ErrorMatches, `.*/cmdline: no such file or directory`)
 	c.Check(cmd, Equals, "")
 
-	err = ioutil.WriteFile(newProcCmdline, []byte("foo bar baz panic=-1\n"), 0644)
+	err = os.WriteFile(newProcCmdline, []byte("foo bar baz panic=-1\n"), 0644)
 	c.Assert(err, IsNil)
 	cmd, err = kcmdline.KernelCommandLine()
 	c.Assert(err, IsNil)

--- a/osutil/meminfo_test.go
+++ b/osutil/meminfo_test.go
@@ -20,7 +20,7 @@
 package osutil_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	. "gopkg.in/check.v1"
@@ -132,13 +132,13 @@ func (s *meminfoSuite) TestMemInfoHappy(c *C) {
 	restore := osutil.MockProcMeminfo(p)
 	defer restore()
 
-	c.Assert(ioutil.WriteFile(p, []byte(meminfoExampleFromLiveSystem), 0644), IsNil)
+	c.Assert(os.WriteFile(p, []byte(meminfoExampleFromLiveSystem), 0644), IsNil)
 
 	mem, err := osutil.TotalUsableMemory()
 	c.Assert(err, IsNil)
 	c.Check(mem, Equals, uint64(32876680)*1024)
 
-	c.Assert(ioutil.WriteFile(p, []byte(`MemTotal:    1234 kB`), 0644), IsNil)
+	c.Assert(os.WriteFile(p, []byte(`MemTotal:    1234 kB`), 0644), IsNil)
 
 	mem, err = osutil.TotalUsableMemory()
 	c.Assert(err, IsNil)
@@ -149,13 +149,13 @@ func (s *meminfoSuite) TestMemInfoHappy(c *C) {
 MemTotal:       32876699 kB
 MemFree:         3478104 kB
 `
-	c.Assert(ioutil.WriteFile(p, []byte(meminfoReorderedWithEmptyLine), 0644), IsNil)
+	c.Assert(os.WriteFile(p, []byte(meminfoReorderedWithEmptyLine), 0644), IsNil)
 
 	mem, err = osutil.TotalUsableMemory()
 	c.Assert(err, IsNil)
 	c.Check(mem, Equals, uint64(32876699)*1024)
 
-	c.Assert(ioutil.WriteFile(p, []byte(meminfoExampleFromPi3), 0644), IsNil)
+	c.Assert(os.WriteFile(p, []byte(meminfoExampleFromPi3), 0644), IsNil)
 
 	// CmaTotal is taken correctly into account
 	mem, err = osutil.TotalUsableMemory()
@@ -209,7 +209,7 @@ Cached:         14550292 kB
 			err:     `cannot convert memory size value: strconv.ParseUint: parsing "0xabcdef": invalid syntax`,
 		},
 	} {
-		c.Assert(ioutil.WriteFile(p, []byte(tc.content), 0644), IsNil)
+		c.Assert(os.WriteFile(p, []byte(tc.content), 0644), IsNil)
 		mem, err := osutil.TotalUsableMemory()
 		c.Assert(err, ErrorMatches, tc.err)
 		c.Check(mem, Equals, uint64(0))

--- a/osutil/mountinfo_linux_test.go
+++ b/osutil/mountinfo_linux_test.go
@@ -20,7 +20,6 @@
 package osutil_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -180,7 +179,7 @@ func (s *mountinfoSuite) TestReadMountInfo2(c *C) {
 // Test that loading mountinfo from a file works as expected.
 func (s *mountinfoSuite) TestLoadMountInfo1(c *C) {
 	fname := filepath.Join(c.MkDir(), "mountinfo")
-	err := ioutil.WriteFile(fname, []byte(mountInfoSample), 0644)
+	err := os.WriteFile(fname, []byte(mountInfoSample), 0644)
 	c.Assert(err, IsNil)
 	restore := osutil.MockProcSelfMountInfoLocation(fname)
 	defer restore()
@@ -201,7 +200,7 @@ func (s *mountinfoSuite) TestLoadMountInfo2(c *C) {
 // Test that trying to load mountinfo without permissions reports an error.
 func (s *mountinfoSuite) TestLoadMountInfo3(c *C) {
 	fname := filepath.Join(c.MkDir(), "mountinfo")
-	err := ioutil.WriteFile(fname, []byte(mountInfoSample), 0644)
+	err := os.WriteFile(fname, []byte(mountInfoSample), 0644)
 	c.Assert(err, IsNil)
 	err = os.Chmod(fname, 0000)
 	c.Assert(err, IsNil)

--- a/osutil/mountprofile_linux_test.go
+++ b/osutil/mountprofile_linux_test.go
@@ -21,7 +21,6 @@ package osutil_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -48,7 +47,7 @@ func (s *profileSuite) TestLoadMountProfile1(c *C) {
 func (s *profileSuite) TestLoadMountProfile2(c *C) {
 	dir := c.MkDir()
 	fname := filepath.Join(dir, "existing")
-	err := ioutil.WriteFile(fname, []byte("name-1 dir-1 type-1 options-1 1 1 # 1st entry"), 0644)
+	err := os.WriteFile(fname, []byte("name-1 dir-1 type-1 options-1 1 1 # 1st entry"), 0644)
 	c.Assert(err, IsNil)
 	p, err := osutil.LoadMountProfile(fname)
 	c.Assert(err, IsNil)
@@ -62,7 +61,7 @@ func (s *profileSuite) TestLoadMountProfile2(c *C) {
 func (s *profileSuite) TestLoadMountProfile3(c *C) {
 	dir := c.MkDir()
 	fname := filepath.Join(dir, "existing")
-	err := ioutil.WriteFile(fname, []byte(`
+	err := os.WriteFile(fname, []byte(`
    # comment with leading spaces
 name#-1 dir#-1 type#-1 options#-1 1 1 # inline comment
 # comment without leading spaces

--- a/osutil/stat_test.go
+++ b/osutil/stat_test.go
@@ -21,7 +21,6 @@ package osutil_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -42,7 +41,7 @@ func (ts *StatTestSuite) TestFileDoesNotExist(c *C) {
 
 func (ts *StatTestSuite) TestFileExistsSimple(c *C) {
 	fname := filepath.Join(c.MkDir(), "foo")
-	err := ioutil.WriteFile(fname, []byte(fname), 0644)
+	err := os.WriteFile(fname, []byte(fname), 0644)
 	c.Assert(err, IsNil)
 
 	c.Assert(osutil.FileExists(fname), Equals, true)
@@ -50,7 +49,7 @@ func (ts *StatTestSuite) TestFileExistsSimple(c *C) {
 
 func (ts *StatTestSuite) TestFileExistsExistsOddPermissions(c *C) {
 	fname := filepath.Join(c.MkDir(), "foo")
-	err := ioutil.WriteFile(fname, []byte(fname), 0100)
+	err := os.WriteFile(fname, []byte(fname), 0100)
 	c.Assert(err, IsNil)
 
 	c.Assert(osutil.FileExists(fname), Equals, true)
@@ -88,7 +87,7 @@ func (ts *StatTestSuite) TestExecutableExists(c *C) {
 	c.Check(osutil.ExecutableExists("xyzzy"), Equals, false)
 
 	fname := filepath.Join(d, "xyzzy")
-	c.Assert(ioutil.WriteFile(fname, []byte{}, 0644), IsNil)
+	c.Assert(os.WriteFile(fname, []byte{}, 0644), IsNil)
 	c.Check(osutil.ExecutableExists("xyzzy"), Equals, false)
 
 	c.Assert(os.Chmod(fname, 0755), IsNil)
@@ -121,7 +120,7 @@ func makeTestPathInDir(c *C, dir, path string, mode os.FileMode) string {
 	} else {
 		// request for a file
 		c.Assert(os.MkdirAll(filepath.Dir(path), 0755), IsNil)
-		c.Assert(ioutil.WriteFile(path, nil, mode), IsNil)
+		c.Assert(os.WriteFile(path, nil, mode), IsNil)
 	}
 
 	return path
@@ -232,7 +231,7 @@ func (ts *StatTestSuite) TestIsExecutable(c *C) {
 		err := os.Remove(p)
 		c.Check(err == nil || os.IsNotExist(err), Equals, true)
 
-		err = ioutil.WriteFile(p, []byte(""), tc.mode)
+		err = os.WriteFile(p, []byte(""), tc.mode)
 		c.Assert(err, IsNil)
 		c.Check(osutil.IsExecutable(p), Equals, tc.is)
 	}
@@ -281,7 +280,7 @@ func (ts *StatTestSuite) TestRegularFileExists(c *C) {
 				c.Assert(err, IsNil, comment)
 			} else {
 				// make it a normal file
-				err := ioutil.WriteFile(fullpath, nil, 0644)
+				err := os.WriteFile(fullpath, nil, 0644)
 				c.Assert(err, IsNil, comment)
 			}
 		}

--- a/osutil/strace/strace_test.go
+++ b/osutil/strace/strace_test.go
@@ -20,7 +20,6 @@
 package strace_test
 
 import (
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -89,7 +88,7 @@ func (s *straceSuite) TestStraceCommandNoStrace(c *C) {
 
 	tmp := c.MkDir()
 	os.Setenv("PATH", tmp)
-	err := ioutil.WriteFile(filepath.Join(tmp, "sudo"), nil, 0755)
+	err := os.WriteFile(filepath.Join(tmp, "sudo"), nil, 0755)
 	c.Assert(err, IsNil)
 
 	_, err = strace.Command(nil, "foo")

--- a/osutil/syncdir_test.go
+++ b/osutil/syncdir_test.go
@@ -22,7 +22,6 @@ package osutil_test
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -47,7 +46,7 @@ func (s *EnsureDirStateSuite) SetUpTest(c *C) {
 
 func (s *EnsureDirStateSuite) TestVerifiesExpectedFiles(c *C) {
 	name := filepath.Join(s.dir, "expected.snap")
-	err := ioutil.WriteFile(name, []byte("expected"), 0600)
+	err := os.WriteFile(name, []byte("expected"), 0600)
 	c.Assert(err, IsNil)
 	changed, removed, err := osutil.EnsureDirState(s.dir, s.glob, map[string]osutil.FileState{
 		"expected.snap": &osutil.MemoryFileState{Content: []byte("expected"), Mode: 0600},
@@ -66,11 +65,11 @@ func (s *EnsureDirStateSuite) TestVerifiesExpectedFiles(c *C) {
 
 func (s *EnsureDirStateSuite) TestTwoPatterns(c *C) {
 	name1 := filepath.Join(s.dir, "expected.snap")
-	err := ioutil.WriteFile(name1, []byte("expected-1"), 0600)
+	err := os.WriteFile(name1, []byte("expected-1"), 0600)
 	c.Assert(err, IsNil)
 
 	name2 := filepath.Join(s.dir, "expected.snap-update-ns")
-	err = ioutil.WriteFile(name2, []byte("expected-2"), 0600)
+	err = os.WriteFile(name2, []byte("expected-2"), 0600)
 	c.Assert(err, IsNil)
 
 	changed, removed, err := osutil.EnsureDirStateGlobs(s.dir, []string{"*.snap", "*.snap-update-ns"}, map[string]osutil.FileState{
@@ -95,7 +94,7 @@ func (s *EnsureDirStateSuite) TestTwoPatterns(c *C) {
 
 func (s *EnsureDirStateSuite) TestMultipleMatches(c *C) {
 	name := filepath.Join(s.dir, "foo")
-	err := ioutil.WriteFile(name, []byte("content"), 0600)
+	err := os.WriteFile(name, []byte("content"), 0600)
 	c.Assert(err, IsNil)
 	// When a file is matched by multiple globs it removed correctly.
 	changed, removed, err := osutil.EnsureDirStateGlobs(s.dir, []string{"foo", "f*"}, nil)
@@ -123,7 +122,7 @@ func (s *EnsureDirStateSuite) TestCreatesMissingFiles(c *C) {
 
 func (s *EnsureDirStateSuite) TestRemovesUnexpectedFiless(c *C) {
 	name := filepath.Join(s.dir, "evil.snap")
-	err := ioutil.WriteFile(name, []byte(`evil text`), 0600)
+	err := os.WriteFile(name, []byte(`evil text`), 0600)
 	c.Assert(err, IsNil)
 	changed, removed, err := osutil.EnsureDirState(s.dir, s.glob, map[string]osutil.FileState{})
 	c.Assert(err, IsNil)
@@ -137,7 +136,7 @@ func (s *EnsureDirStateSuite) TestRemovesUnexpectedFiless(c *C) {
 
 func (s *EnsureDirStateSuite) TestIgnoresUnrelatedFiles(c *C) {
 	name := filepath.Join(s.dir, "unrelated")
-	err := ioutil.WriteFile(name, []byte(`text`), 0600)
+	err := os.WriteFile(name, []byte(`text`), 0600)
 	c.Assert(err, IsNil)
 	changed, removed, err := osutil.EnsureDirState(s.dir, s.glob, map[string]osutil.FileState{})
 	c.Assert(err, IsNil)
@@ -151,7 +150,7 @@ func (s *EnsureDirStateSuite) TestIgnoresUnrelatedFiles(c *C) {
 
 func (s *EnsureDirStateSuite) TestCorrectsFilesWithDifferentSize(c *C) {
 	name := filepath.Join(s.dir, "differing.snap")
-	err := ioutil.WriteFile(name, []byte(``), 0600)
+	err := os.WriteFile(name, []byte(``), 0600)
 	c.Assert(err, IsNil)
 	changed, removed, err := osutil.EnsureDirState(s.dir, s.glob, map[string]osutil.FileState{
 		"differing.snap": &osutil.MemoryFileState{Content: []byte(`Hello World`), Mode: 0600},
@@ -170,7 +169,7 @@ func (s *EnsureDirStateSuite) TestCorrectsFilesWithDifferentSize(c *C) {
 
 func (s *EnsureDirStateSuite) TestCorrectsFilesWithSameSize(c *C) {
 	name := filepath.Join(s.dir, "differing.snap")
-	err := ioutil.WriteFile(name, []byte("evil"), 0600)
+	err := os.WriteFile(name, []byte("evil"), 0600)
 	c.Assert(err, IsNil)
 	changed, removed, err := osutil.EnsureDirState(s.dir, s.glob, map[string]osutil.FileState{
 		"differing.snap": &osutil.MemoryFileState{Content: []byte("good"), Mode: 0600},
@@ -190,7 +189,7 @@ func (s *EnsureDirStateSuite) TestCorrectsFilesWithSameSize(c *C) {
 func (s *EnsureDirStateSuite) TestFixesFilesWithBadPermissions(c *C) {
 	name := filepath.Join(s.dir, "sensitive.snap")
 	// NOTE: the existing file is currently wide-open for everyone"
-	err := ioutil.WriteFile(name, []byte("password"), 0666)
+	err := os.WriteFile(name, []byte("password"), 0666)
 	c.Assert(err, IsNil)
 	changed, removed, err := osutil.EnsureDirState(s.dir, s.glob, map[string]osutil.FileState{
 		// NOTE: we want the file to be private
@@ -226,7 +225,7 @@ func (s *EnsureDirStateSuite) TestReportsAbnormalPatterns(c *C) {
 func (s *EnsureDirStateSuite) TestRemovesAllManagedFilesOnError(c *C) {
 	// Create a "prior.snap" file
 	prior := filepath.Join(s.dir, "prior.snap")
-	err := ioutil.WriteFile(prior, []byte("data"), 0600)
+	err := os.WriteFile(prior, []byte("data"), 0600)
 	c.Assert(err, IsNil)
 	// Create a "clash.snap" directory to simulate failure
 	clash := filepath.Join(s.dir, "clash.snap")
@@ -247,7 +246,7 @@ func (s *EnsureDirStateSuite) TestRemovesAllManagedFilesOnError(c *C) {
 
 func (s *EnsureDirStateSuite) TestRemovesSymlink(c *C) {
 	original := filepath.Join(s.dir, "original.snap")
-	err := ioutil.WriteFile(original, []byte("data"), 0600)
+	err := os.WriteFile(original, []byte("data"), 0600)
 	c.Assert(err, IsNil)
 
 	symlink := filepath.Join(s.dir, "symlink.snap")
@@ -269,7 +268,7 @@ func (s *EnsureDirStateSuite) TestRemovesSymlink(c *C) {
 
 func (s *EnsureDirStateSuite) TestCreatesMissingSymlink(c *C) {
 	original := filepath.Join(s.dir, "original.snap")
-	err := ioutil.WriteFile(original, []byte("data"), 0600)
+	err := os.WriteFile(original, []byte("data"), 0600)
 	c.Assert(err, IsNil)
 
 	// Created file is reported
@@ -293,11 +292,11 @@ func (s *EnsureDirStateSuite) TestCreatesMissingSymlink(c *C) {
 
 func (s *EnsureDirStateSuite) TestReplaceFileWithSymlink(c *C) {
 	original := filepath.Join(s.dir, "original.snap")
-	err := ioutil.WriteFile(original, []byte("data"), 0600)
+	err := os.WriteFile(original, []byte("data"), 0600)
 	c.Assert(err, IsNil)
 
 	symlink := filepath.Join(s.dir, "symlink.snap")
-	err = ioutil.WriteFile(symlink, []byte("old-data"), 0600)
+	err = os.WriteFile(symlink, []byte("old-data"), 0600)
 	c.Assert(err, IsNil)
 
 	// Changed file is reported

--- a/osutil/synctree_test.go
+++ b/osutil/synctree_test.go
@@ -20,7 +20,6 @@
 package osutil_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -44,7 +43,7 @@ func (s *EnsureTreeStateSuite) SetUpTest(c *C) {
 func (s *EnsureTreeStateSuite) TestVerifiesExpectedFiles(c *C) {
 	c.Assert(os.MkdirAll(filepath.Join(s.dir, "foo", "bar"), 0755), IsNil)
 	name := filepath.Join(s.dir, "foo", "bar", "expected.snap")
-	c.Assert(ioutil.WriteFile(name, []byte("expected"), 0600), IsNil)
+	c.Assert(os.WriteFile(name, []byte("expected"), 0600), IsNil)
 	changed, removed, err := osutil.EnsureTreeState(s.dir, s.globs, map[string]map[string]osutil.FileState{
 		"foo/bar": {
 			"expected.snap": &osutil.MemoryFileState{Content: []byte("expected"), Mode: 0600},
@@ -82,8 +81,8 @@ func (s *EnsureTreeStateSuite) TestRemovesUnexpectedFiles(c *C) {
 	c.Assert(os.MkdirAll(filepath.Join(s.dir, "bar"), 0755), IsNil)
 	name1 := filepath.Join(s.dir, "foo", "evil1.snap")
 	name2 := filepath.Join(s.dir, "bar", "evil2.snap")
-	c.Assert(ioutil.WriteFile(name1, []byte(`evil-1`), 0600), IsNil)
-	c.Assert(ioutil.WriteFile(name2, []byte(`evil-2`), 0600), IsNil)
+	c.Assert(os.WriteFile(name1, []byte(`evil-1`), 0600), IsNil)
+	c.Assert(os.WriteFile(name2, []byte(`evil-2`), 0600), IsNil)
 
 	changed, removed, err := osutil.EnsureTreeState(s.dir, s.globs, map[string]map[string]osutil.FileState{
 		"foo": {},
@@ -101,9 +100,9 @@ func (s *EnsureTreeStateSuite) TestRemovesEmptyDirectories(c *C) {
 	name1 := filepath.Join(s.dir, "foo", "file1.snap")
 	name2 := filepath.Join(s.dir, "foo", "unrelated")
 	name3 := filepath.Join(s.dir, "bar", "baz", "file2.snap")
-	c.Assert(ioutil.WriteFile(name1, []byte(`text`), 0600), IsNil)
-	c.Assert(ioutil.WriteFile(name2, []byte(`text`), 0600), IsNil)
-	c.Assert(ioutil.WriteFile(name3, []byte(`text`), 0600), IsNil)
+	c.Assert(os.WriteFile(name1, []byte(`text`), 0600), IsNil)
+	c.Assert(os.WriteFile(name2, []byte(`text`), 0600), IsNil)
+	c.Assert(os.WriteFile(name3, []byte(`text`), 0600), IsNil)
 
 	_, _, err := osutil.EnsureTreeState(s.dir, s.globs, nil)
 	c.Assert(err, IsNil)
@@ -117,7 +116,7 @@ func (s *EnsureTreeStateSuite) TestRemovesEmptyDirectories(c *C) {
 func (s *EnsureTreeStateSuite) TestIgnoresUnrelatedFiles(c *C) {
 	c.Assert(os.MkdirAll(filepath.Join(s.dir, "foo"), 0755), IsNil)
 	name := filepath.Join(s.dir, "foo", "unrelated")
-	err := ioutil.WriteFile(name, []byte(`text`), 0600)
+	err := os.WriteFile(name, []byte(`text`), 0600)
 	c.Assert(err, IsNil)
 	changed, removed, err := osutil.EnsureTreeState(s.dir, s.globs, map[string]map[string]osutil.FileState{})
 	c.Assert(err, IsNil)
@@ -164,9 +163,9 @@ func (s *EnsureTreeStateSuite) TestRemovesFilesOnError(c *C) {
 	name1 := filepath.Join(s.dir, "foo", "file1.snap")
 	name2 := filepath.Join(s.dir, "bar", "file2.snap")
 	name3 := filepath.Join(s.dir, "bar", "dir.snap", "sentinel")
-	c.Assert(ioutil.WriteFile(name1, []byte(`text`), 0600), IsNil)
-	c.Assert(ioutil.WriteFile(name2, []byte(`text`), 0600), IsNil)
-	c.Assert(ioutil.WriteFile(name3, []byte(`text`), 0600), IsNil)
+	c.Assert(os.WriteFile(name1, []byte(`text`), 0600), IsNil)
+	c.Assert(os.WriteFile(name2, []byte(`text`), 0600), IsNil)
+	c.Assert(os.WriteFile(name3, []byte(`text`), 0600), IsNil)
 
 	changed, removed, err := osutil.EnsureTreeState(s.dir, s.globs, map[string]map[string]osutil.FileState{
 		"foo": {

--- a/osutil/user_test.go
+++ b/osutil/user_test.go
@@ -21,7 +21,6 @@ package osutil_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -345,7 +344,7 @@ func (s *delUserSuite) TestDelUserRemovesSudoersIfPresent(c *check.C) {
 	f1 := osutil.SudoersFile("u1")
 
 	// only create u1's sudoers file
-	c.Assert(ioutil.WriteFile(f1, nil, 0600), check.IsNil)
+	c.Assert(os.WriteFile(f1, nil, 0600), check.IsNil)
 
 	// neither of the delusers fail
 	c.Assert(osutil.DelUser("u1", s.opts), check.IsNil)

--- a/overlord/configstate/configcore/certs.go
+++ b/overlord/configstate/configcore/certs.go
@@ -24,7 +24,6 @@ package configcore
 import (
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -81,7 +80,7 @@ func handleCertConfiguration(tr RunTransaction, opts *fsOnlyContext) error {
 			if err := os.MkdirAll(dirs.SnapdStoreSSLCertsDir, 0755); err != nil {
 				return fmt.Errorf("cannot create store ssl certs dir: %v", err)
 			}
-			if err := ioutil.WriteFile(certPath, []byte(cert), 0644); err != nil {
+			if err := os.WriteFile(certPath, []byte(cert), 0644); err != nil {
 				return fmt.Errorf("cannot write store certificate: %v", err)
 			}
 		}

--- a/overlord/configstate/configcore/cloud_test.go
+++ b/overlord/configstate/configcore/cloud_test.go
@@ -22,7 +22,6 @@
 package configcore_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -161,7 +160,7 @@ func (s *cloudSuite) TestHandleCloud(c *C) {
 		c.Logf("tc: %v", i)
 		os.Remove(dirs.CloudInstanceDataFile)
 		if t.instData != "" {
-			err = ioutil.WriteFile(dirs.CloudInstanceDataFile, []byte(t.instData), 0600)
+			err = os.WriteFile(dirs.CloudInstanceDataFile, []byte(t.instData), 0600)
 			c.Assert(err, IsNil)
 		}
 
@@ -193,7 +192,7 @@ func (s *cloudSuite) TestHandleCloudAlreadySeeded(c *C) {
 
 	err := os.MkdirAll(filepath.Dir(dirs.CloudInstanceDataFile), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(dirs.CloudInstanceDataFile, []byte(instData), 0600)
+	err = os.WriteFile(dirs.CloudInstanceDataFile, []byte(instData), 0600)
 	c.Assert(err, IsNil)
 
 	s.state.Lock()

--- a/overlord/configstate/configcore/corecfg_test.go
+++ b/overlord/configstate/configcore/corecfg_test.go
@@ -21,7 +21,7 @@ package configcore_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -181,7 +181,7 @@ NeedDaemonReload=no
 	// in install mode or uc20 run mode, etc. and we don't want to use the
 	// host's proc/cmdline
 	mockCmdline := filepath.Join(dirs.GlobalRootDir, "cmdline")
-	err := ioutil.WriteFile(mockCmdline, nil, 0644)
+	err := os.WriteFile(mockCmdline, nil, 0644)
 	c.Assert(err, IsNil)
 	restore = kcmdline.MockProcCmdline(mockCmdline)
 	s.AddCleanup(restore)

--- a/overlord/configstate/configcore/journal_test.go
+++ b/overlord/configstate/configcore/journal_test.go
@@ -20,7 +20,6 @@
 package configcore_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -150,7 +149,7 @@ func (s *journalSuite) TestDisablePersistentJournalNotManagedBySnapdError(c *C) 
 
 func (s *journalSuite) TestDisablePersistentJournalOnCore(c *C) {
 	c.Assert(os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "/var/log/journal"), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(dirs.GlobalRootDir, "/var/log/journal/.snapd-created"), nil, 0755), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dirs.GlobalRootDir, "/var/log/journal/.snapd-created"), nil, 0755), IsNil)
 
 	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,

--- a/overlord/configstate/configcore/lockout.go
+++ b/overlord/configstate/configcore/lockout.go
@@ -21,7 +21,6 @@ package configcore
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -49,7 +48,7 @@ func handleFaillockConfiguration(dev sysconfig.Device, tr ConfGetter, opts *fsOn
 	case "":
 		// nothing to do if unset
 	case "true":
-		if err := ioutil.WriteFile(marker, nil, 0644); err != nil {
+		if err := os.WriteFile(marker, nil, 0644); err != nil {
 			return err
 		}
 	case "false":

--- a/overlord/configstate/configcore/lockout_test.go
+++ b/overlord/configstate/configcore/lockout_test.go
@@ -20,7 +20,6 @@
 package configcore_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -66,7 +65,7 @@ func (s *faillockSuite) TestFaillockSetFalse(c *C) {
 }
 
 func (s *faillockSuite) TestFaillockSetFalseReset(c *C) {
-	err := ioutil.WriteFile(s.markerPath, nil, 0644)
+	err := os.WriteFile(s.markerPath, nil, 0644)
 	c.Assert(err, IsNil)
 
 	err = configcore.FilesystemOnlyRun(coreDev, &mockConf{
@@ -86,7 +85,7 @@ func (s *faillockSuite) TestFaillockHandlesErrors(c *C) {
 }
 
 func (s *faillockSuite) TestFaillockUnsetChangeNothing(c *C) {
-	err := ioutil.WriteFile(s.markerPath, nil, 0644)
+	err := os.WriteFile(s.markerPath, nil, 0644)
 	c.Assert(err, IsNil)
 
 	err = configcore.FilesystemOnlyRun(coreDev, &mockConf{

--- a/overlord/configstate/configcore/picfg_test.go
+++ b/overlord/configstate/configcore/picfg_test.go
@@ -20,7 +20,6 @@
 package configcore_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -64,7 +63,7 @@ func (s *piCfgSuite) SetUpTest(c *C) {
 }
 
 func (s *piCfgSuite) mockConfig(c *C, txt string) {
-	err := ioutil.WriteFile(s.mockConfigPath, []byte(txt), 0644)
+	err := os.WriteFile(s.mockConfigPath, []byte(txt), 0644)
 	c.Assert(err, IsNil)
 }
 
@@ -177,9 +176,9 @@ func (s *piCfgSuite) TestUpdateConfigUC20RunMode(c *C) {
 	err = os.MkdirAll(filepath.Dir(uc18PiCfg), 0755)
 	c.Assert(err, IsNil)
 
-	err = ioutil.WriteFile(piCfg, []byte(mockConfigTxt), 0644)
+	err = os.WriteFile(piCfg, []byte(mockConfigTxt), 0644)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(uc18PiCfg, []byte(mockConfigTxt), 0644)
+	err = os.WriteFile(uc18PiCfg, []byte(mockConfigTxt), 0644)
 	c.Assert(err, IsNil)
 
 	// apply the config
@@ -211,7 +210,7 @@ func (s *piCfgSuite) testUpdateConfigUC20NonRunMode(c *C, mode string) {
 	err := os.MkdirAll(filepath.Dir(piCfg), 0755)
 	c.Assert(err, IsNil)
 
-	err = ioutil.WriteFile(piCfg, []byte(mockConfigTxt), 0644)
+	err = os.WriteFile(piCfg, []byte(mockConfigTxt), 0644)
 	c.Assert(err, IsNil)
 
 	// apply the config
@@ -245,7 +244,7 @@ func (s *piCfgSuite) TestFilesystemOnlyApply(c *C) {
 
 	// write default config
 	piCfg := filepath.Join(tmpDir, "/boot/uboot/config.txt")
-	c.Assert(ioutil.WriteFile(piCfg, []byte(mockConfigTxt), 0644), IsNil)
+	c.Assert(os.WriteFile(piCfg, []byte(mockConfigTxt), 0644), IsNil)
 
 	c.Assert(configcore.FilesystemOnlyApply(coreDev, tmpDir, conf), IsNil)
 

--- a/overlord/configstate/configcore/proxy.go
+++ b/overlord/configstate/configcore/proxy.go
@@ -24,7 +24,6 @@ package configcore
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -74,7 +73,7 @@ func updateEtcEnvironmentConfig(path string, config map[string]string) error {
 	if toWrite != nil {
 		// XXX: would be great to atomically write but /etc/environment
 		//      is a single bind mount :/
-		return ioutil.WriteFile(path, []byte(strings.Join(toWrite, "\n")), 0644)
+		return os.WriteFile(path, []byte(strings.Join(toWrite, "\n")), 0644)
 	}
 
 	return nil

--- a/overlord/configstate/configcore/proxy_test.go
+++ b/overlord/configstate/configcore/proxy_test.go
@@ -23,7 +23,6 @@ package configcore_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -75,7 +74,7 @@ func (s *proxySuite) SetUpTest(c *C) {
 }
 
 func (s *proxySuite) makeMockEtcEnvironment(c *C) {
-	err := ioutil.WriteFile(s.mockEtcEnvironment, []byte(`
+	err := os.WriteFile(s.mockEtcEnvironment, []byte(`
 PATH="/usr/bin"
 `), 0644)
 	c.Assert(err, IsNil)

--- a/overlord/configstate/configcore/services.go
+++ b/overlord/configstate/configcore/services.go
@@ -22,7 +22,6 @@ package configcore
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -75,7 +74,7 @@ func switchDisableSSHService(sysd systemd.Systemd, serviceName string, disabled 
 
 	units := []string{serviceName}
 	if disabled {
-		if err := ioutil.WriteFile(sshCanary, []byte("SSH has been disabled by snapd system configuration\n"), 0644); err != nil {
+		if err := os.WriteFile(sshCanary, []byte("SSH has been disabled by snapd system configuration\n"), 0644); err != nil {
 			return err
 		}
 		if opts == nil {
@@ -140,7 +139,7 @@ func switchDisableConsoleConfService(sysd systemd.Systemd, serviceName string, d
 	if err := os.MkdirAll(filepath.Dir(consoleConfDisabled), 0755); err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(consoleConfDisabled, []byte("console-conf has been disabled by the snapd system configuration\n"), 0644); err != nil {
+	if err := os.WriteFile(consoleConfDisabled, []byte("console-conf has been disabled by the snapd system configuration\n"), 0644); err != nil {
 		return err
 	}
 

--- a/overlord/configstate/configcore/services_test.go
+++ b/overlord/configstate/configcore/services_test.go
@@ -21,7 +21,6 @@ package configcore_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -180,13 +179,13 @@ func (s *servicesSuite) TestConfigureConsoleConfEnableNotAtRuntime(c *C) {
 recovery_system=20200202
 `
 	c.Assert(os.MkdirAll(filepath.Dir(dirs.SnapModeenvFile), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(dirs.SnapModeenvFile, []byte(modeenvContent), 0644), IsNil)
+	c.Assert(os.WriteFile(dirs.SnapModeenvFile, []byte(modeenvContent), 0644), IsNil)
 
 	// pretend that console-conf is disabled
 	canary := filepath.Join(dirs.GlobalRootDir, "/var/lib/console-conf/complete")
 	err := os.MkdirAll(filepath.Dir(canary), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(canary, nil, 0644)
+	err = os.WriteFile(canary, nil, 0644)
 	c.Assert(err, IsNil)
 
 	// now enable it
@@ -204,7 +203,7 @@ func (s *servicesSuite) TestConfigureConsoleConfDisableNotAtRuntime(c *C) {
 recovery_system=20200202
 `
 	c.Assert(os.MkdirAll(filepath.Dir(dirs.SnapModeenvFile), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(dirs.SnapModeenvFile, []byte(modeenvContent), 0644), IsNil)
+	c.Assert(os.WriteFile(dirs.SnapModeenvFile, []byte(modeenvContent), 0644), IsNil)
 
 	// console-conf is not disabled, i.e. there is no
 	// "/var/lib/console-conf/complete" file
@@ -224,7 +223,7 @@ func (s *servicesSuite) TestConfigureConsoleConfEnableAlreadyEnabledIsFine(c *C)
 recovery_system=20200202
 `
 	c.Assert(os.MkdirAll(filepath.Dir(dirs.SnapModeenvFile), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(dirs.SnapModeenvFile, []byte(modeenvContent), 0644), IsNil)
+	c.Assert(os.WriteFile(dirs.SnapModeenvFile, []byte(modeenvContent), 0644), IsNil)
 
 	// Note that we have no
 	//        /var/lib/console-conf/complete
@@ -243,14 +242,14 @@ func (s *servicesSuite) TestConfigureConsoleConfDisableAlreadyDisabledIsFine(c *
 	canary := filepath.Join(dirs.GlobalRootDir, "/var/lib/console-conf/complete")
 	err := os.MkdirAll(filepath.Dir(canary), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(canary, nil, 0644)
+	err = os.WriteFile(canary, nil, 0644)
 	c.Assert(err, IsNil)
 
 	modeenvContent := `mode=run
 recovery_system=20200202
 `
 	c.Assert(os.MkdirAll(filepath.Dir(dirs.SnapModeenvFile), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(dirs.SnapModeenvFile, []byte(modeenvContent), 0644), IsNil)
+	c.Assert(os.WriteFile(dirs.SnapModeenvFile, []byte(modeenvContent), 0644), IsNil)
 
 	err = configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,
@@ -266,7 +265,7 @@ func (s *servicesSuite) TestConfigureConsoleConfEnableDuringInstallMode(c *C) {
 recovery_system=20200202
 `
 	c.Assert(os.MkdirAll(filepath.Dir(dirs.SnapModeenvFile), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(dirs.SnapModeenvFile, []byte(modeenvContent), 0644), IsNil)
+	c.Assert(os.WriteFile(dirs.SnapModeenvFile, []byte(modeenvContent), 0644), IsNil)
 
 	err := configcore.FilesystemOnlyRun(coreDev, &mockConf{
 		state: s.state,

--- a/overlord/configstate/configcore/swap.go
+++ b/overlord/configstate/configcore/swap.go
@@ -21,7 +21,6 @@ package configcore
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -136,7 +135,7 @@ func handlesystemSwapConfiguration(_ sysconfig.Device, tr ConfGetter, opts *fsOn
 	fileContent := fmt.Sprintf("FILE=%s\nSIZE=%d\n", location, szBytes/quantity.SizeMiB)
 
 	// write the swap config file
-	if err := ioutil.WriteFile(swapConfigPath, []byte(fileContent), 0644); err != nil {
+	if err := os.WriteFile(swapConfigPath, []byte(fileContent), 0644); err != nil {
 		return err
 	}
 

--- a/overlord/configstate/configcore/swap_test.go
+++ b/overlord/configstate/configcore/swap_test.go
@@ -21,7 +21,6 @@ package configcore_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -49,7 +48,7 @@ func (s *swapCfgSuite) SetUpTest(c *C) {
 	err := os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "/etc/"), 0755)
 	c.Assert(err, IsNil)
 
-	err = ioutil.WriteFile(filepath.Join(dirs.GlobalRootDir, "/etc/environment"), nil, 0644)
+	err = os.WriteFile(filepath.Join(dirs.GlobalRootDir, "/etc/environment"), nil, 0644)
 	c.Assert(err, IsNil)
 }
 
@@ -221,7 +220,7 @@ func (s *swapCfgSuite) TestSwapSizeFilesystemOnlyApplyExistingConfig(c *C) {
 	err := os.MkdirAll(filepath.Dir(s.configSwapFile), 0755)
 	c.Assert(err, IsNil)
 
-	err = ioutil.WriteFile(s.configSwapFile, []byte(`FILE=/var/tmp/other-swapfile.swp
+	err = os.WriteFile(s.configSwapFile, []byte(`FILE=/var/tmp/other-swapfile.swp
 SIZE=0`), 0644)
 	c.Assert(err, IsNil)
 

--- a/overlord/configstate/configcore/tmp_test.go
+++ b/overlord/configstate/configcore/tmp_test.go
@@ -21,7 +21,6 @@ package configcore_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -144,7 +143,7 @@ func (s *tmpfsSuite) TestConfigureTmpfsNoFileUpdate(c *C) {
 	c.Assert(err, IsNil)
 	size := "100M"
 	content := "[Mount]\nOptions=mode=1777,strictatime,nosuid,nodev,size=" + size + "\n"
-	err = ioutil.WriteFile(s.servOverridePath, []byte(content), 0644)
+	err = os.WriteFile(s.servOverridePath, []byte(content), 0644)
 	c.Assert(err, IsNil)
 
 	info, err := os.Stat(s.servOverridePath)
@@ -181,11 +180,11 @@ func (s *tmpfsSuite) TestConfigureTmpfsRemovesIfUnset(c *C) {
 
 	// add canary to ensure we don't touch other files
 	canary := filepath.Join(s.servOverrideDir, "05-canary.conf")
-	err = ioutil.WriteFile(canary, nil, 0644)
+	err = os.WriteFile(canary, nil, 0644)
 	c.Assert(err, IsNil)
 
 	content := "[Mount]\nOptions=mode=1777,strictatime,nosuid,nodev,size=1G\n"
-	err = ioutil.WriteFile(s.servOverridePath, []byte(content), 0644)
+	err = os.WriteFile(s.servOverridePath, []byte(content), 0644)
 	c.Assert(err, IsNil)
 
 	err = configcore.FilesystemOnlyRun(coreDev, &mockConf{

--- a/overlord/configstate/configcore/watchdog_test.go
+++ b/overlord/configstate/configcore/watchdog_test.go
@@ -21,7 +21,6 @@ package configcore_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -167,7 +166,7 @@ func (s *watchdogSuite) TestConfigureWatchdogNoFileUpdate(c *C) {
 	content := "[Manager]\n" +
 		fmt.Sprintf("RuntimeWatchdogSec=%d\n", times[0]) +
 		fmt.Sprintf("ShutdownWatchdogSec=%d\n", times[1])
-	err = ioutil.WriteFile(s.mockEtcEnvironment, []byte(content), 0644)
+	err = os.WriteFile(s.mockEtcEnvironment, []byte(content), 0644)
 	c.Assert(err, IsNil)
 
 	info, err := os.Stat(s.mockEtcEnvironment)
@@ -200,14 +199,14 @@ func (s *watchdogSuite) TestConfigureWatchdogRemovesIfEmpty(c *C) {
 	c.Assert(err, IsNil)
 	// add canary to ensure we don't touch other files
 	canary := filepath.Join(dirs.SnapSystemdConfDir, "05-canary.conf")
-	err = ioutil.WriteFile(canary, nil, 0644)
+	err = os.WriteFile(canary, nil, 0644)
 	c.Assert(err, IsNil)
 
 	content := `[Manager]
 RuntimeWatchdogSec=10
 ShutdownWatchdogSec=20
 `
-	err = ioutil.WriteFile(s.mockEtcEnvironment, []byte(content), 0644)
+	err = os.WriteFile(s.mockEtcEnvironment, []byte(content), 0644)
 	c.Assert(err, IsNil)
 
 	err = configcore.FilesystemOnlyRun(coreDev, &mockConf{

--- a/overlord/configstate/handler_test.go
+++ b/overlord/configstate/handler_test.go
@@ -23,7 +23,7 @@ package configstate_test
 
 import (
 	"errors"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -153,7 +153,7 @@ volumes:
 `)
 
 	info := snaptest.MockSnap(c, mockGadgetSnapYaml, &snap.SideInfo{Revision: snap.R(1)})
-	err := ioutil.WriteFile(filepath.Join(info.MountDir(), "meta", "gadget.yaml"), mockGadgetYaml, 0644)
+	err := os.WriteFile(filepath.Join(info.MountDir(), "meta", "gadget.yaml"), mockGadgetYaml, 0644)
 	c.Assert(err, IsNil)
 
 	s.state.Lock()
@@ -227,7 +227,7 @@ volumes:
 `)
 
 	info := snaptest.MockSnap(c, mockGadgetSnapYaml, &snap.SideInfo{Revision: snap.R(1)})
-	err := ioutil.WriteFile(filepath.Join(info.MountDir(), "meta", "gadget.yaml"), mockGadgetYaml, 0644)
+	err := os.WriteFile(filepath.Join(info.MountDir(), "meta", "gadget.yaml"), mockGadgetYaml, 0644)
 	c.Assert(err, IsNil)
 
 	s.state.Lock()
@@ -358,7 +358,7 @@ volumes:
 `)
 
 	info := snaptest.MockSnap(c, mockGadgetSnapYaml, &snap.SideInfo{Revision: snap.R(1)})
-	err := ioutil.WriteFile(filepath.Join(info.MountDir(), "meta", "gadget.yaml"), mockGadgetYaml, 0644)
+	err := os.WriteFile(filepath.Join(info.MountDir(), "meta", "gadget.yaml"), mockGadgetYaml, 0644)
 	c.Assert(err, IsNil)
 
 	s.state.Lock()

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -1902,7 +1901,7 @@ func (m *DeviceManager) Unregister(opts *UnregisterOptions) error {
 		if err := os.MkdirAll(dirs.SnapRunDir, 0755); err != nil {
 			return err
 		}
-		if err := ioutil.WriteFile(filepath.Join(dirs.SnapRunDir, "noregister"), nil, 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(dirs.SnapRunDir, "noregister"), nil, 0644); err != nil {
 			return err
 		}
 	}

--- a/overlord/devicestate/devicestate_cloudinit_test.go
+++ b/overlord/devicestate/devicestate_cloudinit_test.go
@@ -3,7 +3,6 @@ package devicestate_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -106,7 +105,7 @@ func (s *cloudInitUC20Suite) SetUpTest(c *C) {
 
 func (s *cloudInitUC20Suite) TestCloudInitUC20CloudGadgetNoDisable(c *C) {
 	// create a cloud.conf file in the gadget snap's mount dir
-	c.Assert(ioutil.WriteFile(filepath.Join(dirs.SnapMountDir, "pc", "1", "cloud.conf"), nil, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dirs.SnapMountDir, "pc", "1", "cloud.conf"), nil, 0644), IsNil)
 
 	// pretend that cloud-init finished running
 	statusCalls := 0
@@ -358,7 +357,7 @@ func (s *cloudInitSuite) TestCloudInitAlreadyRestrictedFileDoesNothing(c *C) {
 	disableFile := filepath.Join(dirs.GlobalRootDir, "/etc/cloud/cloud.cfg.d/zzzz_snapd.cfg")
 	err := os.MkdirAll(filepath.Dir(disableFile), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(disableFile, nil, 0644)
+	err = os.WriteFile(disableFile, nil, 0644)
 	c.Assert(err, IsNil)
 
 	// mock cloud-init command, but make it always fail, it shouldn't be called
@@ -392,7 +391,7 @@ func (s *cloudInitSuite) TestCloudInitAlreadyDisabledDoesNothing(c *C) {
 	disableFile := filepath.Join(dirs.GlobalRootDir, "/etc/cloud/cloud-init.disabled")
 	err := os.MkdirAll(filepath.Dir(disableFile), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(disableFile, nil, 0644)
+	err = os.WriteFile(disableFile, nil, 0644)
 	c.Assert(err, IsNil)
 
 	// mock cloud-init command, but make it always fail, it shouldn't be called

--- a/overlord/devicestate/devicestate_gadget_test.go
+++ b/overlord/devicestate/devicestate_gadget_test.go
@@ -22,7 +22,6 @@ package devicestate_test
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -367,7 +366,7 @@ func (s *deviceMgrGadgetSuite) testUpdateGadgetSimple(c *C, grade string, encryp
 			// sealed keys stamp
 			stamp := filepath.Join(dirs.SnapFDEDir, "sealed-keys")
 			c.Assert(os.MkdirAll(filepath.Dir(stamp), 0755), IsNil)
-			err = ioutil.WriteFile(stamp, nil, 0644)
+			err = os.WriteFile(stamp, nil, 0644)
 			c.Assert(err, IsNil)
 		}
 	}
@@ -840,7 +839,7 @@ func (s *deviceMgrGadgetSuite) TestCurrentAndUpdateInfo(c *C) {
 	c.Assert(err, ErrorMatches, "cannot read current gadget snap details: .*/33/meta/gadget.yaml: no such file or directory")
 
 	// drop gadget.yaml for current snap
-	ioutil.WriteFile(filepath.Join(ci.MountDir(), "meta/gadget.yaml"), []byte(gadgetYaml), 0644)
+	os.WriteFile(filepath.Join(ci.MountDir(), "meta/gadget.yaml"), []byte(gadgetYaml), 0644)
 
 	current, err = devicestate.CurrentGadgetData(s.state, deviceCtx)
 	c.Assert(err, IsNil)
@@ -876,7 +875,7 @@ volumes:
 `
 
 	// drop gadget.yaml for update snap
-	ioutil.WriteFile(filepath.Join(ui.MountDir(), "meta/gadget.yaml"), []byte(updateGadgetYaml), 0644)
+	os.WriteFile(filepath.Join(ui.MountDir(), "meta/gadget.yaml"), []byte(updateGadgetYaml), 0644)
 
 	update, err = devicestate.PendingGadgetInfo(snapsup, deviceCtx)
 	c.Assert(err, IsNil)

--- a/overlord/devicestate/devicestate_install_api_test.go
+++ b/overlord/devicestate/devicestate_install_api_test.go
@@ -23,7 +23,6 @@ package devicestate_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -464,12 +463,12 @@ func (s *deviceMgrInstallAPISuite) testInstallFinishStep(c *C, opts finishStepOp
 			filepath.Join(seedBootDir, "bootx64.efi"),
 			filepath.Join(seedBootDir, "grubx64.efi"),
 		} {
-			c.Assert(ioutil.WriteFile(p, []byte{}, 0755), IsNil)
+			c.Assert(os.WriteFile(p, []byte{}, 0755), IsNil)
 		}
 
 		bootDir := filepath.Join(dirs.RunDir, "mnt/ubuntu-boot/EFI/boot/")
 		c.Assert(os.MkdirAll(bootDir, 0755), IsNil)
-		c.Assert(ioutil.WriteFile(filepath.Join(bootDir, "grubx64.efi"), []byte{}, 0755), IsNil)
+		c.Assert(os.WriteFile(filepath.Join(bootDir, "grubx64.efi"), []byte{}, 0755), IsNil)
 	}
 
 	s.state.Lock()

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -283,7 +283,7 @@ func (s *deviceMgrInstallModeSuite) doRunChangeTestWithEncryption(c *C, grade st
 
 		err := os.MkdirAll(boot.InitramfsUbuntuSeedDir, 0755)
 		c.Assert(err, IsNil)
-		err = ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "trusted-asset"), nil, 0644)
+		err = os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "trusted-asset"), nil, 0644)
 		c.Assert(err, IsNil)
 	}
 
@@ -388,7 +388,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallTaskErrors(c *C) {
 	})
 	defer restore()
 
-	err := ioutil.WriteFile(filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/modeenv"),
+	err := os.WriteFile(filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/modeenv"),
 		[]byte("mode=install\n"), 0644)
 	c.Assert(err, IsNil)
 
@@ -419,7 +419,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallExpTasks(c *C) {
 	})
 	defer restore()
 
-	err := ioutil.WriteFile(filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/modeenv"),
+	err := os.WriteFile(filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/modeenv"),
 		[]byte("mode=install\n"), 0644)
 	c.Assert(err, IsNil)
 
@@ -475,7 +475,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallRestoresPreseedArtifact(c *C) {
 	})
 	defer restoreApplyPreseed()
 
-	err := ioutil.WriteFile(filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/modeenv"),
+	err := os.WriteFile(filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/modeenv"),
 		[]byte("mode=install\nrecovery_system=20200105\n"), 0644)
 	c.Assert(err, IsNil)
 
@@ -524,7 +524,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallNoPreseedArtifact(c *C) {
 	})
 	defer restoreApplyPreseed()
 
-	err := ioutil.WriteFile(filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/modeenv"),
+	err := os.WriteFile(filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/modeenv"),
 		[]byte("mode=install\nrecovery_system=20200105\n"), 0644)
 	c.Assert(err, IsNil)
 
@@ -573,7 +573,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallRestoresPreseedArtifactError(c *C
 	})
 	defer restoreApplyPreseed()
 
-	err := ioutil.WriteFile(filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/modeenv"),
+	err := os.WriteFile(filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/modeenv"),
 		[]byte("mode=install\nrecovery_system=20200105\n"), 0644)
 	c.Assert(err, IsNil)
 
@@ -621,7 +621,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallRestoresPreseedArtifactModelMisma
 	})
 	defer restoreApplyPreseed()
 
-	err := ioutil.WriteFile(filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/modeenv"),
+	err := os.WriteFile(filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/modeenv"),
 		[]byte("mode=install\nrecovery_system=20200105\n"), 0644)
 	c.Assert(err, IsNil)
 
@@ -757,7 +757,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallWithInstallDeviceHookExpTasks(c *
 	})
 	defer restore()
 
-	err := ioutil.WriteFile(filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/modeenv"),
+	err := os.WriteFile(filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/modeenv"),
 		[]byte("mode=install\n"), 0644)
 	c.Assert(err, IsNil)
 
@@ -839,7 +839,7 @@ func (s *deviceMgrInstallModeSuite) testInstallWithInstallDeviceHookSnapctlReboo
 	})
 	defer restore()
 
-	err := ioutil.WriteFile(filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/modeenv"),
+	err := os.WriteFile(filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/modeenv"),
 		[]byte("mode=install\n"), 0644)
 	c.Assert(err, IsNil)
 
@@ -891,7 +891,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallWithBrokenInstallDeviceHookUnhapp
 	})
 	defer restore()
 
-	err := ioutil.WriteFile(filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/modeenv"),
+	err := os.WriteFile(filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/modeenv"),
 		[]byte("mode=install\n"), 0644)
 	c.Assert(err, IsNil)
 
@@ -947,7 +947,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallSetupRunSystemTaskNoRestarts(c *C
 	})
 	defer restore()
 
-	err := ioutil.WriteFile(filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/modeenv"),
+	err := os.WriteFile(filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/modeenv"),
 		[]byte("mode=install\n"), 0644)
 	c.Assert(err, IsNil)
 
@@ -1140,7 +1140,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallBootloaderVarSetFails(c *C) {
 	restore = installLogic.MockSecbootCheckTPMKeySealingSupported(func(secboot.TPMProvisionMode) error { return fmt.Errorf("no encrypted soup for you") })
 	defer restore()
 
-	err := ioutil.WriteFile(filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/modeenv"),
+	err := os.WriteFile(filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/modeenv"),
 		[]byte("mode=install\nrecovery_system=1234"), 0644)
 	c.Assert(err, IsNil)
 
@@ -1169,7 +1169,7 @@ func (s *deviceMgrInstallModeSuite) testInstallEncryptionValidityChecks(c *C, er
 	restore = installLogic.MockSecbootCheckTPMKeySealingSupported(func(secboot.TPMProvisionMode) error { return nil })
 	defer restore()
 
-	err := ioutil.WriteFile(filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/modeenv"),
+	err := os.WriteFile(filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/modeenv"),
 		[]byte("mode=install\n"), 0644)
 	c.Assert(err, IsNil)
 
@@ -1289,7 +1289,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallModeRunsPrepareRunSystemDataErr(c
 }
 
 func (s *deviceMgrInstallModeSuite) testInstallGadgetNoSave(c *C, grade string) {
-	err := ioutil.WriteFile(filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/modeenv"),
+	err := os.WriteFile(filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/modeenv"),
 		[]byte("mode=install\n"), 0644)
 	c.Assert(err, IsNil)
 
@@ -1300,7 +1300,7 @@ func (s *deviceMgrInstallModeSuite) testInstallGadgetNoSave(c *C, grade string) 
 	c.Assert(err, IsNil)
 	// replace gadget yaml with one that has no ubuntu-save
 	c.Assert(uc20gadgetYaml, Not(testutil.Contains), "ubuntu-save")
-	err = ioutil.WriteFile(filepath.Join(info.MountDir(), "meta/gadget.yaml"), []byte(uc20gadgetYaml), 0644)
+	err = os.WriteFile(filepath.Join(info.MountDir(), "meta/gadget.yaml"), []byte(uc20gadgetYaml), 0644)
 	c.Assert(err, IsNil)
 	devicestate.SetSystemMode(s.mgr, "install")
 	s.state.Unlock()
@@ -1482,7 +1482,7 @@ echo "mock output of: $(basename "$0") $*"
 `)
 	defer mockedSnapCmd.Restore()
 
-	err := ioutil.WriteFile(filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/modeenv"),
+	err := os.WriteFile(filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/modeenv"),
 		[]byte("mode=install\n"), 0644)
 	c.Assert(err, IsNil)
 
@@ -1603,7 +1603,7 @@ func (s *deviceMgrInstallModeSuite) doRunFactoryResetChange(c *C, model *asserts
 
 		err := os.MkdirAll(boot.InitramfsUbuntuSeedDir, 0755)
 		c.Assert(err, IsNil)
-		err = ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "trusted-asset"), nil, 0644)
+		err = os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "trusted-asset"), nil, 0644)
 		c.Assert(err, IsNil)
 	}
 
@@ -1669,10 +1669,10 @@ func (s *deviceMgrInstallModeSuite) doRunFactoryResetChange(c *C, model *asserts
 
 		// this would be done by boot
 		if tc.encrypt {
-			err := ioutil.WriteFile(filepath.Join(boot.InitramfsSeedEncryptionKeyDir, "ubuntu-save.recovery.sealed-key.factory-reset"),
+			err := os.WriteFile(filepath.Join(boot.InitramfsSeedEncryptionKeyDir, "ubuntu-save.recovery.sealed-key.factory-reset"),
 				[]byte("save"), 0644)
 			c.Check(err, IsNil)
-			err = ioutil.WriteFile(filepath.Join(boot.InitramfsSeedEncryptionKeyDir, "ubuntu-data.recovery.sealed-key"),
+			err = os.WriteFile(filepath.Join(boot.InitramfsSeedEncryptionKeyDir, "ubuntu-data.recovery.sealed-key"),
 				[]byte("new-data"), 0644)
 			c.Check(err, IsNil)
 		}
@@ -1895,7 +1895,7 @@ echo "mock output of: $(basename "$0") $*"
 
 	err = os.MkdirAll(filepath.Join(boot.InitramfsUbuntuSaveDir, "device/fde"), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSaveDir, "device/fde/marker"), nil, 0644)
+	err = os.WriteFile(filepath.Join(boot.InitramfsUbuntuSaveDir, "device/fde/marker"), nil, 0644)
 	c.Assert(err, IsNil)
 
 	logbuf, restore := logger.MockLogger()
@@ -1959,7 +1959,7 @@ echo "mock output of: $(basename "$0") $*"
 
 	err = os.MkdirAll(filepath.Join(boot.InitramfsUbuntuSaveDir, "device/fde"), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSaveDir, "device/fde/marker"), nil, 0644)
+	err = os.WriteFile(filepath.Join(boot.InitramfsUbuntuSaveDir, "device/fde/marker"), nil, 0644)
 	c.Assert(err, IsNil)
 
 	logbuf, restore := logger.MockLogger()
@@ -2093,7 +2093,7 @@ func (s *deviceMgrInstallModeSuite) TestFactoryResetPreviouslyEncrypted(c *C) {
 	// pretend snap-bootstrap mounted ubuntu-save and there is an encryption marker file
 	err := os.MkdirAll(filepath.Join(boot.InitramfsUbuntuSaveDir, "device/fde"), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSaveDir, "device/fde/marker"), nil, 0644)
+	err = os.WriteFile(filepath.Join(boot.InitramfsUbuntuSaveDir, "device/fde/marker"), nil, 0644)
 	c.Assert(err, IsNil)
 
 	// no serials, no device keys
@@ -2397,7 +2397,7 @@ func (s *deviceMgrInstallModeSuite) TestInstallWithUbuntuSaveSnapFoldersHappy(c 
 	restore = osutil.MockMountInfo(fmt.Sprintf(mountSnapSaveFmt, dirs.GlobalRootDir))
 	defer restore()
 
-	err = ioutil.WriteFile(filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/modeenv"),
+	err = os.WriteFile(filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/modeenv"),
 		[]byte("mode=install\n"), 0644)
 	c.Assert(err, IsNil)
 

--- a/overlord/devicestate/devicestate_recovery_keys_test.go
+++ b/overlord/devicestate/devicestate_recovery_keys_test.go
@@ -22,7 +22,6 @@ package devicestate_test
 import (
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -59,7 +58,7 @@ func mockSnapFDEFile(c *C, fname string, data []byte) {
 	p := filepath.Join(dirs.SnapFDEDir, fname)
 	err := os.MkdirAll(filepath.Dir(p), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(p, data, 0644)
+	err = os.WriteFile(p, data, 0644)
 	c.Assert(err, IsNil)
 }
 
@@ -200,7 +199,7 @@ func (s *deviceMgrRecoveryKeysSuite) TestEnsureRecoveryKeyInstallMode(c *C) {
 	p := filepath.Join(filepath.Join(dirs.GlobalRootDir, "/run/mnt/ubuntu-data/system-data/var/lib/snapd/device/fde"), "marker")
 	err = os.MkdirAll(filepath.Dir(p), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(p, nil, 0644)
+	err = os.WriteFile(p, nil, 0644)
 	c.Assert(err, IsNil)
 
 	keys, err := s.mgr.EnsureRecoveryKeys()

--- a/overlord/devicestate/devicestate_remodel_test.go
+++ b/overlord/devicestate/devicestate_remodel_test.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -1390,14 +1389,14 @@ volumes:
 	c.Check(err, ErrorMatches, "cannot read new gadget metadata: .*/new-gadget/1/meta/gadget.yaml: no such file or directory")
 
 	// drop gadget.yaml to the new gadget
-	err = ioutil.WriteFile(filepath.Join(info.MountDir(), "meta/gadget.yaml"), []byte(mockGadget), 0644)
+	err = os.WriteFile(filepath.Join(info.MountDir(), "meta/gadget.yaml"), []byte(mockGadget), 0644)
 	c.Assert(err, IsNil)
 
 	err = devicestate.CheckGadgetRemodelCompatible(s.state, info, currInfo, snapf, snapstate.Flags{}, remodelCtx)
 	c.Check(err, ErrorMatches, "cannot read current gadget metadata: .*/gadget/123/meta/gadget.yaml: no such file or directory")
 
 	// drop gadget.yaml to the current gadget
-	err = ioutil.WriteFile(filepath.Join(currInfo.MountDir(), "meta/gadget.yaml"), []byte(mockGadget), 0644)
+	err = os.WriteFile(filepath.Join(currInfo.MountDir(), "meta/gadget.yaml"), []byte(mockGadget), 0644)
 	c.Assert(err, IsNil)
 
 	err = devicestate.CheckGadgetRemodelCompatible(s.state, info, currInfo, snapf, snapstate.Flags{}, remodelCtx)

--- a/overlord/devicestate/devicestate_serial_test.go
+++ b/overlord/devicestate/devicestate_serial_test.go
@@ -23,7 +23,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -116,7 +115,7 @@ func (s *deviceMgrSerialSuite) mockServer(c *C, reqID string, bhv *devicestatete
 	fname := filepath.Join(dirs.SnapdStoreSSLCertsDir, "test-server-certs.pem")
 	err := os.MkdirAll(filepath.Dir(fname), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(fname, extraCerts, 0644)
+	err = os.WriteFile(fname, extraCerts, 0644)
 	c.Assert(err, IsNil)
 	return mockServer
 }
@@ -2256,7 +2255,7 @@ func (s *deviceMgrSerialSuite) TestFullDeviceRegistrationBlockedByNoRegister(c *
 
 	// create /run/snapd/noregister
 	c.Assert(os.MkdirAll(dirs.SnapRunDir, 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(dirs.SnapRunDir, "noregister"), nil, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dirs.SnapRunDir, "noregister"), nil, 0644), IsNil)
 
 	// attempt to run the whole device registration process
 	s.state.Unlock()

--- a/overlord/devicestate/devicestate_systems_test.go
+++ b/overlord/devicestate/devicestate_systems_test.go
@@ -23,7 +23,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -2414,7 +2413,7 @@ func (s *modelAndGadgetInfoSuite) TestSystemAndGadgetInfoErrorWrongGadget(c *C) 
 	isClassic := false
 	s.makeMockUC20SeedWithGadgetYaml(c, "some-label", mockGadgetUCYaml, isClassic)
 	// break the seed by changing things
-	err := ioutil.WriteFile(filepath.Join(dirs.SnapSeedDir, "snaps", "pc_1.snap"), []byte(`content-changed`), 0644)
+	err := os.WriteFile(filepath.Join(dirs.SnapSeedDir, "snaps", "pc_1.snap"), []byte(`content-changed`), 0644)
 	c.Assert(err, IsNil)
 
 	_, _, _, err = s.mgr.SystemAndGadgetAndEncryptionInfo("some-label")

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -22,7 +22,6 @@ package devicestate_test
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -2128,20 +2127,20 @@ func (s *deviceMgrSuite) TestDeviceManagerEnsurePostFactoryResetEncrypted(c *C) 
 
 	// encrypted system
 	mockSnapFDEFile(c, "marker", nil)
-	err := ioutil.WriteFile(filepath.Join(dirs.SnapFDEDir, "ubuntu-save.key"),
+	err := os.WriteFile(filepath.Join(dirs.SnapFDEDir, "ubuntu-save.key"),
 		[]byte("save-key"), 0644)
 	c.Assert(err, IsNil)
 	c.Assert(os.MkdirAll(boot.InitramfsSeedEncryptionKeyDir, 0755), IsNil)
-	err = ioutil.WriteFile(filepath.Join(boot.InitramfsSeedEncryptionKeyDir, "ubuntu-save.recovery.sealed-key"),
+	err = os.WriteFile(filepath.Join(boot.InitramfsSeedEncryptionKeyDir, "ubuntu-save.recovery.sealed-key"),
 		[]byte("old"), 0644)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(boot.InitramfsSeedEncryptionKeyDir, "ubuntu-save.recovery.sealed-key.factory-reset"),
+	err = os.WriteFile(filepath.Join(boot.InitramfsSeedEncryptionKeyDir, "ubuntu-save.recovery.sealed-key.factory-reset"),
 		[]byte("save"), 0644)
 	c.Assert(err, IsNil)
 	// matches the .factory key
 	factoryResetMarkercontent := []byte(`{"fallback-save-key-sha3-384":"d192153f0a50e826c6eb400c8711750ed0466571df1d151aaecc8c73095da7ec104318e7bf74d5e5ae2940827bf8402b"}
 `)
-	c.Assert(ioutil.WriteFile(filepath.Join(dirs.SnapDeviceDir, "factory-reset"), factoryResetMarkercontent, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dirs.SnapDeviceDir, "factory-reset"), factoryResetMarkercontent, 0644), IsNil)
 
 	completeCalls := 0
 	restore := devicestate.MockMarkFactoryResetComplete(func(encrypted bool) error {
@@ -2183,7 +2182,7 @@ func (s *deviceMgrSuite) TestDeviceManagerEnsurePostFactoryResetEncrypted(c *C) 
 	c.Check(os.Rename(filepath.Join(boot.InitramfsSeedEncryptionKeyDir, "ubuntu-save.recovery.sealed-key.factory-reset"),
 		filepath.Join(boot.InitramfsSeedEncryptionKeyDir, "ubuntu-save.recovery.sealed-key")),
 		IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(dirs.SnapDeviceDir, "factory-reset"), factoryResetMarkercontent, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dirs.SnapDeviceDir, "factory-reset"), factoryResetMarkercontent, 0644), IsNil)
 
 	devicestate.SetPostFactoryResetRan(s.mgr, false)
 	err = s.mgr.Ensure()
@@ -2206,16 +2205,16 @@ func (s *deviceMgrSuite) TestDeviceManagerEnsurePostFactoryResetEncryptedError(c
 	// encrypted system
 	mockSnapFDEFile(c, "marker", nil)
 	c.Assert(os.MkdirAll(boot.InitramfsSeedEncryptionKeyDir, 0755), IsNil)
-	err := ioutil.WriteFile(filepath.Join(boot.InitramfsSeedEncryptionKeyDir, "ubuntu-save.recovery.sealed-key"),
+	err := os.WriteFile(filepath.Join(boot.InitramfsSeedEncryptionKeyDir, "ubuntu-save.recovery.sealed-key"),
 		[]byte("old"), 0644)
 	c.Check(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(boot.InitramfsSeedEncryptionKeyDir, "ubuntu-save.recovery.sealed-key.factory-reset"),
+	err = os.WriteFile(filepath.Join(boot.InitramfsSeedEncryptionKeyDir, "ubuntu-save.recovery.sealed-key.factory-reset"),
 		[]byte("save"), 0644)
 	c.Check(err, IsNil)
 	// does not match the save key
 	factoryResetMarkercontent := []byte(`{"fallback-save-key-sha3-384":"uh-oh"}
 `)
-	c.Assert(ioutil.WriteFile(filepath.Join(dirs.SnapDeviceDir, "factory-reset"), factoryResetMarkercontent, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dirs.SnapDeviceDir, "factory-reset"), factoryResetMarkercontent, 0644), IsNil)
 
 	completeCalls := 0
 	restore := devicestate.MockMarkFactoryResetComplete(func(encrypted bool) error {
@@ -2256,7 +2255,7 @@ func (s *deviceMgrSuite) TestDeviceManagerEnsurePostFactoryResetUnencrypted(c *C
 
 	// mock the factory reset marker of a system that isn't encrypted
 	c.Assert(os.MkdirAll(dirs.SnapDeviceDir, 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(dirs.SnapDeviceDir, "factory-reset"), []byte("{}"), 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dirs.SnapDeviceDir, "factory-reset"), []byte("{}"), 0644), IsNil)
 
 	completeCalls := 0
 	restore := devicestate.MockMarkFactoryResetComplete(func(encrypted bool) error {

--- a/overlord/devicestate/firstboot_preseed_test.go
+++ b/overlord/devicestate/firstboot_preseed_test.go
@@ -21,7 +21,6 @@ package devicestate_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -289,7 +288,7 @@ snaps:
  - name: core
    file: %s
 `, fooFname, barFname, coreFname))
-	err := ioutil.WriteFile(filepath.Join(dirs.SnapSeedDir, "seed.yaml"), content, 0644)
+	err := os.WriteFile(filepath.Join(dirs.SnapSeedDir, "seed.yaml"), content, 0644)
 	c.Assert(err, IsNil)
 
 	// run the firstboot stuff
@@ -375,7 +374,7 @@ snaps:
  - name: core18
    file: %s
 `, snapdFname, fooFname, core18Fname))
-	err := ioutil.WriteFile(filepath.Join(dirs.SnapSeedDir, "seed.yaml"), content, 0644)
+	err := os.WriteFile(filepath.Join(dirs.SnapSeedDir, "seed.yaml"), content, 0644)
 	c.Assert(err, IsNil)
 
 	// run the firstboot stuff
@@ -507,7 +506,7 @@ snaps:
  - name: bar
    file: %s
 `, snapdFname, core18Fname, fooFname, barFname))
-	err := ioutil.WriteFile(filepath.Join(dirs.SnapSeedDir, "seed.yaml"), content, 0644)
+	err := os.WriteFile(filepath.Join(dirs.SnapSeedDir, "seed.yaml"), content, 0644)
 	c.Assert(err, IsNil)
 
 	// run the firstboot stuff

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -21,7 +21,6 @@ package devicestate_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
@@ -332,7 +331,7 @@ func (s *firstBoot16Suite) TestPopulateFromSeedOnClassicEmptySeedYaml(c *C) {
 	s.WriteAssertions("model.asserts", assertsChain...)
 
 	// create an empty seed.yaml
-	err = ioutil.WriteFile(filepath.Join(dirs.SnapSeedDir, "seed.yaml"), nil, 0644)
+	err = os.WriteFile(filepath.Join(dirs.SnapSeedDir, "seed.yaml"), nil, 0644)
 	c.Assert(err, IsNil)
 
 	st.Lock()
@@ -369,7 +368,7 @@ func (s *firstBoot16Suite) TestPopulateFromSeedOnClassicNoSeedYamlWithCloudInsta
 }`
 	err := os.MkdirAll(filepath.Dir(dirs.CloudInstanceDataFile), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(dirs.CloudInstanceDataFile, []byte(instData), 0600)
+	err = os.WriteFile(dirs.CloudInstanceDataFile, []byte(instData), 0600)
 	c.Assert(err, IsNil)
 
 	st.Lock()
@@ -555,7 +554,7 @@ snaps:
    unasserted: true
    file: %s
 `, coreFname, kernelFname, gadgetFname, fooFname, filepath.Base(targetSnapFile2)))
-	err = ioutil.WriteFile(filepath.Join(dirs.SnapSeedDir, "seed.yaml"), content, 0644)
+	err = os.WriteFile(filepath.Join(dirs.SnapSeedDir, "seed.yaml"), content, 0644)
 	c.Assert(err, IsNil)
 
 	// run the firstboot stuff
@@ -773,7 +772,7 @@ snaps:
  - name: bar
    file: %s
 `, coreFname, kernelFname, gadgetFname, fooFname, barFname))
-	err := ioutil.WriteFile(filepath.Join(dirs.SnapSeedDir, "seed.yaml"), content, 0644)
+	err := os.WriteFile(filepath.Join(dirs.SnapSeedDir, "seed.yaml"), content, 0644)
 	c.Assert(err, IsNil)
 
 	// run the firstboot stuff
@@ -879,7 +878,7 @@ snaps:
  - name: foo
    file: %s
 `, coreFname, kernelFname, gadgetFname, fooFname))
-	err := ioutil.WriteFile(filepath.Join(dirs.SnapSeedDir, "seed.yaml"), content, 0644)
+	err := os.WriteFile(filepath.Join(dirs.SnapSeedDir, "seed.yaml"), content, 0644)
 	c.Assert(err, IsNil)
 
 	// run the firstboot stuff
@@ -1037,7 +1036,7 @@ snaps:
  - name: foo
    file: %s
 `, coreFname, kernelFname, gadgetFname, fooFname))
-	err := ioutil.WriteFile(filepath.Join(dirs.SnapSeedDir, "seed.yaml"), content, 0644)
+	err := os.WriteFile(filepath.Join(dirs.SnapSeedDir, "seed.yaml"), content, 0644)
 	c.Assert(err, IsNil)
 
 	// run the firstboot stuff
@@ -1415,7 +1414,7 @@ snaps:
  - name: pc
    file: %s
 `, snapdFname, core18Fname, kernelFname, gadgetFname))
-	err := ioutil.WriteFile(filepath.Join(dirs.SnapSeedDir, "seed.yaml"), content, 0644)
+	err := os.WriteFile(filepath.Join(dirs.SnapSeedDir, "seed.yaml"), content, 0644)
 	c.Assert(err, IsNil)
 
 	// run the firstboot stuff
@@ -1538,7 +1537,7 @@ snaps:
  - name: other-base
    file: %s
 `, snapdFname, core18Fname, kernelFname, gadgetFname, snapFname, baseFname))
-	err := ioutil.WriteFile(filepath.Join(dirs.SnapSeedDir, "seed.yaml"), content, 0644)
+	err := os.WriteFile(filepath.Join(dirs.SnapSeedDir, "seed.yaml"), content, 0644)
 	c.Assert(err, IsNil)
 
 	// run the firstboot stuff
@@ -1575,7 +1574,7 @@ snaps:
  - name: pc
    file: %s
 `, snapdFname, core18Fname, kernelFname, gadgetFname))
-	err := ioutil.WriteFile(filepath.Join(dirs.SnapSeedDir, "seed.yaml"), content, 0644)
+	err := os.WriteFile(filepath.Join(dirs.SnapSeedDir, "seed.yaml"), content, 0644)
 	c.Assert(err, IsNil)
 
 	// run the firstboot stuff
@@ -1642,7 +1641,7 @@ snaps:
  - name: gtk-common-themes
    file: %s
 `, coreFname, kernelFname, gadgetFname, calcFname, themesFname))
-	err := ioutil.WriteFile(filepath.Join(dirs.SnapSeedDir, "seed.yaml"), content, 0644)
+	err := os.WriteFile(filepath.Join(dirs.SnapSeedDir, "seed.yaml"), content, 0644)
 	c.Assert(err, IsNil)
 
 	// run the firstboot stuff
@@ -1715,7 +1714,7 @@ snaps:
    file: %s
 `, coreFname, kernelFname, gadgetFname, localFname))
 
-	c.Assert(ioutil.WriteFile(filepath.Join(dirs.SnapSeedDir, "seed.yaml"), content, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dirs.SnapSeedDir, "seed.yaml"), content, 0644), IsNil)
 
 	// run the firstboot stuff
 	s.startOverlord(c)
@@ -1763,7 +1762,7 @@ snaps:
  - name: core18
    file: %s
 `, snapdFname, fooFname, core18Fname))
-	err := ioutil.WriteFile(filepath.Join(dirs.SnapSeedDir, "seed.yaml"), content, 0644)
+	err := os.WriteFile(filepath.Join(dirs.SnapSeedDir, "seed.yaml"), content, 0644)
 	c.Assert(err, IsNil)
 
 	// run the firstboot stuff
@@ -1849,7 +1848,7 @@ snaps:
  - name: core18
    file: %s
 `, snapdFname, core18Fname))
-	err := ioutil.WriteFile(filepath.Join(dirs.SnapSeedDir, "seed.yaml"), content, 0644)
+	err := os.WriteFile(filepath.Join(dirs.SnapSeedDir, "seed.yaml"), content, 0644)
 	c.Assert(err, IsNil)
 
 	// run the firstboot stuff
@@ -1904,7 +1903,7 @@ snaps:
  - name: pc
    file: %s
 `, snapdFname, fooFname, core18Fname, gadgetFname))
-	err := ioutil.WriteFile(filepath.Join(dirs.SnapSeedDir, "seed.yaml"), content, 0644)
+	err := os.WriteFile(filepath.Join(dirs.SnapSeedDir, "seed.yaml"), content, 0644)
 	c.Assert(err, IsNil)
 
 	// run the firstboot stuff
@@ -2109,7 +2108,7 @@ snaps:
  - name: bar
    file: %s
 `, snapdFname, core18Fname, fooFname, barFname))
-	err := ioutil.WriteFile(filepath.Join(dirs.SnapSeedDir, "seed.yaml"), content, 0644)
+	err := os.WriteFile(filepath.Join(dirs.SnapSeedDir, "seed.yaml"), content, 0644)
 	c.Assert(err, IsNil)
 
 	// run the firstboot stuff
@@ -2186,7 +2185,7 @@ func (s *firstBoot16Suite) mockServer(c *C, reqID string) *httptest.Server {
 	fname := filepath.Join(dirs.SnapdStoreSSLCertsDir, "test-server-certs.pem")
 	err := os.MkdirAll(filepath.Dir(fname), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(fname, extraCerts, 0644)
+	err = os.WriteFile(fname, extraCerts, 0644)
 	c.Assert(err, IsNil)
 	return mockServer
 }
@@ -2236,7 +2235,7 @@ snaps:
  - name: pc
    file: %s
 `, snapdFname, core18Fname, kernelFname, gadgetFname))
-	err := ioutil.WriteFile(filepath.Join(dirs.SnapSeedDir, "seed.yaml"), content, 0644)
+	err := os.WriteFile(filepath.Join(dirs.SnapSeedDir, "seed.yaml"), content, 0644)
 	c.Assert(err, IsNil)
 
 	// run the firstboot stuff

--- a/overlord/devicestate/remodel_test.go
+++ b/overlord/devicestate/remodel_test.go
@@ -22,7 +22,6 @@ package devicestate_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -960,7 +959,7 @@ func writeDeviceModelToUbuntuBoot(c *C, model *asserts.Model) {
 	var buf bytes.Buffer
 	c.Assert(asserts.NewEncoder(&buf).Encode(model), IsNil)
 	c.Assert(os.MkdirAll(filepath.Join(boot.InitramfsUbuntuBootDir, "device"), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "device/model"),
+	c.Assert(os.WriteFile(filepath.Join(boot.InitramfsUbuntuBootDir, "device/model"),
 		buf.Bytes(), 0755),
 		IsNil)
 }

--- a/overlord/healthstate/healthstate_test.go
+++ b/overlord/healthstate/healthstate_test.go
@@ -20,7 +20,6 @@
 package healthstate_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -125,7 +124,7 @@ func (s *healthSuite) testHealth(c *check.C, cond healthHookTestCondition) {
 		hookFn := filepath.Join(s.info.MountDir(), "meta", "hooks", "check-health")
 		c.Assert(os.MkdirAll(filepath.Dir(hookFn), 0755), check.IsNil)
 		// the hook won't actually be called, but needs to exist
-		c.Assert(ioutil.WriteFile(hookFn, nil, 0755), check.IsNil)
+		c.Assert(os.WriteFile(hookFn, nil, 0755), check.IsNil)
 	}
 
 	s.state.Lock()

--- a/overlord/ifacestate/helpers_test.go
+++ b/overlord/ifacestate/helpers_test.go
@@ -22,7 +22,6 @@ package ifacestate_test
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -400,7 +399,7 @@ apps:
 	// Put a fake system key in place, we just want to see that file being removed.
 	err := os.MkdirAll(filepath.Dir(dirs.SnapSystemKeyFile), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(dirs.SnapSystemKeyFile, []byte("system-key"), 0755)
+	err = os.WriteFile(dirs.SnapSystemKeyFile, []byte("system-key"), 0755)
 	c.Assert(err, IsNil)
 
 	// Put up a fake logger to capture logged messages.

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -23,7 +23,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -6351,7 +6350,7 @@ volumes:
         bootloader: grub
 `)
 
-	err := ioutil.WriteFile(filepath.Join(gadgetInfo.MountDir(), "meta", "gadget.yaml"), gadgetYaml, 0644)
+	err := os.WriteFile(filepath.Join(gadgetInfo.MountDir(), "meta", "gadget.yaml"), gadgetYaml, 0644)
 	c.Assert(err, IsNil)
 
 	s.MockModel(c, nil)
@@ -6637,7 +6636,7 @@ volumes:
         bootloader: grub
 `)
 
-	err := ioutil.WriteFile(filepath.Join(gadgetInfo.MountDir(), "meta", "gadget.yaml"), gadgetYaml, 0644)
+	err := os.WriteFile(filepath.Join(gadgetInfo.MountDir(), "meta", "gadget.yaml"), gadgetYaml, 0644)
 	c.Assert(err, IsNil)
 
 	s.state.Lock()
@@ -6699,7 +6698,7 @@ volumes:
         bootloader: grub
 `)
 
-	err := ioutil.WriteFile(filepath.Join(gadgetInfo.MountDir(), "meta", "gadget.yaml"), gadgetYaml, 0644)
+	err := os.WriteFile(filepath.Join(gadgetInfo.MountDir(), "meta", "gadget.yaml"), gadgetYaml, 0644)
 	c.Assert(err, IsNil)
 
 	s.state.Lock()

--- a/overlord/install/install_test.go
+++ b/overlord/install/install_test.go
@@ -448,7 +448,7 @@ func (s *installSuite) TestEncryptionSupportInfoForceUnencrypted(c *C) {
 		} else {
 			err := os.MkdirAll(filepath.Dir(forceUnencryptedPath), 0755)
 			c.Assert(err, IsNil)
-			err = ioutil.WriteFile(forceUnencryptedPath, nil, 0644)
+			err = os.WriteFile(forceUnencryptedPath, nil, 0644)
 			c.Assert(err, IsNil)
 		}
 
@@ -824,7 +824,7 @@ func (s *installSuite) mockBootloader(c *C, trustedAssets bool, managedAssets bo
 
 		err := os.MkdirAll(boot.InitramfsUbuntuSeedDir, 0755)
 		c.Assert(err, IsNil)
-		err = ioutil.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "trusted-asset"), nil, 0644)
+		err = os.WriteFile(filepath.Join(boot.InitramfsUbuntuSeedDir, "trusted-asset"), nil, 0644)
 		c.Assert(err, IsNil)
 	} else {
 		bl := bootloadertest.Mock("mock", bootloaderRootdir)
@@ -970,7 +970,7 @@ func (s *installSuite) TestPrepareRunSystemDataSupportsCloudInitInDangerous(c *C
 	err := os.MkdirAll(cloudCfg, 0755)
 	c.Assert(err, IsNil)
 	for _, mockCfg := range []string{"foo.cfg", "bar.cfg"} {
-		err = ioutil.WriteFile(filepath.Join(cloudCfg, mockCfg), []byte(fmt.Sprintf("%s config", mockCfg)), 0644)
+		err = os.WriteFile(filepath.Join(cloudCfg, mockCfg), []byte(fmt.Sprintf("%s config", mockCfg)), 0644)
 		c.Assert(err, IsNil)
 	}
 
@@ -997,7 +997,7 @@ func (s *installSuite) TestPrepareRunSystemDataSupportsCloudInitGadgetAndSeedCon
 	err := os.MkdirAll(cloudCfg, 0755)
 	c.Assert(err, IsNil)
 	for _, mockCfg := range []string{"foo.cfg", "bar.cfg"} {
-		err = ioutil.WriteFile(filepath.Join(cloudCfg, mockCfg), []byte(fmt.Sprintf("%s config", mockCfg)), 0644)
+		err = os.WriteFile(filepath.Join(cloudCfg, mockCfg), []byte(fmt.Sprintf("%s config", mockCfg)), 0644)
 		c.Assert(err, IsNil)
 	}
 
@@ -1007,7 +1007,7 @@ func (s *installSuite) TestPrepareRunSystemDataSupportsCloudInitGadgetAndSeedCon
 	})
 
 	// we also have gadget cloud init too
-	err = ioutil.WriteFile(filepath.Join(gadgetDir, "cloud.conf"), nil, 0644)
+	err = os.WriteFile(filepath.Join(gadgetDir, "cloud.conf"), nil, 0644)
 	c.Assert(err, IsNil)
 
 	err = install.PrepareRunSystemData(mockModel, gadgetDir, s.perfTimings)
@@ -1030,7 +1030,7 @@ func (s *installSuite) TestPrepareRunSystemDataSupportsCloudInitBothGadgetAndUbu
 	err := os.MkdirAll(cloudCfg, 0755)
 	c.Assert(err, IsNil)
 	for _, mockCfg := range []string{"foo.cfg", "bar.cfg"} {
-		err = ioutil.WriteFile(filepath.Join(cloudCfg, mockCfg), []byte(fmt.Sprintf("%s config", mockCfg)), 0644)
+		err = os.WriteFile(filepath.Join(cloudCfg, mockCfg), []byte(fmt.Sprintf("%s config", mockCfg)), 0644)
 		c.Assert(err, IsNil)
 	}
 
@@ -1038,7 +1038,7 @@ func (s *installSuite) TestPrepareRunSystemDataSupportsCloudInitBothGadgetAndUbu
 	mockModel := s.mockModel(nil)
 
 	// we also have gadget cloud init too
-	err = ioutil.WriteFile(filepath.Join(gadgetDir, "cloud.conf"), nil, 0644)
+	err = os.WriteFile(filepath.Join(gadgetDir, "cloud.conf"), nil, 0644)
 	c.Assert(err, IsNil)
 
 	err = install.PrepareRunSystemData(mockModel, gadgetDir, s.perfTimings)
@@ -1083,7 +1083,7 @@ func (s *installSuite) TestPrepareRunSystemDataSecuredGadgetCloudConfCloudInit(c
 	})
 
 	// pretend we have a cloud.conf from the gadget
-	err := ioutil.WriteFile(filepath.Join(gadgetDir, "cloud.conf"), nil, 0644)
+	err := os.WriteFile(filepath.Join(gadgetDir, "cloud.conf"), nil, 0644)
 	c.Assert(err, IsNil)
 
 	err = install.PrepareRunSystemData(mockModel, gadgetDir, s.perfTimings)
@@ -1104,7 +1104,7 @@ func (s *installSuite) TestPrepareRunSystemDataSecuredNoUbuntuSeedCloudInit(c *C
 	err := os.MkdirAll(cloudCfg, 0755)
 	c.Assert(err, IsNil)
 	for _, mockCfg := range []string{"foo.cfg", "bar.cfg"} {
-		err = ioutil.WriteFile(filepath.Join(cloudCfg, mockCfg), []byte(fmt.Sprintf("%s config", mockCfg)), 0644)
+		err = os.WriteFile(filepath.Join(cloudCfg, mockCfg), []byte(fmt.Sprintf("%s config", mockCfg)), 0644)
 		c.Assert(err, IsNil)
 	}
 
@@ -1136,7 +1136,7 @@ func (s *installSuite) TestPrepareRunSystemDataWritesTimesyncdClockHappy(c *C) {
 
 	clockTsInSrc := filepath.Join(dirs.GlobalRootDir, "/var/lib/systemd/timesync/clock")
 	c.Assert(os.MkdirAll(filepath.Dir(clockTsInSrc), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(clockTsInSrc, nil, 0644), IsNil)
+	c.Assert(os.WriteFile(clockTsInSrc, nil, 0644), IsNil)
 	// a month old timestamp file
 	c.Assert(os.Chtimes(clockTsInSrc, now.AddDate(0, -1, 0), now.AddDate(0, -1, 0)), IsNil)
 
@@ -1164,7 +1164,7 @@ func (s *installSuite) TestPrepareRunSystemDataWritesTimesyncdClockErr(c *C) {
 
 	clockTsInSrc := filepath.Join(dirs.GlobalRootDir, "/var/lib/systemd/timesync/clock")
 	c.Assert(os.MkdirAll(filepath.Dir(clockTsInSrc), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(clockTsInSrc, nil, 0644), IsNil)
+	c.Assert(os.WriteFile(clockTsInSrc, nil, 0644), IsNil)
 
 	timesyncDirInDst := filepath.Join(filepath.Join(dirs.GlobalRootDir, "/run/mnt/ubuntu-data/system-data"), "/var/lib/systemd/timesync/")
 	c.Assert(os.MkdirAll(timesyncDirInDst, 0755), IsNil)
@@ -1259,7 +1259,7 @@ func (s *installSuite) TestApplyPreseededData(c *C) {
 	model := s.setupCore20Seed(c)
 
 	c.Assert(os.MkdirAll(writableDir, 0755), IsNil)
-	c.Assert(ioutil.WriteFile(preseedArtifact, nil, 0644), IsNil)
+	c.Assert(os.WriteFile(preseedArtifact, nil, 0644), IsNil)
 	c.Assert(os.MkdirAll(filepath.Join(dirs.SnapSeedDir, "snaps"), 0755), IsNil)
 	c.Assert(os.MkdirAll(dirs.SnapBlobDir, 0755), IsNil)
 
@@ -1347,7 +1347,7 @@ func (s *installSuite) TestApplyPreseededDataAssertionMissing(c *C) {
 	s.setupCore20Seed(c)
 
 	c.Assert(os.MkdirAll(writableDir, 0755), IsNil)
-	c.Assert(ioutil.WriteFile(preseedArtifact, nil, 0644), IsNil)
+	c.Assert(os.WriteFile(preseedArtifact, nil, 0644), IsNil)
 	c.Assert(os.MkdirAll(filepath.Join(dirs.SnapSeedDir, "snaps"), 0755), IsNil)
 	c.Assert(os.MkdirAll(dirs.SnapBlobDir, 0755), IsNil)
 
@@ -1363,7 +1363,7 @@ func (s *installSuite) TestApplyPreseededDataAssertionMissing(c *C) {
 
 	preseedAsPath := filepath.Join(ubuntuSeedDir, "systems", sysLabel, "preseed")
 	// empty "preseed" assertion file
-	c.Assert(ioutil.WriteFile(preseedAsPath, nil, 0644), IsNil)
+	c.Assert(os.WriteFile(preseedAsPath, nil, 0644), IsNil)
 
 	err = install.ApplyPreseededData(preseedSeed, writableDir)
 	c.Assert(err, ErrorMatches, `system preseed assertion file must contain a preseed assertion`)
@@ -1375,8 +1375,8 @@ func (s *installSuite) TestApplyPreseededDataSnapMismatch(c *C) {
 
 	snapPath1 := filepath.Join(dirs.GlobalRootDir, "essential-snap_1.snap")
 	snapPath2 := filepath.Join(dirs.GlobalRootDir, "mode-snap_3.snap")
-	c.Assert(ioutil.WriteFile(snapPath1, nil, 0644), IsNil)
-	c.Assert(ioutil.WriteFile(snapPath2, nil, 0644), IsNil)
+	c.Assert(os.WriteFile(snapPath1, nil, 0644), IsNil)
+	c.Assert(os.WriteFile(snapPath2, nil, 0644), IsNil)
 
 	ubuntuSeedDir := filepath.Join(dirs.GlobalRootDir, "run/mnt/ubuntu-seed")
 	sysLabel := "20220105"
@@ -1384,7 +1384,7 @@ func (s *installSuite) TestApplyPreseededDataSnapMismatch(c *C) {
 	preseedArtifact := filepath.Join(ubuntuSeedDir, "systems", sysLabel, "preseed.tgz")
 	c.Assert(os.MkdirAll(filepath.Join(ubuntuSeedDir, "systems", sysLabel), 0755), IsNil)
 	c.Assert(os.MkdirAll(writableDir, 0755), IsNil)
-	c.Assert(ioutil.WriteFile(preseedArtifact, nil, 0644), IsNil)
+	c.Assert(os.WriteFile(preseedArtifact, nil, 0644), IsNil)
 
 	model := s.mockModel(map[string]interface{}{
 		"grade": "dangerous",
@@ -1460,7 +1460,7 @@ func (s *installSuite) TestApplyPreseededDataWrongDigest(c *C) {
 	defer mockTarCmd.Restore()
 
 	snapPath1 := filepath.Join(dirs.GlobalRootDir, "essential-snap_1.snap")
-	c.Assert(ioutil.WriteFile(snapPath1, nil, 0644), IsNil)
+	c.Assert(os.WriteFile(snapPath1, nil, 0644), IsNil)
 
 	ubuntuSeedDir := filepath.Join(dirs.GlobalRootDir, "run/mnt/ubuntu-seed")
 	sysLabel := "20220105"
@@ -1468,7 +1468,7 @@ func (s *installSuite) TestApplyPreseededDataWrongDigest(c *C) {
 	preseedArtifact := filepath.Join(ubuntuSeedDir, "systems", sysLabel, "preseed.tgz")
 	c.Assert(os.MkdirAll(filepath.Join(ubuntuSeedDir, "systems", sysLabel), 0755), IsNil)
 	c.Assert(os.MkdirAll(writableDir, 0755), IsNil)
-	c.Assert(ioutil.WriteFile(preseedArtifact, nil, 0644), IsNil)
+	c.Assert(os.WriteFile(preseedArtifact, nil, 0644), IsNil)
 
 	model := s.mockModel(map[string]interface{}{
 		"grade": "dangerous",

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -466,7 +466,7 @@ SNAPD_APPARMOR_REEXEC=1
 			infoFile := filepath.Join(dirs.SnapMountDir, snapName, rev, dirs.CoreLibExecDir, "info")
 			err = os.MkdirAll(filepath.Dir(infoFile), 0755)
 			c.Assert(err, IsNil)
-			err = ioutil.WriteFile(infoFile, []byte(defaultInfoFile), 0644)
+			err = os.WriteFile(infoFile, []byte(defaultInfoFile), 0644)
 			c.Assert(err, IsNil)
 		}
 	}
@@ -488,7 +488,7 @@ SNAPD_APPARMOR_REEXEC=1
 	snapdCloudInitRestrictedFile := filepath.Join(dirs.GlobalRootDir, "etc/cloud/cloud.cfg.d/zzzz_snapd.cfg")
 	err = os.MkdirAll(filepath.Dir(snapdCloudInitRestrictedFile), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(snapdCloudInitRestrictedFile, nil, 0644)
+	err = os.WriteFile(snapdCloudInitRestrictedFile, nil, 0644)
 	c.Assert(err, IsNil)
 
 	logbuf, restore := logger.MockLogger()
@@ -6616,7 +6616,7 @@ func (s *mgrsSuiteCore) TestHappyDeviceRegistrationWithPrepareDeviceHook(c *C) {
 	fname := filepath.Join(dirs.SnapdStoreSSLCertsDir, "test-server-certs.pem")
 	err = os.MkdirAll(filepath.Dir(fname), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(fname, extraCerts, 0644)
+	err = os.WriteFile(fname, extraCerts, 0644)
 	c.Assert(err, IsNil)
 
 	pDBhv := &devicestatetest.PrepareDeviceBehavior{
@@ -6766,7 +6766,7 @@ func (s *mgrsSuiteCore) TestRemodelReregistration(c *C) {
 	fname := filepath.Join(dirs.SnapdStoreSSLCertsDir, "test-server-certs.pem")
 	err = os.MkdirAll(filepath.Dir(fname), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(fname, extraCerts, 0644)
+	err = os.WriteFile(fname, extraCerts, 0644)
 	c.Assert(err, IsNil)
 
 	r := devicestatetest.MockGadget(c, st, "gadget", snap.R(2), nil)
@@ -7043,11 +7043,11 @@ func (s *mgrsSuiteCore) testRemodelUC20WithRecoverySystem(c *C, encrypted bool) 
 			e := grubenv.NewEnv(env)
 			c.Assert(e.Save(), IsNil)
 		case "grub.cfg":
-			c.Assert(ioutil.WriteFile(env, []byte(grubBootConfig), 0644), IsNil)
+			c.Assert(os.WriteFile(env, []byte(grubBootConfig), 0644), IsNil)
 		case "grubx64.efi", "bootx64.efi":
-			c.Assert(ioutil.WriteFile(env, []byte("content"), 0644), IsNil)
+			c.Assert(os.WriteFile(env, []byte("content"), 0644), IsNil)
 		default:
-			c.Assert(ioutil.WriteFile(env, nil, 0644), IsNil)
+			c.Assert(os.WriteFile(env, nil, 0644), IsNil)
 		}
 	}
 
@@ -7059,21 +7059,21 @@ func (s *mgrsSuiteCore) testRemodelUC20WithRecoverySystem(c *C, encrypted bool) 
 			"grubx64.efi-21e42a075b0d7bb6177c0eb3b3a1c8c6de6d4b4f902759eae5555e9cf3bebd21277a27102fd5426da989bde96c0cf848",
 			"bootx64.efi-21e42a075b0d7bb6177c0eb3b3a1c8c6de6d4b4f902759eae5555e9cf3bebd21277a27102fd5426da989bde96c0cf848",
 		} {
-			err := ioutil.WriteFile(filepath.Join(assetsCacheDir, cachedAsset), []byte("content"), 0644)
+			err := os.WriteFile(filepath.Join(assetsCacheDir, cachedAsset), []byte("content"), 0644)
 			c.Assert(err, IsNil)
 		}
 	}
 
 	// state of booted kernel
 	c.Assert(os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "boot/grub/pc-kernel_2.snap"), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(dirs.GlobalRootDir, "/boot/grub/pc-kernel_2.snap/kernel.efi"),
+	c.Assert(os.WriteFile(filepath.Join(dirs.GlobalRootDir, "/boot/grub/pc-kernel_2.snap/kernel.efi"),
 		[]byte("kernel-efi"), 0755), IsNil)
 	c.Assert(os.Symlink("pc-kernel_2.snap/kernel.efi", filepath.Join(dirs.GlobalRootDir, "boot/grub/kernel.efi")), IsNil)
 
 	if encrypted {
 		stamp := filepath.Join(dirs.SnapFDEDir, "sealed-keys")
 		c.Assert(os.MkdirAll(filepath.Dir(stamp), 0755), IsNil)
-		c.Assert(ioutil.WriteFile(stamp, nil, 0644), IsNil)
+		c.Assert(os.WriteFile(stamp, nil, 0644), IsNil)
 	}
 
 	// new snaps from the store
@@ -7207,7 +7207,7 @@ func (s *mgrsSuiteCore) testRemodelUC20WithRecoverySystem(c *C, encrypted bool) 
 	}
 
 	// make sure cmdline matches what we expect in the modeenv
-	c.Assert(ioutil.WriteFile(filepath.Join(dirs.GlobalRootDir, "proc/cmdline"),
+	c.Assert(os.WriteFile(filepath.Join(dirs.GlobalRootDir, "proc/cmdline"),
 		[]byte("snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1"), 0644),
 		IsNil)
 
@@ -7474,7 +7474,7 @@ func (s *mgrsSuiteCore) testRemodelUC20WithRecoverySystemSimpleSetUp(c *C) {
 			e := grubenv.NewEnv(env)
 			c.Assert(e.Save(), IsNil)
 		case "grub.cfg":
-			c.Assert(ioutil.WriteFile(env, []byte(grubBootConfig), 0644), IsNil)
+			c.Assert(os.WriteFile(env, []byte(grubBootConfig), 0644), IsNil)
 		default:
 			c.Fatalf("unexpected file %v", env)
 		}
@@ -7482,7 +7482,7 @@ func (s *mgrsSuiteCore) testRemodelUC20WithRecoverySystemSimpleSetUp(c *C) {
 
 	// state of booted kernel
 	c.Assert(os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "boot/grub/pc-kernel_2.snap"), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(dirs.GlobalRootDir, "/boot/grub/pc-kernel_2.snap/kernel.efi"),
+	c.Assert(os.WriteFile(filepath.Join(dirs.GlobalRootDir, "/boot/grub/pc-kernel_2.snap/kernel.efi"),
 		[]byte("kernel-efi"), 0755), IsNil)
 	c.Assert(os.Symlink("pc-kernel_2.snap/kernel.efi", filepath.Join(dirs.GlobalRootDir, "boot/grub/kernel.efi")), IsNil)
 
@@ -7551,7 +7551,7 @@ func (s *mgrsSuiteCore) testRemodelUC20WithRecoverySystemSimpleSetUp(c *C) {
 		ModelSignKeyID: model.SignKeyID(),
 	}
 	// make sure cmdline matches what we expect in the modeenv
-	c.Assert(ioutil.WriteFile(filepath.Join(dirs.GlobalRootDir, "proc/cmdline"),
+	c.Assert(os.WriteFile(filepath.Join(dirs.GlobalRootDir, "proc/cmdline"),
 		[]byte("snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1"), 0644),
 		IsNil)
 
@@ -8116,7 +8116,7 @@ func (s *mgrsSuiteCore) TestRemodelUC20BackToPreviousGadget(c *C) {
 	})
 
 	// pretend we have the right command line
-	c.Assert(ioutil.WriteFile(filepath.Join(dirs.GlobalRootDir, "proc/cmdline"),
+	c.Assert(os.WriteFile(filepath.Join(dirs.GlobalRootDir, "proc/cmdline"),
 		[]byte("snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1 foo bar baz"), 0444),
 		IsNil)
 
@@ -8297,7 +8297,7 @@ func (s *mgrsSuiteCore) TestRemodelUC20ExistingGadgetSnapDifferentChannel(c *C) 
 	})
 
 	// pretend we have the right command line
-	c.Assert(ioutil.WriteFile(filepath.Join(dirs.GlobalRootDir, "proc/cmdline"),
+	c.Assert(os.WriteFile(filepath.Join(dirs.GlobalRootDir, "proc/cmdline"),
 		[]byte("snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1 foo bar baz"), 0444),
 		IsNil)
 
@@ -8733,7 +8733,7 @@ func (s *mgrsSuiteCore) TestRemodelUC20ToUC22(c *C) {
 	// we've rebooted
 	restart.MockPending(st, restart.RestartUnset)
 	// pretend we have the right command line
-	c.Assert(ioutil.WriteFile(filepath.Join(dirs.GlobalRootDir, "proc/cmdline"),
+	c.Assert(os.WriteFile(filepath.Join(dirs.GlobalRootDir, "proc/cmdline"),
 		[]byte("snapd_recovery_mode=run console=ttyS0 console=tty1 panic=-1 uc22"), 0444),
 		IsNil)
 
@@ -8971,12 +8971,12 @@ WantedBy=multi-user.target
 
 	err := os.MkdirAll(dirs.SnapServicesDir, 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(dirs.SnapServicesDir, "snap.test-snap.svc1.service"), []byte(initialUnitFile), 0644)
+	err = os.WriteFile(filepath.Join(dirs.SnapServicesDir, "snap.test-snap.svc1.service"), []byte(initialUnitFile), 0644)
 	c.Assert(err, IsNil)
 
 	// we also need to setup the usr-lib-snapd.mount file too
 	usrLibSnapdMountFile := filepath.Join(dirs.SnapServicesDir, wrappers.SnapdToolingMountUnit)
-	err = ioutil.WriteFile(usrLibSnapdMountFile, nil, 0644)
+	err = os.WriteFile(usrLibSnapdMountFile, nil, 0644)
 	c.Assert(err, IsNil)
 
 	// the modification time of the usr-lib-snapd.mount file is the first
@@ -9208,12 +9208,12 @@ WantedBy=multi-user.target
 
 	err := os.MkdirAll(dirs.SnapServicesDir, 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(dirs.SnapServicesDir, "snap.test-snap.svc1.service"), []byte(initialUnitFile), 0644)
+	err = os.WriteFile(filepath.Join(dirs.SnapServicesDir, "snap.test-snap.svc1.service"), []byte(initialUnitFile), 0644)
 	c.Assert(err, IsNil)
 
 	// we also need to setup the usr-lib-snapd.mount file too
 	usrLibSnapdMountFile := filepath.Join(dirs.SnapServicesDir, wrappers.SnapdToolingMountUnit)
-	err = ioutil.WriteFile(usrLibSnapdMountFile, nil, 0644)
+	err = os.WriteFile(usrLibSnapdMountFile, nil, 0644)
 	c.Assert(err, IsNil)
 
 	// the modification time of the usr-lib-snapd.mount file is the first
@@ -9765,7 +9765,7 @@ func (s *mgrsSuiteCore) testGadgetKernelCommandLine(c *C, gadgetPath string, gad
 	defer restore()
 
 	cmdlineAfterRebootPath := filepath.Join(c.MkDir(), "mock-cmdline")
-	c.Assert(ioutil.WriteFile(cmdlineAfterRebootPath, []byte(commandLineAfterReboot), 0644), IsNil)
+	c.Assert(os.WriteFile(cmdlineAfterRebootPath, []byte(commandLineAfterReboot), 0644), IsNil)
 
 	// pretend we booted with the right kernel
 	bl.SetBootVars(map[string]string{"snap_kernel": "pc-kernel_1.snap"})
@@ -10475,7 +10475,7 @@ func (bs *baseMgrsSuite) makeMockedDisk(c *C, partNames []string) {
 	fakeDiskDeviceNode := filepath.Join(dirs.GlobalRootDir, "/dev/vda")
 	fakePartDeviceNode := fakeDiskDeviceNode + "p1"
 	// create fakedevice node
-	err = ioutil.WriteFile(fakePartDeviceNode, nil, 0644)
+	err = os.WriteFile(fakePartDeviceNode, nil, 0644)
 	c.Assert(err, IsNil)
 
 	for _, partName := range partNames {
@@ -10962,7 +10962,7 @@ func (ms *gadgetUpdatesSuite) makeMockedDev(c *C, structureName string) {
 	fakeDiskDeviceNode := filepath.Join(dirs.GlobalRootDir, "/dev/fakedevice0")
 	fakePartDeviceNode := fakeDiskDeviceNode + "p1"
 	// create fakedevice node
-	err = ioutil.WriteFile(fakePartDeviceNode, nil, 0644)
+	err = os.WriteFile(fakePartDeviceNode, nil, 0644)
 	c.Assert(err, IsNil)
 	// and point the mocked by-label entry to the fakedevice node
 	err = os.Symlink(fakePartDeviceNode, filepath.Join(byLabelDir, structureName))

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -52,6 +52,7 @@ import (
 	"github.com/snapcore/snapd/overlord/snapshotstate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	_ "github.com/snapcore/snapd/overlord/snapstate/policy"
+
 	// import to register linkNotify callback
 	_ "github.com/snapcore/snapd/overlord/snapstate/agentnotify"
 	"github.com/snapcore/snapd/overlord/state"

--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -170,7 +170,7 @@ func (ovs *overlordSuite) TestNewWithGoodState(c *C) {
 	defer func() { timings.DurationThreshold = oldDurationThreshold }()
 
 	fakeState := []byte(fmt.Sprintf(`{"data":{"patch-level":%d,"patch-sublevel":%d,"patch-sublevel-last-version":%q,"some":"data","refresh-privacy-key":"0123456789ABCDEF"},"changes":null,"tasks":null,"last-change-id":0,"last-task-id":0,"last-lane-id":0}`, patch.Level, patch.Sublevel, snapdtool.Version))
-	err := ioutil.WriteFile(dirs.SnapStateFile, fakeState, 0600)
+	err := os.WriteFile(dirs.SnapStateFile, fakeState, 0600)
 	c.Assert(err, IsNil)
 
 	o, err := overlord.New(nil)
@@ -199,7 +199,7 @@ func (ovs *overlordSuite) TestNewWithGoodState(c *C) {
 
 func (ovs *overlordSuite) TestNewWithStateSnapmgrUpdate(c *C) {
 	fakeState := []byte(fmt.Sprintf(`{"data":{"patch-level":%d,"some":"data"},"changes":null,"tasks":null,"last-change-id":0,"last-task-id":0,"last-lane-id":0}`, patch.Level))
-	err := ioutil.WriteFile(dirs.SnapStateFile, fakeState, 0600)
+	err := os.WriteFile(dirs.SnapStateFile, fakeState, 0600)
 	c.Assert(err, IsNil)
 
 	o, err := overlord.New(nil)
@@ -217,7 +217,7 @@ func (ovs *overlordSuite) TestNewWithStateSnapmgrUpdate(c *C) {
 
 func (ovs *overlordSuite) TestNewWithInvalidState(c *C) {
 	fakeState := []byte(``)
-	err := ioutil.WriteFile(dirs.SnapStateFile, fakeState, 0600)
+	err := os.WriteFile(dirs.SnapStateFile, fakeState, 0600)
 	c.Assert(err, IsNil)
 
 	_, err = overlord.New(nil)
@@ -236,7 +236,7 @@ func (ovs *overlordSuite) TestNewWithPatches(c *C) {
 	patch.Mock(1, 1, map[int][]patch.PatchFunc{1: {p, sp}})
 
 	fakeState := []byte(`{"data":{"patch-level":0, "patch-sublevel":0}}`)
-	err := ioutil.WriteFile(dirs.SnapStateFile, fakeState, 0600)
+	err := os.WriteFile(dirs.SnapStateFile, fakeState, 0600)
 	c.Assert(err, IsNil)
 
 	o, err := overlord.New(nil)
@@ -1177,7 +1177,7 @@ func (ovs *overlordSuite) TestRequestRestartHandler(c *C) {
 
 func (ovs *overlordSuite) TestVerifyRebootNoPendingReboot(c *C) {
 	fakeState := []byte(fmt.Sprintf(`{"data":{"patch-level":%d,"patch-sublevel":%d,"some":"data","refresh-privacy-key":"0123456789ABCDEF"},"changes":null,"tasks":null,"last-change-id":0,"last-task-id":0,"last-lane-id":0}`, patch.Level, patch.Sublevel))
-	err := ioutil.WriteFile(dirs.SnapStateFile, fakeState, 0600)
+	err := os.WriteFile(dirs.SnapStateFile, fakeState, 0600)
 	c.Assert(err, IsNil)
 
 	rb := &testRestartHandler{}
@@ -1190,7 +1190,7 @@ func (ovs *overlordSuite) TestVerifyRebootNoPendingReboot(c *C) {
 
 func (ovs *overlordSuite) TestVerifyRebootOK(c *C) {
 	fakeState := []byte(fmt.Sprintf(`{"data":{"patch-level":%d,"patch-sublevel":%d,"some":"data","refresh-privacy-key":"0123456789ABCDEF","system-restart-from-boot-id":%q},"changes":null,"tasks":null,"last-change-id":0,"last-task-id":0,"last-lane-id":0}`, patch.Level, patch.Sublevel, "boot-id-prev"))
-	err := ioutil.WriteFile(dirs.SnapStateFile, fakeState, 0600)
+	err := os.WriteFile(dirs.SnapStateFile, fakeState, 0600)
 	c.Assert(err, IsNil)
 
 	rb := &testRestartHandler{}
@@ -1203,7 +1203,7 @@ func (ovs *overlordSuite) TestVerifyRebootOK(c *C) {
 
 func (ovs *overlordSuite) TestVerifyRebootOKButError(c *C) {
 	fakeState := []byte(fmt.Sprintf(`{"data":{"patch-level":%d,"patch-sublevel":%d,"some":"data","refresh-privacy-key":"0123456789ABCDEF","system-restart-from-boot-id":%q},"changes":null,"tasks":null,"last-change-id":0,"last-task-id":0,"last-lane-id":0}`, patch.Level, patch.Sublevel, "boot-id-prev"))
-	err := ioutil.WriteFile(dirs.SnapStateFile, fakeState, 0600)
+	err := os.WriteFile(dirs.SnapStateFile, fakeState, 0600)
 	c.Assert(err, IsNil)
 
 	e := errors.New("boom")
@@ -1220,7 +1220,7 @@ func (ovs *overlordSuite) TestVerifyRebootDidNotHappen(c *C) {
 	c.Assert(err, IsNil)
 
 	fakeState := []byte(fmt.Sprintf(`{"data":{"patch-level":%d,"patch-sublevel":%d,"some":"data","refresh-privacy-key":"0123456789ABCDEF","system-restart-from-boot-id":%q},"changes":null,"tasks":null,"last-change-id":0,"last-task-id":0,"last-lane-id":0}`, patch.Level, patch.Sublevel, curBootID))
-	err = ioutil.WriteFile(dirs.SnapStateFile, fakeState, 0600)
+	err = os.WriteFile(dirs.SnapStateFile, fakeState, 0600)
 	c.Assert(err, IsNil)
 
 	rb := &testRestartHandler{}
@@ -1236,7 +1236,7 @@ func (ovs *overlordSuite) TestVerifyRebootDidNotHappenError(c *C) {
 	c.Assert(err, IsNil)
 
 	fakeState := []byte(fmt.Sprintf(`{"data":{"patch-level":%d,"patch-sublevel":%d,"some":"data","refresh-privacy-key":"0123456789ABCDEF","system-restart-from-boot-id":%q},"changes":null,"tasks":null,"last-change-id":0,"last-task-id":0,"last-lane-id":0}`, patch.Level, patch.Sublevel, curBootID))
-	err = ioutil.WriteFile(dirs.SnapStateFile, fakeState, 0600)
+	err = os.WriteFile(dirs.SnapStateFile, fakeState, 0600)
 	c.Assert(err, IsNil)
 
 	e := errors.New("boom")

--- a/overlord/patch/patch1_test.go
+++ b/overlord/patch/patch1_test.go
@@ -21,7 +21,6 @@ package patch_test
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -92,7 +91,7 @@ func (s *patch1Suite) SetUpTest(c *C) {
 
 	err := os.MkdirAll(filepath.Dir(dirs.SnapStateFile), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(dirs.SnapStateFile, statePatch1JSON, 0644)
+	err = os.WriteFile(dirs.SnapStateFile, statePatch1JSON, 0644)
 	c.Assert(err, IsNil)
 }
 

--- a/overlord/patch/patch2_test.go
+++ b/overlord/patch/patch2_test.go
@@ -20,7 +20,6 @@
 package patch_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -119,7 +118,7 @@ func (s *patch2Suite) SetUpTest(c *C) {
 
 	err := os.MkdirAll(filepath.Dir(dirs.SnapStateFile), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(dirs.SnapStateFile, statePatch2JSON, 0644)
+	err = os.WriteFile(dirs.SnapStateFile, statePatch2JSON, 0644)
 	c.Assert(err, IsNil)
 }
 

--- a/overlord/patch/patch3_test.go
+++ b/overlord/patch/patch3_test.go
@@ -20,7 +20,6 @@
 package patch_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -102,7 +101,7 @@ func (s *patch3Suite) SetUpTest(c *C) {
 
 	err := os.MkdirAll(filepath.Dir(dirs.SnapStateFile), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(dirs.SnapStateFile, statePatch3JSON, 0644)
+	err = os.WriteFile(dirs.SnapStateFile, statePatch3JSON, 0644)
 	c.Assert(err, IsNil)
 }
 

--- a/overlord/patch/patch4_test.go
+++ b/overlord/patch/patch4_test.go
@@ -20,7 +20,6 @@
 package patch_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -229,7 +228,7 @@ func (s *patch4Suite) SetUpTest(c *C) {
 
 	err := os.MkdirAll(filepath.Dir(dirs.SnapStateFile), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(dirs.SnapStateFile, statePatch4JSON, 0644)
+	err = os.WriteFile(dirs.SnapStateFile, statePatch4JSON, 0644)
 	c.Assert(err, IsNil)
 }
 

--- a/overlord/patch/patch6_1_test.go
+++ b/overlord/patch/patch6_1_test.go
@@ -20,7 +20,6 @@
 package patch_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -188,7 +187,7 @@ func (s *patch61Suite) SetUpTest(c *C) {
 
 	err := os.MkdirAll(filepath.Dir(dirs.SnapStateFile), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(dirs.SnapStateFile, statePatch6_1JSON, 0644)
+	err = os.WriteFile(dirs.SnapStateFile, statePatch6_1JSON, 0644)
 	c.Assert(err, IsNil)
 
 	snap.MockSanitizePlugsSlots(func(*snap.Info) {})

--- a/overlord/patch/patch6_test.go
+++ b/overlord/patch/patch6_test.go
@@ -21,7 +21,6 @@ package patch_test
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -133,7 +132,7 @@ func (s *patch6Suite) SetUpTest(c *C) {
 
 	err := os.MkdirAll(filepath.Dir(dirs.SnapStateFile), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(dirs.SnapStateFile, statePatch5JSON, 0644)
+	err = os.WriteFile(dirs.SnapStateFile, statePatch5JSON, 0644)
 	c.Assert(err, IsNil)
 }
 

--- a/overlord/servicestate/quota_handlers_test.go
+++ b/overlord/servicestate/quota_handlers_test.go
@@ -21,7 +21,6 @@ package servicestate_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -2347,7 +2346,7 @@ func (s *quotaHandlersSuite) TestUpdateJournalQuota(c *C) {
 	// group as a mock, so manually do this here.
 	fooConfPath := filepath.Join(dirs.SnapSystemdDir, "journald@snap-foo.conf")
 	c.Assert(os.MkdirAll(filepath.Dir(fooConfPath), 0755), IsNil)
-	err = ioutil.WriteFile(fooConfPath, []byte(`[Journal]
+	err = os.WriteFile(fooConfPath, []byte(`[Journal]
 SystemMaxUse=16M
 `), 0644)
 	c.Assert(err, IsNil)

--- a/overlord/servicestate/service_control_test.go
+++ b/overlord/servicestate/service_control_test.go
@@ -20,7 +20,6 @@
 package servicestate_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -121,7 +120,7 @@ func (s *serviceControlSuite) mockTestSnap(c *C) *snap.Info {
 	// mock systemd service units, this is required when testing "stop"
 	err := os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "etc/systemd/system/"), 0775)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(dirs.GlobalRootDir, "etc/systemd/system/snap.test-snap.foo.service"), nil, 0644)
+	err = os.WriteFile(filepath.Join(dirs.GlobalRootDir, "etc/systemd/system/snap.test-snap.foo.service"), nil, 0644)
 	c.Assert(err, IsNil)
 
 	return info

--- a/overlord/servicestate/servicemgr_test.go
+++ b/overlord/servicestate/servicemgr_test.go
@@ -21,7 +21,6 @@ package servicestate_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -371,7 +370,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesWritesServicesFilesUC18(c
 	err := os.MkdirAll(dirs.SnapServicesDir, 0755)
 	c.Assert(err, IsNil)
 	usrLibSnapdMountFile := filepath.Join(dirs.SnapServicesDir, wrappers.SnapdToolingMountUnit)
-	err = ioutil.WriteFile(usrLibSnapdMountFile, nil, 0644)
+	err = os.WriteFile(usrLibSnapdMountFile, nil, 0644)
 	c.Assert(err, IsNil)
 
 	r := s.mockSystemctlCalls(c, []expectedSystemctl{
@@ -414,7 +413,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesWritesServicesFilesVitali
 	err = os.MkdirAll(dirs.SnapServicesDir, 0755)
 	c.Assert(err, IsNil)
 	usrLibSnapdMountFile := filepath.Join(dirs.SnapServicesDir, wrappers.SnapdToolingMountUnit)
-	err = ioutil.WriteFile(usrLibSnapdMountFile, nil, 0644)
+	err = os.WriteFile(usrLibSnapdMountFile, nil, 0644)
 	c.Assert(err, IsNil)
 
 	r := s.mockSystemctlCalls(c, []expectedSystemctl{
@@ -452,7 +451,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesWritesServicesFilesAndDoe
 	err := os.MkdirAll(dirs.SnapServicesDir, 0755)
 	c.Assert(err, IsNil)
 	usrLibSnapdMountFile := filepath.Join(dirs.SnapServicesDir, wrappers.SnapdToolingMountUnit)
-	err = ioutil.WriteFile(usrLibSnapdMountFile, nil, 0644)
+	err = os.WriteFile(usrLibSnapdMountFile, nil, 0644)
 	c.Assert(err, IsNil)
 
 	now := time.Now()
@@ -496,7 +495,7 @@ echo %[1]q
 		snapName:             "test-snap",
 		snapRev:              "42",
 	})
-	err = ioutil.WriteFile(svcFile, []byte(requiresContent), 0644)
+	err = os.WriteFile(svcFile, []byte(requiresContent), 0644)
 	c.Assert(err, IsNil)
 
 	r = s.mockSystemctlCalls(c, []expectedSystemctl{
@@ -539,7 +538,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesWritesServicesFilesAndIgn
 	err := os.MkdirAll(dirs.SnapServicesDir, 0755)
 	c.Assert(err, IsNil)
 	usrLibSnapdMountFile := filepath.Join(dirs.SnapServicesDir, wrappers.SnapdToolingMountUnit)
-	err = ioutil.WriteFile(usrLibSnapdMountFile, nil, 0644)
+	err = os.WriteFile(usrLibSnapdMountFile, nil, 0644)
 	c.Assert(err, IsNil)
 
 	now := time.Now()
@@ -567,7 +566,7 @@ exit 1
 		snapName:             "test-snap",
 		snapRev:              "42",
 	})
-	err = ioutil.WriteFile(svcFile, []byte(requiresContent), 0644)
+	err = os.WriteFile(svcFile, []byte(requiresContent), 0644)
 	c.Assert(err, IsNil)
 
 	r = s.mockSystemctlCalls(c, []expectedSystemctl{
@@ -616,7 +615,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesWritesServicesFilesAndRes
 	err := os.MkdirAll(dirs.SnapServicesDir, 0755)
 	c.Assert(err, IsNil)
 	usrLibSnapdMountFile := filepath.Join(dirs.SnapServicesDir, wrappers.SnapdToolingMountUnit)
-	err = ioutil.WriteFile(usrLibSnapdMountFile, nil, 0644)
+	err = os.WriteFile(usrLibSnapdMountFile, nil, 0644)
 	c.Assert(err, IsNil)
 
 	now := time.Now()
@@ -631,7 +630,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesWritesServicesFilesAndRes
 		snapName:             "test-snap",
 		snapRev:              "42",
 	})
-	err = ioutil.WriteFile(svcFile, []byte(requiresContent), 0644)
+	err = os.WriteFile(svcFile, []byte(requiresContent), 0644)
 	c.Assert(err, IsNil)
 
 	slightFuture := now.Add(30 * time.Minute).Format(systemdTimeFormat)
@@ -702,7 +701,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesWritesServicesFilesButDoe
 	err := os.MkdirAll(dirs.SnapServicesDir, 0755)
 	c.Assert(err, IsNil)
 	usrLibSnapdMountFile := filepath.Join(dirs.SnapServicesDir, wrappers.SnapdToolingMountUnit)
-	err = ioutil.WriteFile(usrLibSnapdMountFile, nil, 0644)
+	err = os.WriteFile(usrLibSnapdMountFile, nil, 0644)
 	c.Assert(err, IsNil)
 
 	now := time.Now()
@@ -717,7 +716,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesWritesServicesFilesButDoe
 		snapName:             "test-snap",
 		snapRev:              "42",
 	})
-	err = ioutil.WriteFile(svcFile, []byte(requiresContent), 0644)
+	err = os.WriteFile(svcFile, []byte(requiresContent), 0644)
 	c.Assert(err, IsNil)
 
 	slightFuture := now.Add(30 * time.Minute).Format(systemdTimeFormat)
@@ -781,7 +780,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesDoesNotRestartServicesKil
 	err := os.MkdirAll(dirs.SnapServicesDir, 0755)
 	c.Assert(err, IsNil)
 	usrLibSnapdMountFile := filepath.Join(dirs.SnapServicesDir, wrappers.SnapdToolingMountUnit)
-	err = ioutil.WriteFile(usrLibSnapdMountFile, nil, 0644)
+	err = os.WriteFile(usrLibSnapdMountFile, nil, 0644)
 	c.Assert(err, IsNil)
 
 	now := time.Now()
@@ -796,7 +795,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesDoesNotRestartServicesKil
 		snapName:             "test-snap",
 		snapRev:              "42",
 	})
-	err = ioutil.WriteFile(svcFile, []byte(requiresContent), 0644)
+	err = os.WriteFile(svcFile, []byte(requiresContent), 0644)
 	c.Assert(err, IsNil)
 
 	theFuture := now.Add(1 * time.Hour).Format(systemdTimeFormat)
@@ -847,7 +846,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesDoesNotRestartServicesKil
 	err := os.MkdirAll(dirs.SnapServicesDir, 0755)
 	c.Assert(err, IsNil)
 	usrLibSnapdMountFile := filepath.Join(dirs.SnapServicesDir, wrappers.SnapdToolingMountUnit)
-	err = ioutil.WriteFile(usrLibSnapdMountFile, nil, 0644)
+	err = os.WriteFile(usrLibSnapdMountFile, nil, 0644)
 	c.Assert(err, IsNil)
 
 	now := time.Now()
@@ -862,7 +861,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesDoesNotRestartServicesKil
 		snapName:             "test-snap",
 		snapRev:              "42",
 	})
-	err = ioutil.WriteFile(svcFile, []byte(requiresContent), 0644)
+	err = os.WriteFile(svcFile, []byte(requiresContent), 0644)
 	c.Assert(err, IsNil)
 
 	theFuture := now.Add(1 * time.Hour).Format(systemdTimeFormat)
@@ -913,7 +912,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesSimpleRewritesServicesFil
 	err := os.MkdirAll(dirs.SnapServicesDir, 0755)
 	c.Assert(err, IsNil)
 	usrLibSnapdMountFile := filepath.Join(dirs.SnapServicesDir, wrappers.SnapdToolingMountUnit)
-	err = ioutil.WriteFile(usrLibSnapdMountFile, nil, 0644)
+	err = os.WriteFile(usrLibSnapdMountFile, nil, 0644)
 	c.Assert(err, IsNil)
 
 	// this test is about the specific scenario we have now when using systemctl
@@ -945,7 +944,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesSimpleRewritesServicesFil
 		snapName:             "test-snap",
 		snapRev:              "42",
 	})
-	err = ioutil.WriteFile(svcFile, []byte(requiresContent), 0644)
+	err = os.WriteFile(svcFile, []byte(requiresContent), 0644)
 	c.Assert(err, IsNil)
 
 	r := s.mockSystemctlCalls(c, []expectedSystemctl{
@@ -1006,7 +1005,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesSimpleRewritesServicesFil
 	err := os.MkdirAll(dirs.SnapServicesDir, 0755)
 	c.Assert(err, IsNil)
 	usrLibSnapdMountFile := filepath.Join(dirs.SnapServicesDir, wrappers.SnapdToolingMountUnit)
-	err = ioutil.WriteFile(usrLibSnapdMountFile, nil, 0644)
+	err = os.WriteFile(usrLibSnapdMountFile, nil, 0644)
 	c.Assert(err, IsNil)
 
 	// this test is like TestEnsureSnapServicesSimpleRewritesServicesFilesAndRestartsTimePrecisionSilly,
@@ -1038,7 +1037,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesSimpleRewritesServicesFil
 		snapName:             "test-snap",
 		snapRev:              "42",
 	})
-	err = ioutil.WriteFile(svcFile, []byte(requiresContent), 0644)
+	err = os.WriteFile(svcFile, []byte(requiresContent), 0644)
 	c.Assert(err, IsNil)
 
 	r := s.mockSystemctlCalls(c, []expectedSystemctl{
@@ -1099,7 +1098,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesSimpleRewritesServicesFil
 	err := os.MkdirAll(dirs.SnapServicesDir, 0755)
 	c.Assert(err, IsNil)
 	usrLibSnapdMountFile := filepath.Join(dirs.SnapServicesDir, wrappers.SnapdToolingMountUnit)
-	err = ioutil.WriteFile(usrLibSnapdMountFile, nil, 0644)
+	err = os.WriteFile(usrLibSnapdMountFile, nil, 0644)
 	c.Assert(err, IsNil)
 
 	now := time.Now()
@@ -1117,7 +1116,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesSimpleRewritesServicesFil
 		snapName:             "test-snap",
 		snapRev:              "42",
 	})
-	err = ioutil.WriteFile(svcFile, []byte(requiresContent), 0644)
+	err = os.WriteFile(svcFile, []byte(requiresContent), 0644)
 	c.Assert(err, IsNil)
 
 	r := s.mockSystemctlCalls(c, []expectedSystemctl{
@@ -1178,7 +1177,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesNoChangeServiceFileDoesNo
 	err := os.MkdirAll(dirs.SnapServicesDir, 0755)
 	c.Assert(err, IsNil)
 	usrLibSnapdMountFile := filepath.Join(dirs.SnapServicesDir, wrappers.SnapdToolingMountUnit)
-	err = ioutil.WriteFile(usrLibSnapdMountFile, nil, 0644)
+	err = os.WriteFile(usrLibSnapdMountFile, nil, 0644)
 	c.Assert(err, IsNil)
 
 	now := time.Now()
@@ -1193,7 +1192,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesNoChangeServiceFileDoesNo
 		snapName:             "test-snap",
 		snapRev:              "42",
 	})
-	err = ioutil.WriteFile(svcFile, []byte(content), 0644)
+	err = os.WriteFile(svcFile, []byte(content), 0644)
 	c.Assert(err, IsNil)
 
 	// we don't use systemctl at all because we didn't change anything
@@ -1222,7 +1221,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesDoesNotRestartServicesWhe
 	err := os.MkdirAll(dirs.SnapServicesDir, 0755)
 	c.Assert(err, IsNil)
 	usrLibSnapdMountFile := filepath.Join(dirs.SnapServicesDir, wrappers.SnapdToolingMountUnit)
-	err = ioutil.WriteFile(usrLibSnapdMountFile, nil, 0644)
+	err = os.WriteFile(usrLibSnapdMountFile, nil, 0644)
 	c.Assert(err, IsNil)
 
 	now := time.Now()
@@ -1236,7 +1235,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesDoesNotRestartServicesWhe
 		snapName:             "test-snap",
 		snapRev:              "42",
 	})
-	err = ioutil.WriteFile(svcFile, []byte(requiresContent), 0644)
+	err = os.WriteFile(svcFile, []byte(requiresContent), 0644)
 	c.Assert(err, IsNil)
 
 	r := s.mockSystemctlCalls(c, []expectedSystemctl{
@@ -1278,7 +1277,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesWritesServicesFilesAndRes
 	err := os.MkdirAll(dirs.SnapServicesDir, 0755)
 	c.Assert(err, IsNil)
 	usrLibSnapdMountFile := filepath.Join(dirs.SnapServicesDir, wrappers.SnapdToolingMountUnit)
-	err = ioutil.WriteFile(usrLibSnapdMountFile, nil, 0644)
+	err = os.WriteFile(usrLibSnapdMountFile, nil, 0644)
 	c.Assert(err, IsNil)
 
 	now := time.Now()
@@ -1293,7 +1292,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesWritesServicesFilesAndRes
 		snapName:             "test-snap",
 		snapRev:              "42",
 	})
-	err = ioutil.WriteFile(svcFile, []byte(requiresContent), 0644)
+	err = os.WriteFile(svcFile, []byte(requiresContent), 0644)
 	c.Assert(err, IsNil)
 
 	slightFuture := now.Add(30 * time.Minute).Format(systemdTimeFormat)
@@ -1366,7 +1365,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesWritesServicesFilesAndTri
 	err := os.MkdirAll(dirs.SnapServicesDir, 0755)
 	c.Assert(err, IsNil)
 	usrLibSnapdMountFile := filepath.Join(dirs.SnapServicesDir, wrappers.SnapdToolingMountUnit)
-	err = ioutil.WriteFile(usrLibSnapdMountFile, nil, 0644)
+	err = os.WriteFile(usrLibSnapdMountFile, nil, 0644)
 	c.Assert(err, IsNil)
 
 	now := time.Now()
@@ -1381,7 +1380,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesWritesServicesFilesAndTri
 		snapName:             "test-snap",
 		snapRev:              "42",
 	})
-	err = ioutil.WriteFile(svcFile, []byte(requiresContent), 0644)
+	err = os.WriteFile(svcFile, []byte(requiresContent), 0644)
 	c.Assert(err, IsNil)
 
 	slightFuture := now.Add(30 * time.Minute).Format(systemdTimeFormat)

--- a/overlord/snapshotstate/backend/backend.go
+++ b/overlord/snapshotstate/backend/backend.go
@@ -29,7 +29,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -686,7 +685,7 @@ func (t *importTransaction) Commit() error {
 }
 
 func (t *importTransaction) lock() error {
-	return ioutil.WriteFile(t.lockPath, nil, 0644)
+	return os.WriteFile(t.lockPath, nil, 0644)
 }
 
 func (t *importTransaction) unlock() error {

--- a/overlord/snapshotstate/snapshotstate_test.go
+++ b/overlord/snapshotstate/snapshotstate_test.go
@@ -98,7 +98,7 @@ func (snapshotSuite) TestNewSnapshotSetID(c *check.C) {
 	c.Assert(st.Get("last-snapshot-set-id", &stateSetID), check.IsNil)
 	c.Check(stateSetID, check.Equals, uint64(1))
 
-	c.Assert(ioutil.WriteFile(filepath.Join(dirs.SnapshotsDir, "9_some-snap-1.zip"), []byte{}, 0644), check.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dirs.SnapshotsDir, "9_some-snap-1.zip"), []byte{}, 0644), check.IsNil)
 
 	// Disk last set id 9 > state set id 1, use 9++ = 10
 	sid, err = snapshotstate.NewSnapshotSetID(st)
@@ -116,7 +116,7 @@ func (snapshotSuite) TestNewSnapshotSetID(c *check.C) {
 	c.Assert(st.Get("last-snapshot-set-id", &stateSetID), check.IsNil)
 	c.Check(stateSetID, check.Equals, uint64(11))
 
-	c.Assert(ioutil.WriteFile(filepath.Join(dirs.SnapshotsDir, "88_some-snap-1.zip"), []byte{}, 0644), check.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dirs.SnapshotsDir, "88_some-snap-1.zip"), []byte{}, 0644), check.IsNil)
 
 	// Disk last set id 88 > state set id 11, use 88++ = 89
 	sid, err = snapshotstate.NewSnapshotSetID(st)

--- a/overlord/snapstate/autorefresh_gating_test.go
+++ b/overlord/snapstate/autorefresh_gating_test.go
@@ -22,7 +22,6 @@ package snapstate_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -129,7 +128,7 @@ func mockInstalledSnap(c *C, st *state.State, snapYaml string, hasHook bool) *sn
 
 	if hasHook {
 		c.Assert(os.MkdirAll(snapInfo.HooksDir(), 0775), IsNil)
-		err := ioutil.WriteFile(filepath.Join(snapInfo.HooksDir(), "gate-auto-refresh"), nil, 0755)
+		err := os.WriteFile(filepath.Join(snapInfo.HooksDir(), "gate-auto-refresh"), nil, 0755)
 		c.Assert(err, IsNil)
 	}
 	return snapInfo

--- a/overlord/snapstate/backend/aliases_test.go
+++ b/overlord/snapstate/backend/aliases_test.go
@@ -20,7 +20,6 @@
 package backend_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -55,7 +54,7 @@ func (s *aliasesSuite) SetUpTest(c *C) {
 	c.Assert(os.MkdirAll(dirs.CompletersDir, 0755), IsNil)
 	c.Assert(os.MkdirAll(dirs.LegacyCompletersDir, 0755), IsNil)
 	c.Assert(os.MkdirAll(filepath.Dir(dirs.CompleteShPath(s.base)), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(dirs.CompleteShPath(s.base), nil, 0644), IsNil)
+	c.Assert(os.WriteFile(dirs.CompleteShPath(s.base), nil, 0644), IsNil)
 }
 
 func (s *aliasesSuite) TearDownTest(c *C) {

--- a/overlord/snapstate/backend/copydata_test.go
+++ b/overlord/snapstate/backend/copydata_test.go
@@ -99,14 +99,14 @@ func (s *copydataSuite) testCopyData(c *C, snapDir string, opts *dirs.SnapDirOpt
 	c.Assert(err, IsNil)
 
 	canaryDataFile := filepath.Join(v1.DataDir(), "canary.txt")
-	err = ioutil.WriteFile(canaryDataFile, canaryData, 0644)
+	err = os.WriteFile(canaryDataFile, canaryData, 0644)
 	c.Assert(err, IsNil)
 	canaryDataFile = filepath.Join(v1.CommonDataDir(), "canary.common")
-	err = ioutil.WriteFile(canaryDataFile, canaryData, 0644)
+	err = os.WriteFile(canaryDataFile, canaryData, 0644)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(homeData, "canary.home"), canaryData, 0644)
+	err = os.WriteFile(filepath.Join(homeData, "canary.home"), canaryData, 0644)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(homeCommonData, "canary.common_home"), canaryData, 0644)
+	err = os.WriteFile(filepath.Join(homeCommonData, "canary.common_home"), canaryData, 0644)
 	c.Assert(err, IsNil)
 
 	v2 := snaptest.MockSnap(c, helloYaml2, &snap.SideInfo{Revision: snap.R(20)})
@@ -154,10 +154,10 @@ func (s *copydataSuite) TestCopyDataNoUserHomes(c *C) {
 	c.Assert(err, IsNil)
 
 	canaryDataFile := filepath.Join(v1.DataDir(), "canary.txt")
-	err = ioutil.WriteFile(canaryDataFile, []byte(""), 0644)
+	err = os.WriteFile(canaryDataFile, []byte(""), 0644)
 	c.Assert(err, IsNil)
 	canaryDataFile = filepath.Join(v1.CommonDataDir(), "canary.common")
-	err = ioutil.WriteFile(canaryDataFile, []byte(""), 0644)
+	err = os.WriteFile(canaryDataFile, []byte(""), 0644)
 	c.Assert(err, IsNil)
 
 	v2 := snaptest.MockSnap(c, helloYaml2, &snap.SideInfo{Revision: snap.R(20)})
@@ -179,7 +179,7 @@ func (s *copydataSuite) populateData(c *C, revision snap.Revision) {
 	subdir := filepath.Join(datadir, "random-subdir")
 	err := os.MkdirAll(subdir, 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(subdir, "canary"), []byte(fmt.Sprintln(revision)), 0644)
+	err = os.WriteFile(filepath.Join(subdir, "canary"), []byte(fmt.Sprintln(revision)), 0644)
 	c.Assert(err, IsNil)
 }
 
@@ -203,7 +203,7 @@ func (s copydataSuite) populateHomeDataWithSnapDir(c *C, user string, snapDir st
 	homeData := filepath.Join(homedir, "hello", revision.String())
 	err := os.MkdirAll(homeData, 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(homeData, "canary.home"), []byte(fmt.Sprintln(revision)), 0644)
+	err = os.WriteFile(filepath.Join(homeData, "canary.home"), []byte(fmt.Sprintln(revision)), 0644)
 	c.Assert(err, IsNil)
 
 	return homedir
@@ -518,8 +518,8 @@ func (s *copydataSuite) TestCopyDataSameRevision(c *C) {
 	homedir2 := s.populateHomeData(c, "user2", snap.R(10))
 	c.Assert(os.MkdirAll(v1.DataDir(), 0755), IsNil)
 	c.Assert(os.MkdirAll(v1.CommonDataDir(), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(v1.DataDir(), "canary.txt"), nil, 0644), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(v1.CommonDataDir(), "canary.common"), nil, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(v1.DataDir(), "canary.txt"), nil, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(v1.CommonDataDir(), "canary.common"), nil, 0644), IsNil)
 
 	// the data is there
 	for _, fn := range []string{
@@ -554,8 +554,8 @@ func (s *copydataSuite) TestUndoCopyDataSameRevision(c *C) {
 	homedir2 := s.populateHomeData(c, "user2", snap.R(10))
 	c.Assert(os.MkdirAll(v1.DataDir(), 0755), IsNil)
 	c.Assert(os.MkdirAll(v1.CommonDataDir(), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(v1.DataDir(), "canary.txt"), nil, 0644), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(v1.CommonDataDir(), "canary.common"), nil, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(v1.DataDir(), "canary.txt"), nil, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(v1.CommonDataDir(), "canary.common"), nil, 0644), IsNil)
 
 	// the data is there
 	for _, fn := range []string{
@@ -623,7 +623,7 @@ func (s *copydataSuite) TestSetupCommonSaveDataFirstInstall(c *C) {
 	c.Assert(err, IsNil)
 
 	// create a test file to make sure this also gets removed
-	c.Assert(ioutil.WriteFile(filepath.Join(v1.CommonDataSaveDir(), "canary.txt"), nil, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(v1.CommonDataSaveDir(), "canary.txt"), nil, 0644), IsNil)
 
 	// removes correctly when no previous info is present
 	err = s.be.UndoSetupSnapSaveData(v1, nil, mockDev, progress.Null)
@@ -645,7 +645,7 @@ func (s *copydataSuite) TestSetupCommonSaveDataSameRevision(c *C) {
 	v1 := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
 
 	c.Assert(os.MkdirAll(v1.CommonDataSaveDir(), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(v1.CommonDataSaveDir(), "canary.txt"), nil, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(v1.CommonDataSaveDir(), "canary.txt"), nil, 0644), IsNil)
 	c.Assert(osutil.FileExists(filepath.Join(v1.CommonDataSaveDir(), "canary.txt")), Equals, true)
 
 	// setup snap save data works
@@ -660,7 +660,7 @@ func (s *copydataSuite) TestUndoSetupCommonSaveDataClassic(c *C) {
 	v1 := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
 
 	c.Assert(os.MkdirAll(v1.CommonDataSaveDir(), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(v1.CommonDataSaveDir(), "canary.txt"), nil, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(v1.CommonDataSaveDir(), "canary.txt"), nil, 0644), IsNil)
 	c.Assert(osutil.FileExists(filepath.Join(v1.CommonDataSaveDir(), "canary.txt")), Equals, true)
 
 	// make sure that undo doesn't do anything on a classic system
@@ -674,7 +674,7 @@ func (s *copydataSuite) TestUndoSetupCommonSaveDataSameRevision(c *C) {
 	v1 := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
 
 	c.Assert(os.MkdirAll(v1.CommonDataSaveDir(), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(v1.CommonDataSaveDir(), "canary.txt"), nil, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(v1.CommonDataSaveDir(), "canary.txt"), nil, 0644), IsNil)
 	c.Assert(osutil.FileExists(filepath.Join(v1.CommonDataSaveDir(), "canary.txt")), Equals, true)
 
 	// make sure that undo doesn't do anything with a previous version present
@@ -706,7 +706,7 @@ func (s *copydataSuite) TestHideSnapData(c *C) {
 	c.Assert(err, IsNil)
 
 	commonFilePath := filepath.Join(info.UserCommonDataDir(homedir, nil), "file.txt")
-	err = ioutil.WriteFile(commonFilePath, []byte("some content"), 0640)
+	err = os.WriteFile(commonFilePath, []byte("some content"), 0640)
 	c.Assert(err, IsNil)
 
 	// make 'current' symlink
@@ -810,10 +810,10 @@ func (s *copydataSuite) TestHideSnapDataOverwrite(c *C) {
 	c.Assert(os.MkdirAll(snapDir, 0700), IsNil)
 
 	revFile := filepath.Join(snapDir, "canary.home")
-	c.Assert(ioutil.WriteFile(revFile, []byte("stuff"), 0600), IsNil)
+	c.Assert(os.WriteFile(revFile, []byte("stuff"), 0600), IsNil)
 
 	otherFile := filepath.Join(snapDir, "file")
-	c.Assert(ioutil.WriteFile(otherFile, []byte("stuff"), 0600), IsNil)
+	c.Assert(os.WriteFile(otherFile, []byte("stuff"), 0600), IsNil)
 
 	c.Assert(s.be.HideSnapData("hello"), IsNil)
 
@@ -850,7 +850,7 @@ func (s *copydataSuite) TestUndoHideSnapData(c *C) {
 	c.Assert(err, IsNil)
 
 	hiddenRevFile := filepath.Join(info.UserDataDir(homedir, opts), "file.txt")
-	err = ioutil.WriteFile(hiddenRevFile, []byte("some content"), 0640)
+	err = os.WriteFile(hiddenRevFile, []byte("some content"), 0640)
 	c.Assert(err, IsNil)
 
 	// write file in common
@@ -858,7 +858,7 @@ func (s *copydataSuite) TestUndoHideSnapData(c *C) {
 	c.Assert(err, IsNil)
 
 	hiddenCommonFile := filepath.Join(info.UserCommonDataDir(homedir, opts), "file.txt")
-	err = ioutil.WriteFile(hiddenCommonFile, []byte("other content"), 0640)
+	err = os.WriteFile(hiddenCommonFile, []byte("other content"), 0640)
 	c.Assert(err, IsNil)
 
 	// make 'current' symlink
@@ -988,7 +988,7 @@ func (s *copydataSuite) TestCleanupAfterCopyAndMigration(c *C) {
 
 func (s *copydataSuite) TestRemoveIfEmpty(c *C) {
 	file := filepath.Join(s.tempdir, "random")
-	c.Assert(ioutil.WriteFile(file, []byte("stuff"), 0664), IsNil)
+	c.Assert(os.WriteFile(file, []byte("stuff"), 0664), IsNil)
 
 	// dir contains a file, shouldn't do anything
 	c.Assert(backend.RemoveIfEmpty(s.tempdir), IsNil)
@@ -1071,7 +1071,7 @@ func (s *copydataSuite) TestInitSnapUserHome(c *C) {
 	c.Assert(os.MkdirAll(revDir, 0700), IsNil)
 
 	filePath := filepath.Join(revDir, "file")
-	c.Assert(ioutil.WriteFile(filePath, []byte("stuff"), 0664), IsNil)
+	c.Assert(os.WriteFile(filePath, []byte("stuff"), 0664), IsNil)
 	dirPath := filepath.Join(revDir, "dir")
 	c.Assert(os.Mkdir(dirPath, 0775), IsNil)
 
@@ -1284,7 +1284,7 @@ func (s *copydataSuite) TestInitAlreadyExistsFile(c *C) {
 	newHome := snap.UserExposedHomeDir(usr.HomeDir, snapName)
 	parent := filepath.Dir(newHome)
 	c.Assert(os.MkdirAll(parent, 0700), IsNil)
-	c.Assert(ioutil.WriteFile(newHome, nil, 0600), IsNil)
+	c.Assert(os.WriteFile(newHome, nil, 0600), IsNil)
 
 	rev, err := snap.ParseRevision("2")
 	c.Assert(err, IsNil)
@@ -1314,7 +1314,7 @@ func (s *copydataSuite) TestInitAlreadyExistsDir(c *C) {
 	// ~/Snap/some-snap already exists but is file
 	newHome := snap.UserExposedHomeDir(usr.HomeDir, snapName)
 	c.Assert(os.MkdirAll(newHome, 0700), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(newHome, "file"), nil, 0600), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(newHome, "file"), nil, 0600), IsNil)
 
 	rev, err := snap.ParseRevision("2")
 	c.Assert(err, IsNil)
@@ -1347,7 +1347,7 @@ func (s *copydataSuite) TestRemoveExposedHome(c *C) {
 	snapName := "some-snap"
 	exposedDir := filepath.Join(usr.HomeDir, dirs.ExposedSnapHomeDir, snapName)
 	c.Assert(os.MkdirAll(exposedDir, 0700), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(exposedDir, "file"), []byte("foo"), 0600), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(exposedDir, "file"), []byte("foo"), 0600), IsNil)
 	var undoInfo backend.UndoInfo
 	undoInfo.Created = append(undoInfo.Created, exposedDir)
 
@@ -1389,7 +1389,7 @@ func (s *copydataSuite) TestRemoveExposedKeepGoingOnFail(c *C) {
 
 		exposedDir := filepath.Join(homedir, dirs.ExposedSnapHomeDir, snapName)
 		c.Assert(os.MkdirAll(exposedDir, 0700), IsNil)
-		c.Assert(ioutil.WriteFile(filepath.Join(exposedDir, "file"), []byte("foo"), 0700), IsNil)
+		c.Assert(os.WriteFile(filepath.Join(exposedDir, "file"), []byte("foo"), 0700), IsNil)
 		usrs = append(usrs, usr)
 		undoInfo.Created = append(undoInfo.Created, exposedDir)
 	}

--- a/overlord/snapstate/backend/link_test.go
+++ b/overlord/snapstate/backend/link_test.go
@@ -22,7 +22,6 @@ package backend_test
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -471,7 +470,7 @@ apps:
 
 	guiDir := filepath.Join(s.info.MountDir(), "meta", "gui")
 	c.Assert(os.MkdirAll(guiDir, 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(guiDir, "bin.desktop"), []byte(`
+	c.Assert(os.WriteFile(filepath.Join(guiDir, "bin.desktop"), []byte(`
 [Desktop Entry]
 Name=bin
 Icon=${SNAP}/bin.png

--- a/overlord/snapstate/catalogrefresh_test.go
+++ b/overlord/snapstate/catalogrefresh_test.go
@@ -22,7 +22,6 @@ package snapstate_test
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -174,7 +173,7 @@ func (s *catalogRefreshTestSuite) TestCatalogRefreshNotNeeded(c *C) {
 func (s *catalogRefreshTestSuite) TestCatalogRefreshNewEnough(c *C) {
 	// write a fake sections file just to have it
 	c.Assert(os.MkdirAll(filepath.Dir(dirs.SnapNamesFile), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(dirs.SnapNamesFile, nil, 0644), IsNil)
+	c.Assert(os.WriteFile(dirs.SnapNamesFile, nil, 0644), IsNil)
 	// set the timestamp to something known
 	t0 := time.Now().Truncate(time.Hour)
 	c.Assert(os.Chtimes(dirs.SnapNamesFile, t0, t0), IsNil)
@@ -195,7 +194,7 @@ func (s *catalogRefreshTestSuite) TestCatalogRefreshNewEnough(c *C) {
 func (s *catalogRefreshTestSuite) TestCatalogRefreshTooNew(c *C) {
 	// write a fake sections file just to have it
 	c.Assert(os.MkdirAll(filepath.Dir(dirs.SnapNamesFile), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(dirs.SnapNamesFile, nil, 0644), IsNil)
+	c.Assert(os.WriteFile(dirs.SnapNamesFile, nil, 0644), IsNil)
 	// but set the timestamp in the future
 	t := time.Now().Add(time.Hour)
 	c.Assert(os.Chtimes(dirs.SnapNamesFile, t, t), IsNil)

--- a/overlord/snapstate/cookies_test.go
+++ b/overlord/snapstate/cookies_test.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	. "gopkg.in/check.v1"
@@ -83,7 +84,7 @@ func (s *cookiesSuite) TestSyncCookies(c *C) {
 		"some-snap":  nil,
 		"other-snap": nil})
 	staleCookieFile := filepath.Join(dirs.SnapCookieDir, "snap.stale-cookie-snap")
-	c.Assert(ioutil.WriteFile(staleCookieFile, nil, 0644), IsNil)
+	c.Assert(os.WriteFile(staleCookieFile, nil, 0644), IsNil)
 	c.Assert(osutil.FileExists(staleCookieFile), Equals, true)
 
 	// some-snap doesn't have cookie
@@ -137,7 +138,7 @@ func (s *cookiesSuite) TestRemoveSnapCookie(c *C) {
 
 	cookieFile := filepath.Join(dirs.SnapCookieDir, "snap.bar")
 
-	c.Assert(ioutil.WriteFile(cookieFile, nil, 0644), IsNil)
+	c.Assert(os.WriteFile(cookieFile, nil, 0644), IsNil)
 
 	// remove should not fail if cookie is not there
 	c.Assert(s.snapmgr.removeSnapCookie(s.st, "bar"), IsNil)

--- a/overlord/snapstate/handlers_link_test.go
+++ b/overlord/snapstate/handlers_link_test.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -1644,7 +1645,7 @@ func (s *linkSnapSuite) TestLinkSnapInjectsAutoConnectIfMissing(c *C) {
 
 func (s *linkSnapSuite) TestDoLinkSnapFailureCleansUpAux(c *C) {
 	// this is very chummy with the order of LinkSnap
-	c.Assert(ioutil.WriteFile(dirs.SnapSeqDir, nil, 0644), IsNil)
+	c.Assert(os.WriteFile(dirs.SnapSeqDir, nil, 0644), IsNil)
 
 	// we start without the auxiliary store info
 	c.Check(snapstate.AuxStoreInfoFilename("foo-id"), testutil.FileAbsent)

--- a/overlord/snapstate/readme_test.go
+++ b/overlord/snapstate/readme_test.go
@@ -20,7 +20,6 @@
 package snapstate_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -69,7 +68,7 @@ func (s *readmeSuite) TestWriteSnapREADME(c *C) {
 	// Corrupted file is cured.
 	err := os.Remove(f)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(f, []byte("corrupted"), 0644)
+	err = os.WriteFile(f, []byte("corrupted"), 0644)
 	c.Assert(err, IsNil)
 	c.Assert(snapstate.WriteSnapReadme(), IsNil)
 	c.Check(f, testutil.FileContains, "https://forum.snapcraft.io/t/the-snap-directory/2817")

--- a/overlord/snapstate/refresh_test.go
+++ b/overlord/snapstate/refresh_test.go
@@ -20,7 +20,6 @@
 package snapstate_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -130,7 +129,7 @@ func (s *refreshSuite) TestPendingSnapRefreshInfo(c *C) {
 	err = snapstate.NewBusySnapError(s.info, nil, []string{"app"}, nil)
 	desktopFile := s.info.Apps["app"].DesktopFile()
 	c.Assert(os.MkdirAll(filepath.Dir(desktopFile), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(desktopFile, nil, 0644), IsNil)
+	c.Assert(os.WriteFile(desktopFile, nil, 0644), IsNil)
 	refreshInfo = err.PendingSnapRefreshInfo()
 	c.Check(refreshInfo.InstanceName, Equals, s.info.InstanceName())
 	c.Check(refreshInfo.BusyAppName, Equals, "app")

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -4116,7 +4115,7 @@ volumes:
 `)
 
 	info := snaptest.MockSnap(c, mockGadgetSnapYaml, &snap.SideInfo{Revision: snap.R(2)})
-	err := ioutil.WriteFile(filepath.Join(info.MountDir(), "meta", "gadget.yaml"), mockGadgetYaml, 0644)
+	err := os.WriteFile(filepath.Join(info.MountDir(), "meta", "gadget.yaml"), mockGadgetYaml, 0644)
 	c.Assert(err, IsNil)
 
 	gi, err := gadget.ReadInfo(info.MountDir(), nil)
@@ -5522,7 +5521,7 @@ version: 1
 	c.Assert(os.Chmod(dstDir, 0700), IsNil)
 
 	c.Assert(os.Mkdir(filepath.Join(dstDir, "meta"), 0700), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(dstDir, "meta", "snap.yaml"), yaml, 0700), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dstDir, "meta", "snap.yaml"), yaml, 0700), IsNil)
 
 	// snapdir has /meta/snap.yaml, but / is 0700
 	brokenSnap := filepath.Join(c.MkDir(), "broken.snap")

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -24,7 +24,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -308,7 +307,7 @@ SNAPD_APPARMOR_REEXEC=1
 			infoFile := filepath.Join(dirs.SnapMountDir, snapName, rev, dirs.CoreLibExecDir, "info")
 			err = os.MkdirAll(filepath.Dir(infoFile), 0755)
 			c.Assert(err, IsNil)
-			err = ioutil.WriteFile(infoFile, []byte(defaultInfoFile), 0644)
+			err = os.WriteFile(infoFile, []byte(defaultInfoFile), 0644)
 			c.Assert(err, IsNil)
 		}
 	}
@@ -3529,21 +3528,21 @@ SNAPD_APPARMOR_REEXEC=1
 	infoFile := filepath.Join(dirs.SnapMountDir, snapName, "1", dirs.CoreLibExecDir, "info")
 	err := os.MkdirAll(filepath.Dir(infoFile), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(infoFile, []byte(vulnInfoFile), 0644)
+	err = os.WriteFile(infoFile, []byte(vulnInfoFile), 0644)
 	c.Assert(err, IsNil)
 
 	// revision 2 fixed
 	infoFile2 := filepath.Join(dirs.SnapMountDir, snapName, "2", dirs.CoreLibExecDir, "info")
 	err = os.MkdirAll(filepath.Dir(infoFile2), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(infoFile2, []byte(fixedInfoFile), 0644)
+	err = os.WriteFile(infoFile2, []byte(fixedInfoFile), 0644)
 	c.Assert(err, IsNil)
 
 	// revision 11 fixed
 	infoFile11 := filepath.Join(dirs.SnapMountDir, snapName, "11", dirs.CoreLibExecDir, "info")
 	err = os.MkdirAll(filepath.Dir(infoFile11), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(infoFile11, []byte(fixedInfoFile), 0644)
+	err = os.WriteFile(infoFile11, []byte(fixedInfoFile), 0644)
 	c.Assert(err, IsNil)
 
 	// use generic classic model
@@ -3766,9 +3765,9 @@ func (s *snapmgrTestSuite) TestEsnureCleansOldSideloads(c *C) {
 	s1 := filepath.Join(dirs.SnapBlobDir, dirs.LocalInstallBlobTempPrefix+"-12345")
 	s2 := filepath.Join(dirs.SnapBlobDir, dirs.LocalInstallBlobTempPrefix+"-67890")
 
-	c.Assert(ioutil.WriteFile(s0, nil, 0600), IsNil)
-	c.Assert(ioutil.WriteFile(s1, nil, 0600), IsNil)
-	c.Assert(ioutil.WriteFile(s2, nil, 0600), IsNil)
+	c.Assert(os.WriteFile(s0, nil, 0600), IsNil)
+	c.Assert(os.WriteFile(s1, nil, 0600), IsNil)
+	c.Assert(os.WriteFile(s2, nil, 0600), IsNil)
 
 	t1 := time.Now()
 	t0 := t1.Add(-time.Hour)
@@ -5365,7 +5364,7 @@ version: 1.0
 `, gadgetSideInfo)
 
 	gadgetYamlWhole := strings.Join(append([]string{gadgetYaml}, extraGadgetYaml...), "")
-	err := ioutil.WriteFile(filepath.Join(gadgetInfo.MountDir(), "meta/gadget.yaml"), []byte(gadgetYamlWhole), 0600)
+	err := os.WriteFile(filepath.Join(gadgetInfo.MountDir(), "meta/gadget.yaml"), []byte(gadgetYamlWhole), 0600)
 	c.Assert(err, IsNil)
 
 	snapstate.Set(s.state, "the-gadget", &snapstate.SnapState{
@@ -8825,7 +8824,7 @@ WantedBy=snapd.mounts.target
 WantedBy=multi-user.target
 `[1:], what, dirs.SnapMountDir)
 	os.MkdirAll(dirs.SnapServicesDir, 0755)
-	err := ioutil.WriteFile(mountFile, []byte(mountContent), 0644)
+	err := os.WriteFile(mountFile, []byte(mountContent), 0644)
 	c.Assert(err, IsNil)
 
 	s.reloadOrRestarts[unitName] = 0
@@ -8902,7 +8901,7 @@ WantedBy=snapd.mounts.target
 WantedBy=multi-user.target
 `[1:], what, dirs.StripRootDir(dirs.SnapMountDir))
 	os.MkdirAll(dirs.SnapServicesDir, 0755)
-	err := ioutil.WriteFile(mountFile, []byte(mountContent), 0644)
+	err := os.WriteFile(mountFile, []byte(mountContent), 0644)
 	c.Assert(err, IsNil)
 
 	s.reloadOrRestarts[unitName] = 0

--- a/overlord/snapstate/snapstate_try_test.go
+++ b/overlord/snapstate/snapstate_try_test.go
@@ -21,7 +21,6 @@ package snapstate_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -64,7 +63,7 @@ func (s *snapmgrTestSuite) testTrySetsTryMode(flags snapstate.Flags, c *C, extra
 			buf.WriteString(extra)
 		}
 	}
-	err = ioutil.WriteFile(tryYaml, buf.Bytes(), 0644)
+	err = os.WriteFile(tryYaml, buf.Bytes(), 0644)
 	c.Assert(err, IsNil)
 
 	chg := s.state.NewChange("try", "try snap")

--- a/overlord/state/copy_test.go
+++ b/overlord/state/copy_test.go
@@ -21,6 +21,7 @@ package state_test
 
 import (
 	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	. "gopkg.in/check.v1"
@@ -32,7 +33,7 @@ func (ss *stateSuite) TestCopyStateAlreadyExists(c *C) {
 	srcStateFile := filepath.Join(c.MkDir(), "src-state.json")
 
 	dstStateFile := filepath.Join(c.MkDir(), "dst-state.json")
-	err := ioutil.WriteFile(dstStateFile, nil, 0644)
+	err := os.WriteFile(dstStateFile, nil, 0644)
 	c.Assert(err, IsNil)
 
 	err = state.CopyState(srcStateFile, dstStateFile, []string{"some-data"})
@@ -84,7 +85,7 @@ const stateSuffix = `,"changes":{},"tasks":{},"last-change-id":0,"last-task-id":
 func (ss *stateSuite) TestCopyStateIntegration(c *C) {
 	// create a mock srcState
 	srcStateFile := filepath.Join(c.MkDir(), "src-state.json")
-	err := ioutil.WriteFile(srcStateFile, srcStateContent, 0644)
+	err := os.WriteFile(srcStateFile, srcStateContent, 0644)
 	c.Assert(err, IsNil)
 
 	// copy
@@ -109,7 +110,7 @@ var srcStateContent1 = []byte(`{
 
 func (ss *stateSuite) TestCopyState(c *C) {
 	srcStateFile := filepath.Join(c.MkDir(), "src-state.json")
-	err := ioutil.WriteFile(srcStateFile, srcStateContent1, 0644)
+	err := os.WriteFile(srcStateFile, srcStateContent1, 0644)
 	c.Assert(err, IsNil)
 
 	dstStateFile := filepath.Join(c.MkDir(), "dst-state.json")
@@ -123,7 +124,7 @@ func (ss *stateSuite) TestCopyState(c *C) {
 
 func (ss *stateSuite) TestCopyStateUnmarshalNotMap(c *C) {
 	srcStateFile := filepath.Join(c.MkDir(), "src-state.json")
-	err := ioutil.WriteFile(srcStateFile, srcStateContent1, 0644)
+	err := os.WriteFile(srcStateFile, srcStateContent1, 0644)
 	c.Assert(err, IsNil)
 
 	dstStateFile := filepath.Join(c.MkDir(), "dst-state.json")
@@ -133,7 +134,7 @@ func (ss *stateSuite) TestCopyStateUnmarshalNotMap(c *C) {
 
 func (ss *stateSuite) TestCopyStateDuplicatesInDataEntriesAreFine(c *C) {
 	srcStateFile := filepath.Join(c.MkDir(), "src-state.json")
-	err := ioutil.WriteFile(srcStateFile, srcStateContent1, 0644)
+	err := os.WriteFile(srcStateFile, srcStateContent1, 0644)
 	c.Assert(err, IsNil)
 
 	dstStateFile := filepath.Join(c.MkDir(), "dst-state.json")

--- a/packaging/debian-sid/patches/0007-i18n-use-dummy-localizations-to-avoid-dependencies.patch
+++ b/packaging/debian-sid/patches/0007-i18n-use-dummy-localizations-to-avoid-dependencies.patch
@@ -184,7 +184,7 @@ index 81cb050a76b824d1b83e97e02c08628520329d96..86b59f3b439e9c27d37cfb35e21d8472
 -
 -	po := filepath.Join(fullLocaleDir, "snappy-test.po")
 -	mo := filepath.Join(fullLocaleDir, "snappy-test.mo")
--	err = ioutil.WriteFile(po, mockLocalePo, 0644)
+-	err = os.WriteFile(po, mockLocalePo, 0644)
 -	c.Assert(err, IsNil)
 -
 -	cmd := exec.Command("msgfmt", po, "--output-file", mo)

--- a/polkit/pid_start_time_test.go
+++ b/polkit/pid_start_time_test.go
@@ -22,7 +22,6 @@
 package polkit
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -63,7 +62,7 @@ func (s *polkitSuite) TestGetStartTimeBadPid(c *check.C) {
 func (s *polkitSuite) TestProcStatParsing(c *check.C) {
 	filename := filepath.Join(c.MkDir(), "stat")
 	contents := []byte("18433 (cat) R 9732 18433 9732 34818 18433 4194304 96 0 1 0 0 0 0 0 20 0 1 0 123104764 7602176 182 18446744073709551615 94902526107648 94902526138492 140734457666896 0 0 0 0 0 0 0 0 0 17 5 0 0 0 0 0 94902528236168 94902528237760 94902542680064 140734457672267 140734457672287 140734457672287 140734457675759 0")
-	err := ioutil.WriteFile(filename, contents, 0644)
+	err := os.WriteFile(filename, contents, 0644)
 	c.Assert(err, check.IsNil)
 
 	startTime, err := getStartTimeForProcStatFile(filename)

--- a/randutil/crypto_test.go
+++ b/randutil/crypto_test.go
@@ -21,7 +21,6 @@ package randutil_test
 
 import (
 	"encoding/base64"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -72,7 +71,7 @@ func (s *cryptoRandutilSuite) TestRandomKernelUUIDNoPerm(c *C) {
 	uuidPath := filepath.Join(c.MkDir(), "no-perm")
 	defer randutil.MockKernelUUIDPath(uuidPath)()
 
-	err := ioutil.WriteFile(uuidPath, []byte(kernelTestUUID), 0)
+	err := os.WriteFile(uuidPath, []byte(kernelTestUUID), 0)
 	c.Assert(err, IsNil)
 
 	value, err := randutil.RandomKernelUUID()
@@ -92,7 +91,7 @@ func (s *cryptoRandutilSuite) TestRandomKernelUUID(c *C) {
 		uuidPath := filepath.Join(c.MkDir(), "uuid")
 		defer randutil.MockKernelUUIDPath(uuidPath)()
 
-		err := ioutil.WriteFile(uuidPath, []byte(uuid), 0444)
+		err := os.WriteFile(uuidPath, []byte(uuid), 0444)
 		c.Assert(err, IsNil)
 
 		value, err := randutil.RandomKernelUUID()

--- a/release/release_test.go
+++ b/release/release_test.go
@@ -22,6 +22,7 @@ package release_test
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -59,7 +60,7 @@ HOME_URL="http://www.ubuntu.com/"
 SUPPORT_URL="http://help.ubuntu.com/"
 BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"
 `
-	err := ioutil.WriteFile(mockOSRelease, []byte(s), 0644)
+	err := os.WriteFile(mockOSRelease, []byte(s), 0644)
 	c.Assert(err, IsNil)
 
 	return mockOSRelease
@@ -128,7 +129,7 @@ VERSION_ID="0.4"
 HOME_URL="http://elementary.io/"
 SUPPORT_URL="http://elementary.io/support/"
 BUG_REPORT_URL="https://bugs.launchpad.net/elementary/+filebug"`
-	err := ioutil.WriteFile(mockOSRelease, []byte(dump), 0644)
+	err := os.WriteFile(mockOSRelease, []byte(dump), 0644)
 	c.Assert(err, IsNil)
 
 	reset := release.MockOSReleasePath(mockOSRelease)
@@ -156,7 +157,7 @@ CENTOS_MANTISBT_PROJECT="CentOS-7"
 CENTOS_MANTISBT_PROJECT_VERSION="7"
 REDHAT_SUPPORT_PRODUCT="centos"
 REDHAT_SUPPORT_PRODUCT_VERSION="7"`
-	err := ioutil.WriteFile(mockOSRelease, []byte(dump), 0644)
+	err := os.WriteFile(mockOSRelease, []byte(dump), 0644)
 	c.Assert(err, IsNil)
 
 	reset := release.MockOSReleasePath(mockOSRelease)
@@ -176,7 +177,7 @@ ID="ubuntu-core"
 VARIANT_ID="desktop"
 VERSION_ID="22"
 "`
-	err := ioutil.WriteFile(mockOSRelease, []byte(dump), 0644)
+	err := os.WriteFile(mockOSRelease, []byte(dump), 0644)
 	c.Assert(err, IsNil)
 
 	reset := release.MockOSReleasePath(mockOSRelease)

--- a/sandbox/apparmor/apparmor_test.go
+++ b/sandbox/apparmor/apparmor_test.go
@@ -85,7 +85,7 @@ func (*apparmorSuite) TestAppArmorInternalAppArmorParser(c *C) {
 	d := filepath.Join(dirs.SnapMountDir, "/snapd/42", "/usr/lib/snapd")
 	c.Assert(os.MkdirAll(d, 0755), IsNil)
 	p := filepath.Join(d, "apparmor_parser")
-	c.Assert(ioutil.WriteFile(p, nil, 0755), IsNil)
+	c.Assert(os.WriteFile(p, nil, 0755), IsNil)
 	restore := snapdtool.MockOsReadlink(func(path string) (string, error) {
 		c.Assert(path, Equals, "/proc/self/exe")
 		return filepath.Join(d, "snapd"), nil
@@ -277,7 +277,7 @@ func (s *apparmorSuite) TestProbeAppArmorParserFeatures(c *C) {
 		}
 		// probeParserFeatures() sorts the features
 		sort.Strings(expFeatures)
-		err := ioutil.WriteFile(filepath.Join(d, "codes"), []byte(contents), 0755)
+		err := os.WriteFile(filepath.Join(d, "codes"), []byte(contents), 0755)
 		c.Assert(err, IsNil)
 		mockParserCmd := testutil.MockCommand(c, "apparmor_parser", fmt.Sprintf(`
 cat >> %[1]s/stdin
@@ -344,7 +344,7 @@ profile snap-test {
 	d := filepath.Join(dirs.SnapMountDir, "/snapd/42", "/usr/lib/snapd")
 	c.Assert(os.MkdirAll(d, 0755), IsNil)
 	p := filepath.Join(d, "apparmor_parser")
-	c.Assert(ioutil.WriteFile(p, nil, 0755), IsNil)
+	c.Assert(os.WriteFile(p, nil, 0755), IsNil)
 	restore = snapdtool.MockOsReadlink(func(path string) (string, error) {
 		c.Assert(path, Equals, "/proc/self/exe")
 		return filepath.Join(d, "snapd"), nil
@@ -506,13 +506,13 @@ func (s *apparmorSuite) TestSnapdAppArmorSupportsReexecImpl(c *C) {
 	d := filepath.Join(dirs.GlobalRootDir, dirs.CoreLibExecDir)
 	c.Assert(os.MkdirAll(d, 0755), IsNil)
 	infoFile := filepath.Join(d, "info")
-	c.Assert(ioutil.WriteFile(infoFile, []byte("VERSION=foo"), 0644), IsNil)
+	c.Assert(os.WriteFile(infoFile, []byte("VERSION=foo"), 0644), IsNil)
 	c.Check(apparmor.SnapdAppArmorSupportsRexecImpl(), Equals, false)
-	c.Assert(ioutil.WriteFile(infoFile, []byte("VERSION=foo\nSNAPD_APPARMOR_REEXEC=0"), 0644), IsNil)
+	c.Assert(os.WriteFile(infoFile, []byte("VERSION=foo\nSNAPD_APPARMOR_REEXEC=0"), 0644), IsNil)
 	c.Check(apparmor.SnapdAppArmorSupportsRexecImpl(), Equals, false)
-	c.Assert(ioutil.WriteFile(infoFile, []byte("VERSION=foo\nSNAPD_APPARMOR_REEXEC=foo"), 0644), IsNil)
+	c.Assert(os.WriteFile(infoFile, []byte("VERSION=foo\nSNAPD_APPARMOR_REEXEC=foo"), 0644), IsNil)
 	c.Check(apparmor.SnapdAppArmorSupportsRexecImpl(), Equals, false)
-	c.Assert(ioutil.WriteFile(infoFile, []byte("VERSION=foo\nSNAPD_APPARMOR_REEXEC=1"), 0644), IsNil)
+	c.Assert(os.WriteFile(infoFile, []byte("VERSION=foo\nSNAPD_APPARMOR_REEXEC=1"), 0644), IsNil)
 	c.Check(apparmor.SnapdAppArmorSupportsRexecImpl(), Equals, true)
 }
 
@@ -528,7 +528,7 @@ func (s *apparmorSuite) TestSetupConfCacheDirsWithInternalApparmor(c *C) {
 	d := filepath.Join(dirs.SnapMountDir, "/snapd/42", "/usr/lib/snapd")
 	c.Assert(os.MkdirAll(d, 0755), IsNil)
 	p := filepath.Join(d, "apparmor_parser")
-	c.Assert(ioutil.WriteFile(p, nil, 0755), IsNil)
+	c.Assert(os.WriteFile(p, nil, 0755), IsNil)
 	restore := snapdtool.MockOsReadlink(func(path string) (string, error) {
 		c.Assert(path, Equals, "/proc/self/exe")
 		return filepath.Join(d, "snapd"), nil
@@ -563,7 +563,7 @@ func (s *apparmorSuite) TestSystemAppArmorLoadsSnapPolicyErr(c *C) {
 		return
 	}
 	// log generated for errors
-	err = ioutil.WriteFile(fakeApparmorFunctionsPath, nil, 0100)
+	err = os.WriteFile(fakeApparmorFunctionsPath, nil, 0100)
 	c.Assert(err, IsNil)
 	c.Check(apparmor.SystemAppArmorLoadsSnapPolicy(), Equals, false)
 	c.Check(log.String(), Matches, `(?ms).* DEBUG: cannot open apparmor functions file: open .*/lib/apparmor/functions: permission denied`)
@@ -592,7 +592,7 @@ func (s *apparmorSuite) TestSystemAppArmorLoadsSnapPolicy(c *C) {
 		// 18.04
 		{`PROFILES_VAR="/var/lib/snapd/apparmor/profiles"`, true},
 	} {
-		err := ioutil.WriteFile(fakeApparmorFunctionsPath, []byte(tc.apparmorFunctionsContent), 0644)
+		err := os.WriteFile(fakeApparmorFunctionsPath, []byte(tc.apparmorFunctionsContent), 0644)
 		c.Assert(err, IsNil)
 
 		loadsPolicy := apparmor.SystemAppArmorLoadsSnapPolicy()

--- a/sandbox/apparmor/process_test.go
+++ b/sandbox/apparmor/process_test.go
@@ -20,7 +20,6 @@
 package apparmor_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -65,11 +64,11 @@ func (s *apparmorSuite) TestSnapAppFromPidNewKernelPath(c *C) {
 	// when the new file exists we use that one
 	newProcFile := filepath.Join(d, "proc/42/attr/apparmor/current")
 	c.Assert(os.MkdirAll(filepath.Dir(newProcFile), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(newProcFile, []byte("snap.foo.app"), 0644), IsNil)
+	c.Assert(os.WriteFile(newProcFile, []byte("snap.foo.app"), 0644), IsNil)
 
 	oldProcFile := filepath.Join(d, "proc/42/attr/current")
 	c.Assert(os.MkdirAll(filepath.Dir(oldProcFile), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(oldProcFile, []byte("random-other-unread-data"), 0644), IsNil)
+	c.Assert(os.WriteFile(oldProcFile, []byte("random-other-unread-data"), 0644), IsNil)
 
 	name, app, hook, err := apparmor.SnapAppFromPid(42)
 	c.Assert(err, IsNil)
@@ -90,7 +89,7 @@ func (s *apparmorSuite) TestSnapAppFromPid(c *C) {
 	procFile := filepath.Join(d, "proc/42/attr/current")
 	c.Assert(os.MkdirAll(filepath.Dir(procFile), 0755), IsNil)
 
-	c.Assert(ioutil.WriteFile(procFile, []byte("not-read"), 0000), IsNil)
+	c.Assert(os.WriteFile(procFile, []byte("not-read"), 0000), IsNil)
 	_, _, _, err = apparmor.SnapAppFromPid(42)
 	c.Check(err, ErrorMatches, `open .*/proc/42/attr/current: permission denied`)
 	c.Assert(os.Remove(procFile), IsNil)
@@ -120,7 +119,7 @@ func (s *apparmorSuite) TestSnapAppFromPid(c *C) {
 		contents: "snap.foo.hook.app.garbage\n",
 		err:      `unknown snap related security label "snap.foo.hook.app.garbage"`,
 	}} {
-		c.Assert(ioutil.WriteFile(procFile, []byte(t.contents), 0644), IsNil)
+		c.Assert(os.WriteFile(procFile, []byte(t.contents), 0644), IsNil)
 		name, app, hook, err := apparmor.SnapAppFromPid(42)
 		if t.err != "" {
 			c.Check(err, ErrorMatches, t.err)

--- a/sandbox/apparmor/profile_test.go
+++ b/sandbox/apparmor/profile_test.go
@@ -156,7 +156,7 @@ func (s *appArmorSuite) TestRemoveCachedProfiles(c *C) {
 	c.Assert(err, IsNil)
 
 	fname := filepath.Join(apparmor.CacheDir, "profile")
-	ioutil.WriteFile(fname, []byte("blob"), 0600)
+	os.WriteFile(fname, []byte("blob"), 0600)
 	err = apparmor.RemoveCachedProfiles([]string{"profile"}, apparmor.CacheDir)
 	c.Assert(err, IsNil)
 	_, err = os.Stat(fname)
@@ -178,10 +178,10 @@ func (s *appArmorSuite) TestRemoveCachedProfilesInForest(c *C) {
 	err = os.MkdirAll(subdir, 0700)
 	c.Assert(err, IsNil)
 	features := filepath.Join(subdir, ".features")
-	ioutil.WriteFile(features, []byte("blob"), 0644)
+	os.WriteFile(features, []byte("blob"), 0644)
 
 	fname := filepath.Join(subdir, "profile")
-	ioutil.WriteFile(fname, []byte("blob"), 0600)
+	os.WriteFile(fname, []byte("blob"), 0600)
 	err = apparmor.RemoveCachedProfiles([]string{"profile"}, apparmor.CacheDir)
 	c.Assert(err, IsNil)
 	_, err = os.Stat(fname)
@@ -272,14 +272,14 @@ func (s *appArmorSuite) TestLoadedApparmorProfilesReturnsErrorOnMissingFile(c *C
 }
 
 func (s *appArmorSuite) TestLoadedApparmorProfilesCanParseEmptyFile(c *C) {
-	ioutil.WriteFile(s.profilesFilename, []byte(""), 0600)
+	os.WriteFile(s.profilesFilename, []byte(""), 0600)
 	profiles, err := apparmor.LoadedProfiles()
 	c.Assert(err, IsNil)
 	c.Check(profiles, HasLen, 0)
 }
 
 func (s *appArmorSuite) TestLoadedApparmorProfilesParsesAndFiltersData(c *C) {
-	ioutil.WriteFile(s.profilesFilename, []byte(
+	os.WriteFile(s.profilesFilename, []byte(
 		// The output contains some of the snappy-specific elements
 		// and some non-snappy elements pulled from Ubuntu 16.04 desktop
 		//
@@ -310,11 +310,11 @@ webbrowser-app//oxide_helper (enforce)
 }
 
 func (s *appArmorSuite) TestLoadedApparmorProfilesHandlesParsingErrors(c *C) {
-	ioutil.WriteFile(s.profilesFilename, []byte("broken stuff here\n"), 0600)
+	os.WriteFile(s.profilesFilename, []byte("broken stuff here\n"), 0600)
 	profiles, err := apparmor.LoadedProfiles()
 	c.Assert(err, ErrorMatches, "newline in format does not match input")
 	c.Check(profiles, IsNil)
-	ioutil.WriteFile(s.profilesFilename, []byte("truncated"), 0600)
+	os.WriteFile(s.profilesFilename, []byte("truncated"), 0600)
 	profiles, err = apparmor.LoadedProfiles()
 	c.Assert(err, ErrorMatches, `syntax error, expected: name \(mode\)`)
 	c.Check(profiles, IsNil)
@@ -365,7 +365,7 @@ func (s *appArmorSuite) TestSnapConfineDistroProfilePath(c *C) {
 			fullPath := filepath.Join(baseDir, path)
 			err := os.MkdirAll(filepath.Dir(fullPath), 0755)
 			c.Assert(err, IsNil)
-			err = ioutil.WriteFile(fullPath, []byte("I'm an ELF binary"), 0755)
+			err = os.WriteFile(fullPath, []byte("I'm an ELF binary"), 0755)
 			c.Assert(err, IsNil)
 		}
 		var expectedPath string
@@ -405,7 +405,7 @@ func (s *appArmorSuite) writeSystemParams(c *C, homedirs []string) {
 	conents := fmt.Sprintf("homedirs=%s\n", strings.Join(homedirs, ","))
 
 	c.Assert(os.MkdirAll(path.Dir(sspPath), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(sspPath, []byte(conents), 0644), IsNil)
+	c.Assert(os.WriteFile(sspPath, []byte(conents), 0644), IsNil)
 }
 
 func (s *appArmorSuite) TestSetupSnapConfineSnippetsHomedirs(c *C) {
@@ -637,7 +637,7 @@ func (s *appArmorSuite) TestSetupSnapConfineGeneratedPolicyError2(c *C) {
 	c.Assert(err, IsNil)
 	err = os.MkdirAll(filepath.Dir(apparmor.SnapConfineAppArmorDir), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(apparmor.SnapConfineAppArmorDir, []byte(""), 0644)
+	err = os.WriteFile(apparmor.SnapConfineAppArmorDir, []byte(""), 0644)
 	c.Assert(err, IsNil)
 
 	wasChanged, err := apparmor.SetupSnapConfineSnippets()
@@ -669,7 +669,7 @@ func (s *appArmorSuite) TestSetupSnapConfineGeneratedPolicyError3(c *C) {
 	err := os.MkdirAll(apparmor.SnapConfineAppArmorDir, 0755)
 	c.Assert(err, IsNil)
 	f := filepath.Join(apparmor.SnapConfineAppArmorDir, "generated-test")
-	err = ioutil.WriteFile(f, []byte("spurious content"), 0644)
+	err = os.WriteFile(f, []byte("spurious content"), 0644)
 	c.Assert(err, IsNil)
 	err = os.Chmod(apparmor.SnapConfineAppArmorDir, 0555)
 	c.Assert(err, IsNil)
@@ -694,8 +694,8 @@ func (s *appArmorSuite) TestRemoveSnapConfineSnippets(c *C) {
 	// Create the snap-confine directory and put a few files.
 	err := os.MkdirAll(apparmor.SnapConfineAppArmorDir, 0755)
 	c.Assert(err, IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(apparmor.SnapConfineAppArmorDir, "cap-test"), []byte("foo"), 0644), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(apparmor.SnapConfineAppArmorDir, "my-file"), []byte("foo"), 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(apparmor.SnapConfineAppArmorDir, "cap-test"), []byte("foo"), 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(apparmor.SnapConfineAppArmorDir, "my-file"), []byte("foo"), 0644), IsNil)
 
 	err = apparmor.RemoveSnapConfineSnippets()
 	c.Check(err, IsNil)

--- a/sandbox/cgroup/cgroup_test.go
+++ b/sandbox/cgroup/cgroup_test.go
@@ -20,7 +20,6 @@ package cgroup_test
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -147,7 +146,7 @@ var mockCgroup = []byte(`
 func (s *cgroupSuite) TestProgGroupHappy(c *C) {
 	err := os.MkdirAll(filepath.Join(s.rootDir, "proc/333"), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(s.rootDir, "proc/333/cgroup"), mockCgroup, 0755)
+	err = os.WriteFile(filepath.Join(s.rootDir, "proc/333/cgroup"), mockCgroup, 0755)
 	c.Assert(err, IsNil)
 
 	group, err := cgroup.ProcGroup(333, cgroup.MatchV1Controller("freezer"))
@@ -187,7 +186,7 @@ func (s *cgroupSuite) TestProgGroupMissingGroup(c *C) {
 
 	err := os.MkdirAll(filepath.Join(s.rootDir, "proc/333"), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(s.rootDir, "proc/333/cgroup"), noFreezerCgroup, 0755)
+	err = os.WriteFile(filepath.Join(s.rootDir, "proc/333/cgroup"), noFreezerCgroup, 0755)
 	c.Assert(err, IsNil)
 
 	group, err := cgroup.ProcGroup(333, cgroup.MatchV1Controller("freezer"))
@@ -211,7 +210,7 @@ var mockCgroupConfusingCpu = []byte(`
 func (s *cgroupSuite) TestProgGroupConfusingCpu(c *C) {
 	err := os.MkdirAll(filepath.Join(s.rootDir, "proc/333"), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(s.rootDir, "proc/333/cgroup"), mockCgroupConfusingCpu, 0755)
+	err = os.WriteFile(filepath.Join(s.rootDir, "proc/333/cgroup"), mockCgroupConfusingCpu, 0755)
 	c.Assert(err, IsNil)
 
 	group, err := cgroup.ProcGroup(333, cgroup.MatchV1Controller("cpu"))
@@ -273,7 +272,7 @@ func (s *cgroupSuite) TestProcessPathInTrackingCgroup(c *C) {
 	} {
 		restoreCGVersion := cgroup.MockVersion(scenario.cgVersion, nil)
 
-		c.Assert(ioutil.WriteFile(f, []byte(scenario.cgroups), 0644), IsNil)
+		c.Assert(os.WriteFile(f, []byte(scenario.cgroups), 0644), IsNil)
 		path, err := cgroup.ProcessPathInTrackingCgroup(1234)
 		if scenario.errMsg != "" {
 			c.Assert(err, ErrorMatches, scenario.errMsg)
@@ -300,7 +299,7 @@ func (s *cgroupSuite) TestProcessPathInTrackingCgroupV2SpecialCase(c *C) {
 	f := filepath.Join(d, "proc", "1234", "cgroup")
 	c.Assert(os.MkdirAll(filepath.Dir(f), 0755), IsNil)
 
-	c.Assert(ioutil.WriteFile(f, []byte(text), 0644), IsNil)
+	c.Assert(os.WriteFile(f, []byte(text), 0644), IsNil)
 	path, err := cgroup.ProcessPathInTrackingCgroup(1234)
 	c.Assert(err, IsNil)
 	// Because v2 is not really mounted, we ignore the entry 0::/

--- a/sandbox/cgroup/freezer.go
+++ b/sandbox/cgroup/freezer.go
@@ -85,7 +85,7 @@ var ThawSnapProcesses = thawSnapProcessesImplV1
 // originate from.
 func freezeSnapProcessesImplV1(snapName string) error {
 	fname := filepath.Join(freezerCgroupV1Dir, fmt.Sprintf("snap.%s", snapName), "freezer.state")
-	if err := ioutil.WriteFile(fname, []byte("FROZEN"), 0644); err != nil && os.IsNotExist(err) {
+	if err := os.WriteFile(fname, []byte("FROZEN"), 0644); err != nil && os.IsNotExist(err) {
 		// When there's no freezer cgroup we don't have to freeze anything.
 		// This can happen when no process belonging to a given snap has been
 		// started yet.
@@ -112,7 +112,7 @@ func freezeSnapProcessesImplV1(snapName string) error {
 
 func thawSnapProcessesImplV1(snapName string) error {
 	fname := filepath.Join(freezerCgroupV1Dir, fmt.Sprintf("snap.%s", snapName), "freezer.state")
-	if err := ioutil.WriteFile(fname, []byte("THAWED"), 0644); err != nil && os.IsNotExist(err) {
+	if err := os.WriteFile(fname, []byte("THAWED"), 0644); err != nil && os.IsNotExist(err) {
 		// When there's no freezer cgroup we don't have to thaw anything.
 		// This can happen when no process belonging to a given snap has been
 		// started yet.
@@ -163,7 +163,7 @@ func applyToSnap(snapName string, action func(groupName string) error, skipError
 	})
 }
 
-// writeExistingFile can be used as a drop-in replacement for ioutil.WriteFile,
+// writeExistingFile can be used as a drop-in replacement for os.WriteFile,
 // but does not create a file when it does not exist
 func writeExistingFile(where string, data []byte, mode os.FileMode) error {
 	f, err := os.OpenFile(where, os.O_WRONLY|os.O_TRUNC, mode)

--- a/sandbox/cgroup/freezer_test.go
+++ b/sandbox/cgroup/freezer_test.go
@@ -21,7 +21,6 @@ package cgroup_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -135,7 +134,7 @@ func (s *freezerV2Suite) TestFreezeSnapProcessesV2OtherGroups(c *C) {
 
 	procPidCgroup := filepath.Join(dirs.GlobalRootDir, fmt.Sprintf("proc/%v/cgroup", pid))
 	c.Assert(os.MkdirAll(filepath.Dir(procPidCgroup), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(procPidCgroup, []byte("0::/foo/bar"), 0755), IsNil)
+	c.Assert(os.WriteFile(procPidCgroup, []byte("0::/foo/bar"), 0755), IsNil)
 
 	// When the freezer cgroup filesystem doesn't exist we do nothing at all.
 	c.Assert(cgroup.FreezeSnapProcesses("foo"), IsNil)
@@ -154,7 +153,7 @@ func (s *freezerV2Suite) TestFreezeSnapProcessesV2OtherGroups(c *C) {
 		canaryOther, canarySubgroup, canaryUserSocket, canaryServiceSocket, canaryMount, canarySlice,
 	} {
 		c.Assert(os.MkdirAll(filepath.Dir(p), 0755), IsNil)
-		c.Assert(ioutil.WriteFile(p, []byte("0"), 0644), IsNil)
+		c.Assert(os.WriteFile(p, []byte("0"), 0644), IsNil)
 	}
 
 	c.Assert(cgroup.FreezeSnapProcesses("foo"), IsNil)
@@ -182,7 +181,7 @@ func (s *freezerV2Suite) TestFreezeSnapProcessesV2OtherGroups(c *C) {
 
 	// unfreeze some groups
 	for _, p := range []string{g2, g3} {
-		c.Assert(ioutil.WriteFile(p, []byte("0"), 0644), IsNil)
+		c.Assert(os.WriteFile(p, []byte("0"), 0644), IsNil)
 	}
 	c.Assert(cgroup.FreezeSnapProcesses("foo"), IsNil)
 	// all are frozen again
@@ -218,11 +217,11 @@ func (s *freezerV2Suite) TestFreezeSnapProcessesV2OwnGroup(c *C) {
 	procPidCgroup := filepath.Join(dirs.GlobalRootDir, fmt.Sprintf("proc/%v/cgroup", pid))
 	c.Assert(os.MkdirAll(filepath.Dir(procPidCgroup), 0755), IsNil)
 	// mock our own group
-	c.Assert(ioutil.WriteFile(procPidCgroup, []byte("0::/system.slice/snap.foo.app.own-own-own.scope"), 0755), IsNil)
+	c.Assert(os.WriteFile(procPidCgroup, []byte("0::/system.slice/snap.foo.app.own-own-own.scope"), 0755), IsNil)
 	// prepare the stage
 	for _, p := range []string{gOwn, g1, g2, g3, g4, canary} {
 		c.Assert(os.MkdirAll(filepath.Dir(p), 0755), IsNil)
-		c.Assert(ioutil.WriteFile(p, []byte("0"), 0644), IsNil)
+		c.Assert(os.WriteFile(p, []byte("0"), 0644), IsNil)
 	}
 
 	c.Assert(cgroup.FreezeSnapProcesses("foo"), IsNil)
@@ -276,7 +275,7 @@ func (s *freezerV2Suite) TestThawSnapProcessesV2(c *C) {
 	} {
 		c.Assert(os.MkdirAll(filepath.Dir(p), 0755), IsNil)
 		// well known, but invalid status of canaries
-		c.Assert(ioutil.WriteFile(p, []byte("99"), 0644), IsNil)
+		c.Assert(os.WriteFile(p, []byte("99"), 0644), IsNil)
 	}
 
 	c.Assert(cgroup.ThawSnapProcesses("foo"), IsNil)
@@ -295,7 +294,7 @@ func (s *freezerV2Suite) TestThawSnapProcessesV2(c *C) {
 		canaryOther, canarySubgroup, canaryUserSocket, canaryServiceSocket, canaryMount, canarySlice,
 	} {
 		// make them appear frozen
-		c.Assert(ioutil.WriteFile(p, []byte("1"), 0644), IsNil)
+		c.Assert(os.WriteFile(p, []byte("1"), 0644), IsNil)
 	}
 	c.Assert(cgroup.ThawSnapProcesses("foo"), IsNil)
 	for _, p := range []string{g1, g2, g3, g4} {
@@ -310,7 +309,7 @@ func (s *freezerV2Suite) TestThawSnapProcessesV2(c *C) {
 
 	// freeze only some the groups groups
 	for _, p := range []string{g2, g3} {
-		c.Assert(ioutil.WriteFile(p, []byte("1"), 0644), IsNil)
+		c.Assert(os.WriteFile(p, []byte("1"), 0644), IsNil)
 	}
 	c.Assert(cgroup.ThawSnapProcesses("foo"), IsNil)
 	// all are frozen again
@@ -335,12 +334,12 @@ func (s *freezerV2Suite) TestFreezeThawSnapProcessesV2ErrWalking(c *C) {
 	procPidCgroup := filepath.Join(dirs.GlobalRootDir, fmt.Sprintf("proc/%v/cgroup", pid))
 	c.Assert(os.MkdirAll(filepath.Dir(procPidCgroup), 0755), IsNil)
 	// mock our own group
-	c.Assert(ioutil.WriteFile(procPidCgroup, []byte("0::/system.slice/snap.foo.app.own-own-own.scope"), 0755), IsNil)
+	c.Assert(os.WriteFile(procPidCgroup, []byte("0::/system.slice/snap.foo.app.own-own-own.scope"), 0755), IsNil)
 	// prepare the stage
 	c.Assert(os.MkdirAll(filepath.Dir(g), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(g, []byte("0"), 0644), IsNil)
+	c.Assert(os.WriteFile(g, []byte("0"), 0644), IsNil)
 	c.Assert(os.MkdirAll(filepath.Dir(gUnfreeze), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(gUnfreeze, []byte("1"), 0644), IsNil)
+	c.Assert(os.WriteFile(gUnfreeze, []byte("1"), 0644), IsNil)
 
 	c.Assert(os.Chmod(filepath.Dir(g), 0000), IsNil)
 	// make the cleanup happy
@@ -354,7 +353,7 @@ func (s *freezerV2Suite) TestFreezeThawSnapProcessesV2ErrWalking(c *C) {
 	// other group was unfrozen
 	c.Check(gUnfreeze, testutil.FileEquals, "0")
 
-	c.Assert(ioutil.WriteFile(gUnfreeze, []byte("1"), 0644), IsNil)
+	c.Assert(os.WriteFile(gUnfreeze, []byte("1"), 0644), IsNil)
 	// make file access fail
 	c.Assert(os.Chmod(filepath.Dir(g), 0755), IsNil)
 	c.Assert(os.Chmod(g, 0000), IsNil)
@@ -371,7 +370,7 @@ func (s *freezerV2Suite) TestFreezeThawSnapProcessesV2ErrWalking(c *C) {
 	c.Check(gUnfreeze, testutil.FileEquals, "0")
 
 	// make unfreezing fail
-	c.Assert(ioutil.WriteFile(gUnfreeze, []byte("1"), 0644), IsNil)
+	c.Assert(os.WriteFile(gUnfreeze, []byte("1"), 0644), IsNil)
 	c.Assert(os.Chmod(filepath.Dir(gUnfreeze), 0000), IsNil)
 	defer os.Chmod(filepath.Dir(gUnfreeze), 0755)
 
@@ -396,7 +395,7 @@ func (s *freezerV2Suite) TestFreezeThawSnapProcessesV2ErrNotFound(c *C) {
 	procPidCgroup := filepath.Join(dirs.GlobalRootDir, fmt.Sprintf("proc/%v/cgroup", pid))
 	c.Assert(os.MkdirAll(filepath.Dir(procPidCgroup), 0755), IsNil)
 	// mock our own group
-	c.Assert(ioutil.WriteFile(procPidCgroup, []byte("0::/system.slice/snap.foo.app.own-own-own.scope"), 0755), IsNil)
+	c.Assert(os.WriteFile(procPidCgroup, []byte("0::/system.slice/snap.foo.app.own-own-own.scope"), 0755), IsNil)
 	// prepare the directories, but not the files, those should trigger ENOENT
 	c.Assert(os.MkdirAll(filepath.Dir(g1), 0755), IsNil)
 	c.Assert(os.MkdirAll(filepath.Dir(g2), 0755), IsNil)
@@ -428,7 +427,7 @@ func (s *freezerV2Suite) TestApplyToSnapCallbacks(c *C) {
 	for _, p := range []string{g, gErr} {
 		c.Assert(os.MkdirAll(filepath.Dir(p), 0755), IsNil)
 		// groups aren't frozen
-		c.Assert(ioutil.WriteFile(p, []byte("0"), 0644), IsNil)
+		c.Assert(os.WriteFile(p, []byte("0"), 0644), IsNil)
 	}
 
 	var visited []string

--- a/sandbox/cgroup/memory_test.go
+++ b/sandbox/cgroup/memory_test.go
@@ -19,7 +19,7 @@
 package cgroup_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	. "gopkg.in/check.v1"
@@ -54,7 +54,7 @@ func (s *memorySuite) TestCheckMemoryCgroupHappy(c *C) {
 	extra := "memory	2	223	1"
 	content := cgroupContentCommon + "\n" + extra
 
-	err := ioutil.WriteFile(s.mockCgroupsFile, []byte(content), 0644)
+	err := os.WriteFile(s.mockCgroupsFile, []byte(content), 0644)
 	c.Assert(err, IsNil)
 	err = cgroup.CheckMemoryCgroup()
 	c.Assert(err, IsNil)
@@ -70,7 +70,7 @@ func (s *memorySuite) TestCheckMemoryCgroupMissing(c *C) {
 func (s *memorySuite) TestCheckMemoryCgroupNoMemoryEntry(c *C) {
 	content := cgroupContentCommon
 
-	err := ioutil.WriteFile(s.mockCgroupsFile, []byte(content), 0644)
+	err := os.WriteFile(s.mockCgroupsFile, []byte(content), 0644)
 	c.Assert(err, IsNil)
 	err = cgroup.CheckMemoryCgroup()
 	c.Assert(err, ErrorMatches, "cannot find memory cgroup in .*/cgroups")
@@ -80,7 +80,7 @@ func (s *memorySuite) TestCheckMemoryCgroupInvalidMemoryEntry(c *C) {
 	extra := "memory	invalid line"
 	content := cgroupContentCommon + "\n" + extra
 
-	err := ioutil.WriteFile(s.mockCgroupsFile, []byte(content), 0644)
+	err := os.WriteFile(s.mockCgroupsFile, []byte(content), 0644)
 	c.Assert(err, IsNil)
 	err = cgroup.CheckMemoryCgroup()
 	c.Assert(err, ErrorMatches, `cannot parse cgroups file: invalid line "memory\\tinvalid line"`)
@@ -90,7 +90,7 @@ func (s *memorySuite) TestCheckMemoryCgroupDisabled(c *C) {
 	extra := "memory	2	223	0"
 	content := cgroupContentCommon + "\n" + extra
 
-	err := ioutil.WriteFile(s.mockCgroupsFile, []byte(content), 0644)
+	err := os.WriteFile(s.mockCgroupsFile, []byte(content), 0644)
 	c.Assert(err, IsNil)
 	err = cgroup.CheckMemoryCgroup()
 	c.Assert(err, ErrorMatches, "memory cgroup is disabled on this system")

--- a/sandbox/cgroup/monitor_test.go
+++ b/sandbox/cgroup/monitor_test.go
@@ -20,7 +20,6 @@
 package cgroup_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -255,7 +254,7 @@ func (s *monitorSuite) TestMonitorSnapEndedIntegration(c *C) {
 	mockProcsFile := filepath.Join(dirs.GlobalRootDir, "/sys/fs/cgroup/user.slice/user-1000.slice/user@1000.service/app.slice/snap.firefox.firefox-fa61f25b-92e1-4316-8acb-2b95af841855.scope/cgroup.procs")
 	err := os.MkdirAll(filepath.Dir(mockProcsFile), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(mockProcsFile, []byte("57003\n57004"), 0644)
+	err = os.WriteFile(mockProcsFile, []byte("57003\n57004"), 0644)
 	c.Assert(err, IsNil)
 
 	// wait for firefox to end

--- a/sandbox/cgroup/process_test.go
+++ b/sandbox/cgroup/process_test.go
@@ -20,7 +20,6 @@
 package cgroup_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -32,7 +31,7 @@ import (
 func (s *cgroupSuite) mockPidCgroup(c *C, text string) int {
 	f := filepath.Join(s.rootDir, "proc/333/cgroup")
 	c.Assert(os.MkdirAll(filepath.Dir(f), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(f, []byte(text), 0755), IsNil)
+	c.Assert(os.WriteFile(f, []byte(text), 0755), IsNil)
 	return 333
 }
 

--- a/sandbox/cgroup/scanning_test.go
+++ b/sandbox/cgroup/scanning_test.go
@@ -21,7 +21,6 @@ package cgroup_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -109,7 +108,7 @@ func (s *scanningSuite) writePids(c *C, dir string, pids []int) string {
 
 	c.Assert(os.MkdirAll(path, 0755), IsNil)
 	finalPath := filepath.Join(path, "cgroup.procs")
-	c.Assert(ioutil.WriteFile(finalPath, buf.Bytes(), 0644), IsNil)
+	c.Assert(os.WriteFile(finalPath, buf.Bytes(), 0644), IsNil)
 	return finalPath
 }
 
@@ -353,7 +352,7 @@ func (s *scanningSuite) TestPidsOfSnapUnrelated(c *C) {
 		// We want to ensure this is not read by accident.
 		f := filepath.Join(s.rootDir, "/sys/fs/cgroup/unrelated.txt")
 		c.Assert(os.MkdirAll(filepath.Dir(f), 0755), IsNil)
-		c.Assert(ioutil.WriteFile(f, []byte("666"), 0644), IsNil)
+		c.Assert(os.WriteFile(f, []byte("666"), 0644), IsNil)
 
 		pids, err := cgroup.PidsOfSnap("pkg")
 		c.Assert(err, IsNil, comment)
@@ -383,7 +382,7 @@ func (s *scanningSuite) TestPathsOfSnapUnrelated(c *C) {
 		// We want to ensure this is not read by accident.
 		f := filepath.Join(s.rootDir, "/sys/fs/cgroup/unrelated.txt")
 		c.Assert(os.MkdirAll(filepath.Dir(f), 0755), IsNil)
-		c.Assert(ioutil.WriteFile(f, []byte("666"), 0644), IsNil)
+		c.Assert(os.WriteFile(f, []byte("666"), 0644), IsNil)
 
 		paths, err := cgroup.InstancePathsOfSnap("pkg", options)
 		c.Assert(err, IsNil, comment)

--- a/sandbox/cgroup/tracking_test.go
+++ b/sandbox/cgroup/tracking_test.go
@@ -22,7 +22,6 @@ package cgroup_test
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -42,7 +41,7 @@ import (
 func enableFeatures(c *C, ff ...features.SnapdFeature) {
 	c.Assert(os.MkdirAll(dirs.FeaturesDir, 0755), IsNil)
 	for _, f := range ff {
-		c.Assert(ioutil.WriteFile(f.ControlFile(), nil, 0755), IsNil)
+		c.Assert(os.WriteFile(f.ControlFile(), nil, 0755), IsNil)
 	}
 }
 

--- a/sandbox/selinux/label_linux_test.go
+++ b/sandbox/selinux/label_linux_test.go
@@ -21,7 +21,7 @@ package selinux_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 
@@ -39,7 +39,7 @@ var _ = check.Suite(&labelSuite{})
 
 func (l *labelSuite) SetUpTest(c *check.C) {
 	l.path = filepath.Join(c.MkDir(), "foo")
-	ioutil.WriteFile(l.path, []byte("foo"), 0644)
+	os.WriteFile(l.path, []byte("foo"), 0644)
 }
 
 func (l *labelSuite) TestVerifyHappyOk(c *check.C) {

--- a/sandbox/selinux/selinux_linux_test.go
+++ b/sandbox/selinux/selinux_linux_test.go
@@ -21,7 +21,7 @@ package selinux_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -86,14 +86,14 @@ func (s *selinuxSuite) TestIsEnforcingHappy(c *check.C) {
 
 	enforcePath := filepath.Join(dir, "enforce")
 
-	err := ioutil.WriteFile(enforcePath, []byte("1"), 0644)
+	err := os.WriteFile(enforcePath, []byte("1"), 0644)
 	c.Assert(err, check.IsNil)
 
 	enforcing, err := selinux.IsEnforcing()
 	c.Assert(err, check.IsNil)
 	c.Assert(enforcing, check.Equals, true)
 
-	err = ioutil.WriteFile(enforcePath, []byte("0"), 0644)
+	err = os.WriteFile(enforcePath, []byte("0"), 0644)
 	c.Assert(err, check.IsNil)
 
 	enforcing, err = selinux.IsEnforcing()
@@ -118,7 +118,7 @@ func (s *selinuxSuite) TestIsEnforcingFailGarbage(c *check.C) {
 
 	enforcePath := filepath.Join(dir, "enforce")
 
-	err := ioutil.WriteFile(enforcePath, []byte("garbage"), 0644)
+	err := os.WriteFile(enforcePath, []byte("garbage"), 0644)
 	c.Assert(err, check.IsNil)
 
 	enforcing, err := selinux.IsEnforcing()
@@ -134,7 +134,7 @@ func (s *selinuxSuite) TestIsEnforcingFailOther(c *check.C) {
 
 	enforcePath := filepath.Join(dir, "enforce")
 
-	err := ioutil.WriteFile(enforcePath, []byte("not-readable"), 0000)
+	err := os.WriteFile(enforcePath, []byte("not-readable"), 0000)
 	c.Assert(err, check.IsNil)
 
 	enforcing, err := selinux.IsEnforcing()

--- a/secboot/keymgr/keymgr_luks2_test.go
+++ b/secboot/keymgr/keymgr_luks2_test.go
@@ -21,7 +21,6 @@ package keymgr_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -67,7 +66,7 @@ func (s *keymgrSuite) SetUpTest(c *C) {
 	c.Assert(os.MkdirAll(dirs.RunDir, 0755), IsNil)
 
 	mockedMeminfoFile := filepath.Join(c.MkDir(), "meminfo")
-	err := ioutil.WriteFile(mockedMeminfoFile, []byte(mockedMeminfo), 0644)
+	err := os.WriteFile(mockedMeminfoFile, []byte(mockedMeminfo), 0644)
 	c.Assert(err, IsNil)
 	s.AddCleanup(osutil.MockProcMeminfo(mockedMeminfoFile))
 }
@@ -871,7 +870,7 @@ func (s *keymgrSuite) TestRecoveryKDF(c *C) {
 	_, err := keymgr.RecoveryKDF()
 	c.Assert(err, ErrorMatches, "cannot get usable memory for KDF parameters when adding the recovery key: open .*")
 
-	c.Assert(ioutil.WriteFile(mockedMeminfoFile, []byte(mockedMeminfo), 0644), IsNil)
+	c.Assert(os.WriteFile(mockedMeminfoFile, []byte(mockedMeminfo), 0644), IsNil)
 
 	opts, err := keymgr.RecoveryKDF()
 	c.Assert(err, IsNil)
@@ -883,7 +882,7 @@ func (s *keymgrSuite) TestRecoveryKDF(c *C) {
 	const lotsOfMem = `MemTotal:         2097152 kB
 CmaTotal:         131072 kB
 `
-	c.Assert(ioutil.WriteFile(mockedMeminfoFile, []byte(lotsOfMem), 0644), IsNil)
+	c.Assert(os.WriteFile(mockedMeminfoFile, []byte(lotsOfMem), 0644), IsNil)
 	opts, err = keymgr.RecoveryKDF()
 	c.Assert(err, IsNil)
 	c.Assert(opts, DeepEquals, &luks2.KDFOptions{
@@ -894,7 +893,7 @@ CmaTotal:         131072 kB
 	const littleMem = `MemTotal:         262144 kB
 CmaTotal:         131072 kB
 `
-	c.Assert(ioutil.WriteFile(mockedMeminfoFile, []byte(littleMem), 0644), IsNil)
+	c.Assert(os.WriteFile(mockedMeminfoFile, []byte(littleMem), 0644), IsNil)
 	opts, err = keymgr.RecoveryKDF()
 	c.Assert(err, IsNil)
 	c.Assert(opts, DeepEquals, &luks2.KDFOptions{

--- a/secboot/secboot_sb_test.go
+++ b/secboot/secboot_sb_test.go
@@ -29,7 +29,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -667,7 +666,7 @@ func (s *secbootSuite) TestEFIImageFromBootFile(c *C) {
 
 	// set up some test files
 	existingFile := filepath.Join(tmpDir, "foo")
-	err := ioutil.WriteFile(existingFile, nil, 0644)
+	err := os.WriteFile(existingFile, nil, 0644)
 	c.Assert(err, IsNil)
 	missingFile := filepath.Join(tmpDir, "bar")
 	snapFile := filepath.Join(tmpDir, "test.snap")
@@ -759,7 +758,7 @@ func (s *secbootSuite) TestProvisionTPM(c *C) {
 
 		lockoutAuthData := []byte{'l', 'o', 'c', 'k', 'o', 'u', 't', 1, 1, 1, 1, 1, 1, 1, 1, 1}
 		if tc.writeLockoutAuth {
-			c.Assert(ioutil.WriteFile(filepath.Join(d, "lockout-auth"), lockoutAuthData, 0644), IsNil)
+			c.Assert(os.WriteFile(filepath.Join(d, "lockout-auth"), lockoutAuthData, 0644), IsNil)
 		}
 
 		// mock provisioning
@@ -816,7 +815,7 @@ func (s *secbootSuite) TestSealKey(c *C) {
 		var mockBF []bootloader.BootFile
 		for _, name := range []string{"a", "b", "c", "d"} {
 			mockFileName := filepath.Join(tmpDir, name)
-			err := ioutil.WriteFile(mockFileName, nil, 0644)
+			err := os.WriteFile(mockFileName, nil, 0644)
 			c.Assert(err, IsNil)
 			mockBF = append(mockBF, bootloader.NewBootFile("", mockFileName, bootloader.RoleRecovery))
 		}
@@ -828,7 +827,7 @@ func (s *secbootSuite) TestSealKey(c *C) {
 		var kernelSnap snap.Container
 		snapPath := filepath.Join(tmpDir, "kernel.snap")
 		if tc.badSnapFile {
-			err := ioutil.WriteFile(snapPath, nil, 0644)
+			err := os.WriteFile(snapPath, nil, 0644)
 			c.Assert(err, IsNil)
 		} else {
 			var err error
@@ -1102,12 +1101,12 @@ func (s *secbootSuite) TestResealKey(c *C) {
 	} {
 		mockTPMPolicyAuthKey := []byte{1, 3, 3, 7}
 		mockTPMPolicyAuthKeyFile := filepath.Join(c.MkDir(), "policy-auth-key-file")
-		err := ioutil.WriteFile(mockTPMPolicyAuthKeyFile, mockTPMPolicyAuthKey, 0600)
+		err := os.WriteFile(mockTPMPolicyAuthKeyFile, mockTPMPolicyAuthKey, 0600)
 		c.Assert(err, IsNil)
 
 		mockEFI := bootloader.NewBootFile("", filepath.Join(c.MkDir(), "file.efi"), bootloader.RoleRecovery)
 		if !tc.missingFile {
-			err := ioutil.WriteFile(mockEFI.Path, nil, 0644)
+			err := os.WriteFile(mockEFI.Path, nil, 0644)
 			c.Assert(err, IsNil)
 		}
 
@@ -1276,7 +1275,7 @@ func createMockSnapFile(snapDir, snapPath, snapType string) (snap.Container, err
 	if err := os.MkdirAll(filepath.Dir(snapYamlPath), 0755); err != nil {
 		return nil, err
 	}
-	if err := ioutil.WriteFile(snapYamlPath, []byte("name: foo"), 0644); err != nil {
+	if err := os.WriteFile(snapYamlPath, []byte("name: foo"), 0644); err != nil {
 		return nil, err
 	}
 	sqfs := squashfs.New(snapPath)
@@ -1473,7 +1472,7 @@ func (s *secbootSuite) TestUnlockVolumeUsingSealedKeyIfEncryptedFdeRevealKeyV1An
 	// disk-key without any json
 	mockSealedKeyFile := filepath.Join(c.MkDir(), "keyfile")
 	sealedKeyContent := []byte("USK$sealed-key-not-json-to-match-denver-project")
-	err := ioutil.WriteFile(mockSealedKeyFile, sealedKeyContent, 0600)
+	err := os.WriteFile(mockSealedKeyFile, sealedKeyContent, 0600)
 	c.Assert(err, IsNil)
 
 	opts := &secboot.UnlockVolumeUsingSealedKeyOptions{}
@@ -1626,7 +1625,7 @@ func makeMockSealedKeyFile(c *C, handle json.RawMessage) string {
 		handleJSON = fmt.Sprintf(`"platform_handle":%s,`, handle)
 	}
 	sealedKeyContent := fmt.Sprintf(`{"platform_name":"fde-hook-v2",%s"encrypted_payload":"%s"}`, handleJSON, makeMockEncryptedPayloadString())
-	err := ioutil.WriteFile(mockSealedKeyFile, []byte(sealedKeyContent), 0600)
+	err := os.WriteFile(mockSealedKeyFile, []byte(sealedKeyContent), 0600)
 	c.Assert(err, IsNil)
 	return mockSealedKeyFile
 }
@@ -2007,7 +2006,7 @@ func (s *secbootSuite) TestUnlockVolumeUsingSealedKeyIfEncryptedFdeRevealKeyV1(c
 	// note that we write a v1 created keyfile here, i.e. it's a raw
 	// disk-key without any json
 	mockSealedKeyFile := filepath.Join(c.MkDir(), "keyfile")
-	err := ioutil.WriteFile(mockSealedKeyFile, mockEncryptedDiskKey, 0600)
+	err := os.WriteFile(mockSealedKeyFile, mockEncryptedDiskKey, 0600)
 	c.Assert(err, IsNil)
 
 	opts := &secboot.UnlockVolumeUsingSealedKeyOptions{}
@@ -2080,7 +2079,7 @@ func (s *secbootSuite) TestPCRHandleOfSealedKey(c *C) {
 
 	skf := filepath.Join(d, "sealed-key")
 	// partially valid sealed key with correct header magic
-	c.Assert(ioutil.WriteFile(skf, []byte{0x55, 0x53, 0x4b, 0x24, 1, 1, 1, 'k', 'e', 'y', 1, 1, 1}, 0644), IsNil)
+	c.Assert(os.WriteFile(skf, []byte{0x55, 0x53, 0x4b, 0x24, 1, 1, 1, 'k', 'e', 'y', 1, 1, 1}, 0644), IsNil)
 	h, err = secboot.PCRHandleOfSealedKey(skf)
 	c.Assert(err, ErrorMatches, "(?s)cannot open key file: invalid key data: cannot unmarshal AFIS header: .*")
 	c.Check(h, Equals, uint32(0))
@@ -2182,7 +2181,7 @@ func (s *secbootSuite) testMarkSuccessfulEncrypted(c *C, sealingMethod device.Se
 
 	// write fake lockout auth
 	lockoutAuthValue := []byte("tpm-lockout-auth-key")
-	err = ioutil.WriteFile(filepath.Join(saveFDEDir, "tpm-lockout-auth"), lockoutAuthValue, 0600)
+	err = os.WriteFile(filepath.Join(saveFDEDir, "tpm-lockout-auth"), lockoutAuthValue, 0600)
 	c.Assert(err, IsNil)
 
 	daLockResetCalls := 0

--- a/seed/internal/options20_test.go
+++ b/seed/internal/options20_test.go
@@ -20,7 +20,7 @@
 package internal_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	. "gopkg.in/check.v1"
@@ -43,7 +43,7 @@ snaps:
 
 func (s *options20Suite) TestSimple(c *C) {
 	fn := filepath.Join(c.MkDir(), "options.yaml")
-	err := ioutil.WriteFile(fn, mockOptions20, 0644)
+	err := os.WriteFile(fn, mockOptions20, 0644)
 	c.Assert(err, IsNil)
 
 	options20, err := internal.ReadOptions20(fn)
@@ -62,7 +62,7 @@ func (s *options20Suite) TestSimple(c *C) {
 
 func (s *options20Suite) TestEmpty(c *C) {
 	fn := filepath.Join(c.MkDir(), "options.yaml")
-	err := ioutil.WriteFile(fn, []byte(`
+	err := os.WriteFile(fn, []byte(`
 snaps:
  -
 `), 0644)
@@ -74,7 +74,7 @@ snaps:
 
 func (s *options20Suite) TestNoPathAllowed(c *C) {
 	fn := filepath.Join(c.MkDir(), "options.yaml")
-	err := ioutil.WriteFile(fn, []byte(`
+	err := os.WriteFile(fn, []byte(`
 snaps:
  - name: foo
    unasserted: foo/bar.snap
@@ -87,7 +87,7 @@ snaps:
 
 func (s *options20Suite) TestDuplicatedSnapName(c *C) {
 	fn := filepath.Join(c.MkDir(), "options.yaml")
-	err := ioutil.WriteFile(fn, []byte(`
+	err := os.WriteFile(fn, []byte(`
 snaps:
  - name: foo
    channel: stable
@@ -102,7 +102,7 @@ snaps:
 
 func (s *options20Suite) TestValidateChannelUnhappy(c *C) {
 	fn := filepath.Join(c.MkDir(), "options.yaml")
-	err := ioutil.WriteFile(fn, []byte(`
+	err := os.WriteFile(fn, []byte(`
 snaps:
  - name: foo
    channel: invalid/channel/
@@ -115,7 +115,7 @@ snaps:
 
 func (s *options20Suite) TestValidateSnapIDUnhappy(c *C) {
 	fn := filepath.Join(c.MkDir(), "options.yaml")
-	err := ioutil.WriteFile(fn, []byte(`
+	err := os.WriteFile(fn, []byte(`
 snaps:
  - name: foo
    id: foo
@@ -128,7 +128,7 @@ snaps:
 
 func (s *options20Suite) TestValidateNameUnhappy(c *C) {
 	fn := filepath.Join(c.MkDir(), "options.yaml")
-	err := ioutil.WriteFile(fn, []byte(`
+	err := os.WriteFile(fn, []byte(`
 snaps:
  - name: invalid--name
    unasserted: ./foo.snap
@@ -141,7 +141,7 @@ snaps:
 
 func (s *options20Suite) TestValidateNameInstanceUnsupported(c *C) {
 	fn := filepath.Join(c.MkDir(), "options.yaml")
-	err := ioutil.WriteFile(fn, []byte(`
+	err := os.WriteFile(fn, []byte(`
 snaps:
  - name: foo_1
    unasserted: ./foo.snap
@@ -154,7 +154,7 @@ snaps:
 
 func (s *options20Suite) TestValidateNameMissing(c *C) {
 	fn := filepath.Join(c.MkDir(), "options.yaml")
-	err := ioutil.WriteFile(fn, []byte(`
+	err := os.WriteFile(fn, []byte(`
 snaps:
  - unasserted: ./foo.snap
 `), 0644)
@@ -166,7 +166,7 @@ snaps:
 
 func (s *options20Suite) TestValidateOptionMissing(c *C) {
 	fn := filepath.Join(c.MkDir(), "options.yaml")
-	err := ioutil.WriteFile(fn, []byte(`
+	err := os.WriteFile(fn, []byte(`
 snaps:
  - name: foo
 `), 0644)

--- a/seed/internal/seed_yaml_test.go
+++ b/seed/internal/seed_yaml_test.go
@@ -20,7 +20,7 @@
 package internal_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -49,7 +49,7 @@ snaps:
 
 func (s *seedYamlTestSuite) TestSimple(c *C) {
 	fn := filepath.Join(c.MkDir(), "seed.yaml")
-	err := ioutil.WriteFile(fn, mockSeedYaml, 0644)
+	err := os.WriteFile(fn, mockSeedYaml, 0644)
 	c.Assert(err, IsNil)
 
 	seedYaml, err := internal.ReadSeedYaml(fn)
@@ -78,7 +78,7 @@ snaps:
 
 func (s *seedYamlTestSuite) TestNoPathAllowed(c *C) {
 	fn := filepath.Join(c.MkDir(), "seed.yaml")
-	err := ioutil.WriteFile(fn, badMockSeedYaml, 0644)
+	err := os.WriteFile(fn, badMockSeedYaml, 0644)
 	c.Assert(err, IsNil)
 
 	_, err = internal.ReadSeedYaml(fn)
@@ -87,7 +87,7 @@ func (s *seedYamlTestSuite) TestNoPathAllowed(c *C) {
 
 func (s *seedYamlTestSuite) TestDuplicatedSnapName(c *C) {
 	fn := filepath.Join(c.MkDir(), "seed.yaml")
-	err := ioutil.WriteFile(fn, []byte(`
+	err := os.WriteFile(fn, []byte(`
 snaps:
  - name: foo
    channel: stable
@@ -104,7 +104,7 @@ snaps:
 
 func (s *seedYamlTestSuite) TestValidateChannelUnhappy(c *C) {
 	fn := filepath.Join(c.MkDir(), "seed.yaml")
-	err := ioutil.WriteFile(fn, []byte(`
+	err := os.WriteFile(fn, []byte(`
 snaps:
  - name: foo
    channel: invalid/channel/
@@ -117,7 +117,7 @@ snaps:
 
 func (s *seedYamlTestSuite) TestValidateNameUnhappy(c *C) {
 	fn := filepath.Join(c.MkDir(), "seed.yaml")
-	err := ioutil.WriteFile(fn, []byte(`
+	err := os.WriteFile(fn, []byte(`
 snaps:
  - name: invalid--name
    file: ./foo.snap
@@ -130,7 +130,7 @@ snaps:
 
 func (s *seedYamlTestSuite) TestValidateNameInstanceUnsupported(c *C) {
 	fn := filepath.Join(c.MkDir(), "seed.yaml")
-	err := ioutil.WriteFile(fn, []byte(`
+	err := os.WriteFile(fn, []byte(`
 snaps:
  - name: foo_1
    file: ./foo.snap
@@ -143,7 +143,7 @@ snaps:
 
 func (s *seedYamlTestSuite) TestValidateNameMissing(c *C) {
 	fn := filepath.Join(c.MkDir(), "seed.yaml")
-	err := ioutil.WriteFile(fn, []byte(`
+	err := os.WriteFile(fn, []byte(`
 snaps:
  - file: ./foo.snap
 `), 0644)
@@ -155,7 +155,7 @@ snaps:
 
 func (s *seedYamlTestSuite) TestValidateFileMissing(c *C) {
 	fn := filepath.Join(c.MkDir(), "seed.yaml")
-	err := ioutil.WriteFile(fn, []byte(`
+	err := os.WriteFile(fn, []byte(`
 snaps:
  - name: foo
 `), 0644)

--- a/seed/seed16_test.go
+++ b/seed/seed16_test.go
@@ -21,7 +21,6 @@ package seed_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -234,7 +233,7 @@ func (s *seed16Suite) TestLoadMetaInvalidSeedYaml(c *C) {
 		}},
 	})
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(s.SeedDir, "seed.yaml"), content, 0644)
+	err = os.WriteFile(filepath.Join(s.SeedDir, "seed.yaml"), content, 0644)
 	c.Assert(err, IsNil)
 
 	err = s.seed16.LoadMeta(seed.AllModes, nil, s.perfTimings)
@@ -410,7 +409,7 @@ func (s *seed16Suite) writeSeed(c *C, seedSnaps []*seed.InternalSnap16) {
 		"snaps": seedSnaps,
 	})
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(s.SeedDir, "seed.yaml"), content, 0644)
+	err = os.WriteFile(filepath.Join(s.SeedDir, "seed.yaml"), content, 0644)
 	c.Assert(err, IsNil)
 }
 

--- a/seed/seed20_test.go
+++ b/seed/seed20_test.go
@@ -22,7 +22,6 @@ package seed_test
 import (
 	"crypto"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -3174,7 +3173,7 @@ func (s *seed20Suite) createMinimalSeed(c *C, grade string, sysLabel string) see
 func (s *seed20Suite) writeInvalidAutoImportAssertion(c *C, sysLabel string, perm os.FileMode) {
 	autoImportAssert := filepath.Join(s.SeedDir, "systems", sysLabel, "auto-import.assert")
 	// write invalid data
-	err := ioutil.WriteFile(autoImportAssert, []byte(strings.Repeat("a", 512)), perm)
+	err := os.WriteFile(autoImportAssert, []byte(strings.Repeat("a", 512)), perm)
 	c.Assert(err, IsNil)
 }
 
@@ -3217,7 +3216,7 @@ func (s *seed20Suite) TestPreseedCapableSeed(c *C) {
 	}, nil)
 
 	preseedArtifact := filepath.Join(s.SeedDir, "systems", sysLabel, "preseed.tgz")
-	c.Assert(ioutil.WriteFile(preseedArtifact, nil, 0644), IsNil)
+	c.Assert(os.WriteFile(preseedArtifact, nil, 0644), IsNil)
 	sha3_384, _, err := osutil.FileDigest(preseedArtifact, crypto.SHA3_384)
 	c.Assert(err, IsNil)
 	digest, err := asserts.EncodeDigest(crypto.SHA3_384, sha3_384)
@@ -3294,7 +3293,7 @@ func (s *seed20Suite) TestPreseedCapableSeedErrors(c *C) {
 	}, nil)
 
 	preseedArtifact := filepath.Join(s.SeedDir, "systems", sysLabel, "preseed.tgz")
-	c.Assert(ioutil.WriteFile(preseedArtifact, nil, 0644), IsNil)
+	c.Assert(os.WriteFile(preseedArtifact, nil, 0644), IsNil)
 	sha3_384, _, err := osutil.FileDigest(preseedArtifact, crypto.SHA3_384)
 	c.Assert(err, IsNil)
 	digest, err := asserts.EncodeDigest(crypto.SHA3_384, sha3_384)
@@ -3453,7 +3452,7 @@ func (s *seed20Suite) TestPreseedCapableSeedAlternateAuthority(c *C) {
 	}, nil)
 
 	preseedArtifact := filepath.Join(s.SeedDir, "systems", sysLabel, "preseed.tgz")
-	c.Assert(ioutil.WriteFile(preseedArtifact, nil, 0644), IsNil)
+	c.Assert(os.WriteFile(preseedArtifact, nil, 0644), IsNil)
 	sha3_384, _, err := osutil.FileDigest(preseedArtifact, crypto.SHA3_384)
 	c.Assert(err, IsNil)
 	digest, err := asserts.EncodeDigest(crypto.SHA3_384, sha3_384)

--- a/seed/seedwriter/manifest.go
+++ b/seed/seedwriter/manifest.go
@@ -23,7 +23,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sort"
 	"strconv"
@@ -390,5 +389,5 @@ func (sm *Manifest) Write(filePath string) error {
 	for _, key := range revisionKeys {
 		fmt.Fprintf(buf, "%s\n", sm.revsSeeded[key])
 	}
-	return ioutil.WriteFile(filePath, buf.Bytes(), 0755)
+	return os.WriteFile(filePath, buf.Bytes(), 0755)
 }

--- a/seed/seedwriter/manifest_test.go
+++ b/seed/seedwriter/manifest_test.go
@@ -21,6 +21,7 @@ package seedwriter_test
 
 import (
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -50,7 +51,7 @@ func (s *manifestSuite) SetUpTest(c *C) {
 
 func (s *manifestSuite) writeManifest(c *C, contents string) string {
 	manifestFile := filepath.Join(s.root, "seed.manifest")
-	err := ioutil.WriteFile(manifestFile, []byte(contents), 0644)
+	err := os.WriteFile(manifestFile, []byte(contents), 0644)
 	c.Assert(err, IsNil)
 	return manifestFile
 }

--- a/seed/seedwriter/seed16.go
+++ b/seed/seedwriter/seed16.go
@@ -21,7 +21,6 @@ package seedwriter
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -235,7 +234,7 @@ func (tr *tree16) writeAssertions(db asserts.RODatabase, modelRefs []*asserts.Re
 			if err != nil {
 				return fmt.Errorf("internal error: lost saved assertion")
 			}
-			if err = ioutil.WriteFile(filepath.Join(seedAssertsDir, afn), asserts.Encode(a), 0644); err != nil {
+			if err = os.WriteFile(filepath.Join(seedAssertsDir, afn), asserts.Encode(a), 0644); err != nil {
 				return err
 			}
 		}

--- a/seed/validate_test.go
+++ b/seed/validate_test.go
@@ -22,7 +22,6 @@ package seed_test
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -98,7 +97,7 @@ func (s *validateSuite) makeSnapInSeed(c *C, snapYaml string) {
 
 func (s *validateSuite) makeSeedYaml(c *C, seedYaml string) string {
 	tmpf := filepath.Join(s.SeedDir, "seed.yaml")
-	err := ioutil.WriteFile(tmpf, []byte(seedYaml), 0644)
+	err := os.WriteFile(tmpf, []byte(seedYaml), 0644)
 	c.Assert(err, IsNil)
 	return tmpf
 }
@@ -246,7 +245,7 @@ func (s *validateSuite) makeBrokenSnap(c *C, snapYaml string) (snapPath string) 
 	metaSnapYaml := filepath.Join(snapBuildDir, "meta", "snap.yaml")
 	err := os.MkdirAll(filepath.Dir(metaSnapYaml), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(metaSnapYaml, []byte(snapYaml), 0644)
+	err = os.WriteFile(metaSnapYaml, []byte(snapYaml), 0644)
 	c.Assert(err, IsNil)
 
 	// need to build the snap "manually" pack.Snap() will do validation

--- a/snap/broken_test.go
+++ b/snap/broken_test.go
@@ -20,7 +20,6 @@
 package snap_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -46,7 +45,7 @@ func (s *brokenSuite) TearDownTest(c *C) {
 func touch(c *C, path string) {
 	err := os.MkdirAll(filepath.Dir(path), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(path, nil, 0644)
+	err = os.WriteFile(path, nil, 0644)
 	c.Assert(err, IsNil)
 }
 

--- a/snap/container_test.go
+++ b/snap/container_test.go
@@ -20,7 +20,6 @@
 package snap_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -78,7 +77,7 @@ version: 1
 	c.Check(stat.Mode().Perm(), Equals, os.FileMode(0700)) // just to be sure
 
 	c.Assert(os.Mkdir(filepath.Join(d, "meta"), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(d, "meta", "snap.yaml"), nil, 0444), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(d, "meta", "snap.yaml"), nil, 0444), IsNil)
 
 	// snapdir has /meta/snap.yaml, but / is 0700
 
@@ -113,7 +112,7 @@ version: 1
 	d := c.MkDir()
 	c.Assert(os.Chmod(d, 0755), IsNil)
 	c.Assert(os.Mkdir(filepath.Join(d, "meta"), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(d, "meta", "snap.yaml"), nil, 0), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(d, "meta", "snap.yaml"), nil, 0), IsNil)
 
 	// snapdir's / and /meta are 0755 (i.e. OK),
 	// /meta/snap.yaml exists, but isn't readable
@@ -151,7 +150,7 @@ func emptyContainer(c *C) *snapdir.SnapDir {
 	d := c.MkDir()
 	c.Assert(os.Chmod(d, 0755), IsNil)
 	c.Assert(os.Mkdir(filepath.Join(d, "meta"), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(d, "meta", "snap.yaml"), nil, 0444), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(d, "meta", "snap.yaml"), nil, 0444), IsNil)
 	return snapdir.New(d)
 }
 
@@ -196,7 +195,7 @@ apps:
   command: foo
 `
 	d := emptyContainer(c)
-	c.Assert(ioutil.WriteFile(filepath.Join(d.Path(), "foo"), nil, 0444), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(d.Path(), "foo"), nil, 0444), IsNil)
 
 	// snapdir contains the app, but the app is not executable
 
@@ -216,7 +215,7 @@ apps:
 `
 	d := emptyContainer(c)
 	c.Assert(os.Mkdir(filepath.Join(d.Path(), "apps"), 0700), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(d.Path(), "apps", "foo"), nil, 0555), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(d.Path(), "apps", "foo"), nil, 0555), IsNil)
 
 	// snapdir contains executable app, but path to executable isn't rx
 
@@ -237,7 +236,7 @@ apps:
 `
 	d := emptyContainer(c)
 	c.Assert(os.Mkdir(filepath.Join(d.Path(), "svcs"), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(d.Path(), "svcs", "bar"), nil, 0), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(d.Path(), "svcs", "bar"), nil, 0), IsNil)
 
 	// snapdir contains service, but it isn't executable
 
@@ -258,7 +257,7 @@ apps:
 `
 	d := emptyContainer(c)
 	c.Assert(os.Mkdir(filepath.Join(d.Path(), "cmds"), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(d.Path(), "cmds", "foo"), nil, 0555), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(d.Path(), "cmds", "foo"), nil, 0555), IsNil)
 	c.Assert(os.Mkdir(filepath.Join(d.Path(), "comp"), 0755), IsNil)
 
 	// snapdir contains executable app, in a rx path, but refers
@@ -301,7 +300,7 @@ apps:
 `
 	d := emptyContainer(c)
 	fn := filepath.Join(d.Path(), "foo")
-	c.Assert(ioutil.WriteFile(fn+".real", nil, 0444), IsNil)
+	c.Assert(os.WriteFile(fn+".real", nil, 0444), IsNil)
 	c.Assert(os.Symlink(fn+".real", fn), IsNil)
 
 	// snapdir contains a command that's a symlink to a file that's not world-rx
@@ -322,7 +321,7 @@ apps:
 `
 	d := emptyContainer(c)
 	fn := filepath.Join(d.Path(), "foo")
-	c.Assert(ioutil.WriteFile(fn+".real", nil, 0555), IsNil)
+	c.Assert(os.WriteFile(fn+".real", nil, 0555), IsNil)
 	c.Assert(os.Symlink(fn+".real", fn), IsNil)
 
 	// snapdir contains a command that's a symlink to a file that's world-rx
@@ -355,12 +354,12 @@ apps:
 `
 	d := emptyContainer(c)
 	c.Assert(os.Mkdir(filepath.Join(d.Path(), "cmds"), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(d.Path(), "cmds", "foo"), nil, 0555), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(d.Path(), "cmds", "foo"), nil, 0555), IsNil)
 	c.Assert(os.Mkdir(filepath.Join(d.Path(), "comp"), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(d.Path(), "comp", "foo.sh"), nil, 0555), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(d.Path(), "comp", "foo.sh"), nil, 0555), IsNil)
 
 	c.Assert(os.Mkdir(filepath.Join(d.Path(), "svcs"), 0700), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(d.Path(), "svcs", "bar"), nil, 0500), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(d.Path(), "svcs", "bar"), nil, 0500), IsNil)
 
 	c.Assert(os.Mkdir(filepath.Join(d.Path(), "garbage"), 0755), IsNil)
 	c.Assert(os.Mkdir(filepath.Join(d.Path(), "garbage", "zero"), 0), IsNil)

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -22,7 +22,6 @@ package snap_test
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -461,7 +460,7 @@ func (s *infoSuite) TestReadInfoUnparsable(c *C) {
 	si := &snap.SideInfo{Revision: snap.R(42), EditedSummary: "esummary"}
 	p := filepath.Join(snap.MinimalPlaceInfo("sample", si.Revision).MountDir(), "meta", "snap.yaml")
 	c.Assert(os.MkdirAll(filepath.Dir(p), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(p, []byte(`- :`), 0644), IsNil)
+	c.Assert(os.WriteFile(p, []byte(`- :`), 0644), IsNil)
 
 	info, err := snap.ReadInfo("sample", si)
 	c.Check(info, IsNil)
@@ -476,7 +475,7 @@ func (s *infoSuite) TestReadInfoUnfindable(c *C) {
 	si := &snap.SideInfo{Revision: snap.R(42), EditedSummary: "esummary"}
 	p := filepath.Join(snap.MinimalPlaceInfo("sample", si.Revision).MountDir(), "meta", "snap.yaml")
 	c.Assert(os.MkdirAll(filepath.Dir(p), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(p, []byte(``), 0644), IsNil)
+	c.Assert(os.WriteFile(p, []byte(``), 0644), IsNil)
 
 	info, err := snap.ReadInfo("sample", si)
 	c.Check(err, ErrorMatches, `cannot find installed snap "sample" at revision 42: missing file .*var/lib/snapd/snaps/sample_42.snap`)
@@ -488,7 +487,7 @@ func (s *infoSuite) TestReadInfoDanglingSymlink(c *C) {
 	mpi := snap.MinimalPlaceInfo("sample", si.Revision)
 	p := filepath.Join(mpi.MountDir(), "meta", "snap.yaml")
 	c.Assert(os.MkdirAll(filepath.Dir(p), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(p, []byte(`name: test`), 0644), IsNil)
+	c.Assert(os.WriteFile(p, []byte(`name: test`), 0644), IsNil)
 	c.Assert(os.MkdirAll(filepath.Dir(mpi.MountFile()), 0755), IsNil)
 	c.Assert(os.Symlink("/dangling", mpi.MountFile()), IsNil)
 
@@ -514,7 +513,7 @@ func makeTestSnap(c *C, snapYaml string) string {
 	c.Assert(err, IsNil)
 
 	// our regular snap.yaml
-	err = ioutil.WriteFile(filepath.Join(snapSource, "meta", "snap.yaml"), []byte(snapYaml), 0644)
+	err = os.WriteFile(filepath.Join(snapSource, "meta", "snap.yaml"), []byte(snapYaml), 0644)
 	c.Assert(err, IsNil)
 
 	dest := filepath.Join(tmp, "foo.snap")

--- a/snap/integrity/dmverity/veritysetup.go
+++ b/snap/integrity/dmverity/veritysetup.go
@@ -23,7 +23,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"regexp"
 	"strconv"
@@ -137,7 +137,7 @@ func Format(dataDevice string, hashDevice string) (*Info, error) {
 		return nil, err
 	} else if deploy {
 		space := make([]byte, 4096)
-		ioutil.WriteFile(hashDevice, space, 0644)
+		os.WriteFile(hashDevice, space, 0644)
 	}
 
 	cmd := exec.Command("veritysetup", "format", dataDevice, hashDevice)

--- a/snap/pack/pack.go
+++ b/snap/pack/pack.go
@@ -182,7 +182,7 @@ func excludesFile() (filename string, err error) {
 		return "", err
 	}
 
-	// inspited by ioutil.WriteFile
+	// inspited by os.WriteFile
 	n, err := tmpf.Write([]byte(excludesContent))
 	if err == nil && n < len(excludesContent) {
 		err = io.ErrShortWrite

--- a/snap/snapdir/snapdir_test.go
+++ b/snap/snapdir/snapdir_test.go
@@ -21,7 +21,6 @@ package snapdir_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -47,7 +46,7 @@ func (s *SnapdirTestSuite) TestIsSnapDir(c *C) {
 	d := c.MkDir()
 	err := os.MkdirAll(filepath.Join(d, "meta"), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(d, "meta/snap.yaml"), nil, 0644)
+	err = os.WriteFile(filepath.Join(d, "meta/snap.yaml"), nil, 0644)
 	c.Assert(err, IsNil)
 
 	c.Check(snapdir.IsSnapDir(d), Equals, true)
@@ -62,7 +61,7 @@ func (s *SnapdirTestSuite) TestNotIsSnapDir(c *C) {
 func (s *SnapdirTestSuite) TestReadFile(c *C) {
 	d := c.MkDir()
 	needle := []byte(`stuff`)
-	err := ioutil.WriteFile(filepath.Join(d, "foo"), needle, 0644)
+	err := os.WriteFile(filepath.Join(d, "foo"), needle, 0644)
 	c.Assert(err, IsNil)
 
 	sn := snapdir.New(d)
@@ -74,7 +73,7 @@ func (s *SnapdirTestSuite) TestReadFile(c *C) {
 func (s *SnapdirTestSuite) TestRandomAccessFile(c *C) {
 	d := c.MkDir()
 	needle := []byte(`stuff`)
-	err := ioutil.WriteFile(filepath.Join(d, "foo"), needle, 0644)
+	err := os.WriteFile(filepath.Join(d, "foo"), needle, 0644)
 	c.Assert(err, IsNil)
 
 	sn := snapdir.New(d)
@@ -96,9 +95,9 @@ func (s *SnapdirTestSuite) TestListDir(c *C) {
 
 	err := os.MkdirAll(filepath.Join(d, "test"), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(d, "test", "test1"), nil, 0644)
+	err = os.WriteFile(filepath.Join(d, "test", "test1"), nil, 0644)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(d, "test", "test2"), nil, 0644)
+	err = os.WriteFile(filepath.Join(d, "test", "test2"), nil, 0644)
 	c.Assert(err, IsNil)
 
 	sn := snapdir.New(d)

--- a/snap/snapenv/snapenv_test.go
+++ b/snap/snapenv/snapenv_test.go
@@ -21,7 +21,6 @@ package snapenv
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -149,7 +148,7 @@ func (ts *HTestSuite) TestUserForClassicConfinement(c *C) {
 	// With the classic-preserves-xdg-runtime-dir feature enabled the snap
 	// per-user environment contains no overrides for XDG_RUNTIME_DIR.
 	f := features.ClassicPreservesXdgRuntimeDir
-	c.Assert(ioutil.WriteFile(f.ControlFile(), nil, 0644), IsNil)
+	c.Assert(os.WriteFile(f.ControlFile(), nil, 0644), IsNil)
 	env = userEnv(mockClassicSnapInfo, "/root", nil)
 	c.Assert(env, DeepEquals, osutil.Environment{
 		// NOTE: Both HOME and XDG_RUNTIME_DIR are not defined here.
@@ -281,7 +280,7 @@ func (ts *HTestSuite) TestParallelInstallUserForClassicConfinement(c *C) {
 	// With the classic-preserves-xdg-runtime-dir feature enabled the snap
 	// per-user environment contains no overrides for XDG_RUNTIME_DIR.
 	f := features.ClassicPreservesXdgRuntimeDir
-	c.Assert(ioutil.WriteFile(f.ControlFile(), nil, 0644), IsNil)
+	c.Assert(os.WriteFile(f.ControlFile(), nil, 0644), IsNil)
 	env = userEnv(&info, "/root", nil)
 	c.Assert(env, DeepEquals, osutil.Environment{
 		// NOTE, Both HOME and XDG_RUNTIME_DIR are not defined here.

--- a/snap/snapfile/snapfile_test.go
+++ b/snap/snapfile/snapfile_test.go
@@ -20,7 +20,6 @@
 package snapfile_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -58,7 +57,7 @@ func (s *snapFileTestSuite) TestOpenSquashfs(c *C) {
 	c.Assert(err, IsNil)
 
 	// our regular snap.yaml
-	err = ioutil.WriteFile(filepath.Join(tmp, "meta", "snap.yaml"), []byte("name: foo"), 0644)
+	err = os.WriteFile(filepath.Join(tmp, "meta", "snap.yaml"), []byte("name: foo"), 0644)
 	c.Assert(err, IsNil)
 
 	// build it
@@ -98,7 +97,7 @@ func (s *snapFileTestSuite) TestOpenSnapdir(c *C) {
 	c.Assert(err, IsNil)
 
 	// our regular snap.yaml
-	err = ioutil.WriteFile(filepath.Join(tmp, "meta", "snap.yaml"), []byte("name: foo"), 0644)
+	err = os.WriteFile(filepath.Join(tmp, "meta", "snap.yaml"), []byte("name: foo"), 0644)
 	c.Assert(err, IsNil)
 
 	sn, err := snapfile.Open(tmp)
@@ -127,7 +126,7 @@ func (s *snapFileTestSuite) TestOpenSnapdirUnsupportedFormat(c *C) {
 	// make a file with garbage data
 	tmp := c.MkDir()
 	fn := filepath.Join(tmp, "some-format")
-	err := ioutil.WriteFile(fn, []byte("not-a-real-header"), 0644)
+	err := os.WriteFile(fn, []byte("not-a-real-header"), 0644)
 	c.Assert(err, IsNil)
 
 	_, err = snapfile.Open(fn)
@@ -144,7 +143,7 @@ func (s *snapFileTestSuite) TestOpenSnapdirFileNoExists(c *C) {
 
 func (s *snapFileTestSuite) TestOpenSnapdirFileEmpty(c *C) {
 	emptyFile := filepath.Join(c.MkDir(), "foo")
-	err := ioutil.WriteFile(emptyFile, nil, 0644)
+	err := os.WriteFile(emptyFile, nil, 0644)
 	c.Assert(err, IsNil)
 	_, err = snapfile.Open(emptyFile)
 	c.Assert(err, FitsTypeOf, snap.NotSnapError{})
@@ -160,7 +159,7 @@ func (s *snapFileTestSuite) TestFileOpenForSnapDirErrors(c *C) {
 
 func (s *snapFileTestSuite) TestNotSnapErrorInvalidDir(c *C) {
 	tmpdir := c.MkDir()
-	err := ioutil.WriteFile(filepath.Join(tmpdir, "foo"), nil, 0644)
+	err := os.WriteFile(filepath.Join(tmpdir, "foo"), nil, 0644)
 	c.Assert(err, IsNil)
 	_, err = snapfile.Open(tmpdir)
 	c.Assert(err, FitsTypeOf, snap.NotSnapError{})

--- a/snap/snapshots_test.go
+++ b/snap/snapshots_test.go
@@ -21,7 +21,6 @@ package snap_test
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -204,7 +203,7 @@ func (s *snapshotSuite) TestReadSnapshotYamlFailures(c *C) {
 		},
 	} {
 		manifestFile := filepath.Join(c.MkDir(), "snapshots.yaml")
-		err := ioutil.WriteFile(manifestFile, []byte(testData.contents), 0644)
+		err := os.WriteFile(manifestFile, []byte(testData.contents), 0644)
 		c.Assert(err, IsNil)
 		defer snap.MockOsOpen(func(string) (*os.File, error) {
 			return os.Open(manifestFile)
@@ -217,7 +216,7 @@ func (s *snapshotSuite) TestReadSnapshotYamlFailures(c *C) {
 
 func (s *snapshotSuite) TestReadSnapshotYamlHappy(c *C) {
 	manifestFile := filepath.Join(c.MkDir(), "snapshots.yaml")
-	err := ioutil.WriteFile(manifestFile, []byte(snapshotHappyYaml), 0644)
+	err := os.WriteFile(manifestFile, []byte(snapshotHappyYaml), 0644)
 	c.Assert(err, IsNil)
 
 	defer snap.MockOsOpen(func(path string) (*os.File, error) {

--- a/snap/snaptest/snaptest.go
+++ b/snap/snaptest/snaptest.go
@@ -22,7 +22,6 @@ package snaptest
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -63,14 +62,14 @@ func mockSnap(c *check.C, instanceName, yamlText string, sideInfo *snap.SideInfo
 	metaDir := filepath.Join(snapInfo.MountDir(), "meta")
 	err = os.MkdirAll(metaDir, 0755)
 	c.Assert(err, check.IsNil)
-	err = ioutil.WriteFile(filepath.Join(metaDir, "snap.yaml"), []byte(yamlText), 0644)
+	err = os.WriteFile(filepath.Join(metaDir, "snap.yaml"), []byte(yamlText), 0644)
 	c.Assert(err, check.IsNil)
 
 	// Write the .snap to disk
 	err = os.MkdirAll(filepath.Dir(snapInfo.MountFile()), 0755)
 	c.Assert(err, check.IsNil)
 	snapContents := fmt.Sprintf("%s-%s-%s", sideInfo.RealName, sideInfo.SnapID, sideInfo.Revision)
-	err = ioutil.WriteFile(snapInfo.MountFile(), []byte(snapContents), 0644)
+	err = os.WriteFile(snapInfo.MountFile(), []byte(snapContents), 0644)
 	c.Assert(err, check.IsNil)
 	snapInfo.Size = int64(len(snapContents))
 
@@ -186,7 +185,7 @@ func PopulateDir(dir string, files [][]string) {
 		if err != nil {
 			panic(err)
 		}
-		err = ioutil.WriteFile(fpath, []byte(content), 0755)
+		err = os.WriteFile(fpath, []byte(content), 0755)
 		if err != nil {
 			panic(err)
 		}
@@ -216,7 +215,7 @@ func MakeTestSnapInfoWithFiles(c *check.C, snapYamlContent string, files [][]str
 	err := os.MkdirAll(filepath.Join(snapSource, "meta"), 0755)
 	c.Assert(err, check.IsNil)
 	snapYamlFn := filepath.Join(snapSource, "meta", "snap.yaml")
-	err = ioutil.WriteFile(snapYamlFn, []byte(snapYamlContent), 0644)
+	err = os.WriteFile(snapYamlFn, []byte(snapYamlContent), 0644)
 	c.Assert(err, check.IsNil)
 	PopulateDir(snapSource, files)
 	restoreSanitize := snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {})

--- a/snap/squashfs/squashfs_test.go
+++ b/snap/squashfs/squashfs_test.go
@@ -65,17 +65,17 @@ func makeSnapContents(c *C, manifest, data string) string {
 	c.Assert(err, IsNil)
 
 	// our regular snap.yaml
-	err = ioutil.WriteFile(filepath.Join(tmp, "meta", "snap.yaml"), []byte(manifest), 0644)
+	err = os.WriteFile(filepath.Join(tmp, "meta", "snap.yaml"), []byte(manifest), 0644)
 	c.Assert(err, IsNil)
 
 	// some hooks
-	err = ioutil.WriteFile(filepath.Join(tmp, "meta", "hooks", "foo-hook"), nil, 0755)
+	err = os.WriteFile(filepath.Join(tmp, "meta", "hooks", "foo-hook"), nil, 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(tmp, "meta", "hooks", "bar-hook"), nil, 0755)
+	err = os.WriteFile(filepath.Join(tmp, "meta", "hooks", "bar-hook"), nil, 0755)
 	c.Assert(err, IsNil)
 	// And a file in another directory in there, just for testing (not a valid
 	// hook)
-	err = ioutil.WriteFile(filepath.Join(tmp, "meta", "hooks", "dir", "baz"), nil, 0755)
+	err = os.WriteFile(filepath.Join(tmp, "meta", "hooks", "dir", "baz"), nil, 0755)
 	c.Assert(err, IsNil)
 
 	// some empty directories
@@ -83,7 +83,7 @@ func makeSnapContents(c *C, manifest, data string) string {
 	c.Assert(err, IsNil)
 
 	// some data
-	err = ioutil.WriteFile(filepath.Join(tmp, "data.bin"), []byte(data), 0644)
+	err = os.WriteFile(filepath.Join(tmp, "data.bin"), []byte(data), 0644)
 	c.Assert(err, IsNil)
 
 	return tmp
@@ -148,7 +148,7 @@ func (s *SquashfsTestSuite) TestNotFileHasSquashfsHeader(c *C) {
 	}
 
 	for _, d := range data {
-		err := ioutil.WriteFile("not-a-snap", []byte(d), 0644)
+		err := os.WriteFile("not-a-snap", []byte(d), 0644)
 		c.Assert(err, IsNil)
 
 		c.Check(squashfs.FileHasSquashfsHeader("not-a-snap"), Equals, false)
@@ -592,9 +592,9 @@ func (s *SquashfsTestSuite) TestBuildAll(c *C) {
 	buildDir := c.MkDir()
 	err := os.MkdirAll(filepath.Join(buildDir, "/random/dir"), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(buildDir, "data.bin"), []byte("data"), 0644)
+	err = os.WriteFile(filepath.Join(buildDir, "data.bin"), []byte("data"), 0644)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(buildDir, "random", "data.bin"), []byte("more data"), 0644)
+	err = os.WriteFile(filepath.Join(buildDir, "random", "data.bin"), []byte("more data"), 0644)
 	c.Assert(err, IsNil)
 
 	sn := squashfs.New(filepath.Join(c.MkDir(), "foo.snap"))
@@ -625,13 +625,13 @@ func (s *SquashfsTestSuite) TestBuildUsesExcludes(c *C) {
 	buildDir := c.MkDir()
 	err := os.MkdirAll(filepath.Join(buildDir, "/random/dir"), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(buildDir, "data.bin"), []byte("data"), 0644)
+	err = os.WriteFile(filepath.Join(buildDir, "data.bin"), []byte("data"), 0644)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(buildDir, "random", "data.bin"), []byte("more data"), 0644)
+	err = os.WriteFile(filepath.Join(buildDir, "random", "data.bin"), []byte("more data"), 0644)
 	c.Assert(err, IsNil)
 
 	excludesFilename := filepath.Join(buildDir, ".snapignore")
-	err = ioutil.WriteFile(excludesFilename, []byte(`
+	err = os.WriteFile(excludesFilename, []byte(`
 # ignore just one of the data.bin files we just added (the toplevel one)
 data.bin
 # also ignore ourselves
@@ -872,16 +872,16 @@ func (s *SquashfsTestSuite) TestBuildChecksReadDifferentFiles(c *C) {
 
 	err := os.MkdirAll(filepath.Join(d, "ro-dir"), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(d, "ro-dir", "in-ro-dir"), []byte("123"), 0664)
+	err = os.WriteFile(filepath.Join(d, "ro-dir", "in-ro-dir"), []byte("123"), 0664)
 	c.Assert(err, IsNil)
 	err = os.Chmod(filepath.Join(d, "ro-dir"), 0000)
 	c.Assert(err, IsNil)
 	// so that tear down does not complain
 	defer os.Chmod(filepath.Join(d, "ro-dir"), 0755)
 
-	err = ioutil.WriteFile(filepath.Join(d, "ro-file"), []byte("123"), 0000)
+	err = os.WriteFile(filepath.Join(d, "ro-file"), []byte("123"), 0000)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(d, "ro-empty-file"), nil, 0000)
+	err = os.WriteFile(filepath.Join(d, "ro-empty-file"), nil, 0000)
 	c.Assert(err, IsNil)
 
 	err = syscall.Mkfifo(filepath.Join(d, "fifo"), 0000)
@@ -907,7 +907,7 @@ func (s *SquashfsTestSuite) TestBuildChecksReadErrorLimit(c *C) {
 	// make more than maxErrPaths entries
 	for i := 0; i < squashfs.MaxErrPaths; i++ {
 		p := filepath.Join(d, fmt.Sprintf("0%d", i))
-		err := ioutil.WriteFile(p, []byte("123"), 0000)
+		err := os.WriteFile(p, []byte("123"), 0000)
 		c.Assert(err, IsNil)
 		err = os.Chmod(p, 0000)
 		c.Assert(err, IsNil)

--- a/snap/sysparams/sysparams_test.go
+++ b/snap/sysparams/sysparams_test.go
@@ -21,7 +21,6 @@ package sysparams_test
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -92,7 +91,7 @@ func (s *sysParamsTestSuite) TestWriteFailure(c *C) {
 func (s *sysParamsTestSuite) TestOpenExisting(c *C) {
 	sspPath := dirs.SnapSystemParamsUnder(dirs.GlobalRootDir)
 	c.Assert(os.MkdirAll(path.Dir(sspPath), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(sspPath, []byte("homedirs=my-path/foo/bar,foo\n"), 0644), IsNil)
+	c.Assert(os.WriteFile(sspPath, []byte("homedirs=my-path/foo/bar,foo\n"), 0644), IsNil)
 
 	ssp, err := sysparams.Open("")
 	c.Check(err, IsNil)
@@ -103,7 +102,7 @@ func (s *sysParamsTestSuite) TestOpenExisting(c *C) {
 func (s *sysParamsTestSuite) TestOpenExistingEmpty(c *C) {
 	sspPath := dirs.SnapSystemParamsUnder(dirs.GlobalRootDir)
 	c.Assert(os.MkdirAll(path.Dir(sspPath), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(sspPath, []byte("\n"), 0644), IsNil)
+	c.Assert(os.WriteFile(sspPath, []byte("\n"), 0644), IsNil)
 
 	ssp, err := sysparams.Open("")
 	c.Check(err, IsNil)
@@ -113,7 +112,7 @@ func (s *sysParamsTestSuite) TestOpenExistingEmpty(c *C) {
 func (s *sysParamsTestSuite) TestOpenExistingWithInvalidContent(c *C) {
 	sspPath := dirs.SnapSystemParamsUnder(dirs.GlobalRootDir)
 	c.Assert(os.MkdirAll(path.Dir(sspPath), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(sspPath, []byte("xuifu93\n"), 0644), IsNil)
+	c.Assert(os.WriteFile(sspPath, []byte("xuifu93\n"), 0644), IsNil)
 
 	ssp, err := sysparams.Open("")
 	c.Check(err, ErrorMatches, `cannot parse system-params: invalid line: "xuifu93"`)
@@ -123,7 +122,7 @@ func (s *sysParamsTestSuite) TestOpenExistingWithInvalidContent(c *C) {
 func (s *sysParamsTestSuite) TestOpenExistingWithComments(c *C) {
 	sspPath := dirs.SnapSystemParamsUnder(dirs.GlobalRootDir)
 	c.Assert(os.MkdirAll(path.Dir(sspPath), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(sspPath, []byte("# this is a comment line\n"), 0644), IsNil)
+	c.Assert(os.WriteFile(sspPath, []byte("# this is a comment line\n"), 0644), IsNil)
 
 	ssp, err := sysparams.Open("")
 	c.Check(err, IsNil)
@@ -133,7 +132,7 @@ func (s *sysParamsTestSuite) TestOpenExistingWithComments(c *C) {
 func (s *sysParamsTestSuite) TestOpenExistingWithDoubleEqual(c *C) {
 	sspPath := dirs.SnapSystemParamsUnder(dirs.GlobalRootDir)
 	c.Assert(os.MkdirAll(path.Dir(sspPath), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(sspPath, []byte("homedirs=my-path/foo/bar,foo=bar\n"), 0644), IsNil)
+	c.Assert(os.WriteFile(sspPath, []byte("homedirs=my-path/foo/bar,foo=bar\n"), 0644), IsNil)
 
 	ssp, err := sysparams.Open("")
 	c.Check(err, IsNil)
@@ -147,7 +146,7 @@ homedirs=foo/baz
 `
 	sspPath := dirs.SnapSystemParamsUnder(dirs.GlobalRootDir)
 	c.Assert(os.MkdirAll(path.Dir(sspPath), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(sspPath, []byte(contents), 0644), IsNil)
+	c.Assert(os.WriteFile(sspPath, []byte(contents), 0644), IsNil)
 
 	ssp, err := sysparams.Open("")
 	c.Check(err, ErrorMatches, `cannot parse system-params: duplicate entry found: "homedirs"`)

--- a/snapdtool/cmdutil_test.go
+++ b/snapdtool/cmdutil_test.go
@@ -21,7 +21,6 @@ package snapdtool_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -57,12 +56,12 @@ func (s *cmdutilSuite) makeMockLdSoConf(c *C, root string) {
 	err = os.MkdirAll(ldSoConfD, 0755)
 	c.Assert(err, IsNil)
 
-	err = ioutil.WriteFile(ldSoConf, []byte("include /etc/ld.so.conf.d/*.conf"), 0644)
+	err = os.WriteFile(ldSoConf, []byte("include /etc/ld.so.conf.d/*.conf"), 0644)
 	c.Assert(err, IsNil)
 
 	ldSoConf1 := filepath.Join(ldSoConfD, "x86_64-linux-gnu.conf")
 
-	err = ioutil.WriteFile(ldSoConf1, []byte(`
+	err = os.WriteFile(ldSoConf1, []byte(`
 # Multiarch support
 /lib/x86_64-linux-gnu
 /usr/lib/x86_64-linux-gnu`), 0644)

--- a/snapdtool/info_file_test.go
+++ b/snapdtool/info_file_test.go
@@ -21,7 +21,7 @@ package snapdtool_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	. "gopkg.in/check.v1"
@@ -41,7 +41,7 @@ func (s *infoFileSuite) TestNoVersionFile(c *C) {
 func (s *infoFileSuite) TestNoVersionData(c *C) {
 	top := c.MkDir()
 	infoFile := filepath.Join(top, "info")
-	c.Assert(ioutil.WriteFile(infoFile, []byte("foo"), 0644), IsNil)
+	c.Assert(os.WriteFile(infoFile, []byte("foo"), 0644), IsNil)
 
 	_, _, err := snapdtool.SnapdVersionFromInfoFile(top)
 	c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot find version in snapd info file %q`, infoFile))
@@ -50,7 +50,7 @@ func (s *infoFileSuite) TestNoVersionData(c *C) {
 func (s *infoFileSuite) TestVersionHappy(c *C) {
 	top := c.MkDir()
 	infoFile := filepath.Join(top, "info")
-	c.Assert(ioutil.WriteFile(infoFile, []byte("VERSION=1.2.3"), 0644), IsNil)
+	c.Assert(os.WriteFile(infoFile, []byte("VERSION=1.2.3"), 0644), IsNil)
 
 	ver, flags, err := snapdtool.SnapdVersionFromInfoFile(top)
 	c.Assert(err, IsNil)
@@ -61,7 +61,7 @@ func (s *infoFileSuite) TestVersionHappy(c *C) {
 func (s *infoFileSuite) TestInfoVersionFlags(c *C) {
 	top := c.MkDir()
 	infoFile := filepath.Join(top, "info")
-	c.Assert(ioutil.WriteFile(infoFile, []byte("VERSION=1.2.3\nFOO=BAR"), 0644), IsNil)
+	c.Assert(os.WriteFile(infoFile, []byte("VERSION=1.2.3\nFOO=BAR"), 0644), IsNil)
 
 	ver, flags, err := snapdtool.SnapdVersionFromInfoFile(top)
 	c.Assert(err, IsNil)

--- a/snapdtool/tool_linux_test.go
+++ b/snapdtool/tool_linux_test.go
@@ -98,7 +98,7 @@ func benchmarkCSRE(b *testing.B, data string) {
 		b.Fatalf("mkdirall: %v", err)
 	}
 
-	if err = ioutil.WriteFile(filepath.Join(tempdir, dirs.CoreLibExecDir, "info"), []byte(data), 0600); err != nil {
+	if err = os.WriteFile(filepath.Join(tempdir, dirs.CoreLibExecDir, "info"), []byte(data), 0600); err != nil {
 		b.Fatalf("%v", err)
 	}
 	b.ResetTimer()

--- a/snapdtool/tool_test.go
+++ b/snapdtool/tool_test.go
@@ -21,7 +21,6 @@ package snapdtool_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -80,13 +79,13 @@ func (s *toolSuite) syscallExec(argv0 string, argv []string, envv []string) (err
 func (s *toolSuite) fakeCoreVersion(c *C, coreDir, version string) {
 	p := filepath.Join(coreDir, "/usr/lib/snapd")
 	c.Assert(os.MkdirAll(p, 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(p, "info"), []byte("VERSION="+version), 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(p, "info"), []byte("VERSION="+version), 0644), IsNil)
 }
 
 func (s *toolSuite) fakeInternalTool(c *C, coreDir, toolName string) string {
 	s.fakeCoreVersion(c, coreDir, "42")
 	p := filepath.Join(coreDir, "/usr/lib/snapd", toolName)
-	c.Assert(ioutil.WriteFile(p, nil, 0755), IsNil)
+	c.Assert(os.WriteFile(p, nil, 0755), IsNil)
 
 	return p
 }
@@ -173,7 +172,7 @@ func (s *toolSuite) TestSystemSnapSupportsReExecBadInfoContent(c *C) {
 	// can't understand snapd/info if all it holds are potatoes
 	p := s.snapdPath + "/usr/lib/snapd"
 	c.Assert(os.MkdirAll(p, 0755), IsNil)
-	c.Assert(ioutil.WriteFile(p+"/info", []byte("potatoes"), 0644), IsNil)
+	c.Assert(os.WriteFile(p+"/info", []byte("potatoes"), 0644), IsNil)
 
 	c.Check(snapdtool.SystemSnapSupportsReExec(s.snapdPath), Equals, false)
 }
@@ -277,7 +276,7 @@ func (s *toolSuite) TestInternalToolPathWithOtherDevLocationWhenExecutable(c *C)
 	devTool := filepath.Join(dirs.GlobalRootDir, "/tmp/potato")
 	err := os.MkdirAll(filepath.Dir(devTool), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(devTool, []byte(""), 0755)
+	err = os.WriteFile(devTool, []byte(""), 0755)
 	c.Assert(err, IsNil)
 
 	path, err := snapdtool.InternalToolPath("potato")
@@ -294,7 +293,7 @@ func (s *toolSuite) TestInternalToolPathWithOtherDevLocationNonExecutable(c *C) 
 	devTool := filepath.Join(dirs.GlobalRootDir, "/tmp/non-executable-potato")
 	err := os.MkdirAll(filepath.Dir(devTool), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(devTool, []byte(""), 0644)
+	err = os.WriteFile(devTool, []byte(""), 0644)
 	c.Assert(err, IsNil)
 
 	path, err := snapdtool.InternalToolPath("non-executable-potato")

--- a/store/cache_test.go
+++ b/store/cache_test.go
@@ -21,7 +21,6 @@ package store_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -56,7 +55,7 @@ func (s *cacheSuite) makeTestFile(c *C, name, content string) string {
 }
 func (s *cacheSuite) makeTestFileInDir(c *C, dir, name, content string) string {
 	p := filepath.Join(dir, name)
-	err := ioutil.WriteFile(p, []byte(content), 0644)
+	err := os.WriteFile(p, []byte(content), 0644)
 	c.Assert(err, IsNil)
 	return p
 }
@@ -185,7 +184,7 @@ func (s *cacheSuite) TestCleanupContinuesOnError(c *C) {
 
 func (s *cacheSuite) TestHardLinkCount(c *C) {
 	p := filepath.Join(s.tmp, "foo")
-	err := ioutil.WriteFile(p, nil, 0644)
+	err := os.WriteFile(p, nil, 0644)
 	c.Assert(err, IsNil)
 
 	// trivial case
@@ -218,7 +217,7 @@ func (s *cacheSuite) TestHardLinkCount(c *C) {
 
 func (s *cacheSuite) TestCacheHitOnErrExist(c *C) {
 	targetPath := filepath.Join(s.tmp, "foo")
-	err := ioutil.WriteFile(targetPath, nil, 0644)
+	err := os.WriteFile(targetPath, nil, 0644)
 	c.Assert(err, IsNil)
 
 	// put file in target path

--- a/store/download_test.go
+++ b/store/download_test.go
@@ -26,7 +26,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -672,7 +671,7 @@ func (s *downloadSuite) TestDownloadWithDelta(c *C) {
 		defer restore()
 		restore = store.MockApplyDelta(func(_ *store.Store, name string, deltaPath string, deltaInfo *snap.DeltaInfo, targetPath string, targetSha3_384 string) error {
 			c.Check(deltaInfo, Equals, &testCase.info.Deltas[0])
-			err := ioutil.WriteFile(targetPath, []byte("snap-content-via-delta"), 0644)
+			err := os.WriteFile(targetPath, []byte("snap-content-via-delta"), 0644)
 			c.Assert(err, IsNil)
 			return nil
 		})

--- a/store/store_download_test.go
+++ b/store/store_download_test.go
@@ -126,7 +126,7 @@ func (s *storeDownloadSuite) TestDownloadRangeRequest(c *C) {
 	snap.Size = int64(len(expectedContentStr))
 
 	targetFn := filepath.Join(c.MkDir(), "foo_1.0_all.snap")
-	err := ioutil.WriteFile(targetFn+".partial", []byte(partialContentStr), 0644)
+	err := os.WriteFile(targetFn+".partial", []byte(partialContentStr), 0644)
 	c.Assert(err, IsNil)
 
 	err = s.store.Download(s.ctx, "foo", targetFn, &snap.DownloadInfo, nil, nil, nil)
@@ -145,7 +145,7 @@ func (s *storeDownloadSuite) TestResumeOfCompleted(c *C) {
 	snap.Size = int64(len(expectedContentStr))
 
 	targetFn := filepath.Join(c.MkDir(), "foo_1.0_all.snap")
-	err := ioutil.WriteFile(targetFn+".partial", []byte(expectedContentStr), 0644)
+	err := os.WriteFile(targetFn+".partial", []byte(expectedContentStr), 0644)
 	c.Assert(err, IsNil)
 
 	err = s.store.Download(s.ctx, "foo", targetFn, &snap.DownloadInfo, nil, nil, nil)
@@ -269,7 +269,7 @@ func (s *storeDownloadSuite) TestResumeOfCompletedRetriedOnHashFailure(c *C) {
 	snap.Size = 50000
 
 	targetFn := filepath.Join(c.MkDir(), "foo_1.0_all.snap")
-	c.Assert(ioutil.WriteFile(targetFn+".partial", badbuf, 0644), IsNil)
+	c.Assert(os.WriteFile(targetFn+".partial", badbuf, 0644), IsNil)
 	err := s.store.Download(s.ctx, "foo", targetFn, &snap.DownloadInfo, nil, nil, nil)
 	c.Assert(err, IsNil)
 
@@ -304,7 +304,7 @@ func (s *storeDownloadSuite) TestResumeOfTooMuchDataWorks(c *C) {
 	snap.Size = int64(len(snapContent))
 
 	targetFn := filepath.Join(c.MkDir(), "foo_1.0_all.snap")
-	c.Assert(ioutil.WriteFile(targetFn+".partial", []byte(tooMuchLocalData), 0644), IsNil)
+	c.Assert(os.WriteFile(targetFn+".partial", []byte(tooMuchLocalData), 0644), IsNil)
 	err := s.store.Download(s.ctx, "foo", targetFn, &snap.DownloadInfo, nil, nil, nil)
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, 1)
@@ -365,7 +365,7 @@ func (s *storeDownloadSuite) TestDownloadRangeRequestRetryOnHashError(c *C) {
 	snap.Size = int64(len(expectedContentStr))
 
 	targetFn := filepath.Join(c.MkDir(), "foo_1.0_all.snap")
-	err := ioutil.WriteFile(targetFn+".partial", []byte(partialContentStr), 0644)
+	err := os.WriteFile(targetFn+".partial", []byte(partialContentStr), 0644)
 	c.Assert(err, IsNil)
 
 	err = s.store.Download(s.ctx, "foo", targetFn, &snap.DownloadInfo, nil, nil, nil)
@@ -392,7 +392,7 @@ func (s *storeDownloadSuite) TestDownloadRangeRequestFailOnHashError(c *C) {
 	snap.Size = int64(len(partialContentStr) + 1)
 
 	targetFn := filepath.Join(c.MkDir(), "foo_1.0_all.snap")
-	err := ioutil.WriteFile(targetFn+".partial", []byte(partialContentStr), 0644)
+	err := os.WriteFile(targetFn+".partial", []byte(partialContentStr), 0644)
 	c.Assert(err, IsNil)
 
 	err = s.store.Download(s.ctx, "foo", targetFn, &snap.DownloadInfo, nil, nil, nil)
@@ -649,16 +649,16 @@ func (s *storeDownloadSuite) TestApplyDelta(c *C) {
 		targetSnapPath := filepath.Join(dirs.SnapBlobDir, targetSnapName)
 		err := os.MkdirAll(filepath.Dir(currentSnapPath), 0755)
 		c.Assert(err, IsNil)
-		err = ioutil.WriteFile(currentSnapPath, nil, 0644)
+		err = os.WriteFile(currentSnapPath, nil, 0644)
 		c.Assert(err, IsNil)
 		deltaPath := filepath.Join(dirs.SnapBlobDir, "the.delta")
-		err = ioutil.WriteFile(deltaPath, nil, 0644)
+		err = os.WriteFile(deltaPath, nil, 0644)
 		c.Assert(err, IsNil)
 		// When testing a case where the call to the external
 		// xdelta3 is successful,
 		// simulate the resulting .partial.
 		if testCase.error == "" {
-			err = ioutil.WriteFile(targetSnapPath+".partial", nil, 0644)
+			err = os.WriteFile(targetSnapPath+".partial", nil, 0644)
 			c.Assert(err, IsNil)
 		}
 
@@ -805,7 +805,7 @@ func (s *storeDownloadSuite) TestDownloadStreamCachedOK(c *C) {
 	})()
 
 	c.Assert(os.MkdirAll(dirs.SnapDownloadCacheDir, 0700), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(dirs.SnapDownloadCacheDir, "sha3_384-of-foo"), expectedContent, 0600), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dirs.SnapDownloadCacheDir, "sha3_384-of-foo"), expectedContent, 0600), IsNil)
 
 	cache := store.NewCacheManager(dirs.SnapDownloadCacheDir, 1)
 	defer s.store.MockCacher(cache)()

--- a/store/tooling/tooling_test.go
+++ b/store/tooling/tooling_test.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -149,7 +148,7 @@ func (s *toolingSuite) TestNewToolingStoreInvalidUbuntuStoreURL(c *C) {
 func (s *toolingSuite) TestNewToolingStoreWithAuthFile(c *C) {
 	tmpdir := c.MkDir()
 	authFn := filepath.Join(tmpdir, "auth.json")
-	err := ioutil.WriteFile(authFn, []byte(`{
+	err := os.WriteFile(authFn, []byte(`{
 "macaroon": "MACAROON",
 "discharges": ["DISCHARGE"]
 }`), 0600)
@@ -175,7 +174,7 @@ func (s *toolingSuite) TestNewToolingStoreWithBase64AuthFile(c *C) {
 "d": "DISCHARGE"
 }`)
 	enc := []byte(base64.StdEncoding.EncodeToString(authObj))
-	err := ioutil.WriteFile(authFn, enc, 0600)
+	err := os.WriteFile(authFn, enc, 0600)
 	c.Assert(err, IsNil)
 
 	os.Setenv("UBUNTU_STORE_AUTH_DATA_FILENAME", authFn)
@@ -212,7 +211,7 @@ unbound_discharge =
 	}
 
 	for _, t := range tests {
-		err := ioutil.WriteFile(authFn, []byte(t.data), 0600)
+		err := os.WriteFile(authFn, []byte(t.data), 0600)
 		c.Assert(err, IsNil)
 
 		_, err = tooling.NewToolingStore()
@@ -223,7 +222,7 @@ unbound_discharge =
 func (s *toolingSuite) TestNewToolingStoreWithAuthFromSnapcraftLoginFile(c *C) {
 	tmpdir := c.MkDir()
 	authFn := filepath.Join(tmpdir, "auth.json")
-	err := ioutil.WriteFile(authFn, []byte(`[login.ubuntu.com]
+	err := os.WriteFile(authFn, []byte(`[login.ubuntu.com]
 macaroon = MACAROON
 unbound_discharge = DISCHARGE
 

--- a/syscheck/version_test.go
+++ b/syscheck/version_test.go
@@ -20,7 +20,6 @@
 package syscheck_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -104,14 +103,14 @@ func (s *syscheckSuite) TestRHEL7x(c *C) {
 	c.Assert(err, IsNil)
 
 	// the knob is there, but disabled
-	err = ioutil.WriteFile(p, []byte("0\n"), 0644)
+	err = os.WriteFile(p, []byte("0\n"), 0644)
 	c.Assert(err, IsNil)
 
 	err = syscheck.CheckKernelVersion()
 	c.Assert(err, ErrorMatches, "fs.may_detach_mounts kernel parameter is supported but disabled")
 
 	// actually enabled
-	err = ioutil.WriteFile(p, []byte("1\n"), 0644)
+	err = os.WriteFile(p, []byte("1\n"), 0644)
 	c.Assert(err, IsNil)
 
 	err = syscheck.CheckKernelVersion()
@@ -152,14 +151,14 @@ func (s *syscheckSuite) TestCentOS7x(c *C) {
 	c.Assert(err, IsNil)
 
 	// the knob there, but disabled
-	err = ioutil.WriteFile(p, []byte("0\n"), 0644)
+	err = os.WriteFile(p, []byte("0\n"), 0644)
 	c.Assert(err, IsNil)
 
 	err = syscheck.CheckKernelVersion()
 	c.Assert(err, ErrorMatches, "fs.may_detach_mounts kernel parameter is supported but disabled")
 
 	// actually enabled
-	err = ioutil.WriteFile(p, []byte("1\n"), 0644)
+	err = os.WriteFile(p, []byte("1\n"), 0644)
 	c.Assert(err, IsNil)
 
 	err = syscheck.CheckKernelVersion()

--- a/sysconfig/cloudinit.go
+++ b/sysconfig/cloudinit.go
@@ -60,7 +60,7 @@ func DisableCloudInit(rootDir string) error {
 	if err := os.MkdirAll(ubuntuDataCloud, 0755); err != nil {
 		return fmt.Errorf("cannot make cloud config dir: %v", err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(ubuntuDataCloud, "cloud-init.disabled"), nil, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(ubuntuDataCloud, "cloud-init.disabled"), nil, 0644); err != nil {
 		return fmt.Errorf("cannot disable cloud-init: %v", err)
 	}
 
@@ -650,7 +650,7 @@ func configureCloudInit(model *asserts.Model, opts *Options) (err error) {
 		// measure
 		yaml := []byte(fmt.Sprintf(genericCloudRestrictYamlPattern, strings.Join(installOpts.AllowedDatasources, ",")))
 		restrictFile := filepath.Join(ubuntuDataCloudDir(WritableDefaultsDir(opts.TargetRootDir)), "cloud.cfg.d/99_snapd_datasource.cfg")
-		return ioutil.WriteFile(restrictFile, yaml, 0644)
+		return os.WriteFile(restrictFile, yaml, 0644)
 	}
 
 	return nil
@@ -931,13 +931,13 @@ func RestrictCloudInit(state CloudInitState, opts *CloudInitRestrictOptions) (Cl
 		// labels to use as datasources, i.e. a USB drive inserted by an
 		// attacker with label CIDATA will defeat security measures on Ubuntu
 		// Core, so with the additional fs_label spec, we disable that import.
-		err = ioutil.WriteFile(cloudInitRestrictFile, nocloudRestrictYaml, 0644)
+		err = os.WriteFile(cloudInitRestrictFile, nocloudRestrictYaml, 0644)
 	default:
 		// all other cases are either not local on UC20, or not NoCloud and as
 		// such we simply restrict cloud-init to the specific datasource used so
 		// that an attack via NoCloud is protected against
 		yaml := []byte(fmt.Sprintf(genericCloudRestrictYamlPattern, res.DataSource))
-		err = ioutil.WriteFile(cloudInitRestrictFile, yaml, 0644)
+		err = os.WriteFile(cloudInitRestrictFile, yaml, 0644)
 	}
 
 	return res, err

--- a/sysconfig/cloudinit_test.go
+++ b/sysconfig/cloudinit_test.go
@@ -61,7 +61,7 @@ func (s *sysconfigSuite) makeCloudCfgSrcDirFiles(c *C, cfgs ...string) (string, 
 	names := make([]string, 0, len(cfgs))
 	for i, mockCfg := range cfgs {
 		configFileName := fmt.Sprintf("seed-config-%d.cfg", i)
-		err := ioutil.WriteFile(filepath.Join(cloudCfgSrcDir, configFileName), []byte(mockCfg), 0644)
+		err := os.WriteFile(filepath.Join(cloudCfgSrcDir, configFileName), []byte(mockCfg), 0644)
 		c.Assert(err, IsNil)
 		names = append(names, configFileName)
 	}
@@ -74,7 +74,7 @@ func (s *sysconfigSuite) makeGadgetCloudConfFile(c *C, content string) string {
 	if content == "" {
 		content = "#cloud-config some gadget cloud config"
 	}
-	err := ioutil.WriteFile(gadgetCloudConf, []byte(content), 0644)
+	err := os.WriteFile(gadgetCloudConf, []byte(content), 0644)
 	c.Assert(err, IsNil)
 
 	return gadgetDir
@@ -90,7 +90,7 @@ func (s *sysconfigSuite) TestHasGadgetCloudConf(c *C) {
 
 	// creating one now is true
 	gadgetCloudConf := filepath.Join(gadgetDir, "cloud.conf")
-	err := ioutil.WriteFile(gadgetCloudConf, []byte("gadget cloud config"), 0644)
+	err := os.WriteFile(gadgetCloudConf, []byte("gadget cloud config"), 0644)
 	c.Assert(err, IsNil)
 
 	c.Assert(sysconfig.HasGadgetCloudConf(gadgetDir), Equals, true)
@@ -665,7 +665,7 @@ fi
 			cloudDir := filepath.Join(dirs.GlobalRootDir, "etc/cloud")
 			err := os.MkdirAll(cloudDir, 0755)
 			c.Assert(err, IsNil)
-			err = ioutil.WriteFile(filepath.Join(cloudDir, "cloud-init.disabled"), nil, 0644)
+			err = os.WriteFile(filepath.Join(cloudDir, "cloud-init.disabled"), nil, 0644)
 			c.Assert(err, IsNil)
 		}
 
@@ -673,7 +673,7 @@ fi
 			cloudDir := filepath.Join(dirs.GlobalRootDir, "etc/cloud/cloud.cfg.d")
 			err := os.MkdirAll(cloudDir, 0755)
 			c.Assert(err, IsNil)
-			err = ioutil.WriteFile(filepath.Join(cloudDir, "zzzz_snapd.cfg"), nil, 0644)
+			err = os.WriteFile(filepath.Join(cloudDir, "zzzz_snapd.cfg"), nil, 0644)
 			c.Assert(err, IsNil)
 		}
 
@@ -929,7 +929,7 @@ func (s *sysconfigSuite) TestRestrictCloudInit(c *C) {
 		if t.cloudInitStatusJSON != "" {
 			err := os.MkdirAll(filepath.Dir(statusJSONFile), 0755)
 			c.Assert(err, IsNil, comment)
-			err = ioutil.WriteFile(statusJSONFile, []byte(t.cloudInitStatusJSON), 0644)
+			err = os.WriteFile(statusJSONFile, []byte(t.cloudInitStatusJSON), 0644)
 			c.Assert(err, IsNil, comment)
 		}
 
@@ -1117,7 +1117,7 @@ func (s *sysconfigSuite) TestCloudDatasourcesInUse(c *C) {
 	for _, t := range tt {
 		comment := Commentf(t.comment)
 		configFile := filepath.Join(c.MkDir(), "cloud.conf")
-		err := ioutil.WriteFile(configFile, []byte(t.configFileContent), 0644)
+		err := os.WriteFile(configFile, []byte(t.configFileContent), 0644)
 		c.Assert(err, IsNil, comment)
 		res, err := sysconfig.CloudDatasourcesInUse(configFile)
 		if t.expError != "" {
@@ -1243,7 +1243,7 @@ func (s *sysconfigSuite) TestCloudDatasourcesInUseForDirInUse(c *C) {
 		dir := c.MkDir()
 		for basename, content := range t.configFilesContents {
 			configFile := filepath.Join(dir, basename)
-			err := ioutil.WriteFile(configFile, []byte(content), 0644)
+			err := os.WriteFile(configFile, []byte(content), 0644)
 			c.Assert(err, IsNil, comment)
 		}
 
@@ -1428,7 +1428,7 @@ reporting:
 	for i, t := range tt {
 		comment := Commentf(t.comment)
 		inFile := filepath.Join(dir, fmt.Sprintf("%d.cfg", i))
-		err := ioutil.WriteFile(inFile, []byte(t.inStr), 0755)
+		err := os.WriteFile(inFile, []byte(t.inStr), 0755)
 		c.Assert(err, IsNil, comment)
 
 		out, err := sysconfig.FilterCloudCfgFile(inFile, []string{"MAAS"})

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -1146,7 +1146,7 @@ func (s *SystemdTestSuite) TestMountUnitPath(c *C) {
 func makeMockFile(c *C, path string) {
 	err := os.MkdirAll(filepath.Dir(path), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(path, nil, 0644)
+	err = os.WriteFile(path, nil, 0644)
 	c.Assert(err, IsNil)
 }
 
@@ -1219,7 +1219,7 @@ LazyUnmount=yes
 WantedBy=snapd.mounts.target
 WantedBy=multi-user.target
 `[1:], mockSnapPath)
-	err = ioutil.WriteFile(filepath.Join(dirs.SnapServicesDir, "snap-snapname-123.mount"), []byte(content), 0644)
+	err = os.WriteFile(filepath.Join(dirs.SnapServicesDir, "snap-snapname-123.mount"), []byte(content), 0644)
 	c.Assert(err, IsNil)
 
 	mountUnitName, err := NewUnderRoot(rootDir, SystemMode, nil).EnsureMountUnitFile("foo", "42", mockSnapPath, "/snap/snapname/123", "squashfs")
@@ -1279,7 +1279,7 @@ LazyUnmount=yes
 WantedBy=snapd.mounts.target
 WantedBy=multi-user.target
 `[1:], mockSnapPath)
-	err = ioutil.WriteFile(filepath.Join(dirs.SnapServicesDir, "snap-snapname-123.mount"), []byte(content), 0644)
+	err = os.WriteFile(filepath.Join(dirs.SnapServicesDir, "snap-snapname-123.mount"), []byte(content), 0644)
 	c.Assert(err, IsNil)
 
 	mountUnitName, err := NewUnderRoot(rootDir, SystemMode, nil).EnsureMountUnitFile("foo", "42", mockSnapPath, "/snap/snapname/123", "squashfs")
@@ -1409,7 +1409,7 @@ func (s *SystemdTestSuite) TestWriteSELinuxMountUnit(c *C) {
 	mockSnapPath := filepath.Join(c.MkDir(), "/var/lib/snappy/snaps/foo_1.0.snap")
 	err := os.MkdirAll(filepath.Dir(mockSnapPath), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(mockSnapPath, nil, 0644)
+	err = os.WriteFile(mockSnapPath, nil, 0644)
 	c.Assert(err, IsNil)
 
 	mountUnitName, err := New(SystemMode, nil).EnsureMountUnitFile("foo", "42", mockSnapPath, "/snap/snapname/123", "squashfs")
@@ -1455,7 +1455,7 @@ exit 0
 	mockSnapPath := filepath.Join(c.MkDir(), "/var/lib/snappy/snaps/foo_1.0.snap")
 	err := os.MkdirAll(filepath.Dir(mockSnapPath), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(mockSnapPath, nil, 0644)
+	err = os.WriteFile(mockSnapPath, nil, 0644)
 	c.Assert(err, IsNil)
 
 	mountUnitName, err := New(SystemMode, nil).EnsureMountUnitFile("foo", "x1", mockSnapPath, "/snap/snapname/123", "squashfs")
@@ -1497,7 +1497,7 @@ exit 0
 	mockSnapPath := filepath.Join(c.MkDir(), "/var/lib/snappy/snaps/foo_1.0.snap")
 	err := os.MkdirAll(filepath.Dir(mockSnapPath), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(mockSnapPath, nil, 0644)
+	err = os.WriteFile(mockSnapPath, nil, 0644)
 	c.Assert(err, IsNil)
 
 	mountUnitName, err := New(SystemMode, nil).EnsureMountUnitFile("foo", "x1", mockSnapPath, "/snap/snapname/123", "squashfs")
@@ -1624,7 +1624,7 @@ func (s *SystemdTestSuite) TestIsActiveUnexpectedErr(c *C) {
 
 func makeMockMountUnit(c *C, mountDir string) string {
 	mountUnit := MountUnitPath(dirs.StripRootDir(mountDir))
-	err := ioutil.WriteFile(mountUnit, nil, 0644)
+	err := os.WriteFile(mountUnit, nil, 0644)
 	c.Assert(err, IsNil)
 	return mountUnit
 }
@@ -1843,7 +1843,7 @@ LazyUnmount=yes
 WantedBy=snapd.mounts.target
 WantedBy=multi-user.target
 `[1:], mockSnapPath)
-	err = ioutil.WriteFile(filepath.Join(dirs.SnapServicesDir, "snap-snapname-123.mount"), []byte(content), 0644)
+	err = os.WriteFile(filepath.Join(dirs.SnapServicesDir, "snap-snapname-123.mount"), []byte(content), 0644)
 	c.Assert(err, IsNil)
 
 	_, err = sysd.EnsureMountUnitFile("foo", "42", mockSnapPath, "/snap/snapname/123", "squashfs")
@@ -1888,7 +1888,7 @@ LazyUnmount=yes
 WantedBy=snapd.mounts.target
 WantedBy=multi-user.target
 `[1:], mockSnapPath)
-	err = ioutil.WriteFile(filepath.Join(dirs.SnapServicesDir, "snap-snapname-123.mount"), []byte(content), 0644)
+	err = os.WriteFile(filepath.Join(dirs.SnapServicesDir, "snap-snapname-123.mount"), []byte(content), 0644)
 	c.Assert(err, IsNil)
 
 	mountUnitName, err := sysd.EnsureMountUnitFile("foo", "42", mockSnapPath, "/snap/snapname/123", "squashfs")
@@ -2091,7 +2091,7 @@ Options=do,not,matter,either
 WantedBy=doesntmatter.target
 X-SnapdOrigin=%s
 `, snapName, where, origin)
-		return ioutil.WriteFile(path, []byte(contents), 0644)
+		return os.WriteFile(path, []byte(contents), 0644)
 	}
 
 	// Prepare the unit files

--- a/tests/lib/fakestore/refresh/refresh.go
+++ b/tests/lib/fakestore/refresh/refresh.go
@@ -108,7 +108,7 @@ func writeAssert(a asserts.Assertion, targetDir string) (string, error) {
 	if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
 		return "", err
 	}
-	err := ioutil.WriteFile(p, asserts.Encode(a), 0644)
+	err := os.WriteFile(p, asserts.Encode(a), 0644)
 	return p, err
 }
 

--- a/tests/lib/fakestore/store/store_test.go
+++ b/tests/lib/fakestore/store/store_test.go
@@ -482,7 +482,7 @@ func (s *storeTestSuite) TestAssertionsEndpointFromAssertsDir(c *C) {
 	c.Assert(err, IsNil)
 	rev := a.(*asserts.SnapRevision)
 
-	err = ioutil.WriteFile(filepath.Join(s.store.assertDir, "foo_36.snap-revision"), []byte(exampleSnapRev), 0655)
+	err = os.WriteFile(filepath.Join(s.store.assertDir, "foo_36.snap-revision"), []byte(exampleSnapRev), 0655)
 	c.Assert(err, IsNil)
 
 	resp, err := s.StoreGet(`/v2/assertions/snap-revision/` + rev.SnapSHA3_384())
@@ -496,7 +496,7 @@ func (s *storeTestSuite) TestAssertionsEndpointFromAssertsDir(c *C) {
 }
 
 func (s *storeTestSuite) TestAssertionsEndpointSequenceAssertion(c *C) {
-	err := ioutil.WriteFile(filepath.Join(s.store.assertDir, "base-set.validation-set"), []byte(exampleValidationSet), 0655)
+	err := os.WriteFile(filepath.Join(s.store.assertDir, "base-set.validation-set"), []byte(exampleValidationSet), 0655)
 	c.Assert(err, IsNil)
 
 	resp, err := s.StoreGet(`/v2/assertions/validation-set/16/canonical/base-set?sequence=2`)
@@ -510,7 +510,7 @@ func (s *storeTestSuite) TestAssertionsEndpointSequenceAssertion(c *C) {
 }
 
 func (s *storeTestSuite) TestAssertionsEndpointSequenceAssertionLatest(c *C) {
-	err := ioutil.WriteFile(filepath.Join(s.store.assertDir, "base-set.validation-set"), []byte(exampleValidationSet), 0655)
+	err := os.WriteFile(filepath.Join(s.store.assertDir, "base-set.validation-set"), []byte(exampleValidationSet), 0655)
 	c.Assert(err, IsNil)
 
 	resp, err := s.StoreGet(`/v2/assertions/validation-set/16/canonical/base-set?sequence=latest`)
@@ -524,7 +524,7 @@ func (s *storeTestSuite) TestAssertionsEndpointSequenceAssertionLatest(c *C) {
 }
 
 func (s *storeTestSuite) TestAssertionsEndpointSequenceAssertionInvalidSequence(c *C) {
-	err := ioutil.WriteFile(filepath.Join(s.store.assertDir, "base-set.validation-set"), []byte(exampleValidationSet), 0655)
+	err := os.WriteFile(filepath.Join(s.store.assertDir, "base-set.validation-set"), []byte(exampleValidationSet), 0655)
 	c.Assert(err, IsNil)
 
 	resp, err := s.StoreGet(`/v2/assertions/validation-set/16/canonical/base-set?sequence=0`)

--- a/tests/lib/list-interfaces.go
+++ b/tests/lib/list-interfaces.go
@@ -1,7 +1,10 @@
 package main
 
-import "fmt"
-import "github.com/snapcore/snapd/interfaces/builtin"
+import (
+	"fmt"
+
+	"github.com/snapcore/snapd/interfaces/builtin"
+)
 
 func main() {
 	for _, iface := range builtin.Interfaces() {

--- a/tests/lib/uc20-create-partitions/main.go
+++ b/tests/lib/uc20-create-partitions/main.go
@@ -21,7 +21,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/jessevdk/go-flags"
@@ -105,7 +104,7 @@ func main() {
 			"save-key":     saveKey[:],
 		}
 		for keyFileName, keyData := range toWrite {
-			if err := ioutil.WriteFile(keyFileName, keyData, 0644); err != nil {
+			if err := os.WriteFile(keyFileName, keyData, 0644); err != nil {
 				panic(err)
 			}
 		}

--- a/testutil/dbustest.go
+++ b/testutil/dbustest.go
@@ -22,7 +22,6 @@ package testutil
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -75,7 +74,7 @@ func (s *DBusTest) SetUpSuite(c *C) {
 
 	s.tmpdir = c.MkDir()
 	configFile := filepath.Join(s.tmpdir, "session.conf")
-	err := ioutil.WriteFile(configFile, []byte(fmt.Sprintf(sessionBusConfigTemplate, s.tmpdir)), 0644)
+	err := os.WriteFile(configFile, []byte(fmt.Sprintf(sessionBusConfigTemplate, s.tmpdir)), 0644)
 	c.Assert(err, IsNil)
 	s.dbusDaemon = exec.Command("dbus-daemon", "--print-address", fmt.Sprintf("--config-file=%s", configFile))
 	s.dbusDaemon.Stderr = os.Stderr

--- a/testutil/exec.go
+++ b/testutil/exec.go
@@ -129,7 +129,7 @@ func mockCommand(c *check.C, basename, script, template string) *MockCmd {
 		newpath = binDir + ":" + os.Getenv("PATH")
 	}
 	fmt.Fprintf(&wholeScript, template, logFile, script)
-	err := ioutil.WriteFile(exeFile, wholeScript.Bytes(), 0700)
+	err := os.WriteFile(exeFile, wholeScript.Bytes(), 0700)
 	if err != nil {
 		panic(err)
 	}
@@ -166,7 +166,7 @@ func MockLockedCommand(c *check.C, basename, script string) *MockCmd {
 // Useful when you want to check the ordering of things.
 func (cmd *MockCmd) Also(basename, script string) *MockCmd {
 	exeFile := path.Join(cmd.binDir, basename)
-	err := ioutil.WriteFile(exeFile, []byte(fmt.Sprintf(scriptTpl, cmd.logFile, script)), 0700)
+	err := os.WriteFile(exeFile, []byte(fmt.Sprintf(scriptTpl, cmd.logFile, script)), 0700)
 	if err != nil {
 		panic(err)
 	}

--- a/testutil/filecontentchecker_test.go
+++ b/testutil/filecontentchecker_test.go
@@ -21,7 +21,7 @@ package testutil_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 
@@ -42,11 +42,11 @@ func (s *fileContentCheckerSuite) TestFileEquals(c *check.C) {
 	d := c.MkDir()
 	content := "not-so-random-string"
 	filename := filepath.Join(d, "canary")
-	c.Assert(ioutil.WriteFile(filename, []byte(content), 0644), check.IsNil)
+	c.Assert(os.WriteFile(filename, []byte(content), 0644), check.IsNil)
 	equalRefereceFilename := filepath.Join(d, "canary-reference-equal")
-	c.Assert(ioutil.WriteFile(equalRefereceFilename, []byte(content), 0644), check.IsNil)
+	c.Assert(os.WriteFile(equalRefereceFilename, []byte(content), 0644), check.IsNil)
 	notEqualRefereceFilename := filepath.Join(d, "canary-reference-not-equal")
-	c.Assert(ioutil.WriteFile(notEqualRefereceFilename, []byte("not-equal"), 0644), check.IsNil)
+	c.Assert(os.WriteFile(notEqualRefereceFilename, []byte("not-equal"), 0644), check.IsNil)
 
 	testInfo(c, FileEquals, "FileEquals", []string{"filename", "contents"})
 	testCheck(c, FileEquals, true, "", filename, content)
@@ -72,7 +72,7 @@ func (s *fileContentCheckerSuite) TestFileContains(c *check.C) {
 	d := c.MkDir()
 	content := "not-so-random-string"
 	filename := filepath.Join(d, "canary")
-	c.Assert(ioutil.WriteFile(filename, []byte(content), 0644), check.IsNil)
+	c.Assert(os.WriteFile(filename, []byte(content), 0644), check.IsNil)
 
 	testInfo(c, FileContains, "FileContains", []string{"filename", "contents"})
 	testCheck(c, FileContains, true, "", filename, content[1:])
@@ -99,7 +99,7 @@ func (s *fileContentCheckerSuite) TestFileMatches(c *check.C) {
 	d := c.MkDir()
 	content := "not-so-random-string"
 	filename := filepath.Join(d, "canary")
-	c.Assert(ioutil.WriteFile(filename, []byte(content), 0644), check.IsNil)
+	c.Assert(os.WriteFile(filename, []byte(content), 0644), check.IsNil)
 
 	testInfo(c, FileMatches, "FileMatches", []string{"filename", "regex"})
 	testCheck(c, FileMatches, true, "", filename, ".*")

--- a/testutil/filepresencechecker_test.go
+++ b/testutil/filepresencechecker_test.go
@@ -21,7 +21,7 @@ package testutil_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"gopkg.in/check.v1"
@@ -39,7 +39,7 @@ func (*filePresenceCheckerSuite) TestFilePresent(c *check.C) {
 	testInfo(c, FilePresent, "FilePresent", []string{"filename"})
 	testCheck(c, FilePresent, false, `filename must be a string`, 42)
 	testCheck(c, FilePresent, false, fmt.Sprintf(`file %q is absent but should exist`, filename), filename)
-	c.Assert(ioutil.WriteFile(filename, nil, 0644), check.IsNil)
+	c.Assert(os.WriteFile(filename, nil, 0644), check.IsNil)
 	testCheck(c, FilePresent, true, "", filename)
 }
 
@@ -49,6 +49,6 @@ func (*filePresenceCheckerSuite) TestFileAbsent(c *check.C) {
 	testInfo(c, FileAbsent, "FileAbsent", []string{"filename"})
 	testCheck(c, FileAbsent, false, `filename must be a string`, 42)
 	testCheck(c, FileAbsent, true, "", filename)
-	c.Assert(ioutil.WriteFile(filename, nil, 0644), check.IsNil)
+	c.Assert(os.WriteFile(filename, nil, 0644), check.IsNil)
 	testCheck(c, FileAbsent, false, fmt.Sprintf(`file %q is present but should not exist`, filename), filename)
 }

--- a/usersession/agent/rest_api_test.go
+++ b/usersession/agent/rest_api_test.go
@@ -24,7 +24,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
@@ -534,7 +533,7 @@ func (s *restSuite) TestPostPendingRefreshNotificationBusyAppDesktopFile(c *C) {
 	err := os.MkdirAll(dirs.SnapDesktopFilesDir, 0755)
 	c.Assert(err, IsNil)
 	desktopFilePath := filepath.Join(dirs.SnapDesktopFilesDir, "pkg_app.desktop")
-	err = ioutil.WriteFile(desktopFilePath, []byte(`
+	err = os.WriteFile(desktopFilePath, []byte(`
 [Desktop Entry]
 Icon=app.png
 	`), 0644)
@@ -561,7 +560,7 @@ func (s *restSuite) TestPostPendingRefreshNotificationBusyAppMalformedDesktopFil
 	err := os.MkdirAll(dirs.SnapDesktopFilesDir, 0755)
 	c.Assert(err, IsNil)
 	desktopFilePath := filepath.Join(dirs.SnapDesktopFilesDir, "pkg_app.desktop")
-	err = ioutil.WriteFile(desktopFilePath, []byte(`garbage!`), 0644)
+	err = os.WriteFile(desktopFilePath, []byte(`garbage!`), 0644)
 	c.Assert(err, IsNil)
 
 	s.testPostPendingRefreshNotificationBody(c, refreshInfo)

--- a/usersession/agent/session_agent_test.go
+++ b/usersession/agent/session_agent_test.go
@@ -23,7 +23,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -158,7 +157,7 @@ func (s *sessionAgentSuite) TestExitOnIdle(c *C) {
 func (s *sessionAgentSuite) TestFdoNotification(c *C) {
 	desktopFile := "[Desktop Entry]\nIcon=/path/appicon.png"
 	c.Assert(os.MkdirAll(filepath.Join(dirs.SnapDesktopFilesDir), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(dirs.SnapDesktopFilesDir, "app.desktop"), []byte(desktopFile), 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dirs.SnapDesktopFilesDir, "app.desktop"), []byte(desktopFile), 0644), IsNil)
 
 	backend, err := notificationtest.NewFdoServer()
 	c.Assert(err, IsNil)
@@ -202,7 +201,7 @@ func (s *sessionAgentSuite) TestFdoNotification(c *C) {
 func (s *sessionAgentSuite) TestGtkNotification(c *C) {
 	desktopFile := "[Desktop Entry]\nIcon=/path/appicon.png"
 	c.Assert(os.MkdirAll(filepath.Join(dirs.SnapDesktopFilesDir), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(dirs.SnapDesktopFilesDir, "app.desktop"), []byte(desktopFile), 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dirs.SnapDesktopFilesDir, "app.desktop"), []byte(desktopFile), 0644), IsNil)
 
 	backend, err := notificationtest.NewGtkServer()
 	c.Assert(err, IsNil)

--- a/usersession/autostart/autostart_test.go
+++ b/usersession/autostart/autostart_test.go
@@ -20,7 +20,6 @@
 package autostart_test
 
 import (
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path"
@@ -184,7 +183,7 @@ func (s *autostartSuite) TestTryAutostartInvalid(c *C) {
 func writeFile(c *C, path string, content []byte) {
 	err := os.MkdirAll(filepath.Dir(path), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(path, content, 0644)
+	err = os.WriteFile(path, content, 0644)
 	c.Assert(err, IsNil)
 }
 

--- a/usersession/userd/launcher_test.go
+++ b/usersession/userd/launcher_test.go
@@ -21,7 +21,6 @@ package userd_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -154,7 +153,7 @@ func (s *launcherSuite) TestOpenFileUserAccepts(c *C) {
 	defer restore()
 
 	path := filepath.Join(c.MkDir(), "test.txt")
-	c.Assert(ioutil.WriteFile(path, []byte("Hello world"), 0644), IsNil)
+	c.Assert(os.WriteFile(path, []byte("Hello world"), 0644), IsNil)
 
 	file, err := os.Open(path)
 	c.Assert(err, IsNil)
@@ -175,7 +174,7 @@ func (s *launcherSuite) TestOpenFileUserDeclines(c *C) {
 	defer restore()
 
 	path := filepath.Join(c.MkDir(), "test.txt")
-	c.Assert(ioutil.WriteFile(path, []byte("Hello world"), 0644), IsNil)
+	c.Assert(os.WriteFile(path, []byte("Hello world"), 0644), IsNil)
 
 	file, err := os.Open(path)
 	c.Assert(err, IsNil)
@@ -249,7 +248,7 @@ func (s *launcherSuite) TestFailsOnUbuntuCore(c *C) {
 	defer restore()
 
 	path := filepath.Join(c.MkDir(), "test.txt")
-	c.Assert(ioutil.WriteFile(path, []byte("Hello world"), 0644), IsNil)
+	c.Assert(os.WriteFile(path, []byte("Hello world"), 0644), IsNil)
 	file, err := os.Open(path)
 	c.Assert(err, IsNil)
 	defer file.Close()

--- a/usersession/userd/privileged_desktop_launcher_test.go
+++ b/usersession/userd/privileged_desktop_launcher_test.go
@@ -20,7 +20,6 @@
 package userd_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -63,11 +62,11 @@ func (s *privilegedDesktopLauncherSuite) SetUpTest(c *C) {
 	desktopContent := strings.Replace(tmpMircadeDesktop, "/snap/bin/", dirs.SnapBinariesDir, -1)
 
 	deskTopFile := filepath.Join(dirs.SnapDesktopFilesDir, "mircade_mircade.desktop")
-	c.Assert(ioutil.WriteFile(deskTopFile, []byte(desktopContent), 0644), IsNil)
+	c.Assert(os.WriteFile(deskTopFile, []byte(desktopContent), 0644), IsNil)
 
 	// Create a shadowed desktop file ID
-	c.Assert(ioutil.WriteFile(filepath.Join(dirs.GlobalRootDir, "/usr/share/applications/shadow-test.desktop"), []byte("[Desktop Entry]"), 0644), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(dirs.SnapDesktopFilesDir, "shadow-test.desktop"), []byte("[Desktop Entry]"), 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dirs.GlobalRootDir, "/usr/share/applications/shadow-test.desktop"), []byte("[Desktop Entry]"), 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dirs.SnapDesktopFilesDir, "shadow-test.desktop"), []byte("[Desktop Entry]"), 0644), IsNil)
 
 	s.mockEnv("HOME", filepath.Join(dirs.GlobalRootDir, "/home/user"))
 	s.mockEnv("XDG_DATA_HOME", "")

--- a/usersession/userd/settings_test.go
+++ b/usersession/userd/settings_test.go
@@ -20,7 +20,6 @@
 package userd_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -252,7 +251,7 @@ func (s *settingsSuite) testSetUserDeclined(c *C) {
 	df := filepath.Join(dirs.SnapDesktopFilesDir, "some-snap_bar.desktop")
 	err := os.MkdirAll(filepath.Dir(df), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(df, nil, 0644)
+	err = os.WriteFile(df, nil, 0644)
 	c.Assert(err, IsNil)
 
 	err = s.settings.Set("default-web-browser", "bar.desktop", ":some-dbus-sender")
@@ -294,7 +293,7 @@ func (s *settingsSuite) testSetUserAccepts(c *C) {
 	df := filepath.Join(dirs.SnapDesktopFilesDir, "some-snap_foo.desktop")
 	err := os.MkdirAll(filepath.Dir(df), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(df, nil, 0644)
+	err = os.WriteFile(df, nil, 0644)
 	c.Assert(err, IsNil)
 
 	err = s.settings.Set("default-web-browser", "foo.desktop", ":some-dbus-sender")
@@ -314,7 +313,7 @@ func (s *settingsSuite) testSetUserAcceptsURLScheme(c *C) {
 	df := filepath.Join(dirs.SnapDesktopFilesDir, "some-snap_ircclient.desktop")
 	err := os.MkdirAll(filepath.Dir(df), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(df, nil, 0644)
+	err = os.WriteFile(df, nil, 0644)
 	c.Assert(err, IsNil)
 
 	err = s.settings.SetSub("default-url-scheme-handler", "irc", "ircclient.desktop", ":some-dbus-sender")
@@ -384,7 +383,7 @@ func (s *settingsSuite) TestSetUserAcceptsZenityUrlSchemeXdgSettingsError(c *C) 
 	df := filepath.Join(dirs.SnapDesktopFilesDir, "some-snap_ircclient.desktop")
 	err := os.MkdirAll(filepath.Dir(df), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(df, nil, 0644)
+	err = os.WriteFile(df, nil, 0644)
 	c.Assert(err, IsNil)
 
 	err = s.settings.SetSub("default-url-scheme-handler", "irc2", "ircclient.desktop", ":some-dbus-sender")

--- a/usersession/xdgopenproxy/userd_launcher_test.go
+++ b/usersession/xdgopenproxy/userd_launcher_test.go
@@ -21,7 +21,6 @@ package xdgopenproxy_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -75,7 +74,7 @@ func (s *userdSuite) TestOpenFile(c *C) {
 	launcher := &xdgopenproxy.UserdLauncher{}
 
 	path := filepath.Join(c.MkDir(), "test.txt")
-	c.Assert(ioutil.WriteFile(path, []byte("hello world"), 0644), IsNil)
+	c.Assert(os.WriteFile(path, []byte("hello world"), 0644), IsNil)
 
 	err := launcher.OpenFile(s.SessionBus, path)
 	c.Check(err, IsNil)
@@ -90,7 +89,7 @@ func (s *userdSuite) TestOpenFileError(c *C) {
 	launcher := &xdgopenproxy.UserdLauncher{}
 
 	path := filepath.Join(c.MkDir(), "test.txt")
-	c.Assert(ioutil.WriteFile(path, []byte("hello world"), 0644), IsNil)
+	c.Assert(os.WriteFile(path, []byte("hello world"), 0644), IsNil)
 
 	err := launcher.OpenFile(s.SessionBus, path)
 	c.Check(err, FitsTypeOf, dbus.Error{})
@@ -124,7 +123,7 @@ func (s *userdSuite) TestOpenUnreadableFile(c *C) {
 	launcher := &xdgopenproxy.UserdLauncher{}
 
 	path := filepath.Join(c.MkDir(), "test.txt")
-	c.Assert(ioutil.WriteFile(path, []byte("hello world"), 0644), IsNil)
+	c.Assert(os.WriteFile(path, []byte("hello world"), 0644), IsNil)
 	c.Assert(os.Chmod(path, 0), IsNil)
 
 	err := launcher.OpenFile(s.SessionBus, path)

--- a/wrappers/binaries_test.go
+++ b/wrappers/binaries_test.go
@@ -20,7 +20,6 @@
 package wrappers_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -125,7 +124,7 @@ func (s *binariesTestSuite) prepareReadOnlyLegacyDir(c *C) {
 	}
 
 	c.Assert(os.MkdirAll(filepath.Dir(dirs.CompleteShPath(s.base)), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(dirs.CompleteShPath(s.base), nil, 0644), IsNil)
+	c.Assert(os.WriteFile(dirs.CompleteShPath(s.base), nil, 0644), IsNil)
 
 	f, err := os.OpenFile(dirs.BashCompletionScript, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0644)
 	c.Assert(err, IsNil)
@@ -150,7 +149,7 @@ func (s *binariesTestSuite) prepareUseLegacy(c *C) {
 	}
 
 	c.Assert(os.MkdirAll(filepath.Dir(dirs.CompleteShPath(s.base)), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(dirs.CompleteShPath(s.base), nil, 0644), IsNil)
+	c.Assert(os.WriteFile(dirs.CompleteShPath(s.base), nil, 0644), IsNil)
 
 	f, err := os.OpenFile(dirs.BashCompletionScript, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0644)
 	c.Assert(err, IsNil)
@@ -174,7 +173,7 @@ func (s *binariesTestSuite) prepareOldButNotThatOld(c *C) {
 	}
 
 	c.Assert(os.MkdirAll(filepath.Dir(dirs.CompleteShPath(s.base)), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(dirs.CompleteShPath(s.base), nil, 0644), IsNil)
+	c.Assert(os.WriteFile(dirs.CompleteShPath(s.base), nil, 0644), IsNil)
 
 	f, err := os.OpenFile(dirs.BashCompletionScript, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0644)
 	c.Assert(err, IsNil)
@@ -198,7 +197,7 @@ func (s *binariesTestSuite) prepareUnknownVersion(c *C) {
 	}
 
 	c.Assert(os.MkdirAll(filepath.Dir(dirs.CompleteShPath(s.base)), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(dirs.CompleteShPath(s.base), nil, 0644), IsNil)
+	c.Assert(os.WriteFile(dirs.CompleteShPath(s.base), nil, 0644), IsNil)
 
 	f, err := os.OpenFile(dirs.BashCompletionScript, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0644)
 	c.Assert(err, IsNil)
@@ -238,7 +237,7 @@ func (s *binariesTestSuite) prepareWithCompleters(c *C) {
 		c.Check(os.MkdirAll(filepath.Join(dirs.SnapMountDir, "snapd/current/usr/lib/snapd"), 0755), IsNil)
 	}
 	c.Assert(os.MkdirAll(filepath.Dir(dirs.CompleteShPath(s.base)), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(dirs.CompleteShPath(s.base), nil, 0644), IsNil)
+	c.Assert(os.WriteFile(dirs.CompleteShPath(s.base), nil, 0644), IsNil)
 }
 
 func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveWithCompleters(c *C) {
@@ -259,7 +258,7 @@ func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveWithLegacyCompleters(c *
 		c.Check(os.MkdirAll(filepath.Join(dirs.SnapMountDir, "snapd/current/usr/lib/snapd"), 0755), IsNil)
 	}
 	c.Assert(os.MkdirAll(filepath.Dir(dirs.CompleteShPath(s.base)), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(dirs.CompleteShPath(s.base), nil, 0644), IsNil)
+	c.Assert(os.WriteFile(dirs.CompleteShPath(s.base), nil, 0644), IsNil)
 	c.Assert(os.Symlink(dirs.CompleteShPath(s.base), filepath.Join(dirs.LegacyCompletersDir, "hello-snap.world")), IsNil)
 
 	s.testAddSnapBinariesAndRemove(c, false, false)
@@ -291,10 +290,10 @@ func (s *binariesTestSuite) prepareWithExistingCompleters(c *C) {
 		c.Check(os.MkdirAll(filepath.Join(dirs.SnapMountDir, "snapd/current/usr/lib/snapd"), 0755), IsNil)
 	}
 	c.Assert(os.MkdirAll(filepath.Dir(dirs.CompleteShPath(s.base)), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(dirs.CompleteShPath(s.base), nil, 0644), IsNil)
+	c.Assert(os.WriteFile(dirs.CompleteShPath(s.base), nil, 0644), IsNil)
 	// existing completers -> they're left alone \o/
-	c.Assert(ioutil.WriteFile(filepath.Join(dirs.CompletersDir, "hello-snap.world"), nil, 0644), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(dirs.CompletersDir, "hello-snap.universe"), nil, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dirs.CompletersDir, "hello-snap.world"), nil, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dirs.CompletersDir, "hello-snap.universe"), nil, 0644), IsNil)
 }
 
 func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveWithExistingCompleters(c *C) {
@@ -313,10 +312,10 @@ func (s *binariesTestSuite) prepareWithExistingLegacyCompleters(c *C) {
 		c.Check(os.MkdirAll(filepath.Join(dirs.SnapMountDir, "snapd/current/usr/lib/snapd"), 0755), IsNil)
 	}
 	c.Assert(os.MkdirAll(filepath.Dir(dirs.CompleteShPath(s.base)), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(dirs.CompleteShPath(s.base), nil, 0644), IsNil)
+	c.Assert(os.WriteFile(dirs.CompleteShPath(s.base), nil, 0644), IsNil)
 	// existing completers -> they're left alone \o/
-	c.Assert(ioutil.WriteFile(filepath.Join(dirs.LegacyCompletersDir, "hello-snap.world"), nil, 0644), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(dirs.LegacyCompletersDir, "hello-snap.universe"), nil, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dirs.LegacyCompletersDir, "hello-snap.world"), nil, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dirs.LegacyCompletersDir, "hello-snap.universe"), nil, 0644), IsNil)
 }
 
 func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveWithExistingLegacyCompleters(c *C) {

--- a/wrappers/dbus_test.go
+++ b/wrappers/dbus_test.go
@@ -20,7 +20,6 @@
 package wrappers_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -132,14 +131,14 @@ func (s *dbusTestSuite) TestAddSnapDBusActivationFilesRemovesLeftovers(c *C) {
 	c.Assert(os.MkdirAll(dirs.SnapDBusSystemServicesDir, 0755), IsNil)
 
 	sessionSvc := filepath.Join(dirs.SnapDBusSessionServicesDir, "org.example.Baz.service")
-	c.Assert(ioutil.WriteFile(sessionSvc, []byte("[D-BUS Service]\nX-Snap=snapname\n"), 0644), IsNil)
+	c.Assert(os.WriteFile(sessionSvc, []byte("[D-BUS Service]\nX-Snap=snapname\n"), 0644), IsNil)
 	systemSvc := filepath.Join(dirs.SnapDBusSessionServicesDir, "org.example.Baz.service")
-	c.Assert(ioutil.WriteFile(systemSvc, []byte("[D-BUS Service]\nX-Snap=snapname\n"), 0644), IsNil)
+	c.Assert(os.WriteFile(systemSvc, []byte("[D-BUS Service]\nX-Snap=snapname\n"), 0644), IsNil)
 
 	otherSessionSvc := filepath.Join(dirs.SnapDBusSessionServicesDir, "org.example.OtherSnap.service")
-	c.Assert(ioutil.WriteFile(otherSessionSvc, []byte("[D-BUS Service]\nX-Snap=other-snap\n"), 0644), IsNil)
+	c.Assert(os.WriteFile(otherSessionSvc, []byte("[D-BUS Service]\nX-Snap=other-snap\n"), 0644), IsNil)
 	otherSystemSvc := filepath.Join(dirs.SnapDBusSystemServicesDir, "org.example.OtherSnap.service")
-	c.Assert(ioutil.WriteFile(otherSystemSvc, []byte("[D-BUS Service]\nX-Snap=other-snap\n"), 0644), IsNil)
+	c.Assert(os.WriteFile(otherSystemSvc, []byte("[D-BUS Service]\nX-Snap=other-snap\n"), 0644), IsNil)
 
 	info := snaptest.MockSnap(c, dbusSnapYaml, &snap.SideInfo{Revision: snap.R(12)})
 	err := wrappers.AddSnapDBusActivationFiles(info)
@@ -158,14 +157,14 @@ func (s *dbusTestSuite) TestRemoveSnapDBusActivationFiles(c *C) {
 	c.Assert(os.MkdirAll(dirs.SnapDBusSystemServicesDir, 0755), IsNil)
 
 	sessionSvc := filepath.Join(dirs.SnapDBusSessionServicesDir, "org.example.Baz.service")
-	c.Assert(ioutil.WriteFile(sessionSvc, []byte("[D-BUS Service]\nX-Snap=snapname\n"), 0644), IsNil)
+	c.Assert(os.WriteFile(sessionSvc, []byte("[D-BUS Service]\nX-Snap=snapname\n"), 0644), IsNil)
 	systemSvc := filepath.Join(dirs.SnapDBusSessionServicesDir, "org.example.Baz.service")
-	c.Assert(ioutil.WriteFile(systemSvc, []byte("[D-BUS Service]\nX-Snap=snapname\n"), 0644), IsNil)
+	c.Assert(os.WriteFile(systemSvc, []byte("[D-BUS Service]\nX-Snap=snapname\n"), 0644), IsNil)
 
 	otherSessionSvc := filepath.Join(dirs.SnapDBusSessionServicesDir, "org.example.OtherSnap.service")
-	c.Assert(ioutil.WriteFile(otherSessionSvc, []byte("[D-BUS Service]\nX-Snap=other-snap\n"), 0644), IsNil)
+	c.Assert(os.WriteFile(otherSessionSvc, []byte("[D-BUS Service]\nX-Snap=other-snap\n"), 0644), IsNil)
 	otherSystemSvc := filepath.Join(dirs.SnapDBusSystemServicesDir, "org.example.OtherSnap.service")
-	c.Assert(ioutil.WriteFile(otherSystemSvc, []byte("[D-BUS Service]\nX-Snap=other-snap\n"), 0644), IsNil)
+	c.Assert(os.WriteFile(otherSystemSvc, []byte("[D-BUS Service]\nX-Snap=other-snap\n"), 0644), IsNil)
 
 	info := snaptest.MockSnap(c, dbusSnapYaml, &snap.SideInfo{Revision: snap.R(12)})
 	err := wrappers.RemoveSnapDBusActivationFiles(info)

--- a/wrappers/desktop_test.go
+++ b/wrappers/desktop_test.go
@@ -21,7 +21,6 @@ package wrappers_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -78,7 +77,7 @@ func (s *desktopSuite) TestEnsurePackageDesktopFiles(c *C) {
 
 	oldDesktopFilePath := filepath.Join(dirs.SnapDesktopFilesDir, "foo_foobar2.desktop")
 	c.Assert(os.MkdirAll(dirs.SnapDesktopFilesDir, 0755), IsNil)
-	c.Assert(ioutil.WriteFile(oldDesktopFilePath, mockDesktopFile, 0644), IsNil)
+	c.Assert(os.WriteFile(oldDesktopFilePath, mockDesktopFile, 0644), IsNil)
 	c.Assert(osutil.FileExists(oldDesktopFilePath), Equals, true)
 
 	info := snaptest.MockSnap(c, desktopAppYaml, &snap.SideInfo{Revision: snap.R(11)})
@@ -86,7 +85,7 @@ func (s *desktopSuite) TestEnsurePackageDesktopFiles(c *C) {
 	// generate .desktop file in the package baseDir
 	baseDir := info.MountDir()
 	c.Assert(os.MkdirAll(filepath.Join(baseDir, "meta", "gui"), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(baseDir, "meta", "gui", "foobar.desktop"), mockDesktopFile, 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(baseDir, "meta", "gui", "foobar.desktop"), mockDesktopFile, 0644), IsNil)
 
 	err := wrappers.EnsureSnapDesktopFiles(info)
 	c.Assert(err, IsNil)
@@ -113,7 +112,7 @@ func (s *desktopSuite) TestRemovePackageDesktopFiles(c *C) {
 
 	err := os.MkdirAll(dirs.SnapDesktopFilesDir, 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(mockDesktopFilePath, mockDesktopFile, 0644)
+	err = os.WriteFile(mockDesktopFilePath, mockDesktopFile, 0644)
 	c.Assert(err, IsNil)
 	info, err := snap.InfoFromSnapYaml([]byte(desktopAppYaml))
 	c.Assert(err, IsNil)
@@ -132,9 +131,9 @@ func (s *desktopSuite) TestParallelInstancesRemovePackageDesktopFiles(c *C) {
 
 	err := os.MkdirAll(dirs.SnapDesktopFilesDir, 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(mockDesktopFilePath, mockDesktopFile, 0644)
+	err = os.WriteFile(mockDesktopFilePath, mockDesktopFile, 0644)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(mockDesktopInstanceFilePath, mockDesktopFile, 0644)
+	err = os.WriteFile(mockDesktopInstanceFilePath, mockDesktopFile, 0644)
 	c.Assert(err, IsNil)
 	info, err := snap.InfoFromSnapYaml([]byte(desktopAppYaml))
 	c.Assert(err, IsNil)
@@ -149,7 +148,7 @@ func (s *desktopSuite) TestParallelInstancesRemovePackageDesktopFiles(c *C) {
 	c.Assert(osutil.FileExists(mockDesktopInstanceFilePath), Equals, true)
 
 	// restore the non-instance file
-	err = ioutil.WriteFile(mockDesktopFilePath, mockDesktopFile, 0644)
+	err = os.WriteFile(mockDesktopFilePath, mockDesktopFile, 0644)
 	c.Assert(err, IsNil)
 
 	s.mockUpdateDesktopDatabase.ForgetCalls()
@@ -173,7 +172,7 @@ func (s *desktopSuite) TestEnsurePackageDesktopFilesCleanup(c *C) {
 	c.Assert(err, IsNil)
 
 	mockDesktopInstanceFilePath := filepath.Join(dirs.SnapDesktopFilesDir, "foo+instance_foobar.desktop")
-	err = ioutil.WriteFile(mockDesktopInstanceFilePath, mockDesktopFile, 0644)
+	err = os.WriteFile(mockDesktopInstanceFilePath, mockDesktopFile, 0644)
 	c.Assert(err, IsNil)
 
 	err = os.MkdirAll(filepath.Join(dirs.SnapDesktopFilesDir, "foo_foobar2.desktop", "potato"), 0755)
@@ -186,9 +185,9 @@ func (s *desktopSuite) TestEnsurePackageDesktopFilesCleanup(c *C) {
 	err = os.MkdirAll(filepath.Join(baseDir, "meta", "gui"), 0755)
 	c.Assert(err, IsNil)
 
-	err = ioutil.WriteFile(filepath.Join(baseDir, "meta", "gui", "foobar1.desktop"), mockDesktopFile, 0644)
+	err = os.WriteFile(filepath.Join(baseDir, "meta", "gui", "foobar1.desktop"), mockDesktopFile, 0644)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(baseDir, "meta", "gui", "foobar2.desktop"), mockDesktopFile, 0644)
+	err = os.WriteFile(filepath.Join(baseDir, "meta", "gui", "foobar2.desktop"), mockDesktopFile, 0644)
 	c.Assert(err, IsNil)
 
 	err = wrappers.EnsureSnapDesktopFiles(info)
@@ -585,7 +584,7 @@ func (s *desktopSuite) TestAddRemoveDesktopFiles(c *C) {
 		err := os.MkdirAll(filepath.Join(baseDir, "meta", "gui"), 0755)
 		c.Assert(err, IsNil)
 
-		err = ioutil.WriteFile(filepath.Join(baseDir, "meta", "gui", t.upstreamDesktopFileName), mockDesktopFile, 0644)
+		err = os.WriteFile(filepath.Join(baseDir, "meta", "gui", t.upstreamDesktopFileName), mockDesktopFile, 0644)
 		c.Assert(err, IsNil)
 
 		err = wrappers.EnsureSnapDesktopFiles(info)

--- a/wrappers/icons_test.go
+++ b/wrappers/icons_test.go
@@ -20,7 +20,6 @@
 package wrappers_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -60,14 +59,14 @@ func (s *iconsTestSuite) TestFindIconFiles(c *C) {
 	iconsDir := filepath.Join(baseDir, "meta", "gui", "icons")
 	c.Assert(os.MkdirAll(filepath.Join(iconsDir, "hicolor", "256x256", "apps"), 0755), IsNil)
 	c.Assert(os.MkdirAll(filepath.Join(iconsDir, "hicolor", "scalable", "apps"), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(iconsDir, "hicolor", "256x256", "apps", "snap.hello-snap.foo.png"), []byte("256x256"), 0644), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(iconsDir, "hicolor", "scalable", "apps", "snap.hello-snap.foo.svg"), []byte("scalable"), 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(iconsDir, "hicolor", "256x256", "apps", "snap.hello-snap.foo.png"), []byte("256x256"), 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(iconsDir, "hicolor", "scalable", "apps", "snap.hello-snap.foo.svg"), []byte("scalable"), 0644), IsNil)
 
 	// Some files that shouldn't be picked up
-	c.Assert(ioutil.WriteFile(filepath.Join(iconsDir, "hicolor", "scalable", "apps", "snap.hello-snap.foo.exe"), []byte("bad extension"), 0644), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(iconsDir, "hicolor", "scalable", "apps", "org.example.hello.png"), []byte("bad prefix"), 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(iconsDir, "hicolor", "scalable", "apps", "snap.hello-snap.foo.exe"), []byte("bad extension"), 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(iconsDir, "hicolor", "scalable", "apps", "org.example.hello.png"), []byte("bad prefix"), 0644), IsNil)
 	c.Assert(os.MkdirAll(filepath.Join(iconsDir, "snap.whatever"), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(iconsDir, "snap.whatever", "snap.hello-snap.foo.png"), []byte("bad dir"), 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(iconsDir, "snap.whatever", "snap.hello-snap.foo.png"), []byte("bad dir"), 0644), IsNil)
 
 	icons, err := wrappers.FindIconFiles(info.SnapName(), iconsDir)
 	sort.Strings(icons)
@@ -84,11 +83,11 @@ func (s *iconsTestSuite) TestEnsureSnapIcons(c *C) {
 	baseDir := info.MountDir()
 	iconsDir := filepath.Join(baseDir, "meta", "gui", "icons")
 	c.Assert(os.MkdirAll(filepath.Join(iconsDir, "hicolor", "scalable", "apps"), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(iconsDir, "hicolor", "scalable", "apps", "snap.hello-snap.foo.svg"), []byte("scalable"), 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(iconsDir, "hicolor", "scalable", "apps", "snap.hello-snap.foo.svg"), []byte("scalable"), 0644), IsNil)
 
 	c.Assert(os.MkdirAll(filepath.Join(dirs.SnapDesktopIconsDir, "hicolor", "scalable", "apps"), 0755), IsNil)
 	oldIconFile := filepath.Join(dirs.SnapDesktopIconsDir, "hicolor", "scalable", "apps", "snap.hello-snap.bar.svg")
-	c.Assert(ioutil.WriteFile(oldIconFile, []byte("scalable"), 0644), IsNil)
+	c.Assert(os.WriteFile(oldIconFile, []byte("scalable"), 0644), IsNil)
 
 	c.Assert(wrappers.EnsureSnapIcons(info), IsNil)
 	iconFile := filepath.Join(dirs.SnapDesktopIconsDir, "hicolor", "scalable", "apps", "snap.hello-snap.foo.svg")
@@ -106,7 +105,7 @@ func (s *iconsTestSuite) TestRemoveSnapIcons(c *C) {
 	iconDir := filepath.Join(dirs.SnapDesktopIconsDir, "hicolor", "scalable", "apps")
 	iconFile := filepath.Join(iconDir, "snap.hello-snap.foo.svg")
 	c.Assert(os.MkdirAll(iconDir, 0755), IsNil)
-	c.Assert(ioutil.WriteFile(iconFile, []byte("contents"), 0644), IsNil)
+	c.Assert(os.WriteFile(iconFile, []byte("contents"), 0644), IsNil)
 
 	info := snaptest.MockSnap(c, packageHello, &snap.SideInfo{Revision: snap.R(11)})
 	c.Assert(wrappers.RemoveSnapIcons(info), IsNil)
@@ -120,7 +119,7 @@ func (s *iconsTestSuite) TestParallelInstanceEnsureIcons(c *C) {
 	baseDir := info.MountDir()
 	iconsDir := filepath.Join(baseDir, "meta", "gui", "icons")
 	c.Assert(os.MkdirAll(filepath.Join(iconsDir, "hicolor", "scalable", "apps"), 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(iconsDir, "hicolor", "scalable", "apps", "snap.hello-snap.foo.svg"), []byte("scalable"), 0644), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(iconsDir, "hicolor", "scalable", "apps", "snap.hello-snap.foo.svg"), []byte("scalable"), 0644), IsNil)
 
 	c.Assert(wrappers.EnsureSnapIcons(info), IsNil)
 	iconFile := filepath.Join(dirs.SnapDesktopIconsDir, "hicolor", "scalable", "apps", "snap.hello-snap_instance.foo.svg")
@@ -135,9 +134,9 @@ func (s *iconsTestSuite) TestParallelInstanceRemoveIcons(c *C) {
 	iconDir := filepath.Join(dirs.SnapDesktopIconsDir, "hicolor", "scalable", "apps")
 	c.Assert(os.MkdirAll(iconDir, 0755), IsNil)
 	snapNameFile := filepath.Join(iconDir, "snap.hello-snap.foo.svg")
-	c.Assert(ioutil.WriteFile(snapNameFile, []byte("contents"), 0644), IsNil)
+	c.Assert(os.WriteFile(snapNameFile, []byte("contents"), 0644), IsNil)
 	instanceNameFile := filepath.Join(iconDir, "snap.hello-snap_instance.foo.svg")
-	c.Assert(ioutil.WriteFile(instanceNameFile, []byte("contents"), 0644), IsNil)
+	c.Assert(os.WriteFile(instanceNameFile, []byte("contents"), 0644), IsNil)
 
 	info := snaptest.MockSnap(c, packageHello, &snap.SideInfo{Revision: snap.R(11)})
 	info.InstanceKey = "instance"

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -1363,10 +1363,10 @@ WantedBy=multi-user.target
 	c.Assert(err, IsNil)
 
 	oldContent := fmt.Sprintf(sliceTempl, "foogroup", memLimit1.String())
-	err = ioutil.WriteFile(sliceFile, []byte(oldContent), 0644)
+	err = os.WriteFile(sliceFile, []byte(oldContent), 0644)
 	c.Assert(err, IsNil)
 
-	err = ioutil.WriteFile(svcFile, []byte(svcContent), 0644)
+	err = os.WriteFile(svcFile, []byte(svcContent), 0644)
 	c.Assert(err, IsNil)
 
 	// use new memory limit
@@ -1464,10 +1464,10 @@ WantedBy=multi-user.target
 	err := os.MkdirAll(filepath.Dir(sliceFile), 0755)
 	c.Assert(err, IsNil)
 
-	err = ioutil.WriteFile(sliceFile, []byte(fmt.Sprintf(sliceTempl, "foogroup", memLimit.String(), taskLimit)), 0644)
+	err = os.WriteFile(sliceFile, []byte(fmt.Sprintf(sliceTempl, "foogroup", memLimit.String(), taskLimit)), 0644)
 	c.Assert(err, IsNil)
 
-	err = ioutil.WriteFile(svcFile, []byte(svcContent), 0644)
+	err = os.WriteFile(svcFile, []byte(svcContent), 0644)
 	c.Assert(err, IsNil)
 
 	resourceLimits := quota.NewResourcesBuilder().WithMemoryLimit(memLimit).WithThreadLimit(taskLimit).Build()
@@ -1529,7 +1529,7 @@ MemoryLimit=1024
 	err = os.MkdirAll(filepath.Dir(sliceFile), 0755)
 	c.Assert(err, IsNil)
 
-	err = ioutil.WriteFile(sliceFile, []byte(fmt.Sprintf(sliceTempl, "foogroup")), 0644)
+	err = os.WriteFile(sliceFile, []byte(fmt.Sprintf(sliceTempl, "foogroup")), 0644)
 	c.Assert(err, IsNil)
 
 	// removing it deletes it
@@ -2011,7 +2011,7 @@ WantedBy=multi-user.target
 
 	err := os.MkdirAll(filepath.Dir(svc1File), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(svc1File, []byte(svc1Content), 0644)
+	err = os.WriteFile(svc1File, []byte(svc1Content), 0644)
 	c.Assert(err, IsNil)
 
 	// both will be written, one is new
@@ -2104,7 +2104,7 @@ WantedBy=multi-user.target
 
 	err := os.MkdirAll(filepath.Dir(svc1File), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(svc1File, []byte(svc1Content), 0644)
+	err = os.WriteFile(svc1File, []byte(svc1Content), 0644)
 	c.Assert(err, IsNil)
 
 	m := map[*snap.Info]*wrappers.SnapServiceOptions{
@@ -2175,7 +2175,7 @@ WantedBy=multi-user.target
 
 	err := os.MkdirAll(filepath.Dir(svcFile), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(svcFile, []byte(origContent), 0644)
+	err = os.WriteFile(svcFile, []byte(origContent), 0644)
 	c.Assert(err, IsNil)
 
 	// now ensuring with no options will not modify anything or trigger a
@@ -2243,7 +2243,7 @@ WantedBy=multi-user.target
 
 	err := os.MkdirAll(filepath.Dir(svcFile), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(svcFile, []byte(origContent), 0644)
+	err = os.WriteFile(svcFile, []byte(origContent), 0644)
 	c.Assert(err, IsNil)
 
 	// now ensuring with the VitalityRank set will modify the file
@@ -2307,7 +2307,7 @@ WantedBy=multi-user.target
 
 	err := os.MkdirAll(filepath.Dir(svcFile), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(svcFile, []byte(origContent), 0644)
+	err = os.WriteFile(svcFile, []byte(origContent), 0644)
 	c.Assert(err, IsNil)
 
 	// make systemctl fail the first time when we try to do a daemon-reload,
@@ -2477,7 +2477,7 @@ WantedBy=multi-user.target
 
 	err := os.MkdirAll(filepath.Dir(svc1File), 0755)
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(svc1File, []byte(svc1Content), 0644)
+	err = os.WriteFile(svc1File, []byte(svc1Content), 0644)
 	c.Assert(err, IsNil)
 
 	// make systemctl fail the first time when we try to do a daemon-reload,


### PR DESCRIPTION
Replace `ioutil.WriteFile` with `os.WriteFile` since the former has been deprecated since go1.16 and simply calls the latter. All of `ioutil`'s functions have been deprecated but not all are a matter of simply replacing calls and doing each function at a time make it easier to review.
