### PR TITLE
o/devicestate: fix panic when attempting remodel to model with an snap that has an optional presence

### DIFF
--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -720,13 +720,14 @@ func remodelTasks(ctx context.Context, st *state.State, current, new *asserts.Mo
 				return nil, err
 			}
 
-			if modelSnap.Presence == "required" {
-				needsInstall = true
-			} else {
-				// if the snap isn't already installed, and it isn't required,
-				// then there is nothing to do
+			// if the snap isn't already installed, and it isn't required,
+			// then there is nothing to do. note that if the snap is installed,
+			// we might need to change the channel.
+			if modelSnap.Presence != "required" {
 				continue
 			}
+
+			needsInstall = true
 		}
 
 		// default channel can be set only in UC20 models

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -709,6 +709,11 @@ func remodelTasks(ctx context.Context, st *state.State, current, new *asserts.Mo
 	// go through all the model snaps, see if there are new required snaps
 	// or a track for existing ones needs to be updated
 	for _, modelSnap := range new.SnapsWithoutEssential() {
+		// if the snap isn't required, then we don't do anything right now
+		if modelSnap.Presence != "required" {
+			continue
+		}
+
 		logger.Debugf("adding remodel tasks for non-essential snap %s", modelSnap.Name)
 
 		// TODO|XXX: have methods that take refs directly
@@ -719,10 +724,9 @@ func remodelTasks(ctx context.Context, st *state.State, current, new *asserts.Mo
 			if !isNotInstalled(err) {
 				return nil, err
 			}
-			if modelSnap.Presence == "required" {
-				needsInstall = true
-			}
+			needsInstall = true
 		}
+
 		// default channel can be set only in UC20 models
 		newModelSnapChannel, err := modelSnapChannelFromDefaultOrPinnedTrack(new, modelSnap)
 		if err != nil {

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -709,11 +709,6 @@ func remodelTasks(ctx context.Context, st *state.State, current, new *asserts.Mo
 	// go through all the model snaps, see if there are new required snaps
 	// or a track for existing ones needs to be updated
 	for _, modelSnap := range new.SnapsWithoutEssential() {
-		// if the snap isn't required, then we don't do anything right now
-		if modelSnap.Presence != "required" {
-			continue
-		}
-
 		logger.Debugf("adding remodel tasks for non-essential snap %s", modelSnap.Name)
 
 		// TODO|XXX: have methods that take refs directly
@@ -724,7 +719,14 @@ func remodelTasks(ctx context.Context, st *state.State, current, new *asserts.Mo
 			if !isNotInstalled(err) {
 				return nil, err
 			}
-			needsInstall = true
+
+			if modelSnap.Presence == "required" {
+				needsInstall = true
+			} else {
+				// if the snap isn't already installed, and it isn't required,
+				// then there is nothing to do
+				continue
+			}
 		}
 
 		// default channel can be set only in UC20 models

--- a/overlord/devicestate/devicestate_remodel_test.go
+++ b/overlord/devicestate/devicestate_remodel_test.go
@@ -2024,6 +2024,11 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20RequiredSnapsAndRecoverySystem(c 
 				"id":       snaptest.AssertedSnapID("new-required-snap-2"),
 				"presence": "required",
 			},
+			map[string]interface{}{
+				"name":     "new-optional-snap-1",
+				"id":       snaptest.AssertedSnapID("new-optional-snap-1"),
+				"presence": "optional",
+			},
 		},
 	})
 	chg, err := devicestate.Remodel(s.state, new, nil, nil)


### PR DESCRIPTION
When attempting a remodel to a model that includes a snap that has its presence set to `optional`, then you will encounter a panic if that optional snap is not already present on the system. This change fixes that panic. I will have a follow-up PR that makes the logic inside of this for-loop a bit simpler, hopefully reducing the likelihood of something like this in the future.