### PR TITLE
client,tests: do not try to change the gid when reading/removing auth.json

### DIFF
--- a/client/login.go
+++ b/client/login.go
@@ -146,7 +146,7 @@ func writeAuthData(user User) error {
 
 // readAuthData reads previously written authentication details
 func readAuthData() (*User, error) {
-	_, uid, gid, err := realUidGid()
+	_, uid, _, err := realUidGid()
 	if err != nil {
 		return nil, err
 	}
@@ -154,7 +154,7 @@ func readAuthData() (*User, error) {
 	var user User
 	sourceFile := storeAuthDataFilename("")
 
-	if err := sys.RunAsUidGid(uid, gid, func() error {
+	if err := sys.RunAsUidGid(uid, sys.FlagID, func() error {
 		f, err := os.Open(sourceFile)
 		if err != nil {
 			return err
@@ -173,14 +173,14 @@ func readAuthData() (*User, error) {
 
 // removeAuthData removes any previously written authentication details.
 func removeAuthData() error {
-	_, uid, gid, err := realUidGid()
+	_, uid, _, err := realUidGid()
 	if err != nil {
 		return err
 	}
 
 	filename := storeAuthDataFilename("")
 
-	return sys.RunAsUidGid(uid, gid, func() error {
+	return sys.RunAsUidGid(uid, sys.FlagID, func() error {
 		return os.Remove(filename)
 	})
 }

--- a/tests/main/nfs-support/task.yaml
+++ b/tests/main/nfs-support/task.yaml
@@ -34,6 +34,8 @@ restore: |
         umount /home
     fi
 
+    rm -f ~test/.snap/auth.json
+
     # Restore the fstab backup file if one exists.
     if [ -e /tmp/fstab.orig ]; then
         mv /tmp/fstab.orig /etc/fstab
@@ -133,8 +135,9 @@ execute: |
 
     # Export /home over NFS.
     mkdir -p /etc/exports.d/
-    echo '/home localhost(rw,no_subtree_check,no_root_squash)' > /etc/exports.d/test.exports
-   
+    # no no_root_squash as we want to test for that scenario
+    echo '/home localhost(rw,no_subtree_check)' > /etc/exports.d/test.exports
+
     # Make sure the nfs service is running
     case "$SPREAD_SYSTEM" in
         ubuntu-14.04-*)
@@ -192,6 +195,15 @@ execute: |
     #shellcheck disable=SC2016
     su -c 'snap run test-snapd-sh.with-home-plug -c "touch \$SNAP_USER_DATA/smoke-nfs3-tcp"' test
 
+    # With this the following snap commands will generate EOF errors but
+    # not perm issues
+    su -c 'cd; install -d -m 0700 .snap; install  -m 0600 /dev/null .snap/auth.json' test
+    # Test auth.json access
+    su -c 'snap list' test 2>&1 |MATCH EOF
+    su -c 'sudo snap list' test 2>&1 |MATCH EOF
+    # XXX this fails
+    #su -c 'sg systemd-journal -c "snap list"' test 2>&1 |MATCH EOF
+
     # Unmount /home and restart snapd so that we can check another thing.
     umount_with_retry /home
     restart_snapd
@@ -217,6 +229,9 @@ execute: |
         # As a non-root user perform a write over NFS-mounted /home
         #shellcheck disable=SC2016
         su -c 'snap run test-snapd-sh.with-home-plug -c "touch \$SNAP_USER_DATA/smoke-nfs3-udp"' test
+        # Test auth.json access
+        su -c 'snap list' test 2>&1 |MATCH EOF
+        su -c 'sudo snap list' test 2>&1 |MATCH EOF
 
         # Unmount /home and restart snapd so that we can check another thing.
         umount_with_retry /home
@@ -239,6 +254,9 @@ execute: |
     # As a non-root user perform a write over NFS-mounted /home
     #shellcheck disable=SC2016
     su -c 'snap run test-snapd-sh.with-home-plug -c "touch \$SNAP_USER_DATA/smoke-nfs4"' test
+    # Test auth.json access
+    su -c 'snap list' test 2>&1 |MATCH EOF
+    su -c 'sudo snap list' test 2>&1 |MATCH EOF
 
     # Unmount /home and restart snapd so that we can check another thing.
     umount_with_retry /home

--- a/tests/main/nfs-support/task.yaml
+++ b/tests/main/nfs-support/task.yaml
@@ -12,7 +12,8 @@ backends: [-autopkgtest]
 # opensuse: the test is failing after retry several times the snapd service reaching the systemd start-limit.
 # fedora, centos: disable until we figure out how to handle NFS and SELinux
 #                 labels, labels can only be exported for NFSv4.2+ with security_label option
-systems: [-ubuntu-core-*, -opensuse-*, -fedora-*, -centos-*]
+# ubuntu-14.04-64: group 'systemd-journal' does not exist
+systems: [-ubuntu-core-*, -opensuse-*, -fedora-*, -centos-*, -ubuntu-14.04-64]
 
 prepare: |
     "$TESTSTOOLS"/snaps-state install-local test-snapd-sh

--- a/tests/main/nfs-support/task.yaml
+++ b/tests/main/nfs-support/task.yaml
@@ -201,8 +201,7 @@ execute: |
     # Test auth.json access
     su -c 'snap list' test 2>&1 |MATCH EOF
     su -c 'sudo snap list' test 2>&1 |MATCH EOF
-    # XXX this fails
-    #su -c 'sg systemd-journal -c "snap list"' test 2>&1 |MATCH EOF
+    su -c 'sg systemd-journal -c "snap list"' test 2>&1 |MATCH EOF
 
     # Unmount /home and restart snapd so that we can check another thing.
     umount_with_retry /home
@@ -232,6 +231,7 @@ execute: |
         # Test auth.json access
         su -c 'snap list' test 2>&1 |MATCH EOF
         su -c 'sudo snap list' test 2>&1 |MATCH EOF
+        su -c 'sg systemd-journal -c "snap list"' test 2>&1 |MATCH EOF
 
         # Unmount /home and restart snapd so that we can check another thing.
         umount_with_retry /home
@@ -257,6 +257,7 @@ execute: |
     # Test auth.json access
     su -c 'snap list' test 2>&1 |MATCH EOF
     su -c 'sudo snap list' test 2>&1 |MATCH EOF
+    su -c 'sg systemd-journal -c "snap list"' test 2>&1 |MATCH EOF
 
     # Unmount /home and restart snapd so that we can check another thing.
     umount_with_retry /home


### PR DESCRIPTION
the group is not relevant for this even under NFS, otoh
trying to switch it fails under running with sg

this makes sg lxd -c "snap..." work again

also test the fixes for access to auth.json under NFS more in general