### PR TITLE
tests: fix system-snap-refresh in uc20

### DIFF
--- a/tests/core/system-snap-refresh/task.yaml
+++ b/tests/core/system-snap-refresh/task.yaml
@@ -17,18 +17,14 @@ prepare: |
     echo "SNAPD_SHUTDOWN_DELAY=1" >> /etc/environment
     systemctl restart snapd
 
-restore: |
-    TARGET_SNAP_NAME=core
-    if os.query is-core18; then
-        TARGET_SNAP_NAME=core18
-    elif os.query is-core20; then
-        TARGET_SNAP_NAME=core20
-    fi
+    TARGET_SNAP_NAME="$(snaps.name core)"
+    # Save initial revition
+    "$TESTSTOOLS"/snaps-state show-revision "$TARGET_SNAP_NAME" > initi_rev.log
 
-    if not snap remove "$TARGET_SNAP_NAME" --revision=x2; then
-        snap changes
-        exit 1
-    fi
+restore: |
+    TARGET_SNAP_NAME="$(snaps.name core)"
+    # We need to make sure the base snap has the initial rev
+    test "$("$TESTSTOOLS"/snaps-state show-revision "$TARGET_SNAP_NAME")" == "$(cat initi_rev.log)"
     
     # remove SNAPD_SHUTDOWN_DELAY from /etc/environment again
     #shellcheck disable=SC2005
@@ -36,14 +32,7 @@ restore: |
     systemctl restart snapd
 
 execute: |
-    TARGET_SNAP_NAME=core
-    if os.query is-core18; then
-        TARGET_SNAP_NAME=core18
-    elif os.query is-core20; then
-        TARGET_SNAP_NAME=core20
-    elif os.query is-core22; then
-        TARGET_SNAP_NAME=core22
-    fi
+    TARGET_SNAP_NAME="$(snaps.name core)"
 
     # After installing a new version of the core/core18 snap the system is rebooted
     if [ "$SPREAD_REBOOT" = 0 ]; then

--- a/tests/core/system-snap-refresh/task.yaml
+++ b/tests/core/system-snap-refresh/task.yaml
@@ -36,7 +36,7 @@ execute: |
 
     # After installing a new version of the core/core18 snap the system is rebooted
     if [ "$SPREAD_REBOOT" = 0 ]; then
-        currRev="$(readlink /snap/${TARGET_SNAP_NAME}/current)"
+        currRev="$(readlink /snap/"${TARGET_SNAP_NAME}"/current)"
         echo "$currRev" > initialRev
 
         # use journalctl wrapper to grep only the logs collected while the test is running
@@ -46,7 +46,7 @@ execute: |
         fi
 
         # install new target snap
-        snap install --dangerous --no-wait "/var/lib/snapd/snaps/${TARGET_SNAP_NAME}_${currRev}.snap"
+        snap install --dangerous --no-wait /var/lib/snapd/snaps/"${TARGET_SNAP_NAME}"_"${currRev}".snap
 
         # Detect in the logs when the reboot can been triggered
         "$TESTSTOOLS"/journal-state match-log -n 50 --wait 2 "Waiting for system reboot"
@@ -57,7 +57,7 @@ execute: |
         snap watch --last=install
 
         # Check the current revision has changed
-        currRev="$(readlink /snap/${TARGET_SNAP_NAME}/current)"
+        currRev="$(readlink /snap/"${TARGET_SNAP_NAME}"/current)"
         [ "$(cat initialRev)" !=  "$currRev" ]
 
         # revert the target snap
@@ -71,6 +71,6 @@ execute: |
         # Wait for the revert to complete.
         snap watch --last=revert-snap
         # Check the current revision is the same than the original
-        currRev="$(readlink /snap/${TARGET_SNAP_NAME}/current)"
+        currRev="$(readlink /snap/"${TARGET_SNAP_NAME}"/current)"
         [ "$(cat initialRev)" ==  "$currRev" ]
     fi

--- a/tests/core/system-snap-refresh/task.yaml
+++ b/tests/core/system-snap-refresh/task.yaml
@@ -18,7 +18,7 @@ prepare: |
     systemctl restart snapd
 
     TARGET_SNAP_NAME="$(snaps.name core)"
-    # Save initial revition
+    # Save initial revision
     "$TESTSTOOLS"/snaps-state show-revision "$TARGET_SNAP_NAME" > initi_rev.log
 
 restore: |

--- a/tests/lib/tools/snaps-state
+++ b/tests/lib/tools/snaps-state
@@ -5,6 +5,7 @@ show_help() {
     echo "       install-local <snap-name> [OPTIONS]"
     echo "       install-local-as <snap-name> <dest-name> [OPTIONS]"
     echo "       show-name <snap>"
+    echo "       show-revision <snap>"
     echo "       is-confinement-supported <classic|devmode|strict>"
     echo "       repack-snapd-deb-into-snap <snapd|core>"
     echo "       repack-core-snap-into-snapd-snap"
@@ -97,6 +98,15 @@ show_name() {
             exit 1
             ;;
     esac
+}
+
+show_revision() {
+    local snap="$1"
+    if not snap list "$snap"; then
+        echo "snaps-state: the snap $snap is not installed" >&2
+        exit 1
+    fi
+    snap info "$snap" | awk "/installed: / {print(\$3)}" | sed -e 's/(\(.*\))/\1/'
 }
 
 is_confinement_supported() {

--- a/tests/lib/tools/snaps-state
+++ b/tests/lib/tools/snaps-state
@@ -102,7 +102,7 @@ show_name() {
 
 show_revision() {
     local snap="$1"
-    if not snap list "$snap"; then
+    if not snap list "$snap" &>/dev/null; then
         echo "snaps-state: the snap $snap is not installed" >&2
         exit 1
     fi

--- a/tests/main/snaps-state/task.yaml
+++ b/tests/main/snaps-state/task.yaml
@@ -84,7 +84,7 @@ execute: |
 
     # Check the core revision
     core_rev=$("$TESTSTOOLS"/snaps-state show-revision "$core_name")
-    snap list "$core_name" | match "\($core_rev\)"
+    snap list "$core_name" | MATCH "\($core_rev\)"
     # Check the snap revision when it is not installed
     "$TESTSTOOLS"/snaps-state show-revision not_installed 2>&1 | MATCH "snaps-state: the snap not_installed is not installed"
 

--- a/tests/main/snaps-state/task.yaml
+++ b/tests/main/snaps-state/task.yaml
@@ -84,7 +84,7 @@ execute: |
 
     # Check the core revision
     core_rev=$("$TESTSTOOLS"/snaps-state show-revision "$core_name")
-    snap list "$core_name" | MATCH "\($core_rev\)"
+    snap info "$core_name" | grep "installed:" | MATCH "\($core_rev\)"
     # Check the snap revision when it is not installed
     "$TESTSTOOLS"/snaps-state show-revision not_installed 2>&1 | MATCH "snaps-state: the snap not_installed is not installed"
 

--- a/tests/main/snaps-state/task.yaml
+++ b/tests/main/snaps-state/task.yaml
@@ -82,6 +82,12 @@ execute: |
     kernel_name=$("$TESTSTOOLS"/snaps-state show-name kernel)
     gadget_name=$("$TESTSTOOLS"/snaps-state show-name gadget)
 
+    # Check the core revision
+    core_rev=$("$TESTSTOOLS"/snaps-state show-revision "$core_name")
+    snap list "$core_name" | match "\($core_rev\)"
+    # Check the snap revision when it is not installed
+    "$TESTSTOOLS"/snaps-state show-revision not_installed 2>&1 | MATCH "snaps-state: the snap not_installed is not installed"
+
     # Check the core, kernel and gadget snaps
     snap list "$core_name"
     if os.query is-core; then


### PR DESCRIPTION
Simplify the system-snap-refresh test and validate the base snap during restore is the same revision than the initial one (no need to remove).

Also it is included a new function to determine the revision of a snap and the test is updated accordingly.
