### PR TITLE
i/builtin: fix u2f tests that was broken by adding new device

### DIFF
--- a/interfaces/builtin/u2f_devices_test.go
+++ b/interfaces/builtin/u2f_devices_test.go
@@ -89,7 +89,7 @@ func (s *u2fDevicesInterfaceSuite) TestAppArmorSpec(c *C) {
 func (s *u2fDevicesInterfaceSuite) TestUDevSpec(c *C) {
 	spec := &udev.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 27)
+	c.Assert(spec.Snippets(), HasLen, 28)
 	c.Assert(spec.Snippets(), testutil.Contains, `# u2f-devices
 # Yubico YubiKey
 SUBSYSTEM=="hidraw", KERNEL=="hidraw*", ATTRS{idVendor}=="1050", ATTRS{idProduct}=="0113|0114|0115|0116|0120|0121|0200|0402|0403|0406|0407|0410", TAG+="snap_consumer_app"`)


### PR DESCRIPTION
5238d0581c9ed5ca3b0fdd80c63ac02628326ded broke the test by adding a new device. This should fix it.