### PR TITLE
o/snapstate: only use names passed to refreshCandidates

### DIFF
--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -239,8 +239,9 @@ func MockAsyncPendingRefreshNotification(fn func(context.Context, *userclient.Cl
 
 // re-refresh related
 var (
-	RefreshedSnaps  = refreshedSnaps
-	ReRefreshFilter = reRefreshFilter
+	RefreshedSnaps     = refreshedSnaps
+	ReRefreshFilter    = reRefreshFilter
+	UpdateManyFiltered = updateManyFiltered
 
 	MaybeRestoreValidationSetsAndRevertSnaps = maybeRestoreValidationSetsAndRevertSnaps
 )

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -9040,7 +9040,7 @@ func (s *snapmgrTestSuite) TestSaveMonitoredRefreshCandidatesOnAutoRefreshThrott
 		"snap-c-id":          true,
 	}
 	type requestRecord struct {
-		opts    *store.RefreshOptions
+		opts    store.RefreshOptions
 		snapIDs map[string]bool
 	}
 	var requests []requestRecord
@@ -9061,7 +9061,7 @@ func (s *snapmgrTestSuite) TestSaveMonitoredRefreshCandidatesOnAutoRefreshThrott
 		}
 
 		requests = append(requests, requestRecord{
-			opts:    ro,
+			opts:    *ro,
 			snapIDs: snapIDs,
 		})
 


### PR DESCRIPTION
This commit fixes a regression caused by (#13259).

`refreshCandidates` wrapper was trying to check for updates for existing refresh candidates that were monitored even when not being passed in `names`. This caused snapd to crash when trying to access the `SnapState` for those updates later.

Thanks @pedronis for finding this and suggesting the fix.