### PR TITLE
cmd/snap-repair: make snap-repair respect store.offline configurable

### DIFF
--- a/cmd/snap-repair/export_test.go
+++ b/cmd/snap-repair/export_test.go
@@ -30,9 +30,12 @@ import (
 )
 
 var (
-	ParseArgs = parseArgs
-	Run       = run
+	ParseArgs       = parseArgs
+	Run             = run
+	ErrStoreOffline = errStoreOffline
 )
+
+type RepairConfig = repairConfig
 
 func MockBaseURL(baseurl string) (restore func()) {
 	orig := baseURL


### PR DESCRIPTION
The handler for the `store.access` configurable writes a file to `/var/lib/snapd/repair.json`. Example:
```shell
ubuntu@core22:/var/lib/snapd$ cat repair.json | jq .
{
  "store-offline": true
}
```

This PR modifies `snap-repair` to parse this file and disable store access if `store-offline` is set to true. If the file is not present or unparseable for some reason, then the store will be assumed to be online.

Example of running `snap-repair` when the store is offline:
```shell
ubuntu@core22:~$ sudo ./snap-repair run
error: snap store is marked offline
```