### PR TITLE
o/devicestate: refactor remodelEssentialSnapTasks for readability

### DIFF
--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -552,29 +552,23 @@ func remodelEssentialSnapTasks(ctx context.Context, st *state.State, pathSI *pat
 	}
 
 	if edgeTask := ts.MaybeEdge(snapstate.LastBeforeLocalModificationsEdge); edgeTask != nil {
-		// no task is marked as being last
-		// before local modifications are
-		// introduced, indicating that the
-		// update is a simple
+		// no task is marked as being last before local modifications are
+		// introduced, indicating that the update is a simple
 		// switch-snap-channel
 		return ts, nil
 	}
 
 	switch ms.newModelSnap.SnapType {
 	case "kernel", "base":
-		// in other cases make sure that
-		// the kernel or base is linked
-		// and available, and that
-		// kernel updates boot assets if
-		// needed
+		// in other cases make sure that the kernel or base is linked and
+		// available, and that kernel updates boot assets if needed
 		ts, err = snapstate.AddLinkNewBaseOrKernel(st, ts)
 		if err != nil {
 			return nil, err
 		}
 	case "gadget":
-		// gadget snaps may need gadget
-		// related tasks such as assets
-		// update or command line update
+		// gadget snaps may need gadget related tasks such as assets update or
+		// command line update
 		ts, err = snapstate.AddGadgetAssetsTasks(st, ts)
 		if err != nil {
 			return nil, err

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -529,11 +529,11 @@ func remodelEssentialSnapTasks(ctx context.Context, st *state.State, pathSI *pat
 			snapstate.Flags{}, deviceCtx, fromChange)
 	}
 
+	// in UC20+ models, the model can specify a channel for each
+	// snap, thus making it possible to change already installed
+	// kernel or base snaps
 	changed := false
 	if ms.new.Grade() != asserts.ModelGradeUnset {
-		// in UC20+ models, the model can specify a channel for each
-		// snap, thus making it possible to change already installed
-		// kernel or base snaps
 		changed, err = installedSnapChannelChanged(st, ms.newModelSnap.SnapName(), newModelSnapChannel)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This change eliminates some code-nesting and makes things a bit more readable, in my opinion. I can close this though, if no one agrees!

The only change to the actual logic that I made was eliminating the check to see if the `*state.TaskSet` returned from `remodelVar.UpdateWithDeviceContext` is `nil`, since none of the code paths that I see in that method can result in a `nil` task set when `err == nil`.