### PR TITLE
tests: group the systems used in the github workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -356,6 +356,7 @@ jobs:
     # release branches
     if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/master' }}
     runs-on: self-hosted
+    name: ${{ matrix.group }}
     strategy:
       # FIXME: enable fail-fast mode once spread can cancel an executing job.
       # Disable fail-fast mode as it doesn't function with spread. It seems
@@ -371,30 +372,22 @@ jobs:
             system: arch-linux-64
           - group: centos
             system: centos-7-64 centos-8-64 centos-9-64
-          - group: debian-11
+          - group: debian-required
             system: debian-11-64
-          - group: debian-12
-            system: debian-12-64
-          - group: debian-sid
-            system: debian-sid-64
+          - group: debian-no-required
+            system: debian-12-64 debian-sid-64
           - group: fedora
             system: fedora-38-64 fedora-39-64
           - group: opensuse
             system: opensuse-15.4-64 opensuse-15.5-64 opensuse-tumbleweed-64
-          - group: ubuntu-14.04
-            system: ubuntu-14.04
-          - group: ubuntu-16.04
-            system: ubuntu-16.04
-          - group: ubuntu-18.04
+          - group: ubuntu-trusty-xenial
+            system: ubuntu-14.04-64 ubuntu-16.04-64
+          - group: ubuntu-bionic
             system: ubuntu-18.04-32 ubuntu-18.04-64
-          - group: ubuntu-20.04
-            system: ubuntu-20.04-64
-          - group: ubuntu-22.04
-            system: ubuntu-22.04-64
-          - group: ubuntu-23.04
-            system: ubuntu-23.04-64
-          - group: ubuntu-23.10
-            system: ubuntu-23.10-64
+          - group: ubuntu-focal-jammy
+            system: ubuntu-20.04-64 ubuntu-22.04-64
+          - group: ubuntu-no-lts
+            system: ubuntu-23.04-64 ubuntu-23.10-64
           - group: ubuntu-core-16
             system: ubuntu-core-16-64
           - group: ubuntu-core-18

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -379,7 +379,7 @@ jobs:
           - group: fedora
             systems: 'fedora-38-64 fedora-39-64'
           - group: opensuse
-            systems: 'opensuse-15.4-64 opensuse-15.5-64 opensuse-tumbleweed-64'
+            systems: 'opensuse-15.5-64 opensuse-tumbleweed-64'
           - group: ubuntu-trusty-xenial
             systems: 'ubuntu-14.04-64 ubuntu-16.04-64'
           - group: ubuntu-bionic

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -369,37 +369,37 @@ jobs:
           - group: amazon-linux
             system: amazon-linux-2-64 amazon-linux-2023-64
           - group: arch-linux
-            system: arch-linux-64
+            systems: arch-linux-64
           - group: centos
-            system: centos-7-64 centos-8-64 centos-9-64
-          - group: debian-required
-            system: debian-11-64
-          - group: debian-no-required
+            systems: centos-7-64 centos-8-64 centos-9-64
+          - group: debian-req
+            systems: debian-11-64
+          - group: debian-no-req
             system: debian-12-64 debian-sid-64
           - group: fedora
             system: fedora-38-64 fedora-39-64
           - group: opensuse
-            system: opensuse-15.4-64 opensuse-15.5-64 opensuse-tumbleweed-64
+            systems: opensuse-15.4-64 opensuse-15.5-64 opensuse-tumbleweed-64
           - group: ubuntu-trusty-xenial
             system: ubuntu-14.04-64 ubuntu-16.04-64
           - group: ubuntu-bionic
-            system: ubuntu-18.04-32 ubuntu-18.04-64
+            systems: ubuntu-18.04-32 ubuntu-18.04-64
           - group: ubuntu-focal-jammy
             system: ubuntu-20.04-64 ubuntu-22.04-64
           - group: ubuntu-no-lts
             system: ubuntu-23.04-64 ubuntu-23.10-64
           - group: ubuntu-core-16
-            system: ubuntu-core-16-64
+            systems: ubuntu-core-16-64
           - group: ubuntu-core-18
-            system: ubuntu-core-18-64
+            systems: ubuntu-core-18-64
           - group: ubuntu-core-20
-            system: ubuntu-core-20-64
+            systems: ubuntu-core-20-64
           - group: ubuntu-core-22
-            system: ubuntu-core-22-64
+            systems: ubuntu-core-22-64
           - group: ubuntu-arm
-            system: ubuntu-20.04-arm-64 ubuntu-core-22-arm-64
+            systems: ubuntu-20.04-arm-64 ubuntu-core-22-arm-64
           - group: ubuntu-secboot
-            system: ubuntu-secboot-20.04-64
+            systems: ubuntu-secboot-20.04-64
     steps:
     - name: Cleanup job workspace
       id: cleanup-job-workspace
@@ -469,8 +469,8 @@ jobs:
           fi
 
           # Save previous failed test results in FAILED_TESTS env var
-          RUN_TESTS=
-          for SYSTEM in ${{ matrix.system }}; do
+          RUN_TESTS=""
+          for SYSTEM in ${{ matrix.systems }}; do
               RUN_TESTS="$RUN_TESTS $BACKEND:$SYSTEM:tests/..."
           done
           if [ -n "$FAILED_TESTS" ]; then
@@ -521,8 +521,8 @@ jobs:
               fi
 
               echo "Determining which tests were executed"
-              RUN_TESTS=
-              for SYSTEM in ${{ matrix.system }}; do
+              RUN_TESTS=""
+              for SYSTEM in ${{ matrix.systems }}; do
                   RUN_TESTS="$RUN_TESTS $BACKEND:$SYSTEM:tests/..."
               done
               if [ -n "$FAILED_TESTS" ]; then

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -367,7 +367,7 @@ jobs:
       matrix:
         include:
           - group: amazon-linux
-            system: 'amazon-linux-2-64 amazon-linux-2023-64'
+            systems: 'amazon-linux-2-64 amazon-linux-2023-64'
           - group: arch-linux
             systems: 'arch-linux-64'
           - group: centos
@@ -375,21 +375,21 @@ jobs:
           - group: debian-req
             systems: 'debian-11-64'
           - group: debian-no-req
-            system: 'debian-12-64 debian-sid-64'
+            systems: 'debian-12-64 debian-sid-64'
           - group: fedora
-            system: 'fedora-38-64 fedora-39-64'
+            systems: 'fedora-38-64 fedora-39-64'
           - group: opensuse
             systems: 'opensuse-15.4-64 opensuse-15.5-64 opensuse-tumbleweed-64'
           - group: ubuntu-trusty-xenial
-            system: 'ubuntu-14.04-64 ubuntu-16.04-64'
+            systems: 'ubuntu-14.04-64 ubuntu-16.04-64'
           - group: ubuntu-bionic
             systems: 'ubuntu-18.04-32 ubuntu-18.04-64'
           - group: ubuntu-focal-jammy
-            system: 'ubuntu-20.04-64 ubuntu-22.04-64'
+            systems: 'ubuntu-20.04-64 ubuntu-22.04-64'
           - group: ubuntu-no-lts
-            system: 'ubuntu-23.04-64 ubuntu-23.10-64'
+            systems: 'ubuntu-23.04-64 ubuntu-23.10-64'
           - group: ubuntu-daily
-            system: 'ubuntu-24.04'
+            systems: 'ubuntu-24.04'
           - group: ubuntu-core-16
             systems: 'ubuntu-core-16-64'
           - group: ubuntu-core-18
@@ -470,13 +470,14 @@ jobs:
               SPREAD=spread-arm
           fi
 
-          # Save previous failed test results in FAILED_TESTS env var
           RUN_TESTS=""
-          for SYSTEM in ${{ matrix.systems }}; do
-              RUN_TESTS="$RUN_TESTS $BACKEND:$SYSTEM:tests/..."
-          done
+          # Save previous failed test results in FAILED_TESTS env var
           if [ -n "$FAILED_TESTS" ]; then
               RUN_TESTS="$FAILED_TESTS"
+          else
+              for SYSTEM in ${{ matrix.systems }}; do
+                  RUN_TESTS="$RUN_TESTS $BACKEND:$SYSTEM:tests/..."
+              done
           fi
           # Run spread tests
           # "pipefail" ensures that a non-zero status from the spread is

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -355,8 +355,8 @@ jobs:
     # have spread jobs run on master on PRs only, but on both PRs and pushes to
     # release branches
     if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/master' }}
-    runs-on: self-hosted
     name: ${{ matrix.group }}
+    runs-on: self-hosted
     strategy:
       # FIXME: enable fail-fast mode once spread can cancel an executing job.
       # Disable fail-fast mode as it doesn't function with spread. It seems
@@ -365,40 +365,40 @@ jobs:
       # fail-fast while we tackle that problem upstream.
       fail-fast: false
       matrix:
-          - group: amazon-linux
-            system: amazon-linux-2-64 amazon-linux-2023-64
-          - group: arch-linux
-            systems: arch-linux-64
-          - group: centos
-            systems: centos-7-64 centos-8-64 centos-9-64
-          - group: debian-req
-            systems: debian-11-64
-          - group: debian-no-req
-            system: debian-12-64 debian-sid-64
-          - group: fedora
-            system: fedora-38-64 fedora-39-64
-          - group: opensuse
-            systems: opensuse-15.4-64 opensuse-15.5-64 opensuse-tumbleweed-64
-          - group: ubuntu-trusty-xenial
-            system: ubuntu-14.04-64 ubuntu-16.04-64
-          - group: ubuntu-bionic
-            systems: ubuntu-18.04-32 ubuntu-18.04-64
-          - group: ubuntu-focal-jammy
-            system: ubuntu-20.04-64 ubuntu-22.04-64
-          - group: ubuntu-no-lts
-            system: ubuntu-23.04-64 ubuntu-23.10-64
-          - group: ubuntu-core-16
-            systems: ubuntu-core-16-64
-          - group: ubuntu-core-18
-            systems: ubuntu-core-18-64
-          - group: ubuntu-core-20
-            systems: ubuntu-core-20-64
-          - group: ubuntu-core-22
-            systems: ubuntu-core-22-64
-          - group: ubuntu-arm
-            systems: ubuntu-20.04-arm-64 ubuntu-core-22-arm-64
-          - group: ubuntu-secboot
-            systems: ubuntu-secboot-20.04-64
+        - group: amazon-linux
+          system: amazon-linux-2-64 amazon-linux-2023-64
+        - group: arch-linux
+          systems: arch-linux-64
+        - group: centos
+          systems: centos-7-64 centos-8-64 centos-9-64
+        - group: debian-req
+          systems: debian-11-64
+        - group: debian-no-req
+          system: debian-12-64 debian-sid-64
+        - group: fedora
+          system: fedora-38-64 fedora-39-64
+        - group: opensuse
+          systems: opensuse-15.4-64 opensuse-15.5-64 opensuse-tumbleweed-64
+        - group: ubuntu-trusty-xenial
+          system: ubuntu-14.04-64 ubuntu-16.04-64
+        - group: ubuntu-bionic
+          systems: ubuntu-18.04-32 ubuntu-18.04-64
+        - group: ubuntu-focal-jammy
+          system: ubuntu-20.04-64 ubuntu-22.04-64
+        - group: ubuntu-no-lts
+          system: ubuntu-23.04-64 ubuntu-23.10-64
+        - group: ubuntu-core-16
+          systems: ubuntu-core-16-64
+        - group: ubuntu-core-18
+          systems: ubuntu-core-18-64
+        - group: ubuntu-core-20
+          systems: ubuntu-core-20-64
+        - group: ubuntu-core-22
+          systems: ubuntu-core-22-64
+        - group: ubuntu-arm
+          systems: ubuntu-20.04-arm-64 ubuntu-core-22-arm-64
+        - group: ubuntu-secboot
+          systems: ubuntu-secboot-20.04-64
     steps:
     - name: Cleanup job workspace
       id: cleanup-job-workspace

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -462,7 +462,7 @@ jobs:
 
           BACKEND=google
           SPREAD=spread
-          if [[ "${{ matrix.group }}" =~ -arm- ]]; then
+          if [[ "${{ matrix.systems }}" =~ -arm- ]]; then
               BACKEND=google-arm
               SPREAD=spread-arm
           fi
@@ -515,7 +515,7 @@ jobs:
               ./tests/lib/external/snapd-testing-tools/utils/log-parser spread.log --output spread-results.json
 
               BACKEND=google
-              if [[ "${{ matrix.group }}" =~ -arm- ]]; then
+              if [[ "${{ matrix.systems }}" =~ -arm- ]]; then
                   BACKEND=google-arm
               fi
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -371,7 +371,7 @@ jobs:
           - group: arch-linux
             systems: arch-linux-64
           - group: centos
-            systems: centos-7-64 centos-8-64 centos-9-64
+            systems: 'centos-7-64 centos-8-64 centos-9-64'
           - group: debian-req
             systems: debian-11-64
           - group: debian-no-req
@@ -379,11 +379,11 @@ jobs:
           - group: fedora
             system: fedora-38-64 fedora-39-64
           - group: opensuse
-            systems: opensuse-15.4-64 opensuse-15.5-64 opensuse-tumbleweed-64
+            systems: 'opensuse-15.4-64 opensuse-15.5-64 opensuse-tumbleweed-64'
           - group: ubuntu-trusty-xenial
             system: ubuntu-14.04-64 ubuntu-16.04-64
           - group: ubuntu-bionic
-            systems: ubuntu-18.04-32 ubuntu-18.04-64
+            systems: 'ubuntu-18.04-32 ubuntu-18.04-64'
           - group: ubuntu-focal-jammy
             system: ubuntu-20.04-64 ubuntu-22.04-64
           - group: ubuntu-no-lts
@@ -397,7 +397,7 @@ jobs:
           - group: ubuntu-core-22
             systems: ubuntu-core-22-64
           - group: ubuntu-arm
-            systems: ubuntu-20.04-arm-64 ubuntu-core-22-arm-64
+            systems: 'ubuntu-20.04-arm-64 ubuntu-core-22-arm-64'
           - group: ubuntu-secboot
             systems: ubuntu-secboot-20.04-64
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -364,36 +364,49 @@ jobs:
       # fail-fast while we tackle that problem upstream.
       fail-fast: false
       matrix:
-        system:
-        - amazon-linux-2-64
-        - amazon-linux-2023-64
-        - arch-linux-64
-        - centos-7-64
-        - centos-8-64
-        - centos-9-64
-        - debian-11-64
-        - debian-12-64
-        - debian-sid-64
-        - fedora-38-64
-        - fedora-39-64
-        - opensuse-15.5-64
-        - opensuse-tumbleweed-64
-        - ubuntu-14.04-64
-        - ubuntu-16.04-64
-        - ubuntu-18.04-32
-        - ubuntu-18.04-64
-        - ubuntu-20.04-64
-        - ubuntu-20.04-arm-64
-        - ubuntu-22.04-64
-        - ubuntu-23.04-64
-        - ubuntu-23.10-64
-        - ubuntu-24.04-64
-        - ubuntu-core-16-64
-        - ubuntu-core-18-64
-        - ubuntu-core-20-64
-        - ubuntu-core-22-64
-        - ubuntu-core-22-arm-64
-        - ubuntu-secboot-20.04-64
+        include:
+          - group: amazon-linux
+            system: amazon-linux-2-64 amazon-linux-2023-64
+          - group: arch-linux
+            system: arch-linux-64
+          - group: centos
+            system: centos-7-64 centos-8-64 centos-9-64
+          - group: debian-11
+            system: debian-11-64
+          - group: debian-12
+            system: debian-12-64
+          - group: debian-sid
+            system: debian-sid-64
+          - group: fedora
+            system: fedora-38-64 fedora-39-64
+          - group: opensuse
+            system: opensuse-15.4-64 opensuse-15.5-64 opensuse-tumbleweed-64
+          - group: ubuntu-14.04
+            system: ubuntu-14.04
+          - group: ubuntu-16.04
+            system: ubuntu-16.04
+          - group: ubuntu-18.04
+            system: ubuntu-18.04-32 ubuntu-18.04-64
+          - group: ubuntu-20.04
+            system: ubuntu-20.04-64
+          - group: ubuntu-22.04
+            system: ubuntu-22.04-64
+          - group: ubuntu-23.04
+            system: ubuntu-23.04-64
+          - group: ubuntu-23.10
+            system: ubuntu-23.10-64
+          - group: ubuntu-core-16
+            system: ubuntu-core-16-64
+          - group: ubuntu-core-18
+            system: ubuntu-core-18-64
+          - group: ubuntu-core-20
+            system: ubuntu-core-20-64
+          - group: ubuntu-core-22
+            system: ubuntu-core-22-64
+          - group: ubuntu-arm
+            system: ubuntu-20.04-arm-64 ubuntu-core-22-arm-64
+          - group: ubuntu-secboot
+            system: ubuntu-secboot-20.04-64
     steps:
     - name: Cleanup job workspace
       id: cleanup-job-workspace
@@ -417,7 +430,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: "${{ github.workspace }}/.test-results"
-        key: "${{ github.job }}-results-${{ github.run_id }}-${{ matrix.system }}-${{ steps.get-previous-attempt.outputs.previous_attempt }}"
+        key: "${{ github.job }}-results-${{ github.run_id }}-${{ matrix.group }}-${{ steps.get-previous-attempt.outputs.previous_attempt }}"
 
     - name: Prepare test results env and vars
       id: prepare-test-results-env
@@ -457,13 +470,16 @@ jobs:
 
           BACKEND=google
           SPREAD=spread
-          if [[ "${{ matrix.system }}" =~ -arm- ]]; then
+          if [[ "${{ matrix.group }}" =~ -arm- ]]; then
               BACKEND=google-arm
               SPREAD=spread-arm
           fi
 
           # Save previous failed test results in FAILED_TESTS env var
-          RUN_TESTS="$BACKEND:${{ matrix.system }}:tests/..."
+          RUN_TESTS=
+          for SYSTEM in ${{ matrix.system }}; do
+              RUN_TESTS="$RUN_TESTS $BACKEND:$SYSTEM:tests/..."
+          done
           if [ -n "$FAILED_TESTS" ]; then
               RUN_TESTS="$FAILED_TESTS"
           fi
@@ -507,12 +523,15 @@ jobs:
               ./tests/lib/external/snapd-testing-tools/utils/log-parser spread.log --output spread-results.json
 
               BACKEND=google
-              if [[ "${{ matrix.system }}" =~ -arm- ]]; then
+              if [[ "${{ matrix.group }}" =~ -arm- ]]; then
                   BACKEND=google-arm
               fi
 
               echo "Determining which tests were executed"
-              RUN_TESTS="$BACKEND:${{ matrix.system }}:tests/..."
+              RUN_TESTS=
+              for SYSTEM in ${{ matrix.system }}; do
+                  RUN_TESTS="$RUN_TESTS $BACKEND:$SYSTEM:tests/..."
+              done
               if [ -n "$FAILED_TESTS" ]; then
                   RUN_TESTS="$FAILED_TESTS"
               fi
@@ -532,7 +551,7 @@ jobs:
       uses: actions/cache/save@v3
       with:
         path: "${{ github.workspace }}/.test-results"
-        key: "${{ github.job }}-results-${{ github.run_id }}-${{ matrix.system }}-${{ github.run_attempt }}"
+        key: "${{ github.job }}-results-${{ github.run_id }}-${{ matrix.group }}-${{ github.run_attempt }}"
 
   spread-nested:
     needs: [unit-tests]

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -365,41 +365,40 @@ jobs:
       # fail-fast while we tackle that problem upstream.
       fail-fast: false
       matrix:
-        include:
           - group: amazon-linux
             system: amazon-linux-2-64 amazon-linux-2023-64
-          - group: arch-linux
-            systems: arch-linux-64
-          - group: centos
+        - group: arch-linux
+          systems: arch-linux-64
+        - group: centos
             systems: centos-7-64 centos-8-64 centos-9-64
           - group: debian-req
-            systems: debian-11-64
+          systems: debian-11-64
           - group: debian-no-req
             system: debian-12-64 debian-sid-64
-          - group: fedora
+        - group: fedora
             system: fedora-38-64 fedora-39-64
-          - group: opensuse
+        - group: opensuse
             systems: opensuse-15.4-64 opensuse-15.5-64 opensuse-tumbleweed-64
           - group: ubuntu-trusty-xenial
             system: ubuntu-14.04-64 ubuntu-16.04-64
           - group: ubuntu-bionic
-            systems: 'ubuntu-18.04-32 ubuntu-18.04-64'
+          systems: ubuntu-18.04-32 ubuntu-18.04-64
           - group: ubuntu-focal-jammy
             system: ubuntu-20.04-64 ubuntu-22.04-64
           - group: ubuntu-no-lts
             system: ubuntu-23.04-64 ubuntu-23.10-64
-          - group: ubuntu-core-16
-            systems: ubuntu-core-16-64
-          - group: ubuntu-core-18
-            systems: ubuntu-core-18-64
-          - group: ubuntu-core-20
-            systems: ubuntu-core-20-64
-          - group: ubuntu-core-22
-            systems: ubuntu-core-22-64
-          - group: ubuntu-arm
+        - group: ubuntu-core-16
+          systems: ubuntu-core-16-64
+        - group: ubuntu-core-18
+          systems: ubuntu-core-18-64
+        - group: ubuntu-core-20
+          systems: ubuntu-core-20-64
+        - group: ubuntu-core-22
+          systems: ubuntu-core-22-64
+        - group: ubuntu-arm
             systems: ubuntu-20.04-arm-64 ubuntu-core-22-arm-64
-          - group: ubuntu-secboot
-            systems: ubuntu-secboot-20.04-64
+        - group: ubuntu-secboot
+          systems: ubuntu-secboot-20.04-64
     steps:
     - name: Cleanup job workspace
       id: cleanup-job-workspace

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -365,42 +365,43 @@ jobs:
       # fail-fast while we tackle that problem upstream.
       fail-fast: false
       matrix:
-        - group: amazon-linux
-          system: 'amazon-linux-2-64 amazon-linux-2023-64'
-        - group: arch-linux
-          systems: 'arch-linux-64'
-        - group: centos
-          systems: 'centos-7-64 centos-8-64 centos-9-64'
-        - group: debian-req
-          systems: 'debian-11-64'
-        - group: debian-no-req
-          system: 'debian-12-64 debian-sid-64'
-        - group: fedora
-          system: 'fedora-38-64 fedora-39-64'
-        - group: opensuse
-          systems: 'opensuse-15.4-64 opensuse-15.5-64 opensuse-tumbleweed-64'
-        - group: ubuntu-trusty-xenial
-          system: 'ubuntu-14.04-64 ubuntu-16.04-64'
-        - group: ubuntu-bionic
-          systems: 'ubuntu-18.04-32 ubuntu-18.04-64'
-        - group: ubuntu-focal-jammy
-          system: 'ubuntu-20.04-64 ubuntu-22.04-64'
-        - group: ubuntu-no-lts
-          system: 'ubuntu-23.04-64 ubuntu-23.10-64'
-        - group: ubuntu-daily
-          system: 'ubuntu-24.04'
-        - group: ubuntu-core-16
-          systems: 'ubuntu-core-16-64'
-        - group: ubuntu-core-18
-          systems: 'ubuntu-core-18-64'
-        - group: ubuntu-core-20
-          systems: 'ubuntu-core-20-64'
-        - group: ubuntu-core-22
-          systems: 'ubuntu-core-22-64'
-        - group: ubuntu-arm
-          systems: 'ubuntu-20.04-arm-64 ubuntu-core-22-arm-64'
-        - group: ubuntu-secboot
-          systems: 'ubuntu-secboot-20.04-64'
+        include:
+          - group: amazon-linux
+            system: 'amazon-linux-2-64 amazon-linux-2023-64'
+          - group: arch-linux
+            systems: 'arch-linux-64'
+          - group: centos
+            systems: 'centos-7-64 centos-8-64 centos-9-64'
+          - group: debian-req
+            systems: 'debian-11-64'
+          - group: debian-no-req
+            system: 'debian-12-64 debian-sid-64'
+          - group: fedora
+            system: 'fedora-38-64 fedora-39-64'
+          - group: opensuse
+            systems: 'opensuse-15.4-64 opensuse-15.5-64 opensuse-tumbleweed-64'
+          - group: ubuntu-trusty-xenial
+            system: 'ubuntu-14.04-64 ubuntu-16.04-64'
+          - group: ubuntu-bionic
+            systems: 'ubuntu-18.04-32 ubuntu-18.04-64'
+          - group: ubuntu-focal-jammy
+            system: 'ubuntu-20.04-64 ubuntu-22.04-64'
+          - group: ubuntu-no-lts
+            system: 'ubuntu-23.04-64 ubuntu-23.10-64'
+          - group: ubuntu-daily
+            system: 'ubuntu-24.04'
+          - group: ubuntu-core-16
+            systems: 'ubuntu-core-16-64'
+          - group: ubuntu-core-18
+            systems: 'ubuntu-core-18-64'
+          - group: ubuntu-core-20
+            systems: 'ubuntu-core-20-64'
+          - group: ubuntu-core-22
+            systems: 'ubuntu-core-22-64'
+          - group: ubuntu-arm
+            systems: 'ubuntu-20.04-arm-64 ubuntu-core-22-arm-64'
+          - group: ubuntu-secboot
+            systems: 'ubuntu-secboot-20.04-64'
     steps:
     - name: Cleanup job workspace
       id: cleanup-job-workspace

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -389,7 +389,7 @@ jobs:
           - group: ubuntu-no-lts
             systems: 'ubuntu-23.04-64 ubuntu-23.10-64'
           - group: ubuntu-daily
-            systems: 'ubuntu-24.04'
+            systems: 'ubuntu-24.04-64'
           - group: ubuntu-core-16
             systems: 'ubuntu-core-16-64'
           - group: ubuntu-core-18

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -367,38 +367,38 @@ jobs:
       matrix:
           - group: amazon-linux
             system: amazon-linux-2-64 amazon-linux-2023-64
-        - group: arch-linux
-          systems: arch-linux-64
-        - group: centos
+          - group: arch-linux
+            systems: arch-linux-64
+          - group: centos
             systems: centos-7-64 centos-8-64 centos-9-64
           - group: debian-req
-          systems: debian-11-64
+            systems: debian-11-64
           - group: debian-no-req
             system: debian-12-64 debian-sid-64
-        - group: fedora
+          - group: fedora
             system: fedora-38-64 fedora-39-64
-        - group: opensuse
+          - group: opensuse
             systems: opensuse-15.4-64 opensuse-15.5-64 opensuse-tumbleweed-64
           - group: ubuntu-trusty-xenial
             system: ubuntu-14.04-64 ubuntu-16.04-64
           - group: ubuntu-bionic
-          systems: ubuntu-18.04-32 ubuntu-18.04-64
+            systems: ubuntu-18.04-32 ubuntu-18.04-64
           - group: ubuntu-focal-jammy
             system: ubuntu-20.04-64 ubuntu-22.04-64
           - group: ubuntu-no-lts
             system: ubuntu-23.04-64 ubuntu-23.10-64
-        - group: ubuntu-core-16
-          systems: ubuntu-core-16-64
-        - group: ubuntu-core-18
-          systems: ubuntu-core-18-64
-        - group: ubuntu-core-20
-          systems: ubuntu-core-20-64
-        - group: ubuntu-core-22
-          systems: ubuntu-core-22-64
-        - group: ubuntu-arm
+          - group: ubuntu-core-16
+            systems: ubuntu-core-16-64
+          - group: ubuntu-core-18
+            systems: ubuntu-core-18-64
+          - group: ubuntu-core-20
+            systems: ubuntu-core-20-64
+          - group: ubuntu-core-22
+            systems: ubuntu-core-22-64
+          - group: ubuntu-arm
             systems: ubuntu-20.04-arm-64 ubuntu-core-22-arm-64
-        - group: ubuntu-secboot
-          systems: ubuntu-secboot-20.04-64
+          - group: ubuntu-secboot
+            systems: ubuntu-secboot-20.04-64
     steps:
     - name: Cleanup job workspace
       id: cleanup-job-workspace

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -387,6 +387,8 @@ jobs:
           system: 'ubuntu-20.04-64 ubuntu-22.04-64'
         - group: ubuntu-no-lts
           system: 'ubuntu-23.04-64 ubuntu-23.10-64'
+        - group: ubuntu-daily
+          system: 'ubuntu-24.04'
         - group: ubuntu-core-16
           systems: 'ubuntu-core-16-64'
         - group: ubuntu-core-18

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -366,39 +366,39 @@ jobs:
       fail-fast: false
       matrix:
         - group: amazon-linux
-          system: amazon-linux-2-64 amazon-linux-2023-64
+          system: 'amazon-linux-2-64 amazon-linux-2023-64'
         - group: arch-linux
-          systems: arch-linux-64
+          systems: 'arch-linux-64'
         - group: centos
-          systems: centos-7-64 centos-8-64 centos-9-64
+          systems: 'centos-7-64 centos-8-64 centos-9-64'
         - group: debian-req
-          systems: debian-11-64
+          systems: 'debian-11-64'
         - group: debian-no-req
-          system: debian-12-64 debian-sid-64
+          system: 'debian-12-64 debian-sid-64'
         - group: fedora
-          system: fedora-38-64 fedora-39-64
+          system: 'fedora-38-64 fedora-39-64'
         - group: opensuse
-          systems: opensuse-15.4-64 opensuse-15.5-64 opensuse-tumbleweed-64
+          systems: 'opensuse-15.4-64 opensuse-15.5-64 opensuse-tumbleweed-64'
         - group: ubuntu-trusty-xenial
-          system: ubuntu-14.04-64 ubuntu-16.04-64
+          system: 'ubuntu-14.04-64 ubuntu-16.04-64'
         - group: ubuntu-bionic
-          systems: ubuntu-18.04-32 ubuntu-18.04-64
+          systems: 'ubuntu-18.04-32 ubuntu-18.04-64'
         - group: ubuntu-focal-jammy
-          system: ubuntu-20.04-64 ubuntu-22.04-64
+          system: 'ubuntu-20.04-64 ubuntu-22.04-64'
         - group: ubuntu-no-lts
-          system: ubuntu-23.04-64 ubuntu-23.10-64
+          system: 'ubuntu-23.04-64 ubuntu-23.10-64'
         - group: ubuntu-core-16
-          systems: ubuntu-core-16-64
+          systems: 'ubuntu-core-16-64'
         - group: ubuntu-core-18
-          systems: ubuntu-core-18-64
+          systems: 'ubuntu-core-18-64'
         - group: ubuntu-core-20
-          systems: ubuntu-core-20-64
+          systems: 'ubuntu-core-20-64'
         - group: ubuntu-core-22
-          systems: ubuntu-core-22-64
+          systems: 'ubuntu-core-22-64'
         - group: ubuntu-arm
-          systems: ubuntu-20.04-arm-64 ubuntu-core-22-arm-64
+          systems: 'ubuntu-20.04-arm-64 ubuntu-core-22-arm-64'
         - group: ubuntu-secboot
-          systems: ubuntu-secboot-20.04-64
+          systems: 'ubuntu-secboot-20.04-64'
     steps:
     - name: Cleanup job workspace
       id: cleanup-job-workspace

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -371,7 +371,7 @@ jobs:
           - group: arch-linux
             systems: arch-linux-64
           - group: centos
-            systems: 'centos-7-64 centos-8-64 centos-9-64'
+            systems: centos-7-64 centos-8-64 centos-9-64
           - group: debian-req
             systems: debian-11-64
           - group: debian-no-req
@@ -379,7 +379,7 @@ jobs:
           - group: fedora
             system: fedora-38-64 fedora-39-64
           - group: opensuse
-            systems: 'opensuse-15.4-64 opensuse-15.5-64 opensuse-tumbleweed-64'
+            systems: opensuse-15.4-64 opensuse-15.5-64 opensuse-tumbleweed-64
           - group: ubuntu-trusty-xenial
             system: ubuntu-14.04-64 ubuntu-16.04-64
           - group: ubuntu-bionic
@@ -397,7 +397,7 @@ jobs:
           - group: ubuntu-core-22
             systems: ubuntu-core-22-64
           - group: ubuntu-arm
-            systems: 'ubuntu-20.04-arm-64 ubuntu-core-22-arm-64'
+            systems: ubuntu-20.04-arm-64 ubuntu-core-22-arm-64
           - group: ubuntu-secboot
             systems: ubuntu-secboot-20.04-64
     steps:


### PR DESCRIPTION
The idea of this change is to reduce the number of github runners needed to run the spread tests of a PR.

The systems in a group will be executed together in the same spread run, so in this case the number of runners needed to executed the whole change is reduced from 29 to 21

This approach could be also used to group in a different way the systems.

It is important to consider that required and non required systems don't have to be part of the same group.
