### PR TITLE
many: introduce and use snap.SelfContainedSetPrereqTracker

### DIFF
--- a/image/image_test.go
+++ b/image/image_test.go
@@ -2800,7 +2800,8 @@ func (s *imageSuite) TestSetupSeedMissingContentProvider(c *C) {
 	}
 
 	err := image.SetupSeed(s.tsto, model, opts)
-	c.Check(err, ErrorMatches, `prerequisites need to be added explicitly: cannot use snap "snap-req-content-provider": default provider "gtk-common-themes" is missing`)
+	// XXX content is empty because we disable SanitizePlugsSlots
+	c.Check(err, ErrorMatches, `prerequisites need to be added explicitly: cannot use snap "snap-req-content-provider": default provider "gtk-common-themes" or any alternative provider for content "" is missing`)
 }
 
 func (s *imageSuite) TestSetupSeedClassic(c *C) {

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/snapcore/snapd/bootloader/bootloadertest"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/assertstate"
@@ -1679,6 +1680,103 @@ snaps:
 	c.Check(hasConn, Equals, true)
 	c.Check(conn.(map[string]interface{})["auto"], Equals, true)
 	c.Check(conn.(map[string]interface{})["interface"], Equals, "content")
+}
+
+func (s *firstBoot16Suite) TestPopulateFromSeedAlternativeContentProviderAndOrder(c *C) {
+	logbuf, restore := logger.MockLogger()
+	defer restore()
+
+	bloader := boottest.MockUC16Bootenv(bootloadertest.Mock("mock", c.MkDir()))
+	bootloader.Force(bloader)
+	defer bootloader.Force(nil)
+	bloader.SetBootKernel("pc-kernel_1.snap")
+	bloader.SetBootBase("core_1.snap")
+
+	coreFname, kernelFname, gadgetFname := s.makeCoreSnaps(c, "")
+
+	// a snap that uses content providers
+	snapYaml := `name: gnome-calculator
+version: 1.0
+plugs:
+ gtk-3-themes:
+  interface: content
+  default-provider: gtk-common-themes
+  target: $SNAP/data-dir/themes
+`
+	calcFname, calcDecl, calcRev := s.MakeAssertedSnap(c, snapYaml, nil, snap.R(128), "developerid")
+	s.WriteAssertions("calc.asserts", s.devAcct, calcRev, calcDecl)
+
+	// put a 2nd firstboot snap into the SnapBlobDir
+	snapYaml = `name: gtk-common-themes-alt
+version: 1.0
+slots:
+ gtk-3-themes:
+  interface: content
+  source:
+   read:
+    - $SNAP/share/themes/Adawaita
+`
+	themesFname, themesDecl, themesRev := s.MakeAssertedSnap(c, snapYaml, nil, snap.R(65), "developerid")
+	s.WriteAssertions("themes.asserts", s.devAcct, themesDecl, themesRev)
+
+	// add a model assertion and its chain
+	assertsChain := s.makeModelAssertionChain(c, "my-model", nil)
+	s.WriteAssertions("model.asserts", assertsChain...)
+
+	// create a seed.yaml
+	content := []byte(fmt.Sprintf(`
+snaps:
+ - name: core
+   file: %s
+ - name: pc-kernel
+   file: %s
+ - name: pc
+   file: %s
+ - name: gnome-calculator
+   file: %s
+ - name: gtk-common-themes-alt
+   file: %s
+`, coreFname, kernelFname, gadgetFname, calcFname, themesFname))
+	err := os.WriteFile(filepath.Join(dirs.SnapSeedDir, "seed.yaml"), content, 0644)
+	c.Assert(err, IsNil)
+
+	// run the firstboot stuff
+	s.startOverlord(c)
+	st := s.overlord.State()
+	st.Lock()
+	defer st.Unlock()
+
+	tsAll, err := devicestate.PopulateStateFromSeedImpl(s.overlord.DeviceManager(), s.perfTimings)
+	c.Assert(err, IsNil)
+	// use the expected kind otherwise settle with start another one
+	chg := st.NewChange("seed", "run the populate from seed changes")
+	for _, ts := range tsAll {
+		chg.AddAll(ts)
+	}
+	c.Assert(st.Changes(), HasLen, 1)
+
+	// avoid device reg
+	chg1 := st.NewChange("become-operational", "init device")
+	chg1.SetStatus(state.DoingStatus)
+
+	st.Unlock()
+	err = s.overlord.Settle(settleTimeout)
+	st.Lock()
+
+	c.Assert(chg.Err(), IsNil)
+	c.Assert(err, IsNil)
+
+	// verify the result
+	var conns map[string]interface{}
+	err = st.Get("conns", &conns)
+	c.Assert(err, IsNil)
+	c.Check(conns, HasLen, 1)
+	conn, hasConn := conns["gnome-calculator:gtk-3-themes gtk-common-themes-alt:gtk-3-themes"]
+	c.Check(hasConn, Equals, true)
+	c.Check(conn.(map[string]interface{})["auto"], Equals, true)
+	c.Check(conn.(map[string]interface{})["interface"], Equals, "content")
+
+	c.Check(logbuf.String(), Matches, `(?sm).*seed prerequisites: snap "gnome-calculator" requires a provider for content "gtk-3-themes", a candidate slot is available \(gtk-common-themes-alt:gtk-3-themes\) but not the default-provider, ensure a single auto-connection \(or possibly a connection\) is in-place.*`)
 }
 
 func (s *firstBoot16Suite) TestPopulateFromSeedMissingBase(c *C) {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -973,13 +973,13 @@ func IsErrAndNotWait(err error) bool {
 
 // defaultProviderContentAttrs takes a snap.Info and returns a map of
 // default providers to the value of content attributes they should
-// provide. Content attributes already provided by a snap in the system are omitted.
+// provide. Content attributes already provided by a snap in the system are omitted. What is returned depends on the behavior of the passed PrereqTracker.
 func defaultProviderContentAttrs(st *state.State, info *snap.Info, prqt PrereqTracker) map[string][]string {
 	if prqt == nil {
 		prqt = snap.SimplePrereqTracker{}
 	}
 	repo := ifacerepo.Get(st)
-	return prqt.DefaultProviderContentAttrs(info, repo)
+	return prqt.MissingProviderContentTags(info, repo)
 }
 
 func getKeys(kv map[string][]string) []string {
@@ -1100,15 +1100,19 @@ func ensureInstallPreconditions(st *state.State, info *snap.Info, flags Flags, s
 type PrereqTracker interface {
 	// Add adds a snap for tracking.
 	Add(*snap.Info)
-	// DefaultProviderContentAttrs returns a map keyed by the names of all
-	// default-providers for the content plugs that the given snap.Info
-	// needs. The map values are the corresponding content tags.
-	// If repo is not nil, any content tag provided by an existing slot in
-	// it is considered already available and filtered out from the result.
-	// info might or might have not been passed already to Add.
-	// snapstate uses the result to decide to install providers
-	// automatically.
-	DefaultProviderContentAttrs(info *snap.Info, repo snap.InterfaceRepo) map[string][]string
+	// MissingProviderContetTags returns a map keyed by the names of all
+	// missing default-providers for the content plugs that the given
+	// snap.Info needs. The map values are the corresponding content tags.
+	// Different prerequisites trackers might decide in different
+	// ways which providers are missing. Either making assumptions about
+	// the snap operations that are being set up or considering
+	// just the snap info and repo.
+	// In the latter case if repo is not nil, any content tag provided by
+	// an existing slot in it should be considered already available and
+	// filtered out from the result. info might or might have not been
+	// passed already to Add. snapstate uses the result to decide to
+	// install providers automatically.
+	MissingProviderContentTags(info *snap.Info, repo snap.InterfaceRepo) map[string][]string
 }
 
 // addPrereq adds the given prerequisite snap to the tracker, if the tracker is

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1094,9 +1094,11 @@ type PrereqTracker interface {
 	// DefaultProviderContentAttrs returns a map keyed by the names of all
 	// default-providers for the content plugs that the given snap.Info
 	// needs. The map values are the corresponding content tags.
-	// If repo is not nil, any content tag provided by an existing slot in it
-	// is considered already available and filtered out from the result.
+	// If repo is not nil, any content tag provided by an existing slot in
+	// it is considered already available and filtered out from the result.
 	// info might or might have not been passed already to Add.
+	// snapstate uses the result to decide to install providers
+	// automatically.
 	DefaultProviderContentAttrs(info *snap.Info, repo snap.InterfaceRepo) map[string][]string
 }
 

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -363,7 +363,7 @@ func (s *snapmgrTestSuite) TestInstallWithDeviceContext(c *C) {
 
 	c.Assert(prqt.infos, HasLen, 1)
 	c.Check(prqt.infos[0].SnapName(), Equals, "some-snap")
-	c.Check(prqt.defaultProviderContentAttrsCalls, Equals, 1)
+	c.Check(prqt.missingProviderContentTagsCalls, Equals, 1)
 }
 
 func (s *snapmgrTestSuite) TestInstallPathWithDeviceContext(c *C) {
@@ -391,7 +391,7 @@ version: 1.0
 
 	c.Assert(prqt.infos, HasLen, 1)
 	c.Check(prqt.infos[0].SnapName(), Equals, "some-snap")
-	c.Check(prqt.defaultProviderContentAttrsCalls, Equals, 1)
+	c.Check(prqt.missingProviderContentTagsCalls, Equals, 1)
 }
 
 func (s *snapmgrTestSuite) TestInstallPathWithDeviceContextBadFile(c *C) {
@@ -2116,7 +2116,7 @@ version: 1.0`)
 
 	c.Assert(prqt.infos, HasLen, 1)
 	c.Check(prqt.infos[0], DeepEquals, info)
-	c.Check(prqt.defaultProviderContentAttrsCalls, Equals, 1)
+	c.Check(prqt.missingProviderContentTagsCalls, Equals, 1)
 
 	chg.AddAll(ts)
 

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -4257,20 +4257,20 @@ func (s *snapmgrTestSuite) TestUpdateWithDeviceContext(c *C) {
 
 	c.Assert(prqt.infos, HasLen, 1)
 	c.Check(prqt.infos[0].SnapName(), Equals, "some-snap")
-	c.Check(prqt.defaultProviderContentAttrsCalls, Equals, 1)
+	c.Check(prqt.missingProviderContentTagsCalls, Equals, 1)
 }
 
 type testPrereqTracker struct {
-	infos                            []*snap.Info
-	defaultProviderContentAttrsCalls int
+	infos                           []*snap.Info
+	missingProviderContentTagsCalls int
 }
 
 func (prqt *testPrereqTracker) Add(info *snap.Info) {
 	prqt.infos = append(prqt.infos, info)
 }
 
-func (prqt *testPrereqTracker) DefaultProviderContentAttrs(*snap.Info, snap.InterfaceRepo) map[string][]string {
-	prqt.defaultProviderContentAttrsCalls++
+func (prqt *testPrereqTracker) MissingProviderContentTags(*snap.Info, snap.InterfaceRepo) map[string][]string {
+	prqt.missingProviderContentTagsCalls++
 	return nil
 }
 
@@ -4306,7 +4306,7 @@ version: 1.0
 	c.Assert(s.state.TaskCount(), Equals, len(ts.Tasks()))
 	c.Assert(prqt.infos, HasLen, 1)
 	c.Check(prqt.infos[0].SnapName(), Equals, "some-snap")
-	c.Check(prqt.defaultProviderContentAttrsCalls, Equals, 1)
+	c.Check(prqt.missingProviderContentTagsCalls, Equals, 1)
 }
 
 func (s *snapmgrTestSuite) TestUpdatePathWithDeviceContextSwitchChannel(c *C) {

--- a/seed/seedwriter/writer.go
+++ b/seed/seedwriter/writer.go
@@ -1280,7 +1280,7 @@ func (w *Writer) checkPrereqsInMode(mode string) error {
 	warns, errs := snap.ValidateBasesAndProviders(snaps)
 	if errs != nil {
 		var errPrefix string
-		// XXX do better in terms of error structuring
+		// XXX TODO: return an error that subsumes all the errors
 		if mode == "run" {
 			errPrefix = "prerequisites need to be added explicitly"
 		} else {

--- a/seed/seedwriter/writer.go
+++ b/seed/seedwriter/writer.go
@@ -1277,7 +1277,8 @@ func (w *Writer) checkPrereqsInMode(mode string) error {
 	for _, sn := range w.byModeSnaps[mode] {
 		snaps = append(snaps, sn.Info)
 	}
-	if errs := snap.ValidateBasesAndProviders(snaps); errs != nil {
+	warns, errs := snap.ValidateBasesAndProviders(snaps)
+	if errs != nil {
 		var errPrefix string
 		// XXX do better in terms of error structuring
 		if mode == "run" {
@@ -1286,6 +1287,13 @@ func (w *Writer) checkPrereqsInMode(mode string) error {
 			errPrefix = fmt.Sprintf("prerequisites need to be added explicitly for relevant mode %s", mode)
 		}
 		return fmt.Errorf("%s: %v", errPrefix, errs[0])
+	}
+	wfmt := "%v"
+	if mode != "run" {
+		wfmt = fmt.Sprintf("prerequisites for mode %s: %%v", mode)
+	}
+	for _, warn := range warns {
+		w.warningf(wfmt, warn)
 	}
 	return nil
 }

--- a/seed/validate.go
+++ b/seed/validate.go
@@ -124,7 +124,8 @@ func ValidateFromYaml(seedYamlFile string) error {
 		return nil
 	})
 
-	if errs2 := snap.ValidateBasesAndProviders(snapInfos); errs2 != nil {
+	// TODO: surface the warnings too, like we do for snap container checks
+	if _, errs2 := snap.ValidateBasesAndProviders(snapInfos); errs2 != nil {
 		ve.addErr("", errs2...)
 	}
 	if ve.hasErrors() {

--- a/seed/validate_test.go
+++ b/seed/validate_test.go
@@ -28,6 +28,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/seed"
 	"github.com/snapcore/snapd/seed/seedtest"
 	"github.com/snapcore/snapd/snap"
@@ -61,7 +62,7 @@ type: base
 
 func (s *validateSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
-	s.BaseTest.AddCleanup(snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {}))
+	s.BaseTest.AddCleanup(snap.MockSanitizePlugsSlots(builtin.SanitizePlugsSlots))
 
 	s.TestingSeed16 = &seedtest.TestingSeed16{}
 	s.SetupAssertSigning("canonical")
@@ -146,6 +147,7 @@ plugs:
  gtk-3-themes:
   interface: content
   default-provider: gtk-common-themes
+  target: $SNAP/themes
 `)
 	seedFn := s.makeSeedYaml(c, `
 snaps:
@@ -157,7 +159,7 @@ snaps:
 
 	err := seed.ValidateFromYaml(seedFn)
 	c.Assert(err, ErrorMatches, `cannot validate seed:
- - cannot use snap "need-df": default provider "gtk-common-themes" is missing`)
+ - cannot use snap "need-df": default provider "gtk-common-themes" or any alternative provider for content "gtk-3-themes" is missing`)
 }
 
 func (s *validateSuite) TestValidateFromYamlSnapSnapdHappy(c *C) {
@@ -291,6 +293,7 @@ plugs:
  gtk-3-themes:
   interface: content
   default-provider: gtk-common-themes
+  target: $SNAP/themes
 `)
 
 	// "version" is missing in this yaml
@@ -316,7 +319,7 @@ snaps:
 	err = seed.ValidateFromYaml(seedFn)
 	c.Assert(err, ErrorMatches, `cannot validate seed:
  - cannot use snap "/.*/snaps/some-snap-invalid-yaml_1.snap": invalid snap version: cannot be empty
- - cannot use snap "need-df": default provider "gtk-common-themes" is missing`)
+ - cannot use snap "need-df": default provider "gtk-common-themes" or any alternative provider for content "gtk-3-themes" is missing`)
 }
 
 func (s *validateSuite) TestValidateFromYamlSnapSnapMissing(c *C) {

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -1147,12 +1147,12 @@ func (SimplePrereqTracker) Add(*Info) {
 	// SimplePrereqTracker is stateless, nothing to do.
 }
 
-// DefaultProviderContentAttrs returns a map keyed by the names of all
+// MissingProviderContentTags returns a map keyed by the names of all
 // default-providers for the content plugs that the given snap.Info
 // needs. The map values are the corresponding content tags.
 // If repo is not nil, any content tag provided by an existing slot in it
 // is considered already available and filtered out from the result.
-func (SimplePrereqTracker) DefaultProviderContentAttrs(info *Info, repo InterfaceRepo) map[string][]string {
+func (SimplePrereqTracker) MissingProviderContentTags(info *Info, repo InterfaceRepo) map[string][]string {
 	availTags := contentIfaceAvailable(repo)
 	providerSnapsToContentTag := make(map[string][]string)
 	for _, plug := range info.Plugs {
@@ -1185,7 +1185,7 @@ func contentIfaceAvailable(repo InterfaceRepo) map[string]bool {
 // XXX TODO: switch away from using/needing this in favor of the prereq
 // trackers.
 func NeededDefaultProviders(info *Info) (providerSnapsToContentTag map[string][]string) {
-	return (SimplePrereqTracker{}).DefaultProviderContentAttrs(info, nil)
+	return (SimplePrereqTracker{}).MissingProviderContentTags(info, nil)
 }
 
 // SelfContainedPrereqTracker is a stateful helper to track
@@ -1215,11 +1215,11 @@ func (prqt *SelfContainedSetPrereqTracker) Add(info *Info) {
 	}
 }
 
-// DefaultProviderContentAttrs implements snapstate.PrereqTracker.
+// MissingProviderContentTags implements snapstate.PrereqTracker.
 // Given how snapstate uses this and as SelfContainedSetPrereqTracker is for
 // when no automatic fetching of prerequisites is desired, this always returns
 // nil.
-func (prqt *SelfContainedSetPrereqTracker) DefaultProviderContentAttrs(info *Info, repo InterfaceRepo) map[string][]string {
+func (prqt *SelfContainedSetPrereqTracker) MissingProviderContentTags(info *Info, repo InterfaceRepo) map[string][]string {
 	return nil
 }
 

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -1223,7 +1223,7 @@ func (prqt *SelfContainedSetPrereqTracker) DefaultProviderContentAttrs(info *Inf
 	return nil
 }
 
-func analyzeContentSlot(slot *SlotInfo) (contentTag string) {
+func maybeContentSlot(slot *SlotInfo) (contentTag string) {
 	if slot.Interface != "content" {
 		return ""
 	}
@@ -1231,7 +1231,7 @@ func analyzeContentSlot(slot *SlotInfo) (contentTag string) {
 	return contentTag
 }
 
-func analyzeContentPlug(plug *PlugInfo) (contentTag, defaultProviderSnap string) {
+func maybeContentPlug(plug *PlugInfo) (contentTag, defaultProviderSnap string) {
 	if plug.Interface != "content" {
 		return "", ""
 	}
@@ -1288,7 +1288,7 @@ func (prqt *SelfContainedSetPrereqTracker) Check() (warnings, errs []error) {
 	contentSlots := make(map[string][]*SlotInfo)
 	for _, info := range prqt.snaps {
 		for _, slot := range info.Slots {
-			contentTag := analyzeContentSlot(slot)
+			contentTag := maybeContentSlot(slot)
 			if contentTag == "" {
 				continue
 			}
@@ -1312,7 +1312,7 @@ func (prqt *SelfContainedSetPrereqTracker) Check() (warnings, errs []error) {
 		// or otherwise
 		plugNames := make([]string, 0, len(info.Plugs))
 		for plugName, plug := range info.Plugs {
-			_, defaultProvider := analyzeContentPlug(plug)
+			_, defaultProvider := maybeContentPlug(plug)
 			if defaultProvider == "" {
 				continue
 			}
@@ -1321,7 +1321,7 @@ func (prqt *SelfContainedSetPrereqTracker) Check() (warnings, errs []error) {
 		sort.Strings(plugNames)
 		for _, plugName := range plugNames {
 			plug := info.Plugs[plugName]
-			wantedTag, defaultProvider := analyzeContentPlug(plug)
+			wantedTag, defaultProvider := maybeContentPlug(plug)
 			candSlots := contentSlots[wantedTag]
 			switch len(candSlots) {
 			case 0:

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -2266,7 +2266,7 @@ func (s *ValidateSuite) TestSimplePrereqTracker(c *C) {
 	repo := interfaces.NewRepository()
 
 	prqt := SimplePrereqTracker{}
-	providerContentAttrs := prqt.DefaultProviderContentAttrs(info, repo)
+	providerContentAttrs := prqt.MissingProviderContentTags(info, repo)
 	c.Check(providerContentAttrs, HasLen, 2)
 	sort.Strings(providerContentAttrs["common-themes"])
 	c.Check(providerContentAttrs["common-themes"], DeepEquals, []string{"bar", "foo"})
@@ -2285,7 +2285,7 @@ func (s *ValidateSuite) TestSimplePrereqTracker(c *C) {
 	}
 	err := repo.AddSlot(barSlot)
 	c.Assert(err, IsNil)
-	providerContentAttrs = prqt.DefaultProviderContentAttrs(info, repo)
+	providerContentAttrs = prqt.MissingProviderContentTags(info, repo)
 	c.Check(providerContentAttrs, HasLen, 2)
 	c.Check(providerContentAttrs["common-themes"], DeepEquals, []string{"foo"})
 	// stays the same
@@ -2299,14 +2299,14 @@ func (s *ValidateSuite) TestSimplePrereqTracker(c *C) {
 	}
 	err = repo.AddSlot(fooSlot)
 	c.Assert(err, IsNil)
-	providerContentAttrs = prqt.DefaultProviderContentAttrs(info, repo)
+	providerContentAttrs = prqt.MissingProviderContentTags(info, repo)
 	c.Check(providerContentAttrs, HasLen, 1)
 	c.Check(providerContentAttrs["common-themes"], IsNil)
 	// stays the same
 	c.Check(providerContentAttrs["some-snap"], DeepEquals, []string{"baz"})
 
 	// no repo => no filtering
-	providerContentAttrs = prqt.DefaultProviderContentAttrs(info, nil)
+	providerContentAttrs = prqt.MissingProviderContentTags(info, nil)
 	c.Check(providerContentAttrs, HasLen, 2)
 	sort.Strings(providerContentAttrs["common-themes"])
 	c.Check(providerContentAttrs["common-themes"], DeepEquals, []string{"bar", "foo"})
@@ -2318,7 +2318,7 @@ func (s *ValidateSuite) TestSelfContainedSetPrereqTrackerBasics(c *C) {
 	var prqt snapstate.PrereqTracker = NewSelfContainedSetPrereqTracker()
 
 	// this ignores arguments and always returns nil
-	c.Check(prqt.DefaultProviderContentAttrs(nil, nil), IsNil)
+	c.Check(prqt.MissingProviderContentTags(nil, nil), IsNil)
 }
 
 func (s *validateSuite) TestSelfContainedSetPrereqTrackerMissingBase(c *C) {

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -1973,7 +1973,12 @@ plugs:
     interface: content
     content: icon-themes
     default-provider: gtk-common-themes
-
+  other-content:
+    interface: content
+    content: other
+    # no default provider
+  # unrelated plug
+  network:
 `
 
 func (s *ValidateSuite) TestNeededDefaultProviders(c *C) {
@@ -2300,4 +2305,259 @@ func (s *ValidateSuite) TestSimplePrereqTracker(c *C) {
 	sort.Strings(providerContentAttrs["common-themes"])
 	c.Check(providerContentAttrs["common-themes"], DeepEquals, []string{"bar", "foo"})
 	c.Check(providerContentAttrs["some-snap"], DeepEquals, []string{"baz"})
+}
+
+func (s *ValidateSuite) TestSelfContainedSetPrereqTrackerBasics(c *C) {
+	// check that it implements the needed interface
+	var prqt snapstate.PrereqTracker = NewSelfContainedSetPrereqTracker()
+
+	// this ignores arguments and always returns nil
+	c.Check(prqt.DefaultProviderContentAttrs(nil, nil), IsNil)
+}
+
+func (s *validateSuite) TestSelfContainedSetPrereqTrackerMissingBase(c *C) {
+	const yaml = `name: some-snap
+base: some-base
+version: 1.0`
+
+	strk := NewScopedTracker()
+	info, err := InfoFromSnapYamlWithSideInfo([]byte(yaml), nil, strk)
+	c.Assert(err, IsNil)
+
+	prqt := NewSelfContainedSetPrereqTracker()
+	prqt.Add(info)
+
+	_, errors := prqt.Check()
+	c.Assert(errors, HasLen, 1)
+	c.Check(errors[0], ErrorMatches, `cannot use snap "some-snap": base "some-base" is missing`)
+}
+
+func (s *validateSuite) TestSelfContainedSetPrereqTrackerMissingMCore(c *C) {
+	const yaml = `name: some-snap
+version: 1.0`
+
+	strk := NewScopedTracker()
+	info, err := InfoFromSnapYamlWithSideInfo([]byte(yaml), nil, strk)
+	c.Assert(err, IsNil)
+
+	prqt := NewSelfContainedSetPrereqTracker()
+	prqt.Add(info)
+
+	_, errors := prqt.Check()
+	c.Assert(errors, HasLen, 1)
+	c.Check(errors[0], ErrorMatches, `cannot use snap "some-snap": required snap "core" missing`)
+}
+
+func (s *validateSuite) TestSelfContainedSetPrereqTrackerMissingDefaultProvider(c *C) {
+	strk := NewScopedTracker()
+	snapInfo, err := InfoFromSnapYamlWithSideInfo([]byte(yamlNeedDf), nil, strk)
+	c.Assert(err, IsNil)
+
+	const coreYaml = `name: core
+version: 1.0
+type: os`
+
+	coreInfo, err := InfoFromSnapYamlWithSideInfo([]byte(coreYaml), nil, strk)
+	c.Assert(err, IsNil)
+
+	prqt := NewSelfContainedSetPrereqTracker()
+	prqt.Add(snapInfo)
+	prqt.Add(coreInfo)
+
+	_, errors := prqt.Check()
+	c.Assert(errors, HasLen, 2)
+	c.Check(errors[0], ErrorMatches, `cannot use snap "need-df": default provider "gtk-common-themes" or any alternative provider for content "gtk-3-themes" is missing`)
+	c.Check(errors[1], ErrorMatches, `cannot use snap "need-df": default provider "gtk-common-themes" or any alternative provider for content "icon-themes" is missing`)
+}
+
+func (s *validateSuite) TestSelfContainedSetPrereqTrackerDefaultProviderHappy(c *C) {
+	strk := NewScopedTracker()
+	snapInfo, err := InfoFromSnapYamlWithSideInfo([]byte(yamlNeedDf), nil, strk)
+	c.Assert(err, IsNil)
+
+	const coreYaml = `name: core
+version: 1.0
+type: os`
+
+	coreInfo, err := InfoFromSnapYamlWithSideInfo([]byte(coreYaml), nil, strk)
+	c.Assert(err, IsNil)
+
+	const gtkCommonThemesYaml = `name: gtk-common-themes
+version: 1.0
+slots:
+  gtk-3-themes:
+    interface: content
+    read: [$SNAP/themes]
+  icon-themes:
+    interface: content
+    read: [$SNAP/themes]
+`
+	defer MockSanitizePlugsSlots(builtin.SanitizePlugsSlots)()
+
+	gtkCommonThemesInfo, err := InfoFromSnapYamlWithSideInfo([]byte(gtkCommonThemesYaml), nil, strk)
+	c.Assert(err, IsNil)
+
+	prqt := NewSelfContainedSetPrereqTracker()
+	prqt.Add(snapInfo)
+	prqt.Add(coreInfo)
+	prqt.Add(gtkCommonThemesInfo)
+
+	warns, errors := prqt.Check()
+	c.Assert(errors, HasLen, 0)
+	c.Assert(warns, HasLen, 0)
+}
+
+func (s *validateSuite) TestSelfContainedSetPrereqTrackerAlternativeProviders(c *C) {
+	strk := NewScopedTracker()
+	snapInfo, err := InfoFromSnapYamlWithSideInfo([]byte(yamlNeedDf), nil, strk)
+	c.Assert(err, IsNil)
+
+	const coreYaml = `name: core
+version: 1.0
+type: os`
+
+	coreInfo, err := InfoFromSnapYamlWithSideInfo([]byte(coreYaml), nil, strk)
+	c.Assert(err, IsNil)
+
+	const iconsProviderYaml = `name: icons-provider
+version: 1.0
+slots:
+  serve-icon-themes:
+    interface: content
+    content: icon-themes
+`
+	const themesProviderYaml = `name: themes-provider
+version: 1.0
+slots:
+  serve-gtk-3-themes:
+    interface: content
+    content: gtk-3-themes
+`
+	iconsProviderInfo, err := InfoFromSnapYamlWithSideInfo([]byte(iconsProviderYaml), nil, strk)
+	c.Assert(err, IsNil)
+	themesProviderInfo, err := InfoFromSnapYamlWithSideInfo([]byte(themesProviderYaml), nil, strk)
+	c.Assert(err, IsNil)
+
+	prqt := NewSelfContainedSetPrereqTracker()
+	prqt.Add(snapInfo)
+	prqt.Add(coreInfo)
+	prqt.Add(iconsProviderInfo)
+	prqt.Add(themesProviderInfo)
+
+	warns, errors := prqt.Check()
+	c.Assert(errors, HasLen, 0)
+	c.Assert(warns, HasLen, 2)
+	c.Check(warns[0], ErrorMatches, `snap "need-df" requires a provider for content "gtk-3-themes", a candidate slot is available \(themes-provider:serve-gtk-3-themes\) but not the default-provider, ensure a single auto-connection \(or possibly a connection\) is in-place`)
+	c.Check(warns[1], ErrorMatches, `snap "need-df" requires a provider for content "icon-themes", a candidate slot is available \(icons-provider:serve-icon-themes\) but not the default-provider, ensure a single auto-connection \(or possibly a connection\) is in-place`)
+}
+
+func (s *validateSuite) TestSelfContainedSetPrereqTrackerDefaultProviderAlternativeProvider(c *C) {
+	strk := NewScopedTracker()
+	snapInfo, err := InfoFromSnapYamlWithSideInfo([]byte(yamlNeedDf), nil, strk)
+	c.Assert(err, IsNil)
+
+	const coreYaml = `name: core
+version: 1.0
+type: os`
+
+	coreInfo, err := InfoFromSnapYamlWithSideInfo([]byte(coreYaml), nil, strk)
+	c.Assert(err, IsNil)
+
+	const gtkCommonThemesYaml = `name: gtk-common-themes
+version: 1.0
+slots:
+  gtk-3-themes:
+    interface: content
+    read: [$SNAP/themes]
+  icon-themes:
+    interface: content
+    read: [$SNAP/themes]
+`
+	const themesProvider2Yaml = `name: themes-provider
+version: 1.0
+slots:
+  serve-gtk-3-themes:
+    interface: content
+    content: gtk-3-themes
+    read: [$SNAP/stuff]
+`
+	defer MockSanitizePlugsSlots(builtin.SanitizePlugsSlots)()
+
+	gtkCommonThemesInfo, err := InfoFromSnapYamlWithSideInfo([]byte(gtkCommonThemesYaml), nil, strk)
+	c.Assert(err, IsNil)
+	themesProvider2Info, err := InfoFromSnapYamlWithSideInfo([]byte(themesProvider2Yaml), nil, strk)
+	c.Assert(err, IsNil)
+
+	prqt := NewSelfContainedSetPrereqTracker()
+	prqt.Add(snapInfo)
+	prqt.Add(coreInfo)
+	prqt.Add(gtkCommonThemesInfo)
+	prqt.Add(themesProvider2Info)
+
+	warns, errors := prqt.Check()
+	c.Assert(errors, HasLen, 0)
+	c.Assert(warns, HasLen, 1)
+	c.Check(warns[0], ErrorMatches, `snap "need-df" requires a provider for content "gtk-3-themes", many candidates slots are available \(themes-provider:serve-gtk-3-themes\) including from default-provider gtk-common-themes:gtk-3-themes, ensure a single auto-connection \(or possibly a connection\) is in-place`)
+}
+
+func (s *validateSuite) TestSelfContainedSetPrereqTrackerDoubleAlternativeProviders(c *C) {
+	strk := NewScopedTracker()
+	snapInfo, err := InfoFromSnapYamlWithSideInfo([]byte(yamlNeedDf), nil, strk)
+	c.Assert(err, IsNil)
+
+	const coreYaml = `name: core
+version: 1.0
+type: os`
+
+	coreInfo, err := InfoFromSnapYamlWithSideInfo([]byte(coreYaml), nil, strk)
+	c.Assert(err, IsNil)
+
+	const iconsProviderYaml = `name: icons-provider
+version: 1.0
+slots:
+  serve-icon-themes:
+    interface: content
+    content: icon-themes
+    read: [$SNAP/stuff]
+`
+	const themesProviderYaml = `name: themes-provider
+version: 1.0
+slots:
+  serve-gtk-3-themes:
+    interface: content
+    content: gtk-3-themes
+    read: [$SNAP/stuff]
+`
+	const themesProvider2Yaml = `name: themes-provider2
+version: 1.1
+slots:
+  gtk-3-themes:
+    interface: content
+    read: [$SNAP/stuff]
+  unrelated-slot:
+    interface: dbus
+    bus: system
+    name: foo.Foo
+`
+	defer MockSanitizePlugsSlots(builtin.SanitizePlugsSlots)()
+
+	iconsProviderInfo, err := InfoFromSnapYamlWithSideInfo([]byte(iconsProviderYaml), nil, strk)
+	c.Assert(err, IsNil)
+	themesProviderInfo, err := InfoFromSnapYamlWithSideInfo([]byte(themesProviderYaml), nil, strk)
+	c.Assert(err, IsNil)
+	themesProvider2Info, err := InfoFromSnapYamlWithSideInfo([]byte(themesProvider2Yaml), nil, strk)
+	c.Assert(err, IsNil)
+
+	prqt := NewSelfContainedSetPrereqTracker()
+	prqt.Add(snapInfo)
+	prqt.Add(coreInfo)
+	prqt.Add(iconsProviderInfo)
+	prqt.Add(themesProviderInfo)
+	prqt.Add(themesProvider2Info)
+
+	warns, errors := prqt.Check()
+	c.Assert(errors, HasLen, 0)
+	c.Assert(warns, HasLen, 2)
+	c.Check(warns[0], ErrorMatches, `snap "need-df" requires a provider for content "gtk-3-themes", many candidate slots are available \(themes-provider2:gtk-3-themes, themes-provider:serve-gtk-3-themes\) but not the default-provider, ensure a single auto-connection \(or possibly a connection\) is in-place`)
+	c.Check(warns[1], ErrorMatches, `snap "need-df" requires a provider for content "icon-themes", a candidate slot is available \(icons-provider:serve-icon-themes\) but not the default-provider, ensure a single auto-connection \(or possibly a connection\) is in-place`)
 }


### PR DESCRIPTION
also in snap.ValidateBasesAndProviders

these now can produce warnings, OTOH the relaxed checks allow to build/seed an
image even if a content requirement is fulfilled by an alternative provider

notice that with the relaxed checks seeding might fail or the system not work
if the right auto-connections or connections are not in-place

snaps used as default-providers usually have been taken care of already but it
might be up to the user to ask to set that up for alternative ones