### PR TITLE
cmd/snap,o/devicestate: consistently stop auto-import of assertions during install modes (install, factory-reset)

### DIFF
--- a/cmd/snap/cmd_auto_import.go
+++ b/cmd/snap/cmd_auto_import.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2020 Canonical Ltd
+ * Copyright (C) 2014-2023 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -308,13 +308,13 @@ func removableBlockDevices() (removableDevices []string) {
 	return removableDevices
 }
 
-// inInstallmode returns true if it's UC20 system in install mode
+// inInstallmode returns true if it's UC20 system in install/factory-reset modes
 func inInstallMode() bool {
 	modeenv, err := boot.ReadModeenv(dirs.GlobalRootDir)
 	if err != nil {
 		return false
 	}
-	return modeenv.Mode == "install"
+	return modeenv.Mode == "install" || modeenv.Mode == "factory-reset"
 }
 
 func (x *cmdAutoImport) Execute(args []string) error {
@@ -328,7 +328,7 @@ func (x *cmdAutoImport) Execute(args []string) error {
 	}
 	// TODO:UC20: workaround for LP: #1860231
 	if inInstallMode() {
-		fmt.Fprintf(Stderr, "auto-import is disabled in install-mode\n")
+		fmt.Fprintf(Stderr, "auto-import is disabled in install modes\n")
 		return nil
 	}
 

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -1023,10 +1023,10 @@ func (m *DeviceManager) ensureAutoImportAssertions() error {
 		return nil
 	}
 
-	if m.SystemMode(SysAny) == "install" {
-		// we do not auto-import assertions during install mode
+	mode := m.SystemMode(SysAny)
+	if mode == "install" || mode == "factory-reset" {
+		// we do not auto-import assertions during install modes
 		// snap auto-import also does not
-		// XXX same for factory-reset?
 		return nil
 	}
 

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2022 Canonical Ltd
+ * Copyright (C) 2016-2023 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -1020,6 +1020,13 @@ func (m *DeviceManager) ensureAutoImportAssertions() error {
 
 	if m.earlyDeviceSeed == nil {
 		// we have no seed cached yet, no point to check further
+		return nil
+	}
+
+	if m.SystemMode(SysAny) == "install" {
+		// we do not auto-import assertions during install mode
+		// snap auto-import also does not
+		// XXX same for factory-reset?
 		return nil
 	}
 

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -2543,6 +2543,31 @@ func (s *deviceMgrSuite) TestHandleAutoImportAssertionClassic(c *C) {
 	c.Assert(autoImported, Equals, false)
 }
 
+func (s *deviceMgrSuite) TestHandleAutoImportAssertionInstallMode(c *C) {
+	a := devicestate.MockProcessAutoImportAssertion(func(*state.State, seed.Seed, asserts.RODatabase, func(batch *asserts.Batch) error) error {
+		panic("trying to process auto-import-assertion in install mode")
+	})
+	defer a()
+
+	s.mockSystemMode(c, "install")
+	s.state.Lock()
+	s.cacheDeviceCore20Seed(c)
+	s.state.Set("seeded", nil)
+	s.state.Unlock()
+
+	err := devicestate.EnsureAutoImportAssertions(s.mgr)
+	c.Check(err, IsNil)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// ensure state has not been changed
+	var autoImported bool
+	err = s.state.Get("asserts-early-auto-imported", &autoImported)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
+	c.Assert(autoImported, Equals, false)
+}
+
 func (s *deviceMgrSuite) TestHandleAutoImportAssertionWhenDone(c *C) {
 	a := devicestate.MockProcessAutoImportAssertion(func(*state.State, seed.Seed, asserts.RODatabase, func(batch *asserts.Batch) error) error {
 		panic("trying to process auto-import-assertion after it was already processed")

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -2543,13 +2543,13 @@ func (s *deviceMgrSuite) TestHandleAutoImportAssertionClassic(c *C) {
 	c.Assert(autoImported, Equals, false)
 }
 
-func (s *deviceMgrSuite) TestHandleAutoImportAssertionInstallMode(c *C) {
+func (s *deviceMgrSuite) testHandleAutoImportAssertionInstallModes(c *C, mode string) {
 	a := devicestate.MockProcessAutoImportAssertion(func(*state.State, seed.Seed, asserts.RODatabase, func(batch *asserts.Batch) error) error {
-		panic("trying to process auto-import-assertion in install mode")
+		panic("trying to process auto-import-assertion in install modes")
 	})
 	defer a()
 
-	s.mockSystemMode(c, "install")
+	s.mockSystemMode(c, mode)
 	s.state.Lock()
 	s.cacheDeviceCore20Seed(c)
 	s.state.Set("seeded", nil)
@@ -2566,6 +2566,14 @@ func (s *deviceMgrSuite) TestHandleAutoImportAssertionInstallMode(c *C) {
 	err = s.state.Get("asserts-early-auto-imported", &autoImported)
 	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
 	c.Assert(autoImported, Equals, false)
+}
+
+func (s *deviceMgrSuite) TestHandleAutoImportAssertionInstallMode(c *C) {
+	s.testHandleAutoImportAssertionInstallModes(c, "install")
+}
+
+func (s *deviceMgrSuite) TestHandleAutoImportAssertionFactoryResetMode(c *C) {
+	s.testHandleAutoImportAssertionInstallModes(c, "factory-reset")
 }
 
 func (s *deviceMgrSuite) TestHandleAutoImportAssertionWhenDone(c *C) {


### PR DESCRIPTION
we do not expect nor want users to log in during those modes