### PR TITLE
gadget/update.go: make sure to update boot before seed

### DIFF
--- a/gadget/update.go
+++ b/gadget/update.go
@@ -1611,8 +1611,19 @@ func resolveUpdate(oldVol *PartiallyLaidOutVolume, newVol *LaidOutVolume, policy
 	if len(oldVol.LaidOutStructure) != len(newVol.LaidOutStructure) {
 		return nil, errors.New("internal error: the number of structures in new and old volume definitions is different")
 	}
+	// We must order updates from the latest binary in the boot
+	// chain to the newest. So any seed partitions should come
+	// after boot partitions.
+	var seedUpdates []updatePair
+	var bootUpdates []updatePair
 	for j, oldStruct := range oldVol.LaidOutStructure {
 		newStruct := newVol.LaidOutStructure[j]
+		updatesTarget := &updates
+		if strings.HasPrefix(newStruct.Role(), "system-seed") {
+			updatesTarget = &seedUpdates
+		} else if strings.HasPrefix(newStruct.Role(), "system-boot") {
+			updatesTarget = &bootUpdates
+		}
 		// update only when the policy says so; boot assets
 		// are assumed to be backwards compatible, once
 		// deployed they are not rolled back or replaced unless
@@ -1631,13 +1642,15 @@ func resolveUpdate(oldVol *PartiallyLaidOutVolume, newVol *LaidOutVolume, policy
 			newVol.LaidOutStructure[j].ResolvedContent = resolvedContent
 
 			// and add to updates
-			updates = append(updates, updatePair{
+			*updatesTarget = append(*updatesTarget, updatePair{
 				from:   &oldVol.LaidOutStructure[j],
 				to:     &newVol.LaidOutStructure[j],
 				volume: newVol.Volume,
 			})
 		}
 	}
+	updates = append(updates, bootUpdates...)
+	updates = append(updates, seedUpdates...)
 	return updates, nil
 }
 

--- a/gadget/update_test.go
+++ b/gadget/update_test.go
@@ -1146,7 +1146,7 @@ func (u *updateTestSuite) TestUpdateApplyUC20MissingInitialMapFullLogicOnlySyste
 				Device: "/dev/vda",
 				Offset: quantity.OffsetMiB,
 			})
-		case 2:
+		case 5:
 			// ubuntu-seed
 			c.Check(ps.Name(), Equals, "ubuntu-seed")
 			c.Check(ps.HasFilesystem(), Equals, true)
@@ -1160,7 +1160,7 @@ func (u *updateTestSuite) TestUpdateApplyUC20MissingInitialMapFullLogicOnlySyste
 			c.Assert(loc, Equals, gadget.StructureLocation{
 				RootMountPoint: "/run/mnt/ubuntu-seed",
 			})
-		case 3:
+		case 4:
 			// ubuntu-boot
 			c.Check(ps.Name(), Equals, "ubuntu-boot")
 			c.Check(ps.HasFilesystem(), Equals, true)
@@ -1174,7 +1174,7 @@ func (u *updateTestSuite) TestUpdateApplyUC20MissingInitialMapFullLogicOnlySyste
 			c.Assert(loc, Equals, gadget.StructureLocation{
 				RootMountPoint: "/run/mnt/ubuntu-boot",
 			})
-		case 4:
+		case 2:
 			// ubuntu-save
 			c.Check(ps.Name(), Equals, "ubuntu-save")
 			c.Check(ps.HasFilesystem(), Equals, true)
@@ -1188,7 +1188,7 @@ func (u *updateTestSuite) TestUpdateApplyUC20MissingInitialMapFullLogicOnlySyste
 			c.Assert(loc, Equals, gadget.StructureLocation{
 				RootMountPoint: "/run/mnt/ubuntu-save",
 			})
-		case 5:
+		case 3:
 			// ubuntu-data
 			c.Check(ps.Name(), Equals, "ubuntu-data")
 			c.Check(ps.HasFilesystem(), Equals, true)
@@ -1414,7 +1414,7 @@ func (u *updateTestSuite) TestUpdateApplyUC20MissingInitialMapFullLogicOnlySyste
 				Device: "/dev/vda",
 				Offset: quantity.Offset(0),
 			})
-		case 1:
+		case 3:
 			// ubuntu-seed
 			c.Check(ps.Name(), Equals, "ubuntu-seed")
 			c.Check(ps.HasFilesystem(), Equals, true)
@@ -1440,7 +1440,7 @@ func (u *updateTestSuite) TestUpdateApplyUC20MissingInitialMapFullLogicOnlySyste
 			c.Assert(loc, Equals, gadget.StructureLocation{
 				RootMountPoint: "/run/mnt/ubuntu-boot",
 			})
-		case 3:
+		case 1:
 			// ubuntu-save
 			c.Check(ps.Name(), Equals, "ubuntu-save")
 			c.Check(ps.HasFilesystem(), Equals, true)
@@ -1701,7 +1701,7 @@ func (u *updateTestSuite) TestUpdateApplyUC20MissingInitialMapFullLogicOnlySyste
 				Device: "/dev/vda",
 				Offset: quantity.OffsetMiB,
 			})
-		case 2:
+		case 5:
 			// ubuntu-seed
 			c.Check(ps.Name(), Equals, "ubuntu-seed")
 			c.Check(ps.HasFilesystem(), Equals, true)
@@ -1714,7 +1714,7 @@ func (u *updateTestSuite) TestUpdateApplyUC20MissingInitialMapFullLogicOnlySyste
 			c.Assert(loc, Equals, gadget.StructureLocation{
 				RootMountPoint: "/run/mnt/ubuntu-seed",
 			})
-		case 3:
+		case 4:
 			// ubuntu-boot
 			c.Check(ps.Name(), Equals, "ubuntu-boot")
 			c.Check(ps.HasFilesystem(), Equals, true)
@@ -1727,7 +1727,7 @@ func (u *updateTestSuite) TestUpdateApplyUC20MissingInitialMapFullLogicOnlySyste
 			c.Assert(loc, Equals, gadget.StructureLocation{
 				RootMountPoint: "/run/mnt/ubuntu-boot",
 			})
-		case 4:
+		case 2:
 			// ubuntu-save
 			c.Check(ps.Name(), Equals, "ubuntu-save")
 			c.Check(ps.HasFilesystem(), Equals, true)
@@ -1740,7 +1740,7 @@ func (u *updateTestSuite) TestUpdateApplyUC20MissingInitialMapFullLogicOnlySyste
 			c.Assert(loc, Equals, gadget.StructureLocation{
 				RootMountPoint: "/run/mnt/ubuntu-save",
 			})
-		case 5:
+		case 3:
 			// ubuntu-data
 			c.Check(ps.Name(), Equals, "ubuntu-data")
 			c.Check(ps.HasFilesystem(), Equals, true)
@@ -1983,7 +1983,7 @@ func (u *updateTestSuite) TestUpdateApplyUC20WithInitialMapAllVolumesUpdatedFull
 					Device: "/dev/vda",
 					Offset: quantity.OffsetMiB,
 				})
-			case 2:
+			case 5:
 				// ubuntu-seed
 				c.Check(ps.Name(), Equals, "ubuntu-seed")
 				c.Check(ps.HasFilesystem(), Equals, true)
@@ -1996,7 +1996,7 @@ func (u *updateTestSuite) TestUpdateApplyUC20WithInitialMapAllVolumesUpdatedFull
 				c.Assert(loc, Equals, gadget.StructureLocation{
 					RootMountPoint: filepath.Join(dirs.GlobalRootDir, "/run/mnt/ubuntu-seed"),
 				})
-			case 3:
+			case 4:
 				// ubuntu-boot
 				c.Check(ps.Name(), Equals, "ubuntu-boot")
 				c.Check(ps.HasFilesystem(), Equals, true)
@@ -2009,7 +2009,7 @@ func (u *updateTestSuite) TestUpdateApplyUC20WithInitialMapAllVolumesUpdatedFull
 				c.Assert(loc, Equals, gadget.StructureLocation{
 					RootMountPoint: filepath.Join(dirs.GlobalRootDir, "/run/mnt/ubuntu-boot"),
 				})
-			case 4:
+			case 2:
 				// ubuntu-save
 				c.Check(ps.Name(), Equals, "ubuntu-save")
 				c.Check(ps.HasFilesystem(), Equals, true)
@@ -2022,7 +2022,7 @@ func (u *updateTestSuite) TestUpdateApplyUC20WithInitialMapAllVolumesUpdatedFull
 				c.Assert(loc, Equals, gadget.StructureLocation{
 					RootMountPoint: filepath.Join(dirs.GlobalRootDir, "/run/mnt/ubuntu-save"),
 				})
-			case 5:
+			case 3:
 				// ubuntu-data
 				c.Check(ps.Name(), Equals, "ubuntu-data")
 				c.Check(ps.HasFilesystem(), Equals, true)


### PR DESCRIPTION
Boot assets must be updated in the reverse order of boot chain.  This is because new shim binary may not contain the certificate for older grub binaries, or even may revoke them. But new grub binaries may have several signatures.
    
Binaries from seed are loaded before binaries from boot. So the boot partition should be updated before the seed partition.

