### PR TITLE
cmd/snap: use updated "current" revision after snap refresh run inhibition

### DIFF
--- a/cmd/snaplock/runinhibit/inhibit.go
+++ b/cmd/snaplock/runinhibit/inhibit.go
@@ -207,15 +207,15 @@ func Unlock(snapName string) error {
 }
 
 func WithReadLock(snapName string, action func() error) error {
-	lock, err := osutil.OpenExistingLockForReading(HintFile(snapName))
+	flock, err := osutil.OpenExistingLockForReading(HintFile(snapName))
 	if os.IsNotExist(err) {
 		return action()
 	}
 	if err != nil {
 		return err
 	}
-	defer lock.Close()
-	if err := lock.ReadLock(); err != nil {
+	defer flock.Close()
+	if err := flock.ReadLock(); err != nil {
 		return err
 	}
 	return action()

--- a/cmd/snaplock/runinhibit/inhibit.go
+++ b/cmd/snaplock/runinhibit/inhibit.go
@@ -206,6 +206,21 @@ func Unlock(snapName string) error {
 	return nil
 }
 
+func WithReadLock(snapName string, action func() error) error {
+	lock, err := osutil.OpenExistingLockForReading(HintFile(snapName))
+	if os.IsNotExist(err) {
+		return action()
+	}
+	if err != nil {
+		return err
+	}
+	defer lock.Close()
+	if err := lock.ReadLock(); err != nil {
+		return err
+	}
+	return action()
+}
+
 // IsLocked returns the state of the run inhibition lock for the given snap.
 //
 // It returns the current, non-empty hint if inhibition is in place. Otherwise

--- a/cmd/snaplock/runinhibit/inhibit_test.go
+++ b/cmd/snaplock/runinhibit/inhibit_test.go
@@ -21,6 +21,7 @@ package runinhibit_test
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -31,6 +32,7 @@ import (
 
 	"github.com/snapcore/snapd/cmd/snaplock/runinhibit"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -205,4 +207,30 @@ func (s *runInhibitSuite) TestLockWithHintFilePostfix(c *C) {
 	// This would confuse inhibit info to overwrite the hint file
 	err := runinhibit.LockWithHint("pkg", "lock", s.inhibitInfo)
 	c.Assert(err, ErrorMatches, `hint cannot have value "lock"`)
+}
+
+func (s *runInhibitSuite) TestWithReadLock(c *C) {
+	c.Assert(runinhibit.LockWithHint("some-snap", runinhibit.HintInhibitedForRefresh, s.inhibitInfo), IsNil)
+
+	lock, err := osutil.OpenExistingLockForReading(runinhibit.HintFile("some-snap"))
+	c.Assert(err, IsNil)
+	defer lock.Close()
+	c.Assert(lock.TryLock(), IsNil) // Lock is not held
+	lock.Unlock()
+
+	err = runinhibit.WithReadLock("some-snap", func() error {
+		c.Assert(lock.TryLock(), Equals, osutil.ErrAlreadyLocked) // Lock is held
+		return errors.New("error-is-propagated")
+	})
+	c.Check(err, ErrorMatches, "error-is-propagated")
+
+	c.Assert(lock.TryLock(), IsNil) // Lock is not held
+}
+
+func (s *runInhibitSuite) TestWithReadLockHintFileNotExist(c *C) {
+	err := runinhibit.WithReadLock("some-snap", func() error {
+		c.Assert(runinhibit.HintFile("some-snap"), testutil.FileAbsent)
+		return errors.New("error-is-propagated")
+	})
+	c.Check(err, ErrorMatches, "error-is-propagated")
 }


### PR DESCRIPTION
This PR now passes the updated "current" revision after snap refresh run inhibition passing the correct snap information (including new revision).
It also fixes the case where new snap revision might have the waited app removed.

For context: https://github.com/snapcore/snapd/pull/13066