### PR TITLE
tests: fix tests checks and add missing details in spread tests - part 1

### DIFF
--- a/run-checks
+++ b/run-checks
@@ -348,7 +348,8 @@ if [ "$STATIC" = 1 ]; then
 
         echo "Checking tests formatting"
         if [ -n "$FILTERED_TESTS" ]; then
-            ./tests/lib/external/snapd-testing-tools/utils/check-test-format --tests "$FILTERED_TESTS"
+            # shellcheck disable=SC2086
+            ./tests/lib/external/snapd-testing-tools/utils/check-test-format --tests $FILTERED_TESTS
         fi
     fi
 

--- a/tests/main/ack/task.yaml
+++ b/tests/main/ack/task.yaml
@@ -1,5 +1,8 @@
 summary: Check snap ack
 
+details: |
+    Verify the basic scenarios for the snap ack command
+
 systems: [-ubuntu-core-*-arm-*]
 
 execute: |

--- a/tests/main/alias/task.yaml
+++ b/tests/main/alias/task.yaml
@@ -1,5 +1,8 @@
 summary: Check snap alias and snap unalias
 
+details: |
+    Verify the basic scenarios for the snap alias, unalias and aliases commands.
+
 prepare: |
     "$TESTSTOOLS"/snaps-state install-local aliases
 

--- a/tests/main/api-get-systems-label/task.yaml
+++ b/tests/main/api-get-systems-label/task.yaml
@@ -1,5 +1,8 @@
 summary: verify that the /systems/<label> api works
 
+details: |
+  Verify the basic functionality for the /systems/<label> API
+
 systems:
   # TODO: also test classic/core hybrid systems once they are ready
   - ubuntu-core-2*

--- a/tests/main/appstream-id/task.yaml
+++ b/tests/main/appstream-id/task.yaml
@@ -1,5 +1,9 @@
 summary: Verify AppStream ID integration
 
+details: |
+    Verify the AppStream ID is included in the search API response and also validate
+    that the AppStream ID is included in the installed snaps and apps API response.
+
 # ubuntu-core: no curl
 # ubuntu-14.04: curl too old, missing --unix-socket
 systems: [-ubuntu-14.04-*, -ubuntu-core*]

--- a/tests/main/apt-hooks/task.yaml
+++ b/tests/main/apt-hooks/task.yaml
@@ -1,5 +1,9 @@
 summary: Ensure apt hooks work
 
+details: |
+    Verify the snap catalog is stored locally and apt command shows a
+    message to install the snap with the same name of the requested deb
+
 # apt hook only available on 18.04+ and aws-cli only for amd64
 systems: [ubuntu-18.04-64, ubuntu-2*-64]
 

--- a/tests/main/aspects/task.yaml
+++ b/tests/main/aspects/task.yaml
@@ -1,5 +1,8 @@
 summary: Check the aspects API
 
+details: |
+  Verify the basic scenarios of the aspects API
+
 # ubuntu-14.04-64's curl doesn't support --unix-socket
 systems: [-ubuntu-14.04-*]
 

--- a/tests/main/auth-errors/task.yaml
+++ b/tests/main/auth-errors/task.yaml
@@ -1,5 +1,10 @@
 summary: Check that the authentication errors are properly reported.
 
+details: |
+    Verify that in ubuntu core just authenticated users are allowed to
+    install snaps ans to connect interfaces. Also validate the error
+    messages are the expected.
+
 systems: [-ubuntu-core-*]
 
 prepare: |


### PR DESCRIPTION
Add details to tests. This is part of the documentation plan.

Also it fixes issue in tests check when there are more than 1 test to validate.
Without this fix, the run-checks is failing when a PR changes more than 1 test.
