### PR TITLE
sysconfig/cloudinit: Check if disabled via kernel commandline

### DIFF
--- a/sysconfig/cloudinit.go
+++ b/sysconfig/cloudinit.go
@@ -36,6 +36,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/osutil/kcmdline"
 	"github.com/snapcore/snapd/strutil"
 )
 
@@ -740,6 +741,16 @@ func CloudInitStatus() (CloudInitState, error) {
 	// return special status for that
 	disabledFile := filepath.Join(dirs.GlobalRootDir, cloudInitDisabledFile)
 	if osutil.FileExists(disabledFile) {
+		return CloudInitDisabledPermanently, nil
+	}
+
+	// if it was explicitly disabled via the kernel commandline, then
+	// return special status for that, if commandline is unavailable,
+	// assume not disabled
+	cmdline, err := kcmdline.KeyValues("cloud-init")
+	if err != nil {
+		logger.Noticef("WARNING: cannot obtain cloud-init from kernel command line: %v", err)
+	} else if cmdline["cloud-init"] == "disabled" {
 		return CloudInitDisabledPermanently, nil
 	}
 


### PR DESCRIPTION
Currently snapd manually checks for the presence of `/etc/cloud/cloud-init.disabled` to avoid running `cloud-init status`. This is done to avoid having to run `cloud-init status` to check current status. Similarly, snapd can check the kernel commandline for `cloud-init=disabled` which also [disables cloud-init permanently](https://cloudinit.readthedocs.io/en/latest/howto/disable_cloud_init.html#method-2-kernel-commandline).

A unit test is included.