### PR TITLE
tests/nested/manual/install-min-size: make it more stable

### DIFF
--- a/tests/nested/manual/install-min-size/task.yaml
+++ b/tests/nested/manual/install-min-size/task.yaml
@@ -47,7 +47,7 @@ execute: |
   boot_id=$(tests.nested boot-id)
 
   # Install new gadget
-  remote.exec "sudo snap install --dangerous pc.snap"
+  remote.exec "sudo snap install --dangerous pc.snap" || [ "$?" -eq 255 ]
   # It should reboot now
   remote.wait-for reboot "$boot_id"
 


### PR DESCRIPTION
`snap install` may cause reboot before the command ends, which causes a deconnection. ssh returns 255 when a error happens, so we detect the deconnection that way.