### PR TITLE
snap: create ContainerPlaceInfo interface

### DIFF
--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -96,7 +96,7 @@ type managerBackend interface {
 	RemoveSnapCommonData(info *snap.Info, opts *dirs.SnapDirOptions) error
 	RemoveSnapSaveData(info *snap.Info, dev snap.Device) error
 	RemoveSnapDataDir(info *snap.Info, hasOtherInstances bool) error
-	RemoveSnapMountUnits(s snap.PlaceInfo, meter progress.Meter) error
+	RemoveContainerMountUnits(s snap.ContainerPlaceInfo, meter progress.Meter) error
 	DiscardSnapNamespace(snapName string) error
 	RemoveSnapInhibitLock(snapName string) error
 	RemoveAllSnapAppArmorProfiles() error

--- a/overlord/snapstate/backend/mountunit.go
+++ b/overlord/snapstate/backend/mountunit.go
@@ -45,10 +45,10 @@ func removeMountUnit(mountDir string, meter progress.Meter) error {
 	return sysd.RemoveMountUnitFile(mountDir)
 }
 
-func (b Backend) RemoveSnapMountUnits(s snap.PlaceInfo, meter progress.Meter) error {
+func (b Backend) RemoveContainerMountUnits(s snap.ContainerPlaceInfo, meter progress.Meter) error {
 	sysd := systemd.New(systemd.SystemMode, meter)
 	originFilter := ""
-	mountPoints, err := sysd.ListMountUnits(s.InstanceName(), originFilter)
+	mountPoints, err := sysd.ListMountUnits(s.ContainerName(), originFilter)
 	if err != nil {
 		return err
 	}

--- a/overlord/snapstate/backend/mountunit_test.go
+++ b/overlord/snapstate/backend/mountunit_test.go
@@ -168,7 +168,7 @@ func (s *mountunitSuite) TestRemoveSnapMountUnitsFailOnList(c *C) {
 	defer restore()
 
 	b := backend.Backend{}
-	err := b.RemoveSnapMountUnits(info, progress.Null)
+	err := b.RemoveContainerMountUnits(info, progress.Null)
 	c.Check(err, Equals, expectedErr)
 	c.Check(sysd.ListMountUnitsCalls, HasLen, 1)
 	c.Check(sysd.ListMountUnitsCalls, DeepEquals, []ParamsForListMountUnits{
@@ -200,7 +200,7 @@ func (s *mountunitSuite) TestRemoveSnapMountUnitsFailOnRemoval(c *C) {
 	defer restore()
 
 	b := backend.Backend{}
-	err := b.RemoveSnapMountUnits(info, progress.Null)
+	err := b.RemoveContainerMountUnits(info, progress.Null)
 	c.Check(err, Equals, expectedErr)
 	c.Check(sysd.ListMountUnitsCalls, HasLen, 1)
 	c.Check(sysd.ListMountUnitsCalls, DeepEquals, []ParamsForListMountUnits{
@@ -233,7 +233,7 @@ func (s *mountunitSuite) TestRemoveSnapMountUnitsHappy(c *C) {
 	defer restore()
 
 	b := backend.Backend{}
-	err := b.RemoveSnapMountUnits(info, progress.Null)
+	err := b.RemoveContainerMountUnits(info, progress.Null)
 	c.Check(err, IsNil)
 	c.Check(sysd.ListMountUnitsCalls, HasLen, 1)
 	c.Check(sysd.ListMountUnitsCalls, DeepEquals, []ParamsForListMountUnits{

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -1248,10 +1248,10 @@ func (f *fakeSnappyBackend) RemoveSnapDataDir(info *snap.Info, otherInstances bo
 	return f.maybeErrForLastOp()
 }
 
-func (f *fakeSnappyBackend) RemoveSnapMountUnits(s snap.PlaceInfo, meter progress.Meter) error {
+func (f *fakeSnappyBackend) RemoveContainerMountUnits(s snap.ContainerPlaceInfo, meter progress.Meter) error {
 	f.ops = append(f.ops, fakeOp{
 		op:   "remove-snap-mount-units",
-		name: s.InstanceName(),
+		name: s.ContainerName(),
 	})
 	return f.maybeErrForLastOp()
 }

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -3363,7 +3363,7 @@ func (m *SnapManager) doDiscardSnap(t *state.Task, _ *tomb.Tomb) error {
 		return &state.Retry{After: 3 * time.Minute}
 	}
 	if len(snapst.Sequence.Revisions) == 0 {
-		if err = m.backend.RemoveSnapMountUnits(snapsup.placeInfo(), nil); err != nil {
+		if err = m.backend.RemoveContainerMountUnits(snapsup.containerInfo(), nil); err != nil {
 			return err
 		}
 

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -161,6 +161,10 @@ func (snapsup *SnapSetup) Revision() snap.Revision {
 	return snapsup.SideInfo.Revision
 }
 
+func (snapsup *SnapSetup) containerInfo() snap.ContainerPlaceInfo {
+	return snap.MinimalContainerInfo(snapsup.InstanceName(), snapsup.Revision())
+}
+
 func (snapsup *SnapSetup) placeInfo() snap.PlaceInfo {
 	return snap.MinimalPlaceInfo(snapsup.InstanceName(), snapsup.Revision())
 }

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -24,7 +24,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -9268,7 +9267,6 @@ version: 1.0
 			break
 		}
 	}
-	log.Printf("%s", ts.MaybeEdge(snapstate.EndEdge).Kind())
 	c.Assert(t, NotNil)
 	c.Check(ts.MaybeEdge(snapstate.EndEdge).ID(), Equals, t.ID())
 }
@@ -9305,7 +9303,6 @@ epoch: 1
 			break
 		}
 	}
-	log.Printf("%s", ts.MaybeEdge(snapstate.EndEdge).Kind())
 	c.Assert(t, NotNil)
 	c.Check(ts.MaybeEdge(snapstate.EndEdge).ID(), Equals, t.ID())
 }

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -1234,6 +1234,28 @@ func (s *infoSuite) testInstanceDirAndFileMethods(c *C, info snap.PlaceInfo) {
 	c.Check(info.BinaryNameGlobs(), DeepEquals, []string{"name_instance", "name_instance.*"})
 }
 
+func (s *infoSuite) TestComponentPlaceInfoMethods(c *C) {
+	dirs.SetRootDir("")
+	info := snap.MinimalContainerInfo("name", snap.R("1"))
+
+	var cpi snap.ContainerPlaceInfo = info
+	c.Check(cpi.ContainerName(), Equals, "name")
+	c.Check(cpi.Filename(), Equals, "name_1.snap")
+	c.Check(cpi.MountDir(), Equals, fmt.Sprintf("%s/name/1", dirs.SnapMountDir))
+	c.Check(cpi.MountFile(), Equals, "/var/lib/snapd/snaps/name_1.snap")
+}
+
+func (s *infoSuite) TestComponentPlaceInfoMethodsParallelInstall(c *C) {
+	dirs.SetRootDir("")
+	info := snap.MinimalContainerInfo("name_instance", snap.R("1"))
+
+	var cpi snap.ContainerPlaceInfo = info
+	c.Check(cpi.ContainerName(), Equals, "name_instance")
+	c.Check(cpi.Filename(), Equals, "name_instance_1.snap")
+	c.Check(cpi.MountDir(), Equals, fmt.Sprintf("%s/name_instance/1", dirs.SnapMountDir))
+	c.Check(cpi.MountFile(), Equals, "/var/lib/snapd/snaps/name_instance_1.snap")
+}
+
 func BenchmarkTestParsePlaceInfoFromSnapFileName(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		for _, sn := range []string{


### PR DESCRIPTION
and implement for snap.Info type. This interface will be used when
possible to make easier to reuse code for components where possible.
