### PR TITLE
daemon,o/servicestate: support for scopes and users in API for services

### DIFF
--- a/daemon/api_apps_test.go
+++ b/daemon/api_apps_test.go
@@ -45,7 +45,6 @@ import (
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/systemd"
 	"github.com/snapcore/snapd/testutil"
-	"github.com/snapcore/snapd/wrappers"
 )
 
 var _ = check.Suite(&appsSuite{})
@@ -536,7 +535,7 @@ func (s *appsSuite) testPostAppsUser(c *check.C, inst servicestate.Instruction, 
 func (s *appsSuite) TestPostAppsStartOne(c *check.C) {
 	inst := servicestate.Instruction{Action: "start", Names: []string{"snap-a.svc2"}}
 	expected := []serviceControlArgs{
-		{action: "start", names: []string{"snap-a.svc2"}, scope: servicestate.ScopeSelector(wrappers.ServiceScopeAll)},
+		{action: "start", names: []string{"snap-a.svc2"}, scope: servicestate.ScopeSelector{"system", "user"}},
 	}
 	chg := s.testPostApps(c, inst, expected)
 	chg.State().Lock()
@@ -551,7 +550,7 @@ func (s *appsSuite) TestPostAppsStartOne(c *check.C) {
 func (s *appsSuite) TestPostAppsStartTwo(c *check.C) {
 	inst := servicestate.Instruction{Action: "start", Names: []string{"snap-a"}}
 	expected := []serviceControlArgs{
-		{action: "start", names: []string{"snap-a.svc1", "snap-a.svc2"}, scope: servicestate.ScopeSelector(wrappers.ServiceScopeAll)},
+		{action: "start", names: []string{"snap-a.svc1", "snap-a.svc2"}, scope: servicestate.ScopeSelector{"system", "user"}},
 	}
 	chg := s.testPostApps(c, inst, expected)
 
@@ -567,7 +566,7 @@ func (s *appsSuite) TestPostAppsStartTwo(c *check.C) {
 func (s *appsSuite) TestPostAppsStartThree(c *check.C) {
 	inst := servicestate.Instruction{Action: "start", Names: []string{"snap-a", "snap-b"}}
 	expected := []serviceControlArgs{
-		{action: "start", names: []string{"snap-a.svc1", "snap-a.svc2", "snap-b.svc3"}, scope: servicestate.ScopeSelector(wrappers.ServiceScopeAll)},
+		{action: "start", names: []string{"snap-a.svc1", "snap-a.svc2", "snap-b.svc3"}, scope: servicestate.ScopeSelector{"system", "user"}},
 	}
 	chg := s.testPostApps(c, inst, expected)
 	// check the summary expands the snap into actual apps
@@ -584,7 +583,7 @@ func (s *appsSuite) TestPostAppsStartThree(c *check.C) {
 func (s *appsSuite) TestPostAppsStop(c *check.C) {
 	inst := servicestate.Instruction{Action: "stop", Names: []string{"snap-a.svc2"}}
 	expected := []serviceControlArgs{
-		{action: "stop", names: []string{"snap-a.svc2"}, scope: servicestate.ScopeSelector(wrappers.ServiceScopeAll)},
+		{action: "stop", names: []string{"snap-a.svc2"}, scope: servicestate.ScopeSelector{"system", "user"}},
 	}
 	s.testPostApps(c, inst, expected)
 }
@@ -592,7 +591,7 @@ func (s *appsSuite) TestPostAppsStop(c *check.C) {
 func (s *appsSuite) TestPostAppsRestart(c *check.C) {
 	inst := servicestate.Instruction{Action: "restart", Names: []string{"snap-a.svc2"}}
 	expected := []serviceControlArgs{
-		{action: "restart", names: []string{"snap-a.svc2"}, scope: servicestate.ScopeSelector(wrappers.ServiceScopeAll)},
+		{action: "restart", names: []string{"snap-a.svc2"}, scope: servicestate.ScopeSelector{"system", "user"}},
 	}
 	s.testPostApps(c, inst, expected)
 }
@@ -601,7 +600,7 @@ func (s *appsSuite) TestPostAppsReload(c *check.C) {
 	inst := servicestate.Instruction{Action: "restart", Names: []string{"snap-a.svc2"}}
 	inst.Reload = true
 	expected := []serviceControlArgs{
-		{action: "restart", options: "reload", names: []string{"snap-a.svc2"}, scope: servicestate.ScopeSelector(wrappers.ServiceScopeAll)},
+		{action: "restart", options: "reload", names: []string{"snap-a.svc2"}, scope: servicestate.ScopeSelector{"system", "user"}},
 	}
 	s.testPostApps(c, inst, expected)
 }
@@ -610,7 +609,7 @@ func (s *appsSuite) TestPostAppsEnableNow(c *check.C) {
 	inst := servicestate.Instruction{Action: "start", Names: []string{"snap-a.svc2"}}
 	inst.Enable = true
 	expected := []serviceControlArgs{
-		{action: "start", options: "enable", names: []string{"snap-a.svc2"}, scope: servicestate.ScopeSelector(wrappers.ServiceScopeAll)},
+		{action: "start", options: "enable", names: []string{"snap-a.svc2"}, scope: servicestate.ScopeSelector{"system", "user"}},
 	}
 	s.testPostApps(c, inst, expected)
 }
@@ -619,7 +618,7 @@ func (s *appsSuite) TestPostAppsDisableNow(c *check.C) {
 	inst := servicestate.Instruction{Action: "stop", Names: []string{"snap-a.svc2"}}
 	inst.Disable = true
 	expected := []serviceControlArgs{
-		{action: "stop", options: "disable", names: []string{"snap-a.svc2"}, scope: servicestate.ScopeSelector(wrappers.ServiceScopeAll)},
+		{action: "stop", options: "disable", names: []string{"snap-a.svc2"}, scope: servicestate.ScopeSelector{"system", "user"}},
 	}
 	s.testPostApps(c, inst, expected)
 }
@@ -641,7 +640,7 @@ func (s *appsSuite) TestPostAppsScopesUserAsRootNotAllowed(c *check.C) {
 	inst := servicestate.Instruction{
 		Action: "start",
 		Names:  []string{"snap-a.svc1"},
-		Scope:  servicestate.ScopeSelector(wrappers.ServiceScopeUser),
+		Scope:  servicestate.ScopeSelector{"user"},
 		Users: servicestate.UserSelector{
 			Selector: servicestate.UserSelectionSelf,
 		},
@@ -661,14 +660,14 @@ func (s *appsSuite) TestPostAppsUsersAsRootHappy(c *check.C) {
 	inst := servicestate.Instruction{
 		Action: "start",
 		Names:  []string{"snap-a.svc1"},
-		Scope:  servicestate.ScopeSelector(wrappers.ServiceScopeUser),
+		Scope:  servicestate.ScopeSelector{"user"},
 		Users: servicestate.UserSelector{
 			Selector: servicestate.UserSelectionAll,
 		},
 	}
 	expected := []serviceControlArgs{
 		// Expect no user to appear as we are not logged in
-		{action: "start", names: []string{"snap-a.svc1"}, scope: servicestate.ScopeSelector(wrappers.ServiceScopeUser)},
+		{action: "start", names: []string{"snap-a.svc1"}, scope: servicestate.ScopeSelector{"user"}},
 	}
 	s.testPostApps(c, inst, expected)
 }
@@ -676,7 +675,7 @@ func (s *appsSuite) TestPostAppsUsersAsRootHappy(c *check.C) {
 func (s *appsSuite) TestPostAppsScopesNotSpecifiedForRoot(c *check.C) {
 	inst := servicestate.Instruction{Action: "start", Names: []string{"snap-e.svc4"}}
 	expected := []serviceControlArgs{
-		{action: "start", names: []string{"snap-e.svc4"}, scope: servicestate.ScopeSelector(wrappers.ServiceScopeAll)},
+		{action: "start", names: []string{"snap-e.svc4"}, scope: servicestate.ScopeSelector{"system", "user"}},
 	}
 	s.testPostApps(c, inst, expected)
 }
@@ -685,13 +684,13 @@ func (s *appsSuite) TestPostAppsUsersAsUserHappy(c *check.C) {
 	inst := servicestate.Instruction{
 		Action: "start",
 		Names:  []string{"snap-a.svc1"},
-		Scope:  servicestate.ScopeSelector(wrappers.ServiceScopeUser),
+		Scope:  servicestate.ScopeSelector{"user"},
 		Users: servicestate.UserSelector{
 			Selector: servicestate.UserSelectionAll,
 		},
 	}
 	expected := []serviceControlArgs{
-		{action: "start", names: []string{"snap-a.svc1"}, scope: servicestate.ScopeSelector(wrappers.ServiceScopeUser)},
+		{action: "start", names: []string{"snap-a.svc1"}, scope: servicestate.ScopeSelector{"user"}},
 	}
 	s.testPostAppsUser(c, inst, expected, "")
 }
@@ -716,7 +715,7 @@ func (s *appsSuite) TestPostAppsUsersUser(c *check.C) {
 		},
 	}
 	expected := []serviceControlArgs{
-		{action: "start", names: []string{"snap-a.svc1"}, scope: servicestate.ScopeSelector(wrappers.ServiceScopeSystem), users: []string{"username"}},
+		{action: "start", names: []string{"snap-a.svc1"}, scope: servicestate.ScopeSelector{"system"}, users: []string{"username"}},
 	}
 	s.testPostAppsUser(c, inst, expected, "")
 }
@@ -731,21 +730,21 @@ func (s *appsSuite) TestPostAppsUsersWithUsernames(c *check.C) {
 	}
 	expected := []serviceControlArgs{
 		// Expect no user to appear as we are not logged in
-		{action: "start", names: []string{"snap-a.svc1"}, scope: servicestate.ScopeSelector(wrappers.ServiceScopeAll), users: []string{"my-user", "other-user"}},
+		{action: "start", names: []string{"snap-a.svc1"}, scope: servicestate.ScopeSelector{"system", "user"}, users: []string{"my-user", "other-user"}},
 	}
 	s.testPostApps(c, inst, expected)
 }
 
 func (s *appsSuite) TestPostAppsUserNotSpecifiedForRoot(c *check.C) {
-	inst := servicestate.Instruction{Action: "start", Names: []string{"snap-e.svc4"}, Scope: servicestate.ScopeSelector(wrappers.ServiceScopeSystem)}
+	inst := servicestate.Instruction{Action: "start", Names: []string{"snap-e.svc4"}, Scope: servicestate.ScopeSelector{"system"}}
 	expected := []serviceControlArgs{
-		{action: "start", names: []string{"snap-e.svc4"}, scope: servicestate.ScopeSelector(wrappers.ServiceScopeSystem)},
+		{action: "start", names: []string{"snap-e.svc4"}, scope: servicestate.ScopeSelector{"system"}},
 	}
 	s.testPostApps(c, inst, expected)
 }
 
 func (s *appsSuite) TestPostAppsUserNotSpecifiedForUser(c *check.C) {
-	inst := servicestate.Instruction{Action: "start", Names: []string{"snap-e.svc4"}, Scope: servicestate.ScopeSelector(wrappers.ServiceScopeUser)}
+	inst := servicestate.Instruction{Action: "start", Names: []string{"snap-e.svc4"}, Scope: servicestate.ScopeSelector{"user"}}
 	s.testPostAppsUser(c, inst, nil, "cannot perform operation on services: non-root users must specify users when targeting user services")
 }
 

--- a/daemon/api_apps_test.go
+++ b/daemon/api_apps_test.go
@@ -636,7 +636,7 @@ func (s *appsSuite) TestPostAppsFailedToGetUser(c *check.C) {
 	c.Check(rspe.Message, check.Matches, "cannot perform operation on services: failed")
 }
 
-func (s *appsSuite) TestPostAppsScopesUserAsRootNotAllowed(c *check.C) {
+func (s *appsSuite) TestPostAppsScopesSelfAsRootNotAllowed(c *check.C) {
 	inst := servicestate.Instruction{
 		Action: "start",
 		Names:  []string{"snap-a.svc1"},
@@ -653,10 +653,10 @@ func (s *appsSuite) TestPostAppsScopesUserAsRootNotAllowed(c *check.C) {
 
 	rspe := s.errorReq(c, req, s.authUser)
 	c.Check(rspe.Status, check.Equals, 400)
-	c.Check(rspe.Message, check.Matches, "cannot perform operation on services: cannot use \"self\" for root user")
+	c.Check(rspe.Message, check.Matches, `cannot use "self" for root user`)
 }
 
-func (s *appsSuite) TestPostAppsUsersAsRootHappy(c *check.C) {
+func (s *appsSuite) TestPostAppsAllUsersAsRootHappy(c *check.C) {
 	inst := servicestate.Instruction{
 		Action: "start",
 		Names:  []string{"snap-a.svc1"},

--- a/daemon/api_base_test.go
+++ b/daemon/api_base_test.go
@@ -26,6 +26,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"os/user"
 	"path/filepath"
 	"time"
 
@@ -237,6 +238,25 @@ func (s *apiBaseSuite) SetUpTest(c *check.C) {
 
 	s.Brands = assertstest.NewSigningAccounts(s.StoreSigning)
 	s.Brands.Register("my-brand", brandPrivKey, nil)
+
+	s.AddCleanup(daemon.MockSystemUserFromRequest(func(r *http.Request) (*user.User, error) {
+		if s.authUser != nil {
+			return &user.User{
+				Uid:      "1337",
+				Gid:      "42",
+				Username: s.authUser.Username,
+				Name:     s.authUser.Username,
+				HomeDir:  "",
+			}, nil
+		}
+		return &user.User{
+			Uid:      "0",
+			Gid:      "0",
+			Username: "root",
+			Name:     "root",
+			HomeDir:  "",
+		}, nil
+	}))
 }
 
 func (s *apiBaseSuite) mockModel(st *state.State, model *asserts.Model) {

--- a/daemon/export_api_apps_test.go
+++ b/daemon/export_api_apps_test.go
@@ -20,13 +20,15 @@
 package daemon
 
 import (
+	"os/user"
+
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/servicestate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 )
 
-func MockServicestateControl(f func(st *state.State, appInfos []*snap.AppInfo, inst *servicestate.Instruction, flags *servicestate.Flags, context *hookstate.Context) ([]*state.TaskSet, error)) (restore func()) {
+func MockServicestateControl(f func(st *state.State, appInfos []*snap.AppInfo, inst *servicestate.Instruction, cu *user.User, flags *servicestate.Flags, context *hookstate.Context) ([]*state.TaskSet, error)) (restore func()) {
 	old := servicestateControl
 	servicestateControl = f
 	return func() {

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -22,6 +22,7 @@ package daemon
 import (
 	"context"
 	"net/http"
+	"os/user"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -369,5 +370,11 @@ func MockAspectstateSet(f func(st *state.State, account, bundleName, aspect stri
 func MockRebootNoticeWait(d time.Duration) (restore func()) {
 	restore = testutil.Backup(&rebootNoticeWait)
 	rebootNoticeWait = d
+	return restore
+}
+
+func MockSystemUserFromRequest(f func(r *http.Request) (*user.User, error)) (restore func()) {
+	restore = testutil.Backup(&systemUserFromRequest)
+	systemUserFromRequest = f
 	return restore
 }

--- a/overlord/hookstate/ctlcmd/export_test.go
+++ b/overlord/hookstate/ctlcmd/export_test.go
@@ -21,6 +21,7 @@ package ctlcmd
 
 import (
 	"fmt"
+	"os/user"
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/overlord/devicestate"
@@ -63,7 +64,7 @@ func MockKmodUnloadModule(f func(string) error) (restore func()) {
 	return r
 }
 
-func MockServicestateControlFunc(f func(*state.State, []*snap.AppInfo, *servicestate.Instruction, *servicestate.Flags, *hookstate.Context) ([]*state.TaskSet, error)) (restore func()) {
+func MockServicestateControlFunc(f func(*state.State, []*snap.AppInfo, *servicestate.Instruction, *user.User, *servicestate.Flags, *hookstate.Context) ([]*state.TaskSet, error)) (restore func()) {
 	old := servicestateControl
 	servicestateControl = f
 	return func() { servicestateControl = old }

--- a/overlord/hookstate/ctlcmd/helpers.go
+++ b/overlord/hookstate/ctlcmd/helpers.go
@@ -143,7 +143,7 @@ func runServiceCommand(context *hookstate.Context, inst *servicestate.Instructio
 	flags := &servicestate.Flags{CreateExecCommandTasks: true}
 	// passing context so we can ignore self-conflicts with the current change
 	st.Lock()
-	tts, err := servicestateControl(st, appInfos, inst, flags, context)
+	tts, err := servicestateControl(st, appInfos, inst, nil, flags, context)
 	st.Unlock()
 	if err != nil {
 		return err

--- a/overlord/hookstate/ctlcmd/services_test.go
+++ b/overlord/hookstate/ctlcmd/services_test.go
@@ -22,6 +22,7 @@ package ctlcmd_test
 import (
 	"context"
 	"fmt"
+	"os/user"
 	"sort"
 
 	. "gopkg.in/check.v1"
@@ -138,7 +139,7 @@ apps:
 `
 
 func mockServiceChangeFunc(testServiceControlInputs func(appInfos []*snap.AppInfo, inst *servicestate.Instruction)) func() {
-	return ctlcmd.MockServicestateControlFunc(func(st *state.State, appInfos []*snap.AppInfo, inst *servicestate.Instruction, flags *servicestate.Flags, context *hookstate.Context) ([]*state.TaskSet, error) {
+	return ctlcmd.MockServicestateControlFunc(func(st *state.State, appInfos []*snap.AppInfo, inst *servicestate.Instruction, cu *user.User, flags *servicestate.Flags, context *hookstate.Context) ([]*state.TaskSet, error) {
 		testServiceControlInputs(appInfos, inst)
 		return nil, fmt.Errorf("forced error")
 	})

--- a/overlord/servicestate/servicestate.go
+++ b/overlord/servicestate/servicestate.go
@@ -20,9 +20,11 @@
 package servicestate
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"os/user"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -42,12 +44,187 @@ import (
 	"github.com/snapcore/snapd/wrappers"
 )
 
+type UserSelection int
+
+const (
+	UserSelectionList UserSelection = iota
+	UserSelectionSelf
+	UserSelectionAll
+)
+
+// UserSelector is a support structure for correctly translating a way of
+// representing both a list of user-names, and specific keywords like "self"
+// and "all" for JSON marshalling.
+//
+// When "Selector == UserSelectionList" then Names is used as the data source and
+// the data is treated like a list of strings.
+// When "Selector == UserSelectionSelf|UserSelectionAll", then the data source will
+// be a single string that represent this in the form of "self|all".
+type UserSelector struct {
+	Names    []string
+	Selector UserSelection
+}
+
+// UserList returns a decoded list of users which takes any keyword into account.
+// Takes the current user to be able to handle special keywords like 'user'.
+func (us *UserSelector) UserList(currentUser *user.User) ([]string, error) {
+	switch us.Selector {
+	case UserSelectionList:
+		return us.Names, nil
+	case UserSelectionSelf:
+		if currentUser == nil {
+			return nil, fmt.Errorf("internal error: for \"self\" the current user must be provided")
+		}
+		if currentUser.Uid == "0" {
+			return nil, fmt.Errorf("cannot use \"self\" for root user")
+		}
+		return []string{currentUser.Username}, nil
+	case UserSelectionAll:
+		// Empty list indicates all.
+		return nil, nil
+	}
+	return nil, fmt.Errorf("internal error: unsupported selector %d specified", us.Selector)
+}
+
+func (us UserSelector) MarshalJSON() ([]byte, error) {
+	switch us.Selector {
+	case UserSelectionList:
+		return json.Marshal(us.Names)
+	case UserSelectionSelf:
+		return json.Marshal("self")
+	case UserSelectionAll:
+		return json.Marshal("all")
+	default:
+		return nil, fmt.Errorf("internal error: unsupported selector %d specified", us.Selector)
+	}
+}
+
+func (us *UserSelector) UnmarshalJSON(b []byte) error {
+	// Try treating it as a list of usernames first
+	var users []string
+	if err := json.Unmarshal(b, &users); err == nil {
+		us.Names = users
+		us.Selector = UserSelectionList
+		return nil
+	}
+
+	// Fallback to string, which would indicate a keyword
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return fmt.Errorf("cannot unmarshal, expected a string or a list of strings")
+	}
+
+	switch s {
+	case "self":
+		us.Selector = UserSelectionSelf
+	case "all":
+		us.Selector = UserSelectionAll
+	default:
+		return fmt.Errorf(`cannot unmarshal, expected one of: "self", "all"`)
+	}
+	return nil
+}
+
+type ScopeSelector wrappers.ServiceScope
+
+func (ss *ScopeSelector) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return fmt.Errorf("cannot unmarshal, expected a string")
+	}
+
+	// XXX: Currently this will not allow non-root users to target both
+	// user/system daemons at once. Unless we do a similar trick like
+	// UserSelector or introduce a specific "all" so we can keep distinguishing
+	// between not-set and all.
+	switch s {
+	case "":
+		*ss = ScopeSelector(wrappers.ServiceScopeAll)
+	case "system":
+		*ss = ScopeSelector(wrappers.ServiceScopeSystem)
+	case "user":
+		*ss = ScopeSelector(wrappers.ServiceScopeUser)
+	default:
+		return fmt.Errorf(`cannot unmarshal, expected one of: "system", "user"`)
+	}
+	return nil
+}
+
 type Instruction struct {
-	Action string   `json:"action"`
-	Names  []string `json:"names"`
+	Action string        `json:"action"`
+	Names  []string      `json:"names"`
+	Scope  ScopeSelector `json:"scope"`
+	Users  UserSelector  `json:"users"`
 	client.StartOptions
 	client.StopOptions
 	client.RestartOptions
+}
+
+func (i *Instruction) ServiceScope() wrappers.ServiceScope {
+	return wrappers.ServiceScope(i.Scope)
+}
+
+func (i *Instruction) hasUserService(apps []*snap.AppInfo) bool {
+	for _, app := range apps {
+		if app.IsService() && app.DaemonScope == snap.UserDaemon {
+			return true
+		}
+	}
+	return false
+}
+
+// EnsureDefaultScopeForUser sets up default scopes based on the type of user
+// if none were provided.
+// Make sure to call Instruction.Validate() before calling this.
+func (i *Instruction) EnsureDefaultScopeForUser(u *user.User) {
+	// Set default scopes if not provided
+	if i.Scope == ScopeSelector(wrappers.ServiceScopeAll) {
+		// If non-root imply the service scope only to keep in line with backwards compatibility
+		if u.Uid != "0" {
+			i.Scope = ScopeSelector(wrappers.ServiceScopeSystem)
+		}
+	}
+}
+
+func (i *Instruction) validateScope(u *user.User, apps []*snap.AppInfo) error {
+	if i.Scope == ScopeSelector(wrappers.ServiceScopeAll) {
+		// Providing no scope is only an issue for non-root users if the
+		// target is user-daemons.
+		if u.Uid != "0" && i.hasUserService(apps) {
+			return fmt.Errorf("non-root users must specify service scope when targeting user services")
+		}
+	}
+	return nil
+}
+
+func (i *Instruction) validateUsers(u *user.User, apps []*snap.AppInfo) error {
+	users, err := i.Users.UserList(u)
+	if err != nil {
+		return err
+	}
+
+	// Perform some additional user checks
+	if len(users) == 0 {
+		// It is an error for a non-root to not specify any users if we are targeting
+		// user daemons
+		if u.Uid != "0" && i.hasUserService(apps) {
+			return fmt.Errorf("non-root users must specify users when targeting user services")
+		}
+	}
+	return nil
+}
+
+// Validate validates the some of the data members in the Instruction. Currently
+// this validates user-list and scope. This should only be called once when the structure
+// is initialized/deserialized.
+func (i *Instruction) Validate(u *user.User, apps []*snap.AppInfo) error {
+	if err := i.validateScope(u, apps); err != nil {
+		return err
+	}
+	if err := i.validateUsers(u, apps); err != nil {
+		return err
+	}
+	return nil
 }
 
 type ServiceActionConflictError struct{ error }
@@ -75,7 +252,7 @@ func computeExplicitServices(appInfos []*snap.AppInfo, names []string) map[strin
 }
 
 // serviceControlTs creates "service-control" task for every snap derived from appInfos.
-func serviceControlTs(st *state.State, appInfos []*snap.AppInfo, inst *Instruction) (*state.TaskSet, error) {
+func serviceControlTs(st *state.State, appInfos []*snap.AppInfo, inst *Instruction, cu *user.User) (*state.TaskSet, error) {
 	servicesBySnap := make(map[string][]string, len(appInfos))
 	explicitServices := computeExplicitServices(appInfos, inst.Names)
 	sortedNames := make([]string, 0, len(appInfos))
@@ -101,7 +278,18 @@ func serviceControlTs(st *state.State, appInfos []*snap.AppInfo, inst *Instructi
 			return nil, err
 		}
 
-		cmd := &ServiceAction{SnapName: snapName}
+		users, err := inst.Users.UserList(cu)
+		if err != nil {
+			return nil, err
+		}
+
+		cmd := &ServiceAction{
+			SnapName: snapName,
+			ScopeOptions: wrappers.ScopeOptions{
+				Scope: inst.ServiceScope(),
+				Users: users,
+			},
+		}
 		switch {
 		case inst.Action == "start":
 			cmd.Action = "start"
@@ -167,7 +355,7 @@ type Flags struct {
 // The appInfos and inst define the services and the command to execute.
 // Context is used to determine change conflicts - we will not conflict with
 // tasks from same change as that of context's.
-func Control(st *state.State, appInfos []*snap.AppInfo, inst *Instruction, flags *Flags, context *hookstate.Context) ([]*state.TaskSet, error) {
+func Control(st *state.State, appInfos []*snap.AppInfo, inst *Instruction, cu *user.User, flags *Flags, context *hookstate.Context) ([]*state.TaskSet, error) {
 	var tts []*state.TaskSet
 	var ctlcmds []string
 
@@ -237,7 +425,7 @@ func Control(st *state.State, appInfos []*snap.AppInfo, inst *Instruction, flags
 
 	// XXX: serviceControlTs could be merged with above logic at the cost of
 	// slightly more complicated logic.
-	ts, err := serviceControlTs(st, appInfos, inst)
+	ts, err := serviceControlTs(st, appInfos, inst, cu)
 	if err != nil {
 		return nil, err
 	}

--- a/overlord/servicestate/servicestate.go
+++ b/overlord/servicestate/servicestate.go
@@ -215,13 +215,8 @@ func (i *Instruction) validateScope(u *user.User, apps []*snap.AppInfo) error {
 }
 
 func (i *Instruction) validateUsers(u *user.User, apps []*snap.AppInfo) error {
-	users, err := i.Users.UserList(u)
-	if err != nil {
-		return err
-	}
-
 	// Perform some additional user checks
-	if len(users) == 0 {
+	if i.Users.Selector == UserSelectionList && len(i.Users.Names) == 0 {
 		// It is an error for a non-root to not specify any users if we are targeting
 		// user daemons
 		if u.Uid != "0" && i.hasUserService(apps) {

--- a/overlord/servicestate/servicestate_test.go
+++ b/overlord/servicestate/servicestate_test.go
@@ -538,6 +538,15 @@ func (s *instructionSuite) TestValidateNoUsersForNonRootOnlySystemServicesHappy(
 	c.Check(inst.Validate(s.defaultUser, s.systemServices), IsNil)
 }
 
+func (s *instructionSuite) TestValidateAllUsersForNonRootHappy(c *C) {
+	// Provide scopes to avoid hitting any checks in validateScope
+	inst := &servicestate.Instruction{
+		Scope: servicestate.ScopeSelector{"system", "user"},
+		Users: servicestate.UserSelector{Selector: servicestate.UserSelectionAll},
+	}
+	c.Check(inst.Validate(s.defaultUser, s.mixServices), IsNil)
+}
+
 func (s *instructionSuite) TestValidateNoUsersForNonRootMixServicesFails(c *C) {
 	// Provide scopes to avoid hitting any checks in validateScope
 	inst := &servicestate.Instruction{Scope: servicestate.ScopeSelector{"system", "user"}}

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -81,10 +81,10 @@ var killWait = 5 * time.Second
 type ScopeOptions struct {
 	// Scope determines the types of services affected. This can be either
 	// or both of system services and user services.
-	Scope ServiceScope
+	Scope ServiceScope `json:"scope,omitempty"`
 	// Users if set, determines which users the operation should include, if
 	// the scope includes user services.
-	Users []string
+	Users []string `json:"users,omitempty"`
 }
 
 type userServiceClient struct {


### PR DESCRIPTION
Implements support for scopes and users in the API for service control.

Next parts:
Support for querying user daemons in servicestate: https://github.com/snapcore/snapd/pull/13380
Support for --user/--users/--system in cli: https://github.com/snapcore/snapd/pull/13367 + https://github.com/snapcore/snapd/pull/13368 + https://github.com/snapcore/snapd/pull/13381