### PR TITLE
seed/seedwriter,image: prereq check strategy change to use snap.ValidateBasesAndProviders

### DIFF
--- a/image/image_test.go
+++ b/image/image_test.go
@@ -2649,31 +2649,6 @@ func (s *imageSuite) TestSetupSeedCore18GadgetDefaults(c *C) {
 	c.Check(osutil.FileExists(filepath.Join(rootdir, "_writable_defaults/etc/ssh/sshd_not_to_be_run")), Equals, true)
 }
 
-func (s *imageSuite) TestSetupSeedSnapCoreSatisfiesCore16(c *C) {
-	restore := image.MockTrusted(s.StoreSigning.Trusted)
-	defer restore()
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
-		"architecture":   "amd64",
-		"gadget":         "pc",
-		"kernel":         "pc-kernel",
-		"required-snaps": []interface{}{"snap-req-core16-base"},
-	})
-
-	rootdir := filepath.Join(c.MkDir(), "image")
-	s.setupSnaps(c, map[string]string{
-		"core":                "canonical",
-		"pc":                  "canonical",
-		"pc-kernel":           "canonical",
-		"snap-req-other-base": "canonical",
-	}, "")
-	opts := &image.Options{
-		PrepareDir: filepath.Dir(rootdir),
-	}
-
-	err := image.SetupSeed(s.tsto, model, opts)
-	c.Assert(err, IsNil)
-}
-
 func (s *imageSuite) TestSetupSeedStoreAssertionMissing(c *C) {
 	restore := image.MockTrusted(s.StoreSigning.Trusted)
 	defer restore()
@@ -2825,7 +2800,7 @@ func (s *imageSuite) TestSetupSeedMissingContentProvider(c *C) {
 	}
 
 	err := image.SetupSeed(s.tsto, model, opts)
-	c.Check(err, ErrorMatches, `cannot use snap "snap-req-content-provider" without its default content provider "gtk-common-themes" being added explicitly`)
+	c.Check(err, ErrorMatches, `prerequisites need to be added explicitly: cannot use snap "snap-req-content-provider": default provider "gtk-common-themes" is missing`)
 }
 
 func (s *imageSuite) TestSetupSeedClassic(c *C) {

--- a/seed/seedwriter/seed16.go
+++ b/seed/seedwriter/seed16.go
@@ -116,11 +116,6 @@ func (pol *policy16) checkBase(info *snap.Info, modes []string, availableByMode 
 	return fmt.Errorf("cannot add snap %q without also adding its base %q explicitly", info.SnapName(), info.Base)
 }
 
-func (pol *policy16) checkAvailable(snapRef naming.SnapRef, modes []string, availableByMode map[string]*naming.SnapSet) bool {
-	availableSnaps := availableByMode["run"]
-	return availableSnaps.Contains(snapRef)
-}
-
 func (pol *policy16) needsImplicitSnaps(availableByMode map[string]*naming.SnapSet) (bool, error) {
 	availableSnaps := availableByMode["run"]
 	// do we need to add implicitly either snapd (or core)

--- a/seed/seedwriter/seed20.go
+++ b/seed/seedwriter/seed20.go
@@ -107,13 +107,6 @@ func (pol *policy20) checkBase(info *snap.Info, modes []string, availableByMode 
 	}
 
 	whichBase := fmt.Sprintf("its base %q", base)
-	if base == "core16" {
-		if pol.checkAvailable(naming.Snap("core"), modes, availableByMode) {
-			return nil
-		}
-		whichBase += ` (or "core")`
-	}
-
 	return fmt.Errorf("cannot add snap %q without also adding %s explicitly%s", info.SnapName(), whichBase, errorMsgForModesSuffix(modes))
 }
 

--- a/seed/seedwriter/writer.go
+++ b/seed/seedwriter/writer.go
@@ -1263,7 +1263,10 @@ func (w *Writer) checkPrereqsInMode(mode string) error {
 	nephemeral := len(w.byModeSnaps["ephemeral"])
 	var snaps []*snap.Info
 	if mode != "run" && mode != "ephemeral" {
-		// include snap marked for any ephemeral mode
+		// mode is a concrete ephemeral mode
+		// (not run, not ephemeral which is the set of snaps
+		//  shared by all ephemeral modes)
+		// so we include snap marked for any ephemeral mode
 		snaps = make([]*snap.Info, 0, nmode+nephemeral)
 		for _, sn := range w.byModeSnaps["ephemeral"] {
 			snaps = append(snaps, sn.Info)

--- a/seed/seedwriter/writer.go
+++ b/seed/seedwriter/writer.go
@@ -1232,6 +1232,10 @@ func (w *Writer) Downloaded(fetchAsserts AssertsFetchFunc) (complete bool, err e
 }
 
 func (w *Writer) checkPrereqs() error {
+	// as we error on the first problem we want to check snaps mode by mode
+	// in a fixed order; we start with run then
+	// ephemeral as snaps marked as such need to be self-contained
+	// then specific modes sorted
 	modes := make([]string, 0, len(w.availableByMode))
 	modes = append(modes, "run")
 	fixed := 1
@@ -1246,7 +1250,6 @@ func (w *Writer) checkPrereqs() error {
 		modes = append(modes, m)
 	}
 	sort.Strings(modes[fixed:])
-	w.checkPrereqsInMode("ephemeral")
 	for _, m := range modes {
 		if err := w.checkPrereqsInMode(m); err != nil {
 			return err

--- a/seed/seedwriter/writer.go
+++ b/seed/seedwriter/writer.go
@@ -238,8 +238,6 @@ type policy interface {
 
 	checkBase(s *snap.Info, modes []string, availableByMode map[string]*naming.SnapSet) error
 
-	checkAvailable(snpRef naming.SnapRef, modes []string, availableByMode map[string]*naming.SnapSet) bool
-
 	checkClassicSnap(sn *SeedSnap) error
 
 	needsImplicitSnaps(availableByMode map[string]*naming.SnapSet) (bool, error)

--- a/seed/seedwriter/writer_test.go
+++ b/seed/seedwriter/writer_test.go
@@ -724,7 +724,7 @@ func (s *writerSuite) TestDownloadedMissingDefaultProvider(c *C) {
 	s.makeSnap(c, "cont-consumer", "developerid")
 
 	_, _, err := s.upToDownloaded(c, model, s.fillDownloadedSnap, s.fetchAsserts(c))
-	c.Check(err, ErrorMatches, `cannot use snap "cont-consumer" without its default content provider "cont-producer" being added explicitly`)
+	c.Check(err, ErrorMatches, `prerequisites need to be added explicitly: cannot use snap "cont-consumer": default provider "cont-producer" is missing`)
 }
 
 func (s *writerSuite) TestDownloadedCheckType(c *C) {
@@ -2685,7 +2685,7 @@ func (s *writerSuite) TestDownloadedCore20MissingDefaultProviderModes(c *C) {
 
 	s.opts.Label = "20191003"
 	_, _, err := s.upToDownloaded(c, model, s.fillDownloadedSnap, s.fetchAsserts(c))
-	c.Check(err, ErrorMatches, `cannot use snap "cont-consumer" without its default content provider "cont-producer" being added explicitly for all relevant modes \(recover\)`)
+	c.Check(err, ErrorMatches, `prerequisites need to be added explicitly for relevant mode recover: cannot use snap "cont-consumer": default provider "cont-producer" is missing`)
 }
 
 func (s *writerSuite) TestCore20NonDangerousDisallowedDevmodeSnaps(c *C) {

--- a/seed/seedwriter/writer_test.go
+++ b/seed/seedwriter/writer_test.go
@@ -164,11 +164,6 @@ plugs:
      content: cont
      default-provider: cont-producer
 `,
-	"required-base-core16": `name: required-base-core16
-type: app
-base: core16
-version: 1.0
-`,
 	"my-devmode": `name: my-devmode
 type: app
 version: 1
@@ -1932,23 +1927,6 @@ func (s *writerSuite) TestSeedSnapsWriteMetaClassicMinModelSnapdFromModelWins(c 
 	}
 }
 
-func (s *writerSuite) TestSeedSnapsWriteMetaClassicSnapdOnlyMissingCore16(c *C) {
-	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
-		"classic":        "true",
-		"architecture":   "amd64",
-		"gadget":         "classic-gadget18",
-		"required-snaps": []interface{}{"core18", "required-base-core16"},
-	})
-
-	s.makeSnap(c, "snapd", "")
-	s.makeSnap(c, "core18", "")
-	s.makeSnap(c, "classic-gadget18", "")
-	s.makeSnap(c, "required-base-core16", "developerid")
-
-	_, _, err := s.upToDownloaded(c, model, s.fillMetaDownloadedSnap, s.fetchAsserts(c))
-	c.Check(err, ErrorMatches, `cannot use "required-base-core16" requiring base "core16" without adding "core16" \(or "core"\) explicitly`)
-}
-
 func (s *writerSuite) TestSeedSnapsWriteMetaExtraSnaps(c *C) {
 	model := s.Brands.Model("my-brand", "my-model", map[string]interface{}{
 		"display-name":   "my model",
@@ -2602,7 +2580,6 @@ func (s *writerSuite) TestDownloadedCore20CheckBaseCoreXX(c *C) {
 	s.makeSnap(c, "pc=20", "")
 	s.makeSnap(c, "core", "")
 	s.makeSnap(c, "required", "")
-	s.makeSnap(c, "required-base-core16", "")
 
 	coreEnt := map[string]interface{}{
 		"name": "core",
@@ -2614,19 +2591,12 @@ func (s *writerSuite) TestDownloadedCore20CheckBaseCoreXX(c *C) {
 		"id":   s.AssertedSnapID("required"),
 	}
 
-	requiredBaseCore16Ent := map[string]interface{}{
-		"name": "required-base-core16",
-		"id":   s.AssertedSnapID("required-base-core16"),
-	}
-
 	tests := []struct {
 		snaps []interface{}
 		err   string
 	}{
 		{[]interface{}{coreEnt, requiredEnt}, ""},
-		{[]interface{}{coreEnt, requiredBaseCore16Ent}, ""},
 		{[]interface{}{requiredEnt}, `cannot add snap "required" without also adding its base "core" explicitly`},
-		{[]interface{}{requiredBaseCore16Ent}, `cannot add snap "required-base-core16" without also adding its base "core16" \(or "core"\) explicitly`},
 	}
 
 	baseLabel := "20191003"


### PR DESCRIPTION
this is a preparatory step to fix the image building side of the issue of not supporting when a default-provider content is fulfilled by an alternative snap

this also drops some tests and behavior related to core16, as it's not pursued anymore and it was getting in the way here