### PR TITLE
tests: fix selinux policy to support change in polkit_agent interface

### DIFF
--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -402,6 +402,13 @@ allow snappy_t var_t:sock_file unlink;
 allow snappy_t unconfined_t:dir search;
 allow snappy_t unconfined_t:file { open read };
 
+# Allow snapd to get file attributes in policykit_auth_exec_t domain
+gen_require(`
+    type policykit_auth_exec_t;
+')
+allow snappy_t policykit_auth_exec_t:file { getattr };
+allow snappy_cli_t policykit_auth_exec_t:file { getattr };
+
 # the release package calls stat() on /proc/sys/fs/binfmt_misc/WSLInterop to
 # detect WSL
 gen_require(`


### PR DESCRIPTION
The selinux-clean test started failing in fedora and centos recently.

It is caused by a change in the polkit_agent interface where now the polkit-agent-helper-1 is located here
/usr/lib{exec,/polkit-1}/polkit-agent-helper-1

The change has been introduced in:
https://github.com/snapcore/snapd/pull/13261

The denial produced is the following:
type=AVC msg=audit(1698154354.527:12577): avc:  denied  { getattr } for pid=82525 comm="snapd" path="/usr/lib/polkit-1/polkit-agent-helper-1" dev="sda5" ino=109823 scontext=system_u:system_r:snappy_t:s0 tcontext=system_u:object_r:policykit_auth_exec_t:s0 tclass=file permissive=1
