### PR TITLE
tests/connected-after-reboot-revert: modify installed kernel

### DIFF
--- a/tests/nested/core/connected-after-reboot-revert/task.yaml
+++ b/tests/nested/core/connected-after-reboot-revert/task.yaml
@@ -11,13 +11,7 @@ systems: [ubuntu-16.04-64, ubuntu-18.04-64, ubuntu-20.04-64, ubuntu-22.04-64]
 execute: |
   echo "Build kernel with failing post-refresh hook"
   VERSION="$(tests.nested show version)"
-  CHANNEL=$VERSION
-  if [ "$VERSION" -eq 16 ]; then
-      CHANNEL=latest
-  fi
-  rm -rf pc-kernel
-  snap download --basename=pc-kernel --channel="$CHANNEL/edge" pc-kernel
-  unsquashfs -d pc-kernel pc-kernel.snap
+  unsquashfs -d pc-kernel "$(tests.nested get extra-snaps-path)"/pc-kernel.snap
   HOOKS_D=pc-kernel/meta/hooks/
   POST_REFRESH_P=$HOOKS_D/post-refresh
   mkdir -p "$HOOKS_D"

--- a/tests/nested/core/kernel-revert-after-boot/task.yaml
+++ b/tests/nested/core/kernel-revert-after-boot/task.yaml
@@ -10,13 +10,8 @@ systems: [ubuntu-16.04-64, ubuntu-18.04-64, ubuntu-20.04-64, ubuntu-22.04-64]
 execute: |
   echo "Build kernel with failing post-refresh hook"
   VERSION="$(tests.nested show version)"
-  CHANNEL=$VERSION
-  if [ "$VERSION" -eq 16 ]; then
-      CHANNEL=latest
-  fi
 
-  snap download --basename=pc-kernel --channel="$CHANNEL/edge" pc-kernel
-  unsquashfs -d pc-kernel pc-kernel.snap
+  unsquashfs -d pc-kernel "$(tests.nested get extra-snaps-path)"/pc-kernel.snap
   HOOKS_D=pc-kernel/meta/hooks/
   POST_REFRESH_P=$HOOKS_D/post-refresh
   mkdir -p "$HOOKS_D"


### PR DESCRIPTION
Modify installed kernel instead of downloading it, this will speed up the tests. Also, we cannot use pc-kernel from the edge channel anymore as it is not signed now with Canonical keys.