### PR TITLE
tests: fix interfaces-content test by clearing snap cache

### DIFF
--- a/tests/main/interfaces-content/task.yaml
+++ b/tests/main/interfaces-content/task.yaml
@@ -23,6 +23,9 @@ prepare: |
 
     tests.systemd stop-unit snapd.service
     rm -f /var/lib/snapd/state.json
+    # clear cache to prevent it from being used in the download, because that core
+    # was modified by the prepare suite and will fail to be validated
+    rm -f /var/lib/snapd/snaps/core_*
     systemctl start snapd
     snap wait system seed.loaded
 


### PR DESCRIPTION
The interfaces-content tests was failing because installing the test-snapd-content-plug snap was pulling in the core snap which couldn't be validated. The root cause was that the download core revision (16203) is the same as the revision downloaded and modified during the prepare stage so it triggered a cache hit. The installation would then try to find an assertion based on the snap's digest which doesn't exist because it was modified. Clearing the cache fixes the problem.