### PR TITLE
daemon,cmd/snap: support for user services in snap services

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # In progress:
 * Installation of local snap components
-* Started support for snap services to show real status of user daemons
+
+# New in snapd 2.63:
+* Support for snap services to show the current status of user daemons
 
 # New in snapd 2.62:
 * Aspects based configuration schema support (experimental)

--- a/client/apps.go
+++ b/client/apps.go
@@ -75,6 +75,11 @@ type AppOptions struct {
 	// If Service is true, only return apps that are services
 	// (app.IsService() is true); otherwise, return all.
 	Service bool
+	// Global if set, returns only the global status of the services. This
+	// is only relevant for user services, where we either return the status
+	// of the services for the current user, or the global enable status.
+	// For root-users, global is always implied.
+	Global bool
 }
 
 // Apps returns information about all matching apps. Each name can be
@@ -87,6 +92,9 @@ func (client *Client) Apps(names []string, opts AppOptions) ([]*AppInfo, error) 
 	}
 	if opts.Service {
 		q.Add("select", "service")
+	}
+	if opts.Global {
+		q.Add("global", fmt.Sprintf("%t", opts.Global))
 	}
 
 	var appInfos []*AppInfo

--- a/client/apps_test.go
+++ b/client/apps_test.go
@@ -65,7 +65,19 @@ func testClientAppsService(cs *clientSuite, c *check.C) ([]*client.AppInfo, erro
 	return services, err
 }
 
-var appcheckers = []func(*clientSuite, *check.C) ([]*client.AppInfo, error){testClientApps, testClientAppsService}
+func testClientAppsGlobal(cs *clientSuite, c *check.C) ([]*client.AppInfo, error) {
+	services, err := cs.cli.Apps([]string{"foo", "bar"}, client.AppOptions{Global: true})
+	c.Check(cs.req.URL.Path, check.Equals, "/v2/apps")
+	c.Check(cs.req.Method, check.Equals, "GET")
+	query := cs.req.URL.Query()
+	c.Check(query, check.HasLen, 2)
+	c.Check(query.Get("names"), check.Equals, "foo,bar")
+	c.Check(query.Get("global"), check.Equals, "true")
+
+	return services, err
+}
+
+var appcheckers = []func(*clientSuite, *check.C) ([]*client.AppInfo, error){testClientApps, testClientAppsService, testClientAppsGlobal}
 
 func (cs *clientSuite) TestClientServiceGetHappy(c *check.C) {
 	expected := []*client.AppInfo{mksvc("foo", "foo"), mksvc("bar", "bar1")}

--- a/cmd/snap/cmd_services.go
+++ b/cmd/snap/cmd_services.go
@@ -57,13 +57,13 @@ var (
 The services command lists information about the services specified, or about
 the services in all currently installed snaps.
 
-If executed as root user, the enable status of any user service will be whether
-it's globally enabled (i.e systemctl is-enabled). To view the current enable/active
+If executed as root user, the 'Startup' column of any user service will be whether
+it's globally enabled (i.e systemctl is-enabled). To view the actual 'Startup'|'Current'
 status of the user services for the root user itself, --user can be provided.
 
-If executed as a non-root user, the enable/active status of user services will be
-the current status for the invoking user. To view the global enablement status of
-user services, --global can be provided.
+If executed as a non-root user, the 'Startup'|'Current' status of user services 
+will be the current status for the invoking user. To view the global enablement
+status of user services, --global can be provided.
 `)
 	shortLogsHelp = i18n.G("Retrieve logs for services")
 	longLogsHelp  = i18n.G(`

--- a/cmd/snap/cmd_services_test.go
+++ b/cmd/snap/cmd_services_test.go
@@ -504,28 +504,6 @@ func (s *appOpSuite) TestAppStatusInvalidUserGlobalSwitches(c *check.C) {
 	c.Check(err, check.ErrorMatches, `cannot combine --global and --user switches.`)
 }
 
-func (s *appOpSuite) TestAppStatusInvalidUserGlobalSwitchesRoot(c *check.C) {
-	r := snap.MockUserCurrent(func() (*user.User, error) {
-		return &user.User{
-			Uid: "0",
-		}, nil
-	})
-	defer r()
-	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"services", "--global"})
-	c.Check(err, check.ErrorMatches, `unsupported argument --global when root.`)
-}
-
-func (s *appOpSuite) TestAppStatusInvalidUserGlobalSwitchesNonRoot(c *check.C) {
-	r := snap.MockUserCurrent(func() (*user.User, error) {
-		return &user.User{
-			Uid: "1337",
-		}, nil
-	})
-	defer r()
-	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"services", "--user"})
-	c.Check(err, check.ErrorMatches, `unsupported argument --user when not root.`)
-}
-
 func (s *appOpSuite) TestAppStatusNoServices(c *check.C) {
 	n := 0
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/snap/cmd_services_test.go
+++ b/cmd/snap/cmd_services_test.go
@@ -486,7 +486,40 @@ func (s *appOpSuite) TestAppStatusUserFailed(c *check.C) {
 	})
 	defer r()
 	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"services"})
-	c.Check(err, check.ErrorMatches, `cannot get the current user: oh-no`)
+	c.Check(err, check.ErrorMatches, `cannot get the current user: oh-no.`)
+}
+
+func (s *appOpSuite) TestAppStatusInvalidUserGlobalSwitches(c *check.C) {
+	r := snap.MockUserCurrent(func() (*user.User, error) {
+		return &user.User{
+			Uid: "0",
+		}, nil
+	})
+	defer r()
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"services", "--global", "--user"})
+	c.Check(err, check.ErrorMatches, `cannot combine --global and --user switches.`)
+}
+
+func (s *appOpSuite) TestAppStatusInvalidUserGlobalSwitchesRoot(c *check.C) {
+	r := snap.MockUserCurrent(func() (*user.User, error) {
+		return &user.User{
+			Uid: "0",
+		}, nil
+	})
+	defer r()
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"services", "--global"})
+	c.Check(err, check.ErrorMatches, `unsupported argument --global when root.`)
+}
+
+func (s *appOpSuite) TestAppStatusInvalidUserGlobalSwitchesNonRoot(c *check.C) {
+	r := snap.MockUserCurrent(func() (*user.User, error) {
+		return &user.User{
+			Uid: "1337",
+		}, nil
+	})
+	defer r()
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"services", "--user"})
+	c.Check(err, check.ErrorMatches, `unsupported argument --user when not root.`)
 }
 
 func (s *appOpSuite) TestAppStatusNoServices(c *check.C) {

--- a/cmd/snap/cmd_services_test.go
+++ b/cmd/snap/cmd_services_test.go
@@ -480,6 +480,15 @@ func (s *appOpSuite) TestServiceCompletion(c *check.C) {
 	c.Check(n, check.Equals, 7)
 }
 
+func (s *appOpSuite) TestAppStatusUserFailed(c *check.C) {
+	r := snap.MockUserCurrent(func() (*user.User, error) {
+		return nil, fmt.Errorf("oh-no")
+	})
+	defer r()
+	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"services"})
+	c.Check(err, check.ErrorMatches, `cannot get the current user: oh-no`)
+}
+
 func (s *appOpSuite) TestAppStatusNoServices(c *check.C) {
 	n := 0
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {

--- a/daemon/api_apps.go
+++ b/daemon/api_apps.go
@@ -57,7 +57,7 @@ var (
 )
 
 var newStatusDecorator = func(ctx context.Context, isGlobal bool, uid string) clientutil.StatusDecorator {
-	if uid == "0" || isGlobal {
+	if isGlobal {
 		return servicestate.NewStatusDecorator(progress.Null)
 	} else {
 		return servicestate.NewStatusDecoratorForUid(progress.Null, ctx, uid)

--- a/daemon/api_apps_test.go
+++ b/daemon/api_apps_test.go
@@ -457,7 +457,7 @@ func (s *appsSuite) TestGetUserAppsInfoServices(c *check.C) {
 	svcs := rsp.Result.([]client.AppInfo)
 	c.Assert(svcs, check.HasLen, 4)
 
-	for name, _ := range s.decoratorResults {
+	for name := range s.decoratorResults {
 		snapName, app := daemon.SplitAppName(name)
 		needle := client.AppInfo{
 			Snap:        snapName,

--- a/daemon/api_base_test.go
+++ b/daemon/api_base_test.go
@@ -241,7 +241,7 @@ func (s *apiBaseSuite) SetUpTest(c *check.C) {
 	s.AddCleanup(daemon.MockSystemUserFromRequest(func(r *http.Request) (*user.User, error) {
 		if s.authUser != nil {
 			return &user.User{
-				Uid:      "1337",
+				Uid:      fmt.Sprintf("%d", os.Getuid()),
 				Gid:      "42",
 				Username: s.authUser.Username,
 				Name:     s.authUser.Username,

--- a/daemon/api_base_test.go
+++ b/daemon/api_base_test.go
@@ -241,7 +241,7 @@ func (s *apiBaseSuite) SetUpTest(c *check.C) {
 	s.AddCleanup(daemon.MockSystemUserFromRequest(func(r *http.Request) (*user.User, error) {
 		if s.authUser != nil {
 			return &user.User{
-				Uid:      fmt.Sprintf("%d", os.Getuid()),
+				Uid:      "1337",
 				Gid:      "42",
 				Username: s.authUser.Username,
 				Name:     s.authUser.Username,

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/client/clientutil"
 	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/restart"
@@ -385,4 +386,10 @@ func MockOsReadlink(f func(string) (string, error)) func() {
 	return func() {
 		osReadlink = old
 	}
+}
+
+func MockNewStatusDecorator(f func(ctx context.Context, isGlobal bool, uid string) clientutil.StatusDecorator) (restore func()) {
+	restore = testutil.Backup(&newStatusDecorator)
+	newStatusDecorator = f
+	return restore
 }

--- a/overlord/servicestate/servicestate.go
+++ b/overlord/servicestate/servicestate.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	"github.com/snapcore/snapd/client"
+	"github.com/snapcore/snapd/client/clientutil"
 	"github.com/snapcore/snapd/overlord/cmdstate"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/hookstate"
@@ -364,7 +365,7 @@ type StatusDecorator struct {
 // user.
 func NewStatusDecorator(rep interface {
 	Notify(string)
-}) *StatusDecorator {
+}) clientutil.StatusDecorator {
 	return &StatusDecorator{
 		sysd:           systemd.New(systemd.SystemMode, rep),
 		globalUserSysd: systemd.New(systemd.GlobalUserMode, rep),
@@ -376,7 +377,7 @@ func NewStatusDecorator(rep interface {
 // user-services for a specific user.
 func NewStatusDecoratorForUid(rep interface {
 	Notify(string)
-}, context context.Context, uid string) *StatusDecorator {
+}, context context.Context, uid string) clientutil.StatusDecorator {
 	return &StatusDecorator{
 		sysd:           systemd.New(systemd.SystemMode, rep),
 		globalUserSysd: systemd.New(systemd.GlobalUserMode, rep),

--- a/tests/main/services-user/task.yaml
+++ b/tests/main/services-user/task.yaml
@@ -56,14 +56,46 @@ execute: |
     systemctl status snap.test-snapd-user-service.svc3.service | MATCH "running"
     systemctl status snap.test-snapd-user-service.svc4.service | MATCH "running"
 
+    echo "(root) Verifying what snap services is reporting"
+    snap services | cat -n > services-root.txt
+    MATCH "     1\s+Service\s+Startup\s+Current\s+Notes$" < services-root.txt
+    MATCH "     2\s+test-snapd-user-service.svc1\s+enabled\s+-\s+user$" < services-root.txt
+    MATCH "     3\s+test-snapd-user-service.svc2\s+enabled\s+-\s+user$" < services-root.txt
+    MATCH "     4\s+test-snapd-user-service.svc3\s+enabled\s+active\s+-$" < services-root.txt
+    MATCH "     5\s+test-snapd-user-service.svc4\s+enabled\s+active\s+-$" < services-root.txt
+
     echo "(user test) We can see the user services running"
     tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH "active"
     tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH "active"
+
+    echo "(user test) Verifying what snap services is reporting"
+    tests.session -u test exec snap services | cat -n > services-user.txt
+    MATCH "     1\s+Service\s+Startup\s+Current\s+Notes$" < services-user.txt
+    MATCH "     2\s+test-snapd-user-service.svc1\s+enabled\s+active\s+user$" < services-user.txt
+    MATCH "     3\s+test-snapd-user-service.svc2\s+enabled\s+active\s+user$" < services-user.txt
+    MATCH "     4\s+test-snapd-user-service.svc3\s+enabled\s+active\s+-$" < services-user.txt
+    MATCH "     5\s+test-snapd-user-service.svc4\s+enabled\s+active\s+-$" < services-user.txt
 
     echo "(user test2) We can see the user services running"
     tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH "active"
     tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH "active"
 
+    echo "(user test2) Verifying what snap services is reporting"
+    tests.session -u test2 exec snap services | cat -n > services-user2.txt
+    MATCH "     1\s+Service\s+Startup\s+Current\s+Notes$" < services-user2.txt
+    MATCH "     2\s+test-snapd-user-service.svc1\s+enabled\s+active\s+user$" < services-user2.txt
+    MATCH "     3\s+test-snapd-user-service.svc2\s+enabled\s+active\s+user$" < services-user2.txt
+    MATCH "     4\s+test-snapd-user-service.svc3\s+enabled\s+active\s+-$" < services-user2.txt
+    MATCH "     5\s+test-snapd-user-service.svc4\s+enabled\s+active\s+-$" < services-user2.txt
+
+    # when --global is passed we should see identical output to the one from root
+    tests.session -u test exec snap services --global | cat -n > services-user-global.txt
+    MATCH "     1\s+Service\s+Startup\s+Current\s+Notes$" < services-user-global.txt
+    MATCH "     2\s+test-snapd-user-service.svc1\s+enabled\s+-\s+user$" < services-user-global.txt
+    MATCH "     3\s+test-snapd-user-service.svc2\s+enabled\s+-\s+user$" < services-user-global.txt
+    MATCH "     4\s+test-snapd-user-service.svc3\s+enabled\s+active\s+-$" < services-user-global.txt
+    MATCH "     5\s+test-snapd-user-service.svc4\s+enabled\s+active\s+-$" < services-user-global.txt
+    
     # if root is making this request, implied scopes are all
     echo "(root) Stopping all services for snap"
     snap stop test-snapd-user-service

--- a/tests/main/services-user/task.yaml
+++ b/tests/main/services-user/task.yaml
@@ -64,6 +64,14 @@ execute: |
     MATCH "     4\s+test-snapd-user-service.svc3\s+enabled\s+active\s+-$" < services-root.txt
     MATCH "     5\s+test-snapd-user-service.svc4\s+enabled\s+active\s+-$" < services-root.txt
 
+    echo "(root) Verifying what snap services is reporting with --user"
+    snap services --user | cat -n > services-root.txt
+    MATCH "     1\s+Service\s+Startup\s+Current\s+Notes$" < services-root-user.txt
+    MATCH "     2\s+test-snapd-user-service.svc1\s+enabled\s+active\s+user$" < services-root-user.txt
+    MATCH "     3\s+test-snapd-user-service.svc2\s+enabled\s+active\s+user$" < services-root.txt
+    MATCH "     4\s+test-snapd-user-service.svc3\s+enabled\s+active\s+-$" < services-root-user.txt
+    MATCH "     5\s+test-snapd-user-service.svc4\s+enabled\s+active\s+-$" < services-root-user.txt
+
     echo "(user test) We can see the user services running"
     tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH "active"
     tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH "active"

--- a/tests/main/services-user/task.yaml
+++ b/tests/main/services-user/task.yaml
@@ -65,10 +65,10 @@ execute: |
     MATCH "     5\s+test-snapd-user-service.svc4\s+enabled\s+active\s+-$" < services-root.txt
 
     echo "(root) Verifying what snap services is reporting with --user"
-    snap services --user | cat -n > services-root.txt
+    snap services --user | cat -n > services-root-user.txt
     MATCH "     1\s+Service\s+Startup\s+Current\s+Notes$" < services-root-user.txt
     MATCH "     2\s+test-snapd-user-service.svc1\s+enabled\s+active\s+user$" < services-root-user.txt
-    MATCH "     3\s+test-snapd-user-service.svc2\s+enabled\s+active\s+user$" < services-root.txt
+    MATCH "     3\s+test-snapd-user-service.svc2\s+enabled\s+active\s+user$" < services-root-user.txt
     MATCH "     4\s+test-snapd-user-service.svc3\s+enabled\s+active\s+-$" < services-root-user.txt
     MATCH "     5\s+test-snapd-user-service.svc4\s+enabled\s+active\s+-$" < services-root-user.txt
 


### PR DESCRIPTION
Implements support for user services in `snap services`

For a root user, `snap services` behaviour will not change. It will show the global enable status of user services. It will be possible to see the status of user-services with the new `--user` switch.
For a non-root user, `snap services` will now default to show the status of user services for the current user.

Introduces a new flag for non-root users. `--global` which is equivelent to the behaviour we have today (and the behaviour for root-users). `snap services --global`

Introduces a new flag for root users. `--user` which is equivilent to the default behavior of non-root users.