### PR TITLE
cmd/snapd-generator: read mountinfo for pid 1  (2.60)

### DIFF
--- a/cmd/snapd-generator/main.c
+++ b/cmd/snapd-generator/main.c
@@ -45,11 +45,11 @@ static sc_mountinfo_entry *find_root_mountinfo(sc_mountinfo * mounts)
 
 static int ensure_root_fs_shared(const char *normal_dir)
 {
-	// Load /proc/self/mountinfo so that we can inspect the root filesystem.
+	// Load /proc/1/mountinfo so that we can inspect the root filesystem.
 	sc_mountinfo *mounts SC_CLEANUP(sc_cleanup_mountinfo) = NULL;
-	mounts = sc_parse_mountinfo(NULL);
+	mounts = sc_parse_mountinfo("/proc/1/mountinfo");
 	if (!mounts) {
-		fprintf(stderr, "cannot open or parse /proc/self/mountinfo\n");
+		fprintf(stderr, "cannot open or parse /proc/1/mountinfo\n");
 		return 1;
 	}
 

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/osutil/squashfs"
 	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/auth"
 	userclient "github.com/snapcore/snapd/usersession/client"
@@ -170,6 +171,9 @@ func (s *snapmgrBaseTest) SetUpTest(c *C) {
 		state:               s.state,
 		downloadError:       make(map[string]error),
 	}
+
+	// make tests work consistently also in containers
+	s.AddCleanup(squashfs.MockNeedsFuse(false))
 
 	// setup a bootloader for policy and boot
 	s.bl = bootloadertest.Mock("mock", c.MkDir())


### PR DESCRIPTION
Systemd now runs generators in a sandbox. That means `/proc/self/mountinfo` does not represent correctly the mounts of the system.
