### PR TITLE
interfaces/media-control: also allow 'k' (lock)

### DIFF
--- a/interfaces/builtin/media_control.go
+++ b/interfaces/builtin/media_control.go
@@ -36,7 +36,7 @@ const mediaControlBaseDeclarationSlots = `
 
 const mediaControlConnectedPlugAppArmor = `
 # Control of media devices
-/dev/media[0-9]* rw,
+/dev/media[0-9]* rwk,
 
 # Access to V4L subnodes configuration
 # See https://www.kernel.org/doc/html/v4.12/media/uapi/v4l/dev-subdev.html

--- a/interfaces/builtin/media_control_test.go
+++ b/interfaces/builtin/media_control_test.go
@@ -80,7 +80,7 @@ func (s *MediacontrolInterfaceSuite) TestAppArmorSpec(c *C) {
 	spec := &apparmor.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.coreSlot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
-	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/dev/media[0-9]* rw,`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/dev/media[0-9]* rwk,`)
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/dev/v4l-subdev[0-9]* rw,`)
 }
 


### PR DESCRIPTION
libcamera requires file locking on `/dev/media[0-9]*`. AppArmor denies locking currently, resulting in a _"Pipeline handler in use"_ error. Adding a `k` permission will solve this issue for AppArmor.