### PR TITLE
run-checks: fix invocation to check-test-format

### DIFF
--- a/run-checks
+++ b/run-checks
@@ -325,7 +325,7 @@ if [ "$STATIC" = 1 ]; then
 
     if [ -z "${SKIP_TESTS_FORMAT_CHECK-}" ] || [ "$SKIP_TESTS_FORMAT_CHECK" = 0 ]; then
         CHANGED_TESTS=""
-        FILTERED_TESTS=""
+        FILTERED_TESTS=()
         EXCLUDE_PATH=tests/lib/external/snapd-testing-tools
         if [ -n "$CHANGED_FILES" ]; then
             # shellcheck disable=SC2086
@@ -338,17 +338,13 @@ if [ "$STATIC" = 1 ]; then
         # shellcheck disable=SC2086
         for test in $CHANGED_TESTS; do
             if ! echo "$test" | grep -q "$EXCLUDE_PATH"; then
-                if [ -z "$FILTERED_TESTS" ]; then
-                    FILTERED_TESTS="$test"
-                else
-                    FILTERED_TESTS="$FILTERED_TESTS $test"
-                fi
+                FILTERED_TESTS+=(--tests "$test")
             fi
         done
 
         echo "Checking tests formatting"
-        if [ -n "$FILTERED_TESTS" ]; then
-            ./tests/lib/external/snapd-testing-tools/utils/check-test-format --tests "$FILTERED_TESTS"
+        if [ "${#FILTERED_TESTS[*]}" -gt 0 ]; then
+            ./tests/lib/external/snapd-testing-tools/utils/check-test-format "${FILTERED_TESTS[@]}"
         fi
     fi
 


### PR DESCRIPTION
check-test-format expects multiple --tests arguments. But we pass a space separated list.
