### PR TITLE
release/2.60: sync with latest bugfix for ubuntu mantic

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# New in snapd 2.60.5:
+* Read mountinfo for PID 1
+  This fixes snapd-generator reading incorrect mounts due to Systemd mount
+  generators now running in a sandbox. The bug causes problems when upgrading
+  Ubuntu Desktop from 23.04 to 23.10 resulting in missing snap mounts that in
+  turn cause errors with automatically connecting plugs and slots for newly
+  installed snaps.
+
 # New in snapd 2.60.4:
 * Switch to plug/slot in the "qualcomm-ipc-router" interface
   but keeping backward compatibility

--- a/cmd/snapd-generator/main.c
+++ b/cmd/snapd-generator/main.c
@@ -45,11 +45,11 @@ static sc_mountinfo_entry *find_root_mountinfo(sc_mountinfo * mounts)
 
 static int ensure_root_fs_shared(const char *normal_dir)
 {
-	// Load /proc/self/mountinfo so that we can inspect the root filesystem.
+	// Load /proc/1/mountinfo so that we can inspect the root filesystem.
 	sc_mountinfo *mounts SC_CLEANUP(sc_cleanup_mountinfo) = NULL;
-	mounts = sc_parse_mountinfo(NULL);
+	mounts = sc_parse_mountinfo("/proc/1/mountinfo");
 	if (!mounts) {
-		fprintf(stderr, "cannot open or parse /proc/self/mountinfo\n");
+		fprintf(stderr, "cannot open or parse /proc/1/mountinfo\n");
 		return 1;
 	}
 

--- a/cmd/snapd-generator/main.c
+++ b/cmd/snapd-generator/main.c
@@ -89,8 +89,13 @@ static int ensure_root_fs_shared(const char *normal_dir)
 	fprintf(f, "Where=" SNAP_MOUNT_DIR "\n");
 	fprintf(f, "Type=none\n");
 	fprintf(f, "Options=bind,shared\n");
-	fprintf(f, "[Install]\n");
-	fprintf(f, "WantedBy=local-fs.target\n");
+
+        /* We do not need to create symlinks from any target since
+         * this generated mount will automically be added to implicit
+         * dependencies of sub mount units through
+         * `RequiresMountsFor`.
+         */
+
 	return 0;
 }
 


### PR DESCRIPTION
Ubuntu 23.10 (Mantic) was updated with commit: "cmd/snapd-generator: read mountinfo for pid 1" from PR https://github.com/snapcore/snapd/pull/13129.

This sync ensures that snapd release 2.60 latest have all the changes of current [mantic-proposed](https://code.launchpad.net/~git-ubuntu-import/ubuntu/+source/snapd/+git/snapd/+ref/applied/ubuntu/mantic-proposed) in case we need to build again from this release branch.
