### PR TITLE
tests/main/postrm-purge: make check units more robust

### DIFF
--- a/tests/main/postrm-purge/task.yaml
+++ b/tests/main/postrm-purge/task.yaml
@@ -108,7 +108,7 @@ execute: |
     fi
 
     # Check no snapd services are listed
-    systemctl -l | NOMATCH "snapd\."
+    systemctl list-units --legend=no "snapd.*" | NOMATCH "loaded"
 
     echo "No dangling service symlinks are left behind"
     test -z "$(find /etc/systemd/system/multi-user.target.wants/ -name 'snap.test-snapd-service.*')"


### PR DESCRIPTION
If a unit not from snapd depends on a snapd units (e.g. with After=), the unit will still be listed. We have to check only "loaded" units to make sure no unit remains.
