### PR TITLE
cmd/libsnap-confine-private: pass env real-home to snap-update-ns

### DIFF
--- a/cmd/libsnap-confine-private/tool.c
+++ b/cmd/libsnap-confine-private/tool.c
@@ -117,6 +117,22 @@ void sc_call_snap_update_ns_as_user(int snap_update_ns_fd,
 				 "XDG_RUNTIME_DIR=%s", xdg_runtime_dir);
 	}
 
+	const char *snap_real_home = getenv("SNAP_REAL_HOME");
+	char snap_real_home_env[PATH_MAX + sizeof("SNAP_REAL_HOME=")] = { 0 };
+	if (snap_real_home != NULL) {
+		sc_must_snprintf(snap_real_home_env,
+				 sizeof(snap_real_home_env),
+				 "SNAP_REAL_HOME=%s", snap_real_home);
+        }
+
+	const char *snap_uid = getenv("SNAP_UID");
+	char snap_uid_env[PATH_MAX + sizeof("SNAP_UID=")] = { 0 };
+	if (snap_uid != NULL) {
+		sc_must_snprintf(snap_uid_env,
+				 sizeof(snap_uid_env),
+				 "SNAP_UID=%s", snap_uid);
+        }
+
 	char *argv[] = {
 		"snap-update-ns",
 		/* This tells snap-update-ns we are calling from snap-confine and locking is in place */
@@ -129,7 +145,9 @@ void sc_call_snap_update_ns_as_user(int snap_update_ns_fd,
 		 * with either SNAPD_DEBUG=0 or SNAPD_DEBUG=1, see that function
 		 * for details. */
 		"SNAPD_DEBUG=x",
-		xdg_runtime_dir_env, NULL
+		xdg_runtime_dir_env,
+		snap_real_home_env,
+		snap_uid_env, NULL
 	};
 	sc_call_snapd_tool_with_apparmor(snap_update_ns_fd,
 					 "snap-update-ns", apparmor,

--- a/cmd/libsnap-confine-private/tool.c
+++ b/cmd/libsnap-confine-private/tool.c
@@ -125,14 +125,6 @@ void sc_call_snap_update_ns_as_user(int snap_update_ns_fd,
 				 "SNAP_REAL_HOME=%s", snap_real_home);
         }
 
-	const char *snap_uid = getenv("SNAP_UID");
-	char snap_uid_env[PATH_MAX + sizeof("SNAP_UID=")] = { 0 };
-	if (snap_uid != NULL) {
-		sc_must_snprintf(snap_uid_env,
-				 sizeof(snap_uid_env),
-				 "SNAP_UID=%s", snap_uid);
-        }
-
 	char *argv[] = {
 		"snap-update-ns",
 		/* This tells snap-update-ns we are calling from snap-confine and locking is in place */
@@ -146,8 +138,7 @@ void sc_call_snap_update_ns_as_user(int snap_update_ns_fd,
 		 * for details. */
 		"SNAPD_DEBUG=x",
 		xdg_runtime_dir_env,
-		snap_real_home_env,
-		snap_uid_env, NULL
+		snap_real_home_env, NULL
 	};
 	sc_call_snapd_tool_with_apparmor(snap_update_ns_fd,
 					 "snap-update-ns", apparmor,

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -714,7 +714,7 @@ static void enter_non_classic_execution_environment(sc_invocation * inv,
 	sc_maybe_fixup_permissions();
 	sc_maybe_fixup_udev();
 
-	/* User mount profiles do not apply to non-root users. */
+	/* User mount profiles only apply to non-root users. */
 	if (real_uid != 0) {
 		debug("joining preserved per-user mount namespace");
 		retval =


### PR DESCRIPTION
Modify snap-confine to pass environment variables `$SNAP_UID` and `$SNAP_REAL_HOME` when a non-root user runs a non-classic snap application.

`$SNAP_REAL_HOME` is passed to `snap-update-ns` to enable expanding the new `ensure-dir` mount entries used for the personal-files interface that reference `$HOME`.  It is proposed that `$SNAP_UID` is also passed to `snap-update-ns` to allow for a basic sanity check to ensure that `$SNAP_REAL_HOME` belongs to the correct uid.

Call path:
`snap-confine.c | main() -> enter_non_classic_execution_environment() -> snap-confine/mount-support.c | sc_setup_user_mounts() -> libsnap-confine-private/tool.c | sc_call_snap_update_ns_as_user()`

This PR is `part 1` of a larger feature to automatically create missing personal-files interface parent directories.

There are 3 parts in total:
- Part 1: `pass env real-home and uid to snap-update-ns`              | [pull/13244](https://github.com/snapcore/snapd/pull/13244)
- Part 2: `many: ensure-dir mounts for personal-files missing dirs` | [pull/13260](https://github.com/snapcore/snapd/pull/13260)
- Part 3: `add snap-update-ns support for ensure-dir mounts`        | [pull/13342](https://github.com/snapcore/snapd/pull/13342)


Additional information:
- [Relevant section in spec](https://docs.google.com/document/d/1yRqiFcdAIUjwakIQdijtW61vKojcJN2vTjrcwJvLAdo/edit#heading=h.f1vzrc21ib3n)
- Jira [SNAPDENG-8233](https://warthogs.atlassian.net/browse/SNAPDENG-8233)

[SNAPDENG-8233]: https://warthogs.atlassian.net/browse/SNAPDENG-8233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ