### PR TITLE
interfaces/desktop: allow DBus communication with colord

### DIFF
--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -134,6 +134,30 @@ dbus (send)
     interface="org.gnome.Mutter.IdleMonitor"
     member="GetIdletime"
     peer=(label=###SLOT_SECURITY_TAGS###),
+
+# Allow for color managed applications to communicate with colord
+dbus (receive, send)
+  bus=system
+  interface=org.freedesktop.ColorManager
+  path=/org/freedesktop/ColorManager
+  member=FindDeviceByProperty
+  peer=(label=unconfined),
+dbus (send)
+  bus=system
+  interface=org.freedesktop.DBus.Properties
+  path=/org/freedesktop/ColorManager
+  member="Get{,All}"
+  peer=(label=unconfined),
+dbus (send)
+  bus=system
+  interface=org.freedesktop.DBus.Properties
+  path="/org/freedesktop/ColorManager/{devices,profiles}/*"
+  member="Get{,All}"
+  peer=(label=unconfined),
+
+# Allow access to the ICC profiles in the home directory to
+# be refered to from colord
+owner @{HOME}/.local/share/icc r,
 `
 
 const desktopConnectedPlugAppArmorClassic = `

--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -156,7 +156,7 @@ dbus (send)
   peer=(label=unconfined),
 
 # Allow access to the ICC profiles in the home directory to
-# be refered to from colord
+# be referred to from colord
 owner @{HOME}/.local/share/icc r,
 `
 


### PR DESCRIPTION
These set of rules allow for color managed applications to communicate with colord, which will be able to tell such applications which ICC profile to load.

This solution in itself is not complete, as it would still require a plug definition for personal files of the following form:

plugs:
  dot-local-share-icc:
    interface: personal-files
    read:
    - $HOME/.local/share/icc

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
