### PR TITLE
tests/core20-boot-config-update: wait for the reboot before the watch

### DIFF
--- a/tests/nested/manual/core20-boot-config-update/task.yaml
+++ b/tests/nested/manual/core20-boot-config-update/task.yaml
@@ -92,7 +92,6 @@ execute: |
   echo "Install new (unasserted) snapd and wait for reboot/change finishing"
   boot_id="$( tests.nested boot-id )"
   REMOTE_CHG_ID=$(remote.exec sudo snap install --dangerous snapd-boot-config-update.snap --no-wait)
-  remote.exec sudo snap watch "${REMOTE_CHG_ID}"
   if [ "$VARIANT" != "gadget-full" ]; then
     # reboot is automatically requested by snapd only if part of the command
     # line is changed, in case of gadget overriding the command line fully
@@ -100,6 +99,7 @@ execute: |
     # is not used, hence there is no resealing and no reboot
     remote.wait-for reboot "${boot_id}"
   fi
+  remote.exec sudo snap watch "${REMOTE_CHG_ID}"
   
   echo "check boot assets have been updated"
   remote.exec "sudo cat /boot/grub/grub.cfg" | MATCH "Snapd-Boot-Config-Edition: 4"

--- a/tests/nested/manual/core20-boot-config-update/task.yaml
+++ b/tests/nested/manual/core20-boot-config-update/task.yaml
@@ -92,15 +92,11 @@ execute: |
   echo "Install new (unasserted) snapd and wait for reboot/change finishing"
   boot_id="$( tests.nested boot-id )"
   REMOTE_CHG_ID=$(remote.exec sudo snap install --dangerous snapd-boot-config-update.snap --no-wait)
-  if [ "$VARIANT" != "gadget-full" ]; then
-    # reboot is automatically requested by snapd only if part of the command
-    # line is changed, in case of gadget overriding the command line fully
-    # (gadget-full variant) the static part of the command line from new snapd
-    # is not used, hence there is no resealing and no reboot
-    remote.wait-for reboot "${boot_id}"
-  fi
+  # reboot is automatically requested by snapd in case grub.cfg changes
+  remote.wait-for reboot "${boot_id}"
+
   remote.exec sudo snap watch "${REMOTE_CHG_ID}"
-  
+
   echo "check boot assets have been updated"
   remote.exec "sudo cat /boot/grub/grub.cfg" | MATCH "Snapd-Boot-Config-Edition: 4"
   remote.exec "sudo cat /boot/grub/grub.cfg" | MATCH "set snapd_static_cmdline_args='.*bootassetstesting'"


### PR DESCRIPTION
In some cases the reboot was happening while running "snap watch", it makes more sense to run this after the reboot to ensure that the change has finished.