### PR TITLE
o/state: implement core support for notices

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts_test.go
@@ -3311,7 +3311,7 @@ grade=signed
 		c.Check(fiParent.Mode(), Equals, os.FileMode(os.ModeDir|0750))
 	}
 
-	c.Check(filepath.Join(ephemeralUbuntuData, "system-data/var/lib/snapd/state.json"), testutil.FileEquals, `{"data":{"auth":{"last-id":1,"macaroon-key":"not-a-cookie","users":[{"id":1,"name":"mvo"}]}},"changes":{},"tasks":{},"last-change-id":0,"last-task-id":0,"last-lane-id":0}`)
+	c.Check(filepath.Join(ephemeralUbuntuData, "system-data/var/lib/snapd/state.json"), testutil.FileEquals, `{"data":{"auth":{"last-id":1,"macaroon-key":"not-a-cookie","users":[{"id":1,"name":"mvo"}]}},"changes":{},"tasks":{},"last-change-id":0,"last-task-id":0,"last-lane-id":0,"last-notice-id":0}`)
 
 	// finally check that the recovery system bootenv was updated to be in run
 	// mode

--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -169,7 +169,15 @@ func (ovs *overlordSuite) TestNewWithGoodState(c *C) {
 	timings.DurationThreshold = time.Second * 30
 	defer func() { timings.DurationThreshold = oldDurationThreshold }()
 
-	fakeState := []byte(fmt.Sprintf(`{"data":{"patch-level":%d,"patch-sublevel":%d,"patch-sublevel-last-version":%q,"some":"data","refresh-privacy-key":"0123456789ABCDEF"},"changes":null,"tasks":null,"last-change-id":0,"last-task-id":0,"last-lane-id":0}`, patch.Level, patch.Sublevel, snapdtool.Version))
+	fakeState := []byte(fmt.Sprintf(`{
+		"data": {"patch-level": %d, "patch-sublevel": %d, "patch-sublevel-last-version": %q, "some": "data", "refresh-privacy-key": "0123456789ABCDEF"},
+		"changes": null,
+		"tasks": null,
+		"last-change-id": 0,
+		"last-task-id": 0,
+		"last-lane-id": 0,
+		"last-notice-id": 0
+	}`, patch.Level, patch.Sublevel, snapdtool.Version))
 	err := os.WriteFile(dirs.SnapStateFile, fakeState, 0600)
 	c.Assert(err, IsNil)
 

--- a/overlord/state/copy_test.go
+++ b/overlord/state/copy_test.go
@@ -80,7 +80,7 @@ var srcStateContent = []byte(`
 }
 `)
 
-const stateSuffix = `,"changes":{},"tasks":{},"last-change-id":0,"last-task-id":0,"last-lane-id":0}`
+const stateSuffix = `,"changes":{},"tasks":{},"last-change-id":0,"last-task-id":0,"last-lane-id":0,"last-notice-id":0}`
 
 func (ss *stateSuite) TestCopyStateIntegration(c *C) {
 	// create a mock srcState

--- a/overlord/state/export_test.go
+++ b/overlord/state/export_test.go
@@ -73,3 +73,9 @@ var (
 	ErrNoWarningExpireAfter = errNoWarningExpireAfter
 	ErrNoWarningRepeatAfter = errNoWarningRepeatAfter
 )
+
+// NumNotices returns the total bumber of notices, including expired ones that
+// haven't yet been pruned.
+func (s *State) NumNotices() int {
+	return len(s.notices)
+}

--- a/overlord/state/notices.go
+++ b/overlord/state/notices.go
@@ -161,11 +161,6 @@ const (
 	// status was updated. The key for change-update notices is the change ID.
 	ChangeUpdateNotice NoticeType = "change-update"
 
-	// A custom notice with key and data fields provided by the user. The key
-	// must be in the format "mydomain.io/mykey" to ensure well-namespaced
-	// notice keys.
-	CustomNotice NoticeType = "custom"
-
 	// Warnings are a subset of notices where the key is a human-readable
 	// warning message.
 	WarningNotice NoticeType = "warning"
@@ -173,7 +168,7 @@ const (
 
 func (t NoticeType) Valid() bool {
 	switch t {
-	case ChangeUpdateNotice, CustomNotice, WarningNotice:
+	case ChangeUpdateNotice, WarningNotice:
 		return true
 	}
 	return false

--- a/overlord/state/notices.go
+++ b/overlord/state/notices.go
@@ -1,0 +1,420 @@
+// Copyright (c) 2023 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package state
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+	"time"
+)
+
+const (
+	// defaultNoticeExpireAfter is the default expiry time for notices.
+	defaultNoticeExpireAfter = 7 * 24 * time.Hour
+)
+
+// Notice represents an aggregated notice. The combination of type and key is unique.
+type Notice struct {
+	// Server-generated unique ID for this notice (a surrogate key).
+	//
+	// Currently this is a monotonically increasing number, but that may well
+	// change in future. If your code relies on it being a number, it will break.
+	id string
+
+	// The notice type represents a group of notices originating from a common
+	// source. For example, notices originating from the CLI client have type
+	// "custom".
+	noticeType NoticeType
+
+	// The notice key is a string that differentiates notices of this type.
+	// Notices recorded with the type and key of an existing notice count as
+	// an occurrence of that notice.
+	//
+	// This is limited to a maximum of MaxNoticeKeyLength bytes when added
+	// (it's an error to add a notice with a longer key).
+	key string
+
+	// The first time one of these notices (type and key combination) occurs.
+	firstOccurred time.Time
+
+	// The last time one of these notices occurred. This is updated every time
+	// one of these notices occurs.
+	lastOccurred time.Time
+
+	// The time this notice was last "repeated". This is set when one of these
+	// notices first occurs, and updated when it reoccurs at least
+	// repeatAfter after the previous lastRepeated time.
+	//
+	// Notices and WaitNotices return notices ordered by lastRepeated time, so
+	// repeated notices will appear at the end of the returned list.
+	lastRepeated time.Time
+
+	// The number of times one of these notices has occurred.
+	occurrences int
+
+	// Additional data captured from the last occurrence of one of these notices.
+	lastData map[string]string
+
+	// How long after one of these was last repeated should we allow it to repeat.
+	repeatAfter time.Duration
+
+	// How long since one of these last occurred until we should drop the notice.
+	//
+	// The repeatAfter duration must be less than this, because the notice
+	// won't be tracked after it expires.
+	expireAfter time.Duration
+}
+
+func (n *Notice) String() string {
+	return fmt.Sprintf("Notice %s (%s:%s)", n.id, n.noticeType, n.key)
+}
+
+// expired reports whether this notice has expired (relative to the given "now").
+func (n *Notice) expired(now time.Time) bool {
+	return n.lastOccurred.Add(n.expireAfter).Before(now)
+}
+
+// jsonNotice exists so we can control how a Notice is marshalled to JSON. It
+// needs to live in this package (rather than the API) because we save state
+// to disk as JSON.
+type jsonNotice struct {
+	ID            string            `json:"id"`
+	Type          string            `json:"type"`
+	Key           string            `json:"key"`
+	FirstOccurred time.Time         `json:"first-occurred"`
+	LastOccurred  time.Time         `json:"last-occurred"`
+	LastRepeated  time.Time         `json:"last-repeated"`
+	Occurrences   int               `json:"occurrences"`
+	LastData      map[string]string `json:"last-data,omitempty"`
+	RepeatAfter   string            `json:"repeat-after,omitempty"`
+	ExpireAfter   string            `json:"expire-after,omitempty"`
+}
+
+func (n *Notice) MarshalJSON() ([]byte, error) {
+	jn := jsonNotice{
+		ID:            n.id,
+		Type:          string(n.noticeType),
+		Key:           n.key,
+		FirstOccurred: n.firstOccurred,
+		LastOccurred:  n.lastOccurred,
+		LastRepeated:  n.lastRepeated,
+		Occurrences:   n.occurrences,
+		LastData:      n.lastData,
+	}
+	if n.repeatAfter != 0 {
+		jn.RepeatAfter = n.repeatAfter.String()
+	}
+	if n.expireAfter != 0 {
+		jn.ExpireAfter = n.expireAfter.String()
+	}
+	return json.Marshal(jn)
+}
+
+func (n *Notice) UnmarshalJSON(data []byte) error {
+	var jn jsonNotice
+	err := json.Unmarshal(data, &jn)
+	if err != nil {
+		return err
+	}
+	n.id = jn.ID
+	n.noticeType = NoticeType(jn.Type)
+	n.key = jn.Key
+	n.firstOccurred = jn.FirstOccurred
+	n.lastOccurred = jn.LastOccurred
+	n.lastRepeated = jn.LastRepeated
+	n.occurrences = jn.Occurrences
+	n.lastData = jn.LastData
+	if jn.RepeatAfter != "" {
+		n.repeatAfter, err = time.ParseDuration(jn.RepeatAfter)
+		if err != nil {
+			return fmt.Errorf("invalid repeat-after duration: %w", err)
+		}
+	}
+	if jn.ExpireAfter != "" {
+		n.expireAfter, err = time.ParseDuration(jn.ExpireAfter)
+		if err != nil {
+			return fmt.Errorf("invalid expire-after duration: %w", err)
+		}
+	}
+	return nil
+}
+
+type NoticeType string
+
+const (
+	// Recorded whenever a change is updated: when it is first spawned or its
+	// status was updated. The key for change-update notices is the change ID.
+	ChangeUpdateNotice NoticeType = "change-update"
+
+	// A custom notice reported via the Pebble client API or "pebble notify".
+	// The key and data fields are provided by the user. The key must be in
+	// the format "mydomain.io/mykey" to ensure well-namespaced notice keys.
+	CustomNotice NoticeType = "custom"
+
+	// Warnings are a subset of notices where the key is a human-readable
+	// warning message.
+	WarningNotice NoticeType = "warning"
+)
+
+func (t NoticeType) Valid() bool {
+	switch t {
+	case ChangeUpdateNotice, CustomNotice, WarningNotice:
+		return true
+	}
+	return false
+}
+
+// AddNoticeOptions holds optional parameters for an AddNotice call.
+type AddNoticeOptions struct {
+	// Data is the optional key-value data for this occurrence.
+	Data map[string]string
+
+	// RepeatAfter defines how long after this notice was last repeated we
+	// should allow it to repeat. Zero means always repeat.
+	RepeatAfter time.Duration
+
+	// Time, if set, overrides time.Now() as the notice occurrence time.
+	Time time.Time
+}
+
+// AddNotice records an occurrence of a notice with the specified type and key
+// and options.
+func (s *State) AddNotice(noticeType NoticeType, key string, options *AddNoticeOptions) (string, error) {
+	if options == nil {
+		options = &AddNoticeOptions{}
+	}
+	err := validateNotice(noticeType, key, options)
+	if err != nil {
+		return "", err
+	}
+
+	s.writing()
+
+	now := options.Time
+	if now.IsZero() {
+		now = time.Now()
+	}
+	now = now.UTC()
+	newOrRepeated := false
+	uniqueKey := noticeKey{noticeType, key}
+	notice, ok := s.notices[uniqueKey]
+	if !ok {
+		// First occurrence of this notice type+key
+		s.lastNoticeId++
+		notice = &Notice{
+			id:            strconv.Itoa(s.lastNoticeId),
+			noticeType:    noticeType,
+			key:           key,
+			firstOccurred: now,
+			lastRepeated:  now,
+			expireAfter:   defaultNoticeExpireAfter,
+			occurrences:   1,
+		}
+		s.notices[uniqueKey] = notice
+		newOrRepeated = true
+	} else {
+		// Additional occurrence, update existing notice
+		notice.occurrences++
+		if options.RepeatAfter == 0 || now.After(notice.lastRepeated.Add(options.RepeatAfter)) {
+			// Update last repeated time if repeat-after time has elapsed (or is zero)
+			notice.lastRepeated = now
+			newOrRepeated = true
+		}
+	}
+	notice.lastOccurred = now
+	notice.lastData = options.Data
+	notice.repeatAfter = options.RepeatAfter
+
+	if newOrRepeated {
+		s.noticeCond.Broadcast()
+	}
+
+	return notice.id, nil
+}
+
+func validateNotice(noticeType NoticeType, key string, options *AddNoticeOptions) error {
+	if !noticeType.Valid() {
+		return fmt.Errorf("internal error: attempted to add notice with invalid type %q", noticeType)
+	}
+	if key == "" {
+		return fmt.Errorf("internal error: attempted to add %s notice with invalid key %q", noticeType, key)
+	}
+	return nil
+}
+
+type noticeKey struct {
+	noticeType NoticeType
+	key        string
+}
+
+// NoticeFilter allows filtering notices by various fields.
+type NoticeFilter struct {
+	// Types, if not empty, includes only notices whose type is one of these.
+	Types []NoticeType
+
+	// Keys, if not empty, includes only notices whose key is one of these.
+	Keys []string
+
+	// After, if set, includes only notices that were last repeated after this time.
+	After time.Time
+}
+
+// matches reports whether the notice n matches this filter
+func (f *NoticeFilter) matches(n *Notice) bool {
+	if f == nil {
+		return true
+	}
+	// Can't use strutil.ListContains as Types is []NoticeType, not []string
+	if len(f.Types) > 0 && !sliceContains(f.Types, n.noticeType) {
+		return false
+	}
+	if len(f.Keys) > 0 && !sliceContains(f.Keys, n.key) {
+		return false
+	}
+	if !f.After.IsZero() && !n.lastRepeated.After(f.After) {
+		return false
+	}
+	return true
+}
+
+func sliceContains[T comparable](haystack []T, needle T) bool {
+	for _, v := range haystack {
+		if v == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// Notices returns the list of notices that match the filter (if any),
+// ordered by the last-repeated time.
+func (s *State) Notices(filter *NoticeFilter) []*Notice {
+	s.reading()
+
+	notices := s.flattenNotices(filter)
+	sort.Slice(notices, func(i, j int) bool {
+		return notices[i].lastRepeated.Before(notices[j].lastRepeated)
+	})
+	return notices
+}
+
+// Notice returns a single notice by ID, or nil if not found.
+func (s *State) Notice(id string) *Notice {
+	s.reading()
+
+	// Could use another map for lookup, but the number of notices will likely
+	// be small, and this function is probably only used rarely by the CLI, so
+	// performance is unlikely to matter.
+	for _, notice := range s.notices {
+		if notice.id == id {
+			return notice
+		}
+	}
+	return nil
+}
+
+func (s *State) flattenNotices(filter *NoticeFilter) []*Notice {
+	now := time.Now()
+	var notices []*Notice
+	for _, n := range s.notices {
+		if n.expired(now) || !filter.matches(n) {
+			continue
+		}
+		notices = append(notices, n)
+	}
+	return notices
+}
+
+func (s *State) unflattenNotices(flat []*Notice) {
+	now := time.Now()
+	s.notices = make(map[noticeKey]*Notice)
+	for _, n := range flat {
+		if n.expired(now) {
+			continue
+		}
+		uniqueKey := noticeKey{n.noticeType, n.key}
+		s.notices[uniqueKey] = n
+	}
+}
+
+// WaitNotices waits for notices that match the filter to exist or occur,
+// returning the list of matching notices ordered by the last-repeated time.
+//
+// It waits till there is at least one matching notice or the context is
+// cancelled. If there are existing notices that match the filter,
+// WaitNotices will return them immediately.
+func (s *State) WaitNotices(ctx context.Context, filter *NoticeFilter) ([]*Notice, error) {
+	s.reading()
+
+	// If there are existing notices, return them right away.
+	//
+	// State is already locked here by the caller, so notices won't be added
+	// concurrently.
+	notices := s.Notices(filter)
+	if len(notices) > 0 {
+		return notices, nil
+	}
+
+	// When the context is done/cancelled, wake up the waiters so that they
+	// can check their ctx.Err() and return if they're cancelled.
+	//
+	// TODO: replace this with context.AfterFunc once we're on Go 1.21.
+	stop := contextAfterFunc(ctx, func() {
+		// We need to acquire the cond lock here to be sure that the Broadcast
+		// below won't occur before the call to Wait, which would result in a
+		// missed signal (and deadlock).
+		s.noticeCond.L.Lock()
+		defer s.noticeCond.L.Unlock()
+
+		s.noticeCond.Broadcast()
+	})
+	defer stop()
+
+	for {
+		// Wait till a new notice occurs or a context is cancelled.
+		s.noticeCond.Wait()
+
+		// If this context is cancelled, return the error.
+		ctxErr := ctx.Err()
+		if ctxErr != nil {
+			return nil, ctxErr
+		}
+
+		// Otherwise check if there are now matching notices.
+		notices = s.Notices(filter)
+		if len(notices) > 0 {
+			return notices, nil
+		}
+	}
+}
+
+// Remove this and just use context.AfterFunc once we're on Go 1.21.
+func contextAfterFunc(ctx context.Context, f func()) func() {
+	stopCh := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			f()
+		case <-stopCh:
+		}
+	}()
+	stop := func() {
+		close(stopCh)
+	}
+	return stop
+}

--- a/overlord/state/notices.go
+++ b/overlord/state/notices.go
@@ -37,8 +37,8 @@ type Notice struct {
 	id string
 
 	// The notice type represents a group of notices originating from a common
-	// source. For example, notices originating from the CLI client have type
-	// "custom".
+	// source. For example, notices which provide human-readable warnings have
+	// the type "warning".
 	noticeType NoticeType
 
 	// The notice key is a string that differentiates notices of this type.
@@ -161,9 +161,9 @@ const (
 	// status was updated. The key for change-update notices is the change ID.
 	ChangeUpdateNotice NoticeType = "change-update"
 
-	// A custom notice reported via the Pebble client API or "pebble notify".
-	// The key and data fields are provided by the user. The key must be in
-	// the format "mydomain.io/mykey" to ensure well-namespaced notice keys.
+	// A custom notice with key and data fields provided by the user. The key
+	// must be in the format "mydomain.io/mykey" to ensure well-namespaced
+	// notice keys.
 	CustomNotice NoticeType = "custom"
 
 	// Warnings are a subset of notices where the key is a human-readable
@@ -318,8 +318,8 @@ func (s *State) Notice(id string) *Notice {
 	s.reading()
 
 	// Could use another map for lookup, but the number of notices will likely
-	// be small, and this function is probably only used rarely by the CLI, so
-	// performance is unlikely to matter.
+	// be small, and this function is probably only used rarely, so performance
+	// is unlikely to matter.
 	for _, notice := range s.notices {
 		if notice.id == id {
 			return notice

--- a/overlord/state/notices_test.go
+++ b/overlord/state/notices_test.go
@@ -1,0 +1,496 @@
+// Copyright (c) 2023 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package state_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+type noticesSuite struct{}
+
+var _ = Suite(&noticesSuite{})
+
+func (s *noticesSuite) TestMarshal(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	start := time.Now()
+	addNotice(c, st, state.CustomNotice, "foo.com/bar", nil)
+	time.Sleep(time.Microsecond) // ensure there's time between the occurrences
+	addNotice(c, st, state.CustomNotice, "foo.com/bar", &state.AddNoticeOptions{
+		Data: map[string]string{"k": "v"},
+	})
+
+	notices := st.Notices(nil)
+	c.Assert(notices, HasLen, 1)
+
+	// Convert it to a map so we're not testing the JSON string directly
+	// (order of fields doesn't matter).
+	n := noticeToMap(c, notices[0])
+
+	firstOccurred, err := time.Parse(time.RFC3339, n["first-occurred"].(string))
+	c.Assert(err, IsNil)
+	c.Assert(!firstOccurred.Before(start), Equals, true) // firstOccurred >= start
+	lastOccurred, err := time.Parse(time.RFC3339, n["last-occurred"].(string))
+	c.Assert(err, IsNil)
+	c.Assert(lastOccurred.After(firstOccurred), Equals, true) // lastOccurred > firstOccurred
+	lastRepeated, err := time.Parse(time.RFC3339, n["last-repeated"].(string))
+	c.Assert(err, IsNil)
+	c.Assert(lastRepeated.After(firstOccurred), Equals, true) // lastRepeated > firstOccurred
+
+	delete(n, "first-occurred")
+	delete(n, "last-occurred")
+	delete(n, "last-repeated")
+	c.Assert(n, DeepEquals, map[string]any{
+		"id":           "1",
+		"type":         "custom",
+		"key":          "foo.com/bar",
+		"occurrences":  2.0,
+		"last-data":    map[string]any{"k": "v"},
+		"expire-after": "168h0m0s",
+	})
+}
+
+func (s *noticesSuite) TestUnmarshal(c *C) {
+	noticeJSON := []byte(`{
+		"id": "1",
+		"type": "custom",
+		"key": "foo.com/bar",
+		"first-occurred": "2023-09-01T05:23:01Z",
+		"last-occurred": "2023-09-01T07:23:02Z",
+		"last-repeated": "2023-09-01T06:23:03.123456789Z",
+		"occurrences": 2,
+		"last-data": {"k": "v"},
+		"repeat-after": "60m",
+		"expire-after": "168h0m0s"
+	}`)
+	var notice *state.Notice
+	err := json.Unmarshal(noticeJSON, &notice)
+	c.Assert(err, IsNil)
+
+	// The Notice fields aren't exported, so we need to marshal it into JSON
+	// and then unmarshal it into a map to test.
+	n := noticeToMap(c, notice)
+	c.Assert(n, DeepEquals, map[string]any{
+		"id":             "1",
+		"type":           "custom",
+		"key":            "foo.com/bar",
+		"first-occurred": "2023-09-01T05:23:01Z",
+		"last-occurred":  "2023-09-01T07:23:02Z",
+		"last-repeated":  "2023-09-01T06:23:03.123456789Z",
+		"occurrences":    2.0,
+		"last-data":      map[string]any{"k": "v"},
+		"repeat-after":   "1h0m0s",
+		"expire-after":   "168h0m0s",
+	})
+}
+
+func (s *noticesSuite) TestOccurrences(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	addNotice(c, st, state.CustomNotice, "foo.com/bar", nil)
+	addNotice(c, st, state.CustomNotice, "foo.com/bar", nil)
+	addNotice(c, st, state.CustomNotice, "foo.com/bar", nil)
+	time.Sleep(time.Microsecond)
+	addNotice(c, st, state.ChangeUpdateNotice, "123", nil)
+
+	notices := st.Notices(nil)
+	c.Assert(notices, HasLen, 2)
+	n := noticeToMap(c, notices[0])
+	c.Check(n["id"], Equals, "1")
+	c.Check(n["occurrences"], Equals, 3.0)
+	n = noticeToMap(c, notices[1])
+	c.Check(n["id"], Equals, "2")
+	c.Check(n["occurrences"], Equals, 1.0)
+}
+
+func (s *noticesSuite) TestRepeatAfterFirst(c *C) {
+	s.testRepeatAfter(c, 10*time.Second, 0, 10*time.Second)
+}
+
+func (s *noticesSuite) TestRepeatAfterSecond(c *C) {
+	s.testRepeatAfter(c, 0, 10*time.Second, 10*time.Second)
+}
+
+func (s *noticesSuite) TestRepeatAfterBoth(c *C) {
+	s.testRepeatAfter(c, 10*time.Second, 10*time.Second, 10*time.Second)
+}
+
+func (s *noticesSuite) testRepeatAfter(c *C, first, second, delay time.Duration) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	addNotice(c, st, state.CustomNotice, "foo.com/bar", &state.AddNoticeOptions{
+		RepeatAfter: first,
+	})
+	time.Sleep(time.Microsecond)
+
+	notices := st.Notices(nil)
+	c.Assert(notices, HasLen, 1)
+	n := noticeToMap(c, notices[0])
+	firstOccurred, err := time.Parse(time.RFC3339, n["first-occurred"].(string))
+	c.Assert(err, IsNil)
+	lastRepeated, err := time.Parse(time.RFC3339, n["last-repeated"].(string))
+	c.Assert(err, IsNil)
+
+	// LastRepeated won't yet be updated as we only waited 1us (repeat-after is long)
+	c.Assert(lastRepeated.Equal(firstOccurred), Equals, true)
+
+	// Add a notice (with faked time) after a long time and ensure it has repeated
+	future := time.Now().Add(delay)
+	addNotice(c, st, state.CustomNotice, "foo.com/bar", &state.AddNoticeOptions{
+		RepeatAfter: second,
+		Time:        future,
+	})
+	notices = st.Notices(nil)
+	c.Assert(notices, HasLen, 1)
+	n = noticeToMap(c, notices[0])
+	newLastRepeated, err := time.Parse(time.RFC3339, n["last-repeated"].(string))
+	c.Assert(err, IsNil)
+	c.Assert(newLastRepeated.After(lastRepeated), Equals, true)
+}
+
+func (s *noticesSuite) TestNoticesFilterType(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	addNotice(c, st, state.CustomNotice, "foo.com/bar", nil)
+	time.Sleep(time.Microsecond)
+	addNotice(c, st, state.ChangeUpdateNotice, "123", nil)
+	time.Sleep(time.Microsecond)
+	addNotice(c, st, state.WarningNotice, "Warning 1!", nil)
+	time.Sleep(time.Microsecond)
+	addNotice(c, st, state.WarningNotice, "Warning 2!", nil)
+
+	// No types
+	notices := st.Notices(nil)
+	c.Assert(notices, HasLen, 4)
+
+	// One type
+	notices = st.Notices(&state.NoticeFilter{Types: []state.NoticeType{state.WarningNotice}})
+	c.Assert(notices, HasLen, 2)
+	n := noticeToMap(c, notices[0])
+	c.Check(n["type"], Equals, "warning")
+	c.Check(n["key"], Equals, "Warning 1!")
+	n = noticeToMap(c, notices[1])
+	c.Check(n["type"], Equals, "warning")
+	c.Check(n["key"], Equals, "Warning 2!")
+
+	// Multiple types
+	notices = st.Notices(&state.NoticeFilter{Types: []state.NoticeType{
+		state.ChangeUpdateNotice,
+		state.CustomNotice,
+	}})
+	c.Assert(notices, HasLen, 2)
+	n = noticeToMap(c, notices[0])
+	c.Check(n["type"], Equals, "custom")
+	c.Check(n["key"], Equals, "foo.com/bar")
+	n = noticeToMap(c, notices[1])
+	c.Check(n["type"], Equals, "change-update")
+	c.Check(n["key"], Equals, "123")
+}
+
+func (s *noticesSuite) TestNoticesFilterKey(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	addNotice(c, st, state.CustomNotice, "foo.com/bar", nil)
+	time.Sleep(time.Microsecond)
+	addNotice(c, st, state.CustomNotice, "example.com/x", nil)
+	time.Sleep(time.Microsecond)
+	addNotice(c, st, state.CustomNotice, "foo.com/baz", nil)
+
+	// No keys
+	notices := st.Notices(nil)
+	c.Assert(notices, HasLen, 3)
+
+	// One key
+	notices = st.Notices(&state.NoticeFilter{Keys: []string{"example.com/x"}})
+	c.Assert(notices, HasLen, 1)
+	n := noticeToMap(c, notices[0])
+	c.Check(n["type"], Equals, "custom")
+	c.Check(n["key"], Equals, "example.com/x")
+
+	// Multiple keys
+	notices = st.Notices(&state.NoticeFilter{Keys: []string{
+		"foo.com/bar",
+		"foo.com/baz",
+	}})
+	c.Assert(notices, HasLen, 2)
+	n = noticeToMap(c, notices[0])
+	c.Check(n["type"], Equals, "custom")
+	c.Check(n["key"], Equals, "foo.com/bar")
+	n = noticeToMap(c, notices[1])
+	c.Check(n["type"], Equals, "custom")
+	c.Check(n["key"], Equals, "foo.com/baz")
+}
+
+func (s *noticesSuite) TestNoticesFilterAfter(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	addNotice(c, st, state.CustomNotice, "foo.com/x", nil)
+	notices := st.Notices(nil)
+	c.Assert(notices, HasLen, 1)
+	n := noticeToMap(c, notices[0])
+	lastRepeated, err := time.Parse(time.RFC3339, n["last-repeated"].(string))
+	c.Assert(err, IsNil)
+
+	time.Sleep(time.Microsecond)
+	addNotice(c, st, state.CustomNotice, "foo.com/y", nil)
+
+	notices = st.Notices(&state.NoticeFilter{After: lastRepeated})
+	c.Assert(notices, HasLen, 1)
+	n = noticeToMap(c, notices[0])
+	c.Check(n["type"], Equals, "custom")
+	c.Check(n["key"], Equals, "foo.com/y")
+}
+
+func (s *noticesSuite) TestNotice(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	addNotice(c, st, state.CustomNotice, "foo.com/x", nil)
+	time.Sleep(time.Microsecond)
+	addNotice(c, st, state.CustomNotice, "foo.com/y", nil)
+	time.Sleep(time.Microsecond)
+	addNotice(c, st, state.CustomNotice, "foo.com/z", nil)
+
+	notices := st.Notices(nil)
+	c.Assert(notices, HasLen, 3)
+	n := noticeToMap(c, notices[1])
+	noticeId, ok := n["id"].(string)
+	c.Assert(ok, Equals, true)
+
+	notice := st.Notice(noticeId)
+	c.Assert(notice, NotNil)
+	n = noticeToMap(c, notice)
+	c.Check(n["type"], Equals, "custom")
+	c.Check(n["key"], Equals, "foo.com/y")
+}
+
+func (s *noticesSuite) TestEmptyState(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	notices := st.Notices(nil)
+	c.Check(notices, HasLen, 0)
+}
+
+func (s *noticesSuite) TestCheckpoint(c *C) {
+	backend := &fakeStateBackend{}
+	st := state.New(backend)
+	st.Lock()
+	addNotice(c, st, state.CustomNotice, "foo.com/bar", nil)
+	st.Unlock()
+	c.Assert(backend.checkpoints, HasLen, 1)
+
+	st2, err := state.ReadState(nil, bytes.NewReader(backend.checkpoints[0]))
+	c.Assert(err, IsNil)
+	st2.Lock()
+	defer st2.Unlock()
+
+	notices := st2.Notices(nil)
+	c.Assert(notices, HasLen, 1)
+	n := noticeToMap(c, notices[0])
+	c.Check(n["type"], Equals, "custom")
+	c.Check(n["key"], Equals, "foo.com/bar")
+}
+
+func (s *noticesSuite) TestDeleteExpired(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	old := time.Now().Add(-8 * 24 * time.Hour)
+	addNotice(c, st, state.CustomNotice, "foo.com/w", &state.AddNoticeOptions{
+		Time: old,
+	})
+	addNotice(c, st, state.CustomNotice, "foo.com/x", &state.AddNoticeOptions{
+		Time: old,
+	})
+	addNotice(c, st, state.CustomNotice, "foo.com/y", nil)
+	time.Sleep(time.Microsecond)
+	addNotice(c, st, state.CustomNotice, "foo.com/z", nil)
+
+	c.Assert(st.NumNotices(), Equals, 4)
+	st.Prune(time.Now(), 0, 0, 0)
+	c.Assert(st.NumNotices(), Equals, 2)
+
+	notices := st.Notices(nil)
+	c.Assert(notices, HasLen, 2)
+	n := noticeToMap(c, notices[0])
+	c.Assert(n["key"], Equals, "foo.com/y")
+	n = noticeToMap(c, notices[1])
+	c.Assert(n["key"], Equals, "foo.com/z")
+}
+
+func (s *noticesSuite) TestWaitNoticesExisting(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	addNotice(c, st, state.CustomNotice, "foo.com/bar", nil)
+	addNotice(c, st, state.CustomNotice, "example.com/x", nil)
+	addNotice(c, st, state.CustomNotice, "foo.com/baz", nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	notices, err := st.WaitNotices(ctx, &state.NoticeFilter{Keys: []string{"example.com/x"}})
+	c.Assert(err, IsNil)
+	c.Assert(notices, HasLen, 1)
+	n := noticeToMap(c, notices[0])
+	c.Check(n["type"], Equals, "custom")
+	c.Check(n["key"], Equals, "example.com/x")
+}
+
+func (s *noticesSuite) TestWaitNoticesNew(c *C) {
+	st := state.New(nil)
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		st.Lock()
+		defer st.Unlock()
+		addNotice(c, st, state.CustomNotice, "example.com/x", nil)
+		addNotice(c, st, state.CustomNotice, "example.com/y", nil)
+	}()
+
+	st.Lock()
+	defer st.Unlock()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	notices, err := st.WaitNotices(ctx, &state.NoticeFilter{Keys: []string{"example.com/y"}})
+	c.Assert(err, IsNil)
+	c.Assert(notices, HasLen, 1)
+	n := noticeToMap(c, notices[0])
+	c.Assert(n["key"], Equals, "example.com/y")
+}
+
+func (s *noticesSuite) TestWaitNoticesTimeout(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+	notices, err := st.WaitNotices(ctx, nil)
+	c.Assert(err, ErrorMatches, "context deadline exceeded")
+	c.Assert(notices, HasLen, 0)
+}
+
+func (s *noticesSuite) TestWaitNoticesLongPoll(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	go func() {
+		for i := 0; i < 10; i++ {
+			st.Lock()
+			addNotice(c, st, state.CustomNotice, fmt.Sprintf("a.b/%d", i), nil)
+			st.Unlock()
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	var after time.Time
+	for total := 0; total < 10; {
+		notices, err := st.WaitNotices(ctx, &state.NoticeFilter{After: after})
+		c.Assert(err, IsNil)
+		c.Assert(len(notices) > 0, Equals, true)
+		total += len(notices)
+		n := noticeToMap(c, notices[len(notices)-1])
+		lastRepeated, err := time.Parse(time.RFC3339, n["last-repeated"].(string))
+		c.Assert(err, IsNil)
+		after = lastRepeated
+	}
+}
+
+func (s *noticesSuite) TestWaitNoticesConcurrent(c *C) {
+	const numWaiters = 100
+
+	st := state.New(nil)
+
+	var wg sync.WaitGroup
+	for i := 0; i < numWaiters; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			st.Lock()
+			defer st.Unlock()
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			key := fmt.Sprintf("a.b/%d", i)
+			notices, err := st.WaitNotices(ctx, &state.NoticeFilter{Keys: []string{key}})
+			c.Assert(err, IsNil)
+			c.Assert(notices, HasLen, 1)
+			n := noticeToMap(c, notices[0])
+			c.Assert(n["key"], Equals, key)
+		}(i)
+	}
+
+	for i := 0; i < numWaiters; i++ {
+		st.Lock()
+		addNotice(c, st, state.CustomNotice, fmt.Sprintf("a.b/%d", i), nil)
+		st.Unlock()
+		time.Sleep(time.Microsecond)
+	}
+
+	// Wait for WaitNotice goroutines to finish
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		done <- struct{}{}
+	}()
+	select {
+	case <-time.After(time.Second):
+		c.Fatalf("timed out waiting for WaitNotice goroutines to finish")
+	case <-done:
+	}
+}
+
+// noticeToMap converts a Notice to a map using a JSON marshal-unmarshal round trip.
+func noticeToMap(c *C, notice *state.Notice) map[string]any {
+	buf, err := json.Marshal(notice)
+	c.Assert(err, IsNil)
+	var n map[string]any
+	err = json.Unmarshal(buf, &n)
+	c.Assert(err, IsNil)
+	return n
+}
+
+func addNotice(c *C, st *state.State, noticeType state.NoticeType, key string, options *state.AddNoticeOptions) {
+	_, err := st.AddNotice(noticeType, key, options)
+	c.Assert(err, IsNil)
+}

--- a/overlord/state/state.go
+++ b/overlord/state/state.go
@@ -87,6 +87,7 @@ type State struct {
 	lastTaskId   int
 	lastChangeId int
 	lastLaneId   int
+	lastNoticeId int
 	// lastHandlerId is not serialized, it's only used during runtime
 	// for registering runtime callbacks
 	lastHandlerId int
@@ -96,6 +97,9 @@ type State struct {
 	changes  map[string]*Change
 	tasks    map[string]*Task
 	warnings map[string]*Warning
+	notices  map[noticeKey]*Notice
+
+	noticeCond *sync.Cond
 
 	modified bool
 
@@ -110,18 +114,21 @@ type State struct {
 
 // New returns a new empty state.
 func New(backend Backend) *State {
-	return &State{
+	st := &State{
 		backend:             backend,
 		data:                make(customData),
 		changes:             make(map[string]*Change),
 		tasks:               make(map[string]*Task),
 		warnings:            make(map[string]*Warning),
+		notices:             make(map[noticeKey]*Notice),
 		modified:            true,
 		cache:               make(map[interface{}]interface{}),
 		pendingChangeByAttr: make(map[string]func(*Change) bool),
 		taskHandlers:        make(map[int]func(t *Task, old Status, new Status)),
 		changeHandlers:      make(map[int]func(chg *Change, old Status, new Status)),
 	}
+	st.noticeCond = sync.NewCond(st) // use State.Lock and State.Unlock
+	return st
 }
 
 // Modified returns whether the state was modified since the last checkpoint.
@@ -158,10 +165,12 @@ type marshalledState struct {
 	Changes  map[string]*Change          `json:"changes"`
 	Tasks    map[string]*Task            `json:"tasks"`
 	Warnings []*Warning                  `json:"warnings,omitempty"`
+	Notices  []*Notice                   `json:"notices,omitempty"`
 
 	LastChangeId int `json:"last-change-id"`
 	LastTaskId   int `json:"last-task-id"`
 	LastLaneId   int `json:"last-lane-id"`
+	LastNoticeId int `json:"last-notice-id"`
 }
 
 // MarshalJSON makes State a json.Marshaller
@@ -172,10 +181,12 @@ func (s *State) MarshalJSON() ([]byte, error) {
 		Changes:  s.changes,
 		Tasks:    s.tasks,
 		Warnings: s.flattenWarnings(),
+		Notices:  s.flattenNotices(nil),
 
 		LastTaskId:   s.lastTaskId,
 		LastChangeId: s.lastChangeId,
 		LastLaneId:   s.lastLaneId,
+		LastNoticeId: s.lastNoticeId,
 	})
 }
 
@@ -191,9 +202,11 @@ func (s *State) UnmarshalJSON(data []byte) error {
 	s.changes = unmarshalled.Changes
 	s.tasks = unmarshalled.Tasks
 	s.unflattenWarnings(unmarshalled.Warnings)
+	s.unflattenNotices(unmarshalled.Notices)
 	s.lastChangeId = unmarshalled.LastChangeId
 	s.lastTaskId = unmarshalled.LastTaskId
 	s.lastLaneId = unmarshalled.LastLaneId
+	s.lastNoticeId = unmarshalled.LastNoticeId
 	// backlink state again
 	for _, t := range s.tasks {
 		t.state = s
@@ -423,7 +436,7 @@ func (s *State) RegisterPendingChangeByAttr(attr string, f func(*Change) bool) {
 //     changes than the limit set via "maxReadyChanges" those changes in ready
 //     state will also removed even if they are below the pruneWait duration.
 //
-//   - it removes expired warnings.
+//   - it removes expired warnings and notices.
 func (s *State) Prune(startOfOperation time.Time, pruneWait, abortWait time.Duration, maxReadyChanges int) {
 	now := time.Now()
 	pruneLimit := now.Add(-pruneWait)
@@ -448,6 +461,12 @@ func (s *State) Prune(startOfOperation time.Time, pruneWait, abortWait time.Dura
 	for k, w := range s.warnings {
 		if w.ExpiredBefore(now) {
 			delete(s.warnings, k)
+		}
+	}
+
+	for k, n := range s.notices {
+		if n.expired(now) {
+			delete(s.notices, k)
 		}
 	}
 

--- a/overlord/state/state.go
+++ b/overlord/state/state.go
@@ -591,6 +591,7 @@ func ReadState(backend Backend, r io.Reader) (*State, error) {
 		return nil, fmt.Errorf("cannot read state: %s", err)
 	}
 	s.backend = backend
+	s.noticeCond = sync.NewCond(s)
 	s.modified = false
 	s.cache = make(map[interface{}]interface{})
 	s.pendingChangeByAttr = make(map[string]func(*Change) bool)

--- a/overlord/state/state_test.go
+++ b/overlord/state/state_test.go
@@ -576,6 +576,7 @@ func (ss *stateSuite) TestEmptyStateDataAndCheckpointReadAndSet(c *C) {
 		"changes",
 		"tasks",
 		"warnings",
+		"notices",
 		"cache",
 		"pendingChangeByAttr",
 		"taskHandlers",


### PR DESCRIPTION
The addition of Notices in snapd is based on Pebble Notices, for which the spec can be found at [JU048](https://docs.google.com/document/d/16PJ85fefalQd7JbWSxkRWn0Ye-Hs8S1yE99eW7pk8fA).

This PR adds notices to the snapd state, and exposes them primarily through `state.Notice`, `state.Notices`, and `state.WaitNotices`. The former allows looking up a particular notice by ID, and the latter two return existing notices which match the given optional filter. Notably, `state.WaitNotices` can be used to long-poll for new notices as they occur.

The corresponding PR in Pebble is: https://github.com/canonical/pebble/pull/295