### PR TITLE
tests: fix selinux-lxd in centos-7

### DIFF
--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -257,7 +257,7 @@ gen_require(`
 	type usr_t;
 ')
 allow snappy_t usr_t:dir { write remove_name add_name };
-allow snappy_t usr_t:lnk_file { create unlink };
+allow snappy_t usr_t:lnk_file { create unlink rename };
 
 # Allow snapd to use ssh-keygen
 ssh_exec_keygen(snappy_t)


### PR DESCRIPTION
Update the selinux policy to fix the denial which is shown in centos 7

type=AVC msg=audit(09/26/23 12:44:11.492:315) : avc:  denied  { rename } for  pid=28207 comm=snapd name=lxd.lxc.yLBQbN9J4LrW~ dev="sda2" ino=17679133 scontext=system_u:system_r:snappy_t:s0 tcontext=system_u:object_r:usr_t:s0 tclass=lnk_file permissive=1

