### PR TITLE
systemd: make sure confined mount units are mounted after snapd-apparmor

### DIFF
--- a/cmd/snap-mgmt/snap-mgmt.sh.in
+++ b/cmd/snap-mgmt/snap-mgmt.sh.in
@@ -129,6 +129,7 @@ purge() {
         rm -f "/etc/systemd/system/$unit"
         rm -f "/etc/systemd/system/multi-user.target.wants/$unit"
         rm -f "/etc/systemd/system/snapd.mounts.target.wants/${unit}"
+        rm -f "/etc/systemd/system/snapd.mounts.snapd.target.wants/${unit}"
     done
     # Remove empty ".wants/" directory created by enabling mount units
     rmdir "/etc/systemd/system/snapd.mounts.target.wants" || true
@@ -148,7 +149,7 @@ purge() {
     done
 
     # stop snapd services
-    for serv in snapd.autoimport.service snapd.seeded.service snapd.apparmor.service snapd.mounts.target snapd.mounts-pre.target; do
+    for serv in snapd.autoimport.service snapd.seeded.service snapd.apparmor.service snapd.mounts.target snapd.mounts-pre.target snapd.mounts-pre.confined.target snapd.mounts.snapd.target; do
         systemctl_stop "$serv"
     done
 

--- a/data/systemd/snapd.apparmor.service.in
+++ b/data/systemd/snapd.apparmor.service.in
@@ -12,6 +12,10 @@ Before=sysinit.target
 After=apparmor.service
 ConditionSecurity=apparmor
 RequiresMountsFor=/var/cache/apparmor /var/lib/snapd/apparmor/profiles
+Wants=snapd.mounts.snapd.target
+After=snapd.mounts.snapd.target
+Wants=snapd.mounts-pre.confined.target
+Before=snapd.mounts-pre.confined.target
 
 [Service]
 Type=oneshot

--- a/data/systemd/snapd.mounts-pre.confined.target
+++ b/data/systemd/snapd.mounts-pre.confined.target
@@ -1,0 +1,5 @@
+[Unit]
+Description=Mounting snaps
+RefuseManualStart=yes
+# Started from snapd-appamor.service
+# X-Snapd-Snap: do-not-start

--- a/data/systemd/snapd.mounts.snapd.target
+++ b/data/systemd/snapd.mounts.snapd.target
@@ -1,0 +1,5 @@
+[Unit]
+Description=Mounted snapd snaps
+Wants=snapd.mounts-pre.target
+# Started from snapd-apparmor.service
+# X-Snapd-Snap: do-not-start

--- a/data/systemd/snapd.mounts.target
+++ b/data/systemd/snapd.mounts.target
@@ -1,6 +1,5 @@
 [Unit]
 Description=Mounted snaps
-Before=local-fs.target
 Wants=snapd.mounts-pre.target
 # Started from snapd.service
 # X-Snapd-Snap: do-not-start

--- a/image/preseed/preseed_classic_test.go
+++ b/image/preseed/preseed_classic_test.go
@@ -360,6 +360,7 @@ func (s *preseedSuite) TestReset(c *C) {
 			// add the mount in multi-user.target
 			{filepath.Join(dirs.SnapServicesDir, "multi-user.target.wants", "snap-foo.mount"), ""},
 			{filepath.Join(dirs.SnapServicesDir, "snapd.mounts.target.wants", "snap-foo.mount"), ""},
+			{filepath.Join(dirs.SnapServicesDir, "snapd.mounts.snapd.target.wants", "snap-snapd-foo.mount"), ""},
 			{filepath.Join(dirs.SnapDataDir, "foo", "bar"), ""},
 			{filepath.Join(dirs.SnapCacheDir, "foocache", "bar"), ""},
 			{filepath.Join(apparmor_sandbox.CacheDir, "foo", "bar"), ""},

--- a/image/preseed/reset.go
+++ b/image/preseed/reset.go
@@ -109,6 +109,7 @@ var ResetPreseededChroot = func(preseedChroot string) error {
 		filepath.Join(dirs.SnapServicesDir, "multi-user.target.wants", "snap-*.mount"),
 		filepath.Join(dirs.SnapServicesDir, "default.target.wants", "snap-*.mount"),
 		filepath.Join(dirs.SnapServicesDir, "snapd.mounts.target.wants", "snap-*.mount"),
+		filepath.Join(dirs.SnapServicesDir, "snapd.mounts.snapd.target.wants", "snap-snapd-*.mount"),
 		filepath.Join(dirs.SnapUserServicesDir, "snap.*.service"),
 		filepath.Join(dirs.SnapUserServicesDir, "snap.*.socket"),
 		filepath.Join(dirs.SnapUserServicesDir, "snap.*.timer"),

--- a/overlord/hookstate/ctlcmd/mount.go
+++ b/overlord/hookstate/ctlcmd/mount.go
@@ -195,6 +195,8 @@ func (m *mountCommand) ensureMount(sysd systemd.Systemd) (string, error) {
 		Fstype:      m.Type,
 		Options:     m.optionsList,
 		Origin:      "mount-control",
+		Confined:    true, // this should be only useful for confined snaps
+		IsSnapd:     false,
 	})
 	if err != nil {
 		_ = sysd.RemoveMountUnitFile(m.Positional.Where)

--- a/overlord/hookstate/ctlcmd/mount_test.go
+++ b/overlord/hookstate/ctlcmd/mount_test.go
@@ -287,6 +287,8 @@ func (s *mountSuite) TestUnitCreationFailure(c *C) {
 			Where:       "/dest",
 			Fstype:      "ext4",
 			Origin:      "mount-control",
+			Confined:    true,
+			IsSnapd:     false,
 		},
 	})
 }
@@ -307,6 +309,8 @@ func (s *mountSuite) TestHappy(c *C) {
 			Fstype:      "ext4",
 			Options:     []string{"sync", "rw"},
 			Origin:      "mount-control",
+			Confined:    true,
+			IsSnapd:     false,
 		},
 	})
 }
@@ -329,6 +333,8 @@ func (s *mountSuite) TestHappyWithVariableExpansion(c *C) {
 			Where:       where,
 			Options:     []string{"bind", "ro"},
 			Origin:      "mount-control",
+			Confined:    true,
+			IsSnapd:     false,
 		},
 	})
 }
@@ -349,6 +355,8 @@ func (s *mountSuite) TestHappyWithCommasInPath(c *C) {
 			Where:       "/dest,with,commas",
 			Options:     []string{"ro"},
 			Origin:      "mount-control",
+			Confined:    true,
+			IsSnapd:     false,
 		},
 	})
 }
@@ -369,6 +377,8 @@ func (s *mountSuite) TestEnsureMountUnitFailed(c *C) {
 			Fstype:      "ext4",
 			Options:     []string{"sync", "rw"},
 			Origin:      "mount-control",
+			Confined:    true,
+			IsSnapd:     false,
 		},
 	})
 
@@ -392,6 +402,8 @@ func (s *mountSuite) TestEnsureMountUnitFailedRemoveFailed(c *C) {
 			Fstype:      "ext4",
 			Options:     []string{"sync", "rw"},
 			Origin:      "mount-control",
+			Confined:    true,
+			IsSnapd:     false,
 		},
 	})
 

--- a/overlord/snapstate/backend/mountunit.go
+++ b/overlord/snapstate/backend/mountunit.go
@@ -36,7 +36,7 @@ func addMountUnit(c snap.ContainerPlaceInfo, preseed bool, meter progress.Meter)
 	} else {
 		sysd = systemd.New(systemd.SystemMode, meter)
 	}
-	_, err := sysd.EnsureMountUnitFile(c.MountDescription(), squashfsPath, whereDir, "squashfs")
+	_, err := sysd.EnsureMountUnitFile(c.MountDescription(), squashfsPath, whereDir, "squashfs", c.Confined(), c.IsSnapd())
 	return err
 }
 

--- a/overlord/snapstate/backend/mountunit_test.go
+++ b/overlord/snapstate/backend/mountunit_test.go
@@ -35,6 +35,7 @@ import (
 
 type ParamsForEnsureMountUnitFile struct {
 	description, what, where, fstype string
+	confined, isSnapd                bool
 }
 
 type ResultForEnsureMountUnitFile struct {
@@ -55,9 +56,9 @@ type FakeSystemd struct {
 	ListMountUnitsResult ResultForListMountUnits
 }
 
-func (s *FakeSystemd) EnsureMountUnitFile(description, what, where, fstype string) (string, error) {
+func (s *FakeSystemd) EnsureMountUnitFile(description, what, where, fstype string, confined, isSnapd bool) (string, error) {
 	s.EnsureMountUnitFileCalls = append(s.EnsureMountUnitFileCalls,
-		ParamsForEnsureMountUnitFile{description, what, where, fstype})
+		ParamsForEnsureMountUnitFile{description, what, where, fstype, confined, isSnapd})
 	return s.EnsureMountUnitFileResult.path, s.EnsureMountUnitFileResult.err
 }
 
@@ -123,6 +124,8 @@ func (s *mountunitSuite) TestAddMountUnit(c *C) {
 		what:        "/var/lib/snapd/snaps/foo_13.snap",
 		where:       fmt.Sprintf("%s/foo/13", dirs.StripRootDir(dirs.SnapMountDir)),
 		fstype:      "squashfs",
+		confined:    true,
+		isSnapd:     false,
 	}
 	c.Check(sysd.EnsureMountUnitFileCalls, DeepEquals, []ParamsForEnsureMountUnitFile{
 		expectedParameters,

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -1229,7 +1229,7 @@ func (m *SnapManager) ensureMountsUpdated() error {
 			}
 			squashfsPath := dirs.StripRootDir(info.MountFile())
 			whereDir := dirs.StripRootDir(info.MountDir())
-			if _, err = sysd.EnsureMountUnitFile(info.MountDescription(), squashfsPath, whereDir, "squashfs"); err != nil {
+			if _, err = sysd.EnsureMountUnitFile(info.MountDescription(), squashfsPath, whereDir, "squashfs", info.Confined(), info.IsSnapd()); err != nil {
 				return err
 			}
 		}

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -8762,7 +8762,10 @@ func (s *snapmgrTestSuite) TestResolveValidationSetsEnforcementErrorWithInvalidS
 }
 
 func (s *snapmgrTestSuite) TestEnsureSnapStateRewriteMounts(c *C) {
-	restore := snapstate.MockEnsuredMountsUpdated(s.snapmgr, false)
+	restore := squashfs.MockNeedsFuse(false)
+	defer restore()
+
+	restore = snapstate.MockEnsuredMountsUpdated(s.snapmgr, false)
 	defer restore()
 
 	testSnapSideInfo := &snap.SideInfo{RealName: "test-snap", Revision: snap.R(42)}
@@ -8791,8 +8794,12 @@ apps:
 [Unit]
 Description=Mount unit for test-snap, revision 42
 After=snapd.mounts-pre.target
+After=snapd.mounts-pre.confined.target
+DefaultDependencies=no
+Before=umount.target
+Conflicts=umount.target
+After=local-fs-pre.target
 Before=snapd.mounts.target
-Before=local-fs.target
 
 [Mount]
 What=%s
@@ -8820,8 +8827,12 @@ WantedBy=multi-user.target
 [Unit]
 Description=Mount unit for test-snap, revision 42
 After=snapd.mounts-pre.target
+After=snapd.mounts-pre.confined.target
+DefaultDependencies=no
+Before=umount.target
+Conflicts=umount.target
+After=local-fs-pre.target
 Before=snapd.mounts.target
-Before=local-fs.target
 
 [Mount]
 What=%s
@@ -8839,7 +8850,10 @@ WantedBy=multi-user.target
 }
 
 func (s *snapmgrTestSuite) TestEnsureSnapStateRewriteMountsNoChange(c *C) {
-	restore := snapstate.MockEnsuredMountsUpdated(s.snapmgr, false)
+	restore := squashfs.MockNeedsFuse(false)
+	defer restore()
+
+	restore = snapstate.MockEnsuredMountsUpdated(s.snapmgr, false)
 	defer restore()
 
 	testSnapSideInfo := &snap.SideInfo{RealName: "test-snap", Revision: snap.R(42)}
@@ -8868,8 +8882,12 @@ apps:
 [Unit]
 Description=Mount unit for test-snap, revision 42
 After=snapd.mounts-pre.target
+After=snapd.mounts-pre.confined.target
+DefaultDependencies=no
+Before=umount.target
+Conflicts=umount.target
+After=local-fs-pre.target
 Before=snapd.mounts.target
-Before=local-fs.target
 
 [Mount]
 What=%s
@@ -8897,6 +8915,9 @@ WantedBy=multi-user.target
 }
 
 func (s *snapmgrTestSuite) TestEnsureSnapStateRewriteMountsCreated(c *C) {
+	restore := squashfs.MockNeedsFuse(false)
+	defer restore()
+
 	testSnapSideInfo := &snap.SideInfo{RealName: "test-snap", Revision: snap.R(42)}
 	testSnapState := &snapstate.SnapState{
 		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{testSnapSideInfo}),
@@ -8923,7 +8944,7 @@ apps:
 		c.Assert(os.Remove(mountFile), IsNil)
 	}
 
-	restore := snapstate.MockEnsuredMountsUpdated(s.snapmgr, false)
+	restore = snapstate.MockEnsuredMountsUpdated(s.snapmgr, false)
 	defer restore()
 
 	s.reloadOrRestarts[unitName] = 0
@@ -8937,8 +8958,12 @@ apps:
 [Unit]
 Description=Mount unit for test-snap, revision 42
 After=snapd.mounts-pre.target
+After=snapd.mounts-pre.confined.target
+DefaultDependencies=no
+Before=umount.target
+Conflicts=umount.target
+After=local-fs-pre.target
 Before=snapd.mounts.target
-Before=local-fs.target
 
 [Mount]
 What=%s

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -65,7 +65,7 @@
 %global provider_prefix %{provider}.%{provider_tld}/%{project}/%{repo}
 %global import_path     %{provider_prefix}
 
-%global snappy_svcs      snapd.service snapd.socket snapd.autoimport.service snapd.seeded.service snapd.mounts.target snapd.mounts-pre.target
+%global snappy_svcs      snapd.service snapd.socket snapd.autoimport.service snapd.seeded.service snapd.mounts.target snapd.mounts-pre.target snapd.mounts-pre.confined.target snapd.mounts.snapd.target
 %global snappy_user_svcs snapd.session-agent.service snapd.session-agent.socket
 
 # Until we have a way to add more extldflags to gobuild macro...
@@ -838,6 +838,8 @@ popd
 %{_unitdir}/snapd.seeded.service
 %{_unitdir}/snapd.mounts.target
 %{_unitdir}/snapd.mounts-pre.target
+%{_unitdir}/snapd.mounts-pre.confined.target
+%{_unitdir}/snapd.mounts.snapd.target
 %{_userunitdir}/snapd.session-agent.service
 %{_userunitdir}/snapd.session-agent.socket
 %{_tmpfilesdir}/snapd.conf

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -29,7 +29,7 @@
 
 # The list of systemd services we are expected to ship. Note that this does
 # not include services that are only required on core systems.
-%global systemd_services_list snapd.socket snapd.service snapd.seeded.service snapd.failure.service %{?with_apparmor:snapd.apparmor.service} snapd.mounts.target snapd.mounts-pre.target
+%global systemd_services_list snapd.socket snapd.service snapd.seeded.service snapd.failure.service %{?with_apparmor:snapd.apparmor.service} snapd.mounts.target snapd.mounts-pre.target snapd.mounts-pre.confined.target snapd.mounts.snapd.target
 %global systemd_user_services_list snapd.session-agent.socket
 
 # Alternate snap mount directory: not used by openSUSE.
@@ -487,6 +487,8 @@ fi
 %{_unitdir}/snapd.socket
 %{_unitdir}/snapd.mounts.target
 %{_unitdir}/snapd.mounts-pre.target
+%{_unitdir}/snapd.mounts-pre.confined.target
+%{_unitdir}/snapd.mounts.snapd.target
 %{_userunitdir}/snapd.session-agent.service
 %{_userunitdir}/snapd.session-agent.socket
 

--- a/packaging/ubuntu-14.04/snapd.postrm
+++ b/packaging/ubuntu-14.04/snapd.postrm
@@ -97,9 +97,11 @@ if [ "$1" = "purge" ]; then
         rm -f "/etc/systemd/system/$unit"
         rm -f "/etc/systemd/system/multi-user.target.wants/$unit"
         rm -f "/etc/systemd/system/snapd.mounts.target.wants/$unit"
+        rm -f "/etc/systemd/system/snapd.mounts.snapd.target.wants/$unit"
     done
     # Remove empty ".wants/" directory created by enabling mount units
     rmdir "/etc/systemd/system/snapd.mounts.target.wants" || true
+    rmdir "/etc/systemd/system/snapd.mounts.snapd.target.wants" || true
     # Units may have been removed do a reload
     systemctl -q daemon-reload || true
 

--- a/packaging/ubuntu-16.04/snapd.postrm
+++ b/packaging/ubuntu-16.04/snapd.postrm
@@ -103,9 +103,11 @@ if [ "$1" = "purge" ]; then
         rm -f "/etc/systemd/system/$unit"
         rm -f "/etc/systemd/system/multi-user.target.wants/$unit"
         rm -f "/etc/systemd/system/snapd.mounts.target.wants/$unit"
+        rm -f "/etc/systemd/system/snapd.mounts.snapd.target.wants/$unit"
     done
     # Remove empty ".wants/" directory created by enabling mount units
     rmdir "/etc/systemd/system/snapd.mounts.target.wants" || true
+    rmdir "/etc/systemd/system/snapd.mounts.snapd.target.wants" || true
     # Units may have been removed do a reload
     systemctl -q daemon-reload || true
 

--- a/snap/component.go
+++ b/snap/component.go
@@ -123,6 +123,15 @@ func (c *componentPlaceInfo) MountDescription() string {
 	return fmt.Sprintf("Mount unit for %s, revision %s", c.ContainerName(), c.compRevision)
 }
 
+func (c *componentPlaceInfo) Confined() bool {
+	// does not matter
+	return false
+}
+
+func (c *componentPlaceInfo) IsSnapd() bool {
+	return false
+}
+
 // ReadComponentInfoFromContainer reads ComponentInfo from a snap component container.
 func ReadComponentInfoFromContainer(compf Container) (*ComponentInfo, error) {
 	yamlData, err := compf.ReadFile("meta/component.yaml")

--- a/snap/info.go
+++ b/snap/info.go
@@ -62,6 +62,14 @@ type ContainerPlaceInfo interface {
 
 	// MountDescription is the value for the mount unit Description field.
 	MountDescription() string
+
+	// Confined tells if the snap is expected to be run confined
+	// only and expects apparmor to be initialized before being
+	// mounted.
+	Confined() bool
+
+	// IsSnapd tells if the snap is snapd itself
+	IsSnapd() bool
 }
 
 // PlaceInfo offers all the information about where a snap and its data are
@@ -656,6 +664,14 @@ func (s *Info) MountFile() string {
 // MountDescription returns the mount unit Description field.
 func (s *Info) MountDescription() string {
 	return fmt.Sprintf("Mount unit for %s, revision %s", s.InstanceName(), s.Revision)
+}
+
+func (s *Info) Confined() bool {
+	return s.Confinement != ClassicConfinement
+}
+
+func (s *Info) IsSnapd() bool {
+	return s.Type() == TypeSnapd
 }
 
 // HooksDir returns the directory containing the snap's hooks.

--- a/systemd/emulation.go
+++ b/systemd/emulation.go
@@ -124,7 +124,7 @@ func (s *emulation) LogReader(services []string, n int, follow, namespaces bool)
 	return nil, fmt.Errorf("LogReader")
 }
 
-func (s *emulation) EnsureMountUnitFile(description, what, where, fstype string) (string, error) {
+func (s *emulation) EnsureMountUnitFile(description, what, where, fstype string, confined, isSnapd bool) (string, error) {
 	if osutil.IsDirectory(what) {
 		return "", fmt.Errorf("bind-mounted directory is not supported in emulation mode")
 	}
@@ -141,6 +141,8 @@ func (s *emulation) EnsureMountUnitFile(description, what, where, fstype string)
 		Where:       where,
 		Fstype:      fstype,
 		Options:     mountUnitOptions,
+		Confined:    confined,
+		IsSnapd:     isSnapd,
 	})
 	if err != nil {
 		return "", err

--- a/tests/core/config-defaults-once/task.yaml
+++ b/tests/core/config-defaults-once/task.yaml
@@ -1,6 +1,10 @@
 summary: |
     Test that configuration defaults are only applied once.
 
+details: |
+    This test verifies that installing snapd or core base does not
+    reset configuration to defaults.
+
 # it is not yet possible to install snapd on UC16
 # TODO:UC20: enable for UC20, currently fails because there is no seed.yaml in
 #            the same place as UC18
@@ -79,6 +83,7 @@ restore: |
        rm -f "/etc/systemd/system/$sysp"
        rm -f "/etc/systemd/system/multi-user.target.wants/$sysp"
        rm -f "/etc/systemd/system/snapd.mounts.target.wants/$sysp"
+       rm -f "/etc/systemd/system/snapd.mounts.snapd.target.wants/$sysp"
        rm -f "/var/lib/snapd/snaps/${SNAP}"_*.snap
        rm -rf "/snap/$SNAP"
        systemctl daemon-reload

--- a/tests/core/core-to-snapd-failover16/task.yaml
+++ b/tests/core/core-to-snapd-failover16/task.yaml
@@ -1,5 +1,10 @@
 summary: Test the failover scenario of the snapd snap installation on a UC16 system
 
+details: |
+    This test verifies that installing a broken snapd snap on top of
+    core on UC16 multiple times reverts potential changes done during
+    installation.
+
 # snapd snap is already installed by default on uc18+
 systems: [ubuntu-core-16-*]
 
@@ -56,6 +61,8 @@ execute: |
     test ! -e /etc/systemd/system/usr-lib-snapd.mount
     test ! -e /etc/systemd/system/snapd.mounts.target
     test ! -e /etc/systemd/system/snapd.mounts-pre.target
+    test ! -e /etc/systemd/system/snapd.mounts.snapd.target
+    test ! -e /etc/systemd/system/snapd.mounts-pre.confined.target
     test ! -e /etc/systemd/system/snap-snapd-x1.mount
     test ! -e /snap/snapd/x1
   done

--- a/tests/core/snapd-failover/task.yaml
+++ b/tests/core/snapd-failover/task.yaml
@@ -1,5 +1,9 @@
 summary: Check that snapd failure handling works
 
+details: |
+    This test verifies that installing a broken snapd snap multiple
+    times reverts potential changes done during installation.
+
 prepare: |
     # on UC16, we should transition to using the snapd snap before running the 
     # test because it by default uses the core snap
@@ -137,6 +141,7 @@ execute: |
             rm -f /etc/systemd/system/snapd.*.{service,timer,socket}
             rm -f /etc/systemd/system/*.wants/snapd.*.{service,timer,socket}
             rm -f /etc/systemd/system/snapd.mounts.target.wants/snap-snapd-*.mount
+            rm -f /etc/systemd/system/snapd.mounts.snapd.target.wants/snap-snapd-*.mount
             rm -f /etc/systemd/system/multi-user.target.wants/snap-snapd-*.mount
             systemctl daemon-reload
             # this will have the "snapd" snap /usr/lib/snapd bind mounted

--- a/tests/core/snapd16/task.yaml
+++ b/tests/core/snapd16/task.yaml
@@ -1,5 +1,8 @@
 summary: Test snapd install on a UC16 system
 
+details: |
+    This test veries that snapd snap can install properly on UC16.
+
 # snapd snap is already installed by default on uc18+
 systems: [ubuntu-core-16-*]
 
@@ -61,6 +64,7 @@ execute: |
         rm -f /etc/systemd/system/snapd.*.{service,timer,socket}
         rm -f /etc/systemd/system/*.wants/snapd.*.{service,timer,socket}
         rm -f /etc/systemd/system/snapd.mounts.target.wants/snap-snapd-*.mount
+        rm -f /etc/systemd/system/snapd.mounts.snapd.target.wants/snap-snapd-*.mount
         rm -f /etc/systemd/system/multi-user.target.wants/snap-snapd-*.mount
         systemctl daemon-reload
         # this will have the "snapd" snap /usr/lib/snapd bind mounted

--- a/tests/main/postrm-purge/task.yaml
+++ b/tests/main/postrm-purge/task.yaml
@@ -115,6 +115,8 @@ execute: |
     # shellcheck disable=SC2251
     ! test -d /etc/systemd/system/snapd.mounts.target.wants
     # shellcheck disable=SC2251
+    ! test -d /etc/systemd/system/snapd.mounts.snapd.target.wants
+    # shellcheck disable=SC2251
     ! test -d /etc/systemd/system/multi-user.target.wants
     test -z "$(find /etc/systemd/system/sockets.target.wants/ -name 'snap.*')"
     test -z "$(find /etc/systemd/system/timers.target.wants/ -name 'snap.*')"

--- a/tests/main/preseed-core20/task.yaml
+++ b/tests/main/preseed-core20/task.yaml
@@ -133,6 +133,7 @@ execute: |
   MATCH "^etc/systemd/system/snapd.mounts.target.wants/snap-core20-.*.mount" < files.log
   MATCH "^etc/systemd/system/multi-user.target.wants/snap-core20-.*.mount" < files.log
   MATCH "^etc/systemd/system/snapd.mounts.target.wants/snap-snapd-.*.mount" < files.log
+  MATCH "^etc/systemd/system/snapd.mounts.snapd.target.wants/snap-snapd-.*.mount" < files.log
   MATCH "^etc/systemd/system/multi-user.target.wants/snap-snapd-.*.mount" < files.log
   MATCH "^etc/systemd/system/multi-user.target.wants/snapd.seeded.service" < files.log
   MATCH "^etc/systemd/system/multi-user.target.wants/snapd.recovery-chooser-trigger.service" < files.log

--- a/tests/main/preseed/task.yaml
+++ b/tests/main/preseed/task.yaml
@@ -133,6 +133,7 @@ execute: |
   test -L "$SYSTEMD_UNITS"/system/snapd.mounts.target.wants/snap-"${LXD_BASE_SNAP}"-*.mount
   test -L "$SYSTEMD_UNITS"/system/multi-user.target.wants/snap-"${LXD_BASE_SNAP}"-*.mount
   test -L "$SYSTEMD_UNITS"/system/snapd.mounts.target.wants/snap-snapd-*.mount
+  test -L "$SYSTEMD_UNITS"/system/snapd.mounts.snapd.target.wants/snap-snapd-*.mount
   test -L "$SYSTEMD_UNITS"/system/multi-user.target.wants/snap-snapd-*.mount
 
   for unit in snap.lxd.daemon.service snap.lxd.daemon.unix.socket snap.lxd.activate.service; do

--- a/tests/main/snap-mgmt/task.yaml
+++ b/tests/main/snap-mgmt/task.yaml
@@ -1,5 +1,8 @@
 summary: Check that snap-mgmt.sh works
 
+details: |
+    This test verifies smap-mgmt.sh can purge snapd from a system.
+
 # slow in autopkgtest (>1m)
 backends: [-autopkgtest]
 
@@ -133,6 +136,8 @@ execute: |
     test -z "$(find /etc/systemd/system/multi-user.target.wants/ -name 'snap.test-snapd-service.*')"
     # shellcheck disable=SC2251
     ! test -d /etc/systemd/system/snapd.mounts.target.wants
+    # shellcheck disable=SC2251
+    ! test -d /etc/systemd/system/snapd.mounts.snapd.target.wants
     # shellcheck disable=SC2251
     ! test -d /etc/systemd/system/multi-user.target.wants
     test -z "$(find /etc/systemd/system/sockets.target.wants/ -name 'snap.*')"


### PR DESCRIPTION
There is a theoretical situation where a confined snap is run unconfined if something in the boot runs it without waiting for snapd-apparmor to be started. To avoid this situation, we delay the mount of confined snap for after snapd-apparmor is started.

Snapd snap is still mounted before because we need to run snapd-apparmor from the snap.