### PR TITLE
i/b/fwupd.go: add access sysfs attributes needed by amdgpu

### DIFF
--- a/interfaces/builtin/fwupd.go
+++ b/interfaces/builtin/fwupd.go
@@ -146,6 +146,10 @@ const fwupdPermanentSlotAppArmor = `
   /sys/devices/**/drm r,
   /sys/devices/**/drm/** r,
 
+  # Required by plugin amdgpu
+  /sys/devices/**/psp_vbflash rw,
+  /sys/devices/**/psp_vbflash_status r,
+
   # DBus accesses
   #include <abstractions/dbus-strict>
   dbus (send)


### PR DESCRIPTION
Added in upstream: fwupd/fwupd#6236