### PR TITLE
interfaces: new "ros" host file system support

### DIFF
--- a/interfaces/builtin/ros_opt_data.go
+++ b/interfaces/builtin/ros_opt_data.go
@@ -56,7 +56,7 @@ func init() {
 	registerIface(&rosOptDataInterface{commonInterface{
 		name:                  "ros-opt-data",
 		summary:               rosOptDataSummary,
-		implicitOnCore:        true,
+		implicitOnCore:        false,
 		implicitOnClassic:     true,
 		baseDeclarationSlots:  rosOptDataBaseDeclarationSlots,
 		connectedPlugAppArmor: rosOptDataConnectedPlugAppArmor,

--- a/interfaces/builtin/ros_opt_data.go
+++ b/interfaces/builtin/ros_opt_data.go
@@ -1,0 +1,55 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+const rosOptDataSummary = `Allows read-only access to the xacro,yaml,urdf,stl files in /opt/ros folder`
+
+const rosOptDataBaseDeclarationSlots = `
+  ros-opt-data:
+    allow-installation:
+      slot-snap-type:
+        - core
+`
+
+const rosOptDataConnectedPlugAppArmor = `
+# Description: Allows read-only access to the xacro,yaml,urdf,stl files in /opt/ros folder
+# capability dac_read_search,  # this should not be necessary, the idea is to read only what normal user can read
+/var/lib/snapd/hostfs/opt/ros/ r,
+/var/lib/snapd/hostfs/opt/ros/**/ r,
+/var/lib/snapd/hostfs/opt/ros/**/*.xacro r,
+/var/lib/snapd/hostfs/opt/ros/**/*.yaml r,
+/var/lib/snapd/hostfs/opt/ros/**/*.urdf r,
+/var/lib/snapd/hostfs/opt/ros/**/*.stl r,
+`
+
+type rosOptDataInterface struct {
+	commonInterface
+}
+
+func init() {
+	registerIface(&rosOptDataInterface{commonInterface{
+		name:                  "ros-opt-data",
+		summary:               rosOptDataSummary,
+		implicitOnCore:        true,
+		implicitOnClassic:     true,
+		baseDeclarationSlots:  rosOptDataBaseDeclarationSlots,
+		connectedPlugAppArmor: rosOptDataConnectedPlugAppArmor,
+	}})
+}

--- a/interfaces/builtin/ros_opt_data.go
+++ b/interfaces/builtin/ros_opt_data.go
@@ -19,7 +19,7 @@
 
 package builtin
 
-const rosOptDataSummary = `Allows read-only access to the xacro,yaml,urdf,stl files in /opt/ros folder`
+const rosOptDataSummary = `Allows read-only access to the static data such as xacro,yaml,urdf,stl,... in the standard /opt/ros folder`
 
 const rosOptDataBaseDeclarationSlots = `
   ros-opt-data:
@@ -33,10 +33,19 @@ const rosOptDataConnectedPlugAppArmor = `
 # capability dac_read_search,  # this should not be necessary, the idea is to read only what normal user can read
 /var/lib/snapd/hostfs/opt/ros/ r,
 /var/lib/snapd/hostfs/opt/ros/**/ r,
-/var/lib/snapd/hostfs/opt/ros/**/*.xacro r,
-/var/lib/snapd/hostfs/opt/ros/**/*.yaml r,
-/var/lib/snapd/hostfs/opt/ros/**/*.urdf r,
-/var/lib/snapd/hostfs/opt/ros/**/*.stl r,
+/var/lib/snapd/hostfs/opt/ros/**/*.config r,        # for robot configuration
+/var/lib/snapd/hostfs/opt/ros/**/*.yaml r,          # for robot configuration
+/var/lib/snapd/hostfs/opt/ros/**/*.xacro r,         # for robot macro description files
+/var/lib/snapd/hostfs/opt/ros/**/*.urdf r,          # for robot description files
+/var/lib/snapd/hostfs/opt/ros/**/*.stl r,           # for robot 3d meshes
+/var/lib/snapd/hostfs/opt/ros/**/*.dae r,           # for robot 3d meshes
+/var/lib/snapd/hostfs/opt/ros/**/*.png r,           # for robot meshes
+/var/lib/snapd/hostfs/opt/ros/**/*.jpg r,           # for robot meshes
+/var/lib/snapd/hostfs/opt/ros/**/*.sh r,            # for sourcing the ros workspace from shell
+/var/lib/snapd/hostfs/opt/ros/**/*.zsh r,           # for sourcing the ros workspace from shell
+/var/lib/snapd/hostfs/opt/ros/**/*.bash r,          # for sourcing the ros workspace from shell
+/var/lib/snapd/hostfs/opt/ros/**/package.xml r,     # for package.xml metadata
+
 `
 
 type rosOptDataInterface struct {

--- a/interfaces/builtin/ros_opt_data_test.go
+++ b/interfaces/builtin/ros_opt_data_test.go
@@ -75,8 +75,6 @@ func (s *rosOptDataInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
 }
 
-
-
 func (s *rosOptDataInterfaceSuite) TestAppArmorSpec(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
@@ -84,20 +82,15 @@ func (s *rosOptDataInterfaceSuite) TestAppArmorSpec(c *C) {
 	spec := &apparmor.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
-	// does this test breaks if I put a comment in front of the capability?
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `capability dac_read_search,`)
-	
-	// aren't we testing if a documentation string is equal to itself?
-	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `# Description: Allow read-only access`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `# Description: Allows read-only access`)
 }
 
 func (s *rosOptDataInterfaceSuite) TestStaticInfo(c *C) {
 	si := interfaces.StaticInfoOf(s.iface)
 	c.Assert(si.ImplicitOnCore, Equals, true)
 	c.Assert(si.ImplicitOnClassic, Equals, true)
-
-	// aren't we testing if a documentation string is equal to itself?
-	c.Assert(si.Summary, Equals, `allows read-only access`)
+	c.Assert(si.Summary, testutil.Contains, `Allows read-only access`)
 	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "ros-opt-data")
 }
 

--- a/interfaces/builtin/ros_opt_data_test.go
+++ b/interfaces/builtin/ros_opt_data_test.go
@@ -51,16 +51,16 @@ apps:
   plugs: [ros-opt-data]
 `
 
-const rosOptDataCoreYaml = `name: core
+const rosOptDataProducerYaml = `name: producer
 version: 0
-type: os
-slots:
-  ros-opt-data:
+apps:
+  app:
+   slots: [ros-opt-data]
 `
 
 func (s *rosOptDataInterfaceSuite) SetUpTest(c *C) {
 	s.plug, s.plugInfo = MockConnectedPlug(c, rosOptDataConsumerYaml, nil, "ros-opt-data")
-	s.slot, s.slotInfo = MockConnectedSlot(c, rosOptDataCoreYaml, nil, "ros-opt-data")
+	s.slot, s.slotInfo = MockConnectedSlot(c, rosOptDataProducerYaml, nil, "ros-opt-data")
 }
 
 func (s *rosOptDataInterfaceSuite) TestName(c *C) {
@@ -88,7 +88,7 @@ func (s *rosOptDataInterfaceSuite) TestAppArmorSpec(c *C) {
 
 func (s *rosOptDataInterfaceSuite) TestStaticInfo(c *C) {
 	si := interfaces.StaticInfoOf(s.iface)
-	c.Assert(si.ImplicitOnCore, Equals, true)
+	c.Assert(si.ImplicitOnCore, Equals, false)
 	c.Assert(si.ImplicitOnClassic, Equals, true)
 	c.Assert(si.Summary, testutil.Contains, `Allows read-only access`)
 	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "ros-opt-data")

--- a/interfaces/builtin/ros_opt_data_test.go
+++ b/interfaces/builtin/ros_opt_data_test.go
@@ -1,0 +1,110 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type rosOptDataInterfaceSuite struct {
+	testutil.BaseTest
+
+	iface    interfaces.Interface
+	slotInfo *snap.SlotInfo
+	slot     *interfaces.ConnectedSlot
+	plugInfo *snap.PlugInfo
+	plug     *interfaces.ConnectedPlug
+}
+
+var _ = Suite(&rosOptDataInterfaceSuite{
+	iface: builtin.MustInterface("ros-opt-data"),
+})
+
+const rosOptDataConsumerYaml = `name: consumer
+version: 0
+apps:
+ app:
+  plugs: [ros-opt-data]
+`
+
+const rosOptDataCoreYaml = `name: core
+version: 0
+type: os
+slots:
+  ros-opt-data:
+`
+
+func (s *rosOptDataInterfaceSuite) SetUpTest(c *C) {
+	s.plug, s.plugInfo = MockConnectedPlug(c, rosOptDataConsumerYaml, nil, "ros-opt-data")
+	s.slot, s.slotInfo = MockConnectedSlot(c, rosOptDataCoreYaml, nil, "ros-opt-data")
+}
+
+func (s *rosOptDataInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "ros-opt-data")
+}
+
+func (s *rosOptDataInterfaceSuite) TestSanitizeSlot(c *C) {
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.slotInfo), IsNil)
+}
+
+func (s *rosOptDataInterfaceSuite) TestSanitizePlug(c *C) {
+	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
+}
+
+
+
+func (s *rosOptDataInterfaceSuite) TestAppArmorSpec(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	spec := &apparmor.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	// does this test breaks if I put a comment in front of the capability?
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `capability dac_read_search,`)
+	
+	// aren't we testing if a documentation string is equal to itself?
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `# Description: Allow read-only access`)
+}
+
+func (s *rosOptDataInterfaceSuite) TestStaticInfo(c *C) {
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Assert(si.ImplicitOnCore, Equals, true)
+	c.Assert(si.ImplicitOnClassic, Equals, true)
+
+	// aren't we testing if a documentation string is equal to itself?
+	c.Assert(si.Summary, Equals, `allows read-only access`)
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "ros-opt-data")
+}
+
+func (s *rosOptDataInterfaceSuite) TestAutoConnect(c *C) {
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.slotInfo), Equals, true)
+}
+
+func (s *rosOptDataInterfaceSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -167,6 +167,7 @@ func (s *baseDeclSuite) TestAutoConnection(c *C) {
 		"online-accounts-service": true,
 		"opengl":                  true,
 		"optical-drive":           true,
+		"ros-opt-data":            true,
 		"screen-inhibit-control":  true,
 		"ubuntu-download-manager": true,
 		"unity7":                  true,

--- a/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
@@ -62,6 +62,9 @@ apps:
   camera:
     command: bin/run
     plugs: [ camera ]
+  can-bus:
+    command: bin/run
+    plugs: [ can-bus ]
   cifs-mount:
     command: bin/run
     plugs: [ cifs-mount ]
@@ -182,12 +185,6 @@ apps:
   home:
     command: bin/run
     plugs: [ home ]
-  system-packages-doc:
-    command: bin/run
-    plugs: [ system-packages-doc ]
-  system-source-code:
-    command: bin/run
-    plugs: [ system-source-code ]
   hostname-control:
     command: bin/run
     plugs: [ hostname-control ]
@@ -431,9 +428,6 @@ apps:
   service-watchdog:
     command: bin/run
     plugs: [ daemon-notify ]
-  can-bus:
-    command: bin/run
-    plugs: [ can-bus ]
   sd-control:
     command: bin/run
     plugs: [ sd-control ]
@@ -458,6 +452,12 @@ apps:
   system-observe:
     command: bin/run
     plugs: [ system-observe ]
+  system-packages-doc:
+    command: bin/run
+    plugs: [ system-packages-doc ]
+  system-source-code:
+    command: bin/run
+    plugs: [ system-source-code ]
   system-trace:
     command: bin/run
     plugs: [ system-trace ]

--- a/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
@@ -404,6 +404,9 @@ apps:
   removable-media:
     command: bin/run
     plugs: [ removable-media ]
+  ros-opt-data:
+    command: bin/run
+    plugs: [ ros-opt-data ]
   screen-inhibit-control:
     command: bin/run
     plugs: [ screen-inhibit-control ]

--- a/tests/main/interfaces-ros-opt-data/task.yaml
+++ b/tests/main/interfaces-ros-opt-data/task.yaml
@@ -1,0 +1,81 @@
+summary: Ensure that the system-files interface works.
+
+details: |
+    The system-files interface allows access specific system files or directories.
+
+environment:
+    # keep in sync with ./test-snapd-sh/meta/snap.yaml
+    TESTDIR: /mnt/testdir
+
+prepare: |
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
+
+    # Fist layer of dirs and files
+    "$TESTSTOOLS"/fs-state mock-dir "$TESTDIR"
+    "$TESTSTOOLS"/fs-state mock-file "$TESTDIR"/.testfile1
+    "$TESTSTOOLS"/fs-state mock-file "$TESTDIR"/readonly_file1
+    "$TESTSTOOLS"/fs-state mock-dir "$TESTDIR"/.testdir1
+    "$TESTSTOOLS"/fs-state mock-dir "$TESTDIR"/testdir1
+
+    # Second layer of dirs and files
+    "$TESTSTOOLS"/fs-state mock-file "$TESTDIR"/.testdir1/.testfile2
+    "$TESTSTOOLS"/fs-state mock-file "$TESTDIR/.testdir1/test file2"
+    "$TESTSTOOLS"/fs-state mock-dir "$TESTDIR"/root
+
+    # Not accessible dirs and files
+    "$TESTSTOOLS"/fs-state mock-dir /root/.testdir1
+    "$TESTSTOOLS"/fs-state mock-file /root/.testfile1
+
+restore: |
+    "$TESTSTOOLS"/fs-state restore-dir "$TESTDIR"
+    "$TESTSTOOLS"/fs-state restore-dir /root/.testdir1
+    "$TESTSTOOLS"/fs-state restore-dir /root/.testfile1
+
+execute: |
+    echo "The interface is not connected by default"
+    snap interfaces -i system-files | MATCH "\\- +test-snapd-sh:system-files"
+
+    echo "When the interface is connected"
+    snap connect test-snapd-sh:system-files
+
+    echo "Then the snap is able to access all the files and dirs in /testdir"
+    test-snapd-sh.with-system-files-plug -c "cat $TESTDIR/.testfile1" | MATCH "mock file"
+    test-snapd-sh.with-system-files-plug -c "cat $TESTDIR/readonly_file1" MATCH "mock file"
+    test-snapd-sh.with-system-files-plug -c "ls $TESTDIR/.testdir1"
+    test-snapd-sh.with-system-files-plug -c "ls $TESTDIR/testdir1"
+    test-snapd-sh.with-system-files-plug -c "cat $TESTDIR/.testdir1/.testfile2" | MATCH "mock file"
+    test-snapd-sh.with-system-files-plug -c "cat $TESTDIR'/.testdir1/test file2'" | MATCH "mock file"
+    test-snapd-sh.with-system-files-plug -c "ls $TESTDIR/root/"
+
+    echo "Then the snap is able to write just $TESTDIR/.testdir1 and $TESTDIR/.testfile1"
+    test-snapd-sh.with-system-files-plug -c "echo test >> $TESTDIR/.testfile1"
+    test-snapd-sh.with-system-files-plug -c "touch $TESTDIR/.testdir1/testfile2"
+
+    if [ "$(snap debug confinement)" = partial ] ; then
+        exit 0
+    fi
+
+    if test-snapd-sh.with-system-files-plug -c "echo test >> $TESTDIR/readonly_file1" 2> call.error; then
+        echo "Expected permission error writing the system file"
+        exit 1
+    fi
+    MATCH "Permission denied" < call.error
+
+    echo "Then the snap is not able to to access files and dirs in $HOME"
+    test-snapd-sh.with-system-files-plug -c "ls /root/.testdir1" 2>&1| MATCH "Permission denied"
+    test-snapd-sh.with-system-files-plug -c "cat /root/.testfile1" 2>&1| MATCH "Permission denied"
+
+    echo "When the plug is disconnected"
+    snap disconnect test-snapd-sh:system-files
+
+    echo "Then the snap is not able to read files and dirs in $HOME"
+    if test-snapd-sh.with-system-files-plug -c "ls $TESTDIR/.testdir1" 2> call.error; then
+        echo "Expected permission error accessing the system dir"
+        exit 1
+    fi
+    MATCH "Permission denied" < call.error
+    if test-snapd-sh.with-system-files-plug -c "cat $TESTDIR/.testfile1" 2> call.error; then
+        echo "Expected permission error accessing the system file"
+        exit 1
+    fi
+    MATCH "Permission denied" < call.error

--- a/tests/main/interfaces-ros-opt-data/task.yaml
+++ b/tests/main/interfaces-ros-opt-data/task.yaml
@@ -20,7 +20,7 @@ prepare: |
     # Second layer of dirs and files
     "$TESTSTOOLS"/fs-state mock-file "$TESTDIR"/testdir1/file.yaml
     "$TESTSTOOLS"/fs-state mock-file "$TESTDIR/testdir1/file_no_extension"
-    "$TESTSTOOLS"/fs-state mock-dir "$TESTDIR"/empty_dir/
+    "$TESTSTOOLS"/fs-state mock-dir "$TESTDIR"/empty_dir
 
     # Not accessible dirs and files
     "$TESTSTOOLS"/fs-state mock-file "$TESTDIR"/file.so
@@ -28,7 +28,6 @@ prepare: |
 
 restore: |
     "$TESTSTOOLS"/fs-state restore-dir "$TESTDIR"
-    "$TESTSTOOLS"/fs-state restore-dir "$TESTDIR"/testdir1
 
 execute: |
     echo "The interface is connected by default"

--- a/tests/main/interfaces-ros-opt-data/task.yaml
+++ b/tests/main/interfaces-ros-opt-data/task.yaml
@@ -6,6 +6,7 @@ details: |
 environment:
     # keep in sync with ./test-snapd-sh/meta/snap.yaml
     TESTDIR: /opt/ros/testdir
+    SNAP_TESTDIR: /var/lib/snapd/hostfs/opt/ros/testdir
 
 prepare: |
     "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
@@ -18,6 +19,7 @@ prepare: |
     "$TESTSTOOLS"/fs-state mock-file "$TESTDIR"/file.urdf
 
     # Second layer of dirs and files
+    "$TESTSTOOLS"/fs-state mock-dir "$TESTDIR"/testdir1
     "$TESTSTOOLS"/fs-state mock-file "$TESTDIR"/testdir1/file.yaml
     "$TESTSTOOLS"/fs-state mock-file "$TESTDIR/testdir1/file_no_extension"
     "$TESTSTOOLS"/fs-state mock-dir "$TESTDIR"/empty_dir
@@ -31,58 +33,58 @@ restore: |
 
 execute: |
     echo "The interface is connected by default"
-    snap interfaces -i ros-opt-data | MATCH "\\- +test-snapd-sh:ros-opt-data"
+    snap interfaces -i ros-opt-data | MATCH "test-snapd-sh:opt-ros"
 
     echo "So the snap is able to access all the allowed files and dirs in /opt/ros"
-    test-snapd-sh.with-opt-ros-plug -c "cat $TESTDIR/file.yaml" | MATCH "mock file"
-    test-snapd-sh.with-opt-ros-plug -c "cat $TESTDIR/file.xacro" | MATCH "mock file"
-    test-snapd-sh.with-opt-ros-plug -c "cat $TESTDIR/file.stl" | MATCH "mock file"
-    test-snapd-sh.with-opt-ros-plug -c "cat $TESTDIR/file.urdf" | MATCH "mock file"
-    test-snapd-sh.with-opt-ros-plug -c "cat $TESTDIR/testdir1/file.yaml" | MATCH "mock file"
+    test-snapd-sh.app-with-opt-ros-plug -c "cat $SNAP_TESTDIR/file.yaml" | MATCH "mock file"
+    test-snapd-sh.app-with-opt-ros-plug -c "cat $SNAP_TESTDIR/file.xacro" | MATCH "mock file"
+    test-snapd-sh.app-with-opt-ros-plug -c "cat $SNAP_TESTDIR/file.stl" | MATCH "mock file"
+    test-snapd-sh.app-with-opt-ros-plug -c "cat $SNAP_TESTDIR/file.urdf" | MATCH "mock file"
+    test-snapd-sh.app-with-opt-ros-plug -c "cat $SNAP_TESTDIR/testdir1/file.yaml" | MATCH "mock file"
 
-    test-snapd-sh.with-opt-ros-plug -c "ls $TESTDIR/testdir1"
-    test-snapd-sh.with-opt-ros-plug -c "ls $TESTDIR/empty_dir"
+    test-snapd-sh.app-with-opt-ros-plug -c "ls $SNAP_TESTDIR/testdir1"
+    test-snapd-sh.app-with-opt-ros-plug -c "ls $SNAP_TESTDIR/empty_dir"
 
     if [ "$(snap debug confinement)" = partial ] ; then
         exit 0
     fi
 
     echo "Then the snap is not able to to write files"
-    if test-snapd-sh.with-opt-ros-plug -c "echo test >> $TESTDIR/file.yaml" 2> call.error; then
+    if test-snapd-sh.app-with-opt-ros-plug -c "echo test >> $SNAP_TESTDIR/file.yaml" 2> call.error; then
         echo "Expected permission error when writing a file, no error received"
         exit 1
     fi
     MATCH "Permission denied" < call.error
 
     echo "Then the snap is not able to to access other files"
-    test-snapd-sh.with-opt-ros-plug -c "ls /root" 2>&1| MATCH "Permission denied"
+    test-snapd-sh.app-with-opt-ros-plug -c "ls /root" 2>&1| MATCH "Permission denied"
 
-    if test-snapd-sh.with-opt-ros-plug -c "cat $TESTDIR/file.txt" 2> call.error; then
+    if test-snapd-sh.app-with-opt-ros-plug -c "cat $SNAP_TESTDIR/file.txt" 2> call.error; then
         echo "Expected permission error accessing file.txt, no error received"
         exit 1
     fi
     MATCH "Permission denied" < call.error
-    if test-snapd-sh.with-opt-ros-plug -c "cat $TESTDIR/file.so" 2> call.error; then
+    if test-snapd-sh.app-with-opt-ros-plug -c "cat $SNAP_TESTDIR/file.so" 2> call.error; then
         echo "Expected permission error accessing file.so, no error received"
         exit 1
     fi
     MATCH "Permission denied" < call.error
-    if test-snapd-sh.with-opt-ros-plug -c "cat $TESTDIR/testdir1/file_no_extension" 2> call.error; then
+    if test-snapd-sh.app-with-opt-ros-plug -c "cat $SNAP_TESTDIR/testdir1/file_no_extension" 2> call.error; then
         echo "Expected permission error accessing file with no extension, no error received"
         exit 1
     fi
     MATCH "Permission denied" < call.error
 
     echo "When the plug is disconnected"
-    snap disconnect test-snapd-sh:ros-opt-data
+    snap disconnect test-snapd-sh:opt-ros
 
     echo "Then the snap is not able to read files and dirs in /opt/ros"
-    if test-snapd-sh.with-opt-ros-plug -c "ls $TESTDIR" 2> call.error; then
+    if test-snapd-sh.app-with-opt-ros-plug -c "ls $SNAP_TESTDIR" 2> call.error; then
         echo "Expected permission error accessing the opt/ros dir, no error received"
         exit 1
     fi
     MATCH "Permission denied" < call.error
-    if test-snapd-sh.with-opt-ros-plug -c "cat $TESTDIR/file.yaml" 2> call.error; then
+    if test-snapd-sh.app-with-opt-ros-plug -c "cat $SNAP_TESTDIR/file.yaml" 2> call.error; then
         echo "Expected permission error accessing a file.yaml, no error received"
         exit 1
     fi

--- a/tests/main/interfaces-ros-opt-data/task.yaml
+++ b/tests/main/interfaces-ros-opt-data/task.yaml
@@ -5,77 +5,86 @@ details: |
 
 environment:
     # keep in sync with ./test-snapd-sh/meta/snap.yaml
-    TESTDIR: /mnt/testdir
+    TESTDIR: /opt/ros/testdir
 
 prepare: |
     "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
 
     # Fist layer of dirs and files
     "$TESTSTOOLS"/fs-state mock-dir "$TESTDIR"
-    "$TESTSTOOLS"/fs-state mock-file "$TESTDIR"/.testfile1
-    "$TESTSTOOLS"/fs-state mock-file "$TESTDIR"/readonly_file1
-    "$TESTSTOOLS"/fs-state mock-dir "$TESTDIR"/.testdir1
-    "$TESTSTOOLS"/fs-state mock-dir "$TESTDIR"/testdir1
+    "$TESTSTOOLS"/fs-state mock-file "$TESTDIR"/file.yaml
+    "$TESTSTOOLS"/fs-state mock-file "$TESTDIR"/file.xacro
+    "$TESTSTOOLS"/fs-state mock-file "$TESTDIR"/file.stl
+    "$TESTSTOOLS"/fs-state mock-file "$TESTDIR"/file.urdf
 
     # Second layer of dirs and files
-    "$TESTSTOOLS"/fs-state mock-file "$TESTDIR"/.testdir1/.testfile2
-    "$TESTSTOOLS"/fs-state mock-file "$TESTDIR/.testdir1/test file2"
-    "$TESTSTOOLS"/fs-state mock-dir "$TESTDIR"/root
+    "$TESTSTOOLS"/fs-state mock-file "$TESTDIR"/testdir1/file.yaml
+    "$TESTSTOOLS"/fs-state mock-file "$TESTDIR/testdir1/file_no_extension"
+    "$TESTSTOOLS"/fs-state mock-dir "$TESTDIR"/empty_dir/
 
     # Not accessible dirs and files
-    "$TESTSTOOLS"/fs-state mock-dir /root/.testdir1
-    "$TESTSTOOLS"/fs-state mock-file /root/.testfile1
+    "$TESTSTOOLS"/fs-state mock-file "$TESTDIR"/file.so
+    "$TESTSTOOLS"/fs-state mock-file "$TESTDIR"/file.txt
 
 restore: |
     "$TESTSTOOLS"/fs-state restore-dir "$TESTDIR"
-    "$TESTSTOOLS"/fs-state restore-dir /root/.testdir1
-    "$TESTSTOOLS"/fs-state restore-dir /root/.testfile1
+    "$TESTSTOOLS"/fs-state restore-dir "$TESTDIR"/testdir1
 
 execute: |
-    echo "The interface is not connected by default"
-    snap interfaces -i system-files | MATCH "\\- +test-snapd-sh:system-files"
+    echo "The interface is connected by default"
+    snap interfaces -i ros-opt-data | MATCH "\\- +test-snapd-sh:ros-opt-data"
 
-    echo "When the interface is connected"
-    snap connect test-snapd-sh:system-files
+    echo "So the snap is able to access all the allowed files and dirs in /opt/ros"
+    test-snapd-sh.with-opt-ros-plug -c "cat $TESTDIR/file.yaml" | MATCH "mock file"
+    test-snapd-sh.with-opt-ros-plug -c "cat $TESTDIR/file.xacro" | MATCH "mock file"
+    test-snapd-sh.with-opt-ros-plug -c "cat $TESTDIR/file.stl" | MATCH "mock file"
+    test-snapd-sh.with-opt-ros-plug -c "cat $TESTDIR/file.urdf" | MATCH "mock file"
+    test-snapd-sh.with-opt-ros-plug -c "cat $TESTDIR/testdir1/file.yaml" | MATCH "mock file"
 
-    echo "Then the snap is able to access all the files and dirs in /testdir"
-    test-snapd-sh.with-system-files-plug -c "cat $TESTDIR/.testfile1" | MATCH "mock file"
-    test-snapd-sh.with-system-files-plug -c "cat $TESTDIR/readonly_file1" MATCH "mock file"
-    test-snapd-sh.with-system-files-plug -c "ls $TESTDIR/.testdir1"
-    test-snapd-sh.with-system-files-plug -c "ls $TESTDIR/testdir1"
-    test-snapd-sh.with-system-files-plug -c "cat $TESTDIR/.testdir1/.testfile2" | MATCH "mock file"
-    test-snapd-sh.with-system-files-plug -c "cat $TESTDIR'/.testdir1/test file2'" | MATCH "mock file"
-    test-snapd-sh.with-system-files-plug -c "ls $TESTDIR/root/"
-
-    echo "Then the snap is able to write just $TESTDIR/.testdir1 and $TESTDIR/.testfile1"
-    test-snapd-sh.with-system-files-plug -c "echo test >> $TESTDIR/.testfile1"
-    test-snapd-sh.with-system-files-plug -c "touch $TESTDIR/.testdir1/testfile2"
+    test-snapd-sh.with-opt-ros-plug -c "ls $TESTDIR/testdir1"
+    test-snapd-sh.with-opt-ros-plug -c "ls $TESTDIR/empty_dir"
 
     if [ "$(snap debug confinement)" = partial ] ; then
         exit 0
     fi
 
-    if test-snapd-sh.with-system-files-plug -c "echo test >> $TESTDIR/readonly_file1" 2> call.error; then
-        echo "Expected permission error writing the system file"
+    echo "Then the snap is not able to to write files"
+    if test-snapd-sh.with-opt-ros-plug -c "echo test >> $TESTDIR/file.yaml" 2> call.error; then
+        echo "Expected permission error when writing a file, no error received"
         exit 1
     fi
     MATCH "Permission denied" < call.error
 
-    echo "Then the snap is not able to to access files and dirs in $HOME"
-    test-snapd-sh.with-system-files-plug -c "ls /root/.testdir1" 2>&1| MATCH "Permission denied"
-    test-snapd-sh.with-system-files-plug -c "cat /root/.testfile1" 2>&1| MATCH "Permission denied"
+    echo "Then the snap is not able to to access other files"
+    test-snapd-sh.with-opt-ros-plug -c "ls /root" 2>&1| MATCH "Permission denied"
+
+    if test-snapd-sh.with-opt-ros-plug -c "cat $TESTDIR/file.txt" 2> call.error; then
+        echo "Expected permission error accessing file.txt, no error received"
+        exit 1
+    fi
+    MATCH "Permission denied" < call.error
+    if test-snapd-sh.with-opt-ros-plug -c "cat $TESTDIR/file.so" 2> call.error; then
+        echo "Expected permission error accessing file.so, no error received"
+        exit 1
+    fi
+    MATCH "Permission denied" < call.error
+    if test-snapd-sh.with-opt-ros-plug -c "cat $TESTDIR/testdir1/file_no_extension" 2> call.error; then
+        echo "Expected permission error accessing file with no extension, no error received"
+        exit 1
+    fi
+    MATCH "Permission denied" < call.error
 
     echo "When the plug is disconnected"
-    snap disconnect test-snapd-sh:system-files
+    snap disconnect test-snapd-sh:ros-opt-data
 
-    echo "Then the snap is not able to read files and dirs in $HOME"
-    if test-snapd-sh.with-system-files-plug -c "ls $TESTDIR/.testdir1" 2> call.error; then
-        echo "Expected permission error accessing the system dir"
+    echo "Then the snap is not able to read files and dirs in /opt/ros"
+    if test-snapd-sh.with-opt-ros-plug -c "ls $TESTDIR" 2> call.error; then
+        echo "Expected permission error accessing the opt/ros dir, no error received"
         exit 1
     fi
     MATCH "Permission denied" < call.error
-    if test-snapd-sh.with-system-files-plug -c "cat $TESTDIR/.testfile1" 2> call.error; then
-        echo "Expected permission error accessing the system file"
+    if test-snapd-sh.with-opt-ros-plug -c "cat $TESTDIR/file.yaml" 2> call.error; then
+        echo "Expected permission error accessing a file.yaml, no error received"
         exit 1
     fi
     MATCH "Permission denied" < call.error

--- a/tests/main/interfaces-ros-opt-data/test-snapd-sh/bin/sh
+++ b/tests/main/interfaces-ros-opt-data/test-snapd-sh/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+PS1='$ '
+exec /bin/sh "$@"

--- a/tests/main/interfaces-ros-opt-data/test-snapd-sh/meta/snap.yaml
+++ b/tests/main/interfaces-ros-opt-data/test-snapd-sh/meta/snap.yaml
@@ -3,11 +3,11 @@ summary: A no-strings-attached, no-fuss shell for writing tests
 version: 1.0
 
 plugs:
-    system-files:
-        read: [/mnt/testdir]
-        write: [/mnt/testdir/.testdir1, /mnt/testdir/.testfile1]
+    opt-ros:  
+        interface: ros-opt-data
+        read: [/opt/ros]
 
 apps:
-    with-system-files-plug:
+    app-with-opt-ros-plug:
         command: bin/sh
-        plugs: [system-files]
+        plugs: [opt-ros]

--- a/tests/main/interfaces-ros-opt-data/test-snapd-sh/meta/snap.yaml
+++ b/tests/main/interfaces-ros-opt-data/test-snapd-sh/meta/snap.yaml
@@ -1,0 +1,13 @@
+name: test-snapd-sh
+summary: A no-strings-attached, no-fuss shell for writing tests
+version: 1.0
+
+plugs:
+    system-files:
+        read: [/mnt/testdir]
+        write: [/mnt/testdir/.testdir1, /mnt/testdir/.testfile1]
+
+apps:
+    with-system-files-plug:
+        command: bin/sh
+        plugs: [system-files]

--- a/tests/main/interfaces-ros-opt-data/test-snapd-sh/meta/snap.yaml
+++ b/tests/main/interfaces-ros-opt-data/test-snapd-sh/meta/snap.yaml
@@ -5,7 +5,6 @@ version: 1.0
 plugs:
     opt-ros:  
         interface: ros-opt-data
-        read: [/opt/ros]
 
 apps:
     app-with-opt-ros-plug:


### PR DESCRIPTION
This PR adds a new "ros" interface that allows snaps to access the host "/opt/ros" paths. This allows ros snaps to access to shared configuration and similar data.