### PR TITLE
aspects: support "number" type in aspect schemas

### DIFF
--- a/aspects/schema.go
+++ b/aspects/schema.go
@@ -553,7 +553,7 @@ type numberSchema struct {
 	choices []float64
 }
 
-// Validate that raw is a valid integer and meets the schema's constraints.
+// Validate that raw is a valid number and meets the schema's constraints.
 func (v *numberSchema) Validate(raw []byte) error {
 	var num float64
 	if err := json.Unmarshal(raw, &num); err != nil {

--- a/aspects/schema.go
+++ b/aspects/schema.go
@@ -153,6 +153,8 @@ func (s *StorageSchema) newTypeSchema(typ string) (parser, error) {
 		return &intSchema{}, nil
 	case "any":
 		return &anySchema{}, nil
+	case "number":
+		return &numberSchema{}, nil
 	default:
 		if typ != "" && typ[0] == '$' {
 			return s.getUserType(typ[1:])
@@ -469,29 +471,7 @@ func (v *intSchema) Validate(raw []byte) error {
 		return err
 	}
 
-	if len(v.choices) != 0 {
-		var found bool
-		for _, choice := range v.choices {
-			if num == choice {
-				found = true
-				break
-			}
-		}
-
-		if !found {
-			return fmt.Errorf(`integer %d is not one of the allowed choices`, num)
-		}
-	}
-
-	if v.min != nil && num < *v.min {
-		return fmt.Errorf(`integer %d is less than allowed minimum %d`, num, *v.min)
-	}
-
-	if v.max != nil && num > *v.max {
-		return fmt.Errorf(`integer %d is greater than allowed maximum %d`, num, *v.max)
-	}
-
-	return nil
+	return validateNumber(num, v.choices, v.min, v.max)
 }
 
 func (v *intSchema) parseConstraints(constraints map[string]json.RawMessage) error {
@@ -556,5 +536,95 @@ func (v *anySchema) Validate(raw []byte) error {
 
 func (v *anySchema) parseConstraints(constraints map[string]json.RawMessage) error {
 	// no error because we're not explicitly rejecting unsupported keywords (for now)
+	return nil
+}
+
+type numberSchema struct {
+	min     *float64
+	max     *float64
+	choices []float64
+}
+
+// Validate that raw is a valid integer and meets the schema's constraints.
+func (v *numberSchema) Validate(raw []byte) error {
+	var num float64
+	if err := json.Unmarshal(raw, &num); err != nil {
+		return err
+	}
+
+	return validateNumber(num, v.choices, v.min, v.max)
+}
+
+func validateNumber[Num ~int64 | ~float64](num Num, choices []Num, min, max *Num) error {
+	if len(choices) != 0 {
+		var found bool
+		for _, choice := range choices {
+			if num == choice {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			return fmt.Errorf(`%v is not one of the allowed choices`, num)
+		}
+	}
+
+	// these comparisons are susceptible to floating-point errors but given that
+	// this won't be used for general storage it should be precise enough
+	if min != nil && num < *min {
+		return fmt.Errorf(`%v is less than allowed minimum %v`, num, *min)
+	}
+
+	if max != nil && num > *max {
+		return fmt.Errorf(`%v is greater than allowed maximum %v`, num, *max)
+	}
+
+	return nil
+}
+
+func (v *numberSchema) parseConstraints(constraints map[string]json.RawMessage) error {
+	if rawChoices, ok := constraints["choices"]; ok {
+		var choices []float64
+		err := json.Unmarshal(rawChoices, &choices)
+		if err != nil {
+			return fmt.Errorf(`cannot parse "choices" constraint: %v`, err)
+		}
+
+		if len(choices) == 0 {
+			return fmt.Errorf(`cannot have "choices" constraint with empty list`)
+		}
+
+		v.choices = choices
+	}
+
+	if rawMin, ok := constraints["min"]; ok {
+		if v.choices != nil {
+			return fmt.Errorf(`cannot have "choices" and "min" constraints`)
+		}
+
+		var min float64
+		if err := json.Unmarshal(rawMin, &min); err != nil {
+			return fmt.Errorf(`cannot parse "min" constraint: %v`, err)
+		}
+		v.min = &min
+	}
+
+	if rawMax, ok := constraints["max"]; ok {
+		if v.choices != nil {
+			return fmt.Errorf(`cannot have "choices" and "max" constraints`)
+		}
+
+		var max float64
+		if err := json.Unmarshal(rawMax, &max); err != nil {
+			return fmt.Errorf(`cannot parse "max" constraint: %v`, err)
+		}
+		v.max = &max
+	}
+
+	if v.min != nil && v.max != nil && *v.min > *v.max {
+		return fmt.Errorf(`cannot have "min" constraint with value greater than "max"`)
+	}
+
 	return nil
 }

--- a/aspects/schema_test.go
+++ b/aspects/schema_test.go
@@ -879,7 +879,7 @@ func (*schemaSuite) TestIntegerMustMatchChoices(c *C) {
 		if num == 1 || num == 3 {
 			c.Assert(err, IsNil)
 		} else {
-			c.Assert(err, ErrorMatches, fmt.Sprintf(`integer %d is not one of the allowed choices`, num))
+			c.Assert(err, ErrorMatches, fmt.Sprintf(`%d is not one of the allowed choices`, num))
 		}
 	}
 }
@@ -906,9 +906,9 @@ func (*schemaSuite) TestIntegerMustMatchMinMax(c *C) {
 
 		err := schema.Validate(input)
 		if num < min {
-			c.Assert(err, ErrorMatches, fmt.Sprintf(`integer %d is less than allowed minimum %d`, num, min))
+			c.Assert(err, ErrorMatches, fmt.Sprintf(`%d is less than allowed minimum %d`, num, min))
 		} else if num > max {
-			c.Assert(err, ErrorMatches, fmt.Sprintf(`integer %d is greater than allowed maximum %d`, num, max))
+			c.Assert(err, ErrorMatches, fmt.Sprintf(`%d is greater than allowed maximum %d`, num, max))
 		} else {
 			c.Assert(err, IsNil)
 		}
@@ -1136,4 +1136,197 @@ func (*schemaSuite) TestAnyTypeRejectsBadJSON(c *C) {
 }`)
 	err = schema.Validate(input)
 	c.Assert(err, ErrorMatches, `invalid character .*`)
+}
+
+func (*schemaSuite) TestNumberValidFloatAndInt(c *C) {
+	schemaStr := []byte(`{
+	"schema": {
+		"foo": "number",
+		"bar": "number"
+	}
+}`)
+
+	schema, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, IsNil)
+
+	input := []byte(`{
+	"foo": 1.2,
+	"bar": 1
+}`)
+
+	err = schema.Validate(input)
+	c.Assert(err, IsNil)
+}
+
+func (*schemaSuite) TestNumberMustMatchChoices(c *C) {
+	schemaStr := []byte(`{
+	"schema": {
+		"foo": {
+			"type": "number",
+			"choices": [1,	3.0]
+		}
+	}
+}`)
+
+	schema, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, IsNil)
+
+	for _, num := range []float64{0, 1, 2, 3, 4} {
+		input := []byte(fmt.Sprintf(`{
+	"foo": %f
+}`, num))
+
+		err := schema.Validate(input)
+		if num == 1 || num == 3 {
+			c.Assert(err, IsNil)
+		} else {
+			c.Assert(err, ErrorMatches, fmt.Sprintf(`%v is not one of the allowed choices`, num))
+		}
+	}
+}
+
+func (*schemaSuite) TestNumberMustMatchMinMax(c *C) {
+	min, max := float32(0.1), float32(3)
+	schemaStr := []byte(fmt.Sprintf(`{
+	"schema": {
+		"foo": {
+			"type": "number",
+			"min": %.1f,
+			"max": %f
+		}
+	}
+}`, min, max))
+
+	schema, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, IsNil)
+
+	for _, num := range []float32{0, 0.1, 2, 3, 4} {
+		input := []byte(fmt.Sprintf(`{
+	"foo": %.25f
+}`, num))
+
+		err := schema.Validate(input)
+		if num < min {
+			c.Assert(err, ErrorMatches, fmt.Sprintf(`%v is less than allowed minimum %v`, num, min))
+		} else if num > max {
+			c.Assert(err, ErrorMatches, fmt.Sprintf(`%v is greater than allowed maximum %v`, num, max))
+		} else {
+			c.Assert(err, IsNil)
+		}
+	}
+}
+
+func (*schemaSuite) TestNumberWithWrongTypes(c *C) {
+	schemaStr := []byte(`{
+	"schema": {
+		"foo": "number"
+	}
+}`)
+
+	schema, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, IsNil)
+
+	input := []byte(`{
+	"foo": "bar"
+}`)
+
+	err = schema.Validate(input)
+	c.Assert(err, ErrorMatches, `json: cannot unmarshal string into Go value of type float64`)
+}
+
+func (*schemaSuite) TestNumberChoicesAndMinMaxFail(c *C) {
+	schemaStr := []byte(`{
+	"schema": {
+		"foo": {
+			"type": "number",
+			"min": 0,
+			"choices": [0]
+		}
+	}
+}`)
+
+	_, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, ErrorMatches, `cannot have "choices" and "min" constraints`)
+
+	schemaStr = []byte(`{
+	"schema": {
+		"foo": {
+			"type": "number",
+			"max": 0,
+			"choices": [0]
+		}
+	}
+}`)
+
+	_, err = aspects.ParseSchema(schemaStr)
+	c.Assert(err, ErrorMatches, `cannot have "choices" and "max" constraints`)
+}
+
+func (*schemaSuite) TestNumberEmptyChoicesFail(c *C) {
+	schemaStr := []byte(`{
+	"schema": {
+		"foo": {
+			"type": "number",
+			"choices": []
+		}
+	}
+}`)
+
+	_, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, ErrorMatches, `cannot have "choices" constraint with empty list`)
+}
+
+func (*schemaSuite) TestNumberBadChoicesConstraint(c *C) {
+	schemaStr := []byte(`{
+	"schema": {
+		"foo": {
+			"type": "number",
+			"choices": 5
+		}
+	}
+}`)
+
+	_, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, ErrorMatches, `cannot parse "choices" constraint: json: cannot unmarshal number into Go value of type \[\]float64`)
+}
+
+func (*schemaSuite) TestNumberBadMinMaxConstraints(c *C) {
+	schemaStr := []byte(`{
+	"schema": {
+		"foo": {
+			"type": "number",
+			"min": "5"
+		}
+	}
+}`)
+
+	_, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, ErrorMatches, `cannot parse "min" constraint: json: cannot unmarshal string into Go value of type float64`)
+
+	schemaStr = []byte(`{
+	"schema": {
+		"foo": {
+			"type": "number",
+			"max": "5"
+		}
+	}
+}`)
+
+	_, err = aspects.ParseSchema(schemaStr)
+	c.Assert(err, ErrorMatches, `cannot parse "max" constraint: json: cannot unmarshal string into Go value of type float64`)
+}
+
+func (*schemaSuite) TestNumberMinGreaterThanMaxConstraintFail(c *C) {
+	schemaStr := []byte(`{
+	"schema": {
+		"foo": {
+			"type": "number",
+			"min": 5,
+			"max": 1
+		}
+	}
+}`)
+
+	_, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, ErrorMatches, `cannot have "min" constraint with value greater than "max"`)
 }


### PR DESCRIPTION
Adds support for the "number" type in aspect schemas, with constraints to restrict its max, min and allowed values. I used generics to implement a generic validation of the number and int types. I'm not sure if we've used generics before since the codebase predates them but AFAIK we've also never explicitly decided against them. Since this package is new and self-contained, I didn't see a reason not to here.