### PR TITLE
o/snapstate: try to make the check-rerefresh summary cleaner/clearer

### DIFF
--- a/overlord/snapstate/autorefresh_gating_test.go
+++ b/overlord/snapstate/autorefresh_gating_test.go
@@ -2022,7 +2022,7 @@ func (s *snapmgrTestSuite) TestAutoRefreshPhase2(c *C) {
 	defer s.state.Unlock()
 
 	tasks := chg.Tasks()
-	c.Check(tasks[len(tasks)-1].Summary(), Equals, `Monitoring snaps "base-snap-b", "snap-a" for need of extra refresh steps`)
+	c.Check(tasks[len(tasks)-1].Summary(), Equals, `Monitoring snaps "base-snap-b", "snap-a" to determine whether extra refresh steps are required`)
 
 	var snaps map[string]interface{}
 	c.Assert(chg.Tasks()[0].Kind(), Equals, "conditional-auto-refresh")
@@ -2088,7 +2088,7 @@ func (s *snapmgrTestSuite) TestAutoRefreshPhase2Held(c *C) {
 	c.Check(snaps["snap-a"], NotNil)
 
 	// no re-refresh for base-snap-b because it was held.
-	c.Check(tasks[len(tasks)-1].Summary(), Equals, `Monitoring snap "snap-a" for need of extra refresh steps`)
+	c.Check(tasks[len(tasks)-1].Summary(), Equals, `Monitoring snap "snap-a" to determine whether extra refresh steps are required`)
 }
 
 func (s *snapmgrTestSuite) TestAutoRefreshPhase2Proceed(c *C) {
@@ -2518,7 +2518,7 @@ func (s *snapmgrTestSuite) TestAutoRefreshPhase2GatedSnaps(c *C) {
 	tasks := chg.Tasks()
 	verifyPhasedAutorefreshTasks(c, tasks, expected)
 	// no re-refresh for snap-a because it was held.
-	c.Check(tasks[len(tasks)-1].Summary(), Equals, `Monitoring snap "base-snap-b" for need of extra refresh steps`)
+	c.Check(tasks[len(tasks)-1].Summary(), Equals, `Monitoring snap "base-snap-b" to determine whether extra refresh steps are required`)
 
 	// only snap-a remains in refresh-candidates because it was held;
 	// base-snap-b got pruned (was refreshed).

--- a/overlord/snapstate/autorefresh_gating_test.go
+++ b/overlord/snapstate/autorefresh_gating_test.go
@@ -2022,7 +2022,7 @@ func (s *snapmgrTestSuite) TestAutoRefreshPhase2(c *C) {
 	defer s.state.Unlock()
 
 	tasks := chg.Tasks()
-	c.Check(tasks[len(tasks)-1].Summary(), Equals, `Handling re-refresh of "base-snap-b", "snap-a" as needed`)
+	c.Check(tasks[len(tasks)-1].Summary(), Equals, `Monitoring snaps "base-snap-b", "snap-a" for need of extra refresh steps`)
 
 	var snaps map[string]interface{}
 	c.Assert(chg.Tasks()[0].Kind(), Equals, "conditional-auto-refresh")
@@ -2088,7 +2088,7 @@ func (s *snapmgrTestSuite) TestAutoRefreshPhase2Held(c *C) {
 	c.Check(snaps["snap-a"], NotNil)
 
 	// no re-refresh for base-snap-b because it was held.
-	c.Check(tasks[len(tasks)-1].Summary(), Equals, `Handling re-refresh of "snap-a" as needed`)
+	c.Check(tasks[len(tasks)-1].Summary(), Equals, `Monitoring snap "snap-a" for need of extra refresh steps`)
 }
 
 func (s *snapmgrTestSuite) TestAutoRefreshPhase2Proceed(c *C) {
@@ -2518,7 +2518,7 @@ func (s *snapmgrTestSuite) TestAutoRefreshPhase2GatedSnaps(c *C) {
 	tasks := chg.Tasks()
 	verifyPhasedAutorefreshTasks(c, tasks, expected)
 	// no re-refresh for snap-a because it was held.
-	c.Check(tasks[len(tasks)-1].Summary(), Equals, `Handling re-refresh of "base-snap-b" as needed`)
+	c.Check(tasks[len(tasks)-1].Summary(), Equals, `Monitoring snap "base-snap-b" for need of extra refresh steps`)
 
 	// only snap-a remains in refresh-candidates because it was held;
 	// base-snap-b got pruned (was refreshed).

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -128,6 +128,8 @@ var (
 	TaskSetsByTypeForEssentialSnaps = taskSetsByTypeForEssentialSnaps
 	SetDefaultRestartBoundaries     = setDefaultRestartBoundaries
 	DeviceModelBootBase             = deviceModelBootBase
+
+	ReRefreshSummary = reRefreshSummary
 )
 
 const (

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -2113,13 +2113,13 @@ func reRefreshSummary(updated []string, flags *Flags) string {
 	case 0:
 		return ""
 	case 1:
-		msg = fmt.Sprintf(i18n.G("Monitoring snap %q for need of extra refresh steps"), updated[0])
+		msg = fmt.Sprintf(i18n.G("Monitoring snap %q to determine whether extra refresh steps are required"), updated[0])
 	case 2, 3:
 		quoted := strutil.Quoted(updated)
 		// TRANSLATORS: the %s is a comma-separated list of quoted snap names
-		msg = fmt.Sprintf(i18n.G("Monitoring snaps %s for need of extra refresh steps"), quoted)
+		msg = fmt.Sprintf(i18n.G("Monitoring snaps %s to determine whether extra refresh steps are required"), quoted)
 	default:
-		msg = fmt.Sprintf(i18n.G("Monitoring the %d snaps for need of extra refresh steps"), len(updated))
+		msg = fmt.Sprintf(i18n.G("Monitoring %d snaps to determine whether extra refresh steps are required"), len(updated))
 	}
 	return msg
 }

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -2093,7 +2093,7 @@ func finalizeUpdate(st *state.State, tasksets []*state.TaskSet, hasUpdates bool,
 		// _actually_ re-refresh, but it'll be a subset of updated
 		// (and equal to updated if nothing goes wrong)
 		sort.Strings(updated)
-		rerefresh := st.NewTask("check-rerefresh", fmt.Sprintf("Handling re-refresh of %s as needed", strutil.Quoted(updated)))
+		rerefresh := st.NewTask("check-rerefresh", reRefreshSummary(updated, globalFlags))
 		rerefresh.Set("rerefresh-setup", reRefreshSetup{
 			UserID: userID,
 			Flags:  globalFlags,
@@ -2101,6 +2101,27 @@ func finalizeUpdate(st *state.State, tasksets []*state.TaskSet, hasUpdates bool,
 		tasksets = append(tasksets, state.NewTaskSet(rerefresh))
 	}
 	return tasksets
+}
+
+func reRefreshSummary(updated []string, flags *Flags) string {
+	var msg string
+	n := len(updated)
+	if n > 1 && !flags.IsAutoRefresh {
+		n = 2
+	}
+	switch n {
+	case 0:
+		return ""
+	case 1:
+		msg = fmt.Sprintf(i18n.G("Monitoring snap %q for need of extra refresh steps"), updated[0])
+	case 2, 3:
+		quoted := strutil.Quoted(updated)
+		// TRANSLATORS: the %s is a comma-separated list of quoted snap names
+		msg = fmt.Sprintf(i18n.G("Monitoring snaps %s for need of extra refresh steps"), quoted)
+	default:
+		msg = fmt.Sprintf(i18n.G("Monitoring the %d snaps for need of extra refresh steps"), len(updated))
+	}
+	return msg
 }
 
 func applyAutoAliasesDelta(st *state.State, delta map[string][]string, op string, refreshAll bool, fromChange string, linkTs func(instanceName string, ts *state.TaskSet)) (*state.TaskSet, error) {

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -9006,3 +9006,51 @@ func (s *snapmgrTestSuite) TestRefreshCandidatesMergeFlags(c *C) {
 		},
 	})
 }
+
+func (s *snapmgrTestSuite) TestReRefreshSummary(c *C) {
+	type testcase struct {
+		snaps         []string
+		isAutoRefresh bool
+		summary       string
+	}
+
+	cases := []testcase{
+		{},
+		{
+			snaps:         []string{"one"},
+			isAutoRefresh: true,
+			summary:       `Monitoring snap "one" to determine whether extra refresh steps are required`,
+		},
+		{
+			snaps:         []string{"one", "two"},
+			isAutoRefresh: true,
+			summary:       `Monitoring snaps "one", "two" to determine whether extra refresh steps are required`,
+		},
+		{
+			snaps:         []string{"one", "two", "three"},
+			isAutoRefresh: true,
+			summary:       `Monitoring snaps "one", "two", "three" to determine whether extra refresh steps are required`,
+		},
+		{
+			snaps:         []string{"one", "two", "three", "four"},
+			isAutoRefresh: true,
+			summary:       `Monitoring 4 snaps to determine whether extra refresh steps are required`,
+		},
+		{
+			snaps:         []string{"one", "two", "three"},
+			isAutoRefresh: false,
+			summary:       `Monitoring snaps "one", "two", "three" to determine whether extra refresh steps are required`,
+		},
+		{
+			snaps:         []string{"one", "two", "three", "four"},
+			isAutoRefresh: false,
+			summary:       `Monitoring snaps "one", "two", "three", "four" to determine whether extra refresh steps are required`,
+		},
+	}
+
+	for _, tc := range cases {
+		summary := snapstate.ReRefreshSummary(tc.snaps, &snapstate.Flags{IsAutoRefresh: tc.isAutoRefresh})
+		cmt := Commentf("unexpected re-refresh summary for %d snaps (auto-refresh: %t)", len(tc.snaps), tc.isAutoRefresh)
+		c.Check(summary, Equals, tc.summary, cmt)
+	}
+}

--- a/tests/core/kernel-and-base-single-reboot/task.yaml
+++ b/tests/core/kernel-and-base-single-reboot/task.yaml
@@ -98,11 +98,11 @@ execute: |
         snap changes | MATCH "$change_id\s+(Done|Error)"
         # we expect re-refresh to fail since the tests uses a fake store
         snap change "$change_id" > tasks.done
-        MATCH '^Error .* Handling re-refresh' < tasks.done
+        MATCH '^Error .* Monitoring .* to determine whether extra refresh steps are required' < tasks.done
         # no other errors
-        grep -v 'Handling re-refresh' < tasks.done | NOMATCH '^Error'
+        grep -v 'Monitoring .* to determine whether extra refresh steps are required' < tasks.done | NOMATCH '^Error'
         # nothing was undone
-        grep -v 'Handling re-refresh' < tasks.done | NOMATCH '^Undone'
+        grep -v 'Monitoring .* to determine whether extra refresh steps are required' < tasks.done | NOMATCH '^Undone'
         # we did not even try to hijack shutdown (/bin/systemctl) because that
         # could race with snapd (if that wanted to call it), so just check that
         # the system is in a stable state once we have already determined that


### PR DESCRIPTION
@niemeyer remarked that the message was a bit  mysterious and that listing all snaps for auto-refresh got very noisy

we still need to address the mechanics of how the task is run but that needs support from overlord/state and is a bigger change
