### PR TITLE
interface: allow nested directories under /sys/devices/platform for gpio paths

### DIFF
--- a/interfaces/builtin/gpio_control.go
+++ b/interfaces/builtin/gpio_control.go
@@ -46,7 +46,7 @@ const gpioControlConnectedPlugAppArmor = `
 /sys/class/gpio/gpio[0-9]*/{active_low,direction,value,edge} rw,
 # apparmor needs the symlink targets which on most platforms the path
 # below (see also PR#12816)
-/sys/devices/platform/*/gpio/gpio[0-9]*/{active_low,direction,value,edge} rw,
+/sys/devices/platform/**/gpio/gpio[0-9]*/{active_low,direction,value,edge} rw,
 `
 
 func init() {


### PR DESCRIPTION
This PR fixes the issue where even with an active gpio-control interface the gpio devices cannot be accessed.

Some devices have their gpio paths under nested directories (e.g. `/sys/devices/platform/<SOC>/<DIR1>/<DIR2>/gpio/gpio10/value`).
