### PR TITLE
client,cmd/snap: introduce --user, --system and --users switches for snap service operations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # In progress:
 * Installation of local snap components
-* Started improving support for user daemons by introducing new control switches --user/--users/--system for service operations
+* Started support for snap services to show real status of user daemons
 
 # Next:
 * state: add support for notices (from pebble)
@@ -8,6 +8,7 @@
 * Mandatory device cgroup for all snaps using bare and core24 base as well as future bases
 * Added API route for creating recovery systems: POST to `/v2/systems` with action `create`
 * Added API route for removing recovery systems: POST to `/v2/systems/{label}` with action `remove`
+* Support for user daemons by introducing new control switches --user/--system/--users for service start/stop/restart
 
 # New in snapd 2.61.3:
 * Install systemd files in correct location for 24.04

--- a/client/apps.go
+++ b/client/apps.go
@@ -188,8 +188,10 @@ func (client *Client) Logs(names []string, opts LogOptions) (<-chan Log, error) 
 var ErrNoNames = errors.New(`"names" must not be empty`)
 
 type appInstruction struct {
-	Action string   `json:"action"`
-	Names  []string `json:"names"`
+	Action          string   `json:"action"`
+	Names           []string `json:"names"`
+	Scope           []string `json:"scope,omitempty"`
+	ServicesOfUsers []string `json:"user-services-of,omitempty"`
 	StartOptions
 	StopOptions
 	RestartOptions
@@ -207,15 +209,17 @@ type StartOptions struct {
 // It takes a list of names that can be snaps, of which all their
 // services are started, or snap.service which are individual
 // services to start; it shouldn't be empty.
-func (client *Client) Start(names []string, opts StartOptions) (changeID string, err error) {
+func (client *Client) Start(names []string, scope []string, users []string, opts StartOptions) (changeID string, err error) {
 	if len(names) == 0 {
 		return "", ErrNoNames
 	}
 
 	buf, err := json.Marshal(appInstruction{
-		Action:       "start",
-		Names:        names,
-		StartOptions: opts,
+		Action:          "start",
+		Names:           names,
+		Scope:           scope,
+		ServicesOfUsers: users,
+		StartOptions:    opts,
 	})
 	if err != nil {
 		return "", err
@@ -235,15 +239,17 @@ type StopOptions struct {
 // It takes a list of names that can be snaps, of which all their
 // services are stopped, or snap.service which are individual
 // services to stop; it shouldn't be empty.
-func (client *Client) Stop(names []string, opts StopOptions) (changeID string, err error) {
+func (client *Client) Stop(names []string, scope []string, users []string, opts StopOptions) (changeID string, err error) {
 	if len(names) == 0 {
 		return "", ErrNoNames
 	}
 
 	buf, err := json.Marshal(appInstruction{
-		Action:      "stop",
-		Names:       names,
-		StopOptions: opts,
+		Action:          "stop",
+		Names:           names,
+		Scope:           scope,
+		ServicesOfUsers: users,
+		StopOptions:     opts,
 	})
 	if err != nil {
 		return "", err
@@ -264,15 +270,17 @@ type RestartOptions struct {
 // services are restarted, or snap.service which are individual
 // services to restart; it shouldn't be empty. If the service is not
 // running, starts it.
-func (client *Client) Restart(names []string, opts RestartOptions) (changeID string, err error) {
+func (client *Client) Restart(names []string, scope []string, users []string, opts RestartOptions) (changeID string, err error) {
 	if len(names) == 0 {
 		return "", ErrNoNames
 	}
 
 	buf, err := json.Marshal(appInstruction{
-		Action:         "restart",
-		Names:          names,
-		RestartOptions: opts,
+		Action:          "restart",
+		Names:           names,
+		Scope:           scope,
+		ServicesOfUsers: users,
+		RestartOptions:  opts,
 	})
 	if err != nil {
 		return "", err

--- a/client/apps.go
+++ b/client/apps.go
@@ -295,8 +295,8 @@ var ErrNoNames = errors.New(`"names" must not be empty`)
 type appInstruction struct {
 	Action string        `json:"action"`
 	Names  []string      `json:"names"`
-	Scope  ScopeSelector `json:"scope"`
-	Users  UserSelector  `json:"users"`
+	Scope  ScopeSelector `json:"scope,omitempty"`
+	Users  UserSelector  `json:"users,omitempty"`
 	StartOptions
 	StopOptions
 	RestartOptions

--- a/client/apps_test.go
+++ b/client/apps_test.go
@@ -217,64 +217,112 @@ func (cs *clientSuite) TestClientLogsNotFound(c *check.C) {
 	c.Check(actual, check.HasLen, 0)
 }
 
+func (cs *clientSuite) checkCommonFields(c *check.C, reqOp map[string]interface{}, names, scope, users []string, comment check.CommentInterface) {
+	inames := make([]interface{}, len(names))
+	for i, name := range names {
+		inames[i] = interface{}(name)
+	}
+
+	c.Check(reqOp["names"], check.DeepEquals, inames, comment)
+	if len(scope) > 0 {
+		snames := make([]interface{}, len(scope))
+		for i, scope := range scope {
+			snames[i] = interface{}(scope)
+		}
+		c.Check(reqOp["scope"], check.DeepEquals, snames, comment)
+	} else {
+		c.Check(reqOp["scope"], check.IsNil, comment)
+	}
+	if len(users) > 0 {
+		unames := make([]interface{}, len(users))
+		for i, u := range users {
+			unames[i] = interface{}(u)
+		}
+		c.Check(reqOp["user-services-of"], check.DeepEquals, unames, comment)
+	} else {
+		c.Check(reqOp["user-services-of"], check.IsNil, comment)
+	}
+}
+
 func (cs *clientSuite) TestClientServiceStart(c *check.C) {
 	cs.status = 202
 	cs.rsp = `{"type": "async", "status-code": 202, "change": "24"}`
 
-	type scenario struct {
-		names   []string
-		opts    client.StartOptions
-		comment check.CommentInterface
+	tests := []struct {
+		names []string
+		scope []string
+		users []string
+		opts  client.StartOptions
+	}{
+		{},
+		{
+			opts: client.StartOptions{
+				Enable: true,
+			},
+		},
+		{
+			names: []string{"foo"},
+		},
+		{
+			names: []string{"foo"},
+			opts: client.StartOptions{
+				Enable: true,
+			},
+		},
+		{
+			names: []string{"foo", "bar", "baz"},
+		},
+		{
+			names: []string{"foo", "bar", "baz"},
+			opts: client.StartOptions{
+				Enable: true,
+			},
+		},
+		{
+			names: []string{"foo"},
+			scope: []string{"user"},
+		},
+		{
+			names: []string{"foo"},
+			scope: []string{"system"},
+		},
+		{
+			names: []string{"foo"},
+			scope: []string{"system", "user"},
+		},
+		{
+			names: []string{"foo"},
+			users: []string{"user"},
+		},
+		{
+			names: []string{"foo"},
+			users: []string{"users"},
+		},
 	}
 
-	var scenarios []scenario
-
-	for _, names := range [][]string{
-		nil, {},
-		{"foo"},
-		{"foo", "bar", "baz"},
-	} {
-		for _, opts := range []client.StartOptions{
-			{Enable: true},
-			{Enable: false},
-		} {
-			scenarios = append(scenarios, scenario{
-				names:   names,
-				opts:    opts,
-				comment: check.Commentf("{%q; %#v}", names, opts),
-			})
-		}
-	}
-
-	for _, sc := range scenarios {
-		id, err := cs.cli.Start(sc.names, sc.opts)
+	for _, sc := range tests {
+		comment := check.Commentf("{%q; %q; %q; %#v}", sc.names, sc.scope, sc.users, sc.opts)
+		id, err := cs.cli.Start(sc.names, sc.scope, sc.users, sc.opts)
 		if len(sc.names) == 0 {
-			c.Check(id, check.Equals, "", sc.comment)
-			c.Check(err, check.Equals, client.ErrNoNames, sc.comment)
-			c.Check(cs.req, check.IsNil, sc.comment) // i.e. the request was never done
+			c.Check(id, check.Equals, "", comment)
+			c.Check(err, check.Equals, client.ErrNoNames, comment)
+			c.Check(cs.req, check.IsNil, comment) // i.e. the request was never done
 		} else {
-			c.Assert(err, check.IsNil, sc.comment)
-			c.Check(id, check.Equals, "24", sc.comment)
-			c.Check(cs.req.URL.Path, check.Equals, "/v2/apps", sc.comment)
-			c.Check(cs.req.Method, check.Equals, "POST", sc.comment)
-			c.Check(cs.req.URL.Query(), check.HasLen, 0, sc.comment)
-
-			inames := make([]interface{}, len(sc.names))
-			for i, name := range sc.names {
-				inames[i] = interface{}(name)
-			}
+			c.Assert(err, check.IsNil, comment)
+			c.Check(id, check.Equals, "24", comment)
+			c.Check(cs.req.URL.Path, check.Equals, "/v2/apps", comment)
+			c.Check(cs.req.Method, check.Equals, "POST", comment)
+			c.Check(cs.req.URL.Query(), check.HasLen, 0, comment)
 
 			var reqOp map[string]interface{}
-			c.Assert(json.NewDecoder(cs.req.Body).Decode(&reqOp), check.IsNil, sc.comment)
+			c.Assert(json.NewDecoder(cs.req.Body).Decode(&reqOp), check.IsNil, comment)
+			c.Check(reqOp["action"], check.Equals, "start", comment)
+			cs.checkCommonFields(c, reqOp, sc.names, sc.scope, sc.users, comment)
 			if sc.opts.Enable {
-				c.Check(len(reqOp), check.Equals, 3, sc.comment)
-				c.Check(reqOp["enable"], check.Equals, true, sc.comment)
+				c.Check(reqOp["enable"], check.Equals, true, comment)
 			} else {
-				c.Check(len(reqOp), check.Equals, 2, sc.comment)
-				c.Check(reqOp["enable"], check.IsNil, sc.comment)
+				c.Check(reqOp["enable"], check.IsNil, comment)
 			}
-			c.Check(reqOp["action"], check.Equals, "start", sc.comment)
-			c.Check(reqOp["names"], check.DeepEquals, inames, sc.comment)
 		}
 	}
 }
@@ -283,60 +331,81 @@ func (cs *clientSuite) TestClientServiceStop(c *check.C) {
 	cs.status = 202
 	cs.rsp = `{"type": "async", "status-code": 202, "change": "24"}`
 
-	type tT struct {
-		names   []string
-		opts    client.StopOptions
-		comment check.CommentInterface
+	tests := []struct {
+		names []string
+		scope []string
+		users []string
+		opts  client.StopOptions
+	}{
+		{},
+		{
+			opts: client.StopOptions{
+				Disable: true,
+			},
+		},
+		{
+			names: []string{"foo"},
+		},
+		{
+			names: []string{"foo"},
+			opts: client.StopOptions{
+				Disable: true,
+			},
+		},
+		{
+			names: []string{"foo", "bar", "baz"},
+		},
+		{
+			names: []string{"foo", "bar", "baz"},
+			opts: client.StopOptions{
+				Disable: true,
+			},
+		},
+		{
+			names: []string{"foo"},
+			scope: []string{"user"},
+		},
+		{
+			names: []string{"foo"},
+			scope: []string{"system"},
+		},
+		{
+			names: []string{"foo"},
+			scope: []string{"system", "user"},
+		},
+		{
+			names: []string{"foo"},
+			users: []string{"user"},
+		},
+		{
+			names: []string{"foo"},
+			users: []string{"users"},
+		},
 	}
 
-	var scs []tT
-
-	for _, names := range [][]string{
-		nil, {},
-		{"foo"},
-		{"foo", "bar", "baz"},
-	} {
-		for _, opts := range []client.StopOptions{
-			{Disable: true},
-			{Disable: false},
-		} {
-			scs = append(scs, tT{
-				names:   names,
-				opts:    opts,
-				comment: check.Commentf("{%q; %#v}", names, opts),
-			})
-		}
-	}
-
-	for _, sc := range scs {
-		id, err := cs.cli.Stop(sc.names, sc.opts)
+	for _, sc := range tests {
+		comment := check.Commentf("{%q; %q; %q; %#v}", sc.names, sc.scope, sc.users, sc.opts)
+		id, err := cs.cli.Stop(sc.names, sc.scope, sc.users, sc.opts)
 		if len(sc.names) == 0 {
-			c.Check(id, check.Equals, "", sc.comment)
-			c.Check(err, check.Equals, client.ErrNoNames, sc.comment)
-			c.Check(cs.req, check.IsNil, sc.comment) // i.e. the request was never done
+			c.Check(id, check.Equals, "", comment)
+			c.Check(err, check.Equals, client.ErrNoNames, comment)
+			c.Check(cs.req, check.IsNil, comment) // i.e. the request was never done
 		} else {
-			c.Assert(err, check.IsNil, sc.comment)
-			c.Check(id, check.Equals, "24", sc.comment)
-			c.Check(cs.req.URL.Path, check.Equals, "/v2/apps", sc.comment)
-			c.Check(cs.req.Method, check.Equals, "POST", sc.comment)
-			c.Check(cs.req.URL.Query(), check.HasLen, 0, sc.comment)
-
-			inames := make([]interface{}, len(sc.names))
-			for i, name := range sc.names {
-				inames[i] = interface{}(name)
-			}
+			c.Assert(err, check.IsNil, comment)
+			c.Check(id, check.Equals, "24", comment)
+			c.Check(cs.req.URL.Path, check.Equals, "/v2/apps", comment)
+			c.Check(cs.req.Method, check.Equals, "POST", comment)
+			c.Check(cs.req.URL.Query(), check.HasLen, 0, comment)
 
 			var reqOp map[string]interface{}
-			c.Assert(json.NewDecoder(cs.req.Body).Decode(&reqOp), check.IsNil, sc.comment)
+			c.Assert(json.NewDecoder(cs.req.Body).Decode(&reqOp), check.IsNil, comment)
+			c.Check(reqOp["action"], check.Equals, "stop", comment)
+			cs.checkCommonFields(c, reqOp, sc.names, sc.scope, sc.users, comment)
 			if sc.opts.Disable {
-				c.Check(len(reqOp), check.Equals, 3, sc.comment)
-				c.Check(reqOp["disable"], check.Equals, true, sc.comment)
+				c.Check(reqOp["disable"], check.Equals, true, comment)
 			} else {
-				c.Check(len(reqOp), check.Equals, 2, sc.comment)
-				c.Check(reqOp["disable"], check.IsNil, sc.comment)
+				c.Check(reqOp["disable"], check.IsNil, comment)
 			}
-			c.Check(reqOp["action"], check.Equals, "stop", sc.comment)
-			c.Check(reqOp["names"], check.DeepEquals, inames, sc.comment)
 		}
 	}
 }
@@ -345,60 +414,81 @@ func (cs *clientSuite) TestClientServiceRestart(c *check.C) {
 	cs.status = 202
 	cs.rsp = `{"type": "async", "status-code": 202, "change": "24"}`
 
-	type tT struct {
-		names   []string
-		opts    client.RestartOptions
-		comment check.CommentInterface
+	tests := []struct {
+		names []string
+		scope []string
+		users []string
+		opts  client.RestartOptions
+	}{
+		{},
+		{
+			opts: client.RestartOptions{
+				Reload: true,
+			},
+		},
+		{
+			names: []string{"foo"},
+		},
+		{
+			names: []string{"foo"},
+			opts: client.RestartOptions{
+				Reload: true,
+			},
+		},
+		{
+			names: []string{"foo", "bar", "baz"},
+		},
+		{
+			names: []string{"foo", "bar", "baz"},
+			opts: client.RestartOptions{
+				Reload: true,
+			},
+		},
+		{
+			names: []string{"foo"},
+			scope: []string{"user"},
+		},
+		{
+			names: []string{"foo"},
+			scope: []string{"system"},
+		},
+		{
+			names: []string{"foo"},
+			scope: []string{"system", "user"},
+		},
+		{
+			names: []string{"foo"},
+			users: []string{"user"},
+		},
+		{
+			names: []string{"foo"},
+			users: []string{"users"},
+		},
 	}
 
-	var scs []tT
-
-	for _, names := range [][]string{
-		nil, {},
-		{"foo"},
-		{"foo", "bar", "baz"},
-	} {
-		for _, opts := range []client.RestartOptions{
-			{Reload: true},
-			{Reload: false},
-		} {
-			scs = append(scs, tT{
-				names:   names,
-				opts:    opts,
-				comment: check.Commentf("{%q; %#v}", names, opts),
-			})
-		}
-	}
-
-	for _, sc := range scs {
-		id, err := cs.cli.Restart(sc.names, sc.opts)
+	for _, sc := range tests {
+		comment := check.Commentf("{%q; %q; %q; %#v}", sc.names, sc.scope, sc.users, sc.opts)
+		id, err := cs.cli.Restart(sc.names, sc.scope, sc.users, sc.opts)
 		if len(sc.names) == 0 {
-			c.Check(id, check.Equals, "", sc.comment)
-			c.Check(err, check.Equals, client.ErrNoNames, sc.comment)
-			c.Check(cs.req, check.IsNil, sc.comment) // i.e. the request was never done
+			c.Check(id, check.Equals, "", comment)
+			c.Check(err, check.Equals, client.ErrNoNames, comment)
+			c.Check(cs.req, check.IsNil, comment) // i.e. the request was never done
 		} else {
-			c.Assert(err, check.IsNil, sc.comment)
-			c.Check(id, check.Equals, "24", sc.comment)
-			c.Check(cs.req.URL.Path, check.Equals, "/v2/apps", sc.comment)
-			c.Check(cs.req.Method, check.Equals, "POST", sc.comment)
-			c.Check(cs.req.URL.Query(), check.HasLen, 0, sc.comment)
-
-			inames := make([]interface{}, len(sc.names))
-			for i, name := range sc.names {
-				inames[i] = interface{}(name)
-			}
+			c.Assert(err, check.IsNil, comment)
+			c.Check(id, check.Equals, "24", comment)
+			c.Check(cs.req.URL.Path, check.Equals, "/v2/apps", comment)
+			c.Check(cs.req.Method, check.Equals, "POST", comment)
+			c.Check(cs.req.URL.Query(), check.HasLen, 0, comment)
 
 			var reqOp map[string]interface{}
-			c.Assert(json.NewDecoder(cs.req.Body).Decode(&reqOp), check.IsNil, sc.comment)
+			c.Assert(json.NewDecoder(cs.req.Body).Decode(&reqOp), check.IsNil, comment)
+			cs.checkCommonFields(c, reqOp, sc.names, sc.scope, sc.users, comment)
+			c.Check(reqOp["action"], check.Equals, "restart", comment)
 			if sc.opts.Reload {
-				c.Check(len(reqOp), check.Equals, 3, sc.comment)
-				c.Check(reqOp["reload"], check.Equals, true, sc.comment)
+				c.Check(reqOp["reload"], check.Equals, true, comment)
 			} else {
-				c.Check(len(reqOp), check.Equals, 2, sc.comment)
-				c.Check(reqOp["reload"], check.IsNil, sc.comment)
+				c.Check(reqOp["reload"], check.IsNil, comment)
 			}
-			c.Check(reqOp["action"], check.Equals, "restart", sc.comment)
-			c.Check(reqOp["names"], check.DeepEquals, inames, sc.comment)
 		}
 	}
 }

--- a/cmd/snap/cmd_services.go
+++ b/cmd/snap/cmd_services.go
@@ -202,7 +202,7 @@ func (s *svcLogs) Execute(args []string) error {
 	return nil
 }
 
-func serviceScope(user, users, system bool) ([]string, error) {
+func serviceScope(user, users, system bool) (client.ScopeSelector, error) {
 	switch {
 	case user && system:
 		return nil, fmt.Errorf("--user and --system cannot be used in conjunction with each other")
@@ -211,21 +211,26 @@ func serviceScope(user, users, system bool) ([]string, error) {
 	case users && system:
 		return nil, fmt.Errorf("--users and --system cannot be used in conjunction with each other")
 	case (user || users) && !system:
-		return []string{"user"}, nil
+		return client.ScopeSelector([]string{"user"}), nil
 	case !(user || users) && system:
-		return []string{"system"}, nil
+		return client.ScopeSelector([]string{"system"}), nil
 	}
 	return nil, nil
 }
 
-func serviceUsers(user, users bool) []string {
+func serviceUsers(user, users bool) client.UserSelector {
 	switch {
 	case user && !users:
-		return []string{"user"}
+		return client.UserSelector{
+			Selector: client.UserSelectionSelf,
+		}
 	case users:
-		return []string{"users"}
+		return client.UserSelector{
+			Selector: client.UserSelectionAll,
+		}
 	}
-	return nil
+	// empty for now
+	return client.UserSelector{}
 }
 
 type svcStart struct {

--- a/cmd/snap/cmd_services.go
+++ b/cmd/snap/cmd_services.go
@@ -188,7 +188,7 @@ func (s *svcLogs) Execute(args []string) error {
 type userAndScopeMixin struct {
 	System bool   `long:"system"`
 	User   bool   `long:"user"`
-	Users  string `long:"users" optional:"yes"`
+	Users  string `long:"users"`
 }
 
 var userAndScopeDescs = mixinDescs{

--- a/cmd/snap/cmd_services.go
+++ b/cmd/snap/cmd_services.go
@@ -197,7 +197,7 @@ var userAndScopeDescs = mixinDescs{
 	// TRANSLATORS: This should not start with a lowercase letter.
 	"user": i18n.G("The operation should only affect user services for the current user."),
 	// TRANSLATORS: This should not start with a lowercase letter.
-	"users": i18n.G("The operation should affect all user services."),
+	"users": i18n.G("If provided and set to 'all', the operation should affect services for all users."),
 }
 
 func (um *userAndScopeMixin) validateScopes() error {
@@ -205,7 +205,7 @@ func (um *userAndScopeMixin) validateScopes() error {
 	case um.System && um.User:
 		return fmt.Errorf("--system and --user cannot be used in conjunction with each other")
 	case um.Users != "" && um.User:
-		return fmt.Errorf("--user and --users=all cannot be used in conjunction with each other")
+		return fmt.Errorf("--user and --users cannot be used in conjunction with each other")
 	case um.Users != "" && um.Users != "all":
 		return fmt.Errorf("only \"all\" is supported as a value for --users")
 	}
@@ -233,6 +233,8 @@ func (um *userAndScopeMixin) serviceUsers() client.UserSelector {
 			Selector: client.UserSelectionAll,
 		}
 	}
+	// Currently not reachable as um.Users can only be 'all' for now, but when
+	// we introduce support for lists of usernames, this will be hit.
 	return client.UserSelector{
 		Selector: client.UserSelectionList,
 		Names:    strutil.CommaSeparatedList(um.Users),

--- a/cmd/snap/cmd_services.go
+++ b/cmd/snap/cmd_services.go
@@ -188,7 +188,7 @@ func (s *svcLogs) Execute(args []string) error {
 type userAndScopeMixin struct {
 	System bool   `long:"system"`
 	User   bool   `long:"user"`
-	Users  string `long:"users" optional:"yes" optional-value:"all"`
+	Users  string `long:"users" optional:"yes"`
 }
 
 var userAndScopeDescs = mixinDescs{
@@ -202,8 +202,10 @@ var userAndScopeDescs = mixinDescs{
 
 func (um *userAndScopeMixin) validateScopes() error {
 	switch {
+	case um.System && um.User:
+		return fmt.Errorf("--system and --user cannot be used in conjunction with each other")
 	case um.Users != "" && um.User:
-		return fmt.Errorf("--user and --users cannot be used in conjunction with each other")
+		return fmt.Errorf("--user and --users=all cannot be used in conjunction with each other")
 	case um.Users != "" && um.Users != "all":
 		return fmt.Errorf("only \"all\" is supported as a value for --users")
 	}

--- a/cmd/snap/cmd_services_test.go
+++ b/cmd/snap/cmd_services_test.go
@@ -257,7 +257,7 @@ func (s *appOpSuite) TestAppOpsScopeInvalid(c *check.C) {
 	for _, op := range []string{"start", "stop", "restart"} {
 		c.Check(checkInvocation(op, []string{"foo"}, []string{"user", "users=all"}), check.ErrorMatches, `--user and --users=all cannot be used in conjunction with each other`)
 		c.Check(checkInvocation(op, []string{"bar"}, []string{"system", "user"}), check.ErrorMatches, `--system and --user cannot be used in conjunction with each other`)
-		c.Check(checkInvocation(op, []string{"baz"}, []string{"users=my-user", "system"}), check.ErrorMatches, `only "all" is supported as a value for --users`)
+		c.Check(checkInvocation(op, []string{"baz"}, []string{"users=my-user"}), check.ErrorMatches, `only "all" is supported as a value for --users`)
 	}
 }
 

--- a/cmd/snap/cmd_services_test.go
+++ b/cmd/snap/cmd_services_test.go
@@ -213,6 +213,9 @@ func (s *appOpSuite) TestAppOpsScopeSwitches(c *check.C) {
 
 	summaries := []string{"Started.", "Stopped.", "Restarted."}
 	for i, op := range []string{"start", "stop", "restart"} {
+
+		// Check without any scope options, that should default to empty
+		// 'users' and no scope. This is the same as '--system --users'
 		c.Check(checkInvocation(op, summaries[i], []string{"foo", "bar"}, nil), check.DeepEquals, map[string]interface{}{
 			"action": op,
 			"names":  []interface{}{"foo", "bar"},
@@ -224,18 +227,13 @@ func (s *appOpSuite) TestAppOpsScopeSwitches(c *check.C) {
 			"scope":  []interface{}{"user"},
 			"users":  "self",
 		})
-		c.Check(checkInvocation(op, summaries[i], []string{"foo", "bar"}, []string{"user", "system"}), check.DeepEquals, map[string]interface{}{
-			"action": op,
-			"names":  []interface{}{"foo", "bar"},
-			"users":  "self",
-		})
-		c.Check(checkInvocation(op, summaries[i], []string{"foo", "bar"}, []string{"users"}), check.DeepEquals, map[string]interface{}{
+		c.Check(checkInvocation(op, summaries[i], []string{"foo", "bar"}, []string{"users=all"}), check.DeepEquals, map[string]interface{}{
 			"action": op,
 			"names":  []interface{}{"foo", "bar"},
 			"scope":  []interface{}{"user"},
 			"users":  "all",
 		})
-		c.Check(checkInvocation(op, summaries[i], []string{"foo", "bar"}, []string{"users", "system"}), check.DeepEquals, map[string]interface{}{
+		c.Check(checkInvocation(op, summaries[i], []string{"foo", "bar"}, []string{"users=all", "system"}), check.DeepEquals, map[string]interface{}{
 			"action": op,
 			"names":  []interface{}{"foo", "bar"},
 			"users":  "all",
@@ -257,8 +255,9 @@ func (s *appOpSuite) TestAppOpsScopeInvalid(c *check.C) {
 	}
 
 	for _, op := range []string{"start", "stop", "restart"} {
-		c.Check(checkInvocation(op, []string{"foo"}, []string{"user", "users"}), check.ErrorMatches, `--user and --users cannot be used in conjunction with each other`)
-		c.Check(checkInvocation(op, []string{"foo"}, []string{"users=my-user", "system"}), check.ErrorMatches, `only "all" is supported as a value for --users`)
+		c.Check(checkInvocation(op, []string{"foo"}, []string{"user", "users=all"}), check.ErrorMatches, `--user and --users=all cannot be used in conjunction with each other`)
+		c.Check(checkInvocation(op, []string{"bar"}, []string{"system", "user"}), check.ErrorMatches, `--system and --user cannot be used in conjunction with each other`)
+		c.Check(checkInvocation(op, []string{"baz"}, []string{"users=my-user", "system"}), check.ErrorMatches, `only "all" is supported as a value for --users`)
 	}
 }
 

--- a/cmd/snap/cmd_services_test.go
+++ b/cmd/snap/cmd_services_test.go
@@ -60,6 +60,7 @@ func (s *appOpSuite) expectedBody(op string, names, extra []string) map[string]i
 	expectedBody := map[string]interface{}{
 		"action": op,
 		"names":  inames,
+		"users":  []interface{}{},
 	}
 	for _, x := range extra {
 		expectedBody[x] = true
@@ -215,23 +216,31 @@ func (s *appOpSuite) TestAppOpsScopeSwitches(c *check.C) {
 		c.Check(checkInvocation(op, summaries[i], []string{"foo", "bar"}, nil), check.DeepEquals, map[string]interface{}{
 			"action": op,
 			"names":  []interface{}{"foo", "bar"},
+			"users":  []interface{}{},
 		})
 		c.Check(checkInvocation(op, summaries[i], []string{"foo", "bar"}, []string{"user"}), check.DeepEquals, map[string]interface{}{
-			"action":           op,
-			"names":            []interface{}{"foo", "bar"},
-			"scope":            []interface{}{"user"},
-			"user-services-of": []interface{}{"user"},
+			"action": op,
+			"names":  []interface{}{"foo", "bar"},
+			"scope":  []interface{}{"user"},
+			"users":  "self",
 		})
 		c.Check(checkInvocation(op, summaries[i], []string{"foo", "bar"}, []string{"users"}), check.DeepEquals, map[string]interface{}{
-			"action":           op,
-			"names":            []interface{}{"foo", "bar"},
-			"scope":            []interface{}{"user"},
-			"user-services-of": []interface{}{"users"},
+			"action": op,
+			"names":  []interface{}{"foo", "bar"},
+			"scope":  []interface{}{"user"},
+			"users":  "all",
+		})
+		c.Check(checkInvocation(op, summaries[i], []string{"foo", "bar"}, []string{"users=my-user,other-user"}), check.DeepEquals, map[string]interface{}{
+			"action": op,
+			"names":  []interface{}{"foo", "bar"},
+			"scope":  []interface{}{"user"},
+			"users":  []interface{}{"my-user", "other-user"},
 		})
 		c.Check(checkInvocation(op, summaries[i], []string{"foo", "bar"}, []string{"system"}), check.DeepEquals, map[string]interface{}{
 			"action": op,
 			"names":  []interface{}{"foo", "bar"},
 			"scope":  []interface{}{"system"},
+			"users":  []interface{}{},
 		})
 	}
 }

--- a/cmd/snap/cmd_services_test.go
+++ b/cmd/snap/cmd_services_test.go
@@ -224,17 +224,21 @@ func (s *appOpSuite) TestAppOpsScopeSwitches(c *check.C) {
 			"scope":  []interface{}{"user"},
 			"users":  "self",
 		})
+		c.Check(checkInvocation(op, summaries[i], []string{"foo", "bar"}, []string{"user", "system"}), check.DeepEquals, map[string]interface{}{
+			"action": op,
+			"names":  []interface{}{"foo", "bar"},
+			"users":  "self",
+		})
 		c.Check(checkInvocation(op, summaries[i], []string{"foo", "bar"}, []string{"users"}), check.DeepEquals, map[string]interface{}{
 			"action": op,
 			"names":  []interface{}{"foo", "bar"},
 			"scope":  []interface{}{"user"},
 			"users":  "all",
 		})
-		c.Check(checkInvocation(op, summaries[i], []string{"foo", "bar"}, []string{"users=my-user,other-user"}), check.DeepEquals, map[string]interface{}{
+		c.Check(checkInvocation(op, summaries[i], []string{"foo", "bar"}, []string{"users", "system"}), check.DeepEquals, map[string]interface{}{
 			"action": op,
 			"names":  []interface{}{"foo", "bar"},
-			"scope":  []interface{}{"user"},
-			"users":  []interface{}{"my-user", "other-user"},
+			"users":  "all",
 		})
 		c.Check(checkInvocation(op, summaries[i], []string{"foo", "bar"}, []string{"system"}), check.DeepEquals, map[string]interface{}{
 			"action": op,
@@ -253,9 +257,8 @@ func (s *appOpSuite) TestAppOpsScopeInvalid(c *check.C) {
 	}
 
 	for _, op := range []string{"start", "stop", "restart"} {
-		c.Check(checkInvocation(op, []string{"foo"}, []string{"user", "system"}), check.ErrorMatches, `--user and --system cannot be used in conjunction with each other`)
 		c.Check(checkInvocation(op, []string{"foo"}, []string{"user", "users"}), check.ErrorMatches, `--user and --users cannot be used in conjunction with each other`)
-		c.Check(checkInvocation(op, []string{"foo"}, []string{"users", "system"}), check.ErrorMatches, `--users and --system cannot be used in conjunction with each other`)
+		c.Check(checkInvocation(op, []string{"foo"}, []string{"users=my-user", "system"}), check.ErrorMatches, `only "all" is supported as a value for --users`)
 	}
 }
 

--- a/cmd/snap/cmd_services_test.go
+++ b/cmd/snap/cmd_services_test.go
@@ -255,7 +255,7 @@ func (s *appOpSuite) TestAppOpsScopeInvalid(c *check.C) {
 	}
 
 	for _, op := range []string{"start", "stop", "restart"} {
-		c.Check(checkInvocation(op, []string{"foo"}, []string{"user", "users=all"}), check.ErrorMatches, `--user and --users=all cannot be used in conjunction with each other`)
+		c.Check(checkInvocation(op, []string{"foo"}, []string{"user", "users=all"}), check.ErrorMatches, `--user and --users cannot be used in conjunction with each other`)
 		c.Check(checkInvocation(op, []string{"bar"}, []string{"system", "user"}), check.ErrorMatches, `--system and --user cannot be used in conjunction with each other`)
 		c.Check(checkInvocation(op, []string{"baz"}, []string{"users=my-user"}), check.ErrorMatches, `only "all" is supported as a value for --users`)
 	}

--- a/daemon/api_apps_test.go
+++ b/daemon/api_apps_test.go
@@ -86,7 +86,7 @@ type serviceControlArgs struct {
 	action  string
 	options string
 	names   []string
-	scope   servicestate.ScopeSelector
+	scope   client.ScopeSelector
 	users   []string
 }
 
@@ -541,7 +541,7 @@ func (s *appsSuite) testPostAppsUser(c *check.C, inst servicestate.Instruction, 
 func (s *appsSuite) TestPostAppsStartOne(c *check.C) {
 	inst := servicestate.Instruction{Action: "start", Names: []string{"snap-a.svc2"}}
 	expected := []serviceControlArgs{
-		{action: "start", names: []string{"snap-a.svc2"}, scope: servicestate.ScopeSelector{"system", "user"}},
+		{action: "start", names: []string{"snap-a.svc2"}, scope: client.ScopeSelector{"system", "user"}},
 	}
 	chg := s.testPostApps(c, inst, expected)
 	chg.State().Lock()
@@ -556,7 +556,7 @@ func (s *appsSuite) TestPostAppsStartOne(c *check.C) {
 func (s *appsSuite) TestPostAppsStartTwo(c *check.C) {
 	inst := servicestate.Instruction{Action: "start", Names: []string{"snap-a"}}
 	expected := []serviceControlArgs{
-		{action: "start", names: []string{"snap-a.svc1", "snap-a.svc2"}, scope: servicestate.ScopeSelector{"system", "user"}},
+		{action: "start", names: []string{"snap-a.svc1", "snap-a.svc2"}, scope: client.ScopeSelector{"system", "user"}},
 	}
 	chg := s.testPostApps(c, inst, expected)
 
@@ -572,7 +572,7 @@ func (s *appsSuite) TestPostAppsStartTwo(c *check.C) {
 func (s *appsSuite) TestPostAppsStartThree(c *check.C) {
 	inst := servicestate.Instruction{Action: "start", Names: []string{"snap-a", "snap-b"}}
 	expected := []serviceControlArgs{
-		{action: "start", names: []string{"snap-a.svc1", "snap-a.svc2", "snap-b.svc3"}, scope: servicestate.ScopeSelector{"system", "user"}},
+		{action: "start", names: []string{"snap-a.svc1", "snap-a.svc2", "snap-b.svc3"}, scope: client.ScopeSelector{"system", "user"}},
 	}
 	chg := s.testPostApps(c, inst, expected)
 	// check the summary expands the snap into actual apps
@@ -589,7 +589,7 @@ func (s *appsSuite) TestPostAppsStartThree(c *check.C) {
 func (s *appsSuite) TestPostAppsStop(c *check.C) {
 	inst := servicestate.Instruction{Action: "stop", Names: []string{"snap-a.svc2"}}
 	expected := []serviceControlArgs{
-		{action: "stop", names: []string{"snap-a.svc2"}, scope: servicestate.ScopeSelector{"system", "user"}},
+		{action: "stop", names: []string{"snap-a.svc2"}, scope: client.ScopeSelector{"system", "user"}},
 	}
 	s.testPostApps(c, inst, expected)
 }
@@ -597,7 +597,7 @@ func (s *appsSuite) TestPostAppsStop(c *check.C) {
 func (s *appsSuite) TestPostAppsRestart(c *check.C) {
 	inst := servicestate.Instruction{Action: "restart", Names: []string{"snap-a.svc2"}}
 	expected := []serviceControlArgs{
-		{action: "restart", names: []string{"snap-a.svc2"}, scope: servicestate.ScopeSelector{"system", "user"}},
+		{action: "restart", names: []string{"snap-a.svc2"}, scope: client.ScopeSelector{"system", "user"}},
 	}
 	s.testPostApps(c, inst, expected)
 }
@@ -606,7 +606,7 @@ func (s *appsSuite) TestPostAppsReload(c *check.C) {
 	inst := servicestate.Instruction{Action: "restart", Names: []string{"snap-a.svc2"}}
 	inst.Reload = true
 	expected := []serviceControlArgs{
-		{action: "restart", options: "reload", names: []string{"snap-a.svc2"}, scope: servicestate.ScopeSelector{"system", "user"}},
+		{action: "restart", options: "reload", names: []string{"snap-a.svc2"}, scope: client.ScopeSelector{"system", "user"}},
 	}
 	s.testPostApps(c, inst, expected)
 }
@@ -615,7 +615,7 @@ func (s *appsSuite) TestPostAppsEnableNow(c *check.C) {
 	inst := servicestate.Instruction{Action: "start", Names: []string{"snap-a.svc2"}}
 	inst.Enable = true
 	expected := []serviceControlArgs{
-		{action: "start", options: "enable", names: []string{"snap-a.svc2"}, scope: servicestate.ScopeSelector{"system", "user"}},
+		{action: "start", options: "enable", names: []string{"snap-a.svc2"}, scope: client.ScopeSelector{"system", "user"}},
 	}
 	s.testPostApps(c, inst, expected)
 }
@@ -624,7 +624,7 @@ func (s *appsSuite) TestPostAppsDisableNow(c *check.C) {
 	inst := servicestate.Instruction{Action: "stop", Names: []string{"snap-a.svc2"}}
 	inst.Disable = true
 	expected := []serviceControlArgs{
-		{action: "stop", options: "disable", names: []string{"snap-a.svc2"}, scope: servicestate.ScopeSelector{"system", "user"}},
+		{action: "stop", options: "disable", names: []string{"snap-a.svc2"}, scope: client.ScopeSelector{"system", "user"}},
 	}
 	s.testPostApps(c, inst, expected)
 }
@@ -646,9 +646,9 @@ func (s *appsSuite) TestPostAppsScopesSelfAsRootNotAllowed(c *check.C) {
 	inst := servicestate.Instruction{
 		Action: "start",
 		Names:  []string{"snap-a.svc1"},
-		Scope:  servicestate.ScopeSelector{"user"},
-		Users: servicestate.UserSelector{
-			Selector: servicestate.UserSelectionSelf,
+		Scope:  client.ScopeSelector{"user"},
+		Users: client.UserSelector{
+			Selector: client.UserSelectionSelf,
 		},
 	}
 	postBody, err := json.Marshal(inst)
@@ -666,14 +666,14 @@ func (s *appsSuite) TestPostAppsAllUsersAsRootHappy(c *check.C) {
 	inst := servicestate.Instruction{
 		Action: "start",
 		Names:  []string{"snap-a.svc1"},
-		Scope:  servicestate.ScopeSelector{"user"},
-		Users: servicestate.UserSelector{
-			Selector: servicestate.UserSelectionAll,
+		Scope:  client.ScopeSelector{"user"},
+		Users: client.UserSelector{
+			Selector: client.UserSelectionAll,
 		},
 	}
 	expected := []serviceControlArgs{
 		// Expect no user to appear as we are not logged in
-		{action: "start", names: []string{"snap-a.svc1"}, scope: servicestate.ScopeSelector{"user"}},
+		{action: "start", names: []string{"snap-a.svc1"}, scope: client.ScopeSelector{"user"}},
 	}
 	s.testPostApps(c, inst, expected)
 }
@@ -681,7 +681,7 @@ func (s *appsSuite) TestPostAppsAllUsersAsRootHappy(c *check.C) {
 func (s *appsSuite) TestPostAppsScopesNotSpecifiedForRoot(c *check.C) {
 	inst := servicestate.Instruction{Action: "start", Names: []string{"snap-e.svc4"}}
 	expected := []serviceControlArgs{
-		{action: "start", names: []string{"snap-e.svc4"}, scope: servicestate.ScopeSelector{"system", "user"}},
+		{action: "start", names: []string{"snap-e.svc4"}, scope: client.ScopeSelector{"system", "user"}},
 	}
 	s.testPostApps(c, inst, expected)
 }
@@ -690,13 +690,13 @@ func (s *appsSuite) TestPostAppsUsersAsUserHappy(c *check.C) {
 	inst := servicestate.Instruction{
 		Action: "start",
 		Names:  []string{"snap-a.svc1"},
-		Scope:  servicestate.ScopeSelector{"user"},
-		Users: servicestate.UserSelector{
-			Selector: servicestate.UserSelectionAll,
+		Scope:  client.ScopeSelector{"user"},
+		Users: client.UserSelector{
+			Selector: client.UserSelectionAll,
 		},
 	}
 	expected := []serviceControlArgs{
-		{action: "start", names: []string{"snap-a.svc1"}, scope: servicestate.ScopeSelector{"user"}},
+		{action: "start", names: []string{"snap-a.svc1"}, scope: client.ScopeSelector{"user"}},
 	}
 	s.testPostAppsUser(c, inst, expected, "")
 }
@@ -705,8 +705,8 @@ func (s *appsSuite) TestPostAppsScopesNotSpecifiedForUser(c *check.C) {
 	inst := servicestate.Instruction{
 		Action: "start",
 		Names:  []string{"snap-e.svc4"},
-		Users: servicestate.UserSelector{
-			Selector: servicestate.UserSelectionSelf,
+		Users: client.UserSelector{
+			Selector: client.UserSelectionSelf,
 		},
 	}
 	s.testPostAppsUser(c, inst, nil, "cannot perform operation on services: non-root users must specify service scope when targeting user services")
@@ -716,12 +716,12 @@ func (s *appsSuite) TestPostAppsUsersUser(c *check.C) {
 	inst := servicestate.Instruction{
 		Action: "start",
 		Names:  []string{"snap-a.svc1"},
-		Users: servicestate.UserSelector{
-			Selector: servicestate.UserSelectionSelf,
+		Users: client.UserSelector{
+			Selector: client.UserSelectionSelf,
 		},
 	}
 	expected := []serviceControlArgs{
-		{action: "start", names: []string{"snap-a.svc1"}, scope: servicestate.ScopeSelector{"system"}, users: []string{"username"}},
+		{action: "start", names: []string{"snap-a.svc1"}, scope: client.ScopeSelector{"system"}, users: []string{"username"}},
 	}
 	s.testPostAppsUser(c, inst, expected, "")
 }
@@ -730,27 +730,27 @@ func (s *appsSuite) TestPostAppsUsersWithUsernames(c *check.C) {
 	inst := servicestate.Instruction{
 		Action: "start",
 		Names:  []string{"snap-a.svc1"},
-		Users: servicestate.UserSelector{
+		Users: client.UserSelector{
 			Names: []string{"my-user", "other-user"},
 		},
 	}
 	expected := []serviceControlArgs{
 		// Expect no user to appear as we are not logged in
-		{action: "start", names: []string{"snap-a.svc1"}, scope: servicestate.ScopeSelector{"system", "user"}, users: []string{"my-user", "other-user"}},
+		{action: "start", names: []string{"snap-a.svc1"}, scope: client.ScopeSelector{"system", "user"}, users: []string{"my-user", "other-user"}},
 	}
 	s.testPostApps(c, inst, expected)
 }
 
 func (s *appsSuite) TestPostAppsUserNotSpecifiedForRoot(c *check.C) {
-	inst := servicestate.Instruction{Action: "start", Names: []string{"snap-e.svc4"}, Scope: servicestate.ScopeSelector{"system"}}
+	inst := servicestate.Instruction{Action: "start", Names: []string{"snap-e.svc4"}, Scope: client.ScopeSelector{"system"}}
 	expected := []serviceControlArgs{
-		{action: "start", names: []string{"snap-e.svc4"}, scope: servicestate.ScopeSelector{"system"}},
+		{action: "start", names: []string{"snap-e.svc4"}, scope: client.ScopeSelector{"system"}},
 	}
 	s.testPostApps(c, inst, expected)
 }
 
 func (s *appsSuite) TestPostAppsUserNotSpecifiedForUser(c *check.C) {
-	inst := servicestate.Instruction{Action: "start", Names: []string{"snap-e.svc4"}, Scope: servicestate.ScopeSelector{"user"}}
+	inst := servicestate.Instruction{Action: "start", Names: []string{"snap-e.svc4"}, Scope: client.ScopeSelector{"user"}}
 	s.testPostAppsUser(c, inst, nil, "cannot perform operation on services: non-root users must specify users when targeting user services")
 }
 

--- a/tests/main/services-user/task.yaml
+++ b/tests/main/services-user/task.yaml
@@ -6,16 +6,24 @@ details: |
     when performing these operations.
 
 # Only run on systems with polkit rules are supported
-systems: [ ubuntu-2* ]
+# TODO: add 24 once stable
+systems: [ ubuntu-20.04-64, ubuntu-22.04-64 ]
 
 prepare: |
     snap set system experimental.user-daemons=true
     tests.session kill-leaked
+
+    # prepare users for testing
     tests.session -u test prepare
+
+    if ! useradd -m -d /home/test2 test2; then
+        # Ubuntu Core requires using extrausers db
+        useradd --extrausers -m -d /home/test2 test2
+    fi
 
     cat <<\EOF >/etc/polkit-1/localauthority/50-local.d/spread.pkla
     [Normal Staff Permissions]
-    Identity=unix-user:test
+    Identity=unix-user:test;unix-user:test2
     Action=io.snapcraft.snapd.manage
     ResultAny=yes
     ResultInactive=no
@@ -24,12 +32,20 @@ prepare: |
 
 restore: |
     tests.session -u test restore
+    tests.session -u test2 restore
+    if ! userdel -rf test2; then
+        userdel --extrausers -rf test2
+    fi
     snap unset system experimental.user-daemons
 
 debug: |
     tests.session dump
+
+    # dump information
     tests.session -u test exec systemctl --user status snapd.session-agent.service || true
     tests.session -u test exec journalctl --user || true
+    tests.session -u test2 exec systemctl --user status snapd.session-agent.service || true
+    tests.session -u test2 exec journalctl --user || true
 
 execute: |
     echo "Installing the service snap"
@@ -39,35 +55,49 @@ execute: |
     systemctl status snap.test-snapd-user-service.svc3.service | MATCH "running"
     systemctl status snap.test-snapd-user-service.svc4.service | MATCH "running"
 
-    echo "We can see the user services running"
+    echo "(user test) We can see the user services running"
     tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH "active"
     tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH "active"
+
+    echo "(user test2) We can see the user services running"
+    tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH "active"
+    tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH "active"
 
     # if root is making this request, implied scopes are all
     echo "(root) Stopping all services for snap"
     snap stop test-snapd-user-service
     systemctl status snap.test-snapd-user-service.svc3.service | MATCH "inactive"
     systemctl status snap.test-snapd-user-service.svc4.service | MATCH "inactive"
+
+    echo "(user test) We can see the user services stopped"
     tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH "inactive"
     tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH "inactive"
 
+    echo "(user test2) We can see the user services stopped"
+    tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH "inactive"
+    tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH "inactive"
+
     # if non-root are making requests, and user services are the target,
     # then its an error to not specify --user scope
-    echo "(user) Trying to start services for snap, which will fail with no scope set"
+    echo "(user test) Trying to start services for snap, which will fail with no scope set"
     tests.session -u test exec snap start test-snapd-user-service 2>&1 | tr '\n' ' ' | tr -s ' ' | MATCH "non-root users must specify service scope when targeting user services"
     
-    echo "(user) Starting user services for snap with scope --user"
+    echo "(user test) Starting user services for snap with scope --user"
     tests.session -u test exec snap start --user test-snapd-user-service
 
-    echo "And we can see the user services running"
+    echo "(user test) And we can see the user services running"
     tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH "active"
     tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH "active"
 
-    echo "System services are still not running"
+    echo "(user test2) Services are still not running"
+    tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH "inactive"
+    tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH "inactive"
+
+    echo "(root) Services are still not running"
     systemctl status snap.test-snapd-user-service.svc3.service | MATCH "inactive"
     systemctl status snap.test-snapd-user-service.svc4.service | MATCH "inactive"
 
-    echo "(user) Trying to start system services without root, will fail"
+    echo "(user test) Trying to start system services without root, will fail"
     tests.session -u test exec snap start --system test-snapd-user-service 2>&1 | tr '\n' ' ' | tr -s ' ' | MATCH "non-root users must specify users when targeting user services"
 
     echo "(root) Stopping all services for snap"
@@ -76,6 +106,8 @@ execute: |
     systemctl status snap.test-snapd-user-service.svc4.service | MATCH "inactive"
     tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH "inactive"
     tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH "inactive"
+    tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH "inactive"
+    tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH "inactive"
 
     echo "(root) Starting system services for snap with scope --system"
     snap start --system test-snapd-user-service
@@ -83,8 +115,11 @@ execute: |
     echo "And only system services are running"
     systemctl status snap.test-snapd-user-service.svc3.service | MATCH "running"
     systemctl status snap.test-snapd-user-service.svc4.service | MATCH "running"
+
     tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH "inactive"
     tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH "inactive"
+    tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH "inactive"
+    tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH "inactive"
 
     echo "(root) Starting user services for snap with scope --user"
     snap start --user test-snapd-user-service 2>&1 | tr '\n' ' ' | tr -s ' ' | MATCH "cannot use \"self\" for root user"
@@ -92,7 +127,11 @@ execute: |
     echo "(root) Starting user services for snap with scope --users"
     snap start --users test-snapd-user-service
 
-    echo "And we can see the user services running"
+    echo "(user test) And we can see the user services running"
     tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH "active"
     tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH "active"
+
+    echo "(user test2) And we can see the user services running"
+    tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH "active"
+    tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH "active"
 

--- a/tests/main/services-user/task.yaml
+++ b/tests/main/services-user/task.yaml
@@ -1,0 +1,98 @@
+summary: Check that snap service operations can be selected for both user and system services
+
+details: |
+    With the addition of --user, --users and --system switches for snap operations like
+    snap start/stop/restart, we want to test that we can select user and/or system services,
+    when performing these operations.
+
+# ubuntu-14.04: no support for user sessions used by test helpers
+systems: [ -ubuntu-14.04-* ]
+
+prepare: |
+    snap set system experimental.user-daemons=true
+    tests.session kill-leaked
+    tests.session -u test prepare
+
+    cat <<\EOF >/etc/polkit-1/localauthority/50-local.d/spread.pkla
+    [Normal Staff Permissions]
+    Identity=unix-user:test
+    Action=io.snapcraft.snapd.manage
+    ResultAny=yes
+    ResultInactive=no
+    ResultActive=yes
+    EOF
+
+restore: |
+    tests.session -u test restore
+    snap unset system experimental.user-daemons
+
+debug: |
+    tests.session dump
+    tests.session -u test exec systemctl --user status snapd.session-agent.service || true
+    tests.session -u test exec journalctl --user || true
+
+execute: |
+    echo "Installing the service snap"
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-user-service
+
+    echo "We can see the system services running"
+    systemctl status snap.test-snapd-user-service.svc3.service | MATCH "running"
+    systemctl status snap.test-snapd-user-service.svc4.service | MATCH "running"
+
+    echo "We can see the user services running"
+    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH "active"
+    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH "active"
+
+    # if root is making this request, implied scopes are all
+    echo "(root) Stopping all services for snap"
+    snap stop test-snapd-user-service
+    systemctl status snap.test-snapd-user-service.svc3.service | MATCH "inactive"
+    systemctl status snap.test-snapd-user-service.svc4.service | MATCH "inactive"
+    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH "inactive"
+    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH "inactive"
+
+    # if non-root are making requests, and user services are the target,
+    # then its an error to not specify --user scope
+    echo "(user) Trying to start services for snap, which will fail with no scope set"
+    tests.session -u test exec snap start test-snapd-user-service 2>&1 | MATCH "a service scope must be provided"
+    
+    echo "(user) Starting user services for snap with scope --user"
+    tests.session -u test exec snap start --user test-snapd-user-service
+
+    echo "And we can see the user services running"
+    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH "active"
+    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH "active"
+
+    echo "System services are still not running"
+    systemctl status snap.test-snapd-user-service.svc3.service | MATCH "inactive"
+    systemctl status snap.test-snapd-user-service.svc4.service | MATCH "inactive"
+
+    echo "(user) Trying to start system services without root, will fail"
+    tests.session -u test exec snap start --system test-snapd-user-service 2>&1 | MATCH "no users were listed"
+
+    echo "(root) Stopping all services for snap"
+    snap stop test-snapd-user-service
+    systemctl status snap.test-snapd-user-service.svc3.service | MATCH "inactive"
+    systemctl status snap.test-snapd-user-service.svc4.service | MATCH "inactive"
+    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH "inactive"
+    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH "inactive"
+
+    echo "(root) Starting system services for snap with scope --system"
+    snap start --system test-snapd-user-service
+
+    echo "And only system services are running"
+    systemctl status snap.test-snapd-user-service.svc3.service | MATCH "running"
+    systemctl status snap.test-snapd-user-service.svc4.service | MATCH "running"
+    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH "inactive"
+    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH "inactive"
+
+    echo "(root) Starting user services for snap with scope --user"
+    snap start --user test-snapd-user-service 2>&1 | MATCH "cannot use \"user\""
+
+    echo "(root) Starting user services for snap with scope --users"
+    snap start --users test-snapd-user-service
+
+    echo "And we can see the user services running"
+    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH "active"
+    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH "active"
+

--- a/tests/main/services-user/task.yaml
+++ b/tests/main/services-user/task.yaml
@@ -124,8 +124,8 @@ execute: |
     echo "(root) Starting user services for snap with scope --user"
     snap start --user test-snapd-user-service 2>&1 | tr '\n' ' ' | tr -s ' ' | MATCH "cannot use \"self\" for root user"
 
-    echo "(root) Starting user services for snap with scope --users"
-    snap start --users test-snapd-user-service
+    echo "(root) Starting user services for snap with scope --users=all"
+    snap start --users=all test-snapd-user-service
 
     echo "(user test) And we can see the user services running"
     tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH "active"
@@ -135,3 +135,20 @@ execute: |
     tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH "active"
     tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH "active"
 
+    echo "(root) Stopping all services for snap again"
+    snap stop test-snapd-user-service
+    systemctl status snap.test-snapd-user-service.svc3.service | MATCH "inactive"
+    systemctl status snap.test-snapd-user-service.svc4.service | MATCH "inactive"
+    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH "inactive"
+    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH "inactive"
+    tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH "inactive"
+    tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH "inactive"
+
+    echo "(root) Starting all services for snap with scopes --system and --users=all"
+    snap start --system --users=all test-snapd-user-service
+    systemctl status snap.test-snapd-user-service.svc3.service | MATCH "active"
+    systemctl status snap.test-snapd-user-service.svc4.service | MATCH "active"
+    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH "active"
+    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH "active"
+    tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH "active"
+    tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH "active"

--- a/tests/main/services-user/task.yaml
+++ b/tests/main/services-user/task.yaml
@@ -5,8 +5,8 @@ details: |
     snap start/stop/restart, we want to test that we can select user and/or system services,
     when performing these operations.
 
-# ubuntu-14.04: no support for user sessions used by test helpers
-systems: [ -ubuntu-14.04-* ]
+# Only run on systems with polkit rules are supported
+systems: [ ubuntu-2* ]
 
 prepare: |
     snap set system experimental.user-daemons=true
@@ -54,7 +54,7 @@ execute: |
     # if non-root are making requests, and user services are the target,
     # then its an error to not specify --user scope
     echo "(user) Trying to start services for snap, which will fail with no scope set"
-    tests.session -u test exec snap start test-snapd-user-service 2>&1 | MATCH "a service scope must be provided"
+    tests.session -u test exec snap start test-snapd-user-service 2>&1 | tr '\n' ' ' | tr -s ' ' | MATCH "non-root users must specify service scope when targeting user services"
     
     echo "(user) Starting user services for snap with scope --user"
     tests.session -u test exec snap start --user test-snapd-user-service
@@ -68,7 +68,7 @@ execute: |
     systemctl status snap.test-snapd-user-service.svc4.service | MATCH "inactive"
 
     echo "(user) Trying to start system services without root, will fail"
-    tests.session -u test exec snap start --system test-snapd-user-service 2>&1 | MATCH "no users were listed"
+    tests.session -u test exec snap start --system test-snapd-user-service 2>&1 | tr '\n' ' ' | tr -s ' ' | MATCH "non-root users must specify users when targeting user services"
 
     echo "(root) Stopping all services for snap"
     snap stop test-snapd-user-service
@@ -87,7 +87,7 @@ execute: |
     tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH "inactive"
 
     echo "(root) Starting user services for snap with scope --user"
-    snap start --user test-snapd-user-service 2>&1 | MATCH "cannot use \"user\""
+    snap start --user test-snapd-user-service 2>&1 | tr '\n' ' ' | tr -s ' ' | MATCH "cannot use \"self\" for root user"
 
     echo "(root) Starting user services for snap with scope --users"
     snap start --users test-snapd-user-service

--- a/tests/main/services-user/test-snapd-user-service/bin/start
+++ b/tests/main/services-user/test-snapd-user-service/bin/start
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+systemd-notify --ready
+
+while true; do
+    echo "running"
+    sleep 10
+done

--- a/tests/main/services-user/test-snapd-user-service/meta/snap.yaml
+++ b/tests/main/services-user/test-snapd-user-service/meta/snap.yaml
@@ -1,0 +1,17 @@
+name: test-snapd-user-service
+version: 1.0
+apps:
+    svc1:
+        command: bin/start
+        daemon: simple
+        daemon-scope: user
+    svc2:
+        command: bin/start
+        daemon: simple
+        daemon-scope: user
+    svc3:
+        command: bin/start
+        daemon: simple
+    svc4:
+        command: bin/start
+        daemon: simple


### PR DESCRIPTION
Introduces the new switches `--user` to select user services for the current user, `--system` to select system services and `--users` to select user services for all users for the following operations:
`snap start`, `snap stop` and `snap restart`

