### PR TITLE
secboot/luks2: remove unused variable

### DIFF
--- a/secboot/luks2/luks2.go
+++ b/secboot/luks2/luks2.go
@@ -19,15 +19,6 @@
 
 package luks2
 
-import (
-	"io"
-	"os"
-)
-
-var (
-	stderr io.Writer = os.Stderr
-)
-
 // SlotPriority represents the priority of a keyslot.
 type SlotPriority int
 


### PR DESCRIPTION
Removes an unused variable that is breaking the build on master.