### PR TITLE
daemon: allow polkit "io.snapcraft.snapd.manage" for /v2/apps endpoint

### DIFF
--- a/daemon/api_apps.go
+++ b/daemon/api_apps.go
@@ -44,7 +44,7 @@ var (
 		GET:         getAppsInfo,
 		POST:        postApps,
 		ReadAccess:  openAccess{},
-		WriteAccess: authenticatedAccess{},
+		WriteAccess: authenticatedAccess{Polkit: polkitActionManage},
 	}
 
 	logsCmd = &Command{

--- a/daemon/api_apps_test.go
+++ b/daemon/api_apps_test.go
@@ -167,6 +167,12 @@ func (s *appsSuite) SetUpTest(c *check.C) {
 	d.Overlord().Loop()
 	s.AddCleanup(func() { d.Overlord().Stop() })
 	s.AddCleanup(systemd.MockSystemdVersion(237, nil))
+	s.expectAppsAccess()
+}
+
+func (s *appsSuite) expectAppsAccess() {
+	s.expectOpenAccess()
+	s.expectWriteAccess(daemon.AuthenticatedAccess{Polkit: "io.snapcraft.snapd.manage"})
 }
 
 func (s *appsSuite) TestSplitAppName(c *check.C) {


### PR DESCRIPTION
As a part of the user-daemons support for services:

I want to allow polkit for the /v2/apps endpoint to allow non-root users to access the service API by interacting with polkit. This also enabled me to test non-root functionality in spread by using polkit policies. (See usage here: https://github.com/snapcore/snapd/pull/13368/files#diff-2521ae83c7dfc63ca503b0ea7c20fbf3ae285aaabfa8168355f15aa1f6ac4d53)

This of course may have other implications, and I want to get feedback on enabling polkit access to /v2/apps for "io.snapcraft.snapd.manage" scope.