### PR TITLE
aspects: Get() matches request on prefixes and returns results in a merged namespace

### DIFF
--- a/aspects/aspects.go
+++ b/aspects/aspects.go
@@ -24,7 +24,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
+	"reflect"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/snapcore/snapd/jsonutil"
@@ -60,17 +63,27 @@ type NotFoundError struct {
 	Account    string
 	BundleName string
 	Aspect     string
-	Field      string
+	Request    string
 	Cause      string
 }
 
 func (e *NotFoundError) Error() string {
-	return fmt.Sprintf("cannot find field %q of aspect %s/%s/%s: %s", e.Field, e.Account, e.BundleName, e.Aspect, e.Cause)
+	return fmt.Sprintf("cannot find value for %q in aspect %s/%s/%s: %s", e.Request, e.Account, e.BundleName, e.Aspect, e.Cause)
 }
 
 func (e *NotFoundError) Is(err error) bool {
 	_, ok := err.(*NotFoundError)
 	return ok
+}
+
+func notFoundErrorFrom(a *Aspect, request, errMsg string) *NotFoundError {
+	return &NotFoundError{
+		Account:    a.bundle.Account,
+		BundleName: a.bundle.Name,
+		Aspect:     a.Name,
+		Request:    request,
+		Cause:      errMsg,
+	}
 }
 
 // InvalidAccessError represents a failure to perform a read or write due to the
@@ -152,6 +165,7 @@ func newAspect(bundle *Bundle, name string, aspectPatterns []map[string]string) 
 		bundle:         bundle,
 	}
 
+	readRequests := make(map[string]bool)
 	for _, aspectPattern := range aspectPatterns {
 		request, ok := aspectPattern["request"]
 		if !ok || request == "" {
@@ -176,6 +190,14 @@ func newAspect(bundle *Bundle, name string, aspectPatterns []map[string]string) 
 
 		if err := validateRequestStoragePair(request, storage); err != nil {
 			return nil, err
+		}
+
+		switch aspectPattern["access"] {
+		case "read", "read-write", "":
+			if readRequests[request] {
+				return nil, fmt.Errorf(`cannot have several reading rules with the same "request" field`)
+			}
+			readRequests[request] = true
 		}
 
 		accPattern, err := newAccessPattern(request, storage, aspectPattern["access"])
@@ -280,12 +302,12 @@ type Aspect struct {
 func (a *Aspect) Set(databag DataBag, request string, value interface{}) error {
 	requestSubkeys := strings.Split(request, ".")
 	for _, accessPatt := range a.accessPatterns {
-		placeholders, ok := accessPatt.match(requestSubkeys)
+		placeholders, _, ok := accessPatt.match(requestSubkeys)
 		if !ok {
 			continue
 		}
 
-		storagePath, err := accessPatt.getStorage(placeholders)
+		storagePath, err := accessPatt.storagePath(placeholders)
 		if err != nil {
 			return err
 		}
@@ -306,57 +328,144 @@ func (a *Aspect) Set(databag DataBag, request string, value interface{}) error {
 		return a.bundle.schema.Validate(data)
 	}
 
-	return &NotFoundError{
-		Account:    a.bundle.Account,
-		BundleName: a.bundle.Name,
-		Aspect:     a.Name,
-		Field:      request,
-		Cause:      "field not found",
-	}
+	return notFoundErrorFrom(a, request, "no matching rule")
 }
 
-// Get returns the aspect value identified by the name. If either the named aspect
-// or the corresponding value can't be found, a NotFoundError is returned.
-func (a *Aspect) Get(databag DataBag, request string, value interface{}) error {
+// Get returns the aspect value identified by the request. If either the named
+// aspect or the corresponding value can't be found, a NotFoundError is returned.
+func (a *Aspect) Get(databag DataBag, request string, value *interface{}) error {
+	matches, err := a.matchGetRequest(request)
+	if err != nil {
+		return err
+	}
+
+	var merged interface{}
+	for _, match := range matches {
+		var val interface{}
+		if err := databag.Get(match.storagePath, &val); err != nil {
+			if errors.Is(err, PathNotFoundError("")) {
+				continue
+			}
+			return err
+		}
+
+		// build namespace around result
+		namespace := match.namespace
+		for i := len(namespace) - 1; i >= 0; i-- {
+			val = map[string]interface{}{namespace[i]: val}
+		}
+
+		// merge result with results from other matching rules
+		merged, err = merge(merged, val)
+		if err != nil {
+			return err
+		}
+	}
+
+	if merged == nil {
+		return notFoundErrorFrom(a, request, "no stored value for matching rules")
+	}
+
+	// the top level maps the request to the remaining namespace
+	*value = map[string]interface{}{request: merged}
+	return nil
+}
+
+func merge(old, new interface{}) (interface{}, error) {
+	if old == nil {
+		return new, nil
+	} else if new == nil {
+		return old, nil
+	}
+
+	oldType, newType := reflect.TypeOf(old).Kind(), reflect.TypeOf(new).Kind()
+	if oldType != newType {
+		return nil, fmt.Errorf("cannot merge results of different types %T, %T", old, new)
+	}
+
+	if oldType != reflect.Map {
+		// if the values are both scalars/lists, the new replaces the old value
+		return new, nil
+	}
+
+	// if the values are maps, merge them recursively
+	oldMap, newMap := old.(map[string]interface{}), new.(map[string]interface{})
+	for k, v := range newMap {
+		if storeVal, ok := oldMap[k]; ok {
+			merged, err := merge(storeVal, v)
+			if err != nil {
+				return nil, err
+			}
+			v = merged
+		}
+
+		oldMap[k] = v
+	}
+
+	return oldMap, nil
+}
+
+type match struct {
+	// storagePath contains the storage path specified in the matching entry with
+	// any placeholders provided by the request filled in.
+	storagePath string
+
+	// namespace contains the unmatched parts of the entry's request.
+	namespace []string
+}
+
+// matchGetRequest either returns the first exact match for the request or, if
+// no entry is an exact match, one or more entries that the request matches a
+// prefix of. If no match is found, a NotFoundError is returned.
+func (a *Aspect) matchGetRequest(request string) (matches []match, err error) {
 	subkeys := strings.Split(request, ".")
+
 	for _, accessPatt := range a.accessPatterns {
-		placeholders, ok := accessPatt.match(subkeys)
+		placeholders, unmatched, ok := accessPatt.match(subkeys)
 		if !ok {
 			continue
 		}
 
-		storagePath, err := accessPatt.getStorage(placeholders)
+		path, err := accessPatt.storagePath(placeholders)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		if !accessPatt.isReadable() {
-			return &InvalidAccessError{RequestedAccess: read, FieldAccess: accessPatt.access, Field: request}
+			return nil, &InvalidAccessError{RequestedAccess: read, FieldAccess: accessPatt.access, Field: request}
 		}
 
-		if err := databag.Get(storagePath, value); err != nil {
-			var pathErr PathNotFoundError
-			if errors.As(err, &pathErr) {
-				return &NotFoundError{
-					Account:    a.bundle.Account,
-					BundleName: a.bundle.Name,
-					Aspect:     a.Name,
-					Field:      request,
-					Cause:      string(pathErr),
-				}
-			}
-			return err
-		}
-		return nil
+		m := match{storagePath: path, namespace: unmatched}
+		matches = append(matches, m)
 	}
 
-	return &NotFoundError{
-		Account:    a.bundle.Account,
-		BundleName: a.bundle.Name,
-		Aspect:     a.Name,
-		Field:      request,
-		Cause:      "field not found",
+	// sort matches by namespace to ensure that nested matches are read after
+	sort.Sort(byNamespace(matches))
+
+	if len(matches) == 0 {
+		return nil, notFoundErrorFrom(a, request, "no matching rule")
 	}
+
+	return matches, nil
+}
+
+type byNamespace []match
+
+func (b byNamespace) Len() int      { return len(b) }
+func (b byNamespace) Swap(x, y int) { b[x], b[y] = b[y], b[x] }
+func (b byNamespace) Less(x, y int) bool {
+	xNamespace, yNamespace := b[x].namespace, b[y].namespace
+
+	minLen := int(math.Min(float64(len(xNamespace)), float64(len(yNamespace))))
+	for i := 0; i < minLen; i++ {
+		if xNamespace[i] < yNamespace[i] {
+			return true
+		} else if xNamespace[i] > yNamespace[i] {
+			return false
+		}
+	}
+
+	return len(xNamespace) < len(yNamespace)
 }
 
 func newAccessPattern(request, storage, accesstype string) (*accessPattern, error) {
@@ -392,9 +501,10 @@ func newAccessPattern(request, storage, accesstype string) (*accessPattern, erro
 	}
 
 	return &accessPattern{
-		request: requestMatchers,
-		storage: pathWriters,
-		access:  accType,
+		originalRequest: request,
+		request:         requestMatchers,
+		storage:         pathWriters,
+		access:          accType,
 	}, nil
 }
 
@@ -406,34 +516,37 @@ func isPlaceholder(part string) bool {
 // to match a request and map it into a corresponding storage, potentially with
 // placeholders filled in.
 type accessPattern struct {
-	request []requestMatcher
-	storage []storageWriter
-	access  accessType
+	originalRequest string
+	request         []requestMatcher
+	storage         []storageWriter
+	access          accessType
 }
 
-// match takes a list of subkeys and returns true if those subkeys match the pattern's
-// name. If the name contains placeholders, those will be mapped to their values in
-// the supplied subkeys and set in the map. Example: if pattern.name=["{foo}", "b", "{bar}"],
-// and nameSubkeys=["a", "b", "c"], then it returns true and the map will contain
-// {"foo": "a", "bar": "c"}.
-func (p *accessPattern) match(reqSubkeys []string) (map[string]string, bool) {
-	if len(p.request) != len(reqSubkeys) {
-		return nil, false
+// match returns true if the subkeys match the pattern exactly or as a prefix.
+// If placeholders are "filled in" when matching, those are returned in a map.
+// If the subkeys match as a prefix, the unmatched subkeys are returned.
+func (p *accessPattern) match(reqSubkeys []string) (placeholders map[string]string, unmatched []string, match bool) {
+	if len(p.request) < len(reqSubkeys) {
+		return nil, nil, false
 	}
 
-	placeholders := make(map[string]string)
+	placeholders = make(map[string]string)
 	for i, subkey := range reqSubkeys {
 		if !p.request[i].match(subkey, placeholders) {
-			return nil, false
+			return nil, nil, false
 		}
 	}
 
-	return placeholders, true
+	for _, key := range p.request[len(reqSubkeys):] {
+		unmatched = append(unmatched, key.String())
+	}
+
+	return placeholders, unmatched, true
 }
 
-// getStorage takes a map of placeholders to their values in the aspect name and
+// storagePath takes a map of placeholders to their values in the aspect name and
 // returns the path with its placeholder values filled in with the map's values.
-func (p *accessPattern) getStorage(placeholders map[string]string) (string, error) {
+func (p *accessPattern) storagePath(placeholders map[string]string) (string, error) {
 	sb := &strings.Builder{}
 
 	for _, subkey := range p.storage {
@@ -443,6 +556,7 @@ func (p *accessPattern) getStorage(placeholders map[string]string) (string, erro
 			}
 		}
 
+		// TODO: this doesn't support unmatched placeholders yet
 		if err := subkey.write(sb, placeholders); err != nil {
 			return "", err
 		}
@@ -464,6 +578,7 @@ func (p accessPattern) isWriteable() bool {
 // can be a literal value of a placeholder delineated by curly brackets.
 type requestMatcher interface {
 	match(subkey string, placeholders map[string]string) bool
+	String() string
 }
 
 type storageWriter interface {
@@ -495,6 +610,11 @@ func (p placeholder) write(sb *strings.Builder, placeholders map[string]string) 
 	return err
 }
 
+// String returns the placeholder as a string.
+func (p placeholder) String() string {
+	return "{" + string(p) + "}"
+}
+
 // literal is a non-placeholder name/path subkey.
 type literal string
 
@@ -507,6 +627,11 @@ func (p literal) match(subkey string, _ map[string]string) bool {
 func (p literal) write(sb *strings.Builder, _ map[string]string) error {
 	_, err := sb.WriteString(string(p))
 	return err
+}
+
+// String returns the literal as a string.
+func (p literal) String() string {
+	return string(p)
 }
 
 type PathNotFoundError string

--- a/aspects/aspects_test.go
+++ b/aspects/aspects_test.go
@@ -198,22 +198,22 @@ func (s *aspectSuite) TestAspectNotFound(c *C) {
 	var value interface{}
 	err = aspect.Get(databag, "missing", &value)
 	c.Assert(err, testutil.ErrorIs, &aspects.NotFoundError{})
-	c.Assert(err, ErrorMatches, `cannot find value for "missing" in aspect acc/foo/bar: no matching rule`)
+	c.Assert(err, ErrorMatches, `cannot find value for "missing" in aspect acc/foo/bar: no matching read rule`)
 
 	err = aspect.Set(databag, "missing", "thing")
 	c.Assert(err, testutil.ErrorIs, &aspects.NotFoundError{})
-	c.Assert(err, ErrorMatches, `cannot find value for "missing" in aspect acc/foo/bar: no matching rule`)
+	c.Assert(err, ErrorMatches, `cannot find value for "missing" in aspect acc/foo/bar: no matching write rule`)
 
 	err = aspect.Get(databag, "top-level", &value)
 	c.Assert(err, testutil.ErrorIs, &aspects.NotFoundError{})
-	c.Assert(err, ErrorMatches, `cannot find value for "top-level" in aspect acc/foo/bar: no stored value for matching rules`)
+	c.Assert(err, ErrorMatches, `cannot find value for "top-level" in aspect acc/foo/bar: no value for matching rules`)
 
 	err = aspect.Set(databag, "nested", "thing")
 	c.Assert(err, IsNil)
 
 	err = aspect.Get(databag, "other-nested", &value)
 	c.Assert(err, testutil.ErrorIs, &aspects.NotFoundError{})
-	c.Assert(err, ErrorMatches, `cannot find value for "other-nested" in aspect acc/foo/bar: no stored value for matching rules`)
+	c.Assert(err, ErrorMatches, `cannot find value for "other-nested" in aspect acc/foo/bar: no value for matching rules`)
 }
 
 func (s *aspectSuite) TestAspectBadRead(c *C) {
@@ -263,7 +263,7 @@ func (s *aspectSuite) TestAspectsAccessControl(c *C) {
 		{
 			request: "read-only",
 			// unrelated error
-			getErr: `cannot find value for "read-only" in aspect acc/bundle/foo: no stored value for matching rules`,
+			getErr: `cannot find value for "read-only" in aspect acc/bundle/foo: no value for matching rules`,
 			setErr: `cannot write field "read-only": only supports read access`,
 		},
 		{

--- a/aspects/aspects_test.go
+++ b/aspects/aspects_test.go
@@ -36,40 +36,59 @@ func Test(t *testing.T) { TestingT(t) }
 var _ = Suite(&aspectSuite{})
 
 func (*aspectSuite) TestNewAspectBundle(c *C) {
-	_, err := aspects.NewAspectBundle("acc", "foo", nil, aspects.NewJSONSchema())
-	c.Assert(err, ErrorMatches, `cannot define aspects bundle: no aspects`)
+	type testcase struct {
+		bundle map[string]interface{}
+		err    string
+	}
 
-	_, err = aspects.NewAspectBundle("acc", "foo", map[string]interface{}{
-		"bar": "baz",
-	}, aspects.NewJSONSchema())
-	c.Assert(err, ErrorMatches, `cannot define aspect "bar": access patterns should be a list of maps`)
-
-	_, err = aspects.NewAspectBundle("acc", "foo", map[string]interface{}{
-		"bar": []map[string]string{},
-	}, aspects.NewJSONSchema())
-	c.Assert(err, ErrorMatches, `cannot define aspect "bar": no access patterns found`)
-
-	_, err = aspects.NewAspectBundle("acc", "foo", map[string]interface{}{
-		"bar": []map[string]string{
-			{"storage": "foo"},
+	tcs := []testcase{
+		{
+			err: `cannot define aspects bundle: no aspects`,
 		},
-	}, aspects.NewJSONSchema())
-	c.Assert(err, ErrorMatches, `cannot define aspect "bar": access patterns must have a "request" field`)
-
-	_, err = aspects.NewAspectBundle("acc", "foo", map[string]interface{}{
-		"bar": []map[string]string{
-			{"request": "foo"},
+		{
+			bundle: map[string]interface{}{"bar": "baz"},
+			err:    `cannot define aspect "bar": access patterns should be a list of maps`,
 		},
-	}, aspects.NewJSONSchema())
-	c.Assert(err, ErrorMatches, `cannot define aspect "bar": access patterns must have a "storage" field`)
-
-	aspectBundle, err := aspects.NewAspectBundle("acc", "foo", map[string]interface{}{
-		"bar": []map[string]string{
-			{"request": "a", "storage": "b"},
+		{
+			bundle: map[string]interface{}{"bar": []map[string]string{}},
+			err:    `cannot define aspect "bar": no access patterns found`,
 		},
-	}, aspects.NewJSONSchema())
-	c.Assert(err, IsNil)
-	c.Check(aspectBundle, Not(IsNil))
+		{
+			bundle: map[string]interface{}{"bar": []map[string]string{{"storage": "foo"}}},
+			err:    `cannot define aspect "bar": access patterns must have a "request" field`,
+		},
+		{
+			bundle: map[string]interface{}{"bar": []map[string]string{{"request": "foo"}}},
+			err:    `cannot define aspect "bar": access patterns must have a "storage" field`,
+		},
+		{
+			bundle: map[string]interface{}{
+				"bar": []map[string]string{
+					{"request": "a", "storage": "b"},
+					{"request": "a", "storage": "c"},
+				},
+			},
+			err: `cannot define aspect "bar": cannot have several reading rules with the same "request" field`,
+		},
+		{
+			bundle: map[string]interface{}{
+				"bar": []map[string]string{
+					{"request": "a", "storage": "c", "access": "write"},
+					{"request": "a", "storage": "b"},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		aspectBundle, err := aspects.NewAspectBundle("acc", "foo", tc.bundle, aspects.NewJSONSchema())
+		if tc.err != "" {
+			c.Assert(err, ErrorMatches, tc.err)
+		} else {
+			c.Assert(err, IsNil)
+			c.Check(aspectBundle, Not(IsNil))
+		}
+	}
 }
 
 func (s *aspectSuite) TestAccessTypes(c *C) {
@@ -130,37 +149,37 @@ func (*aspectSuite) TestGetAndSetAspects(c *C) {
 	err = wsAspect.Set(databag, "ssid", "my-ssid")
 	c.Assert(err, IsNil)
 
-	var ssid string
+	var ssid interface{}
 	err = wsAspect.Get(databag, "ssid", &ssid)
 	c.Assert(err, IsNil)
-	c.Check(ssid, Equals, "my-ssid")
+	c.Check(ssid, DeepEquals, map[string]interface{}{"ssid": "my-ssid"})
 
 	// nested list value
 	err = wsAspect.Set(databag, "ssids", []string{"one", "two"})
 	c.Assert(err, IsNil)
 
-	var ssids []string
+	var ssids interface{}
 	err = wsAspect.Get(databag, "ssids", &ssids)
 	c.Assert(err, IsNil)
-	c.Check(ssids, DeepEquals, []string{"one", "two"})
+	c.Check(ssids, DeepEquals, map[string]interface{}{"ssids": []interface{}{"one", "two"}})
 
 	// top-level string
-	var topLevel string
+	var topLevel interface{}
 	err = wsAspect.Set(databag, "top-level", "randomValue")
 	c.Assert(err, IsNil)
 
 	err = wsAspect.Get(databag, "top-level", &topLevel)
 	c.Assert(err, IsNil)
-	c.Check(topLevel, Equals, "randomValue")
+	c.Check(topLevel, DeepEquals, map[string]interface{}{"top-level": "randomValue"})
 
 	// dotted request paths are permitted
 	err = wsAspect.Set(databag, "dotted.path", 3)
 	c.Assert(err, IsNil)
 
-	var num int
+	var num interface{}
 	err = wsAspect.Get(databag, "dotted.path", &num)
 	c.Assert(err, IsNil)
-	c.Check(num, Equals, 3)
+	c.Check(num, DeepEquals, map[string]interface{}{"dotted.path": float64(3)})
 }
 
 func (s *aspectSuite) TestAspectNotFound(c *C) {
@@ -176,25 +195,25 @@ func (s *aspectSuite) TestAspectNotFound(c *C) {
 
 	aspect := aspectBundle.Aspect("bar")
 
-	var value string
+	var value interface{}
 	err = aspect.Get(databag, "missing", &value)
 	c.Assert(err, testutil.ErrorIs, &aspects.NotFoundError{})
-	c.Assert(err, ErrorMatches, `cannot find field "missing" of aspect acc/foo/bar: field not found`)
+	c.Assert(err, ErrorMatches, `cannot find value for "missing" in aspect acc/foo/bar: no matching rule`)
 
 	err = aspect.Set(databag, "missing", "thing")
 	c.Assert(err, testutil.ErrorIs, &aspects.NotFoundError{})
-	c.Assert(err, ErrorMatches, `cannot find field "missing" of aspect acc/foo/bar: field not found`)
+	c.Assert(err, ErrorMatches, `cannot find value for "missing" in aspect acc/foo/bar: no matching rule`)
 
 	err = aspect.Get(databag, "top-level", &value)
 	c.Assert(err, testutil.ErrorIs, &aspects.NotFoundError{})
-	c.Assert(err, ErrorMatches, `cannot find field "top-level" of aspect acc/foo/bar: no value was found under path "top-level"`)
+	c.Assert(err, ErrorMatches, `cannot find value for "top-level" in aspect acc/foo/bar: no stored value for matching rules`)
 
 	err = aspect.Set(databag, "nested", "thing")
 	c.Assert(err, IsNil)
 
 	err = aspect.Get(databag, "other-nested", &value)
 	c.Assert(err, testutil.ErrorIs, &aspects.NotFoundError{})
-	c.Assert(err, ErrorMatches, `cannot find field "other-nested" of aspect acc/foo/bar: no value was found under path "top.nested-two"`)
+	c.Assert(err, ErrorMatches, `cannot find value for "other-nested" in aspect acc/foo/bar: no stored value for matching rules`)
 }
 
 func (s *aspectSuite) TestAspectBadRead(c *C) {
@@ -211,13 +230,9 @@ func (s *aspectSuite) TestAspectBadRead(c *C) {
 	err = aspect.Set(databag, "one", "foo")
 	c.Assert(err, IsNil)
 
-	var value string
+	var value interface{}
 	err = aspect.Get(databag, "onetwo", &value)
 	c.Assert(err, ErrorMatches, `cannot read path prefix "one": prefix maps to string`)
-
-	var listVal []string
-	err = aspect.Get(databag, "one", &listVal)
-	c.Assert(err, ErrorMatches, `cannot read value of "one" into \*\[\]string: maps to string`)
 }
 
 func (s *aspectSuite) TestAspectsAccessControl(c *C) {
@@ -248,7 +263,7 @@ func (s *aspectSuite) TestAspectsAccessControl(c *C) {
 		{
 			request: "read-only",
 			// unrelated error
-			getErr: `cannot find field "read-only" of aspect acc/bundle/foo: no value was found under path "path"`,
+			getErr: `cannot find value for "read-only" in aspect acc/bundle/foo: no stored value for matching rules`,
 			setErr: `cannot write field "read-only": only supports read access`,
 		},
 		{
@@ -266,7 +281,7 @@ func (s *aspectSuite) TestAspectsAccessControl(c *C) {
 			c.Assert(err, IsNil, cmt)
 		}
 
-		var value string
+		var value interface{}
 		err = aspect.Get(databag, t.request, &value)
 		if t.getErr != "" {
 			c.Assert(err.Error(), Equals, t.getErr, cmt)
@@ -307,67 +322,65 @@ func (s *witnessDataBag) getLastPaths() (get, set string) {
 }
 
 func (s *aspectSuite) TestAspectAssertionWithPlaceholder(c *C) {
-	aspectBundle, err := aspects.NewAspectBundle("acc", "bundle", map[string]interface{}{
-		"foo": []map[string]string{
-			{"request": "defaults.{foo}", "storage": "first.{foo}.last"},
-			{"request": "{bar}.name", "storage": "first.{bar}"},
-			{"request": "first.{baz}.last", "storage": "{baz}.last"},
-			{"request": "first.{foo}.{bar}", "storage": "{foo}.mid.{bar}"},
-			{"request": "{foo}.mid2.{bar}", "storage": "{bar}.mid2.{foo}"},
-			{"request": "multi.{foo}", "storage": "{foo}.multi.{foo}"},
-		},
-	}, aspects.NewJSONSchema())
-	c.Assert(err, IsNil)
-
-	aspect := aspectBundle.Aspect("foo")
-
 	for _, t := range []struct {
+		rule     map[string]string
 		testName string
 		request  string
 		storage  string
 	}{
 		{
 			testName: "placeholder last to mid",
+			rule:     map[string]string{"request": "defaults.{foo}", "storage": "first.{foo}.last"},
 			request:  "defaults.abc",
 			storage:  "first.abc.last",
 		},
 		{
 			testName: "placeholder first to last",
+			rule:     map[string]string{"request": "{bar}.name", "storage": "first.{bar}"},
 			request:  "foo.name",
 			storage:  "first.foo",
 		},
 		{
 			testName: "placeholder mid to first",
+			rule:     map[string]string{"request": "first.{baz}.last", "storage": "{baz}.last"},
 			request:  "first.foo.last",
 			storage:  "foo.last",
 		},
 		{
 			testName: "two placeholders in order",
+			rule:     map[string]string{"request": "first.{foo}.{bar}", "storage": "{foo}.mid.{bar}"},
 			request:  "first.one.two",
 			storage:  "one.mid.two",
 		},
 		{
 			testName: "two placeholders out of order",
-			request:  "first2.mid2.two2",
+			rule:     map[string]string{"request": "{foo}.mid1.{bar}", "storage": "{bar}.mid2.{foo}"},
+			request:  "first2.mid1.two2",
 			storage:  "two2.mid2.first2",
 		},
 		{
 			testName: "one placeholder mapping to several",
+			rule:     map[string]string{"request": "multi.{foo}", "storage": "{foo}.multi.{foo}"},
 			request:  "multi.firstLast",
 			storage:  "firstLast.multi.firstLast",
 		},
 	} {
 		cmt := Commentf("sub-test %q failed", t.testName)
 
+		aspectBundle, err := aspects.NewAspectBundle("acc", "bundle", map[string]interface{}{
+			"foo": []map[string]string{t.rule},
+		}, aspects.NewJSONSchema())
+		c.Assert(err, IsNil)
+		aspect := aspectBundle.Aspect("foo")
+
 		databag := newWitnessDataBag(aspects.NewJSONDataBag())
-		err := aspect.Set(databag, t.request, "expectedValue")
+		err = aspect.Set(databag, t.request, "expectedValue")
 		c.Assert(err, IsNil, cmt)
 
-		var obtainedValue string
+		var obtainedValue interface{}
 		err = aspect.Get(databag, t.request, &obtainedValue)
 		c.Assert(err, IsNil, cmt)
-
-		c.Assert(obtainedValue, Equals, "expectedValue", cmt)
+		c.Assert(obtainedValue, DeepEquals, map[string]interface{}{t.request: "expectedValue"}, cmt)
 
 		getPath, setPath := databag.getLastPaths()
 		c.Assert(getPath, Equals, t.storage, cmt)
@@ -469,13 +482,13 @@ func (s *aspectSuite) TestAspectUnsetTopLevelEntry(c *C) {
 	err = aspect.Set(databag, "foo", nil)
 	c.Assert(err, IsNil)
 
-	var value string
+	var value interface{}
 	err = aspect.Get(databag, "foo", &value)
 	c.Assert(err, testutil.ErrorIs, &aspects.NotFoundError{})
 
 	err = aspect.Get(databag, "bar", &value)
 	c.Assert(err, IsNil)
-	c.Assert(value, Equals, "bval")
+	c.Assert(value, DeepEquals, map[string]interface{}{"bar": "bval"})
 }
 
 func (s *aspectSuite) TestAspectUnsetLeafWithSiblings(c *C) {
@@ -498,14 +511,14 @@ func (s *aspectSuite) TestAspectUnsetLeafWithSiblings(c *C) {
 	err = aspect.Set(databag, "bar", nil)
 	c.Assert(err, IsNil)
 
-	var value string
+	var value interface{}
 	err = aspect.Get(databag, "bar", &value)
 	c.Assert(err, testutil.ErrorIs, &aspects.NotFoundError{})
 
 	// doesn't affect the other leaf entry under "foo"
 	err = aspect.Get(databag, "baz", &value)
 	c.Assert(err, IsNil)
-	c.Assert(value, Equals, "bazVal")
+	c.Assert(value, DeepEquals, map[string]interface{}{"baz": "bazVal"})
 }
 
 func (s *aspectSuite) TestAspectUnsetWithNestedEntry(c *C) {
@@ -617,4 +630,262 @@ func (s *aspectSuite) TestJSONDataBagCopy(c *C) {
 	data, err = bagCopy.Data()
 	c.Assert(err, IsNil)
 	c.Assert(string(data), Equals, `{"foo":"baz"}`)
+}
+
+func (s *aspectSuite) TestAspectGetResultNamespaceMatchesRequest(c *C) {
+	databag := aspects.NewJSONDataBag()
+	aspectBundle, err := aspects.NewAspectBundle("acc", "bundle", map[string]interface{}{
+		"bar": []map[string]string{
+			{"request": "one", "storage": "one"},
+			{"request": "one.two", "storage": "one.two"},
+			{"request": "onetwo", "storage": "one.two"},
+		},
+	}, aspects.NewJSONSchema())
+	c.Assert(err, IsNil)
+
+	aspect := aspectBundle.Aspect("bar")
+	err = aspect.Set(databag, "one", map[string]interface{}{"two": "value"})
+	c.Assert(err, IsNil)
+
+	var value interface{}
+	err = aspect.Get(databag, "one.two", &value)
+	c.Assert(err, IsNil)
+	c.Assert(value, DeepEquals, map[string]interface{}{"one.two": "value"})
+
+	value = nil
+	err = aspect.Get(databag, "onetwo", &value)
+	c.Assert(err, IsNil)
+	// the key matches the request, not the storage storage
+	c.Assert(value, DeepEquals, map[string]interface{}{"onetwo": "value"})
+
+	value = nil
+	err = aspect.Get(databag, "one", &value)
+	c.Assert(err, IsNil)
+	c.Assert(value, DeepEquals, map[string]interface{}{"one": map[string]interface{}{"two": "value"}})
+}
+
+func (s *aspectSuite) TestAspectGetMatchesOnPrefix(c *C) {
+	databag := aspects.NewJSONDataBag()
+	aspectBundle, err := aspects.NewAspectBundle("acc", "bundle", map[string]interface{}{
+		"statuses": []map[string]string{
+			{"request": "snapd.status", "storage": "snaps.snapd.status"},
+			{"request": "snaps", "storage": "snaps"},
+		},
+	}, aspects.NewJSONSchema())
+	c.Assert(err, IsNil)
+
+	aspect := aspectBundle.Aspect("statuses")
+	err = aspect.Set(databag, "snaps", map[string]map[string]interface{}{
+		"snapd":   {"status": "active", "version": "1.0"},
+		"firefox": {"status": "inactive", "version": "9.0"},
+	})
+	c.Assert(err, IsNil)
+
+	var value interface{}
+	err = aspect.Get(databag, "snapd.status", &value)
+	c.Assert(err, IsNil)
+	c.Assert(value, DeepEquals, map[string]interface{}{"snapd.status": "active"})
+
+	value = nil
+	err = aspect.Get(databag, "snapd", &value)
+	c.Assert(err, IsNil)
+	c.Assert(value, DeepEquals, map[string]interface{}{"snapd": map[string]interface{}{"status": "active"}})
+}
+
+func (s *aspectSuite) TestAspectGetNoMatchRequestLongerThanPattern(c *C) {
+	databag := aspects.NewJSONDataBag()
+	aspectBundle, err := aspects.NewAspectBundle("acc", "bundle", map[string]interface{}{
+		"statuses": []map[string]string{
+			{"request": "snapd", "storage": "snaps.snapd"},
+		},
+	}, aspects.NewJSONSchema())
+	c.Assert(err, IsNil)
+
+	aspect := aspectBundle.Aspect("statuses")
+	err = aspect.Set(databag, "snapd", map[string]interface{}{
+		"status": "active", "version": "1.0",
+	})
+	c.Assert(err, IsNil)
+
+	var value interface{}
+	err = aspect.Get(databag, "snapd.status", &value)
+	c.Assert(err, testutil.ErrorIs, &aspects.NotFoundError{})
+}
+
+func (s *aspectSuite) TestAspectManyPrefixMatches(c *C) {
+	databag := aspects.NewJSONDataBag()
+	aspectBundle, err := aspects.NewAspectBundle("acc", "bundle", map[string]interface{}{
+		"statuses": []map[string]string{
+			{"request": "status.firefox", "storage": "snaps.firefox.status"},
+			{"request": "status.snapd", "storage": "snaps.snapd.status"},
+		},
+	}, aspects.NewJSONSchema())
+	c.Assert(err, IsNil)
+
+	aspect := aspectBundle.Aspect("statuses")
+	err = aspect.Set(databag, "status.firefox", "active")
+	c.Assert(err, IsNil)
+
+	err = aspect.Set(databag, "status.snapd", "disabled")
+	c.Assert(err, IsNil)
+
+	var value interface{}
+	err = aspect.Get(databag, "status", &value)
+	c.Assert(err, IsNil)
+	c.Assert(value, DeepEquals, map[string]interface{}{
+		"status": map[string]interface{}{
+			"snapd":   "disabled",
+			"firefox": "active",
+		},
+	})
+}
+
+func (s *aspectSuite) TestAspectCombineNamespacesInPrefixMatches(c *C) {
+	databag := aspects.NewJSONDataBag()
+	aspectBundle, err := aspects.NewAspectBundle("acc", "bundle", map[string]interface{}{
+		"statuses": []map[string]string{
+			{"request": "status.foo.bar.firefox", "storage": "snaps.firefox.status"},
+			{"request": "status.foo.snapd", "storage": "snaps.snapd.status"},
+		},
+	}, aspects.NewJSONSchema())
+	c.Assert(err, IsNil)
+
+	err = databag.Set("snaps", map[string]interface{}{
+		"firefox": map[string]interface{}{
+			"status": "active",
+		},
+		"snapd": map[string]interface{}{
+			"status": "disabled",
+		},
+	})
+	c.Assert(err, IsNil)
+
+	aspect := aspectBundle.Aspect("statuses")
+
+	var value interface{}
+	err = aspect.Get(databag, "status", &value)
+	c.Assert(err, IsNil)
+	c.Assert(value, DeepEquals, map[string]interface{}{
+		"status": map[string]interface{}{
+			"foo": map[string]interface{}{
+				"bar": map[string]interface{}{
+					"firefox": "active",
+				},
+				"snapd": "disabled",
+			},
+		},
+	})
+}
+
+func (s *aspectSuite) TestGetScalarOverwritesLeafOfMapValue(c *C) {
+	databag := aspects.NewJSONDataBag()
+	aspectBundle, err := aspects.NewAspectBundle("acc", "bundle", map[string]interface{}{
+		"motors": []map[string]string{
+			{"request": "motors.a.speed", "storage": "new-speed.a"},
+			{"request": "motors", "storage": "motors"},
+		},
+	}, aspects.NewJSONSchema())
+	c.Assert(err, IsNil)
+
+	err = databag.Set("motors", map[string]interface{}{
+		"a": map[string]interface{}{
+			"speed": 100,
+		},
+	})
+	c.Assert(err, IsNil)
+
+	err = databag.Set("new-speed", map[string]interface{}{
+		"a": 101.5,
+	})
+	c.Assert(err, IsNil)
+
+	aspect := aspectBundle.Aspect("motors")
+
+	var value interface{}
+	err = aspect.Get(databag, "motors", &value)
+	c.Assert(err, IsNil)
+	c.Assert(value, DeepEquals, map[string]interface{}{"motors": map[string]interface{}{"a": map[string]interface{}{"speed": 101.5}}})
+}
+
+func (s *aspectSuite) TestGetSingleScalarOk(c *C) {
+	databag := aspects.NewJSONDataBag()
+	aspectBundle, err := aspects.NewAspectBundle("acc", "bundle", map[string]interface{}{
+		"foo": []map[string]string{
+			{"request": "foo", "storage": "foo"},
+		},
+	}, aspects.NewJSONSchema())
+	c.Assert(err, IsNil)
+
+	err = databag.Set("foo", "bar")
+	c.Assert(err, IsNil)
+
+	aspect := aspectBundle.Aspect("foo")
+
+	var value interface{}
+	err = aspect.Get(databag, "foo", &value)
+
+	c.Assert(err, IsNil)
+	c.Assert(value, DeepEquals, map[string]interface{}{"foo": "bar"})
+}
+
+func (s *aspectSuite) TestGetMatchScalarAndMapError(c *C) {
+	databag := aspects.NewJSONDataBag()
+	aspectBundle, err := aspects.NewAspectBundle("acc", "bundle", map[string]interface{}{
+		"foo": []map[string]string{
+			{"request": "foo", "storage": "bar"},
+			{"request": "foo.baz", "storage": "baz"},
+		},
+	}, aspects.NewJSONSchema())
+	c.Assert(err, IsNil)
+
+	err = databag.Set("bar", 1)
+	c.Assert(err, IsNil)
+	err = databag.Set("baz", 2)
+	c.Assert(err, IsNil)
+
+	aspect := aspectBundle.Aspect("foo")
+
+	var value interface{}
+	err = aspect.Get(databag, "foo", &value)
+	c.Assert(err, ErrorMatches, `cannot merge results of different types float64, map\[string\]interface {}`)
+}
+
+func (s *aspectSuite) TestGetRulesAreSortedByParentage(c *C) {
+	databag := aspects.NewJSONDataBag()
+	aspectBundle, err := aspects.NewAspectBundle("acc", "bundle", map[string]interface{}{
+		"foo": []map[string]string{
+			{"request": "foo.bar.baz", "storage": "third"},
+			{"request": "foo", "storage": "first"},
+			{"request": "foo.bar", "storage": "second"},
+		},
+	}, aspects.NewJSONSchema())
+	c.Assert(err, IsNil)
+	aspect := aspectBundle.Aspect("foo")
+
+	err = databag.Set("first", map[string]interface{}{"bar": map[string]interface{}{"baz": "first"}})
+	c.Assert(err, IsNil)
+
+	var value interface{}
+	err = aspect.Get(databag, "foo", &value)
+	c.Assert(err, IsNil)
+	// returned the value read by entry "foo"
+	c.Assert(value, DeepEquals, map[string]interface{}{"foo": map[string]interface{}{"bar": map[string]interface{}{"baz": "first"}}})
+
+	err = databag.Set("second", map[string]interface{}{"baz": "second"})
+	c.Assert(err, IsNil)
+
+	value = nil
+	err = aspect.Get(databag, "foo", &value)
+	c.Assert(err, IsNil)
+	// the leaf is replaced by a value read from a rule that is nested
+	c.Assert(value, DeepEquals, map[string]interface{}{"foo": map[string]interface{}{"bar": map[string]interface{}{"baz": "second"}}})
+
+	err = databag.Set("third", "third")
+	c.Assert(err, IsNil)
+
+	value = nil
+	err = aspect.Get(databag, "foo", &value)
+	c.Assert(err, IsNil)
+	// lastly, it reads the value from "foo.bar.baz" the most nested entry
+	c.Assert(value, DeepEquals, map[string]interface{}{"foo": map[string]interface{}{"bar": map[string]interface{}{"baz": "third"}}})
 }

--- a/aspects/aspects_test.go
+++ b/aspects/aspects_test.go
@@ -206,14 +206,14 @@ func (s *aspectSuite) TestAspectNotFound(c *C) {
 
 	err = aspect.Get(databag, "top-level", &value)
 	c.Assert(err, testutil.ErrorIs, &aspects.NotFoundError{})
-	c.Assert(err, ErrorMatches, `cannot find value for "top-level" in aspect acc/foo/bar: no value for matching rules`)
+	c.Assert(err, ErrorMatches, `cannot find value for "top-level" in aspect acc/foo/bar: matching rules don't map to any values`)
 
 	err = aspect.Set(databag, "nested", "thing")
 	c.Assert(err, IsNil)
 
 	err = aspect.Get(databag, "other-nested", &value)
 	c.Assert(err, testutil.ErrorIs, &aspects.NotFoundError{})
-	c.Assert(err, ErrorMatches, `cannot find value for "other-nested" in aspect acc/foo/bar: no value for matching rules`)
+	c.Assert(err, ErrorMatches, `cannot find value for "other-nested" in aspect acc/foo/bar: matching rules don't map to any values`)
 }
 
 func (s *aspectSuite) TestAspectBadRead(c *C) {
@@ -263,7 +263,7 @@ func (s *aspectSuite) TestAspectsAccessControl(c *C) {
 		{
 			request: "read-only",
 			// unrelated error
-			getErr: `cannot find value for "read-only" in aspect acc/bundle/foo: no value for matching rules`,
+			getErr: `cannot find value for "read-only" in aspect acc/bundle/foo: matching rules don't map to any values`,
 			setErr: `cannot write field "read-only": only supports read access`,
 		},
 		{

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -335,7 +335,7 @@ var (
 	MaxReadBuflen = maxReadBuflen
 )
 
-func MockAspectstateGet(f func(databag aspects.DataBag, account, bundleName, aspect, field string, value interface{}) error) (restore func()) {
+func MockAspectstateGet(f func(databag aspects.DataBag, account, bundleName, aspect, field string, value *interface{}) error) (restore func()) {
 	old := aspectstateGetAspect
 	aspectstateGetAspect = f
 	return func() {

--- a/overlord/aspectstate/aspectstate.go
+++ b/overlord/aspectstate/aspectstate.go
@@ -43,7 +43,7 @@ func SetAspect(databag aspects.DataBag, account, bundleName, aspect, field strin
 			Account:    account,
 			BundleName: bundleName,
 			Aspect:     aspect,
-			Field:      field,
+			Request:    field,
 			Cause:      "aspect not found",
 		}
 	}
@@ -58,7 +58,7 @@ func SetAspect(databag aspects.DataBag, account, bundleName, aspect, field strin
 // GetAspect finds the aspect identified by the account, bundleName and aspect
 // and returns the specified field value from the provided matching databag
 // through the value output parameter.
-func GetAspect(databag aspects.DataBag, account, bundleName, aspect, field string, value interface{}) error {
+func GetAspect(databag aspects.DataBag, account, bundleName, aspect, field string, value *interface{}) error {
 	accPatterns := aspecttest.MockWifiSetupAspect()
 	schema := aspects.NewJSONSchema()
 
@@ -73,7 +73,7 @@ func GetAspect(databag aspects.DataBag, account, bundleName, aspect, field strin
 			Account:    account,
 			BundleName: bundleName,
 			Aspect:     aspect,
-			Field:      field,
+			Request:    field,
 			Cause:      "aspect not found",
 		}
 	}

--- a/overlord/aspectstate/aspectstate_test.go
+++ b/overlord/aspectstate/aspectstate_test.go
@@ -63,12 +63,12 @@ func (s *aspectTestSuite) TestGetNotFound(c *C) {
 
 	err = aspectstate.GetAspect(databag, "system", "network", "wifi-setup", "ssid", &res)
 	c.Assert(err, FitsTypeOf, &aspects.NotFoundError{})
-	c.Assert(err, ErrorMatches, `cannot find value for "ssid" in aspect system/network/wifi-setup: no stored value for matching rules`)
+	c.Assert(err, ErrorMatches, `cannot find value for "ssid" in aspect system/network/wifi-setup: no value for matching rules`)
 	c.Check(res, IsNil)
 
 	err = aspectstate.GetAspect(databag, "system", "network", "wifi-setup", "other-field", &res)
 	c.Assert(err, FitsTypeOf, &aspects.NotFoundError{})
-	c.Assert(err, ErrorMatches, `cannot find value for "other-field" in aspect system/network/wifi-setup: no matching rule`)
+	c.Assert(err, ErrorMatches, `cannot find value for "other-field" in aspect system/network/wifi-setup: no matching read rule`)
 	c.Check(res, IsNil)
 }
 
@@ -87,7 +87,7 @@ func (s *aspectTestSuite) TestSetNotFound(c *C) {
 	databag := aspects.NewJSONDataBag()
 	err := aspectstate.SetAspect(databag, "system", "network", "wifi-setup", "foo", "bar")
 	c.Assert(err, FitsTypeOf, &aspects.NotFoundError{})
-	c.Assert(err, ErrorMatches, `cannot find value for "foo" in aspect system/network/wifi-setup: no matching rule`)
+	c.Assert(err, ErrorMatches, `cannot find value for "foo" in aspect system/network/wifi-setup: no matching write rule`)
 
 	err = aspectstate.SetAspect(databag, "system", "network", "other-aspect", "foo", "bar")
 	c.Assert(err, FitsTypeOf, &aspects.NotFoundError{})

--- a/overlord/aspectstate/aspectstate_test.go
+++ b/overlord/aspectstate/aspectstate_test.go
@@ -63,7 +63,7 @@ func (s *aspectTestSuite) TestGetNotFound(c *C) {
 
 	err = aspectstate.GetAspect(databag, "system", "network", "wifi-setup", "ssid", &res)
 	c.Assert(err, FitsTypeOf, &aspects.NotFoundError{})
-	c.Assert(err, ErrorMatches, `cannot find value for "ssid" in aspect system/network/wifi-setup: no value for matching rules`)
+	c.Assert(err, ErrorMatches, `cannot find value for "ssid" in aspect system/network/wifi-setup: matching rules don't map to any values`)
 	c.Check(res, IsNil)
 
 	err = aspectstate.GetAspect(databag, "system", "network", "wifi-setup", "other-field", &res)

--- a/overlord/aspectstate/aspectstate_test.go
+++ b/overlord/aspectstate/aspectstate_test.go
@@ -49,7 +49,7 @@ func (s *aspectTestSuite) TestGetAspect(c *C) {
 	var res interface{}
 	err = aspectstate.GetAspect(databag, "system", "network", "wifi-setup", "ssid", &res)
 	c.Assert(err, IsNil)
-	c.Assert(res, Equals, "foo")
+	c.Assert(res, DeepEquals, map[string]interface{}{"ssid": "foo"})
 }
 
 func (s *aspectTestSuite) TestGetNotFound(c *C) {
@@ -58,19 +58,18 @@ func (s *aspectTestSuite) TestGetNotFound(c *C) {
 	var res interface{}
 	err := aspectstate.GetAspect(databag, "system", "network", "other-aspect", "ssid", &res)
 	c.Assert(err, FitsTypeOf, &aspects.NotFoundError{})
-	c.Assert(err, ErrorMatches, `cannot find field "ssid" of aspect system/network/other-aspect: aspect not found`)
+	c.Assert(err, ErrorMatches, `cannot find value for "ssid" in aspect system/network/other-aspect: aspect not found`)
 	c.Check(res, IsNil)
 
 	err = aspectstate.GetAspect(databag, "system", "network", "wifi-setup", "ssid", &res)
 	c.Assert(err, FitsTypeOf, &aspects.NotFoundError{})
-	c.Assert(err, ErrorMatches, `cannot find field "ssid" of aspect system/network/wifi-setup: no value was found under path "wifi"`)
+	c.Assert(err, ErrorMatches, `cannot find value for "ssid" in aspect system/network/wifi-setup: no stored value for matching rules`)
 	c.Check(res, IsNil)
 
 	err = aspectstate.GetAspect(databag, "system", "network", "wifi-setup", "other-field", &res)
 	c.Assert(err, FitsTypeOf, &aspects.NotFoundError{})
-	c.Assert(err, ErrorMatches, `cannot find field "other-field" of aspect system/network/wifi-setup: field not found`)
+	c.Assert(err, ErrorMatches, `cannot find value for "other-field" in aspect system/network/wifi-setup: no matching rule`)
 	c.Check(res, IsNil)
-
 }
 
 func (s *aspectTestSuite) TestSetAspect(c *C) {
@@ -78,21 +77,21 @@ func (s *aspectTestSuite) TestSetAspect(c *C) {
 	err := aspectstate.SetAspect(databag, "system", "network", "wifi-setup", "ssid", "foo")
 	c.Assert(err, IsNil)
 
-	var val string
+	var val interface{}
 	err = databag.Get("wifi.ssid", &val)
 	c.Assert(err, IsNil)
-	c.Assert(val, Equals, "foo")
+	c.Assert(val, DeepEquals, "foo")
 }
 
 func (s *aspectTestSuite) TestSetNotFound(c *C) {
 	databag := aspects.NewJSONDataBag()
 	err := aspectstate.SetAspect(databag, "system", "network", "wifi-setup", "foo", "bar")
 	c.Assert(err, FitsTypeOf, &aspects.NotFoundError{})
-	c.Assert(err, ErrorMatches, `cannot find field "foo" of aspect system/network/wifi-setup: field not found`)
+	c.Assert(err, ErrorMatches, `cannot find value for "foo" in aspect system/network/wifi-setup: no matching rule`)
 
 	err = aspectstate.SetAspect(databag, "system", "network", "other-aspect", "foo", "bar")
 	c.Assert(err, FitsTypeOf, &aspects.NotFoundError{})
-	c.Assert(err, ErrorMatches, `cannot find field "foo" of aspect system/network/other-aspect: aspect not found`)
+	c.Assert(err, ErrorMatches, `cannot find value for "foo" in aspect system/network/other-aspect: aspect not found`)
 }
 
 func (s *aspectTestSuite) TestSetAccessError(c *C) {

--- a/tests/main/aspects/task.yaml
+++ b/tests/main/aspects/task.yaml
@@ -38,7 +38,7 @@ execute: |
   # check it was deleted
   curl -sS --unix-socket /run/snapd.socket localhost/v2/aspects/system/network/wifi-setup?fields=ssid -X GET > response.txt
   jq -r '."status-code"' < response.txt | MATCH 404
-  jq -r '.result.message' < response.txt | MATCH 'cannot find field "ssid" of aspect system/network/wifi-setup: no value was found under path "wifi"'
+  jq -r '.result.message' < response.txt | MATCH 'cannot find value for "ssid" in aspect system/network/wifi-setup: no stored value for matching rules'
 
   # write values using a placeholder access
   curl -sS --unix-socket /run/snapd.socket localhost/v2/aspects/system/network/wifi-setup -X PUT -d '{"private.my-company": "my-config"}' > response.txt
@@ -58,7 +58,7 @@ execute: |
   # check it was deleted
   curl -sS --unix-socket /run/snapd.socket localhost/v2/aspects/system/network/wifi-setup?fields=private.my-company -X GET > response.txt
   jq -r '."status-code"' < response.txt | MATCH 404
-  jq -r '.result.message' < response.txt | MATCH 'cannot find field "private.my-company" of aspect system/network/wifi-setup: no value was found under path "wifi.my-company"'
+  jq -r '.result.message' < response.txt | MATCH 'cannot find value for "private.my-company" in aspect system/network/wifi-setup: no stored value for matching rules'
 
   # check second value remains
   curl -sS --unix-socket /run/snapd.socket localhost/v2/aspects/system/network/wifi-setup?fields=private.your-company -X GET > response.txt

--- a/tests/main/aspects/task.yaml
+++ b/tests/main/aspects/task.yaml
@@ -38,7 +38,7 @@ execute: |
   # check it was deleted
   curl -sS --unix-socket /run/snapd.socket localhost/v2/aspects/system/network/wifi-setup?fields=ssid -X GET > response.txt
   jq -r '."status-code"' < response.txt | MATCH 404
-  jq -r '.result.message' < response.txt | MATCH 'cannot find value for "ssid" in aspect system/network/wifi-setup: no value for matching rules'
+  jq -r '.result.message' < response.txt | MATCH $'cannot find value for "ssid" in aspect system/network/wifi-setup: matching rules don\'t map to any values'
 
   # write values using a placeholder access
   curl -sS --unix-socket /run/snapd.socket localhost/v2/aspects/system/network/wifi-setup -X PUT -d '{"private.my-company": "my-config"}' > response.txt
@@ -58,7 +58,7 @@ execute: |
   # check it was deleted
   curl -sS --unix-socket /run/snapd.socket localhost/v2/aspects/system/network/wifi-setup?fields=private.my-company -X GET > response.txt
   jq -r '."status-code"' < response.txt | MATCH 404
-  jq -r '.result.message' < response.txt | MATCH 'cannot find value for "private.my-company" in aspect system/network/wifi-setup: no value for matching rules'
+  jq -r '.result.message' < response.txt | MATCH $'cannot find value for "private.my-company" in aspect system/network/wifi-setup: matching rules don\'t map to any values'
 
   # check second value remains
   curl -sS --unix-socket /run/snapd.socket localhost/v2/aspects/system/network/wifi-setup?fields=private.your-company -X GET > response.txt

--- a/tests/main/aspects/task.yaml
+++ b/tests/main/aspects/task.yaml
@@ -38,7 +38,7 @@ execute: |
   # check it was deleted
   curl -sS --unix-socket /run/snapd.socket localhost/v2/aspects/system/network/wifi-setup?fields=ssid -X GET > response.txt
   jq -r '."status-code"' < response.txt | MATCH 404
-  jq -r '.result.message' < response.txt | MATCH 'cannot find value for "ssid" in aspect system/network/wifi-setup: no stored value for matching rules'
+  jq -r '.result.message' < response.txt | MATCH 'cannot find value for "ssid" in aspect system/network/wifi-setup: no value for matching rules'
 
   # write values using a placeholder access
   curl -sS --unix-socket /run/snapd.socket localhost/v2/aspects/system/network/wifi-setup -X PUT -d '{"private.my-company": "my-config"}' > response.txt
@@ -58,7 +58,7 @@ execute: |
   # check it was deleted
   curl -sS --unix-socket /run/snapd.socket localhost/v2/aspects/system/network/wifi-setup?fields=private.my-company -X GET > response.txt
   jq -r '."status-code"' < response.txt | MATCH 404
-  jq -r '.result.message' < response.txt | MATCH 'cannot find value for "private.my-company" in aspect system/network/wifi-setup: no stored value for matching rules'
+  jq -r '.result.message' < response.txt | MATCH 'cannot find value for "private.my-company" in aspect system/network/wifi-setup: no value for matching rules'
 
   # check second value remains
   curl -sS --unix-socket /run/snapd.socket localhost/v2/aspects/system/network/wifi-setup?fields=private.your-company -X GET > response.txt


### PR DESCRIPTION
Get() can match requests to prefixes of the "request" field specified in the aspect's rules. When it does, the result is returned in a namespace equivalent to the unmatched sub-keys. Conceptually, the specified "request" is a namespace that the user's request cuts through during the operation. If there is more than one match for a request, the results are merged when possible (e.g., maps are merged and scalar can replace other scalars in leafs).