### PR TITLE
aspects: convert untyped constant before calling Sprintf

### DIFF
--- a/aspects/schema_test.go
+++ b/aspects/schema_test.go
@@ -1046,14 +1046,14 @@ func (*schemaSuite) TestIntegerMinMaxOver32Bits(c *C) {
 			"max": %d
 		}
 	}
-}`, math.MinInt64, math.MaxInt64))
+}`, int64(math.MinInt64), int64(math.MaxInt64)))
 
 	schema, err := aspects.ParseSchema(schemaStr)
 	c.Assert(err, IsNil)
 
 	input := []byte(fmt.Sprintf(`{
 	"foo": %d
-}`, math.MinInt64))
+}`, int64(math.MinInt64)))
 
 	err = schema.Validate(input)
 	c.Assert(err, IsNil)
@@ -1067,7 +1067,7 @@ func (*schemaSuite) TestIntegerChoicesOver32Bits(c *C) {
 			"choices": [%d, %d]
 		}
 	}
-}`, math.MinInt64, math.MaxInt64))
+}`, int64(math.MinInt64), int64(math.MaxInt64)))
 
 	schema, err := aspects.ParseSchema(schemaStr)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
This was failing to compile on 32-bit architectures because the untyped constants were implicitly converted to an int which they overflowed. Explicitly converting the constant to int64 fixes the issue.