### PR TITLE
packaging: move directory for snapd-generator in debian sid

### DIFF
--- a/packaging/debian-sid/snapd.install
+++ b/packaging/debian-sid/snapd.install
@@ -39,5 +39,4 @@ usr/lib/snapd/snap-gdbserver-shim
 
 # use "usr/lib" here because apparently systemd looks only there
 usr/lib/systemd/system-environment-generators
-# but system generators end up in lib
-lib/systemd/system-generators
+usr/lib/systemd/system-generators


### PR DESCRIPTION
In debian sid, the system-generators are being created in usr/lib/systemd/system-generators instead of lib

This is needed to avoid this error building snapd:

dh_install: warning: Cannot find (any matches for) "lib/systemd/system-generators" (tried in ., debian/tmp)

dh_install: warning: snapd missing files: lib/systemd/system-generators
dh_install: error: missing files, aborting
make[1]: *** [debian/rules:265: override_dh_install-arch] Error 25