### PR TITLE
o/snapstate: fix flaky local install cleanup test

### DIFF
--- a/overlord/snapstate/handlers_link_test.go
+++ b/overlord/snapstate/handlers_link_test.go
@@ -1886,11 +1886,9 @@ func (s *linkSnapSuite) TestDoUndoLinkSnapRestoresLastRefreshTime(c *C) {
 	lastRefresh, err := time.Parse(time.RFC3339, "2021-06-10T10:00:00Z")
 	c.Assert(err, IsNil)
 
-	var called int
 	restoreTimeNow := snapstate.MockTimeNow(func() time.Time {
 		now, err := time.Parse(time.RFC3339, "2021-07-20T10:00:00Z")
 		c.Assert(err, IsNil)
-		called++
 		return now
 	})
 	defer restoreTimeNow()
@@ -1926,7 +1924,6 @@ func (s *linkSnapSuite) TestDoUndoLinkSnapRestoresLastRefreshTime(c *C) {
 	c.Assert(snapstate.Get(s.state, "snap", &snapst), IsNil)
 	// the original last-refresh-time has been restored.
 	c.Check(snapst.LastRefreshTime.Equal(lastRefresh), Equals, true)
-	c.Check(called, Equals, 1)
 }
 
 func (s *linkSnapSuite) TestUndoLinkSnapdFirstInstall(c *C) {

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -1032,7 +1032,7 @@ func (m *SnapManager) localInstallCleanup() error {
 	m.state.Lock()
 	defer m.state.Unlock()
 
-	now := time.Now()
+	now := timeNow()
 	cutoff := now.Add(-localInstallCleanupWait)
 	if localInstallLastCleanup.After(cutoff) {
 		return nil

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -3728,16 +3728,20 @@ func (s *snapmgrTestSuite) TestEsnureCleansOldSideloads(c *C) {
 	// set last cleanup to epoch
 	snapstate.MockLocalInstallLastCleanup(time.Time{})
 
+	now := t1
+	restore := snapstate.MockTimeNow(func() time.Time {
+		return now
+	})
+	defer restore()
+
 	s.snapmgr.Ensure()
 	// oldest sideload gone
 	c.Assert(filenames(), DeepEquals, []string{s2, s0})
 
-	time.Sleep(200 * time.Millisecond)
-
+	now = t1.Add(200 * time.Millisecond)
 	s.snapmgr.Ensure()
 	// all sideloads gone
 	c.Assert(filenames(), DeepEquals, []string{s0})
-
 }
 
 func (s *snapmgrTestSuite) verifyRefreshLast(c *C) {


### PR DESCRIPTION
The local cleanup test was failing on some systems due timing issues. I had to remove a check in another test because it started failing due to the new call to the mocked function. It was a somewhat roundabout way to check that LastRefreshTime was set by the link-snap task so I think there's not much loss in removing it
