### PR TITLE
o/snapstate: wrap `refreshCandidates` to mitigate store throttling

### DIFF
--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -8987,6 +8987,121 @@ func (s *snapmgrTestSuite) TestSaveRefreshCandidatesOnAutoRefresh(c *C) {
 	c.Check(cands["some-other-snap"], NotNil)
 }
 
+type customStore struct {
+	*fakeStore
+
+	customSnapAction func(context.Context, []*store.CurrentSnap, []*store.SnapAction, store.AssertionQuery, *auth.UserState, *store.RefreshOptions) ([]store.SnapActionResult, []store.AssertionResult, error)
+}
+
+func (s customStore) SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, assertQuery store.AssertionQuery, user *auth.UserState, opts *store.RefreshOptions) ([]store.SnapActionResult, []store.AssertionResult, error) {
+	return s.customSnapAction(ctx, currentSnaps, actions, assertQuery, user, opts)
+}
+
+func (s *snapmgrTestSuite) TestSaveMonitoredRefreshCandidatesOnAutoRefreshThrottled(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active: true,
+		Sequence: []*snap.SideInfo{
+			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
+		},
+		Current:  snap.R(1),
+		SnapType: "app",
+	})
+	snapstate.Set(s.state, "some-other-snap", &snapstate.SnapState{
+		Active: true,
+		Sequence: []*snap.SideInfo{
+			{RealName: "some-other-snap", SnapID: "some-other-snap-id", Revision: snap.R(1)},
+		},
+		Current:  snap.R(1),
+		SnapType: "app",
+	})
+	snapstate.Set(s.state, "snap-c", &snapstate.SnapState{
+		Active: true,
+		Sequence: []*snap.SideInfo{
+			{RealName: "snap-c", SnapID: "snap-c-id", Revision: snap.R(1)},
+		},
+		Current:  snap.R(1),
+		SnapType: "app",
+	})
+
+	// simulate existing refresh hint from older refresh with
+	// some-other-snap being monitored
+	cands := map[string]*snapstate.RefreshCandidate{
+		"some-other-snap": {Monitored: true},
+		"snap-c":          {},
+	}
+	s.state.Set("refresh-candidates", &cands)
+
+	// simulate store throttling some snaps' during auto-refresh
+	isThrottled := map[string]bool{
+		"some-other-snap-id": true,
+		"snap-c-id":          true,
+	}
+	type requestRecord struct {
+		opts    *store.RefreshOptions
+		snapIDs map[string]bool
+	}
+	var requests []requestRecord
+	sto := customStore{fakeStore: s.fakeStore}
+	sto.customSnapAction = func(ctx context.Context, cs []*store.CurrentSnap, sa []*store.SnapAction, aq store.AssertionQuery, us *auth.UserState, ro *store.RefreshOptions) ([]store.SnapActionResult, []store.AssertionResult, error) {
+		var actionResult []store.SnapActionResult
+
+		snapIDs := map[string]bool{}
+		for _, action := range sa {
+			snapIDs[action.SnapID] = true
+			// throttle refresh requests if this is an auto-refresh
+			if isThrottled[action.SnapID] && ro.Scheduled {
+				continue
+			}
+			info, err := s.fakeStore.lookupRefresh(refreshCand{snapID: action.SnapID})
+			c.Assert(err, IsNil)
+			actionResult = append(actionResult, store.SnapActionResult{Info: info})
+		}
+
+		requests = append(requests, requestRecord{
+			opts:    ro,
+			snapIDs: snapIDs,
+		})
+
+		return actionResult, nil, nil
+	}
+	snapstate.ReplaceStore(s.state, &sto)
+
+	names, tss, err := snapstate.AutoRefresh(context.Background(), s.state)
+	c.Assert(err, IsNil)
+	c.Assert(tss, NotNil)
+	c.Check(names, DeepEquals, []string{"some-other-snap", "some-snap"})
+
+	// check store request was retried
+	c.Check(requests, HasLen, 2)
+
+	// first time, all snaps were requested
+	c.Check(requests[0].snapIDs["some-snap-id"], Equals, true)
+	c.Check(requests[0].snapIDs["some-other-snap-id"], Equals, true)
+	c.Check(requests[0].snapIDs["snap-c-id"], Equals, true)
+	// auto-refresh -> scheduled
+	c.Check(requests[0].opts.Scheduled, Equals, true)
+
+	// second time, only some-other-snap was retried because it
+	// was in old refresh-candidates and was monitored as well
+	c.Check(requests[1].snapIDs["some-snap-id"], Equals, false)
+	c.Check(requests[1].snapIDs["some-other-snap-id"], Equals, true)
+	c.Check(requests[1].snapIDs["snap-c-id"], Equals, false)
+	// retry mimicking manual refresh
+	c.Check(requests[1].opts.Scheduled, Equals, false)
+
+	// check that refresh-candidates in the state were updated
+	var newCands map[string]*snapstate.RefreshCandidate
+	err = s.state.Get("refresh-candidates", &newCands)
+	c.Assert(err, IsNil)
+
+	c.Assert(newCands, HasLen, 2)
+	c.Check(newCands["some-snap"], NotNil)
+	c.Check(newCands["some-other-snap"], NotNil)
+}
+
 func (s *snapmgrTestSuite) TestRefreshCandidatesMergeFlags(c *C) {
 	si := &snap.SideInfo{
 		RealName: "some-snap",

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -11354,20 +11354,7 @@ func (s *snapmgrTestSuite) TestUpdateSetsRestartBoundaries(c *C) {
 	c.Check(linkSnap2.Get("restart-boundary", &boundary), ErrorMatches, `no state entry for key "restart-boundary"`)
 }
 
-type customStore struct {
-	*fakeStore
-
-	customSnapAction func(context.Context, []*store.CurrentSnap, []*store.SnapAction, store.AssertionQuery, *auth.UserState, *store.RefreshOptions) ([]store.SnapActionResult, []store.AssertionResult, error)
-}
-
-func (s customStore) SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, assertQuery store.AssertionQuery, user *auth.UserState, opts *store.RefreshOptions) ([]store.SnapActionResult, []store.AssertionResult, error) {
-	return s.customSnapAction(ctx, currentSnaps, actions, assertQuery, user, opts)
-}
-
-func (s *snapmgrTestSuite) TestUpdateManyRevOptsOrder(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
+func (s *snapmgrTestSuite) testUpdateManyRevOptsOrder(c *C, isThrottled map[string]bool) {
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
 		Sequence: []*snap.SideInfo{
@@ -11397,15 +11384,17 @@ func (s *snapmgrTestSuite) TestUpdateManyRevOptsOrder(c *C) {
 	sto := customStore{fakeStore: s.fakeStore}
 	sto.customSnapAction = func(ctx context.Context, cs []*store.CurrentSnap, sa []*store.SnapAction, aq store.AssertionQuery, us *auth.UserState, ro *store.RefreshOptions) ([]store.SnapActionResult, []store.AssertionResult, error) {
 		if len(sa) == 0 {
-			requestSnapToAction = nil
 			return nil, nil, nil
 		}
 
 		var actionResult []store.SnapActionResult
-		requestSnapToAction = make(map[string]*store.SnapAction, len(sa))
 		for _, action := range sa {
 			requestSnapToAction[action.InstanceName] = action
 
+			// throttle refresh requests if this is an auto-refresh
+			if isThrottled[action.SnapID] && ro.Scheduled {
+				continue
+			}
 			info, err := s.fakeStore.lookupRefresh(refreshCand{snapID: action.SnapID})
 			c.Assert(err, IsNil)
 			actionResult = append(actionResult, store.SnapActionResult{Info: info})
@@ -11437,14 +11426,15 @@ func (s *snapmgrTestSuite) TestUpdateManyRevOptsOrder(c *C) {
 	}
 
 	testOrder := func(names []string) {
-		requestSnapToAction = nil
+		requestSnapToAction = make(map[string]*store.SnapAction, 3)
 		revOpts := getRevOpts(names)
-		_, _, err := snapstate.UpdateMany(context.Background(), s.state, names, revOpts, 0, nil)
+		flags := snapstate.Flags{IsAutoRefresh: isThrottled != nil}
+		_, _, err := snapstate.UpdateMany(context.Background(), s.state, names, revOpts, 0, &flags)
 		c.Assert(err, IsNil)
 		c.Check(requestSnapToAction, NotNil)
-		for _, name := range names {
-			c.Check(requestSnapToAction[name].Revision, Equals, nameToRevOpts[name].Revision, Commentf("snap %q sent revision is incorrect", name))
-			c.Check(requestSnapToAction[name].ValidationSets, DeepEquals, nameToRevOpts[name].ValidationSets, Commentf("snap %q sent validation sets are incorrect", name))
+		for name, action := range requestSnapToAction {
+			c.Check(action.Revision, Equals, nameToRevOpts[name].Revision, Commentf("snap %q sent revision is incorrect", name))
+			c.Check(action.ValidationSets, DeepEquals, nameToRevOpts[name].ValidationSets, Commentf("snap %q sent validation sets are incorrect", name))
 		}
 	}
 
@@ -11513,4 +11503,31 @@ func (s *snapmgrTestSuite) TestSnapdRefreshForRemodel(c *C) {
 	_, err = snapstate.UpdateWithDeviceContext(s.state, "snapd", opts, s.user.ID, snapstate.Flags{}, nil, nil, "")
 	c.Check(err, FitsTypeOf, &snapstate.ChangeConflictError{})
 	c.Check(err, ErrorMatches, "remodeling in progress, no other changes allowed until this is done")
+}
+
+func (s *snapmgrTestSuite) TestUpdateManyRevOptsOrder(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.testUpdateManyRevOptsOrder(c, nil)
+}
+
+func (s *snapmgrTestSuite) TestRefreshCandidatesThrottledRevOptsRemap(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// simulate existing monitored refresh hint from older refresh
+	cands := map[string]*snapstate.RefreshCandidate{
+		"some-other-snap": {Monitored: true},
+		"snap-c":          {Monitored: true},
+	}
+	s.state.Set("refresh-candidates", &cands)
+
+	// simulate store throttling some snaps' during auto-refresh
+	isThrottled := map[string]bool{
+		"some-other-snap-id": true,
+		"snap-c-id":          true,
+	}
+
+	s.testUpdateManyRevOptsOrder(c, isThrottled)
 }

--- a/overlord/snapstate/storehelpers.go
+++ b/overlord/snapstate/storehelpers.go
@@ -613,7 +613,95 @@ func collectCurrentSnaps(snapStates map[string]*SnapState, holds map[string][]st
 	return curSnaps, nil
 }
 
+// refreshCandidates is a wrapper for refreshCandidatesCore.
+//
+// It addresses the case where the store doesn't return refresh candidates for
+// snaps with already existing monitored refresh-candidates due to inconsistent
+// store return being caused by the throttling.
+// A second request is sent for eligible snaps that might have been throttled
+// with the RevisionOptions.Scheduled option turned off.
+//
+// Note: This wrapper is a short term solution and should be removed once a better
+// solution is reached.
 func refreshCandidates(ctx context.Context, st *state.State, names []string, revOpts []*RevisionOptions, user *auth.UserState, opts *store.RefreshOptions) ([]*snap.Info, map[string]*SnapState, map[string]bool, error) {
+	var revOptsByName map[string]*RevisionOptions
+	if revOpts != nil {
+		revOptsByName = make(map[string]*RevisionOptions, len(revOpts))
+		for i, opts := range revOpts {
+			revOptsByName[names[i]] = opts
+		}
+	}
+
+	updates, stateByInstanceName, ignoreValidation, err := refreshCandidatesCore(ctx, st, names, revOpts, user, opts)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	var oldHints map[string]*refreshCandidate
+	if err := st.Get("refresh-candidates", &oldHints); err != nil {
+		if errors.Is(err, &state.NoStateError{}) {
+			// do nothing
+			return updates, stateByInstanceName, ignoreValidation, nil
+		}
+
+		return nil, nil, nil, fmt.Errorf("cannot get refresh-candidates: %v", err)
+	}
+
+	var missingNames []string
+	snapStates, err := All(st)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	for name, hint := range oldHints {
+		if _, ok := snapStates[name]; !ok {
+			continue
+		}
+		if !snapStates[name].IsInstalled() {
+			continue
+		}
+		if !hint.Monitored {
+			continue
+		}
+		hasUpdate := false
+		for _, update := range updates {
+			if update.InstanceName() == name {
+				hasUpdate = true
+				break
+			}
+		}
+		if hasUpdate {
+			continue
+		}
+
+		missingNames = append(missingNames, name)
+	}
+
+	if len(missingNames) > 0 {
+		var missingRevOpts []*RevisionOptions
+		if revOpts != nil {
+			for _, name := range missingNames {
+				missingRevOpts = append(missingRevOpts, revOptsByName[name])
+			}
+		}
+		// mimic manual refresh to avoid throttling.
+		// context: snaps may be throttled by the store to balance load
+		// and therefore may not always receive an update (even if one was
+		// returned before). forcing a manual refresh should be fine since
+		// we already started a pre-download for this snap, so no extra
+		// load is being exerted on the store.
+		opts.Scheduled = false
+		moreUpdates, _, _, err := refreshCandidatesCore(ctx, st, missingNames, missingRevOpts, user, opts)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		updates = append(updates, moreUpdates...)
+	}
+
+	return updates, stateByInstanceName, ignoreValidation, nil
+}
+
+func refreshCandidatesCore(ctx context.Context, st *state.State, names []string, revOpts []*RevisionOptions, user *auth.UserState, opts *store.RefreshOptions) ([]*snap.Info, map[string]*SnapState, map[string]bool, error) {
 	snapStates, err := All(st)
 	if err != nil {
 		return nil, nil, nil, err


### PR DESCRIPTION
This wrapper addresses the case were the store doesn't return refresh candidates for snaps with already existing `refresh-candidates` that are being monitored due to throttling.

A second request is sent for eligible snaps that might have been throttled with the `RevisionOptions.Scheduled` option turned off.

This PR should unblock #13215.
