### PR TITLE
interfaces: update polkit-agent interface to handle new location of polkit-agent-helper-1

### DIFF
--- a/interfaces/builtin/polkit_agent.go
+++ b/interfaces/builtin/polkit_agent.go
@@ -93,11 +93,11 @@ dbus (receive, send)
     peer=(label=unconfined),
 
 # Allow agent to execute the setuid polkit-agent-helper-1 in a subprofile
-/usr/libexec/polkit-agent-helper-1 Cxr -> polkit_agent_helper,
+/usr/lib{exec,/polkit-1}/polkit-agent-helper-1 Cxr -> polkit_agent_helper,
 
 profile polkit_agent_helper (attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
-  /usr/libexec/polkit-agent-helper-1 rm,
+  /usr/lib{exec,/polkit-1}/polkit-agent-helper-1 rm,
 
   # polkit-agent-helper-1 performs PAM authentication, which includes
   # pam-extrausers on Ubuntu Core.
@@ -139,7 +139,7 @@ func init() {
 	registerIface(&commonInterface{
 		name:                  "polkit-agent",
 		summary:               polkitAgentSummary,
-		implicitOnCore:        osutil.FileExists("/usr/libexec/polkit-agent-helper-1"),
+		implicitOnCore:        osutil.FileExists("/usr/libexec/polkit-agent-helper-1") || osutil.FileExists("/usr/lib/polkit-1/polkit-agent-helper-1"),
 		baseDeclarationPlugs:  polkitAgentBaseDeclarationPlugs,
 		baseDeclarationSlots:  polkitAgentBaseDeclarationSlots,
 		connectedPlugAppArmor: polkitAgentConnectedPlugAppArmor,

--- a/interfaces/builtin/polkit_agent_test.go
+++ b/interfaces/builtin/polkit_agent_test.go
@@ -69,7 +69,7 @@ func (s *PolkitAgentSuite) TestName(c *C) {
 func (s *PolkitAgentSuite) TestStaticInfo(c *C) {
 	si := interfaces.StaticInfoOf(s.iface)
 	c.Check(si.ImplicitOnClassic, Equals, false)
-	c.Check(si.ImplicitOnCore, Equals, osutil.FileExists("/usr/libexec/polkit-agent-helper-1"))
+	c.Check(si.ImplicitOnCore, Equals, osutil.FileExists("/usr/libexec/polkit-agent-helper-1") || osutil.FileExists("/usr/lib/polkit-1/polkit-agent-helper-1"))
 }
 
 func (s *PolkitAgentSuite) TestAppArmor(c *C) {


### PR DESCRIPTION
New versions of polkit, such as the one in Ubuntu 23.10 move the polkit-agent-helper-1 executable from `/usr/libexec` to `/usr/lib/polkit-1`. The change can be seen in this file listing from the package:

https://packages.ubuntu.com/mantic/amd64/polkitd/filelist

This PR updates the polkit-agent interface to match the new path.