### PR TITLE
cmd/snap-confine: add libnvidia-gpucomp to the list of nvidia driver library globs

### DIFF
--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -94,6 +94,7 @@ static const char *nvidia_globs[] = {
 	"libnvidia-glcore.so*",
 	"libnvidia-glsi.so*",
 	"libnvidia-glvkspirv.so*",
+	"libnvidia-gpucomp.so*",
 	"libnvidia-ifr.so*",
 	"libnvidia-ml.so*",
 	"libnvidia-opencl.so*",


### PR DESCRIPTION
Upcoming versions of the NVIDIA driver will include a new component:

https://forums.developer.nvidia.com/t/new-driver-component-libnvidia-gpucomp/267060

Update the list of NVIDIA driver libraries so that it can be included in the runtime environment along with the others.
