### PR TITLE
i/b/fwupd.go: Allow write access to COD capsule update directory

### DIFF
--- a/interfaces/builtin/fwupd.go
+++ b/interfaces/builtin/fwupd.go
@@ -129,6 +129,8 @@ const fwupdPermanentSlotAppArmor = `
   /boot/efi/EFI/*/fw/** rw,
   /boot/efi/EFI/fwupd/ rw,
   /boot/efi/EFI/fwupd/** rw,
+  /boot/efi/EFI/UpdateCapsule/ rw,
+  /boot/efi/EFI/UpdateCapsule/** rw,
 
   # Allow access from efivar library
   /sys/devices/{pci*,platform}/**/block/**/partition r,


### PR DESCRIPTION
On aarch64 devices supporting it, capsule update on disk will be used. This require access to the ESP's EFI/UpdateCapsule.

Fixes fwupd/fwupd#6256