### PR TITLE
tests: skip layout-change test in all arm devices

### DIFF
--- a/tests/main/layout-change/task.yaml
+++ b/tests/main/layout-change/task.yaml
@@ -9,8 +9,8 @@ details: |
 
 systems:
     # the snaps aren't available for ARM or 32bit systems.
-    - -ubuntu-18.04-32
-    - -ubuntu-*-arm-64
+    - -ubuntu-*-32
+    - -ubuntu-*-arm*
 
 prepare: |
     echo "Removing snaps"


### PR DESCRIPTION
Currently it is failing on armhf and also in ubuntu-core-16-32 (beta validation)
