### PR TITLE
o/servicestate: support for user services

### DIFF
--- a/overlord/servicestate/servicestate.go
+++ b/overlord/servicestate/servicestate.go
@@ -20,12 +20,14 @@
 package servicestate
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
 	"os/user"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -40,6 +42,7 @@ import (
 	"github.com/snapcore/snapd/snap/quota"
 	"github.com/snapcore/snapd/strutil"
 	"github.com/snapcore/snapd/systemd"
+	usc "github.com/snapcore/snapd/usersession/client"
 	"github.com/snapcore/snapd/wrappers"
 )
 
@@ -350,15 +353,35 @@ func Control(st *state.State, appInfos []*snap.AppInfo, inst *Instruction, cu *u
 type StatusDecorator struct {
 	sysd           systemd.Systemd
 	globalUserSysd systemd.Systemd
+	context        context.Context
+	uid            string
 }
 
 // NewStatusDecorator returns a new StatusDecorator.
+//
+// Using NewStatusDecorator will only allow for global status of user-services
+// as StatusDecorator is designed to contain a single set of results for a single
+// user.
 func NewStatusDecorator(rep interface {
 	Notify(string)
 }) *StatusDecorator {
 	return &StatusDecorator{
 		sysd:           systemd.New(systemd.SystemMode, rep),
 		globalUserSysd: systemd.New(systemd.GlobalUserMode, rep),
+	}
+}
+
+// NewStatusDecoratorForUid returns a new StatusDecorator, but configured
+// for a specific uid. This allows the StatusDecorator to get statuses for
+// user-services for a specific user.
+func NewStatusDecoratorForUid(rep interface {
+	Notify(string)
+}, context context.Context, uid string) *StatusDecorator {
+	return &StatusDecorator{
+		sysd:           systemd.New(systemd.SystemMode, rep),
+		globalUserSysd: systemd.New(systemd.GlobalUserMode, rep),
+		context:        context,
+		uid:            uid,
 	}
 }
 
@@ -374,6 +397,69 @@ func (sd *StatusDecorator) hasEnabledActivator(appInfo *client.AppInfo) bool {
 	return false
 }
 
+// queryUserServiceStatus returns a list of service-statuses for the users configured.
+func (sd *StatusDecorator) queryUserServiceStatus(units []string) ([]*systemd.UnitStatus, error) {
+	// Avoid any expensive call if there are no user daemons
+	if len(units) == 0 {
+		return nil, nil
+	}
+
+	uid, err := strconv.Atoi(sd.uid)
+	if err != nil {
+		return nil, err
+	}
+
+	cli := usc.NewForUids(uid)
+	sts, failures, err := cli.ServiceStatus(sd.context, units)
+	if err != nil {
+		return nil, err
+	}
+
+	// Return the first service failure, if any failures were reported
+	if len(failures[uid]) > 0 {
+		return nil, fmt.Errorf("cannot retrieve service %q status: %v",
+			failures[uid][0].Service, failures[uid][0].Error)
+	}
+
+	// Convert the received unit statuses to systemd-unit statuses
+	var sysdStatuses []*systemd.UnitStatus
+	for _, sts := range sts[uid] {
+		sysdStatuses = append(sysdStatuses, sts.SystemdUnitStatus())
+	}
+	return sysdStatuses, nil
+}
+
+func (sd *StatusDecorator) queryServiceStatus(scope snap.DaemonScope, units []string) ([]*systemd.UnitStatus, error) {
+	var sts []*systemd.UnitStatus
+	var err error
+	switch scope {
+	case snap.SystemDaemon:
+		// sysd.Status() makes sure that we get only the units we asked
+		// for and raises an error otherwise.
+		sts, err = sd.sysd.Status(units)
+	case snap.UserDaemon:
+		// Support the previous behavior of retrieving the global enablement
+		// status of user services if no uid is configured for this status
+		// decorator.
+		if sd.uid != "" {
+			sts, err = sd.queryUserServiceStatus(units)
+		} else {
+			sts, err = sd.globalUserSysd.Status(units)
+		}
+	default:
+		return nil, fmt.Errorf("internal error: unknown daemon-scope %q", scope)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	// ensure we get the correct unit count, otherwise report an error.
+	if len(sts) != len(units) {
+		return nil, fmt.Errorf("expected %d results, got %d", len(units), len(sts))
+	}
+	return sts, nil
+}
+
 // DecorateWithStatus adds service status information to the given
 // client.AppInfo associated with the given snap.AppInfo.
 // If the snap is inactive or the app is not service it does nothing.
@@ -384,15 +470,6 @@ func (sd *StatusDecorator) DecorateWithStatus(appInfo *client.AppInfo, snapApp *
 	if !snapApp.Snap.IsActive() || !snapApp.IsService() {
 		// nothing to do
 		return nil
-	}
-	var sysd systemd.Systemd
-	switch snapApp.DaemonScope {
-	case snap.SystemDaemon:
-		sysd = sd.sysd
-	case snap.UserDaemon:
-		sysd = sd.globalUserSysd
-	default:
-		return fmt.Errorf("internal error: unknown daemon-scope %q", snapApp.DaemonScope)
 	}
 
 	// collect all services for a single call to systemctl
@@ -414,15 +491,11 @@ func (sd *StatusDecorator) DecorateWithStatus(appInfo *client.AppInfo, snapApp *
 		serviceNames = append(serviceNames, timerUnit)
 	}
 
-	// sysd.Status() makes sure that we get only the units we asked
-	// for and raises an error otherwise
-	sts, err := sysd.Status(serviceNames)
+	sts, err := sd.queryServiceStatus(snapApp.DaemonScope, serviceNames)
 	if err != nil {
 		return fmt.Errorf("cannot get status of services of app %q: %v", appInfo.Name, err)
 	}
-	if len(sts) != len(serviceNames) {
-		return fmt.Errorf("cannot get status of services of app %q: expected %d results, got %d", appInfo.Name, len(serviceNames), len(sts))
-	}
+
 	for _, st := range sts {
 		switch filepath.Ext(st.Name) {
 		case ".service":

--- a/overlord/servicestate/servicestate.go
+++ b/overlord/servicestate/servicestate.go
@@ -397,7 +397,7 @@ func (sd *StatusDecorator) hasEnabledActivator(appInfo *client.AppInfo) bool {
 	return false
 }
 
-// queryUserServiceStatus returns a list of service-statuses for the users configured.
+// queryUserServiceStatus returns a list of service-statuses for the configured users.
 func (sd *StatusDecorator) queryUserServiceStatus(units []string) ([]*systemd.UnitStatus, error) {
 	// Avoid any expensive call if there are no user daemons
 	if len(units) == 0 {

--- a/usersession/client/client.go
+++ b/usersession/client/client.go
@@ -36,6 +36,7 @@ import (
 	"time"
 
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/systemd"
 )
 
 // dialSessionAgent connects to a user's session agent
@@ -332,6 +333,19 @@ type ServiceUnitStatus struct {
 	Active           bool     `json:"active"`
 	Installed        bool     `json:"installed"`
 	NeedDaemonReload bool     `json:"needs-reload"`
+}
+
+func (us *ServiceUnitStatus) SystemdUnitStatus() *systemd.UnitStatus {
+	return &systemd.UnitStatus{
+		Daemon:           us.Daemon,
+		Id:               us.Id,
+		Name:             us.Name,
+		Names:            us.Names,
+		Enabled:          us.Enabled,
+		Active:           us.Active,
+		Installed:        us.Installed,
+		NeedDaemonReload: us.NeedDaemonReload,
+	}
 }
 
 func (client *Client) ServiceStatus(ctx context.Context, services []string) (map[int][]ServiceUnitStatus, map[int][]ServiceFailure, error) {

--- a/wrappers/internal/service_status.go
+++ b/wrappers/internal/service_status.go
@@ -123,23 +123,10 @@ var userSessionQueryServiceStatusMany = func(units []string) (map[int][]client.S
 	return cli.ServiceStatus(ctx, units)
 }
 
-func clientUnitStatusToSystemdUnitStatus(unitStatus client.ServiceUnitStatus) *systemd.UnitStatus {
-	return &systemd.UnitStatus{
-		Daemon:           unitStatus.Daemon,
-		Id:               unitStatus.Id,
-		Name:             unitStatus.Name,
-		Names:            unitStatus.Names,
-		Enabled:          unitStatus.Enabled,
-		Active:           unitStatus.Active,
-		Installed:        unitStatus.Installed,
-		NeedDaemonReload: unitStatus.NeedDaemonReload,
-	}
-}
-
 func mapServiceStatusMany(stss []client.ServiceUnitStatus) map[string]*systemd.UnitStatus {
 	stsMap := make(map[string]*systemd.UnitStatus, len(stss))
 	for _, sts := range stss {
-		stsMap[sts.Name] = clientUnitStatusToSystemdUnitStatus(sts)
+		stsMap[sts.Name] = sts.SystemdUnitStatus()
 	}
 	return stsMap
 }


### PR DESCRIPTION
First of two PRs that implements support for user services in `snap services` command. 
