### PR TITLE
tests: avoid removing preinstalled snaps in external devices

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -1443,6 +1443,16 @@ prepare_ubuntu_core() {
         # Create the file with the initial environment before saving the state
         tests.env start initial
 
+        # save preinstalled snaps when tests are executed in external systems
+        # the preinstalled snaps shouldn't be removed during tests clean up
+        # this is needed just for external devices because those could be using
+        # custom images with pre-installed snaps which cannot be removed, such
+        # as the network-manager.
+        if [ "$SPREAD_BACKEND" == "external" ]; then
+            PREINSTALLED_SNAPS="$(snap list | tail -n +2 | awk '{print $1}' | tr '\n' ' ')"
+            tests.env set initial PREINSTALLED_SNAPS "$PREINSTALLED_SNAPS"
+        fi
+
         # important to remove disabled snaps before calling save_snapd_state
         # or restore will break
         remove_disabled_snaps

--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -127,7 +127,9 @@ reset_all_snap() {
     fi
 
     skip_snaps=""
-    for skip_remove_snap in $SKIP_REMOVE_SNAPS; do
+
+    PREINSTALLED_SNAPS="$(tests.env get initial PREINSTALLED_SNAPS)"
+    for skip_remove_snap in $SKIP_REMOVE_SNAPS $PREINSTALLED_SNAPS; do
         skip_snaps="$skip_snaps --skip $skip_remove_snap"
     done
     # shellcheck disable=SC2086


### PR DESCRIPTION
Save preinstalled snaps when tests are executed in external systems 
The preinstalled snaps shouldn't be removed during tests clean up 
This is needed just for external devices because those could be using custom images with pre-installed snaps which cannot be removed, such as the network-manager.
