### PR TITLE
overlord: make link-snap request a reboot for gadget updates if any update to assets was made

### DIFF
--- a/overlord/devicestate/devicestate_gadget_test.go
+++ b/overlord/devicestate/devicestate_gadget_test.go
@@ -386,6 +386,11 @@ func (s *deviceMgrGadgetSuite) testUpdateGadgetSimple(c *C, grade string, encryp
 	s.state.Lock()
 	defer s.state.Unlock()
 
+	// Ensure that "gadget-restart-required" was set
+	var restartRequired bool
+	c.Check(chg.Get("gadget-restart-required", &restartRequired), IsNil)
+	c.Check(restartRequired, Equals, true)
+
 	// Expect the change to be in wait status at this point, as a restart
 	// will have been requested
 	c.Check(t.Status(), Equals, state.WaitStatus)
@@ -1230,6 +1235,11 @@ func (s *deviceMgrGadgetSuite) testGadgetCommandlineUpdateRun(c *C, fromFiles, t
 
 	if errMatch == "" {
 		if opts.updated && !argsAppended {
+			// Ensure that "gadget-restart-required" was set
+			var restartRequired bool
+			c.Check(chg.Get("gadget-restart-required", &restartRequired), IsNil)
+			c.Check(restartRequired, Equals, true)
+
 			// Expect the change to be in wait status at this point, as a restart
 			// will have been requested
 			c.Check(tsk.Status(), Equals, state.WaitStatus)
@@ -1269,6 +1279,10 @@ func (s *deviceMgrGadgetSuite) testGadgetCommandlineUpdateRun(c *C, fromFiles, t
 		} else {
 			// update was not applied or failed
 			c.Check(s.restartRequests, HasLen, 0)
+
+			// Ensure that "gadget-restart-required" was not set
+			var restartRequired bool
+			c.Check(chg.Get("gadget-restart-required", &restartRequired), FitsTypeOf, &state.NoStateError{})
 		}
 	} else {
 		c.Assert(chg.IsReady(), Equals, true)
@@ -1938,6 +1952,11 @@ func (s *deviceMgrGadgetSuite) TestGadgetCommandlineClassicWithModesUpdateUndo(c
 
 	s.state.Lock()
 	defer s.state.Unlock()
+
+	// Ensure that "gadget-restart-required" was set
+	var restartRequired bool
+	c.Check(chg.Get("gadget-restart-required", &restartRequired), IsNil)
+	c.Check(restartRequired, Equals, true)
 
 	// Expect the change to be in wait status at this point, as a restart
 	// will have been requested

--- a/overlord/devicestate/handlers_gadget.go
+++ b/overlord/devicestate/handlers_gadget.go
@@ -84,6 +84,11 @@ var (
 	gadgetUpdate = gadget.Update
 )
 
+func setGadgetRestartRequired(t *state.Task) {
+	chg := t.Change()
+	chg.Set("gadget-restart-required", true)
+}
+
 func (m *DeviceManager) doUpdateGadgetAssets(t *state.Task, _ *tomb.Tomb) error {
 	st := t.State()
 	st.Lock()
@@ -213,6 +218,7 @@ func (m *DeviceManager) doUpdateGadgetAssets(t *state.Task, _ *tomb.Tomb) error 
 
 	// TODO: consider having the option to do this early via recovery in
 	// core20, have fallback code as well there
+	setGadgetRestartRequired(t)
 	return snapstate.FinishTaskWithRestart(t, state.DoneStatus, restart.RestartSystem, nil)
 }
 
@@ -334,6 +340,9 @@ func (m *DeviceManager) updateGadgetCommandLine(t *state.Task, st *state.State, 
 	updated, err = boot.UpdateCommandLineForGadgetComponent(devCtx, gadgetData.RootDir, cmdlineAppend)
 	if err != nil {
 		return false, fmt.Errorf("cannot update kernel command line from gadget: %v", err)
+	}
+	if updated {
+		setGadgetRestartRequired(t)
 	}
 	return updated, nil
 }


### PR DESCRIPTION
Something I had missed is that `link-snap` for gadget will not request a restart (i.e RestartRequired is hardcoded to false in bootstate20.go), which makes a change that contains a gadget not do any immediate restarts during the change. Instead gadget changes will restart when the change completes (goes into done), which is different from the previous logic.

Currently we set boundaries on `link-snap`, but not the gadget tasks `update-gadget-assets` or `update-gadget-cmdline`, which are the tasks that request reboots during a gadget update. But we don't want to set boundaries on those either as we don't want to end in a sitautation where we do 2 reboots, and we cannot know before-hand whether one of these (or both) will request a reboot.

Instead we make the tasks set a variable on the change if a update is required, and then we use that should it be set for the link-snap. This also fixes a couple of unit test cases where I had mis-interpreted how the change was working. This fix should go into 2.61