### PR TITLE
interfaces/builtin: Add ProductIDPattern of GoTrust Idem Key with NFC and usb-c

### DIFF
--- a/interfaces/builtin/u2f_devices.go
+++ b/interfaces/builtin/u2f_devices.go
@@ -150,7 +150,7 @@ var u2fDevices = []u2fDevice{
 	{
 		Name:             "GoTrust Idem Key",
 		VendorIDPattern:  "32a3",
-		ProductIDPattern: "3201",
+		ProductIDPattern: "3201|3203",
 	},
 	{
 		Name:             "Trezor",


### PR DESCRIPTION
My Idem Key with nfc and usb-c has the ProductIDPattern given in PR. I assume the ID Pattern 3201 is the pattern of the usb-a Version.
 lsusb output is
```
Bus 001 Device 010: ID 32a3:3203 GoTrust Idem Key 1C
```
Please add. 