### PR TITLE
osutil: move to useradd from adduser

### DIFF
--- a/osutil/export_test.go
+++ b/osutil/export_test.go
@@ -149,6 +149,14 @@ func MockLookPath(new func(string) (string, error)) (restore func()) {
 	}
 }
 
+func MockhasAddUserExecutable(new func() bool) (restore func()) {
+	old := hasAddUserExecutable
+	hasAddUserExecutable = new
+	return func() {
+		hasAddUserExecutable = old
+	}
+}
+
 func SetAtomicFileRenamed(aw *AtomicFile, renamed bool) {
 	aw.renamed = renamed
 }

--- a/osutil/user.go
+++ b/osutil/user.go
@@ -219,8 +219,10 @@ func AddUser(name string, opts *AddUserOptions) error {
 		"--disabled-password",
 	}
 	if !hasAddUserExecutable() {
-		// No reason to use --badname for useradd, we are already a lot more
-		// strict than useradd, with our own regex "IsValidUsername".
+		// No reason to use --badname for useradd, we are already a lot
+		// more strict than useradd, with our own regex
+		// "IsValidUsername". Users created by useradd have the password
+		// disabled by default.
 		cmdStr = []string{
 			"useradd",
 			"--comment", opts.Gecos,

--- a/osutil/user.go
+++ b/osutil/user.go
@@ -199,7 +199,7 @@ var hasAddUserExecutable = func() bool {
 // AddUser uses the Debian/Ubuntu/derivative 'adduser' command for creating
 // regular login users on Ubuntu Core. 'adduser' is not portable cross-distro
 // but is convenient for creating regular login users.
-// if 'adduser' is not avaialble, 'useradd' is used instead.
+// if 'adduser' is not available, 'useradd' is used instead.
 // This order is preferred as older version of 'useradd' does not support
 // "--badname" option.
 //

--- a/osutil/user.go
+++ b/osutil/user.go
@@ -213,15 +213,7 @@ func AddUser(name string, opts *AddUserOptions) error {
 
 	var userTool string
 	var cmdStr []string
-	if hasAddUserExecutable() {
-		userTool = "adduser"
-		cmdStr = []string{
-			"adduser",
-			"--force-badname",
-			"--gecos", opts.Gecos,
-			"--disabled-password",
-		}
-	} else {
+	if !hasAddUserExecutable() {
 		userTool = "useradd"
 		cmdStr = []string{
 			"useradd",
@@ -229,6 +221,14 @@ func AddUser(name string, opts *AddUserOptions) error {
 			"--comment", opts.Gecos,
 			"--create-home",
 			"--shell", "/bin/bash",
+		}
+	} else {
+		userTool = "adduser"
+		cmdStr = []string{
+			"adduser",
+			"--force-badname",
+			"--gecos", opts.Gecos,
+			"--disabled-password",
 		}
 	}
 

--- a/osutil/user.go
+++ b/osutil/user.go
@@ -200,8 +200,6 @@ var hasAddUserExecutable = func() bool {
 // regular login users on Ubuntu Core. 'adduser' is not portable cross-distro
 // but is convenient for creating regular login users.
 // if 'adduser' is not available, 'useradd' is used instead.
-// This order is preferred as older version of 'useradd' does not support
-// "--badname" option.
 //
 // The username created by this function will be checked against
 // IsValidUsername().

--- a/osutil/user.go
+++ b/osutil/user.go
@@ -60,16 +60,19 @@ type AddUserOptions struct {
 // We check the (user)name ourselves, adduser is a bit too
 // strict (i.e. no `.`) - this regexp is in sync with that SSO
 // allows as valid usernames.
+// On systems where there are no adduser, this is the regex that verifies
+// users being created, and serves as a replacement for the regex that adduser
+// was providing.
 //
 // IsValidUsername define what is valid for a "system-user" assertion.
-var IsValidUsername = regexp.MustCompile(`^[a-z0-9][-a-z0-9+._]*$`).MatchString
+var IsValidUsername = regexp.MustCompile(`^[a-z0-9][-a-z0-9._]*$`).MatchString
 
 // IsValidSnapSystemUsername defines what is valid for the
 // "system-usernames" stanza in the snap.yaml.
 //
 // Unlike a normal username a system usernames can be encloused in "_"
 // (e.g. _username_ is valid)
-var IsValidSnapSystemUsername = regexp.MustCompile(`^([_][-a-z0-9+._]+[_]|[a-z0-9][-a-z0-9+._]*)$`).MatchString
+var IsValidSnapSystemUsername = regexp.MustCompile(`^([_][-a-z0-9._]+[_]|[a-z0-9][-a-z0-9._]*)$`).MatchString
 
 // EnsureSnapUserGroup uses the standard shadow utilities' 'useradd'
 // and 'groupadd' commands for creating non-login system users and
@@ -218,9 +221,10 @@ func AddUser(name string, opts *AddUserOptions) error {
 		"--disabled-password",
 	}
 	if !hasAddUserExecutable() {
+		// No reason to use --badname for useradd, we are already a lot more
+		// strict than useradd, with our own regex "IsValidUsername".
 		cmdStr = []string{
 			"useradd",
-			"--badname",
 			"--comment", opts.Gecos,
 			"--create-home",
 			"--shell", "/bin/bash",

--- a/osutil/user.go
+++ b/osutil/user.go
@@ -196,7 +196,7 @@ var hasAddUserExecutable = func() bool {
 // AddUser uses the Debian/Ubuntu/derivative 'adduser' command for creating
 // regular login users on Ubuntu Core. 'adduser' is not portable cross-distro
 // but is convenient for creating regular login users.
-// if 'adduser', 'useradd' is used instead.
+// if 'adduser' is not avaialble, 'useradd' is used instead.
 // This order is preferred as older version of 'useradd' does not support
 // "--badname" option.
 //

--- a/osutil/user.go
+++ b/osutil/user.go
@@ -211,10 +211,8 @@ func AddUser(name string, opts *AddUserOptions) error {
 		return fmt.Errorf("cannot add user %q: name contains invalid characters", name)
 	}
 
-	var userTool string
 	var cmdStr []string
 	if !hasAddUserExecutable() {
-		userTool = "useradd"
 		cmdStr = []string{
 			"useradd",
 			"--badname",
@@ -223,7 +221,6 @@ func AddUser(name string, opts *AddUserOptions) error {
 			"--shell", "/bin/bash",
 		}
 	} else {
-		userTool = "adduser"
 		cmdStr = []string{
 			"adduser",
 			"--force-badname",
@@ -239,7 +236,7 @@ func AddUser(name string, opts *AddUserOptions) error {
 
 	cmd := exec.Command(cmdStr[0], cmdStr[1:]...)
 	if output, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("%s failed with: %s", userTool, OutputErr(output, err))
+		return fmt.Errorf("%s failed with: %s", cmdStr[0], OutputErr(output, err))
 	}
 
 	if opts.Sudoer {

--- a/osutil/user.go
+++ b/osutil/user.go
@@ -211,7 +211,12 @@ func AddUser(name string, opts *AddUserOptions) error {
 		return fmt.Errorf("cannot add user %q: name contains invalid characters", name)
 	}
 
-	var cmdStr []string
+	cmdStr := []string{
+		"adduser",
+		"--force-badname",
+		"--gecos", opts.Gecos,
+		"--disabled-password",
+	}
 	if !hasAddUserExecutable() {
 		cmdStr = []string{
 			"useradd",
@@ -219,13 +224,6 @@ func AddUser(name string, opts *AddUserOptions) error {
 			"--comment", opts.Gecos,
 			"--create-home",
 			"--shell", "/bin/bash",
-		}
-	} else {
-		cmdStr = []string{
-			"adduser",
-			"--force-badname",
-			"--gecos", opts.Gecos,
-			"--disabled-password",
 		}
 	}
 

--- a/osutil/user_test.go
+++ b/osutil/user_test.go
@@ -164,6 +164,8 @@ karl.sagan ALL=(ALL) NOPASSWD:ALL
 }
 
 func (s *createUserSuite) TestAddUserSSHKeys(c *check.C) {
+	r := osutil.MockhasAddUserExecutable(func() bool { return true })
+	defer r()
 	err := osutil.AddUser("karl.sagan", &osutil.AddUserOptions{
 		SSHKeys: []string{"ssh-key1", "ssh-key2"},
 	})
@@ -173,6 +175,8 @@ func (s *createUserSuite) TestAddUserSSHKeys(c *check.C) {
 }
 
 func (s *createUserSuite) TestAddUserInvalidUsername(c *check.C) {
+	r := osutil.MockhasAddUserExecutable(func() bool { return true })
+	defer r()
 	err := osutil.AddUser("k!", nil)
 	c.Assert(err, check.ErrorMatches, `cannot add user "k!": name contains invalid characters`)
 }
@@ -226,6 +230,8 @@ func (s *createUserSuite) TestAddUserWithPasswordForceChange(c *check.C) {
 }
 
 func (s *createUserSuite) TestAddUserPasswordForceChangeUnhappy(c *check.C) {
+	r := osutil.MockhasAddUserExecutable(func() bool { return true })
+	defer r()
 	mockSudoers := c.MkDir()
 	restorer := osutil.MockSudoersDotD(mockSudoers)
 	defer restorer()
@@ -309,10 +315,8 @@ func (s *createUserSuite) TestUserAddUnhappy(c *check.C) {
 
 	mockUserAdd := testutil.MockCommand(c, "useradd", "echo some error; exit 1")
 	defer mockUserAdd.Restore()
-
 	err := osutil.AddUser("lakatos", nil)
 	c.Assert(err, check.ErrorMatches, "useradd failed with: some error")
-
 }
 
 var usernameTestCases = map[string]bool{

--- a/osutil/user_test.go
+++ b/osutil/user_test.go
@@ -100,7 +100,7 @@ func (s *createUserSuite) TestUserAddExtraUsersFalse(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	c.Check(s.mockUserAdd.Calls(), check.DeepEquals, [][]string{
-		{"useradd", "--badname", "--comment", "my gecos", "--create-home", "--shell", "/bin/bash", "lakatos"},
+		{"useradd", "--comment", "my gecos", "--create-home", "--shell", "/bin/bash", "lakatos"},
 	})
 }
 
@@ -130,7 +130,7 @@ func (s *createUserSuite) TestUserAddExtraUsersTrue(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	c.Check(s.mockUserAdd.Calls(), check.DeepEquals, [][]string{
-		{"useradd", "--badname", "--comment", "my gecos", "--create-home", "--shell", "/bin/bash", "--extrausers", "lakatos"},
+		{"useradd", "--comment", "my gecos", "--create-home", "--shell", "/bin/bash", "--extrausers", "lakatos"},
 	})
 }
 
@@ -219,7 +219,7 @@ func (s *createUserSuite) TestAddUserWithPasswordForceChange(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	c.Check(s.mockUserAdd.Calls(), check.DeepEquals, [][]string{
-		{"useradd", "--badname", "--comment", "my gecos", "--create-home", "--shell", "/bin/bash", "karl.popper"},
+		{"useradd", "--comment", "my gecos", "--create-home", "--shell", "/bin/bash", "karl.popper"},
 	})
 	c.Check(s.mockUserMod.Calls(), check.DeepEquals, [][]string{
 		{"usermod", "--password", "$6$salt$hash", "karl.popper"},
@@ -322,11 +322,11 @@ func (s *createUserSuite) TestUserAddUnhappy(c *check.C) {
 var usernameTestCases = map[string]bool{
 	"a":       true,
 	"a-b":     true,
-	"a+b":     true,
+	"a+b":     false,
 	"a.b":     true,
 	"a_b":     true,
 	"1":       true,
-	"1+":      true,
+	"1+":      false,
 	"1.":      true,
 	"1_":      true,
 	"-":       false,


### PR DESCRIPTION
`adduser` is perl based tool. Moving to `useradd` removes this dependency.
To maintain backwards compatibility as much as possible, prefer use of `adduser` if available and only then defer to `useradd`.


Older versions of `useradd` do not support `--badnames` option, so it is not safe to default to `useradd`.
This strategy will not affect UC22-, but will allow to have UC24+ without `adduser`, and therefore remove Perl dependency there.