### PR TITLE
i/b/microceph-support: add microceph-support interface

### DIFF
--- a/interfaces/builtin/microceph_support.go
+++ b/interfaces/builtin/microceph_support.go
@@ -27,6 +27,14 @@ const microcephSupportBaseDeclarationPlugs = `
     deny-auto-connection: true
 `
 
+const microcephSupportBaseDeclarationSlots = `
+  microceph-support:
+    allow-installation:
+      slot-snap-type:
+        - core
+    deny-auto-connection: true
+`
+
 const microcephSupportConnectedPlugAppArmor = `
 
 # Allow bcache devices to be accessed since DM devices may be set up on top of those.
@@ -54,6 +62,7 @@ func init() {
 		summary:               microcephSupportSummary,
 		implicitOnCore:        true,
 		implicitOnClassic:     true,
+		baseDeclarationSlots:  microcephSupportBaseDeclarationSlots,
 		baseDeclarationPlugs:  microcephSupportBaseDeclarationPlugs,
 		connectedPlugAppArmor: microcephSupportConnectedPlugAppArmor,
 	})

--- a/interfaces/builtin/microceph_support.go
+++ b/interfaces/builtin/microceph_support.go
@@ -1,0 +1,60 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+const microcephSupportSummary = `allows operating as the MicroCeph service`
+
+const microcephSupportBaseDeclarationPlugs = `
+  microceph-support:
+    allow-installation: false
+    deny-auto-connection: true
+`
+
+const microcephSupportConnectedPlugAppArmor = `
+
+# Allow bcache devices to be accessed since DM devices may be set up on top of those.
+/dev/bcache[0-9]{,[0-9],[0-9][0-9]} rwk,                   # bcache (up to 1000 devices)
+# Access to individual partitions
+/dev/hd[a-t][0-9]{,[0-9],[0-9][0-9]} rwk,                  # IDE, MFM, RLL
+/dev/sd{,[a-z]}[a-z][0-9]{,[0-9],[0-9][0-9]} rwk,          # SCSI
+/dev/vd{,[a-z]}[a-z][0-9]{,[0-9],[0-9][0-9]} rwk,          # virtio
+/dev/nvme{[0-9],[1-9][0-9]}n{[1-9],[1-5][0-9],6[0-3]}p[0-9]{,[0-9],[0-9][0-9]} rwk, # NVMe
+# Access device mapper blockdevs
+/dev/dm-[0-9]{,[0-9],[0-9][0-9]} rwk,                      # device mapper (up to 1000 devices)
+# Allow managing of rbd-backed block devices
+/sys/bus/rbd/add rwk,                                      # add block dev
+/sys/bus/rbd/remove rwk,                                   # remove block dev
+/sys/bus/rbd/add_single_major rwk,                         # add single major dev
+/sys/bus/rbd/remove_single_major rwk,                      # remove single major dev
+/sys/bus/rbd/supported_features r,                         # display enabled features
+/sys/bus/rbd/devices/** rwk,                               # manage individual block devs
+
+`
+
+func init() {
+	registerIface(&commonInterface{
+		name:                  "microceph-support",
+		summary:               microcephSupportSummary,
+		implicitOnCore:        true,
+		implicitOnClassic:     true,
+		baseDeclarationPlugs:  microcephSupportBaseDeclarationPlugs,
+		connectedPlugAppArmor: microcephSupportConnectedPlugAppArmor,
+	})
+}

--- a/interfaces/builtin/microceph_support_test.go
+++ b/interfaces/builtin/microceph_support_test.go
@@ -73,7 +73,7 @@ func (s *MicrocephSupportInterfaceSuite) TestSanitizePlug(c *C) {
 }
 
 func (s *MicrocephSupportInterfaceSuite) TestAppArmorSpec(c *C) {
-	spec := &apparmor.Specification{}
+	spec := apparmor.NewSpecification(interfaces.NewSnapAppSet(s.plug.Snap()))
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/sys/bus/rbd/add_single_major rwk,                         # add single major dev\n")

--- a/interfaces/builtin/microceph_support_test.go
+++ b/interfaces/builtin/microceph_support_test.go
@@ -1,0 +1,96 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type MicrocephSupportInterfaceSuite struct {
+	iface    interfaces.Interface
+	slotInfo *snap.SlotInfo
+	slot     *interfaces.ConnectedSlot
+	plugInfo *snap.PlugInfo
+	plug     *interfaces.ConnectedPlug
+}
+
+var _ = Suite(&MicrocephSupportInterfaceSuite{
+	iface: builtin.MustInterface("microceph-support"),
+})
+
+const microcephSupportConsumerYaml = `name: consumer
+version: 0
+apps:
+ app:
+  plugs: [microceph-support]
+`
+
+const microcephSupportCoreYaml = `name: core
+version: 0
+type: os
+slots:
+  microceph-support:
+`
+
+func (s *MicrocephSupportInterfaceSuite) SetUpTest(c *C) {
+	s.plug, s.plugInfo = MockConnectedPlug(c, microcephSupportConsumerYaml, nil, "microceph-support")
+	s.slot, s.slotInfo = MockConnectedSlot(c, microcephSupportCoreYaml, nil, "microceph-support")
+}
+
+func (s *MicrocephSupportInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "microceph-support")
+}
+
+func (s *MicrocephSupportInterfaceSuite) TestSanitizeSlot(c *C) {
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.slotInfo), IsNil)
+}
+
+func (s *MicrocephSupportInterfaceSuite) TestSanitizePlug(c *C) {
+	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
+}
+
+func (s *MicrocephSupportInterfaceSuite) TestAppArmorSpec(c *C) {
+	spec := &apparmor.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/sys/bus/rbd/add_single_major rwk,                         # add single major dev\n")
+}
+
+func (s *MicrocephSupportInterfaceSuite) TestStaticInfo(c *C) {
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Assert(si.ImplicitOnCore, Equals, true)
+	c.Assert(si.ImplicitOnClassic, Equals, true)
+	c.Assert(si.Summary, Equals, `allows operating as the MicroCeph service`)
+	c.Assert(si.BaseDeclarationPlugs, testutil.Contains, "microceph-support")
+}
+
+func (s *MicrocephSupportInterfaceSuite) TestAutoConnect(c *C) {
+	c.Check(s.iface.AutoConnect(nil, nil), Equals, true)
+}
+
+func (s *MicrocephSupportInterfaceSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2018 Canonical Ltd
+ * Copyright (C) 2016-2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -864,15 +864,16 @@ var (
 		"wayland":                   {"app", "core"},
 		"x11":                       {"app", "core"},
 		// snowflakes
-		"classic-support": nil,
-		"custom-device":   nil,
-		"docker":          nil,
-		"lxd":             nil,
-		"microceph":       nil,
-		"microovn":        nil,
-		"pkcs11":          nil,
-		"posix-mq":        nil,
-		"shared-memory":   nil,
+		"classic-support":   nil,
+		"custom-device":     nil,
+		"docker":            nil,
+		"lxd":               nil,
+		"microceph":         nil,
+		"microceph-support": nil,
+		"microovn":          nil,
+		"pkcs11":            nil,
+		"posix-mq":          nil,
+		"shared-memory":     nil,
 	}
 
 	restrictedPlugInstallation = map[string][]string{
@@ -1017,6 +1018,7 @@ func (s *baseDeclSuite) TestPlugInstallation(c *C) {
 		"kernel-module-load":      true,
 		"kubernetes-support":      true,
 		"lxd-support":             true,
+		"microceph-support":       true,
 		"microstack-support":      true,
 		"mount-control":           true,
 		"multipass-support":       true,

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -1314,6 +1314,7 @@ func (s *baseDeclSuite) TestValidity(c *C) {
 		"kernel-module-load":      true,
 		"kubernetes-support":      true,
 		"lxd-support":             true,
+		"microceph-support":       true,
 		"microstack-support":      true,
 		"mount-control":           true,
 		"multipass-support":       true,

--- a/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
@@ -269,6 +269,9 @@ apps:
   microceph:
     command: bin/run
     plugs: [ microceph ]
+  microceph-support:
+    command: bin/run
+    plugs: [ microceph-support ]
   microovn:
     command: bin/run
     plugs: [ microovn ]


### PR DESCRIPTION
Add separate microceph-support interface in order to allow more types of block devices to be added as an OSD (bcache, indiv. partitions, device mapper)

Also allow access to the rbd sysfs controls for managing rbd-backed block devices (cf. https://docs.kernel.org/admin-guide/abi-testing.html#abi-file-testing-sysfs-bus-rbd)

