### PR TITLE
tests: fix core20-to-core22 test

### DIFF
--- a/tests/nested/manual/core20-to-core22/task.yaml
+++ b/tests/nested/manual/core20-to-core22/task.yaml
@@ -83,5 +83,5 @@ execute: |
     echo "And back to run mode"
     remote.exec "sudo snap wait system seed.loaded"
     remote.exec sudo snap reboot --run | MATCH 'Reboot into "run" mode.'
-    rmeote.wait-for reboot "${boot_id}"
+    remote.wait-for reboot "${boot_id}"
     remote.exec 'sudo cat /proc/cmdline' | MATCH "snapd_recovery_mode=run "


### PR DESCRIPTION
The command has a typo which is fixed
