### PR TITLE
i/builtin: update gpio profile to match pattern that contains multiple subdirectories under /sys/devices/platform

### DIFF
--- a/interfaces/builtin/gpio_control.go
+++ b/interfaces/builtin/gpio_control.go
@@ -46,7 +46,7 @@ const gpioControlConnectedPlugAppArmor = `
 /sys/class/gpio/gpio[0-9]*/{active_low,direction,value,edge} rw,
 # apparmor needs the symlink targets which on most platforms the path
 # below (see also PR#12816)
-/sys/devices/platform/*/gpio/gpio[0-9]*/{active_low,direction,value,edge} rw,
+/sys/devices/platform/**/gpio/gpio[0-9]*/{active_low,direction,value,edge} rw,
 `
 
 func init() {


### PR DESCRIPTION
A followup from #12816. This change will allow access to devices that are in any number of sub-directories in `/sys/devices/platform`. Unsure if this is the change we want, might be too liberal.

Example of paths that do not match the current pattern:
```
/sys/devices/platform/INT3452:00/gpiochip/gpio/gpio123
/sys/devices/platform/soc@0/soc@0:bus@30000000/30200000.gpio/gpiochip0/gpio/gpio123
```