### PR TITLE
many: add components side info to snapstate

### DIFF
--- a/daemon/api_aliases_test.go
+++ b/daemon/api_aliases_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 )
@@ -520,9 +521,9 @@ func (s *aliasesSuite) TestAliases(c *check.C) {
 	st := d.Overlord().State()
 	st.Lock()
 	snapstate.Set(st, "alias-snap1", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap1", Revision: snap.R(11)},
-		},
+		}),
 		Current: snap.R(11),
 		Active:  true,
 		Aliases: map[string]*snapstate.AliasTarget{
@@ -531,9 +532,9 @@ func (s *aliasesSuite) TestAliases(c *check.C) {
 		},
 	})
 	snapstate.Set(st, "alias-snap2", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap2", Revision: snap.R(12)},
-		},
+		}),
 		Current:             snap.R(12),
 		Active:              true,
 		AutoAliasesDisabled: true,

--- a/daemon/api_base_test.go
+++ b/daemon/api_base_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/snapcore/snapd/overlord/devicestate/devicestatetest"
 	"github.com/snapcore/snapd/overlord/ifacestate"
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/sandbox"
 	"github.com/snapcore/snapd/snap"
@@ -414,13 +415,13 @@ func (s *apiBaseSuite) mockSnap(c *check.C, yamlText string) *snap.Info {
 	// Put a side info into the state
 	snapstate.Set(st, snapInfo.InstanceName(), &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{
 				RealName: snapInfo.SnapName(),
 				Revision: snapInfo.Revision,
 				SnapID:   "ididid",
 			},
-		},
+		}),
 		Current:  snapInfo.Revision,
 		SnapType: string(snapInfo.Type()),
 	})
@@ -481,7 +482,7 @@ version: %s
 	var snapst snapstate.SnapState
 	snapstate.Get(st, instanceName, &snapst)
 	snapst.Active = active
-	snapst.Sequence = append(snapst.Sequence, &snapInfo.SideInfo)
+	snapst.Sequence.Revisions = append(snapst.Sequence.Revisions, snapstate.NewRevisionSideInfo(&snapInfo.SideInfo, nil))
 	snapst.Current = snapInfo.SideInfo.Revision
 	snapst.TrackingChannel = "stable"
 	snapst.InstanceKey = instanceKey

--- a/daemon/api_find_test.go
+++ b/daemon/api_find_test.go
@@ -128,10 +128,10 @@ func (s *findSuite) TestFindRefreshSideloaded(c *check.C) {
 	err := snapstate.Get(st, "store", &snapst)
 	st.Unlock()
 	c.Assert(err, check.IsNil)
-	c.Assert(snapst.Sequence, check.HasLen, 1)
+	c.Assert(snapst.Sequence.Revisions, check.HasLen, 1)
 
 	// clear the snapid
-	snapst.Sequence[0].SnapID = ""
+	snapst.Sequence.Revisions[0].Snap.SnapID = ""
 	st.Lock()
 	snapstate.Set(st, "store", &snapst)
 	st.Unlock()

--- a/daemon/api_snap_file_test.go
+++ b/daemon/api_snap_file_test.go
@@ -66,7 +66,7 @@ func (s *snapFileSuite) TestGetFile(c *check.C) {
 				sideInfo := &snap.SideInfo{Revision: snap.R(-1), RealName: "foo"}
 				snapst.Active = scen.active
 				snapst.Current = sideInfo.Revision
-				snapst.Sequence = append(snapst.Sequence, sideInfo)
+				snapst.Sequence.Revisions = append(snapst.Sequence.Revisions, snapstate.NewRevisionSideInfo(sideInfo, nil))
 				if scen.try {
 					snapst.TryMode = true
 				}

--- a/daemon/api_validate_test.go
+++ b/daemon/api_validate_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/snapcore/snapd/overlord/assertstate/assertstatetest"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/naming"
@@ -394,12 +395,12 @@ func (s *apiValidationSetsSuite) TestGetValidationSetLatestFromRemote(c *check.C
 
 	snapstate.Set(st, "snap-a", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{{RealName: "snap-a", Revision: snap.R(2), SnapID: "snapaid"}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "snap-a", Revision: snap.R(2), SnapID: "snapaid"}}),
 		Current:  snap.R(2),
 	})
 	snapstate.Set(st, "snap-b", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{{RealName: "snap-b", Revision: snap.R(4), SnapID: "snapbid"}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "snap-b", Revision: snap.R(4), SnapID: "snapbid"}}),
 		Current:  snap.R(4),
 	})
 
@@ -462,7 +463,7 @@ func (s *apiValidationSetsSuite) TestGetValidationSetLatestFromRemoteRealValidat
 		st.Lock()
 		snapstate.Set(st, "snap-b", &snapstate.SnapState{
 			Active:   true,
-			Sequence: []*snap.SideInfo{{RealName: "snap-b", Revision: tc.revision, SnapID: "yOqKhntON3vR7kwEbVPsILm7bUViPDzz"}},
+			Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "snap-b", Revision: tc.revision, SnapID: "yOqKhntON3vR7kwEbVPsILm7bUViPDzz"}}),
 			Current:  tc.revision,
 		})
 		st.Unlock()
@@ -519,7 +520,7 @@ func (s *apiValidationSetsSuite) TestGetValidationSetSpecificSequenceFromRemote(
 
 	snapstate.Set(st, "snap-a", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{{RealName: "snap-a", Revision: snap.R(33), SnapID: "snapaid"}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "snap-a", Revision: snap.R(33), SnapID: "snapaid"}}),
 		Current:  snap.R(33),
 	})
 
@@ -805,7 +806,7 @@ func (s *apiValidationSetsSuite) TestApplyValidationSetEnforceMode(c *check.C) {
 
 	snapstate.Set(st, "snap-b", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{{RealName: "snap-b", Revision: snap.R(1), SnapID: "yOqKhntON3vR7kwEbVPsILm7bUViPDzz"}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "snap-b", Revision: snap.R(1), SnapID: "yOqKhntON3vR7kwEbVPsILm7bUViPDzz"}}),
 		Current:  snap.R(1),
 	})
 
@@ -857,7 +858,7 @@ func (s *apiValidationSetsSuite) TestApplyValidationSetEnforceModeIgnoreValidati
 
 	snapstate.Set(st, "snap-b", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{{RealName: "snap-b", Revision: snap.R(1), SnapID: "yOqKhntON3vR7kwEbVPsILm7bUViPDzz"}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "snap-b", Revision: snap.R(1), SnapID: "yOqKhntON3vR7kwEbVPsILm7bUViPDzz"}}),
 		Current:  snap.R(1),
 		Flags:    snapstate.Flags{IgnoreValidation: true},
 	})
@@ -907,7 +908,7 @@ func (s *apiValidationSetsSuite) TestApplyValidationSetEnforceModeSpecificSequen
 
 	snapstate.Set(st, "snap-b", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{{RealName: "snap-b", Revision: snap.R(1), SnapID: "yOqKhntON3vR7kwEbVPsILm7bUViPDzz"}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "snap-b", Revision: snap.R(1), SnapID: "yOqKhntON3vR7kwEbVPsILm7bUViPDzz"}}),
 		Current:  snap.R(1),
 	})
 
@@ -945,7 +946,7 @@ func (s *apiValidationSetsSuite) TestApplyValidationSetEnforceModeError(c *check
 
 	snapstate.Set(st, "snap-b", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{{RealName: "snap-b", Revision: snap.R(1), SnapID: "yOqKhntON3vR7kwEbVPsILm7bUViPDzz"}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "snap-b", Revision: snap.R(1), SnapID: "yOqKhntON3vR7kwEbVPsILm7bUViPDzz"}}),
 		Current:  snap.R(1),
 	})
 

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/snapcore/snapd/overlord/patch"
 	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/standby"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
@@ -610,7 +611,7 @@ func (s *daemonSuite) TestStartStop(c *check.C) {
 	si := &snap.SideInfo{RealName: "core", Revision: snap.R(1), SnapID: "core-snap-id"}
 	snapstate.Set(st, "core", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  snap.R(1),
 	})
 	st.Unlock()
@@ -749,7 +750,7 @@ func (s *daemonSuite) TestGracefulStop(c *check.C) {
 	si := &snap.SideInfo{RealName: "core", Revision: snap.R(1), SnapID: "core-snap-id"}
 	snapstate.Set(st, "core", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  snap.R(1),
 	})
 	st.Unlock()

--- a/daemon/snap.go
+++ b/daemon/snap.go
@@ -135,20 +135,20 @@ func allLocalSnapInfos(st *state.State, all bool, wanted map[string]bool) ([]abo
 		var aboutThis []aboutSnap
 		var info *snap.Info
 		if all {
-			for _, seq := range snapst.Sequence {
-				info, err = snap.ReadInfo(name, seq)
+			for _, si := range snapst.Sequence.SideInfos() {
+				info, err = snap.ReadInfo(name, si)
 				if err != nil {
 					// single revision may be broken
 					_, instanceKey := snap.SplitInstanceName(name)
 					info = &snap.Info{
-						SideInfo:    *seq,
+						SideInfo:    *si,
 						InstanceKey: instanceKey,
 						Broken:      err.Error(),
 					}
 					// clear the error
 					err = nil
 				}
-				info.Publisher, err = assertstate.PublisherStoreAccount(st, seq.SnapID)
+				info.Publisher, err = assertstate.PublisherStoreAccount(st, si.SnapID)
 				if err != nil {
 					return nil, err
 				}

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -1164,9 +1164,9 @@ func (s *assertMgrSuite) stateFromDecl(c *C, decl *asserts.SnapDeclaration, inst
 	snapID := decl.SnapID()
 	snapstate.Set(s.state, instanceName, &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: snapName, SnapID: snapID, Revision: revno},
-		},
+		}),
 		Current:     revno,
 		InstanceKey: instanceKey,
 	})
@@ -1291,9 +1291,9 @@ func (s *assertMgrSuite) TestRefreshSnapDeclarationsNoStore(c *C) {
 	s.stateFromDecl(c, snapDeclBar, "", snap.R(3))
 	snapstate.Set(s.state, "local", &snapstate.SnapState{
 		Active: false,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "local", Revision: snap.R(-1)},
-		},
+		}),
 		Current: snap.R(-1),
 	})
 
@@ -2107,9 +2107,9 @@ func (s *assertMgrSuite) TestValidateRefreshesValidationOK(c *C) {
 	s.stateFromDecl(c, snapDeclBaz, "", snap.R(1))
 	snapstate.Set(s.state, "local", &snapstate.SnapState{
 		Active: false,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "local", Revision: snap.R(-1)},
-		},
+		}),
 		Current: snap.R(-1),
 	})
 
@@ -2179,9 +2179,9 @@ func (s *assertMgrSuite) TestValidateRefreshesRevokedValidation(c *C) {
 	s.stateFromDecl(c, snapDeclBaz, "", snap.R(1))
 	snapstate.Set(s.state, "local", &snapstate.SnapState{
 		Active: false,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "local", Revision: snap.R(-1)},
-		},
+		}),
 		Current: snap.R(-1),
 	})
 
@@ -2827,7 +2827,7 @@ func (s *assertMgrSuite) TestRefreshValidationSetAssertionsEnforcingModeHappyNot
 
 	snapstate.Set(s.state, "foo", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{{RealName: "foo", Revision: snap.R(1), SnapID: "qOqKhntON3vR7kwEbVPsILm7bUViPDzz"}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "foo", Revision: snap.R(1), SnapID: "qOqKhntON3vR7kwEbVPsILm7bUViPDzz"}}),
 		Current:  snap.R(1),
 	})
 	snaptest.MockSnap(c, string(`name: foo
@@ -2911,7 +2911,7 @@ func (s *assertMgrSuite) TestRefreshValidationSetAssertionsEnforcingModeHappyPin
 
 	snapstate.Set(s.state, "foo", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{{RealName: "foo", Revision: snap.R(1), SnapID: "qOqKhntON3vR7kwEbVPsILm7bUViPDzz"}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "foo", Revision: snap.R(1), SnapID: "qOqKhntON3vR7kwEbVPsILm7bUViPDzz"}}),
 		Current:  snap.R(1),
 	})
 	snaptest.MockSnap(c, string(`name: foo
@@ -3120,9 +3120,9 @@ func (s *assertMgrSuite) TestRefreshValidationSetAssertionsEnforcingModeWrongSna
 
 	snapstate.Set(s.state, "foo", &snapstate.SnapState{
 		Active: false,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "foo", Revision: snap.R(1)},
-		},
+		}),
 		Current: snap.R(1),
 	})
 

--- a/overlord/configstate/configcore/kernel_test.go
+++ b/overlord/configstate/configcore/kernel_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/hookstate/hooktest"
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
@@ -226,7 +227,7 @@ func (s *kernelSuite) mockGadget(c *C) {
 	defer s.state.Unlock()
 	snapstate.Set(s.state, "pc", &snapstate.SnapState{
 		SnapType: "gadget",
-		Sequence: []*snap.SideInfo{pcSideInfo},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{pcSideInfo}),
 		Current:  pcSideInfo.Revision,
 		Active:   true,
 	})

--- a/overlord/configstate/configcore/vitality_test.go
+++ b/overlord/configstate/configcore/vitality_test.go
@@ -133,7 +133,7 @@ func (s *vitalitySuite) testConfigureVitalityWithValidSnap(c *C, uc18 bool) {
 	snaptest.MockSnap(c, mockSnapWithService, si)
 	s.state.Lock()
 	snapstate.Set(s.state, "test-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  snap.R(1),
 		Active:   true,
 		SnapType: "app",
@@ -173,7 +173,7 @@ func (s *vitalitySuite) TestConfigureVitalityWithQuotaGroup(c *C) {
 	snaptest.MockSnap(c, mockSnapWithService, si)
 	s.state.Lock()
 	snapstate.Set(s.state, "test-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  snap.R(1),
 		Active:   true,
 		SnapType: "app",
@@ -241,7 +241,7 @@ func (s *vitalitySuite) TestConfigureVitalityManySnaps(c *C) {
 		snaptest.MockSnap(c, mockSnapWithService, si)
 		s.state.Lock()
 		snapstate.Set(s.state, snapName, &snapstate.SnapState{
-			Sequence: []*snap.SideInfo{si},
+			Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 			Current:  snap.R(1),
 			Active:   true,
 			SnapType: "app",
@@ -272,7 +272,7 @@ func (s *vitalitySuite) TestConfigureVitalityManySnapsDelta(c *C) {
 		snaptest.MockSnap(c, mockSnapWithService, si)
 		s.state.Lock()
 		snapstate.Set(s.state, snapName, &snapstate.SnapState{
-			Sequence: []*snap.SideInfo{si},
+			Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 			Current:  snap.R(1),
 			Active:   true,
 			SnapType: "app",
@@ -307,7 +307,7 @@ func (s *vitalitySuite) TestConfigureVitalityManySnapsOneRemovedOneUnchanged(c *
 		snaptest.MockSnap(c, mockSnapWithService, si)
 		s.state.Lock()
 		snapstate.Set(s.state, snapName, &snapstate.SnapState{
-			Sequence: []*snap.SideInfo{si},
+			Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 			Current:  snap.R(1),
 			Active:   true,
 			SnapType: "app",
@@ -365,7 +365,7 @@ func (s *vitalitySuite) TestConfigureVitalityNotActiveSnap(c *C) {
 	snaptest.MockSnap(c, mockSnapWithService, si)
 	s.state.Lock()
 	snapstate.Set(s.state, "test-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  snap.R(1),
 		Active:   false,
 		SnapType: "app",

--- a/overlord/configstate/configstate_test.go
+++ b/overlord/configstate/configstate_test.go
@@ -88,9 +88,9 @@ var configureTests = []struct {
 func (s *tasksetsSuite) TestConfigureInstalled(c *C) {
 	s.state.Lock()
 	snapstate.Set(s.state, "test-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "test-snap", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		Active:   true,
 		SnapType: "app",
@@ -161,9 +161,9 @@ func (s *tasksetsSuite) TestConfigureInstalledConflict(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 	snapstate.Set(s.state, "test-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "test-snap", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		Active:   true,
 		SnapType: "app",
@@ -197,9 +197,9 @@ func (s *tasksetsSuite) TestConfigureInstalledDenyBases(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 	snapstate.Set(s.state, "test-base", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "test-base", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		Active:   true,
 		SnapType: "base",
@@ -214,9 +214,9 @@ func (s *tasksetsSuite) TestConfigureInstalledDenySnapd(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 	snapstate.Set(s.state, "snapd", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "snapd", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		Active:   true,
 		SnapType: "snapd",
@@ -229,9 +229,9 @@ func (s *tasksetsSuite) TestConfigureInstalledDenySnapd(c *C) {
 func (s *tasksetsSuite) TestDefaultConfigure(c *C) {
 	s.state.Lock()
 	snapstate.Set(s.state, "test-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "test-snap", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		Active:   true,
 		SnapType: "app",

--- a/overlord/configstate/handler_test.go
+++ b/overlord/configstate/handler_test.go
@@ -79,9 +79,9 @@ type: os
 	})
 	snapstate.Set(s.state, "core", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "core", Revision: snap.R(1), SnapID: "core-snap-id"},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "os",
 	})
@@ -158,9 +158,9 @@ volumes:
 	s.state.Lock()
 	snapstate.Set(s.state, "canonical-pc", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "canonical-pc", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "gadget",
 	})
@@ -179,9 +179,9 @@ hooks:
 	snaptest.MockSnap(c, mockTestSnapYaml, &snap.SideInfo{Revision: snap.R(11)})
 	snapstate.Set(s.state, "test-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "test-snap", Revision: snap.R(11), SnapID: "testsnapidididididididididididid"},
-		},
+		}),
 		Current:  snap.R(11),
 		SnapType: "app",
 	})
@@ -232,9 +232,9 @@ volumes:
 	s.state.Lock()
 	snapstate.Set(s.state, "canonical-pc", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "canonical-pc", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "gadget",
 	})
@@ -246,9 +246,9 @@ volumes:
 
 	snapstate.Set(s.state, "test-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "test-snap", Revision: snap.R(11), SnapID: "testsnapidididididididididididid"},
-		},
+		}),
 		Current:  snap.R(11),
 		SnapType: "app",
 	})
@@ -320,9 +320,9 @@ hooks:
 	s.state.Lock()
 	snapstate.Set(s.state, "test-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "test-snap", Revision: snap.R(11), SnapID: "testsnapidididididididididididid"},
-		},
+		}),
 		Current:  snap.R(11),
 		SnapType: "app",
 	})
@@ -363,9 +363,9 @@ volumes:
 	s.state.Lock()
 	snapstate.Set(s.state, "canonical-pc", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "canonical-pc", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "gadget",
 	})
@@ -385,9 +385,9 @@ hooks:
 	snaptest.MockSnap(c, mockTestSnapYaml, &snap.SideInfo{Revision: snap.R(11)})
 	snapstate.Set(s.state, "test-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "test-snap", Revision: snap.R(11), SnapID: "testsnapidididididididididididid"},
-		},
+		}),
 		Current:  snap.R(11),
 		SnapType: "app",
 	})
@@ -471,9 +471,9 @@ func (s *configcoreHandlerSuite) SetUpTest(c *C) {
 	s.state.Set("seeded", true)
 	snapstate.Set(s.state, "canonical-pc", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "canonical-pc", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "gadget",
 	})
@@ -510,9 +510,9 @@ volumes:
 
 	snapstate.Set(s.state, "snapd", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "snapd", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "snapd",
 	})
@@ -570,9 +570,9 @@ volumes:
 
 	snapstate.Set(s.state, "core", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "core", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "os",
 	})

--- a/overlord/devicestate/devicestate_bootconfig_test.go
+++ b/overlord/devicestate/devicestate_bootconfig_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/snapcore/snapd/overlord/devicestate/devicestatetest"
 	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
@@ -61,7 +62,7 @@ func (s *deviceMgrBootconfigSuite) mockGadget(c *C, yaml string) {
 	}
 	snapstate.Set(s.state, "pc", &snapstate.SnapState{
 		SnapType: "gadget",
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 		Active:   true,
 	})

--- a/overlord/devicestate/devicestate_gadget_test.go
+++ b/overlord/devicestate/devicestate_gadget_test.go
@@ -274,7 +274,7 @@ func (s *deviceMgrGadgetSuite) setupGadgetUpdate(c *C, modelGrade, gadgetYamlCon
 
 	snapstate.Set(s.state, "foo-gadget", &snapstate.SnapState{
 		SnapType: "gadget",
-		Sequence: []*snap.SideInfo{siCurrent},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siCurrent}),
 		Current:  siCurrent.Revision,
 		Active:   true,
 	})
@@ -607,7 +607,7 @@ func (s *deviceMgrGadgetSuite) TestUpdateGadgetOnCoreBadGadgetYaml(c *C) {
 
 	snapstate.Set(s.state, "foo-gadget", &snapstate.SnapState{
 		SnapType: "gadget",
-		Sequence: []*snap.SideInfo{siCurrent},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siCurrent}),
 		Current:  siCurrent.Revision,
 		Active:   true,
 	})
@@ -658,7 +658,7 @@ func (s *deviceMgrGadgetSuite) TestUpdateGadgetOnCoreParanoidChecks(c *C) {
 
 	snapstate.Set(s.state, "foo-gadget", &snapstate.SnapState{
 		SnapType: "gadget",
-		Sequence: []*snap.SideInfo{siCurrent},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siCurrent}),
 		Current:  siCurrent.Revision,
 		Active:   true,
 	})
@@ -776,7 +776,7 @@ volumes:
 
 	snapstate.Set(s.state, "foo-gadget", &snapstate.SnapState{
 		SnapType: "gadget",
-		Sequence: []*snap.SideInfo{siCurrent},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siCurrent}),
 		Current:  siCurrent.Revision,
 		Active:   true,
 	})
@@ -839,7 +839,7 @@ func (s *deviceMgrGadgetSuite) TestCurrentAndUpdateInfo(c *C) {
 
 	snapstate.Set(s.state, "foo-gadget", &snapstate.SnapState{
 		SnapType: "gadget",
-		Sequence: []*snap.SideInfo{siCurrent},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siCurrent}),
 		Current:  siCurrent.Revision,
 		Active:   true,
 	})
@@ -1041,7 +1041,7 @@ volumes:
 	s.setupModelWithGadget(c, "foo-gadget")
 	snapstate.Set(s.state, "foo-gadget", &snapstate.SnapState{
 		SnapType: "gadget",
-		Sequence: []*snap.SideInfo{siGadget},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siGadget}),
 		Current:  siGadget.Revision,
 		Active:   true,
 	})
@@ -1061,7 +1061,7 @@ volumes:
 	snaptest.MockSnapWithFiles(c, snapKernelYaml, siNext, nil)
 	snapstate.Set(s.state, "pc-kernel", &snapstate.SnapState{
 		SnapType: "kernel",
-		Sequence: []*snap.SideInfo{siNext, siCurrent},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siNext, siCurrent}),
 		Current:  siCurrent.Revision,
 		Active:   true,
 	})
@@ -1201,7 +1201,7 @@ func (s *deviceMgrGadgetSuite) testGadgetCommandlineUpdateRun(c *C, fromFiles, t
 	}
 	snapstate.Set(s.state, "pc", &snapstate.SnapState{
 		SnapType: "gadget",
-		Sequence: []*snap.SideInfo{currentSi},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{currentSi}),
 		Current:  currentSi.Revision,
 		Active:   true,
 	})
@@ -1776,7 +1776,7 @@ func (s *deviceMgrGadgetSuite) TestGadgetCommandlineUpdateUndo(c *C) {
 	}
 	snapstate.Set(s.state, "pc", &snapstate.SnapState{
 		SnapType: "gadget",
-		Sequence: []*snap.SideInfo{currentSi},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{currentSi}),
 		Current:  currentSi.Revision,
 		Active:   true,
 	})
@@ -1908,7 +1908,7 @@ func (s *deviceMgrGadgetSuite) TestGadgetCommandlineClassicWithModesUpdateUndo(c
 	}
 	snapstate.Set(s.state, "pc", &snapstate.SnapState{
 		SnapType: "gadget",
-		Sequence: []*snap.SideInfo{currentSi},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{currentSi}),
 		Current:  currentSi.Revision,
 		Active:   true,
 	})
@@ -2027,7 +2027,7 @@ func (s *deviceMgrGadgetSuite) TestGadgetCommandlineUpdateNoChangeNoRebootsUndo(
 	}
 	snapstate.Set(s.state, "pc", &snapstate.SnapState{
 		SnapType: "gadget",
-		Sequence: []*snap.SideInfo{currentSi},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{currentSi}),
 		Current:  currentSi.Revision,
 		Active:   true,
 	})

--- a/overlord/devicestate/devicestate_install_mode_test.go
+++ b/overlord/devicestate/devicestate_install_mode_test.go
@@ -143,7 +143,7 @@ func (s *deviceMgrInstallModeSuite) makeMockInstalledPcKernelAndGadget(c *C, ins
 	}
 	snapstate.Set(s.state, "pc-kernel", &snapstate.SnapState{
 		SnapType: "kernel",
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 		Active:   true,
 	})
@@ -159,7 +159,7 @@ func (s *deviceMgrInstallModeSuite) makeMockInstalledPcKernelAndGadget(c *C, ins
 	}
 	snapstate.Set(s.state, "core20", &snapstate.SnapState{
 		SnapType: "base",
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 		Active:   true,
 	})
@@ -176,7 +176,7 @@ func (s *deviceMgrInstallModeSuite) makeMockInstalledPcGadget(c *C, installDevic
 	}
 	snapstate.Set(s.state, "pc", &snapstate.SnapState{
 		SnapType: "gadget",
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 		Active:   true,
 	})

--- a/overlord/devicestate/devicestate_remodel_test.go
+++ b/overlord/devicestate/devicestate_remodel_test.go
@@ -1433,7 +1433,7 @@ volumes:
 
 	snapstate.Set(s.state, "gadget", &snapstate.SnapState{
 		SnapType: "gadget",
-		Sequence: []*snap.SideInfo{siCurrent},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siCurrent}),
 		Current:  siCurrent.Revision,
 		Active:   true,
 	})
@@ -1619,7 +1619,7 @@ volumes:
 	})
 	snapstate.Set(s.state, "pc", &snapstate.SnapState{
 		SnapType: "gadget",
-		Sequence: []*snap.SideInfo{siModelGadget},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siModelGadget}),
 		Current:  siModelGadget.Revision,
 		Active:   true,
 	})
@@ -1795,7 +1795,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelGadgetAssetsParanoidCheck(c *C) {
 	}
 	snapstate.Set(s.state, "pc", &snapstate.SnapState{
 		SnapType: "gadget",
-		Sequence: []*snap.SideInfo{siModelGadget},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siModelGadget}),
 		Current:  siModelGadget.Revision,
 		Active:   true,
 	})
@@ -1991,7 +1991,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20RequiredSnapsAndRecoverySystem(c 
 	}
 	snapstate.Set(s.state, "pc", &snapstate.SnapState{
 		SnapType:        "gadget",
-		Sequence:        []*snap.SideInfo{siModelGadget},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siModelGadget}),
 		Current:         siModelGadget.Revision,
 		Active:          true,
 		TrackingChannel: "20/stable",
@@ -2004,7 +2004,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20RequiredSnapsAndRecoverySystem(c 
 	}
 	snapstate.Set(s.state, "pc-kernel", &snapstate.SnapState{
 		SnapType:        "kernel",
-		Sequence:        []*snap.SideInfo{siModelKernel},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siModelKernel}),
 		Current:         siModelKernel.Revision,
 		Active:          true,
 		TrackingChannel: "20/stable",
@@ -2017,7 +2017,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20RequiredSnapsAndRecoverySystem(c 
 	}
 	snapstate.Set(s.state, "core20", &snapstate.SnapState{
 		SnapType:        "base",
-		Sequence:        []*snap.SideInfo{siModelBase},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siModelBase}),
 		Current:         siModelBase.Revision,
 		Active:          true,
 		TrackingChannel: "latest/stable",
@@ -2030,7 +2030,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20RequiredSnapsAndRecoverySystem(c 
 	}
 	snapstate.Set(s.state, "snapd", &snapstate.SnapState{
 		SnapType:        "snapd",
-		Sequence:        []*snap.SideInfo{siModelSnapd},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siModelSnapd}),
 		Current:         siModelSnapd.Revision,
 		Active:          true,
 		TrackingChannel: "latest/stable",
@@ -2323,7 +2323,7 @@ func (s *deviceMgrRemodelSuite) testRemodelUC20SwitchKernelGadgetBaseSnaps(c *C,
 	}
 	snapstate.Set(s.state, "pc", &snapstate.SnapState{
 		SnapType: "gadget",
-		Sequence: []*snap.SideInfo{siModelGadget},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siModelGadget}),
 		Current:  siModelGadget.Revision,
 		Active:   true,
 	})
@@ -2335,7 +2335,7 @@ func (s *deviceMgrRemodelSuite) testRemodelUC20SwitchKernelGadgetBaseSnaps(c *C,
 	}
 	snapstate.Set(s.state, "pc-kernel", &snapstate.SnapState{
 		SnapType: "kernel",
-		Sequence: []*snap.SideInfo{siModelKernel},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siModelKernel}),
 		Current:  siModelKernel.Revision,
 		Active:   true,
 	})
@@ -2347,7 +2347,7 @@ func (s *deviceMgrRemodelSuite) testRemodelUC20SwitchKernelGadgetBaseSnaps(c *C,
 	}
 	snapstate.Set(s.state, "core20", &snapstate.SnapState{
 		SnapType:        "base",
-		Sequence:        []*snap.SideInfo{siModelBase},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siModelBase}),
 		Current:         siModelBase.Revision,
 		Active:          true,
 		TrackingChannel: "latest/stable",
@@ -2570,7 +2570,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20SwitchKernelBaseGadgetSnapsInstal
 	}
 	snapstate.Set(s.state, "pc", &snapstate.SnapState{
 		SnapType:        "gadget",
-		Sequence:        []*snap.SideInfo{siModelGadget},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siModelGadget}),
 		Current:         siModelGadget.Revision,
 		Active:          true,
 		TrackingChannel: "20/stable",
@@ -2583,7 +2583,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20SwitchKernelBaseGadgetSnapsInstal
 	}
 	snapstate.Set(s.state, "pc-kernel", &snapstate.SnapState{
 		SnapType:        "kernel",
-		Sequence:        []*snap.SideInfo{siModelKernel},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siModelKernel}),
 		Current:         siModelKernel.Revision,
 		Active:          true,
 		TrackingChannel: "20/stable",
@@ -2607,7 +2607,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20SwitchKernelBaseGadgetSnapsInstal
 		info := snaptest.MakeSnapFileAndDir(c, snapYaml, nil, si)
 		snapstate.Set(s.state, alreadyInstalledName, &snapstate.SnapState{
 			SnapType:        string(info.Type()),
-			Sequence:        []*snap.SideInfo{si},
+			Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 			Current:         si.Revision,
 			Active:          true,
 			TrackingChannel: channel,
@@ -2890,7 +2890,7 @@ func (s *deviceMgrRemodelSuite) testRemodelUC20SwitchKernelBaseGadgetSnapsInstal
 	}
 	snapstate.Set(s.state, "pc", &snapstate.SnapState{
 		SnapType:        "gadget",
-		Sequence:        []*snap.SideInfo{siModelGadget},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siModelGadget}),
 		Current:         siModelGadget.Revision,
 		Active:          true,
 		TrackingChannel: "20/stable",
@@ -2903,7 +2903,7 @@ func (s *deviceMgrRemodelSuite) testRemodelUC20SwitchKernelBaseGadgetSnapsInstal
 	}
 	snapstate.Set(s.state, "pc-kernel", &snapstate.SnapState{
 		SnapType:        "kernel",
-		Sequence:        []*snap.SideInfo{siModelKernel},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siModelKernel}),
 		Current:         siModelKernel.Revision,
 		Active:          true,
 		TrackingChannel: "20/stable",
@@ -2925,7 +2925,7 @@ func (s *deviceMgrRemodelSuite) testRemodelUC20SwitchKernelBaseGadgetSnapsInstal
 		info := snaptest.MakeSnapFileAndDir(c, snapYaml, nil, si)
 		snapstate.Set(s.state, alreadyInstalledName, &snapstate.SnapState{
 			SnapType:        string(info.Type()),
-			Sequence:        []*snap.SideInfo{si},
+			Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 			Current:         si.Revision,
 			Active:          true,
 			TrackingChannel: channel,
@@ -3156,7 +3156,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20SwitchKernelBaseSnapsInstalledSna
 	}
 	snapstate.Set(s.state, "pc", &snapstate.SnapState{
 		SnapType:        "gadget",
-		Sequence:        []*snap.SideInfo{siModelGadget},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siModelGadget}),
 		Current:         siModelGadget.Revision,
 		Active:          true,
 		TrackingChannel: "20/stable",
@@ -3169,7 +3169,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20SwitchKernelBaseSnapsInstalledSna
 	}
 	snapstate.Set(s.state, "pc-kernel", &snapstate.SnapState{
 		SnapType:        "kernel",
-		Sequence:        []*snap.SideInfo{siModelKernel},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siModelKernel}),
 		Current:         siModelKernel.Revision,
 		Active:          true,
 		TrackingChannel: "20/stable",
@@ -3190,7 +3190,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20SwitchKernelBaseSnapsInstalledSna
 		info := snaptest.MakeSnapFileAndDir(c, snapYaml, nil, si)
 		snapstate.Set(s.state, alreadyInstalledName, &snapstate.SnapState{
 			SnapType:        string(info.Type()),
-			Sequence:        []*snap.SideInfo{si},
+			Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 			Current:         si.Revision,
 			Active:          true,
 			TrackingChannel: channel,
@@ -3384,7 +3384,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20EssentialSnapsTrackingDifferentCh
 	}
 	snapstate.Set(s.state, "pc", &snapstate.SnapState{
 		SnapType:        "gadget",
-		Sequence:        []*snap.SideInfo{siModelGadget},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siModelGadget}),
 		Current:         siModelGadget.Revision,
 		Active:          true,
 		TrackingChannel: "20/edge",
@@ -3397,7 +3397,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20EssentialSnapsTrackingDifferentCh
 	}
 	snapstate.Set(s.state, "pc-kernel", &snapstate.SnapState{
 		SnapType:        "kernel",
-		Sequence:        []*snap.SideInfo{siModelKernel},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siModelKernel}),
 		Current:         siModelKernel.Revision,
 		Active:          true,
 		TrackingChannel: "20/edge",
@@ -3410,7 +3410,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20EssentialSnapsTrackingDifferentCh
 	}
 	snapstate.Set(s.state, "core20", &snapstate.SnapState{
 		SnapType:        "base",
-		Sequence:        []*snap.SideInfo{siModelBase},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siModelBase}),
 		Current:         siModelBase.Revision,
 		Active:          true,
 		TrackingChannel: "20/edge",
@@ -3559,7 +3559,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20EssentialSnapsAlreadyInstalledAnd
 	}
 	snapstate.Set(s.state, "pc", &snapstate.SnapState{
 		SnapType:        "gadget",
-		Sequence:        []*snap.SideInfo{siModelGadget},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siModelGadget}),
 		Current:         siModelGadget.Revision,
 		Active:          true,
 		TrackingChannel: "",
@@ -3571,7 +3571,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20EssentialSnapsAlreadyInstalledAnd
 	}
 	snapstate.Set(s.state, "pc-kernel", &snapstate.SnapState{
 		SnapType:        "kernel",
-		Sequence:        []*snap.SideInfo{siModelKernel},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siModelKernel}),
 		Current:         siModelKernel.Revision,
 		Active:          true,
 		TrackingChannel: "",
@@ -3583,7 +3583,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20EssentialSnapsAlreadyInstalledAnd
 	}
 	snapstate.Set(s.state, "core20", &snapstate.SnapState{
 		SnapType:        "base",
-		Sequence:        []*snap.SideInfo{siModelBase},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siModelBase}),
 		Current:         siModelBase.Revision,
 		Active:          true,
 		TrackingChannel: "",
@@ -3739,7 +3739,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20BaseNoDownloadSimpleChannelSwitch
 	}
 	snapstate.Set(s.state, "pc", &snapstate.SnapState{
 		SnapType:        "gadget",
-		Sequence:        []*snap.SideInfo{siModelGadget},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siModelGadget}),
 		Current:         siModelGadget.Revision,
 		Active:          true,
 		TrackingChannel: "20/stable",
@@ -3752,7 +3752,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20BaseNoDownloadSimpleChannelSwitch
 	}
 	snapstate.Set(s.state, "pc-kernel", &snapstate.SnapState{
 		SnapType:        "kernel",
-		Sequence:        []*snap.SideInfo{siModelKernel},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siModelKernel}),
 		Current:         siModelKernel.Revision,
 		Active:          true,
 		TrackingChannel: "20/stable",
@@ -3765,7 +3765,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20BaseNoDownloadSimpleChannelSwitch
 	}
 	snapstate.Set(s.state, "core20", &snapstate.SnapState{
 		SnapType: "base",
-		Sequence: []*snap.SideInfo{siModelBase},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siModelBase}),
 		Current:  siModelBase.Revision,
 		Active:   true,
 		// the same channel as in the current model
@@ -3934,7 +3934,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20EssentialNoDownloadSimpleChannelS
 	}
 	snapstate.Set(s.state, "pc", &snapstate.SnapState{
 		SnapType:        "gadget",
-		Sequence:        []*snap.SideInfo{siModelGadget},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siModelGadget}),
 		Current:         siModelGadget.Revision,
 		Active:          true,
 		TrackingChannel: "20/stable",
@@ -3947,7 +3947,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20EssentialNoDownloadSimpleChannelS
 	}
 	snapstate.Set(s.state, "pc-kernel", &snapstate.SnapState{
 		SnapType:        "kernel",
-		Sequence:        []*snap.SideInfo{siModelKernel},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siModelKernel}),
 		Current:         siModelKernel.Revision,
 		Active:          true,
 		TrackingChannel: "20/stable",
@@ -3960,7 +3960,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20EssentialNoDownloadSimpleChannelS
 	}
 	snapstate.Set(s.state, "core20", &snapstate.SnapState{
 		SnapType:        "base",
-		Sequence:        []*snap.SideInfo{siModelBase},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siModelBase}),
 		Current:         siModelBase.Revision,
 		Active:          true,
 		TrackingChannel: "latest/stable",
@@ -3973,7 +3973,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelUC20EssentialNoDownloadSimpleChannelS
 	}
 	snapstate.Set(s.state, "snap-1-base", &snapstate.SnapState{
 		SnapType:        "base",
-		Sequence:        []*snap.SideInfo{appBase},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{appBase}),
 		Current:         appBase.Revision,
 		Active:          true,
 		TrackingChannel: "latest/stable",
@@ -3995,7 +3995,7 @@ base: snap-1-base
 
 	snapstate.Set(s.state, "snap-1", &snapstate.SnapState{
 		SnapType: "app",
-		Sequence: []*snap.SideInfo{&info.SideInfo},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&info.SideInfo}),
 		Current:  info.Revision,
 		Active:   true,
 		// the same channel as in the current model
@@ -4127,7 +4127,7 @@ func (s *deviceMgrRemodelSuite) testRemodelUC20LabelConflicts(c *C, tc remodelUC
 	}
 	snapstate.Set(s.state, "pc", &snapstate.SnapState{
 		SnapType:        "gadget",
-		Sequence:        []*snap.SideInfo{siModelGadget},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siModelGadget}),
 		Current:         siModelGadget.Revision,
 		Active:          true,
 		TrackingChannel: "20/stable",
@@ -4140,7 +4140,7 @@ func (s *deviceMgrRemodelSuite) testRemodelUC20LabelConflicts(c *C, tc remodelUC
 	}
 	snapstate.Set(s.state, "pc-kernel", &snapstate.SnapState{
 		SnapType:        "kernel",
-		Sequence:        []*snap.SideInfo{siModelKernel},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siModelKernel}),
 		Current:         siModelKernel.Revision,
 		Active:          true,
 		TrackingChannel: "20/stable",
@@ -4153,7 +4153,7 @@ func (s *deviceMgrRemodelSuite) testRemodelUC20LabelConflicts(c *C, tc remodelUC
 	}
 	snapstate.Set(s.state, "core20", &snapstate.SnapState{
 		SnapType:        "base",
-		Sequence:        []*snap.SideInfo{siModelBase},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siModelBase}),
 		Current:         siModelBase.Revision,
 		Active:          true,
 		TrackingChannel: "latest/stable",
@@ -4315,7 +4315,7 @@ func (s *deviceMgrRemodelSuite) testUC20RemodelSetModel(c *C, tc uc20RemodelSetM
 	}
 	snapstate.Set(s.state, "pc", &snapstate.SnapState{
 		SnapType:        "gadget",
-		Sequence:        []*snap.SideInfo{siModelGadget},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siModelGadget}),
 		Current:         siModelGadget.Revision,
 		Active:          true,
 		TrackingChannel: "20/stable",
@@ -4328,7 +4328,7 @@ func (s *deviceMgrRemodelSuite) testUC20RemodelSetModel(c *C, tc uc20RemodelSetM
 	}
 	snapstate.Set(s.state, "pc-kernel", &snapstate.SnapState{
 		SnapType:        "kernel",
-		Sequence:        []*snap.SideInfo{siModelKernel},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siModelKernel}),
 		Current:         siModelKernel.Revision,
 		Active:          true,
 		TrackingChannel: "20/stable",
@@ -4341,7 +4341,7 @@ func (s *deviceMgrRemodelSuite) testUC20RemodelSetModel(c *C, tc uc20RemodelSetM
 	}
 	snapstate.Set(s.state, "core20", &snapstate.SnapState{
 		SnapType:        "base",
-		Sequence:        []*snap.SideInfo{siModelBase},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siModelBase}),
 		Current:         siModelBase.Revision,
 		Active:          true,
 		TrackingChannel: "latest/stable",
@@ -4588,7 +4588,7 @@ func (s *deviceMgrRemodelSuite) testUC20RemodelLocalNonEssential(c *C, tc *uc20R
 	}
 	snapstate.Set(s.state, "pc", &snapstate.SnapState{
 		SnapType:        "gadget",
-		Sequence:        []*snap.SideInfo{siModelGadget},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siModelGadget}),
 		Current:         siModelGadget.Revision,
 		Active:          true,
 		TrackingChannel: "20/stable",
@@ -4601,7 +4601,7 @@ func (s *deviceMgrRemodelSuite) testUC20RemodelLocalNonEssential(c *C, tc *uc20R
 	}
 	snapstate.Set(s.state, "pc-kernel", &snapstate.SnapState{
 		SnapType:        "kernel",
-		Sequence:        []*snap.SideInfo{siModelKernel},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siModelKernel}),
 		Current:         siModelKernel.Revision,
 		Active:          true,
 		TrackingChannel: "20/stable",
@@ -4614,7 +4614,7 @@ func (s *deviceMgrRemodelSuite) testUC20RemodelLocalNonEssential(c *C, tc *uc20R
 	}
 	snapstate.Set(s.state, "core20", &snapstate.SnapState{
 		SnapType:        "base",
-		Sequence:        []*snap.SideInfo{siModelBase},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siModelBase}),
 		Current:         siModelBase.Revision,
 		Active:          true,
 		TrackingChannel: "latest/stable",
@@ -4628,7 +4628,7 @@ func (s *deviceMgrRemodelSuite) testUC20RemodelLocalNonEssential(c *C, tc *uc20R
 		}
 		snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 			SnapType:        "app",
-			Sequence:        []*snap.SideInfo{siSomeSnap},
+			Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siSomeSnap}),
 			Current:         siSomeSnap.Revision,
 			Active:          true,
 			TrackingChannel: "latest/stable",
@@ -4861,7 +4861,7 @@ func (s *deviceMgrRemodelSuite) TestUC20RemodelSetModelWithReboot(c *C) {
 	snapstate.Set(s.state, info.InstanceName(), &snapstate.SnapState{
 		SnapType: string(info.Type()),
 		Active:   true,
-		Sequence: []*snap.SideInfo{&info.SideInfo},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&info.SideInfo}),
 		Current:  info.Revision,
 	})
 
@@ -4889,7 +4889,7 @@ func (s *deviceMgrRemodelSuite) TestUC20RemodelSetModelWithReboot(c *C) {
 	}
 	snapstate.Set(s.state, "pc", &snapstate.SnapState{
 		SnapType:        "gadget",
-		Sequence:        []*snap.SideInfo{siModelGadget},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siModelGadget}),
 		Current:         siModelGadget.Revision,
 		Active:          true,
 		TrackingChannel: "20/stable",
@@ -4902,7 +4902,7 @@ func (s *deviceMgrRemodelSuite) TestUC20RemodelSetModelWithReboot(c *C) {
 	}
 	snapstate.Set(s.state, "pc-kernel", &snapstate.SnapState{
 		SnapType:        "kernel",
-		Sequence:        []*snap.SideInfo{siModelKernel},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siModelKernel}),
 		Current:         siModelKernel.Revision,
 		Active:          true,
 		TrackingChannel: "20/stable",
@@ -4915,7 +4915,7 @@ func (s *deviceMgrRemodelSuite) TestUC20RemodelSetModelWithReboot(c *C) {
 	}
 	snapstate.Set(s.state, "core20", &snapstate.SnapState{
 		SnapType:        "base",
-		Sequence:        []*snap.SideInfo{siModelBase},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siModelBase}),
 		Current:         siModelBase.Revision,
 		Active:          true,
 		TrackingChannel: "latest/stable",
@@ -5294,7 +5294,7 @@ plugs:
 		snapstate.Set(s.state, info.InstanceName(), &snapstate.SnapState{
 			SnapType:        string(info.Type()),
 			Active:          true,
-			Sequence:        []*snap.SideInfo{&info.SideInfo},
+			Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&info.SideInfo}),
 			Current:         info.Revision,
 			TrackingChannel: "latest/stable",
 		})
@@ -5333,7 +5333,7 @@ plugs:
 	}
 	snapstate.Set(s.state, "pc", &snapstate.SnapState{
 		SnapType:        "gadget",
-		Sequence:        []*snap.SideInfo{siModelGadget},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siModelGadget}),
 		Current:         siModelGadget.Revision,
 		Active:          true,
 		TrackingChannel: "20/stable",
@@ -5346,7 +5346,7 @@ plugs:
 	}
 	snapstate.Set(s.state, "pc-kernel", &snapstate.SnapState{
 		SnapType:        "kernel",
-		Sequence:        []*snap.SideInfo{siModelKernel},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siModelKernel}),
 		Current:         siModelKernel.Revision,
 		Active:          true,
 		TrackingChannel: "20/stable",
@@ -5359,7 +5359,7 @@ plugs:
 	}
 	snapstate.Set(s.state, "core20", &snapstate.SnapState{
 		SnapType:        "base",
-		Sequence:        []*snap.SideInfo{siModelBase},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siModelBase}),
 		Current:         siModelBase.Revision,
 		Active:          true,
 		TrackingChannel: "latest/stable",
@@ -5512,7 +5512,7 @@ plugs:
 	snapstate.Set(s.state, info.InstanceName(), &snapstate.SnapState{
 		SnapType:        string(info.Type()),
 		Active:          true,
-		Sequence:        []*snap.SideInfo{&info.SideInfo},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&info.SideInfo}),
 		Current:         info.Revision,
 		TrackingChannel: "latest/stable",
 	})
@@ -5554,7 +5554,7 @@ plugs:
 	}
 	snapstate.Set(s.state, "pc", &snapstate.SnapState{
 		SnapType:        "gadget",
-		Sequence:        []*snap.SideInfo{siModelGadget},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siModelGadget}),
 		Current:         siModelGadget.Revision,
 		Active:          true,
 		TrackingChannel: "20/stable",
@@ -5567,7 +5567,7 @@ plugs:
 	}
 	snapstate.Set(s.state, "pc-kernel", &snapstate.SnapState{
 		SnapType:        "kernel",
-		Sequence:        []*snap.SideInfo{siModelKernel},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siModelKernel}),
 		Current:         siModelKernel.Revision,
 		Active:          true,
 		TrackingChannel: "20/stable",
@@ -5580,7 +5580,7 @@ plugs:
 	}
 	snapstate.Set(s.state, "core20", &snapstate.SnapState{
 		SnapType:        "base",
-		Sequence:        []*snap.SideInfo{siModelBase},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siModelBase}),
 		Current:         siModelBase.Revision,
 		Active:          true,
 		TrackingChannel: "latest/stable",
@@ -5751,7 +5751,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelVerifyOrderOfTasks(c *C) {
 	}
 	snapstate.Set(s.state, "pc", &snapstate.SnapState{
 		SnapType:        "gadget",
-		Sequence:        []*snap.SideInfo{siModelGadget},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siModelGadget}),
 		Current:         siModelGadget.Revision,
 		Active:          true,
 		TrackingChannel: "20/stable",
@@ -5765,7 +5765,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelVerifyOrderOfTasks(c *C) {
 	}
 	snapstate.Set(s.state, "pc-kernel", &snapstate.SnapState{
 		SnapType:        "kernel",
-		Sequence:        []*snap.SideInfo{siModelKernel},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siModelKernel}),
 		Current:         siModelKernel.Revision,
 		Active:          true,
 		TrackingChannel: "20/stable",
@@ -5779,7 +5779,7 @@ func (s *deviceMgrRemodelSuite) TestRemodelVerifyOrderOfTasks(c *C) {
 	}
 	snapstate.Set(s.state, "core20", &snapstate.SnapState{
 		SnapType:        "base",
-		Sequence:        []*snap.SideInfo{siModelBase},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siModelBase}),
 		Current:         siModelBase.Revision,
 		Active:          true,
 		TrackingChannel: "latest/stable",

--- a/overlord/devicestate/devicestate_systems_test.go
+++ b/overlord/devicestate/devicestate_systems_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/snapcore/snapd/overlord/install"
 	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/secboot"
@@ -1386,7 +1387,7 @@ func (s *deviceMgrSystemsCreateSuite) makeSnapInState(c *C, name string, rev sna
 	snapstate.Set(s.state, info.InstanceName(), &snapstate.SnapState{
 		SnapType: string(info.Type()),
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 	})
 

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -612,7 +612,7 @@ func (s *deviceMgrSuite) TestDeviceManagerEnsureBootOkBootloaderHappy(c *C) {
 	snapstate.Set(s.state, "core", &snapstate.SnapState{
 		SnapType: "os",
 		Active:   true,
-		Sequence: []*snap.SideInfo{siCore1},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siCore1}),
 		Current:  siCore1.Revision,
 	})
 
@@ -644,7 +644,7 @@ func (s *deviceMgrSuite) TestDeviceManagerEnsureBootOkUpdateBootRevisionsHappy(c
 	snapstate.Set(s.state, "kernel", &snapstate.SnapState{
 		SnapType: "kernel",
 		Active:   true,
-		Sequence: []*snap.SideInfo{siKernel1},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siKernel1}),
 		Current:  siKernel1.Revision,
 	})
 
@@ -653,7 +653,7 @@ func (s *deviceMgrSuite) TestDeviceManagerEnsureBootOkUpdateBootRevisionsHappy(c
 	snapstate.Set(s.state, "core", &snapstate.SnapState{
 		SnapType: "os",
 		Active:   true,
-		Sequence: []*snap.SideInfo{siCore1, siCore2},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siCore1, siCore2}),
 		Current:  siCore2.Revision,
 	})
 
@@ -1094,7 +1094,7 @@ func makeInstalledMockCoreSnapWithSnapdControl(c *C, st *state.State) *snap.Info
 	sideInfoCore11 := &snap.SideInfo{RealName: "core", Revision: snap.R(11), SnapID: "core-id"}
 	snapstate.Set(st, "core", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{sideInfoCore11},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{sideInfoCore11}),
 		Current:  sideInfoCore11.Revision,
 		SnapType: "os",
 	})
@@ -1128,7 +1128,7 @@ func makeInstalledMockSnap(c *C, st *state.State, yml string) *snap.Info {
 	sideInfo11 := &snap.SideInfo{RealName: "snap-with-snapd-control", Revision: snap.R(11), SnapID: "snap-with-snapd-control-id"}
 	snapstate.Set(st, "snap-with-snapd-control", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{sideInfo11},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{sideInfo11}),
 		Current:  sideInfo11.Revision,
 		SnapType: "app",
 	})
@@ -1142,7 +1142,7 @@ func makeInstalledMockKernelSnap(c *C, st *state.State, yml string) *snap.Info {
 	sideInfo11 := &snap.SideInfo{RealName: "pc-kernel", Revision: snap.R(11), SnapID: "pc-kernel-id"}
 	snapstate.Set(st, "pc-kernel", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{sideInfo11},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{sideInfo11}),
 		Current:  sideInfo11.Revision,
 		SnapType: "kernel",
 	})

--- a/overlord/devicestate/devicestatetest/gadget.go
+++ b/overlord/devicestate/devicestatetest/gadget.go
@@ -30,6 +30,7 @@ import (
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
@@ -64,7 +65,7 @@ version: gadget
 	snapstate.Set(st, name, &snapstate.SnapState{
 		SnapType: "gadget",
 		Active:   true,
-		Sequence: []*snap.SideInfo{sideInfoGadget},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{sideInfoGadget}),
 		Current:  revision,
 	})
 

--- a/overlord/devicestate/handlers_test.go
+++ b/overlord/devicestate/handlers_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/snapcore/snapd/overlord/devicestate/devicestatetest"
 	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/overlord/storecontext"
 	"github.com/snapcore/snapd/release"
@@ -79,21 +80,21 @@ func (s *deviceMgrSuite) TestSetModelHandlerNewRevision(c *C) {
 	snapstate.Set(s.state, "foo", &snapstate.SnapState{
 		SnapType: "app",
 		Active:   true,
-		Sequence: []*snap.SideInfo{fooSI},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{fooSI}),
 		Current:  fooSI.Revision,
 		Flags:    snapstate.Flags{Required: true},
 	})
 	snapstate.Set(s.state, "bar", &snapstate.SnapState{
 		SnapType: "app",
 		Active:   true,
-		Sequence: []*snap.SideInfo{barSI},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{barSI}),
 		Current:  barSI.Revision,
 		Flags:    snapstate.Flags{Required: true},
 	})
 	snapstate.Set(s.state, "pc-kernel", &snapstate.SnapState{
 		SnapType: "kernel",
 		Active:   true,
-		Sequence: []*snap.SideInfo{pcKernelSI},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{pcKernelSI}),
 		Current:  pcKernelSI.Revision,
 		Flags:    snapstate.Flags{Required: true},
 	})
@@ -485,7 +486,7 @@ apps:
 
 	snapstate.Set(st, "test-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 		SnapType: "app",
 	})

--- a/overlord/healthstate/healthstate_test.go
+++ b/overlord/healthstate/healthstate_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/snapcore/snapd/overlord/healthstate"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
@@ -77,7 +78,7 @@ func (s *healthSuite) SetUpTest(c *check.C) {
 	snapstate.ReplaceStore(s.state, storetest.Store{})
 	sideInfo := &snap.SideInfo{RealName: "test-snap", Revision: snap.R(42)}
 	snapstate.Set(s.state, "test-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{sideInfo},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{sideInfo}),
 		Current:  snap.R(42),
 		Active:   true,
 		SnapType: "app",

--- a/overlord/hookstate/ctlcmd/is_connected_test.go
+++ b/overlord/hookstate/ctlcmd/is_connected_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
 	"github.com/snapcore/snapd/overlord/hookstate/hooktest"
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
@@ -138,13 +139,13 @@ func mockInstalledSnap(c *C, st *state.State, snapYaml, cohortKey string) {
 	info := snaptest.MockSnapCurrent(c, snapYaml, &snap.SideInfo{Revision: snap.R(1)})
 	snapstate.Set(st, info.InstanceName(), &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{
 				RealName: info.SnapName(),
 				Revision: info.Revision,
 				SnapID:   info.InstanceName() + "-id",
 			},
-		},
+		}),
 		Current:         info.Revision,
 		TrackingChannel: "stable",
 		CohortKey:       cohortKey,

--- a/overlord/hookstate/ctlcmd/services_test.go
+++ b/overlord/hookstate/ctlcmd/services_test.go
@@ -176,24 +176,24 @@ func (s *servicectlSuite) SetUpTest(c *C) {
 	})
 	snapstate.Set(s.st, info1.InstanceName(), &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{
 				RealName: info1.SnapName(),
 				Revision: info1.Revision,
 				SnapID:   "test-snap-id",
 			},
-		},
+		}),
 		Current: info1.Revision,
 	})
 	snapstate.Set(s.st, info2.InstanceName(), &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{
 				RealName: info2.SnapName(),
 				Revision: info2.Revision,
 				SnapID:   "other-snap-id",
 			},
-		},
+		}),
 		Current: info2.Revision,
 	})
 

--- a/overlord/hookstate/hooks_test.go
+++ b/overlord/hookstate/hooks_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
@@ -77,7 +78,7 @@ func (s *gateAutoRefreshHookSuite) SetUpTest(c *C) {
 	snaptest.MockSnap(c, snapaYaml, si)
 	snapstate.Set(s.state, "snap-a", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  snap.R(1),
 	})
 
@@ -85,7 +86,7 @@ func (s *gateAutoRefreshHookSuite) SetUpTest(c *C) {
 	snaptest.MockSnap(c, snapbYaml, si2)
 	snapstate.Set(s.state, "snap-b", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si2},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si2}),
 		Current:  snap.R(1),
 	})
 
@@ -93,7 +94,7 @@ func (s *gateAutoRefreshHookSuite) SetUpTest(c *C) {
 	snaptest.MockSnap(c, snapaBaseYaml, si3)
 	snapstate.Set(s.state, "base-snap-a", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si3},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si3}),
 		Current:  snap.R(1),
 	})
 

--- a/overlord/hookstate/hookstate_test.go
+++ b/overlord/hookstate/hookstate_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/snapcore/snapd/overlord/hookstate/hooktest"
 	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
@@ -132,7 +133,7 @@ func (s *baseHookManagerSuite) setUpSnap(c *C, instanceName string, yaml string)
 	snaptest.MockSnapInstance(c, instanceName, yaml, sideInfo)
 	snapstate.Set(s.state, instanceName, &snapstate.SnapState{
 		Active:      true,
-		Sequence:    []*snap.SideInfo{sideInfo},
+		Sequence:    snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{sideInfo}),
 		Current:     snap.R(1),
 		InstanceKey: instanceKey,
 	})
@@ -1016,7 +1017,7 @@ func (s *hookManagerSuite) TestHookTasksForDifferentSnapsRunConcurrently(c *C) {
 	c.Assert(info.Hooks, HasLen, 1)
 	snapstate.Set(s.state, "test-snap-1", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{sideInfo},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{sideInfo}),
 		Current:  snap.R(1),
 	})
 
@@ -1024,7 +1025,7 @@ func (s *hookManagerSuite) TestHookTasksForDifferentSnapsRunConcurrently(c *C) {
 	snaptest.MockSnap(c, snapYaml2, sideInfo)
 	snapstate.Set(s.state, "test-snap-2", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{sideInfo},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{sideInfo}),
 		Current:  snap.R(1),
 	})
 

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -412,7 +412,7 @@ func (m *InterfaceManager) doDiscardConns(task *state.Task, _ *tomb.Tomb) error 
 		return err
 	}
 
-	if err == nil && len(snapst.Sequence) != 0 {
+	if err == nil && len(snapst.Sequence.Revisions) != 0 {
 		return fmt.Errorf("cannot discard connections for snap %q while it is present", instanceName)
 	}
 	conns, err := getConns(st)

--- a/overlord/ifacestate/handlers_test.go
+++ b/overlord/ifacestate/handlers_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/snapcore/snapd/overlord/ifacestate"
 	"github.com/snapcore/snapd/overlord/servicestate/servicestatetest"
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/quota"
@@ -118,7 +119,7 @@ func mockInstalledSnap(c *C, st *state.State, snapYaml string) *snap.Info {
 	si := &snap.SideInfo{RealName: snapName, SnapID: snapName + "-id", Revision: snap.R(1)}
 	snapstate.Set(st, snapName, &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 		SnapType: string(snapInfo.Type()),
 	})

--- a/overlord/ifacestate/helpers_test.go
+++ b/overlord/ifacestate/helpers_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/ifacestate"
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
@@ -302,7 +303,7 @@ func (s *helpersSuite) TestCheckIsSystemSnapPresentWithCore(c *C) {
 
 	snapstate.Set(s.st, snapInfo.InstanceName(), &snapstate.SnapState{
 		Active:      true,
-		Sequence:    []*snap.SideInfo{sideInfo},
+		Sequence:    snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{sideInfo}),
 		Current:     sideInfo.Revision,
 		SnapType:    string(snapInfo.Type()),
 		InstanceKey: snapInfo.InstanceKey,
@@ -332,7 +333,7 @@ func (s *helpersSuite) TestCheckIsSystemSnapPresentWithSnapd(c *C) {
 
 	snapstate.Set(s.st, snapInfo.InstanceName(), &snapstate.SnapState{
 		Active:      true,
-		Sequence:    []*snap.SideInfo{sideInfo},
+		Sequence:    snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{sideInfo}),
 		Current:     sideInfo.Revision,
 		SnapType:    string(snapInfo.Type()),
 		InstanceKey: snapInfo.InstanceKey,
@@ -383,7 +384,7 @@ apps:
 	st.Lock()
 	snapst := &snapstate.SnapState{
 		SnapType: string(snap.TypeApp),
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Active:   true,
 		Current:  snap.R(1),
 	}
@@ -432,7 +433,7 @@ apps:
 		st.Lock()
 		snapst := &snapstate.SnapState{
 			SnapType: string(snap.TypeApp),
-			Sequence: []*snap.SideInfo{si},
+			Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 			Active:   true,
 			Current:  snap.R(1),
 		}

--- a/overlord/ifacestate/hotplug_test.go
+++ b/overlord/ifacestate/hotplug_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/snapcore/snapd/overlord/ifacestate"
 	"github.com/snapcore/snapd/overlord/ifacestate/udevmonitor"
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
@@ -167,7 +168,7 @@ func (s *hotplugSuite) SetUpTest(c *C) {
 	s.state.Lock()
 	snapstate.Set(s.state, "core", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  snap.R(1),
 		SnapType: "os",
 	})
@@ -354,7 +355,7 @@ slots:
 `, gadgetSideInfo)
 	snapstate.Set(s.state, "the-gadget", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{&gadgetInfo.SideInfo},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&gadgetInfo.SideInfo}),
 		Current:  snap.R(1),
 		SnapType: "gadget"})
 	st.Unlock()
@@ -444,7 +445,7 @@ func (s *hotplugSuite) TestHotplugAddWithAutoconnect(c *C) {
 	c.Assert(repo.AddPlug(testSnap.Plugs["plug"]), IsNil)
 	snapstate.Set(s.state, "consumer", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -518,7 +519,7 @@ func (s *hotplugSuite) TestHotplugRemove(c *C) {
 	}), IsNil)
 	snapstate.Set(s.state, "consumer", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -603,7 +604,7 @@ func (s *hotplugSuite) TestHotplugEnumerationDone(c *C) {
 	}), IsNil)
 	snapstate.Set(s.state, "consumer", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  snap.R(1),
 		SnapType: "app"})
 
@@ -705,7 +706,7 @@ func (s *hotplugSuite) TestHotplugDeviceUpdate(c *C) {
 	}), IsNil)
 	snapstate.Set(s.state, "consumer", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  snap.R(1),
 		SnapType: "app"})
 

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -1886,7 +1886,7 @@ func (s *interfaceManagerSuite) testStaleAutoConnectionsNotRemovedIfSnapBroken(c
 	// have one of them in state, and broken due to missing snap.yaml
 	snapstate.Set(s.state, brokenSnapName, &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{sideInfo},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{sideInfo}),
 		Current:  sideInfo.Revision,
 		SnapType: "app",
 	})
@@ -2110,7 +2110,7 @@ func (s *interfaceManagerSuite) mockSnapInstance(c *C, instanceName, yamlText st
 	// Put a side info into the state
 	snapstate.Set(s.state, snapInfo.InstanceName(), &snapstate.SnapState{
 		Active:      true,
-		Sequence:    []*snap.SideInfo{sideInfo},
+		Sequence:    snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{sideInfo}),
 		Current:     sideInfo.Revision,
 		SnapType:    string(snapInfo.Type()),
 		InstanceKey: snapInfo.InstanceKey,
@@ -2130,7 +2130,7 @@ func (s *interfaceManagerSuite) mockUpdatedSnap(c *C, yamlText string, revision 
 	var snapst snapstate.SnapState
 	err := snapstate.Get(s.state, snapInfo.InstanceName(), &snapst)
 	c.Assert(err, IsNil)
-	snapst.Sequence = append(snapst.Sequence, sideInfo)
+	snapst.Sequence.Revisions = append(snapst.Sequence.Revisions, snapstate.NewRevisionSideInfo(sideInfo, nil))
 	snapstate.Set(s.state, snapInfo.InstanceName(), &snapst)
 
 	return snapInfo
@@ -2162,7 +2162,7 @@ func (s *interfaceManagerSuite) addSetupSnapSecurityChangeWithOptions(c *C, snap
 		if opts.install {
 			c.Check(snapst.IsInstalled(), Equals, false)
 			snapst.Current = snapsup.SideInfo.Revision
-			snapst.Sequence = []*snap.SideInfo{snapsup.SideInfo}
+			snapst.Sequence = snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{snapsup.SideInfo})
 		} else {
 			c.Check(snapst.PendingSecurity, DeepEquals, &snapstate.PendingSecurityState{
 				SideInfo: snapsup.SideInfo,
@@ -3289,7 +3289,7 @@ slots:
 	for _, snapName := range []string{"producer", "consumer"} {
 		snapstate.Set(s.state, snapName, &snapstate.SnapState{
 			Active:   true,
-			Sequence: []*snap.SideInfo{{Revision: snap.R(1)}, {Revision: snap.R(2)}},
+			Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{Revision: snap.R(1)}, {Revision: snap.R(2)}}),
 			Current:  snap.R(2),
 			SnapType: string("app"),
 		})
@@ -3393,7 +3393,7 @@ slots:
 	for _, snapName := range []string{"producer", "consumer"} {
 		snapstate.Set(s.state, snapName, &snapstate.SnapState{
 			Active:   true,
-			Sequence: []*snap.SideInfo{{Revision: snap.R(1)}, {Revision: snap.R(2)}},
+			Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{Revision: snap.R(1)}, {Revision: snap.R(2)}}),
 			Current:  snap.R(2),
 			SnapType: string("app"),
 		})
@@ -5997,7 +5997,7 @@ func (s *interfaceManagerSuite) TestSnapsWithSecurityProfiles(c *C) {
 	snaptest.MockSnap(c, `name: snap0`, si0)
 	snapstate.Set(s.state, "snap0", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si0},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si0}),
 		Current:  si0.Revision,
 	})
 
@@ -6066,7 +6066,7 @@ func (s *interfaceManagerSuite) TestSnapsWithSecurityProfilesUsesPendingSecurity
 	snaptest.MockSnap(c, `name: snap0`, si0)
 	snapstate.Set(s.state, "snap0", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si0},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si0}),
 		Current:  si0.Revision,
 	})
 	si1 := &snap.SideInfo{
@@ -6076,7 +6076,7 @@ func (s *interfaceManagerSuite) TestSnapsWithSecurityProfilesUsesPendingSecurity
 	snaptest.MockSnap(c, `name: snap1`, si1)
 	snapstate.Set(s.state, "snap1", &snapstate.SnapState{
 		Active:   false,
-		Sequence: []*snap.SideInfo{si1},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si1}),
 		Current:  si1.Revision,
 		PendingSecurity: &snapstate.PendingSecurityState{
 			SideInfo: si1,
@@ -6089,7 +6089,7 @@ func (s *interfaceManagerSuite) TestSnapsWithSecurityProfilesUsesPendingSecurity
 	snaptest.MockSnap(c, `name: snap2`, si2)
 	snapstate.Set(s.state, "snap2", &snapstate.SnapState{
 		Active:   false,
-		Sequence: []*snap.SideInfo{si2},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si2}),
 		Current:  si2.Revision,
 		PendingSecurity: &snapstate.PendingSecurityState{
 			SideInfo: nil,
@@ -6123,7 +6123,7 @@ func (s *interfaceManagerSuite) TestSnapsWithSecurityProfilesMiddleOfFirstBoot(c
 	snaptest.MockSnap(c, `name: snap0`, si0)
 	snapstate.Set(s.state, "snap0", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si0},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si0}),
 		Current:  si0.Revision,
 	})
 
@@ -6133,7 +6133,7 @@ func (s *interfaceManagerSuite) TestSnapsWithSecurityProfilesMiddleOfFirstBoot(c
 	}
 	snaptest.MockSnap(c, `name: snap1`, si1)
 	snapstate.Set(s.state, "snap1", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si1},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si1}),
 		Current:  si1.Revision,
 	})
 
@@ -6749,13 +6749,13 @@ func (s *interfaceManagerSuite) testChangeConflict(c *C, kind string) {
 
 	snapstate.Set(s.state, "producer", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{{RealName: "producer", SnapID: "producer-id", Revision: snap.R(1)}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "producer", SnapID: "producer-id", Revision: snap.R(1)}}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
 	snapstate.Set(s.state, "consumer", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{{RealName: "consumer", SnapID: "consumer-id", Revision: snap.R(1)}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "consumer", SnapID: "consumer-id", Revision: snap.R(1)}}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -6810,9 +6810,9 @@ func (s *interfaceManagerSuite) TestUDevMonitorInit(c *C) {
 	st.Lock()
 	snapstate.Set(s.state, "core", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "core", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "os",
 	})
@@ -6851,9 +6851,9 @@ func (s *interfaceManagerSuite) TestUDevMonitorInitErrors(c *C) {
 	st.Lock()
 	snapstate.Set(s.state, "core", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "core", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "os",
 	})
@@ -6919,9 +6919,9 @@ func (s *interfaceManagerSuite) TestUDevMonitorInitWaitsForCore(c *C) {
 	st.Lock()
 	snapstate.Set(s.state, "core", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "core", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "os",
 	})
@@ -7007,7 +7007,7 @@ func (s *interfaceManagerSuite) setupHotplugConnectTestData(c *C) *state.Change 
 	c.Assert(repo.AddPlug(testSnap.Plugs["plug"]), IsNil)
 	snapstate.Set(s.state, "consumer", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -7235,7 +7235,7 @@ func mockConsumer(c *C, st *state.State, repo *interfaces.Repository, snapYaml, 
 	c.Assert(repo.AddPlug(consumer.Plugs[plugName]), IsNil)
 	snapstate.Set(st, consumerSnapName, &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -7320,7 +7320,7 @@ func (s *interfaceManagerSuite) TestHotplugDisconnect(c *C) {
 	c.Assert(repo.AddPlug(testSnap.Plugs["plug"]), IsNil)
 	snapstate.Set(s.state, "consumer", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -7401,7 +7401,7 @@ func (s *interfaceManagerSuite) testHotplugDisconnectWaitsForCoreRefresh(c *C, t
 	c.Assert(repo.AddPlug(testSnap.Plugs["plug"]), IsNil)
 	snapstate.Set(s.state, "consumer", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -7499,7 +7499,7 @@ func (s *interfaceManagerSuite) TestHotplugDisconnectWaitsForDisconnectPlug(c *C
 	c.Assert(repo.AddPlug(testSnap.Plugs["plug"]), IsNil)
 	snapstate.Set(s.state, "consumer", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -8270,7 +8270,7 @@ func (s *interfaceManagerSuite) TestTransitionConnectionsCoreMigration(c *C) {
 	snapstate.Set(st, "core", nil)
 	snapstate.Set(st, "ubuntu-core", &snapstate.SnapState{
 		Active:          true,
-		Sequence:        []*snap.SideInfo{{RealName: "ubuntu-core", SnapID: "ubuntu-core-snap-id", Revision: snap.R(1)}},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "ubuntu-core", SnapID: "ubuntu-core-snap-id", Revision: snap.R(1)}}),
 		Current:         snap.R(1),
 		SnapType:        "os",
 		TrackingChannel: "beta",
@@ -9280,7 +9280,7 @@ func (s *interfaceManagerSuite) TestOnSnapLinkageChanged(c *C) {
 		SnapType: "app",
 		Active:   false,
 		Current:  snap.R(1),
-		Sequence: []*snap.SideInfo{&info.SideInfo},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&info.SideInfo}),
 		PendingSecurity: &snapstate.PendingSecurityState{
 			SideInfo: &info.SideInfo,
 		},
@@ -9301,6 +9301,6 @@ func (s *interfaceManagerSuite) TestOnSnapLinkageChanged(c *C) {
 		SnapType: "app",
 		Active:   true,
 		Current:  snap.R(1),
-		Sequence: []*snap.SideInfo{&info.SideInfo},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&info.SideInfo}),
 	})
 }

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -81,6 +81,7 @@ import (
 	"github.com/snapcore/snapd/overlord/snapshotstate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/secboot"
@@ -448,9 +449,9 @@ func (s *baseMgrsSuite) SetUpTest(c *C) {
 	// add core itself
 	snapstate.Set(st, "core", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "core", SnapID: fakeSnapID("core"), Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "os",
 		Flags: snapstate.Flags{
@@ -545,7 +546,7 @@ func (ms *baseMgrsSuite) mockInstalledSnapWithRevAndFiles(c *C, snapYaml string,
 	}
 	snapstate.Set(st, info.InstanceName(), &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  info.Revision,
 		SnapType: string(info.Type()),
 	})
@@ -2186,9 +2187,9 @@ version: @VERSION@
 
 	snapstate.Set(st, "bar", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "bar", SnapID: "bar-id", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -2501,7 +2502,7 @@ type: kernel`
 	snapstate.Set(st, "pc-kernel", &snapstate.SnapState{
 		SnapType: "kernel",
 		Active:   true,
-		Sequence: []*snap.SideInfo{si1},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si1}),
 		Current:  si1.Revision,
 	})
 	snaptest.MockSnapWithFiles(c, packageKernel, si1, [][]string{
@@ -2511,7 +2512,7 @@ type: kernel`
 	snapstate.Set(st, "core18", &snapstate.SnapState{
 		SnapType: "base",
 		Active:   true,
-		Sequence: []*snap.SideInfo{si2},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si2}),
 		Current:  si2.Revision,
 	})
 
@@ -2604,7 +2605,7 @@ type: kernel`
 	snapstate.Set(st, "pc-kernel", &snapstate.SnapState{
 		SnapType: "kernel",
 		Active:   true,
-		Sequence: []*snap.SideInfo{si1},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si1}),
 		Current:  si1.Revision,
 	})
 	snaptest.MockSnapWithFiles(c, packageKernel, si1, [][]string{
@@ -2614,7 +2615,7 @@ type: kernel`
 	snapstate.Set(st, "core18", &snapstate.SnapState{
 		SnapType: "base",
 		Active:   true,
-		Sequence: []*snap.SideInfo{si2},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si2}),
 		Current:  si2.Revision,
 	})
 
@@ -2763,7 +2764,7 @@ type: kernel`
 	snapstate.Set(st, "pc-kernel", &snapstate.SnapState{
 		SnapType: "kernel",
 		Active:   true,
-		Sequence: []*snap.SideInfo{si1},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si1}),
 		Current:  si1.Revision,
 	})
 	snaptest.MockSnapWithFiles(c, packageKernel, si1, [][]string{
@@ -2773,7 +2774,7 @@ type: kernel`
 	snapstate.Set(st, "core20", &snapstate.SnapState{
 		SnapType: "base",
 		Active:   true,
-		Sequence: []*snap.SideInfo{si2},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si2}),
 		Current:  si2.Revision,
 	})
 
@@ -2845,8 +2846,8 @@ type: kernel`
 	var snapst snapstate.SnapState
 	err = snapstate.Get(st, "pc-kernel", &snapst)
 	c.Assert(err, IsNil)
-	c.Check(snapst.Sequence, HasLen, 2)
-	c.Check(snapst.Sequence, DeepEquals, []*snap.SideInfo{si1, &kernelSnapInfo.SideInfo})
+	c.Check(snapst.Sequence.Revisions, HasLen, 2)
+	c.Check(snapst.Sequence, DeepEquals, snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si1, &kernelSnapInfo.SideInfo}))
 	c.Check(snapst.Active, Equals, true)
 	c.Check(snapst.Current, DeepEquals, snap.R(-1))
 
@@ -2933,7 +2934,7 @@ type: kernel`
 	snapstate.Set(st, "pc-kernel", &snapstate.SnapState{
 		SnapType: "kernel",
 		Active:   true,
-		Sequence: []*snap.SideInfo{si1},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si1}),
 		Current:  si1.Revision,
 	})
 	snaptest.MockSnapWithFiles(c, packageKernel, si1, [][]string{
@@ -2943,7 +2944,7 @@ type: kernel`
 	snapstate.Set(st, "core20", &snapstate.SnapState{
 		SnapType: "base",
 		Active:   true,
-		Sequence: []*snap.SideInfo{si2},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si2}),
 		Current:  si2.Revision,
 	})
 
@@ -3034,8 +3035,8 @@ type: kernel`
 	var snapst snapstate.SnapState
 	err = snapstate.Get(st, "pc-kernel", &snapst)
 	c.Assert(err, IsNil)
-	c.Check(snapst.Sequence, HasLen, 1)
-	c.Check(snapst.Sequence, DeepEquals, []*snap.SideInfo{si1})
+	c.Check(snapst.Sequence.Revisions, HasLen, 1)
+	c.Check(snapst.Sequence, DeepEquals, snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si1}))
 	c.Check(snapst.Active, Equals, true)
 	c.Check(snapst.Current, DeepEquals, snap.R(1))
 
@@ -3955,7 +3956,7 @@ assumes: [something-that-is-not-provided]
 	si := &snap.SideInfo{RealName: "some-snap", SnapID: fakeSnapID("some-snap"), Revision: snap.R(1)}
 	snapstate.Set(st, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -3985,7 +3986,7 @@ assumes: [something-that-is-not-provided]
 	si := &snap.SideInfo{RealName: "some-snap", SnapID: fakeSnapID("some-snap"), Revision: snap.R(1)}
 	snapstate.Set(st, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -4360,13 +4361,13 @@ version: @VERSION@`
 
 	snapstate.Set(st, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
 	snapstate.Set(st, "other-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{oi},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{oi}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -4469,7 +4470,7 @@ version: 1`
 	si2 := &snap.SideInfo{RealName: "some-snap", SnapID: fakeSnapID("some-snap"), Revision: snap.R(2)}
 	snapstate.Set(st, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si0, si1, si2},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si0, si1, si2}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -4543,13 +4544,13 @@ func (s *mgrsSuite) testUpdateWithAutoconnectRetry(c *C, updateSnapName, removeS
 
 	snapstate.Set(st, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
 	snapstate.Set(st, "other-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{oi},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{oi}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -4666,13 +4667,13 @@ hooks:
 
 	snapstate.Set(st, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
 	snapstate.Set(st, "other-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{oi},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{oi}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -4755,13 +4756,13 @@ func (s *mgrsSuite) TestDisconnectOnUninstallRemovesAutoconnection(c *C) {
 
 	snapstate.Set(st, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
 	snapstate.Set(st, "other-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{oi},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{oi}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -4958,7 +4959,7 @@ func (s *mgrsSuiteCore) TestRemodelRequiredSnapsAdded(c *C) {
 	snapstate.Set(st, "old-required-snap-1", &snapstate.SnapState{
 		SnapType: "app",
 		Active:   true,
-		Sequence: []*snap.SideInfo{si1},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si1}),
 		Current:  si1.Revision,
 		Flags:    snapstate.Flags{Required: true},
 	})
@@ -5063,7 +5064,7 @@ func (s *mgrsSuiteCore) TestRemodelRequiredSnapsAddedUndo(c *C) {
 	snapstate.Set(st, "old-required-snap-1", &snapstate.SnapState{
 		SnapType: "app",
 		Active:   true,
-		Sequence: []*snap.SideInfo{si1},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si1}),
 		Current:  si1.Revision,
 		Flags:    snapstate.Flags{Required: true},
 	})
@@ -5186,7 +5187,7 @@ func (ms *mgrsSuiteCore) TestRemodelSwitchToDifferentBase(c *C) {
 	si := &snap.SideInfo{RealName: "core18", SnapID: fakeSnapID("core18"), Revision: snap.R(1)}
 	snapstate.Set(st, "core18", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  snap.R(1),
 		SnapType: "base",
 	})
@@ -5194,7 +5195,7 @@ func (ms *mgrsSuiteCore) TestRemodelSwitchToDifferentBase(c *C) {
 	gadgetSnapYaml := "name: pc\nversion: 1.0\ntype: gadget"
 	snapstate.Set(st, "pc", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si2},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si2}),
 		Current:  snap.R(1),
 		SnapType: "gadget",
 	})
@@ -5327,7 +5328,7 @@ func (ms *mgrsSuiteCore) TestRemodelSwitchToDifferentBaseUndo(c *C) {
 	si := &snap.SideInfo{RealName: "core18", SnapID: fakeSnapID("core18"), Revision: snap.R(1)}
 	snapstate.Set(st, "core18", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  snap.R(1),
 		SnapType: "base",
 	})
@@ -5337,7 +5338,7 @@ func (ms *mgrsSuiteCore) TestRemodelSwitchToDifferentBaseUndo(c *C) {
 	gadgetSnapYaml := "name: pc\nversion: 1.0\ntype: gadget"
 	snapstate.Set(st, "pc", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si2},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si2}),
 		Current:  snap.R(1),
 		SnapType: "gadget",
 	})
@@ -5470,7 +5471,7 @@ func (ms *mgrsSuiteCore) TestRemodelSwitchToDifferentBaseUndoOnRollback(c *C) {
 	si := &snap.SideInfo{RealName: "core18", SnapID: fakeSnapID("core18"), Revision: snap.R(1)}
 	snapstate.Set(st, "core18", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  snap.R(1),
 		SnapType: "base",
 	})
@@ -5480,7 +5481,7 @@ func (ms *mgrsSuiteCore) TestRemodelSwitchToDifferentBaseUndoOnRollback(c *C) {
 	gadgetSnapYaml := "name: pc\nversion: 1.0\ntype: gadget"
 	snapstate.Set(st, "pc", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si2},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si2}),
 		Current:  snap.R(1),
 		SnapType: "gadget",
 	})
@@ -5656,7 +5657,7 @@ func (ms *mgrsSuite) TestRefreshSimplePrevRev(c *C) {
 	}
 	snapstate.Set(st, info.InstanceName(), &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si1, si2},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si1, si2}),
 		Current:  snap.R(2),
 		SnapType: string(info.Type()),
 	})
@@ -5759,7 +5760,7 @@ func (ms *mgrsSuite) TestRefreshSimpleRevertToLocalFromLocalFile(c *C) {
 	}
 	snapstate.Set(st, info.InstanceName(), &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si1, si2},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si1, si2}),
 		Current:  snap.R(2),
 		SnapType: string(info.Type()),
 	})
@@ -5839,7 +5840,7 @@ func (s *kernelSuite) SetUpTest(c *C) {
 	si := &snap.SideInfo{RealName: "pc-kernel", SnapID: fakeSnapID("pc-kernel"), Revision: snap.R(1)}
 	snapstate.Set(st, "pc-kernel", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  snap.R(1),
 		SnapType: "kernel",
 	})
@@ -5850,7 +5851,7 @@ func (s *kernelSuite) SetUpTest(c *C) {
 	gadgetSnapYaml := "name: pc\nversion: 1.0\ntype: gadget"
 	snapstate.Set(st, "pc", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si2},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si2}),
 		Current:  snap.R(1),
 		SnapType: "gadget",
 	})
@@ -6269,7 +6270,7 @@ func (s *mgrsSuiteCore) TestRemodelSwitchGadgetTrack(c *C) {
 	si := &snap.SideInfo{RealName: "pc", SnapID: fakeSnapID("pc"), Revision: snap.R(1)}
 	snapstate.Set(st, "pc", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  snap.R(1),
 		SnapType: "gadget",
 	})
@@ -6374,7 +6375,7 @@ func (s *mgrsSuiteCore) TestRemodelSwitchToDifferentGadget(c *C) {
 	si := &snap.SideInfo{RealName: "core18", SnapID: fakeSnapID("core18"), Revision: snap.R(1)}
 	snapstate.Set(st, "core18", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  snap.R(1),
 		SnapType: "base",
 	})
@@ -6382,7 +6383,7 @@ func (s *mgrsSuiteCore) TestRemodelSwitchToDifferentGadget(c *C) {
 	gadgetSnapYaml := "name: pc\nversion: 1.0\ntype: gadget"
 	snapstate.Set(st, "pc", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si2},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si2}),
 		Current:  snap.R(1),
 		SnapType: "gadget",
 	})
@@ -6525,7 +6526,7 @@ func (s *mgrsSuiteCore) TestRemodelSwitchToIncompatibleGadget(c *C) {
 	si := &snap.SideInfo{RealName: "core18", SnapID: fakeSnapID("core18"), Revision: snap.R(1)}
 	snapstate.Set(st, "core18", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  snap.R(1),
 		SnapType: "base",
 	})
@@ -6533,7 +6534,7 @@ func (s *mgrsSuiteCore) TestRemodelSwitchToIncompatibleGadget(c *C) {
 	gadgetSnapYaml := "name: pc\nversion: 1.0\ntype: gadget"
 	snapstate.Set(st, "pc", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si2},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si2}),
 		Current:  snap.R(1),
 		SnapType: "gadget",
 	})
@@ -7050,7 +7051,7 @@ func (s *mgrsSuiteCore) makeInstalledSnapInStateForRemodel(c *C, name string, re
 	snapstate.Set(s.o.State(), name, &snapstate.SnapState{
 		SnapType:        string(snapInfo.Type()),
 		Active:          true,
-		Sequence:        []*snap.SideInfo{si},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:         si.Revision,
 		TrackingChannel: channel,
 	})
@@ -8476,9 +8477,9 @@ func (s *mgrsSuiteCore) TestRemodelUC20SnapWithPrereqsMissingDeps(c *C) {
 	snapstate.Set(st, "core", nil)
 	snapstate.Set(st, "snapd", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "snapd", SnapID: fakeSnapID("snapd"), Revision: snap.R(1)},
-		},
+		}),
 		Current:         snap.R(1),
 		SnapType:        "snapd",
 		TrackingChannel: "latest/stable",
@@ -8525,13 +8526,13 @@ func (s *mgrsSuite) TestCheckRefreshFailureWithConcurrentRemoveOfConnectedSnap(c
 
 	snapstate.Set(st, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
 	snapstate.Set(st, "other-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{oi},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{oi}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -8920,7 +8921,7 @@ type: kernel`
 	snapstate.Set(st, "pc-kernel", &snapstate.SnapState{
 		SnapType: "kernel",
 		Active:   true,
-		Sequence: []*snap.SideInfo{si1},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si1}),
 		Current:  si1.Revision,
 	})
 	snaptest.MockSnapWithFiles(c, packageKernel, si1, [][]string{
@@ -8930,7 +8931,7 @@ type: kernel`
 	snapstate.Set(st, "core18", &snapstate.SnapState{
 		SnapType: "base",
 		Active:   true,
-		Sequence: []*snap.SideInfo{si2},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si2}),
 		Current:  si2.Revision,
 	})
 
@@ -9023,7 +9024,7 @@ type: snapd`
 	// add the test snap service
 	testSnapSideInfo := &snap.SideInfo{RealName: "test-snap", Revision: snap.R(42)}
 	snapstate.Set(st, "test-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{testSnapSideInfo},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{testSnapSideInfo}),
 		Current:  snap.R(42),
 		Active:   true,
 		SnapType: "app",
@@ -9154,7 +9155,7 @@ NeedDaemonReload=no
 	snapstate.Set(st, "snapd", &snapstate.SnapState{
 		SnapType: "snapd",
 		Active:   true,
-		Sequence: []*snap.SideInfo{si1},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si1}),
 		Current:  si1.Revision,
 	})
 	snaptest.MockSnapWithFiles(c, "name: snapd\ntype: snapd\nversion: 123", si1, nil)
@@ -9260,7 +9261,7 @@ type: snapd`
 	// add the test snap service
 	testSnapSideInfo := &snap.SideInfo{RealName: "test-snap", Revision: snap.R(42)}
 	snapstate.Set(st, "test-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{testSnapSideInfo},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{testSnapSideInfo}),
 		Current:  snap.R(42),
 		Active:   true,
 		SnapType: "app",
@@ -9402,7 +9403,7 @@ NeedDaemonReload=no
 	snapstate.Set(st, "snapd", &snapstate.SnapState{
 		SnapType: "snapd",
 		Active:   true,
-		Sequence: []*snap.SideInfo{si1},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si1}),
 		Current:  si1.Revision,
 	})
 	snaptest.MockSnapWithFiles(c, "name: snapd\ntype: snapd\nversion: 123", si1, nil)
@@ -9557,7 +9558,7 @@ func (s *mgrsSuite) testUC20RunUpdateManagedBootConfig(c *C, snapPath string, si
 	snapstate.Set(st, "snapd", &snapstate.SnapState{
 		SnapType: "snapd",
 		Active:   true,
-		Sequence: []*snap.SideInfo{si1},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si1}),
 		Current:  si1.Revision,
 	})
 	snaptest.MockSnapWithFiles(c, "name: snapd\ntype: snapd\nversion: 123", si1, nil)
@@ -9567,21 +9568,21 @@ func (s *mgrsSuite) testUC20RunUpdateManagedBootConfig(c *C, snapPath string, si
 		SnapType: "base",
 
 		Active:   true,
-		Sequence: []*snap.SideInfo{si2},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si2}),
 		Current:  si2.Revision,
 	})
 	si3 := &snap.SideInfo{RealName: "pc-kernel", Revision: snap.R(1)}
 	snapstate.Set(st, "pc-kernel", &snapstate.SnapState{
 		SnapType: "kernel",
 		Active:   true,
-		Sequence: []*snap.SideInfo{si3},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si3}),
 		Current:  si3.Revision,
 	})
 	si4 := &snap.SideInfo{RealName: "pc", Revision: snap.R(1)}
 	snapstate.Set(st, "pc", &snapstate.SnapState{
 		SnapType: "gadget",
 		Active:   true,
-		Sequence: []*snap.SideInfo{si4},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si4}),
 		Current:  si4.Revision,
 	})
 	const pcGadget = `
@@ -9739,21 +9740,21 @@ func (s *mgrsSuite) testNonUC20RunUpdateManagedBootConfig(c *C, snapPath string,
 	snapstate.Set(st, "snapd", &snapstate.SnapState{
 		SnapType: "snapd",
 		Active:   true,
-		Sequence: []*snap.SideInfo{si1},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si1}),
 		Current:  si1.Revision,
 	})
 	si2 := &snap.SideInfo{RealName: "core", Revision: snap.R(1)}
 	snapstate.Set(st, "core", &snapstate.SnapState{
 		SnapType: "base",
 		Active:   true,
-		Sequence: []*snap.SideInfo{si2},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si2}),
 		Current:  si2.Revision,
 	})
 	si3 := &snap.SideInfo{RealName: "pc-kernel", Revision: snap.R(1)}
 	snapstate.Set(st, "pc-kernel", &snapstate.SnapState{
 		SnapType: "kernel",
 		Active:   true,
-		Sequence: []*snap.SideInfo{si3},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si3}),
 		Current:  si3.Revision,
 	})
 
@@ -9947,7 +9948,7 @@ func (s *mgrsSuiteCore) testGadgetKernelCommandLine(c *C, gadgetPath string, gad
 	snapstate.Set(st, "snapd", &snapstate.SnapState{
 		SnapType: "snapd",
 		Active:   true,
-		Sequence: []*snap.SideInfo{si1},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si1}),
 		Current:  si1.Revision,
 	})
 	snaptest.MockSnapWithFiles(c, "name: snapd\ntype: snapd\nversion: 123", si1, nil)
@@ -9956,21 +9957,21 @@ func (s *mgrsSuiteCore) testGadgetKernelCommandLine(c *C, gadgetPath string, gad
 	snapstate.Set(st, "core20", &snapstate.SnapState{
 		SnapType: "base",
 		Active:   true,
-		Sequence: []*snap.SideInfo{si2},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si2}),
 		Current:  si2.Revision,
 	})
 	si3 := &snap.SideInfo{RealName: "pc-kernel", Revision: snap.R(1)}
 	snapstate.Set(st, "pc-kernel", &snapstate.SnapState{
 		SnapType: "kernel",
 		Active:   true,
-		Sequence: []*snap.SideInfo{si3},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si3}),
 		Current:  si3.Revision,
 	})
 	si4 := &snap.SideInfo{RealName: "pc", Revision: snap.R(1)}
 	snapstate.Set(st, "pc", &snapstate.SnapState{
 		SnapType: "gadget",
 		Active:   true,
-		Sequence: []*snap.SideInfo{si4},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si4}),
 		Current:  si4.Revision,
 	})
 	snaptest.MockSnapWithFiles(c, pcGadget, si4, currentFiles)
@@ -10270,25 +10271,25 @@ func (s *mgrsSuiteCore) testUpdateKernelBaseSingleRebootSetup(c *C) (*boottest.R
 	snapstate.Set(st, "core", nil)
 	snapstate.Set(st, "pc-kernel", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{siKernel},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siKernel}),
 		Current:  snap.R(1),
 		SnapType: "kernel",
 	})
 	snapstate.Set(st, "core20", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{siBase},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siBase}),
 		Current:  snap.R(1),
 		SnapType: "base",
 	})
 	snapstate.Set(st, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{siSnap},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siSnap}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
 	snapstate.Set(st, "snapd", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{siSnapd},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siSnapd}),
 		Current:  snap.R(1),
 		SnapType: "snapd",
 	})
@@ -10539,25 +10540,25 @@ func (s *mgrsSuiteCore) testUpdateKernelBaseSingleRebootWithGadgetSetup(c *C, sn
 	snapstate.Set(st, "core", nil)
 	snapstate.Set(st, "pc-kernel", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{siKernel},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siKernel}),
 		Current:  snap.R(1),
 		SnapType: "kernel",
 	})
 	snapstate.Set(st, "core20", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{siBase},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siBase}),
 		Current:  snap.R(1),
 		SnapType: "base",
 	})
 	snapstate.Set(st, "snapd", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{siSnapd},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siSnapd}),
 		Current:  snap.R(1),
 		SnapType: "snapd",
 	})
 	snapstate.Set(st, "pc", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{siGadget},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siGadget}),
 		Current:  snap.R(1),
 		SnapType: "gadget",
 	})

--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/snapcore/snapd/overlord/patch"
 	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snapdenv"
@@ -1299,17 +1300,17 @@ func (ovs *overlordSuite) TestStartupTimeout(c *C) {
 	// have two snaps
 	snapstate.Set(st, "core18", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "core18", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "base",
 	})
 	snapstate.Set(st, "foo", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "foo", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})

--- a/overlord/patch/patch2_test.go
+++ b/overlord/patch/patch2_test.go
@@ -159,8 +159,8 @@ func (s *patch2Suite) TestPatch2(c *C) {
 	var snapst snapstate.SnapState
 	err = snapstate.Get(st, "foo", &snapst)
 	c.Assert(err, IsNil)
-	c.Check(snapst.Sequence[0].RealName, Equals, "foo")
-	c.Check(snapst.Sequence[1].RealName, Equals, "foo")
+	c.Check(snapst.Sequence.Revisions[0].Snap.RealName, Equals, "foo")
+	c.Check(snapst.Sequence.Revisions[1].Snap.RealName, Equals, "foo")
 
 	// transition of:
 	// - Candidate for "bar" -> tasks SnapSetup.SideInfo

--- a/overlord/patch/patch6_3_test.go
+++ b/overlord/patch/patch6_3_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord/patch"
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 )
@@ -290,7 +291,7 @@ func (s *patch63Suite) TestPatch63(c *C) {
 	// none of the other information has changed
 	c.Check(all["prefix-postfix-slashes"], DeepEquals, &snapstate.SnapState{
 		SnapType: "app",
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{
 				RealName:    "prefix-postfix-slashes",
 				SnapID:      "Hswp9oOzj3b4mw8gcC00XtxWnKH9QiCQ",
@@ -304,7 +305,7 @@ func (s *patch63Suite) TestPatch63(c *C) {
 				Channel:     "edge",
 				EditedTitle: "some-title",
 			},
-		},
+		}),
 		Active:          true,
 		Current:         snap.R(32),
 		TrackingChannel: "latest/edge",

--- a/overlord/servicestate/quota_control_test.go
+++ b/overlord/servicestate/quota_control_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/snapcore/snapd/overlord/servicestate"
 	"github.com/snapcore/snapd/overlord/servicestate/servicestatetest"
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/quota"
@@ -684,7 +685,7 @@ func (s *quotaControlSuite) TestEnsureSnapAbsentFromQuotaGroup(c *C) {
 	// and test-snap2
 	si2 := &snap.SideInfo{RealName: "test-snap2", Revision: snap.R(42)}
 	snapst2 := &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si2},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si2}),
 		Current:  si2.Revision,
 		Active:   true,
 		SnapType: "app",
@@ -898,7 +899,7 @@ func (s *quotaControlSuite) TestSnapOpUpdateQuotaConflict(c *C) {
 	// and test-snap2
 	si2 := &snap.SideInfo{RealName: "test-snap2", Revision: snap.R(42)}
 	snapst2 := &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si2},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si2}),
 		Current:  si2.Revision,
 		Active:   true,
 		SnapType: "app",
@@ -1010,7 +1011,7 @@ func (s *quotaControlSuite) TestUpdateQuotaSnapOpConflict(c *C) {
 	// and test-snap2
 	si2 := &snap.SideInfo{RealName: "test-snap2", Revision: snap.R(42)}
 	snapst2 := &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si2},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si2}),
 		Current:  si2.Revision,
 		Active:   true,
 		SnapType: "app",
@@ -1118,7 +1119,7 @@ func (s *quotaControlSuite) TestUpdateQuotaUpdateQuotaConflict(c *C) {
 	// and test-snap2
 	si2 := &snap.SideInfo{RealName: "test-snap2", Revision: snap.R(42)}
 	snapst2 := &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si2},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si2}),
 		Current:  si2.Revision,
 		Active:   true,
 		SnapType: "app",
@@ -1158,7 +1159,7 @@ func (s *quotaControlSuite) TestUpdateQuotaRemoveQuotaConflict(c *C) {
 	// and test-snap2
 	si2 := &snap.SideInfo{RealName: "test-snap2", Revision: snap.R(42)}
 	snapst2 := &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si2},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si2}),
 		Current:  si2.Revision,
 		Active:   true,
 		SnapType: "app",
@@ -1197,7 +1198,7 @@ func (s *quotaControlSuite) TestRemoveQuotaUpdateQuotaConflict(c *C) {
 	// and test-snap2
 	si2 := &snap.SideInfo{RealName: "test-snap2", Revision: snap.R(42)}
 	snapst2 := &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si2},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si2}),
 		Current:  si2.Revision,
 		Active:   true,
 		SnapType: "app",
@@ -1230,7 +1231,7 @@ func (s *quotaControlSuite) TestCreateQuotaCreateQuotaConflict(c *C) {
 	// and test-snap2
 	si2 := &snap.SideInfo{RealName: "test-snap2", Revision: snap.R(42)}
 	snapst2 := &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si2},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si2}),
 		Current:  si2.Revision,
 		Active:   true,
 		SnapType: "app",
@@ -1276,7 +1277,7 @@ func (s *quotaControlSuite) TestAddSnapToQuotaGroupQuotaConflict(c *C) {
 	// and test-snap2
 	si2 := &snap.SideInfo{RealName: "test-snap2", Revision: snap.R(42)}
 	snapst2 := &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si2},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si2}),
 		Current:  si2.Revision,
 		Active:   true,
 		SnapType: "app",

--- a/overlord/servicestate/quota_handlers_test.go
+++ b/overlord/servicestate/quota_handlers_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/snapcore/snapd/overlord/servicestate"
 	"github.com/snapcore/snapd/overlord/servicestate/servicestatetest"
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/quota"
@@ -1460,7 +1461,7 @@ func (s *quotaHandlersSuite) TestQuotaSnapAddSnapNestedFails(c *C) {
 	// and test-snap2
 	si2 := &snap.SideInfo{RealName: "test-snap2", Revision: snap.R(42)}
 	snapst2 := &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si2},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si2}),
 		Current:  si2.Revision,
 		Active:   true,
 		SnapType: "app",
@@ -1637,7 +1638,7 @@ func (s *quotaHandlersSuite) TestQuotaSnapAddSnapServicesFailOnInvalidSnapServic
 	// and test-snap2
 	si2 := &snap.SideInfo{RealName: "test-snap2", Revision: snap.R(42)}
 	snapst2 := &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si2},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si2}),
 		Current:  si2.Revision,
 		Active:   true,
 		SnapType: "app",
@@ -1815,7 +1816,7 @@ func (s *quotaHandlersSuite) TestQuotaSnapCorrectlyDetectErrorsIfCreatingSubgrou
 	// and test-snap2
 	si2 := &snap.SideInfo{RealName: "test-snap2", Revision: snap.R(42)}
 	snapst2 := &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si2},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si2}),
 		Current:  si2.Revision,
 		Active:   true,
 		SnapType: "app",
@@ -1955,7 +1956,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateSubGroupTooBig(c *C) {
 	// and test-snap2
 	si2 := &snap.SideInfo{RealName: "test-snap2", Revision: snap.R(42)}
 	snapst2 := &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si2},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si2}),
 		Current:  si2.Revision,
 		Active:   true,
 		SnapType: "app",
@@ -2454,7 +2455,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnap(c *C) {
 	// and test-snap2
 	si2 := &snap.SideInfo{RealName: "test-snap2", Revision: snap.R(42)}
 	snapst2 := &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si2},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si2}),
 		Current:  si2.Revision,
 		Active:   true,
 		SnapType: "app",
@@ -2520,7 +2521,7 @@ func (s *quotaHandlersSuite) TestQuotaUpdateAddSnapAlreadyInOtherGroup(c *C) {
 	// and test-snap2
 	si2 := &snap.SideInfo{RealName: "test-snap2", Revision: snap.R(42)}
 	snapst2 := &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si2},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si2}),
 		Current:  si2.Revision,
 		Active:   true,
 		SnapType: "app",
@@ -2969,7 +2970,7 @@ func (s *quotaHandlersSuite) TestAffectedSnapServices(c *C) {
 	// and test-snap2
 	si2 := &snap.SideInfo{RealName: "test-snap2", Revision: snap.R(42)}
 	snapst2 := &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si2},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si2}),
 		Current:  si2.Revision,
 		Active:   true,
 		SnapType: "app",
@@ -3018,7 +3019,7 @@ func (s *quotaHandlersSuite) TestAffectedSnapServicesExtraSnaps(c *C) {
 	// and test-snap2
 	si2 := &snap.SideInfo{RealName: "test-snap2", Revision: snap.R(42)}
 	snapst2 := &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si2},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si2}),
 		Current:  si2.Revision,
 		Active:   true,
 		SnapType: "app",
@@ -3100,7 +3101,7 @@ func (s *quotaHandlersSuite) TestQuotaSnapServicesRestartOnlyRelevantServices(c 
 	// and test-snap3
 	si3 := &snap.SideInfo{RealName: "test-snap3", Revision: snap.R(42)}
 	snapst3 := &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si3},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si3}),
 		Current:  si3.Revision,
 		Active:   true,
 		SnapType: "app",

--- a/overlord/servicestate/service_control_test.go
+++ b/overlord/servicestate/service_control_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/servicestate"
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
@@ -112,7 +113,7 @@ func (s *serviceControlSuite) mockTestSnap(c *C) *snap.Info {
 	info := snaptest.MockSnap(c, servicesSnapYaml1, &si)
 	snapstate.Set(s.state, "test-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{&si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		Current:  snap.R(7),
 		SnapType: "app",
 	})
@@ -504,7 +505,7 @@ func (s *serviceControlSuite) TestNoopWhenNoServices(c *C) {
 	snaptest.MockSnap(c, `name: test-snap`, &si)
 	snapstate.Set(st, "test-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{&si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		Current:  snap.R(7),
 		SnapType: "app",
 	})

--- a/overlord/servicestate/servicemgr_test.go
+++ b/overlord/servicestate/servicemgr_test.go
@@ -130,7 +130,7 @@ func (s *baseServiceMgrTestSuite) SetUpTest(c *C) {
 	// snapstate to be setup as needed
 	s.testSnapSideInfo = &snap.SideInfo{RealName: "test-snap", Revision: snap.R(42)}
 	s.testSnapState = &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{s.testSnapSideInfo},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{s.testSnapSideInfo}),
 		Current:  snap.R(42),
 		Active:   true,
 		SnapType: "app",
@@ -329,7 +329,7 @@ func (s *ensureSnapServiceSuite) TestEnsureSnapServicesSkipsSnapdSnap(c *C) {
 	// it is special
 	sideInfo := &snap.SideInfo{RealName: "snapd", Revision: snap.R(42)}
 	snapstate.Set(s.state, "snapd", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{sideInfo},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{sideInfo}),
 		Current:  snap.R(42),
 		Active:   true,
 		SnapType: string(snap.TypeSnapd),

--- a/overlord/servicestate/servicestate_test.go
+++ b/overlord/servicestate/servicestate_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/snapcore/snapd/overlord/servicestate"
 	"github.com/snapcore/snapd/overlord/servicestate/servicestatetest"
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/quota"
@@ -403,7 +404,7 @@ func (s *snapServiceOptionsSuite) TestServiceControlTaskSummaries(c *C) {
 	snp := &snap.Info{SideInfo: si}
 	snapstate.Set(st, "foo", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{&si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -475,7 +476,7 @@ func (s *snapServiceOptionsSuite) TestLogReader(c *C) {
 	snp := &snap.Info{SideInfo: si}
 	snapstate.Set(st, "foo", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{&si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -522,7 +523,7 @@ func (s *snapServiceOptionsSuite) TestLogReaderFailsWithNonServices(c *C) {
 	snp := &snap.Info{SideInfo: si}
 	snapstate.Set(st, "foo", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{&si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -553,7 +554,7 @@ func (s *snapServiceOptionsSuite) TestLogReaderNamespaces(c *C) {
 	snp := &snap.Info{SideInfo: si}
 	snapstate.Set(st, "foo", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{&si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})

--- a/overlord/snapshotstate/snapshotstate_test.go
+++ b/overlord/snapshotstate/snapshotstate_test.go
@@ -397,9 +397,9 @@ func (snapshotSuite) createConflictingChange(c *check.C) (st *state.State, resto
 
 	snapstate.Set(st, "foo", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "foo", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -452,9 +452,9 @@ func (snapshotSuite) TestSaveConflictsWithSnapstate(c *check.C) {
 
 	snapstate.Set(st, "foo", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "foo", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -574,9 +574,9 @@ func (s snapshotSuite) TestSaveOneSnap(c *check.C) {
 
 	snapstate.Set(st, "a-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "a-snap", Revision: snap.R(1)},
-		},
+		}),
 		Current: snap.R(1),
 	})
 
@@ -640,7 +640,7 @@ func (snapshotSuite) TestSaveIntegration(c *check.C) {
 		sideInfo := &snap.SideInfo{RealName: name, Revision: snap.R(i + 1)}
 		snapstate.Set(st, name, &snapstate.SnapState{
 			Active:   true,
-			Sequence: []*snap.SideInfo{sideInfo},
+			Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{sideInfo}),
 			Current:  sideInfo.Revision,
 			SnapType: "app",
 		})
@@ -751,7 +751,7 @@ exec /bin/tar "$@"
 		sideInfo := &snap.SideInfo{RealName: name, Revision: snap.R(i + 1)}
 		snapstate.Set(st, name, &snapstate.SnapState{
 			Active:   true,
-			Sequence: []*snap.SideInfo{sideInfo},
+			Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{sideInfo}),
 			Current:  sideInfo.Revision,
 			SnapType: "app",
 		})
@@ -856,7 +856,7 @@ exec /bin/tar "$@"
 	sideInfo := &snap.SideInfo{RealName: "tar-fail-snap", Revision: snap.R(1)}
 	snapstate.Set(st, "tar-fail-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{sideInfo},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{sideInfo}),
 		Current:  sideInfo.Revision,
 		SnapType: "app",
 	})
@@ -953,7 +953,7 @@ func (snapshotSuite) TestRestoreConflictsWithSnapstate(c *check.C) {
 		return map[string]*snapstate.SnapState{
 			"foo": {
 				Active:   true,
-				Sequence: []*snap.SideInfo{sideInfo},
+				Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{sideInfo}),
 				Current:  sideInfo.Revision,
 			},
 		}, nil
@@ -986,9 +986,9 @@ func (snapshotSuite) TestRestoreConflictsWithSnapstate(c *check.C) {
 
 	snapstate.Set(st, "foo", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "foo", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -1038,9 +1038,9 @@ func (snapshotSuite) TestRestoreChecksChangesToSnapID(c *check.C) {
 		return map[string]*snapstate.SnapState{
 			"a-snap": {
 				Active: true,
-				Sequence: []*snap.SideInfo{
+				Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 					{RealName: "a-snap", Revision: snap.R(1), SnapID: "1234567890"},
-				},
+				}),
 				Current: snap.R(1),
 			},
 		}, nil
@@ -1075,7 +1075,7 @@ func (snapshotSuite) TestRestoreChecksChangesToEpoch(c *check.C) {
 		return map[string]*snapstate.SnapState{
 			"a-snap": {
 				Active:   true,
-				Sequence: []*snap.SideInfo{sideInfo},
+				Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{sideInfo}),
 				Current:  sideInfo.Revision,
 			},
 		}, nil
@@ -1116,7 +1116,7 @@ func (snapshotSuite) TestRestoreWorksWithCompatibleEpoch(c *check.C) {
 		return map[string]*snapstate.SnapState{
 			"a-snap": {
 				Active:   true,
-				Sequence: []*snap.SideInfo{sideInfo},
+				Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{sideInfo}),
 				Current:  sideInfo.Revision,
 			},
 		}, nil
@@ -1251,7 +1251,7 @@ func testRestoreIntegration(c *check.C, snapDataDir string, opts *dirs.SnapDirOp
 		sideInfo := &snap.SideInfo{RealName: name, Revision: snap.R(i + 1)}
 		snapstate.Set(st, name, &snapstate.SnapState{
 			Active:   true,
-			Sequence: []*snap.SideInfo{sideInfo},
+			Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{sideInfo}),
 			Current:  sideInfo.Revision,
 			SnapType: "app",
 		})
@@ -1332,7 +1332,7 @@ func (snapshotSuite) TestRestoreIntegrationFails(c *check.C) {
 		sideInfo := &snap.SideInfo{RealName: name, Revision: snap.R(i + 1)}
 		snapstate.Set(st, name, &snapstate.SnapState{
 			Active:   true,
-			Sequence: []*snap.SideInfo{sideInfo},
+			Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{sideInfo}),
 			Current:  sideInfo.Revision,
 			SnapType: "app",
 		})
@@ -1910,7 +1910,7 @@ func (snapshotSuite) TestEstimateSnapshotSize(c *check.C) {
 	sideInfo := &snap.SideInfo{RealName: "some-snap", Revision: snap.R(2)}
 	snapstate.Set(st, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{sideInfo},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{sideInfo}),
 		Current:  sideInfo.Revision,
 	})
 
@@ -1931,7 +1931,7 @@ func (snapshotSuite) TestEstimateSnapshotSizeWithConfig(c *check.C) {
 	sideInfo := &snap.SideInfo{RealName: "some-snap", Revision: snap.R(2)}
 	snapstate.Set(st, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{sideInfo},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{sideInfo}),
 		Current:  sideInfo.Revision,
 	})
 
@@ -1959,7 +1959,7 @@ func (snapshotSuite) TestEstimateSnapshotSizeError(c *check.C) {
 	sideInfo := &snap.SideInfo{RealName: "some-snap", Revision: snap.R(2)}
 	snapstate.Set(st, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{sideInfo},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{sideInfo}),
 		Current:  sideInfo.Revision,
 	})
 
@@ -1979,7 +1979,7 @@ func (snapshotSuite) TestEstimateSnapshotSizeWithUsers(c *check.C) {
 	sideInfo := &snap.SideInfo{RealName: "some-snap", Revision: snap.R(2)}
 	snapstate.Set(st, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{sideInfo},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{sideInfo}),
 		Current:  sideInfo.Revision,
 	})
 

--- a/overlord/snapstate/agentnotify/agentnotify_test.go
+++ b/overlord/snapstate/agentnotify/agentnotify_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/agentnotify"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 )
@@ -66,9 +67,9 @@ func (s *agentNotifySuite) TestNotifyAgentOnLinkChange(c *C) {
 		callCount = 0
 		snapstate.Set(s.st, "some-snap", &snapstate.SnapState{
 			Active: tc.active,
-			Sequence: []*snap.SideInfo{{
+			Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{
 				RealName: "some-snap", Revision: snap.R(1)},
-			},
+			}),
 			Current: snap.R(1),
 		})
 		snapsup := &snapstate.SnapSetup{

--- a/overlord/snapstate/aliasesv2_test.go
+++ b/overlord/snapstate/aliasesv2_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
@@ -159,9 +160,9 @@ func (s *snapmgrTestSuite) TestAutoAliasesDelta(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current: snap.R(11),
 		Active:  true,
 		Aliases: map[string]*snapstate.AliasTarget{
@@ -208,23 +209,23 @@ func (s *snapmgrTestSuite) TestAutoAliasesDeltaAll(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current: snap.R(11),
 		Active:  true,
 	})
 	snapstate.Set(s.state, "other-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "other-snap", Revision: snap.R(2)},
-		},
+		}),
 		Current: snap.R(2),
 		Active:  true,
 	})
 	snapstate.Set(s.state, "alias-snap-apps-go-away", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap-apps-go-away", Revision: snap.R(1)},
-		},
+		}),
 		Current: snap.R(1),
 		Active:  true,
 		Aliases: map[string]*snapstate.AliasTarget{
@@ -266,9 +267,9 @@ func (s *snapmgrTestSuite) TestAutoAliasesDeltaOverManual(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current: snap.R(11),
 		Active:  true,
 		Aliases: map[string]*snapstate.AliasTarget{
@@ -340,9 +341,9 @@ func (s *snapmgrTestSuite) TestCheckAliasesConflictsAgainstAliases(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "other-snap1", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "other-snap", Revision: snap.R(2)},
-		},
+		}),
 		Current:             snap.R(2),
 		Active:              true,
 		AutoAliasesDisabled: true,
@@ -353,9 +354,9 @@ func (s *snapmgrTestSuite) TestCheckAliasesConflictsAgainstAliases(c *C) {
 	})
 
 	snapstate.Set(s.state, "other-snap2", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "other-snap", Revision: snap.R(2)},
-		},
+		}),
 		Current:             snap.R(2),
 		Active:              true,
 		AutoAliasesDisabled: false,
@@ -366,9 +367,9 @@ func (s *snapmgrTestSuite) TestCheckAliasesConflictsAgainstAliases(c *C) {
 	})
 
 	snapst3 := snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "other-snap", Revision: snap.R(2)},
-		},
+		}),
 		Current:             snap.R(2),
 		Active:              true,
 		AutoAliasesDisabled: true,
@@ -456,7 +457,7 @@ func (s *snapmgrTestSuite) TestCheckAliasesConflictsAgainstSnaps(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}}),
 		Current:  snap.R(7),
 		SnapType: "app",
 	})
@@ -525,16 +526,16 @@ func (s *snapmgrTestSuite) TestAliasTasks(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current: snap.R(11),
 		Active:  true,
 	})
 	snapstate.Set(s.state, "some-snap_instance", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current:     snap.R(11),
 		Active:      true,
 		InstanceKey: "instance",
@@ -581,9 +582,9 @@ func (s *snapmgrTestSuite) TestAliasRunThrough(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current: snap.R(11),
 		Active:  true,
 	})
@@ -630,16 +631,16 @@ func (s *snapmgrTestSuite) TestParallelInstanceAliasRunThrough(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current: snap.R(11),
 		Active:  true,
 	})
 	snapstate.Set(s.state, "alias-snap_foo", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current:     snap.R(11),
 		Active:      true,
 		InstanceKey: "foo",
@@ -692,9 +693,9 @@ func (s *snapmgrTestSuite) TestAliasNoTarget(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current: snap.R(11),
 		Active:  true,
 	})
@@ -718,9 +719,9 @@ func (s *snapmgrTestSuite) TestAliasTargetIsDaemon(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current: snap.R(11),
 		Active:  true,
 	})
@@ -752,9 +753,9 @@ func (s *snapmgrTestSuite) TestAliasOverAutoRunThrough(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current: snap.R(11),
 		Active:  true,
 		Aliases: map[string]*snapstate.AliasTarget{
@@ -801,7 +802,7 @@ func (s *snapmgrTestSuite) TestAliasUpdateChangeConflict(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}}),
 		Current:  snap.R(7),
 		SnapType: "app",
 	})
@@ -821,7 +822,7 @@ func (s *snapmgrTestSuite) TestUpdateAliasChangeConflict(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}}),
 		Current:  snap.R(7),
 		SnapType: "app",
 	})
@@ -840,16 +841,16 @@ func (s *snapmgrTestSuite) TestAliasAliasConflict(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current: snap.R(11),
 		Active:  true,
 	})
 	snapstate.Set(s.state, "other-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "other-snap", Revision: snap.R(2)},
-		},
+		}),
 		Current: snap.R(2),
 		Active:  true,
 		Aliases: map[string]*snapstate.AliasTarget{
@@ -876,9 +877,9 @@ func (s *snapmgrTestSuite) TestParallelInstanceAliasConflict(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current: snap.R(11),
 		Active:  true,
 		Aliases: map[string]*snapstate.AliasTarget{
@@ -886,9 +887,9 @@ func (s *snapmgrTestSuite) TestParallelInstanceAliasConflict(c *C) {
 		},
 	})
 	snapstate.Set(s.state, "alias-snap_foo", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current:     snap.R(11),
 		Active:      true,
 		InstanceKey: "foo",
@@ -931,9 +932,9 @@ func (s *snapmgrTestSuite) TestDisableAllAliasesTasks(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
-			{RealName: "some-snap", Revision: snap.R(11)},
-		},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "alias-snap", Revision: snap.R(11)},
+		}),
 		Current: snap.R(11),
 		Active:  true,
 	})
@@ -952,9 +953,9 @@ func (s *snapmgrTestSuite) TestDisableAllAliasesRunThrough(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current: snap.R(11),
 		Active:  true,
 		Aliases: map[string]*snapstate.AliasTarget{
@@ -1010,9 +1011,9 @@ func (s *snapmgrTestSuite) TestParallelInstanceDisableAllAliasesRunThrough(c *C)
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "alias-snap_instance", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current: snap.R(11),
 		Active:  true,
 		Aliases: map[string]*snapstate.AliasTarget{
@@ -1023,9 +1024,9 @@ func (s *snapmgrTestSuite) TestParallelInstanceDisableAllAliasesRunThrough(c *C)
 		InstanceKey: "instance",
 	})
 	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current: snap.R(11),
 		Active:  true,
 		Aliases: map[string]*snapstate.AliasTarget{
@@ -1089,9 +1090,9 @@ func (s *snapmgrTestSuite) TestRemoveManualAliasTasks(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current: snap.R(11),
 		Active:  true,
 		Aliases: map[string]*snapstate.AliasTarget{
@@ -1119,9 +1120,9 @@ func (s *snapmgrTestSuite) TestRemoveManualAliasRunThrough(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current: snap.R(11),
 		Active:  true,
 		Aliases: map[string]*snapstate.AliasTarget{
@@ -1169,9 +1170,9 @@ func (s *snapmgrTestSuite) TestRemoveManualAliasOverAutoRunThrough(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current: snap.R(11),
 		Active:  true,
 		Aliases: map[string]*snapstate.AliasTarget{
@@ -1215,9 +1216,9 @@ func (s *snapmgrTestSuite) TestParallelInstanceRemoveManualAliasRunThrough(c *C)
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "alias-snap_instance", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current: snap.R(11),
 		Active:  true,
 		Aliases: map[string]*snapstate.AliasTarget{
@@ -1271,7 +1272,7 @@ func (s *snapmgrTestSuite) TestUpdateDisableAllAliasesChangeConflict(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}}),
 		Current:  snap.R(7),
 		SnapType: "app",
 		Aliases: map[string]*snapstate.AliasTarget{
@@ -1294,7 +1295,7 @@ func (s *snapmgrTestSuite) TestUpdateRemoveManualAliasChangeConflict(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}}),
 		Current:  snap.R(7),
 		SnapType: "app",
 		Aliases: map[string]*snapstate.AliasTarget{
@@ -1317,7 +1318,7 @@ func (s *snapmgrTestSuite) TestDisableAllAliasesUpdateChangeConflict(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}}),
 		Current:  snap.R(7),
 		SnapType: "app",
 	})
@@ -1337,7 +1338,7 @@ func (s *snapmgrTestSuite) TestRemoveManualAliasUpdateChangeConflict(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}}),
 		Current:  snap.R(7),
 		SnapType: "app",
 		Aliases: map[string]*snapstate.AliasTarget{
@@ -1359,9 +1360,9 @@ func (s *snapmgrTestSuite) TestPreferTasks(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
-			{RealName: "some-snap", Revision: snap.R(11)},
-		},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "alias-snap", Revision: snap.R(11)},
+		}),
 		Current: snap.R(11),
 		Active:  true,
 	})
@@ -1380,9 +1381,9 @@ func (s *snapmgrTestSuite) TestPreferRunThrough(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current:             snap.R(11),
 		Active:              true,
 		AutoAliasesDisabled: true,
@@ -1431,9 +1432,9 @@ func (s *snapmgrTestSuite) TestParallelInstancePreferRunThrough(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current: snap.R(11),
 		Active:  true,
 		Aliases: map[string]*snapstate.AliasTarget{
@@ -1442,9 +1443,9 @@ func (s *snapmgrTestSuite) TestParallelInstancePreferRunThrough(c *C) {
 		},
 	})
 	snapstate.Set(s.state, "alias-snap_instance", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current:             snap.R(11),
 		Active:              true,
 		AutoAliasesDisabled: true,
@@ -1511,7 +1512,7 @@ func (s *snapmgrTestSuite) TestUpdatePreferChangeConflict(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:              true,
-		Sequence:            []*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}},
+		Sequence:            snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}}),
 		Current:             snap.R(7),
 		SnapType:            "app",
 		AutoAliasesDisabled: true,
@@ -1535,7 +1536,7 @@ func (s *snapmgrTestSuite) TestPreferUpdateChangeConflict(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:              true,
-		Sequence:            []*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}},
+		Sequence:            snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}}),
 		Current:             snap.R(7),
 		SnapType:            "app",
 		AutoAliasesDisabled: true,

--- a/overlord/snapstate/autorefresh_gating_test.go
+++ b/overlord/snapstate/autorefresh_gating_test.go
@@ -121,7 +121,7 @@ func mockInstalledSnap(c *C, st *state.State, snapYaml string, hasHook bool) *sn
 	si := &snap.SideInfo{RealName: snapName, SnapID: snapName + "-id", Revision: snap.R(1)}
 	snapstate.Set(st, snapName, &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 		SnapType: string(snapInfo.Type()),
 	})
@@ -1793,7 +1793,7 @@ func (s *autorefreshGatingSuite) TestHoldRefreshesBySystemIndefinitely(c *C) {
 		RealName: "some-snap",
 	}
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 		Active:   true,
 	})
@@ -1828,7 +1828,7 @@ func (s *autorefreshGatingSuite) TestUnholdSnaps(c *C) {
 		RealName: "some-snap",
 	}
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 		Active:   true,
 	})

--- a/overlord/snapstate/autorefresh_test.go
+++ b/overlord/snapstate/autorefresh_test.go
@@ -129,9 +129,9 @@ func (s *autoRefreshTestSuite) SetUpTest(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", Revision: snap.R(5), SnapID: "some-snap-id"},
-		},
+		}),
 		Current:  snap.R(5),
 		SnapType: "app",
 		UserID:   1,
@@ -949,7 +949,7 @@ func (s *autoRefreshTestSuite) TestInitialInhibitRefreshWithinInhibitWindow(c *C
 	si := &snap.SideInfo{RealName: "pkg", Revision: snap.R(1)}
 	info := &snap.Info{SideInfo: *si}
 	snapst := &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 	}
 	snapsup := &snapstate.SnapSetup{Flags: snapstate.Flags{IsAutoRefresh: true}}
@@ -986,7 +986,7 @@ func (s *autoRefreshTestSuite) TestSubsequentInhibitRefreshWithinInhibitWindow(c
 	si := &snap.SideInfo{RealName: "pkg", Revision: snap.R(1)}
 	info := &snap.Info{SideInfo: *si}
 	snapst := &snapstate.SnapState{
-		Sequence:             []*snap.SideInfo{si},
+		Sequence:             snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:              si.Revision,
 		RefreshInhibitedTime: &pastInstant,
 	}
@@ -1029,7 +1029,7 @@ func (s *autoRefreshTestSuite) TestInhibitRefreshRefreshesWhenOverdue(c *C) {
 	si := &snap.SideInfo{RealName: "pkg", Revision: snap.R(1)}
 	info := &snap.Info{SideInfo: *si}
 	snapst := &snapstate.SnapState{
-		Sequence:             []*snap.SideInfo{si},
+		Sequence:             snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:              si.Revision,
 		RefreshInhibitedTime: &pastInstant,
 	}
@@ -1059,7 +1059,7 @@ func (s *autoRefreshTestSuite) TestInhibitNoNotificationOnManualRefresh(c *C) {
 	si := &snap.SideInfo{RealName: "pkg", Revision: snap.R(1)}
 	info := &snap.Info{SideInfo: *si}
 	snapst := &snapstate.SnapState{
-		Sequence:             []*snap.SideInfo{si},
+		Sequence:             snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:              si.Revision,
 		RefreshInhibitedTime: &pastInstant,
 	}
@@ -1156,7 +1156,7 @@ func (s *autoRefreshTestSuite) addRefreshableSnap(names ...string) {
 		si := &snap.SideInfo{RealName: name, SnapID: fmt.Sprintf("%s-id", name), Revision: snap.R(1)}
 		snapstate.Set(s.state, name, &snapstate.SnapState{
 			Active:   true,
-			Sequence: []*snap.SideInfo{si},
+			Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 			Current:  si.Revision,
 			SnapType: string(snap.TypeApp),
 		})

--- a/overlord/snapstate/booted_test.go
+++ b/overlord/snapstate/booted_test.go
@@ -140,8 +140,9 @@ func (bs *bootedSuite) makeInstalledKernelOS(c *C, st *state.State) {
 	snapstate.Set(st, "core", &snapstate.SnapState{
 		SnapType: "os",
 		Active:   true,
-		Sequence: []*snap.SideInfo{osSI1, osSI2},
-		Current:  snap.R(2),
+		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos([]*snapstate.RevisionSideState{snapstate.NewRevisionSideInfo(osSI1, nil),
+			snapstate.NewRevisionSideInfo(osSI2, nil)}),
+		Current: snap.R(2),
 	})
 
 	snaptest.MockSnap(c, "name: canonical-pc-linux\ntype: os\nversion: 1", kernelSI1)
@@ -149,8 +150,9 @@ func (bs *bootedSuite) makeInstalledKernelOS(c *C, st *state.State) {
 	snapstate.Set(st, "canonical-pc-linux", &snapstate.SnapState{
 		SnapType: "kernel",
 		Active:   true,
-		Sequence: []*snap.SideInfo{kernelSI1, kernelSI2},
-		Current:  snap.R(2),
+		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos([]*snapstate.RevisionSideState{snapstate.NewRevisionSideInfo(kernelSI1, nil),
+			snapstate.NewRevisionSideInfo(kernelSI2, nil)}),
+		Current: snap.R(2),
 	})
 
 }
@@ -275,7 +277,7 @@ func (bs *bootedSuite) TestUpdateBootRevisionsOSErrorsLate(c *C) {
 	snapstate.Set(st, "canonical-pc-linux", &snapstate.SnapState{
 		SnapType: "kernel",
 		Active:   true,
-		Sequence: []*snap.SideInfo{kernelSI2},
+		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos([]*snapstate.RevisionSideState{snapstate.NewRevisionSideInfo(kernelSI2, nil)}),
 		Current:  snap.R(2),
 	})
 
@@ -284,8 +286,9 @@ func (bs *bootedSuite) TestUpdateBootRevisionsOSErrorsLate(c *C) {
 	snapstate.Set(st, "core", &snapstate.SnapState{
 		SnapType: "os",
 		Active:   true,
-		Sequence: []*snap.SideInfo{osSI1, osSI2},
-		Current:  snap.R(2),
+		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos([]*snapstate.RevisionSideState{snapstate.NewRevisionSideInfo(osSI1, nil),
+			snapstate.NewRevisionSideInfo(osSI2, nil)}),
+		Current: snap.R(2),
 	})
 	bs.fakeBackend.linkSnapFailTrigger = filepath.Join(dirs.SnapMountDir, "/core/1")
 
@@ -556,8 +559,9 @@ func (bs *bootedSuite) TestFinishRestartClassicWithModesCoreIgnored(c *C) {
 	snapstate.Set(st, "canonical-pc-linux", &snapstate.SnapState{
 		SnapType: "kernel",
 		Active:   true,
-		Sequence: []*snap.SideInfo{kernelSI1, kernelSI2},
-		Current:  snap.R(2),
+		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos([]*snapstate.RevisionSideState{snapstate.NewRevisionSideInfo(kernelSI1, nil),
+			snapstate.NewRevisionSideInfo(kernelSI2, nil)}),
+		Current: snap.R(2),
 	})
 	// we have core22 and current is r2
 	osSI1 := &snap.SideInfo{RealName: "core22", Revision: snap.R(1)}
@@ -567,8 +571,9 @@ func (bs *bootedSuite) TestFinishRestartClassicWithModesCoreIgnored(c *C) {
 	snapstate.Set(st, "core22", &snapstate.SnapState{
 		SnapType: "base",
 		Active:   true,
-		Sequence: []*snap.SideInfo{osSI1, osSI2},
-		Current:  snap.R(2),
+		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos([]*snapstate.RevisionSideState{snapstate.NewRevisionSideInfo(osSI1, nil),
+			snapstate.NewRevisionSideInfo(osSI2, nil)}),
+		Current: snap.R(2),
 	})
 	// now pretend that for whatever reason the modeenv reports that
 	// r1 was booted (which is a bug as on a classic+modes

--- a/overlord/snapstate/check_snap_test.go
+++ b/overlord/snapstate/check_snap_test.go
@@ -320,7 +320,7 @@ version: 1
 	snapstate.Set(st, "gadget", &snapstate.SnapState{
 		SnapType: "gadget",
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 	})
 
@@ -362,7 +362,7 @@ version: 1
 	snapstate.Set(st, "gadget", &snapstate.SnapState{
 		SnapType: "gadget",
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 	})
 
@@ -404,7 +404,7 @@ version: 1
 	snapstate.Set(st, "gadget", &snapstate.SnapState{
 		SnapType: "gadget",
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 	})
 
@@ -437,7 +437,7 @@ func (s *checkSnapSuite) setupKernelGadgetSnaps(st *state.State) {
 	snapstate.Set(st, "gadget", &snapstate.SnapState{
 		SnapType: string(snap.TypeGadget),
 		Active:   true,
-		Sequence: []*snap.SideInfo{gadgetInfo},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{gadgetInfo}),
 		Current:  gadgetInfo.Revision,
 	})
 
@@ -449,7 +449,7 @@ func (s *checkSnapSuite) setupKernelGadgetSnaps(st *state.State) {
 	snapstate.Set(st, "kernel", &snapstate.SnapState{
 		SnapType: string(snap.TypeKernel),
 		Active:   true,
-		Sequence: []*snap.SideInfo{kernelInfo},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{kernelInfo}),
 		Current:  kernelInfo.Revision,
 	})
 }
@@ -558,7 +558,7 @@ version: 1
 	snapstate.Set(st, "gadget", &snapstate.SnapState{
 		SnapType: "gadget",
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 	})
 
@@ -599,7 +599,7 @@ version: 1
 	snapstate.Set(st, "gadget", &snapstate.SnapState{
 		SnapType: "gadget",
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 	})
 
@@ -759,7 +759,7 @@ version: 1
 	snapstate.Set(st, "kernel", &snapstate.SnapState{
 		SnapType: "kernel",
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 	})
 
@@ -801,7 +801,7 @@ version: 1
 	snapstate.Set(st, "kernel", &snapstate.SnapState{
 		SnapType: "kernel",
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 	})
 
@@ -845,7 +845,7 @@ version: 1
 	snapstate.Set(st, "other-kernel", &snapstate.SnapState{
 		SnapType: "kernel",
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 	})
 
@@ -933,7 +933,7 @@ version: 1
 	snapstate.Set(st, "some-base", &snapstate.SnapState{
 		SnapType: "base",
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 	})
 
@@ -969,7 +969,7 @@ version: 1
 `, si)
 	snapstate.Set(st, "foo", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 	})
 
@@ -1075,7 +1075,7 @@ version: 1
 	snapstate.Set(st, "core", &snapstate.SnapState{
 		SnapType: "os",
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 	})
 
@@ -1410,7 +1410,7 @@ version: 1
 	snapstate.Set(st, "kernel", &snapstate.SnapState{
 		SnapType: "kernel",
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 	})
 
@@ -1461,7 +1461,7 @@ version: 1
 	snapstate.Set(st, "gadget", &snapstate.SnapState{
 		SnapType: "gadget",
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 	})
 

--- a/overlord/snapstate/dbus_test.go
+++ b/overlord/snapstate/dbus_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -82,7 +83,7 @@ func (s *snapmgrTestSuite) TestCheckDBusServiceConflictsSystem(c *C) {
 	}
 	snapstate.Set(s.state, "other-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 		SnapType: "app",
 	})
@@ -117,7 +118,7 @@ func (s *snapmgrTestSuite) TestCheckDBusServiceConflictsSession(c *C) {
 	}
 	snapstate.Set(s.state, "other-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 		SnapType: "app",
 	})
@@ -155,7 +156,7 @@ func (s *snapmgrTestSuite) TestCheckDBusServiceConflictsDifferentBuses(c *C) {
 	}
 	snapstate.Set(s.state, "system-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 		SnapType: "app",
 	})
@@ -170,7 +171,7 @@ func (s *snapmgrTestSuite) TestCheckDBusServiceConflictsDifferentBuses(c *C) {
 	}
 	snapstate.Set(s.state, "session-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 		SnapType: "app",
 	})
@@ -205,7 +206,7 @@ func (s *snapmgrTestSuite) TestCheckDBusServiceConflictsNoConflictWithSelf(c *C)
 	}
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 		SnapType: "app",
 	})
@@ -240,7 +241,7 @@ func (s *snapmgrTestSuite) TestInstallDBusActivationConflicts(c *C) {
 	}
 	snapstate.Set(s.state, "other-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 		SnapType: "app",
 	})

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1848,17 +1848,17 @@ func writeSeqFile(name string, snapst *SnapState) error {
 	}
 
 	b, err := json.Marshal(&struct {
-		Sequence              []*snap.SideInfo `json:"sequence"`
-		Current               string           `json:"current"`
-		MigratedHidden        bool             `json:"migrated-hidden"`
-		MigratedToExposedHome bool             `json:"migrated-exposed-home"`
+		Sequence              SnapSequence `json:"sequence"`
+		Current               string       `json:"current"`
+		MigratedHidden        bool         `json:"migrated-hidden"`
+		MigratedToExposedHome bool         `json:"migrated-exposed-home"`
 	}{
 		Sequence: snapst.Sequence,
 		Current:  snapst.Current.String(),
 		// if the snap state if empty, we're probably undoing a failed install.
 		// Reset the flags to false
-		MigratedHidden:        len(snapst.Sequence) > 0 && snapst.MigratedHidden,
-		MigratedToExposedHome: len(snapst.Sequence) > 0 && snapst.MigratedToExposedHome,
+		MigratedHidden:        len(snapst.Sequence.Revisions) > 0 && snapst.MigratedHidden,
+		MigratedToExposedHome: len(snapst.Sequence.Revisions) > 0 && snapst.MigratedToExposedHome,
 	})
 	if err != nil {
 		return err
@@ -1997,26 +1997,26 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (err error) {
 	// find if the snap is already installed before we modify snapst below
 	isInstalled := snapst.IsInstalled()
 
-	cand := snapsup.SideInfo
-	m.backend.Candidate(cand)
+	cand := NewRevisionSideInfo(snapsup.SideInfo, nil)
+	m.backend.Candidate(cand.Snap)
 
-	oldCandidateIndex := snapst.LastIndex(cand.Revision)
+	oldCandidateIndex := snapst.LastIndex(cand.Snap.Revision)
 
 	var oldRevsBeforeCand []snap.Revision
 	if oldCandidateIndex < 0 {
-		snapst.Sequence = append(snapst.Sequence, cand)
+		snapst.Sequence.Revisions = append(snapst.Sequence.Revisions, cand)
 	} else if !snapsup.Revert {
 		// save the revs before the candidate, so undoLink can account for discarded revs when putting it back
-		for _, si := range snapst.Sequence[:oldCandidateIndex] {
-			oldRevsBeforeCand = append(oldRevsBeforeCand, si.Revision)
+		for _, si := range snapst.Sequence.Revisions[:oldCandidateIndex] {
+			oldRevsBeforeCand = append(oldRevsBeforeCand, si.Snap.Revision)
 		}
 		// remove the old candidate from the sequence, add it at the end
-		copy(snapst.Sequence[oldCandidateIndex:len(snapst.Sequence)-1], snapst.Sequence[oldCandidateIndex+1:])
-		snapst.Sequence[len(snapst.Sequence)-1] = cand
+		copy(snapst.Sequence.Revisions[oldCandidateIndex:len(snapst.Sequence.Revisions)-1], snapst.Sequence.Revisions[oldCandidateIndex+1:])
+		snapst.Sequence.Revisions[len(snapst.Sequence.Revisions)-1] = cand
 	}
 
 	oldCurrent := snapst.Current
-	snapst.Current = cand.Revision
+	snapst.Current = cand.Snap.Revision
 	snapst.Active = true
 	oldChannel := snapst.TrackingChannel
 	if snapsup.Channel != "" {
@@ -2067,7 +2067,7 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (err error) {
 	// migration related ops
 	setMigrationFlagsinState(snapst, snapsup)
 
-	newInfo, err := readInfo(snapsup.InstanceName(), cand, 0)
+	newInfo, err := readInfo(snapsup.InstanceName(), cand.Snap, 0)
 	if err != nil {
 		return err
 	}
@@ -2167,7 +2167,7 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (err error) {
 		}
 	}
 
-	if len(snapst.Sequence) == 1 {
+	if len(snapst.Sequence.Revisions) == 1 {
 		if err := m.createSnapCookie(st, snapsup.InstanceName()); err != nil {
 			return fmt.Errorf("cannot create snap cookie: %v", err)
 		}
@@ -2198,7 +2198,7 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (err error) {
 			delete(snapst.RevertStatus, oldCurrent.N)
 		}
 	} else {
-		delete(snapst.RevertStatus, cand.Revision.N)
+		delete(snapst.RevertStatus, cand.Snap.Revision.N)
 	}
 
 	// Record the fact that the snap was refreshed successfully.
@@ -2208,21 +2208,21 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) (err error) {
 		snapst.LastRefreshTime = &now
 	}
 
-	if cand.SnapID != "" {
+	if cand.Snap.SnapID != "" {
 		// write the auxiliary store info
 		aux := &auxStoreInfo{
 			Media:   snapsup.Media,
 			Website: snapsup.Website,
 		}
-		if err := keepAuxStoreInfo(cand.SnapID, aux); err != nil {
+		if err := keepAuxStoreInfo(cand.Snap.SnapID, aux); err != nil {
 			return err
 		}
-		if len(snapst.Sequence) == 1 {
+		if len(snapst.Sequence.Revisions) == 1 {
 			defer func() {
 				if IsErrAndNotWait(err) {
 					// the install is getting undone, and there are no more of this snap
 					// try to remove the aux info we just created
-					discardAuxStoreInfo(cand.SnapID)
+					discardAuxStoreInfo(cand.Snap.SnapID)
 				}
 			}()
 		}
@@ -2623,7 +2623,7 @@ func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
-	if len(snapst.Sequence) == 1 {
+	if len(snapst.Sequence.Revisions) == 1 {
 		// XXX: shouldn't these two just log and carry on? this is an undo handler...
 		timings.Run(perfTimings, "discard-snap-namespace", fmt.Sprintf("discard the namespace of snap %q", snapsup.InstanceName()), func(tm timings.Measurer) {
 			err = m.backend.DiscardSnapNamespace(snapsup.InstanceName())
@@ -2650,15 +2650,15 @@ func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	if oldCandidateIndex < 0 {
-		snapst.Sequence = append(snapst.Sequence[:currentIndex], snapst.Sequence[currentIndex+1:]...)
+		snapst.Sequence.Revisions = append(snapst.Sequence.Revisions[:currentIndex], snapst.Sequence.Revisions[currentIndex+1:]...)
 	} else if !isRevert {
 		// account for revisions discarded before the install failed
-		discarded := countMissingRevs(oldRevsBeforeCand, snapst.Sequence)
+		discarded := countMissingRevs(oldRevsBeforeCand, snapst.Sequence.Revisions)
 		oldCandidateIndex -= discarded
 
-		oldCand := snapst.Sequence[currentIndex]
-		copy(snapst.Sequence[oldCandidateIndex+1:], snapst.Sequence[oldCandidateIndex:])
-		snapst.Sequence[oldCandidateIndex] = oldCand
+		oldCand := snapst.Sequence.Revisions[currentIndex]
+		copy(snapst.Sequence.Revisions[oldCandidateIndex+1:], snapst.Sequence.Revisions[oldCandidateIndex:])
+		snapst.Sequence.Revisions[oldCandidateIndex] = oldCand
 	}
 	snapst.Current = oldCurrent
 	snapst.Active = false
@@ -2692,7 +2692,7 @@ func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	// refresh/install) by restoring the configuration of "old current".
 	// similarly, we need to re-save the disabled services if there is a
 	// revision for us to go back to, see comment below for full explanation
-	if len(snapst.Sequence) > 0 {
+	if len(snapst.Sequence.Revisions) > 0 {
 		if err = config.RestoreRevisionConfig(st, snapsup.InstanceName(), oldCurrent); err != nil {
 			return err
 		}
@@ -2780,12 +2780,12 @@ func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	return nil
 }
 
-// countMissingRevs counts how many of the revisions aren't present in the sequence of sideInfos
-func countMissingRevs(revisions []snap.Revision, sideInfos []*snap.SideInfo) int {
+// countMissingRevs counts how many of the revisions aren't present in the sequence
+func countMissingRevs(revisions []snap.Revision, revSideInfos []*RevisionSideState) int {
 	var found int
 	for _, rev := range revisions {
-		for _, si := range sideInfos {
-			if si.Revision == rev {
+		for _, si := range revSideInfos {
+			if si.Snap.Revision == rev {
 				found++
 			}
 		}
@@ -3278,7 +3278,7 @@ func (m *SnapManager) doClearSnapData(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
-	if len(snapst.Sequence) == 1 {
+	if len(snapst.Sequence.Revisions) == 1 {
 		// Only remove data common between versions if this is the last version
 		if err = m.backend.RemoveSnapCommonData(info, dirOpts); err != nil {
 			return err
@@ -3334,21 +3334,21 @@ func (m *SnapManager) doDiscardSnap(t *state.Task, _ *tomb.Tomb) error {
 	// drop any potential revert status for this revision
 	delete(snapst.RevertStatus, snapsup.Revision().N)
 
-	if len(snapst.Sequence) == 1 {
-		snapst.Sequence = nil
+	if len(snapst.Sequence.Revisions) == 1 {
+		snapst.Sequence.Revisions = nil
 		snapst.Current = snap.Revision{}
 	} else {
-		newSeq := make([]*snap.SideInfo, 0, len(snapst.Sequence))
-		for _, si := range snapst.Sequence {
-			if si.Revision == snapsup.Revision() {
+		newSeq := make([]*RevisionSideState, 0, len(snapst.Sequence.Revisions))
+		for _, si := range snapst.Sequence.Revisions {
+			if si.Snap.Revision == snapsup.Revision() {
 				// leave out
 				continue
 			}
 			newSeq = append(newSeq, si)
 		}
-		snapst.Sequence = newSeq
+		snapst.Sequence.Revisions = newSeq
 		if snapst.Current == snapsup.Revision() {
-			snapst.Current = newSeq[len(newSeq)-1].Revision
+			snapst.Current = newSeq[len(newSeq)-1].Snap.Revision
 		}
 	}
 
@@ -3362,7 +3362,7 @@ func (m *SnapManager) doDiscardSnap(t *state.Task, _ *tomb.Tomb) error {
 		t.Errorf("cannot remove snap file %q, will retry in 3 mins: %s", snapsup.InstanceName(), err)
 		return &state.Retry{After: 3 * time.Minute}
 	}
-	if len(snapst.Sequence) == 0 {
+	if len(snapst.Sequence.Revisions) == 0 {
 		if err = m.backend.RemoveSnapMountUnits(snapsup.placeInfo(), nil); err != nil {
 			return err
 		}

--- a/overlord/snapstate/handlers_aliasesv2_test.go
+++ b/overlord/snapstate/handlers_aliasesv2_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 )
@@ -43,9 +44,9 @@ func (s *snapmgrTestSuite) TestDoSetAutoAliases(c *C) {
 	}
 
 	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current:             snap.R(11),
 		Active:              true,
 		AutoAliasesDisabled: false,
@@ -98,9 +99,9 @@ func (s *snapmgrTestSuite) TestDoSetAutoAliasesFirstInstall(c *C) {
 	}
 
 	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current: snap.R(11),
 		Active:  true,
 	})
@@ -148,9 +149,9 @@ func (s *snapmgrTestSuite) TestDoUndoSetAutoAliases(c *C) {
 	}
 
 	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current:        snap.R(11),
 		Active:         true,
 		AliasesPending: true,
@@ -209,9 +210,9 @@ func (s *snapmgrTestSuite) TestDoSetAutoAliasesConflict(c *C) {
 	}
 
 	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current:        snap.R(11),
 		Active:         true,
 		AliasesPending: true,
@@ -222,9 +223,9 @@ func (s *snapmgrTestSuite) TestDoSetAutoAliasesConflict(c *C) {
 		},
 	})
 	snapstate.Set(s.state, "other-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "other-snap", Revision: snap.R(3)},
-		},
+		}),
 		Current:        snap.R(3),
 		Active:         true,
 		AliasesPending: true,
@@ -265,9 +266,9 @@ func (s *snapmgrTestSuite) TestDoUndoSetAutoAliasesConflict(c *C) {
 	}
 
 	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current:        snap.R(11),
 		Active:         true,
 		AliasesPending: true,
@@ -279,9 +280,9 @@ func (s *snapmgrTestSuite) TestDoUndoSetAutoAliasesConflict(c *C) {
 	})
 
 	otherSnapState := &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "other-snap", Revision: snap.R(3)},
-		},
+		}),
 		Current:             snap.R(3),
 		Active:              true,
 		AutoAliasesDisabled: false,
@@ -363,9 +364,9 @@ func (s *snapmgrTestSuite) TestDoSetAutoAliasesFirstInstallUnaliased(c *C) {
 	}
 
 	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current: snap.R(11),
 		Active:  true,
 	})
@@ -414,9 +415,9 @@ func (s *snapmgrTestSuite) TestDoUndoSetAutoAliasesFirstInstallUnaliased(c *C) {
 	}
 
 	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current: snap.R(11),
 		Active:  true,
 	})
@@ -458,9 +459,9 @@ func (s *snapmgrTestSuite) TestDoSetupAliases(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current:             snap.R(11),
 		Active:              true,
 		AutoAliasesDisabled: true,
@@ -508,9 +509,9 @@ func (s *snapmgrTestSuite) TestDoUndoSetupAliases(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current:             snap.R(11),
 		Active:              true,
 		AutoAliasesDisabled: true,
@@ -568,9 +569,9 @@ func (s *snapmgrTestSuite) TestDoSetupAliasesAuto(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current:             snap.R(11),
 		Active:              true,
 		AutoAliasesDisabled: false,
@@ -618,9 +619,9 @@ func (s *snapmgrTestSuite) TestDoUndoSetupAliasesAuto(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current:             snap.R(11),
 		Active:              true,
 		AutoAliasesDisabled: false,
@@ -678,9 +679,9 @@ func (s *snapmgrTestSuite) TestDoSetupAliasesNothing(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current: snap.R(11),
 		Active:  true,
 	})
@@ -724,9 +725,9 @@ func (s *snapmgrTestSuite) TestDoUndoSetupAliasesNothing(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current: snap.R(11),
 		Active:  true,
 	})
@@ -778,9 +779,9 @@ func (s *snapmgrTestSuite) TestDoPruneAutoAliasesAuto(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current:        snap.R(11),
 		Active:         true,
 		AliasesPending: false,
@@ -835,9 +836,9 @@ func (s *snapmgrTestSuite) TestDoPruneAutoAliasesAutoPending(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current:        snap.R(11),
 		Active:         true,
 		AliasesPending: true,
@@ -882,9 +883,9 @@ func (s *snapmgrTestSuite) TestDoPruneAutoAliasesManualAndDisabled(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current:             snap.R(11),
 		Active:              true,
 		AutoAliasesDisabled: true,
@@ -948,9 +949,9 @@ func (s *snapmgrTestSuite) TestDoRefreshAliases(c *C) {
 	}
 
 	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current:        snap.R(11),
 		Active:         true,
 		AliasesPending: false,
@@ -1021,9 +1022,9 @@ func (s *snapmgrTestSuite) TestDoUndoRefreshAliases(c *C) {
 	}
 
 	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current:        snap.R(11),
 		Active:         true,
 		AliasesPending: false,
@@ -1111,9 +1112,9 @@ func (s *snapmgrTestSuite) TestDoUndoRefreshAliasesFromEmpty(c *C) {
 	}
 
 	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current:        snap.R(11),
 		Active:         true,
 		AliasesPending: false,
@@ -1186,9 +1187,9 @@ func (s *snapmgrTestSuite) TestDoRefreshAliasesPending(c *C) {
 	}
 
 	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current:        snap.R(11),
 		Active:         true,
 		AliasesPending: true,
@@ -1245,9 +1246,9 @@ func (s *snapmgrTestSuite) TestDoUndoRefreshAliasesPending(c *C) {
 	}
 
 	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current:        snap.R(11),
 		Active:         true,
 		AliasesPending: true,
@@ -1310,9 +1311,9 @@ func (s *snapmgrTestSuite) TestDoRefreshAliasesConflict(c *C) {
 	}
 
 	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current: snap.R(11),
 		Active:  true,
 		Aliases: map[string]*snapstate.AliasTarget{
@@ -1322,9 +1323,9 @@ func (s *snapmgrTestSuite) TestDoRefreshAliasesConflict(c *C) {
 		},
 	})
 	snapstate.Set(s.state, "other-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "other-snap", Revision: snap.R(3)},
-		},
+		}),
 		Current: snap.R(3),
 		Active:  true,
 		Aliases: map[string]*snapstate.AliasTarget{
@@ -1364,9 +1365,9 @@ func (s *snapmgrTestSuite) TestDoUndoRefreshAliasesConflict(c *C) {
 	}
 
 	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current:        snap.R(11),
 		Active:         true,
 		AliasesPending: false,
@@ -1383,9 +1384,9 @@ func (s *snapmgrTestSuite) TestDoUndoRefreshAliasesConflict(c *C) {
 		defer st.Unlock()
 
 		snapstate.Set(s.state, "other-snap", &snapstate.SnapState{
-			Sequence: []*snap.SideInfo{
+			Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 				{RealName: "other-snap", Revision: snap.R(3)},
-			},
+			}),
 			Current:        snap.R(3),
 			Active:         true,
 			AliasesPending: false,
@@ -1479,9 +1480,9 @@ func (s *snapmgrTestSuite) TestDoUndoDisableAliases(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current: snap.R(11),
 		Active:  true,
 		Aliases: map[string]*snapstate.AliasTarget{
@@ -1552,9 +1553,9 @@ func (s *snapmgrTestSuite) TestDoPreferAliases(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current:             snap.R(11),
 		Active:              true,
 		AutoAliasesDisabled: true,
@@ -1565,9 +1566,9 @@ func (s *snapmgrTestSuite) TestDoPreferAliases(c *C) {
 		},
 	})
 	snapstate.Set(s.state, "other-alias-snap1", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "other-alias-snap1", Revision: snap.R(3)},
-		},
+		}),
 		Current: snap.R(3),
 		Active:  true,
 		Aliases: map[string]*snapstate.AliasTarget{
@@ -1575,9 +1576,9 @@ func (s *snapmgrTestSuite) TestDoPreferAliases(c *C) {
 		},
 	})
 	snapstate.Set(s.state, "other-alias-snap2", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "other-alias-snap2", Revision: snap.R(3)},
-		},
+		}),
 		Current:        snap.R(3),
 		Active:         true,
 		AliasesPending: true,
@@ -1587,9 +1588,9 @@ func (s *snapmgrTestSuite) TestDoPreferAliases(c *C) {
 		},
 	})
 	snapstate.Set(s.state, "other-alias-snap3", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "other-alias-snap3", Revision: snap.R(3)},
-		},
+		}),
 		Current: snap.R(3),
 		Active:  true,
 		Aliases: map[string]*snapstate.AliasTarget{
@@ -1676,9 +1677,9 @@ func (s *snapmgrTestSuite) TestDoUndoPreferAliases(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current:             snap.R(11),
 		Active:              true,
 		AutoAliasesDisabled: true,
@@ -1689,9 +1690,9 @@ func (s *snapmgrTestSuite) TestDoUndoPreferAliases(c *C) {
 		},
 	})
 	snapstate.Set(s.state, "other-alias-snap1", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "other-alias-snap1", Revision: snap.R(3)},
-		},
+		}),
 		Current: snap.R(3),
 		Active:  true,
 		Aliases: map[string]*snapstate.AliasTarget{
@@ -1699,9 +1700,9 @@ func (s *snapmgrTestSuite) TestDoUndoPreferAliases(c *C) {
 		},
 	})
 	snapstate.Set(s.state, "other-alias-snap2", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "other-alias-snap2", Revision: snap.R(3)},
-		},
+		}),
 		Current:        snap.R(3),
 		Active:         true,
 		AliasesPending: true,
@@ -1711,9 +1712,9 @@ func (s *snapmgrTestSuite) TestDoUndoPreferAliases(c *C) {
 		},
 	})
 	snapstate.Set(s.state, "other-alias-snap3", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "other-alias-snap3", Revision: snap.R(3)},
-		},
+		}),
 		Current: snap.R(3),
 		Active:  true,
 		Aliases: map[string]*snapstate.AliasTarget{
@@ -1800,9 +1801,9 @@ func (s *snapmgrTestSuite) TestDoUndoPreferAliasesConflict(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current:             snap.R(11),
 		Active:              true,
 		AutoAliasesDisabled: true,
@@ -1813,9 +1814,9 @@ func (s *snapmgrTestSuite) TestDoUndoPreferAliasesConflict(c *C) {
 		},
 	})
 	snapstate.Set(s.state, "other-alias-snap1", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "other-alias-snap1", Revision: snap.R(3)},
-		},
+		}),
 		Current: snap.R(3),
 		Active:  true,
 		Aliases: map[string]*snapstate.AliasTarget{
@@ -1823,9 +1824,9 @@ func (s *snapmgrTestSuite) TestDoUndoPreferAliasesConflict(c *C) {
 		},
 	})
 	snapstate.Set(s.state, "other-alias-snap2", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "other-alias-snap2", Revision: snap.R(3)},
-		},
+		}),
 		Current:        snap.R(3),
 		Active:         true,
 		AliasesPending: true,
@@ -1835,9 +1836,9 @@ func (s *snapmgrTestSuite) TestDoUndoPreferAliasesConflict(c *C) {
 		},
 	})
 	snapstate.Set(s.state, "other-alias-snap3", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "other-alias-snap3", Revision: snap.R(3)},
-		},
+		}),
 		Current: snap.R(3),
 		Active:  true,
 		Aliases: map[string]*snapstate.AliasTarget{
@@ -1965,9 +1966,9 @@ func (s *snapmgrTestSuite) TestDoSetAutoAliasesFirstInstallPrefer(c *C) {
 	}
 
 	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current: snap.R(11),
 		Active:  true,
 	})
@@ -2016,9 +2017,9 @@ func (s *snapmgrTestSuite) TestDoUndoSetAutoAliasesFirstInstallPrefer(c *C) {
 	}
 
 	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current: snap.R(11),
 		Active:  true,
 	})

--- a/overlord/snapstate/handlers_copy_test.go
+++ b/overlord/snapstate/handlers_copy_test.go
@@ -25,6 +25,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 )
@@ -46,7 +47,7 @@ func (s *copySnapDataSuite) TestDoCopySnapDataFailedRead(c *C) {
 	// With a snap "pkg" at revision 42
 	si := &snap.SideInfo{RealName: "pkg", Revision: snap.R(42)}
 	snapstate.Set(s.state, "pkg", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 		Active:   true,
 	})

--- a/overlord/snapstate/handlers_discard_test.go
+++ b/overlord/snapstate/handlers_discard_test.go
@@ -57,10 +57,10 @@ func (s *discardSnapSuite) SetUpTest(c *C) {
 func (s *discardSnapSuite) TestDoDiscardSnapSuccess(c *C) {
 	s.state.Lock()
 	snapstate.Set(s.state, "foo", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "foo", Revision: snap.R(3)},
 			{RealName: "foo", Revision: snap.R(33)},
-		},
+		}),
 		Current:  snap.R(33),
 		SnapType: "app",
 	})
@@ -84,7 +84,7 @@ func (s *discardSnapSuite) TestDoDiscardSnapSuccess(c *C) {
 	err := snapstate.Get(s.state, "foo", &snapst)
 	c.Assert(err, IsNil)
 
-	c.Check(snapst.Sequence, HasLen, 1)
+	c.Check(snapst.Sequence.Revisions, HasLen, 1)
 	c.Check(snapst.Current, Equals, snap.R(3))
 	c.Check(t.Status(), Equals, state.DoneStatus)
 }
@@ -106,9 +106,9 @@ func (s *discardSnapSuite) TestDoDiscardSnapInQuotaGroup(c *C) {
 	defer func() { c.Assert(ensureSnapAbsentFromQuotaGroupCalls, Equals, 1) }()
 
 	snapstate.Set(s.state, "foo", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "foo", Revision: snap.R(3)},
-		},
+		}),
 		Current:  snap.R(3),
 		SnapType: "app",
 	})
@@ -138,9 +138,9 @@ func (s *discardSnapSuite) TestDoDiscardSnapInQuotaGroup(c *C) {
 func (s *discardSnapSuite) TestDoDiscardSnapToEmpty(c *C) {
 	s.state.Lock()
 	snapstate.Set(s.state, "foo", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "foo", Revision: snap.R(3)},
-		},
+		}),
 		Current:  snap.R(3),
 		SnapType: "app",
 	})
@@ -168,9 +168,9 @@ func (s *discardSnapSuite) TestDoDiscardSnapToEmpty(c *C) {
 func (s *discardSnapSuite) TestDoDiscardSnapErrorsForActive(c *C) {
 	s.state.Lock()
 	snapstate.Set(s.state, "foo", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "foo", Revision: snap.R(3)},
-		},
+		}),
 		Current:  snap.R(3),
 		Active:   true,
 		SnapType: "app",
@@ -200,10 +200,10 @@ func (s *discardSnapSuite) TestDoDiscardSnapErrorsForActive(c *C) {
 func (s *discardSnapSuite) TestDoDiscardSnapNoErrorsForActive(c *C) {
 	s.state.Lock()
 	snapstate.Set(s.state, "foo", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "foo", Revision: snap.R(3)},
 			{RealName: "foo", Revision: snap.R(33)},
-		},
+		}),
 		Current:  snap.R(33),
 		Active:   true,
 		SnapType: "app",
@@ -231,7 +231,7 @@ func (s *discardSnapSuite) TestDoDiscardSnapNoErrorsForActive(c *C) {
 	c.Assert(err, IsNil)
 
 	c.Assert(chg.Err(), IsNil)
-	c.Check(snapst.Sequence, HasLen, 1)
+	c.Check(snapst.Sequence.Revisions, HasLen, 1)
 	c.Check(snapst.Current, Equals, snap.R(33))
 	c.Check(t.Status(), Equals, state.DoneStatus)
 }
@@ -249,10 +249,10 @@ func (s *discardSnapSuite) TestDoDiscardSnapdRemovesLate(c *C) {
 	s.state.Lock()
 
 	snapstate.Set(s.state, "snapd", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "snapd", Revision: snap.R(3)},
 			{RealName: "snapd", Revision: snap.R(33)},
-		},
+		}),
 		Current:  snap.R(33),
 		SnapType: "snapd",
 	})
@@ -277,7 +277,7 @@ func (s *discardSnapSuite) TestDoDiscardSnapdRemovesLate(c *C) {
 	err := snapstate.Get(s.state, "snapd", &snapst)
 	c.Assert(err, IsNil)
 
-	c.Check(snapst.Sequence, HasLen, 1)
+	c.Check(snapst.Sequence.Revisions, HasLen, 1)
 	c.Check(snapst.Current, Equals, snap.R(3))
 	c.Check(t.Status(), Equals, state.DoneStatus)
 	c.Check(removeLateCalledFor, DeepEquals, [][]string{

--- a/overlord/snapstate/handlers_link_test.go
+++ b/overlord/snapstate/handlers_link_test.go
@@ -134,7 +134,7 @@ func (s *linkSnapSuite) TestDoLinkSnapSuccess(c *C) {
 	c.Check(typ, Equals, snap.TypeApp)
 
 	c.Check(snapst.Active, Equals, true)
-	c.Check(snapst.Sequence, HasLen, 1)
+	c.Check(snapst.Sequence.Revisions, HasLen, 1)
 	c.Check(snapst.Current, Equals, snap.R(33))
 	c.Check(snapst.TrackingChannel, Equals, "latest/beta")
 	c.Check(snapst.UserID, Equals, 2)
@@ -185,7 +185,7 @@ func (s *linkSnapSuite) TestDoLinkSnapSuccessWithCohort(c *C) {
 	c.Check(typ, Equals, snap.TypeApp)
 
 	c.Check(snapst.Active, Equals, true)
-	c.Check(snapst.Sequence, HasLen, 1)
+	c.Check(snapst.Sequence.Revisions, HasLen, 1)
 	c.Check(snapst.Current, Equals, snap.R(33))
 	c.Check(snapst.TrackingChannel, Equals, "latest/beta")
 	c.Check(snapst.UserID, Equals, 2)
@@ -231,9 +231,9 @@ func (s *linkSnapSuite) TestDoLinkSnapSuccessNoUserID(c *C) {
 func (s *linkSnapSuite) TestDoLinkSnapSuccessUserIDAlreadySet(c *C) {
 	s.state.Lock()
 	snapstate.Set(s.state, "foo", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "foo", Revision: snap.R(1)},
-		},
+		}),
 		Current: snap.R(1),
 		UserID:  1,
 	})
@@ -274,9 +274,9 @@ func (s *linkSnapSuite) TestDoLinkSnapSuccessUserIDAlreadySet(c *C) {
 func (s *linkSnapSuite) TestDoLinkSnapSuccessUserLoggedOut(c *C) {
 	s.state.Lock()
 	snapstate.Set(s.state, "foo", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "foo", Revision: snap.R(1)},
-		},
+		}),
 		Current: snap.R(1),
 		UserID:  1,
 	})
@@ -314,7 +314,7 @@ func (s *linkSnapSuite) TestDoLinkSnapSeqFile(c *C) {
 		Revision: snap.R(11),
 	}
 	snapstate.Set(s.state, "foo", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si11},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si11}),
 		Current:  si11.Revision,
 	})
 	// add a new one
@@ -432,7 +432,7 @@ func (s *linkSnapSuite) TestDoUnlinkCurrentSnapWithIgnoreRunning(c *C) {
 	// With a snap "pkg" at revision 42
 	si := &snap.SideInfo{RealName: "pkg", Revision: snap.R(42)}
 	snapstate.Set(s.state, "pkg", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 		Active:   true,
 	})
@@ -481,7 +481,7 @@ func (s *linkSnapSuite) TestDoUnlinkCurrentSnapWithIgnoreRunning(c *C) {
 	err := snapstate.Get(s.state, "pkg", &snapst)
 	c.Assert(err, IsNil)
 	c.Check(snapst.Active, Equals, false)
-	c.Check(snapst.Sequence, HasLen, 1)
+	c.Check(snapst.Sequence.Revisions, HasLen, 1)
 	c.Check(snapst.Current, Equals, snap.R(42))
 	c.Check(task.Status(), Equals, state.DoneStatus)
 	expected := fakeOps{{
@@ -509,7 +509,7 @@ func (s *linkSnapSuite) TestDoUndoUnlinkCurrentSnapWithVitalityScore(c *C) {
 		Revision: snap.R(33),
 	}
 	snapstate.Set(s.state, "foo", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si1},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si1}),
 		Current:  si1.Revision,
 		Active:   true,
 	})
@@ -536,7 +536,7 @@ func (s *linkSnapSuite) TestDoUndoUnlinkCurrentSnapWithVitalityScore(c *C) {
 	err = snapstate.Get(s.state, "foo", &snapst)
 	c.Assert(err, IsNil)
 	c.Check(snapst.Active, Equals, true)
-	c.Check(snapst.Sequence, HasLen, 1)
+	c.Check(snapst.Sequence.Revisions, HasLen, 1)
 	c.Check(snapst.Current, Equals, snap.R(11))
 	c.Check(t.Status(), Equals, state.UndoneStatus)
 
@@ -571,7 +571,7 @@ func (s *linkSnapSuite) TestDoUnlinkCurrentSnapSnapdNop(c *C) {
 	siOld := *si
 	siOld.Revision = snap.R(20)
 	snapstate.Set(s.state, "snapd", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{&siOld},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&siOld}),
 		Current:  siOld.Revision,
 		Active:   true,
 		SnapType: "snapd",
@@ -596,7 +596,7 @@ func (s *linkSnapSuite) TestDoUnlinkCurrentSnapSnapdNop(c *C) {
 	err := snapstate.Get(s.state, "snapd", &snapst)
 	c.Assert(err, IsNil)
 	c.Check(snapst.Active, Equals, false)
-	c.Check(snapst.Sequence, HasLen, 1)
+	c.Check(snapst.Sequence.Revisions, HasLen, 1)
 	c.Check(snapst.Current, Equals, snap.R(20))
 	c.Check(task.Status(), Equals, state.DoneStatus)
 	// backend unlink was not called
@@ -618,7 +618,7 @@ func (s *linkSnapSuite) TestDoUnlinkSnapdUnlinks(c *C) {
 		Revision: snap.R(20),
 	}
 	snapstate.Set(s.state, "snapd", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 		Active:   true,
 	})
@@ -642,7 +642,7 @@ func (s *linkSnapSuite) TestDoUnlinkSnapdUnlinks(c *C) {
 	err := snapstate.Get(s.state, "snapd", &snapst)
 	c.Assert(err, IsNil)
 	c.Check(snapst.Active, Equals, false)
-	c.Check(snapst.Sequence, HasLen, 1)
+	c.Check(snapst.Sequence.Revisions, HasLen, 1)
 	c.Check(snapst.Current, Equals, snap.R(20))
 	c.Check(task.Status(), Equals, state.DoneStatus)
 	// backend was called to unlink the snap
@@ -1078,7 +1078,7 @@ func (s *linkSnapSuite) TestDoLinkSnapSuccessCoreAndSnapdNoCoreRestart(c *C) {
 		Revision: snap.R(64),
 	}
 	snapstate.Set(s.state, "snapd", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{siSnapd},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siSnapd}),
 		Current:  siSnapd.Revision,
 		Active:   true,
 		SnapType: "snapd",
@@ -1190,7 +1190,7 @@ func (s *linkSnapSuite) TestDoLinkSnapdSnapCleanupOnErrorNthInstall(c *C) {
 	siOld := *si
 	siOld.Revision = snap.R(20)
 	snapstate.Set(s.state, "snapd", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{&siOld},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&siOld}),
 		Current:  siOld.Revision,
 		Active:   true,
 		SnapType: "snapd",
@@ -1269,7 +1269,7 @@ func (s *linkSnapSuite) TestDoLinkSnapdDiscardsNsOnDowngrade(c *C) {
 	}
 	snapstate.Set(s.state, "snapd", &snapstate.SnapState{
 		Active:          true,
-		Sequence:        []*snap.SideInfo{siSnapd, si},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siSnapd, si}),
 		Current:         siSnapd.Revision,
 		TrackingChannel: "latest/stable",
 		SnapType:        "snapd",
@@ -1345,7 +1345,7 @@ func (s *linkSnapSuite) TestDoLinkSnapdRemovesAppArmorProfilesOnSnapdDowngrade(c
 	}
 	snapstate.Set(s.state, "snapd", &snapstate.SnapState{
 		Active:          true,
-		Sequence:        []*snap.SideInfo{siSnapd, si},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siSnapd, si}),
 		Current:         siSnapd.Revision,
 		TrackingChannel: "latest/stable",
 		SnapType:        "snapd",
@@ -1409,7 +1409,7 @@ func (s *linkSnapSuite) TestDoUndoLinkSnapSequenceDidNotHaveCandidate(c *C) {
 		Revision: snap.R(2),
 	}
 	snapstate.Set(s.state, "foo", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si1},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si1}),
 		Current:  si1.Revision,
 	})
 	t := s.state.NewTask("link-snap", "test")
@@ -1436,7 +1436,7 @@ func (s *linkSnapSuite) TestDoUndoLinkSnapSequenceDidNotHaveCandidate(c *C) {
 	err := snapstate.Get(s.state, "foo", &snapst)
 	c.Assert(err, IsNil)
 	c.Check(snapst.Active, Equals, false)
-	c.Check(snapst.Sequence, HasLen, 1)
+	c.Check(snapst.Sequence.Revisions, HasLen, 1)
 	c.Check(snapst.Current, Equals, snap.R(1))
 	c.Check(t.Status(), Equals, state.UndoneStatus)
 }
@@ -1453,7 +1453,7 @@ func (s *linkSnapSuite) TestDoUndoLinkSnapSequenceHadCandidate(c *C) {
 		Revision: snap.R(2),
 	}
 	snapstate.Set(s.state, "foo", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si1, si2},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si1, si2}),
 		Current:  si2.Revision,
 	})
 	t := s.state.NewTask("link-snap", "test")
@@ -1480,7 +1480,7 @@ func (s *linkSnapSuite) TestDoUndoLinkSnapSequenceHadCandidate(c *C) {
 	err := snapstate.Get(s.state, "foo", &snapst)
 	c.Assert(err, IsNil)
 	c.Check(snapst.Active, Equals, false)
-	c.Check(snapst.Sequence, HasLen, 2)
+	c.Check(snapst.Sequence.Revisions, HasLen, 2)
 	c.Check(snapst.Current, Equals, snap.R(2))
 	c.Check(t.Status(), Equals, state.UndoneStatus)
 }
@@ -1524,7 +1524,7 @@ func (s *linkSnapSuite) TestDoUndoUnlinkCurrentSnapCore(c *C) {
 		Revision: snap.R(2),
 	}
 	snapstate.Set(s.state, "core", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si1},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si1}),
 		Current:  si1.Revision,
 		Active:   true,
 		SnapType: "os",
@@ -1552,7 +1552,7 @@ func (s *linkSnapSuite) TestDoUndoUnlinkCurrentSnapCore(c *C) {
 	err := snapstate.Get(s.state, "core", &snapst)
 	c.Assert(err, IsNil)
 	c.Check(snapst.Active, Equals, true)
-	c.Check(snapst.Sequence, HasLen, 1)
+	c.Check(snapst.Sequence.Revisions, HasLen, 1)
 	c.Check(snapst.Current, Equals, snap.R(1))
 	c.Check(t.Status(), Equals, state.UndoneStatus)
 
@@ -1581,7 +1581,7 @@ func (s *linkSnapSuite) TestDoUndoUnlinkCurrentSnapCoreBase(c *C) {
 		Revision: snap.R(2),
 	}
 	snapstate.Set(s.state, "core18", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si1},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si1}),
 		Current:  si1.Revision,
 		Active:   true,
 		SnapType: "base",
@@ -1617,7 +1617,7 @@ func (s *linkSnapSuite) TestDoUndoUnlinkCurrentSnapCoreBase(c *C) {
 	err := snapstate.Get(s.state, "core18", &snapst)
 	c.Assert(err, IsNil)
 	c.Check(snapst.Active, Equals, true)
-	c.Check(snapst.Sequence, HasLen, 1)
+	c.Check(snapst.Sequence.Revisions, HasLen, 1)
 	c.Check(snapst.Current, Equals, snap.R(1))
 	c.Check(t.Status(), Equals, state.UndoneStatus)
 
@@ -1779,7 +1779,7 @@ func (s *linkSnapSuite) TestLinkSnapResetsRefreshInhibitedTime(c *C) {
 	si := &snap.SideInfo{RealName: "snap", Revision: snap.R(1)}
 	sup := &snapstate.SnapSetup{SideInfo: si}
 	snapstate.Set(s.state, "snap", &snapstate.SnapState{
-		Sequence:             []*snap.SideInfo{si},
+		Sequence:             snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:              si.Revision,
 		RefreshInhibitedTime: &instant,
 	})
@@ -1820,7 +1820,7 @@ func (s *linkSnapSuite) TestDoUndoLinkSnapRestoresRefreshInhibitedTime(c *C) {
 	si := &snap.SideInfo{RealName: "snap", Revision: snap.R(1)}
 	sup := &snapstate.SnapSetup{SideInfo: si}
 	snapstate.Set(s.state, "snap", &snapstate.SnapState{
-		Sequence:             []*snap.SideInfo{si},
+		Sequence:             snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:              si.Revision,
 		RefreshInhibitedTime: &instant,
 	})
@@ -1867,7 +1867,7 @@ func (s *linkSnapSuite) TestLinkSnapSetsLastRefreshTime(c *C) {
 	si := &snap.SideInfo{RealName: "snap", Revision: snap.R(1)}
 	sup := &snapstate.SnapSetup{SideInfo: si}
 	snapstate.Set(s.state, "snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 		// LastRefreshTime not set initially (first install)
 	})
@@ -1915,7 +1915,7 @@ func (s *linkSnapSuite) TestLinkSnapUpdatesLastRefreshTime(c *C) {
 	si := &snap.SideInfo{RealName: "snap", Revision: snap.R(1)}
 	sup := &snapstate.SnapSetup{SideInfo: si}
 	snapstate.Set(s.state, "snap", &snapstate.SnapState{
-		Sequence:        []*snap.SideInfo{si},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:         si.Revision,
 		LastRefreshTime: &lastRefresh,
 	})
@@ -1963,7 +1963,7 @@ func (s *linkSnapSuite) TestDoUndoLinkSnapRestoresLastRefreshTime(c *C) {
 	si := &snap.SideInfo{RealName: "snap", Revision: snap.R(1)}
 	sup := &snapstate.SnapSetup{SideInfo: si}
 	snapstate.Set(s.state, "snap", &snapstate.SnapState{
-		Sequence:        []*snap.SideInfo{si},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:         si.Revision,
 		LastRefreshTime: &lastRefresh,
 	})
@@ -2075,7 +2075,7 @@ func (s *linkSnapSuite) TestUndoLinkSnapdNthInstall(c *C) {
 	siOld := *si
 	siOld.Revision = snap.R(20)
 	snapstate.Set(s.state, "snapd", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{&siOld},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&siOld}),
 		Current:  siOld.Revision,
 		Active:   true,
 		SnapType: "snapd",
@@ -2187,7 +2187,7 @@ func (s *linkSnapSuite) testDoUnlinkSnapRefreshAwareness(c *C) *state.Change {
 		Revision: snap.R(1),
 	}
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si1},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si1}),
 		Current:  si1.Revision,
 		Active:   true,
 	})
@@ -2283,14 +2283,14 @@ func (s *linkSnapSuite) TestMaybeUndoRemodelBootChangesNeedsUndo(c *C) {
 	// both kernel and new-kernel are instaleld at this point
 	si := &snap.SideInfo{RealName: "kernel", Revision: snap.R(1)}
 	snapstate.Set(s.state, "kernel", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		SnapType: "kernel",
 		Current:  snap.R(1),
 	})
 	snaptest.MockSnap(c, "name: kernel\ntype: kernel\nversion: 1.0", si)
 	si2 := &snap.SideInfo{RealName: "new-kernel", Revision: snap.R(1)}
 	snapstate.Set(s.state, "new-kernel", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si2},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si2}),
 		SnapType: "kernel",
 		Current:  snap.R(1),
 	})

--- a/overlord/snapstate/handlers_mount_test.go
+++ b/overlord/snapstate/handlers_mount_test.go
@@ -84,7 +84,7 @@ func (s *mountSnapSuite) TestDoUndoMountSnap(c *C) {
 		Revision: snap.R(2),
 	}
 	snapstate.Set(s.state, "core", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si1},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si1}),
 		Current:  si1.Revision,
 		SnapType: "os",
 	})
@@ -152,7 +152,7 @@ func (s *mountSnapSuite) TestDoMountSnapErrorReadInfo(c *C) {
 		Revision: snap.R(2),
 	}
 	snapstate.Set(s.state, "borken", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si1},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si1}),
 		Current:  si1.Revision,
 		SnapType: "app",
 	})
@@ -216,7 +216,7 @@ func (s *mountSnapSuite) TestDoMountSnapEpochError(c *C) {
 		Revision: snap.R(2),
 	}
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si1},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si1}),
 		Current:  si1.Revision,
 		SnapType: "app",
 	})
@@ -311,7 +311,7 @@ func (s *mountSnapSuite) TestDoMountSnapUndoError(c *C) {
 		Revision: snap.R(2),
 	}
 	snapstate.Set(s.state, "borken-undo-setup", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si1},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si1}),
 		Current:  si1.Revision,
 		SnapType: "app",
 	})
@@ -378,7 +378,7 @@ func (s *mountSnapSuite) TestDoMountSnapErrorNotFound(c *C) {
 		Revision: snap.R(2),
 	}
 	snapstate.Set(s.state, "not-there", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si1},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si1}),
 		Current:  si1.Revision,
 		SnapType: "app",
 	})
@@ -458,7 +458,7 @@ func (s *mountSnapSuite) TestDoMountNotMountedRetryRetry(c *C) {
 		Revision: snap.R(2),
 	}
 	snapstate.Set(s.state, "not-there", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si1},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si1}),
 		Current:  si1.Revision,
 		SnapType: "app",
 	})

--- a/overlord/snapstate/handlers_prereq_test.go
+++ b/overlord/snapstate/handlers_prereq_test.go
@@ -94,7 +94,7 @@ func (s *prereqSuite) TestDoPrereqNothingToDo(c *C) {
 		Revision: snap.R(1),
 	}
 	snapstate.Set(s.state, "core", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si1},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si1}),
 		Current:  si1.Revision,
 	})
 
@@ -237,9 +237,9 @@ func (s *prereqSuite) TestDoPrereqTalksToStoreAndQueues(c *C) {
 
 	snapstate.Set(s.state, "core", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "core", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "os",
 	})
@@ -342,7 +342,7 @@ func (s *prereqSuite) TestDoPrereqRetryWhenBaseInFlight(c *C) {
 			var snapst snapstate.SnapState
 			snapstate.Get(st, snapsup.InstanceName(), &snapst)
 			snapst.Current = snapsup.Revision()
-			snapst.Sequence = append(snapst.Sequence, snapsup.SideInfo)
+			snapst.Sequence.Revisions = append(snapst.Sequence.Revisions, snapstate.NewRevisionSideInfo(snapsup.SideInfo, nil))
 			snapstate.Set(st, snapsup.InstanceName(), &snapst)
 
 			// check that prerequisites task is not done yet, it must wait for core.
@@ -410,9 +410,9 @@ func (s *prereqSuite) TestDoPrereqChannelEnvvars(c *C) {
 
 	snapstate.Set(s.state, "core", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "core", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "os",
 	})
@@ -538,7 +538,7 @@ func (s *prereqSuite) TestDoPrereqCore16wCoreNothingToDo(c *C) {
 		Revision: snap.R(1),
 	}
 	snapstate.Set(s.state, "core", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si1},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si1}),
 		Current:  si1.Revision,
 	})
 
@@ -838,12 +838,12 @@ func (s *prereqSuite) TestDoPrereqSkipDuringRemodel(c *C) {
 
 	// install snapd so that prerequisites handler won't try to install it
 	snapstate.Set(s.state, "snapd", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{
 				RealName: "snapd",
 				Revision: snap.R(1),
 			},
-		},
+		}),
 		Current: snap.R(1),
 	})
 

--- a/overlord/snapstate/handlers_rerefresh_test.go
+++ b/overlord/snapstate/handlers_rerefresh_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
@@ -470,9 +471,9 @@ func (*reRefreshSuite) TestFilterReturnsFalseIfEpochEqual(c *C) {
 	// these work because we're mocking ReadInfo
 	snapst := &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", Revision: snap.R(7)},
-		},
+		}),
 		Current:  snap.R(7),
 		SnapType: "app",
 	}
@@ -486,9 +487,9 @@ func (s *reRefreshSuite) TestFilterReturnsFalseIfEpochEqualZero(c *C) {
 	// these work because we're mocking ReadInfo
 	snapst := &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "snap-with-empty-epoch", Revision: snap.R(7)},
-		},
+		}),
 		Current:  snap.R(7),
 		SnapType: "app",
 	}
@@ -584,7 +585,7 @@ func (s *validationSetsSuite) TestMaybeRestoreValidationSetsAndRevertSnapsOneRev
 	si11 := &snap.SideInfo{RealName: "some-snap1", SnapID: "aaqKhntON3vR7kwEbVPsILm7bUViPDzx", Revision: snap.R(1)}
 	snapstate.Set(s.state, "some-snap1", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si11, si1},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si11, si1}),
 		Current:  snap.R(3),
 		SnapType: "app",
 	})
@@ -594,7 +595,7 @@ func (s *validationSetsSuite) TestMaybeRestoreValidationSetsAndRevertSnapsOneRev
 	si2 := &snap.SideInfo{RealName: "some-snap2", SnapID: "bgtKhntON3vR7kwEbVPsILm7bUViPDzx", Revision: snap.R(2)}
 	snapstate.Set(s.state, "some-snap2", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si2},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si2}),
 		Current:  snap.R(2),
 		SnapType: "app",
 	})
@@ -603,7 +604,7 @@ func (s *validationSetsSuite) TestMaybeRestoreValidationSetsAndRevertSnapsOneRev
 	si3 := &snap.SideInfo{RealName: "some-snap3", SnapID: "abcKhntON3vR7kwEbVPsILm7bUViPDzx", Revision: snap.R(3)}
 	snapstate.Set(s.state, "some-snap3", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si3},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si3}),
 		Current:  snap.R(3),
 		SnapType: "app",
 	})
@@ -687,7 +688,7 @@ func (s *validationSetsSuite) TestMaybeRestoreValidationSetsAndRevertNoSnapsRefr
 	si1 := &snap.SideInfo{RealName: "some-snap1", SnapID: "aaqKhntON3vR7kwEbVPsILm7bUViPDzx", Revision: snap.R(1)}
 	snapstate.Set(s.state, "some-snap1", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si1},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si1}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -758,7 +759,7 @@ func (s *validationSetsSuite) TestMaybeRestoreValidationSetsAndRevertJustValidat
 	si1 := &snap.SideInfo{RealName: "some-snap1", SnapID: "aaqKhntON3vR7kwEbVPsILm7bUViPDzx", Revision: snap.R(1)}
 	snapstate.Set(s.state, "some-snap1", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si1},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si1}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -767,7 +768,7 @@ func (s *validationSetsSuite) TestMaybeRestoreValidationSetsAndRevertJustValidat
 	si3 := &snap.SideInfo{RealName: "some-snap2", SnapID: "abcKhntON3vR7kwEbVPsILm7bUViPDzx", Revision: snap.R(3)}
 	snapstate.Set(s.state, "some-snap2", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si3},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si3}),
 		Current:  snap.R(3),
 		SnapType: "app",
 	})
@@ -825,7 +826,7 @@ func (s *validationSetsSuite) TestMaybeRestoreValidationSetsAndRevertStillValid(
 	si1 := &snap.SideInfo{RealName: "some-snap1", SnapID: "aaqKhntON3vR7kwEbVPsILm7bUViPDzx", Revision: snap.R(3)}
 	snapstate.Set(s.state, "some-snap1", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si1},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si1}),
 		Current:  snap.R(3),
 		SnapType: "app",
 	})
@@ -834,7 +835,7 @@ func (s *validationSetsSuite) TestMaybeRestoreValidationSetsAndRevertStillValid(
 	si3 := &snap.SideInfo{RealName: "some-snap2", SnapID: "abcKhntON3vR7kwEbVPsILm7bUViPDzx", Revision: snap.R(1)}
 	snapstate.Set(s.state, "some-snap2", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si3},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si3}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})

--- a/overlord/snapstate/policy/base.go
+++ b/overlord/snapstate/policy/base.go
@@ -98,7 +98,7 @@ func baseUsedBy(st *state.State, baseName string) ([]string, error) {
 			continue
 		}
 
-		for _, si := range snapst.Sequence {
+		for _, si := range snapst.Sequence.SideInfos() {
 			snapInfo, err := snap.ReadInfo(name, si)
 			if err == nil {
 				if typ := snapInfo.Type(); typ != snap.TypeApp && typ != snap.TypeGadget {

--- a/overlord/snapstate/policy/canremove_test.go
+++ b/overlord/snapstate/policy/canremove_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/policy"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
@@ -70,7 +71,7 @@ func (s *canRemoveSuite) TestEphemeralAppIsNotOK(c *check.C) {
 func (s *canRemoveSuite) TestOneGadgetRevisionIsOK(c *check.C) {
 	snapst := &snapstate.SnapState{
 		Current:  snap.R(1),
-		Sequence: []*snap.SideInfo{{Revision: snap.R(1), RealName: "gadget"}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{Revision: snap.R(1), RealName: "gadget"}}),
 	}
 	c.Check(policy.NewGadgetPolicy("gadget").CanRemove(s.st, snapst, snap.R(1), coreDev), check.IsNil)
 }
@@ -78,7 +79,7 @@ func (s *canRemoveSuite) TestOneGadgetRevisionIsOK(c *check.C) {
 func (s *canRemoveSuite) TestOtherGadgetIsOK(c *check.C) {
 	snapst := &snapstate.SnapState{
 		Current:  snap.R(1),
-		Sequence: []*snap.SideInfo{{Revision: snap.R(1), RealName: "gadget"}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{Revision: snap.R(1), RealName: "gadget"}}),
 	}
 	c.Check(policy.NewGadgetPolicy("gadget2").CanRemove(s.st, snapst, snap.R(0), coreDev), check.IsNil)
 }
@@ -86,7 +87,7 @@ func (s *canRemoveSuite) TestOtherGadgetIsOK(c *check.C) {
 func (s *canRemoveSuite) TestEphemeralGadgetIsNotOK(c *check.C) {
 	snapst := &snapstate.SnapState{
 		Current:  snap.R(1),
-		Sequence: []*snap.SideInfo{{Revision: snap.R(1), RealName: "gadget"}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{Revision: snap.R(1), RealName: "gadget"}}),
 	}
 	c.Check(policy.NewGadgetPolicy("gadget2").CanRemove(s.st, snapst, snap.R(0), ephemeralDev), check.DeepEquals, policy.ErrEphemeralSnapsNotRemovalable)
 }
@@ -94,7 +95,7 @@ func (s *canRemoveSuite) TestEphemeralGadgetIsNotOK(c *check.C) {
 func (s *canRemoveSuite) TestLastGadgetsAreNotOK(c *check.C) {
 	snapst := &snapstate.SnapState{
 		Current:  snap.R(1),
-		Sequence: []*snap.SideInfo{{Revision: snap.R(1), RealName: "gadget"}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{Revision: snap.R(1), RealName: "gadget"}}),
 	}
 	c.Check(policy.NewGadgetPolicy("gadget").CanRemove(s.st, snapst, snap.R(0), coreDev), check.Equals, policy.ErrIsModel)
 }
@@ -105,7 +106,7 @@ func (s *canRemoveSuite) TestLastOSAndKernelAreNotOK(c *check.C) {
 
 	snapst := &snapstate.SnapState{
 		Current:  snap.R(1),
-		Sequence: []*snap.SideInfo{{Revision: snap.R(1), RealName: "kernel"}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{Revision: snap.R(1), RealName: "kernel"}}),
 	}
 	// model base is "" -> OS can't be removed
 	c.Check(policy.NewOSPolicy("").CanRemove(s.st, snapst, snap.R(0), coreDev), check.Equals, policy.ErrIsModel)
@@ -123,7 +124,7 @@ func (s *canRemoveSuite) TestOSInUseNotOK(c *check.C) {
 
 	snapst := &snapstate.SnapState{
 		Current:  snap.R(1),
-		Sequence: []*snap.SideInfo{{Revision: snap.R(1), RealName: "core"}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{Revision: snap.R(1), RealName: "core"}}),
 	}
 	// normally this would be fine
 	c.Check(policy.NewOSPolicy("").CanRemove(s.st, snapst, snap.R(1), coreDev), check.IsNil)
@@ -138,7 +139,7 @@ func (s *canRemoveSuite) TestOSRequiredNotOK(c *check.C) {
 
 	snapst := &snapstate.SnapState{
 		Current:  snap.R(1),
-		Sequence: []*snap.SideInfo{{Revision: snap.R(1), RealName: "core"}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{Revision: snap.R(1), RealName: "core"}}),
 		Flags:    snapstate.Flags{Required: true},
 	}
 	// can't remove them all if they're required
@@ -153,7 +154,7 @@ func (s *canRemoveSuite) TestOSUbuntuCoreOK(c *check.C) {
 
 	snapst := &snapstate.SnapState{
 		Current:  snap.R(1),
-		Sequence: []*snap.SideInfo{{Revision: snap.R(1), RealName: "ubuntu-core"}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{Revision: snap.R(1), RealName: "ubuntu-core"}}),
 	}
 	c.Check(policy.NewOSPolicy("").CanRemove(s.st, snapst, snap.R(0), coreDev), check.IsNil)
 }
@@ -164,7 +165,7 @@ func (s *canRemoveSuite) TestKernelBootInUseIsKept(c *check.C) {
 
 	snapst := &snapstate.SnapState{
 		Current:  snap.R(1),
-		Sequence: []*snap.SideInfo{{Revision: snap.R(1), RealName: "kernel"}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{Revision: snap.R(1), RealName: "kernel"}}),
 	}
 
 	s.bootloader.SetBootKernel("kernel_1.snap")
@@ -178,7 +179,7 @@ func (s *canRemoveSuite) TestBootInUseError(c *check.C) {
 
 	snapst := &snapstate.SnapState{
 		Current:  snap.R(1),
-		Sequence: []*snap.SideInfo{{Revision: snap.R(1), RealName: "kernel"}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{Revision: snap.R(1), RealName: "kernel"}}),
 	}
 
 	bootloader.ForceError(errors.New("broken bootloader"))
@@ -192,7 +193,7 @@ func (s *canRemoveSuite) TestBaseInUseIsKept(c *check.C) {
 
 	snapst := &snapstate.SnapState{
 		Current:  snap.R(1),
-		Sequence: []*snap.SideInfo{{Revision: snap.R(1), RealName: "core18"}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{Revision: snap.R(1), RealName: "core18"}}),
 	}
 	// if not used for boot, removing a single one is ok
 	c.Check(policy.NewBasePolicy("core18").CanRemove(s.st, snapst, snap.R(1), coreDev), check.IsNil)
@@ -207,7 +208,7 @@ func (s *canRemoveSuite) TestBaseInUseIsKept(c *check.C) {
 func (s *canRemoveSuite) TestRemoveNonModelKernelIsOk(c *check.C) {
 	snapst := &snapstate.SnapState{
 		Current:  snap.R(1),
-		Sequence: []*snap.SideInfo{{Revision: snap.R(1), RealName: "other-non-model-kernel"}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{Revision: snap.R(1), RealName: "other-non-model-kernel"}}),
 	}
 
 	c.Check(policy.NewKernelPolicy("kernel").CanRemove(s.st, snapst, snap.R(0), coreDev), check.IsNil)
@@ -216,7 +217,7 @@ func (s *canRemoveSuite) TestRemoveNonModelKernelIsOk(c *check.C) {
 func (s *canRemoveSuite) TestRemoveEphemeralKernelIsNotOK(c *check.C) {
 	snapst := &snapstate.SnapState{
 		Current:  snap.R(1),
-		Sequence: []*snap.SideInfo{{Revision: snap.R(1), RealName: "other-non-model-kernel"}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{Revision: snap.R(1), RealName: "other-non-model-kernel"}}),
 	}
 
 	c.Check(policy.NewKernelPolicy("kernel").CanRemove(s.st, snapst, snap.R(0), ephemeralDev), check.DeepEquals, policy.ErrEphemeralSnapsNotRemovalable)
@@ -228,7 +229,7 @@ func (s *canRemoveSuite) TestLastOSWithModelBaseIsOk(c *check.C) {
 
 	snapst := &snapstate.SnapState{
 		Current:  snap.R(1),
-		Sequence: []*snap.SideInfo{{Revision: snap.R(1), RealName: "core"}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{Revision: snap.R(1), RealName: "core"}}),
 	}
 
 	c.Check(policy.NewOSPolicy("core18").CanRemove(s.st, snapst, snap.R(0), coreDev), check.IsNil)
@@ -240,7 +241,7 @@ func (s *canRemoveSuite) TestEphemeralCoreIsNotOK(c *check.C) {
 
 	snapst := &snapstate.SnapState{
 		Current:  snap.R(1),
-		Sequence: []*snap.SideInfo{{Revision: snap.R(1), RealName: "core"}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{Revision: snap.R(1), RealName: "core"}}),
 	}
 
 	c.Check(policy.NewOSPolicy("core20").CanRemove(s.st, snapst, snap.R(0), ephemeralDev), check.DeepEquals, policy.ErrEphemeralSnapsNotRemovalable)
@@ -255,14 +256,14 @@ func (s *canRemoveSuite) TestLastOSWithModelBaseButOsInUse(c *check.C) {
 	si := &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)}
 	snaptest.MockSnap(c, "name: some-snap\nversion: 1.0", si)
 	snapstate.Set(s.st, "some-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  snap.R(1),
 	})
 
 	// now pretend we want to remove the core snap
 	snapst := &snapstate.SnapState{
 		Current:  snap.R(1),
-		Sequence: []*snap.SideInfo{{Revision: snap.R(1), RealName: "core"}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{Revision: snap.R(1), RealName: "core"}}),
 	}
 	c.Check(policy.NewOSPolicy("core18").CanRemove(s.st, snapst, snap.R(0), coreDev), check.DeepEquals, policy.InUseByErr("some-snap"))
 }
@@ -276,7 +277,7 @@ func (s *canRemoveSuite) TestLastOSWithModelBaseButOsInUseByGadget(c *check.C) {
 	si := &snap.SideInfo{RealName: "some-gadget", SnapID: "some-gadget-id", Revision: snap.R(1)}
 	snaptest.MockSnap(c, "name: some-gadget\ntype: gadget\nversion: 1.0", si)
 	snapstate.Set(s.st, "some-gadget", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  snap.R(1),
 		SnapType: "gadget",
 	})
@@ -284,7 +285,7 @@ func (s *canRemoveSuite) TestLastOSWithModelBaseButOsInUseByGadget(c *check.C) {
 	// now pretend we want to remove the core snap
 	snapst := &snapstate.SnapState{
 		Current:  snap.R(1),
-		Sequence: []*snap.SideInfo{{Revision: snap.R(1), RealName: "core"}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{Revision: snap.R(1), RealName: "core"}}),
 	}
 	c.Check(policy.NewOSPolicy("core18").CanRemove(s.st, snapst, snap.R(0), coreDev), check.DeepEquals, policy.InUseByErr("some-gadget"))
 }
@@ -295,7 +296,7 @@ func (s *canRemoveSuite) TestBaseUnused(c *check.C) {
 
 	snapst := &snapstate.SnapState{
 		Current:  snap.R(1),
-		Sequence: []*snap.SideInfo{{Revision: snap.R(1), RealName: "foo"}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{Revision: snap.R(1), RealName: "foo"}}),
 	}
 
 	c.Check(policy.NewBasePolicy("core18").CanRemove(s.st, snapst, snap.R(1), coreDev), check.IsNil)
@@ -308,7 +309,7 @@ func (s *canRemoveSuite) TestEphemeralBaseIsNotOK(c *check.C) {
 
 	snapst := &snapstate.SnapState{
 		Current:  snap.R(1),
-		Sequence: []*snap.SideInfo{{Revision: snap.R(1), RealName: "foo"}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{Revision: snap.R(1), RealName: "foo"}}),
 	}
 
 	c.Check(policy.NewBasePolicy("core18").CanRemove(s.st, snapst, snap.R(1), ephemeralDev), check.DeepEquals, policy.ErrEphemeralSnapsNotRemovalable)
@@ -320,7 +321,7 @@ func (s *canRemoveSuite) TestBaseUnusedButRequired(c *check.C) {
 
 	snapst := &snapstate.SnapState{
 		Current:  snap.R(1),
-		Sequence: []*snap.SideInfo{{Revision: snap.R(1), RealName: "foo"}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{Revision: snap.R(1), RealName: "foo"}}),
 		Flags:    snapstate.Flags{Required: true},
 	}
 
@@ -336,14 +337,14 @@ func (s *canRemoveSuite) TestBaseInUse(c *check.C) {
 	si := &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)}
 	snaptest.MockSnap(c, "name: some-snap\nversion: 1.0\nbase: some-base", si)
 	snapstate.Set(s.st, "some-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  snap.R(1),
 	})
 
 	// pretend now we want to remove "some-base"
 	snapst := &snapstate.SnapState{
 		Current:  snap.R(1),
-		Sequence: []*snap.SideInfo{{Revision: snap.R(1), RealName: "some-base"}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{Revision: snap.R(1), RealName: "some-base"}}),
 	}
 	c.Check(policy.NewBasePolicy("core18").CanRemove(s.st, snapst, snap.R(0), coreDev), check.DeepEquals, policy.InUseByErr("some-snap"))
 }
@@ -358,14 +359,14 @@ func (s *canRemoveSuite) TestBaseInUseBrokenApp(c *check.C) {
 	snaptest.MockSnap(c, "name: some-snap\nversion: 1.0\nbase: some-base", si)
 	// NOTE no snaptest.MockSnap for si2 -> snap is actually broken
 	snapstate.Set(s.st, "some-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si2, si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si2, si}),
 		Current:  snap.R(2),
 	})
 
 	// pretend now we want to remove "some-base"
 	snapst := &snapstate.SnapState{
 		Current:  snap.R(1),
-		Sequence: []*snap.SideInfo{{Revision: snap.R(1), RealName: "some-base"}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{Revision: snap.R(1), RealName: "some-base"}}),
 	}
 	c.Check(policy.NewBasePolicy("core18").CanRemove(s.st, snapst, snap.R(0), coreDev), check.DeepEquals, policy.InUseByErr("some-snap"))
 }
@@ -383,20 +384,20 @@ func (s *canRemoveSuite) TestBaseInUseOtherRevision(c *check.C) {
 	snaptest.MockSnap(c, "name: some-snap\nversion: 1.0\n", si2)
 	snapstate.Set(s.st, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si, si2},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si, si2}),
 		Current:  snap.R(2),
 	})
 
 	// pretend now we want to remove "some-base"
 	snapst := &snapstate.SnapState{
 		Current:  snap.R(1),
-		Sequence: []*snap.SideInfo{{Revision: snap.R(1), RealName: "some-base"}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{Revision: snap.R(1), RealName: "some-base"}}),
 	}
 	// revision 1 requires some-base
 	c.Check(policy.NewBasePolicy("core18").CanRemove(s.st, snapst, snap.R(0), coreDev), check.DeepEquals, policy.InUseByErr("some-snap"))
 
 	// now pretend we want to remove the core snap
-	snapst.Sequence[0].RealName = "core"
+	snapst.Sequence.Revisions[0].Snap.RealName = "core"
 	// but revision 2 requires core
 	c.Check(policy.NewOSPolicy("core18").CanRemove(s.st, snapst, snap.R(0), coreDev), check.DeepEquals, policy.InUseByErr("some-snap"))
 }
@@ -408,7 +409,7 @@ func (s *canRemoveSuite) TestSnapdTypePolicy(c *check.C) {
 	si := &snap.SideInfo{Revision: snap.R(1), RealName: "snapd"}
 	snapst := &snapstate.SnapState{
 		Current:  snap.R(1),
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 	}
 
 	// snapd cannot be removed on core
@@ -423,14 +424,14 @@ func (s *canRemoveSuite) TestSnapdTypePolicy(c *check.C) {
 	onClassic = true
 	snapstate.Set(s.st, "snapd", &snapstate.SnapState{
 		Current:  snap.R(1),
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 	})
 	c.Check(policy.NewSnapdPolicy(onClassic).CanRemove(s.st, snapst, snap.R(0), classicDev), check.IsNil)
 
 	// but it cannot be removed when there are more snaps installed
 	snapstate.Set(s.st, "other-snap", &snapstate.SnapState{
 		Current:  snap.R(1),
-		Sequence: []*snap.SideInfo{{Revision: snap.R(1), RealName: "other-snap"}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{Revision: snap.R(1), RealName: "other-snap"}}),
 	})
 	c.Check(policy.NewSnapdPolicy(onClassic).CanRemove(s.st, snapst, snap.R(0), classicDev), check.Equals, policy.ErrSnapdNotYetRemovableOnClassic)
 }

--- a/overlord/snapstate/refresh_test.go
+++ b/overlord/snapstate/refresh_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/snapcore/snapd/cmd/snaplock/runinhibit"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
@@ -137,7 +138,7 @@ func (s *refreshSuite) TestPendingSnapRefreshInfo(c *C) {
 }
 
 func (s *refreshSuite) addInstalledSnap(snapst *snapstate.SnapState) (*snapstate.SnapState, *snap.Info) {
-	snapName := snapst.Sequence[0].RealName
+	snapName := snapst.Sequence.Revisions[0].Snap.RealName
 	snapstate.Set(s.state, snapName, snapst)
 	info := &snap.Info{SideInfo: snap.SideInfo{RealName: snapName, Revision: snapst.Current}}
 	return snapst, info
@@ -146,9 +147,9 @@ func (s *refreshSuite) addInstalledSnap(snapst *snapstate.SnapState) (*snapstate
 func (s *refreshSuite) addFakeInstalledSnap() (*snapstate.SnapState, *snap.Info) {
 	return s.addInstalledSnap(&snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "pkg", Revision: snap.R(5), SnapID: "pkg-snap-id"},
-		},
+		}),
 		Current:  snap.R(5),
 		SnapType: "app",
 		UserID:   1,

--- a/overlord/snapstate/refreshhints_test.go
+++ b/overlord/snapstate/refreshhints_test.go
@@ -96,9 +96,9 @@ func (s *refreshHintsTestSuite) SetUpTest(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", Revision: snap.R(5), SnapID: "some-snap-id"},
-		},
+		}),
 		Current:         snap.R(5),
 		SnapType:        "app",
 		UserID:          1,
@@ -203,9 +203,9 @@ func (s *refreshHintsTestSuite) TestRefreshHintsStoresRefreshCandidates(c *C) {
 
 	snapstate.Set(s.state, "other-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "other-snap", Revision: snap.R(1), SnapID: "other-snap-id"},
-		},
+		}),
 		Current:         snap.R(1),
 		SnapType:        "app",
 		TrackingChannel: "devel",
@@ -425,9 +425,9 @@ func (s *refreshHintsTestSuite) TestRefreshHintsNotApplicableWrongArch(c *C) {
 
 	snapstate.Set(s.state, "other-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "other-snap", Revision: snap.R(1), SnapID: "other-snap-id"},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -471,9 +471,9 @@ func (s *refreshHintsTestSuite) TestRefreshHintsAbortsMonitoringForRemovedCandid
 	s.state.Lock()
 	snapstate.Set(s.state, "other-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "other-snap", Revision: snap.R(1), SnapID: "other-snap-id"},
-		},
+		}),
 		Current: snap.R(1),
 	})
 	s.state.Unlock()
@@ -527,7 +527,7 @@ func (s *refreshHintsTestSuite) TestRefreshHintsNotApplicableWrongEpoch(c *C) {
 	snaptest.MockSnap(c, otherSnapYaml, si)
 	snapstate.Set(s.state, "other-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -21,6 +21,7 @@ package snapstate
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -188,10 +189,87 @@ const (
 	NotBlocked
 )
 
+// RevisionSideState contains the side information for a snap and related components
+// installed in the system.
+type RevisionSideState struct {
+	Snap       *snap.SideInfo
+	Components []*snap.ComponentSideInfo
+}
+
+// revisionSideInfoMarshal is an ancillary structure used exclusively to
+// help marshaling of RevisionSideInfo.
+type revisionSideInfoMarshal struct {
+	// SideInfo is included for compatibility with older snapd state files
+	*snap.SideInfo
+	CompSideInfo []*snap.ComponentSideInfo `yaml:"components,omitempty" json:"components,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaler interface
+func (bsi RevisionSideState) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&revisionSideInfoMarshal{bsi.Snap, bsi.Components})
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface
+func (bsi *RevisionSideState) UnmarshalJSON(in []byte) error {
+	var aux revisionSideInfoMarshal
+	if err := json.Unmarshal(in, &aux); err != nil {
+		return err
+	}
+	bsi.Snap = aux.SideInfo
+	bsi.Components = aux.CompSideInfo
+	return nil
+}
+
+// NewRevisionSideInfo creates a RevisionSideInfo from snap and
+// related components side information.
+func NewRevisionSideInfo(snapSideInfo *snap.SideInfo, compSideInfo []*snap.ComponentSideInfo) *RevisionSideState {
+	return &RevisionSideState{Snap: snapSideInfo, Components: compSideInfo}
+}
+
+// SnapSequence is a container for a slice containing revisions of
+// snaps plus related components.
+// TODO add methods to access Revisions (length, copy, append) and
+// use them in handlers.go and snapstate.go.
+type SnapSequence struct {
+	// Revisions contains information for a snap revision and
+	// components SideInfo.
+	Revisions []*RevisionSideState
+}
+
+// MarshalJSON implements the json.Marshaler interface. We override the default
+// so serialization of the SnapState.Sequence field is compatible to what was
+// produced when it was defined as a []*snap.SideInfo. This is also the reason
+// to have SnapSequence.UnmarshalJSON and MarshalJSON/UnmarshalJSON for
+// RevisionSideState.
+func (snapSeq SnapSequence) MarshalJSON() ([]byte, error) {
+	return json.Marshal(snapSeq.Revisions)
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface
+func (snapSeq *SnapSequence) UnmarshalJSON(in []byte) error {
+	aux := []*RevisionSideState{}
+	if err := json.Unmarshal(in, &aux); err != nil {
+		return err
+	}
+	snapSeq.Revisions = aux
+	return nil
+}
+
+// SideInfos returns a slice with all the SideInfos for the snap sequence.
+func (snapSeq SnapSequence) SideInfos() []*snap.SideInfo {
+	sis := make([]*snap.SideInfo, len(snapSeq.Revisions))
+	for i, rev := range snapSeq.Revisions {
+		sis[i] = rev.Snap
+	}
+	return sis
+}
+
 // SnapState holds the state for a snap installed in the system.
 type SnapState struct {
-	SnapType string           `json:"type"` // Use Type and SetType
-	Sequence []*snap.SideInfo `json:"sequence"`
+	SnapType string `json:"type"` // Use Type and SetType
+	// Sequence contains installation side state for a snap revision and
+	// related components.
+	Sequence SnapSequence `json:"sequence"`
 
 	// RevertStatus maps revisions to RevertStatus for revisions that
 	// need special handling in Block().
@@ -289,8 +367,8 @@ func (snapst *SnapState) SetType(typ snap.Type) {
 // IsInstalled returns whether the snap is installed, i.e. snapst represents an installed snap with Current revision set.
 func (snapst *SnapState) IsInstalled() bool {
 	if snapst.Current.Unset() {
-		if len(snapst.Sequence) > 0 {
-			panic(fmt.Sprintf("snapst.Current and snapst.Sequence out of sync: %#v %#v", snapst.Current, snapst.Sequence))
+		if len(snapst.Sequence.Revisions) > 0 {
+			panic(fmt.Sprintf("snapst.Current and snapst.Sequence.Revisions out of sync: %#v %#v", snapst.Current, snapst.Sequence.Revisions))
 		}
 
 		return false
@@ -302,7 +380,7 @@ func (snapst *SnapState) IsInstalled() bool {
 // start at -1 and are counted down.
 func (snapst *SnapState) LocalRevision() snap.Revision {
 	var local snap.Revision
-	for _, si := range snapst.Sequence {
+	for _, si := range snapst.Sequence.SideInfos() {
 		if si.Revision.Local() && si.Revision.N < local.N {
 			local = si.Revision
 		}
@@ -316,13 +394,13 @@ func (snapst *SnapState) CurrentSideInfo() *snap.SideInfo {
 		return nil
 	}
 	if idx := snapst.LastIndex(snapst.Current); idx >= 0 {
-		return snapst.Sequence[idx]
+		return snapst.Sequence.Revisions[idx].Snap
 	}
-	panic("cannot find snapst.Current in the snapst.Sequence")
+	panic("cannot find snapst.Current in the snapst.Sequence.Revisions")
 }
 
 func (snapst *SnapState) previousSideInfo() *snap.SideInfo {
-	n := len(snapst.Sequence)
+	n := len(snapst.Sequence.Revisions)
 	if n < 2 {
 		return nil
 	}
@@ -331,14 +409,14 @@ func (snapst *SnapState) previousSideInfo() *snap.SideInfo {
 	if currentIndex <= 0 {
 		return nil
 	}
-	return snapst.Sequence[currentIndex-1]
+	return snapst.Sequence.Revisions[currentIndex-1].Snap
 }
 
 // LastIndex returns the last index of the given revision in the
-// snapst.Sequence
+// snapst.Sequence.Revisions
 func (snapst *SnapState) LastIndex(revision snap.Revision) int {
-	for i := len(snapst.Sequence) - 1; i >= 0; i-- {
-		if snapst.Sequence[i].Revision == revision {
+	for i := len(snapst.Sequence.Revisions) - 1; i >= 0; i-- {
+		if snapst.Sequence.Revisions[i].Snap.Revision == revision {
 			return i
 		}
 	}
@@ -352,17 +430,17 @@ func (snapst *SnapState) Block() []snap.Revision {
 	// return revisions from Sequence[currentIndex:], potentially excluding
 	// some of them based on RevertStatus.
 	currentIndex := snapst.LastIndex(snapst.Current)
-	if currentIndex < 0 || currentIndex+1 == len(snapst.Sequence) {
+	if currentIndex < 0 || currentIndex+1 == len(snapst.Sequence.Revisions) {
 		return nil
 	}
 	out := []snap.Revision{}
-	for _, si := range snapst.Sequence[currentIndex+1:] {
-		if status, ok := snapst.RevertStatus[si.Revision.N]; ok {
+	for _, si := range snapst.Sequence.Revisions[currentIndex+1:] {
+		if status, ok := snapst.RevertStatus[si.Snap.Revision.N]; ok {
 			if status == NotBlocked {
 				continue
 			}
 		}
-		out = append(out, si.Revision)
+		out = append(out, si.Snap.Revision)
 	}
 	return out
 }
@@ -443,7 +521,7 @@ func (snapst *SnapState) InstanceName() string {
 }
 
 func revisionInSequence(snapst *SnapState, needle snap.Revision) bool {
-	for _, si := range snapst.Sequence {
+	for _, si := range snapst.Sequence.SideInfos() {
 		if si.Revision == needle {
 			return true
 		}
@@ -706,7 +784,7 @@ func (m *SnapManager) ensureVulnerableSnapRemoved(name string) error {
 	// check if the installed, active version is fixed
 	fixedVersionInstalled := false
 	inactiveVulnRevisions := []snap.Revision{}
-	for _, si := range snapSt.Sequence {
+	for _, si := range snapSt.Sequence.SideInfos() {
 		// check this version
 		s := snap.Info{SideInfo: *si}
 		ver, _, err := snapdtool.SnapdVersionFromInfoFile(filepath.Join(s.MountDir(), dirs.CoreLibExecDir))

--- a/overlord/snapstate/snapstate_config_defaults_test.go
+++ b/overlord/snapstate/snapstate_config_defaults_test.go
@@ -47,9 +47,9 @@ func (s *snapmgrTestSuite) TestConfigDefaults(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", Revision: snap.R(11), SnapID: "somesnapidididididididididididid"},
-		},
+		}),
 		Current:  snap.R(11),
 		SnapType: "app",
 	})
@@ -61,9 +61,9 @@ func (s *snapmgrTestSuite) TestConfigDefaults(c *C) {
 
 	snapstate.Set(s.state, "local-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "local-snap", Revision: snap.R(5)},
-		},
+		}),
 		Current:  snap.R(5),
 		SnapType: "app",
 	})
@@ -107,9 +107,9 @@ func (s *snapmgrTestSuite) TestConfigDefaultsSmokeUC20(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", Revision: snap.R(11), SnapID: "somesnapidididididididididididid"},
-		},
+		}),
 		Current:  snap.R(11),
 		SnapType: "app",
 	})
@@ -134,9 +134,9 @@ func (s *snapmgrTestSuite) TestConfigDefaultsNoGadget(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", Revision: snap.R(11), SnapID: "somesnapidididididididididididid"},
-		},
+		}),
 		Current:  snap.R(11),
 		SnapType: "app",
 	})
@@ -166,9 +166,9 @@ defaults:
 
 	snapstate.Set(s.state, "core", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", Revision: snap.R(11), SnapID: "the-core-ididididididididididid"},
-		},
+		}),
 		Current:  snap.R(11),
 		SnapType: "os",
 	})
@@ -211,9 +211,9 @@ defaults:
 	snapstate.Set(s.state, "core", nil)
 	snapstate.Set(s.state, "snapd", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "snapd", SnapID: "the-snapd-snapidididididididididi", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "snapd",
 	})
@@ -251,9 +251,9 @@ defaults:
 
 	snapstate.Set(s.state, "core", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "core", SnapID: "thecoresnapididididididididididi", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "os",
 	})
@@ -272,7 +272,7 @@ func (s *snapmgrTestSuite) TestTransitionCoreTasksNoUbuntuCore(c *C) {
 
 	snapstate.Set(s.state, "core", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{{RealName: "core", SnapID: "core-snap-id", Revision: snap.R(1)}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "core", SnapID: "core-snap-id", Revision: snap.R(1)}}),
 		Current:  snap.R(1),
 		SnapType: "os",
 	})

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -468,9 +468,9 @@ func (s *snapmgrTestSuite) TestInstallHookNotRunForInstalledSnap(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", Revision: snap.R(7)},
-		},
+		}),
 		Current:  snap.R(7),
 		SnapType: "app",
 	})
@@ -499,7 +499,7 @@ func (s *snapmgrTestSuite) TestInstallFailsOnDisabledSnap(c *C) {
 	snapst := &snapstate.SnapState{
 		Active:          false,
 		TrackingChannel: "channel/stable",
-		Sequence:        []*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(2)}},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(2)}}),
 		Current:         snap.R(2),
 		SnapType:        "app",
 	}
@@ -526,9 +526,9 @@ func (s *snapmgrTestSuite) TestInstallFailsOnBusySnap(c *C) {
 	// With a snap state indicating a snap is already installed.
 	snapst := &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	}
@@ -582,9 +582,9 @@ func (s *snapmgrTestSuite) TestInstallWithIgnoreRunningProceedsOnBusySnap(c *C) 
 	// With a snap state indicating a snap is already installed.
 	snapst := &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "pkg", SnapID: "pkg-id", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	}
@@ -653,9 +653,9 @@ func (s *snapmgrTestSuite) TestInstallDespiteBusySnap(c *C) {
 	var longAgo = time.Now().UTC().Round(time.Second).Add(-time.Hour * 24 * 8)
 	snapst := &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
-		},
+		}),
 		Current:              snap.R(1),
 		SnapType:             "app",
 		RefreshInhibitedTime: &longAgo,
@@ -831,9 +831,9 @@ func (s *snapmgrTestSuite) TestInstallAliasConflict(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "otherfoosnap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "otherfoosnap", Revision: snap.R(30)},
-		},
+		}),
 		Current: snap.R(30),
 		Active:  true,
 		Aliases: map[string]*snapstate.AliasTarget{
@@ -971,7 +971,7 @@ func (s sneakyStore) SnapAction(ctx context.Context, currentSnaps []*store.Curre
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
 		TrackingChannel: "latest/edge",
-		Sequence:        []*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)}},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)}}),
 		Current:         snap.R(1),
 		SnapType:        "app",
 	})
@@ -1086,9 +1086,9 @@ func (s *snapmgrTestSuite) TestInstallPathAsRefresh(c *C) {
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
 		Flags:  snapstate.Flags{DevMode: true},
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
-		},
+		}),
 		Current:         snap.R(1),
 		SnapType:        "app",
 		TrackingChannel: "wibbly/stable",
@@ -1152,7 +1152,7 @@ func (s *snapmgrTestSuite) TestInstallPathFailsEarlyOnEpochMismatch(c *C) {
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
 		TrackingChannel: "latest/edge",
-		Sequence:        []*snap.SideInfo{{RealName: "some-snap", Revision: snap.R(7)}},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "some-snap", Revision: snap.R(7)}}),
 		Current:         snap.R(7),
 	})
 
@@ -1331,12 +1331,12 @@ func (s *snapmgrTestSuite) TestInstallRunThrough(c *C) {
 	c.Assert(snapst, NotNil)
 	c.Assert(snapst.Active, Equals, true)
 	c.Assert(snapst.TrackingChannel, Equals, "some-channel/stable")
-	c.Assert(snapst.Sequence[0], DeepEquals, &snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "some-snap",
 		SnapID:   "some-snap-id",
 		Channel:  "some-channel",
 		Revision: snap.R(11),
-	})
+	}, nil))
 	c.Assert(snapst.Required, Equals, false)
 
 	// we end with the auxiliary store info
@@ -1514,12 +1514,12 @@ func (s *snapmgrTestSuite) testParallelInstanceInstallRunThrough(c *C, inputFlag
 	c.Assert(snapst, NotNil)
 	c.Assert(snapst.Active, Equals, true)
 	c.Assert(snapst.TrackingChannel, Equals, "some-channel/stable")
-	c.Assert(snapst.Sequence[0], DeepEquals, &snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "some-snap",
 		SnapID:   "some-snap-id",
 		Channel:  "some-channel",
 		Revision: snap.R(11),
-	})
+	}, nil))
 	c.Assert(snapst.Required, Equals, false)
 	c.Assert(snapst.InstanceKey, Equals, "instance")
 
@@ -1878,12 +1878,12 @@ func (s *snapmgrTestSuite) TestInstallWithCohortRunThrough(c *C) {
 	c.Assert(snapst.Active, Equals, true)
 	c.Assert(snapst.TrackingChannel, Equals, "some-channel/stable")
 	c.Assert(snapst.CohortKey, Equals, "scurries")
-	c.Assert(snapst.Sequence[0], DeepEquals, &snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "some-snap",
 		SnapID:   "some-snap-id",
 		Revision: snap.R(666),
 		Channel:  "some-channel",
-	})
+	}, nil))
 	c.Assert(snapst.Required, Equals, false)
 }
 
@@ -2043,11 +2043,11 @@ func (s *snapmgrTestSuite) TestInstallWithRevisionRunThrough(c *C) {
 	c.Assert(snapst.Active, Equals, true)
 	c.Assert(snapst.TrackingChannel, Equals, "some-channel/stable")
 	c.Assert(snapst.CohortKey, Equals, "")
-	c.Assert(snapst.Sequence[0], DeepEquals, &snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "some-snap",
 		SnapID:   "some-snap-id",
 		Revision: snap.R(42),
-	})
+	}, nil))
 	c.Assert(snapst.Required, Equals, false)
 }
 
@@ -2207,11 +2207,11 @@ version: 1.0`)
 	c.Assert(err, IsNil)
 
 	c.Assert(snapst.Active, Equals, true)
-	c.Assert(snapst.Sequence[0], DeepEquals, &snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "mock",
 		Channel:  "",
 		Revision: snap.R(-1),
-	})
+	}, nil))
 	c.Assert(snapst.LocalRevision(), Equals, snap.R(-1))
 }
 
@@ -2224,9 +2224,9 @@ func (s *snapmgrTestSuite) TestInstallSubsequentLocalRunThrough(c *C) {
 
 	snapstate.Set(s.state, "mock", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "mock", Revision: snap.R(-2)},
-		},
+		}),
 		Current:  snap.R(-2),
 		SnapType: "app",
 	})
@@ -2334,7 +2334,7 @@ epoch: 1*
 	c.Assert(err, IsNil)
 
 	c.Assert(snapst.Active, Equals, true)
-	c.Assert(snapst.Sequence, HasLen, 2)
+	c.Assert(snapst.Sequence.Revisions, HasLen, 2)
 	c.Assert(snapst.CurrentSideInfo(), DeepEquals, &snap.SideInfo{
 		RealName: "mock",
 		Channel:  "",
@@ -2352,9 +2352,9 @@ func (s *snapmgrTestSuite) TestInstallOldSubsequentLocalRunThrough(c *C) {
 
 	snapstate.Set(s.state, "mock", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "mock", Revision: snap.R(100001)},
-		},
+		}),
 		Current:  snap.R(100001),
 		SnapType: "app",
 	})
@@ -2446,7 +2446,7 @@ epoch: 1*
 	c.Assert(err, IsNil)
 
 	c.Assert(snapst.Active, Equals, true)
-	c.Assert(snapst.Sequence, HasLen, 2)
+	c.Assert(snapst.Sequence.Revisions, HasLen, 2)
 	c.Assert(snapst.CurrentSideInfo(), DeepEquals, &snap.SideInfo{
 		RealName: "mock",
 		Channel:  "",
@@ -2517,7 +2517,7 @@ version: 1.0`)
 
 	c.Assert(snapst.Active, Equals, true)
 	c.Assert(snapst.TrackingChannel, Equals, "")
-	c.Assert(snapst.Sequence[0], DeepEquals, si)
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(si, nil))
 	c.Assert(snapst.LocalRevision().Unset(), Equals, true)
 	c.Assert(snapst.Required, Equals, true)
 }
@@ -2765,12 +2765,12 @@ func (s *snapmgrTestSuite) TestInstallWithoutCoreRunThrough1(c *C) {
 	c.Assert(snapst, NotNil)
 	c.Assert(snapst.Active, Equals, true)
 	c.Assert(snapst.TrackingChannel, Equals, "latest/stable")
-	c.Assert(snapst.Sequence[0], DeepEquals, &snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "core",
 		Channel:  "stable",
 		SnapID:   "core-id",
 		Revision: snap.R(11),
-	})
+	}, nil))
 }
 
 func (s *snapmgrTestSuite) TestInstallWithoutCoreTwoSnapsRunThrough(c *C) {
@@ -2878,25 +2878,25 @@ func (s *snapmgrTestSuite) TestInstallWithoutCoreTwoSnapsWithFailureRunThrough(c
 		err = snapstate.Get(s.state, "core", &snapst)
 		c.Assert(err, IsNil)
 		c.Assert(snapst.Active, Equals, true)
-		c.Assert(snapst.Sequence, HasLen, 1)
-		c.Assert(snapst.Sequence[0], DeepEquals, &snap.SideInfo{
+		c.Assert(snapst.Sequence.Revisions, HasLen, 1)
+		c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
 			RealName: "core",
 			SnapID:   "core-id",
 			Channel:  "stable",
 			Revision: snap.R(11),
-		})
+		}, nil))
 
 		var snapst2 snapstate.SnapState
 		err = snapstate.Get(s.state, "snap2", &snapst2)
 		c.Assert(err, IsNil)
 		c.Assert(snapst2.Active, Equals, true)
-		c.Assert(snapst2.Sequence, HasLen, 1)
-		c.Assert(snapst2.Sequence[0], DeepEquals, &snap.SideInfo{
+		c.Assert(snapst2.Sequence.Revisions, HasLen, 1)
+		c.Assert(snapst2.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
 			RealName: "snap2",
 			SnapID:   "snap2-id",
 			Channel:  "",
 			Revision: snap.R(21),
-		})
+		}, nil))
 	}
 }
 
@@ -2937,9 +2937,9 @@ func (s behindYourBackStore) SnapAction(ctx context.Context, currentSnaps []*sto
 			}
 			snapstate.Set(s.state, "core", &snapstate.SnapState{
 				Active: true,
-				Sequence: []*snap.SideInfo{
+				Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 					{RealName: "core", Revision: snap.R(1)},
-				},
+				}),
 				Current:  snap.R(1),
 				SnapType: "os",
 			})
@@ -3020,20 +3020,20 @@ func (s *snapmgrTestSuite) TestInstallWithoutCoreConflictingInstall(c *C) {
 	snapst := snaps["core"]
 	c.Assert(snapst, NotNil)
 	c.Assert(snapst.Active, Equals, true)
-	c.Assert(snapst.Sequence[0], DeepEquals, &snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "core",
 		Revision: snap.R(1),
-	})
+	}, nil))
 
 	snapst = snaps["some-snap"]
 	c.Assert(snapst, NotNil)
 	c.Assert(snapst.Active, Equals, true)
-	c.Assert(snapst.Sequence[0], DeepEquals, &snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "some-snap",
 		SnapID:   "some-snap-id",
 		Channel:  "some-channel",
 		Revision: snap.R(11),
-	})
+	}, nil))
 }
 
 func (s *snapmgrTestSuite) TestInstallDefaultProviderRunThrough(c *C) {
@@ -3311,9 +3311,9 @@ func (s *snapmgrTestSuite) TestInstallPathWithMetadataChannelSwitchKernel(c *C) 
 	r := snapstatetest.MockDeviceModel(ModelWithKernelTrack("18"))
 	defer r()
 	snapstate.Set(s.state, "kernel", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "kernel", Revision: snap.R(11)},
-		},
+		}),
 		TrackingChannel: "18/stable",
 		Current:         snap.R(11),
 		Active:          true,
@@ -3342,9 +3342,9 @@ func (s *snapmgrTestSuite) TestInstallPathWithMetadataChannelSwitchGadget(c *C) 
 	r := snapstatetest.MockDeviceModel(ModelWithGadgetTrack("18"))
 	defer r()
 	snapstate.Set(s.state, "brand-gadget", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "brand-gadget", Revision: snap.R(11)},
-		},
+		}),
 		TrackingChannel: "18/stable",
 		Current:         snap.R(11),
 		Active:          true,
@@ -3793,24 +3793,24 @@ func (s *snapmgrTestSuite) TestInstallManyWithPrereqsTransactionally(c *C) {
 	snapst := snaps["core"]
 	c.Assert(snapst, NotNil)
 	c.Assert(snapst.Active, Equals, true)
-	c.Assert(snapst.Sequence[0], DeepEquals, &snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "core",
 		SnapID:   "core-id",
 		Revision: snap.R(11),
 		Channel:  "stable",
-	})
+	}, nil))
 
 	// Verify the snaps we wanted to install
 	for _, s := range snapsToInstall {
 		snapst = snaps[s]
 		c.Assert(snapst, NotNil)
 		c.Assert(snapst.Active, Equals, true)
-		c.Assert(snapst.Sequence[0], DeepEquals, &snap.SideInfo{
+		c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
 			RealName: s,
 			SnapID:   s + "-id",
 			Channel:  "stable",
 			Revision: snap.R(11),
-		})
+		}, nil))
 	}
 }
 
@@ -4061,7 +4061,7 @@ func (s *snapmgrTestSuite) TestGadgetDefaultsInstalled(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)}}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -4597,7 +4597,7 @@ func (s *snapmgrTestSuite) TestInstallWithOutdatedPrereq(c *C) {
 		RealName: "content-snap",
 	}
 	snapstate.Set(s.state, "snap-content-slot", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{info},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{info}),
 		Current:  info.Revision,
 		Active:   true,
 	})
@@ -5045,7 +5045,7 @@ func (s *snapmgrTestSuite) testRetainCorrectNumRevisions(c *C, installFn install
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
 		TrackingChannel: "latest/stable",
-		Sequence:        []*snap.SideInfo{si},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:         si.Revision,
 		SnapType:        "app",
 	})
@@ -5067,7 +5067,7 @@ func (s *snapmgrTestSuite) testRetainCorrectNumRevisions(c *C, installFn install
 	var snapst snapstate.SnapState
 	err = snapstate.Get(s.state, "some-snap", &snapst)
 	c.Assert(err, IsNil)
-	c.Assert(snapst.Sequence, DeepEquals, []*snap.SideInfo{si})
+	c.Assert(snapst.Sequence, DeepEquals, snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}))
 }
 
 func (s *snapmgrTestSuite) TestInstallPathMany(c *C) {
@@ -5291,7 +5291,7 @@ func (s *snapmgrTestSuite) TestInstallPathManyAsUpdate(c *C) {
 		}
 		snapstate.Set(s.state, name, &snapstate.SnapState{
 			Active:   true,
-			Sequence: []*snap.SideInfo{si},
+			Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 			Current:  si.Revision,
 			SnapType: "app",
 		})
@@ -5470,7 +5470,7 @@ func (s *snapmgrTestSuite) TestInstallPathManyFailOnEpochMismatch(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{{RealName: "some-snap", Revision: snap.R(-1)}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "some-snap", Revision: snap.R(-1)}}),
 		Current:  snap.R(-1),
 	})
 	yaml := `name: some-snap
@@ -5512,7 +5512,7 @@ func (s *snapmgrTestSuite) TestInstallPathManyClassicAsUpdate(c *C) {
 		}
 		snapstate.Set(s.state, name, &snapstate.SnapState{
 			Active:   true,
-			Sequence: []*snap.SideInfo{si},
+			Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 			Current:  si.Revision,
 			Flags:    snapstate.Flags{Classic: true},
 		})

--- a/overlord/snapstate/snapstate_remove_test.go
+++ b/overlord/snapstate/snapstate_remove_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
@@ -45,9 +46,9 @@ func (s *snapmgrTestSuite) TestRemoveTasks(c *C) {
 
 	snapstate.Set(s.state, "foo", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "foo", Revision: snap.R(11)},
-		},
+		}),
 		Current:  snap.R(11),
 		SnapType: "app",
 	})
@@ -69,9 +70,9 @@ func (s *snapmgrTestSuite) TestRemoveTasksAutoSnapshotDisabled(c *C) {
 
 	snapstate.Set(s.state, "foo", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "foo", Revision: snap.R(11)},
-		},
+		}),
 		Current:  snap.R(11),
 		SnapType: "app",
 	})
@@ -97,9 +98,9 @@ func (s *snapmgrTestSuite) TestRemoveTasksAutoSnapshotDisabledByPurgeFlag(c *C) 
 
 	snapstate.Set(s.state, "foo", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "foo", Revision: snap.R(11)},
-		},
+		}),
 		Current:  snap.R(11),
 		SnapType: "app",
 	})
@@ -125,10 +126,10 @@ func (s *snapmgrTestSuite) TestRemoveHookNotExecutedIfNotLastRevison(c *C) {
 
 	snapstate.Set(s.state, "foo", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "foo", Revision: snap.R(11)},
 			{RealName: "foo", Revision: snap.R(12)},
-		},
+		}),
 		Current: snap.R(12),
 	})
 
@@ -146,7 +147,7 @@ func (s *snapmgrTestSuite) TestRemoveConflict(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{{RealName: "some-snap", Revision: snap.R(11)}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "some-snap", Revision: snap.R(11)}}),
 		Current:  snap.R(11),
 	})
 
@@ -190,7 +191,7 @@ func (s *snapmgrTestSuite) testRemoveDiskSpaceCheck(c *C, featureFlag, automatic
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{{RealName: "some-snap", Revision: snap.R(11)}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "some-snap", Revision: snap.R(11)}}),
 		Current:  snap.R(11),
 		SnapType: "app",
 	})
@@ -243,7 +244,7 @@ func (s *snapmgrTestSuite) TestRemoveRunThrough(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{&si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		Current:  si.Revision,
 		SnapType: "app",
 	})
@@ -385,14 +386,14 @@ func (s *snapmgrTestSuite) TestParallelInstanceRemoveRunThrough(c *C) {
 	// pretend we have both a regular snap and a parallel instance
 	snapstate.Set(s.state, "some-snap_instance", &snapstate.SnapState{
 		Active:      true,
-		Sequence:    []*snap.SideInfo{&si},
+		Sequence:    snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		Current:     si.Revision,
 		SnapType:    "app",
 		InstanceKey: "instance",
 	})
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{&si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		Current:  si.Revision,
 		SnapType: "app",
 	})
@@ -538,14 +539,14 @@ func (s *snapmgrTestSuite) TestParallelInstanceRemoveRunThroughOtherInstances(c 
 	// pretend we have both a regular snap and a parallel instance
 	snapstate.Set(s.state, "some-snap_instance", &snapstate.SnapState{
 		Active:      true,
-		Sequence:    []*snap.SideInfo{&si},
+		Sequence:    snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		Current:     si.Revision,
 		SnapType:    "app",
 		InstanceKey: "instance",
 	})
 	snapstate.Set(s.state, "some-snap_other", &snapstate.SnapState{
 		Active:      true,
-		Sequence:    []*snap.SideInfo{&si},
+		Sequence:    snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		Current:     si.Revision,
 		SnapType:    "app",
 		InstanceKey: "other",
@@ -658,7 +659,7 @@ func (s *snapmgrTestSuite) TestRemoveWithManyRevisionsRunThrough(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{&si5, &si3, &si7},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si5, &si3, &si7}),
 		Current:  si7.Revision,
 		SnapType: "app",
 	})
@@ -831,7 +832,7 @@ func (s *snapmgrTestSuite) TestRemoveOneRevisionRunThrough(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{&si5, &si3, &si7},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si5, &si3, &si7}),
 		Current:  si7.Revision,
 		SnapType: "app",
 	})
@@ -884,7 +885,7 @@ func (s *snapmgrTestSuite) TestRemoveOneRevisionRunThrough(c *C) {
 	var snapst snapstate.SnapState
 	err = snapstate.Get(s.state, "some-snap", &snapst)
 	c.Assert(err, IsNil)
-	c.Check(snapst.Sequence, HasLen, 2)
+	c.Check(snapst.Sequence.Revisions, HasLen, 2)
 }
 
 func (s *snapmgrTestSuite) TestRemoveOneRevisionDropsRevertStatus(c *C) {
@@ -908,7 +909,7 @@ func (s *snapmgrTestSuite) TestRemoveOneRevisionDropsRevertStatus(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{&si5, &si3, &si7},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si5, &si3, &si7}),
 		Current:  si7.Revision,
 		RevertStatus: map[int]snapstate.RevertStatus{
 			3: snapstate.NotBlocked,
@@ -929,7 +930,7 @@ func (s *snapmgrTestSuite) TestRemoveOneRevisionDropsRevertStatus(c *C) {
 	var snapst snapstate.SnapState
 	err = snapstate.Get(s.state, "some-snap", &snapst)
 	c.Assert(err, IsNil)
-	c.Check(snapst.Sequence, HasLen, 2)
+	c.Check(snapst.Sequence.Revisions, HasLen, 2)
 	// revert status of revision 3 got dropped
 	c.Check(snapst.RevertStatus, DeepEquals, map[int]snapstate.RevertStatus{
 		5: snapstate.NotBlocked,
@@ -947,7 +948,7 @@ func (s *snapmgrTestSuite) TestRemoveLastRevisionRunThrough(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   false,
-		Sequence: []*snap.SideInfo{&si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		Current:  si.Revision,
 		SnapType: "app",
 	})
@@ -1057,7 +1058,7 @@ func (s *snapmgrTestSuite) TestRemoveCurrentActiveRevisionRefused(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{&si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		Current:  si.Revision,
 		SnapType: "app",
 	})
@@ -1078,7 +1079,7 @@ func (s *snapmgrTestSuite) TestRemoveCurrentRevisionOfSeveralRefused(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{&si, &si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si, &si}),
 		Current:  si.Revision,
 		SnapType: "app",
 	})
@@ -1099,7 +1100,7 @@ func (s *snapmgrTestSuite) TestRemoveMissingRevisionRefused(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{&si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		Current:  si.Revision,
 		SnapType: "app",
 	})
@@ -1120,7 +1121,7 @@ func (s *snapmgrTestSuite) TestRemoveRefused(c *C) {
 
 	snapstate.Set(s.state, "brand-gadget", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{&si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		Current:  si.Revision,
 		SnapType: "gadget",
 	})
@@ -1141,7 +1142,7 @@ func (s *snapmgrTestSuite) TestRemoveRefusedLastRevision(c *C) {
 
 	snapstate.Set(s.state, "brand-gadget", &snapstate.SnapState{
 		Active:   false,
-		Sequence: []*snap.SideInfo{&si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		Current:  si.Revision,
 		SnapType: "gadget",
 	})
@@ -1162,14 +1163,14 @@ func (s *snapmgrTestSuite) TestRemoveDeletesConfigOnLastRevision(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{&si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		Current:  si.Revision,
 		SnapType: "app",
 	})
 
 	snapstate.Set(s.state, "another-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{&si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		Current:  si.Revision,
 		SnapType: "app",
 	})
@@ -1226,7 +1227,7 @@ func (s *snapmgrTestSuite) TestRemoveDoesntDeleteConfigIfNotLastRevision(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{&si1, &si2},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si1, &si2}),
 		Current:  si2.Revision,
 		SnapType: "app",
 	})
@@ -1263,16 +1264,16 @@ func (s *snapmgrTestSuite) TestRemoveMany(c *C) {
 
 	snapstate.Set(s.state, "one", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "one", SnapID: "one-id", Revision: snap.R(1)},
-		},
+		}),
 		Current: snap.R(1),
 	})
 	snapstate.Set(s.state, "two", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "two", SnapID: "two-id", Revision: snap.R(1)},
-		},
+		}),
 		Current: snap.R(1),
 	})
 
@@ -1353,17 +1354,17 @@ func (s *snapmgrTestSuite) testRemoveManyDiskSpaceCheck(c *C, featureFlag, autom
 	snapstate.Set(s.state, "one", &snapstate.SnapState{
 		Active:   true,
 		SnapType: "app",
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "one", SnapID: "one-id", Revision: snap.R(1)},
-		},
+		}),
 		Current: snap.R(1),
 	})
 	snapstate.Set(s.state, "two", &snapstate.SnapState{
 		Active:   true,
 		SnapType: "app",
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "two", SnapID: "two-id", Revision: snap.R(1)},
-		},
+		}),
 		Current: snap.R(1),
 	})
 
@@ -1492,7 +1493,7 @@ func makeTestSnaps(c *C, st *state.State) {
 
 	snapstate.Set(st, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{&si1, &si2},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si1, &si2}),
 		Current:  si1.Revision,
 		SnapType: "app",
 	})
@@ -1532,8 +1533,8 @@ func (s *snapmgrTestSuite) TestRemoveManyUndoRestoresCurrent(c *C) {
 	c.Assert(snapstate.Get(s.state, "some-snap", &snapst), IsNil)
 	c.Check(snapst.Active, Equals, true)
 	c.Check(snapst.Current, Equals, snap.Revision{N: 1})
-	c.Assert(snapst.Sequence, HasLen, 1)
-	c.Check(snapst.Sequence[0].Revision, Equals, snap.Revision{N: 1})
+	c.Assert(snapst.Sequence.Revisions, HasLen, 1)
+	c.Check(snapst.Sequence.Revisions[0].Snap.Revision, Equals, snap.Revision{N: 1})
 
 	expected := fakeOps{
 		{
@@ -1613,8 +1614,8 @@ func (s *snapmgrTestSuite) TestRemoveManyUndoLeavesInactiveSnapAfterDataIsLost(c
 	// after its data was removed.
 	c.Check(snapst.Active, Equals, false)
 	c.Check(snapst.Current, Equals, snap.Revision{N: 1})
-	c.Assert(snapst.Sequence, HasLen, 1)
-	c.Check(snapst.Sequence[0].Revision, Equals, snap.Revision{N: 1})
+	c.Assert(snapst.Sequence.Revisions, HasLen, 1)
+	c.Check(snapst.Sequence.Revisions[0].Snap.Revision, Equals, snap.Revision{N: 1})
 
 	expected := fakeOps{
 		{
@@ -1696,7 +1697,7 @@ func (s *snapmgrTestSuite) TestRemovePrunesRefreshGatingDataOnLastRevision(c *C)
 		t := time.Now()
 		snapstate.Set(s.state, sn, &snapstate.SnapState{
 			Active:          true,
-			Sequence:        []*snap.SideInfo{&si},
+			Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 			Current:         si.Revision,
 			SnapType:        "app",
 			LastRefreshTime: &t,
@@ -1754,10 +1755,10 @@ func (s *snapmgrTestSuite) TestRemoveKeepsGatingDataIfNotLastRevision(c *C) {
 	t := time.Now()
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", Revision: snap.R(11)},
 			{RealName: "some-snap", Revision: snap.R(12)},
-		},
+		}),
 		Current:         snap.R(11),
 		SnapType:        "app",
 		LastRefreshTime: &t,
@@ -1820,7 +1821,7 @@ func (s *validationSetsSuite) removeSnapReferencedByValidationSet(c *C, presence
 	}
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{&si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		Current:  si.Revision,
 		SnapType: "app",
 	})
@@ -1886,7 +1887,7 @@ func (s *validationSetsSuite) TestRemoveSnapRequiredByValidationSetAtSpecificRev
 	}
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{&si1, &si2, &si3},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si1, &si2, &si3}),
 		Current:  si1.Revision,
 		SnapType: "app",
 	})
@@ -1937,7 +1938,7 @@ func (s *validationSetsSuite) TestRemoveSnapRequiredByValidationSetAtSpecificRev
 	// rev 1 is active
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{&si1, &si2},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si1, &si2}),
 		Current:  si1.Revision,
 		SnapType: "app",
 	})
@@ -1981,21 +1982,21 @@ func (s *snapmgrTestSuite) TestRemoveDeduplicatesSnapNames(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{
 			RealName: "some-snap",
 			SnapID:   "some-snap-id",
 			Revision: snap.R(1),
-		}},
+		}}),
 		Current: snap.R(1),
 		Active:  true,
 	})
 
 	snapstate.Set(s.state, "some-base", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{
 			RealName: "some-base",
 			SnapID:   "some-base-id",
 			Revision: snap.R(1),
-		}},
+		}}),
 		Current: snap.R(1),
 		Active:  true,
 	})
@@ -2011,18 +2012,18 @@ func (s *snapmgrTestSuite) TestRemoveManyWithPurge(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "app",
 		Active:   true,
 	})
 
 	snapstate.Set(s.state, "foo", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "foo", SnapID: "foo-id", Revision: snap.R(11)},
-		},
+		}),
 		Current:  snap.R(11),
 		SnapType: "app",
 		Active:   true,

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -98,12 +98,12 @@ func (s *snapmgrTestSuite) TestUpdateDoesGC(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(2)},
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(3)},
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(4)},
-		},
+		}),
 		Current:  snap.R(4),
 		SnapType: "app",
 	})
@@ -170,9 +170,9 @@ func (s *snapmgrTestSuite) TestRepeatedUpdatesDoGC(c *C) {
 	// start with a single revision
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", SnapID: "some-snap-id", Channel: "some-channel", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -199,11 +199,11 @@ func (s *snapmgrTestSuite) TestRepeatedUpdatesDoGC(c *C) {
 		var snapst snapstate.SnapState
 		c.Assert(snapstate.Get(s.state, "some-snap", &snapst), IsNil)
 		// and we expect 2 revisions at all times
-		c.Check(snapst.Sequence, HasLen, 2)
-		c.Check(snapst.Sequence, DeepEquals, []*snap.SideInfo{
+		c.Check(snapst.Sequence.Revisions, HasLen, 2)
+		c.Check(snapst.Sequence, DeepEquals, snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", SnapID: "some-snap-id", Channel: "some-channel", Revision: snap.R(refreshRev - 1)},
 			{RealName: "some-snap", SnapID: "some-snap-id", Channel: "some-channel", Revision: snap.R(refreshRev)},
-		})
+		}))
 	}
 }
 
@@ -230,7 +230,7 @@ func (s *snapmgrTestSuite) testUpdateScenario(c *C, desc string, t switchScenari
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
-		Sequence:        []*snap.SideInfo{&si},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		Active:          true,
 		Current:         si.Revision,
 		TrackingChannel: t.chanFrom,
@@ -302,7 +302,7 @@ func (s *snapmgrTestSuite) TestUpdateTasksWithOldCurrent(c *C) {
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
 		TrackingChannel: "latest/edge",
-		Sequence:        []*snap.SideInfo{si1, si2, si3, si4},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si1, si2, si3, si4}),
 		Current:         snap.R(2),
 		SnapType:        "app",
 	})
@@ -348,7 +348,7 @@ func (s *snapmgrTestSuite) TestUpdateCanDoBackwards(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{&si7, &si11},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si7, &si11}),
 		Current:  si11.Revision,
 		SnapType: "app",
 	})
@@ -421,10 +421,10 @@ func (s *snapmgrTestSuite) TestUpdateCanDoBackwards(c *C) {
 	c.Assert(s.fakeBackend.ops, DeepEquals, expected)
 }
 
-func revs(seq []*snap.SideInfo) []int {
+func revs(seq []*snapstate.RevisionSideState) []int {
 	revs := make([]int, len(seq))
 	for i, si := range seq {
-		revs[i] = si.Revision.N
+		revs[i] = si.Snap.Revision.N
 	}
 
 	return revs
@@ -454,7 +454,7 @@ func (s *snapmgrTestSuite) testOpSequence(c *C, opts *opSeqOpts) (*snapstate.Sna
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
 		TrackingChannel: "latest/edge",
-		Sequence:        seq,
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos(seq),
 		Current:         snap.R(opts.current),
 		SnapType:        "app",
 	})
@@ -498,7 +498,7 @@ func (s *snapmgrTestSuite) testOpSequence(c *C, opts *opSeqOpts) (*snapstate.Sna
 	var snapst snapstate.SnapState
 	err = snapstate.Get(s.state, "some-snap", &snapst)
 	c.Assert(err, IsNil)
-	c.Check(revs(snapst.Sequence), DeepEquals, opts.after)
+	c.Check(revs(snapst.Sequence.Revisions), DeepEquals, opts.after)
 
 	return &snapst, ts
 }
@@ -582,9 +582,9 @@ func (s *snapmgrTestSuite) TestUpdateLayoutsChecksFeatureFlag(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -613,9 +613,9 @@ func (s *snapmgrTestSuite) TestUpdateManyExplicitLayoutsChecksFeatureFlag(c *C) 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
 		TrackingChannel: "channel-for-layout/stable",
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -644,9 +644,9 @@ func (s *snapmgrTestSuite) TestUpdateManyLayoutsChecksFeatureFlag(c *C) {
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
 		TrackingChannel: "channel-for-layout/stable",
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -671,9 +671,9 @@ func (s *snapmgrTestSuite) TestUpdateFailsEarlyOnEpochMismatch(c *C) {
 
 	snapstate.Set(s.state, "some-epoch-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-epoch-snap", SnapID: "some-epoch-snap-id", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -689,7 +689,7 @@ func (s *snapmgrTestSuite) TestUpdateTasksPropagatesErrors(c *C) {
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
 		TrackingChannel: "latest/edge",
-		Sequence:        []*snap.SideInfo{{RealName: "some-snap", SnapID: "fakestore-please-error-on-refresh", Revision: snap.R(7)}},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "some-snap", SnapID: "fakestore-please-error-on-refresh", Revision: snap.R(7)}}),
 		Current:         snap.R(7),
 	})
 
@@ -704,7 +704,7 @@ func (s *snapmgrTestSuite) TestUpdateTasks(c *C) {
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
 		TrackingChannel: "latest/edge",
-		Sequence:        []*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}}),
 		Current:         snap.R(7),
 		SnapType:        "app",
 	})
@@ -743,7 +743,7 @@ func (s *snapmgrTestSuite) TestUpdateAmendRunThrough(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
-		Sequence:        []*snap.SideInfo{&si},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		Current:         si.Revision,
 		SnapType:        "app",
 		TrackingChannel: "latest/stable",
@@ -839,18 +839,18 @@ func (s *snapmgrTestSuite) TestUpdateAmendRunThrough(c *C) {
 	c.Assert(err, IsNil)
 
 	c.Assert(snapst.Active, Equals, true)
-	c.Assert(snapst.Sequence, HasLen, 2)
-	c.Assert(snapst.Sequence[0], DeepEquals, &snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions, HasLen, 2)
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "some-snap",
 		Channel:  "",
 		Revision: snap.R(-42),
-	})
-	c.Assert(snapst.Sequence[1], DeepEquals, &snap.SideInfo{
+	}, nil))
+	c.Assert(snapst.Sequence.Revisions[1], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "some-snap",
 		Channel:  "some-channel",
 		SnapID:   "some-snap-id",
 		Revision: snap.R(11),
-	})
+	}, nil))
 }
 
 func (s *snapmgrTestSuite) TestUpdateRunThrough(c *C) {
@@ -883,7 +883,7 @@ func (s *snapmgrTestSuite) TestUpdateRunThrough(c *C) {
 
 	snapstate.Set(s.state, "services-snap", &snapstate.SnapState{
 		Active:          true,
-		Sequence:        []*snap.SideInfo{&si},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		Current:         si.Revision,
 		SnapType:        "app",
 		TrackingChannel: "latest/stable",
@@ -1087,19 +1087,19 @@ func (s *snapmgrTestSuite) TestUpdateRunThrough(c *C) {
 	c.Assert(snapst.LastRefreshTime, NotNil)
 	c.Check(snapst.LastRefreshTime.Equal(now), Equals, true)
 	c.Assert(snapst.Active, Equals, true)
-	c.Assert(snapst.Sequence, HasLen, 2)
-	c.Assert(snapst.Sequence[0], DeepEquals, &snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions, HasLen, 2)
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "services-snap",
 		SnapID:   "services-snap-id",
 		Channel:  "",
 		Revision: snap.R(7),
-	})
-	c.Assert(snapst.Sequence[1], DeepEquals, &snap.SideInfo{
+	}, nil))
+	c.Assert(snapst.Sequence.Revisions[1], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "services-snap",
 		Channel:  "some-channel",
 		SnapID:   "services-snap-id",
 		Revision: snap.R(11),
-	})
+	}, nil))
 	c.Check(snapst.CohortKey, Equals, "some-cohort")
 
 	// we end up with the auxiliary store info
@@ -1124,7 +1124,7 @@ func (s *snapmgrTestSuite) TestUpdateDropsRevertStatus(c *C) {
 	}
 	snapstate.Set(s.state, "services-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{&si, &si2},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si, &si2}),
 		Current:  si.Revision,
 		RevertStatus: map[int]snapstate.RevertStatus{
 			11: snapstate.NotBlocked,
@@ -1150,19 +1150,19 @@ func (s *snapmgrTestSuite) TestUpdateDropsRevertStatus(c *C) {
 	c.Assert(snapstate.Get(s.state, "services-snap", &snapst), IsNil)
 	c.Assert(snapst.Active, Equals, true)
 	c.Assert(snapst.Current, Equals, snap.R(11))
-	c.Assert(snapst.Sequence, HasLen, 2)
-	c.Assert(snapst.Sequence[0], DeepEquals, &snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions, HasLen, 2)
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "services-snap",
 		SnapID:   "services-snap-id",
 		Channel:  "",
 		Revision: snap.R(7),
-	})
-	c.Assert(snapst.Sequence[1], DeepEquals, &snap.SideInfo{
+	}, nil))
+	c.Assert(snapst.Sequence.Revisions[1], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "services-snap",
 		Channel:  "some-channel",
 		SnapID:   "services-snap-id",
 		Revision: snap.R(11),
-	})
+	}, nil))
 	c.Check(snapst.RevertStatus, HasLen, 0)
 }
 
@@ -1186,7 +1186,7 @@ func (s *snapmgrTestSuite) TestUpdateResetsHoldState(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
-		Sequence:        []*snap.SideInfo{&si},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		Current:         si.Revision,
 		SnapType:        "app",
 		TrackingChannel: "latest/stable",
@@ -1194,7 +1194,7 @@ func (s *snapmgrTestSuite) TestUpdateResetsHoldState(c *C) {
 
 	snapstate.Set(s.state, "other-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{&si2},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si2}),
 		Current:  si.Revision,
 		SnapType: "app",
 	})
@@ -1250,7 +1250,7 @@ func (s *snapmgrTestSuite) TestParallelInstanceUpdateRunThrough(c *C) {
 
 	snapstate.Set(s.state, "services-snap_instance", &snapstate.SnapState{
 		Active:          true,
-		Sequence:        []*snap.SideInfo{&si},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		Current:         si.Revision,
 		SnapType:        "app",
 		TrackingChannel: "latest/stable",
@@ -1442,19 +1442,19 @@ func (s *snapmgrTestSuite) TestParallelInstanceUpdateRunThrough(c *C) {
 
 	c.Assert(snapst.InstanceKey, Equals, "instance")
 	c.Assert(snapst.Active, Equals, true)
-	c.Assert(snapst.Sequence, HasLen, 2)
-	c.Assert(snapst.Sequence[0], DeepEquals, &snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions, HasLen, 2)
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "services-snap",
 		SnapID:   "services-snap-id",
 		Channel:  "",
 		Revision: snap.R(7),
-	})
-	c.Assert(snapst.Sequence[1], DeepEquals, &snap.SideInfo{
+	}, nil))
+	c.Assert(snapst.Sequence.Revisions[1], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "services-snap",
 		Channel:  "some-channel",
 		SnapID:   "services-snap-id",
 		Revision: snap.R(11),
-	})
+	}, nil))
 }
 
 func (s *snapmgrTestSuite) TestUpdateWithNewBase(c *C) {
@@ -1471,7 +1471,7 @@ func (s *snapmgrTestSuite) TestUpdateWithNewBase(c *C) {
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
 		TrackingChannel: "latest/edge",
-		Sequence:        []*snap.SideInfo{si},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:         snap.R(7),
 		SnapType:        "app",
 	})
@@ -1504,18 +1504,18 @@ func (s *snapmgrTestSuite) TestUpdateWithAlreadyInstalledBase(c *C) {
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
 		TrackingChannel: "latest/edge",
-		Sequence:        []*snap.SideInfo{si},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:         snap.R(7),
 		SnapType:        "app",
 	})
 	snapstate.Set(s.state, "some-base", &snapstate.SnapState{
 		Active:          true,
 		TrackingChannel: "latest/stable",
-		Sequence: []*snap.SideInfo{{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{
 			RealName: "some-base",
 			SnapID:   "some-base-id",
 			Revision: snap.R(1),
-		}},
+		}}),
 		Current:  snap.R(1),
 		SnapType: "base",
 	})
@@ -1550,7 +1550,7 @@ func (s *snapmgrTestSuite) TestUpdateWithNewDefaultProvider(c *C) {
 	snapstate.Set(s.state, "snap-content-plug", &snapstate.SnapState{
 		Active:          true,
 		TrackingChannel: "latest/edge",
-		Sequence:        []*snap.SideInfo{si},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:         snap.R(7),
 		SnapType:        "app",
 	})
@@ -1586,18 +1586,18 @@ func (s *snapmgrTestSuite) TestUpdateWithInstalledDefaultProvider(c *C) {
 	snapstate.Set(s.state, "snap-content-plug", &snapstate.SnapState{
 		Active:          true,
 		TrackingChannel: "latest/edge",
-		Sequence:        []*snap.SideInfo{si},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:         snap.R(7),
 		SnapType:        "app",
 	})
 	snapstate.Set(s.state, "snap-content-slot", &snapstate.SnapState{
 		Active:          true,
 		TrackingChannel: "latest/stable",
-		Sequence: []*snap.SideInfo{{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{
 			RealName: "snap-content-slot",
 			SnapID:   "snap-content-slot-id",
 			Revision: snap.R(1),
-		}},
+		}}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -1633,9 +1633,9 @@ func (s *snapmgrTestSuite) TestUpdateRememberedUserRunThrough(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", Revision: snap.R(5), SnapID: "some-snap-id"},
-		},
+		}),
 		Current:  snap.R(5),
 		SnapType: "app",
 		UserID:   1,
@@ -1692,7 +1692,7 @@ func (s *snapmgrTestSuite) TestUpdateModelKernelSwitchTrackRunThrough(c *C) {
 	defer r1()
 	snapstate.Set(s.state, "kernel", &snapstate.SnapState{
 		Active:          true,
-		Sequence:        []*snap.SideInfo{&si},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		Current:         si.Revision,
 		TrackingChannel: "18/stable",
 	})
@@ -1771,19 +1771,19 @@ func (s *snapmgrTestSuite) TestUpdateModelKernelSwitchTrackRunThrough(c *C) {
 
 	c.Assert(snapst.Active, Equals, true)
 	c.Assert(snapst.TrackingChannel, Equals, "18/edge")
-	c.Assert(snapst.Sequence, HasLen, 2)
-	c.Assert(snapst.Sequence[0], DeepEquals, &snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions, HasLen, 2)
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "kernel",
 		SnapID:   "kernel-id",
 		Channel:  "",
 		Revision: snap.R(7),
-	})
-	c.Assert(snapst.Sequence[1], DeepEquals, &snap.SideInfo{
+	}, nil))
+	c.Assert(snapst.Sequence.Revisions[1], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "kernel",
 		Channel:  "18/edge",
 		SnapID:   "kernel-id",
 		Revision: snap.R(11),
-	})
+	}, nil))
 }
 
 func (s *snapmgrTestSuite) TestUpdateManyMultipleCredsNoUserRunThrough(c *C) {
@@ -1792,26 +1792,26 @@ func (s *snapmgrTestSuite) TestUpdateManyMultipleCredsNoUserRunThrough(c *C) {
 
 	snapstate.Set(s.state, "core", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "core", Revision: snap.R(1), SnapID: "core-snap-id"},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "os",
 	})
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", Revision: snap.R(5), SnapID: "some-snap-id"},
-		},
+		}),
 		Current:  snap.R(5),
 		SnapType: "app",
 		UserID:   1,
 	})
 	snapstate.Set(s.state, "services-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "services-snap", Revision: snap.R(2), SnapID: "services-snap-id"},
-		},
+		}),
 		Current:  snap.R(2),
 		SnapType: "app",
 		UserID:   2,
@@ -1898,26 +1898,26 @@ func (s *snapmgrTestSuite) TestUpdateManyMultipleCredsUserRunThrough(c *C) {
 
 	snapstate.Set(s.state, "core", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "core", Revision: snap.R(1), SnapID: "core-snap-id"},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "os",
 	})
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", Revision: snap.R(5), SnapID: "some-snap-id"},
-		},
+		}),
 		Current:  snap.R(5),
 		SnapType: "app",
 		UserID:   1,
 	})
 	snapstate.Set(s.state, "services-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "services-snap", Revision: snap.R(2), SnapID: "services-snap-id"},
-		},
+		}),
 		Current:  snap.R(2),
 		SnapType: "app",
 		UserID:   2,
@@ -2023,26 +2023,26 @@ func (s *snapmgrTestSuite) TestUpdateManyMultipleCredsUserWithNoStoreAuthRunThro
 
 	snapstate.Set(s.state, "core", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "core", Revision: snap.R(1), SnapID: "core-snap-id"},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "os",
 	})
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", Revision: snap.R(5), SnapID: "some-snap-id"},
-		},
+		}),
 		Current:  snap.R(5),
 		SnapType: "app",
 		UserID:   1,
 	})
 	snapstate.Set(s.state, "services-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "services-snap", Revision: snap.R(2), SnapID: "services-snap-id"},
-		},
+		}),
 		Current:  snap.R(2),
 		SnapType: "app",
 		UserID:   3,
@@ -2137,7 +2137,7 @@ func (s *snapmgrTestSuite) TestUpdateUndoRunThrough(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{&si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		Current:  si.Revision,
 		SnapType: "app",
 	})
@@ -2300,13 +2300,13 @@ func (s *snapmgrTestSuite) TestUpdateUndoRunThrough(c *C) {
 	c.Assert(err, IsNil)
 
 	c.Assert(snapst.Active, Equals, true)
-	c.Assert(snapst.Sequence, HasLen, 1)
-	c.Assert(snapst.Sequence[0], DeepEquals, &snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions, HasLen, 1)
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "some-snap",
 		SnapID:   "some-snap-id",
 		Channel:  "",
 		Revision: snap.R(7),
-	})
+	}, nil))
 }
 
 func lastWithLane(tasks []*state.Task) *state.Task {
@@ -2353,7 +2353,7 @@ func (s *snapmgrTestSuite) TestUpdateUndoRestoresRevisionConfig(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
-		Sequence:        []*snap.SideInfo{&si2, &si},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si2, &si}),
 		TrackingChannel: "latest/stable",
 		Current:         si.Revision,
 		SnapType:        "app",
@@ -2397,9 +2397,9 @@ func (s *snapmgrTestSuite) TestUpdateMakesConfigSnapshot(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -2447,7 +2447,7 @@ func (s *snapmgrTestSuite) TestUpdateTotalUndoRunThrough(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
-		Sequence:        []*snap.SideInfo{&si},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		TrackingChannel: "latest/stable",
 		Current:         si.Revision,
 		SnapType:        "app",
@@ -2640,13 +2640,13 @@ func (s *snapmgrTestSuite) TestUpdateTotalUndoRunThrough(c *C) {
 
 	c.Assert(snapst.Active, Equals, true)
 	c.Assert(snapst.TrackingChannel, Equals, "latest/stable")
-	c.Assert(snapst.Sequence, HasLen, 1)
-	c.Assert(snapst.Sequence[0], DeepEquals, &snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions, HasLen, 1)
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "some-snap",
 		SnapID:   "some-snap-id",
 		Channel:  "",
 		Revision: snap.R(7),
-	})
+	}, nil))
 }
 
 func (s *snapmgrTestSuite) TestUpdateSameRevision(c *C) {
@@ -2661,7 +2661,7 @@ func (s *snapmgrTestSuite) TestUpdateSameRevision(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
-		Sequence:        []*snap.SideInfo{&si},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		TrackingChannel: "channel-for-7/stable",
 		Current:         si.Revision,
 	})
@@ -2676,9 +2676,9 @@ func (s *snapmgrTestSuite) TestUpdateToRevisionRememberedUserRunThrough(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", Revision: snap.R(5), SnapID: "some-snap-id"},
-		},
+		}),
 		Current:  snap.R(5),
 		SnapType: "app",
 		UserID:   1,
@@ -2739,7 +2739,7 @@ func (s *snapmgrTestSuite) TestUpdateNoStoreResults(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
-		Sequence:        []*snap.SideInfo{&si},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		TrackingChannel: "channel-for-7/stable",
 		Current:         si.Revision,
 	})
@@ -2765,7 +2765,7 @@ func (s *snapmgrTestSuite) TestUpdateNoStoreResultsWithChannelChange(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
-		Sequence:        []*snap.SideInfo{&si},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		TrackingChannel: "channel-for-9/stable",
 		Current:         si.Revision,
 	})
@@ -2786,7 +2786,7 @@ func (s *snapmgrTestSuite) TestUpdateSameRevisionSwitchesChannel(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
-		Sequence:        []*snap.SideInfo{&si},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		TrackingChannel: "other-chanenl/stable",
 		Current:         si.Revision,
 	})
@@ -2809,7 +2809,7 @@ func (s *snapmgrTestSuite) TestUpdateSameRevisionSwitchesChannelConflict(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
-		Sequence:        []*snap.SideInfo{&si},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		TrackingChannel: "other-channel/stable",
 		Current:         si.Revision,
 	})
@@ -2836,7 +2836,7 @@ func (s *snapmgrTestSuite) TestUpdateSameRevisionSwitchChannelRunThrough(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
-		Sequence:        []*snap.SideInfo{&si},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		TrackingChannel: "other-channel/stable",
 		Current:         si.Revision,
 	})
@@ -2909,13 +2909,13 @@ func (s *snapmgrTestSuite) TestUpdateSameRevisionSwitchChannelRunThrough(c *C) {
 	c.Assert(err, IsNil)
 
 	c.Assert(snapst.Active, Equals, true)
-	c.Assert(snapst.Sequence, HasLen, 1)
-	c.Assert(snapst.Sequence[0], DeepEquals, &snap.SideInfo{
+	c.Assert(snapst.Sequence.Revisions, HasLen, 1)
+	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "some-snap",
 		SnapID:   "some-snap-id",
 		Channel:  "channel-for-7/stable",
 		Revision: snap.R(7),
-	})
+	}, nil))
 }
 
 func (s *snapmgrTestSuite) TestUpdateSameRevisionToggleIgnoreValidation(c *C) {
@@ -2930,7 +2930,7 @@ func (s *snapmgrTestSuite) TestUpdateSameRevisionToggleIgnoreValidation(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
-		Sequence:        []*snap.SideInfo{&si},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		TrackingChannel: "channel-for-7/stable",
 		Current:         si.Revision,
 	})
@@ -2953,7 +2953,7 @@ func (s *snapmgrTestSuite) TestUpdateSameRevisionToggleIgnoreValidationConflict(
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
-		Sequence:        []*snap.SideInfo{&si},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		TrackingChannel: "channel-for-7/stable",
 		Current:         si.Revision,
 	})
@@ -2981,7 +2981,7 @@ func (s *snapmgrTestSuite) TestUpdateSameRevisionToggleIgnoreValidationRunThroug
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
-		Sequence:        []*snap.SideInfo{&si},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		TrackingChannel: "channel-for-7/stable",
 		Current:         si.Revision,
 	})
@@ -3019,13 +3019,13 @@ func (s *snapmgrTestSuite) TestUpdateSameRevisionToggleIgnoreValidationRunThroug
 	c.Assert(err, IsNil)
 
 	c.Check(snapst.Active, Equals, true)
-	c.Check(snapst.Sequence, HasLen, 1)
-	c.Check(snapst.Sequence[0], DeepEquals, &snap.SideInfo{
+	c.Check(snapst.Sequence.Revisions, HasLen, 1)
+	c.Check(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
 		RealName: "some-snap",
 		SnapID:   "some-snap-id",
 		Channel:  "channel-for-7",
 		Revision: snap.R(7),
-	})
+	}, nil))
 	c.Check(snapst.IgnoreValidation, Equals, true)
 }
 
@@ -3041,7 +3041,7 @@ func (s *snapmgrTestSuite) TestUpdateValidateRefreshesSaysNo(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{&si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		Current:  si.Revision,
 	})
 
@@ -3072,7 +3072,7 @@ func (s *snapmgrTestSuite) TestUpdateValidateRefreshesSaysNoButIgnoreValidationI
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{&si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		Current:  si.Revision,
 		SnapType: "app",
 	})
@@ -3106,7 +3106,7 @@ func (s *snapmgrTestSuite) TestUpdateIgnoreValidationSticky(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{&si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		Current:  si.Revision,
 		SnapType: "app",
 	})
@@ -3282,13 +3282,13 @@ func (s *snapmgrTestSuite) TestParallelInstanceUpdateIgnoreValidationSticky(c *C
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{&si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		Current:  si.Revision,
 		SnapType: "app",
 	})
 	snapstate.Set(s.state, "some-snap_instance", &snapstate.SnapState{
 		Active:      true,
-		Sequence:    []*snap.SideInfo{&si},
+		Sequence:    snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		Current:     si.Revision,
 		SnapType:    "app",
 		InstanceKey: "instance",
@@ -3470,7 +3470,7 @@ func (s *snapmgrTestSuite) TestUpdateFromLocal(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
-		Sequence:        []*snap.SideInfo{&si},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		TrackingChannel: "channel-for-7/stable",
 		Current:         si.Revision,
 	})
@@ -3490,7 +3490,7 @@ func (s *snapmgrTestSuite) TestUpdateAmend(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
-		Sequence:        []*snap.SideInfo{&si},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		TrackingChannel: "channel-for-7/stable",
 		Current:         si.Revision,
 	})
@@ -3519,7 +3519,7 @@ func (s *snapmgrTestSuite) TestUpdateAmendSnapNotFound(c *C) {
 
 	snapstate.Set(s.state, "snap-unknown", &snapstate.SnapState{
 		Active:          true,
-		Sequence:        []*snap.SideInfo{&si},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		TrackingChannel: "latest/stable",
 		Current:         si.Revision,
 	})
@@ -3546,7 +3546,7 @@ func (s *snapmgrTestSuite) TestSingleUpdateBlockedRevision(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{&si7, &si11},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si7, &si11}),
 		Current:  si7.Revision,
 		SnapType: "app",
 	})
@@ -3586,7 +3586,7 @@ func (s *snapmgrTestSuite) TestMultiUpdateBlockedRevision(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{&si7, &si11},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si7, &si11}),
 		Current:  si7.Revision,
 		SnapType: "app",
 	})
@@ -3627,7 +3627,7 @@ func (s *snapmgrTestSuite) TestAllUpdateBlockedRevision(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{&si7, &si11},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si7, &si11}),
 		Current:  si7.Revision,
 	})
 
@@ -3668,7 +3668,7 @@ func (s *snapmgrTestSuite) TestAllUpdateRevisionNotBlocked(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{&si7, &si11},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si7, &si11}),
 		Current:  si7.Revision,
 		RevertStatus: map[int]snapstate.RevertStatus{
 			si7.Revision.N: snapstate.NotBlocked,
@@ -3718,17 +3718,17 @@ func (s *snapmgrTestSuite) TestUpdateManyPartialFailureCheckRerefreshDone(c *C) 
 
 	snapstate.Set(s.state, "some-other-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-other-snap", SnapID: "some-other-snap-id", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -3815,9 +3815,9 @@ func (s *snapmgrTestSuite) TestUpdateManyAutoAliasesScenarios(c *C) {
 
 	snapstate.Set(s.state, "other-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "other-snap", SnapID: "other-snap-id", Revision: snap.R(2)},
-		},
+		}),
 		Current:  snap.R(2),
 		SnapType: "app",
 	})
@@ -3834,9 +3834,9 @@ func (s *snapmgrTestSuite) TestUpdateManyAutoAliasesScenarios(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(4)},
-		},
+		}),
 		Current:  snap.R(4),
 		SnapType: "app",
 	})
@@ -3967,9 +3967,9 @@ func (s *snapmgrTestSuite) TestUpdateOneAutoAliasesScenarios(c *C) {
 	s.fakeBackend.addSnapApp("other-snap", "cmdB")
 	snapstate.Set(s.state, "other-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "other-snap", SnapID: "other-snap-id", Revision: snap.R(2)},
-		},
+		}),
 		Current:  snap.R(2),
 		SnapType: "app",
 	})
@@ -3986,9 +3986,9 @@ func (s *snapmgrTestSuite) TestUpdateOneAutoAliasesScenarios(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(4)},
-		},
+		}),
 		Current:  snap.R(4),
 		SnapType: "app",
 	})
@@ -4116,7 +4116,7 @@ func (s *snapmgrTestSuite) TestUpdateLocalSnapFails(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{&si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		Current:  si.Revision,
 	})
 
@@ -4136,7 +4136,7 @@ func (s *snapmgrTestSuite) TestUpdateDisabledUnsupported(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   false,
-		Sequence: []*snap.SideInfo{&si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		Current:  si.Revision,
 	})
 
@@ -4158,7 +4158,7 @@ func (s *snapmgrTestSuite) TestUpdateKernelTrackChecksSwitchingTracks(c *C) {
 	defer r()
 	snapstate.Set(s.state, "kernel", &snapstate.SnapState{
 		Active:          true,
-		Sequence:        []*snap.SideInfo{&si},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		Current:         si.Revision,
 		TrackingChannel: "18/stable",
 	})
@@ -4194,7 +4194,7 @@ func (s *snapmgrTestSuite) TestUpdateGadgetTrackChecksSwitchingTracks(c *C) {
 	defer r()
 	snapstate.Set(s.state, "brand-gadget", &snapstate.SnapState{
 		Active:          true,
-		Sequence:        []*snap.SideInfo{&si},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		Current:         si.Revision,
 		TrackingChannel: "18/stable",
 	})
@@ -4232,7 +4232,7 @@ func (s *snapmgrTestSuite) TestUpdateWithDeviceContext(c *C) {
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
 		TrackingChannel: "latest/edge",
-		Sequence:        []*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}}),
 		Current:         snap.R(7),
 		SnapType:        "app",
 	})
@@ -4289,7 +4289,7 @@ func (s *snapmgrTestSuite) TestUpdatePathWithDeviceContext(c *C) {
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
 		TrackingChannel: "latest/edge",
-		Sequence:        []*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}}),
 		Current:         snap.R(7),
 		SnapType:        "app",
 	})
@@ -4324,7 +4324,7 @@ func (s *snapmgrTestSuite) TestUpdatePathWithDeviceContextSwitchChannel(c *C) {
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
 		TrackingChannel: "latest/edge",
-		Sequence:        []*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}}),
 		Current:         snap.R(7),
 		SnapType:        "app",
 	})
@@ -4355,7 +4355,7 @@ func (s *snapmgrTestSuite) TestUpdatePathWithDeviceContextBadFile(c *C) {
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
 		TrackingChannel: "latest/edge",
-		Sequence:        []*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}}),
 		Current:         snap.R(7),
 		SnapType:        "app",
 	})
@@ -4386,9 +4386,9 @@ func (s *snapmgrTestSuite) TestUpdateWithDeviceContextToRevision(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", Revision: snap.R(5), SnapID: "some-snap-id"},
-		},
+		}),
 		Current:  snap.R(5),
 		SnapType: "app",
 		UserID:   1,
@@ -4408,7 +4408,7 @@ func (s *snapmgrTestSuite) TestUpdateTasksCoreSetsIgnoreOnConfigure(c *C) {
 	snapstate.Set(s.state, "core", &snapstate.SnapState{
 		Active:          true,
 		TrackingChannel: "latest/edge",
-		Sequence:        []*snap.SideInfo{{RealName: "core", SnapID: "core-snap-id", Revision: snap.R(7)}},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "core", SnapID: "core-snap-id", Revision: snap.R(7)}}),
 		Current:         snap.R(7),
 		SnapType:        "os",
 	})
@@ -4439,7 +4439,7 @@ func (s *snapmgrTestSuite) TestUpdateDevModeConfinementFiltering(c *C) {
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
 		TrackingChannel: "channel-for-devmode/stable",
-		Sequence:        []*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}}),
 		Current:         snap.R(7),
 		SnapType:        "app",
 	})
@@ -4463,7 +4463,7 @@ func (s *snapmgrTestSuite) TestUpdateClassicConfinementFiltering(c *C) {
 
 	snapstate.Set(s.state, "some-snap-now-classic", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{{RealName: "some-snap-now-classic", SnapID: "some-snap-now-classic-id", Revision: snap.R(7)}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "some-snap-now-classic", SnapID: "some-snap-now-classic-id", Revision: snap.R(7)}}),
 		Current:  snap.R(7),
 		SnapType: "app",
 	})
@@ -4503,7 +4503,7 @@ func (s *snapmgrTestSuite) TestUpdateClassicFromClassic(c *C) {
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
 		TrackingChannel: "channel-for-classic/stable",
-		Sequence:        []*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}}),
 		Current:         snap.R(7),
 		SnapType:        "app",
 		Flags:           snapstate.Flags{Classic: true},
@@ -4572,7 +4572,7 @@ func (s *snapmgrTestSuite) TestUpdateStrictFromClassic(c *C) {
 	snapstate.Set(s.state, "some-snap-was-classic", &snapstate.SnapState{
 		Active:          true,
 		TrackingChannel: "channel/stable",
-		Sequence:        []*snap.SideInfo{{RealName: "some-snap-was-classic", SnapID: "some-snap-was-classic-id", Revision: snap.R(7)}},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "some-snap-was-classic", SnapID: "some-snap-was-classic-id", Revision: snap.R(7)}}),
 		Current:         snap.R(7),
 		SnapType:        "app",
 		Flags:           snapstate.Flags{Classic: true},
@@ -4594,7 +4594,7 @@ func (s *snapmgrTestSuite) TestUpdateChannelFallback(c *C) {
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
 		TrackingChannel: "latest/edge",
-		Sequence:        []*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}}),
 		Current:         snap.R(7),
 		SnapType:        "app",
 	})
@@ -4617,7 +4617,7 @@ func (s *snapmgrTestSuite) TestUpdateTooEarly(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}}),
 		Current:  snap.R(7),
 		SnapType: "app",
 	})
@@ -4633,7 +4633,7 @@ func (s *snapmgrTestSuite) TestUpdateConflict(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}}),
 		Current:  snap.R(7),
 		SnapType: "app",
 	})
@@ -4667,12 +4667,12 @@ func (s *snapmgrTestSuite) testUpdateCreatesGCTasks(c *C, expectedDiscards int) 
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(2)},
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(3)},
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(4)},
-		},
+		}),
 		Current:  snap.R(4),
 		SnapType: "app",
 	})
@@ -4695,12 +4695,12 @@ func (s *snapmgrTestSuite) TestUpdateCreatesDiscardAfterCurrentTasks(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(2)},
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(3)},
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(4)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -4720,7 +4720,7 @@ func (s *snapmgrTestSuite) TestUpdateManyTooEarly(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}}),
 		Current:  snap.R(7),
 		SnapType: "app",
 	})
@@ -4736,12 +4736,12 @@ func (s *snapmgrTestSuite) TestUpdateMany(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(2)},
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(3)},
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(4)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -4782,7 +4782,7 @@ func (s *snapmgrTestSuite) TestUpdateManyIgnoreRunning(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
-		Sequence:        []*snap.SideInfo{&si},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		Current:         si.Revision,
 		SnapType:        "app",
 		TrackingChannel: "latest/stable",
@@ -4819,7 +4819,7 @@ func (s *snapmgrTestSuite) TestUpdateManyTransactionally(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
-		Sequence:        []*snap.SideInfo{&si},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		Current:         si.Revision,
 		SnapType:        "app",
 		TrackingChannel: "latest/stable",
@@ -4827,7 +4827,7 @@ func (s *snapmgrTestSuite) TestUpdateManyTransactionally(c *C) {
 
 	snapstate.Set(s.state, "some-other-snap", &snapstate.SnapState{
 		Active:          true,
-		Sequence:        []*snap.SideInfo{&si2},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si2}),
 		Current:         si2.Revision,
 		SnapType:        "app",
 		TrackingChannel: "latest/stable",
@@ -4873,18 +4873,18 @@ func (s *snapmgrTestSuite) TestUpdateManyTransactionallyFails(c *C) {
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
 		TrackingChannel: "latest/edge",
-		Sequence:        []*snap.SideInfo{si},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:         snap.R(7),
 		SnapType:        "app",
 	})
 	snapstate.Set(s.state, "some-other-snap", &snapstate.SnapState{
 		Active:          true,
 		TrackingChannel: "latest/stable",
-		Sequence: []*snap.SideInfo{{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{
 			RealName: "some-other-snap",
 			SnapID:   "some-other-snap-id",
 			Revision: snap.R(1),
-		}},
+		}}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -4927,9 +4927,9 @@ func (s *snapmgrTestSuite) TestUpdateManyFailureDoesntUndoSnapdRefresh(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
-		},
+		}),
 		Current:         snap.R(1),
 		SnapType:        "app",
 		TrackingChannel: "channel-for-base/stable",
@@ -4937,27 +4937,27 @@ func (s *snapmgrTestSuite) TestUpdateManyFailureDoesntUndoSnapdRefresh(c *C) {
 
 	snapstate.Set(s.state, "core18", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "core18", SnapID: "core18-snap-id", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "base",
 	})
 
 	snapstate.Set(s.state, "some-base", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-base", SnapID: "some-base-id", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "base",
 	})
 
 	snapstate.Set(s.state, "snapd", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "snapd", SnapID: "snapd-snap-id", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -5023,7 +5023,7 @@ func (s *snapmgrTestSuite) TestUpdateManyDevModeConfinementFiltering(c *C) {
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
 		TrackingChannel: "channel-for-devmode/stable",
-		Sequence:        []*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}}),
 		Current:         snap.R(7),
 		SnapType:        "app",
 	})
@@ -5044,7 +5044,7 @@ func (s *snapmgrTestSuite) TestUpdateManyClassicConfinementFiltering(c *C) {
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
 		TrackingChannel: "channel-for-classic/stable",
-		Sequence:        []*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}}),
 		Current:         snap.R(7),
 		SnapType:        "app",
 	})
@@ -5065,7 +5065,7 @@ func (s *snapmgrTestSuite) TestUpdateManyClassic(c *C) {
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
 		TrackingChannel: "channel-for-classic/stable",
-		Sequence:        []*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}}),
 		Current:         snap.R(7),
 		SnapType:        "app",
 		Flags:           snapstate.Flags{Classic: true},
@@ -5088,7 +5088,7 @@ func (s *snapmgrTestSuite) TestUpdateManyClassicToStrict(c *C) {
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
 		TrackingChannel: "stable",
-		Sequence:        []*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}}),
 		Current:         snap.R(7),
 		SnapType:        "app",
 		Flags:           snapstate.Flags{Classic: true},
@@ -5113,9 +5113,9 @@ func (s *snapmgrTestSuite) TestUpdateManyDevMode(c *C) {
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
 		Flags:  snapstate.Flags{DevMode: true},
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -5132,9 +5132,9 @@ func (s *snapmgrTestSuite) TestUpdateAllDevMode(c *C) {
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
 		Flags:  snapstate.Flags{DevMode: true},
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -5176,27 +5176,27 @@ func (s *snapmgrTestSuite) TestUpdateManyWaitForBasesUC16(c *C) {
 
 	snapstate.Set(s.state, "core", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "core", SnapID: "core-snap-id", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "os",
 	})
 
 	snapstate.Set(s.state, "some-base", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-base", SnapID: "some-base-id", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "base",
 	})
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
-		},
+		}),
 		Current:         snap.R(1),
 		SnapType:        "app",
 		TrackingChannel: "channel-for-base/stable",
@@ -5247,36 +5247,36 @@ func (s *snapmgrTestSuite) TestUpdateManyWaitForBasesUC18(c *C) {
 
 	snapstate.Set(s.state, "core18", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "core18", SnapID: "core18-snap-id", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "base",
 	})
 
 	snapstate.Set(s.state, "some-base", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-base", SnapID: "some-base-id", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "base",
 	})
 
 	snapstate.Set(s.state, "snapd", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "snapd", SnapID: "snapd-snap-id", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
-		},
+		}),
 		Current:         snap.R(1),
 		SnapType:        "app",
 		TrackingChannel: "channel-for-base/stable",
@@ -5340,9 +5340,9 @@ func (s *validationSetsSuite) TestUpdateManyWithRevisionOpts(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -5378,9 +5378,9 @@ func (s *snapmgrTestSuite) TestUpdateManyValidateRefreshes(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -5421,22 +5421,22 @@ func (s *snapmgrTestSuite) TestParallelInstanceUpdateMany(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(2)},
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(3)},
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(4)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
 	snapstate.Set(s.state, "some-snap_instance", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(2)},
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(3)},
-		},
+		}),
 		Current:     snap.R(3),
 		SnapType:    "app",
 		InstanceKey: "instance",
@@ -5483,17 +5483,17 @@ func (s *snapmgrTestSuite) TestParallelInstanceUpdateManyValidateRefreshes(c *C)
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
 	snapstate.Set(s.state, "some-snap_instance", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
-		},
+		}),
 		Current:     snap.R(1),
 		SnapType:    "app",
 		InstanceKey: "instance",
@@ -5539,9 +5539,9 @@ func (s *snapmgrTestSuite) TestUpdateManyValidateRefreshesUnhappy(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
-		},
+		}),
 		Current: snap.R(1),
 	})
 
@@ -5604,18 +5604,18 @@ func (s *snapmgrTestSuite) testUpdateManyDiskSpaceCheck(c *C, featureFlag, failD
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
 
 	snapstate.Set(s.state, "snapd", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "snapd", SnapID: "snapd-snap-id", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -5688,7 +5688,7 @@ func (s *snapmgrTestSuite) TestUnlinkCurrentSnapLastActiveDisabledServicesSet(c 
 
 	snapstate.Set(s.state, "services-snap", &snapstate.SnapState{
 		Active:                     true,
-		Sequence:                   []*snap.SideInfo{&si},
+		Sequence:                   snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		Current:                    si.Revision,
 		SnapType:                   "app",
 		TrackingChannel:            "stable",
@@ -5745,7 +5745,7 @@ func (s *snapmgrTestSuite) TestUnlinkCurrentSnapMergedLastActiveDisabledServices
 
 	snapstate.Set(s.state, "services-snap", &snapstate.SnapState{
 		Active:                     true,
-		Sequence:                   []*snap.SideInfo{&si},
+		Sequence:                   snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		Current:                    si.Revision,
 		SnapType:                   "app",
 		TrackingChannel:            "stable",
@@ -5802,7 +5802,7 @@ func (s *snapmgrTestSuite) TestUnlinkCurrentSnapPassthroughLastActiveDisabledSer
 
 	snapstate.Set(s.state, "services-snap", &snapstate.SnapState{
 		Active:                     true,
-		Sequence:                   []*snap.SideInfo{&si},
+		Sequence:                   snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		Current:                    si.Revision,
 		SnapType:                   "app",
 		TrackingChannel:            "stable",
@@ -5852,9 +5852,9 @@ func (s *snapmgrTestSuite) TestStopSnapServicesSavesSnapSetupLastActiveDisabledS
 	}()
 
 	snapstate.Set(s.state, "services-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "services-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current: snap.R(11),
 		Active:  true,
 	})
@@ -5906,9 +5906,9 @@ func (s *snapmgrTestSuite) TestStopSnapServicesFirstSavesSnapSetupLastActiveDisa
 	}()
 
 	snapstate.Set(s.state, "services-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "services-snap", Revision: snap.R(11)},
-		},
+		}),
 		Current: snap.R(11),
 		Active:  true,
 		// leave this line to keep gofmt 1.10 happy
@@ -5954,9 +5954,9 @@ func (s *snapmgrTestSuite) TestRefreshDoesntRestoreRevisionConfig(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -6019,18 +6019,18 @@ func (s *snapmgrTestSuite) TestUpdateContentProviderDownloadFailure(c *C) {
 	snapstate.Set(s.state, "snap-content-plug", &snapstate.SnapState{
 		Active:          true,
 		TrackingChannel: "latest/edge",
-		Sequence:        []*snap.SideInfo{si},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:         snap.R(7),
 		SnapType:        "app",
 	})
 	snapstate.Set(s.state, "snap-content-slot", &snapstate.SnapState{
 		Active:          true,
 		TrackingChannel: "latest/stable",
-		Sequence: []*snap.SideInfo{{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{
 			RealName: "snap-content-slot",
 			SnapID:   "snap-content-slot-id",
 			Revision: snap.R(1),
-		}},
+		}}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -6066,9 +6066,9 @@ func (s *snapmgrTestSuite) TestNoReRefreshInUpdate(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -6112,9 +6112,9 @@ func (s *snapmgrTestSuite) TestEmptyUpdateWithChannelChangeAndAutoAlias(c *C) {
 
 	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
 		TrackingChannel: "latest/stable",
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "alias-snap", Revision: snap.R(11), SnapID: "alias-snap-id"},
-		},
+		}),
 		Current: snap.R(11),
 		Active:  true,
 	})
@@ -6175,9 +6175,9 @@ func (s *snapmgrTestSuite) testUpdateDiskSpaceCheck(c *C, featureFlag, failInsta
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(4)},
-		},
+		}),
 		Current:  snap.R(4),
 		SnapType: "app",
 	})
@@ -6236,11 +6236,11 @@ func (s *snapmgrTestSuite) TestUpdateSnapAndOutdatedPrereq(c *C) {
 	updateSnaps := []string{"outdated-consumer", "outdated-producer"}
 	for _, snapName := range updateSnaps {
 		snapstate.Set(s.state, snapName, &snapstate.SnapState{
-			Sequence: []*snap.SideInfo{{
+			Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{
 				RealName: snapName,
 				SnapID:   fmt.Sprintf("%s-id", snapName),
 				Revision: snap.R(1),
-			}},
+			}}),
 			Current: snap.R(1),
 			Active:  true,
 		})
@@ -6270,20 +6270,20 @@ func (s *snapmgrTestSuite) TestUpdatePrereqDetectConflictWithPrereq(c *C) {
 	s.state.Lock()
 
 	snapstate.Set(s.state, "outdated-producer", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{
 			RealName: "outdated-producer",
 			SnapID:   "outdated-producer-id",
 			Revision: snap.R(1),
-		}},
+		}}),
 		Current: snap.R(1),
 		Active:  false,
 	})
 	snapstate.Set(s.state, "outdated-consumer", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{
 			RealName: "outdated-consumer",
 			SnapID:   "outdated-consumer-id",
 			Revision: snap.R(1),
-		}},
+		}}),
 		Current: snap.R(1),
 		Active:  true,
 	})
@@ -6326,16 +6326,16 @@ func (s *snapmgrTestSuite) TestUpdatePrereqWithConflictingTask(c *C) {
 		Revision: snap.R(1),
 	}
 	snapstate.Set(s.state, "outdated-producer", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{prodInfo},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{prodInfo}),
 		Current:  snap.R(1),
 		Active:   true,
 	})
 	snapstate.Set(s.state, "outdated-consumer", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{
 			RealName: "outdated-consumer",
 			SnapID:   "outdated-consumer-id",
 			Revision: snap.R(1),
-		}},
+		}}),
 		Current: snap.R(1),
 		Active:  true,
 	})
@@ -6375,22 +6375,22 @@ func (s *snapmgrTestSuite) TestUpdateNoRetryIfPrereqTaskFails(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "outdated-producer", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{
 			RealName: "outdated-producer",
 			SnapID:   "outdated-producer-id",
 			Revision: snap.R(1),
-		}},
+		}}),
 		Current: snap.R(1),
 		// this will cause the update refresh to fail but the (prerequisites) task
 		// shouldn't be retried
 		Active: false,
 	})
 	snapstate.Set(s.state, "outdated-consumer", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{
 			RealName: "outdated-consumer",
 			SnapID:   "outdated-consumer-id",
 			Revision: snap.R(1),
-		}},
+		}}),
 		Current: snap.R(1),
 		Active:  true,
 	})
@@ -6421,16 +6421,16 @@ func (s *snapmgrTestSuite) TestUpdatePrereqIgnoreDuplOpInSameChange(c *C) {
 		Revision: snap.R(1),
 	}
 	snapstate.Set(s.state, "outdated-producer", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{prodInfo},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{prodInfo}),
 		Current:  snap.R(1),
 		Active:   true,
 	})
 	snapstate.Set(s.state, "outdated-consumer", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{
 			RealName: "outdated-consumer",
 			SnapID:   "outdated-consumer-id",
 			Revision: snap.R(1),
-		}},
+		}}),
 		Current: snap.R(1),
 		Active:  true,
 	})
@@ -6513,9 +6513,9 @@ func (s *validationSetsSuite) TestUpdateSnapRequiredByValidationSetAlreadyAtRequ
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(4)},
-		},
+		}),
 		Current:  snap.R(4),
 		SnapType: "app",
 	})
@@ -6553,7 +6553,7 @@ func (s *validationSetsSuite) TestUpdateSnapRequiredByValidationRefreshToRequire
 	si := &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)}
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -6623,7 +6623,7 @@ func (s *validationSetsSuite) TestUpdateSnapRequiredByValidationSetAnyRevision(c
 	si := &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)}
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -6692,7 +6692,7 @@ func (s *validationSetsSuite) TestUpdateToRevisionSnapRequiredByValidationSetAny
 	si := &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)}
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -6762,7 +6762,7 @@ func (s *validationSetsSuite) TestUpdateToRevisionSnapRequiredByValidationWithMa
 	si := &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)}
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -6831,7 +6831,7 @@ func (s *validationSetsSuite) TestUpdateToRevisionSnapRequiredByValidationAlread
 	si := &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(4)}
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  snap.R(4),
 		SnapType: "app",
 	})
@@ -6875,9 +6875,9 @@ func (s *validationSetsSuite) TestUpdateToRevisionSnapRequiredByValidationWrongR
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -6920,7 +6920,7 @@ func (s *validationSetsSuite) TestUpdateToWrongRevisionIgnoreValidation(c *C) {
 	si := &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)}
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  snap.R(1),
 		SnapType: "app",
 		Flags: snapstate.Flags{
@@ -6990,9 +6990,9 @@ func (s *validationSetsSuite) TestUpdateManyRequiredByValidationSetAlreadyAtCorr
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(5)},
-		},
+		}),
 		Current:  snap.R(5),
 		SnapType: "app",
 	})
@@ -7031,7 +7031,7 @@ func (s *validationSetsSuite) TestUpdateManyRequiredByValidationSetsCohortIgnore
 	si := &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)}
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:    true,
-		Sequence:  []*snap.SideInfo{si},
+		Sequence:  snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:   snap.R(1),
 		SnapType:  "app",
 		CohortKey: "cohortkey",
@@ -7097,7 +7097,7 @@ func (s *validationSetsSuite) TestUpdateManyRequiredByValidationSetIgnoreValidat
 	si := &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)}
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  snap.R(1),
 		SnapType: "app",
 		Flags: snapstate.Flags{
@@ -7162,9 +7162,9 @@ func (s *validationSetsSuite) TestUpdateSnapRequiredByValidationSetAlreadyAtRequ
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(4)},
-		},
+		}),
 		Current:  snap.R(4),
 		SnapType: "app",
 	})
@@ -7199,7 +7199,7 @@ func (s *validationSetsSuite) TestUpdateToRevisionWithValidationSets(c *C) {
 	si := &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)}
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -7245,20 +7245,20 @@ func (s *snapmgrTestSuite) TestUpdatePrerequisiteWithSameDeviceContext(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "outdated-producer", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{
 			RealName: "outdated-producer",
 			SnapID:   "outdated-producer-id",
 			Revision: snap.R(1),
-		}},
+		}}),
 		Current: snap.R(1),
 		Active:  true,
 	})
 	snapstate.Set(s.state, "outdated-consumer", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{
 			RealName: "outdated-consumer",
 			SnapID:   "outdated-consumer-id",
 			Revision: snap.R(1),
-		}},
+		}}),
 		Current: snap.R(1),
 		Active:  true,
 	})
@@ -7343,7 +7343,7 @@ func (s *validationSetsSuite) testUpdateManyValidationSetsPartialFailure(c *C) *
 	si1 := &snap.SideInfo{RealName: "some-snap", SnapID: "aaqKhntON3vR7kwEbVPsILm7bUViPDzx", Revision: snap.R(1)}
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si1},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si1}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -7352,7 +7352,7 @@ func (s *validationSetsSuite) testUpdateManyValidationSetsPartialFailure(c *C) *
 	si2 := &snap.SideInfo{RealName: "some-other-snap", SnapID: "bgtKhntON3vR7kwEbVPsILm7bUViPDzx", Revision: snap.R(1)}
 	snapstate.Set(s.state, "some-other-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si2},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si2}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -7466,20 +7466,20 @@ func (s *snapmgrTestSuite) TestUpdatePrerequisiteBackwardsCompat(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "outdated-producer", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{
 			RealName: "outdated-producer",
 			SnapID:   "outdated-producer-id",
 			Revision: snap.R(1),
-		}},
+		}}),
 		Current: snap.R(1),
 		Active:  true,
 	})
 	snapstate.Set(s.state, "outdated-consumer", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{
 			RealName: "outdated-consumer",
 			SnapID:   "outdated-consumer-id",
 			Revision: snap.R(1),
-		}},
+		}}),
 		Current: snap.R(1),
 		Active:  true,
 	})
@@ -7514,21 +7514,21 @@ func (s *snapmgrTestSuite) TestUpdateDeduplicatesSnapNames(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{
 			RealName: "some-snap",
 			SnapID:   "some-snap-id",
 			Revision: snap.R(1),
-		}},
+		}}),
 		Current: snap.R(1),
 		Active:  true,
 	})
 
 	snapstate.Set(s.state, "some-base", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{
 			RealName: "some-base",
 			SnapID:   "some-base-id",
 			Revision: snap.R(1),
-		}},
+		}}),
 		Current: snap.R(1),
 		Active:  true,
 	})
@@ -7552,7 +7552,7 @@ func (s *snapmgrTestSuite) TestUpdateDoHiddenDirMigration(c *C) {
 		RealName: "some-snap",
 	}
 	snapst := &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{info},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{info}),
 		Current:  info.Revision,
 		Active:   true,
 	}
@@ -7591,7 +7591,7 @@ func (s *snapmgrTestSuite) TestUndoMigrationIfUpdateFailsAfterSettingState(c *C)
 		RealName: "some-snap",
 	}
 	snapst := &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{info},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{info}),
 		Current:  info.Revision,
 		Active:   true,
 	}
@@ -7641,7 +7641,7 @@ func (s *snapmgrTestSuite) TestUndoMigrationIfUpdateFails(c *C) {
 		RealName: "some-snap",
 	}
 	snapst := &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{info},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{info}),
 		Current:  info.Revision,
 		Active:   true,
 	}
@@ -7681,7 +7681,7 @@ func (s *snapmgrTestSuite) TestUpdateAfterMigration(c *C) {
 		RealName: "some-snap",
 	}
 	snapst := &snapstate.SnapState{
-		Sequence:       []*snap.SideInfo{info},
+		Sequence:       snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{info}),
 		Current:        info.Revision,
 		Active:         true,
 		MigratedHidden: true,
@@ -7722,7 +7722,7 @@ func (s *snapmgrTestSuite) TestUpdateAfterCore22Migration(c *C) {
 		RealName: "some-snap",
 	}
 	snapst := &snapstate.SnapState{
-		Sequence:              []*snap.SideInfo{info},
+		Sequence:              snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{info}),
 		Current:               info.Revision,
 		Active:                true,
 		MigratedHidden:        true,
@@ -7787,7 +7787,7 @@ func (s *snapmgrTestSuite) testUndoRevertMigrationIfRevertFails(c *C, prepFail p
 	}
 
 	snapst := &snapstate.SnapState{
-		Sequence:       []*snap.SideInfo{info},
+		Sequence:       snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{info}),
 		Current:        info.Revision,
 		Active:         true,
 		MigratedHidden: true,
@@ -7845,7 +7845,7 @@ func (s *snapmgrTestSuite) TestRevertMigration(c *C) {
 	}
 
 	snapst := &snapstate.SnapState{
-		Sequence:       []*snap.SideInfo{info},
+		Sequence:       snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{info}),
 		Current:        info.Revision,
 		Active:         true,
 		MigratedHidden: true,
@@ -7879,7 +7879,7 @@ func (s *snapmgrTestSuite) TestUpdateDoHiddenDirMigrationOnCore22(c *C) {
 		RealName: "snap-core18-to-core22",
 	}
 	snapst := &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 		Active:   true,
 	}
@@ -7918,7 +7918,7 @@ func (s *snapmgrTestSuite) TestUndoMigrationIfUpdateToCore22FailsAfterWritingSta
 		RealName: "snap-core18-to-core22",
 	}
 	snapst := &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 		Active:   true,
 	}
@@ -7927,11 +7927,11 @@ func (s *snapmgrTestSuite) TestUndoMigrationIfUpdateToCore22FailsAfterWritingSta
 
 	// adding core22 so it's easier to find the other snap's tasks below
 	snapstate.Set(s.state, "core22", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{
 			SnapID:   "core22",
 			Revision: snap.R("2"),
 			RealName: "core22",
-		}},
+		}}),
 		Current:  snap.R("2"),
 		SnapType: "base",
 	})
@@ -7977,7 +7977,7 @@ func (s *snapmgrTestSuite) TestUndoMigrationIfUpdateToCore22Fails(c *C) {
 		RealName: "snap-core18-to-core22",
 	}
 	snapst := &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 		Active:   true,
 	}
@@ -8020,7 +8020,7 @@ func (s *snapmgrTestSuite) TestUpdateMigrateTurnOffFlagAndRefreshToCore22(c *C) 
 		RealName: "snap-core18-to-core22",
 	}
 	snapst := &snapstate.SnapState{
-		Sequence:       []*snap.SideInfo{si},
+		Sequence:       snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:        si.Revision,
 		Active:         true,
 		MigratedHidden: true,
@@ -8062,7 +8062,7 @@ func (s *snapmgrTestSuite) TestUpdateMigrateTurnOffFlagAndRefreshToCore22ButFail
 		RealName: "snap-core18-to-core22",
 	}
 	snapst := &snapstate.SnapState{
-		Sequence:       []*snap.SideInfo{si},
+		Sequence:       snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:        si.Revision,
 		Active:         true,
 		MigratedHidden: true,
@@ -8165,7 +8165,7 @@ func (s *snapmgrTestSuite) TestUndoInstallAfterDeletingRevisions(c *C) {
 	}
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: seq,
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos(seq),
 		Current:  seq[len(seq)-1].Revision,
 	})
 
@@ -8202,7 +8202,7 @@ func (s *snapmgrTestSuite) TestUndoInstallAfterDeletingRevisions(c *C) {
 	var snapst snapstate.SnapState
 	err = snapstate.Get(s.state, "some-snap", &snapst)
 	c.Assert(err, IsNil)
-	c.Assert(snapst.Sequence, DeepEquals, seq[2:])
+	c.Assert(snapst.Sequence, DeepEquals, snapstatetest.NewSequenceFromSnapSideInfos(seq[2:]))
 
 	linkTask := findLastTask(chg, "link-snap")
 	c.Check(linkTask.Status(), Equals, state.UndoneStatus)
@@ -8263,7 +8263,7 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootHappy(c *C) {
 		}
 		snapstate.Set(s.state, si.RealName, &snapstate.SnapState{
 			Active:          true,
-			Sequence:        []*snap.SideInfo{si},
+			Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 			Current:         si.Revision,
 			TrackingChannel: "latest/stable",
 			SnapType:        typ,
@@ -8360,19 +8360,19 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootHappy(c *C) {
 		c.Assert(err, IsNil)
 
 		c.Assert(snapst.Active, Equals, true)
-		c.Assert(snapst.Sequence, HasLen, 2)
-		c.Assert(snapst.Sequence[0], DeepEquals, &snap.SideInfo{
+		c.Assert(snapst.Sequence.Revisions, HasLen, 2)
+		c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
 			RealName: name,
 			SnapID:   snapID,
 			Channel:  "",
 			Revision: snap.R(7),
-		})
-		c.Assert(snapst.Sequence[1], DeepEquals, &snap.SideInfo{
+		}, nil))
+		c.Assert(snapst.Sequence.Revisions[1], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
 			RealName: name,
 			Channel:  "latest/stable",
 			SnapID:   snapID,
 			Revision: snap.R(11),
-		})
+		}, nil))
 	}
 
 	// ops come in semi random order, but we know that link and auto-connect
@@ -8453,7 +8453,7 @@ func (s *snapmgrTestSuite) TestUpdateGadgetKernelSingleRebootHappy(c *C) {
 		}
 		snapstate.Set(s.state, si.RealName, &snapstate.SnapState{
 			Active:          true,
-			Sequence:        []*snap.SideInfo{si},
+			Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 			Current:         si.Revision,
 			TrackingChannel: "latest/stable",
 			SnapType:        typ,
@@ -8550,19 +8550,19 @@ func (s *snapmgrTestSuite) TestUpdateGadgetKernelSingleRebootHappy(c *C) {
 		c.Assert(err, IsNil)
 
 		c.Assert(snapst.Active, Equals, true)
-		c.Assert(snapst.Sequence, HasLen, 2)
-		c.Assert(snapst.Sequence[0], DeepEquals, &snap.SideInfo{
+		c.Assert(snapst.Sequence.Revisions, HasLen, 2)
+		c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
 			RealName: name,
 			SnapID:   snapID,
 			Channel:  "",
 			Revision: snap.R(7),
-		})
-		c.Assert(snapst.Sequence[1], DeepEquals, &snap.SideInfo{
+		}, nil))
+		c.Assert(snapst.Sequence.Revisions[1], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
 			RealName: name,
 			Channel:  "latest/stable",
 			SnapID:   snapID,
 			Revision: snap.R(11),
-		})
+		}, nil))
 	}
 
 	// ops come in semi random order, but we know that link and auto-connect
@@ -8643,7 +8643,7 @@ func (s *snapmgrTestSuite) TestUpdateBaseGadgetSingleRebootHappy(c *C) {
 		}
 		snapstate.Set(s.state, si.RealName, &snapstate.SnapState{
 			Active:          true,
-			Sequence:        []*snap.SideInfo{si},
+			Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 			Current:         si.Revision,
 			TrackingChannel: "latest/stable",
 			SnapType:        typ,
@@ -8739,19 +8739,19 @@ func (s *snapmgrTestSuite) TestUpdateBaseGadgetSingleRebootHappy(c *C) {
 		c.Assert(err, IsNil)
 
 		c.Assert(snapst.Active, Equals, true)
-		c.Assert(snapst.Sequence, HasLen, 2)
-		c.Assert(snapst.Sequence[0], DeepEquals, &snap.SideInfo{
+		c.Assert(snapst.Sequence.Revisions, HasLen, 2)
+		c.Assert(snapst.Sequence.Revisions[0], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
 			RealName: name,
 			SnapID:   snapID,
 			Channel:  "",
 			Revision: snap.R(7),
-		})
-		c.Assert(snapst.Sequence[1], DeepEquals, &snap.SideInfo{
+		}, nil))
+		c.Assert(snapst.Sequence.Revisions[1], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
 			RealName: name,
 			Channel:  "latest/stable",
 			SnapID:   snapID,
 			Revision: snap.R(11),
-		})
+		}, nil))
 	}
 
 	// ops come in semi random order, but we know that link and auto-connect
@@ -8822,7 +8822,7 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootWithCannotRebootSetHa
 		}
 		snapstate.Set(s.state, si.RealName, &snapstate.SnapState{
 			Active:          true,
-			Sequence:        []*snap.SideInfo{si},
+			Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 			Current:         si.Revision,
 			TrackingChannel: "latest/stable",
 			SnapType:        typ,
@@ -8920,7 +8920,7 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootUnsupportedWithCoreHa
 		}
 		snapstate.Set(s.state, si.RealName, &snapstate.SnapState{
 			Active:          true,
-			Sequence:        []*snap.SideInfo{si},
+			Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 			Current:         si.Revision,
 			TrackingChannel: "latest/stable",
 			SnapType:        typ,
@@ -9003,13 +9003,13 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootUnsupportedWithCoreHa
 		c.Assert(err, IsNil)
 
 		c.Assert(snapst.Active, Equals, true)
-		c.Assert(snapst.Sequence, HasLen, 2)
-		c.Assert(snapst.Sequence[1], DeepEquals, &snap.SideInfo{
+		c.Assert(snapst.Sequence.Revisions, HasLen, 2)
+		c.Assert(snapst.Sequence.Revisions[1], DeepEquals, snapstate.NewRevisionSideInfo(&snap.SideInfo{
 			RealName: name,
 			Channel:  "latest/stable",
 			SnapID:   snapID,
 			Revision: snap.R(11),
-		})
+		}, nil))
 	}
 }
 
@@ -9059,7 +9059,7 @@ func (s *snapmgrTestSuite) TestUpdateBaseGadgetKernelSingleReboot(c *C) {
 		}
 		snapstate.Set(s.state, si.RealName, &snapstate.SnapState{
 			Active:          true,
-			Sequence:        []*snap.SideInfo{si},
+			Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 			Current:         si.Revision,
 			TrackingChannel: "latest/stable",
 			SnapType:        typ,
@@ -9182,7 +9182,7 @@ func (s *snapmgrTestSuite) TestUpdateBaseKernelSingleRebootUndone(c *C) {
 		}
 		snapstate.Set(s.state, si.RealName, &snapstate.SnapState{
 			Active:          true,
-			Sequence:        []*snap.SideInfo{si},
+			Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 			Current:         si.Revision,
 			TrackingChannel: "latest/stable",
 			SnapType:        typ,
@@ -9361,7 +9361,7 @@ func (s *snapmgrTestSuite) TestUpdateBaseGadgetKernelSingleRebootUndone(c *C) {
 		}
 		snapstate.Set(s.state, si.RealName, &snapstate.SnapState{
 			Active:          true,
-			Sequence:        []*snap.SideInfo{si},
+			Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 			Current:         si.Revision,
 			TrackingChannel: "latest/stable",
 			SnapType:        typ,
@@ -9540,7 +9540,7 @@ func (s *snapmgrTestSuite) testUpdateEssentialSnapsOrder(c *C, order []string) {
 		snaptest.MockSnap(c, snapYaml, si)
 		snapstate.Set(s.state, sn, &snapstate.SnapState{
 			Active:          true,
-			Sequence:        []*snap.SideInfo{si},
+			Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 			Current:         si.Revision,
 			TrackingChannel: "latest/stable",
 			SnapType:        types[sn],
@@ -9779,7 +9779,7 @@ func (s *snapmgrTestSuite) TestUpdateBaseAndSnapdOrder(c *C) {
 	snaptest.MockSnap(c, "name: snapd\nversion: 1.2.3\ntype: snapd", siSnapd)
 	snapstate.Set(s.state, "snapd", &snapstate.SnapState{
 		Active:          true,
-		Sequence:        []*snap.SideInfo{siSnapd},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siSnapd}),
 		Current:         siSnapd.Revision,
 		TrackingChannel: "latest/stable",
 		SnapType:        "snapd",
@@ -9788,7 +9788,7 @@ func (s *snapmgrTestSuite) TestUpdateBaseAndSnapdOrder(c *C) {
 	snaptest.MockSnap(c, "name: core18\nversion: 1.2.3\ntype: base", siBase)
 	snapstate.Set(s.state, "core18", &snapstate.SnapState{
 		Active:          true,
-		Sequence:        []*snap.SideInfo{siBase},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{siBase}),
 		Current:         siBase.Revision,
 		TrackingChannel: "latest/stable",
 		SnapType:        "base",
@@ -9858,7 +9858,7 @@ func (s *snapmgrTestSuite) TestUpdateConsidersProvenance(c *C) {
 	snapstate.Set(s.state, "provenance-snap", &snapstate.SnapState{
 		Active:          true,
 		TrackingChannel: "latest/edge",
-		Sequence:        []*snap.SideInfo{{RealName: "provenance-snap", SnapID: "provenance-snap-id", Revision: snap.R(7)}},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "provenance-snap", SnapID: "provenance-snap-id", Revision: snap.R(7)}}),
 		Current:         snap.R(7),
 		SnapType:        "app",
 	})
@@ -9888,7 +9888,7 @@ func (s *snapmgrTestSuite) TestGeneralRefreshSkipsGatedSnaps(c *C) {
 		snaptest.MockSnap(c, `name: some-snap`, si)
 		snapstate.Set(s.state, name, &snapstate.SnapState{
 			Active:   true,
-			Sequence: []*snap.SideInfo{si},
+			Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 			Current:  si.Revision,
 		})
 	}
@@ -9935,7 +9935,7 @@ func (s *snapmgrTestSuite) TestUpdateManyTransactionalWithLane(c *C) {
 		snaptest.MockSnap(c, `name: some-snap`, si)
 		snapstate.Set(s.state, name, &snapstate.SnapState{
 			Active:   true,
-			Sequence: []*snap.SideInfo{si},
+			Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 			Current:  si.Revision,
 		})
 	}
@@ -9974,7 +9974,7 @@ func (s *snapmgrTestSuite) TestUpdateManyLaneErrorsWithLaneButNoTransaction(c *C
 		snaptest.MockSnap(c, `name: some-snap`, si)
 		snapstate.Set(s.state, name, &snapstate.SnapState{
 			Active:   true,
-			Sequence: []*snap.SideInfo{si},
+			Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 			Current:  si.Revision,
 		})
 	}
@@ -10010,7 +10010,7 @@ func (s *snapmgrTestSuite) TestUpdateTransactionalWithLane(c *C) {
 	snaptest.MockSnap(c, `name: some-snap`, si)
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 	})
 
@@ -10048,7 +10048,7 @@ func (s *snapmgrTestSuite) TestUpdateLaneErrorsWithLaneButNoTransaction(c *C) {
 	snaptest.MockSnap(c, `name: some-snap`, si)
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 	})
 
@@ -10074,7 +10074,7 @@ func (s *snapmgrTestSuite) TestConditionalAutoRefreshCreatesPreDownloadChange(c 
 	si := &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)}
 	snapst := &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 		SnapType: string(snap.TypeApp),
 	}
@@ -10121,7 +10121,7 @@ func (s *snapmgrTestSuite) TestAutoRefreshCreatePreDownload(c *C) {
 	si := &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)}
 	snapst := &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 		SnapType: string(snap.TypeApp),
 	}
@@ -10159,7 +10159,7 @@ func (s *snapmgrTestSuite) TestAutoRefreshBusySnapButOngoingPreDownload(c *C) {
 	si := &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)}
 	snapst := &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 		SnapType: string(snap.TypeApp),
 	}
@@ -10211,7 +10211,7 @@ func (s *snapmgrTestSuite) TestReRefreshCreatesPreDownloadChange(c *C) {
 	si := &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)}
 	snapst := &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 		SnapType: string(snap.TypeApp),
 	}
@@ -10384,7 +10384,7 @@ func (s *snapmgrTestSuite) TestPreDownloadTaskContinuesAutoRefreshIfSoftCheckOk(
 	snaptest.MockSnap(c, `name: foo`, si)
 	snapstate.Set(s.state, "foo", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 	})
 
@@ -10446,7 +10446,7 @@ func (s *snapmgrTestSuite) TestDownloadTaskMonitorsSnapStoppedAndNotifiesOnSoftC
 	snaptest.MockSnap(c, `name: foo`, si)
 	snapstate.Set(s.state, "foo", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 	})
 	snapsup := &snapstate.SnapSetup{
@@ -10553,7 +10553,7 @@ func (s *snapmgrTestSuite) TestDownloadTaskMonitorsRepeated(c *C) {
 	snaptest.MockSnap(c, `name: foo`, si)
 	snapstate.Set(s.state, "foo", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 	})
 	snapsup := &snapstate.SnapSetup{
@@ -10654,7 +10654,7 @@ func (s *snapmgrTestSuite) TestUnlinkMonitorSnapOnHardCheckFailure(c *C) {
 	snaptest.MockSnap(c, `name: some-snap`, si)
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 	})
 
@@ -10738,7 +10738,7 @@ func (s *snapmgrTestSuite) TestDeletedMonitoredMapIsCorrectlyDeleted(c *C) {
 	snaptest.MockSnap(c, `name: foo`, si)
 	snapstate.Set(s.state, "foo", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 	})
 	snapsup := &snapstate.SnapSetup{
@@ -10847,7 +10847,7 @@ func (s *snapmgrTestSuite) TestPreDownloadWithIgnoreRunningRefresh(c *C) {
 	snaptest.MockSnap(c, `name: some-snap`, si)
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 	})
 	snapsup := &snapstate.SnapSetup{
@@ -10941,7 +10941,7 @@ func (s *snapmgrTestSuite) TestRefreshNoRelatedMonitoring(c *C) {
 	snaptest.MockSnap(c, `name: some-snap`, si)
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 	})
 	s.state.Cache("monitored-snaps", map[string]context.CancelFunc{"other-snap": func() {}})
@@ -10969,7 +10969,7 @@ func (s *snapmgrTestSuite) TestMonitoringIsPersistedAndRestored(c *C) {
 	snaptest.MockSnap(c, `name: some-snap`, si)
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 	})
 	snapsup := &snapstate.SnapSetup{
@@ -11051,7 +11051,7 @@ func (s *snapmgrTestSuite) testNoMonitoringWithCands(c *C, cands map[string]*sna
 	snaptest.MockSnap(c, `name: some-snap`, si)
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{si},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
 		Current:  si.Revision,
 	})
 	snapsup := &snapstate.SnapSetup{
@@ -11158,7 +11158,7 @@ func (s *snapmgrTestSuite) testUpdateDowngradeBlockedByOtherChanges(c *C, old, n
 
 	snapstate.Set(s.state, "snapd", &snapstate.SnapState{
 		Active:          true,
-		Sequence:        []*snap.SideInfo{&si1, &si2, &si3},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si1, &si2, &si3}),
 		TrackingChannel: "latest/stable",
 		Current:         si2.Revision,
 	})
@@ -11254,13 +11254,13 @@ func (s *snapmgrTestSuite) testUpdateNotAllowedWhileDowngrading(c *C, old, new s
 
 	snapstate.Set(s.state, "snapd", &snapstate.SnapState{
 		Active:          true,
-		Sequence:        []*snap.SideInfo{&si1, &si2, &si3},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si1, &si2, &si3}),
 		TrackingChannel: "latest/stable",
 		Current:         si2.Revision,
 	})
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:          true,
-		Sequence:        []*snap.SideInfo{&si},
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&si}),
 		TrackingChannel: "other-chanel/stable",
 		Current:         si.Revision,
 	})
@@ -11325,12 +11325,12 @@ func (s *snapmgrTestSuite) TestUpdateSetsRestartBoundaries(c *C) {
 	defer r()
 	snapstate.Set(s.state, "brand-gadget", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{&siGadget},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&siGadget}),
 		Current:  siGadget.Revision,
 	})
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
-		Sequence: []*snap.SideInfo{&siSomeSnap},
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&siSomeSnap}),
 		Current:  siSomeSnap.Revision,
 	})
 
@@ -11357,25 +11357,25 @@ func (s *snapmgrTestSuite) TestUpdateSetsRestartBoundaries(c *C) {
 func (s *snapmgrTestSuite) testUpdateManyRevOptsOrder(c *C, isThrottled map[string]bool) {
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
 	snapstate.Set(s.state, "some-other-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-other-snap", SnapID: "some-other-snap-id", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
 	snapstate.Set(s.state, "snap-c", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "snap-c", SnapID: "snap-c-id", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -11459,9 +11459,9 @@ func (s *snapmgrTestSuite) TestSnapdRefreshForRemodel(c *C) {
 	snapstate.Set(s.state, "snapd", &snapstate.SnapState{
 		Active:          true,
 		TrackingChannel: "latest/edge",
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "snapd", SnapID: "snapd-snap-id", Revision: snap.R(44)},
-			{RealName: "snapd", SnapID: "snapd-snap-id", Revision: snap.R(22)}},
+			{RealName: "snapd", SnapID: "snapd-snap-id", Revision: snap.R(22)}}),
 		Current:  snap.R(44),
 		SnapType: "app",
 	})
@@ -11538,17 +11538,17 @@ func (s *snapmgrTestSuite) TestUpdateManyFilteredForSnapsNotInOldHints(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
 	snapstate.Set(s.state, "some-other-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-other-snap", SnapID: "some-other-snap-id", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
@@ -11617,17 +11617,17 @@ func (s *snapmgrTestSuite) TestUpdateManyFilteredNotAutoRefreshNoRetry(c *C) {
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})
 	snapstate.Set(s.state, "some-other-snap", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "some-other-snap", SnapID: "some-other-snap-id", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "app",
 	})

--- a/overlord/snapstate/snapstatetest/snapstate.go
+++ b/overlord/snapstate/snapstatetest/snapstate.go
@@ -1,0 +1,37 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstatetest
+
+import (
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/snap"
+)
+
+func NewSequenceFromSnapSideInfos(snapSideInfo []*snap.SideInfo) snapstate.SnapSequence {
+	revSis := make([]*snapstate.RevisionSideState, len(snapSideInfo))
+	for i, si := range snapSideInfo {
+		revSis[i] = snapstate.NewRevisionSideInfo(si, nil)
+	}
+	return snapstate.SnapSequence{Revisions: revSis}
+}
+
+func NewSequenceFromRevisionSideInfos(revsSideInfo []*snapstate.RevisionSideState) snapstate.SnapSequence {
+	return snapstate.SnapSequence{Revisions: revsSideInfo}
+}

--- a/overlord/snapstate/storehelpers_test.go
+++ b/overlord/snapstate/storehelpers_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
@@ -158,9 +159,9 @@ func (f installSizeTestStore) SnapAction(ctx context.Context, currentSnaps []*st
 func (s *snapmgrTestSuite) mockCoreSnap(c *C) {
 	snapstate.Set(s.state, "core", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "core", SnapID: "core-id", Revision: snap.R(1)},
-		},
+		}),
 		Current:  snap.R(1),
 		SnapType: "os",
 	})
@@ -228,9 +229,9 @@ func (s *snapmgrTestSuite) TestInstallSizeWithBases(c *C) {
 	// base of some-snap4 is already installed
 	snapstate.Set(st, "yet-another-base", &snapstate.SnapState{
 		Active: true,
-		Sequence: []*snap.SideInfo{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
 			{RealName: "yet-another-base", Revision: snap.R(1), SnapID: "yet-another-base-id"},
-		},
+		}),
 		Current: snap.R(1),
 	})
 

--- a/snap/component.go
+++ b/snap/component.go
@@ -33,6 +33,14 @@ type ComponentInfo struct {
 	Description string              `yaml:"description"`
 }
 
+// ComponentSideInfo is the equivalent of SideInfo for components, and
+// includes relevant information for which the canonical source is a
+// snap store.
+type ComponentSideInfo struct {
+	Component naming.ComponentRef `json:"component"`
+	Revision  Revision            `json:"revision"`
+}
+
 // ReadComponentInfoFromContainer reads ComponentInfo from a snap component container.
 func ReadComponentInfoFromContainer(compf Container) (*ComponentInfo, error) {
 	yamlData, err := compf.ReadFile("meta/component.yaml")

--- a/snap/info.go
+++ b/snap/info.go
@@ -282,19 +282,19 @@ func SnapDir(home string, opts *dirs.SnapDirOptions) string {
 // from the store but is not required for working offline should not
 // end up in SideInfo.
 type SideInfo struct {
-	RealName    string              `yaml:"name,omitempty" json:"name,omitempty"`
-	SnapID      string              `yaml:"snap-id" json:"snap-id"`
-	Revision    Revision            `yaml:"revision" json:"revision"`
-	Channel     string              `yaml:"channel,omitempty" json:"channel,omitempty"`
-	EditedLinks map[string][]string `yaml:"links,omitempty" json:"links,omitempty"`
+	RealName    string              `json:"name,omitempty"`
+	SnapID      string              `json:"snap-id"`
+	Revision    Revision            `json:"revision"`
+	Channel     string              `json:"channel,omitempty"`
+	EditedLinks map[string][]string `json:"links,omitempty"`
 	// subsumed by EditedLinks, by need to set for if we revert
 	// to old snapd
-	LegacyEditedContact string `yaml:"contact,omitempty" json:"contact,omitempty"`
-	EditedTitle         string `yaml:"title,omitempty" json:"title,omitempty"`
-	EditedSummary       string `yaml:"summary,omitempty" json:"summary,omitempty"`
-	EditedDescription   string `yaml:"description,omitempty" json:"description,omitempty"`
-	Private             bool   `yaml:"private,omitempty" json:"private,omitempty"`
-	Paid                bool   `yaml:"paid,omitempty" json:"paid,omitempty"`
+	LegacyEditedContact string `json:"contact,omitempty"`
+	EditedTitle         string `json:"title,omitempty"`
+	EditedSummary       string `json:"summary,omitempty"`
+	EditedDescription   string `json:"description,omitempty"`
+	Private             bool   `json:"private,omitempty"`
+	Paid                bool   `json:"paid,omitempty"`
 }
 
 // Info provides information about snaps.

--- a/snap/naming/componentref.go
+++ b/snap/naming/componentref.go
@@ -26,8 +26,8 @@ import (
 
 // ComponentRef contains the component name and the owner snap name.
 type ComponentRef struct {
-	SnapName      string
-	ComponentName string
+	SnapName      string `yaml:"snap-name" json:"snap-name"`
+	ComponentName string `yaml:"component-name" json:"component-name"`
 }
 
 // NewComponentRef returns a reference to a snap component.


### PR DESCRIPTION
Add components information to the snap state. This is included in the Sequence variable, so we need to handle in a special way the marshaling to keep compatibility with state files created by older snapd versions.

The change to the Sequence field implies multiple changes in tests that use it. Ancillary methods to handle this have been created.
