### PR TITLE
usersession: implement restart controls and status querying for user services

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # In progress:
 * Installation of local snap components
+* Started improving support for user daemons by introducing new control switches --user/--users/--system for service operations
 
 # Next:
 * state: add support for notices (from pebble)

--- a/usersession/agent/export_test.go
+++ b/usersession/agent/export_test.go
@@ -26,6 +26,7 @@ import (
 var (
 	SessionInfoCmd                = sessionInfoCmd
 	ServiceControlCmd             = serviceControlCmd
+	ServiceStatusCmd              = serviceStatusCmd
 	PendingRefreshNotificationCmd = pendingRefreshNotificationCmd
 	FinishRefreshNotificationCmd  = finishRefreshNotificationCmd
 )

--- a/usersession/agent/response.go
+++ b/usersession/agent/response.go
@@ -95,6 +95,7 @@ type errorKind string
 const (
 	errorKindLoginRequired  = errorKind("login-required")
 	errorKindServiceControl = errorKind("service-control")
+	errorKindServiceStatus  = errorKind("service-status")
 )
 
 type errorValue interface{}


### PR DESCRIPTION
This is the next part of adding remaining user-services support in the wrappers package. This PR adds support for restarting and querying of service status. 

Next parts:
Supporting restart/querying user daemons in wrappers: https://github.com/snapcore/snapd/pull/13337
Support for scopes/user-selection in daemon API: https://github.com/snapcore/snapd/pull/13338
Support for querying user daemons in servicestate: https://github.com/snapcore/snapd/pull/13380
Support for --user/--users/--system in cli: https://github.com/snapcore/snapd/pull/13367 + https://github.com/snapcore/snapd/pull/13368 + https://github.com/snapcore/snapd/pull/13381