### PR TITLE
many: replace exec.CombinedOutput when output is parsed

### DIFF
--- a/cmd/snap-bootstrap/initramfs_systemd_mount.go
+++ b/cmd/snap-bootstrap/initramfs_systemd_mount.go
@@ -22,7 +22,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -185,14 +184,9 @@ func doSystemdMountImpl(what, where string, opts *systemdMountOptions) error {
 		args = append(args, "--property=Before=initrd-fs.target")
 	}
 
-	// note that we do not currently parse any output from systemd-mount, but if
-	// we ever do, take special care surrounding the debug output that systemd
-	// outputs with the "debug" kernel command line present (or equivalently the
-	// SYSTEMD_LOG_LEVEL=debug env var) which will add lots of additional output
-	// to stderr from systemd commands
-	out, err := exec.Command("systemd-mount", args...).CombinedOutput()
+	stdout, stderr, err := osutil.RunSplitOutput("systemd-mount", args...)
 	if err != nil {
-		return osutil.OutputErr(out, err)
+		return osutil.OutputErrCombine(stdout, stderr, err)
 	}
 
 	if !opts.NoWait {

--- a/cmd/snap-failure/cmd_snapd.go
+++ b/cmd/snap-failure/cmd_snapd.go
@@ -140,9 +140,9 @@ func (c *cmdSnapd) Execute(args []string) error {
 	}
 	logger.Noticef("stopping snapd socket")
 	// stop the socket unit so that we can start snapd on its own
-	output, err := exec.Command("systemctl", "stop", "snapd.socket").CombinedOutput()
+	stdout, stderr, err := osutil.RunSplitOutput("systemctl", "stop", "snapd.socket")
 	if err != nil {
-		return osutil.OutputErr(output, err)
+		return osutil.OutputErrCombine(stdout, stderr, err)
 	}
 
 	logger.Noticef("restoring invoking snapd from: %v", snapdPath)

--- a/daemon/api_general.go
+++ b/daemon/api_general.go
@@ -24,7 +24,6 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
-	"os/exec"
 	"sort"
 	"time"
 
@@ -91,7 +90,7 @@ func init() {
 		buildID = bid
 	}
 	// cache systemd-detect-virt output as it's unlikely to change :-)
-	if buf, err := exec.Command("systemd-detect-virt").CombinedOutput(); err == nil {
+	if buf, _, err := osutil.RunSplitOutput("systemd-detect-virt"); err == nil {
 		systemdVirt = string(bytes.TrimSpace(buf))
 	}
 }

--- a/errtracker/errtracker.go
+++ b/errtracker/errtracker.go
@@ -168,15 +168,14 @@ func (db *reportsDB) MarkReported(dupSig string) error {
 }
 
 func whoopsieEnabled() bool {
-	cmd := exec.Command("systemctl", "is-enabled", "whoopsie.service")
-	output, _ := cmd.CombinedOutput()
-	switch string(output) {
+	stdout, stderr, _ := osutil.RunSplitOutput("systemctl", "is-enabled", "whoopsie.service")
+	switch string(stdout) {
 	case "enabled\n":
 		return true
 	case "disabled\n":
 		return false
 	default:
-		logger.Debugf("unexpected output when checking for whoopsie.service (not installed?): %s", output)
+		logger.Debugf("unexpected output when checking for whoopsie.service (not installed?): %s (stderr: %s)", stdout, stderr)
 		return true
 	}
 }
@@ -268,12 +267,11 @@ func ReportRepair(repair, errMsg, dupSig string, extra map[string]string) (strin
 }
 
 func detectVirt() string {
-	cmd := exec.Command("systemd-detect-virt")
-	output, err := cmd.CombinedOutput()
+	stdout, _, err := osutil.RunSplitOutput("systemd-detect-virt")
 	if err != nil {
 		return ""
 	}
-	return strings.TrimSpace(string(output))
+	return strings.TrimSpace(string(stdout))
 }
 
 func journalError() string {

--- a/osutil/disks/blockdev.go
+++ b/osutil/disks/blockdev.go
@@ -21,7 +21,6 @@ package disks
 
 import (
 	"fmt"
-	"os/exec"
 	"strconv"
 	"strings"
 
@@ -29,9 +28,9 @@ import (
 )
 
 func blockdevSizeCmd(cmd, devpath string) (uint64, error) {
-	out, err := exec.Command("blockdev", cmd, devpath).CombinedOutput()
+	out, stderr, err := osutil.RunSplitOutput("blockdev", cmd, devpath)
 	if err != nil {
-		return 0, osutil.OutputErr(out, err)
+		return 0, osutil.OutputErrCombine(out, stderr, err)
 	}
 	nospace := strings.TrimSpace(string(out))
 	sz, err := strconv.ParseUint(nospace, 10, 64)

--- a/osutil/disks/disks_linux.go
+++ b/osutil/disks/disks_linux.go
@@ -55,17 +55,17 @@ func MockUdevPropertiesForDevice(new func(string, string) (map[string]string, er
 	old := udevadmProperties
 	// for better testing we mock the udevadm command output so that we still
 	// test the parsing
-	udevadmProperties = func(typeOpt, dev string) ([]byte, error) {
+	udevadmProperties = func(typeOpt, dev string) ([]byte, []byte, error) {
 		props, err := new(typeOpt, dev)
 		if err != nil {
-			return []byte(err.Error()), err
+			return []byte(err.Error()), []byte{}, err
 		}
 		// put it into udevadm format output, i.e. "KEY=VALUE\n"
 		output := ""
 		for k, v := range props {
 			output += fmt.Sprintf("%s=%s\n", k, v)
 		}
-		return []byte(output), nil
+		return []byte(output), []byte{}, nil
 	}
 	return func() {
 		udevadmProperties = old
@@ -89,17 +89,16 @@ func parseDeviceMajorMinor(s string) (int, int, error) {
 	return maj, min, nil
 }
 
-var udevadmProperties = func(typeOpt, device string) ([]byte, error) {
+var udevadmProperties = func(typeOpt, device string) ([]byte, []byte, error) {
 	// TODO: maybe combine with gadget interfaces hotplug code where the udev
 	// db is parsed?
-	cmd := exec.Command("udevadm", "info", "--query", "property", typeOpt, device)
-	return cmd.CombinedOutput()
+	return osutil.RunSplitOutput("udevadm", "info", "--query", "property", typeOpt, device)
 }
 
 func udevProperties(typeOpt, device string) (map[string]string, error) {
-	out, err := udevadmProperties(typeOpt, device)
+	out, stderr, err := udevadmProperties(typeOpt, device)
 	if err != nil {
-		return nil, osutil.OutputErr(out, err)
+		return nil, osutil.OutputErrCombine(out, stderr, err)
 	}
 	r := bytes.NewBuffer(out)
 

--- a/osutil/exec.go
+++ b/osutil/exec.go
@@ -20,6 +20,8 @@
 package osutil
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -172,4 +174,27 @@ func StreamCommand(name string, args ...string) (io.ReadCloser, error) {
 	}
 
 	return &waitingReader{reader: pipe, cmd: cmd}, nil
+}
+
+// RunCmd runs a command and returns separately stdout and stderr
+// output, and an error.
+func RunCmd(c *exec.Cmd) ([]byte, []byte, error) {
+	if c.Stdout != nil {
+		return nil, nil, errors.New("osutil.Run: Stdout already set")
+	}
+	if c.Stderr != nil {
+		return nil, nil, errors.New("osutil.Run: Stderr already set")
+	}
+	var stdout, stderr bytes.Buffer
+	c.Stdout = &stdout
+	c.Stderr = &stderr
+	err := c.Run()
+	return stdout.Bytes(), stderr.Bytes(), err
+}
+
+// RunSplitOutput runs name command with arg arguments and returns
+// stdout, stderr, and an error.
+func RunSplitOutput(name string, arg ...string) ([]byte, []byte, error) {
+	cmd := exec.Command(name, arg...)
+	return RunCmd(cmd)
 }

--- a/osutil/group.go
+++ b/osutil/group.go
@@ -22,7 +22,6 @@ package osutil
 import (
 	"bytes"
 	"fmt"
-	"os/exec"
 	"os/user"
 	"strconv"
 )
@@ -63,8 +62,7 @@ func getent(database, name string) (uint64, error) {
 		database,
 		name,
 	}
-	cmd := exec.Command(cmdStr[0], cmdStr[1:]...)
-	output, err := cmd.CombinedOutput()
+	output, stderr, err := RunSplitOutput(cmdStr[0], cmdStr[1:]...)
 	if err != nil {
 		// according to getent(1) the exit value of "2" means:
 		// "One or more supplied key could not be found in the
@@ -76,7 +74,7 @@ func getent(database, name string) (uint64, error) {
 			}
 			return 0, user.UnknownGroupError(name)
 		}
-		return 0, fmt.Errorf("getent failed with: %v", OutputErr(output, err))
+		return 0, fmt.Errorf("getent failed with: %v", OutputErrCombine(output, stderr, err))
 	}
 
 	// passwd has 7 entries and group 4. In both cases, parts[2] is the id

--- a/osutil/outputerr.go
+++ b/osutil/outputerr.go
@@ -37,3 +37,21 @@ func OutputErr(output []byte, err error) error {
 	}
 	return err
 }
+
+// CombineStdOutErr combines stdout and stderr byte arrays into a
+// single one.
+func CombineStdOutErr(stdout, stderr []byte) []byte {
+	msg := stdout
+	if stderr != nil && len(stderr) > 0 {
+		msg = bytes.Join([][]byte{stdout, stderr}, []byte("\nstderr:\n"))
+	}
+	msg = bytes.TrimSpace(msg)
+	return msg
+}
+
+// OutputErr formats an error based on output if its length is not zero,
+// or returns err otherwise.
+func OutputErrCombine(stdout, stderr []byte, err error) error {
+	msg := CombineStdOutErr(stdout, stderr)
+	return OutputErr(msg, err)
+}

--- a/osutil/outputerr_test.go
+++ b/osutil/outputerr_test.go
@@ -36,6 +36,10 @@ func (ts *outputErrSuite) TestOutputErrOutputWithoutNewlines(c *C) {
 	err := fmt.Errorf("test error")
 	formattedErr := osutil.OutputErr([]byte(output), err)
 	c.Check(formattedErr, ErrorMatches, output)
+	formattedErr = osutil.OutputErrCombine([]byte(output), nil, err)
+	c.Check(formattedErr, ErrorMatches, output)
+	formattedErr = osutil.OutputErrCombine([]byte(output), []byte{}, err)
+	c.Check(formattedErr, ErrorMatches, output)
 }
 
 func (ts *outputErrSuite) TestOutputErrOutputWithNewlines(c *C) {
@@ -53,4 +57,13 @@ func (ts *outputErrSuite) TestOutputErrNoOutput(c *C) {
 	err := fmt.Errorf("test error")
 	formattedErr := osutil.OutputErr([]byte{}, err)
 	c.Check(formattedErr, Equals, err)
+}
+
+func (ts *outputErrSuite) TestOutputErrOutputWithStderr(c *C) {
+	output := "test output"
+	stderr := "something bad happened"
+	err := fmt.Errorf("test error")
+	formattedErr := osutil.OutputErrCombine([]byte(output), []byte(stderr), err)
+	c.Check(formattedErr.Error(), Equals, "\n-----\n"+output+"\nstderr:\n"+stderr+
+		"\n-----")
 }

--- a/overlord/configstate/configcore/hostname.go
+++ b/overlord/configstate/configcore/hostname.go
@@ -109,9 +109,9 @@ func getHostnameFromSystemHelper(key string) (interface{}, error) {
 
 func getHostnameFromSystem() (string, error) {
 	// try pretty hostname first
-	output, err := exec.Command("hostnamectl", "status", "--pretty").CombinedOutput()
+	output, stderr, err := osutil.RunSplitOutput("hostnamectl", "status", "--pretty")
 	if err != nil {
-		return "", fmt.Errorf("cannot get hostname (pretty): %v", osutil.OutputErr(output, err))
+		return "", fmt.Errorf("cannot get hostname (pretty): %v", osutil.OutputErrCombine(output, stderr, err))
 	}
 	prettyHostname := strings.TrimSpace(string(output))
 	if len(prettyHostname) > 0 {
@@ -119,9 +119,9 @@ func getHostnameFromSystem() (string, error) {
 	}
 
 	// then static hostname
-	output, err = exec.Command("hostnamectl", "status", "--static").CombinedOutput()
+	output, stderr, err = osutil.RunSplitOutput("hostnamectl", "status", "--static")
 	if err != nil {
-		return "", fmt.Errorf("cannot get hostname: %v", osutil.OutputErr(output, err))
+		return "", fmt.Errorf("cannot get hostname: %v", osutil.OutputErrCombine(output, stderr, err))
 	}
 	return strings.TrimSpace(string(output)), nil
 }

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -1564,7 +1564,7 @@ func (s *deviceMgrSuite) TestDeviceManagerStartupUC20UbuntuSaveSystemCtlFails(c 
 
 	err = mgr.StartUp()
 	c.Assert(err, NotNil)
-	c.Check(err.Error(), Equals, "cannot set up ubuntu-save: systemctl command [start var-lib-snapd-save.mount] failed with exit status 1: failed\n")
+	c.Check(err.Error(), Equals, "cannot set up ubuntu-save: systemctl command [start var-lib-snapd-save.mount] failed with exit status 1: failed")
 	c.Check(sysctlCmd.Calls(), DeepEquals, [][]string{
 		{"systemctl", "start", "var-lib-snapd-save.mount"},
 	})

--- a/overlord/servicestate/servicemgr.go
+++ b/overlord/servicestate/servicemgr.go
@@ -225,9 +225,9 @@ func serviceControlAffectedSnaps(t *state.Task) ([]string, error) {
 func getBootTime() (time.Time, error) {
 	cmd := exec.Command("uptime", "-s")
 	cmd.Env = append(cmd.Env, "TZ=UTC")
-	out, err := cmd.CombinedOutput()
+	out, stderr, err := osutil.RunCmd(cmd)
 	if err != nil {
-		return time.Time{}, osutil.OutputErr(out, err)
+		return time.Time{}, osutil.OutputErrCombine(out, stderr, err)
 	}
 
 	// parse the output from the command as a time

--- a/snap/integrity/dmverity/veritysetup.go
+++ b/snap/integrity/dmverity/veritysetup.go
@@ -24,7 +24,6 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"os/exec"
 	"regexp"
 	"strconv"
 	"strings"
@@ -85,10 +84,9 @@ func getRootHashFromOutput(output []byte) (rootHash string, err error) {
 }
 
 func verityVersion() (major, minor, patch int, err error) {
-	cmd := exec.Command("veritysetup", "--version")
-	output, err := cmd.CombinedOutput()
+	output, stderr, err := osutil.RunSplitOutput("veritysetup", "--version")
 	if err != nil {
-		return -1, -1, -1, osutil.OutputErr(output, err)
+		return -1, -1, -1, osutil.OutputErrCombine(output, stderr, err)
 	}
 
 	exp := regexp.MustCompile(`(\d+)\.(\d+)\.(\d+)`)
@@ -140,11 +138,9 @@ func Format(dataDevice string, hashDevice string) (*Info, error) {
 		os.WriteFile(hashDevice, space, 0644)
 	}
 
-	cmd := exec.Command("veritysetup", "format", dataDevice, hashDevice)
-
-	output, err := cmd.CombinedOutput()
+	output, stderr, err := osutil.RunSplitOutput("veritysetup", "format", dataDevice, hashDevice)
 	if err != nil {
-		return nil, osutil.OutputErr(output, err)
+		return nil, osutil.OutputErrCombine(output, stderr, err)
 	}
 
 	logger.Debugf("cmd: 'veritysetup format %s %s':\n%s", dataDevice, hashDevice, string(output))

--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -380,10 +380,10 @@ func (s *Snap) Walk(relative string, walkFn filepath.WalkFunc) error {
 
 // ListDir returns the content of a single directory inside a squashfs snap.
 func (s *Snap) ListDir(dirPath string) ([]string, error) {
-	output, err := exec.Command(
-		"unsquashfs", "-no-progress", "-dest", "_", "-l", s.path, dirPath).CombinedOutput()
+	output, stderr, err := osutil.RunSplitOutput(
+		"unsquashfs", "-no-progress", "-dest", "_", "-l", s.path, dirPath)
 	if err != nil {
-		return nil, osutil.OutputErr(output, err)
+		return nil, osutil.OutputErrCombine(output, stderr, err)
 	}
 
 	prefixPath := path.Join("_", dirPath)

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -118,12 +118,11 @@ func MockNewSystemd(f func(be Backend, rootDir string, mode InstanceMode, rep Re
 
 // systemctlCmd calls systemctl with the given args, returning its standard output (and wrapped error)
 var systemctlCmd = func(args ...string) ([]byte, error) {
-	// TODO: including stderr here breaks many things when systemd is in debug
-	// output mode, see LP #1885597
-	bs, err := exec.Command("systemctl", args...).CombinedOutput()
+	bs, stderr, err := osutil.RunSplitOutput("systemctl", args...)
 	if err != nil {
 		exitCode, runErr := osutil.ExitCode(err)
-		return nil, &Error{cmd: args, exitCode: exitCode, runErr: runErr, msg: bs}
+		return nil, &Error{cmd: args, exitCode: exitCode, runErr: runErr,
+			msg: osutil.CombineStdOutErr(bs, stderr)}
 	}
 
 	return bs, nil
@@ -1695,9 +1694,9 @@ func (s *systemd) Run(command []string, opts *RunOptions) ([]byte, error) {
 	cmd := exec.Command("systemd-run", runArgs...)
 	cmd.Stdin = opts.Stdin
 
-	output, err := cmd.CombinedOutput()
+	stdout, stderr, err := osutil.RunCmd(cmd)
 	if err != nil {
-		return nil, fmt.Errorf("cannot run %q: %v", command, osutil.OutputErr(output, err))
+		return nil, fmt.Errorf("cannot run %q: %v", command, osutil.OutputErrCombine(stdout, stderr, err))
 	}
-	return output, nil
+	return stdout, nil
 }

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -2342,13 +2342,13 @@ func (s *SystemdTestSuite) TestSystemdRunError(c *C) {
 	c.Assert(err, ErrorMatches, `cannot run \["bad-cmd" "arg1"\]: fail`)
 }
 
-func (s *SystemdTestSuite) TestSystemdRunHappy(c *C) {
+func (s *SystemdTestSuite) TestSystemdRunHappyNoStderr(c *C) {
 	sr := testutil.MockCommand(c, "systemd-run", `echo "happy output" && >&2 echo "to stderr"`)
 	defer sr.Restore()
 
 	sysd := New(SystemMode, s.rep)
 	output, err := sysd.Run([]string{"happy-cmd", "arg1"}, nil)
-	c.Check(string(output), Equals, "happy output\nto stderr\n")
+	c.Check(string(output), Equals, "happy output\n")
 	c.Check(err, IsNil)
 	c.Check(sr.Calls(), DeepEquals, [][]string{
 		{"systemd-run", "--wait", "--pipe", "--collect", "--service-type=exec", "--quiet", "--", "happy-cmd", "arg1"},
@@ -2392,7 +2392,7 @@ func (s *systemdErrorSuite) TestErrorStringNormalError(c *C) {
 	defer systemctl.Restore()
 
 	_, err := Version()
-	c.Check(err, ErrorMatches, `systemctl command \[--version\] failed with exit status 11: I fail\n`)
+	c.Check(err, ErrorMatches, `systemctl command \[--version\] failed with exit status 11: I fail`)
 }
 
 func (s *systemdErrorSuite) TestErrorStringNoOutput(c *C) {

--- a/usersession/userd/launcher.go
+++ b/usersession/userd/launcher.go
@@ -161,12 +161,9 @@ func checkOnClassic() *dbus.Error {
 var validDesktopFileName = regexp.MustCompile(`^[A-Za-z-_][A-Za-z0-9-_]*(\.[A-Za-z-_][A-Za-z0-9-_]*)*\.desktop$`)
 
 func schemeHasHandler(scheme string) (bool, error) {
-	cmd := exec.Command("xdg-mime", "query", "default", "x-scheme-handler/"+scheme)
-	// TODO: consider using Output() in case xdg-mime starts logging to
-	// stderr
-	out, err := cmd.CombinedOutput()
+	out, stderr, err := osutil.RunSplitOutput("xdg-mime", "query", "default", "x-scheme-handler/"+scheme)
 	if err != nil {
-		return false, osutil.OutputErr(out, err)
+		return false, osutil.OutputErrCombine(out, stderr, err)
 	}
 	out = bytes.TrimSpace(out)
 	// if the output is a valid desktop file we have a handler for the given

--- a/usersession/userd/settings.go
+++ b/usersession/userd/settings.go
@@ -222,9 +222,9 @@ func setDialog(s *Settings, setspec *settingSpec, desktopFile string, sender dbu
 }
 
 func checkOutput(cmd *exec.Cmd, command string, setspec *settingSpec) (string, *dbus.Error) {
-	output, err := cmd.CombinedOutput()
+	output, stderr, err := osutil.RunCmd(cmd)
 	if err != nil {
-		return "", dbus.MakeFailedError(fmt.Errorf("cannot %s %s setting: %s", command, setspec, osutil.OutputErr(output, err)))
+		return "", dbus.MakeFailedError(fmt.Errorf("cannot %s %s setting: %s", command, setspec, osutil.OutputErrCombine(output, stderr, err)))
 	}
 	return string(output), nil
 }

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -2973,7 +2973,7 @@ func (s *servicesTestSuite) TestServicesEnableStateFail(c *C) {
 	defer r.Restore()
 
 	_, err := wrappers.ServicesEnableState(info, progress.Null)
-	c.Assert(err, ErrorMatches, ".*show --property=Id,ActiveState,UnitFileState,Type,Names,NeedDaemonReload snap.hello-snap.svc1.service\\] failed with exit status 1: whoops\n.*")
+	c.Assert(err, ErrorMatches, ".*show --property=Id,ActiveState,UnitFileState,Type,Names,NeedDaemonReload snap.hello-snap.svc1.service\\] failed with exit status 1: whoops.*")
 
 	c.Assert(r.Calls(), DeepEquals, [][]string{
 		{"systemctl", "show", "--property=Id,ActiveState,UnitFileState,Type,Names,NeedDaemonReload", svc1File},


### PR DESCRIPTION
Some invocations to external programs used exec.CombinedOutput, that
combines stdout and strerr into a single byte array. This can be an
issue if this output is parsed, as many programs print debug output or
warnings to stderr and that data is unexpected by the parsers. This
patch changes to using osutil.RunSplitOutput or osutil.RunCmd (that
return separately stdout and stderr) when we need to parse stdout, and
also in some other cases when printing separately both streams could
be helpful. Fixes LP #1885597.