### PR TITLE
osutil/mkfs: disable orphan_file feature for ext4

### DIFF
--- a/osutil/mkfs/mkfs.go
+++ b/osutil/mkfs/mkfs.go
@@ -72,7 +72,7 @@ func mkfsExt4(img, label, contentsRootDir string, deviceSize, sectorSize quantit
 	// Switched to use mkfs defaults for https://bugs.launchpad.net/snappy/+bug/1878374
 	// For caveats/requirements in case we need support for older systems:
 	// https://github.com/snapcore/snapd/pull/6997#discussion_r293967140
-	mkfsArgs := []string{"mkfs.ext4"}
+	mkfsArgs := []string{"mkfs.ext4", "-O", "^orphan_file"}
 
 	const size32MiB = 32 * quantity.SizeMiB
 	if deviceSize != 0 && deviceSize <= size32MiB {

--- a/osutil/mkfs/mkfs_test.go
+++ b/osutil/mkfs/mkfs_test.go
@@ -29,6 +29,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/osutil/mkfs"
+	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -69,7 +70,6 @@ func (m *mkfsSuite) TestMkfsExt4Happy(c *C) {
 		{
 			"fakeroot",
 			"mkfs.ext4",
-			"-O", "^orphan_file",
 			"-d", "contents",
 			"-L", "my-label",
 			"foo.img",
@@ -85,7 +85,6 @@ func (m *mkfsSuite) TestMkfsExt4Happy(c *C) {
 		{
 			"fakeroot",
 			"mkfs.ext4",
-			"-O", "^orphan_file",
 			"-d", "contents",
 			"foo.img",
 		},
@@ -100,12 +99,28 @@ func (m *mkfsSuite) TestMkfsExt4Happy(c *C) {
 		{
 			"fakeroot",
 			"mkfs.ext4",
-			"-O", "^orphan_file",
 			"-L", "my-label",
 			"foo.img",
 		},
 	})
 
+	cmd.ForgetCalls()
+
+	// when running on Lunar, remove orphan_file feature
+	restore := release.MockReleaseInfo(&release.OS{VersionID: "23.04"})
+	defer restore()
+
+	err = mkfs.Make("ext4", "foo.img", "my-label", 0, 0)
+	c.Assert(err, IsNil)
+	c.Check(cmd.Calls(), DeepEquals, [][]string{
+		{
+			"fakeroot",
+			"mkfs.ext4",
+			"-O", "^orphan_file",
+			"-L", "my-label",
+			"foo.img",
+		},
+	})
 }
 
 func (m *mkfsSuite) TestMkfsExt4WithSize(c *C) {
@@ -118,7 +133,6 @@ func (m *mkfsSuite) TestMkfsExt4WithSize(c *C) {
 		{
 			"fakeroot",
 			"mkfs.ext4",
-			"-O", "^orphan_file",
 			"-d", "contents",
 			"-L", "my-label",
 			"foo.img",
@@ -134,7 +148,6 @@ func (m *mkfsSuite) TestMkfsExt4WithSize(c *C) {
 		{
 			"fakeroot",
 			"mkfs.ext4",
-			"-O", "^orphan_file",
 			"-b", "1024",
 			"-d", "contents",
 			"foo.img",
@@ -150,7 +163,6 @@ func (m *mkfsSuite) TestMkfsExt4WithSize(c *C) {
 		{
 			"fakeroot",
 			"mkfs.ext4",
-			"-O", "^orphan_file",
 			"-b", "1024",
 			"-d", "contents",
 			"foo.img",
@@ -166,7 +178,6 @@ func (m *mkfsSuite) TestMkfsExt4WithSize(c *C) {
 		{
 			"fakeroot",
 			"mkfs.ext4",
-			"-O", "^orphan_file",
 			"-b", "4096",
 			"-d", "contents",
 			"foo.img",

--- a/osutil/mkfs/mkfs_test.go
+++ b/osutil/mkfs/mkfs_test.go
@@ -103,14 +103,17 @@ func (m *mkfsSuite) TestMkfsExt4Happy(c *C) {
 			"foo.img",
 		},
 	})
+}
 
-	cmd.ForgetCalls()
+func (m *mkfsSuite) TestMkfsExt4OnLunar(c *C) {
+	cmd := testutil.MockCommand(c, "fakeroot", "")
+	defer cmd.Restore()
 
 	// when running on Lunar, remove orphan_file feature
 	restore := release.MockReleaseInfo(&release.OS{VersionID: "23.04"})
 	defer restore()
 
-	err = mkfs.Make("ext4", "foo.img", "my-label", 0, 0)
+	err := mkfs.Make("ext4", "foo.img", "my-label", 0, 0)
 	c.Assert(err, IsNil)
 	c.Check(cmd.Calls(), DeepEquals, [][]string{
 		{

--- a/osutil/mkfs/mkfs_test.go
+++ b/osutil/mkfs/mkfs_test.go
@@ -69,6 +69,7 @@ func (m *mkfsSuite) TestMkfsExt4Happy(c *C) {
 		{
 			"fakeroot",
 			"mkfs.ext4",
+			"-O", "^orphan_file",
 			"-d", "contents",
 			"-L", "my-label",
 			"foo.img",
@@ -84,6 +85,7 @@ func (m *mkfsSuite) TestMkfsExt4Happy(c *C) {
 		{
 			"fakeroot",
 			"mkfs.ext4",
+			"-O", "^orphan_file",
 			"-d", "contents",
 			"foo.img",
 		},
@@ -98,6 +100,7 @@ func (m *mkfsSuite) TestMkfsExt4Happy(c *C) {
 		{
 			"fakeroot",
 			"mkfs.ext4",
+			"-O", "^orphan_file",
 			"-L", "my-label",
 			"foo.img",
 		},
@@ -115,6 +118,7 @@ func (m *mkfsSuite) TestMkfsExt4WithSize(c *C) {
 		{
 			"fakeroot",
 			"mkfs.ext4",
+			"-O", "^orphan_file",
 			"-d", "contents",
 			"-L", "my-label",
 			"foo.img",
@@ -130,6 +134,7 @@ func (m *mkfsSuite) TestMkfsExt4WithSize(c *C) {
 		{
 			"fakeroot",
 			"mkfs.ext4",
+			"-O", "^orphan_file",
 			"-b", "1024",
 			"-d", "contents",
 			"foo.img",
@@ -145,6 +150,7 @@ func (m *mkfsSuite) TestMkfsExt4WithSize(c *C) {
 		{
 			"fakeroot",
 			"mkfs.ext4",
+			"-O", "^orphan_file",
 			"-b", "1024",
 			"-d", "contents",
 			"foo.img",
@@ -160,6 +166,7 @@ func (m *mkfsSuite) TestMkfsExt4WithSize(c *C) {
 		{
 			"fakeroot",
 			"mkfs.ext4",
+			"-O", "^orphan_file",
 			"-b", "4096",
 			"-d", "contents",
 			"foo.img",


### PR DESCRIPTION
The SRU to fix [LP #2025339](https://bugs.launchpad.net/ubuntu/+source/e2fsprogs/+bug/2025339) has been rejected. So I would like to find a solution in snapd to fix https://bugs.launchpad.net/ubuntu-image/+bug/2028564.

Currently I disabled the `orphan_file` feature in every case but this will not work for series older than lunar because this feature was not present (mkfs.ext4 fails with a `Invalid filesystem option set: ^orphan_file` error). An ideal solution would be to do it only when running on Lunar. I am looking into it but do you know if there is already an easy way to check the series in snapd?

Currently, calling mkfs.ext4 without any option will result in a filesystem with the orphan_file feature disabled on mantic and up, so we do not loose anything setting it up explicitly for now.    
