### PR TITLE
wrappers: restructure service code, and split into an internal package

### DIFF
--- a/wrappers/core18.go
+++ b/wrappers/core18.go
@@ -34,13 +34,13 @@ import (
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/systemd"
+	"github.com/snapcore/snapd/wrappers/internal"
 )
 
 // catches units that run /usr/bin/snap (with args), or things in /usr/lib/snapd/
 var execStartRe = regexp.MustCompile(`(?m)^ExecStart=(/usr/bin/snap\s+.*|/usr/lib/snapd/.*)$`)
 
-// snapdToolingMountUnit is the name of the mount unit that makes the
-const SnapdToolingMountUnit = "usr-lib-snapd.mount"
+const SnapdToolingMountUnit = internal.SnapdToolingMountUnit
 
 func snapdSkipStart(content []byte) bool {
 	return bytes.Contains(content, []byte("X-Snapd-Snap: do-not-start"))

--- a/wrappers/core18.go
+++ b/wrappers/core18.go
@@ -34,13 +34,13 @@ import (
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/systemd"
-	"github.com/snapcore/snapd/wrappers/internal"
 )
 
 // catches units that run /usr/bin/snap (with args), or things in /usr/lib/snapd/
 var execStartRe = regexp.MustCompile(`(?m)^ExecStart=(/usr/bin/snap\s+.*|/usr/lib/snapd/.*)$`)
 
-const SnapdToolingMountUnit = internal.SnapdToolingMountUnit
+// snapdToolingMountUnit is the name of the mount unit that provides the snapd tooling
+const SnapdToolingMountUnit = "usr-lib-snapd.mount"
 
 func snapdSkipStart(content []byte) bool {
 	return bytes.Contains(content, []byte("X-Snapd-Snap: do-not-start"))

--- a/wrappers/export_test.go
+++ b/wrappers/export_test.go
@@ -27,11 +27,6 @@ import (
 
 // some internal helper exposed for testing
 var (
-	// services
-	GenerateSnapServiceFile = generateSnapServiceFile
-	GenerateSnapSocketFiles = generateSnapSocketFiles
-	GenerateSnapTimerFile   = generateSnapTimerFile
-
 	// dbus
 	GenerateDBusActivationFile = generateDBusActivationFile
 
@@ -41,14 +36,9 @@ var (
 	RewriteIconLine        = rewriteIconLine
 	IsValidDesktopFileLine = isValidDesktopFileLine
 
-	// timers
-	GenerateOnCalendarSchedules = generateOnCalendarSchedules
-
 	// icons
 	FindIconFiles = findIconFiles
 )
-
-type GenerateSnapServicesOptions = generateSnapServicesOptions
 
 func MockKillWait(wait time.Duration) (restore func()) {
 	oldKillWait := killWait

--- a/wrappers/internal/export_test.go
+++ b/wrappers/internal/export_test.go
@@ -1,0 +1,24 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package internal
+
+var (
+	GenerateOnCalendarSchedules = generateOnCalendarSchedules
+)

--- a/wrappers/internal/journal_conf_gen.go
+++ b/wrappers/internal/journal_conf_gen.go
@@ -1,0 +1,77 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package internal
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/snapcore/snapd/snap/quota"
+)
+
+func formatJournalSizeConf(grp *quota.Group) string {
+	if grp.JournalLimit.Size == 0 {
+		return ""
+	}
+	return fmt.Sprintf(`SystemMaxUse=%[1]d
+RuntimeMaxUse=%[1]d
+`, grp.JournalLimit.Size)
+}
+
+func formatJournalRateConf(grp *quota.Group) string {
+	if !grp.JournalLimit.RateEnabled {
+		return ""
+	}
+	return fmt.Sprintf(`RateLimitIntervalSec=%dus
+RateLimitBurst=%d
+`, grp.JournalLimit.RatePeriod.Microseconds(), grp.JournalLimit.RateCount)
+}
+
+func GenerateQuotaJournaldConfFile(grp *quota.Group) []byte {
+	if grp.JournalLimit == nil {
+		return nil
+	}
+
+	sizeOptions := formatJournalSizeConf(grp)
+	rateOptions := formatJournalRateConf(grp)
+	// Set Storage=auto for all journal namespaces we create. This is
+	// the setting for the default namespace, and 'persistent' is the default
+	// setting for all namespaces. However we want namespaces to honor the
+	// journal.persistent setting, and this only works if Storage is set
+	// to 'auto'.
+	// See https://www.freedesktop.org/software/systemd/man/journald.conf.html#Storage=
+	template := `# Journald configuration for snap quota group %[1]s
+[Journal]
+Storage=auto
+`
+	buf := bytes.Buffer{}
+	fmt.Fprintf(&buf, template, grp.Name)
+	fmt.Fprint(&buf, sizeOptions, rateOptions)
+	return buf.Bytes()
+}
+
+func GenerateQuotaJournalServiceFile(grp *quota.Group) []byte {
+	buf := bytes.Buffer{}
+	template := `[Service]
+LogsDirectory=
+`
+	fmt.Fprint(&buf, template)
+	return buf.Bytes()
+}

--- a/wrappers/internal/service_slice_gen.go
+++ b/wrappers/internal/service_slice_gen.go
@@ -1,0 +1,112 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package internal
+
+import (
+	"bytes"
+	"fmt"
+	"runtime"
+
+	"github.com/snapcore/snapd/snap/quota"
+	"github.com/snapcore/snapd/strutil"
+)
+
+func min(a, b int) int {
+	if b < a {
+		return b
+	}
+	return a
+}
+
+func formatCpuGroupSlice(grp *quota.Group) string {
+	header := `# Always enable cpu accounting, so the following cpu quota options have an effect
+CPUAccounting=true
+`
+	buf := bytes.NewBufferString(header)
+
+	count, percentage := grp.GetLocalCPUQuota()
+	if percentage != 0 {
+		// convert the number of cores and the allowed percentage
+		// to the systemd specific format.
+		cpuQuotaSnap := count * percentage
+		cpuQuotaMax := runtime.NumCPU() * 100
+
+		// The CPUQuota setting is only available since systemd 213
+		fmt.Fprintf(buf, "CPUQuota=%d%%\n", min(cpuQuotaSnap, cpuQuotaMax))
+	}
+
+	if grp.CPULimit != nil && len(grp.CPULimit.CPUSet) != 0 {
+		allowedCpusValue := strutil.IntsToCommaSeparated(grp.CPULimit.CPUSet)
+		fmt.Fprintf(buf, "AllowedCPUs=%s\n", allowedCpusValue)
+	}
+
+	buf.WriteString("\n")
+	return buf.String()
+}
+
+func formatMemoryGroupSlice(grp *quota.Group) string {
+	header := `# Always enable memory accounting otherwise the MemoryMax setting does nothing.
+MemoryAccounting=true
+`
+	buf := bytes.NewBufferString(header)
+	if grp.MemoryLimit != 0 {
+		valuesTemplate := `MemoryMax=%[1]d
+# for compatibility with older versions of systemd
+MemoryLimit=%[1]d
+
+`
+		fmt.Fprintf(buf, valuesTemplate, grp.MemoryLimit)
+	}
+	return buf.String()
+}
+
+func formatTaskGroupSlice(grp *quota.Group) string {
+	header := `# Always enable task accounting in order to be able to count the processes/
+# threads, etc for a slice
+TasksAccounting=true
+`
+	buf := bytes.NewBufferString(header)
+
+	if grp.ThreadLimit != 0 {
+		fmt.Fprintf(buf, "TasksMax=%d\n", grp.ThreadLimit)
+	}
+	return buf.String()
+}
+
+// GenerateQuotaSliceUnitFile generates a systemd slice unit definition for the
+// specified quota group.
+func GenerateQuotaSliceUnitFile(grp *quota.Group) []byte {
+	buf := bytes.Buffer{}
+
+	cpuOptions := formatCpuGroupSlice(grp)
+	memoryOptions := formatMemoryGroupSlice(grp)
+	taskOptions := formatTaskGroupSlice(grp)
+	template := `[Unit]
+Description=Slice for snap quota group %[1]s
+Before=slices.target
+X-Snappy=yes
+
+[Slice]
+`
+
+	fmt.Fprintf(&buf, template, grp.Name)
+	fmt.Fprint(&buf, cpuOptions, memoryOptions, taskOptions)
+	return buf.Bytes()
+}

--- a/wrappers/internal/service_socket_gen.go
+++ b/wrappers/internal/service_socket_gen.go
@@ -1,0 +1,129 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package internal
+
+import (
+	"bytes"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/osutil/sys"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/systemd"
+)
+
+func renderListenStream(socket *snap.SocketInfo) string {
+	s := socket.App.Snap
+	listenStream := socket.ListenStream
+	switch socket.App.DaemonScope {
+	case snap.SystemDaemon:
+		listenStream = strings.Replace(listenStream, "$SNAP_DATA", s.DataDir(), -1)
+		// TODO: when we support User/Group in the generated
+		// systemd unit, adjust this accordingly
+		serviceUserUid := sys.UserID(0)
+		runtimeDir := s.UserXdgRuntimeDir(serviceUserUid)
+		listenStream = strings.Replace(listenStream, "$XDG_RUNTIME_DIR", runtimeDir, -1)
+		listenStream = strings.Replace(listenStream, "$SNAP_COMMON", s.CommonDataDir(), -1)
+	case snap.UserDaemon:
+		// TODO: use SnapDirOpts here. User daemons are also an experimental
+		// feature so, for simplicity, we can not pass opts here for now
+		listenStream = strings.Replace(listenStream, "$SNAP_USER_DATA", s.UserDataDir("%h", nil), -1)
+		listenStream = strings.Replace(listenStream, "$SNAP_USER_COMMON", s.UserCommonDataDir("%h", nil), -1)
+		// FIXME: find some way to share code with snap.UserXdgRuntimeDir()
+		listenStream = strings.Replace(listenStream, "$XDG_RUNTIME_DIR", fmt.Sprintf("%%t/snap.%s", s.InstanceName()), -1)
+	default:
+		panic("unknown snap.DaemonScope")
+	}
+	return listenStream
+}
+
+func generateSnapServiceSocketUnitFile(appInfo *snap.AppInfo, socketName string) []byte {
+	socketTemplate := `[Unit]
+# Auto-generated, DO NOT EDIT
+Description=Socket {{.SocketName}} for snap application {{.App.Snap.InstanceName}}.{{.App.Name}}
+{{- if .MountUnit}}
+Requires={{.MountUnit}}
+After={{.MountUnit}}
+{{- end}}
+X-Snappy=yes
+
+[Socket]
+Service={{.ServiceFileName}}
+FileDescriptorName={{.SocketInfo.Name}}
+ListenStream={{.ListenStream}}
+{{- if .SocketInfo.SocketMode}}
+SocketMode={{.SocketInfo.SocketMode | printf "%04o"}}
+{{- end}}
+
+[Install]
+WantedBy={{.SocketsTarget}}
+`
+	var templateOut bytes.Buffer
+	t := template.Must(template.New("socket-wrapper").Parse(socketTemplate))
+
+	socket := appInfo.Sockets[socketName]
+	listenStream := renderListenStream(socket)
+	wrapperData := struct {
+		App             *snap.AppInfo
+		ServiceFileName string
+		SocketsTarget   string
+		MountUnit       string
+		SocketName      string
+		SocketInfo      *snap.SocketInfo
+		ListenStream    string
+	}{
+		App:             appInfo,
+		ServiceFileName: filepath.Base(appInfo.ServiceFile()),
+		SocketsTarget:   systemd.SocketsTarget,
+		SocketName:      socketName,
+		SocketInfo:      socket,
+		ListenStream:    listenStream,
+	}
+	switch appInfo.DaemonScope {
+	case snap.SystemDaemon:
+		wrapperData.MountUnit = filepath.Base(systemd.MountUnitPath(appInfo.Snap.MountDir()))
+	case snap.UserDaemon:
+		// nothing
+	default:
+		panic("unknown snap.DaemonScope")
+	}
+
+	if err := t.Execute(&templateOut, wrapperData); err != nil {
+		// this can never happen, except we forget a variable
+		logger.Panicf("Unable to execute template: %v", err)
+	}
+
+	return templateOut.Bytes()
+}
+
+func GenerateSnapSocketUnitFiles(app *snap.AppInfo) (map[string][]byte, error) {
+	if err := snap.ValidateApp(app); err != nil {
+		return nil, err
+	}
+
+	socketFiles := make(map[string][]byte)
+	for name := range app.Sockets {
+		socketFiles[name] = generateSnapServiceSocketUnitFile(app, name)
+	}
+	return socketFiles, nil
+}

--- a/wrappers/internal/service_socket_gen_test.go
+++ b/wrappers/internal/service_socket_gen_test.go
@@ -1,0 +1,115 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package internal_test
+
+import (
+	"fmt"
+	"strings"
+
+	. "gopkg.in/check.v1"
+
+	_ "github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+	"github.com/snapcore/snapd/wrappers/internal"
+)
+
+type serviceSocketUnitGenSuite struct {
+	testutil.BaseTest
+}
+
+var _ = Suite(&serviceSocketUnitGenSuite{})
+
+func (s *serviceSocketUnitGenSuite) TestGenerateSnapServiceWithSockets(c *C) {
+	const sock1ExpectedFmt = `[Unit]
+# Auto-generated, DO NOT EDIT
+Description=Socket sock1 for snap application some-snap.app
+Requires=%s-some\x2dsnap-44.mount
+After=%s-some\x2dsnap-44.mount
+X-Snappy=yes
+
+[Socket]
+Service=snap.some-snap.app.service
+FileDescriptorName=sock1
+ListenStream=%s/sock1.socket
+SocketMode=0666
+
+[Install]
+WantedBy=sockets.target
+`
+	const sock2ExpectedFmt = `[Unit]
+# Auto-generated, DO NOT EDIT
+Description=Socket sock2 for snap application some-snap.app
+Requires=%s-some\x2dsnap-44.mount
+After=%s-some\x2dsnap-44.mount
+X-Snappy=yes
+
+[Socket]
+Service=snap.some-snap.app.service
+FileDescriptorName=sock2
+ListenStream=%s/sock2.socket
+
+[Install]
+WantedBy=sockets.target
+`
+
+	si := &snap.Info{
+		SuggestedName: "some-snap",
+		Version:       "1.0",
+		SideInfo:      snap.SideInfo{Revision: snap.R(44)},
+	}
+	service := &snap.AppInfo{
+		Snap:        si,
+		Name:        "app",
+		Command:     "bin/foo start",
+		Daemon:      "simple",
+		DaemonScope: snap.SystemDaemon,
+		Plugs:       map[string]*snap.PlugInfo{"network-bind": {Interface: "network-bind"}},
+		Sockets: map[string]*snap.SocketInfo{
+			"sock1": {
+				Name:         "sock1",
+				ListenStream: "$SNAP_DATA/sock1.socket",
+				SocketMode:   0666,
+			},
+			"sock2": {
+				Name:         "sock2",
+				ListenStream: "$SNAP_DATA/sock2.socket",
+			},
+		},
+	}
+	service.Sockets["sock1"].App = service
+	service.Sockets["sock2"].App = service
+
+	sock1Expected := fmt.Sprintf(sock1ExpectedFmt, mountUnitPrefix, mountUnitPrefix, si.DataDir())
+	sock2Expected := fmt.Sprintf(sock2ExpectedFmt, mountUnitPrefix, mountUnitPrefix, si.DataDir())
+
+	generatedWrapper, err := internal.GenerateSnapServiceUnitFile(service, nil)
+	c.Assert(err, IsNil)
+	c.Assert(strings.Contains(string(generatedWrapper), "[Install]"), Equals, false)
+	c.Assert(strings.Contains(string(generatedWrapper), "WantedBy=multi-user.target"), Equals, false)
+
+	generatedSockets, err := internal.GenerateSnapSocketUnitFiles(service)
+	c.Assert(err, IsNil)
+	c.Assert(generatedSockets, HasLen, 2)
+	c.Assert(generatedSockets, DeepEquals, map[string][]byte{
+		"sock1": []byte(sock1Expected),
+		"sock2": []byte(sock2Expected),
+	})
+}

--- a/wrappers/internal/service_status.go
+++ b/wrappers/internal/service_status.go
@@ -1,0 +1,142 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package internal
+
+import (
+	"path/filepath"
+	"sort"
+
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/systemd"
+)
+
+// ServiceStatus represents the status of a service, and any of its activation
+// service units. It also provides a method isEnabled which can determine the true
+// enable status for services that are activated.
+type ServiceStatus struct {
+	name        string
+	service     *systemd.UnitStatus
+	activators  []*systemd.UnitStatus
+	slotEnabled bool
+}
+
+func (s *ServiceStatus) Name() string {
+	return s.name
+}
+
+func (s *ServiceStatus) ServiceUnitStatus() *systemd.UnitStatus {
+	return s.service
+}
+
+func (s *ServiceStatus) IsEnabled() bool {
+	// If the service is slot activated, it cannot be disabled and thus always
+	// is enabled.
+	if s.slotEnabled {
+		return true
+	}
+
+	// If there are no activator units, then return status of the
+	// primary service.
+	if len(s.activators) == 0 {
+		return s.service.Enabled
+	}
+
+	// Just a single of those activators need to be enabled for us
+	// to report the service as enabled.
+	for _, a := range s.activators {
+		if a.Enabled {
+			return true
+		}
+	}
+	return false
+}
+
+func appServiceUnitsMany(apps []*snap.AppInfo) []string {
+	var allUnits []string
+	for _, app := range apps {
+		if !app.IsService() {
+			continue
+		}
+		// TODO: handle user daemons
+		if app.DaemonScope != snap.SystemDaemon {
+			continue
+		}
+		svc, activators := SnapServiceUnits(app)
+		allUnits = append(allUnits, svc)
+		allUnits = append(allUnits, activators...)
+	}
+	return allUnits
+}
+
+func serviceIsSlotActivated(app *snap.AppInfo) bool {
+	return len(app.ActivatesOn) > 0
+}
+
+func QueryServiceStatusMany(sysd systemd.Systemd, apps []*snap.AppInfo) ([]*ServiceStatus, error) {
+	allUnits := appServiceUnitsMany(apps)
+	unitStatuses, err := sysd.Status(allUnits)
+	if err != nil {
+		return nil, err
+	}
+
+	var appStatuses []*ServiceStatus
+	var statusIndex int
+	for _, app := range apps {
+		if !app.IsService() {
+			continue
+		}
+		// TODO: handle user daemons
+		if app.DaemonScope != snap.SystemDaemon {
+			continue
+		}
+
+		// This builds on the principle that sysd.Status returns service unit statuses
+		// in the exact same order we requested them in.
+		_, activators := SnapServiceUnits(app)
+		svcSt := &ServiceStatus{
+			name:        app.Name,
+			service:     unitStatuses[statusIndex],
+			slotEnabled: serviceIsSlotActivated(app),
+		}
+		if len(activators) > 0 {
+			svcSt.activators = unitStatuses[statusIndex+1 : statusIndex+1+len(activators)]
+		}
+		appStatuses = append(appStatuses, svcSt)
+		statusIndex += 1 + len(activators)
+	}
+	return appStatuses, nil
+}
+
+// SnapServiceUnits returns the service unit of the primary service, and a list
+// of service units for the activation services.
+func SnapServiceUnits(app *snap.AppInfo) (service string, activators []string) {
+	// Add application sockets
+	for _, socket := range app.Sockets {
+		activators = append(activators, filepath.Base(socket.File()))
+	}
+	// Sort the results from sockets for consistency
+	sort.Strings(activators)
+
+	// Add application timer
+	if app.Timer != nil {
+		activators = append(activators, filepath.Base(app.Timer.File()))
+	}
+	return app.ServiceName(), activators
+}

--- a/wrappers/internal/service_timer_gen.go
+++ b/wrappers/internal/service_timer_gen.go
@@ -1,0 +1,310 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package internal
+
+import (
+	"bytes"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/randutil"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/systemd"
+	"github.com/snapcore/snapd/timeutil"
+)
+
+func makeAbbrevWeekdays(start time.Weekday, end time.Weekday) []string {
+	out := make([]string, 0, 7)
+	for w := start; w%7 != (end + 1); w++ {
+		out = append(out, time.Weekday(w % 7).String()[0:3])
+	}
+	return out
+}
+
+// daysRange generates a string representing a continuous range between given
+// day numbers, which due to compatiblilty with old systemd version uses a
+// verbose syntax of x,y,z instead of x..z
+func daysRange(start, end uint) string {
+	var buf bytes.Buffer
+	for i := start; i <= end; i++ {
+		buf.WriteString(strconv.FormatInt(int64(i), 10))
+		if i < end {
+			buf.WriteRune(',')
+		}
+	}
+	return buf.String()
+}
+
+// generateOnCalendarSchedules converts a schedule into OnCalendar schedules
+// suitable for use in systemd *.timer units using systemd.time(7)
+// https://www.freedesktop.org/software/systemd/man/systemd.time.html
+// XXX: old systemd versions do not support x..y ranges
+func generateOnCalendarSchedules(schedule []*timeutil.Schedule) []string {
+	calendarEvents := make([]string, 0, len(schedule))
+	for _, sched := range schedule {
+		days := make([]string, 0, len(sched.WeekSpans))
+		for _, week := range sched.WeekSpans {
+			abbrev := strings.Join(makeAbbrevWeekdays(week.Start.Weekday, week.End.Weekday), ",")
+
+			if week.Start.Pos == timeutil.EveryWeek && week.End.Pos == timeutil.EveryWeek {
+				// eg: mon, mon-fri, fri-mon
+				days = append(days, fmt.Sprintf("%s *-*-*", abbrev))
+				continue
+			}
+			// examples:
+			// mon1 - Mon *-*-1..7 (Monday during the first 7 days)
+			// fri1 - Fri *-*-1..7 (Friday during the first 7 days)
+
+			// entries below will make systemd timer expire more
+			// frequently than the schedule suggests, however snap
+			// runner evaluates current time and gates the actual
+			// action
+			//
+			// mon1-tue - *-*-1..7 *-*-8 (anchored at first
+			// Monday; Monday happens during the 7 days,
+			// Tuesday can possibly happen on the 8th day if
+			// the month started on Tuesday)
+			//
+			// mon-tue1 - *-*~1 *-*-1..7 (anchored at first
+			// Tuesday; matching Monday can happen on the
+			// last day of previous month if Tuesday is the
+			// 1st)
+			//
+			// mon5-tue - *-*~1..7 *-*-1 (anchored at last
+			// Monday, the matching Tuesday can still happen
+			// within the last 7 days, or on the 1st of the
+			// next month)
+			//
+			// fri4-mon - *-*-22-31 *-*-1..7 (anchored at 4th
+			// Friday, can span onto the next month, extreme case in
+			// February when 28th is Friday)
+			//
+			// XXX: since old versions of systemd, eg. 229 available
+			// in 16.04 does not support x..y ranges, days need to
+			// be enumerated like so:
+			// Mon *-*-1..7 -> Mon *-*-1,2,3,4,5,6,7
+			//
+			// XXX: old systemd versions do not support the last n
+			// days syntax eg, *-*~1, thus the range needs to be
+			// generated in more verbose way like so:
+			// Mon *-*~1..7 -> Mon *-*-22,23,24,25,26,27,28,29,30,31
+			// (22-28 is the last week, but the month can have
+			// anywhere from 28 to 31 days)
+			//
+			startPos := week.Start.Pos
+			endPos := startPos
+			if !week.AnchoredAtStart() {
+				startPos = week.End.Pos
+				endPos = startPos
+			}
+			startDay := (startPos-1)*7 + 1
+			endDay := (endPos) * 7
+
+			if week.IsSingleDay() {
+				// single day, can use the 'weekday' filter
+				if startPos == timeutil.LastWeek {
+					// last week of a month, which can be
+					// 22-28 in case of February, while
+					// month can have between 28 and 31 days
+					days = append(days,
+						fmt.Sprintf("%s *-*-%s", abbrev, daysRange(22, 31)))
+				} else {
+					days = append(days,
+						fmt.Sprintf("%s *-*-%s", abbrev, daysRange(startDay, endDay)))
+				}
+				continue
+			}
+
+			if week.AnchoredAtStart() {
+				// explore the edge cases first
+				switch startPos {
+				case timeutil.LastWeek:
+					// starts in the last week of the month and
+					// possibly spans into the first week of the
+					// next month;
+					// month can have between 28 and 31
+					// days
+					days = append(days,
+						// trailing 29-31 that are not part of a full week
+						fmt.Sprintf("*-*-%s", daysRange(29, 31)),
+						fmt.Sprintf("*-*-%s", daysRange(1, 7)))
+				case 4:
+					// a range in the 4th week can span onto
+					// the next week, which is either 28-31
+					// or in extreme case (eg. February with
+					// 28 days) 1-7 of the next month
+					days = append(days,
+						// trailing 29-31 that are not part of a full week
+						fmt.Sprintf("*-*-%s", daysRange(29, 31)),
+						fmt.Sprintf("*-*-%s", daysRange(1, 7)))
+				default:
+					// can possibly spill into the next week
+					days = append(days,
+						fmt.Sprintf("*-*-%s", daysRange(startDay+7, endDay+7)))
+				}
+
+				if startDay < 28 {
+					days = append(days,
+						fmt.Sprintf("*-*-%s", daysRange(startDay, endDay)))
+				} else {
+					// from the end of the month
+					days = append(days,
+						fmt.Sprintf("*-*-%s", daysRange(startDay-7, endDay-7)))
+				}
+			} else {
+				switch endPos {
+				case timeutil.LastWeek:
+					// month can have between 28 and 31
+					// days, add trailing 29-31 that are not
+					// part of a full week
+					days = append(days, fmt.Sprintf("*-*-%s", daysRange(29, 31)))
+				case 1:
+					// possibly spans from the last week of the
+					// previous month and ends in the first week of
+					// current month
+					days = append(days, fmt.Sprintf("*-*-%s", daysRange(22, 31)))
+				default:
+					// can possibly spill into the previous week
+					days = append(days,
+						fmt.Sprintf("*-*-%s", daysRange(startDay-7, endDay-7)))
+				}
+				if endDay < 28 {
+					days = append(days,
+						fmt.Sprintf("*-*-%s", daysRange(startDay, endDay)))
+				} else {
+					days = append(days,
+						fmt.Sprintf("*-*-%s", daysRange(startDay-7, endDay-7)))
+				}
+			}
+		}
+
+		if len(days) == 0 {
+			// no weekday spec, meaning the timer runs every day
+			days = []string{"*-*-*"}
+		}
+
+		startTimes := make([]string, 0, len(sched.ClockSpans))
+		for _, clocks := range sched.ClockSpans {
+			// use expanded clock spans
+			for _, span := range clocks.ClockSpans() {
+				when := span.Start
+				if span.Spread {
+					length := span.End.Sub(span.Start)
+					if length < 0 {
+						// span Start wraps around, so we have '00:00.Sub(23:45)'
+						length = -length
+					}
+					if length > 5*time.Minute {
+						// replicate what timeutil.Next() does
+						// and cut some time at the end of the
+						// window so that events do not happen
+						// directly one after another
+						length -= 5 * time.Minute
+					}
+					when = when.Add(randutil.RandomDuration(length))
+				}
+				if when.Hour == 24 {
+					// 24:00 for us means the other end of
+					// the day, for systemd we need to
+					// adjust it to the 0-23 hour range
+					when.Hour -= 24
+				}
+
+				startTimes = append(startTimes, when.String())
+			}
+		}
+
+		for _, day := range days {
+			if len(startTimes) == 0 {
+				// current schedule is days only
+				calendarEvents = append(calendarEvents, day)
+				continue
+			}
+
+			for _, startTime := range startTimes {
+				calendarEvents = append(calendarEvents, fmt.Sprintf("%s %s", day, startTime))
+			}
+		}
+	}
+	return calendarEvents
+}
+
+func GenerateSnapServiceTimerUnitFile(app *snap.AppInfo) ([]byte, error) {
+	timerTemplate := `[Unit]
+# Auto-generated, DO NOT EDIT
+Description=Timer {{.TimerName}} for snap application {{.App.Snap.InstanceName}}.{{.App.Name}}
+{{- if .MountUnit}}
+Requires={{.MountUnit}}
+After={{.MountUnit}}
+{{- end}}
+X-Snappy=yes
+
+[Timer]
+Unit={{.ServiceFileName}}
+{{ range .Schedules }}OnCalendar={{ . }}
+{{ end }}
+[Install]
+WantedBy={{.TimersTarget}}
+`
+	var templateOut bytes.Buffer
+	t := template.Must(template.New("timer-wrapper").Parse(timerTemplate))
+
+	timerSchedule, err := timeutil.ParseSchedule(app.Timer.Timer)
+	if err != nil {
+		return nil, err
+	}
+
+	schedules := generateOnCalendarSchedules(timerSchedule)
+
+	wrapperData := struct {
+		App             *snap.AppInfo
+		ServiceFileName string
+		TimersTarget    string
+		TimerName       string
+		MountUnit       string
+		Schedules       []string
+	}{
+		App:             app,
+		ServiceFileName: filepath.Base(app.ServiceFile()),
+		TimersTarget:    systemd.TimersTarget,
+		TimerName:       app.Name,
+		Schedules:       schedules,
+	}
+	switch app.DaemonScope {
+	case snap.SystemDaemon:
+		wrapperData.MountUnit = filepath.Base(systemd.MountUnitPath(app.Snap.MountDir()))
+	case snap.UserDaemon:
+		// nothing
+	default:
+		panic("unknown snap.DaemonScope")
+	}
+
+	if err := t.Execute(&templateOut, wrapperData); err != nil {
+		// this can never happen, except we forget a variable
+		logger.Panicf("Unable to execute template: %v", err)
+	}
+
+	return templateOut.Bytes(), nil
+}

--- a/wrappers/internal/service_timer_gen_test.go
+++ b/wrappers/internal/service_timer_gen_test.go
@@ -1,0 +1,289 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package internal_test
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	. "gopkg.in/check.v1"
+
+	_ "github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+	"github.com/snapcore/snapd/timeout"
+	"github.com/snapcore/snapd/timeutil"
+	"github.com/snapcore/snapd/wrappers/internal"
+)
+
+type serviceTimerUnitGenSuite struct {
+	testutil.BaseTest
+}
+
+var _ = Suite(&serviceTimerUnitGenSuite{})
+
+func (s *serviceTimerUnitGenSuite) TestServiceTimerUnit(c *C) {
+	const expectedServiceFmt = `[Unit]
+# Auto-generated, DO NOT EDIT
+Description=Timer app for snap application snap.app
+Requires=%s-snap-44.mount
+After=%s-snap-44.mount
+X-Snappy=yes
+
+[Timer]
+Unit=snap.snap.app.service
+OnCalendar=*-*-* 10:00
+OnCalendar=*-*-* 11:00
+
+[Install]
+WantedBy=timers.target
+`
+
+	expectedService := fmt.Sprintf(expectedServiceFmt, mountUnitPrefix, mountUnitPrefix)
+	service := &snap.AppInfo{
+		Snap: &snap.Info{
+			SuggestedName: "snap",
+			Version:       "0.3.4",
+			SideInfo:      snap.SideInfo{Revision: snap.R(44)},
+		},
+		Name:        "app",
+		Command:     "bin/foo start",
+		Daemon:      "simple",
+		DaemonScope: snap.SystemDaemon,
+		StopTimeout: timeout.DefaultTimeout,
+		Timer: &snap.TimerInfo{
+			Timer: "10:00-12:00/2",
+		},
+	}
+	service.Timer.App = service
+
+	generatedWrapper, err := internal.GenerateSnapServiceTimerUnitFile(service)
+	c.Assert(err, IsNil)
+
+	c.Logf("timer: \n%v\n", string(generatedWrapper))
+	c.Assert(string(generatedWrapper), Equals, expectedService)
+}
+
+func (s *serviceTimerUnitGenSuite) TestServiceTimerUnitBadTimer(c *C) {
+	service := &snap.AppInfo{
+		Snap: &snap.Info{
+			SuggestedName: "snap",
+			Version:       "0.3.4",
+			SideInfo:      snap.SideInfo{Revision: snap.R(44)},
+		},
+		Name:        "app",
+		Command:     "bin/foo start",
+		Daemon:      "simple",
+		DaemonScope: snap.SystemDaemon,
+		StopTimeout: timeout.DefaultTimeout,
+		Timer: &snap.TimerInfo{
+			Timer: "bad-timer",
+		},
+	}
+	service.Timer.App = service
+
+	generatedWrapper, err := internal.GenerateSnapServiceTimerUnitFile(service)
+	c.Assert(err, ErrorMatches, `cannot parse "bad-timer": "bad" is not a valid weekday`)
+	c.Assert(generatedWrapper, IsNil)
+}
+
+func (s *serviceTimerUnitGenSuite) TestServiceTimerServiceUnit(c *C) {
+	const expectedServiceFmt = `[Unit]
+# Auto-generated, DO NOT EDIT
+Description=Service for snap application snap.app
+Requires=%s-snap-44.mount
+Wants=network.target
+After=%s-snap-44.mount network.target snapd.apparmor.service
+X-Snappy=yes
+
+[Service]
+EnvironmentFile=-/etc/environment
+ExecStart=/usr/bin/snap run --timer="10:00-12:00,,mon,23:00~01:00/2" snap.app
+SyslogIdentifier=snap.app
+Restart=%s
+WorkingDirectory=/var/snap/snap/44
+TimeoutStopSec=30
+Type=%s
+`
+
+	expectedService := fmt.Sprintf(expectedServiceFmt, mountUnitPrefix, mountUnitPrefix, "on-failure", "simple")
+	service := &snap.AppInfo{
+		Snap: &snap.Info{
+			SuggestedName: "snap",
+			Version:       "0.3.4",
+			SideInfo:      snap.SideInfo{Revision: snap.R(44)},
+		},
+		Name:        "app",
+		Command:     "bin/foo start",
+		Daemon:      "simple",
+		DaemonScope: snap.SystemDaemon,
+		StopTimeout: timeout.DefaultTimeout,
+		Timer: &snap.TimerInfo{
+			Timer: "10:00-12:00,,mon,23:00~01:00/2",
+		},
+	}
+
+	generatedWrapper, err := internal.GenerateSnapServiceUnitFile(service, nil)
+	c.Assert(err, IsNil)
+
+	c.Logf("service: \n%v\n", string(generatedWrapper))
+	c.Assert(string(generatedWrapper), Equals, expectedService)
+}
+
+func (s *serviceTimerUnitGenSuite) TestTimerGenerateSchedules(c *C) {
+	systemdAnalyzePath, _ := exec.LookPath("systemd-analyze")
+	if systemdAnalyzePath != "" {
+		// systemd-analyze is in the path, but it will fail if the
+		// daemon is not running (as it happens in LP builds) and writes
+		// the following to stderr:
+		//   Failed to create bus connection: No such file or directory
+		cmd := exec.Command(systemdAnalyzePath, "calendar", "12:00")
+		err := cmd.Run()
+		if err != nil {
+			// turns out it's not usable, disable extra verification
+			fmt.Fprintln(os.Stderr, `WARNING: systemd-analyze not usable, cannot validate a known schedule "12:00"`)
+			systemdAnalyzePath = ""
+		}
+	}
+
+	if systemdAnalyzePath == "" {
+		fmt.Fprintln(os.Stderr, "WARNING: generated schedules will not be validated by systemd-analyze")
+	}
+
+	for _, t := range []struct {
+		in         string
+		expected   []string
+		randomized bool
+	}{{
+		in:       "9:00-11:00,,20:00-22:00",
+		expected: []string{"*-*-* 09:00", "*-*-* 20:00"},
+	}, {
+		in:       "9:00-11:00/2,,20:00",
+		expected: []string{"*-*-* 09:00", "*-*-* 10:00", "*-*-* 20:00"},
+	}, {
+		in:         "9:00~11:00/2,,20:00",
+		expected:   []string{`\*-\*-\* 09:[0-5][0-9]`, `\*-\*-\* 10:[0-5][0-9]`, `\*-\*-\* 20:00`},
+		randomized: true,
+	}, {
+		in:       "mon,10:00,,fri,15:00",
+		expected: []string{"Mon *-*-* 10:00", "Fri *-*-* 15:00"},
+	}, {
+		in:       "mon-fri,10:00-11:00",
+		expected: []string{"Mon,Tue,Wed,Thu,Fri *-*-* 10:00"},
+	}, {
+		in:       "fri-mon,10:00-11:00",
+		expected: []string{"Fri,Sat,Sun,Mon *-*-* 10:00"},
+	}, {
+		in:       "mon5,10:00",
+		expected: []string{"Mon *-*-22,23,24,25,26,27,28,29,30,31 10:00"},
+	}, {
+		in:       "mon2,10:00",
+		expected: []string{"Mon *-*-8,9,10,11,12,13,14 10:00"},
+	}, {
+		in:       "mon2,mon1,10:00",
+		expected: []string{"Mon *-*-8,9,10,11,12,13,14 10:00", "Mon *-*-1,2,3,4,5,6,7 10:00"},
+	}, {
+		// (deprecated syntax, reduced to mon1-mon)
+		// NOTE: non-representable, assumes that service runner does the
+		// filtering of when to run the timer
+		in:       "mon1-mon3,10:00",
+		expected: []string{"*-*-8,9,10,11,12,13,14 10:00", "*-*-1,2,3,4,5,6,7 10:00"},
+	}, {
+		in:         "mon,10:00~12:00,,fri,15:00",
+		expected:   []string{`Mon \*-\*-\* 1[01]:[0-5][0-9]`, `Fri \*-\*-\* 15:00`},
+		randomized: true,
+	}, {
+		in:         "23:00~24:00/4",
+		expected:   []string{`\*-\*-\* 23:[01][0-9]`, `\*-\*-\* 23:[12][0-9]`, `\*-\*-\* 23:[34][0-9]`, `*-*-* 23:[45][0-9]`},
+		randomized: true,
+	}, {
+		in:         "23:00~01:00/4",
+		expected:   []string{`\*-\*-\* 23:[0-2][0-9]`, `\*-\*-\* 23:[3-5][0-9]`, `\*-\*-\* 00:[0-2][0-9]`, `\*-\*-\* 00:[3-5][0-9]`},
+		randomized: true,
+	}, {
+		in:       "23:00-01:00/4",
+		expected: []string{`*-*-* 23:00`, `*-*-* 23:30`, `*-*-* 00:00`, `*-*-* 00:30`},
+	}, {
+		in:       "24:00",
+		expected: []string{`*-*-* 00:00`},
+	}, {
+		// NOTE: non-representable, assumes that service runner does the
+		// filtering of when to run the timer
+		in:       "fri-mon1,10:00",
+		expected: []string{"*-*-22,23,24,25,26,27,28,29,30,31 10:00", "*-*-1,2,3,4,5,6,7 10:00"},
+	}, {
+		// NOTE: non-representable, assumes that service runner does the
+		// filtering of when to run the timer
+		in:       "mon5-fri,10:00",
+		expected: []string{"*-*-29,30,31 10:00", "*-*-1,2,3,4,5,6,7 10:00", "*-*-22,23,24,25,26,27,28 10:00"},
+	}, {
+		// NOTE: non-representable, assumes that service runner does the
+		// filtering of when to run the timer
+		in:       "mon4-fri,10:00",
+		expected: []string{"*-*-29,30,31 10:00", "*-*-1,2,3,4,5,6,7 10:00", "*-*-22,23,24,25,26,27,28 10:00"},
+	}, {
+		// NOTE: non-representable, assumes that service runner does the
+		// filtering of when to run the timer
+		in:       "mon-fri2,10:00",
+		expected: []string{"*-*-1,2,3,4,5,6,7 10:00", "*-*-8,9,10,11,12,13,14 10:00"},
+	}, {
+		// NOTE: non-representable, assumes that service runner does the
+		// filtering of when to run the timer
+		in:       "mon-fri5,10:00",
+		expected: []string{"*-*-29,30,31 10:00", "*-*-22,23,24,25,26,27,28 10:00"},
+	}, {
+		// NOTE: non-representable, assumes that service runner does the
+		// filtering of when to run the timer
+		in:       "mon1-mon,10:00",
+		expected: []string{"*-*-8,9,10,11,12,13,14 10:00", "*-*-1,2,3,4,5,6,7 10:00"},
+	}, {
+		in:       "mon",
+		expected: []string{"Mon *-*-*"},
+	}, {
+		in:       "mon,fri",
+		expected: []string{"Mon *-*-*", "Fri *-*-*"},
+	}, {
+		in:       "mon2,mon1",
+		expected: []string{"Mon *-*-8,9,10,11,12,13,14", "Mon *-*-1,2,3,4,5,6,7"},
+	}} {
+		c.Logf("trying %+v", t)
+
+		schedule, err := timeutil.ParseSchedule(t.in)
+		c.Check(err, IsNil)
+
+		timer := internal.GenerateOnCalendarSchedules(schedule)
+		c.Check(timer, Not(IsNil))
+		if !t.randomized {
+			c.Check(timer, DeepEquals, t.expected)
+		} else {
+			c.Assert(timer, HasLen, len(t.expected))
+			for i := range timer {
+				c.Check(timer[i], Matches, t.expected[i])
+			}
+		}
+
+		if systemdAnalyzePath != "" {
+			cmd := exec.Command(systemdAnalyzePath, append([]string{"calendar"}, timer...)...)
+			out, err := cmd.CombinedOutput()
+			c.Check(err, IsNil, Commentf("systemd-analyze failed with output:\n%s", string(out)))
+		}
+	}
+}

--- a/wrappers/internal/service_unit_gen.go
+++ b/wrappers/internal/service_unit_gen.go
@@ -1,0 +1,335 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package internal
+
+import (
+	"bytes"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/quota"
+	"github.com/snapcore/snapd/strutil"
+	"github.com/snapcore/snapd/systemd"
+	"github.com/snapcore/snapd/timeout"
+)
+
+// snapdToolingMountUnit is the name of the mount unit that provides the snapd tooling
+const SnapdToolingMountUnit = "usr-lib-snapd.mount"
+
+// SnapServicesUnitOptions is a struct for controlling the generated service
+// definition for a snap service.
+type SnapServicesUnitOptions struct {
+	// VitalityRank is the rank of all services in the specified snap used by
+	// the OOM killer when OOM conditions are reached.
+	VitalityRank int
+
+	// QuotaGroup is the quota group for the service.
+	QuotaGroup *quota.Group
+
+	// RequireMountedSnapdSnap is whether the generated units should depend on
+	// the snapd snap being mounted, this is specific to systems like UC18 and
+	// UC20 which have the snapd snap and need to have units generated
+	RequireMountedSnapdSnap bool
+}
+
+func serviceStopTimeout(app *snap.AppInfo) time.Duration {
+	tout := app.StopTimeout
+	if tout == 0 {
+		tout = timeout.DefaultTimeout
+	}
+	return time.Duration(tout)
+}
+
+func generateServiceNames(snap *snap.Info, appNames []string) []string {
+	names := make([]string, 0, len(appNames))
+
+	for _, name := range appNames {
+		if app := snap.Apps[name]; app != nil {
+			names = append(names, app.ServiceName())
+		}
+	}
+	return names
+}
+
+func GenerateSnapServiceUnitFile(appInfo *snap.AppInfo, opts *SnapServicesUnitOptions) ([]byte, error) {
+	if opts == nil {
+		opts = &SnapServicesUnitOptions{}
+	}
+
+	if err := snap.ValidateApp(appInfo); err != nil {
+		return nil, err
+	}
+
+	// assemble all of the service directive snippets for all interfaces that
+	// this service needs to include in the generated systemd file
+
+	// use an ordered set to ensure we don't duplicate any keys from interfaces
+	// that specify the same snippet
+
+	// TODO: maybe we should error if multiple interfaces specify different
+	// values for the same directive, otherwise one of them will overwrite the
+	// other? What happens right now is that the snippet from the plug that
+	// comes last will win in the case of directives that can have only one
+	// value, but for some directives, systemd combines their values into a
+	// list.
+	ifaceServiceSnippets := &strutil.OrderedSet{}
+
+	for _, plug := range appInfo.Plugs {
+		iface, err := interfaces.ByName(plug.Interface)
+		if err != nil {
+			return nil, fmt.Errorf("error processing plugs while generating service unit for %v: %v", appInfo.SecurityTag(), err)
+		}
+		snips, err := interfaces.PermanentPlugServiceSnippets(iface, plug)
+		if err != nil {
+			return nil, fmt.Errorf("error processing plugs while generating service unit for %v: %v", appInfo.SecurityTag(), err)
+		}
+		for _, snip := range snips {
+			ifaceServiceSnippets.Put(snip)
+		}
+	}
+
+	// join the service snippets into one string to be included in the
+	// template
+	ifaceSpecifiedServiceSnippet := strings.Join(ifaceServiceSnippets.Items(), "\n")
+
+	serviceTemplate := `[Unit]
+# Auto-generated, DO NOT EDIT
+Description=Service for snap application {{.App.Snap.InstanceName}}.{{.App.Name}}
+{{- if .MountUnit }}
+Requires={{.MountUnit}}
+{{- end }}
+{{- if .PrerequisiteTarget}}
+Wants={{.PrerequisiteTarget}}
+{{- end}}
+{{- if .After}}
+After={{ stringsJoin .After " " }}
+{{- end}}
+{{- if .Before}}
+Before={{ stringsJoin .Before " "}}
+{{- end}}
+{{- if .CoreMountedSnapdSnapDep}}
+Wants={{ stringsJoin .CoreMountedSnapdSnapDep " "}}
+After={{ stringsJoin .CoreMountedSnapdSnapDep " "}}
+{{- end}}
+X-Snappy=yes
+
+[Service]
+EnvironmentFile=-/etc/environment
+ExecStart={{.App.LauncherCommand}}
+SyslogIdentifier={{.App.Snap.InstanceName}}.{{.App.Name}}
+Restart={{.Restart}}
+{{- if .App.RestartDelay}}
+RestartSec={{.App.RestartDelay.Seconds}}
+{{- end}}
+WorkingDirectory={{.WorkingDir}}
+{{- if .App.StopCommand}}
+ExecStop={{.App.LauncherStopCommand}}
+{{- end}}
+{{- if .App.ReloadCommand}}
+ExecReload={{.App.LauncherReloadCommand}}
+{{- end}}
+{{- if .App.PostStopCommand}}
+ExecStopPost={{.App.LauncherPostStopCommand}}
+{{- end}}
+{{- if .StopTimeout}}
+TimeoutStopSec={{.StopTimeout.Seconds}}
+{{- end}}
+{{- if .StartTimeout}}
+TimeoutStartSec={{.StartTimeout.Seconds}}
+{{- end}}
+Type={{.App.Daemon}}
+{{- if .Remain}}
+RemainAfterExit={{.Remain}}
+{{- end}}
+{{- if .BusName}}
+BusName={{.BusName}}
+{{- end}}
+{{- if .App.WatchdogTimeout}}
+WatchdogSec={{.App.WatchdogTimeout.Seconds}}
+{{- end}}
+{{- if .KillMode}}
+KillMode={{.KillMode}}
+{{- end}}
+{{- if .KillSignal}}
+KillSignal={{.KillSignal}}
+{{- end}}
+{{- if .OOMAdjustScore }}
+OOMScoreAdjust={{.OOMAdjustScore}}
+{{- end}}
+{{- if .InterfaceServiceSnippets}}
+{{.InterfaceServiceSnippets}}
+{{- end}}
+{{- if .SliceUnit}}
+Slice={{.SliceUnit}}
+{{- end}}
+{{- if .LogNamespace}}
+LogNamespace={{.LogNamespace}}
+{{- end}}
+{{- if not (or .App.Sockets .App.Timer .App.ActivatesOn) }}
+
+[Install]
+WantedBy={{.ServicesTarget}}
+{{- end}}
+`
+	var templateOut bytes.Buffer
+	tmpl := template.New("service-wrapper")
+	tmpl.Funcs(template.FuncMap{
+		"stringsJoin": strings.Join,
+	})
+	t := template.Must(tmpl.Parse(serviceTemplate))
+
+	restartCond := appInfo.RestartCond.String()
+	if restartCond == "" {
+		restartCond = snap.RestartOnFailure.String()
+	}
+
+	// use score -900+vitalityRank, where vitalityRank starts at 1
+	// and considering snapd itself has OOMScoreAdjust=-900
+	const baseOOMAdjustScore = -900
+	var oomAdjustScore int
+	if opts.VitalityRank > 0 {
+		oomAdjustScore = baseOOMAdjustScore + opts.VitalityRank
+	}
+
+	var remain string
+	if appInfo.Daemon == "oneshot" {
+		// any restart condition other than "no" is invalid for oneshot daemons
+		restartCond = "no"
+		// If StopExec is present for a oneshot service than we also need
+		// RemainAfterExit=yes
+		if appInfo.StopCommand != "" {
+			remain = "yes"
+		}
+	}
+	var killMode string
+	if !appInfo.StopMode.KillAll() {
+		killMode = "process"
+	}
+
+	var busName string
+	if appInfo.Daemon == "dbus" {
+		busName = appInfo.BusName
+		if busName == "" && len(appInfo.ActivatesOn) != 0 {
+			slot := appInfo.ActivatesOn[len(appInfo.ActivatesOn)-1]
+			if err := slot.Attr("name", &busName); err != nil {
+				// This should be impossible for a valid AppInfo
+				logger.Noticef("Cannot get 'name' attribute of dbus slot %q: %v", slot.Name, err)
+			}
+		}
+	}
+
+	wrapperData := struct {
+		App *snap.AppInfo
+
+		Restart                  string
+		WorkingDir               string
+		StopTimeout              time.Duration
+		StartTimeout             time.Duration
+		ServicesTarget           string
+		PrerequisiteTarget       string
+		MountUnit                string
+		Remain                   string
+		KillMode                 string
+		KillSignal               string
+		OOMAdjustScore           int
+		BusName                  string
+		Before                   []string
+		After                    []string
+		InterfaceServiceSnippets string
+		SliceUnit                string
+		LogNamespace             string
+
+		Home    string
+		EnvVars string
+
+		CoreMountedSnapdSnapDep []string
+	}{
+		App: appInfo,
+
+		InterfaceServiceSnippets: ifaceSpecifiedServiceSnippet,
+
+		Restart:        restartCond,
+		StopTimeout:    serviceStopTimeout(appInfo),
+		StartTimeout:   time.Duration(appInfo.StartTimeout),
+		Remain:         remain,
+		KillMode:       killMode,
+		KillSignal:     appInfo.StopMode.KillSignal(),
+		OOMAdjustScore: oomAdjustScore,
+		BusName:        busName,
+
+		Before: generateServiceNames(appInfo.Snap, appInfo.Before),
+		After:  generateServiceNames(appInfo.Snap, appInfo.After),
+
+		// systemd runs as PID 1 so %h will not work.
+		Home: "/root",
+	}
+	switch appInfo.DaemonScope {
+	case snap.SystemDaemon:
+		wrapperData.ServicesTarget = systemd.ServicesTarget
+		wrapperData.PrerequisiteTarget = systemd.PrerequisiteTarget
+		wrapperData.MountUnit = filepath.Base(systemd.MountUnitPath(appInfo.Snap.MountDir()))
+		wrapperData.WorkingDir = appInfo.Snap.DataDir()
+		wrapperData.After = append(wrapperData.After, "snapd.apparmor.service")
+	case snap.UserDaemon:
+		wrapperData.ServicesTarget = systemd.UserServicesTarget
+		// FIXME: ideally use UserDataDir("%h"), but then the
+		// unit fails if the directory doesn't exist.
+		wrapperData.WorkingDir = appInfo.Snap.DataDir()
+	default:
+		panic("unknown snap.DaemonScope")
+	}
+
+	// check the quota group slice
+	if opts.QuotaGroup != nil {
+		wrapperData.SliceUnit = opts.QuotaGroup.SliceFileName()
+		if opts.QuotaGroup.JournalQuotaSet() {
+			wrapperData.LogNamespace = opts.QuotaGroup.JournalNamespaceName()
+		}
+	}
+
+	// Add extra "After" targets
+	if wrapperData.PrerequisiteTarget != "" {
+		wrapperData.After = append([]string{wrapperData.PrerequisiteTarget}, wrapperData.After...)
+	}
+	if wrapperData.MountUnit != "" {
+		wrapperData.After = append([]string{wrapperData.MountUnit}, wrapperData.After...)
+	}
+
+	if opts.RequireMountedSnapdSnap {
+		// on core 18+ systems, the snapd tooling is exported
+		// into the host system via a special mount unit, which
+		// also adds an implicit dependency on the snapd snap
+		// mount thus /usr/bin/snap points
+		wrapperData.CoreMountedSnapdSnapDep = []string{SnapdToolingMountUnit}
+	}
+
+	if err := t.Execute(&templateOut, wrapperData); err != nil {
+		// this can never happen, except we forget a variable
+		logger.Panicf("Unable to execute template: %v", err)
+	}
+
+	return templateOut.Bytes(), nil
+}

--- a/wrappers/internal/service_unit_gen.go
+++ b/wrappers/internal/service_unit_gen.go
@@ -36,9 +36,6 @@ import (
 	"github.com/snapcore/snapd/timeout"
 )
 
-// snapdToolingMountUnit is the name of the mount unit that provides the snapd tooling
-const SnapdToolingMountUnit = "usr-lib-snapd.mount"
-
 // SnapServicesUnitOptions is a struct for controlling the generated service
 // definition for a snap service.
 type SnapServicesUnitOptions struct {
@@ -49,10 +46,9 @@ type SnapServicesUnitOptions struct {
 	// QuotaGroup is the quota group for the service.
 	QuotaGroup *quota.Group
 
-	// RequireMountedSnapdSnap is whether the generated units should depend on
-	// the snapd snap being mounted, this is specific to systems like UC18 and
-	// UC20 which have the snapd snap and need to have units generated
-	RequireMountedSnapdSnap bool
+	// CoreMountedSnapdSnapDep is whether the generated unit should depend on
+	// the provided snapd snapd being mounted
+	CoreMountedSnapdSnapDep string
 }
 
 func serviceStopTimeout(app *snap.AppInfo) time.Duration {
@@ -317,13 +313,8 @@ WantedBy={{.ServicesTarget}}
 	if wrapperData.MountUnit != "" {
 		wrapperData.After = append([]string{wrapperData.MountUnit}, wrapperData.After...)
 	}
-
-	if opts.RequireMountedSnapdSnap {
-		// on core 18+ systems, the snapd tooling is exported
-		// into the host system via a special mount unit, which
-		// also adds an implicit dependency on the snapd snap
-		// mount thus /usr/bin/snap points
-		wrapperData.CoreMountedSnapdSnapDep = []string{SnapdToolingMountUnit}
+	if opts.CoreMountedSnapdSnapDep != "" {
+		wrapperData.CoreMountedSnapdSnapDep = []string{opts.CoreMountedSnapdSnapDep}
 	}
 
 	if err := t.Execute(&templateOut, wrapperData); err != nil {

--- a/wrappers/internal/service_unit_gen_test.go
+++ b/wrappers/internal/service_unit_gen_test.go
@@ -21,8 +21,6 @@ package internal_test
 
 import (
 	"fmt"
-	"os"
-	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -38,17 +36,16 @@ import (
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
 	"github.com/snapcore/snapd/timeout"
-	"github.com/snapcore/snapd/timeutil"
 	"github.com/snapcore/snapd/wrappers/internal"
 )
 
-type servicesWrapperGenSuite struct {
+type serviceUnitGenSuite struct {
 	testutil.BaseTest
 }
 
 func TestInternal(t *testing.T) { TestingT(t) }
 
-var _ = Suite(&servicesWrapperGenSuite{})
+var _ = Suite(&serviceUnitGenSuite{})
 
 const expectedServiceFmt = `[Unit]
 # Auto-generated, DO NOT EDIT
@@ -132,16 +129,16 @@ Type=%s
 	expectedTypeForkingWrapper = fmt.Sprintf(expectedServiceWrapperFmt, mountUnitPrefix, mountUnitPrefix, "forking", expectedInstallSection)
 )
 
-func (s *servicesWrapperGenSuite) SetUpTest(c *C) {
+func (s *serviceUnitGenSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
 	s.BaseTest.AddCleanup(snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {}))
 }
 
-func (s *servicesWrapperGenSuite) TearDownTest(c *C) {
+func (s *serviceUnitGenSuite) TearDownTest(c *C) {
 	s.BaseTest.TearDownTest(c)
 }
 
-func (s *servicesWrapperGenSuite) TestWriteSnapServiceUnitFileOnClassic(c *C) {
+func (s *serviceUnitGenSuite) TestWriteSnapServiceUnitFileOnClassic(c *C) {
 	yamlText := `
 name: snap
 version: 1.0
@@ -164,7 +161,7 @@ apps:
 	c.Check(string(generatedWrapper), Equals, expectedAppService)
 }
 
-func (s *servicesWrapperGenSuite) TestGenerateSnapServiceOnCore(c *C) {
+func (s *serviceUnitGenSuite) TestGenerateSnapServiceOnCore(c *C) {
 	defer func() { dirs.SetRootDir("/") }()
 
 	expectedAppServiceOnCore := `[Unit]
@@ -248,7 +245,7 @@ WantedBy=multi-user.target
 	c.Check(string(generatedWrapper), Equals, expectedAppServiceOnCoreWithSnapd)
 }
 
-func (s *servicesWrapperGenSuite) TestWriteSnapServiceUnitFileWithStartTimeout(c *C) {
+func (s *serviceUnitGenSuite) TestWriteSnapServiceUnitFileWithStartTimeout(c *C) {
 	yamlText := `
 name: snap
 version: 1.0
@@ -268,7 +265,7 @@ apps:
 	c.Check(string(generatedWrapper), testutil.Contains, "\nTimeoutStartSec=600\n")
 }
 
-func (s *servicesWrapperGenSuite) TestWriteSnapServiceUnitFileRestart(c *C) {
+func (s *serviceUnitGenSuite) TestWriteSnapServiceUnitFileRestart(c *C) {
 	yamlTextTemplate := `
 name: snap
 apps:
@@ -297,7 +294,7 @@ apps:
 	}
 }
 
-func (s *servicesWrapperGenSuite) TestWriteSnapServiceUnitFileTypeForking(c *C) {
+func (s *serviceUnitGenSuite) TestWriteSnapServiceUnitFileTypeForking(c *C) {
 	service := &snap.AppInfo{
 		Snap: &snap.Info{
 			SuggestedName: "xkcd-webserver",
@@ -319,7 +316,7 @@ func (s *servicesWrapperGenSuite) TestWriteSnapServiceUnitFileTypeForking(c *C) 
 	c.Assert(string(generatedWrapper), Equals, expectedTypeForkingWrapper)
 }
 
-func (s *servicesWrapperGenSuite) TestWriteSnapServiceUnitFileIllegalChars(c *C) {
+func (s *serviceUnitGenSuite) TestWriteSnapServiceUnitFileIllegalChars(c *C) {
 	service := &snap.AppInfo{
 		Snap: &snap.Info{
 			SuggestedName: "xkcd-webserver",
@@ -340,7 +337,7 @@ func (s *servicesWrapperGenSuite) TestWriteSnapServiceUnitFileIllegalChars(c *C)
 	c.Assert(err, NotNil)
 }
 
-func (s *servicesWrapperGenSuite) TestGenServiceFileWithBusName(c *C) {
+func (s *serviceUnitGenSuite) TestGenServiceFileWithBusName(c *C) {
 	yamlText := `
 name: snap
 version: 1.0
@@ -372,7 +369,7 @@ apps:
 	c.Assert(string(generatedWrapper), Equals, expectedDbusService)
 }
 
-func (s *servicesWrapperGenSuite) TestGenServiceFileWithBusNameOnly(c *C) {
+func (s *serviceUnitGenSuite) TestGenServiceFileWithBusNameOnly(c *C) {
 
 	yamlText := `
 name: snap
@@ -400,7 +397,7 @@ apps:
 	c.Assert(string(generatedWrapper), Equals, expectedDbusService)
 }
 
-func (s *servicesWrapperGenSuite) TestGenServiceFileWithBusNameFromSlot(c *C) {
+func (s *serviceUnitGenSuite) TestGenServiceFileWithBusNameFromSlot(c *C) {
 
 	yamlText := `
 name: snap
@@ -438,7 +435,7 @@ apps:
 	c.Assert(string(generatedWrapper), Equals, expectedDbusService)
 }
 
-func (s *servicesWrapperGenSuite) TestGenOneshotServiceFile(c *C) {
+func (s *serviceUnitGenSuite) TestGenOneshotServiceFile(c *C) {
 
 	info := snaptest.MockInfo(c, `
 name: snap
@@ -461,7 +458,7 @@ apps:
 	c.Assert(string(generatedWrapper), Equals, expectedOneshotService)
 }
 
-func (s *servicesWrapperGenSuite) TestGenerateSnapUserServiceFile(c *C) {
+func (s *serviceUnitGenSuite) TestGenerateSnapUserServiceFile(c *C) {
 	yamlText := `
 name: snap
 version: 1.0
@@ -485,84 +482,7 @@ apps:
 	c.Check(string(generatedWrapper), Equals, expectedUserAppService)
 }
 
-func (s *servicesWrapperGenSuite) TestGenerateSnapServiceWithSockets(c *C) {
-	const sock1ExpectedFmt = `[Unit]
-# Auto-generated, DO NOT EDIT
-Description=Socket sock1 for snap application some-snap.app
-Requires=%s-some\x2dsnap-44.mount
-After=%s-some\x2dsnap-44.mount
-X-Snappy=yes
-
-[Socket]
-Service=snap.some-snap.app.service
-FileDescriptorName=sock1
-ListenStream=%s/sock1.socket
-SocketMode=0666
-
-[Install]
-WantedBy=sockets.target
-`
-	const sock2ExpectedFmt = `[Unit]
-# Auto-generated, DO NOT EDIT
-Description=Socket sock2 for snap application some-snap.app
-Requires=%s-some\x2dsnap-44.mount
-After=%s-some\x2dsnap-44.mount
-X-Snappy=yes
-
-[Socket]
-Service=snap.some-snap.app.service
-FileDescriptorName=sock2
-ListenStream=%s/sock2.socket
-
-[Install]
-WantedBy=sockets.target
-`
-
-	si := &snap.Info{
-		SuggestedName: "some-snap",
-		Version:       "1.0",
-		SideInfo:      snap.SideInfo{Revision: snap.R(44)},
-	}
-	service := &snap.AppInfo{
-		Snap:        si,
-		Name:        "app",
-		Command:     "bin/foo start",
-		Daemon:      "simple",
-		DaemonScope: snap.SystemDaemon,
-		Plugs:       map[string]*snap.PlugInfo{"network-bind": {Interface: "network-bind"}},
-		Sockets: map[string]*snap.SocketInfo{
-			"sock1": {
-				Name:         "sock1",
-				ListenStream: "$SNAP_DATA/sock1.socket",
-				SocketMode:   0666,
-			},
-			"sock2": {
-				Name:         "sock2",
-				ListenStream: "$SNAP_DATA/sock2.socket",
-			},
-		},
-	}
-	service.Sockets["sock1"].App = service
-	service.Sockets["sock2"].App = service
-
-	sock1Expected := fmt.Sprintf(sock1ExpectedFmt, mountUnitPrefix, mountUnitPrefix, si.DataDir())
-	sock2Expected := fmt.Sprintf(sock2ExpectedFmt, mountUnitPrefix, mountUnitPrefix, si.DataDir())
-
-	generatedWrapper, err := internal.GenerateSnapServiceUnitFile(service, nil)
-	c.Assert(err, IsNil)
-	c.Assert(strings.Contains(string(generatedWrapper), "[Install]"), Equals, false)
-	c.Assert(strings.Contains(string(generatedWrapper), "WantedBy=multi-user.target"), Equals, false)
-
-	generatedSockets, err := internal.GenerateSnapSocketUnitFiles(service)
-	c.Assert(err, IsNil)
-	c.Assert(generatedSockets, HasLen, 2)
-	c.Assert(generatedSockets, DeepEquals, map[string][]byte{
-		"sock1": []byte(sock1Expected),
-		"sock2": []byte(sock2Expected),
-	})
-}
-
-func (s *servicesWrapperGenSuite) TestServiceAfterBefore(c *C) {
+func (s *serviceUnitGenSuite) TestServiceAfterBefore(c *C) {
 	const expectedServiceFmt = `[Unit]
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application snap.app
@@ -653,255 +573,7 @@ WantedBy=multi-user.target
 	}
 }
 
-func (s *servicesWrapperGenSuite) TestServiceTimerUnit(c *C) {
-	const expectedServiceFmt = `[Unit]
-# Auto-generated, DO NOT EDIT
-Description=Timer app for snap application snap.app
-Requires=%s-snap-44.mount
-After=%s-snap-44.mount
-X-Snappy=yes
-
-[Timer]
-Unit=snap.snap.app.service
-OnCalendar=*-*-* 10:00
-OnCalendar=*-*-* 11:00
-
-[Install]
-WantedBy=timers.target
-`
-
-	expectedService := fmt.Sprintf(expectedServiceFmt, mountUnitPrefix, mountUnitPrefix)
-	service := &snap.AppInfo{
-		Snap: &snap.Info{
-			SuggestedName: "snap",
-			Version:       "0.3.4",
-			SideInfo:      snap.SideInfo{Revision: snap.R(44)},
-		},
-		Name:        "app",
-		Command:     "bin/foo start",
-		Daemon:      "simple",
-		DaemonScope: snap.SystemDaemon,
-		StopTimeout: timeout.DefaultTimeout,
-		Timer: &snap.TimerInfo{
-			Timer: "10:00-12:00/2",
-		},
-	}
-	service.Timer.App = service
-
-	generatedWrapper, err := internal.GenerateSnapServiceTimerUnitFile(service)
-	c.Assert(err, IsNil)
-
-	c.Logf("timer: \n%v\n", string(generatedWrapper))
-	c.Assert(string(generatedWrapper), Equals, expectedService)
-}
-
-func (s *servicesWrapperGenSuite) TestServiceTimerUnitBadTimer(c *C) {
-	service := &snap.AppInfo{
-		Snap: &snap.Info{
-			SuggestedName: "snap",
-			Version:       "0.3.4",
-			SideInfo:      snap.SideInfo{Revision: snap.R(44)},
-		},
-		Name:        "app",
-		Command:     "bin/foo start",
-		Daemon:      "simple",
-		DaemonScope: snap.SystemDaemon,
-		StopTimeout: timeout.DefaultTimeout,
-		Timer: &snap.TimerInfo{
-			Timer: "bad-timer",
-		},
-	}
-	service.Timer.App = service
-
-	generatedWrapper, err := internal.GenerateSnapServiceTimerUnitFile(service)
-	c.Assert(err, ErrorMatches, `cannot parse "bad-timer": "bad" is not a valid weekday`)
-	c.Assert(generatedWrapper, IsNil)
-}
-
-func (s *servicesWrapperGenSuite) TestServiceTimerServiceUnit(c *C) {
-	const expectedServiceFmt = `[Unit]
-# Auto-generated, DO NOT EDIT
-Description=Service for snap application snap.app
-Requires=%s-snap-44.mount
-Wants=network.target
-After=%s-snap-44.mount network.target snapd.apparmor.service
-X-Snappy=yes
-
-[Service]
-EnvironmentFile=-/etc/environment
-ExecStart=/usr/bin/snap run --timer="10:00-12:00,,mon,23:00~01:00/2" snap.app
-SyslogIdentifier=snap.app
-Restart=%s
-WorkingDirectory=/var/snap/snap/44
-TimeoutStopSec=30
-Type=%s
-`
-
-	expectedService := fmt.Sprintf(expectedServiceFmt, mountUnitPrefix, mountUnitPrefix, "on-failure", "simple")
-	service := &snap.AppInfo{
-		Snap: &snap.Info{
-			SuggestedName: "snap",
-			Version:       "0.3.4",
-			SideInfo:      snap.SideInfo{Revision: snap.R(44)},
-		},
-		Name:        "app",
-		Command:     "bin/foo start",
-		Daemon:      "simple",
-		DaemonScope: snap.SystemDaemon,
-		StopTimeout: timeout.DefaultTimeout,
-		Timer: &snap.TimerInfo{
-			Timer: "10:00-12:00,,mon,23:00~01:00/2",
-		},
-	}
-
-	generatedWrapper, err := internal.GenerateSnapServiceUnitFile(service, nil)
-	c.Assert(err, IsNil)
-
-	c.Logf("service: \n%v\n", string(generatedWrapper))
-	c.Assert(string(generatedWrapper), Equals, expectedService)
-}
-
-func (s *servicesWrapperGenSuite) TestTimerGenerateSchedules(c *C) {
-	systemdAnalyzePath, _ := exec.LookPath("systemd-analyze")
-	if systemdAnalyzePath != "" {
-		// systemd-analyze is in the path, but it will fail if the
-		// daemon is not running (as it happens in LP builds) and writes
-		// the following to stderr:
-		//   Failed to create bus connection: No such file or directory
-		cmd := exec.Command(systemdAnalyzePath, "calendar", "12:00")
-		err := cmd.Run()
-		if err != nil {
-			// turns out it's not usable, disable extra verification
-			fmt.Fprintln(os.Stderr, `WARNING: systemd-analyze not usable, cannot validate a known schedule "12:00"`)
-			systemdAnalyzePath = ""
-		}
-	}
-
-	if systemdAnalyzePath == "" {
-		fmt.Fprintln(os.Stderr, "WARNING: generated schedules will not be validated by systemd-analyze")
-	}
-
-	for _, t := range []struct {
-		in         string
-		expected   []string
-		randomized bool
-	}{{
-		in:       "9:00-11:00,,20:00-22:00",
-		expected: []string{"*-*-* 09:00", "*-*-* 20:00"},
-	}, {
-		in:       "9:00-11:00/2,,20:00",
-		expected: []string{"*-*-* 09:00", "*-*-* 10:00", "*-*-* 20:00"},
-	}, {
-		in:         "9:00~11:00/2,,20:00",
-		expected:   []string{`\*-\*-\* 09:[0-5][0-9]`, `\*-\*-\* 10:[0-5][0-9]`, `\*-\*-\* 20:00`},
-		randomized: true,
-	}, {
-		in:       "mon,10:00,,fri,15:00",
-		expected: []string{"Mon *-*-* 10:00", "Fri *-*-* 15:00"},
-	}, {
-		in:       "mon-fri,10:00-11:00",
-		expected: []string{"Mon,Tue,Wed,Thu,Fri *-*-* 10:00"},
-	}, {
-		in:       "fri-mon,10:00-11:00",
-		expected: []string{"Fri,Sat,Sun,Mon *-*-* 10:00"},
-	}, {
-		in:       "mon5,10:00",
-		expected: []string{"Mon *-*-22,23,24,25,26,27,28,29,30,31 10:00"},
-	}, {
-		in:       "mon2,10:00",
-		expected: []string{"Mon *-*-8,9,10,11,12,13,14 10:00"},
-	}, {
-		in:       "mon2,mon1,10:00",
-		expected: []string{"Mon *-*-8,9,10,11,12,13,14 10:00", "Mon *-*-1,2,3,4,5,6,7 10:00"},
-	}, {
-		// (deprecated syntax, reduced to mon1-mon)
-		// NOTE: non-representable, assumes that service runner does the
-		// filtering of when to run the timer
-		in:       "mon1-mon3,10:00",
-		expected: []string{"*-*-8,9,10,11,12,13,14 10:00", "*-*-1,2,3,4,5,6,7 10:00"},
-	}, {
-		in:         "mon,10:00~12:00,,fri,15:00",
-		expected:   []string{`Mon \*-\*-\* 1[01]:[0-5][0-9]`, `Fri \*-\*-\* 15:00`},
-		randomized: true,
-	}, {
-		in:         "23:00~24:00/4",
-		expected:   []string{`\*-\*-\* 23:[01][0-9]`, `\*-\*-\* 23:[12][0-9]`, `\*-\*-\* 23:[34][0-9]`, `*-*-* 23:[45][0-9]`},
-		randomized: true,
-	}, {
-		in:         "23:00~01:00/4",
-		expected:   []string{`\*-\*-\* 23:[0-2][0-9]`, `\*-\*-\* 23:[3-5][0-9]`, `\*-\*-\* 00:[0-2][0-9]`, `\*-\*-\* 00:[3-5][0-9]`},
-		randomized: true,
-	}, {
-		in:       "23:00-01:00/4",
-		expected: []string{`*-*-* 23:00`, `*-*-* 23:30`, `*-*-* 00:00`, `*-*-* 00:30`},
-	}, {
-		in:       "24:00",
-		expected: []string{`*-*-* 00:00`},
-	}, {
-		// NOTE: non-representable, assumes that service runner does the
-		// filtering of when to run the timer
-		in:       "fri-mon1,10:00",
-		expected: []string{"*-*-22,23,24,25,26,27,28,29,30,31 10:00", "*-*-1,2,3,4,5,6,7 10:00"},
-	}, {
-		// NOTE: non-representable, assumes that service runner does the
-		// filtering of when to run the timer
-		in:       "mon5-fri,10:00",
-		expected: []string{"*-*-29,30,31 10:00", "*-*-1,2,3,4,5,6,7 10:00", "*-*-22,23,24,25,26,27,28 10:00"},
-	}, {
-		// NOTE: non-representable, assumes that service runner does the
-		// filtering of when to run the timer
-		in:       "mon4-fri,10:00",
-		expected: []string{"*-*-29,30,31 10:00", "*-*-1,2,3,4,5,6,7 10:00", "*-*-22,23,24,25,26,27,28 10:00"},
-	}, {
-		// NOTE: non-representable, assumes that service runner does the
-		// filtering of when to run the timer
-		in:       "mon-fri2,10:00",
-		expected: []string{"*-*-1,2,3,4,5,6,7 10:00", "*-*-8,9,10,11,12,13,14 10:00"},
-	}, {
-		// NOTE: non-representable, assumes that service runner does the
-		// filtering of when to run the timer
-		in:       "mon-fri5,10:00",
-		expected: []string{"*-*-29,30,31 10:00", "*-*-22,23,24,25,26,27,28 10:00"},
-	}, {
-		// NOTE: non-representable, assumes that service runner does the
-		// filtering of when to run the timer
-		in:       "mon1-mon,10:00",
-		expected: []string{"*-*-8,9,10,11,12,13,14 10:00", "*-*-1,2,3,4,5,6,7 10:00"},
-	}, {
-		in:       "mon",
-		expected: []string{"Mon *-*-*"},
-	}, {
-		in:       "mon,fri",
-		expected: []string{"Mon *-*-*", "Fri *-*-*"},
-	}, {
-		in:       "mon2,mon1",
-		expected: []string{"Mon *-*-8,9,10,11,12,13,14", "Mon *-*-1,2,3,4,5,6,7"},
-	}} {
-		c.Logf("trying %+v", t)
-
-		schedule, err := timeutil.ParseSchedule(t.in)
-		c.Check(err, IsNil)
-
-		timer := internal.GenerateOnCalendarSchedules(schedule)
-		c.Check(timer, Not(IsNil))
-		if !t.randomized {
-			c.Check(timer, DeepEquals, t.expected)
-		} else {
-			c.Assert(timer, HasLen, len(t.expected))
-			for i := range timer {
-				c.Check(timer[i], Matches, t.expected[i])
-			}
-		}
-
-		if systemdAnalyzePath != "" {
-			cmd := exec.Command(systemdAnalyzePath, append([]string{"calendar"}, timer...)...)
-			out, err := cmd.CombinedOutput()
-			c.Check(err, IsNil, Commentf("systemd-analyze failed with output:\n%s", string(out)))
-		}
-	}
-}
-
-func (s *servicesWrapperGenSuite) TestKillModeSig(c *C) {
+func (s *serviceUnitGenSuite) TestKillModeSig(c *C) {
 	for _, rm := range []string{"sigterm", "sighup", "sigusr1", "sigusr2", "sigint"} {
 		service := &snap.AppInfo{
 			Snap: &snap.Info{
@@ -944,7 +616,7 @@ WantedBy=multi-user.target
 	}
 }
 
-func (s *servicesWrapperGenSuite) TestRestartDelay(c *C) {
+func (s *serviceUnitGenSuite) TestRestartDelay(c *C) {
 	service := &snap.AppInfo{
 		Snap: &snap.Info{
 			SuggestedName: "snap",
@@ -984,7 +656,7 @@ WantedBy=multi-user.target
 `, mountUnitPrefix, mountUnitPrefix))
 }
 
-func (s *servicesWrapperGenSuite) TestVitalityScore(c *C) {
+func (s *serviceUnitGenSuite) TestVitalityScore(c *C) {
 	service := &snap.AppInfo{
 		Snap: &snap.Info{
 			SuggestedName: "snap",
@@ -1026,7 +698,7 @@ WantedBy=multi-user.target
 `, mountUnitPrefix, mountUnitPrefix))
 }
 
-func (s *servicesWrapperGenSuite) TestQuotaGroupSlice(c *C) {
+func (s *serviceUnitGenSuite) TestQuotaGroupSlice(c *C) {
 	service := &snap.AppInfo{
 		Snap: &snap.Info{
 			SuggestedName: "snap",
@@ -1069,7 +741,7 @@ WantedBy=multi-user.target
 `, mountUnitPrefix, mountUnitPrefix))
 }
 
-func (s *servicesWrapperGenSuite) TestQuotaGroupLogNamespace(c *C) {
+func (s *serviceUnitGenSuite) TestQuotaGroupLogNamespace(c *C) {
 	service := &snap.AppInfo{
 		Snap: &snap.Info{
 			SuggestedName: "snap",
@@ -1113,7 +785,7 @@ WantedBy=multi-user.target
 `, mountUnitPrefix, mountUnitPrefix))
 }
 
-func (s *servicesWrapperGenSuite) TestQuotaGroupLogNamespaceInheritParent(c *C) {
+func (s *serviceUnitGenSuite) TestQuotaGroupLogNamespaceInheritParent(c *C) {
 	service := &snap.AppInfo{
 		Snap: &snap.Info{
 			SuggestedName: "snap",

--- a/wrappers/internal/service_unit_gen_test.go
+++ b/wrappers/internal/service_unit_gen_test.go
@@ -206,7 +206,7 @@ apps:
 	dirs.SetRootDir("/")
 
 	opts := internal.SnapServicesUnitOptions{
-		RequireMountedSnapdSnap: false,
+		CoreMountedSnapdSnapDep: "",
 	}
 	generatedWrapper, err := internal.GenerateSnapServiceUnitFile(app, &opts)
 	c.Assert(err, IsNil)
@@ -214,7 +214,7 @@ apps:
 
 	// now with additional dependency on tooling
 	opts = internal.SnapServicesUnitOptions{
-		RequireMountedSnapdSnap: true,
+		CoreMountedSnapdSnapDep: "usr-lib-snapd.mount",
 	}
 	generatedWrapper, err = internal.GenerateSnapServiceUnitFile(app, &opts)
 	c.Assert(err, IsNil)

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -20,34 +20,26 @@
 package wrappers
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sort"
-	"strconv"
-	"strings"
-	"text/template"
 	"time"
 
 	"github.com/snapcore/snapd/dirs"
-	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
-	"github.com/snapcore/snapd/osutil/sys"
 	"github.com/snapcore/snapd/progress"
-	"github.com/snapcore/snapd/randutil"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/quota"
 	"github.com/snapcore/snapd/strutil"
 	"github.com/snapcore/snapd/systemd"
 	"github.com/snapcore/snapd/timeout"
-	"github.com/snapcore/snapd/timeutil"
 	"github.com/snapcore/snapd/timings"
 	"github.com/snapcore/snapd/usersession/client"
+	"github.com/snapcore/snapd/wrappers/internal"
 )
 
 type Interacter interface {
@@ -56,146 +48,6 @@ type Interacter interface {
 
 // wait this time between TERM and KILL
 var killWait = 5 * time.Second
-
-func serviceStopTimeout(app *snap.AppInfo) time.Duration {
-	tout := app.StopTimeout
-	if tout == 0 {
-		tout = timeout.DefaultTimeout
-	}
-	return time.Duration(tout)
-}
-
-func generateSnapServiceFile(app *snap.AppInfo, opts *generateSnapServicesOptions) ([]byte, error) {
-	if err := snap.ValidateApp(app); err != nil {
-		return nil, err
-	}
-
-	return genServiceFile(app, opts)
-}
-
-func min(a, b int) int {
-	if b < a {
-		return b
-	}
-	return a
-}
-
-func formatCpuGroupSlice(grp *quota.Group) string {
-	header := `# Always enable cpu accounting, so the following cpu quota options have an effect
-CPUAccounting=true
-`
-	buf := bytes.NewBufferString(header)
-
-	count, percentage := grp.GetLocalCPUQuota()
-	if percentage != 0 {
-		// convert the number of cores and the allowed percentage
-		// to the systemd specific format.
-		cpuQuotaSnap := count * percentage
-		cpuQuotaMax := runtime.NumCPU() * 100
-
-		// The CPUQuota setting is only available since systemd 213
-		fmt.Fprintf(buf, "CPUQuota=%d%%\n", min(cpuQuotaSnap, cpuQuotaMax))
-	}
-
-	if grp.CPULimit != nil && len(grp.CPULimit.CPUSet) != 0 {
-		allowedCpusValue := strutil.IntsToCommaSeparated(grp.CPULimit.CPUSet)
-		fmt.Fprintf(buf, "AllowedCPUs=%s\n", allowedCpusValue)
-	}
-
-	buf.WriteString("\n")
-	return buf.String()
-}
-
-func formatMemoryGroupSlice(grp *quota.Group) string {
-	header := `# Always enable memory accounting otherwise the MemoryMax setting does nothing.
-MemoryAccounting=true
-`
-	buf := bytes.NewBufferString(header)
-	if grp.MemoryLimit != 0 {
-		valuesTemplate := `MemoryMax=%[1]d
-# for compatibility with older versions of systemd
-MemoryLimit=%[1]d
-
-`
-		fmt.Fprintf(buf, valuesTemplate, grp.MemoryLimit)
-	}
-	return buf.String()
-}
-
-func formatTaskGroupSlice(grp *quota.Group) string {
-	header := `# Always enable task accounting in order to be able to count the processes/
-# threads, etc for a slice
-TasksAccounting=true
-`
-	buf := bytes.NewBufferString(header)
-
-	if grp.ThreadLimit != 0 {
-		fmt.Fprintf(buf, "TasksMax=%d\n", grp.ThreadLimit)
-	}
-	return buf.String()
-}
-
-// generateGroupSliceFile generates a systemd slice unit definition for the
-// specified quota group.
-func generateGroupSliceFile(grp *quota.Group) []byte {
-	buf := bytes.Buffer{}
-
-	cpuOptions := formatCpuGroupSlice(grp)
-	memoryOptions := formatMemoryGroupSlice(grp)
-	taskOptions := formatTaskGroupSlice(grp)
-	template := `[Unit]
-Description=Slice for snap quota group %[1]s
-Before=slices.target
-X-Snappy=yes
-
-[Slice]
-`
-
-	fmt.Fprintf(&buf, template, grp.Name)
-	fmt.Fprint(&buf, cpuOptions, memoryOptions, taskOptions)
-	return buf.Bytes()
-}
-
-func formatJournalSizeConf(grp *quota.Group) string {
-	if grp.JournalLimit.Size == 0 {
-		return ""
-	}
-	return fmt.Sprintf(`SystemMaxUse=%[1]d
-RuntimeMaxUse=%[1]d
-`, grp.JournalLimit.Size)
-}
-
-func formatJournalRateConf(grp *quota.Group) string {
-	if !grp.JournalLimit.RateEnabled {
-		return ""
-	}
-	return fmt.Sprintf(`RateLimitIntervalSec=%dus
-RateLimitBurst=%d
-`, grp.JournalLimit.RatePeriod.Microseconds(), grp.JournalLimit.RateCount)
-}
-
-func generateJournaldConfFile(grp *quota.Group) []byte {
-	if grp.JournalLimit == nil {
-		return nil
-	}
-
-	sizeOptions := formatJournalSizeConf(grp)
-	rateOptions := formatJournalRateConf(grp)
-	// Set Storage=auto for all journal namespaces we create. This is
-	// the setting for the default namespace, and 'persistent' is the default
-	// setting for all namespaces. However we want namespaces to honor the
-	// journal.persistent setting, and this only works if Storage is set
-	// to 'auto'.
-	// See https://www.freedesktop.org/software/systemd/man/journald.conf.html#Storage=
-	template := `# Journald configuration for snap quota group %[1]s
-[Journal]
-Storage=auto
-`
-	buf := bytes.Buffer{}
-	fmt.Fprintf(&buf, template, grp.Name)
-	fmt.Fprint(&buf, sizeOptions, rateOptions)
-	return buf.Bytes()
-}
 
 func stopUserServices(cli *client.Client, inter Interacter, services ...string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout.DefaultTimeout))
@@ -247,23 +99,6 @@ func serviceIsSlotActivated(app *snap.AppInfo) bool {
 	return len(app.ActivatesOn) > 0
 }
 
-// serviceUnits returns the service unit of the primary service, and a list
-// of service units for the activation services.
-func serviceUnits(app *snap.AppInfo) (service string, activators []string) {
-	// Add application sockets
-	for _, socket := range app.Sockets {
-		activators = append(activators, filepath.Base(socket.File()))
-	}
-	// Sort the results from sockets for consistency
-	sort.Strings(activators)
-
-	// Add application timer
-	if app.Timer != nil {
-		activators = append(activators, filepath.Base(app.Timer.File()))
-	}
-	return app.ServiceName(), activators
-}
-
 // StartServicesFlags carries extra flags for StartServices.
 type StartServicesFlags struct {
 	Enable bool
@@ -296,7 +131,7 @@ func StartServices(apps []*snap.AppInfo, disabledSvcs []string, flags *StartServ
 		if servicesStarted {
 			for i := len(apps) - 1; i >= 0; i-- {
 				app := apps[i]
-				svc, activators := serviceUnits(app)
+				svc, activators := internal.SnapServiceUnits(app)
 				if e := stopService(systemSysd, inter, app.DaemonScope, append(activators, svc)); e != nil {
 					inter.Notify(fmt.Sprintf("While trying to stop previously started service %q: %v", app.ServiceName(), e))
 				}
@@ -345,7 +180,7 @@ func StartServices(apps []*snap.AppInfo, disabledSvcs []string, flags *StartServ
 		}
 		// Get all units for the service, but we only deal with
 		// the activators here.
-		_, activators := serviceUnits(app)
+		_, activators := internal.SnapServiceUnits(app)
 		if len(activators) == 0 {
 			// just skip if there are no activated units
 			continue
@@ -597,7 +432,7 @@ func (es *ensureSnapServicesContext) reloadModified() error {
 
 // ensureSnapServiceSystemdUnits takes care of writing .service files for all services
 // registered in snap.Info apps.
-func (es *ensureSnapServicesContext) ensureSnapServiceSystemdUnits(snapInfo *snap.Info, opts *generateSnapServicesOptions) error {
+func (es *ensureSnapServicesContext) ensureSnapServiceSystemdUnits(snapInfo *snap.Info, opts *internal.SnapServicesUnitOptions) error {
 	handleFileModification := func(app *snap.AppInfo, unitType string, name, path string, content []byte) error {
 		old, modifiedFile, err := tryFileUpdate(path, content)
 		if err != nil {
@@ -665,7 +500,7 @@ func (es *ensureSnapServicesContext) ensureSnapServiceSystemdUnits(snapInfo *sna
 
 		// Generate new service file state, make an app-specific generateSnapServicesOptions
 		// to avoid modifying the original copy, if we were to override the quota group.
-		content, err := generateSnapServiceFile(svc, &generateSnapServicesOptions{
+		content, err := internal.GenerateSnapServiceUnitFile(svc, &internal.SnapServicesUnitOptions{
 			QuotaGroup:              quotaGrp,
 			VitalityRank:            opts.VitalityRank,
 			RequireMountedSnapdSnap: opts.RequireMountedSnapdSnap,
@@ -680,7 +515,7 @@ func (es *ensureSnapServicesContext) ensureSnapServiceSystemdUnits(snapInfo *sna
 		}
 
 		// Generate systemd .socket files if needed
-		socketFiles, err := generateSnapSocketFiles(svc)
+		socketFiles, err := internal.GenerateSnapSocketUnitFiles(svc)
 		if err != nil {
 			return err
 		}
@@ -692,7 +527,7 @@ func (es *ensureSnapServicesContext) ensureSnapServiceSystemdUnits(snapInfo *sna
 		}
 
 		if svc.Timer != nil {
-			content, err := generateSnapTimerFile(svc)
+			content, err := internal.GenerateSnapServiceTimerUnitFile(svc)
 			if err != nil {
 				return err
 			}
@@ -720,7 +555,7 @@ func (es *ensureSnapServicesContext) ensureSnapsSystemdServices() (*quota.QuotaG
 		}
 
 		// always use RequireMountedSnapdSnap options from the global options
-		genServiceOpts := &generateSnapServicesOptions{
+		genServiceOpts := &internal.SnapServicesUnitOptions{
 			RequireMountedSnapdSnap: es.opts.RequireMountedSnapdSnap,
 			VitalityRank:            snapSvcOpts.VitalityRank,
 			QuotaGroup:              snapSvcOpts.QuotaGroup,
@@ -771,7 +606,7 @@ func (es *ensureSnapServicesContext) ensureSnapSlices(quotaGroups *quota.QuotaGr
 
 	// now make sure that all of the slice units exist
 	for _, grp := range quotaGroups.AllQuotaGroups() {
-		content := generateGroupSliceFile(grp)
+		content := internal.GenerateQuotaSliceUnitFile(grp)
 
 		sliceFileName := grp.SliceFileName()
 		path := filepath.Join(dirs.SnapServicesDir, sliceFileName)
@@ -818,7 +653,7 @@ func (es *ensureSnapServicesContext) ensureSnapJournaldUnits(quotaGroups *quota.
 			continue
 		}
 
-		contents := generateJournaldConfFile(grp)
+		contents := internal.GenerateQuotaJournaldConfFile(grp)
 		fileName := grp.JournalConfFileName()
 
 		path := filepath.Join(dirs.SnapSystemdDir, fileName)
@@ -860,7 +695,7 @@ func (es *ensureSnapServicesContext) ensureJournalQuotaServiceUnits(quotaGroups 
 		}
 
 		dropInPath := grp.JournalServiceDropInFile()
-		content := genJournalServiceFile(grp)
+		content := internal.GenerateQuotaJournalServiceFile(grp)
 		if err := handleFileModification(grp, dropInPath, content); err != nil {
 			return err
 		}
@@ -927,22 +762,6 @@ func EnsureSnapServices(snaps map[*snap.Info]*SnapServiceOptions, opts *EnsureSn
 	return context.reloadModified()
 }
 
-// generateSnapServicesOptions is a struct for controlling the generated service
-// definition for a snap service.
-type generateSnapServicesOptions struct {
-	// VitalityRank is the rank of all services in the specified snap used by
-	// the OOM killer when OOM conditions are reached.
-	VitalityRank int
-
-	// QuotaGroup is the quota group for the service.
-	QuotaGroup *quota.Group
-
-	// RequireMountedSnapdSnap is whether the generated units should depend on
-	// the snapd snap being mounted, this is specific to systems like UC18 and
-	// UC20 which have the snapd snap and need to have units generated
-	RequireMountedSnapdSnap bool
-}
-
 // StopServicesFlags carries extra flags for StopServices.
 type StopServicesFlags struct {
 	Disable bool
@@ -991,7 +810,7 @@ func StopServices(apps []*snap.AppInfo, flags *StopServicesFlags, reason snap.Se
 		// StartServices logic does actually not enable/start any service which are activated,
 		// but rather only the activation services themselves, so one might argue if it
 		// is really necessary to disable the primary service.
-		svc, activators := serviceUnits(app)
+		svc, activators := internal.SnapServiceUnits(app)
 
 		var err error
 		timings.Run(tm, "stop-service", fmt.Sprintf("stop service %q", app.ServiceName()), func(nested timings.Measurer) {
@@ -1142,737 +961,6 @@ func RemoveSnapServices(s *snap.Info, inter Interacter) error {
 	return nil
 }
 
-func genServiceNames(snap *snap.Info, appNames []string) []string {
-	names := make([]string, 0, len(appNames))
-
-	for _, name := range appNames {
-		if app := snap.Apps[name]; app != nil {
-			names = append(names, app.ServiceName())
-		}
-	}
-	return names
-}
-
-func genServiceFile(appInfo *snap.AppInfo, opts *generateSnapServicesOptions) ([]byte, error) {
-	if opts == nil {
-		opts = &generateSnapServicesOptions{}
-	}
-
-	// assemble all of the service directive snippets for all interfaces that
-	// this service needs to include in the generated systemd file
-
-	// use an ordered set to ensure we don't duplicate any keys from interfaces
-	// that specify the same snippet
-
-	// TODO: maybe we should error if multiple interfaces specify different
-	// values for the same directive, otherwise one of them will overwrite the
-	// other? What happens right now is that the snippet from the plug that
-	// comes last will win in the case of directives that can have only one
-	// value, but for some directives, systemd combines their values into a
-	// list.
-	ifaceServiceSnippets := &strutil.OrderedSet{}
-
-	for _, plug := range appInfo.Plugs {
-		iface, err := interfaces.ByName(plug.Interface)
-		if err != nil {
-			return nil, fmt.Errorf("error processing plugs while generating service unit for %v: %v", appInfo.SecurityTag(), err)
-		}
-		snips, err := interfaces.PermanentPlugServiceSnippets(iface, plug)
-		if err != nil {
-			return nil, fmt.Errorf("error processing plugs while generating service unit for %v: %v", appInfo.SecurityTag(), err)
-		}
-		for _, snip := range snips {
-			ifaceServiceSnippets.Put(snip)
-		}
-	}
-
-	// join the service snippets into one string to be included in the
-	// template
-	ifaceSpecifiedServiceSnippet := strings.Join(ifaceServiceSnippets.Items(), "\n")
-
-	serviceTemplate := `[Unit]
-# Auto-generated, DO NOT EDIT
-Description=Service for snap application {{.App.Snap.InstanceName}}.{{.App.Name}}
-{{- if .MountUnit }}
-Requires={{.MountUnit}}
-{{- end }}
-{{- if .PrerequisiteTarget}}
-Wants={{.PrerequisiteTarget}}
-{{- end}}
-{{- if .After}}
-After={{ stringsJoin .After " " }}
-{{- end}}
-{{- if .Before}}
-Before={{ stringsJoin .Before " "}}
-{{- end}}
-{{- if .CoreMountedSnapdSnapDep}}
-Wants={{ stringsJoin .CoreMountedSnapdSnapDep " "}}
-After={{ stringsJoin .CoreMountedSnapdSnapDep " "}}
-{{- end}}
-X-Snappy=yes
-
-[Service]
-EnvironmentFile=-/etc/environment
-ExecStart={{.App.LauncherCommand}}
-SyslogIdentifier={{.App.Snap.InstanceName}}.{{.App.Name}}
-Restart={{.Restart}}
-{{- if .App.RestartDelay}}
-RestartSec={{.App.RestartDelay.Seconds}}
-{{- end}}
-WorkingDirectory={{.WorkingDir}}
-{{- if .App.StopCommand}}
-ExecStop={{.App.LauncherStopCommand}}
-{{- end}}
-{{- if .App.ReloadCommand}}
-ExecReload={{.App.LauncherReloadCommand}}
-{{- end}}
-{{- if .App.PostStopCommand}}
-ExecStopPost={{.App.LauncherPostStopCommand}}
-{{- end}}
-{{- if .StopTimeout}}
-TimeoutStopSec={{.StopTimeout.Seconds}}
-{{- end}}
-{{- if .StartTimeout}}
-TimeoutStartSec={{.StartTimeout.Seconds}}
-{{- end}}
-Type={{.App.Daemon}}
-{{- if .Remain}}
-RemainAfterExit={{.Remain}}
-{{- end}}
-{{- if .BusName}}
-BusName={{.BusName}}
-{{- end}}
-{{- if .App.WatchdogTimeout}}
-WatchdogSec={{.App.WatchdogTimeout.Seconds}}
-{{- end}}
-{{- if .KillMode}}
-KillMode={{.KillMode}}
-{{- end}}
-{{- if .KillSignal}}
-KillSignal={{.KillSignal}}
-{{- end}}
-{{- if .OOMAdjustScore }}
-OOMScoreAdjust={{.OOMAdjustScore}}
-{{- end}}
-{{- if .InterfaceServiceSnippets}}
-{{.InterfaceServiceSnippets}}
-{{- end}}
-{{- if .SliceUnit}}
-Slice={{.SliceUnit}}
-{{- end}}
-{{- if .LogNamespace}}
-LogNamespace={{.LogNamespace}}
-{{- end}}
-{{- if not (or .App.Sockets .App.Timer .App.ActivatesOn) }}
-
-[Install]
-WantedBy={{.ServicesTarget}}
-{{- end}}
-`
-	var templateOut bytes.Buffer
-	tmpl := template.New("service-wrapper")
-	tmpl.Funcs(template.FuncMap{
-		"stringsJoin": strings.Join,
-	})
-	t := template.Must(tmpl.Parse(serviceTemplate))
-
-	restartCond := appInfo.RestartCond.String()
-	if restartCond == "" {
-		restartCond = snap.RestartOnFailure.String()
-	}
-
-	// use score -900+vitalityRank, where vitalityRank starts at 1
-	// and considering snapd itself has OOMScoreAdjust=-900
-	const baseOOMAdjustScore = -900
-	var oomAdjustScore int
-	if opts.VitalityRank > 0 {
-		oomAdjustScore = baseOOMAdjustScore + opts.VitalityRank
-	}
-
-	var remain string
-	if appInfo.Daemon == "oneshot" {
-		// any restart condition other than "no" is invalid for oneshot daemons
-		restartCond = "no"
-		// If StopExec is present for a oneshot service than we also need
-		// RemainAfterExit=yes
-		if appInfo.StopCommand != "" {
-			remain = "yes"
-		}
-	}
-	var killMode string
-	if !appInfo.StopMode.KillAll() {
-		killMode = "process"
-	}
-
-	var busName string
-	if appInfo.Daemon == "dbus" {
-		busName = appInfo.BusName
-		if busName == "" && len(appInfo.ActivatesOn) != 0 {
-			slot := appInfo.ActivatesOn[len(appInfo.ActivatesOn)-1]
-			if err := slot.Attr("name", &busName); err != nil {
-				// This should be impossible for a valid AppInfo
-				logger.Noticef("Cannot get 'name' attribute of dbus slot %q: %v", slot.Name, err)
-			}
-		}
-	}
-
-	wrapperData := struct {
-		App *snap.AppInfo
-
-		Restart                  string
-		WorkingDir               string
-		StopTimeout              time.Duration
-		StartTimeout             time.Duration
-		ServicesTarget           string
-		PrerequisiteTarget       string
-		MountUnit                string
-		Remain                   string
-		KillMode                 string
-		KillSignal               string
-		OOMAdjustScore           int
-		BusName                  string
-		Before                   []string
-		After                    []string
-		InterfaceServiceSnippets string
-		SliceUnit                string
-		LogNamespace             string
-
-		Home    string
-		EnvVars string
-
-		CoreMountedSnapdSnapDep []string
-	}{
-		App: appInfo,
-
-		InterfaceServiceSnippets: ifaceSpecifiedServiceSnippet,
-
-		Restart:        restartCond,
-		StopTimeout:    serviceStopTimeout(appInfo),
-		StartTimeout:   time.Duration(appInfo.StartTimeout),
-		Remain:         remain,
-		KillMode:       killMode,
-		KillSignal:     appInfo.StopMode.KillSignal(),
-		OOMAdjustScore: oomAdjustScore,
-		BusName:        busName,
-
-		Before: genServiceNames(appInfo.Snap, appInfo.Before),
-		After:  genServiceNames(appInfo.Snap, appInfo.After),
-
-		// systemd runs as PID 1 so %h will not work.
-		Home: "/root",
-	}
-	switch appInfo.DaemonScope {
-	case snap.SystemDaemon:
-		wrapperData.ServicesTarget = systemd.ServicesTarget
-		wrapperData.PrerequisiteTarget = systemd.PrerequisiteTarget
-		wrapperData.MountUnit = filepath.Base(systemd.MountUnitPath(appInfo.Snap.MountDir()))
-		wrapperData.WorkingDir = appInfo.Snap.DataDir()
-		wrapperData.After = append(wrapperData.After, "snapd.apparmor.service")
-	case snap.UserDaemon:
-		wrapperData.ServicesTarget = systemd.UserServicesTarget
-		// FIXME: ideally use UserDataDir("%h"), but then the
-		// unit fails if the directory doesn't exist.
-		wrapperData.WorkingDir = appInfo.Snap.DataDir()
-	default:
-		panic("unknown snap.DaemonScope")
-	}
-
-	// check the quota group slice
-	if opts.QuotaGroup != nil {
-		wrapperData.SliceUnit = opts.QuotaGroup.SliceFileName()
-		if opts.QuotaGroup.JournalQuotaSet() {
-			wrapperData.LogNamespace = opts.QuotaGroup.JournalNamespaceName()
-		}
-	}
-
-	// Add extra "After" targets
-	if wrapperData.PrerequisiteTarget != "" {
-		wrapperData.After = append([]string{wrapperData.PrerequisiteTarget}, wrapperData.After...)
-	}
-	if wrapperData.MountUnit != "" {
-		wrapperData.After = append([]string{wrapperData.MountUnit}, wrapperData.After...)
-	}
-
-	if opts.RequireMountedSnapdSnap {
-		// on core 18+ systems, the snapd tooling is exported
-		// into the host system via a special mount unit, which
-		// also adds an implicit dependency on the snapd snap
-		// mount thus /usr/bin/snap points
-		wrapperData.CoreMountedSnapdSnapDep = []string{SnapdToolingMountUnit}
-	}
-
-	if err := t.Execute(&templateOut, wrapperData); err != nil {
-		// this can never happen, except we forget a variable
-		logger.Panicf("Unable to execute template: %v", err)
-	}
-
-	return templateOut.Bytes(), nil
-}
-
-func genServiceSocketFile(appInfo *snap.AppInfo, socketName string) []byte {
-	socketTemplate := `[Unit]
-# Auto-generated, DO NOT EDIT
-Description=Socket {{.SocketName}} for snap application {{.App.Snap.InstanceName}}.{{.App.Name}}
-{{- if .MountUnit}}
-Requires={{.MountUnit}}
-After={{.MountUnit}}
-{{- end}}
-X-Snappy=yes
-
-[Socket]
-Service={{.ServiceFileName}}
-FileDescriptorName={{.SocketInfo.Name}}
-ListenStream={{.ListenStream}}
-{{- if .SocketInfo.SocketMode}}
-SocketMode={{.SocketInfo.SocketMode | printf "%04o"}}
-{{- end}}
-
-[Install]
-WantedBy={{.SocketsTarget}}
-`
-	var templateOut bytes.Buffer
-	t := template.Must(template.New("socket-wrapper").Parse(socketTemplate))
-
-	socket := appInfo.Sockets[socketName]
-	listenStream := renderListenStream(socket)
-	wrapperData := struct {
-		App             *snap.AppInfo
-		ServiceFileName string
-		SocketsTarget   string
-		MountUnit       string
-		SocketName      string
-		SocketInfo      *snap.SocketInfo
-		ListenStream    string
-	}{
-		App:             appInfo,
-		ServiceFileName: filepath.Base(appInfo.ServiceFile()),
-		SocketsTarget:   systemd.SocketsTarget,
-		SocketName:      socketName,
-		SocketInfo:      socket,
-		ListenStream:    listenStream,
-	}
-	switch appInfo.DaemonScope {
-	case snap.SystemDaemon:
-		wrapperData.MountUnit = filepath.Base(systemd.MountUnitPath(appInfo.Snap.MountDir()))
-	case snap.UserDaemon:
-		// nothing
-	default:
-		panic("unknown snap.DaemonScope")
-	}
-
-	if err := t.Execute(&templateOut, wrapperData); err != nil {
-		// this can never happen, except we forget a variable
-		logger.Panicf("Unable to execute template: %v", err)
-	}
-
-	return templateOut.Bytes()
-}
-
-func genJournalServiceFile(grp *quota.Group) []byte {
-	buf := bytes.Buffer{}
-	template := `[Service]
-LogsDirectory=
-`
-	fmt.Fprint(&buf, template)
-	return buf.Bytes()
-}
-
-func generateSnapSocketFiles(app *snap.AppInfo) (map[string][]byte, error) {
-	if err := snap.ValidateApp(app); err != nil {
-		return nil, err
-	}
-
-	socketFiles := make(map[string][]byte)
-	for name := range app.Sockets {
-		socketFiles[name] = genServiceSocketFile(app, name)
-	}
-	return socketFiles, nil
-}
-
-func renderListenStream(socket *snap.SocketInfo) string {
-	s := socket.App.Snap
-	listenStream := socket.ListenStream
-	switch socket.App.DaemonScope {
-	case snap.SystemDaemon:
-		listenStream = strings.Replace(listenStream, "$SNAP_DATA", s.DataDir(), -1)
-		// TODO: when we support User/Group in the generated
-		// systemd unit, adjust this accordingly
-		serviceUserUid := sys.UserID(0)
-		runtimeDir := s.UserXdgRuntimeDir(serviceUserUid)
-		listenStream = strings.Replace(listenStream, "$XDG_RUNTIME_DIR", runtimeDir, -1)
-		listenStream = strings.Replace(listenStream, "$SNAP_COMMON", s.CommonDataDir(), -1)
-	case snap.UserDaemon:
-		// TODO: use SnapDirOpts here. User daemons are also an experimental
-		// feature so, for simplicity, we can not pass opts here for now
-		listenStream = strings.Replace(listenStream, "$SNAP_USER_DATA", s.UserDataDir("%h", nil), -1)
-		listenStream = strings.Replace(listenStream, "$SNAP_USER_COMMON", s.UserCommonDataDir("%h", nil), -1)
-		// FIXME: find some way to share code with snap.UserXdgRuntimeDir()
-		listenStream = strings.Replace(listenStream, "$XDG_RUNTIME_DIR", fmt.Sprintf("%%t/snap.%s", s.InstanceName()), -1)
-	default:
-		panic("unknown snap.DaemonScope")
-	}
-	return listenStream
-}
-
-func generateSnapTimerFile(app *snap.AppInfo) ([]byte, error) {
-	timerTemplate := `[Unit]
-# Auto-generated, DO NOT EDIT
-Description=Timer {{.TimerName}} for snap application {{.App.Snap.InstanceName}}.{{.App.Name}}
-{{- if .MountUnit}}
-Requires={{.MountUnit}}
-After={{.MountUnit}}
-{{- end}}
-X-Snappy=yes
-
-[Timer]
-Unit={{.ServiceFileName}}
-{{ range .Schedules }}OnCalendar={{ . }}
-{{ end }}
-[Install]
-WantedBy={{.TimersTarget}}
-`
-	var templateOut bytes.Buffer
-	t := template.Must(template.New("timer-wrapper").Parse(timerTemplate))
-
-	timerSchedule, err := timeutil.ParseSchedule(app.Timer.Timer)
-	if err != nil {
-		return nil, err
-	}
-
-	schedules := generateOnCalendarSchedules(timerSchedule)
-
-	wrapperData := struct {
-		App             *snap.AppInfo
-		ServiceFileName string
-		TimersTarget    string
-		TimerName       string
-		MountUnit       string
-		Schedules       []string
-	}{
-		App:             app,
-		ServiceFileName: filepath.Base(app.ServiceFile()),
-		TimersTarget:    systemd.TimersTarget,
-		TimerName:       app.Name,
-		Schedules:       schedules,
-	}
-	switch app.DaemonScope {
-	case snap.SystemDaemon:
-		wrapperData.MountUnit = filepath.Base(systemd.MountUnitPath(app.Snap.MountDir()))
-	case snap.UserDaemon:
-		// nothing
-	default:
-		panic("unknown snap.DaemonScope")
-	}
-
-	if err := t.Execute(&templateOut, wrapperData); err != nil {
-		// this can never happen, except we forget a variable
-		logger.Panicf("Unable to execute template: %v", err)
-	}
-
-	return templateOut.Bytes(), nil
-}
-
-func makeAbbrevWeekdays(start time.Weekday, end time.Weekday) []string {
-	out := make([]string, 0, 7)
-	for w := start; w%7 != (end + 1); w++ {
-		out = append(out, time.Weekday(w % 7).String()[0:3])
-	}
-	return out
-}
-
-// daysRange generates a string representing a continuous range between given
-// day numbers, which due to compatiblilty with old systemd version uses a
-// verbose syntax of x,y,z instead of x..z
-func daysRange(start, end uint) string {
-	var buf bytes.Buffer
-	for i := start; i <= end; i++ {
-		buf.WriteString(strconv.FormatInt(int64(i), 10))
-		if i < end {
-			buf.WriteRune(',')
-		}
-	}
-	return buf.String()
-}
-
-// generateOnCalendarSchedules converts a schedule into OnCalendar schedules
-// suitable for use in systemd *.timer units using systemd.time(7)
-// https://www.freedesktop.org/software/systemd/man/systemd.time.html
-// XXX: old systemd versions do not support x..y ranges
-func generateOnCalendarSchedules(schedule []*timeutil.Schedule) []string {
-	calendarEvents := make([]string, 0, len(schedule))
-	for _, sched := range schedule {
-		days := make([]string, 0, len(sched.WeekSpans))
-		for _, week := range sched.WeekSpans {
-			abbrev := strings.Join(makeAbbrevWeekdays(week.Start.Weekday, week.End.Weekday), ",")
-
-			if week.Start.Pos == timeutil.EveryWeek && week.End.Pos == timeutil.EveryWeek {
-				// eg: mon, mon-fri, fri-mon
-				days = append(days, fmt.Sprintf("%s *-*-*", abbrev))
-				continue
-			}
-			// examples:
-			// mon1 - Mon *-*-1..7 (Monday during the first 7 days)
-			// fri1 - Fri *-*-1..7 (Friday during the first 7 days)
-
-			// entries below will make systemd timer expire more
-			// frequently than the schedule suggests, however snap
-			// runner evaluates current time and gates the actual
-			// action
-			//
-			// mon1-tue - *-*-1..7 *-*-8 (anchored at first
-			// Monday; Monday happens during the 7 days,
-			// Tuesday can possibly happen on the 8th day if
-			// the month started on Tuesday)
-			//
-			// mon-tue1 - *-*~1 *-*-1..7 (anchored at first
-			// Tuesday; matching Monday can happen on the
-			// last day of previous month if Tuesday is the
-			// 1st)
-			//
-			// mon5-tue - *-*~1..7 *-*-1 (anchored at last
-			// Monday, the matching Tuesday can still happen
-			// within the last 7 days, or on the 1st of the
-			// next month)
-			//
-			// fri4-mon - *-*-22-31 *-*-1..7 (anchored at 4th
-			// Friday, can span onto the next month, extreme case in
-			// February when 28th is Friday)
-			//
-			// XXX: since old versions of systemd, eg. 229 available
-			// in 16.04 does not support x..y ranges, days need to
-			// be enumerated like so:
-			// Mon *-*-1..7 -> Mon *-*-1,2,3,4,5,6,7
-			//
-			// XXX: old systemd versions do not support the last n
-			// days syntax eg, *-*~1, thus the range needs to be
-			// generated in more verbose way like so:
-			// Mon *-*~1..7 -> Mon *-*-22,23,24,25,26,27,28,29,30,31
-			// (22-28 is the last week, but the month can have
-			// anywhere from 28 to 31 days)
-			//
-			startPos := week.Start.Pos
-			endPos := startPos
-			if !week.AnchoredAtStart() {
-				startPos = week.End.Pos
-				endPos = startPos
-			}
-			startDay := (startPos-1)*7 + 1
-			endDay := (endPos) * 7
-
-			if week.IsSingleDay() {
-				// single day, can use the 'weekday' filter
-				if startPos == timeutil.LastWeek {
-					// last week of a month, which can be
-					// 22-28 in case of February, while
-					// month can have between 28 and 31 days
-					days = append(days,
-						fmt.Sprintf("%s *-*-%s", abbrev, daysRange(22, 31)))
-				} else {
-					days = append(days,
-						fmt.Sprintf("%s *-*-%s", abbrev, daysRange(startDay, endDay)))
-				}
-				continue
-			}
-
-			if week.AnchoredAtStart() {
-				// explore the edge cases first
-				switch startPos {
-				case timeutil.LastWeek:
-					// starts in the last week of the month and
-					// possibly spans into the first week of the
-					// next month;
-					// month can have between 28 and 31
-					// days
-					days = append(days,
-						// trailing 29-31 that are not part of a full week
-						fmt.Sprintf("*-*-%s", daysRange(29, 31)),
-						fmt.Sprintf("*-*-%s", daysRange(1, 7)))
-				case 4:
-					// a range in the 4th week can span onto
-					// the next week, which is either 28-31
-					// or in extreme case (eg. February with
-					// 28 days) 1-7 of the next month
-					days = append(days,
-						// trailing 29-31 that are not part of a full week
-						fmt.Sprintf("*-*-%s", daysRange(29, 31)),
-						fmt.Sprintf("*-*-%s", daysRange(1, 7)))
-				default:
-					// can possibly spill into the next week
-					days = append(days,
-						fmt.Sprintf("*-*-%s", daysRange(startDay+7, endDay+7)))
-				}
-
-				if startDay < 28 {
-					days = append(days,
-						fmt.Sprintf("*-*-%s", daysRange(startDay, endDay)))
-				} else {
-					// from the end of the month
-					days = append(days,
-						fmt.Sprintf("*-*-%s", daysRange(startDay-7, endDay-7)))
-				}
-			} else {
-				switch endPos {
-				case timeutil.LastWeek:
-					// month can have between 28 and 31
-					// days, add trailing 29-31 that are not
-					// part of a full week
-					days = append(days, fmt.Sprintf("*-*-%s", daysRange(29, 31)))
-				case 1:
-					// possibly spans from the last week of the
-					// previous month and ends in the first week of
-					// current month
-					days = append(days, fmt.Sprintf("*-*-%s", daysRange(22, 31)))
-				default:
-					// can possibly spill into the previous week
-					days = append(days,
-						fmt.Sprintf("*-*-%s", daysRange(startDay-7, endDay-7)))
-				}
-				if endDay < 28 {
-					days = append(days,
-						fmt.Sprintf("*-*-%s", daysRange(startDay, endDay)))
-				} else {
-					days = append(days,
-						fmt.Sprintf("*-*-%s", daysRange(startDay-7, endDay-7)))
-				}
-			}
-		}
-
-		if len(days) == 0 {
-			// no weekday spec, meaning the timer runs every day
-			days = []string{"*-*-*"}
-		}
-
-		startTimes := make([]string, 0, len(sched.ClockSpans))
-		for _, clocks := range sched.ClockSpans {
-			// use expanded clock spans
-			for _, span := range clocks.ClockSpans() {
-				when := span.Start
-				if span.Spread {
-					length := span.End.Sub(span.Start)
-					if length < 0 {
-						// span Start wraps around, so we have '00:00.Sub(23:45)'
-						length = -length
-					}
-					if length > 5*time.Minute {
-						// replicate what timeutil.Next() does
-						// and cut some time at the end of the
-						// window so that events do not happen
-						// directly one after another
-						length -= 5 * time.Minute
-					}
-					when = when.Add(randutil.RandomDuration(length))
-				}
-				if when.Hour == 24 {
-					// 24:00 for us means the other end of
-					// the day, for systemd we need to
-					// adjust it to the 0-23 hour range
-					when.Hour -= 24
-				}
-
-				startTimes = append(startTimes, when.String())
-			}
-		}
-
-		for _, day := range days {
-			if len(startTimes) == 0 {
-				// current schedule is days only
-				calendarEvents = append(calendarEvents, day)
-				continue
-			}
-
-			for _, startTime := range startTimes {
-				calendarEvents = append(calendarEvents, fmt.Sprintf("%s %s", day, startTime))
-			}
-		}
-	}
-	return calendarEvents
-}
-
-// serviceStatus represents the status of a service, and any of its activation
-// service units. It also provides a method isEnabled which can determine the true
-// enable status for services that are activated.
-type serviceStatus struct {
-	name        string
-	service     *systemd.UnitStatus
-	activators  []*systemd.UnitStatus
-	slotEnabled bool
-}
-
-func (s *serviceStatus) isEnabled() bool {
-	// If the service is slot activated, it cannot be disabled and thus always
-	// is enabled.
-	if s.slotEnabled {
-		return true
-	}
-
-	// If there are no activator units, then return status of the
-	// primary service.
-	if len(s.activators) == 0 {
-		return s.service.Enabled
-	}
-
-	// Just a single of those activators need to be enabled for us
-	// to report the service as enabled.
-	for _, a := range s.activators {
-		if a.Enabled {
-			return true
-		}
-	}
-	return false
-}
-
-func appServiceUnitsMany(apps []*snap.AppInfo) []string {
-	var allUnits []string
-	for _, app := range apps {
-		if !app.IsService() {
-			continue
-		}
-		// TODO: handle user daemons
-		if app.DaemonScope != snap.SystemDaemon {
-			continue
-		}
-		svc, activators := serviceUnits(app)
-		allUnits = append(allUnits, svc)
-		allUnits = append(allUnits, activators...)
-	}
-	return allUnits
-}
-
-func queryServiceStatusMany(sysd systemd.Systemd, apps []*snap.AppInfo) ([]*serviceStatus, error) {
-	allUnits := appServiceUnitsMany(apps)
-	unitStatuses, err := sysd.Status(allUnits)
-	if err != nil {
-		return nil, err
-	}
-
-	var appStatuses []*serviceStatus
-	var statusIndex int
-	for _, app := range apps {
-		if !app.IsService() {
-			continue
-		}
-		// TODO: handle user daemons
-		if app.DaemonScope != snap.SystemDaemon {
-			continue
-		}
-
-		// This builds on the principle that sysd.Status returns service unit statuses
-		// in the exact same order we requested them in.
-		_, activators := serviceUnits(app)
-		svcSt := &serviceStatus{
-			name:        app.Name,
-			service:     unitStatuses[statusIndex],
-			slotEnabled: serviceIsSlotActivated(app),
-		}
-		if len(activators) > 0 {
-			svcSt.activators = unitStatuses[statusIndex+1 : statusIndex+1+len(activators)]
-		}
-		appStatuses = append(appStatuses, svcSt)
-		statusIndex += 1 + len(activators)
-	}
-	return appStatuses, nil
-}
-
 type RestartServicesFlags struct {
 	// Reload set if we might need to reload the service definitions.
 	Reload bool
@@ -1899,15 +987,15 @@ func RestartServices(apps []*snap.AppInfo, explicitServices []string,
 	sysd := systemd.New(systemd.SystemMode, inter)
 
 	// Get service statuses for each of the apps
-	sts, err := queryServiceStatusMany(sysd, apps)
+	sts, err := internal.QueryServiceStatusMany(sysd, apps)
 	if err != nil {
 		return err
 	}
 
 	for _, st := range sts {
-		unitName := st.service.Name
-		unitActive := st.service.Active
-		unitEnabled := st.isEnabled()
+		unitName := st.ServiceUnitStatus().Name
+		unitActive := st.ServiceUnitStatus().Active
+		unitEnabled := st.IsEnabled()
 
 		// If the unit was explicitly mentioned in the command line, restart it
 		// even if it is disabled; otherwise, we only restart units which are
@@ -1944,7 +1032,7 @@ func RestartServices(apps []*snap.AppInfo, explicitServices []string,
 // together with their enable/disable status.
 func ServicesEnableState(s *snap.Info, inter Interacter) (map[string]bool, error) {
 	sysd := systemd.New(systemd.SystemMode, inter)
-	sts, err := queryServiceStatusMany(sysd, s.Services())
+	sts, err := internal.QueryServiceStatusMany(sysd, s.Services())
 	if err != nil {
 		return nil, err
 	}
@@ -1952,7 +1040,7 @@ func ServicesEnableState(s *snap.Info, inter Interacter) (map[string]bool, error
 	// loop over all services in the snap, storing the current enable status
 	snapSvcsState := make(map[string]bool, len(sts))
 	for _, st := range sts {
-		snapSvcsState[st.name] = st.isEnabled()
+		snapSvcsState[st.Name()] = st.IsEnabled()
 	}
 	return snapSvcsState, nil
 }
@@ -1961,7 +1049,7 @@ func ServicesEnableState(s *snap.Info, inter Interacter) (map[string]bool, error
 // in the snap.
 func QueryDisabledServices(info *snap.Info, pb progress.Meter) ([]string, error) {
 	sysd := systemd.New(systemd.SystemMode, pb)
-	sts, err := queryServiceStatusMany(sysd, info.Services())
+	sts, err := internal.QueryServiceStatusMany(sysd, info.Services())
 	if err != nil {
 		return nil, err
 	}
@@ -1969,8 +1057,8 @@ func QueryDisabledServices(info *snap.Info, pb progress.Meter) ([]string, error)
 	// add all disabled services to the list
 	disabledSnapSvcs := []string{}
 	for _, st := range sts {
-		if !st.isEnabled() {
-			disabledSnapSvcs = append(disabledSnapSvcs, st.name)
+		if !st.IsEnabled() {
+			disabledSnapSvcs = append(disabledSnapSvcs, st.Name())
 		}
 	}
 


### PR DESCRIPTION
Split out internal functionality in the wrappers package for services into an 'internal' package. Nothing functionality/test wise is changed, this also makes it easy to see what's tested and what's not tested.