### PR TITLE
cmd/snap: use updated "current" revision after snap refresh run inhibition (spike-1)

### DIFF
--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -238,17 +238,15 @@ func (s *RunSuite) TestSnapRunAppRunsChecksInhibitionLock(c *check.C) {
 	c.Assert(os.WriteFile(features.RefreshAppAwareness.ControlFile(), []byte(nil), 0644), check.IsNil)
 
 	var called int
-	restore := snaprun.MockWaitInhibitUnlock(func(snapName string, waitFor runinhibit.Hint) (bool, error) {
+	restore := snaprun.MockHintFromFile(func(file *os.File) (runinhibit.Hint, error) {
 		called++
-		// uninhibit snap run
-		runinhibit.Unlock(snapName)
-		return false, nil
+		return "", nil
 	})
 	defer restore()
 
 	rest, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--", "snapname.app", "--arg1"})
 	c.Assert(err, check.IsNil)
-	c.Check(called, check.Equals, 2)
+	c.Check(called, check.Equals, 1)
 	c.Assert(rest, check.DeepEquals, []string{"snapname.app", "--arg1"})
 	c.Check(execArg0, check.Equals, filepath.Join(dirs.DistroLibExecDir, "snap-confine"))
 	c.Check(execArgs, check.DeepEquals, []string{
@@ -256,44 +254,6 @@ func (s *RunSuite) TestSnapRunAppRunsChecksInhibitionLock(c *check.C) {
 		"snap.snapname.app",
 		filepath.Join(dirs.CoreLibExecDir, "snap-exec"),
 		"snapname.app", "--arg1"})
-}
-
-func (s *RunSuite) TestSnapRunAppInhibitedSnapReinhibitedAfterChecks(c *check.C) {
-	defer mockSnapConfine(dirs.DistroLibExecDir)()
-
-	// mock installed snap
-	snaptest.MockSnapCurrent(c, string(mockYaml), &snap.SideInfo{Revision: snap.R("x2")})
-
-	var execArg0 string
-	var execArgs []string
-	restorer := snaprun.MockSyscallExec(func(arg0 string, args []string, envv []string) error {
-		execArg0 = arg0
-		execArgs = args
-		return nil
-	})
-	defer restorer()
-
-	inhibitInfo := runinhibit.InhibitInfo{Previous: snap.R("x2")}
-	c.Assert(runinhibit.LockWithHint("snapname", runinhibit.HintInhibitedForRefresh, inhibitInfo), check.IsNil)
-	c.Assert(os.MkdirAll(dirs.FeaturesDir, 0755), check.IsNil)
-	c.Assert(os.WriteFile(features.RefreshAppAwareness.ControlFile(), []byte(nil), 0644), check.IsNil)
-
-	var called int
-	restore := snaprun.MockWaitInhibitUnlock(func(snapName string, waitFor runinhibit.Hint) (bool, error) {
-		called++
-		// not removing inhibition lock while mocking waitInhibitUnlock return
-		// as not-inhibited simulates race condition where the snap is
-		// reinhibited just after inhibition checks are done
-		return true, nil
-	})
-	defer restore()
-
-	rest, err := snaprun.Parser(snaprun.Client()).ParseArgs([]string{"run", "--", "snapname.app", "--arg1"})
-	c.Assert(err, check.ErrorMatches, "internal error: snap run was inhibited again after waiting for first inhibition")
-	c.Check(called, check.Equals, 1)
-	c.Assert(rest, check.DeepEquals, []string{"--", "snapname.app", "--arg1"})
-	c.Check(execArg0, check.Equals, "")
-	c.Check(execArgs, check.IsNil)
 }
 
 func (s *RunSuite) TestSnapRunAppNewRevisionAfterInhibition(c *check.C) {
@@ -319,16 +279,16 @@ func (s *RunSuite) TestSnapRunAppNewRevisionAfterInhibition(c *check.C) {
 	c.Assert(os.WriteFile(features.RefreshAppAwareness.ControlFile(), []byte(nil), 0644), check.IsNil)
 
 	var called int
-	restore := snaprun.MockWaitInhibitUnlock(func(snapName string, waitFor runinhibit.Hint) (bool, error) {
+	restore := snaprun.MockHintFromFile(func(file *os.File) (runinhibit.Hint, error) {
 		called++
 		if called == 2 {
 			// mock installed snap's new revision
 			c.Assert(os.Remove(filepath.Join(si.MountDir(), "../current")), check.IsNil)
 			snaptest.MockSnapCurrent(c, string(mockYaml), &snap.SideInfo{Revision: snap.R("x3")})
-			// uninhibit snap run
-			runinhibit.Unlock(snapName)
+			// uninhibit snap
+			return "", nil
 		}
-		return false, nil
+		return runinhibit.HintInhibitedForRefresh, nil
 	})
 	defer restore()
 
@@ -371,16 +331,16 @@ apps:
 	c.Assert(os.WriteFile(features.RefreshAppAwareness.ControlFile(), []byte(nil), 0644), check.IsNil)
 
 	var called int
-	restore := snaprun.MockWaitInhibitUnlock(func(snapName string, waitFor runinhibit.Hint) (bool, error) {
+	restore := snaprun.MockHintFromFile(func(file *os.File) (runinhibit.Hint, error) {
 		called++
 		if called == 2 {
 			// mock installed snap's new revision
 			c.Assert(os.Remove(filepath.Join(si.MountDir(), "../current")), check.IsNil)
-			snaptest.MockSnapCurrent(c, string(mockYaml2), &snap.SideInfo{Revision: snap.R("x3")})
-			// uninhibit snap run
-			runinhibit.Unlock(snapName)
+			snaptest.MockSnapCurrent(c, string(mockYaml), &snap.SideInfo{Revision: snap.R("x3")})
+			// uninhibit snap
+			return "", nil
 		}
-		return false, nil
+		return runinhibit.HintInhibitedForRefresh, nil
 	})
 	defer restore()
 
@@ -428,10 +388,10 @@ func (s *RunSuite) TestSnapRunHookNoRuninhibit(c *check.C) {
 	defer restorer()
 
 	var called bool
-	restore := snaprun.MockWaitInhibitUnlock(func(snapName string, waitFor runinhibit.Hint) (bool, error) {
+	restore := snaprun.MockHintFromFile(func(file *os.File) (runinhibit.Hint, error) {
 		called = true
-		c.Errorf("WaitInhibitUnlock should not have been called")
-		return false, nil
+		c.Errorf("hintFromFile should not have been called")
+		return "", nil
 	})
 	defer restore()
 
@@ -474,10 +434,10 @@ func (s *RunSuite) TestSnapRunAppRuninhibitSkipsServices(c *check.C) {
 	c.Assert(os.WriteFile(features.RefreshAppAwareness.ControlFile(), []byte(nil), 0644), check.IsNil)
 
 	var called bool
-	restore := snaprun.MockWaitInhibitUnlock(func(snapName string, waitFor runinhibit.Hint) (bool, error) {
+	restore := snaprun.MockHintFromFile(func(file *os.File) (runinhibit.Hint, error) {
 		called = true
-		c.Errorf("WaitInhibitUnlock should not have been called")
-		return false, nil
+		c.Errorf("hintFromFile should not have been called")
+		return "", nil
 	})
 	defer restore()
 
@@ -1961,48 +1921,14 @@ func (s *RunSuite) TestRunGdbserverNoGdbserver(c *check.C) {
 	c.Assert(err, check.ErrorMatches, "please install gdbserver on your system")
 }
 
-func (s *RunSuite) TestWaitInhibitUnlock(c *check.C) {
-	var called int
-	restore := snaprun.MockIsLocked(func(snapName string) (runinhibit.Hint, runinhibit.InhibitInfo, error) {
-		called++
-		if called < 5 {
-			return runinhibit.HintInhibitedForRefresh, runinhibit.InhibitInfo{}, nil
-		}
-		return runinhibit.HintNotInhibited, runinhibit.InhibitInfo{}, nil
-	})
-	defer restore()
-
-	notInhibited, err := snaprun.WaitInhibitUnlock("some-snap", runinhibit.HintNotInhibited)
-	c.Assert(err, check.IsNil)
-	c.Check(notInhibited, check.Equals, true)
-	c.Check(called, check.Equals, 5)
-}
-
-func (s *RunSuite) TestWaitInhibitUnlockWaitsForSpecificHint(c *check.C) {
-	var called int
-	restore := snaprun.MockIsLocked(func(snapName string) (runinhibit.Hint, runinhibit.InhibitInfo, error) {
-		called++
-		if called < 5 {
-			return runinhibit.HintInhibitedGateRefresh, runinhibit.InhibitInfo{}, nil
-		}
-		return runinhibit.HintInhibitedForRefresh, runinhibit.InhibitInfo{}, nil
-	})
-	defer restore()
-
-	notInhibited, err := snaprun.WaitInhibitUnlock("some-snap", runinhibit.HintInhibitedForRefresh)
-	c.Assert(err, check.IsNil)
-	c.Check(notInhibited, check.Equals, false)
-	c.Check(called, check.Equals, 5)
-}
-
 func (s *RunSuite) TestWaitWhileInhibitedNoop(c *check.C) {
 	var called int
-	restore := snaprun.MockIsLocked(func(snapName string) (runinhibit.Hint, runinhibit.InhibitInfo, error) {
+	restore := snaprun.MockHintFromFile(func(file *os.File) (runinhibit.Hint, error) {
 		called++
 		if called < 2 {
-			return runinhibit.HintInhibitedGateRefresh, runinhibit.InhibitInfo{}, nil
+			return runinhibit.HintInhibitedGateRefresh, nil
 		}
-		return runinhibit.HintNotInhibited, runinhibit.InhibitInfo{}, nil
+		return runinhibit.HintNotInhibited, nil
 	})
 	defer restore()
 
@@ -2011,7 +1937,11 @@ func (s *RunSuite) TestWaitWhileInhibitedNoop(c *check.C) {
 
 	inhibitInfo := runinhibit.InhibitInfo{Previous: snap.R(11)}
 	c.Assert(runinhibit.LockWithHint("some-snap", runinhibit.HintInhibitedGateRefresh, inhibitInfo), check.IsNil)
-	c.Assert(snaprun.WaitWhileInhibited("some-snap"), check.IsNil)
+
+	action := func() error {
+		return nil
+	}
+	c.Assert(snaprun.WaitWhileInhibited("some-snap", action), check.IsNil)
 	c.Check(called, check.Equals, 2)
 
 	c.Check(meter.Values, check.HasLen, 0)
@@ -2023,12 +1953,12 @@ func (s *RunSuite) TestWaitWhileInhibitedNoop(c *check.C) {
 
 func (s *RunSuite) TestWaitWhileInhibitedTextFlow(c *check.C) {
 	var called int
-	restore := snaprun.MockIsLocked(func(snapName string) (runinhibit.Hint, runinhibit.InhibitInfo, error) {
+	restore := snaprun.MockHintFromFile(func(file *os.File) (runinhibit.Hint, error) {
 		called++
 		if called < 2 {
-			return runinhibit.HintInhibitedForRefresh, runinhibit.InhibitInfo{}, nil
+			return runinhibit.HintInhibitedForRefresh, nil
 		}
-		return runinhibit.HintNotInhibited, runinhibit.InhibitInfo{}, nil
+		return runinhibit.HintNotInhibited, nil
 	})
 	defer restore()
 
@@ -2037,7 +1967,9 @@ func (s *RunSuite) TestWaitWhileInhibitedTextFlow(c *check.C) {
 
 	inhibitInfo := runinhibit.InhibitInfo{Previous: snap.R(11)}
 	c.Assert(runinhibit.LockWithHint("some-snap", runinhibit.HintInhibitedGateRefresh, inhibitInfo), check.IsNil)
-	c.Assert(snaprun.WaitWhileInhibited("some-snap"), check.IsNil)
+
+	action := func() error { return nil }
+	c.Assert(snaprun.WaitWhileInhibited("some-snap", action), check.IsNil)
 	c.Check(called, check.Equals, 2)
 
 	c.Check(s.Stdout(), check.Equals, "snap package cannot be used now: gate-refresh\n")
@@ -2054,9 +1986,9 @@ func (s *RunSuite) TestWaitWhileInhibitedGraphicalSessionFlow(c *check.C) {
 	restoreIsGraphicalSession := snaprun.MockIsGraphicalSession(true)
 	defer restoreIsGraphicalSession()
 
-	restoreTryNotifyRefresh := snaprun.MockTryNotifyRefreshViaSnapDesktopIntegrationFlow(func(snapName string) (bool, error) {
+	restoreTryNotifyRefresh := snaprun.MockTryNotifyRefreshViaSnapDesktopIntegrationFlow(func(snapName string) bool {
 		c.Check(snapName, check.Equals, "some-snap")
-		return false, nil
+		return false
 	})
 	defer restoreTryNotifyRefresh()
 
@@ -2078,19 +2010,20 @@ func (s *RunSuite) TestWaitWhileInhibitedGraphicalSessionFlow(c *check.C) {
 	defer restoreFinishRefreshNotification()
 
 	var called int
-	restore := snaprun.MockIsLocked(func(snapName string) (runinhibit.Hint, runinhibit.InhibitInfo, error) {
-		c.Check(snapName, check.Equals, "some-snap")
+	restore := snaprun.MockHintFromFile(func(file *os.File) (runinhibit.Hint, error) {
 		called++
 		if called < 2 {
-			return runinhibit.HintInhibitedForRefresh, runinhibit.InhibitInfo{}, nil
+			return runinhibit.HintInhibitedForRefresh, nil
 		}
-		return runinhibit.HintNotInhibited, runinhibit.InhibitInfo{}, nil
+		return runinhibit.HintNotInhibited, nil
 	})
 	defer restore()
 
 	inhibitInfo := runinhibit.InhibitInfo{Previous: snap.R(11)}
 	c.Assert(runinhibit.LockWithHint("some-snap", runinhibit.HintInhibitedForRefresh, inhibitInfo), check.IsNil)
-	c.Assert(snaprun.WaitWhileInhibited("some-snap"), check.IsNil)
+
+	action := func() error { return nil }
+	c.Assert(snaprun.WaitWhileInhibited("some-snap", action), check.IsNil)
 	c.Check(called, check.Equals, 2)
 	c.Check(s.Stdout(), check.Equals, "")
 }
@@ -2102,9 +2035,9 @@ func (s *RunSuite) TestWaitWhileInhibitedGraphicalSessionFlowError(c *check.C) {
 	restoreIsGraphicalSession := snaprun.MockIsGraphicalSession(true)
 	defer restoreIsGraphicalSession()
 
-	restoreTryNotifyRefresh := snaprun.MockTryNotifyRefreshViaSnapDesktopIntegrationFlow(func(snapName string) (bool, error) {
+	restoreTryNotifyRefresh := snaprun.MockTryNotifyRefreshViaSnapDesktopIntegrationFlow(func(snapName string) bool {
 		c.Check(snapName, check.Equals, "some-snap")
-		return false, nil
+		return false
 	})
 	defer restoreTryNotifyRefresh()
 
@@ -2119,13 +2052,13 @@ func (s *RunSuite) TestWaitWhileInhibitedGraphicalSessionFlowError(c *check.C) {
 
 	inhibitInfo := runinhibit.InhibitInfo{Previous: snap.R(11)}
 	c.Assert(runinhibit.LockWithHint("some-snap", runinhibit.HintInhibitedForRefresh, inhibitInfo), check.IsNil)
-	restore := snaprun.MockIsLocked(func(snapName string) (runinhibit.Hint, runinhibit.InhibitInfo, error) {
-		c.Check(snapName, check.Equals, "some-snap")
-		return runinhibit.HintInhibitedForRefresh, runinhibit.InhibitInfo{}, nil
+	restore := snaprun.MockHintFromFile(func(file *os.File) (runinhibit.Hint, error) {
+		return runinhibit.HintInhibitedForRefresh, nil
 	})
 	defer restore()
 
-	c.Assert(snaprun.WaitWhileInhibited("some-snap"), check.ErrorMatches, "boom")
+	action := func() error { return nil }
+	c.Assert(snaprun.WaitWhileInhibited("some-snap", action), check.ErrorMatches, "boom")
 }
 
 func (s *RunSuite) TestWaitWhileInhibitedGraphicalSessionFlowErrorOnFinish(c *check.C) {
@@ -2135,9 +2068,9 @@ func (s *RunSuite) TestWaitWhileInhibitedGraphicalSessionFlowErrorOnFinish(c *ch
 	restoreIsGraphicalSession := snaprun.MockIsGraphicalSession(true)
 	defer restoreIsGraphicalSession()
 
-	restoreTryNotifyRefresh := snaprun.MockTryNotifyRefreshViaSnapDesktopIntegrationFlow(func(snapName string) (bool, error) {
+	restoreTryNotifyRefresh := snaprun.MockTryNotifyRefreshViaSnapDesktopIntegrationFlow(func(snapName string) bool {
 		c.Check(snapName, check.Equals, "some-snap")
-		return false, nil
+		return false
 	})
 	defer restoreTryNotifyRefresh()
 
@@ -2161,17 +2094,17 @@ func (s *RunSuite) TestWaitWhileInhibitedGraphicalSessionFlowErrorOnFinish(c *ch
 	inhibitInfo := runinhibit.InhibitInfo{Previous: snap.R(11)}
 	c.Assert(runinhibit.LockWithHint("some-snap", runinhibit.HintInhibitedForRefresh, inhibitInfo), check.IsNil)
 	n := 0
-	restore := snaprun.MockIsLocked(func(snapName string) (runinhibit.Hint, runinhibit.InhibitInfo, error) {
-		c.Check(snapName, check.Equals, "some-snap")
+	restore := snaprun.MockHintFromFile(func(file *os.File) (runinhibit.Hint, error) {
 		n++
 		if n == 1 {
-			return runinhibit.HintInhibitedForRefresh, runinhibit.InhibitInfo{}, nil
+			return runinhibit.HintInhibitedForRefresh, nil
 		}
-		return runinhibit.HintNotInhibited, runinhibit.InhibitInfo{}, nil
+		return runinhibit.HintNotInhibited, nil
 	})
 	defer restore()
 
-	c.Assert(snaprun.WaitWhileInhibited("some-snap"), check.ErrorMatches, "boom")
+	action := func() error { return nil }
+	c.Assert(snaprun.WaitWhileInhibited("some-snap", action), check.ErrorMatches, "boom")
 }
 
 func (s *RunSuite) TestCreateSnapDirPermissions(c *check.C) {
@@ -2270,9 +2203,8 @@ func (s *RunSuite) TestDesktopIntegrationNoDBus(c *check.C) {
 	restore := dbusutil.MockConnections(noDBus, noDBus)
 	defer restore()
 
-	sent, err := snaprun.TryNotifyRefreshViaSnapDesktopIntegrationFlow("Test")
+	sent := snaprun.TryNotifyRefreshViaSnapDesktopIntegrationFlow("Test")
 	c.Assert(sent, check.Equals, false)
-	c.Assert(err, check.IsNil)
 }
 
 func makeDBusMethodNotAvailableMessage(c *check.C, msg *dbus.Message) *dbus.Message {
@@ -2299,9 +2231,8 @@ func (s *RunSuite) TestDesktopIntegrationDBusAvailableNoMethod(c *check.C) {
 	restore := dbusutil.MockOnlySessionBusAvailable(conn)
 	defer restore()
 
-	sent, err := snaprun.TryNotifyRefreshViaSnapDesktopIntegrationFlow("SnapTest")
+	sent := snaprun.TryNotifyRefreshViaSnapDesktopIntegrationFlow("SnapTest")
 	c.Assert(sent, check.Equals, false)
-	c.Assert(err, check.IsNil)
 }
 
 func makeDBusMethodAvailableMessage(c *check.C, msg *dbus.Message) *dbus.Message {
@@ -2339,7 +2270,6 @@ func (s *RunSuite) TestDesktopIntegrationDBusAvailableMethodWorks(c *check.C) {
 	restore := dbusutil.MockOnlySessionBusAvailable(conn)
 	defer restore()
 
-	sent, err := snaprun.TryNotifyRefreshViaSnapDesktopIntegrationFlow("SnapTest")
+	sent := snaprun.TryNotifyRefreshViaSnapDesktopIntegrationFlow("SnapTest")
 	c.Assert(sent, check.Equals, true)
-	c.Assert(err, check.IsNil)
 }

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -149,9 +149,7 @@ var (
 	MaybePrintCohortKey                           = (*infoWriter).maybePrintCohortKey
 	MaybePrintHealth                              = (*infoWriter).maybePrintHealth
 	MaybePrintRefreshInfo                         = (*infoWriter).maybePrintRefreshInfo
-	WaitInhibitUnlock                             = waitInhibitUnlock
 	WaitWhileInhibited                            = waitWhileInhibited
-	IsLocked                                      = isLocked
 	TryNotifyRefreshViaSnapDesktopIntegrationFlow = tryNotifyRefreshViaSnapDesktopIntegrationFlow
 )
 
@@ -420,22 +418,6 @@ func MockOsChmod(f func(string, os.FileMode) error) (restore func()) {
 	}
 }
 
-func MockWaitInhibitUnlock(f func(snapName string, waitFor runinhibit.Hint) (bool, error)) (restore func()) {
-	old := waitInhibitUnlock
-	waitInhibitUnlock = f
-	return func() {
-		waitInhibitUnlock = old
-	}
-}
-
-func MockIsLocked(f func(snapName string) (runinhibit.Hint, runinhibit.InhibitInfo, error)) (restore func()) {
-	old := isLocked
-	isLocked = f
-	return func() {
-		isLocked = old
-	}
-}
-
 func MockIsGraphicalSession(graphical bool) (restore func()) {
 	old := isGraphicalSession
 	isGraphicalSession = func() bool {
@@ -462,11 +444,19 @@ func MockFinishRefreshNotification(f func(refreshInfo *usersessionclient.Finishe
 	}
 }
 
-func MockTryNotifyRefreshViaSnapDesktopIntegrationFlow(f func(snapName string) (bool, error)) (restore func()) {
+func MockTryNotifyRefreshViaSnapDesktopIntegrationFlow(f func(snapName string) bool) (restore func()) {
 	old := tryNotifyRefreshViaSnapDesktopIntegrationFlow
 	tryNotifyRefreshViaSnapDesktopIntegrationFlow = f
 	return func() {
 		tryNotifyRefreshViaSnapDesktopIntegrationFlow = old
+	}
+}
+
+func MockHintFromFile(f func(*os.File) (runinhibit.Hint, error)) (restore func()) {
+	old := hintFromFile
+	hintFromFile = f
+	return func() {
+		hintFromFile = old
 	}
 }
 

--- a/cmd/snaplock/runinhibit/inhibit.go
+++ b/cmd/snaplock/runinhibit/inhibit.go
@@ -207,15 +207,15 @@ func Unlock(snapName string) error {
 }
 
 func WithReadLock(snapName string, action func() error) error {
-	lock, err := osutil.OpenExistingLockForReading(HintFile(snapName))
+	flock, err := osutil.OpenExistingLockForReading(HintFile(snapName))
 	if os.IsNotExist(err) {
 		return action()
 	}
 	if err != nil {
 		return err
 	}
-	defer lock.Close()
-	if err := lock.ReadLock(); err != nil {
+	defer flock.Close()
+	if err := flock.ReadLock(); err != nil {
 		return err
 	}
 	return action()

--- a/cmd/snaplock/runinhibit/inhibit.go
+++ b/cmd/snaplock/runinhibit/inhibit.go
@@ -206,19 +206,15 @@ func Unlock(snapName string) error {
 	return nil
 }
 
-func WithReadLock(snapName string, action func() error) error {
-	flock, err := osutil.OpenExistingLockForReading(HintFile(snapName))
-	if os.IsNotExist(err) {
-		return action()
+func OpenLock(snapName string) (*osutil.FileLock, error) {
+	if err := os.MkdirAll(InhibitDir, 0755); err != nil {
+		return nil, err
 	}
+	flock, err := openHintFileLock(snapName)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	defer flock.Close()
-	if err := flock.ReadLock(); err != nil {
-		return err
-	}
-	return action()
+	return flock, nil
 }
 
 // IsLocked returns the state of the run inhibition lock for the given snap.

--- a/cmd/snaplock/runinhibit/inhibit.go
+++ b/cmd/snaplock/runinhibit/inhibit.go
@@ -206,6 +206,21 @@ func Unlock(snapName string) error {
 	return nil
 }
 
+func WithReadLock(snapName string, action func() error) error {
+	lock, err := osutil.OpenExistingLockForReading(HintFile(snapName))
+	if os.IsNotExist(err) {
+		return action()
+	}
+	if err != nil {
+		return err
+	}
+	defer lock.Close()
+	if err := lock.ReadLock(); err != nil {
+		return err
+	}
+	return action()
+}
+
 // IsLocked returns the state of the run inhibition lock for the given snap.
 //
 // It returns the current, non-empty hint if inhibition is in place. Otherwise

--- a/cmd/snaplock/runinhibit/inhibit_test.go
+++ b/cmd/snaplock/runinhibit/inhibit_test.go
@@ -21,7 +21,6 @@ package runinhibit_test
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -32,7 +31,6 @@ import (
 
 	"github.com/snapcore/snapd/cmd/snaplock/runinhibit"
 	"github.com/snapcore/snapd/dirs"
-	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -207,30 +205,4 @@ func (s *runInhibitSuite) TestLockWithHintFilePostfix(c *C) {
 	// This would confuse inhibit info to overwrite the hint file
 	err := runinhibit.LockWithHint("pkg", "lock", s.inhibitInfo)
 	c.Assert(err, ErrorMatches, `hint cannot have value "lock"`)
-}
-
-func (s *runInhibitSuite) TestWithReadLock(c *C) {
-	c.Assert(runinhibit.LockWithHint("some-snap", runinhibit.HintInhibitedForRefresh, s.inhibitInfo), IsNil)
-
-	lock, err := osutil.OpenExistingLockForReading(runinhibit.HintFile("some-snap"))
-	c.Assert(err, IsNil)
-	defer lock.Close()
-	c.Assert(lock.TryLock(), IsNil) // Lock is not held
-	lock.Unlock()
-
-	err = runinhibit.WithReadLock("some-snap", func() error {
-		c.Assert(lock.TryLock(), Equals, osutil.ErrAlreadyLocked) // Lock is held
-		return errors.New("error-is-propagated")
-	})
-	c.Check(err, ErrorMatches, "error-is-propagated")
-
-	c.Assert(lock.TryLock(), IsNil) // Lock is not held
-}
-
-func (s *runInhibitSuite) TestWithReadLockHintFileNotExist(c *C) {
-	err := runinhibit.WithReadLock("some-snap", func() error {
-		c.Assert(runinhibit.HintFile("some-snap"), testutil.FileAbsent)
-		return errors.New("error-is-propagated")
-	})
-	c.Check(err, ErrorMatches, "error-is-propagated")
 }

--- a/cmd/snaplock/runinhibit/inhibit_test.go
+++ b/cmd/snaplock/runinhibit/inhibit_test.go
@@ -21,6 +21,7 @@ package runinhibit_test
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -31,6 +32,7 @@ import (
 
 	"github.com/snapcore/snapd/cmd/snaplock/runinhibit"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -205,4 +207,30 @@ func (s *runInhibitSuite) TestLockWithHintFilePostfix(c *C) {
 	// This would confuse inhibit info to overwrite the hint file
 	err := runinhibit.LockWithHint("pkg", "lock", s.inhibitInfo)
 	c.Assert(err, ErrorMatches, `hint cannot have value "lock"`)
+}
+
+func (s *runInhibitSuite) TestWithReadLock(c *C) {
+	c.Assert(runinhibit.LockWithHint("some-snap", runinhibit.HintInhibitedForRefresh, s.inhibitInfo), IsNil)
+
+	lock, err := osutil.OpenExistingLockForReading(runinhibit.HintFile("some-snap"))
+	c.Assert(err, IsNil)
+	defer lock.Close()
+	c.Assert(lock.TryLock(), IsNil) // Lock is not held
+	lock.Unlock()
+
+	err = runinhibit.WithReadLock("some-snap", func() error {
+		c.Assert(lock.TryLock(), Equals, osutil.ErrAlreadyLocked) // Lock is held
+		return errors.New("error-is-propagated")
+	})
+	c.Check(err, ErrorMatches, "error-is-propagated")
+
+	c.Assert(lock.TryLock(), IsNil) // Lock is not held
+}
+
+func (s *runInhibitSuite) TestWithReadLockHintFileNotExist(c *C) {
+	err := runinhibit.WithReadLock("some-snap", func() error {
+		c.Assert(runinhibit.HintFile("some-snap"), testutil.FileAbsent)
+		return errors.New("error-is-propagated")
+	})
+	c.Check(err, ErrorMatches, "error-is-propagated")
 }


### PR DESCRIPTION
This is an alternative to https://github.com/snapcore/snapd/pull/13343 that addresses race conditions discussed.

Another approach is demonstrated here https://github.com/snapcore/snapd/pull/13411.

**NOTE: Please ignore all test related code as it will need serious refactoring which should be postponed until after we decide on an approach.**