### PR TITLE
Fix snap tests on non-debian systems (like opensuse)

### DIFF
--- a/snap/pack/pack_test.go
+++ b/snap/pack/pack_test.go
@@ -588,15 +588,25 @@ esac
 	c.Assert(err, IsNil)
 	defer snapFile.Close()
 
+	fi, err := snapFile.Stat()
+	c.Assert(err, IsNil)
+
+	integrityStartOffset := squashfs.MinimumSnapSize
+	if fi.Size() > int64(65536) {
+		// on non-Debian, the squashfs image is padded up to 64k,
+		// including the integrator data, the overall size is > 64k
+		integrityStartOffset = 65536
+	}
+
 	// example snap has a size of 16384 (4 blocks)
-	_, err = snapFile.Seek(squashfs.MinimumSnapSize, io.SeekStart)
+	_, err = snapFile.Seek(integrityStartOffset, io.SeekStart)
 	c.Assert(err, IsNil)
 
 	integrityHdr := make([]byte, integrity.HeaderSize)
 	_, err = snapFile.Read(integrityHdr)
 	c.Assert(err, IsNil)
 
-	c.Check(bytes.HasPrefix(integrityHdr, magic), Equals, true)
+	c.Assert(bytes.HasPrefix(integrityHdr, magic), Equals, true)
 
 	var hdr interface{}
 	integrityHdr = bytes.Trim(integrityHdr, "\x00")
@@ -611,7 +621,7 @@ esac
 	c.Assert(err, IsNil)
 	c.Check(hdrSize, Equals, uint64(integrity.HeaderSize+verityHashSize))
 
-	fi, err := snapFile.Stat()
+	fi, err = snapFile.Stat()
 	c.Assert(err, IsNil)
-	c.Check(fi.Size(), Equals, int64(squashfs.MinimumSnapSize+(integrity.HeaderSize+verityHashSize)))
+	c.Check(fi.Size(), Equals, int64(integrityStartOffset+(integrity.HeaderSize+verityHashSize)))
 }

--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -509,6 +509,8 @@ type BuildOpts struct {
 // partition table from the snap when a loopback device is created from it. If the snap
 // is smaller than this size, some versions of the kernel will print error logs while
 // scanning the loopback device for partitions.
+// TODO: this isn't reliable, on some distros mkfsquashfs pads up to 64k by
+// default
 const MinimumSnapSize int64 = 16384
 
 // Build builds the snap.
@@ -536,6 +538,7 @@ func (s *Snap) Build(sourceDir string, opts *BuildOpts) error {
 	if err != nil {
 		cmd = exec.Command("mksquashfs")
 	}
+	// TODO: consider adding -nopad to control the padding of the fs image
 	cmd.Args = append(cmd.Args,
 		".", fullSnapPath,
 		"-noappend",

--- a/snap/squashfs/squashfs_test.go
+++ b/snap/squashfs/squashfs_test.go
@@ -981,7 +981,14 @@ func (s *SquashfsTestSuite) TestBuildBelowMinimumSize(c *C) {
 	size, err := sn.Size()
 	c.Assert(err, IsNil)
 
-	c.Assert(size, Equals, squashfs.MinimumSnapSize)
+	switch size {
+	case squashfs.MinimumSnapSize:
+		// all good on Debian based distros
+	case 65536:
+		// this is expected on non-Debian based distros
+	default:
+		c.Fatalf("unexpected squashfs size %v", size)
+	}
 }
 
 func (s *SquashfsTestSuite) TestBuildAboveMinimumSize(c *C) {


### PR DESCRIPTION
Fixed build not completed on non-debian based systems like opensuse due to failing tests . thanks to @bboozzoo for original commits