### PR TITLE
cmd/snap-update-ns: set sythentic mounts `x-snapd.needed-by` to entry id instead of path

### DIFF
--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -125,7 +125,7 @@ func (c *Change) createPath(path string, pokeHoles bool, as *Assumptions) ([]*Ch
 	if needsMimic, mimicPath := mimicRequired(err); needsMimic && pokeHoles {
 		// If the error can be recovered by using a writable mimic
 		// then construct one and try again.
-		logger.Debugf("need to create writable mimic needed to create path %q (original error: %v)", path, err)
+		logger.Debugf("need to create writable mimic needed to create path %q (mount entry id: %q) (original error: %v)", path, c.Entry.XSnapdEntryID(), err)
 		changes, err = createWritableMimic(mimicPath, c.Entry.XSnapdEntryID(), as)
 		if err != nil {
 			err = fmt.Errorf("cannot create writable mimic over %q: %s", mimicPath, err)

--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -126,7 +126,7 @@ func (c *Change) createPath(path string, pokeHoles bool, as *Assumptions) ([]*Ch
 		// If the error can be recovered by using a writable mimic
 		// then construct one and try again.
 		logger.Debugf("need to create writable mimic needed to create path %q (original error: %v)", path, err)
-		changes, err = createWritableMimic(mimicPath, path, as)
+		changes, err = createWritableMimic(mimicPath, c.Entry.XSnapdEntryID(), as)
 		if err != nil {
 			err = fmt.Errorf("cannot create writable mimic over %q: %s", mimicPath, err)
 		} else {

--- a/cmd/snap-update-ns/change_test.go
+++ b/cmd/snap-update-ns/change_test.go
@@ -2781,7 +2781,7 @@ func (s *changeSuite) TestSyntheticNeededByUsesMountEntryID(c *C) {
 	}
 
 	synth, err := chg.Perform(s.as)
-	c.Check(err, IsNil)
+	c.Assert(err, IsNil)
 	c.Check(synth, HasLen, 1)
 	c.Check(synth[0].Entry.XSnapdNeededBy(), Equals, "test-id")
 }
@@ -2817,7 +2817,7 @@ func (s *changeSuite) TestSyntheticNeededByUsesDefaultMountEntryID(c *C) {
 	}
 
 	synth, err := chg.Perform(s.as)
-	c.Check(err, IsNil)
+	c.Assert(err, IsNil)
 	c.Check(synth, HasLen, 1)
 	// XSnapdEntryID defaults to entry target directory if x-snapd.id is unset
 	c.Check(synth[0].Entry.XSnapdNeededBy(), Equals, "/usr/share/target")

--- a/cmd/snap-update-ns/export_test.go
+++ b/cmd/snap-update-ns/export_test.go
@@ -182,6 +182,38 @@ func MockReadlink(fn func(string) (string, error)) (restore func()) {
 	}
 }
 
+func MockSysMkdirat(fn func(dirfd int, path string, mode uint32) (err error)) (restore func()) {
+	old := sysMkdirat
+	sysMkdirat = fn
+	return func() {
+		sysMkdirat = old
+	}
+}
+
+func MockSysMount(fn func(source string, target string, fstype string, flags uintptr, data string) (err error)) (restore func()) {
+	old := sysMount
+	sysMount = fn
+	return func() {
+		sysMount = old
+	}
+}
+
+func MockSysUnmount(fn func(target string, flags int) (err error)) (restore func()) {
+	old := sysUnmount
+	sysUnmount = fn
+	return func() {
+		sysUnmount = old
+	}
+}
+
+func MockSysFchown(fn func(fd int, uid sys.UserID, gid sys.GroupID) error) (restore func()) {
+	old := sysFchown
+	sysFchown = fn
+	return func() {
+		sysFchown = old
+	}
+}
+
 func (as *Assumptions) IsRestricted(path string) bool {
 	return as.isRestricted(path)
 }

--- a/cmd/snap-update-ns/update_test.go
+++ b/cmd/snap-update-ns/update_test.go
@@ -363,7 +363,7 @@ func (s *updateSuite) TestKeepSyntheticMountsLP2043993(c *C) {
 
 	c.Assert(update.ExecuteMountProfileUpdate(upCtx), IsNil)
 	c.Assert(saved.Entries, HasLen, 2)
-	// TODO: investigate why mount order changed
+	// TODO: the change of order is a bit unexpected, but that is a larger issue
 	// synth mount kept because it is needed by a desired mount
 	c.Check(saved.Entries[1].Type, Equals, "tmpfs")
 	c.Check(saved.Entries[1].Name, Equals, "tmpfs")

--- a/cmd/snap-update-ns/update_test.go
+++ b/cmd/snap-update-ns/update_test.go
@@ -22,12 +22,15 @@ package main_test
 import (
 	"bytes"
 	"fmt"
+	"path/filepath"
+	"syscall"
 
 	. "gopkg.in/check.v1"
 
 	update "github.com/snapcore/snapd/cmd/snap-update-ns"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/osutil/sys"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -283,6 +286,91 @@ func (s *updateSuite) TestCannotPerformOvermountChange(c *C) {
 	err := update.ExecuteMountProfileUpdate(upCtx)
 	c.Check(err, Equals, errTesting)
 	c.Check(saved, IsNil)
+}
+
+func (s *updateSuite) TestKeepSyntheticMountsLP2043993(c *C) {
+	baseSourceDir := c.MkDir()
+	sourceFile := filepath.Join(baseSourceDir, "rofs/dir/source")
+
+	baseTargetDir := c.MkDir()
+	targetFile := filepath.Join(baseTargetDir, "target")
+
+	as := update.Assumptions{}
+	restore := as.MockUnrestrictedPaths("/")
+	defer restore()
+
+	// mock for permission errors
+	restore = update.MockSysFchown(func(fd int, uid sys.UserID, gid sys.GroupID) error {
+		return nil
+	})
+	defer restore()
+
+	// mock for permission errors
+	restore = update.MockSysMount(func(source, target, fstype string, flags uintptr, data string) (err error) {
+		return nil
+	})
+	defer restore()
+
+	// mock for permission errors
+	restore = update.MockSysUnmount(func(target string, flags int) (err error) {
+		return nil
+	})
+	defer restore()
+
+	var mkdiratFailed bool
+	restore = update.MockSysMkdirat(func(dirfd int, path string, mode uint32) (err error) {
+		if path == "dir" && !mkdiratFailed {
+			mkdiratFailed = true
+			return syscall.EROFS
+		}
+		return syscall.Mkdirat(dirfd, path, mode)
+	})
+	defer restore()
+
+	desiredMountEntry := osutil.MountEntry{
+		Name:    sourceFile,
+		Dir:     targetFile,
+		Options: []string{"rbind", "rw", "x-snapd.id=test-id", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()},
+	}
+
+	var saved osutil.MountProfile
+	upCtx := &testProfileUpdateContext{
+		assumptions: func() *update.Assumptions {
+			return &as
+		},
+		loadDesiredProfile: func() (*osutil.MountProfile, error) {
+			return &osutil.MountProfile{Entries: []osutil.MountEntry{desiredMountEntry}}, nil
+		},
+		loadCurrentProfile: func() (*osutil.MountProfile, error) {
+			return &saved, nil
+		},
+		saveCurrentProfile: func(profile *osutil.MountProfile) error {
+			saved.Entries = profile.Entries
+			return nil
+		},
+	}
+
+	c.Assert(update.ExecuteMountProfileUpdate(upCtx), IsNil)
+	c.Assert(saved.Entries, HasLen, 2)
+	// synth mount created due to read-only fs
+	c.Check(saved.Entries[0].Type, Equals, "tmpfs")
+	c.Check(saved.Entries[0].Name, Equals, "tmpfs")
+	c.Check(saved.Entries[0].Dir, Equals, filepath.Join(baseSourceDir, "rofs"))
+	c.Check(saved.Entries[0].XSnapdSynthetic(), Equals, true)
+	c.Check(saved.Entries[0].XSnapdNeededBy(), Equals, "test-id")
+	// desired mount exists
+	c.Check(saved.Entries[1], DeepEquals, desiredMountEntry)
+
+	c.Assert(update.ExecuteMountProfileUpdate(upCtx), IsNil)
+	c.Assert(saved.Entries, HasLen, 2)
+	// TODO: investigate why mount order changed
+	// synth mount kept because it is needed by a desired mount
+	c.Check(saved.Entries[1].Type, Equals, "tmpfs")
+	c.Check(saved.Entries[1].Name, Equals, "tmpfs")
+	c.Check(saved.Entries[1].Dir, Equals, filepath.Join(baseSourceDir, "rofs"))
+	c.Check(saved.Entries[1].XSnapdSynthetic(), Equals, true)
+	c.Check(saved.Entries[1].XSnapdNeededBy(), Equals, "test-id")
+	c.Check(saved.Entries[0], DeepEquals, desiredMountEntry)
 }
 
 // testProfileUpdateContext implements MountProfileUpdateContext and is suitable for testing.


### PR DESCRIPTION
`snap-update-ns` was dropping some synthetic mounts due to failure to match desired mounts that depend on them.

This mismatching was due to setting `x-snapd.needed-by` to whatever path that needed it (source or target) and not the mount entry id (`XSnapdEntryID()` which defaults to target if not set) which is later on is used in `NeededChanges()` to compute which synthetic mounts need to be kept.

https://github.com/snapcore/snapd/blob/38a74ecb3f8907e3808ff973f119ae396c53cbfd/cmd/snap-update-ns/change.go#L570-L574
https://github.com/snapcore/snapd/blob/38a74ecb3f8907e3808ff973f119ae396c53cbfd/cmd/snap-update-ns/change.go#L612-L616

Partially fixes: https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/2043993

Mount ordering/logic needs a more in-depth refactor, this is just a bug fix in the existing implementation.

**Note: I only noticed this behavior was happening for parallel install using core22 base only, where an existing install exists and it is not consistently reproducible, this is why I was not able to create a reliable spread test. More investigation is needed regarding ordering that can be better tracked in https://bugs.launchpad.net/snapd/+bug/2034056**

Also, I noticed there seems to be inconsistencies when mounting /usr/share/libdrm in several snaps which causes problems with hardware acceleration for AMD GPUs.