### PR TITLE
tests: fix prepare-image-reproducible test

### DIFF
--- a/tests/main/prepare-image-reproducible/task.yaml
+++ b/tests/main/prepare-image-reproducible/task.yaml
@@ -8,10 +8,12 @@ backends: [-autopkgtest]
 # ubuntu-14, lack of systemd-run
 # ubuntu-20.04-arm*, because we use pc kernel and gadget.
 # ubuntu-core-*-arm-*, because image generade is not amd64
+# ubuntu-18.04-32, lack of pc-kernel snap for pc-i386
 systems:
 - -ubuntu-14.04-*
 - -ubuntu-20.04-arm-*
 - -ubuntu-core-*-arm-*
+- -ubuntu-18.04-32
 
 environment:
     ROOT: /home/test/tmp/


### PR DESCRIPTION
pc-kernel is not avaiblable for i386 architecture, so the tests needs to be skipped

This is what we get in the debug session for the test in i386

> snap info pc-kernel
error: no snap found for "pc-kernel"
