### PR TITLE
tests: add new performance and load test suite

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -1271,7 +1271,14 @@ suites:
             . "$TESTSLIB"/image.sh
             distro_update_package_db
             distro_install_package snapd qemu qemu-utils genisoimage sshpass qemu-kvm cloud-image-utils ovmf kpartx xz-utils mtools ca-certificates xdelta3
-            get_ubuntu_image
+            if os.query is-xenial || os.query is-arm; then
+                # the new ubuntu-image expects mkfs to support -d option, which was not
+                # supported yet by the version of mkfs that shipped with Ubuntu 16.04
+                # also ubuntu-image binary is not prebuilt for arm instances
+                snap install ubuntu-image --channel="$UBUNTU_IMAGE_SNAP_CHANNEL" --classic
+            else
+                get_ubuntu_image
+            fi
   
             # Install the snapd built
             dpkg -i "$SPREAD_PATH"/../snapd_*.deb

--- a/spread.yaml
+++ b/spread.yaml
@@ -1046,6 +1046,22 @@ suites:
         restore: |
             "$TESTSLIB"/prepare-restore.sh --restore-suite
 
+    tests/perf/:
+        summary: Performance and Load tests
+        backends: [external]
+        environment:
+            CONNECTIONS_PERCENTAGE: '$(HOST: echo "${PERF_CONNECTIONS_PERCENTAGE:-100}")'
+            DISCONNECT_INTERFACES: '$(HOST: echo "${PERF_DISCONNECT_INTERFACES:-true}")'
+        manual: true
+        prepare: |
+            "$TESTSLIB"/prepare-restore.sh --prepare-suite
+        prepare-each: |
+            "$TESTSLIB"/prepare-restore.sh --prepare-suite-each
+        restore-each: |
+            "$TESTSLIB"/prepare-restore.sh --restore-suite-each
+        restore: |
+            "$TESTSLIB"/prepare-restore.sh --restore-suite
+
     tests/nested/manual/:
         summary: Tests for nested images controlled manually from the tests
         backends: [google-nested, google-nested-dev, qemu-nested, google-nested-arm]
@@ -1216,6 +1232,63 @@ suites:
         restore-each: |
             tests.nested vm remove
             "$TESTSLIB"/prepare-restore.sh --restore-suite-each
+        restore: |
+            tests.nested restore
+
+            #shellcheck source=tests/lib/pkgdb.sh
+            . "$TESTSLIB"/pkgdb.sh
+            distro_purge_package qemu genisoimage sshpass qemu-kvm cloud-image-utils xz-utils
+
+    tests/nested/perf/:
+        summary: Performance and Load tests preparation suite
+        backends: [google-nested, google-nested-dev, qemu-nested]
+        kill-timeout: 40m
+        environment:
+            NESTED_TYPE: "core"
+            # Enable kvm in the qemu command line
+            NESTED_ENABLE_KVM: '$(HOST: echo "${NESTED_ENABLE_KVM:-true}")'
+            # Enable tpm in the nested vm in case it is supported
+            NESTED_ENABLE_TPM: '$(HOST: echo "${NESTED_ENABLE_TPM:-true}")'
+            # Enable secure boot in the nested vm in case it is supported
+            NESTED_ENABLE_SECURE_BOOT: '$(HOST: echo "${NESTED_ENABLE_SECURE_BOOT:-true}")'
+            # Add snapd debug and log to serial console
+            NESTED_SNAPD_DEBUG_TO_SERIAL: '$(HOST: echo "${NESTED_SNAPD_DEBUG_TO_SERIAL:-false}")'
+            # Add any extra cmd line parameter to the nested vm
+            NESTED_EXTRA_CMDLINE: '$(HOST: echo "${NESTED_EXTRA_CMDLINE:-}")'
+            # Configuration file used for remote tools
+            REMOTE_CFG_FILE: "$PROJECT_PATH/remote.setup.cfg"
+            # Indicates the number of cpus to use in the nested vm
+            NESTED_CPUS: '$(HOST: echo "${NESTED_CPUS:-2}")'
+            # Indicates the amount of memory in MB to use in the nested vm
+            NESTED_MEM: '$(HOST: echo "${NESTED_MEM:-4096}")'
+            SPREAD_URL: https://storage.googleapis.com/snapd-spread-tests/spread/spread-amd64.tar.gz
+
+        manual: true
+        prepare: |
+            #shellcheck source=tests/lib/pkgdb.sh
+            . "$TESTSLIB"/pkgdb.sh
+            #shellcheck source=tests/lib/image.sh
+            . "$TESTSLIB"/image.sh
+            distro_update_package_db
+            distro_install_package snapd qemu qemu-utils genisoimage sshpass qemu-kvm cloud-image-utils ovmf kpartx xz-utils mtools ca-certificates xdelta3
+            get_ubuntu_image
+  
+            # Install the snapd built
+            dpkg -i "$SPREAD_PATH"/../snapd_*.deb
+
+            # Configure the ssh connection to the test vm
+            remote.setup config --host localhost --port 8022 --user user1 --pass ubuntu
+
+            tests.nested prepare
+            tests.nested build-image core
+        prepare-each: |
+            "$TESTSLIB"/prepare-restore.sh --prepare-suite-each
+            tests.nested create-vm core --param-cpus "$NESTED_CPUS" --param-mem "$NESTED_MEM"
+
+        restore-each: |
+            tests.nested vm remove
+            "$TESTSLIB"/prepare-restore.sh --restore-suite-each
+
         restore: |
             tests.nested restore
 

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -1006,14 +1006,14 @@ nested_start_core_vm_unit() {
     # the caller can override PARAM_MEM
     local PARAM_MEM PARAM_SMP
     if [ "$SPREAD_BACKEND" = "google-nested" ] || [ "$SPREAD_BACKEND" = "google-nested-arm" ]; then
-        PARAM_MEM="${NESTED_PARAM_MEM:--m 4096}"
-        PARAM_SMP="-smp 2"
+        PARAM_MEM="-m ${NESTED_MEM:-4096}"
+        PARAM_SMP="-smp ${NESTED_CPUS:-2}"
     elif [ "$SPREAD_BACKEND" = "google-nested-dev" ]; then
-        PARAM_MEM="${NESTED_PARAM_MEM:--m 8192}"
-        PARAM_SMP="-smp 4"
+        PARAM_MEM="-m ${NESTED_MEM:-8192}"
+        PARAM_SMP="-smp ${NESTED_CPUS:-4}"
     elif [ "$SPREAD_BACKEND" = "qemu-nested" ]; then
-        PARAM_MEM="${NESTED_PARAM_MEM:--m 2048}"
-        PARAM_SMP="-smp 1"
+        PARAM_MEM="-m ${NESTED_MEM:-2048}"
+        PARAM_SMP="-smp ${NESTED_CPUS:-1}"
     else
         echo "unknown spread backend $SPREAD_BACKEND"
         exit 1
@@ -1352,13 +1352,14 @@ nested_start_classic_vm() {
     PARAM_SMP="-smp 1"
     # use only 2G of RAM for qemu-nested
     if [ "$SPREAD_BACKEND" = "google-nested" ]; then
-        PARAM_MEM="${NESTED_PARAM_MEM:--m 4096}"
-        PARAM_SMP="-smp 2"
+        PARAM_MEM="-m ${NESTED_MEM:-4096}"
+        PARAM_SMP="-smp ${NESTED_CPUS:-2}"
     elif [ "$SPREAD_BACKEND" = "google-nested-dev" ]; then
-        PARAM_MEM="${NESTED_PARAM_MEM:--m 8192}"
-        PARAM_SMP="-smp 4"
+        PARAM_MEM="-m ${NESTED_MEM:-8192}"
+        PARAM_SMP="-smp ${NESTED_CPUS:-4}"
     elif [ "$SPREAD_BACKEND" = "qemu-nested" ]; then
-        PARAM_MEM="${NESTED_PARAM_MEM:--m 2048}"
+        PARAM_MEM="-m ${NESTED_MEM:-2048}"
+        PARAM_SMP="-smp ${NESTED_CPUS:-1}"
     else
         echo "unknown spread backend $SPREAD_BACKEND"
         exit 1

--- a/tests/lib/tools/tests.nested
+++ b/tests/lib/tools/tests.nested
@@ -4,7 +4,7 @@ show_help() {
     echo "usage: prepare"
     echo "       restore"
     echo "       build-image IMAGE-TYPE"
-    echo "       create-vm IMAGE-TYPE [--param-cdrom PARAM] [--param-mem PARAM]"
+    echo "       create-vm IMAGE-TYPE [--param-cdrom PARAM] [--param-cpus PARAM] [--param-mem PARAM]"
     echo "       is-nested [core|classic|uc16|uc18|uc20|uc22]"
     echo "       show [ATTRIBUTE]"
     echo "       vm <ACTION>"
@@ -131,7 +131,7 @@ create_vm() {
             ;;
     esac
 
-    local NESTED_PARAM_CD NESTED_PARAM_MEM NESTED_PARAM_EXTRA NESTED_TPM_NO_RESTART
+    local NESTED_PARAM_CD NESTED_CPUS NESTED_MEM NESTED_PARAM_EXTRA NESTED_TPM_NO_RESTART
     while [ $# -gt 0 ]; do
         case "$1" in
             --param-cdrom)
@@ -139,7 +139,11 @@ create_vm() {
                 shift 2
                 ;;
             --param-mem)
-                NESTED_PARAM_MEM="$2"
+                NESTED_MEM="$2"
+                shift 2
+                ;;
+            --param-cpus)
+                NESTED_CPUS="$2"
                 shift 2
                 ;;
             --extra-param)
@@ -157,9 +161,9 @@ create_vm() {
         esac
     done
 
-    export NESTED_PARAM_CD NESTED_PARAM_MEM NESTED_PARAM_EXTRA NESTED_TPM_NO_RESTART
+    export NESTED_PARAM_CD NESTED_CPUS NESTED_MEM NESTED_PARAM_EXTRA NESTED_TPM_NO_RESTART
     "$action"
-    unset NESTED_PARAM_CD NESTED_PARAM_MEM NESTED_PARAM_EXTRA NESTED_TPM_NO_RESTART
+    unset NESTED_PARAM_CD NESTED_CPUS NESTED_MEM NESTED_PARAM_EXTRA NESTED_TPM_NO_RESTART
 }
 
 is_nested() {

--- a/tests/nested/manual/minimal-smoke/task.yaml
+++ b/tests/nested/manual/minimal-smoke/task.yaml
@@ -1,5 +1,10 @@
 summary: execute smoke tests in a nested Ubuntu Core VM that meets the minimal requirements
 
+details: |
+    Verify that it is possible to run the smoke test suite in ubuntu core system using the
+    minimal memory requirements. The memory requirement varies depending on the
+    ubuntu core version.
+
 systems: [ubuntu-16.04-64, ubuntu-18.04-64, ubuntu-20.04-64, ubuntu-22.04-64]
 
 environment:

--- a/tests/nested/manual/minimal-smoke/task.yaml
+++ b/tests/nested/manual/minimal-smoke/task.yaml
@@ -35,7 +35,7 @@ execute: |
         exit 1
     fi
 
-    tests.nested create-vm core --param-mem "-m $MINIMAL_MEM"
+    tests.nested create-vm core --param-mem "$MINIMAL_MEM"
 
     echo "Run spread smoke tests using mem: $MINIMAL_MEM"
     set +x

--- a/tests/nested/perf/interfaces-core-provided/task.yaml
+++ b/tests/nested/perf/interfaces-core-provided/task.yaml
@@ -1,0 +1,43 @@
+summary: Ensure that commands run when their core provided interfaces are connected
+
+details: |
+    Install a test snap that plugs as many core provided interfaces as is 
+    possible and verify the command can run (ie, don't test the interface 
+    functionality itself). This will help catch things like AppArmor 
+    policy syntax errors, seccomp policy parsing, udev querying bugs, etc.
+
+environment:
+    CONSUMER_SNAP: test-snapd-policy-app-consumer
+    SPREAD_EXTERNAL_ADDRESS: localhost:8022
+    CONNECTIONS_PERCENTAGE/100_connected: 100
+    DISCONNECT_INTERFACES/100_connected: false
+    NESTED_CPUS/100_connected: 1
+    NESTED_MEM/100_connected: 512
+    CONNECTIONS_PERCENTAGE/100_disconnected: 100
+    DISCONNECT_INTERFACES/100_disconnected: true
+    NESTED_CPUS/100_disconnected: 1
+    NESTED_MEM/100_disconnected: 512
+
+execute: |
+    if os.query is-ubuntu 16.04; then
+        NESTED_SPREAD_SYSTEM=ubuntu-core-16-64
+    elif os.query is-ubuntu 18.04; then
+        NESTED_SPREAD_SYSTEM=ubuntu-core-18-64
+    elif os.query is-ubuntu 20.04; then
+        NESTED_SPREAD_SYSTEM=ubuntu-core-20-64
+    elif os.query is-ubuntu 22.04; then
+        NESTED_SPREAD_SYSTEM=ubuntu-core-22-64
+    else
+        echo "unsupported nested system"
+        exit 1
+    fi
+
+    # Get spread
+    SPREAD="$(tests.nested download spread)"
+
+    # Run sprad test
+    set +x
+    export SPREAD_EXTERNAL_ADDRESS=localhost:8022
+    export PERF_CONNECTIONS_PERCENTAGE="$CONNECTIONS_PERCENTAGE"
+    export PERF_DISCONNECT_INTERFACES="$DISCONNECT_INTERFACES"    
+    "$SPREAD" external:"$NESTED_SPREAD_SYSTEM":tests/perf/interfaces-core-provided

--- a/tests/perf/interfaces-core-provided/task.yaml
+++ b/tests/perf/interfaces-core-provided/task.yaml
@@ -39,7 +39,7 @@ execute: |
 
         # Just connect CONNECTIONS_PERCENTAGE of the interfaces on
         # the current system
-        if [ -n "$CONNECTIONS_PERCENTAGE" ] && [ "$((RANDOM % ((100/$CONNECTIONS_PERCENTAGE)) ))" != 0 ]; then
+        if [ -n "$CONNECTIONS_PERCENTAGE" ] && [ "$((RANDOM % (100 / CONNECTIONS_PERCENTAGE) ))" != 0 ]; then
             echo "skipping plug: $plugcmd"
             continue
         fi

--- a/tests/perf/interfaces-core-provided/task.yaml
+++ b/tests/perf/interfaces-core-provided/task.yaml
@@ -1,0 +1,130 @@
+summary: Ensure that commands run when their core provided interfaces are connected
+
+details: |
+    Install a test snap that plugs as many core provided interfaces as is 
+    possible and verify the command can run (ie, don't test the interface 
+    functionality itself). This will help catch things like AppArmor 
+    policy syntax errors, seccomp policy parsing, udev querying bugs, etc.
+
+environment:
+    CONSUMER_SNAP: test-snapd-policy-app-consumer    
+
+prepare: |
+    echo "Given a snap is installed"
+    "$TESTSTOOLS"/snaps-state install-local "$CONSUMER_SNAP"
+
+    # If possible, prepare a session for the test user. On many systems this
+    # will allow running all tests as the unprivileged user. This shields us
+    # from accidentally triggering any additional processes from run in the
+    # session of the root user and stay behind after this test terminates.
+    if tests.session has-session-systemd-and-dbus; then
+        tests.session -u test prepare
+    fi
+
+restore: |
+    # Remove the snaps to avoid timeout in next test    
+    if tests.session has-session-systemd-and-dbus; then
+        tests.session -u test restore
+    fi
+
+debug: |
+    # get the full journal to see any out-of-memory errors
+    # shellcheck disable=SC2119
+    "$TESTSTOOLS"/journal-state get-log
+
+execute: |
+    echo "For each core-provided slot"
+    SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
+    for plugcmd in "$SNAP_MOUNT_DIR"/bin/"$CONSUMER_SNAP".* ; do
+
+        # Just connect CONNECTIONS_PERCENTAGE of the interfaces on
+        # the current system
+        if [ -n "$CONNECTIONS_PERCENTAGE" ] && [ "$((RANDOM % ((100/$CONNECTIONS_PERCENTAGE)) ))" != 0 ]; then
+            echo "skipping plug: $plugcmd"
+            continue
+        fi
+
+        plugcmd_bn=$(basename "$plugcmd")
+        plug_iface=$(echo "$plugcmd_bn" | tr '.' ':')
+        #shellcheck disable=SC2001
+        slot_iface=$(echo "$plug_iface" | sed "s/$CONSUMER_SNAP//")
+
+        # we test browser-support two different ways, so account for that
+        if [ "$plug_iface" = "$CONSUMER_SNAP:browser-sandbox" ]; then
+            slot_iface=":browser-support"
+        fi
+
+        CONNECTED_PATTERN="$slot_iface +.*$CONSUMER_SNAP"
+        DISCONNECTED_PATTERN="$slot_iface +-"
+
+        # Skip any interfaces that core doesn't ship
+        if ! snap interfaces | grep -E -q "$slot_iface +"; then
+            echo "$slot_iface not present, skipping"
+            continue
+        fi
+
+        if [ "$plug_iface" = "$CONSUMER_SNAP:qualcomm-ipc-router" ] && ( os.query is-trusty || os.query is-xenial || os.query is-core16) ; then
+            # the qualcomm-ipc-router interface is known not to work on xenial,
+            # just check that it cannot be connected and move on
+            snap connect "$plug_iface" "$slot_iface" 2>&1 | MATCH "cannot connect plug on system without qipcrtr socket support"
+            continue
+        fi
+
+        if [ "$plug_iface" = "$CONSUMER_SNAP:mount-control" ] && os.query is-trusty ; then
+            # systemd version is too old, skipping
+            snap connect "$plug_iface" "$slot_iface" 2>&1 | MATCH "systemd version 204 is too old \\(expected at least 209\\)"
+            continue
+        fi
+
+        # The netlink-audit interface adds the `audit_read` capability to the
+        # AppArmor profile, but that's not supported on some older systems
+        if [ "$plug_iface" = "$CONSUMER_SNAP:netlink-audit" ] && os.query is-trusty; then
+            snap connect "$plug_iface" "$slot_iface" 2>&1 | MATCH "cannot connect plug on system without audit_read support"
+            continue
+        fi
+
+        echo "When slot $slot_iface is connected"
+        if snap interfaces | grep -E -q "$DISCONNECTED_PATTERN"; then
+            if [ "$slot_iface" = ":broadcom-asic-control" ] || [ "$slot_iface" = ":firewall-control" ] || [ "$slot_iface" = ":kubernetes-support" ] || [ "$slot_iface" = ":microstack-support" ] || [ "$slot_iface" = ":openvswitch-support" ] || [ "$slot_iface" = ":ppp" ]; then
+                # TODO: when the kmod backend no longer fails on missing
+                # modules, we can remove this
+                snap connect "$plug_iface" "$slot_iface" || true
+            else
+                snap connect "$plug_iface" "$slot_iface"
+            fi
+        fi
+        snap interfaces | MATCH "$CONNECTED_PATTERN"
+
+        echo "Then $plugcmd should succeed"
+        if tests.session has-session-systemd-and-dbus; then
+            tests.session -u test exec "$plugcmd" | MATCH PASS
+        else
+            # If we cannot run the plug command as the test user, in the
+            # relative safety of the user session which gets torn down, then
+            # run the test directly EXCEPT when testing the desktop interface.
+            #
+            # The desktop interface causes, at minimum, XDG document portal to
+            # activate in the root users's session, which is not cleaned up.
+            # Since that interface will only be used in a real session, leaving
+            # it out is acceptable.
+            if [ "$plugcmd" != "${CONSUMER_SNAP}.desktop" ]; then
+                "$plugcmd" | MATCH PASS
+            else
+                echo "skipping $plugcmd on an unsupported system"
+            fi
+        fi
+
+        echo "Finally disconnect the interface"
+        if [ "$DISCONNECT_INTERFACES" == true ] && snap interfaces | grep -E -q "$CONNECTED_PATTERN"; then
+            if [ "$plug_iface" = "$CONSUMER_SNAP:browser-sandbox" ]; then
+                snap disconnect "$CONSUMER_SNAP:browser-support" "$slot_iface"
+            else
+                snap disconnect "$plug_iface" "$slot_iface"
+            fi
+        fi
+    done
+
+    echo "Removing the consumer snap"
+    # When DISCONNECT_INTERFACES = false, then all the interfaces are connected and 
+    # are disconnected suring the snap removal
+    snap remove --purge "$CONSUMER_SNAP"


### PR DESCRIPTION
This is the initial change to support performance tests.

These new tests have to be able to run either in nested vms and in external devices.
The idea is to run nightly and on demand on nested vms and also as part of regular runs on specific devices.

The initial test is about connecting and disconnecting interfaces, covering a specific percentage of those and also test how the system behaves when all are connected together.

