### PR TITLE
revert i/b/microceph: allow more access for microceph-support (#13150)

### DIFF
--- a/interfaces/builtin/microceph.go
+++ b/interfaces/builtin/microceph.go
@@ -32,21 +32,6 @@ const microcephConnectedPlugAppArmor = `
 # Description: allow access to the MicroCeph control socket.
 
 /var/snap/microceph/common/state/control.socket rw,
-
-# Allow bcache devices to be accessed since DM devices may be set up on top of those.
-/dev/bcache[0-9]{,[0-9],[0-9][0-9]} rwk,                   # bcache (up to 1000 devices)
-# Access to individual partitions
-/dev/hd[a-t][0-9]{,[0-9],[0-9][0-9]} rwk,                  # IDE, MFM, RLL
-/dev/sd{,[a-z]}[a-z][0-9]{,[0-9],[0-9][0-9]} rwk,          # SCSI
-/dev/vd{,[a-z]}[a-z][0-9]{,[0-9],[0-9][0-9]} rwk,          # virtio
-/dev/nvme{[0-9],[1-9][0-9]}n{[1-9],[1-5][0-9],6[0-3]}p[0-9]{,[0-9],[0-9][0-9]} rwk, # NVMe
-# Allow managing of rbd-backed block devices
-/sys/bus/rbd/add rwk,                                      # add block dev
-/sys/bus/rbd/remove rwk,                                   # remove block dev
-/sys/bus/rbd/add_single_major rwk,                         # add single major dev
-/sys/bus/rbd/remove_single_major rwk,                      # remove single major dev
-/sys/bus/rbd/supported_features r,                         # display enabled features
-/sys/bus/rbd/devices/** rwk,                               # manage individual block devs
 `
 
 const microcephConnectedPlugSecComp = `


### PR DESCRIPTION
This reverts commit 29878c72f782f44f9ca4aacd6971c7c70258d128.

the permissions are support permission for the service, not for the client side, so they were wrongly placed

