### PR TITLE
o/snapstate: add explicit snap dependency logic for doUpdates

### DIFF
--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -425,6 +425,9 @@ func (f *fakeStore) lookupRefresh(cand refreshCand) (*snap.Info, error) {
 	// for validation-sets testing
 	case "bgtKhntON3vR7kwEbVPsILm7bUViPDzx":
 		name = "some-other-snap"
+	case "some-base-snap-id":
+		name = "some-base-snap"
+		base = "some-base"
 	case "provenance-snap-id":
 		name = "provenance-snap"
 	default:

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -129,6 +129,7 @@ var (
 	SplitTaskSetByRebootEdges            = splitTaskSetByRebootEdges
 	ArrangeSnapToWaitForBaseIfPresent    = arrangeSnapToWaitForBaseIfPresent
 	ArrangeSnapTaskSetsLinkageAndRestart = arrangeSnapTaskSetsLinkageAndRestart
+	ReRefreshSummary                     = reRefreshSummary
 )
 
 const (

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -120,14 +120,15 @@ var (
 
 	AffectedByRefresh = affectedByRefresh
 
-	GetDirMigrationOpts             = getDirMigrationOpts
-	WriteSeqFile                    = writeSeqFile
-	TriggeredMigration              = triggeredMigration
-	TaskSetsByTypeForEssentialSnaps = taskSetsByTypeForEssentialSnaps
-	SetDefaultRestartBoundaries     = setDefaultRestartBoundaries
-	DeviceModelBootBase             = deviceModelBootBase
-
-	ReRefreshSummary = reRefreshSummary
+	GetDirMigrationOpts                  = getDirMigrationOpts
+	WriteSeqFile                         = writeSeqFile
+	TriggeredMigration                   = triggeredMigration
+	TaskSetsByTypeForEssentialSnaps      = taskSetsByTypeForEssentialSnaps
+	SetDefaultRestartBoundaries          = setDefaultRestartBoundaries
+	DeviceModelBootBase                  = deviceModelBootBase
+	SplitTaskSetByRebootEdges            = splitTaskSetByRebootEdges
+	ArrangeSnapToWaitForBaseIfPresent    = arrangeSnapToWaitForBaseIfPresent
+	ArrangeSnapTaskSetsLinkageAndRestart = arrangeSnapTaskSetsLinkageAndRestart
 )
 
 const (

--- a/overlord/snapstate/reboot.go
+++ b/overlord/snapstate/reboot.go
@@ -299,15 +299,6 @@ func taskSetLanesByRebootEdge(ts *state.TaskSet) ([]int, error) {
 	return linkSnap.Lanes(), nil
 }
 
-func listContains(items []int, item int) bool {
-	for _, i := range items {
-		if i == item {
-			return true
-		}
-	}
-	return false
-}
-
 func mergeTaskSetLanes(lanesByTs map[*state.TaskSet][]int) {
 	var allLanes []int
 	for _, lanes := range lanesByTs {
@@ -320,6 +311,15 @@ func mergeTaskSetLanes(lanesByTs map[*state.TaskSet][]int) {
 			}
 		}
 	}
+}
+
+func listContains(items []int, item int) bool {
+	for _, i := range items {
+		if i == item {
+			return true
+		}
+	}
+	return false
 }
 
 // arrangeSnapTaskSetsLinkageAndRestart arranges the correct link-order between all
@@ -458,7 +458,9 @@ func arrangeSnapTaskSetsLinkageAndRestart(st *state.State, providedDeviceCtx Dev
 		}
 	}
 
-	// Ensure essential snaps that are transactional have their lanes merged
+	// Ensure essential snaps that are transactional have their lanes merged. This will effectively
+	// ensure that essential snaps will be undone together should one of the updates fail. So if we
+	// are updating both gadget and kernel, and kernel fails, the gadget will also be undone.
 	mergeTaskSetLanes(lanesByTsToMerge)
 
 	// For the task-sets that have not been split, they must have boundaries set for

--- a/overlord/snapstate/reboot.go
+++ b/overlord/snapstate/reboot.go
@@ -21,23 +21,45 @@ package snapstate
 
 import (
 	"errors"
+	"fmt"
 
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 )
 
-// Observed link order between essential snaps in doUpdate (snapstate.go)
-// base waits for snapd
-// gadget waits for base/os + snapd
-// kernel waits for base/os + snapd + gadget if present
+// only useful for procuring a buggy behavior in the tests
+var enforcedSingleRebootForGadgetKernelBase = false
+
+func MockEnforceSingleRebootForBaseKernelGadget(val bool) (restore func()) {
+	osutil.MustBeTestBinary("mocking can be done only in tests")
+
+	old := enforcedSingleRebootForGadgetKernelBase
+	enforcedSingleRebootForGadgetKernelBase = val
+	return func() {
+		enforcedSingleRebootForGadgetKernelBase = old
+	}
+}
+
+// essentialSnapsRestartOrder describes the essential snaps that
+// need restart boundaries in order.
+// XXX: Snapd is not a part of this (for now), and snapd can essentially
+// request a reboot when updating managed boot assets (i.e grub.cfg). This
+// needs to be double-checked as right now because if snapd requests a restart
+// this won't happen before the snapd update is complete (and not immediate due
+// to no restart-boundaries set yet).
 var essentialSnapsRestartOrder = []snap.Type{
 	snap.TypeOS,
 	// The base will only require restart if it's the base of the model.
 	snap.TypeBase,
 	snap.TypeGadget,
 	// Kernel must wait for gadget because the gadget may define
-	// new "$kernel:refs".
+	// new "$kernel:refs". Sorting the other way is impossible
+	// because a kernel with new kernel-assets would never refresh
+	// because the matching gadget could never get installed
+	// because the gadget always waits for the kernel and if the
+	// kernel aborts the wait tasks (the gadget) is put on "Hold".
 	snap.TypeKernel,
 }
 
@@ -66,11 +88,32 @@ func taskSetsByTypeForEssentialSnaps(tss []*state.TaskSet, bootBase string) (map
 			if snapsup.SnapName() == bootBase {
 				avail[snapsup.Type] = ts
 			}
-		case snap.TypeOS, snap.TypeGadget, snap.TypeKernel:
+		case snap.TypeSnapd, snap.TypeOS, snap.TypeGadget, snap.TypeKernel:
 			avail[snapsup.Type] = ts
 		}
 	}
 	return avail, nil
+}
+
+func nonEssentialSnapTaskSets(tss []*state.TaskSet, bootBase string) (bases, apps map[string]*state.TaskSet) {
+	bases = make(map[string]*state.TaskSet)
+	apps = make(map[string]*state.TaskSet)
+	for _, ts := range tss {
+		snapsup := maybeTaskSetSnapSetup(ts)
+		if snapsup == nil {
+			continue
+		}
+
+		switch snapsup.Type {
+		case snap.TypeBase:
+			if snapsup.SnapName() != bootBase {
+				bases[snapsup.SnapName()] = ts
+			}
+		case snap.TypeApp:
+			apps[snapsup.SnapName()] = ts
+		}
+	}
+	return bases, apps
 }
 
 func findUnlinkTask(ts *state.TaskSet) *state.Task {
@@ -115,12 +158,312 @@ func deviceModelBootBase(st *state.State, providedDeviceCtx DeviceContext) (stri
 	return bootBase, nil
 }
 
+func tasksBefore(task *state.Task) *state.TaskSet {
+	ts := state.NewTaskSet()
+	for _, t := range task.WaitTasks() {
+		ts.AddTask(t)
+		ts.AddAll(tasksBefore(t))
+	}
+	return ts
+}
+
+func tasksAfter(task *state.Task) *state.TaskSet {
+	ts := state.NewTaskSet()
+	for _, t := range task.HaltTasks() {
+		ts.AddTask(t)
+		ts.AddAll(tasksAfter(t))
+	}
+	return ts
+}
+
+// splitTaskSetByRebootEdges makes use of the following edges on a task-set:
+// - BeginEdge (marks the first task of a task-set)
+// - EndEdge (marks the last task of a task-set)
+// - MaybeRebootEdge (marks the last task that needs to run before the reboot)
+// - MaybeRebootWaitEdge (marks the first task that needs to run after the reboot)
+// and from these edges, constructs two new task-sets, one before reboot, and one
+// after reboot.
+func splitTaskSetByRebootEdges(ts *state.TaskSet) (before, after *state.TaskSet, err error) {
+	// TaskSets must have edges set, so we can detect the first and last tasks
+	// of a task-set.
+	firstTask := ts.MaybeEdge(BeginEdge)
+	lastTask := ts.MaybeEdge(EndEdge)
+	if firstTask == nil || lastTask == nil {
+		return nil, nil, fmt.Errorf("internal error: task-set is missing required edges (%q/%q)", BeginEdge, EndEdge)
+	}
+
+	// TaskSets must also have the reboot edges set.
+	linkSnap := ts.MaybeEdge(MaybeRebootEdge)
+	if linkSnap == nil {
+		return nil, nil, fmt.Errorf("internal error: task-set is missing required edge %q", MaybeRebootEdge)
+	}
+	autoConnect := ts.MaybeEdge(MaybeRebootWaitEdge)
+	if autoConnect == nil {
+		return nil, nil, fmt.Errorf("internal error: task-set is missing required edge %q", MaybeRebootWaitEdge)
+	}
+
+	// Create the before task-set, which is the one before reboot, and
+	// setup new edges for the task-set. In this task-set, we expect
+	// the original start task (i.e prerequisites) to be first, and link-snap
+	// to be the last
+	before = state.NewTaskSet(linkSnap)
+	before.AddAll(tasksBefore(linkSnap))
+	before.MarkEdge(firstTask, BeginEdge)
+	before.MarkEdge(linkSnap, EndEdge)
+
+	// Create the after task-set, which is the post-reboot tasks, and setup
+	// new begin/end edges. In this one, we expect auto-connect to be first, and
+	// whatever was last before, is last again.
+	after = state.NewTaskSet(autoConnect)
+	after.AddAll(tasksAfter(autoConnect))
+	after.MarkEdge(autoConnect, BeginEdge)
+	after.MarkEdge(lastTask, EndEdge)
+	return before, after, nil
+}
+
 func bootBaseSnapType(byTypeTss map[snap.Type]*state.TaskSet) snap.Type {
 	if ts := byTypeTss[snap.TypeBase]; ts != nil {
 		return snap.TypeBase
 	}
 	// On UC16 it's the TypeOS
 	return snap.TypeOS
+}
+
+// arrangeSingleRebootForSplitTaskSets sets up restart boundaries for task-sets that have been
+// split into two. It uses the first part of the task-set (i.e the one containing the reboot edges)
+// to set a restart boundary along the 'Do' path for the last task-set, and one along the 'Undo' path
+// for the first task-set, to introduce only one reboot along each direction.
+func arrangeSingleRebootForSplitTaskSets(beforeTss map[snap.Type]*state.TaskSet) error {
+	// Set reboot boundary along the do path for the last essential
+	for i := len(essentialSnapsRestartOrder) - 1; i >= 0; i-- {
+		o := essentialSnapsRestartOrder[i]
+		if beforeTss[o] == nil {
+			continue
+		}
+
+		linkSnap := beforeTss[o].MaybeEdge(EndEdge)
+		if linkSnap == nil {
+			return fmt.Errorf("internal error: no %q edge set in task-set for %q", EndEdge, o)
+		}
+		restart.MarkTaskAsRestartBoundary(linkSnap, restart.RestartBoundaryDirectionDo)
+		break
+	}
+
+	// Set reboot boundary along the undo path for the first essential
+	for _, o := range essentialSnapsRestartOrder {
+		if beforeTss[o] == nil {
+			continue
+		}
+		if unlinkSnap := findUnlinkTask(beforeTss[o]); unlinkSnap != nil {
+			restart.MarkTaskAsRestartBoundary(unlinkSnap, restart.RestartBoundaryDirectionUndo)
+			break
+		}
+	}
+	return nil
+}
+
+// waitForLastTask makes the first task of 'ts' wait for the last task of the 'dep' task-set.
+func waitForLastTask(ts, dep *state.TaskSet) error {
+	last, err := dep.Edge(EndEdge)
+	if err != nil {
+		return err
+	}
+	first, err := ts.Edge(BeginEdge)
+	if err != nil {
+		return err
+	}
+	first.WaitFor(last)
+	return nil
+}
+
+// arrangeSnapToWaitForBaseIfPresent sets up dependency on the base of a snap, if the base is
+// also being updated. The boot-base is ignored here, as the boot-base is handled separately
+// as a part of the essential snaps.
+func arrangeSnapToWaitForBaseIfPresent(snapTs *state.TaskSet, bases map[string]*state.TaskSet) error {
+	snapsup := maybeTaskSetSnapSetup(snapTs)
+	if snapsup == nil {
+		return fmt.Errorf("internal error: failed to get the SnapSetup instance from snap task-set")
+	}
+
+	if baseTs := bases[snapsup.Base]; baseTs != nil {
+		return waitForLastTask(snapTs, baseTs)
+	}
+	return nil
+}
+
+// arrangeSnapTaskSetsLinkageAndRestart arranges the correct link-order between all
+// the provided snap task-sets, and sets up restart boundaries for essential snaps (base, gadget, kernel).
+// Under normal circumstances link-order that will be configured is:
+// snapd => boot-base (reboot) => gadget (reboot) => kernel (reboot) => bases => apps.
+//
+// However this may be configured into the following if conditions are right for single-reboot
+// snapd => boot-base (up to auto-connect) => kernel (up to auto-connect, then reboot) =>
+// -  boot-base => kernel => bases => apps.
+//
+// XXX: Going forward, gadget will be included in the last example, but this is still TODO.
+func arrangeSnapTaskSetsLinkageAndRestart(st *state.State, providedDeviceCtx DeviceContext, tss []*state.TaskSet) error {
+	bootBase, err := deviceModelBootBase(st, providedDeviceCtx)
+	if err != nil {
+		return err
+	}
+
+	byTypeTss, err := taskSetsByTypeForEssentialSnaps(tss, bootBase)
+	if err != nil {
+		return err
+	}
+
+	// If the boot-base is 'core', then we don't allow splitting the task-sets to set up
+	// for single-reboot, as we don't support this behavior on UC16.
+	isUC16 := bootBase == "core"
+	var lastEssentialTs *state.TaskSet
+	essTransactionLane := st.NewLane()
+	beforeTss := make(map[snap.Type]*state.TaskSet)
+	afterTss := make(map[snap.Type]*state.TaskSet)
+	// chainEssentialTs takes a task-set that needs to be 'chained' unto the previous (unless its the first),
+	// a snap type to specify which type of snap is being chained, and two operational flags.
+	// <transactional>: If set, means that it should be part of the transactional lane. Task-sets marked
+	// transactional, will share an additional lane, and in this case should just one of the updates fail, all
+	// those marked transactional will be rolled back.
+	// <split>: If set, the task-set will be split up into two parts. One pre-reboot part, and one post-reboot part.
+	// All chained task-sets that have <split> set will have their pre-reboot part run before the reboot, and then all
+	// post-reboot parts run after the reboot. They will run in the order they are chained.
+	// ts1-pre-reboot => ts2-pre-reboot => [reboot] => ts1-post-reboot => ts2-post-reboot
+	chainEssentialTs := func(ts *state.TaskSet, snapType snap.Type, transactional, split bool) error {
+		if transactional && !isUC16 {
+			ts.JoinLane(essTransactionLane)
+		}
+
+		nextTs := ts
+		if split && !isUC16 {
+			before, after, err := splitTaskSetByRebootEdges(ts)
+			if err != nil {
+				return err
+			}
+			beforeTss[snapType] = before
+			afterTss[snapType] = after
+			nextTs = before
+		}
+		if lastEssentialTs != nil {
+			if err := waitForLastTask(nextTs, lastEssentialTs); err != nil {
+				return err
+			}
+		}
+		lastEssentialTs = nextTs
+		return nil
+	}
+
+	// Snapd always run first if present.
+	if ts := byTypeTss[snap.TypeSnapd]; ts != nil {
+		// Snapd does not need to be part of the transaction, as
+		// it's not really necessary to undo snapd should base/kernel/gadget
+		// fail.
+		const transactional = false
+		const split = false
+		if err := chainEssentialTs(ts, snap.TypeSnapd, transactional, split); err != nil {
+			return err
+		}
+	}
+
+	// Is gadget present? Then we cannot do single-reboot for now
+	// TODO: enable this
+	gadgetTs := byTypeTss[snap.TypeGadget]
+	bootSnapType := bootBaseSnapType(byTypeTss)
+
+	// Then we link in the boot-base, to run after snapd, it could run in it's
+	// entirety before a reboot, as we expect boot-bases to be 'simple' and not
+	// have any hooks.
+	if ts := byTypeTss[bootSnapType]; ts != nil {
+		const transactional = true
+		// We can only do split on this if there is no gadget.
+		split := (gadgetTs == nil || enforcedSingleRebootForGadgetKernelBase)
+		if err := chainEssentialTs(ts, bootSnapType, transactional, split); err != nil {
+			return err
+		}
+	}
+
+	// Next we link in the gadget, and it needs to be part of the transaction
+	// so it will be undone in the event of failures.
+	if gadgetTs != nil {
+		const transactional = true
+		const split = false
+		if err := chainEssentialTs(gadgetTs, snap.TypeGadget, transactional, split); err != nil {
+			return err
+		}
+	}
+
+	// Then we link in the kernel, it needs to run latest, but before other bases and apps.
+	if ts := byTypeTss[snap.TypeKernel]; ts != nil {
+		const transactional = true
+		// We can only do split on this if there is no gadget.
+		split := (gadgetTs == nil || enforcedSingleRebootForGadgetKernelBase)
+		if err := chainEssentialTs(ts, snap.TypeKernel, transactional, split); err != nil {
+			return err
+		}
+	}
+
+	// Now link in all the after task-sets that have been split, which should run
+	// post-reboot.
+	// XXX: Review and validate that this order is correct once we put in gadget
+	for _, o := range essentialSnapsRestartOrder {
+		if afterTss[o] == nil {
+			continue
+		}
+		const transactional = false
+		const split = false
+		if err := chainEssentialTs(afterTss[o], o, transactional, split); err != nil {
+			return err
+		}
+	}
+
+	// Ensure restart boundaries are set, for the task-sets that have been
+	// split, we ensure that boundaries are set *only* for the last of those, to allow
+	// them all to run before the reboot.
+	if len(beforeTss) > 0 {
+		if err := arrangeSingleRebootForSplitTaskSets(beforeTss); err != nil {
+			return err
+		}
+	}
+
+	// For the task-sets that have not been split, they must have boundaries set for
+	// each of them. Reuse the restart order list here, so we go through the correct
+	// list of snap types that needs restart boundaries set.
+	for _, o := range essentialSnapsRestartOrder {
+		// Make sure that the core snap is actually the boot-base
+		if o == snap.TypeOS && bootBase != "core" {
+			continue
+		}
+		// If the snap type was not split (i.e no task-set in "beforeTss"), and
+		// the snap is actually present in this update, then set default restart
+		// boundaries.
+		if beforeTss[o] == nil && byTypeTss[o] != nil {
+			setDefaultRestartBoundaries(byTypeTss[o])
+		}
+	}
+
+	// Now we ensure that all other non-essential bases depend on the last
+	// essential task-set.
+	bases, apps := nonEssentialSnapTaskSets(tss, bootBase)
+	if lastEssentialTs != nil {
+		for _, ts := range bases {
+			if err := waitForLastTask(ts, lastEssentialTs); err != nil {
+				return err
+			}
+		}
+	}
+
+	// And last, we ensure apps wait for any non-essential base it needs, and the last task-set
+	// of any essential-snap that is also being updated.
+	for _, appTs := range apps {
+		if lastEssentialTs != nil {
+			if err := waitForLastTask(appTs, lastEssentialTs); err != nil {
+				return err
+			}
+		}
+		if err := arrangeSnapToWaitForBaseIfPresent(appTs, bases); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // SetEssentialSnapsRestartBoundaries sets up default restart boundaries for a list of task-sets. If the
@@ -137,16 +480,14 @@ func SetEssentialSnapsRestartBoundaries(st *state.State, providedDeviceCtx Devic
 		return err
 	}
 
-	bootSnapType := bootBaseSnapType(byTypeTss)
-
-	// XXX: Currently we don't need to go through the correct order, but we do it
-	// just in preparation of when single-reboot functionality is added.
+	// We don't actually need to go through the exact order, but
+	// we need to go through this exact list of snap types.
 	for _, o := range essentialSnapsRestartOrder {
 		if byTypeTss[o] == nil {
 			continue
 		}
-		// Make sure that the core snap is actually the boot-base
-		if o == snap.TypeOS && bootSnapType != snap.TypeOS {
+		// Make sure that the core snap is actually the boot-base.
+		if o == snap.TypeOS && bootBase != "core" {
 			continue
 		}
 		setDefaultRestartBoundaries(byTypeTss[o])

--- a/overlord/snapstate/reboot_test.go
+++ b/overlord/snapstate/reboot_test.go
@@ -44,7 +44,34 @@ func (s *rebootSuite) SetUpTest(c *C) {
 	s.state = state.New(nil)
 }
 
-func (s *rebootSuite) taskSetForSnapSetup(snapName string, snapType snap.Type) *state.TaskSet {
+func (s *rebootSuite) taskSetForSnapSetup(snapName, base string, snapType snap.Type) *state.TaskSet {
+	snapsup := &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{
+			RealName: snapName,
+			SnapID:   snapName,
+			Revision: snap.R(1),
+		},
+		Type: snapType,
+		Base: base,
+	}
+	t1 := s.state.NewTask("snap-task", "...")
+	t1.Set("snap-setup", snapsup)
+	t2 := s.state.NewTask("unlink-snap", "...")
+	t2.WaitFor(t1)
+	t3 := s.state.NewTask("link-snap", "...")
+	t3.WaitFor(t2)
+	t4 := s.state.NewTask("auto-connect", "...")
+	t4.WaitFor(t3)
+	ts := state.NewTaskSet(t1, t2, t3, t4)
+	// 4 required edges
+	ts.MarkEdge(t1, snapstate.BeginEdge)
+	ts.MarkEdge(t3, snapstate.MaybeRebootEdge)
+	ts.MarkEdge(t4, snapstate.MaybeRebootWaitEdge)
+	ts.MarkEdge(t4, snapstate.EndEdge)
+	return ts
+}
+
+func (s *rebootSuite) taskSetForSnapSetupButNoTasks(snapName string, snapType snap.Type) *state.TaskSet {
 	snapsup := &snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{
 			RealName: snapName,
@@ -55,10 +82,7 @@ func (s *rebootSuite) taskSetForSnapSetup(snapName string, snapType snap.Type) *
 	}
 	t1 := s.state.NewTask("snap-task", "...")
 	t1.Set("snap-setup", snapsup)
-	t2 := s.state.NewTask("link-snap", "...")
-	t3 := s.state.NewTask("unlink-snap", "...")
-	ts := state.NewTaskSet(t1, t2, t3)
-	ts.MarkEdge(t2, snapstate.MaybeRebootEdge)
+	ts := state.NewTaskSet(t1)
 	return ts
 }
 
@@ -67,11 +91,11 @@ func (s *rebootSuite) TestTaskSetsByTypeForEssentialSnapsNoBootBase(c *C) {
 	defer s.state.Unlock()
 
 	tss := []*state.TaskSet{
-		s.taskSetForSnapSetup("my-base", snap.TypeBase),
-		s.taskSetForSnapSetup("my-gadget", snap.TypeGadget),
-		s.taskSetForSnapSetup("my-kernel", snap.TypeKernel),
-		s.taskSetForSnapSetup("my-os", snap.TypeOS),
-		s.taskSetForSnapSetup("my-app", snap.TypeApp),
+		s.taskSetForSnapSetup("my-base", "", snap.TypeBase),
+		s.taskSetForSnapSetup("my-gadget", "", snap.TypeGadget),
+		s.taskSetForSnapSetup("my-kernel", "", snap.TypeKernel),
+		s.taskSetForSnapSetup("my-os", "", snap.TypeOS),
+		s.taskSetForSnapSetup("my-app", "", snap.TypeApp),
 	}
 
 	mappedTaskSets, err := snapstate.TaskSetsByTypeForEssentialSnaps(tss, "")
@@ -88,11 +112,11 @@ func (s *rebootSuite) TestTaskSetsByTypeForEssentialSnapsBootBase(c *C) {
 	defer s.state.Unlock()
 
 	tss := []*state.TaskSet{
-		s.taskSetForSnapSetup("my-base", snap.TypeBase),
-		s.taskSetForSnapSetup("my-gadget", snap.TypeGadget),
-		s.taskSetForSnapSetup("my-kernel", snap.TypeKernel),
-		s.taskSetForSnapSetup("my-os", snap.TypeOS),
-		s.taskSetForSnapSetup("my-app", snap.TypeApp),
+		s.taskSetForSnapSetup("my-base", "", snap.TypeBase),
+		s.taskSetForSnapSetup("my-gadget", "", snap.TypeGadget),
+		s.taskSetForSnapSetup("my-kernel", "", snap.TypeKernel),
+		s.taskSetForSnapSetup("my-os", "", snap.TypeOS),
+		s.taskSetForSnapSetup("my-app", "", snap.TypeApp),
 	}
 
 	mappedTaskSets, err := snapstate.TaskSetsByTypeForEssentialSnaps(tss, "my-base")
@@ -216,6 +240,28 @@ func (s *rebootSuite) hasRestartBoundaries(c *C, ts *state.TaskSet) bool {
 	return true
 }
 
+func (s *rebootSuite) hasDoRestartBoundaries(c *C, ts *state.TaskSet) bool {
+	t := ts.MaybeEdge(snapstate.MaybeRebootEdge)
+	c.Assert(t, NotNil)
+
+	var boundary restart.RestartBoundaryDirection
+	if err := t.Get("restart-boundary", &boundary); err != nil {
+		return false
+	}
+	return true
+}
+
+func (s *rebootSuite) hasUndoRestartBoundaries(c *C, ts *state.TaskSet) bool {
+	t := s.findUnlinkTask(ts)
+	c.Assert(t, NotNil)
+
+	var boundary restart.RestartBoundaryDirection
+	if err := t.Get("restart-boundary", &boundary); err != nil {
+		return false
+	}
+	return true
+}
+
 func (s *rebootSuite) TestSetEssentialSnapsRestartBoundariesUC16(c *C) {
 	defer snapstatetest.MockDeviceModel(DefaultModel())()
 
@@ -223,11 +269,11 @@ func (s *rebootSuite) TestSetEssentialSnapsRestartBoundariesUC16(c *C) {
 	defer s.state.Unlock()
 
 	tss := []*state.TaskSet{
-		s.taskSetForSnapSetup("core20", snap.TypeBase),
-		s.taskSetForSnapSetup("my-gadget", snap.TypeGadget),
-		s.taskSetForSnapSetup("my-kernel", snap.TypeKernel),
-		s.taskSetForSnapSetup("core", snap.TypeOS),
-		s.taskSetForSnapSetup("my-app", snap.TypeApp),
+		s.taskSetForSnapSetup("core20", "", snap.TypeBase),
+		s.taskSetForSnapSetup("my-gadget", "", snap.TypeGadget),
+		s.taskSetForSnapSetup("my-kernel", "", snap.TypeKernel),
+		s.taskSetForSnapSetup("core", "", snap.TypeOS),
+		s.taskSetForSnapSetup("my-app", "", snap.TypeApp),
 	}
 	err := snapstate.SetEssentialSnapsRestartBoundaries(s.state, nil, tss)
 	c.Assert(err, IsNil)
@@ -245,11 +291,11 @@ func (s *rebootSuite) TestSetEssentialSnapsRestartBoundariesUC20(c *C) {
 	defer s.state.Unlock()
 
 	tss := []*state.TaskSet{
-		s.taskSetForSnapSetup("core20", snap.TypeBase),
-		s.taskSetForSnapSetup("brand-gadget", snap.TypeGadget),
-		s.taskSetForSnapSetup("my-kernel", snap.TypeKernel),
-		s.taskSetForSnapSetup("core", snap.TypeOS),
-		s.taskSetForSnapSetup("my-app", snap.TypeApp),
+		s.taskSetForSnapSetup("core20", "", snap.TypeBase),
+		s.taskSetForSnapSetup("brand-gadget", "", snap.TypeGadget),
+		s.taskSetForSnapSetup("my-kernel", "", snap.TypeKernel),
+		s.taskSetForSnapSetup("core", "", snap.TypeOS),
+		s.taskSetForSnapSetup("my-app", "", snap.TypeApp),
 	}
 	err := snapstate.SetEssentialSnapsRestartBoundaries(s.state, nil, tss)
 	c.Assert(err, IsNil)
@@ -258,4 +304,439 @@ func (s *rebootSuite) TestSetEssentialSnapsRestartBoundariesUC20(c *C) {
 	c.Check(s.hasRestartBoundaries(c, tss[2]), Equals, true)
 	c.Check(s.hasRestartBoundaries(c, tss[3]), Equals, false)
 	c.Check(s.hasRestartBoundaries(c, tss[4]), Equals, false)
+}
+
+func (s *rebootSuite) TestSplitTaskSetByRebootEdgesHappy(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	t1 := s.state.NewTask("first", "...")
+	t2 := s.state.NewTask("second", "...")
+	t2.WaitFor(t1)
+	t3 := s.state.NewTask("third", "...")
+	t3.WaitFor(t2)
+	t4 := s.state.NewTask("fourth", "...")
+	t4.WaitFor(t3)
+	t5 := s.state.NewTask("fifth", "...")
+	t5.WaitFor(t4)
+	ts := state.NewTaskSet(t1, t2, t3, t4, t5)
+
+	// 4 required edges
+	ts.MarkEdge(t1, snapstate.BeginEdge)
+	ts.MarkEdge(t3, snapstate.MaybeRebootEdge)
+	ts.MarkEdge(t4, snapstate.MaybeRebootWaitEdge)
+	ts.MarkEdge(t5, snapstate.EndEdge)
+
+	// Split it into two task-sets with new edges
+	before, after, err := snapstate.SplitTaskSetByRebootEdges(ts)
+	c.Check(err, IsNil)
+	c.Check(before, NotNil)
+	c.Check(after, NotNil)
+
+	// verify the new task-sets have edges set
+	c.Check(before.MaybeEdge(snapstate.BeginEdge), Equals, t1)
+	c.Check(before.MaybeEdge(snapstate.EndEdge), Equals, t3)
+
+	c.Check(after.MaybeEdge(snapstate.BeginEdge), Equals, t4)
+	c.Check(after.MaybeEdge(snapstate.EndEdge), Equals, t5)
+
+	// verify that before and after consists of expected tasks
+	c.Check(before.Tasks(), HasLen, 3)
+	c.Check(after.Tasks(), HasLen, 2)
+}
+
+func (s *rebootSuite) TestSplitTaskSetByRebootEdgesMissingEdges(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	t := s.state.NewTask("first", "...")
+	ts := state.NewTaskSet(t)
+
+	// Test without any edges
+	before, after, err := snapstate.SplitTaskSetByRebootEdges(ts)
+	c.Check(err, ErrorMatches, `internal error: task-set is missing required edges \("begin"/"end"\)`)
+	c.Check(before, IsNil)
+	c.Check(after, IsNil)
+
+	// Set begin, end
+	ts.MarkEdge(t, snapstate.BeginEdge)
+	ts.MarkEdge(t, snapstate.EndEdge)
+
+	before, after, err = snapstate.SplitTaskSetByRebootEdges(ts)
+	c.Check(err, ErrorMatches, `internal error: task-set is missing required edge "maybe-reboot"`)
+	c.Check(before, IsNil)
+	c.Check(after, IsNil)
+
+	// set MaybeRebootEdge
+	ts.MarkEdge(t, snapstate.MaybeRebootEdge)
+
+	before, after, err = snapstate.SplitTaskSetByRebootEdges(ts)
+	c.Check(err, ErrorMatches, `internal error: task-set is missing required edge "maybe-reboot-wait"`)
+	c.Check(before, IsNil)
+	c.Check(after, IsNil)
+}
+
+func (s *rebootSuite) setDependsOn(c *C, ts, dep *state.TaskSet) bool {
+	firstTaskOfTs, err := ts.Edge(snapstate.BeginEdge)
+	c.Assert(err, IsNil)
+	lastTaskOfDep, err := dep.Edge(snapstate.EndEdge)
+	c.Assert(err, IsNil)
+
+	for _, wt := range firstTaskOfTs.WaitTasks() {
+		if wt == lastTaskOfDep {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *rebootSuite) TestArrangeSnapToWaitForBaseIfPresentHappy(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	tss := []*state.TaskSet{
+		s.taskSetForSnapSetup("my-base", "", snap.TypeBase),
+		s.taskSetForSnapSetup("my-app", "my-base", snap.TypeApp),
+	}
+
+	err := snapstate.ArrangeSnapToWaitForBaseIfPresent(tss[1], map[string]*state.TaskSet{
+		"my-base": tss[0],
+	})
+	c.Check(err, IsNil)
+	c.Check(s.setDependsOn(c, tss[1], tss[0]), Equals, true)
+}
+
+func (s *rebootSuite) TestArrangeSnapToWaitForBaseIfPresentNotPresent(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	tss := []*state.TaskSet{
+		s.taskSetForSnapSetup("my-base", "", snap.TypeBase),
+		s.taskSetForSnapSetup("my-app", "my-other-base", snap.TypeApp),
+	}
+
+	err := snapstate.ArrangeSnapToWaitForBaseIfPresent(tss[1], map[string]*state.TaskSet{
+		"my-base": tss[0],
+	})
+	c.Check(err, IsNil)
+	c.Check(s.setDependsOn(c, tss[1], tss[0]), Equals, false)
+}
+
+func (s *rebootSuite) taskSetIsTransactional(ts *state.TaskSet) bool {
+	for _, t := range ts.Tasks() {
+		if t.Lanes()[0] == 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *rebootSuite) TestArrangeSnapTaskSetsLinkageAndRestartUC16NoSplits(c *C) {
+	defer snapstatetest.MockDeviceModel(DefaultModel())()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// Run without gadget, as that will make it also non-split currently
+	tss := []*state.TaskSet{
+		s.taskSetForSnapSetup("core", "", snap.TypeOS),
+		s.taskSetForSnapSetup("my-kernel", "", snap.TypeKernel),
+		s.taskSetForSnapSetup("core20", "", snap.TypeBase),
+		s.taskSetForSnapSetup("my-app", "", snap.TypeApp),
+	}
+	err := snapstate.ArrangeSnapTaskSetsLinkageAndRestart(s.state, nil, tss)
+	c.Assert(err, IsNil)
+
+	// core, kernel should have individual restart boundaries
+	c.Check(s.hasRestartBoundaries(c, tss[0]), Equals, true)
+	c.Check(s.hasRestartBoundaries(c, tss[1]), Equals, true)
+	c.Check(s.hasRestartBoundaries(c, tss[2]), Equals, false)
+	c.Check(s.hasRestartBoundaries(c, tss[3]), Equals, false)
+
+	// core and kernel are not transactional on UC16
+	c.Check(s.taskSetIsTransactional(tss[0]), Equals, false)
+	c.Check(s.taskSetIsTransactional(tss[1]), Equals, false)
+	c.Check(s.taskSetIsTransactional(tss[2]), Equals, false)
+	c.Check(s.taskSetIsTransactional(tss[3]), Equals, false)
+}
+
+func (s *rebootSuite) TestArrangeSnapTaskSetsLinkageAndRestartSnapdAndEssential(c *C) {
+	defer snapstatetest.MockDeviceModel(MakeModel20("brand-gadget", nil))()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	tss := []*state.TaskSet{
+		s.taskSetForSnapSetup("snapd", "", snap.TypeSnapd),
+		s.taskSetForSnapSetup("core20", "", snap.TypeBase),
+		s.taskSetForSnapSetup("brand-gadget", "", snap.TypeGadget),
+		s.taskSetForSnapSetup("my-kernel", "", snap.TypeKernel),
+		s.taskSetForSnapSetup("my-app", "", snap.TypeApp),
+	}
+	err := snapstate.ArrangeSnapTaskSetsLinkageAndRestart(s.state, nil, tss)
+	c.Assert(err, IsNil)
+
+	// Expect restart boundaries on core20, gadget and kernel.
+	c.Check(s.hasRestartBoundaries(c, tss[0]), Equals, false)
+	c.Check(s.hasRestartBoundaries(c, tss[1]), Equals, true)
+	c.Check(s.hasRestartBoundaries(c, tss[2]), Equals, true)
+	c.Check(s.hasRestartBoundaries(c, tss[3]), Equals, true)
+	c.Check(s.hasRestartBoundaries(c, tss[4]), Equals, false)
+
+	// base, gadget and kernel are transactional
+	c.Check(s.taskSetIsTransactional(tss[0]), Equals, false)
+	c.Check(s.taskSetIsTransactional(tss[1]), Equals, true)
+	c.Check(s.taskSetIsTransactional(tss[2]), Equals, true)
+	c.Check(s.taskSetIsTransactional(tss[3]), Equals, true)
+	c.Check(s.taskSetIsTransactional(tss[4]), Equals, false)
+}
+
+func (s *rebootSuite) TestArrangeSnapTaskSetsLinkageAndRestartBaseKernel(c *C) {
+	defer snapstatetest.MockDeviceModel(MakeModel20("brand-gadget", nil))()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	tss := []*state.TaskSet{
+		s.taskSetForSnapSetup("core20", "", snap.TypeBase),
+		s.taskSetForSnapSetup("my-kernel", "", snap.TypeKernel),
+	}
+	err := snapstate.ArrangeSnapTaskSetsLinkageAndRestart(s.state, nil, tss)
+	c.Assert(err, IsNil)
+
+	// Expect restart boundaries on both
+	c.Check(s.hasUndoRestartBoundaries(c, tss[0]), Equals, true)
+	c.Check(s.hasDoRestartBoundaries(c, tss[1]), Equals, true)
+
+	linkSnapBase := tss[0].MaybeEdge(snapstate.MaybeRebootEdge)
+	c.Assert(linkSnapBase, NotNil)
+	linkSnapKernel := tss[1].MaybeEdge(snapstate.MaybeRebootEdge)
+	c.Assert(linkSnapKernel, NotNil)
+
+	// linking between the base and kernel is now expected to be split
+	// expect tasks up to and including 'link-snap' to have no other dependencies
+	// than the previous task.
+	for i, t := range tss[0].Tasks() {
+		if i == 0 {
+			c.Check(t.WaitTasks(), HasLen, 0)
+		} else {
+			c.Check(t.WaitTasks(), HasLen, 1)
+			c.Check(t.WaitTasks()[0].ID(), Equals, tss[0].Tasks()[i-1].ID())
+		}
+		if t == linkSnapBase {
+			break
+		}
+	}
+
+	// Grab the tasks we need to check dependencies between
+	firstTaskOfKernel, err := tss[1].Edge(snapstate.BeginEdge)
+	c.Assert(err, IsNil)
+	linkTaskOfKernel, err := tss[1].Edge(snapstate.MaybeRebootEdge)
+	c.Assert(err, IsNil)
+	acTaskOfKernel, err := tss[1].Edge(snapstate.MaybeRebootWaitEdge)
+	c.Assert(err, IsNil)
+	linkTaskOfBase, err := tss[0].Edge(snapstate.MaybeRebootEdge)
+	c.Assert(err, IsNil)
+	acTaskOfBase, err := tss[0].Edge(snapstate.MaybeRebootWaitEdge)
+	c.Assert(err, IsNil)
+	lastTaskOfBase, err := tss[0].Edge(snapstate.EndEdge)
+	c.Assert(err, IsNil)
+
+	// Things that must be correct:
+	// - "prerequisites" (BeginEdge) of kernel must depend on "link-snap" (MaybeRebootEdge) of base
+	c.Check(firstTaskOfKernel.WaitTasks(), testutil.Contains, linkTaskOfBase)
+	// - "auto-connect" (MaybeRebootWaitEdge) of base must depend on "link-snap" of kernel (MaybeRebootEdge)
+	c.Check(acTaskOfBase.WaitTasks(), testutil.Contains, linkTaskOfKernel)
+	// - "auto-connect" (MaybeRebootWaitEdge) of kernel must depend on the last task of base (EndEdge)
+	c.Check(acTaskOfKernel.WaitTasks(), testutil.Contains, lastTaskOfBase)
+
+	// both should be transactional
+	c.Check(s.taskSetIsTransactional(tss[0]), Equals, true)
+	c.Check(s.taskSetIsTransactional(tss[1]), Equals, true)
+
+	// Since they are set up for single-reboot, the base should have restart
+	// boundaries for the undo path, and kernel should have for do path.
+	c.Check(s.hasUndoRestartBoundaries(c, tss[0]), Equals, true)
+	c.Check(s.hasDoRestartBoundaries(c, tss[0]), Equals, false)
+	c.Check(s.hasUndoRestartBoundaries(c, tss[1]), Equals, false)
+	c.Check(s.hasDoRestartBoundaries(c, tss[1]), Equals, true)
+}
+
+func (s *rebootSuite) TestArrangeSnapTaskSetsLinkageAndRestartSnapd(c *C) {
+	defer snapstatetest.MockDeviceModel(MakeModel20("brand-gadget", nil))()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	tss := []*state.TaskSet{
+		s.taskSetForSnapSetup("snapd", "", snap.TypeSnapd),
+	}
+	err := snapstate.ArrangeSnapTaskSetsLinkageAndRestart(s.state, nil, tss)
+	c.Assert(err, IsNil)
+
+	// Do not expect any restart boundaries to be set
+	c.Check(s.hasRestartBoundaries(c, tss[0]), Equals, false)
+
+	// Snapd should never be a part of the single-reboot transaction, we don't
+	// need snapd to rollback if an issue should arise in any of the other essential snaps.
+	c.Check(s.taskSetIsTransactional(tss[0]), Equals, false)
+}
+
+func (s *rebootSuite) TestArrangeSnapTaskSetsLinkageAndRestartBaseGadgetKernel(c *C) {
+	defer snapstatetest.MockDeviceModel(MakeModel20("brand-gadget", nil))()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	tss := []*state.TaskSet{
+		s.taskSetForSnapSetup("core20", "", snap.TypeBase),
+		s.taskSetForSnapSetup("brand-gadget", "", snap.TypeGadget),
+		s.taskSetForSnapSetup("my-kernel", "", snap.TypeKernel),
+	}
+	err := snapstate.ArrangeSnapTaskSetsLinkageAndRestart(s.state, nil, tss)
+	c.Assert(err, IsNil)
+
+	// Expect restart boundaries on all essential snaps here
+	c.Check(s.hasRestartBoundaries(c, tss[0]), Equals, true)
+	c.Check(s.hasRestartBoundaries(c, tss[1]), Equals, true)
+	c.Check(s.hasRestartBoundaries(c, tss[2]), Equals, true)
+
+	// base, gadget and kernel are transactional
+	c.Check(s.taskSetIsTransactional(tss[0]), Equals, true)
+	c.Check(s.taskSetIsTransactional(tss[1]), Equals, true)
+	c.Check(s.taskSetIsTransactional(tss[2]), Equals, true)
+}
+
+func (s *rebootSuite) TestArrangeSnapTaskSetsLinkageAndRestartBootBaseAndOtherBases(c *C) {
+	defer snapstatetest.MockDeviceModel(MakeModel20("brand-gadget", nil))()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	tss := []*state.TaskSet{
+		s.taskSetForSnapSetup("core20", "", snap.TypeBase),
+		s.taskSetForSnapSetup("core18", "", snap.TypeBase),
+		s.taskSetForSnapSetup("my-app", "", snap.TypeApp),
+	}
+	err := snapstate.ArrangeSnapTaskSetsLinkageAndRestart(s.state, nil, tss)
+	c.Assert(err, IsNil)
+
+	// Only the boot-base should have restart boundary.
+	c.Check(s.hasRestartBoundaries(c, tss[0]), Equals, true)
+	c.Check(s.hasRestartBoundaries(c, tss[1]), Equals, false)
+	c.Check(s.hasRestartBoundaries(c, tss[2]), Equals, false)
+
+	// boot-base is transactional
+	c.Check(s.taskSetIsTransactional(tss[0]), Equals, true)
+	c.Check(s.taskSetIsTransactional(tss[1]), Equals, false)
+	c.Check(s.taskSetIsTransactional(tss[2]), Equals, false)
+}
+
+func (s *rebootSuite) TestArrangeSnapTaskSetsLinkageForSnapWithBaseAndWithout(c *C) {
+	defer snapstatetest.MockDeviceModel(MakeModel20("brand-gadget", nil))()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	tss := []*state.TaskSet{
+		s.taskSetForSnapSetup("snap-base", "", snap.TypeBase),
+		s.taskSetForSnapSetup("snap-base-app", "snap-base", snap.TypeApp),
+		s.taskSetForSnapSetup("snap-other-app", "other-base", snap.TypeApp),
+	}
+	err := snapstate.ArrangeSnapTaskSetsLinkageAndRestart(s.state, nil, tss)
+	c.Assert(err, IsNil)
+
+	// No restart boundaries
+	c.Check(s.hasRestartBoundaries(c, tss[0]), Equals, false)
+	c.Check(s.hasRestartBoundaries(c, tss[1]), Equals, false)
+	c.Check(s.hasRestartBoundaries(c, tss[2]), Equals, false)
+
+	// no transactional lane set
+	c.Check(s.taskSetIsTransactional(tss[0]), Equals, false)
+	c.Check(s.taskSetIsTransactional(tss[1]), Equals, false)
+	c.Check(s.taskSetIsTransactional(tss[2]), Equals, false)
+
+	// snap-base-app depends on snap-base, but snap-other-app's base
+	// is not updated
+	c.Check(s.setDependsOn(c, tss[1], tss[0]), Equals, true)
+	c.Check(s.setDependsOn(c, tss[2], tss[0]), Equals, false)
+	c.Check(s.setDependsOn(c, tss[2], tss[1]), Equals, false)
+}
+
+func (s *rebootSuite) TestArrangeSnapTaskSetsLinkageForSnapWithBootBaseAndWithout(c *C) {
+	defer snapstatetest.MockDeviceModel(MakeModel20("brand-gadget", nil))()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	tss := []*state.TaskSet{
+		s.taskSetForSnapSetup("core20", "", snap.TypeBase),
+		s.taskSetForSnapSetup("snap-core20-app", "snap-core20", snap.TypeApp),
+		s.taskSetForSnapSetup("snap-other-app", "other-base", snap.TypeApp),
+	}
+	err := snapstate.ArrangeSnapTaskSetsLinkageAndRestart(s.state, nil, tss)
+	c.Assert(err, IsNil)
+
+	// Restart boundaries is set for core20 as the boot-base
+	c.Check(s.hasRestartBoundaries(c, tss[0]), Equals, true)
+	c.Check(s.hasRestartBoundaries(c, tss[1]), Equals, false)
+	c.Check(s.hasRestartBoundaries(c, tss[2]), Equals, false)
+
+	// Transactional lane set for core20
+	c.Check(s.taskSetIsTransactional(tss[0]), Equals, true)
+	c.Check(s.taskSetIsTransactional(tss[1]), Equals, false)
+	c.Check(s.taskSetIsTransactional(tss[2]), Equals, false)
+
+	// snap-core20-app depends on core20, but snap-other-app' base is
+	// not updated. Yet snap-other-base still depends on core20. But there
+	// is no dependency between snap-core20-app and snap-other-app
+	c.Check(s.setDependsOn(c, tss[1], tss[0]), Equals, true)
+	c.Check(s.setDependsOn(c, tss[2], tss[0]), Equals, true)
+	c.Check(s.setDependsOn(c, tss[2], tss[1]), Equals, false)
+}
+
+func (s *rebootSuite) TestArrangeSnapTaskSetsLinkageAndRestartAll(c *C) {
+	defer snapstatetest.MockDeviceModel(MakeModel20("brand-gadget", nil))()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	tss := []*state.TaskSet{
+		s.taskSetForSnapSetup("snapd", "", snap.TypeSnapd),
+		s.taskSetForSnapSetup("core20", "", snap.TypeBase),
+		s.taskSetForSnapSetup("brand-gadget", "", snap.TypeGadget),
+		s.taskSetForSnapSetup("my-kernel", "", snap.TypeKernel),
+		s.taskSetForSnapSetup("core", "", snap.TypeOS),
+		s.taskSetForSnapSetup("my-app", "", snap.TypeApp),
+	}
+	err := snapstate.ArrangeSnapTaskSetsLinkageAndRestart(s.state, nil, tss)
+	c.Assert(err, IsNil)
+
+	c.Check(s.hasRestartBoundaries(c, tss[0]), Equals, false)
+	c.Check(s.hasRestartBoundaries(c, tss[1]), Equals, true)
+	c.Check(s.hasRestartBoundaries(c, tss[2]), Equals, true)
+	c.Check(s.hasRestartBoundaries(c, tss[3]), Equals, true)
+	c.Check(s.hasRestartBoundaries(c, tss[4]), Equals, false)
+	c.Check(s.hasRestartBoundaries(c, tss[5]), Equals, false)
+
+	// boot-base, gadget and kernel are transactional
+	c.Check(s.taskSetIsTransactional(tss[0]), Equals, false)
+	c.Check(s.taskSetIsTransactional(tss[1]), Equals, true)
+	c.Check(s.taskSetIsTransactional(tss[2]), Equals, true)
+	c.Check(s.taskSetIsTransactional(tss[3]), Equals, true)
+	c.Check(s.taskSetIsTransactional(tss[4]), Equals, false)
+	c.Check(s.taskSetIsTransactional(tss[5]), Equals, false)
+}
+
+func (s *rebootSuite) TestArrangeSnapTaskSetsLinkageAndRestartFailsSplit(c *C) {
+	defer snapstatetest.MockDeviceModel(MakeModel20("brand-gadget", nil))()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	tss := []*state.TaskSet{
+		s.taskSetForSnapSetupButNoTasks("my-kernel", snap.TypeKernel),
+	}
+	err := snapstate.ArrangeSnapTaskSetsLinkageAndRestart(s.state, nil, tss)
+	c.Assert(err, ErrorMatches, `internal error: task-set is missing required edges \("begin\"/"end"\)`)
 }

--- a/overlord/snapstate/reboot_test.go
+++ b/overlord/snapstate/reboot_test.go
@@ -560,8 +560,11 @@ func (s *rebootSuite) TestArrangeSnapTaskSetsLinkageAndRestartSnapd(c *C) {
 	err := snapstate.ArrangeSnapTaskSetsLinkageAndRestart(s.state, nil, tss)
 	c.Assert(err, IsNil)
 
-	// Do not expect any restart boundaries to be set
+	// Do not expect any restart boundaries to be set on snapd
 	c.Check(s.hasRestartBoundaries(c, tss[0]), Equals, false)
+
+	// Expect them to be set on core20 as it's the boot-base
+	c.Check(s.hasRestartBoundaries(c, tss[1]), Equals, true)
 
 	// Snapd should never be a part of the single-reboot transaction, we don't
 	// need snapd to rollback if an issue should arise in any of the other essential snaps.
@@ -671,9 +674,9 @@ func (s *rebootSuite) TestArrangeSnapTaskSetsLinkageForSnapWithBootBaseAndWithou
 	// snap-core20-app depends on core20, but snap-other-app' base is
 	// not updated. Yet snap-other-base still depends on core20. But there
 	// is no dependency between snap-core20-app and snap-other-app
-	c.Check(s.setDependsOn(c, tss[1], tss[0]), Equals, true)
-	c.Check(s.setDependsOn(c, tss[2], tss[0]), Equals, true)
-	c.Check(s.setDependsOn(c, tss[2], tss[1]), Equals, false)
+	c.Check(s.setDependsOn(c, tss[1], tss[0]), Equals, true)  // snap-core20-app depend on core20
+	c.Check(s.setDependsOn(c, tss[2], tss[0]), Equals, true)  // snap-other-app depend on core20
+	c.Check(s.setDependsOn(c, tss[2], tss[1]), Equals, false) // snap-other-app does not depend on snap-core20-app
 }
 
 func (s *rebootSuite) TestArrangeSnapTaskSetsLinkageAndRestartAll(c *C) {

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -268,6 +268,14 @@ version: 1.0
 		c.Assert(te.Get("hook-setup", &hsup), IsNil)
 		c.Check(hsup.Hook, Equals, "install")
 		c.Check(hsup.Snap, Equals, "some-snap")
+
+		te, err = ts.Edge(snapstate.EndEdge)
+		c.Assert(err, IsNil)
+		if skipConfig {
+			c.Check(te.Kind(), Equals, "start-snap-services")
+		} else {
+			c.Check(te.Kind(), Equals, "run-hook")
+		}
 	}
 }
 

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -9065,4 +9066,97 @@ func (s *snapmgrTestSuite) TestReRefreshSummary(c *C) {
 		cmt := Commentf("unexpected re-refresh summary for %d snaps (auto-refresh: %t)", len(tc.snaps), tc.isAutoRefresh)
 		c.Check(summary, Equals, tc.summary, cmt)
 	}
+}
+
+func (s *snapmgrTestSuite) TestEndEdgeSetCorrectlyHealthCheck(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// Under normal circumstances the end-edge is set on the run-hook task
+	opts := &snapstate.RevisionOptions{Channel: "some-channel"}
+	ts, err := snapstate.Install(context.Background(), s.state, "some-snap", opts, s.user.ID, snapstate.Flags{})
+	c.Assert(err, IsNil)
+
+	// find the correct task, and ensure it has the correct edge set
+	var t *state.Task
+	for _, task := range ts.Tasks() {
+		if task.Kind() == "run-hook" {
+			var hooksup hookstate.HookSetup
+			if err := task.Get("hook-setup", &hooksup); err != nil {
+				panic(err)
+			}
+			if hooksup.Hook == "check-health" {
+				t = task
+				break
+			}
+		}
+	}
+	c.Assert(t, NotNil)
+	c.Check(ts.MaybeEdge(snapstate.EndEdge).ID(), Equals, t.ID())
+}
+
+func (s *snapmgrTestSuite) TestEndEdgeSetCorrectlyNoConfigure(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	mockSnap := makeTestSnap(c, `name: some-snap
+version: 1.0
+`)
+
+	// For snaps that skip configure, we expect the end-edge to be set to either of
+	// cleanup task, or start snap services
+	ts, _, err := snapstate.InstallPath(s.state, &snap.SideInfo{
+		RealName: "some-snap",
+		SnapID:   "some-snap-id",
+		Revision: snap.R(8),
+	}, mockSnap, "", "", snapstate.Flags{SkipConfigure: true}, nil)
+	c.Assert(err, IsNil)
+
+	var t *state.Task
+	for _, task := range ts.Tasks() {
+		if task.Kind() == "start-snap-services" {
+			t = task
+			break
+		}
+	}
+	log.Printf("%s", ts.MaybeEdge(snapstate.EndEdge).Kind())
+	c.Assert(t, NotNil)
+	c.Check(ts.MaybeEdge(snapstate.EndEdge).ID(), Equals, t.ID())
+}
+
+func (s *snapmgrTestSuite) TestEndEdgeSetCorrectlyNoConfigureRefresh(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active: true,
+		Flags:  snapstate.Flags{DevMode: true},
+		Sequence: []*snap.SideInfo{
+			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
+		},
+		Current:         snap.R(1),
+		SnapType:        "app",
+		TrackingChannel: "wibbly/stable",
+	})
+
+	mockSnap := makeTestSnap(c, `name: some-snap
+version: 1.0
+epoch: 1
+`)
+
+	// For snaps that skip configure, we expect the end-edge to be set to either of
+	// cleanup task, or start snap services
+	ts, _, err := snapstate.InstallPath(s.state, &snap.SideInfo{RealName: "some-snap"}, mockSnap, "", "edge", snapstate.Flags{SkipConfigure: true}, nil)
+	c.Assert(err, IsNil)
+
+	var t *state.Task
+	for _, task := range ts.Tasks() {
+		if task.Kind() == "cleanup" {
+			t = task
+			break
+		}
+	}
+	log.Printf("%s", ts.MaybeEdge(snapstate.EndEdge).Kind())
+	c.Assert(t, NotNil)
+	c.Check(ts.MaybeEdge(snapstate.EndEdge).ID(), Equals, t.ID())
 }

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -5144,6 +5144,32 @@ func (s *snapmgrTestSuite) TestUpdateAllDevMode(c *C) {
 	c.Check(updates, HasLen, 0)
 }
 
+func taskSetsShareLane(tss ...*state.TaskSet) bool {
+	lanes := make(map[int]int)
+	for _, ts := range tss {
+		// use a known task to read the lanes from, where expect
+		// the task to be in a shared task-lane across the provided
+		// task-sets
+		for _, t := range ts.Tasks() {
+			if t.Kind() == "link-snap" {
+				for _, l := range t.Lanes() {
+					lanes[l]++
+				}
+				break
+			}
+		}
+	}
+	// Now one of the lanes in the map should have the
+	// value of the len(tss), as that would indicate that
+	// link-snap tasks of each task-set have increased that lane.
+	for _, c := range lanes {
+		if c == len(tss) {
+			return true
+		}
+	}
+	return false
+}
+
 func (s *snapmgrTestSuite) TestUpdateManyWaitForBasesUC16(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -5188,28 +5214,28 @@ func (s *snapmgrTestSuite) TestUpdateManyWaitForBasesUC16(c *C) {
 		chg.AddAll(ts)
 	}
 
-	prereqTotal := len(tts[0].Tasks()) + len(tts[1].Tasks())
-	prereqs := map[string]bool{}
-	for i, task := range tts[2].Tasks() {
-		waitTasks := task.WaitTasks()
-		if i == 0 {
-			c.Check(len(waitTasks), Equals, prereqTotal)
-		} else if task.Kind() == "link-snap" {
-			c.Check(len(waitTasks), Equals, prereqTotal+1)
-			for _, pre := range waitTasks {
-				if pre.Kind() == "link-snap" {
-					snapsup, err := snapstate.TaskSnapSetup(pre)
-					c.Assert(err, IsNil)
-					prereqs[snapsup.InstanceName()] = true
-				}
-			}
-		}
-	}
+	// Some-snap is expected to wait for both the essential snap, but
+	// also the base of some-snap. These dependencies are set up between
+	// last tasks of core/some-base, on preprequisites
+	lastTaskOfCore, err := tts[0].Edge(snapstate.EndEdge)
+	c.Assert(err, IsNil)
+	lastTaskOfBase, err := tts[1].Edge(snapstate.EndEdge)
+	c.Assert(err, IsNil)
+	firstTaskOfSnap, err := tts[2].Edge(snapstate.BeginEdge)
+	c.Assert(err, IsNil)
+	c.Check(firstTaskOfSnap.WaitTasks(), HasLen, 2)
+	c.Check(firstTaskOfSnap.WaitTasks(), testutil.Contains, lastTaskOfCore)
+	c.Check(firstTaskOfSnap.WaitTasks(), testutil.Contains, lastTaskOfBase)
 
-	c.Check(prereqs, DeepEquals, map[string]bool{
-		"core":      true,
-		"some-base": true,
-	})
+	// core and the other snaps are not expected to share the same lane
+	c.Check(taskSetsShareLane(tts[0], tts[1]), Equals, false)
+	c.Check(taskSetsShareLane(tts[0], tts[2]), Equals, false)
+	c.Check(taskSetsShareLane(tts[1], tts[2]), Equals, false)
+
+	// Manually verify their lanes
+	c.Check(tts[0].Tasks()[0].Lanes(), DeepEquals, []int{1})
+	c.Check(tts[1].Tasks()[0].Lanes(), DeepEquals, []int{2})
+	c.Check(tts[2].Tasks()[0].Lanes(), DeepEquals, []int{3})
 }
 
 func (s *snapmgrTestSuite) TestUpdateManyWaitForBasesUC18(c *C) {
@@ -5268,32 +5294,29 @@ func (s *snapmgrTestSuite) TestUpdateManyWaitForBasesUC18(c *C) {
 		chg.AddAll(ts)
 	}
 
-	// Note that some-app only waits for snapd+some-base. The core18
-	// base is not special to this snap and not waited for
-	prereqTotal := len(tts[0].Tasks()) + len(tts[1].Tasks())
-	prereqs := map[string]bool{}
-	for i, task := range tts[3].Tasks() {
-		waitTasks := task.WaitTasks()
-		if i == 0 {
-			c.Check(len(waitTasks), Equals, prereqTotal)
-		} else if task.Kind() == "link-snap" {
-			c.Check(len(waitTasks), Equals, prereqTotal+1)
-			for _, pre := range waitTasks {
-				if pre.Kind() == "link-snap" {
-					snapsup, err := snapstate.TaskSnapSetup(pre)
-					c.Assert(err, IsNil)
-					prereqs[snapsup.InstanceName()] = true
-				}
-			}
-		}
-	}
+	// Some-app will be waiting for the bases, which includes both some-base and
+	// core18. The first task of some-snap will be waiting for the last tasks of
+	// those two dependencies.
+	lastTaskOfCore, err := tts[1].Edge(snapstate.EndEdge)
+	c.Assert(err, IsNil)
+	lastTaskOfBase, err := tts[2].Edge(snapstate.EndEdge)
+	c.Assert(err, IsNil)
+	firstTaskOfSnap, err := tts[3].Edge(snapstate.BeginEdge)
+	c.Assert(err, IsNil)
+	c.Check(firstTaskOfSnap.WaitTasks(), HasLen, 2)
+	c.Check(firstTaskOfSnap.WaitTasks(), testutil.Contains, lastTaskOfCore)
+	c.Check(firstTaskOfSnap.WaitTasks(), testutil.Contains, lastTaskOfBase)
 
-	// Note that "core18" is not part of the prereqs for some-app
-	// as it does not use this base.
-	c.Check(prereqs, DeepEquals, map[string]bool{
-		"some-base": true,
-		"snapd":     true,
-	})
+	// Core18 and snapd are not expected to share the same lane, we only
+	// check essential snaps as those are the ones that can end up in same lane.
+	// Although snapd should never be a part of the transactional lane.
+	c.Check(taskSetsShareLane(tts[0], tts[1]), Equals, false)
+
+	// Manually verify the lanes of the initial task for the 4 task-sets
+	c.Check(tts[0].Tasks()[0].Lanes(), DeepEquals, []int{1})    // snapd
+	c.Check(tts[1].Tasks()[0].Lanes(), DeepEquals, []int{2, 5}) // core18
+	c.Check(tts[2].Tasks()[0].Lanes(), DeepEquals, []int{3})    // base
+	c.Check(tts[3].Tasks()[0].Lanes(), DeepEquals, []int{4})    // snap
 }
 
 func (s *validationSetsSuite) TestUpdateManyWithRevisionOpts(c *C) {
@@ -8252,75 +8275,60 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootHappy(c *C) {
 		[]string{"kernel", "core18"}, nil, s.user.ID, &snapstate.Flags{})
 	c.Assert(err, IsNil)
 	c.Assert(affected, DeepEquals, []string{"core18", "kernel"})
-	snapTasks := make(map[string]*state.Task)
-	var kernelTs, baseTs *state.TaskSet
+
+	// Verify that correct dependencies have been set-up for single-reboot
+	// which is a bit more tricky, as task-sets have been split up into pre-boot
+	// things, and post-boot things.
+
+	// Grab the correct task-sets
+	var baseTs, kernelTs *state.TaskSet
 	for _, ts := range tss {
-		chg.AddAll(ts)
-		for _, tsk := range ts.Tasks() {
-			switch tsk.Kind() {
-			// setup-profiles should appear right before link-snap,
-			// while set-auto-aliase appears right after
-			// auto-connect
-			case "link-snap", "auto-connect", "setup-profiles", "set-auto-aliases":
-				snapsup, err := snapstate.TaskSnapSetup(tsk)
-				c.Assert(err, IsNil)
-				snapTasks[fmt.Sprintf("%s@%s", tsk.Kind(), snapsup.Type)] = tsk
-				if tsk.Kind() == "link-snap" {
-					opts := 0
-					if snapsup.Type == snap.TypeBase {
-						opts |= noConfigure
-						baseTs = ts
-					} else if snapsup.Type == snap.TypeKernel {
-						kernelTs = ts
-					}
-					verifyUpdateTasks(c, snapsup.Type, opts, 0, ts)
-				}
+		for _, t := range ts.Tasks() {
+			snapsup, err := snapstate.TaskSnapSetup(t)
+			if err != nil {
+				continue
+			}
+			if snapsup.Type == snap.TypeKernel {
+				kernelTs = ts
+				break
+			} else if snapsup.Type == snap.TypeBase {
+				baseTs = ts
+				break
 			}
 		}
+		chg.AddAll(ts)
 	}
-
-	c.Assert(snapTasks, HasLen, 8)
-	linkSnapKernel := snapTasks["link-snap@kernel"]
-	autoConnectKernel := snapTasks["auto-connect@kernel"]
-	linkSnapBase := snapTasks["link-snap@base"]
-	autoConnectBase := snapTasks["auto-connect@base"]
-	c.Assert(kernelTs, NotNil)
 	c.Assert(baseTs, NotNil)
-	c.Assert(kernelTs.MaybeEdge(snapstate.BeforeMaybeRebootEdge), Equals, snapTasks["setup-profiles@kernel"])
-	c.Assert(kernelTs.MaybeEdge(snapstate.MaybeRebootEdge), Equals, linkSnapKernel)
-	c.Assert(kernelTs.MaybeEdge(snapstate.MaybeRebootWaitEdge), Equals, autoConnectKernel)
-	c.Assert(kernelTs.MaybeEdge(snapstate.AfterMaybeRebootWaitEdge), Equals, snapTasks["set-auto-aliases@kernel"])
+	c.Assert(kernelTs, NotNil)
 
-	c.Assert(baseTs.MaybeEdge(snapstate.BeforeMaybeRebootEdge), Equals, snapTasks["setup-profiles@base"])
-	c.Assert(baseTs.MaybeEdge(snapstate.MaybeRebootEdge), Equals, linkSnapBase)
-	c.Assert(baseTs.MaybeEdge(snapstate.MaybeRebootWaitEdge), Equals, autoConnectBase)
-	c.Assert(baseTs.MaybeEdge(snapstate.AfterMaybeRebootWaitEdge), Equals, snapTasks["set-auto-aliases@base"])
+	// Grab the tasks we need to check dependencies between
+	firstTaskOfKernel, err := kernelTs.Edge(snapstate.BeginEdge)
+	c.Assert(err, IsNil)
+	linkTaskOfKernel, err := kernelTs.Edge(snapstate.MaybeRebootEdge)
+	c.Assert(err, IsNil)
+	acTaskOfKernel, err := kernelTs.Edge(snapstate.MaybeRebootWaitEdge)
+	c.Assert(err, IsNil)
+	linkTaskOfBase, err := baseTs.Edge(snapstate.MaybeRebootEdge)
+	c.Assert(err, IsNil)
+	acTaskOfBase, err := baseTs.Edge(snapstate.MaybeRebootWaitEdge)
+	c.Assert(err, IsNil)
+	lastTaskOfBase, err := baseTs.Edge(snapstate.EndEdge)
+	c.Assert(err, IsNil)
 
-	c.Assert(linkSnapBase.WaitTasks(), DeepEquals, []*state.Task{
-		snapTasks["setup-profiles@base"], snapTasks["setup-profiles@kernel"],
-	})
-	c.Assert(linkSnapKernel.WaitTasks(), DeepEquals, []*state.Task{
-		snapTasks["setup-profiles@kernel"], linkSnapBase,
-	})
-	c.Assert(autoConnectKernel.WaitTasks(), DeepEquals, []*state.Task{
-		snapTasks["link-snap@kernel"], autoConnectBase,
-	})
-	c.Assert(autoConnectBase.WaitTasks(), DeepEquals, []*state.Task{
-		snapTasks["link-snap@base"], snapTasks["link-snap@kernel"],
-	})
-	c.Assert(snapTasks["set-auto-aliases@kernel"].WaitTasks(), DeepEquals, []*state.Task{
-		autoConnectKernel,
-	})
-	c.Assert(snapTasks["set-auto-aliases@base"].WaitTasks(), DeepEquals, []*state.Task{
-		autoConnectBase, autoConnectKernel,
-	})
+	// Things that must be correct:
+	// - "prerequisites" (BeginEdge) of kernel must depend on "link-snap" (MaybeRebootEdge) of base
+	c.Check(firstTaskOfKernel.WaitTasks(), testutil.Contains, linkTaskOfBase)
+	// - "auto-connect" (MaybeRebootWaitEdge) of base must depend on "link-snap" of kernel (MaybeRebootEdge)
+	c.Check(acTaskOfBase.WaitTasks(), testutil.Contains, linkTaskOfKernel)
+	// - "auto-connect" (MaybeRebootWaitEdge) of kernel must depend on the last task of base (EndEdge)
+	c.Check(acTaskOfKernel.WaitTasks(), testutil.Contains, lastTaskOfBase)
 
-	var cannotReboot bool
-	// link-snap of base cannot issue a reboot
-	c.Assert(linkSnapBase.Get("cannot-reboot", &cannotReboot), IsNil)
-	c.Assert(cannotReboot, Equals, true)
-	// but the link-snap of the kernel can issue a reboot
-	c.Assert(linkSnapKernel.Get("cannot-reboot", &cannotReboot), testutil.ErrorIs, state.ErrNoState)
+	// Core18 and kernel should be in the same transactional lane
+	c.Check(taskSetsShareLane(baseTs, kernelTs), Equals, true)
+
+	// Manually verify the lanes of the initial task for the 4 task-sets
+	c.Check(kernelTs.Tasks()[0].Lanes(), DeepEquals, []int{1, 3})
+	c.Check(baseTs.Tasks()[0].Lanes(), DeepEquals, []int{2, 3})
 
 	// have fake backend indicate a need to reboot for both snaps
 	s.fakeBackend.linkSnapMaybeReboot = true
@@ -8382,16 +8390,119 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootHappy(c *C) {
 		}
 	}
 	c.Assert(ops, HasLen, 8)
-	c.Assert(ops[0:2], testutil.DeepUnsortedMatches, []string{
-		"setup-profiles:Doing-kernel/11", "setup-profiles:Doing-core18/11",
+	c.Check(ops[0:4], testutil.DeepUnsortedMatches, []string{
+		"setup-profiles:Doing-kernel/11", "kernel/11",
+		"setup-profiles:Doing-core18/11", "core18/11",
 	})
-	c.Assert(ops[2:6], DeepEquals, []string{
-		"core18/11", "kernel/11",
+	c.Check(ops[4:6], DeepEquals, []string{
 		"auto-connect:Doing-core18/11", "auto-connect:Doing-kernel/11",
 	})
-	c.Assert(ops[6:], testutil.DeepUnsortedMatches, []string{
+	c.Check(ops[6:], testutil.DeepUnsortedMatches, []string{
 		"cleanup-trash-core18", "cleanup-trash-kernel",
 	})
+}
+
+func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootWithCannotRebootSetHappy(c *C) {
+	// Verify the single-reboot still works when using "cannot-reboot" variable, to maintain
+	// backwards compatibility with the previous logic.
+	restore := release.MockOnClassic(false)
+	defer restore()
+	restore = snapstate.MockRevisionDate(nil)
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	var restartRequested []restart.RestartType
+	_, err := restart.Manager(s.state, "boot-id-0", snapstatetest.MockRestartHandler(func(t restart.RestartType) {
+		restartRequested = append(restartRequested, t)
+	}))
+	c.Assert(err, IsNil)
+
+	restore = snapstatetest.MockDeviceModel(MakeModel(map[string]interface{}{
+		"kernel": "kernel",
+		"base":   "core18",
+	}))
+	defer restore()
+
+	siKernel := snap.SideInfo{
+		RealName: "kernel",
+		Revision: snap.R(7),
+		SnapID:   "kernel-id",
+	}
+	siBase := snap.SideInfo{
+		RealName: "core18",
+		Revision: snap.R(7),
+		SnapID:   "core18-snap-id",
+	}
+	for _, si := range []*snap.SideInfo{&siKernel, &siBase} {
+		snaptest.MockSnap(c, fmt.Sprintf(`name: %s`, si.RealName), si)
+		typ := "kernel"
+		if si.RealName == "core18" {
+			typ = "base"
+		}
+		snapstate.Set(s.state, si.RealName, &snapstate.SnapState{
+			Active:          true,
+			Sequence:        []*snap.SideInfo{si},
+			Current:         si.Revision,
+			TrackingChannel: "latest/stable",
+			SnapType:        typ,
+		})
+	}
+
+	chg := s.state.NewChange("refresh", "refresh kernel and base")
+	affected, tss, err := snapstate.UpdateMany(context.Background(), s.state,
+		[]string{"kernel", "core18"}, nil, s.user.ID, &snapstate.Flags{})
+	c.Assert(err, IsNil)
+	c.Assert(affected, DeepEquals, []string{"core18", "kernel"})
+
+	// Get the link-snap task of base, and set "cannot-reboot"
+	var linkSnapOfBase *state.Task
+	for _, ts := range tss {
+		chg.AddAll(ts)
+
+		for _, t := range ts.Tasks() {
+			if t.Kind() != "link-snap" {
+				continue
+			}
+
+			snapsup, err := snapstate.TaskSnapSetup(t)
+			if err != nil {
+				continue
+			}
+			if snapsup.Type == snap.TypeBase {
+				linkSnapOfBase = t
+				break
+			}
+		}
+	}
+	c.Assert(linkSnapOfBase, NotNil)
+
+	// Fake an older snapd having set this in a previous change
+	linkSnapOfBase.Set("cannot-reboot", true)
+
+	// have fake backend indicate a need to reboot for both snaps
+	s.fakeBackend.linkSnapMaybeReboot = true
+	s.fakeBackend.linkSnapRebootFor = map[string]bool{
+		"kernel": true,
+		"core18": true,
+	}
+
+	defer s.se.Stop()
+	s.settle(c)
+
+	// mock restart for the 'link-snap' step and run change to
+	// completion.
+	s.mockRestartAndSettle(c, chg)
+
+	c.Check(chg.Status(), Equals, state.DoneStatus)
+	// a single system restart was requested
+	c.Check(restartRequested, DeepEquals, []restart.RestartType{
+		restart.RestartSystem,
+	})
+	// verify that the log message appeared in the link-snap task
+	c.Check(linkSnapOfBase.Log(), HasLen, 1)
+	c.Check(linkSnapOfBase.Log()[0], Matches, `.* reboot postponed to later tasks`)
 }
 
 func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootUnsupportedWithCoreHappy(c *C) {
@@ -8442,7 +8553,6 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootUnsupportedWithCoreHa
 		[]string{"kernel", "core"}, nil, s.user.ID, &snapstate.Flags{})
 	c.Assert(err, IsNil)
 	c.Assert(affected, DeepEquals, []string{"core", "kernel"})
-	snapTasks := make(map[string]*state.Task)
 	var kernelTs, coreTs *state.TaskSet
 	for _, ts := range tss {
 		chg.AddAll(ts)
@@ -8452,7 +8562,6 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootUnsupportedWithCoreHa
 			case "link-snap", "auto-connect", "setup-profiles", "set-auto-aliases":
 				snapsup, err := snapstate.TaskSnapSetup(tsk)
 				c.Assert(err, IsNil)
-				snapTasks[fmt.Sprintf("%s@%s", tsk.Kind(), snapsup.Type)] = tsk
 				if tsk.Kind() == "link-snap" {
 					opts := 0
 					verifyUpdateTasks(c, snapsup.Type, opts, 0, ts)
@@ -8466,38 +8575,22 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootUnsupportedWithCoreHa
 		}
 	}
 
-	c.Assert(snapTasks, HasLen, 8)
-	linkSnapKernel := snapTasks["link-snap@kernel"]
-	autoConnectKernel := snapTasks["auto-connect@kernel"]
-	linkSnapBase := snapTasks["link-snap@os"]
-	autoConnectBase := snapTasks["auto-connect@os"]
-	c.Assert(kernelTs, NotNil)
-	c.Assert(coreTs, NotNil)
-	c.Assert(kernelTs.MaybeEdge(snapstate.BeforeMaybeRebootEdge), Equals, snapTasks["setup-profiles@kernel"])
-	c.Assert(kernelTs.MaybeEdge(snapstate.MaybeRebootEdge), Equals, linkSnapKernel)
-	c.Assert(kernelTs.MaybeEdge(snapstate.MaybeRebootWaitEdge), Equals, autoConnectKernel)
-	c.Assert(kernelTs.MaybeEdge(snapstate.AfterMaybeRebootWaitEdge), Equals, snapTasks["set-auto-aliases@kernel"])
+	// Core should come first, and it's "prerequisite" task should have no
+	// dependencies. The first task of kernel should depend on the last task
+	// of core. Single-reboot is not supported, so we expect them to run in serial.
+	firstTaskOfBase, err := coreTs.Edge(snapstate.BeginEdge)
+	c.Assert(err, IsNil)
+	firstTaskOfKernel, err := kernelTs.Edge(snapstate.BeginEdge)
+	c.Assert(err, IsNil)
+	lastTaskOfBase, err := coreTs.Edge(snapstate.EndEdge)
+	c.Assert(err, IsNil)
+	c.Check(firstTaskOfBase.WaitTasks(), HasLen, 0)
+	c.Check(firstTaskOfKernel.WaitTasks(), testutil.Contains, lastTaskOfBase)
 
-	c.Assert(coreTs.MaybeEdge(snapstate.BeforeMaybeRebootEdge), Equals, snapTasks["setup-profiles@os"])
-	c.Assert(coreTs.MaybeEdge(snapstate.MaybeRebootEdge), Equals, linkSnapBase)
-	c.Assert(coreTs.MaybeEdge(snapstate.MaybeRebootWaitEdge), Equals, autoConnectBase)
-	c.Assert(coreTs.MaybeEdge(snapstate.AfterMaybeRebootWaitEdge), Equals, snapTasks["set-auto-aliases@os"])
+	// Core and kernel should not be in the same transactional lane, as this
+	// is behaviour we want to have on UC16
+	c.Check(taskSetsShareLane(coreTs, kernelTs), Equals, false)
 
-	c.Assert(coreTs, NotNil)
-
-	c.Assert(linkSnapBase.WaitTasks(), DeepEquals, []*state.Task{
-		snapTasks["setup-profiles@os"],
-	})
-	c.Assert(autoConnectBase.WaitTasks(), DeepEquals, []*state.Task{
-		snapTasks["link-snap@os"],
-	})
-	// kernel tasks have an implicit dependency on all "core" tasks
-	c.Assert(linkSnapKernel.WaitTasks(), DeepEquals, append([]*state.Task{
-		snapTasks["setup-profiles@kernel"],
-	}, coreTs.Tasks()...))
-	c.Assert(autoConnectKernel.WaitTasks(), DeepEquals, append([]*state.Task{
-		snapTasks["link-snap@kernel"],
-	}, coreTs.Tasks()...))
 	// have fake backend indicate a need to reboot for both snaps
 	s.fakeBackend.linkSnapMaybeReboot = true
 	s.fakeBackend.linkSnapRebootFor = map[string]bool{
@@ -8599,9 +8692,10 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootUnsupportedWithGadget
 		[]string{"kernel", "core18", "gadget"}, nil, s.user.ID, &snapstate.Flags{})
 	c.Assert(err, IsNil)
 	c.Assert(affected, DeepEquals, []string{"core18", "gadget", "kernel"})
-	var kernelTsk, baseTsk, gadgetTsk *state.Task
+	var kernelTs, baseTs, gadgetTs *state.TaskSet
 	for _, ts := range tss {
 		chg.AddAll(ts)
+	inner:
 		for _, tsk := range ts.Tasks() {
 			switch tsk.Kind() {
 			// setup-profiles should appear right before link-snap,
@@ -8612,26 +8706,46 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootUnsupportedWithGadget
 				c.Assert(err, IsNil)
 				switch snapsup.InstanceName() {
 				case "kernel":
-					kernelTsk = tsk
+					kernelTs = ts
 				case "gadget":
-					gadgetTsk = tsk
+					gadgetTs = ts
 				case "core18":
-					baseTsk = tsk
+					baseTs = ts
 				}
-				var flag bool
-				// the flag isn't set for any of link-snap tasks
-				c.Assert(tsk.Get("cannot-reboot", &flag), testutil.ErrorIs, state.ErrNoState)
+				break inner
 			}
 		}
 	}
+	c.Assert(kernelTs, NotNil)
+	c.Assert(baseTs, NotNil)
+	c.Assert(gadgetTs, NotNil)
 
-	c.Assert(kernelTsk, NotNil)
-	c.Assert(baseTsk, NotNil)
-	c.Assert(gadgetTsk, NotNil)
+	// Core18, gadget and kernel should end up in the same transactional lane
+	c.Check(taskSetsShareLane(baseTs, gadgetTs, kernelTs), Equals, true)
 
-	c.Assert(kernelTsk.WaitTasks(), testutil.Contains, gadgetTsk)
-	c.Assert(kernelTsk.WaitTasks(), Not(testutil.Contains), baseTsk)
-	c.Assert(baseTsk.WaitTasks(), Not(testutil.Contains), kernelTsk)
+	// Core should come first, and it's "prerequisite" task should have no
+	// dependencies.
+	// The first task of gadget should depend on the last task of base.
+	// The first task of kernel should depend on the last task of gadget.
+	// Single-reboot is not supported, so we expect them to run in serial.
+	firstTaskOfBase, err := baseTs.Edge(snapstate.BeginEdge)
+	c.Assert(err, IsNil)
+	lastTaskOfBase, err := baseTs.Edge(snapstate.EndEdge)
+	c.Assert(err, IsNil)
+	firstTaskOfGadget, err := gadgetTs.Edge(snapstate.BeginEdge)
+	c.Assert(err, IsNil)
+	lastTaskOfGadget, err := gadgetTs.Edge(snapstate.EndEdge)
+	c.Assert(err, IsNil)
+	firstTaskOfKernel, err := kernelTs.Edge(snapstate.BeginEdge)
+	c.Assert(err, IsNil)
+	c.Check(firstTaskOfBase.WaitTasks(), HasLen, 0)
+	c.Check(firstTaskOfGadget.WaitTasks(), testutil.Contains, lastTaskOfBase)
+	c.Check(firstTaskOfKernel.WaitTasks(), testutil.Contains, lastTaskOfGadget)
+
+	// Manually verify their lanes
+	c.Check(firstTaskOfBase.Lanes(), DeepEquals, []int{2, 4})
+	c.Check(firstTaskOfGadget.Lanes(), DeepEquals, []int{3, 4})
+	c.Check(firstTaskOfKernel.Lanes(), DeepEquals, []int{1, 4})
 }
 
 func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootUndone(c *C) {
@@ -8683,30 +8797,53 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootUndone(c *C) {
 		[]string{"kernel", "core18"}, nil, s.user.ID, &snapstate.Flags{})
 	c.Assert(err, IsNil)
 	c.Assert(affected, DeepEquals, []string{"core18", "kernel"})
-	var autoConnectBase, autoConnectKernel *state.Task
+
+	// Verify that correct dependencies have been set-up for single-reboot
+	// which is a bit more tricky, as task-sets have been split up into pre-boot
+	// things, and post-boot things.
+
+	// Grab the correct task-sets
+	var baseTs, kernelTs *state.TaskSet
 	for _, ts := range tss {
-		chg.AddAll(ts)
-		for _, tsk := range ts.Tasks() {
-			if tsk.Kind() == "auto-connect" {
-				snapsup, err := snapstate.TaskSnapSetup(tsk)
-				c.Assert(err, IsNil)
-				if snapsup.Type == "kernel" {
-					autoConnectKernel = tsk
-				} else {
-					autoConnectBase = tsk
-				}
+		for _, t := range ts.Tasks() {
+			snapsup, err := snapstate.TaskSnapSetup(t)
+			if err != nil {
+				continue
+			}
+			if snapsup.Type == snap.TypeKernel {
+				kernelTs = ts
+				break
+			} else if snapsup.Type == snap.TypeBase {
+				baseTs = ts
 				break
 			}
 		}
+		chg.AddAll(ts)
 	}
-	// verify auto connect of kernel waits for base
-	waitsForBase := false
-	for _, tsk := range autoConnectKernel.WaitTasks() {
-		if tsk == autoConnectBase {
-			waitsForBase = true
-		}
-	}
-	c.Assert(waitsForBase, Equals, true, Commentf("auto-connect of kernel does not wait for base"))
+	c.Assert(baseTs, NotNil)
+	c.Assert(kernelTs, NotNil)
+
+	// Grab the tasks we need to check dependencies between
+	firstTaskOfKernel, err := kernelTs.Edge(snapstate.BeginEdge)
+	c.Assert(err, IsNil)
+	linkTaskOfKernel, err := kernelTs.Edge(snapstate.MaybeRebootEdge)
+	c.Assert(err, IsNil)
+	acTaskOfKernel, err := kernelTs.Edge(snapstate.MaybeRebootWaitEdge)
+	c.Assert(err, IsNil)
+	linkTaskOfBase, err := baseTs.Edge(snapstate.MaybeRebootEdge)
+	c.Assert(err, IsNil)
+	acTaskOfBase, err := baseTs.Edge(snapstate.MaybeRebootWaitEdge)
+	c.Assert(err, IsNil)
+	lastTaskOfBase, err := baseTs.Edge(snapstate.EndEdge)
+	c.Assert(err, IsNil)
+
+	// Things that must be correct:
+	// - "prerequisites" (BeginEdge) of kernel must depend on "link-snap" (MaybeRebootEdge) of base
+	c.Check(firstTaskOfKernel.WaitTasks(), testutil.Contains, linkTaskOfBase)
+	// - "auto-connect" (MaybeRebootWaitEdge) of base must depend on "link-snap" of kernel (MaybeRebootEdge)
+	c.Check(acTaskOfBase.WaitTasks(), testutil.Contains, linkTaskOfKernel)
+	// - "auto-connect" (MaybeRebootWaitEdge) of kernel must depend on the last task of base (EndEdge)
+	c.Check(acTaskOfKernel.WaitTasks(), testutil.Contains, lastTaskOfBase)
 
 	// have fake backend indicate a need to reboot for both snaps
 	s.fakeBackend.linkSnapMaybeReboot = true
@@ -8768,6 +8905,175 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootUndone(c *C) {
 	c.Assert(ops[5:], testutil.DeepUnsortedMatches, []string{"core18/7", "kernel/7"})
 }
 
+func (s *snapmgrTestSuite) TestUpdateBaseGadgetKernelWithKernelUndone(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+	restore = snapstate.MockRevisionDate(nil)
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// make it easier for us to mock the whole gadget update so we don't
+	// have to jump through to many hoops.
+	s.o.TaskRunner().AddHandler("update-gadget-assets",
+		func(task *state.Task, tomb *tomb.Tomb) error {
+			task.State().Lock()
+			defer task.State().Unlock()
+			chg := task.Change()
+			chg.Set("gadget-restart-required", true)
+			return nil
+		},
+		func(task *state.Task, tomb *tomb.Tomb) error { return nil })
+
+	s.o.TaskRunner().AddHandler("update-gadget-cmdline",
+		func(task *state.Task, tomb *tomb.Tomb) error { return nil },
+		func(task *state.Task, tomb *tomb.Tomb) error { return nil })
+
+	var restartRequested []restart.RestartType
+	_, err := restart.Manager(s.state, "boot-id-0", snapstatetest.MockRestartHandler(func(t restart.RestartType) {
+		restartRequested = append(restartRequested, t)
+	}))
+	c.Assert(err, IsNil)
+
+	restore = snapstatetest.MockDeviceModel(ModelWithBase("core18"))
+	defer restore()
+
+	siKernel := snap.SideInfo{
+		RealName: "kernel",
+		Revision: snap.R(7),
+		SnapID:   "kernel-id",
+	}
+	siBase := snap.SideInfo{
+		RealName: "core18",
+		Revision: snap.R(7),
+		SnapID:   "core18-snap-id",
+	}
+	siGadget := snap.SideInfo{
+		RealName: "gadget",
+		Revision: snap.R(7),
+		SnapID:   "gadget-core18-id",
+	}
+	for _, si := range []*snap.SideInfo{&siKernel, &siBase, &siGadget} {
+		snaptest.MockSnap(c, fmt.Sprintf(`name: %s`, si.RealName), si)
+		typ := "kernel"
+		if si.RealName == "core18" {
+			typ = "base"
+		} else if si.RealName == "gadget" {
+			typ = "gadget"
+		}
+		snapstate.Set(s.state, si.RealName, &snapstate.SnapState{
+			Active:          true,
+			Sequence:        []*snap.SideInfo{si},
+			Current:         si.Revision,
+			TrackingChannel: "latest/stable",
+			SnapType:        typ,
+		})
+	}
+
+	chg := s.state.NewChange("refresh", "refresh base, gadget and kernel")
+	affected, tss, err := snapstate.UpdateMany(context.Background(), s.state,
+		[]string{"kernel", "core18", "gadget"}, nil, s.user.ID, &snapstate.Flags{})
+	c.Assert(err, IsNil)
+	c.Assert(affected, DeepEquals, []string{"core18", "gadget", "kernel"})
+
+	// Grab the correct task-sets
+	var baseTs, gadgetTs, kernelTs *state.TaskSet
+	for _, ts := range tss {
+		for _, t := range ts.Tasks() {
+			snapsup, err := snapstate.TaskSnapSetup(t)
+			if err != nil {
+				continue
+			}
+			if snapsup.Type == snap.TypeKernel {
+				kernelTs = ts
+				break
+			} else if snapsup.Type == snap.TypeBase {
+				baseTs = ts
+				break
+			} else if snapsup.Type == snap.TypeGadget {
+				gadgetTs = ts
+				break
+			}
+		}
+		chg.AddAll(ts)
+	}
+	c.Assert(baseTs, NotNil)
+	c.Assert(kernelTs, NotNil)
+	c.Assert(gadgetTs, NotNil)
+
+	// have fake backend indicate a need to reboot for both snaps
+	s.fakeBackend.linkSnapMaybeReboot = true
+	s.fakeBackend.linkSnapRebootFor = map[string]bool{
+		"kernel": true,
+		"core18": true,
+		"gadget": true,
+	}
+	errInjected := 0
+	s.fakeBackend.maybeInjectErr = func(op *fakeOp) error {
+		if op.op == "auto-connect:Doing" && op.name == "kernel" {
+			errInjected++
+			return fmt.Errorf("auto-connect-kernel mock error")
+		}
+		return nil
+	}
+
+	defer s.se.Stop()
+	s.settle(c)
+
+	// base requests a reboot
+	s.mockRestartAndSettle(c, chg)
+
+	// gadget requests a reboot
+	s.mockRestartAndSettle(c, chg)
+
+	// kernel requests a reboot
+	s.mockRestartAndSettle(c, chg)
+
+	// kernel snap requests another restart along the undo path at 'unlink-current-snap'
+	s.mockRestartAndSettle(c, chg)
+
+	// Since updates are run serialized, and not setup for single-reboot when gadget is involved
+	// for now, then the updates that complete (base, gadget) before kernel which fails, are not
+	// undone as they are essentially complete because of their individual lanes. If they should
+	// be completely transactional (i.e all be undone, they must be invoked with a shared lane).
+	// This means we only expect them to be forced transactional, is when we set up for single-reboot.
+	for _, t := range baseTs.Tasks() {
+		c.Check(t.Status(), Equals, state.DoneStatus)
+	}
+	for _, t := range gadgetTs.Tasks() {
+		c.Check(t.Status(), Equals, state.DoneStatus)
+	}
+	for _, t := range kernelTs.Tasks() {
+		switch t.Status() {
+		case state.UndoneStatus, state.ErrorStatus, state.HoldStatus:
+			continue
+		case state.DoneStatus:
+			// following tasks don't have undo logic
+			switch t.Kind() {
+			case "prerequisites", "validate-snap", "run-hook":
+				break
+			default:
+				c.Errorf("unexpected done-status for kernel task %s", t.Kind())
+			}
+		default:
+			c.Errorf("unexpected status for kernel task %s: %s", t.Kind(), t.Status())
+		}
+	}
+
+	c.Check(chg.Status(), Equals, state.ErrorStatus)
+	c.Check(chg.Err(), ErrorMatches, `(?s).*\(auto-connect-kernel mock error\)`)
+	c.Check(restartRequested, DeepEquals, []restart.RestartType{
+		// do path
+		restart.RestartSystem,
+		restart.RestartSystem,
+		restart.RestartSystem,
+		// undo
+		restart.RestartSystem,
+	})
+	c.Check(errInjected, Equals, 1)
+}
+
 func failAfterLinkSnap(ol *overlord.Overlord, chg *state.Change) error {
 	err := errors.New("expected")
 	ol.TaskRunner().AddHandler("fail", func(*state.Task, *tomb.Tomb) error {
@@ -8783,6 +9089,251 @@ func failAfterLinkSnap(ol *overlord.Overlord, chg *state.Change) error {
 	}
 
 	return err
+}
+
+func (s *snapmgrTestSuite) testUpdateEssentialSnapsOrder(c *C, order []string, singleReboot bool) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+	restore = snapstate.MockRevisionDate(nil)
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// make it easier for us to mock the whole gadget update so we don't
+	// have to jump through to many hoops. Streamline it a bit as well by
+	// making sure that one of the tasks requires a reboot by the link-snap
+	s.o.TaskRunner().AddHandler("update-gadget-assets",
+		func(task *state.Task, tomb *tomb.Tomb) error {
+			task.State().Lock()
+			defer task.State().Unlock()
+			chg := task.Change()
+			chg.Set("gadget-restart-required", true)
+			return nil
+		},
+		func(task *state.Task, tomb *tomb.Tomb) error { return nil })
+
+	s.o.TaskRunner().AddHandler("update-gadget-cmdline",
+		func(task *state.Task, tomb *tomb.Tomb) error { return nil },
+		func(task *state.Task, tomb *tomb.Tomb) error { return nil })
+
+	var restartRequested []restart.RestartType
+	_, err := restart.Manager(s.state, "boot-id-0", snapstatetest.MockRestartHandler(func(t restart.RestartType) {
+		restartRequested = append(restartRequested, t)
+	}))
+	c.Assert(err, IsNil)
+
+	restore = snapstatetest.MockDeviceModel(ModelWithBase("core18"))
+	defer restore()
+
+	types := map[string]string{
+		"snapd":          "snapd",
+		"core18":         "base",
+		"gadget":         "gadget",
+		"kernel":         "kernel",
+		"some-base":      "base",
+		"some-base-snap": "app",
+	}
+	snapIds := map[string]string{
+		"snapd":          "snapd-snap-id",
+		"core18":         "core18-snap-id",
+		"gadget":         "gadget-core18-id",
+		"kernel":         "kernel-id",
+		"some-base":      "some-base-id",
+		"some-base-snap": "some-base-snap-id",
+	}
+
+	for _, sn := range order {
+		si := &snap.SideInfo{RealName: sn, Revision: snap.R(1), SnapID: snapIds[sn]}
+		snapYaml := fmt.Sprintf("name: %s\nversion: 1.2.3\ntype: %s", sn, types[sn])
+		if sn == "some-base-snap" {
+			// add a base for the app if the base is in the update list
+			snapYaml += "\nbase: some-base"
+		}
+
+		snaptest.MockSnap(c, snapYaml, si)
+		snapstate.Set(s.state, sn, &snapstate.SnapState{
+			Active:          true,
+			Sequence:        []*snap.SideInfo{si},
+			Current:         si.Revision,
+			TrackingChannel: "latest/stable",
+			SnapType:        types[sn],
+		})
+	}
+
+	chg := s.state.NewChange("refresh", fmt.Sprintf("refresh %v", order))
+	affected, tss, err := snapstate.UpdateMany(context.Background(), s.state,
+		order, nil, s.user.ID, &snapstate.Flags{NoReRefresh: true})
+	c.Assert(err, IsNil)
+	sort.Strings(affected)
+	c.Assert(affected, testutil.DeepUnsortedMatches, order)
+
+	findTs := func(sn string) *state.TaskSet {
+		for _, ts := range tss {
+			for _, tsk := range ts.Tasks() {
+				if tsk.Kind() == "prerequisites" {
+					snapsup, err := snapstate.TaskSnapSetup(tsk)
+					c.Assert(err, IsNil)
+					if snapsup.InstanceName() == sn {
+						return ts
+					}
+					break
+				}
+			}
+		}
+		return nil
+	}
+
+	// Map all relevant task-sets.
+	tsByName := make(map[string]*state.TaskSet)
+	for _, sn := range order {
+		ts := findTs(sn)
+		c.Assert(ts, NotNil)
+		chg.AddAll(ts)
+		tsByName[sn] = ts
+	}
+
+	// Ensure no circular dependency
+	c.Check(chg.CheckTaskDependencies(), IsNil)
+
+	// If the task-sets are expect to be arranged for single-reboot
+	// we have to verify connections a bit different
+	if singleReboot {
+		// Ensure that pre-requisites are correctly linked
+		for i, sn := range order {
+			if i == 0 {
+				continue
+			}
+
+			prevTs := tsByName[order[i-1]]
+			currentTs := tsByName[sn]
+
+			firstTaskOfCurrent, err := currentTs.Edge(snapstate.BeginEdge)
+			c.Assert(err, IsNil)
+			linkSnapOfPrev, err := prevTs.Edge(snapstate.MaybeRebootEdge)
+			c.Assert(err, IsNil)
+			c.Check(firstTaskOfCurrent.WaitTasks(), testutil.Contains, linkSnapOfPrev)
+		}
+		// Ensure that auto-connect is correctly linked.
+		lastTs := tsByName[order[len(order)-1]]
+		for i, sn := range order {
+			// Skip for last entry.
+			if i == len(order)-1 {
+				break
+			}
+
+			// Get previous task-set, for the first entry this would be the task-set
+			// in the last entry.
+			var prevTs *state.TaskSet
+			if i == 0 {
+				prevTs = lastTs
+			} else {
+				prevTs = tsByName[order[i-1]]
+			}
+			currentTs := tsByName[sn]
+
+			// "auto-connect" must depend on "link-snap" of previous
+			acTaskOfCurrent, err := currentTs.Edge(snapstate.MaybeRebootWaitEdge)
+			c.Assert(err, IsNil)
+			linkSnapOfPrev, err := prevTs.Edge(snapstate.MaybeRebootEdge)
+			c.Assert(err, IsNil)
+			c.Check(acTaskOfCurrent.WaitTasks(), testutil.Contains, linkSnapOfPrev)
+		}
+	} else {
+		// Verify by using edges that tasks are correctly connected to the previous
+		// task-set.
+		for i, sn := range order {
+			if i == 0 {
+				continue
+			}
+
+			prevTs := tsByName[order[i-1]]
+			currentTs := tsByName[sn]
+
+			firstTaskOfCurrent, err := currentTs.Edge(snapstate.BeginEdge)
+			c.Assert(err, IsNil)
+			lastTaskOfPrev, err := prevTs.Edge(snapstate.EndEdge)
+			c.Assert(err, IsNil)
+			c.Check(firstTaskOfCurrent.WaitTasks(), testutil.Contains, lastTaskOfPrev)
+		}
+	}
+
+	// determine the number of reboots we expect
+	s.fakeBackend.linkSnapRebootFor = make(map[string]bool)
+	for _, o := range order {
+		switch o {
+		case "core18", "kernel", "gadget":
+			s.fakeBackend.linkSnapRebootFor[o] = true
+		}
+	}
+	s.fakeBackend.linkSnapMaybeReboot = len(s.fakeBackend.linkSnapRebootFor) > 0
+
+	defer s.se.Stop()
+	s.settle(c)
+
+	if !s.fakeBackend.linkSnapMaybeReboot {
+		// no reboot expected, skip to next checks
+	} else if singleReboot {
+		c.Check(chg.IsReady(), Equals, false)
+		c.Check(chg.Status(), Equals, state.WaitStatus)
+
+		// one reboot expected
+		s.mockRestartAndSettle(c, chg)
+	} else {
+		// perform a reboot for each snap that requires a reboot
+		for _, o := range order {
+			if s.fakeBackend.linkSnapRebootFor[o] {
+				// expect change to be in wait-state before the reboot
+				c.Check(chg.IsReady(), Equals, false)
+				c.Check(chg.Status(), Equals, state.WaitStatus)
+
+				s.mockRestartAndSettle(c, chg)
+			}
+		}
+	}
+
+	c.Check(chg.IsReady(), Equals, true)
+	c.Check(chg.Status(), Equals, state.DoneStatus)
+}
+
+func (s *snapmgrTestSuite) TestUpdateEssentialSnapsOrderAll(c *C) {
+	s.testUpdateEssentialSnapsOrder(c, []string{"snapd", "core18", "gadget", "kernel"}, false)
+}
+
+func (s *snapmgrTestSuite) TestUpdateEssentialSnapsOrderSnapdBase(c *C) {
+	s.testUpdateEssentialSnapsOrder(c, []string{"snapd", "core18"}, false)
+}
+
+func (s *snapmgrTestSuite) TestUpdateEssentialSnapsOrderBaseGadgetKernel(c *C) {
+	s.testUpdateEssentialSnapsOrder(c, []string{"core18", "gadget", "kernel"}, false)
+}
+
+func (s *snapmgrTestSuite) TestUpdateEssentialSnapsOrderBaseKernel(c *C) {
+	s.testUpdateEssentialSnapsOrder(c, []string{"core18", "kernel"}, true)
+}
+
+func (s *snapmgrTestSuite) TestUpdateEssentialSnapsOrderBaseGadget(c *C) {
+	s.testUpdateEssentialSnapsOrder(c, []string{"core18", "gadget"}, false)
+}
+
+func (s *snapmgrTestSuite) TestUpdateEssentialSnapsOrderBaseGadgetAndSnaps(c *C) {
+	s.testUpdateEssentialSnapsOrder(c, []string{"core18", "gadget", "some-base", "some-base-snap"}, false)
+}
+
+func (s *snapmgrTestSuite) TestUpdateEssentialSnapsOrderGadgetKernel(c *C) {
+	s.testUpdateEssentialSnapsOrder(c, []string{"gadget", "kernel"}, false)
+}
+
+func (s *snapmgrTestSuite) TestUpdateEssentialSnapsOrderGadgetKernelAndSnaps(c *C) {
+	s.testUpdateEssentialSnapsOrder(c, []string{"gadget", "kernel", "some-base", "some-base-snap"}, false)
+}
+
+func (s *snapmgrTestSuite) TestUpdateSnapsOrderSnapdBaseApp(c *C) {
+	s.testUpdateEssentialSnapsOrder(c, []string{"snapd", "some-base", "some-base-snap"}, false)
+}
+
+func (s *snapmgrTestSuite) TestUpdateSnapsOrderBaseApp(c *C) {
+	s.testUpdateEssentialSnapsOrder(c, []string{"some-base", "some-base-snap"}, false)
 }
 
 func (s *snapmgrTestSuite) TestUpdateBaseAndSnapdOrder(c *C) {
@@ -8832,6 +9383,10 @@ func (s *snapmgrTestSuite) TestUpdateBaseAndSnapdOrder(c *C) {
 	sort.Strings(affected)
 	c.Assert(affected, DeepEquals, []string{"core18", "snapd"})
 
+	// Core18 and snapd are both essential snaps, so we verify that the order between
+	// them are correct. Snapd should *always* be updated first, and core18 must have
+	// a dependency on snapd
+
 	// grab the task sets of snapd and the base
 	var snapdTs, baseTs *state.TaskSet
 	for _, ts := range tss {
@@ -8848,12 +9403,15 @@ func (s *snapmgrTestSuite) TestUpdateBaseAndSnapdOrder(c *C) {
 			}
 		}
 	}
+	c.Assert(snapdTs, NotNil)
+	c.Assert(baseTs, NotNil)
 
-	// verify that the base tasks depend on the last task of snapd
-	snapdts := snapdTs.Tasks()
-	for _, bts := range baseTs.Tasks() {
-		c.Check(bts.WaitTasks(), testutil.Contains, snapdts[len(snapdts)-1])
-	}
+	// Use edges to verify there are correct dependencies
+	firstTaskOfBase, err := baseTs.Edge(snapstate.BeginEdge)
+	c.Assert(err, IsNil)
+	lastTaskOfSnapd, err := snapdTs.Edge(snapstate.EndEdge)
+	c.Assert(err, IsNil)
+	c.Check(firstTaskOfBase.WaitTasks(), testutil.Contains, lastTaskOfSnapd)
 
 	s.fakeBackend.linkSnapMaybeReboot = true
 	s.fakeBackend.linkSnapRebootFor = map[string]bool{

--- a/tests/core/kernel-base-gadget-failover/task.yaml
+++ b/tests/core/kernel-base-gadget-failover/task.yaml
@@ -21,15 +21,6 @@ restore: |
         exit
     fi
     
-    if [ "$SPREAD_REBOOT" = 0 ]; then
-        "$TESTSTOOLS"/store-state teardown-fake-store "$BLOB_DIR"
-
-        # restore the previous revisions
-        snap revert core18 --revision="$(cat core.rev)"
-        
-        REBOOT
-    fi
-
 execute: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then
         echo "This test needs test keys to be trusted"
@@ -71,6 +62,16 @@ execute: |
 
         REBOOT
     elif [ "$SPREAD_REBOOT" = 2 ]; then
+        # wait for reboot to occur as gadget reverts
+        retry -n 50 --wait 1 sh -c 'journalctl -b -u snapd | MATCH "Waiting for system reboot"'
+
+        REBOOT
+    elif [ "$SPREAD_REBOOT" = 3 ]; then
+        # wait for reboot to occur as base reverts
+        retry -n 50 --wait 1 sh -c 'journalctl -b -u snapd | MATCH "Waiting for system reboot"'
+
+        REBOOT
+    elif [ "$SPREAD_REBOOT" = 4 ]; then
         change_id="$(cat refresh-change-id)"
         # we expect the change to have failed due to the kernel not booting
         # properly
@@ -78,14 +79,11 @@ execute: |
         snap changes | MATCH "$change_id\s+Error"
         snap change "$change_id" > tasks.done
         
-        # Since updates are run serialized, and not setup for single-reboot when gadget is involved
-        # for now, then the updates that complete (base, gadget) before kernel which fails, are not
-        # undone as they are essentially complete because of their individual lanes. If they should
-        # be completely transactional (i.e all be undone, they must be invoked with a shared lane).
-        # This means we only expect them to be forced transactional, is when we set up for single-reboot.
+        # and since kernel, gadget and base all are considered to be forced as a transaction
+        # we expect all to be undone
         MATCH 'Undone\s+.*Make snap "pc-kernel" .* available' < tasks.done
-        MATCH 'Done\s+.*Make snap "core18" .* available' < tasks.done
-        MATCH 'Done\s+.*Make snap "pc" .* available' < tasks.done
+        MATCH 'Undone\s+.*Make snap "core18" .* available' < tasks.done
+        MATCH 'Undone\s+.*Make snap "pc" .* available' < tasks.done
 
         # boot variables should have been cleared
         snap debug boot-vars > boot-vars.dump
@@ -98,15 +96,15 @@ execute: |
         # Note: on bionic, is-system-running does not support --wait
         retry -n 30 sh -c '(systemctl is-system-running || true) | MATCH "(running|degraded)"'
 
-        # we're expecting the old revisions to be back for kernel
+        # we're expecting the old revisions to be back
         original_kernel="$(cat pc-kernel.rev)"
         original_core="$(cat core.rev)"
         original_pc="$(cat pc.rev)"
 
-        # verify that current points to old revisions for kernel only
+        # verify that current points to old revisions
         test "$(readlink /snap/pc-kernel/current)" = "$original_kernel"
-        test "$(readlink /snap/core18/current)" != "$original_core"
-        test "$(readlink /snap/pc/current)" != "$original_pc"
+        test "$(readlink /snap/core18/current)" = "$original_core"
+        test "$(readlink /snap/pc/current)" = "$original_pc"
     else
         echo "unexpected reboot"
         exit 1

--- a/tests/core/kernel-base-gadget-failover/task.yaml
+++ b/tests/core/kernel-base-gadget-failover/task.yaml
@@ -1,0 +1,113 @@
+summary: Verify behavior of undoing essential snap updates, when updating base, gadget and kernel
+
+# TODO make the test work with ubuntu-core-20
+systems: [ubuntu-core-18-*]
+
+environment:
+    BLOB_DIR: $(pwd)/fake-store-blobdir
+
+prepare: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+    readlink "/snap/pc-kernel/current" > pc-kernel.rev
+    readlink "/snap/core18/current" > core.rev
+    readlink "/snap/pc/current" > pc.rev
+
+restore: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+    
+    if [ "$SPREAD_REBOOT" = 0 ]; then
+        "$TESTSTOOLS"/store-state teardown-fake-store "$BLOB_DIR"
+
+        # restore the previous revisions
+        snap revert core18 --revision="$(cat core.rev)"
+        
+        REBOOT
+    fi
+
+execute: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+
+    snap ack "$TESTSLIB/assertions/testrootorg-store.account-key"
+    "$TESTSTOOLS"/store-state setup-fake-store "$BLOB_DIR"
+
+    if [ "$SPREAD_REBOOT" = 0 ]; then
+        # break the pc-kernel snap
+        unsquashfs -d pc-kernel-snap /var/lib/snapd/snaps/pc-kernel_*.snap
+        truncate -s 0 pc-kernel-snap/initrd.img
+
+        "$TESTSTOOLS"/store-state init-fake-refreshes "$BLOB_DIR" pc-kernel --snap-blob "$PWD/pc-kernel-snap"
+        "$TESTSTOOLS"/store-state init-fake-refreshes "$BLOB_DIR" core18
+        "$TESTSTOOLS"/store-state init-fake-refreshes "$BLOB_DIR" pc
+
+        snap refresh --no-wait core18 pc pc-kernel > refresh-change-id
+        
+        # wait for the link task to be done for base
+        retry -n 50 --wait 1 sh -c 'journalctl -b -u snapd | MATCH "Waiting for system reboot"'
+
+        snap debug boot-vars > boot-vars.dump
+        MATCH 'snap_mode=try' < boot-vars.dump
+        MATCH 'snap_try_core=core18_.*.snap' < boot-vars.dump
+
+        REBOOT
+    elif [ "$SPREAD_REBOOT" = 1 ]; then
+        change_id="$(cat refresh-change-id)"
+        snap watch "$change_id" || true
+
+        # wait for the link task to be done for gadget
+        retry -n 50 --wait 1 sh -c 'journalctl -b -u snapd | MATCH "Waiting for system reboot"'
+
+        snap debug boot-vars > boot-vars.dump
+        MATCH 'snap_mode=try' < boot-vars.dump
+        MATCH 'snap_try_kernel=pc-kernel_.*.snap' < boot-vars.dump
+
+        REBOOT
+    elif [ "$SPREAD_REBOOT" = 2 ]; then
+        change_id="$(cat refresh-change-id)"
+        # we expect the change to have failed due to the kernel not booting
+        # properly
+        snap watch "$change_id" || true
+        snap changes | MATCH "$change_id\s+Error"
+        snap change "$change_id" > tasks.done
+        
+        # Since updates are run serialized, and not setup for single-reboot when gadget is involved
+        # for now, then the updates that complete (base, gadget) before kernel which fails, are not
+        # undone as they are essentially complete because of their individual lanes. If they should
+        # be completely transactional (i.e all be undone, they must be invoked with a shared lane).
+        # This means we only expect them to be forced transactional, is when we set up for single-reboot.
+        MATCH 'Undone\s+.*Make snap "pc-kernel" .* available' < tasks.done
+        MATCH 'Done\s+.*Make snap "core18" .* available' < tasks.done
+        MATCH 'Done\s+.*Make snap "pc" .* available' < tasks.done
+
+        # boot variables should have been cleared
+        snap debug boot-vars > boot-vars.dump
+        MATCH 'snap_mode=$' < boot-vars.dump
+        MATCH 'snap_try_core=$' < boot-vars.dump
+        MATCH 'snap_try_kernel=$' < boot-vars.dump
+
+        # make sure the system is in stable state, no pending reboots
+        # XXX systemctl exits with non-0 when in degraded state
+        # Note: on bionic, is-system-running does not support --wait
+        retry -n 30 sh -c '(systemctl is-system-running || true) | MATCH "(running|degraded)"'
+
+        # we're expecting the old revisions to be back for kernel
+        original_kernel="$(cat pc-kernel.rev)"
+        original_core="$(cat core.rev)"
+        original_pc="$(cat pc.rev)"
+
+        # verify that current points to old revisions for kernel only
+        test "$(readlink /snap/pc-kernel/current)" = "$original_kernel"
+        test "$(readlink /snap/core18/current)" != "$original_core"
+        test "$(readlink /snap/pc/current)" != "$original_pc"
+    else
+        echo "unexpected reboot"
+        exit 1
+    fi

--- a/tests/core/kernel-base-gadget-failover/task.yaml
+++ b/tests/core/kernel-base-gadget-failover/task.yaml
@@ -1,5 +1,21 @@
 summary: Verify behavior of undoing essential snap updates, when updating base, gadget and kernel
 
+details: |
+    Test ensures that if one of the essential snaps fail to update, together with
+    other essential snaps (boot-base, gadget, kernel specifically), then all of
+    them are rolled back.
+
+    The order we expect things to happen in is:
+    1. Boot-base updates and requests restart
+    2. Gadget updates and requests restart
+    3. Kernel updates, requests restart
+    4. Kernel update fails, reverts to previous
+    5. Gadget reverts, no restart request
+       - The reason for this is that there are no command-line changes, i.e no request done
+       - The second reason is that "update-gadget-assets" have no undo logic, i.e no request done 
+    6. Boot-base reverts, requests restart
+    7. Change is undone, with 4 reboots.
+
 # TODO make the test work with ubuntu-core-20
 systems: [ubuntu-core-18-*]
 
@@ -62,7 +78,8 @@ execute: |
 
         REBOOT
     elif [ "$SPREAD_REBOOT" = 2 ]; then
-        # wait for reboot to occur as change reverts
+        # wait for reboot to occur as change reverts, at this point kernel will have reverted, and
+        # now we are waiting for the base to request a restart as the gadget is not requesting one
         retry -n 50 --wait 1 sh -c 'journalctl -b -u snapd | MATCH "Waiting for system reboot"'
 
         REBOOT

--- a/tests/core/kernel-base-gadget-failover/task.yaml
+++ b/tests/core/kernel-base-gadget-failover/task.yaml
@@ -62,16 +62,11 @@ execute: |
 
         REBOOT
     elif [ "$SPREAD_REBOOT" = 2 ]; then
-        # wait for reboot to occur as gadget reverts
+        # wait for reboot to occur as change reverts
         retry -n 50 --wait 1 sh -c 'journalctl -b -u snapd | MATCH "Waiting for system reboot"'
 
         REBOOT
     elif [ "$SPREAD_REBOOT" = 3 ]; then
-        # wait for reboot to occur as base reverts
-        retry -n 50 --wait 1 sh -c 'journalctl -b -u snapd | MATCH "Waiting for system reboot"'
-
-        REBOOT
-    elif [ "$SPREAD_REBOOT" = 4 ]; then
         change_id="$(cat refresh-change-id)"
         # we expect the change to have failed due to the kernel not booting
         # properly


### PR DESCRIPTION
Move the snap dependency logic out of doUpdates, and move it into explicit functions that coordinate snap changes. This also gets rid of the behavior that `rearrangeBaseKernelForSingleReboot` introduces, which carefully rearranges task-sets to overlap correctly to support a single-reboot.

Instead the snap-dependency logic has been made much more visible, and is manually arranged instead of done in a loop. The new dependency logic also supports the single-reboot functionality, but by splitting task-sets into two parts (i.e pre-boot and post-boot), instead of rearranging individual tasks.
