### PR TITLE
a/snapasserts, o/assertstate: add functions to help during remodel

### DIFF
--- a/asserts/snapasserts/validation_sets.go
+++ b/asserts/snapasserts/validation_sets.go
@@ -194,37 +194,6 @@ type ValidationSets struct {
 	snaps map[string]*snapContraints
 }
 
-// Revisions returns the set of snap revisions that is enforced by the
-// validation sets that ValidationSets manages.
-func (v *ValidationSets) Revisions() (map[string]snap.Revision, error) {
-	if err := v.Conflict(); err != nil {
-		return nil, fmt.Errorf("cannot get revisions when validation sets are in conflict: %w", err)
-	}
-
-	snapNameToRevision := make(map[string]snap.Revision, len(v.snaps))
-	for _, sn := range v.snaps {
-		for revision := range sn.revisions {
-			switch revision {
-			case invalidPresRevision, unspecifiedRevision:
-				continue
-			default:
-				snapNameToRevision[sn.name] = revision
-			}
-		}
-	}
-	return snapNameToRevision, nil
-}
-
-// Keys returns a slice of ValidationSetKey structs that represent each
-// validation set that this type knowns about.
-func (v *ValidationSets) Keys() []ValidationSetKey {
-	keys := make([]ValidationSetKey, 0, len(v.sets))
-	for _, vs := range v.sets {
-		keys = append(keys, NewValidationSetKey(vs))
-	}
-	return keys
-}
-
 const presConflict asserts.Presence = "conflict"
 
 var unspecifiedRevision = snap.R(0)
@@ -356,6 +325,37 @@ func NewValidationSets() *ValidationSets {
 
 func valSetKey(valset *asserts.ValidationSet) string {
 	return fmt.Sprintf("%s/%s", valset.AccountID(), valset.Name())
+}
+
+// Revisions returns the set of snap revisions that is enforced by the
+// validation sets that ValidationSets manages.
+func (v *ValidationSets) Revisions() (map[string]snap.Revision, error) {
+	if err := v.Conflict(); err != nil {
+		return nil, fmt.Errorf("cannot get revisions when validation sets are in conflict: %w", err)
+	}
+
+	snapNameToRevision := make(map[string]snap.Revision, len(v.snaps))
+	for _, sn := range v.snaps {
+		for revision := range sn.revisions {
+			switch revision {
+			case invalidPresRevision, unspecifiedRevision:
+				continue
+			default:
+				snapNameToRevision[sn.name] = revision
+			}
+		}
+	}
+	return snapNameToRevision, nil
+}
+
+// Keys returns a slice of ValidationSetKey structs that represent each
+// validation set that this type knowns about.
+func (v *ValidationSets) Keys() []ValidationSetKey {
+	keys := make([]ValidationSetKey, 0, len(v.sets))
+	for _, vs := range v.sets {
+		keys = append(keys, NewValidationSetKey(vs))
+	}
+	return keys
 }
 
 // Add adds the given asserts.ValidationSet to the combination.

--- a/asserts/snapasserts/validation_sets.go
+++ b/asserts/snapasserts/validation_sets.go
@@ -61,6 +61,11 @@ func (e *ValidationSetsConflictError) Error() string {
 	return buf.String()
 }
 
+func (e *ValidationSetsConflictError) Is(err error) bool {
+	_, ok := err.(*ValidationSetsConflictError)
+	return ok
+}
+
 // ValidationSetsValidationError describes an error arising
 // from validation of snaps against ValidationSets.
 type ValidationSetsValidationError struct {
@@ -187,6 +192,37 @@ type ValidationSets struct {
 	sets map[string]*asserts.ValidationSet
 	// snaps maps snap-ids to snap constraints
 	snaps map[string]*snapContraints
+}
+
+// Revisions returns the set of snap revisions that is enforced by the
+// validation sets that ValidationSets manages.
+func (v *ValidationSets) Revisions() (map[string]snap.Revision, error) {
+	if err := v.Conflict(); err != nil {
+		return nil, fmt.Errorf("cannot get revisions when validation sets are in conflict: %w", err)
+	}
+
+	snapNameToRevision := make(map[string]snap.Revision, len(v.snaps))
+	for _, sn := range v.snaps {
+		for revision := range sn.revisions {
+			switch revision {
+			case invalidPresRevision, unspecifiedRevision:
+				continue
+			default:
+				snapNameToRevision[sn.name] = revision
+			}
+		}
+	}
+	return snapNameToRevision, nil
+}
+
+// Keys returns a slice of ValidationSetKey structs that represent each
+// validation set that this type knowns about.
+func (v *ValidationSets) Keys() []ValidationSetKey {
+	keys := make([]ValidationSetKey, 0, len(v.sets))
+	for _, vs := range v.sets {
+		keys = append(keys, NewValidationSetKey(vs))
+	}
+	return keys
 }
 
 const presConflict asserts.Presence = "conflict"
@@ -590,6 +626,28 @@ func (v *ValidationSets) CheckPresenceRequired(snapRef naming.SnapRef) ([]Valida
 
 	sort.Sort(ValidationSetKeySlice(keys))
 	return keys, snapRev, nil
+}
+
+// CanBePresent returns true if a snap can be present in a situation in which
+// these validation sets are being applied.
+func (v *ValidationSets) CanBePresent(snapRef naming.SnapRef) bool {
+	cstrs := v.constraintsForSnap(snapRef)
+	if cstrs == nil {
+		return true
+	}
+	return cstrs.presence != asserts.PresenceInvalid
+}
+
+// RequiredSnaps returns a list of the names of all of the snaps that are
+// required by any validation set known to this type.
+func (v *ValidationSets) RequiredSnaps() []string {
+	var names []string
+	for _, sn := range v.snaps {
+		if sn.presence == asserts.PresenceRequired {
+			names = append(names, sn.name)
+		}
+	}
+	return names
 }
 
 // CheckPresenceInvalid returns the list of all validation sets that declare

--- a/asserts/snapasserts/validation_sets_test.go
+++ b/asserts/snapasserts/validation_sets_test.go
@@ -1369,6 +1369,49 @@ func (s *validationSetsSuite) TestRequiredSnapNames(c *C) {
 	})
 }
 
+func (s *validationSetsSuite) TestRevisionsConflict(c *C) {
+	valset1 := assertstest.FakeAssertion(map[string]interface{}{
+		"type":         "validation-set",
+		"authority-id": "account-id",
+		"series":       "16",
+		"account-id":   "account-id",
+		"name":         "my-snap-ctl",
+		"sequence":     "1",
+		"snaps": []interface{}{
+			map[string]interface{}{
+				"name":     "my-snap",
+				"id":       snaptest.AssertedSnapID("my-snap"),
+				"presence": "required",
+				"revision": "10",
+			},
+		},
+	}).(*asserts.ValidationSet)
+
+	valset2 := assertstest.FakeAssertion(map[string]interface{}{
+		"type":         "validation-set",
+		"authority-id": "account-id",
+		"series":       "16",
+		"account-id":   "account-id",
+		"name":         "my-snap-ctl2",
+		"sequence":     "2",
+		"snaps": []interface{}{
+			map[string]interface{}{
+				"name":     "my-snap",
+				"id":       snaptest.AssertedSnapID("my-snap"),
+				"presence": "required",
+				"revision": "11",
+			},
+		},
+	}).(*asserts.ValidationSet)
+
+	valsets := snapasserts.NewValidationSets()
+	c.Assert(valsets.Add(valset1), IsNil)
+	c.Assert(valsets.Add(valset2), IsNil)
+
+	_, err := valsets.Revisions()
+	c.Assert(err, testutil.ErrorIs, &snapasserts.ValidationSetsConflictError{})
+}
+
 func (s *validationSetsSuite) TestValidationSetsConflictErrorIs(c *C) {
 	err := &snapasserts.ValidationSetsConflictError{}
 

--- a/asserts/snapasserts/validation_sets_test.go
+++ b/asserts/snapasserts/validation_sets_test.go
@@ -20,6 +20,7 @@
 package snapasserts_test
 
 import (
+	"errors"
 	"fmt"
 	"math/rand"
 	"sort"
@@ -1366,4 +1367,14 @@ func (s *validationSetsSuite) TestRequiredSnapNames(c *C) {
 		"other-snap",
 		"another-snap",
 	})
+}
+
+func (s *validationSetsSuite) TestValidationSetsConflictErrorIs(c *C) {
+	err := &snapasserts.ValidationSetsConflictError{}
+
+	c.Check(err.Is(&snapasserts.ValidationSetsConflictError{}), Equals, true)
+	c.Check(err.Is(errors.New("other error")), Equals, false)
+
+	wrapped := fmt.Errorf("wrapped error: %w", err)
+	c.Check(wrapped, testutil.ErrorIs, &snapasserts.ValidationSetsConflictError{})
 }

--- a/asserts/snapasserts/validation_sets_test.go
+++ b/asserts/snapasserts/validation_sets_test.go
@@ -32,6 +32,8 @@ import (
 	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/naming"
+	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
 )
 
 type validationSetsSuite struct{}
@@ -1141,4 +1143,227 @@ func (s *validationSetsSuite) TestValidationSetKeyComponents(c *C) {
 		},
 	}).(*asserts.ValidationSet))
 	c.Assert(valsetKey.Components(), DeepEquals, []string{"a", "b", "c", "13"})
+}
+
+func (s *validationSetsSuite) TestRevisions(c *C) {
+	valset1 := assertstest.FakeAssertion(map[string]interface{}{
+		"type":         "validation-set",
+		"authority-id": "account-id",
+		"series":       "16",
+		"account-id":   "account-id",
+		"name":         "my-snap-ctl",
+		"sequence":     "1",
+		"snaps": []interface{}{
+			map[string]interface{}{
+				"name":     "my-snap",
+				"id":       snaptest.AssertedSnapID("my-snap"),
+				"presence": "optional",
+				"revision": "10",
+			},
+			map[string]interface{}{
+				"name":     "other-snap",
+				"id":       snaptest.AssertedSnapID("other-snap"),
+				"presence": "required",
+			},
+			// invalid snap should not be present in the result of (*ValidationSets).Revisions()
+			map[string]interface{}{
+				"name":     "invalid-snap",
+				"id":       snaptest.AssertedSnapID("invalid-snap"),
+				"presence": "invalid",
+			},
+		},
+	}).(*asserts.ValidationSet)
+
+	valset2 := assertstest.FakeAssertion(map[string]interface{}{
+		"type":         "validation-set",
+		"authority-id": "account-id",
+		"series":       "16",
+		"account-id":   "account-id",
+		"name":         "my-snap-ctl2",
+		"sequence":     "2",
+		"snaps": []interface{}{
+			map[string]interface{}{
+				"name":     "other-snap",
+				"id":       snaptest.AssertedSnapID("other-snap"),
+				"presence": "optional",
+				"revision": "11",
+			},
+			map[string]interface{}{
+				"name":     "another-snap",
+				"id":       snaptest.AssertedSnapID("another-snap"),
+				"presence": "required",
+				"revision": "12",
+			},
+		},
+	}).(*asserts.ValidationSet)
+
+	valsets := snapasserts.NewValidationSets()
+
+	// no validation sets
+	revisions, err := valsets.Revisions()
+	c.Assert(err, IsNil)
+	c.Check(revisions, HasLen, 0)
+
+	c.Assert(valsets.Add(valset1), IsNil)
+	c.Assert(valsets.Add(valset2), IsNil)
+
+	// validity
+	c.Assert(valsets.Conflict(), IsNil)
+
+	revisions, err = valsets.Revisions()
+	c.Assert(err, IsNil)
+	c.Check(revisions, HasLen, 3)
+
+	c.Check(revisions, DeepEquals, map[string]snap.Revision{
+		"my-snap":      snap.R(10),
+		"other-snap":   snap.R(11),
+		"another-snap": snap.R(12),
+	})
+}
+
+func (s *validationSetsSuite) TestCanBePresent(c *C) {
+	var snaps []*asserts.ValidationSetSnap
+	valset1 := assertstest.FakeAssertion(map[string]interface{}{
+		"type":         "validation-set",
+		"authority-id": "account-id",
+		"series":       "16",
+		"account-id":   "account-id",
+		"name":         "my-snap-ctl",
+		"sequence":     "1",
+		"snaps": []interface{}{
+			map[string]interface{}{
+				"name":     "my-snap",
+				"id":       snaptest.AssertedSnapID("my-snap"),
+				"presence": "invalid",
+			},
+			map[string]interface{}{
+				"name":     "other-snap",
+				"id":       snaptest.AssertedSnapID("other-snap"),
+				"presence": "required",
+			},
+		},
+	}).(*asserts.ValidationSet)
+
+	snaps = append(snaps, valset1.Snaps()...)
+
+	valset2 := assertstest.FakeAssertion(map[string]interface{}{
+		"type":         "validation-set",
+		"authority-id": "account-id",
+		"series":       "16",
+		"account-id":   "account-id",
+		"name":         "my-snap-ctl2",
+		"sequence":     "2",
+		"snaps": []interface{}{
+			map[string]interface{}{
+				"name":     "other-snap",
+				"id":       snaptest.AssertedSnapID("other-snap"),
+				"presence": "optional",
+			},
+			map[string]interface{}{
+				"name":     "another-snap",
+				"id":       snaptest.AssertedSnapID("another-snap"),
+				"presence": "invalid",
+			},
+		},
+	}).(*asserts.ValidationSet)
+
+	snaps = append(snaps, valset2.Snaps()...)
+
+	valsets := snapasserts.NewValidationSets()
+
+	c.Assert(valsets.Add(valset1), IsNil)
+	c.Assert(valsets.Add(valset2), IsNil)
+
+	// validity
+	c.Assert(valsets.Conflict(), IsNil)
+
+	for _, sn := range snaps {
+		c.Check(valsets.CanBePresent(sn), Equals, sn.Presence != asserts.PresenceInvalid)
+	}
+}
+
+func (s *validationSetsSuite) TestKeys(c *C) {
+	valset1 := assertstest.FakeAssertion(map[string]interface{}{
+		"type":         "validation-set",
+		"authority-id": "account-id",
+		"series":       "16",
+		"account-id":   "account-id",
+		"name":         "my-snap-ctl",
+		"sequence":     "1",
+		"snaps":        []interface{}{},
+	}).(*asserts.ValidationSet)
+
+	valset2 := assertstest.FakeAssertion(map[string]interface{}{
+		"type":         "validation-set",
+		"authority-id": "account-id",
+		"series":       "16",
+		"account-id":   "account-id",
+		"name":         "my-snap-ctl2",
+		"sequence":     "2",
+		"snaps":        []interface{}{},
+	}).(*asserts.ValidationSet)
+
+	valsets := snapasserts.NewValidationSets()
+
+	c.Assert(valsets.Add(valset1), IsNil)
+	c.Assert(valsets.Add(valset2), IsNil)
+
+	c.Check(valsets.Keys(), testutil.DeepUnsortedMatches, []snapasserts.ValidationSetKey{
+		"16/account-id/my-snap-ctl2/2",
+		"16/account-id/my-snap-ctl/1",
+	})
+}
+
+func (s *validationSetsSuite) TestRequiredSnapNames(c *C) {
+	valset1 := assertstest.FakeAssertion(map[string]interface{}{
+		"type":         "validation-set",
+		"authority-id": "account-id",
+		"series":       "16",
+		"account-id":   "account-id",
+		"name":         "my-snap-ctl",
+		"sequence":     "1",
+		"snaps": []interface{}{
+			map[string]interface{}{
+				"name":     "my-snap",
+				"id":       snaptest.AssertedSnapID("my-snap"),
+				"presence": "invalid",
+			},
+			map[string]interface{}{
+				"name":     "other-snap",
+				"id":       snaptest.AssertedSnapID("other-snap"),
+				"presence": "required",
+			},
+		},
+	}).(*asserts.ValidationSet)
+
+	valset2 := assertstest.FakeAssertion(map[string]interface{}{
+		"type":         "validation-set",
+		"authority-id": "account-id",
+		"series":       "16",
+		"account-id":   "account-id",
+		"name":         "my-snap-ctl2",
+		"sequence":     "2",
+		"snaps": []interface{}{
+			map[string]interface{}{
+				"name":     "other-snap",
+				"id":       snaptest.AssertedSnapID("other-snap"),
+				"presence": "optional",
+			},
+			map[string]interface{}{
+				"name":     "another-snap",
+				"id":       snaptest.AssertedSnapID("another-snap"),
+				"presence": "required",
+			},
+		},
+	}).(*asserts.ValidationSet)
+
+	valsets := snapasserts.NewValidationSets()
+
+	c.Assert(valsets.Add(valset1), IsNil)
+	c.Assert(valsets.Add(valset2), IsNil)
+
+	c.Check(valsets.RequiredSnaps(), testutil.DeepUnsortedMatches, []string{
+		"other-snap",
+		"another-snap",
+	})
 }

--- a/overlord/assertstate/assertstate.go
+++ b/overlord/assertstate/assertstate.go
@@ -1130,8 +1130,8 @@ func TemporaryDB(st *state.State) *asserts.Database {
 	return db.WithStackedBackstore(asserts.NewMemoryBackstore())
 }
 
-// ValidationSetsModelFlags contains flags for ValidationSetsFromModel.
-type ValidationSetsModelFlags struct {
+// ValidationSetsModelOptions contains options for ValidationSetsFromModel.
+type ValidationSetsModelOptions struct {
 	// Offline should be set to true if the store should not be accessed. Any
 	// assertions will be retrieved from the existing assertions database. If
 	// the assertions are not present in the database, an error will be
@@ -1141,7 +1141,7 @@ type ValidationSetsModelFlags struct {
 
 // ValidationSetsFromModel takes in a model and creates a
 // snapasserts.ValidationSets from any validation sets that the model includes.
-func ValidationSetsFromModel(st *state.State, model *asserts.Model, deviceCtx snapstate.DeviceContext, flags ValidationSetsModelFlags) (*snapasserts.ValidationSets, error) {
+func ValidationSetsFromModel(st *state.State, model *asserts.Model, deviceCtx snapstate.DeviceContext, options ValidationSetsModelOptions) (*snapasserts.ValidationSets, error) {
 	var sets []*asserts.ValidationSet
 	save := func(a asserts.Assertion) error {
 		if vs, ok := a.(*asserts.ValidationSet); ok {
@@ -1164,7 +1164,7 @@ func ValidationSetsFromModel(st *state.State, model *asserts.Model, deviceCtx sn
 	store := snapstate.Store(st, deviceCtx)
 
 	retrieve := func(ref *asserts.Ref) (asserts.Assertion, error) {
-		if flags.Offline {
+		if options.Offline {
 			return ref.Resolve(db.Find)
 		}
 
@@ -1175,7 +1175,7 @@ func ValidationSetsFromModel(st *state.State, model *asserts.Model, deviceCtx sn
 	}
 
 	retrieveSeq := func(ref *asserts.AtSequence) (asserts.Assertion, error) {
-		if flags.Offline {
+		if options.Offline {
 			return resolveValidationSetAssertion(ref, db)
 		}
 

--- a/overlord/assertstate/assertstate.go
+++ b/overlord/assertstate/assertstate.go
@@ -1141,7 +1141,7 @@ type ValidationSetsModelFlags struct {
 
 // ValidationSetsFromModel takes in a model and creates a
 // snapasserts.ValidationSets from any validation sets that the model includes.
-func ValidationSetsFromModel(st *state.State, model *asserts.Model, store snapstate.StoreService, flags ValidationSetsModelFlags) (*snapasserts.ValidationSets, error) {
+func ValidationSetsFromModel(st *state.State, model *asserts.Model, deviceCtx snapstate.DeviceContext, flags ValidationSetsModelFlags) (*snapasserts.ValidationSets, error) {
 	var sets []*asserts.ValidationSet
 	save := func(a asserts.Assertion) error {
 		if vs, ok := a.(*asserts.ValidationSet); ok {
@@ -1160,6 +1160,8 @@ func ValidationSetsFromModel(st *state.State, model *asserts.Model, store snapst
 	}
 
 	db := DB(st)
+
+	store := snapstate.Store(st, deviceCtx)
 
 	retrieve := func(ref *asserts.Ref) (asserts.Assertion, error) {
 		if flags.Offline {

--- a/overlord/assertstate/assertstate.go
+++ b/overlord/assertstate/assertstate.go
@@ -1141,7 +1141,7 @@ type ValidationSetsModelOptions struct {
 
 // ValidationSetsFromModel takes in a model and creates a
 // snapasserts.ValidationSets from any validation sets that the model includes.
-func ValidationSetsFromModel(st *state.State, model *asserts.Model, deviceCtx snapstate.DeviceContext, options ValidationSetsModelOptions) (*snapasserts.ValidationSets, error) {
+func ValidationSetsFromModel(st *state.State, model *asserts.Model, opts ValidationSetsModelOptions, deviceCtx snapstate.DeviceContext) (*snapasserts.ValidationSets, error) {
 	var sets []*asserts.ValidationSet
 	save := func(a asserts.Assertion) error {
 		if vs, ok := a.(*asserts.ValidationSet); ok {
@@ -1164,7 +1164,7 @@ func ValidationSetsFromModel(st *state.State, model *asserts.Model, deviceCtx sn
 	store := snapstate.Store(st, deviceCtx)
 
 	retrieve := func(ref *asserts.Ref) (asserts.Assertion, error) {
-		if options.Offline {
+		if opts.Offline {
 			return ref.Resolve(db.Find)
 		}
 
@@ -1175,7 +1175,7 @@ func ValidationSetsFromModel(st *state.State, model *asserts.Model, deviceCtx sn
 	}
 
 	retrieveSeq := func(ref *asserts.AtSequence) (asserts.Assertion, error) {
-		if options.Offline {
+		if opts.Offline {
 			return resolveValidationSetAssertion(ref, db)
 		}
 

--- a/overlord/assertstate/assertstate.go
+++ b/overlord/assertstate/assertstate.go
@@ -1129,3 +1129,87 @@ func TemporaryDB(st *state.State) *asserts.Database {
 	db := cachedDB(st)
 	return db.WithStackedBackstore(asserts.NewMemoryBackstore())
 }
+
+// ValidationSetsModelFlags contains flags for ValidationSetsFromModel.
+type ValidationSetsModelFlags struct {
+	// Offline should be set to true if the store should not be accessed. Any
+	// assertions will be retrieved from the existing assertions database. If
+	// the assertions are not present in the database, an error will be
+	// returned.
+	Offline bool
+}
+
+// ValidationSetsFromModel takes in a model and creates a
+// snapasserts.ValidationSets from any validation sets that the model includes.
+func ValidationSetsFromModel(st *state.State, model *asserts.Model, store snapstate.StoreService, flags ValidationSetsModelFlags) (*snapasserts.ValidationSets, error) {
+	var sets []*asserts.ValidationSet
+	save := func(a asserts.Assertion) error {
+		if vs, ok := a.(*asserts.ValidationSet); ok {
+			sets = append(sets, vs)
+		}
+
+		if err := Add(st, a); err != nil {
+			if err, ok := err.(*asserts.RevisionError); ok {
+				logger.Noticef("assertion not added due to same or newer revision already present: %d", err.Current)
+				return nil
+			}
+			return err
+		}
+
+		return nil
+	}
+
+	db := DB(st)
+
+	retrieve := func(ref *asserts.Ref) (asserts.Assertion, error) {
+		if flags.Offline {
+			return ref.Resolve(db.Find)
+		}
+
+		st.Unlock()
+		defer st.Lock()
+
+		return store.Assertion(ref.Type, ref.PrimaryKey, nil)
+	}
+
+	retrieveSeq := func(ref *asserts.AtSequence) (asserts.Assertion, error) {
+		if flags.Offline {
+			return resolveValidationSetAssertion(ref, db)
+		}
+
+		st.Unlock()
+		defer st.Lock()
+
+		return store.SeqFormingAssertion(ref.Type, ref.SequenceKey, ref.Sequence, nil)
+	}
+
+	fetcher := asserts.NewSequenceFormingFetcher(db, retrieve, retrieveSeq, save)
+
+	for _, vs := range model.ValidationSets() {
+		if err := fetcher.FetchSequence(vs.AtSequence()); err != nil {
+			return nil, err
+		}
+	}
+
+	vSets := snapasserts.NewValidationSets()
+	for _, vs := range sets {
+		vSets.Add(vs)
+	}
+
+	if err := vSets.Conflict(); err != nil {
+		return nil, err
+	}
+
+	return vSets, nil
+}
+
+func resolveValidationSetAssertion(seq *asserts.AtSequence, db asserts.RODatabase) (asserts.Assertion, error) {
+	if seq.Sequence <= 0 {
+		hdrs, err := asserts.HeadersFromSequenceKey(seq.Type, seq.SequenceKey)
+		if err != nil {
+			return nil, err
+		}
+		return db.FindSequence(seq.Type, hdrs, -1, seq.Type.MaxSupportedFormat())
+	}
+	return seq.Resolve(db.Find)
+}

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -5026,9 +5026,9 @@ func (s *assertMgrSuite) testValidationSetsFromModel(c *C, offline bool) {
 		CtxStore: store,
 	}
 
-	sets, err := assertstate.ValidationSetsFromModel(s.state, model, deviceCtx, assertstate.ValidationSetsModelOptions{
+	sets, err := assertstate.ValidationSetsFromModel(s.state, model, assertstate.ValidationSetsModelOptions{
 		Offline: offline,
-	})
+	}, deviceCtx)
 	c.Assert(err, IsNil)
 
 	c.Check(sets.RequiredSnaps(), testutil.DeepUnsortedMatches, []string{"some-snap", "some-other-snap"})
@@ -5094,8 +5094,8 @@ func (s *assertMgrSuite) TestValidationSetsFromModelConflict(c *C) {
 	c.Assert(assertstate.Add(s.state, barVset), IsNil)
 	c.Assert(assertstate.Add(s.state, fooVset), IsNil)
 
-	_, err := assertstate.ValidationSetsFromModel(s.state, model, s.trivialDeviceCtx, assertstate.ValidationSetsModelOptions{
+	_, err := assertstate.ValidationSetsFromModel(s.state, model, assertstate.ValidationSetsModelOptions{
 		Offline: true,
-	})
+	}, s.trivialDeviceCtx)
 	c.Check(err, testutil.ErrorIs, &snapasserts.ValidationSetsConflictError{})
 }

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -5026,7 +5026,7 @@ func (s *assertMgrSuite) testValidationSetsFromModel(c *C, offline bool) {
 		CtxStore: store,
 	}
 
-	sets, err := assertstate.ValidationSetsFromModel(s.state, model, deviceCtx, assertstate.ValidationSetsModelFlags{
+	sets, err := assertstate.ValidationSetsFromModel(s.state, model, deviceCtx, assertstate.ValidationSetsModelOptions{
 		Offline: offline,
 	})
 	c.Assert(err, IsNil)
@@ -5094,7 +5094,7 @@ func (s *assertMgrSuite) TestValidationSetsFromModelConflict(c *C) {
 	c.Assert(assertstate.Add(s.state, barVset), IsNil)
 	c.Assert(assertstate.Add(s.state, fooVset), IsNil)
 
-	_, err := assertstate.ValidationSetsFromModel(s.state, model, s.trivialDeviceCtx, assertstate.ValidationSetsModelFlags{
+	_, err := assertstate.ValidationSetsFromModel(s.state, model, s.trivialDeviceCtx, assertstate.ValidationSetsModelOptions{
 		Offline: true,
 	})
 	c.Check(err, testutil.ErrorIs, &snapasserts.ValidationSetsConflictError{})

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -5022,7 +5022,11 @@ func (s *assertMgrSuite) testValidationSetsFromModel(c *C, offline bool) {
 		}()
 	}
 
-	sets, err := assertstate.ValidationSetsFromModel(s.state, model, store, assertstate.ValidationSetsModelFlags{
+	deviceCtx := &snapstatetest.TrivialDeviceContext{
+		CtxStore: store,
+	}
+
+	sets, err := assertstate.ValidationSetsFromModel(s.state, model, deviceCtx, assertstate.ValidationSetsModelFlags{
 		Offline: offline,
 	})
 	c.Assert(err, IsNil)
@@ -5090,7 +5094,7 @@ func (s *assertMgrSuite) TestValidationSetsFromModelConflict(c *C) {
 	c.Assert(assertstate.Add(s.state, barVset), IsNil)
 	c.Assert(assertstate.Add(s.state, fooVset), IsNil)
 
-	_, err := assertstate.ValidationSetsFromModel(s.state, model, &storetest.Store{}, assertstate.ValidationSetsModelFlags{
+	_, err := assertstate.ValidationSetsFromModel(s.state, model, s.trivialDeviceCtx, assertstate.ValidationSetsModelFlags{
 		Offline: true,
 	})
 	c.Check(err, testutil.ErrorIs, &snapasserts.ValidationSetsConflictError{})

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -106,6 +106,30 @@ func (sto *fakeStore) Assertion(assertType *asserts.AssertionType, key []string,
 	return ref.Resolve(sto.db.Find)
 }
 
+func (sto *fakeStore) SeqFormingAssertion(assertType *asserts.AssertionType, sequenceKey []string, sequence int, user *auth.UserState) (asserts.Assertion, error) {
+	sto.pokeStateLock()
+
+	restore := asserts.MockMaxSupportedFormat(asserts.SnapDeclarationType, sto.maxDeclSupportedFormat)
+	defer restore()
+
+	ref := &asserts.AtSequence{
+		Type:        assertType,
+		SequenceKey: sequenceKey,
+		Sequence:    sequence,
+		Pinned:      sequence > 0,
+	}
+
+	if ref.Sequence <= 0 {
+		hdrs, err := asserts.HeadersFromSequenceKey(ref.Type, ref.SequenceKey)
+		if err != nil {
+			return nil, err
+		}
+		return sto.db.FindSequence(ref.Type, hdrs, -1, -1)
+	}
+
+	return ref.Resolve(sto.db.Find)
+}
+
 func (sto *fakeStore) SnapAction(_ context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, assertQuery store.AssertionQuery, user *auth.UserState, opts *store.RefreshOptions) ([]store.SnapActionResult, []store.AssertionResult, error) {
 	sto.pokeStateLock()
 
@@ -4877,4 +4901,197 @@ func (s *assertMgrSuite) TestForgetValidationSetPreferEnforcedByModelHappy(c *C)
 
 	err := assertstate.ForgetValidationSet(s.state, s.dev1Acct.AccountID(), "foo")
 	c.Check(err, IsNil)
+}
+
+type fakeAssertionStore struct {
+	storetest.Store
+
+	assertion           func(*asserts.AssertionType, []string, *auth.UserState) (asserts.Assertion, error)
+	seqFormingAssertion func(*asserts.AssertionType, []string, int, *auth.UserState) (asserts.Assertion, error)
+}
+
+func (f *fakeAssertionStore) Assertion(assertType *asserts.AssertionType, key []string, userState *auth.UserState) (asserts.Assertion, error) {
+	return f.assertion(assertType, key, userState)
+}
+
+func (f *fakeAssertionStore) SeqFormingAssertion(assertType *asserts.AssertionType, sequenceKey []string, sequence int, user *auth.UserState) (asserts.Assertion, error) {
+	return f.seqFormingAssertion(assertType, sequenceKey, sequence, user)
+}
+
+func (s *assertMgrSuite) TestValidationSetsFromModelOnline(c *C) {
+	const offline = false
+	s.testValidationSetsFromModel(c, offline)
+}
+
+func (s *assertMgrSuite) TestValidationSetsFromModelOffline(c *C) {
+	const offline = true
+	s.testValidationSetsFromModel(c, offline)
+}
+
+func (s *assertMgrSuite) testValidationSetsFromModel(c *C, offline bool) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	model := assertstest.FakeAssertion(map[string]interface{}{
+		"type":         "model",
+		"authority-id": "my-brand",
+		"series":       "16",
+		"brand-id":     "my-brand",
+		"model":        "my-model",
+		"architecture": "amd64",
+		"gadget":       "gadget",
+		"kernel":       "krnl",
+		"validation-sets": []interface{}{
+			map[string]interface{}{
+				"account-id": s.dev1Acct.AccountID(),
+				"name":       "foo",
+				"mode":       "enforce",
+			},
+			map[string]interface{}{
+				"account-id": s.dev1Acct.AccountID(),
+				"name":       "bar",
+				"sequence":   "2",
+				"mode":       "enforce",
+			},
+		},
+	}).(*asserts.Model)
+
+	s.setModel(model)
+
+	snapsInFoo := []interface{}{
+		map[string]interface{}{
+			"id":       snaptest.AssertedSnapID("some-snap"),
+			"name":     "some-snap",
+			"presence": "required",
+		},
+	}
+
+	fooVset := s.validationSetAssertForSnaps(c, "foo", "1", "1", snapsInFoo)
+
+	snapsInBar := []interface{}{
+		map[string]interface{}{
+			"id":       snaptest.AssertedSnapID("some-other-snap"),
+			"name":     "some-other-snap",
+			"presence": "required",
+		},
+	}
+
+	barVset := s.validationSetAssertForSnaps(c, "bar", "2", "1", snapsInBar)
+
+	var store snapstate.StoreService
+	if offline {
+		c.Assert(assertstate.Add(s.state, s.storeSigning.StoreAccountKey("")), IsNil)
+		c.Assert(assertstate.Add(s.state, s.dev1Acct), IsNil)
+		c.Assert(assertstate.Add(s.state, s.dev1AcctKey), IsNil)
+		c.Assert(assertstate.Add(s.state, barVset), IsNil)
+		c.Assert(assertstate.Add(s.state, fooVset), IsNil)
+
+		// any store operations will panic since we're using storetest.Store
+		store = &storetest.Store{}
+	} else {
+		c.Assert(s.storeSigning.Add(barVset), IsNil)
+		c.Assert(s.storeSigning.Add(fooVset), IsNil)
+
+		assertsFetched := 0
+		seqFormingAssertsFetched := 0
+
+		store = &fakeAssertionStore{
+			assertion: func(assertType *asserts.AssertionType, key []string, user *auth.UserState) (asserts.Assertion, error) {
+				assertsFetched++
+				switch assertType.Name {
+				case "account-key", "account":
+					return s.fakeStore.Assertion(assertType, key, user)
+				}
+				return nil, fmt.Errorf("unexpected assertion type: %s", assertType.Name)
+			},
+			seqFormingAssertion: func(assertType *asserts.AssertionType, sequenceKey []string, sequence int, user *auth.UserState) (asserts.Assertion, error) {
+				seqFormingAssertsFetched++
+				if assertType.Name != "validation-set" {
+					return nil, fmt.Errorf("unexpected assertion type: %s", assertType.Name)
+				}
+				return s.fakeStore.SeqFormingAssertion(assertType, sequenceKey, sequence, user)
+			},
+		}
+
+		defer func() {
+			// two account keys, one account
+			c.Check(assertsFetched, Equals, 3)
+
+			// two validation sets
+			c.Check(seqFormingAssertsFetched, Equals, 2)
+		}()
+	}
+
+	sets, err := assertstate.ValidationSetsFromModel(s.state, model, store, assertstate.ValidationSetsModelFlags{
+		Offline: offline,
+	})
+	c.Assert(err, IsNil)
+
+	c.Check(sets.RequiredSnaps(), testutil.DeepUnsortedMatches, []string{"some-snap", "some-other-snap"})
+	c.Check(sets.Keys(), testutil.DeepUnsortedMatches, []snapasserts.ValidationSetKey{
+		snapasserts.ValidationSetKey(fmt.Sprintf("16/%s/foo/1", s.dev1Acct.AccountID())),
+		snapasserts.ValidationSetKey(fmt.Sprintf("16/%s/bar/2", s.dev1Acct.AccountID())),
+	})
+}
+
+func (s *assertMgrSuite) TestValidationSetsFromModelConflict(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	model := assertstest.FakeAssertion(map[string]interface{}{
+		"type":         "model",
+		"authority-id": "my-brand",
+		"series":       "16",
+		"brand-id":     "my-brand",
+		"model":        "my-model",
+		"architecture": "amd64",
+		"gadget":       "gadget",
+		"kernel":       "krnl",
+		"validation-sets": []interface{}{
+			map[string]interface{}{
+				"account-id": s.dev1Acct.AccountID(),
+				"name":       "foo",
+				"mode":       "enforce",
+			},
+			map[string]interface{}{
+				"account-id": s.dev1Acct.AccountID(),
+				"name":       "bar",
+				"sequence":   "2",
+				"mode":       "enforce",
+			},
+		},
+	}).(*asserts.Model)
+
+	s.setModel(model)
+
+	snapsInFoo := []interface{}{
+		map[string]interface{}{
+			"id":       snaptest.AssertedSnapID("some-snap"),
+			"name":     "some-snap",
+			"presence": "required",
+		},
+	}
+
+	fooVset := s.validationSetAssertForSnaps(c, "foo", "1", "1", snapsInFoo)
+
+	snapsInBar := []interface{}{
+		map[string]interface{}{
+			"id":       snaptest.AssertedSnapID("some-snap"),
+			"name":     "some-snap",
+			"presence": "invalid",
+		},
+	}
+
+	barVset := s.validationSetAssertForSnaps(c, "bar", "2", "1", snapsInBar)
+
+	c.Assert(assertstate.Add(s.state, s.storeSigning.StoreAccountKey("")), IsNil)
+	c.Assert(assertstate.Add(s.state, s.dev1Acct), IsNil)
+	c.Assert(assertstate.Add(s.state, s.dev1AcctKey), IsNil)
+	c.Assert(assertstate.Add(s.state, barVset), IsNil)
+	c.Assert(assertstate.Add(s.state, fooVset), IsNil)
+
+	_, err := assertstate.ValidationSetsFromModel(s.state, model, &storetest.Store{}, assertstate.ValidationSetsModelFlags{
+		Offline: true,
+	})
+	c.Check(err, testutil.ErrorIs, &snapasserts.ValidationSetsConflictError{})
 }


### PR DESCRIPTION
These functions/methods will be used in a later PR that takes into account validation sets during a remodel.

Usage of the new functionality is in this PR here: #13243