### PR TITLE
o/devicestate: refactor remodelTasks for readability

### DIFF
--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -844,9 +844,14 @@ func remodelTasks(ctx context.Context, st *state.State, current, new *asserts.Mo
 			}
 			tss = append(tss, ts)
 
-			// if this is true, then the snap's revision was changed, and we
-			// need to extract the prerequisites from the task set. otherwise,
-			// we treat the snap as if it were unchanged.
+			// we can know that the snap's revision was changed by checking for
+			// the presence of an edge on the task set that separates tasks that
+			// do and do not modify the system. if the edge is present, then the
+			// revision was changed, and we need to extract the snap's
+			// prerequisites from the task set. the absence of this edge,
+			// indicates that only the snap's channel was changed and the
+			// revision was unchanged. in this case, we treat the snap as if it
+			// were unchanged.
 			if ts.MaybeEdge(snapstate.LastBeforeLocalModificationsEdge) != nil {
 				if err := updateNeededSnapsFromTs(ts); err != nil {
 					return nil, err

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -791,6 +791,10 @@ func remodelTasks(ctx context.Context, st *state.State, current, new *asserts.Mo
 			needsInstall = true
 		}
 
+		// at this point, the snap will either be accounted for, or we will
+		// return an error from this loop
+		snapsAccountedFor[modelSnap.SnapName()] = true
+
 		// default channel can be set only in UC20 models
 		newModelSnapChannel, err := modelSnapChannelFromDefaultOrPinnedTrack(new, modelSnap)
 		if err != nil {
@@ -799,9 +803,8 @@ func remodelTasks(ctx context.Context, st *state.State, current, new *asserts.Mo
 
 		snapPathSi := sideInfoAndPathFromID(localSnaps, paths, modelSnap.ID())
 
-		var ts *state.TaskSet
 		if needsInstall {
-			ts, err = remodelVar.InstallWithDeviceContext(ctx, st,
+			ts, err := remodelVar.InstallWithDeviceContext(ctx, st,
 				snapPathSi, modelSnap.SnapName(), newModelSnapChannel,
 				userID, snapstate.Flags{Required: true}, deviceCtx,
 				fromChange)
@@ -809,56 +812,51 @@ func remodelTasks(ctx context.Context, st *state.State, current, new *asserts.Mo
 				return nil, err
 			}
 			tss = append(tss, ts)
-		} else if currentInfo != nil && newModelSnapChannel != "" {
-			// the snap is already installed and has its default
-			// channel declared in the model, but the local install
-			// may be tracking a different channel
-			changed, err := installedSnapChannelChanged(st, modelSnap.SnapName(), newModelSnapChannel)
-			if err != nil {
-				return nil, err
-			}
-			if changed {
-				ts, err = remodelVar.UpdateWithDeviceContext(st,
-					snapPathSi, modelSnap.SnapName(),
-					newModelSnapChannel, userID,
-					snapstate.Flags{NoReRefresh: true},
-					deviceCtx, fromChange)
-				if err != nil {
-					return nil, err
-				}
-				tss = append(tss, ts)
-			}
-		}
-		if currentInfo == nil {
-			// snap is not installed, we have a task set then
+
 			if err := updateNeededSnapsFromTs(ts); err != nil {
 				return nil, err
 			}
-		} else {
-			// snap is installed already, so we have 2 possible
-			// scenarios, one the snap will be updated, in which
-			// case we have a task set and should make sure that the
-			// prerequisites of the new revision are accounted for,
-			// or two, the snap revision is not being modified so
-			// grab whatever is required for the current revision
-			if ts != nil && ts.MaybeEdge(snapstate.LastBeforeLocalModificationsEdge) != nil {
-				// not a simple task snap-switch-channel, so
-				// take the prerequisites needed by the new
-				// revision we're updating to
+
+			continue
+		}
+
+		// the snap is already installed and has its default channel declared in
+		// the model, but the local install may be tracking a different channel
+		changed, err := installedSnapChannelChanged(st, modelSnap.SnapName(), newModelSnapChannel)
+		if err != nil {
+			return nil, err
+		}
+
+		// snap is installed already, so we have 2 possible scenarios:
+		// 1. the snap will be updated (new channel or revision), in which case
+		// we should make sure that the prerequisites of the new revision are
+		// accounted for
+		// 2. the snap channel or revision is not being modified so grab
+		// whatever is required for the current revision
+		if changed {
+			ts, err := remodelVar.UpdateWithDeviceContext(st,
+				snapPathSi, modelSnap.SnapName(),
+				newModelSnapChannel, userID,
+				snapstate.Flags{NoReRefresh: true},
+				deviceCtx, fromChange)
+			if err != nil {
+				return nil, err
+			}
+			tss = append(tss, ts)
+			if ts.MaybeEdge(snapstate.LastBeforeLocalModificationsEdge) != nil {
 				if err := updateNeededSnapsFromTs(ts); err != nil {
 					return nil, err
 				}
-			} else {
-				if currentInfo.Base != "" {
-					neededSnaps[currentInfo.Base] = true
-				}
-				// deal with content providers
-				for defProvider := range snap.NeededDefaultProviders(currentInfo) {
-					neededSnaps[defProvider] = true
-				}
+			}
+		} else {
+			if currentInfo.Base != "" {
+				neededSnaps[currentInfo.Base] = true
+			}
+			// deal with content providers
+			for defProvider := range snap.NeededDefaultProviders(currentInfo) {
+				neededSnaps[defProvider] = true
 			}
 		}
-		snapsAccountedFor[modelSnap.SnapName()] = true
 	}
 	// Now we know what snaps are in the model and whether they have any
 	// dependencies. Verify that the model is self contained, in the sense

--- a/overlord/devicestate/devicestate_remodel_test.go
+++ b/overlord/devicestate/devicestate_remodel_test.go
@@ -3914,7 +3914,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20EssentialNoDownloadSimpleChannelS
 			map[string]interface{}{
 				"name":            "snap-1-base",
 				"id":              snaptest.AssertedSnapID("snap-1-base"),
-				"type":            "app",
+				"type":            "base",
 				"default-channel": "latest/stable",
 			},
 		},
@@ -4002,7 +4002,7 @@ base: snap-1-base
 		TrackingChannel: "latest/stable",
 	})
 
-	// base uses a new default channel
+	// snap-1 uses a new default channel
 	new := s.brands.Model("canonical", "pc-model", map[string]interface{}{
 		"architecture": "amd64",
 		"base":         "core20",

--- a/overlord/devicestate/devicestate_remodel_test.go
+++ b/overlord/devicestate/devicestate_remodel_test.go
@@ -3887,10 +3887,6 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20EssentialNoDownloadSimpleChannelS
 	})
 	defer restore()
 
-	now := time.Now()
-	restore = devicestate.MockTimeNow(func() time.Time { return now })
-	defer restore()
-
 	// set a model assertion
 	s.makeModelAssertionInState(c, "canonical", "pc-model", map[string]interface{}{
 		"architecture": "amd64",

--- a/overlord/devicestate/devicestate_remodel_test.go
+++ b/overlord/devicestate/devicestate_remodel_test.go
@@ -5078,12 +5078,12 @@ plugs:
 			RealName: "foo-missing-deps",
 		})
 		snapstate.Set(s.state, info.InstanceName(), &snapstate.SnapState{
-			SnapType: string(info.Type()),
-			Active:   true,
-			Sequence: []*snap.SideInfo{&info.SideInfo},
-			Current:  info.Revision,
+			SnapType:        string(info.Type()),
+			Active:          true,
+			Sequence:        []*snap.SideInfo{&info.SideInfo},
+			Current:         info.Revision,
+			TrackingChannel: "latest/stable",
 		})
-
 	}
 
 	new := s.brands.Model("canonical", "pc-new-model", map[string]interface{}{
@@ -5273,7 +5273,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelTasksSelfContainedModelMissingDepsOfM
 		c.Check(fromChange, Equals, "99")
 		c.Check(opts.Channel, Equals, "latest/stable")
 
-		return nil, nil
+		return state.NewTaskSet(), nil
 	})
 	defer restore()
 
@@ -5296,10 +5296,11 @@ plugs:
 		RealName: "bar-missing-deps",
 	})
 	snapstate.Set(s.state, info.InstanceName(), &snapstate.SnapState{
-		SnapType: string(info.Type()),
-		Active:   true,
-		Sequence: []*snap.SideInfo{&info.SideInfo},
-		Current:  info.Revision,
+		SnapType:        string(info.Type()),
+		Active:          true,
+		Sequence:        []*snap.SideInfo{&info.SideInfo},
+		Current:         info.Revision,
+		TrackingChannel: "latest/stable",
 	})
 
 	new := s.brands.Model("canonical", "pc-new-model", map[string]interface{}{

--- a/overlord/devicestate/devicestate_remodel_test.go
+++ b/overlord/devicestate/devicestate_remodel_test.go
@@ -3867,7 +3867,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20EssentialNoDownloadSimpleChannelS
 	s.state.Set("seeded", true)
 	s.state.Set("refresh-privacy-key", "some-privacy-key")
 
-	restore := devicestate.MockSnapstateUpdateWithDeviceContext(func(st *state.State, name string, opts *snapstate.RevisionOptions, userID int, flags snapstate.Flags, deviceCtx snapstate.DeviceContext, fromChange string) (*state.TaskSet, error) {
+	restore := devicestate.MockSnapstateUpdateWithDeviceContext(func(st *state.State, name string, opts *snapstate.RevisionOptions, userID int, flags snapstate.Flags, prqt snapstate.PrereqTracker, deviceCtx snapstate.DeviceContext, fromChange string) (*state.TaskSet, error) {
 		// expecting an update call for the base snap
 		c.Assert(name, Equals, "snap-1")
 		c.Check(flags.Required, Equals, false)
@@ -3881,7 +3881,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20EssentialNoDownloadSimpleChannelS
 	})
 	defer restore()
 
-	restore = devicestate.MockSnapstateInstallWithDeviceContext(func(ctx context.Context, st *state.State, name string, opts *snapstate.RevisionOptions, userID int, flags snapstate.Flags, deviceCtx snapstate.DeviceContext, fromChange string) (*state.TaskSet, error) {
+	restore = devicestate.MockSnapstateInstallWithDeviceContext(func(ctx context.Context, st *state.State, name string, opts *snapstate.RevisionOptions, userID int, flags snapstate.Flags, prqt snapstate.PrereqTracker, deviceCtx snapstate.DeviceContext, fromChange string) (*state.TaskSet, error) {
 		// no snaps are getting installed
 		return nil, fmt.Errorf("unexpected install call")
 	})


### PR DESCRIPTION
~~#13230 should be merged first before reviewing this.~~ done!

The loop that is responsible for updating/installing snaps that are in the new model is pretty complicated and difficult to trace through. This PR hopefully simplifies the logic a bit, while maintaining the current functionality.