### PR TITLE
many: replace name w/ request and path w/ storage

### DIFF
--- a/aspects/aspects_test.go
+++ b/aspects/aspects_test.go
@@ -51,21 +51,21 @@ func (*aspectSuite) TestNewAspectBundle(c *C) {
 
 	_, err = aspects.NewAspectBundle("acc", "foo", map[string]interface{}{
 		"bar": []map[string]string{
-			{"path": "foo"},
+			{"storage": "foo"},
 		},
 	}, aspects.NewJSONSchema())
-	c.Assert(err, ErrorMatches, `cannot define aspect "bar": access patterns must have a "name" field`)
+	c.Assert(err, ErrorMatches, `cannot define aspect "bar": access patterns must have a "request" field`)
 
 	_, err = aspects.NewAspectBundle("acc", "foo", map[string]interface{}{
 		"bar": []map[string]string{
-			{"name": "foo"},
+			{"request": "foo"},
 		},
 	}, aspects.NewJSONSchema())
-	c.Assert(err, ErrorMatches, `cannot define aspect "bar": access patterns must have a "path" field`)
+	c.Assert(err, ErrorMatches, `cannot define aspect "bar": access patterns must have a "storage" field`)
 
 	aspectBundle, err := aspects.NewAspectBundle("acc", "foo", map[string]interface{}{
 		"bar": []map[string]string{
-			{"name": "a", "path": "b"},
+			{"request": "a", "storage": "b"},
 		},
 	}, aspects.NewJSONSchema())
 	c.Assert(err, IsNil)
@@ -98,7 +98,7 @@ func (s *aspectSuite) TestAccessTypes(c *C) {
 	} {
 		aspectBundle, err := aspects.NewAspectBundle("acc", "foo", map[string]interface{}{
 			"bar": []map[string]string{
-				{"name": "a", "path": "b", "access": t.access},
+				{"request": "a", "storage": "b", "access": t.access},
 			}}, aspects.NewJSONSchema())
 
 		cmt := Commentf("\"%s access\" sub-test failed", t.access)
@@ -116,10 +116,10 @@ func (*aspectSuite) TestGetAndSetAspects(c *C) {
 	databag := aspects.NewJSONDataBag()
 	aspectBundle, err := aspects.NewAspectBundle("system", "network", map[string]interface{}{
 		"wifi-setup": []map[string]string{
-			{"name": "ssids", "path": "wifi.ssids"},
-			{"name": "ssid", "path": "wifi.ssid"},
-			{"name": "top-level", "path": "top-level"},
-			{"name": "dotted.name", "path": "dotted"},
+			{"request": "ssids", "storage": "wifi.ssids"},
+			{"request": "ssid", "storage": "wifi.ssid"},
+			{"request": "top-level", "storage": "top-level"},
+			{"request": "dotted.path", "storage": "dotted"},
 		},
 	}, aspects.NewJSONSchema())
 	c.Assert(err, IsNil)
@@ -153,12 +153,12 @@ func (*aspectSuite) TestGetAndSetAspects(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(topLevel, Equals, "randomValue")
 
-	// dotted names are permitted
-	err = wsAspect.Set(databag, "dotted.name", 3)
+	// dotted request paths are permitted
+	err = wsAspect.Set(databag, "dotted.path", 3)
 	c.Assert(err, IsNil)
 
 	var num int
-	err = wsAspect.Get(databag, "dotted.name", &num)
+	err = wsAspect.Get(databag, "dotted.path", &num)
 	c.Assert(err, IsNil)
 	c.Check(num, Equals, 3)
 }
@@ -167,9 +167,9 @@ func (s *aspectSuite) TestAspectNotFound(c *C) {
 	databag := aspects.NewJSONDataBag()
 	aspectBundle, err := aspects.NewAspectBundle("acc", "foo", map[string]interface{}{
 		"bar": []map[string]string{
-			{"name": "top-level", "path": "top-level"},
-			{"name": "nested", "path": "top.nested-one"},
-			{"name": "other-nested", "path": "top.nested-two"},
+			{"request": "top-level", "storage": "top-level"},
+			{"request": "nested", "storage": "top.nested-one"},
+			{"request": "other-nested", "storage": "top.nested-two"},
 		},
 	}, aspects.NewJSONSchema())
 	c.Assert(err, IsNil)
@@ -201,8 +201,8 @@ func (s *aspectSuite) TestAspectBadRead(c *C) {
 	databag := aspects.NewJSONDataBag()
 	aspectBundle, err := aspects.NewAspectBundle("acc", "foo", map[string]interface{}{
 		"bar": []map[string]string{
-			{"name": "one", "path": "one"},
-			{"name": "onetwo", "path": "one.two"},
+			{"request": "one", "storage": "one"},
+			{"request": "onetwo", "storage": "one.two"},
 		},
 	}, aspects.NewJSONSchema())
 	c.Assert(err, IsNil)
@@ -223,10 +223,10 @@ func (s *aspectSuite) TestAspectBadRead(c *C) {
 func (s *aspectSuite) TestAspectsAccessControl(c *C) {
 	aspectBundle, err := aspects.NewAspectBundle("acc", "bundle", map[string]interface{}{
 		"foo": []map[string]string{
-			{"name": "default", "path": "path.default"},
-			{"name": "read-write", "path": "path.read-write", "access": "read-write"},
-			{"name": "read-only", "path": "path.read-only", "access": "read"},
-			{"name": "write-only", "path": "path.write-only", "access": "write"},
+			{"request": "default", "storage": "path.default"},
+			{"request": "read-write", "storage": "path.read-write", "access": "read-write"},
+			{"request": "read-only", "storage": "path.read-only", "access": "read"},
+			{"request": "write-only", "storage": "path.write-only", "access": "write"},
 		},
 	}, aspects.NewJSONSchema())
 	c.Assert(err, IsNil)
@@ -234,32 +234,32 @@ func (s *aspectSuite) TestAspectsAccessControl(c *C) {
 	aspect := aspectBundle.Aspect("foo")
 
 	for _, t := range []struct {
-		name   string
-		getErr string
-		setErr string
+		request string
+		getErr  string
+		setErr  string
 	}{
 		{
-			name: "read-write",
+			request: "read-write",
 		},
 		{
 			// defaults to "read-write"
-			name: "default",
+			request: "default",
 		},
 		{
-			name: "read-only",
+			request: "read-only",
 			// unrelated error
 			getErr: `cannot find field "read-only" of aspect acc/bundle/foo: no value was found under path "path"`,
 			setErr: `cannot write field "read-only": only supports read access`,
 		},
 		{
-			name:   "write-only",
-			getErr: `cannot read field "write-only": only supports write access`,
+			request: "write-only",
+			getErr:  `cannot read field "write-only": only supports write access`,
 		},
 	} {
-		cmt := Commentf("sub-test %q failed", t.name)
+		cmt := Commentf("sub-test %q failed", t.request)
 		databag := aspects.NewJSONDataBag()
 
-		err := aspect.Set(databag, t.name, "thing")
+		err := aspect.Set(databag, t.request, "thing")
 		if t.setErr != "" {
 			c.Assert(err.Error(), Equals, t.setErr, cmt)
 		} else {
@@ -267,7 +267,7 @@ func (s *aspectSuite) TestAspectsAccessControl(c *C) {
 		}
 
 		var value string
-		err = aspect.Get(databag, t.name, &value)
+		err = aspect.Get(databag, t.request, &value)
 		if t.getErr != "" {
 			c.Assert(err.Error(), Equals, t.getErr, cmt)
 		} else {
@@ -309,12 +309,12 @@ func (s *witnessDataBag) getLastPaths() (get, set string) {
 func (s *aspectSuite) TestAspectAssertionWithPlaceholder(c *C) {
 	aspectBundle, err := aspects.NewAspectBundle("acc", "bundle", map[string]interface{}{
 		"foo": []map[string]string{
-			{"name": "defaults.{foo}", "path": "first.{foo}.last"},
-			{"name": "{bar}.name", "path": "first.{bar}"},
-			{"name": "first.{baz}.last", "path": "{baz}.last"},
-			{"name": "first.{foo}.{bar}", "path": "{foo}.mid.{bar}"},
-			{"name": "{foo}.mid2.{bar}", "path": "{bar}.mid2.{foo}"},
-			{"name": "multi.{foo}", "path": "{foo}.multi.{foo}"},
+			{"request": "defaults.{foo}", "storage": "first.{foo}.last"},
+			{"request": "{bar}.name", "storage": "first.{bar}"},
+			{"request": "first.{baz}.last", "storage": "{baz}.last"},
+			{"request": "first.{foo}.{bar}", "storage": "{foo}.mid.{bar}"},
+			{"request": "{foo}.mid2.{bar}", "storage": "{bar}.mid2.{foo}"},
+			{"request": "multi.{foo}", "storage": "{foo}.multi.{foo}"},
 		},
 	}, aspects.NewJSONSchema())
 	c.Assert(err, IsNil)
@@ -323,123 +323,123 @@ func (s *aspectSuite) TestAspectAssertionWithPlaceholder(c *C) {
 
 	for _, t := range []struct {
 		testName string
-		name     string
-		path     string
+		request  string
+		storage  string
 	}{
 		{
 			testName: "placeholder last to mid",
-			name:     "defaults.abc",
-			path:     "first.abc.last",
+			request:  "defaults.abc",
+			storage:  "first.abc.last",
 		},
 		{
 			testName: "placeholder first to last",
-			name:     "foo.name",
-			path:     "first.foo",
+			request:  "foo.name",
+			storage:  "first.foo",
 		},
 		{
 			testName: "placeholder mid to first",
-			name:     "first.foo.last",
-			path:     "foo.last",
+			request:  "first.foo.last",
+			storage:  "foo.last",
 		},
 		{
 			testName: "two placeholders in order",
-			name:     "first.one.two",
-			path:     "one.mid.two",
+			request:  "first.one.two",
+			storage:  "one.mid.two",
 		},
 		{
 			testName: "two placeholders out of order",
-			name:     "first2.mid2.two2",
-			path:     "two2.mid2.first2",
+			request:  "first2.mid2.two2",
+			storage:  "two2.mid2.first2",
 		},
 		{
 			testName: "one placeholder mapping to several",
-			name:     "multi.firstLast",
-			path:     "firstLast.multi.firstLast",
+			request:  "multi.firstLast",
+			storage:  "firstLast.multi.firstLast",
 		},
 	} {
 		cmt := Commentf("sub-test %q failed", t.testName)
 
 		databag := newWitnessDataBag(aspects.NewJSONDataBag())
-		err := aspect.Set(databag, t.name, "expectedValue")
+		err := aspect.Set(databag, t.request, "expectedValue")
 		c.Assert(err, IsNil, cmt)
 
 		var obtainedValue string
-		err = aspect.Get(databag, t.name, &obtainedValue)
+		err = aspect.Get(databag, t.request, &obtainedValue)
 		c.Assert(err, IsNil, cmt)
 
 		c.Assert(obtainedValue, Equals, "expectedValue", cmt)
 
 		getPath, setPath := databag.getLastPaths()
-		c.Assert(getPath, Equals, t.path, cmt)
-		c.Assert(setPath, Equals, t.path, cmt)
+		c.Assert(getPath, Equals, t.storage, cmt)
+		c.Assert(setPath, Equals, t.storage, cmt)
 	}
 }
 
-func (s *aspectSuite) TestAspectNameAndPathValidation(c *C) {
+func (s *aspectSuite) TestAspectRequestAndStorageValidation(c *C) {
 	type testcase struct {
 		testName string
-		name     string
-		path     string
+		request  string
+		storage  string
 		err      string
 	}
 
 	for _, tc := range []testcase{
 		{
-			testName: "empty subkeys in name",
-			name:     "a..b", path: "a.b", err: `invalid access name "a..b": cannot have empty subkeys`,
+			testName: "empty subkeys in request",
+			request:  "a..b", storage: "a.b", err: `invalid request "a..b": cannot have empty subkeys`,
 		},
 		{
 			testName: "empty subkeys in path",
-			name:     "a.b", path: "c..b", err: `invalid path "c..b": cannot have empty subkeys`,
+			request:  "a.b", storage: "c..b", err: `invalid storage "c..b": cannot have empty subkeys`,
 		},
 		{
 			testName: "placeholder mismatch (same number)",
-			name:     "bad.{foo}", path: "bad.{bar}", err: `placeholder "{foo}" from access name "bad.{foo}" is absent from path "bad.{bar}"`,
+			request:  "bad.{foo}", storage: "bad.{bar}", err: `placeholder "{foo}" from request "bad.{foo}" is absent from storage "bad.{bar}"`,
 		},
 		{
 			testName: "placeholder mismatch (different number)",
-			name:     "{foo}", path: "{foo}.bad.{bar}", err: `access name "{foo}" and path "{foo}.bad.{bar}" have mismatched placeholders`,
+			request:  "{foo}", storage: "{foo}.bad.{bar}", err: `request "{foo}" and storage "{foo}.bad.{bar}" have mismatched placeholders`,
 		},
 		{
-			testName: "invalid character in name: $",
-			name:     "a.b$", path: "bad", err: `invalid access name "a.b$": invalid subkey "b$"`,
+			testName: "invalid character in request: $",
+			request:  "a.b$", storage: "bad", err: `invalid request "a.b$": invalid subkey "b$"`,
 		},
 		{
-			testName: "invalid character in path: é",
-			name:     "a.b", path: "a.é", err: `invalid path "a.é": invalid subkey "é"`,
+			testName: "invalid character in storage path: é",
+			request:  "a.b", storage: "a.é", err: `invalid storage "a.é": invalid subkey "é"`,
 		},
 		{
-			testName: "invalid character in name: _",
-			name:     "a.b_c", path: "a.b-c", err: `invalid access name "a.b_c": invalid subkey "b_c"`,
+			testName: "invalid character in request: _",
+			request:  "a.b_c", storage: "a.b-c", err: `invalid request "a.b_c": invalid subkey "b_c"`,
 		},
 		{
 			testName: "invalid leading dash",
-			name:     "-a", path: "a", err: `invalid access name "-a": invalid subkey "-a"`,
+			request:  "-a", storage: "a", err: `invalid request "-a": invalid subkey "-a"`,
 		},
 		{
 			testName: "invalid trailing dash",
-			name:     "a", path: "a-", err: `invalid path "a-": invalid subkey "a-"`,
+			request:  "a", storage: "a-", err: `invalid storage "a-": invalid subkey "a-"`,
 		},
 		{
 			testName: "missing closing curly bracket",
-			name:     "{a{", path: "a", err: `invalid access name "{a{": invalid subkey "{a{"`,
+			request:  "{a{", storage: "a", err: `invalid request "{a{": invalid subkey "{a{"`,
 		},
 		{
 			testName: "missing opening curly bracket",
-			name:     "a", path: "}a}", err: `invalid path "}a}": invalid subkey "}a}"`,
+			request:  "a", storage: "}a}", err: `invalid storage "}a}": invalid subkey "}a}"`,
 		},
 		{
 			testName: "curly brackets not wrapping subkey",
-			name:     "a", path: "a.b{a}c", err: `invalid path "a.b{a}c": invalid subkey "b{a}c"`,
+			request:  "a", storage: "a.b{a}c", err: `invalid storage "a.b{a}c": invalid subkey "b{a}c"`,
 		},
 		{
 			testName: "invalid whitespace character",
-			name:     "a. .c", path: "a.b", err: `invalid access name "a. .c": invalid subkey " "`,
+			request:  "a. .c", storage: "a.b", err: `invalid request "a. .c": invalid subkey " "`,
 		},
 	} {
 		_, err := aspects.NewAspectBundle("acc", "foo", map[string]interface{}{
 			"foo": []map[string]string{
-				{"name": tc.name, "path": tc.path},
+				{"request": tc.request, "storage": tc.storage},
 			},
 		}, aspects.NewJSONSchema())
 
@@ -453,8 +453,8 @@ func (s *aspectSuite) TestAspectUnsetTopLevelEntry(c *C) {
 	databag := aspects.NewJSONDataBag()
 	aspectBundle, err := aspects.NewAspectBundle("acc", "foo", map[string]interface{}{
 		"my-aspect": []map[string]string{
-			{"name": "foo", "path": "foo"},
-			{"name": "bar", "path": "bar"},
+			{"request": "foo", "storage": "foo"},
+			{"request": "bar", "storage": "bar"},
 		},
 	}, aspects.NewJSONSchema())
 	c.Assert(err, IsNil)
@@ -482,8 +482,8 @@ func (s *aspectSuite) TestAspectUnsetLeafWithSiblings(c *C) {
 	databag := aspects.NewJSONDataBag()
 	aspectBundle, err := aspects.NewAspectBundle("acc", "foo", map[string]interface{}{
 		"my-aspect": []map[string]string{
-			{"name": "bar", "path": "foo.bar"},
-			{"name": "baz", "path": "foo.baz"},
+			{"request": "bar", "storage": "foo.bar"},
+			{"request": "baz", "storage": "foo.baz"},
 		},
 	}, aspects.NewJSONSchema())
 	c.Assert(err, IsNil)
@@ -512,8 +512,8 @@ func (s *aspectSuite) TestAspectUnsetWithNestedEntry(c *C) {
 	databag := aspects.NewJSONDataBag()
 	aspectBundle, err := aspects.NewAspectBundle("acc", "foo", map[string]interface{}{
 		"my-aspect": []map[string]string{
-			{"name": "foo", "path": "foo"},
-			{"name": "bar", "path": "foo.bar"},
+			{"request": "foo", "storage": "foo"},
+			{"request": "bar", "storage": "foo.bar"},
 		},
 	}, aspects.NewJSONSchema())
 	c.Assert(err, IsNil)
@@ -537,8 +537,8 @@ func (s *aspectSuite) TestAspectUnsetLeafUnsetsParent(c *C) {
 	databag := aspects.NewJSONDataBag()
 	aspectBundle, err := aspects.NewAspectBundle("acc", "foo", map[string]interface{}{
 		"my-aspect": []map[string]string{
-			{"name": "foo", "path": "foo"},
-			{"name": "bar", "path": "foo.bar"},
+			{"request": "foo", "storage": "foo"},
+			{"request": "bar", "storage": "foo.bar"},
 		},
 	}, aspects.NewJSONSchema())
 	c.Assert(err, IsNil)
@@ -563,8 +563,8 @@ func (s *aspectSuite) TestAspectUnsetAlreadyUnsetEntry(c *C) {
 	databag := aspects.NewJSONDataBag()
 	aspectBundle, err := aspects.NewAspectBundle("acc", "foo", map[string]interface{}{
 		"my-aspect": []map[string]string{
-			{"name": "foo", "path": "foo"},
-			{"name": "bar", "path": "one.bar"},
+			{"request": "foo", "storage": "foo"},
+			{"request": "bar", "storage": "one.bar"},
 		},
 	}, aspects.NewJSONSchema())
 	c.Assert(err, IsNil)

--- a/overlord/aspectstate/aspecttest/mock_aspect.go
+++ b/overlord/aspectstate/aspecttest/mock_aspect.go
@@ -24,11 +24,11 @@ package aspecttest
 func MockWifiSetupAspect() map[string]interface{} {
 	return map[string]interface{}{
 		"wifi-setup": []map[string]string{
-			{"name": "ssids", "path": "wifi.ssids"},
-			{"name": "ssid", "path": "wifi.ssid", "access": "read-write"},
-			{"name": "password", "path": "wifi.psk", "access": "write"},
-			{"name": "status", "path": "wifi.status", "access": "read"},
-			{"name": "private.{placeholder}", "path": "wifi.{placeholder}"},
+			{"request": "ssids", "storage": "wifi.ssids"},
+			{"request": "ssid", "storage": "wifi.ssid", "access": "read-write"},
+			{"request": "password", "storage": "wifi.psk", "access": "write"},
+			{"request": "status", "storage": "wifi.status", "access": "read"},
+			{"request": "private.{placeholder}", "storage": "wifi.{placeholder}"},
 		},
 	}
 }


### PR DESCRIPTION
The terminology used in the aspect-bundle assertion and the spec has changed so this just replaces name with request and path with storage.