### PR TITLE
wrappers: support for restarting user-daemons

### DIFF
--- a/wrappers/export_test.go
+++ b/wrappers/export_test.go
@@ -20,9 +20,11 @@
 package wrappers
 
 import (
+	"os/user"
 	"time"
 
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/testutil"
 )
 
 // some internal helper exposed for testing
@@ -35,6 +37,10 @@ var (
 	RewriteExecLine        = rewriteExecLine
 	RewriteIconLine        = rewriteIconLine
 	IsValidDesktopFileLine = isValidDesktopFileLine
+
+	// daemons
+	UsersToUids               = usersToUids
+	NewUserServiceClientNames = newUserServiceClientNames
 
 	// icons
 	FindIconFiles = findIconFiles
@@ -54,4 +60,10 @@ func MockEnsureDirState(f func(dir string, glob string, content map[string]osuti
 	return func() {
 		ensureDirState = oldEnsureDirState
 	}
+}
+
+func MockUserLookup(f func(username string) (*user.User, error)) (restore func()) {
+	restore = testutil.Backup(&userLookup)
+	userLookup = f
+	return restore
 }

--- a/wrappers/internal/export_test.go
+++ b/wrappers/internal/export_test.go
@@ -19,6 +19,17 @@
 
 package internal
 
+import (
+	"github.com/snapcore/snapd/testutil"
+	"github.com/snapcore/snapd/usersession/client"
+)
+
 var (
 	GenerateOnCalendarSchedules = generateOnCalendarSchedules
 )
+
+func MockUserSessionQueryServiceStatusMany(f func(units []string) (map[int][]client.ServiceUnitStatus, map[int][]client.ServiceFailure, error)) (restore func()) {
+	restore = testutil.Backup(&userSessionQueryServiceStatusMany)
+	userSessionQueryServiceStatusMany = f
+	return restore
+}

--- a/wrappers/internal/service_status_test.go
+++ b/wrappers/internal/service_status_test.go
@@ -1,0 +1,600 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package internal_test
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"time"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	_ "github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/progress"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/systemd"
+	"github.com/snapcore/snapd/systemd/systemdtest"
+	"github.com/snapcore/snapd/testutil"
+	"github.com/snapcore/snapd/usersession/agent"
+	"github.com/snapcore/snapd/usersession/client"
+	"github.com/snapcore/snapd/wrappers"
+	"github.com/snapcore/snapd/wrappers/internal"
+)
+
+type serviceStatusSuite struct {
+	testutil.DBusTest
+	tempdir                           string
+	sysdLog                           [][]string
+	systemctlRestorer, delaysRestorer func()
+	agent                             *agent.SessionAgent
+}
+
+var _ = Suite(&serviceStatusSuite{})
+
+func (s *serviceStatusSuite) SetUpTest(c *C) {
+	s.DBusTest.SetUpTest(c)
+	s.tempdir = c.MkDir()
+	s.sysdLog = nil
+	dirs.SetRootDir(s.tempdir)
+
+	s.systemctlRestorer = systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
+		s.sysdLog = append(s.sysdLog, cmd)
+		return []byte("ActiveState=inactive\n"), nil
+	})
+	s.delaysRestorer = systemd.MockStopDelays(2*time.Millisecond, 4*time.Millisecond)
+
+	xdgRuntimeDir := fmt.Sprintf("%s/%d", dirs.XdgRuntimeDirBase, os.Getuid())
+	err := os.MkdirAll(xdgRuntimeDir, 0700)
+	c.Assert(err, IsNil)
+	s.agent, err = agent.New()
+	c.Assert(err, IsNil)
+	s.agent.Start()
+}
+
+func (s *serviceStatusSuite) TearDownTest(c *C) {
+	if s.agent != nil {
+		err := s.agent.Stop()
+		c.Check(err, IsNil)
+	}
+	s.systemctlRestorer()
+	s.delaysRestorer()
+	dirs.SetRootDir("")
+	s.DBusTest.TearDownTest(c)
+}
+
+// addSnapServices adds service units for the snap applications which
+// are services. The services do not get enabled or started.
+func (s *serviceStatusSuite) addSnapServices(snapInfo *snap.Info, preseeding bool) error {
+	m := map[*snap.Info]*wrappers.SnapServiceOptions{
+		snapInfo: nil,
+	}
+	ensureOpts := &wrappers.EnsureSnapServicesOptions{
+		Preseeding: preseeding,
+	}
+	return wrappers.EnsureSnapServices(m, ensureOpts, nil, progress.Null)
+}
+
+func (s *serviceStatusSuite) TestQueryServiceStatusMany(c *C) {
+	const snapYaml = `name: test-snap
+version: 1.0
+apps:
+  foo:
+    command: bin/foo
+    daemon: simple
+    daemon-scope: user
+  bar:
+    command: bin/bar
+    daemon: simple
+`
+	info := snaptest.MockSnap(c, snapYaml, &snap.SideInfo{Revision: snap.R(1)})
+	fooSrvFile := "snap.test-snap.foo.service"
+	barSrvFile := "snap.test-snap.bar.service"
+
+	r := systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
+		s.sysdLog = append(s.sysdLog, cmd)
+		if out := systemdtest.HandleMockAllUnitsActiveOutput(cmd, nil); out != nil {
+			return out, nil
+		}
+		if cmd[0] == "--user" && cmd[1] == "show" {
+			return []byte(`Type=simple
+Id=snap.test-snap.foo.service
+Names=snap.test-snap.foo.service
+ActiveState=inactive
+UnitFileState=enabled
+NeedDaemonReload=no
+`), nil
+		}
+		return []byte(`ActiveState=inactive`), nil
+	})
+	defer r()
+
+	err := s.addSnapServices(info, false)
+	c.Assert(err, IsNil)
+
+	sorted := info.Services()
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Name < sorted[j].Name
+	})
+
+	sysd := systemd.New(systemd.SystemMode, progress.Null)
+	svcs, usrSvcs, err := internal.QueryServiceStatusMany(sorted, sysd)
+	c.Assert(err, IsNil)
+	c.Assert(svcs, HasLen, 1)
+	c.Check(svcs[0].Name(), Equals, "bar")
+	c.Check(svcs[0].IsUserService(), Equals, false)
+	c.Check(svcs[0].ServiceUnitStatus(), DeepEquals, &systemd.UnitStatus{
+		Daemon:           "simple",
+		Id:               barSrvFile,
+		Name:             barSrvFile,
+		Names:            []string{barSrvFile},
+		Enabled:          true,
+		Active:           true,
+		Installed:        true,
+		NeedDaemonReload: false,
+	})
+	c.Assert(usrSvcs, HasLen, 1)
+
+	// To avoid referring directly to the uid (which may be different on different hosts)
+	var hostUid int
+	for hostUid = range usrSvcs {
+		// we expect just one
+	}
+
+	c.Assert(usrSvcs[hostUid], HasLen, 1)
+	c.Check(usrSvcs[hostUid][0].Name(), Equals, "foo")
+	c.Check(usrSvcs[hostUid][0].IsUserService(), Equals, true)
+	c.Check(usrSvcs[hostUid][0].ServiceUnitStatus(), DeepEquals, &systemd.UnitStatus{
+		Daemon:           "simple",
+		Id:               fooSrvFile,
+		Name:             fooSrvFile,
+		Names:            []string{fooSrvFile},
+		Enabled:          true,
+		Active:           false, // ActiveState=inactive
+		Installed:        true,
+		NeedDaemonReload: false,
+	})
+
+	c.Check(s.sysdLog, DeepEquals, [][]string{
+		{"daemon-reload"},
+		{"--user", "daemon-reload"},
+		{"show", "--property=Id,ActiveState,UnitFileState,Type,Names,NeedDaemonReload", barSrvFile},
+		{"--user", "show", "--property=Id,ActiveState,UnitFileState,Type,Names,NeedDaemonReload", fooSrvFile},
+	})
+}
+
+func (s *serviceStatusSuite) TestQueryServiceStatusManyWithSockets(c *C) {
+	const snapYaml = `name: test-snap
+version: 1.0
+apps:
+  foo:
+    command: bin/foo
+    daemon: simple
+    daemon-scope: user
+    plugs: [network-bind]
+    sockets:
+      sock1:
+        listen-stream: $SNAP_USER_COMMON/sock1.socket
+        socket-mode: 0666
+  bar:
+    command: bin/bar
+    daemon: simple
+    plugs: [network-bind]
+    sockets:
+      sock1:
+        listen-stream: $SNAP_COMMON/sock1.socket
+        socket-mode: 0666
+`
+	info := snaptest.MockSnap(c, snapYaml, &snap.SideInfo{Revision: snap.R(1)})
+	fooSrvFile := "snap.test-snap.foo.service"
+	fooSockSrvFile := "snap.test-snap.foo.sock1.socket"
+	barSrvFile := "snap.test-snap.bar.service"
+	barSockSrvFile := "snap.test-snap.bar.sock1.socket"
+
+	r := systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
+		s.sysdLog = append(s.sysdLog, cmd)
+		if out := systemdtest.HandleMockAllUnitsActiveOutput(cmd, nil); out != nil {
+			return out, nil
+		}
+		if cmd[len(cmd)-1] == "daemon-reload" {
+			return []byte(`ActiveState=inactive`), nil
+		}
+
+		return []byte(fmt.Sprintf(`Type=simple
+Id=%[1]s
+Names=%[1]s
+ActiveState=active
+UnitFileState=enabled
+NeedDaemonReload=no
+`, cmd[len(cmd)-1])), nil
+	})
+	defer r()
+
+	err := s.addSnapServices(info, false)
+	c.Assert(err, IsNil)
+
+	sorted := info.Services()
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Name < sorted[j].Name
+	})
+
+	sysd := systemd.New(systemd.SystemMode, progress.Null)
+	svcs, usrSvcs, err := internal.QueryServiceStatusMany(sorted, sysd)
+	c.Assert(err, IsNil)
+	c.Assert(svcs, HasLen, 1)
+	c.Check(svcs[0].Name(), Equals, "bar")
+	c.Check(svcs[0].IsUserService(), Equals, false)
+	c.Check(svcs[0].ServiceUnitStatus(), DeepEquals, &systemd.UnitStatus{
+		Daemon:           "simple",
+		Id:               barSrvFile,
+		Name:             barSrvFile,
+		Names:            []string{barSrvFile},
+		Enabled:          true,
+		Active:           true,
+		Installed:        true,
+		NeedDaemonReload: false,
+	})
+	c.Check(svcs[0].ActivatorUnitStatuses(), DeepEquals, []*systemd.UnitStatus{
+		{
+			Daemon:           "simple",
+			Id:               barSockSrvFile,
+			Name:             barSockSrvFile,
+			Names:            []string{barSockSrvFile},
+			Enabled:          true,
+			Active:           true,
+			Installed:        true,
+			NeedDaemonReload: false,
+		},
+	})
+	c.Assert(usrSvcs, HasLen, 1)
+
+	// To avoid referring directly to the uid (which may be different on different hosts)
+	var hostUid int
+	for hostUid = range usrSvcs {
+		// we expect just one
+	}
+
+	c.Assert(usrSvcs[hostUid], HasLen, 1)
+	c.Check(usrSvcs[hostUid][0].Name(), Equals, "foo")
+	c.Check(usrSvcs[hostUid][0].IsUserService(), Equals, true)
+	c.Check(usrSvcs[hostUid][0].ServiceUnitStatus(), DeepEquals, &systemd.UnitStatus{
+		Daemon:           "simple",
+		Id:               fooSrvFile,
+		Name:             fooSrvFile,
+		Names:            []string{fooSrvFile},
+		Enabled:          true,
+		Active:           true, // ActiveState=active
+		Installed:        true,
+		NeedDaemonReload: false,
+	})
+	c.Check(usrSvcs[hostUid][0].ActivatorUnitStatuses(), DeepEquals, []*systemd.UnitStatus{
+		{
+			Daemon:           "simple",
+			Id:               fooSockSrvFile,
+			Name:             fooSockSrvFile,
+			Names:            []string{fooSockSrvFile},
+			Enabled:          true,
+			Active:           true,
+			Installed:        true,
+			NeedDaemonReload: false,
+		},
+	})
+
+	c.Check(s.sysdLog, DeepEquals, [][]string{
+		{"daemon-reload"},
+		{"--user", "daemon-reload"},
+		{"show", "--property=Id,ActiveState,UnitFileState,Type,Names,NeedDaemonReload", barSrvFile},
+		{"show", "--property=Id,ActiveState,UnitFileState,Names", barSockSrvFile},
+		{"--user", "show", "--property=Id,ActiveState,UnitFileState,Type,Names,NeedDaemonReload", fooSrvFile},
+		{"--user", "show", "--property=Id,ActiveState,UnitFileState,Names", fooSockSrvFile},
+	})
+}
+
+func (s *serviceStatusSuite) TestQueryServiceStatusManyWithTimers(c *C) {
+	const snapYaml = `name: test-snap
+version: 1.0
+apps:
+  foo:
+    command: bin/foo
+    daemon: simple
+    daemon-scope: user
+    timer: 10:00-12:00
+  bar:
+    command: bin/bar
+    daemon: simple
+    timer: 10:00-12:00
+`
+	info := snaptest.MockSnap(c, snapYaml, &snap.SideInfo{Revision: snap.R(1)})
+	fooSrvFile := "snap.test-snap.foo.service"
+	fooTimerSrvFile := "snap.test-snap.foo.timer"
+	barSrvFile := "snap.test-snap.bar.service"
+	barTimerSrvFile := "snap.test-snap.bar.timer"
+
+	r := systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
+		s.sysdLog = append(s.sysdLog, cmd)
+		if out := systemdtest.HandleMockAllUnitsActiveOutput(cmd, nil); out != nil {
+			return out, nil
+		}
+		if cmd[len(cmd)-1] == "daemon-reload" {
+			return []byte(`ActiveState=inactive`), nil
+		}
+
+		return []byte(fmt.Sprintf(`Type=simple
+Id=%[1]s
+Names=%[1]s
+ActiveState=active
+UnitFileState=enabled
+NeedDaemonReload=no
+`, cmd[len(cmd)-1])), nil
+	})
+	defer r()
+
+	err := s.addSnapServices(info, false)
+	c.Assert(err, IsNil)
+
+	sorted := info.Services()
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Name < sorted[j].Name
+	})
+
+	sysd := systemd.New(systemd.SystemMode, progress.Null)
+	svcs, usrSvcs, err := internal.QueryServiceStatusMany(sorted, sysd)
+	c.Assert(err, IsNil)
+	c.Assert(svcs, HasLen, 1)
+	c.Check(svcs[0].Name(), Equals, "bar")
+	c.Check(svcs[0].IsUserService(), Equals, false)
+	c.Check(svcs[0].ServiceUnitStatus(), DeepEquals, &systemd.UnitStatus{
+		Daemon:           "simple",
+		Id:               barSrvFile,
+		Name:             barSrvFile,
+		Names:            []string{barSrvFile},
+		Enabled:          true,
+		Active:           true,
+		Installed:        true,
+		NeedDaemonReload: false,
+	})
+	c.Check(svcs[0].ActivatorUnitStatuses(), DeepEquals, []*systemd.UnitStatus{
+		{
+			Daemon:           "simple",
+			Id:               barTimerSrvFile,
+			Name:             barTimerSrvFile,
+			Names:            []string{barTimerSrvFile},
+			Enabled:          true,
+			Active:           true,
+			Installed:        true,
+			NeedDaemonReload: false,
+		},
+	})
+	c.Assert(usrSvcs, HasLen, 1)
+
+	// To avoid referring directly to the uid (which may be different on different hosts)
+	var hostUid int
+	for hostUid = range usrSvcs {
+		// we expect just one
+	}
+
+	c.Assert(usrSvcs[hostUid], HasLen, 1)
+	c.Check(usrSvcs[hostUid][0].Name(), Equals, "foo")
+	c.Check(usrSvcs[hostUid][0].IsUserService(), Equals, true)
+	c.Check(usrSvcs[hostUid][0].ServiceUnitStatus(), DeepEquals, &systemd.UnitStatus{
+		Daemon:           "simple",
+		Id:               fooSrvFile,
+		Name:             fooSrvFile,
+		Names:            []string{fooSrvFile},
+		Enabled:          true,
+		Active:           true, // ActiveState=active
+		Installed:        true,
+		NeedDaemonReload: false,
+	})
+	c.Check(usrSvcs[hostUid][0].ActivatorUnitStatuses(), DeepEquals, []*systemd.UnitStatus{
+		{
+			Daemon:           "simple",
+			Id:               fooTimerSrvFile,
+			Name:             fooTimerSrvFile,
+			Names:            []string{fooTimerSrvFile},
+			Enabled:          true,
+			Active:           true,
+			Installed:        true,
+			NeedDaemonReload: false,
+		},
+	})
+
+	c.Check(s.sysdLog, DeepEquals, [][]string{
+		{"daemon-reload"},
+		{"--user", "daemon-reload"},
+		{"show", "--property=Id,ActiveState,UnitFileState,Type,Names,NeedDaemonReload", barSrvFile},
+		{"show", "--property=Id,ActiveState,UnitFileState,Names", barTimerSrvFile},
+		{"--user", "show", "--property=Id,ActiveState,UnitFileState,Type,Names,NeedDaemonReload", fooSrvFile},
+		{"--user", "show", "--property=Id,ActiveState,UnitFileState,Names", fooTimerSrvFile},
+	})
+}
+
+func (s *serviceStatusSuite) TestQueryServiceStatusManySystemServicesFail(c *C) {
+	const snapYaml = `name: test-snap
+version: 1.0
+apps:
+  foo:
+    command: bin/foo
+    daemon: simple
+  bar:
+    command: bin/bar
+    daemon: simple
+`
+	info := snaptest.MockSnap(c, snapYaml, &snap.SideInfo{Revision: snap.R(1)})
+	fooSrvFile := "snap.test-snap.foo.service"
+	barSrvFile := "snap.test-snap.bar.service"
+
+	r := systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
+		s.sysdLog = append(s.sysdLog, cmd)
+		if cmd[0] == "daemon-reload" {
+			return []byte(`okay`), nil
+		}
+		return nil, fmt.Errorf("oh noes")
+	})
+	defer r()
+
+	err := s.addSnapServices(info, false)
+	c.Assert(err, IsNil)
+
+	sorted := info.Services()
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Name < sorted[j].Name
+	})
+
+	sysd := systemd.New(systemd.SystemMode, progress.Null)
+	svcs, usrSvcs, err := internal.QueryServiceStatusMany(sorted, sysd)
+	c.Assert(err, ErrorMatches, `oh noes`)
+	c.Assert(svcs, HasLen, 0)
+	c.Assert(usrSvcs, HasLen, 0)
+
+	c.Check(s.sysdLog, DeepEquals, [][]string{
+		{"daemon-reload"},
+		{"show", "--property=Id,ActiveState,UnitFileState,Type,Names,NeedDaemonReload", barSrvFile, fooSrvFile},
+	})
+}
+
+func (s *serviceStatusSuite) TestQueryServiceStatusManyUserFails(c *C) {
+	const snapYaml = `name: test-snap
+version: 1.0
+apps:
+  foo:
+    command: bin/foo
+    daemon: simple
+    daemon-scope: user
+  bar:
+    command: bin/foo
+    daemon: simple
+    daemon-scope: user
+`
+	info := snaptest.MockSnap(c, snapYaml, &snap.SideInfo{Revision: snap.R(1)})
+	fooSrvFile := "snap.test-snap.foo.service"
+	barSrvFile := "snap.test-snap.bar.service"
+
+	r := systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
+		s.sysdLog = append(s.sysdLog, cmd)
+		if cmd[0] == "--user" && cmd[1] == "show" {
+			if cmd[len(cmd)-1] == fooSrvFile {
+				return nil, fmt.Errorf("oh no %s does not exist", fooSrvFile)
+			}
+
+			return []byte(fmt.Sprintf(`Type=simple
+Id=%[1]s
+Names=%[1]s
+ActiveState=inactive
+UnitFileState=enabled
+NeedDaemonReload=no
+`, cmd[len(cmd)-1])), nil
+		}
+		return []byte(`okay`), nil
+	})
+	defer r()
+
+	err := s.addSnapServices(info, false)
+	c.Assert(err, IsNil)
+
+	sorted := info.Services()
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Name < sorted[j].Name
+	})
+
+	sysd := systemd.New(systemd.SystemMode, progress.Null)
+	svcs, usrSvcs, err := internal.QueryServiceStatusMany(sorted, sysd)
+	c.Assert(err, IsNil)
+	c.Assert(svcs, HasLen, 0)
+	c.Assert(usrSvcs, HasLen, 0)
+
+	c.Check(s.sysdLog, DeepEquals, [][]string{
+		{"--user", "daemon-reload"},
+		{"--user", "show", "--property=Id,ActiveState,UnitFileState,Type,Names,NeedDaemonReload", barSrvFile},
+		{"--user", "show", "--property=Id,ActiveState,UnitFileState,Type,Names,NeedDaemonReload", fooSrvFile},
+	})
+}
+
+func (s *serviceStatusSuite) TestQueryServiceStatusManyUserInvalidServicesReceived(c *C) {
+	const snapYaml = `name: test-snap
+version: 1.0
+apps:
+  foo:
+    command: bin/foo
+    daemon: simple
+    daemon-scope: user
+  bar:
+    command: bin/foo
+    daemon: simple
+    daemon-scope: user
+`
+	info := snaptest.MockSnap(c, snapYaml, &snap.SideInfo{Revision: snap.R(1)})
+	fooSrvFile := "snap.test-snap.foo.service"
+
+	err := s.addSnapServices(info, false)
+	c.Assert(err, IsNil)
+
+	sorted := info.Services()
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Name < sorted[j].Name
+	})
+
+	r := internal.MockUserSessionQueryServiceStatusMany(func(units []string) (map[int][]client.ServiceUnitStatus, map[int][]client.ServiceFailure, error) {
+		return map[int][]client.ServiceUnitStatus{
+			1000: {
+				{Name: fooSrvFile},
+			},
+		}, nil, nil
+	})
+	defer r()
+
+	sysd := systemd.New(systemd.SystemMode, progress.Null)
+	svcs, usrSvcs, err := internal.QueryServiceStatusMany(sorted, sysd)
+	c.Assert(err, ErrorMatches, `internal error: no status received for service snap.test-snap.bar.service`)
+	c.Assert(svcs, HasLen, 0)
+	c.Assert(usrSvcs, HasLen, 0)
+}
+
+func (s *serviceStatusSuite) TestSnapServiceUnits(c *C) {
+	const surviveYaml = `name: test-snap
+version: 1.0
+apps:
+  foo:
+    command: bin/foo
+    daemon: simple
+    daemon-scope: user
+    timer: 10:00-12:00,20:00-22:00
+    sockets:
+      sock1:
+       listen-stream: $SNAP_DATA/sock1.socket
+      sock2:
+       listen-stream: $SNAP_DATA/sock2.socket
+`
+	info := snaptest.MockSnap(c, surviveYaml, &snap.SideInfo{Revision: snap.R(1)})
+
+	svc, activators := internal.SnapServiceUnits(info.Apps["foo"])
+	c.Check(svc, Equals, "snap.test-snap.foo.service")
+
+	// The activators must appear the in following order:
+	// Sockets, sorted
+	// Timer unit
+	c.Check(activators, DeepEquals, []string{
+		"snap.test-snap.foo.sock1.socket",
+		"snap.test-snap.foo.sock2.socket",
+		"snap.test-snap.foo.timer",
+	})
+}

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -24,8 +24,10 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/user"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"time"
 
 	"github.com/snapcore/snapd/dirs"
@@ -42,6 +44,31 @@ import (
 	"github.com/snapcore/snapd/wrappers/internal"
 )
 
+// ServiceScope indicates the scope of services that can be present in a snap, which
+// may be affected by an operation.
+type ServiceScope string
+
+const (
+	// ServiceScopeAll indicates both system and user services of a snap.
+	ServiceScopeAll ServiceScope = ""
+	// ServiceScopeSystem indicates just the system services of a snap.
+	ServiceScopeSystem ServiceScope = "system"
+	// ServiceScopeUser indicates just the user services of a snap.
+	ServiceScopeUser ServiceScope = "user"
+)
+
+func (sc ServiceScope) matches(dscope snap.DaemonScope) bool {
+	switch sc {
+	case ServiceScopeAll:
+		return true
+	case ServiceScopeSystem:
+		return dscope == snap.SystemDaemon
+	case ServiceScopeUser:
+		return dscope == snap.UserDaemon
+	}
+	return false
+}
+
 type Interacter interface {
 	Notify(status string)
 }
@@ -49,30 +76,122 @@ type Interacter interface {
 // wait this time between TERM and KILL
 var killWait = 5 * time.Second
 
-func stopUserServices(cli *client.Client, inter Interacter, services ...string) error {
+// ScopeOptions provides ways to limit the effects of service operations
+// to a certain scope, including which users and service type.
+type ScopeOptions struct {
+	// Scope determines the types of services affected. This can be either
+	// or both of system services and user services.
+	Scope ServiceScope
+	// Users if set, determines which users the operation should include, if
+	// the scope includes user services.
+	Users []string
+}
+
+type userServiceClient struct {
+	cli   *client.Client
+	inter Interacter
+}
+
+var userLookup = user.Lookup
+
+func usersToUids(users []string) (map[int]string, error) {
+	uids := make(map[int]string)
+	for _, username := range users {
+		usr, err := userLookup(username)
+		if err != nil {
+			return nil, err
+		}
+		uid, err := strconv.Atoi(usr.Uid)
+		if err != nil {
+			return nil, err
+		}
+		uids[uid] = username
+	}
+	return uids, nil
+}
+
+func newUserServiceClientUids(uids []int, inter Interacter) (*userServiceClient, error) {
+	return &userServiceClient{
+		cli:   client.NewForUids(uids...),
+		inter: inter,
+	}, nil
+}
+
+func newUserServiceClientNames(users []string, inter Interacter) (*userServiceClient, error) {
+	uids, err := usersToUids(users)
+	if err != nil {
+		return nil, err
+	}
+	var keys []int
+	for uid := range uids {
+		keys = append(keys, uid)
+	}
+	return newUserServiceClientUids(keys, inter)
+}
+
+func (c *userServiceClient) stopServices(services ...string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout.DefaultTimeout))
 	defer cancel()
-	failures, err := cli.ServicesStop(ctx, services)
+	failures, err := c.cli.ServicesStop(ctx, services)
 	for _, f := range failures {
-		inter.Notify(fmt.Sprintf("Could not stop service %q for uid %d: %s", f.Service, f.Uid, f.Error))
+		c.inter.Notify(fmt.Sprintf("Could not stop service %q for uid %d: %s", f.Service, f.Uid, f.Error))
 	}
 	return err
 }
 
-func startUserServices(cli *client.Client, inter Interacter, services ...string) error {
+func (c *userServiceClient) startServices(services ...string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout.DefaultTimeout))
 	defer cancel()
-	startFailures, stopFailures, err := cli.ServicesStart(ctx, services)
+	startFailures, stopFailures, err := c.cli.ServicesStart(ctx, services)
 	for _, f := range startFailures {
-		inter.Notify(fmt.Sprintf("Could not start service %q for uid %d: %s", f.Service, f.Uid, f.Error))
+		c.inter.Notify(fmt.Sprintf("Could not start service %q for uid %d: %s", f.Service, f.Uid, f.Error))
 	}
 	for _, f := range stopFailures {
-		inter.Notify(fmt.Sprintf("While trying to stop previously started service %q for uid %d: %s", f.Service, f.Uid, f.Error))
+		c.inter.Notify(fmt.Sprintf("While trying to stop previously started service %q for uid %d: %s", f.Service, f.Uid, f.Error))
 	}
 	return err
 }
 
-func stopService(sysd systemd.Systemd, inter Interacter, scope snap.DaemonScope, svcs []string) error {
+func (c *userServiceClient) restartServices(reload bool, services ...string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout.DefaultTimeout))
+	defer cancel()
+	var failures []client.ServiceFailure
+	var err error
+	if reload {
+		failures, err = c.cli.ServicesReloadOrRestart(ctx, services)
+	} else {
+		failures, err = c.cli.ServicesRestart(ctx, services)
+	}
+	for _, f := range failures {
+		c.inter.Notify(fmt.Sprintf("Could not restart service %q for uid %d: %s", f.Service, f.Uid, f.Error))
+	}
+	return err
+}
+
+func reloadOrRestartServices(sysd systemd.Systemd, cli *userServiceClient, reload bool, scope snap.DaemonScope, svcs []string) error {
+	switch scope {
+	case snap.SystemDaemon:
+		if reload {
+			if err := sysd.ReloadOrRestart(svcs); err != nil {
+				return err
+			}
+		} else {
+			if err := sysd.Restart(svcs); err != nil {
+				return err
+			}
+		}
+	case snap.UserDaemon:
+		if err := cli.restartServices(reload, svcs...); err != nil {
+			return err
+		}
+	default:
+		panic("unknown app.DaemonScope")
+	}
+
+	return nil
+}
+
+func stopService(sysd systemd.Systemd, cli *userServiceClient, scope snap.DaemonScope, svcs []string) error {
 	switch scope {
 	case snap.SystemDaemon:
 		if err := sysd.Stop(svcs); err != nil {
@@ -80,8 +199,7 @@ func stopService(sysd systemd.Systemd, inter Interacter, scope snap.DaemonScope,
 		}
 
 	case snap.UserDaemon:
-		cli := client.New()
-		if err := stopUserServices(cli, inter, svcs...); err != nil {
+		if err := cli.stopServices(svcs...); err != nil {
 			return err
 		}
 	default:
@@ -99,9 +217,11 @@ func serviceIsSlotActivated(app *snap.AppInfo) bool {
 	return len(app.ActivatesOn) > 0
 }
 
-// StartServicesFlags carries extra flags for StartServices.
+// StartServicesFlags carries additional parameters for StartService.
+// XXX: Rename to StartServiceOptions
 type StartServicesFlags struct {
 	Enable bool
+	ScopeOptions
 }
 
 // StartServices starts service units for the applications from the snap which
@@ -114,7 +234,10 @@ func StartServices(apps []*snap.AppInfo, disabledSvcs []string, flags *StartServ
 
 	systemSysd := systemd.New(systemd.SystemMode, inter)
 	userSysd := systemd.New(systemd.GlobalUserMode, inter)
-	cli := client.New()
+	cli, err := newUserServiceClientNames(flags.Users, inter)
+	if err != nil {
+		return err
+	}
 
 	var toEnableSystem []string
 	var toEnableUser []string
@@ -132,7 +255,7 @@ func StartServices(apps []*snap.AppInfo, disabledSvcs []string, flags *StartServ
 			for i := len(apps) - 1; i >= 0; i-- {
 				app := apps[i]
 				svc, activators := internal.SnapServiceUnits(app)
-				if e := stopService(systemSysd, inter, app.DaemonScope, append(activators, svc)); e != nil {
+				if e := stopService(systemSysd, cli, app.DaemonScope, append(activators, svc)); e != nil {
 					inter.Notify(fmt.Sprintf("While trying to stop previously started service %q: %v", app.ServiceName(), e))
 				}
 			}
@@ -175,6 +298,10 @@ func StartServices(apps []*snap.AppInfo, disabledSvcs []string, flags *StartServ
 		if !app.IsService() {
 			continue
 		}
+		// Verify that scope covers this service
+		if !flags.Scope.matches(app.DaemonScope) {
+			continue
+		}
 		if strutil.ListContains(disabledSvcs, app.Name) {
 			continue
 		}
@@ -194,6 +321,10 @@ func StartServices(apps []*snap.AppInfo, disabledSvcs []string, flags *StartServ
 	// now collect all services
 	for _, app := range apps {
 		if !app.IsService() {
+			continue
+		}
+		// Verify that scope covers this service
+		if !flags.Scope.matches(app.DaemonScope) {
 			continue
 		}
 		if serviceIsActivated(app) {
@@ -251,7 +382,7 @@ func StartServices(apps []*snap.AppInfo, disabledSvcs []string, flags *StartServ
 
 	if len(userServices) != 0 {
 		timings.Run(tm, "start-user-services", "start user services", func(nested timings.Measurer) {
-			err = startUserServices(cli, inter, userServices...)
+			err = cli.startServices(userServices...)
 		})
 		// let the cleanup know some services may have been started
 		servicesStarted = true
@@ -769,9 +900,11 @@ func EnsureSnapServices(snaps map[*snap.Info]*SnapServiceOptions, opts *EnsureSn
 	return context.reloadModified()
 }
 
-// StopServicesFlags carries extra flags for StopServices.
+// StopServicesFlags carries additional parameters for StopServices.
+// XXX: Rename to StopServicesOptions
 type StopServicesFlags struct {
 	Disable bool
+	ScopeOptions
 }
 
 // StopServices stops and optionally disables service units for the applications
@@ -786,6 +919,11 @@ func StopServices(apps []*snap.AppInfo, flags *StopServicesFlags, reason snap.Se
 		logger.Debugf("StopServices called for %q, reason: %v", apps, reason)
 	} else {
 		logger.Debugf("StopServices called for %q", apps)
+	}
+
+	cli, err := newUserServiceClientNames(flags.Users, inter)
+	if err != nil {
+		return err
 	}
 
 	disableServices := []string{}
@@ -805,6 +943,10 @@ func StopServices(apps []*snap.AppInfo, flags *StopServicesFlags, reason snap.Se
 				continue
 			}
 		}
+		// Verify that scope covers this service
+		if !flags.Scope.matches(app.DaemonScope) {
+			continue
+		}
 
 		// Is the service slot activated, then lets warn the user this doesn't have any
 		// real effect if a disable was requested
@@ -821,7 +963,7 @@ func StopServices(apps []*snap.AppInfo, flags *StopServicesFlags, reason snap.Se
 
 		var err error
 		timings.Run(tm, "stop-service", fmt.Sprintf("stop service %q", app.ServiceName()), func(nested timings.Measurer) {
-			err = stopService(sysd, inter, app.DaemonScope, append(activators, svc))
+			err = stopService(sysd, cli, app.DaemonScope, append(activators, svc))
 			if err == nil && flags.Disable {
 				disableServices = append(disableServices, append(activators, svc)...)
 			}
@@ -968,11 +1110,51 @@ func RemoveSnapServices(s *snap.Info, inter Interacter) error {
 	return nil
 }
 
+// RestartServicesFlags carries additional parameters for RestartServices.
+// XXX: Rename to RestartServicesOptions
 type RestartServicesFlags struct {
 	// Reload set if we might need to reload the service definitions.
 	Reload bool
 	// AlsoEnabledNonActive set if we to restart also enabled but not running units
 	AlsoEnabledNonActive bool
+	ScopeOptions
+}
+
+func restartServicesByStatus(svcsSts []*internal.ServiceStatus, explicitServices []string,
+	flags *RestartServicesFlags, sysd systemd.Systemd, cli *userServiceClient, tm timings.Measurer) error {
+	for _, st := range svcsSts {
+		unitName := st.ServiceUnitStatus().Name
+		unitActive := st.ServiceUnitStatus().Active
+		unitEnabled := st.IsEnabled()
+		unitScope := snap.SystemDaemon
+		if st.IsUserService() {
+			unitScope = snap.UserDaemon
+		}
+
+		// If the unit was explicitly mentioned in the command line, restart it
+		// even if it is disabled; otherwise, we only restart units which are
+		// currently enabled or running. Reference:
+		// https://forum.snapcraft.io/t/command-line-interface-to-manipulate-services/262/47
+		if !unitActive && !strutil.ListContains(explicitServices, unitName) {
+			if !flags.AlsoEnabledNonActive {
+				logger.Noticef("not restarting inactive unit %s", unitName)
+				continue
+			} else if !unitEnabled {
+				logger.Noticef("not restarting disabled and inactive unit %s", unitName)
+				continue
+			}
+		}
+
+		var err error
+		timings.Run(tm, "restart-service", fmt.Sprintf("restart service %s", unitName), func(nested timings.Measurer) {
+			err = reloadOrRestartServices(sysd, cli, flags.Reload, unitScope, []string{unitName})
+		})
+		if err != nil {
+			// there is nothing we can do about failed service
+			return err
+		}
+	}
+	return nil
 }
 
 // Restart or reload active services in `svcs`.
@@ -994,42 +1176,42 @@ func RestartServices(apps []*snap.AppInfo, explicitServices []string,
 	sysd := systemd.New(systemd.SystemMode, inter)
 
 	// Get service statuses for each of the apps
-	sts, err := internal.QueryServiceStatusMany(sysd, apps)
+	sysSvcs, usrSvcsMap, err := internal.QueryServiceStatusMany(apps, sysd)
 	if err != nil {
 		return err
 	}
 
-	for _, st := range sts {
-		unitName := st.ServiceUnitStatus().Name
-		unitActive := st.ServiceUnitStatus().Active
-		unitEnabled := st.IsEnabled()
+	// Handle restart of system services if scope was set
+	if flags.Scope != ServiceScopeUser {
+		if err := restartServicesByStatus(sysSvcs, explicitServices, flags, sysd, nil, tm); err != nil {
+			return err
+		}
+	}
 
-		// If the unit was explicitly mentioned in the command line, restart it
-		// even if it is disabled; otherwise, we only restart units which are
-		// currently enabled or running. Reference:
-		// https://forum.snapcraft.io/t/command-line-interface-to-manipulate-services/262/47
-		if !unitActive && !strutil.ListContains(explicitServices, unitName) {
-			if !flags.AlsoEnabledNonActive {
-				logger.Noticef("not restarting inactive unit %s", unitName)
-				continue
-			} else if !unitEnabled {
-				logger.Noticef("not restarting disabled and inactive unit %s", unitName)
-				continue
-			}
+	// Handle restart of the user services if scope was set
+	if flags.Scope != ServiceScopeSystem {
+		// Get a list of the uids that we are affecting
+		uids, err := usersToUids(flags.Users)
+		if err != nil {
+			return err
 		}
 
-		var err error
-		timings.Run(tm, "restart-service", fmt.Sprintf("restart service %s", unitName), func(nested timings.Measurer) {
-			if flags.Reload {
-				err = sysd.ReloadOrRestart([]string{unitName})
-			} else {
-				// note: stop followed by start, not just 'restart'
-				err = sysd.Restart([]string{unitName})
+		for uid, stss := range usrSvcsMap {
+			// If specific users were specified, i.e self, then make sure we only
+			// restart services for that user
+			if len(uids) > 0 && uids[uid] == "" {
+				continue
 			}
-		})
-		if err != nil {
-			// there is nothing we can do about failed service
-			return err
+
+			// Create a new client, only targeting that user
+			cli, err := newUserServiceClientUids([]int{uid}, inter)
+			if err != nil {
+				return err
+			}
+
+			if err := restartServicesByStatus(stss, explicitServices, flags, sysd, cli, tm); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -1039,7 +1221,10 @@ func RestartServices(apps []*snap.AppInfo, explicitServices []string,
 // in the snap.
 func QueryDisabledServices(info *snap.Info, pb progress.Meter) ([]string, error) {
 	sysd := systemd.New(systemd.SystemMode, pb)
-	sts, err := internal.QueryServiceStatusMany(sysd, info.Services())
+
+	// TODO: support user-daemons being reported back here, as it will be possible
+	// for services to have different enablement status on different users.
+	sts, _, err := internal.QueryServiceStatusMany(info.Services(), sysd)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Second PR that builds on top of https://github.com/snapcore/snapd/pull/13336. It implements support for querying status of user daemons using the existing `service_status.go`, and then implements restart of user-daemons on top of this.

This PR also adds the concept of `Scope` and `Users` to options for Start/Stop/RestartServices, which is used to control which services should be affected by these operations, it defaults to the current behaviour.

Next parts:
Support for scopes/user-selection in daemon API: https://github.com/snapcore/snapd/pull/13338
Support for querying user daemons in servicestate: https://github.com/snapcore/snapd/pull/13380
Support for --user/--users/--system in cli: https://github.com/snapcore/snapd/pull/13367 + https://github.com/snapcore/snapd/pull/13368 + https://github.com/snapcore/snapd/pull/13381