### PR TITLE
aspects: required keys must have schema entry

### DIFF
--- a/aspects/schema.go
+++ b/aspects/schema.go
@@ -292,6 +292,14 @@ func (v *mapSchema) parseConstraints(constraints map[string]json.RawMessage) err
 			} else {
 				v.requiredCombs = requiredCombs
 			}
+
+			for _, requiredComb := range v.requiredCombs {
+				for _, required := range requiredComb {
+					if _, ok := v.entrySchemas[required]; !ok {
+						return fmt.Errorf(`cannot parse map's "required" constraint: required key %q must have schema entry`, required)
+					}
+				}
+			}
 		}
 
 		return nil

--- a/aspects/schema_test.go
+++ b/aspects/schema_test.go
@@ -385,6 +385,19 @@ func (*schemaSuite) TestMapSchemaWithUnmetAlternativeOfRequiredEntries(c *C) {
 	c.Assert(err, ErrorMatches, "cannot find required combinations of keys")
 }
 
+func (*schemaSuite) TestMapSchemaRequiredNotInSchema(c *C) {
+	schemaStr := []byte(`{
+	"schema": {
+		"foo": "string",
+		"bar": "string"
+	},
+	"required": ["foo", "baz"]
+}`)
+
+	_, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, ErrorMatches, `cannot parse map's "required" constraint: required key "baz" must have schema entry`)
+}
+
 func (*schemaSuite) TestMapInvalidConstraintCombos(c *C) {
 	type testcase struct {
 		name    string


### PR DESCRIPTION
Force required keys to be present in the schema as well. This constraint is the reason why a type "any" is necessary, since the writer may want to express that a key is expected regardless of type.
