### PR TITLE
tests: fix snap-run test for fedora

### DIFF
--- a/tests/main/snap-run/task.yaml
+++ b/tests/main/snap-run/task.yaml
@@ -50,7 +50,7 @@ execute: |
         echo "snap run with an invalid strace option should fail but it did not"
         exit 1
     fi
-    if os.query is-arch-linux || os.query is-opensuse tumbleweed; then
+    if os.query is-arch-linux || os.query is-opensuse tumbleweed || os.query is-fedora; then
         MATCH "Cannot find executable 'invalid'" < stderr
     else
         MATCH "Can't stat 'invalid': No such file or directory" < stderr


### PR DESCRIPTION
Support a new error message displayed when executable is not found.

Similar to https://github.com/snapcore/snapd/pull/13356
