### PR TITLE
tests/core-dump: check that core dumps can be generated on UC

### DIFF
--- a/tests/core/core-dump/core-dump-snap/bin/crash.sh
+++ b/tests/core/core-dump/core-dump-snap/bin/crash.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -e
+
+ulimit -c unlimited
+while true
+do sleep 100
+done

--- a/tests/core/core-dump/core-dump-snap/meta/snap.yaml
+++ b/tests/core/core-dump/core-dump-snap/meta/snap.yaml
@@ -1,0 +1,8 @@
+name: core-dump-snap
+base: ##BASE##
+type: app
+version: 1.0
+apps:
+  crash-svc:
+    command: bin/crash.sh
+    daemon: simple

--- a/tests/core/core-dump/task.yaml
+++ b/tests/core/core-dump/task.yaml
@@ -1,0 +1,27 @@
+summary: Make sure we can generate core dumps on UC
+
+execute: |
+  # To get VERSION_ID defined
+  . /etc/os-release
+  if [ "$VERSION_ID" = 16 ]; then
+      sed -i '/base: ##BASE##/d' core-dump-snap/meta/snap.yaml
+  else
+      BASE=core"$VERSION_ID"
+      sed -i "s/##BASE##/$BASE/" core-dump-snap/meta/snap.yaml
+  fi
+
+  # Install snap with a service that simply waits
+  DUMP_SNAP_FILE=core-dump-snap.snap
+  snap pack core-dump-snap --filename="$DUMP_SNAP_FILE"
+  snap install --dangerous "$DUMP_SNAP_FILE"
+
+  # Allow suid programs like snap-confine to produce a core dump
+  echo 1 > /proc/sys/fs/suid_dumpable
+  # Make sure that dumps are produced in a place writable from snap context
+  echo "/tmp/core.%p" > /proc/sys/kernel/core_pattern
+
+  CRASH_PID=$(retry --wait 1 -n 5 pgrep crash.sh)
+  kill -ABRT "$CRASH_PID"
+
+  # A core dump file should be generated in little time
+  retry --wait 1 -n 5 sh -c "stat /tmp/snap-private-tmp/snap.core-dump-snap/tmp/core.$CRASH_PID"


### PR DESCRIPTION
As reference, see https://forum.snapcraft.io/t/core-dumps-in-snapd/920