### PR TITLE
tests/nested/manual: correct some reboot messages after reboot code changes

### DIFF
--- a/tests/nested/manual/fde-on-classic/task.yaml
+++ b/tests/nested/manual/fde-on-classic/task.yaml
@@ -88,7 +88,7 @@ execute: |
       remote.push "$snap_filename"
       boot_id=$(tests.nested boot-id)
       # install will exit when waiting for the reboot
-      remote.exec sudo snap install --dangerous "$snap_filename" | MATCH "set to wait until a manual system restart allows to continue"
+      remote.exec sudo snap install --dangerous "$snap_filename" | MATCH "Task set to wait until a system restart allows to continue"
 
       # Check that a reboot notification was setup
       remote.exec test -f /run/reboot-required

--- a/tests/nested/manual/muinstaller-real/task.yaml
+++ b/tests/nested/manual/muinstaller-real/task.yaml
@@ -292,7 +292,7 @@ execute: |
       # to not use it at all.
       REMOTE_CHG_ID=$(remote.exec "sudo snap install --no-wait ${snap_name}_*.snap")
       # Wait until we stall in the connection of interface as we wait for a reboot
-      retry --wait 1 -n 120 sh -c "remote.exec \"snap change $REMOTE_CHG_ID | grep -E 'Task set to wait until a manual system restart'\""
+      retry --wait 1 -n 120 sh -c "remote.exec \"snap change $REMOTE_CHG_ID | grep -E 'Task set to wait until a system restart allows to continue'\""
 
       # Check that a reboot notification was setup
       remote.exec test -f /run/reboot-required


### PR DESCRIPTION
Some of the reboot messages for the tasks changed with the restart code changes. Update them to make the tests pass.