### PR TITLE
o/snapstate: use store.access disable auto refresh

### DIFF
--- a/overlord/snapstate/autorefresh_test.go
+++ b/overlord/snapstate/autorefresh_test.go
@@ -1172,7 +1172,7 @@ func (s *autoRefreshTestSuite) TestTooSoonError(c *C) {
 	c.Check(snapstate.TooSoonError{}.Error(), Equals, "cannot auto-refresh so soon")
 }
 
-func setStoreAccess(s *state.State, access any) {
+func setStoreAccess(s *state.State, access interface{}) {
 	s.Lock()
 	defer s.Unlock()
 

--- a/overlord/snapstate/autorefresh_test.go
+++ b/overlord/snapstate/autorefresh_test.go
@@ -1172,7 +1172,7 @@ func (s *autoRefreshTestSuite) TestTooSoonError(c *C) {
 	c.Check(snapstate.TooSoonError{}.Error(), Equals, "cannot auto-refresh so soon")
 }
 
-func setStoreAccess(s *state.State, access string) {
+func setStoreAccess(s *state.State, access any) {
 	s.Lock()
 	defer s.Unlock()
 
@@ -1194,7 +1194,7 @@ func (s *autoRefreshTestSuite) TestSnapStoreOffline(c *C) {
 	c.Check(s.state.Changes(), HasLen, 0)
 	s.state.Unlock()
 
-	setStoreAccess(s.state, "")
+	setStoreAccess(s.state, nil)
 
 	err = af.Ensure()
 	c.Check(err, IsNil)

--- a/overlord/snapstate/autorefresh_test.go
+++ b/overlord/snapstate/autorefresh_test.go
@@ -1194,7 +1194,7 @@ func (s *autoRefreshTestSuite) TestSnapStoreOffline(c *C) {
 	c.Check(s.state.Changes(), HasLen, 0)
 	s.state.Unlock()
 
-	setStoreAccess(s.state, "online")
+	setStoreAccess(s.state, "")
 
 	err = af.Ensure()
 	c.Check(err, IsNil)

--- a/overlord/snapstate/autorefresh_test.go
+++ b/overlord/snapstate/autorefresh_test.go
@@ -1171,3 +1171,36 @@ func (s *autoRefreshTestSuite) TestTooSoonError(c *C) {
 	c.Check(snapstate.TooSoonError{}, Not(testutil.ErrorIs), errors.New(""))
 	c.Check(snapstate.TooSoonError{}.Error(), Equals, "cannot auto-refresh so soon")
 }
+
+func setStoreAccess(s *state.State, access string) {
+	s.Lock()
+	defer s.Unlock()
+
+	tr := config.NewTransaction(s)
+	tr.Set("core", "store.access", access)
+	tr.Commit()
+}
+
+func (s *autoRefreshTestSuite) TestSnapStoreOffline(c *C) {
+	s.addRefreshableSnap("foo")
+
+	setStoreAccess(s.state, "offline")
+
+	af := snapstate.NewAutoRefresh(s.state)
+	err := af.Ensure()
+	c.Check(err, IsNil)
+
+	s.state.Lock()
+	c.Check(s.state.Changes(), HasLen, 0)
+	s.state.Unlock()
+
+	setStoreAccess(s.state, "online")
+
+	err = af.Ensure()
+	c.Check(err, IsNil)
+
+	c.Check(s.store.ops, DeepEquals, []string{"list-refresh"})
+	s.state.Lock()
+	c.Check(s.state.Changes(), HasLen, 1)
+	s.state.Unlock()
+}

--- a/overlord/snapstate/catalogrefresh.go
+++ b/overlord/snapstate/catalogrefresh.go
@@ -59,6 +59,11 @@ func (r *catalogRefresh) Ensure() error {
 	r.state.Lock()
 	defer r.state.Unlock()
 
+	online, err := isStoreOnline(r.state)
+	if err != nil || !online {
+		return err
+	}
+
 	// sneakily don't do anything if in testing
 	if CanAutoRefresh == nil {
 		return nil
@@ -68,7 +73,7 @@ func (r *catalogRefresh) Ensure() error {
 	// do not bother refreshing catalog, snap list is empty anyway
 	// beside there is high change device has no internet
 	var seeded bool
-	err := r.state.Get("seeded", &seeded)
+	err = r.state.Get("seeded", &seeded)
 	if errors.Is(err, state.ErrNoState) || !seeded {
 		logger.Debugf("CatalogRefresh:Ensure: skipping refresh, system is not seeded yet")
 		// not seeded yet

--- a/overlord/snapstate/catalogrefresh_test.go
+++ b/overlord/snapstate/catalogrefresh_test.go
@@ -304,7 +304,7 @@ func (s *catalogRefreshTestSuite) TestSnapStoreOffline(c *C) {
 
 	c.Check(s.store.ops, HasLen, 0)
 
-	setStoreAccess(s.state, "online")
+	setStoreAccess(s.state, "")
 
 	err = af.Ensure()
 	c.Check(err, IsNil)

--- a/overlord/snapstate/catalogrefresh_test.go
+++ b/overlord/snapstate/catalogrefresh_test.go
@@ -294,3 +294,20 @@ func (s *catalogRefreshTestSuite) TestCatalogRefreshSkipWhenTesting(c *C) {
 	c.Check(dirs.SnapNamesFile, testutil.FilePresent)
 	c.Check(dirs.SnapCommandsDB, testutil.FilePresent)
 }
+
+func (s *catalogRefreshTestSuite) TestSnapStoreOffline(c *C) {
+	setStoreAccess(s.state, "offline")
+
+	af := snapstate.NewCatalogRefresh(s.state)
+	err := af.Ensure()
+	c.Check(err, IsNil)
+
+	c.Check(s.store.ops, HasLen, 0)
+
+	setStoreAccess(s.state, "online")
+
+	err = af.Ensure()
+	c.Check(err, IsNil)
+
+	c.Check(s.store.ops, DeepEquals, []string{"sections", "write-catalog"})
+}

--- a/overlord/snapstate/catalogrefresh_test.go
+++ b/overlord/snapstate/catalogrefresh_test.go
@@ -304,7 +304,7 @@ func (s *catalogRefreshTestSuite) TestSnapStoreOffline(c *C) {
 
 	c.Check(s.store.ops, HasLen, 0)
 
-	setStoreAccess(s.state, "")
+	setStoreAccess(s.state, nil)
 
 	err = af.Ensure()
 	c.Check(err, IsNil)

--- a/overlord/snapstate/refreshhints.go
+++ b/overlord/snapstate/refreshhints.go
@@ -124,6 +124,11 @@ func (r *refreshHints) Ensure() error {
 	r.state.Lock()
 	defer r.state.Unlock()
 
+	online, err := isStoreOnline(r.state)
+	if err != nil || !online {
+		return err
+	}
+
 	// CanAutoRefresh is a hook that is set by the devicestate
 	// code to ensure that we only AutoRefresh if the device has
 	// bootstraped itself enough. This is only nil when snapstate

--- a/overlord/snapstate/refreshhints_test.go
+++ b/overlord/snapstate/refreshhints_test.go
@@ -567,7 +567,7 @@ func (s *refreshHintsTestSuite) TestSnapStoreOffline(c *C) {
 
 	c.Check(s.store.ops, HasLen, 0)
 
-	setStoreAccess(s.state, "")
+	setStoreAccess(s.state, nil)
 
 	err = rh.Ensure()
 	c.Check(err, IsNil)

--- a/overlord/snapstate/refreshhints_test.go
+++ b/overlord/snapstate/refreshhints_test.go
@@ -557,3 +557,20 @@ func (s *refreshHintsTestSuite) TestRefreshHintsNotApplicableWrongEpoch(c *C) {
 	// other-snap ignored due to epoch
 	c.Check(candidates["some-snap"], NotNil)
 }
+
+func (s *refreshHintsTestSuite) TestSnapStoreOffline(c *C) {
+	setStoreAccess(s.state, "offline")
+
+	rh := snapstate.NewRefreshHints(s.state)
+	err := rh.Ensure()
+	c.Check(err, IsNil)
+
+	c.Check(s.store.ops, HasLen, 0)
+
+	setStoreAccess(s.state, "online")
+
+	err = rh.Ensure()
+	c.Check(err, IsNil)
+
+	c.Check(s.store.ops, DeepEquals, []string{"list-refresh"})
+}

--- a/overlord/snapstate/refreshhints_test.go
+++ b/overlord/snapstate/refreshhints_test.go
@@ -567,7 +567,7 @@ func (s *refreshHintsTestSuite) TestSnapStoreOffline(c *C) {
 
 	c.Check(s.store.ops, HasLen, 0)
 
-	setStoreAccess(s.state, "online")
+	setStoreAccess(s.state, "")
 
 	err = rh.Ensure()
 	c.Check(err, IsNil)


### PR DESCRIPTION
`store.access` is used to control our access to the store. If this is set to `offline`, we can short-circuit the auto-refreshing of snaps so aren't even attempted.