### PR TITLE
many: skip binaries removal during refresh for RAA UX flow

### DIFF
--- a/overlord/snapstate/backend/link.go
+++ b/overlord/snapstate/backend/link.go
@@ -57,6 +57,10 @@ type LinkContext struct {
 	// RequireMountedSnapdSnap indicates that the apps and services
 	// generated when linking need to use tooling from the snapd snap mount.
 	RequireMountedSnapdSnap bool
+
+	// SkipBinaries indicates that we should skip removing snap binaries,
+	// icons and desktop files in UnlinkSnap
+	SkipBinaries bool
 }
 
 func updateCurrentSymlinks(info *snap.Info) (e error) {
@@ -123,7 +127,7 @@ func (b Backend) LinkSnap(info *snap.Info, dev snap.Device, linkCtx LinkContext,
 			return
 		}
 		timings.Run(tm, "remove-wrappers", fmt.Sprintf("remove wrappers of snap %s", info.InstanceName()), func(timings.Measurer) {
-			removeGeneratedWrappers(info, linkCtx.FirstInstall, progress.Null)
+			removeGeneratedWrappers(info, linkCtx, progress.Null)
 		})
 	}()
 
@@ -240,34 +244,37 @@ func (b Backend) generateWrappers(s *snap.Info, linkCtx LinkContext) error {
 	return nil
 }
 
-func removeGeneratedWrappers(s *snap.Info, firstInstallUndo bool, meter progress.Meter) error {
+func removeGeneratedWrappers(s *snap.Info, linkCtx LinkContext, meter progress.Meter) error {
 	if s.Type() == snap.TypeSnapd {
-		return removeGeneratedSnapdWrappers(s, firstInstallUndo, progress.Null)
+		return removeGeneratedSnapdWrappers(s, linkCtx.FirstInstall, progress.Null)
 	}
 
-	err1 := wrappers.RemoveSnapBinaries(s)
-	if err1 != nil {
-		logger.Noticef("Cannot remove binaries for %q: %v", s.InstanceName(), err1)
+	var err1, err2, err3 error
+	if !linkCtx.SkipBinaries {
+		err1 = wrappers.RemoveSnapBinaries(s)
+		if err1 != nil {
+			logger.Noticef("Cannot remove binaries for %q: %v", s.InstanceName(), err1)
+		}
+
+		err2 = wrappers.RemoveSnapDesktopFiles(s)
+		if err2 != nil {
+			logger.Noticef("Cannot remove desktop files for %q: %v", s.InstanceName(), err2)
+		}
+
+		err3 = wrappers.RemoveSnapIcons(s)
+		if err3 != nil {
+			logger.Noticef("Cannot remove desktop icons for %q: %v", s.InstanceName(), err3)
+		}
 	}
 
-	err2 := wrappers.RemoveSnapDBusActivationFiles(s)
-	if err2 != nil {
-		logger.Noticef("Cannot remove D-Bus activation for %q: %v", s.InstanceName(), err2)
-	}
-
-	err3 := wrappers.RemoveSnapServices(s, meter)
-	if err3 != nil {
-		logger.Noticef("Cannot remove services for %q: %v", s.InstanceName(), err3)
-	}
-
-	err4 := wrappers.RemoveSnapDesktopFiles(s)
+	err4 := wrappers.RemoveSnapDBusActivationFiles(s)
 	if err4 != nil {
-		logger.Noticef("Cannot remove desktop files for %q: %v", s.InstanceName(), err4)
+		logger.Noticef("Cannot remove D-Bus activation for %q: %v", s.InstanceName(), err4)
 	}
 
-	err5 := wrappers.RemoveSnapIcons(s)
+	err5 := wrappers.RemoveSnapServices(s, meter)
 	if err5 != nil {
-		logger.Noticef("Cannot remove desktop icons for %q: %v", s.InstanceName(), err5)
+		logger.Noticef("Cannot remove services for %q: %v", s.InstanceName(), err5)
 	}
 
 	return firstErr(err1, err2, err3, err4, err5)
@@ -309,7 +316,7 @@ func (b Backend) UnlinkSnap(info *snap.Info, linkCtx LinkContext, meter progress
 	}
 
 	// remove generated services, binaries etc
-	err1 := removeGeneratedWrappers(info, linkCtx.FirstInstall, meter)
+	err1 := removeGeneratedWrappers(info, linkCtx, meter)
 
 	// and finally remove current symlinks
 	err2 := removeCurrentSymlinks(info)

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -71,6 +71,7 @@ type fakeOp struct {
 
 	otherInstances         bool
 	unlinkFirstInstallUndo bool
+	unlinkSkipBinaries     bool
 	skipKernelExtraction   bool
 
 	services         []string
@@ -1219,6 +1220,7 @@ func (f *fakeSnappyBackend) UnlinkSnap(info *snap.Info, linkCtx backend.LinkCont
 		path: info.MountDir(),
 
 		unlinkFirstInstallUndo: linkCtx.FirstInstall,
+		unlinkSkipBinaries:     linkCtx.SkipBinaries,
 	})
 	return f.maybeErrForLastOp()
 }

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -537,6 +537,7 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 		prev = removeAliases
 
 		unlink := st.NewTask("unlink-current-snap", fmt.Sprintf(i18n.G("Make current revision for snap %q unavailable"), snapsup.InstanceName()))
+		unlink.Set("unlink-reason", unlinkReasonRefresh)
 		addTask(unlink)
 		prev = unlink
 	}
@@ -2956,6 +2957,7 @@ func MigrateHome(st *state.State, snaps []string) ([]*state.TaskSet, error) {
 		prev = stop
 
 		unlink := st.NewTask("unlink-current-snap", fmt.Sprintf(i18n.G("Make current revision for snap %q unavailable"), name))
+		unlink.Set("unlink-reason", unlinkReasonHomeMigration)
 		addTask(unlink)
 		prev = unlink
 

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -2216,7 +2216,7 @@ version: 1.0`)
 	c.Assert(snapst.LocalRevision(), Equals, snap.R(-1))
 }
 
-func (s *snapmgrTestSuite) TestInstallSubsequentLocalRunThrough(c *C) {
+func (s *snapmgrTestSuite) testInstallSubsequentLocalRunThrough(c *C, refreshAppAwarenessUX bool) {
 	// use the real thing for this one
 	snapstate.MockOpenSnapFile(backend.OpenSnapFile)
 
@@ -2265,8 +2265,9 @@ epoch: 1*
 			inhibitHint: "refresh",
 		},
 		{
-			op:   "unlink-snap",
-			path: filepath.Join(dirs.SnapMountDir, "mock/x2"),
+			op:                 "unlink-snap",
+			path:               filepath.Join(dirs.SnapMountDir, "mock/x2"),
+			unlinkSkipBinaries: refreshAppAwarenessUX,
 		},
 		{
 			op:   "copy-data",
@@ -2342,6 +2343,15 @@ epoch: 1*
 		Revision: snap.R(-3),
 	})
 	c.Assert(snapst.LocalRevision(), Equals, snap.R(-3))
+}
+
+func (s *snapmgrTestSuite) TestInstallSubsequentLocalRunThrough(c *C) {
+	s.testInstallSubsequentLocalRunThrough(c, false)
+}
+
+func (s *snapmgrTestSuite) TestInstallSubsequentLocalRunThroughSkipBinaries(c *C) {
+	s.enableRefreshAppAwarenessUX()
+	s.testInstallSubsequentLocalRunThrough(c, true)
 }
 
 func (s *snapmgrTestSuite) TestInstallOldSubsequentLocalRunThrough(c *C) {


### PR DESCRIPTION
This PR acts as the glue for all previous building blocks. It allows skipping binaries removal during refresh for the refresh-app-awareness UX flow.

- `LinkContext.SkipBinaries` is added to allow `unlink-current-snap` task to skip removing the snap's binaries when RAA is enabled when snap run is inhibited

For context: https://github.com/snapcore/snapd/pull/13066