### PR TITLE
aspects: include paths in validation errors

### DIFF
--- a/aspects/schema_test.go
+++ b/aspects/schema_test.go
@@ -154,7 +154,7 @@ func (*schemaSuite) TestMapWithUnexpectedKey(c *C) {
 	c.Assert(err, IsNil)
 
 	err = schema.Validate(input)
-	c.Assert(err, ErrorMatches, `map contains unexpected key "bar"`)
+	c.Assert(err, ErrorMatches, `cannot validate element under "snaps": map contains unexpected key "bar"`)
 }
 func (*schemaSuite) TestMapWithKeysStringConstraintHappy(c *C) {
 	schemaStr := []byte(`{
@@ -282,7 +282,7 @@ func (*schemaSuite) TestMapWithUnmetValuesConstraint(c *C) {
 	c.Assert(err, IsNil)
 
 	err = schema.Validate(input)
-	c.Assert(err, ErrorMatches, "cannot validate string: json: cannot unmarshal object into Go value of type string")
+	c.Assert(err, ErrorMatches, `cannot validate element under "snaps": cannot validate string: json: cannot unmarshal object into Go value of type string`)
 }
 
 func (*schemaSuite) TestMapSchemaMetConstraintsWithMissingEntry(c *C) {
@@ -323,7 +323,7 @@ func (*schemaSuite) TestMapSchemaUnmetConstraint(c *C) {
 	c.Assert(err, IsNil)
 
 	err = schema.Validate(input)
-	c.Assert(err, ErrorMatches, `cannot validate string: json: cannot unmarshal object into Go value of type string`)
+	c.Assert(err, ErrorMatches, `cannot validate element under "bar": cannot validate string: json: cannot unmarshal object into Go value of type string`)
 }
 
 func (*schemaSuite) TestMapSchemaWithMetRequiredConstraint(c *C) {
@@ -369,7 +369,7 @@ func (*schemaSuite) TestMapSchemaWithUnmetRequiredConstraint(c *C) {
 	c.Assert(err, IsNil)
 
 	err = schema.Validate(input)
-	c.Assert(err, ErrorMatches, "cannot find required combinations of keys")
+	c.Assert(err, ErrorMatches, `cannot validate top level element: cannot find required combinations of keys`)
 }
 
 func (*schemaSuite) TestMapSchemaWithAlternativeOfRequiredEntries(c *C) {
@@ -425,7 +425,7 @@ func (*schemaSuite) TestMapSchemaWithUnmetAlternativeOfRequiredEntries(c *C) {
 	c.Assert(err, IsNil)
 
 	err = schema.Validate(input)
-	c.Assert(err, ErrorMatches, "cannot find required combinations of keys")
+	c.Assert(err, ErrorMatches, `cannot validate top level element: cannot find required combinations of keys`)
 }
 
 func (*schemaSuite) TestMapSchemaRequiredNotInSchema(c *C) {
@@ -566,7 +566,7 @@ func (*schemaSuite) TestStringsWithChoicesFail(c *C) {
 	c.Assert(err, IsNil)
 
 	err = schema.Validate(input)
-	c.Assert(err, ErrorMatches, `string "baz" is not one of the allowed choices`)
+	c.Assert(err, ErrorMatches, `cannot validate element under "snaps": string "baz" is not one of the allowed choices`)
 }
 
 func (*schemaSuite) TestStringChoicesAndPatternsFail(c *C) {
@@ -630,7 +630,7 @@ func (*schemaSuite) TestStringPatternNoMatch(c *C) {
 	c.Assert(err, IsNil)
 
 	err = schema.Validate(input)
-	c.Assert(err, ErrorMatches, `string "F00" doesn't match schema pattern \[fb\]00`)
+	c.Assert(err, ErrorMatches, `cannot validate element under "foo": string "F00" doesn't match schema pattern \[fb\]00`)
 }
 
 func (*schemaSuite) TestStringPatternWrongFormat(c *C) {
@@ -892,7 +892,7 @@ func (*schemaSuite) TestMapBasedUserDefinedTypeFail(c *C) {
 	c.Assert(err, IsNil)
 
 	err = schema.Validate(input)
-	c.Assert(err, ErrorMatches, `cannot validate string: json: .*`)
+	c.Assert(err, ErrorMatches, `cannot validate element under "snaps.version": cannot validate string: json: .*`)
 }
 
 func (*schemaSuite) TestBadUserDefinedTypeName(c *C) {
@@ -933,6 +933,7 @@ func (*schemaSuite) TestIntegerHappy(c *C) {
 	err = schema.Validate(input)
 	c.Assert(err, IsNil)
 }
+
 func (*schemaSuite) TestIntegerMustMatchChoices(c *C) {
 	schemaStr := []byte(`{
 	"schema": {
@@ -955,7 +956,7 @@ func (*schemaSuite) TestIntegerMustMatchChoices(c *C) {
 		if num == 1 || num == 3 {
 			c.Assert(err, IsNil)
 		} else {
-			c.Assert(err, ErrorMatches, fmt.Sprintf(`%d is not one of the allowed choices`, num))
+			c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot validate element under "foo": %d is not one of the allowed choices`, num))
 		}
 	}
 }
@@ -982,9 +983,10 @@ func (*schemaSuite) TestIntegerMustMatchMinMax(c *C) {
 
 		err := schema.Validate(input)
 		if num < min {
-			c.Assert(err, ErrorMatches, fmt.Sprintf(`%d is less than allowed minimum %d`, num, min))
+			c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot validate element under "foo": %d is less than the allowed minimum %d`, num, min))
 		} else if num > max {
-			c.Assert(err, ErrorMatches, fmt.Sprintf(`%d is greater than allowed maximum %d`, num, max))
+			c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot validate element under "foo": %d is greater than the allowed maximum %d`, num, max))
+
 		} else {
 			c.Assert(err, IsNil)
 		}
@@ -1006,14 +1008,14 @@ func (*schemaSuite) TestIntegerWithWrongTypes(c *C) {
 }`)
 
 	err = schema.Validate(input)
-	c.Assert(err, ErrorMatches, `json: cannot unmarshal string into Go value of type int64`)
+	c.Assert(err, ErrorMatches, `cannot validate element under "foo": json: cannot unmarshal string into Go value of type int64`)
 
 	input = []byte(`{
 	"foo": 3.14
 }`)
 
 	err = schema.Validate(input)
-	c.Assert(err, ErrorMatches, `json: cannot unmarshal number 3.14 into Go value of type int64`)
+	c.Assert(err, ErrorMatches, `cannot validate element under "foo": json: cannot unmarshal number 3.14 into Go value of type int64`)
 }
 
 func (*schemaSuite) TestIntegerChoicesAndMinMaxFail(c *C) {
@@ -1212,7 +1214,7 @@ func (*schemaSuite) TestAnyTypeRejectsBadJSON(c *C) {
 	"foo": .
 }`)
 	err = schema.Validate(input)
-	c.Assert(err, ErrorMatches, `invalid character .*`)
+	c.Assert(err, ErrorMatches, `cannot validate top level element: invalid character .*`)
 }
 
 func (*schemaSuite) TestNumberValidFloatAndInt(c *C) {
@@ -1257,7 +1259,7 @@ func (*schemaSuite) TestNumberMustMatchChoices(c *C) {
 		if num == 1 || num == 3 {
 			c.Assert(err, IsNil)
 		} else {
-			c.Assert(err, ErrorMatches, fmt.Sprintf(`%v is not one of the allowed choices`, num))
+			c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot validate element under "foo": %v is not one of the allowed choices`, num))
 		}
 	}
 }
@@ -1284,9 +1286,9 @@ func (*schemaSuite) TestNumberMustMatchMinMax(c *C) {
 
 		err := schema.Validate(input)
 		if num < min {
-			c.Assert(err, ErrorMatches, fmt.Sprintf(`%v is less than allowed minimum %v`, num, min))
+			c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot validate element under "foo": %v is less than the allowed minimum %v`, num, min))
 		} else if num > max {
-			c.Assert(err, ErrorMatches, fmt.Sprintf(`%v is greater than allowed maximum %v`, num, max))
+			c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot validate element under "foo": %v is greater than the allowed maximum %v`, num, max))
 		} else {
 			c.Assert(err, IsNil)
 		}
@@ -1308,7 +1310,7 @@ func (*schemaSuite) TestNumberWithWrongTypes(c *C) {
 }`)
 
 	err = schema.Validate(input)
-	c.Assert(err, ErrorMatches, `json: cannot unmarshal string into Go value of type float64`)
+	c.Assert(err, ErrorMatches, `cannot validate element under "foo": json: cannot unmarshal string into Go value of type float64`)
 }
 
 func (*schemaSuite) TestNumberChoicesAndMinMaxFail(c *C) {
@@ -1420,7 +1422,7 @@ func (*schemaSuite) TestSimpleTypesRejectNull(c *C) {
 		c.Assert(err, IsNil)
 
 		err = schema.Validate([]byte(`{"foo": null}`))
-		c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot accept null value for %q type`, typ))
+		c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot validate element under "foo": cannot accept null value for %q type`, typ))
 	}
 }
 
@@ -1439,7 +1441,7 @@ func (*schemaSuite) TestMapTypeRejectsNull(c *C) {
 	c.Assert(err, IsNil)
 
 	err = schema.Validate([]byte(`{"foo": null}`))
-	c.Assert(err, ErrorMatches, `cannot accept null value for "map" type`)
+	c.Assert(err, ErrorMatches, `cannot validate element under "foo": cannot accept null value for "map" type`)
 }
 
 func (*schemaSuite) TestUserDefinedTypeRejectsNull(c *C) {
@@ -1458,7 +1460,7 @@ func (*schemaSuite) TestUserDefinedTypeRejectsNull(c *C) {
 	c.Assert(err, IsNil)
 
 	err = schema.Validate([]byte(`{"foo": null}`))
-	c.Assert(err, ErrorMatches, `cannot accept null value for "string" type`)
+	c.Assert(err, ErrorMatches, `cannot validate element under "foo": cannot accept null value for "string" type`)
 }
 
 func (*schemaSuite) TestArrayRejectsNull(c *C) {
@@ -1475,7 +1477,7 @@ func (*schemaSuite) TestArrayRejectsNull(c *C) {
 
 	input := []byte(`{"foo": null}`)
 	err = schema.Validate(input)
-	c.Assert(err, ErrorMatches, `cannot accept null value for "array" type`)
+	c.Assert(err, ErrorMatches, `cannot validate element under "foo": cannot accept null value for "array" type`)
 }
 
 func (*schemaSuite) TestBooleanHappy(c *C) {
@@ -1515,7 +1517,7 @@ func (*schemaSuite) TestBooleanWrongType(c *C) {
 }`)
 
 	err = schema.Validate(input)
-	c.Assert(err, ErrorMatches, `json: cannot unmarshal number into Go value of type bool`)
+	c.Assert(err, ErrorMatches, `cannot validate element under "foo": json: cannot unmarshal number into Go value of type bool`)
 }
 
 func (*schemaSuite) TestArrayHappy(c *C) {
@@ -1619,7 +1621,7 @@ func (*schemaSuite) TestArrayEnforcesOnlyOneType(c *C) {
 }`)
 
 	err = schema.Validate(input)
-	c.Assert(err, ErrorMatches, `cannot validate string: json:.*`)
+	c.Assert(err, ErrorMatches, `cannot validate element under "foo": cannot validate string: json:.*`)
 }
 
 func (*schemaSuite) TestArrayWithUniqueRejectsDuplicates(c *C) {
@@ -1641,7 +1643,7 @@ func (*schemaSuite) TestArrayWithUniqueRejectsDuplicates(c *C) {
 }`)
 
 	err = schema.Validate(input)
-	c.Assert(err, ErrorMatches, `cannot accept duplicate values for array with "unique" constraint`)
+	c.Assert(err, ErrorMatches, `cannot validate element under "foo": cannot accept duplicate values for array with "unique" constraint`)
 }
 
 func (*schemaSuite) TestArrayWithoutUniqueAcceptsDuplicates(c *C) {
@@ -1679,4 +1681,155 @@ func (*schemaSuite) TestArrayFailsWithBadUniqueType(c *C) {
 
 	_, err := aspects.ParseSchema(schemaStr)
 	c.Assert(err, ErrorMatches, `cannot parse array's "unique" constraint: json: cannot unmarshal string into Go value of type bool`)
+}
+
+func (*schemaSuite) TestErrorContainsPathPrefixes(c *C) {
+	schemaStr := []byte(`{
+	"schema": {
+		"foo": {
+			"schema": {
+				"bar": {
+					"schema": {
+						"baz": "string"
+					}
+				}
+			}
+		}
+	}
+}`)
+
+	schema, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, IsNil)
+
+	type testcase struct {
+		name  string
+		input []byte
+		err   string
+	}
+
+	testcases := []testcase{
+		{
+			name:  "top level",
+			input: []byte(`{"bar": 1}`),
+			err:   `cannot validate top level element: map contains unexpected key "bar"`,
+		},
+		{
+			name:  "1 level of nesting",
+			input: []byte(`{"foo": {"baz": 1}}`),
+			err:   `cannot validate element under "foo": map contains unexpected key "baz"`,
+		},
+		{
+			name:  "2 levels of nesting",
+			input: []byte(`{"foo": {"bar": {"boo": 1}}}`),
+			err:   `cannot validate element under "foo.bar": map contains unexpected key "boo"`,
+		},
+	}
+
+	for _, tc := range testcases {
+		err = schema.Validate(tc.input)
+		c.Assert(err, ErrorMatches, tc.err, Commentf("test case %q failed", tc.name))
+	}
+}
+
+func (*schemaSuite) TestPathPrefixWithMapUnderUserType(c *C) {
+	schemaStr := []byte(`{
+	"types": {
+		"my-type": {
+			"schema": {
+				"bar": {
+					"type": "int",
+					"min": 0
+				}
+			}
+		}
+	},
+	"schema": {
+		"foo": "$my-type"
+	}
+}`)
+
+	schema, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, IsNil)
+
+	input := []byte(`{"foo": {"bar": -1}}`)
+	err = schema.Validate(input)
+	c.Assert(err, ErrorMatches, `cannot validate element under "foo.bar": -1 is less than the allowed minimum 0`)
+}
+
+func (*schemaSuite) TestPathPrefixWithArrayUnderUserType(c *C) {
+	schemaStr := []byte(`{
+	"types": {
+		"my-type": {
+			"type": "int",
+			"min": 0
+		}
+	},
+	"schema": {
+		"foo": {
+			"type": "array",
+			"values": "$my-type"
+		}
+	}
+}`)
+	schema, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, IsNil)
+
+	input := []byte(`{"foo": [-1]}`)
+	err = schema.Validate(input)
+	c.Assert(err, ErrorMatches, `cannot validate element under "foo": -1 is less than the allowed minimum 0`)
+}
+
+func (*schemaSuite) TestPathPrefixWithArrayUnderUserWithAContainerElementType(c *C) {
+	schemaStr := []byte(`{
+	"types": {
+		"my-type": {
+			"type": "array",
+			"values": {
+				"schema": {
+					"bar": {
+						"type": "int",
+						"min": 0
+					}
+				}
+			}
+		}
+	},
+	"schema": {
+		"foo": "$my-type"
+	}
+}`)
+	schema, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, IsNil)
+
+	input := []byte(`{"foo": [{"bar": -1}]}`)
+	err = schema.Validate(input)
+	c.Assert(err, ErrorMatches, `cannot validate element under "foo.bar": -1 is less than the allowed minimum 0`)
+}
+
+func (*schemaSuite) TestPathPrefixWithKeyOrValueConstraints(c *C) {
+	schemaStr := []byte(`{
+	"schema": {
+		"foo": {
+			"type": "map",
+			"keys": {
+				"type": "string",
+				"choices": ["my-key"]
+			},
+			"values": {
+				"type": "int",
+				"min": 0
+			}
+		}
+	}
+}`)
+	schema, err := aspects.ParseSchema(schemaStr)
+	c.Assert(err, IsNil)
+
+	input := []byte(`{"foo": {"other-key": 1}}`)
+	err = schema.Validate(input)
+	c.Assert(err, ErrorMatches, `cannot validate element under "foo": string "other-key" is not one of the allowed choices`)
+
+	input = []byte(`{"foo": {"my-key": -1}}`)
+	err = schema.Validate(input)
+	c.Assert(err, ErrorMatches, `cannot validate element under "foo": -1 is less than the allowed minimum 0`)
 }


### PR DESCRIPTION
Add path prefixes to validation errors to help users identify the element breaking the aspect's constraints. This turned out to be a bit more complex than I initially thought because elements aren't necessarily parsed in a top-down, BFS-like way. This is because there are user-defined types which are parsed first and then referenced in other definitions. So these pre-parsed schemas need to be updated with the correct path when they are referenced and container types (maps and arrays) need to propagate that down to the schemas that they contain.