### PR TITLE
interfaces: update desktop interface AppArmor permanent slot rules

### DIFF
--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -384,6 +384,14 @@ dbus (send)
     member="Get{,All}"
     peer=(label=unconfined),
 
+# Allow gnome-shell to bind to its various D-Bus names
+dbus (bind)
+    bus=session
+    name=org.gnome.Mutter.*,
+dbus (bind)
+    bus=session
+    name=org.gnome.Shell{,.*},
+
 # Allow access to GDM's private reauthentication channel socket
 unix (connect, receive, send)
     type=stream

--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -377,6 +377,12 @@ dbus (send)
     interface=org.gnome.DisplayManager.Manager
     member=RegisterSession
     peer=(label=unconfined),
+dbus (send)
+    bus=system
+    path=/org/gnome/DisplayManager/Manager
+    interface=org.freedesktop.DBus.Properties
+    member="Get{,All}"
+    peer=(label=unconfined),
 
 # Allow unconfined xdg-desktop-portal to communicate with impl
 # services provided by the snap.

--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -375,7 +375,7 @@ dbus (send)
     bus=system
     path=/org/gnome/DisplayManager/Manager
     interface=org.gnome.DisplayManager.Manager
-    member=RegisterSession
+    member={RegisterSession,OpenReauthenticationChannel}
     peer=(label=unconfined),
 dbus (send)
     bus=system
@@ -383,6 +383,13 @@ dbus (send)
     interface=org.freedesktop.DBus.Properties
     member="Get{,All}"
     peer=(label=unconfined),
+
+# Allow access to GDM's private reauthentication channel socket
+# FIXME: this will break once we upgrade to glib 2.75.x, and GDM
+# starts creating a non-abstract socket in /tmp.
+unix (connect, receive, send)
+    type=stream
+    peer=(addr="@/tmp/dbus-*"),
 
 # Allow unconfined xdg-desktop-portal to communicate with impl
 # services provided by the snap.

--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -385,11 +385,10 @@ dbus (send)
     peer=(label=unconfined),
 
 # Allow access to GDM's private reauthentication channel socket
-# FIXME: this will break once we upgrade to glib 2.75.x, and GDM
-# starts creating a non-abstract socket in /tmp.
 unix (connect, receive, send)
     type=stream
     peer=(addr="@/tmp/dbus-*"),
+/run/gdm3/dbus/dbus-* rw,
 
 # Allow unconfined xdg-desktop-portal to communicate with impl
 # services provided by the snap.

--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -383,6 +383,12 @@ dbus (receive, send)
     interface=org.freedesktop.DBus.Properties
     peer=(label=unconfined),
 
+dbus (send)
+    bus=session
+    interface=org.freedesktop.portal.*
+    path=/org/freedesktop/portal/desktop{,/**}
+    peer=(label=unconfined),
+
 # Allow access to various paths gnome-session and gnome-shell need.
 /etc/fonts{,/**} r,
 /etc/glvnd{,/**} r,

--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -370,6 +370,14 @@ dbus (receive)
     member="{AddNotification,RemoveNotification}"
     peer=(label=unconfined),
 
+# Allow registering session with GDM, necessary for screen locking
+dbus (send)
+    bus=system
+    path=/org/gnome/DisplayManager/Manager
+    interface=org.gnome.DisplayManager.Manager
+    member=RegisterSession
+    peer=(label=unconfined),
+
 # Allow unconfined xdg-desktop-portal to communicate with impl
 # services provided by the snap.
 dbus (receive, send)

--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -392,6 +392,19 @@ dbus (bind)
     bus=session
     name=org.gnome.Shell{,.*},
 
+# Allow the shell to communicate with colord
+dbus (send, receive)
+    bus=system
+    path=/org/freedesktop/ColorManager{,/**}
+    interface=org.freedesktop.ColorManager*
+    peer=(label=unconfined),
+dbus (send, receive)
+    bus=system
+    path=/org/freedesktop/ColorManager{,/**}
+    interface=org.freedesktop.DBus.Properties
+    member={Get,GetAll,PropertiesChanged}
+    peer=(label=unconfined),
+
 # Allow access to GDM's private reauthentication channel socket
 unix (connect, receive, send)
     type=stream

--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -384,6 +384,9 @@ dbus (send)
     member="Get{,All}"
     peer=(label=unconfined),
 
+# Allow access to GDM's private reauthentication channel socket
+/run/gdm3/dbus/dbus-* rw,
+
 # Allow gnome-shell to bind to its various D-Bus names
 dbus (bind)
     bus=session
@@ -413,12 +416,6 @@ dbus (send, receive)
     member={Get,GetAll,PropertiesChanged}
     peer=(label=unconfined),
 
-# Allow access to GDM's private reauthentication channel socket
-unix (connect, receive, send)
-    type=stream
-    peer=(addr="@/tmp/dbus-*"),
-/run/gdm3/dbus/dbus-* rw,
-
 # Allow unconfined xdg-desktop-portal to communicate with impl
 # services provided by the snap.
 dbus (receive, send)
@@ -432,6 +429,7 @@ dbus (receive, send)
     interface=org.freedesktop.DBus.Properties
     peer=(label=unconfined),
 
+# Allow access to the regular xdg-desktop-portal APIs
 dbus (send)
     bus=session
     interface=org.freedesktop.portal.*

--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -392,6 +392,14 @@ dbus (bind)
     bus=session
     name=org.gnome.Shell{,.*},
 
+# Allow gnome-settings-daemon to bind its various D-Bus names
+dbus (bind)
+    bus=session
+    name=org.gnome.SettingsDaemon{,.*},
+dbus (bind)
+    bus=session
+    name=org.gtk.Settings,
+
 # Allow the shell to communicate with colord
 dbus (send, receive)
     bus=system


### PR DESCRIPTION
This PR combines a few changes that we have been using on the Core Desktop images for a while. This includes:

1. Allow snaps with a desktop slot to talk to xdg-desktop-portal. This avoids the need for a self-connected desktop plug on the snap to allow e.g. opening links from apps bundled in the ubuntu-desktop-session snap.
2. Allow access to GDM's `OpenReauthenticationChannel` API and the associated private bus address. This is used by gnome-shell to authenticate the user on its lock screen. To work with newer GNOME versions, we depend on [GDM !226](https://gitlab.gnome.org/GNOME/gdm/-/merge_requests/226) to use a socket location outside of `/tmp` (which can't work with a snap-style private tmp directory).
3. Allow communication with colord on the D-Bus system bus. The shell uses this to access color profiles associated with the display.
4. Allow binding to various D-Bus session names used by gnome-shell and gnome-settings-daemon. We had been using `dbus` interface slots for some of these, but I think it makes sense to grant them via permanent slot rules:
   * There is a regular naming scheme for these names, and more are added release to release.
   * None of the names support D-Bus activation.
   * For the most part, the names are used for communication between different components of the desktop shell. Where it might make sense to allow communication with other application snaps, we'd probably want to handle it through interfaces like `desktop` rather than through these generic `dbus` slots.