### PR TITLE
tests: avoid downloading twice pc-kernel

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -51,7 +51,7 @@ environment:
     BASE_CHANNEL: '$(HOST: echo "${SPREAD_BASE_CHANNEL:-edge}")'
     # Channel for kernel cannot be edge as that one is not signed with Canonical keys
     KERNEL_CHANNEL: '$(HOST: echo "${SPREAD_KERNEL_CHANNEL:-beta}")'
-    GADGET_CHANNEL: '$(HOST: echo "${SPREAD_GADGET_CHANNEL:-edge}")'
+    GADGET_CHANNEL: '$(HOST: echo "${SPREAD_GADGET_CHANNEL:-beta}")'
     SNAPD_CHANNEL: '$(HOST: echo "${SPREAD_SNAPD_CHANNEL:-edge}")'
     REMOTE_STORE: '$(HOST: echo "${SPREAD_REMOTE_STORE:-production}")'
     SNAPPY_USE_STAGING_STORE: '$(HOST: if [ "$SPREAD_REMOTE_STORE" = staging ]; then echo 1; else echo 0; fi)'

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -1169,6 +1169,7 @@ EOF
     fi
     # shellcheck disable=SC2086
     "$UBUNTU_IMAGE" snap \
+                    --image-size 5G \
                     -w "$IMAGE_HOME" "$IMAGE_HOME/pc.model" \
                     --channel "$IMAGE_CHANNEL" \
                     $EXTRA_FUNDAMENTAL \

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -1031,12 +1031,20 @@ EOF
     if [ "$KERNEL_CHANNEL" = "$GADGET_CHANNEL" ]; then
         IMAGE_CHANNEL="$KERNEL_CHANNEL"
     else
-        # download pc-kernel snap for the specified channel and set
-        # ubuntu-image channel to that of the gadget, so that we don't
-        # need to download it
-        snap download --channel="$KERNEL_CHANNEL" pc-kernel
+        if os.query is-core16 || os.query is-core18; then
+            if os.query is-core16; then
+                BRANCH=latest
+            elif os.query is-core18; then
+                BRANCH=18
+            fi
+            # download pc-kernel snap for the specified channel and set
+            # ubuntu-image channel to that of the gadget, so that we don't
+            # need to download it. Do this only for UC16/18 as the UC20+
+            # case is considered a few lines below.
+            snap download --channel="$BRANCH/$KERNEL_CHANNEL" pc-kernel
+            EXTRA_FUNDAMENTAL="--snap $PWD/pc-kernel_*.snap"
+        fi
 
-        EXTRA_FUNDAMENTAL="--snap $PWD/pc-kernel_*.snap"
         IMAGE_CHANNEL="$GADGET_CHANNEL"
     fi
 


### PR DESCRIPTION
pc-kernel was being downloaded twixe in some cases. Prevent that, also this was provoking failures in arm64 spread tests as no kernel was published for latest track for that arch.