### PR TITLE
aspects: support array type in aspect schemas

### DIFF
--- a/aspects/schema.go
+++ b/aspects/schema.go
@@ -143,7 +143,7 @@ func (s *StorageSchema) parse(raw json.RawMessage) (parser, error) {
 			return nil, err
 		}
 	} else if schema.mustConstrain() {
-		return nil, fmt.Errorf(`cannot parse %q: must be map definition with constraints`, typ)
+		return nil, fmt.Errorf(`cannot parse %q: must be schema definition with constraints`, typ)
 	}
 
 	return schema, nil
@@ -728,7 +728,7 @@ func (v *arraySchema) Validate(raw []byte) error {
 		for _, val := range *array {
 			encodedVal := string(val)
 			if _, ok := valSet[encodedVal]; ok {
-				return fmt.Errorf(`cannot accept array with duplicate values`)
+				return fmt.Errorf(`cannot accept duplicate values for array with "unique" constraint`)
 			}
 			valSet[encodedVal] = struct{}{}
 		}
@@ -753,7 +753,7 @@ func (v *arraySchema) parseConstraints(constraints map[string]json.RawMessage) e
 	if rawUnique, ok := constraints["unique"]; ok {
 		var unique bool
 		if err := json.Unmarshal(rawUnique, &unique); err != nil {
-			return fmt.Errorf(`cannot parse "array": %v`, err)
+			return fmt.Errorf(`cannot parse array's "unique" constraint: %v`, err)
 		}
 
 		v.unique = unique

--- a/aspects/schema_test.go
+++ b/aspects/schema_test.go
@@ -1495,7 +1495,7 @@ func (*schemaSuite) TestArrayRequireConstraints(c *C) {
 }`)
 
 	_, err := aspects.ParseSchema(schemaStr)
-	c.Assert(err, ErrorMatches, `cannot parse "array": must be map definition with constraints`)
+	c.Assert(err, ErrorMatches, `cannot parse "array": must be schema definition with constraints`)
 }
 
 func (*schemaSuite) TestArrayRequireValueConstraint(c *C) {
@@ -1565,7 +1565,7 @@ func (*schemaSuite) TestArrayWithUniqueRejectsDuplicates(c *C) {
 }`)
 
 	err = schema.Validate(input)
-	c.Assert(err, ErrorMatches, `cannot accept array with duplicate values`)
+	c.Assert(err, ErrorMatches, `cannot accept duplicate values for array with "unique" constraint`)
 }
 
 func (*schemaSuite) TestArrayWithoutUniqueAcceptsDuplicates(c *C) {
@@ -1602,5 +1602,5 @@ func (*schemaSuite) TestArrayFailsWithBadUniqueType(c *C) {
 }`)
 
 	_, err := aspects.ParseSchema(schemaStr)
-	c.Assert(err, ErrorMatches, `cannot parse "array": json: cannot unmarshal string into Go value of type bool`)
+	c.Assert(err, ErrorMatches, `cannot parse array's "unique" constraint: json: cannot unmarshal string into Go value of type bool`)
 }

--- a/aspects/schema_test.go
+++ b/aspects/schema_test.go
@@ -1568,7 +1568,7 @@ func (*schemaSuite) TestArrayWithUniqueRejectsDuplicates(c *C) {
 	c.Assert(err, ErrorMatches, `cannot accept array with duplicate values`)
 }
 
-func (*schemaSuite) TestArrayWithoutUniqueAccepstDuplicates(c *C) {
+func (*schemaSuite) TestArrayWithoutUniqueAcceptsDuplicates(c *C) {
 	schemaStr := []byte(`{
 	"schema": {
 		"foo": {


### PR DESCRIPTION
Adds support for arrays in aspect schemas. Since this is the only type that must have a map definition with a "values" constraint, I added a new method to the parser interface to distinguish between types that have to have constraints.