### PR TITLE
o/snapstate: check properly conflicts when refreshing snapd

### DIFF
--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -408,7 +408,7 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 			}
 			// If snapsup.Version was smaller, 1 is returned.
 			if res == 1 {
-				if err := CheckChangeConflictRunExclusively(st, "snapd downgrade"); err != nil {
+				if err := checkChangeConflictExclusiveKinds(st, "snapd downgrade", fromChange); err != nil {
 					return nil, err
 				}
 			}


### PR DESCRIPTION
If we were remodeling to a different snapd track and that track contained an older snapd version than the current track, snapd reported incorrectly a conflict with a remodel change. Prevent that by passing to the conflict checker the change we are running.
