### PR TITLE
tests: improve when nested tests execution needs to be executed

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,10 @@ on:
     # we trigger runs on master branch, but we do not run spread on master 
     # branch, the master branch runs are just for unit tests + codecov.io
     branches: [ "master","release/**" ]
+  workflow_run:
+    workflows: ["Pull Request Labeler"]
+    types:
+      - completed
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -598,10 +602,20 @@ jobs:
               fi
           fi
 
+    - name: Collect PR labels
+      id: collect-pr-labels
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+          LABELS="$(gh api -H 'Accept: application/vnd.github+json' /repos/snapcore/snapd/issues/${{ github.event.pull_request.number }}/labels | jq '[.[].name] | join(",")')"
+          echo "labels=$LABELS" >> $GITHUB_OUTPUT
+          echo "Collected labels: $LABELS"
+      shell: bash
+
     - name: Run spread tests
       # run if the commit is pushed to the release/* branch or there is a 'Run
       # nested' label set on the PR
-      if: "contains(github.event.pull_request.labels.*.name, 'Run nested') || contains(github.event.pull_request.labels.*.name, 'Run nested -auto-') || contains(github.ref, 'refs/heads/release/')"
+      if: "contains(steps.collect-pr-labels.outputs.labels, 'Run nested') || contains(github.ref, 'refs/heads/release/')"
       env:
           SPREAD_GOOGLE_KEY: ${{ secrets.SPREAD_GOOGLE_KEY }}
       run: |

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -642,7 +642,7 @@ EOF
                 echo "$GADGET_EXTRA_CMDLINE" > pc-gadget/cmdline.extra
             fi
 
-            # pack it
+            # pack the gadget
             snap pack pc-gadget/ "$NESTED_ASSETS_DIR"
 
             gadget_snap=$(ls "$NESTED_ASSETS_DIR"/pc_*.snap)


### PR DESCRIPTION
This change adds a dependency between the labeler and the tests workflows. Then after the labeler is executed, the nested test job request the labels added to the PR and based on that request it is determined if the nested tests have to be executed.