### PR TITLE
o/snapstate: avoid incurring an extra reboot boundary for core snap when not boot-base

### DIFF
--- a/overlord/snapstate/reboot_test.go
+++ b/overlord/snapstate/reboot_test.go
@@ -216,17 +216,39 @@ func (s *rebootSuite) hasRestartBoundaries(c *C, ts *state.TaskSet) bool {
 	return true
 }
 
-func (s *rebootSuite) TestSetEssentialSnapsRestartBoundaries(c *C) {
+func (s *rebootSuite) TestSetEssentialSnapsRestartBoundariesUC16(c *C) {
 	defer snapstatetest.MockDeviceModel(DefaultModel())()
 
 	s.state.Lock()
 	defer s.state.Unlock()
 
 	tss := []*state.TaskSet{
-		s.taskSetForSnapSetup("core", snap.TypeBase),
+		s.taskSetForSnapSetup("core20", snap.TypeBase),
 		s.taskSetForSnapSetup("my-gadget", snap.TypeGadget),
 		s.taskSetForSnapSetup("my-kernel", snap.TypeKernel),
-		s.taskSetForSnapSetup("my-os", snap.TypeOS),
+		s.taskSetForSnapSetup("core", snap.TypeOS),
+		s.taskSetForSnapSetup("my-app", snap.TypeApp),
+	}
+	err := snapstate.SetEssentialSnapsRestartBoundaries(s.state, nil, tss)
+	c.Assert(err, IsNil)
+	c.Check(s.hasRestartBoundaries(c, tss[0]), Equals, false)
+	c.Check(s.hasRestartBoundaries(c, tss[1]), Equals, true)
+	c.Check(s.hasRestartBoundaries(c, tss[2]), Equals, true)
+	c.Check(s.hasRestartBoundaries(c, tss[3]), Equals, true)
+	c.Check(s.hasRestartBoundaries(c, tss[4]), Equals, false)
+}
+
+func (s *rebootSuite) TestSetEssentialSnapsRestartBoundariesUC20(c *C) {
+	defer snapstatetest.MockDeviceModel(MakeModel20("brand-gadget", nil))()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	tss := []*state.TaskSet{
+		s.taskSetForSnapSetup("core20", snap.TypeBase),
+		s.taskSetForSnapSetup("brand-gadget", snap.TypeGadget),
+		s.taskSetForSnapSetup("my-kernel", snap.TypeKernel),
+		s.taskSetForSnapSetup("core", snap.TypeOS),
 		s.taskSetForSnapSetup("my-app", snap.TypeApp),
 	}
 	err := snapstate.SetEssentialSnapsRestartBoundaries(s.state, nil, tss)
@@ -234,6 +256,6 @@ func (s *rebootSuite) TestSetEssentialSnapsRestartBoundaries(c *C) {
 	c.Check(s.hasRestartBoundaries(c, tss[0]), Equals, true)
 	c.Check(s.hasRestartBoundaries(c, tss[1]), Equals, true)
 	c.Check(s.hasRestartBoundaries(c, tss[2]), Equals, true)
-	c.Check(s.hasRestartBoundaries(c, tss[3]), Equals, true)
+	c.Check(s.hasRestartBoundaries(c, tss[3]), Equals, false)
 	c.Check(s.hasRestartBoundaries(c, tss[4]), Equals, false)
 }


### PR DESCRIPTION
While doing the next step for single-reboot feature, I ran into the issue that `core` base was being marked for restart-boundaries, even when not being the boot base. This happened because the `core` snap shows up in `mappedTss` whenever its being present (unlike other bases, that only show up in `mappedTss` if they're the boot-base), so we must be a bit more careful to make sure that it's *actually* the boot-base, and not just there for other reasons.