### PR TITLE
cmd/snapd-apparmor: add support for incus (LP: #2042512)

### DIFF
--- a/cmd/snapd-apparmor/main.go
+++ b/cmd/snapd-apparmor/main.go
@@ -53,20 +53,21 @@ import (
 // profiles that should be loaded.
 //
 // The only known container environments capable of supporting internal policy
-// are LXD and LXC environment.
+// are LXD, LXC and incus environments.
 //
 // Returns true if the container environment is capable of having its own internal
 // policy and false otherwise.
 //
-// IMPORTANT: This function will return true in the case of a non-LXD/non-LXC
-// system container technology being nested inside of a LXD/LXC container that
-// utilized an AppArmor namespace and profile stacking. The reason true will be
-// returned is because .ns_stacked will be "yes" and .ns_name will still match
-// "lx[dc]-*" since the nested system container technology will not have set up
-// a new AppArmor profile namespace. This will result in the nested system
-// container's boot process to experience failed policy loads but the boot
-// process should continue without any loss of functionality. This is an
-// unsupported configuration that cannot be properly handled by this function.
+// IMPORTANT: This function will return true in the case of a
+// non-LXD/non-LXC/non-incus system container technology being nested inside of
+// a LXD/LXC/incus container that utilized an AppArmor namespace and profile
+// stacking. The reason true will be returned is because .ns_stacked will be
+// "yes" and .ns_name will still match "(lx[dc]|incus)-*" since the nested
+// system container technology will not have set up a new AppArmor profile
+// namespace. This will result in the nested system container's boot process to
+// experience failed policy loads but the boot process should continue without
+// any loss of functionality. This is an unsupported configuration that cannot
+// be properly handled by this function.
 func isContainerWithInternalPolicy() bool {
 	if release.OnWSL {
 		return true
@@ -92,11 +93,11 @@ func isContainerWithInternalPolicy() bool {
 		return false
 	}
 
-	// LXD and LXC set up AppArmor namespaces starting with "lxd-" and
-	// "lxc-", respectively. Return false for all other namespace
-	// identifiers.
+	// LXD, LXC and incus set up AppArmor namespaces starting with "lxd-",
+	// "lxc-" and "incus-" respectively. Return false for all other
+	// namespace identifiers.
 	name := strings.TrimSpace(string(contents))
-	if !strings.HasPrefix(name, "lxd-") && !strings.HasPrefix(name, "lxc-") {
+	if !strings.HasPrefix(name, "lxd-") && !strings.HasPrefix(name, "lxc-") && !strings.HasPrefix(name, "incus-") {
 		return false
 	}
 	return true


### PR DESCRIPTION
Add support to snapd-apparmor to properly support running under incus to fix https://bugs.launchpad.net/snapd/+bug/2042512
